### PR TITLE
Release v8.5.0: changelog + version bump

### DIFF
--- a/Strand/System/AppChangelog.swift
+++ b/Strand/System/AppChangelog.swift
@@ -7,7 +7,7 @@ enum AppChangelog {
 
     /// Bump this when you add a release below. The "What's New" sheet shows automatically when the
     /// stored last-seen version is behind this. (Decoupled from the bundle version on purpose.)
-    static let currentVersion = "8.4.0"
+    static let currentVersion = "8.5.0"
 
     struct Release: Identifiable {
         let version: String
@@ -19,6 +19,19 @@ enum AppChangelog {
 
     /// Newest first.
     static let releases: [Release] = [
+        Release(
+            version: "8.5.0",
+            title: "Raw SpO₂, honest units, and a lighter app",
+            date: "July 2026",
+            items: [
+                "**See your raw blood-oxygen signal (WHOOP 4.0).** The Health screen now surfaces the strap's raw red/IR SpO₂ sensor reading natively — honest, uncalibrated data, no export needed. It's not a clinical %, which needs WHOOP's own calibration.",
+                "**Skin temperature and Effort now respect your settings.** The Deep Timeline shows skin temp in °F when you've chosen Fahrenheit, and the Today \"Effort\" ring finally follows your 0–100 vs WHOOP 0–21 scale (with a decimal on the 21 scale).",
+                "**The \"workout in progress\" card is back on Home.** The Liquid redesign dropped it; an active manual workout is once again visible on the Home screen and taps straight through to Live.",
+                "**Apple Health steps count again.** Steps imported from an Apple Health export now reach your daily totals instead of quietly going missing.",
+                "**Steadier battery alerts and fresher widgets.** The low-battery alert no longer re-fires while you're charging, and the home-screen widget shows your current battery instead of a stale value.",
+                "**Lighter and faster.** A snappier Sleep screen, fewer per-frame allocations on Today, and export imports that can't balloon memory.",
+            ]
+        ),
         Release(
             version: "8.4.0",
             title: "Faster, and fewer sharp edges",

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -22,8 +22,8 @@ android {
         applicationId = "com.noop.whoop"
         minSdk = 26
         targetSdk = 34
-        versionCode = 267
-        versionName = "8.4.0"
+        versionCode = 268
+        versionName = "8.5.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {

--- a/android/app/src/main/java/com/noop/ui/AppChangelog.kt
+++ b/android/app/src/main/java/com/noop/ui/AppChangelog.kt
@@ -25,7 +25,7 @@ object AppChangelog {
      * Bump this when you add a release below. The "What's New" sheet shows automatically when the
      * stored last-seen version is behind this. (Decoupled from the bundle version on purpose.)
      */
-    const val CURRENT_VERSION = "8.4.0"
+    const val CURRENT_VERSION = "8.5.0"
 
     data class Release(
         val version: String,
@@ -36,6 +36,19 @@ object AppChangelog {
 
     /** Newest first. */
     val releases: List<Release> = listOf(
+        Release(
+            version = "8.5.0",
+            title = "Raw SpO₂, honest units, and a lighter app",
+            date = "July 2026",
+            items = listOf(
+                "**See your raw blood-oxygen signal (WHOOP 4.0).** The Health screen now surfaces the strap's raw red/IR SpO₂ sensor reading natively — honest, uncalibrated data, no export needed. It's not a clinical %, which needs WHOOP's own calibration.",
+                "**Skin temperature and Effort now respect your settings.** The Deep Timeline shows skin temp in °F when you've chosen Fahrenheit, and the Today \"Effort\" ring finally follows your 0–100 vs WHOOP 0–21 scale (with a decimal on the 21 scale).",
+                "**The \"workout in progress\" card is back on Home.** The Liquid redesign dropped it; an active manual workout is once again visible on the Home screen and taps straight through to Live.",
+                "**Apple Health steps count again.** Steps imported from an Apple Health export now reach your daily totals instead of quietly going missing.",
+                "**Steadier battery alerts and fresher widgets.** The low-battery alert no longer re-fires while you're charging, and the home-screen widget shows your current battery instead of a stale value.",
+                "**Lighter and faster.** A snappier Sleep screen, fewer per-frame allocations on Today, and export imports that can't balloon memory.",
+            ),
+        ),
         Release(
             version = "8.4.0",
             title = "Faster, and fewer sharp edges",

--- a/docs/releases/v8.5.0.md
+++ b/docs/releases/v8.5.0.md
@@ -1,0 +1,47 @@
+---
+whatsnew:
+  title: "Raw SpO₂, honest units, and a lighter app"
+  date: "July 2026"
+  items:
+    - "**See your raw blood-oxygen signal (WHOOP 4.0).** The Health screen now surfaces the strap's raw red/IR SpO₂ sensor reading natively — honest, uncalibrated data, no export needed. It's not a clinical %, which needs WHOOP's own calibration."
+    - "**Skin temperature and Effort now respect your settings.** The Deep Timeline shows skin temp in °F when you've chosen Fahrenheit, and the Today \"Effort\" ring finally follows your 0–100 vs WHOOP 0–21 scale (with a decimal on the 21 scale)."
+    - "**The \"workout in progress\" card is back on Home.** The Liquid redesign dropped it; an active manual workout is once again visible on the Home screen and taps straight through to Live."
+    - "**Apple Health steps count again.** Steps imported from an Apple Health export now reach your daily totals instead of quietly going missing."
+    - "**Steadier battery alerts and fresher widgets.** The low-battery alert no longer re-fires while you're charging, and the home-screen widget shows your current battery instead of a stale value."
+    - "**Lighter and faster.** A snappier Sleep screen, fewer per-frame allocations on Today, and export imports that can't balloon memory."
+---
+# NOOP v8.5.0
+
+A data-and-polish release: a new native raw-SpO₂ readout, unit/display fixes that make skin temperature and Effort honour your settings, the return of the live workout card, steadier battery behaviour, and a lighter, faster app. Update from the Releases page, AltStore, or `brew upgrade`.
+
+## Added
+
+- **Raw SpO₂ on the Health screen (WHOOP 4.0, #93).** The strap only streams the raw red/IR PPG optical channels — the calibrated blood-oxygen % is a WHOOP cloud computation NOOP can't reproduce. Rather than fake a number, NOOP now surfaces the nightly raw red/IR ADC means as an honest, explicitly *uncalibrated* "Raw SpO₂" reading. Both platforms.
+- **Fitness Age shows a countdown while it builds (#81).** Instead of an empty gauge, Fitness Age now says how many more nights of wear it needs before it can score you.
+
+## Fixed
+
+- **Skin temperature respects the Fahrenheit setting (#101).** The Deep Timeline hard-coded skin temp to °C — the line, axis, stats and readout ignored your unit preference. They now convert to °F when you've chosen it. Both platforms.
+- **The Today "Effort" ring follows your Effort scale (#45).** The hero gauge ignored the 0–100 vs WHOOP 0–21 setting and always showed 0–100. It now shows the scale you picked, with one decimal on the compressed 0–21 axis (matching WHOOP and the rest of the app).
+- **The "workout in progress" card is back on Home (#105).** The Liquid Home rewrite dropped the live indicator that appears while a manual workout is running. It's restored, auto-appears/clears with the workout, and taps through to the live view.
+- **Apple Health steps import into your daily totals (#89).** Imported steps were written everywhere except the daily-metric row the step display actually reads, so they never showed. Fixed on both platforms.
+- **Clearer "Overnight only" HRV wording (#92).** The setting now spells out that continuous background HRV capture (including daytime naps) is paused outside your quiet-hours window, and points you at the "Take an HRV reading" button on the Live screen for an on-demand daytime reading. Both platforms.
+- **Low-battery alert no longer re-fires while charging (#80).** Plugging in no longer re-triggers the low-battery notification.
+- **Battery estimate fixes (#99).** A low-state-of-charge cap and a corrected slope window keep the battery estimate honest near empty.
+- **Home-screen widget shows current battery (#114).** The widget could display a stale value; it now refreshes to the latest reading.
+- **Smaller display fixes.** The Motion metric is now labelled "g" (#102); skin-temp banding no longer misreads an absolute reading (#111); the steps empty-state reads correctly on WHOOP 5.0/MG (#107); Today hero labels no longer wrap (#78); and the Settings Appearance card has its row dividers back (#79).
+
+## Performance
+
+- **Export imports can't balloon memory (#70, #125).** The WHOOP and wearable-export importers were bounded per-entry but not on the *sum* of what they held in RAM. A large or crafted export could accumulate unbounded data before parsing; a per-import total-byte budget now caps peak memory, and a truncated import says so rather than silently dropping data. Both platforms.
+- **Snappier Sleep screen (#128).** The sleep-consistency chart rebuilt its per-night bed/wake fold on every frame; it's now memoized, so scrolling reuses it.
+- **Fewer per-render allocations on Today (#129).** Date formatters that were allocated on every ~1 Hz redraw are hoisted to shared, cached instances.
+
+## Diagnostics & honesty
+
+- **Oura ring: the log now says WHY a time anchor was rejected (#91).** When an Oura ring's UTC anchor won't land (so sleep/daily can't be timed), the strap log now names the reason — an implausible timestamp — instead of failing silently.
+- **Test Centre no longer cries "missing sleep" when sleep was computed (#127).** The Sleep & Rest capture check keyed only on a deep gate trace that legitimately doesn't re-emit when a night was already scored; it now also accepts the per-day computed-sleep line as proof, so a valid capture reads complete. Both platforms.
+
+## Notes
+
+- Raw SpO₂ is a raw sensor reading (unit "ADC"), **not** a calibrated blood-oxygen percentage — an accurate % needs WHOOP's proprietary calibration curve, which no independent app has. The calibrated % still comes through a WHOOP or Apple Health import.

--- a/project.yml
+++ b/project.yml
@@ -11,11 +11,11 @@ options:
   developmentLanguage: en
 settings:
   base:
-    MARKETING_VERSION: "8.4.0"
+    MARKETING_VERSION: "8.5.0"
     # iOS build number (CFBundleVersion). GLOBAL so the iOS app AND its widget extension inherit the
     # SAME value — they must match or iOS warns "extension version must match parent app" (#416).
     # macOS sets its own CFBundleVersion on the Strand target and is unaffected by this.
-    CURRENT_PROJECT_VERSION: "178"
+    CURRENT_PROJECT_VERSION: "179"
     SWIFT_VERSION: "5.0"
     # Emit localizable strings so Xcode auto-extracts every LocalizedStringKey into the
     # String Catalog on build (the English (US) base entries).


### PR DESCRIPTION
Release prep for **v8.5.0** — the changelog + version bumps for everything merged since v8.4.0.

## Files
- **`docs/releases/v8.5.0.md`** — full release notes (Added / Fixed / Performance / Diagnostics & honesty) + the `whatsnew` frontmatter.
- **`android/app/build.gradle.kts`** — `versionCode 267 → 268`, `versionName "8.4.0" → "8.5.0"`.
- **`project.yml`** — `MARKETING_VERSION "8.4.0" → "8.5.0"`, `CURRENT_PROJECT_VERSION "178" → "179"`.
- **In-app "What's New"** — `AppChangelog.swift` + `AppChangelog.kt` get a parallel 8.5.0 entry, and `currentVersion`/`CURRENT_VERSION` bump.

## What's in 8.5.0 (highlights)
- **Added:** raw SpO₂ on Health (WHOOP 4.0, #93); Fitness Age countdown (#81).
- **Fixed:** skin temp °F in Deep Timeline (#101); Effort ring honours the 0–100/WHOOP-0–21 scale (#45); workout-in-progress card back on Home (#105); Apple Health steps count (#89); clearer overnight-HRV copy (#92); battery-alert-while-charging (#80) + battery estimate (#99) + widget freshness (#114); motion "g" (#102), skin-temp banding (#111), MG steps empty-state (#107), hero label wrap (#78), Appearance dividers (#79).
- **Performance:** import RAM budget (#70/#125); Sleep-screen memoize (#128); Today formatter hoists (#129).
- **Diagnostics:** Oura anchor-rejection logging (#91); Test Centre sleep capture-check (#127).

## Notes
- Version is consistent across all five surfaces (8.5.0 / code 268 / build 179 / both in-app changelogs).
- `:app:compileFullDebugKotlin` passes (validates the Kotlin `AppChangelog` entry + the bump); iOS `project.yml`/`AppChangelog.swift` ride the release build.
- No `@handle` credits in the notes (per the release convention).
- After merge: refresh `testing-latest` / dispatch the Release build.