### PR TITLE
Backup & Sync: keep-count dropdown, default 7, ~1am daily, Settings discoverability

### DIFF
--- a/android/app/src/main/java/com/noop/ui/AppRoot.kt
+++ b/android/app/src/main/java/com/noop/ui/AppRoot.kt
@@ -425,7 +425,11 @@ fun AppRoot(viewModel: AppViewModel = viewModel()) {
                 composable(Destination.BackupSync.route) { BackupSyncScreen() }
                 composable(Destination.Notifications.route) { NotificationsSettingsScreen(viewModel) }
                 composable(Destination.Settings.route) {
-                    SettingsScreen(viewModel, onOpenTestCentre = { nav.navigate(Destination.TestCentre.route) })
+                    SettingsScreen(
+                        viewModel,
+                        onOpenTestCentre = { nav.navigate(Destination.TestCentre.route) },
+                        onOpenBackupSync = { nav.navigate(Destination.BackupSync.route) },
+                    )
                 }
                 composable(Destination.TestCentre.route) { TestCentreScreen(viewModel) }
                 // The "More" page — the iOS More tab's twin: a navigated ScreenScaffold page hosting the

--- a/android/app/src/main/java/com/noop/ui/BackupSync.kt
+++ b/android/app/src/main/java/com/noop/ui/BackupSync.kt
@@ -13,6 +13,7 @@ import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
 import java.util.TimeZone
+import java.util.Calendar
 import java.util.concurrent.TimeUnit
 
 /**
@@ -43,11 +44,30 @@ object BackupSync {
     /** Generic binary MIME for the SAF createDocument call (the bytes are a ZIP container). */
     const val MIME = "application/octet-stream"
 
-    /** Default snapshots kept by prune. Identical to the Apple `FolderBackup.keepCount`. */
-    const val DEFAULT_KEEP = 10
+    /** Default snapshots kept by prune: 7, i.e. a week of daily rollback points. (The Apple twin still
+     *  defaults to 10; this fork lowered it — parity dropdown on iOS is a follow-up.) */
+    const val DEFAULT_KEEP = 7
 
     /** A day in ms - the catch-up cadence (mirrors the Apple `dayMs`). */
     private const val DAY_MS = 24L * 60L * 60L * 1000L
+
+    /** Time-of-day the daily snapshot fires: 01:00 (minutes since midnight). A quiet hour; WorkManager
+     *  isn't exact and may slide it into a maintenance window, which is fine for a backup. */
+    const val BACKUP_MINUTE_OF_DAY = 60
+
+    /** Ms from [nowMs] to the next 01:00 wall-clock (today if still ahead, else tomorrow). Pure +
+     *  injectable so the arithmetic is unit-testable without a real clock. Mirrors DebugExportScheduler. */
+    fun delayToNextBackupMs(nowMs: Long = System.currentTimeMillis()): Long {
+        val next = Calendar.getInstance().apply {
+            timeInMillis = nowMs
+            set(Calendar.HOUR_OF_DAY, BACKUP_MINUTE_OF_DAY / 60)
+            set(Calendar.MINUTE, BACKUP_MINUTE_OF_DAY % 60)
+            set(Calendar.SECOND, 0)
+            set(Calendar.MILLISECOND, 0)
+            if (timeInMillis <= nowMs) add(Calendar.DAY_OF_YEAR, 1)
+        }
+        return next.timeInMillis - nowMs
+    }
 
     // ── Pure helpers (unit-tested; mirror the Apple BackupSync) ─────────────────
 
@@ -246,7 +266,12 @@ object BackupSync {
             wm.cancelUniqueWork(WORK)
             return
         }
-        val req = PeriodicWorkRequestBuilder<BackupSyncWorker>(1, TimeUnit.DAYS).build()
+        // Anchor the first run to the next 01:00, then repeat daily. KEEP so an already-scheduled job keeps
+        // its anchor rather than resetting on every app-start (matches DebugExportScheduler); toggling auto
+        // off then on re-anchors. On-launch [catchUpIfDue] still covers any missed day regardless of timing.
+        val req = PeriodicWorkRequestBuilder<BackupSyncWorker>(1, TimeUnit.DAYS)
+            .setInitialDelay(delayToNextBackupMs(), TimeUnit.MILLISECONDS)
+            .build()
         wm.enqueueUniquePeriodicWork(WORK, ExistingPeriodicWorkPolicy.KEEP, req)
     }
 

