### PR TITLE
Android: mergeSleep richness exception — stage-less import yields to computed stages (parity with #241)

### DIFF
--- a/android/app/src/main/java/com/noop/data/WhoopRepository.kt
+++ b/android/app/src/main/java/com/noop/data/WhoopRepository.kt
@@ -1705,14 +1705,26 @@ class WhoopRepository(private val dao: WhoopDao) {
                 val offsetSec = (java.util.TimeZone.getDefault().getOffset(s.endTs * 1000) / 1000).toLong()
                 return com.noop.analytics.AnalyticsEngine.dayString(s.endTs, offsetSec)
             }
-            // #715 — preserve EVERY session (a day with a main night + a nap must keep both); imported
-            // still wins per end-day. Richness exception (ryanbr/noop#241): a sparse import (no stage
-            // data on ANY of its sessions that day) must NOT clobber a computed day that HAS stage data —
-            // otherwise a stage-less WHOOP/Apple/HC re-import blanks the stage breakdown for a night the
-            // strap fully staged. Days where the import carries stages, or where neither side does, keep
-            // the imported-wins rule. Mirrors WhoopStore.SleepMerge (SleepMergeTests).
-            val importedByDay = imported.groupBy { endDay(it) }
-            val computedByDay = computed.groupBy { endDay(it) }
+            return mergeSleepRichness(imported, computed, ::endDay).sortedBy { it.startTs }
+        }
+
+        /** Imported-wins-per-day sleep merge WITH the #241 richness exception, returned UNSORTED so callers
+         *  can apply their own sort/keyer. [mergeSleep] is this keyed by local wake-day + sorted by startTs;
+         *  the Sleep screen (SleepScreen) keys the same way but sorts by effectiveStartTs (#395), so it calls
+         *  this directly to get the SAME richness rule the browse/CSV path uses.
+         *
+         *  #715 — preserve EVERY session (a day with a main night + a nap must keep both). Richness exception
+         *  (ryanbr/noop#241): a sparse import (no stage data on ANY of its sessions that day) must NOT clobber
+         *  a computed day that HAS stage data — otherwise a stage-less WHOOP/Apple/HC re-import blanks the
+         *  stage breakdown for a night the strap fully staged. Days where the import carries stages, or where
+         *  neither side does, keep the imported-wins rule. Mirrors WhoopStore.SleepMerge (SleepMergeTests). */
+        internal fun mergeSleepRichness(
+            imported: List<SleepSession>,
+            computed: List<SleepSession>,
+            endDay: (SleepSession) -> String,
+        ): List<SleepSession> {
+            val importedByDay = imported.groupBy(endDay)
+            val computedByDay = computed.groupBy(endDay)
             val out = ArrayList<SleepSession>(imported.size + computed.size)
             for ((day, imp) in importedByDay) {
                 val comp = computedByDay[day]
@@ -1723,7 +1735,7 @@ class WhoopRepository(private val dao: WhoopDao) {
                 }
             }
             for ((day, comp) in computedByDay) if (day !in importedByDay) out.addAll(comp)
-            return out.sortedBy { it.startTs }
+            return out
         }
 
         /** True when the session carries a non-empty stage payload; null, "", and "[]" carry none.

--- a/android/app/src/main/java/com/noop/data/WhoopRepository.kt
+++ b/android/app/src/main/java/com/noop/data/WhoopRepository.kt
@@ -1706,13 +1706,31 @@ class WhoopRepository(private val dao: WhoopDao) {
                 return com.noop.analytics.AnalyticsEngine.dayString(s.endTs, offsetSec)
             }
             // #715 — preserve EVERY session (a day with a main night + a nap must keep both); imported
-            // still wins per end-day. The old LinkedHashMap<String, SleepSession> overwrote on collision
-            // and silently dropped a second same-day session. Mirrors WhoopStore.SleepMerge (SleepMergeTests).
-            val importedDays = imported.mapTo(HashSet()) { endDay(it) }
+            // still wins per end-day. Richness exception (ryanbr/noop#241): a sparse import (no stage
+            // data on ANY of its sessions that day) must NOT clobber a computed day that HAS stage data —
+            // otherwise a stage-less WHOOP/Apple/HC re-import blanks the stage breakdown for a night the
+            // strap fully staged. Days where the import carries stages, or where neither side does, keep
+            // the imported-wins rule. Mirrors WhoopStore.SleepMerge (SleepMergeTests).
+            val importedByDay = imported.groupBy { endDay(it) }
+            val computedByDay = computed.groupBy { endDay(it) }
             val out = ArrayList<SleepSession>(imported.size + computed.size)
-            out.addAll(imported)
-            for (s in computed) if (endDay(s) !in importedDays) out.add(s)
+            for ((day, imp) in importedByDay) {
+                val comp = computedByDay[day]
+                if (comp != null && imp.none { hasStages(it) } && comp.any { hasStages(it) }) {
+                    out.addAll(comp)   // richer computed day survives a stage-less import
+                } else {
+                    out.addAll(imp)    // imported wins its day (unchanged rule)
+                }
+            }
+            for ((day, comp) in computedByDay) if (day !in importedByDay) out.addAll(comp)
             return out.sortedBy { it.startTs }
+        }
+
+        /** True when the session carries a non-empty stage payload; null, "", and "[]" carry none.
+         *  Twin of WhoopStore.SleepMerge.hasStages. */
+        private fun hasStages(s: SleepSession): Boolean {
+            val json = s.stagesJSON?.trim() ?: return false
+            return json.isNotEmpty() && json != "[]"
         }
     }
 }

