### PR TITLE
test: regression coverage for #175 (resolvedSeries active strap id threading)

### DIFF
--- a/android/app/src/test/java/com/noop/data/ResolvedSeriesActiveStrapTest.kt
+++ b/android/app/src/test/java/com/noop/data/ResolvedSeriesActiveStrapTest.kt
@@ -1,0 +1,163 @@
+package com.noop.data
+
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.lang.reflect.Proxy
+
+/**
+ * #172 / #175 regression — resolvedSeries() must honour a caller-threaded ACTIVE strap id.
+ *
+ * After a strap remove+re-add the IntelligenceEngine banks computed scores under
+ * "<activeStrapId>-noop", not the canonical "my-whoop-noop". resolvedSeries() defaults
+ * strapDeviceId to the canonical "my-whoop", and before #175 no UI caller overrode it, so
+ * [WhoopRepository.sourceCandidates] probed only the canonical pair: the Today Rest ring fell
+ * back to "Calibrating — needs a tracked night" and the Key Metrics Rest card showed no data
+ * while the Sleep tab (already on the #814 union spine) showed fully scored nights.
+ *
+ * These tests pin the BEHAVIOUR either side of that seam, complementing [ResolverUnionTest]
+ * (which pins the candidate LIST shape, #1008) and the call-site census in
+ * [com.noop.ui.ResolvedSeriesCallSiteAuditTest]:
+ *
+ *   • threading the active id resolves scores banked under its computed sibling (the #175 fix);
+ *   • the legacy canonical default MISSES those same scores (the #172 symptom, kept as a
+ *     documented failure shape so the default is never mistaken for re-add-safe);
+ *   • a single-strap install (active == canonical) resolves byte-identically threaded or not;
+ *   • the #1008 union still holds through the threaded read: active wins its day, canonical
+ *     fills the days banked before the re-add.
+ *
+ * Driven through a Proxy-stub [WhoopDao] (no Room): the resolver only touches metricSeries +
+ * dailyMetricsRange, answered from a fixture list; everything else throws.
+ */
+class ResolvedSeriesActiveStrapTest {
+
+    private val canonical = "my-whoop"
+    private val reAdded = "whoop-ABC123" // the id a re-added strap gets (whoop-<uuid>)
+
+    // The wide-open window every Today/Trends caller passes.
+    private val from = "0000-00-00"
+    private val to = "9999-99-99"
+
+    /** Build a repository whose metricSeries answers from [rows] (filtered like the real query:
+     *  by deviceId + key + day window, ascending) and whose dailyMetricsRange is empty. Every
+     *  other dao call throws, proof the resolver reached past its contract. */
+    private fun repo(rows: List<MetricSeriesRow>): WhoopRepository {
+        val dao = Proxy.newProxyInstance(
+            WhoopDao::class.java.classLoader,
+            arrayOf(WhoopDao::class.java),
+        ) { _, method, args ->
+            when (method.name) {
+                "metricSeries" -> {
+                    val a = args!!
+                    val deviceId = a[0] as String
+                    val key = a[1] as String
+                    val lo = a[2] as String
+                    val hi = a[3] as String
+                    rows.filter { it.deviceId == deviceId && it.key == key && it.day >= lo && it.day <= hi }
+                        .sortedBy { it.day }
+                }
+                "dailyMetricsRange" -> emptyList<DailyMetric>()
+                else -> throw UnsupportedOperationException("resolver must not call ${method.name}")
+            }
+        } as WhoopDao
+        return WhoopRepository(dao)
+    }
+
+    private fun row(source: String, day: String, value: Double) =
+        MetricSeriesRow(deviceId = source, day = day, key = "sleep_performance", value = value)
+
+    // --- the #175 fix: threading the active id reaches the re-added strap's banked scores ---
+
+    @Test
+    fun reAddedStrap_threadedActiveId_resolvesScoresBankedUnderItsComputedSibling() = runBlocking {
+        val repo = repo(
+            listOf(
+                row("$reAdded-noop", "2026-07-08", 91.0),
+                row("$reAdded-noop", "2026-07-09", 84.0),
+            ),
+        )
+
+        val resolved = repo.resolvedSeries(
+            "sleep_performance", canonical, from, to,
+            strapDeviceId = reAdded,
+        )
+
+        assertEquals(
+            listOf("2026-07-08" to 91.0, "2026-07-09" to 84.0),
+            resolved.values,
+        )
+        assertEquals(listOf("$reAdded-noop"), resolved.usedSources)
+    }
+
+    /** The #172 symptom, pinned: the legacy canonical DEFAULT cannot see scores banked under the
+     *  re-added strap's computed sibling — exactly why the Rest ring read "Calibrating" while the
+     *  Sleep tab showed scored nights. If this test ever starts passing, the default grew re-add
+     *  awareness and the eight #175 call-site overrides can be reconsidered. */
+    @Test
+    fun reAddedStrap_legacyCanonicalDefault_missesTheBankedScores() = runBlocking {
+        val repo = repo(
+            listOf(
+                row("$reAdded-noop", "2026-07-08", 91.0),
+                row("$reAdded-noop", "2026-07-09", 84.0),
+            ),
+        )
+
+        // No strapDeviceId: the pre-#175 caller shape.
+        val resolved = repo.resolvedSeries("sleep_performance", canonical, from, to)
+
+        assertTrue(
+            "canonical-default read must not see \"$reAdded-noop\" rows (got ${resolved.values})",
+            resolved.values.isEmpty(),
+        )
+    }
+
+    // --- the #175 "byte-identical" claim for single-strap installs ---
+
+    @Test
+    fun singleStrapInstall_threadedAndDefaultReadsAreIdentical() = runBlocking {
+        val repo = repo(
+            listOf(
+                row("$canonical-noop", "2026-07-08", 77.0),
+                row("$canonical-noop", "2026-07-09", 82.0),
+            ),
+        )
+
+        val threaded = repo.resolvedSeries(
+            "sleep_performance", canonical, from, to,
+            strapDeviceId = canonical, // activeStrapId resolves to the canonical id
+        )
+        val default = repo.resolvedSeries("sleep_performance", canonical, from, to)
+
+        assertEquals(default.candidates, threaded.candidates)
+        assertEquals(default.values, threaded.values)
+        assertEquals(listOf("2026-07-08" to 77.0, "2026-07-09" to 82.0), threaded.values)
+    }
+
+    // --- the #1008 union, exercised through the threaded read ---
+
+    @Test
+    fun threadedRead_activeWinsItsDay_canonicalFillsHistoryBankedBeforeReAdd() = runBlocking {
+        val repo = repo(
+            listOf(
+                // History banked under the canonical pair BEFORE the re-add…
+                row("$canonical-noop", "2026-07-01", 70.0),
+                row("$canonical-noop", "2026-07-08", 80.0),
+                // …and the re-added strap's own scored night for the 8th.
+                row("$reAdded-noop", "2026-07-08", 91.0),
+            ),
+        )
+
+        val resolved = repo.resolvedSeries(
+            "sleep_performance", canonical, from, to,
+            strapDeviceId = reAdded,
+        )
+
+        // Active pair wins the day it covers; canonical fills the pre-re-add day. Nothing dropped.
+        assertEquals(
+            listOf("2026-07-01" to 70.0, "2026-07-08" to 91.0),
+            resolved.values,
+        )
+        assertEquals(listOf("$canonical-noop", "$reAdded-noop"), resolved.usedSources.sorted())
+    }
+}

