### PR TITLE
HRV: per-night cleaning-pipeline summary in the always-on log (#195)

### DIFF
--- a/Strand/Data/IntelligenceEngine.swift
+++ b/Strand/Data/IntelligenceEngine.swift
@@ -422,7 +422,8 @@ final class IntelligenceEngine: ObservableObject {
         var scoredNights: [(daily: DailyMetric, strain: Double?, cachedSleep: [CachedSleepSession],
                             workouts: [ExerciseSession], nightlySkin: Double?,
                             sessionMotion: [Int: [Double]],
-                            sessionSleepState: [Int: [Int]])] = []
+                            sessionSleepState: [Int: [Int]],
+                            hrvDiag: String?)] = []   // #195: carried from loop 1, emitted in the main-actor loop
         // Nightly values harvested in pass 1, keyed by day, to seed the pass-2 baseline.
         var nightlyHrvByDay: [String: Double?] = [:]
         var nightlyRhrByDay: [String: Double?] = [:]
@@ -653,20 +654,26 @@ final class IntelligenceEngine: ObservableObject {
                                                      // ring buffer isn't flooded; every night keeps the summary.
                                                      hrvWindowDetail: dayStart == nowLocalMidnight,
                                                      deepHrvWindow: deepHrvWindow)
-                // #195: whole-night HRV cleaning-pipeline summary to the always-on strap log, so a "reads ~2x
+                // #195: whole-night HRV cleaning-pipeline summary for the always-on strap log, so a "reads ~2x
                 // too high" report is triageable without the HRV test mode: RMSSD vs SDNN (rmssd >> sdnn =
                 // beat-to-beat jitter surviving the ectopic filter, not real HRV), meanNN as an HR sanity-check,
                 // and how many R-R intervals survived cleaning (a low count also flags the sparse-capture /
-                // calibration side). A SEPARATE analyzer pass over the in-sleep R-R — does NOT touch the shipped
-                // windowed avgHrv. Emitted here (loop 1) where `rr` is in scope; byte-identical to the Kotlin line.
+                // calibration side — `nInput` is set before the min-beats gate, so a sparse night still shows
+                // its count with rmssd=nil). A SEPARATE analyzer pass over the in-sleep R-R — does NOT touch the
+                // shipped windowed avgHrv. Built here (loop 1) where `rr` is in scope, but EMITTED in the
+                // main-actor replay loop below (diagnosticSink is main-actor isolated), carried on `hrvDiag`.
+                // Byte-identical to the Kotlin line.
                 let sleepRr = rr.filter { r in res.cachedSleep.contains { r.ts >= $0.startTs && r.ts < $0.endTs } }
                     .map { Double($0.rrMs) }
-                if sleepRr.count >= HRVAnalyzer.minBeats {
+                let hrvDiag: String?
+                if sleepRr.isEmpty {
+                    hrvDiag = nil
+                } else {
                     let h = HRVAnalyzer.analyze(rawRR: sleepRr)
                     func ms(_ v: Double?) -> String { v.map { String(format: "%.0f", $0) } ?? "nil" }
                     let rej = h.nInput > 0 ? String(format: "%.0f", 100 * (1 - Double(h.nClean) / Double(h.nInput))) : "0"
-                    diagnosticSink?("hrv diag day=\(res.daily.day) rmssd=\(ms(h.rmssd))ms sdnn=\(ms(h.sdnn))ms "
-                                    + "meanNN=\(ms(h.meanNN))ms rr=\(h.nInput)/\(h.nClean) rejected=\(rej)%", nil)
+                    hrvDiag = "hrv diag day=\(res.daily.day) rmssd=\(ms(h.rmssd))ms sdnn=\(ms(h.sdnn))ms "
+                        + "meanNN=\(ms(h.meanNN))ms rr=\(h.nInput)/\(h.nClean) rejected=\(rej)%"
                 }
                 // ── Steps test mode: 5/MG raw-counter trace ──────────────────────────────────────────────
                 // Only built when the Steps mode is on (the gate was read once before the loop). Recomputes
@@ -740,7 +747,8 @@ final class IntelligenceEngine: ObservableObject {
             scoredNights.append((daily: res.daily, strain: res.strain, cachedSleep: res.cachedSleep,
                                  workouts: res.workouts, nightlySkin: res.nightlySkinTempC,
                                  sessionMotion: res.sessionMotionByStart,
-                                 sessionSleepState: res.sessionSleepStateByStart))
+                                 sessionSleepState: res.sessionSleepStateByStart,
+                                 hrvDiag: hrvDiag))
         }
 
         // ── Seed the baseline from the UNION of imported nightly history + the values just computed.
