### PR TITLE
Android: recognize the Oura ring's live stream as trusted in the Live console (#56 parity)

### DIFF
--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -201,7 +201,8 @@ data class LiveState(
     /** Blank all live biometric readouts (HR + R-R + the rolling buffer) so a stale heart rate or R-R
      *  strip can't outlive the link. Applied on disconnect alongside the charging/bond clears. Twin of
      *  macOS LiveState.clearBiometrics (PR#191). */
-    fun clearedBiometrics(): LiveState = copy(heartRate = null, rr = emptyList(), rrRecent = emptyList())
+    fun clearedBiometrics(): LiveState = copy(heartRate = null, rr = emptyList(), rrRecent = emptyList(),
+                                              streamingLiveHR = false)   // #56: a dropped link is no longer streaming
 }
 
 /**
@@ -1027,7 +1028,13 @@ class WhoopBleClient(
     fun publishExternalLiveHr(hr: Int, rr: List<Int>) {
         if (rr.isNotEmpty()) _state.update { it.withRRIntervals(rr) }
         if (hr in 30..220) {
-            _state.update { it.copy(heartRate = hr, connected = true) }
+            // #56: a non-WHOOP source (the Oura ring, an FTMS machine, a generic HR strap) is actively
+            // streaming live HR. Set streamingLiveHR so the Live console reads it as a trusted stream
+            // instead of "connecting / not trusted" — this seam is invoked ONLY when WHOOP's own BLE is
+            // paused, so it never sets the flag for a WHOOP. `bonded` stays false (no encrypted bond), so
+            // the buzz/alarm/HRV feature gates keep keying off the WHOOP bond. Twin of iOS OuraLiveSource
+            // → LiveState.streamingLiveHR (PR #56).
+            _state.update { it.copy(heartRate = hr, connected = true, streamingLiveHR = true) }
         }
     }
 
@@ -1716,7 +1723,7 @@ class WhoopBleClient(
             // teardownAfterGattFailure → handleDisconnect already publishes connected=false; make the
             // "off" reason explicit for the UI so it reads "Bluetooth is off" rather than "Reconnecting…".
             _state.update { it.copy(
-                connected = false, scanning = false,
+                connected = false, scanning = false, streamingLiveHR = false,   // #56: keep streamingLiveHR ⟹ connected
                 statusNote = "Bluetooth is off. Turn it on to reconnect.",
             ) }
         }
@@ -1784,6 +1791,7 @@ class WhoopBleClient(
         disconnect()
         lastDevice = null   // don't auto-reconnect to the old strap; the next connect scans for the new model
         _state.update { it.copy(connected = false, bonded = false, encryptedBond = false,
+                                streamingLiveHR = false,   // #56: a device switch drops any external stream too
                                 r22FlagsAccepted = 0, deepPacketsThisSession = 0) }   // #174 reset per session
     }
 

--- a/android/app/src/main/java/com/noop/ui/LiveScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/LiveScreen.kt
@@ -742,6 +742,7 @@ private fun ConsoleHeader(live: LiveState, activeConnection: Boolean) {
                 live.encryptedBond && live.backfilling -> "Bonded · syncing" to StrandTone.Accent
                 live.encryptedBond -> "Bonded" to StrandTone.Positive
                 live.bonded -> "Live HR (not fully paired)" to StrandTone.Warning
+                ringStreaming(live) -> "Streaming" to StrandTone.Positive   // #56: trusted non-WHOOP stream
                 live.connected -> "Connected" to StrandTone.Warning
                 live.scanning -> "Searching…" to StrandTone.Warning
                 else -> "Disconnected" to StrandTone.Critical
@@ -857,9 +858,18 @@ private fun OfflineConnectCallout(scanning: Boolean, onConnect: () -> Unit) {
     }
 }
 
+/** #56: a non-WHOOP live source (the Oura ring, and on Android any external HR source that drives
+ *  [LiveState.streamingLiveHR]) that is connected and actively streaming live HR. It streams without a
+ *  WHOOP encrypted bond, so `bonded`/`activeConnection` never trip — which left the console reading
+ *  "stream not yet trusted" for a perfectly good stream. The status copy treats this as a trusted stream;
+ *  the bond-only feature gates (buzz, alarm, HRV snapshot) keep keying off `activeConnection`. Twin of the
+ *  iOS LiveView.ringStreaming. */
+private fun ringStreaming(live: LiveState): Boolean = live.connected && live.streamingLiveHR
+
 private fun connectionModeBadge(live: LiveState, activeConnection: Boolean): String = when {
     activeConnection && live.encryptedBond -> "FULL BOND"
     activeConnection -> "LIVE HR ONLY"
+    ringStreaming(live) -> "STREAMING"
     live.connected -> "CONNECTING"
     live.encryptedBond -> "PAIRED"
     else -> "OFFLINE"
@@ -871,7 +881,7 @@ private fun showsModeBadge(live: LiveState, activeConnection: Boolean): Boolean 
     !(!activeConnection && !live.connected && !live.encryptedBond)
 
 private fun connectionModeColor(live: LiveState, activeConnection: Boolean): Color = when {
-    activeConnection && live.encryptedBond -> Palette.accent
+    (activeConnection && live.encryptedBond) || ringStreaming(live) -> Palette.accent
     activeConnection || live.connected -> Palette.statusWarning
     else -> Palette.metricRose
 }
@@ -1115,7 +1125,7 @@ private fun signalTiles(live: LiveState, bpm: Int?, activeConnection: Boolean): 
     SignalTile(
         "Heart rate",
         bpm?.let { "$it bpm" } ?: "Missing",
-        if (activeConnection) "Streaming now" else "No active stream",
+        if (activeConnection || ringStreaming(live)) "Streaming now" else "No active stream",
         if (bpm == null) Palette.textTertiary else Palette.accent,
     ),
     SignalTile(
@@ -1129,10 +1139,15 @@ private fun signalTiles(live: LiveState, bpm: Int?, activeConnection: Boolean): 
         when {
             activeConnection && live.encryptedBond -> "Encrypted"
             activeConnection -> "Partial"
+            ringStreaming(live) -> "Streaming"
             live.connected -> "Connected"
             else -> "Offline"
         },
-        if (activeConnection && live.encryptedBond) "Controls unlocked" else "Standard HR is not a full bond",
+        when {
+            activeConnection && live.encryptedBond -> "Controls unlocked"
+            ringStreaming(live) -> "Live stream, no WHOOP bond"
+            else -> "Standard HR is not a full bond"
+        },
         connectionModeColor(live, activeConnection),
     ),
     SignalTile(
@@ -1191,7 +1206,7 @@ private fun signalTrustSummary(live: LiveState, activeConnection: Boolean): Stri
 
 private fun connectionModeDetail(live: LiveState, activeConnection: Boolean): String = when {
     activeConnection && live.encryptedBond -> "Full strap stream is active."
-    activeConnection -> "Heart rate stream is active."
+    activeConnection || ringStreaming(live) -> "Heart rate stream is active."
     live.connected -> "Radio connected, stream not yet trusted."
     else -> "No live stream."
 }


### PR DESCRIPTION
## What / why

iOS **PR #56** (pipiche38) makes the Live view treat an actively-streaming non-WHOOP source (the Oura ring) as a **trusted stream** instead of "connecting / not yet trusted". Android had the **identical** WHOOP-only status logic (`LiveScreen.kt`: `CONNECTING`, `stream not yet trusted`, `No active stream`), so an Oura ring looked unconnected there too.

But it couldn't be fixed by copy alone: `LiveState.streamingLiveHR` on Android was an **unfilled stub** (hardcoded `false`, nothing set it) — the ring's HR reaches the UI via `publishExternalLiveHr`, which set `connected = true` but never `streamingLiveHR`. So this PR is two parts.

## 1. Plumb the signal

- `publishExternalLiveHr` (the non-WHOOP live-HR seam — invoked **only** while WHOOP's own BLE is paused) now sets `streamingLiveHR = true`.
- `clearedBiometrics()` (the three teardowns) + the two remaining `connected = false` transitions clear it, so the invariant **`streamingLiveHR ⟹ connected`** always holds (no stale flag leaking into a later WHOOP connect).
- `bonded` stays false → the buzz / alarm / HRV feature gates keep keying off the WHOOP bond. The ring never claims those.

## 2. Status copy (mirrors iOS #56)

A `ringStreaming = connected && streamingLiveHR` predicate feeds the mode badge (**STREAMING**), the pill (**Streaming**, green), the mode colour (accent), the detail (**"Heart rate stream is active."**), and the signal-trust tiles (Heart rate **"Streaming now"**, Connection **"Streaming" / "Live stream, no WHOOP bond"**). Every `ringStreaming` branch sits **after** the WHOOP `activeConnection` checks, so a bonded WHOOP is unaffected.

## Notes

- On Android the signal is driven for **any** external live source (Oura ring, FTMS machine, generic HR strap) — a superset of iOS's Oura-only, and correct for all of them.
- Android-only; compiles (`compileFullReleaseKotlin`) and the BLE unit tests pass locally.
- Pairs with iOS #56; together they close the ring-stream status gap on both platforms.