### PR TITLE
[Oura] Oura integration update

### DIFF
--- a/Packages/OuraProtocol/Sources/OuraProtocol/Framing.swift
+++ b/Packages/OuraProtocol/Sources/OuraProtocol/Framing.swift
@@ -168,10 +168,23 @@ public final class OuraReassembler {
         buf.append(contentsOf: fragment)
         var out: [OuraRecord] = []
         while buf.count >= 2 {
+            let type = buf[0]
             let len = Int(buf[1])
             // A record must cover its 4 timestamp bytes. A len < 4 here is a misaligned byte: drop one
             // and resync rather than emit garbage (honest-data invariant).
             if len < OuraFraming.minRecordLen {
+                buf.removeFirst(1)
+                continue
+            }
+            // RESYNC on an implausible type (OURA_PROTOCOL.md §2.4). The type byte must be a real record
+            // start: a known inner event tag (>= 0x41), or the GetEvents-summary (0x11) / battery (0x0D)
+            // OUTER responses that legitimately ride the same wire and round-trip as sized no-op records.
+            // Any other byte means we are byte-misaligned - typically landed INSIDE a 0x43 debug-text
+            // payload, where ASCII bytes that alias real tags ('p'=0x70 / 'I'=0x49 / 'L'=0x4C / 'Q'=0x51)
+            // would otherwise mint a PHANTOM "summary" whose bogus len swallows the following real records
+            // (e.g. the sleep-phase timeline). Drop one byte and re-scan instead of consuming 2+len of
+            // garbage, so the parser realigns to the next genuine record boundary.
+            if !Self.isPlausibleRecordStart(type) {
                 buf.removeFirst(1)
                 continue
             }
@@ -185,6 +198,16 @@ public final class OuraReassembler {
             buf.removeFirst(total)
         }
         return out
+    }
+
+    /// A byte that can legitimately BEGIN a record on the notify channel: a known inner event tag, or
+    /// the two OUTER command responses that share the wire and are consumed as sized no-op records - the
+    /// GetEvents summary (`0x11`) and battery (`0x0D`), both below the `0x41` tag range. Everything else
+    /// is a byte-misalignment to resync past (§2.4). Kept private + pure so it is exercised via `feed`.
+    static func isPlausibleRecordStart(_ type: UInt8) -> Bool {
+        OuraEventTag(rawValue: type) != nil
+            || type == OuraFraming.getEventsResponseOp
+            || type == OuraFraming.batteryResponseOp
     }
 
     /// Discard any buffered partial bytes (call on disconnect so a half-record does not bleed into the

--- a/Packages/OuraProtocol/Tests/OuraProtocolTests/FramingTests.swift
+++ b/Packages/OuraProtocol/Tests/OuraProtocolTests/FramingTests.swift
@@ -184,11 +184,46 @@ final class FramingTests: XCTestCase {
     }
 
     func testReassemblerLenBelowFourDoesNotEmitGarbageBeforeValidRecord() {
-        // A 2-byte garbage header whose len is < 4 is dropped one byte at a time; because TLV has no
-        // SOF this does not realign to the trailing valid record, but it must NOT emit a bogus record.
+        // A 2-byte garbage header whose len is < 4 is dropped one byte at a time. With the §2.4 type-
+        // resync it now REALIGNS to the trailing valid record (a byte whose type is a known tag) instead
+        // of stalling, and never emits a bogus record.
         let valid = bytes("4e0602000100006c")
         let r = OuraReassembler()
         let recs = r.feed([0x00, 0x01] + valid)   // 00 01 = len 1 (< 4)
         XCTAssertTrue(recs.allSatisfy { $0.type != 0x00 }, "must never emit a type-0 garbage record")
+        XCTAssertEqual(recs.map { $0.type }, [0x4E], "resync recovers the trailing valid record")
+    }
+
+    // MARK: - Reassembler: §2.4 type resync (phantom-summary prevention)
+
+    func testIsPlausibleRecordStart() {
+        XCTAssertTrue(OuraReassembler.isPlausibleRecordStart(0x4E))   // known sleep-phase tag
+        XCTAssertTrue(OuraReassembler.isPlausibleRecordStart(0x70))   // known spo2-smoothed tag
+        XCTAssertTrue(OuraReassembler.isPlausibleRecordStart(0x11))   // GetEvents summary outer op
+        XCTAssertTrue(OuraReassembler.isPlausibleRecordStart(0x0D))   // battery outer op
+        XCTAssertFalse(OuraReassembler.isPlausibleRecordStart(0x30))  // ASCII '0' - misalignment
+        XCTAssertFalse(OuraReassembler.isPlausibleRecordStart(0x3B))  // ASCII ';' - misalignment
+    }
+
+    func testReassemblerResyncsPastUnknownTypeToRecoverNextRecord() {
+        // Two junk bytes whose type is NOT a plausible record start (ASCII '0' then ';', each with a
+        // len >= 4 that would otherwise swallow the real record as a phantom body) precede a valid
+        // sleep-phase record. The parser must resync byte-by-byte and recover the real record.
+        let r = OuraReassembler()
+        let recs = r.feed(bytes("303b" + "4e0602000100006c"))
+        XCTAssertEqual(recs.map { $0.type }, [0x4E])
+        XCTAssertEqual(r.bufferedByteCount, 0)
+    }
+
+    func testReassemblerPreservesSummaryAndBatteryOuterResponses() {
+        // The GetEvents summary (0x11) and battery (0x0D) outer responses ride the same wire and must be
+        // consumed as sized no-op records (NOT resync'd away), so a real event packed behind them still
+        // emerges. Regression guard for the round-trip the notify-channel demux relies on.
+        let summary = bytes("1108ff00727202000300")   // 0x11 len=8, 10 bytes total
+        let event = bytes("4e0602000100006c")          // real sleep-phase record
+        let r = OuraReassembler()
+        let recs = r.feed(summary + event)
+        XCTAssertEqual(recs.map { $0.type }, [0x11, 0x4E])
+        XCTAssertEqual(r.bufferedByteCount, 0)
     }
 }

