### PR TITLE
Fix skin temp ignoring Fahrenheit unit preference in Deep Timeline (#101)

### DIFF
--- a/Strand/Liquid/LiquidTodayView.swift
+++ b/Strand/Liquid/LiquidTodayView.swift
@@ -420,8 +420,11 @@ struct LiquidTodayView: View {
         HStack(alignment: .top, spacing: 4) {
             HeroScoreCell(label: String(localized: "Charge"), score: displayDay?.recovery, tint: StrandPalette.chargeColor,
                           pill: "WHOOP", animated: dataLoaded, onGuide: { guideSection = .charge })
-            HeroScoreCell(label: String(localized: "Effort"), score: displayDay?.strain, tint: StrandPalette.effortColor,
-                          pill: nil, animated: dataLoaded, onGuide: { guideSection = .effort })
+            HeroScoreCell(label: String(localized: "Effort"),
+                          score: displayDay?.strain.map { UnitFormatter.effortValue($0, scale: effortScale) },
+                          tint: StrandPalette.effortColor, pill: nil, animated: dataLoaded,
+                          onGuide: { guideSection = .effort },
+                          maxValue: effortScale == .whoop ? 21 : 100)
             HeroScoreCell(label: String(localized: "Rest"), score: restScore, tint: StrandPalette.restColor,
                           pill: "WHOOP", animated: dataLoaded, onGuide: { guideSection = .rest })
         }
@@ -1065,15 +1068,18 @@ private struct LiquidWordmark: View {
 /// hit-transparent so the tap reaches the vessel). The label row taps through to the scoring guide.
 private struct HeroScoreCell: View {
     let label: String
-    let score: Double?            // 0–100 (nil = no data yet)
+    let score: Double?            // on whatever scale the caller passes (nil = no data yet)
     let tint: Color
     let pill: String?
     let animated: Bool
     let onGuide: () -> Void
+    // The scale `score` is already expressed on — 100 for Charge/Rest, or the user's chosen
+    // Effort scale max (100 or 21, #45) so the vessel fill matches the displayed number.
+    var maxValue: Double = 100
 
     @State private var shown: Double = 0
 
-    private var frac: Double? { score.map { max(0, min(1, $0 / 100)) } }
+    private var frac: Double? { score.map { max(0, min(1, $0 / maxValue)) } }
 
     var body: some View {
         VStack(spacing: 7) {

--- a/Strand/Screens/FullDayChartView.swift
+++ b/Strand/Screens/FullDayChartView.swift
@@ -37,6 +37,14 @@ struct FullDayChartView: View {
     }
 
     @State private var metric: Repository.TimelineMetric = .hr
+    // Imperial/Metric temperature preference (#101) — mirrors MetricExplorerView so skin temp here
+    // respects the same °C/°F override instead of always showing Celsius.
+    @AppStorage(UnitPrefs.systemKey) private var unitSystemRaw = UnitSystem.metric.rawValue
+    @AppStorage(UnitPrefs.temperatureKey) private var temperatureRaw = ""
+    private var temperatureUnit: TemperatureUnit {
+        let system = UnitSystem(rawValue: unitSystemRaw) ?? .metric
+        return UnitPrefs.resolveTemperature(system: system, override: temperatureRaw)
+    }
     /// "Owned only" hides empty non-strap rows; "All sources" surfaces the disclosure (#574). The strap is
     /// always the owned source, so this currently scopes the empty-state copy rather than swapping reads.
     @State private var ownedOnly = true
@@ -199,9 +207,18 @@ struct FullDayChartView: View {
         }
     }
 
+    /// `series.points` converted into the DISPLAYED unit (#101) — for every metric but skin temp this is
+    /// just the raw points; skin temp is stored/read in °C, so when the user has °F selected the chart's
+    /// line, y-axis domain AND gridlines (which plot the raw value, not `format`'s output) need the
+    /// converted number, not just the readout label.
+    private var displayPoints: [TrendPoint] {
+        guard metric == .skinTemp, temperatureUnit == .fahrenheit else { return series.points }
+        return series.points.map { TrendPoint(date: $0.date, value: UnitFormatter.celsiusToFahrenheit($0.value)) }
+    }
+
     private var chart: some View {
         OverviewHRChart(
-            points: series.points,
+            points: displayPoints,
             // #979 spin-off — the same sleep-band + workout-glyph layers the classic Today feeds. Passed
             // on EVERY metric track (they're time annotations, so "when was I asleep / training" reads
             // against skin temp or HRV just as it does against HR); the glyph anchors at the shown
@@ -209,7 +226,7 @@ struct FullDayChartView: View {
             sleep: sleepSpan,
             workouts: workoutSpans,
             gradient: gradientFor(metric),
-            valueRange: valueRange(series.points),
+            valueRange: valueRange(displayPoints),
             xRange: dayBounds,
             height: 280,
             // #979 spin-off — iPhone touch scrub: hold to pin the crosshair, drag to read values under
@@ -290,7 +307,7 @@ struct FullDayChartView: View {
     }
 
     private var statsFooter: some View {
-        let v = series.points.map(\.value)
+        let v = displayPoints.map(\.value)
         return ChartFooter([
             ("Min", format(v.min() ?? 0)),
             ("Avg", format(v.reduce(0, +) / Double(max(1, v.count)))),
@@ -372,13 +389,13 @@ struct FullDayChartView: View {
     }
 
     private var latestReadout: String? {
-        series.points.last.map { "\(format($0.value))\(unitSuffix)" }
+        displayPoints.last.map { "\(format($0.value))\(unitSuffix)" }
     }
 
     private var unitSuffix: String {
         switch metric {
         case .hr: return " bpm"
-        case .skinTemp: return "°C"
+        case .skinTemp: return UnitFormatter.temperatureUnit(temperatureUnit)
         case .respiration: return ""
         case .hrv: return " ms"
         case .spo2, .motion, .bandSleepState: return ""
@@ -388,6 +405,9 @@ struct FullDayChartView: View {
     private func format(_ v: Double) -> String {
         switch metric {
         case .hr, .respiration, .hrv: return String(Int(v.rounded()))
+        // `v` already arrives in the displayed unit — the caller reads from `displayPoints`, which
+        // converts skin temp to °F upfront so the chart's own axis (plotted from the same points)
+        // agrees with this readout (#101).
         case .skinTemp: return String(format: "%.1f", v)
         case .spo2, .motion: return String(format: "%.2f", v)
         // #175: name the band's own state at the nearest code so the readout reads "asleep", not "2.0".


### PR DESCRIPTION
## Summary
- Fixes #45: the Effort scale (0-100 vs WHOOP's 0-21) setting wasn't applied to the Today hero gauge.
- Fixes #101: Deep Timeline hardcoded skin temp to °C regardless of the Fahrenheit unit preference set in Settings — affects the readout label, the chart axis, and the chart's y-domain (all previously computed from the raw Celsius points instead of the resolved `UnitPrefs.temperature` override).

## Test plan
- [x] `xcodebuild build -scheme Strand -destination 'platform=macOS'` succeeds with no new warnings/errors.
- [ ] Manual check on a device: Settings → Fahrenheit, open a day's Deep Timeline on the Skin Temp metric, confirm the readout, chart line, and axis all read in °F.

🤖 Generated with [Claude Code](https://claude.com/claude-code)