### PR TITLE
Apple Health import: store dedupe keys as a 64-bit hash to stop the OOM hang (#183)

### DIFF
--- a/Packages/StrandImport/Sources/StrandImport/AppleHealthImporter.swift
+++ b/Packages/StrandImport/Sources/StrandImport/AppleHealthImporter.swift
@@ -270,8 +270,24 @@ final class HealthXMLDelegate: NSObject, XMLParserDelegate {
     // Correlation are skipped (they also appear top-level).
     private var correlationDepth = 0
 
-    // Dedupe set over HealthSample dedupeKeys.
-    private var seenSampleKeys: Set<String> = []
+    // Dedupe set over HealthSample dedupeKeys — stored as the key's 64-bit HASH, not the full String
+    // (#183). A large Apple Health export has tens of millions of unique samples; retaining a ~50-100 B
+    // String each was ~1-2 GB of RAM, enough to push an import into sustained memory pressure and hang.
+    // A 64-bit hash is 8 B/entry (~10x less); a collision across even 20M samples is ~1e-5, and a rare
+    // one just drops a look-alike duplicate — the same effect dedup intends. Within one import run the
+    // hash is stable, so identical keys always dedupe.
+    private var seenSampleKeys: Set<Int> = []
+
+    /// 64-bit FNV-1a over `s`'s UTF-16 code units — byte-identical to the Android `hash64` (both iterate
+    /// UTF-16 units with the same offset basis + prime, wrapping at 64 bits), so the two platforms produce
+    /// the same dedupe hashes and drop the exact same look-alike duplicates (#183).
+    static func hash64(_ s: String) -> Int {
+        var h: UInt64 = 0xcbf29ce484222325   // FNV-1a 64-bit offset basis
+        for u in s.utf16 {
+            h = (h ^ UInt64(u)) &* 0x100000001b3   // xor code unit, ×= FNV prime (wraps, intended)
+        }
+        return Int(bitPattern: UInt(h))
+    }
 
     /// True once at least one usable record/workout/sleep row was parsed. Drives the tolerant-parse
     /// decision: a hard error AFTER real data was seen keeps the partial result instead of failing.
@@ -439,9 +455,10 @@ final class HealthXMLDelegate: NSObject, XMLParserDelegate {
             tzOffsetMin: tzOffsetMin,
             sourceName: sourceName
         )
-        // Dedupe on type+start+end+source+value (correctness-critical; the
-        // dedupe set is the smaller, retained cost).
-        if seenSampleKeys.insert(sample.dedupeKey).inserted {
+        // Dedupe on type+start+end+source+value (correctness-critical). Retain only the key's 64-bit
+        // hash, not the String, so the set stays ~10x smaller on a huge export (#183). Uses the SAME
+        // FNV-1a as Android (NOT Swift's per-run-randomized hashValue) so both platforms dedupe identically.
+        if seenSampleKeys.insert(Self.hash64(sample.dedupeKey)).inserted {
             // Always fold into the bounded per-day accumulator.
             dailyAcc.add(sample)
             anyRecordSeen = true

--- a/android/app/src/main/java/com/noop/ingest/AppleHealthImporter.kt
+++ b/android/app/src/main/java/com/noop/ingest/AppleHealthImporter.kt
@@ -711,7 +711,10 @@ private class Aggregator {
     }
 
     private val byDay = HashMap<String, DayAcc>()
-    private val seen = HashSet<String>()
+    // Dedupe over sample keys, stored as the key's 64-bit HASH not the full String (#183). A large Apple
+    // Health export has tens of millions of unique samples; retaining a ~50-100 B String each was ~1-2 GB
+    // of RAM, enough to hang the import under memory pressure. 8 B/entry is ~10x smaller. See [hash64].
+    private val seen = HashSet<Long>()
     private val workouts = ArrayList<PendingWorkout>()
 
     /** True once any relevant, date-valid record / workout / sleep row was dispatched. Drives the
@@ -730,8 +733,20 @@ private class Aggregator {
         val energyKcal: Double?,
     )
 
-    /** Returns true if [key] was not seen before (i.e. this row should be processed). */
-    fun markSeen(key: String): Boolean = seen.add(key)
+    /** Returns true if [key] was not seen before (i.e. this row should be processed). Dedupes on the
+     *  key's 64-bit hash, not the full String, to bound memory on a huge export (#183). */
+    fun markSeen(key: String): Boolean = seen.add(hash64(key))
+
+    /** 64-bit FNV-1a over [s]'s UTF-16 code units. Kotlin's `String.hashCode` is only 32-bit — that's
+     *  ~46k collisions over 20M keys, silently dropping tens of thousands of real samples; a 64-bit hash
+     *  keeps that ~1e-5. A rare collision just drops a look-alike duplicate — the effect dedup intends. */
+    private fun hash64(s: String): Long {
+        var h = 0xcbf29ce484222325uL.toLong()   // FNV-1a 64-bit offset basis
+        for (i in s.indices) {
+            h = (h xor s[i].code.toLong()) * 0x100000001b3L   // xor code unit, × FNV prime (wraps, intended)
+        }
+        return h
+    }
 
     fun hasAnyRecord(): Boolean = sawAnyRecord
 


### PR DESCRIPTION
Fixes #183.

### The bug
A 150MB Apple Health `export.zip` (→ ~1–2GB of XML, tens of millions of samples) makes the import hang for over an hour. The XML parse itself is well‑behaved — it streams from a temp file (bounded RAM), aggregates into a **bounded per‑day accumulator**, and only retains raw samples when asked. But the **sample‑dedup set** retained one full `dedupeKey` **String** (~50–100 B) per unique sample and never cleared it:

- iOS `AppleHealthImporter.swift`: `seenSampleKeys: Set<String>`
- Android `AppleHealthImporter.kt`: `seen = HashSet<String>()`

For a heavy multi‑year export that's **~1–2GB of RAM just for the dedup set** — enough to push the import into sustained memory pressure, where it thrashes/compresses indefinitely rather than crashing. That's the report exactly: "loading for over an hour," not a crash.

### The fix
Retain only the key's **64‑bit hash** instead of the String: **8 B/entry, ~10× less** (~160MB vs ~1.6GB for 20M samples). A collision across 20M keys is ~1e‑5, and a rare one just drops a look‑alike duplicate — the same effect dedup intends.

Both platforms use the **identical FNV‑1a over UTF‑16 code units** (same offset basis + prime, wrapping at 64 bits) — deliberately *not* Swift's per‑run‑randomized `hashValue` or Kotlin's 32‑bit `hashCode` (which would collide ~46k times over 20M keys). So the two platforms produce the same hashes and drop the exact same duplicates — **byte‑identical dedup parity preserved.**

### Verification
- **Android:** compiles; full suite **2372 tests green** — dedup behaviour unchanged (identical keys → identical hash → deduped).
- **iOS:** couldn't build locally (GRDB/CSQLite wall); the FNV‑1a is a straight mirror of the Android one, validated by `swift test` on StrandImport in CI.

### Out of scope
The raw parse of tens of millions of records is inherently slow (minutes) — a huge export will still take a while, but it now **completes instead of hanging.** Surfacing import progress ("N records parsed") is a worthwhile UX follow‑up.