--- a/android/app/src/main/java/com/noop/ui/SleepScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/SleepScreen.kt
@@ -85,6 +85,7 @@ import com.noop.analytics.SleepEditGuard
 import com.noop.analytics.SleepStageTotals
 import com.noop.data.DailyMetric
 import com.noop.data.SleepSession
+import com.noop.data.WhoopRepository
 import kotlinx.coroutines.launch
 import org.json.JSONArray
 import org.json.JSONObject
@@ -178,10 +179,12 @@ fun SleepScreen(
                 val offsetSec = (java.util.TimeZone.getDefault().getOffset(ts * 1000) / 1000).toLong()
                 return AnalyticsEngine.dayString(ts, offsetSec)
             }
-            val importedDays = imported.map { localEndDay(it.endTs) }.toHashSet()
-            val computedOnly = computed.filter { localEndDay(it.endTs) !in importedDays }
-            // Sort by the EFFECTIVE onset so a hand-edited bedtime orders the night correctly. (PR #395)
-            (imported + computedOnly).sortedBy { it.effectiveStartTs }
+            // Imported wins per local wake-day, WITH the #241 richness exception (a stage-less import
+            // yields to a computed day that has stages) — the SAME rule the browse/CSV path uses via
+            // WhoopRepository.mergeSleep. Sort by the EFFECTIVE onset so a hand-edited bedtime orders the
+            // night correctly (PR #395).
+            WhoopRepository.mergeSleepRichness(imported, computed) { localEndDay(it.endTs) }
+                .sortedBy { it.effectiveStartTs }
         }.getOrDefault(emptyList())
         nightOffset = 0
     }
@@ -505,9 +508,9 @@ fun SleepScreen(
                                 val offsetSec = (java.util.TimeZone.getDefault().getOffset(ts * 1000) / 1000).toLong()
                                 return AnalyticsEngine.dayString(ts, offsetSec)
                             }
-                            val importedDays = importedSessions.map { localEndDay(it.endTs) }.toHashSet()
-                            val computedOnly = computed.filter { localEndDay(it.endTs) !in importedDays }
-                            (importedSessions + computedOnly).sortedBy { it.effectiveStartTs }
+                            // Same imported-wins + #241 richness merge as the main loader.
+                            WhoopRepository.mergeSleepRichness(importedSessions, computed) { localEndDay(it.endTs) }
+                                .sortedBy { it.effectiveStartTs }
                         }.getOrDefault(sleeps)
                     }
                 },

