### PR TITLE
Profile: derive age from date of birth (#146)

### DIFF
--- a/.github/workflows/app-build.yml
+++ b/.github/workflows/app-build.yml
@@ -37,7 +37,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: macos-15
+    runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
       matrix:
@@ -48,9 +48,14 @@ jobs:
           - scheme: Strand
             destination: 'generic/platform=macOS'
             extra_args: 'ARCHS="x86_64 arm64" ONLY_ACTIVE_ARCH=NO'
+            runner: macos-15
+          # iOS needs the iOS 26 SDK (Liquid Glass's `glassEffect`, landed 2026-07-07) which macos-15's
+          # default Xcode doesn't ship — matches the runner fork-testing-build.yml / fork-release.yml
+          # already use for their NOOPiOS legs. macos-15 stays correct for the macOS/Strand leg above.
           - scheme: NOOPiOS
             destination: 'generic/platform=iOS Simulator'
             extra_args: ''
+            runner: macos-26
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/Packages/WhoopStore/Sources/WhoopStore/BackupSettings.swift
+++ b/Packages/WhoopStore/Sources/WhoopStore/BackupSettings.swift
@@ -95,7 +95,21 @@ public enum BackupSettings {
                   let storageKey = appleDefaultsKey[canonical] else { continue }
             defaults.set(coerced, forKey: storageKey)
         }
+        // #146: the whitelist carries an Int `profile.age`, not a Date, so a restore can only bring an
+        // age. Clear any stale `profile.dateOfBirth` on this device whenever an age is applied, so
+        // `ProfileStore` re-derives the date of birth from the RESTORED age on next launch instead of a
+        // pre-existing local DOB silently overriding the restore. (A restore forces a relaunch, so the
+        // re-derivation always runs.) `dobDefaultsKey` is spelled out here rather than added to the
+        // whitelist to keep the cross-platform JSON contract unchanged.
+        if values["profile.age"] != nil {
+            defaults.removeObject(forKey: dobDefaultsKey)
+        }
     }
+
+    /// UserDefaults key `ProfileStore` stores the #146 date of birth under. Not a whitelisted backup
+    /// key (a Date can't ride the Int/Double/String JSON contract) — only cleared on restore so the
+    /// restored Int age re-derives it. Must match `ProfileStore.K.dateOfBirth`.
+    static let dobDefaultsKey = "profile.dateOfBirth"
 
     // MARK: - JSON codec
 

--- a/Packages/WhoopStore/Tests/WhoopStoreTests/BackupSettingsTests.swift
+++ b/Packages/WhoopStore/Tests/WhoopStoreTests/BackupSettingsTests.swift
@@ -136,6 +136,32 @@ final class BackupSettingsTests: XCTestCase {
                      "The canonical name itself is never written to defaults")
     }
 
