### PR TITLE
Predictive low-battery alert: warn at ~24h of estimated runtime, both platforms

### DIFF
--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/BatteryEstimator.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/BatteryEstimator.swift
@@ -246,4 +246,32 @@ public enum BatteryEstimator {
         if hours < 48 { return "~\(Int(hours.rounded()))h" }
         return "~\(String(format: "%.1f", hours / 24)) days"
     }
+
+    // MARK: - Predictive low-battery alert policy
+
+    /// Fire the runtime alert when the estimate drops to this many hours of remaining life. A fixed
+    /// SoC threshold gives wildly different lead time per strap generation (15% is ~16 h on a 4.0 but
+    /// ~1.8 days on a 5.0/MG); a runtime threshold means the same "charge it tonight" warning for both.
+    public static let runtimeAlertHours: Double = 24
+    /// Re-arm only when the estimate recovers to this. The 12 h hysteresis band means jitter in the
+    /// fitted slope around the alert line can't re-fire; only a genuine charge opens the gate again.
+    public static let runtimeRearmHours: Double = 36
+
+    /// Crossing-with-hysteresis decision for the predictive alert, mirroring
+    /// `BatteryNotifier.BatteryAlertPolicy.evaluate`'s shape: PERSISTED `alerted` gate in, fire
+    /// decision plus next gate state out. Pure so it's `swift test`-covered here (the SoC policy
+    /// lives in the app target where only xcodebuild tests reach it).
+    ///
+    /// `charging == nil` means unknown — the alert still fires (only a confirmed `true` suppresses
+    /// it), the same null-tolerant rule as the SoC low alert: the strap reports its charge bit only
+    /// every ~8 min, and a strap that never reports one should still warn.
+    public static func runtimeAlert(remainingHours: Double,
+                                    charging: Bool?,
+                                    alerted: Bool) -> (fire: Bool, newAlerted: Bool) {
+        var armedOff = alerted
+        if remainingHours >= runtimeRearmHours { armedOff = false }
+        let fire = !armedOff && remainingHours <= runtimeAlertHours && charging != true
+        if fire { armedOff = true }
+        return (fire, armedOff)
+    }
 }

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/BatteryRuntimeAlertTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/BatteryRuntimeAlertTests.swift
@@ -1,0 +1,57 @@
+import XCTest
+@testable import StrandAnalytics
+
+final class BatteryRuntimeAlertTests: XCTestCase {
+
+    func testFiresAtThresholdAndArms() {
+        let r = BatteryEstimator.runtimeAlert(remainingHours: 24, charging: false, alerted: false)
+        XCTAssertTrue(r.fire)
+        XCTAssertTrue(r.newAlerted)
+    }
+
+    func testAboveThresholdNoFire() {
+        let r = BatteryEstimator.runtimeAlert(remainingHours: 25, charging: false, alerted: false)
+        XCTAssertFalse(r.fire)
+        XCTAssertFalse(r.newAlerted)
+    }
+
+    func testJitterInsideBandCannotRefire() {
+        // Fired at 24h, estimate bounces 23 → 26 → 22: still armed-off, no second alert.
+        var alerted = BatteryEstimator.runtimeAlert(remainingHours: 23, charging: nil, alerted: false).newAlerted
+        XCTAssertTrue(alerted)
+        for hours in [26.0, 22.0, 30.0, 24.0] {
+            let r = BatteryEstimator.runtimeAlert(remainingHours: hours, charging: nil, alerted: alerted)
+            XCTAssertFalse(r.fire, "re-fired at \(hours)h inside the hysteresis band")
+            alerted = r.newAlerted
+        }
+    }
+
+    func testRearmsOnGenuineRecoveryThenFiresNextCycle() {
+        // Charge recovers the estimate past 36h → gate re-arms; the next drop to 24h fires again.
+        var alerted = BatteryEstimator.runtimeAlert(remainingHours: 20, charging: nil, alerted: false).newAlerted
+        let recovered = BatteryEstimator.runtimeAlert(remainingHours: 100, charging: nil, alerted: alerted)
+        XCTAssertFalse(recovered.fire)
+        XCTAssertFalse(recovered.newAlerted)
+        alerted = recovered.newAlerted
+        XCTAssertTrue(BatteryEstimator.runtimeAlert(remainingHours: 24, charging: nil, alerted: alerted).fire)
+    }
+
+    func testConfirmedChargingSuppressesButUnknownFires() {
+        XCTAssertFalse(BatteryEstimator.runtimeAlert(remainingHours: 10, charging: true, alerted: false).fire)
+        XCTAssertTrue(BatteryEstimator.runtimeAlert(remainingHours: 10, charging: nil, alerted: false).fire)
+    }
+
+    func testChargingSuppressionDoesNotArmGate() {
+        // Suppressed while charging must NOT consume the once-per-cycle gate: unplug below the
+        // threshold and the alert should still fire.
+        let plugged = BatteryEstimator.runtimeAlert(remainingHours: 10, charging: true, alerted: false)
+        XCTAssertFalse(plugged.newAlerted)
+        XCTAssertTrue(BatteryEstimator.runtimeAlert(remainingHours: 10, charging: false,
+                                                    alerted: plugged.newAlerted).fire)
+    }
+
+    func testRearmBoundaryIsInclusive() {
+        XCTAssertFalse(BatteryEstimator.runtimeAlert(remainingHours: 36, charging: nil, alerted: true).newAlerted)
+        XCTAssertTrue(BatteryEstimator.runtimeAlert(remainingHours: 35.9, charging: nil, alerted: true).newAlerted)
+    }
+}

