### PR TITLE
Tab re-tap: pop via NavigationPath instead of rebuilding the stack (#198)

### DIFF
--- a/Strand/App/RootView.swift
+++ b/Strand/App/RootView.swift
@@ -449,7 +449,12 @@ struct RootView: View {
     @ViewBuilder private var todayDetail: some View {
         #if os(macOS)
         NavigationStack {
-            if liquidTodayEnabled { LiquidTodayView() } else { TodayView() }
+            // Today's root-level links push TabRoute VALUES (#198), so this stack must register
+            // their destinations (once per stack — a double registration double-pushes, #38).
+            Group {
+                if liquidTodayEnabled { LiquidTodayView() } else { TodayView() }
+            }
+            .tabRouteDestinations()
         }
         #else
         TodayView()

--- a/Strand/App/TabRoute.swift
+++ b/Strand/App/TabRoute.swift
@@ -1,0 +1,63 @@
+import SwiftUI
+
+// MARK: - TabRoute
+//
+// Value-based routes for every push that leaves a primary tab's ROOT (#198, Path A). The iOS tab
+// shell binds each tab's `NavigationStack` to a `NavigationPath`, and a path only tracks pushes
+// made through it — a closure-destination `NavigationLink` bypasses the path entirely. So the
+// root-level links in the tab roots must push a VALUE for "re-tap the active tab" to pop back to
+// the root (#135) without the #197 rebuild. Deeper links stay closure-based on purpose: popping a
+// route off the path also pops everything pushed above it, so only the first hop needs a value.
+//
+// Shared with macOS because the tab roots (TodayView / LiquidTodayView / TrendsView) are the SAME
+// views the sidebar shell hosts — every `NavigationStack` that hosts one must register
+// `tabRouteDestinations()`, and must register it exactly ONCE: the same value type resolving
+// against two registrations in one stack double-pushes (see MetricExplorerView, #38).
+
+/// One first-hop destination reachable from a tab root. `Hashable` so it can ride a `NavigationPath`.
+enum TabRoute: Hashable {
+    /// The whole-day, full-resolution HR timeline (Liquid Today's live-HR card tap, #979).
+    case fullDayChart
+    /// One metric's detail page by `MetricCatalog` key — the same tap-through Today's cards and
+    /// Trends' small-multiples share. Each card opens ITS metric (2026-07-02: not the shared
+    /// Health screen).
+    case metric(String)
+    case metricExplorer
+    case workouts
+    case dataSources
+    case stress
+    case sleep
+    case health
+    case hydration
+    case coupled
+}
+
+extension View {
+    /// Maps every `TabRoute` push to its screen. Apply once to the ROOT content of each
+    /// `NavigationStack` that hosts a tab-root view (the iOS tab shell's stacks; the macOS
+    /// Today detail pane and TrendsView's own macOS wrap).
+    func tabRouteDestinations() -> some View {
+        navigationDestination(for: TabRoute.self) { route in
+            switch route {
+            case .fullDayChart: FullDayChartView()
+            case .metric(let key):
+                // Every caller passes a catalog key, so the fallback is theoretical; Health is the
+                // catch-all vitals surface. (Pre-#198 Trends fell back to the Explorer instead —
+                // unified here rather than carrying two never-taken branches.)
+                if let m = MetricCatalog.all.first(where: { $0.key == key }) {
+                    MetricDetailView(metric: m)
+                } else {
+                    HealthView()
+                }
+            case .metricExplorer: MetricExplorerView()
+            case .workouts: WorkoutsView()
+            case .dataSources: DataSourcesView()
+            case .stress: StressView()
+            case .sleep: SleepView()
+            case .health: HealthView()
+            case .hydration: HydrationView()
+            case .coupled: CoupledView()
+            }
+        }
+    }
+}

--- a/Strand/Liquid/LiquidTodayView.swift
+++ b/Strand/Liquid/LiquidTodayView.swift
@@ -460,7 +460,7 @@ struct LiquidTodayView: View {
             // "Full day" affordance so it's discoverable again. (This comment used to claim the Deep
             // Timeline already drew sleep + activity bands — it didn't at the time; the #979 spin-off
             // added that parity in FullDayChartView.)
-            NavigationLink { FullDayChartView() } label: {
+            NavigationLink(value: TabRoute.fullDayChart) {
                 card {
                     VStack(spacing: 10) {
                         // Isolated leaf: it observes LiveState so the ~1 Hz HR notifies re-render ONLY
@@ -513,67 +513,57 @@ struct LiquidTodayView: View {
     private func liquidCard(for card: DashboardCard) -> some View {
         switch card {
         case .stress:
-            cardLink(dest: StressView(), title: card.title, sub: card.subtitle,
+            cardLink(.stress, title: card.title, sub: card.subtitle,
                      value: stressText, tint: StrandPalette.accent, frac: fracOver(stress, 3))
         case .fitnessAge:
-            cardLink(dest: metricDetail("fitness_age"), title: card.title, sub: card.subtitle,
+            cardLink(.metric("fitness_age"), title: card.title, sub: card.subtitle,
                      value: unitText(fitnessAge, card.unit), tint: StrandPalette.chargeColor, frac: 0.5)
         case .vitality:
-            cardLink(dest: metricDetail("vitality"), title: card.title, sub: card.subtitle,
+            cardLink(.metric("vitality"), title: card.title, sub: card.subtitle,
                      value: intText(vitality), tint: liquidPurple, frac: frac(vitality))
         case .hrv:
-            cardLink(dest: metricDetail("hrv"), title: card.title, sub: card.subtitle,
+            cardLink(.metric("hrv"), title: card.title, sub: card.subtitle,
                      value: unitText(displayDay?.avgHrv, card.unit), tint: StrandPalette.metricCyan,
                      frac: fracOver(displayDay?.avgHrv, 120))
         case .restingHr:
-            cardLink(dest: metricDetail("rhr"), title: card.title, sub: card.subtitle,
+            cardLink(.metric("rhr"), title: card.title, sub: card.subtitle,
                      value: unitText(displayDay?.restingHr.map(Double.init), card.unit),
                      tint: StrandPalette.metricRose, frac: fracOver(displayDay?.restingHr.map(Double.init), 100))
         case .respiratory:
-            cardLink(dest: metricDetail("resp_rate"), title: card.title, sub: card.subtitle,
+            cardLink(.metric("resp_rate"), title: card.title, sub: card.subtitle,
                      value: unitText(displayDay?.respRateBpm, card.unit, decimals: 1),
                      tint: StrandPalette.accent, frac: fracOver(displayDay?.respRateBpm, 24))
         case .steps:
-            cardLink(dest: metricDetail("steps_est"), title: card.title, sub: card.subtitle,
+            cardLink(.metric("steps_est"), title: card.title, sub: card.subtitle,
                      value: stepsText, tint: StrandPalette.metricCyan, frac: fracOver(stepCount, 10000))
         case .bloodOxygen:
             // Not wired to a real read yet — render EMPTY (not half-full) so it doesn't imply a reading.
-            cardLink(dest: metricDetail("spo2"), title: card.title, sub: card.subtitle,
+            cardLink(.metric("spo2"), title: card.title, sub: card.subtitle,
                      value: "–", tint: StrandPalette.metricCyan, frac: nil)
         case .skinTemp:
-            cardLink(dest: metricDetail("skin_temp"), title: card.title, sub: card.subtitle,
+            cardLink(.metric("skin_temp"), title: card.title, sub: card.subtitle,
                      value: "–", tint: StrandPalette.metricAmber, frac: nil)
         case .calories:
-            cardLink(dest: metricDetail("active_kcal"), title: card.title, sub: card.subtitle,
+            cardLink(.metric("active_kcal"), title: card.title, sub: card.subtitle,
                      value: "–", tint: StrandPalette.metricAmber, frac: nil)
         case .sleep:
-            cardLink(dest: SleepView(), title: card.title, sub: card.subtitle,
+            cardLink(.sleep, title: card.title, sub: card.subtitle,
                      value: sleepText, tint: StrandPalette.restColor, frac: fracOver(displayDay?.totalSleepMin, 480))
         case .hydration:
-            cardLink(dest: HydrationView(), title: card.title, sub: card.subtitle,
+            cardLink(.hydration, title: card.title, sub: card.subtitle,
                      value: "–", tint: StrandPalette.metricCyan, frac: nil)
         case .coupled:
             // A tap-through to the full Coupled day screen. No value.
-            cardLink(dest: CoupledView(), title: card.title, sub: card.subtitle,
+            cardLink(.coupled, title: card.title, sub: card.subtitle,
                      value: "", tint: StrandPalette.chargeColor, frac: 0.6)
         }
     }
 
-    /// The per-metric detail page (its own data screen with chart + history), looked up by catalog key.
-    /// Each card opens ITS metric (2026-07-02: not the shared Health screen). Falls back to Health
-    /// only if the key is somehow absent from the catalog.
-    @ViewBuilder
-    private func metricDetail(_ key: String) -> some View {
-        if let m = MetricCatalog.all.first(where: { $0.key == key }) {
-            MetricDetailView(metric: m)
-        } else {
-            HealthView()
-        }
-    }
-
-    private func cardLink<Dest: View>(dest: Dest, title: String, sub: String,
-                                      value: String, tint: Color, frac: Double?) -> some View {
-        NavigationLink { dest } label: {
+    /// One card row pushing its `TabRoute` by value — the first hop off the Today root must ride
+    /// the tab's `NavigationPath` so a re-tap of the Today tab can pop it (#198; see TabRoute.swift).
+    private func cardLink(_ route: TabRoute, title: String, sub: String,
+                          value: String, tint: Color, frac: Double?) -> some View {
+        NavigationLink(value: route) {
             HStack(spacing: 12) {
                 LiquidVessel(value: frac, tint: tint, animated: false).frame(width: 30, height: 30)
                 VStack(alignment: .leading, spacing: 1) {
@@ -710,7 +700,7 @@ struct LiquidTodayView: View {
                 ktile(String(localized: "Rest HR"), intText(rhr), "bpm", StrandPalette.metricRose, fracOver(rhr, 100))
                 ktile(String(localized: "Steps"), stepsText, "", StrandPalette.chargeColor, fracOver(stepCount, 10000))
             }
-            NavigationLink { MetricExplorerView() } label: {
+            NavigationLink(value: TabRoute.metricExplorer) {
                 Text("Show all metrics").font(StrandFont.subhead).foregroundStyle(StrandPalette.accent)
                     .frame(maxWidth: .infinity).padding(.top, 2)
             }
@@ -747,7 +737,7 @@ struct LiquidTodayView: View {
         VStack(spacing: 8) {
             sectionHead("LAST WORKOUTS", trailing: "\(workouts.count) total")
             if let w = workouts.first {
-                NavigationLink { WorkoutsView() } label: { workoutCard(w) }
+                NavigationLink(value: TabRoute.workouts) { workoutCard(w) }
                     .buttonStyle(LiquidPressStyle())
             } else {
                 card {
@@ -784,7 +774,7 @@ struct LiquidTodayView: View {
     private var dataSourcesSection: some View {
         VStack(spacing: 8) {
             sectionHead("DATA SOURCES", trailing: "Provenance")
-            NavigationLink { DataSourcesView() } label: {
+            NavigationLink(value: TabRoute.dataSources) {
                 card {
                     VStack(spacing: 12) {
                         HStack {

--- a/Strand/Screens/TodayView.swift
+++ b/Strand/Screens/TodayView.swift
@@ -2006,34 +2006,25 @@ struct TodayView: View {
         switch card {
         case .stress:
             pinnedCardRow(icon: card.icon, tint: tint, title: card.title, subtitle: card.subtitle,
-                          value: dashboardValue(card)) { StressView() }
-        case .fitnessAge:
+                          value: dashboardValue(card), route: .stress)
+        case .fitnessAge, .vitality, .steps, .calories:
             pinnedCardRow(icon: card.icon, tint: tint, title: card.title, subtitle: card.subtitle,
-                          value: dashboardValue(card)) { HealthView() }
-        case .vitality:
-            pinnedCardRow(icon: card.icon, tint: tint, title: card.title, subtitle: card.subtitle,
-                          value: dashboardValue(card)) { HealthView() }
+                          value: dashboardValue(card), route: .health)
         case .hrv, .restingHr, .respiratory, .bloodOxygen, .skinTemp:
             // The overnight vitals share the Health detail screen (the vital-signs surface).
             pinnedCardRow(icon: card.icon, tint: tint, title: card.title, subtitle: card.subtitle,
-                          value: dashboardValue(card)) { HealthView() }
+                          value: dashboardValue(card), route: .health)
         case .sleep:
             pinnedCardRow(icon: card.icon, tint: tint, title: card.title, subtitle: card.subtitle,
-                          value: dashboardValue(card)) { SleepView() }
-        case .steps:
-            pinnedCardRow(icon: card.icon, tint: tint, title: card.title, subtitle: card.subtitle,
-                          value: dashboardValue(card)) { HealthView() }
-        case .calories:
-            pinnedCardRow(icon: card.icon, tint: tint, title: card.title, subtitle: card.subtitle,
-                          value: dashboardValue(card)) { HealthView() }
+                          value: dashboardValue(card), route: .sleep)
         case .hydration:
             pinnedCardRow(icon: card.icon, tint: tint, title: card.title, subtitle: card.subtitle,
-                          value: dashboardValue(card)) { HydrationView() }
+                          value: dashboardValue(card), route: .hydration)
         case .coupled:
             // The Coupled view row (#43) carries NO metric value, it is a tap-through to the full
             // coupled day screen. An empty value renders just the icon + title + subtitle + chevron.
             pinnedCardRow(icon: card.icon, tint: tint, title: card.title, subtitle: card.subtitle,
-                          value: dashboardValue(card)) { CoupledView() }
+                          value: dashboardValue(card), route: .coupled)
         }
     }
 
@@ -2125,14 +2116,13 @@ struct TodayView: View {
     }
 
     /// One WHOOP "My Dashboard" metric row: a thin-line tinted icon, an UPPERCASE tracked label over a grey
-    /// baseline caption, the big white value, and a chevron, the whole row navigates to `destination`. Flat
-    /// WHOOP styling (FrostedCardSurface, no glow), tokens only.
-    @ViewBuilder
-    private func pinnedCardRow<Dest: View>(icon: String, tint: Color, title: String, subtitle: String,
-                                           value: String, @ViewBuilder destination: @escaping () -> Dest) -> some View {
-        NavigationLink {
-            destination()
-        } label: {
+    /// baseline caption, the big white value, and a chevron, the whole row navigates to `route`. Flat
+    /// WHOOP styling (FrostedCardSurface, no glow), tokens only. Pushed by VALUE — the first hop off the
+    /// Today root must ride the tab's `NavigationPath` so a re-tap of the Today tab can pop it (#198;
+    /// see TabRoute.swift).
+    private func pinnedCardRow(icon: String, tint: Color, title: String, subtitle: String,
+                               value: String, route: TabRoute) -> some View {
+        NavigationLink(value: route) {
             HStack(spacing: 12) {
                 RoundedRectangle(cornerRadius: 9, style: .continuous)
                     .fill(tint.opacity(0.14))

--- a/Strand/Screens/TrendsView.swift
+++ b/Strand/Screens/TrendsView.swift
@@ -222,7 +222,9 @@ struct TrendsView: View {
         // (RootView), so — exactly like MetricExplorerView (#753) — wrap the scaffold in one here so the
         // pushes get Back chrome instead of hanging. The SAME shared scaffold renders on both.
         #if os(macOS)
-        NavigationStack { scaffold }
+        // Register the value routes at THIS stack's root; on iOS the tab shell's stack registers
+        // them instead (once per stack — a double registration double-pushes, #38).
+        NavigationStack { scaffold.tabRouteDestinations() }
         #else
         scaffold
         #endif
@@ -571,20 +573,9 @@ struct TrendsView: View {
         // LiquidPressStyle gives the physical settle-inward on press (the liquid tap language). The card's
         // own rich labels (title + chart series + footer stats) are surfaced by the link's button element,
         // with a hint that a tap opens the detail.
-        NavigationLink { metricDetail("recovery") } label: { card }
+        NavigationLink(value: TabRoute.metric("recovery")) { card }
             .buttonStyle(LiquidPressStyle())
             .accessibilityHint(Text(String(localized: "Opens the full Charge metric.")))
-    }
-
-    /// The per-metric detail page (chart + history) for a catalog key — the same tap-through target Today
-    /// and Explore use. Falls back to the metrics Explorer if the key isn't in the catalog.
-    @ViewBuilder
-    private func metricDetail(_ key: String) -> some View {
-        if let m = MetricCatalog.all.first(where: { $0.key == key }) {
-            MetricDetailView(metric: m)
-        } else {
-            MetricExplorerView()
-        }
     }
 
     // MARK: Small multiples — HRV / Resting HR / Day Strain
@@ -692,7 +683,7 @@ struct TrendsView: View {
         )
         // Each small-multiple taps through to its own metric detail (like Today's cards / Explore's rows),
         // with the liquid press settle. The chart itself is left uncluttered — no vessel over it (task).
-        NavigationLink { metricDetail(metricKey) } label: { card }
+        NavigationLink(value: TabRoute.metric(metricKey)) { card }
             .buttonStyle(LiquidPressStyle())
             .accessibilityHint(Text(String(localized: "Opens the full \(accessibilityTitle) metric.")))
     }

--- a/StrandiOS/App/RootTabView.swift
+++ b/StrandiOS/App/RootTabView.swift
@@ -21,14 +21,12 @@ struct RootTabView: View {
     /// Selected tab — bound so tab switches can crossfade (README §Motion: ~240ms opacity swap
     /// between tab roots, calm easing). Defaults to Today.
     @State private var selectedTab: Int = 0
-    /// Bumped per-tab when the user re-taps the already-active tab (#135). Feeds `.id()` on that
-    /// tab's `NavigationStack`, forcing SwiftUI to rebuild it from its root — the near-universal
-    /// iOS convention that re-tapping the active tab pops back to the tab's main page. Each tab's
-    /// stack is independent, so only the reselected tab rebuilds.
-    @State private var todayResetID = 0
-    @State private var trendsResetID = 0
-    @State private var sleepResetID = 0
-    @State private var moreResetID = 0
+    /// One `NavigationPath` per tab, indexed by tab tag. Re-tapping the already-active tab pops
+    /// that tab's stack to its root (#135) by clearing its path — an animated pop that leaves the
+    /// root view alive, so an at-root re-tap keeps scroll position and never re-runs `.task`
+    /// (#198; the #197 resetID/`.id()` rebuild reset both). Requires the tab roots' first-hop
+    /// links to push `TabRoute`/`MoreDestination` VALUES — closure-destination links bypass the path.
+    @State private var tabPaths: [NavigationPath] = Array(repeating: NavigationPath(), count: 4)
     /// Which More-tab groups are expanded (S2). Insights + Body stay open at rest; Data + App collapse to
     /// just their header until tapped. Persisted (#860 item 2): the user's open/closed choice must SURVIVE
     /// leaving and re-entering the More tab (and relaunch), not reset to the seed every visit. Backed by an
@@ -69,10 +67,10 @@ struct RootTabView: View {
             // cleanly in the gap between them — replaces the native tab bar: no overlap, no glow. The
             // native TabView still drives content + per-tab nav state; only its bar is hidden.
             TabView(selection: $selectedTab) {
-                tab(todayTabRoot, "Today", "square.grid.2x2", resetID: todayResetID).tag(0)
-                tab(TrendsView(), "Trends", "chart.line.uptrend.xyaxis", resetID: trendsResetID).tag(1)
-                tab(SleepView(), "Sleep", "bed.double", resetID: sleepResetID).tag(2)
-                moreTab(resetID: moreResetID).tag(3)
+                tab(todayTabRoot, "Today", "square.grid.2x2", path: $tabPaths[0]).tag(0)
+                tab(TrendsView(), "Trends", "chart.line.uptrend.xyaxis", path: $tabPaths[1]).tag(1)
+                tab(SleepView(), "Sleep", "bed.double", path: $tabPaths[2]).tag(2)
+                moreTab(path: $tabPaths[3]).tag(3)
             }
             .tint(StrandPalette.accent)
             .toolbar(.hidden, for: .tabBar)
@@ -96,15 +94,12 @@ struct RootTabView: View {
             )
 
             FloatingTabBar(selection: $selectedTab, onReselect: { tag in
-                // Re-tapping the active tab refreshes that page's data (2026-07-02) and pops its
-                // NavigationStack back to the root (#135) by bumping that tab's resetID.
+                // Re-tapping the active tab refreshes that page's data (2026-07-02) and, from a
+                // subpage, pops that tab's stack back to its root (#135) — an animated pop via the
+                // path, not a rebuild. At the root the pop is skipped, so scroll position survives
+                // and the refresh doesn't double with a re-run of the root's `.task` (#198).
                 Task { await repo.refresh() }
-                switch tag {
-                case 0: todayResetID += 1
-                case 1: trendsResetID += 1
-                case 2: sleepResetID += 1
-                default: moreResetID += 1
-                }
+                if !tabPaths[tag].isEmpty { tabPaths[tag] = NavigationPath() }
             })
         }
         .task {
@@ -193,6 +188,9 @@ struct RootTabView: View {
                 case .liveSession: LiquidTodayView()
                 }
             }
+            // The Trends/Today fallbacks above emit TabRoute value pushes (#198), which need a
+            // destination registered in THIS sheet's stack to resolve.
+            .tabRouteDestinations()
             .background(StrandPalette.surfaceBase.ignoresSafeArea())
             .navigationBarTitleDisplayMode(.inline)
             // #1027: same fix as quickScreen — the pillar screens draw the full-bleed liquid sky, so a
@@ -279,21 +277,22 @@ struct RootTabView: View {
         }
     }
 
-    private func tab<V: View>(_ view: V, _ title: LocalizedStringKey, _ icon: String, resetID: Int) -> some View {
+    private func tab<V: View>(_ view: V, _ title: LocalizedStringKey, _ icon: String,
+                              path: Binding<NavigationPath>) -> some View {
         // Each primary tab gets its OWN NavigationStack so the in-content NavigationLinks (e.g. the Today
         // dashboard card rows) both navigate AND render opaque. An ORPHANED NavigationLink (no
         // NavigationStack ancestor) renders its whole label in a disabled/translucent state — that was
         // washing the Today cards over the hero scene and dimming their text to grey (2026-06-23).
         // The root view hides the system nav bar (each screen draws its own in-content header); pushed
-        // detail screens get their own nav bar + back button.
-        NavigationStack {
+        // detail screens get their own nav bar + back button. The stack is bound to the tab's path so a
+        // re-tap of the active tab can pop it to the root (#135/#198); the roots' first-hop links push
+        // TabRoute values, registered here ONCE per stack (a double registration double-pushes, #38).
+        NavigationStack(path: path) {
             view
                 .background(StrandPalette.surfaceBase.ignoresSafeArea())
                 .toolbar(.hidden, for: .navigationBar)
+                .tabRouteDestinations()
         }
-        // #135: identity keyed on resetID, so bumping it (re-tap while active) tears down and
-        // rebuilds this stack from its root, popping any pushed subpage.
-        .id(resetID)
         .toolbar(.hidden, for: .tabBar)   // we draw our own FloatingTabBar
         .tabItem { Label(title, systemImage: icon) }
     }
@@ -303,39 +302,39 @@ struct RootTabView: View {
     // + SectionHeader's UPPERCASE overline + the 28pt section rhythm). Rebuilt on the shared page chrome:
     // ScreenScaffold for the title1 "More" + subtitle, a `SectionHeader` overline per group, and the group's
     // rows in a single grouped NoopCard with hairline dividers — the same row idiom Settings/Health use.
-    private func moreTab(resetID: Int) -> some View {
-        NavigationStack {
+    private func moreTab(path: Binding<NavigationPath>) -> some View {
+        NavigationStack(path: path) {
             ScreenScaffold(title: "More", subtitle: "Everything else, one tap away",
                            onRefresh: { await repo.refresh() },
                            topBackground: liquidScaffoldSky()) {
                 moreSection("Insights") {
-                    MoreRow("What Moves You", "wand.and.sparkles") { InsightsHubView() }
-                    MoreRow("Intelligence", "brain.head.profile") { IntelligenceView() }
-                    MoreRow("Coach", "sparkles") { CoachView() }
-                    MoreRow("Insights", "lightbulb.fill") { InsightsView() }
-                    MoreRow("Explore", "square.grid.2x2.fill") { MetricExplorerView() }
-                    MoreRow("Compare", "rectangle.split.2x1.fill") { CompareView() }
+                    MoreRow("What Moves You", "wand.and.sparkles", .insightsHub)
+                    MoreRow("Intelligence", "brain.head.profile", .intelligence)
+                    MoreRow("Coach", "sparkles", .coach)
+                    MoreRow("Insights", "lightbulb.fill", .insights)
+                    MoreRow("Explore", "square.grid.2x2.fill", .explore)
+                    MoreRow("Compare", "rectangle.split.2x1.fill", .compare)
                 }
                 moreSection("Body") {
-                    MoreRow("Live", "waveform.path.ecg") { LiveView() }
-                    MoreRow("Workouts", "figure.run") { WorkoutsView() }
-                    MoreRow("Health", "heart.text.square.fill") { HealthView() }
-                    MoreRow("Lab Book", "books.vertical.fill") { LabBookView() }
-                    MoreRow("Stress", "bolt.heart.fill") { StressView() }
-                    MoreRow("Breathe", "wind") { BreathingView() }
-                    MoreRow("Intervals", "timer") { IntervalTimerView() }
+                    MoreRow("Live", "waveform.path.ecg", .live)
+                    MoreRow("Workouts", "figure.run", .workouts)
+                    MoreRow("Health", "heart.text.square.fill", .health)
+                    MoreRow("Lab Book", "books.vertical.fill", .labBook)
+                    MoreRow("Stress", "bolt.heart.fill", .stress)
+                    MoreRow("Breathe", "wind", .breathe)
+                    MoreRow("Intervals", "timer", .intervals)
                     // Experimental beat-to-beat regularity visualization — self-gates on its own consent.
-                    MoreRow("Rhythm", "waveform.path") { RhythmHost() }
+                    MoreRow("Rhythm", "waveform.path", .rhythm)
                 }
                 moreSection("Data") {
-                    MoreRow("Your Data, Fused", "square.stack.3d.up.fill") { FusedRecordHost() }
-                    MoreRow("Apple Health", "heart.fill") { AppleHealthView() }
-                    MoreRow("Mi Band", "figure.walk.motion") { XiaomiBandView() }
-                    MoreRow("Data Sources", "externaldrive.fill") { DataSourcesView() }
-                    MoreRow("Backup & Sync", "externaldrive.fill.badge.icloud") { BackupSyncView() }
+                    MoreRow("Your Data, Fused", "square.stack.3d.up.fill", .fusedRecord)
+                    MoreRow("Apple Health", "heart.fill", .appleHealth)
+                    MoreRow("Mi Band", "figure.walk.motion", .miBand)
+                    MoreRow("Data Sources", "externaldrive.fill", .dataSources)
+                    MoreRow("Backup & Sync", "externaldrive.fill.badge.icloud", .backupSync)
                     // #155: HealthKit-free Apple Health path for sideloaded installs (Siri Shortcut
                     // reads the opt-in Documents/noop_sync.txt drop file).
-                    MoreRow("Shortcuts Export", "square.and.arrow.up.fill") { ShortcutExportSettingsView() }
+                    MoreRow("Shortcuts Export", "square.and.arrow.up.fill", .shortcutsExport)
                 }
                 moreSection("App") {
                     // #805/#811: the v7.3.1 #766 alarm consolidation moved Smart Alarm under a single
@@ -348,19 +347,30 @@ struct RootTabView: View {
                     // and project.yml excludes Screens/NotificationSettingsView.swift from the iOS target),
                     // so it can't compile or apply on iPhone. iPhone's wrist-alert controls live on the
                     // Automations screen instead. Its absence from the iPhone More list is correct.
-                    MoreRow("Alarms", "alarm.fill") { SmartAlarmView() }
-                    MoreRow("Automations", "wand.and.stars") { AutomationsView() }
+                    MoreRow("Alarms", "alarm.fill", .alarms)
+                    MoreRow("Automations", "wand.and.stars", .automations)
                     // The Test Centre (the diagnostics + bug-report hub) gets a first-class home here, not
                     // just buried in Settings, so the feedback loop is one tap from the More tab.
-                    MoreRow("Test Centre", "stethoscope") { TestCentreView() }
-                    MoreRow("Siri & Shortcuts", "mic.fill") { SiriShortcutsSettingsView() }
-                    MoreRow("Settings", "gearshape.fill") { SettingsView() }
+                    MoreRow("Test Centre", "stethoscope", .testCentre)
+                    MoreRow("Siri & Shortcuts", "mic.fill", .siriShortcuts)
+                    MoreRow("Settings", "gearshape.fill", .settings)
                 }
             }
             .toolbar(.hidden, for: .tabBar)   // we draw our own FloatingTabBar
+            // The rows push MoreDestination VALUES so a re-tap of the More tab can pop them off the
+            // bound path (#135/#198). Each destination keeps the per-screen wrapper the rows used to
+            // apply inline (surfaceBase background, inline title bar, hidden bar background):
+            // #1027 — a pushed sky-scaffold screen (Live, Workouts, Health, …) draws a full-bleed liquid
+            // sky; an opaque surfaceBase nav-bar band sat over it and clipped the top on scroll. A hidden
+            // bar background keeps the sky edge-to-edge. On the flat (no-sky) screens this is visually
+            // identical at rest — the destination's own surfaceBase background shows through the bar.
+            .navigationDestination(for: MoreDestination.self) { route in
+                route.destination
+                    .background(StrandPalette.surfaceBase.ignoresSafeArea())
+                    .navigationBarTitleDisplayMode(.inline)
+                    .toolbarBackground(.hidden, for: .navigationBar)
+            }
         }
-        // #135: same reset-on-reselect identity as the other tabs (see `tab(_:_:_:resetID:)`).
-        .id(resetID)
         .tabItem { Label("More", systemImage: "ellipsis.circle.fill") }
     }
 
@@ -419,32 +429,62 @@ struct RootTabView: View {
     }
 }
 
+/// Every screen the More index links to, as a `Hashable` value the tab's `NavigationPath` can carry
+/// (#198): a closure-destination push would bypass the path and be un-poppable on tab re-tap. The
+/// per-screen chrome the old inline links applied lives at the single `navigationDestination(for:)`
+/// registration in `moreTab`.
+private enum MoreDestination: Hashable {
+    case insightsHub, intelligence, coach, insights, explore, compare
+    case live, workouts, health, labBook, stress, breathe, intervals, rhythm
+    case fusedRecord, appleHealth, miBand, dataSources, backupSync, shortcutsExport
+    case alarms, automations, testCentre, siriShortcuts, settings
+
+    @ViewBuilder var destination: some View {
+        switch self {
+        case .insightsHub:     InsightsHubView()
+        case .intelligence:    IntelligenceView()
+        case .coach:           CoachView()
+        case .insights:        InsightsView()
+        case .explore:         MetricExplorerView()
+        case .compare:         CompareView()
+        case .live:            LiveView()
+        case .workouts:        WorkoutsView()
+        case .health:          HealthView()
+        case .labBook:         LabBookView()
+        case .stress:          StressView()
+        case .breathe:         BreathingView()
+        case .intervals:       IntervalTimerView()
+        case .rhythm:          RhythmHost()
+        case .fusedRecord:     FusedRecordHost()
+        case .appleHealth:     AppleHealthView()
+        case .miBand:          XiaomiBandView()
+        case .dataSources:     DataSourcesView()
+        case .backupSync:      BackupSyncView()
+        case .shortcutsExport: ShortcutExportSettingsView()
+        case .alarms:          SmartAlarmView()
+        case .automations:     AutomationsView()
+        case .testCentre:      TestCentreView()
+        case .siriShortcuts:   SiriShortcutsSettingsView()
+        case .settings:        SettingsView()
+        }
+    }
+}
+
 /// One tappable destination row in the More index. A `NavigationLink` whose label is the standard app row:
 /// the SF Symbol icon tinted `StrandPalette.accent`, the title in the body text colour, a `Spacer`, and a
 /// trailing `chevron.right` in `textTertiary`. ~44pt min height + the card's row insets keep the whole row a
-/// comfortable tap target. Each destination keeps the per-screen wrapper the old `link()` applied
-/// (`surfaceBase` background, inline title-bar, toolbar background) so pushed pages look identical to before.
-private struct MoreRow<Destination: View>: View {
+/// comfortable tap target.
+private struct MoreRow: View {
     let title: LocalizedStringKey
     let icon: String
-    @ViewBuilder let destination: () -> Destination
+    let route: MoreDestination
 
-    init(_ title: LocalizedStringKey, _ icon: String,
-         @ViewBuilder _ destination: @escaping () -> Destination) {
-        self.title = title; self.icon = icon; self.destination = destination
+    init(_ title: LocalizedStringKey, _ icon: String, _ route: MoreDestination) {
+        self.title = title; self.icon = icon; self.route = route
     }
 
     var body: some View {
-        NavigationLink {
-            destination()
-                .background(StrandPalette.surfaceBase.ignoresSafeArea())
-                .navigationBarTitleDisplayMode(.inline)
-                // #1027: a pushed sky-scaffold screen (Live, Workouts, Health, …) draws a full-bleed liquid
-                // sky; an opaque surfaceBase nav-bar band sat over it and clipped the top on scroll. A hidden
-                // bar background keeps the sky edge-to-edge. On the flat (no-sky) screens this is visually
-                // identical at rest — the destination's own surfaceBase background shows through the bar.
-                .toolbarBackground(.hidden, for: .navigationBar)
-        } label: {
+        NavigationLink(value: route) {
             HStack(spacing: 14) {
                 // Pin the icon to the accent explicitly. A plain inherited tint gets re-resolved by iOS to
                 // its default blue a beat after first render — so the icons flashed green→blue (#184). The


### PR DESCRIPTION
## What this PR does

Migrates tab re-tap navigation from #197's rebuild mechanism to the maintainer-spec'd **Path A** (#198): each tab's `NavigationStack` is bound to its own `NavigationPath`, and every first hop off a tab root pushes a `Hashable` value.

#197 implemented re-tap-returns-to-root by bumping a per-tab `resetID` fed to `.id()`, which tore down and rebuilt the tab's stack. That fixed the pop but at the costs #198 describes: an at-root re-tap reset scroll position and re-ran the root's `.task` (double-loading on top of the intended refresh), and the pop from a subpage was an unanimated teardown.

Now a re-tap refreshes and clears the path only when non-empty — an animated pop that leaves the root view alive, so scroll survives and `.task` never re-runs. Deeper links stay closure-based on purpose: popping the first-hop route pops everything above it.

Structure:
- `Strand/App/TabRoute.swift` (new): first-hop routes for the shared tab roots + `tabRouteDestinations()`, registered exactly once per stack (a double registration double-pushes, #38). Shared with macOS because the tab roots are the same views the sidebar shell hosts, so `RootView` / `TrendsView` register it for their own stacks.
- `StrandiOS/App/RootTabView.swift`: `resetID`/`.id()` → per-tab `NavigationPath` array; private `MoreDestination` enum for the More index, with the per-screen chrome (#1027) moved to its single `navigationDestination(for:)` registration.
- `LiquidTodayView` / `TodayView` / `TrendsView`: first-hop `NavigationLink` closures → value pushes; the duplicate `metricDetail` helpers collapse into the single `TabRoute.metric` destination.
- `StrandTests/TabRouteMetricKeyTests.swift` (new): pins that every catalog key the tab roots push through `TabRoute.metric` resolves in `MetricCatalog` — an unknown key silently falls back to the Health screen, which no build error would catch. The route→screen switch itself is SwiftUI view code, which this suite can't drive; the sim run below covers it.

Diff budget: +219/−143. The residual + is the route enums — making first-hop destinations explicit values is the point of Path A.

## Type of change

- [x] Bug fix
- [ ] New feature
- [x] Refactor / cleanup
- [ ] Documentation
- [ ] CI / tooling

## How it was tested

- macOS `Strand` scheme builds clean (Xcode 16.3) — no new warnings, none in touched files.
- `StrandTests` targeted run passes (`TabRouteMetricKeyTests` + the existing `MoreListParityTests`). Note for anyone reproducing: running `StrandTests` currently needs a `TEST_HOST` override on the `xcodebuild` command line — `project.yml` pins `TEST_HOST` to `NOOP.app` while the app's `PRODUCT_NAME` is `NOOP Staging` (pre-existing, unrelated to this diff).
- iOS 18.4 simulator (iPhone 16 Pro): ran `NOOPiOS` and verified both #198 behaviors, driving the app with HID-level touch events (`idb ui tap`/`swipe`):
  - re-tap from a subpage → animated pop back to the tab root
  - re-tap at the root → scroll position preserved, no root reload
- An earlier revision of the scroll GIF showed a jump-and-settle on the at-root re-tap. That was an artifact of the synthetic-tap driver used for that recording (an overscroll rubber-band at the list's bottom boundary — the signature bounce past the boundary and back), not app behavior: with HID-level taps the re-tap produces zero scroll movement, including on a diagnostic build that forced `Repository.refresh()` to publish on every re-tap (bypassing its unchanged-data skip) to rule out a refresh re-render moving the scroll. The GIF below is re-recorded with HID taps.
- Caveat: building for the iOS 18.4 SDK required locally stubbing a pre-existing iOS-26-only `glassEffect` use (Xcode 16.3 SDK limitation, unrelated to this diff); the stub is not part of this PR.
- Swift package tests: n/a — no packages touched.

| Subpage re-tap → animated pop | At-root re-tap → scroll preserved |
| --- | --- |
| ![pop](https://gist.githubusercontent.com/pagarsky/892fdde17d9d45ce6cd012e8c5af28bc/raw/tabnav_pop.gif) | ![scroll](https://gist.githubusercontent.com/pagarsky/892fdde17d9d45ce6cd012e8c5af28bc/raw/d43c85d3861601af2852c8c4c7262e42506e2641/tabnav_scroll.gif) |

## Checklist

- [x] Swift package tests pass for any package I touched (`swift test` in `Packages/<name>`)
- [x] Android unit tests pass if I touched `android/` (`./gradlew testFullDebugUnitTest`)
- [x] No new build warnings introduced
- [x] UI changes use only `StrandDesign` tokens — no hardcoded colors, fonts, or spacing
- [x] No hardcoded hex frame bytes; protocol facts live in the schema / decoders
- [x] Follows the conventions in [`docs/CONTRIBUTING.md`](../docs/CONTRIBUTING.md)
- [x] I did not commit generated output (`Strand.xcodeproj/`) or any secrets/keystores

## Related issues

Closes #198

🤖 Generated with [Claude Code](https://claude.com/claude-code)
