### PR TITLE
BLE: cut battery drain (empty-offload backoff + reconnect-churn dwell-gate)

### DIFF
--- a/android/app/src/main/java/com/noop/ble/BackfillPolicy.kt
+++ b/android/app/src/main/java/com/noop/ble/BackfillPolicy.kt
@@ -1,0 +1,86 @@
+package com.noop.ble
+
+import kotlin.math.min
+import kotlin.math.pow
+
+/**
+ * What prompted a historical-offload attempt. Mirror of the Swift `BackfillTrigger`
+ * (Strand/BLE/BackfillPolicy.swift): the same six cases so [BackfillPolicy.shouldRun] gates
+ * byte-identically across platforms (the cross-platform parity contract).
+ */
+enum class BackfillTrigger {
+    /** The repeating 900s timer while connected + bonded. */
+    PERIODIC,
+
+    /** A (re)connect / bond confirmation. */
+    CONNECT,
+
+    /** The app became active (foreground). */
+    FOREGROUND,
+
+    /** The user tapped "Sync now". */
+    MANUAL,
+
+    /** An incoming strap EVENT packet (WHOOP's HighFreqSyncPrompt analog). */
+    STRAP,
+
+    /** #364: an immediate back-to-back continuation of a deep oldest-first backlog, and the bounded
+     *  WHOOP-5 history retry. Un-floored by design; its runaway protection lives in the caller's
+     *  consecutive-cap, not here. */
+    AUTO_CONTINUE,
+}
+
+/**
+ * Pure rate-limiter for historical-offload kicks. No BLE/store deps. Floors match WHOOP
+ * (observed: ~15-min periodic + expedited event syncs). Exact port of the Swift `BackfillPolicy`
+ * (Strand/BLE/BackfillPolicy.swift) — the constants, the empty-streak backoff curve, and the
+ * per-trigger rules are kept byte-identical so Android and macOS throttle the same way. Ports the
+ * gate that [WhoopBleClient.requestSync] previously flagged as unported on Android, so a strap that
+ * keeps offloading nothing (off-wrist / not banking) stops being re-polled every 15 min.
+ */
+object BackfillPolicy {
+    const val PERIODIC_FLOOR_SECONDS = 900.0 // 15 min
+    const val EVENT_FLOOR_SECONDS = 90.0 // absorbs reconnect-flaps / event bursts
+    const val EMPTY_BACKOFF_THRESHOLD = 3 // empties before the floor starts stretching
+    const val MAX_EMPTY_BACKOFF = 4.0 // cap -> ~6-min event / 1-hr periodic floor
+
+    /**
+     * [emptyStreak] = consecutive COMPLETED offloads that banked no sensor records (EmptySyncTracker).
+     * Past [EMPTY_BACKOFF_THRESHOLD] the AUTOMATIC triggers ([BackfillTrigger.PERIODIC] /
+     * [BackfillTrigger.STRAP]) stretch their floor — each further empty doubles it, capped at
+     * [MAX_EMPTY_BACKOFF] — so an off-wrist / not-banking strap that still emits EVENT packets every 90s
+     * isn't re-offloaded every 90s, draining its battery and ours (#77/#120/#216). [BackfillTrigger.MANUAL]
+     * / [BackfillTrigger.CONNECT] / [BackfillTrigger.FOREGROUND] never back off, and the first real record
+     * resets the streak, so baseline cadence resumes instantly — a user- or connection-driven sync is
+     * never delayed.
+     *
+     * [clockUntrusted] = the strap's own RTC currently reads future-dated (#928). Such a strap still
+     * BANKS real rows every pass, so it never trips [emptyStreak], yet chasing its future-dated range is
+     * near-useless (#1012) while each ~60s offload holds the link — so PERIODIC/STRAP are SKIPPED ENTIRELY
+     * while the clock is untrusted. The per-connection CONNECT pass still runs, so a clock that later
+     * self-corrects is picked up on the next connection (or a manual sync).
+     */
+    fun shouldRun(
+        trigger: BackfillTrigger,
+        nowSeconds: Double,
+        lastBackfillAtSeconds: Double?,
+        emptyStreak: Int = 0,
+        clockUntrusted: Boolean = false,
+    ): Boolean {
+        val last = lastBackfillAtSeconds ?: return true
+        val elapsed = nowSeconds - last
+        val backoff: Double = if (emptyStreak >= EMPTY_BACKOFF_THRESHOLD) {
+            min(2.0.pow((emptyStreak - EMPTY_BACKOFF_THRESHOLD + 1).toDouble()), MAX_EMPTY_BACKOFF)
+        } else {
+            1.0
+        }
+        return when (trigger) {
+            // Never floored: user-tapped, and the #364 expedited backlog drain / bounded history retry
+            // (bounded by the caller's consecutive-cap, not here).
+            BackfillTrigger.MANUAL, BackfillTrigger.AUTO_CONTINUE -> true
+            BackfillTrigger.CONNECT, BackfillTrigger.FOREGROUND -> elapsed >= EVENT_FLOOR_SECONDS
+            BackfillTrigger.STRAP -> !clockUntrusted && elapsed >= EVENT_FLOOR_SECONDS * backoff
+            BackfillTrigger.PERIODIC -> !clockUntrusted && elapsed >= PERIODIC_FLOOR_SECONDS * backoff
+        }
+    }
+}

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -423,6 +423,12 @@ class WhoopBleClient(
          *  stays un-backed-off. The ordinary involuntary-reconnect paths use the capped-exponential
          *  [ReconnectBackoff] instead (#48). (BLEManager: "rescanning in 3s".) */
         private const val RECONNECT_DELAY_MS = 3_000L
+        /** A connection must SURVIVE this long before it's "healthy" enough to clear the involuntary-
+         *  reconnect backoff (see the STATE_CONNECTED handler). A band whose ACL is contended by the
+         *  official WHOOP app reaches STATE_CONNECTED briefly each cycle; without this dwell the backoff
+         *  reset there would pin it at attempt 1 = active DIRECT reconnect (#173) forever, churning the
+         *  phone + strap radios. 8s matches the bond-loop quick-timeout window (a link this short is a flap). */
+        private const val RECONNECT_HEALTHY_DWELL_MS = 8_000L
         /** PR #588: after this many CONSECUTIVE involuntary reconnect attempts, drop the scan from the
          *  battery-hungry LOW_LATENCY mode to a lower-power mode. A strap that's genuinely out of range
          *  (left at home, dead battery) would otherwise hold the radio at full power indefinitely while
@@ -1481,6 +1487,17 @@ class WhoopBleClient(
 
     /** Periodic re-offload + idle-watchdog tokens (handler-posted; cancelled on disconnect). */
     private val periodicBackfillRunnable = Runnable { triggerPeriodicBackfill() }
+
+    /** Wall-clock of the last historical-offload KICK (a [beginBackfill] that actually started), or null
+     *  before the first. Feeds [BackfillPolicy.shouldRun] so the automatic periodic/strap floors can space
+     *  kicks — the Android side of the Swift `BLEManager.lastBackfillAt`. */
+    @Volatile private var lastBackfillAtMs: Long? = null
+
+    /** True while the strap's own RTC reads future-dated (#928/#1012): its offloads bank real rows but the
+     *  range is un-trustworthy, so [BackfillPolicy] SKIPS the automatic periodic/strap kicks (the per-connect
+     *  pass still re-checks). Refreshed from [isFutureDatedNewest] at each completed offload's continue
+     *  decision, so a clock that self-corrects clears it. Twin of the Swift `clockUntrusted` shouldRun arg. */
+    @Volatile private var clockUntrusted: Boolean = false
     private val backfillTimeoutRunnable = Runnable { onBackfillTimeout() }
 
     /** Live-stream keep-alive (port of BLEManager.keepAliveTimer): re-arms realtime, polls battery,
@@ -2709,6 +2726,17 @@ class WhoopBleClient(
         pendingReconnectRunnable = null
     }
 
+    /** Run [action] after [delayMs], but ONLY if the SAME continuous connection is still up when it fires.
+     *  A reconnect (or bond-loop cycle) bumps [connectGeneration], so a transient cycle-connect can't
+     *  satisfy the guard even though the device address is identical across cycles. Both STATE_CONNECTED
+     *  survived-the-dwell timers use it: the re-pair-guide clear (#711) and the reconnect-backoff reset. */
+    private fun runIfConnectionSurvives(delayMs: Long, action: () -> Unit) {
+        val gen = connectGeneration
+        handler.postDelayed({
+            if (_state.value.connected && connectGeneration == gen) action()
+        }, delayMs)
+    }
+
     /** Clear the pairing-hint streak + any published hint for a FRESH user-initiated Connect (#78). Kept
      *  off the involuntary-reconnect path on purpose: the streak must SURVIVE automatic reconnects (like
      *  the #52 pinnedBondRefusals counter) so it can accumulate to the threshold across the strap dropping
@@ -3042,9 +3070,12 @@ class WhoopBleClient(
                     // #1030 (ryanbr): a real link is up — cancel any pending involuntary reconnect so a
                     // stale backoff timer can't fire and reset+close this connection.
                     cancelPendingReconnect()
-                    // A successful connect clears the reconnect backoff — the next involuntary drop
-                    // starts the 3,6,12…s schedule afresh (iOS didConnect: failedConnectAttempts=0, #48).
-                    resetReconnectBackoff()
+                    // A successful connect clears the reconnect backoff (iOS didConnect:
+                    // failedConnectAttempts=0, #48) — but DEFERRED behind the connectGeneration guard below
+                    // (see the reset after the re-pair-guide block) so it only fires once THIS connection has
+                    // SURVIVED [RECONNECT_HEALTHY_DWELL_MS]. Resetting immediately would let a WHOOP-app-
+                    // contended band that flaps through STATE_CONNECTED every few seconds churn active DIRECT
+                    // reconnects forever (#173); deferring lets the backoff escalate to PASSIVE instead.
                     // A connect succeeded → clear the stale-bond re-pair guide UNLESS we are in a known
                     // bond-loop (#617). In that loop the strap "connects" every ~3 s before timing out
                     // again, so clearing here wiped the guide on EVERY cycle: it flashed for ~1 s and
@@ -3059,18 +3090,22 @@ class WhoopBleClient(
                     ) }
                     connectGeneration += 1
                     if (keepGuide) {
-                        val gen = connectGeneration
-                        handler.postDelayed({
-                            // Clear only if the SAME continuous connection is still up: a reconnect (loop
-                            // cycle) bumps connectGeneration, so a transient cycle-connect can't satisfy this
-                            // even though the device address is identical across cycles. Without it, the timer
-                            // could fire during a later cycle's brief connect and wrongly wipe the guide.
-                            if (_state.value.connected && connectGeneration == gen) {
-                                postBondLoop.reset()        // survived the window → the bond-loop is resolved
-                                _state.update { it.copy(reconnectGuide = null) }
-                            }
-                        }, postBondLoop.quickTimeoutWindowMs + 1_000L)
+                        // Clear the guide only if the SAME continuous connection survives the window (a
+                        // reconnect/loop cycle bumps connectGeneration, so a transient cycle-connect can't
+                        // satisfy the guard even though the device address is identical across cycles).
+                        runIfConnectionSurvives(postBondLoop.quickTimeoutWindowMs + 1_000L) {
+                            postBondLoop.reset()        // survived the window → the bond-loop is resolved
+                            _state.update { it.copy(reconnectGuide = null) }
+                        }
                     }
+                    // Clear the involuntary-reconnect backoff only once THIS connection has SURVIVED the dwell
+                    // — same connectGeneration guard as the guide-clear above. A flapping (ACL-contended) band
+                    // bumps connectGeneration on its next brief connect, so this no-ops and failedReconnect-
+                    // Attempts keeps accumulating → the involuntary reconnect escalates to low-power PASSIVE
+                    // autoConnect (>= 3) instead of hammering active DIRECT connects. A genuinely healthy link
+                    // survives the dwell and resets, keeping the snappy 3s first retry. Android hardening for
+                    // the shared-ACL flap; no iOS analogue (iOS isn't co-resident with the WHOOP app).
+                    runIfConnectionSurvives(RECONNECT_HEALTHY_DWELL_MS) { resetReconnectBackoff() }
                     // Multi-WHOOP: publish the connected strap's stable BLE address so SourceCoordinator can
                     // adopt it onto the active registry device's peripheralId on first connect. Additive twin
                     // of macOS BLEManager.connectedPeripheralUUID (set in didConnect). Decoupled from the
@@ -3876,7 +3911,7 @@ class WhoopBleClient(
         // Mac prototype), then re-offload every BACKFILL_INTERVAL_MS. Port of the didWriteValueFor
         // tail: asyncAfter(1.5s) { requestSync(.connect) } + startBackfillTimer().
         backfillStarted = true
-        handler.postDelayed({ requestSync() }, INITIAL_BACKFILL_DELAY_MS)
+        handler.postDelayed({ requestSync(BackfillTrigger.CONNECT) }, INITIAL_BACKFILL_DELAY_MS)
         startBackfillTimer()
         startKeepAlive()
         // Arm realtime HR now if a screen already wants it (Live/Health Monitor opened before the bond
@@ -4388,7 +4423,7 @@ class WhoopBleClient(
                 log("WHOOP 5/MG: clock synced (set/get) — strap can persist history now")
                 if (!backfillStarted) {
                     backfillStarted = true
-                    handler.postDelayed({ requestSync() }, INITIAL_BACKFILL_DELAY_MS)
+                    handler.postDelayed({ requestSync(BackfillTrigger.CONNECT) }, INITIAL_BACKFILL_DELAY_MS)
                     startBackfillTimer()
                 }
                 return
@@ -4553,6 +4588,7 @@ class WhoopBleClient(
         // not "no banked history / charge to 100%". A fresh offload (count 0) keeps the honest guidance.
         backfiller.begin(connectedFamily, continuedAfterRows = consecutiveAutoContinues > 0)   // family drives the +4 puffin offset for 5/MG (#78)
         backfilling = true
+        lastBackfillAtMs = System.currentTimeMillis()   // the BackfillPolicy floor is measured from the last KICK
         ackedChunksThisSession = 0
         decodedChunksThisSession = 0
         consoleChunksThisSession = 0
@@ -4594,13 +4630,30 @@ class WhoopBleClient(
 
     /**
      * The single gated entry point for every historical-offload kick. Runs only when connected +
-     * bonded and NOT already mid-backfill. Port of `requestSync` minus the BackfillPolicy
-     * rate-limiter (see FLAG: the policy gate isn't ported here — the only triggers wired are the
-     * once-per-connect kick and the 900s periodic timer, which is itself the coarse rate limit).
+     * bonded and NOT already mid-backfill, then through [BackfillPolicy] (the Swift parity gate, now
+     * ported — see Strand/BLE/BackfillPolicy.swift): the caller passes the [BackfillTrigger] so the
+     * AUTOMATIC periodic/strap kicks are floored, empty-streak-backed-off, and skipped on an untrusted
+     * clock, while manual/connect/foreground run at the 90s event floor. Previously the fixed 900s timer
+     * was the only coarse limit, so a not-banking strap was re-offloaded every 15 min forever.
      */
-    private fun requestSync() {
+    private fun requestSync(trigger: BackfillTrigger) {
         val s = _state.value
         if (!canRequestSync(s.connected, s.bonded, backfilling)) return
+        if (!BackfillPolicy.shouldRun(
+                trigger = trigger,
+                nowSeconds = System.currentTimeMillis() / 1000.0,
+                lastBackfillAtSeconds = lastBackfillAtMs?.let { it / 1000.0 },
+                emptyStreak = emptySyncTracker.consecutiveEmptySyncs,
+                clockUntrusted = clockUntrusted,
+            )
+        ) {
+            log(
+                "Backfill: skipped ($trigger) - policy floor not met " +
+                    "(empty streak ${emptySyncTracker.consecutiveEmptySyncs}" +
+                    "${if (clockUntrusted) ", clock future-dated" else ""})",
+            )
+            return
+        }
         beginBackfill()
     }
 
@@ -4614,12 +4667,12 @@ class WhoopBleClient(
      * thread, and every other timer/GATT path is pinned to this handler (see connectGatt(..., handler)).
      */
     fun syncNow() {
-        handler.post { requestSync() }
+        handler.post { requestSync(BackfillTrigger.MANUAL) }
     }
 
     /** Periodic-timer callback: re-runs the type-47 offload (the primary metric sync). */
     private fun triggerPeriodicBackfill() {
-        requestSync()
+        requestSync(BackfillTrigger.PERIODIC)
         // Re-arm regardless so the cadence continues for the life of the connection.
         handler.postDelayed(periodicBackfillRunnable, BACKFILL_INTERVAL_MS)
     }
@@ -4688,7 +4741,9 @@ class WhoopBleClient(
             handler.removeCallbacks(backfillTimeoutRunnable)
             backfillFrameQueue.clear()
             log("Backfill: no history frames arrived — retrying request (attempt ${whoop5HistoryAttempts + 1})")
-            handler.postDelayed({ requestSync() }, WHOOP5_HISTORY_RETRY_DELAY_MS)
+            // Bounded mid-attempt retry (whoop5HistoryAttempts < 2): AUTO_CONTINUE so the 90s event floor
+            // can't suppress it — it's continuing THIS connect's offload, not a fresh periodic kick.
+            handler.postDelayed({ requestSync(BackfillTrigger.AUTO_CONTINUE) }, WHOOP5_HISTORY_RETRY_DELAY_MS)
             return
         }
         backfiller.timeoutFired()
@@ -4889,9 +4944,9 @@ class WhoopBleClient(
      * path it instead clears [consecutiveAutoContinues] (#25). The decision is the pure [shouldAutoContinue]
      * so it stays unit-testable.
      * [trimAdvanced] is the spin-detector signal computed in [exitBackfilling] (passed in because that
-     * method has already advanced [lastSessionEndTrim] past the comparison point). Android has no
-     * BackfillPolicy floor ported (only the 900s timer), so [requestSync] needs no special bypass tier —
-     * it always runs when the gate passes. Mirrors Swift `maybeAutoContinueBackfill`.
+     * method has already advanced [lastSessionEndTrim] past the comparison point). The re-kick uses
+     * [BackfillTrigger.AUTO_CONTINUE], one of the un-floored triggers in [BackfillPolicy.shouldRun], so the
+     * 15-min periodic floor can't suppress an in-progress backlog drain. Mirrors Swift `maybeAutoContinueBackfill`.
      */
     private fun maybeAutoContinueBackfill(trimAdvanced: Boolean, rowsPersisted: Int) {
         val s = _state.value
@@ -4901,6 +4956,9 @@ class WhoopBleClient(
         ioScope.launch {
             val frontier = runCatching { repository.latestHrSampleTs(deviceId) }.getOrNull()
             val wallNow = System.currentTimeMillis() / 1000L   // #928: real wall clock, at decision time
+            // Refresh the clock-trust state for BackfillPolicy: a future-dated newest (#1012) makes the
+            // AUTOMATIC periodic/strap kicks near-useless, so the policy skips them until it self-corrects.
+            clockUntrusted = isFutureDatedNewest(newest, wallNow)
             val stillConnected = _state.value.connected && _state.value.bonded
             if (!shouldAutoContinue(
                     stillConnected = stillConnected,
@@ -4919,7 +4977,7 @@ class WhoopBleClient(
                 // frozen-trim / cap / disconnect stop is never misattributed to the clock. Twin of the
                 // Swift maybeAutoContinueBackfill line.
                 if (stillConnected && rowsPersisted > 0 && trimAdvanced &&
-                    count < MAX_AUTO_CONTINUES && isFutureDatedNewest(newest, wallNow)
+                    count < MAX_AUTO_CONTINUES && clockUntrusted   // just set above from isFutureDatedNewest(newest, wallNow)
                 ) {
                     val aheadH = ((newest ?: wallNow) - wallNow) / 3600L
                     log(
@@ -4952,7 +5010,7 @@ class WhoopBleClient(
                         "${newest ?: "?"}); re-kicking offload $consecutiveAutoContinues/$MAX_AUTO_CONTINUES " +
                         "without waiting the 15-min floor.",
                 )
-                requestSync()
+                requestSync(BackfillTrigger.AUTO_CONTINUE)
             }
         }
     }
@@ -5298,6 +5356,10 @@ class WhoopBleClient(
         backfillDraining = false
         backfillFrameQueue.clear()
         strapNewestTs = null
+        // clockUntrusted is DERIVED from strapNewestTs (set in maybeAutoContinueBackfill); clear it with its
+        // source so a torn-down connection can't carry a stale future-clock verdict into the next one and
+        // wrongly skip that connection's automatic periodic/strap kicks before its own offload refreshes it.
+        clockUntrusted = false
         offloadFramesThisSession = 0
         lastOffloadFrameAtMs = 0L   // #174: don't carry a stale cooldown reference into the next session
         historicalKickSent = false

--- a/android/app/src/test/java/com/noop/ble/BackfillPolicyTest.kt
+++ b/android/app/src/test/java/com/noop/ble/BackfillPolicyTest.kt
@@ -1,0 +1,93 @@
+package com.noop.ble
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Parity tests for [BackfillPolicy] — the port of the Swift `BackfillPolicy`
+ * (Strand/BLE/BackfillPolicy.swift). They pin the empty-streak backoff curve and the per-trigger floors
+ * so Android and macOS throttle historical offloads identically (the cross-platform parity contract),
+ * and cover the battery point this port exists for: a not-banking strap stops being re-offloaded every
+ * 15 min.
+ */
+class BackfillPolicyTest {
+
+    // The first-ever call (no prior backfill) always runs, whatever the trigger.
+    @Test
+    fun nullLastAlwaysRuns() {
+        for (t in BackfillTrigger.values()) {
+            assertTrue(t.name, BackfillPolicy.shouldRun(t, nowSeconds = 1000.0, lastBackfillAtSeconds = null))
+        }
+    }
+
+    // MANUAL + AUTO_CONTINUE are never floored (run even 1s after the last kick), and are immune to the
+    // empty-streak backoff and the untrusted-clock skip — a user or an active drain is never delayed.
+    @Test
+    fun manualAndAutoContinueBypassEverything() {
+        assertTrue(BackfillPolicy.shouldRun(BackfillTrigger.MANUAL, 1001.0, 1000.0))
+        assertTrue(BackfillPolicy.shouldRun(BackfillTrigger.AUTO_CONTINUE, 1001.0, 1000.0))
+        assertTrue(
+            BackfillPolicy.shouldRun(
+                BackfillTrigger.MANUAL, 1001.0, 1000.0, emptyStreak = 9, clockUntrusted = true,
+            ),
+        )
+        assertTrue(
+            BackfillPolicy.shouldRun(
+                BackfillTrigger.AUTO_CONTINUE, 1001.0, 1000.0, emptyStreak = 9, clockUntrusted = true,
+            ),
+        )
+    }
+
+    // CONNECT/FOREGROUND use the 90s event floor and NEVER back off on empties.
+    @Test
+    fun connectUsesEventFloorNoBackoff() {
+        assertFalse(BackfillPolicy.shouldRun(BackfillTrigger.CONNECT, 1089.0, 1000.0)) // 89s < 90
+        assertTrue(BackfillPolicy.shouldRun(BackfillTrigger.CONNECT, 1090.0, 1000.0)) // 90s
+        assertTrue(BackfillPolicy.shouldRun(BackfillTrigger.FOREGROUND, 1090.0, 1000.0))
+        // A big empty streak does NOT stretch the event floor for CONNECT/FOREGROUND.
+        assertTrue(BackfillPolicy.shouldRun(BackfillTrigger.CONNECT, 1090.0, 1000.0, emptyStreak = 9))
+    }
+
+    // PERIODIC: 900s base floor, no backoff below the threshold.
+    @Test
+    fun periodicBaseFloor() {
+        assertFalse(BackfillPolicy.shouldRun(BackfillTrigger.PERIODIC, 1899.0, 1000.0)) // 899s < 900
+        assertTrue(BackfillPolicy.shouldRun(BackfillTrigger.PERIODIC, 1900.0, 1000.0)) // 900s
+        // streak 2 is below EMPTY_BACKOFF_THRESHOLD (3) => still the 1x (900s) floor.
+        assertTrue(BackfillPolicy.shouldRun(BackfillTrigger.PERIODIC, 1900.0, 1000.0, emptyStreak = 2))
+    }
+
+    // PERIODIC empty-streak backoff curve: streak 3 -> 2x (1800s), streak 4 -> 4x (3600s), streak>=4 capped.
+    @Test
+    fun periodicBackoffCurveMatchesSwift() {
+        // streak 3 => 2x => floor 1800s
+        assertFalse(BackfillPolicy.shouldRun(BackfillTrigger.PERIODIC, 1000.0 + 1799.0, 1000.0, emptyStreak = 3))
+        assertTrue(BackfillPolicy.shouldRun(BackfillTrigger.PERIODIC, 1000.0 + 1800.0, 1000.0, emptyStreak = 3))
+        // streak 4 => 4x => floor 3600s (1 hr)
+        assertFalse(BackfillPolicy.shouldRun(BackfillTrigger.PERIODIC, 1000.0 + 3599.0, 1000.0, emptyStreak = 4))
+        assertTrue(BackfillPolicy.shouldRun(BackfillTrigger.PERIODIC, 1000.0 + 3600.0, 1000.0, emptyStreak = 4))
+        // streak 9 => 2^7 capped at 4x => still 3600s, not runaway.
+        assertFalse(BackfillPolicy.shouldRun(BackfillTrigger.PERIODIC, 1000.0 + 3599.0, 1000.0, emptyStreak = 9))
+        assertTrue(BackfillPolicy.shouldRun(BackfillTrigger.PERIODIC, 1000.0 + 3600.0, 1000.0, emptyStreak = 9))
+    }
+
+    // STRAP mirrors PERIODIC's backoff but off the 90s event floor: streak 4 => 4x => 360s (~6 min).
+    @Test
+    fun strapEventFloorBacksOff() {
+        assertTrue(BackfillPolicy.shouldRun(BackfillTrigger.STRAP, 1090.0, 1000.0)) // 90s, no streak
+        assertFalse(BackfillPolicy.shouldRun(BackfillTrigger.STRAP, 1000.0 + 359.0, 1000.0, emptyStreak = 4))
+        assertTrue(BackfillPolicy.shouldRun(BackfillTrigger.STRAP, 1000.0 + 360.0, 1000.0, emptyStreak = 4))
+    }
+
+    // An untrusted (future-dated) clock SKIPS the automatic triggers entirely, but never the event/manual
+    // ones — so the per-connection pass still re-checks and a self-corrected clock resumes.
+    @Test
+    fun untrustedClockSkipsAutomaticOnly() {
+        assertFalse(BackfillPolicy.shouldRun(BackfillTrigger.PERIODIC, 100_000.0, 1000.0, clockUntrusted = true))
+        assertFalse(BackfillPolicy.shouldRun(BackfillTrigger.STRAP, 100_000.0, 1000.0, clockUntrusted = true))
+        assertTrue(BackfillPolicy.shouldRun(BackfillTrigger.CONNECT, 1090.0, 1000.0, clockUntrusted = true))
+        assertTrue(BackfillPolicy.shouldRun(BackfillTrigger.FOREGROUND, 1090.0, 1000.0, clockUntrusted = true))
+        assertTrue(BackfillPolicy.shouldRun(BackfillTrigger.MANUAL, 1001.0, 1000.0, clockUntrusted = true))
+    }
+}


### PR DESCRIPTION
Two related fixes for a WHOOP band + phone draining faster than they should, sharing a small BackfillPolicy parity port. Validated on a contended WHOOP 5.0 (fw 50.40.1.0).

## 1. Historical-offload backoff

Android re-ran the type-47 offload **every 15 min for the life of the connection even when the strap kept banking nothing**, waking the strap NAND and holding the link on a fixed cadence. macOS already floors + backs this off via `BackfillPolicy`; that gate was flagged unported on Android (`requestSync` "minus the BackfillPolicy rate-limiter").

Ports `BackfillPolicy` (`Strand/BLE/BackfillPolicy.swift`) to `com.noop.ble.BackfillPolicy`:
- 15-min periodic / 90s event floors,
- an **empty-streak backoff** that stretches the automatic periodic/strap kicks to a 1-hour floor once offloads keep coming back empty,
- a skip of those automatic kicks while the strap clock reads future-dated (#928/#1012).

`requestSync` now takes a `BackfillTrigger` and gates through it; **manual/connect/foreground are never delayed**, and the first real record resets the streak. Covered by `BackfillPolicyTest` (parity with the Swift backoff curve).

## 2. Reconnect-churn dwell-gate

The direct-first reconnect makes involuntary attempts 1‑2 active DIRECT connects. On a band whose ACL is contended by the official WHOOP app it reaches `STATE_CONNECTED` briefly each cycle, and the backoff reset there pinned it at attempt 1 = active DIRECT reconnect indefinitely, keeping both radios hot.

Defers the `STATE_CONNECTED` backoff reset behind the existing `connectGeneration` guard plus an 8s survival dwell (`RECONNECT_HEALTHY_DWELL_MS`): a flap bumps `connectGeneration` so the reset no-ops and `failedReconnectAttempts` accumulates, so the involuntary reconnect **escalates to low-power PASSIVE `autoConnect` (>= 3)** instead of hammering DIRECT. A healthy link survives the dwell and resets, keeping the snappy 3s first retry. It does **not** trip the bond-loop re-pair guide (the band isn't bond-looping, just contended). The survived-dwell guard is shared with the re-pair-guide clear via `runIfConnectionSurvives()`.

## Test plan

- [x] `./gradlew :app:testFullDebugUnitTest --tests "com.noop.ble.*"` green (BackfillPolicyTest + the rest).
- [x] BLE timing behaviour validated on a contended 5.0 (fw 50.40.1.0).
- Android-only reimplementation; the `BackfillPolicy` port mirrors the existing Swift `BackfillPolicy` (no Swift change needed — it already has it).