### PR TITLE
CI: build the macOS app as a universal binary (x86_64 + arm64) (#51)

### DIFF
--- a/.github/workflows/app-build.yml
+++ b/.github/workflows/app-build.yml
@@ -42,10 +42,15 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          # #51: the macOS build must be universal — 'platform=macOS' on an Apple-Silicon runner thins to
+          # arm64-only. Use the generic destination + explicit ARCHS so this CI verify catches an x86_64
+          # break at PR time (matches the release/testing workflows).
           - scheme: Strand
-            destination: 'platform=macOS'
+            destination: 'generic/platform=macOS'
+            extra_args: 'ARCHS="x86_64 arm64" ONLY_ACTIVE_ARCH=NO'
           - scheme: NOOPiOS
             destination: 'generic/platform=iOS Simulator'
+            extra_args: ''
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -59,6 +64,6 @@ jobs:
       - name: Build ${{ matrix.scheme }}
         run: >-
           xcodebuild -scheme '${{ matrix.scheme }}' -configuration Debug
-          -destination '${{ matrix.destination }}'
+          -destination '${{ matrix.destination }}' ${{ matrix.extra_args }}
           CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO
           build

--- a/.github/workflows/fork-release.yml
+++ b/.github/workflows/fork-release.yml
@@ -187,12 +187,25 @@ jobs:
         run: brew install xcodegen
       - name: Generate Xcode project
         run: xcodegen generate
-      - name: Build NOOP.app (macOS, unsigned)
+      - name: Build NOOP.app (macOS, unsigned, universal)
+        # #51: 'platform=macOS' on an Apple-Silicon runner resolves to the host arch and thins the binary to
+        # arm64-only (project.yml's ONLY_ACTIVE_ARCH: NO is set only under configs.Release, so the Debug build
+        # inherits the default YES). That shipped an arm64-only app that won't launch on Intel Macs. Force a
+        # true universal build with the generic destination + explicit ARCHS/ONLY_ACTIVE_ARCH; these
+        # command-line settings override the config, so it stays Debug (unchanged shipping behaviour).
         run: >-
-          xcodebuild -scheme Strand -configuration Debug -destination 'platform=macOS'
+          xcodebuild -scheme Strand -configuration Debug
+          -destination 'generic/platform=macOS' ARCHS="x86_64 arm64" ONLY_ACTIVE_ARCH=NO
           -derivedDataPath build/dd
           CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY=""
           build
+      - name: Verify universal binary
+        run: |
+          APP=$(find build/dd/Build/Products -maxdepth 3 -name '*.app' -type d | head -1)
+          EXE="$APP/Contents/MacOS/$(defaults read "$APP/Contents/Info" CFBundleExecutable)"
+          echo "archs: $(lipo -archs "$EXE")"
+          { lipo -archs "$EXE" | grep -q x86_64 && lipo -archs "$EXE" | grep -q arm64; } \
+            || { echo "::error::macOS binary is not universal (expected x86_64 + arm64)"; exit 1; }
       - name: Package + attach
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/fork-release.yml
+++ b/.github/workflows/fork-release.yml
@@ -202,9 +202,9 @@ jobs:
       - name: Verify universal binary
         run: |
           APP=$(find build/dd/Build/Products -maxdepth 3 -name '*.app' -type d | head -1)
-          EXE="$APP/Contents/MacOS/$(defaults read "$APP/Contents/Info" CFBundleExecutable)"
+          EXE=$(find "$APP/Contents/MacOS" -maxdepth 1 -type f ! -name '*.dylib' | head -1)
           echo "archs: $(lipo -archs "$EXE")"
-          { lipo -archs "$EXE" | grep -q x86_64 && lipo -archs "$EXE" | grep -q arm64; } \
+          { lipo -archs "$EXE" | grep -qw x86_64 && lipo -archs "$EXE" | grep -qw arm64; } \
             || { echo "::error::macOS binary is not universal (expected x86_64 + arm64)"; exit 1; }
       - name: Package + attach
         env:

--- a/.github/workflows/fork-testing-build.yml
+++ b/.github/workflows/fork-testing-build.yml
@@ -92,12 +92,22 @@ jobs:
         run: brew install xcodegen
       - name: Generate Xcode project
         run: xcodegen generate
-      - name: Build NOOP.app (macOS, unsigned)
+      - name: Build NOOP.app (macOS, unsigned, universal)
+        # #51: force a true universal (x86_64 + arm64) build — 'platform=macOS' on an Apple-Silicon runner
+        # thins to arm64-only. Mirrors the release workflow so testing builds match what ships.
         run: >-
-          xcodebuild -scheme Strand -configuration Debug -destination 'platform=macOS'
+          xcodebuild -scheme Strand -configuration Debug
+          -destination 'generic/platform=macOS' ARCHS="x86_64 arm64" ONLY_ACTIVE_ARCH=NO
           -derivedDataPath build/dd
           CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY=""
           build
+      - name: Verify universal binary
+        run: |
+          APP=$(find build/dd/Build/Products -maxdepth 3 -name '*.app' -type d | head -1)
+          EXE="$APP/Contents/MacOS/$(defaults read "$APP/Contents/Info" CFBundleExecutable)"
+          echo "archs: $(lipo -archs "$EXE")"
+          { lipo -archs "$EXE" | grep -q x86_64 && lipo -archs "$EXE" | grep -q arm64; } \
+            || { echo "::error::macOS binary is not universal (expected x86_64 + arm64)"; exit 1; }
       - name: Package + attach
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/fork-testing-build.yml
+++ b/.github/workflows/fork-testing-build.yml
@@ -104,9 +104,9 @@ jobs:
       - name: Verify universal binary
         run: |
           APP=$(find build/dd/Build/Products -maxdepth 3 -name '*.app' -type d | head -1)
-          EXE="$APP/Contents/MacOS/$(defaults read "$APP/Contents/Info" CFBundleExecutable)"
+          EXE=$(find "$APP/Contents/MacOS" -maxdepth 1 -type f ! -name '*.dylib' | head -1)
           echo "archs: $(lipo -archs "$EXE")"
-          { lipo -archs "$EXE" | grep -q x86_64 && lipo -archs "$EXE" | grep -q arm64; } \
+          { lipo -archs "$EXE" | grep -qw x86_64 && lipo -archs "$EXE" | grep -qw arm64; } \
             || { echo "::error::macOS binary is not universal (expected x86_64 + arm64)"; exit 1; }
       - name: Package + attach
         env:


### PR DESCRIPTION
## Problem

The shipped macOS app is **arm64-only** and won't launch on Intel Macs. Confirmed against the released **v8.3.4** zip:

```
NOOP Staging.app/Contents/MacOS/NOOP Staging: Mach-O 64-bit arm64 executable
```

No x86_64 slice anywhere in the bundle. (Reported in #51.)

## Root cause

The macOS build used `-destination 'platform=macOS'`, which on the Apple-Silicon runners resolves to the *host* arch and thins the binary. `project.yml`'s `ONLY_ACTIVE_ARCH: NO` is set **only under `configs.Release`**, so the `-configuration Debug` build inherited the default `YES` → arm64-only.

## Fix

Force a true universal build in all three macOS workflows (`fork-release`, `fork-testing-build`, `app-build`) with the generic destination + explicit archs:

```
-destination 'generic/platform=macOS' ARCHS="x86_64 arm64" ONLY_ACTIVE_ARCH=NO
```

These are command-line build settings that override the project config, so the configuration stays **Debug** and nothing else about the shipping build changes (same signing flags, same output path, same package step). Also added a `lipo -archs` guard to the release + testing jobs that **fails the build if the binary isn't universal**, so this can't silently regress again.

## Verification

Dispatched a testing build off this branch; the new "Verify universal binary" step confirms `x86_64 + arm64` (see run). The minimal-scope approach was chosen deliberately over a broader refactor — this is only the arch flags, no config/signing/bundle-name changes.

Fixes #51.