--- a/Packages/WhoopStore/Sources/WhoopStore/OuraStreamMapping.swift
+++ b/Packages/WhoopStore/Sources/WhoopStore/OuraStreamMapping.swift
@@ -31,12 +31,22 @@ public enum OuraStreamMapping {
     /// WhoopEvent.kind for a decoded sleep-phase code (2-bit: awake/light/deep/rem).
     public static let sleepPhaseEventKind = "OURA_SLEEP_PHASE"
 
+    /// Plausible SpO2 oxygen-saturation percentage band. Aligned with open_oura `tools/run_spo2.py`,
+    /// which computes SpO2 from the r-ratio (tag 0x8b) and CLAMPS the result to `[85, 100]` — Oura's own
+    /// reporting floor and the physiologically plausible band for a worn ring. NOOP uses it as a REJECT
+    /// gate at the persist boundary (drop outside), NEVER a clamp: an out-of-band value is either a raw
+    /// sub-channel that is not a percentage (0x77 `dc_raw` PPG waveform, 0x7B unpinned uint16) or a
+    /// reassembler-misaligned phantom (the −63…4.7M garbage seen on a SpO2-gated-off Gen 3 Horizon), so
+    /// there is no genuine reading to clamp — forcing garbage to "100 %" would fabricate an oxygen value,
+    /// violating the honest-data invariant. Must match the Kotlin twin (OuraStreamMapping.kt).
+    public static let plausibleSpO2Percent = 85...100
+
     /// Build a `Streams` from a batch of decoded Oura events, all stamped at the arrival wall-clock `ts`
     /// (unix seconds). Pure → unit-testable. Section-4 table:
     ///   - `.hr`         (0x55 live-HR push)            → `hr:[HRSample]`
     ///   - `.ibi`        (0x44/0x60 IBI)                → `rr:[RRInterval]`
     ///   - `.hrv`        (0x5D HRV tag, raw int8 b1/b2)  → `events:[WhoopEvent(kind: OURA_HRV)]`
-    ///   - `.spo2`       (0x6F/0x70/0x77)              → `spo2:[SpO2Sample(raw_adc)]`
+    ///   - `.spo2`       (0x6F direct %)                → `spo2:[SpO2Sample]` (only plausible % [85,100])
     ///   - `.temp`       (0x46/0x75)                    → `skinTemp:[SkinTempSample(raw_adc)]`
     ///   - `.sleepPhase` (0x4E/0x5A 2-bit codes)        → `events:[WhoopEvent(kind: OURA_SLEEP_PHASE)]`
     ///   - `.battery`                                   → `battery:[BatterySample]`
@@ -74,9 +84,18 @@ public enum OuraStreamMapping {
                 ]))
 
             case .spo2(let v):
-                // Oura reports a single SpO2 channel; `SpO2Sample` is the WHOOP-shaped two-channel raw row,
-                // so we record the decoded value on `red` and leave `ir` at 0 (no second channel). `unit`
-                // carries the decoder's own scale tag ("raw"/"dc_raw") so downstream never assumes a %.
+                // Persist only PLAUSIBLE SpO2 percentages (`plausibleSpO2Percent`, open_oura's [85,100]).
+                // The ONLY decoder with established percentage semantics is 0x6F (direct per-second %,
+                // ~95-96; OURA_PROTOCOL.md s6.5); the 0x7B uint16 (unpinned scale) and 0x77 `dc_raw` PPG
+                // waveform are NOT oxygen-saturation percentages, so any value outside the band is either
+                // one of those raw sub-channels or a reassembler-misaligned phantom (the −63…4.7M garbage
+                // seen on a SpO2-gated-off Gen 3 Horizon). We DROP it rather than persist an impossible
+                // reading: nothing downstream reads spo2 `red` (AnalyticsEngine nulls spo2Pct), so this
+                // loses no real signal and yields ZERO rows on a ring with SpO2 feature 0x04 OFF. A genuine
+                // 0x6F ~95-96 still passes. `SpO2Sample` is the WHOOP-shaped two-channel raw row: decoded
+                // value on `red`, `ir` at 0 (no second channel), `unit` carries the decoder's own scale
+                // tag. PARITY: mirror this gate in the Kotlin twin (OuraStreamMapping.kt) exactly.
+                guard plausibleSpO2Percent.contains(v.value) else { continue }
                 out.spo2.append(SpO2Sample(ts: ts, red: v.value, ir: 0, unit: v.unit))
 
             case .temp(let v):

