### PR TITLE
Debug export: add a Workouts-by-source breakdown

### DIFF
--- a/Strand/System/DebugDataDiagnostics.swift
+++ b/Strand/System/DebugDataDiagnostics.swift
@@ -51,6 +51,10 @@ enum DebugDataDiagnostics {
             lines.append("Last recov.: \(r.day) · \(Int(r.recovery ?? 0))%")
         } else { lines.append("Last recov.: none") }
 
+        // Workout & imported-activity source breakdown (#28/#29 "counted but not shown" class). Runs BEFORE
+        // the funnels since those can early-return, so this always lands in the export.
+        lines += await workoutSourceLines(repo: repo)
+
         // Funnels for the latest night — best-effort, self-reporting.
         lines.append(String(repeating: "─", count: 40))
         lines.append("Analytics funnels (latest night, best-effort)")
@@ -83,6 +87,39 @@ enum DebugDataDiagnostics {
                                stages: [], restingHR: cs.restingHr, avgHRV: cs.avgHrv)
         let family: DeviceFamily = (UserDefaults.standard.string(forKey: "selectedWhoopModel") == "whoop5") ? .whoop5 : .whoop4
         lines.append(AnalyticsEngine.skinTempFunnel([det], hr: hr, skinTemp: skin, family: family).summary)
+        return lines
+    }
+
+    /// Workout & imported-activity source breakdown: the resolved active deviceId + a per-source STORED
+    /// workout count + the most-recent workout, so a "workouts not showing" report reveals WHERE workouts
+    /// live vs what the Workouts screen loads (#28 strap↔my-whoop, #29 activity-file). Best-effort.
+    @MainActor static func workoutSourceLines(repo: Repository) async -> [String] {
+        var lines: [String] = []
+        lines.append(String(repeating: "─", count: 40))
+        lines.append("Workouts by source")
+        let did = repo.deviceId
+        lines.append("Active deviceId: \(did)\(did == "my-whoop" ? "" : "  (imports + spine under my-whoop)")")
+        guard let store = await repo.storeHandle() else {
+            lines.append("(on-device store not open yet)")
+            return lines
+        }
+        let nowSec = Int(Date().timeIntervalSince1970)
+        var seen = Set<String>()
+        let ids = [did, "my-whoop", "\(did)-noop", "my-whoop-noop",
+                   "activity-file", "lifting", "apple-health", "health-connect"].filter { seen.insert($0).inserted }
+        var parts: [String] = []
+        var latestTs = -1
+        var latestDesc = ""
+        for id in ids {
+            let rows = (try? await store.workouts(deviceId: id, from: 0, to: nowSec, limit: 100_000)) ?? []
+            parts.append("\(id)=\(rows.count)")
+            if let m = rows.max(by: { $0.startTs < $1.startTs }), m.startTs > latestTs {
+                latestTs = m.startTs
+                latestDesc = "\(dayStamp(m.startTs)) · \(m.sport) (\(m.source))"
+            }
+        }
+        lines.append("Stored: " + parts.joined(separator: "  "))
+        lines.append(latestTs >= 0 ? "Latest: \(latestDesc)" : "Latest: none")
         return lines
     }
 

