### PR TITLE
WhoopStore tests: import WhoopProtocol (fixes #185 CI)

### DIFF
--- a/Packages/WhoopStore/Tests/WhoopStoreTests/MigrationTests.swift
+++ b/Packages/WhoopStore/Tests/WhoopStoreTests/MigrationTests.swift
@@ -1,5 +1,6 @@
 import XCTest
 import GRDB
+import WhoopProtocol
 @testable import WhoopStore
 
 final class MigrationTests: XCTestCase {


### PR DESCRIPTION
The v24 rr-seq tests added in #185 use `Streams` / `RRInterval` — **WhoopProtocol** types — but `MigrationTests.swift` doesn't `import WhoopProtocol`, so `swift test` on WhoopStore fails to compile (`cannot find 'Streams'/'RRInterval' in scope`). `BiometricStreamTests` already imports it; this adds the same line to `MigrationTests`.

Caught by the re-enabled `swift-packages` CI — I couldn't compile the Swift locally (GRDB/CSQLite wall), which is exactly why this slipped through. Once this merges and CI re-runs, WhoopStore's tests will actually *execute* the #185 migration logic (equal beats survive, PK includes seq).

**Separately**, re-enabling `swift-packages` surfaced a **pre-existing** WhoopProtocol failure (a compiler type-check timeout in `DecoderOracleTests.swift:86`, unrelated to #185 — it broke while the workflow was disabled since June 27). Not fixed here; flagged for a follow-up.