@@ -901,6 +909,8 @@ final class IntelligenceEngine: ObservableObject {
             // Counts-only (a rounded ms + the window), PII-free; byte-identical to the Kotlin line.
             let hrvLog = daily.avgHrv.map { String(format: "%.1f", $0) } ?? "nil"
             diagnosticSink?("hrv day=\(daily.day) window=\(deepHrvWindow ? "deep" : "whole") avgHrv=\(hrvLog)", nil)
+            // #195: the whole-night HRV cleaning summary built in loop 1 (rmssd vs sdnn / cleaning counts).
+            if let hrvDiagLine = night.hrvDiag { diagnosticSink?(hrvDiagLine, nil) }
             // ── CAPTURE-B: universal dayOwner self-diagnostic (#814/#799) ────────────────────────────────
             // ONE line per scored day, tagged `.universal` so it rides EVERY Test Centre export regardless
             // of which mode is on. It pins down the read/write split #814 is about: `readId` is the owner

--- a/Strand/Data/IntelligenceEngine.swift
+++ b/Strand/Data/IntelligenceEngine.swift
@@ -115,6 +115,10 @@ final class IntelligenceEngine: ObservableObject {
         /// deep-only vs last-SWS summary) for this day, collected off the main actor and replayed tagged
         /// `.hrv` in per-day order. Empty unless the HRV mode is active. (#141)
         let hrvTrace: [String]
+        /// #195: the ALWAYS-ON whole-night HRV cleaning summary (`hrv diag …`), built off the main actor
+        /// where `rr` is in scope and replayed through `diagnosticSink` in pass 2 (which is main-actor
+        /// isolated). nil when the night has no in-sleep R-R.
+        let hrvDiag: String?
     }
 
     struct Computed: Identifiable {
@@ -712,7 +716,8 @@ final class IntelligenceEngine: ObservableObject {
                 }
                 out.append(DayScan(result: res, rhrLine: rhrLine,
                                    readOwner: owner, hrRows: hr.count,
-                                   sleepTrace: sleepTrace, stepsTrace: stepsTrace, hrvTrace: hrvTrace))
+                                   sleepTrace: sleepTrace, stepsTrace: stepsTrace, hrvTrace: hrvTrace,
+                                   hrvDiag: hrvDiag))
             }
             return out
         }.value
@@ -748,7 +753,7 @@ final class IntelligenceEngine: ObservableObject {
                                  workouts: res.workouts, nightlySkin: res.nightlySkinTempC,
                                  sessionMotion: res.sessionMotionByStart,
                                  sessionSleepState: res.sessionSleepStateByStart,
-                                 hrvDiag: hrvDiag))
+                                 hrvDiag: scan.hrvDiag))
         }
 
         // ── Seed the baseline from the UNION of imported nightly history + the values just computed.

--- a/Strand/Data/IntelligenceEngine.swift
+++ b/Strand/Data/IntelligenceEngine.swift
@@ -653,6 +653,21 @@ final class IntelligenceEngine: ObservableObject {
                                                      // ring buffer isn't flooded; every night keeps the summary.
                                                      hrvWindowDetail: dayStart == nowLocalMidnight,
                                                      deepHrvWindow: deepHrvWindow)
+                // #195: whole-night HRV cleaning-pipeline summary to the always-on strap log, so a "reads ~2x
+                // too high" report is triageable without the HRV test mode: RMSSD vs SDNN (rmssd >> sdnn =
+                // beat-to-beat jitter surviving the ectopic filter, not real HRV), meanNN as an HR sanity-check,
+                // and how many R-R intervals survived cleaning (a low count also flags the sparse-capture /
+                // calibration side). A SEPARATE analyzer pass over the in-sleep R-R — does NOT touch the shipped
+                // windowed avgHrv. Emitted here (loop 1) where `rr` is in scope; byte-identical to the Kotlin line.
+                let sleepRr = rr.filter { r in res.cachedSleep.contains { r.ts >= $0.startTs && r.ts < $0.endTs } }
+                    .map { Double($0.rrMs) }
+                if sleepRr.count >= HRVAnalyzer.minBeats {
+                    let h = HRVAnalyzer.analyze(rawRR: sleepRr)
+                    func ms(_ v: Double?) -> String { v.map { String(format: "%.0f", $0) } ?? "nil" }
+                    let rej = h.nInput > 0 ? String(format: "%.0f", 100 * (1 - Double(h.nClean) / Double(h.nInput))) : "0"
+                    diagnosticSink?("hrv diag day=\(res.daily.day) rmssd=\(ms(h.rmssd))ms sdnn=\(ms(h.sdnn))ms "
+                                    + "meanNN=\(ms(h.meanNN))ms rr=\(h.nInput)/\(h.nClean) rejected=\(rej)%", nil)
+                }
                 // ── Steps test mode: 5/MG raw-counter trace ──────────────────────────────────────────────
                 // Only built when the Steps mode is on (the gate was read once before the loop). Recomputes
                 // the SAME wrap-aware @57 sum analyzeDay just ran, over the SAME `daySteps` calendar-day

--- a/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
+++ b/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
@@ -562,6 +562,22 @@ object IntelligenceEngine {
                 deepHrvWindow = deepHrvWindow,
             )
 
