### PR TITLE
Settings: add missing row dividers in the Appearance card (#79)

### DIFF
--- a/Strand/Screens/SettingsView.swift
+++ b/Strand/Screens/SettingsView.swift
@@ -656,6 +656,7 @@ struct SettingsView: View {
                     .fixedSize()
                     .accessibilityLabel("Theme")
                 }
+                rowDivider   // #79: the segmented rows sat flush against each other (missing separator)
                 FormRow(label: "Chart colours") {
                     // Default = NOOP's clean metric ramps; Classic = the throwback red→amber→green
                     // readiness scale (cool→hot zones, green→red stress). Both schemes.
@@ -670,6 +671,7 @@ struct SettingsView: View {
                     .accessibilityLabel("Chart colours")
                 }
                 #if os(iOS)
+                rowDivider   // #79: separator before App icon (inside #if so macOS keeps a single divider)
                 FormRow(label: "App icon") {
                     Picker("App icon", selection: $useNavyIcon) {
                         Text("Default").tag(false)

--- a/android/app/src/main/java/com/noop/ui/SettingsScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/SettingsScreen.kt
@@ -909,6 +909,8 @@ fun SettingsScreen(
                     },
                 )
             }
+            RowDivider()   // #79 parity: the hairline every other section has between FormRows (Android rows
+                           // were already 16dp-spaced, unlike iOS where they touched — this matches both)
             FormRow(label = "Chart colours") {
                 // Titanium = brand gold/amber/blue ramps; Classic = throwback red→green readiness scale
                 // (cool→hot zones, green→red stress). Re-colours every gauge/chart, in both schemes.


### PR DESCRIPTION
Fixes #79 — in the **Appearance** card on iOS, the option rows touch each other, unlike the card above it.

### Cause
`SettingsView.appearanceCard` lays its rows in `VStack(spacing: 0)` but — unlike `profileCard` and every other card — has **no `rowDivider`** between **Theme → Chart colours → App icon**. So they sit flush. (`rowDivider` is the standard 1px hairline + 4pt padding used throughout Settings.)

### Fix
- **iOS:** add `rowDivider` between Theme↔Chart colours and Chart colours↔App icon. The App-icon divider is inside `#if os(iOS)`, so **macOS** (no App-icon row) keeps a single divider before the toggle section — no double line.
- **Android parity:** the rows there were already 16dp-spaced (`SettingsSection`'s content `Column(spacedBy(16.dp))`), so they weren't touching — but they lacked the hairline every *other* Android section draws between FormRows. Added `RowDivider()` between Theme and Chart colours so it matches iOS and the rest of Settings.

Layout only, no behavior change.

### Testing
Android **compiles locally** (`compileFullDebugKotlin`, exit 0). iOS is a trivial view insertion (CI-gated on WSL). Verified by inspection against the `profileCard`/other-section pattern.

Files: `Strand/Screens/SettingsView.swift`, `android/.../SettingsScreen.kt`.