### PR TITLE
Reboot: mark the WHOOP 4.0 frame UNVERIFIED (it's ignored on 4.0) (#235)

### DIFF
--- a/Strand/BLE/BLEManager.swift
+++ b/Strand/BLE/BLEManager.swift
@@ -2215,7 +2215,7 @@ public final class BLEManager: NSObject, ObservableObject {
         // Supersede any still-pending reboot (cancels its timers + resets the flag) so a repeat tap can't
         // leave a stale watchdog/settle timer that fires during this new reboot's window.
         clearRebootState()
-        let framing = family == .whoop5 ? "puffin-crc16 (verified on 5.0 fw 50.40.1.0)" : "harvard-crc8"
+        let framing = family == .whoop5 ? "puffin-crc16 (verified on 5.0 fw 50.40.1.0)" : "harvard-crc8 (UNVERIFIED on 4.0)"
         let fw = state.strapFirmware ?? "unknown"
         log("reboot: request family=\(family) fw=\(fw) connected=true bonded=true")
         log("reboot: sent opcode=29 framing=\(framing) payload=empty writeType=withResponse")
@@ -2234,7 +2234,7 @@ public final class BLEManager: NSObject, ObservableObject {
         let work = DispatchWorkItem { [weak self] in
             guard let self, self.rebootRequestedAt != nil, self.state.connected else { return }
             self.log("reboot: no disconnect within 12s — strap may have ignored the command"
-                     + (self.selectedModel.deviceFamily == .whoop5 ? " (5/MG reboot is verified on 5.0 fw 50.40.1.0; if your firmware differs, please share this log on #166)" : ""))
+                     + (self.selectedModel.deviceFamily == .whoop5 ? " (5/MG reboot is verified on 5.0 fw 50.40.1.0; if your firmware differs, please share this log on #166)" : " (the WHOOP 4.0 reboot frame is NOT confirmed yet — please share this log on #235)"))
             self.clearRebootState()
         }
         rebootTimeoutWork = work

--- a/Strand/BLE/Commands.swift
+++ b/Strand/BLE/Commands.swift
@@ -25,10 +25,12 @@ public enum WhoopCommand: UInt8, CaseIterable {
     /// `rh0.C45476d0` passes a null payload). The strap drops the BLE link and re-advertises after boot;
     /// **stored data is kept** (non-destructive), but any in-flight offload is interrupted (chunk-acked,
     /// so nothing is lost — it re-offloads on reconnect). Opcode 29 is shared across WHOOP 4.0 (harvard,
-    /// crc8) and 5/MG (puffin, crc16); the 4.0 form is confirmed from the app builder, the 5/MG framing is
-    /// NOT hardware-confirmed yet — `BLEManager.rebootStrap()` logs the strap's COMMAND_RESPONSE so a 5/MG
-    /// owner's strap log confirms whether the puffin frame is accepted. User-initiated + confirmation-gated
-    /// only; never sent automatically. Driven only by `BLEManager.rebootStrap()`.
+    /// crc8) and 5/MG (puffin, crc16). The **5.0 form is hardware-confirmed** (fw 50.40.1.0, #227). The
+    /// **4.0 form is NOT confirmed** — it was decoded from the app builder but a real 4.0 silently ignores
+    /// this empty-body frame (#235): no reboot, no disconnect, no COMMAND_RESPONSE. The correct 4.0 frame
+    /// (a payload byte? a different opcode?) needs an HCI capture. `BLEManager.rebootStrap()` logs the
+    /// strap's COMMAND_RESPONSE + a no-disconnect watchdog so a strap log shows which case it hit.
+    /// User-initiated + confirmation-gated only; never sent automatically. Driven only by `BLEManager.rebootStrap()`.
     case rebootStrap           = 29
     case getDataRange          = 34
     case getHelloHarvard       = 35

--- a/Strand/Screens/DevicesView.swift
+++ b/Strand/Screens/DevicesView.swift
@@ -169,7 +169,7 @@ private struct DevicesContent: View {
             Button("Cancel", role: .cancel) { rebootTarget = nil }
             Button("Restart") { model.rebootStrap(); rebootTarget = nil }
         } message: { device in
-            Text("Restart \(device.displayName)? It disconnects for about 30 seconds while it reboots, then reconnects on its own. Your recorded data is kept. On WHOOP 5.0/MG this is experimental — if it doesn't restart, your strap log helps us confirm the command.")
+            Text("Restart \(device.displayName)? It disconnects for about 30 seconds while it reboots, then reconnects on its own. Your recorded data is kept. Confirmed on WHOOP 5.0; on WHOOP 4.0 the reboot command isn't confirmed yet — if nothing happens, your strap log helps us pin it down.")
         }
         // Second, strongly-worded delete-data confirm (reached from the Remove card's secondary control)
         .alert("Delete all of this device's data?",

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -2403,7 +2403,7 @@ class WhoopBleClient(
         // Supersede any still-pending reboot (cancels its timers + resets the flag) so a repeat tap can't
         // leave a stale watchdog/settle timer that fires during this new reboot's window.
         clearRebootState()
-        val framing = if (family == DeviceFamily.WHOOP5) "puffin-crc16 (verified on 5.0 fw 50.40.1.0)" else "harvard-crc8"
+        val framing = if (family == DeviceFamily.WHOOP5) "puffin-crc16 (verified on 5.0 fw 50.40.1.0)" else "harvard-crc8 (UNVERIFIED on 4.0)"
         val fw = _state.value.strapFirmware ?: "unknown"
         log("reboot: request family=$family fw=$fw connected=true bonded=true")
         log("reboot: sent opcode=29 framing=$framing payload=empty writeType=withResponse")
@@ -2421,7 +2421,7 @@ class WhoopBleClient(
         val work = Runnable {
             if (rebootRequestedAtMs != null && _state.value.connected) {
                 log("reboot: no disconnect within 12s — strap may have ignored the command" +
-                    if (connectedFamily == DeviceFamily.WHOOP5) " (5/MG reboot is verified on 5.0 fw 50.40.1.0; if your firmware differs, please share this log on #166)" else "")
+                    if (connectedFamily == DeviceFamily.WHOOP5) " (5/MG reboot is verified on 5.0 fw 50.40.1.0; if your firmware differs, please share this log on #166)" else " (the WHOOP 4.0 reboot frame is NOT confirmed yet — please share this log on #235)")
                 clearRebootState()
             }
         }

--- a/android/app/src/main/java/com/noop/protocol/Enums.kt
+++ b/android/app/src/main/java/com/noop/protocol/Enums.kt
@@ -87,9 +87,11 @@ enum class CommandNumber(val rawValue: Int) {
     // REBOOT_STRAP (29) — restart the strap. Empty body (the official app's builder passes a null
     // payload). The strap drops the link and re-advertises after boot; stored data is KEPT
     // (non-destructive), though an in-flight offload is interrupted (chunk-acked, so nothing is lost).
-    // Opcode 29 is shared across WHOOP 4.0 (harvard/crc8) and 5/MG (puffin/crc16); the 4.0 form is
-    // confirmed, the 5/MG framing is NOT hardware-confirmed — rebootStrap() logs the COMMAND_RESPONSE
-    // so a strap log confirms acceptance. User-initiated + confirmation-gated only; never automatic.
+    // Opcode 29 is shared across WHOOP 4.0 (harvard/crc8) and 5/MG (puffin/crc16). The 5.0 form is
+    // hardware-confirmed (fw 50.40.1.0, #227); the 4.0 form is NOT — a real 4.0 silently IGNORES this
+    // empty-body frame (#235: no reboot, no disconnect, no COMMAND_RESPONSE), so the correct 4.0 frame
+    // still needs an HCI capture. rebootStrap() logs the COMMAND_RESPONSE + a no-disconnect watchdog so a
+    // strap log shows which case it hit. User-initiated + confirmation-gated only; never automatic.
     // Port of Swift WhoopCommand.rebootStrap.
     REBOOT_STRAP(29),
     GET_DATA_RANGE(34),

--- a/android/app/src/main/java/com/noop/ui/DevicesScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/DevicesScreen.kt
@@ -272,8 +272,9 @@ fun DevicesScreen(
         ConfirmDialog(
             title = "Restart this strap?",
             message = "Restart ${displayName(device)}? It disconnects for about 30 seconds while it " +
-                "reboots, then reconnects on its own. Your recorded data is kept. On WHOOP 5.0/MG this is " +
-                "experimental — if it doesn't restart, your strap log helps us confirm the command.",
+                "reboots, then reconnects on its own. Your recorded data is kept. Confirmed on WHOOP 5.0; " +
+                "on WHOOP 4.0 the reboot command isn't confirmed yet — if nothing happens, your strap log " +
+                "helps us pin it down.",
             confirmLabel = "Restart",
             destructive = false,
             onConfirm = { viewModel.rebootStrap(); rebootTarget = null },

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -430,8 +430,10 @@ on both transports — unlike haptics, which has a maverick-specific `0x13`.
   payload. This wipes the rolling ~14-day flash history — anything not already offloaded is gone.
 - `REBOOT_STRAP` (29) — **empty body** (builder `rh0.C45476d0` passes a null payload). The strap drops
   the BLE link and re-advertises after boot; stored data is kept. Non-destructive, but interrupts any
-  in-flight offload. 5/MG framing is not hardware-confirmed (haptics already showed 5/MG can diverge on
-  both opcode and payload), so treat the puffin form as unverified until a real wire capture exists.
+  in-flight offload. **WHOOP 5.0 (puffin): hardware-confirmed** — the empty-body frame reboots a 5.0
+  (fw 50.40.1.0, #227). **WHOOP 4.0 (harvard): NOT confirmed** — a real 4.0 silently ignores this
+  empty-body frame (#235: no reboot, no disconnect, no COMMAND_RESPONSE), so the correct 4.0 form (a
+  payload byte? a different opcode?) still needs an HCI capture of the official app rebooting a 4.0.
 
 ---
 


### PR DESCRIPTION
A 4.0 owner (#235, + a second confirm) reports **Restart does nothing on WHOOP 4.0**, and their strap log proves it — the exact `reboot:` debug trail from #216:
```
reboot: sent opcode=29 framing=harvard-crc8 payload=empty writeType=withResponse
→ REBOOT_STRAP payload=
reboot: no disconnect within 12s — strap may have ignored the command
```
Command sent, **no COMMAND_RESPONSE** (no accept or reject), **no disconnect**, strap keeps streaming HR/battery. So a real 4.0 **silently ignores** the empty-body/opcode-29/harvard reboot frame.

## Root cause
The 4.0 form was decoded from the official app's command builder but **never hardware-verified** — only the **5.0** was (#227). It's now clear the 4.0 frame is wrong/incomplete (the strap doesn't recognise it). In #216 the labelling had this backwards (4.0 "confirmed", 5/MG "unverified"); reality is the opposite.

## This PR — honesty only, no behaviour change
The correct 4.0 frame (a payload byte? a different opcode?) needs an **HCI capture of the official app rebooting a 4.0** — so nothing is guessed here. This just makes the app tell the truth:
- Framing log: 4.0 → `harvard-crc8 (UNVERIFIED on 4.0)` (5.0 unchanged, still "verified on 5.0 fw 50.40.1.0").
- No-disconnect watchdog: the 4.0 branch (previously empty) now points at #235.
- Restart confirmation dialog: the backwards "On WHOOP 5.0/MG this is experimental" → "confirmed on WHOOP 5.0; on WHOOP 4.0 the reboot command isn't confirmed yet — if nothing happens, your strap log helps us pin it down."
- `Commands.swift` / `Enums.kt` / `PROTOCOL.md` comments corrected (all claimed 4.0-confirmed + 5/MG-unverified — both stale/backwards).

Both platforms, byte-identical strings. Android `compileFullDebugKotlin` passes; app-target Swift validated via `app-build`. **Follow-up (tracked separately): RE the correct WHOOP 4.0 reboot frame.**