### PR TITLE
R-R (Android): keep equal same-second intervals via a seq tiebreaker (RMSSD was biased high)

### DIFF
--- a/android/app/src/main/java/com/noop/data/Entities.kt
+++ b/android/app/src/main/java/com/noop/data/Entities.kt
@@ -8,10 +8,12 @@ import androidx.room.Index
  * Room entities mirroring the verified GRDB schema in
  * Packages/WhoopStore/Sources/WhoopStore/Database.swift (+ MetricsCache.swift).
  *
- * Natural keys are preserved EXACTLY so insert dedupe (OnConflictStrategy.IGNORE)
- * behaves identically to the Swift `ON CONFLICT(...) DO NOTHING` upserts:
+ * Natural keys mirror the Swift `ON CONFLICT(...) DO NOTHING` upserts so insert dedupe behaves identically,
+ * with ONE deliberate exception noted inline:
  *   - hrSample        PK (deviceId, ts)
- *   - rrInterval      PK (deviceId, ts, rrMs)
+ *   - rrInterval      PK (deviceId, ts, rrMs, seq)  // v18: `seq` tiebreaks EQUAL same-second beats.
+ *                                                   // Diverges from Swift (still deviceId, ts, rrMs) — see
+ *                                                   // the RrInterval doc + PR; Swift needs the same fix.
  *   - event           PK (deviceId, ts, kind)
  *   - battery         PK (deviceId, ts)
  *   - spo2Sample      PK (deviceId, ts)
@@ -82,12 +84,26 @@ data class HrWindowStats(
     val max: Int?,
 )
 
-/** R-R interval. Swift `rrInterval` (v1). PK (deviceId, ts, rrMs), multiple R-R per ts. */
-@Entity(tableName = "rrInterval", primaryKeys = ["deviceId", "ts", "rrMs"])
+/**
+ * R-R interval. Swift `rrInterval` (v1); PK widened in Room v18 to (deviceId, ts, rrMs, **seq**), adding
+ * `seq` as a tiebreaker for two EQUAL R-R intervals that fall in the same 1-second `ts` bucket. Keying by
+ * value alone (deviceId, ts, rrMs) + `ON CONFLICT DO NOTHING` silently dropped the second of two equal
+ * successive beats in a second, removing a zero-difference pair and biasing RMSSD/HRV **high** — the bias
+ * matters most at rest/sleep, exactly when HRV is scored. `seq` counts equal (ts, rrMs) beats (0, 1, …) so
+ * both survive. DISTINCT intervals keep their own (ts, rrMs) slot exactly as before, so no distinct beat is
+ * ever dropped — including across separate insert batches or the live/historical merge (rrMs stays in the
+ * key). Re-syncing identical records reproduces the same (ts, rrMs, seq), so the insert stays idempotent.
+ *
+ * PARITY NOTE: this intentionally diverges from the Swift `rrInterval` key, which is still
+ * (deviceId, ts, rrMs); the identical value-key drop exists in `WhoopStore` (Database.swift / StreamStore /
+ * Reads) and should get the same widening in a follow-up. See the PR description.
+ */
+@Entity(tableName = "rrInterval", primaryKeys = ["deviceId", "ts", "rrMs", "seq"])
 data class RrInterval(
     val deviceId: String,
     val ts: Long,
     val rrMs: Int,
+    val seq: Int = 0,
     val synced: Int = 0,
 )
 

--- a/android/app/src/main/java/com/noop/data/WhoopDao.kt
+++ b/android/app/src/main/java/com/noop/data/WhoopDao.kt
@@ -233,8 +233,9 @@ interface WhoopDao : DeviceRegistryDao {
     suspend fun hrWindowStats(deviceId: String, from: Long, to: Long): HrWindowStats
 
     @Query(
+        // ts, rrMs matches Swift Reads.swift; seq only tiebreaks the rare EQUAL same-second beats (v18).
         "SELECT * FROM rrInterval WHERE deviceId = :deviceId AND ts >= :from AND ts <= :to " +
-            "ORDER BY ts ASC, rrMs ASC LIMIT :limit"
+            "ORDER BY ts ASC, rrMs ASC, seq ASC LIMIT :limit"
     )
     suspend fun rrIntervals(deviceId: String, from: Long, to: Long, limit: Int): List<RrInterval>
 

--- a/android/app/src/main/java/com/noop/data/WhoopDatabase.kt
+++ b/android/app/src/main/java/com/noop/data/WhoopDatabase.kt
@@ -48,7 +48,7 @@ import androidx.sqlite.db.SupportSQLiteDatabase
         LabMarkerRow::class,
         LiveSessionRow::class,
     ],
