### PR TITLE
Today HR chart: round-time axis ticks, dotted gridlines, timed scrub readout

### DIFF
--- a/android/app/src/main/java/com/noop/ui/Charts.kt
+++ b/android/app/src/main/java/com/noop/ui/Charts.kt
@@ -32,6 +32,9 @@ import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import java.time.Instant
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
 import java.util.Locale
 import kotlin.math.abs
 import kotlin.math.roundToInt
@@ -214,8 +217,17 @@ fun LineChart(
     // the 0-21 scale) pass their axis formatter so the label can't leak the stored scale as a bare
     // unconverted number. Default null keeps every other caller byte-identical.
     formatValue: ((Double) -> String)? = null,
+    // Optional per-point unix-second timestamps, index-aligned with [values]: when supplied, the
+    // tap/drag pinpoint read-out prefixes the selected sample's local clock time ("14:32 · 87 bpm").
+    timestamps: List<Long>? = null,
 ) {
     val cleanValues = remember(values) { values.filter { it.isFinite() } }
+    // Timestamps filtered by the SAME finiteness cut as cleanValues so indices stay aligned;
+    // dropped entirely on a length mismatch rather than mislabelling times.
+    val cleanTimestamps = remember(values, timestamps) {
+        if (timestamps == null || timestamps.size != values.size) null
+        else values.indices.filter { values[it].isFinite() }.map { timestamps[it] }
+    }
     var selectedIndex by remember(cleanValues) { mutableIntStateOf(-1) }
     val interactiveModifier = if (selectionEnabled) {
         Modifier
@@ -368,7 +380,11 @@ fun LineChart(
                             drawCircle(color = Palette.surfaceBase.copy(alpha = StrandAlpha.chartShadow), radius = 9f, center = p)
                             drawCircle(color = color, radius = 4.5f, center = p)
                             drawContext.canvas.nativeCanvas.apply {
-                                val label = lineChartSelectionLabel(cleanValues[selectedIndex], formatValue)
+                                val label = lineChartSelectionLabel(
+                                    cleanValues[selectedIndex],
+                                    formatValue,
+                                    cleanTimestamps?.getOrNull(selectedIndex),
+                                )
                                 drawText(label, 8f, 32f, markerPaint)
                             }
                         }
@@ -439,9 +455,20 @@ private fun nearestIndexForX(count: Int, width: Float, x: Float): Int {
 }
 
 /** The tap/drag pinpoint label: the caller's display formatter when supplied (#463), else the raw
- *  near-integer-collapsing default. Split out so the fallback choice is JVM-testable. */
-internal fun lineChartSelectionLabel(value: Double, formatValue: ((Double) -> String)?): String =
-    formatValue?.invoke(value) ?: formatLineValue(value)
+ *  near-integer-collapsing default. When the caller also supplies the sample's [epochSec] the local
+ *  clock time PREFIXES the formatted value ("14:32 · 87 bpm"). Split out so both choices are
+ *  JVM-testable. */
+internal fun lineChartSelectionLabel(
+    value: Double,
+    formatValue: ((Double) -> String)?,
+    epochSec: Long? = null,
+    zone: ZoneId = ZoneId.systemDefault(),
+): String {
+    val base = formatValue?.invoke(value) ?: formatLineValue(value)
+    if (epochSec == null) return base
+    val time = Instant.ofEpochSecond(epochSec).atZone(zone).format(chartTickTimeFormat)
+    return "$time · $base"
+}
 
 private fun formatLineValue(value: Double): String {
     if (!value.isFinite()) return "-"
@@ -791,6 +818,68 @@ fun zoomedWindow(
     if (newHi > bounds.last) { newHi = bounds.last; newLo = newHi - newSpan }
     newLo = newLo.coerceAtLeast(bounds.first)
     return newLo..(newLo + newSpan).coerceAtLeast(newLo + 1)
+}
+
+// MARK: - Round-time x-axis ticks (prototype hr-chart-time-axis)
+
+/** Shared "HH:mm" tick/readout clock format — one instance, DateTimeFormatter is thread-safe. */
+private val chartTickTimeFormat = DateTimeFormatter.ofPattern("HH:mm", Locale.US)
+
+/**
+ * Round wall-clock x-axis ticks for a `[startEpochSec, endEpochSec]` window: (epochSec, "HH:mm")
+ * pairs at fixed round intervals chosen by the visible span (a full day ticks every 6h, a 1h zoom
+ * every 15min). Ticks step in LOCAL wall-clock time from the window's local midnight — a window
+ * crossing midnight labels "00:00" and DST labels stay round; java.time resolves the spring-forward
+ * gap to a valid time and the epoch-dedupe drops the resulting double tick. Pure and clock-free
+ * (ChartTimeTicksTest).
+ */
+fun chartTimeTicks(startEpochSec: Long, endEpochSec: Long, zone: ZoneId): List<Pair<Long, String>> {
+    if (endEpochSec <= startEpochSec) return emptyList()
+    val spanHours = (endEpochSec - startEpochSec) / 3600.0
+    // Thresholds sit below the nominal Today-card windows (24h/12h/6h/3h/1h) so a window whose
+    // banked data covers slightly less than nominal still lands on its intended interval.
+    val stepMinutes = when {
+        spanHours >= 20.0 -> 360L
+        spanHours >= 10.0 -> 180L
+        spanHours >= 5.0 -> 120L
+        spanHours >= 2.0 -> 60L
+        else -> 15L
+    }
+    var tick = Instant.ofEpochSecond(startEpochSec).atZone(zone).toLocalDate().atStartOfDay()
+    val out = ArrayList<Pair<Long, String>>()
+    var lastEpoch = Long.MIN_VALUE
+    // Bounded walk: even a multi-day window at 15-min steps stays well under the guard.
+    var guard = 0
+    while (guard++ < 4096) {
+        val zoned = tick.atZone(zone)
+        val epoch = zoned.toEpochSecond()
+        if (epoch > endEpochSec) break
+        if (epoch in startEpochSec..endEpochSec && epoch > lastEpoch) {
+            out.add(epoch to zoned.format(chartTickTimeFormat))
+            lastEpoch = epoch
+        }
+        tick = tick.plusMinutes(stepMinutes)
+    }
+    return out
+}
+
+/**
+ * Where wall-clock [ts] falls (0…1) across an INDEX-spaced line, interpolating between the
+ * per-point [timestamps] exactly like OverviewHRChart's marker mapping — so a tick's gridline and
+ * its axis label land on the same pixel even when the series has gaps. Null when [ts] is outside
+ * the plotted extent (an off-window tick draws nothing rather than pinning to an edge).
+ */
+fun timestampFraction(timestamps: List<Long>, ts: Long): Float? {
+    val n = timestamps.size
+    if (n < 2) return null
+    if (ts < timestamps.first() || ts > timestamps.last()) return null
+    val hi = timestamps.indexOfFirst { it >= ts }
+    if (hi <= 0) return 0f
+    val lo = hi - 1
+    val t0 = timestamps[lo]
+    val t1 = timestamps[hi]
+    val f = if (t1 > t0) (ts - t0).toFloat() / (t1 - t0).toFloat() else 0f
+    return (lo + f) / (n - 1)
 }
 
 /** Pan [base] by [deltaSeconds], clamped into [bounds] (span preserved). Pure — twin of OverviewHRChart.panned. */

--- a/android/app/src/main/java/com/noop/ui/TodayScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/TodayScreen.kt
@@ -93,6 +93,7 @@ import androidx.compose.foundation.gestures.calculateCentroid
 import androidx.compose.foundation.gestures.calculatePan
 import androidx.compose.foundation.gestures.calculateZoom
 import androidx.compose.foundation.gestures.detectHorizontalDragGestures
+import androidx.compose.ui.layout.Layout
 import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
@@ -4489,6 +4490,13 @@ private fun HeartRateTrendCard(
     val visAvg = visBpm.average().roundToInt()
     val visMin = visBpm.min().roundToInt()
 
+    // Round wall-clock ticks for the RENDERED extent, shared by the gridlines (drawn inside
+    // OverviewHRChart) and the axis-label strip below so they align.
+    val timeTicks = remember(visBuckets) {
+        chartTimeTicks(visBuckets.first().bucket, visBuckets.last().bucket, ZoneId.systemDefault())
+    }
+    val visTimestamps = remember(visBuckets) { visBuckets.map { it.bucket } }
+
     SectionHeader("Heart Rate", overline = selectedLabel)
     NoopCard {
         Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
@@ -4538,52 +4546,43 @@ private fun HeartRateTrendCard(
                 // #829 - renders the zoom window's subset, with the pinch/pan/double-tap transform
                 // detector attached (keyed on the #985-windowed buckets so its captured bounds track
                 // both a reload and a window change — the pinch operates INSIDE the selected window).
-                OverviewHRChart(
-                    buckets = visBuckets,
-                    bpm = visBpm,
-                    sleep = sleepToday,
-                    workouts = workoutsToday,
-                    recovery = displayMetric?.recovery,
-                    strain = displayMetric?.strain,
-                    effortScale = effortScale,
-                    modifier = Modifier
-                        .weight(1f)
-                        .height(Metrics.chartHeight)
-                        .pointerInput(winBuckets) {
-                            hrChartTransformGestures(
-                                buckets = winBuckets,
-                                bounds = zoomBounds,
-                                window = { hrZoom },
-                                onWindow = { hrZoom = it },
-                            )
-                        },
-                )
-            }
-            // X-axis: start / midpoint / end of the loaded window. Each label is read from the
-            // ACTUAL bucket timestamp at that index, converted to the device-local wall clock,             // NOT idx*5 from midnight. hrBuckets only emits filled 5-min slots (gaps when the strap
-            // wasn't worn) and its bucket key is epoch-aligned, so idx*5 mislabelled every tick once
-            // the day had a gap and the labels drifted out of step with the time-positioned markers
-            // (an evening workout read as if it sat earlier in the day) (#544). The line/markers are
-            // already placed by real timestamp, so labelling by real timestamp makes the axis agree.
-            Row(modifier = Modifier.fillMaxWidth()) {
-                val zone = ZoneId.systemDefault()
-                val hhmm = DateTimeFormatter.ofPattern("HH:mm", Locale.US)
-                // #829 - the axis reads the RENDERED subset, so a zoomed window's ticks describe the
-                // visible curve; the "Now" end label only applies to the un-zoomed live day (a zoomed
-                // window's right edge is wherever the user panned it, so it gets its real timestamp).
-                val bucketToTime = { idx: Int ->
-                    val b = visBuckets.getOrNull(idx) ?: visBuckets.last()
-                    Instant.ofEpochSecond(b.bucket).atZone(zone).format(hhmm)
-                }
-                val xLabels = if (visBuckets.size >= 3) {
-                    listOf(
-                        bucketToTime(0),
-                        bucketToTime(visBuckets.size / 2),
-                        if (selectedDay == today && hrZoom == null) "Now" else bucketToTime(visBuckets.size - 1),
+                // The chart and its axis-label strip share this Column so both span exactly the
+                // plot width (not the card width, which includes the y-rail) — a label centred at
+                // a tick fraction lands under its gridline.
+                Column(
+                    modifier = Modifier.weight(1f),
+                    verticalArrangement = Arrangement.spacedBy(4.dp),
+                ) {
+                    OverviewHRChart(
+                        buckets = visBuckets,
+                        bpm = visBpm,
+                        sleep = sleepToday,
+                        workouts = workoutsToday,
+                        recovery = displayMetric?.recovery,
+                        strain = displayMetric?.strain,
+                        effortScale = effortScale,
+                        timeTicks = timeTicks,
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .height(Metrics.chartHeight)
+                            .pointerInput(winBuckets) {
+                                hrChartTransformGestures(
+                                    buckets = winBuckets,
+                                    bounds = zoomBounds,
+                                    window = { hrZoom },
+                                    onWindow = { hrZoom = it },
+                                )
+                            },
                     )
-                } else listOf("Start", "", "Now")
-                xLabels.forEach { lbl ->
-                    Text(lbl, style = NoopType.footnote, color = Palette.textTertiary, modifier = Modifier.weight(1f))
+                    // X-axis: labels use the SAME timestamp interpolation as the line and markers,
+                    // so the axis agrees with the curve even when the day has gaps (#544). "Now"
+                    // only on the un-zoomed live day — a zoomed window's right edge is wherever
+                    // the user panned it (#829).
+                    HrTimeAxisLabels(
+                        ticks = timeTicks,
+                        timestamps = visTimestamps,
+                        showNow = selectedDay == today && hrZoom == null,
+                    )
                 }
             }
             Box(
@@ -4622,6 +4621,50 @@ private fun HeartRateTrendCard(
                             .clickable(onClickLabel = "Reset the heart rate zoom") { hrZoom = null }
                             .padding(horizontal = 6.dp, vertical = 2.dp),
                     )
+                }
+            }
+        }
+    }
+}
+
+// The Today HR x-axis label strip: one Text per round-time tick, centred under its gridline via
+// the SAME per-bucket timestamp interpolation the chart uses (timestampFraction, Charts.kt) and
+// clamped into the strip. "Now" keeps its right-edge slot; a tick label that would collide with
+// it (or with its left neighbour) is skipped rather than overlapped.
+@Composable
+private fun HrTimeAxisLabels(
+    ticks: List<Pair<Long, String>>,
+    timestamps: List<Long>,
+    showNow: Boolean,
+) {
+    Layout(
+        modifier = Modifier.fillMaxWidth(),
+        content = {
+            ticks.forEach { (_, label) ->
+                Text(label, style = NoopType.footnote, color = Palette.textTertiary, maxLines = 1)
+            }
+            if (showNow) {
+                Text("Now", style = NoopType.footnote, color = Palette.textTertiary, maxLines = 1)
+            }
+        },
+    ) { measurables, constraints ->
+        val loose = constraints.copy(minWidth = 0, minHeight = 0)
+        val placeables = measurables.map { it.measure(loose) }
+        val width = constraints.maxWidth
+        val height = placeables.maxOfOrNull { it.height } ?: 0
+        layout(width, height) {
+            val nowPlaceable = if (showNow) placeables.last() else null
+            val nowLeft = nowPlaceable?.let { width - it.width } ?: Int.MAX_VALUE
+            nowPlaceable?.place(width - nowPlaceable.width, 0)
+            var lastRight = Int.MIN_VALUE
+            ticks.forEachIndexed { i, (ts, _) ->
+                val p = placeables[i]
+                val frac = timestampFraction(timestamps, ts) ?: return@forEachIndexed
+                val x = (frac * width - p.width / 2f).roundToInt().coerceIn(0, (width - p.width).coerceAtLeast(0))
+                // Skip a label that would overlap its neighbour or the "Now" marker.
+                if (x > lastRight && x + p.width <= nowLeft - 8) {
+                    p.place(x, 0)
+                    lastRight = x + p.width + 8
                 }
             }
         }
@@ -4747,8 +4790,13 @@ private fun OverviewHRChart(
     strain: Double?,
     effortScale: EffortScale,
     modifier: Modifier,
+    // Round wall-clock (epochSec, "HH:mm") ticks, each drawn as a dotted gridline under the curve.
+    // The matching labels render OUTSIDE this plot-height composable (HrTimeAxisLabels), sharing
+    // the same tick list + timestamp mapping so they align. Empty = no gridlines.
+    timeTicks: List<Pair<Long, String>> = emptyList(),
 ) {
     // The line itself stays the existing shared component, unchanged, markers are a sibling overlay.
+    val bucketTimestamps = remember(buckets) { buckets.map { it.bucket } }
     val minV = bpm.min()
     val maxV = bpm.max()
     val span = (maxV - minV).takeIf { it > 0.0 } ?: 1.0
@@ -4836,6 +4884,23 @@ private fun OverviewHRChart(
         // puts it under the curve, exactly like iOS; the wake divider, Charge/Effort rules and glow end-cap
         // stay in the Canvas AFTER the line (iOS draws those marks after the LineMark too, so they read on
         // top). Only the fill moved; same geometry, same colours.
+        // Dotted round-time gridlines, FIRST so everything (band, curve, markers) reads over them.
+        if (plotW > 0f && plotH > 0f && timeTicks.isNotEmpty()) {
+            val gridDash = remember { PathEffect.dashPathEffect(floatArrayOf(4f, 6f), 0f) }
+            Canvas(modifier = Modifier.fillMaxSize()) {
+                timeTicks.forEach { (ts, _) ->
+                    val frac = timestampFraction(bucketTimestamps, ts) ?: return@forEach
+                    val x = frac * size.width
+                    drawLine(
+                        color = Palette.hairline,
+                        start = Offset(x, 0f),
+                        end = Offset(x, size.height),
+                        strokeWidth = 1f,
+                        pathEffect = gridDash,
+                    )
+                }
+            }
+        }
         if (plotW > 0f && plotH > 0f &&
             sleepStartX != null && sleepEndX != null && sleepEndX > sleepStartX) {
             Canvas(modifier = Modifier.fillMaxSize()) {
@@ -4855,6 +4920,10 @@ private fun OverviewHRChart(
             color = Palette.metricRose,
             fill = true,
             selectionEnabled = true,
+            // Scrub read-out: the timestamps prefix the sample's local clock time and the #463
+            // formatter carries the unit — "14:32 · 87 bpm" instead of a bare "87".
+            formatValue = { "${it.roundToInt()} bpm" },
+            timestamps = bucketTimestamps,
         )
 
         // 2) Wake divider + dashed rules + glow end-cap, drawn in one Canvas ON TOP of the line.

--- a/android/app/src/test/java/com/noop/ui/ChartSelectionLabelTest.kt
+++ b/android/app/src/test/java/com/noop/ui/ChartSelectionLabelTest.kt
@@ -30,4 +30,18 @@ class ChartSelectionLabelTest {
         lineChartSelectionLabel(41.5, { v -> seen = v; "x" })
         assertEquals(41.5, seen!!, 0.0)
     }
+
+    // Prototype (hr-chart-time-axis): a caller-supplied sample timestamp PREFIXES the local clock
+    // time, so the scrub answers "when" — "14:32 · 87 bpm", not a bare value.
+    @Test fun aSuppliedTimestampPrefixesTheLocalClockTime() {
+        val zone = java.time.ZoneId.of("Europe/Kyiv")   // UTC+3 in July
+        val ts = java.time.ZonedDateTime.of(2026, 7, 10, 14, 32, 0, 0, zone).toEpochSecond()
+        assertEquals("14:32 · 87 bpm", lineChartSelectionLabel(87.2, { "${it.toInt()} bpm" }, ts, zone))
+        // Without a formatter the raw default still carries the time prefix.
+        assertEquals("14:32 · 87", lineChartSelectionLabel(87.0, null, ts, zone))
+    }
+
+    @Test fun withoutATimestampTheLabelIsUnchanged() {
+        assertEquals("87", lineChartSelectionLabel(87.0, null, null))
+    }
 }

--- a/android/app/src/test/java/com/noop/ui/ChartTimeTicksTest.kt
+++ b/android/app/src/test/java/com/noop/ui/ChartTimeTicksTest.kt
@@ -1,0 +1,86 @@
+package com.noop.ui
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.time.ZoneId
+import java.time.ZonedDateTime
+
+/**
+ * The round-time x-axis ticks (prototype hr-chart-time-axis). The Today HR axis used to label the
+ * data extent's own endpoints ("00:05 / 10:10 / Now"); chartTimeTicks instead emits fixed round
+ * wall-clock ticks chosen by the visible span, DST-safe via java.time. Pure + clock-free, so these
+ * lock the interval choice, the round alignment, midnight crossing, and the spring-forward dedupe.
+ */
+class ChartTimeTicksTest {
+
+    private val kyiv = ZoneId.of("Europe/Kyiv")
+
+    private fun at(y: Int, mo: Int, d: Int, h: Int, mi: Int, zone: ZoneId = kyiv): Long =
+        ZonedDateTime.of(y, mo, d, h, mi, 0, 0, zone).toEpochSecond()
+
+    @Test fun aFullDayTicksEverySixHoursOnRoundTimes() {
+        val ticks = chartTimeTicks(at(2026, 7, 10, 0, 5), at(2026, 7, 10, 23, 40), kyiv)
+        assertEquals(listOf("06:00", "12:00", "18:00"), ticks.map { it.second })
+        // Tick instants are the labelled wall-clock times, not offsets from the data start.
+        assertEquals(at(2026, 7, 10, 6, 0), ticks.first().first)
+    }
+
+    @Test fun twelveHoursTicksEveryThreeHours() {
+        val ticks = chartTimeTicks(at(2026, 7, 10, 8, 12), at(2026, 7, 10, 20, 12), kyiv)
+        assertEquals(listOf("09:00", "12:00", "15:00", "18:00"), ticks.map { it.second })
+    }
+
+    @Test fun sixHoursTicksEveryTwoHours() {
+        val ticks = chartTimeTicks(at(2026, 7, 10, 9, 30), at(2026, 7, 10, 15, 30), kyiv)
+        assertEquals(listOf("10:00", "12:00", "14:00"), ticks.map { it.second })
+    }
+
+    @Test fun threeHoursTicksEveryHour() {
+        val ticks = chartTimeTicks(at(2026, 7, 10, 13, 10), at(2026, 7, 10, 16, 10), kyiv)
+        assertEquals(listOf("14:00", "15:00", "16:00"), ticks.map { it.second })
+    }
+
+    @Test fun oneHourTicksEveryQuarterHour() {
+        val ticks = chartTimeTicks(at(2026, 7, 10, 14, 5), at(2026, 7, 10, 15, 5), kyiv)
+        assertEquals(listOf("14:15", "14:30", "14:45", "15:00"), ticks.map { it.second })
+    }
+
+    @Test fun aWindowCrossingMidnightLabelsMidnightAsZeroZero() {
+        // Rolling 24h ending mid-morning: the previous day's evening ticks, then "00:00", then today's.
+        val ticks = chartTimeTicks(at(2026, 7, 9, 10, 30), at(2026, 7, 10, 10, 30), kyiv)
+        assertTrue(ticks.map { it.second }.contains("00:00"))
+        assertEquals(listOf("12:00", "18:00", "00:00", "06:00"), ticks.map { it.second })
+    }
+
+    @Test fun emptyAndInvertedWindowsYieldNoTicks() {
+        assertTrue(chartTimeTicks(0L, 0L, kyiv).isEmpty())
+        assertTrue(chartTimeTicks(100L, 50L, kyiv).isEmpty())
+    }
+
+    @Test fun springForwardKeepsLabelsRoundAndUndoubled() {
+        // New York 2026-03-08: 02:00 wall clock jumps to 03:00. An hourly-ticking window over the
+        // gap resolves the skipped 02:00 to the same instant as 03:00; the dedupe keeps ONE tick,
+        // labelled with the wall-clock time that actually exists.
+        val ny = ZoneId.of("America/New_York")
+        val ticks = chartTimeTicks(at(2026, 3, 8, 0, 30, ny), at(2026, 3, 8, 3, 30, ny), ny)
+        assertEquals(listOf("01:00", "03:00"), ticks.map { it.second })
+        val epochs = ticks.map { it.first }
+        assertEquals(epochs.distinct(), epochs)                       // dedup across the gap
+        assertEquals(epochs.sorted(), epochs)                         // still monotonic
+    }
+
+    @Test fun timestampFractionInterpolatesBetweenBucketTimestamps() {
+        val ts = listOf(0L, 100L, 200L, 400L)
+        assertEquals(0f, timestampFraction(ts, 0L)!!, 1e-6f)
+        assertEquals(1f, timestampFraction(ts, 400L)!!, 1e-6f)
+        // Halfway between buckets 1 and 2 → fractional index 1.5 of 3.
+        assertEquals(0.5f, timestampFraction(ts, 150L)!!, 1e-6f)
+        // A gap (200→400) still interpolates within its own segment: 300 → index 2.5 of 3.
+        assertEquals(2.5f / 3f, timestampFraction(ts, 300L)!!, 1e-6f)
+        // Outside the extent, and degenerate lists, map to nothing rather than an edge pin.
+        assertEquals(null, timestampFraction(ts, -1L))
+        assertEquals(null, timestampFraction(ts, 401L))
+        assertEquals(null, timestampFraction(listOf(5L), 5L))
+    }
+}


### PR DESCRIPTION
## What this PR does

The Today HR card's x-axis showed the rendered data extent's own endpoints ("00:05 / 11:05 / Now") with nothing in between, and the tap/drag pinpoint printed the value alone — so a reading was "100 bpm somewhere between 6 and 9 AM". This PR makes the axis read like a clock and the scrub answer *when*:

- **`chartTimeTicks()`** — a pure, JVM-tested function in `Charts.kt` that picks round wall-clock ticks by the visible span (≥20h → 6h, ≥10h → 3h, ≥5h → 2h, ≥2h → 1h, else 15min), stepped in local time from the window's midnight so a window crossing midnight still labels "00:00" and ticks stay round across DST; the spring-forward gap dedupes to a single tick.
- **Dotted gridlines** — a subtle vertical gridline at each tick (`Palette.hairline`, dash 4/6), drawn under the sleep band and the curve. Axis labels are centred under their gridlines via a custom `Layout` with collision-skip; the "Now" end label is preserved on the live un-zoomed day.
- **Timed scrub readout** — `LineChart` gains an *optional* index-aligned `timestamps` parameter; when present, the selection label (from `#463`) is prefixed with the sample's local clock time: "14:32 · 87 bpm".

Only the Today HR card passes `timestamps`; every other `LineChart` consumer is byte-identical (opt-in param).

Deliberate choice: the tick interval follows the *rendered data extent*, not the nominal range chip — a "24h" chip showing only 6h of data gets 2h ticks, which matches what's actually on screen.

Follow-up idea (separate discussion, not in this PR): typed x-axis domains (time-of-day vs date) so the Trends/Sleep charts can adopt the same treatment.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] CI / tooling

## How it was tested

- `./gradlew testFullDebugUnitTest` green, including 11 new tests: `ChartTimeTicksTest` (9 — interval selection per span, midnight alignment across a midnight-crossing window, DST spring-forward dedupe, timestamp interpolation) and `ChartSelectionLabelTest` (+2 for the time prefix).
- `./gradlew assembleFullDebug` builds clean, no new warnings.
- On-device verification on a Galaxy S21+ (Android 15) with real strap data:

| Before | After | Scrub readout |
|---|---|---|
| ![before](https://gist.githubusercontent.com/pagarsky/892fdde17d9d45ce6cd012e8c5af28bc/raw/chart_before.png) | ![after](https://gist.githubusercontent.com/pagarsky/892fdde17d9d45ce6cd012e8c5af28bc/raw/chart_after.png) | ![scrub](https://gist.githubusercontent.com/pagarsky/892fdde17d9d45ce6cd012e8c5af28bc/raw/chart_scrub.png) |

Before: axis labelled with the data extent's endpoints ("00:05 / 11:05"). After: round ticks ("06:00 / 12:00") with dotted gridlines. Scrub: "09:15 · 53 bpm".

## Checklist

- [ ] Swift package tests pass for any package I touched (`swift test` in `Packages/<name>`) — n/a, Android-only
- [x] Android unit tests pass if I touched `android/` (`./gradlew testFullDebugUnitTest`)
- [x] No new build warnings introduced
- [x] UI changes use only `StrandDesign` tokens — no hardcoded colors, fonts, or spacing
- [x] No hardcoded hex frame bytes; protocol facts live in the schema / decoders
- [x] Follows the conventions in [`docs/CONTRIBUTING.md`](../docs/CONTRIBUTING.md)
- [x] I did not commit generated output (`Strand.xcodeproj/`) or any secrets/keystores

## Related issues

Closes #181

🤖 Generated with [Claude Code](https://claude.com/claude-code)