### PR TITLE
Sleep: memoize SleepConsistencyCard per-night fold (perf)

### DIFF
--- a/android/app/src/main/java/com/noop/ui/SleepScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/SleepScreen.kt
@@ -3280,6 +3280,9 @@ private fun LegendDot(label: String, color: Color) {
 
 // MARK: - Sleep Consistency card
 
+/** One night's bed/wake fold for [SleepConsistencyCard], memoized off `sleeps` (#perf). */
+private data class SleepNightTiming(val label: String, val bedHour: Float, val wakeHour: Float)
+
 /**
  * Sleep-consistency chart: for the trailing 14 sessions, draws each night's bed→wake window
  * as a vertical bar against a time-of-day axis, with dashed overlays at the typical bed and
@@ -3288,20 +3291,23 @@ private fun LegendDot(label: String, color: Color) {
  */
 @Composable
 internal fun SleepConsistencyCard(sleeps: List<SleepSession>) {
-    val recent = sleeps.takeLast(14)
-    if (recent.size < 3) return
-
-    data class NightTiming(val label: String, val bedHour: Float, val wakeHour: Float)
-    val sdf = SimpleDateFormat("EEE", Locale.US)
-    val timings = recent.map { s ->
-        val bedCal = Calendar.getInstance().apply { timeInMillis = s.effectiveStartTs * 1000L } // edited bedtime (PR #395)
-        val wakeCal = Calendar.getInstance().apply { timeInMillis = s.endTs * 1000L }
-        val bedH = bedCal.get(Calendar.HOUR_OF_DAY) + bedCal.get(Calendar.MINUTE) / 60f
-        // Fold an evening bedtime to a negative hour so it sorts ABOVE the next-day wake on the axis.
-        val bedNorm = if (bedH > 12f) bedH - 24f else bedH
-        val wakeH = wakeCal.get(Calendar.HOUR_OF_DAY) + wakeCal.get(Calendar.MINUTE) / 60f
-        NightTiming(sdf.format(Date(s.endTs * 1000L)), bedNorm, wakeH)
+    // #perf: building the per-night fold allocates 2 Calendars + a SimpleDateFormat per session (~28
+    // objects for 14 nights). It's a pure derivation of `sleeps` (no wall-clock input), so memoize it on
+    // `sleeps` — scrolling the Sleep screen then reuses it instead of rebuilding it every recompose frame.
+    val timings = remember(sleeps) {
+        val recent = sleeps.takeLast(14)
+        val sdf = SimpleDateFormat("EEE", Locale.US)
+        recent.map { s ->
+            val bedCal = Calendar.getInstance().apply { timeInMillis = s.effectiveStartTs * 1000L } // edited bedtime (PR #395)
+            val wakeCal = Calendar.getInstance().apply { timeInMillis = s.endTs * 1000L }
+            val bedH = bedCal.get(Calendar.HOUR_OF_DAY) + bedCal.get(Calendar.MINUTE) / 60f
+            // Fold an evening bedtime to a negative hour so it sorts ABOVE the next-day wake on the axis.
+            val bedNorm = if (bedH > 12f) bedH - 24f else bedH
+            val wakeH = wakeCal.get(Calendar.HOUR_OF_DAY) + wakeCal.get(Calendar.MINUTE) / 60f
+            SleepNightTiming(sdf.format(Date(s.endTs * 1000L)), bedNorm, wakeH)
+        }
     }
+    if (timings.size < 3) return
 
     fun sd(vals: List<Float>): Float {
         val m = vals.average().toFloat()
@@ -3437,7 +3443,7 @@ internal fun SleepConsistencyCard(sleeps: List<SleepSession>) {
                 listOf(
                     "Score" to "${consistencyPct.roundToInt()}%",
                     "Typical" to "${((bedSdH + wakeSdH) / 2f * 60f).roundToInt()} min SD",
-                    "Nights" to "${recent.size}",
+                    "Nights" to "${timings.size}",
                 ).forEach { (lbl, v) ->
                     Column(modifier = Modifier.weight(1f)) {
                         Overline(lbl, color = Palette.textTertiary)


### PR DESCRIPTION
Small Compose perf fix. `SleepConsistencyCard` rebuilt its per-night bed/wake fold **on every recompose** — `recent.map { … }` allocates 2 `Calendar`s + a `SimpleDateFormat` per session (~28 objects for 14 nights) plus the stat passes over them. Scrolling the Sleep screen re-ran the whole thing each frame.

It's a **pure derivation of `sleeps`** (no wall-clock input), so it's hoisted into `remember(sleeps)` — reused across recompositions, rebuilt only when the nights change. Behaviour is identical (same `timings`, same downstream stats/labels). `NightTiming` moved to a file-level `private data class` so the remembered lambda can return it.

Verified locally: `:app:compileFullDebugKotlin` passes (and the compile caught a genuine out-of-scope `recent.size` in the footer, now `timings.size` — same value, 1:1 map).

Part of a small perf pass; the iOS static-formatter half is a separate PR.