### PR TITLE
Devices: don't show "Active · Live" for a bond-refused strap (#221)

### DIFF
--- a/Strand/Screens/DevicesView.swift
+++ b/Strand/Screens/DevicesView.swift
@@ -92,6 +92,13 @@ private struct DevicesContent: View {
                     device: device,
                     isActive: device.status == .active,
                     isLiveConnected: device.status == .active && live.connected,
+                    // #221: data is actually FLOWING — a genuine WHOOP bond, the 5/MG live-HR-over-unbonded
+                    // shortcut (#69, which flips `bonded` true), or a streaming Oura ring. Only this claims
+                    // "Live"; a bare BLE link (bond refused / still settling) must not.
+                    isLiveStreaming: device.status == .active && live.connected && (live.bonded || live.streamingLiveHR),
+                    // #221: BLE-connected but the strap is REFUSING the encrypted bond (`pairingHint` set —
+                    // the WHOOP app or a stale iOS pairing holds it, so no HR/biometrics flow).
+                    pairingBlocked: device.status == .active && live.connected && live.pairingHint != nil,
                     // Reboot in flight + link currently down → "Reconnecting…" (#166).
                     isReconnecting: device.status == .active && live.rebootInProgress && !live.connected,
                     // The live battery belongs to whichever device is ACTIVE + connected (the WHOOP, a
@@ -288,6 +295,14 @@ private struct DeviceCard: View {
     let device: PairedDevice
     let isActive: Bool
     let isLiveConnected: Bool
+    /// #221: data is actually FLOWING on the active link — a genuine WHOOP encrypted bond, the 5/MG
+    /// live-HR-over-unbonded-profile shortcut (#69), or a streaming Oura ring. Distinct from
+    /// `isLiveConnected` (BLE link up, which is also true before/without a bond): only this claims "Live".
+    var isLiveStreaming: Bool = false
+    /// #221: the active strap is BLE-connected but REFUSING the encrypted bond (`pairingHint` set — held
+    /// by the official WHOOP app or a stale iOS pairing). No HR/biometrics flow, so the card reads
+    /// "Not paired" (pointing at the pairing-mode guidance) instead of a misleading "Live".
+    var pairingBlocked: Bool = false
     /// The active strap's link dropped for a user-initiated reboot and NOOP is auto-reconnecting (#166).
     /// Drives the transient "Reconnecting…" pill; false for every non-reboot state.
     var isReconnecting: Bool = false
@@ -491,9 +506,21 @@ private struct DeviceCard: View {
                 // the instant the link is back.
                 if isReconnecting {
                     StatePill("Reconnecting…", tone: .warning, pulsing: true)
+                } else if isLiveStreaming {
+                    // Data is genuinely flowing (bond or a streaming ring) — the only state that earns "Live".
+                    StatePill("Active · Live", tone: .positive, pulsing: true)
+                } else if isLiveConnected {
+                    // #221: the BLE link is up but NOTHING is streaming. The old code showed "Active · Live"
+                    // here — keyed on the link alone — which read as working when no HR/biometrics flow.
+                    // Refusing the bond (`pairingBlocked`, held by the WHOOP app / a stale pairing) → the
+                    // honest "Not paired"; otherwise the bond is still settling → "Connecting…".
+                    if pairingBlocked {
+                        StatePill("Active · Not paired", tone: .warning)
+                    } else {
+                        StatePill("Active · Connecting…", tone: .warning, pulsing: true)
+                    }
                 } else {
-                    StatePill(isLiveConnected ? "Active · Live" : "Active",
-                              tone: .positive, pulsing: isLiveConnected)
+                    StatePill("Active", tone: .positive)
                 }
             } else {
                 StatePill("Paired", tone: .neutral)
@@ -785,7 +812,7 @@ struct DeviceCardCatalog: View {
                        topBackground: liquidScaffoldSky()) {
             VStack(spacing: NoopMetrics.gap) {
                 DeviceCard(device: Self.dev("whoop-4d", "WHOOP", "4.0", Self.whoopCaps),
-                           isActive: true, isLiveConnected: true,
+                           isActive: true, isLiveConnected: true, isLiveStreaming: true,
                            onMakeActive: {}, onRename: {}, onRemove: nil)
                 DeviceCard(device: Self.dev("whoop-5d", "WHOOP", "5.0 MG",
                                             Self.whoopCaps.union([.steps])),
@@ -818,9 +845,9 @@ struct OuraDeviceDemoScreen: View {
                        subtitle: "A locally-adopted Oura ring, in beta.",
                        topBackground: liquidScaffoldSky()) {
             VStack(spacing: NoopMetrics.gap) {
-                // Active + connected so the card shows "Active · Live" + a live battery readout.
+                // Active + connected + streaming so the card shows "Active · Live" + a live battery readout.
                 DeviceCard(device: DeviceCardCatalog.oura("Oura Ring 3"),
-                           isActive: true, isLiveConnected: true, liveBatteryPct: 71,
+                           isActive: true, isLiveConnected: true, isLiveStreaming: true, liveBatteryPct: 71,
                            onMakeActive: {}, onRename: {}, onRemove: {})
                 // A second, paired-but-not-connected gen-4 ring so the honest local-state note + per-gen
                 // copy render in the same shot.

--- a/android/app/src/main/java/com/noop/ui/DevicesScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/DevicesScreen.kt
@@ -157,6 +157,13 @@ fun DevicesScreen(
                 device = device,
                 isActive = device.status == DeviceStatus.active.name,
                 isLiveConnected = device.status == DeviceStatus.active.name && live.connected,
+                // #221: data is actually FLOWING — a genuine WHOOP bond, the 5/MG live-HR-over-unbonded
+                // shortcut (#69, which flips `bonded` true), or a streaming Oura ring. Only this claims
+                // "Live"; a bare BLE link (bond refused / still settling) must not.
+                isLiveStreaming = device.status == DeviceStatus.active.name && live.connected && (live.bonded || live.streamingLiveHR),
+                // #221: BLE-connected but the strap is REFUSING the encrypted bond (`pairingHint` set —
+                // the WHOOP app or a stale pairing holds it, so no HR/biometrics flow).
+                pairingBlocked = device.status == DeviceStatus.active.name && live.connected && live.pairingHint != null,
                 // Reboot in flight + link currently down → "Reconnecting…" (#166).
                 isReconnecting = device.status == DeviceStatus.active.name && live.rebootInProgress && !live.connected,
                 // The live battery belongs to whichever device is ACTIVE + connected (WHOOP, a generic
@@ -319,6 +326,14 @@ private fun DeviceCard(
     device: PairedDeviceRow,
     isActive: Boolean,
     isLiveConnected: Boolean,
+    /** #221: data is actually FLOWING on the active link — a genuine WHOOP encrypted bond, the 5/MG
+     *  live-HR-over-unbonded-profile shortcut (#69), or a streaming Oura ring. Distinct from
+     *  [isLiveConnected] (BLE link up, also true before/without a bond): only this claims "Live". */
+    isLiveStreaming: Boolean = false,
+    /** #221: the active strap is BLE-connected but REFUSING the encrypted bond (`pairingHint` set — held
+     *  by the official WHOOP app or a stale pairing). No HR/biometrics flow, so the card reads
+     *  "Not paired" instead of a misleading "Live". */
+    pairingBlocked: Boolean = false,
     /** The active strap's link dropped for a user-initiated reboot and NOOP is auto-reconnecting (#166).
      *  Drives the transient "Reconnecting…" pill; false for every non-reboot state. */
     isReconnecting: Boolean = false,
@@ -383,7 +398,7 @@ private fun DeviceCard(
                     StatePill("Beta", tone = StrandTone.Warning, showsDot = false)
                     Spacer(Modifier.width(6.dp))
                 }
-                StatePill(device, isActive, isLiveConnected, isReconnecting)
+                StatePill(device, isActive, isLiveConnected, isLiveStreaming, pairingBlocked, isReconnecting)
             }
 
             // Honest local-takeover state row for an adopted Oura ring that is paired but not the
@@ -492,6 +507,8 @@ private fun StatePill(
     device: PairedDeviceRow,
     isActive: Boolean,
     isLiveConnected: Boolean,
+    isLiveStreaming: Boolean = false,
+    pairingBlocked: Boolean = false,
     isReconnecting: Boolean = false,
 ) {
     when {
@@ -501,12 +518,19 @@ private fun StatePill(
         // as intentional rather than a silent drop to "Active"; clears to "Active · Live" once the link is back.
         isActive && isReconnecting ->
             StatePill("Reconnecting…", tone = StrandTone.Warning, pulsing = true)
+        // Data is genuinely flowing (bond or a streaming ring) — the only state that earns "Live".
+        isActive && isLiveStreaming ->
+            StatePill("Active · Live", tone = StrandTone.Positive, pulsing = true)
+        // #221: the BLE link is up but NOTHING is streaming. The old code showed "Active · Live" here —
+        // keyed on the link alone — which read as working when no HR/biometrics flow. Refusing the bond
+        // (`pairingBlocked`, held by the WHOOP app / a stale pairing) → the honest "Not paired"; otherwise
+        // the bond is still settling → "Connecting…".
+        isActive && isLiveConnected && pairingBlocked ->
+            StatePill("Active · Not paired", tone = StrandTone.Warning)
+        isActive && isLiveConnected ->
+            StatePill("Active · Connecting…", tone = StrandTone.Warning, pulsing = true)
         isActive ->
-            StatePill(
-                if (isLiveConnected) "Active · Live" else "Active",
-                tone = StrandTone.Positive,
-                pulsing = isLiveConnected,
-            )
+            StatePill("Active", tone = StrandTone.Positive)
         else -> StatePill("Paired", tone = StrandTone.Neutral)
     }
 }


### PR DESCRIPTION
Fixes #221.

## Problem
The Devices card badge keyed "Active · Live" purely on the BLE link (`isLiveConnected = active && live.connected`), which is true the instant CoreBluetooth connects — before any encrypted bond — and stays true when a WHOOP 5/MG **refuses** the bond (the official WHOOP app or a stale iOS pairing holds it). In that state no HR/biometrics flow, yet the card rendered a green pulsing **"Active · Live"**, reading as working when it wasn't (HR "Waiting for the strap", Charge/Effort/Rest "–", Buzz greyed out).

## Fix
Gate the "Live" claim on data actually flowing, mirroring `LiveView`'s existing `activeConnection` notion:

- `connected && (bonded || streamingLiveHR)` → **"Active · Live"** — a genuine bond, the #69 live-HR-over-unbonded shortcut, or a streaming Oura ring.
- connected, not streaming, `pairingHint` set → **"Active · Not paired"** (amber) — the bond-refused state; points at the pairing-mode guidance NOOP already surfaces.
- connected, not streaming, no hint → **"Active · Connecting…"** (amber, transient).

Battery/firmware readouts are untouched — they legitimately show on a bare BLE link.

## Cross-platform
Fixes the identical badge in the Android twin (`DevicesScreen.kt`) with matching labels, tones, and logic.

## Verification
- macOS `Strand` scheme builds (shared Swift, so covers the iOS target too).
- Android reviewed by hand — no local SDK to compile; please run `android.yml` / a local `compileFullDebugKotlin` before merge.
- Pure UI/badge change — no analytics/stored-data change, and the BLE/bond path is untouched (nothing new to hardware-test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)