### PR TITLE
refactor(devices): DeviceBrandCatalog — single source of truth for brand recognition

### DIFF
--- a/Packages/WhoopStore/Sources/WhoopStore/DeviceBrandCatalog.swift
+++ b/Packages/WhoopStore/Sources/WhoopStore/DeviceBrandCatalog.swift
@@ -1,0 +1,84 @@
+import Foundation
+
+/// Single source of truth for recognising a wearable BRAND from its advertised BLE name, and the stored
+/// facts that follow from the brand. Pure (no CoreBluetooth), so it lives in the store package and is
+/// covered by `swift test` — the recognition + capability facts are byte-parity-critical, so they must be
+/// asserted headlessly on both platforms. Faithful twin of `android com.noop.data.DeviceBrandCatalog`.
+///
+/// Adding a recognised brand is ONE row in `all`: the wizard's brand labelling, the experimental-tier
+/// capability gate (`ExperimentalBrand`), and the source routing all derive from here instead of re-listing
+/// the advertised-name tokens per call site (previously duplicated across `ExperimentalBrand.recognise` and
+/// two copies of the wizard's `brandGuess`).
+public struct DeviceBrandSpec: Sendable, Equatable {
+    /// Display + stored `PairedDevice.brand` string ("Polar", "Amazfit", "Oura", …).
+    public let brand: String
+    /// Lowercased, diacritic-folded advertised-name substrings that identify this brand. Checked in `all`
+    /// order (most specific first) so a Huami sub-brand like Mi Band wins over the broader Amazfit tokens.
+    public let nameTokens: [String]
+    /// The routing kind stored on the device (drives `SourceCoordinator.makeSource`). `.liveBLE` for a brand
+    /// whose live HR is the standard 0x180D broadcast (generic straps + Garmin); `.huami` / `.oura` for the
+    /// experimental custom-protocol sources.
+    public let sourceKind: SourceKind
+    /// The registry id prefix for a device of this brand ("huami", "oura", "garmin", "strap").
+    public let idPrefix: String
+    /// Whether this brand can stream LIVE heart rate at all in NOOP. `false` for Oura (no open live stream)
+    /// — the wizard routes those to import instead of pretending to connect.
+    public let canStreamLiveHR: Bool
+    /// True for the opt-in EXPERIMENTAL tier (Amazfit / Mi Band / Garmin / Oura); false for the shipped
+    /// generic HR straps (Polar / Wahoo / …). `ExperimentalBrand.recognise` returns only these.
+    public let isExperimentalTier: Bool
+
+    public init(brand: String, nameTokens: [String], sourceKind: SourceKind, idPrefix: String,
+                canStreamLiveHR: Bool, isExperimentalTier: Bool) {
+        self.brand = brand
+        self.nameTokens = nameTokens
+        self.sourceKind = sourceKind
+        self.idPrefix = idPrefix
+        self.canStreamLiveHR = canStreamLiveHR
+        self.isExperimentalTier = isExperimentalTier
+    }
+}
+
+public enum DeviceBrandCatalog {
+    /// The brand table, checked most-specific-first. Order matters ONLY where one name could match two rows:
+    /// Mi Band (a Huami sub-brand) precedes Amazfit so a "Mi Smart Band" is not mis-labelled Amazfit. Tokens
+    /// are otherwise disjoint across rows, so the remaining order is cosmetic.
+    public static let all: [DeviceBrandSpec] = [
+        // EXPERIMENTAL tier — custom-protocol or broadcast live sources, opt-in and best-effort.
+        DeviceBrandSpec(brand: "Mi Band", nameTokens: ["mi band", "miband", "smart band", "xiaomi"],
+                        sourceKind: .huami, idPrefix: "huami", canStreamLiveHR: true, isExperimentalTier: true),
+        DeviceBrandSpec(brand: "Amazfit", nameTokens: ["amazfit", "zepp", "helio", "huami"],
+                        sourceKind: .huami, idPrefix: "huami", canStreamLiveHR: true, isExperimentalTier: true),
+        DeviceBrandSpec(brand: "Garmin",
+                        nameTokens: ["garmin", "forerunner", "fenix", "vivoactive", "venu", "instinct", "epix", "vivosmart", "hrm"],
+                        sourceKind: .liveBLE, idPrefix: "garmin", canStreamLiveHR: true, isExperimentalTier: true),
+        DeviceBrandSpec(brand: "Oura", nameTokens: ["oura"],
+                        sourceKind: .oura, idPrefix: "oura", canStreamLiveHR: false, isExperimentalTier: true),
+        // Shipped generic HR straps — standard 0x180D broadcast, labelled for display only. All route as a
+        // generic live-BLE strap; the wizard picks these through the "Heart-rate strap" type.
+        DeviceBrandSpec(brand: "Polar", nameTokens: ["polar"],
+                        sourceKind: .liveBLE, idPrefix: "strap", canStreamLiveHR: true, isExperimentalTier: false),
+        DeviceBrandSpec(brand: "Wahoo", nameTokens: ["wahoo", "tickr"],
+                        sourceKind: .liveBLE, idPrefix: "strap", canStreamLiveHR: true, isExperimentalTier: false),
+        DeviceBrandSpec(brand: "Coospo", nameTokens: ["coospo"],
+                        sourceKind: .liveBLE, idPrefix: "strap", canStreamLiveHR: true, isExperimentalTier: false),
+        DeviceBrandSpec(brand: "Scosche", nameTokens: ["scosche", "rhythm"],
+                        sourceKind: .liveBLE, idPrefix: "strap", canStreamLiveHR: true, isExperimentalTier: false),
+        DeviceBrandSpec(brand: "Magene", nameTokens: ["magene"],
+                        sourceKind: .liveBLE, idPrefix: "strap", canStreamLiveHR: true, isExperimentalTier: false),
+    ]
+
+    /// The brand whose advertised name matches, or nil if unrecognised. Diacritic-folded + lowercased so
+    /// accented Garmin branding ("vívoactive", "fēnix") matches its ASCII form; substring match in `all`
+    /// order. Twin of android `DeviceBrandCatalog.spec(forAdvertisedName:)`.
+    public static func spec(forAdvertisedName name: String) -> DeviceBrandSpec? {
+        let n = name.folding(options: .diacriticInsensitive, locale: nil).lowercased()
+        return all.first { spec in spec.nameTokens.contains { n.contains($0) } }
+    }
+
+    /// The row for a known brand string ("Amazfit", …), or nil. Lets the typed `ExperimentalBrand` derive
+    /// its facts (capability/routing) from this table rather than re-declaring them.
+    public static func spec(forBrand brand: String) -> DeviceBrandSpec? {
+        all.first { $0.brand == brand }
+    }
+}

