### PR TITLE
DeviceRegistry: delete dead reconcileWhoopModel (follow-up to #180)

### DIFF
--- a/Strand/Data/DeviceRegistry.swift
+++ b/Strand/Data/DeviceRegistry.swift
@@ -102,17 +102,4 @@ final class DeviceRegistry: ObservableObject {
     func device(forPeripheralId peripheralId: String) -> PairedDevice? {
         (try? store.device(forPeripheralId: peripheralId)) ?? nil
     }
-
-    /// Refine the seeded neutral "WHOOP" model on the 'my-whoop' row to the strap the user actually
-    /// picked (migration v15 seeds a placeholder the app can't fill at migration time, since the
-    /// selected model lives in the app's UserDefaults). No-op when it already matches. Best-effort.
-    func reconcileWhoopModel(_ model: String) {
-        guard let rows = try? store.all(),
-              let existing = rows.first(where: { $0.id == "my-whoop" }),
-              existing.model != model else { return }
-        var updated = existing
-        updated.model = model
-        try? store.add(updated)
-        reload()
-    }
 }


### PR DESCRIPTION
## What this PR does

Deletes `DeviceRegistry.reconcileWhoopModel(_:)` — it has zero callers anywhere in the repo (grepped across `Strand/`, `StrandiOS*`, `Packages/`, `android/`; the only hit is the definition itself). The wiring it was written for never landed, so it's unreachable code carrying maintenance weight for nothing.

For the record, its doc comment's intent (in case someone wires it up later): migration v15 seeds a placeholder "WHOOP" model on the `my-whoop` row because the user's selected model lives in the app's UserDefaults, unavailable at migration time; this helper was meant to refine that placeholder to the actual strap model. Git history has the implementation if that ever becomes needed.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor / cleanup
- [ ] Documentation
- [ ] CI / tooling

## How it was tested

`xcodegen generate && xcodebuild -scheme Strand -configuration Debug build` succeeds; no new warnings (the few existing ones are in unrelated files and repro on main). Pure dead-code deletion — no runtime path exists to exercise, and nothing on the BLE path.

## Checklist

- [x] Swift package tests pass for any package I touched (`swift test` in `Packages/<name>`)
- [x] Android unit tests pass if I touched `android/` (`./gradlew testFullDebugUnitTest`)
- [x] No new build warnings introduced
- [x] UI changes use only `StrandDesign` tokens — no hardcoded colors, fonts, or spacing
- [x] No hardcoded hex frame bytes; protocol facts live in the schema / decoders
- [x] Follows the conventions in [`docs/CONTRIBUTING.md`](../docs/CONTRIBUTING.md)
- [x] I did not commit generated output (`Strand.xcodeproj/`) or any secrets/keystores

## Related issues

Follow-up to #180 (dead-code sweep noted during its review).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
