### PR TITLE
refactor(ble): extract LiveHRSource driver protocol; collapse SourceCoordinator

### DIFF
--- a/Strand/BLE/LiveHRSource.swift
+++ b/Strand/BLE/LiveHRSource.swift
@@ -1,0 +1,33 @@
+import Foundation
+
+/// A non-WHOOP live BLE source the `SourceCoordinator` can run as the single active source (a generic HR
+/// strap, an FTMS gym machine, an experimental Huami band, or an experimental Oura ring).
+///
+/// Deliberately MINIMAL: the coordinator only ever starts, targets, and stops a source, so this contract
+/// is exactly `scan` / `connect` / `stop`. All the richer per-source state — `discovered`, `scanning`,
+/// `batteryPct`, `needsPairing`, Oura's `adoptPhase` — stays on the concrete type for the wizard/live UI
+/// to observe; it is NOT part of this protocol. That keeps the coordinator's active-source lifecycle
+/// decoupled from the pairing/observation surface, so adding a brand is a factory arm, not new plumbing.
+///
+/// Every conformer owns its OWN `CBCentralManager` and never references `BLEManager`/`WhoopBleClient`
+/// (the WHOOP-first isolation each source already documents), so nothing here can regress the WHOOP path.
+///
+/// Faithful twin of Android `com.noop.ble.LiveHrSource`.
+@MainActor
+protocol LiveHRSource: AnyObject {
+    /// Discover and connect to the source's peripheral by scanning (the fallback when the registry row
+    /// has no usable stored identifier).
+    func scan()
+    /// Connect directly to the source's known peripheral by its stable identifier (preferred over `scan`).
+    func connect(_ id: UUID)
+    /// Tear the source down and stop streaming. Idempotent.
+    func stop()
+}
+
+// The four shipped sources already expose exactly `scan()` / `connect(_:)` / `stop()`, so conformance is
+// a pure declaration with no logic change (Swift's retroactive-conformance analogue of Android adding
+// `: LiveHrSource` + `override` to each class).
+extension StandardHRSource: LiveHRSource {}
+extension HuamiHRSource: LiveHRSource {}
+extension FTMSSource: LiveHRSource {}
+extension OuraLiveSource: LiveHRSource {}