--- a/android/app/src/main/java/com/noop/ui/BackupSyncScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/BackupSyncScreen.kt
@@ -8,6 +8,7 @@ import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -19,6 +20,8 @@ import androidx.compose.material.icons.filled.CloudUpload
 import androidx.compose.material.icons.filled.FolderOpen
 import androidx.compose.material.icons.filled.Restore
 import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.Switch
 import androidx.compose.material3.SwitchDefaults
 import androidx.compose.material3.Text
@@ -61,6 +64,9 @@ fun BackupSyncScreen() {
     var auto by remember { mutableStateOf(BackupSyncPrefs.autoEnabled(context)) }
     var lastMs by remember { mutableStateOf(BackupSyncPrefs.lastBackupMs(context)) }
     var busy by remember { mutableStateOf(false) }
+    // How many dated snapshots to keep; pruning deletes the oldest beyond this (BackupSync.snapshotsToPrune).
+    var keep by remember { mutableStateOf(BackupSyncPrefs.keepCount(context)) }
+    var keepMenu by remember { mutableStateOf(false) }
 
     // Restore-from-folder sheet state: the listed snapshots, and the one pending confirmation.
     var snapshots by remember { mutableStateOf<List<BackupSync.SnapshotDoc>>(emptyList()) }
@@ -149,8 +155,8 @@ fun BackupSyncScreen() {
                         ) {
                             Text("Daily auto-backup", style = NoopType.body, color = Palette.textPrimary)
                             Text(
-                                "Writes a fresh backup to your folder about once a day (keeps the latest " +
-                                    "${BackupSyncPrefs.keepCount(context)}). Off by default - flip it on if you want it.",
+                                "Writes a fresh dated backup to your folder about once a day (keeps the latest " +
+                                    "$keep). Off by default - flip it on if you want it.",
                                 style = NoopType.footnote, color = Palette.textTertiary,
                             )
                         }
@@ -171,6 +177,50 @@ fun BackupSyncScreen() {
                                 uncheckedBorderColor = Palette.hairline,
                             ),
                         )
