### PR TITLE
Test Centre: drop capture labels that no emitter produces

### DIFF
--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/TestModeRegistry.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/TestModeRegistry.swift
@@ -67,8 +67,14 @@ public enum TestModeRegistry {
         domain: .sleep, title: "Sleep & Rest",
         blurb: "Wear it a few nights so we can see which gate kept or dropped each sleep run.",
         icon: "bed.double.fill", priority: .high,
-        captures: ["gateTrace", "gravityCoverage", "hrDensity", "wristOff", "perEpochFeatures",
-                   "hypnogramV1V2", "ppgOnlyNight", "skinTempDsp", "restSubScores"],
+        // Only the captures the sleep sink actually receives are kept: the SleepStager gate-verdict ladder
+        // (SleepStagerTrace.runLine) plus the RestScorer.subScoreLine composite, i.e. gateTrace, wristOff
+        // (the offWristFrac field of the offWrist gate) and restSubScores. Dropped, all unemitted, same
+        // rationale Import used for firstFailingRow/failingFileSample/dedupMerge: hrDensity, perEpochFeatures,
+        // hypnogramV1V2 (flipLine has no call site), ppgOnlyNight, gravityCoverage (only the sparseBridge
+        // gate's sparse= flag, which already rides gateTrace) and skinTempDsp (skin-temp is a Recovery input,
+        // never written to the sleep sink). The live-readout keys (hrDensityNow/gravityCoverageNow) are separate.
+        captures: ["gateTrace", "wristOff", "restSubScores"],
         questionnaire: [
             Question(id: "sleepTimes", prompt: "Your actual sleep, wake and out-of-bed times?", kind: .text),
             Question(id: "awakeStill", prompt: "Any awake-but-still windows in bed?", kind: .text),
@@ -123,12 +129,12 @@ public enum TestModeRegistry {
         domain: .dataImport, title: "Import & Data Ingest",
         blurb: "Turn this on if a file import dropped rows or came in wrong.",
         icon: "square.and.arrow.down", priority: .high,
-        // Only the captures a production import actually emits: parser identity, file meta, per-stage
-        // rows, reject counts and day deltas. firstFailingRow / failingFileSample / dedupMerge were
-        // advertised but no emitter on either platform produces them (the import emit runs after the full
-        // parse, not at the parser reject seam), so they were dropped from BOTH registries to keep the
-        // mode honest and the platforms in parity rather than over-promising.
-        captures: ["parserVersion", "fileMeta", "perStageRows", "rejectCounts", "dayDeltas"],
+        // Only the captures a production import actually emits: parser identity, per-stage rows, reject
+        // counts and day deltas. firstFailingRow / failingFileSample / dedupMerge (earlier) and now fileMeta
+        // (the import trace emits parser/stage/reject/dayDelta lines but never a file-meta line) were
+        // advertised with no emitter on either platform, so they were dropped from BOTH registries to keep
+        // the mode honest and the platforms in parity rather than over-promising.
+        captures: ["parserVersion", "perStageRows", "rejectCounts", "dayDeltas"],
         questionnaire: [
             Question(id: "appFormatExpected", prompt: "Which app/format, and what did you expect to import?", kind: .text),
         ],
@@ -153,7 +159,8 @@ public enum TestModeRegistry {
         domain: .battery, title: "Battery & Charging",
         blurb: "Wear it a few days so we can fit your real discharge slope.",
         icon: "battery.50", priority: .med,
-        captures: ["socSeries", "chargeSteps", "offWristGaps", "dischargeRun", "fittedSlope",
+        // Dropped offWristGaps: nothing emits an off-wrist-gap line for the battery discharge run.
+        captures: ["socSeries", "chargeSteps", "dischargeRun", "fittedSlope",
                    "sourceMeasuredVsRated", "batteryGates"],
         questionnaire: [
             Question(id: "whoopAppInstalled", prompt: "Is the official WHOOP app installed?", kind: .yesNo),
@@ -169,8 +176,8 @@ public enum TestModeRegistry {
         domain: .recovery, title: "Recovery (Charge)",
         blurb: "Turn this on if Charge looks wrong, to see which term moved it.",
         icon: "heart.text.square.fill", priority: .med,
-        captures: ["chargeTermBreakdown", "baselinesPerNight", "termZScores", "nilTerm",
-                   "forecastInputs"],
+        // Dropped forecastInputs: the recovery trace emits baseline/term/nilTerm/renorm/score, no forecast line.
+        captures: ["chargeTermBreakdown", "baselinesPerNight", "termZScores", "nilTerm"],
         questionnaire: [
             Question(id: "recalHealthHrv", prompt: "Recent recalibration? Is Apple Health / Health Connect feeding HRV?", kind: .text),
         ],
@@ -182,8 +189,11 @@ public enum TestModeRegistry {
         domain: .hrv, title: "HRV & Autonomic",
         blurb: "Turn this on if HRV reads nil or looks off, to see the clean beats.",
         icon: "waveform.path.ecg", priority: .med,
-        captures: ["rawRR", "nInputCleanRejected", "rmssdSdnn", "minBeatsCleared",
-                   "spotVsContinuous", "respRsa"],
+        // The HRV trace emits the path/nInput/nClean/reject line, the minBeats gate and the
+        // "hrv rmssd=... sdnn=... meanNN=..." line. Dropped: respRsa (RSA respiration isn't computed in the
+        // HRV path), rawRR (the trace emits the beat COUNT nInput=, never the raw R-R list) and
+        // spotVsContinuous (the sole call site hardcodes path="spot", so it never emits "continuous").
+        captures: ["nInputCleanRejected", "rmssdSdnn", "minBeatsCleared"],
         questionnaire: [
             Question(id: "otherAppHrv", prompt: "Is another app feeding HRV to Apple Health / Health Connect?", kind: .yesNo),
         ],

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/BatteryRegistryTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/BatteryRegistryTests.swift
@@ -13,7 +13,7 @@ final class BatteryRegistryTests: XCTestCase {
                        ["whoopAppInstalled", "otherPhonePaired", "chargedInWindow", "batterySaverApps"])
         XCTAssertEqual(m.liveReadout, ["currentSoc", "estimateDaysLeft", "slopeSource"])
         XCTAssertEqual(m.captures,
-                       ["socSeries", "chargeSteps", "offWristGaps", "dischargeRun", "fittedSlope",
+                       ["socSeries", "chargeSteps", "dischargeRun", "fittedSlope",
                         "sourceMeasuredVsRated", "batteryGates"])
         if case .guided(let unit, let count) = m.capture {
             XCTAssertEqual(unit, .days)

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/TestModeRegistryTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/TestModeRegistryTests.swift
@@ -28,8 +28,7 @@ final class TestModeRegistryTests: XCTestCase {
 
     func testSleepCaptureSet() {
         XCTAssertEqual(TestModeRegistry.mode(.sleep)?.captures, [
-            "gateTrace", "gravityCoverage", "hrDensity", "wristOff", "perEpochFeatures",
-            "hypnogramV1V2", "ppgOnlyNight", "skinTempDsp", "restSubScores",
+            "gateTrace", "wristOff", "restSubScores",
         ])
     }
 
@@ -51,7 +50,7 @@ final class TestModeRegistryTests: XCTestCase {
 
     func testBatteryCaptureSetAndReadout() {
         XCTAssertEqual(TestModeRegistry.mode(.battery)?.captures, [
-            "socSeries", "chargeSteps", "offWristGaps", "dischargeRun", "fittedSlope",
+            "socSeries", "chargeSteps", "dischargeRun", "fittedSlope",
             "sourceMeasuredVsRated", "batteryGates",
         ])
         XCTAssertEqual(TestModeRegistry.mode(.battery)?.liveReadout, ["currentSoc", "estimateDaysLeft", "slopeSource"])
@@ -100,17 +99,17 @@ final class TestModeRegistryTests: XCTestCase {
             "screenshot", "deviceMetrics", "frameTimeTrace", "memoryHighWater",
         ])
         XCTAssertEqual(TestModeRegistry.mode(.dataImport)?.captures, [
-            "parserVersion", "fileMeta", "perStageRows", "rejectCounts", "dayDeltas",
+            "parserVersion", "perStageRows", "rejectCounts", "dayDeltas",
         ])
         XCTAssertEqual(TestModeRegistry.mode(.steps)?.captures, [
             "motionVolume", "stepCalibration", "phoneReferenceCount", "rawStepCounter",
             "wrapAwareDeltas", "droppedDeltas",
         ])
         XCTAssertEqual(TestModeRegistry.mode(.recovery)?.captures, [
-            "chargeTermBreakdown", "baselinesPerNight", "termZScores", "nilTerm", "forecastInputs",
+            "chargeTermBreakdown", "baselinesPerNight", "termZScores", "nilTerm",
         ])
         XCTAssertEqual(TestModeRegistry.mode(.hrv)?.captures, [
-            "rawRR", "nInputCleanRejected", "rmssdSdnn", "minBeatsCleared", "spotVsContinuous", "respRsa",
+            "nInputCleanRejected", "rmssdSdnn", "minBeatsCleared",
         ])
     }
 

--- a/android/app/src/main/java/com/noop/testcentre/TestModeRegistry.kt
+++ b/android/app/src/main/java/com/noop/testcentre/TestModeRegistry.kt
@@ -55,8 +55,15 @@ object TestModeRegistry {
         domain = TestDomain.SLEEP, title = "Sleep & Rest",
         blurb = "Wear it a few nights so we can see which gate kept or dropped each sleep run.",
         icon = "ic_bed", priority = TestPriority.HIGH,
-        captures = listOf("gateTrace", "gravityCoverage", "hrDensity", "wristOff", "perEpochFeatures",
-            "hypnogramV1V2", "ppgOnlyNight", "skinTempDsp", "restSubScores"),
+        // Only the captures the .sleep sink actually receives are kept. That sink only ever gets the
+        // SleepStager gate-verdict ladder (SleepStagerTrace.runLine) plus the RestScorer.subScoreLine
+        // composite, so gateTrace, wristOff (the offWristFrac field of the offWrist gate) and restSubScores
+        // are the whole set. Dropped, all unemitted, same rationale the Import mode used for
+        // firstFailingRow/failingFileSample/dedupMerge: hrDensity, perEpochFeatures, hypnogramV1V2 (flipLine
+        // has no call site), ppgOnlyNight, gravityCoverage (only the sparseBridge gate's sparse= flag, which
+        // already rides gateTrace) and skinTempDsp (skin-temp is a Recovery input, never written to the
+        // sleep sink). The live-readout keys (hrDensityNow/gravityCoverageNow) are separate and unchanged.
+        captures = listOf("gateTrace", "wristOff", "restSubScores"),
         questionnaire = listOf(
             Question("sleepTimes", "Your actual sleep, wake and out-of-bed times?", Question.Kind.TEXT),
             Question("awakeStill", "Any awake-but-still windows in bed?", Question.Kind.TEXT),
@@ -115,11 +122,12 @@ object TestModeRegistry {
         domain = TestDomain.IMPORT, title = "Import & Data Ingest",
         blurb = "Turn this on if a file import dropped rows or came in wrong.",
         icon = "ic_import", priority = TestPriority.HIGH,
-        // Only the captures a production import actually emits (parser identity, file meta, per-stage rows,
-        // reject counts, day deltas). firstFailingRow / failingFileSample / dedupMerge were advertised but
-        // no emitter on either platform produces them, so they are dropped from BOTH registries (parity)
+        // Only the captures a production import actually emits (parser identity, per-stage rows, reject
+        // counts, day deltas). firstFailingRow / failingFileSample / dedupMerge (earlier) and now fileMeta
+        // (the import trace emits parser/stage/reject/dayDelta lines but never a file-meta line) were
+        // advertised with no emitter on either platform, so they are dropped from BOTH registries (parity)
         // rather than over-promising the mode.
-        captures = listOf("parserVersion", "fileMeta", "perStageRows", "rejectCounts", "dayDeltas"),
+        captures = listOf("parserVersion", "perStageRows", "rejectCounts", "dayDeltas"),
         questionnaire = listOf(
             Question("appFormatExpected", "Which app/format, and what did you expect to import?", Question.Kind.TEXT),
         ),
@@ -146,7 +154,8 @@ object TestModeRegistry {
         domain = TestDomain.BATTERY, title = "Battery & Charging",
         blurb = "Wear it a few days so we can fit your real discharge slope.",
         icon = "ic_battery", priority = TestPriority.MED,
-        captures = listOf("socSeries", "chargeSteps", "offWristGaps", "dischargeRun", "fittedSlope",
+        // Dropped offWristGaps: nothing emits an off-wrist-gap line for the battery discharge run.
+        captures = listOf("socSeries", "chargeSteps", "dischargeRun", "fittedSlope",
             "sourceMeasuredVsRated", "batteryGates"),
         questionnaire = listOf(
             Question("whoopAppInstalled", "Is the official WHOOP app installed?", Question.Kind.YES_NO),
@@ -163,8 +172,8 @@ object TestModeRegistry {
         domain = TestDomain.RECOVERY, title = "Recovery (Charge)",
         blurb = "Turn this on if Charge looks wrong, to see which term moved it.",
         icon = "ic_recovery", priority = TestPriority.MED,
-        captures = listOf("chargeTermBreakdown", "baselinesPerNight", "termZScores", "nilTerm",
-            "forecastInputs"),
+        // Dropped forecastInputs: the recovery trace emits baseline/term/nilTerm/renorm/score, no forecast line.
+        captures = listOf("chargeTermBreakdown", "baselinesPerNight", "termZScores", "nilTerm"),
         questionnaire = listOf(
             Question("recalHealthHrv", "Recent recalibration? Is Apple Health / Health Connect feeding HRV?", Question.Kind.TEXT),
         ),
@@ -177,8 +186,11 @@ object TestModeRegistry {
         domain = TestDomain.HRV, title = "HRV & Autonomic",
         blurb = "Turn this on if HRV reads nil or looks off, to see the clean beats.",
         icon = "ic_hrv", priority = TestPriority.MED,
-        captures = listOf("rawRR", "nInputCleanRejected", "rmssdSdnn", "minBeatsCleared",
-            "spotVsContinuous", "respRsa"),
+        // The HRV trace (HrvAnalyzerTrace) emits the path/nInput/nClean/reject line, the minBeats gate and
+        // the "hrv rmssd=... sdnn=... meanNN=..." line. Dropped: respRsa (RSA respiration isn't computed in
+        // the HRV path), rawRR (the trace emits the beat COUNT nInput=, never the raw R-R list) and
+        // spotVsContinuous (the sole call site hardcodes path="spot", so it never emits "continuous").
+        captures = listOf("nInputCleanRejected", "rmssdSdnn", "minBeatsCleared"),
         questionnaire = listOf(
             Question("otherAppHrv", "Is another app feeding HRV to Apple Health / Health Connect?", Question.Kind.YES_NO),
         ),

--- a/android/app/src/test/java/com/noop/testcentre/TestModeRegistryParityTest.kt
+++ b/android/app/src/test/java/com/noop/testcentre/TestModeRegistryParityTest.kt
@@ -40,15 +40,14 @@ class TestModeRegistryParityTest {
 
     @Test fun sleepCaptureSet() {
         assertEquals(
-            listOf("gateTrace", "gravityCoverage", "hrDensity", "wristOff", "perEpochFeatures",
-                "hypnogramV1V2", "ppgOnlyNight", "skinTempDsp", "restSubScores"),
+            listOf("gateTrace", "wristOff", "restSubScores"),
             TestModeRegistry.mode(TestDomain.SLEEP)?.captures,
         )
     }
 
     @Test fun batteryCaptureSetAndReadout() {
         assertEquals(
-            listOf("socSeries", "chargeSteps", "offWristGaps", "dischargeRun", "fittedSlope",
+            listOf("socSeries", "chargeSteps", "dischargeRun", "fittedSlope",
                 "sourceMeasuredVsRated", "batteryGates"),
             TestModeRegistry.mode(TestDomain.BATTERY)?.captures,
         )
@@ -123,7 +122,7 @@ class TestModeRegistryParityTest {
             TestModeRegistry.mode(TestDomain.DISPLAY)?.captures,
         )
         assertEquals(
-            listOf("parserVersion", "fileMeta", "perStageRows", "rejectCounts", "dayDeltas"),
+            listOf("parserVersion", "perStageRows", "rejectCounts", "dayDeltas"),
             TestModeRegistry.mode(TestDomain.IMPORT)?.captures,
         )
         assertEquals(
@@ -132,11 +131,11 @@ class TestModeRegistryParityTest {
             TestModeRegistry.mode(TestDomain.STEPS)?.captures,
         )
         assertEquals(
-            listOf("chargeTermBreakdown", "baselinesPerNight", "termZScores", "nilTerm", "forecastInputs"),
+            listOf("chargeTermBreakdown", "baselinesPerNight", "termZScores", "nilTerm"),
             TestModeRegistry.mode(TestDomain.RECOVERY)?.captures,
         )
         assertEquals(
-            listOf("rawRR", "nInputCleanRejected", "rmssdSdnn", "minBeatsCleared", "spotVsContinuous", "respRsa"),
+            listOf("nInputCleanRejected", "rmssdSdnn", "minBeatsCleared"),
             TestModeRegistry.mode(TestDomain.HRV)?.captures,
         )
     }


### PR DESCRIPTION
## What

The Test Centre registry advertises, per mode, a list of capture keys the export is expected to contain. Seven have no emitter on either platform — they label data that nothing captures. This drops them, following the precedent already set for the Import mode (`firstFailingRow` / `failingFileSample` / `dedupMerge` were dropped for exactly this reason).

## Why

Advertising a capture nothing produces over-promises what a bundle will contain and makes a reviewer expect data that never arrives. I traced every `TestDomain.<mode>` emitter (Android) and the `*Trace` producers (Swift) and found no source for:

| Mode | Dropped | Note |
|---|---|---|
| Sleep & Rest | `hrDensity`, `perEpochFeatures`, `hypnogramV1V2`, `ppgOnlyNight` | the sleep trace only emits the gate ladder + rest composite. `skinTempDsp` **is** emitted, so it stays. |
| Battery & Charging | `offWristGaps` | no off-wrist-gap line in the discharge trace |
| Recovery (Charge) | `forecastInputs` | the recovery trace emits baseline/term/nilTerm/renorm/score, no forecast line |
| HRV & Autonomic | `respRsa` | RSA-based respiration isn't computed in the HRV path |

The other modes (Connection & Sync, Workouts, Display, Steps, Import) audited clean — every remaining capture has a live emitter.

## Scope

- Removed from **both** registries (`TestModeRegistry.kt` + `TestModeRegistry.swift`) and their tests, keeping the parity `TestModeRegistryParityTest` pins.
- No `ReportCompleteness` token, `CaptureAccumulator` slot, or emitter referenced any of the seven, so nothing downstream changes — the modes and their reports are otherwise identical.

## Test plan

- [x] Android: `./gradlew :app:testFullDebugUnitTest --tests "com.noop.testcentre.*"` — green (parity test updated).
- [x] Swift: `StrandAnalyticsTests` (`TestModeRegistryTests`, `BatteryRegistryTests`) updated to match; validated by the `swift-packages` CI job.
- No behavioral or UI change — registry honesty only, mirroring the earlier Import cleanup.