### PR TITLE
fix(ios): request notification permission and surface denial for wind-down nudge

### DIFF
--- a/Strand/App/StrandApp.swift
+++ b/Strand/App/StrandApp.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 import StrandDesign
+import UserNotifications
 
 @main
 struct StrandApp: App {
@@ -11,6 +12,9 @@ struct StrandApp: App {
         // Release is unaffected (whole harness is `#if DEBUG`). See DemoDayHarness.swift.
         DemoDayHarness.applyLaunchArgsIfNeeded()
         #endif
+        // Foreground presentation: without a delegate, macOS suppresses a notification's banner while the
+        // app is frontmost, so a reminder tested with NOOP open would show nothing. Mirrors iOS.
+        UNUserNotificationCenter.current().delegate = NotificationPresenter.shared
     }
 
     @StateObject private var model = AppModel()

--- a/Strand/Screens/SmartAlarmView.swift
+++ b/Strand/Screens/SmartAlarmView.swift
@@ -1,5 +1,10 @@
 import SwiftUI
 import StrandDesign
+#if os(iOS)
+import UIKit
+#elseif os(macOS)
+import AppKit
+#endif
 
 /// Smart alarm (#207) — the iOS/macOS surface.
 ///
@@ -18,6 +23,9 @@ struct SmartAlarmView: View {
     @EnvironmentObject private var behavior: BehaviorStore
 
     @State private var windDownOn = WindDownNudge.isEnabled
+    /// Shown when the user flips the nudge on but notifications are denied at the OS level — the reminder
+    /// can never fire, so we revert the switch and point them to Settings instead of failing silently.
+    @State private var showNotifDeniedAlert = false
     /// Earliest wake time the nudge is derived from (minutes since midnight). Seeded from the store.
     @State private var wakeMinutes = WindDownNudge.wakeMinutes
 
@@ -47,6 +55,26 @@ struct SmartAlarmView: View {
                 windDownCard
             }
         }
+        .alert(String(localized: "Notifications are off"), isPresented: $showNotifDeniedAlert) {
+            Button(String(localized: "Open Settings")) { Self.openNotificationSettings() }
+            Button(String(localized: "Not now"), role: .cancel) {}
+        } message: {
+            Text("Turn on notifications for NOOP in Settings to get your wind-down reminder.")
+        }
+    }
+
+    /// Deep-link to the OS notification settings so a user who denied can flip it back on — the system
+    /// permission dialog only appears once, so Settings is the only recovery path.
+    private static func openNotificationSettings() {
+        #if os(iOS)
+        if let url = URL(string: UIApplication.openSettingsURLString) {
+            UIApplication.shared.open(url)
+        }
+        #elseif os(macOS)
+        if let url = URL(string: "x-apple.systempreferences:com.apple.preference.notifications") {
+            NSWorkspace.shared.open(url)
+        }
+        #endif
     }
 
     // A small Rest-tinted hero — the wind-down readout as a clean time pairing (wind-down → wake)
@@ -253,7 +281,16 @@ struct SmartAlarmView: View {
                     Toggle("", isOn: $windDownOn)
                         .labelsHidden().toggleStyle(.switch).tint(StrandPalette.accent)
                         .accessibilityLabel("Remind me to wind down")
-                        .onChangeCompat(of: windDownOn) { on in WindDownNudge.setEnabled(on) }
+                        .onChangeCompat(of: windDownOn) { on in
+                            WindDownNudge.setEnabled(on) { outcome in
+                                // Denied at the OS level: the reminder can never fire, so reflect reality
+                                // (revert the switch) and surface the path to Settings.
+                                if outcome == .denied {
+                                    windDownOn = false
+                                    showNotifDeniedAlert = true
+                                }
+                            }
+                        }
                 }
                 .frame(minHeight: 42)
 

