### PR TITLE
WhoopProtocol tests: fix type-check timeout in the gravity-|mag| assertion

### DIFF
--- a/Packages/WhoopProtocol/Tests/WhoopProtocolTests/DecoderOracleTests.swift
+++ b/Packages/WhoopProtocol/Tests/WhoopProtocolTests/DecoderOracleTests.swift
@@ -83,7 +83,13 @@ final class DecoderOracleTests: XCTestCase {
                     let gy = parsed["gravity_y"]?.doubleValue
                     let gz = parsed["gravity_z"]?.doubleValue
                     XCTAssertNotNil(gx, "\(frame.name): gravity did not decode")
-                    let mag = ((gx ?? 0) * (gx ?? 0) + (gy ?? 0) * (gy ?? 0) + (gz ?? 0) * (gz ?? 0)).squareRoot()
+                    // Typed sub-terms: the one-liner ((gx ?? 0)*(gx ?? 0) + …).squareRoot() made Swift's
+                    // type-checker time out ("unable to type-check in reasonable time") — six `?? 0` literals
+                    // over the multiply/add tree. Binding explicit Doubles removes the inference blow-up.
+                    let x: Double = gx ?? 0
+                    let y: Double = gy ?? 0
+                    let z: Double = gz ?? 0
+                    let mag = (x * x + y * y + z * z).squareRoot()
                     XCTAssertEqual(mag, wantMag, accuracy: 0.1, "\(frame.name): |gravity|")
                 default:
                     switch expected {


### PR DESCRIPTION
`DecoderOracleTests.swift:86` computed |gravity| in a single expression:
```swift
let mag = ((gx ?? 0) * (gx ?? 0) + (gy ?? 0) * (gy ?? 0) + (gz ?? 0) * (gz ?? 0)).squareRoot()
```
The six `?? 0` literals over the multiply/add tree blow up Swift's type inference (*"unable to type-check this expression in reasonable time"*), which fails the **entire WhoopProtocol test build**. Fix: bind explicit `Double` sub‑terms first, then square. **Math is unchanged.**

**Pre‑existing**, not related to the R‑R work — it broke while `swift-packages` was disabled (since 2026‑06‑27) and surfaced when we re‑enabled the workflow.

**Validated locally:** WhoopProtocol has no GRDB dependency, so it builds here (unlike WhoopStore). `swift test` → **241 tests pass, 0 failures**.

With this + #186, `swift-packages` should be fully green again.