### PR TITLE
HRV: always-on per-night value + window line in the strap log (#195)

### DIFF
--- a/Strand/Data/IntelligenceEngine.swift
+++ b/Strand/Data/IntelligenceEngine.swift
@@ -879,6 +879,13 @@ final class IntelligenceEngine: ObservableObject {
             let tsmLog = daily.totalSleepMin.map { String(Int($0.rounded())) } ?? "nil"
             diagnosticSink?("sleep day=\(daily.day) totalSleepMin=\(tsmLog) "
                             + "matched=\(night.cachedSleep.count) source=\(source.logToken)", nil)
+            // #195: one always-on line per scored night with the computed HRV value + the window it used,
+            // so an "HRV reads high / deep-sleep window not changing" report is self-diagnosing straight
+            // from the strap log — the whole-night vs deep-sleep value, and `avgHrv=nil window=deep` when a
+            // deep-window night has no detected deep sleep — without needing the HRV & Autonomic test mode.
+            // Counts-only (a rounded ms + the window), PII-free; byte-identical to the Kotlin line.
+            let hrvLog = daily.avgHrv.map { String(format: "%.1f", $0) } ?? "nil"
+            diagnosticSink?("hrv day=\(daily.day) window=\(deepHrvWindow ? "deep" : "whole") avgHrv=\(hrvLog)", nil)
             // ── CAPTURE-B: universal dayOwner self-diagnostic (#814/#799) ────────────────────────────────
             // ONE line per scored day, tagged `.universal` so it rides EVERY Test Centre export regardless
             // of which mode is on. It pins down the read/write split #814 is about: `readId` is the owner

--- a/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
+++ b/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
@@ -783,6 +783,13 @@ object IntelligenceEngine {
                     "matched=${res.sleepSessions.size} " +
                     "source=${daySourceToken(daily.day, importedWhoopDays, appleHealthDays)}",
             )
+            // #195: one always-on line per scored night with the computed HRV value + the window it used,
+            // so an "HRV reads high / deep-sleep window not changing" report is self-diagnosing straight
+            // from the strap log — the whole-night vs deep-sleep value, and `avgHrv=nil window=deep` when a
+            // deep-window night has no detected deep sleep — without needing the HRV & Autonomic test mode.
+            // Counts-only (a rounded ms + the window), PII-free; byte-identical to the Swift line.
+            val hrvLog = daily.avgHrv?.let { String.format(java.util.Locale.US, "%.1f", it) } ?: "nil"
+            diag("hrv day=${daily.day} window=${if (deepHrvWindow) "deep" else "whole"} avgHrv=$hrvLog")
             // ── CAPTURE-B: universal dayOwner self-diagnostic (#814/#799) ────────────────────────────────
             // ONE line per SCORED day, tagged .universal so it rides EVERY Test Centre export regardless of
             // which mode is on. It pins the read/write split #814 is about: readId is the owner this day was


### PR DESCRIPTION
Instrument-first follow-up to #195.

## Why
When someone reports "HRV reads ~2× WHOOP" or "the deep-sleep window doesn't change my values," the strap log already carries the calibration **state** (`[recovery] charge … hrvStatus=calibrating hrvNValid=N`) — that's how #195 was diagnosed. But it does **not** carry the nightly HRV **value** or which **window** produced it. Those live only in the HRV & Autonomic *test-mode* trace, which a reporter usually doesn't have actively emitting during the overnight analysis pass — so "2×" and "did the window apply?" can't be answered from a normal strap log.

## What
One compact, **always-on** line per scored night, emitted via the same `diag` sink as `sleep day=`:

```
hrv day=2026-07-09 window=deep avgHrv=45.3
```

- Shows the computed value, the window in effect (`whole`/`deep`), and `avgHrv=nil window=deep` when a deep-window night has **no detected deep sleep** — the exact things needed to self-diagnose the #195 report class from any strap log, no test mode required.
- **Counts-only** (a rounded ms + the window) — PII-free, following the redacted-log conventions.
- The verbose per-5-min-window trace stays **test-mode-gated** as before (no log bloat).
- **Swift + Kotlin twins, byte-identical format** (`IntelligenceEngine.swift` / `IntelligenceEngine.kt`, next to the existing `sleep day=` line).

## Validation
- Android `compileFullDebugKotlin` passes locally.
- Swift side compile-checked via app-build (app-target Swift — `Strand/Data/IntelligenceEngine.swift` — has no default CI).
- No behavior change: additive log line only.

Refs #195. Enables validating the baseline-re-fold improvement (#201) against real data once it's tried.