### PR TITLE
Android: canonical import outranks computed sibling in sourceCandidates (parity with #241)

### DIFF
--- a/android/app/src/main/java/com/noop/data/WhoopRepository.kt
+++ b/android/app/src/main/java/com/noop/data/WhoopRepository.kt
@@ -1377,17 +1377,19 @@ class WhoopRepository(private val dao: WhoopDao) {
                 return seen.toList()
             }
             if (preferredSource == WHOOP_SOURCE || preferredSource == strapDeviceId) {
-                // Active strap first (live/measured wins per day), then the CANONICAL "my-whoop" import +
-                // its computed sibling so history banked under the canonical id BEFORE a re-add still
-                // resolves , the #814 union model the rest of the read spine already follows
-                // ([importedSourceIdsFor]); the resolver never got wired into it (#1008). uniqued()
-                // collapses these to one pair on a single-device install (active == canonical), so that
-                // path stays byte-identical. Apple is the final cross-source fallback. Mirrors Swift
-                // Repository.sourceCandidates.
+                // Active strap first (live/measured wins per day), then the CANONICAL "my-whoop" import,
+                // THEN the computed siblings, so history banked under the canonical id before a re-add
+                // still resolves (the #814/#1008 union model) AND imports outrank computed estimates — the
+                // documented `imported WHOOP > NOOP-computed` order. The computed sibling used to sit ahead
+                // of the canonical import, so after a device re-add (active != canonical) the new strap's
+                // computed estimates shadowed richer imported my-whoop history. uniqued() collapses these
+                // to one pair per source on a single-device install (active == canonical), so that path
+                // stays byte-identical. Apple is the final cross-source fallback. Mirrors Swift
+                // Repository.sourceCandidates (ryanbr/noop#241).
                 val candidates = mutableListOf(
                     MetricSourceCandidate(strapDeviceId, key),
-                    MetricSourceCandidate(computedSource, key),
                     MetricSourceCandidate(WHOOP_SOURCE, key),
+                    MetricSourceCandidate(computedSource, key),
                     MetricSourceCandidate("$WHOOP_SOURCE-noop", key),
                 )
                 appleCompatibleKey(key)?.let {

--- a/android/app/src/test/java/com/noop/data/ResolverUnionTest.kt
+++ b/android/app/src/test/java/com/noop/data/ResolverUnionTest.kt
@@ -40,13 +40,14 @@ class ResolverUnionTest {
         assertEquals(listOf("my-whoop", "my-whoop-noop"), candidateSources(strap = canonical))
     }
 
-    /** After a re-add the resolver tries the ACTIVE id + its computed sibling FIRST (live/measured wins
-     *  per day), then falls back to the canonical "my-whoop"/"my-whoop-noop" so daily metrics + scores
-     *  banked BEFORE the re-add still resolve. Before #1008 the canonical fallback was missing. */
+    /** After a re-add the resolver tries the ACTIVE strap first (live/measured wins per day), then the
+     *  CANONICAL "my-whoop" IMPORT, then the computed siblings — imports outrank computed estimates, so a
+     *  fresh strap's computed rows no longer shadow richer imported my-whoop history (ryanbr/noop#241
+     *  precedence fix). Before #1008 the canonical fallback was missing entirely. */
     @Test
     fun reAddCandidatesUnionActiveThenCanonical() {
         assertEquals(
-            listOf(reAdded, "$reAdded-noop", "my-whoop", "my-whoop-noop"),
+            listOf(reAdded, "my-whoop", "$reAdded-noop", "my-whoop-noop"),
             candidateSources(strap = reAdded),
         )
     }
@@ -58,7 +59,7 @@ class ResolverUnionTest {
     fun appleFallbackAppendsLastWithMappedKey() {
         val candidates = WhoopRepository.sourceCandidates("rhr", canonical, reAdded)
         assertEquals(
-            listOf(reAdded, "$reAdded-noop", "my-whoop", "my-whoop-noop", "apple-health"),
+            listOf(reAdded, "my-whoop", "$reAdded-noop", "my-whoop-noop", "apple-health"),
             candidates.map { it.source },
         )
         assertEquals("resting_hr", candidates.last().key)


### PR DESCRIPTION
**Follow-up to #241 — the missing Android half.** Land this together with #241.

## Why
#241 reorders `Repository.sourceCandidates` on **Swift only** so the canonical `my-whoop` import outranks the active strap's computed sibling (`<id>-noop`). But Android's `WhoopRepository.sourceCandidates` currently has the **same old order** — I verified on `fork/main`, and its comment even says *"Mirrors Swift Repository.sourceCandidates."* So merging #241 alone would make the two platforms resolve daily metrics in a **different precedence** after a device re-add — a violation of the byte-identical analytics/stored-data contract.

Note: #241's body says this was "already fixed on Android via #240." It wasn't — **#240 is still OPEN**, and its `WhoopRepository.kt` change is the `coveredDays` richness gate; it does not touch `sourceCandidates` ordering. There is no Android twin for the reorder until this PR.

## What
Move `WHOOP_SOURCE` ahead of `computedSource` in the strap-preferred candidate list, so both *real* sources (active-measured, canonical-import) precede the *computed* siblings:

```
before:  [active, active-noop, my-whoop, my-whoop-noop]   (+ apple)
after:   [active, my-whoop, active-noop, my-whoop-noop]   (+ apple)
```

This matches #241's Swift order exactly and implements the documented `imported WHOOP > NOOP-computed` precedence.

## Safety / tests
- **Single-device installs unchanged:** active == canonical, so `uniqued()` still collapses to `[my-whoop, my-whoop-noop, apple]` — byte-identical to before.
- Apple-preferred branch untouched.
- `ResolverUnionTest` updated to pin the corrected re-add order; `compileFullDebugKotlin` + `ResolverUnionTest` pass (8/0).

FYI for whoever finalizes #241: two trivial comment typos in its new tests (`"signal , keep"`, `"equivalent , no"`) — worth a stray-comma cleanup there.