### PR TITLE
Android: read Workouts across the my-whoop union (fixes #28)

### DIFF
--- a/android/app/src/main/java/com/noop/data/WhoopRepository.kt
+++ b/android/app/src/main/java/com/noop/data/WhoopRepository.kt
@@ -1049,6 +1049,19 @@ class WhoopRepository(private val dao: WhoopDao) {
         List<SleepSession> =
         dedupSleepBlocks(computedSourceIds(deviceId).flatMap { dao.sleepSessions(it, from, to, limit) })
 
+    /** Workouts over the read-side UNION of the active strap id AND the canonical "my-whoop" (#814 twin of
+     *  [hrSamplesUnion] / [sleepSessionsUnion]): a re-added / newly-paired strap owns "whoop-<uuid>" while
+     *  imports + prior data live under "my-whoop", so a read pinned to a SINGLE id strands the other's
+     *  workouts — the Workouts screen then reads empty while Data Sources (which queries "my-whoop") shows
+     *  them (#28). Exact-duplicate rows are dropped on the (startTs, sport) natural key, active-strap-first. */
+    suspend fun workoutsUnion(deviceId: String, from: Long, to: Long, limit: Int = DEFAULT_LIMIT): List<WorkoutRow> =
+        dedupWorkoutsByKey(importedSourceIds(deviceId).flatMap { dao.workouts(it, from, to, limit) })
+
+    /** The COMPUTED ("-noop") twin of [workoutsUnion] for detected workouts (the engine writes detected
+     *  sessions under "<importedDeviceId>-noop"), across the computed union ids. */
+    suspend fun detectedWorkoutsUnion(deviceId: String, from: Long, to: Long, limit: Int = DEFAULT_LIMIT): List<WorkoutRow> =
+        dedupWorkoutsByKey(computedSourceIds(deviceId).flatMap { dao.workouts(it, from, to, limit) })
+
     /** Cached daily metrics for the inclusive day range [from, to] (YYYY-MM-DD), oldest first. */
     suspend fun dailyMetrics(deviceId: String, from: String, to: String): List<DailyMetric> =
         dao.dailyMetricsRange(deviceId, from, to)
@@ -1270,6 +1283,14 @@ class WhoopRepository(private val dao: WhoopDao) {
         internal fun dedupSleepBlocks(sessions: List<SleepSession>): List<SleepSession> {
             val seen = HashSet<Pair<Long, Long>>()
             return sessions.filter { seen.add(it.startTs to it.endTs) }
+        }
+
+        /** Drop exact-duplicate workouts sharing an identical (startTs, sport) natural key — the same
+         *  session read under two #814 union ids — keeping the FIRST seen (callers pass active-strap-first
+         *  lists). Twin of [dedupSleepBlocks]. (#28) */
+        internal fun dedupWorkoutsByKey(rows: List<WorkoutRow>): List<WorkoutRow> {
+            val seen = HashSet<Pair<Long, String>>()
+            return rows.filter { seen.add(it.startTs to it.sport) }
         }
 
         /** Build a repository backed by the process-wide singleton database. */

--- a/android/app/src/main/java/com/noop/ui/AppViewModel.kt
+++ b/android/app/src/main/java/com/noop/ui/AppViewModel.kt
@@ -1273,10 +1273,12 @@ class AppViewModel(app: Application) : AndroidViewModel(app) {
     fun loadWorkouts() {
         viewModelScope.launch {
             val now = System.currentTimeMillis() / 1000
-            val whoop = repository.workouts(deviceId, 0L, now)
+            // #28: read across the strap-id + "my-whoop" union (like HR/sleep), so a re-added/newly-paired
+            // strap whose workouts live under "my-whoop" isn't shown an empty Workouts screen.
+            val whoop = repository.workoutsUnion(deviceId, 0L, now)
             val apple = repository.workouts("apple-health", 0L, now) +
                 repository.workouts("health-connect", 0L, now)
-            val detected = repository.workouts(repository.computedDeviceId(deviceId), 0L, now)
+            val detected = repository.detectedWorkoutsUnion(deviceId, 0L, now)
             // Imported lifting sessions (Hevy / Liftosaur) carry a volume-load note but no HR — they're
             // a strength-volume estimate, not cardio. Kept OUT of the strap HR-fill below so we never
             // fabricate a heart rate the lift never measured.


### PR DESCRIPTION
Fixes #28 — Workouts screen empty on a WHOOP 5.0 even though Data Sources lists workouts.

## Root cause (Android-only)
HR, sleep, steps and buckets read the `#814` **union** of the active strap id **and** the canonical `"my-whoop"` (`hrSamplesUnion`, `sleepSessionsUnion`, …). Workouts never got one — `loadWorkouts()` read `repository.workouts(deviceId, …)` under the **single** active strap id.

On a re-added / newly-paired strap, `activeDeviceId = whoop-<uuid>` (≠ `"my-whoop"`), so workouts banked under `"my-whoop"` were invisible to the Workouts screen — while **Data Sources**, which queries `"my-whoop"` directly, listed them. Hence "empty screen but data present."

## Fix
Add `workoutsUnion` / `detectedWorkoutsUnion` (twins of `hrSamplesUnion`/`sleepSessionsUnion`: read across `importedSourceIds`/`computedSourceIds`, dedup on the `(startTs, sport)` natural key) and use them in `loadWorkouts`. Single-WHOOP installs (`deviceId == "my-whoop"`) resolve to one id → **byte-identical** behaviour there.

**iOS already does this** in `Repository.workoutRows()` (unions `importedReadIds`/`computedReadIds`) — so this is Android catching up to iOS, and no iOS change is needed.

## Verify
- Kotlin compiles clean.
- Behaviour: with `activeDeviceId = whoop-<uuid>`, a `"my-whoop"`-stored workout is now returned (was dropped).