### PR TITLE
Fitness Age: gate on the persisted history the card reads, not the in-pass rows

### DIFF
--- a/Strand/Data/IntelligenceEngine.swift
+++ b/Strand/Data/IntelligenceEngine.swift
@@ -950,20 +950,30 @@ final class IntelligenceEngine: ObservableObject {
         // (StrandAnalytics), fully unit-tested; the body term cancels so the headline needs no body metric.
         let fa7 = dailies.sorted { $0.day < $1.day }.suffix(7)
         let faRHRs = fa7.compactMap { $0.restingHr }.map(Double.init)
-        let faActiveStrains = fa7.compactMap { $0.strain }.filter { $0 >= 30 }
-        let faMeanActiveStrain = faActiveStrains.isEmpty ? 0
-            : faActiveStrains.reduce(0, +) / Double(faActiveStrains.count)
         let faWaist: Double? = profile.waistCm > 0 ? profile.waistCm : nil
+        // The Fitness Age gate + compute read the PERSISTED/MERGED last-7 days , the SAME history the
+        // readiness card + dashboard show , NOT this pass's freshly scored `dailies`. A recompute only
+        // re-scores nights whose raw HR still lives in the store, so a nightly wearer whose card reads
+        // "7 of 7 nights" could still leave the engine seeing <4 RHR nights on `dailies`, and Fitness Age
+        // never computed (Vitality did , it needs only 3 of ANY input, which is why Body Age showed but
+        // Fitness Age did not). Kept SEPARATE from `fa7` so Vitality (below), which already computes, is
+        // untouched. Mirrors the Android fix.
+        let faGate7 = (await repo.dailyMetrics(fromDay: oldestDay, toDay: newestDay))
+            .sorted { $0.day < $1.day }.suffix(7)
+        let faGateRHRs = faGate7.compactMap { $0.restingHr }.map(Double.init)
+        let faGateStrains = faGate7.compactMap { $0.strain }.filter { $0 >= 30 }
+        let faGateMeanStrain = faGateStrains.isEmpty ? 0
+            : faGateStrains.reduce(0, +) / Double(faGateStrains.count)
         let faReady = FitnessAgeEngine.assessReadiness(
             hasAge: profile.age > 0, hasSex: !profile.sex.isEmpty,
-            rhrDays: faRHRs.count, activityDays: fa7.compactMap { $0.strain }.count,
+            rhrDays: faGateRHRs.count, activityDays: faGate7.compactMap { $0.strain }.count,
             hasHeightWeight: profile.heightCm > 0 && profile.weightKg > 0, hasWaist: faWaist != nil)
         if faReady.canCompute,
            let faRes = FitnessAgeEngine.compute(
                 age: Double(profile.age), sex: profile.sex,
-                restingHR: IntelligenceEngine.medianOf(faRHRs),
+                restingHR: IntelligenceEngine.medianOf(faGateRHRs),
                 paIndex: FitnessAgeEngine.physicalActivityIndexFromStrain(
-                    activeDaysPerWeek: faActiveStrains.count, meanActiveStrain: faMeanActiveStrain),
+                    activeDaysPerWeek: faGateStrains.count, meanActiveStrain: faGateMeanStrain),
                 waistCm: faWaist) {
             let satKey = IntelligenceEngine.saturdayKey(onOrBefore: newestDay)
             var faPts = [MetricPoint(day: satKey, key: "fitness_age", value: faRes.fitnessAge)]

--- a/Strand/Data/IntelligenceEngine.swift
+++ b/Strand/Data/IntelligenceEngine.swift
@@ -928,6 +928,12 @@ final class IntelligenceEngine: ObservableObject {
         // (Today / Recovery / Strain / Sleep / Trends), not just this screen, reads them. The
         // Repository merges these UNDER any imported "my-whoop" rows, so a real WHOOP import
         // always wins; this only fills the days the strap collected but no import covered.
+        // Snapshot the persisted/merged daily history BEFORE the upsert + stale-evict below , the
+        // accumulated view the readiness card + dashboard read (incl. IMPORTED Apple Health / Health Connect
+        // resting HR, which the engine's computed-only `dailies` never carries). Captured here so the
+        // Fitness Age gate can't be undercut by this pass's own scoring/eviction. Windowed to the range.
+        let faPriorDaily = await repo.dailyMetrics(fromDay: oldestDay, toDay: newestDay)
+
         // Upsert FIRST so the row count never transiently dips (#521).
         if !dailies.isEmpty { _ = try? await store.upsertDailyMetrics(dailies, deviceId: computedId) }
 
@@ -957,9 +963,13 @@ final class IntelligenceEngine: ObservableObject {
         // "7 of 7 nights" could still leave the engine seeing <4 RHR nights on `dailies`, and Fitness Age
         // never computed (Vitality did , it needs only 3 of ANY input, which is why Body Age showed but
         // Fitness Age did not). Kept SEPARATE from `fa7` so Vitality (below), which already computes, is
-        // untouched. Mirrors the Android fix.
-        let faGate7 = (await repo.dailyMetrics(fromDay: oldestDay, toDay: newestDay))
-            .sorted { $0.day < $1.day }.suffix(7)
+        // untouched. Mirrors the Android fix. Gate on the UNION of the pre-rewrite persisted history and
+        // THIS pass's fresh scores (by day, fresh wins), so an RHR night counts whether it survives in the
+        // store, was just scored, or came from an import.
+        var faGateByDay: [String: DailyMetric] = [:]
+        for d in faPriorDaily { faGateByDay[d.day] = d }
+        for d in dailies { faGateByDay[d.day] = d }
+        let faGate7 = faGateByDay.values.sorted { $0.day < $1.day }.suffix(7)
         let faGateRHRs = faGate7.compactMap { $0.restingHr }.map(Double.init)
         let faGateStrains = faGate7.compactMap { $0.strain }.filter { $0 >= 30 }
         let faGateMeanStrain = faGateStrains.isEmpty ? 0

--- a/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
+++ b/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
@@ -892,18 +892,29 @@ object IntelligenceEngine {
         // ── Fitness Age (Phase 2) , weekly, keyed to the week's Saturday ──
         val fa7 = dailies.sortedBy { it.day }.takeLast(7)
         val faRHRs = fa7.mapNotNull { it.restingHr }.map { it.toDouble() }
-        val faActiveStrains = fa7.mapNotNull { it.strain }.filter { it >= 30.0 }
-        val faMeanActiveStrain = if (faActiveStrains.isEmpty()) 0.0 else faActiveStrains.average()
         val faWaist = if (profile.waistCm > 0) profile.waistCm else null
+        // The Fitness Age gate + compute read the PERSISTED/MERGED last-7 days , the SAME history the
+        // readiness card and dashboard show , NOT this pass's freshly scored `dailies`. A recompute only
+        // re-scores nights whose raw HR still lives in the DB, so a nightly wearer whose card reads "7 of 7
+        // nights" could still leave the engine seeing <4 RHR nights on `dailies`, and Fitness Age never
+        // computed (Vitality did , it needs only 3 of ANY input, which is why Body Age showed but Fitness
+        // Age did not). Kept SEPARATE from `fa7` so Vitality (below), which already computes, is untouched.
+        val faGate7 = repo.daysMerged(importedDeviceId).sortedBy { it.day }.takeLast(7)
+        val faGateRHRs = faGate7.mapNotNull { it.restingHr }.map { it.toDouble() }
+        val faGateStrains = faGate7.mapNotNull { it.strain }.filter { it >= 30.0 }
+        val faGateMeanStrain = if (faGateStrains.isEmpty()) 0.0 else faGateStrains.average()
         val faReady = FitnessAgeEngine.assessReadiness(
             hasAge = profile.age > 0, hasSex = profile.sex.isNotEmpty(),
-            rhrDays = faRHRs.size, activityDays = fa7.mapNotNull { it.strain }.size,
+            rhrDays = faGateRHRs.size, activityDays = faGate7.mapNotNull { it.strain }.size,
             hasHeightWeight = profile.heightCm > 0 && profile.weightKg > 0, hasWaist = faWaist != null)
+        // Strap-log proof: the RHR-night count the ENGINE sees for the gate , should equal the
+        // "N of last 7 nights" the readiness card shows. A divergence is the symptom this fix addresses.
+        diag("fitnessAge gate day=$newestDay rhrNights=${faGateRHRs.size} activityDays=${faGate7.mapNotNull { it.strain }.size} conf=${faReady.confidence} canCompute=${faReady.canCompute}")
         if (faReady.canCompute) {
             val faRes = FitnessAgeEngine.compute(
                 age = profile.age, sex = profile.sex,
-                restingHR = medianOfDoubles(faRHRs),
-                paIndex = FitnessAgeEngine.physicalActivityIndexFromStrain(faActiveStrains.size, faMeanActiveStrain),
+                restingHR = medianOfDoubles(faGateRHRs),
+                paIndex = FitnessAgeEngine.physicalActivityIndexFromStrain(faGateStrains.size, faGateMeanStrain),
                 waistCm = faWaist)
             if (faRes != null) {
                 val satKey = saturdayKeyOnOrBefore(newestDay)

--- a/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
+++ b/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
@@ -880,6 +880,14 @@ object IntelligenceEngine {
             }
         }
 
+        // Snapshot the persisted/merged daily history BEFORE the delete+re-upsert below rewrites the
+        // computed window. This is the accumulated view the readiness card + dashboard read ("N of 7
+        // nights"); captured here so the Fitness Age gate (further down) can't be undercut by this pass's
+        // OWN pruning , a recompute only re-scores nights whose raw HR still lives in the store, so reading
+        // after the rewrite would see only the freshly scorable subset. Windowed to the recompute range so
+        // it stays bounded (daysMerged is full-history) and can't drag in stale nights older than the window.
+        val faPriorDaily = repo.daysMerged(importedDeviceId).filter { it.day in oldestDay..newestDay }
+
         repo.deleteComputedDailyInRange(computedId, oldestDay, newestDay)
 
         // Persist the computed scores under the dedicated "-noop" source so the WHOLE
@@ -893,13 +901,16 @@ object IntelligenceEngine {
         val fa7 = dailies.sortedBy { it.day }.takeLast(7)
         val faRHRs = fa7.mapNotNull { it.restingHr }.map { it.toDouble() }
         val faWaist = if (profile.waistCm > 0) profile.waistCm else null
-        // The Fitness Age gate + compute read the PERSISTED/MERGED last-7 days , the SAME history the
-        // readiness card and dashboard show , NOT this pass's freshly scored `dailies`. A recompute only
-        // re-scores nights whose raw HR still lives in the DB, so a nightly wearer whose card reads "7 of 7
-        // nights" could still leave the engine seeing <4 RHR nights on `dailies`, and Fitness Age never
-        // computed (Vitality did , it needs only 3 of ANY input, which is why Body Age showed but Fitness
-        // Age did not). Kept SEPARATE from `fa7` so Vitality (below), which already computes, is untouched.
-        val faGate7 = repo.daysMerged(importedDeviceId).sortedBy { it.day }.takeLast(7)
+        // Gate + compute Fitness Age on the UNION of the pre-rewrite persisted history and THIS pass's
+        // fresh scores (by day, fresh wins) , so an RHR night counts whether it survives in the store OR was
+        // just scored, and whether it sits under this id or a re-added strap's sibling id. The original
+        // (fa7 = dailies) worked while the whole week's raw was always still present; once older raw ages
+        // out, `dailies` alone under-counts vs the card (which reads the merged view) and Fitness Age
+        // silently stops. Kept SEPARATE from `fa7` so Vitality (below), which already computes, is untouched.
+        val faGateByDay = LinkedHashMap<String, DailyMetric>()
+        for (d in faPriorDaily) faGateByDay[d.day] = d
+        for (d in dailies) faGateByDay[d.day] = d
+        val faGate7 = faGateByDay.values.sortedBy { it.day }.takeLast(7)
         val faGateRHRs = faGate7.mapNotNull { it.restingHr }.map { it.toDouble() }
         val faGateStrains = faGate7.mapNotNull { it.strain }.filter { it >= 30.0 }
         val faGateMeanStrain = if (faGateStrains.isEmpty()) 0.0 else faGateStrains.average()


### PR DESCRIPTION
## The bug

Reported from the field: the Fitness Age readiness card shows **every input satisfied** — "Resting heart rate: **7 of last 7 nights**", age/sex **Set**, activity **7 of 7** — yet the card reads **"No Data"** and never produces a value. Meanwhile **Vitality / Body Age computes fine** (54 / 48). Age and sex confirmed set in the profile, so it's not a coverage or profile gap.

## Root cause

The engine gated Fitness Age on `fa7 = dailies` — **this recompute pass's freshly scored nights**. A recompute only re‑scores a night whose **raw HR still lives in the DB** (`if (hr.size < MIN_HR_SAMPLES) continue`), but the computed daily rows (and their resting‑HR) **persist** after the raw streams age out. The readiness card, by contrast, counts the **persisted / merged** daily history.

So the two disagree: the card counts the full persisted week ("7 of 7"), the engine's `dailies` sees fewer than 4 resting‑HR nights → `assessReadiness` returns `NOT_READY` → Fitness Age is never written. **Vitality survives the same sparse `fa7`** because `VitalityEngine` needs only **3 of *any* input** (sleep / HRV / steps), which is exactly why Body Age shows but Fitness Age doesn't.

## Fix

Gate + compute Fitness Age from the **same merged last‑7 the card and dashboard read** (`repo.daysMerged` on Android, `repo.dailyMetrics(fromDay:toDay:)` union on iOS), kept **separate from `fa7`** so Vitality (which already computes) is untouched.

**Monotonic‑safe:** the merged view can only yield **≥** the resting‑HR nights `dailies` had, using valid values — so it can never make Fitness Age compute *less* often. Worst case it's a no‑op; best case it computes.

Also adds a **strap‑log line (Android)** recording the resting‑HR‑night count the engine actually sees for the gate, so any remaining divergence from the card's "N of last 7" is provable from an export.

## Honest caveat / validation

The recompute deletes+reinserts computed rows mid‑pass, so there's a chance the merged read reflects the same narrowed window and the fix is a **no‑op for this exact case**. That's what the diagnostic is for. **To validate:** after this ships and a recompute runs, does Fitness Age populate? If not, the strap‑log `fitnessAge gate … rhrNights=N` line pinpoints whether the persisted store itself is being pruned (a deeper follow‑up).

## Verification
- Android `:app:compileFullDebugKotlin` passes locally.
- iOS reviewed by hand (Charts/Compression can't build on WSL): `repo.dailyMetrics(fromDay:toDay:)` is `async` (non‑throwing), in scope with `oldestDay`/`newestDay`; `fa7`/`faRHRs` retained for Vitality; removed `faActiveStrains`/`faMeanActiveStrain` have zero remaining refs.
