### PR TITLE
Today cards: per-field SpO2 / skin-temp carry (fixes 1+2)

### DIFF
--- a/Packages/WhoopStore/Sources/WhoopStore/MetricsCache.swift
+++ b/Packages/WhoopStore/Sources/WhoopStore/MetricsCache.swift
@@ -97,6 +97,22 @@ public struct DailyMetric: Equatable, Codable {
     public nonisolated static func lastVitalsDay(days: [DailyMetric], todayKey: String) -> DailyMetric? {
         days.last(where: { ($0.avgHrv != nil || $0.restingHr != nil || $0.respRateBpm != nil) && $0.day < todayKey })
     }
+
+    /// PER-FIELD twin of `lastVitalsDay` for SpO₂: the freshest STRICTLY-PRIOR day with a non-nil `spo2Pct`.
+    /// `lastVitalsDay`'s predicate only checks HRV / resting-HR / respiratory, so it can land on a row whose
+    /// `spo2Pct` is nil (the on-device engine writes `spo2Pct = nil` — it banks only raw `spo2Red`/`spo2Ir`;
+    /// only imported rows carry a percentage) while an OLDER imported row holds a real reading. Resolving
+    /// SpO₂ per field keeps the Blood Oxygen card honest instead of "No Data". Same `$0.day < todayKey`
+    /// future-clock guard as `lastVitalsDay`; `days` is oldest→newest. Byte-twin of the Android `lastSpo2Row`.
+    public nonisolated static func lastSpo2Day(days: [DailyMetric], todayKey: String) -> DailyMetric? {
+        days.last(where: { $0.spo2Pct != nil && $0.day < todayKey })
+    }
+
+    /// PER-FIELD twin of `lastVitalsDay` for skin-temperature deviation. See `lastSpo2Day`. Byte-twin of the
+    /// Android `lastSkinTempRow`.
+    public nonisolated static func lastSkinTempDay(days: [DailyMetric], todayKey: String) -> DailyMetric? {
+        days.last(where: { $0.skinTempDevC != nil && $0.day < todayKey })
+    }
 }
 
 extension WhoopStore {

--- a/Packages/WhoopStore/Tests/WhoopStoreTests/DailyMetricLastVitalsDayTests.swift
+++ b/Packages/WhoopStore/Tests/WhoopStoreTests/DailyMetricLastVitalsDayTests.swift
@@ -98,4 +98,57 @@ final class DailyMetricLastVitalsDayTests: XCTestCase {
                     day("2999-01-01", recovery: 80, hrv: 99, rhr: 40)]
         XCTAssertNil(DailyMetric.lastVitalsDay(days: days, todayKey: "2026-06-19"))
     }
