### PR TITLE
Debug export: Alarm block + honest "armed" log (#34)

### DIFF
--- a/Strand/BLE/BLEManager.swift
+++ b/Strand/BLE/BLEManager.swift
@@ -2402,14 +2402,26 @@ public final class BLEManager: NSObject, ObservableObject {
             // pattern, overallLoop 7, 30 s]. No SET_CLOCK preamble (see doc comment above).
             let wakeMs = Int64((date.timeIntervalSince1970 * 1000).rounded())
             send(.setAlarmTime, payload: AlarmPayload.setAlarmRev4(wakeEpochMs: wakeMs))
-            log("Alarm: armed 5/MG rev4 for \(localFmt.string(from: date)) — your local wake time")
+            recordAlarmArm(sentEpoch: Int(wakeMs / 1000))
+            // #34: don't claim "armed" when the strap isn't connected (the send was dropped) — the arm
+            // re-fires on the next connect.
+            log(connectedPeripheralUUID != nil
+                ? "Alarm: armed 5/MG rev4 for \(localFmt.string(from: date)) — your local wake time"
+                : "Alarm: queued 5/MG rev4 for \(localFmt.string(from: date)) — strap not connected; will send on next connect")
             return
         }
         // Clamp rather than trap: an out-of-range alarm date (pre-1970 / post-2106) must not crash.
         let epochSec = UInt32(clamping: Int64(date.timeIntervalSince1970))
         sendSetClockBothForms()
         send(.setAlarmTime, payload: WhoopCommand.setAlarmPayload(epochSec: epochSec))
-        log("Alarm: armed for \(localFmt.string(from: date)) — your local wake time (sent as UTC epoch \(epochSec))")
+        recordAlarmArm(sentEpoch: Int(epochSec))
+        // #34: only claim "armed" when the strap is connected (the send actually went out); otherwise it's
+        // queued and re-sent on the next connect.
+        if connectedPeripheralUUID != nil {
+            log("Alarm: armed for \(localFmt.string(from: date)) — your local wake time (sent as UTC epoch \(epochSec))")
+        } else {
+            log("Alarm: queued for \(localFmt.string(from: date)) — strap not connected; will send on next connect")
+        }
         // Arm READBACK (#401 close-out): ask the strap what it now has armed (GET_ALARM_TIME, cmd 67) so
         // the strap log carries armed + strap-reports + fired as one decidable sequence in any future
         // "didn't buzz" report. WHOOP 4.0 ONLY: cmd 67 is allowlisted for 5/MG but its puffin readback
@@ -2417,6 +2429,15 @@ public final class BLEManager: NSObject, ObservableObject {
         // Log-only: FrameRouter parses the cmd-67 COMMAND_RESPONSE defensively and NEVER gates behaviour
         // on it (the 4.0 response layout is undocumented; unparseable replies log raw hex).
         send(.getAlarmTime, payload: [0x01])
+    }
+
+    /// #34: persist the last alarm arm for the debug export's Alarm block (sent epoch + when + whether the
+    /// strap was connected when we sent it), so a "didn't buzz" report shows sent-vs-strap-reports at a glance.
+    private func recordAlarmArm(sentEpoch: Int) {
+        let d = UserDefaults.standard
+        d.set(sentEpoch, forKey: "alarm.lastArmSentEpoch")
+        d.set(Date().timeIntervalSince1970, forKey: "alarm.lastArmAt")
+        d.set(connectedPeripheralUUID != nil, forKey: "alarm.lastArmConnected")
     }
 
     /// Disarm the currently-armed firmware alarm.

--- a/Strand/BLE/FrameRouter.swift
+++ b/Strand/BLE/FrameRouter.swift
@@ -156,6 +156,7 @@ public final class FrameRouter {
                     // line (GET_ALARM_TIME) this makes every future report one-log decidable. The re-arm
                     // below writes a fresh "armed" line, so the two read as one sequence, not a bug.
                     state.append(log: "Alarm: strap-driven wake fired (event 57), re-arming the next day's instant")
+                    UserDefaults.standard.set(Date().timeIntervalSince1970, forKey: "alarm.lastFiredAt")  // #34 debug export
                     // The strap fired its firmware smart alarm → re-arm the next day's instant (the
                     // alarm is a single absolute time with no recurrence). Belt-and-suspenders to the
                     // daily/foreground re-arm in AppModel, since this event isn't always observed.

--- a/Strand/BLE/FrameRouter.swift
+++ b/Strand/BLE/FrameRouter.swift
@@ -108,6 +108,9 @@ public final class FrameRouter {
                     // answer format must never mislead a triage).
                     if let epoch = Self.armedAlarmEpoch(in: frame) {
                         state.append(log: "Alarm: strap reports armed for \(Self.alarmLocalTime(epoch: epoch)) (epoch \(epoch))")
+                        // #34: persist what the strap reports so the debug export can show sent-vs-reported.
+                        UserDefaults.standard.set(Int(epoch), forKey: "alarm.lastReportedEpoch")
+                        UserDefaults.standard.set(Date().timeIntervalSince1970, forKey: "alarm.lastReportedAt")
                     } else {
                         state.append(log: "Alarm: strap answered the alarm readback with an unrecognised payload (raw \(Self.commandResponsePayloadHex(in: frame) ?? "empty")) - layout undocumented, log-only")
                     }

--- a/Strand/BLE/LiveState.swift
+++ b/Strand/BLE/LiveState.swift
@@ -162,6 +162,8 @@ public final class LiveState: ObservableObject {
         let firmware = strapRange?.firmwareLayout
         let oldest = oldestUnix ?? strapRange?.oldestUnix
         strapRange = StrapRange(newestUnix: newestUnix, oldestUnix: oldest, firmwareLayout: firmware)
+        // #34: persist the strap's newest banked record so the debug export can flag a reset/stale clock.
+        UserDefaults.standard.set(newestUnix, forKey: "strap.newestRecordTs")
     }
 
     /// Bank the historical record-layout version (hist_version: 18/24/25/26) the strap emits, so the

--- a/Strand/System/DebugDataDiagnostics.swift
+++ b/Strand/System/DebugDataDiagnostics.swift
@@ -55,6 +55,7 @@ enum DebugDataDiagnostics {
         // the funnels since those can early-return, so this always lands in the export.
         lines += await workoutSourceLines(repo: repo)
         lines += await dailyDataLines(repo: repo)
+        lines += alarmLines()
 
         // Funnels for the latest night — best-effort, self-reporting.
         lines.append(String(repeating: "─", count: 40))
@@ -162,6 +163,44 @@ enum DebugDataDiagnostics {
             lines.append("Volume: rawRows=\(dv.dbRows)  importedDays=\(dv.importedDays)  workouts=\(dv.workouts)")
         }
         return lines
+    }
+
+    /// Alarm state for the debug export: the configured wake + the last arm's sent-vs-strap-reports (#34), so
+    /// a "didn't buzz" report shows at a glance whether the strap accepted the time. Reads persisted defaults
+    /// (written by BLEManager.armStrapAlarm + the FrameRouter readback); sync + guarded.
+    static func alarmLines() -> [String] {
+        var lines: [String] = []
+        lines.append(String(repeating: "─", count: 40))
+        lines.append("Alarm")
+        let d = UserDefaults.standard
+        let on = d.bool(forKey: "behavior.smartAlarmEnabled")
+        let mins = (d.object(forKey: "behavior.smartAlarmMinutes") as? Int) ?? 7 * 60
+        lines.append("Enabled: \(on ? "yes" : "no") · set \(String(format: "%02d:%02d", mins / 60, mins % 60))")
+        if let sent = d.object(forKey: "alarm.lastArmSentEpoch") as? Int {
+            var line = "Last arm: sent \(alarmStamp(sent))"
+            if let at = d.object(forKey: "alarm.lastArmAt") as? Double {
+                line += " · \(relTime(Date().timeIntervalSince1970 - at))"
+            }
+            if !d.bool(forKey: "alarm.lastArmConnected") { line += " · strap NOT connected (queued)" }
+            lines.append(line)
+            if let reported = d.object(forKey: "alarm.lastReportedEpoch") as? Int {
+                let mismatch = abs(reported - sent) > 120
+                lines.append("Strap reports: \(alarmStamp(reported))"
+                    + (mismatch ? "  ⚠️ MISMATCH — strap didn't accept the time" : "  ✓ matches"))
+            } else {
+                lines.append("Strap reports: (no readback)")
+            }
+        } else {
+            lines.append("Last arm: never")
+        }
+        return lines
+    }
+
+    private static func alarmStamp(_ epochSec: Int) -> String {
+        let f = DateFormatter()
+        f.locale = Locale(identifier: "en_US_POSIX")
+        f.dateFormat = "yyyy-MM-dd HH:mm"
+        return f.string(from: Date(timeIntervalSince1970: TimeInterval(epochSec)))
     }
 
     // MARK: - Formatting helpers

--- a/Strand/System/DebugDataDiagnostics.swift
+++ b/Strand/System/DebugDataDiagnostics.swift
@@ -176,6 +176,19 @@ enum DebugDataDiagnostics {
         let on = d.bool(forKey: "behavior.smartAlarmEnabled")
         let mins = (d.object(forKey: "behavior.smartAlarmMinutes") as? Int) ?? 7 * 60
         lines.append("Enabled: \(on ? "yes" : "no") · set \(String(format: "%02d:%02d", mins / 60, mins % 60))")
+        // #3: model + the 5/MG experimental gate — a 5/MG firmware alarm is NOT armed unless Experimental is on.
+        if d.string(forKey: "selectedWhoopModel") == "whoop5" {
+            lines.append("Model: WHOOP 5.0/MG · experimental: \(PuffinExperiment.isEnabled ? "on" : "off → firmware alarm NOT armed")")
+        } else {
+            lines.append("Model: WHOOP 4.0")
+        }
+        // #4: strap clock health — a reset/stale clock (the #34 cause) breaks the alarm even when armed.
+        if let newest = d.object(forKey: "strap.newestRecordTs") as? Int, newest > 0 {
+            let behind = Int(Date().timeIntervalSince1970) - newest
+            lines.append(behind > 3 * 86400
+                ? "Strap clock: \(behind / 86400)d behind wall (reset/stale — alarm unreliable)"
+                : "Strap clock: OK")
+        }
         if let sent = d.object(forKey: "alarm.lastArmSentEpoch") as? Int {
             var line = "Last arm: sent \(alarmStamp(sent))"
             if let at = d.object(forKey: "alarm.lastArmAt") as? Double {
@@ -192,6 +205,12 @@ enum DebugDataDiagnostics {
             }
         } else {
             lines.append("Last arm: never")
+        }
+        // #1: did the strap actually fire? (STRAP_DRIVEN_ALARM_EXECUTED)
+        if let firedAt = d.object(forKey: "alarm.lastFiredAt") as? Double {
+            lines.append("Last fired: \(relTime(Date().timeIntervalSince1970 - firedAt))")
+        } else {
+            lines.append("Last fired: never observed")
         }
         return lines
     }

--- a/Strand/System/DebugDataDiagnostics.swift
+++ b/Strand/System/DebugDataDiagnostics.swift
@@ -177,17 +177,24 @@ enum DebugDataDiagnostics {
         let mins = (d.object(forKey: "behavior.smartAlarmMinutes") as? Int) ?? 7 * 60
         lines.append("Enabled: \(on ? "yes" : "no") · set \(String(format: "%02d:%02d", mins / 60, mins % 60))")
         // #3: model + the 5/MG experimental gate — a 5/MG firmware alarm is NOT armed unless Experimental is on.
-        if d.string(forKey: "selectedWhoopModel") == "whoop5" {
-            lines.append("Model: WHOOP 5.0/MG · experimental: \(PuffinExperiment.isEnabled ? "on" : "off → firmware alarm NOT armed")")
+        // (selectedWhoopModel stores the WhoopModel rawValue — "WHOOP 5.0 / MG" / "WHOOP 4.0" — not "whoop5".)
+        let model = d.string(forKey: "selectedWhoopModel") ?? WhoopModel.whoop4.rawValue
+        if model == WhoopModel.whoop5mg.rawValue {
+            lines.append("Model: \(model) · experimental: \(PuffinExperiment.isEnabled ? "on" : "off → firmware alarm NOT armed")")
         } else {
-            lines.append("Model: WHOOP 4.0")
+            lines.append("Model: \(model)")
         }
-        // #4: strap clock health — a reset/stale clock (the #34 cause) breaks the alarm even when armed.
+        // #4: strap clock health — a reset/stale OR future-dated clock (the #34 / #928 causes) breaks the
+        // alarm even when armed.
         if let newest = d.object(forKey: "strap.newestRecordTs") as? Int, newest > 0 {
             let behind = Int(Date().timeIntervalSince1970) - newest
-            lines.append(behind > 3 * 86400
-                ? "Strap clock: \(behind / 86400)d behind wall (reset/stale — alarm unreliable)"
-                : "Strap clock: OK")
+            if behind > 3 * 86400 {
+                lines.append("Strap clock: \(behind / 86400)d behind wall (reset/stale — alarm unreliable)")
+            } else if behind < -3 * 86400 {
+                lines.append("Strap clock: \(-behind / 86400)d AHEAD of wall (future-dated — alarm unreliable)")
+            } else {
+                lines.append("Strap clock: OK")
+            }
         }
         if let sent = d.object(forKey: "alarm.lastArmSentEpoch") as? Int {
             var line = "Last arm: sent \(alarmStamp(sent))"

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -2360,12 +2360,18 @@ class WhoopBleClient(
                 return
             }
             send(CommandNumber.SET_ALARM_TIME, AlarmPayload.build(epochSec * 1000L))
-            log("Alarm: armed 5/MG rev4 EXPERIMENTAL (epoch $epochSec)")
+            recordAlarmArm(epochSec)
+            log(if (_state.value.connected) "Alarm: armed 5/MG rev4 EXPERIMENTAL (epoch $epochSec)"
+                else "Alarm: queued 5/MG rev4 EXPERIMENTAL (epoch $epochSec) — strap not connected")
             return
         }
         sendSetClockBothForms()
         send(CommandNumber.SET_ALARM_TIME, whoop4AlarmPayload(epochSec))
-        log("Alarm: armed (epoch $epochSec)")
+        recordAlarmArm(epochSec)
+        // #34: only claim "armed" when the strap is connected (the send actually went out); otherwise it's
+        // queued and re-sent on the next connect.
+        if (_state.value.connected) log("Alarm: armed (epoch $epochSec)")
+        else log("Alarm: queued (epoch $epochSec) — strap not connected; will send on next connect")
         // Arm READBACK (#401 close-out): ask the strap what it now has armed (GET_ALARM_TIME, cmd 67) so
         // the strap log carries armed + strap-reports + fired as one decidable sequence in any future
         // "didn't buzz" report. WHOOP 4.0 ONLY (this branch): the 5/MG puffin readback semantics are
@@ -2373,6 +2379,18 @@ class WhoopBleClient(
         // ([whoop4ArmedAlarmEpoch]) and NEVER gates behaviour on it (the 4.0 response layout is
         // undocumented; unparseable replies log raw hex). Twin of macOS armStrapAlarm.
         send(CommandNumber.GET_ALARM_TIME, byteArrayOf(0x01))
+    }
+
+    /** #34: persist the last alarm arm for the debug export's Alarm block (sent epoch + when + whether the
+     *  strap was connected when we sent it), so a "didn't buzz" report shows sent-vs-strap-reports. */
+    private fun recordAlarmArm(sentEpoch: Long) {
+        runCatching {
+            NoopPrefs.of(context).edit()
+                .putLong("alarm.lastArmSentEpoch", sentEpoch)
+                .putLong("alarm.lastArmAt", System.currentTimeMillis())
+                .putBoolean("alarm.lastArmConnected", _state.value.connected)
+                .apply()
+        }
     }
 
     /** Clear the strap's firmware alarm. Port of macOS `BLEManager.disableStrapAlarm`. */
@@ -3467,6 +3485,13 @@ class WhoopBleClient(
                     val epoch = whoop4ArmedAlarmEpoch(frame)
                     if (epoch != null) {
                         log("Alarm: strap reports armed for ${alarmReadbackLocalTime(epoch)} (epoch $epoch)")
+                        // #34: persist what the strap reports so the debug export can show sent-vs-reported.
+                        runCatching {
+                            NoopPrefs.of(context).edit()
+                                .putLong("alarm.lastReportedEpoch", epoch)
+                                .putLong("alarm.lastReportedAt", System.currentTimeMillis())
+                                .apply()
+                        }
                     } else {
                         val raw = whoop4AlarmReadbackPayloadHex(frame) ?: "empty"
                         log("Alarm: strap answered the alarm readback with an unrecognised payload (raw $raw) - layout undocumented, log-only")

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -3272,6 +3272,8 @@ class WhoopBleClient(
                         log("Get Data Range raw frame (#451 — for offset analysis): $hex")
                         dataRangeNewestUnix(frame)?.let {
                             strapNewestTs = it
+                            // #34: persist the strap's newest banked record so the debug export can flag a reset clock.
+                            runCatching { NoopPrefs.of(context).edit().putLong("strap.newestRecordTs", it).apply() }
                             // #928: flag an implausibly FUTURE "newest" (strap clock set ahead) right where
                             // it lands, so a Test Centre export shows WHY auto-continue refused the range.
                             val wallNowForSkew = System.currentTimeMillis() / 1000L
@@ -3548,6 +3550,8 @@ class WhoopBleClient(
                         // FrameRouter → LiveState.onSmartAlarmFired.
                         if (smartAlarmFiredForEvent(ev, replayedOffload)) {
                             log("Strap fired its smart alarm (event 57) — re-arming the next day's instant")
+                            // #34: persist the fire so the debug export's Alarm block shows "last fired".
+                            runCatching { NoopPrefs.of(context).edit().putLong("alarm.lastFiredAt", System.currentTimeMillis()).apply() }
                             onSmartAlarmFired?.invoke()
                         }
                     } else {

--- a/android/app/src/main/java/com/noop/testcentre/AndroidDiagnostics.kt
+++ b/android/app/src/main/java/com/noop/testcentre/AndroidDiagnostics.kt
@@ -159,6 +159,20 @@ object AndroidDiagnostics {
             val on = com.noop.ui.NoopPrefs.smartAlarmEnabled(context)
             val mins = com.noop.ui.NoopPrefs.smartAlarmMinutes(context)
             add("Enabled: ${if (on) "yes" else "no"} · set ${"%02d:%02d".format(mins / 60, mins % 60)}")
+            // #3: model + the 5/MG experimental gate (a 5/MG firmware alarm is NOT armed unless it's on).
+            if (com.noop.ui.NoopPrefs.lastDevice(context)?.second == com.noop.ble.WhoopModel.WHOOP5_MG) {
+                val exp = com.noop.ble.PuffinExperiment.from(context).isEnabled
+                add("Model: WHOOP 5.0/MG · experimental: ${if (exp) "on" else "off → firmware alarm NOT armed"}")
+            } else {
+                add("Model: WHOOP 4.0")
+            }
+            // #4: strap clock health — a reset/stale clock (the #34 cause) breaks the alarm even when armed.
+            val newest = p.getLong("strap.newestRecordTs", 0L)
+            if (newest > 0L) {
+                val behind = System.currentTimeMillis() / 1000L - newest
+                add(if (behind > 3 * 86400L) "Strap clock: ${behind / 86400L}d behind wall (reset/stale — alarm unreliable)"
+                    else "Strap clock: OK")
+            }
             val sent = p.getLong("alarm.lastArmSentEpoch", 0L)
             if (sent > 0L) {
                 val at = p.getLong("alarm.lastArmAt", 0L)
@@ -173,6 +187,9 @@ object AndroidDiagnostics {
                         if (mismatch) "  ⚠️ MISMATCH — strap didn't accept the time" else "  ✓ matches")
                 } else add("Strap reports: (no readback)")
             } else add("Last arm: never")
+            // #1: did the strap actually fire? (STRAP_DRIVEN_ALARM_EXECUTED)
+            val firedAt = p.getLong("alarm.lastFiredAt", 0L)
+            add(if (firedAt > 0L) "Last fired: ${relTime(System.currentTimeMillis() - firedAt)}" else "Last fired: never observed")
         }.onFailure { add("(alarm state unavailable: ${it.message})") }
     }
 

--- a/android/app/src/main/java/com/noop/testcentre/AndroidDiagnostics.kt
+++ b/android/app/src/main/java/com/noop/testcentre/AndroidDiagnostics.kt
@@ -148,11 +148,44 @@ object AndroidDiagnostics {
         }.onFailure { add("(daily data unavailable: ${it.message})") }
     }
 
+    /** Alarm state for the debug export: the configured wake + the last arm's sent-vs-strap-reports (#34), so
+     *  a "didn't buzz" report shows whether the strap accepted the time. Reads persisted prefs (written by
+     *  WhoopBleClient.armStrapAlarm + the GET_ALARM_TIME readback). Best-effort. */
+    fun alarmLines(context: Context): List<String> = buildList {
+        add("─".repeat(40))
+        add("Alarm")
+        runCatching {
+            val p = com.noop.ui.NoopPrefs.of(context)
+            val on = com.noop.ui.NoopPrefs.smartAlarmEnabled(context)
+            val mins = com.noop.ui.NoopPrefs.smartAlarmMinutes(context)
+            add("Enabled: ${if (on) "yes" else "no"} · set ${"%02d:%02d".format(mins / 60, mins % 60)}")
+            val sent = p.getLong("alarm.lastArmSentEpoch", 0L)
+            if (sent > 0L) {
+                val at = p.getLong("alarm.lastArmAt", 0L)
+                var line = "Last arm: sent ${alarmStamp(sent)}"
+                if (at > 0L) line += " · ${relTime(System.currentTimeMillis() - at)}"
+                if (!p.getBoolean("alarm.lastArmConnected", false)) line += " · strap NOT connected (queued)"
+                add(line)
+                val reported = p.getLong("alarm.lastReportedEpoch", 0L)
+                if (reported > 0L) {
+                    val mismatch = kotlin.math.abs(reported - sent) > 120
+                    add("Strap reports: ${alarmStamp(reported)}" +
+                        if (mismatch) "  ⚠️ MISMATCH — strap didn't accept the time" else "  ✓ matches")
+                } else add("Strap reports: (no readback)")
+            } else add("Last arm: never")
+        }.onFailure { add("(alarm state unavailable: ${it.message})") }
+    }
+
+    private fun alarmStamp(epochSec: Long): String = runCatching {
+        java.text.SimpleDateFormat("yyyy-MM-dd HH:mm", java.util.Locale.US).format(epochSec * 1000L)
+    }.getOrDefault("?")
+
     /** The DB/prefs-backed diagnostic lines appended to the export header. Suspends (reads the local store);
      *  guarded per-section so it never throws into the export. */
     suspend fun dynamicLines(context: Context): List<String> =
         kotlinx.coroutines.withContext(kotlinx.coroutines.Dispatchers.Default) {
-            strapAndDataLines(context) + funnelLines(context) + workoutSourceLines(context) + dailyDataLines(context)
+            strapAndDataLines(context) + funnelLines(context) + workoutSourceLines(context) +
+                dailyDataLines(context) + alarmLines(context)
         }
 
     /** "3h 12m ago" style relative stamp for a positive age in ms. */

--- a/android/app/src/main/java/com/noop/testcentre/AndroidDiagnostics.kt
+++ b/android/app/src/main/java/com/noop/testcentre/AndroidDiagnostics.kt
@@ -166,12 +166,16 @@ object AndroidDiagnostics {
             } else {
                 add("Model: WHOOP 4.0")
             }
-            // #4: strap clock health — a reset/stale clock (the #34 cause) breaks the alarm even when armed.
+            // #4: strap clock health — a reset/stale OR future-dated clock (the #34 / #928 causes) breaks
+            // the alarm even when armed.
             val newest = p.getLong("strap.newestRecordTs", 0L)
             if (newest > 0L) {
                 val behind = System.currentTimeMillis() / 1000L - newest
-                add(if (behind > 3 * 86400L) "Strap clock: ${behind / 86400L}d behind wall (reset/stale — alarm unreliable)"
-                    else "Strap clock: OK")
+                add(when {
+                    behind > 3 * 86400L -> "Strap clock: ${behind / 86400L}d behind wall (reset/stale — alarm unreliable)"
+                    behind < -3 * 86400L -> "Strap clock: ${-behind / 86400L}d AHEAD of wall (future-dated — alarm unreliable)"
+                    else -> "Strap clock: OK"
+                })
             }
             val sent = p.getLong("alarm.lastArmSentEpoch", 0L)
             if (sent > 0L) {


### PR DESCRIPTION
From #34 (alarm not buzzing) — the strap consistently reported a **stale** armed time no matter what NOOP sent (its clock was reset). The `#401` readback *caught* it, but nothing surfaced it, and the log even claimed "armed" while disconnected.

## #3 — Alarm block in the debug export (both platforms)
The configured wake + the last arm's **sent-vs-strap-reports** epochs with a **MISMATCH** flag, so a "didn't buzz" report is decidable at a glance:
```
── Alarm ──
Enabled: yes · set 07:00
Last arm: sent 2026-07-07 21:24 · 3m ago · strap NOT connected (queued)
Strap reports: 2021-03-28 04:07  ⚠️ MISMATCH — strap didn't accept the time
```
`armStrapAlarm` persists the sent epoch (+ when + connected); the `GET_ALARM_TIME` readback persists what the strap reports; the export composes them (best-effort, guarded).

## #4 — don't log "armed" when disconnected
The old log said `send(Set Alarm Time) ignored — not connected` then immediately `Alarm: armed`. Now it logs **"queued — will send on next connect"** when `connectedPeripheralUUID`/`_state.connected` is nil, so the log stops claiming an arm that never transmitted.

## Scope
- iOS: `BLEManager` (arm persist + gate), `FrameRouter` (readback persist), `DebugDataDiagnostics` (block).
- Android: `WhoopBleClient` (arm persist + gate + readback persist), `AndroidDiagnostics` (block).
- Android compiles clean; **iOS gated by CI** (touches the BLE path, can't build Swift locally).