### PR TITLE
Perf: hoist per-render DateFormatters to static

### DIFF
--- a/Strand/Screens/HydrationView.swift
+++ b/Strand/Screens/HydrationView.swift
@@ -337,15 +337,24 @@ struct HydrationView: View {
 
     /// The single-letter weekday for a yyyy-MM-dd key (M T W T F S S), or "·" when unparseable. Mirrors
     /// the Android `weekdayInitial` (EEE → first letter, US locale).
+    // #perf: fixed-locale formatters, hoisted to static so the history-bar ForEach doesn't allocate two
+    // DateFormatters per bar per render (label + a11y both call this). Locale is pinned (en_US_POSIX /
+    // en_US), so caching is behaviour-identical — no dependence on the device locale.
+    private static let dayKeyParser: DateFormatter = {
+        let f = DateFormatter()
+        f.locale = Locale(identifier: "en_US_POSIX")
+        f.dateFormat = "yyyy-MM-dd"
+        return f
+    }()
+    private static let weekdayAbbrev: DateFormatter = {
+        let f = DateFormatter()
+        f.locale = Locale(identifier: "en_US")
+        f.dateFormat = "EEE"
+        return f
+    }()
     private func weekdayInitial(_ dayKey: String) -> String {
-        let parse = DateFormatter()
-        parse.locale = Locale(identifier: "en_US_POSIX")
-        parse.dateFormat = "yyyy-MM-dd"
-        guard let date = parse.date(from: dayKey) else { return "·" }
-        let out = DateFormatter()
-        out.locale = Locale(identifier: "en_US")
-        out.dateFormat = "EEE"
-        return String(out.string(from: date).prefix(1))
+        guard let date = Self.dayKeyParser.date(from: dayKey) else { return "·" }
+        return String(Self.weekdayAbbrev.string(from: date).prefix(1))
     }
 
     /// Log `ml` (additive day total + a per-entry row, #798) and refresh.

--- a/Strand/Screens/TodayView.swift
+++ b/Strand/Screens/TodayView.swift
@@ -4016,15 +4016,20 @@ struct TodayView: View {
         }
     }
 
-    private var dateLine: String {
+    // #perf: fixed-locale (en_US_POSIX), hoisted to static so the ~1 Hz Today body doesn't allocate a
+    // DateFormatter every render. Behaviour-identical — the format + locale are pinned.
+    private static let dateLineFmt: DateFormatter = {
         let f = DateFormatter()
         f.locale = Locale(identifier: "en_US_POSIX")
         f.dateFormat = "EEEE, d MMMM"
+        return f
+    }()
+    private var dateLine: String {
         // The selected day's date when navigated; today's banked-row date (or today) at offset 0.
         if selectedDayOffset == 0, let day = repo.today?.day, let date = Self.dayParser.date(from: day) {
-            return f.string(from: date)
+            return Self.dateLineFmt.string(from: date)
         }
-        return f.string(from: selectedLogicalDay)
+        return Self.dateLineFmt.string(from: selectedLogicalDay)
     }
 
     /// Hero title that names the selected day, "Today's"/"Yesterday's"/"Day's" Synthesis.
@@ -4162,12 +4167,17 @@ struct TodayView: View {
 
     /// "d MMM · HH:mm–HH:mm", start-only when the row has no real end (#157). The "· N bpm"
     /// segment was dropped: the StatTile caption is lineLimit(1) and date + range + bpm clips,     /// avg HR remains on the Workouts screen.
-    private func workoutCaption(_ w: WorkoutRow) -> String {
+    // #perf: fixed-locale (en_US_POSIX), hoisted to static so a workout list doesn't allocate a
+    // DateFormatter per row per render. Behaviour-identical — format + locale pinned. (mirrors `hrTimeFmt`)
+    private static let workoutDateFmt: DateFormatter = {
         let f = DateFormatter()
         f.locale = Locale(identifier: "en_US_POSIX")
         f.dateFormat = "d MMM"
+        return f
+    }()
+    private func workoutCaption(_ w: WorkoutRow) -> String {
         let start = Date(timeIntervalSince1970: TimeInterval(w.startTs))
-        let date = f.string(from: start)
+        let date = Self.workoutDateFmt.string(from: start)
         guard w.endTs > w.startTs else { return "\(date) · \(Self.hrTimeFmt.string(from: start))" }
         let end = Date(timeIntervalSince1970: TimeInterval(w.endTs))
         return "\(date) · \(Self.hrTimeFmt.string(from: start))-\(Self.hrTimeFmt.string(from: end))"


### PR DESCRIPTION
Small allocation-hygiene pass on hot paths (iOS/macOS). Every change is a **verbatim relocation** of existing config into a `static let` — no retyped format strings.

- **`HydrationView.weekdayInitial`** allocated **two** `DateFormatter`s per call, and it's called twice per history bar (label + a11y) inside a `ForEach` → ~4 formatter allocs × N bars every render. Both hoisted to static. (Highest volume.)
- **`TodayView.dateLine` + `workoutCaption`** allocated a `DateFormatter` each on the ~1 Hz Today body / per workout row. Hoisted to static (mirrors the existing `hrTimeFmt`).
- **`DayOwnerResolver.resolve`**: `filter{}.sorted{}.first` → `filter{}.min{}` — drops a full O(n log n) sort + throwaway array to grab one element; identical result.

## Scope decisions from the review
- **Only fixed-locale (`en_US_POSIX`/`en_US`) formatters are hoisted**, so caching is behaviour-identical. The **current-locale** `NumberFormatter`s (`intString`, `stepsText`) and the `Locale.current` `lastChargeDateFmt` are **left alone** — a static would freeze the device locale (stale grouping/format on a language change), not worth the tiny saving.
- Dropped the suggested `.filter{}.count → .count(where:)` nits: `count(where:)` is Swift 6.0+ and this package is `swift-tools-version:5.9`, so it wouldn't compile (and I can't verify iOS locally).

iOS/macOS only — can't compile Swift on WSL, so it rides the next build. Changes are in non-generic structs, no static-name collisions, references verified.

Pairs with the Android perf PR (#128 SleepConsistencyCard memoize).