### PR TITLE
Fix unlabeled Motion readout in Deep Timeline (#102)

### DIFF
--- a/Strand/Screens/FullDayChartView.swift
+++ b/Strand/Screens/FullDayChartView.swift
@@ -381,7 +381,10 @@ struct FullDayChartView: View {
         case .skinTemp: return "°C"
         case .respiration: return ""
         case .hrv: return " ms"
-        case .spo2, .motion, .bandSleepState: return ""
+        // Gravity-vector magnitude (#102): tag it "g" so the readout doesn't read as a bare, unexplained
+        // number — spo2/bandSleepState stay unitless (unitless ratio / a named state, not a magnitude).
+        case .motion: return " g"
+        case .spo2, .bandSleepState: return ""
         }
     }
 


### PR DESCRIPTION
## Summary
- Fixes #102: the Deep Timeline's Motion track showed a bare decimal (e.g. "1.02") with no unit, unlike every other metric on that screen (bpm, ms, °F). It's the gravity-vector magnitude in g, hovering near 1g at rest — without a label there's no way to tell what the number means. Added a " g" unit suffix for `.motion`; `spo2`/`bandSleepState` stay unitless (an unlabeled ratio and a named state, not a magnitude).

## Test plan
- [x] `xcodebuild build -scheme Strand -destination 'platform=macOS'` succeeds with no new warnings/errors.
- [ ] Manual check on a device: open a day's Deep Timeline, select the Motion pill, confirm the readout shows a trailing "g".

🤖 Generated with [Claude Code](https://claude.com/claude-code)