### PR TITLE
Sleep: stop the stage strip clipping into a row of circles (#36)

### DIFF
--- a/android/app/src/main/java/com/noop/ui/SleepScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/SleepScreen.kt
@@ -1267,27 +1267,29 @@ private fun HypnogramWithAxis(
             val total = weights.sum()
             if (stages.isEmpty() || total <= 0f) return@Canvas
 
-            // WIDTH floor: a segment narrower than this reads as a tick. Floor it to ~one strip-height
-            // square so short stages are legible blocks (the Android analogue of the Swift band-min
-            // thickness). Stretches sub-floor stages slightly; proportions of normal stages are intact.
-            val minSegW = h
-            val gap = if (stages.size > 1) 1.5f else 0f
+            // WIDTH floor: a segment narrower than this reads as a hairline, so floor short stages to a
+            // legible block. But the FLOORED widths can sum past the canvas on a fragmented night (many
+            // short segments), and the old loop advanced `x` by the floored width — so the tail ran off
+            // the canvas and clipped, leaving only the first ~w/h segments visible as a row of circles
+            // (#36). Fix: floor every segment, then if the floored total overflows, scale them ALL to fit
+            // so the strip stays a continuous bar for the WHOLE night. Draw rounded RECTS (not round-capped
+            // lines, whose h-wide round cap turned any sub-h segment into a full circle) advancing by the
+            // SAME width we draw, so `x` can never exceed the canvas.
+            val minSegW = h / 2f
+            val floored = weights.map { wt -> if (wt > 0f) maxOf(w * (wt / total), minSegW) else 0f }
+            val flooredSum = floored.sum()
+            val scale = if (flooredSum > w) w / flooredSum else 1f
+            val radius = CornerRadius(2.dp.toPx(), 2.dp.toPx())
             var x = 0f
             stages.forEachIndexed { i, (name, _) ->
-                val rawW = w * (weights[i] / total)
-                if (rawW <= 0f) return@forEachIndexed
-                val segW = maxOf(rawW, minSegW)
-                val drawW = (segW - if (i < stages.size - 1) gap else 0f).coerceAtLeast(0f)
-                if (drawW > 0f) {
-                    val cap = (h / 2f).coerceAtMost(drawW / 2f)
-                    drawLine(
-                        color = stageColorFor(name),
-                        start = Offset(x + cap, h / 2f),
-                        end = Offset((x + drawW - cap).coerceAtLeast(x + cap), h / 2f),
-                        strokeWidth = h,
-                        cap = StrokeCap.Round,
-                    )
-                }
+                val segW = floored[i] * scale
+                if (segW <= 0f) return@forEachIndexed
+                drawRoundRect(
+                    color = stageColorFor(name),
+                    topLeft = Offset(x, 0f),
+                    size = Size(segW.coerceAtMost(w - x), h),
+                    cornerRadius = radius,
+                )
                 x += segW
             }
 


### PR DESCRIPTION
## What #36 reported

On Android the sleep-hero stage graphic renders as a **single row of disconnected circles** (WHOOP 5.0, on-device staging) instead of a continuous stage strip.

<img width="300" src="https://github.com/user-attachments/assets/a3fdf342-62d5-4060-baa5-5b07e3b46da0" />

## Root cause

`HypnogramWithAxis` floored each segment to a min width (`minSegW = h`, 34dp) and advanced `x` by that **floored** width. Two things then break on a fragmented night (a WHOOP 5.0 metadata-only sync produces many short approximate segments):

1. **Overflow / clipping** — the floored widths sum past the canvas, so `x` runs off-screen and the tail clips. Only the first ~`w/h` segments (≈ the ~13 circles in the screenshot) stay visible; the rest of the night is drawn off-canvas.
2. **Circles** — each segment was drawn as an `h`-wide **round-capped line**, so any sub-`h` segment renders as a full `h`-diameter circle rather than a block.

Together: a disconnected row of circles on one line.

## The fix (minimal — keeps the single strip)

- Floor every segment, then if the floored total overflows the canvas, **scale them all to fit** — the strip stays a continuous bar for the *whole* night instead of clipping the tail.
- Draw rounded **rects** (not round-capped lines) advancing by the **same** width they're drawn, so `x` can never exceed the canvas and a narrow segment reads as a thin block, not a circle.
- Proportions of normal-width segments are unchanged; the onset · midpoint · wake axis is untouched.

~20 lines in one function, no analytics change, no new composables.

## Notes

- This is a genuinely data-poor night ("No movement detail", metadata-only sync), so the stages stay **approximate** — the strip is now correct and legible, not more precise.
- Chose the minimal single-strip fix over porting the iOS multi-lane (per-stage rows) layout; the multi-lane remains a possible later enhancement if we want "phases on separate lines."
- Android-only; compiles clean (`compileFullReleaseKotlin`).

Fixes #36.