### PR TITLE
Today: name Health Connect in the collapsed Data Sources summary

### DIFF
--- a/android/app/src/main/java/com/noop/ui/TodayScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/TodayScreen.kt
@@ -5092,9 +5092,9 @@ private fun TodaySourcesSection(
     val applePresent = (footer.appleDays ?: 0) > 0 || (footer.appleWorkouts ?: 0) > 0
     val hcPresent = (footer.hcDays ?: 0) > 0 || (footer.hcWorkouts ?: 0) > 0
     if (!expanded) {
-        // Collapsed: one tappable "Synced from: ..." line. Health Connect folds under the "Apple Watch"
-        // bucket in the summary (both are the phone's health store to the audience); the expanded card
-        // still lists every source by name, so no provenance detail is lost.
+        // Collapsed: one tappable "Synced from: ..." line. Each source is named for what it is —
+        // Health Connect must NOT fold under "Apple Watch" (issue #176: Health-Connect-only users
+        // saw "Synced from: Apple Watch"); the expanded card lists every source by name too.
         val collapsedInteraction = remember { MutableInteractionSource() }
         NoopCard(
             modifier = Modifier
@@ -5109,7 +5109,7 @@ private fun TodaySourcesSection(
         ) {
             Row(verticalAlignment = Alignment.CenterVertically) {
                 Text(
-                    syncedFromSummary(hasWhoop = whoopPresent, hasApple = applePresent || hcPresent, hasXiaomi = false),
+                    syncedFromSummary(hasWhoop = whoopPresent, hasApple = applePresent, hasHealthConnect = hcPresent, hasXiaomi = false),
                     style = NoopType.subhead,
                     color = Palette.textSecondary,
                     maxLines = 1,
@@ -5343,12 +5343,15 @@ internal fun readinessWord(level: ReadinessEngine.Level): String? = when (level)
 /**
  * S5: the collapsed Data Sources footer summary, "Synced from: WHOOP, Apple Watch", listing only sources
  * with data (Apple Health reads as "Apple Watch", the device the audience knows), or "No sources yet".
- * PURE + unit-tested. Byte-identical twin of the Swift TodayView.syncedFromSummary.
+ * PURE + unit-tested. Twin of the Swift TodayView.syncedFromSummary, plus the Android-only
+ * hasHealthConnect source — Health Connect is named for what it is, never folded under "Apple Watch"
+ * (issue #176).
  */
-internal fun syncedFromSummary(hasWhoop: Boolean, hasApple: Boolean, hasXiaomi: Boolean): String {
+internal fun syncedFromSummary(hasWhoop: Boolean, hasApple: Boolean, hasHealthConnect: Boolean = false, hasXiaomi: Boolean): String {
     val names = buildList {
         if (hasWhoop) add("WHOOP")
         if (hasApple) add("Apple Watch")
+        if (hasHealthConnect) add("Health Connect")
         if (hasXiaomi) add("Mi Band")
     }
     return if (names.isEmpty()) "No sources yet" else "Synced from: " + names.joinToString(", ")

--- a/android/app/src/test/java/com/noop/ui/TodayChargeTapCollapseTest.kt
+++ b/android/app/src/test/java/com/noop/ui/TodayChargeTapCollapseTest.kt
@@ -51,6 +51,23 @@ class TodayChargeTapCollapseTest {
     }
 
     @Test
+    fun syncedFromSummary_healthConnectReadsAsHealthConnect() {
+        // #176: a Health-Connect-only user must NOT see "Synced from: Apple Watch".
+        assertEquals(
+            "Synced from: Health Connect",
+            syncedFromSummary(hasWhoop = false, hasApple = false, hasHealthConnect = true, hasXiaomi = false),
+        )
+        assertEquals(
+            "Synced from: WHOOP, Health Connect",
+            syncedFromSummary(hasWhoop = true, hasApple = false, hasHealthConnect = true, hasXiaomi = false),
+        )
+        assertEquals(
+            "Synced from: WHOOP, Apple Watch, Health Connect",
+            syncedFromSummary(hasWhoop = true, hasApple = true, hasHealthConnect = true, hasXiaomi = false),
+        )
+    }
+
+    @Test
     fun syncedFromSummary_noSourcesIsHonest() {
         assertEquals(
             "No sources yet",


### PR DESCRIPTION
## What this PR does

Fixes the collapsed Data Sources footer ("Synced from: ...") mislabeling Health Connect as "Apple Watch". The collapsed summary folded Health Connect into the Apple bucket (`hasApple = applePresent || hcPresent` in `TodayScreen.kt`), so a user whose only source is Health Connect saw **"Synced from: Apple Watch"**, a device they never connected. The expanded card was already correct.

Fix:

- `syncedFromSummary` gains an Android-only `hasHealthConnect` flag (defaulted, so the Swift-parity call shape is unchanged) and lists **"Health Connect"** as its own source name.
- The collapsed call site now passes `hasApple = applePresent, hasHealthConnect = hcPresent`.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] CI / tooling

## How it was tested

**Unit tests:** added `syncedFromSummary_healthConnectReadsAsHealthConnect` covering HC-only, WHOOP+HC, and WHOOP+Apple+HC. `:app:testFullDebugUnitTest --tests com.noop.ui.TodayChargeTapCollapseTest` passes.

**On device:** staging build (`assembleFullRelease -PstagingRelease`) installed on Pixel; sources = WHOOP + Health Connect (Apple Health not connected). No BLE-path changes, so no strap testing needed.

| | Before | After |
|---|---|---|
| Collapsed | ![before collapsed](https://gist.githubusercontent.com/TheBoroer/da313108fde4a9a42d5db8caadcd13bb/raw/41eadd5e89316ea698100e580cb2b7f4f036e74d/gist172_collapsed_bug.png) | ![after collapsed](https://gist.githubusercontent.com/TheBoroer/2426fdc2a093211c4a480ee482b246e4/raw/9dc96fdf0b09b5d26885ca625b2b03444eb64ce7/noop_hc_after_collapsed.png) |
| Expanded | ![before expanded](https://gist.githubusercontent.com/TheBoroer/da313108fde4a9a42d5db8caadcd13bb/raw/0c9afea998f93c7730060f0a06a492e537252a3d/gist172_expanded_truth.png) | ![after expanded](https://gist.githubusercontent.com/TheBoroer/2426fdc2a093211c4a480ee482b246e4/raw/9dc96fdf0b09b5d26885ca625b2b03444eb64ce7/noop_hc_after_expanded.png) |

Collapsed row now reads **"Synced from: WHOOP, Health Connect"**; expanded card unchanged (was already correct).

## Checklist

- [x] Swift package tests pass for any package I touched (`swift test` in `Packages/<name>`) — no Swift packages touched
- [x] Android unit tests pass if I touched `android/` (`./gradlew testFullDebugUnitTest`)
- [ ] No new build warnings introduced
- [x] UI changes use only `StrandDesign` tokens — no hardcoded colors, fonts, or spacing (text-only change, no styling touched)
- [x] No hardcoded hex frame bytes; protocol facts live in the schema / decoders
- [x] Follows the conventions in [`docs/CONTRIBUTING.md`](../docs/CONTRIBUTING.md)
- [x] I did not commit generated output (`Strand.xcodeproj/`) or any secrets/keystores

## Related issues

Closes #176
