### PR TITLE
Compiler-warning cleanup: redundant operators, AutoMirrored icons, shadows, always-true conditions

### DIFF
--- a/android/app/src/main/java/com/noop/ai/AiCoach.kt
+++ b/android/app/src/main/java/com/noop/ai/AiCoach.kt
@@ -409,7 +409,7 @@ class AiCoach(private val repo: WhoopRepository) {
 
         // Local servers (notably Ollama) stop with finish_reason "length" at the context-window edge
         // and give NO error, keep the partial text and append the actionable notice so it isn't silent.
-        val truncated = firstChoice?.optString("finish_reason")?.lowercase() == "length"
+        val truncated = firstChoice.optString("finish_reason").lowercase() == "length"
         return if (truncated) content + TRUNCATION_NOTE else content
     }
 

--- a/android/app/src/main/java/com/noop/analytics/CaffeineDecay.kt
+++ b/android/app/src/main/java/com/noop/analytics/CaffeineDecay.kt
@@ -151,7 +151,7 @@ data class CaffeineActiveEstimate(
                     mgSum += CaffeineDecay.remainingMg(it, hours, halfLifeHours)
                     anyMg = true
                 }
-                if (mostRecentActiveHours == null || hours < mostRecentActiveHours!!) {
+                if (mostRecentActiveHours == null || hours < mostRecentActiveHours) {
                     mostRecentActiveHours = hours
                 }
             }

