### PR TITLE
iOS: fix restore of WAL-header backups (SQLITE_CANTOPEN) — #18

### DIFF
--- a/Packages/WhoopStore/Sources/WhoopStore/DatabaseIntegrity.swift
+++ b/Packages/WhoopStore/Sources/WhoopStore/DatabaseIntegrity.swift
@@ -32,18 +32,22 @@ public enum DatabaseIntegrity {
         guard FileManager.default.fileExists(atPath: path) else {
             return "no database file at that path"
         }
-        var config = Configuration()
-        config.readonly = true
-        do {
+        func quickCheckRows(readonly: Bool) throws -> [String] {
+            var config = Configuration()
+            config.readonly = readonly
             let dbQueue = try DatabaseQueue(path: path, configuration: config)
-            let rows = try dbQueue.read { db in
-                try String.fetchAll(db, sql: "PRAGMA quick_check(1)")
-            }
-            return verdict(fromRows: rows)
+            return try dbQueue.read { db in try String.fetchAll(db, sql: "PRAGMA quick_check(1)") }
+        }
+        do {
+            // Read-only first — never mutates the probed file, and sits safely beside the app's open pool.
+            return verdict(fromRows: try quickCheckRows(readonly: true))
         } catch {
-            // Open or query failed outright (SQLITE_NOTADB on a garbage file, malformed header, …).
-            // That IS the verdict: the file is not a usable database.
-            return error.localizedDescription
+            // A checkpointed WAL backup keeps journal_mode=WAL in its header but ships WITHOUT its -wal/-shm
+            // siblings, so a read-only open can't build the -shm and fails SQLITE_CANTOPEN (#18). Retry
+            // read-write, which builds the -shm and reads it — the probed file is always ours (a staged temp
+            // copy or the just-swapped file). Mirrors the Android probe's read-write fallback.
+            do { return verdict(fromRows: try quickCheckRows(readonly: false)) }
+            catch { return error.localizedDescription }
         }
     }
 


### PR DESCRIPTION
Fixes #18 (Cant restore backup — "SQLite error 14: unable to open database file").

## Root cause (a regression)
The `#1014` import-side `quick_check` gate opens the extracted backup **read-only**. A checkpointed `.noopbak` keeps `journal_mode=WAL` in its header (`wal_checkpoint(TRUNCATE)` folds the frames into the main file but never rewrites the header) yet ships with **no `-wal`/`-shm` siblings** — so the read-only open cant build the `-shm` wal-index and fails **`SQLITE_CANTOPEN`**. This hit **every** `.noopbak` restore; the "8.2.2" in the report was incidental.

## Fix (minimal, iOS-only)
On a failed read-only open, **retry read-write** — which builds the `-shm` and reads the checkpointed file. The probed file is always ours (a staged temp copy / the just-swapped file). This **mirrors the read-write fallback Androids probe already has** (`DataBackup.sqliteQuickCheckFailure`), so Android needed no change — this just brings iOS to parity.

## Why it escaped tests
The round-trip backup test builds a **rollback-mode** throwaway DB, so the WAL-header case never ran.

~14 lines in one file (`DatabaseIntegrity.swift`). Swift compile-gated by CI.