+            // #195: whole-night HRV cleaning-pipeline summary to the always-on strap log, so a "reads ~2x too
+            // high" report is triageable without the HRV test mode: RMSSD vs SDNN (rmssd >> sdnn = beat-to-beat
+            // jitter surviving the ectopic filter, not real HRV), meanNN as an HR sanity-check, and how many R-R
+            // intervals survived cleaning (a low count also flags the sparse-capture / calibration side). A
+            // SEPARATE analyzeRaw pass over the in-sleep R-R — does NOT touch the shipped windowed avgHrv.
+            // Emitted here where `rr` is in scope; byte-identical to the Swift line.
+            val sleepRr = rr.filter { r -> res.sleepSessions.any { r.ts >= it.start && r.ts < it.end } }
+                .map { it.rrMs.toDouble() }
+            if (sleepRr.size >= HrvAnalyzer.MIN_BEATS) {
+                val h = HrvAnalyzer.analyzeRaw(sleepRr)
+                val ms = { v: Double? -> v?.let { String.format(java.util.Locale.US, "%.0f", it) } ?: "nil" }
+                val rej = if (h.nInput > 0) String.format(java.util.Locale.US, "%.0f", 100.0 * (1.0 - h.nClean.toDouble() / h.nInput)) else "0"
+                diag("hrv diag day=${res.daily.day} rmssd=${ms(h.rmssd)}ms sdnn=${ms(h.sdnn)}ms meanNN=${ms(h.meanNN)}ms " +
+                    "rr=${h.nInput}/${h.nClean} rejected=$rej%")
+            }
+
             // Steps test mode: emit the 5/MG raw-counter trace for this day (cumulative @57 series +
             // wrap-aware deltas + dropped deltas), tagged .steps. Only when the mode is on (the sink is
             // non-null), so the default path emits zero .steps lines. The trace recomputes the SAME

--- a/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
+++ b/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
@@ -565,12 +565,13 @@ object IntelligenceEngine {
             // #195: whole-night HRV cleaning-pipeline summary to the always-on strap log, so a "reads ~2x too
             // high" report is triageable without the HRV test mode: RMSSD vs SDNN (rmssd >> sdnn = beat-to-beat
             // jitter surviving the ectopic filter, not real HRV), meanNN as an HR sanity-check, and how many R-R
-            // intervals survived cleaning (a low count also flags the sparse-capture / calibration side). A
-            // SEPARATE analyzeRaw pass over the in-sleep R-R — does NOT touch the shipped windowed avgHrv.
-            // Emitted here where `rr` is in scope; byte-identical to the Swift line.
+            // intervals survived cleaning (a low count also flags the sparse-capture / calibration side —
+            // `nInput` is set before the min-beats gate, so a sparse night still shows its count with
+            // rmssd=nil). A SEPARATE analyzeRaw pass over the in-sleep R-R — does NOT touch the shipped
+            // windowed avgHrv. Emitted here where `rr` is in scope; byte-identical to the Swift line.
             val sleepRr = rr.filter { r -> res.sleepSessions.any { r.ts >= it.start && r.ts < it.end } }
                 .map { it.rrMs.toDouble() }
-            if (sleepRr.size >= HrvAnalyzer.MIN_BEATS) {
+            if (sleepRr.isNotEmpty()) {
                 val h = HrvAnalyzer.analyzeRaw(sleepRr)
                 val ms = { v: Double? -> v?.let { String.format(java.util.Locale.US, "%.0f", it) } ?: "nil" }
                 val rej = if (h.nInput > 0) String.format(java.util.Locale.US, "%.0f", 100.0 * (1.0 - h.nClean.toDouble() / h.nInput)) else "0"


### PR DESCRIPTION
Follow-up to #202, aimed squarely at the **"HRV reads ~2× too high"** reports on #195 (now corroborated by two users against WHOOP *and* Google Fit).

## Why
#202 put the per-night value + window in the strap log (`hrv day=… window=… avgHrv=…`), but not the **R-R cleaning stats** that say *why* it's high. Those only exist in the HRV & Autonomic **test-mode** trace, which reporters rarely have emitting overnight — so a 2× report still can't be triaged from a normal log.

## What
A second **always-on** line per scored night, from a **separate whole-night analyzer pass over the in-sleep R-R** (does **not** touch the shipped windowed `avgHrv`):

```
hrv diag day=2026-07-09 rmssd=47ms sdnn=41ms meanNN=1180ms rr=340/290 rejected=15%
```

It triages the 2× in one line:
- **rmssd vs sdnn** — `rmssd >> sdnn` = beat-to-beat *jitter* surviving the ectopic filter (not real HRV); real HRV keeps them in the same ballpark.
- **meanNN** — HR sanity-check (≈1180 ms → ~51 bpm); rules out a units/scaling error.
- **rr = nInput/nClean + rejected%** — cleaning health; a low `nInput` also flags **sparse capture** (the calibration side of #195) in the same line.

## Notes
- **Additive, zero risk to shipped values** — it's a log-only `analyzeRaw` pass; the windowed `avgHrv` computation is untouched.
- **Swift + Kotlin twins**, both feeding the same `[Double]` rrMs list to the `analyzeRaw` / `analyze(rawRR:)` twin → byte-identical output. (Emitted next to the `analyzeDay` call, where `rr` is in scope, on both platforms.)
- Android `compileFullDebugKotlin` passes locally; Swift via app-build.

Refs #195, #202.