### PR TITLE
fix: thread the registry's active strap id into every resolvedSeries caller

### DIFF
--- a/android/app/src/main/java/com/noop/ui/CompareScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/CompareScreen.kt
@@ -517,7 +517,7 @@ private suspend fun loadFullSeries(
     // Wide window covering all of history (the macOS days = 4000 default).
     val to = todayDay(1)
     val from = todayDay(-4000)
-    return vm.repo.resolvedSeries(metric.key, metric.source, from, to).values
+    return vm.repo.resolvedSeries(metric.key, metric.source, from, to, strapDeviceId = vm.activeStrapId).values
 }
 
 /** "yyyy-MM-dd" for today offset by [deltaDays], fixed UTC. */

--- a/android/app/src/main/java/com/noop/ui/HealthScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/HealthScreen.kt
@@ -2339,7 +2339,8 @@ private suspend fun buildSeriesVitalDetail(vm: AppViewModel, key: String): Vital
         title = "Steps",
         unit = "steps",
         color = Palette.metricCyan,
-        points = vm.repo.resolvedSeries("steps_est", "my-whoop", "0000-00-00", "9999-99-99").values,
+        points = vm.repo.resolvedSeries("steps_est", "my-whoop", "0000-00-00", "9999-99-99",
+            strapDeviceId = vm.activeStrapId).values,
         format = { it.roundToInt().toString() },
     )
     "active_kcal" -> {

--- a/android/app/src/main/java/com/noop/ui/LabBookScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/LabBookScreen.kt
@@ -391,7 +391,7 @@ private fun MarkerDetailSheet(
         val to = labDay(1)
         val from = labDay(-4000)
         val markerSeries = vm.repo.metricSeries(WhoopDao.LAB_BOOK_SOURCE_ID, markerKey, from, to).map { it.day to it.value }
-        val wearable = vm.repo.resolvedSeries(s.key, s.source, from, to).values
+        val wearable = vm.repo.resolvedSeries(s.key, s.source, from, to, strapDeviceId = vm.activeStrapId).values
         val built = LabBookProjection.pairMarkerToWearable(markerSeries, wearable, window.days)
         pairs = built
         correlation = if (built.size >= LAB_FLOOR) {

--- a/android/app/src/main/java/com/noop/ui/TodayScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/TodayScreen.kt
@@ -661,7 +661,8 @@ fun TodayScreen(
     var stepsEstForDay by remember { mutableStateOf<Int?>(null) }
     LaunchedEffect(days, selectedDayKey) {
         val byDay = runCatching {
-            viewModel.repo.resolvedSeries("steps_est", "my-whoop", "0000-00-00", "9999-99-99")
+            viewModel.repo.resolvedSeries("steps_est", "my-whoop", "0000-00-00", "9999-99-99",
+                strapDeviceId = viewModel.activeStrapId)
                 .values.associate { it.first to it.second }
         }.getOrDefault(emptyMap())
         stepsEstForDay = byDay[selectedDayKey]?.let { Math.round(it).toInt() }
@@ -697,7 +698,8 @@ fun TodayScreen(
     var restScoreForDay by remember { mutableStateOf<Double?>(null) }
     LaunchedEffect(days, selectedDayKey, selectedDayOffset) {
         val byDay = runCatching {
-            viewModel.repo.resolvedSeries("sleep_performance", "my-whoop", "0000-00-00", "9999-99-99")
+            viewModel.repo.resolvedSeries("sleep_performance", "my-whoop", "0000-00-00", "9999-99-99",
+                strapDeviceId = viewModel.activeStrapId)
                 .values.associate { it.first to it.second }
         }.getOrDefault(emptyMap())
         // #977: the tail-fallback (latest scored night) is now freshness-gated. A live 5.0 whose sleep never
@@ -719,7 +721,8 @@ fun TodayScreen(
     var restCompositeSpark by remember { mutableStateOf<List<Double>>(emptyList()) }
     LaunchedEffect(days, selectedDay) {
         val byDay = runCatching {
-            viewModel.repo.resolvedSeries("sleep_performance", "my-whoop", "0000-00-00", "9999-99-99")
+            viewModel.repo.resolvedSeries("sleep_performance", "my-whoop", "0000-00-00", "9999-99-99",
+                strapDeviceId = viewModel.activeStrapId)
                 .values.associate { it.first to it.second }
         }.getOrDefault(emptyMap())
         val cutoff = selectedDay.minusDays(13).toString()
@@ -742,7 +745,8 @@ fun TodayScreen(
         val resolved = mutableMapOf<String, String>()
         for (key in listOf("recovery", "sleep_performance")) {
             val win = runCatching {
-                viewModel.repo.resolvedSeries(key, "my-whoop", "0000-00-00", "9999-99-99")
+                viewModel.repo.resolvedSeries(key, "my-whoop", "0000-00-00", "9999-99-99",
+                    strapDeviceId = viewModel.activeStrapId)
                     .points.lastOrNull { it.day == selectedDayKey }?.source
             }.getOrNull()
             if (win != null) resolved[key] = win
@@ -864,11 +868,11 @@ fun TodayScreen(
     // day-level deviceId, so an imported metric on an otherwise-computed day reads honestly. Gated on the
     // ring having a value (a calibrating / empty ring shows no badge). Null → no badge. Mirrors the Swift
     // Today lane (per-ring SourceBadge from provenanceByMetric, gated by ringHasValue).
-    val chargeProvenance = remember(provenanceByMetric, displayMetric) {
-        if (displayMetric?.recovery != null) provenanceByMetric["recovery"]?.let { provenanceDisplayLabel(it) } else null
+    val chargeProvenance = remember(provenanceByMetric, displayMetric, viewModel.activeStrapId) {
+        if (displayMetric?.recovery != null) provenanceByMetric["recovery"]?.let { provenanceDisplayLabel(it, viewModel.activeStrapId) } else null
     }
-    val restProvenance = remember(provenanceByMetric, restScoreForDay) {
-        if (restScoreForDay != null) provenanceByMetric["sleep_performance"]?.let { provenanceDisplayLabel(it) } else null
+    val restProvenance = remember(provenanceByMetric, restScoreForDay, viewModel.activeStrapId) {
+        if (restScoreForDay != null) provenanceByMetric["sleep_performance"]?.let { provenanceDisplayLabel(it, viewModel.activeStrapId) } else null
     }
 
     // 14-day trailing calendar window ending on the phone's actual local day.

--- a/android/app/src/main/java/com/noop/ui/TrendsScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/TrendsScreen.kt
@@ -133,7 +133,8 @@ fun TrendsScreen(vm: AppViewModel) {
     var sleepPerfByDay by remember { mutableStateOf<Map<String, Double>>(emptyMap()) }
     LaunchedEffect(days) {
         sleepPerfByDay = runCatching {
-            vm.repo.resolvedSeries("sleep_performance", "my-whoop", "0000-00-00", "9999-99-99")
+            vm.repo.resolvedSeries("sleep_performance", "my-whoop", "0000-00-00", "9999-99-99",
+                strapDeviceId = vm.activeStrapId)
                 .values.associate { it.first to it.second }
         }.getOrDefault(emptyMap())
     }


### PR DESCRIPTION
## What this PR does

Fixes the Rest ring getting stuck on "Calibrating — needs a track night" after removing and re-adding a WHOOP strap, even though tracked nights exist. The Charge/Rest provenance badges and strap battery could go stale the same way.

**Root cause:** re-adding a strap generates a new BLE `deviceId` (MAC). Several `resolvedSeries` call sites (and the ring provenance badges via `provenanceDisplayLabel`) were keyed on that raw `deviceId` instead of the registry's active strap id (SPINE / #B14), so all data banked under the previous canonical id became invisible to the resolver: the Rest resolver saw zero nights and reported "calibrating".

**Fix:** thread `viewModel.activeStrapId` (the registry's active strap id) through every `resolvedSeries` caller and into `provenanceDisplayLabel` for the Charge/Rest ring badges, so resolution always goes through the canonical strap identity rather than the transient BLE address. 5 files, +18/−12. Single-strap installs resolve `activeStrapId == "my-whoop"`, so that path is byte-identical.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] CI / tooling

## How it was tested

On real hardware: staging build installed on device, sources = WHOOP strap + Health Connect. No BLE protocol changes; this only rewires which strap id the existing resolver is asked about.

| Before | After |
|---|---|
| ![before](https://gist.githubusercontent.com/TheBoroer/3012b3c1f23d2536cd0ce09cf1c94ca8/raw/6e36f2c6b5560e9f671c8812fb44a67a63717884/noop_today.png) | ![after](https://gist.githubusercontent.com/TheBoroer/3012b3c1f23d2536cd0ce09cf1c94ca8/raw/f2e3499589bc69457b31a0e311114923135693d4/noop_today_after.png) |

- Rest ring resolves a score instead of "Calibrating — needs a track night"
- Recovery 77%, Rest HR 53 bpm and the other Key Metrics populate
- Data Sources card resolves correctly: WHOOP badge shows the source name (not the MAC), battery 76% · ~4 days left, 53 days · 8 workouts; Health Connect 50 days · 51 workouts ([screenshot](https://gist.githubusercontent.com/TheBoroer/3012b3c1f23d2536cd0ce09cf1c94ca8/raw/3ad76360f72287a633850f88761e2aa40aec39bc/noop_sources_after.png))

Full screenshot set: https://gist.github.com/TheBoroer/3012b3c1f23d2536cd0ce09cf1c94ca8

## Checklist

- [x] Swift package tests pass for any package I touched (`swift test` in `Packages/<name>`) — no Swift packages touched
- [ ] Android unit tests pass if I touched `android/` (`./gradlew testFullDebugUnitTest`)
- [ ] No new build warnings introduced
- [x] UI changes use only `StrandDesign` tokens — no hardcoded colors, fonts, or spacing (no styling touched)
- [x] No hardcoded hex frame bytes; protocol facts live in the schema / decoders
- [x] Follows the conventions in [`docs/CONTRIBUTING.md`](../docs/CONTRIBUTING.md)
- [x] I did not commit generated output (`Strand.xcodeproj/`) or any secrets/keystores

## Related issues

Closes #172
