### PR TITLE
Settings: group the HRV window with the other HRV settings under Strap (#155)

### DIFF
--- a/Strand/Screens/SettingsView.swift
+++ b/Strand/Screens/SettingsView.swift
@@ -901,6 +901,10 @@ struct SettingsView: View {
                         Task { await model.intelligence.analyzeRecent(); await model.repo.refresh() }
                     }
                 }
+                Text("Whole night is NOOP's default measure; Deep sleep pools HRV over slow-wave sleep only, reading lower and matching WHOOP. Switching re-scores recent nights and recalibrates Charge over a few nights.")
+                    .font(StrandFont.caption)
+                    .foregroundStyle(StrandPalette.textTertiary)
+                    .fixedSize(horizontal: false, vertical: true)
 
                 // MARK: Strap name — rename the WHOOP 4.0's BLE advertising name (Harvard command set).
                 if live.connected && selectedWhoopModelRaw == WhoopModel.whoop4.rawValue {

--- a/Strand/Screens/SettingsView.swift
+++ b/Strand/Screens/SettingsView.swift
@@ -631,29 +631,6 @@ struct SettingsView: View {
                     .fixedSize()
                     .accessibilityLabel("Effort scale")
                 }
-                rowDivider
-                // HRV window (#141) — measure nightly HRV over the whole night (NOOP's long-standing value)
-                // or DEEP sleep only (WHOOP-style, reads lower and more comparable to WHOOP/Polar). Unlike the
-                // Effort scale this CHANGES the number, so a switch re-scores + re-baselines (like a sleep edit).
-                FormRow(label: "HRV window") {
-                    Picker("HRV window", selection: $hrvWindowRaw) {
-                        Text("Whole night").tag(HrvWindow.whole.rawValue)
-                        Text("Deep sleep").tag(HrvWindow.deep.rawValue)
-                    }
-                    .labelsHidden()
-                    .pickerStyle(.segmented)
-                    .fixedSize()
-                    .accessibilityLabel("HRV window")
-                    .onChangeCompat(of: hrvWindowRaw) { _ in
-                        // The new window shifts every night's avgHrv, so the HRV BASELINE must re-learn or
-                        // recovery would compare the new value against a baseline still folded from the old
-                        // window (the EWMA spans further than the ~21 nights that re-score → skewed for weeks).
-                        // Re-anchor the HRV baseline to now (HRV-only sibling of "Recalibrate Charge baseline"),
-                        // then re-score + refresh so the recent trend + fresh baseline both reflect the window.
-                        UserDefaults.standard.set(Date().timeIntervalSince1970, forKey: Baselines.hrvBaselineEpochKey)
-                        Task { await model.intelligence.analyzeRecent(); await model.repo.refresh() }
-                    }
-                }
             }
         }
     }
@@ -899,6 +876,30 @@ struct SettingsView: View {
                         .font(StrandFont.caption)
                         .foregroundStyle(StrandPalette.textTertiary)
                         .fixedSize(horizontal: false, vertical: true)
+                }
+
+                // HRV window (#141) — grouped with the other HRV settings (#155). Whole night (NOOP's
+                // long-standing value) or DEEP sleep only (WHOOP-style, reads lower and more comparable to
+                // WHOOP/Polar). Unlike the Effort scale this CHANGES the number, so a switch re-scores +
+                // re-baselines (like a sleep edit).
+                FormRow(label: "HRV window") {
+                    Picker("HRV window", selection: $hrvWindowRaw) {
+                        Text("Whole night").tag(HrvWindow.whole.rawValue)
+                        Text("Deep sleep").tag(HrvWindow.deep.rawValue)
+                    }
+                    .labelsHidden()
+                    .pickerStyle(.segmented)
+                    .fixedSize()
+                    .accessibilityLabel("HRV window")
+                    .onChangeCompat(of: hrvWindowRaw) { _ in
+                        // The new window shifts every night's avgHrv, so the HRV BASELINE must re-learn or
+                        // recovery would compare the new value against a baseline still folded from the old
+                        // window (the EWMA spans further than the ~21 nights that re-score → skewed for weeks).
+                        // Re-anchor the HRV baseline to now (HRV-only sibling of "Recalibrate Charge baseline"),
+                        // then re-score + refresh so the recent trend + fresh baseline both reflect the window.
+                        UserDefaults.standard.set(Date().timeIntervalSince1970, forKey: Baselines.hrvBaselineEpochKey)
+                        Task { await model.intelligence.analyzeRecent(); await model.repo.refresh() }
+                    }
                 }
 
                 // MARK: Strap name — rename the WHOOP 4.0's BLE advertising name (Harvard command set).

--- a/android/app/src/main/java/com/noop/ui/SettingsScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/SettingsScreen.kt
@@ -1320,6 +1320,11 @@ fun SettingsScreen(
                         },
                     )
                 }
+                Text(
+                    "Whole night is NOOP's default measure; Deep sleep pools HRV over slow-wave sleep only, reading lower and matching WHOOP. Switching re-scores recent nights and recalibrates Charge over a few nights.",
+                    style = NoopType.footnote,
+                    color = Palette.textTertiary,
+                )
 
                 // Diagnostics: "Debug logging" mirrors the strap log to logcat (adb). Default OFF — a
                 // normal user never needs to write the connection log to the system log; the in-app log

--- a/android/app/src/main/java/com/noop/ui/SettingsScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/SettingsScreen.kt
@@ -895,37 +895,6 @@ fun SettingsScreen(
                         },
                     )
                 }
