### PR TITLE
Fix iOS/macOS build: ReadinessChecklistCard.lead is a String (#81 regression)

### DIFF
--- a/Strand/Screens/HealthView.swift
+++ b/Strand/Screens/HealthView.swift
@@ -882,7 +882,9 @@ private struct FitnessAgeSection: View {
 private struct ReadinessChecklistCard: View {
     let readiness: FitnessAgeReadiness
     /// Optional intro line shown above the groups (e.g. the "a few more days" no-value message).
-    let lead: LocalizedStringKey?
+    /// Already-localized text (from `fitnessReadyLead()`, which returns `String(localized:)`), so it's a
+    /// plain `String` rendered verbatim — not a `LocalizedStringKey` (which would re-key a resolved string).
+    let lead: String?
     /// Invoked when the user taps a required-missing row's "Fix in Settings".
     let onFix: () -> Void
 


### PR DESCRIPTION
**The v8.5.0 release build failed to compile on both iOS and macOS** (Android + the bump job succeeded, so `v8.5.0` was published with only the APK):

```
Strand/Screens/HealthView.swift:744: error: cannot convert value of type 'String' to expected argument type 'LocalizedStringKey'
```

## Cause
`fitnessReadyLead()` (from #81, the Fitness Age countdown) returns an **already-localized `String`** (`String(localized:)`, word-for-word matched to Android), but `ReadinessChecklistCard.lead` was typed `LocalizedStringKey?`. It compiled nowhere because the fork runs the Swift build **only at release/on-demand**, not per-commit — so #81's iOS-only change was never compiled before merge.

## Fix
Type `lead` as `String?` and render it verbatim via `Text(String)`. Re-keying an already-resolved localized string through `LocalizedStringKey` would be wrong anyway. Both callers already pass a `String` / `nil` (lines 734 `lead: nil`, 742 `lead: fitnessReadyLead()`), and the only use is the single `Text(lead)`, so it's self-contained.

Single error in the failed logs (no downstream errors), so this unblocks the build. Can't compile Swift on WSL — rides the re-run of the Release workflow.

## Release recovery (after merge)
The `v8.5.0` release exists but is **incomplete** (APK only). Cleanest path: delete the incomplete `v8.5.0` release **and** its tag, then re-dispatch the Release workflow so it recreates `v8.5.0` at this fixed commit with all three artifacts. (Alternatively, just re-run to attach macOS/iOS assets to the existing release — but then the tag stays at the broken commit.)