### PR TITLE
HC writer: require an explicit deviceId — drop the "my-whoop" default (follow-up to #179)

### DIFF
--- a/android/app/src/main/java/com/noop/ingest/HealthConnectWriter.kt
+++ b/android/app/src/main/java/com/noop/ingest/HealthConnectWriter.kt
@@ -68,11 +68,10 @@ object HealthConnectWriter {
      * throws SecurityException otherwise — callers wrap in runCatching).
      *
      * [deviceId] must be the registry's ACTIVE strap id (SPINE / #814): a wizard-paired strap banks
-     * rows under `whoop-<address>`, so the legacy "my-whoop" default reads empty tables and exports
-     * nothing. The default fits only legacy single-WHOOP installs, where the active id resolves to
-     * "my-whoop" anyway.
+     * rows under `whoop-<address>`, so a hardcoded legacy "my-whoop" id reads empty tables and
+     * exports nothing.
      */
-    suspend fun write(context: Context, repo: WhoopRepository, deviceId: String = "my-whoop"): Int {
+    suspend fun write(context: Context, repo: WhoopRepository, deviceId: String): Int {
         if (HealthConnectClient.getSdkStatus(context) != HealthConnectClient.SDK_AVAILABLE) return 0
         val client = HealthConnectClient.getOrCreate(context)
 


### PR DESCRIPTION
## What this PR does

Removes the `deviceId: String = "my-whoop"` default from `HealthConnectWriter.write()`, making the parameter required. The silent `"my-whoop"` fallback is the exact pattern behind the wizard-paired writeback bug #179 fixed (reads empty tables, exports nothing, invisibly — every insert is `runCatching`-wrapped). Since #179 all three call sites pass the registry-resolved active strap id explicitly, so the default is dead weight — and dropping it means a future caller can't reintroduce the bug by omission. The kdoc's two sentences justifying the default go with it.

No callers relied on the default: grep for `HealthConnectWriter.write(` finds only the three post-#179 sites (`AppViewModel` x2, `WhoopBleClient`), all passing `deviceId`. Tests don't call `write()` — it's the thin untestable HC-SDK layer per `HealthExportPlanTest`.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor / cleanup
- [ ] Documentation
- [ ] CI / tooling

## How it was tested

`./gradlew testFullDebugUnitTest assembleFullDebug` green, no new warnings. Signature-only change with all callers already conforming, so compilation is the meaningful check; no runtime behavior changes. Not on the BLE wire path.

## Checklist

- [x] Swift package tests pass for any package I touched (`swift test` in `Packages/<name>`)
- [x] Android unit tests pass if I touched `android/` (`./gradlew testFullDebugUnitTest`)
- [x] No new build warnings introduced
- [x] UI changes use only `StrandDesign` tokens — no hardcoded colors, fonts, or spacing
- [x] No hardcoded hex frame bytes; protocol facts live in the schema / decoders
- [x] Follows the conventions in [`docs/CONTRIBUTING.md`](../docs/CONTRIBUTING.md)
- [x] I did not commit generated output (`Strand.xcodeproj/`) or any secrets/keystores

## Related issues

Follow-up to #179.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
