### PR TITLE
Revert release to unminified (R8 minify crashes at runtime); keep staging-release + versioned names

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -58,13 +58,13 @@ android {
             versionNameSuffix = "-debug"
         }
         release {
-            // Optimised release: R8 code shrink + resource shrink ON. The earlier crash-on-launch was
-            // R8 *full-mode* over-stripping reflective paths (Compose/Room/Tink) — that aggressive mode is
-            // now OFF (android.enableR8.fullMode=false in gradle.properties) and the reflective survivors
-            // (Tink via security-crypto, WorkManager Workers, Room, enums/Parcelable/native) are pinned by
-            // explicit keep rules in proguard-rules.pro. Device-verify a launch before trusting a real ship.
-            isMinifyEnabled = true
-            isShrinkResources = true
+            // Shipped UNMINIFIED for reliability. R8 minification crashes this app at runtime: full-mode
+            // over-strips reflective paths, and even with full-mode OFF + broad keeps (com.noop.** +
+            // Tink/Worker/ViewModel) a minified build STILL died right after the terms gate on a real
+            // device — a library reflective path we couldn't pin without a device to trace. Offline app,
+            // a ~18 MB APK is fine. Re-enabling minify needs the exact crash trace + device verification.
+            isMinifyEnabled = false
+            isShrinkResources = false
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro"

--- a/android/app/proguard-rules.pro
+++ b/android/app/proguard-rules.pro
@@ -12,6 +12,20 @@
 # future reflective/serialized path can't be broken by minification. They are small.
 -keep class com.noop.protocol.** { *; }
 
+# Keep ALL of NOOP's own code. The app's reflective surface is broader than data/protocol:
+# Compose viewModel() instantiates ViewModels (com.noop.ui.*ViewModel) by reflection, Glance
+# instantiates widget classes, and manifest components are resolved by name. R8 renaming any of
+# these crashes the app the first time real content composes (observed: "Accept & Continue" on the
+# terms gate → exit, because the post-gate content resolves AppViewModel/CoachViewModel reflectively).
+# App code is not the size bulk — the shrink win is in the androidx/Compose/kotlin libraries, which
+# still shrink — so keeping our own classes buys reliability cheaply.
+-keep class com.noop.** { *; }
+
+# Generic safety net for any ViewModel (incl. non-com.noop): keep the constructors reflective
+# instantiation needs.
+-keep class * extends androidx.lifecycle.ViewModel { <init>(...); }
+-keep class * extends androidx.lifecycle.AndroidViewModel { <init>(...); }
+
 # --- Reflective survivors that R8 would otherwise strip/rename ---
 
 # Google Tink (via androidx.security:security-crypto → EncryptedSharedPreferences for the

--- a/android/app/proguard-rules.pro
+++ b/android/app/proguard-rules.pro
@@ -1,8 +1,11 @@
 # NOOP — R8 / ProGuard rules.
 #
-# The app is offline and reflection-light, but the release build now runs R8 (minify +
-# resource shrink; full-mode OFF — see gradle.properties). These keeps pin the handful of
-# reflective survivors so a shrunk release matches the debug build's runtime behaviour.
+# The app is offline and reflection-light. Room generates its own keep rules, and
+# Compose ships consumer rules, so this file is mostly empty by design. Add keeps
+# here only if a release build strips something the BLE/protocol layer needs at runtime.
+#
+# NOTE: release currently ships UNMINIFIED (build.gradle.kts) because R8 crashed it at
+# runtime even with broad keeps — so these rules are dormant until minify is re-enabled.
 
 # Keep Room-generated database implementation classes (Room embeds its own rules too,
 # but this is an explicit safety net for the *_Impl classes it generates).
@@ -11,60 +14,6 @@
 # Protocol enums are matched by Int rawValue via fromRaw(...); keep their members so a
 # future reflective/serialized path can't be broken by minification. They are small.
 -keep class com.noop.protocol.** { *; }
-
-# Keep ALL of NOOP's own code. The app's reflective surface is broader than data/protocol:
-# Compose viewModel() instantiates ViewModels (com.noop.ui.*ViewModel) by reflection, Glance
-# instantiates widget classes, and manifest components are resolved by name. R8 renaming any of
-# these crashes the app the first time real content composes (observed: "Accept & Continue" on the
-# terms gate → exit, because the post-gate content resolves AppViewModel/CoachViewModel reflectively).
-# App code is not the size bulk — the shrink win is in the androidx/Compose/kotlin libraries, which
-# still shrink — so keeping our own classes buys reliability cheaply.
--keep class com.noop.** { *; }
-
-# Generic safety net for any ViewModel (incl. non-com.noop): keep the constructors reflective
-# instantiation needs.
--keep class * extends androidx.lifecycle.ViewModel { <init>(...); }
--keep class * extends androidx.lifecycle.AndroidViewModel { <init>(...); }
-
-# --- Reflective survivors that R8 would otherwise strip/rename ---
-
-# Google Tink (via androidx.security:security-crypto → EncryptedSharedPreferences for the
-# encrypted key store). Tink registers KeyManagers reflectively and uses protobuf-generated
-# classes; strip/rename either and the encrypted store throws at first use. Keep both.
--keep class com.google.crypto.tink.** { *; }
--keep class com.google.protobuf.** { *; }
--dontwarn com.google.crypto.tink.**
--dontwarn com.google.protobuf.**
-
-# WorkManager instantiates ListenableWorker subclasses reflectively via the default
-# WorkerFactory: Class.forName(name).getConstructor(Context, WorkerParameters). Keep every
-# Worker's (Context, WorkerParameters) constructor or a background job dies with a ClassNotFound.
--keep public class * extends androidx.work.ListenableWorker {
-    public <init>(android.content.Context, androidx.work.WorkerParameters);
-}
-
-# enum values()/valueOf() are reached reflectively (and by R8's own enum handling). Full-mode
-# is off, but keep them explicitly so ordinal/name round-trips (settings, exports) stay intact.
--keepclassmembers enum * {
-    public static **[] values();
-    public static ** valueOf(java.lang.String);
-}
-
-# Parcelable CREATOR fields are read reflectively by the framework.
--keepclassmembers class * implements android.os.Parcelable {
-    public static final ** CREATOR;
-}
-
-# JNI-bound methods must keep their names.
--keepclasseswithmembernames class * {
-    native <methods>;
-}
-
-# okhttp/okio ship consumer rules but reference optional platform classes not on-device.
--dontwarn okhttp3.internal.platform.**
--dontwarn org.conscrypt.**
--dontwarn org.bouncycastle.**
--dontwarn org.openjsse.**
 
 # Tink (pulled in by androidx.security:security-crypto for the encrypted AI-key store)
 # references errorprone annotations that aren't on the runtime classpath. They're

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -18,10 +18,8 @@ android.useAndroidX=true
 # Kotlin code style for the IDE.
 kotlin.code.style=official
 
-# R8 full mode OFF: full-mode's aggressive reflection-stripping crashed release on launch
-# (Compose/Room/Tink). Standard R8 still shrinks/optimises but keeps default constructors and is
-# forgiving of the reflective libs here. Re-enable only after a device-verified minified launch.
-android.enableR8.fullMode=false
+# R8 full mode for release builds. (Moot while release ships unminified — see build.gradle.kts.)
+android.enableR8.fullMode=true
 
 # Only keep the resources for the configurations actually used (smaller APK).
 android.nonTransitiveRClass=true


### PR DESCRIPTION
## What

Lands on `main` the two commits pushed to `snapshot-v8.2.2` after PR #2:

- `daf186fe` — attempted keep-rule fix for the minified release (kept `com.noop.**` so Compose `viewModel()` wouldn't crash after the terms gate), then
- `8d2e2ae2` — **revert the release to UNMINIFIED**, because minify still crashed at runtime on a library reflective path even with broad keeps.

Net effect on `main`: the release build goes from the **crashing minified config (from PR #2)** back to the reliable **unminified** build the maintainer ships.

## Why

Device-confirmed: the minified release exited on "Accept & Continue" and hit the error screen on reopen; the **debug (unminified) APK works fine through the same flow**, proving it's R8-specific, not a code bug. Unminified release (~18 MB) verified launching on-device.

## Kept

The fork staging-release APK (`-PstagingRelease` → `.staging` id, installs beside official) and version-stamped artifact filenames — both orthogonal to minify.
