### PR TITLE
Fork CI: staging-release APK, versioned artifact names, R8-optimised release

### DIFF
--- a/.github/workflows/fork-testing-build.yml
+++ b/.github/workflows/fork-testing-build.yml
@@ -1,9 +1,10 @@
-# Fork-only: ONE on-demand testing build that publishes ALL three platforms into ONE release.
+# Fork-only: ONE on-demand testing build that publishes ALL platforms into ONE release.
 #
 # A `meta` job creates a single dated prerelease, then the android / macOS / iOS jobs each attach
-# their artifact to that SAME tag — so every release has app-full-debug.apk + NOOP-macos.zip +
-# NOOP-ios-unsigned.ipa together. Replaces the older split fork-testing-apk.yml + fork-testing-apple.yml.
-# Unsigned/debug, no secrets. Trigger from the Actions tab. (Built from noop-staging via --ref.)
+# their artifact to that SAME tag — so every release has app-full-release + app-full-debug (Android)
+# + NOOP-macos.zip + NOOP-ios-unsigned.ipa together, each stamped with the base app version.
+# Replaces the older split fork-testing-apk.yml + fork-testing-apple.yml.
+# Unsigned/debug-keyed, no secrets. Trigger from the Actions tab. (Built from noop-staging via --ref.)
 name: Testing build (fork)
 
 on:
@@ -21,6 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       tag: ${{ steps.m.outputs.tag }}
+      ver: ${{ steps.m.outputs.ver }}
     steps:
       - uses: actions/checkout@v4
       - id: m
@@ -32,16 +34,18 @@ jobs:
           VER=$(grep -m1 'MARKETING_VERSION' project.yml | sed -E 's/.*"([^"]+)".*/\1/')
           SHA="${GITHUB_SHA:0:7}"
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
-          # ROLLING release: recreate the single tag so stale assets/notes never linger — one stable URL,
-          # always the newest build, zero cleanup. (To KEEP a specific build, cut a one-off tag by hand.)
+          echo "ver=$VER" >> "$GITHUB_OUTPUT"
+          # ROLLING release: recreate the single tag so stale (incl. old-version) assets never linger —
+          # one stable URL, always the newest build, zero cleanup. (To KEEP a build, cut a one-off tag.)
           gh release delete "$TAG" --repo "$GITHUB_REPOSITORY" --cleanup-tag --yes || true
           gh release create "$TAG" --repo "$GITHUB_REPOSITORY" --prerelease --target "${{ github.sha }}" \
             --title "NOOP Staging — base ${VER} · ${DATE} · ${SHA}" \
-            --notes "Rolling **latest** testing build — refreshed in place, so this tag is always the newest. NOOP main + ryanbr's open PRs + vetted community PRs, built with the **NOOP Staging** identity (installs **beside** the official app, separate data).
+            --notes "Rolling **latest** testing build — refreshed in place, so this tag is always the newest. NOOP main + ryanbr's open PRs + vetted community PRs, built with the **NOOP Staging** identity (installs **beside** the official app, separate data). Filenames carry the base app version (\`v${VER}\`).
 
