### PR TITLE
Raw SpO2 on Health: WHOOP 4.0 raw PPG ADC — iOS/macOS + Android (#93)

### DIFF
--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/AnalyticsEngine.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/AnalyticsEngine.swift
@@ -487,7 +487,7 @@ public enum AnalyticsEngine {
         // Nightly red/IR ADC means over the detected in-bed spans, or nil when the night carried no raw
         // SpO2 samples in any span. Baseline-independent (unlike skin temp): a RAW device reading, banked
         // as-is for the Health "Raw SpO₂" tile — NOT a calibrated blood-oxygen %. (#93)
-        let nightlySpo2Raw = wornNightlySpo2Raw(matched, spo2: spo2)
+        let nightlySpo2Raw = nightlySpo2RawMeans(matched, spo2: spo2)
 
         // ── Recovery / "Charge" ───────────────────────────────────────────────
         var recovery: Double? = nil
@@ -809,8 +809,10 @@ public enum AnalyticsEngine {
     /// banked as-is (unit "raw_adc"); this is NOT a calibrated blood-oxygen %, which needs WHOOP's
     /// proprietary curve. Unlike skin temp there is deliberately no worn-HR / plausible-range gate: the
     /// value is surfaced honestly as raw ADC, never scored, so there's nothing to poison into a fake %.
-    /// Mirrors the Kotlin `wornNightlySpo2Raw` (#93).
-    static func wornNightlySpo2Raw(_ sessions: [SleepSession], spo2: [SpO2Sample]) -> (red: Int, ir: Int)? {
+    /// No wear gate (unlike skin temp): the strap streams SpO2 only on-wrist, so there's nothing to
+    /// exclude, and this name — matching the Kotlin `nightlySpo2RawMeans` twin — avoids the "worn"
+    /// prefix's false implication of a gate. (#93)
+    static func nightlySpo2RawMeans(_ sessions: [SleepSession], spo2: [SpO2Sample]) -> (red: Int, ir: Int)? {
         guard !sessions.isEmpty, !spo2.isEmpty else { return nil }
         var redSum = 0, irSum = 0, kept = 0
         for s in spo2 where sessions.contains(where: { $0.start <= s.ts && s.ts <= $0.end }) {

--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/AnalyticsEngine.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/AnalyticsEngine.swift
@@ -264,6 +264,12 @@ public enum AnalyticsEngine {
                                   // keeps every 5/MG + pure-function caller byte-identical;
                                   // IntelligenceEngine passes the day owner's real family.
                                   skinTempFamily: DeviceFamily = .whoop5,
+                                  // WHOOP 4.0 raw SpO2 PPG ADC samples (red/IR) for the night window
+                                  // (#93). The nightly red/IR means over detected sleep are banked on the
+                                  // DailyMetric as RAW ADC — honest "the sensor decoded" data, NOT a
+                                  // calibrated blood-oxygen % (that needs WHOOP's proprietary curve).
+                                  // Default empty keeps pure-function callers/tests + non-4.0 nights nil.
+                                  spo2: [SpO2Sample] = [],
                                   profile: UserProfile,
                                   baselines: ProfileBaselines = ProfileBaselines(),
                                   maxHROverride: Double? = nil,
@@ -477,6 +483,12 @@ public enum AnalyticsEngine {
             return round2(Baselines.deviation(v, state: b).delta)
         }
 
+        // ── Raw SpO2 (WHOOP 4.0 v24 PPG ADC) ──────────────────────────────────
+        // Nightly red/IR ADC means over the detected in-bed spans, or nil when the night carried no raw
+        // SpO2 samples in any span. Baseline-independent (unlike skin temp): a RAW device reading, banked
+        // as-is for the Health "Raw SpO₂" tile — NOT a calibrated blood-oxygen %. (#93)
+        let nightlySpo2Raw = wornNightlySpo2Raw(matched, spo2: spo2)
+
         // ── Recovery / "Charge" ───────────────────────────────────────────────
         var recovery: Double? = nil
         // Ordered "why is Charge what it is" rows, built from the SAME inputs as the score
@@ -601,7 +613,9 @@ public enum AnalyticsEngine {
             skinTempDevC: skinTempDevC,
             respRateBpm: respRateDaily,
             steps: stepsTotal,
-            activeKcalEst: activeKcalEst)
+            activeKcalEst: activeKcalEst,
+            spo2Red: nightlySpo2Raw?.red,
+            spo2Ir: nightlySpo2Raw?.ir)
         _ = sleepStart; _ = sleepEnd  // available for callers wiring sleep_start/end columns
 
         // ── Cache rows ────────────────────────────────────────────────────────
@@ -787,6 +801,23 @@ public enum AnalyticsEngine {
                                      family: DeviceFamily = .whoop5,
                                      minSamples: Int = minSkinTempSamples) -> Double? {
         skinTempFunnel(sessions, hr: hr, skinTemp: skinTemp, family: family, minSamples: minSamples).mean
+    }
+
+    /// Nightly means of the WHOOP 4.0 raw SpO2 PPG channels (red/IR ADC) over the detected in-bed
+    /// `sessions`, or nil when no raw SpO2 sample fell inside any span. A sample counts when its
+    /// timestamp lies within a session's [start, end]. RAW device output — the red/IR optical means are
+    /// banked as-is (unit "raw_adc"); this is NOT a calibrated blood-oxygen %, which needs WHOOP's
+    /// proprietary curve. Unlike skin temp there is deliberately no worn-HR / plausible-range gate: the
+    /// value is surfaced honestly as raw ADC, never scored, so there's nothing to poison into a fake %.
+    /// Mirrors the Kotlin `wornNightlySpo2Raw` (#93).
+    static func wornNightlySpo2Raw(_ sessions: [SleepSession], spo2: [SpO2Sample]) -> (red: Int, ir: Int)? {
+        guard !sessions.isEmpty, !spo2.isEmpty else { return nil }
+        var redSum = 0, irSum = 0, kept = 0
+        for s in spo2 where sessions.contains(where: { $0.start <= s.ts && s.ts <= $0.end }) {
+            redSum += s.red; irSum += s.ir; kept += 1
+        }
+        guard kept > 0 else { return nil }
+        return (red: redSum / kept, ir: irSum / kept)
     }
 
     // MARK: - Skin-temp funnel diagnostic (#752)

--- a/Packages/WhoopStore/Sources/WhoopStore/Database.swift
+++ b/Packages/WhoopStore/Sources/WhoopStore/Database.swift
@@ -446,6 +446,16 @@ extension WhoopStore {
                 t.primaryKey(["deviceId", "startTs"])
             }
         }
+        migrator.registerMigration("v23-daily-spo2-raw") { db in
+            // WHOOP 4.0 raw SpO2 PPG ADC means (red/IR) over detected sleep, cached beside the other
+            // in-sleep aggregates (#93). ADDITIVE, mirroring v7's SpO2/skin-temp/resp add: two nullable
+            // INTEGER columns. Existing rows read NULL (no rebuild, no data loss), so an older database
+            // upgraded in place is unaffected — non-4.0 nights + pre-upgrade rows simply stay nil.
+            try db.alter(table: "dailyMetric") { t in
+                t.add(column: "spo2Red", .integer)
+                t.add(column: "spo2Ir", .integer)
+            }
+        }
         return migrator
     }
 }

--- a/Packages/WhoopStore/Sources/WhoopStore/MetricsCache.swift
+++ b/Packages/WhoopStore/Sources/WhoopStore/MetricsCache.swift
@@ -61,17 +61,26 @@ public struct DailyMetric: Equatable, Codable {
     // imported/cloud rows that never carry them stay nil and old call sites are unaffected.
     public let steps: Int?             // daily step total from the cumulative @57 counter
     public let activeKcalEst: Double?  // whole-day HR-only calorie estimate (kcal)
+    // WHOOP 4.0 raw SpO2 PPG ADC means over detected sleep (v23 columns, #93). These are the RAW
+    // red/IR optical channels banked on the v24 historical layout (spo2_red@68 / spo2_ir@70), NOT a
+    // calibrated blood-oxygen % — that needs WHOOP's proprietary curve. Both nullable and on-device
+    // only (imports/cloud never carry them), so old rows + non-4.0 nights stay nil and every existing
+    // call site is unaffected.
+    public let spo2Red: Int?           // mean raw red PPG ADC during detected sleep
+    public let spo2Ir: Int?            // mean raw IR PPG ADC during detected sleep
     public init(day: String, totalSleepMin: Double?, efficiency: Double?, deepMin: Double?,
                 remMin: Double?, lightMin: Double?, disturbances: Int?, restingHr: Int?,
                 avgHrv: Double?, recovery: Double?, strain: Double?, exerciseCount: Int?,
                 spo2Pct: Double? = nil, skinTempDevC: Double? = nil, respRateBpm: Double? = nil,
-                steps: Int? = nil, activeKcalEst: Double? = nil) {
+                steps: Int? = nil, activeKcalEst: Double? = nil,
+                spo2Red: Int? = nil, spo2Ir: Int? = nil) {
         self.day = day; self.totalSleepMin = totalSleepMin; self.efficiency = efficiency
         self.deepMin = deepMin; self.remMin = remMin; self.lightMin = lightMin
         self.disturbances = disturbances; self.restingHr = restingHr; self.avgHrv = avgHrv
         self.recovery = recovery; self.strain = strain; self.exerciseCount = exerciseCount
         self.spo2Pct = spo2Pct; self.skinTempDevC = skinTempDevC; self.respRateBpm = respRateBpm
         self.steps = steps; self.activeKcalEst = activeKcalEst
+        self.spo2Red = spo2Red; self.spo2Ir = spo2Ir
     }
 
     /// The freshest STRICTLY-PRIOR day that carries at least one overnight vital (HRV / resting HR /
@@ -355,8 +364,9 @@ extension WhoopStore {
                     INSERT INTO dailyMetric
                         (deviceId, day, totalSleepMin, efficiency, deepMin, remMin, lightMin,
                          disturbances, restingHr, avgHrv, recovery, strain, exerciseCount,
-                         spo2Pct, skinTempDevC, respRateBpm, steps, activeKcalEst)
-                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                         spo2Pct, skinTempDevC, respRateBpm, steps, activeKcalEst,
+                         spo2Red, spo2Ir)
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                     ON CONFLICT(deviceId, day) DO UPDATE SET
                         totalSleepMin = excluded.totalSleepMin,
                         efficiency = excluded.efficiency,
@@ -373,12 +383,15 @@ extension WhoopStore {
                         skinTempDevC = excluded.skinTempDevC,
                         respRateBpm = excluded.respRateBpm,
                         steps = excluded.steps,
-                        activeKcalEst = excluded.activeKcalEst
+                        activeKcalEst = excluded.activeKcalEst,
+                        spo2Red = excluded.spo2Red,
+                        spo2Ir = excluded.spo2Ir
                     """, arguments: [deviceId, d.day, d.totalSleepMin, d.efficiency, d.deepMin,
                                      d.remMin, d.lightMin, d.disturbances, d.restingHr, d.avgHrv,
                                      d.recovery, d.strain, d.exerciseCount,
                                      d.spo2Pct, d.skinTempDevC, d.respRateBpm,
-                                     d.steps, d.activeKcalEst])
+                                     d.steps, d.activeKcalEst,
+                                     d.spo2Red, d.spo2Ir])
                 n += db.changesCount
             }
             return n
@@ -428,7 +441,8 @@ extension WhoopStore {
             try Row.fetchAll(db, sql: """
                 SELECT day, totalSleepMin, efficiency, deepMin, remMin, lightMin, disturbances,
                        restingHr, avgHrv, recovery, strain, exerciseCount,
-                       spo2Pct, skinTempDevC, respRateBpm, steps, activeKcalEst FROM dailyMetric
+                       spo2Pct, skinTempDevC, respRateBpm, steps, activeKcalEst,
+                       spo2Red, spo2Ir FROM dailyMetric
                 WHERE deviceId = ? AND day >= ? AND day <= ?
                 ORDER BY day ASC
                 """, arguments: [deviceId, from, to])
@@ -441,7 +455,8 @@ extension WhoopStore {
                                 strain: $0["strain"], exerciseCount: $0["exerciseCount"],
                                 spo2Pct: $0["spo2Pct"], skinTempDevC: $0["skinTempDevC"],
                                 respRateBpm: $0["respRateBpm"],
-                                steps: $0["steps"], activeKcalEst: $0["activeKcalEst"])
+                                steps: $0["steps"], activeKcalEst: $0["activeKcalEst"],
+                                spo2Red: $0["spo2Red"], spo2Ir: $0["spo2Ir"])
                 }
         }
     }

--- a/Strand/Data/IntelligenceEngine.swift
+++ b/Strand/Data/IntelligenceEngine.swift
@@ -461,6 +461,9 @@ final class IntelligenceEngine: ObservableObject {
                 let grav = (try? await store.gravitySamples(deviceId: owner, from: from, to: to, limit: 200_000)) ?? []
                 let steps = (try? await store.stepSamples(deviceId: owner, from: from, to: to, limit: 200_000)) ?? []
                 let skin = (try? await store.skinTempSamples(deviceId: owner, from: from, to: to, limit: 200_000)) ?? []
+                // #93: WHOOP 4.0 raw SpO2 PPG samples for the night; analyzeDay banks the nightly red/IR ADC
+                // means on the DailyMetric. Empty on a 5/MG (no v24 spo2 channels) → the raw means stay nil.
+                let spo2 = (try? await store.spo2Samples(deviceId: owner, from: from, to: to, limit: 200_000)) ?? []
                 // #938: the strap family that WROTE this owner's skin-temp rows, so analyzeDay converts the raw
                 // register on the right scale (5/MG banks centidegrees, a WHOOP 4.0 v24 banks a raw ADC). The
                 // registry knows each device's model; unknown/non-WHOOP owners fall back to `.whoop5` (the prior
@@ -556,6 +559,7 @@ final class IntelligenceEngine: ObservableObject {
                                                      dayGravity: dayGrav,
                                                      skinTemp: skin,
                                                      skinTempFamily: skinFamily,   // #938
+                                                     spo2: spo2,                   // #93
                                                      profile: up, baselines: baselines1, maxHROverride: maxHR,
                                                      tzOffsetSeconds: tzOffset, wristOff: wristOff,
                                                      habitualMidsleepSec: habitualMidsleepSec,
@@ -1591,7 +1595,8 @@ private extension DailyMetric {
                     remMin: remMin, lightMin: lightMin, disturbances: disturbances, restingHr: restingHr,
                     avgHrv: avgHrv, recovery: r, strain: strain, exerciseCount: exerciseCount,
                     spo2Pct: spo2Pct, skinTempDevC: sd, respRateBpm: respRateBpm,
-                    steps: steps, activeKcalEst: activeKcalEst)
+                    steps: steps, activeKcalEst: activeKcalEst,
+                    spo2Red: spo2Red, spo2Ir: spo2Ir)
     }
 
     /// Rebuild with substituted sleep-derived fields (a user-corrected wake window), leaving every
@@ -1602,6 +1607,6 @@ private extension DailyMetric {
                     disturbances: disturbances, restingHr: restingHr, avgHrv: avgHrv, recovery: recovery,
                     strain: strain, exerciseCount: exerciseCount, spo2Pct: spo2Pct,
                     skinTempDevC: skinTempDevC, respRateBpm: respRateBpm, steps: steps,
-                    activeKcalEst: activeKcalEst)
+                    activeKcalEst: activeKcalEst, spo2Red: spo2Red, spo2Ir: spo2Ir)
     }
 }

--- a/Strand/Data/Repository.swift
+++ b/Strand/Data/Repository.swift
@@ -2493,7 +2493,11 @@ private extension DailyMetric {
             skinTempDevC: skinTempDevC ?? fallback.skinTempDevC,
             respRateBpm: respRateBpm ?? fallback.respRateBpm,
             steps: steps ?? fallback.steps,
-            activeKcalEst: activeKcalEst ?? fallback.activeKcalEst
+            activeKcalEst: activeKcalEst ?? fallback.activeKcalEst,
+            // Raw SpO2 is on-device only (imports never carry it), so the imported row's nil is
+            // backfilled from the computed fallback — otherwise the nightly means would be lost. (#93)
+            spo2Red: spo2Red ?? fallback.spo2Red,
+            spo2Ir: spo2Ir ?? fallback.spo2Ir
         )
     }
 
@@ -2519,7 +2523,9 @@ private extension DailyMetric {
             skinTempDevC: skinTempDevC,
             respRateBpm: respRateBpm,
             steps: steps,
-            activeKcalEst: activeKcalEst
+            activeKcalEst: activeKcalEst,
+            spo2Red: spo2Red,   // non-sleep field: preserved as-is (#93)
+            spo2Ir: spo2Ir
         )
     }
 }

--- a/Strand/Screens/HealthView.swift
+++ b/Strand/Screens/HealthView.swift
@@ -1225,6 +1225,7 @@ private struct LiquidVitalTile: View {
         case "rhr":        return over(100)
         case "resp_rate":  return over(24)
         case "spo2":       return across(90, 100)
+        case "spo2raw":    return across(0, 65535)   // raw PPG ADC mean over the u16 sensor span (#93)
         case "skin_temp":
             // Absolute skin temp (>= 20 °C) maps across a plausible wrist band; a small ±deviation
             // maps around a half-full centre so a normal night reads mid-gauge, not empty.

--- a/Strand/Screens/VitalSignsSummary.swift
+++ b/Strand/Screens/VitalSignsSummary.swift
@@ -64,7 +64,7 @@ struct BodyVitalReading: Identifiable {
         // judgment. Show a plain "uncalibrated" note when a value decoded, "No data" otherwise. (#93)
         if key == "spo2raw" {
             return banding.band == .noData ? String(localized: "No data")
-                                           : String(localized: "Raw · uncalibrated")
+                                           : String(localized: "Uncalibrated")
         }
         switch (banding.band, banding.basis) {
         case (.noData, _):               return String(localized: "No data")

--- a/Strand/Screens/VitalSignsSummary.swift
+++ b/Strand/Screens/VitalSignsSummary.swift
@@ -60,6 +60,12 @@ struct BodyVitalReading: Identifiable {
     /// Which yardstick judged the value: your own baseline vs the typical adult range. String(localized:)
     /// — StatTile's caption is a plain String rendered via Text(String), which never consults the catalog.
     private var stateText: String {
+        // Raw SpO₂ is a device-dependent ADC, not a clinical value — never claim an in/out-of-range
+        // judgment. Show a plain "uncalibrated" note when a value decoded, "No data" otherwise. (#93)
+        if key == "spo2raw" {
+            return banding.band == .noData ? String(localized: "No data")
+                                           : String(localized: "Raw · uncalibrated")
+        }
         switch (banding.band, banding.basis) {
         case (.noData, _):               return String(localized: "No data")
         case (.inRange, .personal):      return String(localized: "In your range")
@@ -141,12 +147,19 @@ enum BodyVitalSigns {
 
         let respPoints = points(key: "resp", \.respRateBpm)
         let spo2Points = points(key: "spo2", \.spo2Pct)
+        // WHOOP 4.0 raw SpO₂: the (red + IR) / 2 ADC mean per night, present only when both channels
+        // decoded for the day. On-device only, so this resolves to the NOOP-computed row. (#93)
+        let spo2rawPoints = points(key: "spo2raw") { m in
+            guard let r = m.spo2Red, let i = m.spo2Ir else { return nil }
+            return (Double(r) + Double(i)) / 2.0
+        }
         let rhrPoints = points(key: "rhr") { $0.restingHr.map(Double.init) }
         let hrvPoints = points(key: "hrv", \.avgHrv)
         let skinPoints = points(key: "skin", \.skinTempDevC)
 
         let respRow = latest(respPoints)
         let spo2Row = latest(spo2Points)
+        let spo2rawRow = latest(spo2rawPoints)
         let rhrRow = latest(rhrPoints)
         let hrvRow = latest(hrvPoints)
         let skinRow = latest(skinPoints)
@@ -223,6 +236,28 @@ enum BodyVitalSigns {
                 source: spo2Row?.source,
                 missingCaption: String(localized: "No SpO₂ import or Health value"),
                 sparkline: trail(spo2Points)
+            ),
+            BodyVitalReading(
+                key: "spo2raw",
+                label: String(localized: "Raw SpO₂"),
+                unit: "ADC",
+                value: spo2rawRow?.value,
+                format: { String(format: "%.0f", $0) },
+                // Unbanded on purpose: this is the WHOOP 4.0 raw PPG ADC mean, device/placement-dependent
+                // with no clinical range — NOT a calibrated blood-oxygen %. Banding over the full u16 span
+                // just keeps the tile cyan (never "off range") while `stateText` labels it uncalibrated, so
+                // we never fabricate an in-range / out-of-range clinical judgment on raw sensor data. (#93)
+                banding: VitalBands.band(
+                    value: spo2rawRow?.value,
+                    history: [],
+                    populationRange: 0...65535,
+                    cfg: nil
+                ),
+                metricColor: StrandPalette.metricCyan,
+                day: spo2rawRow?.day,
+                source: spo2rawRow?.source,
+                missingCaption: String(localized: "No raw SpO₂ decode for the night"),
+                sparkline: trail(spo2rawPoints)
             ),
             BodyVitalReading(
                 key: "rhr",

--- a/android/app/src/main/java/com/noop/analytics/AnalyticsEngine.kt
+++ b/android/app/src/main/java/com/noop/analytics/AnalyticsEngine.kt
@@ -5,6 +5,7 @@ import com.noop.data.EventRow
 import com.noop.data.GravitySample
 import com.noop.data.HrSample
 import com.noop.data.SkinTempSample
+import com.noop.data.Spo2Sample
 import com.noop.data.RespSample
 import com.noop.data.RrInterval
 import com.noop.data.StepSample
@@ -168,6 +169,11 @@ object AnalyticsEngine {
         // Default WHOOP5 keeps every 5/MG + pure-function caller byte-identical; IntelligenceEngine passes
         // the day owner's real family.
         skinTempFamily: DeviceFamily = DeviceFamily.WHOOP5,
+        // WHOOP 4.0 raw SpO2 PPG ADC samples (red/IR) for the night window (#93). The nightly red/IR
+        // means over detected sleep are banked on the DailyMetric as RAW ADC — honest "the sensor
+        // decoded" data, NOT a calibrated blood-oxygen % (that needs WHOOP's proprietary curve). Default
+        // empty keeps pure-function callers/tests + non-4.0 nights null.
+        spo2: List<Spo2Sample> = emptyList(),
         profile: UserProfile,
         baselines: ProfileBaselines = ProfileBaselines(),
         maxHROverride: Double? = null,
@@ -333,6 +339,12 @@ object AnalyticsEngine {
             baselines.skinTemp?.takeIf { it.usable }?.let { round2(Baselines.deviation(v, it).delta) }
         }
 
+        // ── Raw SpO2 (WHOOP 4.0 v24 PPG ADC) ──────────────────────────────────
+        // Nightly red/IR ADC means over the detected in-bed spans, or null when the night carried no raw
+        // SpO2 samples in any span. Baseline-independent (unlike skin temp): a RAW device reading banked
+        // as-is for the Health "Raw SpO2" tile — NOT a calibrated blood-oxygen %. (#93)
+        val nightlySpo2Raw = nightlySpo2RawMeans(matched, spo2)
+
         // ── Rest (sleep_performance composite, 0–100) ─────────────────────────
         // Replaces the bare efficiency proxy: duration-vs-personal-need 0.50 + efficiency 0.20 +
         // restorative (deep+REM)/asleep 0.20 + consistency 0.10. Stored under the sleep_performance
@@ -488,6 +500,8 @@ object AnalyticsEngine {
             respRateBpm = respRateDaily,
             steps = stepsTotal,
             activeKcalEst = activeKcalEst,
+            spo2Red = nightlySpo2Raw?.first,
+            spo2Ir = nightlySpo2Raw?.second,
         )
 
         // ── Per-score confidence tiers (mirror Swift ScoreConfidence.derive decisions) ──
@@ -573,6 +587,34 @@ object AnalyticsEngine {
         family: DeviceFamily = DeviceFamily.WHOOP5,
         minSamples: Int = MIN_SKIN_TEMP_SAMPLES_INLINE,
     ): Double? = skinTempFunnel(sessions, hr, skinTemp, family, minSamples).mean
+
+    /**
+     * Nightly means of the WHOOP 4.0 raw SpO2 PPG channels (red/IR ADC) over the detected in-bed
+     * [sessions], or null when no raw SpO2 sample fell inside any span. A sample counts when its
+     * timestamp lies within a session's [start, end]. WHOOP 4.0 banks these as raw PPG ADC values
+     * (spo2_red@68 / spo2_ir@70 on the v24 historical layout) but NOT a calibrated blood-oxygen % —
+     * computing one needs WHOOP's proprietary curve, so we surface the RAW means only. Deliberately NO
+     * wear gate (unlike skin temp): the strap only streams SpO2 on-wrist, so there is no off-charger
+     * drift to exclude, and the value is surfaced honestly as raw ADC — never scored — so there is
+     * nothing to poison into a fake %. Pure + deterministic; twin of the Swift `wornNightlySpo2Raw`. (#93)
+     */
+    internal fun nightlySpo2RawMeans(
+        sessions: List<DetectedSleep>,
+        spo2: List<Spo2Sample>,
+    ): Pair<Int, Int>? {
+        if (sessions.isEmpty() || spo2.isEmpty()) return null
+        var redSum = 0L
+        var irSum = 0L
+        var kept = 0
+        for (s in spo2) {
+            if (sessions.none { s.ts in it.start..it.end }) continue
+            redSum += s.red
+            irSum += s.ir
+            kept++
+        }
+        if (kept == 0) return null
+        return (redSum / kept).toInt() to (irSum / kept).toInt()
+    }
 
     /** Plausible worn skin-temperature range (°C). Off-wrist/charging samples drift to ambient and are
      *  excluded; the strap's own decode gate is the looser 20–45. (PR #85) */

--- a/android/app/src/main/java/com/noop/analytics/AnalyticsEngine.kt
+++ b/android/app/src/main/java/com/noop/analytics/AnalyticsEngine.kt
@@ -596,7 +596,7 @@ object AnalyticsEngine {
      * computing one needs WHOOP's proprietary curve, so we surface the RAW means only. Deliberately NO
      * wear gate (unlike skin temp): the strap only streams SpO2 on-wrist, so there is no off-charger
      * drift to exclude, and the value is surfaced honestly as raw ADC — never scored — so there is
-     * nothing to poison into a fake %. Pure + deterministic; twin of the Swift `wornNightlySpo2Raw`. (#93)
+     * nothing to poison into a fake %. Pure + deterministic; twin of the Swift `nightlySpo2RawMeans`. (#93)
      */
     internal fun nightlySpo2RawMeans(
         sessions: List<DetectedSleep>,

--- a/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
+++ b/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
@@ -438,6 +438,9 @@ object IntelligenceEngine {
             val grav = repo.gravitySamples(owner, from, to, STREAM_LIMIT)
             val steps = repo.stepSamples(owner, from, to, STREAM_LIMIT)
             val skin = repo.skinTempSamples(owner, from, to, STREAM_LIMIT)
+            // #93: WHOOP 4.0 raw SpO2 PPG samples for the night; analyzeDay banks the nightly red/IR ADC
+            // means on the DailyMetric. Empty on a 5/MG (no v24 spo2 channels) → the raw means stay null.
+            val spo2 = repo.spo2Samples(owner, from, to, STREAM_LIMIT)
             // #938: the strap family that WROTE this owner's skin-temp rows, so analyzeDay converts the raw
             // register on the right scale (5/MG banks centidegrees, a WHOOP 4.0 v24 banks a raw ADC). The
             // owner source resolves it from the registry; unknown/non-WHOOP owners fall back to WHOOP5 (the
@@ -501,6 +504,7 @@ object IntelligenceEngine {
                 dayGravity = dayGrav,
                 skinTemp = skin,
                 skinTempFamily = skinFamily,   // #938
+                spo2 = spo2,                   // #93
                 profile = profile,
                 baselines = baselines1,
                 maxHROverride = maxHROverride,

--- a/android/app/src/main/java/com/noop/data/Entities.kt
+++ b/android/app/src/main/java/com/noop/data/Entities.kt
@@ -230,6 +230,12 @@ data class DailyMetric(
     // by AnalyticsEngine (Keytel active + Harris–Benedict BMR). Null when the day has no scored HR
     // window. NOT cloud/clinical parity, a heart-rate estimate. (#78)
     val activeKcalEst: Double? = null,
+    // WHOOP 4.0 raw SpO2 PPG ADC means over detected sleep (v17 columns, #93). The RAW red/IR optical
+    // channels banked on the v24 historical layout (spo2_red@68 / spo2_ir@70), NOT a calibrated
+    // blood-oxygen % — that needs WHOOP's proprietary curve. Both nullable and on-device only
+    // (imports/cloud never carry them), so old rows + non-4.0 nights stay null.
+    val spo2Red: Int? = null,           // mean raw red PPG ADC during detected sleep
+    val spo2Ir: Int? = null,            // mean raw IR PPG ADC during detected sleep
 )
 
 /**

--- a/android/app/src/main/java/com/noop/data/WhoopDatabase.kt
+++ b/android/app/src/main/java/com/noop/data/WhoopDatabase.kt
@@ -48,7 +48,7 @@ import androidx.sqlite.db.SupportSQLiteDatabase
         LabMarkerRow::class,
         LiveSessionRow::class,
     ],
-    version = 16,
+    version = 17,
     exportSchema = false,
 )
 abstract class WhoopDatabase : RoomDatabase() {
@@ -426,6 +426,26 @@ abstract class WhoopDatabase : RoomDatabase() {
             }
         }
 
+        /**
+         * v16 -> v17: ADDITIVE, adds the WHOOP 4.0 raw SpO2 PPG ADC means (red/IR) to `dailyMetric`,
+         * cached beside the other in-sleep aggregates (#93). Two nullable INTEGER columns, mirroring the
+         * v7 spo2Pct/skinTempDevC/respRateBpm add and the Swift WhoopStore v23 migration. Existing rows
+         * read NULL (ALTER ADD COLUMN, no table rebuild, no data loss), so an in-place upgrade of an older
+         * database is unaffected — pre-upgrade rows + non-4.0 nights simply stay null. No destructive
+         * fallback (see the class doc). Room's Int? maps to a nullable INTEGER (no NOT NULL / no DEFAULT),
+         * so the SQL must match Room's generated schema exactly. Exposed for a plain-JVM unit test.
+         */
+        internal val DAILY_SPO2_RAW_MIGRATION_SQL: List<String> = listOf(
+            "ALTER TABLE `dailyMetric` ADD COLUMN `spo2Red` INTEGER",
+            "ALTER TABLE `dailyMetric` ADD COLUMN `spo2Ir` INTEGER",
+        )
+
+        internal val MIGRATION_16_17 = object : Migration(16, 17) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                for (stmt in DAILY_SPO2_RAW_MIGRATION_SQL) db.execSQL(stmt)
+            }
+        }
+
         private fun build(appContext: Context): WhoopDatabase =
             Room.databaseBuilder(appContext, WhoopDatabase::class.java, DB_NAME)
                 // #1014: replace ONLY the corruption handling of the default open-helper. The
@@ -440,7 +460,7 @@ abstract class WhoopDatabase : RoomDatabase() {
                     MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5,
                     MIGRATION_5_6, MIGRATION_6_7, MIGRATION_7_8, MIGRATION_8_9, MIGRATION_9_10,
                     MIGRATION_10_11, MIGRATION_11_12, MIGRATION_12_13, MIGRATION_13_14,
-                    MIGRATION_14_15, MIGRATION_15_16,
+                    MIGRATION_14_15, MIGRATION_15_16, MIGRATION_16_17,
                 )
                 // #1037: a FRESH install builds the schema straight at the current version and runs NO
                 // migrations, so the MIGRATION_7_8 "my-whoop" registry seed never fires and the WHOOP,

--- a/android/app/src/main/java/com/noop/data/WhoopRepository.kt
+++ b/android/app/src/main/java/com/noop/data/WhoopRepository.kt
@@ -1588,6 +1588,10 @@ class WhoopRepository(private val dao: WhoopDao) {
                     respRateBpm = d.respRateBpm ?: c.respRateBpm,
                     steps = d.steps ?: c.steps,
                     activeKcalEst = d.activeKcalEst ?: c.activeKcalEst,
+                    // Raw SpO2 is on-device only (imports never carry it), so the imported row's null
+                    // is backfilled from the computed row — otherwise the nightly means would be lost. (#93)
+                    spo2Red = d.spo2Red ?: c.spo2Red,
+                    spo2Ir = d.spo2Ir ?: c.spo2Ir,
                 )
                 // #993: a BARE imported sleep total must never override a night the strap actually
                 // scored. HealthConnectImporter backfills a "my-whoop" daily row carrying ONLY

--- a/android/app/src/main/java/com/noop/ui/HealthScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/HealthScreen.kt
@@ -1523,6 +1523,9 @@ private data class Vital(
     /** The in-range caption that stands in for a StatePill inside the fixed-height tile.
      *  The wording says which yardstick judged it: your baseline vs typical ranges. */
     val stateCaption: String = when {
+        // Raw SpO₂ is a device-dependent ADC, not a clinical value — never claim an in/out-of-range
+        // judgment. Show a plain "uncalibrated" note when a value decoded, "No data" otherwise. (#93)
+        key == "spo2raw" -> if (banding.band == VitalBands.Band.NO_DATA) "No data" else "Uncalibrated"
         banding.band == VitalBands.Band.NO_DATA -> "No data"
         banding.basis == VitalBands.Basis.PERSONAL ->
             if (banding.band == VitalBands.Band.IN_RANGE) "In your range" else "Off your baseline"
@@ -1620,6 +1623,13 @@ private fun vitalsFor(
         skinUnitLabel,
         skinFormat,
     )
+    // WHOOP 4.0 raw SpO₂: the (red + IR) / 2 ADC mean per night, present only when both channels
+    // decoded for the day. Averaged for a single "signal decoded" tile; both channels stay in the DB. (#93)
+    val spo2RawMean: (DailyMetric) -> Double? = { row ->
+        if (row.spo2Red != null && row.spo2Ir != null) (row.spo2Red + row.spo2Ir) / 2.0 else null
+    }
+    val spo2rawRangeCaption =
+        rangeCaption(days.mapNotNull(spo2RawMean), "ADC") { String.format(Locale.US, "%.0f", it) }
     return listOf(
         Vital(
             key = "resp", label = "Resp Rate", unit = "rpm",
@@ -1644,6 +1654,22 @@ private fun vitalsFor(
             banding = VitalBands.band(d?.spo2Pct, emptyList(), 95.0..100.0, null),
             metricColor = Palette.metricCyan,
             sparkline = trail(d?.spo2Pct) { it.spo2Pct },
+        ),
+        Vital(
+            // Issue #93: WHOOP 4.0 raw SpO₂ PPG ADC mean (red+IR)/2 per night. NOT a calibrated
+            // blood-oxygen % — that needs WHOOP's proprietary curve. Shown as RAW ADC so users can SEE
+            // the sensor data decoded, without fabricating a clinical-looking number. Banding over the
+            // full u16 span just keeps the tile cyan (never "off range"); `stateCaption` labels it
+            // uncalibrated, so we never assert an in/out-of-range clinical judgment on raw sensor data.
+            key = "spo2raw", label = "Raw SpO₂", unit = "ADC",
+            value = d?.let(spo2RawMean), format = { String.format("%.0f", it) },
+            deltaText = deltaText(d?.let(spo2RawMean), previous(spo2RawMean), decimals = 0),
+            readingDay = todayKey,
+            asOfLabel = asOfLabel(todayKey),
+            rangeCaption = spo2rawRangeCaption,
+            banding = VitalBands.band(d?.let(spo2RawMean), emptyList(), 0.0..65535.0, null),
+            metricColor = Palette.metricCyan,
+            sparkline = trail(d?.let(spo2RawMean)) { spo2RawMean(it) },
         ),
         Vital(
             key = "rhr", label = "Resting HR", unit = "bpm",
@@ -1950,6 +1976,7 @@ private fun latestVitals(days: List<DailyMetric>, tempUnit: TemperatureUnit): Li
     return listOf(
         latestVital("resp", days, tempUnit, emptyByKey) { it.respRateBpm != null },
         latestVital("spo2", days, tempUnit, emptyByKey) { it.spo2Pct != null },
+        latestVital("spo2raw", days, tempUnit, emptyByKey) { it.spo2Red != null && it.spo2Ir != null },
         latestVital("rhr", days, tempUnit, emptyByKey) { it.restingHr != null },
         latestVital("hrv", days, tempUnit, emptyByKey) { it.avgHrv != null },
         latestVital("skin", days, tempUnit, emptyByKey) { it.skinTempDevC != null },

--- a/android/app/src/test/java/com/noop/analytics/NightlySpo2RawTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/NightlySpo2RawTest.kt
@@ -1,0 +1,73 @@
+package com.noop.analytics
+
+import com.noop.data.Spo2Sample
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * Pure unit test for [AnalyticsEngine.nightlySpo2RawMeans] (WHOOP 4.0 raw SpO2 red/IR ADC means over
+ * detected sleep, #93). Twin of the Swift `wornNightlySpo2Raw`. No wear gate: the strap streams SpO2
+ * only on-wrist, so a sample counts purely by whether its timestamp lands inside a detected in-bed span.
+ */
+class NightlySpo2RawTest {
+
+    private fun sleep(start: Long, end: Long) =
+        DetectedSleep(start = start, end = end, efficiency = 0.9, stages = emptyList(),
+            restingHR = 55, avgHRV = 60.0)
+
+    private fun spo2(ts: Long, red: Int, ir: Int) =
+        Spo2Sample(deviceId = "my-whoop", ts = ts, red = red, ir = ir)
+
+    @Test
+    fun emptyInputs_returnNull() {
+        assertNull(AnalyticsEngine.nightlySpo2RawMeans(emptyList(), listOf(spo2(100, 1, 1))))
+        assertNull(AnalyticsEngine.nightlySpo2RawMeans(listOf(sleep(0, 1000)), emptyList()))
+    }
+
+    @Test
+    fun inWindowSamples_averageRedAndIrSeparately() {
+        val sessions = listOf(sleep(1000, 2000))
+        val samples = listOf(
+            spo2(1100, red = 30000, ir = 20000),
+            spo2(1500, red = 32000, ir = 24000),
+        )
+        val (red, ir) = AnalyticsEngine.nightlySpo2RawMeans(sessions, samples)!!
+        assertEquals(31000, red)   // (30000 + 32000) / 2
+        assertEquals(22000, ir)    // (20000 + 24000) / 2
+    }
+
+    @Test
+    fun samplesOutsideEveryWindow_returnNull() {
+        val sessions = listOf(sleep(1000, 2000))
+        val samples = listOf(spo2(500, 1, 1), spo2(2500, 2, 2))  // both outside [1000, 2000]
+        assertNull(AnalyticsEngine.nightlySpo2RawMeans(sessions, samples))
+    }
+
+    @Test
+    fun onlyInWindowSamplesCount_boundariesInclusive() {
+        val sessions = listOf(sleep(1000, 2000))
+        val samples = listOf(
+            spo2(999, red = 9, ir = 9),        // just before → dropped
+            spo2(1000, red = 100, ir = 200),   // inclusive start → kept
+            spo2(2000, red = 300, ir = 400),   // inclusive end → kept
+            spo2(2001, red = 9, ir = 9),       // just after → dropped
+        )
+        val (red, ir) = AnalyticsEngine.nightlySpo2RawMeans(sessions, samples)!!
+        assertEquals(200, red)   // (100 + 300) / 2
+        assertEquals(300, ir)    // (200 + 400) / 2
+    }
+
+    @Test
+    fun multipleSessions_unionOfWindows() {
+        val sessions = listOf(sleep(1000, 1500), sleep(3000, 3500))
+        val samples = listOf(
+            spo2(1200, red = 10, ir = 20),   // in first
+            spo2(2000, red = 99, ir = 99),   // gap → dropped
+            spo2(3200, red = 30, ir = 40),   // in second
+        )
+        val (red, ir) = AnalyticsEngine.nightlySpo2RawMeans(sessions, samples)!!
+        assertEquals(20, red)   // (10 + 30) / 2
+        assertEquals(30, ir)    // (20 + 40) / 2
+    }
+}

--- a/android/app/src/test/java/com/noop/analytics/NightlySpo2RawTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/NightlySpo2RawTest.kt
@@ -7,7 +7,7 @@ import org.junit.Test
 
 /**
  * Pure unit test for [AnalyticsEngine.nightlySpo2RawMeans] (WHOOP 4.0 raw SpO2 red/IR ADC means over
- * detected sleep, #93). Twin of the Swift `wornNightlySpo2Raw`. No wear gate: the strap streams SpO2
+ * detected sleep, #93). Twin of the Swift `nightlySpo2RawMeans`. No wear gate: the strap streams SpO2
  * only on-wrist, so a sample counts purely by whether its timestamp lands inside a detected in-bed span.
  */
 class NightlySpo2RawTest {

--- a/android/app/src/test/java/com/noop/data/DailySpo2RawMigrationTest.kt
+++ b/android/app/src/test/java/com/noop/data/DailySpo2RawMigrationTest.kt
@@ -1,0 +1,61 @@
+package com.noop.data
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Guards the additive v16 -> v17 Room migration (the raw SpO2 red/IR ADC columns on `dailyMetric`, #93),
+ * the Android twin of the Swift WhoopStore v23 migration. No Robolectric here, so the migration SQL is
+ * exposed as an internal constant ([WhoopDatabase.DAILY_SPO2_RAW_MIGRATION_SQL]) and pinned to Room's
+ * generated shape for the two nullable Int columns: `ALTER TABLE ADD COLUMN ... INTEGER` (no NOT NULL,
+ * no DEFAULT), so an in-place upgrade of an older database keeps every existing row (columns read NULL).
+ */
+class DailySpo2RawMigrationTest {
+
+    @Test
+    fun migration_isAdditive_onlyAddColumn() {
+        val sql = WhoopDatabase.DAILY_SPO2_RAW_MIGRATION_SQL
+        assertEquals("two ADD COLUMN statements", 2, sql.size)
+        for (s in sql) {
+            val up = s.trimStart().uppercase()
+            assertTrue("only ALTER TABLE ADD COLUMN allowed, got: $s", up.startsWith("ALTER TABLE"))
+            assertTrue("must be an ADD COLUMN, got: $s", up.contains("ADD COLUMN"))
+            // Nullable columns: Room emits no NOT NULL / no DEFAULT for an Int?; a NOT NULL add without a
+            // default would fail on a non-empty table (the older-DB regression this guards against).
+            assertTrue("nullable column must not be NOT NULL: $s", !up.contains("NOT NULL"))
+            for (banned in listOf("DROP ", "DELETE ", "UPDATE ", "INSERT ", "RENAME ")) {
+                assertTrue("additive migration must not contain '$banned': $s", !up.contains(banned))
+            }
+        }
+    }
+
+    @Test
+    fun migration_addsExactColumns() {
+        assertEquals(
+            listOf(
+                "ALTER TABLE `dailyMetric` ADD COLUMN `spo2Red` INTEGER",
+                "ALTER TABLE `dailyMetric` ADD COLUMN `spo2Ir` INTEGER",
+            ),
+            WhoopDatabase.DAILY_SPO2_RAW_MIGRATION_SQL,
+        )
+    }
+
+    @Test
+    fun migration_versionPair_is16to17() {
+        assertEquals(16, WhoopDatabase.MIGRATION_16_17.startVersion)
+        assertEquals(17, WhoopDatabase.MIGRATION_16_17.endVersion)
+    }
+
+    @Test
+    fun dailyMetric_rawSpo2Fields_defaultNull() {
+        // Old rows + non-4.0 nights never set these; the entity default must be null so the merge +
+        // Room round-trip leave pre-upgrade data untouched.
+        val bare = DailyMetric(deviceId = "my-whoop", day = "2026-07-03")
+        assertEquals(null, bare.spo2Red)
+        assertEquals(null, bare.spo2Ir)
+        val filled = bare.copy(spo2Red = 31000, spo2Ir = 28000)
+        assertEquals(31000, filled.spo2Red)
+        assertEquals(28000, filled.spo2Ir)
+    }
+}


### PR DESCRIPTION
iOS/macOS parity for the Android raw-SpO₂ support (#100), closing the platform gap on #93.

## What
The WHOOP 4.0 v24 historical layout banks the raw red/IR PPG ADC channels (`spo2_red@68` / `spo2_ir@70`). This surfaces them on iOS/macOS the same way Android does:

- `AnalyticsEngine.analyzeDay` now takes the night's `spo2` samples and `wornNightlySpo2Raw` aggregates the **red/IR ADC means over detected sleep** (nil when no raw sample falls in an in-bed span). Banked on `DailyMetric.spo2Red` / `.spo2Ir`.
- `IntelligenceEngine` reads `store.spo2Samples` for the night window and threads them in (empty on a 5/MG → stays nil).
- Health screen gets a **"Raw SpO₂"** vital tile: value `(red + IR) / 2`, unit `ADC`, **unbanded / "uncalibrated"** caption.

This is honest *"the sensor decoded"* data — **not** a calibrated blood-oxygen %, which needs WHOOP's proprietary curve. No fabricated clinical number, no in/out-of-range judgment on raw ADC.

## No regression for older databases ✅
The two `dailyMetric` columns are added by an **additive GRDB migration** `v23-daily-spo2-raw` (`ALTER TABLE dailyMetric ADD COLUMN`), mirroring `v7`'s `spo2Pct`/`skinTempDevC`/`respRateBpm` add exactly:

- Existing rows read **NULL** — no table rebuild, no data loss.
- The migrator has **no `eraseDatabaseOnSchemaChange`**, so an in-place upgrade of an older DB just applies `v23` on next open (an older imported `.noopbak` gets the missing migrations too).
- Both fields are **nullable + on-device only** (imports/cloud never carry them), so pre-upgrade rows and non-4.0 nights stay nil and every existing call site is unaffected.
- `DailyMetric` keeps synthesized `Codable` — older JSON blobs decode the missing keys as nil.

## Merge discipline
Carried through both `DailyMetric.with()` copies and the merge helpers: `fillingNilFields` **coalesces** (`spo2Red ?? fallback.spo2Red`) so the computed value survives an import merge; `takingSleepFields` preserves it as a non-sleep field.

## Files
`MetricsCache.swift` (struct + INSERT/SELECT), `Database.swift` (v23 migration), `AnalyticsEngine.swift` (`wornNightlySpo2Raw` + threading), `IntelligenceEngine.swift` (fetch + `.with()` copies), `Repository.swift` (merge helpers), `VitalSignsSummary.swift` + `HealthView.swift` (the tile).