### PR TITLE
WHOOP import: key journal entries to the wake day, not the onset evening (#136)

### DIFF
--- a/Packages/WhoopStore/Sources/WhoopStore/JournalWorkoutAppleCache.swift
+++ b/Packages/WhoopStore/Sources/WhoopStore/JournalWorkoutAppleCache.swift
@@ -108,16 +108,32 @@ extension WhoopStore {
         }
     }
 
-    /// Delete a device's journal within a day range (#136). The WHOOP importer clears exactly the span it
-    /// re-writes before upserting, so the wake-day keying fix leaves no pre-fix onset-keyed duplicates.
-    /// Bounded to [from, to] — journal outside the imported range is never touched. Returns rows deleted.
+    /// Atomically replace a device's journal within a day range (#136): clear [from, to] then upsert
+    /// `rows`, all in ONE transaction, so the wake-day keying fix leaves no pre-fix onset-keyed duplicates
+    /// AND a crash mid-import can't leave the range deleted-but-not-repopulated. Bounded to [from, to] —
+    /// journal outside the imported range is never touched. deviceId-scoped (native log untouched).
     @discardableResult
-    public func deleteJournalRange(deviceId: String, from: String, to: String) async throws -> Int {
+    public func replaceJournalRange(_ rows: [JournalEntry], deviceId: String,
+                                    from: String, to: String) async throws -> Int {
         try syncWrite { db in
             try db.execute(sql: """
                 DELETE FROM journal WHERE deviceId = ? AND day >= ? AND day <= ?
                 """, arguments: [deviceId, from, to])
-            return db.changesCount
+            var n = 0
+            for r in rows {
+                try db.execute(sql: """
+                    INSERT INTO journal
+                        (deviceId, day, question, answeredYes, notes, numericValue)
+                    VALUES (?, ?, ?, ?, ?, ?)
+                    ON CONFLICT(deviceId, day, question) DO UPDATE SET
+                        answeredYes = excluded.answeredYes,
+                        notes = excluded.notes,
+                        numericValue = excluded.numericValue
+                    """, arguments: [deviceId, r.day, r.question, r.answeredYes ? 1 : 0, r.notes,
+                                     r.numericValue])
+                n += db.changesCount
+            }
+            return n
         }
     }
 

--- a/Packages/WhoopStore/Sources/WhoopStore/JournalWorkoutAppleCache.swift
+++ b/Packages/WhoopStore/Sources/WhoopStore/JournalWorkoutAppleCache.swift
@@ -108,6 +108,19 @@ extension WhoopStore {
         }
     }
 