-                RowDivider()
-                // HRV window (#141) — measure nightly HRV over the whole night (NOOP's long-standing value)
-                // or DEEP sleep only (WHOOP-style, reads lower and more comparable to WHOOP/Polar). Unlike the
-                // Effort scale this CHANGES the number, so a switch forces a re-score + re-baseline.
-                FormRow(label = "HRV window") {
-                    SegmentedPillControl(
-                        items = listOf(HrvWindow.WHOLE_NIGHT, HrvWindow.DEEP_SLEEP),
-                        selection = hrvWindow,
-                        label = { if (it == HrvWindow.DEEP_SLEEP) "Deep sleep" else "Whole night" },
-                        onSelect = {
-                            hrvWindow = it
-                            UnitPrefs.setHrvWindow(context, it)
-                            // The new window shifts every night's avgHrv, so the HRV BASELINE must re-learn or
-                            // recovery would compare the new value against a baseline still folded from the old
-                            // window (only the recent ~21 nights re-score, but the baseline EWMA spans further —
-                            // it would read skewed for weeks). Re-anchor the HRV baseline to now (same key +
-                            // mechanism as "Recalibrate Charge baseline"), then force a re-score so the recent
-                            // trend + the fresh baseline both reflect the new window. A few nights to settle.
-                            NoopPrefs.of(context).edit()
-                                .putLong(Baselines.hrvBaselineEpochKey, System.currentTimeMillis() / 1000L)
-                                .apply()
-                            NoopPrefs.setAnalyzeWatermark(context, "")
-                            vm.syncNow()
-                            Toast.makeText(
-                                context,
-                                "Re-learning your HRV over the ${if (it == HrvWindow.DEEP_SLEEP) "deep-sleep" else "whole-night"} window. Charge recalibrates over the next few nights.",
-                                Toast.LENGTH_LONG,
-                            ).show()
-                        },
-                    )
-                }
             }
         }
 
@@ -1318,6 +1287,38 @@ fun SettingsScreen(
                             ),
                         )
                     }
+                }
+
+                // HRV window (#141) — grouped with the other HRV settings (#155). Measure nightly HRV over
+                // the whole night (NOOP's long-standing value) or DEEP sleep only (WHOOP-style, reads lower
+                // and more comparable to WHOOP/Polar). Unlike the Effort scale this CHANGES the number, so a
+                // switch forces a re-score + re-baseline.
+                FormRow(label = "HRV window") {
+                    SegmentedPillControl(
+                        items = listOf(HrvWindow.WHOLE_NIGHT, HrvWindow.DEEP_SLEEP),
+                        selection = hrvWindow,
+                        label = { if (it == HrvWindow.DEEP_SLEEP) "Deep sleep" else "Whole night" },
+                        onSelect = {
+                            hrvWindow = it
+                            UnitPrefs.setHrvWindow(context, it)
+                            // The new window shifts every night's avgHrv, so the HRV BASELINE must re-learn or
+                            // recovery would compare the new value against a baseline still folded from the old
+                            // window (only the recent ~21 nights re-score, but the baseline EWMA spans further —
+                            // it would read skewed for weeks). Re-anchor the HRV baseline to now (same key +
+                            // mechanism as "Recalibrate Charge baseline"), then force a re-score so the recent
+                            // trend + the fresh baseline both reflect the new window. A few nights to settle.
+                            NoopPrefs.of(context).edit()
+                                .putLong(Baselines.hrvBaselineEpochKey, System.currentTimeMillis() / 1000L)
+                                .apply()
+                            NoopPrefs.setAnalyzeWatermark(context, "")
+                            vm.syncNow()
+                            Toast.makeText(
+                                context,
+                                "Re-learning your HRV over the ${if (it == HrvWindow.DEEP_SLEEP) "deep-sleep" else "whole-night"} window. Charge recalibrates over the next few nights.",
+                                Toast.LENGTH_LONG,
+                            ).show()
+                        },
+                    )
                 }
 
                 // Diagnostics: "Debug logging" mirrors the strap log to logcat (adb). Default OFF — a


### PR DESCRIPTION
Fixes #155.

The HRV window toggle (#141) shipped in **Settings → Units**, but the other HRV settings — **Continuous HRV capture** and **Overnight only** — live under **Strap**. So the HRV controls were split across two sections, and the reporter (rightly) found the window hard to locate.

### Change
Move the **HRV window** row from the Units section into the **Strap** section, directly after the Continuous / Overnight‑only block, so the three HRV settings read as one group. Both platforms, symmetric:
- Android `SettingsScreen.kt`: Units → Strap (after the Overnight‑only block)
- iOS `SettingsView.swift`: `unitsCard` → `strapCard` (same relative spot)

### Why it's safe
Pure UI relocation. The pref key (`UnitPrefs.hrvWindowKey = "hrv.window"`) and the entire onSelect logic (baseline re‑anchor + watermark clear + re‑score) travel with the row unchanged — no behavior, storage, or analytics change. The state vars are declared at the top of each view, so they were already in scope from either section.

Android compiles clean; iOS is a row move within the same view (brace‑balanced, verified by read — local Swift build hits the usual wall, release CI validates).

### Note on the one semantic trade-off
The HRV window is technically a *computation‑methodology* choice (it also affects imported history, not just live capture), which is why it originally sat in Units. But grouping by topic — all "HRV" settings together — wins for discoverability, and Strap already hosts the HRV capture toggles.
