### PR TITLE
Widget: keep the Home-screen widget fresh (publish on background + live battery/connection) (#114)

### DIFF
--- a/StrandiOS/App/StrandiOSApp.swift
+++ b/StrandiOS/App/StrandiOSApp.swift
@@ -122,6 +122,19 @@ struct StrandiOSApp: App {
                     // so a refresh storm can't burn the ~50/day complication transfer budget.
                     Task { await watch.pushLatest(from: model) }
                 }
+                // #114: strap battery % and connection are LIVE (model.live), not repo-cache, so they never
+                // bump refreshSeq — the widget's battery would otherwise never move while the app is open
+                // (the "battery not updating" report). Republish on those too, foreground-gated. Both are
+                // low-frequency (battery ~every 8 min; connection flips are rare), so no throttle is needed
+                // and foreground-initiated reloads are budget-exempt. dropFirst() skips the attach replay.
+                .onReceive(model.live.$batteryPct.dropFirst()) { _ in
+                    guard scenePhase == .active else { return }
+                    Task { await WidgetSnapshot.publish(from: model) }
+                }
+                .onReceive(model.live.$connected.dropFirst()) { _ in
+                    guard scenePhase == .active else { return }
+                    Task { await WidgetSnapshot.publish(from: model) }
+                }
                 // #581: the `noop://import-health` deep link the iOS Shortcut opens after building the
                 // HealthKit-free payload. Filter on the host so other future schemes don't trip the
                 // importer; macOS never registers the scheme so this stays iOS-only.
@@ -163,6 +176,10 @@ struct StrandiOSApp: App {
                     await watch.pushLatest(from: model)
                 }
             } else if phase == .background {
+                // #114: capture the LAST in-app live state on the way out so the Home widget matches what
+                // the user just saw — its battery/HR/score otherwise lag to the last FOREGROUND refreshSeq
+                // bump. One reload per app-exit is low-frequency and well within WidgetKit's daily budget.
+                Task { await WidgetSnapshot.publish(from: model) }
                 // #155: refresh the Documents/noop_sync.txt drop file the user's Siri Shortcut logs
                 // into Apple Health. Gated inside writeIfEnabled on the opt-in default (OFF) — a
                 // no-op until the user turns on Shortcuts Export.


### PR DESCRIPTION
Addresses the data-staleness half of #114 — the iOS Home-screen widget lagging the app (notably "battery not updating").

### Cause
`WidgetSnapshot.publish` only ran on a **foreground `refreshSeq` bump** (15-min analyze tick / backfill completion / health sync / `.active` transition). Two gaps:
- **Live values don't bump `refreshSeq`.** Strap **battery %** and **connection** live on `model.live`, not the repo cache — so while the app was open and battery changed, the widget never refreshed. That's the "battery not updating."
- **Nothing published on the way out** — the widget could show a state *older* than what the user last saw in-app.

### Fix
- Republish on `model.live.$batteryPct` and `$connected` changes, **foreground-gated** (`.active`). Foreground reloads are budget-exempt, and both are low-frequency (battery ~8 min, connection flips rare), so no throttle needed.
- Publish once on **background/resign**, capturing the last in-app state so the widget matches what the user just saw. The app runs `bluetooth-central` (not suspended in background), so this executes; one reload per app-exit is well within WidgetKit's daily budget.

### Honest scope
WidgetKit is still a **periodic glance** in the background (hard reload budget) — this narrows the app↔widget gap, it doesn't make the widget real-time. Out of scope (separate design calls, not built here): the **"Charge" label reading like battery-charge**, and the **richer illustrations / layout** the reporter also asked for. Also worth noting for the reporter: on a WHOOP MG several of these (Charge/HRV) are often *No Data/calibrating*, so some apparent "inaccuracy" may be the strap, not the widget.

### Testing
StrandiOS target — can't build on WSL; a testing build verifies the Swift compiles. Ideally confirmed on-device (widget updates on battery change + after backgrounding).

File: `StrandiOS/App/StrandiOSApp.swift`.