+
+    // MARK: lastSpo2Day / lastSkinTempDay — the PER-FIELD carries for the two fields lastVitalsDay's
+    // predicate does NOT check. The on-device engine writes spo2Pct = nil (only raw spo2Red/spo2Ir), so
+    // every computed "-noop" row lacks a percentage; only imported rows carry one. A whole-row carry lands
+    // on a row with null spo2Pct/skinTempDevC and the Blood Oxygen / Skin Temp cards read "No Data" even
+    // though an imported row holds a real reading. Byte-twins of the Android lastSpo2Row / lastSkinTempRow.
+
+    /// A day row carrying only the fields these per-field selectors read — mirrors the Android `fieldDay`.
+    private func fieldDay(_ key: String, hrv: Double? = nil,
+                          spo2: Double? = nil, skinTemp: Double? = nil) -> DailyMetric {
+        DailyMetric(day: key, totalSleepMin: nil, efficiency: nil, deepMin: nil, remMin: nil,
+                    lightMin: nil, disturbances: nil, restingHr: nil, avgHrv: hrv, recovery: nil,
+                    strain: nil, exerciseCount: nil, spo2Pct: spo2, skinTempDevC: skinTemp, respRateBpm: nil)
+    }
+
+    func testLastSpo2Day_skipsANewerVitalsRowWithNullSpo2_documentsTheWholeRowBug() {
+        // Last night's computed row has vitals but NO spo2Pct (engine-written nil); an older imported row
+        // has a real 96%. lastVitalsDay picks last night (correct for HRV) — the SpO₂ field must NOT ride
+        // that row, it must resolve independently to the imported reading.
+        let days = [fieldDay("2026-06-17", spo2: 96),               // imported, real reading
+                    fieldDay("2026-06-18", hrv: 41, spo2: nil)]     // computed row: vitals yes, SpO₂ nil
+        XCTAssertEqual(DailyMetric.lastVitalsDay(days: days, todayKey: "2026-06-19")?.day, "2026-06-18")
+        let spo2 = DailyMetric.lastSpo2Day(days: days, todayKey: "2026-06-19")
+        XCTAssertEqual(spo2?.day, "2026-06-17")
+        XCTAssertEqual(spo2?.spo2Pct, 96)
+    }
+
+    func testLastSpo2Day_nil_whenNoPriorRowEverHadAReading_staysHonestNoData() {
+        let days = [fieldDay("2026-06-18", hrv: 41)]
+        XCTAssertNil(DailyMetric.lastSpo2Day(days: days, todayKey: "2026-06-19"))
+    }
+
+    func testLastSpo2Day_neverCarriesAFutureDatedRow() {
+        let days = [fieldDay("2026-06-17", spo2: 96),
+                    fieldDay("2999-01-01", spo2: 99)]              // future-dated pollution
+        XCTAssertEqual(DailyMetric.lastSpo2Day(days: days, todayKey: "2026-06-19")?.day, "2026-06-17")
+    }
+
+    func testLastSkinTempDay_resolvesIndependently_ofVitalsAndSpo2() {
+        // Skin temp lives on yet another row than SpO₂ — each field carries from its own freshest source.
+        let days = [fieldDay("2026-06-16", skinTemp: 0.4),
+                    fieldDay("2026-06-17", spo2: 96),
+                    fieldDay("2026-06-18", hrv: 41)]
+        let skin = DailyMetric.lastSkinTempDay(days: days, todayKey: "2026-06-19")
+        XCTAssertEqual(skin?.day, "2026-06-16")
+        XCTAssertEqual(skin?.skinTempDevC, 0.4)
+    }
+
+    func testLastSkinTempDay_neverCarriesAFutureDatedRow() {
+        let days = [fieldDay("2026-06-16", skinTemp: 0.4),
+                    fieldDay("2999-01-01", skinTemp: 2.1)]
+        XCTAssertEqual(DailyMetric.lastSkinTempDay(days: days, todayKey: "2026-06-19")?.day, "2026-06-16")
+    }
 }