-    version = 17,
+    version = 18,
     exportSchema = false,
 )
 abstract class WhoopDatabase : RoomDatabase() {
@@ -446,6 +446,40 @@ abstract class WhoopDatabase : RoomDatabase() {
             }
         }
 
+        /**
+         * v17 -> v18: REBUILD `rrInterval` to add a `seq` tiebreaker column — PK
+         * (deviceId, ts, rrMs) -> (deviceId, ts, rrMs, seq). The value-only key silently dropped the second
+         * of two EQUAL successive R-R intervals that landed in the same 1-second `ts` bucket (insert is
+         * `ON CONFLICT DO NOTHING`), removing a zero-difference beat pair and biasing RMSSD/HRV high (the bias
+         * matters most at rest/sleep, when HRV is scored). `seq` distinguishes equal (ts, rrMs) beats; distinct
+         * beats keep seq 0 and their existing key, so nothing already stored changes shape.
+         *
+         * A PK change needs a table rebuild (SQLite can't ALTER a PK), but it is **loss-less**: every existing
+         * row is copied with `seq = 0`. That is exact because the OLD PK guaranteed a UNIQUE (deviceId, ts, rrMs)
+         * per row, so seq 0 never collides. No window functions (minSdk 26 SQLite lacks `ROW_NUMBER`).
+         * Already-offloaded R-R survives (the strap trims acked history and won't re-send it). The rebuilt
+         * table's column order + PK MUST match Room's generated schema for [RrInterval] exactly
+         * (deviceId, ts, rrMs, seq, synced; PK deviceId, ts, rrMs, seq) or the no-destructive-fallback open
+         * would throw. Exposed as [RR_SEQ_MIGRATION_SQL] and pinned by [com.noop.data.RrSeqMigrationTest].
+         * NOTE: this only stops FUTURE equal-beat drops; beats already dropped under the old key are
+         * unrecoverable, so it does not retroactively correct historical HRV.
+         */
+        internal val RR_SEQ_MIGRATION_SQL: List<String> = listOf(
+            "CREATE TABLE IF NOT EXISTS `rrInterval_new` (`deviceId` TEXT NOT NULL, `ts` INTEGER NOT NULL, " +
+                "`rrMs` INTEGER NOT NULL, `seq` INTEGER NOT NULL, `synced` INTEGER NOT NULL, " +
+                "PRIMARY KEY(`deviceId`, `ts`, `rrMs`, `seq`))",
+            "INSERT INTO `rrInterval_new` (`deviceId`, `ts`, `rrMs`, `seq`, `synced`) " +
+                "SELECT `deviceId`, `ts`, `rrMs`, 0, `synced` FROM `rrInterval`",
+            "DROP TABLE `rrInterval`",
+            "ALTER TABLE `rrInterval_new` RENAME TO `rrInterval`",
+        )
+
+        internal val MIGRATION_17_18 = object : Migration(17, 18) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                for (stmt in RR_SEQ_MIGRATION_SQL) db.execSQL(stmt)
+            }
+        }
+
         private fun build(appContext: Context): WhoopDatabase =
             Room.databaseBuilder(appContext, WhoopDatabase::class.java, DB_NAME)
                 // #1014: replace ONLY the corruption handling of the default open-helper. The
@@ -460,7 +494,7 @@ abstract class WhoopDatabase : RoomDatabase() {
                     MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5,
                     MIGRATION_5_6, MIGRATION_6_7, MIGRATION_7_8, MIGRATION_8_9, MIGRATION_9_10,
                     MIGRATION_10_11, MIGRATION_11_12, MIGRATION_12_13, MIGRATION_13_14,
-                    MIGRATION_14_15, MIGRATION_15_16, MIGRATION_16_17,
+                    MIGRATION_14_15, MIGRATION_15_16, MIGRATION_16_17, MIGRATION_17_18,
                 )
                 // #1037: a FRESH install builds the schema straight at the current version and runs NO
                 // migrations, so the MIGRATION_7_8 "my-whoop" registry seed never fires and the WHOOP,

