### PR TITLE
BLE: mark 5.0 REBOOT_STRAP framing verified (fw 50.40.1.0)

### DIFF
--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -2386,7 +2386,7 @@ class WhoopBleClient(
         // Supersede any still-pending reboot (cancels its timers + resets the flag) so a repeat tap can't
         // leave a stale watchdog/settle timer that fires during this new reboot's window.
         clearRebootState()
-        val framing = if (family == DeviceFamily.WHOOP5) "puffin-crc16 (UNVERIFIED on 5/MG)" else "harvard-crc8"
+        val framing = if (family == DeviceFamily.WHOOP5) "puffin-crc16 (verified on 5.0 fw 50.40.1.0)" else "harvard-crc8"
         val fw = _state.value.strapFirmware ?: "unknown"
         log("reboot: request family=$family fw=$fw connected=true bonded=true")
         log("reboot: sent opcode=29 framing=$framing payload=empty writeType=withResponse")
@@ -2398,11 +2398,13 @@ class WhoopBleClient(
         _state.update { it.copy(rebootInProgress = true) }
         rebootWatchdog?.let { handler.removeCallbacks(it) }
         // No-disconnect watchdog: still connected after 12s ⇒ the strap didn't act on the command (the key
-        // signal that a 5/MG puffin reboot frame was silently rejected). A real reboot drops within ~1-2s.
+        // signal that a 5/MG puffin reboot frame was silently rejected). A real reboot drops within ~1-2s
+        // when idle; a strap mid-offload finishes the transfer first (observed ~9s on 5.0 fw 50.40.1.0), so
+        // 12s is the cutoff, not the expected latency.
         val work = Runnable {
             if (rebootRequestedAtMs != null && _state.value.connected) {
                 log("reboot: no disconnect within 12s — strap may have ignored the command" +
-                    if (connectedFamily == DeviceFamily.WHOOP5) " (5/MG puffin framing is unverified — please share this log on #166)" else "")
+                    if (connectedFamily == DeviceFamily.WHOOP5) " (5/MG reboot is verified on 5.0 fw 50.40.1.0; if your firmware differs, please share this log on #166)" else "")
                 clearRebootState()
             }
         }


### PR DESCRIPTION
## What

The #216 "Restart strap" flow labels the WHOOP 5/MG puffin-crc16 `REBOOT_STRAP` framing **UNVERIFIED**, and its 12s no-disconnect watchdog asks users to report on #166. This marks it **verified on a WHOOP 5.0 (fw 50.40.1.0)**.

## Verification

Pressed "Restart strap" on a 5.0 and captured the OS Bluetooth log:

- `15:14:06.961` — the 16-byte `REBOOT_STRAP` frame is written; strap ACKs `GATT_SUCCESS`.
- `15:14:15.852` — the band drops with `GATT_CONN_TIMEOUT`, and **both this app AND the official WHOOP app lose the ACL at the same instant** — only the band dropping the link (a reboot) does that, not a per-app disconnect.
- `15:14:18.9` — the band has re-advertised; the app direct-reconnects and re-bonds by `15:14:19.5`.

So the strap acted on the command, rebooted, re-advertised and reconnected — round trip ~12s, well inside the watchdog. The puffin-crc16 framing is correct on the 5.0.

## Changes (log strings + comments only, no behaviour change)

- Framing log: `"puffin-crc16 (UNVERIFIED on 5/MG)"` → `"verified on 5.0 fw 50.40.1.0"`.
- No-disconnect watchdog message: reframed from "framing is unverified" to "verified on 50.40.1.0; if your firmware differs, please share on #166" (still the fail-path signal).
- Note that the ~1-2s idle-reboot latency stretches (~9s observed) when the strap finishes an in-flight offload before rebooting, so the 12s window is the cutoff, not the expected latency.

Answers the open question the code itself points to (#166). No functional change — diagnostic labels only.