### PR TITLE
perf: skip full decode of non-EVENT frames on the offload gesture path (#47 follow-up)

### DIFF
--- a/Packages/WhoopProtocol/Sources/WhoopProtocol/Interpreter.swift
+++ b/Packages/WhoopProtocol/Sources/WhoopProtocol/Interpreter.swift
@@ -190,6 +190,27 @@ public func parseFrame(_ frame: [UInt8], collectFields: Bool = false) -> ParsedF
                        fields: fb.fields, parsed: fb.parsed)
 }
 
+/// #47: the packet type NAME only — NO CRC verify, NO FieldBuilder — for hot-path pre-filters that just
+/// need a frame's TYPE (e.g. "is this an EVENT?") before deciding whether to pay a full `parseFrame`. On a
+/// multi-minute offload of thousands of type-47 records that only ever act on rare EVENT frames, this skips
+/// the redundant decode for the ~99% that aren't. Mirrors `parseFrame`'s family split EXACTLY — the inner
+/// type byte is at [4] on WHOOP4 and [8] on 5/MG, with the same lookup each uses (`schema.typeName` /
+/// `canonicalTypeName`). Returns nil for a frame too short / wrong SOF — which `parseFrame` would also mark
+/// INVALID (never "EVENT") — so a pre-filter guarded on `== "EVENT"` is byte-identical to the full-parse
+/// guard.
+public func frameTypeName(_ frame: [UInt8], family: DeviceFamily) -> String? {
+    guard frame.first == 0xAA else { return nil }
+    let schema = loadSchema()
+    switch family {
+    case .whoop4:
+        guard frame.count >= 8 else { return nil }        // parseFrame's `count < 8` INVALID guard
+        return schema.typeName(Int(frame[4]))
+    case .whoop5:
+        guard frame.count >= 12 else { return nil }       // parseFrameWhoop5's `count < 12` INVALID guard
+        return canonicalTypeName(Int(frame[8]), schema: schema)
+    }
+}
+
 /// Family-aware frame parsing.
 ///
 /// `whoop4` behaves EXACTLY like the no-family `parseFrame(_:)` above (back-compat). `whoop5`

--- a/Packages/WhoopProtocol/Tests/WhoopProtocolTests/FastPathParityTests.swift
+++ b/Packages/WhoopProtocol/Tests/WhoopProtocolTests/FastPathParityTests.swift
@@ -129,20 +129,36 @@ final class FastPathParityTests: XCTestCase {
         }
     }
 
-    /// #47: `frameTypeName` (the cheap type-only peek used by the offload gesture pre-filter) must return
-    /// EXACTLY the `typeName` a full `parseFrame` produces, for every valid frame in the corpus and both
-    /// families — otherwise the pre-filter's `== "EVENT"` guard could diverge from the full-parse guard and
-    /// drop (or over-admit) a gesture. Pins the byte-identity the optimisation rests on.
-    func testFrameTypeNameMatchesFullParseTypeName() throws {
+    /// #47: `frameTypeName` (the cheap type-only peek used by the offload gesture pre-filter) must agree with
+    /// a full `parseFrame` on TWO things, or the pre-filter's `guard frameTypeName == "EVENT"` could diverge
+    /// from the full-parse `guard typeName == "EVENT"` — over-admitting (a wasted parse) or, dangerously,
+    /// DROPPING a real gesture:
+    ///   1. for a VALID frame, the exact type name matches;
+    ///   2. for ANY frame (incl. malformed/short/wrong-SOF), the EVENT *decision* matches — this is the
+    ///      property the pre-filter actually rests on, and it must hold even where the two disagree on the
+    ///      name (frameTypeName returns nil for a short frame; parseFrame calls it "INVALID/FRAGMENT" — both
+    ///      are "not EVENT", so the pre-filter skips exactly as the full parse would).
+    func testFrameTypeNamePreFilterMatchesFullParse() throws {
         func check(_ frame: [UInt8], _ family: DeviceFamily, _ label: String) {
-            XCTAssertEqual(frameTypeName(frame, family: family), parseFrame(frame, family: family).typeName,
-                           "frameTypeName != parseFrame.typeName at \(label)")
+            let peek = frameTypeName(frame, family: family)
+            let full = parseFrame(frame, family: family)
+            if full.ok {
+                XCTAssertEqual(peek, full.typeName, "frameTypeName != parseFrame.typeName at \(label)")
+            }
+            // The contract the offload gesture pre-filter depends on: never drop/over-admit an EVENT.
+            XCTAssertEqual(peek == "EVENT", full.typeName == "EVENT", "EVENT-decision drift at \(label)")
         }
         for (i, frame) in try loadFrames("frames").enumerated() { check(frame, .whoop4, "frames.json #\(i)") }
         for (i, frame) in try loadFrames("historical_frames").enumerated() {
             check(frame, .whoop4, "historical_frames.json #\(i)")
         }
         for v in Self.whoop5Vectors { check(hexToBytes(v.hex), .whoop5, v.label) }
+        // Malformed / boundary frames the corpus doesn't carry, where a false-negative would silently drop a
+        // gesture on real BLE (fragments, corruption). Both peek and full parse must land on "not EVENT".
+        check([], .whoop4, "empty")
+        check([0xAA, 0x01, 0x02], .whoop4, "short (below the 8-byte min)")
+        check([0x00, 0x18, 0x00, 0xff, 0x28, 0x02, 0x0f, 0x00], .whoop4, "wrong SOF")
+        check(hexToBytes("aa010c000001"), .whoop5, "short 5/MG (below the 12-byte min)")
     }
 
     /// The DEFAULT call is the fast path on both entry points, so every live/offload call site

--- a/Packages/WhoopProtocol/Tests/WhoopProtocolTests/FastPathParityTests.swift
+++ b/Packages/WhoopProtocol/Tests/WhoopProtocolTests/FastPathParityTests.swift
@@ -129,6 +129,22 @@ final class FastPathParityTests: XCTestCase {
         }
     }
 
