### PR TITLE
iOS: debug export parity — strap & data state + analytics-funnel diagnostics

### DIFF
--- a/Strand/BLE/FrameRouter.swift
+++ b/Strand/BLE/FrameRouter.swift
@@ -81,6 +81,8 @@ public final class FrameRouter {
             if let fw = parsed.parsed["fw_version"]?.stringValue ?? parsed.parsed["fw_harvard"]?.stringValue,
                state.strapFirmware != fw {
                 state.strapFirmware = fw
+                // Persist so the debug export can name the firmware offline (state clears on disconnect).
+                UserDefaults.standard.set(fw, forKey: "noop.lastFirmware")
             }
             // Advertising-name replies (WHOOP 4.0 / Harvard). GET (cmd 76) carries the current name in
             // its payload; SET (cmd 77) carries only a result byte. The schema has no field decode for

--- a/Strand/BLE/LiveState.swift
+++ b/Strand/BLE/LiveState.swift
@@ -521,7 +521,7 @@ public final class LiveState: ObservableObject {
     /// runs with no live `LiveState` instance. Mirrors `exportableLogText()`'s header so a scheduled drop
     /// reads the same as a manual share; falls back to the live `log` is not available here by design
     /// (this is a `static` so a background task needs no main-actor instance).
-    nonisolated public static func scheduledExportText() -> String {
+    nonisolated public static func scheduledExportText(extraHeaderLines: [String] = []) -> String {
         let v = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "?"
         #if os(iOS)
         let osName = "iOS"
@@ -530,6 +530,7 @@ public final class LiveState: ObservableObject {
         #endif
         var header = "NOOP strap log (scheduled export) — \(osName)\nApp: \(v)\n\(osName): "
             + ProcessInfo.processInfo.operatingSystemVersionString + "\n"
+        if !extraHeaderLines.isEmpty { header += extraHeaderLines.joined(separator: "\n") + "\n" }
         header += String(repeating: "-", count: 40) + "\n"
         return header + persistedLogTail().joined(separator: "\n")
     }
@@ -563,7 +564,7 @@ public final class LiveState: ObservableObject {
     /// OS, and — on iOS — the environment diagnostics that actually cause issues, followed by the live
     /// session log. Shared so BOTH the Live screen's log card AND a macOS Settings shortcut (#507 — a 4.0
     /// owner couldn't find the log on Mac) build the SAME text. Call on the main thread (button taps).
-    func exportableLogText() -> String {
+    func exportableLogText(extraHeaderLines: [String] = []) -> String {
         let v = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "?"
         #if os(iOS)
         let osName = "iOS"
@@ -576,6 +577,7 @@ public final class LiveState: ObservableObject {
         let diagLines = IOSDiagnostics.capture().summaryLines()
         if !diagLines.isEmpty { header += diagLines.joined(separator: "\n") + "\n" }
         #endif
+        if !extraHeaderLines.isEmpty { header += extraHeaderLines.joined(separator: "\n") + "\n" }
         header += String(repeating: "-", count: 40) + "\n"
         return header + log.joined(separator: "\n")
     }

--- a/Strand/Screens/SettingsView.swift
+++ b/Strand/Screens/SettingsView.swift
@@ -807,8 +807,11 @@ struct SettingsView: View {
                     Button("Copy") { PlatformPasteboard.copy(live.exportableLogText()) }
                         .buttonStyle(.plain).font(StrandFont.mono).foregroundStyle(StrandPalette.accent)
                     Button("Save…") {
-                        FileExport.exportText(live.exportableLogText(),
-                                              suggestedName: FileExport.timestampedName("noop-strap-log", ext: "txt"))
+                        Task {
+                            let extra = await DebugDataDiagnostics.dynamicLines(repo: model.repo)
+                            FileExport.exportText(live.exportableLogText(extraHeaderLines: extra),
+                                                  suggestedName: FileExport.timestampedName("noop-strap-log", ext: "txt"))
+                        }
                     }
                     .buttonStyle(.plain).font(StrandFont.mono).foregroundStyle(StrandPalette.accent)
                 }

--- a/Strand/Screens/TestCentreView.swift
+++ b/Strand/Screens/TestCentreView.swift
@@ -123,8 +123,11 @@ struct TestCentreView: View {
                     Button("Copy") { PlatformPasteboard.copy(live.exportableLogText()) }
                         .buttonStyle(.plain).font(StrandFont.mono).foregroundStyle(StrandPalette.accent)
                     Button("Save…") {
-                        FileExport.exportText(live.exportableLogText(),
-                                              suggestedName: FileExport.timestampedName("noop-strap-log", ext: "txt"))
+                        Task {
+                            let extra = await DebugDataDiagnostics.dynamicLines(repo: model.repo)
+                            FileExport.exportText(live.exportableLogText(extraHeaderLines: extra),
+                                                  suggestedName: FileExport.timestampedName("noop-strap-log", ext: "txt"))
+                        }
                     }
                     .buttonStyle(.plain).font(StrandFont.mono).foregroundStyle(StrandPalette.accent)
                 }

--- a/Strand/System/DebugDataDiagnostics.swift
+++ b/Strand/System/DebugDataDiagnostics.swift
@@ -1,0 +1,114 @@
+import Foundation
+import StrandAnalytics
+import WhoopProtocol
+import WhoopStore
+
+/// Strap & data-state + analytics-funnel lines appended to the iOS debug export — the twin of Android's
+/// `AndroidDiagnostics.strapAndDataLines` + `funnelLines`. Best-effort and self-reporting: every section is
+/// guarded so a header build never throws, and the funnels print the sample counts they read and say plainly
+/// when they can't compute, so a shared log never carries a fabricated verdict.
+///
+/// Two entry points, matching the two export paths:
+///   • `strapStateLines()` — SYNC, offline-safe (persisted defaults + timezone). Usable from the scheduled
+///     background export, which has no `Repository`.
+///   • `dynamicLines(repo:)` — ASYNC, the full block (strap state + data spine + recomputed funnels for the
+///     latest night). Used by the interactive "Save…/Share log" buttons, which hold `model.repo`.
+enum DebugDataDiagnostics {
+
+    /// Strap identity + timezone from persisted defaults (sync, offline-safe). Mirrors the prefs-backed
+    /// portion of the Android strap-state block; keys match the iOS @AppStorage / persisted values.
+    static func strapStateLines() -> [String] {
+        var lines: [String] = []
+        lines.append(String(repeating: "─", count: 40))
+        lines.append("Strap & data")
+        let d = UserDefaults.standard
+        let model: String
+        switch d.string(forKey: "selectedWhoopModel") {
+        case "whoop5": model = "WHOOP 5.0 / MG"
+        case "whoop4": model = "WHOOP 4.0"
+        default:       model = "unknown (never paired)"
+        }
+        lines.append("Model:       \(model)")
+        lines.append("Firmware:    \(d.string(forKey: "noop.lastFirmware") ?? "unknown (connect to record)")")
+        let syncSec = d.double(forKey: "lastSyncedAt")
+        lines.append("Last sync:   \(syncSec > 0 ? relTime(Date().timeIntervalSince1970 - syncSec) : "never")")
+        lines.append("Timezone:    \(tzLine())")
+        return lines
+    }
+
+    /// The full dynamic block: strap state + data spine (preloaded `repo.days`) + the REM/skin-temp funnels
+    /// recomputed for the most recent night. Async — it reads the on-device store. Never throws.
+    @MainActor static func dynamicLines(repo: Repository) async -> [String] {
+        var lines = strapStateLines()
+
+        // Data state from the preloaded day spine.
+        let days = repo.days
+        lines.append("History:     \(days.count) day rows")
+        if let s = days.last(where: { ($0.totalSleepMin ?? 0) > 0 }) {
+            lines.append("Last sleep:  \(s.day) · \(Int(s.totalSleepMin ?? 0)) min")
+        } else { lines.append("Last sleep:  none") }
+        if let r = days.last(where: { $0.recovery != nil }) {
+            lines.append("Last recov.: \(r.day) · \(Int(r.recovery ?? 0))%")
+        } else { lines.append("Last recov.: none") }
+
+        // Funnels for the latest night — best-effort, self-reporting.
+        lines.append(String(repeating: "─", count: 40))
+        lines.append("Analytics funnels (latest night, best-effort)")
+        let nowSec = Int(Date().timeIntervalSince1970)
+        guard let cs = await repo.sleepSessions(from: nowSec - 14 * 86400, to: nowSec, limit: 1).last else {
+            lines.append("(no sleep session in the last 14 days to analyze)")
+            return lines
+        }
+        guard let store = await repo.storeHandle() else {
+            lines.append("(on-device store not open yet)")
+            return lines
+        }
+        let did = repo.deviceId
+        let grav = (try? await store.gravitySamples(deviceId: did, from: cs.startTs, to: cs.endTs, limit: 200_000)) ?? []
+        let hr = await repo.hrSamples(from: cs.startTs, to: cs.endTs, limit: 200_000)
+        let rr = (try? await store.rrIntervals(deviceId: did, from: cs.startTs, to: cs.endTs, limit: 200_000)) ?? []
+        let resp = (try? await store.respSamples(deviceId: did, from: cs.startTs, to: cs.endTs, limit: 200_000)) ?? []
+        let skin = (try? await store.skinTempSamples(deviceId: did, from: cs.startTs, to: cs.endTs, limit: 200_000)) ?? []
+        lines.append("Night \(dayStamp(cs.startTs)): grav=\(grav.count) hr=\(hr.count) rr=\(rr.count) resp=\(resp.count) skin=\(skin.count)")
+        if grav.isEmpty && hr.isEmpty {
+            lines.append("(no raw biometric samples under '\(did)' for this night — expected on a freshly re-added strap; reconnect + let a history sync run, then re-export)")
+            return lines
+        }
+        if let rem = SleepStager.remFunnelDiagnostic(start: cs.startTs, end: cs.endTs, grav: grav, hr: hr, rr: rr, resp: resp) {
+            lines.append(rem.summary)
+        } else {
+            lines.append("REM funnel: insufficient motion data (<2 gravity samples)")
+        }
+        let det = SleepSession(start: cs.startTs, end: cs.endTs, efficiency: cs.efficiency ?? 0,
+                               stages: [], restingHR: cs.restingHr, avgHRV: cs.avgHrv)
+        let family: DeviceFamily = (UserDefaults.standard.string(forKey: "selectedWhoopModel") == "whoop5") ? .whoop5 : .whoop4
+        lines.append(AnalyticsEngine.skinTempFunnel([det], hr: hr, skinTemp: skin, family: family).summary)
+        return lines
+    }
+
+    // MARK: - Formatting helpers
+
+    private static func relTime(_ deltaSec: Double) -> String {
+        if deltaSec < 60 { return "just now" }
+        let min = Int(deltaSec / 60)
+        switch true {
+        case min < 60:   return "\(min)m ago"
+        case min < 1440: return "\(min / 60)h \(min % 60)m ago"
+        default:         return "\(min / 1440)d ago"
+        }
+    }
+
+    private static func tzLine() -> String {
+        let tz = TimeZone.current
+        let offMin = tz.secondsFromGMT() / 60
+        let a = abs(offMin)
+        return "\(tz.identifier) (UTC\(offMin >= 0 ? "+" : "-")\(a / 60):\(String(format: "%02d", a % 60)))"
+    }
+
+    private static func dayStamp(_ epochSec: Int) -> String {
+        let f = DateFormatter()
+        f.locale = Locale(identifier: "en_US_POSIX")
+        f.dateFormat = "yyyy-MM-dd"
+        return f.string(from: Date(timeIntervalSince1970: TimeInterval(epochSec)))
+    }
+}

--- a/Strand/System/ScheduledDebugExport.swift
+++ b/Strand/System/ScheduledDebugExport.swift
@@ -164,7 +164,8 @@ enum ScheduledDebugExport {
         let stamp = FileExport.timestamp()
         let logURL = docs.appendingPathComponent("noop-strap-log-\(stamp).txt")
         do {
-            try LiveState.scheduledExportText().write(to: logURL, atomically: true, encoding: .utf8)
+            try LiveState.scheduledExportText(extraHeaderLines: DebugDataDiagnostics.strapStateLines())
+                .write(to: logURL, atomically: true, encoding: .utf8)
         } catch {
             return nil
         }


### PR DESCRIPTION
iOS twin of the Android debug-export PR. The iOS strap-log/bundle header was connectivity-only (`IOSDiagnostics`: device, OS, protected-data, background-refresh, low-power, sideload). Adds the same **strap & data state** + **analytics funnels**.

## Added
- **`DebugDataDiagnostics`** (new):
  - `strapStateLines()` — SYNC, offline-safe: model, last-known firmware, last-sync, timezone (persisted defaults).
  - `dynamicLines(repo:)` — ASYNC: adds the day spine (`repo.days`) + REM/skin-temp funnels recomputed for the latest night. Self-reporting — prints sample counts and says plainly when it cant compute, so it never fabricates a verdict.
- **Firmware persisted** at the `FrameRouter` decode point (`UserDefaults "noop.lastFirmware"`) so it survives disconnect + the background export (mirrors Android).
- `LiveState.exportableLogText` / `scheduledExportText` gain an `extraHeaderLines` param.
- Interactive **Save…** buttons (Settings + Test Centre) build the full async block via `model.repo`; the **scheduled** export injects the sync `strapStateLines()` (no `Repository` in the background — same asymmetry as Androids scheduled path).

## Parity
- Keys match Android (`noop.lastFirmware`) + existing iOS defaults (`selectedWhoopModel`, `lastSyncedAt`).
- Same funnel `.summary` output shape (the Kotlin funnels mirror these Swift originals).
- **No analytics-pipeline changes.**

## Verification
- Swift compile-gated by CI (no local Swift build on the dev box). New file auto-included via the `project.yml` `Strand` directory glob.

Pairs with the Android PR; both target `main` independently.