### PR TITLE
Fitness Age: add a "refresh" button to force an immediate recompute

### DIFF
--- a/Strand/Data/IntelligenceEngine.swift
+++ b/Strand/Data/IntelligenceEngine.swift
@@ -950,20 +950,30 @@ final class IntelligenceEngine: ObservableObject {
         // (StrandAnalytics), fully unit-tested; the body term cancels so the headline needs no body metric.
         let fa7 = dailies.sorted { $0.day < $1.day }.suffix(7)
         let faRHRs = fa7.compactMap { $0.restingHr }.map(Double.init)
-        let faActiveStrains = fa7.compactMap { $0.strain }.filter { $0 >= 30 }
-        let faMeanActiveStrain = faActiveStrains.isEmpty ? 0
-            : faActiveStrains.reduce(0, +) / Double(faActiveStrains.count)
         let faWaist: Double? = profile.waistCm > 0 ? profile.waistCm : nil
+        // The Fitness Age gate + compute read the PERSISTED/MERGED last-7 days , the SAME history the
+        // readiness card + dashboard show , NOT this pass's freshly scored `dailies`. A recompute only
+        // re-scores nights whose raw HR still lives in the store, so a nightly wearer whose card reads
+        // "7 of 7 nights" could still leave the engine seeing <4 RHR nights on `dailies`, and Fitness Age
+        // never computed (Vitality did , it needs only 3 of ANY input, which is why Body Age showed but
+        // Fitness Age did not). Kept SEPARATE from `fa7` so Vitality (below), which already computes, is
+        // untouched. Mirrors the Android fix.
+        let faGate7 = (await repo.dailyMetrics(fromDay: oldestDay, toDay: newestDay))
+            .sorted { $0.day < $1.day }.suffix(7)
+        let faGateRHRs = faGate7.compactMap { $0.restingHr }.map(Double.init)
+        let faGateStrains = faGate7.compactMap { $0.strain }.filter { $0 >= 30 }
+        let faGateMeanStrain = faGateStrains.isEmpty ? 0
+            : faGateStrains.reduce(0, +) / Double(faGateStrains.count)
         let faReady = FitnessAgeEngine.assessReadiness(
             hasAge: profile.age > 0, hasSex: !profile.sex.isEmpty,
-            rhrDays: faRHRs.count, activityDays: fa7.compactMap { $0.strain }.count,
+            rhrDays: faGateRHRs.count, activityDays: faGate7.compactMap { $0.strain }.count,
             hasHeightWeight: profile.heightCm > 0 && profile.weightKg > 0, hasWaist: faWaist != nil)
         if faReady.canCompute,
            let faRes = FitnessAgeEngine.compute(
                 age: Double(profile.age), sex: profile.sex,
-                restingHR: IntelligenceEngine.medianOf(faRHRs),
+                restingHR: IntelligenceEngine.medianOf(faGateRHRs),
                 paIndex: FitnessAgeEngine.physicalActivityIndexFromStrain(
-                    activeDaysPerWeek: faActiveStrains.count, meanActiveStrain: faMeanActiveStrain),
+                    activeDaysPerWeek: faGateStrains.count, meanActiveStrain: faGateMeanStrain),
                 waistCm: faWaist) {
             let satKey = IntelligenceEngine.saturdayKey(onOrBefore: newestDay)
             var faPts = [MetricPoint(day: satKey, key: "fitness_age", value: faRes.fitnessAge)]

--- a/Strand/Data/IntelligenceEngine.swift
+++ b/Strand/Data/IntelligenceEngine.swift
@@ -195,6 +195,58 @@ final class IntelligenceEngine: ObservableObject {
         return fmt.string(from: sat)
     }
 
+    /// Assess Fitness Age readiness from `gateDays` (the merged last-7 the readiness card counts) and, when
+    /// ready, build the fitness_age (+ optional vo2max) points for `satKey`. Empty when not ready. The
+    /// SINGLE source of the gate + compute , shared by the recompute pass and the manual "refresh Fitness
+    /// Age" button so the two can never drift. Profile passed as primitives (no cross-actor object read).
+    /// Mirrors the Android `IntelligenceEngine.fitnessAgeRows`.
+    static func fitnessAgeRows(
+        gateDays: [DailyMetric], age: Int, sex: String, waistCm: Double, heightCm: Double, weightKg: Double,
+        computedId: String, satKey: String,
+    ) -> [MetricPoint] {
+        let rhrs = gateDays.compactMap { $0.restingHr }.map(Double.init)
+        let strains = gateDays.compactMap { $0.strain }.filter { $0 >= 30 }
+        let meanStrain = strains.isEmpty ? 0 : strains.reduce(0, +) / Double(strains.count)
+        let waist: Double? = waistCm > 0 ? waistCm : nil
+        let ready = FitnessAgeEngine.assessReadiness(
+            hasAge: age > 0, hasSex: !sex.isEmpty,
+            rhrDays: rhrs.count, activityDays: gateDays.compactMap { $0.strain }.count,
+            hasHeightWeight: heightCm > 0 && weightKg > 0, hasWaist: waist != nil)
+        guard ready.canCompute,
+              let res = FitnessAgeEngine.compute(
+                age: Double(age), sex: sex,
+                restingHR: medianOf(rhrs),
+                paIndex: FitnessAgeEngine.physicalActivityIndexFromStrain(
+                    activeDaysPerWeek: strains.count, meanActiveStrain: meanStrain),
+                waistCm: waist) else { return [] }
+        var rows = [MetricPoint(day: satKey, key: "fitness_age", value: res.fitnessAge)]
+        if let v = res.vo2max { rows.append(MetricPoint(day: satKey, key: "vo2max_est", value: v)) }
+        return rows
+    }
+
+    /// Manual "refresh Fitness Age" (the button on the not-ready card): recompute the weekly Fitness Age NOW
+    /// from the PERSISTED merged daily history , NO raw-HR rescoring , and upsert it. Same gate
+    /// (`fitnessAgeRows`) + date/window logic as the recompute pass, so it reads exactly what the readiness
+    /// card shows. Light + works offline (stored data only). Returns true if a value was written. Mirrors
+    /// the Android `recomputeFitnessAgeOnly`.
+    func recomputeFitnessAgeOnly(maxDays: Int = 21) async -> Bool {
+        guard let store = await repo.storeHandle() else { return false }
+        let computedId = deviceId + "-noop"
+        let now = Int(Date().timeIntervalSince1970)
+        let tzOffset = TimeZone.current.secondsFromGMT()
+        let nowLocalMidnight = Self.midnightLocal(now, offsetSec: tzOffset)
+        let newestDay = AnalyticsEngine.dayString(nowLocalMidnight, offsetSec: tzOffset)
+        let oldestDay = AnalyticsEngine.dayString(nowLocalMidnight - (maxDays - 1) * 86_400, offsetSec: tzOffset)
+        let gate7 = Array((await repo.dailyMetrics(fromDay: oldestDay, toDay: newestDay))
+            .sorted { $0.day < $1.day }.suffix(7))
+        let rows = Self.fitnessAgeRows(
+            gateDays: gate7, age: profile.age, sex: profile.sex, waistCm: profile.waistCm,
+            heightCm: profile.heightCm, weightKg: profile.weightKg, computedId: computedId,
+            satKey: Self.saturdayKey(onOrBefore: newestDay))
+        if !rows.isEmpty { _ = try? await store.upsertMetricSeries(rows, deviceId: computedId) }
+        return !rows.isEmpty
+    }
+
     /// UserDefaults flag guarding the one-shot #313 full-history Effort rescore (below). Set once the
     /// pass completes so it never re-runs.
     static let effortRescoreFlagKey = "intelligence.effortRescore.v313.done"
@@ -956,40 +1008,25 @@ final class IntelligenceEngine: ObservableObject {
         // (StrandAnalytics), fully unit-tested; the body term cancels so the headline needs no body metric.
         let fa7 = dailies.sorted { $0.day < $1.day }.suffix(7)
         let faRHRs = fa7.compactMap { $0.restingHr }.map(Double.init)
-        let faWaist: Double? = profile.waistCm > 0 ? profile.waistCm : nil
         // The Fitness Age gate + compute read the PERSISTED/MERGED last-7 days , the SAME history the
         // readiness card + dashboard show , NOT this pass's freshly scored `dailies`. A recompute only
         // re-scores nights whose raw HR still lives in the store, so a nightly wearer whose card reads
         // "7 of 7 nights" could still leave the engine seeing <4 RHR nights on `dailies`, and Fitness Age
         // never computed (Vitality did , it needs only 3 of ANY input, which is why Body Age showed but
         // Fitness Age did not). Kept SEPARATE from `fa7` so Vitality (below), which already computes, is
-        // untouched. Mirrors the Android fix. Gate on the UNION of the pre-rewrite persisted history and
-        // THIS pass's fresh scores (by day, fresh wins), so an RHR night counts whether it survives in the
-        // store, was just scored, or came from an import.
+        // untouched. Gate on the UNION of the pre-rewrite persisted history and THIS pass's fresh scores
+        // (by day, fresh wins), so an RHR night counts whether it survives in the store, was just scored,
+        // or came from an import. The gate + compute live in `fitnessAgeRows`, shared with the manual
+        // "refresh Fitness Age" button so the two can never drift.
         var faGateByDay: [String: DailyMetric] = [:]
         for d in faPriorDaily { faGateByDay[d.day] = d }
         for d in dailies { faGateByDay[d.day] = d }
-        let faGate7 = faGateByDay.values.sorted { $0.day < $1.day }.suffix(7)
-        let faGateRHRs = faGate7.compactMap { $0.restingHr }.map(Double.init)
-        let faGateStrains = faGate7.compactMap { $0.strain }.filter { $0 >= 30 }
-        let faGateMeanStrain = faGateStrains.isEmpty ? 0
-            : faGateStrains.reduce(0, +) / Double(faGateStrains.count)
-        let faReady = FitnessAgeEngine.assessReadiness(
-            hasAge: profile.age > 0, hasSex: !profile.sex.isEmpty,
-            rhrDays: faGateRHRs.count, activityDays: faGate7.compactMap { $0.strain }.count,
-            hasHeightWeight: profile.heightCm > 0 && profile.weightKg > 0, hasWaist: faWaist != nil)
-        if faReady.canCompute,
-           let faRes = FitnessAgeEngine.compute(
-                age: Double(profile.age), sex: profile.sex,
-                restingHR: IntelligenceEngine.medianOf(faGateRHRs),
-                paIndex: FitnessAgeEngine.physicalActivityIndexFromStrain(
-                    activeDaysPerWeek: faGateStrains.count, meanActiveStrain: faGateMeanStrain),
-                waistCm: faWaist) {
-            let satKey = IntelligenceEngine.saturdayKey(onOrBefore: newestDay)
-            var faPts = [MetricPoint(day: satKey, key: "fitness_age", value: faRes.fitnessAge)]
-            if let v = faRes.vo2max { faPts.append(MetricPoint(day: satKey, key: "vo2max_est", value: v)) }
-            _ = try? await store.upsertMetricSeries(faPts, deviceId: computedId)
-        }
+        let faGate7 = Array(faGateByDay.values.sorted { $0.day < $1.day }.suffix(7))
+        let faPts = Self.fitnessAgeRows(
+            gateDays: faGate7, age: profile.age, sex: profile.sex, waistCm: profile.waistCm,
+            heightCm: profile.heightCm, weightKg: profile.weightKg, computedId: computedId,
+            satKey: IntelligenceEngine.saturdayKey(onOrBefore: newestDay))
+        if !faPts.isEmpty { _ = try? await store.upsertMetricSeries(faPts, deviceId: computedId) }
 
         // ── Vitality / Body Age (Phase 7) , weekly, keyed to the week's Saturday ────────────────────
         // Roll the last 7 days' wearable signals into the mortality-hazard model and upsert a weekly

--- a/Strand/Data/IntelligenceEngine.swift
+++ b/Strand/Data/IntelligenceEngine.swift
@@ -928,6 +928,12 @@ final class IntelligenceEngine: ObservableObject {
         // (Today / Recovery / Strain / Sleep / Trends), not just this screen, reads them. The
         // Repository merges these UNDER any imported "my-whoop" rows, so a real WHOOP import
         // always wins; this only fills the days the strap collected but no import covered.
+        // Snapshot the persisted/merged daily history BEFORE the upsert + stale-evict below , the
+        // accumulated view the readiness card + dashboard read (incl. IMPORTED Apple Health / Health Connect
+        // resting HR, which the engine's computed-only `dailies` never carries). Captured here so the
+        // Fitness Age gate can't be undercut by this pass's own scoring/eviction. Windowed to the range.
+        let faPriorDaily = await repo.dailyMetrics(fromDay: oldestDay, toDay: newestDay)
+
         // Upsert FIRST so the row count never transiently dips (#521).
         if !dailies.isEmpty { _ = try? await store.upsertDailyMetrics(dailies, deviceId: computedId) }
 
@@ -957,9 +963,13 @@ final class IntelligenceEngine: ObservableObject {
         // "7 of 7 nights" could still leave the engine seeing <4 RHR nights on `dailies`, and Fitness Age
         // never computed (Vitality did , it needs only 3 of ANY input, which is why Body Age showed but
         // Fitness Age did not). Kept SEPARATE from `fa7` so Vitality (below), which already computes, is
-        // untouched. Mirrors the Android fix.
-        let faGate7 = (await repo.dailyMetrics(fromDay: oldestDay, toDay: newestDay))
-            .sorted { $0.day < $1.day }.suffix(7)
+        // untouched. Mirrors the Android fix. Gate on the UNION of the pre-rewrite persisted history and
+        // THIS pass's fresh scores (by day, fresh wins), so an RHR night counts whether it survives in the
+        // store, was just scored, or came from an import.
+        var faGateByDay: [String: DailyMetric] = [:]
+        for d in faPriorDaily { faGateByDay[d.day] = d }
+        for d in dailies { faGateByDay[d.day] = d }
+        let faGate7 = faGateByDay.values.sorted { $0.day < $1.day }.suffix(7)
         let faGateRHRs = faGate7.compactMap { $0.restingHr }.map(Double.init)
         let faGateStrains = faGate7.compactMap { $0.strain }.filter { $0 >= 30 }
         let faGateMeanStrain = faGateStrains.isEmpty ? 0

--- a/Strand/Screens/HealthView.swift
+++ b/Strand/Screens/HealthView.swift
@@ -688,21 +688,12 @@ private struct FitnessAgeSection: View {
             hasWaist: profile.waistCm > 0)
     }
 
-    /// The not-ready card's lead: a concrete countdown of nights-of-wear still needed (from the shared
-    /// `nightsUntilReady`), noting the profile basics only when they're actually missing. Copy is kept
-    /// WORD-FOR-WORD identical to the Android `fitnessReadyLead` so the two platforms match.
+    /// The not-ready card's lead — delegates to the file-scope `fitnessReadyLeadCopy(rhrDays:hasAge:hasSex:)`,
+    /// shared with the Today card's `MetricDetailView` tap-through so both surfaces show the SAME countdown.
     private func fitnessReadyLead() -> String {
-        let rhrDays = repo.days.suffix(7).compactMap { $0.restingHr }.count
-        let remaining = FitnessAgeEngine.nightsUntilReady(rhrDays: rhrDays)
-        let needsBasics = profile.age <= 0 || profile.sex.isEmpty
-        switch (remaining, needsBasics) {
-        case (0, false): return String(localized: "A few more days and we can show your Fitness Age.")
-        case (0, true):  return String(localized: "Add your age and sex below and we can show your Fitness Age.")
-        case (1, false): return String(localized: "1 more night of wear and we can show your Fitness Age.")
-        case (1, true):  return String(localized: "1 more night of wear, plus your age and sex below, and we can show your Fitness Age.")
-        case (let n, false): return String(localized: "\(n) more nights of wear and we can show your Fitness Age.")
-        case (let n, true):  return String(localized: "\(n) more nights of wear, plus your age and sex below, and we can show your Fitness Age.")
-        }
+        fitnessReadyLeadCopy(
+            rhrDays: repo.days.suffix(7).compactMap { $0.restingHr }.count,
+            hasAge: profile.age > 0, hasSex: !profile.sex.isEmpty)
     }
 
     var body: some View {
@@ -872,6 +863,24 @@ private struct FitnessAgeSection: View {
         fitnessAge = faPts.last?.value
         vo2max = vo2Pts.last?.value
         loaded = true
+    }
+}
+
+/// The Fitness Age not-ready lead: a concrete countdown of nights-of-wear still needed (from the shared
+/// `nightsUntilReady`), noting the profile basics only when they're actually missing. File-scope (not a
+/// view method) so BOTH the Health hub's `FitnessAgeCard` and the Today card's `MetricDetailView`
+/// tap-through render the SAME copy from one source. Kept WORD-FOR-WORD identical to the Android
+/// `fitnessReadyLead` so the two platforms match.
+func fitnessReadyLeadCopy(rhrDays: Int, hasAge: Bool, hasSex: Bool) -> String {
+    let remaining = FitnessAgeEngine.nightsUntilReady(rhrDays: rhrDays)
+    let needsBasics = !hasAge || !hasSex
+    switch (remaining, needsBasics) {
+    case (0, false): return String(localized: "A few more days and we can show your Fitness Age.")
+    case (0, true):  return String(localized: "Add your age and sex below and we can show your Fitness Age.")
+    case (1, false): return String(localized: "1 more night of wear and we can show your Fitness Age.")
+    case (1, true):  return String(localized: "1 more night of wear, plus your age and sex below, and we can show your Fitness Age.")
+    case (let n, false): return String(localized: "\(n) more nights of wear and we can show your Fitness Age.")
+    case (let n, true):  return String(localized: "\(n) more nights of wear, plus your age and sex below, and we can show your Fitness Age.")
     }
 }
 

--- a/Strand/Screens/HealthView.swift
+++ b/Strand/Screens/HealthView.swift
@@ -648,12 +648,16 @@ private struct ContributorBar: View {
 private struct FitnessAgeSection: View {
     @EnvironmentObject var repo: Repository
     @EnvironmentObject var profile: ProfileStore
+    /// Drives the not-ready card's "refresh Fitness Age" button (force an immediate recompute).
+    @EnvironmentObject var intelligence: IntelligenceEngine
 
     /// Latest weekly Fitness Age (years) read from the "fitness_age" metricSeries, nil until loaded/computed.
     @State private var fitnessAge: Double?
     /// Latest estimated VO₂max (ml/kg/min) from "vo2max_est" — only present once a waist is set.
     @State private var vo2max: Double?
     @State private var loaded = false
+    /// True while a manual "refresh Fitness Age" recompute is running (spinner in the readiness card).
+    @State private var refreshing = false
 
     /// Reveal the readiness checklist (the "ⓘ How accurate is this?" disclosure under a shown value).
     @State private var showReadiness = false
@@ -733,7 +737,17 @@ private struct FitnessAgeSection: View {
             ReadinessChecklistCard(
                 readiness: readiness,
                 lead: fitnessReadyLead(),
-                onFix: { fitnessSheet = .settings })
+                onFix: { fitnessSheet = .settings },
+                onRefresh: {
+                    guard !refreshing else { return }
+                    refreshing = true
+                    Task {
+                        _ = await intelligence.recomputeFitnessAgeOnly()
+                        await load()
+                        refreshing = false
+                    }
+                },
+                refreshing: refreshing)
         } else {
             // Brief read of the weekly value; honest placeholder rather than an empty gap.
             ComingSoon(what: "Reading your Fitness Age…", symbol: "figure.run")
@@ -896,6 +910,10 @@ private struct ReadinessChecklistCard: View {
     let lead: String?
     /// Invoked when the user taps a required-missing row's "Fix in Settings".
     let onFix: () -> Void
+    /// Optional force-recompute action (the "refresh Fitness Age" button, not-ready state only);
+    /// `refreshing` swaps it for a spinner while the recompute runs. nil = no button.
+    var onRefresh: (() -> Void)? = nil
+    var refreshing: Bool = false
 
     private var drivesAge: [FitnessReadinessItem] { readiness.items.filter { $0.role == .drivesAge } }
     private var unlocksVO2: [FitnessReadinessItem] { readiness.items.filter { $0.role == .unlocksVO2max } }
@@ -906,6 +924,21 @@ private struct ReadinessChecklistCard: View {
                 HStack(spacing: NoopMetrics.rowSpacing) {
                     confidencePill
                     Spacer(minLength: 0)
+                    // Force-recompute affordance: NOOP scores Fitness Age weekly, so this applies it NOW
+                    // from stored data. Spinner while it runs.
+                    if let onRefresh {
+                        if refreshing {
+                            ProgressView().controlSize(.small).tint(StrandPalette.accent)
+                        } else {
+                            Button(action: onRefresh) {
+                                Image(systemName: "arrow.clockwise")
+                                    .font(StrandFont.subhead)
+                                    .foregroundStyle(StrandPalette.accent)
+                            }
+                            .buttonStyle(.plain)
+                            .accessibilityLabel("Refresh Fitness Age now")
+                        }
+                    }
                 }
                 if let lead {
                     Text(lead)
@@ -1411,6 +1444,7 @@ private struct HealthHubLinksSection: View {
         .environmentObject(ProfileStore())
         .environmentObject(AppModel())
         .environmentObject(NavRouter())
+        .environmentObject(IntelligenceEngine(repo: repo, profile: ProfileStore(), deviceId: "preview"))
         .frame(width: 900, height: 760)
         .preferredColorScheme(.dark)
 }

--- a/Strand/Screens/MetricExplorerView.swift
+++ b/Strand/Screens/MetricExplorerView.swift
@@ -402,6 +402,10 @@ struct MetricDetailView: View {
     // Profile basics for the Fitness Age not-ready countdown (age/sex gate its readiness lead). Injected
     // app-wide at the root; previews supply their own. Only read on the fitness_age empty-state path.
     @EnvironmentObject var profile: ProfileStore
+    // Drives the fitness_age not-ready "refresh" button (force an immediate recompute). App-wide injected.
+    @EnvironmentObject var intelligence: IntelligenceEngine
+    /// True while a manual Fitness Age refresh runs (spinner on the not-ready empty state).
+    @State private var refreshing = false
 
     // Imperial/Metric display preference (D#103). Display-only: weight (kg) and skin temp (°C) re-label
     // here; everything else is unit-agnostic and renders unchanged.
@@ -567,7 +571,28 @@ struct MetricDetailView: View {
                         // engine + `fitnessReadyLeadCopy` (parity with Android's VitalDetailScreen fix).
                         // `what` is a LocalizedStringKey; the lead is an already-resolved String, so wrap
                         // it in an interpolation (renders verbatim) rather than passing it as a lookup key.
-                        ComingSoon(what: "\(fitnessReadyLeadCopy(rhrDays: repo.days.suffix(7).compactMap { $0.restingHr }.count, hasAge: profile.age > 0, hasSex: !profile.sex.isEmpty))", symbol: "figure.run")
+                        VStack(alignment: .leading, spacing: NoopMetrics.space2) {
+                            ComingSoon(what: "\(fitnessReadyLeadCopy(rhrDays: repo.days.suffix(7).compactMap { $0.restingHr }.count, hasAge: profile.age > 0, hasSex: !profile.sex.isEmpty))", symbol: "figure.run")
+                            // Force the weekly recompute NOW from stored data (works offline), then re-read.
+                            if refreshing {
+                                ProgressView().controlSize(.small).tint(StrandPalette.accent)
+                            } else {
+                                Button {
+                                    guard !refreshing else { return }
+                                    refreshing = true
+                                    Task {
+                                        _ = await intelligence.recomputeFitnessAgeOnly()
+                                        await load()
+                                        refreshing = false
+                                    }
+                                } label: {
+                                    Label("Refresh Fitness Age", systemImage: "arrow.clockwise")
+                                        .font(StrandFont.subhead)
+                                        .foregroundStyle(StrandPalette.accent)
+                                }
+                                .buttonStyle(.plain)
+                            }
+                        }
                     } else {
                         ComingSoon(what: "Import your history first. A WHOOP export in Data Sources fills every metric you can explore here in about a minute.")
                     }
@@ -1009,11 +1034,13 @@ private func explorerPreviewRepo() -> Repository {
 }
 
 #Preview("Metric Detail") {
-    NavigationStack {
+    let repo = explorerPreviewRepo()
+    return NavigationStack {
         MetricDetailView(metric: MetricCatalog.all.first { $0.key == "recovery" }!)
     }
-    .environmentObject(explorerPreviewRepo())
+    .environmentObject(repo)
     .environmentObject(ProfileStore())
+    .environmentObject(IntelligenceEngine(repo: repo, profile: ProfileStore(), deviceId: "preview"))
     .frame(width: 900, height: 820)
     .preferredColorScheme(.dark)
 }

--- a/Strand/Screens/MetricExplorerView.swift
+++ b/Strand/Screens/MetricExplorerView.swift
@@ -399,6 +399,9 @@ private struct MetricRow: View {
 struct MetricDetailView: View {
     let metric: MetricDescriptor
     @EnvironmentObject var repo: Repository
+    // Profile basics for the Fitness Age not-ready countdown (age/sex gate its readiness lead). Injected
+    // app-wide at the root; previews supply their own. Only read on the fitness_age empty-state path.
+    @EnvironmentObject var profile: ProfileStore
 
     // Imperial/Metric display preference (D#103). Display-only: weight (kg) and skin temp (°C) re-label
     // here; everything else is unit-agnostic and renders unchanged.
@@ -557,7 +560,17 @@ struct MetricDetailView: View {
                     // the ranges to misrepresent, and hiding the bar here would regress this
                     // "for context" intent.
                     rangeBar(effectiveRange: effRange, windowed: win, windowFellBack: fellBack)
-                    ComingSoon(what: "Import your history first. A WHOOP export in Data Sources fills every metric you can explore here in about a minute.")
+                    if metric.key == "fitness_age" {
+                        // Fitness Age is COMPUTED on-device from resting HR + activity — not imported — so
+                        // the generic "import your history" copy was wrong (and a dead end) here. Lead with
+                        // the same "N more nights of wear" countdown the Health hub shows, from the shared
+                        // engine + `fitnessReadyLeadCopy` (parity with Android's VitalDetailScreen fix).
+                        // `what` is a LocalizedStringKey; the lead is an already-resolved String, so wrap
+                        // it in an interpolation (renders verbatim) rather than passing it as a lookup key.
+                        ComingSoon(what: "\(fitnessReadyLeadCopy(rhrDays: repo.days.suffix(7).compactMap { $0.restingHr }.count, hasAge: profile.age > 0, hasSex: !profile.sex.isEmpty))", symbol: "figure.run")
+                    } else {
+                        ComingSoon(what: "Import your history first. A WHOOP export in Data Sources fills every metric you can explore here in about a minute.")
+                    }
                 } else if !loaded {
                     rangeBar(effectiveRange: effRange, windowed: win, windowFellBack: fellBack)
                     ComingSoon(what: "Reading your \(metric.title.lowercased())…")
@@ -1000,6 +1013,7 @@ private func explorerPreviewRepo() -> Repository {
         MetricDetailView(metric: MetricCatalog.all.first { $0.key == "recovery" }!)
     }
     .environmentObject(explorerPreviewRepo())
+    .environmentObject(ProfileStore())
     .frame(width: 900, height: 820)
     .preferredColorScheme(.dark)
 }

--- a/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
+++ b/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
@@ -892,18 +892,29 @@ object IntelligenceEngine {
         // ── Fitness Age (Phase 2) , weekly, keyed to the week's Saturday ──
         val fa7 = dailies.sortedBy { it.day }.takeLast(7)
         val faRHRs = fa7.mapNotNull { it.restingHr }.map { it.toDouble() }
-        val faActiveStrains = fa7.mapNotNull { it.strain }.filter { it >= 30.0 }
-        val faMeanActiveStrain = if (faActiveStrains.isEmpty()) 0.0 else faActiveStrains.average()
         val faWaist = if (profile.waistCm > 0) profile.waistCm else null
+        // The Fitness Age gate + compute read the PERSISTED/MERGED last-7 days , the SAME history the
+        // readiness card and dashboard show , NOT this pass's freshly scored `dailies`. A recompute only
+        // re-scores nights whose raw HR still lives in the DB, so a nightly wearer whose card reads "7 of 7
+        // nights" could still leave the engine seeing <4 RHR nights on `dailies`, and Fitness Age never
+        // computed (Vitality did , it needs only 3 of ANY input, which is why Body Age showed but Fitness
+        // Age did not). Kept SEPARATE from `fa7` so Vitality (below), which already computes, is untouched.
+        val faGate7 = repo.daysMerged(importedDeviceId).sortedBy { it.day }.takeLast(7)
+        val faGateRHRs = faGate7.mapNotNull { it.restingHr }.map { it.toDouble() }
+        val faGateStrains = faGate7.mapNotNull { it.strain }.filter { it >= 30.0 }
+        val faGateMeanStrain = if (faGateStrains.isEmpty()) 0.0 else faGateStrains.average()
         val faReady = FitnessAgeEngine.assessReadiness(
             hasAge = profile.age > 0, hasSex = profile.sex.isNotEmpty(),
-            rhrDays = faRHRs.size, activityDays = fa7.mapNotNull { it.strain }.size,
+            rhrDays = faGateRHRs.size, activityDays = faGate7.mapNotNull { it.strain }.size,
             hasHeightWeight = profile.heightCm > 0 && profile.weightKg > 0, hasWaist = faWaist != null)
+        // Strap-log proof: the RHR-night count the ENGINE sees for the gate , should equal the
+        // "N of last 7 nights" the readiness card shows. A divergence is the symptom this fix addresses.
+        diag("fitnessAge gate day=$newestDay rhrNights=${faGateRHRs.size} activityDays=${faGate7.mapNotNull { it.strain }.size} conf=${faReady.confidence} canCompute=${faReady.canCompute}")
         if (faReady.canCompute) {
             val faRes = FitnessAgeEngine.compute(
                 age = profile.age, sex = profile.sex,
-                restingHR = medianOfDoubles(faRHRs),
-                paIndex = FitnessAgeEngine.physicalActivityIndexFromStrain(faActiveStrains.size, faMeanActiveStrain),
+                restingHR = medianOfDoubles(faGateRHRs),
+                paIndex = FitnessAgeEngine.physicalActivityIndexFromStrain(faGateStrains.size, faGateMeanStrain),
                 waistCm = faWaist)
             if (faRes != null) {
                 val satKey = saturdayKeyOnOrBefore(newestDay)

--- a/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
+++ b/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
@@ -900,40 +900,21 @@ object IntelligenceEngine {
         // ── Fitness Age (Phase 2) , weekly, keyed to the week's Saturday ──
         val fa7 = dailies.sortedBy { it.day }.takeLast(7)
         val faRHRs = fa7.mapNotNull { it.restingHr }.map { it.toDouble() }
-        val faWaist = if (profile.waistCm > 0) profile.waistCm else null
         // Gate + compute Fitness Age on the UNION of the pre-rewrite persisted history and THIS pass's
         // fresh scores (by day, fresh wins) , so an RHR night counts whether it survives in the store OR was
-        // just scored, and whether it sits under this id or a re-added strap's sibling id. The original
-        // (fa7 = dailies) worked while the whole week's raw was always still present; once older raw ages
-        // out, `dailies` alone under-counts vs the card (which reads the merged view) and Fitness Age
-        // silently stops. Kept SEPARATE from `fa7` so Vitality (below), which already computes, is untouched.
+        // just scored, whether it sits under this id or a re-added strap's sibling id, or came from an
+        // import. Kept SEPARATE from `fa7` so Vitality (below), which already computes, is untouched. The
+        // gate + compute live in [fitnessAgeRows] so the manual "refresh Fitness Age" button applies the
+        // SAME rule (no drift).
         val faGateByDay = LinkedHashMap<String, DailyMetric>()
         for (d in faPriorDaily) faGateByDay[d.day] = d
         for (d in dailies) faGateByDay[d.day] = d
         val faGate7 = faGateByDay.values.sortedBy { it.day }.takeLast(7)
-        val faGateRHRs = faGate7.mapNotNull { it.restingHr }.map { it.toDouble() }
-        val faGateStrains = faGate7.mapNotNull { it.strain }.filter { it >= 30.0 }
-        val faGateMeanStrain = if (faGateStrains.isEmpty()) 0.0 else faGateStrains.average()
-        val faReady = FitnessAgeEngine.assessReadiness(
-            hasAge = profile.age > 0, hasSex = profile.sex.isNotEmpty(),
-            rhrDays = faGateRHRs.size, activityDays = faGate7.mapNotNull { it.strain }.size,
-            hasHeightWeight = profile.heightCm > 0 && profile.weightKg > 0, hasWaist = faWaist != null)
-        // Strap-log proof: the RHR-night count the ENGINE sees for the gate , should equal the
-        // "N of last 7 nights" the readiness card shows. A divergence is the symptom this fix addresses.
-        diag("fitnessAge gate day=$newestDay rhrNights=${faGateRHRs.size} activityDays=${faGate7.mapNotNull { it.strain }.size} conf=${faReady.confidence} canCompute=${faReady.canCompute}")
-        if (faReady.canCompute) {
-            val faRes = FitnessAgeEngine.compute(
-                age = profile.age, sex = profile.sex,
-                restingHR = medianOfDoubles(faGateRHRs),
-                paIndex = FitnessAgeEngine.physicalActivityIndexFromStrain(faGateStrains.size, faGateMeanStrain),
-                waistCm = faWaist)
-            if (faRes != null) {
-                val satKey = saturdayKeyOnOrBefore(newestDay)
-                val faPts = mutableListOf(MetricSeriesRow(deviceId = computedId, day = satKey, key = "fitness_age", value = faRes.fitnessAge))
-                faRes.vo2max?.let { faPts.add(MetricSeriesRow(deviceId = computedId, day = satKey, key = "vo2max_est", value = it)) }
-                repo.upsertMetricSeries(faPts)
-            }
-        }
+        val faPts = fitnessAgeRows(faGate7, profile, computedId, saturdayKeyOnOrBefore(newestDay))
+        // Strap-log proof: the RHR-night count the engine sees for the gate , should equal the "N of last 7
+        // nights" the readiness card shows; `computed` says whether the value was (re)written this pass.
+        diag("fitnessAge gate day=$newestDay rhrNights=${faGate7.mapNotNull { it.restingHr }.size} activityDays=${faGate7.mapNotNull { it.strain }.size} computed=${faPts.isNotEmpty()}")
+        if (faPts.isNotEmpty()) repo.upsertMetricSeries(faPts)
 
         // ── Vitality / Body Age (Phase 7) , weekly, keyed to the week's Saturday ──
         // Roll the last 7 days' wearable signals into the mortality-hazard model; VitalityEngine gates on
@@ -1405,6 +1386,53 @@ object IntelligenceEngine {
      * the skin-temp baseline isn't usable yet (< minNightsSeed) , honest cold-start. Rounded to 2 dp
      * to match the imported/demo precision. APPROXIMATE. (PR #85)
      */
+    /** Assess Fitness Age readiness from [gateDays] (the merged last-7 the readiness card counts) and,
+     *  when ready, build the fitness_age (+ optional vo2max) rows keyed to [satKey]. Empty when not ready.
+     *  The SINGLE source of the gate + compute , shared by the recompute pass and the manual "refresh
+     *  Fitness Age" button so the two can never drift. */
+    fun fitnessAgeRows(
+        gateDays: List<DailyMetric>, profile: UserProfile, computedId: String, satKey: String,
+    ): List<MetricSeriesRow> {
+        val rhrs = gateDays.mapNotNull { it.restingHr }.map { it.toDouble() }
+        val strains = gateDays.mapNotNull { it.strain }.filter { it >= 30.0 }
+        val meanStrain = if (strains.isEmpty()) 0.0 else strains.average()
+        val waist = if (profile.waistCm > 0) profile.waistCm else null
+        val ready = FitnessAgeEngine.assessReadiness(
+            hasAge = profile.age > 0, hasSex = profile.sex.isNotEmpty(),
+            rhrDays = rhrs.size, activityDays = gateDays.mapNotNull { it.strain }.size,
+            hasHeightWeight = profile.heightCm > 0 && profile.weightKg > 0, hasWaist = waist != null)
+        if (!ready.canCompute) return emptyList()
+        val res = FitnessAgeEngine.compute(
+            age = profile.age, sex = profile.sex,
+            restingHR = medianOfDoubles(rhrs),
+            paIndex = FitnessAgeEngine.physicalActivityIndexFromStrain(strains.size, meanStrain),
+            waistCm = waist) ?: return emptyList()
+        val rows = mutableListOf(MetricSeriesRow(deviceId = computedId, day = satKey, key = "fitness_age", value = res.fitnessAge))
+        res.vo2max?.let { rows.add(MetricSeriesRow(deviceId = computedId, day = satKey, key = "vo2max_est", value = it)) }
+        return rows
+    }
+
+    /** Manual "refresh Fitness Age" (the button on the not-ready card): recompute the weekly Fitness Age
+     *  NOW from the PERSISTED merged daily history , NO raw-HR rescoring , and upsert it. Uses the same gate
+     *  ([fitnessAgeRows]) and the same date/window logic as the recompute pass, so it reads exactly what the
+     *  readiness card shows. Light + connection-independent (stored data only), so it works even when the
+     *  strap is offline. Returns true if a value was written. */
+    suspend fun recomputeFitnessAgeOnly(
+        repo: WhoopRepository, profile: UserProfile, importedDeviceId: String, maxDays: Int = 21,
+    ): Boolean {
+        val computedId = importedDeviceId + "-noop"
+        val nowSeconds = System.currentTimeMillis() / 1_000L
+        val tzOffsetSeconds = java.util.TimeZone.getDefault().getOffset(nowSeconds * 1_000L) / 1_000L
+        val nowLocalMidnight = midnightLocal(nowSeconds, tzOffsetSeconds)
+        val newestDay = AnalyticsEngine.dayString(nowLocalMidnight, tzOffsetSeconds)
+        val oldestDay = AnalyticsEngine.dayString(nowLocalMidnight - (maxDays - 1) * SECONDS_PER_DAY, tzOffsetSeconds)
+        val gate7 = repo.daysMerged(importedDeviceId)
+            .filter { it.day in oldestDay..newestDay }.sortedBy { it.day }.takeLast(7)
+        val rows = fitnessAgeRows(gate7, profile, computedId, saturdayKeyOnOrBefore(newestDay))
+        if (rows.isNotEmpty()) repo.upsertMetricSeries(rows)
+        return rows.isNotEmpty()
+    }
+
     private fun recomputeSkinTempDev(nightly: Double?, base: BaselineState?): Double? {
         val v = nightly ?: return null
         val b = base?.takeIf { it.usable } ?: return null

--- a/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
+++ b/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
@@ -880,6 +880,14 @@ object IntelligenceEngine {
             }
         }
 
+        // Snapshot the persisted/merged daily history BEFORE the delete+re-upsert below rewrites the
+        // computed window. This is the accumulated view the readiness card + dashboard read ("N of 7
+        // nights"); captured here so the Fitness Age gate (further down) can't be undercut by this pass's
+        // OWN pruning , a recompute only re-scores nights whose raw HR still lives in the store, so reading
+        // after the rewrite would see only the freshly scorable subset. Windowed to the recompute range so
+        // it stays bounded (daysMerged is full-history) and can't drag in stale nights older than the window.
+        val faPriorDaily = repo.daysMerged(importedDeviceId).filter { it.day in oldestDay..newestDay }
+
         repo.deleteComputedDailyInRange(computedId, oldestDay, newestDay)
 
         // Persist the computed scores under the dedicated "-noop" source so the WHOLE
@@ -893,13 +901,16 @@ object IntelligenceEngine {
         val fa7 = dailies.sortedBy { it.day }.takeLast(7)
         val faRHRs = fa7.mapNotNull { it.restingHr }.map { it.toDouble() }
         val faWaist = if (profile.waistCm > 0) profile.waistCm else null
-        // The Fitness Age gate + compute read the PERSISTED/MERGED last-7 days , the SAME history the
-        // readiness card and dashboard show , NOT this pass's freshly scored `dailies`. A recompute only
-        // re-scores nights whose raw HR still lives in the DB, so a nightly wearer whose card reads "7 of 7
-        // nights" could still leave the engine seeing <4 RHR nights on `dailies`, and Fitness Age never
-        // computed (Vitality did , it needs only 3 of ANY input, which is why Body Age showed but Fitness
-        // Age did not). Kept SEPARATE from `fa7` so Vitality (below), which already computes, is untouched.
-        val faGate7 = repo.daysMerged(importedDeviceId).sortedBy { it.day }.takeLast(7)
+        // Gate + compute Fitness Age on the UNION of the pre-rewrite persisted history and THIS pass's
+        // fresh scores (by day, fresh wins) , so an RHR night counts whether it survives in the store OR was
+        // just scored, and whether it sits under this id or a re-added strap's sibling id. The original
+        // (fa7 = dailies) worked while the whole week's raw was always still present; once older raw ages
+        // out, `dailies` alone under-counts vs the card (which reads the merged view) and Fitness Age
+        // silently stops. Kept SEPARATE from `fa7` so Vitality (below), which already computes, is untouched.
+        val faGateByDay = LinkedHashMap<String, DailyMetric>()
+        for (d in faPriorDaily) faGateByDay[d.day] = d
+        for (d in dailies) faGateByDay[d.day] = d
+        val faGate7 = faGateByDay.values.sortedBy { it.day }.takeLast(7)
         val faGateRHRs = faGate7.mapNotNull { it.restingHr }.map { it.toDouble() }
         val faGateStrains = faGate7.mapNotNull { it.strain }.filter { it >= 30.0 }
         val faGateMeanStrain = if (faGateStrains.isEmpty()) 0.0 else faGateStrains.average()

--- a/android/app/src/main/java/com/noop/ui/AppViewModel.kt
+++ b/android/app/src/main/java/com/noop/ui/AppViewModel.kt
@@ -1726,6 +1726,19 @@ class AppViewModel(app: Application) : AndroidViewModel(app) {
      * protocol, so the UI shows an indeterminate indicator + live.syncChunksThisSession, never a percent. */
     fun syncNow() = ble.syncNow()
 
+    /** Force an immediate Fitness Age recompute from stored history , the not-ready card's refresh button.
+     *  Light (no raw-HR rescoring), so it returns fast and works even when the strap is offline. Applies the
+     *  SAME gate as the recompute pass (IntelligenceEngine.fitnessAgeRows). Calls back on the main thread
+     *  with whether a value landed, so the card can re-read + confirm. */
+    fun refreshFitnessAgeNow(onResult: (Boolean) -> Unit) {
+        viewModelScope.launch {
+            val wrote = runCatching {
+                IntelligenceEngine.recomputeFitnessAgeOnly(repository, currentProfile(), deviceId)
+            }.getOrDefault(false)
+            onResult(wrote)
+        }
+    }
+
     // --- Smart alarm (persisted; arms the strap's firmware alarm). Port of macOS BehaviorStore +
     // AppModel.applySmartAlarm. The previous Android UI was a non-persisted mock-up (issue #51).
     // NOTE: the _smartAlarm* state fields are declared ABOVE the init block (next to _illnessWatchEnabled)

--- a/android/app/src/main/java/com/noop/ui/HealthScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/HealthScreen.kt
@@ -577,6 +577,28 @@ private fun ContributorBar(
  *  same convention every screen uses for on-device-computed series (imported is plain "my-whoop"). */
 private const val COMPUTED_SOURCE = "my-whoop-noop"
 
+/** Fitness Age readiness from what a screen can see: RHR coverage over the last 7 merged daily rows
+ *  (drives the "N more nights" countdown), a scored-strain day as the activity signal, and the profile
+ *  basics. Shared by the Health hub's [FitnessAgeSection] and the Today card's [VitalDetailScreen]
+ *  tap-through so ONE gate feeds both surfaces (no drift). Returns (rhrDays, readiness) — rhrDays also
+ *  feeds the not-ready lead. Approximate by design; the weekly value is the authority, this explains gaps. */
+@Composable
+private fun rememberFitnessReadiness(days: List<DailyMetric>, profile: ProfileStore): Pair<Int, FitnessAgeReadiness> {
+    val rhrDays = remember(days) { days.takeLast(7).count { it.restingHr != null } }
+    val readiness = remember(days, profile.age, profile.sex, profile.waistCm) {
+        val activityDays = days.takeLast(7).count { it.strain != null }
+        FitnessAgeEngine.assessReadiness(
+            hasAge = profile.age > 0,
+            hasSex = profile.sex.isNotBlank(),
+            rhrDays = rhrDays,
+            activityDays = activityDays,
+            hasHeightWeight = profile.heightCm > 0 && profile.weightKg > 0,
+            hasWaist = profile.waistCm > 0,
+        )
+    }
+    return rhrDays to readiness
+}
+
 @Composable
 private fun FitnessAgeSection(vm: AppViewModel, days: List<DailyMetric>, profile: ProfileStore) {
     // Latest weekly value + its optional VO₂max companion, read once (metricSeries has no Flow, so we
@@ -598,19 +620,9 @@ private fun FitnessAgeSection(vm: AppViewModel, days: List<DailyMetric>, profile
     // age; activity (a scored strain day) is an enrichment signal; height/weight/waist sit under the
     // VO₂max role. Age/sex come from the profile. Approximate by design — the weekly value is the
     // authority; this just explains the gaps.
-    // rhrDays drives BOTH the readiness verdict AND the not-ready countdown lead, so hoist it out.
-    val rhrDays = remember(days) { days.takeLast(7).count { it.restingHr != null } }
-    val readiness = remember(days, profile.age, profile.sex, profile.waistCm) {
-        val activityDays = days.takeLast(7).count { it.strain != null }
-        FitnessAgeEngine.assessReadiness(
-            hasAge = profile.age > 0,
-            hasSex = profile.sex.isNotBlank(),
-            rhrDays = rhrDays,
-            activityDays = activityDays,
-            hasHeightWeight = profile.heightCm > 0 && profile.weightKg > 0,
-            hasWaist = profile.waistCm > 0,
-        )
-    }
+    // rhrDays drives BOTH the readiness verdict AND the not-ready countdown lead. Shared with the Today
+    // card's tap-through (VitalDetailScreen) via one helper so a single gate feeds both surfaces.
+    val (rhrDays, readiness) = rememberFitnessReadiness(days, profile)
 
     var showChecklist by remember { mutableStateOf(false) }
 
@@ -1860,7 +1872,10 @@ private val SERIES_BACKED_VITAL_KEYS = setOf("fitness_age", "vitality", "steps_e
 @Composable
 fun VitalDetailScreen(vm: AppViewModel, key: String) {
     val days by vm.recentDays.collectAsStateWithLifecycle()
-    val tempUnit = UnitPrefs.temperature(LocalContext.current)
+    val context = LocalContext.current
+    val tempUnit = UnitPrefs.temperature(context)
+    // Profile drives the Fitness Age readiness/countdown shown when that vital has no value yet.
+    val profile = remember { ProfileStore.from(context.applicationContext) }
     val isSeriesBacked = key in SERIES_BACKED_VITAL_KEYS
 
     // Series-backed metrics are loaded async from metricSeries; the plain daily vitals build synchronously
@@ -1878,9 +1893,13 @@ fun VitalDetailScreen(vm: AppViewModel, key: String) {
     else remember(days, key, tempUnit) { buildVitalDetail(days, key, tempUnit) }
     var range by remember { mutableStateOf(VitalDetailRange.MONTH) }
 
+    // When Fitness Age has no value yet we show the readiness countdown, not a trend — so the subtitle
+    // reflects that instead of promising a "historical trend" the card isn't about.
+    val fitnessNotReady = key == "fitness_age" && seriesLoaded && (detail?.points?.isEmpty() != false)
     ScreenScaffold(
         title = detail?.title ?: "Vital Signs",
-        subtitle = "Historical trend from cached daily metrics.",
+        subtitle = if (fitnessNotReady) "What your Fitness Age still needs."
+        else "Historical trend from cached daily metrics.",
     ) {
         if (isSeriesBacked && !seriesLoaded) {
             DataPendingNote(
@@ -1890,6 +1909,19 @@ fun VitalDetailScreen(vm: AppViewModel, key: String) {
             return@ScreenScaffold
         }
         if (detail == null || detail.points.size < 2) {
+            // Fitness Age with NO weekly value yet (zero points): show the readiness checklist + the
+            // "N more nights of wear" countdown — what it actually needs — instead of the generic
+            // "needs two readings to chart" note, which describes the trend line and left the Today
+            // card's tap-through a dead end. A single reading (size 1) keeps the generic note: the value
+            // already shows on the card, only the trend needs a second weekly point.
+            if (key == "fitness_age" && (detail?.points?.isEmpty() != false)) {
+                val (rhrDays, readiness) = rememberFitnessReadiness(days, profile)
+                FitnessReadinessCard(
+                    readiness = readiness, headed = true,
+                    lead = fitnessReadyLead(rhrDays, profile.age > 0, profile.sex.isNotBlank()),
+                )
+                return@ScreenScaffold
+            }
             DataPendingNote(
                 title = "Not enough history yet",
                 body = "This vital needs at least two historical readings before NOOP can chart it.",

--- a/android/app/src/main/java/com/noop/ui/HealthScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/HealthScreen.kt
@@ -21,8 +21,12 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.CompareArrows
 import androidx.compose.material.icons.filled.ChevronRight
 import androidx.compose.material.icons.automirrored.filled.MenuBook
+import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material.icons.filled.Sync
+import android.widget.Toast
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
@@ -601,11 +605,16 @@ private fun rememberFitnessReadiness(days: List<DailyMetric>, profile: ProfileSt
 
 @Composable
 private fun FitnessAgeSection(vm: AppViewModel, days: List<DailyMetric>, profile: ProfileStore) {
+    val context = LocalContext.current
     // Latest weekly value + its optional VO₂max companion, read once (metricSeries has no Flow, so we
     // re-read whenever the merged history changes — a fresh sync/import is what moves these).
     var fitnessAge by remember { mutableStateOf<Double?>(null) }
     var vo2max by remember { mutableStateOf<Double?>(null) }
-    LaunchedEffect(days) {
+    // Manual-refresh plumbing: the not-ready card's refresh button recomputes Fitness Age NOW and bumps
+    // this tick, which re-keys the read below so a freshly written value shows without waiting for a sync.
+    var refreshTick by remember { mutableStateOf(0) }
+    var refreshing by remember { mutableStateOf(false) }
+    LaunchedEffect(days, refreshTick) {
         val fa = runCatching {
             vm.repo.metricSeries(COMPUTED_SOURCE, "fitness_age", "0000-01-01", "9999-12-31")
         }.getOrDefault(emptyList()).lastOrNull()?.value
@@ -641,9 +650,26 @@ private fun FitnessAgeSection(vm: AppViewModel, days: List<DailyMetric>, profile
                 FitnessReadinessCard(readiness = readiness, headed = false)
             }
         } else {
-            // No weekly value yet — lead with a concrete countdown, then the checklist.
-            FitnessReadinessCard(readiness = readiness, headed = true,
-                lead = fitnessReadyLead(rhrDays, profile.age > 0, profile.sex.isNotBlank()))
+            // No weekly value yet — lead with a concrete countdown, then the checklist. The refresh button
+            // forces the weekly recompute now (from stored data), so a ready user doesn't have to wait.
+            FitnessReadinessCard(
+                readiness = readiness, headed = true,
+                lead = fitnessReadyLead(rhrDays, profile.age > 0, profile.sex.isNotBlank()),
+                refreshing = refreshing,
+                onRefresh = {
+                    refreshing = true
+                    vm.refreshFitnessAgeNow { wrote ->
+                        refreshing = false
+                        refreshTick++
+                        Toast.makeText(
+                            context,
+                            if (wrote) "Fitness Age updated."
+                            else "Not enough wear yet — keep your strap on overnight.",
+                            Toast.LENGTH_SHORT,
+                        ).show()
+                    }
+                },
+            )
         }
     }
 }
@@ -930,7 +956,15 @@ private fun fitnessReadyLead(rhrDays: Int, hasAge: Boolean, hasSex: Boolean): St
  *  "Drives your Fitness Age" and "Unlocks your VO₂max". When [headed] (no value yet) it leads with the
  *  [lead] countdown and floats the required-missing items to the top of their group. */
 @Composable
-private fun FitnessReadinessCard(readiness: FitnessAgeReadiness, headed: Boolean, lead: String = "") {
+private fun FitnessReadinessCard(
+    readiness: FitnessAgeReadiness,
+    headed: Boolean,
+    lead: String = "",
+    // When set (the headed/not-ready state), a small refresh affordance sits by the lead and forces an
+    // immediate Fitness Age recompute; [refreshing] swaps it for a spinner while that runs.
+    onRefresh: (() -> Unit)? = null,
+    refreshing: Boolean = false,
+) {
     val drivesAge = readiness.items
         .filter { it.role == FitnessReadinessRole.DRIVES_AGE }
         .sortedBy { if (headed) readinessSortKey(it) else 0 }
@@ -942,11 +976,33 @@ private fun FitnessReadinessCard(readiness: FitnessAgeReadiness, headed: Boolean
         Column(verticalArrangement = Arrangement.spacedBy(Metrics.space16)) {
             if (headed) {
                 Column(verticalArrangement = Arrangement.spacedBy(Metrics.space4)) {
-                    Text(
-                        lead.ifBlank { "A few more days and we can show your Fitness Age." },
-                        style = NoopType.headline,
-                        color = Palette.textPrimary,
-                    )
+                    Row(verticalAlignment = Alignment.Top) {
+                        Text(
+                            lead.ifBlank { "A few more days and we can show your Fitness Age." },
+                            style = NoopType.headline,
+                            color = Palette.textPrimary,
+                            modifier = Modifier.weight(1f),
+                        )
+                        // Force-recompute affordance: NOOP scores Fitness Age weekly, so this lets an
+                        // impatient user apply it NOW from stored data (no strap needed). Spinner while it runs.
+                        if (onRefresh != null) {
+                            if (refreshing) {
+                                CircularProgressIndicator(
+                                    modifier = Modifier.size(20.dp),
+                                    strokeWidth = 2.dp,
+                                    color = Palette.accent,
+                                )
+                            } else {
+                                IconButton(onClick = onRefresh, modifier = Modifier.size(28.dp)) {
+                                    Icon(
+                                        Icons.Filled.Refresh,
+                                        contentDescription = "Refresh Fitness Age now",
+                                        tint = Palette.accent,
+                                    )
+                                }
+                            }
+                        }
+                    }
                     Text(
                         "It compares your resting heart rate and recent activity against people your age. " +
                             "Wear your strap for a full week and it appears here.",
@@ -1883,8 +1939,12 @@ fun VitalDetailScreen(vm: AppViewModel, key: String) {
     // "not enough history" before its rows arrive.
     var seriesDetail by remember(key) { mutableStateOf<VitalDetailModel?>(null) }
     var seriesLoaded by remember(key) { mutableStateOf(false) }
+    // Manual-refresh plumbing for the Fitness Age not-ready state (readiness branch below): the refresh
+    // button recomputes then bumps this tick, re-running the series read so a fresh value shows at once.
+    var refreshTick by remember { mutableStateOf(0) }
+    var refreshing by remember { mutableStateOf(false) }
     if (isSeriesBacked) {
-        LaunchedEffect(key) {
+        LaunchedEffect(key, refreshTick) {
             seriesDetail = buildSeriesVitalDetail(vm, key)
             seriesLoaded = true
         }
@@ -1919,6 +1979,20 @@ fun VitalDetailScreen(vm: AppViewModel, key: String) {
                 FitnessReadinessCard(
                     readiness = readiness, headed = true,
                     lead = fitnessReadyLead(rhrDays, profile.age > 0, profile.sex.isNotBlank()),
+                    refreshing = refreshing,
+                    onRefresh = {
+                        refreshing = true
+                        vm.refreshFitnessAgeNow { wrote ->
+                            refreshing = false
+                            refreshTick++
+                            Toast.makeText(
+                                context,
+                                if (wrote) "Fitness Age updated."
+                                else "Not enough wear yet — keep your strap on overnight.",
+                                Toast.LENGTH_SHORT,
+                            ).show()
+                        }
+                    },
                 )
                 return@ScreenScaffold
             }


### PR DESCRIPTION
## What

A small **refresh** button on the Fitness Age *not-ready* card that forces an immediate recompute — so a ready user doesn't wait for the weekly pass.

NOOP writes Fitness Age only during the intelligence recompute (a 15-min backstop gated by an HR-fingerprint watermark), so the value can lag. This button recomputes Fitness Age **now, from the persisted merged daily history** — no raw-HR rescoring — so it:
- returns in a second or two and **works offline** (stored data only);
- reads **exactly what the readiness card shows** (same merged history);
- **sidesteps the recompute's own delete/rewrite timing**, so it lands the value even in the case where the auto-pass #140 fix might be a no-op.

## How

**Shared gate (no drift):** extracted #140's gate + compute into `IntelligenceEngine.fitnessAgeRows(...)`, used by **both** the recompute pass and the new `recomputeFitnessAgeOnly(...)`.

**Android:** `AppViewModel.refreshFitnessAgeNow` → a `Refresh` `IconButton` (spinner while running) on `FitnessReadinessCard`, wired on the Health hub (`FitnessAgeSection`) and the Today-card tap-through (`VitalDetailScreen`); re-reads the value on completion + a Toast.

**iOS:** engine parity (`fitnessAgeRows` / `recomputeFitnessAgeOnly`); an `arrow.clockwise` button on `ReadinessChecklistCard` (HealthView) and the `fitness_age` empty state (`MetricDetailView`), via the app-wide `IntelligenceEngine` environment object (preview injections added).

## Notes
- **Stacked PR:** this branch includes **#139** (readiness surfaces) and **#140** (gate fix) since the button builds on both. Merge those first, or merge this alone to bring all three. (Squash-merge: verify the button + gate reached main afterwards.)
- Minor UX asymmetry after a refresh writes the *first* reading: iOS `MetricDetailView` shows the value hero; Android `VitalDetailScreen` (a trend view) shows "not enough history to chart" until a 2nd weekly reading — the Toast + the Health-hub hero carry the confirmation either way.

## Verification
- Android `:app:compileFullDebugKotlin` passes locally.
- iOS hand-reviewed (Compression/Charts wall): reuses the engine's own date/window helpers + static `medianOf`/`saturdayKey`; profile passed to the shared helper as primitives (no cross-actor read); required `@EnvironmentObject IntelligenceEngine` is app-wide injected with both direct previews updated.
