### PR TITLE
Fix Health Connect writeback exporting nothing for wizard-paired straps

### DIFF
--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -1337,7 +1337,8 @@ class WhoopBleClient(
                 }
                 // Keep the opt-in Health Connect writeback fresh in background-only operation too.
                 if (NoopPrefs.hcWriteback(context)) {
-                    runCatching { HealthConnectWriter.write(context, repository) }
+                    runCatching { HealthConnectWriter.write(context, repository, deviceId) }
+                        .onSuccess { log("HC writeback: $it record(s)") }
                 }
             } finally {
                 analyzeAfterBackfillScheduled.set(false)

--- a/android/app/src/main/java/com/noop/ingest/HealthConnectWriter.kt
+++ b/android/app/src/main/java/com/noop/ingest/HealthConnectWriter.kt
@@ -66,6 +66,11 @@ object HealthConnectWriter {
      * Write the last [WINDOW_DAYS] of computed metrics. Returns the number of records written,
      * 0 when HC is unavailable / nothing computed yet. Assumes [PERMISSIONS] are granted (HC
      * throws SecurityException otherwise — callers wrap in runCatching).
+     *
+     * [deviceId] must be the registry's ACTIVE strap id (SPINE / #814): a wizard-paired strap banks
+     * rows under `whoop-<address>`, so the legacy "my-whoop" default reads empty tables and exports
+     * nothing. The default fits only legacy single-WHOOP installs, where the active id resolves to
+     * "my-whoop" anyway.
      */
     suspend fun write(context: Context, repo: WhoopRepository, deviceId: String = "my-whoop"): Int {
         if (HealthConnectClient.getSdkStatus(context) != HealthConnectClient.SDK_AVAILABLE) return 0

--- a/android/app/src/main/java/com/noop/ui/AppViewModel.kt
+++ b/android/app/src/main/java/com/noop/ui/AppViewModel.kt
@@ -837,7 +837,7 @@ class AppViewModel(app: Application) : AndroidViewModel(app) {
                 // cycle just upserts. Never let an HC hiccup (perm revoked mid-flight, provider
                 // update) break the analysis loop.
                 if (_hcWriteback.value) {
-                    runCatching { HealthConnectWriter.write(appContext, repository) }
+                    runCatching { HealthConnectWriter.write(appContext, repository, deviceId) }
                 }
                 delay(ANALYZE_INTERVAL_MS) // 15 min, matches the offload cadence
             }
@@ -1665,7 +1665,7 @@ class AppViewModel(app: Application) : AndroidViewModel(app) {
     fun writebackHealthConnectNow() {
         viewModelScope.launch {
             withContext(Dispatchers.IO) {
-                runCatching { HealthConnectWriter.write(appContext, repository) }
+                runCatching { HealthConnectWriter.write(appContext, repository, deviceId) }
             }
         }
     }


### PR DESCRIPTION
## What this PR does

Health Connect writeback silently exported 0 records on wizard-paired installs: `HealthConnectWriter.write()` defaulted to the legacy `"my-whoop"` device id, while a strap added through the Add-Device wizard banks its rows under `whoop-<address>` (`SPINE / #814`). All three call sites relied on the default, and every insert is wrapped in `runCatching`, so the failure was invisible.

This passes the registry-resolved active device id — already in scope at each call site — so the writeback exports the same data the UI reads:

- `AppViewModel`: both `write(...)` calls pass the ViewModel's `deviceId` (resolved at startup from `NoopApplication.activeDeviceId`)
- `WhoopBleClient`: passes its registry-resolved `deviceId` field (kept current by `setActiveDeviceId`), and logs `HC writeback: N record(s)` to the strap log next to the existing "Backfill: N day(s) banked" diagnostic
- `HealthConnectWriter.write()` kdoc documents the parameter contract

Legacy single-WHOOP installs resolve the active id to `"my-whoop"`, so this is a no-op for them. Same bug class as #175 (read side); this is the writeback leg.

**Deliberate non-goals:** no writer-side id union — sleep already unions internally via `sleepSessionsMerged`; a daily-vitals union would collide the non-device-scoped `noop-<metric>-<day>` clientRecordIds in one insert batch; and the HR frontier is a single cursor. Also note `AppViewModel`'s id is startup-resolved, so after a mid-session strap switch the two VM sites pick up the new id at next launch (the BLE site updates immediately) — consistent with the VM's whole read side.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] CI / tooling

## How it was tested

`./gradlew testFullDebugUnitTest` green; `assembleFullDebug` builds with no new warnings. On real hardware (Galaxy S21+, Android 15): restored a production backup (wizard-paired strap, 17 days of data) into a debug install of this branch, enabled "Share back to Health Connect", granted the write permissions — the sleep session and heart-rate series appeared in the HC data browser immediately. The unpatched build with the identical restored data and granted permissions exports nothing (that's the bug). Not on the BLE wire path — no strap protocol behavior changed.

App state (both builds — data exists, share-back on):

| NOOP has the night | Share-back enabled |
|---|---|
| ![app has sleep](https://gist.githubusercontent.com/pagarsky/892fdde17d9d45ce6cd012e8c5af28bc/raw/before_app_has_sleep.png) | ![toggle on](https://gist.githubusercontent.com/pagarsky/892fdde17d9d45ce6cd012e8c5af28bc/raw/before_toggle_on.png) |

Health Connect data browser, before → after:

| Before: Sleep (unpatched) | After: Sleep (this branch) |
|---|---|
| ![before sleep](https://gist.githubusercontent.com/pagarsky/892fdde17d9d45ce6cd012e8c5af28bc/raw/before_sleep_hc.png) | ![after sleep](https://gist.githubusercontent.com/pagarsky/892fdde17d9d45ce6cd012e8c5af28bc/raw/after_sleep_hc.png) |

| Before: Heart rate (unpatched) | After: Heart rate (this branch) |
|---|---|
| ![before hr](https://gist.githubusercontent.com/pagarsky/892fdde17d9d45ce6cd012e8c5af28bc/raw/before_hr_hc.png) | ![after hr](https://gist.githubusercontent.com/pagarsky/892fdde17d9d45ce6cd012e8c5af28bc/raw/after_hr_hc.png) |

(The HC entries read "NOOP Staging" because the debug test build shares that label; the writing package was the patched `com.noop.whoop.debug` install, confirmed via appops access timestamps.)

## Checklist

- [x] Swift package tests pass for any package I touched — n/a, no `Packages/` touched
- [x] Android unit tests pass if I touched `android/` (`./gradlew testFullDebugUnitTest`)
- [x] No new build warnings introduced
- [x] UI changes use only `StrandDesign` tokens — n/a, no UI touched
- [x] No hardcoded hex frame bytes; protocol facts live in the schema / decoders
- [x] Follows the conventions in [`docs/CONTRIBUTING.md`](../docs/CONTRIBUTING.md)
- [x] I did not commit generated output (`Strand.xcodeproj/`) or any secrets/keystores

## Related issues

Closes #178. Sibling of #175 / #172 (read-side active-id threading).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
