### PR TITLE
CI: release workflow bumps version (patch/minor/major) in source before releasing

### DIFF
--- a/.github/workflows/fork-release.yml
+++ b/.github/workflows/fork-release.yml
@@ -1,18 +1,28 @@
-# Fork-only: cut a proper RELEASE (not a rolling snapshot) so the in-app "Check for updates"
-# — which reads GitHub `releases/latest`, and GitHub excludes prereleases — points at this fork.
+# Fork-only: bump the version and cut a proper RELEASE (not a rolling snapshot) so the in-app
+# "Check for updates" — which reads GitHub `releases/latest`, and GitHub excludes prereleases —
+# points at this fork.
 #
-# Contrast with fork-testing-build.yml: THAT publishes the rolling `testing-latest` PRERELEASE
-# (a snapshot), which releases/latest deliberately ignores. THIS publishes a fixed, non-prerelease
-# `v<VERSION>` tag → it becomes "latest release", so UpdateCheck (`.../releases/latest`) finds it and
-# compares versions (isNewer strips the `-staging` suffix, so an installed staging build reads clean).
-# Only release-variant artifacts, each stamped with the version. Trigger from the Actions tab.
+# The `bump` input (patch / minor / major / none) increments the version IN SOURCE — both
+# android/app/build.gradle.kts (versionName + versionCode) and project.yml (MARKETING_VERSION +
+# CURRENT_PROJECT_VERSION) — and commits that to the dispatched branch, so the built app actually
+# REPORTS the new version. Then it publishes a fixed, non-prerelease `v<VERSION>` release with the
+# version-stamped artifacts. releases/latest returns it, so UpdateCheck finds it (isNewer strips the
+# `-staging` suffix, so an installed staging build compares clean).
+#
+# Contrast with fork-testing-build.yml: THAT publishes the rolling `testing-latest` PRERELEASE (a
+# snapshot), which releases/latest deliberately ignores. THIS never touches testing-latest.
 name: Release build (fork)
 
 on:
   workflow_dispatch:
     inputs:
+      bump:
+        description: "Version bump (patch = 0.0.x, minor = 0.x.0, major = x.0.0)"
+        type: choice
+        options: [patch, minor, major, none]
+        default: patch
       version:
-        description: "Release version, e.g. 8.2.2 (blank = read MARKETING_VERSION from project.yml)"
+        description: "Explicit version override, e.g. 8.3.0 (blank = apply the bump above)"
         required: false
         default: ""
 
@@ -24,74 +34,109 @@ concurrency:
   cancel-in-progress: false   # never cancel a release mid-publish
 
 jobs:
-  meta:
+  bump:
     runs-on: ubuntu-latest
     outputs:
-      tag: ${{ steps.m.outputs.tag }}
-      ver: ${{ steps.m.outputs.ver }}
+      ver: ${{ steps.b.outputs.ver }}
+      tag: ${{ steps.b.outputs.tag }}
+      sha: ${{ steps.b.outputs.sha }}
     steps:
       - uses: actions/checkout@v4
-      - id: m
+      - id: b
         env:
           GH_TOKEN: ${{ github.token }}
+          BUMP: ${{ github.event.inputs.bump }}
+          OVERRIDE: ${{ github.event.inputs.version }}
         run: |