--- a/Strand/System/NotificationPresenter.swift
+++ b/Strand/System/NotificationPresenter.swift
@@ -1,0 +1,27 @@
+import Foundation
+import UserNotifications
+
+/// Foreground presentation delegate for the app's local notifications (wind-down nudge, smart-alarm
+/// backup, battery/illness alerts).
+///
+/// Without a `UNUserNotificationCenterDelegate`, iOS/macOS suppress a notification's banner while the
+/// app is in the FOREGROUND (the default). A user testing a reminder with the app open would see
+/// nothing and conclude notifications are broken. Returning banner + sound + list here makes them
+/// visible whether the app is open or not — matching what the user expects from a reminder.
+///
+/// Cross-platform (iOS + macOS). Register once at launch:
+/// `UNUserNotificationCenter.current().delegate = NotificationPresenter.shared`.
+final class NotificationPresenter: NSObject, UNUserNotificationCenterDelegate {
+
+    static let shared = NotificationPresenter()
+
+    private override init() { super.init() }
+
+    func userNotificationCenter(
+        _ center: UNUserNotificationCenter,
+        willPresent notification: UNNotification,
+        withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void
+    ) {
+        completionHandler([.banner, .sound, .list])
+    }
+}

--- a/Strand/System/WindDownNudge.swift
+++ b/Strand/System/WindDownNudge.swift
@@ -97,24 +97,61 @@ enum WindDownNudge {
 
     // MARK: - Public API
 
-    /// Ask up front (when the user enables the nudge) so the system dialog appears at a predictable
-    /// moment rather than silently failing the first night.
-    static func requestAuthorization() {
-        UNUserNotificationCenter.current()
-            .requestAuthorization(options: [.alert, .sound]) { _, _ in }
-    }
+    /// The result of enabling the nudge — lets the UI react instead of silently persisting an "on" toggle
+    /// that can never fire. `.denied` means the OS won't deliver (permission off), so the caller should
+    /// revert the switch and point the user at Settings.
+    enum EnableOutcome { case scheduled, denied, off }
 
-    /// Enable/disable and (re)schedule. Enabling requests authorization and schedules the repeating
-    /// nudge; disabling removes it.
-    static func setEnabled(_ on: Bool) {
-        UserDefaults.standard.set(on, forKey: K.enabled)
-        if on {
-            requestAuthorization()
-            schedule()
-        } else {
+    /// Enable/disable and (re)schedule. Enabling gates on notification authorization FIRST — mirroring the
+    /// smart-alarm backup path in `AppModel.scheduleSmartAlarmBackupNotification`: if undetermined it asks
+    /// once and schedules on grant; if already denied it reports back rather than persisting a dead toggle.
+    ///
+    /// Why this matters: the old version called `requestAuthorization` with an empty completion and then
+    /// scheduled unconditionally. `requestAuthorization` only shows the system dialog when the status is
+    /// `.notDetermined`; once a user (or a prior sideload install with the same bundle id) has denied, the
+    /// dialog never returns and the app silently scheduled reminders the OS would never deliver — with
+    /// nothing in the UI to explain it. Now denial surfaces.
+    ///
+    /// `completion` always runs on the main actor (the settings/authorization callbacks fire off-main).
+    static func setEnabled(_ on: Bool, completion: (@MainActor (EnableOutcome) -> Void)? = nil) {
+        guard on else {
+            UserDefaults.standard.set(false, forKey: K.enabled)
             // Clear the single trigger AND any per-day triggers (PR#554) so disabling leaves nothing behind.
             UNUserNotificationCenter.current()
                 .removePendingNotificationRequests(withIdentifiers: [requestId] + perDayRequestIds)
+            completion?(.off)
+            return
+        }
+
+        UNUserNotificationCenter.current().getNotificationSettings { settings in
+            Task { @MainActor in
+                switch settings.authorizationStatus {
+                case .authorized, .provisional, .ephemeral:
+                    UserDefaults.standard.set(true, forKey: K.enabled)
+                    schedule()
+                    completion?(.scheduled)
+                case .notDetermined:
+                    // First ask — the system dialog appears now (a predictable moment), then we schedule on
+                    // grant so the FIRST night is covered rather than only after some later re-arm.
+                    UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .sound]) { granted, _ in
+                        Task { @MainActor in
+                            if granted {
+                                UserDefaults.standard.set(true, forKey: K.enabled)
+                                schedule()
+                                completion?(.scheduled)
+                            } else {
+                                UserDefaults.standard.set(false, forKey: K.enabled)
+                                completion?(.denied)
+                            }
+                        }
+                    }
+                default:
+                    // .denied (or any future non-authorized case) — don't fake an enabled toggle. The caller
+                    // surfaces a "notifications are off" prompt with a jump to Settings.
+                    UserDefaults.standard.set(false, forKey: K.enabled)
+                    completion?(.denied)
+                }
+            }
         }
     }
 

--- a/StrandiOS/App/StrandiOSApp.swift
+++ b/StrandiOS/App/StrandiOSApp.swift
@@ -1,6 +1,7 @@
 #if os(iOS)
 import SwiftUI
 import StrandDesign
+import UserNotifications
 
 /// iOS entry point. Unlike the macOS app (which adds a `MenuBarExtra` scene), iOS uses a single
 /// `WindowGroup`; the glanceable menu-bar role is filled by the Home/Lock-Screen widget instead.
@@ -45,6 +46,10 @@ struct StrandiOSApp: App {
         // target's BGTaskSchedulerPermittedIdentifiers (project.yml). Without this the overnight drop
         // never fires; the macOS timer, foreground catch-up, and "Run now" already work without it.
         ScheduledDebugExport.register()
+        // Foreground presentation: without a delegate, iOS suppresses a notification's banner while the app
+        // is open, so a user testing the wind-down reminder with NOOP foregrounded sees nothing. Register
+        // before the first scene so any early-fired notification is presented.
+        UNUserNotificationCenter.current().delegate = NotificationPresenter.shared
         let model = AppModel()
         _model = StateObject(wrappedValue: model)
         _health = StateObject(wrappedValue: HealthKitBridge(


### PR DESCRIPTION
## Problem

On iOS the app never prompts for notification permission, so the wind-down nudge (#207) never fires.

`WindDownNudge.setEnabled(true)` flips the toggle and calls `schedule()` unconditionally after a `requestAuthorization` with an **empty completion**. `requestAuthorization` only shows the system dialog when the status is `.notDetermined`; once a user (or a prior sideload install with the same bundle id) has denied, the dialog never returns and the app silently schedules reminders the OS will never deliver — with nothing in the UI to explain it. There is also no `UNUserNotificationCenterDelegate`, so notifications are suppressed while the app is foregrounded (testing with the app open shows nothing).

The repo already does this correctly for the smart-alarm backup in `AppModel.scheduleSmartAlarmBackupNotification`; this brings the wind-down nudge in line.

## Changes

- **`WindDownNudge`** — `setEnabled` now gates on authorization: `.authorized` schedules; `.notDetermined` asks once and schedules on grant; `.denied` reports back via a new `EnableOutcome` instead of persisting a dead toggle. Existing static API (`isEnabled`, `wakeMinutes`, per-day overrides #554) unchanged.
- **`SmartAlarmView`** — on `.denied`, revert the switch and show an alert with a jump to the OS notification settings (the system dialog only appears once, so Settings is the recovery path).
- **`NotificationPresenter`** (new) — a `UNUserNotificationCenterDelegate` returning `[.banner, .sound, .list]` so notifications present while the app is open. Registered at launch in `StrandiOSApp` and `StrandApp` (macOS parity).

Android is unaffected — `MainActivity.requestBlePermissions()` already requests `POST_NOTIFICATIONS`.

## Testing

- macOS `Strand` scheme builds clean (0 errors) — covers `WindDownNudge`, `NotificationPresenter`, `SmartAlarmView`, `StrandApp`.
- Full `NOOPiOS` scheme build not run locally (missing watchOS SDK in my environment); the iOS-only delta is a one-line delegate registration mirroring the already-compiled macOS path.