### PR TITLE
Whoop5Config: add the 16th R22 enable flag (enable_sig12) from a real capture (#103)

### DIFF
--- a/Packages/WhoopProtocol/Sources/WhoopProtocol/Whoop5Config.swift
+++ b/Packages/WhoopProtocol/Sources/WhoopProtocol/Whoop5Config.swift
@@ -37,9 +37,15 @@ public enum Whoop5Config {
         public init(_ name: String, _ value: UInt8) { self.name = name; self.value = value }
     }
 
-    /// The exact ordered enable sequence the official app sends, transcribed verbatim from judes.club's
-    /// frame-builder `FLAGS` array (values are ASCII '1'/'2'). `enable_r22_packets` is what opens the
-    /// type-0x2F biometric stream; the rest tune channel selection, wear detection and sleep behaviour.
+    /// The exact ordered enable sequence the official app sends (values are ASCII '1'/'2').
+    /// `enable_r22_packets` is what opens the type-0x2F biometric stream; the rest tune channel
+    /// selection, wear detection and sleep behaviour.
+    ///
+    /// Flags 1–15 are transcribed verbatim from judes.club's frame-builder `FLAGS` array. Flag 16,
+    /// `enable_sig12`, is NOT in that array: it was observed as a 16th `SET_FF_VALUE` write in a real
+    /// on-strap iOS HCI capture of the official app (WHOOP 5.0, #103), which otherwise reproduced flags
+    /// 1–15 byte-for-byte in this exact order. Its effect is undocumented (like `enable_sig11_during_sleep`);
+    /// it is included because it is part of what the official app actually writes on every connect.
     public static let enableR22Sequence: [Flag] = [
         Flag("enable_r22_packets", 0x32),
         Flag("enable_r22_v2_packets", 0x32),
@@ -56,6 +62,7 @@ public enum Whoop5Config {
         Flag("enable_passive_strap_fit_gen5", 0x31),
         Flag("enable_sig11_during_sleep", 0x32),
         Flag("dorset_inhibit_wpt", 0x32),
+        Flag("enable_sig12", 0x32),   // #103: 16th flag seen in a real on-strap capture, not in judes.club
     ]
 
     /// The 40-byte SET_CONFIG payload body: flag name as UTF-8/ASCII NUL-padded to 32 bytes, value byte

--- a/Packages/WhoopProtocol/Tests/WhoopProtocolTests/Whoop5ConfigTests.swift
+++ b/Packages/WhoopProtocol/Tests/WhoopProtocolTests/Whoop5ConfigTests.swift
@@ -39,16 +39,33 @@ final class Whoop5ConfigTests: XCTestCase {
         XCTAssertTrue(check.ok, "SET_CONFIG frame must pass whoop5 CRC verification")
     }
 
-    func testEnableSequenceIsFifteenFlagsWithDistinctSeqs() {
+    func testEnableSequenceIsSixteenFlagsWithDistinctSeqs() {
         let frames = Whoop5Config.enableSequenceFrames(firstSeq: 1)
-        XCTAssertEqual(frames.count, 15)
+        XCTAssertEqual(frames.count, 16)
         XCTAssertEqual(Whoop5Config.enableR22Sequence.first?.name, "enable_r22_packets")
-        // seq byte lives at inner offset 1 (frame offset 9): 1,2,3,…,15 for this sequence
+        // seq byte lives at inner offset 1 (frame offset 9): 1,2,3,…,16 for this sequence
         let seqs = frames.map { $0[9] }
-        XCTAssertEqual(seqs, Array(1...15))
+        XCTAssertEqual(seqs, Array(1...16))
         // v4 is the one flag whose value is ASCII '1' (0x31), per the documented table
         let v4 = Whoop5Config.enableR22Sequence.first { $0.name == "enable_r22_v4_packets" }
         XCTAssertEqual(v4?.value, 0x31)
+    }
+
+    func testEnableSequenceEndsWithSig12FromRealCapture() {
+        // #103: the 16th flag `enable_sig12` (value ASCII '2') was observed in a real on-strap HCI capture
+        // of the official app, appended after the 15 judes.club-documented flags. It uses the identical
+        // SET_CONFIG encoding, so its frame must build, verify, and carry the exact name+value body.
+        let seq = Whoop5Config.enableR22Sequence
+        XCTAssertEqual(seq.count, 16)
+        XCTAssertEqual(seq.last?.name, "enable_sig12")
+        XCTAssertEqual(seq.last?.value, 0x32)
+        let frame = Whoop5Config.frame(flag: Whoop5Config.Flag("enable_sig12", 0x32), seq: 16)
+        XCTAssertTrue(verifyFrame(frame, family: .whoop5).ok, "enable_sig12 SET_CONFIG must pass CRC")
+        // The 40-byte body carried in the frame is name-NUL-padded with the value at offset 32.
+        let body = Whoop5Config.payloadBody(name: "enable_sig12", value: 0x32)
+        XCTAssertEqual(Array(body[0..<12]), Array("enable_sig12".utf8))
+        XCTAssertTrue(body[12..<32].allSatisfy { $0 == 0 })
+        XCTAssertEqual(body[32], 0x32)
     }
 
     /// Broadcast-HR device-config body (#181): key name ASCII NUL-padded to 32 bytes, then the value

--- a/android/app/src/main/java/com/noop/protocol/Whoop5Config.kt
+++ b/android/app/src/main/java/com/noop/protocol/Whoop5Config.kt
@@ -29,10 +29,12 @@ object Whoop5Config {
     /** One persistent feature flag and the value the official app writes for it (ASCII '1'/'2'). */
     data class Flag(val name: String, val value: Int)
 
-    /** The exact ordered enable sequence the official app sends, transcribed verbatim from
-     *  judes.club's frame-builder FLAGS array. `enable_r22_packets` opens the type-0x2F biometric
-     *  stream; the rest tune channel selection, wear detection and sleep behaviour. Keep in lockstep
-     *  with the Swift `Whoop5Config.enableR22Sequence`. */
+    /** The exact ordered enable sequence the official app sends (values ASCII '1'/'2').
+     *  `enable_r22_packets` opens the type-0x2F biometric stream; the rest tune channel selection, wear
+     *  detection and sleep behaviour. Flags 1–15 are transcribed verbatim from judes.club's frame-builder
+     *  FLAGS array; flag 16 `enable_sig12` is NOT in that array — it was observed as a 16th SET_FF_VALUE
+     *  write in a real on-strap iOS HCI capture (WHOOP 5.0, #103) that otherwise reproduced flags 1–15
+     *  byte-for-byte in this order. Keep in lockstep with the Swift `Whoop5Config.enableR22Sequence`. */
     val enableR22Sequence: List<Flag> = listOf(
         Flag("enable_r22_packets", 0x32),
         Flag("enable_r22_v2_packets", 0x32),
@@ -49,6 +51,7 @@ object Whoop5Config {
         Flag("enable_passive_strap_fit_gen5", 0x31),
         Flag("enable_sig11_during_sleep", 0x32),
         Flag("dorset_inhibit_wpt", 0x32),
+        Flag("enable_sig12", 0x32),   // #103: 16th flag seen in a real on-strap capture, not in judes.club
     )
 
     /** The 40-byte SET_CONFIG payload body: flag name as ASCII NUL-padded to 32 bytes, value byte at

--- a/android/app/src/test/java/com/noop/protocol/Whoop5ConfigTest.kt
+++ b/android/app/src/test/java/com/noop/protocol/Whoop5ConfigTest.kt
@@ -25,14 +25,18 @@ class Whoop5ConfigTest {
     }
 
     @Test
-    fun sequenceIsFifteenFlagsWithExpectedValues() {
+    fun sequenceIsSixteenFlagsWithExpectedValues() {
         val seq = Whoop5Config.enableR22Sequence
-        assertEquals(15, seq.size)
+        assertEquals(16, seq.size)
         assertEquals("enable_r22_packets", seq[0].name)
         assertEquals(0x32, seq[0].value)
         // v4 and the passive-strap-fit flag are the only '1' (0x31) values in the documented set.
         assertEquals(0x31, seq.first { it.name == "enable_r22_v4_packets" }.value)
         assertEquals(0x31, seq.first { it.name == "enable_passive_strap_fit_gen5" }.value)
+        // #103: the 16th flag `enable_sig12` (value '2') was seen in a real on-strap capture, appended
+        // after the 15 judes.club-documented flags. Mirror of the Swift Whoop5ConfigTests guard.
+        assertEquals("enable_sig12", seq.last().name)
+        assertEquals(0x32, seq.last().value)
     }
 
     @Test

--- a/docs/WHOOP5_DEEP_DATA.md
+++ b/docs/WHOOP5_DEEP_DATA.md
@@ -60,7 +60,9 @@ bytes, the value byte (an ASCII `'1'`/`'2'`) at offset 32, then 7 zeros. The exa
 values, is in [`Whoop5Config.swift`](../Packages/WhoopProtocol/Sources/WhoopProtocol/Whoop5Config.swift)
 and [`Whoop5Config.kt`](../android/app/src/main/java/com/noop/protocol/Whoop5Config.kt), golden-tested on
 both platforms. `enable_r22_packets` is the one that opens the type-`0x2F` biometric stream; the rest
-tune channel selection, wear detection and sleep behaviour.
+tune channel selection, wear detection and sleep behaviour. Flags 1–15 come from judes.club's
+frame-builder; the 16th, `enable_sig12`, was added from a real on-strap HCI capture ([#103](https://github.com/ryanbr/noop/issues/103))
+that otherwise reproduced flags 1–15 byte-for-byte in this order.
 
 ## How NOOP uses it (opt-in, reversible)
 
@@ -68,7 +70,7 @@ tune channel selection, wear detection and sleep behaviour.
   *writes* to the strap.
 - A manual **"Send enable sequence to strap"** button (not auto-run on connect), enabled only when a
   5/MG is **bonded and worn** (the R22 stream is on-wrist gated).
-- The 15 flags are written with-response, ~80 ms apart.
+- The 16 flags are written with-response, ~80 ms apart.
 - It's **reversible** — it only changes which data the strap chooses to emit — and is the same thing the
   official app does on every connect.
 - **iOS / Android only on real hardware:** macOS CoreBluetooth can't complete the authenticated SMP bond


### PR DESCRIPTION
## What

The shipped `Whoop5Config.enableR22Sequence` carried the **15** feature flags transcribed from judes.club's frame-builder. A real on-strap iOS **HCI capture** of the official app (WHOOP 5.0, #103) reproduced those 15 **byte-for-byte in the same order**, and then wrote a **16th** `SET_FF_VALUE`:

```
… enable_sig11_during_sleep=2  dorset_inhibit_wpt=2  enable_sig12=2   ← new
```

This appends `enable_sig12` (ASCII `'2'`) so NOOP's enable sequence matches what the official app actually writes on every connect.

## Notes

- **Independent confirmation** of the whole sequence: the capture is a third, on-hardware source that agrees with judes.club + Asherlc/dofek on flags 1–15 (names, order, and the two `'1'` values), which is itself worth having.
- `enable_sig12`'s effect is **undocumented** (same as `enable_sig11_during_sleep`). It uses the **identical** SET_CONFIG encoding, so there is no framing change — only one more entry in the table.
- This intentionally **diverges from the judes.club "byte-for-byte" note** for a good reason: real hardware writes a flag judes.club's builder doesn't list. The source is now noted in the doc + code comments.

## Cross-platform + tests

- Swift `Whoop5Config.swift` + Android `Whoop5Config.kt` twin.
- Both golden tests bumped 15 → 16 flags (seqs 1…16) with a byte-level guard on the new flag (name-NUL-padded body, value at offset 32, frame passes CRC).
- Fixed the two "15 flags" references in `docs/WHOOP5_DEEP_DATA.md`.

## Verification

`cd Packages/WhoopProtocol && swift test` → **253/253 green**. Kotlin twin mirrored but **not compiled** (no Android SDK in my environment) — please run `./gradlew testFullDebugUnitTest`.

Refs #103.

🤖 Generated with [Claude Code](https://claude.com/claude-code)