### PR TITLE
HRV: add a "Deep sleep" window option (WHOOP-comparable) (#141)

### DIFF
--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/AnalyticsEngine.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/AnalyticsEngine.swift
@@ -460,19 +460,20 @@ public enum AnalyticsEngine {
         // Daily resting HR = lowest per-session resting HR across matched sessions.
         let restingHRDaily = matched.compactMap { $0.restingHR }.min()
         // Daily avg HRV = in-bed-weighted mean of per-session avg HRV.
-        let avgHRVDaily: Double? = deepHrvWindow ? {
-            // #141: WHOOP-style HRV — pool RMSSD over DEEP-stage 5-min windows only (slow-wave sleep),
-            // instead of the whole-night mean. Reuses the SAME sessionHrvWindows the HRV trace is built from,
-            // so the displayed value equals the `deepOnly` figure the trace logs. rr sorted (RMSSD =
-            // successive diffs). nil when no deep sleep detected (WHOOP-4.0 staging can be sparse) — the
-            // caller shows calibrating, never a fabricated number.
-            let rrSorted = rr.sorted { $0.ts < $1.ts }
-            let deep = matched.flatMap { s in
-                SleepStager.sessionHrvWindows(start: s.start, end: s.end, rr: rrSorted, stages: s.stages)
-                    .filter { $0.stage == "deep" }.compactMap { $0.rmssd }
+        let avgHRVDaily: Double? = {
+            if deepHrvWindow {
+                // #141: WHOOP-style HRV — pool RMSSD over DEEP-stage 5-min windows only (slow-wave sleep),
+                // instead of the whole-night mean. Reuses the SAME sessionHrvWindows the HRV trace is built
+                // from, so the displayed value equals the `deepOnly` figure the trace logs. rr sorted (RMSSD
+                // = successive diffs). nil when no deep sleep is detected (WHOOP-4.0 staging can be sparse) —
+                // the caller shows calibrating, never a fabricated number.
+                let rrSorted = rr.sorted { $0.ts < $1.ts }
+                let deep = matched.flatMap { s in
+                    SleepStager.sessionHrvWindows(start: s.start, end: s.end, rr: rrSorted, stages: s.stages)
+                        .filter { $0.stage == "deep" }.compactMap { $0.rmssd }
+                }
+                return deep.isEmpty ? nil : deep.reduce(0, +) / Double(deep.count)
             }
-            return deep.isEmpty ? nil : deep.reduce(0, +) / Double(deep.count)
-        }() : {
             let pairs = matched.compactMap { s -> (Double, Double)? in
                 s.avgHRV.map { ($0, Double(s.end - s.start)) }
             }

--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/AnalyticsEngine.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/AnalyticsEngine.swift
@@ -335,7 +335,11 @@ public enum AnalyticsEngine {
                                   // summary). The caller sets it TRUE only for the most-recent night so the
                                   // 5000-line ring buffer isn't flooded (21 nights × ~90 windows would evict the
                                   // always-on diagnostics); the 1-line `hrv nightSummary` is kept for EVERY night.
-                                  hrvWindowDetail: Bool = false) -> DayResult {
+                                  hrvWindowDetail: Bool = false,
+                                  // #141: when true, the nightly HRV is RMSSD over DEEP-sleep windows only
+                                  // (WHOOP-style), instead of the whole-night mean. Threaded from the caller
+                                  // (UnitPrefs.hrvWindowKey). Default false = byte-identical whole-night value.
+                                  deepHrvWindow: Bool = false) -> DayResult {
 
         // Precompute the day's UTC bounds ONCE (#996). `dayString(ts, offsetSec:)` formats the UTC
         // calendar day of (ts + offset) with a FIXED offset, so "== day" is exactly membership in
@@ -456,7 +460,19 @@ public enum AnalyticsEngine {
         // Daily resting HR = lowest per-session resting HR across matched sessions.
         let restingHRDaily = matched.compactMap { $0.restingHR }.min()
         // Daily avg HRV = in-bed-weighted mean of per-session avg HRV.
-        let avgHRVDaily: Double? = {
+        let avgHRVDaily: Double? = deepHrvWindow ? {
+            // #141: WHOOP-style HRV — pool RMSSD over DEEP-stage 5-min windows only (slow-wave sleep),
+            // instead of the whole-night mean. Reuses the SAME sessionHrvWindows the HRV trace is built from,
+            // so the displayed value equals the `deepOnly` figure the trace logs. rr sorted (RMSSD =
+            // successive diffs). nil when no deep sleep detected (WHOOP-4.0 staging can be sparse) — the
+            // caller shows calibrating, never a fabricated number.
+            let rrSorted = rr.sorted { $0.ts < $1.ts }
+            let deep = matched.flatMap { s in
+                SleepStager.sessionHrvWindows(start: s.start, end: s.end, rr: rrSorted, stages: s.stages)
+                    .filter { $0.stage == "deep" }.compactMap { $0.rmssd }
+            }
+            return deep.isEmpty ? nil : deep.reduce(0, +) / Double(deep.count)
+        }() : {
             let pairs = matched.compactMap { s -> (Double, Double)? in
                 s.avgHRV.map { ($0, Double(s.end - s.start)) }
             }

--- a/Strand/Data/IntelligenceEngine.swift
+++ b/Strand/Data/IntelligenceEngine.swift
@@ -485,6 +485,9 @@ final class IntelligenceEngine: ObservableObject {
         // nightly per-window RMSSD (by stage) + the whole-night/deep-only/last-SWS summary, replayed below
         // tagged `.hrv`. When false (the default), no HRV trace is built and analyzeDay's path is unchanged.
         let hrvTraceActive = TestCentre.active(.hrv)
+        // HRV window (#141): read ONCE. When the user picked WHOOP-style, the nightly HRV is RMSSD over deep
+        // sleep only; default whole-night otherwise. Captured into the detached loop, threaded to analyzeDay.
+        let deepHrvWindow = UserDefaults.standard.string(forKey: UnitPrefs.hrvWindowKey) == HrvWindow.deep.rawValue
         // Steps test mode: read the zero-cost gate ONCE here (a single Bool) and capture it into the detached
         // loop. When false (the default), no raw-counter trace is built per day. When true, each day collects
         // the 5/MG cumulative @57 series + wrap-aware deltas + dropped deltas, replayed below tagged `.steps`.
@@ -635,7 +638,8 @@ final class IntelligenceEngine: ObservableObject {
                                                      // Per-window HRV detail ONLY for the most-recent night
                                                      // (dayStart == today's local midnight), so the 5000-line
                                                      // ring buffer isn't flooded; every night keeps the summary.
-                                                     hrvWindowDetail: dayStart == nowLocalMidnight)
+                                                     hrvWindowDetail: dayStart == nowLocalMidnight,
+                                                     deepHrvWindow: deepHrvWindow)
                 // ── Steps test mode: 5/MG raw-counter trace ──────────────────────────────────────────────
                 // Only built when the Steps mode is on (the gate was read once before the loop). Recomputes
                 // the SAME wrap-aware @57 sum analyzeDay just ran, over the SAME `daySteps` calendar-day

--- a/Strand/Data/Units.swift
+++ b/Strand/Data/Units.swift
@@ -54,6 +54,20 @@ enum TrendChartStyle: String, CaseIterable, Identifiable {
     var label: String { self == .bar ? "Bars" : "Line" }
 }
 
+/// Which sleep window the nightly HRV is measured over (#141). NOOP historically averages RMSSD across the
+/// WHOLE night (every stage); WHOOP/Polar/etc. sample the last slow-wave-sleep window, which reads lower.
+/// This lets a user match that. It CHANGES the computed avgHrv (NOT display-only), so a switch re-scores +
+/// re-baselines. Default is the historical whole-night value. Mirrored on Android by NoopPrefs("hrv.window").
+enum HrvWindow: String, CaseIterable, Identifiable {
+    /// RMSSD averaged over every 5-min window of the night (NOOP's long-standing value).
+    case whole
+    /// RMSSD over DEEP (slow-wave) sleep windows only — comparable to WHOOP's reading.
+    case deep
+    var id: String { rawValue }
+    /// Segmented-control label.
+    var label: String { self == .deep ? "Deep sleep" : "Whole night" }
+}
+
 /// UserDefaults keys for the two unit preferences. Public-ish (internal) so `SettingsView`'s
 /// `@AppStorage(UnitPrefs.systemKey)` and the formatter read the SAME key — no drift.
 enum UnitPrefs {
@@ -68,6 +82,11 @@ enum UnitPrefs {
     /// value resolves to `.line` (the classic look). Display-only — the plotted data never changes.
     /// Mirrored on Android by NoopPrefs("trend.chart.style").
     static let trendChartStyleKey = "trend.chart.style"
+
+    /// Nightly-HRV window (#141). Stored raw is an `HrvWindow` rawValue; unset/unknown resolves to `.whole`
+    /// (the historical whole-night value). NOT display-only — it changes the computed avgHrv, so the engine
+    /// reads it and a Settings switch re-scores. Mirrored on Android by NoopPrefs("hrv.window").
+    static let hrvWindowKey = "hrv.window"
 
     /// Display factor for the #268 Effort scale: the stored 0-100 value multiplied by this renders on
     /// the user's chosen axis (1.0 for the native 0-100, 0.21 for the WHOOP-style 0-21). Display-only,

--- a/Strand/Screens/SettingsView.swift
+++ b/Strand/Screens/SettingsView.swift
@@ -66,6 +66,7 @@ struct SettingsView: View {
     // it's shown on NOOP's 0–100 axis or WHOOP's 0–21 Day Strain axis.
     @AppStorage(UnitPrefs.effortScaleKey) private var effortScaleRaw = EffortScale.hundred.rawValue
     @AppStorage(UnitPrefs.trendChartStyleKey) private var trendChartStyleRaw = TrendChartStyle.line.rawValue
+    @AppStorage(UnitPrefs.hrvWindowKey) private var hrvWindowRaw = HrvWindow.whole.rawValue
     // Live-HR Live Activity (Lock Screen + Dynamic Island), iOS only (#336). Default on.
     @AppStorage(UnitPrefs.liveActivityKey) private var liveActivityEnabled = true
     // Alternate app icon (iOS only) — false = Titanium (primary AppIcon), true = Blue Titanium
@@ -629,6 +630,25 @@ struct SettingsView: View {
                     .pickerStyle(.segmented)
                     .fixedSize()
                     .accessibilityLabel("Effort scale")
+                }
+                rowDivider
+                // HRV window (#141) — measure nightly HRV over the whole night (NOOP's long-standing value)
+                // or DEEP sleep only (WHOOP-style, reads lower and more comparable to WHOOP/Polar). Unlike the
+                // Effort scale this CHANGES the number, so a switch re-scores + re-baselines (like a sleep edit).
+                FormRow(label: "HRV window") {
+                    Picker("HRV window", selection: $hrvWindowRaw) {
+                        Text("Whole night").tag(HrvWindow.whole.rawValue)
+                        Text("Deep sleep").tag(HrvWindow.deep.rawValue)
+                    }
+                    .labelsHidden()
+                    .pickerStyle(.segmented)
+                    .fixedSize()
+                    .accessibilityLabel("HRV window")
+                    .onChangeCompat(of: hrvWindowRaw) { _ in
+                        // The engine reads UnitPrefs.hrvWindowKey each pass; re-score + refresh so the change
+                        // is reflected without a relaunch (same path as a sleep edit). History is kept.
+                        Task { await model.intelligence.analyzeRecent(); await model.repo.refresh() }
+                    }
                 }
             }
         }

--- a/Strand/Screens/SettingsView.swift
+++ b/Strand/Screens/SettingsView.swift
@@ -645,8 +645,12 @@ struct SettingsView: View {
                     .fixedSize()
                     .accessibilityLabel("HRV window")
                     .onChangeCompat(of: hrvWindowRaw) { _ in
-                        // The engine reads UnitPrefs.hrvWindowKey each pass; re-score + refresh so the change
-                        // is reflected without a relaunch (same path as a sleep edit). History is kept.
+                        // The new window shifts every night's avgHrv, so the HRV BASELINE must re-learn or
+                        // recovery would compare the new value against a baseline still folded from the old
+                        // window (the EWMA spans further than the ~21 nights that re-score → skewed for weeks).
+                        // Re-anchor the HRV baseline to now (HRV-only sibling of "Recalibrate Charge baseline"),
+                        // then re-score + refresh so the recent trend + fresh baseline both reflect the window.
+                        UserDefaults.standard.set(Date().timeIntervalSince1970, forKey: Baselines.hrvBaselineEpochKey)
                         Task { await model.intelligence.analyzeRecent(); await model.repo.refresh() }
                     }
                 }

--- a/android/app/src/main/java/com/noop/analytics/AnalyticsEngine.kt
+++ b/android/app/src/main/java/com/noop/analytics/AnalyticsEngine.kt
@@ -225,6 +225,10 @@ object AnalyticsEngine {
         // ~90 windows would evict the always-on diagnostics); the 1-line `hrv nightSummary` is kept for EVERY
         // night so the whole-night-vs-deep pattern is still visible across the week.
         hrvWindowDetail: Boolean = false,
+        // #141: when true, the nightly HRV is RMSSD over DEEP-sleep windows only (WHOOP-style), instead of
+        // the whole-night mean. Display-only preference threaded from the caller (UnitPrefs.hrvWindow). The
+        // default (false) is byte-identical to the historical whole-night value.
+        deepHrvWindow: Boolean = false,
     ): DayResult {
 
         // ── Sleep detection + staging ─────────────────────────────────────────
@@ -308,7 +312,19 @@ object AnalyticsEngine {
         // Daily resting HR = lowest per-session resting HR across matched sessions.
         val restingHRDaily: Int? = matched.mapNotNull { it.restingHR }.minOrNull()
         // Daily avg HRV = in-bed-weighted mean of per-session avg HRV.
-        val avgHRVDaily: Double? = run {
+        val avgHRVDaily: Double? = if (deepHrvWindow) {
+            // #141: WHOOP-style HRV — pool RMSSD over DEEP-stage 5-min windows only (slow-wave sleep),
+            // instead of the whole-night mean below. Reuses the SAME sessionHrvWindows the HRV trace is
+            // built from, so the displayed value equals the `deepOnly` figure the trace logs. rr is sorted
+            // (RMSSD = successive diffs). null when the night has no detected deep sleep (WHOOP-4.0 staging
+            // can be sparse) — the caller then shows calibrating, never a fabricated number.
+            val rrSorted = rr.sortedBy { it.ts }
+            val deep = matched.flatMap { s ->
+                SleepStager.sessionHrvWindows(s.start, s.end, rrSorted, s.stages)
+                    .filter { it.stage == "deep" }.mapNotNull { it.rmssd }
+            }
+            if (deep.isEmpty()) null else deep.sum() / deep.size
+        } else run {
             val pairs = matched.mapNotNull { s ->
                 s.avgHRV?.let { it to (s.end - s.start).toDouble() }
             }

--- a/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
+++ b/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
@@ -209,6 +209,9 @@ object IntelligenceEngine {
         // sleep stage) + the whole-night/deep-only/last-SWS summary to the .hrv-tagged strap log. null (the
         // default) = byte-identical default path (no lines). Mirrors the Swift hrvTraceActive wiring.
         hrvTraceSink: ((String) -> Unit)? = null,
+        // #141: nightly HRV over DEEP-sleep windows only (WHOOP-style) when true; whole-night mean (the
+        // historical default) when false. The Context-aware caller reads UnitPrefs.hrvWindow and passes it.
+        deepHrvWindow: Boolean = false,
     ): List<Computed> = withContext(Dispatchers.Default) {
         // Serialise the whole pass so overlapping callers never run two rescores in parallel (see
         // [analyzeGate]). The heavy scoring already ran off the caller's thread via withContext above; the
@@ -217,7 +220,7 @@ object IntelligenceEngine {
             val (out, healed) = analyzeRecentOnCpu(repo, profile, maxDays, importedDeviceId, maxHROverride,
                 nowSeconds, ownerSource, manualStepCoefficient, persistStepsCalibration, baselineEpoch,
                 recoveryEpoch, diag, useExperimentalSleepV2, sleepTraceSink, recoveryTraceSink, stepsTraceSink,
-                universalSink, workoutsTraceSink, hrvTraceSink)
+                universalSink, workoutsTraceSink, hrvTraceSink, deepHrvWindow)
             if (healed == 0) out
             // #899 heal re-pass: the pass above deleted overlapping duplicate sleep sessions AFTER its days
             // were scored, and the read-side dedup those days consumed had no bank-recency witness (the fresh
@@ -227,7 +230,7 @@ object IntelligenceEngine {
             else analyzeRecentOnCpu(repo, profile, maxDays, importedDeviceId, maxHROverride,
                 nowSeconds, ownerSource, manualStepCoefficient, persistStepsCalibration, baselineEpoch,
                 recoveryEpoch, diag, useExperimentalSleepV2, sleepTraceSink, recoveryTraceSink, stepsTraceSink,
-                universalSink, workoutsTraceSink, hrvTraceSink).first
+                universalSink, workoutsTraceSink, hrvTraceSink, deepHrvWindow).first
         }
     }
 
@@ -312,6 +315,9 @@ object IntelligenceEngine {
         // analyzeDay forwards the nightly per-window RMSSD (by stage) + the whole-night/deep-only/last-SWS
         // summary to the .hrv-tagged strap log. Swift twin.
         hrvTraceSink: ((String) -> Unit)? = null,
+        // #141: nightly HRV over DEEP-sleep windows only (WHOOP-style) when true; whole-night default when
+        // false. Threaded into analyzeDay per scored night.
+        deepHrvWindow: Boolean = false,
         // #899 heal re-pass: the second component of the return is how many overlapping duplicate sleep
         // sessions the heal below deleted this pass. The public wrapper re-runs ONCE when it is non-zero
         // so the affected days re-score against the cleaned store.
@@ -535,6 +541,7 @@ object IntelligenceEngine {
                 // Per-window HRV detail ONLY for the most-recent night (dayStart == today's local midnight),
                 // so the 5000-line ring buffer isn't flooded; every night still emits the 1-line summary.
                 hrvWindowDetail = dayStart == nowLocalMidnight,
+                deepHrvWindow = deepHrvWindow,
             )
 
             // Steps test mode: emit the 5/MG raw-counter trace for this day (cumulative @57 series +

--- a/android/app/src/main/java/com/noop/ui/AppViewModel.kt
+++ b/android/app/src/main/java/com/noop/ui/AppViewModel.kt
@@ -824,6 +824,8 @@ class AppViewModel(app: Application) : AndroidViewModel(app) {
                                     .active(com.noop.testcentre.TestDomain.HRV))
                                 { line -> ble.externalLog(line, com.noop.testcentre.TestDomain.HRV) }
                             else null,
+                        // #141: nightly HRV over deep-sleep windows only when the user picked WHOOP-style.
+                        deepHrvWindow = UnitPrefs.hrvWindow(appContext) == HrvWindow.DEEP_SLEEP,
                     )
                     // analyzeRecent now hops to Dispatchers.Default; a scope cancellation surfaces as a
                     // CancellationException that runCatching would otherwise swallow, breaking the loop's

--- a/android/app/src/main/java/com/noop/ui/SettingsScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/SettingsScreen.kt
@@ -907,14 +907,20 @@ fun SettingsScreen(
                         onSelect = {
                             hrvWindow = it
                             UnitPrefs.setHrvWindow(context, it)
-                            // Force the next analyze pass to re-score history under the new window (the value
-                            // + its baseline both move); clearing the watermark bypasses the unchanged-stream
-                            // skip, and syncNow nudges it now rather than at the next 15-min tick.
+                            // The new window shifts every night's avgHrv, so the HRV BASELINE must re-learn or
+                            // recovery would compare the new value against a baseline still folded from the old
+                            // window (only the recent ~21 nights re-score, but the baseline EWMA spans further —
+                            // it would read skewed for weeks). Re-anchor the HRV baseline to now (same key +
+                            // mechanism as "Recalibrate Charge baseline"), then force a re-score so the recent
+                            // trend + the fresh baseline both reflect the new window. A few nights to settle.
+                            NoopPrefs.of(context).edit()
+                                .putLong(Baselines.hrvBaselineEpochKey, System.currentTimeMillis() / 1000L)
+                                .apply()
                             NoopPrefs.setAnalyzeWatermark(context, "")
                             vm.syncNow()
                             Toast.makeText(
                                 context,
-                                "Re-scoring your HRV over the ${if (it == HrvWindow.DEEP_SLEEP) "deep-sleep" else "whole-night"} window. It settles over the next few nights.",
+                                "Re-learning your HRV over the ${if (it == HrvWindow.DEEP_SLEEP) "deep-sleep" else "whole-night"} window. Charge recalibrates over the next few nights.",
                                 Toast.LENGTH_LONG,
                             ).show()
                         },

--- a/android/app/src/main/java/com/noop/ui/SettingsScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/SettingsScreen.kt
@@ -467,6 +467,9 @@ fun SettingsScreen(
     // Trend charts (Line / Bar) — flips the Trends tab between the gradient line and value-ramp bars.
     // Display-only; SharedPreferences isn't reactive, so mirror into local state and persist on select.
     var trendChartStyle by remember { mutableStateOf(UnitPrefs.trendChartStyle(context)) }
+    // HRV window (#141) — whole-night vs deep-sleep (WHOOP-style). NOT display-only: it changes the computed
+    // avgHrv, so a switch clears the analyze watermark to force a re-score + re-baseline on the next pass.
+    var hrvWindow by remember { mutableStateOf(UnitPrefs.hrvWindow(context)) }
     // Day-cycle background (#698) — the time-of-day scene behind Today. Default ON. SharedPreferences
     // isn't reactive, so the Switch mirrors into local state; TodayScreen reads the same pref on entry.
     var showDayCycleBackground by remember { mutableStateOf(NoopPrefs.showDayCycleBackground(context)) }
@@ -889,6 +892,31 @@ fun SettingsScreen(
                         onSelect = {
                             effortScale = it
                             UnitPrefs.setEffortScale(context, it)
+                        },
+                    )
+                }
+                RowDivider()
+                // HRV window (#141) — measure nightly HRV over the whole night (NOOP's long-standing value)
+                // or DEEP sleep only (WHOOP-style, reads lower and more comparable to WHOOP/Polar). Unlike the
+                // Effort scale this CHANGES the number, so a switch forces a re-score + re-baseline.
+                FormRow(label = "HRV window") {
+                    SegmentedPillControl(
+                        items = listOf(HrvWindow.WHOLE_NIGHT, HrvWindow.DEEP_SLEEP),
+                        selection = hrvWindow,
+                        label = { if (it == HrvWindow.DEEP_SLEEP) "Deep sleep" else "Whole night" },
+                        onSelect = {
+                            hrvWindow = it
+                            UnitPrefs.setHrvWindow(context, it)
+                            // Force the next analyze pass to re-score history under the new window (the value
+                            // + its baseline both move); clearing the watermark bypasses the unchanged-stream
+                            // skip, and syncNow nudges it now rather than at the next 15-min tick.
+                            NoopPrefs.setAnalyzeWatermark(context, "")
+                            vm.syncNow()
+                            Toast.makeText(
+                                context,
+                                "Re-scoring your HRV over the ${if (it == HrvWindow.DEEP_SLEEP) "deep-sleep" else "whole-night"} window. It settles over the next few nights.",
+                                Toast.LENGTH_LONG,
+                            ).show()
                         },
                     )
                 }

--- a/android/app/src/main/java/com/noop/ui/Units.kt
+++ b/android/app/src/main/java/com/noop/ui/Units.kt
@@ -78,6 +78,25 @@ enum class TrendChartStyle(val raw: String) {
 }
 
 /**
+ * Which sleep window the nightly HRV is measured over (#141). NOOP historically averages RMSSD across the
+ * WHOLE night (every stage); WHOOP/Polar/etc. sample the last slow-wave-sleep window, which reads lower.
+ * This lets a user match that. It CHANGES the computed avgHrv (not display-only), so a switch re-scores +
+ * re-baselines. Default is the historical whole-night value. Mirrors the macOS [HrvWindow].
+ */
+enum class HrvWindow(val raw: String) {
+    /** RMSSD averaged over every 5-min window of the night (NOOP's long-standing value). */
+    WHOLE_NIGHT("whole"),
+
+    /** RMSSD over DEEP (slow-wave) sleep windows only — comparable to WHOOP's reading. */
+    DEEP_SLEEP("deep");
+
+    companion object {
+        /** An unset/unknown value resolves to the historical whole-night window. */
+        fun fromRaw(raw: String?): HrvWindow = entries.firstOrNull { it.raw == raw } ?: WHOLE_NIGHT
+    }
+}
+
+/**
  * Reads the two unit preferences from [NoopPrefs] and resolves the "match the system" default for
  * temperature. SharedPreferences isn't reactive, so Compose screens read these once into remembered
  * state (exactly like the other toggles) and re-read on a recomposition triggered by the Settings write.
@@ -121,6 +140,18 @@ object UnitPrefs {
     /** Persist the Trends chart style. */
     fun setTrendChartStyle(context: Context, style: TrendChartStyle) {
         NoopPrefs.of(context).edit().putString(KEY_TREND_CHART_STYLE, style.raw).apply()
+    }
+
+    /** SharedPreferences key for the nightly-HRV window (#141). Mirrors macOS @AppStorage("hrv.window"). */
+    const val KEY_HRV_WINDOW = "hrv.window"
+
+    /** The nightly-HRV window (default whole-night). Threaded into the engine's avgHrv computation. */
+    fun hrvWindow(context: Context): HrvWindow =
+        HrvWindow.fromRaw(NoopPrefs.of(context).getString(KEY_HRV_WINDOW, null))
+
+    /** Persist the nightly-HRV window. Changing it re-scores + re-baselines (the value itself moves). */
+    fun setHrvWindow(context: Context, window: HrvWindow) {
+        NoopPrefs.of(context).edit().putString(KEY_HRV_WINDOW, window.raw).apply()
     }
 }
 


### PR DESCRIPTION
## Fixes #141

The reporter (66yo, WHOOP 4.0) sees NOOP's nightly HRV at **45–60** vs their WHOOP app's **20–35** from the *same* R‑R — because NOOP averages RMSSD over the **whole night** (every sleep stage), while WHOOP/Polar/Suunto sample a specific window (slow‑wave sleep / early night). For a 66‑yo, 20–35 is age‑appropriate and 45–60 is implausibly high.

## What this adds

A **Settings → "HRV window"** toggle:
- **Whole night** (default) — NOOP's long‑standing value, **unchanged**.
- **Deep sleep** — RMSSD over deep/SWS 5‑min windows only, comparable to WHOOP.

## How it ties to #141 (and #145)

The deep path reuses the **exact `SleepStager.sessionHrvWindows`** that #145's nightly trace is built from, so **the value a user sees equals the `deepOnly=` figure the `hrv nightSummary` line logs**. That means:
- #145's trace (already merged) is the **validation harness**: the reporter can enable HRV mode, read `deepOnly=` in their export, and that's *exactly* the number they'll get by flipping this toggle.
- No drift between "what we log" and "what we ship."

## Safety / correctness

- **Opt‑in, default whole‑night → byte‑identical for every existing user** (the `else` branch is untouched; **956 analytics tests green**).
- **Not display‑only** — it changes `avgHrv`, so a switch **re‑scores + re‑baselines** (Android clears the analyze watermark + `syncNow()`; iOS `analyzeRecent()` + `refresh()`). Recovery self‑normalizes since it scores HRV‑vs‑baseline, so the visible effect is the HRV number + a few‑night settle.
- **`null` when no deep sleep is detected** → shows calibrating, never a fabricated number (the WHOOP‑4.0 sparse‑deep safety valve).

## Honest caveat

Whether "Deep sleep" lands at WHOOP's exact ~20–35 for this user is an **empirical** question the #145 trace answers (`deepOnly=`), not something I can guarantee blind — but it's opt‑in and safe by default, and directionally it drops the movement‑heavy REM/light/wake windows that inflate the whole‑night mean. Minor known artifact: the re‑score covers the recent window, so the HRV *trend* has a small step at that boundary until older nights re‑score.

## Verification
- Android `:app:compileFullDebugKotlin` + `com.noop.analytics.*` tests (956) pass locally.
- iOS mirrored (Units / AnalyticsEngine / IntelligenceEngine / SettingsView twins); confirmed on the staging CI iOS job.

## Sequencing
Pairs with **#145** (merged). Recommend merging this behind #145 and pointing the #141 reporter at both: enable HRV mode → confirm `deepOnly=` reads near WHOOP → flip the toggle.