+    /// #47: `frameTypeName` (the cheap type-only peek used by the offload gesture pre-filter) must return
+    /// EXACTLY the `typeName` a full `parseFrame` produces, for every valid frame in the corpus and both
+    /// families — otherwise the pre-filter's `== "EVENT"` guard could diverge from the full-parse guard and
+    /// drop (or over-admit) a gesture. Pins the byte-identity the optimisation rests on.
+    func testFrameTypeNameMatchesFullParseTypeName() throws {
+        func check(_ frame: [UInt8], _ family: DeviceFamily, _ label: String) {
+            XCTAssertEqual(frameTypeName(frame, family: family), parseFrame(frame, family: family).typeName,
+                           "frameTypeName != parseFrame.typeName at \(label)")
+        }
+        for (i, frame) in try loadFrames("frames").enumerated() { check(frame, .whoop4, "frames.json #\(i)") }
+        for (i, frame) in try loadFrames("historical_frames").enumerated() {
+            check(frame, .whoop4, "historical_frames.json #\(i)")
+        }
+        for v in Self.whoop5Vectors { check(hexToBytes(v.hex), .whoop5, v.label) }
+    }
+
     /// The DEFAULT call is the fast path on both entry points, so every live/offload call site
     /// (FrameRouter, Collector, Backfiller, rejectedHistoricalRecords, BLEManager clock
     /// correlation) gets the optimisation without a call-site change.

--- a/Strand/BLE/FrameRouter.swift
+++ b/Strand/BLE/FrameRouter.swift
@@ -276,6 +276,12 @@ public final class FrameRouter {
     /// Deliberately does NOT touch lastEvent / sync trigger / bonded / battery — those stay on the normal
     /// handle(frame:) path, so backfill UI behaviour is otherwise unchanged.
     func dispatchLiveGestureIfFresh(frame: [UInt8], now: Int = Int(Date().timeIntervalSince1970)) {
+        // #47: this fires for EVERY frame on the OFFLOAD path (thousands of type-47 records over a
+        // multi-minute sync) purely to catch a rare EVENT gesture. Cheap type-only pre-check skips the full
+        // CRC + FieldBuilder decode for non-EVENT frames — byte-identical: an EVENT frame still gets the
+        // full parse + CRC guard below; a non-EVENT frame was discarded at the `typeName == "EVENT"` guard
+        // anyway. Family-aware (WHOOP4 type @[4], 5/MG @[8]).
+        guard frameTypeName(frame, family: family) == "EVENT" else { return }
         let parsed = parseFrame(frame, family: family)
         guard parsed.ok, parsed.crcOK != false else { return }
         guard parsed.typeName == "EVENT", let ev = parsed.parsed["event"]?.stringValue else { return }


### PR DESCRIPTION
Follow-up to #47/#63. The bigger of the two decode redundancies I flagged.

## Problem

`FrameRouter.dispatchLiveGestureIfFresh` fires for **every** frame on the historical-offload path — **thousands of type-47 records** over a multi-minute sync — purely to catch a rare `EVENT` gesture (double-tap / wrist). It fully parsed each one (**CRC32 + FieldBuilder allocation**) only to discard it at `guard parsed.typeName == "EVENT"`. Offloads carry far more frames than the ~1 Hz live stream #47 targeted, so this is the larger win.

## Fix

- New `WhoopProtocol.frameTypeName(_:family:)`: the packet type **name only** — no CRC verify, no FieldBuilder. Family-aware (inner type byte at `[4]` on WHOOP4, `[8]` on 5/MG, using the same lookup each parse path uses).
- `dispatchLiveGestureIfFresh` now pre-checks `frameTypeName(...) == "EVENT"` and **skips the full parse** for the ~99% that aren't. **Byte-identical:** an EVENT frame still gets the full parse + CRC guard below; a non-EVENT frame was dropped at the typeName guard anyway.

## Verification

- **Ran locally** (WhoopProtocol is a pure package — no Compression wall): a new `FastPathParityTests` case proves `frameTypeName == parseFrame(...).typeName` across the **whoop4 parity + historical corpora and the whoop5 hardware vectors** — **passing**. So the pre-filter's `== "EVENT"` guard provably can't diverge from the full-parse guard.
- CI compiles the app-target `FrameRouter` change.

## Scope / caveat

- **iOS/macOS only.** Android dispatches gestures *inside* `handleFrame` (entangled with routing) and, post-#47, already parses offload frames once — so there's no isolated pre-filter to add there.
- ⚠️ **Needs the same on-strap sanity check as #47** (gestures still fire mid-offload) before merge.

Follow-up to #47.