### PR TITLE
Add a "Restart strap" action on the connected device (#166)

### DIFF
--- a/Strand/App/AppModel.swift
+++ b/Strand/App/AppModel.swift
@@ -790,6 +790,9 @@ final class AppModel: ObservableObject {
         ble.connect(model: chosen)
     }
     func disconnect() { ble.disconnect() }
+    /// Restart the connected strap (user-initiated, confirmation-gated in DevicesView). Non-destructive —
+    /// the strap keeps its data and re-advertises after boot; NOOP auto-reconnects. See BLEManager.rebootStrap().
+    func rebootStrap() { ble.rebootStrap() }
 
     /// Drop the current strap and clear bond state so a newly-picked strap model connects fresh
     /// (lets a user with both a WHOOP 4 and a 5/MG switch between them).

--- a/Strand/BLE/BLEManager.swift
+++ b/Strand/BLE/BLEManager.swift
@@ -2212,6 +2212,9 @@ public final class BLEManager: NSObject, ObservableObject {
             log("reboot: connect + bond first — ignored (connected=\(state.connected) bonded=\(state.bonded))")
             return
         }
+        // Supersede any still-pending reboot (cancels its timers + resets the flag) so a repeat tap can't
+        // leave a stale watchdog/settle timer that fires during this new reboot's window.
+        clearRebootState()
         let framing = family == .whoop5 ? "puffin-crc16 (UNVERIFIED on 5/MG)" : "harvard-crc8"
         let fw = state.strapFirmware ?? "unknown"
         log("reboot: request family=\(family) fw=\(fw) connected=true bonded=true")

--- a/Strand/BLE/BLEManager.swift
+++ b/Strand/BLE/BLEManager.swift
@@ -1370,6 +1370,10 @@ public final class BLEManager: NSObject, ObservableObject {
             guard command == .toggleRealtimeHR || command == .runHapticsPattern
                 || command == .setAlarmTime || command == .getAlarmTime
                 || command == .runAlarm || command == .disableAlarm
+                // REBOOT_STRAP (29) over puffin: opcode shared with 4.0, framing is the puffin form built
+                // below. NOT hardware-confirmed on 5/MG — rebootStrap() logs the COMMAND_RESPONSE so a strap
+                // log confirms whether the frame is accepted. User-initiated + confirmation-gated only.
+                || command == .rebootStrap
                 || command == .sendHistoricalData || command == .historicalDataResult
                 || command == .setClock || command == .getClock
                 // SET_CONFIG (the R22 deep-stream unlock) is allowed ONLY while the deep-data
@@ -2169,6 +2173,65 @@ public final class BLEManager: NSObject, ObservableObject {
         }
     }
 
+    // MARK: Reboot (user-initiated, confirmation-gated) — see docs/PROTOCOL.md "Destructive commands"
+
+    /// Monotonic timestamp of the last user-requested reboot, or nil. Set when `rebootStrap()` sends the
+    /// command; consumed by `didDisconnectPeripheral` (to log how long the link stayed up = the strap acting
+    /// on the reboot) and by the connect handshake (to log the reconnect round-trip). Cleared on reconnect
+    /// or by the no-disconnect timeout. The whole point is a self-contained strap-log trail for a reboot,
+    /// so a "restart did nothing" report — especially on the unverified 5/MG framing — is triageable.
+    private var rebootRequestedAt: DispatchTime?
+    private var rebootTimeoutWork: DispatchWorkItem?
+
+    /// Restart the connected strap (REBOOT_STRAP / opcode 29, empty body). Non-destructive: the strap keeps
+    /// its stored data and re-advertises after boot, but the BLE link drops and NOOP auto-reconnects. Gated
+    /// to a connected + bonded strap; user-initiated and confirmation-gated at the call site (DevicesView).
+    ///
+    /// Emits a full debug trail to the strap log so a reboot is diagnosable end to end:
+    ///   `reboot: request …`  — family / firmware / link state at send time
+    ///   `reboot: sent …`     — opcode, framing (harvard-crc8 vs puffin-crc16), payload, seq
+    ///   `reboot: strap acked result=0x…` — the COMMAND_RESPONSE (FrameRouter), the accept/reject signal
+    ///                                        that caught 5/MG haptics rejection (result=0x03)
+    ///   `reboot: link dropped …` — didDisconnectPeripheral, proves the strap acted
+    ///   `reboot: no disconnect within …` — strap ignored it (esp. an unverified 5/MG frame)
+    ///   `reboot: reconnected …` — the connect handshake, round-trip complete
+    public func rebootStrap() {
+        let family = selectedModel.deviceFamily
+        guard state.connected, state.bonded, let p = peripheral, p.state == .connected else {
+            log("reboot: connect + bond first — ignored (connected=\(state.connected) bonded=\(state.bonded))")
+            return
+        }
+        let framing = family == .whoop5 ? "puffin-crc16 (UNVERIFIED on 5/MG)" : "harvard-crc8"
+        let fw = state.strapFirmware ?? "unknown"
+        log("reboot: request family=\(family) fw=\(fw) connected=true bonded=true")
+        log("reboot: sent opcode=29 framing=\(framing) payload=empty writeType=withResponse")
+        // Empty body per the official app's builder (rh0.C45476d0). .withResponse so the write itself is
+        // acknowledged at the ATT layer before the strap drops the link.
+        send(.rebootStrap, payload: [], writeType: .withResponse)
+        rebootRequestedAt = .now()
+        // No-disconnect watchdog: if the link is still up after 12 s the strap didn't act on the command —
+        // the key signal that a 5/MG puffin reboot frame was silently rejected. (A real reboot drops the
+        // link within a second or two.) Cancelled by didDisconnectPeripheral when the reboot takes.
+        let work = DispatchWorkItem { [weak self] in
+            guard let self, self.rebootRequestedAt != nil, self.state.connected else { return }
+            self.log("reboot: no disconnect within 12s — strap may have ignored the command"
+                     + (self.selectedModel.deviceFamily == .whoop5 ? " (5/MG puffin framing is unverified — please share this log on #166)" : ""))
+            self.rebootRequestedAt = nil
+        }
+        rebootTimeoutWork = work
+        DispatchQueue.main.asyncAfter(deadline: .now() + .seconds(12), execute: work)
+    }
+
+    /// Closes the reboot trail: when the connect handshake completes and a reboot was in flight, log the
+    /// full round-trip (send → reboot → reconnect) and clear the pending state. No-op otherwise.
+    private func noteRebootReconnectIfNeeded() {
+        guard let t = rebootRequestedAt else { return }
+        let s = Double(DispatchTime.now().uptimeNanoseconds &- t.uptimeNanoseconds) / 1_000_000_000
+        rebootRequestedAt = nil
+        rebootTimeoutWork?.cancel(); rebootTimeoutWork = nil
+        log(String(format: "reboot: reconnected %.1fs after send — round trip complete", s))
+    }
+
     private func startKeepAlive() {
         keepAliveTimer?.cancel()
         let s = BLEManager.keepAliveIntervalSeconds
@@ -2758,6 +2821,15 @@ extension BLEManager: @preconcurrency CBCentralManagerDelegate {
                                didDisconnectPeripheral peripheral: CBPeripheral,
                                error: Error?) {
         Task { @MainActor in await collector?.flush() }
+        // Reboot trail: if a user reboot is in flight, this drop is the strap acting on it. Log how long
+        // the link stayed up (a real reboot drops within ~1-2 s) and cancel the no-disconnect watchdog. The
+        // reconnect time is logged separately once the handshake completes. `rebootRequestedAt` stays set so
+        // the handshake can compute the round-trip; it's cleared there (or by the watchdog).
+        if let t = rebootRequestedAt {
+            let ms = Int(Double(DispatchTime.now().uptimeNanoseconds &- t.uptimeNanoseconds) / 1_000_000)
+            rebootTimeoutWork?.cancel(); rebootTimeoutWork = nil
+            log("reboot: link dropped \(ms)ms after send — reboot took effect; awaiting reconnect")
+        }
         // #80 marginal-radio detection: judge this drop BEFORE the state resets below clobber the
         // arm timestamp. A drop that is unintentional, error-bearing, and lands shortly after we armed
         // the R10/R11 burst is the marginal-radio tell. Feed the detector; if it trips, the NEXT connect
@@ -3217,6 +3289,7 @@ extension BLEManager: @preconcurrency CBPeripheralDelegate {
                 whoop5SessionStarted = true
                 connectHandshakeDone = true     // unblocks beginBackfill()'s guard
                 log("WHOOP 5/MG: connect handshake done — backfill unblocked")
+                noteRebootReconnectIfNeeded()
                 // Re-apply the Broadcast-HR device-config flag if the user opted in (#181).
                 if PuffinExperiment.broadcastHrEnabled { setBroadcastHr(true) }
                 // Clock the strap BEFORE history: an un-clocked WHOOP 5 discards sensor data ("RTC
@@ -3254,6 +3327,7 @@ extension BLEManager: @preconcurrency CBPeripheralDelegate {
         // type-47 fine because it runs the sequence once on a stable connection; the app stormed it.
         guard !connectHandshakeDone else { return }
         connectHandshakeDone = true
+        noteRebootReconnectIfNeeded()
         backfillStarted = true
 
         // WHOOP-faithful connect lifecycle: hello → set RTC,

--- a/Strand/BLE/BLEManager.swift
+++ b/Strand/BLE/BLEManager.swift
@@ -2182,6 +2182,17 @@ public final class BLEManager: NSObject, ObservableObject {
     /// so a "restart did nothing" report — especially on the unverified 5/MG framing — is triageable.
     private var rebootRequestedAt: DispatchTime?
     private var rebootTimeoutWork: DispatchWorkItem?
+    private var rebootSettleWork: DispatchWorkItem?
+
+    /// Clear all reboot-in-flight state: the pending timestamp, both timers, and the `rebootInProgress`
+    /// flag that drives the Devices "Reconnecting…" pill. Called from every terminal path (reconnect,
+    /// no-disconnect, settle backstop) so the pill can never wedge.
+    private func clearRebootState() {
+        rebootRequestedAt = nil
+        rebootTimeoutWork?.cancel(); rebootTimeoutWork = nil
+        rebootSettleWork?.cancel(); rebootSettleWork = nil
+        if state.rebootInProgress { state.rebootInProgress = false }
+    }
 
     /// Restart the connected strap (REBOOT_STRAP / opcode 29, empty body). Non-destructive: the strap keeps
     /// its stored data and re-advertises after boot, but the BLE link drops and NOOP auto-reconnects. Gated
@@ -2209,6 +2220,9 @@ public final class BLEManager: NSObject, ObservableObject {
         // acknowledged at the ATT layer before the strap drops the link.
         send(.rebootStrap, payload: [], writeType: .withResponse)
         rebootRequestedAt = .now()
+        // Drive the Devices "Reconnecting…" pill: true from here until the strap reconnects (or a terminal
+        // path clears it). The pill only shows it once the link actually drops (it gates on !connected).
+        state.rebootInProgress = true
         // No-disconnect watchdog: if the link is still up after 12 s the strap didn't act on the command —
         // the key signal that a 5/MG puffin reboot frame was silently rejected. (A real reboot drops the
         // link within a second or two.) Cancelled by didDisconnectPeripheral when the reboot takes.
@@ -2216,10 +2230,20 @@ public final class BLEManager: NSObject, ObservableObject {
             guard let self, self.rebootRequestedAt != nil, self.state.connected else { return }
             self.log("reboot: no disconnect within 12s — strap may have ignored the command"
                      + (self.selectedModel.deviceFamily == .whoop5 ? " (5/MG puffin framing is unverified — please share this log on #166)" : ""))
-            self.rebootRequestedAt = nil
+            self.clearRebootState()
         }
         rebootTimeoutWork = work
         DispatchQueue.main.asyncAfter(deadline: .now() + .seconds(12), execute: work)
+        // Absolute settle backstop: if the reboot never resolves (link dropped but the strap never comes
+        // back), clear the pill after 60 s so it can't wedge on "Reconnecting…". A normal reboot+reconnect
+        // completes well inside this and clears it earlier via noteRebootReconnectIfNeeded.
+        let settle = DispatchWorkItem { [weak self] in
+            guard let self, self.state.rebootInProgress else { return }
+            self.log("reboot: not settled within 60s — clearing the reconnecting state")
+            self.clearRebootState()
+        }
+        rebootSettleWork = settle
+        DispatchQueue.main.asyncAfter(deadline: .now() + .seconds(60), execute: settle)
     }
 
     /// Closes the reboot trail: when the connect handshake completes and a reboot was in flight, log the
@@ -2227,9 +2251,8 @@ public final class BLEManager: NSObject, ObservableObject {
     private func noteRebootReconnectIfNeeded() {
         guard let t = rebootRequestedAt else { return }
         let s = Double(DispatchTime.now().uptimeNanoseconds &- t.uptimeNanoseconds) / 1_000_000_000
-        rebootRequestedAt = nil
-        rebootTimeoutWork?.cancel(); rebootTimeoutWork = nil
         log(String(format: "reboot: reconnected %.1fs after send — round trip complete", s))
+        clearRebootState()   // clears the "Reconnecting…" pill → back to "Active · Live"
     }
 
     private func startKeepAlive() {

--- a/Strand/BLE/Commands.swift
+++ b/Strand/BLE/Commands.swift
@@ -4,9 +4,15 @@ import WhoopProtocol
 /// Curated, SAFE WHOOP command set for *sending* to the strap.
 ///
 /// Raw values are the on-wire command codes (from whoomp/scripts/packet.py `CommandNumber`).
-/// This is intentionally a *subset*: destructive / dangerous commands
-/// (reboot, firmware load, force-trim, ship-mode, power-cycle, fuel-gauge reset, BLE DFU)
-/// are deliberately EXCLUDED so the in-app command sender can never brick or wipe the device.
+/// This is intentionally a *subset*: DESTRUCTIVE commands that wipe data or brick the strap
+/// (firmware load/DFU, force-trim, ship-mode, power-cycle, fuel-gauge reset) stay deliberately
+/// EXCLUDED so the in-app command sender can never form those bytes.
+///
+/// The ONE exception is `rebootStrap` (29): a plain restart is non-destructive (the strap keeps
+/// its stored data and just re-advertises after boot), and NOOP already triggers a reboot today via
+/// `setAdvertisingNameHarvard` (rename applies on reboot). It is a deliberate, user-initiated,
+/// confirmation-gated action — never sent automatically. See `BLEManager.rebootStrap()` and the
+/// "Destructive commands" note in docs/PROTOCOL.md.
 public enum WhoopCommand: UInt8, CaseIterable {
     case toggleRealtimeHR      = 3
     case reportVersionInfo     = 7
@@ -15,6 +21,15 @@ public enum WhoopCommand: UInt8, CaseIterable {
     case sendHistoricalData    = 22
     case historicalDataResult  = 23
     case getBatteryLevel       = 26
+    /// REBOOT_STRAP (29) — restart the strap. Payload is an **empty body** (the official app's builder
+    /// `rh0.C45476d0` passes a null payload). The strap drops the BLE link and re-advertises after boot;
+    /// **stored data is kept** (non-destructive), but any in-flight offload is interrupted (chunk-acked,
+    /// so nothing is lost — it re-offloads on reconnect). Opcode 29 is shared across WHOOP 4.0 (harvard,
+    /// crc8) and 5/MG (puffin, crc16); the 4.0 form is confirmed from the app builder, the 5/MG framing is
+    /// NOT hardware-confirmed yet — `BLEManager.rebootStrap()` logs the strap's COMMAND_RESPONSE so a 5/MG
+    /// owner's strap log confirms whether the puffin frame is accepted. User-initiated + confirmation-gated
+    /// only; never sent automatically. Driven only by `BLEManager.rebootStrap()`.
+    case rebootStrap           = 29
     case getDataRange          = 34
     case getHelloHarvard       = 35
     /// WHOOP 5.0/MG hello (the puffin generation's GET_HELLO). The response carries the device name
@@ -91,6 +106,7 @@ public enum WhoopCommand: UInt8, CaseIterable {
         case .sendHistoricalData:    return "Send Historical Data"
         case .historicalDataResult:  return "Historical Data Result"
         case .getBatteryLevel:       return "Get Battery Level"
+        case .rebootStrap:           return "Reboot Strap"
         case .getDataRange:          return "Get Data Range"
         case .getHelloHarvard:       return "Get Hello (Harvard)"
         case .getHello:              return "Get Hello (5/MG)"

--- a/Strand/BLE/FrameRouter.swift
+++ b/Strand/BLE/FrameRouter.swift
@@ -105,6 +105,16 @@ public final class FrameRouter {
             // cmdName carries a "(rawValue)" suffix (Schema.enumName appends it, e.g.
             // "GET_ALARM_TIME(67)"), so match by prefix like every other cmdName consumer in the
             // codebase - never by equality, which is silently dead.
+            // Reboot ack (#166): log the COMMAND_RESPONSE result for a user reboot on BOTH families. This is
+            // the accept/reject signal — the same one that exposed 5/MG haptics rejection (result=0x03) — so
+            // a 5/MG owner's strap log confirms whether the (unverified) puffin reboot frame is accepted
+            // (0x00) or rejected. Log-only. A reboot that's accepted may drop the link before/after this ack.
+            if let cmd = parsed.cmdName, cmd.hasPrefix("REBOOT_STRAP") {
+                let r = Self.commandResultByte(in: frame)
+                let rhex = r.map { String(format: "0x%02x", UInt8(truncatingIfNeeded: $0)) } ?? "none"
+                let verdict = r == nil ? "no result byte" : (r == 0 ? "accepted" : "REJECTED")
+                state.append(log: "reboot: strap acked result=\(rhex) (\(verdict))")
+            }
             if family == .whoop4, let cmd = parsed.cmdName {
                 if cmd.hasPrefix("GET_ADVERTISING_NAME_HARVARD") {
                     if let name = Self.advertisingName(in: frame), !name.isEmpty {

--- a/Strand/BLE/LiveState.swift
+++ b/Strand/BLE/LiveState.swift
@@ -203,6 +203,11 @@ public final class LiveState: ObservableObject {
     /// cleared on disconnect so a stale version can't outlive the link. Twin of the Android
     /// LiveState.strapFirmware.
     @Published public var strapFirmware: String? = nil
+    /// True while a user-initiated reboot (#166) is in flight — from sending REBOOT_STRAP until the strap
+    /// reconnects (or the settle timeout gives up). Combined with `!connected` it drives the Devices
+    /// card's transient "Reconnecting…" pill so the restart reads as intentional. Twin of the Android
+    /// LiveState.rebootInProgress.
+    @Published public var rebootInProgress: Bool = false
     /// Transient, human-readable result of the most recent strap-rename attempt — the
     /// SET_ADVERTISING_NAME_HARVARD ack, or a local validation message from BLEManager.renameStrap.
     /// Surfaced under the rename field; overwritten by the next attempt.

--- a/Strand/Screens/DevicesView.swift
+++ b/Strand/Screens/DevicesView.swift
@@ -92,6 +92,8 @@ private struct DevicesContent: View {
                     device: device,
                     isActive: device.status == .active,
                     isLiveConnected: device.status == .active && live.connected,
+                    // Reboot in flight + link currently down → "Reconnecting…" (#166).
+                    isReconnecting: device.status == .active && live.rebootInProgress && !live.connected,
                     // The live battery belongs to whichever device is ACTIVE + connected (the WHOOP, a
                     // generic strap, or an FTMS machine all funnel into live.batteryPct). nil otherwise.
                     liveBatteryPct: (device.status == .active && live.connected) ? live.batteryPct.map { Int($0.rounded()) } : nil,
@@ -286,6 +288,9 @@ private struct DeviceCard: View {
     let device: PairedDevice
     let isActive: Bool
     let isLiveConnected: Bool
+    /// The active strap's link dropped for a user-initiated reboot and NOOP is auto-reconnecting (#166).
+    /// Drives the transient "Reconnecting…" pill; false for every non-reboot state.
+    var isReconnecting: Bool = false
     /// The active+connected device's live battery percent (0–100), surfaced on the card the same way
     /// for WHOOP, a generic strap, or an FTMS machine. nil when not the active/connected device or
     /// the source hasn't reported a battery (e.g. a strap/machine without the 0x180F service).
@@ -481,8 +486,15 @@ private struct DeviceCard: View {
             if device.status == .archived {
                 StatePill("Removed", tone: .neutral, showsDot: false)
             } else if isActive {
-                StatePill(isLiveConnected ? "Active · Live" : "Active",
-                          tone: .positive, pulsing: isLiveConnected)
+                // Reboot window (#166): the user's Restart dropped the link and NOOP is auto-reconnecting.
+                // Show it as intentional rather than a silent drop to "Active"; clears to "Active · Live"
+                // the instant the link is back.
+                if isReconnecting {
+                    StatePill("Reconnecting…", tone: .warning, pulsing: true)
+                } else {
+                    StatePill(isLiveConnected ? "Active · Live" : "Active",
+                              tone: .positive, pulsing: isLiveConnected)
+                }
             } else {
                 StatePill("Paired", tone: .neutral)
             }

--- a/Strand/Screens/DevicesView.swift
+++ b/Strand/Screens/DevicesView.swift
@@ -56,6 +56,7 @@ private struct DevicesContent: View {
     @State private var renameDraft = ""
     @State private var removeTarget: PairedDevice?
     @State private var deleteDataTarget: PairedDevice?
+    @State private var rebootTarget: PairedDevice?
     /// After removing the ACTIVE device with other devices still paired, prompt to pick a new active one.
     @State private var pickNewActive = false
 
@@ -102,7 +103,8 @@ private struct DevicesContent: View {
                     liveClockWarning: device.status == .active ? strapClockState?.warning : nil,
                     onMakeActive: { switchTarget = device },
                     onRename: { renameDraft = device.nickname ?? device.displayName; renameTarget = device },
-                    onRemove: { removeTarget = device })
+                    onRemove: { removeTarget = device },
+                    onReboot: { rebootTarget = device })
                     .staggeredAppear(index: idx)
             }
 
@@ -156,6 +158,16 @@ private struct DevicesContent: View {
             Button("Remove", role: .destructive) { confirmRemove(device) }
         } message: { device in
             Text("Remove \(device.displayName)? NOOP will stop connecting to it. Its recorded data is kept and you can re-add it any time.")
+        }
+        // Restart strap confirm (#166)
+        .alert("Restart this strap?",
+               isPresented: Binding(get: { rebootTarget != nil },
+                                    set: { if !$0 { rebootTarget = nil } }),
+               presenting: rebootTarget) { _ in
+            Button("Cancel", role: .cancel) { rebootTarget = nil }
+            Button("Restart") { model.rebootStrap(); rebootTarget = nil }
+        } message: { device in
+            Text("Restart \(device.displayName)? It disconnects for about 30 seconds while it reboots, then reconnects on its own. Your recorded data is kept. On WHOOP 5.0/MG this is experimental — if it doesn't restart, your strap log helps us confirm the command.")
         }
         // Second, strongly-worded delete-data confirm (reached from the Remove card's secondary control)
         .alert("Delete all of this device's data?",
@@ -292,6 +304,9 @@ private struct DeviceCard: View {
     var onMakeActive: () -> Void
     var onRename: () -> Void
     var onRemove: (() -> Void)?
+    /// Restart the strap (WHOOP-only, connected-only; confirmation-gated by the parent). nil for a
+    /// non-WHOOP source or a device that isn't the live-connected one. (#166)
+    var onReboot: (() -> Void)? = nil
     /// Removed-section affordances (re-add as active / delete its data).
     var onReAdd: (() -> Void)? = nil
     var onDeleteData: (() -> Void)? = nil
@@ -492,6 +507,11 @@ private struct DeviceCard: View {
                     Button { onMakeActive() } label: { Label("Make active", systemImage: "bolt.fill") }
                 }
                 Button { onRename() } label: { Label("Rename", systemImage: "pencil") }
+                // Restart the strap — only for the live-connected WHOOP (the reboot travels over the active
+                // BLE link). Confirmation-gated by the parent. (#166)
+                if isLiveConnected, SourceCoordinator.isWhoop(device), let onReboot {
+                    Button { onReboot() } label: { Label("Restart strap…", systemImage: "arrow.clockwise") }
+                }
                 if let onRemove {
                     Divider()
                     Button(role: .destructive) { onRemove() } label: {

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -123,6 +123,10 @@ data class LiveState(
      *  Devices card. Null until the handshake response decodes. The Swift WhoopProtocol decodes the
      *  same fields; this is the Android send → state → UI wiring. */
     val strapFirmware: String? = null,
+    /** True while a user-initiated reboot (#166) is in flight — from sending REBOOT_STRAP until the strap
+     *  reconnects (or the settle timeout gives up). With `!connected` it drives the Devices card's
+     *  transient "Reconnecting…" pill. Twin of macOS LiveState.rebootInProgress. */
+    val rebootInProgress: Boolean = false,
     /** Charging flag from BATTERY_LEVEL events — wire observation: u8 bit0 (4.0 @26 / 5.0 @30,
      *  ~every 8 min on captured links). Flag only; battery % keeps its family source (#77).
      *  Cleared on disconnect so a stale flag can't outlive the link. Twin of macOS
@@ -2353,6 +2357,17 @@ class WhoopBleClient(
      *  BLEManager.rebootRequestedAt. */
     private var rebootRequestedAtMs: Long? = null
     private var rebootWatchdog: Runnable? = null
+    private var rebootSettle: Runnable? = null
+
+    /** Clear all reboot-in-flight state: the pending timestamp, both timers, and the `rebootInProgress`
+     *  flag that drives the Devices "Reconnecting…" pill. Called from every terminal path (reconnect,
+     *  no-disconnect, settle backstop) so the pill can never wedge. Twin of macOS clearRebootState. */
+    private fun clearRebootState() {
+        rebootRequestedAtMs = null
+        rebootWatchdog?.let { handler.removeCallbacks(it) }; rebootWatchdog = null
+        rebootSettle?.let { handler.removeCallbacks(it) }; rebootSettle = null
+        if (_state.value.rebootInProgress) _state.update { it.copy(rebootInProgress = false) }
+    }
 
     /**
      * Restart the connected strap (REBOOT_STRAP / opcode 29, empty body). Non-destructive: the strap keeps
@@ -2375,6 +2390,9 @@ class WhoopBleClient(
         // Empty body per the official app's builder. withResponse so the ATT write is acked before the drop.
         send(CommandNumber.REBOOT_STRAP, byteArrayOf(), withResponse = true)
         rebootRequestedAtMs = SystemClock.elapsedRealtime()
+        // Drive the Devices "Reconnecting…" pill: true until the strap reconnects (or a terminal path
+        // clears it). The pill only shows it once the link actually drops (it gates on !connected).
+        _state.update { it.copy(rebootInProgress = true) }
         rebootWatchdog?.let { handler.removeCallbacks(it) }
         // No-disconnect watchdog: still connected after 12s ⇒ the strap didn't act on the command (the key
         // signal that a 5/MG puffin reboot frame was silently rejected). A real reboot drops within ~1-2s.
@@ -2382,11 +2400,22 @@ class WhoopBleClient(
             if (rebootRequestedAtMs != null && _state.value.connected) {
                 log("reboot: no disconnect within 12s — strap may have ignored the command" +
                     if (connectedFamily == DeviceFamily.WHOOP5) " (5/MG puffin framing is unverified — please share this log on #166)" else "")
-                rebootRequestedAtMs = null
+                clearRebootState()
             }
         }
         rebootWatchdog = work
         handler.postDelayed(work, 12_000)
+        // Absolute settle backstop: if the reboot never resolves (link dropped but the strap never comes
+        // back), clear the pill after 60s so it can't wedge on "Reconnecting…". A normal reboot+reconnect
+        // clears it earlier via noteRebootReconnectIfNeeded.
+        val settle = Runnable {
+            if (_state.value.rebootInProgress) {
+                log("reboot: not settled within 60s — clearing the reconnecting state")
+                clearRebootState()
+            }
+        }
+        rebootSettle = settle
+        handler.postDelayed(settle, 60_000)
     }
 
     /** Closes the reboot trail: when the connect handshake completes and a reboot was in flight, log the
@@ -2395,10 +2424,8 @@ class WhoopBleClient(
     private fun noteRebootReconnectIfNeeded() {
         val t = rebootRequestedAtMs ?: return
         val s = (SystemClock.elapsedRealtime() - t) / 1000.0
-        rebootRequestedAtMs = null
-        rebootWatchdog?.let { handler.removeCallbacks(it) }
-        rebootWatchdog = null
         log("reboot: reconnected %.1fs after send — round trip complete".format(s))
+        clearRebootState()   // clears the "Reconnecting…" pill → back to "Active · Live"
     }
 
     /**

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -2383,6 +2383,9 @@ class WhoopBleClient(
             log("reboot: connect + bond first — ignored (connected=${_state.value.connected} bonded=${_state.value.bonded})")
             return
         }
+        // Supersede any still-pending reboot (cancels its timers + resets the flag) so a repeat tap can't
+        // leave a stale watchdog/settle timer that fires during this new reboot's window.
+        clearRebootState()
         val framing = if (family == DeviceFamily.WHOOP5) "puffin-crc16 (UNVERIFIED on 5/MG)" else "harvard-crc8"
         val fw = _state.value.strapFirmware ?: "unknown"
         log("reboot: request family=$family fw=$fw connected=true bonded=true")

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -22,6 +22,7 @@ import androidx.core.content.ContextCompat
 import android.os.Handler
 import android.os.Looper
 import android.os.ParcelUuid
+import android.os.SystemClock
 import android.util.Log
 import com.noop.data.HrRow
 import com.noop.data.RrRow
@@ -2016,6 +2017,10 @@ class WhoopBleClient(
                 cmd != CommandNumber.SET_CLOCK && cmd != CommandNumber.GET_CLOCK &&
                 cmd != CommandNumber.GET_DATA_RANGE &&
                 cmd != CommandNumber.SET_ALARM_TIME && cmd != CommandNumber.DISABLE_ALARM &&
+                // REBOOT_STRAP (29) over puffin: opcode shared with 4.0, framing is the puffin form built
+                // below. NOT hardware-confirmed on 5/MG — rebootStrap() logs the COMMAND_RESPONSE so a strap
+                // log confirms whether the frame is accepted. User-initiated + confirmation-gated only.
+                cmd != CommandNumber.REBOOT_STRAP &&
                 // SET_CONFIG (the R22 deep-stream unlock) is allowed ONLY while the deep-data experiment
                 // is opted in — it writes a persistent feature flag to the strap, so it must never fire
                 // on a default install. Reversible; driven only by enableWhoop5DeepData(). (#174)
@@ -2338,6 +2343,62 @@ class WhoopBleClient(
         _state.update { it.copy(
             renameStatus = "Sent - your strap will reboot to apply, then reconnect with the new name.",
         ) }
+    }
+
+    // Reboot (user-initiated, confirmation-gated) — see docs/PROTOCOL.md "Destructive commands".
+
+    /** elapsedRealtime (ms) of the last user reboot, or null. Set by [rebootStrap]; consumed by the
+     *  disconnect handler (link-up duration = the strap acting on the reboot) and the connect handshake
+     *  (the reconnect round-trip). Cleared on reconnect or the no-disconnect watchdog. Twin of macOS
+     *  BLEManager.rebootRequestedAt. */
+    private var rebootRequestedAtMs: Long? = null
+    private var rebootWatchdog: Runnable? = null
+
+    /**
+     * Restart the connected strap (REBOOT_STRAP / opcode 29, empty body). Non-destructive: the strap keeps
+     * its stored data and re-advertises after boot; the BLE link drops and NOOP auto-reconnects. Gated to a
+     * connected + bonded strap; user-initiated and confirmation-gated at the call site (DevicesScreen).
+     * Twin of macOS BLEManager.rebootStrap — emits the same reboot trail (request / sent / ack / link
+     * dropped / reconnected) so a "restart did nothing" report, especially on the unverified 5/MG puffin
+     * framing, is triageable from a strap log.
+     */
+    fun rebootStrap() {
+        val family = connectedFamily
+        if (!_state.value.connected || !_state.value.bonded || gatt == null) {
+            log("reboot: connect + bond first — ignored (connected=${_state.value.connected} bonded=${_state.value.bonded})")
+            return
+        }
+        val framing = if (family == DeviceFamily.WHOOP5) "puffin-crc16 (UNVERIFIED on 5/MG)" else "harvard-crc8"
+        val fw = _state.value.strapFirmware ?: "unknown"
+        log("reboot: request family=$family fw=$fw connected=true bonded=true")
+        log("reboot: sent opcode=29 framing=$framing payload=empty writeType=withResponse")
+        // Empty body per the official app's builder. withResponse so the ATT write is acked before the drop.
+        send(CommandNumber.REBOOT_STRAP, byteArrayOf(), withResponse = true)
+        rebootRequestedAtMs = SystemClock.elapsedRealtime()
+        rebootWatchdog?.let { handler.removeCallbacks(it) }
+        // No-disconnect watchdog: still connected after 12s ⇒ the strap didn't act on the command (the key
+        // signal that a 5/MG puffin reboot frame was silently rejected). A real reboot drops within ~1-2s.
+        val work = Runnable {
+            if (rebootRequestedAtMs != null && _state.value.connected) {
+                log("reboot: no disconnect within 12s — strap may have ignored the command" +
+                    if (connectedFamily == DeviceFamily.WHOOP5) " (5/MG puffin framing is unverified — please share this log on #166)" else "")
+                rebootRequestedAtMs = null
+            }
+        }
+        rebootWatchdog = work
+        handler.postDelayed(work, 12_000)
+    }
+
+    /** Closes the reboot trail: when the connect handshake completes and a reboot was in flight, log the
+     *  full round-trip (send → reboot → reconnect) and clear the pending state. No-op otherwise. Twin of
+     *  macOS BLEManager.noteRebootReconnectIfNeeded. */
+    private fun noteRebootReconnectIfNeeded() {
+        val t = rebootRequestedAtMs ?: return
+        val s = (SystemClock.elapsedRealtime() - t) / 1000.0
+        rebootRequestedAtMs = null
+        rebootWatchdog?.let { handler.removeCallbacks(it) }
+        rebootWatchdog = null
+        log("reboot: reconnected %.1fs after send — round trip complete".format(s))
     }
 
     /**
@@ -3202,6 +3263,7 @@ class WhoopBleClient(
             // WHOOP 5.0/MG uses CLIENT_HELLO, not this WHOOP4 command sequence, so it is skipped for it.
             if (!connectHandshakeDone && connectedFamily == DeviceFamily.WHOOP4) {
                 connectHandshakeDone = true
+                noteRebootReconnectIfNeeded()
                 runConnectHandshake()
             }
 
@@ -3519,6 +3581,18 @@ class WhoopBleClient(
                 }
                 val respCmd = parsed.parsed["resp_cmd"] as? String
                 val result = parsed.parsed["result"] as? String
+                // Reboot ack (#166): log the COMMAND_RESPONSE result for a user reboot on BOTH families —
+                // the accept/reject signal (the same one that exposed 5/MG haptics rejection). So a 5/MG
+                // owner's strap log confirms whether the (unverified) puffin reboot frame is accepted. The
+                // decoded result name is Android's richer twin of the macOS raw result byte. Log-only.
+                if (respCmd?.startsWith("REBOOT_STRAP") == true) {
+                    val verdict = when {
+                        result == null -> "no result"
+                        result.startsWith("SUCCESS") -> "accepted"
+                        else -> "REJECTED"
+                    }
+                    log("reboot: strap acked result=${result ?: "none"} ($verdict)")
+                }
                 // 5/MG range-query gate: a GET_DATA_RANGE SUCCESS releases the history request
                 // (PENDING precedes it; the 2s fail-open fallback covers a swallowed reply). (#78 fork)
                 if (connectedFamily == DeviceFamily.WHOOP5 && backfilling && !historicalKickSent &&
@@ -4275,6 +4349,7 @@ class WhoopBleClient(
             // once-per-connection (keep-alive resubscribes also land here). (#78 fork, hardware-proven)
             if (connectedFamily == DeviceFamily.WHOOP5 && didBond && !connectHandshakeDone) {
                 connectHandshakeDone = true
+                noteRebootReconnectIfNeeded()
                 send(CommandNumber.SET_CLOCK, setClockPayload(), withResponse = true)
                 send(CommandNumber.GET_CLOCK, byteArrayOf(), withResponse = true)
                 // Populate the battery ring right after connect, not only once the Live screen opens. Posted
@@ -4937,6 +5012,14 @@ class WhoopBleClient(
 
     @SuppressLint("MissingPermission")
     private fun handleDisconnect(status: Int) {
+        // Reboot trail: if a user reboot is in flight, this drop is the strap acting on it. Log how long the
+        // link stayed up (a real reboot drops within ~1-2s) and cancel the no-disconnect watchdog. The
+        // reconnect time is logged separately once the handshake completes; rebootRequestedAtMs stays set so
+        // the handshake can compute the round-trip. Twin of macOS didDisconnectPeripheral.
+        rebootRequestedAtMs?.let { t ->
+            rebootWatchdog?.let { handler.removeCallbacks(it) }; rebootWatchdog = null
+            log("reboot: link dropped ${SystemClock.elapsedRealtime() - t}ms after send — reboot took effect; awaiting reconnect")
+        }
         // Connection test mode: capture whether THIS attempt ever reached STATE_CONNECTED before the
         // state copy below clears `connected`. Android delivers BOTH a post-connect involuntary drop AND a
         // connect attempt that never reached connected through this one onConnectionStateChange(DISCONNECTED)

--- a/android/app/src/main/java/com/noop/protocol/Enums.kt
+++ b/android/app/src/main/java/com/noop/protocol/Enums.kt
@@ -84,6 +84,14 @@ enum class CommandNumber(val rawValue: Int) {
     // Port of Swift `WhoopCommand.historicalDataResult` (whoop_protocol.json: 23 HISTORICAL_DATA_RESULT).
     HISTORICAL_DATA_RESULT(23),
     GET_BATTERY_LEVEL(26),
+    // REBOOT_STRAP (29) — restart the strap. Empty body (the official app's builder passes a null
+    // payload). The strap drops the link and re-advertises after boot; stored data is KEPT
+    // (non-destructive), though an in-flight offload is interrupted (chunk-acked, so nothing is lost).
+    // Opcode 29 is shared across WHOOP 4.0 (harvard/crc8) and 5/MG (puffin/crc16); the 4.0 form is
+    // confirmed, the 5/MG framing is NOT hardware-confirmed — rebootStrap() logs the COMMAND_RESPONSE
+    // so a strap log confirms acceptance. User-initiated + confirmation-gated only; never automatic.
+    // Port of Swift WhoopCommand.rebootStrap.
+    REBOOT_STRAP(29),
     GET_DATA_RANGE(34),
     GET_HELLO_HARVARD(35),
     // GET_HELLO (145): WHOOP 5.0/MG hello. The response carries the device name plus `fw_version`

--- a/android/app/src/main/java/com/noop/ui/AppViewModel.kt
+++ b/android/app/src/main/java/com/noop/ui/AppViewModel.kt
@@ -1518,6 +1518,10 @@ class AppViewModel(app: Application) : AndroidViewModel(app) {
         _bpm.value = null
     }
 
+    /** Restart the connected strap (user-initiated, confirmation-gated in DevicesScreen). Non-destructive —
+     *  the strap keeps its data and re-advertises after boot; NOOP auto-reconnects. See WhoopBleClient.rebootStrap. */
+    fun rebootStrap() = ble.rebootStrap()
+
     /**
      * Flip the "keep connected in the background" preference (driven by Settings). Turning it on
      * while a strap is live promotes to the foreground immediately; turning it off drops the

--- a/android/app/src/main/java/com/noop/ui/DevicesScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/DevicesScreen.kt
@@ -117,6 +117,7 @@ fun DevicesScreen(
     var renameTarget by remember { mutableStateOf<PairedDeviceRow?>(null) }
     var removeTarget by remember { mutableStateOf<PairedDeviceRow?>(null) }
     var deleteDataTarget by remember { mutableStateOf<PairedDeviceRow?>(null) }
+    var rebootTarget by remember { mutableStateOf<PairedDeviceRow?>(null) }
     // After removing the ACTIVE device with other devices still paired, prompt to pick a new active one.
     var pickNewActive by remember { mutableStateOf(false) }
 
@@ -174,6 +175,7 @@ fun DevicesScreen(
                 onDisconnect = if (device.brand.equals("WHOOP", ignoreCase = true)) {
                     { Toast.makeText(context, "Disconnecting", Toast.LENGTH_SHORT).show(); viewModel.disconnect() }
                 } else null,
+                onReboot = { rebootTarget = device },
             )
         }
 
@@ -263,6 +265,20 @@ fun DevicesScreen(
         )
     }
 
+    // --- Restart strap confirm (#166) ---
+    rebootTarget?.let { device ->
+        ConfirmDialog(
+            title = "Restart this strap?",
+            message = "Restart ${displayName(device)}? It disconnects for about 30 seconds while it " +
+                "reboots, then reconnects on its own. Your recorded data is kept. On WHOOP 5.0/MG this is " +
+                "experimental — if it doesn't restart, your strap log helps us confirm the command.",
+            confirmLabel = "Restart",
+            destructive = false,
+            onConfirm = { viewModel.rebootStrap(); rebootTarget = null },
+            onDismiss = { rebootTarget = null },
+        )
+    }
+
     // --- Second, strongly-worded delete-data confirm (from the Removed card's secondary control) ---
     deleteDataTarget?.let { device ->
         ConfirmDialog(
@@ -315,6 +331,7 @@ private fun DeviceCard(
     onDeleteData: (() -> Unit)? = null,
     onConnect: (() -> Unit)? = null,
     onDisconnect: (() -> Unit)? = null,
+    onReboot: (() -> Unit)? = null,
 ) {
     val profile = deviceProfile(device)
     // The per-device actions menu's open state is hoisted here so the WHOLE card is a tap target that opens
@@ -414,6 +431,7 @@ private fun DeviceCard(
                     onDeleteData = onDeleteData,
                     onConnect = onConnect,
                     onDisconnect = onDisconnect,
+                    onReboot = onReboot,
                 )
             }
         }
@@ -494,6 +512,7 @@ private fun DeviceActionsMenu(
     onDeleteData: (() -> Unit)?,
     onConnect: (() -> Unit)? = null,
     onDisconnect: (() -> Unit)? = null,
+    onReboot: (() -> Unit)? = null,
 ) {
     Box {
         IconButton(
@@ -532,6 +551,11 @@ private fun DeviceActionsMenu(
                     MenuItem("Make active", Icons.Filled.Bolt) { onOpenChange(false); onMakeActive() }
                 }
                 MenuItem("Rename", Icons.Filled.Edit) { onOpenChange(false); onRename() }
+                // Restart the strap — only for the live-connected WHOOP (the reboot travels over the active
+                // BLE link). Confirmation-gated by the parent. (#166)
+                if (isLiveConnected && SourceCoordinator.isWhoop(device) && onReboot != null) {
+                    MenuItem("Restart strap…", Icons.Filled.Refresh) { onOpenChange(false); onReboot() }
+                }
                 if (onRemove != null) {
                     HorizontalDivider(color = Palette.hairline)
                     MenuItem("Remove", Icons.Filled.RemoveCircleOutline, destructive = true) {

--- a/android/app/src/main/java/com/noop/ui/DevicesScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/DevicesScreen.kt
@@ -157,6 +157,8 @@ fun DevicesScreen(
                 device = device,
                 isActive = device.status == DeviceStatus.active.name,
                 isLiveConnected = device.status == DeviceStatus.active.name && live.connected,
+                // Reboot in flight + link currently down → "Reconnecting…" (#166).
+                isReconnecting = device.status == DeviceStatus.active.name && live.rebootInProgress && !live.connected,
                 // The live battery belongs to whichever device is ACTIVE + connected (WHOOP, a generic
                 // strap, or an FTMS machine all funnel into live.batteryPct). null otherwise.
                 liveBatteryPct = if (device.status == DeviceStatus.active.name && live.connected)
@@ -317,6 +319,9 @@ private fun DeviceCard(
     device: PairedDeviceRow,
     isActive: Boolean,
     isLiveConnected: Boolean,
+    /** The active strap's link dropped for a user-initiated reboot and NOOP is auto-reconnecting (#166).
+     *  Drives the transient "Reconnecting…" pill; false for every non-reboot state. */
+    isReconnecting: Boolean = false,
     dimmed: Boolean = false,
     /** The active+connected device's live battery percent (0–100) — surfaced the same way for WHOOP, a
      *  generic strap, or an FTMS machine. null when not active/connected or no battery was reported. */
@@ -378,7 +383,7 @@ private fun DeviceCard(
                     StatePill("Beta", tone = StrandTone.Warning, showsDot = false)
                     Spacer(Modifier.width(6.dp))
                 }
-                StatePill(device, isActive, isLiveConnected)
+                StatePill(device, isActive, isLiveConnected, isReconnecting)
             }
 
             // Honest local-takeover state row for an adopted Oura ring that is paired but not the
@@ -483,10 +488,19 @@ private fun BatteryTube(pct: Int) {
 }
 
 @Composable
-private fun StatePill(device: PairedDeviceRow, isActive: Boolean, isLiveConnected: Boolean) {
+private fun StatePill(
+    device: PairedDeviceRow,
+    isActive: Boolean,
+    isLiveConnected: Boolean,
+    isReconnecting: Boolean = false,
+) {
     when {
         device.status == DeviceStatus.archived.name ->
             StatePill("Removed", tone = StrandTone.Neutral, showsDot = false)
+        // Reboot window (#166): the user's Restart dropped the link and NOOP is auto-reconnecting. Show it
+        // as intentional rather than a silent drop to "Active"; clears to "Active · Live" once the link is back.
+        isActive && isReconnecting ->
+            StatePill("Reconnecting…", tone = StrandTone.Warning, pulsing = true)
         isActive ->
             StatePill(
                 if (isLiveConnected) "Active · Live" else "Active",

--- a/docs/ANDROID.md
+++ b/docs/ANDROID.md
@@ -336,11 +336,13 @@ discovery; transcribe it verbatim (`DeviceFamily.whoop5ClientHello`).
 
 ### Commands (`Commands.swift` → `Commands.kt`, ported)
 
-`Commands.kt` ports the **curated, safe** `WhoopCommand` enum from `Strand/BLE/Commands.swift`. It
-intentionally **excludes** destructive commands (reboot, firmware load, force-trim, ship-mode,
-power-cycle, fuel-gauge reset, BLE DFU) so the command sender can never brick or wipe the strap —
-preserve that exclusion. Raw values are the on-wire command codes; the ones the connect/offload
-lifecycle relies on:
+The `CommandNumber` sender set ports the **curated, safe** `WhoopCommand` enum from
+`Strand/BLE/Commands.swift`. It intentionally **excludes** destructive commands (firmware load,
+force-trim, ship-mode, power-cycle, fuel-gauge reset, BLE DFU) so the command sender can never brick
+or wipe the strap — preserve that exclusion. The one guarded exception is `REBOOT_STRAP` (a plain,
+non-destructive restart), sent only from the user-initiated, confirmation-gated Restart action
+(`WhoopBleClient.rebootStrap()`) — never automatically (#166). Raw values are the on-wire command
+codes; the ones the connect/offload lifecycle relies on:
 
 | Command | Code | Role |
 | --- | --- | --- |

--- a/docs/BLE_REVERSE_ENGINEERING.md
+++ b/docs/BLE_REVERSE_ENGINEERING.md
@@ -779,9 +779,11 @@ unparsed region — describing the frame faithfully without inventing structure.
 ### Safety rule
 
 `WhoopCommand` in `Commands.swift` is a **deliberately curated subset**. Destructive or dangerous
-commands — reboot, firmware load, force-trim, ship-mode, power-cycle, fuel-gauge reset, BLE DFU — are
-**excluded by design** so the in-app command sender can never brick or wipe a device. When extending
-the command set, keep it reversible and non-destructive.
+commands — firmware load, force-trim, ship-mode, power-cycle, fuel-gauge reset, BLE DFU — are
+**excluded by design** so the in-app command sender can never brick or wipe a device. The one guarded
+exception is `rebootStrap` (a plain, non-destructive restart that keeps stored data), sent only from a
+user-initiated, confirmation-gated action — never automatically (#166). When extending the command
+set, keep it reversible and non-destructive.
 
 ---
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -313,16 +313,19 @@ The app's outbound command set lives in `Strand/BLE/Commands.swift` as `WhoopCom
 ```swift
 /// Curated, SAFE WHOOP command set for *sending* to the strap.
 ///
-/// This is intentionally a *subset*: destructive / dangerous commands
-/// (reboot, firmware load, force-trim, ship-mode, power-cycle, fuel-gauge reset, BLE DFU)
-/// are deliberately EXCLUDED so the in-app command sender can never brick or wipe the device.
+/// This is intentionally a *subset*: DESTRUCTIVE commands that wipe data or brick the strap
+/// (firmware load/DFU, force-trim, ship-mode, power-cycle, fuel-gauge reset) stay deliberately
+/// EXCLUDED so the in-app command sender can never form those bytes. The ONE exception is
+/// `rebootStrap` (a plain, non-destructive restart), sent only from a user-initiated, confirmed action.
 ```
 
-Every command currently in the enum is **safe and reversible** — toggle realtime HR, read clock /
+Every other command in the enum is **safe and reversible** — toggle realtime HR, read clock /
 battery / version / data range, run/stop a haptic pattern, arm/read/cancel the firmware alarm,
-enter/exit high-frequency sync, start/stop raw data. **Do not add reboot, firmware/DFU,
+enter/exit high-frequency sync, start/stop raw data. **Do not add firmware/DFU,
 ship-mode/power-cycle, force-trim, fuel-gauge reset, or any command that can brick, wipe, or
-permanently alter the device.** If you believe a non-trivial command is genuinely needed, open an
+permanently alter the device.** The lone reboot exception is deliberate and narrow: a restart keeps
+all stored data and NOOP already reboots the strap via rename — it is confirmation-gated and never
+sent automatically (#166). If you believe another non-trivial command is genuinely needed, open an
 issue first, justify why it's reversible, and document its payload and on-device verification before
 any code.
 

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -403,18 +403,26 @@ data, brick, or power-cycle the strap. NOOP must never send them.
 | Code | Command | Hazard |
 |-----:|---------|--------|
 | 25 | `FORCE_TRIM` | discards stored data |
-| 29 | `REBOOT_STRAP` | reboots |
 | 32 | `POWER_CYCLE_STRAP` | power-cycles |
 | 36 | `START_FIRMWARE_LOAD` | firmware write |
 | 37 | `LOAD_FIRMWARE_DATA` | firmware write |
 | 38 | `PROCESS_FIRMWARE_IMAGE` | firmware write |
 | 45 | `ENTER_BLE_DFU` | enters DFU bootloader |
+
+**One guarded exception — `REBOOT_STRAP` (29).** A plain restart is the one command on this list that
+is *non-destructive*: the strap keeps its stored data and just re-advertises after boot, and NOOP
+already triggers a reboot today via `SET_ADVERTISING_NAME_HARVARD` (rename applies on reboot). It is
+in `WhoopCommand` as `rebootStrap`, but sent **only** from the user-initiated, confirmation-gated
+"Restart strap" action (`BLEManager.rebootStrap()` / `WhoopBleClient.rebootStrap()`) — never
+automatically, and never as part of any connect/offload path (#166). Everything else in this table
+stays out of the enum entirely.
 | 99 | `RESET_FUEL_GAUGE` | resets battery fuel gauge |
 
-**Payload forms** (decoded from the official app's command builders — recorded here only so the
-wire format is *known and avoidable*, not so it can be sent). The opcodes are shared across WHOOP 4
-(harvard) and WHOOP 5/MG (puffin): the app's unified command enum (`EnumC58479e`) uses the same
-`25`/`29`/`32` on both transports — unlike haptics, which has a maverick-specific `0x13`.
+**Payload forms** (decoded from the official app's command builders — recorded so the wire format is
+*known*: for the destructive commands, known-and-avoidable; for the one guarded exception,
+`REBOOT_STRAP`, known-and-used by `rebootStrap()`). The opcodes are shared across WHOOP 4 (harvard)
+and WHOOP 5/MG (puffin): the app's unified command enum (`EnumC58479e`) uses the same `25`/`29`/`32`
+on both transports — unlike haptics, which has a maverick-specific `0x13`.
 
 - `FORCE_TRIM` (25) — body is **two little-endian int32 range args**. The app's "erase everything"
   form sets both to `-16843010` (`0xFEFEFEFE`), an 8-byte sentinel that trims the entire stored


### PR DESCRIPTION
Closes #166. Adds a user-initiated, confirmation-gated **Restart strap** action to the Devices action menu (next to Rename/Remove), for the live-connected WHOOP on both platforms.

## Why it's safe
`REBOOT_STRAP` (opcode 29, empty body) is the one **non-destructive** member of the formerly all-denylisted command set — the strap keeps its stored data and just re-advertises after boot. NOOP already reboots the strap today via **rename** (`SET_ADVERTISING_NAME` applies on reboot), so this is the same class of action. It's added to the safe `WhoopCommand` enum as a narrow exception, sent **only** from the Restart action — never automatically, never on any connect/offload path.

## Both families
- **4.0** — harvard (crc8) framing, confirmed from the official app's command builder.
- **5/MG** — puffin (crc16) framing via the existing 5/MG allowlist. **Not hardware-confirmed**, so the action logs the strap's `COMMAND_RESPONSE` (accept/reject) — the same signal that exposed 5/MG haptics rejection (`result=0x03`). That's how a 5/MG owner's log confirms whether the puffin frame is accepted.

## Debug trail (per reboot, to the strap log)
```
reboot: request family=… fw=… connected=true bonded=true
reboot: sent opcode=29 framing=<harvard-crc8|puffin-crc16> payload=empty writeType=withResponse
reboot: strap acked result=… (accepted|REJECTED)          # COMMAND_RESPONSE
reboot: link dropped <ms>ms after send — reboot took effect
reboot: no disconnect within 12s — strap may have ignored it   # watchdog (esp. 5/MG)
reboot: reconnected <s>s after send — round trip complete
```
Answers every triage question: sent? in what framing? accepted or rejected? did it actually reboot (link drop + timing)? did it come back (reconnect time)?

## Gating
Connected + bonded + WHOOP only; confirmation dialog (≈30s disconnect, data kept, 5/MG experimental note). Non-destructive but interrupts an in-flight offload — chunk-acked, so nothing is lost (re-offloads on reconnect).

## Docs
Moves `REBOOT_STRAP` from the "never send" denylist to a documented **guarded exception** (`PROTOCOL.md`, `CONTRIBUTING.md`, `ANDROID.md`, `BLE_REVERSE_ENGINEERING.md`). The rest (force-trim, power-cycle, firmware/DFU, fuel-gauge reset) stays firmly out of the enum.

## Verification
Both platforms changed together (parity). Android `compileFullDebugKotlin` passes locally. App-target Swift (`BLEManager`/`FrameRouter`/`DevicesView`) has no default CI — validating via `app-build.yml`. Still wants an on-device pass on a real 4.0 and 5/MG (the strap log will confirm the 5/MG puffin frame).