### PR TITLE
Backfill: stop the false "no banked history" alarm on an auto-continue's empty tail (#42)

### DIFF
--- a/Strand/BLE/BLEManager.swift
+++ b/Strand/BLE/BLEManager.swift
@@ -1502,7 +1502,10 @@ public final class BLEManager: NSObject, ObservableObject {
         }
         // Capture the family at begin() (not init): selectedModel is reliably set by connect() before any
         // backfill starts, whereas bootstrapStore() can build the Backfiller before the family is known.
-        backfiller.begin(family: selectedModel.deviceFamily)
+        // #42/#364: consecutiveAutoContinues > 0 means this offload is re-kicked after an EARLIER session in
+        // the same burst banked rows — tell the backfiller so its no-cursor END reads as "caught up", not
+        // "no banked history / charge to 100%". A fresh offload (count 0) keeps the honest guidance.
+        backfiller.begin(family: selectedModel.deviceFamily, continuedAfterRows: consecutiveAutoContinues > 0)
         backfilling = true
         state.backfilling = true
         state.syncChunksThisSession = 0
@@ -1674,9 +1677,14 @@ public final class BLEManager: NSObject, ObservableObject {
                 consoleChunks: state.consoleChunksThisSession,
                 rowsPersisted: backfiller?.sessionRowsPersisted ?? 0)
             let bankedSensorRecords = banking.bankedSensorRecords
