### PR TITLE
R-R (Android): gap-aware RMSSD/pNN50 so a dropped beat can't inflate HRV

### DIFF
--- a/android/app/src/main/java/com/noop/analytics/HrvAnalyzer.kt
+++ b/android/app/src/main/java/com/noop/analytics/HrvAnalyzer.kt
@@ -19,6 +19,15 @@ import kotlin.math.sqrt
  *      (Malik-style filter).
  *   3. Require >= MIN_BEATS (20) valid intervals before a trustworthy result.
  *
+ * Gap-aware successive differences: cleaning DROPS beats, which makes two beats that were not
+ * adjacent in the source become neighbours in the cleaned list. A successive-difference metric
+ * (RMSSD, pNN50) must NOT count the difference across such a splice, or one removed beat injects a
+ * spurious large delta that dominates the mean. [cleanRRGapAware] cleans while remembering where beats
+ * were dropped, and [rmssdGapAware] / [pnn50GapAware] skip any difference that straddles a gap. On a
+ * series with no drops these are identical to the plain versions, so clean data is unchanged. This is
+ * an intentional divergence from the Swift twin, which still splices; porting the same change to
+ * StrandAnalytics/HRVAnalyzer.swift is a follow-up.
+ *
  * Named [HrvAnalyzer] (NOT Hrv) to avoid clashing with the existing
  * com.noop.analytics.Hrv object in Analytics.kt. The two compute RMSSD the same
  * way (sqrt of mean successive squared diffs); HrvAnalyzer additionally cleans
