### PR TITLE
Smart alarm: instrument + warn when the strap keeps refusing the alarm (#34)

### DIFF
--- a/Strand/BLE/BLEManager.swift
+++ b/Strand/BLE/BLEManager.swift
@@ -2461,10 +2461,18 @@ public final class BLEManager: NSObject, ObservableObject {
         d.set(sentEpoch, forKey: "alarm.lastArmSentEpoch")
         d.set(Date().timeIntervalSince1970, forKey: "alarm.lastArmAt")
         d.set(connectedPeripheralUUID != nil, forKey: "alarm.lastArmConnected")
+        // #34: the strap-clock skew (its own RTC minus wall, seconds) AT THE MOMENT we armed. A wrong RTC
+        // is a top cause of the firmware alarm never firing, and knowing the clock state at arm — not just
+        // now — tells whether the arm even had a chance (skew ~0 but the strap still rejects ⇒ a corrupted
+        // alarm register, not a clock problem).
+        d.set(strapClockNow - Int(Date().timeIntervalSince1970), forKey: "alarm.lastArmClockSkew")
     }
 
     /// Disarm the currently-armed firmware alarm.
     func disableStrapAlarm() {
+        // #34: clear the "strap keeps rejecting the alarm" streak/warning — it's about an ACTIVE arm being
+        // refused, and there's nothing armed to refuse once disarmed.
+        UserDefaults.standard.set(0, forKey: "alarm.rejectStreak")
         if selectedModel.deviceFamily == .whoop5 {
             // 5/MG DISABLE_ALARM is REVISION_2 [0x02, 0xFF]; the rev-1 [0x01] form below is WHOOP4.
             send(.disableAlarm, payload: AlarmPayload.disableRev2())

--- a/Strand/BLE/FrameRouter.swift
+++ b/Strand/BLE/FrameRouter.swift
@@ -123,8 +123,18 @@ public final class FrameRouter {
                     if let epoch = Self.armedAlarmEpoch(in: frame) {
                         state.append(log: "Alarm: strap reports armed for \(Self.alarmLocalTime(epoch: epoch)) (epoch \(epoch))")
                         // #34: persist what the strap reports so the debug export can show sent-vs-reported.
-                        UserDefaults.standard.set(Int(epoch), forKey: "alarm.lastReportedEpoch")
-                        UserDefaults.standard.set(Date().timeIntervalSince1970, forKey: "alarm.lastReportedAt")
+                        let d = UserDefaults.standard
+                        d.set(Int(epoch), forKey: "alarm.lastReportedEpoch")
+                        d.set(Date().timeIntervalSince1970, forKey: "alarm.lastReportedAt")
+                        // #34: count CONSECUTIVE rejections (reported ≠ what we last sent) — the signature of
+                        // a corrupted strap alarm register. A matching readback resets it, so a transient
+                        // (first read stale, then correct) never trips the warning; only a persistent refusal
+                        // climbs. SmartAlarmView surfaces the warning at ≥2; the debug export shows the count.
+                        // Observability only — never gates the BLE arm.
+                        if let sent = d.object(forKey: "alarm.lastArmSentEpoch") as? Int {
+                            d.set(abs(Int(epoch) - sent) > 120 ? d.integer(forKey: "alarm.rejectStreak") + 1 : 0,
+                                  forKey: "alarm.rejectStreak")
+                        }
                     } else {
                         state.append(log: "Alarm: strap answered the alarm readback with an unrecognised payload (raw \(Self.commandResponsePayloadHex(in: frame) ?? "empty")) - layout undocumented, log-only")
                     }

--- a/Strand/Screens/SmartAlarmView.swift
+++ b/Strand/Screens/SmartAlarmView.swift
@@ -26,6 +26,11 @@ struct SmartAlarmView: View {
     // behaves exactly as before (one wake time for every evening).
     @State private var perDayOn = WindDownNudge.hasPerDayOverrides
     @State private var overrides: [Int: Int] = WindDownNudge.perDayWakeOverrides
+
+    // #34: consecutive times the strap reported back a DIFFERENT alarm time than we sent (set in
+    // FrameRouter). ≥2 = the strap is persistently refusing the alarm (a corrupted clock/alarm register),
+    // which the strapRejectedCard surfaces with reset guidance. @AppStorage so it updates live.
+    @AppStorage("alarm.rejectStreak") private var alarmRejectStreak = 0
     /// Calendar weekday numbers laid out Monday-first (Mon…Sun → 2,3,4,5,6,7,1), matching AutomationsView.
     private static let weekdayOrder = [2, 3, 4, 5, 6, 7, 1]
 
@@ -37,6 +42,7 @@ struct SmartAlarmView: View {
             VStack(alignment: .leading, spacing: NoopMetrics.sectionGap) {
                 windowHero
                 strapAlarmCard
+                strapRejectedCard   // #34: only shows when the strap keeps refusing the alarm
                 honestyCard
                 windDownCard
             }
@@ -83,6 +89,31 @@ struct SmartAlarmView: View {
             Text(time)
                 .font(StrandFont.number(28))
                 .foregroundStyle(tint)
+        }
+    }
+
+    // #34: shown ONLY when the strap has repeatedly reported back a different alarm time than we sent —
+    // i.e. its firmware is refusing the write (a reset/corrupted clock/alarm register). Gated on the alarm
+    // being on and a rejection STREAK (≥2) so a one-off readback quirk never nags. Actionable: a strap
+    // reset via the official app clears it; the phone Clock alarm covers the gap meanwhile.
+    @ViewBuilder private var strapRejectedCard: some View {
+        if behavior.smartAlarmEnabled && alarmRejectStreak >= 2 {
+            StrandCard(padding: 20) {
+                HStack(alignment: .top, spacing: 12) {
+                    Image(systemName: "exclamationmark.triangle.fill")
+                        .foregroundStyle(StrandPalette.statusWarning)
+                        .accessibilityHidden(true)
+                    VStack(alignment: .leading, spacing: 6) {
+                        Text("Your strap isn't accepting the alarm")
+                            .font(StrandFont.headline)
+                            .foregroundStyle(StrandPalette.textPrimary)
+                        Text("The strap keeps reporting a different time than NOOP sends, so its firmware alarm won't fire at your wake time — usually a strap whose clock or alarm has reset. Reset the strap in the official WHOOP app (or fully charge it and reconnect), and keep your phone's Clock alarm as your wake until it takes.")
+                            .font(StrandFont.footnote)
+                            .foregroundStyle(StrandPalette.textSecondary)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+                }
+            }
         }
     }
 

--- a/Strand/System/DebugDataDiagnostics.swift
+++ b/Strand/System/DebugDataDiagnostics.swift
@@ -231,11 +231,22 @@ enum DebugDataDiagnostics {
                 line += " · \(relTime(Date().timeIntervalSince1970 - at))"
             }
             if !d.bool(forKey: "alarm.lastArmConnected") { line += " · strap NOT connected (queued)" }
+            // #34: the strap-clock skew AT ARM. Skew ~0 but the strap still rejects ⇒ a corrupted alarm
+            // register, not a clock problem (which pins whether a re-clock could ever help).
+            if let skew = d.object(forKey: "alarm.lastArmClockSkew") as? Int, abs(skew) > 3600 {
+                let mag = abs(skew) >= 86400 ? "\(skew / 86400)d" : "\(skew / 3600)h"
+                line += " · strap clock at arm \(skew > 0 ? "+" : "")\(mag)"
+            }
             lines.append(line)
             if let reported = d.object(forKey: "alarm.lastReportedEpoch") as? Int {
                 let mismatch = abs(reported - sent) > 120
-                lines.append("Strap reports: \(alarmStamp(reported))"
-                    + (mismatch ? "  ⚠️ MISMATCH — strap didn't accept the time" : "  ✓ matches"))
+                var rline = "Strap reports: \(alarmStamp(reported))"
+                    + (mismatch ? "  ⚠️ MISMATCH — strap didn't accept the time" : "  ✓ matches")
+                // #34: consecutive rejections — a persistent refusal (vs a one-off) points at a strap whose
+                // alarm register needs a reset, and is what SmartAlarmView warns the user about at ≥2.
+                let streak = d.integer(forKey: "alarm.rejectStreak")
+                if streak >= 2 { rline += " · \(streak) in a row (register likely needs a reset, #34)" }
+                lines.append(rline)
             } else {
                 lines.append("Strap reports: (no readback)")
             }


### PR DESCRIPTION
The diagnosis path for #34 (alarm not buzzing). A strap whose clock/alarm register has reset silently rejects `SET_ALARM_TIME` — the `GET_ALARM_TIME` readback keeps returning an old value (andresbernalc's stayed at a 2021 epoch across six writes) — so the firmware alarm never fires. Until now that mismatch was visible **only in the debug export, and only as a one-shot**. This makes it a persistent signal and surfaces it to the user.

**No BLE command changes** — pure observability + one conditional UI card.

### #2 — instrumentation
- **FrameRouter:** on each readback, count **consecutive** rejections (reported ≠ last sent). A matching readback resets the streak, so a transient (first read stale, then correct) never trips it; only a persistent refusal climbs.
- **recordAlarmArm:** persist the **strap-clock skew at arm**. Skew ≈ 0 while the strap still rejects ⇒ a corrupted alarm **register**, not a clock problem — which pins whether a re-clock could ever help. (For #34's strap the clock had recovered, so this would read ≈0 and point straight at the register.)
- **Debug export Alarm block** surfaces both: clock-at-arm on the `Last arm` line, `N in a row` on `Strap reports`.
- **disableStrapAlarm** clears the streak (nothing armed to refuse once disarmed).

### #4 — user warning
`SmartAlarmView` shows a card **only** when the alarm is on and the strap has refused **≥2 arms in a row**: "Your strap isn't accepting the alarm… reset it in the official WHOOP app, keep your phone's Clock alarm meanwhile." Driven by `@AppStorage("alarm.rejectStreak")` so it appears and clears live.

### Scope / honesty
Not a fix for a corrupted strap — that's firmware-side, only a strap reset clears it. This turns a silent, export-only failure into on-device guidance the affected user can act on. SwiftUI/BLE can't build on WSL; verified by inspection + streak/skew reasoning — needs a device to confirm the card + export lines.

Files: `Strand/BLE/FrameRouter.swift`, `Strand/BLE/BLEManager.swift`, `Strand/System/DebugDataDiagnostics.swift`, `Strand/Screens/SmartAlarmView.swift`.