### PR TITLE
fix(hrv): gap-aware RMSSD/pNN50 on iOS/macOS to match Android (#204 twin)

### DIFF
--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/HRVAnalyzer.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/HRVAnalyzer.swift
@@ -141,6 +141,97 @@ public enum HRVAnalyzer {
         rejectEctopic(rangeFilter(rr))
     }
 
+    // MARK: - Gap-aware cleaning (successive-difference safety) — #204/#195
+
+    /// A cleaned NN series that remembers where beats were dropped. `nn` is byte-identical to `cleanRR`
+    /// over the same input. `contiguous` has the same length: `contiguous[i]` is true when `nn[i]` and
+    /// `nn[i-1]` were adjacent beats in the ORIGINAL series (no beat removed between them by the range or
+    /// ectopic filter) and false when a beat was dropped in between (a splice). Index 0 is always false.
+    public struct CleanSeries: Equatable, Sendable {
+        public let nn: [Double]
+        public let contiguous: [Bool]
+    }
+
+    /// Clean the RR series (range filter then Malik ectopic rejection, exactly like `cleanRR`) while
+    /// tracking which original beats were dropped, so a downstream successive-difference metric can skip
+    /// the difference across a removed beat. `CleanSeries.nn` equals `cleanRR` value for value. Kotlin twin
+    /// of `HrvAnalyzer.cleanRRGapAware`.
+    public static func cleanRRGapAware(_ rr: [Double]) -> CleanSeries {
+        // Pass 1: range filter, keeping each survivor's index in the ORIGINAL series.
+        var rangedIdx: [Int] = []; rangedIdx.reserveCapacity(rr.count)
+        var rangedVal: [Double] = []; rangedVal.reserveCapacity(rr.count)
+        for i in 0..<rr.count {
+            let v = rr[i]
+            if v >= rrMinMs && v <= rrMaxMs { rangedIdx.append(i); rangedVal.append(v) }
+        }
+        // Pass 2: Malik ectopic rejection over the range-filtered values, mirroring `rejectEctopic`
+        // (same windows, same median, same threshold) so the kept values match `cleanRR` exactly, while
+        // carrying each survivor's original index forward.
+        var keptOrig: [Int] = []; keptOrig.reserveCapacity(rangedVal.count)
+        var keptVal: [Double] = []; keptVal.reserveCapacity(rangedVal.count)
+        if rangedVal.count <= ectopicWindowRadius {
+            // rejectEctopic returns the input unchanged for a series this short.
+            for k in 0..<rangedVal.count { keptOrig.append(rangedIdx[k]); keptVal.append(rangedVal[k]) }
+        } else {
+            for i in 0..<rangedVal.count {
+                let lo = max(0, i - ectopicWindowRadius)
+                let hi = min(rangedVal.count - 1, i + ectopicWindowRadius)
+                var neighbours: [Double] = []; neighbours.reserveCapacity(hi - lo)
+                for j in lo...hi where j != i { neighbours.append(rangedVal[j]) }
+                let keep: Bool
+                if neighbours.count < 2 {
+                    keep = true
+                } else {
+                    let med = median(neighbours)
+                    keep = med <= 0 ? true : abs(rangedVal[i] - med) / med <= ectopicThreshold
+                }
+                if keep { keptOrig.append(rangedIdx[i]); keptVal.append(rangedVal[i]) }
+            }
+        }
+        // A survivor is contiguous with its predecessor only when their ORIGINAL indices are adjacent.
+        var contiguous: [Bool] = []; contiguous.reserveCapacity(keptVal.count)
+        for i in 0..<keptVal.count { contiguous.append(i > 0 && keptOrig[i] == keptOrig[i - 1] + 1) }
+        return CleanSeries(nn: keptVal, contiguous: contiguous)
+    }
+
+    /// Task Force RMSSD that counts a successive difference only when the two beats were adjacent in the
+    /// source (`CleanSeries.contiguous`). A difference spanning a dropped beat is skipped, so removing an
+    /// out-of-range/ectopic beat cannot splice its neighbours into a spurious delta. Identical to
+    /// `rmssdRaw` when there are no gaps. nil when no valid successive difference exists. Kotlin twin.
+    public static func rmssdGapAware(_ nn: [Double], _ contiguous: [Bool]) -> Double? {
+        precondition(nn.count == contiguous.count, "nn and contiguous must be the same length")
+        var sumSq = 0.0
+        var count = 0
+        var i = 1
+        while i < nn.count {
+            if contiguous[i] {
+                let d = nn[i] - nn[i - 1]
+                sumSq += d * d
+                count += 1
+            }
+            i += 1
+        }
+        return count < 1 ? nil : (sumSq / Double(count)).squareRoot()
+    }
+
+    /// pNN50 that counts a successive pair only when the two beats were adjacent in the source, skipping
+    /// any pair straddling a dropped beat. Identical to the plain pNN50 when there are no gaps. nil when
+    /// no valid successive pair exists. Kotlin twin of `HrvAnalyzer.pnn50GapAware`.
+    public static func pnn50GapAware(_ nn: [Double], _ contiguous: [Bool]) -> Double? {
+        precondition(nn.count == contiguous.count, "nn and contiguous must be the same length")
+        var nn50 = 0
+        var pairs = 0
+        var i = 1
+        while i < nn.count {
+            if contiguous[i] {
+                if abs(nn[i] - nn[i - 1]) > 50.0 { nn50 += 1 }
+                pairs += 1
+            }
+            i += 1
+        }
+        return pairs < 1 ? nil : Double(nn50) / Double(pairs) * 100.0
+    }
+
     // MARK: - Windowed analysis
 
     /// Compute HRV (RMSSD/SDNN/meanNN/pNN50) over the RR intervals whose ts falls
@@ -170,7 +261,8 @@ public enum HRVAnalyzer {
     ///   skips the gate entirely, so the nightly RMSSD is byte-identical to before this parameter existed.
     public static func analyze(rawRR: [Double], maxRejectedFraction: Double? = nil) -> HRVResult {
         let nInput = rawRR.count
-        let clean = cleanRR(rawRR)
+        let cleaned = cleanRRGapAware(rawRR)
+        let clean = cleaned.nn
         guard clean.count >= minBeats else {
             return .empty(nInput: nInput)
         }
@@ -182,14 +274,13 @@ public enum HRVAnalyzer {
                 return .empty(nInput: nInput)
             }
         }
-        let rmssd = rmssdRaw(clean)
+        // #204/#195: RMSSD and pNN50 are gap-aware — a successive difference across a dropped beat is
+        // skipped so a removed out-of-range/ectopic beat can't splice its neighbours into a spurious delta.
+        // SDNN and meanNN use every clean beat (no successive differences), so they are unchanged.
+        let rmssd = rmssdGapAware(cleaned.nn, cleaned.contiguous)
         let sdnn = sdnnRaw(clean)
         let mean = clean.reduce(0, +) / Double(clean.count)
-
-        // pNN50 over the clean NN series.
-        var nn50 = 0
-        for i in 1..<clean.count where abs(clean[i] - clean[i - 1]) > 50.0 { nn50 += 1 }
-        let pnn50 = Double(nn50) / Double(clean.count - 1) * 100.0
+        let pnn50 = pnn50GapAware(cleaned.nn, cleaned.contiguous)
 
         return HRVResult(rmssd: rmssd, sdnn: sdnn, meanNN: mean, pnn50: pnn50,
                          nInput: nInput, nClean: clean.count)

--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/SleepStager.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/SleepStager.swift
@@ -1935,11 +1935,13 @@ public enum SleepStager {
             // analyze() pipeline. The 0x2A37 RR on a WHOOP 5/MG is PPG-derived and noisier
             // than a 4.0's; rMSSD is built from SUCCESSIVE differences, so an un-rejected
             // jitter spike inflates the session HRV. Ectopic rejection drops those (#262/#235).
-            let cleaned = HRVAnalyzer.cleanRR(bucket)
-            let rmssd: Double? = (cleaned.count >= 2) ? HRVAnalyzer.rmssdRaw(cleaned) : nil
+            // #204/#195: gap-aware — a successive difference straddling a dropped beat is skipped so a
+            // removed out-of-range/ectopic beat can't splice its neighbours into a spurious delta.
+            let cleaned = HRVAnalyzer.cleanRRGapAware(bucket)
+            let rmssd: Double? = (cleaned.nn.count >= 2) ? HRVAnalyzer.rmssdGapAware(cleaned.nn, cleaned.contiguous) : nil
             let center = t + windowS / 2
             let stage = stages.first { center >= $0.start && center < $0.end }?.stage ?? "?"
-            out.append(HrvWindow(startTs: t, stage: stage, cleanBeats: cleaned.count, rmssd: rmssd))
+            out.append(HrvWindow(startTs: t, stage: stage, cleanBeats: cleaned.nn.count, rmssd: rmssd))
             t += windowS
         }
         return out

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/HrvGapAwareTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/HrvGapAwareTests.swift
@@ -1,0 +1,102 @@
+import XCTest
+@testable import StrandAnalytics
+
+/// Gap-aware RMSSD/pNN50 — the Swift twin of Android's `HrvGapAwareTest` (#204/#195).
+///
+/// When cleaning drops a beat (out-of-range or ectopic), its two neighbours become adjacent in the
+/// cleaned list. Plain successive-difference RMSSD counts the difference ACROSS that splice as a real
+/// beat-to-beat delta, and because RMSSD squares each delta one splice can dominate the window and bias
+/// RMSSD high. These prove: no-drop data is unchanged; a middle drop no longer splices; the contiguity
+/// flags mark exactly the splice; end-only drops leave every survivor contiguous; the boundary cases.
+///
+/// (Android's 7th case asserts the mismatched-length guard throws `IllegalArgumentException`; the Swift
+/// guard is a `precondition`, which traps rather than throws and can't be caught in XCTest, so it's
+/// intentionally not ported.)
+final class HrvGapAwareTests: XCTestCase {
+
+    // 1. No drops -> gap-aware equals plain, byte for byte.
+    func testCleanSeriesIsUnchanged() {
+        let rr = (0..<30).map { 800.0 + Double($0 % 5) * 20.0 } // 800..880, all in range, non-ectopic
+        let clean = HRVAnalyzer.cleanRR(rr)
+        XCTAssertEqual(clean.count, rr.count, "fixture must have no drops")
+
+        let cleaned = HRVAnalyzer.cleanRRGapAware(rr)
+        XCTAssertEqual(cleaned.nn, clean)
+        XCTAssertTrue(cleaned.contiguous.dropFirst().allSatisfy { $0 }, "no drops -> every survivor contiguous")
+
+        let plain = HRVAnalyzer.rmssdRaw(clean)!
+        let gapAware = HRVAnalyzer.analyze(rawRR: rr).rmssd!
+        XCTAssertEqual(gapAware, plain, accuracy: 1e-9)
+    }
+
+    // 2. A dropped middle beat must not splice its neighbours (the core fix).
+    func testMidSeriesDropDoesNotSplice() {
+        let rr = Array(repeating: 1000.0, count: 12) + [5000.0] + Array(repeating: 1100.0, count: 12)
+
+        let result = HRVAnalyzer.analyze(rawRR: rr)
+        XCTAssertEqual(result.nInput, 25)
+        XCTAssertEqual(result.nClean, 24)
+        XCTAssertNotNil(result.rmssd)
+        XCTAssertEqual(result.rmssd!, 0.0, accuracy: 1e-9)
+        XCTAssertEqual(result.pnn50!, 0.0, accuracy: 1e-9)
+
+        // The plain (splicing) RMSSD over the SAME cleaned beats is clearly nonzero: proves divergence.
+        let plainSpliced = HRVAnalyzer.rmssdRaw(HRVAnalyzer.cleanRR(rr))!
+        XCTAssertGreaterThan(plainSpliced, 10.0, "plain RMSSD splices the 100 ms jump")
+    }
+
+    // 3. The contiguity flag is false only at the splice.
+    func testContiguityFlagMarksTheSplice() {
+        let rr = Array(repeating: 600.0, count: 3) + [5000.0] + Array(repeating: 600.0, count: 3)
+        let cleaned = HRVAnalyzer.cleanRRGapAware(rr)
+        XCTAssertEqual(cleaned.nn, HRVAnalyzer.cleanRR(rr))
+        XCTAssertEqual(cleaned.nn, Array(repeating: 600.0, count: 6))
+        XCTAssertEqual(cleaned.contiguous, [false, true, true, false, true, true])
+    }
+
+    // 4. Primitive: a spliced pair is excluded from the mean of squared differences.
+    func testRmssdGapAwarePrimitiveSkipsSplice() {
+        let nn = [500.0, 500.0, 1000.0, 1000.0]
+        let contiguous = [false, true, false, true] // index 2 straddles a removed beat
+        XCTAssertEqual(HRVAnalyzer.rmssdGapAware(nn, contiguous)!, 0.0, accuracy: 1e-9)
+        XCTAssertGreaterThan(HRVAnalyzer.rmssdRaw(nn)!, 100.0)
+        XCTAssertEqual(HRVAnalyzer.pnn50GapAware(nn, contiguous)!, 0.0, accuracy: 1e-9)
+    }
+
+    // 5. End-only drops keep every survivor contiguous (matches the #585 gate-test fixtures).
+    func testEndDropsKeepAllContiguous() {
+        let rr = Array(repeating: 800.0, count: 24) + Array(repeating: 100.0, count: 6) // 100 ms tail is out of range
+        let cleaned = HRVAnalyzer.cleanRRGapAware(rr)
+        XCTAssertEqual(cleaned.nn.count, 24)
+        XCTAssertFalse(cleaned.contiguous[0])
+        XCTAssertTrue(cleaned.contiguous.dropFirst().allSatisfy { $0 }, "no interior gap")
+        XCTAssertEqual(HRVAnalyzer.rmssdGapAware(cleaned.nn, cleaned.contiguous), HRVAnalyzer.rmssdRaw(cleaned.nn))
+    }
+
+    // 6. Boundary cases: empty, all-dropped, sub-window series, single survivor, zero valid pairs.
+    func testBoundaryCases() {
+        let empty = HRVAnalyzer.cleanRRGapAware([])
+        XCTAssertTrue(empty.nn.isEmpty && empty.contiguous.isEmpty)
+        XCTAssertNil(HRVAnalyzer.rmssdGapAware(empty.nn, empty.contiguous))
+        XCTAssertNil(HRVAnalyzer.pnn50GapAware(empty.nn, empty.contiguous))
+
+        let allDropped = HRVAnalyzer.cleanRRGapAware(Array(repeating: 5000.0, count: 10)) // all out of range
+        XCTAssertTrue(allDropped.nn.isEmpty)
+        XCTAssertNil(HRVAnalyzer.rmssdGapAware(allDropped.nn, allDropped.contiguous))
+
+        // Series shorter than the ectopic window is kept verbatim, matching cleanRR.
+        let tiny = [800.0, 810.0]
+        let tinyClean = HRVAnalyzer.cleanRRGapAware(tiny)
+        XCTAssertEqual(tinyClean.nn, HRVAnalyzer.cleanRR(tiny))
+        XCTAssertEqual(tinyClean.contiguous, [false, true])
+
+        // One survivor between two dropped beats: no successive pair, nil RMSSD.
+        let single = HRVAnalyzer.cleanRRGapAware([5000.0, 800.0, 5000.0])
+        XCTAssertEqual(single.nn, [800.0])
+        XCTAssertNil(HRVAnalyzer.rmssdGapAware(single.nn, single.contiguous))
+
+        // Two survivors whose only pair straddles a gap: zero valid pairs, nil.
+        XCTAssertNil(HRVAnalyzer.rmssdGapAware([600.0, 900.0], [false, false]))
+        XCTAssertNil(HRVAnalyzer.pnn50GapAware([600.0, 900.0], [false, false]))
+    }
+}

--- a/android/app/src/main/java/com/noop/analytics/HrvAnalyzer.kt
+++ b/android/app/src/main/java/com/noop/analytics/HrvAnalyzer.kt
@@ -24,9 +24,9 @@ import kotlin.math.sqrt
  * (RMSSD, pNN50) must NOT count the difference across such a splice, or one removed beat injects a
  * spurious large delta that dominates the mean. [cleanRRGapAware] cleans while remembering where beats
  * were dropped, and [rmssdGapAware] / [pnn50GapAware] skip any difference that straddles a gap. On a
- * series with no drops these are identical to the plain versions, so clean data is unchanged. This is
- * an intentional divergence from the Swift twin, which still splices; porting the same change to
- * StrandAnalytics/HRVAnalyzer.swift is a follow-up.
+ * series with no drops these are identical to the plain versions, so clean data is unchanged. Kept in
+ * lockstep with the Swift twin `StrandAnalytics/HRVAnalyzer.cleanRRGapAware` / `rmssdGapAware` /
+ * `pnn50GapAware` (ported alongside; both platforms are gap-aware).
  *
  * Named [HrvAnalyzer] (NOT Hrv) to avoid clashing with the existing
  * com.noop.analytics.Hrv object in Analytics.kt. The two compute RMSSD the same


### PR DESCRIPTION
Swift/macOS twin of #204, which fixed gap-aware RMSSD/pNN50 on Android. Keeps the analytics byte-identical across platforms (parity contract).

## Why
When `cleanRR` drops an out-of-range or ectopic beat, its two neighbours become adjacent in the cleaned list. The plain successive-difference RMSSD then counts the difference *across that splice* as a real beat-to-beat delta — and because RMSSD squares each delta, one dropped beat can dominate the window and read HRV high. This is the ~2× over-read seen in #195 (NOOP >100 ms where other apps read 40–60 ms).

Android got the fix in #204; iOS/macOS still spliced, so the two platforms diverged. This closes that gap.

## What
- `HRVAnalyzer.cleanRRGapAware` returns a `CleanSeries` (`nn` + per-beat `contiguous` flag), remembering where beats were dropped. Kept values match `cleanRR` **exactly** (same range filter, same Malik ectopic rejection).
- `rmssdGapAware` / `pnn50GapAware` skip any successive difference that straddles a gap (exclusion, not interpolation — per Clifford & Tarassenko 2005). Identical to the plain estimators on no-drop data, so clean nights are unchanged. SDNN/meanNN use every clean beat (no successive differences), so they're untouched.
- `analyze(rawRR:)` and `SleepStager.sessionHrvWindows` now use the gap-aware path.
- Ports the 6 behavioural cases from Android `HrvGapAwareTest` to XCTest. (The 7th Android case asserts an `IllegalArgumentException`; the Swift guard is a `precondition`, which traps rather than throws and can't be caught in XCTest, so it's intentionally not ported.)
- Updates the Android `HrvAnalyzer` header note now that both platforms are gap-aware (the note previously flagged the Swift side as a follow-up).

## Verification
Analytics parity change, no BLE/hardware path touched. Covered by `swift-packages` CI (StrandAnalytics runs there) — the new `HrvGapAwareTests` mirror the Android suite. On no-drop data the gap-aware result is byte-identical to the previous plain result, so existing nights don't shift.