### PR TITLE
fix(#137): light day Effort from an imported ride's HR on a strap-less day

### DIFF
--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/DayOwnerReadIntegrationTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/DayOwnerReadIntegrationTests.swift
@@ -83,6 +83,37 @@ final class DayOwnerReadIntegrationTests: XCTestCase {
         XCTAssertTrue(read.allSatisfy { $0.bpm == 99 }, "read must follow the locked owner")
     }
 
+    /// #137 (B1): on a STRAP-LESS day — the active WHOOP collected NO HR — an imported activity file's
+    /// HR (source "activity-file", a `.fileImport` device) makes it the day owner, so `dayHr` reads the
+    /// ride's HR and the day Effort ring can light. This is the whole point of registering `activity-file`
+    /// as a `.fileImport` candidate: with the strap absent it's the only source with data, so priority-2
+    /// still wins (an owner is the lowest-priority candidate that HAS data, not merely the lowest priority).
+    /// On a day the strap DID collect HR, the strap (priority 0) would win instead — proven by the first
+    /// test above — so imported HR only ever surfaces where there's no strap data to override it.
+    func testActivityFileOwnsStrapLessDayAndReadReturnsItsHR() async throws {
+        let store = try await WhoopStore.inMemory()    // migration v15 seeds active 'my-whoop' (no data yet)
+        let registry = DeviceRegistryStore(dbQueue: store.registryWriter)
+
+        // The activity-file import device, exactly as DataSourcesView registers it (#137 B1).
+        try registry.add(PairedDevice(id: "activity-file", brand: "Workout files", model: "",
+                                      sourceKind: .fileImport, capabilities: [.hr],
+                                      status: .paired, addedAt: 1, lastSeenAt: 1))
+
+        // ONLY the imported ride has HR this day; the active strap has none (strap-less day).
+        let base = dayStart + 3 * 3_600
+        let rideHR = (0..<300).map { HRSample(ts: base + $0, bpm: 132) }
+        _ = try await store.insert(Streams(hr: rideHR), deviceId: "activity-file")
+
+        let from = dayStart - 30 * 3_600, to = dayStart + 12 * 3_600
+        let owner = try await resolveOwner(store: store, registry: registry, from: from, to: to)
+        XCTAssertEqual(owner, "activity-file",
+                       "with no strap HR, the imported file (priority 2, has data) must own the day")
+
+        let read = try await store.hrSamples(deviceId: owner!, from: from, to: to, limit: 200_000)
+        XCTAssertEqual(read.count, rideHR.count)
+        XCTAssertTrue(read.allSatisfy { $0.bpm == 132 }, "the day read must return the imported ride's HR")
+    }
+
     /// Single-device install (the default): only the seeded active 'my-whoop' is paired. The owner
     /// MUST resolve to 'my-whoop' so behaviour is byte-identical to the pre-I2 code.
     func testSingleDeviceResolvesToWhoopUnchanged() async throws {

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/StrainScorerTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/StrainScorerTests.swift
@@ -34,6 +34,33 @@ final class StrainScorerTests: XCTestCase {
         XCTAssertEqual(s!, 44.27, accuracy: 1e-2)
     }
 
+    /// #137 (partial-day sanity, PR #236 review): an imported ride is a short HR ISLAND — a 1–2 h
+    /// window, not a full day of HR. Prove the day Effort from that island is SENSIBLE: it equals the
+    /// Effort the same ride would score if worn on a strap for a full day. Edwards TRIMP integrates only
+    /// over the samples present, and resting HR (≤ restingHR → zone weight 0) adds zero TRIMP, so a
+    /// strap-less imported ride is neither diluted by the empty hours nor inflated by them — the number
+    /// the user sees is the ride's own honest cardiovascular load, identical to a worn strap.
+    func testImportedRidePartialDayEffortMatchesWornStrap() {
+        // A 90-minute ride @ 150 bpm (moderate), mid-morning, sampled at 1 Hz.
+        let ride = hr(150, 90 * 60, start: 8 * 3_600)
+
+        // Import case (strap-less day): the ride is the ONLY HR on the day.
+        let importEffort = StrainScorer.strain(ride, maxHR: 190, restingHR: 60)
+
+        // Worn-strap case: the SAME ride embedded in a full 24 h of resting HR (60 bpm) around it.
+        let restBefore = hr(60, 8 * 3_600, start: 0)
+        let restAfter  = hr(60, 24 * 3_600 - 8 * 3_600 - 90 * 60, start: 8 * 3_600 + 90 * 60)
+        let wornEffort = StrainScorer.strain(restBefore + ride + restAfter, maxHR: 190, restingHR: 60)
+
+        XCTAssertNotNil(importEffort, "a 90-min HR island clears the minReadings/minSpan gates")
+        // Identical: resting time contributes zero TRIMP, so the island scores the same either way.
+        XCTAssertEqual(importEffort!, wornEffort!, accuracy: 1e-9,
+                       "imported-ride Effort must equal the same ride worn on a strap")
+        // A sensible MODERATE Effort for a 90-min zone-3 ride — not 0 (dark), not saturated (~100).
+        XCTAssertGreaterThan(importEffort!, 20)
+        XCTAssertLessThan(importEffort!, 90)
+    }
+
     func testStrainReturnsNilTooFewReadings() {
         XCTAssertNil(StrainScorer.strain(hr(150, 599), maxHR: 190, restingHR: 60))
     }

--- a/Packages/StrandImport/Sources/StrandImport/ActivityFileImporter.swift
+++ b/Packages/StrandImport/Sources/StrandImport/ActivityFileImporter.swift
@@ -59,6 +59,17 @@ public struct ActivityFile: Sendable, Equatable {
     /// The route as (lat, lon) pairs in order, for the platforms that store a polyline (Android's
     /// `routePolyline`). macOS's shared WorkoutRow has no route column, so it keeps only the summary.
     public var route: [RoutePoint]
+    /// #137: the REAL per-sample HR time series — the (unix-second, bpm) pairs the file actually
+    /// carried. Historically the importer folded these into `avgHr`/`maxHr`/`hrSampleCount` and then
+    /// THREW THE SAMPLES AWAY (deliberately: an imported file never fed the HR-based Effort). We now
+    /// keep them so the app layer can persist them under the `activity-file` source; on a strap-less
+    /// day that lets the imported ride's measured HR light the day Effort ring (the day-owner resolver
+    /// picks `activity-file` as the sole source with HR that day — see IntelligenceEngine.resolveDayOwner).
+    /// This is measured data, not a fabricated strain, so it does not reintroduce the "fabricated
+    /// cardiovascular strain" the WorkoutRow `strain = nil` guard exists to avoid. Only samples that
+    /// carried BOTH a timestamp and a valid HR appear here (a sample with no time can't key into the
+    /// (deviceId, ts) HR store), so `hrSamples.count <= hrSampleCount` in general.
+    public var hrSamples: [ActivityHRSample]
 
     public init(
         kind: Kind,
@@ -72,7 +83,8 @@ public struct ActivityFile: Sendable, Equatable {
         ascentM: Double? = nil,
         gpsPointCount: Int = 0,
         hrSampleCount: Int = 0,
-        route: [RoutePoint] = []
+        route: [RoutePoint] = [],
+        hrSamples: [ActivityHRSample] = []
     ) {
         self.kind = kind
         self.start = start
@@ -86,6 +98,7 @@ public struct ActivityFile: Sendable, Equatable {
         self.gpsPointCount = gpsPointCount
         self.hrSampleCount = hrSampleCount
         self.route = route
+        self.hrSamples = hrSamples
     }
 
     /// Duration in seconds, or nil when start == end (no real interval to claim).
@@ -115,6 +128,21 @@ public struct RoutePoint: Sendable, Equatable {
     public init(lat: Double, lon: Double) {
         self.lat = lat
         self.lon = lon
+    }
+}
+
+/// #137: one persisted HR sample — unix-second timestamp + bpm. Deliberately a LOCAL type (not
+/// WhoopProtocol's `HRSample`) so the pure StrandImport package stays dependency-free; the app layer
+/// maps this 1:1 onto `HRSample` when writing to the HR store. Keep the (ts, bpm) shape in parity with
+/// the Kotlin `ActivityFileImporter.HrSample` twin.
+public struct ActivityHRSample: Sendable, Equatable {
+    /// Wall-clock unix seconds (the sample's own time, from the file).
+    public var ts: Int
+    /// Heart rate in bpm (already range-validated by `validHr` upstream).
+    public var bpm: Int
+    public init(ts: Int, bpm: Int) {
+        self.ts = ts
+        self.bpm = bpm
     }
 }
 
@@ -275,7 +303,11 @@ public enum ActivityFileImporter {
             ascentM: ascent,
             gpsPointCount: route.count,
             hrSampleCount: hrs.count,
-            route: cappedRoute(route)
+            route: cappedRoute(route),
+            // #137: carry the real per-sample HR through (only timestamped+HR samples survive). The
+            // no-timestamp fallback path above intentionally leaves this empty — those samples have no
+            // epoch to key into the HR store.
+            hrSamples: hrSamples(from: samples)
         )
         return ActivityFileImportResult(activity: a, kind: kind, skipped: skipped)
     }
@@ -286,6 +318,23 @@ public enum ActivityFileImporter {
         var point: RoutePoint?
         var elevationM: Double?
         var hr: Int?
+    }
+
+    /// #137: fold the parsed track samples into the persisted HR series. SHARED by every format path
+    /// (GPX/TCX via `build`, FIT via `FitParser.buildResult`) so the three decode to a byte-identical
+    /// HR stream and stay in parity with the Kotlin twin. A sample is kept only when it carried BOTH a
+    /// timestamp and a valid HR: without a time it can't key into the (deviceId, ts) HR store, and
+    /// without HR there's nothing to store. The epoch is finite/range-checked BEFORE the `Int(Double)`
+    /// conversion (never a trapping cast — mirrors the importer's other numeric guards); the upper
+    /// bound is the same 2100-01-01 sanity ceiling `FitParser`/`fitDate` uses, so a crafted file with
+    /// an absurd timestamp is dropped, not stored.
+    static func hrSamples(from samples: [TrackSample]) -> [ActivityHRSample] {
+        samples.compactMap { s in
+            guard let time = s.time, let hr = s.hr else { return nil }
+            let secs = time.timeIntervalSince1970
+            guard secs.isFinite, secs > 0, secs < 4_102_444_800 else { return nil }
+            return ActivityHRSample(ts: Int(secs.rounded()), bpm: hr)
+        }
     }
 
     // MARK: - Geo / summary math

--- a/Packages/StrandImport/Sources/StrandImport/FitParser.swift
+++ b/Packages/StrandImport/Sources/StrandImport/FitParser.swift
@@ -468,7 +468,10 @@ private struct FitDecoder {
             ascentM: ascent,
             gpsPointCount: gpsPointCount,
             hrSampleCount: hrSampleCount,
-            route: ActivityFileImporter.cappedRoute(route)
+            route: ActivityFileImporter.cappedRoute(route),
+            // #137: the real per-record HR series, via the SHARED extractor so FIT persists a
+            // byte-identical HR stream to the GPX/TCX paths (and the Kotlin twin).
+            hrSamples: ActivityFileImporter.hrSamples(from: samples)
         )
         return ActivityFileImportResult(activity: activity, kind: .fit, skipped: skipped)
     }

--- a/Packages/StrandImport/Tests/StrandImportTests/ActivityFileImporterTests.swift
+++ b/Packages/StrandImport/Tests/StrandImportTests/ActivityFileImporterTests.swift
@@ -47,6 +47,33 @@ final class ActivityFileImporterTests: XCTestCase {
         XCTAssertEqual(dist, 222, accuracy: 30)
         // Ascent: +10 then +5 (both > 1 m hysteresis) = 15 m.
         XCTAssertEqual(a.ascentM ?? 0, 15, accuracy: 0.001)
+        // #137: the REAL per-sample HR series is now carried through (not just the avg/max summary),
+        // so the app layer can persist it under the activity-file source and light a strap-less day's
+        // Effort ring. Values in order, timestamped at each point's own time (start + 0/60/120 s).
+        XCTAssertEqual(a.hrSamples.map { $0.bpm }, [120, 140, 160])
+        let base = Int(a.start.timeIntervalSince1970)
+        XCTAssertEqual(a.hrSamples.map { $0.ts }, [base, base + 60, base + 120])
+    }
+
+    func testHrSamplesRequireBothTimestampAndHr() {
+        // #137: a sample must carry BOTH a timestamp and an HR to be persisted — a point with HR but
+        // no <time> can't key into the (deviceId, ts) HR store, and one with a time but no HR has
+        // nothing to store. Here: point 1 has time+HR (kept), point 2 has time but no HR (excluded),
+        // point 3 has HR but no time (excluded). `hrSampleCount` still counts every HR-bearing point.
+        let gpx = """
+        <gpx><trk><trkseg>
+          <trkpt lat="51.5000" lon="-0.1000"><time>2026-06-01T10:00:00Z</time>
+            <extensions><gpxtpx:TrackPointExtension><gpxtpx:hr>120</gpxtpx:hr></gpxtpx:TrackPointExtension></extensions></trkpt>
+          <trkpt lat="51.5010" lon="-0.1000"><time>2026-06-01T10:01:00Z</time></trkpt>
+          <trkpt lat="51.5020" lon="-0.1000">
+            <extensions><gpxtpx:TrackPointExtension><gpxtpx:hr>160</gpxtpx:hr></gpxtpx:TrackPointExtension></extensions></trkpt>
+        </trkseg></trk></gpx>
+        """
+        let r = ActivityFileImporter.parse(data: Data(gpx.utf8), filename: "mixed.gpx")
+        let a = try! XCTUnwrap(r.activity)
+        XCTAssertEqual(a.hrSampleCount, 2)                        // both HR-bearing points counted
+        XCTAssertEqual(a.hrSamples.map { $0.bpm }, [120])        // only the timestamped-with-HR one persisted
+        XCTAssertEqual(a.hrSamples.first?.ts, Int(a.start.timeIntervalSince1970))
     }
 
     func testGpxRejectsNullIslandAndKeepsValidPoints() {
@@ -162,6 +189,11 @@ final class ActivityFileImporterTests: XCTestCase {
         XCTAssertEqual(a.route.first?.lon ?? 0, lon, accuracy: 1e-4)
         // start from the FIT epoch: 631065600 + 100000.
         XCTAssertEqual(a.start.timeIntervalSince1970, 631_065_600 + 100_000, accuracy: 1)
+        // #137: FIT persists the same real per-record HR series as GPX/TCX (shared extractor). Records
+        // are 0/10/20 s apart from the FIT-epoch start; HR 120/140/160.
+        let fitBase = 631_065_600 + 100_000
+        XCTAssertEqual(a.hrSamples.map { $0.bpm }, [120, 140, 160])
+        XCTAssertEqual(a.hrSamples.map { $0.ts }, [fitBase, fitBase + 10, fitBase + 20])
     }
 
     func testFitDetectionFromMagicBytes() {

--- a/Strand/Screens/DataSourcesView.swift
+++ b/Strand/Screens/DataSourcesView.swift
@@ -4,6 +4,7 @@ import StrandDesign
 import StrandImport
 import StrandAnalytics
 import WhoopStore
+import WhoopProtocol   // #137: Streams / HRSample, to persist an imported activity's per-sample HR
 
 struct DataSourcesView: View {
     @EnvironmentObject var model: AppModel
@@ -458,7 +459,16 @@ struct DataSourcesView: View {
     /// Parse a single GPX / TCX / FIT activity file and upsert it as one workout (source
     /// "activity-file"). The route polyline isn't persisted on macOS (the shared WorkoutRow has no route
     /// column), but distance / HR / energy / ascent and an honest "N GPS points · M HR samples" note are.
-    /// No `strain` is stored unless the file carried one — imported files never feed the HR-based Effort.
+    ///
+    /// #137: the imported ride's REAL per-sample HR is now ALSO persisted as an HR stream under the
+    /// `activity-file` deviceId, and `activity-file` is registered as a `.fileImport` device. Together
+    /// (A + B1) that lets a strap-less day's ride light the day Effort ring: the per-day owner resolver
+    /// (`IntelligenceEngine.resolveDayOwner`) treats `activity-file` as an import candidate (priority 2)
+    /// and — being the only source with HR that day — picks it as the day owner, so `dayHr` reads the
+    /// ride's HR and Effort scores from it. On a day the user ALSO wore the strap, the strap (priority
+    /// 0/1) wins ownership and the imported HR is ignored for Effort — the desired behaviour. The
+    /// workout row itself still stores `strain = nil` (we never fabricate a per-workout strain); the day
+    /// Effort is computed from the measured HR stream, exactly as it is for a worn strap.
     private func importActivityFile(url: URL) {
         activityFileImporting = true
         activityFileSummary = nil
@@ -506,6 +516,36 @@ struct DataSourcesView: View {
                     notes: activity.importNote()
                 )
                 try await store.upsertWorkouts([row], deviceId: ActivityFileImporter.sourceId)
+
+                // #137 (A): persist the ride's real per-sample HR under the activity-file source. The
+                // insert is keyed on (deviceId, ts), so re-importing the same file is idempotent (an
+                // identical ts overwrites, never duplicates). Skipped when the file carried no
+                // timestamped HR (a pure GPS track) — nothing to store, so day Effort stays honestly dark.
+                if !activity.hrSamples.isEmpty {
+                    let hr = activity.hrSamples.map { HRSample(ts: $0.ts, bpm: $0.bpm) }
+                    _ = try? await store.insert(Streams(hr: hr), deviceId: ActivityFileImporter.sourceId)
+                }
+
+                // #137 (B1): register `activity-file` as a `.fileImport` device so the per-day owner
+                // resolver can pick it as the day owner on a strap-less day (it iterates the registry's
+                // paired devices; an unregistered source is invisible to it). status `.paired`, NEVER
+                // `.active`, so it can never displace the live strap as the active device; capability
+                // `.hr` marks what the source CAN provide (presence per-day is still gated by an actual
+                // HR read in the resolver). Idempotent (ON CONFLICT(id) DO UPDATE), makeActive: false.
+                model.registerDevice(
+                    PairedDevice(
+                        id: ActivityFileImporter.sourceId,
+                        brand: "Workout files",
+                        model: "",
+                        sourceKind: .fileImport,
+                        capabilities: [.hr],
+                        status: .paired,
+                        addedAt: Int(Date().timeIntervalSince1970),
+                        lastSeenAt: Int(Date().timeIntervalSince1970)
+                    ),
+                    makeActive: false
+                )
+
                 await repo.refresh()
                 activityFileSummary = ActivityFileImporter.summaryText(activity)
                 activityFileFailed = false

--- a/android/app/src/main/java/com/noop/ingest/ActivityFileImporter.kt
+++ b/android/app/src/main/java/com/noop/ingest/ActivityFileImporter.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.net.Uri
 import android.util.Xml
 import com.noop.analytics.RouteMath
+import com.noop.data.HrSample
 import com.noop.data.ImportSummary
 import com.noop.data.WhoopRepository
 import com.noop.data.WorkoutRow
@@ -60,6 +61,13 @@ object ActivityFileImporter {
 
     data class RoutePoint(val lat: Double, val lon: Double)
 
+    /**
+     * #137: one persisted HR sample — unix-second timestamp + bpm. Mirrors the Swift `ActivityHRSample`
+     * (a LOCAL type, not the Room [com.noop.data.HrSample] entity, so the pure-JVM importer needs no
+     * Room dependency; the app layer maps this 1:1 onto `HrSample` when writing to the HR store).
+     */
+    data class HrPoint(val ts: Long, val bpm: Int)
+
     data class Activity(
         val kind: Kind,
         val startTs: Long,          // unix seconds, UTC
@@ -73,6 +81,16 @@ object ActivityFileImporter {
         val gpsPointCount: Int,
         val hrSampleCount: Int,
         val route: List<RoutePoint>,
+        // #137: the REAL per-sample HR time series the file carried — historically folded into
+        // avg/max/hrSampleCount and then discarded (an imported file never fed the HR-based Effort). We
+        // now keep it so the app layer can persist it under the `activity-file` source; on a strap-less
+        // day that lets the ride's measured HR light the day Effort ring (the day-owner resolver picks
+        // `activity-file` as the sole source with HR that day — see IntelligenceEngine.resolveDayOwner).
+        // Measured data, not a fabricated strain, so it doesn't reintroduce the fabricated-strain the
+        // WorkoutRow `strain = null` guard avoids. Only samples carrying BOTH a timestamp and a valid HR
+        // appear here (a sample with no time can't key into the (deviceId, ts) HR store), so in general
+        // hrSamples.size <= hrSampleCount. Defaulted so the no-data build paths need no change.
+        val hrSamples: List<HrPoint> = emptyList(),
     ) {
         val durationS: Double? get() = (endTs - startTs).takeIf { it > 0 }?.toDouble()
 
@@ -101,6 +119,22 @@ object ActivityFileImporter {
         val elevationM: Double?,
         val hr: Int?,
     )
+
+    /**
+     * #137: fold the parsed track samples into the persisted HR series. SHARED by every format path
+     * (GPX/TCX via [build], FIT via [FitDecoder.build]) so the three decode to a byte-identical HR
+     * stream and stay in parity with the Swift twin. A sample is kept only when it carried BOTH a
+     * timestamp and a valid HR: without a time it can't key into the (deviceId, ts) HR store, and
+     * without HR there's nothing to store. The epoch is range-checked with the same 2100-01-01 sanity
+     * ceiling the FIT decoder uses, so a crafted file with an absurd timestamp is dropped, not stored.
+     */
+    internal fun hrSamples(samples: List<Sample>): List<HrPoint> =
+        samples.mapNotNull { s ->
+            val ts = s.timeS ?: return@mapNotNull null
+            val hr = s.hr ?: return@mapNotNull null
+            if (ts <= 0 || ts >= 4_102_444_800L) return@mapNotNull null
+            HrPoint(ts, hr)
+        }
 
     // MARK: - Format detection
 
@@ -181,6 +215,15 @@ object ActivityFileImporter {
 
         repo.upsertDevice(deviceId, name = "Workout files")
         repo.upsertWorkouts(listOf(row))
+
+        // #137 (A): persist the ride's real per-sample HR under the activity-file source. The insert is
+        // keyed on (deviceId, ts) (OnConflict.REPLACE), so re-importing the same file is idempotent — an
+        // identical ts overwrites, never duplicates. Skipped when the file carried no timestamped HR (a
+        // pure GPS track), leaving day Effort honestly dark. Registering activity-file as a `.fileImport`
+        // owner candidate (B1) happens in the UI caller (DataSourcesScreen), mirroring the Swift lane.
+        if (activity.hrSamples.isNotEmpty()) {
+            repo.insertHr(activity.hrSamples.map { HrSample(deviceId = deviceId, ts = it.ts, bpm = it.bpm) })
+        }
 
         return ImportSummary(
             source = SOURCE_LABEL,
@@ -400,6 +443,9 @@ object ActivityFileImporter {
             gpsPointCount = route.size,
             hrSampleCount = hrs.size,
             route = cappedRoute(route),
+            // #137: carry the real per-sample HR through (only timestamped+HR samples survive). The
+            // no-timestamp path above leaves this empty — those samples have no epoch to key the store.
+            hrSamples = hrSamples(samples),
         )
         return Result(a, kind, skipped)
     }
@@ -774,6 +820,9 @@ internal class FitDecoder(raw: ByteArray) {
             gpsPointCount = gpsPointCount,
             hrSampleCount = hrSampleCount,
             route = ActivityFileImporter.cappedRoute(route),
+            // #137: the real per-record HR series, via the SHARED extractor so FIT persists a
+            // byte-identical HR stream to the GPX/TCX paths (and the Swift twin).
+            hrSamples = ActivityFileImporter.hrSamples(samples),
         )
         return ActivityFileImporter.Result(activity, ActivityFileImporter.Kind.FIT, skipped)
     }

--- a/android/app/src/main/java/com/noop/ui/DataSourcesScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/DataSourcesScreen.kt
@@ -56,7 +56,11 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.health.connect.client.HealthConnectClient
 import androidx.health.connect.client.PermissionController
 import com.noop.data.DataBackup
+import com.noop.data.DeviceStatus
 import com.noop.data.ImportSummary
+import com.noop.data.Metric
+import com.noop.data.PairedDeviceRow
+import com.noop.data.SourceKind
 import com.noop.ingest.AppleHealthImporter
 import com.noop.ingest.HealthConnectImporter
 import com.noop.ingest.HealthConnectWriter
@@ -285,7 +289,35 @@ fun DataSourcesScreen(vm: AppViewModel) {
         ActivityResultContracts.OpenDocument(),
     ) { uri ->
         if (uri != null) runImport {
-            ActivityFileImporter.importExport(context, uri, vm.repo).also { vm.loadWorkouts() }
+            ActivityFileImporter.importExport(context, uri, vm.repo).also { summary ->
+                vm.loadWorkouts()
+                // #137 (B1): on a SUCCESSFUL import, register `activity-file` as a `.fileImport` device
+                // so the per-day owner resolver can pick it as the day owner on a strap-less day (it
+                // iterates the registry's paired devices — an unregistered source is invisible to it).
+                // status `paired`, NEVER `active` (makeActive = false), so it can never displace the live
+                // strap; capability `hr` marks what the source CAN provide (per-day presence is still
+                // gated by an actual HR read in the resolver). Idempotent (OnConflict.REPLACE). Twin of
+                // the Swift DataSourcesView `model.registerDevice` call. See ActivityFileImporter (A) for
+                // the matching per-sample HR persist that makes this device a real owner candidate.
+                if (summary.totalRows > 0) {
+                    val now = System.currentTimeMillis() / 1000
+                    vm.registerDevice(
+                        PairedDeviceRow(
+                            id = ActivityFileImporter.SOURCE_ID,
+                            brand = "Workout files",
+                            model = "",
+                            nickname = null,
+                            peripheralId = null,
+                            sourceKind = SourceKind.fileImport.name,
+                            capabilities = Metric.hr.name,
+                            status = DeviceStatus.paired.name,
+                            addedAt = now,
+                            lastSeenAt = now,
+                        ),
+                        makeActive = false,
+                    )
+                }
+            }
         }
     }
 

--- a/android/app/src/test/java/com/noop/ingest/ActivityFileImporterTest.kt
+++ b/android/app/src/test/java/com/noop/ingest/ActivityFileImporterTest.kt
@@ -66,6 +66,34 @@ class ActivityFileImporterTest {
         assertEquals(120.0, a.durationS!!, 1e-6)
         assertEquals(222.0, a.distanceM!!, 30.0)
         assertEquals(15.0, a.ascentM!!, 1e-3)
+        // #137: the REAL per-sample HR series is now carried through (not just avg/max), so the app
+        // layer can persist it under the activity-file source and light a strap-less day's Effort ring.
+        // Values in order, timestamped at each point's own time (start + 0/60/120 s). Parity with Swift.
+        assertEquals(listOf(120, 140, 160), a.hrSamples.map { it.bpm })
+        val base = a.startTs
+        assertEquals(listOf(base, base + 60, base + 120), a.hrSamples.map { it.ts })
+    }
+
+    @Test
+    fun hrSamplesRequireBothTimestampAndHr() {
+        // #137: a sample must carry BOTH a timestamp and an HR to be persisted — a point with HR but no
+        // <time> can't key into the (deviceId, ts) HR store, and one with a time but no HR has nothing to
+        // store. Point 1: time+HR (kept). Point 2: time, no HR (excluded). Point 3: HR, no time
+        // (excluded). `hrSampleCount` still counts every HR-bearing point. Parity with the Swift twin.
+        val gpx = """
+            <gpx><trk><trkseg>
+              <trkpt lat="51.5000" lon="-0.1000"><time>2026-06-01T10:00:00Z</time>
+                <extensions><gpxtpx:TrackPointExtension><gpxtpx:hr>120</gpxtpx:hr></gpxtpx:TrackPointExtension></extensions></trkpt>
+              <trkpt lat="51.5010" lon="-0.1000"><time>2026-06-01T10:01:00Z</time></trkpt>
+              <trkpt lat="51.5020" lon="-0.1000">
+                <extensions><gpxtpx:TrackPointExtension><gpxtpx:hr>160</gpxtpx:hr></gpxtpx:TrackPointExtension></extensions></trkpt>
+            </trkseg></trk></gpx>
+        """.trimIndent()
+        val r = ActivityFileImporter.parse(gpx.toByteArray(Charsets.UTF_8), "mixed.gpx")
+        val a = r.activity!!
+        assertEquals(2, a.hrSampleCount)                    // both HR-bearing points counted
+        assertEquals(listOf(120), a.hrSamples.map { it.bpm }) // only the timestamped-with-HR one persisted
+        assertEquals(a.startTs, a.hrSamples.first().ts)
     }
 
     @Test
@@ -172,6 +200,11 @@ class ActivityFileImporterTest {
         assertEquals(lat, a.route.first().lat, 1e-4)
         assertEquals(lon, a.route.first().lon, 1e-4)
         assertEquals((631_065_600L + 100_000L).toDouble(), a.startTs.toDouble(), 1.0)
+        // #137: FIT persists the same real per-record HR series as GPX/TCX (shared extractor). Records
+        // are 0/10/20 s apart from the FIT-epoch start; HR 120/140/160. Parity with the Swift twin.
+        val fitBase = 631_065_600L + 100_000L
+        assertEquals(listOf(120, 140, 160), a.hrSamples.map { it.bpm })
+        assertEquals(listOf(fitBase, fitBase + 10, fitBase + 20), a.hrSamples.map { it.ts })
     }
 
     @Test


### PR DESCRIPTION
Fixes #137 — an imported GPX/TCX/FIT ride with HR produced neither day HR nor an Effort score.

## Why it happened
The importer parsed per-sample HR but folded it into `avgHr`/`maxHr` and **discarded the samples**, and the `activity-file` source never reached the day-Effort read. So an imported ride was stored honestly (avg/max HR, distance, route) but deliberately kept out of HR/Effort.

## The fix (A + B1), byte-identical across Swift + Kotlin
- **(A) Persist the real per-sample HR** under the `activity-file` source. A shared extractor folds the parsed track samples into an HR stream; only samples carrying **both** a timestamp and a valid HR are stored, keyed on `(deviceId, ts)` so a re-import is idempotent (GPX/TCX/FIT all go through the same extractor).
- **(B1) Register `activity-file` as a `.fileImport` device** so the existing per-day owner resolver (`IntelligenceEngine.resolveDayOwner`, invariant I2) treats it as an import candidate (priority 2). On a **strap-less day** it's the only source with HR → it owns the day → `dayHr` reads the ride's HR → **day Effort lights**. On a day the strap **was** worn, the strap (priority 0/1) wins ownership and the imported HR is ignored — nothing changes for the common case.

The workout row still stores `strain = nil` (no fabricated per-workout strain). The day Effort is computed from the **measured** HR stream exactly as it is for a worn strap — so this surfaces real measured data, not a fabricated estimate.

## ⚠️ Direction check — reverses a deliberate stance
This reverses the explicit **"No HR Effort is touched"** decision for imported files. In the issue thread this direction (A + B1/union) was endorsed by the **reporter (@bartmuskala)**, but not yet by a maintainer. Flagging explicitly since it's a scoring-pipeline change — happy to adjust if you'd prefer it gated (e.g. behind a setting) or a different approach.

## Verification
- ✅ `Packages/StrandImport` `swift test` — new tests: the per-sample HR series carries through (GPX + FIT), and the "needs both timestamp and HR" exclusion rule.
- ✅ `Packages/StrandAnalytics` `swift test` — **new day-owner integration test**: on a strap-less day the `activity-file` import owns the day and the owner read returns the ride's HR (the active strap still wins when it has data).
- ✅ macOS app build (`xcodebuild … build`) — app-target Swift (`DataSourcesView`) compiles; no default CI covers this.
- ✅ Android `./gradlew compileFullDebugKotlin` + full `testFullDebugUnitTest`.
- ✅ **Partial-day Effort pinned by a test** (ryanbr's ask): a new `StrainScorerTests` case proves a 90-min ride's day Effort is *identical* whether it's the only HR on a strap-less day (import) or the same ride worn for a full day — Edwards TRIMP integrates only over the samples present and resting HR adds zero, so the island is neither diluted nor inflated. The moderate ride scores ~58.5/100 (not 0, not saturated). Combined with the day-owner test, both halves of the path (ownership → `dayHr` → Effort) are covered.
- ⏳ **On-device (still worthwhile, not CI-testable):** a real GPX-on-a-strap-less-day import to eyeball the ring in the UI.
