### PR TITLE
fix(issue #92): clarify overnight-only HRV setting and manual HRV reading

### DIFF
--- a/android/app/src/main/java/com/noop/ui/SettingsScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/SettingsScreen.kt
@@ -1149,7 +1149,9 @@ fun SettingsScreen(vm: AppViewModel, onOpenTestCentre: () -> Unit = {}) {
                                 color = Palette.textPrimary,
                             )
                             Text(
-                                "Runs the stream only during your quiet hours window (22:00 to 07:00 by default), roughly halving the battery cost. Daytime Stress readings will be sparser, since Stress reads this live stream.",
+                                "Runs the continuous HRV stream only during your quiet hours window (22:00–07:00 by default), roughly halving the battery cost. Daytime Stress readings will be sparser. " +
+                                "Note: continuous background HRV capture (including daytime naps) is paused outside this window. " +
+                                "For on-demand daytime HRV readings (including naps), use the \"Take an HRV reading\" button on the Live screen.",
                                 style = NoopType.footnote,
                                 color = Palette.textTertiary,
                             )


### PR DESCRIPTION
## Summary
Clarifies the "Overnight only" setting for Continuous HRV capture in Settings → Strap.

## Changes
- Updates the description to explicitly state that continuous background HRV capture (including daytime naps) is paused outside the overnight window
- Directs users to the "Take an HRV reading" button on the Live screen for on-demand daytime HRV readings

## Rationale
This is a baby-step fix: clarifies existing behavior rather than changing the overnight-only window logic itself. The issue (#92) reports that when "Overnight only" is enabled, daytime naps aren't tracked because the continuous HRV stream only runs during the overnight window (22:00-07:00 by default). The manual HRV Snapshot feature (accessible from the Live screen) works independently of this setting since it uses the screen-wants-realtime path that bypasses the overnight window gate.

## Testing
- Verified the Settings screen compiles correctly
- The existing ContinuousHrvWindowTest continues to pass (tests the overnight window predicate)
- No behavioral changes to the overnight window logic itself