### PR TITLE
WHOOP 4.0: learn per-device skin-temp anchor instead of assuming raw 826

### DIFF
--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/AnalyticsEngine.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/AnalyticsEngine.swift
@@ -264,6 +264,15 @@ public enum AnalyticsEngine {
                                   // keeps every 5/MG + pure-function caller byte-identical;
                                   // IntelligenceEngine passes the day owner's real family.
                                   skinTempFamily: DeviceFamily = .whoop5,
+                                  // Per-device WHOOP 4.0 worn anchor raw (#938 second capture): the raw that
+                                  // maps to 33.0 °C for THIS device. The @72 skin-temp ADC's register offset is
+                                  // per-device — a second real 4.0 strap shares the floor (~509) + saturation
+                                  // (2047) but has a worn band ~1100–1600, which the global 826 anchor maps to
+                                  // 47–72 °C, failing 100% of the worn gate. IntelligenceEngine learns it once
+                                  // per run from the owner's own worn median. nil → the family-aware conversion
+                                  // uses the global `Whoop4SkinTemp.anchorRaw`, so every 5/MG + pure-function
+                                  // caller stays byte-identical (`.whoop5` ignores the anchor entirely).
+                                  skinTempAnchorRaw: Double? = nil,
                                   // WHOOP 4.0 raw SpO2 PPG ADC samples (red/IR) for the night window
                                   // (#93). The nightly red/IR means over detected sleep are banked on the
                                   // DailyMetric as RAW ADC — honest "the sensor decoded" data, NOT a
@@ -540,7 +549,8 @@ public enum AnalyticsEngine {
         // personal baseline. In pass 1 baselines.skinTemp is nil so the deviation is nil
         // and the mean is harvested; IntelligenceEngine seeds the baseline from those means
         // and re-derives the deviation in pass 2 (mirrors avgHrv→recovery). APPROXIMATE.
-        let nightlySkinTempC = wornNightlySkinTempC(matched, hr: hr, skinTemp: skinTemp, family: skinTempFamily)
+        let nightlySkinTempC = wornNightlySkinTempC(matched, hr: hr, skinTemp: skinTemp,
+                                                    family: skinTempFamily, anchorRaw: skinTempAnchorRaw)
         let skinTempDevC: Double? = nightlySkinTempC.flatMap { (v: Double) -> Double? in
             guard let b = baselines.skinTemp, b.usable else { return nil }
             return round2(Baselines.deviation(v, state: b).delta)
@@ -862,8 +872,13 @@ public enum AnalyticsEngine {
                                      hr: [HRSample],
                                      skinTemp: [SkinTempSample],
                                      family: DeviceFamily = .whoop5,
+                                     // Per-device WHOOP 4.0 worn anchor raw (#938); nil → the global
+                                     // `Whoop4SkinTemp.anchorRaw`, keeping 5/MG + pure-function callers
+                                     // byte-identical. Threaded straight to the funnel's conversion.
+                                     anchorRaw: Double? = nil,
                                      minSamples: Int = minSkinTempSamples) -> Double? {
-        skinTempFunnel(sessions, hr: hr, skinTemp: skinTemp, family: family, minSamples: minSamples).mean
+        skinTempFunnel(sessions, hr: hr, skinTemp: skinTemp, family: family,
+                       anchorRaw: anchorRaw, minSamples: minSamples).mean
     }
 
     /// Nightly means of the WHOOP 4.0 raw SpO2 PPG channels (red/IR ADC) over the detected in-bed
@@ -945,6 +960,10 @@ public enum AnalyticsEngine {
                                       hr: [HRSample],
                                       skinTemp: [SkinTempSample],
                                       family: DeviceFamily = .whoop5,
+                                      // Per-device WHOOP 4.0 worn anchor raw (#938 second capture); nil → the
+                                      // global `Whoop4SkinTemp.anchorRaw`, so 5/MG + pure-function callers are
+                                      // byte-identical.
+                                      anchorRaw: Double? = nil,
                                       minSamples: Int = minSkinTempSamples) -> SkinTempFunnelDiagnostic {
         let total = skinTemp.count
         // No sessions ⇒ every sample is out of window; no samples ⇒ an empty funnel. Either way the mean is
@@ -962,7 +981,19 @@ public enum AnalyticsEngine {
         for t in skinTemp {
             if !wornSeconds.contains(t.ts) { notWorn += 1; continue }
             if !sessions.contains(where: { t.ts >= $0.start && t.ts <= $0.end }) { outOfWindow += 1; continue }
-            let c = skinTempCelsius(raw: t.raw, family: family)   // #938: family-aware (5/MG=raw/100, 4.0=raw ADC map)
+            // WHOOP 4.0 ONLY (#938 second capture): drop raws outside the plausible worn ADC band BEFORE the
+            // anchor map. The no-contact floor (~509) and the 11-bit saturation ceiling (2047) are doff /
+            // charging transients, not worn skin — with a per-device anchor a floor or pegged raw could
+            // otherwise map into the 28–42 °C window and poison the mean. Attributed to the SAME `outOfRange`
+            // bucket the °C gate uses ("out of plausible range"), so the four drop buckets + kept still sum to
+            // totalSamples. `.whoop5` is untouched here → its centidegree path stays byte-identical.
+            if family == .whoop4,
+               t.raw < Whoop4SkinTemp.wornMinRaw || t.raw > Whoop4SkinTemp.wornMaxRaw {
+                outOfRange += 1; continue
+            }
+            // Per-device anchor (#938): nil anchorRaw → the global `Whoop4SkinTemp.anchorRaw` (826), byte-
+            // identical to the pre-change conversion; `.whoop5` ignores the anchor.
+            let c = skinTempCelsius(raw: t.raw, family: family, anchorRaw: anchorRaw ?? Whoop4SkinTemp.anchorRaw)
             if c < skinTempMinC || c > skinTempMaxC { outOfRange += 1; continue }
             sum += c
             kept += 1

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/SkinTempAnalyticsTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/SkinTempAnalyticsTests.swift
@@ -211,6 +211,86 @@ final class SkinTempAnalyticsTests: XCTestCase {
         XCTAssertFalse(w4.isAbsent)
     }
 
+    // MARK: - per-device worn anchor, end-to-end (#938 second capture)
+
+    /// A second real 4.0 strap: worn raws ~1250–1330 (nightly mean raw ~1290). Under the GLOBAL 826 anchor
+    /// those map to ~54–58 °C, all failing the 28–42 °C worn gate (kept=0, no mean). With the device's OWN
+    /// learned anchor the worn band lands ~33 °C and the night is kept.
+    func testHighRegisterDeviceKeptWithLearnedAnchor() throws {
+        let start = 20_000_000
+        let sess = [session(start: start, durSec: 600)]
+        let hrs = (0..<600).map { hr(start + $0) }
+        // 600 worn samples sweeping raw 1250..1329 (nightly mean ~1290), a whole session inside worn seconds.
+        let temps = (0..<600).map { SkinTempSample(ts: start + $0, raw: 1250 + ($0 % 80)) }
+        let anchor = try XCTUnwrap(Whoop4SkinTemp.deviceAnchorRaw(temps.map { $0.raw }))
+        // GLOBAL anchor (nil → 826): every worn raw maps to ~54–58 °C, all out of range → absent.
+        XCTAssertNil(AnalyticsEngine.wornNightlySkinTempC(sess, hr: hrs, skinTemp: temps, family: .whoop4, anchorRaw: nil))
+        // LEARNED anchor: kept, and the mean sits in the plausible worn band ≈ 33 °C.
+        let mean = try XCTUnwrap(AnalyticsEngine.wornNightlySkinTempC(sess, hr: hrs, skinTemp: temps, family: .whoop4, anchorRaw: anchor))
+        XCTAssertGreaterThan(mean, 28.0)
+        XCTAssertLessThan(mean, 42.0)
+        XCTAssertEqual(mean, 33.0, accuracy: 1.5)
+    }
+
+    /// Two nights whose raw means differ by +20, converted with the SAME window-wide anchor → nightly °C
+    /// means differ by exactly +1.0 (20 × 0.05 slope). This is WHY the anchor is window-wide, not per-night:
+    /// the shared constant offset cancels, leaving the true cross-night deviation intact.
+    func testDeviationPreservedAcrossNightsWithSameAnchor() throws {
+        let anchor = 1290.0
+        func nightMean(_ startTs: Int, raw: Int) throws -> Double {
+            let sess = [session(start: startTs, durSec: 600)]
+            let hrs = (0..<600).map { hr(startTs + $0) }
+            let temps = (0..<600).map { SkinTempSample(ts: startTs + $0, raw: raw) }
+            return try XCTUnwrap(AnalyticsEngine.wornNightlySkinTempC(sess, hr: hrs, skinTemp: temps, family: .whoop4, anchorRaw: anchor))
+        }
+        let n1 = try nightMean(21_000_000, raw: 1290)
+        let n2 = try nightMean(22_000_000, raw: 1310) // +20 raw
+        XCTAssertEqual(n2 - n1, 1.0, accuracy: 1e-9)
+    }
+
+    /// Byte-compat: WHOOP4 with anchorRaw=nil and reporter-band raws (~826) produces the IDENTICAL mean as
+    /// the explicit global anchor (`Whoop4SkinTemp.anchorRaw`=826) — the pre-per-device behaviour.
+    func testWhoop4NilAnchorByteIdenticalToGlobal() throws {
+        let start = 23_000_000
+        let sess = [session(start: start, durSec: 600)]
+        let hrs = (0..<600).map { hr(start + $0) }
+        let temps = (0..<600).map { SkinTempSample(ts: start + $0, raw: 826) }
+        let nilAnchor = try XCTUnwrap(AnalyticsEngine.wornNightlySkinTempC(sess, hr: hrs, skinTemp: temps, family: .whoop4, anchorRaw: nil))
+        let explicitGlobal = try XCTUnwrap(AnalyticsEngine.wornNightlySkinTempC(sess, hr: hrs, skinTemp: temps, family: .whoop4, anchorRaw: Whoop4SkinTemp.anchorRaw))
+        XCTAssertEqual(nilAnchor, 33.0, accuracy: 1e-9) // raw 826 → exactly the 33.0 °C anchor
+        XCTAssertEqual(nilAnchor, explicitGlobal, accuracy: 1e-12)
+    }
+
+    /// WHOOP5 is unchanged by the anchor parameter: a centidegree night is byte-identical with or without one.
+    func testWhoop5IgnoresAnchor() throws {
+        let start = 24_000_000
+        let sess = [session(start: start, durSec: 600)]
+        let hrs = (0..<600).map { hr(start + $0) }
+        let temps = (0..<600).map { skin(start + $0, rawX100: 3400) } // 34 °C centidegrees
+        let noAnchor = try XCTUnwrap(AnalyticsEngine.wornNightlySkinTempC(sess, hr: hrs, skinTemp: temps, family: .whoop5, anchorRaw: nil))
+        let withAnchor = try XCTUnwrap(AnalyticsEngine.wornNightlySkinTempC(sess, hr: hrs, skinTemp: temps, family: .whoop5, anchorRaw: 1290.0))
+        XCTAssertEqual(noAnchor, 34.0, accuracy: 1e-9)
+        XCTAssertEqual(noAnchor, withAnchor, accuracy: 1e-12)
+    }
+
+    /// Doff-floor (509) and pegged-saturation (2047) samples on a WHOOP4 night count as `droppedOutOfRange`
+    /// (dropped BEFORE the anchor map) and the four buckets + kept still sum to totalSamples.
+    func testWhoop4FloorAndSaturationCountAsOutOfRange() throws {
+        let start = 25_000_000
+        let sess = [session(start: start, durSec: 900)]
+        let hrs = (0..<900).map { hr(start + $0) }
+        let worn = (0..<600).map { SkinTempSample(ts: start + $0, raw: 1290) }      // in-band worn
+        let floor = (600..<750).map { SkinTempSample(ts: start + $0, raw: 509) }    // no-contact floor
+        let pegged = (750..<900).map { SkinTempSample(ts: start + $0, raw: 2047) }  // 11-bit saturation
+        let temps = worn + floor + pegged
+        let anchor = try XCTUnwrap(Whoop4SkinTemp.deviceAnchorRaw(temps.map { $0.raw })) // learned from the 600 in-band raws
+        let f = AnalyticsEngine.skinTempFunnel(sess, hr: hrs, skinTemp: temps, family: .whoop4, anchorRaw: anchor)
+        XCTAssertEqual(f.totalSamples, 900)
+        XCTAssertEqual(f.droppedOutOfRange, 300) // 150 floor + 150 saturation, out of the plausible worn ADC band
+        XCTAssertEqual(f.kept, 600)
+        XCTAssertEqual(f.droppedNotWorn + f.droppedOutOfWindow + f.droppedOutOfRange + f.kept, f.totalSamples)
+    }
+
     // MARK: - seed → deviation (skin_temp baseline)
 
     private let skinCfg = Baselines.metricCfg["skin_temp"]!

--- a/Packages/WhoopProtocol/Sources/WhoopProtocol/DeviceFamily.swift
+++ b/Packages/WhoopProtocol/Sources/WhoopProtocol/DeviceFamily.swift
@@ -21,6 +21,25 @@ public enum HeaderCRCKind: String, Sendable, CaseIterable {
 }
 
 public extension DeviceFamily {
+    /// Resolve a device-registry `model` label to the strap family that wrote its rows (#171).
+    ///
+    /// The registry holds several historical spellings for the same hardware: the Add-Device wizard
+    /// stores bare "4.0" / "5.0 MG", other paths match the full picker labels ("WHOOP 4.0" /
+    /// "WHOOP 5.0 / MG"), and the legacy seeded "my-whoop" row stores just "WHOOP". Matching any
+    /// single spelling silently misses the others (#171), so this is the ONE place allowed to
+    /// interpret registry model labels.
+    ///
+    /// "WHOOP" predates the wizard and was written identically for 4.0 and 5/MG installs, so it
+    /// carries no family information; it keeps the prior `.whoop5` fallback, as do nil/unknown
+    /// labels (non-WHOOP imports whose skin temp is already °C) — only a positively-identified 4.0
+    /// changes scale (#938). Mirrors the Kotlin `DeviceFamily.forRegistryModel`.
+    static func forRegistryModel(_ model: String?) -> DeviceFamily {
+        switch model {
+        case "4.0", "WHOOP 4.0": return .whoop4
+        default: return .whoop5
+        }
+    }
+
     /// The header-CRC algorithm this family uses. This is the single switch that the family-aware
     /// `verifyFrame`/`parseFrame` overloads branch on; the payload CRC32 is identical for both.
     var headerCRCKind: HeaderCRCKind {

--- a/Packages/WhoopProtocol/Sources/WhoopProtocol/Streams.swift
+++ b/Packages/WhoopProtocol/Sources/WhoopProtocol/Streams.swift
@@ -73,25 +73,34 @@ public struct SkinTempSample: Equatable, Codable {
 ///   The reporter's doff/don capture gives a steady worn resting value of raw ~826 (worn steady
 ///   ~830–865; a no-contact floor ~510–520 at removal, then banking stops). Under `/100` that worn
 ///   value reads ~8.3 °C — impossible for a wrist streaming a resting HR (~52 bpm). We anchor the
-///   worn value at a defensible nocturnal wrist skin temperature (33.0 °C ↔ raw 826) and carry a
-///   PROVISIONAL slope until a second calibration point exists. Because the downstream use is a
+///   worn value at a defensible nocturnal wrist skin temperature (33.0 °C ↔ the worn anchor raw) and
+///   carry a PROVISIONAL slope until a second calibration point exists. Because the downstream use is a
 ///   deviation from the user's OWN nightly baseline (`skinTempDevC`), the offset is what must be right
 ///   to clear the absolute 28–42 °C worn gate + 20–42 °C baseline clamp; a slope error only rescales
 ///   the deviation and stays directionally correct. All 4.0 values APPROXIMATE.
+///
+///   PER-DEVICE ANCHOR (#938 second capture): `anchorRaw` is the raw that maps to 33.0 °C. It defaults to
+///   the global `Whoop4SkinTemp.anchorRaw` (826, first reporter's strap) so every existing caller is
+///   byte-identical, but the register OFFSET is per-device — a second real 4.0 strap shows the SAME floor
+///   (~509) and saturation (2047) yet a worn band of ~1100–1600 (nightly mean raw ~1290), which the global
+///   826 anchor maps to 47–72 °C (all samples fail the worn gate). The analytics caller therefore learns
+///   `anchorRaw` from the device's OWN worn median (`Whoop4SkinTemp.deviceAnchorRaw`) so the worn band lands
+///   in range; the constant offset cancels in the deviation-from-own-baseline the app consumes.
 ///
 ///   TODO(#938): replace the provisional slope with the exact two-point anchor once a second worn
 ///   point at a markedly different ambient (the reporter offered a colder + a warmer room) pins the
 ///   ADC→°C transfer — including whether it is linear at all. Until then this is a defensible
 ///   worn-range mapping, NOT a claimed-accurate absolute thermometer.
-public func skinTempCelsius(raw: Int, family: DeviceFamily) -> Double {
+public func skinTempCelsius(raw: Int, family: DeviceFamily,
+                            anchorRaw: Double = Whoop4SkinTemp.anchorRaw) -> Double {
     switch family {
     case .whoop5:
         return Double(raw) / 100.0
     case .whoop4:
-        // Anchor: worn resting raw 826 → 33.0 °C. Provisional slope 0.05 °C per raw unit (a ~35-unit
-        // worn-steady spread ≈ ~1.75 °C of nocturnal variation, within the plausible band). See TODO above.
+        // Anchor: worn resting raw `anchorRaw` (per-device, default 826) → 33.0 °C. Provisional slope 0.05 °C
+        // per raw unit (a ~35-unit worn-steady spread ≈ ~1.75 °C of nocturnal variation). See TODO above.
         return Whoop4SkinTemp.anchorCelsius
-            + (Double(raw) - Whoop4SkinTemp.anchorRaw) * Whoop4SkinTemp.provisionalSlopeCPerRaw
+            + (Double(raw) - anchorRaw) * Whoop4SkinTemp.provisionalSlopeCPerRaw
     }
 }
 
@@ -99,12 +108,48 @@ public func skinTempCelsius(raw: Int, family: DeviceFamily) -> Double {
 /// live in ONE place and the two-point-calibration TODO has an obvious home. Kept in lockstep with the
 /// Android `Whoop4SkinTemp`.
 public enum Whoop4SkinTemp {
-    /// Worn resting raw register value the anchor pins (reporter's steady worn baseline, ~826).
+    /// Worn resting raw register value the GLOBAL anchor pins (first reporter's steady worn baseline, ~826).
+    /// Used as the fallback anchor when a device has too few in-band samples to learn its own (#938).
     public static let anchorRaw: Double = 826.0
     /// Physiological nocturnal wrist skin temperature the anchor raw maps to (°C).
     public static let anchorCelsius: Double = 33.0
     /// PROVISIONAL °C-per-raw-unit slope. TODO(#938): replace with the two-point anchor slope.
     public static let provisionalSlopeCPerRaw: Double = 0.05
+
+    // ── Per-device worn anchor (#938, second capture) ─────────────────────────────────────────────────
+    // The @72 skin-temp field is a raw ADC whose register OFFSET is per-device: two real 4.0 straps show the
+    // IDENTICAL no-contact floor (~509) and 11-bit saturation ceiling (2047), but DIFFERENT worn bands — the
+    // first strap ~760–865 (anchored anchorRaw=826), a second ~1100–1600 (nightly mean raw ~1290). Under the
+    // single global anchor the second strap maps to 47–72 °C, so 100% of its samples fail the 28–42 °C worn
+    // gate: kept=0, no nightly mean, no baseline, no skin-temp/illness signal. The floor and ceiling agree
+    // across devices; only the worn offset differs → the anchor must be learned per device from that device's
+    // own worn band. Safe because downstream use is deviation-from-own-baseline (skinTempDevC) and the skin
+    // baseline is re-folded from the same scan window's nightly means every run, so a constant per-run offset
+    // cancels in the deviation.
+
+    /// Lower raw bound of the plausible WORN band. Clear of the no-contact floor (~509–520 observed on two
+    /// devices); banking stops at removal, so floor-and-below values are doff transients, never worn skin —
+    /// excluding them keeps the learned anchor (a median of worn raws) from being dragged down. (#938)
+    public static let wornMinRaw: Int = 550
+    /// Upper raw bound of the plausible WORN band. Clear of the 11-bit register saturation (2047 observed
+    /// pegged during device charging/fault) — a pegged raw is not a worn reading, so it must not enter the
+    /// anchor median or the nightly mean. (#938)
+    public static let wornMaxRaw: Int = 2040
+    /// Minimum in-band samples before a per-device anchor is trusted. Below this, callers fall back to the
+    /// global reporter anchor (`anchorRaw`=826) so sparse-data behavior is byte-identical to today — a
+    /// handful of stray worn raws must not define a device's whole ADC offset. (#938)
+    public static let minAnchorSamples: Int = 100
+
+    /// Per-device worn anchor: median of the in-band raws across the caller's scan window, or nil when fewer
+    /// than `minAnchorSamples` in-band samples exist (caller falls back to `anchorRaw`). Median (not mean) so
+    /// doff/don transients and tails can't drag the anchor. (#938)
+    public static func deviceAnchorRaw(_ raws: [Int]) -> Double? {
+        let inBand = raws.filter { $0 >= wornMinRaw && $0 <= wornMaxRaw }.sorted()
+        if inBand.count < minAnchorSamples { return nil }
+        let n = inBand.count
+        return n % 2 == 1 ? Double(inBand[n / 2])
+            : Double(inBand[n / 2 - 1] + inBand[n / 2]) / 2.0
+    }
 }
 
 public struct RespSample: Equatable, Codable {

--- a/Packages/WhoopProtocol/Tests/WhoopProtocolTests/RegistryModelFamilyTests.swift
+++ b/Packages/WhoopProtocol/Tests/WhoopProtocolTests/RegistryModelFamilyTests.swift
@@ -1,0 +1,48 @@
+import XCTest
+@testable import WhoopProtocol
+
+/// Registry model-label → `DeviceFamily` resolution (#171). Mirrors the Android `RegistryModelFamilyTest`.
+///
+/// The device registry holds several historical spellings for the same hardware — the Add-Device
+/// wizard's bare "4.0" / "5.0 MG", the full picker labels ("WHOOP 4.0" / "WHOOP 5.0 / MG"), and the
+/// legacy seeded "my-whoop" row's bare "WHOOP". Call sites that compared ONE spelling silently missed
+/// the others (issue #171: wizard-paired 4.0 straps decoded on the 5/MG /100 scale, ~8 °C skin temps
+/// in the Deep Timeline). These tests pin the full label contract so a new spelling — or a regression
+/// back to a single-spelling comparison — fails loudly.
+final class RegistryModelFamilyTests: XCTestCase {
+
+    // MARK: - WHOOP 4.0 — every stored spelling must positively identify (the #171 fix)
+
+    func testWizardBare40LabelResolvesToWhoop4() {
+        XCTAssertEqual(DeviceFamily.forRegistryModel("4.0"), .whoop4)
+    }
+
+    func testFullPicker40LabelResolvesToWhoop4() {
+        XCTAssertEqual(DeviceFamily.forRegistryModel("WHOOP 4.0"), .whoop4)
+    }
+
+    // MARK: - WHOOP 5/MG — both spellings keep the /100 path
+
+    func testWizard5MgLabelResolvesToWhoop5() {
+        XCTAssertEqual(DeviceFamily.forRegistryModel("5.0 MG"), .whoop5)
+        // "WHOOP 5.0 MG" is a spelling no writer produces today (the picker writes
+        // "WHOOP 5.0 / MG"); it lands on the safe .whoop5 default, which happens to be correct.
+        XCTAssertEqual(DeviceFamily.forRegistryModel("WHOOP 5.0 MG"), .whoop5)
+        XCTAssertEqual(DeviceFamily.forRegistryModel("WHOOP 5.0 / MG"), .whoop5)
+    }
+
+    // MARK: - Legacy + unknowns — the prior .whoop5 fallback, unchanged
+
+    /// The seeded "my-whoop" row predates the wizard and was written identically for 4.0 and 5/MG
+    /// installs, so "WHOOP" carries no family information; it keeps the prior fallback.
+    func testLegacySeededWhoopLabelKeepsWhoop5Fallback() {
+        XCTAssertEqual(DeviceFamily.forRegistryModel("WHOOP"), .whoop5)
+    }
+
+    func testNilEmptyAndGarbageFallBackToWhoop5() {
+        XCTAssertEqual(DeviceFamily.forRegistryModel(nil), .whoop5)
+        XCTAssertEqual(DeviceFamily.forRegistryModel(""), .whoop5)
+        XCTAssertEqual(DeviceFamily.forRegistryModel("Oura Ring Gen3"), .whoop5)
+        XCTAssertEqual(DeviceFamily.forRegistryModel("garmin-hrm"), .whoop5)
+    }
+}

--- a/Packages/WhoopProtocol/Tests/WhoopProtocolTests/SkinTempConversionTests.swift
+++ b/Packages/WhoopProtocol/Tests/WhoopProtocolTests/SkinTempConversionTests.swift
@@ -58,4 +58,54 @@ final class SkinTempConversionTests: XCTestCase {
         XCTAssertGreaterThan(c, 28.0)
         XCTAssertLessThan(c, 42.0)
     }
+
+    // MARK: - per-device worn anchor (#938 second capture)
+    // The @72 ADC's register offset is per-device: a second real 4.0 strap shares the floor (~509) +
+    // saturation (2047) but a worn band ~1100–1600 (nightly mean raw ~1290). The anchor is learned from the
+    // device's OWN worn median so the worn band lands in range; the offset cancels in skinTempDevC.
+
+    /// Odd count: the anchor is the middle in-band raw.
+    func testDeviceAnchorRawIsMedianOfInBandRaws() throws {
+        let raws = Array(1250...1350) // 101 in-band values, median is the middle one (1300)
+        XCTAssertEqual(raws.count, 101)
+        XCTAssertEqual(try XCTUnwrap(Whoop4SkinTemp.deviceAnchorRaw(raws)), 1300.0, accuracy: 1e-9)
+    }
+
+    /// The no-contact floor (509) and 11-bit saturation (2047) are filtered out of the anchor median entirely.
+    func testDeviceAnchorRawExcludesFloorAndSaturation() throws {
+        let worn = Array(repeating: 1290, count: 100)                       // 100 real worn raws
+        let contaminated = worn + Array(repeating: 509, count: 40) + Array(repeating: 2047, count: 40)
+        // Only the 100 in-band 1290s survive the band filter → median 1290 (floor/ceiling never enter the sort).
+        XCTAssertEqual(try XCTUnwrap(Whoop4SkinTemp.deviceAnchorRaw(contaminated)), 1290.0, accuracy: 1e-9)
+    }
+
+    /// Fewer than `minAnchorSamples` in-band raws → nil, so the caller falls back to the global anchor.
+    func testDeviceAnchorRawNilBelowMinSamples() throws {
+        XCTAssertEqual(Whoop4SkinTemp.minAnchorSamples, 100)
+        XCTAssertNil(Whoop4SkinTemp.deviceAnchorRaw(Array(repeating: 1290, count: 99)))           // 99 < 100
+        XCTAssertEqual(try XCTUnwrap(Whoop4SkinTemp.deviceAnchorRaw(Array(repeating: 1290, count: 100))),
+                       1290.0, accuracy: 1e-9)                                                     // exactly 100
+    }
+
+    /// Even count: the anchor averages the two middle in-band raws.
+    func testDeviceAnchorRawEvenCountAveragesMiddleTwo() throws {
+        let raws = Array(1201...1300) // 100 values, middle two are 1250 and 1251
+        XCTAssertEqual(raws.count, 100)
+        XCTAssertEqual(try XCTUnwrap(Whoop4SkinTemp.deviceAnchorRaw(raws)), 1250.5, accuracy: 1e-9)
+    }
+
+    /// The learned per-device anchor raw maps to 33.0 °C, and +20 raw above it is +1.0 °C (slope 0.05); the
+    /// anchor is ignored on `.whoop5`.
+    func testWhoop4PerDeviceAnchorMapsToAnchorCelsius() {
+        XCTAssertEqual(skinTempCelsius(raw: 1290, family: .whoop4, anchorRaw: 1290.0), 33.0, accuracy: 1e-9)
+        XCTAssertEqual(skinTempCelsius(raw: 1310, family: .whoop4, anchorRaw: 1290.0), 34.0, accuracy: 1e-9)
+        XCTAssertEqual(skinTempCelsius(raw: 3400, family: .whoop5, anchorRaw: 1290.0), 34.0, accuracy: 1e-9)
+    }
+
+    /// Omitting `anchorRaw` uses the global `anchorRaw` (826) → byte-identical to the pre-per-device behaviour.
+    func testWhoop4DefaultAnchorIsGlobal826() {
+        XCTAssertEqual(skinTempCelsius(raw: 859, family: .whoop4, anchorRaw: Whoop4SkinTemp.anchorRaw),
+                       skinTempCelsius(raw: 859, family: .whoop4), accuracy: 1e-12)
+        XCTAssertEqual(skinTempCelsius(raw: 826, family: .whoop4), 33.0, accuracy: 1e-9)
+    }
 }

--- a/Strand/Data/IntelligenceEngine.swift
+++ b/Strand/Data/IntelligenceEngine.swift
@@ -1377,15 +1377,10 @@ final class IntelligenceEngine: ObservableObject {
     }
 
     /// The strap family that wrote `owner`'s skin-temp rows (#938), so the nightly funnel converts the raw
-    /// register on the right scale. The registry stores each device's model string; a positively-identified
-    /// WHOOP 4.0 maps to `.whoop4` (raw-ADC skin-temp map), and EVERYTHING else — a 5/MG, a non-WHOOP source
-    /// (Oura/Apple Watch/etc. whose imported skin temp is already °C, not a strap register), or an unknown
-    /// owner not in the snapshot — falls back to `.whoop5`, the prior /100 behaviour. So this only changes
-    /// the mapping for a device we KNOW is a 4.0, never risking a wrong scale on anything else.
+    /// register on the right scale. The model-label → family mapping (and the `.whoop5` fallback for
+    /// unknowns) lives in `DeviceFamily.forRegistryModel` (#171).
     nonisolated static func skinTempFamily(forOwner owner: String, devices: [PairedDevice]) -> DeviceFamily {
-        guard let model = devices.first(where: { $0.id == owner })?.model,
-              WhoopModel(rawValue: model) == .whoop4 else { return .whoop5 }
-        return .whoop4
+        DeviceFamily.forRegistryModel(devices.first(where: { $0.id == owner })?.model)
     }
 
     /// #137: re-score under-sampled manual workouts. A `manual` workout is scored from the live HR

--- a/Strand/Data/IntelligenceEngine.swift
+++ b/Strand/Data/IntelligenceEngine.swift
@@ -532,6 +532,18 @@ final class IntelligenceEngine: ObservableObject {
                 // registry knows each device's model; unknown/non-WHOOP owners fall back to `.whoop5` (the prior
                 // /100 behaviour), so this only changes the mapping for a device positively identified as a 4.0.
                 let skinFamily = Self.skinTempFamily(forOwner: owner, devices: regDevices)
+                // #938 (second capture): learn THIS device's worn skin-temp anchor raw ONCE, WINDOW-WIDE (the
+                // whole scan window's skin samples), not per-night. The @72 skin-temp ADC's register offset is
+                // per-device — a second real 4.0 strap shares the no-contact floor (~509) + 11-bit saturation
+                // (2047) but a worn band ~1100–1600 (nightly mean raw ~1290), which the global 826 anchor maps
+                // to 47–72 °C, so 100% of its worn samples fail the 28–42 °C gate (kept=0, no baseline, no
+                // signal). WINDOW-WIDE, not per-night: a per-night re-centre would subtract each night's own
+                // mean and ERASE the cross-night deviation the skinTempDevC signal exists to carry.
+                // Deterministic per run; SAFE because the skin baseline is re-folded from the SAME window's
+                // nightly means every run, so this constant offset cancels in the deviation. nil for a non-4.0
+                // owner (`.whoop5` ignores the anchor) or when <100 in-band samples exist → the conversion
+                // falls back to the global anchor (byte-identical to today).
+                let skinAnchorRaw = skinFamily == .whoop4 ? Whoop4SkinTemp.deviceAnchorRaw(skin.map { $0.raw }) : nil
                 // Wrist-wear events in the night window, paired into off-wrist [start, end) intervals for the
                 // off-wrist sleep backstop (#500). The HR-gap proxy in the stager is the always-on guard;
                 // these explicit intervals sharpen it under the FRACTIONAL rule (#504) , a session is dropped
@@ -625,6 +637,7 @@ final class IntelligenceEngine: ObservableObject {
                                                      dayGravity: dayGrav,
                                                      skinTemp: skin,
                                                      skinTempFamily: skinFamily,   // #938
+                                                     skinTempAnchorRaw: skinAnchorRaw,   // #938 second capture
                                                      spo2: spo2,                   // #93
                                                      profile: up, baselines: baselines1, maxHROverride: maxHR,
                                                      tzOffsetSeconds: tzOffset, wristOff: wristOff,

--- a/Strand/Data/Repository.swift
+++ b/Strand/Data/Repository.swift
@@ -1441,16 +1441,14 @@ final class Repository: ObservableObject {
     }
 
     /// Map each device id to the strap family that wrote its rows (#938), for the family-aware skin-temp
-    /// raw→°C conversion. Reads the registry ONCE; a device whose model is "WHOOP 4.0" maps to `.whoop4`,
-    /// and every other id — a 5/MG, a non-WHOOP import, or an id absent from the registry — maps to
-    /// `.whoop5` (the prior /100 behaviour), so only a KNOWN 4.0 changes scale. Best-effort: an unreadable
+    /// raw→°C conversion. Reads the registry ONCE; the model-label → family mapping (and the `.whoop5`
+    /// fallback for unknowns) lives in `DeviceFamily.forRegistryModel` (#171). Best-effort: an unreadable
     /// registry yields an empty map, so every caller falls back to `.whoop5`.
     private static func skinTempFamilies(store: WhoopStore, ids: [String]) -> [String: DeviceFamily] {
         let devices = (try? DeviceRegistryStore(dbQueue: store.registryWriter).all()) ?? []
         var out: [String: DeviceFamily] = [:]
         for id in ids {
-            let isW4 = devices.first(where: { $0.id == id }).map { WhoopModel(rawValue: $0.model) == .whoop4 } ?? false
-            out[id] = isW4 ? .whoop4 : .whoop5
+            out[id] = DeviceFamily.forRegistryModel(devices.first(where: { $0.id == id })?.model)
         }
         return out
     }

--- a/android/app/src/main/java/com/noop/analytics/AnalyticsEngine.kt
+++ b/android/app/src/main/java/com/noop/analytics/AnalyticsEngine.kt
@@ -10,6 +10,7 @@ import com.noop.data.RespSample
 import com.noop.data.RrInterval
 import com.noop.data.StepSample
 import com.noop.protocol.DeviceFamily
+import com.noop.protocol.Whoop4SkinTemp
 import com.noop.protocol.skinTempCelsius
 import org.json.JSONObject
 import java.time.Instant
@@ -169,6 +170,13 @@ object AnalyticsEngine {
         // Default WHOOP5 keeps every 5/MG + pure-function caller byte-identical; IntelligenceEngine passes
         // the day owner's real family.
         skinTempFamily: DeviceFamily = DeviceFamily.WHOOP5,
+        // Per-device WHOOP 4.0 worn anchor raw (#938 second capture): the raw that maps to 33.0 °C for THIS
+        // device. The @72 skin-temp ADC's register offset is per-device — a second real 4.0 strap shares the
+        // floor (~509) + saturation (2047) but has a worn band ~1100–1600, which the global 826 anchor maps
+        // to 47–72 °C, failing 100% of the worn gate. IntelligenceEngine learns it once per run from the
+        // owner's own worn median. null → the family-aware conversion uses the global Whoop4SkinTemp.ANCHOR_RAW,
+        // so every 5/MG + pure-function caller stays byte-identical (WHOOP5 ignores the anchor entirely).
+        skinTempAnchorRaw: Double? = null,
         // WHOOP 4.0 raw SpO2 PPG ADC samples (red/IR) for the night window (#93). The nightly red/IR
         // means over detected sleep are banked on the DailyMetric as RAW ADC — honest "the sensor
         // decoded" data, NOT a calibrated blood-oxygen % (that needs WHOOP's proprietary curve). Default
@@ -399,7 +407,7 @@ object AnalyticsEngine {
         // mean is harvested; IntelligenceEngine seeds the baseline from those means and re-derives the
         // deviation in pass 2 (mirrors avgHrv→recovery). Computed BEFORE Charge so the Charge skin-temp
         // penalty can read it. APPROXIMATE. (PR #85)
-        val nightlySkinTempC = wornNightlySkinTempC(matched, hr, skinTemp, skinTempFamily)
+        val nightlySkinTempC = wornNightlySkinTempC(matched, hr, skinTemp, skinTempFamily, skinTempAnchorRaw)
         val skinTempDevC: Double? = nightlySkinTempC?.let { v ->
             baselines.skinTemp?.takeIf { it.usable }?.let { round2(Baselines.deviation(v, it).delta) }
         }
@@ -650,8 +658,11 @@ object AnalyticsEngine {
         hr: List<HrSample>,
         skinTemp: List<SkinTempSample>,
         family: DeviceFamily = DeviceFamily.WHOOP5,
+        // Per-device WHOOP 4.0 worn anchor raw (#938); null → the global Whoop4SkinTemp.ANCHOR_RAW, keeping
+        // 5/MG + pure-function callers byte-identical. Threaded straight to the funnel's conversion.
+        anchorRaw: Double? = null,
         minSamples: Int = MIN_SKIN_TEMP_SAMPLES_INLINE,
-    ): Double? = skinTempFunnel(sessions, hr, skinTemp, family, minSamples).mean
+    ): Double? = skinTempFunnel(sessions, hr, skinTemp, family, anchorRaw, minSamples).mean
 
     /**
      * Nightly means of the WHOOP 4.0 raw SpO2 PPG channels (red/IR ADC) over the detected in-bed
@@ -727,6 +738,9 @@ object AnalyticsEngine {
         hr: List<HrSample>,
         skinTemp: List<SkinTempSample>,
         family: DeviceFamily = DeviceFamily.WHOOP5,
+        // Per-device WHOOP 4.0 worn anchor raw (#938 second capture); null → the global
+        // Whoop4SkinTemp.ANCHOR_RAW, so 5/MG + pure-function callers are byte-identical.
+        anchorRaw: Double? = null,
         minSamples: Int = MIN_SKIN_TEMP_SAMPLES_INLINE,
     ): SkinTempFunnelDiagnostic {
         val total = skinTemp.size
@@ -749,7 +763,18 @@ object AnalyticsEngine {
         for (t in skinTemp) {
             if (t.ts !in wornSeconds) { notWorn++; continue }
             if (sessions.none { t.ts in it.start..it.end }) { outOfWindow++; continue }
-            val c = skinTempCelsius(t.raw, family)   // #938: family-aware (5/MG=raw/100, 4.0=raw ADC map)
+            // WHOOP 4.0 ONLY (#938 second capture): drop raws outside the plausible worn ADC band BEFORE the
+            // anchor map. The no-contact floor (~509) and the 11-bit saturation ceiling (2047) are doff /
+            // charging transients, not worn skin — with a per-device anchor a floor or pegged raw could
+            // otherwise map into the 28–42 °C window and poison the mean. Attributed to the SAME `outOfRange`
+            // bucket the °C gate uses ("out of plausible range"), so the four drop buckets + kept still sum to
+            // totalSamples. WHOOP5 is untouched here → its centidegree path stays byte-identical.
+            if (family == DeviceFamily.WHOOP4 &&
+                t.raw !in Whoop4SkinTemp.WORN_MIN_RAW..Whoop4SkinTemp.WORN_MAX_RAW
+            ) { outOfRange++; continue }
+            // Per-device anchor (#938): null anchorRaw → the global Whoop4SkinTemp.ANCHOR_RAW (826), byte-
+            // identical to the pre-change conversion; WHOOP5 ignores the anchor.
+            val c = skinTempCelsius(t.raw, family, anchorRaw ?: Whoop4SkinTemp.ANCHOR_RAW)
             if (c < SKIN_TEMP_MIN_C || c > SKIN_TEMP_MAX_C) { outOfRange++; continue }
             sum += c
             kept++

--- a/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
+++ b/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
@@ -6,6 +6,7 @@ import com.noop.data.SleepSession
 import com.noop.data.WhoopRepository
 import com.noop.data.WorkoutRow
 import com.noop.protocol.DeviceFamily
+import com.noop.protocol.Whoop4SkinTemp
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
@@ -464,6 +465,22 @@ object IntelligenceEngine {
             val skinFamily = skinFamilyByOwner.getOrPut(owner) {
                 ownerSource?.skinTempFamily(owner) ?: DeviceFamily.WHOOP5
             }
+            // #938 (second capture): learn THIS device's worn skin-temp anchor raw ONCE, WINDOW-WIDE (the
+            // whole scan window's skin samples), not per-night. The @72 skin-temp ADC's register offset is
+            // per-device — a second real 4.0 strap shares the no-contact floor (~509) + 11-bit saturation
+            // (2047) but a worn band ~1100–1600 (nightly mean raw ~1290), which the global 826 anchor maps to
+            // 47–72 °C, so 100% of its worn samples fail the 28–42 °C gate (kept=0, no baseline, no signal).
+            // WINDOW-WIDE, not per-night: a per-night re-centre would subtract each night's own mean and ERASE
+            // the cross-night deviation the skinTempDevC signal exists to carry. Deterministic per run; SAFE
+            // because the skin baseline is re-folded from the SAME window's nightly means every run, so this
+            // constant offset cancels in the deviation. null for a non-4.0 owner (WHOOP5 ignores the anchor)
+            // or when <100 in-band samples exist → the conversion falls back to the global anchor (byte-
+            // identical to today). Computed here once per owner alongside the family resolution.
+            val skinAnchorRaw = if (skinFamily == DeviceFamily.WHOOP4) {
+                Whoop4SkinTemp.deviceAnchorRaw(skin.map { it.raw })
+            } else {
+                null
+            }
             // Wrist-wear events in the night window, paired into off-wrist [start, end) intervals for the
             // off-wrist sleep backstop (#500). The HR-gap proxy in the stager is the always-on guard;
             // these explicit intervals sharpen it under the FRACTIONAL rule (#504) , a session is dropped
@@ -519,6 +536,7 @@ object IntelligenceEngine {
                 dayGravity = dayGrav,
                 skinTemp = skin,
                 skinTempFamily = skinFamily,   // #938
+                skinTempAnchorRaw = skinAnchorRaw,   // #938 second capture: per-device worn anchor
                 spo2 = spo2,                   // #93
                 profile = profile,
                 baselines = baselines1,

--- a/android/app/src/main/java/com/noop/analytics/RegistryDayOwnerSource.kt
+++ b/android/app/src/main/java/com/noop/analytics/RegistryDayOwnerSource.kt
@@ -1,6 +1,5 @@
 package com.noop.analytics
 
-import com.noop.ble.WhoopModel
 import com.noop.data.DeviceRegistry
 import com.noop.data.DeviceStatus
 import com.noop.data.SourceKind
@@ -46,13 +45,11 @@ class RegistryDayOwnerSource(private val registry: DeviceRegistry) : Intelligenc
     // when they diverge, the #814/#799 spine symptom).
     override suspend fun activeWriteId(): String? = registry.activeDeviceId()
 
-    // #938: resolve the strap family that wrote [deviceId]'s rows from its registry model. A device whose
-    // model is "WHOOP 4.0" maps to WHOOP4 (raw-ADC skin-temp scale); everything else — a 5/MG, a non-WHOOP
-    // import whose skin temp is already °C, or an id absent from the registry — falls back to WHOOP5 (the
-    // prior /100 behaviour). Mirrors the Swift IntelligenceEngine.skinTempFamily(forOwner:devices:).
+    // #938: resolve the strap family that wrote [deviceId]'s rows from its registry model. The model-label
+    // → family mapping (and the WHOOP5 fallback for unknowns) lives in DeviceFamily.forRegistryModel (#171).
+    // Mirrors the Swift IntelligenceEngine.skinTempFamily(forOwner:devices:).
     override suspend fun skinTempFamily(deviceId: String): DeviceFamily {
         val model = registry.all().firstOrNull { it.id == deviceId }?.model
-        return if (WhoopModel.entries.firstOrNull { it.displayName == model } == WhoopModel.WHOOP4)
-            DeviceFamily.WHOOP4 else DeviceFamily.WHOOP5
+        return DeviceFamily.forRegistryModel(model)
     }
 }

--- a/android/app/src/main/java/com/noop/protocol/DeviceFamily.kt
+++ b/android/app/src/main/java/com/noop/protocol/DeviceFamily.kt
@@ -80,6 +80,26 @@ enum class DeviceFamily {
         }
 
     companion object {
+        /**
+         * Resolve a device-registry `model` label to the strap family that wrote its rows (#171).
+         *
+         * The registry holds several historical spellings for the same hardware: the Add-Device
+         * wizard stores bare "4.0" / "5.0 MG", other paths match the full picker labels
+         * ("WHOOP 4.0" / "WHOOP 5.0 / MG"), and the legacy seeded "my-whoop" row stores just
+         * "WHOOP". Matching any single spelling silently misses the others (#171), so this is
+         * the ONE place allowed to interpret registry model labels.
+         *
+         * "WHOOP" predates the wizard and was written identically for 4.0 and 5/MG installs, so
+         * it carries no family information; it keeps the prior WHOOP5 fallback, as do
+         * null/unknown labels (non-WHOOP imports whose skin temp is already °C) — only a
+         * positively-identified 4.0 changes scale (#938). Mirrors the Swift
+         * `DeviceFamily.forRegistryModel`.
+         */
+        fun forRegistryModel(model: String?): DeviceFamily = when (model) {
+            "4.0", "WHOOP 4.0" -> WHOOP4
+            else -> WHOOP5
+        }
+
         /** Whoop 5.0 CLIENT_HELLO bytes (16 bytes). Exposed as a named constant for test/debug use. */
         val WHOOP5_CLIENT_HELLO: ByteArray = byteArrayOf(
             0xAA.toByte(), 0x01, 0x08, 0x00, 0x00, 0x01, 0xE6.toByte(), 0x71,

--- a/android/app/src/main/java/com/noop/protocol/Streams.kt
+++ b/android/app/src/main/java/com/noop/protocol/Streams.kt
@@ -51,7 +51,8 @@ data class SkinTempSample(val ts: Int, val raw: Int, val unit: String = "raw_adc
  * `Whoop4SkinTemp`.
  */
 object Whoop4SkinTemp {
-    /** Worn resting raw register value the anchor pins (reporter's steady worn baseline, ~826). */
+    /** Worn resting raw register value the GLOBAL anchor pins (first reporter's steady worn baseline, ~826).
+     *  Used as the fallback anchor when a device has too few in-band samples to learn its own (#938). */
     const val ANCHOR_RAW: Double = 826.0
 
     /** Physiological nocturnal wrist skin temperature the anchor raw maps to (°C). */
@@ -59,6 +60,43 @@ object Whoop4SkinTemp {
 
     /** PROVISIONAL °C-per-raw-unit slope. TODO(#938): replace with the two-point anchor slope. */
     const val PROVISIONAL_SLOPE_C_PER_RAW: Double = 0.05
+
+    // ── Per-device worn anchor (#938, second capture) ───────────────────────────────────────────────
+    // The @72 skin-temp field is a raw ADC whose register OFFSET is per-device: two real 4.0 straps show
+    // the IDENTICAL no-contact floor (~509) and 11-bit saturation ceiling (2047), but DIFFERENT worn
+    // bands — the first strap ~760–865 (anchored ANCHOR_RAW=826), a second ~1100–1600 (nightly mean raw
+    // ~1290). Under the single global anchor the second strap maps to 47–72 °C, so 100% of its samples
+    // fail the 28–42 °C worn gate: kept=0, no nightly mean, no baseline, no skin-temp/illness signal. The
+    // floor and ceiling agree across devices; only the worn offset differs → the anchor must be learned
+    // per device from that device's own worn band. Safe because downstream use is deviation-from-own-
+    // baseline (skinTempDevC) and the skin baseline is re-folded from the same scan window's nightly means
+    // on every run, so a constant per-run offset cancels in the deviation.
+
+    /** Lower raw bound of the plausible WORN band. Clear of the no-contact floor (~509–520 observed on
+     *  two devices); banking stops at removal, so floor-and-below values are doff transients, never worn
+     *  skin — excluding them keeps the learned anchor (a median of worn raws) from being dragged down. (#938) */
+    const val WORN_MIN_RAW: Int = 550
+
+    /** Upper raw bound of the plausible WORN band. Clear of the 11-bit register saturation (2047 observed
+     *  pegged during device charging/fault) — a pegged raw is not a worn reading, so it must not enter the
+     *  anchor median or the nightly mean. (#938) */
+    const val WORN_MAX_RAW: Int = 2040
+
+    /** Minimum in-band samples before a per-device anchor is trusted. Below this, callers fall back to the
+     *  global reporter anchor ([ANCHOR_RAW]=826) so sparse-data behavior is byte-identical to today — a
+     *  handful of stray worn raws must not define a device's whole ADC offset. (#938) */
+    const val MIN_ANCHOR_SAMPLES: Int = 100
+
+    /** Per-device worn anchor: median of the in-band raws across the caller's scan window, or null
+     *  when fewer than [MIN_ANCHOR_SAMPLES] in-band samples exist (caller falls back to [ANCHOR_RAW]).
+     *  Median (not mean) so doff/don transients and tails can't drag the anchor. (#938) */
+    fun deviceAnchorRaw(raws: List<Int>): Double? {
+        val inBand = raws.filter { it in WORN_MIN_RAW..WORN_MAX_RAW }.sorted()
+        if (inBand.size < MIN_ANCHOR_SAMPLES) return null
+        val n = inBand.size
+        return if (n % 2 == 1) inBand[n / 2].toDouble()
+        else (inBand[n / 2 - 1] + inBand[n / 2]) / 2.0
+    }
 }
 
 /**
@@ -78,21 +116,34 @@ object Whoop4SkinTemp {
  *   reporter's doff/don capture gives a steady worn resting value of raw ~826 (worn steady ~830–865; a
  *   no-contact floor ~510–520 at removal, then banking stops). Under `/100` that reads ~8.3 °C — impossible
  *   for a wrist streaming a resting HR (~52 bpm). We anchor the worn value at a defensible nocturnal wrist
- *   skin temperature (33.0 °C ↔ raw 826) and carry a PROVISIONAL slope until a second calibration point
- *   exists. Because downstream use is a deviation from the user's OWN nightly baseline (skinTempDevC), the
- *   offset is what must be right to clear the absolute 28–42 °C worn gate + 20–42 °C baseline clamp; a slope
- *   error only rescales the deviation and stays directionally correct. All 4.0 values APPROXIMATE.
+ *   skin temperature (33.0 °C ↔ the worn anchor raw) and carry a PROVISIONAL slope until a second
+ *   calibration point exists. Because downstream use is a deviation from the user's OWN nightly baseline
+ *   (skinTempDevC), the offset is what must be right to clear the absolute 28–42 °C worn gate + 20–42 °C
+ *   baseline clamp; a slope error only rescales the deviation and stays directionally correct. All 4.0
+ *   values APPROXIMATE.
+ *
+ *   PER-DEVICE ANCHOR (#938 second capture): [anchorRaw] is the raw that maps to 33.0 °C. It defaults to the
+ *   global [Whoop4SkinTemp.ANCHOR_RAW] (826, first reporter's strap) so every existing caller is byte-
+ *   identical, but the register OFFSET is per-device — a second real 4.0 strap shows the SAME floor (~509)
+ *   and saturation (2047) yet a worn band of ~1100–1600 (nightly mean raw ~1290), which the global 826
+ *   anchor maps to 47–72 °C (all samples fail the worn gate). The analytics caller therefore learns
+ *   [anchorRaw] from the device's OWN worn median ([Whoop4SkinTemp.deviceAnchorRaw]) so the worn band lands
+ *   in range; the constant offset cancels in the deviation-from-own-baseline the app consumes.
  *
  *   TODO(#938): replace the provisional slope with the exact two-point anchor once a second worn point at a
  *   markedly different ambient pins the ADC→°C transfer (including whether it is linear). Until then this is
  *   a defensible worn-range mapping, NOT a claimed-accurate absolute thermometer. Kept in lockstep with the
- *   Swift `skinTempCelsius(raw:family:)`.
+ *   Swift `skinTempCelsius(raw:family:anchorRaw:)`.
  */
-fun skinTempCelsius(raw: Int, family: DeviceFamily): Double = when (family) {
+fun skinTempCelsius(
+    raw: Int,
+    family: DeviceFamily,
+    anchorRaw: Double = Whoop4SkinTemp.ANCHOR_RAW,
+): Double = when (family) {
     DeviceFamily.WHOOP5 -> raw / 100.0
     DeviceFamily.WHOOP4 ->
         Whoop4SkinTemp.ANCHOR_CELSIUS +
-            (raw - Whoop4SkinTemp.ANCHOR_RAW) * Whoop4SkinTemp.PROVISIONAL_SLOPE_C_PER_RAW
+            (raw - anchorRaw) * Whoop4SkinTemp.PROVISIONAL_SLOPE_C_PER_RAW
 }
 
 /**

--- a/android/app/src/main/java/com/noop/ui/FullDayChartScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/FullDayChartScreen.kt
@@ -27,7 +27,6 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import com.noop.analytics.HrvAnalyzer
-import com.noop.ble.WhoopModel
 import com.noop.protocol.DeviceFamily
 import com.noop.protocol.skinTempCelsius
 import kotlinx.coroutines.Dispatchers
@@ -353,12 +352,11 @@ private suspend fun readTimeline(
                 .mapNotNull { if (it.ir > 0) TimelinePoint(it.ts, it.red.toDouble() / it.ir) else null }
         TimelineMetric.SkinTemp -> {
             // #938: family-aware raw→°C — 5/MG centidegrees (raw/100, #156), a WHOOP 4.0 v24 raw ADC map.
-            // Resolve the strap family from [deviceId]'s registry model; a positively-identified 4.0 → WHOOP4,
-            // everything else → WHOOP5 (the prior /100 behaviour). Mirrors Swift Repository.timelineRawMetric.
+            // The registry-model-label → family mapping lives in DeviceFamily.forRegistryModel (#171).
+            // Mirrors Swift Repository.timelineRawMetric.
             val model = runCatching { vm.pairedDevices() }.getOrDefault(emptyList())
                 .firstOrNull { it.id == deviceId }?.model
-            val family = if (WhoopModel.entries.firstOrNull { it.displayName == model } == WhoopModel.WHOOP4)
-                DeviceFamily.WHOOP4 else DeviceFamily.WHOOP5
+            val family = DeviceFamily.forRegistryModel(model)
             runCatching { repo.skinTempSamples(deviceId, from, to, 200_000) }.getOrDefault(emptyList())
                 .map { TimelinePoint(it.ts, skinTempCelsius(it.raw, family)) }
         }

--- a/android/app/src/test/java/com/noop/analytics/SkinTempAnalyticsTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/SkinTempAnalyticsTest.kt
@@ -3,6 +3,7 @@ package com.noop.analytics
 import com.noop.data.HrSample
 import com.noop.data.SkinTempSample
 import com.noop.protocol.DeviceFamily
+import com.noop.protocol.Whoop4SkinTemp
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
@@ -221,6 +222,97 @@ class SkinTempAnalyticsTest {
         val w4 = AnalyticsEngine.skinTempFunnel(sess, hrs, temps, DeviceFamily.WHOOP4)
         assertEquals(600, w4.kept)
         assertFalse(w4.isAbsent)
+    }
+
+    // ── per-device worn anchor, end-to-end (#938 second capture) ─────────────
+
+    /** A second real 4.0 strap: worn raws ~1250–1330 (nightly mean raw ~1290). Under the GLOBAL 826 anchor
+     *  those map to ~54–58 °C, all failing the 28–42 °C worn gate (kept=0, no mean). With the device's OWN
+     *  learned anchor the worn band lands ~33 °C and the night is kept. Mirrors Swift
+     *  testHighRegisterDeviceKeptWithLearnedAnchor. */
+    @Test
+    fun highRegisterDeviceKeptWithLearnedAnchor() {
+        val start = 20_000_000L
+        val sess = listOf(session(start, 600))
+        val hrs = (0 until 600).map { hr(start + it) }
+        // 600 worn samples sweeping raw 1250..1329 (nightly mean ~1290), a whole session inside worn seconds.
+        val temps = (0 until 600).map { skin(start + it, 1250 + (it % 80)) }
+        val anchor = Whoop4SkinTemp.deviceAnchorRaw(temps.map { it.raw })!!
+        // GLOBAL anchor (null → 826): every worn raw maps to ~54–58 °C, all out of range → absent.
+        assertNull(AnalyticsEngine.wornNightlySkinTempC(sess, hrs, temps, DeviceFamily.WHOOP4, null))
+        // LEARNED anchor: kept, and the mean sits in the plausible worn band ≈ 33 °C.
+        val mean = AnalyticsEngine.wornNightlySkinTempC(sess, hrs, temps, DeviceFamily.WHOOP4, anchor)!!
+        assertTrue("worn high-register 4.0 night must clear the 28 °C gate, was $mean", mean > 28.0)
+        assertTrue("worn high-register 4.0 night must stay under 42 °C, was $mean", mean < 42.0)
+        assertEquals("mean sits near the anchor's 33.0 °C", 33.0, mean, 1.5)
+    }
+
+    /** Two nights whose raw means differ by +20, converted with the SAME window-wide anchor → nightly °C
+     *  means differ by exactly +1.0 (20 × 0.05 slope). This is WHY the anchor is window-wide, not per-night:
+     *  the shared constant offset cancels, leaving the true cross-night deviation intact. Mirrors Swift
+     *  testDeviationPreservedAcrossNightsWithSameAnchor. */
+    @Test
+    fun deviationPreservedAcrossNightsWithSameAnchor() {
+        val anchor = 1290.0
+        fun nightMean(startTs: Long, raw: Int): Double {
+            val sess = listOf(session(startTs, 600))
+            val hrs = (0 until 600).map { hr(startTs + it) }
+            val temps = (0 until 600).map { skin(startTs + it, raw) }
+            return AnalyticsEngine.wornNightlySkinTempC(sess, hrs, temps, DeviceFamily.WHOOP4, anchor)!!
+        }
+        val n1 = nightMean(21_000_000L, 1290)
+        val n2 = nightMean(22_000_000L, 1310) // +20 raw
+        assertEquals(1.0, n2 - n1, 1e-9)
+    }
+
+    /** Byte-compat: WHOOP4 with anchorRaw=null and reporter-band raws (~826) produces the IDENTICAL mean as
+     *  the explicit global anchor (ANCHOR_RAW=826) — the pre-per-device behaviour. Mirrors Swift
+     *  testWhoop4NullAnchorByteIdenticalToGlobal. */
+    @Test
+    fun whoop4NullAnchorByteIdenticalToGlobal() {
+        val start = 23_000_000L
+        val sess = listOf(session(start, 600))
+        val hrs = (0 until 600).map { hr(start + it) }
+        val temps = (0 until 600).map { skin(start + it, 826) }
+        val nullAnchor = AnalyticsEngine.wornNightlySkinTempC(sess, hrs, temps, DeviceFamily.WHOOP4, null)!!
+        val explicitGlobal =
+            AnalyticsEngine.wornNightlySkinTempC(sess, hrs, temps, DeviceFamily.WHOOP4, Whoop4SkinTemp.ANCHOR_RAW)!!
+        assertEquals(33.0, nullAnchor, 1e-9) // raw 826 → exactly the 33.0 °C anchor
+        assertEquals(explicitGlobal, nullAnchor, 1e-12)
+    }
+
+    /** WHOOP5 is unchanged by the anchor parameter: a centidegree night is byte-identical with or without one.
+     *  Mirrors Swift testWhoop5IgnoresAnchor. */
+    @Test
+    fun whoop5IgnoresAnchor() {
+        val start = 24_000_000L
+        val sess = listOf(session(start, 600))
+        val hrs = (0 until 600).map { hr(start + it) }
+        val temps = (0 until 600).map { skin(start + it, 3400) } // 34 °C centidegrees
+        val noAnchor = AnalyticsEngine.wornNightlySkinTempC(sess, hrs, temps, DeviceFamily.WHOOP5, null)!!
+        val withAnchor = AnalyticsEngine.wornNightlySkinTempC(sess, hrs, temps, DeviceFamily.WHOOP5, 1290.0)!!
+        assertEquals(34.0, noAnchor, 1e-9)
+        assertEquals(noAnchor, withAnchor, 1e-12)
+    }
+
+    /** Doff-floor (509) and pegged-saturation (2047) samples on a WHOOP4 night count as outOfRange (dropped
+     *  BEFORE the anchor map) and the four buckets + kept still sum to totalSamples. Mirrors Swift
+     *  testWhoop4FloorAndSaturationCountAsOutOfRange. */
+    @Test
+    fun whoop4FloorAndSaturationCountAsOutOfRangeAndBucketsSum() {
+        val start = 25_000_000L
+        val sess = listOf(session(start, 900))
+        val hrs = (0 until 900).map { hr(start + it) }
+        val worn = (0 until 600).map { skin(start + it, 1290) }        // in-band worn
+        val floor = (600 until 750).map { skin(start + it, 509) }      // no-contact floor
+        val pegged = (750 until 900).map { skin(start + it, 2047) }    // 11-bit saturation
+        val temps = worn + floor + pegged
+        val anchor = Whoop4SkinTemp.deviceAnchorRaw(temps.map { it.raw })!! // learned from the 600 in-band raws
+        val f = AnalyticsEngine.skinTempFunnel(sess, hrs, temps, DeviceFamily.WHOOP4, anchor)
+        assertEquals(900, f.totalSamples)
+        assertEquals(300, f.droppedOutOfRange) // 150 floor + 150 saturation, out of the plausible worn ADC band
+        assertEquals(600, f.kept)
+        assertEquals(f.totalSamples, f.droppedNotWorn + f.droppedOutOfWindow + f.droppedOutOfRange + f.kept)
     }
 
     // ── seed → deviation (skin_temp baseline) ───────────────────────────────

--- a/android/app/src/test/java/com/noop/protocol/RegistryModelFamilyTest.kt
+++ b/android/app/src/test/java/com/noop/protocol/RegistryModelFamilyTest.kt
@@ -1,0 +1,57 @@
+package com.noop.protocol
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Registry model-label → [DeviceFamily] resolution (#171). Mirrors the macOS `RegistryModelFamilyTests`.
+ *
+ * The device registry holds several historical spellings for the same hardware — the Add-Device
+ * wizard's bare "4.0" / "5.0 MG", the full picker labels ("WHOOP 4.0" / "WHOOP 5.0 / MG"), and the
+ * legacy seeded "my-whoop" row's bare "WHOOP". Call sites that compared ONE spelling silently missed
+ * the others (issue #171: wizard-paired 4.0 straps decoded on the 5/MG /100 scale, ~8 °C skin temps
+ * in the Deep Timeline). These tests pin the full label contract so a new spelling — or a regression
+ * back to a single-spelling comparison — fails loudly.
+ */
+class RegistryModelFamilyTest {
+
+    // ── WHOOP 4.0 — every stored spelling must positively identify (the #171 fix) ──
+
+    @Test
+    fun wizardBare40LabelResolvesToWhoop4() {
+        assertEquals(DeviceFamily.WHOOP4, DeviceFamily.forRegistryModel("4.0"))
+    }
+
+    @Test
+    fun fullPicker40LabelResolvesToWhoop4() {
+        assertEquals(DeviceFamily.WHOOP4, DeviceFamily.forRegistryModel("WHOOP 4.0"))
+    }
+
+    // ── WHOOP 5/MG — both spellings keep the /100 path ──────────────────────
+
+    @Test
+    fun wizard5MgLabelResolvesToWhoop5() {
+        assertEquals(DeviceFamily.WHOOP5, DeviceFamily.forRegistryModel("5.0 MG"))
+        // "WHOOP 5.0 MG" is a spelling no writer produces today (the picker writes
+        // "WHOOP 5.0 / MG"); it lands on the safe WHOOP5 default, which happens to be correct.
+        assertEquals(DeviceFamily.WHOOP5, DeviceFamily.forRegistryModel("WHOOP 5.0 MG"))
+        assertEquals(DeviceFamily.WHOOP5, DeviceFamily.forRegistryModel("WHOOP 5.0 / MG"))
+    }
+
+    // ── Legacy + unknowns — the prior WHOOP5 fallback, unchanged ────────────
+
+    @Test
+    fun legacySeededWhoopLabelKeepsWhoop5Fallback() {
+        // The seeded "my-whoop" row predates the wizard and was written identically for 4.0 and
+        // 5/MG installs, so "WHOOP" carries no family information; it keeps the prior fallback.
+        assertEquals(DeviceFamily.WHOOP5, DeviceFamily.forRegistryModel("WHOOP"))
+    }
+
+    @Test
+    fun nullEmptyAndGarbageFallBackToWhoop5() {
+        assertEquals(DeviceFamily.WHOOP5, DeviceFamily.forRegistryModel(null))
+        assertEquals(DeviceFamily.WHOOP5, DeviceFamily.forRegistryModel(""))
+        assertEquals(DeviceFamily.WHOOP5, DeviceFamily.forRegistryModel("Oura Ring Gen3"))
+        assertEquals(DeviceFamily.WHOOP5, DeviceFamily.forRegistryModel("garmin-hrm"))
+    }
+}

--- a/android/app/src/test/java/com/noop/protocol/SkinTempConversionTest.kt
+++ b/android/app/src/test/java/com/noop/protocol/SkinTempConversionTest.kt
@@ -2,6 +2,7 @@ package com.noop.protocol
 
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -58,5 +59,67 @@ class SkinTempConversionTest {
         val c = skinTempCelsius(900, DeviceFamily.WHOOP4)
         assertTrue(c > 28.0)
         assertTrue(c < 42.0)
+    }
+
+    // ── per-device worn anchor (#938 second capture) ────────────────────────
+    // The @72 ADC's register offset is per-device: a second real 4.0 strap shares the floor (~509) +
+    // saturation (2047) but a worn band ~1100–1600 (nightly mean raw ~1290). The anchor is learned from the
+    // device's OWN worn median so the worn band lands in range; the offset cancels in skinTempDevC.
+
+    /** Odd count: the anchor is the middle in-band raw. Mirrors Swift testDeviceAnchorRawIsMedianOfInBandRaws. */
+    @Test
+    fun deviceAnchorRawIsMedianOfInBandRaws() {
+        val raws = (1250..1350).toList() // 101 in-band values, median is the middle one (1300)
+        assertEquals(101, raws.size)
+        assertEquals(1300.0, Whoop4SkinTemp.deviceAnchorRaw(raws)!!, 1e-9)
+    }
+
+    /** The no-contact floor (509) and 11-bit saturation ceiling (2047) are filtered out of the anchor median
+     *  entirely. Mirrors Swift testDeviceAnchorRawExcludesFloorAndSaturation. */
+    @Test
+    fun deviceAnchorRawExcludesFloorAndSaturation() {
+        val worn = List(100) { 1290 }                          // 100 real worn raws
+        val contaminated = worn + List(40) { 509 } + List(40) { 2047 } // doff floor + pegged saturation
+        // Only the 100 in-band 1290s survive the band filter → median 1290 (floor/ceiling never enter the sort).
+        assertEquals(1290.0, Whoop4SkinTemp.deviceAnchorRaw(contaminated)!!, 1e-9)
+    }
+
+    /** Fewer than MIN_ANCHOR_SAMPLES in-band raws → null, so the caller falls back to the global anchor
+     *  (byte-identical to today). Mirrors Swift testDeviceAnchorRawNilBelowMinSamples. */
+    @Test
+    fun deviceAnchorRawNullBelowMinSamples() {
+        assertEquals(100, Whoop4SkinTemp.MIN_ANCHOR_SAMPLES)
+        assertNull(Whoop4SkinTemp.deviceAnchorRaw(List(99) { 1290 }))            // 99 < 100 → null
+        assertEquals(1290.0, Whoop4SkinTemp.deviceAnchorRaw(List(100) { 1290 })!!, 1e-9) // exactly 100 → learned
+    }
+
+    /** Even count: the anchor averages the two middle in-band raws. Mirrors Swift
+     *  testDeviceAnchorRawEvenCountAveragesMiddleTwo. */
+    @Test
+    fun deviceAnchorRawEvenCountAveragesMiddleTwo() {
+        val raws = (1201..1300).toList() // 100 values, middle two are 1250 and 1251
+        assertEquals(100, raws.size)
+        assertEquals(1250.5, Whoop4SkinTemp.deviceAnchorRaw(raws)!!, 1e-9)
+    }
+
+    /** The learned per-device anchor raw maps to 33.0 °C, and +20 raw above it is +1.0 °C (slope 0.05); the
+     *  anchor is ignored on WHOOP5. Mirrors Swift testWhoop4PerDeviceAnchorMapsToAnchorCelsius. */
+    @Test
+    fun whoop4PerDeviceAnchorMapsToAnchorCelsius() {
+        assertEquals(33.0, skinTempCelsius(1290, DeviceFamily.WHOOP4, 1290.0), 1e-9)
+        assertEquals(34.0, skinTempCelsius(1310, DeviceFamily.WHOOP4, 1290.0), 1e-9) // +20 raw = +1.0 °C
+        assertEquals(34.0, skinTempCelsius(3400, DeviceFamily.WHOOP5, 1290.0), 1e-9) // WHOOP5 ignores the anchor
+    }
+
+    /** Omitting anchorRaw uses the global ANCHOR_RAW (826) → byte-identical to the pre-per-device behaviour.
+     *  Mirrors Swift testWhoop4DefaultAnchorIsGlobal826. */
+    @Test
+    fun whoop4DefaultAnchorIsGlobal826() {
+        assertEquals(
+            skinTempCelsius(859, DeviceFamily.WHOOP4, Whoop4SkinTemp.ANCHOR_RAW),
+            skinTempCelsius(859, DeviceFamily.WHOOP4),
+            1e-12,
+        )
+        assertEquals(33.0, skinTempCelsius(826, DeviceFamily.WHOOP4), 1e-9)
     }
 }


### PR DESCRIPTION
## What this PR does

Follow-up to #171. The 5/MG decode still assumed every WHOOP 4.0 maps **raw 826 → 0 °C skin-temp deviation**. That anchor is a per-device factory ADC offset, not a protocol constant — on straps whose anchor sits elsewhere, every night reported a constant false deviation, and once it fell outside the plausibility gate the nightly funnel dropped the metric entirely ("needs a track night" forever).

Fix: learn the anchor per device (median of in-band raw samples across worn nights), fall back to the global 826 until enough nights accumulate, and recompute stored nights against the learned anchor so history backfills retroactively from raw samples already on device. Kotlin + Swift kept as exact twins.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] CI / tooling

## How it was tested

Real hardware: **WHOOP 4.0** paired to a OnePlus 8T running the staging build. After install, the recompute pass backfilled `skinTempDevC` for the full prior week from stored raw samples, and the nightly funnel stopped dropping the metric. Leaving as draft while the learned anchor converges over a few more worn nights.

Tests covering the change:
- `SkinTempConversionTests` (`Packages/WhoopProtocol`) — anchor learning + fallback on the raw decode path
- `SkinTempAnalyticsTests` (`Packages/StrandAnalytics`) — deviation/backfill analytics
- Kotlin twins: `SkinTempConversionTest`, `SkinTempAnalyticsTest` (`android/`)

## Checklist

- [x] Swift package tests pass for any package I touched (`swift test` in `Packages/<name>`)
- [x] Android unit tests pass if I touched `android/` (`./gradlew testFullDebugUnitTest`)
- [x] No new build warnings introduced
- [x] UI changes use only `StrandDesign` tokens — no hardcoded colors, fonts, or spacing (no UI changes in this PR)
- [x] No hardcoded hex frame bytes; protocol facts live in the schema / decoders
- [x] Follows the conventions in [`docs/CONTRIBUTING.md`](../docs/CONTRIBUTING.md)
- [x] I did not commit generated output (`Strand.xcodeproj/`) or any secrets/keystores

## Related issues

Follow-up to #171 (wizard-paired WHOOP 4.0 5/MG scale decode).