-          - **Android** — \`app-full-debug.apk\` — install on your phone (allow \"install unknown apps\"). \`com.noop.whoop.debug\`.
-          - **macOS** — \`NOOP-macos.zip\` — unzip, then **right-click → Open** (unsigned; Gatekeeper warns once).
-          - **iOS** — \`NOOP-ios-unsigned.ipa\` — sideload via **AltStore / Sideloadly** (re-signs on-device); embedded watch app stripped.
+          - **Android (release)** — \`app-full-release-v${VER}.apk\` — optimized, non-debuggable build; installs beside the official app. \`com.noop.whoop.staging\`.
+          - **Android (debug)** — \`app-full-debug-v${VER}.apk\` — debuggable build. \`com.noop.whoop.debug\`.
+          - **macOS** — \`NOOP-macos-v${VER}.zip\` — unzip, then **right-click → Open** (unsigned; Gatekeeper warns once).
+          - **iOS** — \`NOOP-ios-unsigned-v${VER}.ipa\` — sideload via **AltStore / Sideloadly** (re-signs on-device); embedded watch app stripped.
 
           Base app version ${VER} · built ${DATE} · \`${SHA}\`."
 
@@ -59,16 +63,24 @@ jobs:
           java-version: '17'
       - uses: gradle/actions/wrapper-validation@v4
       - uses: gradle/actions/setup-gradle@v4
-      # NOTE: the debug APK is signed with the committed android/fork-debug.keystore via an explicit
-      # storeFile in the debug signingConfig (build.gradle.kts, injected by rebuild-staging.sh). We do NOT
+      # NOTE: both APKs are signed with the committed android/fork-debug.keystore via an explicit
+      # storeFile in the debug signingConfig (build.gradle.kts, injected by rebuild-staging.sh) — the
+      # release build falls back to the debug key when no keystore.properties is present. We do NOT
       # copy it to ~/.android/debug.keystore — the runner ignores that path (ANDROID_USER_HOME points off
       # $HOME) and would sign with a fresh random key, breaking sideloaded updates ("App not installed").
-      - name: Build debug APK
-        run: ./gradlew assembleFullDebug
-      - name: Attach APK to the release
+      # -PstagingRelease gives the release APK a .staging app id so it installs beside the official app.
+      - name: Build debug + staging-release APKs
+        run: ./gradlew assembleFullDebug assembleFullRelease -PstagingRelease
+      - name: Version the filenames + attach
         env:
           GH_TOKEN: ${{ github.token }}
-        run: gh release upload "${{ needs.meta.outputs.tag }}" app/build/outputs/apk/full/debug/*.apk --repo "$GITHUB_REPOSITORY" --clobber
+          VER: ${{ needs.meta.outputs.ver }}
+        run: |
+          cp app/build/outputs/apk/full/debug/*.apk "app-full-debug-v${VER}.apk"
+          cp app/build/outputs/apk/full/release/*.apk "app-full-release-v${VER}.apk"
+          gh release upload "${{ needs.meta.outputs.tag }}" \
+            "app-full-release-v${VER}.apk" "app-full-debug-v${VER}.apk" \
+            --repo "$GITHUB_REPOSITORY" --clobber
 
   macos:
     needs: meta
@@ -89,11 +101,12 @@ jobs:
       - name: Package + attach
         env:
           GH_TOKEN: ${{ github.token }}
+          VER: ${{ needs.meta.outputs.ver }}
         run: |
           APP=$(find build/dd/Build/Products -maxdepth 3 -name '*.app' -type d | head -1)
           test -n "$APP" || { echo ".app not found"; exit 1; }
-          ditto -c -k --keepParent "$APP" NOOP-macos.zip
-          gh release upload "${{ needs.meta.outputs.tag }}" NOOP-macos.zip --repo "$GITHUB_REPOSITORY" --clobber
+          ditto -c -k --keepParent "$APP" "NOOP-macos-v${VER}.zip"
+          gh release upload "${{ needs.meta.outputs.tag }}" "NOOP-macos-v${VER}.zip" --repo "$GITHUB_REPOSITORY" --clobber
 
   ios:
     needs: meta
@@ -115,10 +128,11 @@ jobs:
       - name: Package unsigned .ipa (strip the embedded watch app) + attach
         env:
           GH_TOKEN: ${{ github.token }}
+          VER: ${{ needs.meta.outputs.ver }}
         run: |
           APP=$(find build/dd/Build/Products/Debug-iphoneos -maxdepth 1 -name '*.app' -type d | head -1)
           test -n "$APP" || { echo ".app (iphoneos) not found"; exit 1; }
           rm -rf "$APP/Watch"
           rm -rf Payload && mkdir Payload && cp -R "$APP" Payload/
-          zip -qr NOOP-ios-unsigned.ipa Payload
-          gh release upload "${{ needs.meta.outputs.tag }}" NOOP-ios-unsigned.ipa --repo "$GITHUB_REPOSITORY" --clobber
+          zip -qr "NOOP-ios-unsigned-v${VER}.ipa" Payload
+          gh release upload "${{ needs.meta.outputs.tag }}" "NOOP-ios-unsigned-v${VER}.ipa" --repo "$GITHUB_REPOSITORY" --clobber

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -58,12 +58,13 @@ android {
             versionNameSuffix = "-debug"
         }
         release {
-            // R8 full-mode was stripping classes the app needs at runtime (Compose/Room/Tink
-            // reflective paths), so release builds installed then crashed on launch. This is an
-            // offline app where a ~20 MB APK is fine, so we ship UNMINIFIED for reliability.
-            // Re-enabling minify later requires device-verified keep rules first.
-            isMinifyEnabled = false
-            isShrinkResources = false
+            // Optimised release: R8 code shrink + resource shrink ON. The earlier crash-on-launch was
+            // R8 *full-mode* over-stripping reflective paths (Compose/Room/Tink) — that aggressive mode is
+            // now OFF (android.enableR8.fullMode=false in gradle.properties) and the reflective survivors
+            // (Tink via security-crypto, WorkManager Workers, Room, enums/Parcelable/native) are pinned by
+            // explicit keep rules in proguard-rules.pro. Device-verify a launch before trusting a real ship.
+            isMinifyEnabled = true
+            isShrinkResources = true
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro"

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -74,6 +74,13 @@ android {
                 signingConfigs.getByName("release")
             else
                 signingConfigs.getByName("debug")
+            // Fork staging release: built with -PstagingRelease (the fork testing-build CI only), the
+            // release APK gets its own id/name so it installs BESIDE both the official app and the
+            // .debug staging build. A real release (no property) keeps the true com.noop.whoop id.
+            if (project.hasProperty("stagingRelease")) {
+                applicationIdSuffix = ".staging"
+                versionNameSuffix = "-staging"
+            }
         }
     }
 

--- a/android/app/proguard-rules.pro
+++ b/android/app/proguard-rules.pro
@@ -1,8 +1,8 @@
 # NOOP — R8 / ProGuard rules.
 #
-# The app is offline and reflection-light. Room generates its own keep rules, and
-# Compose ships consumer rules, so this file is mostly empty by design. Add keeps
-# here only if a release build strips something the BLE/protocol layer needs at runtime.
+# The app is offline and reflection-light, but the release build now runs R8 (minify +
+# resource shrink; full-mode OFF — see gradle.properties). These keeps pin the handful of
+# reflective survivors so a shrunk release matches the debug build's runtime behaviour.
 
 # Keep Room-generated database implementation classes (Room embeds its own rules too,
 # but this is an explicit safety net for the *_Impl classes it generates).
@@ -11,6 +11,46 @@
 # Protocol enums are matched by Int rawValue via fromRaw(...); keep their members so a
 # future reflective/serialized path can't be broken by minification. They are small.
 -keep class com.noop.protocol.** { *; }
+
+# --- Reflective survivors that R8 would otherwise strip/rename ---
+
+# Google Tink (via androidx.security:security-crypto → EncryptedSharedPreferences for the
+# encrypted key store). Tink registers KeyManagers reflectively and uses protobuf-generated
+# classes; strip/rename either and the encrypted store throws at first use. Keep both.
+-keep class com.google.crypto.tink.** { *; }
+-keep class com.google.protobuf.** { *; }
+-dontwarn com.google.crypto.tink.**
+-dontwarn com.google.protobuf.**
+
+# WorkManager instantiates ListenableWorker subclasses reflectively via the default
+# WorkerFactory: Class.forName(name).getConstructor(Context, WorkerParameters). Keep every
+# Worker's (Context, WorkerParameters) constructor or a background job dies with a ClassNotFound.
+-keep public class * extends androidx.work.ListenableWorker {
+    public <init>(android.content.Context, androidx.work.WorkerParameters);
+}
+
+# enum values()/valueOf() are reached reflectively (and by R8's own enum handling). Full-mode
+# is off, but keep them explicitly so ordinal/name round-trips (settings, exports) stay intact.
+-keepclassmembers enum * {
+    public static **[] values();
+    public static ** valueOf(java.lang.String);
+}
+
+# Parcelable CREATOR fields are read reflectively by the framework.
+-keepclassmembers class * implements android.os.Parcelable {
+    public static final ** CREATOR;
+}
+
+# JNI-bound methods must keep their names.
+-keepclasseswithmembernames class * {
+    native <methods>;
+}
+
+# okhttp/okio ship consumer rules but reference optional platform classes not on-device.
+-dontwarn okhttp3.internal.platform.**
+-dontwarn org.conscrypt.**
+-dontwarn org.bouncycastle.**
+-dontwarn org.openjsse.**
 
 # Tink (pulled in by androidx.security:security-crypto for the encrypted AI-key store)
 # references errorprone annotations that aren't on the runtime classpath. They're

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -18,8 +18,10 @@ android.useAndroidX=true
 # Kotlin code style for the IDE.
 kotlin.code.style=official
 
-# R8 full mode for release builds.
-android.enableR8.fullMode=true
+# R8 full mode OFF: full-mode's aggressive reflection-stripping crashed release on launch
+# (Compose/Room/Tink). Standard R8 still shrinks/optimises but keeps default constructors and is
+# forgiving of the reflective libs here. Re-enable only after a device-verified minified launch.
+android.enableR8.fullMode=false
 
 # Only keep the resources for the configurations actually used (smaller APK).
 android.nonTransitiveRClass=true


### PR DESCRIPTION
## What

Follow-up to PR #1 — lands the two commits that were pushed to `snapshot-v8.2.2` *after* PR #1 merged (which captured the earlier head `0a58630d`):

- **`26156fc9`** — fork CI: adds a **staging-release APK** (`assembleFullRelease -PstagingRelease`, `.staging` app-id so it installs beside the official app) and **version-stamps every artifact** (`app-full-release-v<VER>.apk`, `app-full-debug-v<VER>.apk`, `NOOP-macos-v<VER>.zip`, `NOOP-ios-unsigned-v<VER>.ipa`).
- **`01005749`** — **optimise the release APK**: R8 minify + resource shrink, full-mode OFF, with keep rules for the reflective survivors (Tink/protobuf, WorkManager Workers, enums, Parcelable, native). Verified locally: R8 clean, **18 MB → 4.6 MB**, 4 dex → 1.

## Note

The optimised release APK is un-device-tested (this build type crashed on launch before, under R8 full-mode — now off + keep-ruled). It's published to the fork `testing-latest` release specifically so it can be install-verified on a real device before being trusted for a real ship.
