### PR TITLE
Profile: derive age from date of birth instead of a manual number (#146)

### DIFF
--- a/.github/workflows/app-build.yml
+++ b/.github/workflows/app-build.yml
@@ -37,7 +37,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: macos-15
+    runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
       matrix:
@@ -48,9 +48,14 @@ jobs:
           - scheme: Strand
             destination: 'generic/platform=macOS'
             extra_args: 'ARCHS="x86_64 arm64" ONLY_ACTIVE_ARCH=NO'
+            runner: macos-15
+          # iOS needs the iOS 26 SDK (Liquid Glass's `glassEffect`, landed 2026-07-07) which macos-15's
+          # default Xcode doesn't ship — matches the runner fork-testing-build.yml/fork-release.yml
+          # already use for their NOOPiOS legs. macos-15 stays correct for the macOS/Strand leg above.
           - scheme: NOOPiOS
             destination: 'generic/platform=iOS Simulator'
             extra_args: ''
+            runner: macos-26
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/Packages/WhoopProtocol/Tests/WhoopProtocolTests/DecoderOracleTests.swift
+++ b/Packages/WhoopProtocol/Tests/WhoopProtocolTests/DecoderOracleTests.swift
@@ -83,7 +83,14 @@ final class DecoderOracleTests: XCTestCase {
                     let gy = parsed["gravity_y"]?.doubleValue
                     let gz = parsed["gravity_z"]?.doubleValue
                     XCTAssertNotNil(gx, "\(frame.name): gravity did not decode")
-                    let mag = ((gx ?? 0) * (gx ?? 0) + (gy ?? 0) * (gy ?? 0) + (gz ?? 0) * (gz ?? 0)).squareRoot()
+                    // Broken into named sub-expressions: the single-line nested-optional-coalescing form
+                    // occasionally blew the type-checker's time budget in CI ("unable to type-check this
+                    // expression in reasonable time"), a Swift compiler perf cliff, not a real ambiguity.
+                    let x: Double = gx ?? 0
+                    let y: Double = gy ?? 0
+                    let z: Double = gz ?? 0
+                    let sumSquares: Double = x * x + y * y + z * z
+                    let mag = sumSquares.squareRoot()
                     XCTAssertEqual(mag, wantMag, accuracy: 0.1, "\(frame.name): |gravity|")
                 default:
                     switch expected {

--- a/Strand/Data/Profile.swift
+++ b/Strand/Data/Profile.swift
@@ -6,7 +6,17 @@ import SwiftUI
 /// Powers HR zones, calories and recovery baselines.
 @MainActor
 final class ProfileStore: ObservableObject {
-    @Published var age: Int { didSet { d.set(age, forKey: K.age) } }
+    /// The canonical source of truth for age (#146): stored as a date so age advances on its own
+    /// instead of silently going stale until the user remembers to bump a number.
+    @Published var dateOfBirth: Date {
+        didSet {
+            d.set(dateOfBirth, forKey: K.dateOfBirth)
+            // Keep the legacy `profile.age` key mirrored so the `.noopbak` cross-platform backup
+            // whitelist (BackupSettings, unchanged, still mirrored byte-for-byte by Android) keeps
+            // round-tripping an age value without needing a DOB field on that side too.
+            d.set(age, forKey: K.legacyAge)
+        }
+    }
     @Published var sex: String { didSet { d.set(sex, forKey: K.sex) } }          // "male" | "female" | "nonbinary"
     @Published var weightKg: Double { didSet { d.set(weightKg, forKey: K.weight) } }
     @Published var heightCm: Double { didSet { d.set(heightCm, forKey: K.height) } }
@@ -52,7 +62,11 @@ final class ProfileStore: ObservableObject {
 
     private let d = UserDefaults.standard
     private enum K {
-        static let age = "profile.age", sex = "profile.sex", weight = "profile.weightKg"
+        static let dateOfBirth = "profile.dateOfBirth"
+        /// Pre-#146 storage key. No longer the source of truth, but kept mirrored (see `dateOfBirth`'s
+        /// `didSet`) so the cross-platform backup whitelist keeps working unchanged.
+        static let legacyAge = "profile.age"
+        static let sex = "profile.sex", weight = "profile.weightKg"
         static let height = "profile.heightCm", hrMax = "profile.hrMaxOverride"
         static let stepScale = "profile.stepTicksPerStep"
         static let waist = "profile.waistCm"
@@ -65,7 +79,27 @@ final class ProfileStore: ObservableObject {
     }
 
     init() {
-        age = d.object(forKey: K.age) as? Int ?? 30
+        let storedDOB = d.object(forKey: K.dateOfBirth) as? Date
+        let storedAge = d.object(forKey: K.legacyAge) as? Int
+        let resolvedDOB: Date
+        switch (storedDOB, storedAge) {
+        case let (dob?, age?) where Self.years(from: dob, to: Date()) != age:
+            // The mirrored legacy key moved without `dateOfBirth` (e.g. a `.noopbak` restore applies
+            // straight to `profile.age` in UserDefaults) — resynthesize DOB so the restore takes.
+            resolvedDOB = Self.dateOfBirth(forAge: age)
+        case let (dob?, _):
+            resolvedDOB = dob
+        case let (nil, age?):
+            resolvedDOB = Self.dateOfBirth(forAge: age)
+        case (nil, nil):
+            resolvedDOB = Self.dateOfBirth(forAge: 30)
+        }
+        dateOfBirth = resolvedDOB
+        // `didSet` doesn't fire for a property's own initial assignment inside `init()`, so persist
+        // explicitly here — otherwise a migrated/derived DOB never reaches UserDefaults until the
+        // user next edits it.
+        d.set(resolvedDOB, forKey: K.dateOfBirth)
+        d.set(Self.years(from: resolvedDOB, to: Date()), forKey: K.legacyAge)
         sex = d.string(forKey: K.sex) ?? "male"
         weightKg = d.object(forKey: K.weight) as? Double ?? 75
         heightCm = d.object(forKey: K.height) as? Double ?? 178
@@ -111,8 +145,31 @@ final class ProfileStore: ObservableObject {
     /// nil when 0 (auto-fit), the positive value otherwise.
     var stepsManualOverride: Double? { stepsManualCoefficient > 0 ? stepsManualCoefficient : nil }
 
+    /// Current age in whole years, derived from `dateOfBirth` (#146) rather than a number the user
+    /// has to remember to update. Every existing call site (HR zones, calories, Fitness/Body Age)
+    /// keeps reading this unchanged.
+    var age: Int { Self.years(from: dateOfBirth, to: Date()) }
+
+    /// Whole years elapsed from `from` to `to` (floor, like a birthday not yet reached this year).
+    nonisolated static func years(from: Date, to: Date) -> Int {
+        Calendar.current.dateComponents([.year], from: from, to: to).year ?? 0
+    }
+
+    /// A date-of-birth `age` years before today, anchored to today's month/day so the derived age
+    /// matches exactly (used for migrating the old manually-entered age, and for backup restores that
+    /// only carry the legacy `profile.age` key).
+    nonisolated static func dateOfBirth(forAge age: Int) -> Date {
+        Calendar.current.date(byAdding: .year, value: -age, to: Date()) ?? Date()
+    }
+
     /// Tanaka estimate unless overridden.
     var hrMax: Int { hrMaxOverride > 0 ? hrMaxOverride : Int((208 - 0.7 * Double(age)).rounded()) }
+
+    /// Bounds for the date-of-birth picker, matching the old age `Stepper`'s 13...100 range so a DOB
+    /// pick can't derive an out-of-range age.
+    static var dateOfBirthRange: ClosedRange<Date> {
+        dateOfBirth(forAge: 100)...dateOfBirth(forAge: 13)
+    }
 
     /// Whether the cycle-awareness opt-in applies to this profile (#801). Cycle phase is read from the
     /// MENSTRUAL skin-temperature shift, so the opt-in (the Health card + the Automations toggle) is only

--- a/Strand/Onboarding/OnboardingWizard.swift
+++ b/Strand/Onboarding/OnboardingWizard.swift
@@ -712,8 +712,22 @@ private struct ProfileStep: View {
             VStack(spacing: 16) {
                 StrandCard {
                     VStack(spacing: 18) {
-                        Stepper(value: $profile.age, in: 13...100) {
-                            FieldRow(label: String(localized: "Age"), value: String(localized: "\(profile.age) yrs"))
+                        VStack(alignment: .leading, spacing: 8) {
+                            Text("Date of Birth").strandOverline()
+                            HStack {
+                                DatePicker(
+                                    "",
+                                    selection: $profile.dateOfBirth,
+                                    in: ProfileStore.dateOfBirthRange,
+                                    displayedComponents: [.date]
+                                )
+                                .labelsHidden()
+                                .datePickerStyle(.compact)
+                                Spacer()
+                                Text(String(localized: "\(profile.age) yrs"))
+                                    .font(StrandFont.bodyNumber)
+                                    .foregroundStyle(StrandPalette.textPrimary)
+                            }
                         }
 
                         Divider().overlay(StrandPalette.hairline)

--- a/Strand/Screens/SettingsView.swift
+++ b/Strand/Screens/SettingsView.swift
@@ -296,15 +296,21 @@ struct SettingsView: View {
             blurb: "These power your heart-rate zones, calorie estimates and recovery baselines. Keep them accurate."
         ) {
             VStack(spacing: 0) {
-                FormRow(label: "Age") {
+                FormRow(label: "Date of Birth") {
                     HStack(spacing: 12) {
                         Text("\(profile.age)")
                             .font(StrandFont.bodyNumber)
-                            .foregroundStyle(StrandPalette.textPrimary)
+                            .foregroundStyle(StrandPalette.textSecondary)
                             .frame(minWidth: 28, alignment: .trailing)
-                        Stepper("Age", value: $profile.age, in: 13...100)
-                            .labelsHidden()
-                            .accessibilityLabel("Age, \(profile.age) years")
+                        DatePicker(
+                            "",
+                            selection: $profile.dateOfBirth,
+                            in: ProfileStore.dateOfBirthRange,
+                            displayedComponents: [.date]
+                        )
+                        .labelsHidden()
+                        .datePickerStyle(.compact)
+                        .accessibilityLabel("Date of birth, age \(profile.age) years")
                     }
                 }
                 rowDivider


### PR DESCRIPTION
## What this PR does

Age silently went stale once entered, so age-based metrics (Fitness Age, HR-max/Tanaka, calorie estimates) drifted unless the user remembered to bump the number manually.

`ProfileStore` now stores a `dateOfBirth` and computes age from it; the Settings and onboarding age `Stepper` become a `DatePicker`. A pre-#146 install's stored age is migrated into an equivalent date of birth on first launch, and the legacy `profile.age` UserDefaults key stays mirrored so the existing cross-platform `.noopbak` backup whitelist keeps round-tripping unchanged.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] CI / tooling

## How it was tested

Builds and existing profile/migration tests pass. No BLE path touched.

## Checklist

- [x] Swift package tests pass for any package I touched
- [x] No new build warnings introduced
- [x] UI changes use only `StrandDesign` tokens — no hardcoded colors, fonts, or spacing
- [x] Follows the conventions in `docs/CONTRIBUTING.md`
- [x] I did not commit generated output or any secrets/keystores

## Related issues

Closes #146