### PR TITLE
Android import: bound peak RAM with a per-import total-byte budget (#70 parity)

### DIFF
--- a/android/app/src/main/java/com/noop/ingest/WearableExportImporter.kt
+++ b/android/app/src/main/java/com/noop/ingest/WearableExportImporter.kt
@@ -58,6 +58,13 @@ object WearableExportImporter {
 
     private const val MAX_ENTRY_BYTES = 256L shl 20  // per-entry uncompressed ceiling (zip-bomb guard)
     private const val MAX_FILES = 200_000
+
+    /** Aggregate RAM ceiling across ALL retained wellness files from one import. The real backstop here: a
+     *  zip can carry up to [MAX_FILES] (200k) entries, and the per-entry cap bounds each one but NOT their
+     *  sum — without this a crafted export could accumulate unbounded ByteArray in the map. A whole
+     *  multi-year export is tens of MB, so 1 GB never trips in practice. Mirrors the Swift
+     *  WearableExportImporter.maxTotalBytes (#70). */
+    internal const val MAX_TOTAL_BYTES = 1L shl 30
     private const val MAX_ROWS = 5_000_000
 
     // Oura CSV detection (#857). Header keys are already HeaderNorm-normalized.
@@ -100,7 +107,7 @@ object WearableExportImporter {
     // ------------------------------------------------------------------------
 
     suspend fun importExport(context: Context, uri: Uri, repo: WhoopRepository): ImportSummary {
-        val files = try {
+        val (files, truncated) = try {
             collectFiles(context, uri)
         } catch (e: Exception) {
             return ImportSummary.failure("Wearable export", "Couldn't read the export: ${e.message ?: "unknown error"}")
@@ -128,7 +135,14 @@ object WearableExportImporter {
             }
             return ImportSummary.failure(brand.label, "${brand.label} export held no sleep or daily wellness data.")
         }
-        return persist(repo, brand, parsed)
+        val summary = persist(repo, brand, parsed)
+        // #70: never silently truncate. If the aggregate RAM budget tripped, the retained file set was
+        // partial — surface it plainly rather than reporting a clean import over incomplete data.
+        return if (truncated) {
+            summary.copy(message = summary.message + " (partial — export exceeded the ${MAX_TOTAL_BYTES shr 30} GB import memory budget)")
+        } else {
+            summary
+        }
     }
 
     /** True when every collected file is a raw heart-rate CSV (no daily-summary file): the #857 case. */
@@ -711,7 +725,7 @@ object WearableExportImporter {
     // ------------------------------------------------------------------------
 
     /** Read the picked content. A `.zip` is extracted (zip-bomb-guarded); anything else is one entry. */
-    private fun collectFiles(context: Context, uri: Uri): Map<String, ByteArray> {
+    private fun collectFiles(context: Context, uri: Uri): Pair<Map<String, ByteArray>, Boolean> {
         val head = ByteArray(4)
         context.contentResolver.openInputStream(uri)?.use { it.read(head) }
             ?: throw IllegalStateException("Couldn't open the selected file.")
@@ -721,25 +735,46 @@ object WearableExportImporter {
             val bytes = context.contentResolver.openInputStream(uri)?.use { readCapped(it, MAX_ENTRY_BYTES) }
                 ?: throw IllegalStateException("Couldn't open the selected file.")
             val name = displayName(context, uri)?.lowercase() ?: "export.json"
-            return if (isWellnessFile(name, bytes)) mapOf(name to bytes) else emptyMap()
+            // A single file is one entry — the aggregate budget can't trip here.
+            return (if (isWellnessFile(name, bytes)) mapOf(name to bytes) else emptyMap()) to false
         }
 
+        val raw = context.contentResolver.openInputStream(uri)
+            ?: throw IllegalStateException("Couldn't open the selected file.")
+        return raw.use { collectZipEntries(it, MAX_TOTAL_BYTES) }
+    }
+
+    /** The zip-entry collection loop, extracted so a unit test can drive it from an in-memory zip without a
+     *  ContentResolver (the same seam pattern as [AppleHealthImporter.parseStreamForTest]). Retains wellness
+     *  JSON/CSV first-wins, per-entry + per-count capped, and STOPS once the next retained entry would push
+     *  past [maxTotalBytes] — returning `truncated = true` so the caller can say so instead of silently
+     *  importing a partial set. ZipInputStream yields entries in archive order, so it's deterministic. (#70) */
+    internal fun collectZipEntries(
+        input: InputStream,
+        maxTotalBytes: Long = MAX_TOTAL_BYTES,
+    ): Pair<Map<String, ByteArray>, Boolean> {
         val out = LinkedHashMap<String, ByteArray>()
-        context.contentResolver.openInputStream(uri)?.use { raw ->
-            ZipInputStream(raw).use { zin ->
-                var entry = zin.nextEntry
-                while (entry != null && out.size < MAX_FILES) {
-                    val path = entry.name.lowercase()
-                    val base = last(path)
-                    if (!entry.isDirectory && (base.endsWith(".json") || base.endsWith(".csv"))) {
-                        val bytes = runCatching { readCapped(zin, MAX_ENTRY_BYTES) }.getOrNull()
-                        if (bytes != null && bytes.isNotEmpty() && isWellnessFile(base, bytes)) out[path] = bytes
+        var total = 0L
+        var truncated = false
+        ZipInputStream(input).use { zin ->
+            var entry = zin.nextEntry
+            while (entry != null && out.size < MAX_FILES) {
+                val path = entry.name.lowercase()
+                val base = last(path)
+                if (!entry.isDirectory && (base.endsWith(".json") || base.endsWith(".csv"))) {
+                    val bytes = runCatching { readCapped(zin, MAX_ENTRY_BYTES) }.getOrNull()
+                    // First-wins dedup (was last-wins overwrite) so the running `total` matches the retained
+                    // bytes exactly; mirrors the Swift zip loader's `if result[path] == nil` guard.
+                    if (bytes != null && bytes.isNotEmpty() && isWellnessFile(base, bytes) && !out.containsKey(path)) {
+                        if (total + bytes.size > maxTotalBytes) { truncated = true; break }
+                        out[path] = bytes
+                        total += bytes.size
                     }
-                    entry = zin.nextEntry
                 }
+                entry = zin.nextEntry
             }
         }
-        return out
+        return out to truncated
     }
 
     /** True if the file is a wellness JSON/CSV we care about (filters out a brand's non-wellness bulk). */

--- a/android/app/src/main/java/com/noop/ingest/WhoopCsvImporter.kt
+++ b/android/app/src/main/java/com/noop/ingest/WhoopCsvImporter.kt
@@ -53,6 +53,12 @@ object WhoopCsvImporter {
     /** Per-CSV uncompressed ceiling (zip-bomb guard). Mirrors Swift maxEntryBytes = 256 MB. */
     private const val MAX_ENTRY_BYTES = 256L shl 20
 
+    /** Aggregate RAM ceiling across ALL retained CSVs from one import. The per-entry cap bounds a single
+     *  file but NOT the sum of the retained set — this backstops a crafted export from accumulating
+     *  unbounded ByteArray in the map before parsing. A real WHOOP bundle is a few MB, so 1 GB never trips
+     *  in practice. Mirrors the Swift WhoopExportImporter.maxTotalBytes (#70). */
+    internal const val MAX_TOTAL_BYTES = 1L shl 30
+
     /**
      * Charge/Effort/Rest redesign (2026-06-12): WHOOP "Day Strain" is on WHOOP's 0–21 scale, but
      * NOOP's "Effort" score lives on 0–100 (StrainScorer.maxStrain = 100). Rescale an imported Day
@@ -78,7 +84,7 @@ object WhoopCsvImporter {
         repo: WhoopRepository,
         deviceId: String = WHOOP_DEVICE,
     ): ImportSummary {
-        val csvData: Map<String, ByteArray> = try {
+        val (csvData, truncated) = try {
             loadCsvData(context, uri)
         } catch (e: Exception) {
             return ImportSummary.failure(SOURCE_LABEL, "Could not read export: ${e.message ?: "unknown error"}")
@@ -138,6 +144,9 @@ object WhoopCsvImporter {
             append(" WHOOP rows")
             if (firstDay != null && lastDay != null) append(" ($firstDay → $lastDay)")
             append(".")
+            // #70: never silently truncate. If the aggregate RAM budget tripped, the retained CSV set was
+            // partial — say so plainly instead of reporting a clean import over incomplete data.
+            if (truncated) append(" (partial — export exceeded the ${MAX_TOTAL_BYTES shr 30} GB import memory budget)")
         }
 
         return ImportSummary(
@@ -156,9 +165,15 @@ object WhoopCsvImporter {
      * Accepts a `.zip` (iterated with [ZipInputStream], routed by base filename) or a single
      * `.csv`. Mirrors Swift `loadCSVData` filename routing.
      */
-    private fun loadCsvData(context: Context, uri: Uri): Map<String, ByteArray> {
+    private fun loadCsvData(
+        context: Context,
+        uri: Uri,
+        maxTotalBytes: Long = MAX_TOTAL_BYTES,
+    ): Pair<Map<String, ByteArray>, Boolean> {
         val wanted = setOf(CYCLES_NAME, SLEEPS_NAME, WORKOUTS_NAME, JOURNAL_NAME)
         val result = LinkedHashMap<String, ByteArray>()
+        var total = 0L
+        var truncated = false
 
         // First attempt: treat as a zip. WHOOP exports are zips; this also covers a .zip Uri
         // whose displayName we cannot read. If the stream is not a valid zip, ZipInputStream
@@ -187,7 +202,9 @@ object WhoopCsvImporter {
                                             else -> localizedAlias(base) ?: sniffCsvKind(bytes)
                                         }
                                         if (canonical != null && !result.containsKey(canonical)) {
+                                            if (total + bytes.size > maxTotalBytes) { truncated = true; break }
                                             result[canonical] = bytes
+                                            total += bytes.size
                                         }
                                     }
                                 }
@@ -198,7 +215,7 @@ object WhoopCsvImporter {
                     }
                 }
             }
-            if (result.isNotEmpty()) return result
+            if (result.isNotEmpty()) return result to truncated
         }
 
         // Not a (useful) zip — treat the input as a single CSV. Route by display name; if the
@@ -212,7 +229,7 @@ object WhoopCsvImporter {
         if (routed != null) {
             result[routed] = firstBytes
         }
-        return result
+        return result to false   // single-CSV path holds one file — the budget can't trip here
     }
 
     /** Whether the leading bytes are a local-file-header zip signature ("PK"). */

--- a/android/app/src/test/java/com/noop/ingest/ImportByteBudgetTest.kt
+++ b/android/app/src/test/java/com/noop/ingest/ImportByteBudgetTest.kt
@@ -1,0 +1,87 @@
+package com.noop.ingest
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import java.util.zip.ZipEntry
+import java.util.zip.ZipOutputStream
+
+/**
+ * Pins the Android aggregate-RAM budget for the export importers (#70 parity). Each importer collected
+ * every recognised entry into an in-memory `Map<String, ByteArray>` guarded only by a per-entry cap
+ * (256 MB) and, for Wearable, a per-COUNT cap (200k) — nothing bounded the SUM of the retained set. The
+ * new `maxTotalBytes` budget stops collection once the next retained entry would exceed it, and reports
+ * `truncated` so the import summary can say the set was partial instead of reporting a clean import.
+ *
+ * Drives the extracted [WearableExportImporter.collectZipEntries] seam from an in-memory zip, so no
+ * Context / ContentResolver is needed (the same seam pattern as AppleHealthImporterToleranceTest).
+ * ZipInputStream yields entries in archive order, so which entries survive is deterministic.
+ */
+class ImportByteBudgetTest {
+
+    private fun zipOf(entries: List<Pair<String, ByteArray>>): ByteArray {
+        val bos = ByteArrayOutputStream()
+        ZipOutputStream(bos).use { zos ->
+            for ((name, data) in entries) {
+                zos.putNextEntry(ZipEntry(name))
+                zos.write(data)
+                zos.closeEntry()
+            }
+        }
+        return bos.toByteArray()
+    }
+
+    private fun bytes(n: Int, fill: Char) = ByteArray(n) { fill.code.toByte() }
+
+    @Test
+    fun uncappedRetainsAllWellnessEntries() {
+        val zip = zipOf(listOf("sleep.json" to bytes(1000, 'a'), "heart.json" to bytes(1000, 'b')))
+        val (files, truncated) = WearableExportImporter.collectZipEntries(
+            ByteArrayInputStream(zip), maxTotalBytes = 1L shl 30,
+        )
+        assertEquals(2, files.size)
+        assertFalse("a real-size export never trips the 1 GB budget", truncated)
+    }
+
+    @Test
+    fun budgetStopsAtSumAndReportsTruncated() {
+        val zip = zipOf(listOf("sleep.json" to bytes(1000, 'a'), "heart.json" to bytes(1000, 'b')))
+        // Cap over the first entry (1000) but under the sum (2000): the first is kept, the second trips it.
+        val (files, truncated) = WearableExportImporter.collectZipEntries(
+            ByteArrayInputStream(zip), maxTotalBytes = 1500L,
+        )
+        assertEquals(1, files.size)
+        assertTrue("archive-order first entry survives", files.containsKey("sleep.json"))
+        assertTrue("budget trip must be reported, not silent", truncated)
+    }
+
+    @Test
+    fun retainedBytesNeverExceedBudget() {
+        val zip = zipOf((0 until 10).map { "sleep$it.json" to bytes(1000, 'x') })
+        val (files, truncated) = WearableExportImporter.collectZipEntries(
+            ByteArrayInputStream(zip), maxTotalBytes = 1500L,
+        )
+        assertTrue(truncated)
+        val retained = files.values.sumOf { it.size.toLong() }
+        assertTrue("retained bytes ($retained) must stay within the budget", retained <= 1500L)
+    }
+
+    @Test
+    fun nonWellnessEntriesAreSkippedAndDoNotCountAgainstBudget() {
+        // A junk file between two wellness files: it isn't retained, so it neither trips the budget nor
+        // consumes it — both wellness files survive under a budget sized for exactly the two of them.
+        val zip = zipOf(listOf(
+            "sleep.json" to bytes(1000, 'a'),
+            "photos.png" to bytes(5000, 'z'),   // not wellness, not .json/.csv → skipped entirely
+            "steps.csv" to bytes(1000, 'b'),
+        ))
+        val (files, truncated) = WearableExportImporter.collectZipEntries(
+            ByteArrayInputStream(zip), maxTotalBytes = 2500L,
+        )
+        assertEquals(2, files.size)
+        assertFalse(truncated)
+    }
+}


### PR DESCRIPTION
Android twin of the iOS `StrandImport` change in **#70** — the two importers are deliberate ports of each other, and both had the same gap.

## Problem (same as #70, on Android)
`WhoopCsvImporter` and `WearableExportImporter` each collect every recognised entry into an in-memory `Map<String, ByteArray>` guarded only by a **per-entry** cap (256 MB) and, for Wearable, a **per-count** cap (200k). Nothing bounded the **sum** of the retained set — a large or crafted export (Wearable can carry up to 200k entries) could accumulate unbounded `ByteArray` in RAM before parsing.

## Change
Add an aggregate **`MAX_TOTAL_BYTES` (1 GB)** enforced in both importers' zip loaders: once adding the next retained entry would push the running total past the budget, collection stops. Real exports (a few MB Whoop, tens of MB Wearable) never approach it → behavior-preserving. Matches the Swift `maxTotalBytes`.

## Improvement over #70: **not silent**
#70 (like the pre-existing `MAX_FILES` cap) stops with a bare `break`. Here the loaders return a `truncated` flag and the `ImportSummary` message says **"(partial — export exceeded the 1 GB import memory budget)"** when it trips — so a truncated import is diagnosable instead of reading as a clean import over incomplete data. (This is the log-on-trip nicety noted in the #70 review.)

Also: the Wearable zip loader now dedups **first-wins** (was last-wins overwrite), which keeps the running total exact and matches the Swift zip loader's guard.

## Testability + verification
Extracted `WearableExportImporter.collectZipEntries` as an `InputStream` seam (same pattern as `AppleHealthImporter.parseStreamForTest`), so a JVM unit test drives the budget from an in-memory zip — no `ContentResolver`. **Verified locally:** `:app:compileFullDebugKotlin` + the new `ImportByteBudgetTest` (4 cases) + the full `com.noop.ingest` package all pass — so unlike the iOS side (blocked by the CSQLite wall on WSL), this half is actually test-proven here.

Pairs with #70 (iOS); merge either order.