### PR TITLE
fix(issue #93): surface WHOOP 4.0 raw SpO2 ADC means on Health screen

### DIFF
--- a/android/app/src/main/java/com/noop/analytics/AnalyticsEngine.kt
+++ b/android/app/src/main/java/com/noop/analytics/AnalyticsEngine.kt
@@ -8,6 +8,7 @@ import com.noop.data.SkinTempSample
 import com.noop.data.RespSample
 import com.noop.data.RrInterval
 import com.noop.data.StepSample
+import com.noop.data.Spo2Sample
 import com.noop.protocol.DeviceFamily
 import com.noop.protocol.skinTempCelsius
 import org.json.JSONObject
@@ -168,6 +169,9 @@ object AnalyticsEngine {
         // Default WHOOP5 keeps every 5/MG + pure-function caller byte-identical; IntelligenceEngine passes
         // the day owner's real family.
         skinTempFamily: DeviceFamily = DeviceFamily.WHOOP5,
+        // WHOOP 4.0 raw SpO2 ADC channels (spo2_red@68 / spo2_ir@70 on v24 layout).
+        // Mean of per-second raw ADC values during detected sleep. NOT a blood-oxygen %.
+        spo2: List<Spo2Sample> = emptyList(),
         profile: UserProfile,
         baselines: ProfileBaselines = ProfileBaselines(),
         maxHROverride: Double? = null,
@@ -333,6 +337,11 @@ object AnalyticsEngine {
             baselines.skinTemp?.takeIf { it.usable }?.let { round2(Baselines.deviation(v, it).delta) }
         }
 
+        // ── Nightly RAW SpO2 ADC means (WHOOP 4.0, Issue #93) ─────────────────
+        // Surface the raw red/IR PPG ADC means over detected sleep. NOT a calibrated SpO2 % (that
+        // needs WHOOP's proprietary curve). Null when no SpO2 samples fall inside a sleep window.
+        val nightlySpo2Raw = wornNightlySpo2Raw(matched, spo2)
+
         // ── Rest (sleep_performance composite, 0–100) ─────────────────────────
         // Replaces the bare efficiency proxy: duration-vs-personal-need 0.50 + efficiency 0.20 +
         // restorative (deep+REM)/asleep 0.20 + consistency 0.10. Stored under the sleep_performance
@@ -484,6 +493,8 @@ object AnalyticsEngine {
             strain = strain,
             exerciseCount = workouts.size,
             spo2Pct = null,
+            spo2Red = nightlySpo2Raw?.first,
+            spo2Ir = nightlySpo2Raw?.second,
             skinTempDevC = skinTempDevC,
             respRateBpm = respRateDaily,
             steps = stepsTotal,
@@ -573,6 +584,32 @@ object AnalyticsEngine {
         family: DeviceFamily = DeviceFamily.WHOOP5,
         minSamples: Int = MIN_SKIN_TEMP_SAMPLES_INLINE,
     ): Double? = skinTempFunnel(sessions, hr, skinTemp, family, minSamples).mean
+
+    /**
+     * Wear-gated nightly mean raw SpO2 ADC channels (red + IR), averaged over the detected in-bed
+     * [sessions]. WHOOP 4.0 banks these as raw PPG ADC values (spo2_red@68 / spo2_ir@70 on the v24
+     * historical layout) but NOT a calibrated blood-oxygen % — computing one needs WHOOP's proprietary
+     * calibration curve, so we surface the RAW means only. The strap streams SpO2 solely on-wrist, so
+     * there is no off-wrist wear gate to apply (unlike skin temp). A night with no SpO2 samples inside
+     * any session window yields null. Pure + deterministic. Mirrors the Swift `nightlySpo2Raw`. (Issue #93)
+     */
+    internal fun wornNightlySpo2Raw(
+        sessions: List<DetectedSleep>,
+        spo2: List<Spo2Sample>,
+    ): Pair<Int, Int>? {
+        if (sessions.isEmpty() || spo2.isEmpty()) return null
+        var redSum = 0L
+        var irSum = 0L
+        var kept = 0
+        for (s in spo2) {
+            if (sessions.none { s.ts in it.start..it.end }) continue
+            redSum += s.red
+            irSum += s.ir
+            kept++
+        }
+        if (kept == 0) return null
+        return ((redSum / kept).toInt() to (irSum / kept).toInt())
+    }
 
     /** Plausible worn skin-temperature range (°C). Off-wrist/charging samples drift to ambient and are
      *  excluded; the strap's own decode gate is the looser 20–45. (PR #85) */

--- a/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
+++ b/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
@@ -438,6 +438,10 @@ object IntelligenceEngine {
             val grav = repo.gravitySamples(owner, from, to, STREAM_LIMIT)
             val steps = repo.stepSamples(owner, from, to, STREAM_LIMIT)
             val skin = repo.skinTempSamples(owner, from, to, STREAM_LIMIT)
+            // Issue #93: raw SpO2 ADC rows (WHOOP 4.0 v24 spo2_red@68 / spo2_ir@70). Surfaced as raw
+            // means only — no calibrated % (needs WHOOP's proprietary curve). analyzeDay averages them
+            // over the detected sleep windows.
+            val spo2 = repo.spo2Samples(owner, from, to, STREAM_LIMIT)
             // #938: the strap family that WROTE this owner's skin-temp rows, so analyzeDay converts the raw
             // register on the right scale (5/MG banks centidegrees, a WHOOP 4.0 v24 banks a raw ADC). The
             // owner source resolves it from the registry; unknown/non-WHOOP owners fall back to WHOOP5 (the
@@ -501,6 +505,7 @@ object IntelligenceEngine {
                 dayGravity = dayGrav,
                 skinTemp = skin,
                 skinTempFamily = skinFamily,   // #938
+                spo2 = spo2,
                 profile = profile,
                 baselines = baselines1,
                 maxHROverride = maxHROverride,

--- a/android/app/src/main/java/com/noop/data/Entities.kt
+++ b/android/app/src/main/java/com/noop/data/Entities.kt
@@ -221,6 +221,10 @@ data class DailyMetric(
     val exerciseCount: Int? = null,
     // v7 in-sleep signal aggregates (nullable; computed server-side).
     val spo2Pct: Double? = null,        // mean SpO2 (%) during sleep
+    // WHOOP 4.0 raw SpO2 ADC values (spo2_red@68 / spo2_ir@70 on v24 layout).
+    // Mean of per-second raw ADC values during detected sleep. NOT a blood-oxygen %.
+    val spo2Red: Int? = null,
+    val spo2Ir: Int? = null,
     val skinTempDevC: Double? = null,   // skin-temperature deviation (°C) from baseline
     val respRateBpm: Double? = null,    // mean respiration rate (breaths/min) during sleep
     // On-device derived daily step total from the WHOOP5 step_motion_counter@57 (sum of positive

--- a/android/app/src/main/java/com/noop/data/WhoopDatabase.kt
+++ b/android/app/src/main/java/com/noop/data/WhoopDatabase.kt
@@ -48,7 +48,7 @@ import androidx.sqlite.db.SupportSQLiteDatabase
         LabMarkerRow::class,
         LiveSessionRow::class,
     ],
-    version = 16,
+    version = 17,
     exportSchema = false,
 )
 abstract class WhoopDatabase : RoomDatabase() {
@@ -426,6 +426,33 @@ abstract class WhoopDatabase : RoomDatabase() {
             }
         }
 
+        /**
+         * v16 -> v17: ADDITIVE, adds `dailyMetric.spo2Red` + `dailyMetric.spo2Ir` (both nullable INTEGER),
+         * the Issue #93 "surface WHOOP 4.0 raw SpO2 ADC means" change. The nightly raw red/IR PPG ADC
+         * means (spo2_red@68 / spo2_ir@70 on the v24 historical layout) are now persisted per day so the
+         * Health screen can SHOW the decoded sensor data WITHOUT us fabricating a calibrated blood-oxygen %.
+         *
+         * ALTER ... ADD COLUMN only (no data touched), so existing dailyMetric rows read back with both
+         * columns = NULL (a pre-migration night simply has no raw SpO2 captured yet), an absent value stays
+         * absent, never a fabricated 0. The SQL MUST match Room's generated columns for two `Int?` fields
+         * exactly: INTEGER, no NOT NULL, no SQL DEFAULT (a Kotlin construction default never reaches the
+         * schema), the additive, nullable-safe form of MIGRATION_2_3 (already-offloaded raw streams survive;
+         * the strap trims acked history and won't re-send it). Like the others this is the
+         * no-destructive-fallback path: a mismatch throws loudly rather than silently wiping non-resendable
+         * strap history. Exposed as [DAILY_SPO2_RAW_MIGRATION_SQL] so a plain-JVM unit test can pin the
+         * shape without Robolectric.
+         */
+        internal val DAILY_SPO2_RAW_MIGRATION_SQL: List<String> = listOf(
+            "ALTER TABLE `dailyMetric` ADD COLUMN `spo2Red` INTEGER",
+            "ALTER TABLE `dailyMetric` ADD COLUMN `spo2Ir` INTEGER",
+        )
+
+        internal val MIGRATION_16_17 = object : Migration(16, 17) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                for (stmt in DAILY_SPO2_RAW_MIGRATION_SQL) db.execSQL(stmt)
+            }
+        }
+
         private fun build(appContext: Context): WhoopDatabase =
             Room.databaseBuilder(appContext, WhoopDatabase::class.java, DB_NAME)
                 // #1014: replace ONLY the corruption handling of the default open-helper. The
@@ -440,7 +467,7 @@ abstract class WhoopDatabase : RoomDatabase() {
                     MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5,
                     MIGRATION_5_6, MIGRATION_6_7, MIGRATION_7_8, MIGRATION_8_9, MIGRATION_9_10,
                     MIGRATION_10_11, MIGRATION_11_12, MIGRATION_12_13, MIGRATION_13_14,
-                    MIGRATION_14_15, MIGRATION_15_16,
+                    MIGRATION_14_15, MIGRATION_15_16, MIGRATION_16_17,
                 )
                 // #1037: a FRESH install builds the schema straight at the current version and runs NO
                 // migrations, so the MIGRATION_7_8 "my-whoop" registry seed never fires and the WHOOP,

--- a/android/app/src/main/java/com/noop/data/WhoopRepository.kt
+++ b/android/app/src/main/java/com/noop/data/WhoopRepository.kt
@@ -1584,6 +1584,8 @@ class WhoopRepository(private val dao: WhoopDao) {
                     strain = d.strain ?: c.strain,
                     exerciseCount = d.exerciseCount ?: c.exerciseCount,
                     spo2Pct = d.spo2Pct ?: c.spo2Pct,
+                    spo2Red = d.spo2Red ?: c.spo2Red,
+                    spo2Ir = d.spo2Ir ?: c.spo2Ir,
                     skinTempDevC = d.skinTempDevC ?: c.skinTempDevC,
                     respRateBpm = d.respRateBpm ?: c.respRateBpm,
                     steps = d.steps ?: c.steps,

--- a/android/app/src/main/java/com/noop/ui/HealthScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/HealthScreen.kt
@@ -1645,6 +1645,32 @@ private fun vitalsFor(
             metricColor = Palette.metricCyan,
             sparkline = trail(d?.spo2Pct) { it.spo2Pct },
         ),
+        // Issue #93: WHOOP 4.0 raw SpO2 PPG ADC means (red/IR) per night. NOT a calibrated blood-oxygen
+        // % — that needs WHOOP's proprietary curve. Shown as RAW ADC so users can SEE the sensor data is
+        // decoded, without us fabricating a clinical-looking number. Only present when raw means exist.
+        run {
+            val rawMean = if (d?.spo2Red != null && d?.spo2Ir != null) (d.spo2Red + d.spo2Ir) / 2.0 else null
+            Vital(
+                key = "spo2raw", label = "Raw SpO₂", unit = "ADC",
+                value = rawMean,
+                format = { String.format("%.0f", it) },
+                deltaText = deltaText(
+                    rawMean,
+                    previous { if (it.spo2Red != null && it.spo2Ir != null) (it.spo2Red + it.spo2Ir) / 2.0 else null },
+                    decimals = 0,
+                ),
+                readingDay = todayKey,
+                asOfLabel = asOfLabel(todayKey),
+                rangeCaption = rangeCaption(
+                    days.mapNotNull { if (it.spo2Red != null && it.spo2Ir != null) (it.spo2Red + it.spo2Ir) / 2.0 else null },
+                    "ADC",
+                ) { String.format(Locale.US, "%.0f", it) },
+                // No banding: raw ADC is device/placement-dependent and not a clinical value.
+                banding = VitalBands.band(null, emptyList(), 0.0..1.0, null),
+                metricColor = Palette.metricCyan,
+                sparkline = trail(rawMean) { if (it.spo2Red != null && it.spo2Ir != null) (it.spo2Red + it.spo2Ir) / 2.0 else null },
+            )
+        },
         Vital(
             key = "rhr", label = "Resting HR", unit = "bpm",
             value = d?.restingHr?.toDouble(), format = { it.roundToInt().toString() },
@@ -1950,6 +1976,7 @@ private fun latestVitals(days: List<DailyMetric>, tempUnit: TemperatureUnit): Li
     return listOf(
         latestVital("resp", days, tempUnit, emptyByKey) { it.respRateBpm != null },
         latestVital("spo2", days, tempUnit, emptyByKey) { it.spo2Pct != null },
+        latestVital("spo2raw", days, tempUnit, emptyByKey) { it.spo2Red != null && it.spo2Ir != null },
         latestVital("rhr", days, tempUnit, emptyByKey) { it.restingHr != null },
         latestVital("hrv", days, tempUnit, emptyByKey) { it.avgHrv != null },
         latestVital("skin", days, tempUnit, emptyByKey) { it.skinTempDevC != null },


### PR DESCRIPTION
WHOOP 4.0 already banks raw SpO2 PPG ADC values (spo2_red@68 / spo2_ir@70 on the v24 historical layout) but NOOP intentionally never showed them because computing a calibrated blood-oxygen % needs WHOOP's proprietary curve. This surfaces the RAW red/IR means per night so users can SEE the sensor data is decoded, without fabricating a clinical-looking number.

- Entities: add spo2Red/spo2Ir (Int?) to DailyMetric
- WhoopDatabase: MIGRATION_16_17 (ADD COLUMN, additive/non-destructive) + version 17
- AnalyticsEngine: wornNightlySpo2Raw() averages raw ADC over detected sleep
- IntelligenceEngine: fetch + thread spo2 samples into analyzeDay()
- WhoopRepository: coalesce spo2Red/spo2Ir in mergeDaily (per #112 discipline)
- HealthScreen: new 'Raw SpO2' vital tile (unit ADC, no banding)

## What this PR does

<!-- A short description of the change and why it's needed. -->

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] CI / tooling

## How it was tested

<!--
For anything on the BLE path, say what you tested on real hardware and which
strap (4.0 / 5.0 / MG). For protocol or analytics changes, point to the test
that covers it. "Builds and unit tests pass" alone is not enough for BLE work.
-->

## Checklist

- [ ] Swift package tests pass for any package I touched (`swift test` in `Packages/<name>`)
- [ ] Android unit tests pass if I touched `android/` (`./gradlew testFullDebugUnitTest`)
- [ ] No new build warnings introduced
- [ ] UI changes use only `StrandDesign` tokens — no hardcoded colors, fonts, or spacing
- [ ] No hardcoded hex frame bytes; protocol facts live in the schema / decoders
- [ ] Follows the conventions in [`docs/CONTRIBUTING.md`](../docs/CONTRIBUTING.md)
- [ ] I did not commit generated output (`Strand.xcodeproj/`) or any secrets/keystores

## Related issues

<!-- Closes #N -->
