### PR TITLE
perf: batch the per-session motion/sleep-state reads (N+1 → one query)

### DIFF
--- a/Packages/WhoopStore/Sources/WhoopStore/MetricsCache.swift
+++ b/Packages/WhoopStore/Sources/WhoopStore/MetricsCache.swift
@@ -270,6 +270,66 @@ extension WhoopStore {
         }
     }
 
+    /// Batched twin of `sessionMotion` for a SET of session starts: the persisted per-epoch motion series
+    /// for each of `sessionStarts` that HAS one, in a SINGLE query, keyed by startTs. Same contract as the
+    /// single-key accessor — a start whose column is NULL/absent (or an empty series) is simply omitted from
+    /// the result (absent stays absent, never a fabricated zero array) — but without the per-session
+    /// round-trip the Sleep tab's main-night group used to pay (N single-row reads → one). The `IN (…)` list
+    /// is de-duplicated and chunked to stay well under SQLite's bound-parameter ceiling.
+    public func sessionMotions(deviceId: String, sessionStarts: [Int]) async throws -> [Int: [Double]] {
+        guard !sessionStarts.isEmpty else { return [:] }
+        return try syncRead { db in
+            var out: [Int: [Double]] = [:]
+            let uniq = Array(Set(sessionStarts))
+            var lo = 0
+            while lo < uniq.count {
+                let chunk = Array(uniq[lo ..< min(lo + Self.inClauseChunk, uniq.count)])
+                lo += Self.inClauseChunk
+                let placeholders = chunk.map { _ in "?" }.joined(separator: ",")
+                var args: [DatabaseValueConvertible] = [deviceId]
+                args.append(contentsOf: chunk)
+                let rows = try Row.fetchAll(db, sql: """
+                    SELECT startTs, motionJSON FROM sleepSession
+                    WHERE deviceId = ? AND startTs IN (\(placeholders)) AND motionJSON IS NOT NULL
+                    """, arguments: StatementArguments(args))
+                for row in rows {
+                    let startTs: Int = row["startTs"]
+                    guard let json: String = row["motionJSON"],
+                          let arr = Self.decodeDoubleArray(json), !arr.isEmpty else { continue }
+                    out[startTs] = arr
+                }
+            }
+            return out
+        }
+    }
+
+    /// Batched twin of `sessionSleepState` over a RANGE: every session in `[from, to]` (by startTs) that has
+    /// banked per-epoch band sleep_state, in ONE query, keyed by startTs. The H7 re-onset guard reads the
+    /// SAME `[from, to]` window as its `sleepSessions` call, so a single range scan replaces the per-session
+    /// round-trip (N single-row reads → one); the caller looks each kept (deduped) session up by startTs.
+    /// NULL/absent columns are omitted (absent stays absent), identical to the single-key accessor.
+    public func sessionSleepStates(deviceId: String, from: Int, to: Int) async throws -> [Int: [Int]] {
+        try syncRead { db in
+            var out: [Int: [Int]] = [:]
+            let rows = try Row.fetchAll(db, sql: """
+                SELECT startTs, sleepStateJSON FROM sleepSession
+                WHERE deviceId = ? AND startTs >= ? AND startTs <= ? AND sleepStateJSON IS NOT NULL
+                """, arguments: [deviceId, from, to])
+            for row in rows {
+                let startTs: Int = row["startTs"]
+                guard let json: String = row["sleepStateJSON"],
+                      let arr = Self.decodeIntArray(json), !arr.isEmpty else { continue }
+                out[startTs] = arr
+            }
+            return out
+        }
+    }
+
+    /// SQLite caps the number of bound `?` parameters per statement (SQLITE_MAX_VARIABLE_NUMBER — 999 on the
+    /// system SQLite iOS ships). Chunk `IN (…)` lists comfortably under it, leaving room for the leading
+    /// `deviceId` bind.
+    static let inClauseChunk = 900
+
     /// Compact JSON encoders/decoders for the per-epoch series — a bare `[Double]`/`[Int]` array (no
     /// pretty-printing) so the column stays small and round-trips byte-for-byte with the Android port.
     static func encodeDoubleArray(_ xs: [Double]) -> String? {

--- a/Packages/WhoopStore/Tests/WhoopStoreTests/SleepMotionStateTests.swift
+++ b/Packages/WhoopStore/Tests/WhoopStoreTests/SleepMotionStateTests.swift
@@ -94,6 +94,66 @@ final class SleepMotionStateTests: XCTestCase {
         XCTAssertNil(cleared)
     }
 
+    // MARK: batched aux-blob reads (one query, not N)
+
+    private func upsertBareSession(_ store: WhoopStore, _ s: Int) async throws {
+        try await store.upsertSleepSessions([
+            CachedSleepSession(startTs: s, endTs: s + 8 * 3_600, efficiency: 0.9,
+                               restingHr: 52, avgHrv: 70, stagesJSON: "[]")
+        ], deviceId: dev)
+    }
+
+    /// The batched `sessionMotions` returns EXACTLY what N single `sessionMotion` calls would, keyed by
+    /// start: only starts with a non-empty series appear; absent, empty, and non-existent starts are omitted.
+    func testBatchedSessionMotionsMatchesSingles() async throws {
+        let store = try await WhoopStore.inMemory()
+        let starts = [start, start + 1_000, start + 2_000, start + 3_000]
+        for s in starts { try await upsertBareSession(store, s) }
+        try await store.persistSessionMotion(deviceId: dev, sessionStart: starts[0], motionEpochs: [1.0, 2.0])
+        try await store.persistSessionMotion(deviceId: dev, sessionStart: starts[2], motionEpochs: [3.5])
+        try await store.persistSessionMotion(deviceId: dev, sessionStart: starts[3], motionEpochs: [])  // empty → NULL
+        // starts[1] never written; start+9_999 never a session at all.
+        let query = starts + [start + 9_999]
+
+        let batched = try await store.sessionMotions(deviceId: dev, sessionStarts: query)
+        var singles: [Int: [Double]] = [:]
+        for s in query {
+            if let m = try await store.sessionMotion(deviceId: dev, sessionStart: s), !m.isEmpty { singles[s] = m }
+        }
+        XCTAssertEqual(batched, singles)
+        XCTAssertEqual(batched, [starts[0]: [1.0, 2.0], starts[2]: [3.5]])
+    }
+
+    func testBatchedSessionMotionsEmptyInputNoQuery() async throws {
+        let store = try await storeWithSession()
+        let out = try await store.sessionMotions(deviceId: dev, sessionStarts: [])
+        XCTAssertTrue(out.isEmpty)
+    }
+
+    /// The batched range `sessionSleepStates` returns EXACTLY what per-session `sessionSleepState` reads
+    /// would for the in-window sessions, keyed by start; sessions outside `[from, to]` and NULL-state
+    /// sessions are omitted.
+    func testBatchedSessionSleepStatesMatchesSingles() async throws {
+        let store = try await WhoopStore.inMemory()
+        let inWindow = [start, start + 1_000, start + 2_000]
+        let outside = start + 10 * 24 * 3_600
+        for s in inWindow + [outside] { try await upsertBareSession(store, s) }
+        try await store.persistSessionSleepState(deviceId: dev, sessionStart: inWindow[0], states: [0, 1, 2])
+        try await store.persistSessionSleepState(deviceId: dev, sessionStart: inWindow[2], states: [3])
+        try await store.persistSessionSleepState(deviceId: dev, sessionStart: outside, states: [1, 1])
+        // inWindow[1] never written.
+
+        let from = start, to = start + 5_000
+        let batched = try await store.sessionSleepStates(deviceId: dev, from: from, to: to)
+        var singles: [Int: [Int]] = [:]
+        for s in inWindow {
+            if let st = try await store.sessionSleepState(deviceId: dev, sessionStart: s), !st.isEmpty { singles[s] = st }
+        }
+        XCTAssertEqual(batched, singles)
+        XCTAssertEqual(batched, [inWindow[0]: [0, 1, 2], inWindow[2]: [3]])
+        XCTAssertNil(batched[outside])   // out of window is not returned
+    }
+
     /// A later recompute/import upsert of the SAME session (which never names the two aux columns) must
     /// PRESERVE the banked motion/state — they are not in its column list, so ON CONFLICT leaves them.
     func testUpsertPreservesMotionAndState() async throws {

--- a/Strand/Data/IntelligenceEngine.swift
+++ b/Strand/Data/IntelligenceEngine.swift
@@ -1521,11 +1521,14 @@ final class IntelligenceEngine: ObservableObject {
         let sessions = SleepSessionDedup.dedupe(
             (try? await store.sleepSessions(deviceId: computedId, from: from, to: to,
                                             limit: 4000)) ?? []).kept
+        // One range read of the window's banked band state, keyed by startTs, instead of a single-row SELECT
+        // per kept session. We still expand ONLY the kept (deduped) sessions, in order, so the output is
+        // identical to the old per-session loop — just without the N round-trips.
+        let stateByStart = (try? await store.sessionSleepStates(deviceId: computedId,
+                                                                from: from, to: to)) ?? [:]
         var samples: [(ts: Int, state: Int)] = []
         for s in sessions {
-            guard let states = try? await store.sessionSleepState(deviceId: computedId,
-                                                                  sessionStart: s.startTs),
-                  !states.isEmpty else { continue }
+            guard let states = stateByStart[s.startTs], !states.isEmpty else { continue }
             for (i, st) in states.enumerated() {
                 samples.append((ts: s.startTs + i * epochS, state: st))
             }

--- a/Strand/Data/Repository.swift
+++ b/Strand/Data/Repository.swift
@@ -958,13 +958,10 @@ final class Repository: ObservableObject {
     /// A start with no stored series is omitted from the result (its key is absent).
     func sessionMotions(starts: [Int]) async -> [Int: [Double]] {
         guard !starts.isEmpty, let store = await ensureStore() else { return [:] }
-        var out: [Int: [Double]] = [:]
-        for start in starts {
-            if let m = try? await store.sessionMotion(deviceId: computedDeviceId, sessionStart: start), !m.isEmpty {
-                out[start] = m
-            }
-        }
-        return out
+        // One batched read keyed by startTs, not a single-row SELECT per session start. The store's
+        // batched accessor keeps the exact contract of the old loop: starts with no (or an empty) series
+        // are omitted from the result.
+        return (try? await store.sessionMotions(deviceId: computedDeviceId, sessionStarts: starts)) ?? [:]
     }
 
     /// The user's learned habitual midsleep (local time-of-day seconds), or nil under


### PR DESCRIPTION
## What & why

`analyzeRecent` and the Sleep tab each read a per-session aux blob **one row at a time**:

- `Repository.sessionMotions(starts:)` — a single-row `SELECT motionJSON … WHERE deviceId=? AND startTs=?` **per main-night block**.
- `IntelligenceEngine.bandSleepStateSamples` — one `SELECT sleepStateJSON …` **per kept session** across the whole `[from, to]` window (sessions read at `limit: 4000`).

That's an N+1 on the score-of-record scan path. Post-#997 the surrounding loop already resumes off the main actor, but the reads themselves are still one-per-session.

## The change

Two batched accessors on the store, beside the single-key ones (which the genuine single-session lookups keep using):

- `sessionMotions(deviceId:sessionStarts:)` — one `IN (…)` query over the given starts (de-duplicated, and chunked under SQLite's bound-parameter ceiling so a pathological start-set can't blow the limit).
- `sessionSleepStates(deviceId:from:to:)` — one **range** scan. The sleep guard already reads the SAME `[from, to]` window for its sessions, so it just looks each kept (deduped) session up by `startTs` afterward — no `IN`-list needed.

**Output is identical to the old loops.** Both keep the single-key accessors' exact contract — a NULL/absent or empty series is omitted (absent stays absent, never a fabricated zero array) — and the sleep path still expands **only** the kept (deduped) sessions, in the same order. Only the round-trips change (N single-row reads → one).

## Verification

- New `SleepMotionStateTests` cases prove `batched == N-singles` for both accessors, including absent / empty / non-existent starts and out-of-window exclusion.
- Full `WhoopStore` package suite green — **232 tests, 0 failures** (`swift test`).
- Package-level logic + two app-tier call-site swaps; the app compiles under CI.

## Checklist
- [x] Behavior-preserving (batched read == old per-session loop; equivalence-tested)
- [x] `swift test` green (WhoopStore, 232)
- [x] No schema / migration change — same columns, same key
- [x] Honesty preserved — absent series stays absent (nil), never fabricated
- [x] No hardcoded hex frame bytes / UI-token rules — n/a

*Perf pass, AI-assisted; equivalence-tested locally against the single-key reads.*
