### PR TITLE
Tab bar: scroll-to-top on an at-root re-tap (follow-up to #198/#215)

### DIFF
--- a/Strand/Liquid/LiquidTodayView.swift
+++ b/Strand/Liquid/LiquidTodayView.swift
@@ -185,9 +185,16 @@ struct LiquidTodayView: View {
         return f
     }()
 
+    /// Scroll-to-top on an at-root Today re-tap (#198 follow-up); default 0 so macOS/other contexts stay inert.
+    @Environment(\.scrollToTopSignal) private var scrollToTopSignal
+    private static let topAnchorID = "liquidToday.top"
+
     var body: some View {
+        ScrollViewReader { proxy in
         ScrollView {
             VStack(spacing: 0) {
+                // Zero-height scroll-to-top anchor (#198 follow-up): the target for an at-root Today re-tap.
+                Color.clear.frame(height: 0).id(Self.topAnchorID)
                 // Scroll-offset probe at the very top (before padding), so its minY in the scroll's
                 // coordinate space reads the top OVERSCROLL: ~0 at rest, positive as you pull down.
                 GeometryReader { g in
@@ -282,6 +289,13 @@ struct LiquidTodayView: View {
         // at the top instead of the white scroll-under-titlebar wash.
         .toolbarBackground(.hidden, for: .windowToolbar)
         #endif
+        #if os(iOS)
+        // Scroll-to-top on an at-root Today re-tap (#198 follow-up); iOS-only — the tab shell is the only driver.
+        .onChange(of: scrollToTopSignal) { _, _ in
+            withAnimation(.easeOut(duration: 0.35)) { proxy.scrollTo(Self.topAnchorID, anchor: .top) }
+        }
+        #endif
+        }
     }
 
     // MARK: - Liquid pull-to-refresh

--- a/Strand/Screens/ScreenScaffold.swift
+++ b/Strand/Screens/ScreenScaffold.swift
@@ -33,8 +33,19 @@ struct ScreenScaffold<Content: View, Trailing: View>: View {
     @Environment(\.horizontalSizeClass) private var hSizeClass
     #endif
 
+    /// Bumped (via the environment) when the iOS tab shell wants THIS screen scrolled to the top — an
+    /// at-root re-tap of the active tab (#198 follow-up). Default 0 never changes, so macOS and every
+    /// non-tab screen keep their exact prior scroll behaviour.
+    @Environment(\.scrollToTopSignal) private var scrollToTopSignal
+    /// Zero-height first child of the scroll content, the scroll-to-top target.
+    private static let topAnchorID = "screenScaffold.top"
+
     var body: some View {
+        ScrollViewReader { proxy in
         ScrollView {
+            // Scroll-to-top anchor (#198 follow-up): a zero-height marker pinned above the content so an
+            // at-root tab re-tap can bring the screen back to the very top. Layout-neutral.
+            Color.clear.frame(height: 0).id(Self.topAnchorID)
             column
             #if os(iOS)
             // Unified side margins matching the liquid home (16pt) so every page's cards + header line up
@@ -77,6 +88,14 @@ struct ScreenScaffold<Content: View, Trailing: View>: View {
         // (the scroll-under-titlebar blend). Hide it so the sky reads edge-to-edge and dark, like iOS.
         .toolbarBackground(.hidden, for: .windowToolbar)
         #endif
+        #if os(iOS)
+        // Scroll-to-top on an at-root tab re-tap (#198 follow-up). iOS-only: the tab shell is the only
+        // driver, and gating here keeps the two-param onChange off macOS 13. Inert until the signal moves.
+        .onChange(of: scrollToTopSignal) { _, _ in
+            withAnimation(.easeOut(duration: 0.35)) { proxy.scrollTo(Self.topAnchorID, anchor: .top) }
+        }
+        #endif
+        }
     }
 
     /// The header + content column. `lazy` swaps the eager `VStack` for a `LazyVStack` so a long
@@ -233,5 +252,23 @@ struct DataPendingNote: View {
                 }
             }
         }
+    }
+}
+
+// MARK: - Scroll-to-top signal (#198 follow-up)
+
+/// An incrementing token the iOS tab shell bumps when the user re-taps the ALREADY-at-root active tab,
+/// to scroll that tab's root screen to the top (the other half of the iOS tab convention #197/#198 left
+/// unserved — an at-root re-tap is otherwise a no-op). `ScreenScaffold` and `LiquidTodayView` observe it
+/// and scroll to their top anchor when it changes. Default 0 is never bumped outside the tab shell, so
+/// macOS (sidebar, no tab re-tap) and every non-tab screen are completely unaffected.
+private struct ScrollToTopSignalKey: EnvironmentKey {
+    static let defaultValue: Int = 0
+}
+
+extension EnvironmentValues {
+    var scrollToTopSignal: Int {
+        get { self[ScrollToTopSignalKey.self] }
+        set { self[ScrollToTopSignalKey.self] = newValue }
     }
 }

--- a/Strand/Screens/ScreenScaffold.swift
+++ b/Strand/Screens/ScreenScaffold.swift
@@ -37,15 +37,13 @@ struct ScreenScaffold<Content: View, Trailing: View>: View {
     /// at-root re-tap of the active tab (#198 follow-up). Default 0 never changes, so macOS and every
     /// non-tab screen keep their exact prior scroll behaviour.
     @Environment(\.scrollToTopSignal) private var scrollToTopSignal
-    /// Zero-height first child of the scroll content, the scroll-to-top target.
-    private static let topAnchorID = "screenScaffold.top"
 
     var body: some View {
         ScrollViewReader { proxy in
         ScrollView {
             // Scroll-to-top anchor (#198 follow-up): a zero-height marker pinned above the content so an
             // at-root tab re-tap can bring the screen back to the very top. Layout-neutral.
-            Color.clear.frame(height: 0).id(Self.topAnchorID)
+            Color.clear.frame(height: 0).id(screenScaffoldTopAnchorID)
             column
             #if os(iOS)
             // Unified side margins matching the liquid home (16pt) so every page's cards + header line up
@@ -92,7 +90,7 @@ struct ScreenScaffold<Content: View, Trailing: View>: View {
         // Scroll-to-top on an at-root tab re-tap (#198 follow-up). iOS-only: the tab shell is the only
         // driver, and gating here keeps the two-param onChange off macOS 13. Inert until the signal moves.
         .onChange(of: scrollToTopSignal) { _, _ in
-            withAnimation(.easeOut(duration: 0.35)) { proxy.scrollTo(Self.topAnchorID, anchor: .top) }
+            withAnimation(.easeOut(duration: 0.35)) { proxy.scrollTo(screenScaffoldTopAnchorID, anchor: .top) }
         }
         #endif
         }
@@ -262,6 +260,10 @@ struct DataPendingNote: View {
 /// unserved — an at-root re-tap is otherwise a no-op). `ScreenScaffold` and `LiquidTodayView` observe it
 /// and scroll to their top anchor when it changes. Default 0 is never bumped outside the tab shell, so
 /// macOS (sidebar, no tab re-tap) and every non-tab screen are completely unaffected.
+/// Zero-height scroll-to-top target id. File scope, not a `static` on `ScreenScaffold` — the latter is
+/// generic (`<Content, Trailing>`) and Swift forbids stored static properties on generic types.
+private let screenScaffoldTopAnchorID = "screenScaffold.top"
+
 private struct ScrollToTopSignalKey: EnvironmentKey {
     static let defaultValue: Int = 0
 }

--- a/StrandiOS/App/RootTabView.swift
+++ b/StrandiOS/App/RootTabView.swift
@@ -27,6 +27,11 @@ struct RootTabView: View {
     /// (#198; the #197 resetID/`.id()` rebuild reset both). Requires the tab roots' first-hop
     /// links to push `TabRoute`/`MoreDestination` VALUES — closure-destination links bypass the path.
     @State private var tabPaths: [NavigationPath] = Array(repeating: NavigationPath(), count: 4)
+    /// One scroll-to-top token per tab. Bumped when the user re-taps the active tab while it's ALREADY
+    /// at its root — the other half of the iOS convention #197/#198 left unserved (an at-root re-tap was
+    /// a no-op). Threaded into each tab's root via `\.scrollToTopSignal`; ScreenScaffold / LiquidTodayView
+    /// scroll to their top anchor when their tab's token changes.
+    @State private var scrollTop: [Int] = Array(repeating: 0, count: 4)
     /// Which More-tab groups are expanded (S2). Insights + Body stay open at rest; Data + App collapse to
     /// just their header until tapped. Persisted (#860 item 2): the user's open/closed choice must SURVIVE
     /// leaving and re-entering the More tab (and relaunch), not reset to the seed every visit. Backed by an
@@ -67,10 +72,10 @@ struct RootTabView: View {
             // cleanly in the gap between them — replaces the native tab bar: no overlap, no glow. The
             // native TabView still drives content + per-tab nav state; only its bar is hidden.
             TabView(selection: $selectedTab) {
-                tab(todayTabRoot, "Today", "square.grid.2x2", path: $tabPaths[0]).tag(0)
-                tab(TrendsView(), "Trends", "chart.line.uptrend.xyaxis", path: $tabPaths[1]).tag(1)
-                tab(SleepView(), "Sleep", "bed.double", path: $tabPaths[2]).tag(2)
-                moreTab(path: $tabPaths[3]).tag(3)
+                tab(todayTabRoot, "Today", "square.grid.2x2", path: $tabPaths[0], scrollSignal: scrollTop[0]).tag(0)
+                tab(TrendsView(), "Trends", "chart.line.uptrend.xyaxis", path: $tabPaths[1], scrollSignal: scrollTop[1]).tag(1)
+                tab(SleepView(), "Sleep", "bed.double", path: $tabPaths[2], scrollSignal: scrollTop[2]).tag(2)
+                moreTab(path: $tabPaths[3], scrollSignal: scrollTop[3]).tag(3)
             }
             .tint(StrandPalette.accent)
             .toolbar(.hidden, for: .tabBar)
@@ -99,7 +104,11 @@ struct RootTabView: View {
                 // path, not a rebuild. At the root the pop is skipped, so scroll position survives
                 // and the refresh doesn't double with a re-run of the root's `.task` (#198).
                 Task { await repo.refresh() }
-                if !tabPaths[tag].isEmpty { tabPaths[tag] = NavigationPath() }
+                if !tabPaths[tag].isEmpty {
+                    tabPaths[tag] = NavigationPath()   // on a subpage: animated pop back to the root
+                } else {
+                    scrollTop[tag] += 1                // already at root: scroll to the top (#198 follow-up)
+                }
             })
         }
         .task {
@@ -278,7 +287,7 @@ struct RootTabView: View {
     }
 
     private func tab<V: View>(_ view: V, _ title: LocalizedStringKey, _ icon: String,
-                              path: Binding<NavigationPath>) -> some View {
+                              path: Binding<NavigationPath>, scrollSignal: Int) -> some View {
         // Each primary tab gets its OWN NavigationStack so the in-content NavigationLinks (e.g. the Today
         // dashboard card rows) both navigate AND render opaque. An ORPHANED NavigationLink (no
         // NavigationStack ancestor) renders its whole label in a disabled/translucent state — that was
@@ -293,6 +302,9 @@ struct RootTabView: View {
                 .toolbar(.hidden, for: .navigationBar)
                 .tabRouteDestinations()
         }
+        // Drive this tab's root scroll-to-top on an at-root re-tap (#198 follow-up); read by ScreenScaffold
+        // / LiquidTodayView inside. Only THIS tab's token changes on its reselect, so the others don't scroll.
+        .environment(\.scrollToTopSignal, scrollSignal)
         .toolbar(.hidden, for: .tabBar)   // we draw our own FloatingTabBar
         .tabItem { Label(title, systemImage: icon) }
     }
@@ -302,7 +314,7 @@ struct RootTabView: View {
     // + SectionHeader's UPPERCASE overline + the 28pt section rhythm). Rebuilt on the shared page chrome:
     // ScreenScaffold for the title1 "More" + subtitle, a `SectionHeader` overline per group, and the group's
     // rows in a single grouped NoopCard with hairline dividers — the same row idiom Settings/Health use.
-    private func moreTab(path: Binding<NavigationPath>) -> some View {
+    private func moreTab(path: Binding<NavigationPath>, scrollSignal: Int) -> some View {
         NavigationStack(path: path) {
             ScreenScaffold(title: "More", subtitle: "Everything else, one tap away",
                            onRefresh: { await repo.refresh() },
@@ -371,6 +383,8 @@ struct RootTabView: View {
                     .toolbarBackground(.hidden, for: .navigationBar)
             }
         }
+        // Scroll the More index to the top on an at-root re-tap (#198 follow-up); read by its ScreenScaffold.
+        .environment(\.scrollToTopSignal, scrollSignal)
         .tabItem { Label("More", systemImage: "ellipsis.circle.fill") }
     }
 


### PR DESCRIPTION
Follow-up to #198 / #215. #215 shipped Path A — re-tapping a tab on a subpage animates a pop, and re-tapping **at the root** is a clean no-op. This adds the other half of the iOS convention #197/#198 left unserved: **re-tapping the already-at-root active tab scrolls its root to the top.**

## Approach — an environment token, not param-threading
Rather than thread a parameter through every tab-root view, a `\.scrollToTopSignal` environment token drives it, so the change is minimal and **strictly additive**:

- **`ScreenScaffold`** reads the token and scrolls to a zero-height top anchor when it changes. That covers **Today (classic), Trends, Sleep, and More for free** — they all root in `ScreenScaffold` and are **untouched** by this PR.
- **`LiquidTodayView`** (the one raw-`ScrollView` root) gets the same anchor + observer.
- **`RootTabView`** keeps one token per tab; the reselect handler bumps it **only when the tab is already at its root** (`path.isEmpty`), and sets it per-tab via `.environment`. Only the reselected tab's token changes, so no other tab scrolls.

So the full re-tap behaviour is now: **subpage → animated pop; at-root → scroll-to-top; both keep the refresh.**

## Safety
- Default token is `0` and only ever bumped by the iOS tab shell → **macOS** (sidebar, no tab re-tap) and every non-tab `ScreenScaffold` keep their exact prior scroll behaviour.
- The scroll-to-top `onChange` is `#if os(iOS)` — the tab shell is the only driver, and it keeps the two-param `onChange` off macOS 13.
- iOS/macOS only; Android already does `popUpTo(startDestination){saveState}`.

## Verification
- App-target Swift, **no default CI** — validating via `app-build` (`Strand` macOS + `NOOPiOS`).
- Behaviour isn't compile-checkable: needs an on-device pass — at-root re-tap animates to top, scroll preserved when *not* re-tapping, subpage re-tap still pops, and no macOS sidebar regression.