--- a/Packages/WhoopStore/Tests/WhoopStoreTests/OuraStreamMappingTests.swift
+++ b/Packages/WhoopStore/Tests/WhoopStoreTests/OuraStreamMappingTests.swift
@@ -53,14 +53,42 @@ final class OuraStreamMappingTests: XCTestCase {
     // MARK: - SpO2 -> spo2:[SpO2Sample]
 
     func testSpO2MapsToSpO2StreamPreservingUnit() {
+        // A genuine 0x6F direct percentage (~95-96) passes the plausibility gate and keeps its unit tag.
         let s = OuraStreamMapping.streams(from: [
-            .spo2(OuraSpO2(ringTimestamp: 100, value: 970, unit: "raw")),
-            .spo2(OuraSpO2(ringTimestamp: 101, value: 12345, unit: "dc_raw")),
+            .spo2(OuraSpO2(ringTimestamp: 100, value: 96, unit: "raw")),
+            .spo2(OuraSpO2(ringTimestamp: 101, value: 88, unit: "raw")),
         ], at: ts)
-        XCTAssertEqual(s.spo2.map { $0.red }, [970, 12345])
+        XCTAssertEqual(s.spo2.map { $0.red }, [96, 88])
         XCTAssertEqual(s.spo2.map { $0.ir }, [0, 0])
-        XCTAssertEqual(s.spo2.map { $0.unit }, ["raw", "dc_raw"])
+        XCTAssertEqual(s.spo2.map { $0.unit }, ["raw", "raw"])
         XCTAssertEqual(s.spo2.map { $0.ts }, [ts, ts])
+    }
+
+    func testSpO2ImplausiblePercentagesAreDropped() {
+        // Everything outside open_oura's [85,100] band is a raw sub-channel (0x7B unpinned uint16 / 0x77
+        // dc_raw waveform) or a reassembler-misaligned phantom - never persisted, never clamped. Covers
+        // the real garbage range observed on a SpO2-gated-off Gen 3 Horizon: negatives, zero, >100 %, and
+        // the multi-million dc_raw accumulator. The lone in-band 96 survives so the batch is not rejected
+        // wholesale.
+        let s = OuraStreamMapping.streams(from: [
+            .spo2(OuraSpO2(ringTimestamp: 1, value: -320, unit: "dc_raw")),
+            .spo2(OuraSpO2(ringTimestamp: 2, value: 0, unit: "raw")),
+            .spo2(OuraSpO2(ringTimestamp: 3, value: 84, unit: "raw")),      // just below the floor
+            .spo2(OuraSpO2(ringTimestamp: 4, value: 96, unit: "raw")),      // genuine reading
+            .spo2(OuraSpO2(ringTimestamp: 5, value: 103, unit: "raw")),     // impossible %
+            .spo2(OuraSpO2(ringTimestamp: 6, value: 970, unit: "raw")),     // 0x7B raw, not a %
+            .spo2(OuraSpO2(ringTimestamp: 7, value: 12_856_474, unit: "dc_raw")),
+        ], at: ts)
+        XCTAssertEqual(s.spo2.map { $0.red }, [96], "only the in-band 96% survives")
+    }
+
+    func testSpO2BandEndpointsAreInclusive() {
+        // 85 and 100 are the accepted bounds (open_oura run_spo2.py clamp endpoints).
+        let s = OuraStreamMapping.streams(from: [
+            .spo2(OuraSpO2(ringTimestamp: 1, value: 85, unit: "raw")),
+            .spo2(OuraSpO2(ringTimestamp: 2, value: 100, unit: "raw")),
+        ], at: ts)
+        XCTAssertEqual(s.spo2.map { $0.red }, [85, 100])
     }
 
     // MARK: - Temp 0x46/0x75 -> skinTemp:[SkinTempSample] (centi-degree-C, parity with Kotlin)
@@ -142,7 +170,7 @@ final class OuraStreamMappingTests: XCTestCase {
             .hr(OuraHR(ringTimestamp: 1, bpm: 55, ibiMs: 1090)),
             .ibi(OuraIBI(ringTimestamp: 1, ibiMs: 1090)),
             .hrv(OuraHRV(ringTimestamp: 1, timeMs: 0, b1: 40, b2: 1)),
-            .spo2(OuraSpO2(ringTimestamp: 1, value: 965)),
+            .spo2(OuraSpO2(ringTimestamp: 1, value: 96)),
             .temp(OuraTemp(ringTimestamp: 1, celsius: 34.0)),
             .sleepPhase(OuraSleepPhase(ringTimestamp: 1, index: 0, stage: .light)),
             .battery(OuraBattery(percent: 88)),

--- a/Strand/BLE/OuraLiveSource.swift
+++ b/Strand/BLE/OuraLiveSource.swift
@@ -480,6 +480,13 @@ public final class OuraLiveSource: NSObject, ObservableObject {
                 log("Oura: live-HR enabled - streaming HR / IBI")
                 startReengageTimer()
                 startHistoryFetchTimer()
+                // §5.3 step 1 / open_oura sync recipe step 4: hand the ring the current UTC BEFORE draining
+                // history so it can emit a usable 0x42 time-sync anchor (§5.5). Without this every fetched
+                // record stays "[no anchor yet]" and last-night sleep / skin-temp can't be placed on a
+                // calendar day (the Sleep screen reads matched=0). SyncTime WRITES the ring's clock - the
+                // phone owns ring time, exactly as the official Oura app does on every connect. Sent ONCE
+                // per session here, before the first fetch; the ack-fetch loop never re-sends it.
+                write([OuraCommands.syncTime(unixSeconds: Int(Date().timeIntervalSince1970))])
                 fetchHistoryIfIdle()   // pull last night's banked temp/SpO2/HRV/sleep-phase right away
                 write([OuraCommands.getBattery()])   // ask once HR streams; the 0x0D reply routes to onBattery
             }

--- a/Strand/BLE/OuraLiveSource.swift
+++ b/Strand/BLE/OuraLiveSource.swift
@@ -687,8 +687,21 @@ public final class OuraLiveSource: NSObject, ObservableObject {
                 // steps (MET is not a step count; OuraStreamMapping drops .activityInfo unconditionally).
                 log("Oura: activity (Tier-B) state=\(info.state) met=\(info.met)")
 
+            case .debugText(let ringTimestamp, let text):
+                // 0x43 debug_event: the ring's OWN ASCII firmware diagnostics (state strings), one per TLV
+                // record (OURA_PROTOCOL.md §6.15). Surfaced live for investigation - these carry useful
+                // sleep/history signal (captures show an explicit `in_bed=…` flag, `…in_info=…`, etc). Decoding
+                // them here also stops a debug string from *aliasing* a real event tag: a byte-misaligned
+                // parser reads a letter inside the text ('L'=0x4C / 'I'=0x49) as a `type` byte and mints a
+                // phantom sleep-summary (§2.4 desync rule). Diagnostics only - never persisted or scored. The
+                // trim+non-empty gate keeps a truncated tail byte from logging a blank line.
+                let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+                if !trimmed.isEmpty {
+                    log("Oura: debug (0x43) rt=\(ringTimestamp) \"\(trimmed)\"")
+                }
+
             default:
-                break   // motion / state / rtcBeacon / debugText: not a durable Streams row (see OuraStreamMapping)
+                break   // motion / state / rtcBeacon: not a durable Streams row (see OuraStreamMapping)
             }
         }
     }

