### PR TITLE
Android: sleep stage-timeline rows (iOS #988 port) + HC sleep import fixes

### DIFF
--- a/android/app/src/main/java/com/noop/data/WhoopDao.kt
+++ b/android/app/src/main/java/com/noop/data/WhoopDao.kt
@@ -320,6 +320,50 @@ interface WhoopDao : DeviceRegistryDao {
     fun daysFlow(deviceId: String): Flow<List<DailyMetric>>
 
     /**
+     * Every distinct source id with at least one cached daily row. The Health Connect backfill's
+     * covered-days gate filters these to the strap-native ids
+     * (HealthConnectImporter.isStrapNativeSourceId), so its #112 skip-set also covers an actively
+     * paired strap's "whoop-<mac>" / "whoop-<mac>-noop" rows — not just the canonical
+     * "my-whoop" / "my-whoop-noop" pair.
+     */
+    @Query("SELECT DISTINCT deviceId FROM dailyMetric")
+    suspend fun dailyMetricDeviceIds(): List<String>
+
+    /**
+     * #112 follow-up heal: delete un-edited "my-whoop" sleep sessions that carry NO signal beyond a
+     * window (no efficiency / restingHr / avgHrv / motionJSON / sleepStateJSON — exactly the shape the
+     * Health Connect backfill writes) when a computed ("-noop") session overlaps the same window.
+     * These are the shadow rows an HC import wrote while the covered-days gate missed active-strap
+     * ids; once purged, the richer computed night wins the merge again. Rows a WHOOP CSV / wearable
+     * export wrote carry efficiency (or HR/HRV), and userEdited rows are never touched, so real data
+     * survives. Idempotent: a re-run matches nothing.
+     */
+    @Query(
+        "DELETE FROM sleepSession WHERE deviceId = 'my-whoop' AND userEdited = 0 " +
+            "AND efficiency IS NULL AND restingHr IS NULL AND avgHrv IS NULL " +
+            "AND motionJSON IS NULL AND sleepStateJSON IS NULL " +
+            "AND EXISTS (SELECT 1 FROM sleepSession c WHERE c.deviceId LIKE '%-noop' " +
+            "AND c.startTs < sleepSession.endTs AND c.endTs > sleepSession.startTs)"
+    )
+    suspend fun purgeHcShadowedSleepSessions(): Int
+
+    /**
+     * #112 follow-up heal (daily half): delete "my-whoop" daily rows shaped like the Health Connect
+     * backfill (no efficiency / stage minutes / disturbances / recovery / strain / steps — HC only
+     * writes totals + vitals) on a day a computed ("-noop") source also covers. A sparse row like
+     * this shadows the computed day in the imported-wins merge (#112), blanking Today / regressing
+     * Sleep stages. CSV-imported days carry stage minutes + efficiency and are never matched.
+     */
+    @Query(
+        "DELETE FROM dailyMetric WHERE deviceId = 'my-whoop' " +
+            "AND efficiency IS NULL AND deepMin IS NULL AND remMin IS NULL AND lightMin IS NULL " +
+            "AND disturbances IS NULL AND recovery IS NULL AND strain IS NULL " +
+            "AND steps IS NULL AND activeKcalEst IS NULL " +
+            "AND day IN (SELECT day FROM dailyMetric d WHERE d.deviceId LIKE '%-noop')"
+    )
+    suspend fun purgeHcShadowedDailyMetrics(): Int
+
+    /**
      * #797: the most-recent [limit] daily metrics for a device, returned oldest-first. Backs the bounded
      * dashboard merge: the SQL takes the newest rows (ORDER BY day DESC LIMIT), and the repository flips
      * them to ascending so every downstream consumer sees the SAME oldest-first order as [daysFlow]. A

--- a/android/app/src/main/java/com/noop/data/WhoopRepository.kt
+++ b/android/app/src/main/java/com/noop/data/WhoopRepository.kt
@@ -863,6 +863,27 @@ class WhoopRepository(private val dao: WhoopDao) {
     /** All cached daily metrics for a device, oldest first. Feeds com.noop.analytics.IllnessWatch. */
     suspend fun days(deviceId: String): List<DailyMetric> = dao.days(deviceId)
 
+    /** Every distinct source id with at least one cached daily row. Feeds the Health Connect
+     *  backfill's strap-coverage gate (see HealthConnectImporter.isStrapNativeSourceId). */
+    suspend fun dailyMetricDeviceIds(): List<String> = dao.dailyMetricDeviceIds()
+
+    /**
+     * #112 follow-up heal: delete the Health-Connect-shaped "my-whoop" shadow rows an older import
+     * wrote over strap-covered days, back when the backfill's covered-days gate only knew the
+     * canonical "my-whoop"/"my-whoop-noop" pair and missed active-strap ("whoop-<mac>") ids.
+     *
+     *  - Sleep sessions: un-edited, signal-less windows (no efficiency/HR/HRV/motion — the HC shape)
+     *    that overlap ANY computed ("-noop") session.
+     *  - Daily rows: HC-shaped rows (no efficiency/stages/recovery/strain/steps) on a day a computed
+     *    source also covers.
+     *
+     * The discriminators never match a WHOOP CSV / wearable-export import (those carry efficiency /
+     * stage minutes) or user-edited rows, so real data survives. Idempotent — a re-run matches
+     * nothing. Returns the TOTAL rows deleted (for the heal log).
+     */
+    suspend fun purgeHcShadowedStrapDays(): Int =
+        dao.purgeHcShadowedSleepSessions() + dao.purgeHcShadowedDailyMetrics()
+
     /**
      * One-time #34 refile: move legacy Health Connect data out of the shared "apple-health" bucket into
      * its own "health-connect" source, so it stops being shown as Apple Health. HC workouts are tagged

--- a/android/app/src/main/java/com/noop/ingest/HealthConnectImporter.kt
+++ b/android/app/src/main/java/com/noop/ingest/HealthConnectImporter.kt
@@ -141,6 +141,12 @@ object HealthConnectImporter {
         // Refile any legacy Health Connect data that landed in the shared "apple-health" bucket before
         // #34 BEFORE importing, so a re-import refiles cleanly instead of duplicating across both sources.
         try { repo.refileLegacyHealthConnect() } catch (_: Exception) { /* best-effort */ }
+        // #112 follow-up heal: purge the shadow rows earlier imports wrote while the covered-days
+        // gate missed active-strap ids — sparse HC-shaped "my-whoop" sleep/daily rows sitting over
+        // nights the strap's computed ("-noop") source already covers. Runs BEFORE this import's
+        // own gate is read so the healed coverage is what gets consulted. Idempotent, best-effort
+        // like the refile above.
+        try { repo.purgeHcShadowedStrapDays() } catch (_: Exception) { /* best-effort */ }
 
         val client = client(context)
 
@@ -411,12 +417,17 @@ object HealthConnectImporter {
         }
 
         // Days the strap already covers: read ONCE so we never clobber richer strap data. This is
-        // the UNION of raw imported "my-whoop" rows AND computed "my-whoop-noop" rows — the latter
-        // is the ONLY source for a strap-only WHOOP user (no raw daily rows exist), so without it
-        // the sparse HC backfill (recovery/strain/stages = null) shadows the computed day and blanks
-        // Today / regresses Sleep stages (#112). Each read is wrapped so a missing source is empty,
-        // not fatal; HC still gap-fills any day the strap did NOT cover.
-        val coveredDays: Set<String> = strapDays(repo, WHOOP) + strapDays(repo, WHOOP_COMPUTED)
+        // the UNION across EVERY strap-native source id — the canonical raw "my-whoop" + computed
+        // "my-whoop-noop" pair AND any actively paired strap's "whoop-<mac>" / "whoop-<mac>-noop"
+        // rows (#112 follow-up: the gate previously knew only the canonical pair, so a re-paired
+        // strap's fresh nights were invisible to it and the sparse HC backfill shadowed them). The
+        // computed rows are the ONLY source for a strap-only WHOOP user (no raw daily rows exist),
+        // so without them the sparse HC backfill (recovery/strain/stages = null) shadows the computed
+        // day and blanks Today / regresses Sleep stages (#112). Each read is wrapped so a missing
+        // source is empty, not fatal; HC still gap-fills any day the strap did NOT cover.
+        val coveredDays: Set<String> = buildSet {
+            for (id in strapSourceIds(repo)) addAll(strapDays(repo, id))
+        }
 
         val appleRows = ArrayList<AppleDaily>(acc.size)
         val dailyRows = ArrayList<DailyMetric>(acc.size)
@@ -661,7 +672,7 @@ object HealthConnectImporter {
     /**
      * The set of "YYYY-MM-DD" days the strap already covers under [deviceId], read defensively:
      * a missing/empty source (the normal case for raw "my-whoop" on a strap-only user) yields an
-     * empty set rather than throwing. The caller unions the raw and computed sources (#112).
+     * empty set rather than throwing. The caller unions every strap-native source (#112).
      */
     private suspend fun strapDays(repo: WhoopRepository, deviceId: String): Set<String> =
         try {
@@ -669,6 +680,34 @@ object HealthConnectImporter {
         } catch (e: Exception) {
             emptySet()
         }
+
+    /**
+     * Every source id whose daily rows count as STRAP coverage for the #112 skip-set: the discovered
+     * strap-native ids present in the daily cache, always unioned with the canonical
+     * [WHOOP] / [WHOOP_COMPUTED] pair (so an empty/failed discovery degrades to the old behaviour,
+     * never below it). Read defensively — a DB error must not fail the import.
+     */
+    private suspend fun strapSourceIds(repo: WhoopRepository): Set<String> =
+        try {
+            repo.dailyMetricDeviceIds().filterTo(hashSetOf(WHOOP, WHOOP_COMPUTED)) {
+                isStrapNativeSourceId(it)
+            }
+        } catch (e: Exception) {
+            setOf(WHOOP, WHOOP_COMPUTED)
+        }
+
+    /**
+     * True when [id] is a strap-native daily-metric source: the canonical raw "my-whoop", ANY
+     * on-device computed "-noop" source, or an actively paired strap's raw "whoop-<mac>" id.
+     * These are the sources whose days the HC backfill must never shadow; importer-owned sources
+     * ("health-connect", "apple-health", band importers) are NOT strap coverage. Internal (not
+     * private) so the #112 skip-set semantics stay unit-testable without Room/Context, like
+     * [coveredDaySet].
+     */
+    internal fun isStrapNativeSourceId(id: String): Boolean {
+        val s = id.lowercase()
+        return s == WHOOP || s.endsWith("-noop") || s.startsWith("whoop-")
+    }
 
     /**
      * Pure mapper: the distinct local days carried by [rows]. Factored out (and internal) so the

--- a/android/app/src/main/java/com/noop/ui/SleepScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/SleepScreen.kt
@@ -3267,6 +3267,29 @@ internal fun displaySmoothed(
     return ivs
 }
 
+/** Canonical stage key: trims, lowercases, and folds the "wake"/"awake" alias (stageColorFor parity). */
+internal fun canonicalStage(name: String): String {
+    val n = name.trim().lowercase()
+    return if (n == "wake") "awake" else n
+}
+
+/**
+ * The (startFraction, widthFraction) spans of [rowStage]'s intervals within the night — one entry
+ * per solid segment in that stage's timeline row track. Fractions of [spanSec]; the draw side
+ * applies the min-width floor and canvas clamping.
+ */
+internal fun stageRowSpans(
+    intervals: List<StageInterval>,
+    rowStage: String,
+    spanSec: Double,
+): List<Pair<Float, Float>> {
+    if (spanSec <= 0.0 || !spanSec.isFinite()) return emptyList()
+    val key = canonicalStage(rowStage)
+    return intervals
+        .filter { canonicalStage(it.stage) == key }
+        .map { iv -> (iv.startSec / spanSec).toFloat() to (iv.durationSec / spanSec).toFloat() }
+}
+
 // MARK: - Hours vs Needed card
 
 /**

--- a/android/app/src/main/java/com/noop/ui/SleepScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/SleepScreen.kt
@@ -814,50 +814,53 @@ private fun Hero(
             // so the subtitle tracks the edit even before the stage minutes are recomputed. Uses the
             // EFFECTIVE onset so a hand-edited bedtime is reflected. (#160 / PR #395)
             val inBedMin = session?.let { (it.endTs - it.effectiveStartTs) / 60.0 } ?: s.total
-            ChartCard(
-                title = "Stage breakdown",
-                subtitle = "${durationText(inBedMin)} in bed · ${display.efficiencyText} efficiency" +
-                    (if (display.realSegments != null) " · approx. stages (on-device)" else ""),
-                trailing = durationText(s.asleep),
-                tint = Palette.restColor,
-                footer = {
-                    // WHOOP-style stage rows in the NOOP pip language: swatch + UPPERCASE stage +
-                    // coloured % + a segmented PipBar of the share-of-night + right-aligned duration.
-                    // Same minutes/percentages the old "label · value" footer carried — no new numbers.
-                    // Mirrors the macOS SleepView.stageBreakdownRows. (PipBar)
-                    StageBreakdownRows(s)
-                },
-            ) {
-                // True per-epoch segments when the stager persisted them; else the reconstructed
-                // architecture: light → deep → light → rem → light → awake.
-                val segments = display.realSegments ?: stageSegments(s)
-                if (segments.isNotEmpty()) {
-                    Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
-                        // Hero strip with the band-min-thickness floor (so a short Awake reads as a
-                        // bar, not a tick) + an onset · midpoint · wake time axis when the session
-                        // gives clock times. Mirrors the Swift Hypnogram(showsTimeAxis:).
+            val subtitle = "${durationText(inBedMin)} in bed · ${display.efficiencyText} efficiency" +
+                (if (display.realSegments != null) " · approx. stages (on-device)" else "")
+            // iOS #988 port: true per-epoch segments (≥ 2 — a single run has no transitions to lay
+            // out) get the per-stage timeline rows; the rows ARE the legend, so no footer. Anything
+            // else keeps the honest proportional strip + StageBreakdownRows footer.
+            val real = display.realSegments?.takeIf { it.size >= 2 }
+            if (real != null) {
+                ChartCard(
+                    title = "Stage breakdown",
+                    subtitle = subtitle,
+                    trailing = durationText(s.asleep),
+                    tint = Palette.restColor,
+                    footer = {},
+                ) {
+                    StageTimeline(
+                        realSegments = real,
+                        s = s,
+                        onsetTs = session?.effectiveStartTs,
+                        wakeTs = session?.endTs,
+                        motionEpochs = motionEpochs,
+                    )
+                }
+            } else {
+                ChartCard(
+                    title = "Stage breakdown",
+                    subtitle = subtitle,
+                    trailing = durationText(s.asleep),
+                    tint = Palette.restColor,
+                    footer = { StageBreakdownRows(s) },
+                ) {
+                    // Reconstructed architecture (light → deep → light → rem → light → awake) as the
+                    // flat proportional strip. No MotionStrip and no fake steps here: invented
+                    // architecture has no genuine timeline to anchor to (mirrors the iOS else-branch).
+                    val segments = stageSegments(s)
+                    if (segments.isNotEmpty()) {
                         HypnogramWithAxis(
                             stages = segments,
                             onsetTs = session?.effectiveStartTs,
                             wakeTs = session?.endTs,
                         )
-                        // #407 — subordinate movement/restlessness trace UNDER the hypnogram, on the SAME
-                        // timeline, for the SAME main-night GROUP blocks the hero resolved (selectNight's
-                        // group). Honest empty state when no fragment has persisted motion (older rows).
-                        MotionStrip(motionEpochs)
-                        Row(horizontalArrangement = Arrangement.spacedBy(Metrics.space16)) {
-                            StageLegend("Deep", Palette.sleepDeep)
-                            StageLegend("Light", Palette.sleepLight)
-                            StageLegend("REM", Palette.sleepREM)
-                            StageLegend("Awake", Palette.sleepAwake)
-                        }
+                    } else {
+                        Text(
+                            "No stage breakdown for this night.",
+                            style = NoopType.subhead,
+                            color = Palette.textTertiary,
+                        )
                     }
-                } else {
-                    Text(
-                        "No stage breakdown for this night.",
-                        style = NoopType.subhead,
-                        color = Palette.textTertiary,
-                    )
                 }
             }
         }
@@ -2094,23 +2097,6 @@ private fun NightNavHeader(
                 }
             },
         )
-    }
-}
-
-@Composable
-private fun StageLegend(label: String, color: Color) {
-    Row(
-        horizontalArrangement = Arrangement.spacedBy(Metrics.space6),
-        verticalAlignment = Alignment.CenterVertically,
-    ) {
-        Box(
-            modifier = Modifier
-                .height(Metrics.legendSwatch)
-                .width(Metrics.legendSwatch)
-                .clip(RoundedCornerShape(Metrics.cornerXs))
-                .background(color),
-        )
-        Text(label, style = NoopType.footnote, color = Palette.textTertiary)
     }
 }
 

--- a/android/app/src/main/java/com/noop/ui/SleepScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/SleepScreen.kt
@@ -3212,6 +3212,61 @@ internal fun stageIntervalsFromWeights(
     return out
 }
 
+/**
+ * Display-time smoothing — a straight port of Swift `Hypnogram.displaySmoothed` (WHOOP-style,
+ * Packages/StrandDesign/Sources/StrandDesign/Hypnogram.swift:92). The on-device stager emits
+ * 30 s-epoch runs, so a real night arrives as 60–100 fragments; brief flickers are absorbed into
+ * their surroundings AT DISPLAY TIME. Render-only: totals, percentages and stored data are
+ * computed from the raw segments elsewhere and are untouched. Pass minDurationSec = 0 for raw.
+ */
+internal fun displaySmoothed(
+    intervals: List<StageInterval>,
+    minDurationSec: Double,
+): List<StageInterval> {
+    if (intervals.size <= 2 || minDurationSec <= 0.0) return intervals   // Swift: guard count > 2
+
+    // Coalesce adjacent same-stage runs (also bridges the zero-length seams between epochs).
+    fun coalesce(ivs: List<StageInterval>): MutableList<StageInterval> {
+        val out = mutableListOf<StageInterval>()
+        for (iv in ivs) {
+            val last = out.lastOrNull()
+            if (last != null && last.stage == iv.stage && iv.startSec - last.endSec < 1.0) {
+                out[out.size - 1] = StageInterval(last.stage, last.startSec, iv.endSec)
+            } else {
+                out.add(iv)
+            }
+        }
+        return out
+    }
+
+    var ivs = coalesce(intervals)
+    // Repeatedly absorb the shortest sub-threshold fragment into its longer neighbour,
+    // re-coalescing after each pass, until every remaining block clears the threshold.
+    while (ivs.size > 1) {
+        val idx = ivs.indices
+            .filter { ivs[it].durationSec < minDurationSec }
+            .minByOrNull { ivs[it].durationSec } ?: break
+        val victim = ivs[idx]
+        val prev = if (idx > 0) ivs[idx - 1] else null
+        val next = if (idx < ivs.size - 1) ivs[idx + 1] else null
+        when {
+            prev != null && next != null ->
+                // Absorb into the longer neighbour so the dominant surrounding stage wins.
+                if (prev.durationSec >= next.durationSec) {
+                    ivs[idx - 1] = StageInterval(prev.stage, prev.startSec, victim.endSec)
+                } else {
+                    ivs[idx + 1] = StageInterval(next.stage, victim.startSec, next.endSec)
+                }
+            prev != null -> ivs[idx - 1] = StageInterval(prev.stage, prev.startSec, victim.endSec)
+            next != null -> ivs[idx + 1] = StageInterval(next.stage, victim.startSec, next.endSec)
+            else -> break
+        }
+        ivs.removeAt(idx)
+        ivs = coalesce(ivs)
+    }
+    return ivs
+}
+
 // MARK: - Hours vs Needed card
 
 /**

--- a/android/app/src/main/java/com/noop/ui/SleepScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/SleepScreen.kt
@@ -66,6 +66,7 @@ import androidx.compose.ui.graphics.Shadow
 import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.graphics.drawscope.DrawScope
 import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.graphics.drawscope.clipRect
 import androidx.compose.ui.graphics.nativeCanvas
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.LocalContext
@@ -1307,38 +1308,240 @@ private fun HypnogramWithAxis(
             }
         }
         if (showsAxis && onsetTs != null && wakeTs != null) {
-            val onset = clockTimeLabel(onsetTs)
-            val mid = clockTimeLabel((onsetTs + wakeTs) / 2L)
-            val wake = clockTimeLabel(wakeTs)
-            Row(modifier = Modifier.fillMaxWidth()) {
-                Text(
-                    onset,
-                    style = NoopType.footnote,
-                    color = Palette.textTertiary,
-                    textAlign = TextAlign.Start,
-                    maxLines = 1,
-                    modifier = Modifier.weight(1f),
-                )
-                Text(
-                    mid,
-                    style = NoopType.footnote,
-                    color = Palette.textTertiary,
-                    textAlign = TextAlign.Center,
-                    overflow = TextOverflow.Ellipsis,
-                    maxLines = 1,
-                    modifier = Modifier.weight(1f),
-                )
-                Text(
-                    wake,
-                    style = NoopType.footnote,
-                    color = Palette.textTertiary,
-                    textAlign = TextAlign.End,
-                    maxLines = 1,
-                    modifier = Modifier.weight(1f),
-                )
-            }
+            ClockLabelRow(onsetTs, wakeTs)
         }
     }
+}
+
+/**
+ * The onset · midpoint · wake clock-label row under a night timeline. Extracted from
+ * [HypnogramWithAxis] so the #988 stage-timeline rows share the exact same axis rendering.
+ */
+@Composable
+private fun ClockLabelRow(onsetTs: Long, wakeTs: Long) {
+    val onset = clockTimeLabel(onsetTs)
+    val mid = clockTimeLabel((onsetTs + wakeTs) / 2L)
+    val wake = clockTimeLabel(wakeTs)
+    Row(modifier = Modifier.fillMaxWidth()) {
+        Text(
+            onset,
+            style = NoopType.footnote,
+            color = Palette.textTertiary,
+            textAlign = TextAlign.Start,
+            maxLines = 1,
+            modifier = Modifier.weight(1f),
+        )
+        Text(
+            mid,
+            style = NoopType.footnote,
+            color = Palette.textTertiary,
+            textAlign = TextAlign.Center,
+            overflow = TextOverflow.Ellipsis,
+            maxLines = 1,
+            modifier = Modifier.weight(1f),
+        )
+        Text(
+            wake,
+            style = NoopType.footnote,
+            color = Palette.textTertiary,
+            textAlign = TextAlign.End,
+            maxLines = 1,
+            modifier = Modifier.weight(1f),
+        )
+    }
+}
+
+/** 90 s display floor for the stage rows — rows tolerate fine texture, so 90 s, not the staircase's 300 s. */
+private const val STAGE_ROW_SMOOTH_SEC = 90.0
+
+/**
+ * iOS #988 port — the WHOOP-style per-stage timeline stack that replaces the flat hypnogram strip
+ * for real-stage nights. Four tappable rows in WHOOP order (AWAKE · LIGHT · DEEP · REM), each a
+ * hatched full-night track with solid segments on the shared onset→wake axis; MotionStrip and the
+ * clock-label axis sit under the rows on the SAME timeline; a fixed-height insight slot closes the
+ * stack. The rows ARE the legend — no dot row, no footer. Mirrors SleepView.stageTimeline.
+ */
+@Composable
+private fun StageTimeline(
+    realSegments: List<Pair<String, Float>>,
+    s: Stages,
+    onsetTs: Long?,
+    wakeTs: Long?,
+    motionEpochs: List<Double>,
+) {
+    // Night span: the session window when we have one (the clock axis uses the same span), else
+    // the segments' own summed minutes — the fractions are identical either way.
+    val weightSec = realSegments.sumOf { (_, wt) -> if (wt.isFinite() && wt > 0f) wt.toDouble() * 60.0 else 0.0 }
+    val spanSec = if (onsetTs != null && wakeTs != null && wakeTs > onsetTs) {
+        (wakeTs - onsetTs).toDouble()
+    } else {
+        weightSec
+    }
+    val intervals = remember(realSegments, spanSec) {
+        displaySmoothed(stageIntervalsFromWeights(realSegments, spanSec), STAGE_ROW_SMOOTH_SEC)
+    }
+    // Tap-to-highlight; keyed on the night's segments so navigating nights clears the selection.
+    var selectedStage by remember(realSegments) { mutableStateOf<String?>(null) }
+
+    Column(verticalArrangement = Arrangement.spacedBy(Metrics.space8)) {
+        listOf(
+            Triple("Awake", s.awake, Palette.sleepAwake),
+            Triple("Light", s.light, Palette.sleepLight),
+            Triple("Deep", s.deep, Palette.sleepDeep),
+            Triple("REM", s.rem, Palette.sleepREM),
+        ).forEach { (label, minutes, color) ->
+            StageTimelineRow(
+                label = label,
+                minutes = minutes,
+                total = s.total,
+                color = color,
+                spans = stageRowSpans(intervals, label, spanSec),
+                selected = selectedStage == label,
+                dimmed = selectedStage != null && selectedStage != label,
+                onTap = { selectedStage = if (selectedStage == label) null else label },
+            )
+        }
+        // #407 — MotionStrip component + data path untouched; relocated UNDER the rows on the SAME
+        // timeline. Same inner insets as the rows' tracks so epochs don't skew against the segments.
+        Box(modifier = Modifier.padding(horizontal = Metrics.stageRowPadH)) {
+            MotionStrip(motionEpochs)
+        }
+        if (onsetTs != null && wakeTs != null) {
+            Box(modifier = Modifier.padding(horizontal = Metrics.stageRowPadH)) {
+                ClockLabelRow(onsetTs, wakeTs)
+            }
+        }
+        StageInsight(selectedStage, s)
+    }
+}
+
+/**
+ * One per-stage timeline row: STAGE overline + coloured % + right-aligned duration over a hatched
+ * full-night track with the stage's solid segments. Selected row gets a hairlineStrong stroke;
+ * when ANOTHER row is selected this row's segments and % dim to tertiary. One collapsed a11y node —
+ * "Awake: 49 min, 10 percent of the night". Mirrors SleepView.stageTimelineRow.
+ */
+@Composable
+private fun StageTimelineRow(
+    label: String,
+    minutes: Double,
+    total: Double,
+    color: Color,
+    spans: List<Pair<Float, Float>>,
+    selected: Boolean,
+    dimmed: Boolean,
+    onTap: () -> Unit,
+) {
+    val percent = if (total > 0.0) (minutes / total * 100.0).roundToInt() else 0
+    val segColor = if (dimmed) Palette.textTertiary.copy(alpha = 0.55f) else color
+    val pctColor = if (dimmed) Palette.textTertiary else color
+    val shape = RoundedCornerShape(Metrics.stageRowCorner)
+    Column(
+        verticalArrangement = Arrangement.spacedBy(Metrics.space6),
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(shape)
+            .background(Palette.textPrimary.copy(alpha = 0.045f))
+            .then(if (selected) Modifier.border(1.5.dp, Palette.hairlineStrong, shape) else Modifier)
+            .clickable(onClickLabel = "Highlights this stage on the sleep chart", onClick = onTap)
+            .padding(horizontal = Metrics.stageRowPadH, vertical = Metrics.stageRowPadV)
+            .semantics(mergeDescendants = true) {
+                contentDescription = "$label: ${durationText(minutes)}, $percent percent of the night"
+            },
+    ) {
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Text(
+                label.uppercase(Locale.getDefault()),
+                style = NoopType.overline,
+                color = Palette.textPrimary,
+                maxLines = 1,
+            )
+            Spacer(modifier = Modifier.width(Metrics.space8))
+            Text("$percent%", style = NoopType.captionNumber, color = pctColor, maxLines = 1)
+            Spacer(modifier = Modifier.weight(1f))
+            Text(
+                durationText(minutes),
+                style = NoopType.captionNumber,
+                color = Palette.textPrimary,
+                maxLines = 1,
+            )
+        }
+        StageRowTrack(spans = spans, color = segColor)
+    }
+}
+
+/**
+ * The row's track, drawn in a SINGLE Canvas (PERF: a fragmented night must not become hundreds of
+ * composables — Charts.kt hoist convention): a recessed full-night base with faint diagonal
+ * hatching ("no segment here" reads as "elsewhere in the night", not missing data), then the
+ * stage's solid rounded segments with a width floor, clamped so floored widths stay on-canvas
+ * (same #36 lesson as HypnogramWithAxis).
+ */
+@Composable
+private fun StageRowTrack(spans: List<Pair<Float, Float>>, color: Color) {
+    Canvas(modifier = Modifier.fillMaxWidth().height(Metrics.stageRowTrackHeight)) {
+        val w = size.width
+        val h = size.height
+        if (w <= 0f || h <= 0f) return@Canvas
+
+        val trackRadius = CornerRadius(Metrics.stageSegCorner.toPx(), Metrics.stageSegCorner.toPx())
+        drawRoundRect(color = Palette.surfaceInset, size = Size(w, h), cornerRadius = trackRadius)
+        clipRect(0f, 0f, w, h) {
+            val step = 6.dp.toPx()
+            var x = -h
+            while (x < w) {
+                drawLine(
+                    color = Palette.hairline,
+                    start = Offset(x, h),
+                    end = Offset(x + h, 0f),
+                    strokeWidth = 1f,
+                )
+                x += step
+            }
+        }
+
+        val minW = Metrics.stageSegMinWidth.toPx()
+        val segRadius = CornerRadius(Metrics.stageSegCorner.toPx(), Metrics.stageSegCorner.toPx())
+        spans.forEach { (fracStart, fracWidth) ->
+            if (!fracStart.isFinite() || !fracWidth.isFinite() || fracWidth <= 0f) return@forEach
+            val segW = maxOf(w * fracWidth, minW).coerceAtMost(w)
+            val x0 = (w * fracStart).coerceIn(0f, w - segW)
+            drawRoundRect(
+                color = color,
+                topLeft = Offset(x0, 0f),
+                size = Size(segW, h),
+                cornerRadius = segRadius,
+            )
+        }
+    }
+}
+
+/**
+ * Fixed-height per-stage insight slot under the axis: with a stage selected, that stage tonight;
+ * otherwise the quiet "tap a row" hint. Fixed height so selection never reflows the card. The
+ * 30-day typical-range compare is a follow-up — no such repo call exists on Android yet (design
+ * §Real-stage nights item 6).
+ */
+@Composable
+private fun StageInsight(selectedStage: String?, s: Stages) {
+    val text = when (selectedStage) {
+        "Awake" -> stageInsightLine("Awake", s.awake, s.total)
+        "Light" -> stageInsightLine("Light", s.light, s.total)
+        "Deep" -> stageInsightLine("Deep", s.deep, s.total)
+        "REM" -> stageInsightLine("REM", s.rem, s.total)
+        else -> "Tap a stage to highlight it across the night."
+    }
+    Box(
+        modifier = Modifier.fillMaxWidth().height(Metrics.stageInsightHeight),
+        contentAlignment = Alignment.CenterStart,
+    ) {
+        Text(text, style = NoopType.footnote, color = Palette.textTertiary, maxLines = 2)
+    }
+}
+
+private fun stageInsightLine(label: String, minutes: Double, total: Double): String {
+    val percent = if (total > 0.0) (minutes / total * 100.0).roundToInt() else 0
+    return "$label tonight: ${durationText(minutes)} — $percent% of the night."
 }
 
 /**

--- a/android/app/src/main/java/com/noop/ui/SleepScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/SleepScreen.kt
@@ -3179,6 +3179,39 @@ internal fun parsePersistedSegments(json: String?): List<PersistedSegment>? {
     }.getOrNull()
 }
 
+// MARK: - Stage timeline logic (iOS #988 port — pure, unit-tested)
+
+/** One contiguous run of a single sleep stage, in seconds from the night's onset. */
+internal data class StageInterval(val stage: String, val startSec: Double, val endSec: Double) {
+    val durationSec: Double get() = endSec - startSec
+}
+
+/**
+ * Reconstruct absolute (stage, startSec, endSec) intervals from the hero's ordered
+ * `realSegments` weight pairs (name, minutes) by walking cumulative fractions across [spanSec]
+ * (design 2026-07-10, §Real-stage nights item 3). Non-finite / non-positive weights are skipped —
+ * they carry no drawable width. Returns [] when nothing is drawable.
+ */
+internal fun stageIntervalsFromWeights(
+    segments: List<Pair<String, Float>>,
+    spanSec: Double,
+): List<StageInterval> {
+    if (segments.isEmpty() || !spanSec.isFinite() || spanSec <= 0.0) return emptyList()
+    val weights = segments.map { (_, wt) -> if (wt.isFinite() && wt > 0f) wt.toDouble() else 0.0 }
+    val total = weights.sum()
+    if (total <= 0.0) return emptyList()
+    val out = ArrayList<StageInterval>(segments.size)
+    var cum = 0.0
+    segments.forEachIndexed { i, (name, _) ->
+        val w = weights[i]
+        if (w <= 0.0) return@forEachIndexed
+        val start = spanSec * (cum / total)
+        cum += w
+        out.add(StageInterval(name, start, spanSec * (cum / total)))
+    }
+    return out
+}
+
 // MARK: - Hours vs Needed card
 
 /**

--- a/android/app/src/main/java/com/noop/ui/SleepScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/SleepScreen.kt
@@ -516,6 +516,7 @@ fun SleepScreen(
                 napBlocks = night?.napBlocks ?: emptyList(),
                 habitualMidsleepSec = habitualMidsleep,
                 motionEpochs = night?.groupMotion ?: emptyList(),
+                groupInBedMin = night?.groupInBedMin,
             )
             }
             // Tiles / ledger / trends read the FULL-history model (#940): they stay up when only the
@@ -789,6 +790,10 @@ private fun Hero(
     // Per-epoch MOTION for the main-night GROUP (#407), laid in group order by `selectNight`. Empty → honest
     // empty state. Drawn UNDER the hypnogram on the same timeline. Mirrors iOS SleepView.Night.motionEpochs.
     motionEpochs: List<Double> = emptyList(),
+    // Whole-group time-in-bed minutes for a fragmented night (#561): Σ fragment windows, gaps
+    // excluded, computed by `selectNight`. Null for single-block days → the session-window /
+    // stage-total fallbacks below apply unchanged.
+    groupInBedMin: Double? = null,
 ) {
     Column(verticalArrangement = Arrangement.spacedBy(Metrics.gap)) {
         NightNavHeader(nightOffset, lastIndex, clock, onNavigate, session, onUpdateTimes, onDeleteSession, onAddNap, onPickNightDate)
@@ -813,7 +818,11 @@ private fun Hero(
             // After a bed/wake edit the session window is the source of truth for time-in-bed,
             // so the subtitle tracks the edit even before the stage minutes are recomputed. Uses the
             // EFFECTIVE onset so a hand-edited bedtime is reflected. (#160 / PR #395)
-            val inBedMin = session?.let { (it.endTs - it.effectiveStartTs) / 60.0 } ?: s.total
+            // A fragmented night prefers the GROUP total (#561): `session` is only the WINNING
+            // fragment, so its window alone undershot the summed stage minutes shown beside it.
+            val inBedMin = groupInBedMin
+                ?: session?.let { (it.endTs - it.effectiveStartTs) / 60.0 }
+                ?: s.total
             val subtitle = "${durationText(inBedMin)} in bed · ${display.efficiencyText} efficiency" +
                 (if (display.realSegments != null) " · approx. stages (on-device)" else "")
             // iOS #988 port: true per-epoch segments (≥ 2 — a single run has no transitions to lay
@@ -2721,6 +2730,14 @@ internal data class HeroNight(
     // → the hero shows an honest empty state instead of a fabricated zero trace. Read off the already-
     // resolved group, NOT a re-resolution of the night.
     val groupMotion: List<Double> = emptyList(),
+    // Time-in-bed for the whole main-night GROUP (#561): Σ(endTs − effectiveStartTs) across the
+    // hero fragments, in minutes. The hero subtitle previously derived in-bed from `session` alone
+    // (the single WINNING fragment), so a fragmented night's "Xh in bed" undershot the stage total
+    // it sat next to. Summing fragment windows (NOT wall-clock first-onset→last-wake) excludes the
+    // inter-fragment awake gaps, mirroring sumGroupStages/AnalyticsEngine, so asleep ≤ in-bed and
+    // the efficiency shown beside it stays coherent. Null for a single-block day → the hero keeps
+    // its session-window / stage-total fallbacks.
+    val groupInBedMin: Double? = null,
 )
 
 /** What the hero card draws for the selected night — null means no usable stage data
@@ -2811,8 +2828,13 @@ internal fun selectNight(
     // nightOnsetTs / synth.startTs), closed by the group's latest wake. `session` stays the edit anchor only.
     val heroOnsetTs = heroGroup.firstOrNull()?.effectiveStartTs ?: session.effectiveStartTs
     val heroWakeTs = heroGroup.maxOfOrNull { it.endTs } ?: session.endTs
+    // #561: whole-group time-in-bed (minutes) — fragment windows summed, gaps excluded — so the hero
+    // subtitle matches the multi-fragment stage total it is shown with. Single-block days stay null.
+    val groupInBedMin = if (heroGroup.size > 1) {
+        heroGroup.sumOf { (it.endTs - it.effectiveStartTs).coerceAtLeast(0L) } / 60.0
+    } else null
     return HeroNight(session, dayKey, segments, clockLabelFor(heroOnsetTs, heroWakeTs), napBlocks, groupStages,
-        groupSegments, groupMotion)
+        groupSegments, groupMotion, groupInBedMin)
 }
 
 /**

--- a/android/app/src/main/java/com/noop/ui/Theme.kt
+++ b/android/app/src/main/java/com/noop/ui/Theme.kt
@@ -399,6 +399,14 @@ object Metrics {
     val sparkHeight = 22.dp
     val stageStripHeight = 34.dp
     val motionStripHeight = 40.dp   // #407 — the subordinate movement/restlessness trace under the hypnogram
+    // iOS #988 port — WHOOP-style per-stage sleep timeline rows (design 2026-07-10).
+    val stageRowTrackHeight = 20.dp  // hatched night track + solid stage segments
+    val stageRowCorner = 10.dp       // row background rounding
+    val stageRowPadH = 10.dp         // row inner horizontal padding — MotionStrip/axis share it so epochs align
+    val stageRowPadV = 8.dp          // row inner vertical padding
+    val stageSegMinWidth = 2.dp      // width floor so a brief fragment reads as a block, not a hairline
+    val stageSegCorner = 1.5.dp      // solid segment rounding
+    val stageInsightHeight = 36.dp   // fixed insight slot height — selection never reflows the card
     val trendStripHeight = 120.dp
     val sparklineHeight = 28.dp
     val segmentBarHeight = 18.dp

--- a/android/app/src/test/java/com/noop/ingest/HealthConnectCoveredDaysTest.kt
+++ b/android/app/src/test/java/com/noop/ingest/HealthConnectCoveredDaysTest.kt
@@ -76,4 +76,61 @@ class HealthConnectCoveredDaysTest {
         assertEquals(setOf("2026-06-05", "2026-06-06", "2026-06-07"), covered)
         assertFalse("2026-06-08 left open for gap-fill", "2026-06-08" in covered)
     }
+
+    // ---- #112 follow-up: the gate unions EVERY strap-native source id, not just the canonical
+    // "my-whoop"/"my-whoop-noop" pair, so an actively paired strap's "whoop-<mac>" days are owned.
+
+    @Test
+    fun strapNativeSourceIdsAreRecognised() {
+        // Canonical pair.
+        assertTrue(HealthConnectImporter.isStrapNativeSourceId("my-whoop"))
+        assertTrue(HealthConnectImporter.isStrapNativeSourceId("my-whoop-noop"))
+        // Actively paired strap: raw BLE id + its computed twin.
+        assertTrue(HealthConnectImporter.isStrapNativeSourceId("whoop-aa:bb:cc:dd:ee:ff"))
+        assertTrue(HealthConnectImporter.isStrapNativeSourceId("whoop-aa:bb:cc:dd:ee:ff-noop"))
+        // Any other on-device computed source counts as strap coverage.
+        assertTrue(HealthConnectImporter.isStrapNativeSourceId("xiaomi-band-noop"))
+        // Case-insensitive (ids are stored lowercase, but never rely on it).
+        assertTrue(HealthConnectImporter.isStrapNativeSourceId("WHOOP-AA:BB-NOOP"))
+    }
+
+    @Test
+    fun importerOwnedSourcesAreNotStrapCoverage() {
+        assertFalse(HealthConnectImporter.isStrapNativeSourceId("health-connect"))
+        assertFalse(HealthConnectImporter.isStrapNativeSourceId("apple-health"))
+        assertFalse(HealthConnectImporter.isStrapNativeSourceId("xiaomi-band"))
+        assertFalse(HealthConnectImporter.isStrapNativeSourceId("manual"))
+        assertFalse(HealthConnectImporter.isStrapNativeSourceId(""))
+    }
+
+    /**
+     * The re-paired-strap case behind the shadow-row bug: fresh nights live ONLY under the active
+     * strap's "whoop-<mac>" / "whoop-<mac>-noop" ids. Filtering the discovered id list through
+     * [HealthConnectImporter.isStrapNativeSourceId] and unioning per-id day-sets must own those
+     * days too — the old canonical-pair-only read left them open and HC shadowed them.
+     */
+    @Test
+    fun activeStrapIdsCoverTheirDays() {
+        val discovered = listOf(
+            "my-whoop", "my-whoop-noop",
+            "whoop-aa:bb:cc:dd:ee:ff-noop", // active strap, computed nights only
+            "health-connect", "apple-health", // importer-owned: must NOT contribute coverage
+        )
+        val strapIds = discovered.filter { HealthConnectImporter.isStrapNativeSourceId(it) }
+        assertEquals(listOf("my-whoop", "my-whoop-noop", "whoop-aa:bb:cc:dd:ee:ff-noop"), strapIds)
+
+        val rowsBySource = mapOf(
+            "my-whoop" to listOf(row("my-whoop", "2026-06-01")),
+            "my-whoop-noop" to listOf(row("my-whoop-noop", "2026-06-02")),
+            "whoop-aa:bb:cc:dd:ee:ff-noop" to listOf(row("whoop-aa:bb:cc:dd:ee:ff-noop", "2026-06-09")),
+            "health-connect" to listOf(row("health-connect", "2026-06-10")),
+        )
+        val covered = strapIds.fold(emptySet<String>()) { acc, id ->
+            acc + HealthConnectImporter.coveredDaySet(rowsBySource[id].orEmpty())
+        }
+
+        assertEquals(setOf("2026-06-01", "2026-06-02", "2026-06-09"), covered)
+        // The HC-owned day is NOT strap coverage — it stays open so HC may rewrite its own rows.
+        assertFalse("2026-06-10" in covered)
+    }
 }

--- a/android/app/src/test/java/com/noop/ui/StageDisplaySmoothingTest.kt
+++ b/android/app/src/test/java/com/noop/ui/StageDisplaySmoothingTest.kt
@@ -1,0 +1,121 @@
+package com.noop.ui
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Unit tests for [displaySmoothed], the Kotlin port of Swift `Hypnogram.displaySmoothed`
+ * (Packages/StrandDesign/Sources/StrandDesign/Hypnogram.swift). Fixtures mirror the Swift
+ * semantics: coalesce adjacent same-stage runs, then absorb the SHORTEST sub-threshold fragment
+ * into its LONGER neighbour until every block clears the floor. Render-only smoothing.
+ */
+class StageDisplaySmoothingTest {
+
+    private fun iv(stage: String, start: Double, end: Double) = StageInterval(stage, start, end)
+
+    @Test
+    fun guardsTwoOrFewerIntervalsUntouched() {
+        val two = listOf(iv("light", 0.0, 30.0), iv("deep", 30.0, 60.0))
+        assertEquals(two, displaySmoothed(two, 90.0))   // Swift: guard sorted.count > 2
+    }
+
+    @Test
+    fun coalescesAdjacentSameStageRuns() {
+        val out = displaySmoothed(
+            listOf(
+                iv("light", 0.0, 300.0),
+                iv("light", 300.0, 600.0),   // same stage, zero-length seam → merged
+                iv("deep", 600.0, 900.0),
+            ),
+            minDurationSec = 90.0,
+        )
+        assertEquals(2, out.size)
+        assertEquals(iv("light", 0.0, 600.0), out[0])
+        assertEquals(iv("deep", 600.0, 900.0), out[1])
+    }
+
+    @Test
+    fun absorbsFlickerIntoLongerNeighbour() {
+        // A 30 s deep flicker between 600 s light (longer) and 300 s rem → absorbed into light.
+        val out = displaySmoothed(
+            listOf(
+                iv("light", 0.0, 600.0),
+                iv("deep", 600.0, 630.0),
+                iv("rem", 630.0, 930.0),
+            ),
+            minDurationSec = 90.0,
+        )
+        assertEquals(2, out.size)
+        assertEquals(iv("light", 0.0, 630.0), out[0])
+        assertEquals(iv("rem", 630.0, 930.0), out[1])
+    }
+
+    @Test
+    fun absorptionReCoalescesBridgedRuns() {
+        // light | 30s wake | light → wake absorbed, then the two light runs coalesce into ONE block.
+        val out = displaySmoothed(
+            listOf(
+                iv("light", 0.0, 600.0),
+                iv("wake", 600.0, 630.0),
+                iv("light", 630.0, 1200.0),
+            ),
+            minDurationSec = 90.0,
+        )
+        assertEquals(1, out.size)
+        assertEquals(iv("light", 0.0, 1200.0), out[0])
+    }
+
+    @Test
+    fun edgeFragmentAbsorbsIntoOnlyNeighbour() {
+        val out = displaySmoothed(
+            listOf(
+                iv("wake", 0.0, 30.0),      // leading flicker: only neighbour is `light`
+                iv("light", 30.0, 900.0),
+                iv("deep", 900.0, 1800.0),
+            ),
+            minDurationSec = 90.0,
+        )
+        assertEquals(2, out.size)
+        assertEquals(iv("light", 0.0, 900.0), out[0])
+    }
+
+    @Test
+    fun combOfEpochFlickersCollapses() {
+        // 30 s-epoch comb (the original complaint): alternating light/deep flickers inside a light
+        // night collapse to a single light block — no sub-90 s block survives.
+        val comb = buildList {
+            add(iv("light", 0.0, 1200.0))
+            var t = 1200.0
+            repeat(6) {
+                add(iv("deep", t, t + 30.0)); t += 30.0
+                add(iv("light", t, t + 30.0)); t += 30.0
+            }
+            add(iv("light", t, t + 1200.0))
+        }
+        val out = displaySmoothed(comb, 90.0)
+        assertTrue(out.all { it.durationSec >= 90.0 })
+        assertEquals(1, out.size)
+        assertEquals("light", out[0].stage)
+        assertEquals(0.0, out[0].startSec, 1e-9)
+        assertEquals(comb.last().endSec, out[0].endSec, 1e-9)
+    }
+
+    @Test
+    fun zeroFloorReturnsCoalescedInputUnsmoothed() {
+        val raw = listOf(iv("light", 0.0, 10.0), iv("deep", 10.0, 20.0), iv("rem", 20.0, 30.0))
+        assertEquals(raw, displaySmoothed(raw, 0.0))   // smoothingSeconds: 0 → raw timeline
+    }
+
+    @Test
+    fun totalsPreserved() {
+        val raw = listOf(
+            iv("light", 0.0, 600.0), iv("deep", 600.0, 660.0),
+            iv("rem", 660.0, 1500.0), iv("wake", 1500.0, 1530.0), iv("light", 1530.0, 3000.0),
+        )
+        val out = displaySmoothed(raw, 90.0)
+        assertEquals(0.0, out.first().startSec, 1e-9)
+        assertEquals(3000.0, out.last().endSec, 1e-9)
+        for (i in 1 until out.size) assertEquals(out[i - 1].endSec, out[i].startSec, 1e-9)
+    }
+}

--- a/android/app/src/test/java/com/noop/ui/StageRowSpansTest.kt
+++ b/android/app/src/test/java/com/noop/ui/StageRowSpansTest.kt
@@ -1,0 +1,54 @@
+package com.noop.ui
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Unit tests for [canonicalStage] + [stageRowSpans]: the (fracStart, fracWidth) spans of one
+ * stage's intervals within the night, feeding a single StageRowTrack canvas per timeline row.
+ */
+class StageRowSpansTest {
+
+    private val ivs = listOf(
+        StageInterval("wake", 0.0, 360.0),
+        StageInterval("light", 360.0, 1800.0),
+        StageInterval("deep", 1800.0, 2520.0),
+        StageInterval("light", 2520.0, 3240.0),
+        StageInterval("Awake", 3240.0, 3600.0),
+    )
+
+    @Test
+    fun extractsFractionalSpansForOneStage() {
+        val spans = stageRowSpans(ivs, "Light", 3600.0)
+        assertEquals(2, spans.size)
+        assertEquals(0.1f, spans[0].first, 1e-6f)
+        assertEquals(0.4f, spans[0].second, 1e-6f)
+        assertEquals(0.7f, spans[1].first, 1e-6f)
+        assertEquals(0.2f, spans[1].second, 1e-6f)
+    }
+
+    @Test
+    fun awakeAndWakeAreAliases() {
+        // Row label "Awake" must catch both the "wake" and "Awake" segments (stageColorFor parity).
+        val spans = stageRowSpans(ivs, "Awake", 3600.0)
+        assertEquals(2, spans.size)
+        assertEquals(0.0f, spans[0].first, 1e-6f)
+        assertEquals(0.9f, spans[1].first, 1e-6f)
+    }
+
+    @Test
+    fun matchIsCaseAndWhitespaceInsensitive() {
+        assertEquals("deep", canonicalStage("  Deep "))
+        assertEquals("awake", canonicalStage("WAKE"))
+        assertEquals("awake", canonicalStage("Awake"))
+        assertEquals("rem", canonicalStage("REM"))
+        assertEquals(1, stageRowSpans(ivs, "DEEP", 3600.0).size)
+    }
+
+    @Test
+    fun absentStageOrDegenerateSpanIsEmpty() {
+        assertTrue(stageRowSpans(ivs, "REM", 3600.0).isEmpty())
+        assertTrue(stageRowSpans(ivs, "Deep", 0.0).isEmpty())
+    }
+}

--- a/android/app/src/test/java/com/noop/ui/StageTimelineIntervalsTest.kt
+++ b/android/app/src/test/java/com/noop/ui/StageTimelineIntervalsTest.kt
@@ -1,0 +1,69 @@
+package com.noop.ui
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Unit tests for [stageIntervalsFromWeights], the pure helper behind the Sleep hero's per-stage
+ * timeline rows (iOS #988 port). Reconstructs (stage, startSec, endSec) intervals from the hero's
+ * ordered `realSegments` weight pairs by walking cumulative fractions across the night span.
+ */
+class StageTimelineIntervalsTest {
+
+    @Test
+    fun walksCumulativeFractions() {
+        // 30 + 60 + 30 = 120 min of weights across a 7200 s span → fractions 1/4, 1/2, 1/4.
+        val ivs = stageIntervalsFromWeights(
+            listOf("light" to 30f, "deep" to 60f, "rem" to 30f),
+            spanSec = 7200.0,
+        )
+        assertEquals(3, ivs.size)
+        assertEquals(0.0, ivs[0].startSec, 1e-9)
+        assertEquals(1800.0, ivs[0].endSec, 1e-9)
+        assertEquals("deep", ivs[1].stage)
+        assertEquals(1800.0, ivs[1].startSec, 1e-9)
+        assertEquals(5400.0, ivs[1].endSec, 1e-9)
+        assertEquals(7200.0, ivs[2].endSec, 1e-9)
+    }
+
+    @Test
+    fun intervalsAreContiguousAndCoverSpan() {
+        val ivs = stageIntervalsFromWeights(
+            listOf("wake" to 5f, "light" to 90f, "deep" to 45f, "light" to 100f, "rem" to 40f),
+            spanSec = 28_800.0,
+        )
+        assertEquals(0.0, ivs.first().startSec, 1e-9)
+        assertEquals(28_800.0, ivs.last().endSec, 1e-6)
+        for (i in 1 until ivs.size) assertEquals(ivs[i - 1].endSec, ivs[i].startSec, 1e-9)
+    }
+
+    @Test
+    fun skipsNonFiniteAndNonPositiveWeights() {
+        val ivs = stageIntervalsFromWeights(
+            listOf("light" to 30f, "deep" to Float.NaN, "rem" to -5f, "light" to 0f, "deep" to 30f),
+            spanSec = 3600.0,
+        )
+        assertEquals(2, ivs.size)
+        assertEquals("light", ivs[0].stage)
+        assertEquals("deep", ivs[1].stage)
+        // The two surviving 30 min weights split the span in half.
+        assertEquals(1800.0, ivs[0].endSec, 1e-9)
+        assertEquals(3600.0, ivs[1].endSec, 1e-9)
+    }
+
+    @Test
+    fun emptyOrDegenerateInputReturnsEmpty() {
+        assertTrue(stageIntervalsFromWeights(emptyList(), 3600.0).isEmpty())
+        assertTrue(stageIntervalsFromWeights(listOf("light" to 30f), 0.0).isEmpty())
+        assertTrue(stageIntervalsFromWeights(listOf("light" to 30f), -10.0).isEmpty())
+        assertTrue(stageIntervalsFromWeights(listOf("light" to 30f), Double.NaN).isEmpty())
+        assertTrue(stageIntervalsFromWeights(listOf("light" to 0f, "deep" to Float.NaN), 3600.0).isEmpty())
+    }
+
+    @Test
+    fun durationSecIsEndMinusStart() {
+        val ivs = stageIntervalsFromWeights(listOf("light" to 30f, "deep" to 30f), 3600.0)
+        assertEquals(1800.0, ivs[0].durationSec, 1e-9)
+    }
+}

--- a/docs/superpowers/plans/2026-07-10-android-sleep-stage-timeline.md
+++ b/docs/superpowers/plans/2026-07-10-android-sleep-stage-timeline.md
@@ -1,0 +1,1046 @@
+# Android Sleep Stage-Timeline Rows (iOS #988 port) — Implementation Plan
+
+**Design doc (source of truth):** `docs/superpowers/specs/2026-07-10-android-sleep-stage-timeline-design.md`
+**Date:** 2026-07-10
+
+## Goal
+
+Replace the Android Sleep hero card's flat hypnogram strip + double legend with WHOOP-style
+**per-stage timeline rows** (AWAKE · LIGHT · DEEP · REM), mirroring iOS #988
+(`Strand/Screens/SleepView.swift:640-1290`). Real-stage nights get four tappable rows whose solid
+segments sit on the shared onset→wake axis (display-smoothed at 90 s), with `MotionStrip` and the
+clock-label axis underneath and a fixed-height per-stage insight slot. Fallback (minutes-only)
+nights keep the flat strip + `StageBreakdownRows` footer. The dot `StageLegend` row dies.
+
+## Architecture
+
+Everything lives in the two files that already own this UI:
+
+- `android/app/src/main/java/com/noop/ui/SleepScreen.kt`
+  - **Pure logic** (internal top-level functions, JVM-unit-testable — same pattern as the existing
+    `parsePersistedSegments` + `SleepStageSegmentsTest`):
+    - `StageInterval` — one contiguous stage run in seconds-from-onset.
+    - `stageIntervalsFromWeights(segments, spanSec)` — reconstructs intervals from the hero's
+      ordered `realSegments: List<Pair<String, Float>>` (name, minutes) by cumulative fractions.
+    - `displaySmoothed(intervals, minDurationSec)` — straight port of Swift
+      `Hypnogram.displaySmoothed` (`Packages/StrandDesign/Sources/StrandDesign/Hypnogram.swift:92-136`).
+    - `canonicalStage(name)` + `stageRowSpans(intervals, rowStage, spanSec)` — per-row
+      `(fracStart, fracWidth)` spans.
+  - **UI**: `StageTimeline` (state + stack), `StageTimelineRow` (header + track), `StageRowTrack`
+    (single-Canvas hatched track + segments — PERF: no per-segment `Box`es), `StageInsight`
+    (fixed-height caption), `ClockLabelRow` (extracted from `HypnogramWithAxis`), hero card body
+    rewrite, `StageLegend` deletion.
+- `android/app/src/main/java/com/noop/ui/Theme.kt` — new `Metrics` constants.
+- Tests in `android/app/src/test/java/com/noop/ui/` (JUnit4, plain JVM, `org.junit.Assert`).
+
+**Data flow (unchanged upstream):** `selectNight` → model `groupSegments` →
+`realSegments = segments.map { it.stage to (it.end - it.start) / 60f }` (`SleepScreen.kt:2912`) →
+`HeroDisplay.realSegments` → `Hero(display, …, motionEpochs)`. We consume `realSegments` exactly as
+the strip does today; totals/percentages stay on the raw `Stages` numbers — smoothing is render-only.
+
+## Commands
+
+```bash
+# Run one test class (from repo root):
+cd android && ./gradlew :app:testDebugUnitTest --tests "com.noop.ui.StageDisplaySmoothingTest"
+# Compile check (UI tasks):
+cd android && ./gradlew :app:compileDebugKotlin
+# Full unit suite:
+cd android && ./gradlew :app:testDebugUnitTest
+```
+
+Note: this repo uses git worktrees and a shared stash stack — never bare `git stash`.
+
+---
+
+## Task 1: Interval reconstruction (pure logic + tests)
+
+`realSegments` is an ordered list of `(stageName, minutes)` pairs. Rows need absolute positions, so
+walk cumulative fractions across the night span (design §Real-stage nights, item 3).
+
+### Step 1: Write the failing test
+
+Create `android/app/src/test/java/com/noop/ui/StageTimelineIntervalsTest.kt`:
+
+```kotlin
+package com.noop.ui
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Unit tests for [stageIntervalsFromWeights], the pure helper behind the Sleep hero's per-stage
+ * timeline rows (iOS #988 port). Reconstructs (stage, startSec, endSec) intervals from the hero's
+ * ordered `realSegments` weight pairs by walking cumulative fractions across the night span.
+ */
+class StageTimelineIntervalsTest {
+
+    @Test
+    fun walksCumulativeFractions() {
+        // 30 + 60 + 30 = 120 min of weights across a 7200 s span → fractions 1/4, 1/2, 1/4.
+        val ivs = stageIntervalsFromWeights(
+            listOf("light" to 30f, "deep" to 60f, "rem" to 30f),
+            spanSec = 7200.0,
+        )
+        assertEquals(3, ivs.size)
+        assertEquals(0.0, ivs[0].startSec, 1e-9)
+        assertEquals(1800.0, ivs[0].endSec, 1e-9)
+        assertEquals("deep", ivs[1].stage)
+        assertEquals(1800.0, ivs[1].startSec, 1e-9)
+        assertEquals(5400.0, ivs[1].endSec, 1e-9)
+        assertEquals(7200.0, ivs[2].endSec, 1e-9)
+    }
+
+    @Test
+    fun intervalsAreContiguousAndCoverSpan() {
+        val ivs = stageIntervalsFromWeights(
+            listOf("wake" to 5f, "light" to 90f, "deep" to 45f, "light" to 100f, "rem" to 40f),
+            spanSec = 28_800.0,
+        )
+        assertEquals(0.0, ivs.first().startSec, 1e-9)
+        assertEquals(28_800.0, ivs.last().endSec, 1e-6)
+        for (i in 1 until ivs.size) assertEquals(ivs[i - 1].endSec, ivs[i].startSec, 1e-9)
+    }
+
+    @Test
+    fun skipsNonFiniteAndNonPositiveWeights() {
+        val ivs = stageIntervalsFromWeights(
+            listOf("light" to 30f, "deep" to Float.NaN, "rem" to -5f, "light" to 0f, "deep" to 30f),
+            spanSec = 3600.0,
+        )
+        assertEquals(2, ivs.size)
+        assertEquals("light", ivs[0].stage)
+        assertEquals("deep", ivs[1].stage)
+        // The two surviving 30 min weights split the span in half.
+        assertEquals(1800.0, ivs[0].endSec, 1e-9)
+        assertEquals(3600.0, ivs[1].endSec, 1e-9)
+    }
+
+    @Test
+    fun emptyOrDegenerateInputReturnsEmpty() {
+        assertTrue(stageIntervalsFromWeights(emptyList(), 3600.0).isEmpty())
+        assertTrue(stageIntervalsFromWeights(listOf("light" to 30f), 0.0).isEmpty())
+        assertTrue(stageIntervalsFromWeights(listOf("light" to 30f), -10.0).isEmpty())
+        assertTrue(stageIntervalsFromWeights(listOf("light" to 30f), Double.NaN).isEmpty())
+        assertTrue(stageIntervalsFromWeights(listOf("light" to 0f, "deep" to Float.NaN), 3600.0).isEmpty())
+    }
+
+    @Test
+    fun durationSecIsEndMinusStart() {
+        val ivs = stageIntervalsFromWeights(listOf("light" to 30f, "deep" to 30f), 3600.0)
+        assertEquals(1800.0, ivs[0].durationSec, 1e-9)
+    }
+}
+```
+
+### Step 2: Run it — confirm it fails
+
+```bash
+cd android && ./gradlew :app:testDebugUnitTest --tests "com.noop.ui.StageTimelineIntervalsTest"
+```
+
+Expected: **compilation failure** (`stageIntervalsFromWeights` / `StageInterval` unresolved). That is
+the red step.
+
+### Step 3: Implement
+
+In `android/app/src/main/java/com/noop/ui/SleepScreen.kt`, find
+`internal data class PersistedSegment` (currently line 3151) and the `parsePersistedSegments`
+function that follows it. Insert **after** that function:
+
+```kotlin
+// MARK: - Stage timeline logic (iOS #988 port — pure, unit-tested)
+
+/** One contiguous run of a single sleep stage, in seconds from the night's onset. */
+internal data class StageInterval(val stage: String, val startSec: Double, val endSec: Double) {
+    val durationSec: Double get() = endSec - startSec
+}
+
+/**
+ * Reconstruct absolute (stage, startSec, endSec) intervals from the hero's ordered
+ * `realSegments` weight pairs (name, minutes) by walking cumulative fractions across [spanSec]
+ * (design 2026-07-10, §Real-stage nights item 3). Non-finite / non-positive weights are skipped —
+ * they carry no drawable width. Returns [] when nothing is drawable.
+ */
+internal fun stageIntervalsFromWeights(
+    segments: List<Pair<String, Float>>,
+    spanSec: Double,
+): List<StageInterval> {
+    if (segments.isEmpty() || !spanSec.isFinite() || spanSec <= 0.0) return emptyList()
+    val weights = segments.map { (_, wt) -> if (wt.isFinite() && wt > 0f) wt.toDouble() else 0.0 }
+    val total = weights.sum()
+    if (total <= 0.0) return emptyList()
+    val out = ArrayList<StageInterval>(segments.size)
+    var cum = 0.0
+    segments.forEachIndexed { i, (name, _) ->
+        val w = weights[i]
+        if (w <= 0.0) return@forEachIndexed
+        val start = spanSec * (cum / total)
+        cum += w
+        out.add(StageInterval(name, start, spanSec * (cum / total)))
+    }
+    return out
+}
+```
+
+### Step 4: Run the test — confirm it passes
+
+Same command as Step 2. All 5 tests green.
+
+### Step 5: Commit
+
+```bash
+git add -A && git commit -m "feat: sleep stage-interval reconstruction from hero weight pairs (#988 port)"
+```
+
+---
+
+## Task 2: `displaySmoothed` port (pure logic + tests)
+
+Straight port of Swift `Hypnogram.displaySmoothed`
+(`Packages/StrandDesign/Sources/StrandDesign/Hypnogram.swift:92-136`): coalesce adjacent same-stage
+runs, then repeatedly absorb the **shortest** sub-threshold fragment into its **longer** neighbour,
+re-coalescing each pass. Rows use a 90 s floor (design item 2).
+
+### Step 1: Write the failing test
+
+Create `android/app/src/test/java/com/noop/ui/StageDisplaySmoothingTest.kt`:
+
+```kotlin
+package com.noop.ui
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Unit tests for [displaySmoothed], the Kotlin port of Swift `Hypnogram.displaySmoothed`
+ * (Packages/StrandDesign/Sources/StrandDesign/Hypnogram.swift). Fixtures mirror the Swift
+ * semantics: coalesce adjacent same-stage runs, then absorb the SHORTEST sub-threshold fragment
+ * into its LONGER neighbour until every block clears the floor. Render-only smoothing.
+ */
+class StageDisplaySmoothingTest {
+
+    private fun iv(stage: String, start: Double, end: Double) = StageInterval(stage, start, end)
+
+    @Test
+    fun guardsTwoOrFewerIntervalsUntouched() {
+        val two = listOf(iv("light", 0.0, 30.0), iv("deep", 30.0, 60.0))
+        assertEquals(two, displaySmoothed(two, 90.0))   // Swift: guard sorted.count > 2
+    }
+
+    @Test
+    fun coalescesAdjacentSameStageRuns() {
+        val out = displaySmoothed(
+            listOf(
+                iv("light", 0.0, 300.0),
+                iv("light", 300.0, 600.0),   // same stage, zero-length seam → merged
+                iv("deep", 600.0, 900.0),
+            ),
+            minDurationSec = 90.0,
+        )
+        assertEquals(2, out.size)
+        assertEquals(iv("light", 0.0, 600.0), out[0])
+        assertEquals(iv("deep", 600.0, 900.0), out[1])
+    }
+
+    @Test
+    fun absorbsFlickerIntoLongerNeighbour() {
+        // A 30 s deep flicker between 600 s light (longer) and 300 s rem → absorbed into light.
+        val out = displaySmoothed(
+            listOf(
+                iv("light", 0.0, 600.0),
+                iv("deep", 600.0, 630.0),
+                iv("rem", 630.0, 930.0),
+            ),
+            minDurationSec = 90.0,
+        )
+        assertEquals(2, out.size)
+        assertEquals(iv("light", 0.0, 630.0), out[0])
+        assertEquals(iv("rem", 630.0, 930.0), out[1])
+    }
+
+    @Test
+    fun absorptionReCoalescesBridgedRuns() {
+        // light | 30s wake | light → wake absorbed, then the two light runs coalesce into ONE block.
+        val out = displaySmoothed(
+            listOf(
+                iv("light", 0.0, 600.0),
+                iv("wake", 600.0, 630.0),
+                iv("light", 630.0, 1200.0),
+            ),
+            minDurationSec = 90.0,
+        )
+        assertEquals(1, out.size)
+        assertEquals(iv("light", 0.0, 1200.0), out[0])
+    }
+
+    @Test
+    fun edgeFragmentAbsorbsIntoOnlyNeighbour() {
+        val out = displaySmoothed(
+            listOf(
+                iv("wake", 0.0, 30.0),      // leading flicker: only neighbour is `light`
+                iv("light", 30.0, 900.0),
+                iv("deep", 900.0, 1800.0),
+            ),
+            minDurationSec = 90.0,
+        )
+        assertEquals(2, out.size)
+        assertEquals(iv("light", 0.0, 900.0), out[0])
+    }
+
+    @Test
+    fun combOfEpochFlickersCollapses() {
+        // 30 s-epoch comb (the original complaint): alternating light/deep flickers inside a light
+        // night collapse to a single light block — no sub-90 s block survives.
+        val comb = buildList {
+            add(iv("light", 0.0, 1200.0))
+            var t = 1200.0
+            repeat(6) {
+                add(iv("deep", t, t + 30.0)); t += 30.0
+                add(iv("light", t, t + 30.0)); t += 30.0
+            }
+            add(iv("light", t, t + 1200.0))
+        }
+        val out = displaySmoothed(comb, 90.0)
+        assertTrue(out.all { it.durationSec >= 90.0 })
+        assertEquals(1, out.size)
+        assertEquals("light", out[0].stage)
+        assertEquals(0.0, out[0].startSec, 1e-9)
+        assertEquals(comb.last().endSec, out[0].endSec, 1e-9)
+    }
+
+    @Test
+    fun zeroFloorReturnsCoalescedInputUnsmoothed() {
+        val raw = listOf(iv("light", 0.0, 10.0), iv("deep", 10.0, 20.0), iv("rem", 20.0, 30.0))
+        assertEquals(raw, displaySmoothed(raw, 0.0))   // smoothingSeconds: 0 → raw timeline
+    }
+
+    @Test
+    fun totalsPreserved() {
+        val raw = listOf(
+            iv("light", 0.0, 600.0), iv("deep", 600.0, 660.0),
+            iv("rem", 660.0, 1500.0), iv("wake", 1500.0, 1530.0), iv("light", 1530.0, 3000.0),
+        )
+        val out = displaySmoothed(raw, 90.0)
+        assertEquals(0.0, out.first().startSec, 1e-9)
+        assertEquals(3000.0, out.last().endSec, 1e-9)
+        for (i in 1 until out.size) assertEquals(out[i - 1].endSec, out[i].startSec, 1e-9)
+    }
+}
+```
+
+### Step 2: Run it — confirm it fails
+
+```bash
+cd android && ./gradlew :app:testDebugUnitTest --tests "com.noop.ui.StageDisplaySmoothingTest"
+```
+
+Expected: compile failure (`displaySmoothed` unresolved).
+
+### Step 3: Implement
+
+In `SleepScreen.kt`, directly after `stageIntervalsFromWeights` (Task 1), add:
+
+```kotlin
+/**
+ * Display-time smoothing — a straight port of Swift `Hypnogram.displaySmoothed` (WHOOP-style,
+ * Packages/StrandDesign/Sources/StrandDesign/Hypnogram.swift:92). The on-device stager emits
+ * 30 s-epoch runs, so a real night arrives as 60–100 fragments; brief flickers are absorbed into
+ * their surroundings AT DISPLAY TIME. Render-only: totals, percentages and stored data are
+ * computed from the raw segments elsewhere and are untouched. Pass minDurationSec = 0 for raw.
+ */
+internal fun displaySmoothed(
+    intervals: List<StageInterval>,
+    minDurationSec: Double,
+): List<StageInterval> {
+    if (intervals.size <= 2 || minDurationSec <= 0.0) return intervals   // Swift: guard count > 2
+
+    // Coalesce adjacent same-stage runs (also bridges the zero-length seams between epochs).
+    fun coalesce(ivs: List<StageInterval>): MutableList<StageInterval> {
+        val out = mutableListOf<StageInterval>()
+        for (iv in ivs) {
+            val last = out.lastOrNull()
+            if (last != null && last.stage == iv.stage && iv.startSec - last.endSec < 1.0) {
+                out[out.size - 1] = StageInterval(last.stage, last.startSec, iv.endSec)
+            } else {
+                out.add(iv)
+            }
+        }
+        return out
+    }
+
+    var ivs = coalesce(intervals)
+    // Repeatedly absorb the shortest sub-threshold fragment into its longer neighbour,
+    // re-coalescing after each pass, until every remaining block clears the threshold.
+    while (ivs.size > 1) {
+        val idx = ivs.indices
+            .filter { ivs[it].durationSec < minDurationSec }
+            .minByOrNull { ivs[it].durationSec } ?: break
+        val victim = ivs[idx]
+        val prev = if (idx > 0) ivs[idx - 1] else null
+        val next = if (idx < ivs.size - 1) ivs[idx + 1] else null
+        when {
+            prev != null && next != null ->
+                // Absorb into the longer neighbour so the dominant surrounding stage wins.
+                if (prev.durationSec >= next.durationSec) {
+                    ivs[idx - 1] = StageInterval(prev.stage, prev.startSec, victim.endSec)
+                } else {
+                    ivs[idx + 1] = StageInterval(next.stage, victim.startSec, next.endSec)
+                }
+            prev != null -> ivs[idx - 1] = StageInterval(prev.stage, prev.startSec, victim.endSec)
+            next != null -> ivs[idx + 1] = StageInterval(next.stage, victim.startSec, next.endSec)
+            else -> break
+        }
+        ivs.removeAt(idx)
+        ivs = coalesce(ivs)
+    }
+    return ivs
+}
+```
+
+### Step 4: Run the test — confirm it passes
+
+Same command. All 8 tests green. Also re-run Task 1's class to confirm nothing regressed.
+
+### Step 5: Commit
+
+```bash
+git add -A && git commit -m "feat: port Hypnogram.displaySmoothed to Kotlin for the sleep timeline rows"
+```
+
+---
+
+## Task 3: Per-row span extraction (pure logic + tests)
+
+Each row needs the (fracStart, fracWidth) spans of ONE stage. Segment names come from the stager as
+lowercase (`"wake"`, `"light"`, …) while rows are labeled `"Awake"` etc.; the existing
+`stageColorFor` (SleepScreen.kt:1405) already treats `"awake"`/`"wake"` as aliases — match that.
+
+### Step 1: Write the failing test
+
+Create `android/app/src/test/java/com/noop/ui/StageRowSpansTest.kt`:
+
+```kotlin
+package com.noop.ui
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Unit tests for [canonicalStage] + [stageRowSpans]: the (fracStart, fracWidth) spans of one
+ * stage's intervals within the night, feeding a single StageRowTrack canvas per timeline row.
+ */
+class StageRowSpansTest {
+
+    private val ivs = listOf(
+        StageInterval("wake", 0.0, 360.0),
+        StageInterval("light", 360.0, 1800.0),
+        StageInterval("deep", 1800.0, 2520.0),
+        StageInterval("light", 2520.0, 3240.0),
+        StageInterval("Awake", 3240.0, 3600.0),
+    )
+
+    @Test
+    fun extractsFractionalSpansForOneStage() {
+        val spans = stageRowSpans(ivs, "Light", 3600.0)
+        assertEquals(2, spans.size)
+        assertEquals(0.1f, spans[0].first, 1e-6f)
+        assertEquals(0.4f, spans[0].second, 1e-6f)
+        assertEquals(0.7f, spans[1].first, 1e-6f)
+        assertEquals(0.2f, spans[1].second, 1e-6f)
+    }
+
+    @Test
+    fun awakeAndWakeAreAliases() {
+        // Row label "Awake" must catch both the "wake" and "Awake" segments (stageColorFor parity).
+        val spans = stageRowSpans(ivs, "Awake", 3600.0)
+        assertEquals(2, spans.size)
+        assertEquals(0.0f, spans[0].first, 1e-6f)
+        assertEquals(0.9f, spans[1].first, 1e-6f)
+    }
+
+    @Test
+    fun matchIsCaseAndWhitespaceInsensitive() {
+        assertEquals("deep", canonicalStage("  Deep "))
+        assertEquals("awake", canonicalStage("WAKE"))
+        assertEquals("awake", canonicalStage("Awake"))
+        assertEquals("rem", canonicalStage("REM"))
+        assertEquals(1, stageRowSpans(ivs, "DEEP", 3600.0).size)
+    }
+
+    @Test
+    fun absentStageOrDegenerateSpanIsEmpty() {
+        assertTrue(stageRowSpans(ivs, "REM", 3600.0).isEmpty())
+        assertTrue(stageRowSpans(ivs, "Deep", 0.0).isEmpty())
+    }
+}
+```
+
+### Step 2: Run it — confirm it fails
+
+```bash
+cd android && ./gradlew :app:testDebugUnitTest --tests "com.noop.ui.StageRowSpansTest"
+```
+
+### Step 3: Implement
+
+In `SleepScreen.kt`, directly after `displaySmoothed` (Task 2), add:
+
+```kotlin
+/** Canonical stage key: trims, lowercases, and folds the "wake"/"awake" alias (stageColorFor parity). */
+internal fun canonicalStage(name: String): String {
+    val n = name.trim().lowercase()
+    return if (n == "wake") "awake" else n
+}
+
+/**
+ * The (startFraction, widthFraction) spans of [rowStage]'s intervals within the night — one entry
+ * per solid segment in that stage's timeline row track. Fractions of [spanSec]; the draw side
+ * applies the min-width floor and canvas clamping.
+ */
+internal fun stageRowSpans(
+    intervals: List<StageInterval>,
+    rowStage: String,
+    spanSec: Double,
+): List<Pair<Float, Float>> {
+    if (spanSec <= 0.0 || !spanSec.isFinite()) return emptyList()
+    val key = canonicalStage(rowStage)
+    return intervals
+        .filter { canonicalStage(it.stage) == key }
+        .map { iv -> (iv.startSec / spanSec).toFloat() to (iv.durationSec / spanSec).toFloat() }
+}
+```
+
+### Step 4: Run the test — confirm it passes
+
+Same command; then run all three new classes together:
+
+```bash
+cd android && ./gradlew :app:testDebugUnitTest --tests "com.noop.ui.Stage*"
+```
+
+### Step 5: Commit
+
+```bash
+git add -A && git commit -m "feat: per-stage row span extraction for the sleep timeline rows"
+```
+
+---
+
+## Task 4: `Metrics` constants (Theme.kt)
+
+### Step 1: Implement
+
+In `android/app/src/main/java/com/noop/ui/Theme.kt`, find (currently lines 400-401):
+
+```kotlin
+    val stageStripHeight = 34.dp
+    val motionStripHeight = 40.dp   // #407 — the subordinate movement/restlessness trace under the hypnogram
+```
+
+Insert directly after those two lines:
+
+```kotlin
+    // iOS #988 port — WHOOP-style per-stage sleep timeline rows (design 2026-07-10).
+    val stageRowTrackHeight = 20.dp  // hatched night track + solid stage segments
+    val stageRowCorner = 10.dp       // row background rounding
+    val stageRowPadH = 10.dp         // row inner horizontal padding — MotionStrip/axis share it so epochs align
+    val stageRowPadV = 8.dp          // row inner vertical padding
+    val stageSegMinWidth = 2.dp      // width floor so a brief fragment reads as a block, not a hairline
+    val stageSegCorner = 1.5.dp      // solid segment rounding
+    val stageInsightHeight = 36.dp   // fixed insight slot height — selection never reflows the card
+```
+
+### Step 2: Verify it compiles
+
+```bash
+cd android && ./gradlew :app:compileDebugKotlin
+```
+
+### Step 3: Commit
+
+```bash
+git add -A && git commit -m "feat: Metrics constants for the sleep stage-timeline rows"
+```
+
+---
+
+## Task 5: Timeline composables (UI)
+
+All in `android/app/src/main/java/com/noop/ui/SleepScreen.kt`. No unit tests (Compose UI); the
+verification gate is `compileDebugKotlin` + Task 7's manual checklist.
+
+### Step 1: Add one import
+
+In the import block (alphabetical; near `import androidx.compose.ui.geometry.Size`, line ~61), add:
+
+```kotlin
+import androidx.compose.ui.graphics.drawscope.clipRect
+```
+
+(Everything else the new code uses — `clip`, `border`, `clickable`, `CornerRadius`, `Offset`,
+`Size`, `semantics`, `contentDescription`, `roundToInt`, `Locale` — is already imported.)
+
+### Step 2: Extract `ClockLabelRow` from `HypnogramWithAxis`
+
+`HypnogramWithAxis` (line ~1245) ends with an onset · midpoint · wake label `Row` guarded by
+`if (showsAxis && onsetTs != null && wakeTs != null) { … }`. Replace the **entire contents of that
+`if` block** — the `val onset = clockTimeLabel(onsetTs)` / `val mid = …` / `val wake = …`
+declarations and the whole `Row(modifier = Modifier.fillMaxWidth()) { … }` that follows them —
+with a single call:
+
+```kotlin
+            ClockLabelRow(onsetTs, wakeTs)
+```
+
+Then add the extracted composable **immediately after** `HypnogramWithAxis`'s closing brace,
+moving the old body verbatim:
+
+```kotlin
+/**
+ * The onset · midpoint · wake clock-label row under a night timeline. Extracted from
+ * [HypnogramWithAxis] so the #988 stage-timeline rows share the exact same axis rendering.
+ */
+@Composable
+private fun ClockLabelRow(onsetTs: Long, wakeTs: Long) {
+    val onset = clockTimeLabel(onsetTs)
+    val mid = clockTimeLabel((onsetTs + wakeTs) / 2L)
+    val wake = clockTimeLabel(wakeTs)
+    Row(modifier = Modifier.fillMaxWidth()) {
+        Text(
+            onset,
+            style = NoopType.footnote,
+            color = Palette.textTertiary,
+            textAlign = TextAlign.Start,
+            maxLines = 1,
+            modifier = Modifier.weight(1f),
+        )
+        Text(
+            mid,
+            style = NoopType.footnote,
+            color = Palette.textTertiary,
+            textAlign = TextAlign.Center,
+            overflow = TextOverflow.Ellipsis,
+            maxLines = 1,
+            modifier = Modifier.weight(1f),
+        )
+        Text(
+            wake,
+            style = NoopType.footnote,
+            color = Palette.textTertiary,
+            textAlign = TextAlign.End,
+            maxLines = 1,
+            modifier = Modifier.weight(1f),
+        )
+    }
+}
+```
+
+### Step 3: Add the timeline composables
+
+Insert the following block **after** `ClockLabelRow` (before the `MotionStrip` doc comment):
+
+```kotlin
+/** 90 s display floor for the stage rows — rows tolerate fine texture, so 90 s, not the staircase's 300 s. */
+private const val STAGE_ROW_SMOOTH_SEC = 90.0
+
+/**
+ * iOS #988 port — the WHOOP-style per-stage timeline stack that replaces the flat hypnogram strip
+ * for real-stage nights. Four tappable rows in WHOOP order (AWAKE · LIGHT · DEEP · REM), each a
+ * hatched full-night track with solid segments on the shared onset→wake axis; MotionStrip and the
+ * clock-label axis sit under the rows on the SAME timeline; a fixed-height insight slot closes the
+ * stack. The rows ARE the legend — no dot row, no footer. Mirrors SleepView.stageTimeline.
+ */
+@Composable
+private fun StageTimeline(
+    realSegments: List<Pair<String, Float>>,
+    s: Stages,
+    onsetTs: Long?,
+    wakeTs: Long?,
+    motionEpochs: List<Double>,
+) {
+    // Night span: the session window when we have one (the clock axis uses the same span), else
+    // the segments' own summed minutes — the fractions are identical either way.
+    val weightSec = realSegments.sumOf { (_, wt) -> if (wt.isFinite() && wt > 0f) wt.toDouble() * 60.0 else 0.0 }
+    val spanSec = if (onsetTs != null && wakeTs != null && wakeTs > onsetTs) {
+        (wakeTs - onsetTs).toDouble()
+    } else {
+        weightSec
+    }
+    val intervals = remember(realSegments, spanSec) {
+        displaySmoothed(stageIntervalsFromWeights(realSegments, spanSec), STAGE_ROW_SMOOTH_SEC)
+    }
+    // Tap-to-highlight; keyed on the night's segments so navigating nights clears the selection.
+    var selectedStage by remember(realSegments) { mutableStateOf<String?>(null) }
+
+    Column(verticalArrangement = Arrangement.spacedBy(Metrics.space8)) {
+        listOf(
+            Triple("Awake", s.awake, Palette.sleepAwake),
+            Triple("Light", s.light, Palette.sleepLight),
+            Triple("Deep", s.deep, Palette.sleepDeep),
+            Triple("REM", s.rem, Palette.sleepREM),
+        ).forEach { (label, minutes, color) ->
+            StageTimelineRow(
+                label = label,
+                minutes = minutes,
+                total = s.total,
+                color = color,
+                spans = stageRowSpans(intervals, label, spanSec),
+                selected = selectedStage == label,
+                dimmed = selectedStage != null && selectedStage != label,
+                onTap = { selectedStage = if (selectedStage == label) null else label },
+            )
+        }
+        // #407 — MotionStrip component + data path untouched; relocated UNDER the rows on the SAME
+        // timeline. Same inner insets as the rows' tracks so epochs don't skew against the segments.
+        Box(modifier = Modifier.padding(horizontal = Metrics.stageRowPadH)) {
+            MotionStrip(motionEpochs)
+        }
+        if (onsetTs != null && wakeTs != null) {
+            Box(modifier = Modifier.padding(horizontal = Metrics.stageRowPadH)) {
+                ClockLabelRow(onsetTs, wakeTs)
+            }
+        }
+        StageInsight(selectedStage, s)
+    }
+}
+
+/**
+ * One per-stage timeline row: STAGE overline + coloured % + right-aligned duration over a hatched
+ * full-night track with the stage's solid segments. Selected row gets a hairlineStrong stroke;
+ * when ANOTHER row is selected this row's segments and % dim to tertiary. One collapsed a11y node —
+ * "Awake: 49 min, 10 percent of the night". Mirrors SleepView.stageTimelineRow.
+ */
+@Composable
+private fun StageTimelineRow(
+    label: String,
+    minutes: Double,
+    total: Double,
+    color: Color,
+    spans: List<Pair<Float, Float>>,
+    selected: Boolean,
+    dimmed: Boolean,
+    onTap: () -> Unit,
+) {
+    val percent = if (total > 0.0) (minutes / total * 100.0).roundToInt() else 0
+    val segColor = if (dimmed) Palette.textTertiary.copy(alpha = 0.55f) else color
+    val pctColor = if (dimmed) Palette.textTertiary else color
+    val shape = RoundedCornerShape(Metrics.stageRowCorner)
+    Column(
+        verticalArrangement = Arrangement.spacedBy(Metrics.space6),
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(shape)
+            .background(Palette.textPrimary.copy(alpha = 0.045f))
+            .then(if (selected) Modifier.border(1.5.dp, Palette.hairlineStrong, shape) else Modifier)
+            .clickable(onClickLabel = "Highlights this stage on the sleep chart", onClick = onTap)
+            .padding(horizontal = Metrics.stageRowPadH, vertical = Metrics.stageRowPadV)
+            .semantics(mergeDescendants = true) {
+                contentDescription = "$label: ${durationText(minutes)}, $percent percent of the night"
+            },
+    ) {
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Text(
+                label.uppercase(Locale.getDefault()),
+                style = NoopType.overline,
+                color = Palette.textPrimary,
+                maxLines = 1,
+            )
+            Spacer(modifier = Modifier.width(Metrics.space8))
+            Text("$percent%", style = NoopType.captionNumber, color = pctColor, maxLines = 1)
+            Spacer(modifier = Modifier.weight(1f))
+            Text(
+                durationText(minutes),
+                style = NoopType.captionNumber,
+                color = Palette.textPrimary,
+                maxLines = 1,
+            )
+        }
+        StageRowTrack(spans = spans, color = segColor)
+    }
+}
+
+/**
+ * The row's track, drawn in a SINGLE Canvas (PERF: a fragmented night must not become hundreds of
+ * composables — Charts.kt hoist convention): a recessed full-night base with faint diagonal
+ * hatching ("no segment here" reads as "elsewhere in the night", not missing data), then the
+ * stage's solid rounded segments with a width floor, clamped so floored widths stay on-canvas
+ * (same #36 lesson as HypnogramWithAxis).
+ */
+@Composable
+private fun StageRowTrack(spans: List<Pair<Float, Float>>, color: Color) {
+    Canvas(modifier = Modifier.fillMaxWidth().height(Metrics.stageRowTrackHeight)) {
+        val w = size.width
+        val h = size.height
+        if (w <= 0f || h <= 0f) return@Canvas
+
+        val trackRadius = CornerRadius(Metrics.stageSegCorner.toPx(), Metrics.stageSegCorner.toPx())
+        drawRoundRect(color = Palette.surfaceInset, size = Size(w, h), cornerRadius = trackRadius)
+        clipRect(0f, 0f, w, h) {
+            val step = 6.dp.toPx()
+            var x = -h
+            while (x < w) {
+                drawLine(
+                    color = Palette.hairline,
+                    start = Offset(x, h),
+                    end = Offset(x + h, 0f),
+                    strokeWidth = 1f,
+                )
+                x += step
+            }
+        }
+
+        val minW = Metrics.stageSegMinWidth.toPx()
+        val segRadius = CornerRadius(Metrics.stageSegCorner.toPx(), Metrics.stageSegCorner.toPx())
+        spans.forEach { (fracStart, fracWidth) ->
+            if (!fracStart.isFinite() || !fracWidth.isFinite() || fracWidth <= 0f) return@forEach
+            val segW = maxOf(w * fracWidth, minW).coerceAtMost(w)
+            val x0 = (w * fracStart).coerceIn(0f, w - segW)
+            drawRoundRect(
+                color = color,
+                topLeft = Offset(x0, 0f),
+                size = Size(segW, h),
+                cornerRadius = segRadius,
+            )
+        }
+    }
+}
+
+/**
+ * Fixed-height per-stage insight slot under the axis: with a stage selected, that stage tonight;
+ * otherwise the quiet "tap a row" hint. Fixed height so selection never reflows the card. The
+ * 30-day typical-range compare is a follow-up — no such repo call exists on Android yet (design
+ * §Real-stage nights item 6).
+ */
+@Composable
+private fun StageInsight(selectedStage: String?, s: Stages) {
+    val text = when (selectedStage) {
+        "Awake" -> stageInsightLine("Awake", s.awake, s.total)
+        "Light" -> stageInsightLine("Light", s.light, s.total)
+        "Deep" -> stageInsightLine("Deep", s.deep, s.total)
+        "REM" -> stageInsightLine("REM", s.rem, s.total)
+        else -> "Tap a stage to highlight it across the night."
+    }
+    Box(
+        modifier = Modifier.fillMaxWidth().height(Metrics.stageInsightHeight),
+        contentAlignment = Alignment.CenterStart,
+    ) {
+        Text(text, style = NoopType.footnote, color = Palette.textTertiary, maxLines = 2)
+    }
+}
+
+private fun stageInsightLine(label: String, minutes: Double, total: Double): String {
+    val percent = if (total > 0.0) (minutes / total * 100.0).roundToInt() else 0
+    return "$label tonight: ${durationText(minutes)} — $percent% of the night."
+}
+```
+
+### Step 4: Compile
+
+```bash
+cd android && ./gradlew :app:compileDebugKotlin
+```
+
+Fix only mechanical issues (missing import, typo). If `NoopType.overline` needs the tracking
+applied separately, copy exactly what `StageBreakdownRow` (line ~1180) does — it uses
+`NoopType.overline` directly.
+
+### Step 5: Commit
+
+```bash
+git add -A && git commit -m "feat: StageTimeline row composables for the sleep hero (iOS #988 port)"
+```
+
+---
+
+## Task 6: Hero card body rewrite + `StageLegend` deletion
+
+### Step 1: Rewrite the card body
+
+In `SleepScreen.kt`, inside `Hero` (line ~772), find the block starting at
+`val s = display.stages` (line ~811) through the end of that `ChartCard`'s trailing lambda
+(the `}` after the `"No stage breakdown for this night."` `Text`, line ~862). Today it reads:
+
+```kotlin
+            val s = display.stages
+            // After a bed/wake edit the session window is the source of truth for time-in-bed,
+            // so the subtitle tracks the edit even before the stage minutes are recomputed. Uses the
+            // EFFECTIVE onset so a hand-edited bedtime is reflected. (#160 / PR #395)
+            val inBedMin = session?.let { (it.endTs - it.effectiveStartTs) / 60.0 } ?: s.total
+            ChartCard(
+                title = "Stage breakdown",
+                subtitle = "${durationText(inBedMin)} in bed · ${display.efficiencyText} efficiency" +
+                    (if (display.realSegments != null) " · approx. stages (on-device)" else ""),
+                trailing = durationText(s.asleep),
+                tint = Palette.restColor,
+                footer = {
+                    // WHOOP-style stage rows in the NOOP pip language: swatch + UPPERCASE stage +
+                    // coloured % + a segmented PipBar of the share-of-night + right-aligned duration.
+                    // Same minutes/percentages the old "label · value" footer carried — no new numbers.
+                    // Mirrors the macOS SleepView.stageBreakdownRows. (PipBar)
+                    StageBreakdownRows(s)
+                },
+            ) {
+                // True per-epoch segments when the stager persisted them; else the reconstructed
+                // architecture: light → deep → light → rem → light → awake.
+                val segments = display.realSegments ?: stageSegments(s)
+                if (segments.isNotEmpty()) {
+                    Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                        // Hero strip with the band-min-thickness floor (so a short Awake reads as a
+                        // bar, not a tick) + an onset · midpoint · wake time axis when the session
+                        // gives clock times. Mirrors the Swift Hypnogram(showsTimeAxis:).
+                        HypnogramWithAxis(
+                            stages = segments,
+                            onsetTs = session?.effectiveStartTs,
+                            wakeTs = session?.endTs,
+                        )
+                        // #407 — subordinate movement/restlessness trace UNDER the hypnogram, on the SAME
+                        // timeline, for the SAME main-night GROUP blocks the hero resolved (selectNight's
+                        // group). Honest empty state when no fragment has persisted motion (older rows).
+                        MotionStrip(motionEpochs)
+                        Row(horizontalArrangement = Arrangement.spacedBy(Metrics.space16)) {
+                            StageLegend("Deep", Palette.sleepDeep)
+                            StageLegend("Light", Palette.sleepLight)
+                            StageLegend("REM", Palette.sleepREM)
+                            StageLegend("Awake", Palette.sleepAwake)
+                        }
+                    }
+                } else {
+                    Text(
+                        "No stage breakdown for this night.",
+                        style = NoopType.subhead,
+                        color = Palette.textTertiary,
+                    )
+                }
+            }
+```
+
+Replace it with:
+
+```kotlin
+            val s = display.stages
+            // After a bed/wake edit the session window is the source of truth for time-in-bed,
+            // so the subtitle tracks the edit even before the stage minutes are recomputed. Uses the
+            // EFFECTIVE onset so a hand-edited bedtime is reflected. (#160 / PR #395)
+            val inBedMin = session?.let { (it.endTs - it.effectiveStartTs) / 60.0 } ?: s.total
+            val subtitle = "${durationText(inBedMin)} in bed · ${display.efficiencyText} efficiency" +
+                (if (display.realSegments != null) " · approx. stages (on-device)" else "")
+            // iOS #988 port: true per-epoch segments (≥ 2 — a single run has no transitions to lay
+            // out) get the per-stage timeline rows; the rows ARE the legend, so no footer. Anything
+            // else keeps the honest proportional strip + StageBreakdownRows footer.
+            val real = display.realSegments?.takeIf { it.size >= 2 }
+            if (real != null) {
+                ChartCard(
+                    title = "Stage breakdown",
+                    subtitle = subtitle,
+                    trailing = durationText(s.asleep),
+                    tint = Palette.restColor,
+                    footer = {},
+                ) {
+                    StageTimeline(
+                        realSegments = real,
+                        s = s,
+                        onsetTs = session?.effectiveStartTs,
+                        wakeTs = session?.endTs,
+                        motionEpochs = motionEpochs,
+                    )
+                }
+            } else {
+                ChartCard(
+                    title = "Stage breakdown",
+                    subtitle = subtitle,
+                    trailing = durationText(s.asleep),
+                    tint = Palette.restColor,
+                    footer = { StageBreakdownRows(s) },
+                ) {
+                    // Reconstructed architecture (light → deep → light → rem → light → awake) as the
+                    // flat proportional strip. No MotionStrip and no fake steps here: invented
+                    // architecture has no genuine timeline to anchor to (mirrors the iOS else-branch).
+                    val segments = stageSegments(s)
+                    if (segments.isNotEmpty()) {
+                        HypnogramWithAxis(
+                            stages = segments,
+                            onsetTs = session?.effectiveStartTs,
+                            wakeTs = session?.endTs,
+                        )
+                    } else {
+                        Text(
+                            "No stage breakdown for this night.",
+                            style = NoopType.subhead,
+                            color = Palette.textTertiary,
+                        )
+                    }
+                }
+            }
+```
+
+Behavioral notes (all from the design doc):
+- The `display == null` → "No stage data recorded for this night." branch above this block is untouched.
+- The subtitle marker logic is byte-identical to today (appends iff `display.realSegments != null`),
+  so a 1-segment on-device night falling into the fallback branch still reads "approx. stages (on-device)".
+- `MotionStrip` renders only in the timeline branch (inside `StageTimeline`, Task 5) — the
+  proportional fallback bar has no timeline for epochs to anchor to.
+
+### Step 2: Delete `StageLegend`
+
+Delete the whole `StageLegend` composable (line ~1898, the `@Composable private fun
+StageLegend(label: String, color: Color) { … }` block). It was only called from the four lines
+removed in Step 1 — verify before deleting:
+
+```bash
+grep -rn "StageLegend(" android/app/src/
+```
+
+Expected: no hits outside the definition itself. Leave `Metrics.legendSwatch` alone (check usages —
+if `grep -rn "legendSwatch" android/app/src/main` shows only Theme.kt after the deletion, remove the
+constant too and note it in the commit).
+
+### Step 3: Compile + full unit suite
+
+```bash
+cd android && ./gradlew :app:compileDebugKotlin && ./gradlew :app:testDebugUnitTest
+```
+
+Everything green, including the pre-existing `SleepStageSegmentsTest`.
+
+### Step 4: Commit
+
+```bash
+git add -A && git commit -m "feat: sleep hero uses per-stage timeline rows for real-stage nights (iOS #988 parity)"
+```
+
+---
+
+## Task 7: Verification
+
+### Automated
+
+```bash
+cd android && ./gradlew :app:testDebugUnitTest && ./gradlew :app:compileDebugKotlin
+```
+
+### Manual (emulator or device, debug build)
+
+1. **Real-stage night** (a night the on-device stager persisted — any recent strap night):
+   - Four rows in order AWAKE · LIGHT · DEEP · REM; percents/durations match the old footer's numbers.
+   - Segments read as clean blocks (no 30 s comb); track hatching visible where the stage is absent.
+   - MotionStrip sits under the rows, epochs visually aligned with segment edges (check first/last
+     epoch against onset/wake); clock labels onset · midpoint · wake under it.
+   - Tap DEEP: other rows' segments and % dim, DEEP row gets a stroke, insight slot shows
+     "Deep tonight: …". Tap again: selection clears, hint returns, card height does NOT change.
+   - Navigate to another night and back: selection cleared.
+2. **Fallback night** (imported night, e.g. a Health Connect / minutes-only import): flat strip +
+   `StageBreakdownRows` footer, "approx. stages (on-device)" absent, **no** MotionStrip, no dot legend.
+3. **Honest empties**: night with no stage data → "No stage data recorded for this night."; real
+   night with no persisted motion → MotionStrip's "No movement detail for this night." note.
+4. **Long-press / a11y**: with TalkBack, each row reads as one node — "Awake: 49 min, 10 percent of
+   the night", action hint "Highlights this stage on the sleep chart".
+5. **Theme**: check Classic and default palettes (row bg is a `textPrimary` alpha, must work on both).
+
+### Wrap up
+
+- `git log --oneline` — one commit per task, conventional prefixes.
+- Update the design doc only if implementation deviated (note the deviation inline).

--- a/docs/superpowers/plans/2026-07-10-android-sleep-stage-timeline.md
+++ b/docs/superpowers/plans/2026-07-10-android-sleep-stage-timeline.md
@@ -42,11 +42,11 @@ the strip does today; totals/percentages stay on the raw `Stages` numbers — sm
 
 ```bash
 # Run one test class (from repo root):
-cd android && ./gradlew :app:testDebugUnitTest --tests "com.noop.ui.StageDisplaySmoothingTest"
+cd android && ./gradlew :app:testFullDebugUnitTest --tests "com.noop.ui.StageDisplaySmoothingTest"
 # Compile check (UI tasks):
-cd android && ./gradlew :app:compileDebugKotlin
+cd android && ./gradlew :app:compileFullDebugKotlin
 # Full unit suite:
-cd android && ./gradlew :app:testDebugUnitTest
+cd android && ./gradlew :app:testFullDebugUnitTest
 ```
 
 Note: this repo uses git worktrees and a shared stash stack — never bare `git stash`.
@@ -137,7 +137,7 @@ class StageTimelineIntervalsTest {
 ### Step 2: Run it — confirm it fails
 
 ```bash
-cd android && ./gradlew :app:testDebugUnitTest --tests "com.noop.ui.StageTimelineIntervalsTest"
+cd android && ./gradlew :app:testFullDebugUnitTest --tests "com.noop.ui.StageTimelineIntervalsTest"
 ```
 
 Expected: **compilation failure** (`stageIntervalsFromWeights` / `StageInterval` unresolved). That is
@@ -334,7 +334,7 @@ class StageDisplaySmoothingTest {
 ### Step 2: Run it — confirm it fails
 
 ```bash
-cd android && ./gradlew :app:testDebugUnitTest --tests "com.noop.ui.StageDisplaySmoothingTest"
+cd android && ./gradlew :app:testFullDebugUnitTest --tests "com.noop.ui.StageDisplaySmoothingTest"
 ```
 
 Expected: compile failure (`displaySmoothed` unresolved).
@@ -482,7 +482,7 @@ class StageRowSpansTest {
 ### Step 2: Run it — confirm it fails
 
 ```bash
-cd android && ./gradlew :app:testDebugUnitTest --tests "com.noop.ui.StageRowSpansTest"
+cd android && ./gradlew :app:testFullDebugUnitTest --tests "com.noop.ui.StageRowSpansTest"
 ```
 
 ### Step 3: Implement
@@ -519,7 +519,7 @@ internal fun stageRowSpans(
 Same command; then run all three new classes together:
 
 ```bash
-cd android && ./gradlew :app:testDebugUnitTest --tests "com.noop.ui.Stage*"
+cd android && ./gradlew :app:testFullDebugUnitTest --tests "com.noop.ui.Stage*"
 ```
 
 ### Step 5: Commit
@@ -557,7 +557,7 @@ Insert directly after those two lines:
 ### Step 2: Verify it compiles
 
 ```bash
-cd android && ./gradlew :app:compileDebugKotlin
+cd android && ./gradlew :app:compileFullDebugKotlin
 ```
 
 ### Step 3: Commit
@@ -841,7 +841,7 @@ private fun stageInsightLine(label: String, minutes: Double, total: Double): Str
 ### Step 4: Compile
 
 ```bash
-cd android && ./gradlew :app:compileDebugKotlin
+cd android && ./gradlew :app:compileFullDebugKotlin
 ```
 
 Fix only mechanical issues (missing import, typo). If `NoopType.overline` needs the tracking
@@ -1001,7 +1001,7 @@ constant too and note it in the commit).
 ### Step 3: Compile + full unit suite
 
 ```bash
-cd android && ./gradlew :app:compileDebugKotlin && ./gradlew :app:testDebugUnitTest
+cd android && ./gradlew :app:compileFullDebugKotlin && ./gradlew :app:testFullDebugUnitTest
 ```
 
 Everything green, including the pre-existing `SleepStageSegmentsTest`.
@@ -1019,7 +1019,7 @@ git add -A && git commit -m "feat: sleep hero uses per-stage timeline rows for r
 ### Automated
 
 ```bash
-cd android && ./gradlew :app:testDebugUnitTest && ./gradlew :app:compileDebugKotlin
+cd android && ./gradlew :app:testFullDebugUnitTest && ./gradlew :app:compileFullDebugKotlin
 ```
 
 ### Manual (emulator or device, debug build)

--- a/docs/superpowers/specs/2026-07-10-android-sleep-stage-timeline-design.md
+++ b/docs/superpowers/specs/2026-07-10-android-sleep-stage-timeline-design.md
@@ -1,0 +1,93 @@
+# Android Sleep "Stage breakdown" — mirror iOS #988 stage-timeline rows
+
+**Date:** 2026-07-10
+**Scope:** Android `SleepScreen` hero card only — graph + legend. `MotionStrip` component unchanged.
+**Decision trail:** user approved mirroring iOS's WHOOP sleep-details layout (ryanAtriumAi #988,
+`Strand/Screens/SleepView.swift:640-1290`) instead of building a 4-lane stepped hypnogram, because iOS
+already removed the 4-level staircase — fragmented on-device staging turned it into an unreadable comb.
+
+## Problem
+
+The Android hero card renders the night as one flat proportional strip (`HypnogramWithAxis`) that is hard
+to read, plus TWO legends carrying the same numbers: a colors-only dot row (`StageLegend`) under the
+`MotionStrip`, and a footer (`StageBreakdownRows`: swatch + % + LiquidTube + duration). iOS already moved
+to per-stage timeline rows where "the rows ARE the legend". The platforms have diverged.
+
+## Design
+
+### Real-stage nights (`display.realSegments != null`, ≥ 2 segments)
+
+Replace the card body (`SleepScreen.kt:829-856`) with an Android `StageTimeline`, mirroring
+`SleepView.stageTimeline` minus the HR chart and headline pair (see Non-goals):
+
+1. **Four per-stage timeline rows**, WHOOP order **AWAKE · LIGHT · DEEP · REM**
+   (mirrors `stageTimelineRow`, `SleepView.swift:1204`):
+   - Header: `STAGE` overline + colored `%` + right-aligned duration. Percent basis stays
+     `minutes / s.total` (all four rows, awake included) — same as today and same as iOS.
+   - Track: full-width hatched track = the whole night; solid rounded segments (min width 2dp,
+     corner 1.5dp, height 20dp) where that stage occurred, positioned on the shared onset→wake axis.
+   - Row chrome: 10dp rounded background at `textPrimary` 4.5% alpha; selected row gets a
+     `hairlineStrong` 1.5dp stroke.
+   - **Tap to highlight**: `selectedStage` state; tapping a row dims the other rows' segments to
+     `textTertiary` at 55% alpha and their `%` tint to tertiary. Tap again to clear.
+   - a11y: one collapsed node per row — "Awake: 49 min, 10 percent of the night", hint
+     "Highlights this stage on the sleep chart", button trait. Mirrors iOS exactly.
+2. **Display smoothing**: port `Hypnogram.displaySmoothed(minDuration: 90)` (90 s floor) from
+   `Packages/StrandDesign/Sources/StrandDesign/Hypnogram.swift` as a pure Kotlin function. Rows tolerate
+   fine texture, so 90 s (not the staircase's 300 s).
+3. **Intervals from segments**: Android's `realSegments` is an ordered `List<Pair<String, Float>>`
+   (name, weight). Reconstruct `(stage, startSec, endSec)` intervals by walking cumulative fractions
+   across `wakeTs - effectiveStartTs`. Pure function, unit-tested.
+4. **Time axis**: keep the existing onset · midpoint · wake clock-label row (reuse the
+   `HypnogramWithAxis` axis code), aligned with the rows' inner track insets.
+5. **MotionStrip**: component and data path untouched. Moves to directly UNDER the four rows, above the
+   clock-label row's insight slot — same timeline, same left/right insets as the rows' tracks so epochs
+   line up (iOS anchors `motionStrip` the same way, `SleepView.swift:700`). Rendered only in this
+   real-timeline branch, mirroring iOS: the proportional fallback bar has no timeline to anchor to.
+6. **Per-stage insight slot**: fixed-height caption under the axis — with a stage selected, that stage
+   tonight; otherwise the quiet "tap a row" hint. Fixed height so selection never reflows the card.
+   (30-day typical comparison ships only if the repo call already exists on Android; otherwise the slot
+   shows tonight's value and the typical-range compare is a follow-up.)
+
+Both legends die in this branch: dot `StageLegend` row deleted, `ChartCard` footer dropped
+(`StageBreakdownRows` no longer called here) — the rows are the legend.
+
+### Fallback nights (reconstructed architecture / minutes-only, < 2 real segments)
+
+Mirror iOS's else-branch (`SleepView.swift:657-665`): keep the flat proportional strip (existing shared
+`Hypnogram` geometry) as the chart with subtitle "approx. stages (on-device)", and keep
+`StageBreakdownRows` as the footer legend. No MotionStrip here (no genuine timeline). No fake steps —
+invented architecture is never drawn as transitions.
+
+Unchanged honest states: `display == null` → "No stage data recorded for this night."; empty segments →
+"No stage breakdown for this night."; MotionStrip's own "No movement detail for this night." note.
+
+### Card sizing
+
+The rows stack is taller than the old strip. iOS uses `height: 524` for the timeline card; Android
+`ChartCard` sizes to content — verify no fixed-height clipping, add `Metrics` constants for row height
+(20dp track), row padding (8/10dp), and stack spacing.
+
+## Non-goals (follow-ups, not this change)
+
+- `sleepHRChart` (sleeping-HR trace with stage washes) and `sleepHeadline` (hours-of-sleep /
+  restorative-sleep pair) from iOS #988 — separate port, needs `hrBuckets` plumbing on Android.
+- Motion pipeline changes (imported-night motion backfill, pre-H8 backfill) — discussed and deferred.
+- iOS/macOS changes: none. iOS already ships this layout; this change restores lockstep.
+
+## Files touched
+
+- `android/app/src/main/java/com/noop/ui/SleepScreen.kt` — new `StageTimeline`, `StageTimelineRow`,
+  `StageHatchedTrack`, interval reconstruction + `displaySmoothed` port, `selectedStage` state, hero card
+  body rewrite, `StageLegend` deletion, MotionStrip relocation.
+- `android/app/src/main/java/com/noop/ui/Theme.kt` — new `Metrics` constants.
+- Android unit tests — interval reconstruction, 90 s smoothing parity with Swift fixtures, percent math.
+
+## Risks
+
+- **Fragment tangles**: none by construction — one row per stage can't overlap another stage.
+- **Perf**: 4 rows × N segments as composables; if a fragmented night produces hundreds of segments after
+  90 s smoothing, draw the row track in a single `Canvas`/`drawWithCache` instead of per-segment `Box`es
+  (follow the `Charts.kt` PERF hoist convention).
+- **MotionStrip alignment**: rows have horizontal padding the old full-bleed strip didn't; MotionStrip
+  must adopt the same inner insets or epochs skew against the tracks.


### PR DESCRIPTION
## What this PR does

Ports the iOS #988 sleep stage-timeline rows to Android: replaces the hero card's `StageLegend` with per-stage `StageTimeline` rows (span extraction, `displaySmoothed` port, `Metrics` constants, interval reconstruction from hero weight pairs).

Also fixes three Health Connect / sleep-hero bugs found while validating against strap data:

- **HC importer coveredDays gate** — sleep import now skips days covered by the *active* strap ids, so a flat HC night can no longer shadow a fully-staged strap night.
- **In-bed figure** — hero in-bed now spans the full night group (min onset → max wake across fragments) instead of the main fragment only, matching iOS `SleepView.mergeDay`.
- **Cleanup migration** — purges previously-written HC `my-whoop` sleep rows that shadow strap-computed nights.

<img width="1080" height="2400" alt="sleep-lastnight" src="https://github.com/user-attachments/assets/4662ed7f-304f-4af6-b9ba-fc74e3d879e7" />


## Type of change

- [x] Bug fix
- [x] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] CI / tooling

## How it was tested

- `./gradlew testFullDebugUnitTest` — full `com.noop.ingest.*` and `com.noop.ui.*` packages pass, including the new `HealthConnectCoveredDaysTest` (gate + purge behavior).
- Room compile-time SQL verification covers the two new purge queries in `WhoopDao`.
- No BLE path touched — importer, DAO/repository, and Compose UI only.
- Timeline rows verified on-device against strap-staged nights and HC-only nights (fallback/empty states).

## Checklist

- [x] Swift package tests pass for any package I touched (none touched — Android only)
- [x] Android unit tests pass if I touched `android/` (`./gradlew testFullDebugUnitTest`)
- [x] No new build warnings introduced
- [x] UI changes use only `StrandDesign` tokens — no hardcoded colors, fonts, or spacing
- [x] No hardcoded hex frame bytes; protocol facts live in the schema / decoders
- [x] Follows the conventions in [`docs/CONTRIBUTING.md`](../docs/CONTRIBUTING.md)
- [x] I did not commit generated output (`Strand.xcodeproj/`) or any secrets/keystores

## Related issues

Android port of iOS #988 (stage timeline rows).
