### PR TITLE
docs: repoint dead NoopApp/noop links to ryanbr/noop (curated from #54)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -7,16 +7,16 @@ body:
       value: |
         ### 💬 Just have a question, or "how do I…"?
         **Stop — this form is only for confirmed bugs.** If you want help, want to know how something works, or you're not sure it's a bug, you'll get a faster answer here:
-        - **[Discussions](https://github.com/NoopApp/noop/discussions)** — questions, ideas, "is this normal?", feature requests.
+        - **[Discussions](https://github.com/ryanbr/noop/discussions)** — questions, ideas, "is this normal?", feature requests.
         - **[Discord](https://discord.com/invite/nHK9FHczu)** — the quickest place for a quick question or setup help.
 
         Please use those instead of opening an issue. A question filed as a bug just gets pointed back here, so you'll get sorted faster by starting in the right place. 🙏
 
         ### ⛔ Next — is this already answered?
         Many "bugs" are expected behaviour or a known limit. **Please check these before filing — it's the fastest way to an answer:**
-        - **[FAQ](https://github.com/NoopApp/noop/wiki/FAQ)** — live HR, recovery/sleep, steps, importing, privacy, updates.
-        - **[WHOOP 5.0 / MG status](https://github.com/NoopApp/noop/wiki/WHOOP-5.0-and-MG-Status)** — SpO₂, steps, recovery/sleep on the newer straps (the most common topic).
-        - **[Troubleshooting](https://github.com/NoopApp/noop/wiki/Troubleshooting)** — pairing, "syncs but no data", generic HR straps.
+        - **[FAQ](https://github.com/ryanbr/noop/wiki/FAQ)** — live HR, recovery/sleep, steps, importing, privacy, updates.
+        - **[WHOOP 5.0 / MG status](https://github.com/ryanbr/noop/wiki/WHOOP-5.0-and-MG-Status)** — SpO₂, steps, recovery/sleep on the newer straps (the most common topic).
+        - **[Troubleshooting](https://github.com/ryanbr/noop/wiki/Troubleshooting)** — pairing, "syncs but no data", generic HR straps.
 
         ---
 
@@ -145,9 +145,9 @@ body:
           required: true
         - label: I attached or pasted a strap log above — **or** my bug is a clearly reproducible UI issue that doesn't need one (e.g. a typo, a button that does nothing) and I've described exactly how to see it.
           required: true
-        - label: I checked the [Troubleshooting guide](https://github.com/NoopApp/noop/wiki/Troubleshooting) — especially "history syncs but no data" (most often the strap isn't banking history to flash; charge it to 100% and reconnect).
+        - label: I checked the [Troubleshooting guide](https://github.com/ryanbr/noop/wiki/Troubleshooting) — especially "history syncs but no data" (most often the strap isn't banking history to flash; charge it to 100% and reconnect).
           required: true
-        - label: I checked the [FAQ](https://github.com/NoopApp/noop/wiki/FAQ) and — if I'm on a WHOOP 5.0 / MG — the [5.0/MG status page](https://github.com/NoopApp/noop/wiki/WHOOP-5.0-and-MG-Status), and this isn't an already-known limit (e.g. SpO₂, or recovery/sleep on the 5/MG).
+        - label: I checked the [FAQ](https://github.com/ryanbr/noop/wiki/FAQ) and — if I'm on a WHOOP 5.0 / MG — the [5.0/MG status page](https://github.com/ryanbr/noop/wiki/WHOOP-5.0-and-MG-Status), and this isn't an already-known limit (e.g. SpO₂, or recovery/sleep on the 5/MG).
           required: true
         - label: I've left out anything personal (strap serial, account email, raw export).
           required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -4,16 +4,16 @@ contact_links:
     url: https://discord.com/invite/nHK9FHczu
     about: "Got a question, stuck on setup, or not sure something's a bug? Discord is the fastest place for a quick answer. (Confirmed bugs still go to a GitHub issue, with a strap log.)"
   - name: ❓ FAQ — start here (most questions are answered)
-    url: https://github.com/NoopApp/noop/wiki/FAQ
+    url: https://github.com/ryanbr/noop/wiki/FAQ
     about: "Live HR, recovery/sleep, steps, importing data, privacy, updates — the common questions are answered here. Please check before filing."
   - name: ⌚ WHOOP 5.0 / MG — what works & what doesn't
-    url: https://github.com/NoopApp/noop/wiki/WHOOP-5.0-and-MG-Status
+    url: https://github.com/ryanbr/noop/wiki/WHOOP-5.0-and-MG-Status
     about: "SpO₂, steps, recovery/sleep on the 5.0 and MG — what's supported today, what's still being decoded, and why. Read this before reporting a 5/MG issue."
   - name: 🔧 Troubleshooting — pairing, sync & no-data
-    url: https://github.com/NoopApp/noop/wiki/Troubleshooting
+    url: https://github.com/ryanbr/noop/wiki/Troubleshooting
     about: '"History syncs but no data", pairing/bond failures, generic heart-rate straps, "no recovery/sleep" — most connection issues are solved here first.'
   - name: 💡 Feature ideas & questions — Discussions
-    url: https://github.com/NoopApp/noop/discussions
+    url: https://github.com/ryanbr/noop/discussions
     about: "Got an idea, or not sure if something's a bug? Open a Discussion. Issues are for confirmed bugs with a strap log."
   - name: 👽 Community, tips & release news — r/NOOPApp
     url: https://www.reddit.com/r/NOOPApp/

--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@
 </p>
 
 <p align="center">
-  <a href="https://github.com/ryanbr/noop/releases/latest"><img alt="Latest release" src="https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2FNoopApp%2Fnoop%2Fmain%2Fdocs%2Fstats%2Frelease.json&style=flat-square"></a>
-  <a href="https://github.com/ryanbr/noop/stargazers"><img alt="Stars" src="https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2FNoopApp%2Fnoop%2Fmain%2Fdocs%2Fstats%2Fstars.json&style=flat-square"></a>
+  <a href="https://github.com/ryanbr/noop/releases/latest"><img alt="Latest release" src="https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Fryanbr%2Fnoop%2Fmain%2Fdocs%2Fstats%2Frelease.json&style=flat-square"></a>
+  <a href="https://github.com/ryanbr/noop/stargazers"><img alt="Stars" src="https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Fryanbr%2Fnoop%2Fmain%2Fdocs%2Fstats%2Fstars.json&style=flat-square"></a>
 </p>
 
 <p align="center">
@@ -53,8 +53,8 @@
 Pre-built apps you can run right now:
 
 <p>
-  <a href="https://github.com/ryanbr/noop/releases/latest"><img alt="Version" src="https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2FNoopApp%2Fnoop%2Fmain%2Fdocs%2Fstats%2Frelease.json&style=flat-square"></a>
-  <img alt="Released" src="https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2FNoopApp%2Fnoop%2Fmain%2Fdocs%2Fstats%2Freleased.json&style=flat-square">
+  <a href="https://github.com/ryanbr/noop/releases/latest"><img alt="Version" src="https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Fryanbr%2Fnoop%2Fmain%2Fdocs%2Fstats%2Frelease.json&style=flat-square"></a>
+  <img alt="Released" src="https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Fryanbr%2Fnoop%2Fmain%2Fdocs%2Fstats%2Freleased.json&style=flat-square">
 </p>
 
 | Platform | Build | Notes |
@@ -222,8 +222,8 @@ with the strap and **score recovery, strain and sleep on your own device** — n
 import required.
 
 <p>
-  <a href="https://github.com/ryanbr/noop/releases/latest"><img alt="Latest across all platforms" src="https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2FNoopApp%2Fnoop%2Fmain%2Fdocs%2Fstats%2Frelease.json&style=flat-square"></a>
-  <img alt="Commits per month" src="https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2FNoopApp%2Fnoop%2Fmain%2Fdocs%2Fstats%2Flastcommit.json&style=flat-square">
+  <a href="https://github.com/ryanbr/noop/releases/latest"><img alt="Latest across all platforms" src="https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Fryanbr%2Fnoop%2Fmain%2Fdocs%2Fstats%2Frelease.json&style=flat-square"></a>
+  <img alt="Commits per month" src="https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Fryanbr%2Fnoop%2Fmain%2Fdocs%2Fstats%2Flastcommit.json&style=flat-square">
   <img alt="Top language" src="https://img.shields.io/badge/languages-Swift%20%C2%B7%20Kotlin-E8B84B?style=flat-square">
   <img alt="Code size" src="https://img.shields.io/badge/build-from%20source-6B737B?style=flat-square">
 </p>
@@ -545,12 +545,12 @@ forward. Huge thanks to everyone filing reports, sharing strap logs, and reverse
 protocol alongside us — this project is built on it.
 
 <p>
-  <img alt="Open issues" src="https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2FNoopApp%2Fnoop%2Fmain%2Fdocs%2Fstats%2Fopen.json&style=flat-square">
-  <img alt="Issues resolved" src="https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2FNoopApp%2Fnoop%2Fmain%2Fdocs%2Fstats%2Fresolved.json&style=flat-square">
-  <a href="https://github.com/ryanbr/noop/stargazers"><img alt="Stars" src="https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2FNoopApp%2Fnoop%2Fmain%2Fdocs%2Fstats%2Fstars.json&style=flat-square"></a>
-  <img alt="Forks" src="https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2FNoopApp%2Fnoop%2Fmain%2Fdocs%2Fstats%2Fforks.json&style=flat-square">
-  <img alt="Commits per month" src="https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2FNoopApp%2Fnoop%2Fmain%2Fdocs%2Fstats%2Flastcommit.json&style=flat-square">
-  <img alt="Last commit" src="https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2FNoopApp%2Fnoop%2Fmain%2Fdocs%2Fstats%2Flastcommit.json&style=flat-square">
+  <img alt="Open issues" src="https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Fryanbr%2Fnoop%2Fmain%2Fdocs%2Fstats%2Fopen.json&style=flat-square">
+  <img alt="Issues resolved" src="https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Fryanbr%2Fnoop%2Fmain%2Fdocs%2Fstats%2Fresolved.json&style=flat-square">
+  <a href="https://github.com/ryanbr/noop/stargazers"><img alt="Stars" src="https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Fryanbr%2Fnoop%2Fmain%2Fdocs%2Fstats%2Fstars.json&style=flat-square"></a>
+  <img alt="Forks" src="https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Fryanbr%2Fnoop%2Fmain%2Fdocs%2Fstats%2Fforks.json&style=flat-square">
+  <img alt="Commits per month" src="https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Fryanbr%2Fnoop%2Fmain%2Fdocs%2Fstats%2Flastcommit.json&style=flat-square">
+  <img alt="Last commit" src="https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Fryanbr%2Fnoop%2Fmain%2Fdocs%2Fstats%2Flastcommit.json&style=flat-square">
 </p>
 
 ![Repobeats analytics image](https://repobeats.axiom.co/api/embed/97acba228c083adca8453a1ebf15f18dad2894be.svg "Repobeats analytics image")

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,7 +1,7 @@
 # Getting help with NOOP
 
-- **🐞 Bugs → open a [GitHub issue](https://github.com/NoopApp/noop/issues/new/choose).** There's a template, and bugs are tracked, deduped and linked to fixes here. Include your **NOOP version**, **platform** and **strap model**, plus a **strap log** — NOOP runs entirely on your device, so without one we usually can't tell a real fault from a setup detail. (Android: **Settings → Strap → "Share strap log (for bug reports)"**; macOS: the **Live** screen → **Strap log** card → **Copy**/**Save…**.)
-- **💬 Questions, ideas & how-you-can-help → [GitHub Discussions](https://github.com/NoopApp/noop/discussions).** Ask, share results, and see [exactly what data would move NOOP forward](https://github.com/NoopApp/noop/discussions/147).
+- **🐞 Bugs → open a [GitHub issue](https://github.com/ryanbr/noop/issues/new/choose).** There's a template, and bugs are tracked, deduped and linked to fixes here. Include your **NOOP version**, **platform** and **strap model**, plus a **strap log** — NOOP runs entirely on your device, so without one we usually can't tell a real fault from a setup detail. (Android: **Settings → Strap → "Share strap log (for bug reports)"**; macOS: the **Live** screen → **Strap log** card → **Copy**/**Save…**.)
+- **💬 Questions, ideas & how-you-can-help → [GitHub Discussions](https://github.com/ryanbr/noop/discussions).** Ask, share results, and see [exactly what data would move NOOP forward](https://github.com/ryanbr/noop/discussions/147).
 - **📣 Setup help, tips & release news → [r/NOOPApp](https://www.reddit.com/r/NOOPApp/).** Every release is announced there too.
 - **📖 Docs → the [README](README.md)** covers install (macOS Gatekeeper / Android Play Protect), pairing a WHOOP 5.0/MG, privacy, and importing your history.
 - **📧 Other → thenoopapp@gmail.com**

--- a/Tools/refresh-stats-badges.py
+++ b/Tools/refresh-stats-badges.py
@@ -4,14 +4,14 @@
 The README shows shields.io `endpoint` badges that read these public raw JSON files, so the
 stars/forks/issue counts etc. stay current. Run on a schedule or at release time.
 
-Reads counts from the GitHub API (https://api.github.com/repos/NoopApp/noop) using the token
+Reads counts from the GitHub API (https://api.github.com/repos/ryanbr/noop) using the token
 at ~/.config/noop/gh_token. Writes the docs/stats/*.json files to the LOCAL working tree only;
 committing + pushing is left to the normal multi-push git flow (which also mirrors to noop.fans),
 so the working tree stays the single source of truth and no API-side divergence is created.
 """
 import urllib.request, urllib.error, urllib.parse, json, os
 TOK=open(os.path.expanduser("~/.config/noop/gh_token")).read().strip()
-API="https://api.github.com/repos/NoopApp/noop"
+API="https://api.github.com/repos/ryanbr/noop"
 HERE=os.path.dirname(os.path.abspath(__file__))
 ROOT=os.path.dirname(HERE)
 def req(url):
@@ -32,8 +32,8 @@ _,b=req(API); repo=json.loads(b)
 _,b=req(API+"/releases/latest"); latest=json.loads(b)
 _,b=req(API+"/commits?per_page=1"); last=json.loads(b)[0]["commit"]["author"]["date"][:10]
 # open_issues_count on the repo includes PRs; use the search API to count issues only.
-open_issues=search_count("repo:NoopApp/noop is:issue is:open")
-resolved=search_count("repo:NoopApp/noop is:issue is:closed")
+open_issues=search_count("repo:ryanbr/noop is:issue is:open")
+resolved=search_count("repo:ryanbr/noop is:issue is:closed")
 write("docs/stats/release.json","latest",latest["tag_name"],"E8B84B")
 write("docs/stats/released.json","released",(latest.get("published_at") or "")[:10],"6B737B")
 write("docs/stats/stars.json","stars",repo.get("stargazers_count",0),"E8B84B")

--- a/Tools/release.sh
+++ b/Tools/release.sh
@@ -8,7 +8,7 @@
 #          dist/NOOP-v4.7.0-macos.zip dist/NOOP-v4.7.0.ipa dist/NOOP-v4.7.0.apk \
 #          -- "Bug fixes and the new Lab Book."
 #
-# GitHub is CANONICAL — the release is created there FIRST (NoopApp/noop, marked
+# GitHub is CANONICAL — the release is created there FIRST (ryanbr/noop, marked
 # --latest). The self-hosted Forgejo is published SECOND as a mirror by handing
 # the same args straight to forgejo-release.sh. A Forgejo failure is tolerated:
 # it warns but does NOT abort or fail the run, because the GitHub release already
@@ -26,7 +26,7 @@ set -uo pipefail
 HERE="$(cd "$(dirname "$0")" && pwd)"
 
 # canonical GitHub mirror coordinates (override via env if ever needed)
-GH_REPO="${GH_REPO:-NoopApp/noop}"
+GH_REPO="${GH_REPO:-ryanbr/noop}"
 
 VER="${1:?usage: release.sh <version> <asset...> [-- notes]}"; shift
 TAG="v$VER"

--- a/Tools/update-altstore-source.sh
+++ b/Tools/update-altstore-source.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 #
 # update-altstore-source.sh <version> <ipa> [desc] — refresh altstore-source.json with a new iOS release.
-# The downloadURL points at the canonical GitHub release asset (github.com/NoopApp/noop/releases);
+# The downloadURL points at the canonical GitHub release asset (github.com/ryanbr/noop/releases);
 # noop.fans stays a mirror. Everything else reads CFBundleVersion + size from the IPA,
 # prepends/replaces apps[0].versions[0], and mirrors legacy top-level fields.
 #


### PR DESCRIPTION
## Why

The upstream **NoopApp/noop** repo has been **deleted** — `gh` can't resolve it, and `raw.githubusercontent.com/NoopApp/noop/main/docs/stats/release.json` returns **404** (the `ryanbr/noop` equivalent returns **200**). So a batch of references point at a dead repo.

## What this fixes (live 404s only)

Case-sensitive sweep of `NoopApp/noop` **and** the URL-encoded `NoopApp%2Fnoop` → `ryanbr/noop`:

- **README** — the 12 stats badges (their `img.shields.io` endpoint URLs were `…%2FNoopApp%2Fnoop%2F…` → 404).
- **Issue templates** (`bug_report.yml` + `config.yml`) — FAQ / Troubleshooting / WHOOP-5.0 / Discussions links. The fork's wiki **has** those pages (they return 302; NoopApp returns 404). *(#54 missed these.)*
- **SUPPORT.md** — issue/discussion links.
- **Tools/** — `refresh-stats-badges.py`, `release.sh`, `update-altstore-source.sh` (GitHub API / raw endpoints).

## Deliberately **not** changed

- **Homebrew** (`brew tap noopapp/noop`, `NoopApp/homebrew-noop`, `docs/HOMEBREW.md`, `update-homebrew-cask.sh`) — `ryanbr/homebrew-noop` doesn't exist yet, so repointing would swap one dead tap for another. **Follow-up:** create the tap, then update. The case-sensitive sweep left all lowercase `noopapp` and `homebrew-noop` strings intact.
- **Historical** release notes / CHANGELOG, in-app "What's New" changelog cards, and provenance comments ("recipe in NoopApp/noop PR #600") — a dated record, not live links.
- The app's **update-check + Settings** links are already `ryanbr/noop` (verified), so nothing functional in the app was broken.

## Provenance

Curated from the good parts of **#54** (royabby365) — **excludes** its unrelated 277-line Android Puffin-capture files and its brew-tap change, and **adds** the issue-template links #54 didn't cover. Docs/config/scripts only — no code, nothing to compile.