### PR TITLE
Update altstore-source.json with version 8.3.0

### DIFF
--- a/altstore-source.json
+++ b/altstore-source.json
@@ -18,7 +18,7 @@
       "screenshotURLs": [],
       "versions": [
         {
-          "version": "8.2.2",
+          "version": "8.3.0",
           "buildVersion": "173",
           "date": "2026-07-07",
           "localizedDescription": "NOOP 8.3.0. See the release notes for what changed.",

--- a/altstore-source.json
+++ b/altstore-source.json
@@ -19,6 +19,15 @@
       "versions": [
         {
           "version": "8.2.2",
+          "buildVersion": "173",
+          "date": "2026-07-07",
+          "localizedDescription": "NOOP 8.3.0. See the release notes for what changed.",
+          "downloadURL": "https://github.com/ryanbr/noop/releases/download/v8.3.0/NOOP-ios-unsigned-v8.3.0.ipa",
+          "size": 22431840,
+          "minOSVersion": "17.0"
+        },
+        {
+          "version": "8.2.2",
           "buildVersion": "172",
           "date": "2026-07-06",
           "localizedDescription": "NOOP 8.2.2. See the release notes for what changed.",


### PR DESCRIPTION
## What this PR does
Added new version 8.3.0 with details and download link to `altstore-source.json`.

<!-- A short description of the change and why it's needed. -->

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] CI / tooling

## How it was tested

<!--
For anything on the BLE path, say what you tested on real hardware and which
strap (4.0 / 5.0 / MG). For protocol or analytics changes, point to the test
that covers it. "Builds and unit tests pass" alone is not enough for BLE work.
-->

## Checklist

- [x] Swift package tests pass for any package I touched (`swift test` in `Packages/<name>`)
- [x] Android unit tests pass if I touched `android/` (`./gradlew testFullDebugUnitTest`)
- [x] No new build warnings introduced
- [x] UI changes use only `StrandDesign` tokens — no hardcoded colors, fonts, or spacing
- [x] No hardcoded hex frame bytes; protocol facts live in the schema / decoders
- [x] Follows the conventions in [`docs/CONTRIBUTING.md`](../docs/CONTRIBUTING.md)
- [x] I did not commit generated output (`Strand.xcodeproj/`) or any secrets/keystores