-          VER="${{ github.event.inputs.version }}"
-          if [ -z "$VER" ]; then VER=$(grep -m1 'MARKETING_VERSION' project.yml | sed -E 's/.*"([^"]+)".*/\1/'); fi
-          TAG="v${VER}"
+          set -euo pipefail
+          GRADLE=android/app/build.gradle.kts
+
+          # Android versionName is the source of truth UpdateCheck compares against.
+          CUR=$(grep -m1 'versionName = "' "$GRADLE" | sed -E 's/.*"([^"]+)".*/\1/')
+          IFS=. read -r MA MI PA <<< "$CUR"; MA=${MA:-0}; MI=${MI:-0}; PA=${PA:-0}
+          case "${BUMP:-patch}" in
+            major) NEW="$((MA+1)).0.0" ;;
+            minor) NEW="${MA}.$((MI+1)).0" ;;
+            patch) NEW="${MA}.${MI}.$((PA+1))" ;;
+            none|"") NEW="$CUR" ;;
+            *) echo "Unknown bump: $BUMP" >&2; exit 1 ;;
+          esac
+          [ -n "${OVERRIDE:-}" ] && NEW="$OVERRIDE"
+          TAG="v${NEW}"
+          echo "ver=$NEW" >> "$GITHUB_OUTPUT"
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
-          echo "ver=$VER" >> "$GITHUB_OUTPUT"
-          # A real, IMMUTABLE release at a fixed per-version tag — NOT a prerelease, so releases/latest
-          # returns it. Create it only if missing (so a re-run after a failed platform job just refreshes
-          # assets rather than duplicating/clobbering the release + notes). To re-cut a version, delete its
-          # release first. This never touches the `testing-latest` snapshot.
+          echo "Version: $CUR -> $NEW  (tag $TAG)"
+
+          if [ "$NEW" != "$CUR" ]; then
+            # Bump BOTH platforms' version + build number in source, then commit to the branch so the
+            # built artifacts report $NEW (each build number is an independent monotonic counter).
+            ACODE=$(grep -m1 'versionCode = ' "$GRADLE" | sed -E 's/.*versionCode = ([0-9]+).*/\1/')
+            ICODE=$(grep -m1 'CURRENT_PROJECT_VERSION:' project.yml | sed -E 's/.*"([0-9]+)".*/\1/')
+            sed -i -E "s/versionName = \"[^\"]+\"/versionName = \"$NEW\"/" "$GRADLE"
+            sed -i -E "s/versionCode = [0-9]+/versionCode = $((ACODE+1))/" "$GRADLE"
+            sed -i -E "s/MARKETING_VERSION: \"[^\"]+\"/MARKETING_VERSION: \"$NEW\"/" project.yml
+            sed -i -E "s/CURRENT_PROJECT_VERSION: \"[0-9]+\"/CURRENT_PROJECT_VERSION: \"$((ICODE+1))\"/" project.yml
+            git config user.name 'ryanbr'
+            git config user.email 'ryan.borsix@gmail.com'
+            git commit -am "Release ${NEW}: bump version (${BUMP}) + build numbers"
+            git push origin "HEAD:${GITHUB_REF_NAME}"
+          fi
+          echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
+          # Immutable, NON-prerelease release at the (possibly bumped) commit so releases/latest returns it.
+          # Create only if missing (a re-run refreshes assets rather than clobbering the release/notes).
           if gh release view "$TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
             echo "Release $TAG already exists — re-run: platform jobs will refresh its assets."
           else
-            gh release create "$TAG" --repo "$GITHUB_REPOSITORY" --target "${{ github.sha }}" \
-              --title "NOOP ${VER}" \
-              --notes "NOOP **${VER}** — release build (NOOP Staging identity; installs **beside** the official app, separate data). This is the version the in-app **Check for updates** compares against. Filenames carry the version (\`v${VER}\`).
+            gh release create "$TAG" --repo "$GITHUB_REPOSITORY" --target "$(git rev-parse HEAD)" \
+              --title "NOOP ${NEW}" \
+              --notes "NOOP **${NEW}** — release build (NOOP Staging identity; installs **beside** the official app, separate data). This is the version the in-app **Check for updates** compares against. Filenames carry the version (\`v${NEW}\`).
 
