### PR TITLE
Battery alert: stop re-firing the low-battery notification while charging (#80)

### DIFF
--- a/Strand/System/BatteryNotifier.swift
+++ b/Strand/System/BatteryNotifier.swift
@@ -35,8 +35,12 @@ enum BatteryNotifier {
             var full = fullAlerted
             // The stale 100%-full note must be cleared the moment we re-arm below the full line.
             let clearFull = fullAlerted && pct < fullThreshold
-            // Re-arm (hysteresis) so jitter near a threshold can't re-fire.
-            if charging == true || pct >= lowRearmAbove { low = false }
+            // Re-arm (hysteresis) so jitter near a threshold can't re-fire. #80: re-arm ONLY on genuine
+            // recovery (pct >= lowRearmAbove), NOT on charging. The strap reports its charge bit only every
+            // ~8 min, so it flickers true→nil; re-arming on `true` then firing on the `nil` gap re-fired the
+            // low alert repeatedly WHILE charging. `fireLow`'s `charging != true` still suppresses an explicit
+            // charging reading, and a null-charging strap (generic/FTMS) still alerts.
+            if pct >= lowRearmAbove { low = false }
             if pct < fullThreshold { full = false }
             // Fire at most once per genuine crossing.
             let fireLow = !low && pct <= lowThreshold && charging != true

--- a/StrandTests/BatteryAlertPolicyTests.swift
+++ b/StrandTests/BatteryAlertPolicyTests.swift
@@ -56,16 +56,28 @@ final class BatteryAlertPolicyTests: XCTestCase {
         XCTAssertTrue(again.fireLow)
     }
 
-    // 4. charging == true suppresses the low alert even at 10%, and re-arms the low flag.
-    func testChargingSuppressesAndReArmsLow() {
-        // Already alerted, but now plugged in at 10% — must not fire, and the flag re-arms.
+    // 4. charging == true suppresses the low alert even at 10%, and (#80) does NOT re-arm — an
+    //    already-alerted flag stays set so the charge bit flickering to nil can't re-fire it.
+    func testChargingSuppressesLowWithoutReArming() {
+        // Already alerted, but now plugged in at 10% — must not fire, and the flag must STAY set.
         let r = Policy.evaluate(pct: 10, charging: true, lowAlerted: true, fullAlerted: false)
         XCTAssertFalse(r.fireLow)
-        XCTAssertFalse(r.newLowAlerted)
+        XCTAssertTrue(r.newLowAlerted)   // #80: charging must NOT re-arm
 
         // From a clean state, charging at 10% still suppresses.
         let clean = Policy.evaluate(pct: 10, charging: true, lowAlerted: false, fullAlerted: false)
         XCTAssertFalse(clean.fireLow)
+    }
+
+    // 4b. (#80) The strap reports its charge bit only every ~8 min, so it flickers true→nil. While low, a
+    //     charging read followed by a nil read must NOT re-fire the low alert.
+    func testChargeBitFlickerToNilDoesNotReFireLow() {
+        var low = true   // low alert already fired (before plugging in, or on the first not-charging read)
+        let charging = Policy.evaluate(pct: 12, charging: true, lowAlerted: low, fullAlerted: false)
+        XCTAssertFalse(charging.fireLow); low = charging.newLowAlerted
+        // Next BATTERY_LEVEL event hasn't landed yet → charge state unknown. Must stay silent.
+        let gap = Policy.evaluate(pct: 12, charging: nil, lowAlerted: low, fullAlerted: false)
+        XCTAssertFalse(gap.fireLow)   // was `true` before the #80 fix
     }
 
     // 5. Full fires once at 100%; stays quiet until pct drops below 100, then 100 again re-fires.

--- a/android/app/src/main/java/com/noop/notif/BatteryAlertNotifier.kt
+++ b/android/app/src/main/java/com/noop/notif/BatteryAlertNotifier.kt
@@ -49,8 +49,12 @@ internal object BatteryAlertPolicy {
         var full = fullAlerted
         // The stale 100%-full note must be cleared the moment we re-arm below the full line.
         val clearFull = fullAlerted && pct < FULL_THRESHOLD
-        // Re-arm (hysteresis) so jitter near a threshold can't re-fire.
-        if (charging == true || pct >= LOW_REARM_ABOVE) low = false
+        // Re-arm (hysteresis) so jitter near a threshold can't re-fire. #80: re-arm ONLY on genuine recovery
+        // (pct >= LOW_REARM_ABOVE), NOT on charging. The strap reports its charge bit only every ~8 min, so
+        // it flickers true→null; re-arming on `true` then firing on the `null` gap re-fired the low alert
+        // repeatedly WHILE charging. `fireLow`'s `charging != true` still suppresses an explicit charging
+        // reading, and a null-charging strap (generic/FTMS) still alerts.
+        if (pct >= LOW_REARM_ABOVE) low = false
         if (pct < FULL_THRESHOLD) full = false
         // Fire at most once per genuine crossing.
         val fireLow = !low && pct <= LOW_THRESHOLD && charging != true

--- a/android/app/src/test/java/com/noop/notif/BatteryAlertPolicyTest.kt
+++ b/android/app/src/test/java/com/noop/notif/BatteryAlertPolicyTest.kt
@@ -68,13 +68,27 @@ class BatteryAlertPolicyTest {
         assertTrue(refired.fireLow)
     }
 
-    /** 4. charging == true suppresses the low alert even at 10%, and re-arms the low flag. */
+    /** 4. charging == true suppresses the low alert even at 10%, and (#80) does NOT re-arm — an
+     *  already-alerted flag stays set so the charge bit flickering to null can't re-fire it. */
     @Test
-    fun chargingSuppressesLowAndRearms() {
+    fun chargingSuppressesLowWithoutRearming() {
         val r = BatteryAlertPolicy.evaluate(pct = 10, charging = true, lowAlerted = true, fullAlerted = false)
         assertFalse(r.fireLow)
-        // charging re-arms so once it's unplugged and drains again the alert can fire.
-        assertFalse(r.newLowAlerted)
+        // #80: charging must NOT re-arm. It used to zero the flag here, and the next null-charging read then
+        // re-fired the alert WHILE charging. The already-alerted flag now stays set.
+        assertTrue(r.newLowAlerted)
+    }
+
+    /** 4b. (#80) The strap reports its charge bit only every ~8 min, so it flickers true→null. While low,
+     *  a charging read followed by a null read must NOT re-fire the low alert. */
+    @Test
+    fun chargeBitFlickerToNullDoesNotRefireLow() {
+        var low = true   // low alert already fired (before plugging in, or on the first not-charging read)
+        val charging = BatteryAlertPolicy.evaluate(pct = 12, charging = true, lowAlerted = low, fullAlerted = false)
+        assertFalse(charging.fireLow); low = charging.newLowAlerted
+        // Next BATTERY_LEVEL event hasn't landed yet → charge state unknown. Must stay silent.
+        val gap = BatteryAlertPolicy.evaluate(pct = 12, charging = null, lowAlerted = low, fullAlerted = false)
+        assertFalse(gap.fireLow)   // was `true` before the #80 fix
     }
 
     /** 5. Full fires once at 100; stays armed until pct drops below 100, then 100 again re-fires. */


### PR DESCRIPTION
Fixes #80 — the "charge your strap" low-battery notification fires repeatedly *while the strap is charging*.

### Root cause (both platforms — identical policy)
`BatteryAlertPolicy` already knew about charging, but the two conditions interacted badly:
- re-armed the low flag on `charging == true`, yet
- fired whenever `charging != true` (which includes the `null`/unknown state).

The strap reports its charge bit only on **BATTERY_LEVEL events (~every 8 min)**, so `charging` flickers **`true` → `null`** between events:
1. `true` read → re-arms `low = false` (no fire).
2. `null` gap → `!low` is true, `pct ≤ 15`, `charging != true` is true → **fires again**.

Every flicker re-armed then re-fired → repeated notifications while plugged in.

### Fix
Re-arm the low flag **only on genuine recovery** (`pct >= lowRearmAbove`), not on the charge bit:
```diff
- if (charging == true || pct >= LOW_REARM_ABOVE) low = false
+ if (pct >= LOW_REARM_ABOVE) low = false
```
`fireLow`'s `charging != true` guard is untouched, so:
- an explicit `charging == true` read still suppresses;
- a strap that never reports a charge bit (`charging == null`, e.g. generic/FTMS) still gets low alerts (no regression);
- **charging still re-arms for the next cycle** — via the recovered *percentage* once it climbs past 25%, not the flickering bit. A partial top-up that stays < 25% simply won't nag.

Applied identically to **iOS** (`BatteryNotifier`) and **Android** (`BatteryAlertPolicy`).

### Tests
Updated the "charging suppresses low" case (charging must **not** re-arm now) and added a **true→null flicker regression** on both platforms. **Android unit test green** (`testFullDebugUnitTest --tests BatteryAlertPolicyTest`, exit 0). iOS is the byte-identical mirror (can't run on WSL — StrandTests → GRDB `sqlite3.h` wall — runs in CI).

Files: `Strand/System/BatteryNotifier.swift`, `StrandTests/BatteryAlertPolicyTests.swift`, `android/.../BatteryAlertNotifier.kt`, `android/.../BatteryAlertPolicyTest.kt`.