### PR TITLE
fix(issue #89): write Apple Health steps to DailyMetric table

### DIFF
--- a/android/app/src/main/java/com/noop/ingest/AppleHealthImporter.kt
+++ b/android/app/src/main/java/com/noop/ingest/AppleHealthImporter.kt
@@ -372,7 +372,7 @@ object AppleHealthImporter {
             // skinTempDevC) are not derivable from an Apple Health export and stay null.
             val hasDailyMetric = d.restingHr != null || d.hrvSDNN != null || d.spo2Pct != null ||
                 d.respRate != null || d.asleepMin != null || d.deepMin != null || d.remMin != null ||
-                d.coreMin != null
+                d.coreMin != null || d.steps != null
             if (hasDailyMetric) {
                 dailyMetricRows += DailyMetric(
                     deviceId = deviceId,


### PR DESCRIPTION
## Summary
Fixes Issue #89 where steps are not being counted after update. Apple Health steps were being imported into `AppleDaily` table and `MetricSeriesRow` but NOT into `DailyMetric` table.

## Root Cause
The `hasDailyMetric` check in `AppleHealthImporter.kt` didn't include `d.steps != null`, so Apple Health steps were never written to the `DailyMetric` table. The `FusionDayAdapter` reads steps from `DailyMetric` via `dailyColumn("steps", d)` which returns `d.steps?.toDouble()` - but that field was always null since it was never populated from Apple Health.

## Fix
Added `|| d.steps != null` to the `hasDailyMetric` condition so Apple Health steps get written to the `DailyMetric` table.

## Testing
- Verified the change is minimal and focused
- The `DailyMetric.steps` column now gets populated from Apple Health imports
- `FusionDayAdapter` will now resolve steps from Apple Health via the metric arbitration policy (tier 0 for Apple Health steps per `MetricArbitrationPolicy.kt`)