### PR TITLE
Strap log: soften stale-RTC diag wording ("no clock correlation at decode") — #67 follow-up

### DIFF
--- a/Strand/Collect/Backfiller.swift
+++ b/Strand/Collect/Backfiller.swift
@@ -109,7 +109,8 @@ final class Backfiller {
 
     /// #67 diag: the clock reference the offload ACTUALLY decoded with, captured on the first chunk of the
     /// session. Surfaces whether the stale-RTC timestamp correction (FIX #72's `correctedWall`) could even
-    /// engage. `sessionUsedIdentityRef` = GET_CLOCK never correlated, so decode fell back to an identity
+    /// engage. `sessionUsedIdentityRef` = no clock correlation had landed when the first chunk decoded, so
+    /// that decode fell back to an identity
     /// ref (device==wall==now) → clock offset 0 → correction OFF. On a strap whose RTC has reset, that
     /// silently stores the strap's stale (years-old) timestamps verbatim, so the night lands off the recent
     /// timeline and reads as "missed sleep". Paired with the persisted-nights DATE RANGE below, one strap
@@ -306,7 +307,7 @@ final class Backfiller {
             let offset = wall - device
             let days = offset / 86_400
             if usedIdentityRef {
-                line += " · clock ref: IDENTITY fallback (GET_CLOCK never correlated) - stale-record correction OFF"
+                line += " · clock ref: IDENTITY fallback (no clock correlation at decode) - stale-record correction OFF"
             } else if abs(offset) > 86_400 {
                 line += " · strap clock \(days >= 0 ? "\(days)d behind" : "\(-days)d ahead") wall - correction engaged"
             } else {

--- a/StrandTests/BackfillerSessionTallyTests.swift
+++ b/StrandTests/BackfillerSessionTallyTests.swift
@@ -64,7 +64,7 @@ final class BackfillerSessionTallyTests: XCTestCase {
         let line = Backfiller.sessionClockDiagLine(nightKeys: [marchDay],
                                                    device: 1_783_486_611, wall: 1_783_486_611,
                                                    usedIdentityRef: true)
-        XCTAssertEqual(line, "Backfill: rows landed on 2024-03-24 · clock ref: IDENTITY fallback (GET_CLOCK never correlated) - stale-record correction OFF")
+        XCTAssertEqual(line, "Backfill: rows landed on 2024-03-24 · clock ref: IDENTITY fallback (no clock correlation at decode) - stale-record correction OFF")
     }
 
     // A genuinely stale-but-correlated ref: the correction IS engaged and the behind-by days are named.


### PR DESCRIPTION
Small follow-up to #69 (re-review finding). No behaviour change; log wording only.

The identity-fallback line printed `(GET_CLOCK never correlated)`, but `sessionUsedIdentityRef` is captured on the **first chunk** of the session. Normally the clock correlation lands before chunk 1 (the offload is deferred ~1.5s for exactly that); in the reset-RTC case it never lands — both accurate. But on a slow link GET_CLOCK can reply *late*: chunk 1 decodes on the identity fallback, later chunks on the real ref — so "**never**" is false.

First-chunk capture is still correct for this diagnostic (the early rows are the ones that landed misdated, which is what we want flagged); only the absolute word overreached. Reworded to `(no clock correlation at decode)`, which is true whether or not a late reply lands afterward. Doc comment and the exact-match test assertion updated to match.

Files: `Strand/Collect/Backfiller.swift`, `StrandTests/BackfillerSessionTallyTests.swift`.