### PR TITLE
R-R store: seq tiebreaker so equal same-second beats survive (RMSSD was biased high) (#163)

### DIFF
--- a/android/app/src/main/java/com/noop/data/Entities.kt
+++ b/android/app/src/main/java/com/noop/data/Entities.kt
@@ -8,10 +8,11 @@ import androidx.room.Index
  * Room entities mirroring the verified GRDB schema in
  * Packages/WhoopStore/Sources/WhoopStore/Database.swift (+ MetricsCache.swift).
  *
- * Natural keys are preserved EXACTLY so insert dedupe (OnConflictStrategy.IGNORE)
- * behaves identically to the Swift `ON CONFLICT(...) DO NOTHING` upserts:
+ * Natural keys mirror the Swift `ON CONFLICT(...) DO NOTHING` upserts so insert dedupe behaves
+ * identically, with ONE deliberate exception (see the RrInterval doc):
  *   - hrSample        PK (deviceId, ts)
- *   - rrInterval      PK (deviceId, ts, rrMs)
+ *   - rrInterval      PK (deviceId, ts, rrMs, seq)  // v18: seq tiebreaks EQUAL same-second beats;
+ *                                                   // Swift key is still (deviceId, ts, rrMs) — needs it too
  *   - event           PK (deviceId, ts, kind)
  *   - battery         PK (deviceId, ts)
  *   - spo2Sample      PK (deviceId, ts)
@@ -82,12 +83,26 @@ data class HrWindowStats(
     val max: Int?,
 )
 
-/** R-R interval. Swift `rrInterval` (v1). PK (deviceId, ts, rrMs), multiple R-R per ts. */
-@Entity(tableName = "rrInterval", primaryKeys = ["deviceId", "ts", "rrMs"])
+/**
+ * R-R interval. Swift `rrInterval` (v1); the Room key is widened in v18 to (deviceId, ts, rrMs, seq).
+ * `seq` distinguishes two EQUAL R-R intervals that fall in the same 1-second `ts` bucket: the old
+ * value-only key (deviceId, ts, rrMs) + IGNORE-on-conflict dropped the second of an equal pair, removing
+ * a zero-difference beat and biasing RMSSD/HRV HIGH — worst at rest/sleep, which is exactly when HRV is
+ * scored. `seq` numbers equal (ts, rrMs) beats 0, 1, … so both keep a row; DISTINCT intervals keep seq 0
+ * and their own slot, so no distinct beat is ever dropped (across insert batches or the live/historical
+ * merge — rrMs stays in the key). `seq` is declared BEFORE `synced` so Room's generated column order
+ * matches the v18 rebuild migration exactly.
+ *
+ * PARITY: this diverges from the Swift `rrInterval` key (still deviceId, ts, rrMs). The identical
+ * value-key drop exists in WhoopStore (Database.swift / StreamStore / Reads) and needs the same widening
+ * to keep Android and iOS HRV identical — a required follow-up. Bug + Android approach: #163 (@tanarchytan).
+ */
+@Entity(tableName = "rrInterval", primaryKeys = ["deviceId", "ts", "rrMs", "seq"])
 data class RrInterval(
     val deviceId: String,
     val ts: Long,
     val rrMs: Int,
+    val seq: Int = 0,
     val synced: Int = 0,
 )
 

--- a/android/app/src/main/java/com/noop/data/WhoopDao.kt
+++ b/android/app/src/main/java/com/noop/data/WhoopDao.kt
@@ -233,8 +233,10 @@ interface WhoopDao : DeviceRegistryDao {
     suspend fun hrWindowStats(deviceId: String, from: Long, to: Long): HrWindowStats
 
     @Query(
+        // ts, rrMs matches Swift Reads.swift; seq only orders the rare EQUAL same-second beats among
+        // themselves (identical rrMs → zero successive diff either way), so RMSSD stays order-invariant (v18).
         "SELECT * FROM rrInterval WHERE deviceId = :deviceId AND ts >= :from AND ts <= :to " +
-            "ORDER BY ts ASC, rrMs ASC LIMIT :limit"
+            "ORDER BY ts ASC, rrMs ASC, seq ASC LIMIT :limit"
     )
     suspend fun rrIntervals(deviceId: String, from: Long, to: Long, limit: Int): List<RrInterval>
 

--- a/android/app/src/main/java/com/noop/data/WhoopDatabase.kt
+++ b/android/app/src/main/java/com/noop/data/WhoopDatabase.kt
@@ -48,7 +48,7 @@ import androidx.sqlite.db.SupportSQLiteDatabase
         LabMarkerRow::class,
         LiveSessionRow::class,
     ],
-    version = 17,
+    version = 18,
     exportSchema = false,
 )
 abstract class WhoopDatabase : RoomDatabase() {
@@ -446,6 +446,40 @@ abstract class WhoopDatabase : RoomDatabase() {
             }
         }
 
