### PR TITLE
Fix skin-temp device-family resolution for wizard-paired straps (centralized resolver)

### DIFF
--- a/Packages/WhoopProtocol/Sources/WhoopProtocol/DeviceFamily.swift
+++ b/Packages/WhoopProtocol/Sources/WhoopProtocol/DeviceFamily.swift
@@ -21,6 +21,25 @@ public enum HeaderCRCKind: String, Sendable, CaseIterable {
 }
 
 public extension DeviceFamily {
+    /// Resolve a device-registry `model` label to the strap family that wrote its rows (#171).
+    ///
+    /// The registry holds several historical spellings for the same hardware: the Add-Device wizard
+    /// stores bare "4.0" / "5.0 MG", other paths match the full picker labels ("WHOOP 4.0" /
+    /// "WHOOP 5.0 / MG"), and the legacy seeded "my-whoop" row stores just "WHOOP". Matching any
+    /// single spelling silently misses the others (#171), so this is the ONE place allowed to
+    /// interpret registry model labels.
+    ///
+    /// "WHOOP" predates the wizard and was written identically for 4.0 and 5/MG installs, so it
+    /// carries no family information; it keeps the prior `.whoop5` fallback, as do nil/unknown
+    /// labels (non-WHOOP imports whose skin temp is already °C) — only a positively-identified 4.0
+    /// changes scale (#938). Mirrors the Kotlin `DeviceFamily.forRegistryModel`.
+    static func forRegistryModel(_ model: String?) -> DeviceFamily {
+        switch model {
+        case "4.0", "WHOOP 4.0": return .whoop4
+        default: return .whoop5
+        }
+    }
+
     /// The header-CRC algorithm this family uses. This is the single switch that the family-aware
     /// `verifyFrame`/`parseFrame` overloads branch on; the payload CRC32 is identical for both.
     var headerCRCKind: HeaderCRCKind {

--- a/Packages/WhoopProtocol/Tests/WhoopProtocolTests/RegistryModelFamilyTests.swift
+++ b/Packages/WhoopProtocol/Tests/WhoopProtocolTests/RegistryModelFamilyTests.swift
@@ -1,0 +1,48 @@
+import XCTest
+@testable import WhoopProtocol
+
+/// Registry model-label → `DeviceFamily` resolution (#171). Mirrors the Android `RegistryModelFamilyTest`.
+///
+/// The device registry holds several historical spellings for the same hardware — the Add-Device
+/// wizard's bare "4.0" / "5.0 MG", the full picker labels ("WHOOP 4.0" / "WHOOP 5.0 / MG"), and the
+/// legacy seeded "my-whoop" row's bare "WHOOP". Call sites that compared ONE spelling silently missed
+/// the others (issue #171: wizard-paired 4.0 straps decoded on the 5/MG /100 scale, ~8 °C skin temps
+/// in the Deep Timeline). These tests pin the full label contract so a new spelling — or a regression
+/// back to a single-spelling comparison — fails loudly.
+final class RegistryModelFamilyTests: XCTestCase {
+
+    // MARK: - WHOOP 4.0 — every stored spelling must positively identify (the #171 fix)
+
+    func testWizardBare40LabelResolvesToWhoop4() {
+        XCTAssertEqual(DeviceFamily.forRegistryModel("4.0"), .whoop4)
+    }
+
+    func testFullPicker40LabelResolvesToWhoop4() {
+        XCTAssertEqual(DeviceFamily.forRegistryModel("WHOOP 4.0"), .whoop4)
+    }
+
+    // MARK: - WHOOP 5/MG — both spellings keep the /100 path
+
+    func testWizard5MgLabelResolvesToWhoop5() {
+        XCTAssertEqual(DeviceFamily.forRegistryModel("5.0 MG"), .whoop5)
+        // "WHOOP 5.0 MG" is a spelling no writer produces today (the picker writes
+        // "WHOOP 5.0 / MG"); it lands on the safe .whoop5 default, which happens to be correct.
+        XCTAssertEqual(DeviceFamily.forRegistryModel("WHOOP 5.0 MG"), .whoop5)
+        XCTAssertEqual(DeviceFamily.forRegistryModel("WHOOP 5.0 / MG"), .whoop5)
+    }
+
+    // MARK: - Legacy + unknowns — the prior .whoop5 fallback, unchanged
+
+    /// The seeded "my-whoop" row predates the wizard and was written identically for 4.0 and 5/MG
+    /// installs, so "WHOOP" carries no family information; it keeps the prior fallback.
+    func testLegacySeededWhoopLabelKeepsWhoop5Fallback() {
+        XCTAssertEqual(DeviceFamily.forRegistryModel("WHOOP"), .whoop5)
+    }
+
+    func testNilEmptyAndGarbageFallBackToWhoop5() {
+        XCTAssertEqual(DeviceFamily.forRegistryModel(nil), .whoop5)
+        XCTAssertEqual(DeviceFamily.forRegistryModel(""), .whoop5)
+        XCTAssertEqual(DeviceFamily.forRegistryModel("Oura Ring Gen3"), .whoop5)
+        XCTAssertEqual(DeviceFamily.forRegistryModel("garmin-hrm"), .whoop5)
+    }
+}

--- a/Strand/Data/IntelligenceEngine.swift
+++ b/Strand/Data/IntelligenceEngine.swift
@@ -1377,15 +1377,10 @@ final class IntelligenceEngine: ObservableObject {
     }
 
     /// The strap family that wrote `owner`'s skin-temp rows (#938), so the nightly funnel converts the raw
-    /// register on the right scale. The registry stores each device's model string; a positively-identified
-    /// WHOOP 4.0 maps to `.whoop4` (raw-ADC skin-temp map), and EVERYTHING else — a 5/MG, a non-WHOOP source
-    /// (Oura/Apple Watch/etc. whose imported skin temp is already °C, not a strap register), or an unknown
-    /// owner not in the snapshot — falls back to `.whoop5`, the prior /100 behaviour. So this only changes
-    /// the mapping for a device we KNOW is a 4.0, never risking a wrong scale on anything else.
+    /// register on the right scale. The model-label → family mapping (and the `.whoop5` fallback for
+    /// unknowns) lives in `DeviceFamily.forRegistryModel` (#171).
     nonisolated static func skinTempFamily(forOwner owner: String, devices: [PairedDevice]) -> DeviceFamily {
-        guard let model = devices.first(where: { $0.id == owner })?.model,
-              WhoopModel(rawValue: model) == .whoop4 else { return .whoop5 }
-        return .whoop4
+        DeviceFamily.forRegistryModel(devices.first(where: { $0.id == owner })?.model)
     }
 
     /// #137: re-score under-sampled manual workouts. A `manual` workout is scored from the live HR

--- a/Strand/Data/Repository.swift
+++ b/Strand/Data/Repository.swift
@@ -1441,16 +1441,14 @@ final class Repository: ObservableObject {
     }
 
     /// Map each device id to the strap family that wrote its rows (#938), for the family-aware skin-temp
-    /// raw→°C conversion. Reads the registry ONCE; a device whose model is "WHOOP 4.0" maps to `.whoop4`,
-    /// and every other id — a 5/MG, a non-WHOOP import, or an id absent from the registry — maps to
-    /// `.whoop5` (the prior /100 behaviour), so only a KNOWN 4.0 changes scale. Best-effort: an unreadable
+    /// raw→°C conversion. Reads the registry ONCE; the model-label → family mapping (and the `.whoop5`
+    /// fallback for unknowns) lives in `DeviceFamily.forRegistryModel` (#171). Best-effort: an unreadable
     /// registry yields an empty map, so every caller falls back to `.whoop5`.
     private static func skinTempFamilies(store: WhoopStore, ids: [String]) -> [String: DeviceFamily] {
         let devices = (try? DeviceRegistryStore(dbQueue: store.registryWriter).all()) ?? []
         var out: [String: DeviceFamily] = [:]
         for id in ids {
-            let isW4 = devices.first(where: { $0.id == id }).map { WhoopModel(rawValue: $0.model) == .whoop4 } ?? false
-            out[id] = isW4 ? .whoop4 : .whoop5
+            out[id] = DeviceFamily.forRegistryModel(devices.first(where: { $0.id == id })?.model)
         }
         return out
     }

--- a/android/app/src/main/java/com/noop/analytics/RegistryDayOwnerSource.kt
+++ b/android/app/src/main/java/com/noop/analytics/RegistryDayOwnerSource.kt
@@ -1,6 +1,5 @@
 package com.noop.analytics
 
-import com.noop.ble.WhoopModel
 import com.noop.data.DeviceRegistry
 import com.noop.data.DeviceStatus
 import com.noop.data.SourceKind
@@ -46,13 +45,11 @@ class RegistryDayOwnerSource(private val registry: DeviceRegistry) : Intelligenc
     // when they diverge, the #814/#799 spine symptom).
     override suspend fun activeWriteId(): String? = registry.activeDeviceId()
 
-    // #938: resolve the strap family that wrote [deviceId]'s rows from its registry model. A device whose
-    // model is "WHOOP 4.0" maps to WHOOP4 (raw-ADC skin-temp scale); everything else — a 5/MG, a non-WHOOP
-    // import whose skin temp is already °C, or an id absent from the registry — falls back to WHOOP5 (the
-    // prior /100 behaviour). Mirrors the Swift IntelligenceEngine.skinTempFamily(forOwner:devices:).
+    // #938: resolve the strap family that wrote [deviceId]'s rows from its registry model. The model-label
+    // → family mapping (and the WHOOP5 fallback for unknowns) lives in DeviceFamily.forRegistryModel (#171).
+    // Mirrors the Swift IntelligenceEngine.skinTempFamily(forOwner:devices:).
     override suspend fun skinTempFamily(deviceId: String): DeviceFamily {
         val model = registry.all().firstOrNull { it.id == deviceId }?.model
-        return if (WhoopModel.entries.firstOrNull { it.displayName == model } == WhoopModel.WHOOP4)
-            DeviceFamily.WHOOP4 else DeviceFamily.WHOOP5
+        return DeviceFamily.forRegistryModel(model)
     }
 }

--- a/android/app/src/main/java/com/noop/protocol/DeviceFamily.kt
+++ b/android/app/src/main/java/com/noop/protocol/DeviceFamily.kt
@@ -80,6 +80,26 @@ enum class DeviceFamily {
         }
 
     companion object {
+        /**
+         * Resolve a device-registry `model` label to the strap family that wrote its rows (#171).
+         *
+         * The registry holds several historical spellings for the same hardware: the Add-Device
+         * wizard stores bare "4.0" / "5.0 MG", other paths match the full picker labels
+         * ("WHOOP 4.0" / "WHOOP 5.0 / MG"), and the legacy seeded "my-whoop" row stores just
+         * "WHOOP". Matching any single spelling silently misses the others (#171), so this is
+         * the ONE place allowed to interpret registry model labels.
+         *
+         * "WHOOP" predates the wizard and was written identically for 4.0 and 5/MG installs, so
+         * it carries no family information; it keeps the prior WHOOP5 fallback, as do
+         * null/unknown labels (non-WHOOP imports whose skin temp is already °C) — only a
+         * positively-identified 4.0 changes scale (#938). Mirrors the Swift
+         * `DeviceFamily.forRegistryModel`.
+         */
+        fun forRegistryModel(model: String?): DeviceFamily = when (model) {
+            "4.0", "WHOOP 4.0" -> WHOOP4
+            else -> WHOOP5
+        }
+
         /** Whoop 5.0 CLIENT_HELLO bytes (16 bytes). Exposed as a named constant for test/debug use. */
         val WHOOP5_CLIENT_HELLO: ByteArray = byteArrayOf(
             0xAA.toByte(), 0x01, 0x08, 0x00, 0x00, 0x01, 0xE6.toByte(), 0x71,

--- a/android/app/src/main/java/com/noop/ui/FullDayChartScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/FullDayChartScreen.kt
@@ -27,7 +27,6 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import com.noop.analytics.HrvAnalyzer
-import com.noop.ble.WhoopModel
 import com.noop.protocol.DeviceFamily
 import com.noop.protocol.skinTempCelsius
 import kotlinx.coroutines.Dispatchers
@@ -353,12 +352,11 @@ private suspend fun readTimeline(
                 .mapNotNull { if (it.ir > 0) TimelinePoint(it.ts, it.red.toDouble() / it.ir) else null }
         TimelineMetric.SkinTemp -> {
             // #938: family-aware raw→°C — 5/MG centidegrees (raw/100, #156), a WHOOP 4.0 v24 raw ADC map.
-            // Resolve the strap family from [deviceId]'s registry model; a positively-identified 4.0 → WHOOP4,
-            // everything else → WHOOP5 (the prior /100 behaviour). Mirrors Swift Repository.timelineRawMetric.
+            // The registry-model-label → family mapping lives in DeviceFamily.forRegistryModel (#171).
+            // Mirrors Swift Repository.timelineRawMetric.
             val model = runCatching { vm.pairedDevices() }.getOrDefault(emptyList())
                 .firstOrNull { it.id == deviceId }?.model
-            val family = if (WhoopModel.entries.firstOrNull { it.displayName == model } == WhoopModel.WHOOP4)
-                DeviceFamily.WHOOP4 else DeviceFamily.WHOOP5
+            val family = DeviceFamily.forRegistryModel(model)
             runCatching { repo.skinTempSamples(deviceId, from, to, 200_000) }.getOrDefault(emptyList())
                 .map { TimelinePoint(it.ts, skinTempCelsius(it.raw, family)) }
         }

--- a/android/app/src/test/java/com/noop/protocol/RegistryModelFamilyTest.kt
+++ b/android/app/src/test/java/com/noop/protocol/RegistryModelFamilyTest.kt
@@ -1,0 +1,57 @@
+package com.noop.protocol
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Registry model-label → [DeviceFamily] resolution (#171). Mirrors the macOS `RegistryModelFamilyTests`.
+ *
+ * The device registry holds several historical spellings for the same hardware — the Add-Device
+ * wizard's bare "4.0" / "5.0 MG", the full picker labels ("WHOOP 4.0" / "WHOOP 5.0 / MG"), and the
+ * legacy seeded "my-whoop" row's bare "WHOOP". Call sites that compared ONE spelling silently missed
+ * the others (issue #171: wizard-paired 4.0 straps decoded on the 5/MG /100 scale, ~8 °C skin temps
+ * in the Deep Timeline). These tests pin the full label contract so a new spelling — or a regression
+ * back to a single-spelling comparison — fails loudly.
+ */
+class RegistryModelFamilyTest {
+
+    // ── WHOOP 4.0 — every stored spelling must positively identify (the #171 fix) ──
+
+    @Test
+    fun wizardBare40LabelResolvesToWhoop4() {
+        assertEquals(DeviceFamily.WHOOP4, DeviceFamily.forRegistryModel("4.0"))
+    }
+
+    @Test
+    fun fullPicker40LabelResolvesToWhoop4() {
+        assertEquals(DeviceFamily.WHOOP4, DeviceFamily.forRegistryModel("WHOOP 4.0"))
+    }
+
+    // ── WHOOP 5/MG — both spellings keep the /100 path ──────────────────────
+
+    @Test
+    fun wizard5MgLabelResolvesToWhoop5() {
+        assertEquals(DeviceFamily.WHOOP5, DeviceFamily.forRegistryModel("5.0 MG"))
+        // "WHOOP 5.0 MG" is a spelling no writer produces today (the picker writes
+        // "WHOOP 5.0 / MG"); it lands on the safe WHOOP5 default, which happens to be correct.
+        assertEquals(DeviceFamily.WHOOP5, DeviceFamily.forRegistryModel("WHOOP 5.0 MG"))
+        assertEquals(DeviceFamily.WHOOP5, DeviceFamily.forRegistryModel("WHOOP 5.0 / MG"))
+    }
+
+    // ── Legacy + unknowns — the prior WHOOP5 fallback, unchanged ────────────
+
+    @Test
+    fun legacySeededWhoopLabelKeepsWhoop5Fallback() {
+        // The seeded "my-whoop" row predates the wizard and was written identically for 4.0 and
+        // 5/MG installs, so "WHOOP" carries no family information; it keeps the prior fallback.
+        assertEquals(DeviceFamily.WHOOP5, DeviceFamily.forRegistryModel("WHOOP"))
+    }
+
+    @Test
+    fun nullEmptyAndGarbageFallBackToWhoop5() {
+        assertEquals(DeviceFamily.WHOOP5, DeviceFamily.forRegistryModel(null))
+        assertEquals(DeviceFamily.WHOOP5, DeviceFamily.forRegistryModel(""))
+        assertEquals(DeviceFamily.WHOOP5, DeviceFamily.forRegistryModel("Oura Ring Gen3"))
+        assertEquals(DeviceFamily.WHOOP5, DeviceFamily.forRegistryModel("garmin-hrm"))
+    }
+}


### PR DESCRIPTION
## What this PR does

Fixes #171: wizard-paired WHOOP 4.0 straps showed ~7.6–8.65 °C skin temps in the Deep Timeline.

This was not a °C/°F conversion bug. The Add-Device wizard stores a 4.0's registry model label as bare `"4.0"` (`AddDeviceWizard.kt:268`), but all four skin-temp family resolvers compared the label against the full picker spelling `"WHOOP 4.0"` (`FullDayChartScreen.kt` ~360, `RegistryDayOwnerSource.kt` ~55, `Repository.swift` ~1452, `IntelligenceEngine.swift` ~1386). The comparison never matched for a wizard-paired 4.0, so its samples fell through to the WHOOP 5/MG raw/100 decode rule. A worn 4.0's raw band of 760–865 divided by 100 is exactly the reported 7.6–8.65 °C (34 °C real → 8.46). Other surfaces hide the bug because analytics gates absolute temps to 28–42 °C; the Deep Timeline plots ungated.

This is the third bug from the same class — a registry-written label compared against a hardcoded spelling at a call site (same class as #172/#175 and #178/#179). So rather than patching the four comparisons, this PR centralizes the mapping: one documented `DeviceFamily.forRegistryModel` per platform (`android/.../protocol/DeviceFamily.kt` and `Packages/WhoopProtocol/.../DeviceFamily.swift` — both platform-pure and unit-testable), which is now the ONE place allowed to interpret registry model labels. All four call sites shrink to a call.

Deliberate behavior notes:
- The legacy seeded `"WHOOP"` label (the pre-wizard "my-whoop" row) keeps the prior WHOOP5 fallback: it was written identically for 4.0 and 5/MG installs, so it carries no family information — only a positively-identified 4.0 changes scale (`#938`).
- Null/empty/garbage labels (non-WHOOP imports whose skin temp is already °C) also keep the WHOOP5 fallback, unchanged.
- +101 lines of contract tests on both platforms pin the full label set: `"4.0"`, `"WHOOP 4.0"`, `"5.0 MG"`, `"WHOOP 5.0 / MG"`, legacy `"WHOOP"`, and null/garbage — so a new spelling or a regression back to a single-spelling comparison fails loudly.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] CI / tooling

## How it was tested

- **Android**: `./gradlew testFullDebugUnitTest` green, including the new `RegistryModelFamilyTest` (5/5). `assembleFullDebug` green.
- **macOS/Swift**: `swift build` in `Packages/WhoopProtocol` passes; the full macOS app compiles via xcodegen + xcodebuild (Xcode 16.3) with only 3 pre-existing warnings in untouched files.
- **Known limitation**: `swift test` in `Packages/WhoopProtocol` is blocked by a **pre-existing** type-check timeout in `DecoderOracleTests` on the Swift 6.1 toolchain used here (reproduces on `main` unchanged; `docs/BUILD.md` expects Swift 6.3). The new `RegistryModelFamilyTests` should be watched in CI, where a newer toolchain should run them.
- **Hardware**: could not reproduce on real hardware — our strap is a 5.0 MG, and this bug only manifests on a wizard-paired 4.0. The evidence is the exact arithmetic match: the 4.0's raw skin-temp band (760–865) under the 5/MG /100 rule produces precisely the 7.6–8.65 °C band reported in #171, with 34 °C real → 8.46 as reported.

## Checklist

- [ ] Swift package tests pass for any package I touched (`swift test` in `Packages/<name>`) — blocked by the pre-existing `DecoderOracleTests` type-check timeout on Swift 6.1 (repros on `main`); `swift build` passes and the new tests mirror the green Android suite
- [x] Android unit tests pass if I touched `android/` (`./gradlew testFullDebugUnitTest`)
- [x] No new build warnings introduced
- [x] UI changes use only `StrandDesign` tokens — no hardcoded colors, fonts, or spacing (no UI changes; `FullDayChartScreen` change is resolver logic only)
- [x] No hardcoded hex frame bytes; protocol facts live in the schema / decoders
- [x] Follows the conventions in [`docs/CONTRIBUTING.md`](../docs/CONTRIBUTING.md)
- [x] I did not commit generated output (`Strand.xcodeproj/`) or any secrets/keystores

## Related issues

Closes #171.

Siblings in the same registry-vs-hardcoded-label bug class: #175, #179.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