--- a/android/app/src/test/java/com/noop/ui/ResolvedSeriesCallSiteAuditTest.kt
+++ b/android/app/src/test/java/com/noop/ui/ResolvedSeriesCallSiteAuditTest.kt
@@ -1,0 +1,109 @@
+package com.noop.ui
+
+import org.junit.Assert.assertTrue
+import org.junit.Assume.assumeTrue
+import org.junit.Test
+import java.io.File
+
+/**
+ * #175 call-site census — every UI read through `repo.resolvedSeries(…)` must thread the
+ * registry's ACTIVE strap id.
+ *
+ * The #172 bug was not in the resolver: resolvedSeries() worked, but its `strapDeviceId`
+ * parameter defaulted to the canonical "my-whoop" and NO caller overrode it, so after a strap
+ * re-add every resolver-backed surface (Today Rest ring, Key Metrics Rest card, Trends,
+ * Health, Compare, Lab Book) silently read the wrong source pair. #175 fixed all eight call
+ * sites by passing `strapDeviceId = vm.activeStrapId` — a fix a new caller can quietly regress
+ * by leaning on the default again, which compiles fine and passes every behavioural test that
+ * doesn't simulate a re-add.
+ *
+ * So this test audits the SOURCE: it scans src/main/java/com/noop/ui for `resolvedSeries(`
+ * call sites (comments stripped) and fails on any call that doesn't name `strapDeviceId`.
+ * The behavioural halves live in [com.noop.data.ResolvedSeriesActiveStrapTest] (threaded vs
+ * default read) and [com.noop.data.ResolverUnionTest] (candidate-list shape, #1008).
+ * Follows the source-locating pattern of [GermanLocalizationTest].
+ */
+class ResolvedSeriesCallSiteAuditTest {
+
+    /** The UI source root, tolerant of the test host's working dir (module dir under Gradle,
+     *  repo root under some IDE runners). Skips (assume) when unlocatable rather than
+     *  green-washing the audit. */
+    private fun uiSourceDir(): File? {
+        val userDir = File(System.getProperty("user.dir") ?: ".")
+        return listOf(
+            File(userDir, "src/main/java/com/noop/ui"),
+            File(userDir, "app/src/main/java/com/noop/ui"),
+            File(userDir, "android/app/src/main/java/com/noop/ui"),
+        ).firstOrNull { it.isDirectory }
+    }
+
+    /** Source text with /* block */ and // line comments removed (KDoc headers in these files
+     *  mention resolvedSeries by name). `//` inside a string URL ("https://…") is preserved. */
+    private fun stripComments(source: String): String {
+        val noBlocks = Regex("/\\*.*?\\*/", RegexOption.DOT_MATCHES_ALL).replace(source, "")
+        return noBlocks.lineSequence().joinToString("\n") { line ->
+            var cut = -1
+            var i = 0
+            while (i < line.length - 1) {
+                if (line[i] == '/' && line[i + 1] == '/' && (i == 0 || line[i - 1] != ':')) {
+                    cut = i; break
+                }
+                i++
+            }
+            if (cut >= 0) line.substring(0, cut) else line
+        }
+    }
+
+    /** The full argument text of each `resolvedSeries(…)` call in [source], parens balanced
+     *  across lines. */
+    private fun callArgTexts(source: String): List<String> {
+        val calls = mutableListOf<String>()
+        var searchFrom = 0
+        while (true) {
+            val at = source.indexOf("resolvedSeries(", searchFrom)
+            if (at < 0) break
+            val open = at + "resolvedSeries".length
+            var depth = 0
+            var end = open
+            while (end < source.length) {
+                when (source[end]) {
+                    '(' -> depth++
+                    ')' -> { depth--; if (depth == 0) break }
+                }
+                end++
+            }
+            calls.add(source.substring(open + 1, end))
+            searchFrom = end
+        }
+        return calls
+    }
+
+    @Test
+    fun everyUiResolvedSeriesCallThreadsTheActiveStrapId() {
+        val dir = uiSourceDir()
+        assumeTrue("com/noop/ui sources not reachable from ${System.getProperty("user.dir")}", dir != null)
+
+        val offenders = mutableListOf<String>()
+        var callCount = 0
+        dir!!.walkTopDown().filter { it.isFile && it.extension == "kt" }.forEach { file ->
+            for (args in callArgTexts(stripComments(file.readText()))) {
+                callCount++
+                if (!args.contains("strapDeviceId")) {
+                    offenders.add("${file.name}: resolvedSeries(${args.trim().take(80)}…)")
+                }
+            }
+        }
+
+        // Scanner sanity: #175 fixed eight call sites; the scan finding fewer means the audit
+        // went blind (moved sources, renamed API), not that the problem shrank. If callers were
+        // legitimately consolidated behind a helper that threads the id, update this floor.
+        assertTrue("expected >= 8 resolvedSeries call sites, scanned $callCount", callCount >= 8)
+
+        assertTrue(
+            "resolvedSeries callers must pass `strapDeviceId = vm.activeStrapId` (#172/#175); " +
+                "leaning on the canonical default breaks every strap re-add:\n" +
+                offenders.joinToString("\n"),
+            offenders.isEmpty(),
+        )
+    }
+}


