### PR TITLE
Fix #195: honour the deep-sleep HRV window on Android edit/backfill re-scores

### DIFF
--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -54,11 +54,13 @@ import com.noop.data.NapStore
 import com.noop.ingest.HealthConnectWriter
 import com.noop.notif.InactivityNotifier
 import com.noop.ui.BiofeedbackPrefs
+import com.noop.ui.HrvWindow
 import com.noop.ui.InactivityPrefs
 import com.noop.ui.NoopPrefs
 import com.noop.ui.NotifPrefs
 import com.noop.ui.ProfileStore
 import com.noop.ui.StressNudgeCenter
+import com.noop.ui.UnitPrefs
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -1282,6 +1284,12 @@ class WhoopBleClient(
                             .getLong(Baselines.hrvBaselineEpochKey, 0L).toDouble(),
                         recoveryEpoch = NoopPrefs.of(context)
                             .getLong(Baselines.recoveryBaselineEpochKey, 0L).toDouble(),
+                        // #195/#141: nightly HRV over deep-sleep windows only when the user picked WHOOP-style.
+                        // Read here (the analytics layer is Context-free) and thread it down, exactly like
+                        // baselineEpoch above — otherwise this post-backfill pass would recompute + persist every
+                        // night's HRV over the WHOLE night, silently overwriting the deep-window value the UI
+                        // loop just wrote (the "deep sleep window changes nothing" bug).
+                        deepHrvWindow = UnitPrefs.hrvWindow(context) == HrvWindow.DEEP_SLEEP,
                         // #691: route the engine's per-day diagnostics (incl. the new RHR floor-vs-mean
                         // line) into THIS sync's strap log, so a "NOOP RHR reads lower than my sleeping-HR
                         // app" report carries the proof — the floor (NOOP's WHOOP-style resting HR) beside

--- a/android/app/src/main/java/com/noop/ui/AppViewModel.kt
+++ b/android/app/src/main/java/com/noop/ui/AppViewModel.kt
@@ -1273,6 +1273,10 @@ class AppViewModel(app: Application) : AndroidViewModel(app) {
                     .getLong(Baselines.hrvBaselineEpochKey, 0L).toDouble(),
                 recoveryEpoch = NoopPrefs.of(appContext)
                     .getLong(Baselines.recoveryBaselineEpochKey, 0L).toDouble(),
+                // #195/#141: keep the HRV window consistent with the 15-min loop — without this a sleep edit
+                // would re-score + persist every night's HRV over the WHOLE night, silently overwriting the
+                // deep-window value (the "deep sleep window changes nothing" bug).
+                deepHrvWindow = UnitPrefs.hrvWindow(appContext) == HrvWindow.DEEP_SLEEP,
                 // Opt-in experimental sleep staging (V2) — same flag the 15-min loop reads, so a manual
                 // re-score after an edit stages with the same engine the user chose. (V7 Pillar 3b)
                 useExperimentalSleepV2 = PuffinExperiment.from(appContext).experimentalSleepV2,


### PR DESCRIPTION
## Problem (#195)

On Android, switching **HRV window → Deep sleep** appears to do nothing: the nightly HRV stays at (and re-reads to) the whole-night value, ~2× the WHOOP figure.

## Root cause

The Android analytics layer is deliberately Context-free, so **every caller** of `IntelligenceEngine.analyzeRecent` has to read the HRV-window pref and thread `deepHrvWindow` down itself — the same pattern already used for `baselineEpoch` / `recoveryEpoch` / `useExperimentalSleepV2`.

Only the 15-min UI loop (`AppViewModel`, ~L828) did so. The other two callers defaulted to `deepHrvWindow = false`:

- `AppViewModel.rescoreAfterEdit()` — runs after a sleep edit / manual nap / delete-undo
- `WhoopBleClient` post-backfill pass — runs right after every live sync

So after any live sync or sleep edit, those passes recomputed **and persisted** each night's HRV over the *whole* night, silently overwriting the deep-sleep value the loop had just written. Net effect: the Deep-sleep window never sticks.

## Fix

Thread `deepHrvWindow = UnitPrefs.hrvWindow(context) == HrvWindow.DEEP_SLEEP` through the two missing call sites (+ the two `com.noop.ui` imports `WhoopBleClient` was missing), mirroring the existing `baselineEpoch` threading exactly.

## Parity

**iOS/macOS are unaffected and need no change**: the Swift engine reads the pref *inside* `analyzeRecent` (`IntelligenceEngine.swift`), so all its callers already agree. This is why #195 is an Android-only report.

## Testing

- The bug is at the call-site plumbing level (the `AnalyticsEngine` computation already honours `deepHrvWindow` correctly), so a unit test on the engine wouldn't guard this regression — I deliberately didn't add a token test.
- I couldn't compile locally (no Android SDK on my machine); relying on CI for the build/typecheck.
- Needs on-device confirmation: switch to Deep sleep, do a live sync, verify the nightly HRV now reads the (lower) deep-only value and stays there after an edit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)