### PR TITLE
Fix/oura live console trusted stream

### DIFF
--- a/Strand/Screens/LiveView.swift
+++ b/Strand/Screens/LiveView.swift
@@ -52,6 +52,13 @@ struct LiveView: View {
 
     private var activeConnection: Bool { live.connected && live.bonded }
 
+    /// A non-WHOOP live source (the Oura ring) that is connected and actively streaming live HR. It
+    /// authenticates and streams but never reaches a WHOOP encrypted bond, so `bonded` stays false and
+    /// `activeConnection` never trips — which left the console reading "stream not yet trusted" for a
+    /// perfectly good ring stream. The status copy below treats this as a trusted live stream; the
+    /// bond-only feature gates (buzz, alarm, HRV snapshot) keep keying off `activeConnection`. (#69 twin.)
+    private var ringStreaming: Bool { live.connected && live.streamingLiveHR }
+
     /// The display name of the active device from the registry ("WHOOP", a strap's nickname, …) — what
     /// the user is connected to, or would connect to. Falls back to "WHOOP" before the registry opens or
     /// when none is resolvable, keeping the WHOOP-first tone. Drives the active-device readout + copy.
@@ -197,6 +204,7 @@ struct LiveView: View {
     private var connectionModeBadge: LocalizedStringKey {
         if activeConnection && live.encryptedBond { return "FULL BOND" }
         if activeConnection { return "LIVE HR ONLY" }
+        if ringStreaming { return "STREAMING" }
         if live.connected { return "CONNECTING" }
         if live.encryptedBond { return "PAIRED" }
         return "OFFLINE"
@@ -212,7 +220,7 @@ struct LiveView: View {
     }
 
     private var connectionModeColor: Color {
-        if activeConnection && live.encryptedBond { return StrandPalette.accent }
+        if (activeConnection && live.encryptedBond) || ringStreaming { return StrandPalette.accent }
         if activeConnection || live.connected { return StrandPalette.statusWarning }
         return StrandPalette.metricRose
     }
@@ -224,6 +232,7 @@ struct LiveView: View {
         let (label, color): (String, Color) =
             (activeConnection && live.encryptedBond) ? (String(localized: "Bonded · streaming"), StrandPalette.accent)
             : activeConnection ? (String(localized: "Live HR (not fully paired)"), StrandPalette.statusWarning)
+            : ringStreaming ? (String(localized: "Streaming"), StrandPalette.accent)
             : live.connected ? (String(localized: "Connected"), StrandPalette.statusWarning)
             : live.encryptedBond ? (String(localized: "Paired · idle"), StrandPalette.statusWarning)
             : (String(localized: "Disconnected"), StrandPalette.metricRose)
@@ -820,6 +829,8 @@ private struct LivePhysiology: View {
     @EnvironmentObject private var live: LiveState
 
     private var activeConnection: Bool { live.connected && live.bonded }
+    /// Oura ring actively streaming live HR — trusted stream without a WHOOP bond (see LiveView.ringStreaming).
+    private var ringStreaming: Bool { live.connected && live.streamingLiveHR }
 
     /// The liquid heart pink (matches LiquidThread's default + the mockup #ff6b81).
     private let liquidHeart = Color(.sRGB, red: 1, green: 107 / 255, blue: 129 / 255, opacity: 1)
@@ -929,7 +940,7 @@ private struct LivePhysiology: View {
 
     private var connectionModeDetail: String {
         if activeConnection && live.encryptedBond { return String(localized: "Full strap stream is active.") }
-        if activeConnection { return String(localized: "Heart rate stream is active.") }
+        if activeConnection || ringStreaming { return String(localized: "Heart rate stream is active.") }
         if live.connected { return String(localized: "Radio connected, stream not yet trusted.") }
         return String(localized: "No live stream.")
     }
@@ -942,6 +953,8 @@ private struct LiveSignalTrustRail: View {
     let activeConnection: Bool
 
     private var displayHR: Int? { model.bpm }
+    /// Oura ring actively streaming live HR — trusted stream without a WHOOP bond (see LiveView.ringStreaming).
+    private var ringStreaming: Bool { live.connected && live.streamingLiveHR }
 
     var body: some View {
         LazyVGrid(columns: [GridItem(.adaptive(minimum: 168), spacing: NoopMetrics.gap)],
@@ -954,7 +967,7 @@ private struct LiveSignalTrustRail: View {
     }
 
     private var connectionModeColor: Color {
-        if activeConnection && live.encryptedBond { return StrandPalette.accent }
+        if (activeConnection && live.encryptedBond) || ringStreaming { return StrandPalette.accent }
         if activeConnection || live.connected { return StrandPalette.statusWarning }
         return StrandPalette.metricRose
     }
@@ -984,7 +997,7 @@ private struct LiveSignalTrustRail: View {
         [
             .init(title: String(localized: "Heart rate"),
                   value: displayHR.map { "\($0) bpm" } ?? String(localized: "Missing"),
-                  detail: activeConnection ? String(localized: "Streaming now") : String(localized: "No active stream"),
+                  detail: (activeConnection || ringStreaming) ? String(localized: "Streaming now") : String(localized: "No active stream"),
                   icon: "waveform.path.ecg",
                   tint: displayHR == nil ? StrandPalette.textTertiary : StrandPalette.accent,
                   frac: displayHR.map { min(1, Double($0) / Double(max(1, model.profile.hrMax))) }),
@@ -995,11 +1008,11 @@ private struct LiveSignalTrustRail: View {
                   tint: live.rrRecent.isEmpty ? StrandPalette.textTertiary : StrandPalette.metricCyan,
                   frac: live.rrRecent.isEmpty ? nil : min(1, Double(live.rrRecent.count) / 30)),
             .init(title: String(localized: "Connection"),
-                  value: activeConnection && live.encryptedBond ? String(localized: "Encrypted") : activeConnection ? String(localized: "Partial") : live.connected ? String(localized: "Connected") : String(localized: "Offline"),
-                  detail: activeConnection && live.encryptedBond ? String(localized: "Controls unlocked") : String(localized: "Standard HR is not a full bond"),
+                  value: activeConnection && live.encryptedBond ? String(localized: "Encrypted") : activeConnection ? String(localized: "Partial") : ringStreaming ? String(localized: "Streaming") : live.connected ? String(localized: "Connected") : String(localized: "Offline"),
+                  detail: activeConnection && live.encryptedBond ? String(localized: "Controls unlocked") : ringStreaming ? String(localized: "Authenticated ring stream") : String(localized: "Standard HR is not a full bond"),
                   icon: "lock.shield",
                   tint: connectionModeColor,
-                  frac: activeConnection && live.encryptedBond ? 1 : activeConnection ? 0.66 : live.connected ? 0.33 : nil),
+                  frac: activeConnection && live.encryptedBond ? 1 : activeConnection ? 0.66 : ringStreaming ? 0.66 : live.connected ? 0.33 : nil),
             .init(title: String(localized: "History sync"),
                   value: live.backfilling ? String(localized: "\(live.syncChunksThisSession) chunks") : LiveSyncFormat.lastSyncLabel(live.lastSyncedAt),
                   detail: syncDetail,


### PR DESCRIPTION
## What this PR does
The fix

  In Strand/Screens/LiveView.swift I added a display-only predicate:

  private var ringStreaming: Bool { live.connected && live.streamingLiveHR }

  and taught the status layer to treat it as a trusted live stream, across all the places that were WHOOP-only:

  - Detail caption → "Heart rate stream is active." (instead of "not yet trusted")
  - Connection pill → green "Streaming" (instead of amber "Connected")
  - Mode badge → "STREAMING" (instead of "CONNECTING")
  - Mode color → accent/green (instead of amber)
  - Signal-trust tiles → Heart rate "Streaming now", Connection "Streaming / Authenticated ring stream"

  Crucially, I left activeConnection itself untouched, so the actual bond-only feature gates (buzz, alarm, HRV snapshot, encrypted control) still correctly key off the
  WHOOP bond — the ring shouldn't claim those.

  One caveat I intentionally left alone

  The Wear state / Worn stats still gate on activeConnection, so they'll read "Unknown" for the ring. I didn't route those through ringStreaming because I couldn't
  confirm the Oura path drives live.worn (WRIST_ON/OFF) — showing a false "On wrist" would be worse than "Unknown". If the ring does report wear, say the word and I'll
  wire those up too.


## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] CI / tooling

## How it was tested

<!--
For anything on the BLE path, say what you tested on real hardware and which
strap (4.0 / 5.0 / MG). For protocol or analytics changes, point to the test
that covers it. "Builds and unit tests pass" alone is not enough for BLE work.
-->

## Checklist

- [ ] Swift package tests pass for any package I touched (`swift test` in `Packages/<name>`)
- [ ] Android unit tests pass if I touched `android/` (`./gradlew testFullDebugUnitTest`)
- [ ] No new build warnings introduced
- [ ] UI changes use only `StrandDesign` tokens — no hardcoded colors, fonts, or spacing
- [ ] No hardcoded hex frame bytes; protocol facts live in the schema / decoders
- [ ] Follows the conventions in [`docs/CONTRIBUTING.md`](../docs/CONTRIBUTING.md)
- [ ] I did not commit generated output (`Strand.xcodeproj/`) or any secrets/keystores

## Related issues

<!-- Closes #N -->
