### PR TITLE
Reboot: gated WHOOP 4.0 reboot probe to find the real frame (#235)

### DIFF
--- a/Strand/App/AppModel.swift
+++ b/Strand/App/AppModel.swift
@@ -793,6 +793,9 @@ final class AppModel: ObservableObject {
     /// Restart the connected strap (user-initiated, confirmation-gated in DevicesView). Non-destructive —
     /// the strap keeps its data and re-advertises after boot; NOOP auto-reconnects. See BLEManager.rebootStrap().
     func rebootStrap() { ble.rebootStrap() }
+    /// Send one WHOOP 4.0 reboot-probe candidate (Test Centre → Connection, 4.0 only). Confirmation-gated
+    /// in DevicesView; finds the real 4.0 reboot frame when the production one is ignored (#235).
+    func rebootProbe(_ variant: RebootProbeVariant) { ble.rebootProbe(variant) }
 
     /// Drop the current strap and clear bond state so a newly-picked strap model connects fresh
     /// (lets a user with both a WHOOP 4 and a 5/MG switch between them).

--- a/Strand/BLE/BLEManager.swift
+++ b/Strand/BLE/BLEManager.swift
@@ -2215,7 +2215,7 @@ public final class BLEManager: NSObject, ObservableObject {
         // Supersede any still-pending reboot (cancels its timers + resets the flag) so a repeat tap can't
         // leave a stale watchdog/settle timer that fires during this new reboot's window.
         clearRebootState()
-        let framing = family == .whoop5 ? "puffin-crc16 (verified on 5.0 fw 50.40.1.0)" : "harvard-crc8"
+        let framing = family == .whoop5 ? "puffin-crc16 (verified on 5.0 fw 50.40.1.0)" : "harvard-crc8 (UNVERIFIED on 4.0)"
         let fw = state.strapFirmware ?? "unknown"
         log("reboot: request family=\(family) fw=\(fw) connected=true bonded=true")
         log("reboot: sent opcode=29 framing=\(framing) payload=empty writeType=withResponse")
@@ -2234,7 +2234,7 @@ public final class BLEManager: NSObject, ObservableObject {
         let work = DispatchWorkItem { [weak self] in
             guard let self, self.rebootRequestedAt != nil, self.state.connected else { return }
             self.log("reboot: no disconnect within 12s — strap may have ignored the command"
-                     + (self.selectedModel.deviceFamily == .whoop5 ? " (5/MG reboot is verified on 5.0 fw 50.40.1.0; if your firmware differs, please share this log on #166)" : ""))
+                     + (self.selectedModel.deviceFamily == .whoop5 ? " (5/MG reboot is verified on 5.0 fw 50.40.1.0; if your firmware differs, please share this log on #166)" : " (the WHOOP 4.0 reboot frame is NOT confirmed yet — please share this log on #235)"))
             self.clearRebootState()
         }
         rebootTimeoutWork = work

--- a/Strand/BLE/BLEManager.swift
+++ b/Strand/BLE/BLEManager.swift
@@ -2213,7 +2213,7 @@ public final class BLEManager: NSObject, ObservableObject {
     public func rebootStrap() {
         // Production Restart: opcode 29 REBOOT_STRAP, empty body per the official app's builder
         // (rh0.C45476d0). Confirmed on WHOOP 5.0 (#227); ignored on 4.0 (#235 — see rebootProbe).
-        sendRebootFrame(command: .rebootStrap, opcode: 29, payload: [], probe: nil)
+        sendRebootFrame(command: .rebootStrap, payload: [], probe: nil)
     }
 
     /// Send one candidate reboot frame from the WHOOP 4.0 reboot probe (Test Centre → Connection).
@@ -2226,13 +2226,13 @@ public final class BLEManager: NSObject, ObservableObject {
             log("reboot: probe is WHOOP 4.0 only — ignored (family=\(selectedModel.deviceFamily))")
             return
         }
-        sendRebootFrame(command: variant.command, opcode: variant.opcode, payload: variant.payload, probe: variant)
+        sendRebootFrame(command: variant.command, payload: variant.payload, probe: variant)
     }
 
     /// Shared reboot send + debug trail + watchdog, used by both the production `rebootStrap()` and the
     /// 4.0 `rebootProbe(_:)`. `probe == nil` is the normal restart; a non-nil variant is a probe attempt
     /// (its `logTag` is stamped first so the strap log correlates the attempt with what the strap did).
-    private func sendRebootFrame(command: WhoopCommand, opcode: Int, payload: [UInt8], probe: RebootProbeVariant?) {
+    private func sendRebootFrame(command: WhoopCommand, payload: [UInt8], probe: RebootProbeVariant?) {
         let family = selectedModel.deviceFamily
         guard state.connected, state.bonded, let p = peripheral, p.state == .connected else {
             log("reboot: connect + bond first — ignored (connected=\(state.connected) bonded=\(state.bonded))")
@@ -2241,6 +2241,9 @@ public final class BLEManager: NSObject, ObservableObject {
         // Supersede any still-pending reboot (cancels its timers + resets the flag) so a repeat tap can't
         // leave a stale watchdog/settle timer that fires during this new reboot's window.
         clearRebootState()
+        // The logged opcode is always the command's on-wire value — never a separate field that could
+        // disagree with the bytes actually sent.
+        let opcode = Int(command.rawValue)
         let framing = family == .whoop5 ? "puffin-crc16 (verified on 5.0 fw 50.40.1.0)" : "harvard-crc8 (UNVERIFIED on 4.0)"
         let fw = state.strapFirmware ?? "unknown"
         let payloadDesc = payload.isEmpty ? "empty" : payload.map { String(format: "%02x", $0) }.joined()

--- a/Strand/BLE/BLEManager.swift
+++ b/Strand/BLE/BLEManager.swift
@@ -737,6 +737,10 @@ public final class BLEManager: NSObject, ObservableObject {
     /// isn't. Mirrors the Android `LiveState.whoop5Detected` signal the equivalent screen reads.
     var isWhoop5: Bool { selectedModel.deviceFamily == .whoop5 }
 
+    /// True when the selected/connected strap is a WHOOP 4.0. Read-only window onto the private
+    /// `selectedModel`, used to gate the 4.0-only reboot probe (Test Centre → Connection) in the UI.
+    var isWhoop4: Bool { selectedModel.deviceFamily == .whoop4 }
+
     /// Stable device id; matches the server's existing device for sync parity. Overridable.
     /// Seeded from the init argument, then refined once in bootstrapStore() to the device registry's
     /// active id (still "my-whoop" today) before any store writes use it — see bootstrapStore().
@@ -2207,6 +2211,28 @@ public final class BLEManager: NSObject, ObservableObject {
     ///   `reboot: no disconnect within …` — strap ignored it (esp. an unverified 5/MG frame)
     ///   `reboot: reconnected …` — the connect handshake, round-trip complete
     public func rebootStrap() {
+        // Production Restart: opcode 29 REBOOT_STRAP, empty body per the official app's builder
+        // (rh0.C45476d0). Confirmed on WHOOP 5.0 (#227); ignored on 4.0 (#235 — see rebootProbe).
+        sendRebootFrame(command: .rebootStrap, opcode: 29, payload: [], probe: nil)
+    }
+
+    /// Send one candidate reboot frame from the WHOOP 4.0 reboot probe (Test Centre → Connection).
+    /// WHOOP 4.0 only — a 5.0 already reboots on the production frame (#227), so there is nothing to
+    /// probe there. Reuses the full reboot watchdog/trail, so the strap log shows whether THIS candidate
+    /// dropped the link (`reboot: link dropped …` = it worked) or was ignored (`reboot: no disconnect
+    /// within 12s …`). Confirmation-gated at the call site (DevicesView). See `RebootProbeVariant`.
+    public func rebootProbe(_ variant: RebootProbeVariant) {
+        guard selectedModel.deviceFamily == .whoop4 else {
+            log("reboot: probe is WHOOP 4.0 only — ignored (family=\(selectedModel.deviceFamily))")
+            return
+        }
+        sendRebootFrame(command: variant.command, opcode: variant.opcode, payload: variant.payload, probe: variant)
+    }
+
+    /// Shared reboot send + debug trail + watchdog, used by both the production `rebootStrap()` and the
+    /// 4.0 `rebootProbe(_:)`. `probe == nil` is the normal restart; a non-nil variant is a probe attempt
+    /// (its `logTag` is stamped first so the strap log correlates the attempt with what the strap did).
+    private func sendRebootFrame(command: WhoopCommand, opcode: Int, payload: [UInt8], probe: RebootProbeVariant?) {
         let family = selectedModel.deviceFamily
         guard state.connected, state.bonded, let p = peripheral, p.state == .connected else {
             log("reboot: connect + bond first — ignored (connected=\(state.connected) bonded=\(state.bonded))")
@@ -2217,11 +2243,12 @@ public final class BLEManager: NSObject, ObservableObject {
         clearRebootState()
         let framing = family == .whoop5 ? "puffin-crc16 (verified on 5.0 fw 50.40.1.0)" : "harvard-crc8 (UNVERIFIED on 4.0)"
         let fw = state.strapFirmware ?? "unknown"
+        let payloadDesc = payload.isEmpty ? "empty" : payload.map { String(format: "%02x", $0) }.joined()
+        if let probe { log("reboot: PROBE \(probe.logTag) — trying an unconfirmed WHOOP 4.0 reboot frame (#235)") }
         log("reboot: request family=\(family) fw=\(fw) connected=true bonded=true")
-        log("reboot: sent opcode=29 framing=\(framing) payload=empty writeType=withResponse")
-        // Empty body per the official app's builder (rh0.C45476d0). .withResponse so the write itself is
-        // acknowledged at the ATT layer before the strap drops the link.
-        send(.rebootStrap, payload: [], writeType: .withResponse)
+        log("reboot: sent opcode=\(opcode) framing=\(framing) payload=\(payloadDesc) writeType=withResponse")
+        // .withResponse so the write itself is acknowledged at the ATT layer before the strap drops the link.
+        send(command, payload: payload, writeType: .withResponse)
         rebootRequestedAt = .now()
         // Drive the Devices "Reconnecting…" pill: true from here until the strap reconnects (or a terminal
         // path clears it). The pill only shows it once the link actually drops (it gates on !connected).

--- a/Strand/BLE/Commands.swift
+++ b/Strand/BLE/Commands.swift
@@ -236,7 +236,6 @@ public enum RebootProbeVariant: String, CaseIterable, Sendable {
 
     var command: WhoopCommand { self == .powerCycle32Empty ? .powerCycleStrap : .rebootStrap }
     var payload: [UInt8] { self == .reboot29Payload1 ? [0x01] : [] }
-    var opcode: Int { self == .powerCycle32Empty ? 32 : 29 }
 
     /// Short menu label, e.g. "A · REBOOT_STRAP(29) empty".
     public var menuLabel: String {

--- a/Strand/BLE/Commands.swift
+++ b/Strand/BLE/Commands.swift
@@ -5,14 +5,18 @@ import WhoopProtocol
 ///
 /// Raw values are the on-wire command codes (from whoomp/scripts/packet.py `CommandNumber`).
 /// This is intentionally a *subset*: DESTRUCTIVE commands that wipe data or brick the strap
-/// (firmware load/DFU, force-trim, ship-mode, power-cycle, fuel-gauge reset) stay deliberately
-/// EXCLUDED so the in-app command sender can never form those bytes.
+/// (firmware load/DFU, force-trim, ship-mode, fuel-gauge reset) stay deliberately EXCLUDED so the
+/// in-app command sender can never form those bytes.
 ///
-/// The ONE exception is `rebootStrap` (29): a plain restart is non-destructive (the strap keeps
-/// its stored data and just re-advertises after boot), and NOOP already triggers a reboot today via
-/// `setAdvertisingNameHarvard` (rename applies on reboot). It is a deliberate, user-initiated,
-/// confirmation-gated action — never sent automatically. See `BLEManager.rebootStrap()` and the
-/// "Destructive commands" note in docs/PROTOCOL.md.
+/// TWO restart opcodes are included, both non-destructive (a restart keeps the strap's stored data)
+/// and both user-initiated + confirmation-gated, never sent automatically:
+///   - `rebootStrap` (29): the normal Restart. NOOP already triggers a reboot today via
+///     `setAdvertisingNameHarvard` (rename applies on reboot). See `BLEManager.rebootStrap()`.
+///   - `powerCycleStrap` (32): a harder restart, included ONLY as a candidate for the WHOOP 4.0
+///     reboot probe (Test Centre → Connection, 4.0 only). The 4.0 ignores opcode 29/empty (#235) and
+///     the correct frame is unknown, so the probe tries this alongside 29-with-payload on real 4.0
+///     hardware to find which one actually reboots. Driven only by `BLEManager.rebootProbe(_:)`.
+/// See the "Destructive commands" note in docs/PROTOCOL.md.
 public enum WhoopCommand: UInt8, CaseIterable {
     case toggleRealtimeHR      = 3
     case reportVersionInfo     = 7
@@ -32,6 +36,13 @@ public enum WhoopCommand: UInt8, CaseIterable {
     /// strap's COMMAND_RESPONSE + a no-disconnect watchdog so a strap log shows which case it hit.
     /// User-initiated + confirmation-gated only; never sent automatically. Driven only by `BLEManager.rebootStrap()`.
     case rebootStrap           = 29
+    /// POWER_CYCLE_STRAP (32) — a harder restart than REBOOT_STRAP (a full power cycle of the strap
+    /// SoC vs a warm reboot). Non-destructive: stored data lives in flash and survives, the strap
+    /// re-advertises after boot. Included ONLY as a gated candidate for the WHOOP 4.0 reboot probe
+    /// (#235: a real 4.0 silently ignores opcode 29/empty, and the correct 4.0 reboot frame is unknown).
+    /// NOT hardware-confirmed on any family. Sent only via `BLEManager.rebootProbe(.powerCycle32Empty)`,
+    /// itself gated behind Test Centre → Connection + a confirmation. Never sent automatically.
+    case powerCycleStrap       = 32
     case getDataRange          = 34
     case getHelloHarvard       = 35
     /// WHOOP 5.0/MG hello (the puffin generation's GET_HELLO). The response carries the device name
@@ -109,6 +120,7 @@ public enum WhoopCommand: UInt8, CaseIterable {
         case .historicalDataResult:  return "Historical Data Result"
         case .getBatteryLevel:       return "Get Battery Level"
         case .rebootStrap:           return "Reboot Strap"
+        case .powerCycleStrap:       return "Power Cycle Strap"
         case .getDataRange:          return "Get Data Range"
         case .getHelloHarvard:       return "Get Hello (Harvard)"
         case .getHello:              return "Get Hello (5/MG)"
@@ -199,5 +211,48 @@ public enum WhoopCommand: UInt8, CaseIterable {
             UInt8((trailer >> 24) & 0xFF),
         ]
         return [0xAA] + lenBytes + [headerCRC] + inner + trailerBytes
+    }
+}
+
+/// Candidate reboot frames for the WHOOP 4.0 reboot probe (Test Centre → Connection, WHOOP 4.0 only).
+///
+/// A real WHOOP 4.0 silently ignores NOOP's production reboot frame (opcode 29 REBOOT_STRAP, empty
+/// body — #235: no reboot, no disconnect, no COMMAND_RESPONSE), and the correct 4.0 frame is unknown.
+/// These are the plausible NON-DESTRUCTIVE candidates — a restart / power-cycle only, never a
+/// data-wiping opcode — tried one at a time on real hardware so the strap log tells which one works:
+/// `reboot: link dropped …` = the strap acted; `reboot: no disconnect within 12s …` = ignored.
+///
+/// The definitive fix is still an HCI capture of the official app rebooting a 4.0 (exactly how the
+/// alarm frame was pinned — @ujix's capture, #535). This probe is the interim way to find the frame
+/// when a 4.0 is in hand. The Kotlin twin is `RebootProbeVariant` (WhoopBleClient.kt); the `logTag`
+/// strings are byte-identical across platforms so a strap log reads the same either side.
+public enum RebootProbeVariant: String, CaseIterable, Sendable {
+    /// A — opcode 29 REBOOT_STRAP, empty body: NOOP's current production frame (ignored on 4.0).
+    case reboot29Empty
+    /// B — opcode 32 POWER_CYCLE_STRAP, empty body: a harder restart, never tried.
+    case powerCycle32Empty
+    /// C — opcode 29 REBOOT_STRAP, payload [0x01]: same opcode with a non-empty sub-command byte.
+    case reboot29Payload1
+
+    var command: WhoopCommand { self == .powerCycle32Empty ? .powerCycleStrap : .rebootStrap }
+    var payload: [UInt8] { self == .reboot29Payload1 ? [0x01] : [] }
+    var opcode: Int { self == .powerCycle32Empty ? 32 : 29 }
+
+    /// Short menu label, e.g. "A · REBOOT_STRAP(29) empty".
+    public var menuLabel: String {
+        switch self {
+        case .reboot29Empty:     return "A · REBOOT_STRAP(29) empty"
+        case .powerCycle32Empty: return "B · POWER_CYCLE(32) empty"
+        case .reboot29Payload1:  return "C · REBOOT_STRAP(29) payload=01"
+        }
+    }
+
+    /// Tag written to the strap log so each attempt is correlatable (byte-identical to Kotlin).
+    public var logTag: String {
+        switch self {
+        case .reboot29Empty:     return "A/reboot29-empty"
+        case .powerCycle32Empty: return "B/powercycle32-empty"
+        case .reboot29Payload1:  return "C/reboot29-payload01"
+        }
     }
 }

--- a/Strand/BLE/Commands.swift
+++ b/Strand/BLE/Commands.swift
@@ -25,10 +25,12 @@ public enum WhoopCommand: UInt8, CaseIterable {
     /// `rh0.C45476d0` passes a null payload). The strap drops the BLE link and re-advertises after boot;
     /// **stored data is kept** (non-destructive), but any in-flight offload is interrupted (chunk-acked,
     /// so nothing is lost — it re-offloads on reconnect). Opcode 29 is shared across WHOOP 4.0 (harvard,
-    /// crc8) and 5/MG (puffin, crc16); the 4.0 form is confirmed from the app builder, the 5/MG framing is
-    /// NOT hardware-confirmed yet — `BLEManager.rebootStrap()` logs the strap's COMMAND_RESPONSE so a 5/MG
-    /// owner's strap log confirms whether the puffin frame is accepted. User-initiated + confirmation-gated
-    /// only; never sent automatically. Driven only by `BLEManager.rebootStrap()`.
+    /// crc8) and 5/MG (puffin, crc16). The **5.0 form is hardware-confirmed** (fw 50.40.1.0, #227). The
+    /// **4.0 form is NOT confirmed** — it was decoded from the app builder but a real 4.0 silently ignores
+    /// this empty-body frame (#235): no reboot, no disconnect, no COMMAND_RESPONSE. The correct 4.0 frame
+    /// (a payload byte? a different opcode?) needs an HCI capture. `BLEManager.rebootStrap()` logs the
+    /// strap's COMMAND_RESPONSE + a no-disconnect watchdog so a strap log shows which case it hit.
+    /// User-initiated + confirmation-gated only; never sent automatically. Driven only by `BLEManager.rebootStrap()`.
     case rebootStrap           = 29
     case getDataRange          = 34
     case getHelloHarvard       = 35

--- a/Strand/BLE/FrameRouter.swift
+++ b/Strand/BLE/FrameRouter.swift
@@ -109,7 +109,9 @@ public final class FrameRouter {
             // the accept/reject signal — the same one that exposed 5/MG haptics rejection (result=0x03) — so
             // a 5/MG owner's strap log confirms whether the (unverified) puffin reboot frame is accepted
             // (0x00) or rejected. Log-only. A reboot that's accepted may drop the link before/after this ack.
-            if let cmd = parsed.cmdName, cmd.hasPrefix("REBOOT_STRAP") {
+            // POWER_CYCLE_STRAP is matched too: it's the 4.0 reboot probe's candidate B (#235), and its
+            // result byte is exactly what tells "opcode rejected (recognized, wrong args)" from "ignored".
+            if let cmd = parsed.cmdName, cmd.hasPrefix("REBOOT_STRAP") || cmd.hasPrefix("POWER_CYCLE_STRAP") {
                 let r = Self.commandResultByte(in: frame)
                 let rhex = r.map { String(format: "0x%02x", UInt8(truncatingIfNeeded: $0)) } ?? "none"
                 let verdict = r == nil ? "no result byte" : (r == 0 ? "accepted" : "REJECTED")

--- a/Strand/Screens/DevicesView.swift
+++ b/Strand/Screens/DevicesView.swift
@@ -57,6 +57,8 @@ private struct DevicesContent: View {
     @State private var removeTarget: PairedDevice?
     @State private var deleteDataTarget: PairedDevice?
     @State private var rebootTarget: PairedDevice?
+    /// WHOOP 4.0 reboot probe (Test Centre → Connection, 4.0 only) — the device whose probe sheet is open.
+    @State private var probeTarget: PairedDevice?
     /// After removing the ACTIVE device with other devices still paired, prompt to pick a new active one.
     @State private var pickNewActive = false
 
@@ -106,7 +108,13 @@ private struct DevicesContent: View {
                     onMakeActive: { switchTarget = device },
                     onRename: { renameDraft = device.nickname ?? device.displayName; renameTarget = device },
                     onRemove: { removeTarget = device },
-                    onReboot: { rebootTarget = device })
+                    onReboot: { rebootTarget = device },
+                    // 4.0 reboot probe: only offered when Test Centre → Connection is on AND the live
+                    // strap is a WHOOP 4.0 (a 5.0 already reboots on the production frame). nil otherwise.
+                    onRebootProbe: (device.status == .active && live.connected
+                                    && SourceCoordinator.isWhoop(device)
+                                    && model.ble.isWhoop4
+                                    && TestCentre.active(.connection)) ? { probeTarget = device } : nil)
                     .staggeredAppear(index: idx)
             }
 
@@ -170,6 +178,20 @@ private struct DevicesContent: View {
             Button("Restart") { model.rebootStrap(); rebootTarget = nil }
         } message: { device in
             Text("Restart \(device.displayName)? It disconnects for about 30 seconds while it reboots, then reconnects on its own. Your recorded data is kept. Confirmed on WHOOP 5.0; on WHOOP 4.0 the reboot command isn't confirmed yet — if nothing happens, your strap log helps us pin it down.")
+        }
+        // WHOOP 4.0 reboot probe (#235): only reachable with Test Centre → Connection on and a 4.0 connected.
+        // Tries each candidate frame one at a time so the strap log shows which one actually reboots.
+        .confirmationDialog("WHOOP 4.0 reboot probe",
+                            isPresented: Binding(get: { probeTarget != nil },
+                                                 set: { if !$0 { probeTarget = nil } }),
+                            titleVisibility: .visible,
+                            presenting: probeTarget) { _ in
+            ForEach(RebootProbeVariant.allCases, id: \.self) { variant in
+                Button(variant.menuLabel) { model.rebootProbe(variant); probeTarget = nil }
+            }
+            Button("Cancel", role: .cancel) { probeTarget = nil }
+        } message: { _ in
+            Text("The WHOOP 4.0 reboot frame isn't confirmed — a normal Restart is ignored (#235). Send each candidate and watch the strap log: “link dropped” means it worked; “no disconnect within 12s” means the strap ignored it. Non-destructive — your data is kept. Please share the log so we can pin the real frame.")
         }
         // Second, strongly-worded delete-data confirm (reached from the Remove card's secondary control)
         .alert("Delete all of this device's data?",
@@ -312,6 +334,9 @@ private struct DeviceCard: View {
     /// Restart the strap (WHOOP-only, connected-only; confirmation-gated by the parent). nil for a
     /// non-WHOOP source or a device that isn't the live-connected one. (#166)
     var onReboot: (() -> Void)? = nil
+    /// WHOOP 4.0 reboot probe (Test Centre → Connection, 4.0 only). Non-nil only when the parent has
+    /// decided the probe applies (live-connected WHOOP 4.0 + Connection test mode on); nil otherwise. (#235)
+    var onRebootProbe: (() -> Void)? = nil
     /// Removed-section affordances (re-add as active / delete its data).
     var onReAdd: (() -> Void)? = nil
     var onDeleteData: (() -> Void)? = nil
@@ -523,6 +548,11 @@ private struct DeviceCard: View {
                 // BLE link). Confirmation-gated by the parent. (#166)
                 if isLiveConnected, SourceCoordinator.isWhoop(device), let onReboot {
                     Button { onReboot() } label: { Label("Restart strap…", systemImage: "arrow.clockwise") }
+                }
+                // 4.0 reboot probe (RE): only present when the parent passed a closure (Test Centre →
+                // Connection on + a live WHOOP 4.0). Finds the real reboot frame the 4.0 accepts (#235).
+                if let onRebootProbe {
+                    Button { onRebootProbe() } label: { Label("Reboot probe (4.0 RE)…", systemImage: "ladybug") }
                 }
                 if let onRemove {
                     Divider()

--- a/Strand/Screens/DevicesView.swift
+++ b/Strand/Screens/DevicesView.swift
@@ -169,7 +169,7 @@ private struct DevicesContent: View {
             Button("Cancel", role: .cancel) { rebootTarget = nil }
             Button("Restart") { model.rebootStrap(); rebootTarget = nil }
         } message: { device in
-            Text("Restart \(device.displayName)? It disconnects for about 30 seconds while it reboots, then reconnects on its own. Your recorded data is kept. On WHOOP 5.0/MG this is experimental — if it doesn't restart, your strap log helps us confirm the command.")
+            Text("Restart \(device.displayName)? It disconnects for about 30 seconds while it reboots, then reconnects on its own. Your recorded data is kept. Confirmed on WHOOP 5.0; on WHOOP 4.0 the reboot command isn't confirmed yet — if nothing happens, your strap log helps us pin it down.")
         }
         // Second, strongly-worded delete-data confirm (reached from the Remove card's secondary control)
         .alert("Delete all of this device's data?",

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -2403,7 +2403,7 @@ class WhoopBleClient(
         // Supersede any still-pending reboot (cancels its timers + resets the flag) so a repeat tap can't
         // leave a stale watchdog/settle timer that fires during this new reboot's window.
         clearRebootState()
-        val framing = if (family == DeviceFamily.WHOOP5) "puffin-crc16 (verified on 5.0 fw 50.40.1.0)" else "harvard-crc8"
+        val framing = if (family == DeviceFamily.WHOOP5) "puffin-crc16 (verified on 5.0 fw 50.40.1.0)" else "harvard-crc8 (UNVERIFIED on 4.0)"
         val fw = _state.value.strapFirmware ?: "unknown"
         log("reboot: request family=$family fw=$fw connected=true bonded=true")
         log("reboot: sent opcode=29 framing=$framing payload=empty writeType=withResponse")
@@ -2421,7 +2421,7 @@ class WhoopBleClient(
         val work = Runnable {
             if (rebootRequestedAtMs != null && _state.value.connected) {
                 log("reboot: no disconnect within 12s — strap may have ignored the command" +
-                    if (connectedFamily == DeviceFamily.WHOOP5) " (5/MG reboot is verified on 5.0 fw 50.40.1.0; if your firmware differs, please share this log on #166)" else "")
+                    if (connectedFamily == DeviceFamily.WHOOP5) " (5/MG reboot is verified on 5.0 fw 50.40.1.0; if your firmware differs, please share this log on #166)" else " (the WHOOP 4.0 reboot frame is NOT confirmed yet — please share this log on #235)")
                 clearRebootState()
             }
         }

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -3678,7 +3678,9 @@ class WhoopBleClient(
                 // the accept/reject signal (the same one that exposed 5/MG haptics rejection). So a 5/MG
                 // owner's strap log confirms whether the (unverified) puffin reboot frame is accepted. The
                 // decoded result name is Android's richer twin of the macOS raw result byte. Log-only.
-                if (respCmd?.startsWith("REBOOT_STRAP") == true) {
+                // POWER_CYCLE_STRAP is matched too: it's the 4.0 reboot probe's candidate B (#235), and its
+                // result byte is exactly what tells "opcode rejected (recognized, wrong args)" from "ignored".
+                if (respCmd?.startsWith("REBOOT_STRAP") == true || respCmd?.startsWith("POWER_CYCLE_STRAP") == true) {
                     val verdict = when {
                         result == null -> "no result"
                         result.startsWith("SUCCESS") -> "accepted"

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -38,6 +38,7 @@ import com.noop.protocol.DeviceFamily
 import com.noop.protocol.Framing
 import com.noop.protocol.HapticClock
 import com.noop.protocol.Reassembler
+import com.noop.protocol.RebootProbeVariant
 import com.noop.protocol.Streams
 import com.noop.protocol.Whoop5Config
 import com.noop.protocol.extractStreams
@@ -2395,6 +2396,29 @@ class WhoopBleClient(
      * framing, is triageable from a strap log.
      */
     fun rebootStrap() {
+        // Production Restart: opcode 29 REBOOT_STRAP, empty body per the official app's builder.
+        // Confirmed on WHOOP 5.0 (#227); ignored on 4.0 (#235 — see rebootProbe).
+        sendRebootFrame(CommandNumber.REBOOT_STRAP, 29, byteArrayOf(), null)
+    }
+
+    /** Send one candidate reboot frame from the WHOOP 4.0 reboot probe (Test Centre → Connection).
+     *  WHOOP 4.0 only — a 5.0 already reboots on the production frame (#227), so there is nothing to
+     *  probe there. Reuses the full reboot watchdog/trail so the strap log shows whether THIS candidate
+     *  dropped the link (`reboot: link dropped …`) or was ignored (`reboot: no disconnect within 12s …`).
+     *  Confirmation-gated at the call site (DevicesScreen). Twin of macOS BLEManager.rebootProbe. */
+    fun rebootProbe(variant: RebootProbeVariant) {
+        if (connectedFamily != DeviceFamily.WHOOP4) {
+            log("reboot: probe is WHOOP 4.0 only — ignored (family=$connectedFamily)")
+            return
+        }
+        sendRebootFrame(variant.command, variant.opcode, variant.payload, variant)
+    }
+
+    /** Shared reboot send + debug trail + watchdog, used by both the production [rebootStrap] and the
+     *  4.0 [rebootProbe]. `probe == null` is the normal restart; a non-null variant is a probe attempt
+     *  (its `logTag` is stamped first so the strap log correlates the attempt with what the strap did).
+     *  Twin of macOS BLEManager.sendRebootFrame. */
+    private fun sendRebootFrame(command: CommandNumber, opcode: Int, payload: ByteArray, probe: RebootProbeVariant?) {
         val family = connectedFamily
         if (!_state.value.connected || !_state.value.bonded || gatt == null) {
             log("reboot: connect + bond first — ignored (connected=${_state.value.connected} bonded=${_state.value.bonded})")
@@ -2405,10 +2429,12 @@ class WhoopBleClient(
         clearRebootState()
         val framing = if (family == DeviceFamily.WHOOP5) "puffin-crc16 (verified on 5.0 fw 50.40.1.0)" else "harvard-crc8 (UNVERIFIED on 4.0)"
         val fw = _state.value.strapFirmware ?: "unknown"
+        val payloadDesc = if (payload.isEmpty()) "empty" else payload.joinToString("") { "%02x".format(it.toInt() and 0xFF) }
+        if (probe != null) log("reboot: PROBE ${probe.logTag} — trying an unconfirmed WHOOP 4.0 reboot frame (#235)")
         log("reboot: request family=$family fw=$fw connected=true bonded=true")
-        log("reboot: sent opcode=29 framing=$framing payload=empty writeType=withResponse")
-        // Empty body per the official app's builder. withResponse so the ATT write is acked before the drop.
-        send(CommandNumber.REBOOT_STRAP, byteArrayOf(), withResponse = true)
+        log("reboot: sent opcode=$opcode framing=$framing payload=$payloadDesc writeType=withResponse")
+        // withResponse so the ATT write is acked before the strap drops the link.
+        send(command, payload, withResponse = true)
         rebootRequestedAtMs = SystemClock.elapsedRealtime()
         // Drive the Devices "Reconnecting…" pill: true until the strap reconnects (or a terminal path
         // clears it). The pill only shows it once the link actually drops (it gates on !connected).

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -2398,7 +2398,7 @@ class WhoopBleClient(
     fun rebootStrap() {
         // Production Restart: opcode 29 REBOOT_STRAP, empty body per the official app's builder.
         // Confirmed on WHOOP 5.0 (#227); ignored on 4.0 (#235 — see rebootProbe).
-        sendRebootFrame(CommandNumber.REBOOT_STRAP, 29, byteArrayOf(), null)
+        sendRebootFrame(CommandNumber.REBOOT_STRAP, byteArrayOf(), null)
     }
 
     /** Send one candidate reboot frame from the WHOOP 4.0 reboot probe (Test Centre → Connection).
@@ -2411,14 +2411,14 @@ class WhoopBleClient(
             log("reboot: probe is WHOOP 4.0 only — ignored (family=$connectedFamily)")
             return
         }
-        sendRebootFrame(variant.command, variant.opcode, variant.payload, variant)
+        sendRebootFrame(variant.command, variant.payload, variant)
     }
 
     /** Shared reboot send + debug trail + watchdog, used by both the production [rebootStrap] and the
      *  4.0 [rebootProbe]. `probe == null` is the normal restart; a non-null variant is a probe attempt
      *  (its `logTag` is stamped first so the strap log correlates the attempt with what the strap did).
      *  Twin of macOS BLEManager.sendRebootFrame. */
-    private fun sendRebootFrame(command: CommandNumber, opcode: Int, payload: ByteArray, probe: RebootProbeVariant?) {
+    private fun sendRebootFrame(command: CommandNumber, payload: ByteArray, probe: RebootProbeVariant?) {
         val family = connectedFamily
         if (!_state.value.connected || !_state.value.bonded || gatt == null) {
             log("reboot: connect + bond first — ignored (connected=${_state.value.connected} bonded=${_state.value.bonded})")
@@ -2427,6 +2427,9 @@ class WhoopBleClient(
         // Supersede any still-pending reboot (cancels its timers + resets the flag) so a repeat tap can't
         // leave a stale watchdog/settle timer that fires during this new reboot's window.
         clearRebootState()
+        // The logged opcode is always the command's on-wire value — never a separate field that could
+        // disagree with the bytes actually sent.
+        val opcode = command.rawValue
         val framing = if (family == DeviceFamily.WHOOP5) "puffin-crc16 (verified on 5.0 fw 50.40.1.0)" else "harvard-crc8 (UNVERIFIED on 4.0)"
         val fw = _state.value.strapFirmware ?: "unknown"
         val payloadDesc = if (payload.isEmpty()) "empty" else payload.joinToString("") { "%02x".format(it.toInt() and 0xFF) }

--- a/android/app/src/main/java/com/noop/protocol/Enums.kt
+++ b/android/app/src/main/java/com/noop/protocol/Enums.kt
@@ -87,9 +87,11 @@ enum class CommandNumber(val rawValue: Int) {
     // REBOOT_STRAP (29) — restart the strap. Empty body (the official app's builder passes a null
     // payload). The strap drops the link and re-advertises after boot; stored data is KEPT
     // (non-destructive), though an in-flight offload is interrupted (chunk-acked, so nothing is lost).
-    // Opcode 29 is shared across WHOOP 4.0 (harvard/crc8) and 5/MG (puffin/crc16); the 4.0 form is
-    // confirmed, the 5/MG framing is NOT hardware-confirmed — rebootStrap() logs the COMMAND_RESPONSE
-    // so a strap log confirms acceptance. User-initiated + confirmation-gated only; never automatic.
+    // Opcode 29 is shared across WHOOP 4.0 (harvard/crc8) and 5/MG (puffin/crc16). The 5.0 form is
+    // hardware-confirmed (fw 50.40.1.0, #227); the 4.0 form is NOT — a real 4.0 silently IGNORES this
+    // empty-body frame (#235: no reboot, no disconnect, no COMMAND_RESPONSE), so the correct 4.0 frame
+    // still needs an HCI capture. rebootStrap() logs the COMMAND_RESPONSE + a no-disconnect watchdog so a
+    // strap log shows which case it hit. User-initiated + confirmation-gated only; never automatic.
     // Port of Swift WhoopCommand.rebootStrap.
     REBOOT_STRAP(29),
     GET_DATA_RANGE(34),

--- a/android/app/src/main/java/com/noop/protocol/Enums.kt
+++ b/android/app/src/main/java/com/noop/protocol/Enums.kt
@@ -94,6 +94,13 @@ enum class CommandNumber(val rawValue: Int) {
     // strap log shows which case it hit. User-initiated + confirmation-gated only; never automatic.
     // Port of Swift WhoopCommand.rebootStrap.
     REBOOT_STRAP(29),
+    // POWER_CYCLE_STRAP (32) — a harder restart than REBOOT_STRAP (a full power cycle of the strap SoC
+    // vs a warm reboot). Non-destructive: stored data lives in flash and survives, the strap re-advertises
+    // after boot. Included ONLY as a gated candidate for the WHOOP 4.0 reboot probe (#235: a real 4.0
+    // silently ignores opcode 29/empty, and the correct 4.0 reboot frame is unknown). NOT hardware-confirmed
+    // on any family. Sent only via rebootProbe(POWER_CYCLE_32_EMPTY), itself gated behind Test Centre →
+    // Connection + a confirmation. Never sent automatically. Port of Swift WhoopCommand.powerCycleStrap.
+    POWER_CYCLE_STRAP(32),
     GET_DATA_RANGE(34),
     GET_HELLO_HARVARD(35),
     // GET_HELLO (145): WHOOP 5.0/MG hello. The response carries the device name plus `fw_version`
@@ -133,4 +140,38 @@ enum class CommandNumber(val rawValue: Int) {
         private val byRaw = entries.associateBy { it.rawValue }
         fun fromRaw(raw: Int): CommandNumber? = byRaw[raw]
     }
+}
+
+/**
+ * Candidate reboot frames for the WHOOP 4.0 reboot probe (Test Centre → Connection, WHOOP 4.0 only).
+ *
+ * A real WHOOP 4.0 silently ignores NOOP's production reboot frame (opcode 29 REBOOT_STRAP, empty body
+ * — #235: no reboot, no disconnect, no COMMAND_RESPONSE), and the correct 4.0 frame is unknown. These
+ * are the plausible NON-DESTRUCTIVE candidates — a restart / power-cycle only, never a data-wiping
+ * opcode — tried one at a time on real hardware so the strap log tells which one works: `reboot: link
+ * dropped …` = the strap acted; `reboot: no disconnect within 12s …` = ignored.
+ *
+ * The definitive fix is still an HCI capture of the official app rebooting a 4.0 (exactly how the alarm
+ * frame was pinned — @ujix's capture, #535). This probe is the interim way to find the frame when a 4.0
+ * is in hand. Twin of Swift `RebootProbeVariant` (Commands.swift); the [logTag] strings are byte-identical
+ * across platforms so a strap log reads the same either side.
+ */
+enum class RebootProbeVariant(
+    val command: CommandNumber,
+    val opcode: Int,
+    val payload: ByteArray,
+    /** Short menu label, e.g. "A · REBOOT_STRAP(29) empty". */
+    val menuLabel: String,
+    /** Tag written to the strap log so each attempt is correlatable (byte-identical to Swift). */
+    val logTag: String,
+) {
+    // A — opcode 29 REBOOT_STRAP, empty body: NOOP's current production frame (ignored on 4.0).
+    REBOOT_29_EMPTY(CommandNumber.REBOOT_STRAP, 29, byteArrayOf(),
+        "A · REBOOT_STRAP(29) empty", "A/reboot29-empty"),
+    // B — opcode 32 POWER_CYCLE_STRAP, empty body: a harder restart, never tried.
+    POWER_CYCLE_32_EMPTY(CommandNumber.POWER_CYCLE_STRAP, 32, byteArrayOf(),
+        "B · POWER_CYCLE(32) empty", "B/powercycle32-empty"),
+    // C — opcode 29 REBOOT_STRAP, payload [0x01]: same opcode with a non-empty sub-command byte.
+    REBOOT_29_PAYLOAD1(CommandNumber.REBOOT_STRAP, 29, byteArrayOf(0x01),
+        "C · REBOOT_STRAP(29) payload=01", "C/reboot29-payload01"),
 }

--- a/android/app/src/main/java/com/noop/protocol/Enums.kt
+++ b/android/app/src/main/java/com/noop/protocol/Enums.kt
@@ -158,7 +158,6 @@ enum class CommandNumber(val rawValue: Int) {
  */
 enum class RebootProbeVariant(
     val command: CommandNumber,
-    val opcode: Int,
     val payload: ByteArray,
     /** Short menu label, e.g. "A · REBOOT_STRAP(29) empty". */
     val menuLabel: String,
@@ -166,12 +165,12 @@ enum class RebootProbeVariant(
     val logTag: String,
 ) {
     // A — opcode 29 REBOOT_STRAP, empty body: NOOP's current production frame (ignored on 4.0).
-    REBOOT_29_EMPTY(CommandNumber.REBOOT_STRAP, 29, byteArrayOf(),
+    REBOOT_29_EMPTY(CommandNumber.REBOOT_STRAP, byteArrayOf(),
         "A · REBOOT_STRAP(29) empty", "A/reboot29-empty"),
     // B — opcode 32 POWER_CYCLE_STRAP, empty body: a harder restart, never tried.
-    POWER_CYCLE_32_EMPTY(CommandNumber.POWER_CYCLE_STRAP, 32, byteArrayOf(),
+    POWER_CYCLE_32_EMPTY(CommandNumber.POWER_CYCLE_STRAP, byteArrayOf(),
         "B · POWER_CYCLE(32) empty", "B/powercycle32-empty"),
     // C — opcode 29 REBOOT_STRAP, payload [0x01]: same opcode with a non-empty sub-command byte.
-    REBOOT_29_PAYLOAD1(CommandNumber.REBOOT_STRAP, 29, byteArrayOf(0x01),
+    REBOOT_29_PAYLOAD1(CommandNumber.REBOOT_STRAP, byteArrayOf(0x01),
         "C · REBOOT_STRAP(29) payload=01", "C/reboot29-payload01"),
 }

--- a/android/app/src/main/java/com/noop/ui/AppViewModel.kt
+++ b/android/app/src/main/java/com/noop/ui/AppViewModel.kt
@@ -1522,6 +1522,10 @@ class AppViewModel(app: Application) : AndroidViewModel(app) {
      *  the strap keeps its data and re-advertises after boot; NOOP auto-reconnects. See WhoopBleClient.rebootStrap. */
     fun rebootStrap() = ble.rebootStrap()
 
+    /** Send one WHOOP 4.0 reboot-probe candidate (Test Centre → Connection, 4.0 only). Confirmation-gated
+     *  in DevicesScreen; finds the real 4.0 reboot frame when the production one is ignored (#235). */
+    fun rebootProbe(variant: com.noop.protocol.RebootProbeVariant) = ble.rebootProbe(variant)
+
     /**
      * Flip the "keep connected in the background" preference (driven by Settings). Turning it on
      * while a strap is live promotes to the foreground immediately; turning it off drops the

--- a/android/app/src/main/java/com/noop/ui/DevicesScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/DevicesScreen.kt
@@ -272,8 +272,9 @@ fun DevicesScreen(
         ConfirmDialog(
             title = "Restart this strap?",
             message = "Restart ${displayName(device)}? It disconnects for about 30 seconds while it " +
-                "reboots, then reconnects on its own. Your recorded data is kept. On WHOOP 5.0/MG this is " +
-                "experimental — if it doesn't restart, your strap log helps us confirm the command.",
+                "reboots, then reconnects on its own. Your recorded data is kept. Confirmed on WHOOP 5.0; " +
+                "on WHOOP 4.0 the reboot command isn't confirmed yet — if nothing happens, your strap log " +
+                "helps us pin it down.",
             confirmLabel = "Restart",
             destructive = false,
             onConfirm = { viewModel.rebootStrap(); rebootTarget = null },

--- a/android/app/src/main/java/com/noop/ui/DevicesScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/DevicesScreen.kt
@@ -21,6 +21,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.DirectionsRun
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Bolt
+import androidx.compose.material.icons.filled.BugReport
 import androidx.compose.material.icons.filled.Circle
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Delete
@@ -65,6 +66,9 @@ import com.noop.ble.SourceCoordinator
 import com.noop.data.DeviceStatus
 import com.noop.data.PairedDeviceRow
 import com.noop.data.SourceKind
+import com.noop.protocol.RebootProbeVariant
+import com.noop.testcentre.TestCentre
+import com.noop.testcentre.TestDomain
 import kotlinx.coroutines.launch
 
 // MARK: - Devices
@@ -118,6 +122,8 @@ fun DevicesScreen(
     var removeTarget by remember { mutableStateOf<PairedDeviceRow?>(null) }
     var deleteDataTarget by remember { mutableStateOf<PairedDeviceRow?>(null) }
     var rebootTarget by remember { mutableStateOf<PairedDeviceRow?>(null) }
+    // WHOOP 4.0 reboot probe (Test Centre → Connection, 4.0 only) — the device whose probe sheet is open.
+    var probeTarget by remember { mutableStateOf<PairedDeviceRow?>(null) }
     // After removing the ACTIVE device with other devices still paired, prompt to pick a new active one.
     var pickNewActive by remember { mutableStateOf(false) }
 
@@ -178,6 +184,12 @@ fun DevicesScreen(
                     { Toast.makeText(context, "Disconnecting", Toast.LENGTH_SHORT).show(); viewModel.disconnect() }
                 } else null,
                 onReboot = { rebootTarget = device },
+                // 4.0 reboot probe: only offered when Test Centre → Connection is on AND the live strap is
+                // a WHOOP 4.0 (a 5.0 already reboots on the production frame). null otherwise.
+                onRebootProbe = if (device.status == DeviceStatus.active.name && live.connected &&
+                    SourceCoordinator.isWhoop(device) && !live.whoop5Detected &&
+                    TestCentre.from(context).active(TestDomain.CONNECTION)
+                ) { { probeTarget = device } } else null,
             )
         }
 
@@ -282,6 +294,15 @@ fun DevicesScreen(
         )
     }
 
+    // --- WHOOP 4.0 reboot probe (#235): only reachable with Test Centre → Connection on + a 4.0 connected.
+    //     Tries each candidate frame one at a time so the strap log shows which one actually reboots. ---
+    probeTarget?.let {
+        RebootProbeDialog(
+            onSend = { variant -> viewModel.rebootProbe(variant); probeTarget = null },
+            onDismiss = { probeTarget = null },
+        )
+    }
+
     // --- Second, strongly-worded delete-data confirm (from the Removed card's secondary control) ---
     deleteDataTarget?.let { device ->
         ConfirmDialog(
@@ -338,6 +359,9 @@ private fun DeviceCard(
     onConnect: (() -> Unit)? = null,
     onDisconnect: (() -> Unit)? = null,
     onReboot: (() -> Unit)? = null,
+    // WHOOP 4.0 reboot probe (Test Centre → Connection, 4.0 only). Non-null only when the parent has
+    // decided the probe applies (live-connected WHOOP 4.0 + Connection test mode on); null otherwise. (#235)
+    onRebootProbe: (() -> Unit)? = null,
 ) {
     val profile = deviceProfile(device)
     // The per-device actions menu's open state is hoisted here so the WHOLE card is a tap target that opens
@@ -438,6 +462,7 @@ private fun DeviceCard(
                     onConnect = onConnect,
                     onDisconnect = onDisconnect,
                     onReboot = onReboot,
+                    onRebootProbe = onRebootProbe,
                 )
             }
         }
@@ -528,6 +553,7 @@ private fun DeviceActionsMenu(
     onConnect: (() -> Unit)? = null,
     onDisconnect: (() -> Unit)? = null,
     onReboot: (() -> Unit)? = null,
+    onRebootProbe: (() -> Unit)? = null,
 ) {
     Box {
         IconButton(
@@ -570,6 +596,11 @@ private fun DeviceActionsMenu(
                 // BLE link). Confirmation-gated by the parent. (#166)
                 if (isLiveConnected && SourceCoordinator.isWhoop(device) && onReboot != null) {
                     MenuItem("Restart strap…", Icons.Filled.Refresh) { onOpenChange(false); onReboot() }
+                }
+                // 4.0 reboot probe (RE): only present when the parent passed a closure (Test Centre →
+                // Connection on + a live WHOOP 4.0). Finds the real reboot frame the 4.0 accepts (#235).
+                if (onRebootProbe != null) {
+                    MenuItem("Reboot probe (4.0 RE)…", Icons.Filled.BugReport) { onOpenChange(false); onRebootProbe() }
                 }
                 if (onRemove != null) {
                     HorizontalDivider(color = Palette.hairline)
@@ -666,6 +697,48 @@ private fun ConfirmDialog(
         dismissButton = {
             TextButton(onClick = onDismiss) {
                 Text(cancelLabel, style = NoopType.body, color = Palette.textSecondary)
+            }
+        },
+    )
+}
+
+/** WHOOP 4.0 reboot probe (#235): a candidate list, one button per unconfirmed reboot frame. Gated to
+ *  Test Centre → Connection + a live 4.0 at the call site. Twin of the macOS DevicesView confirmationDialog. */
+@Composable
+private fun RebootProbeDialog(
+    onSend: (RebootProbeVariant) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        containerColor = Palette.surfaceOverlay,
+        title = { Text("WHOOP 4.0 reboot probe", style = NoopType.title2, color = Palette.textPrimary) },
+        text = {
+            Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                Text(
+                    "The WHOOP 4.0 reboot frame isn't confirmed — a normal Restart is ignored (#235). " +
+                        "Send each candidate and watch the strap log: “link dropped” means it worked; " +
+                        "“no disconnect within 12s” means the strap ignored it. Non-destructive — your data " +
+                        "is kept. Please share the log so we can pin the real frame.",
+                    style = NoopType.subhead,
+                    color = Palette.textSecondary,
+                )
+                RebootProbeVariant.entries.forEach { variant ->
+                    TextButton(onClick = { onSend(variant) }, modifier = Modifier.fillMaxWidth()) {
+                        Text(
+                            variant.menuLabel,
+                            style = NoopType.body,
+                            color = Palette.accent,
+                            modifier = Modifier.fillMaxWidth(),
+                        )
+                    }
+                }
+            }
+        },
+        confirmButton = {},
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text("Cancel", style = NoopType.body, color = Palette.textSecondary)
             }
         },
     )

--- a/android/app/src/test/java/com/noop/protocol/RebootProbeVariantTest.kt
+++ b/android/app/src/test/java/com/noop/protocol/RebootProbeVariantTest.kt
@@ -1,0 +1,57 @@
+package com.noop.protocol
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Pins the WHOOP 4.0 reboot-probe candidate table (#235). These values are a byte-identical
+ * cross-platform contract: the [RebootProbeVariant.logTag] (and each candidate's command / payload)
+ * MUST match the Swift `RebootProbeVariant` (Strand/BLE/Commands.swift), so a captured 4.0 strap log
+ * reads the same on either platform. Change one side → change the other, or the log stops correlating.
+ */
+class RebootProbeVariantTest {
+
+    private fun ByteArray.hex() = joinToString("") { "%02x".format(it.toInt() and 0xFF) }
+
+    @Test fun tableOrderAndTagsPinned() {
+        assertEquals(3, RebootProbeVariant.entries.size)
+        assertEquals(
+            listOf("A/reboot29-empty", "B/powercycle32-empty", "C/reboot29-payload01"),
+            RebootProbeVariant.entries.map { it.logTag },
+        )
+        assertEquals(
+            listOf(
+                "A · REBOOT_STRAP(29) empty",
+                "B · POWER_CYCLE(32) empty",
+                "C · REBOOT_STRAP(29) payload=01",
+            ),
+            RebootProbeVariant.entries.map { it.menuLabel },
+        )
+    }
+
+    @Test fun candidateA_reboot29Empty() {
+        val a = RebootProbeVariant.REBOOT_29_EMPTY
+        assertEquals(CommandNumber.REBOOT_STRAP, a.command)
+        assertEquals("", a.payload.hex())
+    }
+
+    @Test fun candidateB_powerCycle32Empty() {
+        val b = RebootProbeVariant.POWER_CYCLE_32_EMPTY
+        assertEquals(CommandNumber.POWER_CYCLE_STRAP, b.command)
+        assertEquals("", b.payload.hex())
+    }
+
+    @Test fun candidateC_reboot29Payload1() {
+        val c = RebootProbeVariant.REBOOT_29_PAYLOAD1
+        assertEquals(CommandNumber.REBOOT_STRAP, c.command)
+        assertEquals("01", c.payload.hex())
+    }
+
+    /** The two restart candidates carry the real, distinct wire opcodes (29 reboot, 32 power-cycle) — a
+     *  guard against a candidate silently pointing at the wrong CommandNumber. */
+    @Test fun candidatesUseExpectedWireOpcodes() {
+        assertEquals(29, RebootProbeVariant.REBOOT_29_EMPTY.command.rawValue)
+        assertEquals(32, RebootProbeVariant.POWER_CYCLE_32_EMPTY.command.rawValue)
+        assertEquals(29, RebootProbeVariant.REBOOT_29_PAYLOAD1.command.rawValue)
+    }
+}

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -430,8 +430,10 @@ on both transports — unlike haptics, which has a maverick-specific `0x13`.
   payload. This wipes the rolling ~14-day flash history — anything not already offloaded is gone.
 - `REBOOT_STRAP` (29) — **empty body** (builder `rh0.C45476d0` passes a null payload). The strap drops
   the BLE link and re-advertises after boot; stored data is kept. Non-destructive, but interrupts any
-  in-flight offload. 5/MG framing is not hardware-confirmed (haptics already showed 5/MG can diverge on
-  both opcode and payload), so treat the puffin form as unverified until a real wire capture exists.
+  in-flight offload. **WHOOP 5.0 (puffin): hardware-confirmed** — the empty-body frame reboots a 5.0
+  (fw 50.40.1.0, #227). **WHOOP 4.0 (harvard): NOT confirmed** — a real 4.0 silently ignores this
+  empty-body frame (#235: no reboot, no disconnect, no COMMAND_RESPONSE), so the correct 4.0 form (a
+  payload byte? a different opcode?) still needs an HCI capture of the official app rebooting a 4.0.
 
 ---
 

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -403,20 +403,33 @@ data, brick, or power-cycle the strap. NOOP must never send them.
 | Code | Command | Hazard |
 |-----:|---------|--------|
 | 25 | `FORCE_TRIM` | discards stored data |
-| 32 | `POWER_CYCLE_STRAP` | power-cycles |
+| 32 | `POWER_CYCLE_STRAP` | power-cycles (gated probe exception — see below) |
 | 36 | `START_FIRMWARE_LOAD` | firmware write |
 | 37 | `LOAD_FIRMWARE_DATA` | firmware write |
 | 38 | `PROCESS_FIRMWARE_IMAGE` | firmware write |
 | 45 | `ENTER_BLE_DFU` | enters DFU bootloader |
-
-**One guarded exception — `REBOOT_STRAP` (29).** A plain restart is the one command on this list that
-is *non-destructive*: the strap keeps its stored data and just re-advertises after boot, and NOOP
-already triggers a reboot today via `SET_ADVERTISING_NAME_HARVARD` (rename applies on reboot). It is
-in `WhoopCommand` as `rebootStrap`, but sent **only** from the user-initiated, confirmation-gated
-"Restart strap" action (`BLEManager.rebootStrap()` / `WhoopBleClient.rebootStrap()`) — never
-automatically, and never as part of any connect/offload path (#166). Everything else in this table
-stays out of the enum entirely.
 | 99 | `RESET_FUEL_GAUGE` | resets battery fuel gauge |
+
+**Two guarded exceptions — both restarts, both non-destructive** (a restart keeps the strap's stored
+data and just re-advertises after boot). Neither is ever sent automatically or on any connect/offload path.
+
+- **`REBOOT_STRAP` (29)** — the normal Restart. NOOP already triggers a reboot today via
+  `SET_ADVERTISING_NAME_HARVARD` (rename applies on reboot). In `WhoopCommand` as `rebootStrap`, sent only
+  from the user-initiated, confirmation-gated "Restart strap" action (`BLEManager.rebootStrap()` /
+  `WhoopBleClient.rebootStrap()`) (#166).
+- **`POWER_CYCLE_STRAP` (32)** — a harder restart, in the enum as `powerCycleStrap` **only** as a candidate
+  for the WHOOP 4.0 reboot probe (below). Sent only from `rebootProbe(.powerCycle32Empty)`, itself gated
+  behind Test Centre → Connection + a confirmation, and 4.0-only. Never on a default install.
+
+Everything else in this table stays out of the enum entirely.
+
+**WHOOP 4.0 reboot probe (#235).** A real 4.0 silently ignores the production `REBOOT_STRAP` frame (see
+below) and the correct 4.0 reboot frame is unknown. The probe (Test Centre → Connection, 4.0 only) sends
+one non-destructive candidate at a time — `REBOOT_STRAP(29)` empty, `POWER_CYCLE_STRAP(32)` empty, or
+`REBOOT_STRAP(29)` with `[0x01]` — reusing the reboot watchdog so the strap log shows which one drops the
+link (worked) vs is ignored. The definitive fix is still an HCI capture of the official app rebooting a
+4.0 (the way the alarm frame was pinned, #535). Driven by `BLEManager.rebootProbe(_:)` /
+`WhoopBleClient.rebootProbe(...)`; candidates enumerated in `RebootProbeVariant`.
 
 **Payload forms** (decoded from the official app's command builders — recorded so the wire format is
 *known*: for the destructive commands, known-and-avoidable; for the one guarded exception,


### PR DESCRIPTION
**Supersedes #242.** This PR now carries the honesty patch (first commit) *and* the probe on top, straight onto `main` — #242 can be closed unmerged.

#242 makes the app *honest* that the WHOOP 4.0 reboot isn't confirmed — but the strap still won't reboot. The correct 4.0 frame is unknown. This PR is the tool to **find** it.

## The probe
Test Centre → Connection, **WHOOP 4.0 only**: a **"Reboot probe (4.0 RE)…"** entry in the device menu opens a candidate list and sends one **non-destructive** frame at a time, reusing the #216 reboot watchdog so the strap log tells you which one worked:

| | Candidate | Meaning |
|---|---|---|
| A | `REBOOT_STRAP(29)` empty | current production frame (ignored on 4.0, #235) |
| B | `POWER_CYCLE(32)` empty | a harder restart, never tried |
| C | `REBOOT_STRAP(29)` payload `01` | same opcode + a non-empty sub-command byte |

Read the strap log after each: `reboot: link dropped …` = it worked → that's the frame; `reboot: no disconnect within 12s …` = the strap ignored it, try the next.

## Why this is the right shape
The definitive fix is an HCI capture of the official app rebooting a 4.0 — exactly how the **alarm** frame was pinned (@ujix's capture, #535). No 4.0 is in hand to capture yet, so this probe finds the frame empirically the moment one is, without shipping another blind guess (the mistake that caused #235).

## Safety
- `POWER_CYCLE_STRAP(32)` is added as a **second guarded exception** to the command enum: a restart is non-destructive (stored data lives in flash), sent **only** via `rebootProbe()`, **4.0-only**, **confirmation-gated**, **never automatic**. `FORCE_TRIM` / firmware / DFU / fuel-gauge stay fully excluded.
- Backend hard-guards `family == WHOOP4`; UI gated on Connection test mode + a live 4.0. A 5.0 already reboots on the production frame (#227) — nothing to probe there.
- `rebootStrap()` refactored to a shared `sendRebootFrame()`; the production path is byte-for-byte unchanged (`opcode=29 … payload=empty`).

## Parity & tests
- New `RebootProbeVariant` on both platforms, **byte-identical** `logTag` strings.
- Android `compileFullDebugKotlin` + `com.noop.protocol.*` tests pass; app-target Swift validated via `app-build`.
- On-device: **no 4.0 to hand yet** — this *is* the tool to run once one is.

`PROTOCOL.md` documents the probe and the two guarded restart exceptions.