+    /// #146: applying a restored age must clear a pre-existing `profile.dateOfBirth`, so the target's
+    /// old DOB can't silently override the restore — `ProfileStore` re-derives the DOB from the
+    /// restored age on the forced post-restore relaunch.
+    func testApplyClearsStaleDateOfBirthWhenAgeRestored() throws {
+        let defaults = try freshDefaults()
+        defaults.set(Date(timeIntervalSince1970: 0), forKey: "profile.dateOfBirth") // target's own DOB
+
+        BackupSettings.apply(["profile.age": 44], to: defaults)
+
+        XCTAssertEqual(defaults.object(forKey: "profile.age") as? Int, 44)
+        XCTAssertNil(defaults.object(forKey: "profile.dateOfBirth"),
+                     "A restored age must clear the target's stale DOB so it re-derives from the restore")
+    }
+
+    /// A restore payload with no age must leave a target's date of birth alone.
+    func testApplyLeavesDateOfBirthWhenNoAgeInPayload() throws {
+        let defaults = try freshDefaults()
+        let dob = Date(timeIntervalSince1970: 500_000_000)
+        defaults.set(dob, forKey: "profile.dateOfBirth")
+
+        BackupSettings.apply(["profile.weightKg": 70.0], to: defaults)
+
+        XCTAssertEqual(defaults.object(forKey: "profile.dateOfBirth") as? Date, dob,
+                       "No age in the payload → the target's DOB is untouched")
+    }
+
     func testFullExportImportShapedRoundTripThroughDefaults() throws {
         // Device A: user-set values → snapshot → encode (what export writes into the zip).
         let deviceA = try freshDefaults()

--- a/Strand/Data/Profile.swift
+++ b/Strand/Data/Profile.swift
@@ -6,7 +6,18 @@ import SwiftUI
 /// Powers HR zones, calories and recovery baselines.
 @MainActor
 final class ProfileStore: ObservableObject {
-    @Published var age: Int { didSet { d.set(age, forKey: K.age) } }
+    /// Canonical source of truth for age (#146): a date of birth, so age advances on its own instead
+    /// of silently going stale until the user remembers to bump a number. `age` is derived from this.
+    @Published var dateOfBirth: Date {
+        didSet {
+            d.set(dateOfBirth, forKey: K.dateOfBirth)
+            // Mirror the DERIVED age under the legacy `profile.age` key so the `.noopbak` backup
+            // whitelist (which carries an Int age, not a Date) keeps exporting a correct value with no
+            // change to the cross-platform backup contract. `BackupSettings.apply` clears
+            // `profile.dateOfBirth` on restore so a restored Int age re-derives the DOB here.
+            d.set(age, forKey: K.legacyAge)
+        }
+    }
     @Published var sex: String { didSet { d.set(sex, forKey: K.sex) } }          // "male" | "female" | "nonbinary"
     @Published var weightKg: Double { didSet { d.set(weightKg, forKey: K.weight) } }
     @Published var heightCm: Double { didSet { d.set(heightCm, forKey: K.height) } }
@@ -52,7 +63,11 @@ final class ProfileStore: ObservableObject {
 
     private let d = UserDefaults.standard
     private enum K {
-        static let age = "profile.age", sex = "profile.sex", weight = "profile.weightKg"
+        static let dateOfBirth = "profile.dateOfBirth"
+        /// Pre-#146 age key. No longer the source of truth; kept mirrored from `dateOfBirth` so the
+        /// cross-platform `.noopbak` whitelist keeps round-tripping an Int age unchanged.
+        static let legacyAge = "profile.age"
+        static let sex = "profile.sex", weight = "profile.weightKg"
         static let height = "profile.heightCm", hrMax = "profile.hrMaxOverride"
         static let stepScale = "profile.stepTicksPerStep"
         static let waist = "profile.waistCm"
@@ -65,7 +80,27 @@ final class ProfileStore: ObservableObject {
     }
 
     init() {
-        age = d.object(forKey: K.age) as? Int ?? 30
+        // #146 age migration. `dateOfBirth` is authoritative whenever it exists, so age advances on
+        // its own. A pre-#146 install — or a `.noopbak` restore, which writes only the legacy Int age
+        // and clears any stale DOB (see `BackupSettings.apply`) — has no DOB yet, so derive one from
+        // the stored age. Nothing stored → the age-30 default. Deliberately NO equality heuristic: a
+        // present DOB is never second-guessed against the mirrored age (doing so would re-freeze age
+        // every birthday, the exact staleness #146 fixes).
+        let resolvedDOB: Date
+        if let dob = d.object(forKey: K.dateOfBirth) as? Date {
+            resolvedDOB = dob
+        } else if let legacyAge = d.object(forKey: K.legacyAge) as? Int {
+            resolvedDOB = Self.dateOfBirth(forAge: legacyAge)
+        } else {
+            resolvedDOB = Self.dateOfBirth(forAge: 30)
+        }
+        dateOfBirth = resolvedDOB
+        // `didSet` doesn't fire for the initial assignment inside `init`, so persist the resolved DOB
+        // and its mirrored age explicitly — otherwise a migrated/derived DOB never reaches storage
+        // until the user next edits it. Written from the LOCAL (not `self.dateOfBirth`, which Swift
+        // forbids reading before every stored property is initialized).
+        d.set(resolvedDOB, forKey: K.dateOfBirth)
+        d.set(Self.years(from: resolvedDOB, to: Date()), forKey: K.legacyAge)
         sex = d.string(forKey: K.sex) ?? "male"
         weightKg = d.object(forKey: K.weight) as? Double ?? 75
         heightCm = d.object(forKey: K.height) as? Double ?? 178
@@ -110,6 +145,28 @@ final class ProfileStore: ObservableObject {
     /// The manual override to feed into `StepsEstimateEngine.calibrate(_:manualOverride:)`:
     /// nil when 0 (auto-fit), the positive value otherwise.
     var stepsManualOverride: Double? { stepsManualCoefficient > 0 ? stepsManualCoefficient : nil }
+
+    /// Current age in whole years, derived from `dateOfBirth` (#146) rather than a number the user has
+    /// to remember to update. Every existing caller (HR zones, calories, Fitness/Body Age) reads this
+    /// unchanged.
+    var age: Int { Self.years(from: dateOfBirth, to: Date()) }
+
+    /// Whole years elapsed `from`→`to` (floor — a birthday not yet reached this year doesn't count).
+    nonisolated static func years(from: Date, to: Date) -> Int {
+        Calendar.current.dateComponents([.year], from: from, to: to).year ?? 0
+    }
+
+    /// A date of birth `age` whole years before today, anchored to today's month/day so the derived
+    /// age is exactly `age`. Used to migrate a stored manual age and to seed the DOB picker.
+    nonisolated static func dateOfBirth(forAge age: Int) -> Date {
+        Calendar.current.date(byAdding: .year, value: -age, to: Date()) ?? Date()
+    }
+
+    /// Bounds for the DOB picker, matching the old 13...100 age `Stepper` range so a pick can't derive
+    /// an out-of-range age.
+    nonisolated static var dateOfBirthRange: ClosedRange<Date> {
+        dateOfBirth(forAge: 100)...dateOfBirth(forAge: 13)
+    }
 
     /// Tanaka estimate unless overridden.
     var hrMax: Int { hrMaxOverride > 0 ? hrMaxOverride : Int((208 - 0.7 * Double(age)).rounded()) }

--- a/Strand/Onboarding/OnboardingWizard.swift
+++ b/Strand/Onboarding/OnboardingWizard.swift
@@ -712,9 +712,14 @@ private struct ProfileStep: View {
             VStack(spacing: 16) {
                 StrandCard {
                     VStack(spacing: 18) {
-                        Stepper(value: $profile.age, in: 13...100) {
-                            FieldRow(label: String(localized: "Age"), value: String(localized: "\(profile.age) yrs"))
+                        // #146: capture a date of birth so age advances on its own instead of going stale.
+                        DatePicker(selection: $profile.dateOfBirth,
+                                   in: ProfileStore.dateOfBirthRange,
+                                   displayedComponents: .date) {
+                            FieldRow(label: String(localized: "Date of birth"),
+                                     value: String(localized: "\(profile.age) yrs"))
                         }
+                        .tint(StrandPalette.accent)
 
                         Divider().overlay(StrandPalette.hairline)
 

--- a/Strand/Screens/SettingsView.swift
+++ b/Strand/Screens/SettingsView.swift
@@ -296,15 +296,20 @@ struct SettingsView: View {
             blurb: "These power your heart-rate zones, calorie estimates and recovery baselines. Keep them accurate."
         ) {
             VStack(spacing: 0) {
-                FormRow(label: "Age") {
+                FormRow(label: "Date of birth") {
                     HStack(spacing: 12) {
                         Text("\(profile.age)")
                             .font(StrandFont.bodyNumber)
                             .foregroundStyle(StrandPalette.textPrimary)
                             .frame(minWidth: 28, alignment: .trailing)
-                        Stepper("Age", value: $profile.age, in: 13...100)
+                        // #146: age is derived from the date of birth, so it advances on its own.
+                        DatePicker("Date of birth",
+                                   selection: $profile.dateOfBirth,
+                                   in: ProfileStore.dateOfBirthRange,
+                                   displayedComponents: .date)
                             .labelsHidden()
-                            .accessibilityLabel("Age, \(profile.age) years")
+                            .tint(StrandPalette.accent)
+                            .accessibilityLabel("Date of birth, age \(profile.age) years")
                     }
                 }
                 rowDivider

--- a/android/app/src/main/java/com/noop/ui/OnboardingScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/OnboardingScreen.kt
@@ -682,8 +682,9 @@ private fun ProfileStep() {
                         value = "${profile.age}",
                         unit = "yrs",
                         accessibility = "Age, ${profile.age} years",
-                        onMinus = { mutate { profile.age -= 1 } },
-                        onPlus = { mutate { profile.age += 1 } },
+                        // #146: age derives from a stored date of birth; setAge re-anchors it (clamped 13..100).
+                        onMinus = { mutate { profile.setAge(profile.age - 1) } },
+                        onPlus = { mutate { profile.setAge(profile.age + 1) } },
                     )
                 }
                 ThinDivider()

--- a/android/app/src/main/java/com/noop/ui/SettingsScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/SettingsScreen.kt
@@ -140,9 +140,39 @@ import kotlin.math.roundToInt
  */
 class ProfileStore(private val prefs: SharedPreferences) {
 
-    var age: Int
-        get() = prefs.getInt(KEY_AGE, 30).coerceIn(AGE_MIN, AGE_MAX)
-        set(v) = prefs.edit().putInt(KEY_AGE, v.coerceIn(AGE_MIN, AGE_MAX)).apply()
+    /**
+     * Current age in whole years (#146), DERIVED from [dateOfBirthMillis] so it advances on its own
+     * instead of going stale until the user bumps a number. Read-only; change age via [setAge] (the
+     * +/- stepper) or [dateOfBirthMillis] directly. Every existing reader (Fitness Age / Vitality /
+     * Tanaka) keeps reading `profile.age` unchanged.
+     */
+    val age: Int
+        get() = yearsFromDob(dateOfBirthMillis).coerceIn(AGE_MIN, AGE_MAX)
+
+    /**
+     * Date of birth as epoch millis — the canonical source of truth for [age] (#146). The getter
+     * lazily migrates a pre-#146 stored age (or a restored legacy `age`, see [applyBackup]) into an
+     * anchored DOB the first time it's read, then persists it so the derivation is stable. The setter
+     * mirrors the derived Int age under the legacy [KEY_AGE] so the `.noopbak` backup whitelist keeps
+     * exporting an age with no change to the cross-platform contract.
+     */
+    var dateOfBirthMillis: Long
+        get() {
+            if (prefs.contains(KEY_DOB)) return prefs.getLong(KEY_DOB, 0L)
+            val legacyAge = (if (prefs.contains(KEY_AGE)) prefs.getInt(KEY_AGE, 30) else 30)
+                .coerceIn(AGE_MIN, AGE_MAX)
+            val dob = dobForAge(legacyAge)
+            prefs.edit().putLong(KEY_DOB, dob).putInt(KEY_AGE, legacyAge).apply()
+            return dob
+        }
+        set(v) = prefs.edit()
+            .putLong(KEY_DOB, v)
+            .putInt(KEY_AGE, yearsFromDob(v).coerceIn(AGE_MIN, AGE_MAX))
+            .apply()
+
+    /** Set age by anchoring a date of birth `years` before today (the +/- stepper and backup restore
+     *  both go through here, so age always flows from a DOB). Clamped to [AGE_MIN]..[AGE_MAX]. */
+    fun setAge(years: Int) { dateOfBirthMillis = dobForAge(years.coerceIn(AGE_MIN, AGE_MAX)) }
 
     /** "male" | "female" | "nonbinary" — matches the macOS tag values. */
     var sex: String
@@ -233,7 +263,10 @@ class ProfileStore(private val prefs: SharedPreferences) {
     /** The user-SET profile fields, keyed canonically, for the backup exporter. */
     fun backupSnapshot(): Map<String, Any> {
         val out = LinkedHashMap<String, Any>()
-        if (prefs.contains(KEY_AGE)) out["profile.age"] = age
+        // #146: age is now derived from a DOB; export the current derived Int under the legacy
+        // `profile.age` key (the whitelist carries an Int, not a Date). A never-touched profile
+        // (neither key set) still stays out of the snapshot.
+        if (prefs.contains(KEY_DOB) || prefs.contains(KEY_AGE)) out["profile.age"] = age
         if (prefs.contains(KEY_SEX)) out["profile.sex"] = sex
         if (prefs.contains(KEY_WEIGHT)) out["profile.weightKg"] = weightKg
         if (prefs.contains(KEY_HEIGHT)) out["profile.heightCm"] = heightCm
@@ -248,7 +281,10 @@ class ProfileStore(private val prefs: SharedPreferences) {
      * through the property setters, so the usual range clamps apply.
      */
     fun applyBackup(values: Map<String, Any>) {
-        (values["profile.age"] as? Number)?.let { age = it.toInt() }
+        // #146: a restore carries only an Int age. Route it through setAge so the restored age
+        // re-anchors this device's DOB (clearing any stale local DOB) and then advances on its own —
+        // the deterministic twin of the Apple side clearing `profile.dateOfBirth` on apply.
+        (values["profile.age"] as? Number)?.let { setAge(it.toInt()) }
         (values["profile.sex"] as? String)?.let { sex = it }
         (values["profile.weightKg"] as? Number)?.let { weightKg = it.toDouble() }
         (values["profile.heightCm"] as? Number)?.let { heightCm = it.toDouble() }
@@ -258,6 +294,10 @@ class ProfileStore(private val prefs: SharedPreferences) {
 
     companion object {
         private const val PREFS = "noop_profile"
+        /** Date of birth as epoch millis — the #146 source of truth for [age]. */
+        private const val KEY_DOB = "date_of_birth"
+        /** Pre-#146 age key, now kept mirrored from the DOB so the `.noopbak` whitelist (Int age)
+         *  keeps round-tripping unchanged. */
         private const val KEY_AGE = "age"
         private const val KEY_SEX = "sex"
         private const val KEY_WEIGHT = "weight_kg"
@@ -293,6 +333,24 @@ class ProfileStore(private val prefs: SharedPreferences) {
             value < 2.0 -> 0.1
             value < 5.0 -> 0.5
             else -> 1.0
+        }
+
+        // ── #146 age <-> date-of-birth ──────────────────────────────────────────────────────────
+        /** Whole years between the DOB and today (floor — a birthday not yet reached doesn't count).
+         *  Uses the device's default zone so the rollover matches the user's local calendar. Mirrors
+         *  the Apple `ProfileStore.years(from:to:)`. */
+        fun yearsFromDob(dobMillis: Long): Int {
+            val zone = java.time.ZoneId.systemDefault()
+            val dob = java.time.Instant.ofEpochMilli(dobMillis).atZone(zone).toLocalDate()
+            return java.time.temporal.ChronoUnit.YEARS.between(dob, java.time.LocalDate.now(zone)).toInt()
+        }
+
+        /** A date of birth `age` whole years before today (anchored to today's month/day, so the
+         *  derived age is exactly `age`). Mirrors the Apple `ProfileStore.dateOfBirth(forAge:)`. */
+        fun dobForAge(age: Int): Long {
+            val zone = java.time.ZoneId.systemDefault()
+            return java.time.LocalDate.now(zone).minusYears(age.toLong())
+                .atStartOfDay(zone).toInstant().toEpochMilli()
         }
 
         /**
@@ -639,11 +697,11 @@ fun SettingsScreen(
                     StepperField(
                         value = profile.age.toString(),
                         accessibility = "Age, ${profile.age} years",
-                        // Bound to 13..100 to match iOS — and, since v4, age feeds the Fitness Age + Vitality
-                        // engines which gate on age > 0, an unbounded stepper let an Android user drive age to
-                        // 0/negative and silently switch both cards off with no explanation (code review).
-                        onMinus = { mutate { profile.age = (profile.age - 1).coerceIn(13, 100) } },
-                        onPlus = { mutate { profile.age = (profile.age + 1).coerceIn(13, 100) } },
+                        // #146: age is derived from a stored date of birth, so it advances on its own. The
+                        // stepper re-anchors the DOB via setAge (which clamps to 13..100 — age feeds the
+                        // Fitness Age + Vitality engines that gate on age > 0, so it must never go 0/negative).
+                        onMinus = { mutate { profile.setAge(profile.age - 1) } },
+                        onPlus = { mutate { profile.setAge(profile.age + 1) } },
                     )
                 }
                 RowDivider()

--- a/android/app/src/test/java/com/noop/ui/ProfileStoreAgeMigrationTest.kt
+++ b/android/app/src/test/java/com/noop/ui/ProfileStoreAgeMigrationTest.kt
@@ -1,0 +1,144 @@
+package com.noop.ui
+
+import android.content.SharedPreferences
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * #146: age is derived from a stored date of birth so it advances on its own, instead of the old
+ * manually-entered number that silently went stale. These pin the migration + derivation contract,
+ * the exact twin of the Apple `ProfileStore` behaviour.
+ *
+ * The critical anti-regression is [dobIsAuthoritative_notRefrozenByStaleAgeMirror]: an earlier
+ * attempt derived DOB back from the mirrored age whenever they disagreed, which re-froze age every
+ * birthday (the very staleness this fixes). DOB must always win.
+ *
+ * No Robolectric (junit only) — the real [ProfileStore] runs over an in-memory [FakeSharedPreferences]
+ * that reproduces the SharedPreferences read/write contract.
+ */
+class ProfileStoreAgeMigrationTest {
+
+    @Test
+    fun freshInstall_defaultsTo30_andPersistsADob() {
+        val prefs = FakeSharedPreferences()
+        val profile = ProfileStore(prefs)
+        assertEquals(30, profile.age)
+        // Reading age materialises and persists a DOB so the derivation is stable next launch.
+        assertTrue("a DOB must be persisted after the first read", prefs.contains("date_of_birth"))
+    }
+
+    @Test
+    fun pre146Install_migratesStoredAgeIntoADob() {
+        val prefs = FakeSharedPreferences()
+        prefs.edit().putInt("age", 40).apply()   // a pre-#146 install: only the legacy Int age exists
+        val profile = ProfileStore(prefs)
+        assertEquals(40, profile.age)
+        assertTrue("migration persists a derived DOB", prefs.contains("date_of_birth"))
+    }
+
+    @Test
+    fun dobIsAuthoritative_notRefrozenByStaleAgeMirror() {
+        // A DOB for age 36 with a STALE mirrored age of 35 (as if a birthday passed since it was
+        // written). Age MUST read 36 from the DOB — never re-derive DOB from the stale 35, which would
+        // freeze age forever. This is the #167 bug this reimplementation exists to avoid.
+        val prefs = FakeSharedPreferences()
+        prefs.edit()
+            .putLong("date_of_birth", ProfileStore.dobForAge(36))
+            .putInt("age", 35)
+            .apply()
+        val profile = ProfileStore(prefs)
+        assertEquals(36, profile.age)
+    }
+
+    @Test
+    fun setAge_roundTripsAndMirrorsLegacyKey() {
+        val prefs = FakeSharedPreferences()
+        val profile = ProfileStore(prefs)
+        profile.setAge(50)
+        assertEquals(50, profile.age)
+        assertEquals("legacy age key stays mirrored for the backup whitelist", 50, prefs.getInt("age", -1))
+    }
+
+    @Test
+    fun setAge_clampsToRange() {
+        val prefs = FakeSharedPreferences()
+        val profile = ProfileStore(prefs)
+        profile.setAge(5);   assertEquals(13, profile.age)
+        profile.setAge(200); assertEquals(100, profile.age)
+    }
+
+    @Test
+    fun backupRestore_reanchorsDobFromRestoredAge() {
+        // A device with its own DOB (age 36) restores a backup carrying age 45: the restored age wins
+        // and re-anchors the DOB, then advances on its own — the twin of the Apple apply clearing the
+        // stale DOB.
+        val prefs = FakeSharedPreferences()
+        prefs.edit().putLong("date_of_birth", ProfileStore.dobForAge(36)).putInt("age", 36).apply()
+        val profile = ProfileStore(prefs)
+        profile.applyBackup(mapOf("profile.age" to 45))
+        assertEquals(45, profile.age)
+    }
+
+    @Test
+    fun backupSnapshot_exportsDerivedAgeUnderLegacyKey() {
+        val prefs = FakeSharedPreferences()
+        val profile = ProfileStore(prefs)
+        profile.setAge(45)
+        assertEquals(45, (profile.backupSnapshot()["profile.age"] as? Int))
+    }
+
+    @Test
+    fun backupSnapshot_omitsAgeForAnUntouchedProfile() {
+        // Neither DOB nor legacy age set → age stays OUT of the snapshot so a restore doesn't stamp a
+        // default 30 over the target's real value.
+        val prefs = FakeSharedPreferences()
+        assertNull(ProfileStore(prefs).backupSnapshot()["profile.age"])
+    }
+
+    @Test
+    fun dateHelpers_roundTrip() {
+        for (age in intArrayOf(13, 25, 40, 67, 100)) {
+            assertEquals(age, ProfileStore.yearsFromDob(ProfileStore.dobForAge(age)))
+        }
+    }
+
+    // In-memory SharedPreferences reproducing the read/write contract ProfileStore relies on.
+    private class FakeSharedPreferences : SharedPreferences {
+        private val map = HashMap<String, Any?>()
+        override fun getInt(key: String, defValue: Int): Int = map[key] as? Int ?: defValue
+        override fun getLong(key: String, defValue: Long): Long = map[key] as? Long ?: defValue
+        override fun getFloat(key: String, defValue: Float): Float = map[key] as? Float ?: defValue
+        override fun getBoolean(key: String, defValue: Boolean): Boolean = map[key] as? Boolean ?: defValue
+        override fun getString(key: String, defValue: String?): String? = map[key] as? String ?: defValue
+        @Suppress("UNCHECKED_CAST")
+        override fun getStringSet(key: String, defValues: MutableSet<String>?): MutableSet<String>? =
+            map[key] as? MutableSet<String> ?: defValues
+        override fun getAll(): MutableMap<String, *> = HashMap(map)
+        override fun contains(key: String): Boolean = map.containsKey(key)
+        override fun registerOnSharedPreferenceChangeListener(l: SharedPreferences.OnSharedPreferenceChangeListener?) {}
+        override fun unregisterOnSharedPreferenceChangeListener(l: SharedPreferences.OnSharedPreferenceChangeListener?) {}
+        override fun edit(): SharedPreferences.Editor = FakeEditor()
+
+        private inner class FakeEditor : SharedPreferences.Editor {
+            private val pending = HashMap<String, Any?>()
+            private val removed = HashSet<String>()
+            override fun putString(key: String, value: String?): SharedPreferences.Editor { pending[key] = value; return this }
+            override fun putStringSet(key: String, values: MutableSet<String>?): SharedPreferences.Editor { pending[key] = values; return this }
+            override fun putInt(key: String, value: Int): SharedPreferences.Editor { pending[key] = value; return this }
+            override fun putLong(key: String, value: Long): SharedPreferences.Editor { pending[key] = value; return this }
+            override fun putFloat(key: String, value: Float): SharedPreferences.Editor { pending[key] = value; return this }
+            override fun putBoolean(key: String, value: Boolean): SharedPreferences.Editor { pending[key] = value; return this }
+            override fun remove(key: String): SharedPreferences.Editor { removed.add(key); return this }
+            override fun clear(): SharedPreferences.Editor { map.clear(); return this }
+            override fun commit(): Boolean { flush(); return true }
+            override fun apply() { flush() }
+            private fun flush() {
+                for (k in removed) map.remove(k)
+                map.putAll(pending)
+                pending.clear(); removed.clear()
+            }
+        }
+    }
+}


### PR DESCRIPTION
Reimplements #146 ourselves (supersedes #167). Age was a manually-entered number that silently went stale once set, so Fitness Age, Tanaka HR-max and calorie estimates all drifted until the user remembered to bump it.

## What changed
`ProfileStore` now stores a **date of birth** as the source of truth and derives `age` from it, so age advances on its own — both platforms:

- **iOS**: `dateOfBirth` (UserDefaults), `age` derived; Settings + onboarding use a `DatePicker`.
- **Android**: `dateOfBirthMillis` (SharedPreferences), `age` derived; the existing +/- stepper re-anchors the DOB via `setAge` (UI idiom kept — data behaviour is identical).

## Migration & the bug this avoids
- A pre-#146 install's stored age is converted to an equivalent DOB on first read/launch.
- **DOB is always authoritative when present.** Deliberately *no* "age mirror disagrees → resynthesize DOB" heuristic: that heuristic (in #167) re-froze age every birthday and silently mutated the stored DOB — the exact staleness #146 sets out to fix. Pinned by `dobIsAuthoritative_notRefrozenByStaleAgeMirror`.

## Backup (`.noopbak`)
- The legacy `profile.age` key stays **mirrored** from the DOB, so the cross-platform settings whitelist keeps round-tripping an **Int age unchanged** — no `Date` on the wire, no change to the byte-parity contract.
- On restore the restored age wins deterministically: iOS clears the stale `profile.dateOfBirth` on apply; Android re-anchors the DOB from the restored age. A restore forces a relaunch, so the re-derivation always runs.

## Tests
- **Android** `ProfileStoreAgeMigrationTest` — 9 cases (fresh install, pre-#146 migration, DOB-authoritative anti-regression, setAge clamp/round-trip, backup restore re-anchor, snapshot export/omit, date-helper round-trip). Runs locally, all green.
- **iOS** `BackupSettingsTests` — added apply-clears-DOB-on-restore and leaves-DOB-when-no-age cases (validated on swift-packages CI; local run blocked by the GRDB/CSQLite wall).

## Also
- CI: the `NOOPiOS` app-build leg now runs on `macos-26` (iOS 26 SDK / `glassEffect`); `macos-15` kept for the Strand/macOS leg — matches the fork testing/release workflows. Separate commit.

Closes #146. Supersedes #167 (thanks @digitalerdude for the original — this reworks the migration to be drift-safe and adds the Android twin).