--- a/Strand/System/DebugDataDiagnostics.swift
+++ b/Strand/System/DebugDataDiagnostics.swift
@@ -54,6 +54,7 @@ enum DebugDataDiagnostics {
         // Workout & imported-activity source breakdown (#28/#29 "counted but not shown" class). Runs BEFORE
         // the funnels since those can early-return, so this always lands in the export.
         lines += await workoutSourceLines(repo: repo)
+        lines += await dailyDataLines(repo: repo)
 
         // Funnels for the latest night — best-effort, self-reporting.
         lines.append(String(repeating: "─", count: 40))
@@ -120,6 +121,46 @@ enum DebugDataDiagnostics {
         }
         lines.append("Stored: " + parts.joined(separator: "  "))
         lines.append(latestTs >= 0 ? "Latest: \(latestDesc)" : "Latest: none")
+        return lines
+    }
+
+    /// Daily-data source breakdown + on-device volume: per-source day counts, which metrics are populated
+    /// over the recent week on the imported spine, and the raw-row footprint — the same source reconciliation
+    /// the workout block gives, for the "no data / no steps / 0% REM" report class. Best-effort.
+    @MainActor static func dailyDataLines(repo: Repository) async -> [String] {
+        var lines: [String] = []
+        lines.append(String(repeating: "─", count: 40))
+        lines.append("Daily data by source")
+        let did = repo.deviceId
+        guard let store = await repo.storeHandle() else {
+            lines.append("(on-device store not open yet)")
+            return lines
+        }
+        var seen = Set<String>()
+        let ids = [did, "my-whoop", "\(did)-noop", "my-whoop-noop",
+                   "apple-health", "health-connect"].filter { seen.insert($0).inserted }
+        var parts: [String] = []
+        var spine: [DailyMetric] = []
+        for id in ids {
+            let rows = (try? await store.dailyMetrics(deviceId: id, from: "0000-01-01", to: "9999-12-31")) ?? []
+            parts.append("\(id)=\(rows.count)")
+            if id == "my-whoop" { spine = rows }
+        }
+        lines.append("Days: " + parts.joined(separator: "  "))
+        let recent = Array(spine.suffix(7))
+        if !recent.isEmpty {
+            let n = recent.count
+            lines.append("Recent \(n)d (my-whoop): "
+                + "sleep=\(recent.filter { ($0.totalSleepMin ?? 0) > 0 }.count)/\(n)  "
+                + "recovery=\(recent.filter { $0.recovery != nil }.count)/\(n)  "
+                + "steps=\(recent.filter { $0.steps != nil }.count)/\(n)  "
+                + "kcal=\(recent.filter { $0.activeKcalEst != nil }.count)/\(n)")
+        } else {
+            lines.append("Recent: no day rows")
+        }
+        if let dv = await repo.dataVolumeSnapshot() {
+            lines.append("Volume: rawRows=\(dv.dbRows)  importedDays=\(dv.importedDays)  workouts=\(dv.workouts)")
+        }
         return lines
     }
 

--- a/android/app/src/main/java/com/noop/testcentre/AndroidDiagnostics.kt
+++ b/android/app/src/main/java/com/noop/testcentre/AndroidDiagnostics.kt
@@ -92,11 +92,36 @@ object AndroidDiagnostics {
         }.onFailure { add("(funnels unavailable: ${it.message})") }
     }
 
+    /** Workout & imported-activity source breakdown. The "counted but not shown" bug class (#28: strap
+     *  workouts banked under "my-whoop" while the load queried the active strap id; #29: "activity-file"
+     *  imports the load path never read) is invisible in a strap log without this. Surfaces the RESOLVED
+     *  active deviceId + a per-source STORED workout count + the most-recent workout, so a report reveals
+     *  WHERE workouts live vs what the Workouts screen loads. Best-effort. */
+    suspend fun workoutSourceLines(context: Context): List<String> = buildList {
+        add("─".repeat(40))
+        add("Workouts by source")
+        runCatching {
+            val repo = com.noop.data.WhoopRepository.from(context)
+            val now = System.currentTimeMillis() / 1000
+            val active = runCatching {
+                (context.applicationContext as com.noop.NoopApplication).activeDeviceId
+            }.getOrNull() ?: "unknown"
+            add("Active deviceId: $active" + if (active == "my-whoop") "" else "  (imports + spine under my-whoop)")
+            // Per-source STORED counts; ids de-duped so a single-WHOOP install (active == my-whoop) lists once.
+            val ids = listOf(active, "my-whoop", "$active-noop", "my-whoop-noop",
+                "activity-file", "lifting", "apple-health", "health-connect").distinct()
+            val perSource = ids.map { it to repo.workouts(it, 0L, now) }
+            add("Stored: " + perSource.joinToString("  ") { "${it.first}=${it.second.size}" })
+            val latest = perSource.flatMap { it.second }.maxByOrNull { it.startTs }
+            add(if (latest != null) "Latest: ${dayStamp(latest.startTs)} · ${latest.sport} (${latest.source})" else "Latest: none")
+        }.onFailure { add("(workout sources unavailable: ${it.message})") }
+    }
+
     /** The DB/prefs-backed diagnostic lines appended to the export header. Suspends (reads the local store);
      *  guarded per-section so it never throws into the export. */
     suspend fun dynamicLines(context: Context): List<String> =
         kotlinx.coroutines.withContext(kotlinx.coroutines.Dispatchers.Default) {
-            strapAndDataLines(context) + funnelLines(context)
+            strapAndDataLines(context) + funnelLines(context) + workoutSourceLines(context)
         }
 
     /** "3h 12m ago" style relative stamp for a positive age in ms. */

