### PR TITLE
Sleep (Android): show the duration trend as a bar chart (#85)

### DIFF
--- a/android/app/src/main/java/com/noop/ui/SleepScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/SleepScreen.kt
@@ -2226,12 +2226,14 @@ private fun DurationTrend(m: SleepModel) {
         ) {
             if (pts.size >= 2) {
                 Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
-                    LineChart(
+                    // #85: sleep duration reads as a per-night histogram (zero-based bars), matching the
+                    // iOS Sleep tab's TrendChart(showsBars:) — a BarMark is proportional to hours slept,
+                    // clearer than a line for a nightly total. BarChart floors at 0 like the iOS bar domain.
+                    BarChart(
                         values = pts,
                         modifier = Modifier.fillMaxWidth().height(Metrics.compactChartHeight)
                             .semantics { contentDescription = "Sleep hours trend chart" },
                         color = Palette.restColor,
-                        fill = true,
                         selectionEnabled = true,
                     )
                     DateAxisRow(m.trendDates)


### PR DESCRIPTION
Android parity follow-up to #168 (which switched the iOS "Hours asleep" trend to a zero-based bar histogram via `TrendChart(showsBars:)`).

Android's `DurationTrend` still used `LineChart(fill = true)`, so the *same* Sleep-tab "Hours asleep" trend rendered as a filled line on Android and bars on iOS. This swaps it to the existing zero-based `BarChart` component (same `values` / `color` / `selectionEnabled`; bars floor at 0, matching the iOS bar domain), so #85 reads consistently on both platforms.

- UI-only, no data/analytics change.
- Compiles locally (`compileFullDebugKotlin`).
- `BarChart` already exists (Charts.kt) and is used elsewhere; this is the `LineChart → BarChart` twin of the iOS `showsArea → showsBars` flip.

Completes #85 on Android.