### PR TITLE
Backfill: skip (not just throttle) automatic offloads for a future-clock strap (#160)

### DIFF
--- a/Strand/BLE/BLEManager.swift
+++ b/Strand/BLE/BLEManager.swift
@@ -2247,9 +2247,10 @@ public final class BLEManager: NSObject, ObservableObject {
             connected: state.connected, bonded: state.bonded, backfilling: backfilling) else { return }
         let now = Date().timeIntervalSince1970
         let last = UserDefaults.standard.object(forKey: BLEManager.backfillLastAtKey) as? Double
-        // #160: fold the strap's already-tracked future-dated clock (#928/#1012) into the SAME rate
-        // limiter the empty-streak backoff uses, so a clock-broken strap's automatic retries stop
-        // competing with realtime HR streaming for BLE airtime as often.
+        // #160: a future-dated-clock strap's recurring automatic offloads (#928/#1012) are near-useless
+        // AND each ~60s session blocks the WHOOP4 realtime-HR keep-alive re-arm (guard !backfilling), so
+        // live HR lapses. Feed the already-tracked future-dated signal into BackfillPolicy, which SKIPS
+        // the .strap/.periodic triggers entirely for such a strap (the .connect pass still re-checks it).
         let clockUntrusted = BackfillContinuation.isFutureDatedNewest(strapNewestTs, wallNowUnix: Int(now))
         guard BackfillPolicy.shouldRun(trigger: trigger, now: now, lastBackfillAt: last,
                                        emptyStreak: emptySyncTracker.consecutiveEmptySyncs,

--- a/Strand/BLE/BackfillPolicy.swift
+++ b/Strand/BLE/BackfillPolicy.swift
@@ -33,33 +33,31 @@ enum BackfillPolicy {
     /// `clockUntrusted` = the strap's own RTC currently reads future-dated (#928: `BackfillContinuation
     /// .isFutureDatedNewest`). Such a strap still BANKS real rows every pass, so it never trips the
     /// `emptyStreak` backoff above, yet #1012 already refuses to chase that range past one pass per
-    /// connection — so the AUTOMATIC triggers get near-zero value from retrying it on the baseline
-    /// cadence, at the cost of BLE airtime that competes with realtime HR streaming for the link (#160:
-    /// reported as "HR not displaying while band is active" on a strap whose logs showed exactly this
-    /// future-dated clock). Maxes the SAME backoff the empty-streak uses immediately — there's no
-    /// "streak" to build for a clock fault the way there is for an empty offload, and it's the automatic
-    /// triggers this exists to protect, so `.connect`/`.foreground`/`.manual`/`.autoContinue` stay
-    /// un-floored exactly as they do for `emptyStreak`.
+    /// connection — so the recurring AUTOMATIC triggers get near-zero value from retrying it, at a real
+    /// cost: each ~60s offload holds the link and blocks the WHOOP4 realtime-HR keep-alive re-arm
+    /// (BLEManager `guard !backfilling`), so live HR lapses (#160: "HR not displaying while band is
+    /// active" on a strap whose logs showed exactly this future-dated clock). So `.strap`/`.periodic` are
+    /// SKIPPED ENTIRELY while the clock is untrusted — the per-connection `.connect` pass still runs, so a
+    /// clock that later self-corrects is picked up on the next connection (or a manual sync). As with
+    /// `emptyStreak`, `.connect`/`.foreground`/`.manual`/`.autoContinue` are never affected.
     static func shouldRun(trigger: BackfillTrigger, now: TimeInterval,
                           lastBackfillAt: TimeInterval?, emptyStreak: Int = 0,
                           clockUntrusted: Bool = false) -> Bool {
         guard let last = lastBackfillAt else { return true }
         let elapsed = now - last
-        let backoff: Double
-        if clockUntrusted {
-            backoff = maxEmptyBackoff
-        } else if emptyStreak >= emptyBackoffThreshold {
-            backoff = min(pow(2.0, Double(emptyStreak - emptyBackoffThreshold + 1)), maxEmptyBackoff)
-        } else {
-            backoff = 1.0
-        }
+        let backoff: Double = emptyStreak >= emptyBackoffThreshold
+            ? min(pow(2.0, Double(emptyStreak - emptyBackoffThreshold + 1)), maxEmptyBackoff)
+            : 1.0
         switch trigger {
         // .manual (user-tapped) and .autoContinue (#364 expedited backlog drain) always run — both are
         // deliberately un-floored; .autoContinue's runaway protection lives in BLEManager's cap, not here.
         case .manual, .autoContinue: return true
         case .connect, .foreground:  return elapsed >= eventFloorSeconds
-        case .strap:                 return elapsed >= eventFloorSeconds * backoff
-        case .periodic:              return elapsed >= periodicFloorSeconds * backoff
+        // #160: a future-dated-clock strap's recurring automatic offloads are near-useless (#1012 won't
+        // trust the range) but each holds the link ~60s and starves the WHOOP4 realtime-HR re-arm, so skip
+        // them entirely — not just stretch the floor. The .connect pass above still re-checks the clock.
+        case .strap:                 return !clockUntrusted && elapsed >= eventFloorSeconds * backoff
+        case .periodic:              return !clockUntrusted && elapsed >= periodicFloorSeconds * backoff
         }
     }
 }

--- a/StrandTests/BackfillPolicyTests.swift
+++ b/StrandTests/BackfillPolicyTests.swift
@@ -55,33 +55,35 @@ final class BackfillPolicyTests: XCTestCase {
 
     // MARK: - #160: future-dated clock backoff
 
-    /// A strap whose RTC reads future-dated (#928) still banks real rows every pass, so it never trips
-    /// emptyStreak — clockUntrusted must independently stretch the .strap floor to the SAME cap.
-    func testClockUntrustedBacksOffStrapEvenWithNoEmptyStreak() {
-        let last = 1000.0 - 200   // passes the baseline (90s) floor, blocked once the 4x cap applies (360s)
-        XCTAssertTrue (BackfillPolicy.shouldRun(trigger: .strap, now: 1000, lastBackfillAt: last,
+    /// #160: a future-dated-clock strap's recurring automatic offloads are SKIPPED ENTIRELY (not just
+    /// throttled) — each ~60s offload starves the WHOOP4 realtime-HR re-arm, and #1012 won't trust the
+    /// range anyway. `.strap` never runs while `clockUntrusted`, no matter how long since the last pass.
+    func testClockUntrustedSkipsStrapEntirely() {
+        // A huge elapsed that would trivially pass every floor: still skipped when the clock is untrusted.
+        XCTAssertTrue (BackfillPolicy.shouldRun(trigger: .strap, now: 1_000_000, lastBackfillAt: 0,
                                                 emptyStreak: 0, clockUntrusted: false))
-        XCTAssertFalse(BackfillPolicy.shouldRun(trigger: .strap, now: 1000, lastBackfillAt: last,
+        XCTAssertFalse(BackfillPolicy.shouldRun(trigger: .strap, now: 1_000_000, lastBackfillAt: 0,
                                                 emptyStreak: 0, clockUntrusted: true))
     }
 
-    func testClockUntrustedBacksOffPeriodicToo() {
-        let last = 10000.0 - 1000   // passes the baseline (900s) floor, blocked once the 4x cap applies (3600s)
-        XCTAssertTrue (BackfillPolicy.shouldRun(trigger: .periodic, now: 10000, lastBackfillAt: last,
+    func testClockUntrustedSkipsPeriodicEntirely() {
+        XCTAssertTrue (BackfillPolicy.shouldRun(trigger: .periodic, now: 1_000_000, lastBackfillAt: 0,
                                                 clockUntrusted: false))
-        XCTAssertFalse(BackfillPolicy.shouldRun(trigger: .periodic, now: 10000, lastBackfillAt: last,
+        XCTAssertFalse(BackfillPolicy.shouldRun(trigger: .periodic, now: 1_000_000, lastBackfillAt: 0,
                                                 clockUntrusted: true))
     }
 
-    /// clockUntrusted maxes the backoff immediately (no streak to build), so it's already at the 4x cap
-    /// a huge emptyStreak would also reach — the two signals must not stack past maxEmptyBackoff.
-    func testClockUntrustedDoesNotStackBeyondCapWithEmptyStreak() {
-        let last = 1000.0 - fe * 4   // exactly at the 4x-capped floor
-        XCTAssertTrue(BackfillPolicy.shouldRun(trigger: .strap, now: 1000, lastBackfillAt: last,
-                                               emptyStreak: 99, clockUntrusted: true))
+    /// The skip is independent of `emptyStreak`: a clock-untrusted strap that is ALSO banking real rows
+    /// (emptyStreak 0) is skipped just the same as one with a long empty streak.
+    func testClockUntrustedSkipRegardlessOfEmptyStreak() {
+        XCTAssertFalse(BackfillPolicy.shouldRun(trigger: .strap, now: 1_000_000, lastBackfillAt: 0,
+                                                emptyStreak: 0, clockUntrusted: true))
+        XCTAssertFalse(BackfillPolicy.shouldRun(trigger: .periodic, now: 1_000_000, lastBackfillAt: 0,
+                                                emptyStreak: 99, clockUntrusted: true))
     }
 
-    /// Same invariant as emptyStreak: clockUntrusted must never delay a user- or connection-driven sync.
+    /// clockUntrusted must never delay a user- or connection-driven sync — the .connect pass is exactly
+    /// how a self-corrected clock gets picked up again after the automatic triggers were skipped.
     func testClockUntrustedNeverDelaysConnectForegroundManualOrAutoContinue() {
         let last = 1000 - fe
         XCTAssertTrue(BackfillPolicy.shouldRun(trigger: .connect, now: 1000, lastBackfillAt: last, clockUntrusted: true))


### PR DESCRIPTION
Root-cause follow-up to #170 (which throttled the retries) for #160 ("HR not displaying while band is active" on a WHOOP 4.0 with a future-dated RTC).

## Root cause
The WHOOP 4.0 realtime-HR keep-alive **re-arm** (`reconcileRealtime()` + the `sendR10R11Realtime`/`toggleRealtimeHR` sends) sits **behind `guard !backfilling else { return }`** in `BLEManager.keepAliveFire()` (BLEManager.swift:2199). WHOOP 4.0 realtime HR **lapses in firmware unless periodically re-armed** — that re-arm is the keep-alive's job. So while a backfill session holds the link, realtime HR is never re-armed and the firmware lets it lapse. A future-dated-clock strap re-triggered `.strap`/`.periodic` backfill constantly (every 10–40s per the reporter's log), so `backfilling` was almost always true → realtime HR never re-armed → **no live HR** (REALTIME_DATA only appeared in the brief windows when backfill idled).

## Fix
#170 throttled those automatic retries; this **skips them entirely** while the clock is untrusted. Such a strap's automatic offload is near-useless anyway (#1012 won't trust the range), so nothing is lost — and:
- The per-connection **`.connect` pass still runs**, so a clock that later self-corrects is picked up on the next connection (or a manual sync).
- `.connect`/`.foreground`/`.manual`/`.autoContinue` are unaffected.

`BackfillPolicyTests` updated to pin the skip (was: throttle-to-cap).

## Validation
- Compile-checked via app-build (BLE path is app-target Swift, no CI unit-test coverage).
- **Needs on-device validation on a WHOOP 4.0 with a future-dated clock** — I can't exercise the BLE path. The safer of the two options considered (the alternative, re-arming realtime mid-offload, risks disrupting the history transfer).

Refs #160, #170.