### PR TITLE
Today: label the Home sleep row with its source + night (#110)

### DIFF
--- a/Strand/Screens/TodayView.swift
+++ b/Strand/Screens/TodayView.swift
@@ -2015,7 +2015,12 @@ struct TodayView: View {
             pinnedCardRow(icon: card.icon, tint: tint, title: card.title, subtitle: card.subtitle,
                           value: dashboardValue(card), route: .health)
         case .sleep:
-            pinnedCardRow(icon: card.icon, tint: tint, title: card.title, subtitle: card.subtitle,
+            // #110: the value is `totalSleepMin` — WHOOP's imported TST, which can legitimately differ
+            // from the Sleep tab's on-device re-staged night. Label the row with its source + which night
+            // so a WHOOP figure (or an older night) is never silently shown as "last night" with no
+            // provenance; fall back to the card's static description when there's no banked sleep.
+            pinnedCardRow(icon: card.icon, tint: tint, title: card.title,
+                          subtitle: sleepSourceSubtitle(displayDay) ?? card.subtitle,
                           value: dashboardValue(card), route: .sleep)
         case .hydration:
             pinnedCardRow(icon: card.icon, tint: tint, title: card.title, subtitle: card.subtitle,
@@ -4101,6 +4106,25 @@ struct TodayView: View {
         guard let m = d?.totalSleepMin else { return "—" }
         let h = Int(m) / 60, mm = Int(m) % 60
         return String(localized: "\(h)h \(mm)m")
+    }
+
+    /// #110: the Home sleep row's value is `totalSleepMin` — WHOOP's imported TST for the day, which can
+    /// legitimately differ from the Sleep tab's on-device re-staged night (with a WHOOP CSV *and* Apple
+    /// Health both imported). Label the row with its source + which night — the same "Whoop"/"On-device"
+    /// winner logic the Sleep tab's `nightSource` badge uses (`repo.importedSleep` keyed by the row's
+    /// wake-day, exactly as `sleepScoreSource` keys it) — so a WHOOP figure, or an older night at a
+    /// split-sleep / timezone edge, is never silently presented as "last night" with no provenance.
+    /// nil → the row keeps its static description (no banked sleep for the day).
+    private func sleepSourceSubtitle(_ d: DailyMetric?) -> String? {
+        guard let d, d.totalSleepMin != nil else { return nil }
+        let source = repo.importedSleep[d.day] != nil
+            ? String(localized: "Whoop") : String(localized: "On-device")
+        // At offset 0 the row IS last night; a navigated past day names its real date so the label never
+        // over-claims "last night".
+        let night = selectedDayOffset == 0
+            ? String(localized: "last night")
+            : Self.lastChargeDateFmt(d.day)
+        return String(localized: "\(source) · \(night)")
     }
 
     /// The Rest tile's caption, hours-in-bed for the day, the figure that used to be the tile's

--- a/android/app/src/main/java/com/noop/ui/TodayScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/TodayScreen.kt
@@ -2824,6 +2824,10 @@ private fun YourCardsSection(
                         estimatedStepsForDay = estimatedStepsForDay,
                     ),
                     tint = dashboardCardTint(card),
+                    // #110: label the sleep row with its source + night (this section renders at offset 0
+                    // only, so it IS last night), so a WHOOP-imported figure is never silently shown as
+                    // "last night" with no provenance. iOS TodayView.sleepSourceSubtitle twin.
+                    subtitleOverride = sleepSourceSubtitle(card, day),
                     // #706/#684: every card now opens its OWN detail, matching iOS. The Stress card -> Stress;
                     // the overnight vitals (HRV / Resting HR / Respiratory / SpO₂ / Skin Temp) + Fitness age /
                     // Vitality / Steps / Calories -> each metric's focused trend (vital_detail/<key>, the iOS
@@ -2840,6 +2844,22 @@ private fun YourCardsSection(
             }
         }
     }
+}
+
+/** #110: the sleep row's value is `totalSleepMin` — WHOOP's imported TST, which can legitimately differ
+ *  from the Sleep tab's on-device re-staged night (WHOOP CSV + Apple Health both imported). Label the row
+ *  with its source (the SAME `daySourceBadge` winner the Sleep tab's `MainSleepFooter` uses) + "last
+ *  night" — `YourCardsSection` renders at offset 0 only, so the row IS last night — so a WHOOP figure is
+ *  never silently shown as "last night" with no provenance. null → the card keeps its static subtitle
+ *  (not the sleep card, or no banked sleep). Twin of iOS `TodayView.sleepSourceSubtitle`; the source
+ *  mechanism differs per platform (Android keys on the day's session source, iOS on `importedSleep`),
+ *  exactly as the two Sleep-tab badges already do, so the label — not the wiring — is what stays in parity. */
+private fun sleepSourceSubtitle(card: DashboardCard, day: DailyMetric?): String? {
+    if (card != DashboardCard.SLEEP) return null
+    val d = day ?: return null
+    if (d.totalSleepMin == null) return null
+    val source = daySourceBadge(d.deviceId).first
+    return "$source · last night"
 }
 
 /** The `vital_detail/<key>` key a metric/vital card opens, or null when the card has its OWN dedicated
@@ -3041,6 +3061,9 @@ private fun DashboardCardRow(
     value: String,
     fraction: Double?,
     tint: Color,
+    // #110: a per-card dynamic subtitle (currently the sleep row's source + night); null keeps the
+    // card's static description.
+    subtitleOverride: String? = null,
     onClick: (() -> Unit)? = null,
 ) {
     // A real number renders white; a placeholder (No Data, or the Stress calibrating state) renders dimmed.
@@ -3091,7 +3114,7 @@ private fun DashboardCardRow(
                 overflow = TextOverflow.Ellipsis,
             )
             Text(
-                card.subtitle,
+                subtitleOverride ?: card.subtitle,
                 style = NoopType.caption,
                 color = Palette.textTertiary,
                 maxLines = 1,


### PR DESCRIPTION
Fixes #110.

## Problem
The Home sleep row shows `totalSleepMin` — WHOOP's imported TST for the day — while the Sleep tab shows `model.night.stages.asleep`, the newest night re-staged **on-device**. Same metric, two derivations: with a WHOOP CSV **and** Apple Health both imported they legitimately diverge, and the Home row carried **no provenance**, so a WHOOP figure (or, at a split-sleep / timezone edge, an older night) read as "last night" with nothing to say otherwise. The Sleep tab already distinguishes source via a `SourceBadge`; Home did not.

## Fix (Option 2 — label it, don't change the value)
Give the pinned sleep row a dynamic subtitle **"&lt;source&gt; · last night"**, where source is the same **"Whoop" / "On-device"** winner the Sleep tab's `nightSource` badge resolves. It falls back to the real date for a navigated past day, and to the card's static description when no sleep is banked.

This keeps `totalSleepMin` as the canonical banked-sleep metric everywhere else (Trends / Health / sleep-debt), so the change only makes the Home tile **honest** rather than shifting numbers (reading the newest on-device night into Home would instead make it disagree with Trends/Health).

## Cross-platform
Same subtitle on the Android Today sleep row. The source mechanism differs per platform (Android keys on the day's session source via `daySourceBadge`, iOS on `repo.importedSleep`) — exactly as the two Sleep-tab source badges already do — so the **label**, not the wiring, is what stays in parity.

## Verification
- macOS `Strand` scheme builds (shared `TodayView.swift`, so covers the iOS target too).
- Android reviewed by hand — no local SDK to compile; please run `android.yml` / a local `compileFullDebugKotlin` before merge.
- Pure presentation — no analytics/stored-data change.
- ⚠️ On-device confirmation that the label reads "Whoop · last night" on the reporter's repro needs a WHOOP-CSV + Apple-Health import loaded (not reproducible without that data).

🤖 Generated with [Claude Code](https://claude.com/claude-code)