### PR TITLE
Settings: use .menu pickers so segmented controls can't oversize the screen (#161)

### DIFF
--- a/Strand/Screens/SettingsView.swift
+++ b/Strand/Screens/SettingsView.swift
@@ -600,8 +600,8 @@ struct SettingsView: View {
                         Text("Imperial").tag(UnitSystem.imperial.rawValue)
                     }
                     .labelsHidden()
-                    .pickerStyle(.segmented)
-                    .fixedSize()
+                    .pickerStyle(.menu)
+                    .tint(StrandPalette.accent)
                     .accessibilityLabel("Measurement system")
                 }
                 rowDivider
@@ -614,8 +614,8 @@ struct SettingsView: View {
                         Text("°F").tag(TemperatureUnit.fahrenheit.rawValue)
                     }
                     .labelsHidden()
-                    .pickerStyle(.segmented)
-                    .fixedSize()
+                    .pickerStyle(.menu)
+                    .tint(StrandPalette.accent)
                     .accessibilityLabel("Temperature unit")
                 }
                 rowDivider
@@ -627,8 +627,8 @@ struct SettingsView: View {
                         Text("0-21").tag(EffortScale.whoop.rawValue)
                     }
                     .labelsHidden()
-                    .pickerStyle(.segmented)
-                    .fixedSize()
+                    .pickerStyle(.menu)
+                    .tint(StrandPalette.accent)
                     .accessibilityLabel("Effort scale")
                 }
             }
@@ -654,8 +654,8 @@ struct SettingsView: View {
                         }
                     }
                     .labelsHidden()
-                    .pickerStyle(.segmented)
-                    .fixedSize()
+                    .pickerStyle(.menu)
+                    .tint(StrandPalette.accent)
                     .accessibilityLabel("Theme")
                 }
                 rowDivider   // #79: the segmented rows sat flush against each other (missing separator)
@@ -668,8 +668,8 @@ struct SettingsView: View {
                         }
                     }
                     .labelsHidden()
-                    .pickerStyle(.segmented)
-                    .fixedSize()
+                    .pickerStyle(.menu)
+                    .tint(StrandPalette.accent)
                     .accessibilityLabel("Chart colours")
                 }
                 rowDivider
@@ -682,8 +682,8 @@ struct SettingsView: View {
                         }
                     }
                     .labelsHidden()
-                    .pickerStyle(.segmented)
-                    .fixedSize()
+                    .pickerStyle(.menu)
+                    .tint(StrandPalette.accent)
                     .accessibilityLabel("Trend chart style")
                 }
                 #if os(iOS)
@@ -694,8 +694,8 @@ struct SettingsView: View {
                         Text("Navy").tag(true)
                     }
                     .labelsHidden()
-                    .pickerStyle(.segmented)
-                    .fixedSize()
+                    .pickerStyle(.menu)
+                    .tint(StrandPalette.accent)
                     .accessibilityLabel("App icon")
                     .onChangeCompat(of: useNavyIcon) { applyAppIcon($0) }
                 }
@@ -888,8 +888,8 @@ struct SettingsView: View {
                         Text("Deep sleep").tag(HrvWindow.deep.rawValue)
                     }
                     .labelsHidden()
-                    .pickerStyle(.segmented)
-                    .fixedSize()
+                    .pickerStyle(.menu)
+                    .tint(StrandPalette.accent)
                     .accessibilityLabel("HRV window")
                     .onChangeCompat(of: hrvWindowRaw) { _ in
                         // The new window shifts every night's avgHrv, so the HRV BASELINE must re-learn or


### PR DESCRIPTION
Fixes #161.

### The bug
On iOS the Settings screen renders **oversized / shifted** (reported on 8.5.2, iOS 26.5). Root cause: the Units/Appearance segmented pickers use `.pickerStyle(.segmented)` + `.fixedSize()`, which pins each to its ideal width. Once a row's label + options exceed the screen width — long labels, a localized string, or **enlarged Text Size** — that row overflows, and SwiftUI sizes the whole Settings column to it, so everything looks too big.

### It's a known, documented failure mode
This is exactly what `#43` already fixed for the **Age/Sex** pickers (see the comment at `SettingsView.swift:318`):
> *"a segmented picker collapses WITHOUT `.fixedSize()` but OVERFLOWS the screen WITH it once the labels are long … or Text Size is enlarged — the oversized Settings screen users reported. A menu is a compact button that fits any label length."*

Age/Sex were switched to `.pickerStyle(.menu)`; the other pickers weren't. This applies the same proven fix to the remaining **eight**: Measurement, Temperature, Effort scale, Theme, Chart colours, Trend charts, App icon, and **HRV window**.

### On the HRV window picker (my regression)
The HRV window picker (added 8.5.1 #147, moved to Strap 8.5.2 #157) followed the old `.fixedSize()` pattern with unusually **wide** options ("Whole night" / "Deep sleep"), so it likely *worsened* this in 8.5.2. Now converted too.

### Why `.menu`, not "remove `.fixedSize()`"
Per the in‑file `#43` note, removing `.fixedSize()` alone makes a segmented picker **collapse** (unreadable), and it doesn't cover the enlarged‑Text‑Size case. `.menu` (a compact dropdown that fits any label length / text size) eliminates the overflow class entirely.

### Scope / verification
- **iOS‑only** — Android uses `SegmentedPillControl`, unaffected by this SwiftUI layout mechanism.
- Mechanical: 8 pickers, `.segmented + .fixedSize()` → `.menu + .tint(StrandPalette.accent)`, mirroring the existing Age/Sex rows.
- It's a **layout** change, so it wants an on‑device / screenshot check (release CI validates the Swift build; local Swift build hits the usual wall).
