### PR TITLE
HRV mode: trace the nightly path (per-window RMSSD by sleep stage) (#141)

### DIFF
--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/AnalyticsEngine.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/AnalyticsEngine.swift
@@ -325,7 +325,12 @@ public enum AnalyticsEngine {
                                   // Sleep & Rest test-mode trace sink (zero-cost default nil = byte-identical).
                                   // When non-nil, the gate trace from detectSleep and the Rest sub-score line
                                   // are forwarded line-by-line. Side-effect-only; never alters the DayResult.
-                                  traceSink: ((String) -> Void)? = nil) -> DayResult {
+                                  traceSink: ((String) -> Void)? = nil,
+                                  // HRV & Autonomic test-mode sink (#141). nil = byte-identical default. When
+                                  // non-nil, the nightly per-5-min-window RMSSDs (tagged by sleep stage) + a
+                                  // whole-night vs deep-only vs last-SWS summary are forwarded so an "HRV reads
+                                  // ~2x higher than WHOOP" report shows WHICH stages lift it.
+                                  hrvTraceSink: ((String) -> Void)? = nil) -> DayResult {
 
         // Precompute the day's UTC bounds ONCE (#996). `dayString(ts, offsetSec:)` formats the UTC
         // calendar day of (ts + offset) with a FIXED offset, so "== day" is exactly membership in
@@ -455,6 +460,33 @@ public enum AnalyticsEngine {
             let weight = pairs.reduce(0.0) { $0 + $1.1 }
             return weight > 0 ? total / weight : nil
         }()
+
+        // ── HRV & Autonomic nightly trace (#141) ──────────────────────────────
+        // Per-5-min-window RMSSD tagged by the sleep stage at its center, then a night summary comparing
+        // NOOP's whole-night mean (what it reports) against a deep-only mean and a WHOOP-style
+        // last-slow-wave-sleep value — so an "HRV reads ~2x higher than WHOOP" report shows WHICH stages
+        // lift it, and lets a deep-sleep-windowed fix be validated before it ships. Reuses the SAME
+        // sessionHrvWindows the value is built from (can't diverge). Zero cost when the sink is nil.
+        if let hrvTraceSink {
+            func r2(_ x: Double) -> Double { (x * 100).rounded() / 100 }
+            var allWin: [SleepStager.HrvWindow] = []
+            for s in matched {
+                let wins = SleepStager.sessionHrvWindows(start: s.start, end: s.end, rr: rr, stages: s.stages)
+                for w in wins {
+                    let rm = w.rmssd.map { "\(r2($0))ms" } ?? "nil"
+                    hrvTraceSink("hrv window t=\((w.startTs - s.start) / 60)min stage=\(w.stage) beats=\(w.cleanBeats) rmssd=\(rm)")
+                }
+                allWin.append(contentsOf: wins)
+            }
+            func meanMs(_ ws: [SleepStager.HrvWindow]) -> String {
+                let v = ws.compactMap { $0.rmssd }
+                return v.isEmpty ? "nil" : "\(r2(v.reduce(0, +) / Double(v.count)))ms"
+            }
+            let withR = allWin.filter { $0.rmssd != nil }
+            let deepW = withR.filter { $0.stage == "deep" }
+            let lastSws = SleepStager.lastDeepRun(allWin).filter { $0.rmssd != nil }
+            hrvTraceSink("hrv nightSummary wholeNight=\(meanMs(withR)) deepOnly=\(meanMs(deepW)) lastSWS=\(meanMs(lastSws)) nWin=\(withR.count) nDeep=\(deepW.count)")
+        }
 
         // Nightly APPROXIMATE respiratory rate (breaths/min) from the R-R stream via
         // RSA. WHOOP5 v18 carries no raw resp ADC, so this is an on-device estimate,

--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/AnalyticsEngine.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/AnalyticsEngine.swift
@@ -485,7 +485,11 @@ public enum AnalyticsEngine {
             let withR = allWin.filter { $0.rmssd != nil }
             let deepW = withR.filter { $0.stage == "deep" }
             let lastSws = SleepStager.lastDeepRun(allWin).filter { $0.rmssd != nil }
-            hrvTraceSink("hrv nightSummary wholeNight=\(meanMs(withR)) deepOnly=\(meanMs(deepW)) lastSWS=\(meanMs(lastSws)) nWin=\(withR.count) nDeep=\(deepW.count)")
+            // `reported` is the value NOOP actually displays (duration-weighted session-mean-of-means);
+            // `wholeNight` is the pooled-window mean it equals on single-session nights and the apples-to-
+            // apples baseline for the deepOnly/lastSWS comparison (all three are pooled window means).
+            let reported = avgHRVDaily.map { "\(r2($0))ms" } ?? "nil"
+            hrvTraceSink("hrv nightSummary reported=\(reported) wholeNight=\(meanMs(withR)) deepOnly=\(meanMs(deepW)) lastSWS=\(meanMs(lastSws)) nWin=\(withR.count) nDeep=\(deepW.count)")
         }
 
         // Nightly APPROXIMATE respiratory rate (breaths/min) from the R-R stream via

--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/AnalyticsEngine.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/AnalyticsEngine.swift
@@ -469,9 +469,12 @@ public enum AnalyticsEngine {
         // sessionHrvWindows the value is built from (can't diverge). Zero cost when the sink is nil.
         if let hrvTraceSink {
             func r2(_ x: Double) -> Double { (x * 100).rounded() / 100 }
+            // sessionHrvWindows requires ts-sorted rr (RMSSD = successive diffs); the value path passes the
+            // stager's pre-sorted rrS, so sort our own copy of the day's raw rr once here for the re-window.
+            let rrSorted = rr.sorted { $0.ts < $1.ts }
             var allWin: [SleepStager.HrvWindow] = []
             for s in matched {
-                let wins = SleepStager.sessionHrvWindows(start: s.start, end: s.end, rr: rr, stages: s.stages)
+                let wins = SleepStager.sessionHrvWindows(start: s.start, end: s.end, rr: rrSorted, stages: s.stages)
                 for w in wins {
                     let rm = w.rmssd.map { "\(r2($0))ms" } ?? "nil"
                     hrvTraceSink("hrv window t=\((w.startTs - s.start) / 60)min stage=\(w.stage) beats=\(w.cleanBeats) rmssd=\(rm)")

--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/AnalyticsEngine.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/AnalyticsEngine.swift
@@ -330,7 +330,12 @@ public enum AnalyticsEngine {
                                   // non-nil, the nightly per-5-min-window RMSSDs (tagged by sleep stage) + a
                                   // whole-night vs deep-only vs last-SWS summary are forwarded so an "HRV reads
                                   // ~2x higher than WHOOP" report shows WHICH stages lift it.
-                                  hrvTraceSink: ((String) -> Void)? = nil) -> DayResult {
+                                  hrvTraceSink: ((String) -> Void)? = nil,
+                                  // Whether to emit the ~90 per-window `hrv window …` lines (vs just the 1-line
+                                  // summary). The caller sets it TRUE only for the most-recent night so the
+                                  // 5000-line ring buffer isn't flooded (21 nights × ~90 windows would evict the
+                                  // always-on diagnostics); the 1-line `hrv nightSummary` is kept for EVERY night.
+                                  hrvWindowDetail: Bool = false) -> DayResult {
 
         // Precompute the day's UTC bounds ONCE (#996). `dayString(ts, offsetSec:)` formats the UTC
         // calendar day of (ts + offset) with a FIXED offset, so "== day" is exactly membership in
@@ -475,9 +480,11 @@ public enum AnalyticsEngine {
             var allWin: [SleepStager.HrvWindow] = []
             for s in matched {
                 let wins = SleepStager.sessionHrvWindows(start: s.start, end: s.end, rr: rrSorted, stages: s.stages)
-                for w in wins {
-                    let rm = w.rmssd.map { "\(r2($0))ms" } ?? "nil"
-                    hrvTraceSink("hrv window t=\((w.startTs - s.start) / 60)min stage=\(w.stage) beats=\(w.cleanBeats) rmssd=\(rm)")
+                if hrvWindowDetail {
+                    for w in wins {
+                        let rm = w.rmssd.map { "\(r2($0))ms" } ?? "nil"
+                        hrvTraceSink("hrv window t=\((w.startTs - s.start) / 60)min stage=\(w.stage) beats=\(w.cleanBeats) rmssd=\(rm)")
+                    }
                 }
                 allWin.append(contentsOf: wins)
             }

--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/CaptureCompleteness.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/CaptureCompleteness.swift
@@ -71,7 +71,7 @@ public enum CaptureCompleteness {
         .steps:      ["stepsRaw", "stepsCal"],
         .battery:    ["bank soc=", "socSeries"],
         .recovery:   ["charge term", "charge score=", "charge nilScore"],
-        .hrv:        ["hrv rmssd=", "hrv result="],
+        .hrv:        ["hrv rmssd=", "hrv result=", "hrv nightSummary"],
         .universal:  ["dayOwner ", "strapClock "],
     ]
 

--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/SleepStager.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/SleepStager.swift
@@ -1900,13 +1900,30 @@ public enum SleepStager {
         return Int(all.rounded())
     }
 
+    /// One 5-min HRV window: its start ts, the sleep stage at its center, the clean-beat count, and the
+    /// window RMSSD (nil when <2 clean beats). Drives both `sessionAvgHRV` and the HRV test-mode trace. (#141)
+    public struct HrvWindow: Sendable {
+        public let startTs: Int
+        public let stage: String
+        public let cleanBeats: Int
+        public let rmssd: Double?
+    }
+
     /// Mean RMSSD over 5-min tumbling windows across the session (ms), or nil.
     /// Uses the same range-filter + ≥2-valid-interval rule as hrv.rmssd().
     static func sessionAvgHRV(start: Int, end: Int, rr: [RRInterval]) -> Double? {
+        let vals = sessionHrvWindows(start: start, end: end, rr: rr, stages: []).compactMap { $0.rmssd }
+        return vals.isEmpty ? nil : vals.reduce(0, +) / Double(vals.count)
+    }
+
+    /// Per-5-min-window RMSSD across a session, each window tagged with the sleep stage at its CENTER
+    /// (from `stages`) — the SINGLE source `sessionAvgHRV` averages, and the HRV nightly trace reads.
+    /// Passing `[]` for `stages` tags every window "?" (the plain-average path needs no stages). (#141)
+    static func sessionHrvWindows(start: Int, end: Int, rr: [RRInterval], stages: [StageSegment]) -> [HrvWindow] {
         let seg = rr.filter { $0.ts >= start && $0.ts <= end }
-        guard !seg.isEmpty else { return nil }
+        guard !seg.isEmpty else { return [] }
         let windowS = 5 * 60
-        var vals: [Double] = []
+        var out: [HrvWindow] = []
         var t = start
         while t < end {
             let bucket = seg.filter { $0.ts >= t && $0.ts < t + windowS }.map { Double($0.rrMs) }
@@ -1915,11 +1932,25 @@ public enum SleepStager {
             // than a 4.0's; rMSSD is built from SUCCESSIVE differences, so an un-rejected
             // jitter spike inflates the session HRV. Ectopic rejection drops those (#262/#235).
             let cleaned = HRVAnalyzer.cleanRR(bucket)
-            if cleaned.count >= 2, let r = HRVAnalyzer.rmssdRaw(cleaned) { vals.append(r) }
+            let rmssd: Double? = (cleaned.count >= 2) ? HRVAnalyzer.rmssdRaw(cleaned) : nil
+            let center = t + windowS / 2
+            let stage = stages.first { center >= $0.start && center < $0.end }?.stage ?? "?"
+            out.append(HrvWindow(startTs: t, stage: stage, cleanBeats: cleaned.count, rmssd: rmssd))
             t += windowS
         }
-        guard !vals.isEmpty else { return nil }
-        return vals.reduce(0, +) / Double(vals.count)
+        return out
+    }
+
+    /// The LAST contiguous run of deep-stage windows in `windows` — the WHOOP-style "last slow-wave-sleep"
+    /// comparator for the HRV nightly trace. Empty when no deep window is present. (#141)
+    static func lastDeepRun(_ windows: [HrvWindow]) -> [HrvWindow] {
+        var lastRun: [HrvWindow] = []
+        var cur: [HrvWindow] = []
+        for w in windows {
+            if w.stage == "deep" { cur.append(w) } else if !cur.isEmpty { lastRun = cur; cur.removeAll() }
+        }
+        if !cur.isEmpty { lastRun = cur }
+        return lastRun
     }
 
     // MARK: - AASM hypnogram metrics

--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/SleepStager.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/SleepStager.swift
@@ -1920,6 +1920,10 @@ public enum SleepStager {
     /// (from `stages`) — the SINGLE source `sessionAvgHRV` averages, and the HRV nightly trace reads.
     /// Passing `[]` for `stages` tags every window "?" (the plain-average path needs no stages). (#141)
     static func sessionHrvWindows(start: Int, end: Int, rr: [RRInterval], stages: [StageSegment]) -> [HrvWindow] {
+        // CONTRACT: `rr` MUST already be ts-sorted (RMSSD is built from SUCCESSIVE differences, so a bucket
+        // has to be chronological). The value path passes the loop's pre-sorted `rrS`; the trace caller sorts
+        // its own copy. Not sorted here on purpose — re-sorting the value path could reorder same-second RR
+        // under Swift's unstable sort and shift the shipped avgHrv. Same contract the original sessionAvgHRV had.
         let seg = rr.filter { $0.ts >= start && $0.ts <= end }
         guard !seg.isEmpty else { return [] }
         let windowS = 5 * 60

--- a/Strand/Data/IntelligenceEngine.swift
+++ b/Strand/Data/IntelligenceEngine.swift
@@ -111,6 +111,10 @@ final class IntelligenceEngine: ObservableObject {
         /// Empty unless the Steps mode is active (the gate is read once before the loop), so the default path
         /// is byte-identical: the trace recomputes the SAME wrap-aware sum analyzeDay already computed.
         let stepsTrace: [String]
+        /// HRV test-mode nightly trace lines (per-5-min-window RMSSD by sleep stage + the whole-night vs
+        /// deep-only vs last-SWS summary) for this day, collected off the main actor and replayed tagged
+        /// `.hrv` in per-day order. Empty unless the HRV mode is active. (#141)
+        let hrvTrace: [String]
     }
 
     struct Computed: Identifiable {
@@ -477,6 +481,10 @@ final class IntelligenceEngine: ObservableObject {
         // runs its byte-identical default path. When true, each day collects its gate-trace + Rest line,
         // replayed below through `diagnosticSink` tagged `.sleep` in per-day order.
         let sleepTraceActive = TestCentre.active(.sleep)
+        // HRV & Autonomic test mode (#141): read the zero-cost gate ONCE. When true, each day collects the
+        // nightly per-window RMSSD (by stage) + the whole-night/deep-only/last-SWS summary, replayed below
+        // tagged `.hrv`. When false (the default), no HRV trace is built and analyzeDay's path is unchanged.
+        let hrvTraceActive = TestCentre.active(.hrv)
         // Steps test mode: read the zero-cost gate ONCE here (a single Bool) and capture it into the detached
         // loop. When false (the default), no raw-counter trace is built per day. When true, each day collects
         // the 5/MG cumulative @57 series + wrap-aware deltas + dropped deltas, replayed below tagged `.steps`.
@@ -606,6 +614,9 @@ final class IntelligenceEngine: ObservableObject {
                 // built ONLY when the mode is active. nil otherwise = analyzeDay's byte-identical default path.
                 var sleepTrace: [String] = []
                 let traceSink: ((String) -> Void)? = sleepTraceActive ? { sleepTrace.append($0) } : nil
+                // HRV mode (#141): a per-day collector for the nightly per-window RMSSD + summary; nil = default.
+                var hrvTrace: [String] = []
+                let hrvTraceSink: ((String) -> Void)? = hrvTraceActive ? { hrvTrace.append($0) } : nil
                 let res = AnalyticsEngine.analyzeDay(day: day, hr: hr, rr: rr, resp: resp, gravity: grav,
                                                      steps: steps, dayHr: dayHr, daySteps: daySteps,
                                                      dayGravity: dayGrav,
@@ -619,7 +630,8 @@ final class IntelligenceEngine: ObservableObject {
                                                      // #690: thread the V2 toggle into the NORMAL staging path so
                                                      // it affects detected nights, not just the self-heal restage.
                                                      useSleepStagerV2: useSleepStagerV2,
-                                                     traceSink: traceSink)
+                                                     traceSink: traceSink,
+                                                     hrvTraceSink: hrvTraceSink)
                 // ── Steps test mode: 5/MG raw-counter trace ──────────────────────────────────────────────
                 // Only built when the Steps mode is on (the gate was read once before the loop). Recomputes
                 // the SAME wrap-aware @57 sum analyzeDay just ran, over the SAME `daySteps` calendar-day
@@ -657,7 +669,7 @@ final class IntelligenceEngine: ObservableObject {
                 }
                 out.append(DayScan(result: res, rhrLine: rhrLine,
                                    readOwner: owner, hrRows: hr.count,
-                                   sleepTrace: sleepTrace, stepsTrace: stepsTrace))
+                                   sleepTrace: sleepTrace, stepsTrace: stepsTrace, hrvTrace: hrvTrace))
             }
             return out
         }.value
@@ -683,6 +695,9 @@ final class IntelligenceEngine: ObservableObject {
             // Sleep & Rest test mode (E5): replay this day's gate-trace + Rest lines tagged `.sleep` so they
             // land under the profile tag in the export. Empty unless the mode is active.
             for line in scan.sleepTrace { diagnosticSink?(line, .sleep) }
+            // HRV test mode (#141): replay this day's nightly per-window RMSSD + summary tagged `.hrv`.
+            // Empty unless the HRV mode is active, so the default path emits zero `.hrv` lines here.
+            for line in scan.hrvTrace { diagnosticSink?(line, .hrv) }
             // Steps test mode: replay this day's 5/MG raw-counter trace tagged `.steps`. Empty unless the
             // mode is active, so the default path emits zero `.steps` lines here.
             for line in scan.stepsTrace { diagnosticSink?(line, .steps) }

--- a/Strand/Data/IntelligenceEngine.swift
+++ b/Strand/Data/IntelligenceEngine.swift
@@ -631,7 +631,11 @@ final class IntelligenceEngine: ObservableObject {
                                                      // it affects detected nights, not just the self-heal restage.
                                                      useSleepStagerV2: useSleepStagerV2,
                                                      traceSink: traceSink,
-                                                     hrvTraceSink: hrvTraceSink)
+                                                     hrvTraceSink: hrvTraceSink,
+                                                     // Per-window HRV detail ONLY for the most-recent night
+                                                     // (dayStart == today's local midnight), so the 5000-line
+                                                     // ring buffer isn't flooded; every night keeps the summary.
+                                                     hrvWindowDetail: dayStart == nowLocalMidnight)
                 // ── Steps test mode: 5/MG raw-counter trace ──────────────────────────────────────────────
                 // Only built when the Steps mode is on (the gate was read once before the loop). Recomputes
                 // the SAME wrap-aware @57 sum analyzeDay just ran, over the SAME `daySteps` calendar-day

--- a/android/app/src/main/java/com/noop/analytics/AnalyticsEngine.kt
+++ b/android/app/src/main/java/com/noop/analytics/AnalyticsEngine.kt
@@ -216,6 +216,10 @@ object AnalyticsEngine {
         // Sleep & Rest test-mode trace sink (E11). null = byte-identical default. When non-null the gate
         // trace from detectSleep and the Rest sub-score line are forwarded line-by-line. Mirrors Swift.
         traceSink: ((String) -> Unit)? = null,
+        // HRV & Autonomic test-mode sink (#141). null = byte-identical default. When non-null, the nightly
+        // per-5-min-window RMSSDs (tagged by sleep stage) + a whole-night vs deep-only vs last-SWS summary
+        // are forwarded so an "HRV reads ~2x higher than WHOOP" report shows WHICH stages lift it.
+        hrvTraceSink: ((String) -> Unit)? = null,
     ): DayResult {
 
         // ── Sleep detection + staging ─────────────────────────────────────────
@@ -310,6 +314,37 @@ object AnalyticsEngine {
                 val weight = pairs.sumOf { it.second }
                 if (weight > 0) total / weight else null
             }
+        }
+
+        // ── HRV & Autonomic nightly trace (#141) ──────────────────────────────
+        // Per-5-min-window RMSSD tagged by the sleep stage at its center, then a night summary comparing
+        // NOOP's whole-night mean (what it reports) against a deep-only mean and a WHOOP-style
+        // last-slow-wave-sleep value — so an "HRV reads ~2x higher than WHOOP" report shows WHICH stages
+        // lift it, and lets a deep-sleep-windowed fix be validated before it ships. Reuses the SAME
+        // sessionHrvWindows the value is built from (can't diverge). Zero cost when the sink is null.
+        if (hrvTraceSink != null) {
+            val allWin = ArrayList<SleepStager.HrvWindow>()
+            for (s in matched) {
+                val wins = SleepStager.sessionHrvWindows(s.start, s.end, rr, s.stages)
+                for (w in wins) {
+                    hrvTraceSink(
+                        "hrv window t=${(w.startTs - s.start) / 60}min stage=${w.stage} " +
+                            "beats=${w.cleanBeats} rmssd=${w.rmssd?.let { round2(it) } ?: "nil"}ms",
+                    )
+                }
+                allWin.addAll(wins)
+            }
+            fun meanMs(ws: List<SleepStager.HrvWindow>): String {
+                val v = ws.mapNotNull { it.rmssd }
+                return if (v.isEmpty()) "nil" else "${round2(v.sum() / v.size)}ms"
+            }
+            val withR = allWin.filter { it.rmssd != null }
+            val deepW = withR.filter { it.stage == "deep" }
+            val lastSws = SleepStager.lastDeepRun(allWin).filter { it.rmssd != null }
+            hrvTraceSink(
+                "hrv nightSummary wholeNight=${meanMs(withR)} deepOnly=${meanMs(deepW)} " +
+                    "lastSWS=${meanMs(lastSws)} nWin=${withR.size} nDeep=${deepW.size}",
+            )
         }
 
         // Nightly APPROXIMATE respiratory rate (breaths/min) from the R-R stream via

--- a/android/app/src/main/java/com/noop/analytics/AnalyticsEngine.kt
+++ b/android/app/src/main/java/com/noop/analytics/AnalyticsEngine.kt
@@ -329,7 +329,7 @@ object AnalyticsEngine {
                 for (w in wins) {
                     hrvTraceSink(
                         "hrv window t=${(w.startTs - s.start) / 60}min stage=${w.stage} " +
-                            "beats=${w.cleanBeats} rmssd=${w.rmssd?.let { round2(it) } ?: "nil"}ms",
+                            "beats=${w.cleanBeats} rmssd=${w.rmssd?.let { "${round2(it)}ms" } ?: "nil"}",
                     )
                 }
                 allWin.addAll(wins)
@@ -341,8 +341,12 @@ object AnalyticsEngine {
             val withR = allWin.filter { it.rmssd != null }
             val deepW = withR.filter { it.stage == "deep" }
             val lastSws = SleepStager.lastDeepRun(allWin).filter { it.rmssd != null }
+            // `reported` is the value NOOP actually displays (duration-weighted session-mean-of-means);
+            // `wholeNight` is the pooled-window mean it equals on single-session nights and the apples-to-
+            // apples baseline for the deepOnly/lastSWS comparison (all three are pooled window means).
             hrvTraceSink(
-                "hrv nightSummary wholeNight=${meanMs(withR)} deepOnly=${meanMs(deepW)} " +
+                "hrv nightSummary reported=${avgHRVDaily?.let { "${round2(it)}ms" } ?: "nil"} " +
+                    "wholeNight=${meanMs(withR)} deepOnly=${meanMs(deepW)} " +
                     "lastSWS=${meanMs(lastSws)} nWin=${withR.size} nDeep=${deepW.size}",
             )
         }

--- a/android/app/src/main/java/com/noop/analytics/AnalyticsEngine.kt
+++ b/android/app/src/main/java/com/noop/analytics/AnalyticsEngine.kt
@@ -323,9 +323,12 @@ object AnalyticsEngine {
         // lift it, and lets a deep-sleep-windowed fix be validated before it ships. Reuses the SAME
         // sessionHrvWindows the value is built from (can't diverge). Zero cost when the sink is null.
         if (hrvTraceSink != null) {
+            // sessionHrvWindows requires ts-sorted rr (RMSSD = successive diffs); the value path passes the
+            // stager's pre-sorted rrS, so sort our own copy of the day's raw rr once here for the re-window.
+            val rrSorted = rr.sortedBy { it.ts }
             val allWin = ArrayList<SleepStager.HrvWindow>()
             for (s in matched) {
-                val wins = SleepStager.sessionHrvWindows(s.start, s.end, rr, s.stages)
+                val wins = SleepStager.sessionHrvWindows(s.start, s.end, rrSorted, s.stages)
                 for (w in wins) {
                     hrvTraceSink(
                         "hrv window t=${(w.startTs - s.start) / 60}min stage=${w.stage} " +

--- a/android/app/src/main/java/com/noop/analytics/AnalyticsEngine.kt
+++ b/android/app/src/main/java/com/noop/analytics/AnalyticsEngine.kt
@@ -220,6 +220,11 @@ object AnalyticsEngine {
         // per-5-min-window RMSSDs (tagged by sleep stage) + a whole-night vs deep-only vs last-SWS summary
         // are forwarded so an "HRV reads ~2x higher than WHOOP" report shows WHICH stages lift it.
         hrvTraceSink: ((String) -> Unit)? = null,
+        // Whether to emit the ~90 per-window `hrv window …` lines (vs just the 1-line summary). The caller
+        // sets it TRUE only for the most-recent night so the 5000-line ring buffer isn't flooded (21 nights ×
+        // ~90 windows would evict the always-on diagnostics); the 1-line `hrv nightSummary` is kept for EVERY
+        // night so the whole-night-vs-deep pattern is still visible across the week.
+        hrvWindowDetail: Boolean = false,
     ): DayResult {
 
         // ── Sleep detection + staging ─────────────────────────────────────────
@@ -329,11 +334,13 @@ object AnalyticsEngine {
             val allWin = ArrayList<SleepStager.HrvWindow>()
             for (s in matched) {
                 val wins = SleepStager.sessionHrvWindows(s.start, s.end, rrSorted, s.stages)
-                for (w in wins) {
-                    hrvTraceSink(
-                        "hrv window t=${(w.startTs - s.start) / 60}min stage=${w.stage} " +
-                            "beats=${w.cleanBeats} rmssd=${w.rmssd?.let { "${round2(it)}ms" } ?: "nil"}",
-                    )
+                if (hrvWindowDetail) {
+                    for (w in wins) {
+                        hrvTraceSink(
+                            "hrv window t=${(w.startTs - s.start) / 60}min stage=${w.stage} " +
+                                "beats=${w.cleanBeats} rmssd=${w.rmssd?.let { "${round2(it)}ms" } ?: "nil"}",
+                        )
+                    }
                 }
                 allWin.addAll(wins)
             }

--- a/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
+++ b/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
@@ -204,6 +204,11 @@ object IntelligenceEngine {
         // detected-bout persist/drop decision to the .workouts-tagged strap log. null (the default) =
         // byte-identical default path (no lines). Mirrors the Swift workoutsTraceActive wiring.
         workoutsTraceSink: ((String) -> Unit)? = null,
+        // HRV & Autonomic test-mode sink (#141). Context-free layer, so the caller reads TestCentre.active(HRV)
+        // and passes a non-null sink ONLY when the mode is on, routing the nightly per-5-min-window RMSSD (by
+        // sleep stage) + the whole-night/deep-only/last-SWS summary to the .hrv-tagged strap log. null (the
+        // default) = byte-identical default path (no lines). Mirrors the Swift hrvTraceActive wiring.
+        hrvTraceSink: ((String) -> Unit)? = null,
     ): List<Computed> = withContext(Dispatchers.Default) {
         // Serialise the whole pass so overlapping callers never run two rescores in parallel (see
         // [analyzeGate]). The heavy scoring already ran off the caller's thread via withContext above; the
@@ -212,7 +217,7 @@ object IntelligenceEngine {
             val (out, healed) = analyzeRecentOnCpu(repo, profile, maxDays, importedDeviceId, maxHROverride,
                 nowSeconds, ownerSource, manualStepCoefficient, persistStepsCalibration, baselineEpoch,
                 recoveryEpoch, diag, useExperimentalSleepV2, sleepTraceSink, recoveryTraceSink, stepsTraceSink,
-                universalSink, workoutsTraceSink)
+                universalSink, workoutsTraceSink, hrvTraceSink)
             if (healed == 0) out
             // #899 heal re-pass: the pass above deleted overlapping duplicate sleep sessions AFTER its days
             // were scored, and the read-side dedup those days consumed had no bank-recency witness (the fresh
@@ -222,7 +227,7 @@ object IntelligenceEngine {
             else analyzeRecentOnCpu(repo, profile, maxDays, importedDeviceId, maxHROverride,
                 nowSeconds, ownerSource, manualStepCoefficient, persistStepsCalibration, baselineEpoch,
                 recoveryEpoch, diag, useExperimentalSleepV2, sleepTraceSink, recoveryTraceSink, stepsTraceSink,
-                universalSink, workoutsTraceSink).first
+                universalSink, workoutsTraceSink, hrvTraceSink).first
         }
     }
 
@@ -303,6 +308,10 @@ object IntelligenceEngine {
         // each detected bout emits a `detectedBout verdict=persisted|droppedOverlap …` line to the .workouts-
         // tagged strap log, so an "auto workout appeared then vanished" is explainable from an export. Swift twin.
         workoutsTraceSink: ((String) -> Unit)? = null,
+        // HRV & Autonomic test-mode sink (#141). null = byte-identical default (no lines); when non-null,
+        // analyzeDay forwards the nightly per-window RMSSD (by stage) + the whole-night/deep-only/last-SWS
+        // summary to the .hrv-tagged strap log. Swift twin.
+        hrvTraceSink: ((String) -> Unit)? = null,
         // #899 heal re-pass: the second component of the return is how many overlapping duplicate sleep
         // sessions the heal below deleted this pass. The public wrapper re-runs ONCE when it is non-zero
         // so the affected days re-score against the cleaned store.
@@ -522,6 +531,7 @@ object IntelligenceEngine {
                 // sink (mode on), detectSleep's gate trace + the Rest sub-score line route to the .sleep-tagged
                 // strap log. The sink is already the routing closure, so there is no per-day collect/replay.
                 traceSink = sleepTraceSink,
+                hrvTraceSink = hrvTraceSink,
             )
 
             // Steps test mode: emit the 5/MG raw-counter trace for this day (cumulative @57 series +

--- a/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
+++ b/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
@@ -532,6 +532,9 @@ object IntelligenceEngine {
                 // strap log. The sink is already the routing closure, so there is no per-day collect/replay.
                 traceSink = sleepTraceSink,
                 hrvTraceSink = hrvTraceSink,
+                // Per-window HRV detail ONLY for the most-recent night (dayStart == today's local midnight),
+                // so the 5000-line ring buffer isn't flooded; every night still emits the 1-line summary.
+                hrvWindowDetail = dayStart == nowLocalMidnight,
             )
 
             // Steps test mode: emit the 5/MG raw-counter trace for this day (cumulative @57 series +

--- a/android/app/src/main/java/com/noop/analytics/SleepStager.kt
+++ b/android/app/src/main/java/com/noop/analytics/SleepStager.kt
@@ -2139,15 +2139,31 @@ object SleepStager {
         return all.roundToInt()
     }
 
+    /** One 5-min HRV window: its start ts, the sleep stage at its center, the clean-beat count, and the
+     *  window RMSSD (null when <2 clean beats). Drives both [sessionAvgHRV] and the HRV test-mode trace. */
+    data class HrvWindow(val startTs: Long, val stage: String, val cleanBeats: Int, val rmssd: Double?)
+
     /**
      * Mean RMSSD over 5-min tumbling windows across the session (ms), or null.
      * Uses the same range-filter + ≥2-valid-interval rule as hrv.rmssd().
      */
     internal fun sessionAvgHRV(start: Long, end: Long, rr: List<RrInterval>): Double? {
+        val vals = sessionHrvWindows(start, end, rr, emptyList()).mapNotNull { it.rmssd }
+        return if (vals.isEmpty()) null else vals.sum() / vals.size.toDouble()
+    }
+
+    /**
+     * Per-5-min-window RMSSD across a session, each window tagged with the sleep stage at its CENTER (from
+     * [stages]) — the SINGLE source [sessionAvgHRV] averages, and the HRV test-mode nightly trace reads.
+     * Passing `emptyList()` for [stages] tags every window "?" (the plain-average path doesn't need stages).
+     */
+    internal fun sessionHrvWindows(
+        start: Long, end: Long, rr: List<RrInterval>, stages: List<StageSegment>,
+    ): List<HrvWindow> {
         val seg = rr.filter { it.ts in start..end }
-        if (seg.isEmpty()) return null
+        if (seg.isEmpty()) return emptyList()
         val windowS = 5 * 60L
-        val vals = ArrayList<Double>()
+        val out = ArrayList<HrvWindow>()
         var t = start
         while (t < end) {
             val bucket = seg.filter { it.ts >= t && it.ts < t + windowS }.map { it.rrMs.toDouble() }
@@ -2156,14 +2172,29 @@ object SleepStager {
             // than a 4.0's; rMSSD is built from SUCCESSIVE differences, so an un-rejected
             // jitter spike inflates the session HRV. Ectopic rejection drops those (#262/#235).
             val cleaned = HrvAnalyzer.cleanRR(bucket)
-            if (cleaned.size >= 2) {
-                val r = HrvAnalyzer.rmssdRaw(cleaned)
-                if (r != null) vals.add(r)
-            }
+            val rmssd = if (cleaned.size >= 2) HrvAnalyzer.rmssdRaw(cleaned) else null
+            val center = t + windowS / 2
+            val stage = stages.firstOrNull { center >= it.start && center < it.end }?.stage ?: "?"
+            out.add(HrvWindow(startTs = t, stage = stage, cleanBeats = cleaned.size, rmssd = rmssd))
             t += windowS
         }
-        if (vals.isEmpty()) return null
-        return vals.sum() / vals.size.toDouble()
+        return out
+    }
+
+    /** The LAST contiguous run of deep-stage windows in [windows] — the WHOOP-style "last slow-wave-sleep"
+     *  comparator for the HRV nightly trace. Empty when no deep window is present. */
+    internal fun lastDeepRun(windows: List<HrvWindow>): List<HrvWindow> {
+        var lastRun: List<HrvWindow> = emptyList()
+        val cur = ArrayList<HrvWindow>()
+        for (w in windows) {
+            if (w.stage == "deep") {
+                cur.add(w)
+            } else if (cur.isNotEmpty()) {
+                lastRun = ArrayList(cur); cur.clear()
+            }
+        }
+        if (cur.isNotEmpty()) lastRun = cur
+        return lastRun
     }
 
     // ── AASM hypnogram metrics ───────────────────────────────────────────────

--- a/android/app/src/main/java/com/noop/analytics/SleepStager.kt
+++ b/android/app/src/main/java/com/noop/analytics/SleepStager.kt
@@ -2160,6 +2160,10 @@ object SleepStager {
     internal fun sessionHrvWindows(
         start: Long, end: Long, rr: List<RrInterval>, stages: List<StageSegment>,
     ): List<HrvWindow> {
+        // CONTRACT: `rr` MUST already be ts-sorted (RMSSD is built from SUCCESSIVE differences, so a bucket
+        // has to be chronological). The value path passes the loop's pre-sorted `rrS`; the trace caller sorts
+        // its own copy. Not sorted here on purpose — re-sorting the value path could reorder same-second RR
+        // under an unstable sort and shift the shipped avgHrv. Same contract the original sessionAvgHRV had.
         val seg = rr.filter { it.ts in start..end }
         if (seg.isEmpty()) return emptyList()
         val windowS = 5 * 60L

--- a/android/app/src/main/java/com/noop/testcentre/ReportCompleteness.kt
+++ b/android/app/src/main/java/com/noop/testcentre/ReportCompleteness.kt
@@ -67,6 +67,10 @@ object ReportCompleteness {
      */
     val evidenceTokens: Map<TestDomain, String> = linkedMapOf(
         TestDomain.SLEEP to "sleep day=",
+        // #141: the NIGHTLY HRV trace proves the HRV mode captured, even when the user never took a manual
+        // (spot) reading — `hrv rmssd=` only fires on the Live-screen snapshot, but the overnight per-window
+        // trace emits `hrv nightSummary …`. So a wear-overnight-and-export HRV capture reads complete.
+        TestDomain.HRV to "hrv nightSummary",
     )
 
     /** Per-domain presence map for [reportText], over [checkedDomains]. PRESENT iff the killer token OR the

--- a/android/app/src/main/java/com/noop/ui/AppViewModel.kt
+++ b/android/app/src/main/java/com/noop/ui/AppViewModel.kt
@@ -816,6 +816,14 @@ class AppViewModel(app: Application) : AndroidViewModel(app) {
                                     .active(com.noop.testcentre.TestDomain.WORKOUTS))
                                 { line -> ble.externalLog(line, com.noop.testcentre.TestDomain.WORKOUTS) }
                             else null,
+                        // HRV & Autonomic test mode (#141): when on, route the nightly per-window RMSSD (by
+                        // sleep stage) + the whole-night/deep-only/last-SWS summary to the .hrv-tagged strap
+                        // log, so an "HRV reads high vs WHOOP" report shows which stages lift the average.
+                        hrvTraceSink =
+                            if (com.noop.testcentre.TestCentre.from(appContext)
+                                    .active(com.noop.testcentre.TestDomain.HRV))
+                                { line -> ble.externalLog(line, com.noop.testcentre.TestDomain.HRV) }
+                            else null,
                     )
                     // analyzeRecent now hops to Dispatchers.Default; a scope cancellation surfaces as a
                     // CancellationException that runCatching would otherwise swallow, breaking the loop's


### PR DESCRIPTION
## Why (#141)

A user reports NOOP's nightly HRV reads **~2× higher than WHOOP/Polar/Suunto** (45–60 vs 20–35 for a 66yo) from the *same* WHOOP 4.0 R‑R — because NOOP averages RMSSD over the **whole night** (`SleepStager.sessionAvgHRV`, all stages) while WHOOP samples the **last slow‑wave‑sleep** window.

But we **couldn't prove which stages lift it**: the HRV test mode only traced the manual **spot** reading (`HrvSnapshotScreen → analyzeTrace`). The nightly value emitted **nothing** — no per‑window RMSSD, no stage tags. So the recommended "instrument first, then tune" couldn't happen.

## What this adds

When **HRV & Autonomic** mode is on, the nightly path now logs to the `.hrv` strap log:

- **Per 5‑min window:** `hrv window t=<min> stage=<deep/light/rem/wake> beats=<n> rmssd=<r>ms`
- **Night summary:** `hrv nightSummary wholeNight=<x> deepOnly=<y> lastSWS=<z> nWin=<n> nDeep=<m>` — NOOP's whole‑night mean **vs** a deep‑only mean **vs** a WHOOP‑style last‑SWS value, side by side.

That single trace: confirms the diagnosis on the reporter's real nights, shows *which* stages inflate the average, and becomes the **validation harness** for a deep‑sleep‑windowed fix (PR 2) — you can watch the candidate value land near WHOOP's 20–35 before shipping.

## How

- **Single source (can't drift):** extracted `SleepStager.sessionHrvWindows(...)` (per‑window RMSSD + stage tag); `sessionAvgHRV` now just averages its non‑nil RMSSDs, so the trace reflects the *exact* computation.
- Threaded an `hrvTraceSink` alongside the existing sleep/steps/recovery sinks (`analyzeRecent → analyzeDay`), gated on `TestDomain.HRV`. **Zero cost when off** (nil sink → byte‑identical default path).
- Capture check accepts the nightly `hrv nightSummary` token, so **wear‑overnight‑and‑export** reads complete without a manual spot reading.
- **No scoring change** — purely additive diagnostics.

## Verification
- Android `:app:compileFullDebugKotlin` passes locally.
- iOS mirrored (SleepStager / AnalyticsEngine / IntelligenceEngine / CaptureCompleteness twins) and hand‑reviewed; will be confirmed by the staging CI iOS job.

## Next
- **PR 2:** deep‑sleep‑windowed `sessionAvgHRV` (behind a setting), validated against this trace on the reporter's export.
