### PR TITLE
Today (liquid): restore the 'workout in progress' card (#105)

### DIFF
--- a/Strand/Liquid/LiquidTodayView.swift
+++ b/Strand/Liquid/LiquidTodayView.swift
@@ -200,6 +200,11 @@ struct LiquidTodayView: View {
 
                 VStack(alignment: .leading, spacing: 12) {
                     scene
+                    // #105: the live "workout in progress" card, dropped in the liquid Home rewrite. Restored
+                    // here as the SAME leaf the classic TodayView renders (and Android's WorkoutInProgressCard),
+                    // sitting right under the hero so an active manual workout is immediately visible and taps
+                    // straight through to Live. Renders nothing when no workout is active.
+                    ActiveWorkoutIndicatorSection()
                     heartRateSection
                     yourCardsSection
                     synthesisSection

--- a/Strand/Screens/TodayView.swift
+++ b/Strand/Screens/TodayView.swift
@@ -148,7 +148,12 @@ private struct ActiveWorkoutIndicatorCard: View {
 /// rewritten `activeWorkout`) re-renders ONLY this card, never the whole Today dashboard, the same
 /// leaf-isolation pattern the file documents for the live status/sync rows. Renders nothing when no workout
 /// is active, so the card auto-appears/clears purely off `AppModel.activeWorkout`.
-private struct ActiveWorkoutIndicatorSection: View {
+///
+/// Non-private so the liquid Home (`LiquidTodayView`) renders the SAME leaf — the liquid rewrite dropped this
+/// indicator (#105), and sharing one implementation keeps the two Today screens (and Android's
+/// `WorkoutInProgressCard`) from drifting. It carries its own `app`/`router` environment objects, so a caller
+/// only needs to place `ActiveWorkoutIndicatorSection()` in its body.
+struct ActiveWorkoutIndicatorSection: View {
     @EnvironmentObject var app: AppModel
     @EnvironmentObject var router: NavRouter
 


### PR DESCRIPTION
Fixes #105 — after the Liquid Design Home rewrite, starting a workout no longer showed an active-workout card on Home.

## Root cause
`LiquidTodayView` (Liquid Home, `liquidTodayEnabled` defaults true → shipping since v8.4.0) never referenced `AppModel.activeWorkout`. The classic `TodayView` renders an `ActiveWorkoutIndicatorSection` off it; the liquid rewrite ported the hero/tiles but dropped that indicator. Android's liquid `TodayScreen` **kept** it (`WorkoutInProgressCard`), so this was an **iOS-only regression + iOS↔Android parity gap**.

## Fix
Render the **same leaf** the classic `TodayView` uses: promote `ActiveWorkoutIndicatorSection` from `private` to internal and place it in `LiquidTodayView` right under the hero. It:
- carries its own `app`/`router` environment objects (injected at `StrandApp` root),
- is **leaf-isolated** — the per-second elapsed clock re-renders only the card, not the whole dashboard,
- renders nothing when no workout is active (auto-appears/clears off `AppModel.activeWorkout`),
- taps through to `router.openActiveWorkout()`.

Sharing one implementation keeps the two iOS Today screens (and Android's card) from drifting again.

## Notes
- **Not a strap issue:** `activeWorkout` is a *user-started manual workout*, so the reporter's 5.0/MG correction is irrelevant — purely a missing view in the liquid rewrite.
- **iOS/macOS only.** Can't compile Swift on WSL, so it rides the next build — but it reuses two existing, shipping implementations (classic `TodayView` + Android), and I verified the one runtime risk: `AppModel`/`NavRouter` are injected at the `StrandApp` root, above both Today views, so the section's `@EnvironmentObject`s resolve.

Closes #105.