--- a/android/app/src/test/java/com/noop/data/MergeSleepLocalDayTest.kt
+++ b/android/app/src/test/java/com/noop/data/MergeSleepLocalDayTest.kt
@@ -24,8 +24,10 @@ class MergeSleepLocalDayTest {
 
     @After fun restore() { TimeZone.setDefault(saved) }
 
-    private fun session(startUtc: Long, endUtc: Long) =
-        SleepSession(deviceId = "my-whoop-noop", startTs = startUtc, endTs = endUtc)
+    private fun session(startUtc: Long, endUtc: Long, stages: String? = null) =
+        SleepSession(deviceId = "my-whoop-noop", startTs = startUtc, endTs = endUtc, stagesJSON = stages)
+
+    private val someStages = """[{"start":0,"end":3600,"stage":"deep"}]"""
 
     /**
      * Two nights, each WAKING at 01:30 LOCAL (UTC+3) on consecutive days, must collapse to two DISTINCT
@@ -83,5 +85,56 @@ class MergeSleepLocalDayTest {
         assertEquals("imported wins on the shared local wake-day", 1, merged.size)
         assertNotNull(merged.first().efficiency)
         assertEquals(95.0, merged.first().efficiency!!, 1e-9)
+    }
+
+    // Richness exception (Android twin of ryanbr/noop#241): a stage-less import must not blank a
+    // computed day that has stage data. Mirrors the Swift SleepMergeTests richness cases.
+
+    private val wake = 1_781_389_800L // 2026-06-14 01:30 local (UTC+3)
+
+    @Test
+    fun mergeSleep_stagelessImportYieldsToComputedDayWithStages() {
+        val comp = session(wake - 8 * 3600L, wake, someStages)
+        val imp = session(wake - 6 * 3600L, wake, null) // same local wake-day, no stages
+        val merged = WhoopRepository.mergeSleep(imported = listOf(imp), computed = listOf(comp))
+        assertEquals("computed with stages survives a stage-less import", listOf(comp.startTs), merged.map { it.startTs })
+    }
+
+    @Test
+    fun mergeSleep_importWithStagesStillWinsItsDay() {
+        val comp = session(wake - 8 * 3600L, wake, someStages)
+        val imp = session(wake - 6 * 3600L, wake, someStages)
+        val merged = WhoopRepository.mergeSleep(imported = listOf(imp), computed = listOf(comp))
+        assertEquals("imported-wins unchanged when the import has stages", listOf(imp.startTs), merged.map { it.startTs })
+    }
+
+    @Test
+    fun mergeSleep_neitherSideHasStages_importStillWins() {
+        val comp = session(wake - 8 * 3600L, wake, null)
+        val imp = session(wake - 6 * 3600L, wake, null)
+        val merged = WhoopRepository.mergeSleep(imported = listOf(imp), computed = listOf(comp))
+        assertEquals("no richness signal -> keep imported-wins", listOf(imp.startTs), merged.map { it.startTs })
+    }
+
+    @Test
+    fun mergeSleep_emptyArrayAndBlankStagesCountAsStageless() {
+        val next = wake + 86_400L
+        val comp0 = session(wake - 8 * 3600L, wake, someStages)
+        val impEmpty = session(wake - 6 * 3600L, wake, "[]")
+        val comp1 = session(next - 8 * 3600L, next, someStages)
+        val impBlank = session(next - 6 * 3600L, next, "  ")
+        val merged = WhoopRepository.mergeSleep(imported = listOf(impEmpty, impBlank), computed = listOf(comp0, comp1))
+        assertEquals("\"[]\" and blank JSON are not stages", listOf(comp0.startTs, comp1.startTs), merged.map { it.startTs })
+    }
+
+    @Test
+    fun mergeSleep_richnessExceptionKeepsEverySessionOfWinningDay() {
+        // computed main night (with stages) + computed nap (no stages); import is stage-less.
+        // The WHOLE computed day survives — #715's keep-every-session guarantee still holds.
+        val night = session(wake - 8 * 3600L, wake, someStages)
+        val nap = session(wake + 10 * 3600L, wake + 11 * 3600L, null) // same local day, no stages
+        val imp = session(wake - 6 * 3600L, wake, null)
+        val merged = WhoopRepository.mergeSleep(imported = listOf(imp), computed = listOf(night, nap))
+        assertEquals("whole computed day (incl. stage-less nap) survives", listOf(night.startTs, nap.startTs), merged.map { it.startTs })
     }
 }

--- a/android/app/src/test/java/com/noop/data/MergeSleepLocalDayTest.kt
+++ b/android/app/src/test/java/com/noop/data/MergeSleepLocalDayTest.kt
@@ -137,4 +137,15 @@ class MergeSleepLocalDayTest {
         val merged = WhoopRepository.mergeSleep(imported = listOf(imp), computed = listOf(night, nap))
         assertEquals("whole computed day (incl. stage-less nap) survives", listOf(night.startTs, nap.startTs), merged.map { it.startTs })
     }
+
+    /** The Sleep screen calls [WhoopRepository.mergeSleepRichness] directly (it sorts by effectiveStartTs,
+     *  not startTs), so pin that it applies the SAME richness rule and returns UNSORTED for the caller. */
+    @Test
+    fun mergeSleepRichness_appliesRichnessAndDoesNotSort() {
+        fun endDay(s: SleepSession) = (s.endTs / 86_400L).toString()
+        val comp = session(wake - 8 * 3600L, wake, someStages)
+        val imp = session(wake - 6 * 3600L, wake, null) // same day, stage-less
+        val out = WhoopRepository.mergeSleepRichness(listOf(imp), listOf(comp), ::endDay)
+        assertEquals("stage-less import yields to computed-with-stages", listOf(comp.startTs), out.map { it.startTs })
+    }
 }