-            let bankedNothing = banking.bankedNothing
-            let sustainedEmpty = emptySyncTracker.recordCompletedSync(
-                bankedSensorRecords: bankedSensorRecords, consoleOnly: bankedNothing)
+            // #42: the empty tail of an auto-continue burst (consecutiveAutoContinues > 0) isn't a "banked
+            // nothing" sync — an EARLIER session in the same burst handed over real rows and this pass just
+            // confirms we're caught up. Don't surface the "charge to 100%" framing, and don't count it toward
+            // the sustained-empty streak (the productive session already cleared it).
+            let productiveBurstTail = consecutiveAutoContinues > 0
+            let bankedNothing = banking.bankedNothing && !productiveBurstTail
+            let sustainedEmpty = productiveBurstTail ? false : emptySyncTracker.recordCompletedSync(
+                bankedSensorRecords: bankedSensorRecords, consoleOnly: banking.bankedNothing)
             if unarchived > 0 {
                 state.lastSyncError = "Synced, but \(archived + unarchived) record(s) couldn't be decoded (unrecognised strap firmware layout), and the on-device archive is full - the \(unarchived) newest weren't preserved. Please share a strap log so the layout can be mapped."
             } else if archived > 0 {

--- a/Strand/Collect/Backfiller.swift
+++ b/Strand/Collect/Backfiller.swift
@@ -87,6 +87,11 @@ final class Backfiller {
     /// tell a banking strap from a broken one. Reset at begin(); read by BLEManager at session end to emit
     /// "persisted N rows (M with motion) across K night(s)". Nights are day-keys (ts / 86400).
     private(set) var sessionRowsPersisted = 0
+    /// #42: set by `begin` when this session continues an auto-continue burst (#364) that already banked
+    /// rows in an earlier session, so a trim=0xFFFFFFFF END here reads as "caught up", not "no history".
+    /// Without it the fresh session's `sessionRowsPersisted` is 0 and the scary "charge to 100%" line
+    /// false-fires on the empty tail of a sync that just offloaded real records.
+    private(set) var continuedAfterRows = false
     private(set) var sessionMotionRows = 0
     /// #727: skin-temp samples banked this session. WHOOP 4.0 carries skin temp (and the raw SpO2 channel)
     /// ONLY in its full DSP sleep records; a strap banking HR/RR-only records reports 0 here even on a
@@ -184,8 +189,9 @@ final class Backfiller {
     /// Called by BLEManager when the strap signals a historical offload is beginning.
     /// chunkOpen starts TRUE: the high-freq-sync biometric replay streams records immediately and
     /// sends one HISTORY_START then repeated HISTORY_ENDs, so we must accumulate from the outset.
-    func begin(family: DeviceFamily) {
+    func begin(family: DeviceFamily, continuedAfterRows: Bool = false) {
         self.family = family
+        self.continuedAfterRows = continuedAfterRows
         isBackfilling = true
         chunk.removeAll(keepingCapacity: true)
         chunkOpen = true
@@ -264,9 +270,15 @@ final class Backfiller {
     /// "caught up, nothing left past the last trim", NOT "no history". Emitting the alarming "fully charge
     /// it" line there falsely scared users whose strap had just synced fine. So pick by `rowsPersisted`:
     /// > 0 gives a neutral caught-up line; 0 gives the genuine no-history guidance. Pure so a fixture pins both.
-    nonisolated static func noCursorLine(rowsPersisted: Int) -> String {
+    nonisolated static func noCursorLine(rowsPersisted: Int, continuedAfterRows: Bool = false) -> String {
         if rowsPersisted > 0 {
             return "Backfill: reached the end of available history (trim=0xFFFFFFFF) - caught up after persisting \(rowsPersisted) row(s) this run. Nothing more to offload."
+        }
+        // #42: the empty tail of an auto-continue burst (#364) that banked rows in an EARLIER session. The
+        // strap synced fine — this pass just confirms we're caught up — so DON'T false-alarm "no banked
+        // history / charge to 100%".
+        if continuedAfterRows {
+            return "Backfill: reached the end of available history (trim=0xFFFFFFFF) - caught up; the strap handed over its banked history earlier this sync. Nothing more to offload."
         }
         return "Backfill: strap reported no flash cursor (trim=0xFFFFFFFF) - it has no banked history to offload. This is a clock/charge state on the strap, not a decode problem; fully charge it and reconnect so it starts banking."
     }
@@ -527,7 +539,7 @@ final class Backfiller {
         // session (loggedNoCursor) and the ack still proceeds below.
         if trim == 0xFFFFFFFF, !loggedNoCursor {
             loggedNoCursor = true
-            log?(Backfiller.noCursorLine(rowsPersisted: sessionRowsPersisted))
+            log?(Backfiller.noCursorLine(rowsPersisted: sessionRowsPersisted, continuedAfterRows: continuedAfterRows))
             // Connection test mode: the no-cursor sentinel as a compact tagged line (gated zero-cost).
             emitConnection(ConnectionTrace.noCursorLine())
         }

--- a/android/app/src/main/java/com/noop/ble/Backfiller.kt
+++ b/android/app/src/main/java/com/noop/ble/Backfiller.kt
@@ -167,6 +167,12 @@ class Backfiller(
      */
     var sessionRowsPersisted = 0
         private set
+    /** #42: set by [begin] when this session continues an auto-continue burst (#364) that already banked
+     *  rows in an earlier session, so a trim=0xFFFFFFFF END here reads as "caught up", not "no history".
+     *  Without it, the fresh session's `sessionRowsPersisted` is 0 and the scary "charge to 100%" line
+     *  false-fires on the empty tail of a sync that just offloaded real records. */
+    var continuedAfterRows = false
+        private set
     var sessionMotionRows = 0
         private set
     /**
@@ -239,8 +245,9 @@ class Backfiller(
      * HISTORY_START then repeated HISTORY_ENDs, so we must accumulate from the outset.
      * Port of Swift `begin()`.
      */
-    fun begin(family: DeviceFamily = DeviceFamily.WHOOP4) {
+    fun begin(family: DeviceFamily = DeviceFamily.WHOOP4, continuedAfterRows: Boolean = false) {
         this.family = family
+        this.continuedAfterRows = continuedAfterRows
         isBackfilling = true
         sessionRowsPersisted = 0
         sessionMotionRows = 0
@@ -474,7 +481,7 @@ class Backfiller(
         // session (loggedNoCursor) and the ack still proceeds below.
         if (trim == 0xFFFFFFFFL && !loggedNoCursor) {
             loggedNoCursor = true
-            log(noCursorLine(sessionRowsPersisted))
+            log(noCursorLine(sessionRowsPersisted, continuedAfterRows))
             // Connection test mode: the no-cursor sentinel as a compact tagged line (gated zero-cost).
             emitConnection { com.noop.analytics.ConnectionTrace.noCursorLine() }
         }
@@ -559,14 +566,21 @@ class Backfiller(
          * > 0 gives a neutral caught-up line; 0 gives the genuine no-history guidance. Pure so a fixture pins both.
          * Twin of the Swift `Backfiller.noCursorLine(rowsPersisted:)`.
          */
-        fun noCursorLine(rowsPersisted: Int): String =
-            if (rowsPersisted > 0) {
-                "Backfill: reached the end of available history (trim=0xFFFFFFFF) - caught up after " +
-                    "persisting $rowsPersisted row(s) this run. Nothing more to offload."
-            } else {
-                "Backfill: strap reported no flash cursor (trim=0xFFFFFFFF) - it has no banked history to " +
-                    "offload. This is a clock/charge state on the strap, not a decode problem; fully charge " +
-                    "it and reconnect so it starts banking."
+        fun noCursorLine(rowsPersisted: Int, continuedAfterRows: Boolean = false): String =
+            when {
+                rowsPersisted > 0 ->
+                    "Backfill: reached the end of available history (trim=0xFFFFFFFF) - caught up after " +
+                        "persisting $rowsPersisted row(s) this run. Nothing more to offload."
+                // #42: the empty tail of an auto-continue burst (#364) that banked rows in an EARLIER
+                // session. The strap synced fine — this pass just confirms we're caught up — so DON'T
+                // false-alarm "no banked history / charge to 100%".
+                continuedAfterRows ->
+                    "Backfill: reached the end of available history (trim=0xFFFFFFFF) - caught up; the " +
+                        "strap handed over its banked history earlier this sync. Nothing more to offload."
+                else ->
+                    "Backfill: strap reported no flash cursor (trim=0xFFFFFFFF) - it has no banked history " +
+                        "to offload. This is a clock/charge state on the strap, not a decode problem; fully " +
+                        "charge it and reconnect so it starts banking."
             }
 
         /**

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -4366,7 +4366,10 @@ class WhoopBleClient(
             return
         }
         if (backfilling) return
-        backfiller.begin(connectedFamily)   // family drives the +4 puffin offset for 5/MG (#78)
+        // #42/#364: consecutiveAutoContinues > 0 means this offload is re-kicked after an EARLIER session
+        // in the same burst banked rows — tell the backfiller so its no-cursor END reads as "caught up",
+        // not "no banked history / charge to 100%". A fresh offload (count 0) keeps the honest guidance.
+        backfiller.begin(connectedFamily, continuedAfterRows = consecutiveAutoContinues > 0)   // family drives the +4 puffin offset for 5/MG (#78)
         backfilling = true
         ackedChunksThisSession = 0
         decodedChunksThisSession = 0
@@ -4536,11 +4539,16 @@ class WhoopBleClient(
             consoleChunks = consoleChunksThisSession,
             rowsPersisted = backfiller.sessionRowsPersisted,
         )
-        val bankedNothing = reason == "HISTORY_COMPLETE" && bankedNothingRaw
+        // #42: the empty tail of an auto-continue burst (consecutiveAutoContinues > 0) isn't a "banked
+        // nothing" sync — an EARLIER session in the same burst handed over real rows and this pass just
+        // confirms we're caught up. Don't surface the "charge to 100%" framing, and don't count it toward
+        // the sustained-empty streak (the productive session already cleared it).
+        val productiveBurstTail = consecutiveAutoContinues > 0
+        val bankedNothing = reason == "HISTORY_COMPLETE" && bankedNothingRaw && !productiveBurstTail
         // #126: only escalate to the clock-lost banner once emptiness is SUSTAINED. A banking cycle (any
         // decoded records / rows persisted) clears the streak, so a single transient empty cycle on a
         // healthy strap stays silent. Track on every completed sync so banking cycles reset it.
-        val sustainedEmpty = if (reason == "HISTORY_COMPLETE")
+        val sustainedEmpty = if (reason == "HISTORY_COMPLETE" && !productiveBurstTail)
             emptySyncTracker.recordCompletedSync(
                 bankedSensorRecords = bankedSensorRecords,
                 consoleOnly = bankedNothingRaw,

--- a/android/app/src/test/java/com/noop/ble/BackfillerSessionTallyTest.kt
+++ b/android/app/src/test/java/com/noop/ble/BackfillerSessionTallyTest.kt
@@ -76,10 +76,27 @@ class BackfillerSessionTallyTest {
         assertFalse(line.contains("fully charge"))
     }
 
+    // #42: trim=0xFFFFFFFF on the EMPTY tail of an auto-continue burst (this session banked 0 rows, but an
+    // earlier session in the burst did \u2014 continuedAfterRows=true) means "caught up", NOT "no history". It
+    // must NOT emit the scary fully-charge guidance even though rowsPersisted is 0.
+    @Test fun noCursorLineContinuedAfterRowsGivesCaughtUpLine() {
+        val line = Backfiller.noCursorLine(0, continuedAfterRows = true)
+        assertTrue(line.contains("caught up"))
+        assertFalse(line.contains("no banked history"))
+        assertFalse(line.contains("fully charge"))
+    }
+
+    // #42: continuedAfterRows only softens the ZERO-row tail; a genuinely empty FRESH run (default false)
+    // still gets the honest no-history guidance.
+    @Test fun noCursorLineFreshEmptyStillGivesNoHistoryGuidance() {
+        assertTrue(Backfiller.noCursorLine(0, continuedAfterRows = false).contains("no banked history"))
+    }
+
     // No em-dash leaks into either branch (project hard rule).
     @Test fun noCursorLineHasNoEmDash() {
         assertFalse(Backfiller.noCursorLine(0).contains("\u2014"))
         assertFalse(Backfiller.noCursorLine(5).contains("\u2014"))
+        assertFalse(Backfiller.noCursorLine(0, continuedAfterRows = true).contains("\u2014"))
     }
 
     // ---- #773 corrupt future-RTC detection ----


### PR DESCRIPTION
## What #42 saw

A WHOOP 4.0 user reported the sync "never had usable chunks — immediately says offloaded" and got a *charge to 100%* prompt, even though their strap was syncing. Their log shows it clearly:

```
offload progress … sessionRows=600 … nights=1
Backfill: … offload result=complete rows=600 nights=1     ← real data offloaded
Backfill: auto-continuing (#364/#451) — the trim advanced …
Backfill: strap reported no flash cursor (trim=0xFFFFFFFF) … fully charge it and reconnect   ← FALSE alarm
Backfill: completed but the strap banked no sensor history … consecutive empty syncs = 1
```

## Root cause

The #783 fix already softens a `trim=0xFFFFFFFF` END to a neutral *"caught up"* line **when the session banked rows** — but it keys on the **current session's** `sessionRowsPersisted`, and the #364 auto-continue starts a **fresh** session (`begin()` resets it to 0). So the empty tail of a *productive* burst prints the scary "no banked history / charge to 100%" line and is logged as an empty sync — right after offloading 600 rows.

## Fix

Carry the burst signal across the session boundary. `begin()` takes a `continuedAfterRows` flag; the BLE client passes `consecutiveAutoContinues > 0` (only ever > 0 after a session that banked rows and re-kicked). Then:

- `Backfiller.noCursorLine` prints "caught up" for a continuation session's empty END instead of the charge-to-100% guidance.
- The completion classifier skips the "banked nothing" framing **and** the sustained-empty streak for that tail (the productive session already cleared the streak).

A genuinely empty **fresh** offload (count 0) is untouched — it still gets the honest no-history guidance.

## Scope / testing

- Both platforms (twin `Backfiller` + `BLEManager`/`WhoopBleClient`).
- Android compiles; `BackfillerSessionTallyTest` passes with new cases for the continuation branch (empty tail after rows → "caught up"; fresh empty → still "no banked history").
- CI build dispatched for the Swift twin.

Note: this fixes the *misleading message*. It does not change actual banking — a strap that genuinely never banks overnight still (correctly) surfaces the sustained empty-sync guidance.

Fixes #42.