### PR TITLE
Today/Deep Timeline: respect °F + Effort scale on the hero, with one-decimal Effort (#45, #101)

### DIFF
--- a/Strand/Liquid/LiquidPrimitives.swift
+++ b/Strand/Liquid/LiquidPrimitives.swift
@@ -383,11 +383,16 @@ struct LiquidPressStyle: ButtonStyle {
 struct CountUpNumber: View, Animatable {
     var value: Double
     var font: Font
+    /// Decimal places to render. 0 (default) keeps the whole-number scores (Charge/Rest/100-scale Effort)
+    /// byte-identical; the WHOOP 0–21 Effort scale passes 1 so the hero matches the app-wide one-decimal
+    /// `effortDisplay` convention instead of rounding 12.6 → "13" (#45).
+    var decimals: Int = 0
     var animatableData: Double {
         get { value }
         set { value = newValue }
     }
     var body: some View {
-        Text("\(Int(value.rounded()))").font(font).monospacedDigit()
+        Text(decimals > 0 ? String(format: "%.\(decimals)f", value) : "\(Int(value.rounded()))")
+            .font(font).monospacedDigit()
     }
 }

--- a/Strand/Liquid/LiquidTodayView.swift
+++ b/Strand/Liquid/LiquidTodayView.swift
@@ -420,8 +420,16 @@ struct LiquidTodayView: View {
         HStack(alignment: .top, spacing: 4) {
             HeroScoreCell(label: String(localized: "Charge"), score: displayDay?.recovery, tint: StrandPalette.chargeColor,
                           pill: "WHOOP", animated: dataLoaded, onGuide: { guideSection = .charge })
-            HeroScoreCell(label: String(localized: "Effort"), score: displayDay?.strain, tint: StrandPalette.effortColor,
-                          pill: nil, animated: dataLoaded, onGuide: { guideSection = .effort })
+            // #45: the hero Effort must honour the user's Effort scale like every other Effort read-out.
+            // Show the value on the chosen scale (0–100 or WHOOP 0–21) with the matching vessel max, and
+            // one decimal on the compressed 0–21 axis to match the app-wide `effortDisplay` convention
+            // (12.6, not a rounded "13"); the 0–100 hero stays a whole number as before.
+            HeroScoreCell(label: String(localized: "Effort"),
+                          score: displayDay?.strain.map { UnitFormatter.effortValue($0, scale: effortScale) },
+                          tint: StrandPalette.effortColor, pill: nil, animated: dataLoaded,
+                          onGuide: { guideSection = .effort },
+                          maxValue: effortScale == .whoop ? 21 : 100,
+                          decimals: effortScale == .whoop ? 1 : 0)
             HeroScoreCell(label: String(localized: "Rest"), score: restScore, tint: StrandPalette.restColor,
                           pill: "WHOOP", animated: dataLoaded, onGuide: { guideSection = .rest })
         }
@@ -1065,15 +1073,21 @@ private struct LiquidWordmark: View {
 /// hit-transparent so the tap reaches the vessel). The label row taps through to the scoring guide.
 private struct HeroScoreCell: View {
     let label: String
-    let score: Double?            // 0–100 (nil = no data yet)
+    let score: Double?            // on whatever scale the caller passes (nil = no data yet)
     let tint: Color
     let pill: String?
     let animated: Bool
     let onGuide: () -> Void
+    // The scale `score` is already expressed on — 100 for Charge/Rest, or the user's chosen Effort scale
+    // max (100 or 21, #45) — so the vessel fill matches the displayed number.
+    var maxValue: Double = 100
+    // Decimal places for the displayed number. 0 keeps the whole-number scores; the WHOOP 0–21 Effort
+    // scale passes 1 to match the app-wide one-decimal `effortDisplay` convention (#45).
+    var decimals: Int = 0
 
     @State private var shown: Double = 0
 
-    private var frac: Double? { score.map { max(0, min(1, $0 / 100)) } }
+    private var frac: Double? { score.map { max(0, min(1, $0 / maxValue)) } }
 
     var body: some View {
         VStack(spacing: 7) {
@@ -1082,7 +1096,7 @@ private struct HeroScoreCell: View {
                     .frame(width: 96, height: 96)
                 Group {
                     if score != nil {
-                        CountUpNumber(value: shown, font: StrandFont.rounded(26))
+                        CountUpNumber(value: shown, font: StrandFont.rounded(26), decimals: decimals)
                     } else {
                         Text("–").font(StrandFont.rounded(26))
                     }
@@ -1104,7 +1118,7 @@ private struct HeroScoreCell: View {
                 .foregroundStyle(StrandPalette.onDarkSecondary)
             }
             .buttonStyle(.plain)
-            .accessibilityLabel(Text("\(label), \(score.map { String(Int($0.rounded())) } ?? String(localized: "no data yet")). See how it is scored."))
+            .accessibilityLabel(Text("\(label), \(score.map { decimals > 0 ? String(format: "%.\(decimals)f", $0) : String(Int($0.rounded())) } ?? String(localized: "no data yet")). See how it is scored."))
             if let pill {
                 Text(pill)
                     .font(StrandFont.overlineScaled(8.5)).tracking(1.2)

--- a/Strand/Screens/FullDayChartView.swift
+++ b/Strand/Screens/FullDayChartView.swift
@@ -37,6 +37,14 @@ struct FullDayChartView: View {
     }
 
     @State private var metric: Repository.TimelineMetric = .hr
+    // Imperial/Metric temperature preference (#101) — mirrors MetricExplorerView so skin temp here
+    // respects the same °C/°F override instead of always showing Celsius.
+    @AppStorage(UnitPrefs.systemKey) private var unitSystemRaw = UnitSystem.metric.rawValue
+    @AppStorage(UnitPrefs.temperatureKey) private var temperatureRaw = ""
+    private var temperatureUnit: TemperatureUnit {
+        let system = UnitSystem(rawValue: unitSystemRaw) ?? .metric
+        return UnitPrefs.resolveTemperature(system: system, override: temperatureRaw)
+    }
     /// "Owned only" hides empty non-strap rows; "All sources" surfaces the disclosure (#574). The strap is
     /// always the owned source, so this currently scopes the empty-state copy rather than swapping reads.
     @State private var ownedOnly = true
@@ -199,9 +207,21 @@ struct FullDayChartView: View {
         }
     }
 
+    /// `series.points` in the DISPLAYED unit (#101) — for every metric but skin temp this is just the raw
+    /// points; skin temp is stored/read in °C, so when the user has °F selected the chart's line, y-axis
+    /// domain AND gridlines (which plot the raw value, not `format`'s output) need the converted number,
+    /// not just the readout label. The timeline series is the ABSOLUTE skin temp (`skinTempCelsius`), so
+    /// the absolute °C→°F conversion (×9/5 + 32) is the right one here — not a deviation rescale.
+    private var displayPoints: [TrendPoint] {
+        guard metric == .skinTemp, temperatureUnit == .fahrenheit else { return series.points }
+        return series.points.map {
+            TrendPoint(date: $0.date, value: UnitFormatter.celsiusToFahrenheit($0.value))
+        }
+    }
+
     private var chart: some View {
         OverviewHRChart(
-            points: series.points,
+            points: displayPoints,
             // #979 spin-off — the same sleep-band + workout-glyph layers the classic Today feeds. Passed
             // on EVERY metric track (they're time annotations, so "when was I asleep / training" reads
             // against skin temp or HRV just as it does against HR); the glyph anchors at the shown
@@ -209,7 +229,7 @@ struct FullDayChartView: View {
             sleep: sleepSpan,
             workouts: workoutSpans,
             gradient: gradientFor(metric),
-            valueRange: valueRange(series.points),
+            valueRange: valueRange(displayPoints),
             xRange: dayBounds,
             height: 280,
             // #979 spin-off — iPhone touch scrub: hold to pin the crosshair, drag to read values under
@@ -290,7 +310,7 @@ struct FullDayChartView: View {
     }
 
     private var statsFooter: some View {
-        let v = series.points.map(\.value)
+        let v = displayPoints.map(\.value)
         return ChartFooter([
             ("Min", format(v.min() ?? 0)),
             ("Avg", format(v.reduce(0, +) / Double(max(1, v.count)))),
@@ -372,13 +392,13 @@ struct FullDayChartView: View {
     }
 
     private var latestReadout: String? {
-        series.points.last.map { "\(format($0.value))\(unitSuffix)" }
+        displayPoints.last.map { "\(format($0.value))\(unitSuffix)" }
     }
 
     private var unitSuffix: String {
         switch metric {
         case .hr: return " bpm"
-        case .skinTemp: return "°C"
+        case .skinTemp: return UnitFormatter.temperatureUnit(temperatureUnit)   // #101: °C / °F per preference
         case .respiration: return ""
         case .hrv: return " ms"
         // Gravity-vector magnitude (#102): tag it "g" so the readout doesn't read as a bare, unexplained
@@ -391,6 +411,8 @@ struct FullDayChartView: View {
     private func format(_ v: Double) -> String {
         switch metric {
         case .hr, .respiration, .hrv: return String(Int(v.rounded()))
+        // `v` already arrives in the displayed unit — callers read from `displayPoints`, which converts
+        // skin temp to °F upfront so the chart's own axis (plotted from the same points) agrees. (#101)
         case .skinTemp: return String(format: "%.1f", v)
         case .spo2, .motion: return String(format: "%.2f", v)
         // #175: name the band's own state at the nearest code so the readout reads "asleep", not "2.0".


### PR DESCRIPTION
Reimplements the two fixes from #104 under our own identity, **with the Effort display-precision nit fixed**. Supersedes #104 — closes #45 and #101.

## #101 — Deep Timeline skin temp respects °F
`FullDayChartView` hardcoded skin temp to °C. Now a `displayPoints` projection converts to °F when the user's temperature preference is Fahrenheit, and the chart **line, y-axis domain + gridlines, stats footer, readout, and unit suffix** all read from it. The timeline series is the **absolute** skin temp (`skinTempCelsius`), so the absolute `×9/5+32` conversion is correct (not a deviation rescale). Mirrors `MetricExplorerView`.

## #45 — Today hero Effort respects the Effort scale
The hero Effort vessel ignored the 0–100 vs WHOOP-0–21 setting (always 0–100). Now it shows `effortValue(strain, scale)` with a matching vessel max (100 or 21) — the fill stays exact while the number honours the toggle like every other Effort read-out.

## The fix over #104
#104 fed the raw value straight to `CountUpNumber`, which renders `Int(rounded())` — so on the WHOOP 0–21 scale the hero showed **"13"** instead of the one-decimal **"12.6"** that the app-wide `effortDisplay` convention (and WHOOP itself) uses, inconsistent with the Effort tile on the same screen. `CountUpNumber` gains a `decimals` param (default `0` keeps Charge/Rest/100-scale byte-identical); the 0–21 Effort hero passes `1`. Accessibility label matches.

## Notes
- iOS/macOS only — **not locally compile-verified** (WSL can't build Swift); self-reviewed (`TrendPoint(date:value:)` init confirmed; the other four `CountUpNumber` call sites use the no-`decimals` form and are unchanged). Rides the next build.
- Worth a follow-up check on whether **Android**'s Deep Timeline / Today hero have the same two gaps, for lockstep.