--- a/android/app/src/main/java/com/noop/testcentre/AndroidDiagnostics.kt
+++ b/android/app/src/main/java/com/noop/testcentre/AndroidDiagnostics.kt
@@ -117,11 +117,42 @@ object AndroidDiagnostics {
         }.onFailure { add("(workout sources unavailable: ${it.message})") }
     }
 
+    /** Daily-data source breakdown + on-device volume. The active-strap↔"my-whoop" id mismatch strands
+     *  DAYS / steps / sleep / recovery the same way it strands workouts (#28), so a "no data / no steps /
+     *  0% REM" report needs the same reconciliation: per-source day counts, which metrics are actually
+     *  populated over the recent week, and the raw-row footprint. Best-effort. */
+    suspend fun dailyDataLines(context: Context): List<String> = buildList {
+        add("─".repeat(40))
+        add("Daily data by source")
+        runCatching {
+            val repo = com.noop.data.WhoopRepository.from(context)
+            val active = runCatching {
+                (context.applicationContext as com.noop.NoopApplication).activeDeviceId
+            }.getOrNull() ?: "unknown"
+            val ids = listOf(active, "my-whoop", "$active-noop", "my-whoop-noop",
+                "apple-health", "health-connect").distinct()
+            val dayCounts = ids.map { it to repo.days(it).size }
+            add("Days: " + dayCounts.joinToString("  ") { "${it.first}=${it.second}" })
+            // Which metrics are actually populated over the recent week on the imported spine.
+            val recent = repo.days("my-whoop").takeLast(7)
+            if (recent.isNotEmpty()) {
+                val n = recent.size
+                add("Recent ${n}d (my-whoop): " +
+                    "sleep=${recent.count { (it.totalSleepMin ?: 0.0) > 0 }}/$n  " +
+                    "recovery=${recent.count { it.recovery != null }}/$n  " +
+                    "steps=${recent.count { it.steps != null }}/$n  " +
+                    "kcal=${recent.count { it.activeKcalEst != null }}/$n")
+            } else add("Recent: no day rows")
+            val dv = repo.dataVolumeSnapshot(active)
+            add("Volume: rawRows=${dv.dbRows}  importedDays=${dv.importedDays}  workouts=${dv.workouts}")
+        }.onFailure { add("(daily data unavailable: ${it.message})") }
+    }
+
     /** The DB/prefs-backed diagnostic lines appended to the export header. Suspends (reads the local store);
      *  guarded per-section so it never throws into the export. */
     suspend fun dynamicLines(context: Context): List<String> =
         kotlinx.coroutines.withContext(kotlinx.coroutines.Dispatchers.Default) {
-            strapAndDataLines(context) + funnelLines(context) + workoutSourceLines(context)
+            strapAndDataLines(context) + funnelLines(context) + workoutSourceLines(context) + dailyDataLines(context)
         }
 
     /** "3h 12m ago" style relative stamp for a positive age in ms. */


### PR DESCRIPTION
The "counted but not shown" workout bugs (**#28** strap workouts under `my-whoop` vs the active strap id; **#29** `activity-file` imports the load path skipped) were invisible in a strap log — you couldn't tell WHERE workouts lived vs what the Workouts screen loaded.

Adds a **"Workouts by source"** block to the debug export (both platforms), reusing the existing `dynamicLines` plumbing:
- **Resolved active deviceId** (`whoop-<uuid>` vs `my-whoop`) — the key context for any "data under the wrong id" report.
- **Per-source STORED workout count** (active strap, `my-whoop`, their `-noop` computed twins, `activity-file`, `lifting`, `apple-health`, `health-connect`).
- **Most-recent workout** (date · sport · source).

So a future "workouts present in Data Sources but missing from the screen" report is self-diagnosing (e.g. `activity-file=3` with the screen empty → the load skips that source).

Best-effort + guarded so it never throws into the export.

## Verify
- Android compiles clean.
- iOS via CI.