### PR TITLE
WhoopStore: widen R-R key with a seq tiebreaker — iOS parity for the RMSSD fix (#163)

### DIFF
--- a/Packages/WhoopStore/Sources/WhoopStore/Database.swift
+++ b/Packages/WhoopStore/Sources/WhoopStore/Database.swift
@@ -456,6 +456,30 @@ extension WhoopStore {
                 t.add(column: "spo2Ir", .integer)
             }
         }
+        migrator.registerMigration("v24-rr-seq") { db in
+            // Widen rrInterval's PK to (deviceId, ts, rrMs, seq). The value-only key + ON CONFLICT DO
+            // NOTHING silently dropped the second of two EQUAL successive R-R intervals in one 1-second
+            // ts bucket, removing a zero-difference beat and biasing RMSSD/HRV high at rest/sleep (when
+            // HRV is scored). `seq` distinguishes equal (ts, rrMs) beats; distinct beats keep seq 0.
+            // Android parity: Room v18 (#163). SQLite can't ALTER a PK, so REBUILD — LOSS-LESS: every row
+            // copied with seq = 0, exact because the old PK made (deviceId, ts, rrMs) unique per row.
+            // Forward-only: already-dropped beats can't be recovered. rrInterval is a leaf table (no FKs
+            // in or out), so the drop/rename is safe.
+            try db.create(table: "rrInterval_new") { t in
+                t.column("deviceId", .text).notNull()
+                t.column("ts", .integer).notNull()
+                t.column("rrMs", .integer).notNull()
+                t.column("seq", .integer).notNull().defaults(to: 0)
+                t.column("synced", .integer).notNull().defaults(to: 0)
+                t.primaryKey(["deviceId", "ts", "rrMs", "seq"])
+            }
+            try db.execute(sql: """
+                INSERT INTO rrInterval_new (deviceId, ts, rrMs, seq, synced)
+                SELECT deviceId, ts, rrMs, 0, synced FROM rrInterval
+                """)
+            try db.execute(sql: "DROP TABLE rrInterval")
+            try db.execute(sql: "ALTER TABLE rrInterval_new RENAME TO rrInterval")
+        }
         return migrator
     }
 }

--- a/Packages/WhoopStore/Sources/WhoopStore/Reads.swift
+++ b/Packages/WhoopStore/Sources/WhoopStore/Reads.swift
@@ -112,7 +112,7 @@ extension WhoopStore {
             try Row.fetchAll(db, sql: """
                 SELECT ts, rrMs FROM rrInterval
                 WHERE deviceId = ? AND ts >= ? AND ts <= ?
-                ORDER BY ts ASC, rrMs ASC LIMIT ?
+                ORDER BY ts ASC, rrMs ASC, seq ASC LIMIT ?
                 """, arguments: [deviceId, from, to, limit])
                 .map { RRInterval(ts: $0["ts"], rrMs: $0["rrMs"]) }
         }

--- a/Packages/WhoopStore/Sources/WhoopStore/StreamStore.swift
+++ b/Packages/WhoopStore/Sources/WhoopStore/StreamStore.swift
@@ -57,11 +57,18 @@ extension WhoopStore {
             }
             if !streams.rr.isEmpty {
                 let stmt = try db.cachedStatement(sql: """
-                    INSERT INTO rrInterval (deviceId, ts, rrMs) VALUES (?, ?, ?)
-                    ON CONFLICT(deviceId, ts, rrMs) DO NOTHING
+                    INSERT INTO rrInterval (deviceId, ts, rrMs, seq) VALUES (?, ?, ?, ?)
+                    ON CONFLICT(deviceId, ts, rrMs, seq) DO NOTHING
                     """)
+                // v24 (#163): number EQUAL (ts, rrMs) beats 0, 1, … within this batch so both survive;
+                // distinct beats keep seq 0 and their own (ts, rrMs, 0) key, so a distinct beat is never
+                // dropped even across batches (rrMs stays in the key). Re-syncing identical rows reproduces
+                // the same (ts, rrMs, seq) → still idempotent. Nested dict = (ts, rrMs) occurrence counter.
+                var seqByTsRr: [Int: [Int: Int]] = [:]
                 for r in streams.rr {
-                    try stmt.execute(arguments: [deviceId, r.ts, r.rrMs])
+                    let seq = seqByTsRr[r.ts]?[r.rrMs] ?? 0
+                    seqByTsRr[r.ts, default: [:]][r.rrMs] = seq + 1
+                    try stmt.execute(arguments: [deviceId, r.ts, r.rrMs, seq])
                     rr += db.changesCount
                 }
             }

--- a/Packages/WhoopStore/Tests/WhoopStoreTests/MigrationTests.swift
+++ b/Packages/WhoopStore/Tests/WhoopStoreTests/MigrationTests.swift
@@ -26,10 +26,42 @@ final class MigrationTests: XCTestCase {
         XCTAssertEqual(cols, ["deviceId", "ts"])
     }
 
