### PR TITLE
Fix #218: wear state reads "Unknown" for a streaming Oura ring

### DIFF
--- a/Strand/Screens/LiveView.swift
+++ b/Strand/Screens/LiveView.swift
@@ -700,13 +700,18 @@ private struct LiveHeaderStats: View {
     /// #218: an Oura ring streams live HR WITHOUT a WHOOP bond, so `activeConnection` (which needs the bond)
     /// is false for it and the wear stat read "—" mid-stream. A live HR stream is itself the wear signal
     /// (Oura only emits PPG HR while worn). `streamingLiveHR` is Oura-only, so this never widens WHOOP.
-    private var liveLink: Bool { activeConnection || (live.connected && live.streamingLiveHR) }
+    private var ringStreaming: Bool { live.connected && live.streamingLiveHR }
+    private var liveLink: Bool { activeConnection || ringStreaming }
+    /// A streaming Oura ring is definitionally worn (PPG needs skin contact), and `worn` isn't reset on a
+    /// source switch — so a stale `worn=false` from a prior WHOOP WRIST_OFF must not read "Off wrist"
+    /// mid-stream. For WHOOP `ringStreaming` is always false, so this is just `live.worn`. #218.
+    private var wornNow: Bool { live.worn || ringStreaming }
 
     var body: some View {
         HStack(spacing: 16) {
             stat(String(localized: "Device"), deviceName)
             stat(String(localized: "Battery"), live.batteryPct.map { "\(Int($0))%" } ?? "—")
-            stat(String(localized: "Worn"), liveLink ? (live.worn ? String(localized: "Yes") : String(localized: "No")) : "—")
+            stat(String(localized: "Worn"), liveLink ? (wornNow ? String(localized: "Yes") : String(localized: "No")) : "—")
             stat(String(localized: "Last sync"), lastSyncLabel)
         }
     }
@@ -962,6 +967,10 @@ private struct LiveSignalTrustRail: View {
     /// #218: a live link for the wear stat = a WHOOP bond OR an Oura HR stream. Oura streams only while worn
     /// (PPG needs skin contact) and stops when removed, so `ringStreaming` doubles as its wear signal.
     private var liveLink: Bool { activeConnection || ringStreaming }
+    /// Streaming ⟹ worn: keeps a stale `worn=false` (from a prior WHOOP WRIST_OFF, never reset on a source
+    /// switch) from reading "Off wrist" while an Oura ring streams. For WHOOP `ringStreaming` is always
+    /// false, so this is just `live.worn`. #218.
+    private var wornNow: Bool { live.worn || ringStreaming }
 
     var body: some View {
         LazyVGrid(columns: [GridItem(.adaptive(minimum: 168), spacing: NoopMetrics.gap)],
@@ -1040,11 +1049,11 @@ private struct LiveSignalTrustRail: View {
             // when removed), so the stream itself is the wear signal; `worn` stays at its default true for
             // Oura until its WEAR_EVENT is wired to `worn` (follow-up).
             .init(title: String(localized: "Wear state"),
-                  value: liveLink ? (live.worn ? String(localized: "On wrist") : String(localized: "Off wrist")) : String(localized: "Unknown"),
-                  detail: liveLink ? (live.worn ? String(localized: "Eligible for live physiology") : String(localized: "Wear the strap for scoring")) : String(localized: "Connect to read wear state"),
+                  value: liveLink ? (wornNow ? String(localized: "On wrist") : String(localized: "Off wrist")) : String(localized: "Unknown"),
+                  detail: liveLink ? (wornNow ? String(localized: "Eligible for live physiology") : String(localized: "Wear the strap for scoring")) : String(localized: "Connect to read wear state"),
                   icon: "sensor.tag.radiowaves.forward",
-                  tint: !liveLink ? StrandPalette.textTertiary : live.worn ? StrandPalette.accent : StrandPalette.statusWarning,
-                  frac: !liveLink ? nil : (live.worn ? 1 : 0.25))
+                  tint: !liveLink ? StrandPalette.textTertiary : wornNow ? StrandPalette.accent : StrandPalette.statusWarning,
+                  frac: !liveLink ? nil : (wornNow ? 1 : 0.25))
         ]
     }
 }

--- a/Strand/Screens/LiveView.swift
+++ b/Strand/Screens/LiveView.swift
@@ -697,12 +697,16 @@ private struct LiveHeaderStats: View {
     @EnvironmentObject private var live: LiveState
     let activeConnection: Bool
     let deviceName: String
+    /// #218: an Oura ring streams live HR WITHOUT a WHOOP bond, so `activeConnection` (which needs the bond)
+    /// is false for it and the wear stat read "—" mid-stream. A live HR stream is itself the wear signal
+    /// (Oura only emits PPG HR while worn). `streamingLiveHR` is Oura-only, so this never widens WHOOP.
+    private var liveLink: Bool { activeConnection || (live.connected && live.streamingLiveHR) }
 
     var body: some View {
         HStack(spacing: 16) {
             stat(String(localized: "Device"), deviceName)
             stat(String(localized: "Battery"), live.batteryPct.map { "\(Int($0))%" } ?? "—")
-            stat(String(localized: "Worn"), activeConnection ? (live.worn ? String(localized: "Yes") : String(localized: "No")) : "—")
+            stat(String(localized: "Worn"), liveLink ? (live.worn ? String(localized: "Yes") : String(localized: "No")) : "—")
             stat(String(localized: "Last sync"), lastSyncLabel)
         }
     }
@@ -955,6 +959,9 @@ private struct LiveSignalTrustRail: View {
     private var displayHR: Int? { model.bpm }
     /// Oura ring actively streaming live HR — trusted stream without a WHOOP bond (see LiveView.ringStreaming).
     private var ringStreaming: Bool { live.connected && live.streamingLiveHR }
+    /// #218: a live link for the wear stat = a WHOOP bond OR an Oura HR stream. Oura streams only while worn
+    /// (PPG needs skin contact) and stops when removed, so `ringStreaming` doubles as its wear signal.
+    private var liveLink: Bool { activeConnection || ringStreaming }
 
     var body: some View {
         LazyVGrid(columns: [GridItem(.adaptive(minimum: 168), spacing: NoopMetrics.gap)],
@@ -1027,13 +1034,17 @@ private struct LiveSignalTrustRail: View {
                   frac: live.batteryPct.map { max(0.02, min(1, $0 / 100)) }),
             // Wear is only trustworthy on a live link: `worn` defaults true (LiveState) and is only
             // updated by WRIST_ON/OFF events, so while OFFLINE it would otherwise read a false-green
-            // "On wrist". Gate the value AND tint on activeConnection (triage fix for PR#191).
+            // "On wrist". Gate the value AND tint on a live link (triage fix for PR#191).
+            // #218: `liveLink` includes an Oura HR stream, not just a WHOOP bond — an Oura ring streams
+            // with no bond, so this read "Unknown" mid-stream. Oura emits PPG HR only while worn (and stops
+            // when removed), so the stream itself is the wear signal; `worn` stays at its default true for
+            // Oura until its WEAR_EVENT is wired to `worn` (follow-up).
             .init(title: String(localized: "Wear state"),
-                  value: activeConnection ? (live.worn ? String(localized: "On wrist") : String(localized: "Off wrist")) : String(localized: "Unknown"),
-                  detail: activeConnection ? (live.worn ? String(localized: "Eligible for live physiology") : String(localized: "Wear the strap for scoring")) : String(localized: "Connect to read wear state"),
+                  value: liveLink ? (live.worn ? String(localized: "On wrist") : String(localized: "Off wrist")) : String(localized: "Unknown"),
+                  detail: liveLink ? (live.worn ? String(localized: "Eligible for live physiology") : String(localized: "Wear the strap for scoring")) : String(localized: "Connect to read wear state"),
                   icon: "sensor.tag.radiowaves.forward",
-                  tint: !activeConnection ? StrandPalette.textTertiary : live.worn ? StrandPalette.accent : StrandPalette.statusWarning,
-                  frac: !activeConnection ? nil : (live.worn ? 1 : 0.25))
+                  tint: !liveLink ? StrandPalette.textTertiary : live.worn ? StrandPalette.accent : StrandPalette.statusWarning,
+                  frac: !liveLink ? nil : (live.worn ? 1 : 0.25))
         ]
     }
 }


### PR DESCRIPTION
Closes #218. On macOS with an Oura Gen3, HR is live and streaming but the Live screen's **Wear State reads "Unknown."**

## Root cause
The wear stat gates on the WHOOP bond:
```swift
private var activeConnection: Bool { live.connected && live.bonded }   // LiveView:53
… value: activeConnection ? (live.worn ? "On wrist" : "Off wrist") : "Unknown"
```
An Oura ring streams with **no WHOOP bond** — `OuraLiveSource` sets `live.connected` + `live.streamingLiveHR`, never `live.bonded`. So `activeConnection` is `false` for a perfectly-streaming ring → the wear stat falls into the `!activeConnection` → **"Unknown"** branch (and the header "Worn" stat reads "—").

The code already tracks the Oura stream via `ringStreaming = live.connected && live.streamingLiveHR` (used for the "STREAMING" pill / accent pulse) — the wear stat just wasn't taught to use it.

## Fix
Widen the wear-stat gate to a `liveLink` = **WHOOP bond OR Oura HR stream**:
```swift
private var liveLink: Bool { activeConnection || ringStreaming }
```
Oura emits PPG HR **only while worn** and stops when the ring is removed, so `ringStreaming` doubles as the wear signal: it now reads **"On wrist"** while streaming and correctly reverts to **"Unknown"** when the ring comes off (stream stops). Applied at both wear displays (the Signal-Trust "Wear state" card + the header "Worn" stat).

## Why it can't regress WHOOP
`live.streamingLiveHR` is set **only** by `OuraLiveSource` — the WHOOP `BLEManager` never touches it (defaults false). So `ringStreaming` is true *only* for a streaming Oura ring; every WHOOP path (4.0 "LIVE HR ONLY", bond-refused 5/MG, etc.) keeps `ringStreaming == false` and is **unchanged**. `activeConnection` is untouched — the gate is only *widened* with an OR.

## Follow-up (not in this PR)
Oura's `WEAR_EVENT` is already decoded (`OuraProtocol/EventTags` → `OuraDriver.state`) but not wired to `live.worn`, so `worn` shows its default `true` for Oura. Wiring it would make the value a real sensor read instead of the streaming-implies-worn inference.

## Verification
Experimental Oura path (macOS/iOS `LiveView`); no Android Oura-live path to mirror. App-target Swift → no default CI, validating `Strand`/`NOOPiOS` via `app-build`. Behaviour wants an on-device check with a ring (streams → "On wrist"; remove → "Unknown") and a WHOOP sanity pass (wear state unchanged).