--- a/Strand/BLE/SourceCoordinator.swift
+++ b/Strand/BLE/SourceCoordinator.swift
@@ -59,29 +59,25 @@ final class SourceCoordinator: ObservableObject {
 
     // MARK: - State
 
-    /// The lazily-created generic-strap source. nil until the first switch to a strap; reused after.
-    private var standardSource: StandardHRSource?
-    /// The lazily-created FTMS gym-equipment source. nil until the first switch to a gym machine. An FTMS
-    /// device (sourceKind `.ftms`) is a non-WHOOP live source, so it runs through the SAME strap edge as
-    /// `standardSource` — only the source object differs. Exactly one of the two is ever live at a time.
-    private var ftmsSource: FTMSSource?
-    /// The lazily-created EXPERIMENTAL Huami source (Amazfit / Zepp / Mi Band). nil until the first switch
-    /// to a `.huami` device. Like the others it's a non-WHOOP live source sharing the same strap edge —
-    /// exactly one of the non-WHOOP sources is ever live at a time.
-    private var huamiSource: HuamiHRSource?
-    /// The lazily-created EXPERIMENTAL Oura source (Oura Ring gen 3/4/5). nil until the first switch to a
-    /// `.oura` device. Like the others it's a non-WHOOP live source sharing the same strap edge: exactly
-    /// one of the non-WHOOP sources is ever live at a time. It owns its OWN `CBCentralManager` and never
-    /// references `BLEManager`/`WhoopBleClient`, so the WHOOP path cannot regress.
+    /// The single non-WHOOP source currently live — a generic HR strap, FTMS machine, Huami band, or Oura
+    /// ring — held behind the `LiveHRSource` protocol. nil while WHOOP is active or nothing else is paired.
+    /// Exactly one non-WHOOP source is ever live at a time, and the coordinator only ever `connect`s /
+    /// `scan`s / `stop`s it. Built by `makeSource(for:)`; each source owns its OWN `CBCentralManager` and
+    /// never references `BLEManager`/`WhoopBleClient`, so the WHOOP path cannot regress.
+    private var activeSource: (any LiveHRSource)?
+    /// The live Oura source, TYPED, kept ALONGSIDE `activeSource` purely so `AppModel` can observe its
+    /// `adoptPhase` / `needsPairing` for the adopt wizard (`coordinator.$ouraSource`). Set in `makeOura`
+    /// (the same object as `activeSource` while an Oura ring is live) and cleared in
+    /// `tearDownNonWhoopSource`. The coordinator's lifecycle logic uses `activeSource`; this is only the
+    /// published UI handle.
     @Published private(set) var ouraSource: OuraLiveSource?
     /// The deviceId for which the user has granted explicit adopt consent (the wizard's irreversible gate +
-    /// "Take over this ring?" confirm). The NEXT `startOuraSource` for THIS id builds its live source with
+    /// "Take over this ring?" confirm). The NEXT `makeOuraSource` for THIS id builds its live source with
     /// `adoptIntent == true`, so the dangerous `0x24` key install can run for exactly that adopt session and
     /// nothing else. Cleared as soon as it is consumed (or when adopt is cancelled), so a later reconnect of
     /// the same ring is a normal read-only session that never re-installs a key.
     private var pendingAdoptDeviceId: String?
-    /// The deviceId the active non-WHOOP source (`standardSource` / `ftmsSource` / `huamiSource` /
-    /// `ouraSource`) runs for.
+    /// The deviceId the active non-WHOOP source (`activeSource`) runs for.
     private var activeStrapId: String?
     /// True once we've transitioned onto a generic strap. While false (the default / WHOOP-active
     /// state), switching to WHOOP is a pure no-op — we never issue a redundant WHOOP (re)scan.
@@ -264,33 +260,10 @@ final class SourceCoordinator: ObservableObject {
         // Switching source→source: stop the previous non-WHOOP source before starting the new one.
         tearDownNonWhoopSource()
 
-        // Route by sourceKind: an FTMS gym machine runs FTMSSource; an EXPERIMENTAL Huami device
-        // (Amazfit / Zepp / Mi Band) runs the HuamiHRSource; an EXPERIMENTAL Oura ring runs the
-        // OuraLiveSource; everything else is a generic HR strap on StandardHRSource. All are non-WHOOP
-        // live sources sharing this same strap edge. (`.liveAppleWatch` never reaches this switch: it's
-        // short-circuited above.)
-        switch sourceKind(for: id) {
-        case .ftms:  startFTMSSource(id: id)
-        case .huami: startHuamiSource(id: id)
-        case .oura:  startOuraSource(id: id)
-        default:     startStandardSource(id: id)
-        }
-        activeStrapId = id
-        onStrap = true
-    }
-
-    /// Start the isolated `StandardHRSource` for a generic HR strap `id`.
-    private func startStandardSource(id: String) {
-        let source = StandardHRSource(
-            live: live,
-            deviceId: id,
-            persist: { [storeHandle] streams in
-                Task { if let store = await storeHandle() { _ = try? await store.insert(streams, deviceId: id) } }
-            },
-            log: straplog,   // generic-HR lifecycle → the SAME exported strap log (issue #421)
-            // Surface the generic strap's standard Battery Service (0x180F) charge the SAME place the
-            // WHOOP strap battery shows (the Live/device status), via the shared LiveState funnel.
-            onBattery: { [live] pct in live.setBattery(Double(pct)) })
+        // Build the isolated source for this device's registered kind (the ONE place that maps a kind to a
+        // concrete driver), then bring it up. `.liveAppleWatch` never reaches here — it's short-circuited
+        // above — so `makeSource` only ever sees a real BLE source kind.
+        let source = makeSource(for: id)
         // CONNECT to the active strap's known peripheral, don't just scan. scan() only discovered + listed
         // it but never connected, so a Polar etc. showed as "found" yet never streamed (#421). connect()
         // reaches the cached peripheral by identifier (or scans-then-connects if not yet cached); a bare
@@ -300,30 +273,54 @@ final class SourceCoordinator: ObservableObject {
         } else {
             source.scan()
         }
-        standardSource = source
+        activeSource = source
+        activeStrapId = id
+        onStrap = true
     }
 
-    /// Start the isolated `FTMSSource` for a gym machine `id`. HR (when the machine reports it) rides the
+    /// Build the isolated `LiveHRSource` for a device id from its registered `sourceKind` — the ONE place
+    /// that maps a kind to a concrete driver. Adding a brand adds ONE arm here (and a conforming source);
+    /// nothing else in the coordinator changes. Each arm keeps its own bespoke construction (persist / log /
+    /// onBattery closures, plus Oura's ringGen / authKey / adoptIntent). Returns the source WITHOUT
+    /// connecting — the caller (`switchToStrap`) does the connect-by-identifier-else-scan bring-up.
+    private func makeSource(for id: String) -> any LiveHRSource {
+        switch sourceKind(for: id) {
+        case .ftms:  return makeFTMSSource(id: id)
+        case .huami: return makeHuamiSource(id: id)
+        case .oura:  return makeOuraSource(id: id)
+        default:     return makeStandardSource(id: id)
+        }
+    }
+
+    /// Build the isolated `StandardHRSource` for a generic HR strap `id`.
+    private func makeStandardSource(id: String) -> any LiveHRSource {
+        StandardHRSource(
+            live: live,
+            deviceId: id,
+            persist: { [storeHandle] streams in
+                Task { if let store = await storeHandle() { _ = try? await store.insert(streams, deviceId: id) } }
+            },
+            log: straplog,   // generic-HR lifecycle → the SAME exported strap log (issue #421)
+            // Surface the generic strap's standard Battery Service (0x180F) charge the SAME place the
+            // WHOOP strap battery shows (the Live/device status), via the shared LiveState funnel.
+            onBattery: { [live] pct in live.setBattery(Double(pct)) })
+    }
+
+    /// Build the isolated `FTMSSource` for a gym machine `id`. HR (when the machine reports it) rides the
     /// SAME `LiveState` channel, so the existing live-workout recorder scores it — no new scoring loop.
-    private func startFTMSSource(id: String) {
-        let source = FTMSSource(
+    private func makeFTMSSource(id: String) -> any LiveHRSource {
+        FTMSSource(
             live: live,
             log: straplog,
             onBattery: { [live] pct in live.setBattery(Double(pct)) })
-        if let pid = peripheralId(for: id), let uuid = UUID(uuidString: pid) {
-            source.connect(uuid)
-        } else {
-            source.scan()
-        }
-        ftmsSource = source
     }
 
-    /// Start the EXPERIMENTAL Huami source (Amazfit / Zepp / Mi Band) for `id`. HR (standard 0x180D when
+    /// Build the EXPERIMENTAL Huami source (Amazfit / Zepp / Mi Band) for `id`. HR (standard 0x180D when
     /// exposed, else the documented Huami custom characteristic) rides the SAME `LiveState` channel as the
     /// other sources, so the existing live UI + recorder handle it — no new scoring loop, no fabricated
     /// data (the source stays at "—" when it can't read a real HR).
-    private func startHuamiSource(id: String) {
-        let source = HuamiHRSource(
+    private func makeHuamiSource(id: String) -> any LiveHRSource {
+        HuamiHRSource(
             live: live,
             deviceId: id,
             persist: { [storeHandle] streams in
@@ -331,24 +328,22 @@ final class SourceCoordinator: ObservableObject {
             },
             log: straplog,
             onBattery: { [live] pct in live.setBattery(Double(pct)) })
-        if let pid = peripheralId(for: id), let uuid = UUID(uuidString: pid) {
-            source.connect(uuid)
-        } else {
-            source.scan()
-        }
-        huamiSource = source
     }
 
-    /// Start the EXPERIMENTAL Oura source (Oura Ring gen 3/4/5) for `id`, driven by the clean-room
+    /// Build the EXPERIMENTAL Oura source (Oura Ring gen 3/4/5) for `id`, driven by the clean-room
     /// `OuraProtocol.OuraDriver`. Decoded raw signals (HR / IBI / HRV / SpO2 / temp / sleep-phase / battery)
     /// ride the SAME `LiveState` + persist channels as the other sources, so NOOP scores the Oura day with
     /// its OWN Charge/Rest exactly like a WHOOP day, while Oura's encrypted readiness/sleep scores are never
     /// read or surfaced. The ring generation is recovered from the registry row's `model` string via
     /// `OuraRingGen.from(model:)`; the 16-byte install key is read from the Keychain via `OuraKeyStore`
     /// (nil → the source drives its HONEST `needsPairing` path and streams nothing, never a fake value).
-    private func startOuraSource(id: String) {
+    ///
+    /// Also publishes the typed `ouraSource` handle (`AppModel` observes it for the adopt wizard) and
+    /// consumes the one-shot adopt consent — both side effects the coordinator must own, so they live here
+    /// rather than in the plain `makeStandard/FTMS/Huami` factories.
+    private func makeOuraSource(id: String) -> any LiveHRSource {
         let ringGen = OuraRingGen.from(model: model(for: id) ?? "")
-        // Adopt consent is consumed for exactly this start: only the session the user explicitly granted may
+        // Adopt consent is consumed for exactly this build: only the session the user explicitly granted may
         // install a key (s3.2). Clearing it here means a later reconnect of the SAME ring is a normal
         // read-only session that re-authenticates with the now-stored key and never re-installs.
         let adoptIntent = (pendingAdoptDeviceId == id)
@@ -365,12 +360,8 @@ final class SourceCoordinator: ObservableObject {
             onBattery: { [live] pct in live.setBattery(Double(pct)) },
             adoptIntent: adoptIntent)
         if adoptIntent { straplog("Oura: adopt consent granted - this session may install NOOP's key") }
-        if let pid = peripheralId(for: id), let uuid = UUID(uuidString: pid) {
-            source.connect(uuid)
-        } else {
-            source.scan()
-        }
-        ouraSource = source
+        ouraSource = source   // the published typed handle for the adopt mirror (same object as activeSource)
+        return source
     }
 
     /// Grant explicit adopt consent for `deviceId` so the NEXT live Oura session for it (started when it
@@ -381,13 +372,14 @@ final class SourceCoordinator: ObservableObject {
         pendingAdoptDeviceId = deviceId
     }
 
-    /// Stop whichever non-WHOOP source (standard strap, FTMS machine, Huami device, or Oura ring) is live,
-    /// and drop the reference. Idempotent. Exactly one is ever live, but we stop all defensively.
+    /// Stop the live non-WHOOP source (standard strap, FTMS machine, Huami device, or Oura ring) and drop
+    /// the reference. Idempotent — exactly one source is ever live. Also nils the published `ouraSource`
+    /// handle so the adopt mirror resets to `.idle` (when an Oura ring was live it is the same object as
+    /// `activeSource`; otherwise it is already nil and this is a no-op).
     private func tearDownNonWhoopSource() {
-        standardSource?.stop(); standardSource = nil
-        ftmsSource?.stop(); ftmsSource = nil
-        huamiSource?.stop(); huamiSource = nil
-        ouraSource?.stop(); ouraSource = nil
+        activeSource?.stop()
+        activeSource = nil
+        ouraSource = nil
     }
 
     // MARK: - Identity adoption

--- a/android/app/src/main/java/com/noop/ble/FtmsSource.kt
+++ b/android/app/src/main/java/com/noop/ble/FtmsSource.kt
@@ -56,7 +56,7 @@ class FtmsSource(
     /** Diagnostic sink for the connect lifecycle — the SAME exportable strap log (issue #421). Every line
      *  is prefixed "FTMS: " so it's distinguishable in the shared log. Default no-op keeps tests silent. */
     private val log: (String) -> Unit = {},
-) {
+) : LiveHrSource {
 
     /** An FTMS machine seen during a scan (UI affordance). */
     data class DiscoveredMachine(val address: String, val name: String, val rssi: Int)
@@ -96,7 +96,7 @@ class FtmsSource(
     // MARK: - Scanning
 
     /** Begin scanning for FTMS machines advertising the 0x1826 service. */
-    fun scan() {
+    override fun scan() {
         seen.clear()
         _discovered.value = emptyList()
         _scanning.value = true
@@ -125,7 +125,7 @@ class FtmsSource(
     // MARK: - Connecting
 
     /** Connect to the chosen machine (by address) and start streaming its machine data. */
-    fun connect(address: String) {
+    override fun connect(address: String) {
         stopScan()
         val device = seen[address] ?: runCatching { adapter?.getRemoteDevice(address) }.getOrNull()
         if (device == null) { pendingConnectAddress = address; return }
@@ -150,7 +150,7 @@ class FtmsSource(
     }
 
     /** Tear down: cancel the connection and stop scanning. Idempotent. */
-    fun stop() {
+    override fun stop() {
         stopScan()
         pendingConnectAddress = null
         gatt?.let { runCatching { it.disconnect(); it.close() } }

--- a/android/app/src/main/java/com/noop/ble/HuamiHrSource.kt
+++ b/android/app/src/main/java/com/noop/ble/HuamiHrSource.kt
@@ -64,7 +64,7 @@ class HuamiHrSource(
     private val log: (String) -> Unit = {},
     /** Fired with the band's battery percent (0–100) when read off 0x2A19. */
     private val onBattery: (Int) -> Unit = {},
-) {
+) : LiveHrSource {
 
     /** A Huami-family device seen during a scan (UI affordance). */
     data class DiscoveredDevice(val address: String, val name: String, val rssi: Int)
@@ -116,7 +116,7 @@ class HuamiHrSource(
      * 0xFEE0, some neither), so scan broadly and keep only the ones whose advertised name reads as an
      * Amazfit / Zepp / Mi Band ([ExperimentalBrand]).
      */
-    fun scan() {
+    override fun scan() {
         seen.clear()
         _discovered.value = emptyList()
         _scanning.value = true
@@ -144,7 +144,7 @@ class HuamiHrSource(
 
     // MARK: - Connecting
 
-    fun connect(address: String) {
+    override fun connect(address: String) {
         stopScan()
         _needsPairing.value = null
         val device = seen[address] ?: runCatching { adapter?.getRemoteDevice(address) }.getOrNull()
@@ -169,7 +169,7 @@ class HuamiHrSource(
         }
     }
 
-    fun stop() {
+    override fun stop() {
         stopScan()
         pendingConnectAddress = null
         gatt?.let { runCatching { it.disconnect(); it.close() } }

--- a/android/app/src/main/java/com/noop/ble/LiveHrSource.kt
+++ b/android/app/src/main/java/com/noop/ble/LiveHrSource.kt
@@ -1,0 +1,30 @@
+package com.noop.ble
+
+/**
+ * A non-WHOOP live BLE source the [SourceCoordinator] can run as the single active source (a generic HR
+ * strap, an FTMS gym machine, an experimental Huami band, or an experimental Oura ring).
+ *
+ * Deliberately MINIMAL: the coordinator only ever starts, targets, and stops a source, so this contract
+ * is exactly [scan] / [connect] / [stop]. All the richer per-source state — discovered peripherals, the
+ * scanning flag, battery, needs-pairing, Oura's adopt phase — stays on the concrete type for the
+ * wizard/live UI to observe; it is NOT part of this interface. That keeps the coordinator's active-source
+ * lifecycle decoupled from the pairing/observation surface, so adding a brand is a factory arm, not new
+ * plumbing.
+ *
+ * Every implementer owns its OWN scanner/GATT and never references [WhoopBleClient] (the WHOOP-first
+ * isolation each source already documents), so nothing here can regress the WHOOP path.
+ *
+ * Faithful twin of Strand/BLE/LiveHRSource.swift.
+ */
+interface LiveHrSource {
+    /** Discover and connect to the source's peripheral by scanning (the fallback when the registry row
+     *  has no usable stored address). */
+    fun scan()
+
+    /** Connect directly to the source's known peripheral by its stable BLE [address] (preferred over
+     *  [scan]). */
+    fun connect(address: String)
+
+    /** Tear the source down and stop streaming. Idempotent. */
+    fun stop()
+}

--- a/android/app/src/main/java/com/noop/ble/OuraLiveSource.kt
+++ b/android/app/src/main/java/com/noop/ble/OuraLiveSource.kt
@@ -105,7 +105,7 @@ class OuraLiveSource(
      * on RNG failure (then provisioning stays honest rather than installing a weak key).
      */
     private val randomKey: () -> IntArray? = { secureRandom16() },
-) {
+) : LiveHrSource {
 
     /**
      * The live outcome of an in-flight adopt (the wizard observes this to leave its Adopting step). Kotlin
@@ -456,7 +456,7 @@ class OuraLiveSource(
     // MARK: - Scanning
 
     /** Begin scanning for Oura rings advertising the ring's base service. */
-    fun scan() {
+    override fun scan() {
         seen.clear()
         _discovered.value = emptyList()
         _scanning.value = true
@@ -492,7 +492,7 @@ class OuraLiveSource(
     // MARK: - Connecting
 
     /** Connect to the chosen discovered ring (by address) and start the auth → enable → stream flow. */
-    fun connect(address: String) {
+    override fun connect(address: String) {
         stopScan()
         _needsPairing.value = null
         // Remember the paired ring so an involuntary drop auto-reconnects to it (#912). An explicit connect
@@ -550,7 +550,7 @@ class OuraLiveSource(
     }
 
     /** Tear down: cancel the connection and stop scanning, persisting anything still buffered. Idempotent. */
-    fun stop() {
+    override fun stop() {
         // A deliberate teardown (device switch / removal) must NOT auto-reconnect: mark it intentional and
         // drop the reconnect target so any pending backoff bails and no fresh one is scheduled (#912). Remove
         // any already-posted reconnect from the main-looper handler too, so it isn't retained for the full

--- a/android/app/src/main/java/com/noop/ble/SourceCoordinator.kt
+++ b/android/app/src/main/java/com/noop/ble/SourceCoordinator.kt
@@ -126,24 +126,14 @@ class SourceCoordinator(
      *  nulled on teardown so a forgotten ring never leaks a stale outcome. */
     private var ouraStateJob: kotlinx.coroutines.Job? = null
 
-    /** The lazily-created generic-strap source. null until the first switch to a strap; reused after. */
-    private var standardSource: StandardHrSource? = null
-    /** The lazily-created FTMS gym-equipment source. null until the first switch to a gym machine. An FTMS
-     *  device (sourceKind "ftms") is a non-WHOOP live source, so it runs through the SAME strap edge as
-     *  [standardSource] — only the source object differs. Exactly one of the two is ever live at a time. */
-    private var ftmsSource: FtmsSource? = null
-    /** The lazily-created EXPERIMENTAL Huami source (Amazfit / Zepp / Mi Band). null until the first switch
-     *  to a "huami" device. Like the others it's a non-WHOOP live source sharing the same strap edge —
-     *  exactly one of the non-WHOOP sources is ever live at a time. */
-    private var huamiSource: HuamiHrSource? = null
-    /** The lazily-created EXPERIMENTAL Oura ring source (gen3 / gen4 / gen5). null until the first switch
-     *  to an "oura" device. Like the others it's a non-WHOOP live source sharing the same strap edge:
-     *  exactly one of the non-WHOOP sources is ever live at a time. Owns its OWN scanner/GATT and never
-     *  touches the WHOOP BLE client; surfaces only the ring's OWN raw signals + open event tags (NOOP
-     *  computes its own Charge/Rest), never Oura's encrypted readiness/sleep scores. */
-    private var ouraSource: OuraLiveSource? = null
-    /** The deviceId the active non-WHOOP source ([standardSource]/[ftmsSource]/[huamiSource]/[ouraSource])
-     *  runs for. */
+    /** The single non-WHOOP source currently live — a generic HR strap, FTMS machine, Huami band, or Oura
+     *  ring — held behind the [LiveHrSource] interface. null while WHOOP is active or nothing else is
+     *  paired. Exactly one non-WHOOP source is ever live at a time, and the coordinator only ever connects /
+     *  scans / stops it. Built by [makeSource]; each source owns its OWN scanner/GATT and never touches the
+     *  WHOOP BLE client, so the WHOOP path cannot regress. (An Oura ring additionally surfaces only its OWN
+     *  raw signals + open event tags — NOOP computes its own Charge/Rest — never Oura's encrypted scores.) */
+    private var activeSource: LiveHrSource? = null
+    /** The deviceId the active non-WHOOP source ([activeSource]) runs for. */
     private var activeStrapId: String? = null
     /** The WHOOP registry id we last pointed the connection at, so a WHOOP→WHOOP switch is detected and a
      *  repeat activation of the SAME WHOOP is a no-op. null until the first WHOOP activation. (MW-3) */
@@ -323,116 +313,132 @@ class SourceCoordinator(
         if (!onStrap) stopWhoop()         // leaving WHOOP for the first non-WHOOP source → pause its BLE
         tearDownNonWhoopSource()          // source→source: stop the previous source first
 
-        // Non-null in production (set at the composition root); only the JVM-test paths that never reach a
-        // strap switch leave it null. Fail loudly rather than silently no-op if that invariant breaks.
-        val ctx = requireNotNull(context) { "SourceCoordinator.context is required to run a strap source" }
         val row = devices.firstOrNull { it.id == id }
         val address = row?.peripheralId
 
-        // Route by sourceKind: an FTMS gym machine runs the FtmsSource; an EXPERIMENTAL Huami device
-        // (Amazfit / Zepp / Mi Band) runs the HuamiHrSource; an EXPERIMENTAL Oura ring runs the
-        // OuraLiveSource; everything else is a generic HR strap on StandardHrSource. All are non-WHOOP
-        // live sources sharing this same strap edge.
-        if (row?.sourceKind == SourceKind.ftms.name) {
-            val source = FtmsSource(
+        // Build the isolated source for this device's registered kind (the ONE place that maps a kind to a
+        // concrete driver), then bring it up. Adding a brand adds ONE arm in [makeSource] plus a conforming
+        // source; nothing else in the coordinator changes.
+        val source = makeSource(id, row)
+        // CONNECT to the active strap's known BLE address, don't just scan. A bare scan discovers + lists
+        // the strap but never connects — so a Polar H10 etc. showed up as "found" yet never streamed
+        // (#421). connect(address) connects directly via getRemoteDevice; a bare scan is the fallback only
+        // when the registry row has no address.
+        if (!address.isNullOrEmpty()) source.connect(address) else source.scan()
+        activeSource = source
+        activeStrapId = id
+        onStrap = true
+    }
+
+    /**
+     * Build the isolated [LiveHrSource] for a device from its registered `sourceKind` — the ONE place that
+     * maps a kind to a concrete driver. An FTMS gym machine runs the FtmsSource; an EXPERIMENTAL Huami
+     * device (Amazfit / Zepp / Mi Band) runs the HuamiHrSource; an EXPERIMENTAL Oura ring runs the
+     * OuraLiveSource; everything else is a generic HR strap on StandardHrSource. Adding a brand adds ONE arm
+     * here (plus a conforming source); nothing else in the coordinator changes. Returns the source WITHOUT
+     * connecting — the caller ([switchToStrap]) does the connect-by-address-else-scan bring-up. Mirrors
+     * macOS `SourceCoordinator.makeSource(for:)`.
+     */
+    private fun makeSource(id: String, row: PairedDeviceRow?): LiveHrSource {
+        // Non-null in production (set at the composition root); only the JVM-test paths that never reach a
+        // strap switch leave it null. Fail loudly rather than silently no-op if that invariant breaks.
+        val ctx = requireNotNull(context) { "SourceCoordinator.context is required to run a strap source" }
+        return when (row?.sourceKind) {
+            SourceKind.ftms.name -> FtmsSource(
                 context = ctx,
                 liveSink = { hr -> liveSink(hr, emptyList()) },  // machine HR → the existing live recorder
                 onBattery = batterySink,                          // machine battery → the same live state
                 log = straplog,
             )
-            if (!address.isNullOrEmpty()) source.connect(address) else source.scan()
-            ftmsSource = source
-        } else if (row?.sourceKind == SourceKind.huami.name) {
-            val repo = requireNotNull(repository) { "SourceCoordinator.repository is required to persist Huami samples" }
-            val source = HuamiHrSource(
-                context = ctx,
-                deviceId = id,
-                liveSink = { hr -> liveSink(hr, emptyList()) },   // Huami HR → the existing live recorder
-                persist = { batch: StreamBatch, deviceId: String ->
-                    scope.launch { runCatching { repo.insert(batch, deviceId) } }
-                },
-                log = straplog,
-                onBattery = batterySink,
-            )
-            if (!address.isNullOrEmpty()) source.connect(address) else source.scan()
-            huamiSource = source
-        } else if (row?.sourceKind == SourceKind.oura.name) {
-            val repo = requireNotNull(repository) { "SourceCoordinator.repository is required to persist Oura samples" }
-            // The ring generation is carried on the row's model ("Oura Ring 3/4/5"); recover it so the
-            // transport clamps the MTU + picks the gen-appropriate live-HR enable command set. Defaults to
-            // gen3 if the model is missing/unrecognised (OuraRingGen.from).
-            val ringGen = OuraRingGen.from(row.model ?: "")
-            val source = OuraLiveSource(
-                context = ctx,
-                deviceId = id,
-                ringGen = ringGen,
-                liveSink = { hr, rr -> liveSink(hr, rr) },   // ring HR + R-R → the existing live recorder
-                // The 16-byte application install key, read from the at-rest-encrypted key store keyed by
-                // this ring's device id. INJECTED, never hardcoded; null drives OuraLiveSource's honest
-                // needs-pairing path (no faked data). Read fresh on each connect so a key provisioned
-                // mid-session (the adopt install) is picked up on the post-install re-auth.
-                authKey = { OuraInstallKeyStore.load(ctx, id) },
-                persist = { batch: StreamBatch, deviceId: String ->
-                    scope.launch { runCatching { repo.insert(batch, deviceId) } }
-                },
-                log = straplog,           // Oura connect/auth/stream lifecycle → the SAME exported strap log (#421)
-                onBattery = batterySink,  // ring battery → the same live state the WHOOP strap battery uses
-            )
-            // CONSUME the one-shot adopt-intent the wizard armed after its irreversible-consent gate AND its
-            // second "Take over" confirm (and ONLY then). True permits the DANGEROUS post-factory-reset key
-            // install for THIS session; the Advanced-key path and every later read-only reconnect read false,
-            // so they NEVER provision a key (OURA_PROTOCOL.md s3.2). One-shot by design: a single consent
-            // provisions ONE install. setAdoptIntent must run BEFORE connect (the driver is built per connect
-            // with allowKeyInstall wired from it).
-            if (OuraInstallKeyStore.consumePendingAdopt(ctx, id)) {
-                source.setAdoptIntent(true)
-                straplog("Oura: adopt consent granted - this session may install NOOP's key")
+            SourceKind.huami.name -> {
+                val repo = requireNotNull(repository) { "SourceCoordinator.repository is required to persist Huami samples" }
+                HuamiHrSource(
+                    context = ctx,
+                    deviceId = id,
+                    liveSink = { hr -> liveSink(hr, emptyList()) },   // Huami HR → the existing live recorder
+                    persist = { batch: StreamBatch, deviceId: String ->
+                        scope.launch { runCatching { repo.insert(batch, deviceId) } }
+                    },
+                    log = straplog,
+                    onBattery = batterySink,
+                )
             }
-            // Mirror this source's live adopt outcome + honest needs-pairing message so the wizard can leave
-            // its Adopting step on a confirmed streaming (success) or an honest Failed. Reset on teardown.
-            ouraStateJob?.cancel()
-            ouraStateJob = scope.launch {
-                launch { source.adoptPhase.collect { _ouraAdoptPhase.value = it } }
-                launch { source.needsPairing.collect { _ouraNeedsPairing.value = it } }
+            SourceKind.oura.name -> makeOuraSource(id, ctx, row)
+            else -> {
+                val repo = requireNotNull(repository) { "SourceCoordinator.repository is required to persist strap samples" }
+                StandardHrSource(
+                    context = ctx,
+                    deviceId = id,
+                    liveSink = liveSink,
+                    persist = { batch: StreamBatch, deviceId: String ->
+                        scope.launch { runCatching { repo.insert(batch, deviceId) } }
+                    },
+                    log = straplog,   // generic-HR lifecycle → the SAME exported strap log (issue #421)
+                    onBattery = batterySink,  // strap battery → the same live state the WHOOP strap battery uses
+                    sensorSink = { metrics ->
+                        // Additive speed/cadence/power → the coordinator's own flow the in-workout UI observes,
+                        // AND the optionally-injected sink (default no-op). Never HR / R-R / scoring.
+                        _sensorMetrics.value = metrics
+                        sensorSink(metrics)
+                    },
+                )
             }
-            if (!address.isNullOrEmpty()) source.connect(address) else source.scan()
-            ouraSource = source
-        } else {
-            val repo = requireNotNull(repository) { "SourceCoordinator.repository is required to persist strap samples" }
-            val source = StandardHrSource(
-                context = ctx,
-                deviceId = id,
-                liveSink = liveSink,
-                persist = { batch: StreamBatch, deviceId: String ->
-                    scope.launch { runCatching { repo.insert(batch, deviceId) } }
-                },
-                log = straplog,   // generic-HR lifecycle → the SAME exported strap log (issue #421)
-                onBattery = batterySink,  // strap battery → the same live state the WHOOP strap battery uses
-                sensorSink = { metrics ->
-                    // Additive speed/cadence/power → the coordinator's own flow the in-workout UI observes,
-                    // AND the optionally-injected sink (default no-op). Never HR / R-R / scoring.
-                    _sensorMetrics.value = metrics
-                    sensorSink(metrics)
-                },
-            )
-            // CONNECT to the active strap's known BLE address, don't just scan. The previous code only
-            // called scan() (it discovered the strap and listed it, but never connected) — so a Polar H10
-            // etc. showed up as "found" yet never streamed (#421). connect(address) connects directly via
-            // getRemoteDevice; we fall back to a bare scan only if the registry row has no address.
-            if (!address.isNullOrEmpty()) source.connect(address) else source.scan()
-            standardSource = source
         }
-        activeStrapId = id
-        onStrap = true
     }
 
-    /** Stop whichever non-WHOOP source (standard strap, FTMS machine, Huami device, or Oura ring) is live,
-     *  and drop the reference. Idempotent. Exactly one is ever live, but we stop all defensively. */
+    /**
+     * Build the EXPERIMENTAL Oura ring source (gen3 / gen4 / gen5) for [id]. Also wires the adopt-outcome
+     * mirror ([ouraStateJob]) and consumes the one-shot adopt consent — side effects the coordinator owns,
+     * so they live here rather than in the plain FTMS / Huami / Standard arms of [makeSource]. Mirrors the
+     * Oura branch of macOS `makeOuraSource`.
+     */
+    private fun makeOuraSource(id: String, ctx: Context, row: PairedDeviceRow?): OuraLiveSource {
+        val repo = requireNotNull(repository) { "SourceCoordinator.repository is required to persist Oura samples" }
+        // The ring generation is carried on the row's model ("Oura Ring 3/4/5"); recover it so the transport
+        // clamps the MTU + picks the gen-appropriate live-HR enable command set. Defaults to gen3 if the
+        // model is missing/unrecognised (OuraRingGen.from).
+        val ringGen = OuraRingGen.from(row?.model ?: "")
+        val source = OuraLiveSource(
+            context = ctx,
+            deviceId = id,
+            ringGen = ringGen,
+            liveSink = { hr, rr -> liveSink(hr, rr) },   // ring HR + R-R → the existing live recorder
+            // The 16-byte application install key, read from the at-rest-encrypted key store keyed by this
+            // ring's device id. INJECTED, never hardcoded; null drives OuraLiveSource's honest needs-pairing
+            // path (no faked data). Read fresh on each connect so a key provisioned mid-session (the adopt
+            // install) is picked up on the post-install re-auth.
+            authKey = { OuraInstallKeyStore.load(ctx, id) },
+            persist = { batch: StreamBatch, deviceId: String ->
+                scope.launch { runCatching { repo.insert(batch, deviceId) } }
+            },
+            log = straplog,           // Oura connect/auth/stream lifecycle → the SAME exported strap log (#421)
+            onBattery = batterySink,  // ring battery → the same live state the WHOOP strap battery uses
+        )
+        // CONSUME the one-shot adopt-intent the wizard armed after its irreversible-consent gate AND its
+        // second "Take over" confirm (and ONLY then). True permits the DANGEROUS post-factory-reset key
+        // install for THIS session; the Advanced-key path and every later read-only reconnect read false, so
+        // they NEVER provision a key (OURA_PROTOCOL.md s3.2). One-shot by design: a single consent provisions
+        // ONE install. setAdoptIntent must run BEFORE connect (the driver is built per connect with
+        // allowKeyInstall wired from it) — the caller connects only after this returns, so the order holds.
+        if (OuraInstallKeyStore.consumePendingAdopt(ctx, id)) {
+            source.setAdoptIntent(true)
+            straplog("Oura: adopt consent granted - this session may install NOOP's key")
+        }
+        // Mirror this source's live adopt outcome + honest needs-pairing message so the wizard can leave its
+        // Adopting step on a confirmed streaming (success) or an honest Failed. Reset on teardown.
+        ouraStateJob?.cancel()
+        ouraStateJob = scope.launch {
+            launch { source.adoptPhase.collect { _ouraAdoptPhase.value = it } }
+            launch { source.needsPairing.collect { _ouraNeedsPairing.value = it } }
+        }
+        return source
+    }
+
+    /** Stop the live non-WHOOP source (standard strap, FTMS machine, Huami device, or Oura ring) and drop
+     *  the reference. Idempotent — exactly one source is ever live. */
     private fun tearDownNonWhoopSource() {
-        standardSource?.stop(); standardSource = null
-        ftmsSource?.stop(); ftmsSource = null
-        huamiSource?.stop(); huamiSource = null
-        ouraSource?.stop(); ouraSource = null
+        activeSource?.stop()
+        activeSource = null
         // Stop mirroring the (now torn-down) Oura source and clear the mirrors so a stale adopt outcome /
         // needs-pairing message never outlives the source or drives a later wizard transition.
         ouraStateJob?.cancel(); ouraStateJob = null

--- a/android/app/src/main/java/com/noop/ble/StandardHrSource.kt
+++ b/android/app/src/main/java/com/noop/ble/StandardHrSource.kt
@@ -73,7 +73,7 @@ class StandardHrSource(
      *  in-exercise readout — it never touches HR/R-R/persistence/scoring. Called on the main looper.
      *  Mirrors [FtmsSource.readingSink]. Default no-op keeps existing call sites compiling. */
     private val sensorSink: (SensorMetrics) -> Unit = {},
-) {
+) : LiveHrSource {
 
     /** Live instantaneous fitness-sensor metrics surfaced via [sensorSink]. Any field is null when it
      *  isn't available yet (no such sensor, or a first CSC/CPS packet — derived values need two). */
@@ -148,7 +148,7 @@ class StandardHrSource(
     // MARK: - Scanning
 
     /** Begin scanning for generic HR straps advertising the 0x180D service. */
-    fun scan() {
+    override fun scan() {
         synchronized(bufferLock) { /* keep buffer across a rescan */ }
         seen.clear()
         _discovered.value = emptyList()
@@ -182,7 +182,7 @@ class StandardHrSource(
     // MARK: - Connecting
 
     /** Connect to the chosen discovered strap (by address) and start streaming its HR. */
-    fun connect(address: String) {
+    override fun connect(address: String) {
         stopScan()
         val device = seen[address] ?: runCatching { adapter?.getRemoteDevice(address) }.getOrNull()
         if (device == null) { pendingConnectAddress = address; return }
@@ -211,7 +211,7 @@ class StandardHrSource(
     }
 
     /** Tear down: cancel the connection and stop scanning, persisting anything still buffered. Idempotent. */
-    fun stop() {
+    override fun stop() {
         stopScan()
         pendingConnectAddress = null
         gatt?.let { runCatching { it.disconnect(); it.close() } }

--- a/docs/DEVICE_DRIVER_ARCHITECTURE.md
+++ b/docs/DEVICE_DRIVER_ARCHITECTURE.md
@@ -195,3 +195,23 @@ Per `CLAUDE.md`, know the coverage before claiming it works:
    Takeout file shapes for those signals. The deeper unbuilt lanes are the *live* ones in
    `DEVICE_SUPPORT_ROADMAP.md` (Polar PMD ECG/PPG, Xiaomi live-BLE sync), which would be the first real
    new drivers built on the Phase 1 `LiveHRSource` abstraction.
+
+## On-strap smoke test — the Phase 1 merge gate
+
+The Phase 1 refactor is byte-identical *by construction* (driver logic untouched, WHOOP-first isolation
+and churn guards preserved), and it compiles on both platforms, but **BLE behaviour cannot be CI- or
+Linux-tested** (`docs/CONTRIBUTING.md` §BLE). Run this once on real hardware before merging, and record
+the result on the PR:
+
+1. **Single-WHOOP zero-regression** (the default, dormant path): launch with only the WHOOP paired.
+   Confirm it connects, bonds, and streams live HR exactly as before — the coordinator must issue no
+   scan / disconnect / re-point (`activeSource` stays nil; it is a pure no-op for one WHOOP).
+2. **WHOOP → generic strap**: pair a standard 0x180D strap (Polar / Wahoo / Coospo / Garmin HRM), make
+   it active. Confirm the WHOOP link tears down and the strap streams live HR under its own device id,
+   with battery + strap-log lines appearing where the WHOOP's do.
+3. **Strap → WHOOP (back)**: make the WHOOP active again. Confirm the strap source stops cleanly and the
+   WHOOP reconnects and resumes — no lingering strap stream, no double connection.
+4. **Idempotence**: re-select the already-active device; confirm nothing churns (no reconnect flap).
+
+If an experimental band (Amazfit/Huami or an Oura ring) is on hand, repeat 2–3 for it to exercise the
+`makeSource` Huami/Oura arms; otherwise the standard-strap pass covers the abstraction's hot path.

--- a/docs/DEVICE_DRIVER_ARCHITECTURE.md
+++ b/docs/DEVICE_DRIVER_ARCHITECTURE.md
@@ -1,0 +1,197 @@
+# Device-driver architecture — pluggable live sources
+
+**Status:** Phase 1 implemented on `feat/multi-device-foundations` (`LiveHRSource`/`LiveHrSource`
+protocol + coordinator collapse, both platforms; macOS app compiles, Android awaits a local/CI compile).
+Companion to
+[`DEVICE_SUPPORT_ROADMAP.md`](DEVICE_SUPPORT_ROADMAP.md), which records the *per-brand protocol facts*
+(what each device exposes and how to reach it). This file covers the *internal architecture*: how a new
+brand becomes a **recipe** instead of bespoke code threaded through the coordinator on both platforms.
+
+North star is unchanged: **WHOOP is primary and must never regress.** Everything here is a refactor of
+the already-shipped experimental multi-source tier — same behaviour, less friction to extend.
+
+## The problem: adding a device is bespoke, four times over
+
+Today a live non-WHOOP source is one of four concrete classes the coordinator holds as **typed
+optionals** and routes to through a **hand-maintained switch**:
+
+- `Strand/BLE/SourceCoordinator.swift` holds `standardSource` / `ftmsSource` / `huamiSource` /
+  `ouraSource` (four `var … ?`), a `switch sourceKind { case .ftms / .huami / .oura / default }`, four
+  near-identical `startXxxSource(id:)` methods, and a `tearDownNonWhoopSource()` that nils all four.
+- Each new brand therefore touches, **on both platforms**:
+  1. `ExperimentalBrand` — a recognition `case` (name-substring → brand);
+  2. `SourceKind` — usually a new kind;
+  3. a whole new `XxxHRSource` class (~150–450 lines, its own `CBCentralManager`);
+  4. `SourceCoordinator` — a new stored optional, a `startXxxSource`, a `switch` arm, a teardown line;
+  5. wizard/UI wiring.
+
+Steps 1, 3, and 5 are irreducible (recognition + the actual driver + honest UI are real per-device
+work). **Step 4 is pure boilerplate that grows O(n) with every brand** — that is what this refactor
+removes.
+
+## The shared surface is already uniform
+
+All four existing sources expose an identical control surface (verified in-tree):
+
+| Method | Standard | Huami | FTMS | Oura |
+|---|---|---|---|---|
+| `func scan()` | ✅ | ✅ | ✅ | ✅ |
+| `func connect(_ id: UUID)` | ✅ | ✅ | ✅ | ✅ |
+| `func stop()` | ✅ | ✅ | ✅ | ✅ |
+
+They also share the same construction wiring — `live: LiveState`, a `persist:` closure, a `log:`
+diagnostic sink, and an `onBattery:` callback — differing only in source-specific extras (Oura adds
+`ringGen` / `authKey` / `adoptIntent`). The coordinator, crucially, **only ever calls `scan` /
+`connect` / `stop`** on the source it holds. The richer `@Published` state (`discovered`, `scanning`,
+`batteryPct`, `needsPairing`, `adoptPhase`) is consumed by the **wizard/pairing UI**, not by the
+coordinator's active-source management — so it stays a separate concern and does **not** belong in this
+protocol.
+
+## Proposal: a `LiveHRSource` protocol + a factory
+
+### 1. The protocol (minimal, exactly the coordinator's needs)
+
+```swift
+/// A non-WHOOP live BLE source the SourceCoordinator can run as the single active source.
+/// Deliberately minimal: the coordinator only starts, targets, and stops. All richer state
+/// (discovered peripherals, scanning flag, battery, pairing prompts) stays on the concrete
+/// type for the wizard/UI to observe — it is not part of this contract.
+@MainActor
+protocol LiveHRSource: AnyObject {
+    func scan()
+    func connect(_ id: UUID)
+    func stop()
+}
+```
+
+`StandardHRSource`, `HuamiHRSource`, `FTMSSource`, `OuraLiveSource` conform **without a single line of
+logic changing** — they already have these three methods. Conformance is a one-line
+`extension StandardHRSource: LiveHRSource {}` each (methods are already `public`).
+
+### 2. The coordinator collapses
+
+Four optionals + a switch + four `startXxxSource` + a four-line teardown become:
+
+```swift
+/// The one non-WHOOP source currently live (nil when WHOOP-active or idle). Exactly one at a time.
+private var activeSource: (any LiveHRSource)?
+
+private func switchToStrap(id: String) {
+    // …unchanged WHOOP-pause / churn-guard logic…
+    tearDownNonWhoopSource()
+    let source = makeSource(for: id)           // factory replaces the per-kind switch
+    if let pid = peripheralId(for: id), let uuid = UUID(uuidString: pid) {
+        source.connect(uuid)                   // connect-by-identifier, unchanged (#421)
+    } else {
+        source.scan()
+    }
+    activeSource = source
+    activeStrapId = id
+    onStrap = true
+}
+
+private func tearDownNonWhoopSource() {
+    activeSource?.stop()
+    activeSource = nil
+}
+
+/// Build the isolated source for a device id from its registered `sourceKind`. The ONE place
+/// that maps a kind → a concrete driver; adding a brand adds one arm here, nothing else in the
+/// coordinator. Each arm keeps its existing bespoke construction (persist/log/onBattery, plus
+/// Oura's ringGen/authKey/adoptIntent).
+private func makeSource(for id: String) -> any LiveHRSource {
+    switch sourceKind(for: id) {
+    case .ftms:  return makeFTMS(id: id)
+    case .huami: return makeHuami(id: id)
+    case .oura:  return makeOura(id: id)
+    default:     return makeStandard(id: id)
+    }
+}
+```
+
+Note the switch does **not** fully disappear — a `sourceKind → concrete init` factory is irreducible
+because each driver's constructor differs (Oura needs a key from the Keychain, etc.). What disappears is
+the **duplication**: four stored optionals → one; four teardown lines → one; the start-methods keep only
+their genuinely-distinct construction and lose the shared connect/scan/store bookkeeping.
+
+### 3. Oura's extra surface stays off the hot path
+
+`OuraLiveSource` is published (`@Published private(set) var ouraSource`) because the adopt-consent UI
+observes `adoptPhase`. Keep a **separate** typed reference for that (`private(set) var ouraSource:
+OuraLiveSource?`) set inside `makeOura`, alongside the protocol-typed `activeSource`. The coordinator's
+lifecycle logic uses `activeSource`; the adopt UI keeps its typed handle. `tearDownNonWhoopSource()`
+nils both. This preserves the exact adopt flow (`requestOuraAdopt` / `pendingAdoptDeviceId`) with no
+behaviour change.
+
+## Cross-platform parity (rule #1)
+
+The Android coordinator (`android/app/src/main/java/com/noop/ble/…`) mirrors the same shape and gets the
+**same** refactor in the **same PR**:
+
+- Kotlin `interface LiveHrSource { fun scan(); fun connect(id: …); fun stop() }`.
+- The Android source-coordinator's per-kind fields/branches collapse to one `activeSource` + a
+  `makeSource(kind)` factory, identical control flow to Swift.
+- No stored value, dedup key, or `.noopbak` field changes — this is an **in-memory runtime refactor
+  only**, so there is no migration and no schema/backup-contract surface. (Call this out explicitly in
+  the PR: parity here is *behavioural*, and the "numbers" — analytics, stored samples — are untouched by
+  construction.)
+
+### Parity checklist (for the PR)
+- [ ] `LiveHRSource` (Swift) ⇄ `LiveHrSource` (Kotlin): same three methods, same semantics.
+- [ ] Coordinator control flow identical: same churn guards, same WHOOP-pause edge, same
+      connect-by-identifier-else-scan fallback (#421), same single-active-source invariant.
+- [ ] Oura adopt-consent path unchanged on both (`adoptIntent` one-shot, key install still consent-gated).
+- [ ] No change to `SourceKind` values, `PairedDevice`/registry rows, persisted samples, or backup keys.
+- [ ] Existing driver unit tests still green on both platforms (they test the drivers, not the wiring).
+
+## What validates this change
+
+Per `CLAUDE.md`, know the coverage before claiming it works:
+
+- **`swift test` (`Packages/**`)** does **not** cover this — the coordinator and drivers live under
+  `Strand/BLE`, i.e. **app-target Swift with no default CI** (`app-build.yml` is disabled). So:
+  - Compile the **macOS app locally**: `xcodegen generate && xcodebuild -project Strand.xcodeproj
+    -scheme Strand -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO build`.
+  - Compile the **Android app locally**: `cd android && ./gradlew compileFullDebugKotlin` +
+    `./gradlew testFullDebugUnitTest`.
+- **BLE behaviour cannot be CI- or Linux-tested.** Because this is a *structural* refactor with the
+  driver logic byte-identical by construction, the risk is low — but the live path still wants **one
+  on-strap smoke test** before merge: pair a WHOOP (confirm zero regression — the coordinator is a no-op
+  for the single-WHOOP user) and one generic HR strap, switch active device both ways, confirm live HR
+  streams and stops cleanly. State exactly what was tested on hardware in the PR.
+
+## Scope guardrails (unchanged NOOP constraints)
+
+- **Clean-room only.** Recognition stays name-substring (see `ExperimentalBrand`); no decompiled app
+  code, no vendor firmware, no DRM circumvention. Deep decoders are re-derived, never GPL-copied — see
+  `DEVICE_SUPPORT_ROADMAP.md` and `BLE_REVERSE_ENGINEERING.md`.
+- **Offline, on-device, anonymous.** No account, no cloud, no telemetry. Cloud "import lanes" for
+  Oura/Fitbit remain off-by-default and out of scope for this refactor.
+- **Honest capability.** A brand with no open live stream (Oura live, Fitbit) must route to file import,
+  never fake a connection or fabricate a value. The protocol does not change that stance.
+- **Design tokens only** for any UI touched.
+
+## Sequencing
+
+1. **Phase 1 — this refactor (one PR).** `LiveHRSource`/`LiveHrSource` protocol + coordinator collapse,
+   both platforms, no behaviour change. Enables everything below.
+2. **Phase 2 — brand facts become a table (done).** The live-strap space is already broadly covered
+   (standard 0x180D straps + Huami + Garmin broadcast + Oura), and Fitbit has no open live stream (it is
+   an import lane, Phase 3) — so the highest-leverage groundwork was to make *recognising* a brand a
+   table row, not to bolt on one more driver. `DeviceBrandCatalog` (`Packages/WhoopStore` +
+   `android/…/data`) is now the single source of truth for advertised-name → `{brand, sourceKind,
+   idPrefix, canStreamLiveHR, isExperimentalTier}`. It replaced three duplicated `brandGuess` copies
+   (Swift) + one (Kotlin) and the token list inside `ExperimentalBrand`, which is now a thin typed view
+   over the catalog. Pinned by pure tests on both platforms. **Follow-up:** fold the wizard's
+   `DeviceType` → registration mapping (stored brand string, id-prefix, sourceKind) through the catalog
+   too — today it still branches on `DeviceType`.
+3. **Phase 3 — generalized file import (already shipped).** `WearableExportImporter` /
+   `FitbitExportParser` / `OuraExportParser` / `GarminExportParser` (+ Kotlin twins) already import a
+   user's own Oura / Fitbit / Garmin data export (fully offline, no cloud) into the shared
+   `WearableDailyRow` / `WearableSleepSession` day model, under a `*-import` source id, with tests green
+   on both platforms. Fitbit specifically reads Google-Takeout `sleep-*` / `resting_heart_rate-*` /
+   `steps-*` JSON. **Genuine remaining work is extension, not construction:** the Fitbit parser leaves
+   HRV / SpO2 / breathing-rate / avg-HR `nil` (it does not fabricate them) — extending it needs the real
+   Takeout file shapes for those signals. The deeper unbuilt lanes are the *live* ones in
+   `DEVICE_SUPPORT_ROADMAP.md` (Polar PMD ECG/PPG, Xiaomi live-BLE sync), which would be the first real
+   new drivers built on the Phase 1 `LiveHRSource` abstraction.


### PR DESCRIPTION
## What & why

Adding a non-WHOOP live source used to mean **four typed optionals + a hand-maintained per-kind switch** in `SourceCoordinator`, on both platforms. This extracts the drivers' already-uniform control surface (`scan` / `connect` / `stop`) into a `LiveHRSource` protocol (Swift) / `LiveHrSource` interface (Kotlin), so the coordinator holds **one** `activeSource` behind a `makeSource` factory:

- four stored optionals → one; four `startXxx` methods + a switch → one factory; a four-line teardown → one.
- Adding a brand is now a factory arm + a conforming source, not new coordinator plumbing.

`StandardHRSource` / `HuamiHRSource` / `FTMSSource` / `OuraLiveSource` conform with **no logic change** (they already expose exactly these three methods). The typed `ouraSource` handle is kept because `AppModel` observes it for the adopt wizard.

## Behaviour

No behaviour change by construction: driver logic, WHOOP-first isolation, churn guards, the Oura adopt-consent order (`setAdoptIntent` before `connect`), and all persisted data are untouched.

See `docs/DEVICE_DRIVER_ARCHITECTURE.md` (added here) for the abstraction, migration path, and parity checklist.

## Verification

- ✅ macOS app compiles — `xcodebuild -scheme Strand … build` **BUILD SUCCEEDED** (app-target Swift; `app-build.yml` is disabled, so validated locally).
- ✅ Android `compileFullDebugKotlin` **BUILD SUCCESSFUL**; existing JVM tests green.
- ⚠️ **BLE behaviour** is byte-identical by construction but still wants **one on-strap smoke test** before merge: single WHOOP (confirm zero regression — coordinator is a no-op there) + one generic HR strap, switch active device both ways, confirm live HR streams and stops cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)