### PR TITLE
Release notes: drop the author-handle credit from the auto breakdown

### DIFF
--- a/.github/workflows/fork-release.yml
+++ b/.github/workflows/fork-release.yml
@@ -126,6 +126,11 @@ jobs:
               AUTO=$(gh api --method POST "repos/${GITHUB_REPOSITORY}/releases/generate-notes" \
                 -f tag_name="$TAG" -f previous_tag_name="$PREV" -f target_commitish="$(git rev-parse HEAD)" \
                 --jq '.body' 2>/dev/null || true)
+              # Drop the per-PR "by @author" credit and any "New Contributors" block — this is a solo fork,
+              # so the auto notes needn't stamp the handle on every line. Keeps the PR titles + links.
+              AUTO=$(printf '%s' "$AUTO" \
+                | sed -E 's/ by @[A-Za-z0-9_-]+//g' \
+                | awk 'BEGIN{skip=0} /^#+ *New Contributors/{skip=1; next} /^#+ /{skip=0} skip{next} {print}')
               [ -n "$AUTO" ] && printf '\n---\n\n%s\n' "$AUTO" >> "$BODY"
             else
               echo "First release (no prior release tag) — skipping the auto PR breakdown."


### PR DESCRIPTION
The auto "What's Changed" (GitHub `generate-notes`) stamps **"by @\<handle\>"** on every PR line and adds a "New Contributors" block. On a solo fork that just self-credits every line, so this strips both from the auto section before it's appended — keeping the PR titles + links.

Already applied the same clean-up to the **published v8.3.1** release body (handle count now 0).