### PR TITLE
iOS: build the sideload IPA in Release, not Debug (#53)

### DIFF
--- a/.github/workflows/fork-release.yml
+++ b/.github/workflows/fork-release.yml
@@ -229,9 +229,12 @@ jobs:
         run: brew install xcodegen
       - name: Generate Xcode project
         run: xcodegen generate
-      - name: Build NOOPiOS for device (unsigned)
+      - name: Build NOOPiOS for device (unsigned, Release)
+        # #53: build RELEASE, not Debug. A Debug build carries get-task-allow + debug artifacts that make a
+        # re-signed sideload fail "integrity could not be verified" on modern iOS; Release (the correct config
+        # for a distributed app) installs clean — confirmed by the reporter's own Release build.
         run: >-
-          xcodebuild -scheme NOOPiOS -configuration Debug -destination 'generic/platform=iOS'
+          xcodebuild -scheme NOOPiOS -configuration Release -destination 'generic/platform=iOS'
           -derivedDataPath build/dd
           CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY=""
           build
@@ -240,7 +243,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           VER: ${{ needs.bump.outputs.ver }}
         run: |
-          APP=$(find build/dd/Build/Products/Debug-iphoneos -maxdepth 1 -name '*.app' -type d | head -1)
+          APP=$(find build/dd/Build/Products/Release-iphoneos -maxdepth 1 -name '*.app' -type d | head -1)
           test -n "$APP" || { echo ".app (iphoneos) not found"; exit 1; }
           rm -rf "$APP/Watch"
           rm -rf Payload && mkdir Payload && cp -R "$APP" Payload/

--- a/.github/workflows/fork-testing-build.yml
+++ b/.github/workflows/fork-testing-build.yml
@@ -129,9 +129,12 @@ jobs:
         run: brew install xcodegen
       - name: Generate Xcode project
         run: xcodegen generate
-      - name: Build NOOPiOS for device (unsigned)
+      - name: Build NOOPiOS for device (unsigned, Release)
+        # #53: build RELEASE, not Debug. A Debug build carries get-task-allow + debug artifacts that make a
+        # re-signed sideload fail "integrity could not be verified" on modern iOS; Release (the correct config
+        # for a distributed app) installs clean — confirmed by the reporter's own Release build.
         run: >-
-          xcodebuild -scheme NOOPiOS -configuration Debug -destination 'generic/platform=iOS'
+          xcodebuild -scheme NOOPiOS -configuration Release -destination 'generic/platform=iOS'
           -derivedDataPath build/dd
           CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY=""
           build
@@ -140,7 +143,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           VER: ${{ needs.meta.outputs.ver }}
         run: |
-          APP=$(find build/dd/Build/Products/Debug-iphoneos -maxdepth 1 -name '*.app' -type d | head -1)
+          APP=$(find build/dd/Build/Products/Release-iphoneos -maxdepth 1 -name '*.app' -type d | head -1)
           test -n "$APP" || { echo ".app (iphoneos) not found"; exit 1; }
           rm -rf "$APP/Watch"
           rm -rf Payload && mkdir Payload && cp -R "$APP" Payload/


### PR DESCRIPTION
## Problem

The prebuilt unsigned `.ipa` fails to sideload — *"Unable to Install NOOP: this app cannot be installed because its integrity could not be verified"* — in KravaSign with either a dev or distribution cert (#53).

## Diagnosis

The reporter's **own** build sideloaded fine. The only material difference: our CI built **`-configuration Debug`**, theirs was **Release**. A Debug build carries `get-task-allow` + debug artifacts that a re-signed sideload install rejects on modern iOS; **Release** (the correct config for a distributed app) installs clean.

Checked and ruled out the reporter's other guess (the watch strip): the phone `Info.plist` has **no** watch reference, so `rm -rf Watch` leaves nothing dangling — and the reporter's working build had the watch **intact**, so it isn't the cause. Watch strip left unchanged (it's for AltStore / free-Apple-ID users who can't sign the embedded watch).

## Fix

Both the release and testing iOS builds now use `-configuration Release` (and read the `.app` from `Release-iphoneos`). No other change.

## Verification

- The testing build off this branch is **green** — so the app **compiles in Release** (no Release-only issues) and the IPA packages. A Release IPA is on the `testing-latest` prerelease for the reporter to confirm the sideload actually installs.
- I can't sideload in this environment, so the reporter re-testing is the real gate — the change just matches their proven-working config.

Fixes #53.