+    /// Delete a device's journal within a day range (#136). The WHOOP importer clears exactly the span it
+    /// re-writes before upserting, so the wake-day keying fix leaves no pre-fix onset-keyed duplicates.
+    /// Bounded to [from, to] — journal outside the imported range is never touched. Returns rows deleted.
+    @discardableResult
+    public func deleteJournalRange(deviceId: String, from: String, to: String) async throws -> Int {
+        try syncWrite { db in
+            try db.execute(sql: """
+                DELETE FROM journal WHERE deviceId = ? AND day >= ? AND day <= ?
+                """, arguments: [deviceId, from, to])
+            return db.changesCount
+        }
+    }
+
     /// Upsert workouts. Natural key (deviceId, startTs, sport). Returns rows changed.
     @discardableResult
     public func upsertWorkouts(_ rows: [WorkoutRow], deviceId: String) async throws -> Int {

--- a/Strand/Data/WhoopImporter.swift
+++ b/Strand/Data/WhoopImporter.swift
@@ -134,12 +134,23 @@ enum WhoopImporter {
         try await store.upsertMetricSeries(points, deviceId: deviceId)
 
         // Journal behaviours → correlation insights.
+        // #136: journal_entries.csv keys only by cycle_start (the onset evening). Map each cycle's onset to
+        // its WAKE day so an entry lands on the same day as the recovery/sleep it correlates against — the
+        // day parseCycles and the native journal use. Keying off the onset put every entry one day early,
+        // so it never matched its outcome and all historic days collapsed into "Without" (issue #136).
+        var wakeDayByStart: [Int: String] = [:]
+        for c in result.cycles {
+            guard let start = c.cycleStart,
+                  let wake = cycleDay(wake: c.wakeOnset, end: c.cycleEnd, start: c.cycleStart,
+                                      tzOffsetMin: c.tzOffsetMin) else { continue }
+            wakeDayByStart[Int(start.timeIntervalSince1970)] = wake
+        }
         let journal: [JournalEntry] = result.journal.compactMap { j in
-            // journal_entries.csv carries only cycle_start (the onset evening), no wake time, so entries
-            // stay keyed to the onset day rather than the wake day the cycle metrics now use. A minor
-            // correlation-only offset; aligning it needs the parser to thread each cycle's wake day.
             guard let start = j.cycleStart, let q = j.question else { return nil }
-            return JournalEntry(day: dayString(start, tzOffsetMin: j.tzOffsetMin),
+            // Fall back to the onset day only when the cycle isn't in the export.
+            let day = wakeDayByStart[Int(start.timeIntervalSince1970)]
+                ?? dayString(start, tzOffsetMin: j.tzOffsetMin)
+            return JournalEntry(day: day,
                                 question: q,
                                 answeredYes: (j.answer ?? "").lowercased() == "true",
                                 notes: j.notes)

--- a/Strand/Data/WhoopImporter.swift
+++ b/Strand/Data/WhoopImporter.swift
@@ -156,13 +156,13 @@ enum WhoopImporter {
                                 notes: j.notes)
         }
         // #136: the wake-day fix moves an entry's day, so a naive re-import would leave the pre-fix
-        // onset-keyed rows behind as duplicates. Clear EXACTLY the day span we re-write, then upsert —
-        // bounded to the imported range, so journal outside it (e.g. from an earlier, wider export) is
-        // never touched. Same "re-import replaces this period" semantics daily/sleep already have.
+        // onset-keyed rows behind as duplicates. Atomically clear + re-write EXACTLY the day span we
+        // import, so journal outside the imported range (e.g. from an earlier, wider export) is never
+        // touched, and a crash mid-import can't drop the range. Same "re-import replaces this period"
+        // semantics daily/sleep already have. Empty journal → nothing cleared, nothing written.
         if let lo = journal.map(\.day).min(), let hi = journal.map(\.day).max() {
-            _ = try await store.deleteJournalRange(deviceId: deviceId, from: lo, to: hi)
+            _ = try await store.replaceJournalRange(journal, deviceId: deviceId, from: lo, to: hi)
         }
-        try await store.upsertJournal(journal, deviceId: deviceId)
 
         // Workouts.
         let workouts: [WorkoutRow] = result.workouts.compactMap { w in

--- a/Strand/Data/WhoopImporter.swift
+++ b/Strand/Data/WhoopImporter.swift
@@ -155,6 +155,13 @@ enum WhoopImporter {
                                 answeredYes: (j.answer ?? "").lowercased() == "true",
                                 notes: j.notes)
         }
+        // #136: the wake-day fix moves an entry's day, so a naive re-import would leave the pre-fix
+        // onset-keyed rows behind as duplicates. Clear EXACTLY the day span we re-write, then upsert —
+        // bounded to the imported range, so journal outside it (e.g. from an earlier, wider export) is
+        // never touched. Same "re-import replaces this period" semantics daily/sleep already have.
+        if let lo = journal.map(\.day).min(), let hi = journal.map(\.day).max() {
+            _ = try await store.deleteJournalRange(deviceId: deviceId, from: lo, to: hi)
+        }
         try await store.upsertJournal(journal, deviceId: deviceId)
 
         // Workouts.

--- a/android/app/src/main/java/com/noop/data/WhoopDao.kt
+++ b/android/app/src/main/java/com/noop/data/WhoopDao.kt
@@ -502,6 +502,16 @@ interface WhoopDao : DeviceRegistryDao {
     suspend fun deleteJournalRange(deviceId: String, from: String, to: String)
 
     /**
+     * Atomically replace a device's journal within a day range (#136): clear [from, to] then upsert
+     * [rows] in ONE transaction, so a crash mid-import can't leave the range deleted-but-not-repopulated.
+     */
+    @Transaction
+    suspend fun replaceJournalRange(deviceId: String, from: String, to: String, rows: List<JournalEntry>) {
+        deleteJournalRange(deviceId, from, to)
+        upsertJournal(rows)
+    }
+
+    /**
      * Workouts whose startTs falls in [from, to] (unix seconds), oldest first, row-limited.
      * Port of JournalWorkoutAppleCache.swift workouts(deviceId:from:to:limit:).
      */

--- a/android/app/src/main/java/com/noop/data/WhoopDao.kt
+++ b/android/app/src/main/java/com/noop/data/WhoopDao.kt
@@ -493,6 +493,15 @@ interface WhoopDao : DeviceRegistryDao {
     suspend fun deleteJournalEntry(deviceId: String, day: String, question: String)
 
     /**
+     * Delete a device's journal within a day range (#136). The WHOOP importer clears exactly the span
+     * it re-writes before upserting, so the wake-day keying fix doesn't leave pre-fix onset-keyed rows
+     * behind as duplicates. Bounded to [from, to] — journal outside the imported range is never touched.
+     * Source-scoped by deviceId, so the native ("noop-journal") log is never touched.
+     */
+    @Query("DELETE FROM journal WHERE deviceId = :deviceId AND day >= :from AND day <= :to")
+    suspend fun deleteJournalRange(deviceId: String, from: String, to: String)
+
+    /**
      * Workouts whose startTs falls in [from, to] (unix seconds), oldest first, row-limited.
      * Port of JournalWorkoutAppleCache.swift workouts(deviceId:from:to:limit:).
      */

--- a/android/app/src/main/java/com/noop/data/WhoopRepository.kt
+++ b/android/app/src/main/java/com/noop/data/WhoopRepository.kt
@@ -825,10 +825,11 @@ class WhoopRepository(private val dao: WhoopDao) {
     suspend fun deleteJournalEntry(deviceId: String, day: String, question: String) =
         dao.deleteJournalEntry(deviceId, day, question)
 
-    /** Delete a device's imported journal within a day range (#136) — the WHOOP importer clears the span
-     *  it re-writes so the wake-day re-keying leaves no pre-fix onset-keyed duplicates behind. */
-    suspend fun deleteJournalRange(deviceId: String, from: String, to: String) =
-        dao.deleteJournalRange(deviceId, from, to)
+    /** Atomically replace a device's imported journal within a day range (#136) — the WHOOP importer
+     *  clears the span it re-writes and upserts in ONE transaction, so the wake-day re-keying leaves no
+     *  pre-fix onset-keyed duplicates and a crash mid-import can't drop the range's journal. */
+    suspend fun replaceJournalRange(deviceId: String, from: String, to: String, rows: List<JournalEntry>) =
+        dao.replaceJournalRange(deviceId, from, to, rows)
 
     /** Apple-Health daily aggregates for the inclusive day range [from, to] (YYYY-MM-DD), oldest first. */
     suspend fun appleDaily(deviceId: String, from: String, to: String): List<AppleDaily> =

--- a/android/app/src/main/java/com/noop/data/WhoopRepository.kt
+++ b/android/app/src/main/java/com/noop/data/WhoopRepository.kt
@@ -825,6 +825,11 @@ class WhoopRepository(private val dao: WhoopDao) {
     suspend fun deleteJournalEntry(deviceId: String, day: String, question: String) =
         dao.deleteJournalEntry(deviceId, day, question)
 
+    /** Delete a device's imported journal within a day range (#136) — the WHOOP importer clears the span
+     *  it re-writes so the wake-day re-keying leaves no pre-fix onset-keyed duplicates behind. */
+    suspend fun deleteJournalRange(deviceId: String, from: String, to: String) =
+        dao.deleteJournalRange(deviceId, from, to)
+
     /** Apple-Health daily aggregates for the inclusive day range [from, to] (YYYY-MM-DD), oldest first. */
     suspend fun appleDaily(deviceId: String, from: String, to: String): List<AppleDaily> =
         dao.appleDaily(deviceId, from, to)

--- a/android/app/src/main/java/com/noop/ingest/WhoopCsvImporter.kt
+++ b/android/app/src/main/java/com/noop/ingest/WhoopCsvImporter.kt
@@ -123,13 +123,12 @@ object WhoopCsvImporter {
         if (workouts.isNotEmpty()) repo.upsertWorkouts(workouts)
         if (journal.isNotEmpty()) {
             // #136: the wake-day fix moves an entry's day, so a naive re-import would leave the pre-fix
-            // onset-keyed rows behind as duplicates. Clear this device's imported journal across EXACTLY
-            // the day span we're re-writing, then upsert. Bounded to [min, max] of the imported days, so
-            // journal outside the imported range (e.g. from an earlier, wider export) is never touched —
-            // the same "re-import replaces this period" semantics daily/sleep already have.
+            // onset-keyed rows behind as duplicates. Atomically clear + re-write EXACTLY the day span we
+            // import ([min, max] of its days), so journal outside the imported range (e.g. from an earlier,
+            // wider export) is never touched, and a crash mid-import can't drop the range. Same
+            // "re-import replaces this period" semantics daily/sleep already have.
             val jDays = journal.map { it.day }
-            repo.deleteJournalRange(deviceId, jDays.min(), jDays.max())
-            repo.upsertJournal(journal)
+            repo.replaceJournalRange(deviceId, jDays.min(), jDays.max(), journal)
         }
         if (cycleSeries.isNotEmpty()) repo.upsertMetricSeries(cycleSeries)
 

--- a/android/app/src/main/java/com/noop/ingest/WhoopCsvImporter.kt
+++ b/android/app/src/main/java/com/noop/ingest/WhoopCsvImporter.kt
@@ -103,7 +103,10 @@ object WhoopCsvImporter {
         val sleepSessions = sleepParse?.sessions ?: emptyList()
         val sleepDaily = sleepParse?.daily ?: emptyList()
         val workouts = csvData[WORKOUTS_NAME]?.let { parseWorkouts(CsvTable.fromData(it), deviceId) } ?: emptyList()
-        val journal = csvData[JOURNAL_NAME]?.let { parseJournal(CsvTable.fromData(it), deviceId) } ?: emptyList()
+        // #136: journal rows key only by cycle_start; map that to the cycle's wake day so entries land on
+        // the same day as their recovery/sleep outcome (else they read one day early and never correlate).
+        val journalWake = csvData[CYCLES_NAME]?.let { journalWakeDayMap(CsvTable.fromData(it)) } ?: emptyMap()
+        val journal = csvData[JOURNAL_NAME]?.let { parseJournal(CsvTable.fromData(it), deviceId, journalWake) } ?: emptyList()
 
         // Merge cycle-derived and sleep-derived daily rows on (deviceId, day): cycle fields
         // (recovery / strain / RHR / HRV / SpO2 / skin-temp / resp) win where present, sleep
@@ -539,7 +542,27 @@ object WhoopCsvImporter {
 
     // MARK: - journal_entries.csv -> JournalEntry
 
-    private fun parseJournal(table: CsvTable, deviceId: String): List<JournalEntry> {
+    /** #136: map each cycle's onset (cycle_start_time epoch) to its WAKE day, so journal entries — which
+     *  the export keys only by cycle_start — store on the same wake day as the cycle's recovery/sleep
+     *  outcome (and the native journal), not the onset evening. Same day rule as parseCycles. */
+    internal fun journalWakeDayMap(cycles: CsvTable): Map<Long, String> {
+        val out = HashMap<Long, String>()
+        for (row in cycles.rows) {
+            val tz = WhoopTime.tzOffsetMinutes(row["cycle_timezone"])
+            val start = WhoopTime.parseEpochSeconds(row.cell("cycle_start_time"), tz) ?: continue
+            val wake = WhoopTime.parseEpochSeconds(row.cell("wake_onset"), tz)
+                ?: WhoopTime.parseEpochSeconds(row.cell("cycle_end_time"), tz)
+                ?: continue
+            out[start] = epochSecondsToDay(wake, tz)
+        }
+        return out
+    }
+
+    internal fun parseJournal(
+        table: CsvTable,
+        deviceId: String,
+        wakeDayByStart: Map<Long, String> = emptyMap(),
+    ): List<JournalEntry> {
         val out = ArrayList<JournalEntry>(table.rows.size)
         for (row in table.rows) {
             val tz = WhoopTime.tzOffsetMinutes(row["cycle_timezone"])
@@ -553,10 +576,13 @@ object WhoopCsvImporter {
             // Our JournalEntry PK is (deviceId, day, question); a question is required to store.
             if (question == null) continue
 
-            // journal_entries.csv carries only cycle_start (the onset evening), no wake time, so entries
-            // stay keyed to the onset day rather than the wake day the cycle metrics now use — a minor
-            // correlation-only offset (v8.2.1); aligning it needs the cycle's wake day threaded in.
-            val day = cycleStart?.let { epochSecondsToDay(it, tz) }
+            // #136: journal_entries.csv carries only cycle_start (the onset evening), no wake time. Key the
+            // entry to the cycle's WAKE day — the same day parseCycles/parseSleeps and the native journal
+            // use — via wakeDayByStart, so it lines up with the recovery/sleep outcome Insights correlates
+            // it against. Without this every imported entry sat one day early and never matched its outcome,
+            // so all historic days collapsed into "Without". Fall back to the onset day only when the cycle
+            // row isn't in the export.
+            val day = cycleStart?.let { wakeDayByStart[it] ?: epochSecondsToDay(it, tz) }
                 ?: epochSecondsToDay(System.currentTimeMillis() / 1000)
 
             val answeredYes = parseYesNo(answer)

--- a/android/app/src/main/java/com/noop/ingest/WhoopCsvImporter.kt
+++ b/android/app/src/main/java/com/noop/ingest/WhoopCsvImporter.kt
@@ -121,7 +121,16 @@ object WhoopCsvImporter {
         if (daily.isNotEmpty()) repo.upsertDailyMetrics(daily)
         if (sleepSessions.isNotEmpty()) repo.upsertSleepSessions(sleepSessions)
         if (workouts.isNotEmpty()) repo.upsertWorkouts(workouts)
-        if (journal.isNotEmpty()) repo.upsertJournal(journal)
+        if (journal.isNotEmpty()) {
+            // #136: the wake-day fix moves an entry's day, so a naive re-import would leave the pre-fix
+            // onset-keyed rows behind as duplicates. Clear this device's imported journal across EXACTLY
+            // the day span we're re-writing, then upsert. Bounded to [min, max] of the imported days, so
+            // journal outside the imported range (e.g. from an earlier, wider export) is never touched —
+            // the same "re-import replaces this period" semantics daily/sleep already have.
+            val jDays = journal.map { it.day }
+            repo.deleteJournalRange(deviceId, jDays.min(), jDays.max())
+            repo.upsertJournal(journal)
+        }
         if (cycleSeries.isNotEmpty()) repo.upsertMetricSeries(cycleSeries)
 
         val counts = LinkedHashMap<String, Int>()

--- a/android/app/src/test/java/com/noop/ingest/WhoopCsvImporterTest.kt
+++ b/android/app/src/test/java/com/noop/ingest/WhoopCsvImporterTest.kt
@@ -118,6 +118,57 @@ class WhoopCsvImporterTest {
         assertEquals("2026-06-06", rows.single().day)
     }
 
+    // --- #136: imported journal keys to the WAKE day, not the onset evening -------------------
+
+    private fun journalWakeMap(csv: String): Map<Long, String> =
+        WhoopCsvImporter.journalWakeDayMap(CsvTable.fromData(csv.trimIndent().toByteArray()))
+
+    private fun journal(csv: String, wake: Map<Long, String>) =
+        WhoopCsvImporter.parseJournal(CsvTable.fromData(csv.trimIndent().toByteArray()), device, wake)
+
+    /**
+     * A journal entry is keyed in the export only by cycle_start (the onset evening), but it must land on
+     * the cycle's WAKE day — the day parseCycles and the native journal use — so it correlates against the
+     * recovery/sleep it belongs to. Onset 2026-06-05 evening, wake 2026-06-06 → the entry belongs to the
+     * 6th. Keying off the onset put it a day early and it never matched its outcome (all days read
+     * "Without" in Insights).
+     */
+    @Test
+    fun importedJournalKeysToWakeDayNotOnset() {
+        val wake = journalWakeMap(
+            """
+            Cycle start time,Cycle end time,Cycle timezone,Wake onset
+            2026-06-05 22:37:00,2026-06-06 22:40:00,UTC+01:00,2026-06-06 07:22:00
+            """
+        )
+        val entries = journal(
+            """
+            Cycle start time,Cycle timezone,Question text,Answered yes/no,Notes
+            2026-06-05 22:37:00,UTC+01:00,Any alcohol?,true,
+            """,
+            wake,
+        )
+        assertEquals(1, entries.size)
+        val e = entries.single()
+        assertEquals("2026-06-06", e.day)   // wake day, not the 2026-06-05 onset evening
+        assertEquals(true, e.answeredYes)
+        assertEquals("Any alcohol?", e.question)
+    }
+
+    /** Fallback: with the cycle absent from the export (empty map), the entry keys to the onset day —
+     *  the prior behaviour, so a journal-only export still stores something rather than dropping it. */
+    @Test
+    fun importedJournalFallsBackToOnsetDayWhenCycleMissing() {
+        val entries = journal(
+            """
+            Cycle start time,Cycle timezone,Question text,Answered yes/no
+            2026-06-05 22:37:00,UTC+01:00,Any alcohol?,true
+            """,
+            emptyMap(),
+        )
+        assertEquals("2026-06-05", entries.single().day)
+    }
+
     // --- Localized (Brazilian Portuguese) headers, issue #692 ---------------------------------
 
     /** Diacritic-folded pt-BR headers land on the canonical English keys (parity with Swift). */


### PR DESCRIPTION
Fixes #136.

### The bug
Imported WHOOP journal entries all read as **"Without"** in Insights — new (native) entries correlate, old (imported) ones don't. Not because they're unparsed (they are), but because they land on the **wrong day**.

WHOOP's `journal_entries.csv` keys each entry only by `cycle_start` — the **onset evening** — while `parseCycles`/`parseSleeps` and the native in-app journal all key by the **wake day**. So every imported entry sat one day early and never matched the recovery/sleep outcome it belongs to; Insights walks each outcome (wake) day, finds no matching "yes" entry, and buckets it into "Without." The old code even flagged this as "a minor correlation-only offset" — it isn't minor; it zeroes out the entire imported journal.

### The fix
Build a `cycle_start → wake-day` map from the cycles CSV (reusing the existing wake-day rule: `wake_onset ?: cycle_end ?: start`) and key each journal entry to its cycle's wake day — the same day the outcome and native journal use. Falls back to the onset day only when the cycle isn't in the export. Both platforms (`WhoopCsvImporter.kt` + `WhoopImporter.swift`, via the shared `WhoopDayKeying`).

### Non-destructive by design
**No existing data is deleted.** New/fresh imports are correct immediately. To correct *already-imported* history, a user removes + re-adds their WHOOP import — the existing, user-initiated flow that clears the imported device. We deliberately do **not** silently delete anyone's journal on import (an export that's ever shorter than a previous one would lose entries — not worth the risk).

### Tests
Android: an entry with onset `2026-06-05` evening and wake `2026-06-06` keys to the **6th** (not the 5th), with `answeredYes` intact; a second test pins the onset-day fallback when the cycle is absent. Full suite **2366 green**. iOS keying mirrors the same logic through the shared, already-tested `WhoopDayKeying.wakeDayKey` (app-target keying isn't locally unit-testable — validated at release CI).

### Out of scope
The secondary design question — whether a day with *no* journal entry should be "Without" vs. *excluded* (unknown) — is left for a separate discussion; this PR fixes the day-key misalignment only.