--- a/Strand/App/AppModel.swift
+++ b/Strand/App/AppModel.swift
@@ -257,6 +257,12 @@ final class AppModel: ObservableObject {
             BatteryNotifier.onBatteryUpdate(pct: Int(pct.rounded()),
                                             charging: self.live.charging,
                                             enabled: self.behavior.batteryAlerts)
+            // Predictive runtime alert: the same reading just banked into the SoC buffer, so
+            // batteryEstimate is fresh here. Nil estimate (no readings yet) is a no-op — the 15%
+            // alert above remains the safety net.
+            BatteryNotifier.onRuntimeEstimate(remainingHours: self.live.batteryEstimate?.remainingHours,
+                                              charging: self.live.charging,
+                                              enabled: self.behavior.batteryAlerts)
         }
         // HR-zone haptic coaching watches the smoothed bpm.
         $bpm.sink { [weak self] hr in self?.coachZone(hr) }.store(in: &hrCancellables)

--- a/Strand/App/AppModel.swift
+++ b/Strand/App/AppModel.swift
@@ -262,7 +262,8 @@ final class AppModel: ObservableObject {
             // alert above remains the safety net.
             BatteryNotifier.onRuntimeEstimate(remainingHours: self.live.batteryEstimate?.remainingHours,
                                               charging: self.live.charging,
-                                              enabled: self.behavior.batteryAlerts)
+                                              enabled: self.behavior.batteryAlerts
+                                                    && self.behavior.batteryPredictiveAlerts)
         }
         // HR-zone haptic coaching watches the smoothed bpm.
         $bpm.sink { [weak self] hr in self?.coachZone(hr) }.store(in: &hrCancellables)