--- a/Packages/WhoopStore/Tests/WhoopStoreTests/DeviceBrandCatalogTests.swift
+++ b/Packages/WhoopStore/Tests/WhoopStoreTests/DeviceBrandCatalogTests.swift
@@ -1,0 +1,77 @@
+import XCTest
+@testable import WhoopStore
+
+/// Pins the pure brand catalog: recognition, ordering, and the byte-parity facts (sourceKind / idPrefix /
+/// capability / tier). The Kotlin twin `DeviceBrandCatalogTest` must assert the SAME cases so the two
+/// platforms recognise a device identically.
+final class DeviceBrandCatalogTests: XCTestCase {
+
+    func testRecognisesEachBrandFromAdvertisedName() {
+        let cases: [(String, String)] = [
+            ("Amazfit Helio Ring", "Amazfit"),
+            ("Zepp E", "Amazfit"),
+            ("Mi Smart Band 8", "Mi Band"),
+            ("Xiaomi Band 9", "Mi Band"),
+            ("Garmin Forerunner 265", "Garmin"),
+            ("fēnix 7", "Garmin"),                 // diacritic-folded to "fenix"
+            ("HRM-Pro", "Garmin"),
+            ("Oura Ring", "Oura"),
+            ("Polar H10", "Polar"),
+            ("Wahoo TICKR", "Wahoo"),
+            ("COOSPO HW9", "Coospo"),
+            ("Scosche Rhythm+", "Scosche"),
+            ("Magene H64", "Magene"),
+        ]
+        for (name, expected) in cases {
+            XCTAssertEqual(DeviceBrandCatalog.spec(forAdvertisedName: name)?.brand, expected, "name=\(name)")
+        }
+    }
+
+    func testUnknownNameIsNil() {
+        XCTAssertNil(DeviceBrandCatalog.spec(forAdvertisedName: "Acme HR 3000"))
+        XCTAssertNil(DeviceBrandCatalog.spec(forAdvertisedName: ""))
+    }
+
+    /// Mi Band is a Huami sub-brand: its tokens must win over the broader Amazfit family so a "Smart Band"
+    /// never mis-labels as Amazfit. Order in `all` guarantees this.
+    func testMiBandWinsOverAmazfit() {
+        XCTAssertEqual(DeviceBrandCatalog.spec(forAdvertisedName: "Mi Band")?.brand, "Mi Band")
+        XCTAssertEqual(DeviceBrandCatalog.spec(forAdvertisedName: "Smart Band 10")?.brand, "Mi Band")
+    }
+
+    func testRoutingAndTierFacts() {
+        func spec(_ brand: String) -> DeviceBrandSpec {
+            guard let s = DeviceBrandCatalog.spec(forBrand: brand) else {
+                XCTFail("missing catalog row for \(brand)"); return DeviceBrandCatalog.all[0]
+            }
+            return s
+        }
+        // Experimental custom-protocol sources route to their own driver kinds.
+        XCTAssertEqual(spec("Amazfit").sourceKind, .huami)
+        XCTAssertEqual(spec("Mi Band").sourceKind, .huami)
+        XCTAssertEqual(spec("Oura").sourceKind, .oura)
+        // Garmin + generic straps are standard 0x180D live-BLE (no proprietary protocol).
+        XCTAssertEqual(spec("Garmin").sourceKind, .liveBLE)
+        XCTAssertEqual(spec("Polar").sourceKind, .liveBLE)
+        // id prefixes match the wizard's registration.
+        XCTAssertEqual(spec("Amazfit").idPrefix, "huami")
+        XCTAssertEqual(spec("Oura").idPrefix, "oura")
+        XCTAssertEqual(spec("Garmin").idPrefix, "garmin")
+        XCTAssertEqual(spec("Polar").idPrefix, "strap")
+        // Honest capability: Oura has no open live stream; everyone else here does.
+        XCTAssertFalse(spec("Oura").canStreamLiveHR)
+        XCTAssertTrue(spec("Amazfit").canStreamLiveHR)
+        XCTAssertTrue(spec("Garmin").canStreamLiveHR)
+        XCTAssertTrue(spec("Polar").canStreamLiveHR)
+        // Tier: the four experimental brands are the opt-in tier; generic straps are not.
+        for b in ["Amazfit", "Mi Band", "Garmin", "Oura"] { XCTAssertTrue(spec(b).isExperimentalTier, b) }
+        for b in ["Polar", "Wahoo", "Coospo", "Scosche", "Magene"] { XCTAssertFalse(spec(b).isExperimentalTier, b) }
+    }
+
+    /// Brand strings are unique (the reverse lookup `spec(forBrand:)` and the `ExperimentalBrand` bridge
+    /// both assume it).
+    func testBrandStringsUnique() {
+        let brands = DeviceBrandCatalog.all.map(\.brand)
+        XCTAssertEqual(Set(brands).count, brands.count)
+    }
+}

--- a/Strand/BLE/ExperimentalBrand.swift
+++ b/Strand/BLE/ExperimentalBrand.swift
@@ -53,6 +53,19 @@ public enum ExperimentalBrand: String, CaseIterable, Sendable, Equatable {
         DeviceBrandCatalog.spec(forBrand: displayBrand)?.canStreamLiveHR ?? false
     }
 