### PR DESCRIPTION
**Re-review follow-up to the merged #241 + #246.** Closes the last parity gap from that pair.

## The gap
#241 added a *richness exception* to Swift `WhoopStore.SleepMerge.merge` — a stage-less import must not blank a computed day that has stage data. But the direct Kotlin twin, `WhoopRepository.mergeSleep` (whose own comment says *"Mirrors WhoopStore.SleepMerge (SleepMergeTests)"*), still had the plain imported-wins logic:

```kotlin
val importedDays = imported.mapTo(HashSet()) { endDay(it) }
out.addAll(imported)
for (s in computed) if (endDay(s) !in importedDays) out.add(s)
```

So after the merge, the two shared-logic twins **diverged**: on iOS a stage-less WHOOP/Apple re-import yields to computed stages; on Android it still clobbered them.

## Why #240 doesn't cover it
#240 (still open) fixes the Android side a *different* way — a Health-Connect-specific `coveredDays` write-gate plus `purgeHcShadowed*` heal that deletes sparse HC rows. It never touches `mergeSleep`, and it only guards **Health Connect** imports — a sparse **Apple/CSV** import would still clobber computed stages at the merge. This PR is the `mergeSleep`-level twin that matches Swift for **all** import sources.

## The fix
Port the exception into `mergeSleep` (group by end-day; if the import for a day has no stages and the computed day does, the computed sessions win — otherwise imported wins, unchanged). Adds `hasStages()` with byte-identical semantics to Swift (`null` / `""` / `"[]"` / blank = no stages).

## Tests
Mirror Swift `SleepMergeTests`' 5 richness cases in `MergeSleepLocalDayTest` (stage-less→computed, import-with-stages-wins, neither-side, `[]`/blank stageless, keep-every-session-of-winning-day). `compileFullDebugKotlin` + `MergeSleepLocalDayTest` pass (8/0). Single-day imported-wins and #715/#304 behaviour unchanged.

---
**Re-review update (2nd commit):** the first commit fixed `mergeSleep` (CSV export + HealthConnectWriter) but the **Sleep screen** builds its night list with its own inline imported-wins merge (two sites) that had no richness — so the actual sleep display would still blank stages on Android while iOS doesn't. Extracted `mergeSleepRichness` and routed both `SleepScreen` sites through it (preserving their `effectiveStartTs` sort). All three sleep consumers now share one richness rule. Tests 9/0.