### PR TITLE
iOS/macOS: clarify overnight-only HRV setting copy (#92)

### DIFF
--- a/Strand/Screens/SettingsView.swift
+++ b/Strand/Screens/SettingsView.swift
@@ -856,7 +856,7 @@ struct SettingsView: View {
                     .onChangeCompat(of: continuousHrvOvernightOnly) { _ in
                         model.ble.setKeepRealtimeForData(PuffinExperiment.keepRealtimeForDataEnabled)
                     }
-                    Text("Runs the stream only during your quiet hours window (22:00 to 07:00 by default), roughly halving the battery cost. Daytime Stress readings will be sparser, since Stress reads this live stream.")
+                    Text("Runs the continuous HRV stream only during your quiet hours window (22:00–07:00 by default), roughly halving the battery cost. Daytime Stress readings will be sparser. Note: continuous background HRV capture (including daytime naps) is paused outside this window. For on-demand daytime HRV readings (including naps), use the \"Take an HRV reading\" button on the Live screen.")
                         .font(StrandFont.caption)
                         .foregroundStyle(StrandPalette.textTertiary)
                         .fixedSize(horizontal: false, vertical: true)


### PR DESCRIPTION
iOS/macOS half of #92, mirroring the Android copy clarification merged in #95 so both platforms describe the **"Overnight only"** continuous-HRV setting identically.

## What
`Strand/Screens/SettingsView.swift` (shared iOS + macOS) had the old vague description; this replaces it with the same wording now on Android `main`:
- states that continuous background HRV capture (including daytime naps) is **paused** outside the quiet-hours window
- points users to the **"Take an HRV reading"** button on the Live screen for an on-demand daytime reading

## Why it's safe / accurate
Copy-only, **verbatim match** to the Android string. No behaviour change — the overnight-window logic and the manual-snapshot realtime bypass are untouched. I verified both facts the copy asserts against the code:
- the Live screen has a button with that exact label (`LiveView.swift` / `HRVSnapshotView.swift`, #127)
- it bypasses the overnight gate: opening the Live screen sets `screenWantsRealtime = true`, which arms the R-R stream regardless of the setting

The stale localized entry for the old string is simply bypassed (the code now looks up the new key; non-English falls back to the new English until re-translated) — same source-string-only scope as #95.

Closes the iOS/macOS side of #92.