### PR TITLE
Settings: Sex picker → .menu, fixes oversized Settings screen (#43)

### DIFF
--- a/Strand/Screens/SettingsView.swift
+++ b/Strand/Screens/SettingsView.swift
@@ -313,8 +313,12 @@ struct SettingsView: View {
                         Text("Non-binary").tag("nonbinary")
                     }
                     .labelsHidden()
-                    .pickerStyle(.segmented)
-                    .fixedSize()
+                    // #43: .menu, not .segmented + .fixedSize(). In FormRow's label(∞)+control HStack a
+                    // segmented picker collapses WITHOUT .fixedSize() but OVERFLOWS the screen WITH it once
+                    // the labels are long (German "Nicht-binär") or Text Size is enlarged — the oversized
+                    // Settings screen users reported. A menu is a compact button that fits any label length.
+                    .pickerStyle(.menu)
+                    .tint(StrandPalette.accent)
                     .accessibilityLabel("Sex")
                 }
                 rowDivider


### PR DESCRIPTION
Fixes #43 — the Settings screen renders oversized / off the right edge on iOS. Two reporters (japothek; adrnxq — **German, since ~8.3.3**), Settings-only, every other screen fine.

### Cause
The **Sex** row (`SettingsView.swift`) is a `.pickerStyle(.segmented)` picker (Male / Female / **Non-binary**) with a bare **`.fixedSize()`**. `FormRow` lays out `Text(label).frame(maxWidth: .infinity) + control` in an HStack — so a segmented picker there *collapses* without `.fixedSize()`, but *with* it the picker is forced to its full intrinsic width. Three labels (one long, longer still in German "Nicht-binär") or an enlarged Text Size make that width exceed the screen, pushing the **whole Settings column** past the edge. That single overflowing row is why the entire screen looks oversized while other screens are fine. It's the only bare `.fixedSize()` in the file (the rest are `horizontal: false`, which is safe). Blame shows the code predates 8.2.2, so the trigger was the German localization lengthening the labels.

### Fix (minimal)
Switch that one picker to `.pickerStyle(.menu)` and drop `.fixedSize()`. A menu is a compact "Male ▾" button that fits any label length, needs no fixed sizing, and is immune to Dynamic Type / localization. Tinted to match the app's other menu pickers (e.g. the backup keep-count). No other rows touched.

### Testing
SwiftUI can't build on the maintainer's box (WSL); this is a standard modifier swap using an existing palette token already used 40× in the file. Verified by inspection + the layout reasoning above; a testing build / on-device check confirms the visual.

File: `Strand/Screens/SettingsView.swift`.