### PR TITLE
iOS Backup & Sync: mirror Android adjustable keep-count (default 7)

### DIFF
--- a/Strand/Data/BackupSync.swift
+++ b/Strand/Data/BackupSync.swift
@@ -112,9 +112,24 @@ enum FolderBackup {
     private static let bookmarkKey = "backupSync.folderBookmark"
     private static let autoKey = "backupSync.auto"
     private static let lastKey = "backupSync.lastMs"
+    private static let keepKey = "backupSync.keepCount"
 
-    /// Keep the latest N snapshots in the folder; older ones are pruned. Matches the Android default.
-    static let keepCount = 10
+    /// Default snapshots kept by prune: 7, i.e. a week of daily rollback points. (Mirrors the Android
+    /// DEFAULT_KEEP; the Android keep-count is likewise user-adjustable.)
+    static let defaultKeep = 7
+
+    /// Retention choices offered by the Backup & Sync keep-count picker (mirrors Android KEEP_OPTIONS).
+    static let keepOptions = [1, 3, 5, 7, 10, 14]
+
+    /// How many latest snapshots to keep; older ones are pruned (oldest-first). User-adjustable via the
+    /// picker; unset reads back as [defaultKeep]. Clamped to a sane 1...100.
+    static var keepCount: Int {
+        get {
+            let v = UserDefaults.standard.integer(forKey: keepKey)   // 0 when never set
+            return v == 0 ? defaultKeep : min(max(v, 1), 100)
+        }
+        set { UserDefaults.standard.set(min(max(newValue, 1), 100), forKey: keepKey) }
+    }
     private static let dayMs = 24 * 60 * 60 * 1000
 
     // MARK: - Persisted state

--- a/Strand/Screens/BackupSyncView.swift
+++ b/Strand/Screens/BackupSyncView.swift
@@ -11,6 +11,7 @@ struct BackupSyncView: View {
     @State private var auto = FolderBackup.autoEnabled
     @State private var folderLabel = FolderBackup.folderLabel()
     @State private var lastMs = FolderBackup.lastBackupMs
+    @State private var keep = FolderBackup.keepCount
     @State private var busy = false
 
     // Result alert (backup outcome / restore outcome).
@@ -88,7 +89,7 @@ struct BackupSyncView: View {
                     VStack(alignment: .leading, spacing: 2) {
                         Text("Daily auto-backup")
                             .font(StrandFont.body).foregroundStyle(StrandPalette.textPrimary)
-                        Text("Backs up to your folder about once a day and keeps the latest \(FolderBackup.keepCount). On this platform it runs when you next open NOOP.")
+                        Text("Backs up to your folder about once a day and keeps the latest \(keep). On this platform it runs when you next open NOOP.")
                             .font(StrandFont.footnote).foregroundStyle(StrandPalette.textTertiary)
                             .fixedSize(horizontal: false, vertical: true)
                     }
@@ -97,6 +98,23 @@ struct BackupSyncView: View {
                         .labelsHidden().toggleStyle(.switch).tint(StrandPalette.accent)
                         .disabled(folderLabel == nil)
                         .onChangeCompat(of: auto) { on in FolderBackup.autoEnabled = on }
+                }
+                // Retention: how many dated snapshots to keep. Wired to FolderBackup.keepCount; the next
+                // backup prunes the oldest beyond this count (BackupSync.snapshotsToPrune, unchanged).
+                HStack(alignment: .center, spacing: 16) {
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text("Keep last snapshots")
+                            .font(StrandFont.body).foregroundStyle(StrandPalette.textPrimary)
+                        Text("Older backups beyond this many are pruned, oldest first (≈ that many days). If data ever corrupts, restore the newest.")
+                            .font(StrandFont.footnote).foregroundStyle(StrandPalette.textTertiary)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+                    Spacer(minLength: 0)
+                    Picker("Keep last snapshots", selection: $keep) {
+                        ForEach(FolderBackup.keepOptions, id: \.self) { n in Text("\(n)").tag(n) }
+                    }
+                    .labelsHidden().pickerStyle(.menu).tint(StrandPalette.accent)
+                    .onChangeCompat(of: keep) { n in FolderBackup.keepCount = n }
                 }
                 Text(lastMs > 0 ? "Last backup: \(relativeTime(lastMs))" : "No backup yet.")
                     .font(StrandFont.caption).foregroundStyle(StrandPalette.textTertiary)


### PR DESCRIPTION
## What

Mirrors the Android keep-count work onto iOS so the Backup & Sync retention is at parity.

- **`FolderBackup.keepCount`**: `static let 10` → user-adjustable (UserDefaults-backed), **default 7**, options `[1,3,5,7,10,14]`, clamped 1…100 (mirrors Android `DEFAULT_KEEP`/`KEEP_OPTIONS`/`setKeepCount`). `prune()` already reads it, so it now honours the choice.
- **`BackupSyncView`**: a "Keep last snapshots" menu picker below the auto toggle, wired to `keepCount`; blurb shows the live count.

## Intentionally NOT mirrored (platform difference)

The Android ~1am WorkManager anchor. iOS has no reliable timed background scheduler (BackgroundTasks is throttled), so it stays the existing **on-launch catch-up** — bounded to ≤1 backup per 24h by its guard, and the screen already says "runs when you next open NOOP". The Settings signpost also already exists on iOS.

## Verification

Swift is CI-gated (no local compile on WSL) — the fork **iOS + macOS build jobs passed** on this branch (run 28836400030), which is the compile check.
