### PR TITLE
Battery estimate: scale the sanity cap to current SoC — fixes "9% = 3 days" (#99)

### DIFF
--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/BatteryEstimator.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/BatteryEstimator.swift
@@ -97,9 +97,11 @@ public enum BatteryEstimator {
 
         let rate = measuredRate ?? (100.0 / max(ratedHours, 1))
         let remaining = max(0, current) / rate
-        // A fresh full charge can't realistically beat about 1.5x the rated life, so clamp out any wild
-        // estimate from a near-flat measured run that still squeaked past the drop gate.
-        let clamped = min(remaining, ratedHours * 1.5)
+        // #99: cap scaled to the CURRENT SoC, not a flat multiple of the FULL rated life. The old
+        // `ratedHours * 1.5` ignored SoC, so a too-slow measured slope at low charge (idle/off-wrist spans,
+        // sparse 5/MG SoC readings) extrapolated 9% to ~3 days — more than a full 12-day MG charge. You can't
+        // realistically stretch the rated per-% runtime past ~1.5x, so bound to that scaled to `current`%.
+        let clamped = min(remaining, ratedHours * 1.5 * (max(0, current) / 100.0))
         return Estimate(remainingHours: clamped,
                         source: measuredRate != nil ? .measured : .rated,
                         currentSoc: current)

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/BatteryEstimatorTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/BatteryEstimatorTests.swift
@@ -84,13 +84,25 @@ final class BatteryEstimatorTests: XCTestCase {
         XCTAssertEqual(e.remainingHours, 285.12, accuracy: 1e-6)   // 99 / (100/288)
     }
 
-    func testClampsToOneAndAHalfTimesRated() {
-        // A slow drain near full charge must not report more than 1.5x the rated life. 100% to 90% over
-        // 20h is 0.5 %/h, current 90% -> 180h raw, clamped to 108*1.5 = 162h.
+    func testClampsToOneAndAHalfTimesRatedScaledToSoc() {
+        // #99: the cap scales with CURRENT SoC (was a flat 1.5x of the FULL rated life). 100% to 90% over
+        // 20h is 0.5 %/h, current 90% -> 180h raw, clamped to 108 * 1.5 * 0.90 = 145.8h (was 162h).
         let e = BatteryEstimator.estimate(samples: [(0, 100), (20 * h, 90)],
                                           ratedHours: BatteryEstimator.ratedLifeHoursWhoop4)!
         XCTAssertEqual(e.source, .measured)
-        XCTAssertEqual(e.remainingHours, 162, accuracy: 1e-6)   // clamped, not 200
+        XCTAssertEqual(e.remainingHours, 145.8, accuracy: 1e-6)   // 108 * 1.5 * 0.90
+    }
+
+    func testLowSocClampScalesWithCurrentCharge() {
+        // #99 (the report): a too-slow discharge (25% -> 9% over 100h ≈ 0.16 %/h, e.g. idle / off-wrist spans
+        // or sparse 5/MG SoC readings) extrapolates 9% to ~56h raw — but 9% of a 12-day MG can't be ~2.3 days.
+        // The SoC-scaled cap bounds it to 288 * 1.5 * 0.09 = 38.88h (~1.6 days), where the OLD flat 1.5x-rated
+        // cap (432h) let the "9% = 3 days" nonsense through.
+        let e = BatteryEstimator.estimate(samples: [(0, 25), (100 * h, 9)],
+                                          ratedHours: BatteryEstimator.ratedLifeHoursWhoop5)!
+        XCTAssertEqual(e.source, .measured)
+        XCTAssertEqual(e.currentSoc, 9, accuracy: 1e-6)
+        XCTAssertEqual(e.remainingHours, 38.88, accuracy: 1e-6)   // 288 * 1.5 * 0.09, not ~56h
     }
 
     func testUnsortedSamplesAreHandled() {

--- a/android/app/src/main/java/com/noop/analytics/BatteryEstimator.kt
+++ b/android/app/src/main/java/com/noop/analytics/BatteryEstimator.kt
@@ -92,9 +92,11 @@ object BatteryEstimator {
 
         val rate = measuredRate ?: (100.0 / maxOf(ratedHours, 1.0))
         val remaining = maxOf(0.0, current) / rate
-        // A fresh full charge can't realistically beat about 1.5x the rated life, so clamp out any wild
-        // estimate from a near-flat measured run that still squeaked past the drop gate.
-        val clamped = minOf(remaining, ratedHours * 1.5)
+        // #99: cap scaled to the CURRENT SoC, not a flat multiple of the FULL rated life. The old
+        // `ratedHours * 1.5` ignored SoC, so a too-slow measured slope at low charge (idle/off-wrist spans,
+        // sparse 5/MG SoC readings) extrapolated 9% to ~3 days — more than a full 12-day MG charge. You can't
+        // realistically stretch the rated per-% runtime past ~1.5x, so bound to that scaled to `current`%.
+        val clamped = minOf(remaining, ratedHours * 1.5 * (maxOf(0.0, current) / 100.0))
         return Estimate(clamped, if (measuredRate != null) Source.MEASURED else Source.RATED, current)
     }
 

--- a/android/app/src/test/java/com/noop/analytics/BatteryEstimatorTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/BatteryEstimatorTest.kt
@@ -84,13 +84,25 @@ class BatteryEstimatorTest {
         assertEquals(285.12, e.remainingHours, 1e-6)   // 99 / (100/288)
     }
 
-    @Test fun clampsToOneAndAHalfTimesRated() {
-        // A slow drain near full charge must not report more than 1.5x the rated life. 100% to 90% over
-        // 20h is 0.5 %/h, current 90% -> 180h raw, clamped to 108*1.5 = 162h.
+    @Test fun clampsToOneAndAHalfTimesRatedScaledToSoc() {
+        // #99: the cap scales with CURRENT SoC (was a flat 1.5x of the FULL rated life). 100% to 90% over
+        // 20h is 0.5 %/h, current 90% -> 180h raw, clamped to 108 * 1.5 * 0.90 = 145.8h (was 162h).
         val e = BatteryEstimator.estimate(listOf(0L to 100.0, 20 * h to 90.0),
             BatteryEstimator.ratedLifeHoursWhoop4)!!
         assertEquals(BatteryEstimator.Source.MEASURED, e.source)
-        assertEquals(162.0, e.remainingHours, 1e-6)   // clamped, not 200
+        assertEquals(145.8, e.remainingHours, 1e-6)   // 108 * 1.5 * 0.90
+    }
+
+    @Test fun lowSocClampScalesWithCurrentCharge() {
+        // #99 (the report): a too-slow discharge (25% -> 9% over 100h ~= 0.16 %/h, e.g. idle / off-wrist
+        // spans or sparse 5/MG SoC readings) extrapolates 9% to ~56h raw — but 9% of a 12-day MG can't be
+        // ~2.3 days. The SoC-scaled cap bounds it to 288 * 1.5 * 0.09 = 38.88h (~1.6 days), where the OLD
+        // flat 1.5x-rated cap (432h) let the "9% = 3 days" nonsense through.
+        val e = BatteryEstimator.estimate(listOf(0L to 25.0, 100 * h to 9.0),
+            BatteryEstimator.ratedLifeHoursWhoop5)!!
+        assertEquals(BatteryEstimator.Source.MEASURED, e.source)
+        assertEquals(9.0, e.currentSoc, 1e-6)
+        assertEquals(38.88, e.remainingHours, 1e-6)   // 288 * 1.5 * 0.09, not ~56h
     }
 
     @Test fun unsortedSamplesAreHandled() {


### PR DESCRIPTION
Fixes #99 — on a WHOOP MG, 9% battery showed "~3 days" remaining.

### Cause
`BatteryEstimator.estimate` computes `remaining = currentSoC ÷ discharge-rate`, clamped only by a **flat** `ratedHours × 1.5` — which **ignores current SoC**. A too-slow measured slope at low charge (idle/off-wrist spans, or sparse 5/MG SoC readings → a tiny %/h) extrapolated 9% to ~3 days = **more than a full 12-day MG charge** (`ratedLifeHoursWhoop5 = 288`). The flat cap (432h for an MG) never caught it. Discharge is also non-linear (faster near empty), which a straight-line fit misses exactly at low SoC.

### Fix
Scale the sanity cap to the **current** SoC: `ratedHours × 1.5 × (current/100)`. You can't realistically stretch the rated per-% runtime past ~1.5×, so this bounds the estimate to a physically-plausible fraction of the rated life. At 9% on an MG → **~1.6 days** instead of 3+, while:
- **rated-fallback** estimates are mathematically unchanged (a rated estimate is exactly `ratedHours×(current/100)`, always ≤ the new cap);
- healthy **mid-range** measured estimates are untouched (well under the cap).

Applied identically on **both platforms** (Swift + Kotlin twin).

### Re-review + testing
Checked against all existing cases: only the one `clamps…` test changes (90% W4: 162 → 145.8h — its exact premise being refined), and the trace tests don't assert the clamp value. Added a **new low-SoC test** pinning the report (25%→9% slow drain → **38.88h**, not ~56h). **Android unit tests green locally**; iOS is the byte-identical twin (same fixtures) — a testing build verifies the Swift compiles.

### On royabby365's question (in-thread)
No new battery-diagnostic test needed — the existing **Test Centre → Battery** panel already exposes the SoC series, fitted slope, and slope source for self-diagnosis. This targeted clamp fixes the reported case without new UI.

Files: `BatteryEstimator.swift`/`.kt` (+ both test files).