### PR TITLE
Backup & Sync: configurable daily backup time (default 1am)

### DIFF
--- a/android/app/src/main/java/com/noop/ui/BackupSync.kt
+++ b/android/app/src/main/java/com/noop/ui/BackupSync.kt
@@ -51,17 +51,19 @@ object BackupSync {
     /** A day in ms - the catch-up cadence (mirrors the Apple `dayMs`). */
     private const val DAY_MS = 24L * 60L * 60L * 1000L
 
-    /** Time-of-day the daily snapshot fires: 01:00 (minutes since midnight). A quiet hour; WorkManager
-     *  isn't exact and may slide it into a maintenance window, which is fine for a backup. */
+    /** DEFAULT time-of-day the daily snapshot fires: 01:00 (minutes since midnight). A quiet hour; the
+     *  user can change it (BackupSyncPrefs.backupMinute). WorkManager isn't exact and may slide it into
+     *  a maintenance window, which is fine for a backup. */
     const val BACKUP_MINUTE_OF_DAY = 60
 
-    /** Ms from [nowMs] to the next 01:00 wall-clock (today if still ahead, else tomorrow). Pure +
-     *  injectable so the arithmetic is unit-testable without a real clock. Mirrors DebugExportScheduler. */
-    fun delayToNextBackupMs(nowMs: Long = System.currentTimeMillis()): Long {
+    /** Ms from [nowMs] to the next occurrence of [minuteOfDay] (minutes since midnight) wall-clock —
+     *  today if still ahead, else tomorrow. Pure + injectable so the arithmetic is unit-testable without
+     *  a real clock. Mirrors DebugExportScheduler. */
+    fun delayToNextBackupMs(nowMs: Long = System.currentTimeMillis(), minuteOfDay: Int = BACKUP_MINUTE_OF_DAY): Long {
         val next = Calendar.getInstance().apply {
             timeInMillis = nowMs
-            set(Calendar.HOUR_OF_DAY, BACKUP_MINUTE_OF_DAY / 60)
-            set(Calendar.MINUTE, BACKUP_MINUTE_OF_DAY % 60)
+            set(Calendar.HOUR_OF_DAY, minuteOfDay / 60)
+            set(Calendar.MINUTE, minuteOfDay % 60)
             set(Calendar.SECOND, 0)
             set(Calendar.MILLISECOND, 0)
             if (timeInMillis <= nowMs) add(Calendar.DAY_OF_YEAR, 1)
@@ -266,13 +268,21 @@ object BackupSync {
             wm.cancelUniqueWork(WORK)
             return
         }
-        // Anchor the first run to the next 01:00, then repeat daily. KEEP so an already-scheduled job keeps
-        // its anchor rather than resetting on every app-start (matches DebugExportScheduler); toggling auto
-        // off then on re-anchors. On-launch [catchUpIfDue] still covers any missed day regardless of timing.
+        // Anchor the first run to the next chosen time-of-day, then repeat daily. KEEP so an already-
+        // scheduled job keeps its anchor rather than resetting on every app-start (matches
+        // DebugExportScheduler); toggling auto off/on OR changing the time via [applyTimeChange]
+        // re-anchors. On-launch [catchUpIfDue] still covers any missed day regardless of timing.
         val req = PeriodicWorkRequestBuilder<BackupSyncWorker>(1, TimeUnit.DAYS)
-            .setInitialDelay(delayToNextBackupMs(), TimeUnit.MILLISECONDS)
+            .setInitialDelay(delayToNextBackupMs(minuteOfDay = BackupSyncPrefs.backupMinute(context)), TimeUnit.MILLISECONDS)
             .build()
         wm.enqueueUniquePeriodicWork(WORK, ExistingPeriodicWorkPolicy.KEEP, req)
+    }
+
+    /** Re-anchor the daily backup to the (just-changed) [BackupSyncPrefs.backupMinute] immediately —
+     *  cancel then reschedule, since KEEP would otherwise leave the old time in place. */
+    fun applyTimeChange(context: Context) {
+        WorkManager.getInstance(context.applicationContext).cancelUniqueWork(WORK)
+        reschedule(context)
     }
 
     /**
@@ -320,6 +330,13 @@ object BackupSyncPrefs {
     /** Master enable for the daily auto-backup. Default OFF (every NOOP automation is opt-in). */
     fun autoEnabled(c: Context): Boolean = p(c).getBoolean("auto", false)
     fun setAutoEnabled(c: Context, on: Boolean) = p(c).edit().putBoolean("auto", on).apply()
+
+    /** Time-of-day the daily backup runs, minutes since local midnight. Default [BackupSync.BACKUP_MINUTE_OF_DAY]
+     *  (01:00). Clamped to a valid minute so a corrupt value can't schedule at nonsense o'clock. */
+    fun backupMinute(c: Context): Int =
+        p(c).getInt("backup_minute", BackupSync.BACKUP_MINUTE_OF_DAY).coerceIn(0, 24 * 60 - 1)
+    fun setBackupMinute(c: Context, m: Int) =
+        p(c).edit().putInt("backup_minute", m.coerceIn(0, 24 * 60 - 1)).apply()
 
     fun lastBackupMs(c: Context): Long = p(c).getLong("last_ms", 0L)
     fun setLastBackupMs(c: Context, ms: Long) = p(c).edit().putLong("last_ms", ms).apply()

--- a/android/app/src/main/java/com/noop/ui/BackupSyncScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/BackupSyncScreen.kt
@@ -67,6 +67,8 @@ fun BackupSyncScreen() {
     // How many dated snapshots to keep; pruning deletes the oldest beyond this (BackupSync.snapshotsToPrune).
     var keep by remember { mutableStateOf(BackupSyncPrefs.keepCount(context)) }
     var keepMenu by remember { mutableStateOf(false) }
+    // Time-of-day the daily backup runs (minutes since midnight); default 01:00, user-adjustable.
+    var backupMinute by remember { mutableStateOf(BackupSyncPrefs.backupMinute(context)) }
 
     // Restore-from-folder sheet state: the listed snapshots, and the one pending confirmation.
     var snapshots by remember { mutableStateOf<List<BackupSync.SnapshotDoc>>(emptyList()) }
@@ -155,8 +157,8 @@ fun BackupSyncScreen() {
                         ) {
                             Text("Daily auto-backup", style = NoopType.body, color = Palette.textPrimary)
                             Text(
-                                "Writes a fresh dated backup to your folder once a day (around 1am), keeping the " +
-                                    "latest $keep. Off by default - flip it on if you want it.",
+                                "Writes a fresh dated backup to your folder once a day at the time below, keeping " +
+                                    "the latest $keep. Off by default - flip it on if you want it.",
                                 style = NoopType.footnote, color = Palette.textTertiary,
                             )
                         }
@@ -222,6 +224,30 @@ fun BackupSyncScreen() {
                                 }
                             }
                         }
+                    }
+                    // Backup time-of-day. Picking a new time re-anchors the schedule immediately
+                    // (BackupSync.applyTimeChange); WorkManager isn't exact so it's best-effort.
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        Column(
+                            modifier = Modifier.weight(1f),
+                            verticalArrangement = Arrangement.spacedBy(2.dp),
+                        ) {
+                            Text("Backup time", style = NoopType.body, color = Palette.textPrimary)
+                            Text(
+                                "Roughly when the daily backup runs (best-effort — the system may slide it a little).",
+                                style = NoopType.footnote, color = Palette.textTertiary,
+                            )
+                        }
+                        Spacer(Modifier.width(16.dp))
+                        TimeChip(
+                            minutes = backupMinute,
+                            accessibilityLabel = "Daily backup time",
+                            onPicked = { m ->
+                                backupMinute = m
+                                BackupSyncPrefs.setBackupMinute(context, m)
+                                runCatching { BackupSync.applyTimeChange(context) }
+                            },
+                        )
                     }
                     Text(
                         if (lastMs > 0L) {

--- a/android/app/src/test/java/com/noop/ui/BackupSyncTest.kt
+++ b/android/app/src/test/java/com/noop/ui/BackupSyncTest.kt
@@ -68,6 +68,16 @@ class BackupSyncTest {
         assertEquals(0, fire.get(java.util.Calendar.MINUTE))
     }
 
+    @Test fun backupDelayHonoursAChosenTime() {
+        // A configured time (06:30 = 390 min) must land the next fire at 06:30, within the next 24h.
+        val now = 1_700_000_000_000L
+        val delay = BackupSync.delayToNextBackupMs(now, minuteOfDay = 6 * 60 + 30)
+        assertTrue(delay in 1..(24L * 60 * 60 * 1000))
+        val fire = java.util.Calendar.getInstance().apply { timeInMillis = now + delay }
+        assertEquals(6, fire.get(java.util.Calendar.HOUR_OF_DAY))
+        assertEquals(30, fire.get(java.util.Calendar.MINUTE))
+    }
+
     @Test fun catchUpDueOnlyAfterADay() {
         val last = 1_782_000_000_000L
         assertFalse(BackupSync.isCatchUpDue(last, last))                       // same instant


### PR DESCRIPTION
Adds a user-set backup time-of-day on the Backup & Sync screen (TimeChip picker, default 01:00). BackupSyncPrefs.backupMinute + setBackupMinute; delayToNextBackupMs takes a minuteOfDay; applyTimeChange re-anchors on change. Android-only (iOS backs up on next launch). Compiles; BackupSyncTest 14 pass.