### PR TITLE
#34: log the raw GET_ALARM_TIME response bytes on a successful readback decode too

### DIFF
--- a/Strand/BLE/FrameRouter.swift
+++ b/Strand/BLE/FrameRouter.swift
@@ -121,7 +121,13 @@ public final class FrameRouter {
                     // exactly as diagnostic. Labelled "strap reports", not "verified" (one firmware's
                     // answer format must never mislead a triage).
                     if let epoch = Self.armedAlarmEpoch(in: frame) {
-                        state.append(log: "Alarm: strap reports armed for \(Self.alarmLocalTime(epoch: epoch)) (epoch \(epoch))")
+                        // #34: log the RAW response bytes alongside the decoded epoch (previously only the
+                        // decode-FAILURE branch below carried them). A successful-but-mismatched decode — the
+                        // strap reporting a plausible epoch that never matches what we armed, the corrupted-
+                        // register signature — needs the raw frame to tell a genuinely-stored stale alarm from
+                        // a misdecode of a fixed response field. Log-only; the decode/behaviour is unchanged.
+                        let raw = Self.commandResponsePayloadHex(in: frame) ?? "empty"
+                        state.append(log: "Alarm: strap reports armed for \(Self.alarmLocalTime(epoch: epoch)) (epoch \(epoch)) [raw \(raw)]")
                         // #34: persist what the strap reports so the debug export can show sent-vs-reported.
                         let d = UserDefaults.standard
                         d.set(Int(epoch), forKey: "alarm.lastReportedEpoch")

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -3547,7 +3547,13 @@ class WhoopBleClient(
                 if (connectedFamily == DeviceFamily.WHOOP4 && respCmd?.startsWith("GET_ALARM_TIME") == true) {
                     val epoch = whoop4ArmedAlarmEpoch(frame)
                     if (epoch != null) {
-                        log("Alarm: strap reports armed for ${alarmReadbackLocalTime(epoch)} (epoch $epoch)")
+                        // #34: log the RAW response bytes alongside the decoded epoch (previously only the
+                        // decode-FAILURE branch below carried them). A successful-but-mismatched decode — the
+                        // strap reporting a plausible epoch that never matches what we armed, the corrupted-
+                        // register signature — needs the raw frame to tell a genuinely-stored stale alarm from
+                        // a misdecode of a fixed response field. Log-only; the decode/behaviour is unchanged.
+                        val raw = whoop4AlarmReadbackPayloadHex(frame) ?: "empty"
+                        log("Alarm: strap reports armed for ${alarmReadbackLocalTime(epoch)} (epoch $epoch) [raw $raw]")
                         // #34: persist what the strap reports so the debug export can show sent-vs-reported.
                         runCatching {
                             NoopPrefs.of(context).edit()


### PR DESCRIPTION
Diagnostic groundwork for #34 (smart alarm not buzzing).

## Why

Triaging the strap log attached to #34, the alarm frames are all well-formed (SET_CLOCK + the #535-verified 9-byte SET_ALARM_TIME are both sent), but every `GET_ALARM_TIME` readback decodes to a **constant stale epoch** (`1616904449` = 2021-03-28) that never matches what was armed — alongside a `strapClock … CLOCK-WARNING (446d behind wall)`. That's the corrupted-alarm-register / stale-RTC signature the `#34` reject-streak diagnostic already catches.

The blocker to confirming it: the raw response bytes are only logged when the decode **fails**. On a successful-but-mismatched decode (exactly this case) we log the interpreted epoch but not the frame — so a report can't distinguish a **genuinely-stored stale alarm** from a **misdecode of a fixed response field** by the defensive decoder.

## Change

Append the raw response payload hex to the `Alarm: strap reports armed for …` line on **both** platforms (`FrameRouter` / `WhoopBleClient`), reusing the existing `commandResponsePayloadHex` / `whoop4AlarmReadbackPayloadHex` helpers.

- **Log-only.** The decode and the arm behaviour are unchanged; the pure decoders (`armedAlarmEpoch` / `whoop4ArmedAlarmEpoch`, pinned by `AlarmReadbackDecodeTests`) are untouched.
- Mirrored across platforms since the readback log is a shared diagnostic.

## Verification

- `Strand` macOS app target **compiles** (`app-build.yml` is disabled, so app-target Swift has no default CI).
- Android mirror **not compiled locally** (no Android SDK) — relying on `android.yml`.
- No behaviour change → no test delta.

## Follow-up (not in this PR)

A GET_CLOCK readback log would confirm whether SET_CLOCK actually sticks (the stale-RTC half of the #34 hypothesis). Left out here to keep this change minimal and log-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)