### PR TITLE
Restore: don't sync into a closed DB, and never ack past un-stored history (#57)

### DIFF
--- a/Strand/BLE/BLEManager.swift
+++ b/Strand/BLE/BLEManager.swift
@@ -1685,6 +1685,12 @@ public final class BLEManager: NSObject, ObservableObject {
             let bankedNothing = banking.bankedNothing && !productiveBurstTail
             let sustainedEmpty = productiveBurstTail ? false : emptySyncTracker.recordCompletedSync(
                 bankedSensorRecords: bankedSensorRecords, consoleOnly: banking.bankedNothing)
+            // #57 debug: write-health for the export. Distinguish "rows actually landed" from "an offload
+            // STALLED on a persist failure" — the latter (usually a restore without a restart) is otherwise
+            // invisible in a report that just shows "0 synced".
+            let du = UserDefaults.standard
+            if (backfiller?.sessionRowsPersisted ?? 0) > 0 { du.set(Date().timeIntervalSince1970, forKey: "sync.lastWriteOkAt") }
+            if backfiller?.persistStalled == true { du.set(Date().timeIntervalSince1970, forKey: "sync.lastWriteStalledAt") }
             if unarchived > 0 {
                 state.lastSyncError = "Synced, but \(archived + unarchived) record(s) couldn't be decoded (unrecognised strap firmware layout), and the on-device archive is full - the \(unarchived) newest weren't preserved. Please share a strap log so the layout can be mapped."
             } else if archived > 0 {

--- a/Strand/Collect/Backfiller.swift
+++ b/Strand/Collect/Backfiller.swift
@@ -96,8 +96,9 @@ final class Backfiller {
     /// cursor) fails this session. While set, `finishChunk` must NOT ack — not even a subsequent EMPTY END,
     /// which skips the insert and would otherwise advance the strap's trim PAST the held records-carrying
     /// chunks, freeing history we never stored. The offload stalls safely (strap keeps everything past the
-    /// last GOOD ack); a fresh session (`begin`) clears it. Twin of the Android guard.
-    private var persistStalled = false
+    /// last GOOD ack); a fresh session (`begin`) clears it. Twin of the Android guard. Exposed read-only so
+    /// the client can surface a "history isn't persisting" signal in the debug export (#57).
+    private(set) var persistStalled = false
     private(set) var sessionMotionRows = 0
     /// #727: skin-temp samples banked this session. WHOOP 4.0 carries skin temp (and the raw SpO2 channel)
     /// ONLY in its full DSP sleep records; a strap banking HR/RR-only records reports 0 here even on a

--- a/Strand/Collect/Backfiller.swift
+++ b/Strand/Collect/Backfiller.swift
@@ -92,6 +92,12 @@ final class Backfiller {
     /// Without it the fresh session's `sessionRowsPersisted` is 0 and the scary "charge to 100%" line
     /// false-fires on the empty tail of a sync that just offloaded real records.
     private(set) var continuedAfterRows = false
+    /// #57: set true the moment ANY chunk's persist (decoded rows / reject archive / raw enqueue / trim
+    /// cursor) fails this session. While set, `finishChunk` must NOT ack — not even a subsequent EMPTY END,
+    /// which skips the insert and would otherwise advance the strap's trim PAST the held records-carrying
+    /// chunks, freeing history we never stored. The offload stalls safely (strap keeps everything past the
+    /// last GOOD ack); a fresh session (`begin`) clears it. Twin of the Android guard.
+    private var persistStalled = false
     private(set) var sessionMotionRows = 0
     /// #727: skin-temp samples banked this session. WHOOP 4.0 carries skin temp (and the raw SpO2 channel)
     /// ONLY in its full DSP sleep records; a strap banking HR/RR-only records reports 0 here even on a
@@ -193,6 +199,7 @@ final class Backfiller {
         self.family = family
         self.continuedAfterRows = continuedAfterRows
         isBackfilling = true
+        persistStalled = false   // #57: fresh session starts un-stalled
         chunk.removeAll(keepingCapacity: true)
         chunkOpen = true
         sessionRowsPersisted = 0
@@ -476,6 +483,7 @@ final class Backfiller {
                 // works" class. We return WITHOUT acking so the strap keeps this chunk and re-sends it next
                 // session (no data loss), but a silent return left a strap log with no trace of the stall.
                 log?("Backfill: failed to persist decoded rows (trim=\(trim)): \(error) — holding ack so the strap re-sends this chunk; history won't advance until the write succeeds.")
+                persistStalled = true   // #57: stall ALL further acks so an empty END can't advance past this
                 return
             }
             // Success-side observability (#150): tally what actually persisted so the session can emit
@@ -499,6 +507,7 @@ final class Backfiller {
             if !rejected.isEmpty, let rejectedSink {
                 guard rejectedSink(rejected, trim, family) else {
                     log?("Backfill: rejected-frame archive failed (trim=\(trim)) — holding ack so the strap re-sends.")
+                    persistStalled = true   // #57
                     return
                 }
             }
@@ -520,6 +529,7 @@ final class Backfiller {
                     // (return) so the strap re-sends — the research toggle's contract is that raw is durable
                     // before the trim advances. Surface it so a stalled offload with raw-capture on is visible.
                     log?("Backfill: failed to enqueue raw batch (trim=\(trim)): \(error) — holding ack so the strap re-sends this chunk; raw capture must be durable before the trim advances.")
+                    persistStalled = true   // #57
                     return
                 }
             }
@@ -544,6 +554,16 @@ final class Backfiller {
             emitConnection(ConnectionTrace.noCursorLine())
         }
 
+        // #57: if an EARLIER chunk this session failed to persist, do NOT advance the cursor or ack — not
+        // even for this (possibly empty/metadata) END. An empty END skips the insert and never throws;
+        // acking it would trim the strap PAST the held records-carrying chunks, freeing history we never
+        // stored. Stall the whole offload until a fresh session with a working store re-offers everything
+        // past the last GOOD ack. Twin of the Android guard.
+        if persistStalled {
+            log?("Backfill: persist stalled earlier this session — NOT acking trim=\(trim) so the strap can't trim past un-stored history. Reconnect once the store is healthy (#57).")
+            return
+        }
+
         do { try await store.setCursor("strap_trim", Int(trim)) } catch {
             // Diag (#601): decoded (and raw, if on) are durable but the strap_trim cursor write failed. We
             // return WITHOUT acking — acking now would let the strap trim past records the cursor hasn't
@@ -551,6 +571,7 @@ final class Backfiller {
             // strap re-offers this chunk next session. A silent return here was a prime "history won't advance"
             // suspect with nothing in the log to confirm it.
             log?("Backfill: failed to write strap_trim cursor (trim=\(trim)): \(error) — holding ack so the strap re-sends this chunk; history won't advance until the cursor write succeeds.")
+            persistStalled = true   // #57
             return
         }
 

--- a/Strand/Data/DataBackup.swift
+++ b/Strand/Data/DataBackup.swift
@@ -416,6 +416,9 @@ enum DataBackup {
                     BackupSettings.apply(BackupSettings.decode(data), to: settingsDefaults)
                 }
             }
+            // #57 debug: record when a restore swapped the DB, so the export can correlate a restore with a
+            // later write stall (a restore not followed by a relaunch is the #57 failure).
+            UserDefaults.standard.set(Date().timeIntervalSince1970, forKey: "backup.lastRestoreAt")
             return .imported(sidecar: sidecar)
         } catch {
             return .failure(String(localized: "Import failed: \(error.localizedDescription)"))

--- a/Strand/System/DebugDataDiagnostics.swift
+++ b/Strand/System/DebugDataDiagnostics.swift
@@ -32,6 +32,19 @@ enum DebugDataDiagnostics {
         lines.append("Firmware:    \(d.string(forKey: "noop.lastFirmware") ?? "unknown (connect to record)")")
         let syncSec = d.double(forKey: "lastSyncedAt")
         lines.append("Last sync:   \(syncSec > 0 ? relTime(Date().timeIntervalSince1970 - syncSec) : "never")")
+        // #57: write-health. "Last sync" fires even on an empty/failed offload, so distinguish "rows
+        // actually landed" from "an offload STALLED on a persist failure" (history won't persist — usually a
+        // backup restored without an app restart, the closed-store class).
+        let now = Date().timeIntervalSince1970
+        let okAt = d.double(forKey: "sync.lastWriteOkAt")
+        let stalledAt = d.double(forKey: "sync.lastWriteStalledAt")
+        let restoreAt = d.double(forKey: "backup.lastRestoreAt")
+        lines.append("Data write:  \(okAt > 0 ? "rows last landed \(relTime(now - okAt))" : "no rows ever persisted")")
+        if stalledAt > 0, stalledAt >= okAt {
+            lines.append("             ⚠ history NOT persisting — last offload STALLED \(relTime(now - stalledAt)) "
+                + "(if you restored a backup, fully restart the app — #57)")
+        }
+        if restoreAt > 0 { lines.append("Last restore: \(relTime(now - restoreAt))") }
         lines.append("Timezone:    \(tzLine())")
         return lines
     }

--- a/android/app/src/main/java/com/noop/ble/Backfiller.kt
+++ b/android/app/src/main/java/com/noop/ble/Backfiller.kt
@@ -177,8 +177,11 @@ class Backfiller(
      *  this session. While set, [finishChunk] must NOT ack — not even a subsequent EMPTY/metadata END, which
      *  skips the insert and would otherwise advance the strap's trim PAST the held records-carrying chunks,
      *  freeing history we never stored (the closed-DB-after-restore data-loss in #57). The offload stalls
-     *  safely (strap keeps everything past the last GOOD ack); a fresh session ([begin]) clears it. */
-    private var persistStalled = false
+     *  safely (strap keeps everything past the last GOOD ack); a fresh session ([begin]) clears it.
+     *  Exposed read-only so the client can surface a "history isn't persisting" signal in the debug export
+     *  (#57 was invisible to a report — the UI just showed "0 synced"). */
+    var persistStalled = false
+        private set
     var sessionMotionRows = 0
         private set
     /**

--- a/android/app/src/main/java/com/noop/ble/Backfiller.kt
+++ b/android/app/src/main/java/com/noop/ble/Backfiller.kt
@@ -173,6 +173,12 @@ class Backfiller(
      *  false-fires on the empty tail of a sync that just offloaded real records. */
     var continuedAfterRows = false
         private set
+    /** #57: set true the moment ANY chunk's persist (decoded rows / reject archive / trim cursor) fails
+     *  this session. While set, [finishChunk] must NOT ack — not even a subsequent EMPTY/metadata END, which
+     *  skips the insert and would otherwise advance the strap's trim PAST the held records-carrying chunks,
+     *  freeing history we never stored (the closed-DB-after-restore data-loss in #57). The offload stalls
+     *  safely (strap keeps everything past the last GOOD ack); a fresh session ([begin]) clears it. */
+    private var persistStalled = false
     var sessionMotionRows = 0
         private set
     /**
@@ -253,6 +259,7 @@ class Backfiller(
         sessionMotionRows = 0
         sessionSkinTempRows = 0
         sessionNightKeys.clear()
+        persistStalled = false   // #57: fresh session starts un-stalled
         loggedNoCursor = false
         loggedFutureRtc = false
         loggedLayoutVersions.clear()
@@ -452,6 +459,7 @@ class Backfiller(
                 // session (no data loss), but a silent return left a strap log with no trace of the stall.
                 // Mirrors the Swift twin's log so a write-stall is falsifiable here too.
                 log("Backfill: failed to persist decoded rows (trim=$trim): $t, holding ack so the strap re-sends this chunk; history won't advance until the write succeeds.")
+                persistStalled = true   // #57: stall ALL further acks so an empty END can't advance past this
                 return // do NOT advance/ack, chunk was never durably committed
             }
             // #77 / #91: any genuinely-undecodable record in this chunk must be ARCHIVED durably before
@@ -463,6 +471,7 @@ class Backfiller(
             // idempotent no-op while the archive retries. No data loss either way.
             if (rejected.isNotEmpty() && !rejectedSink(rejected, trim)) {
                 log("Backfill: rejected-frame archive failed (trim=$trim) — holding ack so the strap re-sends.")
+                persistStalled = true   // #57
                 return
             }
         }
@@ -486,6 +495,17 @@ class Backfiller(
             emitConnection { com.noop.analytics.ConnectionTrace.noCursorLine() }
         }
 
+        // #57: if an EARLIER chunk this session failed to persist, do NOT advance the cursor or ack — not
+        // even for this (possibly empty/metadata) END. `insert` short-circuits empty batches without
+        // touching the store, so an empty END never throws; acking it would trim the strap PAST the held
+        // records-carrying chunks, freeing history we never stored (the closed-DB-after-restore loss). Stall
+        // the whole offload until a fresh session with a working store re-offers everything past the last
+        // GOOD ack.
+        if (persistStalled) {
+            log("Backfill: persist stalled earlier this session — NOT acking trim=$trim so the strap can't trim past un-stored history. Reconnect once the store is healthy (a backup restore needs an app restart, #57).")
+            return
+        }
+
         // Persist the trim cursor BEFORE acking (so a crash between persist and ack still resumes
         // from the right place). Stored via [TrimCursorStore] because the Room schema has no cursor
         // table — see the port FLAG. trim is a u32 carried as Long (unsigned-safe).
@@ -498,6 +518,7 @@ class Backfiller(
             // this chunk next session. A silent return here was a prime "history won't advance" suspect with
             // nothing in the log to confirm it. Mirrors the Swift twin's log.
             log("Backfill: failed to write strap_trim cursor (trim=$trim): $t, holding ack so the strap re-sends this chunk; history won't advance until the cursor write succeeds.")
+            persistStalled = true   // #57
             return
         }
 

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -4573,6 +4573,16 @@ class WhoopBleClient(
         // PR #556 reimpl: persist the HISTORY_COMPLETE instant so "Last synced N ago" survives a BLE-client
         // recreation / process restart and stops reverting to "Never".
         if (reason == "HISTORY_COMPLETE") NoopPrefs.setLastSyncAt(context, nowSec)
+        // #57 debug: write-health signal for the export. "Last sync" fires even on an empty/failed offload,
+        // so it can't distinguish "0 rows because the strap was empty" from "0 rows because writes FAILED".
+        // Record the last time rows actually landed, and the last time an offload STALLED on a persist
+        // failure (the closed-DB-after-restore class) — so a future "sync stuck at 0" report is decidable.
+        runCatching {
+            val p = NoopPrefs.of(context).edit()
+            if (backfiller.sessionRowsPersisted > 0) p.putLong("sync.lastWriteOkAt", nowSec)
+            if (backfiller.persistStalled) p.putLong("sync.lastWriteStalledAt", nowSec)
+            p.apply()
+        }
         // #580: a WHOOP 5/MG whose firmware serves no history offload (acks SEND_HISTORICAL_DATA but emits
         // zero type-0x2F frames) times out every session — but that's NOT a failure: live HR streams fine,
         // the offload is just experimental on that firmware. "Banked" = this offload made ANY offload

--- a/android/app/src/main/java/com/noop/data/DataBackup.kt
+++ b/android/app/src/main/java/com/noop/data/DataBackup.kt
@@ -319,6 +319,12 @@ object DataBackup {
 
         rollbackFile.delete()
         tempSqlite.delete()
+        // #57 debug: record when a restore swapped the DB, so the export can correlate a restore with a
+        // subsequent write stall (a restore that wasn't followed by a restart is exactly the #57 failure).
+        runCatching {
+            com.noop.ui.NoopPrefs.of(appContext).edit()
+                .putLong("backup.lastRestoreAt", System.currentTimeMillis() / 1000L).apply()
+        }
         return ImportResult.NeedsRestart
     }
 

--- a/android/app/src/main/java/com/noop/testcentre/AndroidDiagnostics.kt
+++ b/android/app/src/main/java/com/noop/testcentre/AndroidDiagnostics.kt
@@ -42,6 +42,20 @@ object AndroidDiagnostics {
             add("Firmware:    ${com.noop.ui.NoopPrefs.lastFirmware(context) ?: "unknown (connect to record)"}")
             val syncSec = com.noop.ui.NoopPrefs.lastSyncAt(context)
             add("Last sync:   ${if (syncSec > 0L) relTime(System.currentTimeMillis() - syncSec * 1000L) else "never"}")
+            // #57: write-health. "Last sync" fires even on an empty/failed offload, so distinguish "rows
+            // actually landed" from "an offload STALLED on a persist failure" (history won't persist —
+            // usually a backup restored without an app restart, the closed-DB class).
+            val p = com.noop.ui.NoopPrefs.of(context)
+            val okAt = p.getLong("sync.lastWriteOkAt", 0L)
+            val stalledAt = p.getLong("sync.lastWriteStalledAt", 0L)
+            val restoreAt = p.getLong("backup.lastRestoreAt", 0L)
+            val now = System.currentTimeMillis()
+            add("Data write:  ${if (okAt > 0L) "rows last landed ${relTime(now - okAt * 1000L)}" else "no rows ever persisted"}")
+            if (stalledAt > 0L && stalledAt >= okAt) {
+                add("             ⚠ history NOT persisting — last offload STALLED ${relTime(now - stalledAt * 1000L)} " +
+                    "(if you restored a backup, fully restart the app — #57)")
+            }
+            if (restoreAt > 0L) add("Last restore: ${relTime(now - restoreAt * 1000L)}")
             add("Timezone:    ${tzLine()}")
             val repo = com.noop.data.WhoopRepository.from(context)
             val days = repo.days("my-whoop")

--- a/android/app/src/main/java/com/noop/ui/BackupSyncScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/BackupSyncScreen.kt
@@ -38,6 +38,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import com.noop.data.DataBackup
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -91,12 +92,18 @@ fun BackupSyncScreen() {
                     // Relaunching the process re-opens Room against the restored file. Do it automatically
                     // rather than trust the user to read a toast (which is exactly how #57 happened).
                     Toast.makeText(context, "Backup restored — restarting NOOP…", Toast.LENGTH_LONG).show()
-                    delay(800)   // let the toast render before the process dies
-                    val ctx = context.applicationContext
-                    ctx.packageManager.getLaunchIntentForPackage(ctx.packageName)
-                        ?.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK)
-                        ?.let { ctx.startActivity(it) }
-                    Runtime.getRuntime().exit(0)
+                    // NonCancellable: this coroutine runs in the screen's scope, which is cancelled the
+                    // instant the user navigates away. The restart is a data-safety guarantee (the DB is
+                    // already swapped), so it must complete even if the composition leaves — otherwise the
+                    // user could keep syncing into the closed DB, the very bug we're fixing.
+                    withContext(NonCancellable) {
+                        delay(800)   // let the toast render before the process dies
+                        val ctx = context.applicationContext
+                        ctx.packageManager.getLaunchIntentForPackage(ctx.packageName)
+                            ?.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK)
+                            ?.let { ctx.startActivity(it) }
+                        Runtime.getRuntime().exit(0)
+                    }
                 }
                 is DataBackup.ImportResult.Failed ->
                     Toast.makeText(context, r.message, Toast.LENGTH_LONG).show()

--- a/android/app/src/main/java/com/noop/ui/BackupSyncScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/BackupSyncScreen.kt
@@ -38,6 +38,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import com.noop.data.DataBackup
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
@@ -81,12 +82,25 @@ fun BackupSyncScreen() {
         scope.launch {
             val r = withContext(Dispatchers.IO) { DataBackup.importFrom(context, uri) }
             busy = false
-            val msg = when (r) {
-                is DataBackup.ImportResult.NeedsRestart ->
-                    "Restored. Fully close and reopen NOOP to load it."
-                is DataBackup.ImportResult.Failed -> r.message
+            when (r) {
+                is DataBackup.ImportResult.NeedsRestart -> {
+                    // #57: the restore CLOSED and swapped the database file. The long-lived WhoopRepository +
+                    // BLE client still hold a DAO on the OLD (now-closed) connection, so any strap sync would
+                    // fail with "connection pool has been closed" — and, worse, empty/metadata history ENDs
+                    // would still ack and trim the strap PAST records we can't store, discarding real history.
+                    // Relaunching the process re-opens Room against the restored file. Do it automatically
+                    // rather than trust the user to read a toast (which is exactly how #57 happened).
+                    Toast.makeText(context, "Backup restored — restarting NOOP…", Toast.LENGTH_LONG).show()
+                    delay(800)   // let the toast render before the process dies
+                    val ctx = context.applicationContext
+                    ctx.packageManager.getLaunchIntentForPackage(ctx.packageName)
+                        ?.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK)
+                        ?.let { ctx.startActivity(it) }
+                    Runtime.getRuntime().exit(0)
+                }
+                is DataBackup.ImportResult.Failed ->
+                    Toast.makeText(context, r.message, Toast.LENGTH_LONG).show()
             }
-            Toast.makeText(context, msg, Toast.LENGTH_LONG).show()
         }
     }
 


### PR DESCRIPTION
## What #57 hit

On Android, after **loading a backup from 8.2.2**, strap sync stayed at **0** (live HR worked), and the log showed hundreds of:

```
Backfill: failed to persist decoded rows (trim=…): java.lang.IllegalStateException:
Cannot perform this operation because the connection pool has been closed.
```

Two bugs, both here — and together they **discarded real banked history**.

## Bug 1 — restore leaves the app writing to a closed DB

`NoopApplication.repository` is a `by lazy` that caches a `WhoopDao` from the DB instance built at startup. A restore calls `WhoopDatabase.close()` (closes + nulls the singleton so the file can be swapped; the next `get()` rebuilds against the restored file). But the long-lived repository + BLE client keep the DAO on the **now-closed** instance, so every offload write throws *"connection pool has been closed"* until the **process** restarts. The code already says a restore *requires* a restart (`DataBackup.kt:40/61/144`) but only showed a **dismissable toast** — exactly how the reporter ended up syncing into a dead DB.

**Fix:** auto-relaunch the app after a successful restore (relaunch intent + `exitProcess`), instead of trusting a toast.

## Bug 2 — an empty END acks *past* held records (data loss)

`finishChunk` correctly **holds** the ack when a records-chunk fails to persist. But `repository.insert` **short-circuits empty batches** (`WhoopRepository:170`) without touching the store — so an empty/metadata `HISTORY_END` never throws, reaches `ackTrim`, and **advances the strap's trim past the held records-chunks**, freeing history we never stored. Backfiller's own comment (line 79) names this hazard.

**Fix:** a session `persistStalled` flag — the moment *any* persist (rows / reject archive / trim cursor) fails, **halt all further acks** (including empty ENDs) so the trim can't advance past un-stored data. The offload stalls safely; a fresh session re-offers everything past the last **good** ack.

## Evidence

The reporter's 8.3.4 log: **208** "failed to persist … connection pool has been closed" interleaved 1:1 with **200 distinct acked+advancing trims** — real records freed while the UI showed "0 synced."

## Scope

- Android; compiles (`compileFullReleaseKotlin`), BLE unit tests pass.
- The **Swift Backfiller twin** has the same empty-END-acks-past-held latent bug (bug 2) — flagged as a parity follow-up.
- A dedicated unit test for the stall-guard needs frame-decode scaffolding (WhoopRepository isn't an interface) — noted as follow-up.

Fixes #57.