### PR TITLE
iOS: ship production bundle ID (fixes #26 AltStore install)

### DIFF
--- a/project.yml
+++ b/project.yml
@@ -251,7 +251,7 @@ targets:
           - $(APP_GROUP_ID)
     settings:
       base:
-        PRODUCT_BUNDLE_IDENTIFIER: com.noopapp.noop.staging
+        PRODUCT_BUNDLE_IDENTIFIER: com.noopapp.noop
         PRODUCT_NAME: "NOOP Staging"
         ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon
         # Ship every *.appiconset (not just the primary AppIcon) so the alternate "AppIcon-Navy"
@@ -310,7 +310,7 @@ targets:
           - $(APP_GROUP_ID)
     settings:
       base:
-        PRODUCT_BUNDLE_IDENTIFIER: com.noopapp.noop.staging.widgets
+        PRODUCT_BUNDLE_IDENTIFIER: com.noopapp.noop.widgets
         PRODUCT_NAME: NOOPWidgets
         GENERATE_INFOPLIST_FILE: NO
         TARGETED_DEVICE_FAMILY: "1,2"
@@ -350,7 +350,7 @@ targets:
         # Modern single-target watchOS app — no separate WatchKit extension.
         WKApplication: true
         # Pairs this watch app to the iPhone companion (must match NOOPiOS PRODUCT_BUNDLE_IDENTIFIER).
-        WKCompanionAppBundleIdentifier: com.noopapp.noop.staging
+        WKCompanionAppBundleIdentifier: com.noopapp.noop
         NSHealthShareUsageDescription: "NOOP reads your heart rate from the Watch sensor to show a live readout on your wrist. It stays on your device."
         NSHealthUpdateUsageDescription: "NOOP records a basic workout session on your Watch for a higher-fidelity heart rate. The session stays on your device."
     entitlements:
@@ -362,7 +362,7 @@ targets:
           - $(APP_GROUP_ID)
     settings:
       base:
-        PRODUCT_BUNDLE_IDENTIFIER: com.noopapp.noop.staging.watch
+        PRODUCT_BUNDLE_IDENTIFIER: com.noopapp.noop.watch
         # The bundle FILE is NOOPWatch.app so it doesn't collide with the iPhone app's NOOP.app when it is
         # embedded at NOOP.app/Watch/NOOPWatch.app. The user still sees "NOOP" on the wrist via the
         # CFBundleName / CFBundleDisplayName above.
@@ -412,7 +412,7 @@ targets:
           - $(APP_GROUP_ID)
     settings:
       base:
-        PRODUCT_BUNDLE_IDENTIFIER: com.noopapp.noop.staging.watch.complications
+        PRODUCT_BUNDLE_IDENTIFIER: com.noopapp.noop.watch.complications
         PRODUCT_NAME: NOOPWatchComplications
         GENERATE_INFOPLIST_FILE: NO
         TARGETED_DEVICE_FAMILY: "4"


### PR DESCRIPTION
Fixes #26 — v8.3.1 fails to install via AltStore with *"bundle ID com.noopapp.noop.staging does not match the one specified by the source (com.noopapp.noop)"*.

## Root cause
The iOS app/widgets/watch shipped as **`com.noopapp.noop.staging`** (a `project.yml` overlay), but the AltStore manifest — and every historical release (7.x–8.2.2) — declares **`com.noopapp.noop`**. AltStore keeps the ipa's bundle ID when it re-signs, so `.staging` ≠ the declared ID → rejected. It surfaced now because the AltStore automation added the first `.staging` ipa (8.3.1) to the production manifest.

## Fix
Drop `.staging` from the **iOS-family** targets (app, widgets, watch, complications, `WKCompanionAppBundleIdentifier`) so the ipa is the production `com.noopapp.noop` the manifest already declares — restoring installs and the update path from 8.2.2. iOS has no App Store app to sit "beside" (and NoopApp is closed), so `.staging` served no purpose on iOS. The Swift code already assumes this identity (`StorePaths.productionBundleID`, `WatchScoreSnapshot.appGroupId = group.com.noopapp.noop`).

**Left unchanged:** the macOS bundle ID and the shared `APP_GROUP_ID` (independent of the iOS bundle ID; AltStore free-signing strips app-group entitlements anyway).

## After merge
Re-cut as **8.3.2** to publish a production ipa + refresh the manifest (the current 8.3.1 entry points at the broken `.staging` ipa). CI build verifies the iOS compile; I'll confirm the built ipa's `CFBundleIdentifier` is `com.noopapp.noop` before we ship.