### PR TITLE
Fitness Age detail: show the value on a single weekly reading, not "Not enough history"

### DIFF
--- a/android/app/src/main/java/com/noop/ui/HealthScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/HealthScreen.kt
@@ -1953,13 +1953,17 @@ fun VitalDetailScreen(vm: AppViewModel, key: String) {
     else remember(days, key, tempUnit) { buildVitalDetail(days, key, tempUnit) }
     var range by remember { mutableStateOf(VitalDetailRange.MONTH) }
 
-    // When Fitness Age has no value yet we show the readiness countdown, not a trend — so the subtitle
-    // reflects that instead of promising a "historical trend" the card isn't about.
-    val fitnessNotReady = key == "fitness_age" && seriesLoaded && (detail?.points?.isEmpty() != false)
+    // Fitness Age drives the subtitle by how much history it has, so we never promise a "historical
+    // trend" the view isn't showing: no reading yet -> what it still needs; a single weekly reading ->
+    // that reading (trend to follow); two+ -> the trend. Non-fitness or pre-load falls through to trend.
+    val faPoints = if (key == "fitness_age" && seriesLoaded) (detail?.points?.size ?: 0) else -1
     ScreenScaffold(
         title = detail?.title ?: "Vital Signs",
-        subtitle = if (fitnessNotReady) "What your Fitness Age still needs."
-        else "Historical trend from cached daily metrics.",
+        subtitle = when (faPoints) {
+            0 -> "What your Fitness Age still needs."
+            1 -> "Your latest weekly reading — trend to follow."
+            else -> "Historical trend from cached daily metrics."
+        },
     ) {
         if (isSeriesBacked && !seriesLoaded) {
             DataPendingNote(
@@ -2002,7 +2006,7 @@ fun VitalDetailScreen(vm: AppViewModel, key: String) {
             // never a no-data dead end. Brings Android to parity with iOS (which renders the value hero at
             // a single point).
             if (key == "fitness_age" && detail != null && detail.points.size == 1) {
-                val fa = detail.points.first()
+                val fa = detail.points.last()   // size 1: the single reading (last == the latest)
                 NoopCard {
                     Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
                         Overline("Latest")

--- a/android/app/src/main/java/com/noop/ui/HealthScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/HealthScreen.kt
@@ -1996,6 +1996,36 @@ fun VitalDetailScreen(vm: AppViewModel, key: String) {
                 )
                 return@ScreenScaffold
             }
+            // Fitness Age with exactly ONE weekly reading: the card already shows this value, so the
+            // generic "Not enough history yet" note read as a contradiction on tap-through. Fitness Age is
+            // WEEKLY — only the TREND needs a second point — so show the value + when the chart fills in,
+            // never a no-data dead end. Brings Android to parity with iOS (which renders the value hero at
+            // a single point).
+            if (key == "fitness_age" && detail != null && detail.points.size == 1) {
+                val fa = detail.points.first()
+                NoopCard {
+                    Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                        Overline("Latest")
+                        Text(
+                            text = "${detail.format(fa.second)} ${detail.unit}".trim(),
+                            style = NoopType.chartValueLarge,
+                            color = detail.color,
+                        )
+                        Text(
+                            text = "as of ${fa.first}",
+                            style = NoopType.footnote,
+                            color = Palette.textTertiary,
+                        )
+                        Text(
+                            text = "Fitness Age updates weekly — your trend chart fills in here once a " +
+                                "second weekly reading lands.",
+                            style = NoopType.subhead,
+                            color = Palette.textSecondary,
+                        )
+                    }
+                }
+                return@ScreenScaffold
+            }
             DataPendingNote(
                 title = "Not enough history yet",
                 body = "This vital needs at least two historical readings before NOOP can chart it.",


### PR DESCRIPTION
### The bug (reported on 8.5.1)
Fitness Age shows a value on the Today card, but tapping through shows **"Not enough history yet."** A value on the card and "no data" on tap is a contradiction — and every user hits it in their first week after the 8.5.1 Fitness-Age fix.

### Root cause (Android-only)
The Vital detail view (`HealthScreen.kt`) gates its whole value/stats/chart block on `points.size >= 2`. Fitness Age is a **weekly** metric, so a freshly-scored user has exactly **one** weekly point:
- `size == 0` → readiness countdown (correct)
- `size == 1` → falls through to the generic *"Not enough history yet — needs at least two historical readings to chart it"* — the reported contradiction
- `size >= 2` → value + trend chart

iOS doesn't have this: its `MetricExplorerView` `else` branch renders the value hero at `size >= 1`, so a single reading already shows the value.

### Fix
For `fitness_age` with exactly one reading, Android now shows the value ("Latest N yrs · as of <date>") plus an honest line — *"Fitness Age updates weekly — your trend chart fills in here once a second weekly reading lands."* — instead of the no-data note. Only the trend needed a second point; the value was always there. Brings Android to parity with iOS.

Uses existing components (`NoopCard`/`Overline`/`detail.format`); compiles clean. UI-state gate, so verification is visual (next build). iOS unchanged — already correct.
