### PR TITLE
Debug export: strap & data state + analytics-funnel diagnostics

### DIFF
--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -3430,7 +3430,11 @@ class WhoopBleClient(
                 // resp_cmd, so a single branch covers both families. Stable for the connection, so we
                 // only republish state when it actually changes.
                 (parsed.parsed["fw_version"] as? String ?: parsed.parsed["fw_harvard"] as? String)?.let { fw ->
-                    if (_state.value.strapFirmware != fw) _state.update { it.copy(strapFirmware = fw) }
+                    if (_state.value.strapFirmware != fw) {
+                        _state.update { it.copy(strapFirmware = fw) }
+                        // Persist so the debug export can name the firmware offline (state clears on disconnect).
+                        runCatching { NoopPrefs.setLastFirmware(context, fw) }
+                    }
                 }
                 val respCmd = parsed.parsed["resp_cmd"] as? String
                 val result = parsed.parsed["result"] as? String

--- a/android/app/src/main/java/com/noop/testcentre/AndroidDiagnostics.kt
+++ b/android/app/src/main/java/com/noop/testcentre/AndroidDiagnostics.kt
@@ -27,6 +27,100 @@ object AndroidDiagnostics {
         add("Permissions: ${permissionsText(context)}")
     }
 
+    /**
+     * Strap identity + data-state lines for the debug export. Offline-safe: reads persisted prefs and the
+     * canonical "my-whoop" daily spine, so it works from the scheduled background export too. Model,
+     * last-known firmware, last-sync, timezone, days of history, and the most recent sleep + recovery day.
+     * Best-effort: guarded so it never throws into the export.
+     */
+    suspend fun strapAndDataLines(context: Context): List<String> = buildList {
+        add("─".repeat(40))
+        add("Strap & data")
+        runCatching {
+            val dev = com.noop.ui.NoopPrefs.lastDevice(context)
+            add("Model:       ${dev?.second?.displayName ?: "unknown (never paired)"}")
+            add("Firmware:    ${com.noop.ui.NoopPrefs.lastFirmware(context) ?: "unknown (connect to record)"}")
+            val syncSec = com.noop.ui.NoopPrefs.lastSyncAt(context)
+            add("Last sync:   ${if (syncSec > 0L) relTime(System.currentTimeMillis() - syncSec * 1000L) else "never"}")
+            add("Timezone:    ${tzLine()}")
+            val repo = com.noop.data.WhoopRepository.from(context)
+            val days = repo.days("my-whoop")
+            add("History:     ${days.size} day rows (my-whoop spine)")
+            add("Last sleep:  ${days.lastOrNull { (it.totalSleepMin ?: 0.0) > 0.0 }?.let { "${it.day} · ${it.totalSleepMin?.toInt()} min" } ?: "none"}")
+            add("Last recov.: ${days.lastOrNull { it.recovery != null }?.let { "${it.day} · ${it.recovery?.toInt()}%" } ?: "none"}")
+        }.onFailure { add("(strap/data state unavailable: ${it.message})") }
+    }
+
+    /**
+     * Analytics-funnel lines: recompute the REM + skin-temp funnels for the most recent night so a "0% REM"
+     * / "skin temp absent" report arrives with the funnel breakdown. BEST-EFFORT and self-reporting — it
+     * prints the sample counts it read and says plainly when it can't compute (e.g. a freshly re-added strap
+     * whose raw samples aren't yet under the canonical id), so it never fabricates a misleading verdict.
+     */
+    suspend fun funnelLines(context: Context): List<String> = buildList {
+        add("─".repeat(40))
+        add("Analytics funnels (latest night, best-effort)")
+        runCatching {
+            val repo = com.noop.data.WhoopRepository.from(context)
+            val id = "my-whoop"
+            val nowSec = System.currentTimeMillis() / 1000L
+            val session = repo.sleepSessions(id, nowSec - 14L * 86400L, nowSec, 1).lastOrNull()
+            if (session == null) {
+                add("(no sleep session in the last 14 days to analyze)")
+                return@runCatching
+            }
+            val grav = repo.gravitySamples(id, session.startTs, session.endTs, Int.MAX_VALUE)
+            val hr = repo.hrSamples(id, session.startTs, session.endTs, Int.MAX_VALUE)
+            val rr = repo.rrIntervals(id, session.startTs, session.endTs, Int.MAX_VALUE)
+            val resp = repo.respSamples(id, session.startTs, session.endTs, Int.MAX_VALUE)
+            val skin = repo.skinTempSamples(id, session.startTs, session.endTs, Int.MAX_VALUE)
+            add("Night ${dayStamp(session.startTs)}: grav=${grav.size} hr=${hr.size} rr=${rr.size} resp=${resp.size} skin=${skin.size}")
+            if (grav.isEmpty() && hr.isEmpty()) {
+                add("(no raw biometric samples under '$id' for this night — expected on a freshly re-added strap; reconnect + let a history sync run, then re-export)")
+                return@runCatching
+            }
+            com.noop.analytics.SleepStager.remFunnelDiagnostic(session.startTs, session.endTs, grav, hr, rr, resp)
+                ?.let { add(it.summary) } ?: add("REM funnel: insufficient motion data (<2 gravity samples)")
+            val det = com.noop.analytics.DetectedSleep(
+                start = session.startTs, end = session.endTs,
+                efficiency = session.efficiency ?: 0.0, stages = emptyList(),
+                restingHR = session.restingHr, avgHRV = session.avgHrv,
+            )
+            val family = if (com.noop.ui.NoopPrefs.lastDevice(context)?.second == com.noop.ble.WhoopModel.WHOOP5_MG)
+                com.noop.protocol.DeviceFamily.WHOOP5 else com.noop.protocol.DeviceFamily.WHOOP4
+            add(com.noop.analytics.AnalyticsEngine.skinTempFunnel(listOf(det), hr, skin, family).summary)
+        }.onFailure { add("(funnels unavailable: ${it.message})") }
+    }
+
+    /** The DB/prefs-backed diagnostic lines appended to the export header. Suspends (reads the local store);
+     *  guarded per-section so it never throws into the export. */
+    suspend fun dynamicLines(context: Context): List<String> =
+        kotlinx.coroutines.withContext(kotlinx.coroutines.Dispatchers.Default) {
+            strapAndDataLines(context) + funnelLines(context)
+        }
+
+    /** "3h 12m ago" style relative stamp for a positive age in ms. */
+    private fun relTime(deltaMs: Long): String {
+        if (deltaMs < 60_000L) return "just now"
+        val min = deltaMs / 60_000L
+        return when {
+            min < 60 -> "${min}m ago"
+            min < 1440 -> "${min / 60}h ${min % 60}m ago"
+            else -> "${min / 1440}d ago"
+        }
+    }
+
+    private fun tzLine(): String = runCatching {
+        val tz = java.util.TimeZone.getDefault()
+        val offMin = tz.getOffset(System.currentTimeMillis()) / 60_000
+        val a = kotlin.math.abs(offMin)
+        "${tz.id} (UTC${if (offMin >= 0) "+" else "-"}${a / 60}:${"%02d".format(a % 60)})"
+    }.getOrDefault("unknown")
+
+    private fun dayStamp(epochSec: Long): String = runCatching {
+        java.text.SimpleDateFormat("yyyy-MM-dd", java.util.Locale.US).format(epochSec * 1000L)
+    }.getOrDefault("?")
+
     /** Doze exemption: an app NOT exempt from battery optimisation is the #1 cause of missed overnight
      *  background work on Android. */
     private fun batteryOptimisationText(context: Context): String = runCatching {

--- a/android/app/src/main/java/com/noop/ui/LogExport.kt
+++ b/android/app/src/main/java/com/noop/ui/LogExport.kt
@@ -118,7 +118,7 @@ object LogExport {
      * empty string and we fall back to the rolling buffer alone. Best-effort: returns an empty list on
      * failure rather than throwing into the worker.
      */
-    fun writeScheduledExport(context: Context, logText: String, nowMs: Long = System.currentTimeMillis()): List<File> =
+    suspend fun writeScheduledExport(context: Context, logText: String, nowMs: Long = System.currentTimeMillis()): List<File> =
         runCatching {
             if (logText.isNotBlank()) StrapLogBuffer.replaceWith(logText, nowMs)
             val body = StrapLogBuffer.snapshot(nowMs)
@@ -126,10 +126,12 @@ object LogExport {
             val dir = exportDir(context)
             val out = arrayListOf<File>()
 
+            val dynamic = com.noop.testcentre.AndroidDiagnostics.dynamicLines(context)
             val header = buildString {
                 appendLine("NOOP strap log (scheduled debug export)")
                 appendLine("App:     ${BuildConfig.VERSION_NAME} (${BuildConfig.TIER})")
                 for (line in com.noop.testcentre.AndroidDiagnostics.summaryLines(context)) appendLine(line)
+                for (line in dynamic) appendLine(line)
                 appendLine("─".repeat(40))
             }
             val text = body.ifBlank { "(rolling strap-log buffer is empty; connect to your strap so lines accrue)" }
@@ -161,14 +163,16 @@ object LogExport {
      * Build the shareable strap-log file (header + body + last crash) under cache/logs and return it,
      * so both the single-share and the "raw + log" matched-pair export write the SAME content.
      */
-    private fun writeStrapLogFile(context: Context, logText: String): File {
+    private suspend fun writeStrapLogFile(context: Context, logText: String): File {
         // Mirror every interactively-shared tail into the durable rolling buffer (#510) so the scheduled
         // background export has a current source even when the live BLE client is gone.
         mirrorToRollingBuffer(logText)
+        val dynamic = com.noop.testcentre.AndroidDiagnostics.dynamicLines(context)
         val header = buildString {
             appendLine("NOOP strap log")
             appendLine("App:     ${BuildConfig.VERSION_NAME} (${BuildConfig.TIER})")
             for (line in com.noop.testcentre.AndroidDiagnostics.summaryLines(context)) appendLine(line)
+            for (line in dynamic) appendLine(line)
             appendLine("─".repeat(40))
         }
         val body = logText.ifBlank { "(strap log is empty; connect to your strap, reproduce the issue, then share again)" }
@@ -211,7 +215,7 @@ object LogExport {
     private fun fileUri(context: Context, file: File) =
         FileProvider.getUriForFile(context, "${context.packageName}.fileprovider", file)
 
-    fun shareStrapLog(context: Context, logText: String) {
+    suspend fun shareStrapLog(context: Context, logText: String) {
         runCatching {
             val file = writeStrapLogFile(context, logText)
             val send = Intent(Intent.ACTION_SEND).apply {
@@ -275,7 +279,7 @@ object LogExport {
      * end. Reuses the same file-builders the single-share paths use; both entries are already redacted by
      * their writers.
      */
-    fun shareRawAndLog(context: Context, logText: String, whoop5Connected: Boolean) {
+    suspend fun shareRawAndLog(context: Context, logText: String, whoop5Connected: Boolean) {
         runCatching {
             val logFile = writeStrapLogFile(context, logText)
             val capture = writeCaptureFile(context)

--- a/android/app/src/main/java/com/noop/ui/MainActivity.kt
+++ b/android/app/src/main/java/com/noop/ui/MainActivity.kt
@@ -723,6 +723,18 @@ object NoopPrefs {
     fun setLastSyncAt(context: Context, epochSec: Long) {
         of(context).edit().putLong(KEY_LAST_SYNC_AT, epochSec).apply()
     }
+
+    /** Last-known strap firmware string, persisted on connect so the debug export can name it OFFLINE
+     *  (LiveState.strapFirmware is cleared on disconnect and gone in the scheduled/background export). */
+    const val KEY_LAST_FIRMWARE = "noop.lastFirmware"
+
+    fun lastFirmware(context: Context): String? = of(context).getString(KEY_LAST_FIRMWARE, null)
+
+    fun setLastFirmware(context: Context, fw: String?) {
+        of(context).edit().apply {
+            if (fw.isNullOrBlank()) remove(KEY_LAST_FIRMWARE) else putString(KEY_LAST_FIRMWARE, fw)
+        }.apply()
+    }
 }
 
 /**

--- a/android/app/src/main/java/com/noop/ui/SettingsScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/SettingsScreen.kt
@@ -1311,7 +1311,7 @@ fun SettingsScreen(
                     leadingIcon = Icons.Filled.Upload,
                     kind = NoopButtonKind.Secondary,
                     fullWidth = true,
-                    onClick = { LogExport.shareStrapLog(context, vm.ble.exportLogText()) },
+                    onClick = { scope.launch { LogExport.shareStrapLog(context, vm.ble.exportLogText()) } },
                 )
 
                 // "WHOOP 4.0 vs 5.0/MG — what each can read and why" (FI-2 / #490). Shown to BOTH model
@@ -1572,7 +1572,7 @@ fun SettingsScreen(
                     leadingIcon = Icons.Filled.IosShare,
                     kind = NoopButtonKind.Secondary,
                     fullWidth = true,
-                    onClick = { LogExport.shareRawAndLog(context, vm.ble.exportLogText(), live.whoop5Detected) },
+                    onClick = { scope.launch { LogExport.shareRawAndLog(context, vm.ble.exportLogText(), live.whoop5Detected) } },
                 )
             }
         }

--- a/android/app/src/main/java/com/noop/ui/TestCentreScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/TestCentreScreen.kt
@@ -314,6 +314,7 @@ private fun TestModeRow(
 @Composable
 private fun DiagnosticToolsCard(vm: AppViewModel) {
     val context = LocalContext.current
+    val scope = rememberCoroutineScope()
     var showRecalibrate by remember { mutableStateOf(false) }
     SettingsSectionTC(
         icon = Icons.Filled.Info,
@@ -327,7 +328,7 @@ private fun DiagnosticToolsCard(vm: AppViewModel) {
                 leadingIcon = Icons.Filled.Upload,
                 kind = NoopButtonKind.Secondary,
                 fullWidth = true,
-                onClick = { LogExport.shareStrapLog(context, vm.ble.exportLogText()) },
+                onClick = { scope.launch { LogExport.shareStrapLog(context, vm.ble.exportLogText()) } },
             )
             // Recalibrate Charge baseline, the same Baselines.recalibrateRecoveryBaselines call.
             NoopButton(
@@ -343,7 +344,7 @@ private fun DiagnosticToolsCard(vm: AppViewModel) {
                 leadingIcon = Icons.Filled.Info,
                 kind = NoopButtonKind.Secondary,
                 fullWidth = true,
-                onClick = { LogExport.shareStrapLog(context, vm.ble.exportLogText()) },
+                onClick = { scope.launch { LogExport.shareStrapLog(context, vm.ble.exportLogText()) } },
             )
         }
     }


### PR DESCRIPTION
Enriches the shareable strap-log / bundle header, which was **connectivity-only** (device, OS, battery-opt, permissions), for the **data-quality** bug classes that actually recur (no steps / 0% REM / skin-temp absent / missing nights).

## Added
**Strap & data state** (offline-safe — persisted prefs + the `my-whoop` daily spine):
- Strap model, **last-known firmware** (now persisted on connect so it survives disconnect + the background export), last-sync (relative), timezone/offset, days of history, most recent sleep + recovery day.

**Analytics funnels** (latest night, best-effort, **self-reporting**):
- Recomputes the REM + skin-temp funnels for the most recent sleep session and prints each `.summary`, so a "0% REM" / "skin-temp absent" report arrives with the funnel already broken down.
- Prints the sample counts it read, and says plainly when it **cannot** compute (no recent session / no raw samples under the canonical id) — so it never fabricates a misleading verdict.

## Plumbing
- New `AndroidDiagnostics.dynamicLines(context)` (suspend, on `Dispatchers.Default`) appended to **both** the interactive and scheduled export headers.
- `LogExport` share/write paths become `suspend`; `DebugExportWorker` already runs in a coroutine; the 4 UI share buttons now `launch` on their screen scope.
- `NoopPrefs.lastFirmware` persisted at the firmware-decode point.

## Scope / safety
- **No analytics-pipeline changes** — all additions live in the diagnostics/export layer (kept out of the perf-sensitive analyze path deliberately).
- Every section is guarded (best-effort) so a header build never throws into the export.
- Kotlin + unit-test sources compile clean locally.

## Not included (deliberate)
- Battery %/live-only fields in the *scheduled* export (no live BLE there); iOS parity — both as follow-ups if wanted.