+        /**
+         * v17 -> v18: REBUILD `rrInterval` to widen its PK from (deviceId, ts, rrMs) to
+         * (deviceId, ts, rrMs, seq) — the first non-additive migration in this DB. The value-only key +
+         * IGNORE-on-conflict silently dropped the second of two EQUAL successive R-R intervals in one
+         * 1-second `ts` bucket, deleting a zero-difference beat and biasing RMSSD/HRV high at rest/sleep
+         * (when HRV is scored). `seq` distinguishes equal (ts, rrMs) beats; distinct beats keep seq 0.
+         *
+         * A PK change needs a table rebuild (SQLite can't ALTER a PK) but is LOSS-LESS: every row is copied
+         * with seq = 0, which is exact because the OLD PK guaranteed a unique (deviceId, ts, rrMs) per row,
+         * so seq 0 never collides. No window functions (minSdk-26 SQLite lacks ROW_NUMBER). The rebuilt
+         * table's column order + PK MUST equal Room's generated v18 schema for [RrInterval] exactly —
+         * columns (deviceId, ts, rrMs, seq, synced), PK (deviceId, ts, rrMs, seq) — or the
+         * no-destructive-fallback open throws. `seq` is declared before `synced` in the entity so the
+         * orders match. Forward-only: beats already dropped under the old key can't be recovered, so this
+         * does NOT retroactively fix historical HRV; only inserts after the upgrade stop dropping equal
+         * beats. Exposed as [RR_SEQ_MIGRATION_SQL] and pinned by [com.noop.data.RrSeqMigrationTest].
+         * Diagnosis + approach from #163 (@tanarchytan).
+         */
+        internal val RR_SEQ_MIGRATION_SQL: List<String> = listOf(
+            "CREATE TABLE IF NOT EXISTS `rrInterval_new` (`deviceId` TEXT NOT NULL, `ts` INTEGER NOT NULL, " +
+                "`rrMs` INTEGER NOT NULL, `seq` INTEGER NOT NULL, `synced` INTEGER NOT NULL, " +
+                "PRIMARY KEY(`deviceId`, `ts`, `rrMs`, `seq`))",
+            "INSERT INTO `rrInterval_new` (`deviceId`, `ts`, `rrMs`, `seq`, `synced`) " +
+                "SELECT `deviceId`, `ts`, `rrMs`, 0, `synced` FROM `rrInterval`",
+            "DROP TABLE `rrInterval`",
+            "ALTER TABLE `rrInterval_new` RENAME TO `rrInterval`",
+        )
+
+        internal val MIGRATION_17_18 = object : Migration(17, 18) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                for (stmt in RR_SEQ_MIGRATION_SQL) db.execSQL(stmt)
+            }
+        }
+
         private fun build(appContext: Context): WhoopDatabase =
             Room.databaseBuilder(appContext, WhoopDatabase::class.java, DB_NAME)
                 // #1014: replace ONLY the corruption handling of the default open-helper. The