+    /// The routing kind stored on a device of this brand (from the catalog). Drives `SourceCoordinator`.
+    /// Falls back to `.liveBLE` (a standard-HR strap — never steals the WHOOP path) if the row is missing.
+    public var sourceKind: SourceKind {
+        DeviceBrandCatalog.spec(forBrand: displayBrand)?.sourceKind ?? .liveBLE
+    }
+
+    /// The registry id prefix for a device of this brand (from the catalog); "strap" fallback. The device
+    /// `id` (== sample deviceId) is `"<idPrefix>-<uuid>"`, so this MUST stay byte-identical to the value the
+    /// wizard previously hardcoded — a test pins each experimental brand's prefix.
+    public var idPrefix: String {
+        DeviceBrandCatalog.spec(forBrand: displayBrand)?.idPrefix ?? "strap"
+    }
+
     /// Map a catalog brand string back to the typed case (nil for a non-experimental brand).
     private init?(displayBrand brand: String) {
         switch brand {

--- a/Strand/BLE/ExperimentalBrand.swift
+++ b/Strand/BLE/ExperimentalBrand.swift
@@ -1,13 +1,14 @@
 import Foundation
+import WhoopStore
 
 /// CLEAN-ROOM best-effort recognition of the EXPERIMENTAL band families from an advertised device name.
 ///
-/// This is pure (no CoreBluetooth) so it's unit-tested, and deliberately conservative: a name we don't
-/// recognise returns `nil` rather than a wrong guess. NOTHING here fabricates data — it only labels a
-/// discovered peripheral so the experimental add-device flow can show the honest per-brand guidance.
-///
-/// Recognition is by advertised-name substring only (the cheapest, most reliable public signal). We do
-/// NOT claim a deeper protocol than we have: see each driver for what it can actually read.
+/// This is a thin TYPED VIEW over `DeviceBrandCatalog` (the pure, `swift test`-covered single source of
+/// truth in WhoopStore): the advertised-name tokens and capability facts live there once, and this enum
+/// only names the four experimental families so the drivers can switch on them (`== .garmin`, etc.).
+/// Deliberately conservative: a name we don't recognise returns `nil` rather than a wrong guess. NOTHING
+/// here fabricates data — it only labels a discovered peripheral so the experimental add-device flow can
+/// show the honest per-brand guidance.
 public enum ExperimentalBrand: String, CaseIterable, Sendable, Equatable {
     /// Amazfit / Zepp / Huami family (incl. the Helio ring/band). Live HR is best-effort: standard
     /// 0x180D where exposed, else the documented Huami custom HR characteristic.
@@ -22,30 +23,19 @@ public enum ExperimentalBrand: String, CaseIterable, Sendable, Equatable {
     /// the detection attempt and then points honestly at file import.
     case oura
 
-    /// Best-effort brand from an advertised name. Returns `nil` for an unrecognised name (no wrong guess).
+    /// Best-effort brand from an advertised name. Returns `nil` for an unrecognised name, OR for a name the
+    /// catalog recognises as a NON-experimental generic strap (Polar / Wahoo / …) — `ExperimentalBrand`
+    /// names only the experimental tier. All token matching lives in `DeviceBrandCatalog`.
     public static func recognise(name: String) -> ExperimentalBrand? {
-        // Fold diacritics before matching so Garmin's accented branding (e.g. "vívoactive", "fēnix")
-        // is recognised the same as its ASCII advertised form ("vivoactive", "fenix"). A device can
-        // advertise either, and an unfolded match would silently miss the accented name.
-        let n = name.folding(options: .diacriticInsensitive, locale: nil).lowercased()
-        // Order matters: check the most specific tokens first so e.g. "Amazfit Helio" → amazfit and a
-        // bare "Mi Band" → miBand. Mi Band is a Huami sub-brand, so we test its tokens before amazfit's.
-        if n.contains("mi band") || n.contains("miband") || n.contains("smart band") || n.contains("xiaomi") {
-            return .miBand
+        guard let spec = DeviceBrandCatalog.spec(forAdvertisedName: name), spec.isExperimentalTier else {
+            return nil
         }
-        if n.contains("amazfit") || n.contains("zepp") || n.contains("helio") || n.contains("huami") {
-            return .amazfit
-        }
-        if n.contains("garmin") || n.contains("forerunner") || n.contains("fenix") ||
-            n.contains("vivoactive") || n.contains("venu") || n.contains("instinct") ||
-            n.contains("epix") || n.contains("vivosmart") {
-            return .garmin
-        }
-        if n.contains("oura") { return .oura }
-        return nil
+        return ExperimentalBrand(displayBrand: spec.brand)
     }
 
-    /// The brand label stored on the registry row / shown in the UI. Human, US-neutral, no claims.
+    /// The brand label stored on the registry row / shown in the UI. Human, US-neutral, no claims. This is
+    /// the case ⇄ catalog-brand bridge, so it must match a `DeviceBrandCatalog` row's `brand` exactly (a
+    /// test pins that).
     public var displayBrand: String {
         switch self {
         case .amazfit: return "Amazfit"
@@ -55,12 +45,22 @@ public enum ExperimentalBrand: String, CaseIterable, Sendable, Equatable {
         }
     }
 
-    /// Whether this brand can stream LIVE heart rate at all in NOOP's experimental tier. `false` for Oura
-    /// (no open live stream) — the wizard routes those to file import instead of pretending to connect.
+    /// Whether this brand can stream LIVE heart rate at all in NOOP's experimental tier. Derived from the
+    /// catalog (`false` for Oura — no open live stream — so the wizard routes those to file import instead
+    /// of pretending to connect). Defaults to `false` if the catalog row is somehow missing (a test pins
+    /// that every case resolves).
     public var canStreamLiveHR: Bool {
-        switch self {
-        case .amazfit, .miBand, .garmin: return true
-        case .oura:                      return false
+        DeviceBrandCatalog.spec(forBrand: displayBrand)?.canStreamLiveHR ?? false
+    }
+
+    /// Map a catalog brand string back to the typed case (nil for a non-experimental brand).
+    private init?(displayBrand brand: String) {
+        switch brand {
+        case "Amazfit": self = .amazfit
+        case "Mi Band": self = .miBand
+        case "Garmin":  self = .garmin
+        case "Oura":    self = .oura
+        default:        return nil
         }
     }
 }

--- a/Strand/Screens/AddDeviceWizard.swift
+++ b/Strand/Screens/AddDeviceWizard.swift
@@ -1460,17 +1460,10 @@ struct AddDeviceWizard: View {
         .padding(.top, 10)
     }
 
-    /// Best-effort brand from the advertised name; neutral fallback for unknown straps.
+    /// Best-effort brand from the advertised name; neutral fallback for unknown straps. Delegates to the
+    /// pure `DeviceBrandCatalog` (single source of truth), so the token table lives once.
     private func brandGuess(from name: String) -> String {
-        let lower = name.lowercased()
-        if lower.contains("polar") { return "Polar" }
-        if lower.contains("wahoo") || lower.contains("tickr") { return "Wahoo" }
-        if lower.contains("coospo") { return "Coospo" }
-        if lower.contains("garmin") || lower.contains("hrm") { return "Garmin" }
-        if lower.contains("scosche") || lower.contains("rhythm") { return "Scosche" }
-        if lower.contains("magene") { return "Magene" }
-        if lower.contains("amazfit") || lower.contains("helio") || lower.contains("zepp") { return "Amazfit" }
-        return String(localized: "Heart-rate strap")
+        DeviceBrandCatalog.spec(forAdvertisedName: name)?.brand ?? String(localized: "Heart-rate strap")
     }
 }
 
@@ -1527,15 +1520,7 @@ private struct HRPickList: View {
     }
 
     private func brandGuess(from name: String) -> String {
-        let lower = name.lowercased()
-        if lower.contains("polar") { return "Polar" }
-        if lower.contains("wahoo") || lower.contains("tickr") { return "Wahoo" }
-        if lower.contains("coospo") { return "Coospo" }
-        if lower.contains("garmin") || lower.contains("hrm") { return "Garmin" }
-        if lower.contains("scosche") || lower.contains("rhythm") { return "Scosche" }
-        if lower.contains("magene") { return "Magene" }
-        if lower.contains("amazfit") || lower.contains("helio") || lower.contains("zepp") { return "Amazfit" }
-        return String(localized: "Heart-rate strap")
+        DeviceBrandCatalog.spec(forAdvertisedName: name)?.brand ?? String(localized: "Heart-rate strap")
     }
 }
 

--- a/Strand/Screens/AddDeviceWizard.swift
+++ b/Strand/Screens/AddDeviceWizard.swift
@@ -57,6 +57,19 @@ struct AddDeviceWizard: View {
             default:                                return false
             }
         }
+
+        /// The experimental-tier brand this type registers as, or nil for the non-experimental types
+        /// (WHOOP / generic strap / gym). Bridges the wizard's type picker to the `DeviceBrandCatalog`
+        /// facts (stored brand string, `sourceKind`, id prefix) so those are no longer hardcoded per branch.
+        var experimentalBrand: ExperimentalBrand? {
+            switch self {
+            case .amazfit: return .amazfit
+            case .miBand:  return .miBand
+            case .garmin:  return .garmin
+            case .oura:    return .oura
+            default:       return nil
+            }
+        }
     }
 
     enum Step { case type, prep, pick, confirm }
@@ -1146,9 +1159,9 @@ struct AddDeviceWizard: View {
     private var confirmBrand: String {
         if type?.isWhoop == true { return "WHOOP" }
         if type == .gymEquipment { return String(localized: "Gym equipment") }
-        if type == .amazfit { return "Amazfit" }
-        if type == .miBand { return "Mi Band" }
-        if type == .garmin { return "Garmin" }
+        // Experimental non-Oura types (Amazfit / Mi Band / Garmin) take their stored brand string straight
+        // from the catalog via the type→brand bridge. Oura falls through to its detected-generation label.
+        if let brand = type?.experimentalBrand, brand != .oura { return brand.displayBrand }
         // Oura confirms with the detected generation name + a Beta marker so the user sees what NOOP
         // identified before adopting (the gen is best-effort from the scan, fixed by this pick).
         if let pickedOura { return String(localized: "\(pickedOura.gen.displayName) · Beta") }
@@ -1251,12 +1264,14 @@ struct AddDeviceWizard: View {
                 status: .paired,
                 addedAt: now, lastSeenAt: now)
         } else if let pickedStrap {
-            // Generic HR strap OR a Garmin broadcasting standard HR. Garmin is registered as a `.liveBLE`
-            // device (its live HR IS the standard 0x180D path) but branded "Garmin"; both are HR + HRV.
-            let isGarmin = type == .garmin
+            // Generic HR strap OR a Garmin broadcasting standard HR. Garmin's brand + id prefix come from
+            // the catalog (via the type→brand bridge); it still stores `.liveBLE` (its live HR IS the
+            // standard 0x180D path). A non-Garmin strap keeps the advertised-name brand guess + "strap"
+            // prefix. Both are HR + HRV.
+            let garmin = (type == .garmin) ? ExperimentalBrand.garmin : nil
             device = PairedDevice(
-                id: "\(isGarmin ? "garmin" : "strap")-\(pickedStrap.id.uuidString)",
-                brand: isGarmin ? "Garmin" : brandGuess(from: pickedStrap.name),
+                id: "\(garmin?.idPrefix ?? "strap")-\(pickedStrap.id.uuidString)",
+                brand: garmin?.displayBrand ?? brandGuess(from: pickedStrap.name),
                 model: pickedStrap.name,
                 nickname: name == pickedStrap.name ? nil : name,
                 peripheralId: pickedStrap.id.uuidString,
@@ -1265,16 +1280,17 @@ struct AddDeviceWizard: View {
                 status: .paired,
                 addedAt: now, lastSeenAt: now)
         } else if let pickedHuami {
-            // EXPERIMENTAL Amazfit / Zepp / Mi Band. sourceKind `.huami` routes the SourceCoordinator to
-            // the HuamiHRSource. HR only (the Huami custom characteristic carries no R-R).
-            let brand = (type == .miBand) ? "Mi Band" : "Amazfit"
+            // EXPERIMENTAL Amazfit / Zepp / Mi Band. Brand string, id prefix, and the `.huami` routing all
+            // come from the catalog via the type→brand bridge (was: `(type == .miBand) ? "Mi Band" : …`).
+            // HR only (the Huami custom characteristic carries no R-R).
+            let brand = type?.experimentalBrand ?? .amazfit
             device = PairedDevice(
-                id: "huami-\(pickedHuami.id.uuidString)",
-                brand: brand,
+                id: "\(brand.idPrefix)-\(pickedHuami.id.uuidString)",
+                brand: brand.displayBrand,
                 model: pickedHuami.name,
                 nickname: name == pickedHuami.name ? nil : name,
                 peripheralId: pickedHuami.id.uuidString,
-                sourceKind: .huami,
+                sourceKind: brand.sourceKind,
                 capabilities: [.hr],
                 status: .paired,
                 addedAt: now, lastSeenAt: now)
@@ -1313,13 +1329,15 @@ struct AddDeviceWizard: View {
         let gen = pickedOura.gen
         let uuid = pickedOura.ring.id.uuidString
         let name = confirmName
+        // Brand string, id prefix, and the `.oura` routing come from the catalog via the type→brand bridge.
+        let oura = ExperimentalBrand.oura
         return PairedDevice(
-            id: "oura-\(uuid)",
-            brand: "Oura",
+            id: "\(oura.idPrefix)-\(uuid)",
+            brand: oura.displayBrand,
             model: gen.displayName,
             nickname: name == String(localized: "Oura ring") ? nil : name,
             peripheralId: uuid,
-            sourceKind: .oura,
+            sourceKind: oura.sourceKind,
             capabilities: ouraCapabilities(for: gen),
             status: .paired,
             addedAt: now, lastSeenAt: now)

--- a/android/app/src/main/java/com/noop/ble/ExperimentalBrand.kt
+++ b/android/app/src/main/java/com/noop/ble/ExperimentalBrand.kt
@@ -1,55 +1,44 @@
 package com.noop.ble
 
-import java.text.Normalizer
+import com.noop.data.DeviceBrandCatalog
 
 /**
  * CLEAN-ROOM best-effort recognition of the EXPERIMENTAL band families from an advertised device name.
  *
- * Faithful Kotlin twin of Strand/BLE/ExperimentalBrand.swift. Pure (no android.bluetooth) so it's
- * JVM-unit-tested. Deliberately conservative: an unrecognised name returns null rather than a wrong
+ * Faithful Kotlin twin of Strand/BLE/ExperimentalBrand.swift. A thin TYPED VIEW over [DeviceBrandCatalog]
+ * (the pure, JVM-unit-tested single source of truth in com.noop.data): the advertised-name tokens and
+ * capability facts live there once, and this enum only names the four experimental families so the drivers
+ * can switch on them. Deliberately conservative: an unrecognised name returns null rather than a wrong
  * guess. NOTHING here fabricates data — it only labels a discovered peripheral so the experimental
- * add-device flow can show the honest per-brand guidance. Recognition is by advertised-name substring
- * only (the cheapest, most reliable public signal). US English throughout.
+ * add-device flow can show the honest per-brand guidance. US English throughout.
  */
-enum class ExperimentalBrand(val displayBrand: String, val canStreamLiveHR: Boolean) {
+enum class ExperimentalBrand(val displayBrand: String) {
     /** Amazfit / Zepp / Huami family (incl. Helio ring/band). Best-effort live HR: standard 0x180D where
      *  exposed, else the documented Huami custom HR characteristic. */
-    AMAZFIT("Amazfit", true),
+    AMAZFIT("Amazfit"),
     /** Xiaomi Mi Band (Huami-family). Older bands expose HR on a custom char; newer need an auth handshake
      *  we can't do — the driver surfaces that honestly rather than faking it. */
-    MI_BAND("Mi Band", true),
+    MI_BAND("Mi Band"),
     /** Garmin watch. Live HR is the STANDARD broadcast-HR path (0x180D) when the user enables
      *  "Broadcast Heart Rate" — there is no NOOP-proprietary Garmin protocol. */
-    GARMIN("Garmin", true),
+    GARMIN("Garmin"),
     /** Oura ring. No open live health stream — proprietary, syncs to Oura's app. The driver makes the
      *  detection attempt, then points honestly at file import. */
-    OURA("Oura", false);
+    OURA("Oura");
+
+    /** Whether this brand can stream LIVE heart rate at all, derived from the catalog (false for Oura — no
+     *  open live stream — so the wizard routes it to import). false if the catalog row is somehow missing. */
+    val canStreamLiveHR: Boolean
+        get() = DeviceBrandCatalog.specForBrand(displayBrand)?.canStreamLiveHR ?: false
 
     companion object {
-        /** Best-effort brand from an advertised name. Returns null for an unrecognised name (no wrong guess). */
+        /** Best-effort brand from an advertised name. Returns null for an unrecognised name, OR for a name
+         *  the catalog recognises as a NON-experimental generic strap (Polar / Wahoo / …). All token
+         *  matching lives in [DeviceBrandCatalog]. */
         fun recognise(name: String): ExperimentalBrand? {
-            // Fold diacritics before matching so Garmin's accented branding (e.g. "vívoactive", "fēnix")
-            // is recognised the same as its ASCII advertised form. Mirrors Swift's
-            // `folding(options: .diacriticInsensitive)`. A device can advertise either form.
-            val n = Normalizer.normalize(name, Normalizer.Form.NFD)
-                .replace(Regex("\\p{M}+"), "")
-                .lowercase()
-            // Order matters: most specific tokens first. Mi Band is a Huami sub-brand, so test its tokens
-            // before Amazfit's.
-            if (n.contains("mi band") || n.contains("miband") || n.contains("smart band") || n.contains("xiaomi")) {
-                return MI_BAND
-            }
-            if (n.contains("amazfit") || n.contains("zepp") || n.contains("helio") || n.contains("huami")) {
-                return AMAZFIT
-            }
-            if (n.contains("garmin") || n.contains("forerunner") || n.contains("fenix") ||
-                n.contains("vivoactive") || n.contains("venu") || n.contains("instinct") ||
-                n.contains("epix") || n.contains("vivosmart")
-            ) {
-                return GARMIN
-            }
-            if (n.contains("oura")) return OURA
-            return null
+            val spec = DeviceBrandCatalog.specForAdvertisedName(name) ?: return null
+            if (!spec.isExperimentalTier) return null
+            return values().firstOrNull { it.displayBrand == spec.brand }
         }
     }
 }

--- a/android/app/src/main/java/com/noop/ble/ExperimentalBrand.kt
+++ b/android/app/src/main/java/com/noop/ble/ExperimentalBrand.kt
@@ -1,6 +1,7 @@
 package com.noop.ble
 
 import com.noop.data.DeviceBrandCatalog
+import com.noop.data.SourceKind
 
 /**
  * CLEAN-ROOM best-effort recognition of the EXPERIMENTAL band families from an advertised device name.
@@ -30,6 +31,17 @@ enum class ExperimentalBrand(val displayBrand: String) {
      *  open live stream — so the wizard routes it to import). false if the catalog row is somehow missing. */
     val canStreamLiveHR: Boolean
         get() = DeviceBrandCatalog.specForBrand(displayBrand)?.canStreamLiveHR ?: false
+
+    /** Routing kind stored on a device of this brand (from the catalog); liveBLE fallback (a standard-HR
+     *  strap — never steals the WHOOP path). */
+    val sourceKind: SourceKind
+        get() = DeviceBrandCatalog.specForBrand(displayBrand)?.sourceKind ?: SourceKind.liveBLE
+
+    /** Registry id prefix for a device of this brand (from the catalog); "strap" fallback. The device id
+     *  (== sample deviceId) is "<idPrefix>-<address>", so this MUST stay byte-identical to the value the
+     *  wizard previously hardcoded — a test pins each experimental brand's prefix. */
+    val idPrefix: String
+        get() = DeviceBrandCatalog.specForBrand(displayBrand)?.idPrefix ?: "strap"
 
     companion object {
         /** Best-effort brand from an advertised name. Returns null for an unrecognised name, OR for a name

--- a/android/app/src/main/java/com/noop/data/DeviceBrandCatalog.kt
+++ b/android/app/src/main/java/com/noop/data/DeviceBrandCatalog.kt
@@ -1,0 +1,76 @@
+package com.noop.data
+
+import java.text.Normalizer
+
+/**
+ * Single source of truth for recognising a wearable BRAND from its advertised BLE name, and the stored
+ * facts that follow from the brand. Pure (no android.bluetooth) so it's JVM-unit-tested — the recognition
+ * + capability facts are byte-parity-critical and must be asserted headlessly on both platforms. Faithful
+ * twin of Packages/WhoopStore/Sources/WhoopStore/DeviceBrandCatalog.swift.
+ *
+ * Adding a recognised brand is ONE row in [all]: the wizard's brand labelling ([brandGuess]), the
+ * experimental-tier gate ([com.noop.ble.ExperimentalBrand]), and the source routing all derive from here
+ * instead of re-listing the advertised-name tokens per call site.
+ */
+data class DeviceBrandSpec(
+    /** Display + stored `PairedDeviceRow.brand` string ("Polar", "Amazfit", "Oura", …). */
+    val brand: String,
+    /** Lowercased, diacritic-folded advertised-name substrings that identify this brand. Checked in [all]
+     *  order (most specific first) so a Huami sub-brand like Mi Band wins over the broader Amazfit tokens. */
+    val nameTokens: List<String>,
+    /** The routing kind stored on the device (drives `SourceCoordinator.makeSource`). [SourceKind.liveBLE]
+     *  for a brand whose live HR is the standard 0x180D broadcast (generic straps + Garmin); [SourceKind.huami]
+     *  / [SourceKind.oura] for the experimental custom-protocol sources. */
+    val sourceKind: SourceKind,
+    /** The registry id prefix for a device of this brand ("huami", "oura", "garmin", "strap"). */
+    val idPrefix: String,
+    /** Whether this brand can stream LIVE heart rate at all in NOOP. false for Oura (no open live stream) —
+     *  the wizard routes those to import instead of pretending to connect. */
+    val canStreamLiveHR: Boolean,
+    /** True for the opt-in EXPERIMENTAL tier (Amazfit / Mi Band / Garmin / Oura); false for the shipped
+     *  generic HR straps (Polar / Wahoo / …). `ExperimentalBrand.recognise` returns only these. */
+    val isExperimentalTier: Boolean,
+)
+
+object DeviceBrandCatalog {
+    /** The brand table, checked most-specific-first. Order matters ONLY where one name could match two rows:
+     *  Mi Band (a Huami sub-brand) precedes Amazfit so a "Mi Smart Band" is not mis-labelled Amazfit. Tokens
+     *  are otherwise disjoint across rows, so the remaining order is cosmetic. */
+    val all: List<DeviceBrandSpec> = listOf(
+        // EXPERIMENTAL tier — custom-protocol or broadcast live sources, opt-in and best-effort.
+        DeviceBrandSpec("Mi Band", listOf("mi band", "miband", "smart band", "xiaomi"),
+            SourceKind.huami, "huami", canStreamLiveHR = true, isExperimentalTier = true),
+        DeviceBrandSpec("Amazfit", listOf("amazfit", "zepp", "helio", "huami"),
+            SourceKind.huami, "huami", canStreamLiveHR = true, isExperimentalTier = true),
+        DeviceBrandSpec("Garmin",
+            listOf("garmin", "forerunner", "fenix", "vivoactive", "venu", "instinct", "epix", "vivosmart", "hrm"),
+            SourceKind.liveBLE, "garmin", canStreamLiveHR = true, isExperimentalTier = true),
+        DeviceBrandSpec("Oura", listOf("oura"),
+            SourceKind.oura, "oura", canStreamLiveHR = false, isExperimentalTier = true),
+        // Shipped generic HR straps — standard 0x180D broadcast, labelled for display only.
+        DeviceBrandSpec("Polar", listOf("polar"),
+            SourceKind.liveBLE, "strap", canStreamLiveHR = true, isExperimentalTier = false),
+        DeviceBrandSpec("Wahoo", listOf("wahoo", "tickr"),
+            SourceKind.liveBLE, "strap", canStreamLiveHR = true, isExperimentalTier = false),
+        DeviceBrandSpec("Coospo", listOf("coospo"),
+            SourceKind.liveBLE, "strap", canStreamLiveHR = true, isExperimentalTier = false),
+        DeviceBrandSpec("Scosche", listOf("scosche", "rhythm"),
+            SourceKind.liveBLE, "strap", canStreamLiveHR = true, isExperimentalTier = false),
+        DeviceBrandSpec("Magene", listOf("magene"),
+            SourceKind.liveBLE, "strap", canStreamLiveHR = true, isExperimentalTier = false),
+    )
+
+    /** The brand whose advertised name matches, or null if unrecognised. Diacritic-folded (NFD + strip
+     *  combining marks, mirroring Swift's `.diacriticInsensitive`) + lowercased; substring match in [all]
+     *  order. Twin of Swift `DeviceBrandCatalog.spec(forAdvertisedName:)`. */
+    fun specForAdvertisedName(name: String): DeviceBrandSpec? {
+        val n = Normalizer.normalize(name, Normalizer.Form.NFD)
+            .replace(Regex("\\p{M}+"), "")
+            .lowercase()
+        return all.firstOrNull { spec -> spec.nameTokens.any { n.contains(it) } }
+    }
+
+    /** The row for a known brand string ("Amazfit", …), or null. Lets the typed `ExperimentalBrand` derive
+     *  its facts (capability/routing) from this table rather than re-declaring them. */
+    fun specForBrand(brand: String): DeviceBrandSpec? = all.firstOrNull { it.brand == brand }
+}

--- a/android/app/src/main/java/com/noop/ui/AddDeviceWizard.kt
+++ b/android/app/src/main/java/com/noop/ui/AddDeviceWizard.kt
@@ -55,6 +55,7 @@ import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.noop.ble.ExperimentalBrand
 import com.noop.ble.OuraLiveSource
 import com.noop.ble.StandardHrSource
 import com.noop.ble.WhoopBleClient
@@ -100,6 +101,18 @@ private enum class DeviceType {
 
     /** True for the EXPERIMENTAL tier (shown under a clearly-labelled "Experimental" heading). */
     val isExperimental: Boolean get() = this == Amazfit || this == MiBand || this == Garmin || this == Oura
+
+    /** The experimental-tier brand this type registers as, or null for the non-experimental types
+     *  (WHOOP / generic strap / gym). Bridges the type picker to the [com.noop.data.DeviceBrandCatalog]
+     *  facts (stored brand string, sourceKind, id prefix) so those are no longer hardcoded per branch. */
+    val experimentalBrand: ExperimentalBrand?
+        get() = when (this) {
+            Amazfit -> ExperimentalBrand.AMAZFIT
+            MiBand -> ExperimentalBrand.MI_BAND
+            Garmin -> ExperimentalBrand.GARMIN
+            Oura -> ExperimentalBrand.OURA
+            else -> null
+        }
 
     val title: String
         get() = when (this) {
@@ -245,9 +258,10 @@ fun AddDeviceWizard(
     val confirmBrand = when {
         type?.isWhoop == true -> "WHOOP"
         type == DeviceType.GymEquipment -> "Gym equipment"
-        type == DeviceType.Amazfit -> "Amazfit"
-        type == DeviceType.MiBand -> "Mi Band"
-        type == DeviceType.Garmin -> "Garmin"
+        // Experimental non-Oura types (Amazfit / Mi Band / Garmin) take their stored brand string from the
+        // catalog via the type->brand bridge. Oura confirms with its detected generation label elsewhere.
+        type == DeviceType.Amazfit || type == DeviceType.MiBand || type == DeviceType.Garmin ->
+            type!!.experimentalBrand!!.displayBrand
         pickedStrap != null -> brandGuess(pickedStrap!!.name)
         else -> "Heart-rate strap"
     }
@@ -280,12 +294,14 @@ fun AddDeviceWizard(
                 )
             }
             ps != null -> {
-                // Generic HR strap OR a Garmin broadcasting standard HR. Garmin is registered as a
-                // `liveBLE` device (its live HR IS the standard 0x180D path) but branded "Garmin"; both
-                // are HR + HRV.
+                // Generic HR strap OR a Garmin broadcasting standard HR. Garmin's brand + id prefix come
+                // from the catalog (via the type->brand bridge); it still stores `liveBLE` (its live HR IS
+                // the standard 0x180D path). A non-Garmin strap keeps the advertised-name brand guess +
+                // "strap" prefix. Both are HR + HRV.
+                val garmin = if (isGarmin) ExperimentalBrand.GARMIN else null
                 PairedDeviceRow(
-                    id = "${if (isGarmin) "garmin" else "strap"}-${ps.address}",
-                    brand = if (isGarmin) "Garmin" else brandGuess(ps.name),
+                    id = "${garmin?.idPrefix ?: "strap"}-${ps.address}",
+                    brand = garmin?.displayBrand ?: brandGuess(ps.name),
                     model = ps.name,
                     nickname = if (confirmName == ps.name) null else confirmName,
                     peripheralId = ps.address,
@@ -297,16 +313,17 @@ fun AddDeviceWizard(
                 )
             }
             ph != null -> {
-                // EXPERIMENTAL Amazfit / Zepp / Mi Band. sourceKind "huami" routes the SourceCoordinator
-                // to the HuamiHrSource. HR only (the Huami custom characteristic carries no R-R).
-                val brand = if (type == DeviceType.MiBand) "Mi Band" else "Amazfit"
+                // EXPERIMENTAL Amazfit / Zepp / Mi Band. Brand string, id prefix, and the "huami" routing
+                // all come from the catalog via the type->brand bridge (was: `if (MiBand) "Mi Band" else …`).
+                // HR only (the Huami custom characteristic carries no R-R).
+                val brand = type?.experimentalBrand ?: ExperimentalBrand.AMAZFIT
                 PairedDeviceRow(
-                    id = "huami-${ph.address}",
-                    brand = brand,
+                    id = "${brand.idPrefix}-${ph.address}",
+                    brand = brand.displayBrand,
                     model = ph.name,
                     nickname = if (confirmName == ph.name) null else confirmName,
                     peripheralId = ph.address,
-                    sourceKind = SourceKind.huami.name,
+                    sourceKind = brand.sourceKind.name,
                     capabilities = "hr",
                     status = DeviceStatus.paired.name,
                     addedAt = now,
@@ -358,7 +375,9 @@ fun AddDeviceWizard(
         stopAllScans()
         val ring = pickedOura ?: run { onClose(); return }
         val now = System.currentTimeMillis() / 1000
-        val deviceId = "oura-${ring.address}"
+        // Brand string, id prefix, and the "oura" routing come from the catalog via the type->brand bridge.
+        val oura = ExperimentalBrand.OURA
+        val deviceId = "${oura.idPrefix}-${ring.address}"
         // Advanced (B-Alt): persist the pasted key BEFORE registering so the active source authenticates
         // with it WITHOUT a factory reset (the Oura app keeps working). This path NEVER arms adopt-intent,
         // so the live source never sends the dangerous install opcode.
@@ -374,11 +393,11 @@ fun AddDeviceWizard(
         }
         val device = PairedDeviceRow(
             id = deviceId,
-            brand = "Oura",
+            brand = oura.displayBrand,
             model = ouraGen.displayName,
             nickname = nameDraft.trim().takeIf { it.isNotEmpty() && it != "Oura ring" },
             peripheralId = ring.address,
-            sourceKind = SourceKind.oura.name,
+            sourceKind = oura.sourceKind.name,
             // Gen-filtered: the OuraMetric rawValues are byte-identical to the app-side Metric rawValues
             // (hr/hrv/spo2/skinTemp/sleep), so the joined string round-trips through the registry unchanged.
             capabilities = ouraGen.capabilities.joinToString(",") { it.raw },

--- a/android/app/src/main/java/com/noop/ui/DevicesScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/DevicesScreen.kt
@@ -970,17 +970,8 @@ private fun lastSeenLine(device: PairedDeviceRow, isLiveConnected: Boolean): Str
     else -> "Last seen ${relativeAgo(device.lastSeenAt)}"
 }
 
-/** Best-effort brand from the advertised name. Falls back to a neutral label. Mirrors Swift brandGuess. */
-internal fun brandGuess(name: String): String {
-    val lower = name.lowercase()
-    return when {
-        lower.contains("polar") -> "Polar"
-        lower.contains("wahoo") || lower.contains("tickr") -> "Wahoo"
-        lower.contains("coospo") -> "Coospo"
-        lower.contains("garmin") || lower.contains("hrm") -> "Garmin"
-        lower.contains("scosche") || lower.contains("rhythm") -> "Scosche"
-        lower.contains("magene") -> "Magene"
-        lower.contains("amazfit") || lower.contains("helio") || lower.contains("zepp") -> "Amazfit"
-        else -> "Heart-rate strap"
-    }
-}
+/** Best-effort brand from the advertised name. Falls back to a neutral label. Mirrors Swift brandGuess.
+ *  Delegates to the pure [com.noop.data.DeviceBrandCatalog] (single source of truth) so the token table
+ *  lives once. */
+internal fun brandGuess(name: String): String =
+    com.noop.data.DeviceBrandCatalog.specForAdvertisedName(name)?.brand ?: "Heart-rate strap"

--- a/android/app/src/test/java/com/noop/data/DeviceBrandCatalogTest.kt
+++ b/android/app/src/test/java/com/noop/data/DeviceBrandCatalogTest.kt
@@ -1,0 +1,81 @@
+package com.noop.data
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Pins the pure brand catalog: recognition, ordering, and the byte-parity facts (sourceKind / idPrefix /
+ * capability / tier). Faithful twin of the Swift DeviceBrandCatalogTests — the SAME cases must hold so the
+ * two platforms recognise a device identically.
+ */
+class DeviceBrandCatalogTest {
+
+    @Test
+    fun recognisesEachBrandFromAdvertisedName() {
+        val cases = listOf(
+            "Amazfit Helio Ring" to "Amazfit",
+            "Zepp E" to "Amazfit",
+            "Mi Smart Band 8" to "Mi Band",
+            "Xiaomi Band 9" to "Mi Band",
+            "Garmin Forerunner 265" to "Garmin",
+            "fēnix 7" to "Garmin",            // diacritic-folded to "fenix"
+            "HRM-Pro" to "Garmin",
+            "Oura Ring" to "Oura",
+            "Polar H10" to "Polar",
+            "Wahoo TICKR" to "Wahoo",
+            "COOSPO HW9" to "Coospo",
+            "Scosche Rhythm+" to "Scosche",
+            "Magene H64" to "Magene",
+        )
+        for ((name, expected) in cases) {
+            assertEquals(name, expected, DeviceBrandCatalog.specForAdvertisedName(name)?.brand)
+        }
+    }
+
+    @Test
+    fun unknownNameIsNull() {
+        assertNull(DeviceBrandCatalog.specForAdvertisedName("Acme HR 3000"))
+        assertNull(DeviceBrandCatalog.specForAdvertisedName(""))
+    }
+
+    /** Mi Band (a Huami sub-brand) must win over the broader Amazfit family. */
+    @Test
+    fun miBandWinsOverAmazfit() {
+        assertEquals("Mi Band", DeviceBrandCatalog.specForAdvertisedName("Mi Band")?.brand)
+        assertEquals("Mi Band", DeviceBrandCatalog.specForAdvertisedName("Smart Band 10")?.brand)
+    }
+
+    @Test
+    fun routingAndTierFacts() {
+        fun spec(brand: String): DeviceBrandSpec =
+            requireNotNull(DeviceBrandCatalog.specForBrand(brand)) { "missing catalog row for $brand" }
+
+        assertEquals(SourceKind.huami, spec("Amazfit").sourceKind)
+        assertEquals(SourceKind.huami, spec("Mi Band").sourceKind)
+        assertEquals(SourceKind.oura, spec("Oura").sourceKind)
+        assertEquals(SourceKind.liveBLE, spec("Garmin").sourceKind)
+        assertEquals(SourceKind.liveBLE, spec("Polar").sourceKind)
+
+        assertEquals("huami", spec("Amazfit").idPrefix)
+        assertEquals("oura", spec("Oura").idPrefix)
+        assertEquals("garmin", spec("Garmin").idPrefix)
+        assertEquals("strap", spec("Polar").idPrefix)
+
+        assertFalse(spec("Oura").canStreamLiveHR)
+        assertTrue(spec("Amazfit").canStreamLiveHR)
+        assertTrue(spec("Garmin").canStreamLiveHR)
+        assertTrue(spec("Polar").canStreamLiveHR)
+
+        for (b in listOf("Amazfit", "Mi Band", "Garmin", "Oura")) assertTrue(b, spec(b).isExperimentalTier)
+        for (b in listOf("Polar", "Wahoo", "Coospo", "Scosche", "Magene")) assertFalse(b, spec(b).isExperimentalTier)
+    }
+
+    @Test
+    fun brandStringsUnique() {
+        val brands = DeviceBrandCatalog.all.map { it.brand }
+        assertEquals(brands.size, brands.toSet().size)
+    }
+}


### PR DESCRIPTION
## What & why

Recognising a wearable **brand** from its advertised BLE name was duplicated across `ExperimentalBrand.recognise` and **three** copies of the wizard's `brandGuess` (Swift) / one (Kotlin), each re-listing the same tokens. This extracts a pure `DeviceBrandCatalog` (`Packages/WhoopStore` + `android/…/data`) that owns the full brand table — advertised-name tokens plus the stored facts that follow (`brand`, `sourceKind`, `idPrefix`, `canStreamLiveHR`, tier). **Adding a recognised brand is now one row.**

- `ExperimentalBrand` becomes a thin typed view: `recognise()` / `canStreamLiveHR` / `sourceKind` / `idPrefix` delegate to the catalog; the four cases + `displayBrand` remain as the case⇄brand bridge the drivers switch on.
- The wizard's `brandGuess` copies + Kotlin's top-level `brandGuess` now call the catalog.
- Second commit: the Add-Device wizard's **registration** (stored brand string, id prefix, `sourceKind`) for Amazfit / Mi Band / Garmin / Oura is derived from the catalog via a `DeviceType → ExperimentalBrand` bridge, instead of hardcoded per branch.

## Behaviour

No behaviour change — the derived id prefixes (`huami` / `oura` / `garmin` / `strap`) and sourceKinds are **byte-identical** to the previous literals (pinned by tests), so stored deviceIds and routing are unchanged. This is a dedup, not a data change.

> Context: the live-strap space is already broadly covered (0x180D straps + Huami + Garmin broadcast + Oura), and Fitbit has no open live stream (an import lane), so the leverage here was making *recognition* table-driven rather than bolting on one more driver.

## Verification

- ✅ `swift test` (WhoopStore `DeviceBrandCatalogTests`, 5) green.
- ✅ macOS app compiles — `xcodebuild -scheme Strand … build` **BUILD SUCCEEDED**.
- ✅ Android `compileFullDebugKotlin` **BUILD SUCCESSFUL**; JVM `DeviceBrandCatalogTest` (5) + existing `ExperimentalDriversTest` (15, regression for the delegation) green.