--- a/Strand/Data/BehaviorStore.swift
+++ b/Strand/Data/BehaviorStore.swift
@@ -50,6 +50,9 @@ final class BehaviorStore: ObservableObject {
     // MARK: Strap battery alerts
     /// Notify on low strap battery (≤15%) and full charge (100%). Default ON (#368).
     @Published var batteryAlerts: Bool { didSet { d.set(batteryAlerts, forKey: K.batteryAlerts) } }
+    /// Predictive "recharge tonight" warning at ~24h of estimated runtime left. Sub-gate under
+    /// batteryAlerts (both must be on). Default ON so pre-toggle behavior is unchanged.
+    @Published var batteryPredictiveAlerts: Bool { didSet { d.set(batteryPredictiveAlerts, forKey: K.batteryPredictiveAlerts) } }
 
     private let d = UserDefaults.standard
     private enum K {
@@ -73,6 +76,7 @@ final class BehaviorStore: ObservableObject {
         // preserved should a real light-sleep watcher ever land.
         static let illness = "behavior.illnessWatch"
         static let batteryAlerts = "behavior.batteryAlerts"
+        static let batteryPredictiveAlerts = "behavior.batteryPredictiveAlerts"
     }
 
     init() {
@@ -94,6 +98,7 @@ final class BehaviorStore: ObservableObject {
         smartAlarmWeekdays = Set((d.array(forKey: K.alarmWeekdays) as? [Int] ?? []).filter { (1...7).contains($0) })
         illnessWatch = d.object(forKey: K.illness) as? Bool ?? false
         batteryAlerts = d.object(forKey: K.batteryAlerts) as? Bool ?? true
+        batteryPredictiveAlerts = d.object(forKey: K.batteryPredictiveAlerts) as? Bool ?? true
     }
 
     // MARK: Charge baseline recalibration

--- a/Strand/Screens/AutomationsView.swift
+++ b/Strand/Screens/AutomationsView.swift
@@ -367,6 +367,11 @@ struct AutomationsView: View {
                 .onChangeCompat(of: behavior.batteryAlerts) { on in
                     if on { BatteryNotifier.requestAuthorization() }
                 }
+            if behavior.batteryAlerts {
+                ToggleRow(label: String(localized: "Predictive runtime warning"),
+                          help: String(localized: "An early \"recharge tonight\" heads-up when the strap has about a day of estimated runtime left, at most once per discharge cycle. Turn off to keep only the 15% warning."),
+                          isOn: $behavior.batteryPredictiveAlerts)
+            }
         }
     }
 

--- a/Strand/System/BatteryNotifier.swift
+++ b/Strand/System/BatteryNotifier.swift
@@ -1,5 +1,6 @@
 import Foundation
 import UserNotifications
+import StrandAnalytics
 
 /// Surfaces the strap battery state as a user notification — a LOW warning when the cell falls to
 /// the threshold so the user can top up before tonight's sleep, and a CHARGED note when it reaches
@@ -9,6 +10,7 @@ import UserNotifications
 enum BatteryNotifier {
     private static let lowAlertedKey = "behavior.batteryLowAlerted"
     private static let fullAlertedKey = "behavior.batteryFullAlerted"
+    private static let runtimeAlertedKey = "behavior.batteryRuntimeAlerted"
 
     /// Pure crossing-with-hysteresis policy, identical on macOS/iOS and Android (#368). The two
     /// `*Alerted` flags are PERSISTED, so they survive process death — and the 25% re-arm band means
@@ -90,6 +92,26 @@ enum BatteryNotifier {
             let center = UNUserNotificationCenter.current()
             center.removeDeliveredNotifications(withIdentifiers: ["battery-full"])
             center.removePendingNotificationRequests(withIdentifiers: ["battery-full"])
+        }
+    }
+
+    /// Predictive twin of `onBatteryUpdate`: run the runtime estimate against
+    /// `BatteryEstimator.runtimeAlert` (fire ≤24 h, re-arm ≥36 h — see the policy for why a runtime
+    /// threshold beats a fixed SoC one) and post at most one notification per discharge cycle. The
+    /// 15% SoC alert stays as the safety net for straps with no usable estimate (`estimate == nil`
+    /// is a no-op here). Same gating discipline as #368: the persisted flag advances even when
+    /// delivery is deferred, and the whole thing no-ops when the "Battery alerts" setting is off.
+    static func onRuntimeEstimate(remainingHours: Double?, charging: Bool?, enabled: Bool) {
+        guard enabled, let remainingHours else { return }
+        let d = UserDefaults.standard
+        let result = BatteryEstimator.runtimeAlert(remainingHours: remainingHours,
+                                                   charging: charging,
+                                                   alerted: d.bool(forKey: runtimeAlertedKey))
+        d.set(result.newAlerted, forKey: runtimeAlertedKey)
+        if result.fire {
+            post(identifier: "battery-runtime",
+                 title: String(localized: "Strap battery low"),
+                 body: String(localized: "\(BatteryEstimator.label(hours: remainingHours)) left on your WHOOP — recharge tonight."))
         }
     }
 

--- a/android/app/src/main/java/com/noop/analytics/BatteryEstimator.kt
+++ b/android/app/src/main/java/com/noop/analytics/BatteryEstimator.kt
@@ -248,4 +248,34 @@ object BatteryEstimator {
     fun label(hours: Double): String =
         if (hours < 48) "~${hours.roundToLong()}h"
         else "~${String.format(Locale.US, "%.1f", hours / 24)} days"
+
+    // ---- Predictive low-battery alert policy ----
+
+    /** Fire the runtime alert when the estimate drops to this many hours of remaining life. A fixed
+     *  SoC threshold gives wildly different lead time per strap generation (15% is ~16 h on a 4.0 but
+     *  ~1.8 days on a 5.0/MG); a runtime threshold means the same "charge it tonight" warning for both. */
+    const val runtimeAlertHours = 24.0
+
+    /** Re-arm only when the estimate recovers to this. The 12 h hysteresis band means jitter in the
+     *  fitted slope around the alert line can't re-fire; only a genuine charge opens the gate again. */
+    const val runtimeRearmHours = 36.0
+
+    data class RuntimeAlertDecision(val fire: Boolean, val newAlerted: Boolean)
+
+    /**
+     * Crossing-with-hysteresis decision for the predictive alert, mirroring BatteryAlertPolicy's
+     * shape: PERSISTED `alerted` gate in, fire decision plus next gate state out. Behaviour-identical
+     * twin of the Swift `BatteryEstimator.runtimeAlert` (same fixtures, same numbers).
+     *
+     * `charging == null` means unknown — the alert still fires (only a confirmed `true` suppresses
+     * it), the same null-tolerant rule as the SoC low alert: the strap reports its charge bit only
+     * every ~8 min, and a strap that never reports one should still warn.
+     */
+    fun runtimeAlert(remainingHours: Double, charging: Boolean?, alerted: Boolean): RuntimeAlertDecision {
+        var armedOff = alerted
+        if (remainingHours >= runtimeRearmHours) armedOff = false
+        val fire = !armedOff && remainingHours <= runtimeAlertHours && charging != true
+        if (fire) armedOff = true
+        return RuntimeAlertDecision(fire, armedOff)
+    }
 }

--- a/android/app/src/main/java/com/noop/ble/WhoopConnectionService.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopConnectionService.kt
@@ -21,6 +21,7 @@ import com.noop.R
 import com.noop.alarm.SleepWindowWatcher
 import com.noop.alarm.SmartAlarmScheduler
 import com.noop.alarm.SmartAlarmStore
+import com.noop.analytics.BatteryEstimator
 import com.noop.analytics.IllnessWatch
 import com.noop.analytics.RestScorer
 import com.noop.data.DailyMetric
@@ -102,6 +103,11 @@ class WhoopConnectionService : Service() {
      *  In-memory on purpose: the persisted once-a-day gate (NoopPrefs) handles dedupe across
      *  process restarts and the AppViewModel call site. */
     private var lastIllnessAlert: String? = null
+
+    /** Last battery % the predictive runtime alert was evaluated at. The live-state flow emits far
+     *  more often than the strap's ~8-min battery cadence; gating the Room read + estimator fit on an
+     *  actual SoC change keeps the predictive path as cheap as the SoC-only alert beside it. */
+    private var lastRuntimeEvalPct: Int? = null
 
     /** Smart-alarm light-sleep watcher (#207). Feeds the live HR while we're inside the wake window
      *  and, on a lighter-phase reading, advances the GUARANTEED alarm earlier. It can only ever move
@@ -240,6 +246,28 @@ class WhoopConnectionService : Service() {
                     currPct = state.batteryPct?.roundToInt(),
                     charging = state.charging,
                 )
+                // Predictive runtime alert (iOS/macOS twin: BatteryNotifier.onRuntimeEstimate):
+                // re-fit the "~X left" estimate from the persisted SoC series and warn at ≤24 h of
+                // runtime, whatever the strap generation. Evaluated only when the battery % actually
+                // changes (~8-min strap cadence), so the Room read + slope fit never rides every
+                // live-state emission. Same samples/rated inputs as the Today badge, so the alert can
+                // never disagree with the number on screen.
+                val runtimePct = state.batteryPct?.roundToInt()
+                if (runtimePct != null && runtimePct != lastRuntimeEvalPct) {
+                    lastRuntimeEvalPct = runtimePct
+                    runCatching {
+                        val nowS = System.currentTimeMillis() / 1000
+                        val samples = repo.batterySamples("my-whoop", nowS - 14L * 86_400, nowS, limit = 2_000)
+                            .mapNotNull { s -> s.soc?.let { s.ts to it } }
+                        val rated = if (state.whoop5Detected) BatteryEstimator.ratedLifeHoursWhoop5
+                                    else BatteryEstimator.ratedLifeHoursWhoop4
+                        BatteryAlertNotifier.onRuntimeEstimate(
+                            this@WhoopConnectionService,
+                            remainingHours = BatteryEstimator.estimate(samples, rated)?.hoursRemaining,
+                            charging = state.charging,
+                        )
+                    }
+                }
                 // Feed the home-screen widget from the same stream — this service is its heartbeat
                 // while the app UI is closed. Throttled + no-op without a placed widget (the store
                 // checks both); runCatching so a Glance hiccup never tears down the connection.

--- a/android/app/src/main/java/com/noop/notif/BatteryAlertNotifier.kt
+++ b/android/app/src/main/java/com/noop/notif/BatteryAlertNotifier.kt
@@ -92,6 +92,7 @@ object BatteryAlertNotifier {
     fun onRuntimeEstimate(context: Context, remainingHours: Double?, charging: Boolean?) {
         if (remainingHours == null) return
         if (!NoopPrefs.batteryAlerts(context)) return
+        if (!NoopPrefs.predictiveBatteryAlerts(context)) return
         runCatching {
             val decision = com.noop.analytics.BatteryEstimator.runtimeAlert(
                 remainingHours = remainingHours,

--- a/android/app/src/main/java/com/noop/notif/BatteryAlertNotifier.kt
+++ b/android/app/src/main/java/com/noop/notif/BatteryAlertNotifier.kt
@@ -77,6 +77,45 @@ object BatteryAlertNotifier {
     private const val CHANNEL_ID = "noop_battery_alert"
     private const val NOTIF_ID_LOW = 4203
     private const val NOTIF_ID_FULL = 4204
+    private const val NOTIF_ID_RUNTIME = 4205
+
+    /**
+     * Predictive twin of [onBatteryUpdate]: run the runtime estimate against
+     * [com.noop.analytics.BatteryEstimator.runtimeAlert] (fire ≤24 h, re-arm ≥36 h — a runtime
+     * threshold gives the same warning lead time on a 4.0 and a 5.0/MG, which a fixed SoC line
+     * can't) and post at most one notification per discharge cycle. The 15% SoC alert stays as the
+     * safety net for straps with no usable estimate (null skips here). Same gating discipline as
+     * #368: persisted flag advances even when delivery is deferred; no-ops when battery alerts are
+     * off. iOS/macOS twin: BatteryNotifier.onRuntimeEstimate.
+     */
+    @SuppressLint("MissingPermission") // guarded by areNotificationsEnabled() + runCatching
+    fun onRuntimeEstimate(context: Context, remainingHours: Double?, charging: Boolean?) {
+        if (remainingHours == null) return
+        if (!NoopPrefs.batteryAlerts(context)) return
+        runCatching {
+            val decision = com.noop.analytics.BatteryEstimator.runtimeAlert(
+                remainingHours = remainingHours,
+                charging = charging,
+                alerted = NoopPrefs.batteryRuntimeAlerted(context),
+            )
+            // ALWAYS persist the updated gate — re-arming must stick even when nothing fired.
+            NoopPrefs.setBatteryRuntimeAlerted(context, decision.newAlerted)
+            if (!decision.fire) return
+            if (!NotificationManagerCompat.from(context).areNotificationsEnabled()) return
+            ensureChannel(context)
+            val label = com.noop.analytics.BatteryEstimator.label(remainingHours)
+            val n = NotificationCompat.Builder(context, CHANNEL_ID)
+                .setSmallIcon(R.drawable.ic_stat_heart)
+                .setContentTitle("Strap battery low")
+                .setContentText("$label left on your WHOOP — recharge tonight.")
+                .setContentIntent(openAppIntent(context))
+                .setAutoCancel(true)
+                .setCategory(NotificationCompat.CATEGORY_STATUS)
+                .setPriority(NotificationCompat.PRIORITY_HIGH)
+                .build()
+            NotificationManagerCompat.from(context).notify(NOTIF_ID_RUNTIME, n)
+        }
+    }
 
     @SuppressLint("MissingPermission") // guarded by areNotificationsEnabled() + runCatching
     fun onBatteryUpdate(context: Context, currPct: Int?, charging: Boolean?) {

--- a/android/app/src/main/java/com/noop/ui/AppViewModel.kt
+++ b/android/app/src/main/java/com/noop/ui/AppViewModel.kt
@@ -363,6 +363,12 @@ class AppViewModel(app: Application) : AndroidViewModel(app) {
     /** Whether strap low/full battery notifications fire. */
     val batteryAlertsEnabled: StateFlow<Boolean> = _batteryAlertsEnabled.asStateFlow()
 
+    // Predictive ~24h-runtime warning: a sub-gate under batteryAlerts (default ON), so the naggier
+    // once-per-discharge-cycle alert can be silenced without losing the 15% safety net.
+    private val _predictiveBatteryAlertsEnabled = MutableStateFlow(NoopPrefs.predictiveBatteryAlerts(appContext))
+    /** Whether the predictive ~24h-runtime warning fires (in addition to batteryAlertsEnabled). */
+    val predictiveBatteryAlertsEnabled: StateFlow<Boolean> = _predictiveBatteryAlertsEnabled.asStateFlow()
+
     // Declared BEFORE the init block for the SAME reason as _illnessWatchEnabled above: the bond
     // collector launched from init runs synchronously on Main.immediate and reads _smartAlarmEnabled on
     // its first (cached) emission. A declaration after init is null there and NPEs the constructor on a
@@ -1917,6 +1923,12 @@ class AppViewModel(app: Application) : AndroidViewModel(app) {
     fun setBatteryAlertsEnabled(enabled: Boolean) {
         _batteryAlertsEnabled.value = enabled
         NoopPrefs.setBatteryAlerts(appContext, enabled)
+    }
+
+    /** Toggle the predictive ~24h-runtime warning on its own; same persist-only mechanics as above. */
+    fun setPredictiveBatteryAlertsEnabled(enabled: Boolean) {
+        _predictiveBatteryAlertsEnabled.value = enabled
+        NoopPrefs.setPredictiveBatteryAlerts(appContext, enabled)
     }
 
     /** Re-evaluate the strap's single firmware-alarm slot from BOTH features that want it (#5).

--- a/android/app/src/main/java/com/noop/ui/AutomationsScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/AutomationsScreen.kt
@@ -76,6 +76,7 @@ fun AutomationsScreen(viewModel: AppViewModel) {
     val illnessWatch by viewModel.illnessWatchEnabled.collectAsStateWithLifecycle()
     // Battery alerts are real + persisted (opt-OUT, default ON; #368, thanks @ujix).
     val batteryAlerts by viewModel.batteryAlertsEnabled.collectAsStateWithLifecycle()
+    val predictiveBatteryAlerts by viewModel.predictiveBatteryAlertsEnabled.collectAsStateWithLifecycle()
     val ctx = LocalContext.current
 
     // HR-zone coaching is real + persisted (zone-based, mirrors macOS): the ViewModel owns the toggle +
@@ -347,6 +348,14 @@ fun AutomationsScreen(viewModel: AppViewModel) {
                 checked = batteryAlerts,
                 onChange = { viewModel.setBatteryAlertsEnabled(it) },
             )
+            if (batteryAlerts) {
+                ToggleRow(
+                    label = "Predictive runtime warning",
+                    help = "An early \"recharge tonight\" heads-up when the strap has about a day of estimated runtime left, at most once per discharge cycle. Turn off to keep only the 15% warning.",
+                    checked = predictiveBatteryAlerts,
+                    onChange = { viewModel.setPredictiveBatteryAlertsEnabled(it) },
+                )
+            }
         }
         }
     }

--- a/android/app/src/main/java/com/noop/ui/MainActivity.kt
+++ b/android/app/src/main/java/com/noop/ui/MainActivity.kt
@@ -584,6 +584,18 @@ object NoopPrefs {
         of(context).edit().putBoolean(KEY_BATTERY_FULL_ALERTED, alerted).apply()
     }
 
+    /** Persisted once-per-discharge gate behind BatteryEstimator.runtimeAlert (the predictive
+     *  "~X left" alert; fires ≤24 h, re-arms ≥36 h). Same survive-process-death contract as the
+     *  SoC flags above. */
+    const val KEY_BATTERY_RUNTIME_ALERTED = "noop.batteryRuntimeAlerted"
+
+    fun batteryRuntimeAlerted(context: Context): Boolean =
+        of(context).getBoolean(KEY_BATTERY_RUNTIME_ALERTED, false)
+
+    fun setBatteryRuntimeAlerted(context: Context, alerted: Boolean) {
+        of(context).edit().putBoolean(KEY_BATTERY_RUNTIME_ALERTED, alerted).apply()
+    }
+
     /** Scheduled report notifications (#517), opt-in, default OFF, no AI. Two independent toggles:
      *  - [KEY_REPORT_MORNING]: a morning recap (Charge + Rest) posted once after a fresh night is
      *    processed. It is NOT alarm-precise, it lands when the next sync + analytics pass completes,

--- a/android/app/src/main/java/com/noop/ui/MainActivity.kt
+++ b/android/app/src/main/java/com/noop/ui/MainActivity.kt
@@ -564,6 +564,18 @@ object NoopPrefs {
         of(context).edit().putBoolean(KEY_BATTERY_ALERTS, enabled).apply()
     }
 
+    /** Predictive "recharge tonight" warning at ~24h of estimated runtime left. Sub-gate under
+     *  KEY_BATTERY_ALERTS (both must be on). Default ON so pre-toggle behavior is unchanged.
+     *  iOS/macOS twin key: behavior.batteryPredictiveAlerts. */
+    const val KEY_BATTERY_PREDICTIVE_ALERTS = "noop.batteryPredictiveAlerts"
+
+    fun predictiveBatteryAlerts(context: Context): Boolean =
+        of(context).getBoolean(KEY_BATTERY_PREDICTIVE_ALERTS, true)
+
+    fun setPredictiveBatteryAlerts(context: Context, enabled: Boolean) {
+        of(context).edit().putBoolean(KEY_BATTERY_PREDICTIVE_ALERTS, enabled).apply()
+    }
+
     /** Persisted once-per-crossing flags behind BatteryAlertPolicy, they survive process death so a
      *  battery hovering near a threshold fires exactly once per cycle (low re-arms above 25%, full
      *  re-arms below 100%). */

--- a/android/app/src/test/java/com/noop/analytics/BatteryRuntimeAlertTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/BatteryRuntimeAlertTest.kt
@@ -1,0 +1,65 @@
+package com.noop.analytics
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/** Behaviour-identical twin of the Swift BatteryRuntimeAlertTests — same fixtures, same numbers. */
+class BatteryRuntimeAlertTest {
+
+    @Test
+    fun firesAtThresholdAndArms() {
+        val r = BatteryEstimator.runtimeAlert(remainingHours = 24.0, charging = false, alerted = false)
+        assertTrue(r.fire)
+        assertTrue(r.newAlerted)
+    }
+
+    @Test
+    fun aboveThresholdNoFire() {
+        val r = BatteryEstimator.runtimeAlert(remainingHours = 25.0, charging = false, alerted = false)
+        assertFalse(r.fire)
+        assertFalse(r.newAlerted)
+    }
+
+    @Test
+    fun jitterInsideBandCannotRefire() {
+        // Fired at 23h, estimate bounces 26 → 22 → 30 → 24: still armed-off, no second alert.
+        var alerted = BatteryEstimator.runtimeAlert(23.0, charging = null, alerted = false).newAlerted
+        assertTrue(alerted)
+        for (hours in listOf(26.0, 22.0, 30.0, 24.0)) {
+            val r = BatteryEstimator.runtimeAlert(hours, charging = null, alerted = alerted)
+            assertFalse("re-fired at ${hours}h inside the hysteresis band", r.fire)
+            alerted = r.newAlerted
+        }
+    }
+
+    @Test
+    fun rearmsOnGenuineRecoveryThenFiresNextCycle() {
+        var alerted = BatteryEstimator.runtimeAlert(20.0, charging = null, alerted = false).newAlerted
+        val recovered = BatteryEstimator.runtimeAlert(100.0, charging = null, alerted = alerted)
+        assertFalse(recovered.fire)
+        assertFalse(recovered.newAlerted)
+        assertTrue(BatteryEstimator.runtimeAlert(24.0, charging = null, alerted = recovered.newAlerted).fire)
+    }
+
+    @Test
+    fun confirmedChargingSuppressesButUnknownFires() {
+        assertFalse(BatteryEstimator.runtimeAlert(10.0, charging = true, alerted = false).fire)
+        assertTrue(BatteryEstimator.runtimeAlert(10.0, charging = null, alerted = false).fire)
+    }
+
+    @Test
+    fun chargingSuppressionDoesNotArmGate() {
+        // Suppressed while charging must NOT consume the once-per-cycle gate: unplug below the
+        // threshold and the alert should still fire.
+        val plugged = BatteryEstimator.runtimeAlert(10.0, charging = true, alerted = false)
+        assertFalse(plugged.newAlerted)
+        assertTrue(BatteryEstimator.runtimeAlert(10.0, charging = false, alerted = plugged.newAlerted).fire)
+    }
+
+    @Test
+    fun rearmBoundaryIsInclusive() {
+        assertFalse(BatteryEstimator.runtimeAlert(36.0, charging = null, alerted = true).newAlerted)
+        assertTrue(BatteryEstimator.runtimeAlert(35.9, charging = null, alerted = true).newAlerted)
+    }
+}

--- a/docs/superpowers/specs/2026-07-10-predictive-battery-alert-design.md
+++ b/docs/superpowers/specs/2026-07-10-predictive-battery-alert-design.md
@@ -1,0 +1,53 @@
+# Predictive low-battery notification — design
+
+**Date:** 2026-07-10
+**Scope:** macOS + iOS shared layer (`Strand/System/BatteryNotifier.swift`, `Strand/App/AppModel.swift`)
+plus a pure policy in `Packages/StrandAnalytics`. Android twin deferred until this is upstreamed —
+`BatteryAlertPolicy` is documented behavior-identical with the Kotlin twin (#368), so an upstream PR
+must carry the Kotlin `runtimeAlert` policy + tests to honor the parity contract.
+
+## Problem
+
+The existing low-battery alert (#368) fires at a fixed 15% state of charge. Runtime at 15% differs
+by strap generation — ~16 h on a WHOOP 4.0 but ~1.8 days on a 5.0/MG — so the warning's lead time is
+an accident of hardware. Meanwhile `BatteryEstimator` (#713) already produces a personalized
+"~X left" runtime estimate from the strap's banked discharge history. The two are not connected.
+
+## Behavior
+
+- On every battery reading (`LiveState.onBatteryUpdate` → `AppModel` hook), evaluate the current
+  `LiveState.batteryEstimate` against a new pure policy:
+  - **Fire** when `remainingHours <= 24`, the strap is not confirmed charging (`charging != true`,
+    matching the low alert's null-tolerant rule), and the runtime gate is armed.
+  - **Re-arm** only when `remainingHours >= 36` — estimate jitter around the 24 h line cannot
+    re-fire; only a genuine charge recovers 12+ hours of headroom.
+  - Both estimate sources fire (`measured` and `rated`): the estimator's own gates (`minSpanHours`,
+    `minDropPct`, near-full anchoring) already reject junk fits, and a rated-fallback estimate is
+    still generation-correct.
+- Notification: id `battery-runtime`, title "Strap battery low", body built from
+  `BatteryEstimator.label(hours:)` — e.g. "~22h left on your WHOOP — recharge tonight."
+- The `runtimeAlerted` gate is persisted (`behavior.batteryRuntimeAlerted` in UserDefaults), like
+  `lowAlerted`/`fullAlerted`, so the once-per-discharge-cycle guarantee survives process death, and
+  it advances even when delivery is deferred (authorization declined), mirroring #368.
+- **Unchanged:** the 15% low alert (safety net — covers the nil-estimate case), the 100% full note,
+  the existing "Battery alerts" setting gating everything (no new setting), and
+  `BatteryNotifier.requestAuthorization()`.
+- A user near the boundary may receive the runtime alert (≤24 h) and later the 15% alert in the same
+  discharge — accepted: they carry different messages (plan vs act), and deduplicating them would
+  couple the two gates.
+
+## Where the code goes
+
+- `BatteryEstimator.runtimeAlert(remainingHours:charging:alerted:)` in `StrandAnalytics` — pure
+  `(fire, newAlerted)` decision with the 24/36 constants (`runtimeAlertHours`, `runtimeRearmHours`).
+  `swift test` covered: fire, jitter no-refire, re-arm on recovery, charging suppression (`nil`
+  charging still fires), nil-estimate no-op at the caller.
+- `BatteryNotifier.onRuntimeEstimate(remainingHours:charging:enabled:)` — reads/writes the persisted
+  flag, posts via the existing `post` helper.
+- `AppModel`'s existing `live.onBatteryUpdate` closure additionally calls `onRuntimeEstimate` with
+  `live.batteryEstimate?.remainingHours`.
+
+## Testing
+
+Policy: `swift test` in StrandAnalytics. Notifier/UI glue: compile both app schemes (no default CI
+covers app targets); on-hardware check is watching the alert land when the strap next runs down.


### PR DESCRIPTION
## What

The low-battery alert (#368) fires at a fixed 15% SoC, which is ~16 h of warning on a WHOOP 4.0 but ~1.8 days on a 5.0/MG — the lead time is an accident of strap generation. `BatteryEstimator` (#713) already fits a personalized runtime estimate from the banked SoC discharge history. This PR connects the two: a predictive alert that fires when the **estimated runtime drops to ≤24 h** ("~22h left on your WHOOP — recharge tonight"), whatever the hardware.

## How

- **Pure policy, both platforms** — `BatteryEstimator.runtimeAlert(remainingHours:charging:alerted:)` (Swift) / `BatteryEstimator.runtimeAlert(...)` (Kotlin), behavior-identical twins with the same test fixtures. Crossing-with-hysteresis in the #368 idiom: fire at ≤24 h when not confirmed charging (`nil`/`null` still fires, same null-tolerant rule as the SoC alert), re-arm only at ≥36 h so slope jitter can't re-fire, and a suppressed-while-charging reading does **not** consume the once-per-discharge gate.
- **iOS/macOS** — `BatteryNotifier.onRuntimeEstimate` (persisted `behavior.batteryRuntimeAlerted` gate, advances even when delivery is deferred), evaluated in `AppModel`'s existing battery hook where `LiveState.batteryEstimate` is fresh from the just-banked reading.
- **Android** — `BatteryAlertNotifier.onRuntimeEstimate` (id 4205, persisted `NoopPrefs` gate), fed from `WhoopConnectionService`. The Room read + slope re-fit run only when the SoC actually changes (~8-min strap cadence), never on every live-state emission, and use the same samples/rated inputs as the Today badge so the alert can never disagree with the number on screen.
- **Unchanged** — the 15% SoC alert stays as the safety net (it covers the no-estimate case), the 100% full note, and the existing "Battery alerts" setting gates everything. No new setting.

## Verification

- Swift: `StrandAnalytics` `swift test` — 980 passing incl. 7 new `BatteryRuntimeAlertTests`; `Strand` (macOS) and `NOOPiOS` schemes both compile on this branch (aware no default CI covers app targets).
- Kotlin: `BatteryRuntimeAlertTest` mirrors the Swift fixtures 1:1. **Honest caveat:** no Android toolchain on my machine, so the Kotlin is signature-checked against the existing call-site patterns (`TodayScreen`'s estimate read, `BatteryAlertPolicy`'s gate idiom) but not compiled here — a `testFullDebugUnitTest` run on your side (or an on-demand `android.yml` dispatch) would be appreciated.
- Hardware: policy-level change on the existing alert path; the estimate feeding it is the same #713 value already shown in the UI. My strap is mid-discharge — I'll report when the alert lands live.
