### PR TITLE
Workouts: back-date auto-detect start over the warm-up (#148)

### DIFF
--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/WorkoutDetector.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/WorkoutDetector.swift
@@ -229,6 +229,28 @@ public enum WorkoutDetector {
         return merged
     }
 
+    /// #148: back-date a confirmed run's start over the warm-up. Motion leads HR at the onset of the
+    /// first effort — cardiac warm-up climbs over minutes, so the HR-AND-motion gate clips the leading
+    /// "moving but HR not yet elevated" stretch. Once a run has ALREADY QUALIFIED on its HR-elevated
+    /// core, extend the start backward across contiguous above-`motionThreshold` samples, stopping at
+    /// the first motion gap > `mergeGapS` (a real pause) or the series start. Same motion gate as
+    /// detection — recovers the warm-up without inventing activity, and can't bridge a genuine rest.
+    /// `coreStart` is an active-sample ts (so it exists in `motionTs`); `smooth` is index-aligned.
+    static func backdatedStart(_ coreStart: Int, _ motionTs: [Int], _ smooth: [Double]) -> Int {
+        var i = motionTs.firstIndex(where: { $0 >= coreStart }) ?? motionTs.count
+        guard i < motionTs.count else { return coreStart }
+        var start = coreStart
+        var prevTs = motionTs[i]
+        while i > 0 {
+            i -= 1
+            if smooth[i] <= motionThreshold { break }                    // motion dropped → warm-up start
+            if Double(prevTs - motionTs[i]) > mergeGapS { break }        // real pause → stop
+            start = motionTs[i]
+            prevTs = motionTs[i]
+        }
+        return start
+    }
+
     // MARK: - Public API
 
     /// Detect workouts from the 1 Hz HR + gravity store.
@@ -267,6 +289,7 @@ public enum WorkoutDetector {
         let hrTs = hrSeg.map { $0.ts }
         let hrBpm = hrSeg.map { $0.bpm }
         let smooth = smoothedIntensity(motion, windowS: motionSmoothS)
+        let motionTs = motion.map { $0.ts }
 
         // Walk the gravity timeline; flag samples where BOTH gates hold.
         var activeTs: [Int] = []
@@ -294,18 +317,19 @@ public enum WorkoutDetector {
 
         let minDurS = minExerciseMin * 60.0
         var sessions: [ExerciseSession] = []
-        for (start, end) in runs {
+        for (idx, run) in runs.enumerated() {
+            let (start, end) = run
             // Onset latency tolerance equal to the smoothing window.
             if Double(end - start) < minDurS - motionSmoothS { continue }
-            let window = hrSeg.filter { $0.ts >= start && $0.ts <= end }
-            if window.isEmpty { continue }
-            let bpms = window.map { $0.bpm }
-            let hrSamples = window.map { HRSample(ts: $0.ts, bpm: Int($0.bpm.rounded())) }
+            // Qualify on the HR-elevated CORE (unchanged gates) so the warm-up's low intensity
+            // can't dilute a real workout below the zone-2 bar and drop it (#148).
+            let core = hrSeg.filter { $0.ts >= start && $0.ts <= end }
+            if core.isEmpty { continue }
 
             var zonePct: [Int: Double] = [:]
             var avgHRR: Double? = nil
             if let m = effMaxHR, m > restHR {
-                (zonePct, avgHRR) = boutIntensity(window, restingHR: restHR, maxHR: m)
+                (zonePct, avgHRR) = boutIntensity(core, restingHR: restHR, maxHR: m)
             }
 
             // Intensity qualification: require ≥ MIN_INTENSITY_Z2PLUS in zone 2+.
@@ -313,6 +337,16 @@ public enum WorkoutDetector {
                 let z2plus = (2...5).reduce(0.0) { $0 + (zonePct[$1] ?? 0.0) } / 100.0
                 if z2plus < minIntensityZ2Plus { continue }
             }
+
+            // Qualified → back-date the start over the warm-up and report stats on the full window (#148).
+            // Never back-date past the previous run's end: a continuous-motion stretch whose HR dipped to
+            // resting BETWEEN two efforts (so bridgeRuns kept them separate) must not overlap the earlier one.
+            let floor = idx > 0 ? runs[idx - 1].1 + 1 : Int.min
+            let effStart = max(Self.backdatedStart(start, motionTs, smooth), floor)
+            let window = hrSeg.filter { $0.ts >= effStart && $0.ts <= end }
+            if window.isEmpty { continue }
+            let bpms = window.map { $0.bpm }
+            let hrSamples = window.map { HRSample(ts: $0.ts, bpm: Int($0.bpm.rounded())) }
 
             var kcal: Double? = nil
             var kj: Double? = nil
@@ -328,8 +362,8 @@ public enum WorkoutDetector {
             let strain = StrainScorer.strain(hrSamples, maxHR: effMaxHR, restingHR: restHR)
 
             sessions.append(ExerciseSession(
-                start: start, end: end, avgHR: avg, peakHR: peak, strain: strain,
-                durationS: Double(end - start), zoneTimePct: zonePct, avgHRRPct: avgHRR,
+                start: effStart, end: end, avgHR: avg, peakHR: peak, strain: strain,
+                durationS: Double(end - effStart), zoneTimePct: zonePct, avgHRRPct: avgHRR,
                 hrmax: effMaxHR, hrmaxSource: hrmaxSource, caloriesKcal: kcal, caloriesKJ: kj))
         }
         return sessions

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/WorkoutDetectorTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/WorkoutDetectorTests.swift
@@ -217,4 +217,61 @@ final class WorkoutDetectorTests: XCTestCase {
         let sessions = WorkoutDetector.detect(hr: hr, gravity: grav, age: 30)
         XCTAssertEqual(sessions.count, 2, "separate workouts were over-merged")
     }
+
+    func testWarmupBeforeHrRisesBackdatesStartToMotionOnset() {
+        // #148: motion (walking / cycling) starts, but HR lags ~10 min behind during cardiac
+        // warm-up. The HR-AND-motion gate used to clip that warm-up, dropping the first ~10 min
+        // (the reporter's "way there not tracked, way back tracked"). Motion is continuous from
+        // onset, so a confirmed run's start must back-date to the motion onset, not the HR crossing.
+        let motionStart = 12_000_000
+        let warmupS = 10 * 60   // moving, HR still ~resting (below the floor) → used to be clipped
+        let coreS = 20 * 60     // moving, HR elevated → the HR-gated core
+        var hr: [HRSample] = []
+        var grav: [GravitySample] = []
+        let dayStart = motionStart - 30 * 60
+        let dayEnd = motionStart + warmupS + coreS + 30 * 60
+        for t in dayStart..<dayEnd {
+            let inWarm = t >= motionStart && t < motionStart + warmupS
+            let inCore = t >= motionStart + warmupS && t < motionStart + warmupS + coreS
+            let moving = inWarm || inCore
+            hr.append(HRSample(ts: t, bpm: inCore ? 150 : (inWarm ? 60 : 52)))
+            let phase = moving ? Double(t % 2) * 0.5 : 0.0
+            grav.append(GravitySample(ts: t, x: phase, y: 0, z: 1))
+        }
+        // resting 52 → floor 67: warm-up 60 is below it (clipped without the fix), core 150 clears it.
+        let sessions = WorkoutDetector.detect(hr: hr, gravity: grav, restingHR: 52, age: 30)
+        XCTAssertEqual(sessions.count, 1)
+        let w = sessions[0]
+        XCTAssertLessThanOrEqual(w.start, motionStart + 120,
+            "start \(w.start) not back-dated to motion onset \(motionStart) (HR crossed ~\(motionStart + warmupS))")
+        XCTAssertGreaterThanOrEqual(w.durationS, Double(warmupS + coreS) * 0.9,
+            "duration \(Int(w.durationS))s still excludes the warm-up")
+    }
+
+    func testBackdateDoesNotCrossPreviousWorkoutContinuousMotion() {
+        // #148 guard: you keep walking the whole time (motion never stops), but HR spikes, dips to
+        // resting for a few minutes, then spikes again → two separate efforts (bridgeRuns won't merge
+        // across an HR-to-resting lull). Back-dating the second effort must NOT walk its start across
+        // the still-moving lull into the first one — the two sessions must stay non-overlapping.
+        let startA = 13_000_000
+        let durA = 15 * 60
+        let lull = 6 * 60          // HR at resting, but STILL WALKING
+        let durB = 15 * 60
+        let moveEnd = startA + durA + lull + durB
+        var hr: [HRSample] = []
+        var grav: [GravitySample] = []
+        let dayStart = startA - 30 * 60
+        let dayEnd = moveEnd + 30 * 60
+        for t in dayStart..<dayEnd {
+            let inA = t >= startA && t < startA + durA
+            let inB = t >= startA + durA + lull && t < moveEnd
+            let moving = t >= startA && t < moveEnd   // continuous through the lull
+            hr.append(HRSample(ts: t, bpm: (inA || inB) ? 155 : 52))
+            grav.append(GravitySample(ts: t, x: moving ? Double(t % 2) * 0.5 : 0.0, y: 0, z: 1))
+        }
+        let sessions = WorkoutDetector.detect(hr: hr, gravity: grav, restingHR: 52, age: 30)
+        XCTAssertEqual(sessions.count, 2, "continuous-motion lull did not split into two efforts")
+        XCTAssertGreaterThan(sessions[1].start, sessions[0].end,
+            "second workout (\(sessions[1].start)) overlaps the first (ends \(sessions[0].end))")
+    }
 }

--- a/android/app/src/main/java/com/noop/analytics/WorkoutDetector.kt
+++ b/android/app/src/main/java/com/noop/analytics/WorkoutDetector.kt
@@ -240,7 +240,9 @@ object WorkoutDetector {
      * so it exists in [motionTs]; [smooth] is index-aligned to [motionTs].
      */
     internal fun backdatedStart(coreStart: Long, motionTs: List<Long>, smooth: List<Double>): Long {
-        var i = motionTs.binarySearch(coreStart).let { if (it < 0) -it - 1 else it }
+        // indexOfFirst (not binarySearch): mirrors Swift's firstIndex exactly, so duplicate same-second
+        // motion timestamps resolve to the SAME index on both platforms (byte-parity).
+        var i = motionTs.indexOfFirst { it >= coreStart }
         if (i !in motionTs.indices) return coreStart
         var start = coreStart
         var prevTs = motionTs[i]

--- a/android/app/src/main/java/com/noop/analytics/WorkoutDetector.kt
+++ b/android/app/src/main/java/com/noop/analytics/WorkoutDetector.kt
@@ -229,6 +229,31 @@ object WorkoutDetector {
         return merged
     }
 
+    /**
+     * #148: back-date a confirmed run's start over the warm-up. Motion leads HR at the onset of
+     * the first effort — cardiac warm-up climbs over minutes, so the HR-AND-motion gate clips the
+     * leading "moving but HR not yet elevated" stretch (the reporter's first 10-15 min). Once a run
+     * has ALREADY QUALIFIED on its HR-elevated core, extend the start backward across contiguous
+     * above-[motionThreshold] samples, stopping at the first motion gap > [mergeGapS] (a real pause)
+     * or the series start. Same motion gate as detection — recovers the warm-up without inventing
+     * activity, and can't bridge a genuine rest into the workout. [coreStart] is an active-sample ts,
+     * so it exists in [motionTs]; [smooth] is index-aligned to [motionTs].
+     */
+    internal fun backdatedStart(coreStart: Long, motionTs: List<Long>, smooth: List<Double>): Long {
+        var i = motionTs.binarySearch(coreStart).let { if (it < 0) -it - 1 else it }
+        if (i !in motionTs.indices) return coreStart
+        var start = coreStart
+        var prevTs = motionTs[i]
+        while (i > 0) {
+            i--
+            if (smooth[i] <= motionThreshold) break                    // motion dropped → warm-up start
+            if ((prevTs - motionTs[i]).toDouble() > mergeGapS) break   // real pause → stop
+            start = motionTs[i]
+            prevTs = motionTs[i]
+        }
+        return start
+    }
+
     // ---- Public API ----
 
     /**
@@ -271,6 +296,7 @@ object WorkoutDetector {
         val hrTs = hrSeg.map { it.ts }
         val hrBpm = hrSeg.map { it.bpm.toDouble() }
         val smooth = smoothedIntensity(motion, motionSmoothS)
+        val motionTs = motion.map { it.ts }
 
         // Walk the gravity timeline; flag samples where BOTH gates hold.
         val activeTs = ArrayList<Long>()
@@ -305,18 +331,20 @@ object WorkoutDetector {
 
         val minDurS = minExerciseMin * 60.0
         val sessions = ArrayList<ExerciseSession>()
-        for ((start, end) in runs) {
+        for ((idx, run) in runs.withIndex()) {
+            val (start, end) = run
             // Onset latency tolerance equal to the smoothing window.
             if ((end - start).toDouble() < minDurS - motionSmoothS) continue
-            val window = hrSeg.filter { it.ts in start..end }
-            if (window.isEmpty()) continue
-            val bpms = window.map { it.bpm.toDouble() }
+            // Qualify on the HR-elevated CORE (unchanged gates) so the warm-up's low intensity
+            // can't dilute a real workout below the zone-2 bar and drop it (#148).
+            val core = hrSeg.filter { it.ts in start..end }
+            if (core.isEmpty()) continue
 
             var zonePct: Map<Int, Double> = emptyMap()
             var avgHRR: Double? = null
             val m = effMaxHR
             if (m != null && m > restHR) {
-                val (zp, ah) = boutIntensity(window, restHR, m)
+                val (zp, ah) = boutIntensity(core, restHR, m)
                 zonePct = zp
                 avgHRR = ah
             }
@@ -326,6 +354,15 @@ object WorkoutDetector {
                 val z2plus = (2..5).sumOf { zonePct[it] ?: 0.0 } / 100.0
                 if (z2plus < minIntensityZ2Plus) continue
             }
+
+            // Qualified → back-date the start over the warm-up and report stats on the full window (#148).
+            // Never back-date past the previous run's end: a continuous-motion stretch whose HR dipped to
+            // resting BETWEEN two efforts (so bridgeRuns kept them separate) must not overlap the earlier one.
+            val floor = if (idx > 0) runs[idx - 1].second + 1 else Long.MIN_VALUE
+            val effStart = maxOf(backdatedStart(start, motionTs, smooth), floor)
+            val window = hrSeg.filter { it.ts in effStart..end }
+            if (window.isEmpty()) continue
+            val bpms = window.map { it.bpm.toDouble() }
 
             var kcal: Double? = null
             var kj: Double? = null
@@ -341,12 +378,12 @@ object WorkoutDetector {
 
             sessions.add(
                 ExerciseSession(
-                    start = start,
+                    start = effStart,
                     end = end,
                     avgHR = avg,
                     peakHR = peak,
                     strain = strain,
-                    durationS = (end - start).toDouble(),
+                    durationS = (end - effStart).toDouble(),
                     zoneTimePct = zonePct,
                     avgHRRPct = avgHRR,
                     hrmax = effMaxHR,

--- a/android/app/src/test/java/com/noop/analytics/WorkoutDetectorTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/WorkoutDetectorTest.kt
@@ -99,4 +99,70 @@ class WorkoutDetectorTest {
         val sessions = WorkoutDetector.detect(hr = hrList, gravity = gravList, age = 30.0)
         assertEquals("separate workouts were over-merged", 2, sessions.size)
     }
+
+    @Test fun warmupBeforeHrRises_backdatesStartToMotionOnset() {
+        // #148: motion (walking / cycling) starts, but HR lags ~10 min behind during cardiac
+        // warm-up. The HR-AND-motion gate used to clip that warm-up, dropping the first ~10 min
+        // (the reporter's "way there not tracked, way back tracked"). Motion is continuous from
+        // onset, so a confirmed run's start must back-date to the motion onset, not the HR crossing.
+        val motionStart = 12_000_000L
+        val warmupS = 10L * 60   // moving, HR still ~resting (below the floor) → used to be clipped
+        val coreS = 20L * 60     // moving, HR elevated → the HR-gated core
+        val hrList = ArrayList<HrSample>()
+        val gravList = ArrayList<GravitySample>()
+        val dayStart = motionStart - 30 * 60
+        val dayEnd = motionStart + warmupS + coreS + 30 * 60
+        var t = dayStart
+        while (t < dayEnd) {
+            val inWarm = t >= motionStart && t < motionStart + warmupS
+            val inCore = t >= motionStart + warmupS && t < motionStart + warmupS + coreS
+            val moving = inWarm || inCore
+            hrList.add(hr(t, if (inCore) 150 else if (inWarm) 60 else 52))
+            gravList.add(grav(t, if (moving) (t.mod(2L)).toDouble() * 0.5 else 0.0))
+            t += 1
+        }
+        // resting 52 → floor 67: warm-up 60 is below it (clipped without the fix), core 150 clears it.
+        val sessions = WorkoutDetector.detect(hr = hrList, gravity = gravList, restingHR = 52.0, age = 30.0)
+        assertEquals(1, sessions.size)
+        val w = sessions[0]
+        assertTrue(
+            "start ${w.start} not back-dated to motion onset $motionStart (HR crossed ~${motionStart + warmupS})",
+            w.start <= motionStart + 120,
+        )
+        assertTrue(
+            "duration ${w.durationS.toInt()}s still excludes the warm-up",
+            w.durationS >= (warmupS + coreS).toDouble() * 0.9,
+        )
+    }
+
+    @Test fun backdateDoesNotCrossPreviousWorkout_continuousMotion() {
+        // #148 guard: you keep walking the whole time (motion never stops), but HR spikes, dips to
+        // resting for a few minutes, then spikes again → two separate efforts (bridgeRuns won't merge
+        // across an HR-to-resting lull). Back-dating the second effort must NOT walk its start across
+        // the still-moving lull into the first one — the two sessions must stay non-overlapping.
+        val startA = 13_000_000L
+        val durA = 15L * 60
+        val lull = 6L * 60          // HR at resting, but STILL WALKING
+        val durB = 15L * 60
+        val moveEnd = startA + durA + lull + durB
+        val hrList = ArrayList<HrSample>()
+        val gravList = ArrayList<GravitySample>()
+        val dayStart = startA - 30 * 60
+        val dayEnd = moveEnd + 30 * 60
+        var t = dayStart
+        while (t < dayEnd) {
+            val inA = t >= startA && t < startA + durA
+            val inB = t >= startA + durA + lull && t < moveEnd
+            val moving = t in startA until moveEnd   // continuous through the lull
+            hrList.add(hr(t, if (inA || inB) 155 else 52))
+            gravList.add(grav(t, if (moving) (t.mod(2L)).toDouble() * 0.5 else 0.0))
+            t += 1
+        }
+        val sessions = WorkoutDetector.detect(hr = hrList, gravity = gravList, restingHR = 52.0, age = 30.0)
+        assertEquals("continuous-motion lull did not split into two efforts", 2, sessions.size)
+        assertTrue(
+            "second workout (${sessions[1].start}) overlaps the first (ends ${sessions[0].end})",
+            sessions[1].start > sessions[0].end,
+        )
+    }
 }


### PR DESCRIPTION
Fixes #148 — workout auto-detect drops the first ~10–15 min of a walk/ride.

### Root cause
`WorkoutDetector.detect()` flags a "workout second" only when **both** motion (`smooth > motionThreshold`) **and** HR (`bpm > restingHR + hrMarginBPM`) hold. Motion is present from the first step, but HR **lags** during cardiac warm-up, so a run's start (first second both gates hold) is pushed several minutes in — the leading "moving but HR not yet elevated" stretch is clipped.

This is exactly the reporter's tell: the **way back** tracks perfectly because HR is already elevated from the outbound leg, so it clears the floor from step one.

### Fix
After a run **qualifies on its HR-elevated core** (the zone-2 intensity gate stays on the core, so the low-intensity warm-up can never dilute a real workout below threshold and drop it), back-date its start across the contiguous `> motionThreshold` samples that precede it:

- **bounded by the existing gates** — stops at a motion gap `> mergeGapS` (a real pause). No new tunable.
- **clamped to the previous run's end** — a continuous-motion stretch whose HR dips to resting *between* two efforts (kept separate by `bridgeRuns`) can't back-date into the earlier one → sessions stay non-overlapping.
- `avg` / `duration` / `strain` / `calories` cover the full tracked bout (warm-up correctly folds in); the zone/HRR breakdown continues to describe the HR-elevated effort.

### Tests
- Existing `WorkoutDetector` goldens **unchanged** (their fixtures ramp HR + motion together, so nothing back-dates).
- Two new parity cases each side (Kotlin + Swift): warm-up back-dates to motion onset; continuous-motion inter-effort lull stays non-overlapping.
- Full Android suite: **2364 tests, 0 failures**. iOS mirrored (CI-validated — local Swift build hits the GRDB/SQLite wall).

### Deliberately not in scope
A light walk that **never** lifts HR 15 bpm over resting is still dropped entirely (the `hrMarginBPM` case). Relaxing that margin risks false positives (driving, fidgeting), so it wants the reporter's real onset numbers first — a follow-up once we can instrument it.
