### PR TITLE
iOS: liquid Today honours the Day-cycle background toggle (closes #16 parity gap)

### DIFF
--- a/Strand/Liquid/LiquidTodayView.swift
+++ b/Strand/Liquid/LiquidTodayView.swift
@@ -85,6 +85,10 @@ struct LiquidTodayView: View {
     /// "Sky behind cards" (opt-in, default OFF): extend the day-cycle sky behind the WHOLE scroll so the
     /// Card-transparency slider reveals it under every card. Mirrors Kotlin `NoopPrefs.skyBehindCards`.
     @AppStorage(SkyBehindCardsPrefs.enabledKey) private var skyBehindCards = false
+    /// Day-cycle scene backdrop (#698). Default ON. When off, the liquid Today drops the sky for the plain
+    /// dark canvas — parity with Android and the classic TodayView, which already honour this pref. Mirrors
+    /// Kotlin `NoopPrefs.showDayCycleBackground`.
+    @AppStorage(SceneBackgroundPrefs.enabledKey) private var showDayCycleBackground = true
 
     // MARK: - Day navigation (ported from classic Today: swipe + calendar, day-keyed reads)
 
@@ -223,18 +227,22 @@ struct LiquidTodayView: View {
         .background(alignment: .top) {
             ZStack(alignment: .top) {
                 StrandPalette.surfaceBase
-                // Reduce-motion (and low-power) users get the same sky posed still — no twinkle/breath.
-                // Also static until the first data load settles, so launch isn't fighting a live sky too.
-                // "Sky behind cards" (opt-in): fill the whole backdrop with a softer settle so the sky reads
-                // under every card, instead of the default 340 top band that dissolves into the canvas.
-                Group {
-                    if reduceMotion || !dataLoaded { LiquidSkyStatic(hour: liveHour, settleStrength: skyBehindCards ? 0.78 : 1) }
-                    else { LiquidSky(hour: liveHour, settleStrength: skyBehindCards ? 0.78 : 1) }
+                // Day-cycle scene (#698): the sky only paints when the toggle is ON; off = the plain
+                // surfaceBase canvas above (parity with Android + the classic TodayView).
+                if showDayCycleBackground {
+                    // Reduce-motion (and low-power) users get the same sky posed still — no twinkle/breath.
+                    // Also static until the first data load settles, so launch isn't fighting a live sky too.
+                    // "Sky behind cards" (opt-in): fill the whole backdrop with a softer settle so the sky
+                    // reads under every card, instead of the default 340 top band that dissolves to canvas.
+                    Group {
+                        if reduceMotion || !dataLoaded { LiquidSkyStatic(hour: liveHour, settleStrength: skyBehindCards ? 0.78 : 1) }
+                        else { LiquidSky(hour: liveHour, settleStrength: skyBehindCards ? 0.78 : 1) }
+                    }
+                    .frame(maxWidth: .infinity)
+                    .frame(height: skyBehindCards ? nil : 340, alignment: .top)
+                    .allowsHitTesting(false)
+                    .accessibilityHidden(true)
                 }
-                .frame(maxWidth: .infinity)
-                .frame(height: skyBehindCards ? nil : 340, alignment: .top)
-                .allowsHitTesting(false)
-                .accessibilityHidden(true)
             }
             .ignoresSafeArea()
         }

--- a/Strand/Screens/SettingsView.swift
+++ b/Strand/Screens/SettingsView.swift
@@ -701,11 +701,13 @@ struct SettingsView: View {
                 Toggle(isOn: $skyBehindCards) {
                     Text("Sky behind cards")
                         .font(StrandFont.subhead)
-                        .foregroundStyle(StrandPalette.textPrimary)
+                        // Greyed when day-cycle is off — the sky it extends isn't drawn then (Android parity).
+                        .foregroundStyle(showDayCycleBackground ? StrandPalette.textPrimary : StrandPalette.textTertiary)
                 }
                 .toggleStyle(.switch)
                 .tint(StrandPalette.accent)
-                Text("Extends the sky behind the whole Today screen, so lowering Card transparency lets it show through every card.")
+                .disabled(!showDayCycleBackground)
+                Text("Extends the sky behind the whole Today screen, so lowering Card transparency lets it show through every card. Needs the day-cycle background on.")
                     .font(StrandFont.caption)
                     .foregroundStyle(StrandPalette.textTertiary)
                     .fixedSize(horizontal: false, vertical: true)


### PR DESCRIPTION
Closes the one parity gap flagged in #16. On iOS, `LiquidTodayView` always drew the sky, **ignoring** the "Day-cycle background" setting — so turning it off did **not** give the plain dark canvas it does on Android (and the classic `TodayView`). That also made the "Sky behind cards" switch standalone on iOS vs. day-cycle-gated on Android.

## Changes
- **Gate the liquid Today sky** on `@AppStorage(SceneBackgroundPrefs.enabledKey)` — off = the plain `surfaceBase` canvas (parity with Android + classic Today).
- **Disable/grey the "Sky behind cards" toggle** when the day-cycle background is off (the sky it extends isn`\t drawn then) — mirrors Android`\s `enabled = showDayCycleBackground`.

## Result — full parity
| day-cycle | sky-behind-cards | Android | iOS (after) |
|---|---|---|---|
| ON | OFF | hero-band sky | hero-band sky |
| ON | ON | full sky behind cards | full sky behind cards |
| OFF | — | plain canvas, toggle disabled | plain canvas, toggle disabled |

Default behaviour unchanged (day-cycle defaults ON). Swift compile-gated by CI.