### PR TITLE
Today hero: keep ring labels/pills on one line (oversized card, #74)

### DIFF
--- a/Strand/Liquid/LiquidTodayView.swift
+++ b/Strand/Liquid/LiquidTodayView.swift
@@ -1095,7 +1095,10 @@ private struct HeroScoreCell: View {
             }
             Button(action: onGuide) {
                 HStack(spacing: 3) {
+                    // #74: one line, shrink-to-fit rather than wrap under large Dynamic Type (mirrors the
+                    // score number above) so CHARGE/EFFORT/REST never grow the hero card to two lines.
                     Text(label.uppercased()).font(StrandFont.overline).tracking(1.6)
+                        .lineLimit(1).minimumScaleFactor(0.7)
                     Image(systemName: "chevron.right").font(.system(size: 9, weight: .semibold)).opacity(0.6)
                 }
                 // The hero card fill is pinned dark in BOTH themes, so the CHARGE/EFFORT/REST label must use
@@ -1108,6 +1111,7 @@ private struct HeroScoreCell: View {
             if let pill {
                 Text(pill)
                     .font(StrandFont.overlineScaled(8.5)).tracking(1.2)
+                    .lineLimit(1).minimumScaleFactor(0.8)   // #74: source pill never wraps the hero card
                     // WHOOP pill on the pinned-dark hero card → on-dark token, not the theme-flipping one (#1013).
                     .foregroundStyle(StrandPalette.onDarkSecondary)
                     .padding(.horizontal, 8).padding(.vertical, 2.5)

--- a/android/app/src/main/java/com/noop/ui/Components.kt
+++ b/android/app/src/main/java/com/noop/ui/Components.kt
@@ -396,6 +396,8 @@ fun SourceBadge(text: String, tint: Color = Palette.accent, modifier: Modifier =
         text = text.uppercase(),
         style = NoopType.overline.copy(fontSize = 10.sp, letterSpacing = 0.5.sp),
         color = tint,
+        maxLines = 1,                          // #74: e.g. "ON-DEVICE" stays on one line, never wraps the hero
+        overflow = TextOverflow.Ellipsis,
         modifier = modifier
             .clip(shape)
             .background(tint.copy(alpha = 0.14f))

--- a/android/app/src/main/java/com/noop/ui/TodayScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/TodayScreen.kt
@@ -2328,7 +2328,10 @@ private fun HeroRingColumn(
                     .size(14.dp)
                     .alpha(0f),
             )
-            Text(domain.label.uppercase(), style = NoopType.overline, color = Palette.textSecondary)
+            // #74: never wrap the hero label onto a second line — at a larger font/screen-zoom (Samsung
+            // One UI defaults) "REST" could wrap, growing the whole hero card. One line, ellipsis if forced.
+            Text(domain.label.uppercase(), style = NoopType.overline, color = Palette.textSecondary,
+                 maxLines = 1, overflow = TextOverflow.Ellipsis)
             Icon(
                 Icons.AutoMirrored.Filled.KeyboardArrowRight,
                 contentDescription = "How ${domain.label} is calculated",
@@ -2365,6 +2368,8 @@ private fun HeroSourcePill(text: String) {
         text = text.uppercase(),
         style = NoopType.overline.copy(fontSize = 8.5.sp, letterSpacing = 1.2.sp),
         color = Palette.textSecondary,
+        maxLines = 1,                          // #74: source pill stays on one line
+        overflow = TextOverflow.Ellipsis,
         modifier = Modifier
             .clip(shape)
             .background(Color.White.copy(alpha = 0.05f))


### PR DESCRIPTION
Fixes the practical part of #74 — the Today hero looks oversized / cramped on a Samsung Galaxy S20 FE, with "REST" and "ON-DEVICE" wrapping onto two lines.

### Diagnosis
The ring **size is already responsive** — `ScoreHeroRow`: `((maxWidth - gap*2)/3.1f).coerceIn(90.dp, 112.dp)`. That's not the bug. The gap is the under-ring **labels and source pills**: they're `sp`-sized (so they scale with the device font) and **none was capped to one line**, so at a larger font — or a larger **screen zoom**, which Samsung One UI commonly ships above stock AOSP — they wrap, growing the whole hero card. This is the Android sibling of #43.

Both platforms had it (iOS protects the score number with `lineLimit(1).minimumScaleFactor` but not the label/pill), so this fixes both:

- **Android:** `maxLines = 1` + `TextOverflow.Ellipsis` on the ring label (`TodayScreen`), `HeroSourcePill`, and `SourceBadge`.
- **iOS:** `.lineLimit(1).minimumScaleFactor(...)` on the `HeroScoreCell` label and pill (mirrors the score number right above them).

Layout-only, no logic change.

### Testing
Android Kotlin **compiles locally** (`compileFullDebugKotlin`, exit 0). iOS is a trivial SwiftUI-modifier change (can't build on WSL; CI-gated). Verified by inspection + the layout reasoning.

### Note
This stops the multi-line wrap in all cases. The reporter's Samsung **Screen Zoom / Font Size** is still the amplifier that pushed it over — worth confirming with them (a larger-than-stock default), since that also affects how large the rings render relative to the README screenshots.

Files: `android/.../TodayScreen.kt`, `android/.../Components.kt`, `Strand/Liquid/LiquidTodayView.swift`.