### PR TITLE
BLE (Android): reliable 5/MG reconnect, attach without a scan, live battery + manual controls

### DIFF
--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -604,6 +604,9 @@ class WhoopBleClient(
         // disconnect/reconnect fixes is really a missing keep-alive. We re-arm + poll battery every
         // 30s, and bounce a truly silent link after 120s (the auto version of disconnect+reconnect).
         private const val KEEPALIVE_INTERVAL_MS = 30_000L
+        /** Delay after the 5/MG connect handshake before reading battery (0x2A19), so it doesn't race the
+         *  clock writes on a slow stack while still populating the ring within ~2s of connect. */
+        private const val BATTERY_ON_CONNECT_DELAY_MS = 1_500L
         /** No inbound data for this long ⇒ the link/stream stalled; bounce it to resume streaming. */
         private const val KEEPALIVE_STALL_MS = 120_000L
         /** #580: longer stall fuse for a known history-empty 5/MG. Live HR over 0x2A37 keeps the link alive
@@ -3828,10 +3831,18 @@ class WhoopBleClient(
                 // WHOOP 4.0 only: re-arm realtime HR so the firmware can't let it lapse (while the Live
                 // screen wants it), and poll battery (~60s) — which also keeps the link warm. A 5/MG
                 // strap rejects WHOOP4-framed commands, so we skip them and rely on re-subscribe + bounce.
+                // Advance the tick for BOTH families so the ~60s battery cadence fires on 5/MG too (it used
+                // to increment only inside the WHOOP4 branch, so a 5/MG tick never advanced).
+                keepAliveTick += 1
                 if (connectedFamily == DeviceFamily.WHOOP4) {
                     if (wantsRealtime) { realtimeArmed = true; send(CommandNumber.TOGGLE_REALTIME_HR, byteArrayOf(1)) }
-                    keepAliveTick += 1
                     if (keepAliveTick % 2 == 0) send(CommandNumber.GET_BATTERY_LEVEL)
+                } else if (connectedFamily == DeviceFamily.WHOOP5 && keepAliveTick % 2 == 0) {
+                    // 5/MG battery comes ONLY from a 0x2A19 read (refreshBattery), and the strap sends no
+                    // unsolicited battery notification — so poll it here (~60s) instead of only while the Live
+                    // screen is open. This keeps the battery ring fresh on any screen without a manual
+                    // Body > Health > Sync, and the read doubles as a link keep-warm.
+                    refreshBattery()
                 }
             }
         }
@@ -4230,6 +4241,9 @@ class WhoopBleClient(
                 connectHandshakeDone = true
                 send(CommandNumber.SET_CLOCK, setClockPayload(), withResponse = true)
                 send(CommandNumber.GET_CLOCK, byteArrayOf(), withResponse = true)
+                // Populate the battery ring right after connect (not only once the Live screen opens).
+                // Posted after the clock writes settle so the 0x2A19 read doesn't race them on a slow stack.
+                handler.postDelayed({ refreshBattery() }, BATTERY_ON_CONNECT_DELAY_MS)
                 log("WHOOP 5/MG: clock synced (set/get) — strap can persist history now")
                 if (!backfillStarted) {
                     backfillStarted = true
@@ -5073,9 +5087,16 @@ class WhoopBleClient(
                 // range stops hammering BLE — replaces the old fixed RECONNECT_DELAY_MS. The counter
                 // resets on the next STATE_CONNECTED and on an explicit user Connect. (#48)
                 val directDelay = nextReconnectDelayMs()
-                log("Disconnected (status=$status); reconnecting directly in ${directDelay / 1000}s (attempt $failedReconnectAttempts)")
+                // The FIRST couple of reconnect attempts use the FAST direct connect (autoConnect=false) —
+                // the same path as first-connect. A 5/MG the OS still holds bonded/ACL-connected never
+                // re-emits the advertisement/connection-complete event that autoConnect=true waits for, so
+                // passive mode just hangs — the "very hard to reconnect after a drop, though app-start
+                // connects instantly" report. Fall back to autoConnect=true from the 3rd attempt for a strap
+                // that is genuinely out of range (#61: reconnect when it returns to range, no scan/advert).
+                val passiveReconnect = failedReconnectAttempts >= 3
+                log("Disconnected (status=$status); reconnecting ${if (passiveReconnect) "passively" else "directly"} in ${directDelay / 1000}s (attempt $failedReconnectAttempts)")
                 // #1030 (ryanbr): cancellable backoff timer (see scheduleReconnect).
-                scheduleReconnect(directDelay) { connectToDevice(dev, autoConnect = true) }
+                scheduleReconnect(directDelay) { connectToDevice(dev, autoConnect = passiveReconnect) }
             } else {
                 val rescanDelay = nextReconnectDelayMs()
                 log("Disconnected (status=$status); rescanning in ${rescanDelay / 1000}s (attempt $failedReconnectAttempts)")

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -604,8 +604,9 @@ class WhoopBleClient(
         // disconnect/reconnect fixes is really a missing keep-alive. We re-arm + poll battery every
         // 30s, and bounce a truly silent link after 120s (the auto version of disconnect+reconnect).
         private const val KEEPALIVE_INTERVAL_MS = 30_000L
-        /** Delay after the 5/MG connect handshake before reading battery (0x2A19), so it doesn't race the
-         *  clock writes on a slow stack while still populating the ring within ~2s of connect. */
+        /** Delay after the 5/MG connect handshake before the first battery read (0x2A19), so it does not
+         *  race the clock writes on a slow stack while still populating the ring within a couple of seconds
+         *  of connect. */
         private const val BATTERY_ON_CONNECT_DELAY_MS = 1_500L
         /** No inbound data for this long ⇒ the link/stream stalled; bounce it to resume streaming. */
         private const val KEEPALIVE_STALL_MS = 120_000L
@@ -1586,23 +1587,24 @@ class WhoopBleClient(
             log("Scan already in progress — ignoring")
             return
         }
-        // 5/MG fast path: a strap the OS already bonded connects DIRECTLY — no scan, no advertisement
-        // needed. Real hardware showed scan-reconnects against an OS-bonded 5/MG failing their first
-        // protected GATT operation (status=133), while the direct path reached a working puffin
-        // session. Falls open to the normal scan when no bonded WHOOP is found; a stale bond falls
-        // back to a scan via handleDisconnect. Never used for WHOOP 4. (#78 fork)
-        if (model == WhoopModel.WHOOP5_MG) {
-            val bonded = bondedWhoopDevice()
-            if (bonded != null) {
-                log("Connecting directly to OS-bonded ${bonded.name ?: "WHOOP"}")
-                _state.update { it.copy(
-                    scanning = false, whoop5Detected = false,
-                    statusNote = "Connecting to your bonded ${model.displayName}…",
-                ) }
-                connectToDevice(bonded)
-                bondedDirectAttempt = true   // after connectToDevice: reset() must not clear it
-                return
-            }
+        // Reach a WHOOP 5/MG without a scan. Prefer a band the OS already holds connected
+        // (getConnectedDevices returns it even after it stops advertising), then a bonded band that is not
+        // currently connected (a direct connect avoids the status=133 first-operation failure seen on
+        // scan-based 5/MG reconnects). Both helpers match only a 5/MG strap, so a WHOOP 4 falls through to
+        // the scan below. The family is resolved from the discovered services rather than the selected
+        // model, so this runs for any selected model and pins selectedModel to 5/MG on a hit to keep the
+        // pipeline consistent. A stale connection or bond falls back to a scan via handleDisconnect.
+        val direct = getConnectedWhoopDevice() ?: bondedWhoopDevice()
+        if (direct != null) {
+            selectedModel = WhoopModel.WHOOP5_MG
+            log("Easy-connect: attaching directly to ${direct.name ?: "WHOOP"} (no scan needed)")
+            _state.update { it.copy(
+                scanning = false, whoop5Detected = false,
+                statusNote = "Connecting to your ${WhoopModel.WHOOP5_MG.displayName}…",
+            ) }
+            connectToDevice(direct)
+            bondedDirectAttempt = true   // after connectToDevice: reset() must not clear it
+            return
         }
         startScan(model, allowFallback = true)
     }
@@ -1909,6 +1911,13 @@ class WhoopBleClient(
         selectedModel = model
         scanningForList = true
         _discoveredWhoops.value = emptyList()   // fresh list each time the wizard opens the scan
+        // Also list a WHOOP 5/MG the OS already holds connected, so the wizard can add a band that is not
+        // advertising (rssi 0 marks a connected, non-advertised entry). The scan below still adds any
+        // advertising straps.
+        getConnectedWhoopDevice()?.let { d ->
+            val n = try { d.name } catch (se: SecurityException) { null }
+            _discoveredWhoops.value = listOf(DiscoveredWhoop(address = d.address, name = n, rssi = 0))
+        }
         val filters = listOf(
             ScanFilter.Builder().setServiceUuid(ParcelUuid(model.service)).build(),
         )
@@ -2499,6 +2508,24 @@ class WhoopBleClient(
     /** The OS-bonded 5/MG-family strap, if any (name "WHOOP …" but not "WHOOP 4…" — MG-named units
      *  match too). Fails open to a scan on any lookup problem. (#78 fork) */
     @SuppressLint("MissingPermission")
+    /**
+     * A WHOOP 5/MG the OS already holds GATT-connected. Android multiplexes one ACL across GATT clients, so
+     * a band connected to another app is still returned by getConnectedDevices even after it stops
+     * advertising, and a client can attach to it without a scan. Uses the same 5/MG name filter and
+     * multi-strap pin selection as [bondedWhoopDevice]; a WHOOP 4 is excluded and left to the scan.
+     */
+    private fun getConnectedWhoopDevice(): BluetoothDevice? = try {
+        val connected = bluetoothManager?.getConnectedDevices(BluetoothProfile.GATT)?.filter { d ->
+            val n = try { d.name } catch (se: SecurityException) { null } ?: return@filter false
+            n.startsWith("WHOOP", ignoreCase = true) && !n.startsWith("WHOOP 4", ignoreCase = true)
+        }.orEmpty()
+        val preferred = preferredAddress
+        if (preferred != null) connected.firstOrNull { it.address.equals(preferred, ignoreCase = true) }
+        else connected.firstOrNull()
+    } catch (se: SecurityException) {
+        null
+    }
+
     private fun bondedWhoopDevice(): BluetoothDevice? = try {
         val bonded = adapter?.bondedDevices?.filter { d ->
             val n = try { d.name } catch (se: SecurityException) { null } ?: return@filter false
@@ -3831,17 +3858,17 @@ class WhoopBleClient(
                 // WHOOP 4.0 only: re-arm realtime HR so the firmware can't let it lapse (while the Live
                 // screen wants it), and poll battery (~60s) — which also keeps the link warm. A 5/MG
                 // strap rejects WHOOP4-framed commands, so we skip them and rely on re-subscribe + bounce.
-                // Advance the tick for BOTH families so the ~60s battery cadence fires on 5/MG too (it used
-                // to increment only inside the WHOOP4 branch, so a 5/MG tick never advanced).
+                // Advance the tick for both families so the ~60s battery cadence also fires on 5/MG (it
+                // previously incremented only inside the WHOOP 4 branch).
                 keepAliveTick += 1
                 if (connectedFamily == DeviceFamily.WHOOP4) {
                     if (wantsRealtime) { realtimeArmed = true; send(CommandNumber.TOGGLE_REALTIME_HR, byteArrayOf(1)) }
                     if (keepAliveTick % 2 == 0) send(CommandNumber.GET_BATTERY_LEVEL)
                 } else if (connectedFamily == DeviceFamily.WHOOP5 && keepAliveTick % 2 == 0) {
-                    // 5/MG battery comes ONLY from a 0x2A19 read (refreshBattery), and the strap sends no
-                    // unsolicited battery notification — so poll it here (~60s) instead of only while the Live
-                    // screen is open. This keeps the battery ring fresh on any screen without a manual
-                    // Body > Health > Sync, and the read doubles as a link keep-warm.
+                    // 5/MG battery comes only from a 0x2A19 read and the strap sends no unsolicited battery
+                    // notification, so poll it here (about every 60s) rather than only while the Live screen
+                    // is open. The ring then stays current on any screen without a manual sync, and the read
+                    // keeps the link warm.
                     refreshBattery()
                 }
             }
@@ -4241,8 +4268,8 @@ class WhoopBleClient(
                 connectHandshakeDone = true
                 send(CommandNumber.SET_CLOCK, setClockPayload(), withResponse = true)
                 send(CommandNumber.GET_CLOCK, byteArrayOf(), withResponse = true)
-                // Populate the battery ring right after connect (not only once the Live screen opens).
-                // Posted after the clock writes settle so the 0x2A19 read doesn't race them on a slow stack.
+                // Populate the battery ring right after connect, not only once the Live screen opens. Posted
+                // after the clock writes settle so the 0x2A19 read does not race them on a slow stack.
                 handler.postDelayed({ refreshBattery() }, BATTERY_ON_CONNECT_DELAY_MS)
                 log("WHOOP 5/MG: clock synced (set/get) — strap can persist history now")
                 if (!backfillStarted) {
@@ -5087,12 +5114,12 @@ class WhoopBleClient(
                 // range stops hammering BLE — replaces the old fixed RECONNECT_DELAY_MS. The counter
                 // resets on the next STATE_CONNECTED and on an explicit user Connect. (#48)
                 val directDelay = nextReconnectDelayMs()
-                // The FIRST couple of reconnect attempts use the FAST direct connect (autoConnect=false) —
-                // the same path as first-connect. A 5/MG the OS still holds bonded/ACL-connected never
-                // re-emits the advertisement/connection-complete event that autoConnect=true waits for, so
-                // passive mode just hangs — the "very hard to reconnect after a drop, though app-start
-                // connects instantly" report. Fall back to autoConnect=true from the 3rd attempt for a strap
-                // that is genuinely out of range (#61: reconnect when it returns to range, no scan/advert).
+                // The first reconnect attempts use the fast direct connect (autoConnect=false), the same
+                // path as the initial connect. A 5/MG the OS still holds bonded and ACL-connected never
+                // re-emits the advertisement or connection-complete event that autoConnect=true waits for,
+                // so the passive mode stalls. Fall back to autoConnect=true from the third attempt for a
+                // strap that is genuinely out of range (#61: reconnect once it returns to range, with no
+                // scan or advertisement needed).
                 val passiveReconnect = failedReconnectAttempts >= 3
                 log("Disconnected (status=$status); reconnecting ${if (passiveReconnect) "passively" else "directly"} in ${directDelay / 1000}s (attempt $failedReconnectAttempts)")
                 // #1030 (ryanbr): cancellable backoff timer (see scheduleReconnect).

--- a/android/app/src/main/java/com/noop/ui/DevicesScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/DevicesScreen.kt
@@ -1,5 +1,6 @@
 package com.noop.ui
 
+import android.widget.Toast
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
@@ -165,13 +166,13 @@ fun DevicesScreen(
                 onMakeActive = { switchTarget = device },
                 onRename = { renameTarget = device },
                 onRemove = { removeTarget = device },
-                // Manual connect/disconnect for the WHOOP — the reliable escape hatch when the automatic
-                // reconnect is stuck. connect() runs the same active direct path as onboarding.
+                // Manual connect and disconnect for the WHOOP. A short toast confirms the tap, since the link
+                // state only changes a few seconds later.
                 onConnect = if (device.brand.equals("WHOOP", ignoreCase = true)) {
-                    { viewModel.connect() }
+                    { Toast.makeText(context, "Reconnecting…", Toast.LENGTH_SHORT).show(); viewModel.connect() }
                 } else null,
                 onDisconnect = if (device.brand.equals("WHOOP", ignoreCase = true)) {
-                    { viewModel.disconnect() }
+                    { Toast.makeText(context, "Disconnecting", Toast.LENGTH_SHORT).show(); viewModel.disconnect() }
                 } else null,
             )
         }
@@ -516,10 +517,9 @@ private fun DeviceActionsMenu(
                     }
                 }
             } else {
-                // Manual connect/disconnect (WHOOP only — onConnect is null for other sources). connect()
-                // runs the same active, direct (autoConnect=false) path as onboarding, so it re-establishes a
-                // link the automatic reconnect left stuck, the way re-running setup does. Shown first so it's
-                // the obvious escape hatch.
+                // Manual connect and disconnect (WHOOP only; onConnect is null for other sources). Connect
+                // runs the same direct path as the initial connect, so it recovers a link the automatic
+                // reconnect left stuck. Shown first as the obvious recovery action.
                 if (onConnect != null) {
                     if (isLiveConnected) {
                         MenuItem("Disconnect", Icons.Filled.Close) { onOpenChange(false); onDisconnect?.invoke() }

--- a/android/app/src/main/java/com/noop/ui/DevicesScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/DevicesScreen.kt
@@ -21,12 +21,14 @@ import androidx.compose.material.icons.automirrored.filled.DirectionsRun
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Bolt
 import androidx.compose.material.icons.filled.Circle
+import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material.icons.filled.FavoriteBorder
 import androidx.compose.material.icons.filled.GraphicEq
 import androidx.compose.material.icons.filled.Info
 import androidx.compose.material.icons.filled.MoreVert
+import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material.icons.filled.RemoveCircleOutline
 import androidx.compose.material.icons.filled.Watch
 import androidx.compose.material3.AlertDialog
@@ -163,6 +165,14 @@ fun DevicesScreen(
                 onMakeActive = { switchTarget = device },
                 onRename = { renameTarget = device },
                 onRemove = { removeTarget = device },
+                // Manual connect/disconnect for the WHOOP — the reliable escape hatch when the automatic
+                // reconnect is stuck. connect() runs the same active direct path as onboarding.
+                onConnect = if (device.brand.equals("WHOOP", ignoreCase = true)) {
+                    { viewModel.connect() }
+                } else null,
+                onDisconnect = if (device.brand.equals("WHOOP", ignoreCase = true)) {
+                    { viewModel.disconnect() }
+                } else null,
             )
         }
 
@@ -302,6 +312,8 @@ private fun DeviceCard(
     onRemove: (() -> Unit)?,
     onReAdd: (() -> Unit)? = null,
     onDeleteData: (() -> Unit)? = null,
+    onConnect: (() -> Unit)? = null,
+    onDisconnect: (() -> Unit)? = null,
 ) {
     val profile = deviceProfile(device)
     // The per-device actions menu's open state is hoisted here so the WHOLE card is a tap target that opens
@@ -391,6 +403,7 @@ private fun DeviceCard(
                 DeviceActionsMenu(
                     device = device,
                     isActive = isActive,
+                    isLiveConnected = isLiveConnected,
                     open = menuOpen,
                     onOpenChange = { menuOpen = it },
                     onMakeActive = onMakeActive,
@@ -398,6 +411,8 @@ private fun DeviceCard(
                     onRemove = onRemove,
                     onReAdd = onReAdd,
                     onDeleteData = onDeleteData,
+                    onConnect = onConnect,
+                    onDisconnect = onDisconnect,
                 )
             }
         }
@@ -467,6 +482,7 @@ private fun StatePill(device: PairedDeviceRow, isActive: Boolean, isLiveConnecte
 private fun DeviceActionsMenu(
     device: PairedDeviceRow,
     isActive: Boolean,
+    isLiveConnected: Boolean,
     // Open state is hoisted to the DeviceCard so the whole card (not just this ⋮ button) can open the menu.
     open: Boolean,
     onOpenChange: (Boolean) -> Unit,
@@ -475,6 +491,8 @@ private fun DeviceActionsMenu(
     onRemove: (() -> Unit)?,
     onReAdd: (() -> Unit)?,
     onDeleteData: (() -> Unit)?,
+    onConnect: (() -> Unit)? = null,
+    onDisconnect: (() -> Unit)? = null,
 ) {
     Box {
         IconButton(
@@ -498,6 +516,18 @@ private fun DeviceActionsMenu(
                     }
                 }
             } else {
+                // Manual connect/disconnect (WHOOP only — onConnect is null for other sources). connect()
+                // runs the same active, direct (autoConnect=false) path as onboarding, so it re-establishes a
+                // link the automatic reconnect left stuck, the way re-running setup does. Shown first so it's
+                // the obvious escape hatch.
+                if (onConnect != null) {
+                    if (isLiveConnected) {
+                        MenuItem("Disconnect", Icons.Filled.Close) { onOpenChange(false); onDisconnect?.invoke() }
+                    } else {
+                        MenuItem("Reconnect", Icons.Filled.Refresh) { onOpenChange(false); onConnect() }
+                    }
+                    HorizontalDivider(color = Palette.hairline)
+                }
                 if (!isActive) {
                     MenuItem("Make active", Icons.Filled.Bolt) { onOpenChange(false); onMakeActive() }
                 }


### PR DESCRIPTION
## Summary

Makes WHOOP 5.0/MG reconnect, manual connect and the add-device search actually reach a band, adds a live battery refresh for 5/MG, and gives a one-tap manual recovery in the device menu. Three focused commits; WHOOP 4 behaviour is unchanged.

## Problem

**1. Scan-only could not reach a band another app holds.** The BLE client reached a 5/MG only by scanning for its advertisement. Once the official WHOOP app holds the band it stops advertising, so a manual connect, the add-device search and the automatic reconnect all found nothing and looped on `Scanning for WHOOP...` forever.

**2. Reconnect after a drop used the passive path and hung.** Reconnect called `connectToDevice(autoConnect = true)`, the mode that waits for a fresh advertisement or connection-complete event. A 5/MG the OS still holds bonded and ACL-connected never re-emits that event, so the reconnect stalled, while an app-start connect returns instantly through the `autoConnect = false` fast path.

**3. 5/MG battery only refreshed on a manual sync.** Battery on 5/MG comes only from a `0x2A19` read (`refreshBattery`), which was invoked only from the Live screen, and the keep-alive battery poll was WHOOP4-only. The battery ring refreshed only on a manual Body > Health > Sync.

## Fix

- **Attach without a scan (root cause).** Android multiplexes one ACL across GATT clients, so a band held by another app is still returned by `getConnectedDevices` even when it is not advertising, and a client can attach to it directly. `connect()` and the add-device search now try `getConnectedDevices` first, then a bonded-but-not-connected direct connect, then the scan. Both attach helpers match only a 5/MG strap by name (a WHOOP 4 falls through to the scan) and pin `selectedModel` to 5/MG on a hit, so a fresh install still defaulting to WHOOP 4.0 attaches to a connected 5/MG instead of scanning for the wrong family; the family is resolved from the discovered GATT services.
- **Direct-first reconnect.** Use the fast `autoConnect = false` path for the first two reconnect attempts, then fall back to `autoConnect = true` from the third attempt for a strap that is genuinely out of range (keeps the return-to-range behaviour).
- **Live battery on 5/MG.** Poll `0x2A19` in the keep-alive for 5/MG too (~60s, advancing the keep-alive tick for both families) and read it once after the connect handshake so it populates on connect.
- **Manual Reconnect/Disconnect.** Add Reconnect and Disconnect actions to the WHOOP device's overflow menu (the same menu as Remove) for one-tap recovery when the automatic reconnect is stuck. Reconnect uses the same active direct path onboarding uses. WHOOP only; shown first; Disconnect replaces it while connected.

## Notes

- No schema, permission or dependency changes.
- WHOOP 4 connect/reconnect/battery paths are untouched (5/MG-only name filters, family-gated branches).
- Verified on-device against a WHOOP 5.0/MG: reconnect after drop, manual Reconnect, add-device search and the battery ring all resolve while the band is held by the official app.

## Commits

- `fix(ble): reliable 5/MG reconnect + live battery push`
- `feat(ui): manual Reconnect/Disconnect in the device menu`
- `fix(ble): attach to an OS-connected WHOOP without a scan (getConnectedDevices)`