-          - **Android** — \`app-full-release-v${VER}.apk\` — non-debuggable release build. \`com.noop.whoop.staging\`.
-          - **macOS** — \`NOOP-macos-v${VER}.zip\` — unzip, then **right-click → Open** (unsigned; Gatekeeper warns once).
-          - **iOS** — \`NOOP-ios-unsigned-v${VER}.ipa\` — sideload via **AltStore / Sideloadly** (re-signs on-device); embedded watch app stripped.
+          - **Android** — \`app-full-release-v${NEW}.apk\` — non-debuggable release build. \`com.noop.whoop.staging\`.
+          - **macOS** — \`NOOP-macos-v${NEW}.zip\` — unzip, then **right-click → Open** (unsigned; Gatekeeper warns once).
+          - **iOS** — \`NOOP-ios-unsigned-v${NEW}.ipa\` — sideload via **AltStore / Sideloadly** (re-signs on-device); embedded watch app stripped.
 
           For the newest in-development build instead, see the rolling \`testing-latest\` prerelease."
           fi
 
   android:
-    needs: meta
+    needs: bump
     runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: android
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.bump.outputs.sha }}   # build the bumped commit
       - uses: actions/setup-java@v4
         with:
           distribution: temurin
           java-version: '17'
       - uses: gradle/actions/wrapper-validation@v4
       - uses: gradle/actions/setup-gradle@v4
-      # Release-only (no debug APK on a release). Signed with the committed fork-debug.keystore via the
-      # debug signingConfig storeFile (release falls back to it when no keystore.properties is present);
+      # Release-only (no debug APK). Signed with the committed fork-debug.keystore via the debug
+      # signingConfig storeFile (release falls back to it when no keystore.properties is present);
       # -PstagingRelease gives it the .staging app id so it installs beside the official app.
       - name: Build staging-release APK
         run: ./gradlew assembleFullRelease -PstagingRelease
       - name: Version the filename + attach
         env:
           GH_TOKEN: ${{ github.token }}
-          VER: ${{ needs.meta.outputs.ver }}
+          VER: ${{ needs.bump.outputs.ver }}
         run: |
           cp app/build/outputs/apk/full/release/*.apk "app-full-release-v${VER}.apk"
-          gh release upload "${{ needs.meta.outputs.tag }}" "app-full-release-v${VER}.apk" \
+          gh release upload "${{ needs.bump.outputs.tag }}" "app-full-release-v${VER}.apk" \
             --repo "$GITHUB_REPOSITORY" --clobber
 
   macos:
-    needs: meta
+    needs: bump
     runs-on: macos-15
     timeout-minutes: 40
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.bump.outputs.sha }}
       - name: Install XcodeGen
         run: brew install xcodegen
       - name: Generate Xcode project
@@ -105,20 +150,22 @@ jobs:
       - name: Package + attach
         env:
           GH_TOKEN: ${{ github.token }}
-          VER: ${{ needs.meta.outputs.ver }}
+          VER: ${{ needs.bump.outputs.ver }}
         run: |
           APP=$(find build/dd/Build/Products -maxdepth 3 -name '*.app' -type d | head -1)
           test -n "$APP" || { echo ".app not found"; exit 1; }
           ditto -c -k --keepParent "$APP" "NOOP-macos-v${VER}.zip"
-          gh release upload "${{ needs.meta.outputs.tag }}" "NOOP-macos-v${VER}.zip" --repo "$GITHUB_REPOSITORY" --clobber
+          gh release upload "${{ needs.bump.outputs.tag }}" "NOOP-macos-v${VER}.zip" --repo "$GITHUB_REPOSITORY" --clobber
 
   ios:
-    needs: meta
+    needs: bump
     # iOS 26 Liquid Glass (glassEffect) needs the iOS 26 SDK → Xcode 26 → macos-26.
     runs-on: macos-26
     timeout-minutes: 40
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.bump.outputs.sha }}
       - name: Install XcodeGen
         run: brew install xcodegen
       - name: Generate Xcode project
@@ -132,11 +179,11 @@ jobs:
       - name: Package unsigned .ipa (strip the embedded watch app) + attach
         env:
           GH_TOKEN: ${{ github.token }}
-          VER: ${{ needs.meta.outputs.ver }}
+          VER: ${{ needs.bump.outputs.ver }}
         run: |
           APP=$(find build/dd/Build/Products/Debug-iphoneos -maxdepth 1 -name '*.app' -type d | head -1)
           test -n "$APP" || { echo ".app (iphoneos) not found"; exit 1; }
           rm -rf "$APP/Watch"
           rm -rf Payload && mkdir Payload && cp -R "$APP" Payload/
           zip -qr "NOOP-ios-unsigned-v${VER}.ipa" Payload
-          gh release upload "${{ needs.meta.outputs.tag }}" "NOOP-ios-unsigned-v${VER}.ipa" --repo "$GITHUB_REPOSITORY" --clobber
+          gh release upload "${{ needs.bump.outputs.tag }}" "NOOP-ios-unsigned-v${VER}.ipa" --repo "$GITHUB_REPOSITORY" --clobber


### PR DESCRIPTION
## What

Updates the manual "Release build (fork)" workflow to **bump the version** before releasing.

New `bump` choice input — **patch** (0.0.x) / **minor** (0.x.0) / **major** (x.0.0) / **none**, plus an optional explicit `version` override. The bump job edits the version in source — `android/app/build.gradle.kts` (`versionName`+`versionCode`) and `project.yml` (`MARKETING_VERSION`+`CURRENT_PROJECT_VERSION`) — commits it to the dispatched branch (authored ryanbr), and the platform jobs build that bumped commit so the app reports the new version. Then it cuts the non-prerelease `v<NEW>` release.

## Notes

- Commits the bump to the branch you dispatch from (normal bump-and-tag flow).
- Verified locally: version math (8.2.2 → 8.2.3 / 8.3.0 / 9.0.0) and the seds hit only the version lines (`-debug`/`-staging`/`-demo` suffixes and `$(MARKETING_VERSION)` refs untouched).
- Still never touches the `testing-latest` snapshot; still a non-prerelease so `releases/latest` (the update check) resolves against it.