--- a/android/app/src/main/java/com/noop/analytics/WatchRecovery.kt
+++ b/android/app/src/main/java/com/noop/analytics/WatchRecovery.kt
@@ -49,8 +49,8 @@ object WatchRecovery {
     ): Result {
         // Build both baselines through the production model (Winsorized EWMA + cold-start gating), exactly
         // as the strap path does. HRV feeds the HRV config; resting HR feeds the RHR config.
-        val hrvBase = Baselines.foldHistory(hrvHistory.map { it as Double? }, Baselines.hrvCfg)
-        val rhrBase = Baselines.foldHistory(rhrHistory.map { it as Double? }, Baselines.restingHRCfg)
+        val hrvBase = Baselines.foldHistory(hrvHistory, Baselines.hrvCfg)
+        val rhrBase = Baselines.foldHistory(rhrHistory, Baselines.restingHRCfg)
 
         // Confidence is the SAME helper the strap Charge uses, so the calibrating -> building -> solid arc
         // matches. It reads CALIBRATING whenever recovery would be null (no usable HRV baseline).

--- a/android/app/src/main/java/com/noop/ble/Backfiller.kt
+++ b/android/app/src/main/java/com/noop/ble/Backfiller.kt
@@ -362,12 +362,12 @@ class Backfiller(
                 for (f in frames) {
                     if (spo2Dumped >= com.noop.analytics.Spo2ReTrace.MAX_SAMPLES) break
                     val d = decodeHistorical(f, family) ?: continue
-                    val unix = d["unix"] as? Int ?: continue
+                    val recUnix = d["unix"] as? Int ?: continue
                     connectionLog(
                         com.noop.analytics.Spo2ReTrace.recordLine(
                             frame = f,
                             version = d["hist_version"] as? Int,
-                            unix = unix,
+                            unix = recUnix,
                             red = d["spo2_red"] as? Int,
                             ir = d["spo2_ir"] as? Int,
                             skinRaw = d["skin_temp_raw"] as? Int,

--- a/android/app/src/main/java/com/noop/ble/SourceCoordinator.kt
+++ b/android/app/src/main/java/com/noop/ble/SourceCoordinator.kt
@@ -361,7 +361,7 @@ class SourceCoordinator(
             // The ring generation is carried on the row's model ("Oura Ring 3/4/5"); recover it so the
             // transport clamps the MTU + picks the gen-appropriate live-HR enable command set. Defaults to
             // gen3 if the model is missing/unrecognised (OuraRingGen.from).
-            val ringGen = OuraRingGen.from(row?.model ?: "")
+            val ringGen = OuraRingGen.from(row.model ?: "")
             val source = OuraLiveSource(
                 context = ctx,
                 deviceId = id,

--- a/android/app/src/main/java/com/noop/ble/StandardHrSource.kt
+++ b/android/app/src/main/java/com/noop/ble/StandardHrSource.kt
@@ -375,9 +375,9 @@ class StandardHrSource(
             // exposes — a footpod / bike speed-cadence sensor / power meter read ALONGSIDE HR. Separate
             // services from HR; a device without them yields no characteristic and the HR path is untouched.
             for ((svcUuid, charUuid) in FITNESS_SENSOR_CHARS) {
-                val ch = g.getService(svcUuid)?.getCharacteristic(charUuid) ?: continue
+                val sensorCh = g.getService(svcUuid)?.getCharacteristic(charUuid) ?: continue
                 log("HR-strap: fitness-sensor characteristic $charUuid found — enabling notifications")
-                enableFitnessNotify(g, ch)
+                enableFitnessNotify(g, sensorCh)
             }
         }
 

--- a/android/app/src/main/java/com/noop/data/DataBackup.kt
+++ b/android/app/src/main/java/com/noop/data/DataBackup.kt
@@ -177,7 +177,6 @@ object DataBackup {
                 StageResult.NOT_A_BACKUP -> return ImportResult.Failed(
                     "That file is not a NOOP backup - it doesn't look like a .noopbak archive or a SQLite database."
                 )
-                else -> error("unreachable stage result $staged")
             }
         } catch (e: IOException) {
             tempSqlite.delete()

--- a/android/app/src/main/java/com/noop/ingest/CsvParser.kt
+++ b/android/app/src/main/java/com/noop/ingest/CsvParser.kt
@@ -502,7 +502,7 @@ internal object WhoopTime {
         else if (s.startsWith("-")) { sign = -1; s = s.substring(1) }
 
         // Accept HH:MM or HHMM.
-        var hours = 0
+        var hours: Int
         var minutes = 0
         val colonIdx = s.indexOf(':')
         if (colonIdx >= 0) {

--- a/android/app/src/main/java/com/noop/ui/BreatheScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/BreatheScreen.kt
@@ -17,7 +17,7 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Air
-import androidx.compose.material.icons.filled.ArrowForward
+import androidx.compose.material.icons.automirrored.filled.ArrowForward
 import androidx.compose.material.icons.filled.Bolt
 import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.Favorite
@@ -25,8 +25,8 @@ import androidx.compose.material.icons.filled.GraphicEq
 import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material.icons.filled.Remove
 import androidx.compose.material.icons.filled.Stop
-import androidx.compose.material.icons.filled.VolumeOff
-import androidx.compose.material.icons.filled.VolumeUp
+import androidx.compose.material.icons.automirrored.filled.VolumeOff
+import androidx.compose.material.icons.automirrored.filled.VolumeUp
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Icon
@@ -570,7 +570,7 @@ fun BreatheScreen(viewModel: AppViewModel) {
 private fun AudioCueToggle(checked: Boolean, onChange: (Boolean) -> Unit) {
     Row(modifier = Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
         Icon(
-            if (checked) Icons.Filled.VolumeUp else Icons.Filled.VolumeOff,
+            if (checked) Icons.AutoMirrored.Filled.VolumeUp else Icons.AutoMirrored.Filled.VolumeOff,
             contentDescription = null,
             tint = if (checked) Palette.restBright else Palette.textTertiary,
             modifier = Modifier.size(16.dp).padding(end = 10.dp),
@@ -1113,7 +1113,7 @@ private fun CalmMode(viewModel: AppViewModel, live: com.noop.ble.LiveState, bpm:
                     Row(verticalAlignment = Alignment.Bottom,
                         horizontalArrangement = Arrangement.spacedBy(10.dp)) {
                         Text(bpm?.toString() ?: "—", style = NoopType.number(48f), color = Palette.metricRose)
-                        Icon(Icons.Filled.ArrowForward, contentDescription = null,
+                        Icon(Icons.AutoMirrored.Filled.ArrowForward, contentDescription = null,
                             tint = Palette.textTertiary, modifier = Modifier.padding(bottom = 8.dp))
                         Column {
                             Text("target", style = NoopType.footnote, color = Palette.textTertiary)

--- a/android/app/src/main/java/com/noop/ui/CoachScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/CoachScreen.kt
@@ -22,7 +22,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowDropDown
 import androidx.compose.material.icons.filled.Lock
 import androidx.compose.material.icons.filled.Refresh
-import androidx.compose.material.icons.filled.Send
+import androidx.compose.material.icons.automirrored.filled.Send
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.DropdownMenu
@@ -747,7 +747,7 @@ private fun SendButton(enabled: Boolean, sending: Boolean, onClick: () -> Unit) 
             CircularProgressIndicator(modifier = Modifier.size(20.dp), strokeWidth = 2.dp, color = Palette.accent)
         } else {
             Icon(
-                Icons.Filled.Send,
+                Icons.AutoMirrored.Filled.Send,
                 contentDescription = null,
                 tint = if (enabled) Palette.surfaceBase else Palette.textTertiary,
                 modifier = Modifier.size(20.dp),

--- a/android/app/src/main/java/com/noop/ui/DashboardCards.kt
+++ b/android/app/src/main/java/com/noop/ui/DashboardCards.kt
@@ -6,8 +6,8 @@ import androidx.compose.material.icons.filled.Air
 import androidx.compose.material.icons.filled.AutoAwesome
 import androidx.compose.material.icons.filled.Bedtime
 import androidx.compose.material.icons.filled.Bolt
-import androidx.compose.material.icons.filled.DirectionsRun
-import androidx.compose.material.icons.filled.DirectionsWalk
+import androidx.compose.material.icons.automirrored.filled.DirectionsRun
+import androidx.compose.material.icons.automirrored.filled.DirectionsWalk
 import androidx.compose.material.icons.filled.Favorite
 import androidx.compose.material.icons.filled.Hexagon
 import androidx.compose.material.icons.filled.LocalFireDepartment
@@ -46,9 +46,9 @@ enum class DashboardCard(
     HRV("hrv", "HRV", "Heart-rate variability", "ms", Icons.Filled.MonitorHeart),
     RESTING_HR("restingHr", "Resting HR", "Resting heart rate", "bpm", Icons.Filled.Favorite),
     RESPIRATORY("respiratory", "Respiratory", "Breaths per minute", "rpm", Icons.Filled.Air),
-    STEPS("steps", "Steps", "Today", "", Icons.Filled.DirectionsWalk),
+    STEPS("steps", "Steps", "Today", "", Icons.AutoMirrored.Filled.DirectionsWalk),
     STRESS("stress", "Stress", "Autonomic load", "", Icons.Filled.Bolt),
-    FITNESS_AGE("fitnessAge", "Fitness Age", "Updated weekly", "yrs", Icons.Filled.DirectionsRun),
+    FITNESS_AGE("fitnessAge", "Fitness Age", "Updated weekly", "yrs", Icons.AutoMirrored.Filled.DirectionsRun),
     VITALITY("vitality", "Vitality", "Wellness score", "", Icons.Filled.AutoAwesome),
     BLOOD_OXYGEN("bloodOxygen", "Blood Oxygen", "Blood oxygen", "", Icons.Filled.WaterDrop),
     SKIN_TEMP("skinTemp", "Skin Temp", "Skin temperature", "", Icons.Filled.Thermostat),

--- a/android/app/src/main/java/com/noop/ui/HealthScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/HealthScreen.kt
@@ -20,7 +20,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.CompareArrows
 import androidx.compose.material.icons.filled.ChevronRight
-import androidx.compose.material.icons.filled.MenuBook
+import androidx.compose.material.icons.automirrored.filled.MenuBook
 import androidx.compose.material.icons.filled.Sync
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
@@ -329,7 +329,7 @@ private fun RecordsAndSourcesSection(
     Column(verticalArrangement = Arrangement.spacedBy(Metrics.gap)) {
         SectionHeader("Records & sources", overline = "On this phone")
         RecordRow(
-            icon = Icons.Filled.MenuBook,
+            icon = Icons.AutoMirrored.Filled.MenuBook,
             tint = Palette.metricCyan,
             title = "Lab Book",
             subtitle = "Your bloods, BP and body numbers. Kept private here.",
@@ -475,7 +475,7 @@ private fun HealthContributorsSection(day: DailyMetric?) {
     if (hrv == null && rhr == null && sleepMin == null && resp == null) return
 
     // SOLID once recovery has been scored from these signals; CALIBRATING while the baseline seeds.
-    val solid = day?.recovery != null
+    val solid = day.recovery != null
     Column(verticalArrangement = Arrangement.spacedBy(Metrics.gap)) {
         Row(verticalAlignment = Alignment.CenterVertically) {
             Box(modifier = Modifier.weight(1f)) {

--- a/android/app/src/main/java/com/noop/ui/HrvSnapshotScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/HrvSnapshotScreen.kt
@@ -266,7 +266,7 @@ fun HrvSnapshotScreen(
             if (phase == HrvPhase.Done && r != null && r.rmssd != null) {
                 OutlinedButton(
                     onClick = {
-                        val rmssd = r.rmssd ?: return@OutlinedButton
+                        val rmssd = r.rmssd
                         val day = hrvDayKey(Date())
                         val row = MetricSeriesRow(
                             deviceId = HRV_SNAPSHOT_SOURCE_ID,

--- a/android/app/src/main/java/com/noop/ui/LabBookScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/LabBookScreen.kt
@@ -23,7 +23,7 @@ import androidx.compose.material.icons.filled.ChevronRight
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.FileUpload
 import androidx.compose.material.icons.filled.Info
-import androidx.compose.material.icons.filled.MenuBook
+import androidx.compose.material.icons.automirrored.filled.MenuBook
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
@@ -175,7 +175,7 @@ fun LabBookScreen(vm: AppViewModel) {
                             .background(Palette.metricCyan.copy(alpha = 0.14f)),
                         contentAlignment = Alignment.Center,
                     ) {
-                        Icon(Icons.Filled.MenuBook, contentDescription = null, tint = Palette.metricCyan, modifier = Modifier.size(16.dp))
+                        Icon(Icons.AutoMirrored.Filled.MenuBook, contentDescription = null, tint = Palette.metricCyan, modifier = Modifier.size(16.dp))
                     }
                     Column(modifier = Modifier.weight(1f)) {
                         Text(countLine(markers), style = NoopType.headline, color = Palette.textPrimary)

--- a/android/app/src/main/java/com/noop/ui/NotificationsSettingsScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/NotificationsSettingsScreen.kt
@@ -24,12 +24,12 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.CalendarMonth
 import androidx.compose.material.icons.filled.Call
-import androidx.compose.material.icons.filled.Chat
+import androidx.compose.material.icons.automirrored.filled.Chat
 import androidx.compose.material.icons.filled.Email
 import androidx.compose.material.icons.filled.GraphicEq
 import androidx.compose.material.icons.filled.Info
 import androidx.compose.material.icons.filled.NotificationsActive
-import androidx.compose.material.icons.filled.OpenInNew
+import androidx.compose.material.icons.automirrored.filled.OpenInNew
 import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material.icons.filled.Tune
 import androidx.compose.material.icons.filled.Videocam
@@ -97,7 +97,7 @@ internal enum class NotifCategory(
     val defaultPattern: BuzzPattern,
 ) {
     Email("Email", Icons.Filled.Email, BuzzPattern.Double),
-    Messaging("Messaging", Icons.Filled.Chat, BuzzPattern.Single),
+    Messaging("Messaging", Icons.AutoMirrored.Filled.Chat, BuzzPattern.Single),
     Meetings("Meetings", Icons.Filled.Videocam, BuzzPattern.Triple),
     Calendar("Calendar & Reminders", Icons.Filled.CalendarMonth, BuzzPattern.Double),
 }
@@ -118,14 +118,14 @@ internal data class NotifApp(
 private val notifCatalog: List<NotifApp> = listOf(
     NotifApp("com.google.android.gm", "Gmail", NotifCategory.Email, Icons.Filled.Email),
     NotifApp("com.microsoft.office.outlook", "Outlook", NotifCategory.Email, Icons.Filled.Email),
-    NotifApp("com.whatsapp", "WhatsApp", NotifCategory.Messaging, Icons.Filled.Chat),
-    NotifApp("com.google.android.apps.messaging", "Messages", NotifCategory.Messaging, Icons.Filled.Chat),
-    NotifApp("com.Slack", "Slack", NotifCategory.Messaging, Icons.Filled.Chat),
-    NotifApp("org.telegram.messenger", "Telegram", NotifCategory.Messaging, Icons.Filled.Chat),
+    NotifApp("com.whatsapp", "WhatsApp", NotifCategory.Messaging, Icons.AutoMirrored.Filled.Chat),
+    NotifApp("com.google.android.apps.messaging", "Messages", NotifCategory.Messaging, Icons.AutoMirrored.Filled.Chat),
+    NotifApp("com.Slack", "Slack", NotifCategory.Messaging, Icons.AutoMirrored.Filled.Chat),
+    NotifApp("org.telegram.messenger", "Telegram", NotifCategory.Messaging, Icons.AutoMirrored.Filled.Chat),
     // Teams' ringing-call notifications are handled by the Calls card below (VoIP path). This
     // per-app row covers everything else Teams sends to the shade (chats, @-mentions, channel
     // posts), which read as messages, so it lives under Messaging with the chat glyph.
-    NotifApp("com.microsoft.teams", "Microsoft Teams", NotifCategory.Messaging, Icons.Filled.Chat),
+    NotifApp("com.microsoft.teams", "Microsoft Teams", NotifCategory.Messaging, Icons.AutoMirrored.Filled.Chat),
     NotifApp("us.zoom.videomeetings", "Zoom", NotifCategory.Meetings, Icons.Filled.Videocam),
     NotifApp("com.google.android.calendar", "Calendar", NotifCategory.Calendar, Icons.Filled.CalendarMonth),
 )
@@ -614,7 +614,7 @@ private fun DeliveryNote() {
             horizontalArrangement = Arrangement.spacedBy(6.dp),
         ) {
             Icon(
-                Icons.Filled.OpenInNew,
+                Icons.AutoMirrored.Filled.OpenInNew,
                 contentDescription = null,
                 tint = Palette.accent,
                 modifier = Modifier.size(14.dp),

--- a/android/app/src/main/java/com/noop/ui/SettingsScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/SettingsScreen.kt
@@ -45,7 +45,7 @@ import androidx.compose.material.icons.filled.Favorite
 import androidx.compose.material.icons.filled.Info
 import androidx.compose.material.icons.filled.IosShare
 import androidx.compose.material.icons.filled.KeyboardArrowDown
-import androidx.compose.material.icons.filled.MenuBook
+import androidx.compose.material.icons.automirrored.filled.MenuBook
 import androidx.compose.material.icons.filled.Palette
 import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material.icons.filled.SaveAlt
@@ -2276,7 +2276,7 @@ fun SettingsScreen(
                         horizontalArrangement = Arrangement.spacedBy(10.dp),
                     ) {
                         Icon(
-                            Icons.Filled.MenuBook,
+                            Icons.AutoMirrored.Filled.MenuBook,
                             contentDescription = null,
                             tint = Palette.accent,
                             modifier = Modifier.size(18.dp),

--- a/android/app/src/main/java/com/noop/ui/SleepScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/SleepScreen.kt
@@ -499,15 +499,15 @@ fun SleepScreen(
                             val now = System.currentTimeMillis() / 1000L
                             // Same active∪canonical union as the main loader (#814/#1008), so the
                             // post-nap reload can't snap the browse back to a canonical-only night set.
-                            val imported = vm.repo.sleepSessionsUnion(vm.activeStrapId, 0L, now)
+                            val importedSessions = vm.repo.sleepSessionsUnion(vm.activeStrapId, 0L, now)
                             val computed = vm.repo.computedSleepSessionsUnion(vm.activeStrapId, 0L, now)
                             fun localEndDay(ts: Long): String {
                                 val offsetSec = (java.util.TimeZone.getDefault().getOffset(ts * 1000) / 1000).toLong()
                                 return AnalyticsEngine.dayString(ts, offsetSec)
                             }
-                            val importedDays = imported.map { localEndDay(it.endTs) }.toHashSet()
+                            val importedDays = importedSessions.map { localEndDay(it.endTs) }.toHashSet()
                             val computedOnly = computed.filter { localEndDay(it.endTs) !in importedDays }
-                            (imported + computedOnly).sortedBy { it.effectiveStartTs }
+                            (importedSessions + computedOnly).sortedBy { it.effectiveStartTs }
                         }.getOrDefault(sleeps)
                     }
                 },

--- a/android/app/src/main/java/com/noop/ui/StepsCalibrationScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/StepsCalibrationScreen.kt
@@ -17,7 +17,7 @@ import androidx.compose.foundation.verticalScroll
 import com.noop.data.WhoopRepository
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Close
-import androidx.compose.material.icons.filled.DirectionsWalk
+import androidx.compose.material.icons.automirrored.filled.DirectionsWalk
 import androidx.compose.material.icons.filled.SyncProblem
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
@@ -241,7 +241,7 @@ private fun ExplainerCard() {
     NoopCard(padding = 20.dp) {
         Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
             Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                Icon(Icons.Filled.DirectionsWalk, contentDescription = null, tint = Palette.accent, modifier = Modifier.size(20.dp))
+                Icon(Icons.AutoMirrored.Filled.DirectionsWalk, contentDescription = null, tint = Palette.accent, modifier = Modifier.size(20.dp))
                 Text("How this works", style = NoopType.headline, color = Palette.textPrimary)
             }
             Text(

--- a/android/app/src/main/java/com/noop/ui/TodayScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/TodayScreen.kt
@@ -34,7 +34,7 @@ import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
 import androidx.compose.material.icons.filled.Accessibility
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Air
-import androidx.compose.material.icons.filled.BatteryUnknown
+import androidx.compose.material.icons.automirrored.filled.BatteryUnknown
 import androidx.compose.material.icons.filled.Bedtime
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Favorite
@@ -537,10 +537,6 @@ fun TodayScreen(
     var metricsExpanded by remember { mutableStateOf(false) }
     var sourcesExpanded by remember { mutableStateOf(false) }
     var scoringCardSeen by remember { mutableStateOf(ScoringGuidePrefs.cardSeen(context)) }
-    val dismissScoringCard: () -> Unit = {
-        ScoringGuidePrefs.setCardSeen(context)
-        scoringCardSeen = true
-    }
 
     // Per-card "dismissed into the inbox" flags for the two Today info-cards. A small × on each card
     // sets these (and posts a `.dismissedCard` update); "Restore to Today" in the inbox flips them back
@@ -1266,8 +1262,8 @@ fun TodayScreen(
         // day, so this can't resurrect a stale day, it only stops the gauge dropping below what's earned.
         item {
         val todayEffort = if (selectedDayOffset == 0) {
-            val live = liveTodayStrain; val stored = displayMetric?.strain
-            if (live != null && stored != null) maxOf(live, stored) else (live ?: stored)
+            val liveStrain = liveTodayStrain; val stored = displayMetric?.strain
+            if (liveStrain != null && stored != null) maxOf(liveStrain, stored) else (liveStrain ?: stored)
         } else null
         if (todayEffort != null && todayEffort < 1.0) {
             Row(
@@ -2058,7 +2054,7 @@ private fun LiquidBatteryRing(batteryPct: Double?, onClick: () -> Unit) {
             )
         } else {
             Icon(
-                Icons.Filled.BatteryUnknown,
+                Icons.AutoMirrored.Filled.BatteryUnknown,
                 contentDescription = null,
                 tint = Color.White.copy(alpha = 0.5f),
                 modifier = Modifier.size(15.dp),
@@ -4959,7 +4955,7 @@ private fun OverviewHRChart(
                     )
                 }
                 // Charge rule at wake.
-                if (chargeX != null && recovery != null) {
+                if (chargeX != null) {
                     drawLine(
                         color = Palette.recoveryColor(recovery).copy(alpha = 0.85f),
                         start = Offset(chargeX.coerceIn(0f, size.width), 0f),
@@ -4970,7 +4966,7 @@ private fun OverviewHRChart(
                     )
                 }
                 // Effort rule at now.
-                if (effortX != null && strain != null) {
+                if (effortX != null) {
                     val x = (size.width - 1f).coerceIn(0f, size.width)
                     drawLine(
                         color = Palette.effortTint(strain / StrainScorer.maxStrain).copy(alpha = 0.85f),
@@ -4997,7 +4993,7 @@ private fun OverviewHRChart(
             // 3) Marker labels + sport glyphs, positioned composables (crisp text/icons vs Canvas).
             val topPadDp = 10.dp
             // Sleep duration pill at the band's leading edge.
-            if (sleepStartX != null && sleep != null && (sleepEndX ?: 0f) > (sleepStartX)) {
+            if (sleepStartX != null && (sleepEndX ?: 0f) > (sleepStartX)) {
                 val durLabel = hrHoursMinutes((sleep.endTs - sleep.effectiveStartTs).toInt())
                 ChartMarkerPill(
                     text = durLabel,
@@ -5006,14 +5002,14 @@ private fun OverviewHRChart(
                     modifier = Modifier.markerOffset(sleepStartX, density, topPadDp),
                 )
             }
-            if (chargeX != null && recovery != null) {
+            if (chargeX != null) {
                 ChartMarkerPill(
                     text = "${recovery.roundToInt()}% Charge",
                     color = Palette.recoveryColor(recovery),
                     modifier = Modifier.markerOffset(chargeX, density, topPadDp),
                 )
             }
-            if (effortX != null && strain != null) {
+            if (effortX != null) {
                 ChartMarkerPill(
                     text = "${UnitFormatter.effortDisplay(strain, effortScale)} Effort",
                     color = Palette.effortTint(strain / StrainScorer.maxStrain),

--- a/android/app/src/main/java/com/noop/ui/TrendsReport.kt
+++ b/android/app/src/main/java/com/noop/ui/TrendsReport.kt
@@ -217,7 +217,7 @@ object TrendsReportRenderer {
         } else {
             y = drawHeadlines(canvas, report, y)
             y += 18f
-            y = drawMetrics(canvas, report, series, y)
+            drawMetrics(canvas, report, series, y)
         }
         drawFooter(canvas, generatedOn)
 

--- a/android/app/src/main/java/com/noop/ui/UpdateStore.kt
+++ b/android/app/src/main/java/com/noop/ui/UpdateStore.kt
@@ -72,13 +72,13 @@ data class UpdateItem(
     companion object {
         fun fromJson(o: JSONObject): UpdateItem = UpdateItem(
             id = o.optString("id", UUID.randomUUID().toString()),
-            kind = UpdateKind.fromStorage(o.optString("kind", null)),
+            kind = UpdateKind.fromStorage(if (o.has("kind")) o.optString("kind") else null),
             title = o.optString("title", ""),
             message = o.optString("message", ""),
             date = o.optLong("date", System.currentTimeMillis()),
             read = o.optBoolean("read", false),
-            deepLink = if (o.has("deepLink")) o.optString("deepLink", null) else null,
-            restorePayload = if (o.has("restorePayload")) o.optString("restorePayload", null) else null,
+            deepLink = if (o.has("deepLink")) o.optString("deepLink") else null,
+            restorePayload = if (o.has("restorePayload")) o.optString("restorePayload") else null,
         )
     }
 }

--- a/android/app/src/main/java/com/noop/ui/WorkoutsScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/WorkoutsScreen.kt
@@ -26,12 +26,12 @@ import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.KeyboardArrowDown
 import androidx.compose.material.icons.filled.Lock
-import androidx.compose.material.icons.filled.MergeType
+import androidx.compose.material.icons.automirrored.filled.MergeType
 import androidx.compose.material.icons.filled.RadioButtonUnchecked
 import androidx.compose.material.icons.filled.Search
-import androidx.compose.material.icons.filled.DirectionsBike
-import androidx.compose.material.icons.filled.DirectionsRun
-import androidx.compose.material.icons.filled.DirectionsWalk
+import androidx.compose.material.icons.automirrored.filled.DirectionsBike
+import androidx.compose.material.icons.automirrored.filled.DirectionsRun
+import androidx.compose.material.icons.automirrored.filled.DirectionsWalk
 import androidx.compose.material.icons.filled.FitnessCenter
 import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material.icons.filled.Pool
@@ -46,7 +46,7 @@ import androidx.compose.material.icons.filled.SportsGymnastics
 import androidx.compose.material.icons.filled.SportsMartialArts
 import androidx.compose.material.icons.filled.SportsVolleyball
 import androidx.compose.material.icons.filled.Terrain
-import androidx.compose.material.icons.filled.ShowChart
+import androidx.compose.material.icons.automirrored.filled.ShowChart
 import androidx.compose.material.icons.filled.SportsSoccer
 import androidx.compose.material.icons.filled.SportsTennis
 import androidx.compose.foundation.text.KeyboardOptions
@@ -349,7 +349,7 @@ private fun PostLogNoteBanner(text: String) {
         verticalAlignment = Alignment.Top,
     ) {
         Icon(
-            Icons.Filled.ShowChart,
+            Icons.AutoMirrored.Filled.ShowChart,
             contentDescription = null,
             tint = Palette.effortColor,
             modifier = Modifier.size(16.dp),
@@ -1042,7 +1042,7 @@ private fun SelectionToolbar(
         horizontalArrangement = Arrangement.spacedBy(12.dp),
     ) {
         ToolbarAction(
-            "Merge (${chosen.size})", Icons.Filled.MergeType,
+            "Merge (${chosen.size})", Icons.AutoMirrored.Filled.MergeType,
             tint = if (canMerge) Palette.effortColor else Palette.textTertiary,
             enabled = canMerge, onClick = { onMerge(chosen) },
         )
@@ -1588,7 +1588,7 @@ private fun ManualWorkoutDialog(
                     contentAlignment = Alignment.Center,
                 ) {
                     Icon(
-                        Icons.Filled.DirectionsRun,
+                        Icons.AutoMirrored.Filled.DirectionsRun,
                         contentDescription = null,
                         tint = Palette.effortColor,
                         modifier = Modifier.size(18.dp),
@@ -1978,9 +1978,9 @@ private fun grouped(v: Double): String = String.format(Locale.US, "%,d", v.round
 internal fun sportIcon(sport: String): ImageVector {
     val s = sport.lowercase()
     return when {
-        s.contains("run") -> Icons.Filled.DirectionsRun
-        s.contains("walk") || s.contains("hike") -> Icons.Filled.DirectionsWalk
-        s.contains("cycl") || s.contains("bike") || s.contains("ride") -> Icons.Filled.DirectionsBike
+        s.contains("run") -> Icons.AutoMirrored.Filled.DirectionsRun
+        s.contains("walk") || s.contains("hike") -> Icons.AutoMirrored.Filled.DirectionsWalk
+        s.contains("cycl") || s.contains("bike") || s.contains("ride") -> Icons.AutoMirrored.Filled.DirectionsBike
         s.contains("swim") -> Icons.Filled.Pool
         s.contains("row") -> Icons.Filled.Rowing
         s.contains("yoga") || s.contains("pilates") || s.contains("meditat") || s.contains("stretch") -> Icons.Filled.SelfImprovement


### PR DESCRIPTION
## What

Compiler-warning cleanup — all non-behavioral, each commit compile-verified (`compileFullDebugKotlin` BUILD SUCCESSFUL; ingest+data unit tests pass on the structural ones).

- `d932b25a` — redundant operators: unnecessary safe-calls / `!!` / `as Double?` casts (AiCoach, CaffeineDecay, WatchRecovery).
- `5c617dbf` — deprecated Material icons → AutoMirrored (BreatheScreen, CoachScreen, DashboardCards, HealthScreen, LabBookScreen); unnecessary safe-calls (SourceCoordinator, HealthScreen); redundant Elvis (HrvSnapshotScreen); exhaustive-`when` `else` (DataBackup); redundant initializer (CsvParser); name-shadow renames (Backfiller, StandardHrSource).
- `5003222e` — more AutoMirrored icons (NotificationsSettingsScreen, SettingsScreen, StepsCalibrationScreen, TodayScreen); 5 compiler-proven always-true null sub-conditions removed + shadow rename + dead lambda (TodayScreen); shadow rename (SleepScreen); dead assignment (TrendsReport).
- `9c52ecbf` — UpdateStore null-fallback type mismatches (`optString(name, null)` → guarded idiom); WorkoutsScreen AutoMirrored icons.

## Deliberately not touched

The "unused parameter" warnings (e.g. `inBedSeconds`, `nightsElapsed`, `habitualWakeHour`, `day`, `resp`, `data`, `batch`, `g`, `color`, TodayScreen composable params) are left as-is — they're Kotlin↔Swift signature-parity mirrors or composable-signature params, so removing them would break parity / churn callers. Accepted as benign noise (policy A).

No behavior changes; UI icons only gain automatic RTL mirroring.
