### PR TITLE
Localize missing Appearance settings strings

### DIFF
--- a/Strand/Screens/HealthView.swift
+++ b/Strand/Screens/HealthView.swift
@@ -882,7 +882,7 @@ private struct FitnessAgeSection: View {
 private struct ReadinessChecklistCard: View {
     let readiness: FitnessAgeReadiness
     /// Optional intro line shown above the groups (e.g. the "a few more days" no-value message).
-    let lead: LocalizedStringKey?
+    let lead: String?
     /// Invoked when the user taps a required-missing row's "Fix in Settings".
     let onFix: () -> Void
 


### PR DESCRIPTION
## What this PR does

Four strings under Settings → Appearance ("Sky behind cards" and its
caption, "Card transparency" and its caption) were added to
`SettingsView.swift`'s `appearanceCard` but never made it into
`Strand/Resources/Localizable.xcstrings`, so every non-English locale fell
back to the raw English source text instead of showing a translation.

Adds `de`, `es`, `fr`, `it`, `pt-PT`, `zh-Hans`, and `zh-Hant` entries for
all four strings, reusing existing catalog terminology (e.g. "Frecuencia
cardíaca"/"心率" for Heart Rate, "Fondo según el ciclo del día" for the
day-cycle background) so they read consistently with neighboring rows.

Also includes an unrelated one-line CI fix: `ReadinessChecklistCard.lead`
in `HealthView.swift` was typed `LocalizedStringKey?` but
`fitnessReadyLead()` returns an already-localized `String` (via
`String(localized:)`), which broke the macOS build. Retyped to `String?`
(the only usage is `Text(lead)`, which accepts both). This was a
pre-existing break from commit 75a096a1 (PR #81), not caused by this
branch, but needed fixing to get CI green here.

Note: pt-PT entries in this catalog are marked `needs_review` throughout
(existing entries mix in Spanish words), and the four new ones follow that
same convention — worth a native pt-PT pass over the whole file at some
point.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [x] Documentation
- [ ] CI / tooling

(Closest fit is "Documentation" for the string-catalog content; the
HealthView.swift change is a minimal, unrelated type fix needed for CI.)

## How it was tested

- `Localizable.xcstrings`: validated as JSON and confirmed all four keys
  carry complete localization sets via a Python script.
- `HealthView.swift`: built locally with `xcodegen generate` +
  `xcodebuild -project Strand.xcodeproj -scheme Strand -destination
  "generic/platform=macOS" ARCHS="x86_64 arm64" ONLY_ACTIVE_ARCH=NO build`
  — BUILD SUCCEEDED.

## Checklist

- [ ] Swift package tests pass for any package I touched (`swift test` in `Packages/<name>`) — N/A, no package touched
- [ ] Android unit tests pass if I touched `android/` — N/A, not touched
- [x] No new build warnings introduced
- [x] UI changes use only `StrandDesign` tokens — no hardcoded colors, fonts, or spacing — N/A, no UI code changed
- [x] No hardcoded hex frame bytes; protocol facts live in the schema / decoders — N/A
- [x] Follows the conventions in `docs/CONTRIBUTING.md`
- [x] I did not commit generated output (`Strand.xcodeproj/`) or any secrets/keystores

## Related issues

None