### PR TITLE
Prep v8.3.0: release notes + wire in-app changelog generation into the release workflow

### DIFF
--- a/.github/workflows/fork-release.yml
+++ b/.github/workflows/fork-release.yml
@@ -76,9 +76,19 @@ jobs:
             sed -i -E "s/versionCode = [0-9]+/versionCode = $((ACODE+1))/" "$GRADLE"
             sed -i -E "s/MARKETING_VERSION: \"[^\"]+\"/MARKETING_VERSION: \"$NEW\"/" project.yml
             sed -i -E "s/CURRENT_PROJECT_VERSION: \"[0-9]+\"/CURRENT_PROJECT_VERSION: \"$((ICODE+1))\"/" project.yml
+            # In-app "What's New": generate the AppChangelog entry (both platforms) + bump its constant
+            # from docs/releases/<TAG>.md's whatsnew: front-matter, so the in-app card ships in sync with
+            # this version. Warn (don't fail) if the notes file / its front-matter is missing.
+            if [ -f "docs/releases/${TAG}.md" ]; then
+              python3 -m pip install --quiet pyyaml >/dev/null 2>&1 || true
+              python3 Tools/appchangelog-gen.py "docs/releases/${TAG}.md" \
+                || echo "::warning::appchangelog-gen failed for ${TAG} — in-app 'What's New' not updated."
+            else
+              echo "::warning::No docs/releases/${TAG}.md — GitHub notes + in-app 'What's New' will use placeholders."
+            fi
             git config user.name 'ryanbr'
             git config user.email 'ryan.borsix@gmail.com'
-            git commit -am "Release ${NEW}: bump version (${BUMP}) + build numbers"
+            git commit -am "Release ${NEW}: bump version (${BUMP}) + build numbers + What's New"
             git push origin "HEAD:${GITHUB_REF_NAME}"
           fi
           echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"

--- a/docs/releases/v8.3.0.md
+++ b/docs/releases/v8.3.0.md
@@ -1,0 +1,32 @@
+---
+whatsnew:
+  title: "Backup controls, and a lighter app"
+  date: "July 2026"
+  items:
+    - "**Choose how many backups to keep.** Automatic backups now lets you pick how many daily snapshots to keep (a week by default); older ones are pruned oldest-first."
+    - "**A set backup time.** The daily auto-backup runs around 1 am, so a fresh dated snapshot is waiting overnight without opening the app."
+    - "**Easier to find.** Settings → Backup & restore now links straight to Automatic backups."
+    - "**Lighter.** The donation prompts and the Support screen have been removed."
+---
+# NOOP v8.3.0
+
+A tidy-up release: automatic backups got real controls, a few things that no longer belong were removed, and the project now builds and releases itself. Update from the Releases page, AltStore, or `brew upgrade`.
+
+## Backups
+
+- **Choose how many to keep.** Automatic backups has a new **"Keep last snapshots"** control — pick how many daily copies to keep (default a week), and older ones are pruned oldest-first. Available on Android and iOS.
+- **Runs at a set time.** The daily auto-backup is anchored to run **around 1 am** (best-effort), so you get a fresh dated snapshot overnight without opening the app.
+- **Easier to find.** **Settings → Backup & restore** now has an **"Automatic backups"** entry that takes you straight to the folder picker and toggle.
+
+## Removed
+
+- **Donations and the "Support NOOP" section are gone** — the Today nudge card, the Support screen, and the surrounding copy, on every platform.
+- **The dead `noop.fans` mirror link is removed** (the site closed). The in-app "Project home" link and the docs point at the project's GitHub.
+
+## Under the hood
+
+- **The project builds and releases itself.** On-demand testing builds across Android + macOS + iOS, and a proper Release build that bumps the version and publishes a real release — installed **beside** the official app so it never clashes.
+- **Release notes and "What's New" write themselves** from a single per-version source, with an automatic list of everything that changed since the last release.
+- **A sweep of code cleanups** (deprecated icons, redundant code, name shadows) — no behaviour change.
+
+*(Note: the reliability, Bluetooth, and HRV fixes credited to community contributors shipped in v8.2.2.)*


### PR DESCRIPTION
Adds docs/releases/v8.3.0.md (next-release notes + whatsnew front-matter) and wires Tools/appchangelog-gen.py into the release workflow's bump job (generates the in-app What's New in the release commit). No release is run; AppChangelog stays at 8.2.2 until a release bumps it.