--- a/Strand/BLE/OuraLiveSource.swift
+++ b/Strand/BLE/OuraLiveSource.swift
@@ -695,15 +695,42 @@ public final class OuraLiveSource: NSObject, ObservableObject {
                 // parser reads a letter inside the text ('L'=0x4C / 'I'=0x49) as a `type` byte and mints a
                 // phantom sleep-summary (§2.4 desync rule). Diagnostics only - never persisted or scored. The
                 // trim+non-empty gate keeps a truncated tail byte from logging a blank line.
+                // The channel FLOODS during streaming (hundreds/connect) with repetitive firmware
+                // state-machine chatter - `DHR_mode:3` / `DHR data sub` every ~150 ms, per-beat PPG
+                // windows (`S:…`/`E:…`, uppercase), `DHR_state`/`PPG_cont`/`AFs`/`blestda`, and identical
+                // lines repeated dozens of times (`DHR_info:neg t`). `logDebug` drops those known
+                // high-rate internals and collapses consecutive duplicates, so the useful LOW-rate lines
+                // survive: sleep/lifecycle (`check_sleep`, `no_bedtime`, `wakeup`, `in_bed=…`, the
+                // lowercase `s:`/`e:`/`nb:` sleep boundaries), `auth_key_set`, `batt:…`, `orientation`.
                 let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
-                if !trimmed.isEmpty {
-                    log("Oura: debug (0x43) rt=\(ringTimestamp) \"\(trimmed)\"")
-                }
+                logDebug(trimmed, rt: ringTimestamp)
 
             default:
                 break   // motion / state / rtcBeacon: not a durable Streams row (see OuraStreamMapping)
             }
         }
