### PR TITLE
Fix #226: NOOP missing from Health Connect App permissions on Android 13

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -146,9 +146,15 @@
             android:exported="true"
             android:label="@string/app_name"
             android:theme="@style/Theme.NOOP">
-            <!-- Health Connect permissions-rationale route (Android 13 and below). -->
+            <!-- Health Connect permissions-rationale route for Android 13 and below (#226). The standalone
+                 Health Connect APK on API ≤33 DISCOVERS + lists compatible apps by this intent-filter, so
+                 the action name must be the legacy `androidx.health.ACTION_SHOW_PERMISSIONS_RATIONALE`.
+                 The previous `androidx.health.connect.action.SHOW_PERMISSIONS_RATIONALE` is neither the
+                 API-33 nor API-34 form, so an Android-13 HC APK never enumerated NOOP — it was absent from
+                 Health Connect's "App permissions" entirely and permissions couldn't be granted. Android 14+
+                 (HC in the platform) uses the `ViewPermissionUsageActivity` alias below instead. -->
             <intent-filter>
-                <action android:name="androidx.health.connect.action.SHOW_PERMISSIONS_RATIONALE" />
+                <action android:name="androidx.health.ACTION_SHOW_PERMISSIONS_RATIONALE" />
             </intent-filter>
         </activity>
 


### PR DESCRIPTION
Closes #226. On Android 13, NOOP reports Health Connect not-granted but **doesn't appear in Health Connect's "App permissions" list at all** (confirmed by the reporter in both Allowed *and* Denied), so permissions can't be granted and no HC data imports.

## Root cause
Health Connect is discovered two different ways by OS version:

| | Android 14+ (HC in platform) | Android 13 (HC standalone APK) |
|---|---|---|
| Discovery hook | `VIEW_PERMISSION_USAGE` alias + `HEALTH_PERMISSIONS` category | `androidx.health.ACTION_SHOW_PERMISSIONS_RATIONALE` intent-filter on an exported app activity |
| NOOP had it? | ✅ (`ViewPermissionUsageActivity`) | ❌ |

NOOP's `MainActivity` declared **`androidx.health.connect.action.SHOW_PERMISSIONS_RATIONALE`** — which is *neither* the API-33 legacy form *nor* the API-34 form (and is already contributed by the `connect-client` library anyway). So the **standalone HC APK on Android 13 never enumerated NOOP**, and it was absent from the permissions list entirely. Android 14+ was unaffected because it discovers NOOP via the `VIEW_PERMISSION_USAGE` alias — which is why this only reproduced on Android 13.

## Fix
Correct `MainActivity`'s rationale intent-filter to the legacy discovery action `androidx.health.ACTION_SHOW_PERMISSIONS_RATIONALE`. Manifest-only — the HC `<uses-permission>`s, the `com.google.android.apps.healthdata` `<queries>`, and the Android-14 alias were all already correct.

## Verification
Manifest merges clean (`processFullDebugMainManifest`), and the merged output now carries the legacy action on NOOP's exported `MainActivity`. **This genuinely needs an on-device check on Android 13** (I can't exercise HC discovery here): install a build with this filter → NOOP should now appear under Health Connect → App permissions and be grantable. Android 14+ behaviour is unchanged (still the `VIEW_PERMISSION_USAGE` alias).