### PR TITLE
perf: decode each live WHOOP4 frame once, not 2–3× (#47)

### DIFF
--- a/Strand/BLE/BLEManager.swift
+++ b/Strand/BLE/BLEManager.swift
@@ -3401,7 +3401,12 @@ extension BLEManager: @preconcurrency CBPeripheralDelegate {
                     router.dispatchLiveGestureIfFresh(frame: frame, now: strapClockNow)
                     continue
                 }
-                router.handle(frame: frame)                       // live/UI path
+                // #47: decode this live WHOOP4 frame ONCE here and thread the result to every consumer
+                // (router / clock-correlation / collector) instead of each re-parsing it — steady-state
+                // drops 2→1 parse per frame, pre-clock 3→1. `selectedModel.deviceFamily` is .whoop4 on this
+                // path and matches both router.family and collector.family (a DEBUG assert in each verifies).
+                let parsed = parseFrame(frame, family: selectedModel.deviceFamily)
+                router.handle(parsed: parsed, frame: frame)       // live/UI path
                 if frame.count > 6, frame[6] == WhoopCommand.getDataRange.rawValue {
                     // #451: the decoded "newest" can latch a stale/wrong-epoch field (claypilat saw 2024 when
                     // the real newest was 2026). To tell a genuinely-stale strap apart from a frame-alignment
@@ -3461,7 +3466,7 @@ extension BLEManager: @preconcurrency CBPeripheralDelegate {
                 // Clock correlation runs in both live and backfill modes. Once established it
                 // unblocks both the Collector (live path) and the Backfiller (chunk decoding).
                 if clockRef == nil {
-                    let parsed = parseFrame(frame)
+                    // #47: reuse the single decode above (byte-identical for WHOOP4) instead of re-parsing.
                     if let ref = ClockCorrelation.clockRef(from: parsed, wall: Int(Date().timeIntervalSince1970)) {
                         clockRef = ref
                         collector?.clockRef = ref                  // unblocks buffered persistence
@@ -3477,8 +3482,9 @@ extension BLEManager: @preconcurrency CBPeripheralDelegate {
                     }
                 }
                 if !backfilling {
-                    // Live path (unchanged): synchronous ingest preserves delegate arrival order.
-                    collector?.ingest(frame)
+                    // Live path: synchronous ingest preserves delegate arrival order. #47: thread the
+                    // single parse so the collector's flush doesn't re-decode the batch.
+                    collector?.ingest(frame: frame, parsed: parsed)
                 }
             }
         default:

--- a/Strand/BLE/BLEManager.swift
+++ b/Strand/BLE/BLEManager.swift
@@ -3403,9 +3403,12 @@ extension BLEManager: @preconcurrency CBPeripheralDelegate {
                 }
                 // #47: decode this live WHOOP4 frame ONCE here and thread the result to every consumer
                 // (router / clock-correlation / collector) instead of each re-parsing it — steady-state
-                // drops 2→1 parse per frame, pre-clock 3→1. `selectedModel.deviceFamily` is .whoop4 on this
-                // path and matches both router.family and collector.family (a DEBUG assert in each verifies).
-                let parsed = parseFrame(frame, family: selectedModel.deviceFamily)
+                // drops 2→1 parse per frame, pre-clock 3→1. This is the WHOOP4 custom-notify case (5/MG has
+                // its own case), so parse with `.whoop4` explicitly — the same family this loop already uses
+                // for isOffloadFrame, and byte-identical to all three original parses (router.family /
+                // collector.family / the no-family clock parse all resolve to .whoop4 here; a DEBUG assert in
+                // the router + collector re-checks the invariant).
+                let parsed = parseFrame(frame, family: .whoop4)
                 router.handle(parsed: parsed, frame: frame)       // live/UI path
                 if frame.count > 6, frame[6] == WhoopCommand.getDataRange.rawValue {
                     // #451: the decoded "newest" can latch a stale/wrong-epoch field (claypilat saw 2024 when

--- a/Strand/BLE/FrameRouter.swift
+++ b/Strand/BLE/FrameRouter.swift
@@ -21,8 +21,22 @@ public final class FrameRouter {
     }
 
     /// Handle one complete frame (bytes including 0xAA SOF and the crc32 trailer).
+    /// Parse-then-forward shim (#47). Kept so existing callers/tests that pass raw bytes are unchanged;
+    /// the live BLE seam now parses ONCE and calls `handle(parsed:frame:)` directly.
     public func handle(frame: [UInt8]) {
-        let parsed = parseFrame(frame, family: family)
+        handle(parsed: parseFrame(frame, family: family), frame: frame)
+    }
+
+    /// #47: the caller parses the frame ONCE at the BLE seam and threads the result here, so a live
+    /// WHOOP4 frame is decoded once instead of 2–3× (router + clock-correlation + collector). `frame` is
+    /// still passed for the byte-level sub-decoders below.
+    public func handle(parsed: ParsedFrame, frame: [UInt8]) {
+        #if DEBUG
+        // Guard the "parse once == parse per consumer" invariant in dev/test builds only (assert is stripped
+        // from Release): a threading bug (wrong family / stale frame) trips here, never on a user's wrist.
+        assert(parsed == parseFrame(frame, family: family),
+               "FrameRouter.handle: threaded ParsedFrame != fresh parse (#47 parse-once invariant)")
+        #endif
         guard parsed.ok else { return }
         // Reject frames that failed their checksum — never let bad bytes drive state.
         if parsed.crcOK == false { return }

--- a/Strand/Collect/Collector.swift
+++ b/Strand/Collect/Collector.swift
@@ -63,7 +63,9 @@ final class Collector {
     /// activity sample" action can persist raw even when `enableRawCapture` is off. The window's
     /// monotonic deadline auto-expires so a missed stop callback can't leak raw forever.
     private var rawCapture = RawCaptureWindow()
-    private var buffer: [[UInt8]] = []
+    /// #47: buffer the (raw frame, pre-parsed) pair. The raw bytes are still needed for the raw-capture
+    /// outbox; the parse is the one the BLE seam already did, so `flush` doesn't re-decode the batch.
+    private var buffer: [(frame: [UInt8], parsed: ParsedFrame)] = []
     /// Standard 0x2A37 HR/RR buffer — the reliable, always-on stream, recorded continuously
     /// (independent of the custom realtime stream or which screen is open).
     private var stdHR: [HRSample] = []
@@ -114,10 +116,20 @@ final class Collector {
                                 maxUnsyncedBytes: PrunePolicy.maxUnsyncedBytes)) ?? 0
     }
 
-    /// Buffer one complete frame (synchronous: preserves delegate arrival order).
-    /// Auto-flushes via a detached Task when the cadence threshold is hit (flush is async).
+    /// Parse-then-buffer shim (#47). Kept for callers/tests that pass raw bytes; the live seam calls
+    /// `ingest(frame:parsed:)` with the parse it already did.
     func ingest(_ frame: [UInt8]) {
-        buffer.append(frame)
+        ingest(frame: frame, parsed: parseFrame(frame, family: family))
+    }
+
+    /// Buffer one complete frame + its pre-parsed decode (synchronous: preserves delegate arrival order).
+    /// Auto-flushes via a detached Task when the cadence threshold is hit (flush is async). (#47)
+    func ingest(frame: [UInt8], parsed: ParsedFrame) {
+        #if DEBUG
+        assert(parsed == parseFrame(frame, family: family),
+               "Collector.ingest: threaded ParsedFrame != fresh parse (#47 parse-once invariant)")
+        #endif
+        buffer.append((frame, parsed))
         // Pre-clock only: bound memory if GET_CLOCK never lands while data keeps flowing.
         // Drop OLDEST beyond the cap (keep most recent). Post-clock this branch is skipped —
         // the cadence flush below bounds the buffer instead.
@@ -137,16 +149,17 @@ final class Collector {
         guard let ref = clockRef, !buffer.isEmpty else { return }
         // SNAPSHOT + CLEAR before any await: decoded-before-raw ordering AND the
         // buffer-snapshot-before-await invariant are both satisfied here.
-        let frames = buffer
+        let batch = buffer
         buffer.removeAll(keepingCapacity: true)
 
-        let parsed = frames.map { parseFrame($0, family: family) }
+        let frames = batch.map(\.frame)         // still needed for the raw-capture outbox
+        let parsed = batch.map(\.parsed)        // #47: the seam already decoded these — don't re-parse
         let streams = extractStreams(parsed, deviceClockRef: ref.device, wallClockRef: ref.wall)
         do {
             try await store.insert(streams, deviceId: deviceId)   // DECODED FIRST (durable)
         } catch {
-            // Re-buffer at the front so these frames are retried on the next cadence.
-            buffer.insert(contentsOf: frames, at: 0)
+            // Re-buffer at the front so these frames (and their parses) are retried on the next cadence.
+            buffer.insert(contentsOf: batch, at: 0)
             return
         }
         // Reset only after a successful insert so the interval trigger keeps firing if

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -1444,7 +1444,9 @@ class WhoopBleClient(
     private val collectorLock = Any()
 
     /** Buffered complete custom-channel frames awaiting a batched decode+insert. */
-    private val liveBuffer = ArrayList<ByteArray>()
+    // #47: buffer the (raw frame, pre-parsed) pair. Raw bytes stay for the raw path; the parse is the one
+    // the dispatcher already did, so flushLive doesn't re-decode the batch.
+    private val liveBuffer = ArrayList<Pair<ByteArray, com.noop.protocol.ParsedFrame>>()
     private var batchStartedAtMs = System.currentTimeMillis()
 
     /** Standard 0x2A37 HR/RR buffer — the reliable, always-on stream (port of Collector.stdHR/stdRR). */
@@ -3260,10 +3262,14 @@ class WhoopBleClient(
                     // every offloaded frame for nothing. (The Swift 5/MG inbound loop already hoists this.)
                     val offloadFrame = backfilling && isOffloadFrame(frame, connectedFamily)
                     noteWhoop5R22Telemetry(frame, offloadFrame)  // #174
+                    // #47: decode this frame ONCE and thread it to both consumers (the router below and the
+                    // live collector) instead of each re-parsing it — steady-state drops 2→1 parse per live
+                    // frame. Family-aware, so it's correct for WHOOP4 and 5/MG alike.
+                    val parsed = Framing.parseFrame(frame, connectedFamily)
                     // A frame replayed as part of the historical offload (type 47/48/… during a backfill)
                     // must not drive LIVE-only state (the charging pill). Mirrors iOS, where the offload
                     // path skips the live router entirely. (PR #568 reimpl)
-                    handleFrame(frame, replayedOffload = offloadFrame)
+                    handleFrame(frame, parsed, replayedOffload = offloadFrame)
 
                     // Capture the strap's newest stored record from a GET_DATA_RANGE reply, feeding
                     // the liveness watchdog. The response command byte is family-dependent: @6 on
@@ -3347,8 +3353,9 @@ class WhoopBleClient(
                             routeBackfillFrame(frame)
                         }
                     } else {
-                        // Live path: buffer the frame for a batched decode+insert (port of Collector.ingest).
-                        ingestLiveFrame(frame)
+                        // Live path: buffer the frame + its parse for a batched insert (port of Collector.ingest).
+                        // #47: thread the single parse so flushLive doesn't re-decode the batch.
+                        ingestLiveFrame(frame, parsed)
                     }
                   } catch (t: Throwable) {
                     log("inbound frame handling threw ${t.javaClass.simpleName} — dropping this frame, link stays up")
@@ -3416,8 +3423,15 @@ class WhoopBleClient(
      * Pure decode→state router for one COMPLETE frame.
      * Direct port of `FrameRouter.handle(frame:)`.
      */
-    private fun handleFrame(frame: ByteArray, replayedOffload: Boolean = false) {
-        val parsed = Framing.parseFrame(frame, connectedFamily)
+    /** Parse-then-route shim (#47). Kept for any caller/test that passes raw bytes; the live dispatcher
+     *  parses ONCE and calls the overload below with the result. */
+    private fun handleFrame(frame: ByteArray, replayedOffload: Boolean = false) =
+        handleFrame(frame, Framing.parseFrame(frame, connectedFamily), replayedOffload)
+
+    /** #47: the dispatcher decodes each frame ONCE and threads it here, so a live frame is parsed once
+     *  instead of twice (this router path + the live-collector flush). `frame` is still passed for the
+     *  byte-level sub-decoders. */
+    private fun handleFrame(frame: ByteArray, parsed: com.noop.protocol.ParsedFrame, replayedOffload: Boolean = false) {
         if (!parsed.ok) return
         // Reject frames that failed their checksum — never let bad bytes drive state.
         if (parsed.crcOk == false) return
@@ -4281,9 +4295,14 @@ class WhoopBleClient(
      * serves GET_CLOCK on this firmware) and REALTIME_DATA's `timestamp` is mapped through it; the
      * historical store, which is the real metric source, carries its own unix ts and needs no clock.
      */
-    private fun ingestLiveFrame(frame: ByteArray) {
+    /** Parse-then-buffer shim (#47). Kept for callers that pass raw bytes; the live dispatcher passes the
+     *  parse it already did. */
+    private fun ingestLiveFrame(frame: ByteArray) =
+        ingestLiveFrame(frame, Framing.parseFrame(frame, connectedFamily))
+
+    private fun ingestLiveFrame(frame: ByteArray, parsed: com.noop.protocol.ParsedFrame) {
         val shouldFlush = synchronized(collectorLock) {
-            liveBuffer.add(frame)   // synchronous append preserves GATT-callback arrival order
+            liveBuffer.add(frame to parsed)   // synchronous append preserves GATT-callback arrival order
             liveBuffer.size >= FLUSH_MAX_FRAMES ||
                 (System.currentTimeMillis() - batchStartedAtMs) >= FLUSH_MAX_INTERVAL_MS
         }
@@ -4311,7 +4330,7 @@ class WhoopBleClient(
         // on today's timeline whatever the strap's clock says, and is a no-op when the clock is already
         // valid (newest frame ≈ now). The dense, authoritative source is still the type-47 history store.
         val now = (System.currentTimeMillis() / 1000L).toInt()
-        val parsed = frames.map { Framing.parseFrame(it, connectedFamily) }
+        val parsed = frames.map { it.second }   // #47: the dispatcher already decoded these — don't re-parse
         val newestRealtimeTs = parsed.asSequence()
             .filter { it.ok && it.crcOk != false && it.typeName == "REALTIME_DATA" }
             .mapNotNull { (it.parsed["timestamp"] as? Number)?.toInt() }


### PR DESCRIPTION
Reimplements **#47** (MrL0's analysis) under the NOOP identity — conservatively.

## Problem

A single reassembled live **WHOOP 4.0** frame is decoded **2× steady-state** (router + collector flush) and **3× pre-clock** (+ the clock-correlation parse). Each redundant parse re-runs `verifyFrame` (CRC32) + a `FieldBuilder` allocation on the type-43 realtime flood. (`loadSchema()` is cached, so it's *not* a JSON re-decode — the real redundant cost is CRC + FieldBuilder alloc.)

## Fix — parse once at the BLE seam, thread `ParsedFrame` through

Structure-preserving and byte-identical:
- **FrameRouter:** add `handle(parsed:frame:)`; `handle(frame:)` stays a parse-then-forward **shim**.
- **Collector:** buffer `(frame, parsed)` pairs; `flush` uses the stored parse; `ingest(_:)` stays a shim (raw bytes still buffered for the raw-capture outbox).
- **BLEManager** (WHOOP4 loop): parse once, reuse for router + clock-correlation + collector.
- **Android twin** (`WhoopBleClient`): dispatcher parses once → `handleFrame(frame, parsed, …)` + `ingestLiveFrame(frame, parsed)`; `liveBuffer` holds pairs; `flushLive` reuses the parse. Shims kept.

## Safety

- **DEBUG-only equivalence assert** (iOS `FrameRouter`/`Collector`): the threaded `ParsedFrame` must equal a fresh parse, so a threading bug (wrong family / stale frame) trips in dev/test — **never on a wrist**. Release builds strip it (zero cost).
- **5/MG path unchanged** — it never ingested REALTIME_DATA into the collector, so no redundancy there.
- No wire/command change; output is the same `ParsedFrame`s, decoded once.

## Verification

- Android compiles + BLE/protocol unit tests pass; iOS via CI.
- ⚠️ **Needs an on-strap sanity check before merge** (live HR/RR still tick, fresh-connect still clock-correlates) — I can't strap-test in this environment. This is the real gate for a live-BLE change.

Closes #47.