+    }
+
+    // MARK: - Debug-text (0x43) filter — Phase-1 investigation logging
+
+    /// Prefixes of the ring's high-rate firmware chatter to DROP from the strap log (case-sensitive, so
+    /// the UPPERCASE PPG markers `S:`/`E:` are dropped while the lowercase sleep boundaries `s:`/`e:`
+    /// survive). Widen this list to quieten the log further, or trim it to see more while investigating.
+    private static let debugDropPrefixes = [
+        "DHR_mode", "DHR data sub", "DHR_state", "DHR_info",   // ~150 ms HR state-machine chatter
+        "PPG_cont", "S:", "E:", "AFs", "blestda", "nr", "BQ",  // per-beat PPG windows / AGC / BLE state
+    ]
+    /// Last debug string we logged, to collapse consecutive identical lines (e.g. `DHR_info:neg t` ×20).
+    private var lastDebugText: String?
+
+    /// Log a decoded 0x43 debug string unless it is empty, a known high-rate flood (drop-prefix), or an
+    /// immediate duplicate of the previous logged line. Investigation only — never persisted or scored.
+    private func logDebug(_ text: String, rt: UInt32) {
+        guard !text.isEmpty,
+              !Self.debugDropPrefixes.contains(where: { text.hasPrefix($0) }),
+              text != lastDebugText else { return }
+        lastDebugText = text
+        log("Oura: debug (0x43) rt=\(rt) \"\(text)\"")
     }
 
     // MARK: - Re-engagement timer (daytime-HR auto-reverts ~20s)

