### PR TITLE
docs: v8.3.2 release notes + What's New

### DIFF
--- a/docs/releases/v8.3.2.md
+++ b/docs/releases/v8.3.2.md
@@ -1,0 +1,20 @@
+---
+whatsnew:
+  title: "Workout display fixes"
+  date: "July 2026"
+  items:
+    - "**Imported workout files show up.** A FIT / GPX / TCX file you import now appears in Workouts — it was saved and counted, but the list wasn't reading that source."
+    - "**Workouts return after re-pairing your strap.** Re-adding a strap could hide workouts recorded before it; the Workouts screen now finds them again."
+---
+# NOOP v8.3.2
+
+A workouts fix-up: imported files and re-paired straps now show their sessions, and shared strap logs carry more of what's needed to solve a report. Update from the Releases page, AltStore, or `brew upgrade`.
+
+## Fixed
+
+- **Imported activity files now appear in Workouts (#29).** A FIT / GPX / TCX import reported success and was counted in Data Sources, but never showed in the Workouts list — the load path didn't read the imported-file source. It does now, with the "File import" badge.
+- **Workouts show after re-adding / pairing a strap (#28).** Workouts banked under your canonical history became invisible once a strap was re-paired, because the Workouts screen queried only the new strap's id. It now reads across both — the same union every other screen already uses — so nothing disappears on a re-pair.
+
+## Under the hood
+
+- **More useful bug reports.** The strap log you share now includes a workout + daily-data **source breakdown** (which id/source each metric lives under, vs. what the screen shows) and an on-device **data-volume** line, so a "present in Data Sources but missing from the screen" report is diagnosable at a glance.


### PR DESCRIPTION
Adds `docs/releases/v8.3.2.md` — the source the Release workflow reads for the GitHub release body **and** the in-app "What's New" (`whatsnew:` front-matter).

Covers what landed since v8.3.1:
- **Fixed** — imported activity files show in Workouts (#29); workouts return after re-pairing a strap (#28).
- **Under the hood** — richer debug export (workout + daily-data source breakdown + data-volume).

(The #26 iOS bundle-ID fix already shipped in the v8.3.1 re-publish, so it's not called out here; the auto "What's Changed" still lists it.)

Docs-only, so it doesn't trigger the path-filtered CI. Merge this, then dispatch **Release build → bump = patch** and this becomes 8.3.2's notes automatically.