### PR TITLE
Settings: "Sky behind cards" — day-cycle sky behind the whole Today scroll (opt-in)

### DIFF
--- a/android/app/src/main/java/com/noop/ui/Components.kt
+++ b/android/app/src/main/java/com/noop/ui/Components.kt
@@ -1256,6 +1256,9 @@ fun LazyScreenScaffold(
     // the scene paints in the wrapping Box (promoted to its own compositing layer) and the LazyColumn is
     // transparent so the scene shows through behind the rows. Mirrors the iOS scaffold's topBackground.
     topBackground: (@Composable () -> Unit)? = null,
+    // When true, the [topBackground] fills the WHOLE scaffold (viewport) instead of the top band — the
+    // "sky behind cards" mode, so a full-height backdrop shows behind every scrolling row.
+    fullBleedBackground: Boolean = false,
     content: LazyListScope.() -> Unit,
 ) {
     // The header row: optional leading action, the title/subtitle, optional trailing action. Omitted
@@ -1324,11 +1327,16 @@ fun LazyScreenScaffold(
         val statusBarTop = WindowInsets.statusBars.asPaddingValues().calculateTopPadding()
         Box(modifier = modifier.fillMaxSize().background(Palette.surfaceBase)) {
             Box(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .align(Alignment.TopCenter)
-                    .offset(y = -statusBarTop)
-                    .graphicsLayer { },
+                modifier = (
+                    if (fullBleedBackground) {
+                        // Sky-behind-cards: the backdrop fills the whole viewport (covers under the status
+                        // bar already), so the transparent rows scroll OVER a full-height sky.
+                        Modifier.fillMaxSize()
+                    } else {
+                        // Default: a top-anchored band bled up behind the status bar.
+                        Modifier.fillMaxWidth().align(Alignment.TopCenter).offset(y = -statusBarTop)
+                    }
+                    ).graphicsLayer { },
             ) {
                 topBackground()
             }

--- a/android/app/src/main/java/com/noop/ui/LiquidScreenSky.kt
+++ b/android/app/src/main/java/com/noop/ui/LiquidScreenSky.kt
@@ -2,6 +2,7 @@ package com.noop.ui
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.runtime.Composable
@@ -46,20 +47,21 @@ import androidx.compose.ui.unit.dp
  *  `topBackground` slot. [height] is the sky band; the sky fades into the theme canvas within it, so the
  *  cards below sit on the flat surface. Mirrors the iOS `liquidScaffoldSky`. */
 @Composable
-fun LiquidScreenSky(height: Dp = 340.dp) {
+fun LiquidScreenSky(height: Dp = 340.dp, fillHeight: Boolean = false) {
+    // "Sky behind cards" (opt-in): fill the whole viewport and hold the atmosphere with a softer settle so
+    // the sky still reads UNDER the lower cards, instead of the default top-band that dissolves to canvas.
+    val sizeMod = if (fillHeight) Modifier.fillMaxSize() else Modifier.fillMaxWidth().height(height)
     Box(
-        modifier = Modifier
-            .fillMaxWidth()
-            .height(height)
+        modifier = sizeMod
             .background(Palette.surfaceBase)
             .clearAndSetSemantics {}, // decorative — invisible to TalkBack
     ) {
         // The static time-of-day sky, top-aligned, settling into Palette.surfaceBase over its lower half.
         LiquidSkyStatic(
             hour = null, // live local hour (hour + minute/60)
-            modifier = Modifier
-                .fillMaxWidth()
-                .height(height),
+            modifier = if (fillHeight) Modifier.fillMaxSize() else Modifier.fillMaxWidth().height(height),
+            // A partial settle in fill-height mode keeps the horizon tint alive behind the scroll.
+            settleStrength = if (fillHeight) 0.78f else 1f,
         )
     }
 }

--- a/android/app/src/main/java/com/noop/ui/LiquidSky.kt
+++ b/android/app/src/main/java/com/noop/ui/LiquidSky.kt
@@ -145,6 +145,9 @@ private fun androidx.compose.ui.graphics.drawscope.DrawScope.renderLiquidSky(
     now: Double,
     settle: Color,
     animate: Boolean,
+    // How fully the sky dissolves into the canvas at the bottom (1 = the default seamless fade to the flat
+    // page; <1 holds the atmosphere so the sky still reads under a full-height "sky behind cards" backdrop).
+    settleStrength: Float = 1f,
 ) {
     val s = liquidSkyAt(hour)
     val w = size.width
@@ -227,7 +230,7 @@ private fun androidx.compose.ui.graphics.drawscope.DrawScope.renderLiquidSky(
         brush = Brush.verticalGradient(
             colors = listOf(
                 settle.copy(alpha = 0f),
-                settle,
+                settle.copy(alpha = settleStrength.coerceIn(0f, 1f)),
             ),
             startY = h * 0.45f,
             endY = h,
@@ -293,11 +296,11 @@ fun LiquidSky(hour: Double? = null, modifier: Modifier = Modifier) {
  * [hour] defaults to live local time when null.
  */
 @Composable
-fun LiquidSkyStatic(hour: Double? = null, modifier: Modifier = Modifier) {
+fun LiquidSkyStatic(hour: Double? = null, modifier: Modifier = Modifier, settleStrength: Float = 1f) {
     val settle = liquidSettleColor
     val h = hour ?: liquidLiveHour()
     Canvas(modifier = modifier) {
-        renderLiquidSky(hour = h, now = 0.0, settle = settle, animate = false)
+        renderLiquidSky(hour = h, now = 0.0, settle = settle, animate = false, settleStrength = settleStrength)
     }
 }
 

--- a/android/app/src/main/java/com/noop/ui/MainActivity.kt
+++ b/android/app/src/main/java/com/noop/ui/MainActivity.kt
@@ -489,6 +489,18 @@ object NoopPrefs {
         of(context).edit().putInt(KEY_CARD_OPACITY, percent.coerceIn(0, 100)).apply()
     }
 
+    /** "Sky behind cards" (opt-in, default OFF): extend the day-cycle sky behind the WHOLE Today scroll
+     *  (not just the top band) so the Card-transparency slider reveals it under every card. Pairs with
+     *  [showDayCycleBackground] — no effect when the scene is off. Read once on Today entry. */
+    const val KEY_SKY_BEHIND_CARDS = "noop.skyBehindCards"
+
+    fun skyBehindCards(context: Context): Boolean =
+        of(context).getBoolean(KEY_SKY_BEHIND_CARDS, false)
+
+    fun setSkyBehindCards(context: Context, enabled: Boolean) {
+        of(context).edit().putBoolean(KEY_SKY_BEHIND_CARDS, enabled).apply()
+    }
+
     /** Coach on-device signals (v5): when ON, the opt-in BYO-key Coach's grounding context may include a
      *  SUMMARY-ONLY line of on-device correlations + Lab Book markers (no raw egress). A SECOND opt-in on
      *  top of the existing "let the coach use my data" consent. Default OFF, keeps the anonymity posture. */

--- a/android/app/src/main/java/com/noop/ui/SettingsScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/SettingsScreen.kt
@@ -467,6 +467,9 @@ fun SettingsScreen(
     // Day-cycle background (#698) — the time-of-day scene behind Today. Default ON. SharedPreferences
     // isn't reactive, so the Switch mirrors into local state; TodayScreen reads the same pref on entry.
     var showDayCycleBackground by remember { mutableStateOf(NoopPrefs.showDayCycleBackground(context)) }
+    // "Sky behind cards" (opt-in, default OFF) — extend the day-cycle sky behind the whole Today scroll so
+    // Card transparency reveals it under every card. Mirrors into local state; TodayScreen reads on entry.
+    var skyBehindCards by remember { mutableStateOf(NoopPrefs.skyBehindCards(context)) }
     // Card-surface opacity (0f = clear, 1f = solid), for the "Card transparency" slider. Live-previews via
     // CardAppearance; saved on release.
     var cardOpacity by remember { mutableStateOf(NoopPrefs.cardOpacityPercent(context) / 100f) }
@@ -945,6 +948,43 @@ fun SettingsScreen(
                     onCheckedChange = {
                         showDayCycleBackground = it
                         NoopPrefs.setShowDayCycleBackground(context, it)
+                    },
+                    colors = SwitchDefaults.colors(
+                        checkedThumbColor = Palette.surfaceBase,
+                        checkedTrackColor = Palette.accent,
+                        uncheckedThumbColor = Palette.textSecondary,
+                        uncheckedTrackColor = Palette.surfaceInset,
+                        uncheckedBorderColor = Palette.hairline,
+                    ),
+                )
+            }
+
+            // Sky behind cards (opt-in): extend the day-cycle sky behind the WHOLE Today scroll so the Card
+            // transparency slider reveals it under every card, not just the hero. Off = the sky stays a top
+            // band and lower cards fade toward the flat canvas. Needs the day-cycle background to be on.
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(16.dp),
+            ) {
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(
+                        "Sky behind cards",
+                        style = NoopType.subhead,
+                        color = if (showDayCycleBackground) Palette.textPrimary else Palette.textTertiary,
+                    )
+                    Text(
+                        "Extends the sky behind the whole Today screen, so lowering Card transparency lets it show through every card. Needs the day-cycle background on.",
+                        style = NoopType.footnote,
+                        color = Palette.textTertiary,
+                    )
+                }
+                Switch(
+                    enabled = showDayCycleBackground,
+                    checked = skyBehindCards && showDayCycleBackground,
+                    onCheckedChange = {
+                        skyBehindCards = it
+                        NoopPrefs.setSkyBehindCards(context, it)
                     },
                     colors = SwitchDefaults.colors(
                         checkedThumbColor = Palette.surfaceBase,

--- a/android/app/src/main/java/com/noop/ui/TodayScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/TodayScreen.kt
@@ -486,6 +486,9 @@ fun TodayScreen(
     // the scaffold paints the plain dark surface canvas instead. SharedPreferences isn't reactive, so
     // this is read once into local state (mirrors iOS @AppStorage in TodayView).
     val showDayCycleBackground = remember { NoopPrefs.showDayCycleBackground(context) }
+    // "Sky behind cards" (opt-in, default OFF): extend the day-cycle sky behind the WHOLE scroll so the
+    // Card-transparency slider reveals it under every card (no effect when the scene is off). Read once.
+    val skyBehindCards = remember { NoopPrefs.skyBehindCards(context) }
     var hydrationTotalMl by remember { mutableStateOf(0.0) }
     // #989: `days` only changes on a data refresh, which a hydration write never causes, so the card sat
     // stale after logging a drink until an unrelated sync landed. Keying on the store's mutationSeq too
@@ -955,7 +958,9 @@ fun TodayScreen(
         // LiquidScreenSky() slot verbatim.
         // #698, gated on the "Day-cycle background" setting (default ON). Off passes null, so the scaffold
         // paints the plain dark surface canvas instead, mirroring iOS's `showDayCycleBackground ? ... : nil`.
-        topBackground = if (showDayCycleBackground) { { LiquidScreenSky() } } else null,
+        topBackground = if (showDayCycleBackground) { { LiquidScreenSky(fillHeight = skyBehindCards) } } else null,
+        // Sky-behind-cards fills the viewport so the transparent cards reveal the sky the whole way down.
+        fullBleedBackground = showDayCycleBackground && skyBehindCards,
     ) {
         item {
         // LIQUID Today header (iOS LiquidTodayView.scene parity), a full structural rebuild to mirror the


### PR DESCRIPTION
Follow-up to card transparency. Right now the transparency slider only visibly affects the **hero** card, because the day-cycle sky is a ~340dp top band and everything below sits on the flat dark canvas — so a lower card fading toward transparent just reveals dark.

This adds an **opt-in** toggle **Settings → Appearance → “Sky behind cards”** (default **OFF**) that extends the sky behind the **whole** Today scroll, so lowering Card transparency reveals it under **every** card.

## How
- `renderLiquidSky` / `LiquidSkyStatic` gain a `settleStrength` knob. Default `1f` keeps the current seamless fade-to-canvas; fill-height mode uses `0.78` so the horizon tint survives behind the scroll instead of dissolving to dark.
- `LiquidScreenSky(fillHeight = true)` fills the viewport; `LazyScreenScaffold(fullBleedBackground = true)` paints the backdrop full-size instead of a top band (still bled under the status bar).
- `TodayScreen` reads `NoopPrefs.skyBehindCards`; the Settings switch is **gated on the day-cycle background** (no effect when the scene is off, greys out when it is).

## Scope / safety
- **Default OFF** → zero change for existing users; respects the #698 plain-canvas choice.
- **Android only, Today screen** for now, so it can be eyeballed on a testing build. iOS parity + the other liquid screens (Stress/Sleep/…) to follow **if you like the look**.
- Pairs with the shipped Card transparency slider — turn both on to see the sky through the cards.

## Verify
- Kotlin compiles clean.
- To try: build `sky-behind-cards`, Settings → Appearance → turn on “Sky behind cards”, then drag Card transparency up.