--- a/android/app/src/main/java/com/noop/data/OuraStreamMapping.kt
+++ b/android/app/src/main/java/com/noop/data/OuraStreamMapping.kt
@@ -38,6 +38,18 @@ object OuraStreamMapping {
     const val EVENT_SLEEP_PHASE = "OURA_SLEEP_PHASE"
 
     /**
+     * Plausible SpO2 oxygen-saturation percentage band. Aligned with open_oura `tools/run_spo2.py`,
+     * which computes SpO2 from the r-ratio (tag 0x8b) and CLAMPS the result to [85, 100] - Oura's own
+     * reporting floor and the physiologically plausible band for a worn ring. Used as a REJECT gate at
+     * the persist boundary (drop outside), NEVER a clamp: an out-of-band value is either a raw
+     * sub-channel that is not a percentage (0x77 dc_raw PPG waveform, 0x7B unpinned uint16) or a
+     * reassembler-misaligned phantom (the -63..4.7M garbage seen on a SpO2-gated-off Gen 3 Horizon), so
+     * there is no genuine reading to clamp - forcing garbage to "100%" would fabricate an oxygen value,
+     * violating the honest-data invariant. Must match the Swift twin (OuraStreamMapping.plausibleSpO2Percent).
+     */
+    val PLAUSIBLE_SPO2_PERCENT = 85..100
+
+    /**
      * Fold a batch of decoded [events] into a protocol [Streams] for one flush. [anchor] maps a
      * ring-clock timestamp to wall-clock unix seconds (null => drop the sample). Pure: no BLE, no DB,
      * no clock, fully JVM-unit-testable. Tier-B events never reach scoring; if any leak in (they only
@@ -76,10 +88,18 @@ object OuraStreamMapping {
                 }
 
                 is OuraEvent.Spo2 -> {
-                    // The ring exposes ONE combined SpO2 reading (not separate red/ir channels): its
-                    // raw value goes in `red`; `ir` stays 0 (an unread channel, never a fabricated
-                    // second reading). `unit` carries the decoder's own scale tag so downstream never
-                    // assumes a percentage, mirroring the Swift twin's SpO2Sample(unit:).
+                    // Persist only PLAUSIBLE SpO2 percentages (PLAUSIBLE_SPO2_PERCENT, open_oura's
+                    // [85,100]). The ONLY decoder with established percentage semantics is 0x6F (direct
+                    // per-second %, ~95-96; OURA_PROTOCOL.md s6.5); the 0x7B uint16 (unpinned scale) and
+                    // 0x77 dc_raw PPG waveform are NOT oxygen-saturation percentages, so any value outside
+                    // the band is either one of those raw sub-channels or a reassembler-misaligned phantom
+                    // (the -63..4.7M garbage seen on a SpO2-gated-off Gen 3 Horizon). DROP it rather than
+                    // persist an impossible reading: nothing downstream reads spo2 red, so this loses no
+                    // real signal and yields ZERO rows on a ring with SpO2 feature 0x04 OFF. A genuine 0x6F
+                    // ~95-96 still passes. The ring exposes ONE combined channel: value in `red`, `ir` 0
+                    // (unread channel, never fabricated), `unit` carries the decoder's own scale tag.
+                    // PARITY: mirror the Swift twin's [85,100] gate exactly.
+                    if (ev.value.value !in PLAUSIBLE_SPO2_PERCENT) continue
                     val ts = anchor(ev.value.ringTimestamp) ?: continue
                     out.spo2.add(Spo2Sample(ts = ts, red = ev.value.value, ir = 0, unit = ev.value.unit))
                 }

--- a/android/app/src/test/java/com/noop/data/OuraStreamMappingTest.kt
+++ b/android/app/src/test/java/com/noop/data/OuraStreamMappingTest.kt
@@ -96,6 +96,40 @@ class OuraStreamMappingTest {
     }
 
     @Test
+    fun spo2ImplausiblePercentagesAreDropped() {
+        // PARITY with Swift testSpO2ImplausiblePercentagesAreDropped: only values in open_oura's
+        // [85,100] band survive. Everything outside is a raw sub-channel (0x7B unpinned uint16 / 0x77
+        // dc_raw waveform) or a reassembler-misaligned phantom - never persisted, never clamped. Covers
+        // the garbage range seen on a SpO2-gated-off Gen 3 Horizon (negatives, zero, >100%, multi-million
+        // dc_raw accumulator); the lone in-band 96 survives so the batch is not rejected wholesale.
+        val s = OuraStreamMapping.streams(
+            listOf(
+                OuraEvent.Spo2(OuraSpO2(ringTimestamp = 1, value = -320, unit = "dc_raw")),
+                OuraEvent.Spo2(OuraSpO2(ringTimestamp = 2, value = 0)),
+                OuraEvent.Spo2(OuraSpO2(ringTimestamp = 3, value = 84)),   // just below the floor
+                OuraEvent.Spo2(OuraSpO2(ringTimestamp = 4, value = 96)),   // genuine reading
+                OuraEvent.Spo2(OuraSpO2(ringTimestamp = 5, value = 103)),  // impossible %
+                OuraEvent.Spo2(OuraSpO2(ringTimestamp = 6, value = 970)),  // 0x7B raw, not a %
+                OuraEvent.Spo2(OuraSpO2(ringTimestamp = 7, value = 12_856_474, unit = "dc_raw")),
+            ),
+            anchor,
+        )
+        assertEquals(listOf(96), s.spo2.map { it.red }) // only the in-band 96% survives
+    }
+
+    @Test
+    fun spo2BandEndpointsAreInclusive() {
+        val s = OuraStreamMapping.streams(
+            listOf(
+                OuraEvent.Spo2(OuraSpO2(ringTimestamp = 1, value = 85)),
+                OuraEvent.Spo2(OuraSpO2(ringTimestamp = 2, value = 100)),
+            ),
+            anchor,
+        )
+        assertEquals(listOf(85, 100), s.spo2.map { it.red })
+    }
+
+    @Test
     fun tempPersistsAsHundredthsOfDegree() {
         val s = OuraStreamMapping.streams(
             listOf(OuraEvent.Temp(OuraTemp(ringTimestamp = 4, celsius = 33.27))),

--- a/docs/OURA_PROTOCOL.md
+++ b/docs/OURA_PROTOCOL.md
@@ -93,6 +93,8 @@ Returned during history fetch (`0x10`/`0x11`) and live streaming. Each record: [
 ### 2.4 Multi-packet payloads
 There is no application-level fragmentation header beyond the TLV `len`. A record never spans two notifications in the verified corpus; each notification contains whole frames/records. NOOP's parser must still be defensive: buffer partial trailing bytes across notifications and only emit complete `2+len` records.
 
+> **Byte-alignment desync → phantom tags (live Gen 3, 2026-07-08).** Observed: a run of `0x43` debug_event records (ASCII, §6.15) surfaced in the log as a single **`0x4C` "sleep_summary"** whose "payload" spilled across the following real `0x43` records (the later `43 0c ..`/`43 0b ..` headers were visible inline; the first record's `type` byte was missing). Root cause: the reassembler lost byte-alignment and read an ASCII byte inside a debug string as a `type` byte — `0x4C` is the letter **`L`**, `0x49`=`I`, `0x53`=`S`, all legal debug-text characters that alias real event tags. A desynced parser can therefore *fabricate* a `0x4C`/`0x49` "sleep summary" (or corrupt a genuine record). **Defensive rule:** validate each record before emitting it — reject `len < 4` (a record must cover its 4 timestamp bytes) and, on an implausible `type`/`len`, **resynchronise** (advance one byte and re-scan) rather than emitting the record; never let an unverified `type` byte from a mid-stream position mint a Tier-B summary event. `0x43` debug text should be decoded to ASCII and surfaced, not left to alias a sleep tag.
+
 ---
 
 ## 3. Authentication Handshake
@@ -354,7 +356,7 @@ bits 14–15 : qual_b
 - **`0x72` `sleep_acm_period`** (16 B): values0–2 = `whole(8)+frac(8)/255`; values3–5 = `whole(4)+frac(12)/4095`. [ringverse]
 - **`0x49` `sleep_summary_1`**: start/end as uint16 LE minutes-before-event. [ringverse]
 - **`0x76` `bedtime_period`**: start/end as uint32 LE ringTimestamps → map to UTC (§5.5). [ringverse]
-- Tags `0x48,0x4A–0x4D,0x4F,0x57,0x58` are additional sleep summary/feature variants in the dictionary; layouts **(UNVERIFIED)** - decode only after fixtures. [ringverse]
+- Tags `0x48,0x4A–0x4D,0x4F,0x57,0x58` are additional sleep summary/feature variants in the dictionary; layouts **(UNVERIFIED)** - decode only after fixtures. [ringverse] **Beware phantom sightings:** a `0x4C`/`0x49` "sleep_summary" whose payload is ASCII (e.g. contains `in_bed=…`, readable words) is almost certainly misframed `0x43` debug text, not a real summary — see §2.4 desync rule and §6.15. Confirm a candidate summary is binary and length-consistent before treating it as a fixture.
 
 ### 6.13 Motion / activity
 - **`0x47` `motion_events`** (variable): byte6 bits`[7:5]`=field_a, `[4:0]`=field_b; bytes7–9 = three **int8 × 8** axis magnitudes; optional bytes10–11. [ringverse]
@@ -371,7 +373,7 @@ bits 14–15 : qual_b
 
 ### 6.15 Lifecycle / state
 - **`0x41` ring_start_ind** (18 B): bytes6–10 = 40-bit device id; bytes15–19 config; triggers anchor invalidation on rt regress. [ringverse][open_ring]
-- **`0x43` debug_event**: ASCII text (state strings). [open_ring][open_oura-r3]
+- **`0x43` debug_event**: ASCII text (state strings), one string per TLV record (`43 <len> <rt:u32 LE> <ascii len-4>`). Live Gen 3 captures (2026-07-08) show short firmware diagnostics with sequential ring counters, e.g. `"Sw to App"`, `"in_bed=0"`, `"…in_info=6"`, `"bc 0x43"` — useful sleep/history signal (an explicit `in_bed` flag). NOOP decodes these to `OuraEvent.debugText`; surface them in the strap log. **Caution:** because the payload is arbitrary ASCII, a byte-misaligned parser can read a letter (`L`=0x4C, `I`=0x49, `S`=0x53) as a record `type` and mis-emit a phantom sleep-summary — see the desync rule in §2.4. [open_ring][open_oura-r3]
 - **`0x45` state_change_ind / `0x53` wear_event**: byte6 = STATE_* enum; optional trailing UTF-8 string if payload>5. STATE enum: `0 unspecified,1 not_in_finger,2 finger_detection,3 user_active,4 user_in_rest,5 hr_user_active,6 hr_user_in_rest,7 out_of_power,8 charging,9 hibernate_low_power,20–22 production,30 hw_test`. [open_ring]
 - **`0x85` rtc_beacon_ind** (10 B): `unix_s:u32 LE`, reserved 4 B, trailer u16 LE ∈ {`0x01F6`,`0x01F8`}. [open_ring]
 

--- a/docs/OURA_PROTOCOL.md
+++ b/docs/OURA_PROTOCOL.md
@@ -12,6 +12,7 @@
 - **[open_oura-feat]** - Th0rgal/open_oura `docs/ring-features.md` (feature gating).
 - **[relue]** - relue/oura_ring_reverse `docs/.../heartbeat_replication_guide.md` and `heartbeat_complete_flow.md` (no-license; Ring 3 live-HR).
 - **[oura-rs]** - Th0rgal/open_oura `crates/oura-protocol/src/events.rs` (no-license Rust clean-room decoder; facts cited only, no code copied). Its event tags marked `"_status": "unvalidated"` are treated the same as our Tier B - plausible, not ground-truth-confirmed.
+- **[sleepnet]** - Th0rgal/open_oura `docs/algorithms/sleepnet.md` (no-license; describes Oura's on-phone sleep-staging model + its encryption, NOT a BLE protocol layout). See §6.12.1.
 
 > **CONFLICT NOTE (resolution rule):** The relue archive file `event_data_definition.md` describes events as **protobuf varint** records (e.g. `0x55` SLEEP_HR with field tags). This contradicts the **byte-for-byte verified TLV framing** in [open_ring] and [ringverse]. The TLV/bit-packed model from [open_ring]/[ringverse] is authoritative for our decoders; the protobuf description is treated as unverified/likely AI-fabricated and is NOT used. Where a layout is only attested by a single no-license, AI-generated doc, it is marked **(UNVERIFIED)** and our decoder must gate it behind a fixture test before trusting it.
 
@@ -357,6 +358,28 @@ bits 14–15 : qual_b
 - **`0x49` `sleep_summary_1`**: start/end as uint16 LE minutes-before-event. [ringverse]
 - **`0x76` `bedtime_period`**: start/end as uint32 LE ringTimestamps → map to UTC (§5.5). [ringverse]
 - Tags `0x48,0x4A–0x4D,0x4F,0x57,0x58` are additional sleep summary/feature variants in the dictionary; layouts **(UNVERIFIED)** - decode only after fixtures. [ringverse] **Beware phantom sightings:** a `0x4C`/`0x49` "sleep_summary" whose payload is ASCII (e.g. contains `in_bed=…`, readable words) is almost certainly misframed `0x43` debug text, not a real summary — see §2.4 desync rule and §6.15. Confirm a candidate summary is binary and length-consistent before treating it as a fixture.
+
+#### 6.12.1 The polished hypnogram is cloud-locked (SleepNet) — NOOP does not chase it
+The 4-stage hypnogram the **Oura app** shows is **not** produced on the ring and is **not** on the BLE
+wire. It is the output of **SleepNet**, a PyTorch model that runs **on the phone** (in Oura's app, not
+in the ring's firmware/`ecore`) and classifies sleep in **per-30-second epochs**. The model ships as
+`oura_models.apk/assets/sleepstaging_2_6_0.pt.enc` (~114 KB) **encrypted AES-256-GCM**
+(`[12-byte IV][ciphertext + 16-byte tag]`, `AES/GCM/NoPadding`, `GCMParameterSpec(128, iv)`); the GCM key
+is **fetched from Oura's servers** (per-model, labelled, rotatable) and only cached on a logged-in device.
+So the finished hypnogram is **the one Oura metric that is not reproducible without Oura's cloud**. [sleepnet]
+
+**Consequence for NOOP (honest-data invariant, §1):** we neither can nor do reproduce SleepNet — the key
+is cloud-gated, and even with it, surfacing Oura's encrypted proprietary score is exactly what NOOP does
+not do. NOOP builds its **own** sleep session from signals that genuinely cross the BLE boundary:
+- the ring's own **2-bit `0x4E`/`0x5A` phase codes** (§6.12, **Tier A** — the ring's coarse on-device
+  awake/light/deep/REM classification, decoded and persisted as `OURA_SLEEP_PHASE` events);
+- the ring's own **sleep-window boundaries** — `0x49`/`0x76` summary/bedtime (Tier-B until fixtured) and
+  the **`0x43` debug narration** `check_sleep` / `in_bed` / `s: <start>` / `e: <end>` (§6.15), which on
+  live Gen 3 (2026-07-08) reported a ~552-min window corroborating the `0x49` summary;
+- plus NOOP's **own** staging over raw HR / HRV / skin-temp / motion.
+
+These are leads for a NOOP-side sleep-session builder, **not** a path to Oura's hypnogram. Do not label a
+NOOP-derived hypnogram as "Oura sleep stages": it is NOOP's own, from the ring's raw + coarse signals.
 
 ### 6.13 Motion / activity
 - **`0x47` `motion_events`** (variable): byte6 bits`[7:5]`=field_a, `[4:0]`=field_b; bytes7–9 = three **int8 × 8** axis magnitudes; optional bytes10–11. [ringverse]


### PR DESCRIPTION
## What this PR does

The branch is one coherent piece of work: getting a freshly-paired Oura ring's own data to actually land in NOOP as dated, trustworthy rows — the reason Sleep and Skin-Temp cards were blank despite the ring streaming.

The core fix addresses the root cause: NOOP was never telling the ring what time it was. Without a SyncTime handshake on connect, the ring never  emitted its UTC time-sync anchor, so every history-fetched sample (last night's sleep phases, skin temperature) arrived with a ring-clock timestamp  that couldn't be placed on a calendar day — and anything that can't be dated never reaches the daily metrics the cards read. Sending SyncTime at the  start of each session unlocks that anchor; in testing it took persisted skin-temp from a single sample to five hundred, with real timestamps.

The second fix hardens the record parser. The ring emits a chatty ASCII debug channel, and its bytes happen to alias real event-tag numbers. When  the byte stream slipped out of alignment, the parser would mint a phantom "sleep summary" whose bogus length swallowed the genuine sleep-phase  records that followed — starving the very data we'd just unlocked. The reassembler now validates that a record actually begins with a plausible tag  and re-synchronises byte-by-byte otherwise, so debug text can no longer masquerade as a summary. Recovered sleep-phase events roughly doubled.

The third fix is an honesty backstop for a side effect of all that misalignment: stray phantoms were decoding into impossible SpO2 values —  negatives, millions — and getting persisted, on a ring whose SpO2 feature is switched off entirely. A plausibility gate at the persist boundary now  keeps only physiologically real percentages (85–100, matching open_oura's own bound) and drops the rest rather than clamping them, because clamping  garbage to "100%" would fabricate a reading. It's mirrored on the Android side to keep the two platforms in lock-step.

 Underpinning the debugging, the branch also surfaces the ring's diagnostic channel in the strap log — with a filter that mutes the high-rate  firmware noise while preserving the meaningful lines (the in_bed flag, the sleep-window s:/e: boundaries). That visibility is what made the anchor  and framing problems diagnosable in the first place.

Finally, the protocol spec is updated with two findings: the framing desync rule, and — importantly for the road ahead — that Oura's polished sleep  hypnogram is produced by an encrypted, cloud-key-gated model on the phone and simply isn't on the BLE wire. So NOOP won't chase it; it will build  its own sleep session from the ring's raw and coarse signals.

Notably, the branch is deliberately scoped to these fixes plus documentation — the still-experimental Tier-B activity/steps estimator is kept out,  so this can be reviewed and merged on its own.

## Type of change

- [x] Bug fix
- [x] New feature
- [ ] Refactor / cleanup
- [x] Documentation
- [ ] CI / tooling

## How it was tested

Tested on MacOs with an Oura Ring Gen 3

## Checklist

- [x] Swift package tests pass for any package I touched (`swift test` in `Packages/<name>`)
- [ ] Android unit tests pass if I touched `android/` (`./gradlew testFullDebugUnitTest`)
- [x] No new build warnings introduced
- [ ] UI changes use only `StrandDesign` tokens — no hardcoded colors, fonts, or spacing
- [ ] No hardcoded hex frame bytes; protocol facts live in the schema / decoders
- [ ] Follows the conventions in [`docs/CONTRIBUTING.md`](../docs/CONTRIBUTING.md)
- [x] I did not commit generated output (`Strand.xcodeproj/`) or any secrets/keystores

## Related issues

<!-- Closes #N -->