@@ -153,6 +162,95 @@ object HrvAnalyzer {
     /** Full clean: range filter → ectopic rejection. Returns the clean NN series. */
     fun cleanRR(rr: List<Double>): List<Double> = rejectEctopic(rangeFilter(rr))
 
+    // ── Gap-aware cleaning (successive-difference safety) ─────────────────────
+
+    /**
+     * A cleaned NN series that remembers where beats were dropped. [nn] is byte-identical to [cleanRR]
+     * over the same input. [contiguous] has the same length: `contiguous[i]` is true when `nn[i]` and
+     * `nn[i - 1]` were adjacent beats in the ORIGINAL series (no beat removed between them by the range
+     * or ectopic filter) and false when a beat was dropped in between (a splice). Index 0 is always
+     * false: the first beat has no predecessor.
+     */
+    data class CleanSeries(val nn: List<Double>, val contiguous: List<Boolean>)
+
+    /**
+     * Clean the RR series (range filter then Malik ectopic rejection, exactly like [cleanRR]) while
+     * tracking which original beats were dropped, so a downstream successive-difference metric can skip
+     * the difference across a removed beat. [CleanSeries.nn] equals [cleanRR] value for value.
+     */
+    fun cleanRRGapAware(rr: List<Double>): CleanSeries {
+        // Pass 1: range filter, keeping each survivor's index in the ORIGINAL series.
+        val rangedIdx = ArrayList<Int>(rr.size)
+        val rangedVal = ArrayList<Double>(rr.size)
+        for (i in rr.indices) {
+            val v = rr[i]
+            if (v >= RR_MIN_MS && v <= RR_MAX_MS) { rangedIdx.add(i); rangedVal.add(v) }
+        }
+        // Pass 2: Malik ectopic rejection over the range-filtered values, mirroring [rejectEctopic]
+        // (same windows, same median, same threshold) so the kept values match cleanRR exactly, while
+        // carrying each survivor's original index forward.
+        val keptOrig = ArrayList<Int>(rangedVal.size)
+        val keptVal = ArrayList<Double>(rangedVal.size)
+        if (rangedVal.size <= ECTOPIC_WINDOW_RADIUS) {
+            // rejectEctopic returns the input unchanged for a series this short.
+            for (k in rangedVal.indices) { keptOrig.add(rangedIdx[k]); keptVal.add(rangedVal[k]) }
+        } else {
+            for (i in rangedVal.indices) {
+                val lo = maxOf(0, i - ECTOPIC_WINDOW_RADIUS)
+                val hi = minOf(rangedVal.size - 1, i + ECTOPIC_WINDOW_RADIUS)
+                val neighbours = ArrayList<Double>(hi - lo)
+                for (j in lo..hi) if (j != i) neighbours.add(rangedVal[j])
+                val keep = when {
+                    neighbours.size < 2 -> true
+                    else -> {
+                        val med = median(neighbours)
+                        if (med <= 0) true else abs(rangedVal[i] - med) / med <= ECTOPIC_THRESHOLD
+                    }
+                }
+                if (keep) { keptOrig.add(rangedIdx[i]); keptVal.add(rangedVal[i]) }
+            }
+        }
+        // A survivor is contiguous with its predecessor only when their ORIGINAL indices are adjacent.
+        val contiguous = ArrayList<Boolean>(keptVal.size)
+        for (i in keptVal.indices) contiguous.add(i > 0 && keptOrig[i] == keptOrig[i - 1] + 1)
+        return CleanSeries(keptVal, contiguous)
+    }
+
+    /**
+     * Task Force RMSSD that counts a successive difference only when the two beats were adjacent in the
+     * source ([CleanSeries.contiguous]). A difference spanning a dropped beat is skipped, so removing an
+     * out-of-range or ectopic beat cannot splice its neighbours into a spurious delta. Identical to
+     * [rmssdRaw] when there are no gaps. Returns null when no valid successive difference exists.
+     */
+    fun rmssdGapAware(nn: List<Double>, contiguous: List<Boolean>): Double? {
+        require(nn.size == contiguous.size) { "nn and contiguous must be the same length" }
+        var sumSq = 0.0
+        var count = 0
+        for (i in 1 until nn.size) {
+            if (!contiguous[i]) continue
+            val d = nn[i] - nn[i - 1]
+            sumSq += d * d
+            count += 1
+        }
+        return if (count < 1) null else sqrt(sumSq / count.toDouble())
+    }
+
+    /**
+     * pNN50 (% of successive |ΔNN| > 50 ms) counting only gap-free pairs, mirroring [rmssdGapAware].
+     * Identical to the plain pNN50 when there are no gaps. Returns null when no valid pair exists.
+     */
+    fun pnn50GapAware(nn: List<Double>, contiguous: List<Boolean>): Double? {
+        require(nn.size == contiguous.size) { "nn and contiguous must be the same length" }
+        var nn50 = 0
+        var pairs = 0
+        for (i in 1 until nn.size) {
+            if (!contiguous[i]) continue
+            if (abs(nn[i] - nn[i - 1]) > 50.0) nn50 += 1
+            pairs += 1
+        }
+        return if (pairs < 1) null else nn50.toDouble() / pairs.toDouble() * 100.0
+    }
+
     // ── Windowed analysis ────────────────────────────────────────────────────
 
     /**
@@ -186,7 +284,8 @@ object HrvAnalyzer {
      */
     fun analyzeRaw(rawRR: List<Double>, maxRejectedFraction: Double? = null): HrvResult {
         val nInput = rawRR.size
-        val clean = cleanRR(rawRR)
+        val cleaned = cleanRRGapAware(rawRR)
+        val clean = cleaned.nn
         if (clean.size < MIN_BEATS) {
             return HrvResult.empty(nInput)
         }
@@ -198,16 +297,13 @@ object HrvAnalyzer {
                 return HrvResult.empty(nInput)
             }
         }
-        val rmssd = rmssdRaw(clean)
+        // RMSSD and pNN50 are gap-aware: a successive difference across a dropped beat is skipped so a
+        // removed out-of-range/ectopic beat cannot splice its neighbours into a spurious delta. SDNN and
+        // meanNN use every clean beat (no successive differences), so they are unchanged.
+        val rmssd = rmssdGapAware(cleaned.nn, cleaned.contiguous)
         val sdnn = sdnnRaw(clean)
         val mean = clean.sum() / clean.size.toDouble()
-
-        // pNN50 over the clean NN series.
-        var nn50 = 0
-        for (i in 1 until clean.size) {
-            if (abs(clean[i] - clean[i - 1]) > 50.0) nn50 += 1
-        }
-        val pnn50 = nn50.toDouble() / (clean.size - 1).toDouble() * 100.0
+        val pnn50 = pnn50GapAware(cleaned.nn, cleaned.contiguous)
 
         return HrvResult(rmssd = rmssd, sdnn = sdnn, meanNN = mean, pnn50 = pnn50,
             nInput = nInput, nClean = clean.size)

--- a/android/app/src/main/java/com/noop/analytics/SleepStager.kt
+++ b/android/app/src/main/java/com/noop/analytics/SleepStager.kt
@@ -2140,7 +2140,8 @@ object SleepStager {
     }
 
     /** One 5-min HRV window: its start ts, the sleep stage at its center, the clean-beat count, and the
-     *  window RMSSD (null when <2 clean beats). Drives both [sessionAvgHRV] and the HRV test-mode trace. */
+     *  window RMSSD (null when fewer than 2 clean beats, or when every successive pair straddles a dropped
+     *  beat). Drives both [sessionAvgHRV] and the HRV test-mode trace. */
     data class HrvWindow(val startTs: Long, val stage: String, val cleanBeats: Int, val rmssd: Double?)
 
     /**
@@ -2175,11 +2176,14 @@ object SleepStager {
             // analyze() pipeline. The 0x2A37 RR on a WHOOP 5/MG is PPG-derived and noisier
             // than a 4.0's; rMSSD is built from SUCCESSIVE differences, so an un-rejected
             // jitter spike inflates the session HRV. Ectopic rejection drops those (#262/#235).
-            val cleaned = HrvAnalyzer.cleanRR(bucket)
-            val rmssd = if (cleaned.size >= 2) HrvAnalyzer.rmssdRaw(cleaned) else null
+            // Gap-aware: a dropped ectopic/out-of-range beat must not splice its two neighbours into a
+            // spurious successive difference, which is the exact spike the rejection above is meant to
+            // remove. See HrvAnalyzer.rmssdGapAware.
+            val cleaned = HrvAnalyzer.cleanRRGapAware(bucket)
+            val rmssd = if (cleaned.nn.size >= 2) HrvAnalyzer.rmssdGapAware(cleaned.nn, cleaned.contiguous) else null
             val center = t + windowS / 2
             val stage = stages.firstOrNull { center >= it.start && center < it.end }?.stage ?: "?"
-            out.add(HrvWindow(startTs = t, stage = stage, cleanBeats = cleaned.size, rmssd = rmssd))
+            out.add(HrvWindow(startTs = t, stage = stage, cleanBeats = cleaned.nn.size, rmssd = rmssd))
             t += windowS
         }
         return out

--- a/android/app/src/test/java/com/noop/analytics/HrvGapAwareTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/HrvGapAwareTest.kt
@@ -1,0 +1,129 @@
+package com.noop.analytics
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Gap-aware RMSSD/pNN50 (R-R optimization #1).
+ *
+ * When cleaning drops a beat (out-of-range or ectopic), its two neighbours become adjacent in the
+ * cleaned list. The plain successive-difference RMSSD then counts the difference ACROSS that splice as
+ * a real beat-to-beat delta, and because RMSSD squares each delta one splice can dominate the whole
+ * window and bias RMSSD high. These tests prove:
+ *   1. on a series with no drops the gap-aware result is identical to the plain result (no regression);
+ *   2. a beat dropped in the MIDDLE no longer splices its neighbours into a spurious delta;
+ *   3. the contiguity flags mark exactly the splice position;
+ *   4. drops only at the END leave every survivor contiguous (the shape the existing gate tests use).
+ */
+class HrvGapAwareTest {
+
+    // 1. No drops -> gap-aware equals plain, byte for byte.
+    @Test
+    fun cleanSeriesIsUnchanged() {
+        val rr = (0 until 30).map { 800.0 + (it % 5) * 20.0 } // 800..880, all in range, non-ectopic
+        val clean = HrvAnalyzer.cleanRR(rr)
+        assertEquals("fixture must have no drops", rr.size, clean.size)
+
+        val cleaned = HrvAnalyzer.cleanRRGapAware(rr)
+        assertEquals(clean, cleaned.nn)
+        assertTrue("no drops -> every survivor contiguous", cleaned.contiguous.drop(1).all { it })
+
+        val plain = HrvAnalyzer.rmssdRaw(clean)!!
+        val gapAware = HrvAnalyzer.analyzeRaw(rr).rmssd!!
+        assertEquals(plain, gapAware, 1e-9)
+    }
+
+    // 2. A dropped middle beat must not splice its neighbours (the core fix).
+    @Test
+    fun midSeriesDropDoesNotSplice() {
+        // 12x1000, one out-of-range 5000 (dropped by the range filter), 12x1100. The two 1000/1100 runs
+        // stay within 20% of each other so the ectopic filter keeps them; only the 5000 is removed.
+        val rr = List(12) { 1000.0 } + listOf(5000.0) + List(12) { 1100.0 }
+
+        val result = HrvAnalyzer.analyzeRaw(rr)
+        assertEquals(25, result.nInput)
+        assertEquals(24, result.nClean)
+        // Every kept successive difference is zero (within each flat run); the only nonzero delta is the
+        // 1000->1100 step across the removed beat, which is skipped -> RMSSD and pNN50 are 0.
+        assertNotNull(result.rmssd)
+        assertEquals(0.0, result.rmssd!!, 1e-9)
+        assertEquals(0.0, result.pnn50!!, 1e-9)
+
+        // The plain (splicing) RMSSD over the SAME cleaned beats is clearly nonzero: proves divergence.
+        val plainSpliced = HrvAnalyzer.rmssdRaw(HrvAnalyzer.cleanRR(rr))!!
+        assertTrue("plain RMSSD splices the 100 ms jump: $plainSpliced", plainSpliced > 10.0)
+    }
+
+    // 3. The contiguity flag is false only at the splice.
+    @Test
+    fun contiguityFlagMarksTheSplice() {
+        val rr = List(3) { 600.0 } + listOf(5000.0) + List(3) { 600.0 }
+        val cleaned = HrvAnalyzer.cleanRRGapAware(rr)
+        assertEquals(HrvAnalyzer.cleanRR(rr), cleaned.nn)
+        assertEquals(List(6) { 600.0 }, cleaned.nn)
+        // Survivors 0,1,2 then 4,5,6 in the source: the boundary between the 3rd and 4th is a splice.
+        assertEquals(listOf(false, true, true, false, true, true), cleaned.contiguous)
+    }
+
+    // 4. Primitive: a spliced pair is excluded from the mean of squared differences.
+    @Test
+    fun rmssdGapAwarePrimitiveSkipsSplice() {
+        val nn = listOf(500.0, 500.0, 1000.0, 1000.0)
+        val contiguous = listOf(false, true, false, true) // index 2 straddles a removed beat
+        assertEquals(0.0, HrvAnalyzer.rmssdGapAware(nn, contiguous)!!, 1e-9)
+        // Same values with the plain estimator DO count the 500 ms splice.
+        assertTrue(HrvAnalyzer.rmssdRaw(nn)!! > 100.0)
+
+        assertEquals(0.0, HrvAnalyzer.pnn50GapAware(nn, contiguous)!!, 1e-9)
+    }
+
+    // 5. End-only drops keep every survivor contiguous (matches the #585 gate-test fixtures).
+    @Test
+    fun endDropsKeepAllContiguous() {
+        val rr = List(24) { 800.0 } + List(6) { 100.0 } // 100 ms tail is out of range
+        val cleaned = HrvAnalyzer.cleanRRGapAware(rr)
+        assertEquals(24, cleaned.nn.size)
+        assertFalse(cleaned.contiguous[0])
+        assertTrue("no interior gap", cleaned.contiguous.drop(1).all { it })
+        assertEquals(HrvAnalyzer.rmssdRaw(cleaned.nn), HrvAnalyzer.rmssdGapAware(cleaned.nn, cleaned.contiguous))
+    }
+
+    // 6. Boundary cases: empty, all-dropped, series shorter than the ectopic window, single survivor,
+    //    and a two-beat pair that straddles a gap (zero valid pairs).
+    @Test
+    fun boundaryCases() {
+        val empty = HrvAnalyzer.cleanRRGapAware(emptyList())
+        assertTrue(empty.nn.isEmpty() && empty.contiguous.isEmpty())
+        assertNull(HrvAnalyzer.rmssdGapAware(empty.nn, empty.contiguous))
+        assertNull(HrvAnalyzer.pnn50GapAware(empty.nn, empty.contiguous))
+
+        val allDropped = HrvAnalyzer.cleanRRGapAware(List(10) { 5000.0 }) // all out of range
+        assertTrue(allDropped.nn.isEmpty())
+        assertNull(HrvAnalyzer.rmssdGapAware(allDropped.nn, allDropped.contiguous))
+
+        // Series shorter than the ectopic window is kept verbatim, matching cleanRR.
+        val tiny = listOf(800.0, 810.0)
+        val tinyClean = HrvAnalyzer.cleanRRGapAware(tiny)
+        assertEquals(HrvAnalyzer.cleanRR(tiny), tinyClean.nn)
+        assertEquals(listOf(false, true), tinyClean.contiguous)
+
+        // One survivor between two dropped beats: no successive pair, null RMSSD.
+        val single = HrvAnalyzer.cleanRRGapAware(listOf(5000.0, 800.0, 5000.0))
+        assertEquals(listOf(800.0), single.nn)
+        assertNull(HrvAnalyzer.rmssdGapAware(single.nn, single.contiguous))
+
+        // Two survivors whose only pair straddles a gap: zero valid pairs, null.
+        assertNull(HrvAnalyzer.rmssdGapAware(listOf(600.0, 900.0), listOf(false, false)))
+        assertNull(HrvAnalyzer.pnn50GapAware(listOf(600.0, 900.0), listOf(false, false)))
+    }
+
+    // 7. Mismatched-length inputs fail fast rather than silently miscounting.
+    @Test(expected = IllegalArgumentException::class)
+    fun mismatchedLengthThrows() {
+        HrvAnalyzer.rmssdGapAware(listOf(600.0, 900.0), listOf(true))
+    }
+}


### PR DESCRIPTION
## Summary

When the HRV cleaning drops an out-of-range or ectopic beat, its two surviving neighbours become adjacent in the compacted clean list, and the plain successive-difference RMSSD counts that spliced difference as a real beat-to-beat delta. Because RMSSD squares each delta, one removed beat injects a spurious large ΔNN that biases RMSSD and pNN50 high. This adds a gap-aware path that skips any successive difference straddling a dropped beat. On a series with no drops it is byte-identical to before, so clean data and the existing golden vectors are unchanged.

This is the analysis-side companion to the storage-side seq fix (#163): #163 stopped equal same-second intervals colliding at storage, this stops the cleaning splice at analysis. Both remove the same class of RMSSD high bias, from opposite sides.

## The fix

- `cleanRRGapAware` cleans exactly like `cleanRR` (byte-identical clean values), while tracking which beats were dropped via a per-beat contiguity flag.
- `rmssdGapAware` and `pnn50GapAware` skip any successive difference that straddles a gap and divide by the count of valid pairs. They are identical to the plain versions when there are no drops, and require equal-length inputs.
- Wired into `analyzeRaw` (spot, daytime, windowed HRV) and the nightly `SleepStager.sessionHrvWindows`. `SDNN` and `meanNN` use no successive differences and are untouched.

## Why exclusion, not interpolation

For a time-domain index, skipping the difference across a removed beat is the correct handling. Interpolating a replacement beat instead biases RMSSD low (Clifford and Tarassenko 2005). So the gap-aware path excludes rather than fills.

## Notes

- Swift parity: this is an intentional divergence from the Swift `HRVAnalyzer` on drop-containing data, documented in the file header. The Swift side should get the same change as a follow-up, the same pattern as #163 whose iOS parity landed in #185.
- Same splice class, out of scope here: `rollingRmssd`, the `HrvFreqDomain` tachogram, and the direct `rmssdRaw` calls in `RhythmScreener` and `ResonanceEngine` still compute over a plain-cleaned series. Left for follow-ups so this PR stays focused on the nightly and spot RMSSD path.
- Relates to #195: this reduces the "noop HRV reads roughly double WHOOP" over-read reported there. It does not address the deep-sleep-window part of that issue.

## Test plan

- New `HrvGapAwareTest` (7 cases): a mid-series drop no longer inflates RMSSD, clean data is byte-identical to the plain path, the contiguity flag marks exactly the splice, and boundary cases (empty, all-dropped, sub-window series, single survivor, zero valid pairs, mismatched-length guard) are asserted.
- Existing `HrvAnalyzerGateTest`, `HrvAnalyzerTraceTest`, and `SpotHrvReadingTest` pass unchanged, because their fixtures only drop beats at the tail or use uniform clean values, so they are not sensitive to the splice.