@@ -460,7 +494,7 @@ abstract class WhoopDatabase : RoomDatabase() {
                     MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5,
                     MIGRATION_5_6, MIGRATION_6_7, MIGRATION_7_8, MIGRATION_8_9, MIGRATION_9_10,
                     MIGRATION_10_11, MIGRATION_11_12, MIGRATION_12_13, MIGRATION_13_14,
-                    MIGRATION_14_15, MIGRATION_15_16, MIGRATION_16_17,
+                    MIGRATION_14_15, MIGRATION_15_16, MIGRATION_16_17, MIGRATION_17_18,
                 )
                 // #1037: a FRESH install builds the schema straight at the current version and runs NO
                 // migrations, so the MIGRATION_7_8 "my-whoop" registry seed never fires and the WHOOP,

--- a/android/app/src/main/java/com/noop/data/WhoopRepository.kt
+++ b/android/app/src/main/java/com/noop/data/WhoopRepository.kt
@@ -50,6 +50,31 @@ data class StreamBatch(
 data class HrRow(val ts: Long, val bpm: Int)
 data class RrRow(val ts: Long, val rrMs: Int)
 
+/**
+ * Attach a tiebreaker `seq` to each R-R row before insert (Room v18). Multiple beats share one
+ * whole-second `ts`; the old PK (deviceId, ts, rrMs) + IGNORE-on-conflict silently dropped the second of
+ * two EQUAL successive intervals in a second, removing a zero-difference pair and biasing RMSSD/HRV high.
+ * `seq` counts occurrences of each EQUAL (ts, rrMs) beat (0, 1, …) so both survive.
+ *
+ * Keying by (ts, rrMs) — NOT ts alone — is deliberate: distinct intervals keep seq 0 and thus their own
+ * (deviceId, ts, rrMs, 0) key, so a distinct beat is never dropped even when same-second beats arrive in
+ * SEPARATE insert batches or via the live/historical merge (a ts-only counter would restart per batch and
+ * collide distinct beats — a data-loss regression). Re-syncing identical records reproduces the same
+ * (ts, rrMs, seq), so the insert stays idempotent. Residual: two EQUAL beats in one second that straddle a
+ * live-flush boundary still collide (the counter is batch-local) — the same narrow case the old key dropped
+ * and strictly no worse; the authoritative historical path delivers a second's beats atomically in one
+ * batch. Pure so it is unit-testable. Approach from #163 (@tanarchytan).
+ */
+internal fun assignRrSeq(deviceId: String, rows: List<RrRow>): List<RrInterval> {
+    val seqByBeat = HashMap<Pair<Long, Int>, Int>()
+    return rows.map { row ->
+        val key = row.ts to row.rrMs
+        val s = seqByBeat.getOrDefault(key, 0)
+        seqByBeat[key] = s + 1
+        RrInterval(deviceId = deviceId, ts = row.ts, rrMs = row.rrMs, seq = s)
+    }
+}
+
 /** payloadJSON is the deterministic sorted-keys JSON for the remaining parsed fields. */
 data class EventEntry(val ts: Long, val kind: String, val payloadJSON: String)
 data class BatteryRow(val ts: Long, val soc: Double?, val mv: Int?, val charging: Boolean? = null)
@@ -172,7 +197,7 @@ class WhoopRepository(private val dao: WhoopDao) {
         val hrIds = if (streams.hr.isEmpty()) emptyList() else
             dao.insertHr(streams.hr.map { HrSample(deviceId, it.ts, it.bpm) })
         val rrIds = if (streams.rr.isEmpty()) emptyList() else
-            dao.insertRr(streams.rr.map { RrInterval(deviceId, it.ts, it.rrMs) })
+            dao.insertRr(assignRrSeq(deviceId, streams.rr))
         val evIds = if (streams.events.isEmpty()) emptyList() else
             dao.insertEvents(streams.events.map { EventRow(deviceId, it.ts, it.kind, it.payloadJSON) })
         val batIds = if (streams.battery.isEmpty()) emptyList() else

--- a/android/app/src/test/java/com/noop/data/RrSeqMigrationTest.kt
+++ b/android/app/src/test/java/com/noop/data/RrSeqMigrationTest.kt
@@ -1,0 +1,88 @@
+package com.noop.data
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Guards the v17 -> v18 Room migration that widens `rrInterval`'s PK to add a `seq` tiebreaker (#163,
+ * approach from @tanarchytan), and the pure `assignRrSeq` insert helper that populates it. No Robolectric
+ * here, so — like the other migration tests — the SQL is exposed as [WhoopDatabase.RR_SEQ_MIGRATION_SQL]
+ * and pinned to Room's generated v18 shape: the rebuilt table's column order + PK MUST match [RrInterval]
+ * exactly (deviceId, ts, rrMs, seq, synced; PK deviceId, ts, rrMs, seq) or the no-destructive-fallback
+ * open throws. The seq logic is exercised directly.
+ */
+class RrSeqMigrationTest {
+
+    @Test
+    fun migration_versionPair_is17to18() {
+        assertEquals(17, WhoopDatabase.MIGRATION_17_18.startVersion)
+        assertEquals(18, WhoopDatabase.MIGRATION_17_18.endVersion)
+    }
+
+    @Test
+    fun migration_rebuildsTable_matchingRoomGeneratedSchema() {
+        assertEquals(
+            listOf(
+                "CREATE TABLE IF NOT EXISTS `rrInterval_new` (`deviceId` TEXT NOT NULL, `ts` INTEGER NOT NULL, " +
+                    "`rrMs` INTEGER NOT NULL, `seq` INTEGER NOT NULL, `synced` INTEGER NOT NULL, " +
+                    "PRIMARY KEY(`deviceId`, `ts`, `rrMs`, `seq`))",
+                "INSERT INTO `rrInterval_new` (`deviceId`, `ts`, `rrMs`, `seq`, `synced`) " +
+                    "SELECT `deviceId`, `ts`, `rrMs`, 0, `synced` FROM `rrInterval`",
+                "DROP TABLE `rrInterval`",
+                "ALTER TABLE `rrInterval_new` RENAME TO `rrInterval`",
+            ),
+            WhoopDatabase.RR_SEQ_MIGRATION_SQL,
+        )
+    }
+
+    @Test
+    fun migration_isLossless_copiesEveryRowWithSeqZero() {
+        val sql = WhoopDatabase.RR_SEQ_MIGRATION_SQL
+        val insert = sql.single { it.startsWith("INSERT") }.uppercase()
+        // Copies EVERY row from the old table — no WHERE / GROUP BY — with seq forced to 0. Exact because
+        // the old PK (deviceId, ts, rrMs) was unique per row, so seq 0 never collides.
+        assertTrue("copies from the old table", insert.contains("FROM `RRINTERVAL`"))
+        assertTrue("no row filter or dedupe", !insert.contains(" WHERE ") && !insert.contains(" GROUP BY "))
+        // seq must sit before synced in both the CREATE and the entity, so Room's column order matches.
+        val create = sql.single { it.startsWith("CREATE") }
+        assertTrue("seq column declared before synced", create.indexOf("`seq`") < create.indexOf("`synced`"))
+    }
+
+    @Test
+    fun assignRrSeq_keepsEqualSameSecondBeats_withDistinctSeq() {
+        // Two EQUAL intervals in the same second: both survive, seq 0 then 1 — the pair the old key dropped.
+        val out = assignRrSeq("my-whoop", listOf(RrRow(100, 812), RrRow(100, 812)))
+        assertEquals(2, out.size)
+        assertEquals(listOf(0, 1), out.map { it.seq })
+        assertTrue(out.all { it.ts == 100L && it.rrMs == 812 && it.deviceId == "my-whoop" })
+    }
+
+    @Test
+    fun assignRrSeq_distinctBeats_keepSeqZero() {
+        // Distinct (ts, rrMs) beats each keep seq 0 — including two different values in the same second.
+        val out = assignRrSeq("d", listOf(RrRow(100, 602), RrRow(100, 613), RrRow(101, 602)))
+        assertEquals(listOf(0, 0, 0), out.map { it.seq })
+    }
+
+    @Test
+    fun assignRrSeq_distinctCrossBatchBeats_doNotCollide() {
+        // Distinct beats arriving in SEPARATE batches keep their own (ts, rrMs, 0) key — different rrMs =
+        // different PK, so IGNORE-on-conflict keeps both (the regression a ts-only counter would cause).
+        val b1 = assignRrSeq("d", listOf(RrRow(100, 602)))
+        val b2 = assignRrSeq("d", listOf(RrRow(100, 613)))
+        assertEquals(0, b1.single().seq)
+        assertEquals(0, b2.single().seq)
+    }
+
+    @Test
+    fun assignRrSeq_isIdempotent_reSyncReproducesSameKeys() {
+        val rows = listOf(RrRow(100, 812), RrRow(100, 812), RrRow(101, 700))
+        assertEquals(assignRrSeq("d", rows), assignRrSeq("d", rows))
+    }
+
+    @Test
+    fun rrInterval_seq_defaultsToZero() {
+        assertEquals(0, RrInterval(deviceId = "d", ts = 1, rrMs = 800).seq)
+    }
+}


### PR DESCRIPTION
Reimplements the fix from **#163** (diagnosis + approach by **@tanarchytan**) under the NoopApp identity. **Android‑only** — see the parity note.

### The bug
`rrInterval` PK `(deviceId, ts, rrMs)` + `IGNORE`‑on‑conflict silently drops the **second of two equal successive R‑R intervals** in the same 1‑second `ts` bucket. RMSSD is the root‑mean‑square of *successive differences*, so dropping an equal pair removes a **zero‑difference** term → **RMSSD/HRV biased high**, worst at rest/sleep (when HRV is scored). Real v18 records carry multiple R‑R per second, so it's a live path — and it's a second, independent contributor to the "HRV reads high" family alongside the #141/#147 window work.

### The fix
Widen the Room key to `(deviceId, ts, rrMs, seq)`:
- `assignRrSeq` numbers equal `(ts, rrMs)` beats `0, 1, …` at insert so both survive; distinct intervals keep `seq 0` and their own slot, so no distinct beat is ever dropped — including across separate insert batches or the live/historical merge (`rrMs` stays in the key). Idempotent re‑sync.
- Read order stays `ts, rrMs (+ seq)` → RMSSD is order‑invariant.
- **v17→v18 rebuild migration** (the first non‑additive one): loss‑less copy with `seq = 0` (exact — the old PK was unique), no `ROW_NUMBER` (minSdk‑26). `seq` is declared **before** `synced` so Room's generated column order matches the rebuild — verified, and the alternative would crash at open (`exportSchema=false`, no destructive fallback).

### Verification
- `RrSeqMigrationTest` (plain‑JVM, matching the existing migration‑test pattern): SQL pinned to Room's v18 shape, `seq` before `synced` guard, and `assignRrSeq` — equal beats survive `0,1`; distinct/cross‑batch beats don't collide; idempotent.
- Compile passes → **Room codegen accepted the v18 entity**. Full Android suite **2374 green**.
- Forward‑only: beats already dropped under the old key are unrecoverable, so this doesn't retroactively fix historical HRV.

### ⚠️ PARITY — required follow‑up
This widens **only** the Android/Room key. The identical value‑key drop exists in Swift `WhoopStore` (`Database.swift` PK, `StreamStore` insert, `Reads.swift` order). **Shipping this alone diverges Android vs iOS HRV**, so the matching `WhoopStore` widening + GRDB migration must land before this is considered complete. I couldn't build the Swift packages here; happy to write that port next.

Credit to @tanarchytan for the diagnosis and the Android approach (their PR #163).