--- a/Strand/Data/Repository.swift
+++ b/Strand/Data/Repository.swift
@@ -425,6 +425,20 @@ final class Repository: ObservableObject {
     nonisolated static func lastVitalsDay(days: [DailyMetric], todayKey: String) -> DailyMetric? {
         DailyMetric.lastVitalsDay(days: days, todayKey: todayKey)
     }
+
+    /// PER-FIELD SpO₂ carry — the twin of `lastVitalsDay(days:todayKey:)` for the field its predicate does
+    /// NOT check. The engine writes `spo2Pct = nil` on computed rows (only imported rows carry a percentage),
+    /// so a whole-row carry lands on a null `spo2Pct`; this resolves the freshest strictly-prior row that
+    /// actually has one. Forwards to the pure package selector — pass the future-clock-safe key (the later of
+    /// logical/local) so the `< todayKey` bound is honest. See `DailyMetric.lastSpo2Day`.
+    nonisolated static func lastSpo2Day(days: [DailyMetric], todayKey: String) -> DailyMetric? {
+        DailyMetric.lastSpo2Day(days: days, todayKey: todayKey)
+    }
+
+    /// PER-FIELD skin-temperature-deviation carry — twin of the above. See `DailyMetric.lastSkinTempDay`.
+    nonisolated static func lastSkinTempDay(days: [DailyMetric], todayKey: String) -> DailyMetric? {
+        DailyMetric.lastSkinTempDay(days: days, todayKey: todayKey)
+    }
     /// The trailing 7 CALENDAR days ending today (for the week strip), oldest→newest , not the last 7
     /// stored rows, which on a stale import were old data. ISO yyyy-MM-dd compares chronologically.
     var week: [DailyMetric] {

--- a/Strand/Screens/TodayView.swift
+++ b/Strand/Screens/TodayView.swift
@@ -515,6 +515,23 @@ struct TodayView: View {
         return Repository.lastVitalsDay(days: repo.days, todayKey: displayDay?.day ?? selectedDayKey)
     }
 
+    /// PER-FIELD SpO₂ carry — the twin of `lastVitalsDay` for the field its predicate does NOT check. The
+    /// on-device engine writes `spo2Pct = nil` (it banks only raw `spo2Red`/`spo2Ir`), so every computed
+    /// "-noop" row lacks a percentage; only imported rows carry one. A whole-row carry (`lastScoredRecoveryDay`
+    /// or `lastVitalsDay`) therefore lands on a row with null `spo2Pct` and the Blood Oxygen card reads
+    /// "No Data" even though an imported row holds a real reading. Resolving SpO₂ independently (the last
+    /// strictly-prior row that HAS it) mirrors the Android `lastSpo2Row`. Only on today; today's key bounds it.
+    private var lastSpo2Day: DailyMetric? {
+        guard selectedDayOffset == 0 else { return nil }
+        return Repository.lastSpo2Day(days: repo.days, todayKey: displayDay?.day ?? selectedDayKey)
+    }
+
+    /// PER-FIELD skin-temperature-deviation carry — twin of `lastSpo2Day`; mirrors the Android `lastSkinTempRow`.
+    private var lastSkinTempDay: DailyMetric? {
+        guard selectedDayOffset == 0 else { return nil }
+        return Repository.lastSkinTempDay(days: repo.days, todayKey: displayDay?.day ?? selectedDayKey)
+    }
+
     /// Pure carry-over selector behind `lastScoredRecoveryDay`, extracted so the gate + selection can be
     /// unit-tested without a live view (mirrors `buildingHintCopy` / the Android `lastScoredRecoveryDay`).
     /// Returns the freshest scored prior row to carry over, or nil. `days` is oldest→newest; the chosen
@@ -2073,10 +2090,16 @@ struct TodayView: View {
             return withUnit(d?.respRateBpm.map { String(format: "%.1f", $0) }
                             ?? sparks["resp_rate"]?.last.map { String(format: "%.1f", $0) } ?? "—")
         case .bloodOxygen:
-            return d?.spo2Pct.map { String(format: "%.0f%%", $0) } ?? "—"
+            // PER-FIELD carry: today → whole-row vitals carry → the last row that actually HAS a reading
+            // (computed "-noop" rows write spo2Pct = nil), so this card agrees with the Key Metrics tile
+            // (`d?.spo2Pct ?? carriedVital(perField: lastSpo2Day)`). Mirrors the Android dashboardCardValue.
+            return (d?.spo2Pct ?? lastVitalsDay?.spo2Pct ?? lastSpo2Day?.spo2Pct)
+                .map { String(format: "%.0f%%", $0) } ?? "—"
         case .skinTemp:
-            // Stored as a deviation from baseline (°C); show it signed so +/- reads honestly.
-            return d?.skinTempDevC.map { String(format: "%+.1f°", $0) } ?? "—"
+            // Stored as a deviation from baseline (°C); show it signed so +/- reads honestly. Same per-field
+            // carry as Blood Oxygen.
+            return (d?.skinTempDevC ?? lastVitalsDay?.skinTempDevC ?? lastSkinTempDay?.skinTempDevC)
+                .map { String(format: "%+.1f°", $0) } ?? "—"
         case .sleep:
             return sleepValue(d)
         case .steps:
@@ -3061,11 +3084,19 @@ struct TodayView: View {
         unit: String,
         today: Double?,
         prior: (DailyMetric) -> Double?,
+        perField: DailyMetric? = nil,
         format: (Double) -> String
     ) -> (value: String, caption: String?) {
         if let v = today { return (format(v), unit) }
         if let p = lastScoredRecoveryDay, let v = prior(p) {
             return (format(v), carriedCaption(p))
+        }
+        // PER-FIELD carry: the whole-row carry above (`lastScoredRecoveryDay`) can land on a row whose field
+        // is nil (the engine writes spo2Pct = nil on computed "-noop" rows), so fall through to the freshest
+        // strictly-prior row that HAS this field, stamped with its OWN carried date. Tried after the whole-row
+        // carry so a genuine last-scored-night reading keeps its caption. Mirrors the Android per-field carry.
+        if let pf = perField, let v = prior(pf) {
+            return (format(v), carriedCaption(pf))
         }
         // H10, an empty vital on TODAY reads honestly ("After tonight's sleep") instead of a lone unit
         // beside a bare ", ", which looked like a fault; a navigated PAST day keeps the plain unit (it's
@@ -3164,8 +3195,12 @@ struct TodayView: View {
                 sparkColor: StrandPalette.metricRose
             )
         case .bloodOxygen:
+            // PER-FIELD carry (perField: lastSpo2Day): the whole-row `lastScoredRecoveryDay` carry lands on a
+            // row whose spo2Pct is nil (computed rows never bank a percentage), so the tile falls through to
+            // the last row that actually has a reading. Mirrors the Android Blood Oxygen tile's spo2CarryDay.
             let spo2 = carriedVital(unit: "SpO₂", today: d?.spo2Pct,
-                                    prior: { $0.spo2Pct }, format: { String(format: "%.0f%%", $0) })
+                                    prior: { $0.spo2Pct }, perField: lastSpo2Day,
+                                    format: { String(format: "%.0f%%", $0) })
             StatTile(
                 label: "Blood Oxygen",
                 value: spo2.value,

--- a/android/app/src/main/java/com/noop/ui/LogicalDay.kt
+++ b/android/app/src/main/java/com/noop/ui/LogicalDay.kt
@@ -111,7 +111,7 @@ internal fun lastVitalsRow(days: List<DailyMetric>, todayKey: String): DailyMetr
  * [lastVitalsRow]'s predicate only checks HRV/resting-HR/respiratory, so it can select a row whose spo2Pct is
  * null (the on-device engine writes spo2Pct = null; only imported rows carry it) while an OLDER imported row
  * has a real reading. Resolving SpO₂ per field keeps the Blood Oxygen card honest instead of "No Data".
- * Same `it.day < todayKey` future-clock guard. Mirrors Swift VitalSourceResolution's per-field pick.
+ * Same `it.day < todayKey` future-clock guard. Mirrors Swift `DailyMetric.lastSpo2Day` / `lastSkinTempDay`.
  */
 internal fun lastSpo2Row(days: List<DailyMetric>, todayKey: String): DailyMetric? =
     days.lastOrNull { it.spo2Pct != null && it.day < todayKey }

--- a/android/app/src/main/java/com/noop/ui/LogicalDay.kt
+++ b/android/app/src/main/java/com/noop/ui/LogicalDay.kt
@@ -106,6 +106,20 @@ internal fun widgetAnchorRow(days: List<DailyMetric>, logicalKey: String, localK
 internal fun lastVitalsRow(days: List<DailyMetric>, todayKey: String): DailyMetric? =
     days.lastOrNull { (it.avgHrv != null || it.restingHr != null || it.respRateBpm != null) && it.day < todayKey }
 
+/**
+ * PER-FIELD twin of [lastVitalsRow] for SpO₂: the freshest strictly-prior row with a non-null [DailyMetric.spo2Pct].
+ * [lastVitalsRow]'s predicate only checks HRV/resting-HR/respiratory, so it can select a row whose spo2Pct is
+ * null (the on-device engine writes spo2Pct = null; only imported rows carry it) while an OLDER imported row
+ * has a real reading. Resolving SpO₂ per field keeps the Blood Oxygen card honest instead of "No Data".
+ * Same `it.day < todayKey` future-clock guard. Mirrors Swift VitalSourceResolution's per-field pick.
+ */
+internal fun lastSpo2Row(days: List<DailyMetric>, todayKey: String): DailyMetric? =
+    days.lastOrNull { it.spo2Pct != null && it.day < todayKey }
+
+/** PER-FIELD twin of [lastVitalsRow] for skin temperature deviation. See [lastSpo2Row]. */
+internal fun lastSkinTempRow(days: List<DailyMetric>, todayKey: String): DailyMetric? =
+    days.lastOrNull { it.skinTempDevC != null && it.day < todayKey }
+
 /** 04:00 local — the hour the logical day rolls. Between midnight and this hour, Today stays put. */
 internal const val LOGICAL_DAY_ROLLOVER_HOUR: Int = 4
 

--- a/android/app/src/main/java/com/noop/ui/TodayScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/TodayScreen.kt
@@ -847,7 +847,7 @@ fun TodayScreen(
     // or lastVitalsDay) therefore lands on a row with null spo2Pct/skinTempDevC and the Blood Oxygen /
     // Skin Temp cards read "No Data" even though an imported row holds a real reading. Resolving the two
     // fields independently (last strictly-prior row with the field non-null) mirrors iOS
-    // VitalSourceResolution's per-field pick. Same #547 future-clock bound; non-null only on today.
+    // TodayView.lastSpo2Day / lastSkinTempDay. Same #547 future-clock bound; non-null only on today.
     val lastSpo2Day: DailyMetric? = remember(days, carryOverTodayKey, selectedDayOffset, displayMetric) {
         if (selectedDayOffset == 0) lastSpo2Row(days, maxOf(displayMetric?.day ?: "", carryOverTodayKey)) else null
     }
@@ -1244,7 +1244,7 @@ fun TodayScreen(
                 // PER-FIELD SpO₂ / skin-temp carries: lastVitalsDay's predicate only checks HRV/RHR/resp,
                 // so these two fields resolve independently to the last row that actually has them
                 // (imported rows; computed "-noop" rows never carry spo2Pct). Mirrors iOS per-field
-                // VitalSourceResolution.
+                // carry (TodayView.lastSpo2Day / lastSkinTempDay via carriedVital).
                 spo2Day = lastSpo2Day,
                 skinTempDay = lastSkinTempDay,
                 stress = stressToday,
@@ -4102,7 +4102,7 @@ private fun MetricGrid(
     carriedDay: DailyMetric? = null,
     // PER-FIELD SpO₂ carry (see lastSpo2Row): carriedDay is recovery-gated and lands on rows whose
     // spo2Pct is null (computed rows never carry one), so the Blood Oxygen tile falls through to the
-    // last row that actually has a reading. Mirrors iOS VitalSourceResolution's per-field pick.
+    // last row that actually has a reading. Mirrors iOS TodayView.lastSpo2Day (carriedVital's per-field fallback).
     spo2CarryDay: DailyMetric? = null,
     unitSystem: UnitSystem = UnitSystem.METRIC,
     effortScale: EffortScale = EffortScale.HUNDRED,

--- a/android/app/src/main/java/com/noop/ui/TodayScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/TodayScreen.kt
@@ -841,6 +841,19 @@ fun TodayScreen(
     val lastVitalsDay: DailyMetric? = remember(days, carryOverTodayKey, selectedDayOffset, displayMetric) {
         if (selectedDayOffset == 0) lastVitalsRow(days, maxOf(displayMetric?.day ?: "", carryOverTodayKey)) else null
     }
+    // PER-FIELD SpO₂ / skin-temp carries, the twin of lastVitalsDay for the two fields its predicate does
+    // NOT check. The on-device engine writes spo2Pct = null (only raw spo2Red/spo2Ir), so every computed
+    // "-noop" row lacks a percentage; only imported rows carry one. A whole-row carry (lastScoredRecoveryDay
+    // or lastVitalsDay) therefore lands on a row with null spo2Pct/skinTempDevC and the Blood Oxygen /
+    // Skin Temp cards read "No Data" even though an imported row holds a real reading. Resolving the two
+    // fields independently (last strictly-prior row with the field non-null) mirrors iOS
+    // VitalSourceResolution's per-field pick. Same #547 future-clock bound; non-null only on today.
+    val lastSpo2Day: DailyMetric? = remember(days, carryOverTodayKey, selectedDayOffset, displayMetric) {
+        if (selectedDayOffset == 0) lastSpo2Row(days, maxOf(displayMetric?.day ?: "", carryOverTodayKey)) else null
+    }
+    val lastSkinTempDay: DailyMetric? = remember(days, carryOverTodayKey, selectedDayOffset, displayMetric) {
+        if (selectedDayOffset == 0) lastSkinTempRow(days, maxOf(displayMetric?.day ?: "", carryOverTodayKey)) else null
+    }
     // Carry-over Charge for TODAY, the prior scored row's recovery + its "Last night · <date>" caption.
     // Derived from lastScoredRecoveryDay so Charge and every other recovery tile carry the SAME prior day.
     val lastScoredCharge: LastCharge? = remember(lastScoredRecoveryDay) {
@@ -1228,6 +1241,12 @@ fun TodayScreen(
                 // Respiratory cards read PER-FIELD today-first with THIS fallback, so a night whose recovery
                 // was nulled post-update still surfaces its OWN preserved vitals (not an older scored day's).
                 vitalsDay = lastVitalsDay,
+                // PER-FIELD SpO₂ / skin-temp carries: lastVitalsDay's predicate only checks HRV/RHR/resp,
+                // so these two fields resolve independently to the last row that actually has them
+                // (imported rows; computed "-noop" rows never carry spo2Pct). Mirrors iOS per-field
+                // VitalSourceResolution.
+                spo2Day = lastSpo2Day,
+                skinTempDay = lastSkinTempDay,
                 stress = stressToday,
                 fitnessAge = fitnessAgeToday,
                 vitality = vitalityToday,
@@ -1356,6 +1375,7 @@ fun TodayScreen(
                 recoveryCalibration = recoveryCalibration,
                 lastScoredCharge = lastScoredCharge,
                 carriedDay = lastScoredRecoveryDay,
+                spo2CarryDay = lastSpo2Day,
                 unitSystem = unitSystem,
                 effortScale = effortScale,
                 latestWeightKg = weightKg,
@@ -2756,6 +2776,8 @@ private fun YourCardsSection(
     day: DailyMetric?,
     carriedDay: DailyMetric?,
     vitalsDay: DailyMetric?,
+    spo2Day: DailyMetric?,
+    skinTempDay: DailyMetric?,
     stress: Double?,
     fitnessAge: Double?,
     vitality: Double?,
@@ -2802,6 +2824,8 @@ private fun YourCardsSection(
                         day = day,
                         carriedDay = carriedDay,
                         vitalsDay = vitalsDay,
+                        spo2Day = spo2Day,
+                        skinTempDay = skinTempDay,
                         stress = stress,
                         fitnessAge = fitnessAge,
                         vitality = vitality,
@@ -2969,6 +2993,8 @@ private fun dashboardCardValue(
     day: DailyMetric?,
     carriedDay: DailyMetric?,
     vitalsDay: DailyMetric?,
+    spo2Day: DailyMetric?,
+    skinTempDay: DailyMetric?,
     stress: Double?,
     fitnessAge: Double?,
     vitality: Double?,
@@ -2992,10 +3018,13 @@ private fun dashboardCardValue(
         DashboardCard.RESPIRATORY ->
             withUnit((day?.respRateBpm ?: vitalsDay?.respRateBpm)?.let { String.format(Locale.US, "%.1f", it) } ?: NO_DATA)
         DashboardCard.BLOOD_OXYGEN ->
-            vd?.spo2Pct?.let { String.format(Locale.US, "%.0f%%", it) } ?: NO_DATA
+            // PER-FIELD carry: the whole-row carries (vd) land on rows whose spo2Pct is null (the engine
+            // writes spo2Pct = null on computed rows), so fall through to the last row that HAS one.
+            (vd?.spo2Pct ?: spo2Day?.spo2Pct)?.let { String.format(Locale.US, "%.0f%%", it) } ?: NO_DATA
         DashboardCard.SKIN_TEMP ->
             // Stored as a deviation from baseline (°C); show it signed so +/- reads honestly.
-            vd?.skinTempDevC?.let { String.format(Locale.US, "%+.1f°", it) } ?: NO_DATA
+            // Same per-field carry as Blood Oxygen.
+            (vd?.skinTempDevC ?: skinTempDay?.skinTempDevC)?.let { String.format(Locale.US, "%+.1f°", it) } ?: NO_DATA
         DashboardCard.SLEEP -> sleepValue(vd)
         DashboardCard.STEPS -> {
             val real = day?.steps?.let { intStringGrouped(it.toDouble()) }
@@ -4071,6 +4100,10 @@ private fun MetricGrid(
     recoveryCalibration: Int? = null,
     lastScoredCharge: LastCharge? = null,
     carriedDay: DailyMetric? = null,
+    // PER-FIELD SpO₂ carry (see lastSpo2Row): carriedDay is recovery-gated and lands on rows whose
+    // spo2Pct is null (computed rows never carry one), so the Blood Oxygen tile falls through to the
+    // last row that actually has a reading. Mirrors iOS VitalSourceResolution's per-field pick.
+    spo2CarryDay: DailyMetric? = null,
     unitSystem: UnitSystem = UnitSystem.METRIC,
     effortScale: EffortScale = EffortScale.HUNDRED,
     latestWeightKg: Double? = null,
@@ -4151,7 +4184,7 @@ private fun MetricGrid(
             )
         },
         KeyMetric.BLOOD_OXYGEN to run {
-            val v = d?.spo2Pct ?: carriedDay?.spo2Pct
+            val v = d?.spo2Pct ?: carriedDay?.spo2Pct ?: spo2CarryDay?.spo2Pct
             KeyTileData(
                 label = "Blood Oxygen",
                 value = v?.let { String.format(Locale.US, "%.0f", it) } ?: NO_DATA,

--- a/android/app/src/test/java/com/noop/ui/TodayMetricTilesTest.kt
+++ b/android/app/src/test/java/com/noop/ui/TodayMetricTilesTest.kt
@@ -468,4 +468,69 @@ class TodayMetricTilesTest {
         assertEquals(50.0, vitals?.avgHrv)
         assertEquals(55, vitals?.restingHr)
     }
+
+    // MARK: lastSpo2Row / lastSkinTempRow — the PER-FIELD carries for the two fields lastVitalsRow's
+    // predicate does NOT check. The on-device engine writes spo2Pct = null (only raw spo2Red/spo2Ir), so
+    // every computed "-noop" row lacks a percentage; only imported rows carry one. A whole-row carry lands
+    // on a row with null spo2Pct/skinTempDevC and the Blood Oxygen / Skin Temp cards read "No Data" even
+    // though an imported row holds a real reading. Mirrors iOS VitalSourceResolution's per-field pick.
+
+    private fun fieldDay(
+        day: String,
+        hrv: Double? = null,
+        spo2: Double? = null,
+        skinTemp: Double? = null,
+    ) = DailyMetric(deviceId = "my-whoop", day = day, avgHrv = hrv, spo2Pct = spo2, skinTempDevC = skinTemp)
+
+    @Test
+    fun lastSpo2Row_skipsANewerVitalsRowWithNullSpo2_documentsTheWholeRowBug() {
+        // Last night's computed row has vitals but NO spo2Pct (engine-written null); an older imported row
+        // has a real 96%. lastVitalsRow picks last night (correct for HRV) — the SpO₂ field must NOT ride
+        // that row, it must resolve independently to the imported reading.
+        val days = listOf(
+            fieldDay("2026-06-17", spo2 = 96.0),                 // imported, real reading
+            fieldDay("2026-06-18", hrv = 41.0, spo2 = null),     // computed row: vitals yes, SpO₂ null
+        )
+        assertEquals("2026-06-18", lastVitalsRow(days, todayKey = "2026-06-19")?.day)
+        val spo2 = lastSpo2Row(days, todayKey = "2026-06-19")
+        assertEquals("2026-06-17", spo2?.day)
+        assertEquals(96.0, spo2?.spo2Pct)
+    }
+
+    @Test
+    fun lastSpo2Row_null_whenNoPriorRowEverHadAReading_staysHonestNoData() {
+        val days = listOf(fieldDay("2026-06-18", hrv = 41.0))
+        assertNull(lastSpo2Row(days, todayKey = "2026-06-19"))
+    }
+
+    @Test
+    fun lastSpo2Row_neverCarriesAFutureDatedRow() {
+        val days = listOf(
+            fieldDay("2026-06-17", spo2 = 96.0),
+            fieldDay("2999-01-01", spo2 = 99.0),                 // future-dated pollution
+        )
+        assertEquals("2026-06-17", lastSpo2Row(days, todayKey = "2026-06-19")?.day)
+    }
+
+    @Test
+    fun lastSkinTempRow_resolvesIndependently_ofVitalsAndSpo2() {
+        // Skin temp lives on yet another row than SpO₂ — each field carries from its own freshest source.
+        val days = listOf(
+            fieldDay("2026-06-16", skinTemp = 0.4),
+            fieldDay("2026-06-17", spo2 = 96.0),
+            fieldDay("2026-06-18", hrv = 41.0),
+        )
+        val skin = lastSkinTempRow(days, todayKey = "2026-06-19")
+        assertEquals("2026-06-16", skin?.day)
+        assertEquals(0.4, skin?.skinTempDevC)
+    }
+
+    @Test
+    fun lastSkinTempRow_neverCarriesAFutureDatedRow() {
+        val days = listOf(
+            fieldDay("2026-06-16", skinTemp = 0.4),
+            fieldDay("2999-01-01", skinTemp = 2.1),
+        )
+        assertEquals("2026-06-16", lastSkinTempRow(days, todayKey = "2026-06-19")?.day)
+    }
 }


### PR DESCRIPTION
## What this PR does

After the logical-day rollover, the **Blood Oxygen** and **Skin Temperature** Today cards read "No Data" even though an imported row holds a real reading. This lands the fix on **both platforms**.

Root cause (shared Android + iOS): the on-device engine writes `spo2Pct = null` (it banks only raw `spo2Red`/`spo2Ir`) and no `skinTempDevC`, so every computed `-noop` row lacks both fields; only imported rows carry them. The whole-row carries (`lastScoredRecoveryDay` / `lastVitalsRow` on Android, `lastScoredRecoveryDay` / `lastVitalsDay` on iOS) select by recovery/vitals presence, so they land on a row where both fields are null and the cards blank out.

**Fix 1 — per-field selectors.** Android (`LogicalDay.kt`): `lastSpo2Row` / `lastSkinTempRow`. iOS (`MetricsCache.swift`): `lastSpo2Day` / `lastSkinTempDay`, with `Repository` forwarders. Both are per-field twins of the vitals carry that pick the freshest strictly-prior row where the field *itself* is non-null, with the same future-clock guard (#547 precedent).

**Fix 2 — wiring.** Android (`TodayScreen.kt`): `dashboardCardValue` and the Key Metrics grid (`spo2CarryDay`). iOS (`TodayView.swift`): `dashboardValue` and the Blood Oxygen tile — `carriedVital` gains a `perField` fallback, tried *after* the whole-row carry so a genuine last-scored night keeps its "Last night" caption. Both platforms resolve today-first → whole-row carry → per-field, so the card and the tile agree.

**Cross-platform parity (correction).** An earlier draft of this description said the Android change "mirrored" an iOS `VitalSourceResolution` per-field pick (citing PR #261). Those references point at the pre-fork upstream repo (now offline), so they can't be followed here — and in the current tree there's no such type and no per-field SpO₂/skin-temp selector on iOS: it shared the same bug. Corrected per review (thanks @ryanbr) — this PR now carries the iOS twin so both platforms ship the fix together, and the stale `VitalSourceResolution` comments on both sides now point at the real `lastSpo2Day` / `lastSkinTempDay`.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] CI / tooling

## How it was tested

No BLE-path changes on either platform — pure UI-side selection logic on already-stored rows.

- **Android:** five `TodayMetricTilesTest` cases (incl. the documenting test showing `lastVitalsRow` alone selects a row with null `spo2Pct`) plus future-dated-row guards for both new selectors. `:app:testFullDebugUnitTest` green. Device verification: staging release build (full flavor) on a physical device paired to a 4.0 strap — Blood Oxygen and Skin Temp cards survive the rollover with carried-date captions, per-field carry works independently, fresh readings replace carried values, HRV / Resting HR / Respiratory tiles unaffected.
- **iOS / macOS:** five `DailyMetricLastVitalsDayTests` cases mirror the Android per-field cases — `swift test` (WhoopStore) green, no strap. App-target Swift (`TodayView` / `Repository`) compiled with a macOS `Strand` build (default CI does not cover app targets): BUILD SUCCEEDED, no new warnings.

## Checklist

- [x] Swift package tests pass for any package I touched (`swift test` WhoopStore — green)
- [x] Android unit tests pass (`./gradlew testFullDebugUnitTest`)
- [x] App-target Swift compiled locally (macOS `Strand` build; default CI does not validate app targets)
- [x] No new build warnings introduced
- [x] UI changes use only design tokens — n/a, logic only, no visual changes
- [x] No hardcoded hex frame bytes; protocol facts live in the schema / decoders — n/a, no protocol changes
- [x] Follows the conventions in `docs/CONTRIBUTING.md`
- [x] I did not commit generated output (`Strand.xcodeproj/`) or any secrets/keystores

## Related issues

Related: #547 (future-clock guard precedent). Not in this PR: deriving computed SpO₂ / skin-temp daily values from the raw `spo2Red`/`spo2Ir` and `skinTempSample` data on `-noop` rows — a separate follow-up on both platforms (no tracking issue filed yet).
