### PR TITLE
i18n: localize Today strings + complete the French catalog (#35)

### DIFF
--- a/Strand/Liquid/LiquidTodayView.swift
+++ b/Strand/Liquid/LiquidTodayView.swift
@@ -418,11 +418,11 @@ struct LiquidTodayView: View {
 
     private var heroCard: some View {
         HStack(alignment: .top, spacing: 4) {
-            HeroScoreCell(label: "Charge", score: displayDay?.recovery, tint: StrandPalette.chargeColor,
+            HeroScoreCell(label: String(localized: "Charge"), score: displayDay?.recovery, tint: StrandPalette.chargeColor,
                           pill: "WHOOP", animated: dataLoaded, onGuide: { guideSection = .charge })
-            HeroScoreCell(label: "Effort", score: displayDay?.strain, tint: StrandPalette.effortColor,
+            HeroScoreCell(label: String(localized: "Effort"), score: displayDay?.strain, tint: StrandPalette.effortColor,
                           pill: nil, animated: dataLoaded, onGuide: { guideSection = .effort })
-            HeroScoreCell(label: "Rest", score: restScore, tint: StrandPalette.restColor,
+            HeroScoreCell(label: String(localized: "Rest"), score: restScore, tint: StrandPalette.restColor,
                           pill: "WHOOP", animated: dataLoaded, onGuide: { guideSection = .rest })
         }
         .padding(.vertical, 16)
@@ -632,7 +632,7 @@ struct LiquidTodayView: View {
                         Text(synthLine).font(StrandFont.body).foregroundStyle(StrandPalette.textPrimary)
                             .fixedSize(horizontal: false, vertical: true)
                         if synthesisExpanded {
-                            Text(readiness.summary).font(StrandFont.caption)
+                            Text(LocalizedStringKey(readiness.summary)).font(StrandFont.caption)
                                 .foregroundStyle(StrandPalette.textSecondary)
                                 .fixedSize(horizontal: false, vertical: true)
                         }
@@ -661,11 +661,11 @@ struct LiquidTodayView: View {
                         Text(line).font(StrandFont.caption).foregroundStyle(StrandPalette.textTertiary)
                     }
                 }
-                vitalRow("Heart-rate variability", unitText(hrv, "ms"),
+                vitalRow(String(localized: "Heart-rate variability"), unitText(hrv, "ms"),
                          StrandPalette.metricCyan, fracOver(hrv, 120))
-                vitalRow("Resting heart rate", unitText(rhr, "bpm"),
+                vitalRow(String(localized: "Resting heart rate"), unitText(rhr, "bpm"),
                          StrandPalette.metricRose, fracOver(rhr, 100))
-                vitalRow("Breaths per minute", unitText(resp, "rpm", decimals: 1),
+                vitalRow(String(localized: "Breaths per minute"), unitText(resp, "rpm", decimals: 1),
                          StrandPalette.accent, fracOver(resp, 24))
             }
         }
@@ -690,12 +690,12 @@ struct LiquidTodayView: View {
         return VStack(spacing: 8) {
             sectionHead("KEY METRICS", trailing: "14-day trend")
             LazyVGrid(columns: Array(repeating: GridItem(.flexible(), spacing: 8), count: 3), spacing: 8) {
-                ktile("Recovery", intText(displayDay?.recovery), "%", StrandPalette.chargeColor, frac(displayDay?.recovery))
-                ktile("Strain", intText(displayDay?.strain), "%", StrandPalette.effortColor, frac(displayDay?.strain))
-                ktile("Sleep", sleepText, "", StrandPalette.restColor, fracOver(displayDay?.totalSleepMin, 480))
-                ktile("HRV", intText(hrv), "ms", StrandPalette.metricCyan, fracOver(hrv, 120))
-                ktile("Rest HR", intText(rhr), "bpm", StrandPalette.metricRose, fracOver(rhr, 100))
-                ktile("Steps", stepsText, "", StrandPalette.chargeColor, fracOver(stepCount, 10000))
+                ktile(String(localized: "Recovery"), intText(displayDay?.recovery), "%", StrandPalette.chargeColor, frac(displayDay?.recovery))
+                ktile(String(localized: "Strain"), intText(displayDay?.strain), "%", StrandPalette.effortColor, frac(displayDay?.strain))
+                ktile(String(localized: "Sleep"), sleepText, "", StrandPalette.restColor, fracOver(displayDay?.totalSleepMin, 480))
+                ktile(String(localized: "HRV"), intText(hrv), "ms", StrandPalette.metricCyan, fracOver(hrv, 120))
+                ktile(String(localized: "Rest HR"), intText(rhr), "bpm", StrandPalette.metricRose, fracOver(rhr, 100))
+                ktile(String(localized: "Steps"), stepsText, "", StrandPalette.chargeColor, fracOver(stepCount, 10000))
             }
             NavigationLink { MetricExplorerView() } label: {
                 Text("Show all metrics").font(StrandFont.subhead).foregroundStyle(StrandPalette.accent)
@@ -795,9 +795,9 @@ struct LiquidTodayView: View {
 
     private func sectionHead(_ title: String, trailing: String) -> some View {
         HStack(alignment: .firstTextBaseline) {
-            Text(title).font(StrandFont.overline).tracking(1.6).foregroundStyle(StrandPalette.textTertiary)
+            Text(LocalizedStringKey(title)).font(StrandFont.overline).tracking(1.6).foregroundStyle(StrandPalette.textTertiary)
             Spacer()
-            Text(trailing).font(StrandFont.caption).foregroundStyle(StrandPalette.textTertiary)
+            Text(LocalizedStringKey(trailing)).font(StrandFont.caption).foregroundStyle(StrandPalette.textTertiary)
         }
         .padding(.horizontal, 2)
         .padding(.top, 4)
@@ -889,26 +889,28 @@ struct LiquidTodayView: View {
 
     private var readinessWord: String? {
         switch readiness.level {
-        case .primed: return "Push"
-        case .balanced: return "Maintain"
-        case .strained, .rundown: return "Rest"
+        case .primed: return String(localized: "Push")
+        case .balanced: return String(localized: "Maintain")
+        case .strained, .rundown: return String(localized: "Rest")
         case .insufficient: return nil
         }
     }
 
     private var synthLine: String {
         switch readiness.level {
-        case .primed: return "You're primed. A hard session should land well today."
-        case .balanced: return "You're in a good spot for training."
-        case .strained: return "Signals are down a touch. Keep it easy today."
-        case .rundown: return "Several recovery signals are down. Prioritise rest today."
-        case .insufficient: return "Still learning your baseline. A few more nights and this fills in."
+        case .primed: return String(localized: "You're primed. A hard session should land well today.")
+        case .balanced: return String(localized: "You're in a good spot for training.")
+        case .strained: return String(localized: "Signals are down a touch. Keep it easy today.")
+        case .rundown: return String(localized: "Several recovery signals are down. Prioritise rest today.")
+        case .insufficient: return String(localized: "Still learning your baseline. A few more nights and this fills in.")
         }
     }
 
     private var greeting: String {
         let h = Calendar.current.component(.hour, from: Date())
-        return h < 12 ? "Good morning" : h < 17 ? "Good afternoon" : "Good evening"
+        return h < 12 ? String(localized: "Good morning")
+            : h < 17 ? String(localized: "Good afternoon")
+            : String(localized: "Good evening")
     }
 
     private var stepCount: Double? { displayDay?.steps.map(Double.init) ?? stepsEst }
@@ -1102,7 +1104,7 @@ private struct HeroScoreCell: View {
                 .foregroundStyle(StrandPalette.onDarkSecondary)
             }
             .buttonStyle(.plain)
-            .accessibilityLabel(Text("\(label), \(score.map { String(Int($0.rounded())) } ?? "no data yet"). See how it is scored."))
+            .accessibilityLabel(Text("\(label), \(score.map { String(Int($0.rounded())) } ?? String(localized: "no data yet")). See how it is scored."))
             if let pill {
                 Text(pill)
                     .font(StrandFont.overlineScaled(8.5)).tracking(1.2)
@@ -1167,9 +1169,9 @@ private struct LiquidLiveHR: View {
         return nil
     }
     private var subtitle: String {
-        if isLive { return "Live · beat by beat" }
-        if fallback.count >= 2 { return "5-minute average · since midnight" }
-        return live.connected ? "Waiting for the strap" : "Strap not connected"
+        if isLive { return String(localized: "Live · beat by beat") }
+        if fallback.count >= 2 { return String(localized: "5-minute average · since midnight") }
+        return live.connected ? String(localized: "Waiting for the strap") : String(localized: "Strap not connected")
     }
 
     var body: some View {
@@ -1200,11 +1202,11 @@ private struct LiquidLiveHR: View {
             if series.count >= 2 {
                 LiquidThread(bpm: series, tint: tint, height: 92, animated: animated)
                 HStack {
-                    stat("Min", series.min())
+                    stat(String(localized: "Min"), series.min())
                     Spacer()
-                    stat("Avg", series.reduce(0, +) / Double(series.count))
+                    stat(String(localized: "Avg"), series.reduce(0, +) / Double(series.count))
                     Spacer()
-                    stat("Max", series.max())
+                    stat(String(localized: "Max"), series.max())
                 }
             } else {
                 Text(live.connected ? "Waiting for a live heartbeat…" : "Connect your strap to see live heart rate")
@@ -1270,8 +1272,11 @@ private struct LiquidBatteryButton: View {
         .accessibilityLabel(batteryAccessibility)
     }
     private var batteryAccessibility: String {
-        let base = live.batteryPct.map { "Strap battery \(Int($0.rounded())) percent" } ?? "Strap battery"
-        return live.charging == true ? base + ", charging" : base
+        guard let pct = live.batteryPct else { return String(localized: "Strap battery") }
+        let n = Int(pct.rounded())
+        return live.charging == true
+            ? String(localized: "Strap battery \(n) percent, charging")
+            : String(localized: "Strap battery \(n) percent")
     }
     private func ringColor(_ p: Double) -> Color {
         p < 15 ? StrandPalette.statusCritical : p < 35 ? StrandPalette.statusWarning : StrandPalette.chargeColor

--- a/Strand/Screens/FusedRecordView.swift
+++ b/Strand/Screens/FusedRecordView.swift
@@ -213,7 +213,7 @@ private struct FusedMetricRowView: View {
         VStack(alignment: .leading, spacing: 6) {
             // Top line: metric label + the winning value (best-sourced), right-aligned.
             HStack(alignment: .firstTextBaseline, spacing: 10) {
-                Text(row.label)
+                Text(LocalizedStringKey(row.label))
                     .font(StrandFont.headline)
                     .foregroundStyle(StrandPalette.textPrimary)
                 Spacer(minLength: 8)

--- a/Strand/Screens/TodayView.swift
+++ b/Strand/Screens/TodayView.swift
@@ -1510,7 +1510,7 @@ struct TodayView: View {
                         HStack(spacing: 10) {
                             Circle().fill(readinessColor(r.level)).frame(width: 10, height: 10)
                                 .accessibilityHidden(true)
-                            Text(r.headline).font(StrandFont.headline)
+                            Text(LocalizedStringKey(r.headline)).font(StrandFont.headline)
                                 .foregroundStyle(StrandPalette.textPrimary)
                                 .accessibilityLabel("Readiness: \(levelWord(r.level)). \(r.headline)")
                             Spacer()
@@ -1521,7 +1521,7 @@ struct TodayView: View {
                                     .help("Acute (7-day) vs chronic (28-day) training load. 0.8-1.3 is the sweet spot.")
                             }
                         }
-                        Text(r.summary).font(StrandFont.subhead)
+                        Text(LocalizedStringKey(r.summary)).font(StrandFont.subhead)
                             .foregroundStyle(StrandPalette.textSecondary)
                             .fixedSize(horizontal: false, vertical: true)
                         if !r.signals.isEmpty {
@@ -1537,7 +1537,7 @@ struct TodayView: View {
                                         .padding(.top, 4)
                                         .accessibilityHidden(true)
                                     VStack(alignment: .leading, spacing: 2) {
-                                        Text(s.label).font(StrandFont.caption)
+                                        Text(LocalizedStringKey(s.label)).font(StrandFont.caption)
                                             .foregroundStyle(StrandPalette.textSecondary)
                                         if let evidence = s.evidence {
                                             Text(evidence).font(StrandFont.captionNumber)
@@ -1547,13 +1547,13 @@ struct TodayView: View {
                                         }
                                     }
                                         .frame(width: 104, alignment: .leading)
-                                    Text(s.detail).font(StrandFont.caption)
+                                    Text(LocalizedStringKey(s.detail)).font(StrandFont.caption)
                                         .foregroundStyle(StrandPalette.textTertiary)
                                         .fixedSize(horizontal: false, vertical: true)
                                     Spacer(minLength: 0)
                                 }
                                 .accessibilityElement(children: .ignore)
-                                .accessibilityLabel("\(s.label), \(flagWord(s.flag)): \(s.detail)")
+                                .accessibilityLabel(Text("\(Text(LocalizedStringKey(s.label))), \(flagWord(s.flag)): \(Text(LocalizedStringKey(s.detail)))"))
                             }
                         }
                     }


### PR DESCRIPTION
Reworks the closed #35 (from @pipiche38) under the NOOP identity.

## 1. Make Today/record strings translatable

Several UI strings were passed as **function arguments** (not literal `Text` views), so Xcode never extracted them into the String Catalog and they couldn't be translated:

- Static labels → `String(localized:)`: hero **Charge/Effort/Rest**, the vital rows (HRV / Resting HR / Breaths), the key-metric tiles, `readinessWord`, the readiness synthesis line, `greeting`, and the live-HR subtitle + Min/Avg/Max.
- Dynamic strings that originate in the **StrandAnalytics package** or a data row (`readiness.summary`/`headline`, the fused-metric row label, section-head titles) → rendered via `LocalizedStringKey` so the **app** catalog translates them at display. Localizing those at their source would mean making the analytics package itself localized (its own catalog + `bundle: .module`) — out of scope here.

## 2. Complete the French locale

The catalog carried only **~465 French entries vs ~3000** for German/Spanish. This fills **every** string — French now covers all **3088** entries. Purely additive (the diff is +19k/−9): de/es and existing entries are untouched, and the file validates as JSON.

## Reworked vs #35

Dropped #35's `batteryAccessibility` change: it declared `let estimateText: String? = nil` — dead code that **shadowed** the real `estimateText` computed property — and folded the ", charging" suffix *into* the localization key. Replaced with two clean keys ("Strap battery %lld percent" / "…, charging").

## Notes

- French strings taken as-is from the contributor (native speaker); a later native pass can refine any phrasing.
- Swift-only + catalog; CI build dispatched to verify (Swift can't be compiled locally).

Closes #35.