### PR TITLE
Test Centre: capture check accepts computed-sleep evidence (#127)

### DIFF
--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/CaptureCompleteness.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/CaptureCompleteness.swift
@@ -58,7 +58,12 @@ public enum CaptureCompleteness {
     /// found no raw counter STILL emits an honest "noRawCounter"-style line and that counts as a real
     /// trace (the mode worked; the strap just had nothing), not an INCOMPLETE.
     public static let tokens: [TestDomain: [String]] = [
-        .sleep:      ["gate run=", "sleepProvenance"],
+        // `sleep day=` (#127): the always-on per-day provenance line (from the diagnostic sink, not the
+        // SLEEP-gated gate/provenance traces). A night scored on the backfill pass, or already scored so
+        // analyzeRecent skips the traced gate, still emits it and proves sleep was computed — so a valid
+        // capture is not flagged INCOMPLETE just because the deeper `gate run=`/`sleepProvenance` traces
+        // didn't re-fire. Same "the mode worked even if the strap had nothing" rule as `steps` below.
+        .sleep:      ["gate run=", "sleepProvenance", "sleep day="],
         .connection: ["clockDrift", "bondState"],
         .workouts:   ["autoDetect", "session event=", "detectedBout"],
         .display:    ["dataVolume", "frameSummary"],

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/CaptureCompletenessTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/CaptureCompletenessTests.swift
@@ -103,6 +103,28 @@ final class CaptureCompletenessTests: XCTestCase {
         XCTAssertEqual(CaptureCompleteness.reportSection([]), "")
     }
 
+    func testSleepOKFromComputedProvenanceLineWithoutGateTrace() {
+        // #127: `gate run=` / `sleepProvenance` only emit when the sleep-stager gate re-runs under the SLEEP
+        // trace sink; a night scored on the backfill/post-sync pass (or already scored) won't re-fire them.
+        // The always-on per-day `sleep day=` diagnostic still proves sleep was computed, so the capture must
+        // read OK rather than INCOMPLETE. This is the exact #127 report shape (no gate run=).
+        let report = """
+        [universal] dayOwner day=2026-07-09 readId=my-whoop writeActiveId=my-whoop hrRows=27001 provenance=measured
+        sleep day=2026-07-09 totalSleepMin=426 matched=1 source=computed
+        """
+        let checks = CaptureCompleteness.evaluate(activeDomains: [.sleep, .universal], reportText: report)
+        XCTAssertEqual(checks.first { $0.domain == "sleep" }?.status, .ok,
+                       "a computed-sleep capture is not INCOMPLETE even without the gate trace")
+        XCTAssertFalse(CaptureCompleteness.anyIncomplete(checks))
+    }
+
+    func testSleepStillIncompleteWithNoSleepDiagnosticAtAll() {
+        // The guard still fires when the capture carries NO sleep evidence of any kind.
+        let report = "[universal] dayOwner day=2026-07-09 readId=x writeActiveId=x hrRows=0 provenance=none"
+        let checks = CaptureCompleteness.evaluate(activeDomains: [.sleep, .universal], reportText: report)
+        XCTAssertEqual(checks.first { $0.domain == "sleep" }?.status, .incomplete)
+    }
+
     func testTokenMapMatchesEmitterTokensExactly() {
         // Guard against a silent emitter rename: each token must be the verbatim leading text the live
         // emitter writes. These literals mirror the *Trace files (verified at authoring time).

--- a/android/app/src/main/java/com/noop/testcentre/ReportCompleteness.kt
+++ b/android/app/src/main/java/com/noop/testcentre/ReportCompleteness.kt
@@ -54,13 +54,30 @@ object ReportCompleteness {
     fun checkedDomains(active: Set<TestDomain>): List<TestDomain> =
         killerTokens.keys.filter { it == TestDomain.UNIVERSAL || it in active }
 
-    /** Per-domain presence map for [reportText], over [checkedDomains]. A token is PRESENT iff its
-     *  substring occurs anywhere in the report text. Deterministic order (killerTokens order). */
+    /**
+     * Secondary EVIDENCE tokens: a domain also counts as PRESENT if one of these appears, for when its
+     * primary killer TRACE legitimately didn't re-emit in this capture (#127). SLEEP's `gate run=` only
+     * fires when the sleep-stager gate actually (re-)runs under the SLEEP-gated trace sink; a night scored
+     * on the backfill/post-sync pass, or already scored so `analyzeRecent(force=false)` skips the gate,
+     * won't re-emit it — yet the always-on per-day diagnostic line (`sleep day=… totalSleepMin=… source=…`)
+     * IS in the report and proves the sleep pipeline evaluated the day. Accepting it mirrors the Swift
+     * twin's multi-token `.sleep` and the same "the mode worked, even if the strap had nothing" rule the
+     * steps domain already uses, so a valid capture is no longer flagged INCOMPLETE for a trace that just
+     * didn't re-run. `gate run=` stays the preferred (deeper) trace; this only rescues the legit gap.
+     */
+    val evidenceTokens: Map<TestDomain, String> = linkedMapOf(
+        TestDomain.SLEEP to "sleep day=",
+    )
+
+    /** Per-domain presence map for [reportText], over [checkedDomains]. PRESENT iff the killer token OR the
+     *  domain's evidence token (if any, #127) occurs anywhere in the report. Deterministic order. */
     fun statuses(reportText: String, active: Set<TestDomain>): LinkedHashMap<TestDomain, Status> {
         val out = LinkedHashMap<TestDomain, Status>()
         for (d in checkedDomains(active)) {
             val token = killerTokens[d] ?: continue
-            out[d] = if (reportText.contains(token)) Status.PRESENT else Status.MISSING
+            val present = reportText.contains(token) ||
+                evidenceTokens[d]?.let { reportText.contains(it) } == true
+            out[d] = if (present) Status.PRESENT else Status.MISSING
         }
         return out
     }

--- a/android/app/src/test/java/com/noop/testcentre/ReportCompletenessParityTest.kt
+++ b/android/app/src/test/java/com/noop/testcentre/ReportCompletenessParityTest.kt
@@ -62,6 +62,31 @@ class ReportCompletenessParityTest {
         assertEquals(ReportCompleteness.Status.MISSING, s[TestDomain.CONNECTION])
     }
 
+    @Test fun sleepIsPresentFromComputedProvenanceLineWithoutGateRun() {
+        // #127: `gate run=` only re-emits when the sleep-stager gate re-runs under the SLEEP trace sink; a
+        // night scored on the backfill/post-sync pass (or already scored, so analyzeRecent(force=false)
+        // skips the gate) won't re-fire it. The always-on per-day provenance line still proves sleep was
+        // computed, so a valid capture must NOT read INCOMPLETE just because the deeper trace didn't re-run.
+        val report = buildString {
+            appendLine("dayOwner day=2026-07-09 readId=my-whoop writeActiveId=my-whoop hrRows=27001 provenance=measured")
+            appendLine("sleep day=2026-07-09 totalSleepMin=426 matched=1 source=computed")
+            // NOTE: no `gate run=` in this capture — exactly the #127 report.
+        }
+        val s = ReportCompleteness.statuses(report, active = setOf(TestDomain.SLEEP))
+        assertEquals(ReportCompleteness.Status.PRESENT, s[TestDomain.SLEEP])
+        val section = ReportCompleteness.captureCheckSection(report, active = setOf(TestDomain.SLEEP))
+        assertTrue("a computed-sleep capture must read complete, not INCOMPLETE",
+            section.endsWith("complete: all active traces present"))
+    }
+
+    @Test fun sleepStillMissingWhenNoSleepDiagnosticAtAll() {
+        // The guard still fires when the capture carries NO sleep evidence of any kind (neither the gate
+        // trace nor a per-day provenance line) — a genuinely thin report.
+        val report = "dayOwner day=2026-07-09 readId=x writeActiveId=x hrRows=0 provenance=none"
+        val s = ReportCompleteness.statuses(report, active = setOf(TestDomain.SLEEP))
+        assertEquals(ReportCompleteness.Status.MISSING, s[TestDomain.SLEEP])
+    }
+
     @Test fun captureCheckSectionExactText_complete() {
         val report = "x dayOwner day=D y\nz [sleep] gate run=1 KEPT gate=accepted w"
         val section = ReportCompleteness.captureCheckSection(report, active = setOf(TestDomain.SLEEP))


### PR DESCRIPTION
Fixes #127 — the "Sleep & Rest" capture check reported **`INCOMPLETE: missing sleep`** even though sleep was demonstrably computed (`sleep day=2026-07-09 totalSleepMin=426 … source=computed` in the reporter's own log).

## Root cause
The check only accepted the SLEEP **killer trace `gate run=`**, which the sleep-stager gate emits **only when it (re-)runs under the SLEEP-gated trace sink**. A night scored on the **backfill/post-sync pass**, or already scored so `analyzeRecent(force=false)` skips the gate, never re-fires it — so the deeper trace is legitimately absent even though sleep is correct. Meanwhile the always-on per-day diagnostic line `sleep day=… totalSleepMin=… source=…` (from the *diagnostic* sink, not the trace sink) **is** present and proves the pipeline evaluated the day.

## Fix
Accept **`sleep day=`** as a valid sleep trace on both platforms — the same *"the mode worked even if the strap had nothing"* rule the `steps` domain already uses. `gate run=` stays the preferred deeper trace; this only rescues the legitimate gap.
- **Android** `ReportCompleteness`: new `evidenceTokens` map (`SLEEP → "sleep day="`), OR'd into `statuses`. `killerTokens` unchanged → parity test still holds.
- **iOS** `CaptureCompleteness`: add `"sleep day="` to the multi-token `.sleep` list (iOS has the identical latent bug — both its tokens are trace-sink-gated).

## Will it fix the report? Yes.
The reporter's capture contains `sleep day=2026-07-09 totalSleepMin=426 …`, so SLEEP now reads **present** → the verdict flips from `INCOMPLETE: missing sleep` to `complete: all active traces present`.

## Verification
- **Android:** `compileFullDebugKotlin` + `ReportCompletenessParityTest` pass locally (new cases: computed-sleep-only report ⇒ present; no-sleep-diagnostic report ⇒ still MISSING).
- **iOS:** mirror change + 2 tests; rides CI (`StrandAnalytics` can't build on WSL — CSQLite wall). Verified no existing test breaks (the token-map pin doesn't assert `.sleep`'s list; `fullReport` has no `sleep day=` so `count == 2` still holds).

## Not covered (separate, informational)
`universal: MISSING (dayOwner day=)` remains — the backfill scoring pass (`WhoopBleClient`) doesn't wire `universalSink` the way `AppViewModel` does. It's **informational** (universal never triggers INCOMPLETE), so it doesn't affect this verdict; worth a small follow-up to wire it for parity.

Re-review note: the platforms' completeness guards have quietly **diverged** (Android single-token `ReportCompleteness` / `=== Capture check ===`; iOS multi-token `CaptureCompleteness` / `[OK]`), despite the "byte-identical twin" comment. Fixed each in its own idiom; flagging the drift.