-    func testRrIntervalPrimaryKeyIncludesRrMs() async throws {
+    /// v24 widens the R-R key with a `seq` tiebreaker so two EQUAL successive intervals in the same
+    /// second both survive (the old value-only key dropped the 2nd, biasing RMSSD/HRV high). #163.
+    func testRrIntervalPrimaryKeyIncludesSeq() async throws {
         let store = try await WhoopStore.inMemory()
         let cols = try await store.primaryKeyColumns("rrInterval")
-        XCTAssertEqual(cols, ["deviceId", "ts", "rrMs"])
+        XCTAssertEqual(cols, ["deviceId", "ts", "rrMs", "seq"])
+    }
+
+    func testV24AddsSeqColumnToRrInterval() async throws {
+        let store = try await WhoopStore.inMemory()
+        let cols = try await store.columnNamesForTest(table: "rrInterval")
+        XCTAssertTrue(cols.contains("seq"), "rrInterval missing v24 seq column")
+    }
+
+    func testV24KeepsEqualSameSecondBeats() async throws {
+        let store = try await WhoopStore.inMemory()
+        try await store.upsertDevice(id: "dev1", mac: nil, name: nil)
+        // Two EQUAL R-R intervals in the same second: the old value-only key dropped the 2nd; v24 keeps both.
+        let n = try await store.insert(
+            Streams(rr: [RRInterval(ts: 100, rrMs: 812), RRInterval(ts: 100, rrMs: 812)]),
+            deviceId: "dev1")
+        XCTAssertEqual(n.rr, 2)
+        let read = try await store.rrIntervals(deviceId: "dev1", from: 0, to: 1_000, limit: 100)
+        XCTAssertEqual(read.count, 2)
+        XCTAssertTrue(read.allSatisfy { $0.ts == 100 && $0.rrMs == 812 })
+    }
+
+    func testV24DistinctBeatsAllKept() async throws {
+        let store = try await WhoopStore.inMemory()
+        try await store.upsertDevice(id: "dev1", mac: nil, name: nil)
+        // Distinct (ts, rrMs) beats — incl. two values in the same second — each keep seq 0 and their slot.
+        let n = try await store.insert(
+            Streams(rr: [RRInterval(ts: 100, rrMs: 602), RRInterval(ts: 100, rrMs: 613),
+                         RRInterval(ts: 101, rrMs: 602)]),
+            deviceId: "dev1")
+        XCTAssertEqual(n.rr, 3)
     }
 
     /// v5 adds a `synced` column to all 8 decoded tables.


### PR DESCRIPTION
Completes the R‑R equal‑beat fix by porting it to Swift `WhoopStore` — the **parity follow‑up** to **#163** (which fixed Android). Until this lands, Android and iOS compute different RMSSD/HRV from the same strap data.

### The fix (mirrors Android exactly)
The `rrInterval` key `(deviceId, ts, rrMs)` + `ON CONFLICT DO NOTHING` silently dropped the second of two **equal** successive R‑R intervals in one 1‑second bucket → removed a zero‑difference beat → **RMSSD/HRV biased high** at rest/sleep.

- **`Database.swift`** — GRDB migration `v24-rr-seq` rebuilds `rrInterval` to PK `(deviceId, ts, rrMs, seq)`. Loss‑less copy with `seq = 0` (exact — the old PK was unique). `rrInterval` is a leaf table (no FKs), so the drop/rename is safe. GRDB runs *all* migrations on fresh installs too, so new and upgraded DBs both get `seq`.
- **`StreamStore.swift`** — number equal `(ts, rrMs)` beats `0, 1, …` per batch so both survive; distinct beats keep `seq 0` (never dropped across batches). Re‑sync stays idempotent.
- **`Reads.swift`** — `ORDER BY ts, rrMs, seq` → RMSSD is order‑invariant (equal beats = 0 diff).

### Tests
`MigrationTests`: PK now includes `seq`; two equal same‑second beats survive (insert count 2, read 2); distinct beats all kept. Mirrors the Android `RrSeqMigrationTest`. No existing test breaks — the parse tests don't touch the DB, and `InsertTests`/`ReadTests` use distinct beats + idempotent re‑sync.

### Schema parity
Matches Android exactly: Room v18 PK == GRDB v24 PK `(deviceId, ts, rrMs, seq)`. `WhoopStoreInfo.schemaVersion` left at `18` — it's already out of sync with the migration count and pinned `== 18` by an existing test; bumping it is a separate pre‑existing cleanup.

### ⚠️ Verification caveat
I **could not build or test the Swift packages locally** (the usual GRDB→CSQLite `sqlite3.h` wall). Every referenced API (`Streams(rr:)` defaults, the `insert` tuple's `.rr`, `store.rrIntervals`/`columnNamesForTest`/`primaryKeyColumns`, GRDB `db.create`/`db.execute`) was verified against existing in‑repo usage. **Release CI runs `swift test` on `WhoopStore`** — that's the validation gate here.

Credit @tanarchytan for the diagnosis + Android approach (#163).
