### PR TITLE
iOS: "Sky behind cards" parity — day-cycle sky behind the whole Today scroll (opt-in)

### DIFF
--- a/Packages/StrandDesign/Sources/StrandDesign/Appearance.swift
+++ b/Packages/StrandDesign/Sources/StrandDesign/Appearance.swift
@@ -106,6 +106,14 @@ public enum CardAppearancePrefs {
     public static let defaultPercent = 100
 }
 
+/// "Sky behind cards" (opt-in, default OFF): extend the day-cycle sky behind the WHOLE Today scroll (not
+/// just the top band) so the Card-transparency setting reveals it under every card. Read in `LiquidTodayView`
+/// via `@AppStorage(SkyBehindCardsPrefs.enabledKey)` and toggled from Settings → Appearance. Mirror in
+/// Kotlin via `NoopPrefs.skyBehindCards`.
+public enum SkyBehindCardsPrefs {
+    public static let enabledKey = "noop.skyBehindCards"
+}
+
 // MARK: - Light-idiom helpers
 
 /// An additive glow (ring blooms, sparkline heads, hero halos) only reads on a DARK canvas —

--- a/Strand/Liquid/LiquidSky.swift
+++ b/Strand/Liquid/LiquidSky.swift
@@ -61,6 +61,9 @@ private let liquidStars: [LiquidStar] = (0..<70).map { _ in
 struct LiquidSky: View {
     /// Hour of day 0...24. Defaults to live time when nil.
     var hour: Double?
+    /// How fully the sky dissolves into the canvas at the bottom (1 = the default seamless fade; <1 holds
+    /// the atmosphere so the sky still reads under a full-height "sky behind cards" backdrop).
+    var settleStrength: Double = 1
     @Environment(\.colorScheme) private var scheme
 
     var body: some View {
@@ -123,7 +126,7 @@ struct LiquidSky: View {
         // Settle into the page: a long fade to the theme's surfaceBase over the lower half so the sky
         // dissolves seamlessly into the body — no hard cut (the light-mode dark→white slam is gone).
         ctx.fill(Path(CGRect(x: 0, y: h * 0.45, width: w, height: h * 0.55)),
-                 with: .linearGradient(Gradient(colors: [settle.opacity(0), settle]),
+                 with: .linearGradient(Gradient(colors: [settle.opacity(0), settle.opacity(settleStrength)]),
                                        startPoint: CGPoint(x: 0, y: h * 0.45), endPoint: CGPoint(x: 0, y: h)))
     }
 }
@@ -148,6 +151,9 @@ func liquidScaffoldSky(height: CGFloat = 240) -> AnyView {
 /// minus the twinkle/breath, matching the classic app's static scene image for scroll perf.
 struct LiquidSkyStatic: View {
     var hour: Double?
+    /// See `LiquidSky.settleStrength` — 1 = default seamless fade; <1 holds the atmosphere for the
+    /// full-height "sky behind cards" backdrop.
+    var settleStrength: Double = 1
     @Environment(\.colorScheme) private var scheme
 
     var body: some View {
@@ -177,7 +183,7 @@ struct LiquidSkyStatic: View {
                 }
             }
             ctx.fill(Path(CGRect(x: 0, y: hh * 0.45, width: w, height: hh * 0.55)),
-                     with: .linearGradient(Gradient(colors: [settle.opacity(0), settle]),
+                     with: .linearGradient(Gradient(colors: [settle.opacity(0), settle.opacity(settleStrength)]),
                                            startPoint: CGPoint(x: 0, y: hh * 0.45), endPoint: CGPoint(x: 0, y: hh)))
         }
     }

--- a/Strand/Liquid/LiquidTodayView.swift
+++ b/Strand/Liquid/LiquidTodayView.swift
@@ -82,6 +82,9 @@ struct LiquidTodayView: View {
     /// Content sits above the surface so it stays readable. Mirrors Kotlin `NoopPrefs.cardOpacityPercent`.
     @AppStorage(CardAppearancePrefs.opacityKey) private var cardOpacityPercent = CardAppearancePrefs.defaultPercent
     private var cardOpacity: Double { max(0, min(1, Double(cardOpacityPercent) / 100)) }
+    /// "Sky behind cards" (opt-in, default OFF): extend the day-cycle sky behind the WHOLE scroll so the
+    /// Card-transparency slider reveals it under every card. Mirrors Kotlin `NoopPrefs.skyBehindCards`.
+    @AppStorage(SkyBehindCardsPrefs.enabledKey) private var skyBehindCards = false
 
     // MARK: - Day navigation (ported from classic Today: swipe + calendar, day-keyed reads)
 
@@ -222,12 +225,14 @@ struct LiquidTodayView: View {
                 StrandPalette.surfaceBase
                 // Reduce-motion (and low-power) users get the same sky posed still — no twinkle/breath.
                 // Also static until the first data load settles, so launch isn't fighting a live sky too.
+                // "Sky behind cards" (opt-in): fill the whole backdrop with a softer settle so the sky reads
+                // under every card, instead of the default 340 top band that dissolves into the canvas.
                 Group {
-                    if reduceMotion || !dataLoaded { LiquidSkyStatic(hour: liveHour) }
-                    else { LiquidSky(hour: liveHour) }
+                    if reduceMotion || !dataLoaded { LiquidSkyStatic(hour: liveHour, settleStrength: skyBehindCards ? 0.78 : 1) }
+                    else { LiquidSky(hour: liveHour, settleStrength: skyBehindCards ? 0.78 : 1) }
                 }
                 .frame(maxWidth: .infinity)
-                .frame(height: 340, alignment: .top)
+                .frame(height: skyBehindCards ? nil : 340, alignment: .top)
                 .allowsHitTesting(false)
                 .accessibilityHidden(true)
             }

--- a/Strand/Screens/SettingsView.swift
+++ b/Strand/Screens/SettingsView.swift
@@ -77,6 +77,9 @@ struct SettingsView: View {
     // Day-cycle scene backdrop behind Today (#698). Default ON. Off swaps the scene for a plain dark
     // canvas. TodayView reads the same key to gate its SceneScreenBackground.
     @AppStorage(SceneBackgroundPrefs.enabledKey) private var showDayCycleBackground = true
+    // "Sky behind cards" (opt-in, default OFF): extend the day-cycle sky behind the whole Today scroll so
+    // Card transparency reveals it under every card. Mirrors Kotlin NoopPrefs.skyBehindCards.
+    @AppStorage(SkyBehindCardsPrefs.enabledKey) private var skyBehindCards = false
     // Card-surface opacity percent (100 = solid). Reactive — moving the slider live-updates every card.
     @AppStorage(CardAppearancePrefs.opacityKey) private var cardOpacityPercent = CardAppearancePrefs.defaultPercent
     // Hydration tracker (opt-in, MVP). Default OFF — when off the hydration dashboard card + detail are
@@ -687,6 +690,22 @@ struct SettingsView: View {
                 .toggleStyle(.switch)
                 .tint(StrandPalette.accent)
                 Text("Shows a soft sunrise, day, dusk and night scene behind the Today screen. Turn it off for a plain dark canvas. Your cards stay exactly as readable.")
+                    .font(StrandFont.caption)
+                    .foregroundStyle(StrandPalette.textTertiary)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+
+                // MARK: Sky behind cards — extend the day-cycle sky behind the WHOLE Today scroll so the
+                // Card-transparency slider reveals it under every card (not just the hero). Opt-in, off by
+                // default; pairs with Card transparency below.
+                Toggle(isOn: $skyBehindCards) {
+                    Text("Sky behind cards")
+                        .font(StrandFont.subhead)
+                        .foregroundStyle(StrandPalette.textPrimary)
+                }
+                .toggleStyle(.switch)
+                .tint(StrandPalette.accent)
+                Text("Extends the sky behind the whole Today screen, so lowering Card transparency lets it show through every card.")
                     .font(StrandFont.caption)
                     .foregroundStyle(StrandPalette.textTertiary)
                     .fixedSize(horizontal: false, vertical: true)


### PR DESCRIPTION
iOS parity for #15 (Android). The liquid Today sky is a 340 top band, so Card transparency only reveals it behind the **hero**; lower cards fade toward the flat canvas.

Adds the same opt-in **Settings → Appearance → "Sky behind cards"** toggle (default **OFF**) that extends the sky behind the **whole** Today scroll.

## How (mirrors the Android knobs)
- `LiquidSky` / `LiquidSkyStatic` gain a `settleStrength` — `1` keeps the current seamless fade-to-canvas; fill mode uses `0.78` so the horizon tint survives behind the scroll instead of dissolving to dark.
- `LiquidTodayView`’s backdrop drops the `340` frame (fills the view) with the softer settle when the toggle is on.
- New `SkyBehindCardsPrefs.enabledKey` = `"noop.skyBehindCards"` — the **same key** as Kotlin `NoopPrefs.skyBehindCards`, shared with the Settings `Toggle`.

## Scope / safety
- **Default OFF** → zero change for existing users.
- Swift compile-gated by CI (can’t build on the dev box).

## Verify
- iOS/macOS build via CI.
- Try: Settings → Appearance → turn on “Sky behind cards”, then drag Card transparency up.