### PR TITLE
macOS: import the official app's store into the fork build (#39)

### DIFF
--- a/Strand/Collect/StorePaths.swift
+++ b/Strand/Collect/StorePaths.swift
@@ -37,6 +37,13 @@ enum StorePaths {
         if containerAppSupport != appSupport {
             migrateLegacyStoreIfNeeded(from: appSupport.appendingPathComponent("OpenWhoop", isDirectory: true),
                                        to: base, dbURL: dbURL)
+        } else {
+            // Fork ".staging" build: it installs BESIDE the official app, so its store lives at the plain
+            // ~/Library/Application Support/OpenWhoop, NOT the official app's sandbox container. The first
+            // launch (our store still empty) COPIES the official com.noopapp.noop container store in, so a
+            // user coming from official NOOP keeps their history (#39). (Prod/sandboxed builds took the
+            // branch above and never reach here.)
+            importOfficialContainerStoreIfNeeded(into: base, dbURL: dbURL)
         }
         #endif
 
@@ -103,6 +110,33 @@ enum StorePaths {
                 // original in place so the data is never lost.
                 try? fm.copyItem(at: src, to: dst)
             }
+        }
+    }
+
+    /// Fork ".staging" builds keep their store outside the official app's sandbox container, so a user
+    /// moving from official NOOP would otherwise see an empty database (#39). The first time (our store
+    /// still empty), COPY the official `com.noopapp.noop` container store in. COPY — never move — because
+    /// the official app may still be installed and using it. The distributed build is unsigned (so it isn't
+    /// sandboxed and CAN read the sibling container); if a sandbox is unexpectedly engaged,
+    /// `homeDirectoryForCurrentUser` points inside OUR container and the official store is unreachable, so
+    /// we bail rather than guess a path.
+    private static func importOfficialContainerStoreIfNeeded(into stagingDir: URL, dbURL: URL) {
+        guard !destinationHasData(dbURL) else { return }
+        let fm = FileManager.default
+        let home = fm.homeDirectoryForCurrentUser
+        guard !home.standardizedFileURL.path.contains("/Library/Containers/") else { return }
+
+        let officialDir = home.appendingPathComponent(
+            "Library/Containers/com.noopapp.noop/Data/Library/Application Support/OpenWhoop", isDirectory: true)
+        let officialDB = officialDir.appendingPathComponent("whoop.sqlite")
+        guard fm.fileExists(atPath: officialDB.path), fileSize(of: officialDB) > 0 else { return }
+
+        for suffix in ["", "-wal", "-shm"] {
+            let src = officialDir.appendingPathComponent("whoop.sqlite\(suffix)")
+            let dst = stagingDir.appendingPathComponent("whoop.sqlite\(suffix)")
+            guard fm.fileExists(atPath: src.path) else { continue }
+            if fm.fileExists(atPath: dst.path) { try? fm.removeItem(at: dst) }
+            try? fm.copyItem(at: src, to: dst)
         }
     }
 


### PR DESCRIPTION
## What #39 reported

Installing **8.3.2 on macOS over 8.2.x opens an empty database** — all data appears lost. Old path `~/Library/Containers/com.noopapp.noop/Data/…/OpenWhoop`; new path `~/Library/Application Support/OpenWhoop`.

## Root cause

The v8.3.0 `719477a8` "NOOP Staging identity" rename set the macOS bundle ID to `com.noopapp.noop.staging` so the fork installs **beside** the official app. But `StorePaths.macOSProductionContainerAppSupport` pins the store to the sandbox container **only** for the exact production ID `com.noopapp.noop`; under `.staging` it uses the plain `~/Library/Application Support/OpenWhoop`, and the existing `migrateLegacyStoreIfNeeded` (gated on `containerAppSupport != appSupport`) never runs. So a user coming from the official app reads a fresh, empty directory.

**The data was never deleted** — it's still in the official app's container.

## Fix — keep `.staging`, copy the official store in

Rather than flip the bundle ID (which would make the fork *replace* the official app), keep the beside-install `.staging` identity and **copy** the official `com.noopapp.noop` container store into the fork's store on first launch:

- **Copy, never move** — the official app may still be installed and using it.
- Runs only when the fork's store is still **empty** (same `destinationHasData` guard as the existing migration), so it never clobbers a fork user who already has data.
- The distributed macOS build is **unsigned** (`CODE_SIGNING_ALLOWED=NO` in `fork-release.yml`), so it isn't sandboxed and *can* read the sibling container. If a sandbox is ever unexpectedly engaged, `homeDirectoryForCurrentUser` points inside our own container and the official store is unreachable → we bail rather than guess.

## Who is affected, and what happens

- **Coming from official / fork v8.2.x** (data in the container, fork store empty) → store copied in, **data reappears**. ✓ (the reporter)
- **Fork v8.3.x-only** (data already in the plain path) → store non-empty → skipped, keeps working. ✓
- **Data in both** (older container + newer fork data) → keeps the **fork** data (never clobbered); the container copy is skipped. Nothing deleted; the container remains for manual recovery.

No bundle-ID / identity change; the fork stays "NOOP Staging" beside the official app. Swift-only change; CI build dispatched to verify (can't compile Swift locally).

Fixes #39.