### PR TITLE
BLE: mark 5.0 REBOOT_STRAP framing verified on Swift too (#227 parity)

### DIFF
--- a/Strand/BLE/BLEManager.swift
+++ b/Strand/BLE/BLEManager.swift
@@ -2215,7 +2215,7 @@ public final class BLEManager: NSObject, ObservableObject {
         // Supersede any still-pending reboot (cancels its timers + resets the flag) so a repeat tap can't
         // leave a stale watchdog/settle timer that fires during this new reboot's window.
         clearRebootState()
-        let framing = family == .whoop5 ? "puffin-crc16 (UNVERIFIED on 5/MG)" : "harvard-crc8"
+        let framing = family == .whoop5 ? "puffin-crc16 (verified on 5.0 fw 50.40.1.0)" : "harvard-crc8"
         let fw = state.strapFirmware ?? "unknown"
         log("reboot: request family=\(family) fw=\(fw) connected=true bonded=true")
         log("reboot: sent opcode=29 framing=\(framing) payload=empty writeType=withResponse")
@@ -2227,12 +2227,14 @@ public final class BLEManager: NSObject, ObservableObject {
         // path clears it). The pill only shows it once the link actually drops (it gates on !connected).
         state.rebootInProgress = true
         // No-disconnect watchdog: if the link is still up after 12 s the strap didn't act on the command —
-        // the key signal that a 5/MG puffin reboot frame was silently rejected. (A real reboot drops the
-        // link within a second or two.) Cancelled by didDisconnectPeripheral when the reboot takes.
+        // the key signal that a 5/MG puffin reboot frame was silently rejected. A real reboot drops within
+        // ~1-2 s when idle; a strap mid-offload finishes the transfer first (observed ~9 s on 5.0
+        // fw 50.40.1.0), so 12 s is the cutoff, not the expected latency. Cancelled by
+        // didDisconnectPeripheral when the reboot takes.
         let work = DispatchWorkItem { [weak self] in
             guard let self, self.rebootRequestedAt != nil, self.state.connected else { return }
             self.log("reboot: no disconnect within 12s — strap may have ignored the command"
-                     + (self.selectedModel.deviceFamily == .whoop5 ? " (5/MG puffin framing is unverified — please share this log on #166)" : ""))
+                     + (self.selectedModel.deviceFamily == .whoop5 ? " (5/MG reboot is verified on 5.0 fw 50.40.1.0; if your firmware differs, please share this log on #166)" : ""))
             self.clearRebootState()
         }
         rebootTimeoutWork = work


### PR DESCRIPTION
Follow-up to #227, which marked the WHOOP 5/MG puffin-crc16 `REBOOT_STRAP` framing **verified** (on-hardware capture, 5.0 fw 50.40.1.0) on Android but only touched `WhoopBleClient.kt`. `BLEManager.swift` still said "UNVERIFIED on 5/MG", so an iPhone/Mac 5.0 owner saw the opposite diagnostic of an Android one.

The puffin reboot framing is the same protocol on 5/MG regardless of platform (both build `puffinCommandFrame(29, empty)`), so tanarchytan's verification carries to iOS/macOS. Brings the two strap-log strings + the no-disconnect watchdog comment into lockstep with Android.

**Log strings + comment only — no behaviour change.** App-target Swift, so validating the compile via `app-build`.