### PR TITLE
perf: bound import RAM with a per-import total-byte budget

### DIFF
--- a/Packages/StrandImport/Sources/StrandImport/WearableExportImporter.swift
+++ b/Packages/StrandImport/Sources/StrandImport/WearableExportImporter.swift
@@ -31,7 +31,14 @@ import ZIPFoundation
 
 public struct WearableExportImporter {
 
-    public init() {}
+    /// Aggregate ceiling on the bytes held in RAM across ALL retained wellness files from one import. This
+    /// is the real backstop here: a folder/zip can carry up to `maxFiles` (200k) entries, and the per-entry
+    /// cap bounds each one but NOT their sum — without this a crafted export could accumulate unbounded
+    /// `Data` in the result dict. A whole multi-year export is tens of MB, so 1 GB never trips in practice.
+    /// Injectable so tests can exercise the budget with tiny inputs.
+    let maxTotalBytes: Int
+
+    public init(maxTotalBytes: Int = 1 << 30) { self.maxTotalBytes = maxTotalBytes }
 
     /// Hard ceilings (DoS guards, parity with ActivityFileImporter / WhoopExportImporter).
     /// A whole multi-year wellness export is tens of MB of JSON; 256 MB per entry is generous.
@@ -196,6 +203,7 @@ public struct WearableExportImporter {
     private func loadFromFolder(_ folder: URL) throws -> [String: Data] {
         let fm = FileManager.default
         var result: [String: Data] = [:]
+        var total = 0
         guard let e = fm.enumerator(at: folder, includingPropertiesForKeys: [.fileSizeKey, .isRegularFileKey],
                                     options: [.skipsHiddenFiles]) else {
             throw ImportError.fileNotFound(folder.path)
@@ -211,7 +219,11 @@ public struct WearableExportImporter {
             guard Self.isWellnessFile(name, data: data) else { continue }
             // Key on the path RELATIVE to the folder so brand detection can see "di_connect/..." etc.
             let rel = u.path.hasPrefix(base) ? String(u.path.dropFirst(base.count)).lowercased() : name
-            result[rel.hasPrefix("/") ? String(rel.dropFirst()) : rel] = data
+            let key = rel.hasPrefix("/") ? String(rel.dropFirst()) : rel
+            guard result[key] == nil else { continue }
+            if total + data.count > maxTotalBytes { break }   // aggregate RAM ceiling across retained files
+            result[key] = data
+            total += data.count
         }
         return result
     }
@@ -222,6 +234,7 @@ public struct WearableExportImporter {
         catch { throw ImportError.notAZipOrFolder(zipURL.path) }
 
         var result: [String: Data] = [:]
+        var total = 0
         for entry in archive {
             if result.count >= Self.maxFiles { break }
             guard entry.type == .file else { continue }
@@ -240,7 +253,11 @@ public struct WearableExportImporter {
                 }
             } catch { continue }   // corrupt / truncated / oversized → skip, never import partial
             guard !buffer.isEmpty, Self.isWellnessFile(base, data: buffer) else { continue }
-            if result[path] == nil { result[path] = buffer }
+            if result[path] == nil {
+                if total + buffer.count > maxTotalBytes { break }   // aggregate RAM ceiling across retained files
+                result[path] = buffer
+                total += buffer.count
+            }
         }
         return result
     }

--- a/Packages/StrandImport/Sources/StrandImport/WhoopExportImporter.swift
+++ b/Packages/StrandImport/Sources/StrandImport/WhoopExportImporter.swift
@@ -12,7 +12,13 @@ import ZIPFoundation
 /// located **by filename**, case-insensitively, anywhere in the tree.
 public struct WhoopExportImporter {
 
-    public init() {}
+    /// Aggregate ceiling on the bytes held in RAM across ALL retained CSVs from one import. The per-entry
+    /// cap (`maxEntryBytes`) bounds a single file, but NOT the sum of the retained set — this backstops a
+    /// crafted export from accumulating unbounded `Data` in the result dict. A real Whoop bundle is a few
+    /// MB, so 1 GB never trips in practice. Injectable so tests can exercise the budget with tiny inputs.
+    let maxTotalBytes: Int
+
+    public init(maxTotalBytes: Int = 1 << 30) { self.maxTotalBytes = maxTotalBytes }
 
     // MARK: - Strain → Effort rescale (Charge/Effort/Rest redesign, 2026-06-12)
 
@@ -150,6 +156,7 @@ public struct WhoopExportImporter {
     private func loadFromFolder(_ folder: URL) throws -> [String: Data] {
         let fm = FileManager.default
         var result: [String: Data] = [:]
+        var total = 0
 
         guard let enumerator = fm.enumerator(
             at: folder,
@@ -167,7 +174,9 @@ public struct WhoopExportImporter {
             guard let data = try? Data(contentsOf: fileURL) else { continue }
             // Route by English name, localized filename alias, then header content (issue #3).
             if let key = Self.canonicalKey(base: base, data: data), result[key] == nil {
+                if total + data.count > maxTotalBytes { break }   // aggregate RAM ceiling across retained CSVs
                 result[key] = data
+                total += data.count
             }
         }
         return result
@@ -186,6 +195,7 @@ public struct WhoopExportImporter {
         }
 
         var result: [String: Data] = [:]
+        var total = 0
 
         for entry in archive {
             guard entry.type == .file else { continue }
@@ -211,7 +221,9 @@ public struct WhoopExportImporter {
             guard !buffer.isEmpty else { continue }
             // Route by English name, localized filename alias, then header content (issue #3).
             if let key = Self.canonicalKey(base: base, data: buffer), result[key] == nil {
+                if total + buffer.count > maxTotalBytes { break }   // aggregate RAM ceiling across retained CSVs
                 result[key] = buffer
+                total += buffer.count
             }
         }
         return result

--- a/Packages/StrandImport/Tests/StrandImportTests/ImportByteBudgetTests.swift
+++ b/Packages/StrandImport/Tests/StrandImportTests/ImportByteBudgetTests.swift
@@ -1,0 +1,86 @@
+import XCTest
+import ZIPFoundation
+@testable import StrandImport
+
+/// The export importers must not buffer an unbounded slice of an archive in RAM. Before, each importer
+/// collected every recognised entry into a `[String: Data]` with only a PER-ENTRY cap — the SUM of the
+/// retained set was unbounded (the Wearable path can carry up to `maxFiles` = 200k entries). These tests
+/// pin the new aggregate `maxTotalBytes` budget: once adding the next retained entry would exceed it,
+/// collection stops. ZIPFoundation preserves add-order, so which entries survive is deterministic.
+final class ImportByteBudgetTests: XCTestCase {
+    private var tempDirs: [URL] = []
+
+    override func tearDownWithError() throws {
+        for d in tempDirs { try? FileManager.default.removeItem(at: d) }
+        tempDirs.removeAll()
+    }
+
+    private func makeTempDir() -> URL {
+        let d = FileManager.default.temporaryDirectory
+            .appendingPathComponent("strandimport-budget-\(UUID().uuidString)")
+        try? FileManager.default.createDirectory(at: d, withIntermediateDirectories: true)
+        tempDirs.append(d)
+        return d
+    }
+
+    /// Build a zip from ordered `(entryPath, rawBytes)` pairs.
+    private func makeZip(named: String, entries: [(String, Data)]) throws -> URL {
+        let zipURL = makeTempDir().appendingPathComponent(named)
+        let archive = try Archive(url: zipURL, accessMode: .create)
+        for (path, data) in entries {
+            try archive.addEntry(with: path, type: .file, uncompressedSize: Int64(data.count)) { position, size in
+                let start = data.startIndex + Int(position)
+                return data.subdata(in: start ..< start + size)
+            }
+        }
+        return zipURL
+    }
+
+    // MARK: Whoop — a cap admitting only the first CSV drops the rest (end-to-end through parse)
+
+    func testWhoopZipStopsAtTotalByteBudget() throws {
+        let cycles = Fixtures.data("physiological_cycles.csv")
+        let zip = try makeZip(named: "whoop.zip", entries: [
+            ("physiological_cycles.csv", cycles),
+            ("sleeps.csv", Fixtures.data("sleeps.csv")),
+            ("workouts.csv", Fixtures.data("workouts.csv")),
+            ("journal_entries.csv", Fixtures.data("journal_entries.csv")),
+        ])
+
+        // Uncapped: all four CSVs are parsed.
+        let full = try WhoopExportImporter().import(from: zip)
+        XCTAssertEqual(full.cycles.count, 2)
+        XCTAssertEqual(full.sleeps.count, 2)
+        XCTAssertEqual(full.workouts.count, 2)
+        XCTAssertEqual(full.journal.count, 2)
+
+        // Cap = just over the first (cycles) CSV: the budget trips before the second retained entry, so only
+        // cycles survives — no unbounded buffering of the whole archive.
+        let capped = try WhoopExportImporter(maxTotalBytes: cycles.count + 1).import(from: zip)
+        XCTAssertEqual(capped.cycles.count, 2)
+        XCTAssertTrue(capped.sleeps.isEmpty)
+        XCTAssertTrue(capped.workouts.isEmpty)
+        XCTAssertTrue(capped.journal.isEmpty)
+    }
+
+    // MARK: Wearable — the real offender: cap bounds the retained set regardless of entry count
+
+    func testWearableZipStopsAtTotalByteBudget() throws {
+        // Content is irrelevant to collection (the wellness filter is name-based); size is what matters.
+        let blob = Data(repeating: 0x20, count: 400)   // 400 bytes each, all "sleep*" → wellness by name
+        let zip = try makeZip(named: "wearable.zip", entries: [
+            ("sleep_a.json", blob),
+            ("sleep_b.json", blob),
+            ("sleep_c.json", blob),
+        ])
+
+        let full = try WearableExportImporter().collectFiles(from: zip)
+        XCTAssertEqual(full.count, 3)
+
+        // Cap = 1.5 blobs: admits the first, trips before the second.
+        let cap = 600
+        let capped = try WearableExportImporter(maxTotalBytes: cap).collectFiles(from: zip)
+        XCTAssertEqual(capped.count, 1)
+        XCTAssertLessThanOrEqual(capped.values.reduce(0) { $0 + $1.count }, cap)
+    }
+}


### PR DESCRIPTION
## What & why

The Whoop and Wearable export importers each collect every recognised entry into a `[String: Data]` held **entirely in memory**, guarded only by a **per-entry** ceiling (`maxEntryBytes` = 256 MB). Nothing bounded the **sum** of the retained set — and the Wearable path can carry up to `maxFiles` = **200 000** entries. A large (or crafted) export could accumulate unbounded `Data` in the result dict before the parser ever runs.

## The change

Add an injectable `maxTotalBytes` budget (default **1 GB**) and enforce it in **both importers, in both the zip and folder loaders**: once adding the next retained entry would push the running total past the budget, collection stops. Peak import RAM is now bounded regardless of how many entries the archive holds. Real exports — a few MB (Whoop) to tens of MB (Wearable) — never approach it.

## Why a byte budget, not temp-file streaming

`AppleHealthImporter` streams its single big `export.xml` to a temp file — but that works only because its **XML parser reads incrementally from disk**. These two importers instead parse **in-memory `Data`** (CSV tables / JSON), and brand-detection needs the whole file-set together. So the bytes have to be in RAM to be parsed at all; spilling them to disk would just mean reading them back. The correct RAM bound here is therefore a cap on their **sum**, which is what this adds.

## Verification

- New `ImportByteBudgetTests`: a cap admitting only the first entry drops the rest — Whoop end-to-end through parse, Wearable via `collectFiles` — and the retained bytes stay within budget. (ZIPFoundation preserves entry order, so the outcome is deterministic.)
- Existing importer suites unaffected: `WhoopExportImporterTests` (20), `WearableExportImporterTests` (15), `ImportCoordinatorTests` (9) all green.
- Full `StrandImport` package suite green — **170 tests, 0 failures** (`swift test`).

## Checklist
- [x] Behavior-preserving for real exports (budget never trips below 1 GB; normal imports unchanged)
- [x] `swift test` green (StrandImport, 170)
- [x] Both importers, both zip + folder paths covered
- [x] No format / schema change; default preserves current behavior
- [x] No hardcoded hex frame bytes / UI-token rules — n/a

*Perf/robustness pass, AI-assisted; budget behavior tested locally with tiny injected caps.*
