### PR TITLE
Widget (iOS): throttle the live-HR republish to 60s (#114 follow-up)

### DIFF
--- a/StrandiOS/App/StrandiOSApp.swift
+++ b/StrandiOS/App/StrandiOSApp.swift
@@ -138,11 +138,14 @@ struct StrandiOSApp: App {
                 // #114 (follow-up): `WidgetSnapshot.bpm` reads `model.bpm` (WidgetPublish.swift), the
                 // smoothed live HR — same LIVE-not-repo-cache category as battery/connected above, so it
                 // has the same gap: nothing bumped `refreshSeq` while a heart-rate stream was live, so the
-                // widget's HR froze at the last foreground snapshot for the rest of the session. `model.bpm`
-                // already change-guards itself in `ingestHR()` (only assigns when the smoothed median
-                // actually moves), so this can't out-pace the battery/connected hooks' throttling story.
+                // widget's HR froze at the last foreground snapshot for the rest of the session. UNLIKE
+                // battery/connection, HR is HIGH-frequency (the smoothed median moves every few seconds
+                // under activity), so — unlike the ungated hooks above — this one is throttled through
+                // `HRPublishThrottle` (60 s, mirroring Android's PushGate HR cadence) so it can't re-run
+                // publish's `exploreSeries` read + `reloadAllTimelines()` on every tick.
                 .onReceive(model.$bpm.dropFirst()) { _ in
                     guard scenePhase == .active else { return }
+                    guard WidgetSnapshot.HRPublishThrottle.admit() else { return }
                     Task { await WidgetSnapshot.publish(from: model) }
                 }
                 // #581: the `noop://import-health` deep link the iOS Shortcut opens after building the

--- a/StrandiOS/Widgets/WidgetPublish.swift
+++ b/StrandiOS/Widgets/WidgetPublish.swift
@@ -62,5 +62,25 @@ extension WidgetSnapshot {
         snap.save()
         WidgetCenter.shared.reloadAllTimelines()
     }
+
+    /// #114/#169: HR is the ONE high-frequency widget-publish trigger — `model.bpm` moves every few
+    /// seconds during activity, unlike battery (~8 min) or connection flips (rare). Left ungated, the
+    /// `model.$bpm` hook re-ran `publish`'s `exploreSeries` read + `reloadAllTimelines()` on every tick.
+    /// This caps HR-DRIVEN publishes to one per `interval`, mirroring Android's `PushGate` 60 s
+    /// `HR_REFRESH_MS` cadence. Only the bpm hook consults it; the low-frequency score/battery/connection/
+    /// scenePhase publish sites stay ungated, exactly as before. `@MainActor` (the hook already runs there),
+    /// so the shared timestamp needs no locking.
+    @MainActor
+    enum HRPublishThrottle {
+        static let interval: TimeInterval = 60
+        private static var lastPublishedAt: Date = .distantPast
+        /// True (and stamps `now`) when at least `interval` has elapsed since the last HR-driven publish;
+        /// false to skip this HR change. The first call always admits (`.distantPast`).
+        static func admit(now: Date = Date()) -> Bool {
+            guard now.timeIntervalSince(lastPublishedAt) >= interval else { return false }
+            lastPublishedAt = now
+            return true
+        }
+    }
 }
 #endif


### PR DESCRIPTION
Follow-up to #169 (which republished the widget on live HR changes).

**The gap #169 exposed:** `WidgetSnapshot.publish` is ungated — every call does a full `exploreSeries` repository read + `WidgetCenter.reloadAllTimelines()` (WidgetPublish.swift). The pre-existing battery/connection hooks were fine ungated because they're low-frequency (battery ~8 min, connection flips rare — the code comment even says "no throttle is needed"). But HR is **high-frequency** — `model.bpm`'s smoothed median moves every few seconds under activity — so the `model.$bpm` hook re-ran that series read + reload on every tick.

**Fix:** add `HRPublishThrottle` (60 s), consulted **only** by the bpm hook, mirroring Android's `PushGate` `HR_REFRESH_MS` cadence. During activity the widget HR now updates once per 60 s (matching Android) instead of every tick.

- The low-frequency score/battery/connection/scenePhase publish sites stay **ungated exactly as before** — this is a targeted throttle on the one new high-frequency source, so it can't regress the other paths.
- `@MainActor` (the hook already runs there), so the shared timestamp needs no locking.
- No unit test: `HRPublishThrottle` lives in the StrandiOS app target, which no CI test job runs (swift-packages covers only `Packages/**`); the logic is a trivial elapsed-time gate mirroring Android's tested `PushGate`. Validated by the app-build compile.

Refs #114, #169.