### PR TITLE
Oura: log WHY a UTC anchor was rejected — iOS + Android (#91)

### DIFF
--- a/Packages/OuraProtocol/Sources/OuraProtocol/OuraDriver.swift
+++ b/Packages/OuraProtocol/Sources/OuraProtocol/OuraDriver.swift
@@ -241,6 +241,14 @@ public final class OuraDriver {
         return seconds * 1000   // safe: bounded input, cannot overflow
     }
 
+    /// True when `seconds` falls inside the anchor plausibility window (2020-01-01 .. 2035-01-01), i.e. the
+    /// `.timeSync` / `.rtcBeacon` ingest would accept it. A record whose epoch is outside this is silently
+    /// ignored so a garbage value can't anchor history to ~1970. Exposed READ-ONLY so OuraLiveSource can log
+    /// WHY an anchor was rejected (#91) without duplicating the bounds or reaching into anchor state. Pure.
+    public static func isPlausibleAnchorEpoch(_ seconds: Int64) -> Bool {
+        plausibleAnchorMs(fromEpochSeconds: seconds) != nil
+    }
+
     // MARK: - Record ingest (decode)
 
     /// Decode one parsed TLV inner record into zero or more events. A malformed/short record (or an

--- a/Packages/OuraProtocol/Tests/OuraProtocolTests/OuraDriverTests.swift
+++ b/Packages/OuraProtocol/Tests/OuraProtocolTests/OuraDriverTests.swift
@@ -67,6 +67,17 @@ final class OuraDriverTests: XCTestCase {
         XCTAssertEqual(d.phase, .needsKeyInstall)
     }
 
+    func testIsPlausibleAnchorEpochBounds() {
+        // The anchor plausibility window is [2020-01-01, 2035-01-01] UTC. OuraLiveSource reads this same
+        // predicate to log WHY an anchor was rejected (#91), so the boundaries are pinned here.
+        XCTAssertTrue(OuraDriver.isPlausibleAnchorEpoch(1_577_836_800))   // 2020-01-01, inclusive min
+        XCTAssertTrue(OuraDriver.isPlausibleAnchorEpoch(2_051_222_400))   // 2035-01-01, inclusive max
+        XCTAssertTrue(OuraDriver.isPlausibleAnchorEpoch(1_700_000_000))   // ~2023, mid-window
+        XCTAssertFalse(OuraDriver.isPlausibleAnchorEpoch(1_577_836_799))  // one second before min
+        XCTAssertFalse(OuraDriver.isPlausibleAnchorEpoch(2_051_222_401))  // one second past max
+        XCTAssertFalse(OuraDriver.isPlausibleAnchorEpoch(0))              // epoch 0 — the ~1970 anchor #91 must avoid
+    }
+
     func testFactoryResetStatusDrivesNeedsKeyInstall() {
         let d = OuraDriver(ringGen: .gen3, authKey: key)
         _ = d.nextStep(after: .ready)

--- a/Strand/BLE/OuraLiveSource.swift
+++ b/Strand/BLE/OuraLiveSource.swift
@@ -657,14 +657,31 @@ public final class OuraLiveSource: NSObject, ObservableObject {
                     pendingAnchorEvents.append((e, v.ringTimestamp))
                 }
 
-            case .timeSync:
-                if !loggedAnchor {
-                    loggedAnchor = true
-                    log("Oura: UTC time anchor acquired - history-fetched samples now get their real time")
+            case .timeSync(let ts):
+                // #91: a 0x42 whose epoch is outside the 2020–2035 plausibility window is silently ignored,
+                // so history samples stay unanchored (no sleep/daily). Log the rejection with the offending
+                // epoch; only announce "acquired" when the sync ACTUALLY anchored (the old unconditional
+                // "acquired" line fired even on a rejected sync). `epochMs` holds the raw wire value, which
+                // is unix SECONDS despite the name (s6.11).
+                if OuraDriver.isPlausibleAnchorEpoch(ts.epochMs) {
+                    if !loggedAnchor {
+                        loggedAnchor = true
+                        log("Oura: UTC time anchor acquired - history-fetched samples now get their real time")
+                    }
+                } else {
+                    log("Oura: 0x42 time-sync REJECTED - implausible epoch \(ts.epochMs)s (outside the 2020–2035 anchor window); history samples stay unanchored (#91)")
                 }
                 // The 0x42 time-sync can arrive ANYWHERE in a history-fetch stream, not necessarily first.
                 // Anything parked while unanchored gets its real time retroactively the moment an anchor lands.
                 drainPendingAnchorEvents()
+
+            case .rtcBeacon(let r):
+                // #91: the 0x85 beacon is the SECONDARY anchor (fills the gap only until a 0x42 arrives). A
+                // beacon ignored because a primary anchor already exists is NORMAL and not logged; only an
+                // IMPLAUSIBLE-epoch beacon is a real failure (it can never anchor), so log just that.
+                if !OuraDriver.isPlausibleAnchorEpoch(Int64(r.unixSeconds)) {
+                    log("Oura: 0x85 RTC beacon REJECTED - implausible epoch \(r.unixSeconds)s (outside the 2020–2035 anchor window) (#91)")
+                }
 
             case .tierB(let summary):
                 // INVESTIGATION ONLY (real_steps / activity-summary / sleep-summary / smoothed-SpO2,
@@ -688,7 +705,7 @@ public final class OuraLiveSource: NSObject, ObservableObject {
                 log("Oura: activity (Tier-B) state=\(info.state) met=\(info.met)")
 
             default:
-                break   // motion / state / rtcBeacon / debugText: not a durable Streams row (see OuraStreamMapping)
+                break   // motion / state / debugText: not a durable Streams row (see OuraStreamMapping)
             }
         }
     }

--- a/android/app/src/main/java/com/noop/ble/OuraLiveSource.kt
+++ b/android/app/src/main/java/com/noop/ble/OuraLiveSource.kt
@@ -1081,13 +1081,32 @@ class OuraLiveSource(
             is OuraEvent.Hrv -> enqueueAnchoredOrPark(e, e.value.ringTimestamp, d)
             is OuraEvent.SleepPhaseEvent -> enqueueAnchoredOrPark(e, e.value.ringTimestamp, d)
             is OuraEvent.TimeSyncEvent -> {
-                if (!loggedAnchor) {
-                    loggedAnchor = true
-                    log("Oura: UTC time anchor acquired - history-fetched samples now get their real time")
+                // #91: a 0x42 whose epoch is outside the 2020–2035 plausibility window is silently ignored,
+                // so history samples stay unanchored (no sleep/daily). Log the rejection with the offending
+                // epoch; only announce "acquired" when the sync ACTUALLY anchored (the old unconditional
+                // "acquired" line fired even on a rejected sync). `epochMs` holds the raw wire value, which
+                // is unix SECONDS despite the name (s6.11).
+                if (d.isPlausibleAnchorEpoch(e.value.epochMs)) {
+                    if (!loggedAnchor) {
+                        loggedAnchor = true
+                        log("Oura: UTC time anchor acquired - history-fetched samples now get their real time")
+                    }
+                } else {
+                    log("Oura: 0x42 time-sync REJECTED - implausible epoch ${e.value.epochMs}s (outside the " +
+                        "2020–2035 anchor window); history samples stay unanchored (#91)")
                 }
                 // The 0x42 time-sync can arrive ANYWHERE in a history-fetch stream, not necessarily first.
                 // Anything parked while unanchored gets its real time retroactively the moment it lands.
                 drainPendingAnchorEvents()
+            }
+            is OuraEvent.RtcBeaconEvent -> {
+                // #91: the 0x85 beacon is the SECONDARY anchor (fills the gap only until a 0x42 arrives). A
+                // beacon ignored because a primary anchor already exists is NORMAL and not logged; only an
+                // IMPLAUSIBLE-epoch beacon is a real failure (it can never anchor), so log just that.
+                if (!d.isPlausibleAnchorEpoch(e.value.unixSeconds)) {
+                    log("Oura: 0x85 RTC beacon REJECTED - implausible epoch ${e.value.unixSeconds}s (outside " +
+                        "the 2020–2035 anchor window) (#91)")
+                }
             }
             is OuraEvent.TierB -> {
                 // INVESTIGATION ONLY (real_steps / activity-summary / sleep-summary / smoothed-SpO2,

--- a/android/app/src/main/java/com/noop/oura/OuraDriver.kt
+++ b/android/app/src/main/java/com/noop/oura/OuraDriver.kt
@@ -330,6 +330,14 @@ class OuraDriver(
         return epochSeconds * 1000   // safe: bounded input, cannot overflow
     }
 
+    /**
+     * True when [epochSeconds] falls inside the anchor plausibility window (2020-01-01 .. 2035-01-01), i.e.
+     * `setAnchorIfPlausible` would accept it. A 0x42/0x85 whose epoch is outside this is silently ignored so
+     * a garbage value can't anchor history to ~1970. Exposed READ-ONLY so OuraLiveSource can log WHY an
+     * anchor was rejected (#91) without duplicating the bounds or reaching into anchor state. Pure.
+     */
+    fun isPlausibleAnchorEpoch(epochSeconds: Long): Boolean = plausibleAnchorMs(epochSeconds) != null
+
     // MARK: - Record ingest (decode)
 
     /**

--- a/android/app/src/test/java/com/noop/oura/OuraDriverTest.kt
+++ b/android/app/src/test/java/com/noop/oura/OuraDriverTest.kt
@@ -2,6 +2,7 @@ package com.noop.oura
 
 import org.junit.Assert.assertArrayEquals
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
@@ -21,6 +22,20 @@ class OuraDriverTest {
     private val rt: Long = 0x0001_0002
 
     private fun bytes(s: String) = OuraTestHex.bytes(s)
+
+    @Test
+    fun testIsPlausibleAnchorEpochBounds() {
+        // The anchor plausibility window is [2020-01-01, 2035-01-01] UTC. OuraLiveSource reads this same
+        // predicate to log WHY an anchor was rejected (#91), so the boundaries are pinned here. Twin of the
+        // Swift OuraDriverTests.testIsPlausibleAnchorEpochBounds.
+        val d = OuraDriver(ringGen = OuraRingGen.GEN3, authKey = key)
+        assertTrue(d.isPlausibleAnchorEpoch(1_577_836_800L))    // 2020-01-01, inclusive min
+        assertTrue(d.isPlausibleAnchorEpoch(2_051_222_400L))    // 2035-01-01, inclusive max
+        assertTrue(d.isPlausibleAnchorEpoch(1_700_000_000L))    // ~2023, mid-window
+        assertFalse(d.isPlausibleAnchorEpoch(1_577_836_799L))   // one second before min
+        assertFalse(d.isPlausibleAnchorEpoch(2_051_222_401L))   // one second past max
+        assertFalse(d.isPlausibleAnchorEpoch(0L))               // epoch 0 — the ~1970 anchor #91 must avoid
+    }
 
     // MARK: - Full happy-path step sequence (auth -> enable triplet -> streaming)
 


### PR DESCRIPTION
Cross-platform diagnostic observability for **#91** (Oura anchor never lands → history samples stay unanchored → no sleep/daily data). Reimplements the intent of **#96** correctly, and supersedes it.

## Approach
Each driver exposes a pure, read-only `isPlausibleAnchorEpoch(epoch)` — the same 2020–2035 window the `.timeSync`/`.rtcBeacon` ingest already gates on. `OuraLiveSource`, on receiving a 0x42/0x85 event, uses it to log the **precise** rejection:
- **0x42 time-sync** with an implausible epoch → log the offending epoch value.
- **0x85 RTC beacon** with an implausible epoch → log it. A beacon merely ignored because a primary anchor already exists is **normal** and deliberately **not** logged (no noise).

It also fixes a **latent bug**: the "UTC time anchor acquired" line fired on the first time-sync *unconditionally* — even when that sync was rejected as implausible. It now announces "acquired" only when the sync actually anchored.

## Why not #96's implementation
#96 does **not compile** — it logs off a `d.hasAnchor` property that doesn't exist anywhere in the tree (its own PR body claims to add it, but the commit doesn't). Beyond that: it added a `Boolean` return to `setAnchorIfPlausible` that's **never used** (dead code + unused-variable warnings), de-privatised the method for no caller, and its messages were wrong (the 0x85 "primary already set" branch can never fire via `!hasAnchor`; the 0x42 epoch was divided by 1000). Reading the driver's own predicate compiles, uses the real signal, and logs the right reason with the right value.

## Files & verification
Drivers (`OuraDriver.swift` / `OuraDriver.kt`): the predicate. Sources (`OuraLiveSource.swift` / `.kt`): the logging. Plus a pinned-boundary unit test on **both** platforms (Swift + Kotlin twins).

- **Android:** `:app:compileFullDebugKotlin` + `OuraDriverTest` pass locally.
- **iOS:** the `OuraProtocol` package **builds + all 33 `OuraDriverTests` pass** on WSL (pure Swift, no SQLite wall), so the driver predicate + test are verified. The `OuraLiveSource.swift` log wiring is self-reviewed and rides the next iOS build (app target can't compile on WSL).