### PR TITLE
docs: v8.3.1 release notes + What's New

### DIFF
--- a/docs/releases/v8.3.1.md
+++ b/docs/releases/v8.3.1.md
@@ -1,0 +1,31 @@
+---
+whatsnew:
+  title: "Backup restore fixed, plus appearance controls"
+  date: "July 2026"
+  items:
+    - "**Restoring a backup works again.** A good backup could fail to restore with a database error; NOOP now reads it correctly during its safety check, so your snapshots restore."
+    - "**Card transparency.** Settings → Appearance now lets you dial how see-through the cards are — solid to clear, saved and applied live."
+    - "**Sky behind cards.** An optional setting extends the day-cycle sky behind the whole Today screen, so it shows through transparent cards."
+    - "**More useful bug reports.** The shared strap log now includes your strap + data state and the sleep-analysis funnels, so a report arrives with the detail to fix it."
+---
+# NOOP v8.3.1
+
+A fixes-and-polish release: the backup-restore failure is fixed, the Today screen gains two appearance controls, and shared strap logs carry more of what's needed to solve a report. Update from the Releases page, AltStore, or `brew upgrade`.
+
+## Fixed
+
+- **Restoring a backup works again (#18).** Importing a `.noopbak` could fail with *"This backup file is damaged … unable to open database file"* — even for a perfectly good backup — because the safety check opened it the wrong way. NOOP now reads the backup correctly during that check, so restores go through, while still refusing a genuinely damaged file. (iOS / macOS; Android was already handling this.)
+
+## Appearance
+
+- **Card transparency.** **Settings → Appearance** has a new slider that fades every card — Heart Rate, Key Metrics, Recovery Vitals, the score hero, and the rest — from solid to see-through, saved and previewed live as you drag. Android and iOS.
+- **Sky behind cards.** A new opt-in toggle extends the day-cycle sky behind the **whole** Today screen (not just the top band), so lowering Card transparency reveals it under every card. Off by default; needs the day-cycle background on.
+- On iOS, the **Day-cycle background** setting now also applies to the redesigned Today — turning it off gives the plain dark canvas, matching Android.
+
+## Diagnostics
+
+- **Richer strap logs for bug reports.** The strap log you share now also carries your **strap & data state** (model, firmware, last sync, days of history, most recent sleep / recovery) and the **REM + skin-temp analysis funnels** for the latest night — so a "0% REM" or "won't sync" report arrives with the detail needed to diagnose it. It self-reports when it can't compute a value, and never adds anything personal the log didn't already contain.
+
+## Under the hood
+
+- **AltStore updates itself.** Each release now updates the AltStore / SideStore source automatically, so sideload users are offered new versions without a manual step.


### PR DESCRIPTION
Adds `docs/releases/v8.3.1.md` — the single source the Release workflow reads for the GitHub release body **and** the in-app "What's New" (via the `whatsnew:` front-matter).

Covers everything on `main` since the v8.3.0 tag:
- **Fixed** — backup restore failing with "unable to open database file" (#18 / PR #22).
- **Appearance** — Card transparency (#14), Sky behind cards (#15–17), iOS day-cycle honoring.
- **Diagnostics** — richer strap logs: strap & data state + REM/skin-temp funnels (#20/#21).
- **Under the hood** — AltStore source auto-update (#23).

Written to match the v8.3.0 notes format. When you dispatch the Release build for `v8.3.1`, this file becomes the release notes + What's New automatically.