### PR DESCRIPTION
## What this PR does

Follow-up to #175, which fixed REST resolution after a strap re-add but shipped without tests. That bug surfaced in two places, both fed by the same `resolvedSeries` read: the Key Metrics REST card showing "no data", and the REST circle in the Today header (the "Charge / Effort / Rest" trio) stuck on "Calibrating". This adds two regression suites that pin the fix:

- **`ResolvedSeriesActiveStrapTest`** (behavioral, `Proxy`-stub dao, no Room): proves that threading the registry's active strap id resolves scores banked under `"<activeStrapId>-noop"` after a strap re-add, while the legacy canonical default misses them (the exact #172 symptom, kept as a documented failure shape); that single-strap installs resolve identically threaded or not; and that the #1008 sleep-union survives the threaded read.
- **`ResolvedSeriesCallSiteAuditTest`** (source census): scans `com/noop/ui` for `resolvedSeries(` call sites and fails any caller that doesn't pass `strapDeviceId` — the class of regression #175 fixed compiles silently, so this keeps future call sites honest.

Refs #172, #175.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [x] CI / tooling

## How it was tested

No BLE or protocol changes — tests only. `./gradlew testFullDebugUnitTest`: 2394 tests, 0 failures, 0 skipped (includes the 5 new tests). Both new suites were also verified to fail against the pre-#175 call sites (legacy canonical-default resolution reproduces the "no data" shape).

## Checklist

- [ ] Swift package tests pass for any package I touched (`swift test` in `Packages/<name>`)
- [x] Android unit tests pass if I touched `android/` (`./gradlew testFullDebugUnitTest`)
- [x] No new build warnings introduced
- [ ] UI changes use only `StrandDesign` tokens — no hardcoded colors, fonts, or spacing
- [x] No hardcoded hex frame bytes; protocol facts live in the schema / decoders
- [x] Follows the conventions in [`docs/CONTRIBUTING.md`](../docs/CONTRIBUTING.md)
- [x] I did not commit generated output (`Strand.xcodeproj/`) or any secrets/keystores

## Related issues

Refs #172, #175
