### PR TITLE
Workouts: show imported activity files (FIT/GPX/TCX) — fixes #29

### DIFF
--- a/Strand/Data/Repository.swift
+++ b/Strand/Data/Repository.swift
@@ -1931,6 +1931,10 @@ final class Repository: ObservableObject {
         rows += (try? await store.workouts(deviceId: "apple-health", from: lo, to: hi, limit: 5000)) ?? []
         // Imported lifting sessions (Hevy / Liftosaur) live under their own "lifting" source.
         rows += (try? await store.workouts(deviceId: "lifting", from: lo, to: hi, limit: 5000)) ?? []
+        // #29: imported activity FILES (FIT / GPX / TCX) live under their own "activity-file" source — read
+        // them too, or a successful file import never appears in the Workouts list (Data Sources counts it,
+        // the load didn't). HR is reconciled from the strap trace at the end like every other row.
+        rows += (try? await store.workouts(deviceId: "activity-file", from: lo, to: hi, limit: 5000)) ?? []
         rows = Self.dedupWorkoutsByNaturalKey(rows)
         let spans = WorkoutSource.parseDismissedSpans(dismissedDetectedSpans)
         // #687: collapse the SAME activity tracked live under the strap AND imported from Health Connect /

--- a/android/app/src/main/java/com/noop/ui/AppViewModel.kt
+++ b/android/app/src/main/java/com/noop/ui/AppViewModel.kt
@@ -36,6 +36,7 @@ import com.noop.data.DailyMetric
 import com.noop.data.HrSample
 import com.noop.data.WhoopRepository
 import com.noop.data.WorkoutRow
+import com.noop.ingest.ActivityFileImporter
 import com.noop.ingest.HealthConnectImporter
 import com.noop.ingest.HealthConnectWriter
 import com.noop.ingest.LiftingImporter
@@ -1283,13 +1284,19 @@ class AppViewModel(app: Application) : AndroidViewModel(app) {
             // a strength-volume estimate, not cardio. Kept OUT of the strap HR-fill below so we never
             // fabricate a heart rate the lift never measured.
             val lifting = repository.workouts(LiftingImporter.SOURCE_ID, 0L, now)
+            // #29: imported activity FILES (FIT / GPX / TCX) live under their own "activity-file" source, so
+            // without reading it a successful file import never appears in the Workouts list (Data Sources
+            // counts it, the load didn't). They're cardio (often GPS + HR), so they go through the strap
+            // HR-fill below like the imported Apple sessions — a GPX with no HR borrows the strap's, while a
+            // FIT that already carries HR is untouched (fill only fills nulls).
+            val activityFiles = repository.workouts(ActivityFileImporter.SOURCE_ID, 0L, now)
             val markers = repository.dismissedDetected(deviceId)
             // Fill imported sessions' missing HR from strap samples (#77), same as before; detected /
             // manual rows already carry their own HR so they pass through unchanged. #961: also backfill a
             // strap-native row's Effort (strain) from the strap trace when it's null, so a live/manual
             // session that ended with sparse HR can't show a blank Effort while the day total counted it.
             val filled = repository.fillWorkoutHrFromStrap(
-                (whoop + apple + detected),
+                (whoop + apple + detected + activityFiles),
                 strainMaxHR = profileStore.hrMax.toDouble(),
                 strainSex = profileStore.sex,
             )


### PR DESCRIPTION
Fixes #29 — an imported FIT/GPX/TCX file reports success and is counted, but never appears in the Workouts list.

## Root cause (both platforms)
Imported activity files are stored under their own **`"activity-file"`** source (`ActivityFileImporter`). Both **Data Sources** screens count that source (hence "3 uploads"), and there's a `WorkoutSource.activityFile` **"File import" badge** ready to render them — but **neither workout-load path reads it**:
- Android `loadWorkouts` reads strap-union / apple / health-connect / detected / **lifting** — not `"activity-file"`.
- iOS `workoutRows` reads importedReadIds / computedReadIds / apple-health / **lifting** — not `"activity-file"`.

So the imports are stored + counted + badge-ready, but the load query never fetches them.

## Fix
Read `"activity-file"` alongside the other imported sources, in both load paths:
- **Android**: read it and route through `fillWorkoutHrFromStrap` like imported Apple sessions (cardio — a GPX with no HR borrows the strap's; a FIT with HR is untouched, the fill only fills nulls).
- **iOS**: read it next to `"lifting"`; HR is reconciled from the strap trace at the end like every other row.

Distinct from #28 (that was the strap↔`"my-whoop"` union). This one genuinely needed **both** platforms.

## Verify
- Android Kotlin compiles clean.
- iOS via CI.
- Behaviour: after importing a FIT/GPX/TCX, the session now appears in Workouts with a "File import" badge.