### PR TITLE
Dashboard: give Hydration its own icon, distinct from Blood Oxygen (#150)

### DIFF
--- a/Strand/Screens/DashboardCards.swift
+++ b/Strand/Screens/DashboardCards.swift
@@ -93,7 +93,7 @@ enum DashboardCard: String, CaseIterable, Identifiable {
         case .skinTemp:    return "thermometer.medium"
         case .sleep:       return "bed.double.fill"
         case .calories:    return "flame.fill"
-        case .hydration:   return "drop.fill"
+        case .hydration:   return "waterbottle.fill"
         case .coupled:     return "circle.hexagongrid.fill"
         }
     }

--- a/android/app/src/main/java/com/noop/ui/DashboardCards.kt
+++ b/android/app/src/main/java/com/noop/ui/DashboardCards.kt
@@ -10,6 +10,7 @@ import androidx.compose.material.icons.automirrored.filled.DirectionsRun
 import androidx.compose.material.icons.automirrored.filled.DirectionsWalk
 import androidx.compose.material.icons.filled.Favorite
 import androidx.compose.material.icons.filled.Hexagon
+import androidx.compose.material.icons.filled.LocalDrink
 import androidx.compose.material.icons.filled.LocalFireDepartment
 import androidx.compose.material.icons.filled.MonitorHeart
 import androidx.compose.material.icons.filled.Thermostat
@@ -54,7 +55,7 @@ enum class DashboardCard(
     SKIN_TEMP("skinTemp", "Skin Temp", "Skin temperature", "", Icons.Filled.Thermostat),
     SLEEP("sleep", "Sleep", "Last night", "", Icons.Filled.Bedtime),
     CALORIES("calories", "Calories", "Active energy", "kcal", Icons.Filled.LocalFireDepartment),
-    HYDRATION("hydration", "Hydration", "Today's fluid", "", Icons.Filled.WaterDrop),
+    HYDRATION("hydration", "Hydration", "Today's fluid", "", Icons.Filled.LocalDrink),
 
     // Optional, default-OFF (task #43): a tap-through to the Coupled view (the WHOOP-style day read). Unlike
     // every other card it carries NO metric value of its own, it is a navigation row that opens the full


### PR DESCRIPTION
Part of #150 — metric card icons on Home/Trends are hard to tell apart.

The clearest offender was objective: **Blood Oxygen and Hydration rendered the identical tile** on both platforms — same glyph (iOS `drop.fill`, Android `WaterDrop`) *and* same tint. This gives Hydration its own drink-vessel glyph:

- iOS `DashboardCards.swift`: `drop.fill` → `waterbottle.fill`
- Android `DashboardCards.kt`: `WaterDrop` → `LocalDrink` (+ import)

Data-only change to the card catalog — no layout or logic touched. Android compiles clean; iOS is a one-symbol swap (validated at release CI — local Swift build hits the usual wall).

### Not in this PR
This is the safe, unambiguous half of #150. The reporter's main point — HRV vs RHR blur because the Liquid-Glass frosting desaturates the per-metric tint (`metricPurple` vs `metricRose` collapse) — is a separate, design-touch change (a tinted contrast disc behind each symbol so the hue survives the glass). That's worth eyeballing on a staging build before merging, so it'll come as a follow-up.