+                    }
+                    // Retention: how many dated snapshots to keep. Wired to the existing setKeepCount; the
+                    // next backup (auto or "Back up now") prunes the oldest beyond this count.
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        Column(
+                            modifier = Modifier.weight(1f),
+                            verticalArrangement = Arrangement.spacedBy(2.dp),
+                        ) {
+                            Text("Keep last snapshots", style = NoopType.body, color = Palette.textPrimary)
+                            Text(
+                                "Older backups beyond this many are pruned, oldest first.",
+                                style = NoopType.footnote, color = Palette.textTertiary,
+                            )
+                        }
+                        Spacer(Modifier.width(16.dp))
+                        Box {
+                            TextButton(
+                                enabled = treeUri != null && !busy,
+                                onClick = { keepMenu = true },
+                            ) {
+                                Text("$keep", style = NoopType.body, color = Palette.accent)
+                            }
+                            DropdownMenu(
+                                expanded = keepMenu,
+                                onDismissRequest = { keepMenu = false },
+                            ) {
+                                KEEP_OPTIONS.forEach { n ->
+                                    DropdownMenuItem(
+                                        text = {
+                                            Text(
+                                                "$n",
+                                                style = NoopType.body,
+                                                color = if (n == keep) Palette.accent else Palette.textPrimary,
+                                            )
+                                        },
+                                        onClick = {
+                                            keep = n
+                                            BackupSyncPrefs.setKeepCount(context, n)
+                                            keepMenu = false
+                                        },
+                                    )
+                                }
+                            }
+                        }
                     }
                     Text(
                         if (lastMs > 0L) {
@@ -337,6 +387,10 @@ fun BackupSyncScreen() {
  * slips through still meets importFrom's magic-byte + Room/GRDB-origin validation before it can touch
  * the live DB.
  */
+/** Retention choices for the "Keep last snapshots" menu. Each snapshot is a dated .noopbak; the daily
+ *  job keeps this many and prunes the oldest. Kept modest — a few days of rollback without hoarding. */
+private val KEEP_OPTIONS = listOf(1, 3, 5, 7, 10, 14)
+
 private val RESTORE_MIME_TYPES = arrayOf(
     "application/octet-stream",
     "application/zip",

--- a/android/app/src/main/java/com/noop/ui/BackupSyncScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/BackupSyncScreen.kt
@@ -155,8 +155,8 @@ fun BackupSyncScreen() {
                         ) {
                             Text("Daily auto-backup", style = NoopType.body, color = Palette.textPrimary)
                             Text(
-                                "Writes a fresh dated backup to your folder about once a day (keeps the latest " +
-                                    "$keep). Off by default - flip it on if you want it.",
+                                "Writes a fresh dated backup to your folder once a day (around 1am), keeping the " +
+                                    "latest $keep. Off by default - flip it on if you want it.",
                                 style = NoopType.footnote, color = Palette.textTertiary,
                             )
                         }
@@ -187,7 +187,8 @@ fun BackupSyncScreen() {
                         ) {
                             Text("Keep last snapshots", style = NoopType.body, color = Palette.textPrimary)
                             Text(
-                                "Older backups beyond this many are pruned, oldest first.",
+                                "Older backups beyond this many are pruned, oldest first (≈ that many days of " +
+                                    "daily backups). For recovery: if data ever corrupts, grab the newest snapshot.",
                                 style = NoopType.footnote, color = Palette.textTertiary,
                             )
                         }

--- a/android/app/src/main/java/com/noop/ui/SettingsScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/SettingsScreen.kt
@@ -52,6 +52,7 @@ import androidx.compose.material.icons.filled.SaveAlt
 import androidx.compose.material.icons.filled.Science
 import androidx.compose.material.icons.filled.Sensors
 import androidx.compose.material.icons.filled.Straighten
+import androidx.compose.material.icons.filled.CloudSync
 import androidx.compose.material.icons.filled.Storage
 import androidx.compose.material.icons.filled.Upload
 import androidx.compose.material.icons.filled.Vibration
@@ -312,7 +313,11 @@ class ProfileStore(private val prefs: SharedPreferences) {
 // MARK: - Screen
 
 @Composable
-fun SettingsScreen(vm: AppViewModel, onOpenTestCentre: () -> Unit = {}) {
+fun SettingsScreen(
+    vm: AppViewModel,
+    onOpenTestCentre: () -> Unit = {},
+    onOpenBackupSync: () -> Unit = {},
+) {
     val context = LocalContext.current
     val scope = rememberCoroutineScope()
     val live by vm.live.collectAsStateWithLifecycle()
@@ -1965,6 +1970,24 @@ fun SettingsScreen(vm: AppViewModel, onOpenTestCentre: () -> Unit = {}) {
                         "Export CSV writes a WHOOP-format zip of your days, sleeps, workouts and journal that re-imports into NOOP on Android or Mac. On-device computed rows are marked APPROXIMATE in its Source column; the .noopbak backup stays the lossless restore path.",
                 )
             }
+        }
+
+        // --- Automatic backups ---
+        // Discoverability signpost: the daily-backup toggle, folder picker and keep-count live on the
+        // separate Backup & Sync screen; surface an entry here, right under the one-off Backup & restore,
+        // since that's where a user looks for "turn on automatic backups".
+        SettingsSection(
+            icon = Icons.Filled.CloudSync,
+            title = "Automatic backups",
+            blurb = "Have NOOP save a dated backup to a folder every day (around 1am) and keep the last several - so if data ever corrupts, restore the newest. Point the folder at Drive/Dropbox for off-device copies. Off until you switch it on.",
+        ) {
+            NoopButton(
+                text = "Set up automatic backups",
+                leadingIcon = Icons.Filled.CloudSync,
+                kind = NoopButtonKind.Primary,
+                fullWidth = true,
+                onClick = onOpenBackupSync,
+            )
         }
 
         // --- About ---

--- a/android/app/src/test/java/com/noop/ui/BackupSyncTest.kt
+++ b/android/app/src/test/java/com/noop/ui/BackupSyncTest.kt
@@ -51,9 +51,21 @@ class BackupSyncTest {
         assertTrue(BackupSync.snapshotsToPrune(names, keep = 10).isEmpty())
     }
 
-    @Test fun defaultKeepMatchesApple() {
-        // Must-fix #6: the keep-N default is 10 on both platforms.
-        assertEquals(10, BackupSync.DEFAULT_KEEP)
+    @Test fun defaultKeepIsAWeek() {
+        // Fork choice: a week of daily rollback points. (Apple twin still defaults to 10; the keep-count
+        // is now user-adjustable via the Backup & Sync dropdown regardless.)
+        assertEquals(7, BackupSync.DEFAULT_KEEP)
+    }
+
+    @Test fun backupDelayLandsAtOneAm() {
+        // The daily snapshot is anchored to 01:00 local: from any instant, the delay must put the next
+        // fire at hour 01:00, within the next 24h. TZ-agnostic (checks the resolved wall-clock).
+        val now = 1_700_000_000_000L
+        val delay = BackupSync.delayToNextBackupMs(now)
+        assertTrue(delay in 1..(24L * 60 * 60 * 1000))
+        val fire = java.util.Calendar.getInstance().apply { timeInMillis = now + delay }
+        assertEquals(1, fire.get(java.util.Calendar.HOUR_OF_DAY))
+        assertEquals(0, fire.get(java.util.Calendar.MINUTE))
     }
 
     @Test fun catchUpDueOnlyAfterADay() {


### PR DESCRIPTION
## What

Backup & Sync tuning — makes the daily auto-backup useful for corruption recovery and discoverable:

- **`d1552a63`** — a **"Keep last snapshots"** dropdown on the Backup & Sync screen (1 / 3 / 5 / 7 / 10 / 14), wired to the existing `setKeepCount`; pruning removes the oldest beyond the chosen count (unchanged `snapshotsToPrune`).
- **`dcda27a2`** — **default keep = 7** (a week of daily rollback points) and the daily job is **anchored to ~01:00** (`setInitialDelay(delayToNextBackupMs())`, mirroring `DebugExportScheduler`); on-launch `catchUpIfDue` still covers a missed day.
- **`996fbb8f`** — a **"Automatic backups"** section in **Settings, right below "Backup & restore"**, with a "Set up automatic backups" button that opens the Backup & Sync screen (new `onOpenBackupSync` nav callback) — so users find it where they look.

## Notes

- Same `.noopbak` format as manual Backup & Restore (both go through `DataBackup.exportTo`/`importFrom`) — snapshots are interchangeable.
- Auto-backup stays **opt-in / off by default**; the toggle cancels the WorkManager job and the worker re-checks the flag, so it can be fully disabled.
- ~1am is best-effort (WorkManager, not an exact alarm).
- iOS parity: the twin `FolderBackup.keepCount` still defaults to 10 with no picker — a matching iOS dropdown + default is a follow-up.

## Testing

`BackupSyncTest` 13 pass (default-is-7 assertion updated; added `backupDelayLandsAtOneAm`). Compiles clean; published to the fork `testing-latest` build.