--- a/android/app/src/main/java/com/noop/data/WhoopRepository.kt
+++ b/android/app/src/main/java/com/noop/data/WhoopRepository.kt
@@ -50,6 +50,31 @@ data class StreamBatch(
 data class HrRow(val ts: Long, val bpm: Int)
 data class RrRow(val ts: Long, val rrMs: Int)
 
+/**
+ * Attach a tiebreaker `seq` to each R-R interval before insert (Room v18). Multiple beats share one
+ * whole-second `ts`; the old PK (deviceId, ts, rrMs) + IGNORE-on-conflict silently dropped the second of
+ * two EQUAL successive intervals in the same second, removing a zero-difference pair and biasing RMSSD/HRV
+ * high. `seq` counts occurrences of each EQUAL (ts, rrMs) beat (0, 1, …), so both survive.
+ *
+ * Keying by (ts, rrMs) — not ts alone — is deliberate: DISTINCT intervals keep seq 0 and thus their own
+ * (deviceId, ts, rrMs, 0) key, so a distinct beat is NEVER dropped even when same-second beats arrive in
+ * SEPARATE insert batches or via the live/historical merge (an earlier ts-only index would have restarted
+ * per batch and collided distinct beats — a data-loss regression). Re-syncing identical records reproduces
+ * the same (ts, rrMs, seq) → the insert stays idempotent. The residual: two EQUAL beats in one second that
+ * straddle a live-flush boundary still collide (batch-local), the same narrow case the old key dropped and
+ * strictly no worse; the authoritative historical path delivers a second's beats atomically in one batch.
+ * Pure so it is unit-testable.
+ */
+internal fun assignRrSeq(deviceId: String, rows: List<RrRow>): List<RrInterval> {
+    val seqByBeat = HashMap<Pair<Long, Int>, Int>()
+    return rows.map { row ->
+        val key = row.ts to row.rrMs
+        val s = seqByBeat.getOrDefault(key, 0)
+        seqByBeat[key] = s + 1
+        RrInterval(deviceId = deviceId, ts = row.ts, rrMs = row.rrMs, seq = s)
+    }
+}
+
 /** payloadJSON is the deterministic sorted-keys JSON for the remaining parsed fields. */
 data class EventEntry(val ts: Long, val kind: String, val payloadJSON: String)
 data class BatteryRow(val ts: Long, val soc: Double?, val mv: Int?, val charging: Boolean? = null)
@@ -172,7 +197,7 @@ class WhoopRepository(private val dao: WhoopDao) {
         val hrIds = if (streams.hr.isEmpty()) emptyList() else
             dao.insertHr(streams.hr.map { HrSample(deviceId, it.ts, it.bpm) })
         val rrIds = if (streams.rr.isEmpty()) emptyList() else
-            dao.insertRr(streams.rr.map { RrInterval(deviceId, it.ts, it.rrMs) })
+            dao.insertRr(assignRrSeq(deviceId, streams.rr))
         val evIds = if (streams.events.isEmpty()) emptyList() else
             dao.insertEvents(streams.events.map { EventRow(deviceId, it.ts, it.kind, it.payloadJSON) })
         val batIds = if (streams.battery.isEmpty()) emptyList() else

--- a/android/app/src/test/java/com/noop/data/RrSeqMigrationTest.kt
+++ b/android/app/src/test/java/com/noop/data/RrSeqMigrationTest.kt
@@ -1,0 +1,94 @@
+package com.noop.data
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Guards the v17 -> v18 Room migration that adds a `seq` tiebreaker to `rrInterval`
+ * (PK (deviceId, ts, rrMs) -> (deviceId, ts, rrMs, seq)), plus the [assignRrSeq] insert helper. The
+ * value-only key silently dropped the second of two EQUAL R-R intervals in the same 1-second `ts` bucket
+ * (insert is `ON CONFLICT DO NOTHING`), biasing RMSSD/HRV high.
+ *
+ * This environment has no Robolectric / Room-testing, so the migration SQL is pinned to Room's generated
+ * shape for [RrInterval] and the insert seq-assignment is proven pure (the actual bug-fix proof, incl. the
+ * cross-batch case where distinct same-second beats must NOT collide).
+ */
+class RrSeqMigrationTest {
+
+    // Compose the on-disk primary key so tests assert real collision behaviour, not just field values.
+    private fun pk(r: RrInterval) = listOf(r.deviceId, r.ts, r.rrMs, r.seq)
+
+    @Test
+    fun migration_versionPair_is17to18() {
+        assertEquals(17, WhoopDatabase.MIGRATION_17_18.startVersion)
+        assertEquals(18, WhoopDatabase.MIGRATION_17_18.endVersion)
+    }
+
+    @Test
+    fun migration_rebuildsTable_losslessly_seqZero_noWindowFns() {
+        val sql = WhoopDatabase.RR_SEQ_MIGRATION_SQL
+        assertEquals("create, copy, drop, rename", 4, sql.size)
+        // The rebuilt table MUST match Room's generated schema for RrInterval exactly (column order + PK),
+        // or the no-destructive-fallback open would throw on a schema-identity mismatch.
+        assertEquals(
+            "CREATE TABLE IF NOT EXISTS `rrInterval_new` (`deviceId` TEXT NOT NULL, `ts` INTEGER NOT NULL, " +
+                "`rrMs` INTEGER NOT NULL, `seq` INTEGER NOT NULL, `synced` INTEGER NOT NULL, " +
+                "PRIMARY KEY(`deviceId`, `ts`, `rrMs`, `seq`))",
+            sql[0],
+        )
+        // Every existing row copied with seq = 0 (old PK made (deviceId, ts, rrMs) unique, so seq 0 is safe).
+        assertEquals(
+            "INSERT INTO `rrInterval_new` (`deviceId`, `ts`, `rrMs`, `seq`, `synced`) " +
+                "SELECT `deviceId`, `ts`, `rrMs`, 0, `synced` FROM `rrInterval`",
+            sql[1],
+        )
+        assertTrue("preserves history (no DELETE of source before copy)", !sql[1].uppercase().contains("DELETE"))
+        assertEquals("DROP TABLE `rrInterval`", sql[2])
+        assertEquals("ALTER TABLE `rrInterval_new` RENAME TO `rrInterval`", sql[3])
+        assertTrue("no window functions (minSdk26 SQLite)", !sql.joinToString(" ").uppercase().contains("ROW_NUMBER"))
+    }
+
+    /** THE fix: two EQUAL intervals in the same second now get distinct keys (the second was dropped before). */
+    @Test
+    fun assignRrSeq_equalIntervalsSameSecond_survive_withDistinctKeys() {
+        val ts = 1_780_916_150L
+        val out = assignRrSeq("my-whoop", listOf(RrRow(ts, 600), RrRow(ts, 600), RrRow(ts, 610)))
+        assertEquals("nothing dropped", 3, out.size)
+        assertEquals("equal (ts,rrMs) beats get 0,1; the distinct 610 gets 0", listOf(0, 1, 0), out.map { it.seq })
+        assertEquals(listOf(600, 600, 610), out.map { it.rrMs })
+        assertEquals("distinct (deviceId, ts, rrMs, seq) PKs", 3, out.map { pk(it) }.toSet().size)
+    }
+
+    /**
+     * REGRESSION GUARD (the adversarial-review finding): distinct same-second beats arriving in SEPARATE
+     * insert batches (e.g. live 0x2A37 straddling a buffer flush, or the live/historical merge) must NOT
+     * collide. Because seq keys on (ts, rrMs), distinct values keep seq 0 and their own PK — no drop.
+     */
+    @Test
+    fun assignRrSeq_distinctBeatsAcrossBatches_doNotCollide() {
+        val ts = 1_780_916_150L
+        val batch1 = assignRrSeq("d", listOf(RrRow(ts, 600)))   // flush A
+        val batch2 = assignRrSeq("d", listOf(RrRow(ts, 560)))   // flush B, same wall-second
+        val pks = (batch1 + batch2).map { pk(it) }
+        assertEquals("both seq 0 but distinct rrMs → distinct PKs, neither dropped", 2, pks.toSet().size)
+        // A ts-only index would have given both seq 0 with rrMs out of the key → identical PK → one dropped.
+    }
+
+    /** Re-syncing an identical batch reproduces the same (ts, rrMs, seq) → idempotent (IGNORE dedupes). */
+    @Test
+    fun assignRrSeq_idempotentOnResync() {
+        val batch = listOf(RrRow(100L, 800), RrRow(100L, 800), RrRow(101L, 790))
+        val r1 = assignRrSeq("d", batch)
+        assertEquals("equal 800s get 0,1; 790 gets 0", listOf(0, 1, 0), r1.map { it.seq })
+        assertEquals("same input → same keys", r1.map { pk(it) }, assignRrSeq("d", batch).map { pk(it) })
+    }
+
+    /** The real v18 golden record ([602,613]) round-trips: distinct values, both seq 0, both kept. */
+    @Test
+    fun assignRrSeq_realV18Record() {
+        val out = assignRrSeq("my-whoop", listOf(RrRow(1_780_916_150L, 602), RrRow(1_780_916_150L, 613)))
+        assertEquals(listOf(602, 613), out.map { it.rrMs })
+        assertEquals(listOf(0, 0), out.map { it.seq })
+    }
+}


### PR DESCRIPTION
## Summary

The Android `rrInterval` store drops the second of two equal successive R-R intervals that fall in the same one-second `ts` bucket, which biases RMSSD and HRV high. This adds a `seq` tiebreaker so both survive, while never dropping distinct beats.

## The bug

`rrInterval` PK is `(deviceId, ts, rrMs)` with `OnConflictStrategy.IGNORE` (the Android twin of the Swift `ON CONFLICT DO NOTHING` upsert). Every beat in a record or notification is stamped with one whole-second `ts` (historical `HistoricalStreams`, live `System.currentTimeMillis()/1000`). When two successive intervals in the same second are equal, for example `[812, 812]`, they share the full key and the second is silently dropped. That removes a zero-difference beat pair, so RMSSD comes out high. The upward bias lands at rest and during sleep, which is when HRV is scored. The real v18 records in `decoder_oracle.json` carry multiple R-R per second, so the collision is a live path, not a theoretical one.

## The fix

Widen the PK to `(deviceId, ts, rrMs, seq)`, adding `seq` as a tiebreaker for equal `(ts, rrMs)` beats.

- `assignRrSeq` numbers equal `(ts, rrMs)` beats `0, 1, ...` at insert, so both survive.
- Distinct intervals keep `seq 0` and their own `(ts, rrMs)` slot, so no distinct beat is ever dropped, including when same-second beats arrive in separate insert batches or via the live and historical merge. An earlier iteration keyed on `ts` alone, which restarted `seq` per batch and could drop distinct cross-batch beats. Keeping `rrMs` in the key avoids that.
- Read order stays `ORDER BY ts, rrMs` (plus `seq`) to match Swift `Reads.swift`.
- Re-syncing identical offload records reproduces the same `(ts, rrMs, seq)`, so the insert stays idempotent.

## Migration (Room v17 to v18)

A PK change needs a table rebuild because SQLite cannot alter a primary key. It is loss-less: every existing row is copied with `seq = 0`, which is exact because the old PK guaranteed a unique `(deviceId, ts, rrMs)` per row. No window functions, since minSdk 26 SQLite has no `ROW_NUMBER`. The migration SQL is exposed as `RR_SEQ_MIGRATION_SQL` and pinned by a plain-JVM test, matching the existing per-migration test pattern.

This is the first non-additive (table-rebuild) migration in the DB, and the app runs with `exportSchema=false` and no destructive fallback, so the rebuilt table was verified to match Room's generated v18 schema exactly. A mismatch would throw at open.

Forward-only: beats already dropped under the old key are unrecoverable, so this does not retroactively correct historical HRV. Only inserts after the upgrade stop dropping equal beats.

## Verification

- Unit test `RrSeqMigrationTest`: equal same-second beats survive with distinct keys, distinct beats in separate batches do not collide (regression guard), re-sync is idempotent, the real v18 golden record `[602, 613]` round-trips, and the migration SQL is pinned to Room's generated schema.
- The exact migration SQL run against SQLite with populated rows: all rows preserved, `seq` assigned, equal beats kept, distinct cross-batch beats kept.
- On device: a fresh install generates the v18 schema `PRIMARY KEY(deviceId, ts, rrMs, seq)` identical to the migration target, and a real in-place upgrade from the released v17 (8.5.2) to this v18 ran the Room migration cleanly, with `user_version` going 17 to 18, the table rebuilt, and no crash.

## Swift parity

This widens only the Android and Room key. The identical value-key drop exists in the Swift `WhoopStore` (`Database.swift` PK `(deviceId, ts, rrMs)`, `StreamStore.swift` insert, `Reads.swift` `ORDER BY ts, rrMs`). I could not build or test the Swift packages in my environment, so this PR is scoped to Android with an inline note. The same widening should follow in `WhoopStore` to keep parity. I am happy to port it if you would rather have it in one change.

## Scope

One concern, one commit, one schema migration. No protocol or UI changes.
