### PR TITLE
feat(oura): opt-in Oura Cloud API import — one-time historical backfill

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -95,3 +95,6 @@ __pycache__/
 # Local release artifacts (zips/ipas built for upload; never tracked)
 dist/
 err.txt
+
+# Oura OAuth app credentials (BYO; never committed)
+Strand/Oura/OuraSecrets.xcconfig

--- a/Packages/StrandImport/Sources/StrandImport/OuraApiModels.swift
+++ b/Packages/StrandImport/Sources/StrandImport/OuraApiModels.swift
@@ -1,0 +1,46 @@
+import Foundation
+
+// MARK: - Neutral models emitted by OuraApiParser (network-free; the app-target writer maps them to WhoopStore).
+
+/// One heart-rate sample (→ hrSample on write). `ts` is unix seconds, `bpm` is positive.
+public struct OuraHRPoint: Sendable, Equatable {
+    public let ts: Int
+    public let bpm: Int
+    public init(ts: Int, bpm: Int) { self.ts = ts; self.bpm = bpm }
+}
+
+/// One Oura detailed sleep period: the shared `session` (incl. decoded stages) plus the rich extras the
+/// shared model can't hold. `movement30s` → sleepSession.motionJSON; `hr` → hrSample. (HRV samples stay
+/// in the raw archive only — there is no rMSSD-per-sample table; the per-night average is on `session`.)
+public struct OuraSleepPeriod: Sendable, Equatable {
+    public var session: WearableSleepSession
+    public var movement30s: [Int]
+    public var hr: [OuraHRPoint]
+    public init(session: WearableSleepSession, movement30s: [Int], hr: [OuraHRPoint]) {
+        self.session = session; self.movement30s = movement30s; self.hr = hr
+    }
+}
+
+/// One extra daily scalar Oura returns that the wide `dailyMetric` columns don't hold (→ metricSeries on
+/// write). `key` is the metricSeries key; the brand's OWN scores use a `ref_` prefix and its contributor
+/// breakdowns an `oura_` prefix, so they are browseable but never mistaken for a NOOP score.
+public struct OuraDailyExtra: Sendable, Equatable {
+    public let day: String
+    public let key: String
+    public let value: Double
+    public init(day: String, key: String, value: Double) { self.day = day; self.key = key; self.value = value }
+}
+
+/// One Oura workout (→ the `workout` table on write). Times are UTC; metric fields nil when absent.
+public struct OuraWorkout: Sendable, Equatable {
+    public let start: Date
+    public let end: Date
+    public let activity: String
+    public let source: String
+    public let energyKcal: Double?
+    public let distanceM: Double?
+    public init(start: Date, end: Date, activity: String, source: String, energyKcal: Double?, distanceM: Double?) {
+        self.start = start; self.end = end; self.activity = activity; self.source = source
+        self.energyKcal = energyKcal; self.distanceM = distanceM
+    }
+}

--- a/Packages/StrandImport/Sources/StrandImport/OuraApiParser+Daily.swift
+++ b/Packages/StrandImport/Sources/StrandImport/OuraApiParser+Daily.swift
@@ -1,0 +1,89 @@
+import Foundation
+
+public extension OuraApiParser {
+
+    /// Parse a day-keyed summary endpoint's documents. `endpoint` selects the field mapping. Writes to
+    /// `WearableDailyRow` columns only where the on-device schema already has a home (RHR, skin-temp dev,
+    /// steps, calories, SpO2); everything else — and ALL of Oura's own scores — becomes `OuraDailyExtra`.
+    static func parseDaily(_ docs: [[String: Any]], endpoint: String) -> (days: [WearableDailyRow], extras: [OuraDailyExtra]) {
+        var byDay: [String: WearableDailyRow] = [:]
+        var extras: [OuraDailyExtra] = []
+        func extra(_ day: String, _ key: String, _ v: Double?) {
+            if let v { extras.append(OuraDailyExtra(day: day, key: key, value: v)) }
+        }
+
+        for doc in docs {
+            guard let day = WearableJSON.str(doc, "day") else { continue }
+            switch endpoint {
+
+            case "daily_readiness":
+                var r = byDay[day] ?? WearableDailyRow(day: day)
+                if let c = doc["contributors"] as? [String: Any] {
+                    r.restingHr = WearableJSON.posInt(c, "resting_heart_rate") ?? r.restingHr
+                    for (k, _) in c { extra(day, "oura_readiness_\(k)", WearableJSON.posDbl(c, k)) }
+                }
+                r.skinTempDevC = WearableJSON.dbl(doc, "temperature_deviation") ?? r.skinTempDevC
+                r.readinessScore = WearableJSON.posInt(doc, "score") ?? r.readinessScore
+                extra(day, "ref_readiness_score", WearableJSON.posDbl(doc, "score"))
+                byDay[day] = r
+
+            case "daily_sleep":
+                extra(day, "ref_sleep_score", WearableJSON.posDbl(doc, "score"))
+                if let c = doc["contributors"] as? [String: Any] {
+                    for (k, _) in c { extra(day, "oura_sleep_\(k)", WearableJSON.posDbl(c, k)) }
+                }
+
+            case "daily_activity":
+                var r = byDay[day] ?? WearableDailyRow(day: day)
+                r.steps = WearableJSON.posInt(doc, "steps") ?? r.steps
+                r.activeKcal = WearableJSON.posDbl(doc, "active_calories") ?? r.activeKcal
+                r.totalKcal = WearableJSON.posDbl(doc, "total_calories") ?? r.totalKcal
+                extra(day, "ref_activity_score", WearableJSON.posDbl(doc, "score"))
+                extra(day, "oura_equiv_walk_m", WearableJSON.posDbl(doc, "equivalent_walking_distance"))
+                byDay[day] = r
+
+            case "daily_spo2":
+                var r = byDay[day] ?? WearableDailyRow(day: day)
+                if let s = doc["spo2_percentage"] as? [String: Any] {
+                    r.spo2Pct = WearableJSON.posDbl(s, "average") ?? r.spo2Pct
+                    extra(day, "spo2", WearableJSON.posDbl(s, "average"))
+                }
+                extra(day, "oura_breathing_disturbance_index", WearableJSON.dbl(doc, "breathing_disturbance_index"))
+                byDay[day] = r
+
+            case "daily_stress":
+                extra(day, "oura_stress_high_s", WearableJSON.posDbl(doc, "stress_high"))
+                extra(day, "oura_recovery_high_s", WearableJSON.posDbl(doc, "recovery_high"))
+
+            case "daily_resilience":
+                if let c = doc["contributors"] as? [String: Any] {
+                    for (k, _) in c { extra(day, "oura_resilience_\(k)", WearableJSON.dbl(c, k)) }
+                }
+                extra(day, "ref_resilience_level", resilienceLevel(WearableJSON.str(doc, "level")))
+
+            case "daily_cardiovascular_age":
+                extra(day, "oura_vascular_age", WearableJSON.dbl(doc, "vascular_age"))
+                extra(day, "oura_pulse_wave_velocity", WearableJSON.dbl(doc, "pulse_wave_velocity"))
+
+            case "vO2_max":
+                extra(day, "vo2max", WearableJSON.posDbl(doc, "vo2_max"))
+
+            default:
+                break
+            }
+        }
+        return (Array(byDay.values), extras)
+    }
+
+    /// Oura resilience level → an ordered reference number (1…5). Reference-only — never a NOOP score.
+    static func resilienceLevel(_ s: String?) -> Double? {
+        switch s {
+        case "limited":     return 1
+        case "adequate":    return 2
+        case "solid":       return 3
+        case "strong":      return 4
+        case "exceptional": return 5
+        default:            return nil
+        }
+    }
+}

--- a/Packages/StrandImport/Sources/StrandImport/OuraApiParser+Events.swift
+++ b/Packages/StrandImport/Sources/StrandImport/OuraApiParser+Events.swift
@@ -1,0 +1,34 @@
+import Foundation
+
+public extension OuraApiParser {
+
+    /// Parse `workout` documents → `OuraWorkout`. Rows without a valid time span are skipped.
+    static func parseWorkouts(_ docs: [[String: Any]]) -> [OuraWorkout] {
+        var out: [OuraWorkout] = []
+        for w in docs {
+            guard let start = WhoopTime.parseISOWithOffset(WearableJSON.str(w, "start_datetime")),
+                  let end = WhoopTime.parseISOWithOffset(WearableJSON.str(w, "end_datetime")),
+                  end > start else { continue }
+            out.append(OuraWorkout(
+                start: start, end: end,
+                activity: WearableJSON.str(w, "activity") ?? "workout",
+                source: WearableJSON.str(w, "source") ?? "oura",
+                energyKcal: WearableJSON.posDbl(w, "calories"),
+                distanceM: WearableJSON.posDbl(w, "distance")))
+        }
+        return out
+    }
+
+    /// Parse a `/v2/usercollection/heartrate` page's `data[]` → HR points. Each row is
+    /// {timestamp, bpm, source}; non-positive bpm is dropped. (The `source` enum is preserved in the raw
+    /// archive, not in the compact hrSample.)
+    static func parseHeartRate(_ docs: [[String: Any]]) -> [OuraHRPoint] {
+        var out: [OuraHRPoint] = []
+        for h in docs {
+            guard let ts = WhoopTime.parseISOWithOffset(WearableJSON.str(h, "timestamp")),
+                  let bpm = WearableJSON.posInt(h, "bpm") else { continue }
+            out.append(OuraHRPoint(ts: Int(ts.timeIntervalSince1970), bpm: bpm))
+        }
+        return out
+    }
+}

--- a/Packages/StrandImport/Sources/StrandImport/OuraApiParser.swift
+++ b/Packages/StrandImport/Sources/StrandImport/OuraApiParser.swift
@@ -1,0 +1,90 @@
+import Foundation
+
+// MARK: - Oura API v2 document parser (PURE / network-free)
+//
+// Takes already-fetched JSON `data[]` arrays (the OuraAPIClient does the I/O in the app target) and maps
+// them to NOOP's normalized models. Reuses the SAME field semantics as OuraExportParser — the account export
+// and the API share field names (bedtime_start, total_sleep_duration, …) — and adds the hypnogram +
+// time-series the file export never carried. Crafted-input safe via WearableJSON.
+
+public enum OuraApiParser {
+
+    /// Parse `sleep` documents (detailed periods; multiple per day are possible). Returns one
+    /// `OuraSleepPeriod` per usable period plus a per-day sleep rollup folded onto `WearableDailyRow`.
+    public static func parseSleep(_ docs: [[String: Any]]) -> (periods: [OuraSleepPeriod], days: [WearableDailyRow]) {
+        var periods: [OuraSleepPeriod] = []
+        var byDay: [String: WearableDailyRow] = [:]
+
+        for s in docs {
+            guard let start = WhoopTime.parseISOWithOffset(WearableJSON.str(s, "bedtime_start")),
+                  let end = WhoopTime.parseISOWithOffset(WearableJSON.str(s, "bedtime_end")),
+                  end > start else { continue }
+
+            // Durations are SECONDS in the API → minutes.
+            func minutes(_ k: String) -> Double? { WearableJSON.posDbl(s, k).map { $0 / 60.0 } }
+
+            // Stages: prefer the finer 30-sec hypnogram, else the 5-min; never synthesize one.
+            let stages: [WearableSleepStageInterval]
+            if let p30 = WearableJSON.str(s, "sleep_phase_30_sec"), !p30.isEmpty {
+                stages = OuraHypnogram.decode(p30, start: start, epochSeconds: 30)
+            } else if let p5 = WearableJSON.str(s, "sleep_phase_5_min"), !p5.isEmpty {
+                stages = OuraHypnogram.decode(p5, start: start, epochSeconds: 300)
+            } else {
+                stages = []
+            }
+
+            let session = WearableSleepSession(
+                start: start, end: end,
+                deepMin: minutes("deep_sleep_duration"),
+                lightMin: minutes("light_sleep_duration"),
+                remMin: minutes("rem_sleep_duration"),
+                awakeMin: minutes("awake_time"),
+                totalSleepMin: minutes("total_sleep_duration"),
+                efficiencyPct: WearableJSON.posDbl(s, "efficiency"),
+                avgHr: WearableJSON.posInt(s, "average_heart_rate"),
+                lowestHr: WearableJSON.posInt(s, "lowest_heart_rate"),
+                avgHrvMs: WearableJSON.posDbl(s, "average_hrv"),
+                respRateBpm: WearableJSON.posDbl(s, "average_breath"),
+                sleepScore: nil,                                // the night's reference score comes from daily_sleep
+                stages: stages)
+
+            let movement = WearableJSON.str(s, "movement_30_sec").map(OuraHypnogram.movement) ?? []
+            let hr = sampleSeries(s["heart_rate"])
+            periods.append(OuraSleepPeriod(session: session, movement30s: movement, hr: hr))
+
+            // Fold the night onto its calendar day (Oura's "day" = the wake day).
+            let key = WearableJSON.str(s, "day") ?? WearableExportImporter.dayString(end)
+            var row = byDay[key] ?? WearableDailyRow(day: key)
+            row.totalSleepMin = row.totalSleepMin ?? session.totalSleepMin
+            row.deepMin = row.deepMin ?? session.deepMin
+            row.lightMin = row.lightMin ?? session.lightMin
+            row.remMin = row.remMin ?? session.remMin
+            row.awakeMin = row.awakeMin ?? session.awakeMin
+            row.efficiencyPct = row.efficiencyPct ?? session.efficiencyPct
+            row.avgHrvMs = row.avgHrvMs ?? session.avgHrvMs
+            row.respRateBpm = row.respRateBpm ?? session.respRateBpm
+            if row.restingHr == nil { row.restingHr = session.lowestHr }
+            byDay[key] = row
+        }
+        return (periods, Array(byDay.values))
+    }
+
+    /// Decode an Oura `PublicSample` object ({interval, items:[Double?], timestamp}) into HR points.
+    /// Non-finite / non-positive items are dropped (Oura uses null/0 for gaps).
+    static func sampleSeries(_ any: Any?) -> [OuraHRPoint] {
+        guard let obj = any as? [String: Any],
+              let interval = WearableJSON.dbl(obj, "interval"), interval > 0,
+              let items = obj["items"] as? [Any],
+              let t0 = WhoopTime.parseISOWithOffset(WearableJSON.str(obj, "timestamp")) else { return [] }
+        var out: [OuraHRPoint] = []
+        for (i, item) in items.enumerated() {
+            guard let v = (item as? Double) ?? (item as? NSNumber)?.doubleValue, v.isFinite, v > 0 else { continue }
+            // Finite-but-huge `ts` or `bpm` (e.g. a crafted `interval`/item of 1e300) must never trap
+            // Int(...); skip the sample instead, mirroring WearableJSON.int's -9e18...9e18 range guard.
+            let ts = t0.timeIntervalSince1970 + Double(i) * interval
+            guard ts.isFinite, ts >= -9e18, ts <= 9e18, v <= 9e18 else { continue }
+            out.append(OuraHRPoint(ts: Int(ts), bpm: Int(v)))
+        }
+        return out
+    }
+}

--- a/Packages/StrandImport/Sources/StrandImport/OuraHypnogram.swift
+++ b/Packages/StrandImport/Sources/StrandImport/OuraHypnogram.swift
@@ -1,0 +1,49 @@
+import Foundation
+
+// MARK: - Oura compact per-epoch sleep strings (DOCUMENTED Oura API v2 encodings; NOOP's own decoder)
+//
+// The Oura `sleep` object carries two compact strings. Their digit legends are DIFFERENT — never share a
+// decoder between them:
+//   • sleep_phase_5_min / sleep_phase_30_sec — the hypnogram: '1'=deep, '2'=light, '3'=REM, '4'=awake.
+//   • movement_30_sec                         — motion:      '1'=no motion, '2'=restless, '3'=tossing, '4'=active.
+
+public enum OuraHypnogram {
+
+    /// `sleep_phase_*` digit → NOOP stage string ("deep"/"light"/"rem"/"wake", matching
+    /// `WearableSleepStageInterval`). Unknown digits → nil (skipped, the epoch clock still advances).
+    public static func stageName(_ ch: Character) -> String? {
+        switch ch {
+        case "1": return "deep"
+        case "2": return "light"
+        case "3": return "rem"
+        case "4": return "wake"
+        default:  return nil
+        }
+    }
+
+    /// Decode a `sleep_phase_5_min` (epochSeconds 300) or `sleep_phase_30_sec` (epochSeconds 30) string into
+    /// contiguous [{stage,start,end}] segments, epoch-aligned from `start`. Adjacent equal stages are merged.
+    public static func decode(_ phases: String, start: Date, epochSeconds: Int) -> [WearableSleepStageInterval] {
+        var out: [WearableSleepStageInterval] = []
+        for (i, ch) in phases.enumerated() {
+            guard let stage = stageName(ch) else { continue }
+            let segStart = start.addingTimeInterval(Double(i * epochSeconds))
+            let segEnd = segStart.addingTimeInterval(Double(epochSeconds))
+            if var last = out.last, last.stage == stage, last.end == segStart {
+                last.end = segEnd
+                out[out.count - 1] = last
+            } else {
+                out.append(WearableSleepStageInterval(stage: stage, start: segStart, end: segEnd))
+            }
+        }
+        return out
+    }
+
+    /// Decode `movement_30_sec` into per-epoch motion magnitudes 1…4 (unknown digit → 0). 30-sec epochs.
+    public static func movement(_ s: String) -> [Int] {
+        s.map { ch in
+            switch ch { case "1": return 1; case "2": return 2; case "3": return 3; case "4": return 4
+                        default: return 0 }
+        }
+    }
+}

--- a/Packages/StrandImport/Tests/StrandImportTests/OuraApiParserDailyTests.swift
+++ b/Packages/StrandImport/Tests/StrandImportTests/OuraApiParserDailyTests.swift
@@ -1,0 +1,42 @@
+import XCTest
+@testable import StrandImport
+
+final class OuraApiParserDailyTests: XCTestCase {
+    func testReadinessMapsRhrSkinTempAndRefScore() {
+        let (days, extras) = OuraApiParser.parseDaily([[
+            "day": "2026-01-02", "score": 80, "temperature_deviation": -0.2,
+            "contributors": ["resting_heart_rate": 50, "hrv_balance": 70]
+        ]], endpoint: "daily_readiness")
+        XCTAssertEqual(days.first?.restingHr, 50)
+        XCTAssertEqual(days.first?.skinTempDevC, -0.2)
+        XCTAssertEqual(days.first?.readinessScore, 80)
+        XCTAssertTrue(extras.contains(OuraDailyExtra(day: "2026-01-02", key: "ref_readiness_score", value: 80)))
+        XCTAssertTrue(extras.contains(OuraDailyExtra(day: "2026-01-02", key: "oura_readiness_hrv_balance", value: 70)))
+    }
+
+    func testActivityMapsStepsAndScoreIsReferenceOnly() {
+        let (days, extras) = OuraApiParser.parseDaily([[
+            "day": "2026-01-02", "score": 88, "steps": 9000,
+            "active_calories": 500, "total_calories": 2400
+        ]], endpoint: "daily_activity")
+        XCTAssertEqual(days.first?.steps, 9000)
+        XCTAssertEqual(days.first?.activeKcal, 500)
+        // The activity SCORE is reference-only — never a dailyMetric score column.
+        XCTAssertTrue(extras.contains(OuraDailyExtra(day: "2026-01-02", key: "ref_activity_score", value: 88)))
+    }
+
+    func testResilienceLevelEncodedReferenceOnly() {
+        let (_, extras) = OuraApiParser.parseDaily([[
+            "day": "2026-01-02", "level": "solid", "contributors": ["sleep_recovery": 60.0]
+        ]], endpoint: "daily_resilience")
+        XCTAssertTrue(extras.contains(OuraDailyExtra(day: "2026-01-02", key: "ref_resilience_level", value: 3)))
+        XCTAssertTrue(extras.contains(OuraDailyExtra(day: "2026-01-02", key: "oura_resilience_sleep_recovery", value: 60)))
+    }
+
+    func testSpo2MapsAverage() {
+        let (days, _) = OuraApiParser.parseDaily([[
+            "day": "2026-01-02", "spo2_percentage": ["average": 96.5]
+        ]], endpoint: "daily_spo2")
+        XCTAssertEqual(days.first?.spo2Pct, 96.5)
+    }
+}

--- a/Packages/StrandImport/Tests/StrandImportTests/OuraApiParserEventsTests.swift
+++ b/Packages/StrandImport/Tests/StrandImportTests/OuraApiParserEventsTests.swift
@@ -1,0 +1,26 @@
+import XCTest
+@testable import StrandImport
+
+final class OuraApiParserEventsTests: XCTestCase {
+    func testWorkoutParse() throws {
+        let w = OuraApiParser.parseWorkouts([[
+            "activity": "running", "source": "autodetected",
+            "start_datetime": "2026-01-02T07:00:00+00:00", "end_datetime": "2026-01-02T07:40:00+00:00",
+            "calories": 410, "distance": 6200
+        ]])
+        XCTAssertEqual(w.count, 1)
+        XCTAssertEqual(w.first?.activity, "running")
+        XCTAssertEqual(w.first?.source, "autodetected")
+        XCTAssertEqual(w.first?.energyKcal, 410)
+        XCTAssertEqual(w.first?.distanceM, 6200)
+    }
+
+    func testHeartRatePageParseDropsNonPositive() {
+        let hr = OuraApiParser.parseHeartRate([
+            ["timestamp": "2026-01-02T07:00:00+00:00", "bpm": 120, "source": "workout"],
+            ["timestamp": "2026-01-02T07:05:00+00:00", "bpm": 0,   "source": "workout"]   // dropped
+        ])
+        XCTAssertEqual(hr.map(\.bpm), [120])
+        XCTAssertEqual(hr.first?.ts, Int(ISO8601DateFormatter().date(from: "2026-01-02T07:00:00Z")!.timeIntervalSince1970))
+    }
+}

--- a/Packages/StrandImport/Tests/StrandImportTests/OuraApiParserSleepTests.swift
+++ b/Packages/StrandImport/Tests/StrandImportTests/OuraApiParserSleepTests.swift
@@ -1,0 +1,74 @@
+import XCTest
+@testable import StrandImport
+
+final class OuraApiParserSleepTests: XCTestCase {
+    func testParsesPeriodWithHypnogramAndFoldsDay() throws {
+        let docs: [[String: Any]] = [[
+            "id": "s1", "day": "2026-01-02",
+            "bedtime_start": "2026-01-01T23:00:00+00:00",
+            "bedtime_end": "2026-01-02T06:00:00+00:00",
+            "total_sleep_duration": 24000, "deep_sleep_duration": 6000,
+            "light_sleep_duration": 12000, "rem_sleep_duration": 6000, "awake_time": 1200,
+            "efficiency": 92, "average_heart_rate": 55, "lowest_heart_rate": 48,
+            "average_hrv": 65, "average_breath": 14.2,
+            "sleep_phase_5_min": "1234",
+            "movement_30_sec": "1212",
+            "heart_rate": ["interval": 300, "timestamp": "2026-01-01T23:00:00+00:00",
+                           "items": [60, 58, NSNull(), 57]]
+        ]]
+        let (periods, days) = OuraApiParser.parseSleep(docs)
+        XCTAssertEqual(periods.count, 1)
+        let p = try XCTUnwrap(periods.first)
+        XCTAssertEqual(p.session.totalSleepMin, 400)              // 24000s ÷ 60
+        XCTAssertEqual(p.session.lowestHr, 48)
+        XCTAssertEqual(p.session.avgHrvMs, 65)
+        XCTAssertEqual(p.session.stages.map(\.stage), ["deep", "light", "rem", "wake"])
+        XCTAssertEqual(p.movement30s, [1, 2, 1, 2])
+        XCTAssertEqual(p.hr.map(\.bpm), [60, 58, 57])            // null sample dropped
+        // ts = bedtime_start epoch + i*interval, using the ORIGINAL items index (the null at i=2 is
+        // skipped, so the 3rd kept sample is i=3, i.e. epoch + 900, not epoch + 600).
+        let bedtimeStart = try XCTUnwrap(WhoopTime.parseISOWithOffset("2026-01-01T23:00:00+00:00"))
+        let ts0 = Int(bedtimeStart.timeIntervalSince1970)
+        XCTAssertEqual(p.hr.map(\.ts), [ts0, ts0 + 300, ts0 + 900])
+        XCTAssertEqual(days.count, 1)
+        XCTAssertEqual(days.first?.day, "2026-01-02")
+        XCTAssertEqual(days.first?.totalSleepMin, 400)
+        XCTAssertEqual(days.first?.restingHr, 48)                // lowestHr ≈ resting fallback
+        XCTAssertEqual(days.first?.respRateBpm, 14.2)            // average_breath folded onto the day rollup
+    }
+
+    func testSkipsPeriodWithInvalidSpan() {
+        let (periods, _) = OuraApiParser.parseSleep([["bedtime_start": "nope", "bedtime_end": "nope"]])
+        XCTAssertTrue(periods.isEmpty)
+    }
+
+    func testSampleSeriesSkipsFiniteButHugeValuesWithoutCrashing() throws {
+        // Both `ts` and `bpm` in sampleSeries are Double->Int casts; a finite-but-huge value for EITHER
+        // (a crafted `interval` or a crafted `items` element) must be skipped, never trap Int(...).
+
+        // A huge `interval` blows the 2nd sample's ts (t0 + 1*interval) past Int range; the 1st sample's
+        // ts (t0 + 0*interval == t0) stays in range and must still be kept.
+        let hugeIntervalDocs: [[String: Any]] = [[
+            "day": "2026-01-02",
+            "bedtime_start": "2026-01-01T23:00:00+00:00",
+            "bedtime_end": "2026-01-02T06:00:00+00:00",
+            "heart_rate": ["interval": 1e300, "timestamp": "2026-01-01T23:00:00+00:00",
+                           "items": [60, 58]]
+        ]]
+        let (hugeIntervalPeriods, _) = OuraApiParser.parseSleep(hugeIntervalDocs)
+        let hugeIntervalPeriod = try XCTUnwrap(hugeIntervalPeriods.first)
+        XCTAssertEqual(hugeIntervalPeriod.hr.map(\.bpm), [60])
+
+        // A huge `items` element (bpm itself) must be skipped even with a perfectly normal interval/ts.
+        let hugeItemDocs: [[String: Any]] = [[
+            "day": "2026-01-02",
+            "bedtime_start": "2026-01-01T23:00:00+00:00",
+            "bedtime_end": "2026-01-02T06:00:00+00:00",
+            "heart_rate": ["interval": 300, "timestamp": "2026-01-01T23:00:00+00:00",
+                           "items": [60, 1e300, 58]]
+        ]]
+        let (hugeItemPeriods, _) = OuraApiParser.parseSleep(hugeItemDocs)
+        let hugeItemPeriod = try XCTUnwrap(hugeItemPeriods.first)
+        XCTAssertEqual(hugeItemPeriod.hr.map(\.bpm), [60, 58])
+    }
+}

--- a/Packages/StrandImport/Tests/StrandImportTests/OuraHypnogramTests.swift
+++ b/Packages/StrandImport/Tests/StrandImportTests/OuraHypnogramTests.swift
@@ -1,0 +1,29 @@
+import XCTest
+@testable import StrandImport
+
+final class OuraHypnogramTests: XCTestCase {
+    private func d(_ iso: String) -> Date { ISO8601DateFormatter().date(from: iso)! }
+
+    func testStageLegendMapsOuraDigits() {
+        XCTAssertEqual(OuraHypnogram.stageName("1"), "deep")
+        XCTAssertEqual(OuraHypnogram.stageName("2"), "light")
+        XCTAssertEqual(OuraHypnogram.stageName("3"), "rem")
+        XCTAssertEqual(OuraHypnogram.stageName("4"), "wake")
+        XCTAssertNil(OuraHypnogram.stageName("0"))
+    }
+
+    func testDecodeMergesAdjacentEqualStagesAndAligns() {
+        let start = d("2026-01-01T23:00:00Z")
+        // "1123" → deep(2 epochs merged), light(1), rem(1); 5-min epochs.
+        let segs = OuraHypnogram.decode("1123", start: start, epochSeconds: 300)
+        XCTAssertEqual(segs.map(\.stage), ["deep", "light", "rem"])
+        XCTAssertEqual(segs[0].start, start)
+        XCTAssertEqual(segs[0].end, start.addingTimeInterval(600))   // two 5-min epochs merged
+        XCTAssertEqual(segs[2].end, start.addingTimeInterval(1200))  // total 4 epochs = 20 min
+    }
+
+    func testMovementLegendIsDistinctFromStages() {
+        // movement uses 1=no motion … 4=active; unknown → 0.
+        XCTAssertEqual(OuraHypnogram.movement("1234x"), [1, 2, 3, 4, 0])
+    }
+}

--- a/Packages/WhoopStore/Sources/WhoopStore/Database.swift
+++ b/Packages/WhoopStore/Sources/WhoopStore/Database.swift
@@ -480,6 +480,26 @@ extension WhoopStore {
             try db.execute(sql: "DROP TABLE rrInterval")
             try db.execute(sql: "ALTER TABLE rrInterval_new RENAME TO rrInterval")
         }
+
+        // v25: Oura live-API raw payload archive (lossless) behind the opt-in cloud import. One row per
+        // fetched page, keyed (deviceId, endpoint, documentId); payloadJSON holds the verbatim page body
+        // so any field can be re-derived later without re-fetching from the API. Additive only — a NEW
+        // table, no existing row touched, old readers unaffected. Numbered v25: upstream's v24-rr-seq
+        // landed in the same window and registers first to keep the sequence.
+        migrator.registerMigration("v25-oura-raw") { db in
+            try db.create(table: "ouraRaw") { t in
+                t.column("deviceId", .text).notNull()
+                t.column("endpoint", .text).notNull()       // "sleep" | "daily_readiness" | "heartrate" | …
+                t.column("documentId", .text).notNull()     // synthesized page key (endpoint + window + index)
+                t.column("day", .text)                       // YYYY-MM-DD when day-keyed (nullable)
+                t.column("payloadJSON", .text).notNull()     // verbatim page body
+                t.column("fetchedAt", .integer).notNull()    // unix seconds
+                t.primaryKey(["deviceId", "endpoint", "documentId"])
+            }
+            // Per-endpoint reads scan (deviceId, endpoint) then walk day in order.
+            try db.create(index: "idx_ouraRaw_device_endpoint_day",
+                          on: "ouraRaw", columns: ["deviceId", "endpoint", "day"])
+        }
         return migrator
     }
 }

--- a/Packages/WhoopStore/Sources/WhoopStore/OuraRawStore.swift
+++ b/Packages/WhoopStore/Sources/WhoopStore/OuraRawStore.swift
@@ -1,0 +1,77 @@
+import Foundation
+import GRDB
+
+// MARK: - v25 store: lossless Oura live-API payload archive
+// Mirrors MetricSeriesStore exactly: a Codable row struct, an idempotent ON CONFLICT upsert keyed by the
+// natural key (deviceId, endpoint, documentId), and range reads — all GRDB work via syncWrite/syncRead.
+// This is the "as much as we can get" backstop: the verbatim payload is kept so a future metric can be
+// derived without re-hitting the Oura API.
+
+/// One archived Oura API payload. Natural key (deviceId, endpoint, documentId).
+public struct OuraRawRow: Equatable, Codable, Sendable {
+    public let endpoint: String     // "sleep" | "daily_readiness" | "heartrate" | …
+    public let documentId: String   // Oura `id`; for heartrate pages, a synthesized window key
+    public let day: String?         // YYYY-MM-DD when the document is day-keyed
+    public let payloadJSON: String  // verbatim object
+    public let fetchedAt: Int       // unix seconds
+    public init(endpoint: String, documentId: String, day: String?, payloadJSON: String, fetchedAt: Int) {
+        self.endpoint = endpoint; self.documentId = documentId
+        self.day = day; self.payloadJSON = payloadJSON; self.fetchedAt = fetchedAt
+    }
+}
+
+extension WhoopStore {
+
+    /// Upsert raw Oura payloads. Idempotent by (deviceId, endpoint, documentId): re-pulling the same
+    /// document overwrites its payload/day/fetchedAt rather than duplicating. Returns rows changed.
+    @discardableResult
+    public func upsertOuraRaw(_ rows: [OuraRawRow], deviceId: String) async throws -> Int {
+        try syncWrite { db in
+            var n = 0
+            for r in rows {
+                try db.execute(sql: """
+                    INSERT INTO ouraRaw (deviceId, endpoint, documentId, day, payloadJSON, fetchedAt)
+                    VALUES (?, ?, ?, ?, ?, ?)
+                    ON CONFLICT(deviceId, endpoint, documentId) DO UPDATE SET
+                        day = excluded.day,
+                        payloadJSON = excluded.payloadJSON,
+                        fetchedAt = excluded.fetchedAt
+                    """, arguments: [deviceId, r.endpoint, r.documentId, r.day, r.payloadJSON, r.fetchedAt])
+                n += db.changesCount
+            }
+            return n
+        }
+    }
+
+    /// Archived payloads for a device + endpoint, oldest day first (null days sort first in SQLite).
+    public func ouraRaw(deviceId: String, endpoint: String) async throws -> [OuraRawRow] {
+        try syncRead { db in
+            try Row.fetchAll(db, sql: """
+                SELECT endpoint, documentId, day, payloadJSON, fetchedAt FROM ouraRaw
+                WHERE deviceId = ? AND endpoint = ?
+                ORDER BY day ASC
+                """, arguments: [deviceId, endpoint])
+                .map { OuraRawRow(endpoint: $0["endpoint"], documentId: $0["documentId"],
+                                  day: $0["day"], payloadJSON: $0["payloadJSON"], fetchedAt: $0["fetchedAt"]) }
+        }
+    }
+
+    /// Count archived payloads for a device + endpoint (diagnostics / import summary).
+    public func ouraRawCount(deviceId: String, endpoint: String) async throws -> Int {
+        try syncRead { db in
+            try Int.fetchOne(db, sql:
+                "SELECT COUNT(*) FROM ouraRaw WHERE deviceId = ? AND endpoint = ?",
+                arguments: [deviceId, endpoint]) ?? 0
+        }
+    }
+
+    /// Remove every archived Oura payload for a device (used by Disconnect — `deleteAllData` does not
+    /// cover `ouraRaw`). Returns rows deleted.
+    @discardableResult
+    public func deleteOuraRaw(deviceId: String) async throws -> Int {
+        try syncWrite { db in
+            try db.execute(sql: "DELETE FROM ouraRaw WHERE deviceId = ?", arguments: [deviceId])
+            return db.changesCount
+        }
+    }
+}

--- a/Packages/WhoopStore/Sources/WhoopStore/PairedDevice.swift
+++ b/Packages/WhoopStore/Sources/WhoopStore/PairedDevice.swift
@@ -34,6 +34,12 @@ public struct PairedDevice: Equatable, Sendable, Identifiable {
         if model.localizedCaseInsensitiveContains(brand) { return model }
         return "\(brand) \(model)"
     }
+
+    /// True for a data-partition source (a cloud API pull or a file/CSV import) rather than a live,
+    /// connectable device. UI that offers "make active" must exclude these: activating one would demote
+    /// whatever live device (WHOOP, a BLE strap, Apple Watch) currently drives BLE routing + day-owner
+    /// priority 0 — an import source has no live connection to hand that role to.
+    public var isImportSource: Bool { sourceKind == .cloudImport || sourceKind == .fileImport }
 }
 
 public enum DeviceStatus: String, Sendable, CaseIterable { case active, paired, archived }

--- a/Packages/WhoopStore/Tests/WhoopStoreTests/OuraRawStoreTests.swift
+++ b/Packages/WhoopStore/Tests/WhoopStoreTests/OuraRawStoreTests.swift
@@ -1,0 +1,40 @@
+import XCTest
+import GRDB
+@testable import WhoopStore
+
+final class OuraRawStoreTests: XCTestCase {
+    func testUpsertIsIdempotentByNaturalKey() async throws {
+        let store = try await WhoopStore.inMemory()
+        let first = OuraRawRow(endpoint: "sleep", documentId: "abc", day: "2026-01-01",
+                               payloadJSON: #"{"id":"abc","v":1}"#, fetchedAt: 100)
+        let n1 = try await store.upsertOuraRaw([first], deviceId: "oura-api")
+        XCTAssertEqual(n1, 1)
+
+        // Re-pull the same document id with a newer payload → overwrite in place, still one row.
+        let second = OuraRawRow(endpoint: "sleep", documentId: "abc", day: "2026-01-01",
+                                payloadJSON: #"{"id":"abc","v":2}"#, fetchedAt: 200)
+        _ = try await store.upsertOuraRaw([second], deviceId: "oura-api")
+
+        let rows = try await store.ouraRaw(deviceId: "oura-api", endpoint: "sleep")
+        XCTAssertEqual(rows.count, 1)
+        XCTAssertEqual(rows.first?.payloadJSON, #"{"id":"abc","v":2}"#)
+        XCTAssertEqual(rows.first?.fetchedAt, 200)
+        let sleepCount = try await store.ouraRawCount(deviceId: "oura-api", endpoint: "sleep")
+        XCTAssertEqual(sleepCount, 1)
+        // A different endpoint is a different partition.
+        let dailySleepCount = try await store.ouraRawCount(deviceId: "oura-api", endpoint: "daily_sleep")
+        XCTAssertEqual(dailySleepCount, 0)
+    }
+
+    func testDeleteOuraRawRemovesAllForDevice() async throws {
+        let store = try await WhoopStore.inMemory()
+        _ = try await store.upsertOuraRaw([
+            OuraRawRow(endpoint: "sleep", documentId: "a", day: "2026-01-01", payloadJSON: "{}", fetchedAt: 1),
+            OuraRawRow(endpoint: "workout", documentId: "b", day: "2026-01-01", payloadJSON: "{}", fetchedAt: 1),
+        ], deviceId: "oura-api")
+        let deleted = try await store.deleteOuraRaw(deviceId: "oura-api")
+        XCTAssertEqual(deleted, 2)
+        let remainingCount = try await store.ouraRawCount(deviceId: "oura-api", endpoint: "sleep")
+        XCTAssertEqual(remainingCount, 0)
+    }
+}

--- a/Strand/Data/Repository.swift
+++ b/Strand/Data/Repository.swift
@@ -449,7 +449,7 @@ final class Repository: ObservableObject {
     /// stream, so the source-only fold in IntelligenceEngine scores them from the daily aggregate vs the
     /// person's own baseline. Matches `WearableBrand.sourceId` plus Health Connect (Android imports HC's
     /// daily metrics under the strap source, but a sideloaded/standalone HC source id is covered too).
-    static let wearableImportSources = ["oura-import", "fitbit-import", "garmin-import", healthConnectSource]
+    static let wearableImportSources = ["oura-import", "fitbit-import", "garmin-import", "oura-api", healthConnectSource]
 
     /// `yyyy-MM-dd` in the device's local zone, matching how `DailyMetric.day` is stored.
     private static let dayKeyFormatter: DateFormatter = {

--- a/Strand/Oura/AuthProvider.swift
+++ b/Strand/Oura/AuthProvider.swift
@@ -1,0 +1,18 @@
+import Foundation
+import AuthenticationServices
+
+/// The auth seam. Today's concrete provider is `OuraOAuthProvider` (BYO-app authorization-code, Task 3);
+/// a future backend-mediated provider can replace it without touching the API client or the sync layer.
+protocol AuthProvider {
+    /// True when tokens are stored (connected), regardless of expiry.
+    var isConnected: Bool { get }
+    /// Return a currently-valid access token, refreshing transparently if the stored one is expired.
+    func validAccessToken() async throws -> String
+    /// Force an unconditional refresh (regardless of expiry) and return the new access token.
+    /// Used when a token was rejected server-side (401) even though it wasn't clock-expired.
+    func refreshedAccessToken() async throws -> String
+    /// Run the interactive authorization (opens Oura's consent page) and store the resulting tokens.
+    @MainActor func authorize(presentationAnchor: ASPresentationAnchor) async throws
+    /// Forget the stored tokens (disconnect).
+    func signOut()
+}

--- a/Strand/Oura/AuthProvider.swift
+++ b/Strand/Oura/AuthProvider.swift
@@ -1,3 +1,7 @@
+// Compiled ONLY when the OURA_CLOUD_IMPORT compilation condition is set (by the untracked
+// OuraSecrets.xcconfig — see OuraConfig.xcconfig). A default build contains none of this code,
+// keeping "fully offline" a byte-level property of the shipped binary, not a runtime promise.
+#if OURA_CLOUD_IMPORT
 import Foundation
 import AuthenticationServices
 
@@ -16,3 +20,4 @@ protocol AuthProvider {
     /// Forget the stored tokens (disconnect).
     func signOut()
 }
+#endif // OURA_CLOUD_IMPORT

--- a/Strand/Oura/OuraAPIClient.swift
+++ b/Strand/Oura/OuraAPIClient.swift
@@ -1,3 +1,7 @@
+// Compiled ONLY when the OURA_CLOUD_IMPORT compilation condition is set (by the untracked
+// OuraSecrets.xcconfig — see OuraConfig.xcconfig). A default build contains none of this code,
+// keeping "fully offline" a byte-level property of the shipped binary, not a runtime promise.
+#if OURA_CLOUD_IMPORT
 import Foundation
 
 enum OuraEnvironment {
@@ -111,3 +115,4 @@ final class OuraAPIClient {
         }
     }
 }
+#endif // OURA_CLOUD_IMPORT

--- a/Strand/Oura/OuraAPIClient.swift
+++ b/Strand/Oura/OuraAPIClient.swift
@@ -1,0 +1,113 @@
+import Foundation
+
+enum OuraEnvironment {
+    case production, sandbox
+    var baseURL: String {
+        switch self {
+        case .production: return "https://api.ouraring.com/v2/usercollection"
+        case .sandbox:    return "https://api.ouraring.com/v2/sandbox/usercollection"
+        }
+    }
+}
+
+/// One decoded page of an Oura list/time-series response.
+struct OuraPage {
+    let data: [[String: Any]]
+    let nextToken: String?
+}
+
+/// Pure (network-free) response-envelope parsing, unit-tested directly.
+enum OuraAPI {
+    static func parsePage(_ data: Data) throws -> OuraPage {
+        guard let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            throw OuraError.decode
+        }
+        let rows = (obj["data"] as? [[String: Any]]) ?? []
+        return OuraPage(data: rows, nextToken: obj["next_token"] as? String)
+    }
+}
+
+/// The Oura v2 API client. Injected `AuthProvider` supplies the bearer token (refreshing on expiry);
+/// injected `session` makes it URLProtocol-testable. Follows `next_token` paging, retries 429 with a
+/// bounded backoff, and refreshes-once on 401. Networking lives here in the app target by design.
+final class OuraAPIClient {
+    private let auth: AuthProvider
+    private let environment: OuraEnvironment
+    private let session: URLSession
+    private let backoff: TimeInterval
+    private let maxPages = 10_000   // runaway guard (logged if hit)
+
+    init(auth: AuthProvider, environment: OuraEnvironment = .production,
+         session: URLSession = .shared, backoff: TimeInterval = 2) {
+        self.auth = auth
+        self.environment = environment
+        self.session = session
+        self.backoff = backoff
+    }
+
+    /// Fetch every page of `endpoint` for `query`, following `next_token`, returning concatenated rows.
+    func fetchAll(endpoint: String, query: [String: String]) async throws -> [[String: Any]] {
+        var rows: [[String: Any]] = []
+        try await forEachPage(endpoint: endpoint, query: query) { page in rows.append(contentsOf: page.data) }
+        return rows
+    }
+
+    /// Fetch every page, returning the verbatim page bodies (for Plan 3's lossless raw archive).
+    func fetchAllRaw(endpoint: String, query: [String: String]) async throws -> [Data] {
+        var bodies: [Data] = []
+        try await forEachPage(endpoint: endpoint, query: query, rawSink: { bodies.append($0) }) { _ in }
+        return bodies
+    }
+
+    private func forEachPage(endpoint: String, query: [String: String],
+                             rawSink: ((Data) -> Void)? = nil,
+                             _ handle: (OuraPage) -> Void) async throws {
+        var next: String? = nil
+        var pages = 0
+        repeat {
+            var q = query
+            if let next { q["next_token"] = next }
+            let (data, _) = try await getWithRetry(endpoint: endpoint, query: q)
+            rawSink?(data)
+            let page = try OuraAPI.parsePage(data)
+            handle(page)
+            next = page.nextToken
+            pages += 1
+            if pages >= maxPages { break }   // Plan-3 note: log if this cap is ever hit.
+        } while next != nil
+    }
+
+    /// GET with auth + 429-backoff + 401-refresh-once. Returns (body, status).
+    private func getWithRetry(endpoint: String, query: [String: String]) async throws -> (Data, Int) {
+        for attempt in 0..<3 {
+            let token = try await auth.validAccessToken()
+            let (data, code) = try await get(endpoint: endpoint, query: query, token: token)
+            switch code {
+            case 200..<300:
+                return (data, code)
+            case 429:
+                if backoff > 0 { try? await Task.sleep(nanoseconds: UInt64(backoff * 1_000_000_000)) }
+                continue
+            case 401 where attempt == 0:
+                _ = try? await auth.refreshedAccessToken()   // force a real refresh; the loop-top re-reads the saved token
+                continue
+            default:
+                throw OuraError.badResponse(code, String(data: data, encoding: .utf8) ?? "")
+            }
+        }
+        throw OuraError.rateLimited
+    }
+
+    private func get(endpoint: String, query: [String: String], token: String) async throws -> (Data, Int) {
+        var comps = URLComponents(string: "\(environment.baseURL)/\(endpoint)")!
+        if !query.isEmpty { comps.queryItems = query.map { URLQueryItem(name: $0.key, value: $0.value) } }
+        var req = URLRequest(url: comps.url!)
+        req.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        do {
+            let (data, resp) = try await session.data(for: req)
+            return (data, (resp as? HTTPURLResponse)?.statusCode ?? 0)
+        } catch {
+            throw OuraError.network(error.localizedDescription)
+        }
+    }
+}

--- a/Strand/Oura/OuraConfig.xcconfig
+++ b/Strand/Oura/OuraConfig.xcconfig
@@ -1,0 +1,5 @@
+// Tracked wrapper so a clean checkout (no local credentials) still generates and builds.
+// OuraSecrets.xcconfig is gitignored; when absent, the optional include is skipped, the
+// OURA_* build settings stay undefined, the Info.plist keys resolve to empty strings, and
+// OuraCredentials.fromBundle returns nil — the whole Oura Cloud lane is inert.
+#include? "OuraSecrets.xcconfig"

--- a/Strand/Oura/OuraConfig.xcconfig
+++ b/Strand/Oura/OuraConfig.xcconfig
@@ -1,5 +1,12 @@
 // Tracked wrapper so a clean checkout (no local credentials) still generates and builds.
-// OuraSecrets.xcconfig is gitignored; when absent, the optional include is skipped, the
-// OURA_* build settings stay undefined, the Info.plist keys resolve to empty strings, and
-// OuraCredentials.fromBundle returns nil — the whole Oura Cloud lane is inert.
+//
+// OuraSecrets.xcconfig is gitignored and user-created (template: OuraSecrets.example.xcconfig).
+// It carries BOTH halves of the opt-in:
+//   1. the OURA_* OAuth credentials, and
+//   2. SWIFT_ACTIVE_COMPILATION_CONDITIONS += OURA_CLOUD_IMPORT, which compiles the Oura import
+//      lane (everything in Strand/Oura/*.swift plus its UI card and tests) into the binary.
+// When the file is absent — every default build — the optional include below is skipped: the
+// OURA_CLOUD_IMPORT condition is never set, so NO Oura network code is compiled at all, and the
+// $(OURA_*) Info.plist keys resolve to empty strings. "Fully offline" is a property of the bytes
+// in the default binary, not a runtime check.
 #include? "OuraSecrets.xcconfig"

--- a/Strand/Oura/OuraConnectModel.swift
+++ b/Strand/Oura/OuraConnectModel.swift
@@ -1,0 +1,102 @@
+import Foundation
+import Combine
+import AuthenticationServices
+import WhoopStore
+#if os(iOS)
+import UIKit
+#endif
+
+/// Drives the Data Sources "Connect Oura" card: connect (OAuth) → one-time backfill → honest summary →
+/// disconnect. @MainActor so all @Published mutations are main-thread; the network/backfill hops off-main.
+///
+/// `repo: Repository` is taken as a PARAMETER on each action rather than stored at construction. `Repository`
+/// only reaches `DataSourcesView` via `@EnvironmentObject`, which SwiftUI populates after `init()` runs —
+/// storing it in a property initializer (`@StateObject private var oura = OuraConnectModel(repo: repo)`)
+/// either fails to compile (a property initializer can't reference another instance member) or, moved into
+/// a custom `init()`, crashes at runtime ("No ObservableObject of type Repository found") because the
+/// environment isn't resolved yet. This mirrors how the sibling `wearableCard`/`importWearable(url:)` on
+/// `DataSourcesView` read `repo` lazily inside their action closures instead of at construction time.
+@MainActor
+final class OuraConnectModel: ObservableObject {
+    @Published var busy = false
+    @Published var statusText: String?
+    @Published var isConnected = OuraTokenStore.isConnected
+
+    /// True when the BYO-app credentials are present (else the lane is disabled with guidance).
+    var isConfigured: Bool { OuraCredentials.fromBundle != nil }
+
+    func connectAndImport(repo: Repository) {
+        guard let creds = OuraCredentials.fromBundle else {
+            statusText = "Add your Oura app's client_id/secret to OuraSecrets.xcconfig first."; return
+        }
+        setBusy(true); statusText = "Connecting to Oura…"
+        Task {
+            do {
+                let provider = OuraOAuthProvider(credentials: creds)
+                try await provider.authorize(presentationAnchor: ouraPresentationAnchor())
+                isConnected = true
+                guard let store = await repo.storeHandle() else { fail("No local store."); return }
+                let client = OuraAPIClient(auth: provider, environment: .production)
+                let coord = OuraSyncCoordinator(fetcher: client, store: store)
+                let today = Self.dayFormatter.string(from: Date())
+                statusText = "Importing your Oura history…"
+                let s = try await coord.runFullImport(today: today) { [weak self] p in
+                    Task { @MainActor in
+                        if p.endpoint == "saving" { self?.statusText = "Saving to your database…" }
+                        else { self?.statusText = "Importing \(p.endpoint)\(p.detail.map { " (\($0))" } ?? "")…" }
+                    }
+                }
+                await repo.refresh()
+                var line = "Imported \(s.days) days · \(s.sleeps) sleeps · \(s.workouts) workouts · \(s.hrSamples) HR samples"
+                if !s.skippedEndpoints.isEmpty {
+                    line += " · skipped: \(s.skippedEndpoints.joined(separator: ", ")) — tap Sync again to retry"
+                }
+                statusText = line
+            } catch { fail((error as? LocalizedError)?.errorDescription ?? error.localizedDescription) }
+            setBusy(false)
+        }
+    }
+
+    func disconnect(repo: Repository) {
+        busy = true
+        Task {
+            OuraOAuthProvider(credentials: OuraCredentials.fromBundle ?? .init(clientId: "", clientSecret: "", redirectURI: "")).signOut()
+            if let store = await repo.storeHandle() {
+                do {
+                    try await store.deleteAllData(deviceId: "oura-api")
+                    try await store.deleteOuraRaw(deviceId: "oura-api")
+                    // M-1: `deleteAllData` intentionally leaves the `pairedDevice` registry row intact
+                    // (archiving/removing it is a separate op — DeviceRegistryStore.swift) so it doesn't
+                    // just purge data, else a data-less "Oura (cloud)" card lingers in DevicesView. Archive
+                    // it via the same off-actor raw-write pattern OuraSyncWriter.persist uses to register
+                    // the row on connect (`registryWriter` is `nonisolated`; `DeviceRegistryStore` is a
+                    // thin synchronous, Sendable wrapper — no separate actor hop needed).
+                    try DeviceRegistryStore(dbQueue: store.registryWriter).archive("oura-api")
+                    statusText = "Disconnected."
+                } catch {
+                    statusText = "Disconnected, but couldn't fully clear local Oura data: \(error.localizedDescription)"
+                }
+                await repo.refresh()
+            } else {
+                statusText = "Disconnected."
+            }
+            isConnected = false; busy = false
+        }
+    }
+
+    private func fail(_ m: String) { statusText = m; setBusy(false) }
+
+    /// Busy also pins the screen awake on iOS: the backfill is a foreground URLSession flow, and an
+    /// auto-lock mid-import suspends the app and freezes the run with no error. Always reset on exit.
+    private func setBusy(_ b: Bool) {
+        busy = b
+        #if os(iOS)
+        UIApplication.shared.isIdleTimerDisabled = b
+        #endif
+    }
+    private static let dayFormatter: DateFormatter = {
+        let f = DateFormatter(); f.calendar = Calendar(identifier: .gregorian)
+        f.locale = Locale(identifier: "en_US_POSIX"); f.timeZone = TimeZone(identifier: "UTC")
+        f.dateFormat = "yyyy-MM-dd"; return f
+    }()
+}

--- a/Strand/Oura/OuraConnectModel.swift
+++ b/Strand/Oura/OuraConnectModel.swift
@@ -1,3 +1,7 @@
+// Compiled ONLY when the OURA_CLOUD_IMPORT compilation condition is set (by the untracked
+// OuraSecrets.xcconfig — see OuraConfig.xcconfig). A default build contains none of this code,
+// keeping "fully offline" a byte-level property of the shipped binary, not a runtime promise.
+#if OURA_CLOUD_IMPORT
 import Foundation
 import Combine
 import AuthenticationServices
@@ -100,3 +104,4 @@ final class OuraConnectModel: ObservableObject {
         f.dateFormat = "yyyy-MM-dd"; return f
     }()
 }
+#endif // OURA_CLOUD_IMPORT

--- a/Strand/Oura/OuraCredentials.swift
+++ b/Strand/Oura/OuraCredentials.swift
@@ -1,0 +1,26 @@
+import Foundation
+
+/// The user's own Oura OAuth app credentials, injected at build time via an untracked xcconfig →
+/// Info.plist (Task 5). Absent credentials mean the Connect flow is unavailable (surfaced in the UI).
+struct OuraCredentials: Equatable {
+    let clientId: String
+    let clientSecret: String
+    let redirectURI: String
+
+    /// Build from an Info-dictionary-shaped map. Returns nil unless all three keys are present and
+    /// non-blank (so a build without the xcconfig cleanly disables the lane rather than half-configuring).
+    static func from(_ info: [String: Any]) -> OuraCredentials? {
+        func nonBlank(_ key: String) -> String? {
+            guard let s = (info[key] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines),
+                  !s.isEmpty else { return nil }
+            return s
+        }
+        guard let id = nonBlank("OURA_CLIENT_ID"),
+              let secret = nonBlank("OURA_CLIENT_SECRET"),
+              let redirect = nonBlank("OURA_REDIRECT_URI") else { return nil }
+        return OuraCredentials(clientId: id, clientSecret: secret, redirectURI: redirect)
+    }
+
+    /// The live credentials from the app bundle's Info.plist, or nil if not configured.
+    static var fromBundle: OuraCredentials? { from(Bundle.main.infoDictionary ?? [:]) }
+}

--- a/Strand/Oura/OuraCredentials.swift
+++ b/Strand/Oura/OuraCredentials.swift
@@ -1,3 +1,7 @@
+// Compiled ONLY when the OURA_CLOUD_IMPORT compilation condition is set (by the untracked
+// OuraSecrets.xcconfig — see OuraConfig.xcconfig). A default build contains none of this code,
+// keeping "fully offline" a byte-level property of the shipped binary, not a runtime promise.
+#if OURA_CLOUD_IMPORT
 import Foundation
 
 /// The user's own Oura OAuth app credentials, injected at build time via an untracked xcconfig →
@@ -24,3 +28,4 @@ struct OuraCredentials: Equatable {
     /// The live credentials from the app bundle's Info.plist, or nil if not configured.
     static var fromBundle: OuraCredentials? { from(Bundle.main.infoDictionary ?? [:]) }
 }
+#endif // OURA_CLOUD_IMPORT

--- a/Strand/Oura/OuraError.swift
+++ b/Strand/Oura/OuraError.swift
@@ -1,3 +1,7 @@
+// Compiled ONLY when the OURA_CLOUD_IMPORT compilation condition is set (by the untracked
+// OuraSecrets.xcconfig — see OuraConfig.xcconfig). A default build contains none of this code,
+// keeping "fully offline" a byte-level property of the shipped binary, not a runtime promise.
+#if OURA_CLOUD_IMPORT
 import Foundation
 
 /// User-facing failure reasons for the Oura cloud-import lane, mapped to clear, non-crashing messages.
@@ -31,3 +35,4 @@ enum OuraError: LocalizedError, Equatable {
         }
     }
 }
+#endif // OURA_CLOUD_IMPORT

--- a/Strand/Oura/OuraError.swift
+++ b/Strand/Oura/OuraError.swift
@@ -1,0 +1,33 @@
+import Foundation
+
+/// User-facing failure reasons for the Oura cloud-import lane, mapped to clear, non-crashing messages.
+/// Mirrors AICoachError's shape (LocalizedError + errorDescription).
+enum OuraError: LocalizedError, Equatable {
+    case notConnected
+    case authFailed(String)
+    case tokenExchangeFailed(String)
+    case badResponse(Int, String)
+    case rateLimited
+    case network(String)
+    case decode
+
+    var errorDescription: String? {
+        switch self {
+        case .notConnected:
+            return "Connect your Oura account first."
+        case .authFailed(let d):
+            return "Oura sign-in didn't complete: \(d)"
+        case .tokenExchangeFailed(let d):
+            return "Couldn't exchange the Oura authorization code: \(d)"
+        case .badResponse(let code, let detail):
+            let extra = detail.isEmpty ? "" : " — \(detail)"
+            return "Oura returned an error (\(code))\(extra)."
+        case .rateLimited:
+            return "Oura is rate-limiting requests. Waiting before retrying."
+        case .network(let d):
+            return "Network problem talking to Oura: \(d)"
+        case .decode:
+            return "Couldn't read Oura's response."
+        }
+    }
+}

--- a/Strand/Oura/OuraOAuth.swift
+++ b/Strand/Oura/OuraOAuth.swift
@@ -1,0 +1,77 @@
+import Foundation
+
+/// Pure (network-free) pieces of the Oura OAuth2 authorization-code flow: URL/request builders and the
+/// token-response parser. Unit-tested directly; the interactive step + the actual POST live in
+/// OuraOAuthProvider. No PKCE (Oura's flow doesn't support it), so the exchange carries the client_secret.
+enum OuraOAuth {
+    static let authorizeEndpoint = URL(string: "https://cloud.ouraring.com/oauth/authorize")!
+    static let tokenEndpoint = URL(string: "https://api.ouraring.com/oauth/token")!
+    // No hardcoded scope list. Oura's own docs: the `scope` param is OPTIONAL and "if left blank, the
+    // application will request ALL available scopes" — which is exactly the goal, and sidesteps two
+    // documentation traps hit live: the SpO2 scope's name differs between the OpenAPI spec ("spo2Daily")
+    // and the auth docs ("spo2"), and the dev portal grants scopes the public docs don't list at all
+    // (Stress, Heart Health, Ring Configuration — the docs still say "8 scopes", the portal shows 11).
+    // Omitting `scope` requests everything the app registration is configured for; the user still picks
+    // on Oura's consent screen.
+
+    /// The consent URL to open in ASWebAuthenticationSession. `state` is a caller-generated nonce echoed
+    /// back on redirect and verified, to defeat CSRF / stray callbacks.
+    static func authorizeURL(credentials: OuraCredentials, state: String) -> URL {
+        var comps = URLComponents(url: authorizeEndpoint, resolvingAgainstBaseURL: false)!
+        comps.queryItems = [
+            .init(name: "response_type", value: "code"),
+            .init(name: "client_id", value: credentials.clientId),
+            .init(name: "redirect_uri", value: credentials.redirectURI),
+            // `scope` deliberately omitted — see the note above: blank = all available scopes.
+            .init(name: "state", value: state),
+        ]
+        return comps.url!
+    }
+
+    static func tokenExchangeRequest(credentials: OuraCredentials, code: String) -> URLRequest {
+        form(tokenEndpoint, [
+            "grant_type": "authorization_code",
+            "code": code,
+            "redirect_uri": credentials.redirectURI,
+            "client_id": credentials.clientId,
+            "client_secret": credentials.clientSecret,
+        ])
+    }
+
+    static func refreshRequest(credentials: OuraCredentials, refreshToken: String) -> URLRequest {
+        form(tokenEndpoint, [
+            "grant_type": "refresh_token",
+            "refresh_token": refreshToken,
+            "client_id": credentials.clientId,
+            "client_secret": credentials.clientSecret,
+        ])
+    }
+
+    /// Parse a token endpoint response. `now` is injected so expiry is deterministic in tests.
+    static func parseTokenResponse(_ data: Data, now: Date) throws -> OuraTokens {
+        guard let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let access = obj["access_token"] as? String, !access.isEmpty else {
+            let detail = String(data: data, encoding: .utf8) ?? ""
+            throw OuraError.tokenExchangeFailed(detail)
+        }
+        let refresh = obj["refresh_token"] as? String
+        let expiresIn = (obj["expires_in"] as? Double) ?? (obj["expires_in"] as? Int).map(Double.init) ?? 2_592_000
+        return OuraTokens(accessToken: access, refreshToken: refresh,
+                          expiresAt: now.addingTimeInterval(expiresIn))
+    }
+
+    private static func form(_ url: URL, _ fields: [String: String]) -> URLRequest {
+        var req = URLRequest(url: url)
+        req.httpMethod = "POST"
+        req.setValue("application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
+        // x-www-form-urlencoded: escape everything but unreserved chars. Crucially '+' (else the server
+        // decodes it to a space) and the '&'/'=' separators — URLComponents.percentEncodedQuery leaves '+'
+        // unescaped, which silently corrupts base64 client_secret/code/refresh_token values.
+        var allowed = CharacterSet.alphanumerics
+        allowed.insert(charactersIn: "-._~")
+        func enc(_ s: String) -> String { s.addingPercentEncoding(withAllowedCharacters: allowed) ?? s }
+        req.httpBody = fields.map { "\(enc($0.key))=\(enc($0.value))" }
+            .joined(separator: "&").data(using: .utf8)
+        return req
+    }
+}

--- a/Strand/Oura/OuraOAuth.swift
+++ b/Strand/Oura/OuraOAuth.swift
@@ -1,3 +1,7 @@
+// Compiled ONLY when the OURA_CLOUD_IMPORT compilation condition is set (by the untracked
+// OuraSecrets.xcconfig — see OuraConfig.xcconfig). A default build contains none of this code,
+// keeping "fully offline" a byte-level property of the shipped binary, not a runtime promise.
+#if OURA_CLOUD_IMPORT
 import Foundation
 
 /// Pure (network-free) pieces of the Oura OAuth2 authorization-code flow: URL/request builders and the
@@ -75,3 +79,4 @@ enum OuraOAuth {
         return req
     }
 }
+#endif // OURA_CLOUD_IMPORT

--- a/Strand/Oura/OuraOAuthProvider.swift
+++ b/Strand/Oura/OuraOAuthProvider.swift
@@ -1,3 +1,7 @@
+// Compiled ONLY when the OURA_CLOUD_IMPORT compilation condition is set (by the untracked
+// OuraSecrets.xcconfig — see OuraConfig.xcconfig). A default build contains none of this code,
+// keeping "fully offline" a byte-level property of the shipped binary, not a runtime promise.
+#if OURA_CLOUD_IMPORT
 import Foundation
 import AuthenticationServices
 
@@ -73,3 +77,4 @@ final class OuraOAuthProvider: NSObject, AuthProvider, ASWebAuthenticationPresen
         anchor ?? ASPresentationAnchor()
     }
 }
+#endif // OURA_CLOUD_IMPORT

--- a/Strand/Oura/OuraOAuthProvider.swift
+++ b/Strand/Oura/OuraOAuthProvider.swift
@@ -1,0 +1,75 @@
+import Foundation
+import AuthenticationServices
+
+/// BYO-app OAuth2 authorization-code AuthProvider. Runs ASWebAuthenticationSession for the interactive
+/// consent, exchanges the code for tokens (Keychain), and refreshes on demand. The `session` is injected
+/// so the token exchange/refresh POSTs are URLProtocol-testable; the interactive step is integration-only.
+final class OuraOAuthProvider: NSObject, AuthProvider, ASWebAuthenticationPresentationContextProviding {
+    private let credentials: OuraCredentials
+    private let session: URLSession
+    private var anchor: ASPresentationAnchor?
+
+    init(credentials: OuraCredentials, session: URLSession = .shared) {
+        self.credentials = credentials
+        self.session = session
+    }
+
+    var isConnected: Bool { OuraTokenStore.isConnected }
+    func signOut() { OuraTokenStore.clear() }
+
+    func validAccessToken() async throws -> String {
+        guard let tokens = OuraTokenStore.load() else { throw OuraError.notConnected }
+        if !tokens.isExpired { return tokens.accessToken }
+        return try await refreshedAccessToken()
+    }
+
+    /// Unconditionally refresh, regardless of the stored token's expiry state.
+    func refreshedAccessToken() async throws -> String {
+        guard let refresh = OuraTokenStore.load()?.refreshToken else { throw OuraError.notConnected }
+        let refreshed = try await exchange(OuraOAuth.refreshRequest(credentials: credentials, refreshToken: refresh))
+        guard OuraTokenStore.save(refreshed) else { throw OuraError.tokenExchangeFailed("keychain write failed") }
+        return refreshed.accessToken
+    }
+
+    @MainActor
+    func authorize(presentationAnchor: ASPresentationAnchor) async throws {
+        self.anchor = presentationAnchor
+        let state = UUID().uuidString
+        let url = OuraOAuth.authorizeURL(credentials: credentials, state: state)
+        let scheme = URL(string: credentials.redirectURI)?.scheme
+
+        let callback: URL = try await withCheckedThrowingContinuation { cont in
+            let webSession = ASWebAuthenticationSession(url: url, callbackURLScheme: scheme) { url, err in
+                if let url { cont.resume(returning: url) }
+                else { cont.resume(throwing: OuraError.authFailed(err?.localizedDescription ?? "cancelled")) }
+            }
+            webSession.presentationContextProvider = self
+            webSession.prefersEphemeralWebBrowserSession = false
+            if !webSession.start() { cont.resume(throwing: OuraError.authFailed("couldn't start web session")) }
+        }
+
+        let items = URLComponents(url: callback, resolvingAgainstBaseURL: false)?.queryItems ?? []
+        let q = Dictionary(uniqueKeysWithValues: items.map { ($0.name, $0.value ?? "") })
+        guard q["state"] == state else { throw OuraError.authFailed("state mismatch") }
+        guard let code = q["code"], !code.isEmpty else { throw OuraError.authFailed(q["error"] ?? "no code") }
+
+        let tokens = try await exchange(OuraOAuth.tokenExchangeRequest(credentials: credentials, code: code))
+        guard OuraTokenStore.save(tokens) else { throw OuraError.tokenExchangeFailed("keychain write failed") }
+    }
+
+    /// POST a token request and parse the response (shared by exchange + refresh).
+    private func exchange(_ req: URLRequest) async throws -> OuraTokens {
+        let (data, resp): (Data, URLResponse)
+        do { (data, resp) = try await session.data(for: req) }
+        catch { throw OuraError.network(error.localizedDescription) }
+        let code = (resp as? HTTPURLResponse)?.statusCode ?? 0
+        guard (200..<300).contains(code) else {
+            throw OuraError.tokenExchangeFailed("HTTP \(code): \(String(data: data, encoding: .utf8) ?? "")")
+        }
+        return try OuraOAuth.parseTokenResponse(data, now: Date())
+    }
+
+    func presentationAnchor(for session: ASWebAuthenticationSession) -> ASPresentationAnchor {
+        anchor ?? ASPresentationAnchor()
+    }
+}

--- a/Strand/Oura/OuraPresentationAnchor.swift
+++ b/Strand/Oura/OuraPresentationAnchor.swift
@@ -1,3 +1,7 @@
+// Compiled ONLY when the OURA_CLOUD_IMPORT compilation condition is set (by the untracked
+// OuraSecrets.xcconfig — see OuraConfig.xcconfig). A default build contains none of this code,
+// keeping "fully offline" a byte-level property of the shipped binary, not a runtime promise.
+#if OURA_CLOUD_IMPORT
 import AuthenticationServices
 #if os(iOS)
 import UIKit
@@ -18,3 +22,4 @@ import AppKit
     return ASPresentationAnchor()
     #endif
 }
+#endif // OURA_CLOUD_IMPORT

--- a/Strand/Oura/OuraPresentationAnchor.swift
+++ b/Strand/Oura/OuraPresentationAnchor.swift
@@ -1,0 +1,20 @@
+import AuthenticationServices
+#if os(iOS)
+import UIKit
+#elseif os(macOS)
+import AppKit
+#endif
+
+/// The app's key window as an ASPresentationAnchor for ASWebAuthenticationSession. Modeled on
+/// DisplayScreenshot's window lookup. Falls back to a bare anchor (OuraOAuthProvider tolerates it).
+@MainActor func ouraPresentationAnchor() -> ASPresentationAnchor {
+    #if os(iOS)
+    let scenes = UIApplication.shared.connectedScenes.compactMap { $0 as? UIWindowScene }
+    let scene = scenes.first { $0.activationState == .foregroundActive } ?? scenes.first
+    return scene?.keyWindow ?? scene?.windows.first ?? ASPresentationAnchor()
+    #elseif os(macOS)
+    return NSApplication.shared.keyWindow ?? NSApplication.shared.windows.first ?? ASPresentationAnchor()
+    #else
+    return ASPresentationAnchor()
+    #endif
+}

--- a/Strand/Oura/OuraSecrets.example.xcconfig
+++ b/Strand/Oura/OuraSecrets.example.xcconfig
@@ -1,5 +1,10 @@
 // Copy to OuraSecrets.xcconfig (gitignored) and fill in your own Oura OAuth app's values.
 // Register a free app at the Oura developer portal; set the redirect URI to noop://oura/callback.
+//
+// Creating this file is ALSO what compiles the Oura import lane in: the compilation condition
+// below gates every file in Strand/Oura/ (see OuraConfig.xcconfig). Without this file, a build
+// contains zero Oura network code — "fully offline" stays a byte-level property of the binary.
+SWIFT_ACTIVE_COMPILATION_CONDITIONS = $(inherited) OURA_CLOUD_IMPORT
 OURA_CLIENT_ID = your_client_id_here
 OURA_CLIENT_SECRET = your_client_secret_here
 // .xcconfig treats // as a start-of-comment ANYWHERE on the line (not just at line-start), so a

--- a/Strand/Oura/OuraSecrets.example.xcconfig
+++ b/Strand/Oura/OuraSecrets.example.xcconfig
@@ -1,0 +1,9 @@
+// Copy to OuraSecrets.xcconfig (gitignored) and fill in your own Oura OAuth app's values.
+// Register a free app at the Oura developer portal; set the redirect URI to noop://oura/callback.
+OURA_CLIENT_ID = your_client_id_here
+OURA_CLIENT_SECRET = your_client_secret_here
+// .xcconfig treats // as a start-of-comment ANYWHERE on the line (not just at line-start), so a
+// literal "noop://oura/callback" here gets silently truncated to "noop:" — the empty macro
+// expansion $() below breaks up the "//" token without changing the resolved string, which is
+// still exactly noop://oura/callback at build time. Keep this trick if you edit the value.
+OURA_REDIRECT_URI = noop:/$()/oura/callback

--- a/Strand/Oura/OuraSyncCoordinator.swift
+++ b/Strand/Oura/OuraSyncCoordinator.swift
@@ -1,0 +1,165 @@
+import Foundation
+import WhoopStore
+import WhoopProtocol
+import StrandImport
+
+/// Abstracts the page fetch so the coordinator is testable without a live network (OuraAPIClient conforms).
+protocol OuraPageFetching {
+    func fetchAllRaw(endpoint: String, query: [String: String]) async throws -> [Data]
+}
+extension OuraAPIClient: OuraPageFetching {}
+
+struct OuraSyncProgress: Equatable {
+    let endpoint: String
+    let pages: Int
+    /// Optional human detail (e.g. "window 4/17" for the chunked heartrate fetch).
+    var detail: String? = nil
+}
+
+/// One-time backfill across every Oura v2 endpoint → an assembled OuraSyncResult → OuraSyncWriter. Merges
+/// the per-day WearableDailyRows across endpoints (daily endpoints BEFORE sleep, so readiness RHR wins).
+final class OuraSyncCoordinator {
+    private let fetcher: OuraPageFetching
+    private let store: WhoopStore
+    init(fetcher: OuraPageFetching, store: WhoopStore) { self.fetcher = fetcher; self.store = store }
+
+    /// Daily-summary endpoints handed to `parseDaily(_, endpoint:)`. Ordered so `daily_readiness` merges
+    /// before `sleep` (RHR precedence). `daily_sleep` etc. contribute extras only.
+    private static let dailyEndpoints = ["daily_readiness", "daily_activity", "daily_spo2", "daily_sleep",
+                                         "daily_stress", "daily_resilience", "daily_cardiovascular_age", "vO2_max"]
+    /// Endpoints with no Plan-1 parser — archived raw only.
+    private static let rawOnlyEndpoints = ["personal_info", "ring_configuration", "sleep_time", "session",
+                                           "tag", "enhanced_tag", "rest_mode_period", "ring_battery_level"]
+
+    func runFullImport(startDate: String = "2013-01-01", today: String,
+                       onProgress: @escaping (OuraSyncProgress) -> Void = { _ in }) async throws -> OuraSyncSummary {
+        let deviceId = "oura-api"
+        var result = OuraSyncResult()
+        var byDay: [String: WearableDailyRow] = [:]
+
+        func fetchRawQuery(_ endpoint: String, query: [String: String]) async throws -> [Data] {
+            let pages = try await fetcher.fetchAllRaw(endpoint: endpoint, query: query)
+            // Window-scoped raw key so multi-window endpoints (heartrate) never collide, and a re-pull
+            // of the same window stays idempotent (same key → upsert overwrite).
+            let windowKey = query["start_datetime"] ?? query["start_date"] ?? startDate
+            var idx = 0
+            for body in pages {
+                result.rawPages.append(OuraRawRow(endpoint: endpoint, documentId: "\(endpoint)-\(windowKey)-\(idx)",
+                                                  day: nil, payloadJSON: String(data: body, encoding: .utf8) ?? "",
+                                                  fetchedAt: Int(Date().timeIntervalSince1970)))
+                idx += 1
+            }
+            onProgress(OuraSyncProgress(endpoint: endpoint, pages: pages.count))
+            return pages
+        }
+        func fetchRaw(_ endpoint: String, dateParam: String?) async throws -> [Data] {
+            var q: [String: String] = [:]
+            if let dateParam { q[dateParam] = startDate; q[dateParam == "start_datetime" ? "end_datetime" : "end_date"] = today }
+            return try await fetchRawQuery(endpoint, query: q)
+        }
+
+        func docs(_ pages: [Data]) -> [[String: Any]] {
+            pages.flatMap { (try? JSONSerialization.jsonObject(with: $0) as? [String: Any])?["data"] as? [[String: Any]] ?? [] }
+        }
+        func merge(_ rows: [WearableDailyRow]) {
+            for r in rows {
+                var m = byDay[r.day] ?? WearableDailyRow(day: r.day)
+                m.restingHr = m.restingHr ?? r.restingHr; m.avgHrvMs = m.avgHrvMs ?? r.avgHrvMs
+                m.skinTempDevC = m.skinTempDevC ?? r.skinTempDevC; m.spo2Pct = m.spo2Pct ?? r.spo2Pct
+                m.steps = m.steps ?? r.steps; m.activeKcal = m.activeKcal ?? r.activeKcal
+                m.totalKcal = m.totalKcal ?? r.totalKcal; m.respRateBpm = m.respRateBpm ?? r.respRateBpm
+                m.totalSleepMin = m.totalSleepMin ?? r.totalSleepMin; m.deepMin = m.deepMin ?? r.deepMin
+                m.lightMin = m.lightMin ?? r.lightMin; m.remMin = m.remMin ?? r.remMin
+                m.awakeMin = m.awakeMin ?? r.awakeMin; m.efficiencyPct = m.efficiencyPct ?? r.efficiencyPct
+                byDay[r.day] = m
+            }
+        }
+
+        // One failing endpoint must not abort the whole backfill (spec §7 — honest partial). A fetch
+        // error (e.g. a scope 401 like the live spo2 naming mismatch) records the endpoint as skipped
+        // and the run continues; the UI surfaces the skips from the summary.
+        var skipped: [String] = []
+
+        // Daily endpoints first (readiness RHR precedence), extras accumulate.
+        for endpoint in Self.dailyEndpoints {
+            do {
+                let pages = try await fetchRaw(endpoint, dateParam: "start_date")
+                let (days, extras) = OuraApiParser.parseDaily(docs(pages), endpoint: endpoint)
+                merge(days); result.extras.append(contentsOf: extras)
+            } catch { skipped.append(endpoint) }
+        }
+        // Sleep last (its lowestHr fallback only fills days readiness didn't cover).
+        do {
+            let sleepPages = try await fetchRaw("sleep", dateParam: "start_date")
+            let (periods, sleepDays) = OuraApiParser.parseSleep(docs(sleepPages))
+            result.sleepPeriods = periods; merge(sleepDays)
+        } catch { skipped.append("sleep") }
+        // Workouts.
+        do {
+            let workoutPages = try await fetchRaw("workout", dateParam: "start_date")
+            result.workouts = OuraApiParser.parseWorkouts(docs(workoutPages))
+        } catch { skipped.append("workout") }
+        // Raw-only endpoints (no parser).
+        for endpoint in Self.rawOnlyEndpoints {
+            do {
+                _ = try await fetchRaw(endpoint, dateParam: ["personal_info", "ring_configuration"].contains(endpoint) ? nil : "start_date")
+            } catch { skipped.append(endpoint) }
+        }
+
+        // Persist the light data (days/sleeps/workouts/extras/raw + source registration) FIRST, as a
+        // durable checkpoint. It's small and fetched one call apiece; landing it in SQLite before the long
+        // heart-rate backfill means an interruption during HR can never cost it.
+        result.days = Array(byDay.values)
+        onProgress(OuraSyncProgress(endpoint: "saving", pages: 0))
+        var summary = try await OuraSyncWriter.persist(result, into: store, deviceId: deviceId)
+
+        // Whole-day heart-rate: the ONE endpoint with a hard ≤30-day range cap (probe-verified: a wider
+        // span is HTTP 400 "Timerange ... has to be less than or equal to 30 days"; an unencoded '+00:00'
+        // offset 422s since '+' decodes to a space). Fetched in 30-day windows of full ISO-'Z' datetimes,
+        // floored at the earliest day the dailies returned (never page years of empty pre-account time).
+        // CRITICAL: each window is PERSISTED before advancing, so a lock or interruption keeps every
+        // completed window instead of losing the whole series (the prior one-shot end-persist did exactly
+        // that). Re-runs re-fetch from the floor; hrSample dedupes on (deviceId, ts) and ouraRaw on
+        // (endpoint, documentId), so replaying an already-saved window is a harmless overwrite.
+        do {
+            let floorDay = byDay.keys.min() ?? startDate
+            var cursor = Self.dayFmt.date(from: floorDay) ?? Date(timeIntervalSince1970: 0)
+            let endDate = (Self.dayFmt.date(from: today) ?? Date()).addingTimeInterval(86_400)
+            let totalWindows = max(1, Int(ceil(endDate.timeIntervalSince(cursor) / (30 * 86_400))))
+            let fetchedAt = Int(Date().timeIntervalSince1970)
+            var window = 0
+            while cursor < endDate {
+                window += 1
+                onProgress(OuraSyncProgress(endpoint: "heartrate", pages: 0, detail: "window \(window)/\(totalWindows)"))
+                let next = min(cursor.addingTimeInterval(30 * 86_400), endDate)
+                let startISO = Self.isoFmt.string(from: cursor)
+                let pages = try await fetcher.fetchAllRaw(endpoint: "heartrate",
+                    query: ["start_datetime": startISO, "end_datetime": Self.isoFmt.string(from: next)])
+                // Persist THIS window before fetching the next — the durability guarantee.
+                let rawRows = pages.enumerated().map { idx, body in
+                    OuraRawRow(endpoint: "heartrate", documentId: "heartrate-\(startISO)-\(idx)", day: nil,
+                               payloadJSON: String(data: body, encoding: .utf8) ?? "", fetchedAt: fetchedAt)
+                }
+                if !rawRows.isEmpty { summary.rawPages += try await store.upsertOuraRaw(rawRows, deviceId: deviceId) }
+                let hr = OuraApiParser.parseHeartRate(docs(pages)).map { HRSample(ts: $0.ts, bpm: $0.bpm) }
+                if !hr.isEmpty { summary.hrSamples += try await store.insert(Streams(hr: hr), deviceId: deviceId).hr }
+                cursor = next
+            }
+        } catch { skipped.append("heartrate") }
+
+        summary.skippedEndpoints = skipped
+        return summary
+    }
+
+    // UTC day / ISO-'Z' datetime formatters for the windowed heartrate fetch.
+    private static let dayFmt: DateFormatter = {
+        let f = DateFormatter(); f.calendar = Calendar(identifier: .gregorian)
+        f.locale = Locale(identifier: "en_US_POSIX"); f.timeZone = TimeZone(identifier: "UTC")
+        f.dateFormat = "yyyy-MM-dd"; return f
+    }()
+    private static let isoFmt: DateFormatter = {
+        let f = DateFormatter(); f.calendar = Calendar(identifier: .gregorian)
+        f.locale = Locale(identifier: "en_US_POSIX"); f.timeZone = TimeZone(identifier: "UTC")
+        f.dateFormat = "yyyy-MM-dd'T'HH:mm:ss'Z'"; return f
+    }()
+}

--- a/Strand/Oura/OuraSyncCoordinator.swift
+++ b/Strand/Oura/OuraSyncCoordinator.swift
@@ -1,3 +1,7 @@
+// Compiled ONLY when the OURA_CLOUD_IMPORT compilation condition is set (by the untracked
+// OuraSecrets.xcconfig — see OuraConfig.xcconfig). A default build contains none of this code,
+// keeping "fully offline" a byte-level property of the shipped binary, not a runtime promise.
+#if OURA_CLOUD_IMPORT
 import Foundation
 import WhoopStore
 import WhoopProtocol
@@ -163,3 +167,4 @@ final class OuraSyncCoordinator {
         f.dateFormat = "yyyy-MM-dd'T'HH:mm:ss'Z'"; return f
     }()
 }
+#endif // OURA_CLOUD_IMPORT

--- a/Strand/Oura/OuraSyncResult.swift
+++ b/Strand/Oura/OuraSyncResult.swift
@@ -1,3 +1,7 @@
+// Compiled ONLY when the OURA_CLOUD_IMPORT compilation condition is set (by the untracked
+// OuraSecrets.xcconfig — see OuraConfig.xcconfig). A default build contains none of this code,
+// keeping "fully offline" a byte-level property of the shipped binary, not a runtime promise.
+#if OURA_CLOUD_IMPORT
 import Foundation
 import StrandImport
 import WhoopStore   // OuraRawRow lives in WhoopStore (OuraRawStore.swift), not StrandImport
@@ -28,3 +32,4 @@ struct OuraSyncSummary: Equatable {
     var days = 0, sleeps = 0, workouts = 0, hrSamples = 0, metricPoints = 0, rawPages = 0
     var skippedEndpoints: [String] = []
 }
+#endif // OURA_CLOUD_IMPORT

--- a/Strand/Oura/OuraSyncResult.swift
+++ b/Strand/Oura/OuraSyncResult.swift
@@ -1,0 +1,30 @@
+import Foundation
+import StrandImport
+import WhoopStore   // OuraRawRow lives in WhoopStore (OuraRawStore.swift), not StrandImport
+
+/// The fully-assembled, parsed output of one Oura backfill, ready to persist. The coordinator (Task 2)
+/// builds this (merging per-day rows across endpoints); the writer (below) maps it to WhoopStore.
+struct OuraSyncResult {
+    var days: [WearableDailyRow]        // already coalesced per calendar day
+    var sleepPeriods: [OuraSleepPeriod]
+    var extras: [OuraDailyExtra]        // every ref_*/oura_*/vo2max scalar → metricSeries
+    var workouts: [OuraWorkout]
+    var heartRate: [OuraHRPoint]        // from the /heartrate endpoint (whole-day)
+    var rawPages: [OuraRawRow]          // every fetched page, verbatim
+    var ringModel: String?             // from ring_configuration, for the PairedDevice model
+
+    init(days: [WearableDailyRow] = [], sleepPeriods: [OuraSleepPeriod] = [], extras: [OuraDailyExtra] = [],
+         workouts: [OuraWorkout] = [], heartRate: [OuraHRPoint] = [], rawPages: [OuraRawRow] = [],
+         ringModel: String? = nil) {
+        self.days = days; self.sleepPeriods = sleepPeriods; self.extras = extras
+        self.workouts = workouts; self.heartRate = heartRate; self.rawPages = rawPages; self.ringModel = ringModel
+    }
+}
+
+/// Counts written, for the honest import summary. `skippedEndpoints` lists endpoints whose fetch failed
+/// (e.g. a scope 401) — the backfill continues past them (honest partial, spec §7) and the UI surfaces
+/// the skips so a partial import never silently looks complete.
+struct OuraSyncSummary: Equatable {
+    var days = 0, sleeps = 0, workouts = 0, hrSamples = 0, metricPoints = 0, rawPages = 0
+    var skippedEndpoints: [String] = []
+}

--- a/Strand/Oura/OuraSyncWriter.swift
+++ b/Strand/Oura/OuraSyncWriter.swift
@@ -1,3 +1,7 @@
+// Compiled ONLY when the OURA_CLOUD_IMPORT compilation condition is set (by the untracked
+// OuraSecrets.xcconfig — see OuraConfig.xcconfig). A default build contains none of this code,
+// keeping "fully offline" a byte-level property of the shipped binary, not a runtime promise.
+#if OURA_CLOUD_IMPORT
 import Foundation
 import WhoopStore
 import WhoopProtocol
@@ -87,3 +91,4 @@ enum OuraSyncWriter {
         return (try? JSONSerialization.data(withJSONObject: segs)).flatMap { String(data: $0, encoding: .utf8) }
     }
 }
+#endif // OURA_CLOUD_IMPORT

--- a/Strand/Oura/OuraSyncWriter.swift
+++ b/Strand/Oura/OuraSyncWriter.swift
@@ -1,0 +1,89 @@
+import Foundation
+import WhoopStore
+import WhoopProtocol
+import StrandImport
+
+/// Maps an assembled `OuraSyncResult` into the on-device WhoopStore under `deviceId = "oura-api"` — the
+/// cloud sibling of `Strand/Data/WearableImporter.swift`. HONEST DATA: Oura's own scores go only to
+/// ref_*/oura_* metricSeries keys; `DailyMetric.recovery`/`.strain` stay nil. The source registers as
+/// `.cloudImport`, which is structurally priority-2 in DayOwnerResolver, so it never seizes a WHOOP day.
+enum OuraSyncWriter {
+
+    @discardableResult
+    static func persist(_ result: OuraSyncResult, into store: WhoopStore,
+                        deviceId: String = "oura-api") async throws -> OuraSyncSummary {
+        var summary = OuraSyncSummary()
+
+        // 0. Register the cloud source (the one thing WearableImporter skips). Idempotent by id.
+        let now = Int(Date().timeIntervalSince1970)
+        let device = PairedDevice(
+            id: deviceId, brand: "Oura", model: result.ringModel ?? "Oura (cloud)",
+            sourceKind: .cloudImport, capabilities: [], status: .paired,
+            addedAt: now, lastSeenAt: now)
+        try DeviceRegistryStore(dbQueue: store.registryWriter).add(device)
+
+        // 1. Raw archive — verbatim, every page, lossless.
+        if !result.rawPages.isEmpty {
+            summary.rawPages = try await store.upsertOuraRaw(result.rawPages, deviceId: deviceId)
+        }
+
+        // 2. Days → DailyMetric. recovery/strain ALWAYS nil (never Oura's readiness). Mirrors WearableImporter.
+        let metrics = result.days.map { d in
+            DailyMetric(day: d.day, totalSleepMin: d.totalSleepMin, efficiency: d.efficiencyPct,
+                        deepMin: d.deepMin, remMin: d.remMin, lightMin: d.lightMin, disturbances: nil,
+                        restingHr: d.restingHr, avgHrv: d.avgHrvMs, recovery: nil, strain: nil,
+                        exerciseCount: nil, spo2Pct: d.spo2Pct, skinTempDevC: d.skinTempDevC,
+                        respRateBpm: d.respRateBpm, steps: d.steps, activeKcalEst: d.activeKcal)
+        }
+        summary.days = try await store.upsertDailyMetrics(metrics, deviceId: deviceId)
+
+        // 3. Sleep sessions → CachedSleepSession (+ stagesJSON), then per-session motion via the dedicated setter.
+        var sessions: [CachedSleepSession] = []
+        for p in result.sleepPeriods {
+            let startTs = Int(p.session.start.timeIntervalSince1970)
+            let endTs = Int(p.session.end.timeIntervalSince1970)
+            sessions.append(CachedSleepSession(
+                startTs: startTs, endTs: endTs, efficiency: p.session.efficiencyPct,
+                restingHr: p.session.lowestHr ?? p.session.avgHr, avgHrv: p.session.avgHrvMs,
+                stagesJSON: stagesJSON(p.session.stages)))
+        }
+        summary.sleeps = try await store.upsertSleepSessions(sessions, deviceId: deviceId)
+        for p in result.sleepPeriods where !p.movement30s.isEmpty {   // motionJSON is NOT on the sleep upsert
+            _ = try await store.persistSessionMotion(
+                deviceId: deviceId, sessionStart: Int(p.session.start.timeIntervalSince1970),
+                motionEpochs: p.movement30s.map(Double.init))
+        }
+
+        // 4. HR → hrSample via the Streams insert path (in-sleep HR + the whole-day /heartrate series).
+        var hr: [HRSample] = result.heartRate.map { HRSample(ts: $0.ts, bpm: $0.bpm) }
+        for p in result.sleepPeriods { hr.append(contentsOf: p.hr.map { HRSample(ts: $0.ts, bpm: $0.bpm) }) }
+        if !hr.isEmpty {
+            let counts = try await store.insert(Streams(hr: hr), deviceId: deviceId)
+            summary.hrSamples = counts.hr
+        }
+
+        // 5. Workouts → WorkoutRow.
+        let workouts = result.workouts.map { w in
+            WorkoutRow(startTs: Int(w.start.timeIntervalSince1970), endTs: Int(w.end.timeIntervalSince1970),
+                       sport: w.activity, source: w.source, durationS: w.end.timeIntervalSince(w.start),
+                       energyKcal: w.energyKcal, avgHr: nil, maxHr: nil, strain: nil,
+                       distanceM: w.distanceM, zonesJSON: nil, notes: nil)
+        }
+        summary.workouts = try await store.upsertWorkouts(workouts, deviceId: deviceId)
+
+        // 6. Extras → metricSeries (ref_*/oura_*/vo2max — parity with the file-import lane, sourced from
+        //    the extras array so vo2max/ref_sleep_score are never lost even though DailyMetric lacks them).
+        let points = result.extras.map { MetricPoint(day: $0.day, key: $0.key, value: $0.value) }
+        summary.metricPoints = try await store.upsertMetricSeries(points, deviceId: deviceId)
+
+        return summary
+    }
+
+    /// Serialize decoded stages to the `[{start,end,stage}]` JSON the cache stores (same shape as WearableImporter).
+    private static func stagesJSON(_ stages: [WearableSleepStageInterval]) -> String? {
+        guard !stages.isEmpty else { return nil }
+        let segs = stages.map { ["start": Int($0.start.timeIntervalSince1970),
+                                 "end": Int($0.end.timeIntervalSince1970), "stage": $0.stage] as [String: Any] }
+        return (try? JSONSerialization.data(withJSONObject: segs)).flatMap { String(data: $0, encoding: .utf8) }
+    }
+}

--- a/Strand/Oura/OuraTokenStore.swift
+++ b/Strand/Oura/OuraTokenStore.swift
@@ -1,0 +1,59 @@
+import Foundation
+import Security
+
+/// The OAuth tokens for the Oura cloud lane. `expiresAt` is absolute (computed from `expires_in` at
+/// exchange time). `isExpired` applies a 60 s skew so we refresh slightly early rather than mid-request.
+struct OuraTokens: Equatable, Codable {
+    let accessToken: String
+    let refreshToken: String?
+    let expiresAt: Date
+
+    var isExpired: Bool { Date() >= expiresAt.addingTimeInterval(-60) }
+}
+
+/// Keychain Services wrapper for the Oura tokens. One generic-password item (JSON-encoded `OuraTokens`)
+/// under a fixed service, so tokens never land in UserDefaults, a plist, or on disk in the clear.
+/// Mirrors AIKeyStore exactly (delete-then-add, kSecAttrAccessibleAfterFirstUnlock).
+enum OuraTokenStore {
+    private static let service = "com.noop.oura"
+    private static let account = "oauth-tokens"
+
+    private static var baseQuery: [String: Any] {
+        [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account,
+        ]
+    }
+
+    /// Store (or replace) the tokens. Returns false if the Keychain write fails (so callers never assume
+    /// a token is stored when it isn't).
+    @discardableResult
+    static func save(_ tokens: OuraTokens) -> Bool {
+        guard let data = try? JSONEncoder().encode(tokens) else { return false }
+        SecItemDelete(baseQuery as CFDictionary)
+        var attrs = baseQuery
+        attrs[kSecValueData as String] = data
+        attrs[kSecAttrAccessible as String] = kSecAttrAccessibleAfterFirstUnlock
+        return SecItemAdd(attrs as CFDictionary, nil) == errSecSuccess
+    }
+
+    /// Load the stored tokens, or nil if none.
+    static func load() -> OuraTokens? {
+        var query = baseQuery
+        query[kSecReturnData as String] = kCFBooleanTrue
+        query[kSecMatchLimit as String] = kSecMatchLimitOne
+        var item: CFTypeRef?
+        guard SecItemCopyMatching(query as CFDictionary, &item) == errSecSuccess,
+              let data = item as? Data,
+              let tokens = try? JSONDecoder().decode(OuraTokens.self, from: data) else { return nil }
+        return tokens
+    }
+
+    /// Remove any stored tokens.
+    static func clear() { SecItemDelete(baseQuery as CFDictionary) }
+
+    /// True when tokens are present (regardless of expiry — an expired token is still "connected", it
+    /// just needs a refresh).
+    static var isConnected: Bool { load() != nil }
+}

--- a/Strand/Oura/OuraTokenStore.swift
+++ b/Strand/Oura/OuraTokenStore.swift
@@ -1,3 +1,7 @@
+// Compiled ONLY when the OURA_CLOUD_IMPORT compilation condition is set (by the untracked
+// OuraSecrets.xcconfig — see OuraConfig.xcconfig). A default build contains none of this code,
+// keeping "fully offline" a byte-level property of the shipped binary, not a runtime promise.
+#if OURA_CLOUD_IMPORT
 import Foundation
 import Security
 
@@ -57,3 +61,4 @@ enum OuraTokenStore {
     /// just needs a refresh).
     static var isConnected: Bool { load() != nil }
 }
+#endif // OURA_CLOUD_IMPORT

--- a/Strand/Resources/Info.plist
+++ b/Strand/Resources/Info.plist
@@ -18,6 +18,15 @@
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
 	<string>$(MARKETING_VERSION)</string>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>noop</string>
+			</array>
+		</dict>
+	</array>
 	<key>CFBundleVersion</key>
 	<string>198</string>
 	<key>LSApplicationCategoryType</key>
@@ -33,5 +42,11 @@
 	<string>NOOP connects directly to your WHOOP strap over Bluetooth to read heart rate, R-R intervals, battery, and sensor data locally on your Mac. Nothing leaves your device.</string>
 	<key>NSLocationWhenInUseUsageDescription</key>
 	<string>NOOP records your route during an outdoor workout to show distance, pace, and a map. The route stays on your device. Nothing leaves it.</string>
+	<key>OURA_CLIENT_ID</key>
+	<string>$(OURA_CLIENT_ID)</string>
+	<key>OURA_CLIENT_SECRET</key>
+	<string>$(OURA_CLIENT_SECRET)</string>
+	<key>OURA_REDIRECT_URI</key>
+	<string>$(OURA_REDIRECT_URI)</string>
 </dict>
 </plist>

--- a/Strand/Screens/DataSourcesView.swift
+++ b/Strand/Screens/DataSourcesView.swift
@@ -32,6 +32,12 @@ struct DataSourcesView: View {
     @State private var wearableImporting = false
     @State private var wearableSummary: String?
     @State private var wearableFailed = false
+    // Oura (cloud) import: connect via OAuth and backfill the full history over the Oura API, as an
+    // alternative to the manual "Oura / Fitbit / Garmin export" file above. `OuraConnectModel` takes
+    // `repo: Repository` as a call-time parameter (not at construction) — `repo` is an
+    // `@EnvironmentObject`, unavailable until after this view's `init()` runs, so storing it at
+    // `@StateObject` construction time would either fail to compile or crash at runtime.
+    @StateObject private var oura = OuraConnectModel()
     // "Remove Apple Health imported data" (ah-delete #616): a destructive escape hatch that purges every
     // row stored under the "apple-health" source via DeviceRegistryStore.deleteAllData. Two-step (a
     // confirmation alert) since it can't be undone. Local to this screen; no live strap data is touched.
@@ -70,8 +76,8 @@ struct DataSourcesView: View {
         ScreenScaffold(title: "Data Sources",
                        subtitle: "Everything stays on \(Platform.deviceNounPhrase). Bring your history in once, then it's yours.",
                        onRefresh: { await repo.refresh() },
-                       // PERF: a nine-card import/source column (WHOOP, Apple Health, Xiaomi, nutrition,
-                       // lifting, activity files, wearables, broadcast-out, live strap). The LazyVStack
+                       // PERF: a ten-card import/source column (WHOOP, Apple Health, Xiaomi, nutrition,
+                       // lifting, activity files, wearables, Oura cloud, broadcast-out, live strap). The LazyVStack
                        // path is byte-identical layout. The cards stay in their inner VStack(sectionSpacing)
                        // for pixel-identical spacing, so the lazy win is partial until they're promoted to
                        // direct children. NOTE: this screen still observes `LiveState` for the broadcaster
@@ -86,8 +92,9 @@ struct DataSourcesView: View {
                 liftingCard.staggeredAppear(index: 4)
                 activityFileCard.staggeredAppear(index: 5)
                 wearableCard.staggeredAppear(index: 6)
-                broadcastHrCard.staggeredAppear(index: 7)
-                liveCard.staggeredAppear(index: 8)
+                ouraCloudCard.staggeredAppear(index: 7)
+                broadcastHrCard.staggeredAppear(index: 8)
+                liveCard.staggeredAppear(index: 9)
             }
         }
         .onAppear {
@@ -277,6 +284,36 @@ struct DataSourcesView: View {
             if let s = wearableSummary {
                 Text(s).font(StrandFont.subhead)
                     .foregroundStyle(wearableFailed ? StrandPalette.statusWarning : StrandPalette.statusPositive)
+            }
+        }
+    }
+
+    /// Oura (cloud): OAuth connect + one-time API backfill, as an alternative to the manual export file
+    /// above. `oura.connectAndImport(repo:)`/`disconnect(repo:)` take `repo` at call time (see the
+    /// `@StateObject` declaration's note) rather than storing it in `OuraConnectModel` at construction.
+    private var ouraCloudCard: some View {
+        card(title: String(localized: "Oura (cloud)"), icon: "circle.circle", tint: StrandPalette.metricPurple,
+             subtitle: String(localized: "Connect your Oura account and import your full history over the API.")) {
+            VStack(alignment: .leading, spacing: 8) {
+                if oura.isConnected {
+                    HStack {
+                        Button { oura.connectAndImport(repo: repo) } label: { Label("Sync again", systemImage: "arrow.clockwise") }
+                            .buttonStyle(NoopButtonStyle(.primary))
+                        Button(role: .destructive) { oura.disconnect(repo: repo) } label: { Label("Disconnect", systemImage: "xmark.circle") }
+                            .buttonStyle(NoopButtonStyle(.destructive))
+                    }.disabled(oura.busy)
+                } else {
+                    Button { oura.connectAndImport(repo: repo) } label: {
+                        Label(oura.busy ? "Working…" : "Connect Oura & Import Everything", systemImage: "link")
+                    }
+                    .buttonStyle(NoopButtonStyle(.primary))
+                    .disabled(oura.busy || !oura.isConfigured)
+                    if !oura.isConfigured {
+                        Text("Add your Oura app credentials to OuraSecrets.xcconfig to enable this.")
+                            .font(.caption).foregroundStyle(.secondary)
+                    }
+                }
+                if let s = oura.statusText { Text(s).font(.caption).foregroundStyle(.secondary) }
             }
         }
     }

--- a/Strand/Screens/DataSourcesView.swift
+++ b/Strand/Screens/DataSourcesView.swift
@@ -32,12 +32,15 @@ struct DataSourcesView: View {
     @State private var wearableImporting = false
     @State private var wearableSummary: String?
     @State private var wearableFailed = false
-    // Oura (cloud) import: connect via OAuth and backfill the full history over the Oura API, as an
-    // alternative to the manual "Oura / Fitbit / Garmin export" file above. `OuraConnectModel` takes
+    #if OURA_CLOUD_IMPORT
+    // Oura history import (compiled in ONLY with OURA_CLOUD_IMPORT): a one-time, user-initiated,
+    // foreground OAuth + backfill of the user's own history over the Oura API, as an alternative to
+    // the manual "Oura / Fitbit / Garmin export" file above. `OuraConnectModel` takes
     // `repo: Repository` as a call-time parameter (not at construction) — `repo` is an
     // `@EnvironmentObject`, unavailable until after this view's `init()` runs, so storing it at
     // `@StateObject` construction time would either fail to compile or crash at runtime.
     @StateObject private var oura = OuraConnectModel()
+    #endif
     // "Remove Apple Health imported data" (ah-delete #616): a destructive escape hatch that purges every
     // row stored under the "apple-health" source via DeviceRegistryStore.deleteAllData. Two-step (a
     // confirmation alert) since it can't be undone. Local to this screen; no live strap data is touched.
@@ -92,7 +95,9 @@ struct DataSourcesView: View {
                 liftingCard.staggeredAppear(index: 4)
                 activityFileCard.staggeredAppear(index: 5)
                 wearableCard.staggeredAppear(index: 6)
+                #if OURA_CLOUD_IMPORT
                 ouraCloudCard.staggeredAppear(index: 7)
+                #endif
                 broadcastHrCard.staggeredAppear(index: 8)
                 liveCard.staggeredAppear(index: 9)
             }
@@ -288,23 +293,26 @@ struct DataSourcesView: View {
         }
     }
 
-    /// Oura (cloud): OAuth connect + one-time API backfill, as an alternative to the manual export file
-    /// above. `oura.connectAndImport(repo:)`/`disconnect(repo:)` take `repo` at call time (see the
-    /// `@StateObject` declaration's note) rather than storing it in `OuraConnectModel` at construction.
+    #if OURA_CLOUD_IMPORT
+    /// Oura history import: a one-time, user-initiated, foreground OAuth + API backfill of the user's
+    /// own history — an *import* in the same family as the export-file importers above, not a sync
+    /// (nothing runs in the background, on a timer, or at launch). `oura.connectAndImport(repo:)`/
+    /// `disconnect(repo:)` take `repo` at call time (see the `@StateObject` declaration's note)
+    /// rather than storing it in `OuraConnectModel` at construction.
     private var ouraCloudCard: some View {
-        card(title: String(localized: "Oura (cloud)"), icon: "circle.circle", tint: StrandPalette.metricPurple,
-             subtitle: String(localized: "Connect your Oura account and import your full history over the API.")) {
+        card(title: String(localized: "Oura history import"), icon: "circle.circle", tint: StrandPalette.metricPurple,
+             subtitle: String(localized: "A one-time import of your own Oura history over the Oura API. Runs only when you tap it.")) {
             VStack(alignment: .leading, spacing: 8) {
                 if oura.isConnected {
                     HStack {
-                        Button { oura.connectAndImport(repo: repo) } label: { Label("Sync again", systemImage: "arrow.clockwise") }
+                        Button { oura.connectAndImport(repo: repo) } label: { Label("Import again", systemImage: "arrow.clockwise") }
                             .buttonStyle(NoopButtonStyle(.primary))
-                        Button(role: .destructive) { oura.disconnect(repo: repo) } label: { Label("Disconnect", systemImage: "xmark.circle") }
+                        Button(role: .destructive) { oura.disconnect(repo: repo) } label: { Label("Forget Oura access", systemImage: "xmark.circle") }
                             .buttonStyle(NoopButtonStyle(.destructive))
                     }.disabled(oura.busy)
                 } else {
                     Button { oura.connectAndImport(repo: repo) } label: {
-                        Label(oura.busy ? "Working…" : "Connect Oura & Import Everything", systemImage: "link")
+                        Label(oura.busy ? "Working…" : "Import your Oura history", systemImage: "square.and.arrow.down")
                     }
                     .buttonStyle(NoopButtonStyle(.primary))
                     .disabled(oura.busy || !oura.isConfigured)
@@ -317,6 +325,7 @@ struct DataSourcesView: View {
             }
         }
     }
+    #endif // OURA_CLOUD_IMPORT
 
     private func presentImporter(_ target: ImportTarget) {
         importTarget = target

--- a/Strand/Screens/DevicesView.swift
+++ b/Strand/Screens/DevicesView.swift
@@ -64,6 +64,10 @@ private struct DevicesContent: View {
 
     private var activeDevices: [PairedDevice] { registry.devices.filter { $0.status != .archived } }
     private var removedDevices: [PairedDevice] { registry.devices.filter { $0.status == .archived } }
+    /// I-1: `activeDevices` minus import sources (cloud/file) — the candidates actually eligible for
+    /// "make active". An import source is a data partition, not a live device; offering it here would let
+    /// activating it demote the live WHOOP driving BLE routing + day-owner priority 0.
+    private var activatableDevices: [PairedDevice] { activeDevices.filter { !$0.isImportSource } }
 
     /// #987: the active+connected strap's clock state, from the SAME pure ConnectionReadout parsers the
     /// Test Centre Connection panel binds (one source of truth). nil (no row at all) until the WHOOP path
@@ -217,7 +221,9 @@ private struct DevicesContent: View {
         .confirmationDialog("Pick a new active strap",
                             isPresented: $pickNewActive,
                             titleVisibility: .visible) {
-            ForEach(activeDevices) { device in
+            // I-1: import sources (Oura cloud import, file imports) are excluded — they're data
+            // partitions, not live devices, and must never be offered as an active-strap candidate.
+            ForEach(activatableDevices) { device in
                 Button(device.displayName) { registry.setActive(device.id) }
             }
             Button("Leave none active", role: .cancel) { }
@@ -294,8 +300,9 @@ private struct DevicesContent: View {
         registry.archive(device.id)
         removeTarget = nil
         if wasActive {
-            // Other paired devices left → ask which becomes active; otherwise no active device remains.
-            if !activeDevices.isEmpty {
+            // Other ACTIVATABLE devices left → ask which becomes active; otherwise (none left, or only
+            // import sources remain) no active device remains and there's nothing to offer (I-1).
+            if !activatableDevices.isEmpty {
                 pickNewActive = true
             }
         }
@@ -468,16 +475,20 @@ private struct DeviceCard: View {
 
     /// The card's primary tap action, or nil when there isn't one. A paired-but-not-active band → make it
     /// active; a removed band → re-add it as active. The active band and any card without those callbacks
-    /// have no whole-card tap (their controls live entirely in the ⋮ menu).
+    /// have no whole-card tap (their controls live entirely in the ⋮ menu). I-1: an import source (Oura
+    /// cloud import, file imports) never offers activation — it's a data partition, not a live device;
+    /// making it "active" would demote whatever live device drives BLE routing + day-owner priority 0.
     private var primaryAction: (() -> Void)? {
+        if device.isImportSource { return nil }
         if device.status == .archived { return onReAdd }
         if !isActive { return onMakeActive }
         return nil
     }
 
     /// Short accent hint mirroring the primary tap, shown in the footer row. nil when the card has no
-    /// whole-card action (active band / menu-only removed band).
+    /// whole-card action (active band / menu-only removed band / I-1 import source).
     private var primaryActionHint: String? {
+        if device.isImportSource { return nil }
         if device.status == .archived { return onReAdd == nil ? nil : String(localized: "Make active") }
         if !isActive { return String(localized: "Make active") }
         return nil
@@ -529,7 +540,9 @@ private struct DeviceCard: View {
     private var actionsMenu: some View {
         Menu {
             if device.status == .archived {
-                if let onReAdd {
+                // I-1: a removed import source (e.g. Oura cloud import, archived on Disconnect) never
+                // offers "Make active" reactivation — it's a data partition, not a live device.
+                if let onReAdd, !device.isImportSource {
                     Button { onReAdd() } label: { Label("Make active", systemImage: "bolt.fill") }
                 }
                 Button { onRename() } label: { Label("Rename", systemImage: "pencil") }
@@ -540,7 +553,7 @@ private struct DeviceCard: View {
                     }
                 }
             } else {
-                if !isActive {
+                if !isActive && !device.isImportSource {
                     Button { onMakeActive() } label: { Label("Make active", systemImage: "bolt.fill") }
                 }
                 Button { onRename() } label: { Label("Rename", systemImage: "pencil") }

--- a/StrandTests/OuraAPIClientTests.swift
+++ b/StrandTests/OuraAPIClientTests.swift
@@ -1,0 +1,88 @@
+import XCTest
+import AuthenticationServices
+@testable import Strand
+
+/// A stub AuthProvider that hands out a fixed token and counts refreshes.
+private final class StubAuth: AuthProvider {
+    var token = "tok-1"
+    var validCalls = 0
+    var refreshCount = 0
+    var isConnected: Bool { true }
+    func validAccessToken() async throws -> String { validCalls += 1; return token }
+    func refreshedAccessToken() async throws -> String { refreshCount += 1; token = "tok-refreshed"; return token }
+    @MainActor func authorize(presentationAnchor: ASPresentationAnchor) async throws {}
+    func signOut() {}
+}
+
+final class OuraAPIClientTests: XCTestCase {
+    override func setUp() { super.setUp(); OuraURLProtocolStub.reset() }
+
+    func testParsePageExtractsDataAndNextToken() throws {
+        let json = #"{"data":[{"id":"a"},{"id":"b"}],"next_token":"tok2"}"#.data(using: .utf8)!
+        let page = try OuraAPI.parsePage(json)
+        XCTAssertEqual(page.data.count, 2)
+        XCTAssertEqual(page.nextToken, "tok2")
+    }
+
+    func testFetchAllFollowsNextTokenThenStops() async throws {
+        OuraURLProtocolStub.queue = [
+            .init(status: 200, body: #"{"data":[{"id":"a"}],"next_token":"t2"}"#.data(using: .utf8)!),
+            .init(status: 200, body: #"{"data":[{"id":"b"}],"next_token":null}"#.data(using: .utf8)!),
+        ]
+        let client = OuraAPIClient(auth: StubAuth(), environment: .production,
+                                   session: OuraURLProtocolStub.session())
+        let rows = try await client.fetchAll(endpoint: "daily_sleep", query: ["start_date": "2026-01-01"])
+        XCTAssertEqual(rows.count, 2)
+        // Second request carried next_token=t2.
+        XCTAssertTrue(OuraURLProtocolStub.requestedURLs.last?.absoluteString.contains("next_token=t2") ?? false)
+    }
+
+    func test429IsRetriedAfterBackoff() async throws {
+        OuraURLProtocolStub.queue = [
+            .init(status: 429, body: Data()),
+            .init(status: 200, body: #"{"data":[{"id":"a"}],"next_token":null}"#.data(using: .utf8)!),
+        ]
+        let client = OuraAPIClient(auth: StubAuth(), environment: .production,
+                                   session: OuraURLProtocolStub.session(), backoff: 0)
+        let rows = try await client.fetchAll(endpoint: "daily_sleep", query: [:])
+        XCTAssertEqual(rows.count, 1)
+    }
+
+    func testSandboxBaseURL() async throws {
+        OuraURLProtocolStub.queue = [.init(status: 200,
+            body: #"{"data":[],"next_token":null}"#.data(using: .utf8)!)]
+        let client = OuraAPIClient(auth: StubAuth(), environment: .sandbox,
+                                   session: OuraURLProtocolStub.session())
+        _ = try await client.fetchAll(endpoint: "personal_info", query: [:])
+        XCTAssertTrue(OuraURLProtocolStub.requestedURLs.first?.absoluteString.contains("/v2/sandbox/") ?? false)
+    }
+
+    func test401TriggersRefreshThenRetrySucceeds() async throws {
+        OuraURLProtocolStub.queue = [
+            .init(status: 401, body: Data()),
+            .init(status: 200, body: #"{"data":[{"id":"a"}],"next_token":null}"#.data(using: .utf8)!),
+        ]
+        let stub = StubAuth()
+        let client = OuraAPIClient(auth: stub, environment: .production,
+                                   session: OuraURLProtocolStub.session())
+        let rows = try await client.fetchAll(endpoint: "daily_sleep", query: [:])
+        XCTAssertEqual(rows.count, 1)
+        XCTAssertEqual(stub.refreshCount, 1)
+    }
+
+    func test429ExhaustionThrowsRateLimited() async throws {
+        OuraURLProtocolStub.queue = [
+            .init(status: 429, body: Data()),
+            .init(status: 429, body: Data()),
+            .init(status: 429, body: Data()),
+        ]
+        let client = OuraAPIClient(auth: StubAuth(), environment: .production,
+                                   session: OuraURLProtocolStub.session(), backoff: 0)
+        do {
+            _ = try await client.fetchAll(endpoint: "daily_sleep", query: [:])
+            XCTFail("expected rateLimited to be thrown")
+        } catch {
+            XCTAssertEqual(error as? OuraError, OuraError.rateLimited)
+        }
+    }
+}

--- a/StrandTests/OuraAPIClientTests.swift
+++ b/StrandTests/OuraAPIClientTests.swift
@@ -1,3 +1,6 @@
+// Tests the OURA_CLOUD_IMPORT-gated Oura import lane; compiled only when the flag is set
+// (StrandTests shares the app's OuraConfig.xcconfig, so flag + creds arrive together).
+#if OURA_CLOUD_IMPORT
 import XCTest
 import AuthenticationServices
 @testable import Strand
@@ -86,3 +89,4 @@ final class OuraAPIClientTests: XCTestCase {
         }
     }
 }
+#endif // OURA_CLOUD_IMPORT

--- a/StrandTests/OuraCredentialsTests.swift
+++ b/StrandTests/OuraCredentialsTests.swift
@@ -1,3 +1,6 @@
+// Tests the OURA_CLOUD_IMPORT-gated Oura import lane; compiled only when the flag is set
+// (StrandTests shares the app's OuraConfig.xcconfig, so flag + creds arrive together).
+#if OURA_CLOUD_IMPORT
 import XCTest
 @testable import Strand
 
@@ -19,3 +22,4 @@ final class OuraCredentialsTests: XCTestCase {
         ]))  // blank id
     }
 }
+#endif // OURA_CLOUD_IMPORT

--- a/StrandTests/OuraCredentialsTests.swift
+++ b/StrandTests/OuraCredentialsTests.swift
@@ -1,0 +1,21 @@
+import XCTest
+@testable import Strand
+
+final class OuraCredentialsTests: XCTestCase {
+    func testParsesCompleteInfoDict() {
+        let info: [String: Any] = [
+            "OURA_CLIENT_ID": "cid", "OURA_CLIENT_SECRET": "secret",
+            "OURA_REDIRECT_URI": "noop://oura/callback",
+        ]
+        let c = OuraCredentials.from(info)
+        XCTAssertEqual(c, OuraCredentials(clientId: "cid", clientSecret: "secret",
+                                          redirectURI: "noop://oura/callback"))
+    }
+
+    func testNilWhenAnyKeyMissingOrBlank() {
+        XCTAssertNil(OuraCredentials.from(["OURA_CLIENT_ID": "cid", "OURA_CLIENT_SECRET": "s"]))  // no redirect
+        XCTAssertNil(OuraCredentials.from([
+            "OURA_CLIENT_ID": "", "OURA_CLIENT_SECRET": "s", "OURA_REDIRECT_URI": "noop://x",
+        ]))  // blank id
+    }
+}

--- a/StrandTests/OuraOAuthTests.swift
+++ b/StrandTests/OuraOAuthTests.swift
@@ -1,0 +1,66 @@
+import XCTest
+@testable import Strand
+
+final class OuraOAuthTests: XCTestCase {
+    private let creds = OuraCredentials(clientId: "cid", clientSecret: "sec",
+                                        redirectURI: "noop://oura/callback")
+
+    func testAuthorizeURLHasRequiredParams() throws {
+        let url = OuraOAuth.authorizeURL(credentials: creds, state: "xyz")
+        let comps = try XCTUnwrap(URLComponents(url: url, resolvingAgainstBaseURL: false))
+        XCTAssertEqual(comps.host, "cloud.ouraring.com")
+        XCTAssertEqual(comps.path, "/oauth/authorize")
+        let q = Dictionary(uniqueKeysWithValues: (comps.queryItems ?? []).map { ($0.name, $0.value) })
+        XCTAssertEqual(q["response_type"], "code")
+        XCTAssertEqual(q["client_id"], "cid")
+        XCTAssertEqual(q["redirect_uri"], "noop://oura/callback")
+        XCTAssertEqual(q["state"], "xyz")
+        // `scope` is deliberately omitted: Oura grants ALL app-configured scopes when it's blank —
+        // covering the portal-only scopes (Stress, Heart Health, Ring Configuration) the docs don't name.
+        XCTAssertNil(q["scope"])
+    }
+
+    func testTokenExchangeRequestIsFormPost() throws {
+        let req = OuraOAuth.tokenExchangeRequest(credentials: creds, code: "the-code")
+        XCTAssertEqual(req.url?.absoluteString, "https://api.ouraring.com/oauth/token")
+        XCTAssertEqual(req.httpMethod, "POST")
+        XCTAssertEqual(req.value(forHTTPHeaderField: "Content-Type"), "application/x-www-form-urlencoded")
+        let body = String(data: req.httpBody ?? Data(), encoding: .utf8) ?? ""
+        XCTAssertTrue(body.contains("grant_type=authorization_code"))
+        XCTAssertTrue(body.contains("code=the-code"))
+        XCTAssertTrue(body.contains("client_id=cid"))
+        XCTAssertTrue(body.contains("client_secret=sec"))
+    }
+
+    func testParseTokenResponseComputesExpiry() throws {
+        let now = Date(timeIntervalSince1970: 1_000_000)
+        let json = #"{"access_token":"acc","refresh_token":"ref","expires_in":86400}"#.data(using: .utf8)!
+        let tokens = try OuraOAuth.parseTokenResponse(json, now: now)
+        XCTAssertEqual(tokens.accessToken, "acc")
+        XCTAssertEqual(tokens.refreshToken, "ref")
+        XCTAssertEqual(tokens.expiresAt, now.addingTimeInterval(86400))
+    }
+
+    func testParseTokenResponseDefaultsExpiryWhenExpiresInAbsent() throws {
+        let now = Date(timeIntervalSince1970: 1_000_000)
+        let json = #"{"access_token":"acc"}"#.data(using: .utf8)!
+        let tokens = try OuraOAuth.parseTokenResponse(json, now: now)
+        XCTAssertEqual(tokens.accessToken, "acc")
+        XCTAssertNil(tokens.refreshToken)
+        XCTAssertEqual(tokens.expiresAt, now.addingTimeInterval(2_592_000))
+    }
+
+    func testParseTokenResponseThrowsOnMissingAccessToken() {
+        let json = #"{"error":"invalid_grant"}"#.data(using: .utf8)!
+        XCTAssertThrowsError(try OuraOAuth.parseTokenResponse(json, now: Date()))
+    }
+
+    func testTokenExchangeRequestEscapesReservedCharsInSecret() {
+        let c = OuraCredentials(clientId: "cid", clientSecret: "aB+cd/eF12==", redirectURI: "noop://oura/callback")
+        let req = OuraOAuth.tokenExchangeRequest(credentials: c, code: "x+y")
+        let body = String(data: req.httpBody ?? Data(), encoding: .utf8) ?? ""
+        XCTAssertTrue(body.contains("client_secret=aB%2Bcd%2FeF12%3D%3D"))   // + -> %2B, / -> %2F, = -> %3D
+        XCTAssertTrue(body.contains("code=x%2By"))                            // + escaped, not left literal
+        XCTAssertFalse(body.contains("aB+cd"))                                // no raw '+'
+    }
+}

--- a/StrandTests/OuraOAuthTests.swift
+++ b/StrandTests/OuraOAuthTests.swift
@@ -1,3 +1,6 @@
+// Tests the OURA_CLOUD_IMPORT-gated Oura import lane; compiled only when the flag is set
+// (StrandTests shares the app's OuraConfig.xcconfig, so flag + creds arrive together).
+#if OURA_CLOUD_IMPORT
 import XCTest
 @testable import Strand
 
@@ -64,3 +67,4 @@ final class OuraOAuthTests: XCTestCase {
         XCTAssertFalse(body.contains("aB+cd"))                                // no raw '+'
     }
 }
+#endif // OURA_CLOUD_IMPORT

--- a/StrandTests/OuraSyncCoordinatorTests.swift
+++ b/StrandTests/OuraSyncCoordinatorTests.swift
@@ -1,0 +1,101 @@
+import XCTest
+import WhoopStore
+@testable import StrandImport
+@testable import Strand
+
+/// A fetcher that serves canned page bodies per endpoint (and can fail chosen endpoints, like a scope 401).
+private final class StubFetcher: OuraPageFetching {
+    var pages: [String: [Data]] = [:]
+    var capturedQueries: [String: [String: String]] = [:]
+    var callCounts: [String: Int] = [:]
+    var failEndpoints: Set<String> = []
+    var failAfterCall: [String: Int] = [:]   // endpoint → allow this many calls, then throw (mimics a mid-run suspend)
+    func fetchAllRaw(endpoint: String, query: [String: String]) async throws -> [Data] {
+        capturedQueries[endpoint] = query
+        callCounts[endpoint, default: 0] += 1
+        if failEndpoints.contains(endpoint) { throw OuraError.badResponse(401, "token is not authorized") }
+        if let limit = failAfterCall[endpoint], (callCounts[endpoint] ?? 0) > limit {
+            throw OuraError.badResponse(500, "simulated interruption")
+        }
+        return pages[endpoint] ?? []
+    }
+}
+
+final class OuraSyncCoordinatorTests: XCTestCase {
+    func testBackfillFetchesParsesAndWrites() async throws {
+        let store = try await WhoopStore.inMemory()
+        let fetcher = StubFetcher()
+        fetcher.pages["daily_readiness"] = [#"{"data":[{"day":"2026-01-02","score":80,"contributors":{"resting_heart_rate":50}}],"next_token":null}"#.data(using: .utf8)!]
+        fetcher.pages["daily_activity"] = [#"{"data":[{"day":"2026-01-02","steps":9000}],"next_token":null}"#.data(using: .utf8)!]
+        fetcher.pages["sleep"] = [#"{"data":[{"id":"s1","day":"2026-01-02","bedtime_start":"2026-01-01T23:00:00+00:00","bedtime_end":"2026-01-02T06:00:00+00:00","total_sleep_duration":24000,"lowest_heart_rate":48,"sleep_phase_5_min":"1234"}],"next_token":null}"#.data(using: .utf8)!]
+
+        var progress: [String] = []
+        let coord = OuraSyncCoordinator(fetcher: fetcher, store: store)
+        let summary = try await coord.runFullImport(today: "2026-02-01") { progress.append($0.endpoint) }
+
+        XCTAssertEqual(summary.days, 1)
+        XCTAssertEqual(summary.sleeps, 1)
+        XCTAssertTrue(summary.rawPages >= 3)
+        XCTAssertTrue(progress.contains("sleep"))
+
+        // Coalesce + RHR precedence: daily_readiness's true RHR (50) wins over sleep's lowestHr (48).
+        let days = try await store.dailyMetrics(deviceId: "oura-api", from: "2026-01-01", to: "2026-01-03")
+        XCTAssertEqual(days.first?.restingHr, 50)
+        XCTAssertEqual(days.first?.steps, 9000)
+        XCTAssertEqual(days.first?.totalSleepMin, 400)
+    }
+
+    func testEndpointDateParamsAreWiredCorrectly() async throws {
+        let store = try await WhoopStore.inMemory()
+        let fetcher = StubFetcher()
+        // A daily page sets the heartrate window floor (2026-01-02); today 2026-02-01 → exactly two
+        // 30-day windows. Heartrate has a hard ≤30-day range cap upstream, so windowing is load-bearing.
+        fetcher.pages["daily_readiness"] = [#"{"data":[{"day":"2026-01-02","score":80}],"next_token":null}"#.data(using: .utf8)!]
+        let coord = OuraSyncCoordinator(fetcher: fetcher, store: store)
+        _ = try await coord.runFullImport(today: "2026-02-01")
+
+        // Windowed, full ISO-'Z' datetimes (bare dates parse upstream but a +00:00 offset 422s), ≤30d each.
+        XCTAssertEqual(fetcher.callCounts["heartrate"], 2)
+        XCTAssertEqual(fetcher.capturedQueries["heartrate"]?["start_datetime"], "2026-02-01T00:00:00Z")
+        XCTAssertEqual(fetcher.capturedQueries["heartrate"]?["end_datetime"], "2026-02-02T00:00:00Z")
+        XCTAssertNil(fetcher.capturedQueries["heartrate"]?["start_date"])
+
+        XCTAssertEqual(fetcher.capturedQueries["personal_info"], [:])
+        XCTAssertEqual(fetcher.capturedQueries["ring_configuration"], [:])
+
+        XCTAssertNotNil(fetcher.capturedQueries["daily_readiness"]?["start_date"])
+        XCTAssertNotNil(fetcher.capturedQueries["daily_readiness"]?["end_date"])
+    }
+
+    func testHeartRateWindowPersistsBeforeAnInterruptionSoProgressSurvives() async throws {
+        let store = try await WhoopStore.inMemory()
+        let fetcher = StubFetcher()
+        // A daily day in early Jan floors the HR windows; today mid-March → several 30-day windows.
+        fetcher.pages["daily_readiness"] = [#"{"data":[{"day":"2026-01-02","score":80}],"next_token":null}"#.data(using: .utf8)!]
+        // Each heartrate window returns one sample, but the fetcher dies AFTER the first window —
+        // exactly the screen-lock/suspend failure that used to lose the entire series.
+        fetcher.pages["heartrate"] = [#"{"data":[{"bpm":58,"timestamp":"2026-01-05T12:00:00.000Z"}],"next_token":null}"#.data(using: .utf8)!]
+        fetcher.failAfterCall["heartrate"] = 1
+
+        let coord = OuraSyncCoordinator(fetcher: fetcher, store: store)
+        let summary = try await coord.runFullImport(today: "2026-03-15")
+
+        XCTAssertTrue(summary.skippedEndpoints.contains("heartrate"))   // interruption reported honestly
+        XCTAssertEqual(summary.days, 1)                                 // light data landed before HR began
+        XCTAssertGreaterThan(summary.hrSamples, 0)                      // window 1's HR was durably saved BEFORE the failure
+        // Ground truth in the store, not just the summary: the first window's sample is really persisted.
+        let hr = try await store.hrSamples(deviceId: "oura-api", from: 0, to: Int.max, limit: 1000)
+        XCTAssertFalse(hr.isEmpty)
+    }
+
+    func testFailingEndpointIsSkippedNotFatal() async throws {
+        let store = try await WhoopStore.inMemory()
+        let fetcher = StubFetcher()
+        fetcher.pages["daily_readiness"] = [#"{"data":[{"day":"2026-01-02","score":80,"contributors":{"resting_heart_rate":50}}],"next_token":null}"#.data(using: .utf8)!]
+        fetcher.failEndpoints = ["daily_spo2"]   // the live failure mode: scope 401 on one endpoint
+        let coord = OuraSyncCoordinator(fetcher: fetcher, store: store)
+        let summary = try await coord.runFullImport(today: "2026-02-01")
+        XCTAssertEqual(summary.days, 1)                              // the rest of the backfill still lands
+        XCTAssertEqual(summary.skippedEndpoints, ["daily_spo2"])     // and the skip is reported honestly
+    }
+}

--- a/StrandTests/OuraSyncCoordinatorTests.swift
+++ b/StrandTests/OuraSyncCoordinatorTests.swift
@@ -1,3 +1,6 @@
+// Tests the OURA_CLOUD_IMPORT-gated Oura import lane; compiled only when the flag is set
+// (StrandTests shares the app's OuraConfig.xcconfig, so flag + creds arrive together).
+#if OURA_CLOUD_IMPORT
 import XCTest
 import WhoopStore
 @testable import StrandImport
@@ -99,3 +102,4 @@ final class OuraSyncCoordinatorTests: XCTestCase {
         XCTAssertEqual(summary.skippedEndpoints, ["daily_spo2"])     // and the skip is reported honestly
     }
 }
+#endif // OURA_CLOUD_IMPORT

--- a/StrandTests/OuraSyncWriterTests.swift
+++ b/StrandTests/OuraSyncWriterTests.swift
@@ -1,3 +1,6 @@
+// Tests the OURA_CLOUD_IMPORT-gated Oura import lane; compiled only when the flag is set
+// (StrandTests shares the app's OuraConfig.xcconfig, so flag + creds arrive together).
+#if OURA_CLOUD_IMPORT
 import XCTest
 import WhoopStore
 import WhoopProtocol
@@ -64,3 +67,4 @@ final class OuraSyncWriterTests: XCTestCase {
         XCTAssertNil(days.first?.strain)
     }
 }
+#endif // OURA_CLOUD_IMPORT

--- a/StrandTests/OuraSyncWriterTests.swift
+++ b/StrandTests/OuraSyncWriterTests.swift
@@ -1,0 +1,66 @@
+import XCTest
+import WhoopStore
+import WhoopProtocol
+@testable import StrandImport
+@testable import Strand
+
+final class OuraSyncWriterTests: XCTestCase {
+    private func iso(_ s: String) -> Date { ISO8601DateFormatter().date(from: s)! }
+
+    func testPersistWritesAllStoresAndRegistersCloudSource() async throws {
+        let store = try await WhoopStore.inMemory()
+
+        var day = WearableDailyRow(day: "2026-01-02")
+        day.restingHr = 50; day.steps = 9000; day.totalSleepMin = 400
+
+        let session = WearableSleepSession(
+            start: iso("2026-01-01T23:00:00Z"), end: iso("2026-01-02T06:00:00Z"),
+            deepMin: 100, lightMin: 200, remMin: 100, awakeMin: 20, totalSleepMin: 400,
+            efficiencyPct: 92, avgHr: 55, lowestHr: 48, avgHrvMs: 65, respRateBpm: 14,
+            sleepScore: nil, stages: [WearableSleepStageInterval(stage: "deep",
+                start: iso("2026-01-01T23:00:00Z"), end: iso("2026-01-01T23:05:00Z"))])
+        let period = OuraSleepPeriod(session: session, movement30s: [1, 2, 1],
+                                     hr: [OuraHRPoint(ts: Int(iso("2026-01-01T23:00:00Z").timeIntervalSince1970), bpm: 60)])
+
+        let result = OuraSyncResult(
+            days: [day], sleepPeriods: [period],
+            extras: [OuraDailyExtra(day: "2026-01-02", key: "ref_readiness_score", value: 80),
+                     OuraDailyExtra(day: "2026-01-02", key: "vo2max", value: 44)],
+            workouts: [OuraWorkout(start: iso("2026-01-02T07:00:00Z"), end: iso("2026-01-02T07:40:00Z"),
+                                   activity: "running", source: "autodetected", energyKcal: 410, distanceM: 6200)],
+            heartRate: [OuraHRPoint(ts: Int(iso("2026-01-02T07:00:00Z").timeIntervalSince1970), bpm: 120)],
+            rawPages: [OuraRawRow(endpoint: "sleep", documentId: "s1", day: "2026-01-02",
+                                  payloadJSON: "{}", fetchedAt: 100)],
+            ringModel: "Oura Ring Gen3")
+
+        let summary = try await OuraSyncWriter.persist(result, into: store)
+
+        XCTAssertEqual(summary.days, 1)
+        XCTAssertEqual(summary.sleeps, 1)
+        XCTAssertEqual(summary.workouts, 1)
+        XCTAssertEqual(summary.hrSamples, 2)           // in-sleep 60bpm + whole-day 120bpm, distinct ts
+        XCTAssertGreaterThan(summary.metricPoints, 0)
+        XCTAssertEqual(summary.rawPages, 1)
+
+        // Cloud source registered as .cloudImport, .paired (never .active — single-active invariant;
+        // an import source must never seize the live-device slot alongside a paired WHOOP).
+        let devices = try DeviceRegistryStore(dbQueue: store.registryWriter).all()
+        let oura = devices.first { $0.id == "oura-api" }
+        XCTAssertEqual(oura?.sourceKind, .cloudImport)
+        XCTAssertEqual(oura?.model, "Oura Ring Gen3")
+        XCTAssertEqual(oura?.status, .paired)
+
+        // Honest data: the reference score is a metricSeries key, never a DailyMetric score column.
+        let refs = try await store.metricSeries(deviceId: "oura-api", key: "ref_readiness_score",
+                                                 from: "2026-01-01", to: "2026-01-03")
+        XCTAssertEqual(refs.first?.value, 80)
+        let vo2 = try await store.metricSeries(deviceId: "oura-api", key: "vo2max",
+                                               from: "2026-01-01", to: "2026-01-03")
+        XCTAssertEqual(vo2.first?.value, 44)          // vo2max parity via extras
+
+        // Honest data, read back through the day accessor: recovery/strain stay nil (never Oura's readiness).
+        let days = try await store.dailyMetrics(deviceId: "oura-api", from: "2026-01-01", to: "2026-01-03")
+        XCTAssertNil(days.first?.recovery)
+        XCTAssertNil(days.first?.strain)
+    }
+}

--- a/StrandTests/OuraTokenStoreTests.swift
+++ b/StrandTests/OuraTokenStoreTests.swift
@@ -1,0 +1,33 @@
+import XCTest
+@testable import Strand
+
+final class OuraTokenStoreTests: XCTestCase {
+    override func setUp() { super.setUp(); OuraTokenStore.clear() }
+    override func tearDown() { OuraTokenStore.clear(); super.tearDown() }
+
+    func testSaveLoadClearRoundTrip() {
+        XCTAssertFalse(OuraTokenStore.isConnected)
+        XCTAssertNil(OuraTokenStore.load())
+
+        let exp = Date(timeIntervalSince1970: 2_000_000_000)
+        let t = OuraTokens(accessToken: "acc", refreshToken: "ref", expiresAt: exp)
+        XCTAssertTrue(OuraTokenStore.save(t))
+        XCTAssertTrue(OuraTokenStore.isConnected)
+
+        let loaded = OuraTokenStore.load()
+        XCTAssertEqual(loaded, t)
+
+        OuraTokenStore.clear()
+        XCTAssertNil(OuraTokenStore.load())
+        XCTAssertFalse(OuraTokenStore.isConnected)
+    }
+
+    func testExpiryUsesSkew() {
+        let almostNow = OuraTokens(accessToken: "a", refreshToken: nil,
+                                   expiresAt: Date(timeIntervalSinceNow: 30))   // <60 s away
+        XCTAssertTrue(almostNow.isExpired)
+        let later = OuraTokens(accessToken: "a", refreshToken: nil,
+                               expiresAt: Date(timeIntervalSinceNow: 600))
+        XCTAssertFalse(later.isExpired)
+    }
+}

--- a/StrandTests/OuraTokenStoreTests.swift
+++ b/StrandTests/OuraTokenStoreTests.swift
@@ -1,3 +1,6 @@
+// Tests the OURA_CLOUD_IMPORT-gated Oura import lane; compiled only when the flag is set
+// (StrandTests shares the app's OuraConfig.xcconfig, so flag + creds arrive together).
+#if OURA_CLOUD_IMPORT
 import XCTest
 @testable import Strand
 
@@ -31,3 +34,4 @@ final class OuraTokenStoreTests: XCTestCase {
         XCTAssertFalse(later.isExpired)
     }
 }
+#endif // OURA_CLOUD_IMPORT

--- a/StrandTests/OuraURLProtocolStub.swift
+++ b/StrandTests/OuraURLProtocolStub.swift
@@ -1,0 +1,32 @@
+import Foundation
+
+/// Test-only URLProtocol that serves canned responses by request order, so the paging loop and
+/// status-code handling are driven deterministically without a live socket.
+final class OuraURLProtocolStub: URLProtocol {
+    struct Stubbed { let status: Int; let body: Data }
+    /// FIFO queue of responses; each request pops the next. Set before the test acts.
+    nonisolated(unsafe) static var queue: [Stubbed] = []
+    /// Captured request URLs, in order, for assertions.
+    nonisolated(unsafe) static var requestedURLs: [URL] = []
+
+    static func reset() { queue = []; requestedURLs = [] }
+
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+    override func startLoading() {
+        if let u = request.url { Self.requestedURLs.append(u) }
+        let s = Self.queue.isEmpty ? Stubbed(status: 500, body: Data()) : Self.queue.removeFirst()
+        let resp = HTTPURLResponse(url: request.url!, statusCode: s.status, httpVersion: nil, headerFields: nil)!
+        client?.urlProtocol(self, didReceive: resp, cacheStoragePolicy: .notAllowed)
+        client?.urlProtocol(self, didLoad: s.body)
+        client?.urlProtocolDidFinishLoading(self)
+    }
+    override func stopLoading() {}
+
+    /// A URLSession wired to this stub.
+    static func session() -> URLSession {
+        let cfg = URLSessionConfiguration.ephemeral
+        cfg.protocolClasses = [OuraURLProtocolStub.self]
+        return URLSession(configuration: cfg)
+    }
+}

--- a/StrandiOS/Resources/Info.plist
+++ b/StrandiOS/Resources/Info.plist
@@ -37,6 +37,15 @@
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
 	<string>$(MARKETING_VERSION)</string>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>noop</string>
+			</array>
+		</dict>
+	</array>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>LSApplicationCategoryType</key>
@@ -58,6 +67,12 @@
 	<string>NOOP records your route during an outdoor workout to show distance, pace, and a map, and keeps recording while the screen is off. The route stays on your device. Nothing leaves it.</string>
 	<key>NSSupportsLiveActivities</key>
 	<true/>
+	<key>OURA_CLIENT_ID</key>
+	<string>$(OURA_CLIENT_ID)</string>
+	<key>OURA_CLIENT_SECRET</key>
+	<string>$(OURA_CLIENT_SECRET)</string>
+	<key>OURA_REDIRECT_URI</key>
+	<string>$(OURA_REDIRECT_URI)</string>
 	<key>UIBackgroundModes</key>
 	<array>
 		<string>bluetooth-central</string>

--- a/docs/DATA_MODEL.md
+++ b/docs/DATA_MODEL.md
@@ -60,14 +60,20 @@ single `DatabaseQueue` and applies these PRAGMAs before any query runs:
 | `busyMode` | `.timeout(5)` | 5-second busy timeout under write contention. |
 
 `WhoopStore` is an `actor`: all GRDB calls run on the actor's serial executor (off the main
-thread) through the `syncRead` / `syncWrite` helpers. The reported schema version is
-`WhoopStoreInfo.schemaVersion = 9`.
+thread) through the `syncRead` / `syncWrite` helpers. `WhoopStoreInfo.schemaVersion` is a
+separate, manually-maintained constant (currently `18`) that has lagged the real migration
+history for a while and should not be read as the schema's true version. The migrator itself
+(`makeMigrator()`, below) is the source of truth for what tables/columns exist, and has run
+through **v25** (`v25-oura-raw` — the Oura raw-payload archive, the newest addition; see
+below).
 
 ---
 
 ## Schema at a glance
 
-The schema falls into four groups:
+The schema falls into five groups (this section predates, and undercounts, everything added
+after v9 — see the schema-version note above; the Oura raw archive below is the one
+post-v9 addition currently documented here):
 
 | Group | Tables | Origin |
 | --- | --- | --- |
@@ -76,6 +82,7 @@ The schema falls into four groups:
 | **Raw outbox** (transient) | `rawBatch` | Compressed raw BLE frames, prunable |
 | **Bookkeeping** | `cursors` | Highwater / read cursors |
 | **Metric caches** | `sleepSession`, `dailyMetric`, `journal`, `workout`, `appleDaily`, `metricSeries` | Derived metrics + CSV / Apple-Health imports |
+| **Oura raw archive** (durable, v25) | `ouraRaw` | Verbatim Oura API payloads behind the opt-in cloud import — see below |
 
 All timestamp columns named `ts`, `startTs`, `endTs`, `capturedAt`, etc. are **unix seconds**
 (integers). Day-keyed cache tables use a `day` text column in `YYYY-MM-DD` form and compare it
@@ -441,12 +448,56 @@ those reads index-only. Accessors: `upsertMetricSeries(...)`, `metricSeries(...)
 
 ---
 
+## Oura raw-payload archive
+
+This section documents the one table added after this document's v9 baseline (see the
+schema-version note above): the lossless backstop behind the opt-in Oura cloud import
+(off by default; user-initiated OAuth backfill — `docs/PRIVACY_SECURITY.md` §1.1b). It is
+**not** a metric cache like the tables above — it stores verbatim API responses, not decoded
+values, so any field Oura returns can be re-derived later without re-fetching.
+
+### `ouraRaw` *(v25)*
+
+One row per fetched PAGE of an Oura API endpoint response — not one row per Oura document; a
+single page's `data` array can carry many documents (`OuraRawStore.swift`, `struct OuraRawRow`).
+Written by `OuraSyncCoordinator.fetchRaw(_:dateParam:)` in the app target (`Strand/Oura/`).
+Natural key `(deviceId, endpoint, documentId)`. Migration `v25-oura-raw`
+(`Packages/WhoopStore/Sources/WhoopStore/Database.swift`) — additive only, a new table, no
+existing row touched.
+
+| Column | Type | Notes |
+| --- | --- | --- |
+| `deviceId` | TEXT NOT NULL | Part of PK. `"oura-api"` for the live cloud-import lane. |
+| `endpoint` | TEXT NOT NULL | Part of PK. Oura endpoint name, e.g. `"sleep"`, `"daily_readiness"`, `"heartrate"`. |
+| `documentId` | TEXT NOT NULL | Part of PK. A SYNTHESIZED page key, `"<endpoint>-<startDate>-<pageIndex>"` (`startDate` is the backfill window's start date, `pageIndex` the fetched page's 0-based position) — never Oura's own document `id`, for any endpoint. |
+| `day` | TEXT | `YYYY-MM-DD`, nullable. Currently always NULL — the coordinator never sets it. Reserved for a future per-document (rather than per-page) keying scheme. |
+| `payloadJSON` | TEXT NOT NULL | Verbatim JSON body of the fetched page (the raw HTTP response, including its `data` array of documents) — losslessness holds at the page level, not the individual-document level. |
+| `fetchedAt` | INTEGER NOT NULL | Unix seconds. |
+
+**Primary key:** `(deviceId, endpoint, documentId)`. `upsertOuraRaw(...)` is idempotent on this
+key via `ON CONFLICT(...) DO UPDATE` — re-pulling the SAME window (same `startDate`, so the same
+`pageIndex` synthesizes the same `documentId`) overwrites that page's `day`/`payloadJSON`/
+`fetchedAt` in place rather than duplicating.
+
+**Index** — `idx_ouraRaw_device_endpoint_day` on `(deviceId, endpoint, day)`, so per-endpoint
+reads (`ouraRaw(deviceId:endpoint:)`) scan `(deviceId, endpoint)` and walk `day` in order
+without a table scan.
+
+**Not covered by `deleteAllData(deviceId:)`.** Unlike the metric-cache tables above, `ouraRaw`
+is not in `DeviceRegistryStore.deviceScopedTables`, so the general per-device wipe skips it by
+construction. Disconnecting Oura calls the dedicated `deleteOuraRaw(deviceId:)` alongside
+`deleteAllData(deviceId:)` (`Strand/Oura/OuraConnectModel.swift`) so the raw archive is purged
+too, not left behind.
+
+---
+
 ## Index summary
 
 | Index | Table | Columns | Purpose |
 | --- | --- | --- | --- |
 | *(implicit PK)* | every table above | (its natural key) | Dedupe + primary lookup. |
 | `idx_metricSeries_device_key_day` | `metricSeries` | `deviceId, key, day` | Index-only per-metric range reads. |
+| `idx_ouraRaw_device_endpoint_day` | `ouraRaw` | `deviceId, endpoint, day` | Index-only per-endpoint range reads. |
 
 Every other table relies on its primary-key index; the decoded-stream and date-range reads are all
 served by the `(deviceId, ts)` / `(deviceId, day)` / `(deviceId, startTs)` primary keys.

--- a/docs/DATA_MODEL.md
+++ b/docs/DATA_MODEL.md
@@ -451,7 +451,7 @@ those reads index-only. Accessors: `upsertMetricSeries(...)`, `metricSeries(...)
 ## Oura raw-payload archive
 
 This section documents the one table added after this document's v9 baseline (see the
-schema-version note above): the lossless backstop behind the opt-in Oura cloud import
+schema-version note above): the lossless backstop behind the opt-in Oura history import
 (off by default; user-initiated OAuth backfill — `docs/PRIVACY_SECURITY.md` §1.1b). It is
 **not** a metric cache like the tables above — it stores verbatim API responses, not decoded
 values, so any field Oura returns can be re-derived later without re-fetching.

--- a/docs/DEVICE_SUPPORT_ROADMAP.md
+++ b/docs/DEVICE_SUPPORT_ROADMAP.md
@@ -14,7 +14,7 @@ source stands and the protocol facts we've verified, so the next build can pick 
 | **Polar deep streams** (ECG / PPG / ACC / PPI) | 🔬 Protocol verified, decoder not built | PMD service (below) — alpha, hardware-gated |
 | **Garmin** (sleep / HRV / Body Battery / SpO₂ / FIT) | 📋 Researched, not built | Local BLE re-derive (Gadgetbridge-informed, **never** GPLv3 copy) |
 | **Amazfit / Zepp** (incl. Helio deep) | 📋 Researched, not built | Encrypted Huami BLE — needs a one-time **user-pasted** vendor key (NOOP never logs into the vendor cloud) |
-| **Oura** | 📋 Researched, not built | Cloud API v2 — off-by-default OAuth **import** lane only |
+| **Oura** | 🔬 Built (cloud import) | Cloud API v2 — off-by-default OAuth, one-time backfill; local BLE ring also supported |
 | **Fitbit / Google** | 📋 Researched, not built | Build against **Google Health** API (Fitbit Web API sunsets Sept 2026) — off-by-default import |
 
 ## Polar Measurement Data (PMD) — verified protocol

--- a/docs/PRIVACY_SECURITY.md
+++ b/docs/PRIVACY_SECURITY.md
@@ -26,12 +26,13 @@ local SQLite — has no network layer at all: no phone-home, no analytics, no ac
 no login, no cloud sync, and no telemetry. Everything NOOP computes about you lives in a
 single SQLite file on your own device.
 
-There are exactly **two** opt-in exceptions: the **AI Coach** (§1.1a) and the **Oura cloud
+There are exactly **two** opt-in exceptions: the **AI Coach** (§1.1a) and the **Oura history
 import** (§1.1b). The AI Coach is off until you turn it on with your own API key; when you
 ask it a question it sends a short text summary of your recent metrics to the provider you
-choose. The Oura cloud import is off until you connect your own Oura account; instead of
-sending data out, it pulls your own Oura data **in** over OAuth, using your own Oura
-developer app, and never sends any of your existing NOOP data out. Nothing else in the app
+choose. The Oura history import is **not even compiled into a default build** — the code
+only exists in your binary if you build from source with your own Oura developer app's
+credentials (§1.1b); instead of sending data out, it pulls your own Oura data **in** over
+OAuth, once, and never sends any of your existing NOOP data out. Nothing else in the app
 ever touches the network, and your raw biometric streams never leave the device through
 either exception.
 
@@ -42,10 +43,11 @@ deliberately export it to another store on the **same device**:
 |------|-----------|-----------|
 | Live collection | Bluetooth LE, strap → device | Read-only from the strap |
 | File import (Apple Health, WHOOP CSV, nutrition CSV) | User-selected files on disk | Read-only from disk |
-| Oura cloud import (opt-in, §1.1b) | HTTPS OAuth + REST, `api.ouraring.com` → device | Read-only from your own Oura account |
+| Oura history import (opt-in build flag, §1.1b) | HTTPS OAuth + REST, `api.ouraring.com` → device | Read-only from your own Oura account |
 | Apple Health export, incl. iOS "Export for Shortcuts" | On-device, user-initiated | NOOP → your Apple Health, on your device only (§1.3) |
 
-The only **network** paths are the opt-in AI Coach and the opt-in Oura cloud import; the
+The only **network** paths are the opt-in AI Coach and the compile-time-optional Oura
+history import; the
 biometric pipeline produces no network traffic of any kind. The Apple Health export above is
 an **on-device** hand-off, not a network upload — see §1.3.
 
@@ -54,7 +56,7 @@ an **on-device** hand-off, not a network upload — see §1.3.
 The biometric pipeline and all five Swift packages
 (`WhoopProtocol`, `WhoopStore`, `StrandAnalytics`, `StrandImport`, `StrandDesign`)
 contain **no** use of `URLSession`, `URLRequest`, `NWConnection`, `dataTask`, or any
-other networking API — still true after the Oura cloud import (§1.1b) landed: its OAuth
+other networking API — still true after the Oura history import (§1.1b) landed: its OAuth
 and REST calls live entirely in the app target, `Strand/Oura/`, and `StrandImport`
 gained only pure, network-free parsers for Oura's payload shapes. These Swift packages
 are **shared by the macOS and iOS apps** (iOS is build-from-source only — no App Store /
@@ -64,7 +66,7 @@ Room for storage and Kotlin for the BLE / import / Coach paths; its own Oura sup
 the local BLE ring-pairing lane, not a network API, so it has no equivalent to §1.1b. The
 **only** networking anywhere in the app is the AI Coach (`Strand/AI/AICoach.swift` on the
 Swift side — macOS and iOS — `com.noop.ai.AiCoach` on Android), described in §1.1a, and
-the Oura cloud import (`Strand/Oura/`, Swift-only — macOS and iOS), described in §1.1b.
+the Oura history import (`Strand/Oura/`, Swift-only — macOS and iOS), described in §1.1b.
 The package manifests reference dependency *download* URLs that Swift Package Manager
 resolves at build time, never at runtime:
 
@@ -79,7 +81,7 @@ importers. Neither opens a socket.
 ### 1.1a The AI Coach (optional, off by default, bring your own key)
 
 The AI Coach lets you ask questions about your data in plain language. It is one of the
-two features that use the network (the other is the Oura cloud import, §1.1b), and only
+two features that use the network (the other is the Oura history import, §1.1b), and only
 on your terms:
 
 - **Off until you enable it.** You enter your own API key for the provider you choose
@@ -97,20 +99,26 @@ on your terms:
   provider you picked, under your own account. NOOP runs no server in between and keeps
   no copy.
 
-If you never enable the AI Coach and never connect Oura (§1.1b), NOOP makes zero network
-connections.
+If you never enable the AI Coach and never build the Oura import in (§1.1b), NOOP makes
+zero network connections — and in a default build, the Oura code isn't in the binary to
+begin with.
 
-### 1.1b The Oura cloud import (optional, off by default, bring your own OAuth app)
+### 1.1b The Oura history import (compiled out by default, bring your own OAuth app)
 
-The Oura cloud import pulls your own historical Oura data into NOOP over Oura's official
-API — a one-time backfill you trigger yourself, not an ongoing background sync:
+The Oura history import pulls your own historical Oura data into NOOP over Oura's official
+API — a one-time, foreground backfill you trigger yourself, not an ongoing background sync
+(nothing runs on a timer, at launch, or in the background):
 
-- **Off until you connect it.** Nothing happens until you register your own free Oura
-  developer app and drop its client ID/secret into an untracked
-  `Strand/Oura/OuraSecrets.xcconfig` (absent/blank credentials cleanly disable the lane —
-  `OuraCredentials.fromBundle` — and the Data Sources card says so instead of connecting),
-  then tap **"Connect Oura & Import Everything"** in Data Sources. No credentials
-  configured, no network calls, ever.
+- **Not in the binary unless you build it in.** Every file of the lane's network code
+  (`Strand/Oura/*.swift` and its Data Sources card) sits behind the `OURA_CLOUD_IMPORT`
+  compilation condition, which is **unset in every default build** — the release binaries
+  and any plain `xcodegen && xcodebuild` from a clean checkout contain **zero Oura network
+  code**, provably, at the byte level. The condition is set only by the untracked
+  `Strand/Oura/OuraSecrets.xcconfig` you create yourself from the example template, which
+  also carries your own Oura developer app's client ID/secret — so the code and the
+  credentials arrive in the same deliberate act. Then the import runs only when you tap
+  **"Import your Oura history"** in Data Sources. (Belt-and-braces, the runtime guard
+  remains too: absent/blank credentials disable the lane — `OuraCredentials.fromBundle`.)
 - **What is sent.** An OAuth authorization-code handshake — you sign into Oura's own
   consent page (`cloud.ouraring.com`) through Apple's system `ASWebAuthenticationSession`,
   not an in-app WebView NOOP controls — followed by bearer-token `GET` requests to
@@ -126,15 +134,15 @@ API — a one-time backfill you trigger yourself, not an ongoing background sync
   imports, no computed scores — ever leaves the device via this lane. It is inbound-only.
 - **Your app, your grant, revocable at Oura.** You register your own OAuth app at Oura's
   developer portal; NOOP runs no server in between. Revoke access any time from your Oura
-  account settings, or tap **Disconnect** in NOOP, which signs out locally and deletes the
-  stored tokens plus every row this lane wrote — including the raw archive (`ouraRaw`
-  table, see `docs/DATA_MODEL.md`).
+  account settings, or tap **Forget Oura access** in NOOP, which signs out locally and
+  deletes the stored tokens plus every row this lane wrote — including the raw archive
+  (`ouraRaw` table, see `docs/DATA_MODEL.md`).
 - **Tokens in the Keychain, not a plist.** The access/refresh tokens are stored via
   `OuraTokenStore` as a single Keychain item (`kSecAttrAccessibleAfterFirstUnlock`), the
   same pattern as the AI Coach's API key (`AIKeyStore`) — never UserDefaults, never on
   disk in the clear.
 
-If you never connect Oura, NOOP makes zero calls to `ouraring.com`.
+If you never build the lane in, your binary cannot call `ouraring.com` — the code is not there.
 
 ### 1.2 The macOS sandbox (and what it means for the AI Coach and the Oura import)
 
@@ -160,7 +168,7 @@ That is the entire entitlement file. Four keys:
   explicitly picks (and write the database in its own container).
 - **`network.client`** — outbound socket access. Added for the AI Coach on a
   signed/sandboxed build, where the sandbox otherwise refuses any socket the app tries
-  to open (#128); the Oura cloud import (§1.1b) now relies on the same entitlement. The
+  to open (#128); the Oura history import (§1.1b) now relies on the same entitlement. The
   ad-hoc distributed build applies **no** entitlements at all (unsigned build + ad-hoc
   re-sign), so this key only matters for a signed/sandboxed build. The entitlement only
   permits the socket the sandbox would otherwise refuse — it doesn't make either feature
@@ -490,13 +498,13 @@ dedicated source id `nutrition-csv`, alongside your other metrics and entirely o
 ## 4. What NOOP does *not* collect or transmit
 
 - **No NOOP account, no NOOP login.** Nothing to sign into with NOOP itself; NOOP
-  issues no credentials of its own. The one exception is opt-in: the Oura cloud import
+  issues no credentials of its own. The one exception is opt-in: the Oura history import
   (§1.1b) has *you* sign into *your own* Oura account, at Oura's own login page, over
   OAuth — NOOP never sees your Oura password, only the resulting tokens, kept in the
   Keychain.
 - **No telemetry / analytics / crash reporting.** No third-party SDKs of that kind.
 - **No cloud, no sync, no remote backup of NOOP's own data.** Your NOOP data never
-  leaves the machine via NOOP. The Oura cloud import (§1.1b) is the one path that
+  leaves the machine via NOOP. The Oura history import (§1.1b) is the one path that
   reaches a cloud service, and it is **inbound only** — it pulls your own Oura data in;
   it does not sync or back up any NOOP data out.
 - **No advertising identifiers, no tracking.**
@@ -510,8 +518,8 @@ dedicated source id `nutrition-csv`, alongside your other metrics and entirely o
 
 | Surface | Risk | Mitigation | Where |
 |---------|------|------------|-------|
-| Process | Data exfiltration / network egress | Only two opt-in features network: the AI Coach (your key, to your chosen provider, a text summary — §1.1a) and the Oura cloud import (your own OAuth app, to `api.ouraring.com`, inbound-only — §1.1b). Nothing else makes a network call, and nothing is sent until you ask. Both work on Android/iOS where shipped (Android's Oura support is local-BLE only, no cloud lane); on macOS both cross the sandbox on the same `network.client` entitlement, present since #128 (§1.2) | `Strand/AI/AICoach.swift`, `Strand/Oura/`, `android/.../ai/AiCoach.kt` |
-| Oura cloud import | OAuth token / scope leakage, cross-account data mixing | Off by default; tokens Keychain-only (`kSecAttrAccessibleAfterFirstUnlock`, never UserDefaults/plist); fixed OAuth scopes set at build time; raw + normalized rows partitioned under `deviceId = "oura-api"`; Oura's own scores kept reference-only (`ref_*`/`oura_*` metricSeries keys, never NOOP's Charge/Effort/Rest); `.cloudImport` is structurally priority-2 so it never seizes a WHOOP day; Disconnect purges tokens + every `oura-api` row incl. the raw archive | `Strand/Oura/OuraTokenStore.swift`, `Strand/Oura/OuraConnectModel.swift`, `Packages/WhoopStore/Sources/WhoopStore/OuraRawStore.swift` |
+| Process | Data exfiltration / network egress | Only two opt-in features network: the AI Coach (your key, to your chosen provider, a text summary — §1.1a) and the Oura history import (your own OAuth app, to `api.ouraring.com`, inbound-only — §1.1b). Nothing else makes a network call, and nothing is sent until you ask. Both work on Android/iOS where shipped (Android's Oura support is local-BLE only, no cloud lane); on macOS both cross the sandbox on the same `network.client` entitlement, present since #128 (§1.2) | `Strand/AI/AICoach.swift`, `Strand/Oura/`, `android/.../ai/AiCoach.kt` |
+| Oura history import | OAuth token / scope leakage, cross-account data mixing | Compiled out by default (`OURA_CLOUD_IMPORT`, §1.1b); tokens Keychain-only (`kSecAttrAccessibleAfterFirstUnlock`, never UserDefaults/plist); fixed OAuth scopes set at build time; raw + normalized rows partitioned under `deviceId = "oura-api"`; Oura's own scores kept reference-only (`ref_*`/`oura_*` metricSeries keys, never NOOP's Charge/Effort/Rest); `.cloudImport` is structurally priority-2 so it never seizes a WHOOP day; Forget Oura access purges tokens + every `oura-api` row incl. the raw archive | `Strand/Oura/OuraTokenStore.swift`, `Strand/Oura/OuraConnectModel.swift`, `Packages/WhoopStore/Sources/WhoopStore/OuraRawStore.swift` |
 | Filesystem | Broad disk access | Only `files.user-selected.read-write`; data stays in the sandbox container | `Strand.entitlements`, `Strand/Collect/StorePaths.swift` |
 | BLE frames | Malformed / adversarial packets | CRC8 + CRC32 (+ CRC16 for v5) gating; reject on failure | `WhoopProtocol/Framing.swift`, `Strand/BLE/FrameRouter.swift` |
 | BLE frames | Out-of-bounds reads from short/lying length | `nil`-returning bounds-checked readers; slice clamping; min-length guards | `WhoopProtocol/Interpreter.swift` |

--- a/docs/PRIVACY_SECURITY.md
+++ b/docs/PRIVACY_SECURITY.md
@@ -26,37 +26,47 @@ local SQLite — has no network layer at all: no phone-home, no analytics, no ac
 no login, no cloud sync, and no telemetry. Everything NOOP computes about you lives in a
 single SQLite file on your own device.
 
-There is exactly **one** opt-in exception: the **AI Coach** (§1.1a). It is off until you
-turn it on with your own API key; when you ask it a question it sends a short text
-summary of your recent metrics to the provider you choose. Nothing else in the app ever
-touches the network, and your raw data never does.
+There are exactly **two** opt-in exceptions: the **AI Coach** (§1.1a) and the **Oura cloud
+import** (§1.1b). The AI Coach is off until you turn it on with your own API key; when you
+ask it a question it sends a short text summary of your recent metrics to the provider you
+choose. The Oura cloud import is off until you connect your own Oura account; instead of
+sending data out, it pulls your own Oura data **in** over OAuth, using your own Oura
+developer app, and never sends any of your existing NOOP data out. Nothing else in the app
+ever touches the network, and your raw biometric streams never leave the device through
+either exception.
 
-Data enters NOOP two ways, and leaves it (other than the optional AI Coach) only when **you**
+Data enters NOOP three ways, and leaves it (other than the optional AI Coach) only when **you**
 deliberately export it to another store on the **same device**:
 
 | Path | Transport | Direction |
 |------|-----------|-----------|
 | Live collection | Bluetooth LE, strap → device | Read-only from the strap |
 | File import (Apple Health, WHOOP CSV, nutrition CSV) | User-selected files on disk | Read-only from disk |
+| Oura cloud import (opt-in, §1.1b) | HTTPS OAuth + REST, `api.ouraring.com` → device | Read-only from your own Oura account |
 | Apple Health export, incl. iOS "Export for Shortcuts" | On-device, user-initiated | NOOP → your Apple Health, on your device only (§1.3) |
 
-The only **network** path is the opt-in AI Coach; the biometric pipeline produces no network
-traffic of any kind. The Apple Health export above is an **on-device** hand-off, not a network
-upload — see §1.3.
+The only **network** paths are the opt-in AI Coach and the opt-in Oura cloud import; the
+biometric pipeline produces no network traffic of any kind. The Apple Health export above is
+an **on-device** hand-off, not a network upload — see §1.3.
 
-### 1.1 Network code: only the optional AI Coach
+### 1.1 Network code: only the two optional exceptions
 
 The biometric pipeline and all five Swift packages
 (`WhoopProtocol`, `WhoopStore`, `StrandAnalytics`, `StrandImport`, `StrandDesign`)
 contain **no** use of `URLSession`, `URLRequest`, `NWConnection`, `dataTask`, or any
-other networking API. These Swift packages are **shared by the macOS and iOS apps**
-(iOS is build-from-source only — no App Store / TestFlight — and was folded into the
-main tree in v1.94), so the Swift-side privacy behaviour described here applies equally
-to both. Android is a separate codebase using Room for storage and Kotlin for the BLE /
-import / Coach paths. The **only** networking anywhere in the app is the AI Coach
-(`Strand/AI/AICoach.swift` on the Swift side — macOS and iOS — `com.noop.ai.AiCoach` on
-Android), described in §1.1a. The package manifests reference dependency *download* URLs
-that Swift Package Manager resolves at build time, never at runtime:
+other networking API — still true after the Oura cloud import (§1.1b) landed: its OAuth
+and REST calls live entirely in the app target, `Strand/Oura/`, and `StrandImport`
+gained only pure, network-free parsers for Oura's payload shapes. These Swift packages
+are **shared by the macOS and iOS apps** (iOS is build-from-source only — no App Store /
+TestFlight — and was folded into the main tree in v1.94), so the Swift-side privacy
+behaviour described here applies equally to both. Android is a separate codebase using
+Room for storage and Kotlin for the BLE / import / Coach paths; its own Oura support is
+the local BLE ring-pairing lane, not a network API, so it has no equivalent to §1.1b. The
+**only** networking anywhere in the app is the AI Coach (`Strand/AI/AICoach.swift` on the
+Swift side — macOS and iOS — `com.noop.ai.AiCoach` on Android), described in §1.1a, and
+the Oura cloud import (`Strand/Oura/`, Swift-only — macOS and iOS), described in §1.1b.
+The package manifests reference dependency *download* URLs that Swift Package Manager
+resolves at build time, never at runtime:
 
 ```
 Packages/WhoopStore/Package.swift   → https://github.com/groue/GRDB.swift.git
@@ -68,8 +78,9 @@ importers. Neither opens a socket.
 
 ### 1.1a The AI Coach (optional, off by default, bring your own key)
 
-The AI Coach lets you ask questions about your data in plain language. It is the one
-feature that uses the network, and only on your terms:
+The AI Coach lets you ask questions about your data in plain language. It is one of the
+two features that use the network (the other is the Oura cloud import, §1.1b), and only
+on your terms:
 
 - **Off until you enable it.** You enter your own API key for the provider you choose
   (Anthropic, OpenAI, or a local / self-hosted OpenAI-compatible LLM such as Ollama or
@@ -86,20 +97,58 @@ feature that uses the network, and only on your terms:
   provider you picked, under your own account. NOOP runs no server in between and keeps
   no copy.
 
-If you never enable the AI Coach, NOOP makes zero network connections.
+If you never enable the AI Coach and never connect Oura (§1.1b), NOOP makes zero network
+connections.
 
-### 1.2 The macOS sandbox (and what it means for the AI Coach)
+### 1.1b The Oura cloud import (optional, off by default, bring your own OAuth app)
 
-On macOS the App Sandbox is the backstop. The app ships with a deliberately minimal
-entitlement set (`Strand/Resources/Strand.entitlements`):
+The Oura cloud import pulls your own historical Oura data into NOOP over Oura's official
+API — a one-time backfill you trigger yourself, not an ongoing background sync:
+
+- **Off until you connect it.** Nothing happens until you register your own free Oura
+  developer app and drop its client ID/secret into an untracked
+  `Strand/Oura/OuraSecrets.xcconfig` (absent/blank credentials cleanly disable the lane —
+  `OuraCredentials.fromBundle` — and the Data Sources card says so instead of connecting),
+  then tap **"Connect Oura & Import Everything"** in Data Sources. No credentials
+  configured, no network calls, ever.
+- **What is sent.** An OAuth authorization-code handshake — you sign into Oura's own
+  consent page (`cloud.ouraring.com`) through Apple's system `ASWebAuthenticationSession`,
+  not an in-app WebView NOOP controls — followed by bearer-token `GET` requests to
+  `api.ouraring.com/v2/usercollection/*` carrying only your access token and the
+  endpoint/date-range parameters needed to page through your history. No NOOP data rides
+  along with these requests beyond the token itself.
+- **What comes back.** Your own Oura data — sleep, readiness, activity, workouts, heart
+  rate, and the other endpoints your granted scopes cover — flowing **in**, once, to seed
+  your local database. Oura's own readiness/sleep scores are kept for reference only
+  (`ref_*`/`oura_*` metric keys); NOOP's own Charge/Effort/Rest are never derived from
+  them and are never sent anywhere.
+- **What is NOT sent.** None of your existing NOOP data — no WHOOP streams, no other
+  imports, no computed scores — ever leaves the device via this lane. It is inbound-only.
+- **Your app, your grant, revocable at Oura.** You register your own OAuth app at Oura's
+  developer portal; NOOP runs no server in between. Revoke access any time from your Oura
+  account settings, or tap **Disconnect** in NOOP, which signs out locally and deletes the
+  stored tokens plus every row this lane wrote — including the raw archive (`ouraRaw`
+  table, see `docs/DATA_MODEL.md`).
+- **Tokens in the Keychain, not a plist.** The access/refresh tokens are stored via
+  `OuraTokenStore` as a single Keychain item (`kSecAttrAccessibleAfterFirstUnlock`), the
+  same pattern as the AI Coach's API key (`AIKeyStore`) — never UserDefaults, never on
+  disk in the clear.
+
+If you never connect Oura, NOOP makes zero calls to `ouraring.com`.
+
+### 1.2 The macOS sandbox (and what it means for the AI Coach and the Oura import)
+
+On macOS the App Sandbox is the backstop. The app ships with a minimal entitlement set
+(`Strand/Resources/Strand.entitlements`):
 
 ```xml
 <key>com.apple.security.app-sandbox</key>                       <true/>
 <key>com.apple.security.device.bluetooth</key>                  <true/>
 <key>com.apple.security.files.user-selected.read-write</key>    <true/>
+<key>com.apple.security.network.client</key>                    <true/>
 ```
 
-That is the entire entitlement file. Three keys:
+That is the entire entitlement file. Four keys:
 
 - **`app-sandbox`** — the process runs inside the macOS App Sandbox container.
 - **`device.bluetooth`** — permits BLE access to talk to the strap. The matching
@@ -109,24 +158,25 @@ That is the entire entitlement file. Three keys:
   your device."*
 - **`files.user-selected.read-write`** — lets the app read import files the user
   explicitly picks (and write the database in its own container).
+- **`network.client`** — outbound socket access. Added for the AI Coach on a
+  signed/sandboxed build, where the sandbox otherwise refuses any socket the app tries
+  to open (#128); the Oura cloud import (§1.1b) now relies on the same entitlement. The
+  ad-hoc distributed build applies **no** entitlements at all (unsigned build + ad-hoc
+  re-sign), so this key only matters for a signed/sandboxed build. The entitlement only
+  permits the socket the sandbox would otherwise refuse — it doesn't make either feature
+  call out on its own; both stay off until you deliberately turn the Coach on or tap
+  Connect Oura.
 
 Notably **absent**:
 
-- `com.apple.security.network.client` — **no outbound network entitlement.** The macOS
-  sandbox will refuse any socket the app tries to open, **including the AI Coach's**. So
-  on the sandboxed macOS build the AI Coach cannot reach the network as currently
-  shipped — the whole macOS app, Coach included, is offline. (Android has no equivalent
-  sandbox restriction, so the AI Coach's call works there with your own key. The iOS app
-  shares the same Swift Coach code; whether its Coach can reach the network depends on
-  that build's own entitlements.) Turning the macOS Coach on would mean adding this
-  entitlement; until that's a deliberate choice, it stays out and macOS stays fully
-  offline.
 - `com.apple.security.network.server` — no inbound listener.
 - No `files.downloads`, `files.documents`, or any broad filesystem entitlement —
   the app cannot wander the disk; it sees only what the user hands it through the
   open panel, plus its own sandbox container.
 
-This is the structural guarantee behind "offline by design" on macOS: the privacy
+This is the structural guarantee behind "offline by design" on macOS: the sandbox
+permits exactly the two deliberate, opt-in exceptions above and nothing else — no
+undeclared entitlement could smuggle out a connection the user didn't ask for. The
 property is enforced by the OS, not merely by convention.
 
 > **Note on Hardened Runtime.** `project.yml` currently sets
@@ -439,14 +489,20 @@ dedicated source id `nutrition-csv`, alongside your other metrics and entirely o
 
 ## 4. What NOOP does *not* collect or transmit
 
-- **No accounts, no login.** Nothing to sign into; no credentials
-  stored.
+- **No NOOP account, no NOOP login.** Nothing to sign into with NOOP itself; NOOP
+  issues no credentials of its own. The one exception is opt-in: the Oura cloud import
+  (§1.1b) has *you* sign into *your own* Oura account, at Oura's own login page, over
+  OAuth — NOOP never sees your Oura password, only the resulting tokens, kept in the
+  Keychain.
 - **No telemetry / analytics / crash reporting.** No third-party SDKs of that kind.
-- **No cloud, no sync, no remote backup.** Your data never leaves the machine via
-  NOOP.
+- **No cloud, no sync, no remote backup of NOOP's own data.** Your NOOP data never
+  leaves the machine via NOOP. The Oura cloud import (§1.1b) is the one path that
+  reaches a cloud service, and it is **inbound only** — it pulls your own Oura data in;
+  it does not sync or back up any NOOP data out.
 - **No advertising identifiers, no tracking.**
 - **No WHOOP account or API credentials.** NOOP talks only to the strap over local
-  BLE; it does not authenticate against, or pull from, any WHOOP server.
+  BLE; it does not authenticate against, or pull from, any WHOOP server. (Oura is the
+  one account-based exception — see above and §1.1b.)
 
 ---
 
@@ -454,7 +510,8 @@ dedicated source id `nutrition-csv`, alongside your other metrics and entirely o
 
 | Surface | Risk | Mitigation | Where |
 |---------|------|------------|-------|
-| Process | Data exfiltration / network egress | Only the opt-in AI Coach networks (your key, to your chosen provider, a text summary — §1.1a) — nothing else makes a network call, and nothing is sent until you ask. The Coach's call works on Android (and on iOS if that build's entitlements allow it), but is **blocked by the macOS App Sandbox as shipped** (no `network.client` entitlement — §1.2), so macOS stays fully offline | `Strand/AI/AICoach.swift`, `android/.../ai/AiCoach.kt` |
+| Process | Data exfiltration / network egress | Only two opt-in features network: the AI Coach (your key, to your chosen provider, a text summary — §1.1a) and the Oura cloud import (your own OAuth app, to `api.ouraring.com`, inbound-only — §1.1b). Nothing else makes a network call, and nothing is sent until you ask. Both work on Android/iOS where shipped (Android's Oura support is local-BLE only, no cloud lane); on macOS both cross the sandbox on the same `network.client` entitlement, present since #128 (§1.2) | `Strand/AI/AICoach.swift`, `Strand/Oura/`, `android/.../ai/AiCoach.kt` |
+| Oura cloud import | OAuth token / scope leakage, cross-account data mixing | Off by default; tokens Keychain-only (`kSecAttrAccessibleAfterFirstUnlock`, never UserDefaults/plist); fixed OAuth scopes set at build time; raw + normalized rows partitioned under `deviceId = "oura-api"`; Oura's own scores kept reference-only (`ref_*`/`oura_*` metricSeries keys, never NOOP's Charge/Effort/Rest); `.cloudImport` is structurally priority-2 so it never seizes a WHOOP day; Disconnect purges tokens + every `oura-api` row incl. the raw archive | `Strand/Oura/OuraTokenStore.swift`, `Strand/Oura/OuraConnectModel.swift`, `Packages/WhoopStore/Sources/WhoopStore/OuraRawStore.swift` |
 | Filesystem | Broad disk access | Only `files.user-selected.read-write`; data stays in the sandbox container | `Strand.entitlements`, `Strand/Collect/StorePaths.swift` |
 | BLE frames | Malformed / adversarial packets | CRC8 + CRC32 (+ CRC16 for v5) gating; reject on failure | `WhoopProtocol/Framing.swift`, `Strand/BLE/FrameRouter.swift` |
 | BLE frames | Out-of-bounds reads from short/lying length | `nil`-returning bounds-checked readers; slice clamping; min-length guards | `WhoopProtocol/Interpreter.swift` |

--- a/docs/superpowers/plans/2026-06-27-oura-live-api-import-1-foundation.md
+++ b/docs/superpowers/plans/2026-06-27-oura-live-api-import-1-foundation.md
@@ -1,0 +1,874 @@
+# Oura Live API Import — Plan 1: Foundation (pure parsers + raw storage)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+> **⚠️ v8.5.2 reconciliation (2026-06-30).** Written against v7.2.3; this branch (`oura-cloud-import`) is rebased onto upstream **v8.5.2** (`ryanbr/noop`). Deltas verified against current code:
+> 1. **Migration is `v24`, not `v19`.** The migrator is at **v23** (`v19-step-activity-class` … `v23-daily-spo2-raw`); append `v24-oura-raw` after the v23 block. (Fixed inline in Task 1.)
+> 2. **Provenance (Plan 3):** register the source with `PairedDevice.sourceKind = .cloudImport` — it already exists (`PairedDevice.swift:42`) and is treated as non-day-owning (`IntelligenceEngine.swift:1369`). Do **not** invent a new SourceKind; keep `deviceId = "oura-api"`.
+> 3. **`motionJSON` (Plan 3)** is written via the dedicated `persistSessionMotion(deviceId:sessionStart:motionEpochs:[Double])` (`MetricsCache.swift:234`) after the sleep upsert (not through it); map `movement30s` `[Int]→[Double]`.
+> 4. Also add `"oura-api"` to `Repository.wearableImportSources` (`Repository.swift:452`); disconnect via the actor `store.deleteAllData(deviceId:)` (`DataSourcesView.swift:598`).
+> 5. Citations shifted: `WhoopTime.parseISOWithOffset` → `CSVParsing.swift:509`; `WearableJSON` is in `WearableExportImporter.swift:329`. **Tasks 2–5 compile against v8.5.2 unchanged** — only Task 1's migration number moves.
+
+**Goal:** Build the network-free core of the Oura live-API lane — the lossless raw payload store and the pure JSON→model parsers (incl. the sleep hypnogram) — fully unit-tested, touching only new files plus one additive migration.
+
+**Architecture:** Two packages, additive only. `WhoopStore` gains a `ouraRaw` table (migration **v24**) and an `OuraRawStore` extension mirroring `MetricSeriesStore`. `StrandImport` gains pure decoders (`OuraHypnogram`, `OuraApiParser`) and small neutral model structs that reuse the existing `OuraExportParser` field semantics, `WhoopTime`, and `WearableJSON`. No networking, no edits to existing exhaustive switches, no app-target changes — so this plan can't break any existing build path. The fetch layer, auth, writer, and UI come in Plans 2–3.
+
+**Tech Stack:** Swift 5.9, GRDB 6.29.3 (pinned), XCTest, `Foundation`. iOS 16 / macOS 13 (both package platforms; the lane ships iOS-only but the packages stay multi-platform).
+
+## Global Constraints
+
+Every task implicitly includes these (verbatim from the spec):
+- **Packages stay network-free.** No `URLSession`/`URLRequest`/`NWConnection` in `StrandImport` or `WhoopStore`. (`StrandImport` banner: "STAY OFFLINE: nothing here touches the network.")
+- **Honest data.** Oura's own scores (readiness/sleep/activity/resilience) are written ONLY under reference keys (`ref_*`) or namespaced (`oura_*`) — never as a NOOP score column (`recovery`/`strain`). NOOP recomputes downstream.
+- **Untrusted input is hostile.** Parse via the existing `WearableJSON` finite/range-checked coercion (`dbl`/`int`/`posInt`/`posDbl`/`str`); never trap on attacker NaN/inf/huge values.
+- **Additive migrations only.** New tables/indexes; never alter or drop existing rows. The live migrator is at **v23** (`Packages/WhoopStore/Sources/WhoopStore/Database.swift`); this adds **v24** (`v19`–`v23` already exist).
+- **Pinned deps.** Add no new dependency. Versions across `Packages/*/Package.swift` must stay identical (`GRDB.swift exact 6.29.3`, `ZIPFoundation exact 0.9.20`).
+- **Provenance string.** The live-API partition is `deviceId = "oura-api"` (distinct from the file lane's `"oura-import"`).
+
+---
+
+### Task 1: `ouraRaw` table (migration v24) + `OuraRawStore`
+
+Lossless archive of every raw Oura payload, keyed by `(deviceId, endpoint, documentId)`, idempotent on re-pull.
+
+**Files:**
+- Modify: `Packages/WhoopStore/Sources/WhoopStore/Database.swift` (add migration after the `v23-daily-spo2-raw` block, before `return migrator`)
+- Create: `Packages/WhoopStore/Sources/WhoopStore/OuraRawStore.swift`
+- Test: `Packages/WhoopStore/Tests/WhoopStoreTests/OuraRawStoreTests.swift`
+
+**Interfaces:**
+- Consumes: `WhoopStore.inMemory()`, the actor's `syncWrite`/`syncRead` helpers, `db.changesCount` (all existing).
+- Produces:
+  - `struct OuraRawRow { let endpoint: String; let documentId: String; let day: String?; let payloadJSON: String; let fetchedAt: Int }`
+  - `WhoopStore.upsertOuraRaw(_ rows: [OuraRawRow], deviceId: String) async throws -> Int`
+  - `WhoopStore.ouraRaw(deviceId: String, endpoint: String) async throws -> [OuraRawRow]`
+  - `WhoopStore.ouraRawCount(deviceId: String, endpoint: String) async throws -> Int`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `Packages/WhoopStore/Tests/WhoopStoreTests/OuraRawStoreTests.swift`:
+
+```swift
+import XCTest
+import GRDB
+@testable import WhoopStore
+
+final class OuraRawStoreTests: XCTestCase {
+    func testUpsertIsIdempotentByNaturalKey() async throws {
+        let store = try await WhoopStore.inMemory()
+        let first = OuraRawRow(endpoint: "sleep", documentId: "abc", day: "2026-01-01",
+                               payloadJSON: #"{"id":"abc","v":1}"#, fetchedAt: 100)
+        let n1 = try await store.upsertOuraRaw([first], deviceId: "oura-api")
+        XCTAssertEqual(n1, 1)
+
+        // Re-pull the same document id with a newer payload → overwrite in place, still one row.
+        let second = OuraRawRow(endpoint: "sleep", documentId: "abc", day: "2026-01-01",
+                                payloadJSON: #"{"id":"abc","v":2}"#, fetchedAt: 200)
+        _ = try await store.upsertOuraRaw([second], deviceId: "oura-api")
+
+        let rows = try await store.ouraRaw(deviceId: "oura-api", endpoint: "sleep")
+        XCTAssertEqual(rows.count, 1)
+        XCTAssertEqual(rows.first?.payloadJSON, #"{"id":"abc","v":2}"#)
+        XCTAssertEqual(rows.first?.fetchedAt, 200)
+        XCTAssertEqual(try await store.ouraRawCount(deviceId: "oura-api", endpoint: "sleep"), 1)
+        // A different endpoint is a different partition.
+        XCTAssertEqual(try await store.ouraRawCount(deviceId: "oura-api", endpoint: "daily_sleep"), 0)
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `swift test --package-path Packages/WhoopStore --filter OuraRawStoreTests`
+Expected: FAIL — compile error, `OuraRawRow` / `upsertOuraRaw` undefined.
+
+- [ ] **Step 3: Add migration v24**
+
+In `Packages/WhoopStore/Sources/WhoopStore/Database.swift`, insert immediately **after the `v23-daily-spo2-raw` block** and before `return migrator` (`v19`–`v23` already exist, so v24 is the next free slot — do NOT reuse v19):
+
+```swift
+        // v24: Oura live-API raw payload archive (lossless). One row per (deviceId, endpoint, documentId);
+        // payloadJSON holds the verbatim Oura object so any field can be re-derived later without re-fetching
+        // from the API. Additive only — a NEW table, no existing row touched, old readers unaffected.
+        migrator.registerMigration("v24-oura-raw") { db in
+            try db.create(table: "ouraRaw") { t in
+                t.column("deviceId", .text).notNull()
+                t.column("endpoint", .text).notNull()       // "sleep" | "daily_readiness" | "heartrate" | …
+                t.column("documentId", .text).notNull()     // Oura `id`; heartrate pages use a window key
+                t.column("day", .text)                       // YYYY-MM-DD when day-keyed (nullable)
+                t.column("payloadJSON", .text).notNull()     // verbatim object
+                t.column("fetchedAt", .integer).notNull()    // unix seconds
+                t.primaryKey(["deviceId", "endpoint", "documentId"])
+            }
+            // Per-endpoint reads scan (deviceId, endpoint) then walk day in order.
+            try db.create(index: "idx_ouraRaw_device_endpoint_day",
+                          on: "ouraRaw", columns: ["deviceId", "endpoint", "day"])
+        }
+```
+
+- [ ] **Step 4: Implement `OuraRawStore`**
+
+Create `Packages/WhoopStore/Sources/WhoopStore/OuraRawStore.swift`:
+
+```swift
+import Foundation
+import GRDB
+
+// MARK: - v19 store: lossless Oura live-API payload archive
+// Mirrors MetricSeriesStore exactly: a Codable row struct, an idempotent ON CONFLICT upsert keyed by the
+// natural key (deviceId, endpoint, documentId), and range reads — all GRDB work via syncWrite/syncRead.
+// This is the "as much as we can get" backstop: the verbatim payload is kept so a future metric can be
+// derived without re-hitting the Oura API.
+
+/// One archived Oura API payload. Natural key (deviceId, endpoint, documentId).
+public struct OuraRawRow: Equatable, Codable, Sendable {
+    public let endpoint: String     // "sleep" | "daily_readiness" | "heartrate" | …
+    public let documentId: String   // Oura `id`; for heartrate pages, a synthesized window key
+    public let day: String?         // YYYY-MM-DD when the document is day-keyed
+    public let payloadJSON: String  // verbatim object
+    public let fetchedAt: Int       // unix seconds
+    public init(endpoint: String, documentId: String, day: String?, payloadJSON: String, fetchedAt: Int) {
+        self.endpoint = endpoint; self.documentId = documentId
+        self.day = day; self.payloadJSON = payloadJSON; self.fetchedAt = fetchedAt
+    }
+}
+
+extension WhoopStore {
+
+    /// Upsert raw Oura payloads. Idempotent by (deviceId, endpoint, documentId): re-pulling the same
+    /// document overwrites its payload/day/fetchedAt rather than duplicating. Returns rows changed.
+    @discardableResult
+    public func upsertOuraRaw(_ rows: [OuraRawRow], deviceId: String) async throws -> Int {
+        try syncWrite { db in
+            var n = 0
+            for r in rows {
+                try db.execute(sql: """
+                    INSERT INTO ouraRaw (deviceId, endpoint, documentId, day, payloadJSON, fetchedAt)
+                    VALUES (?, ?, ?, ?, ?, ?)
+                    ON CONFLICT(deviceId, endpoint, documentId) DO UPDATE SET
+                        day = excluded.day,
+                        payloadJSON = excluded.payloadJSON,
+                        fetchedAt = excluded.fetchedAt
+                    """, arguments: [deviceId, r.endpoint, r.documentId, r.day, r.payloadJSON, r.fetchedAt])
+                n += db.changesCount
+            }
+            return n
+        }
+    }
+
+    /// Archived payloads for a device + endpoint, oldest day first (null days sort first in SQLite).
+    public func ouraRaw(deviceId: String, endpoint: String) async throws -> [OuraRawRow] {
+        try syncRead { db in
+            try Row.fetchAll(db, sql: """
+                SELECT endpoint, documentId, day, payloadJSON, fetchedAt FROM ouraRaw
+                WHERE deviceId = ? AND endpoint = ?
+                ORDER BY day ASC
+                """, arguments: [deviceId, endpoint])
+                .map { OuraRawRow(endpoint: $0["endpoint"], documentId: $0["documentId"],
+                                  day: $0["day"], payloadJSON: $0["payloadJSON"], fetchedAt: $0["fetchedAt"]) }
+        }
+    }
+
+    /// Count archived payloads for a device + endpoint (diagnostics / import summary).
+    public func ouraRawCount(deviceId: String, endpoint: String) async throws -> Int {
+        try syncRead { db in
+            try Int.fetchOne(db, sql:
+                "SELECT COUNT(*) FROM ouraRaw WHERE deviceId = ? AND endpoint = ?",
+                arguments: [deviceId, endpoint]) ?? 0
+        }
+    }
+}
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `swift test --package-path Packages/WhoopStore --filter OuraRawStoreTests`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Packages/WhoopStore/Sources/WhoopStore/Database.swift \
+        Packages/WhoopStore/Sources/WhoopStore/OuraRawStore.swift \
+        Packages/WhoopStore/Tests/WhoopStoreTests/OuraRawStoreTests.swift
+git commit -m "feat(store): ouraRaw lossless payload archive (migration v24) + OuraRawStore"
+```
+
+---
+
+### Task 2: `OuraHypnogram` decoder
+
+Pure decode of Oura's two compact per-epoch sleep strings. The legends DIFFER — one decoder must never serve both.
+
+**Files:**
+- Create: `Packages/StrandImport/Sources/StrandImport/OuraHypnogram.swift`
+- Test: `Packages/StrandImport/Tests/StrandImportTests/OuraHypnogramTests.swift`
+
+**Interfaces:**
+- Consumes: `WearableSleepStageInterval` (existing, `ImportModels.swift`: `var stage: String; var start, end: Date`).
+- Produces:
+  - `OuraHypnogram.stageName(_ ch: Character) -> String?`
+  - `OuraHypnogram.decode(_ phases: String, start: Date, epochSeconds: Int) -> [WearableSleepStageInterval]`
+  - `OuraHypnogram.movement(_ s: String) -> [Int]`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `Packages/StrandImport/Tests/StrandImportTests/OuraHypnogramTests.swift`:
+
+```swift
+import XCTest
+@testable import StrandImport
+
+final class OuraHypnogramTests: XCTestCase {
+    private func d(_ iso: String) -> Date { ISO8601DateFormatter().date(from: iso)! }
+
+    func testStageLegendMapsOuraDigits() {
+        XCTAssertEqual(OuraHypnogram.stageName("1"), "deep")
+        XCTAssertEqual(OuraHypnogram.stageName("2"), "light")
+        XCTAssertEqual(OuraHypnogram.stageName("3"), "rem")
+        XCTAssertEqual(OuraHypnogram.stageName("4"), "wake")
+        XCTAssertNil(OuraHypnogram.stageName("0"))
+    }
+
+    func testDecodeMergesAdjacentEqualStagesAndAligns() {
+        let start = d("2026-01-01T23:00:00Z")
+        // "1123" → deep(2 epochs merged), light(1), rem(1); 5-min epochs.
+        let segs = OuraHypnogram.decode("1123", start: start, epochSeconds: 300)
+        XCTAssertEqual(segs.map(\.stage), ["deep", "light", "rem"])
+        XCTAssertEqual(segs[0].start, start)
+        XCTAssertEqual(segs[0].end, start.addingTimeInterval(600))   // two 5-min epochs merged
+        XCTAssertEqual(segs[2].end, start.addingTimeInterval(1200))  // total 4 epochs = 20 min
+    }
+
+    func testMovementLegendIsDistinctFromStages() {
+        // movement uses 1=no motion … 4=active; unknown → 0.
+        XCTAssertEqual(OuraHypnogram.movement("1234x"), [1, 2, 3, 4, 0])
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `swift test --package-path Packages/StrandImport --filter OuraHypnogramTests`
+Expected: FAIL — `OuraHypnogram` undefined.
+
+- [ ] **Step 3: Implement the decoder**
+
+Create `Packages/StrandImport/Sources/StrandImport/OuraHypnogram.swift`:
+
+```swift
+import Foundation
+
+// MARK: - Oura compact per-epoch sleep strings (DOCUMENTED Oura API v2 encodings; NOOP's own decoder)
+//
+// The Oura `sleep` object carries two compact strings. Their digit legends are DIFFERENT — never share a
+// decoder between them:
+//   • sleep_phase_5_min / sleep_phase_30_sec — the hypnogram: '1'=deep, '2'=light, '3'=REM, '4'=awake.
+//   • movement_30_sec                         — motion:      '1'=no motion, '2'=restless, '3'=tossing, '4'=active.
+
+public enum OuraHypnogram {
+
+    /// `sleep_phase_*` digit → NOOP stage string ("deep"/"light"/"rem"/"wake", matching
+    /// `WearableSleepStageInterval`). Unknown digits → nil (skipped, the epoch clock still advances).
+    public static func stageName(_ ch: Character) -> String? {
+        switch ch {
+        case "1": return "deep"
+        case "2": return "light"
+        case "3": return "rem"
+        case "4": return "wake"
+        default:  return nil
+        }
+    }
+
+    /// Decode a `sleep_phase_5_min` (epochSeconds 300) or `sleep_phase_30_sec` (epochSeconds 30) string into
+    /// contiguous [{stage,start,end}] segments, epoch-aligned from `start`. Adjacent equal stages are merged.
+    public static func decode(_ phases: String, start: Date, epochSeconds: Int) -> [WearableSleepStageInterval] {
+        var out: [WearableSleepStageInterval] = []
+        for (i, ch) in phases.enumerated() {
+            guard let stage = stageName(ch) else { continue }
+            let segStart = start.addingTimeInterval(Double(i * epochSeconds))
+            let segEnd = segStart.addingTimeInterval(Double(epochSeconds))
+            if var last = out.last, last.stage == stage, last.end == segStart {
+                last.end = segEnd
+                out[out.count - 1] = last
+            } else {
+                out.append(WearableSleepStageInterval(stage: stage, start: segStart, end: segEnd))
+            }
+        }
+        return out
+    }
+
+    /// Decode `movement_30_sec` into per-epoch motion magnitudes 1…4 (unknown digit → 0). 30-sec epochs.
+    public static func movement(_ s: String) -> [Int] {
+        s.map { ch in
+            switch ch { case "1": return 1; case "2": return 2; case "3": return 3; case "4": return 4
+                        default: return 0 }
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `swift test --package-path Packages/StrandImport --filter OuraHypnogramTests`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Packages/StrandImport/Sources/StrandImport/OuraHypnogram.swift \
+        Packages/StrandImport/Tests/StrandImportTests/OuraHypnogramTests.swift
+git commit -m "feat(import): OuraHypnogram decoder (sleep_phase + movement, distinct legends)"
+```
+
+---
+
+### Task 3: `OuraApiParser.parseSleep` + sleep models
+
+Parse detailed `sleep` periods into the shared `WearableSleepSession` (now WITH stages — the headline win) plus the rich extras (movement, in-sleep HR) the shared model can't hold, and fold the per-day sleep rollup.
+
+**Files:**
+- Create: `Packages/StrandImport/Sources/StrandImport/OuraApiModels.swift`
+- Create: `Packages/StrandImport/Sources/StrandImport/OuraApiParser.swift`
+- Test: `Packages/StrandImport/Tests/StrandImportTests/OuraApiParserSleepTests.swift`
+
+**Interfaces:**
+- Consumes: `OuraHypnogram` (Task 2); existing `WearableSleepSession`, `WearableDailyRow`, `WearableJSON` (`str`/`dbl`/`posDbl`/`posInt`, in `WearableExportImporter.swift:329`), `WhoopTime.parseISOWithOffset(_:)` (`CSVParsing.swift:509`), `WearableExportImporter.dayString(_:)`.
+- Produces:
+  - `struct OuraHRPoint { let ts: Int; let bpm: Int }`
+  - `struct OuraSleepPeriod { var session: WearableSleepSession; var movement30s: [Int]; var hr: [OuraHRPoint] }`
+  - `enum OuraApiParser` with `static func parseSleep(_ docs: [[String: Any]]) -> (periods: [OuraSleepPeriod], days: [WearableDailyRow])` and `static func sampleSeries(_ any: Any?) -> [OuraHRPoint]`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `Packages/StrandImport/Tests/StrandImportTests/OuraApiParserSleepTests.swift`:
+
+```swift
+import XCTest
+@testable import StrandImport
+
+final class OuraApiParserSleepTests: XCTestCase {
+    func testParsesPeriodWithHypnogramAndFoldsDay() throws {
+        let docs: [[String: Any]] = [[
+            "id": "s1", "day": "2026-01-02",
+            "bedtime_start": "2026-01-01T23:00:00+00:00",
+            "bedtime_end": "2026-01-02T06:00:00+00:00",
+            "total_sleep_duration": 24000, "deep_sleep_duration": 6000,
+            "light_sleep_duration": 12000, "rem_sleep_duration": 6000, "awake_time": 1200,
+            "efficiency": 92, "average_heart_rate": 55, "lowest_heart_rate": 48,
+            "average_hrv": 65, "average_breath": 14.2,
+            "sleep_phase_5_min": "1234",
+            "movement_30_sec": "1212",
+            "heart_rate": ["interval": 300, "timestamp": "2026-01-01T23:00:00+00:00",
+                           "items": [60, 58, NSNull(), 57]]
+        ]]
+        let (periods, days) = OuraApiParser.parseSleep(docs)
+        XCTAssertEqual(periods.count, 1)
+        let p = try XCTUnwrap(periods.first)
+        XCTAssertEqual(p.session.totalSleepMin, 400)              // 24000s ÷ 60
+        XCTAssertEqual(p.session.lowestHr, 48)
+        XCTAssertEqual(p.session.avgHrvMs, 65)
+        XCTAssertEqual(p.session.stages.map(\.stage), ["deep", "light", "rem", "wake"])
+        XCTAssertEqual(p.movement30s, [1, 2, 1, 2])
+        XCTAssertEqual(p.hr.map(\.bpm), [60, 58, 57])            // null sample dropped
+        XCTAssertEqual(days.count, 1)
+        XCTAssertEqual(days.first?.day, "2026-01-02")
+        XCTAssertEqual(days.first?.totalSleepMin, 400)
+        XCTAssertEqual(days.first?.restingHr, 48)                // lowestHr ≈ resting fallback
+    }
+
+    func testSkipsPeriodWithInvalidSpan() {
+        let (periods, _) = OuraApiParser.parseSleep([["bedtime_start": "nope", "bedtime_end": "nope"]])
+        XCTAssertTrue(periods.isEmpty)
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `swift test --package-path Packages/StrandImport --filter OuraApiParserSleepTests`
+Expected: FAIL — `OuraApiParser` / `OuraSleepPeriod` undefined.
+
+- [ ] **Step 3: Add the sleep models**
+
+Create `Packages/StrandImport/Sources/StrandImport/OuraApiModels.swift`:
+
+```swift
+import Foundation
+
+// MARK: - Neutral models emitted by OuraApiParser (network-free; the app-target writer maps them to WhoopStore).
+
+/// One heart-rate sample (→ hrSample on write). `ts` is unix seconds, `bpm` is positive.
+public struct OuraHRPoint: Sendable, Equatable {
+    public let ts: Int
+    public let bpm: Int
+    public init(ts: Int, bpm: Int) { self.ts = ts; self.bpm = bpm }
+}
+
+/// One Oura detailed sleep period: the shared `session` (incl. decoded stages) plus the rich extras the
+/// shared model can't hold. `movement30s` → sleepSession.motionJSON; `hr` → hrSample. (HRV samples stay
+/// in the raw archive only — there is no rMSSD-per-sample table; the per-night average is on `session`.)
+public struct OuraSleepPeriod: Sendable, Equatable {
+    public var session: WearableSleepSession
+    public var movement30s: [Int]
+    public var hr: [OuraHRPoint]
+    public init(session: WearableSleepSession, movement30s: [Int], hr: [OuraHRPoint]) {
+        self.session = session; self.movement30s = movement30s; self.hr = hr
+    }
+}
+```
+
+- [ ] **Step 4: Implement `parseSleep`**
+
+Create `Packages/StrandImport/Sources/StrandImport/OuraApiParser.swift`:
+
+```swift
+import Foundation
+
+// MARK: - Oura API v2 document parser (PURE / network-free)
+//
+// Takes already-fetched JSON `data[]` arrays (the OuraAPIClient does the I/O in the app target) and maps
+// them to NOOP's normalized models. Reuses the SAME field semantics as OuraExportParser — the account export
+// and the API share field names (bedtime_start, total_sleep_duration, …) — and adds the hypnogram +
+// time-series the file export never carried. Crafted-input safe via WearableJSON.
+
+public enum OuraApiParser {
+
+    /// Parse `sleep` documents (detailed periods; multiple per day are possible). Returns one
+    /// `OuraSleepPeriod` per usable period plus a per-day sleep rollup folded onto `WearableDailyRow`.
+    public static func parseSleep(_ docs: [[String: Any]]) -> (periods: [OuraSleepPeriod], days: [WearableDailyRow]) {
+        var periods: [OuraSleepPeriod] = []
+        var byDay: [String: WearableDailyRow] = [:]
+
+        for s in docs {
+            guard let start = WhoopTime.parseISOWithOffset(WearableJSON.str(s, "bedtime_start")),
+                  let end = WhoopTime.parseISOWithOffset(WearableJSON.str(s, "bedtime_end")),
+                  end > start else { continue }
+
+            // Durations are SECONDS in the API → minutes.
+            func minutes(_ k: String) -> Double? { WearableJSON.posDbl(s, k).map { $0 / 60.0 } }
+
+            // Stages: prefer the finer 30-sec hypnogram, else the 5-min; never synthesize one.
+            let stages: [WearableSleepStageInterval]
+            if let p30 = WearableJSON.str(s, "sleep_phase_30_sec"), !p30.isEmpty {
+                stages = OuraHypnogram.decode(p30, start: start, epochSeconds: 30)
+            } else if let p5 = WearableJSON.str(s, "sleep_phase_5_min"), !p5.isEmpty {
+                stages = OuraHypnogram.decode(p5, start: start, epochSeconds: 300)
+            } else {
+                stages = []
+            }
+
+            let session = WearableSleepSession(
+                start: start, end: end,
+                deepMin: minutes("deep_sleep_duration"),
+                lightMin: minutes("light_sleep_duration"),
+                remMin: minutes("rem_sleep_duration"),
+                awakeMin: minutes("awake_time"),
+                totalSleepMin: minutes("total_sleep_duration"),
+                efficiencyPct: WearableJSON.posDbl(s, "efficiency"),
+                avgHr: WearableJSON.posInt(s, "average_heart_rate"),
+                lowestHr: WearableJSON.posInt(s, "lowest_heart_rate"),
+                avgHrvMs: WearableJSON.posDbl(s, "average_hrv"),
+                respRateBpm: WearableJSON.posDbl(s, "average_breath"),
+                sleepScore: nil,                                // the night's reference score comes from daily_sleep
+                stages: stages)
+
+            let movement = WearableJSON.str(s, "movement_30_sec").map(OuraHypnogram.movement) ?? []
+            let hr = sampleSeries(s["heart_rate"])
+            periods.append(OuraSleepPeriod(session: session, movement30s: movement, hr: hr))
+
+            // Fold the night onto its calendar day (Oura's "day" = the wake day).
+            let key = WearableJSON.str(s, "day") ?? WearableExportImporter.dayString(end)
+            var row = byDay[key] ?? WearableDailyRow(day: key)
+            row.totalSleepMin = row.totalSleepMin ?? session.totalSleepMin
+            row.deepMin = row.deepMin ?? session.deepMin
+            row.lightMin = row.lightMin ?? session.lightMin
+            row.remMin = row.remMin ?? session.remMin
+            row.awakeMin = row.awakeMin ?? session.awakeMin
+            row.efficiencyPct = row.efficiencyPct ?? session.efficiencyPct
+            row.avgHrvMs = row.avgHrvMs ?? session.avgHrvMs
+            if row.restingHr == nil { row.restingHr = session.lowestHr }
+            byDay[key] = row
+        }
+        return (periods, Array(byDay.values))
+    }
+
+    /// Decode an Oura `PublicSample` object ({interval, items:[Double?], timestamp}) into HR points.
+    /// Non-finite / non-positive items are dropped (Oura uses null/0 for gaps).
+    static func sampleSeries(_ any: Any?) -> [OuraHRPoint] {
+        guard let obj = any as? [String: Any],
+              let interval = WearableJSON.dbl(obj, "interval"), interval > 0,
+              let items = obj["items"] as? [Any],
+              let t0 = WhoopTime.parseISOWithOffset(WearableJSON.str(obj, "timestamp")) else { return [] }
+        var out: [OuraHRPoint] = []
+        for (i, item) in items.enumerated() {
+            guard let v = (item as? Double) ?? (item as? NSNumber)?.doubleValue, v.isFinite, v > 0 else { continue }
+            out.append(OuraHRPoint(ts: Int(t0.timeIntervalSince1970 + Double(i) * interval), bpm: Int(v)))
+        }
+        return out
+    }
+}
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `swift test --package-path Packages/StrandImport --filter OuraApiParserSleepTests`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Packages/StrandImport/Sources/StrandImport/OuraApiModels.swift \
+        Packages/StrandImport/Sources/StrandImport/OuraApiParser.swift \
+        Packages/StrandImport/Tests/StrandImportTests/OuraApiParserSleepTests.swift
+git commit -m "feat(import): OuraApiParser.parseSleep — sessions with hypnogram, movement, in-sleep HR"
+```
+
+---
+
+### Task 4: `OuraApiParser.parseDaily` (summary endpoints) + extras
+
+One dispatching parser for the day-keyed summary endpoints. Maps onto `WearableDailyRow` columns where a home exists; everything else becomes `OuraDailyExtra` points (→ `metricSeries`). Oura's own scores land ONLY under `ref_*`/`oura_*` keys (honest data).
+
+**Files:**
+- Modify: `Packages/StrandImport/Sources/StrandImport/OuraApiModels.swift` (add `OuraDailyExtra`)
+- Create: `Packages/StrandImport/Sources/StrandImport/OuraApiParser+Daily.swift`
+- Test: `Packages/StrandImport/Tests/StrandImportTests/OuraApiParserDailyTests.swift`
+
+**Interfaces:**
+- Consumes: existing `WearableDailyRow`, `WearableJSON`.
+- Produces:
+  - `struct OuraDailyExtra { let day: String; let key: String; let value: Double }`
+  - `OuraApiParser.parseDaily(_ docs: [[String: Any]], endpoint: String) -> (days: [WearableDailyRow], extras: [OuraDailyExtra])`
+  - `OuraApiParser.resilienceLevel(_ s: String?) -> Double?`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `Packages/StrandImport/Tests/StrandImportTests/OuraApiParserDailyTests.swift`:
+
+```swift
+import XCTest
+@testable import StrandImport
+
+final class OuraApiParserDailyTests: XCTestCase {
+    func testReadinessMapsRhrSkinTempAndRefScore() {
+        let (days, extras) = OuraApiParser.parseDaily([[
+            "day": "2026-01-02", "score": 80, "temperature_deviation": -0.2,
+            "contributors": ["resting_heart_rate": 50, "hrv_balance": 70]
+        ]], endpoint: "daily_readiness")
+        XCTAssertEqual(days.first?.restingHr, 50)
+        XCTAssertEqual(days.first?.skinTempDevC, -0.2)
+        XCTAssertEqual(days.first?.readinessScore, 80)
+        XCTAssertTrue(extras.contains(OuraDailyExtra(day: "2026-01-02", key: "ref_readiness_score", value: 80)))
+        XCTAssertTrue(extras.contains(OuraDailyExtra(day: "2026-01-02", key: "oura_readiness_hrv_balance", value: 70)))
+    }
+
+    func testActivityMapsStepsAndScoreIsReferenceOnly() {
+        let (days, extras) = OuraApiParser.parseDaily([[
+            "day": "2026-01-02", "score": 88, "steps": 9000,
+            "active_calories": 500, "total_calories": 2400
+        ]], endpoint: "daily_activity")
+        XCTAssertEqual(days.first?.steps, 9000)
+        XCTAssertEqual(days.first?.activeKcal, 500)
+        // The activity SCORE is reference-only — never a dailyMetric score column.
+        XCTAssertTrue(extras.contains(OuraDailyExtra(day: "2026-01-02", key: "ref_activity_score", value: 88)))
+    }
+
+    func testResilienceLevelEncodedReferenceOnly() {
+        let (_, extras) = OuraApiParser.parseDaily([[
+            "day": "2026-01-02", "level": "solid", "contributors": ["sleep_recovery": 60.0]
+        ]], endpoint: "daily_resilience")
+        XCTAssertTrue(extras.contains(OuraDailyExtra(day: "2026-01-02", key: "ref_resilience_level", value: 3)))
+        XCTAssertTrue(extras.contains(OuraDailyExtra(day: "2026-01-02", key: "oura_resilience_sleep_recovery", value: 60)))
+    }
+
+    func testSpo2MapsAverage() {
+        let (days, _) = OuraApiParser.parseDaily([[
+            "day": "2026-01-02", "spo2_percentage": ["average": 96.5]
+        ]], endpoint: "daily_spo2")
+        XCTAssertEqual(days.first?.spo2Pct, 96.5)
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `swift test --package-path Packages/StrandImport --filter OuraApiParserDailyTests`
+Expected: FAIL — `parseDaily` / `OuraDailyExtra` undefined.
+
+- [ ] **Step 3: Add the `OuraDailyExtra` model**
+
+Append to `Packages/StrandImport/Sources/StrandImport/OuraApiModels.swift`:
+
+```swift
+/// One extra daily scalar Oura returns that the wide `dailyMetric` columns don't hold (→ metricSeries on
+/// write). `key` is the metricSeries key; the brand's OWN scores use a `ref_` prefix and its contributor
+/// breakdowns an `oura_` prefix, so they are browseable but never mistaken for a NOOP score.
+public struct OuraDailyExtra: Sendable, Equatable {
+    public let day: String
+    public let key: String
+    public let value: Double
+    public init(day: String, key: String, value: Double) { self.day = day; self.key = key; self.value = value }
+}
+```
+
+- [ ] **Step 4: Implement `parseDaily`**
+
+Create `Packages/StrandImport/Sources/StrandImport/OuraApiParser+Daily.swift`:
+
+```swift
+import Foundation
+
+public extension OuraApiParser {
+
+    /// Parse a day-keyed summary endpoint's documents. `endpoint` selects the field mapping. Writes to
+    /// `WearableDailyRow` columns only where the on-device schema already has a home (RHR, skin-temp dev,
+    /// steps, calories, SpO2); everything else — and ALL of Oura's own scores — becomes `OuraDailyExtra`.
+    static func parseDaily(_ docs: [[String: Any]], endpoint: String) -> (days: [WearableDailyRow], extras: [OuraDailyExtra]) {
+        var byDay: [String: WearableDailyRow] = [:]
+        var extras: [OuraDailyExtra] = []
+        func extra(_ day: String, _ key: String, _ v: Double?) {
+            if let v { extras.append(OuraDailyExtra(day: day, key: key, value: v)) }
+        }
+
+        for doc in docs {
+            guard let day = WearableJSON.str(doc, "day") else { continue }
+            switch endpoint {
+
+            case "daily_readiness":
+                var r = byDay[day] ?? WearableDailyRow(day: day)
+                if let c = doc["contributors"] as? [String: Any] {
+                    r.restingHr = WearableJSON.posInt(c, "resting_heart_rate") ?? r.restingHr
+                    for (k, _) in c { extra(day, "oura_readiness_\(k)", WearableJSON.posDbl(c, k)) }
+                }
+                r.skinTempDevC = WearableJSON.dbl(doc, "temperature_deviation") ?? r.skinTempDevC
+                r.readinessScore = WearableJSON.posInt(doc, "score") ?? r.readinessScore
+                extra(day, "ref_readiness_score", WearableJSON.posDbl(doc, "score"))
+                byDay[day] = r
+
+            case "daily_sleep":
+                extra(day, "ref_sleep_score", WearableJSON.posDbl(doc, "score"))
+                if let c = doc["contributors"] as? [String: Any] {
+                    for (k, _) in c { extra(day, "oura_sleep_\(k)", WearableJSON.posDbl(c, k)) }
+                }
+
+            case "daily_activity":
+                var r = byDay[day] ?? WearableDailyRow(day: day)
+                r.steps = WearableJSON.posInt(doc, "steps") ?? r.steps
+                r.activeKcal = WearableJSON.posDbl(doc, "active_calories") ?? r.activeKcal
+                r.totalKcal = WearableJSON.posDbl(doc, "total_calories") ?? r.totalKcal
+                extra(day, "ref_activity_score", WearableJSON.posDbl(doc, "score"))
+                extra(day, "oura_equiv_walk_m", WearableJSON.posDbl(doc, "equivalent_walking_distance"))
+                byDay[day] = r
+
+            case "daily_spo2":
+                var r = byDay[day] ?? WearableDailyRow(day: day)
+                if let s = doc["spo2_percentage"] as? [String: Any] {
+                    r.spo2Pct = WearableJSON.posDbl(s, "average") ?? r.spo2Pct
+                    extra(day, "spo2", WearableJSON.posDbl(s, "average"))
+                }
+                extra(day, "oura_breathing_disturbance_index", WearableJSON.dbl(doc, "breathing_disturbance_index"))
+                byDay[day] = r
+
+            case "daily_stress":
+                extra(day, "oura_stress_high_s", WearableJSON.posDbl(doc, "stress_high"))
+                extra(day, "oura_recovery_high_s", WearableJSON.posDbl(doc, "recovery_high"))
+
+            case "daily_resilience":
+                if let c = doc["contributors"] as? [String: Any] {
+                    for (k, _) in c { extra(day, "oura_resilience_\(k)", WearableJSON.dbl(c, k)) }
+                }
+                extra(day, "ref_resilience_level", resilienceLevel(WearableJSON.str(doc, "level")))
+
+            case "daily_cardiovascular_age":
+                extra(day, "oura_vascular_age", WearableJSON.dbl(doc, "vascular_age"))
+                extra(day, "oura_pulse_wave_velocity", WearableJSON.dbl(doc, "pulse_wave_velocity"))
+
+            case "vO2_max":
+                extra(day, "vo2max", WearableJSON.posDbl(doc, "vo2_max"))
+
+            default:
+                break
+            }
+        }
+        return (Array(byDay.values), extras)
+    }
+
+    /// Oura resilience level → an ordered reference number (1…5). Reference-only — never a NOOP score.
+    static func resilienceLevel(_ s: String?) -> Double? {
+        switch s {
+        case "limited":     return 1
+        case "adequate":    return 2
+        case "solid":       return 3
+        case "strong":      return 4
+        case "exceptional": return 5
+        default:            return nil
+        }
+    }
+}
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `swift test --package-path Packages/StrandImport --filter OuraApiParserDailyTests`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Packages/StrandImport/Sources/StrandImport/OuraApiModels.swift \
+        Packages/StrandImport/Sources/StrandImport/OuraApiParser+Daily.swift \
+        Packages/StrandImport/Tests/StrandImportTests/OuraApiParserDailyTests.swift
+git commit -m "feat(import): OuraApiParser.parseDaily — summary endpoints, scores kept reference-only"
+```
+
+---
+
+### Task 5: `OuraApiParser` events — workouts + heart-rate time series
+
+Parse `workout` documents (→ workout table later) and the `/heartrate` time-series page (→ hrSample later).
+
+**Files:**
+- Modify: `Packages/StrandImport/Sources/StrandImport/OuraApiModels.swift` (add `OuraWorkout`)
+- Create: `Packages/StrandImport/Sources/StrandImport/OuraApiParser+Events.swift`
+- Test: `Packages/StrandImport/Tests/StrandImportTests/OuraApiParserEventsTests.swift`
+
+**Interfaces:**
+- Consumes: existing `WearableJSON`, `WhoopTime.parseISOWithOffset(_:)`; `OuraHRPoint` (Task 3).
+- Produces:
+  - `struct OuraWorkout { let start: Date; let end: Date; let activity: String; let source: String; let energyKcal: Double?; let distanceM: Double? }`
+  - `OuraApiParser.parseWorkouts(_ docs: [[String: Any]]) -> [OuraWorkout]`
+  - `OuraApiParser.parseHeartRate(_ docs: [[String: Any]]) -> [OuraHRPoint]`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `Packages/StrandImport/Tests/StrandImportTests/OuraApiParserEventsTests.swift`:
+
+```swift
+import XCTest
+@testable import StrandImport
+
+final class OuraApiParserEventsTests: XCTestCase {
+    func testWorkoutParse() throws {
+        let w = OuraApiParser.parseWorkouts([[
+            "activity": "running", "source": "autodetected",
+            "start_datetime": "2026-01-02T07:00:00+00:00", "end_datetime": "2026-01-02T07:40:00+00:00",
+            "calories": 410, "distance": 6200
+        ]])
+        XCTAssertEqual(w.count, 1)
+        XCTAssertEqual(w.first?.activity, "running")
+        XCTAssertEqual(w.first?.source, "autodetected")
+        XCTAssertEqual(w.first?.energyKcal, 410)
+        XCTAssertEqual(w.first?.distanceM, 6200)
+    }
+
+    func testHeartRatePageParseDropsNonPositive() {
+        let hr = OuraApiParser.parseHeartRate([
+            ["timestamp": "2026-01-02T07:00:00+00:00", "bpm": 120, "source": "workout"],
+            ["timestamp": "2026-01-02T07:05:00+00:00", "bpm": 0,   "source": "workout"]   // dropped
+        ])
+        XCTAssertEqual(hr.map(\.bpm), [120])
+        XCTAssertEqual(hr.first?.ts, Int(ISO8601DateFormatter().date(from: "2026-01-02T07:00:00Z")!.timeIntervalSince1970))
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `swift test --package-path Packages/StrandImport --filter OuraApiParserEventsTests`
+Expected: FAIL — `parseWorkouts` / `OuraWorkout` undefined.
+
+- [ ] **Step 3: Add the `OuraWorkout` model**
+
+Append to `Packages/StrandImport/Sources/StrandImport/OuraApiModels.swift`:
+
+```swift
+/// One Oura workout (→ the `workout` table on write). Times are UTC; metric fields nil when absent.
+public struct OuraWorkout: Sendable, Equatable {
+    public let start: Date
+    public let end: Date
+    public let activity: String
+    public let source: String
+    public let energyKcal: Double?
+    public let distanceM: Double?
+    public init(start: Date, end: Date, activity: String, source: String, energyKcal: Double?, distanceM: Double?) {
+        self.start = start; self.end = end; self.activity = activity; self.source = source
+        self.energyKcal = energyKcal; self.distanceM = distanceM
+    }
+}
+```
+
+- [ ] **Step 4: Implement the event parsers**
+
+Create `Packages/StrandImport/Sources/StrandImport/OuraApiParser+Events.swift`:
+
+```swift
+import Foundation
+
+public extension OuraApiParser {
+
+    /// Parse `workout` documents → `OuraWorkout`. Rows without a valid time span are skipped.
+    static func parseWorkouts(_ docs: [[String: Any]]) -> [OuraWorkout] {
+        var out: [OuraWorkout] = []
+        for w in docs {
+            guard let start = WhoopTime.parseISOWithOffset(WearableJSON.str(w, "start_datetime")),
+                  let end = WhoopTime.parseISOWithOffset(WearableJSON.str(w, "end_datetime")),
+                  end > start else { continue }
+            out.append(OuraWorkout(
+                start: start, end: end,
+                activity: WearableJSON.str(w, "activity") ?? "workout",
+                source: WearableJSON.str(w, "source") ?? "oura",
+                energyKcal: WearableJSON.posDbl(w, "calories"),
+                distanceM: WearableJSON.posDbl(w, "distance")))
+        }
+        return out
+    }
+
+    /// Parse a `/v2/usercollection/heartrate` page's `data[]` → HR points. Each row is
+    /// {timestamp, bpm, source}; non-positive bpm is dropped. (The `source` enum is preserved in the raw
+    /// archive, not in the compact hrSample.)
+    static func parseHeartRate(_ docs: [[String: Any]]) -> [OuraHRPoint] {
+        var out: [OuraHRPoint] = []
+        for h in docs {
+            guard let ts = WhoopTime.parseISOWithOffset(WearableJSON.str(h, "timestamp")),
+                  let bpm = WearableJSON.posInt(h, "bpm") else { continue }
+            out.append(OuraHRPoint(ts: Int(ts.timeIntervalSince1970), bpm: bpm))
+        }
+        return out
+    }
+}
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `swift test --package-path Packages/StrandImport --filter OuraApiParserEventsTests`
+Expected: PASS.
+
+- [ ] **Step 6: Run the full package test suites (no regressions)**
+
+Run: `swift test --package-path Packages/StrandImport && swift test --package-path Packages/WhoopStore`
+Expected: PASS (all existing tests + the 5 new suites).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add Packages/StrandImport/Sources/StrandImport/OuraApiModels.swift \
+        Packages/StrandImport/Sources/StrandImport/OuraApiParser+Events.swift \
+        Packages/StrandImport/Tests/StrandImportTests/OuraApiParserEventsTests.swift
+git commit -m "feat(import): OuraApiParser workouts + heartrate time-series parsing"
+```
+
+---
+
+## Plan 1 self-review
+
+- **Spec coverage:** §8.5 raw store → T1. §8.2 hypnogram/movement/in-sleep HR → T2/T3. `sleep` mapping → T3. Daily summaries + reference-only scores (§8.1, G4) → T4. Workouts + heartrate (§8.1, §8.3) → T5. Sessions/tags/rest_mode/personal_info/ring_* normalization is intentionally deferred to Plan 3's writer (raw-archived here via T1's store regardless). No spec requirement for the *foundation* layer is unaddressed.
+- **Network-free:** every new file imports only `Foundation`/`GRDB`. ✓ (Constraint.)
+- **Honest data:** every Oura score is emitted under `ref_*`/`oura_*` only; no path writes `recovery`/`strain`. ✓ (Asserted in T4.)
+- **Type consistency:** `OuraHRPoint` defined in T3, reused verbatim in T5. `OuraApiParser` opened in T3, extended in T4/T5. `OuraDailyExtra`/`OuraWorkout` appended to the same `OuraApiModels.swift`. No dangling references.
+- **No placeholders:** every step has full code + exact run command + expected result.
+
+## What Plans 2 & 3 add (scope preview — detailed separately on request)
+
+- **Plan 2 — Network + auth (app target `Strand/Oura/`):** `OuraCredentials` (xcconfig→Info.plist), `OuraTokenStore` (Keychain, mirroring `AIKeyStore`), `AuthProvider` + `OuraOAuthProvider` (`ASWebAuthenticationSession` + code→token exchange, refresh), `OuraAPIClient` (`URLSession`, `next_token` paging, 429/401 handling, prod/sandbox base URL) — tested with a `URLProtocol` stub and the Oura sandbox tree.
+- **Plan 3 — Orchestration + UI + wiring:** `OuraSyncWriter` (parsed models → `upsertDailyMetrics`/`upsertSleepSessions`(+stagesJSON/motionJSON)/`upsertMetricSeries`/`insert(hrSample)`/`upsertWorkouts` + `upsertOuraRaw` + `DeviceRegistryStore.add`, no day-ownership seizure), `OuraSyncCoordinator` (one-time backfill across all endpoints), `DataSourceKind.ouraApi` + exhaustive-switch updates, the Data Sources "Connect Oura & Import Everything" card/progress/summary/disconnect, `project.yml`/Info.plist/.gitignore wiring, and doc updates (`PRIVACY_SECURITY.md` second opt-in network lane, `DEVICE_SUPPORT_ROADMAP.md`, `DATA_MODEL.md`).

--- a/docs/superpowers/plans/2026-06-27-oura-live-api-import-2-network-auth.md
+++ b/docs/superpowers/plans/2026-06-27-oura-live-api-import-2-network-auth.md
@@ -1,0 +1,894 @@
+# Oura Live API Import — Plan 2: Network + Auth (app target)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build the app-target network + auth layer for the Oura cloud import — Keychain token storage, credentials, the OAuth2 authorization-code flow (bring-your-own Oura app), and the paging/backoff `URLSession` API client — behind an `AuthProvider` seam, all in `Strand/Oura/`.
+
+**Architecture:** Networking lives in the **app target** (`Strand/`), beside `Strand/AI/AICoach.swift` — never in a package (the packages stay network-free; that's the privacy invariant Plan 1 preserved). We mirror three proven app-target patterns: `AIKeyStore` (Keychain), `AICoachError` (`LocalizedError`), and the injected `session: URLSession = .shared` seam with **pure parse/build helpers split out** so the request-building, response-envelope parsing, paging, and token math are unit-tested without a live socket. The interactive `ASWebAuthenticationSession` step is thin, behind `AuthProvider`, and integration-verified (it opens a browser — not headless-unit-testable).
+
+**Tech stack:** Swift 6.3.1 (app builds via XcodeGen `Strand.xcodeproj`), `Foundation` + `Security` (Keychain) + `AuthenticationServices` (`ASWebAuthenticationSession`, new to this repo). XCTest in `StrandTests`. Tests run via `xcodebuild`, NOT `swift test` (this is the Xcode app target, not an SPM package).
+
+## Global Constraints
+
+Every task implicitly includes these:
+- **Networking only in the app target.** These files live in `Strand/Oura/`. No package gains a `URLSession`/`URLRequest`/`ASWebAuthenticationSession` import. `Strand/` sources are auto-globbed into both the `Strand` (macOS) and `NOOPiOS` targets by `project.yml` — no manifest edit needed for new `.swift` files (but the project must be regenerated: `xcodegen generate`).
+- **Second opt-in network lane.** This is off-by-default and user-initiated (the AI Coach is the first exception). Data flow is inbound (Oura → device, under the user's own OAuth grant). No NOOP server. Tokens live only in the Keychain, never UserDefaults/plist/logs.
+- **BYO Oura app, no PKCE.** OAuth2 authorization-code against Oura: authorize `https://cloud.ouraring.com/oauth/authorize`, token `https://api.ouraring.com/oauth/token`, bearer header `Authorization: Bearer <token>`. `client_id`+`client_secret` come from an untracked xcconfig via Info.plist (Task 5). Scopes (all 8): `email personal daily heartrate workout tag session spo2Daily`.
+- **Testability seam.** Every networked type takes `session: URLSession = .shared` in its initializer (mirroring `AICoachEngine`), so tests inject a `URLSession` backed by a `URLProtocol` stub. Pure builders/parsers are `static` and separately unit-tested (mirroring `AnthropicClient.parseModels`).
+- **Provenance / consumes Plan 1.** This plan does not write to the store yet (that's Plan 3). It produces the fetched raw JSON pages + tokens that Plan 3's writer consumes. `deviceId = "oura-api"` is the partition (Plan 3).
+- **Build/test path.** `xcodegen generate` then `xcodebuild -project Strand.xcodeproj -scheme Strand -destination 'platform=macOS' test -only-testing:StrandTests/<Class> CODE_SIGNING_ALLOWED=NO`. The first build is a full app compile (minutes); subsequent task builds are incremental. The full macOS app compiling clean under this toolchain is confirmed.
+
+---
+
+### Task 1: `OuraError` + `OuraTokenStore` (Keychain)
+
+The typed error surface and secure token storage, mirroring `AICoachError` / `AIKeyStore`.
+
+**Files:**
+- Create: `Strand/Oura/OuraError.swift`
+- Create: `Strand/Oura/OuraTokenStore.swift`
+- Test: `StrandTests/OuraTokenStoreTests.swift`
+
+**Interfaces:**
+- Produces:
+  - `enum OuraError: LocalizedError { case notConnected, authFailed(String), badResponse(Int, String), rateLimited, network(String), decode, tokenExchangeFailed(String) }`
+  - `struct OuraTokens: Equatable { let accessToken: String; let refreshToken: String?; let expiresAt: Date }` with `var isExpired: Bool` (true within a 60 s skew of `expiresAt`).
+  - `enum OuraTokenStore` with `static func save(_ tokens: OuraTokens) -> Bool`, `static func load() -> OuraTokens?`, `static func clear()`, `static var isConnected: Bool`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `StrandTests/OuraTokenStoreTests.swift`:
+
+```swift
+import XCTest
+@testable import Strand
+
+final class OuraTokenStoreTests: XCTestCase {
+    override func setUp() { super.setUp(); OuraTokenStore.clear() }
+    override func tearDown() { OuraTokenStore.clear(); super.tearDown() }
+
+    func testSaveLoadClearRoundTrip() {
+        XCTAssertFalse(OuraTokenStore.isConnected)
+        XCTAssertNil(OuraTokenStore.load())
+
+        let exp = Date(timeIntervalSince1970: 2_000_000_000)
+        let t = OuraTokens(accessToken: "acc", refreshToken: "ref", expiresAt: exp)
+        XCTAssertTrue(OuraTokenStore.save(t))
+        XCTAssertTrue(OuraTokenStore.isConnected)
+
+        let loaded = OuraTokenStore.load()
+        XCTAssertEqual(loaded, t)
+
+        OuraTokenStore.clear()
+        XCTAssertNil(OuraTokenStore.load())
+        XCTAssertFalse(OuraTokenStore.isConnected)
+    }
+
+    func testExpiryUsesSkew() {
+        let almostNow = OuraTokens(accessToken: "a", refreshToken: nil,
+                                   expiresAt: Date(timeIntervalSinceNow: 30))   // <60 s away
+        XCTAssertTrue(almostNow.isExpired)
+        let later = OuraTokens(accessToken: "a", refreshToken: nil,
+                               expiresAt: Date(timeIntervalSinceNow: 600))
+        XCTAssertFalse(later.isExpired)
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `xcodegen generate && xcodebuild -project Strand.xcodeproj -scheme Strand -destination 'platform=macOS' test -only-testing:StrandTests/OuraTokenStoreTests CODE_SIGNING_ALLOWED=NO 2>&1 | tail -20`
+Expected: FAIL — `OuraTokenStore` / `OuraTokens` / `OuraError` undefined (compile error).
+
+- [ ] **Step 3: Implement `OuraError`**
+
+Create `Strand/Oura/OuraError.swift`:
+
+```swift
+import Foundation
+
+/// User-facing failure reasons for the Oura cloud-import lane, mapped to clear, non-crashing messages.
+/// Mirrors AICoachError's shape (LocalizedError + errorDescription).
+enum OuraError: LocalizedError, Equatable {
+    case notConnected
+    case authFailed(String)
+    case tokenExchangeFailed(String)
+    case badResponse(Int, String)
+    case rateLimited
+    case network(String)
+    case decode
+
+    var errorDescription: String? {
+        switch self {
+        case .notConnected:
+            return "Connect your Oura account first."
+        case .authFailed(let d):
+            return "Oura sign-in didn't complete: \(d)"
+        case .tokenExchangeFailed(let d):
+            return "Couldn't exchange the Oura authorization code: \(d)"
+        case .badResponse(let code, let detail):
+            let extra = detail.isEmpty ? "" : " — \(detail)"
+            return "Oura returned an error (\(code))\(extra)."
+        case .rateLimited:
+            return "Oura is rate-limiting requests. Waiting before retrying."
+        case .network(let d):
+            return "Network problem talking to Oura: \(d)"
+        case .decode:
+            return "Couldn't read Oura's response."
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Implement `OuraTokens` + `OuraTokenStore`**
+
+Create `Strand/Oura/OuraTokenStore.swift`:
+
+```swift
+import Foundation
+import Security
+
+/// The OAuth tokens for the Oura cloud lane. `expiresAt` is absolute (computed from `expires_in` at
+/// exchange time). `isExpired` applies a 60 s skew so we refresh slightly early rather than mid-request.
+struct OuraTokens: Equatable, Codable {
+    let accessToken: String
+    let refreshToken: String?
+    let expiresAt: Date
+
+    var isExpired: Bool { Date() >= expiresAt.addingTimeInterval(-60) }
+}
+
+/// Keychain Services wrapper for the Oura tokens. One generic-password item (JSON-encoded `OuraTokens`)
+/// under a fixed service, so tokens never land in UserDefaults, a plist, or on disk in the clear.
+/// Mirrors AIKeyStore exactly (delete-then-add, kSecAttrAccessibleAfterFirstUnlock).
+enum OuraTokenStore {
+    private static let service = "com.noop.oura"
+    private static let account = "oauth-tokens"
+
+    private static var baseQuery: [String: Any] {
+        [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account,
+        ]
+    }
+
+    /// Store (or replace) the tokens. Returns false if the Keychain write fails (so callers never assume
+    /// a token is stored when it isn't).
+    @discardableResult
+    static func save(_ tokens: OuraTokens) -> Bool {
+        guard let data = try? JSONEncoder().encode(tokens) else { return false }
+        SecItemDelete(baseQuery as CFDictionary)
+        var attrs = baseQuery
+        attrs[kSecValueData as String] = data
+        attrs[kSecAttrAccessible as String] = kSecAttrAccessibleAfterFirstUnlock
+        return SecItemAdd(attrs as CFDictionary, nil) == errSecSuccess
+    }
+
+    /// Load the stored tokens, or nil if none.
+    static func load() -> OuraTokens? {
+        var query = baseQuery
+        query[kSecReturnData as String] = kCFBooleanTrue
+        query[kSecMatchLimit as String] = kSecMatchLimitOne
+        var item: CFTypeRef?
+        guard SecItemCopyMatching(query as CFDictionary, &item) == errSecSuccess,
+              let data = item as? Data,
+              let tokens = try? JSONDecoder().decode(OuraTokens.self, from: data) else { return nil }
+        return tokens
+    }
+
+    /// Remove any stored tokens.
+    static func clear() { SecItemDelete(baseQuery as CFDictionary) }
+
+    /// True when tokens are present (regardless of expiry — an expired token is still "connected", it
+    /// just needs a refresh).
+    static var isConnected: Bool { load() != nil }
+}
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `xcodebuild -project Strand.xcodeproj -scheme Strand -destination 'platform=macOS' test -only-testing:StrandTests/OuraTokenStoreTests CODE_SIGNING_ALLOWED=NO 2>&1 | tail -20`
+Expected: PASS (`Test Suite 'OuraTokenStoreTests' passed`). If the Keychain is unavailable in the test host and `save` returns false, note it in the report — the AICoach Keychain tests establish that the host allows it; if they pass and this doesn't, investigate before proceeding.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Strand/Oura/OuraError.swift Strand/Oura/OuraTokenStore.swift StrandTests/OuraTokenStoreTests.swift
+git commit -m "feat(oura): OuraError + OuraTokenStore (Keychain token storage)"
+```
+
+---
+
+### Task 2: `OuraCredentials` + `AuthProvider` protocol
+
+Read the BYO-app credentials from Info.plist (injected via xcconfig in Task 5) and define the auth seam.
+
+**Files:**
+- Create: `Strand/Oura/OuraCredentials.swift`
+- Create: `Strand/Oura/AuthProvider.swift`
+- Test: `StrandTests/OuraCredentialsTests.swift`
+
+**Interfaces:**
+- Consumes: nothing from Task 1.
+- Produces:
+  - `struct OuraCredentials: Equatable { let clientId: String; let clientSecret: String; let redirectURI: String }` with `static func from(_ info: [String: Any]) -> OuraCredentials?` (nil if any key missing/blank) and `static var fromBundle: OuraCredentials?` (reads `Bundle.main.infoDictionary`).
+  - `protocol AuthProvider { var isConnected: Bool { get }; func validAccessToken() async throws -> String; func authorize(presentationAnchor: ASPresentationAnchor) async throws; func signOut() }`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `StrandTests/OuraCredentialsTests.swift`:
+
+```swift
+import XCTest
+@testable import Strand
+
+final class OuraCredentialsTests: XCTestCase {
+    func testParsesCompleteInfoDict() {
+        let info: [String: Any] = [
+            "OURA_CLIENT_ID": "cid", "OURA_CLIENT_SECRET": "secret",
+            "OURA_REDIRECT_URI": "noop://oura/callback",
+        ]
+        let c = OuraCredentials.from(info)
+        XCTAssertEqual(c, OuraCredentials(clientId: "cid", clientSecret: "secret",
+                                          redirectURI: "noop://oura/callback"))
+    }
+
+    func testNilWhenAnyKeyMissingOrBlank() {
+        XCTAssertNil(OuraCredentials.from(["OURA_CLIENT_ID": "cid", "OURA_CLIENT_SECRET": "s"]))  // no redirect
+        XCTAssertNil(OuraCredentials.from([
+            "OURA_CLIENT_ID": "", "OURA_CLIENT_SECRET": "s", "OURA_REDIRECT_URI": "noop://x",
+        ]))  // blank id
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `xcodegen generate && xcodebuild -project Strand.xcodeproj -scheme Strand -destination 'platform=macOS' test -only-testing:StrandTests/OuraCredentialsTests CODE_SIGNING_ALLOWED=NO 2>&1 | tail -20`
+Expected: FAIL — `OuraCredentials` undefined.
+
+- [ ] **Step 3: Implement `OuraCredentials`**
+
+Create `Strand/Oura/OuraCredentials.swift`:
+
+```swift
+import Foundation
+
+/// The user's own Oura OAuth app credentials, injected at build time via an untracked xcconfig →
+/// Info.plist (Task 5). Absent credentials mean the Connect flow is unavailable (surfaced in the UI).
+struct OuraCredentials: Equatable {
+    let clientId: String
+    let clientSecret: String
+    let redirectURI: String
+
+    /// Build from an Info-dictionary-shaped map. Returns nil unless all three keys are present and
+    /// non-blank (so a build without the xcconfig cleanly disables the lane rather than half-configuring).
+    static func from(_ info: [String: Any]) -> OuraCredentials? {
+        func nonBlank(_ key: String) -> String? {
+            guard let s = (info[key] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines),
+                  !s.isEmpty else { return nil }
+            return s
+        }
+        guard let id = nonBlank("OURA_CLIENT_ID"),
+              let secret = nonBlank("OURA_CLIENT_SECRET"),
+              let redirect = nonBlank("OURA_REDIRECT_URI") else { return nil }
+        return OuraCredentials(clientId: id, clientSecret: secret, redirectURI: redirect)
+    }
+
+    /// The live credentials from the app bundle's Info.plist, or nil if not configured.
+    static var fromBundle: OuraCredentials? { from(Bundle.main.infoDictionary ?? [:]) }
+}
+```
+
+- [ ] **Step 4: Implement `AuthProvider`**
+
+Create `Strand/Oura/AuthProvider.swift`:
+
+```swift
+import Foundation
+import AuthenticationServices
+
+/// The auth seam. Today's concrete provider is `OuraOAuthProvider` (BYO-app authorization-code, Task 3);
+/// a future backend-mediated provider can replace it without touching the API client or the sync layer.
+protocol AuthProvider {
+    /// True when tokens are stored (connected), regardless of expiry.
+    var isConnected: Bool { get }
+    /// Return a currently-valid access token, refreshing transparently if the stored one is expired.
+    func validAccessToken() async throws -> String
+    /// Run the interactive authorization (opens Oura's consent page) and store the resulting tokens.
+    @MainActor func authorize(presentationAnchor: ASPresentationAnchor) async throws
+    /// Forget the stored tokens (disconnect).
+    func signOut()
+}
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `xcodebuild -project Strand.xcodeproj -scheme Strand -destination 'platform=macOS' test -only-testing:StrandTests/OuraCredentialsTests CODE_SIGNING_ALLOWED=NO 2>&1 | tail -20`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Strand/Oura/OuraCredentials.swift Strand/Oura/AuthProvider.swift StrandTests/OuraCredentialsTests.swift
+git commit -m "feat(oura): OuraCredentials (Info.plist) + AuthProvider seam"
+```
+
+---
+
+### Task 3: OAuth pure builders + `OuraOAuthProvider`
+
+The authorization-code flow: pure URL/body builders + token-response parser (unit-tested), plus the provider that runs `ASWebAuthenticationSession` and the token-exchange POST.
+
+**Files:**
+- Create: `Strand/Oura/OuraOAuth.swift` (pure builders/parser)
+- Create: `Strand/Oura/OuraOAuthProvider.swift` (`AuthProvider` impl)
+- Test: `StrandTests/OuraOAuthTests.swift`
+
+**Interfaces:**
+- Consumes: `OuraCredentials`, `OuraTokens`, `OuraTokenStore`, `OuraError`, `AuthProvider`.
+- Produces:
+  - `enum OuraOAuth` with pure statics: `authorizeURL(credentials:state:) -> URL`, `tokenExchangeRequest(credentials:code:) -> URLRequest`, `refreshRequest(credentials:refreshToken:) -> URLRequest`, `parseTokenResponse(_ data: Data, now: Date) throws -> OuraTokens`, and `static let scopes: [String]`.
+  - `final class OuraOAuthProvider: AuthProvider` (init `credentials:session:`).
+
+- [ ] **Step 1: Write the failing test**
+
+Create `StrandTests/OuraOAuthTests.swift`:
+
+```swift
+import XCTest
+@testable import Strand
+
+final class OuraOAuthTests: XCTestCase {
+    private let creds = OuraCredentials(clientId: "cid", clientSecret: "sec",
+                                        redirectURI: "noop://oura/callback")
+
+    func testAuthorizeURLHasRequiredParams() throws {
+        let url = OuraOAuth.authorizeURL(credentials: creds, state: "xyz")
+        let comps = try XCTUnwrap(URLComponents(url: url, resolvingAgainstBaseURL: false))
+        XCTAssertEqual(comps.host, "cloud.ouraring.com")
+        XCTAssertEqual(comps.path, "/oauth/authorize")
+        let q = Dictionary(uniqueKeysWithValues: (comps.queryItems ?? []).map { ($0.name, $0.value) })
+        XCTAssertEqual(q["response_type"], "code")
+        XCTAssertEqual(q["client_id"], "cid")
+        XCTAssertEqual(q["redirect_uri"], "noop://oura/callback")
+        XCTAssertEqual(q["state"], "xyz")
+        XCTAssertEqual(q["scope"], OuraOAuth.scopes.joined(separator: " "))
+    }
+
+    func testTokenExchangeRequestIsFormPost() throws {
+        let req = OuraOAuth.tokenExchangeRequest(credentials: creds, code: "the-code")
+        XCTAssertEqual(req.url?.absoluteString, "https://api.ouraring.com/oauth/token")
+        XCTAssertEqual(req.httpMethod, "POST")
+        XCTAssertEqual(req.value(forHTTPHeaderField: "Content-Type"), "application/x-www-form-urlencoded")
+        let body = String(data: req.httpBody ?? Data(), encoding: .utf8) ?? ""
+        XCTAssertTrue(body.contains("grant_type=authorization_code"))
+        XCTAssertTrue(body.contains("code=the-code"))
+        XCTAssertTrue(body.contains("client_id=cid"))
+        XCTAssertTrue(body.contains("client_secret=sec"))
+    }
+
+    func testParseTokenResponseComputesExpiry() throws {
+        let now = Date(timeIntervalSince1970: 1_000_000)
+        let json = #"{"access_token":"acc","refresh_token":"ref","expires_in":86400}"#.data(using: .utf8)!
+        let tokens = try OuraOAuth.parseTokenResponse(json, now: now)
+        XCTAssertEqual(tokens.accessToken, "acc")
+        XCTAssertEqual(tokens.refreshToken, "ref")
+        XCTAssertEqual(tokens.expiresAt, now.addingTimeInterval(86400))
+    }
+
+    func testParseTokenResponseThrowsOnMissingAccessToken() {
+        let json = #"{"error":"invalid_grant"}"#.data(using: .utf8)!
+        XCTAssertThrowsError(try OuraOAuth.parseTokenResponse(json, now: Date()))
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `xcodegen generate && xcodebuild -project Strand.xcodeproj -scheme Strand -destination 'platform=macOS' test -only-testing:StrandTests/OuraOAuthTests CODE_SIGNING_ALLOWED=NO 2>&1 | tail -20`
+Expected: FAIL — `OuraOAuth` undefined.
+
+- [ ] **Step 3: Implement the pure builders/parser**
+
+Create `Strand/Oura/OuraOAuth.swift`:
+
+```swift
+import Foundation
+
+/// Pure (network-free) pieces of the Oura OAuth2 authorization-code flow: URL/request builders and the
+/// token-response parser. Unit-tested directly; the interactive step + the actual POST live in
+/// OuraOAuthProvider. No PKCE (Oura's flow doesn't support it), so the exchange carries the client_secret.
+enum OuraOAuth {
+    static let authorizeEndpoint = URL(string: "https://cloud.ouraring.com/oauth/authorize")!
+    static let tokenEndpoint = URL(string: "https://api.ouraring.com/oauth/token")!
+    static let scopes = ["email", "personal", "daily", "heartrate", "workout", "tag", "session", "spo2Daily"]
+
+    /// The consent URL to open in ASWebAuthenticationSession. `state` is a caller-generated nonce echoed
+    /// back on redirect and verified, to defeat CSRF / stray callbacks.
+    static func authorizeURL(credentials: OuraCredentials, state: String) -> URL {
+        var comps = URLComponents(url: authorizeEndpoint, resolvingAgainstBaseURL: false)!
+        comps.queryItems = [
+            .init(name: "response_type", value: "code"),
+            .init(name: "client_id", value: credentials.clientId),
+            .init(name: "redirect_uri", value: credentials.redirectURI),
+            .init(name: "scope", value: scopes.joined(separator: " ")),
+            .init(name: "state", value: state),
+        ]
+        return comps.url!
+    }
+
+    static func tokenExchangeRequest(credentials: OuraCredentials, code: String) -> URLRequest {
+        form(tokenEndpoint, [
+            "grant_type": "authorization_code",
+            "code": code,
+            "redirect_uri": credentials.redirectURI,
+            "client_id": credentials.clientId,
+            "client_secret": credentials.clientSecret,
+        ])
+    }
+
+    static func refreshRequest(credentials: OuraCredentials, refreshToken: String) -> URLRequest {
+        form(tokenEndpoint, [
+            "grant_type": "refresh_token",
+            "refresh_token": refreshToken,
+            "client_id": credentials.clientId,
+            "client_secret": credentials.clientSecret,
+        ])
+    }
+
+    /// Parse a token endpoint response. `now` is injected so expiry is deterministic in tests.
+    static func parseTokenResponse(_ data: Data, now: Date) throws -> OuraTokens {
+        guard let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let access = obj["access_token"] as? String, !access.isEmpty else {
+            let detail = String(data: data, encoding: .utf8) ?? ""
+            throw OuraError.tokenExchangeFailed(detail)
+        }
+        let refresh = obj["refresh_token"] as? String
+        let expiresIn = (obj["expires_in"] as? Double) ?? (obj["expires_in"] as? Int).map(Double.init) ?? 2_592_000
+        return OuraTokens(accessToken: access, refreshToken: refresh,
+                          expiresAt: now.addingTimeInterval(expiresIn))
+    }
+
+    private static func form(_ url: URL, _ fields: [String: String]) -> URLRequest {
+        var req = URLRequest(url: url)
+        req.httpMethod = "POST"
+        req.setValue("application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
+        var comps = URLComponents()
+        comps.queryItems = fields.map { URLQueryItem(name: $0.key, value: $0.value) }
+        req.httpBody = comps.percentEncodedQuery?.data(using: .utf8)
+        return req
+    }
+}
+```
+
+- [ ] **Step 4: Implement `OuraOAuthProvider`**
+
+Create `Strand/Oura/OuraOAuthProvider.swift`:
+
+```swift
+import Foundation
+import AuthenticationServices
+
+/// BYO-app OAuth2 authorization-code AuthProvider. Runs ASWebAuthenticationSession for the interactive
+/// consent, exchanges the code for tokens (Keychain), and refreshes on demand. The `session` is injected
+/// so the token exchange/refresh POSTs are URLProtocol-testable; the interactive step is integration-only.
+final class OuraOAuthProvider: NSObject, AuthProvider, ASWebAuthenticationPresentationContextProviding {
+    private let credentials: OuraCredentials
+    private let session: URLSession
+    private var anchor: ASPresentationAnchor?
+
+    init(credentials: OuraCredentials, session: URLSession = .shared) {
+        self.credentials = credentials
+        self.session = session
+    }
+
+    var isConnected: Bool { OuraTokenStore.isConnected }
+    func signOut() { OuraTokenStore.clear() }
+
+    func validAccessToken() async throws -> String {
+        guard let tokens = OuraTokenStore.load() else { throw OuraError.notConnected }
+        if !tokens.isExpired { return tokens.accessToken }
+        guard let refresh = tokens.refreshToken else { throw OuraError.notConnected }
+        let req = OuraOAuth.refreshRequest(credentials: credentials, refreshToken: refresh)
+        let refreshed = try await exchange(req)
+        _ = OuraTokenStore.save(refreshed)
+        return refreshed.accessToken
+    }
+
+    @MainActor
+    func authorize(presentationAnchor: ASPresentationAnchor) async throws {
+        self.anchor = presentationAnchor
+        let state = UUID().uuidString
+        let url = OuraOAuth.authorizeURL(credentials: credentials, state: state)
+        let scheme = URL(string: credentials.redirectURI)?.scheme
+
+        let callback: URL = try await withCheckedThrowingContinuation { cont in
+            let webSession = ASWebAuthenticationSession(url: url, callbackURLScheme: scheme) { url, err in
+                if let url { cont.resume(returning: url) }
+                else { cont.resume(throwing: OuraError.authFailed(err?.localizedDescription ?? "cancelled")) }
+            }
+            webSession.presentationContextProvider = self
+            webSession.prefersEphemeralWebBrowserSession = false
+            if !webSession.start() { cont.resume(throwing: OuraError.authFailed("couldn't start web session")) }
+        }
+
+        let items = URLComponents(url: callback, resolvingAgainstBaseURL: false)?.queryItems ?? []
+        let q = Dictionary(uniqueKeysWithValues: items.map { ($0.name, $0.value ?? "") })
+        guard q["state"] == state else { throw OuraError.authFailed("state mismatch") }
+        guard let code = q["code"], !code.isEmpty else { throw OuraError.authFailed(q["error"] ?? "no code") }
+
+        let tokens = try await exchange(OuraOAuth.tokenExchangeRequest(credentials: credentials, code: code))
+        guard OuraTokenStore.save(tokens) else { throw OuraError.tokenExchangeFailed("keychain write failed") }
+    }
+
+    /// POST a token request and parse the response (shared by exchange + refresh).
+    private func exchange(_ req: URLRequest) async throws -> OuraTokens {
+        let (data, resp): (Data, URLResponse)
+        do { (data, resp) = try await session.data(for: req) }
+        catch { throw OuraError.network(error.localizedDescription) }
+        let code = (resp as? HTTPURLResponse)?.statusCode ?? 0
+        guard (200..<300).contains(code) else {
+            throw OuraError.tokenExchangeFailed("HTTP \(code): \(String(data: data, encoding: .utf8) ?? "")")
+        }
+        return try OuraOAuth.parseTokenResponse(data, now: Date())
+    }
+
+    func presentationAnchor(for session: ASWebAuthenticationSession) -> ASPresentationAnchor {
+        anchor ?? ASPresentationAnchor()
+    }
+}
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `xcodebuild -project Strand.xcodeproj -scheme Strand -destination 'platform=macOS' test -only-testing:StrandTests/OuraOAuthTests CODE_SIGNING_ALLOWED=NO 2>&1 | tail -20`
+Expected: PASS (4 tests). Note in the report: `OuraOAuthProvider.authorize` (the interactive ASWebAuthenticationSession step) is compile-verified here but exercised only in live/integration testing — its pure inputs (`authorizeURL`, exchange request, response parse) and the exchange POST path are what the tests cover.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Strand/Oura/OuraOAuth.swift Strand/Oura/OuraOAuthProvider.swift StrandTests/OuraOAuthTests.swift
+git commit -m "feat(oura): OAuth2 authorization-code flow (pure builders + OuraOAuthProvider)"
+```
+
+---
+
+### Task 4: `OuraAPIClient` — paging + backoff
+
+The `URLSession` client: per-endpoint fetch, `next_token` paging, 429 backoff, 401 refresh-once, prod/sandbox base URL. Pure envelope parser split out for unit tests; the networked paths driven by a `URLProtocol` stub.
+
+**Files:**
+- Create: `Strand/Oura/OuraAPIClient.swift`
+- Create: `StrandTests/OuraURLProtocolStub.swift` (reusable stub)
+- Test: `StrandTests/OuraAPIClientTests.swift`
+
+**Interfaces:**
+- Consumes: `AuthProvider`, `OuraError`.
+- Produces:
+  - `enum OuraEnvironment { case production, sandbox; var baseURL: String }`
+  - `struct OuraPage { let data: [[String: Any]]; let nextToken: String? }` — intentionally NOT `Equatable` (`[[String: Any]]` isn't); tests assert on `.count`/fields.
+  - `enum OuraAPI` pure: `static func parsePage(_ data: Data) throws -> OuraPage`.
+  - `final class OuraAPIClient` init `auth:environment:session:` with `func fetchAll(endpoint: String, query: [String: String]) async throws -> [[String: Any]]` (follows `next_token`, returns concatenated `data`), and `func fetchAllRaw(endpoint:query:) async throws -> [Data]` (the verbatim page bodies for Plan 3's raw archive).
+
+- [ ] **Step 1: Write the failing test + the URLProtocol stub**
+
+Create `StrandTests/OuraURLProtocolStub.swift`:
+
+```swift
+import Foundation
+
+/// Test-only URLProtocol that serves canned responses by request order, so the paging loop and
+/// status-code handling are driven deterministically without a live socket.
+final class OuraURLProtocolStub: URLProtocol {
+    struct Stubbed { let status: Int; let body: Data }
+    /// FIFO queue of responses; each request pops the next. Set before the test acts.
+    nonisolated(unsafe) static var queue: [Stubbed] = []
+    /// Captured request URLs, in order, for assertions.
+    nonisolated(unsafe) static var requestedURLs: [URL] = []
+
+    static func reset() { queue = []; requestedURLs = [] }
+
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+    override func startLoading() {
+        if let u = request.url { Self.requestedURLs.append(u) }
+        let s = Self.queue.isEmpty ? Stubbed(status: 500, body: Data()) : Self.queue.removeFirst()
+        let resp = HTTPURLResponse(url: request.url!, statusCode: s.status, httpVersion: nil, headerFields: nil)!
+        client?.urlProtocol(self, didReceive: resp, cacheStoragePolicy: .notAllowed)
+        client?.urlProtocol(self, didLoad: s.body)
+        client?.urlProtocolDidFinishLoading(self)
+    }
+    override func stopLoading() {}
+
+    /// A URLSession wired to this stub.
+    static func session() -> URLSession {
+        let cfg = URLSessionConfiguration.ephemeral
+        cfg.protocolClasses = [OuraURLProtocolStub.self]
+        return URLSession(configuration: cfg)
+    }
+}
+```
+
+Create `StrandTests/OuraAPIClientTests.swift`:
+
+```swift
+import XCTest
+import AuthenticationServices
+@testable import Strand
+
+/// A stub AuthProvider that hands out a fixed token and counts refreshes.
+private final class StubAuth: AuthProvider {
+    var token = "tok-1"
+    var validCalls = 0
+    var isConnected: Bool { true }
+    func validAccessToken() async throws -> String { validCalls += 1; return token }
+    @MainActor func authorize(presentationAnchor: ASPresentationAnchor) async throws {}
+    func signOut() {}
+}
+
+final class OuraAPIClientTests: XCTestCase {
+    override func setUp() { super.setUp(); OuraURLProtocolStub.reset() }
+
+    func testParsePageExtractsDataAndNextToken() throws {
+        let json = #"{"data":[{"id":"a"},{"id":"b"}],"next_token":"tok2"}"#.data(using: .utf8)!
+        let page = try OuraAPI.parsePage(json)
+        XCTAssertEqual(page.data.count, 2)
+        XCTAssertEqual(page.nextToken, "tok2")
+    }
+
+    func testFetchAllFollowsNextTokenThenStops() async throws {
+        OuraURLProtocolStub.queue = [
+            .init(status: 200, body: #"{"data":[{"id":"a"}],"next_token":"t2"}"#.data(using: .utf8)!),
+            .init(status: 200, body: #"{"data":[{"id":"b"}],"next_token":null}"#.data(using: .utf8)!),
+        ]
+        let client = OuraAPIClient(auth: StubAuth(), environment: .production,
+                                   session: OuraURLProtocolStub.session())
+        let rows = try await client.fetchAll(endpoint: "daily_sleep", query: ["start_date": "2026-01-01"])
+        XCTAssertEqual(rows.count, 2)
+        // Second request carried next_token=t2.
+        XCTAssertTrue(OuraURLProtocolStub.requestedURLs.last?.absoluteString.contains("next_token=t2") ?? false)
+    }
+
+    func test429IsRetriedAfterBackoff() async throws {
+        OuraURLProtocolStub.queue = [
+            .init(status: 429, body: Data()),
+            .init(status: 200, body: #"{"data":[{"id":"a"}],"next_token":null}"#.data(using: .utf8)!),
+        ]
+        let client = OuraAPIClient(auth: StubAuth(), environment: .production,
+                                   session: OuraURLProtocolStub.session(), backoff: 0)
+        let rows = try await client.fetchAll(endpoint: "daily_sleep", query: [:])
+        XCTAssertEqual(rows.count, 1)
+    }
+
+    func testSandboxBaseURL() async throws {
+        OuraURLProtocolStub.queue = [.init(status: 200,
+            body: #"{"data":[],"next_token":null}"#.data(using: .utf8)!)]
+        let client = OuraAPIClient(auth: StubAuth(), environment: .sandbox,
+                                   session: OuraURLProtocolStub.session())
+        _ = try await client.fetchAll(endpoint: "personal_info", query: [:])
+        XCTAssertTrue(OuraURLProtocolStub.requestedURLs.first?.absoluteString.contains("/v2/sandbox/") ?? false)
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `xcodegen generate && xcodebuild -project Strand.xcodeproj -scheme Strand -destination 'platform=macOS' test -only-testing:StrandTests/OuraAPIClientTests CODE_SIGNING_ALLOWED=NO 2>&1 | tail -20`
+Expected: FAIL — `OuraAPIClient` / `OuraAPI` undefined.
+
+- [ ] **Step 3: Implement `OuraAPIClient`**
+
+Create `Strand/Oura/OuraAPIClient.swift`:
+
+```swift
+import Foundation
+
+enum OuraEnvironment {
+    case production, sandbox
+    var baseURL: String {
+        switch self {
+        case .production: return "https://api.ouraring.com/v2/usercollection"
+        case .sandbox:    return "https://api.ouraring.com/v2/sandbox/usercollection"
+        }
+    }
+}
+
+/// One decoded page of an Oura list/time-series response.
+struct OuraPage {
+    let data: [[String: Any]]
+    let nextToken: String?
+}
+
+/// Pure (network-free) response-envelope parsing, unit-tested directly.
+enum OuraAPI {
+    static func parsePage(_ data: Data) throws -> OuraPage {
+        guard let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            throw OuraError.decode
+        }
+        let rows = (obj["data"] as? [[String: Any]]) ?? []
+        return OuraPage(data: rows, nextToken: obj["next_token"] as? String)
+    }
+}
+
+/// The Oura v2 API client. Injected `AuthProvider` supplies the bearer token (refreshing on expiry);
+/// injected `session` makes it URLProtocol-testable. Follows `next_token` paging, retries 429 with a
+/// bounded backoff, and refreshes-once on 401. Networking lives here in the app target by design.
+final class OuraAPIClient {
+    private let auth: AuthProvider
+    private let environment: OuraEnvironment
+    private let session: URLSession
+    private let backoff: TimeInterval
+    private let maxPages = 10_000   // runaway guard (logged if hit)
+
+    init(auth: AuthProvider, environment: OuraEnvironment = .production,
+         session: URLSession = .shared, backoff: TimeInterval = 2) {
+        self.auth = auth
+        self.environment = environment
+        self.session = session
+        self.backoff = backoff
+    }
+
+    /// Fetch every page of `endpoint` for `query`, following `next_token`, returning concatenated rows.
+    func fetchAll(endpoint: String, query: [String: String]) async throws -> [[String: Any]] {
+        var rows: [[String: Any]] = []
+        try await forEachPage(endpoint: endpoint, query: query) { page in rows.append(contentsOf: page.data) }
+        return rows
+    }
+
+    /// Fetch every page, returning the verbatim page bodies (for Plan 3's lossless raw archive).
+    func fetchAllRaw(endpoint: String, query: [String: String]) async throws -> [Data] {
+        var bodies: [Data] = []
+        try await forEachPage(endpoint: endpoint, query: query, rawSink: { bodies.append($0) }) { _ in }
+        return bodies
+    }
+
+    private func forEachPage(endpoint: String, query: [String: String],
+                             rawSink: ((Data) -> Void)? = nil,
+                             _ handle: (OuraPage) -> Void) async throws {
+        var next: String? = nil
+        var pages = 0
+        repeat {
+            var q = query
+            if let next { q["next_token"] = next }
+            let (data, _) = try await getWithRetry(endpoint: endpoint, query: q)
+            rawSink?(data)
+            let page = try OuraAPI.parsePage(data)
+            handle(page)
+            next = page.nextToken
+            pages += 1
+            if pages >= maxPages { break }   // Plan-3 note: log if this cap is ever hit.
+        } while next != nil
+    }
+
+    /// GET with auth + 429-backoff + 401-refresh-once. Returns (body, status).
+    private func getWithRetry(endpoint: String, query: [String: String]) async throws -> (Data, Int) {
+        for attempt in 0..<3 {
+            let token = try await auth.validAccessToken()
+            let (data, code) = try await get(endpoint: endpoint, query: query, token: token)
+            switch code {
+            case 200..<300:
+                return (data, code)
+            case 429:
+                if backoff > 0 { try? await Task.sleep(nanoseconds: UInt64(backoff * 1_000_000_000)) }
+                continue
+            case 401 where attempt == 0:
+                _ = try? await auth.validAccessToken()   // force a refresh, then retry once
+                continue
+            default:
+                throw OuraError.badResponse(code, String(data: data, encoding: .utf8) ?? "")
+            }
+        }
+        throw OuraError.rateLimited
+    }
+
+    private func get(endpoint: String, query: [String: String], token: String) async throws -> (Data, Int) {
+        var comps = URLComponents(string: "\(environment.baseURL)/\(endpoint)")!
+        if !query.isEmpty { comps.queryItems = query.map { URLQueryItem(name: $0.key, value: $0.value) } }
+        var req = URLRequest(url: comps.url!)
+        req.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        do {
+            let (data, resp) = try await session.data(for: req)
+            return (data, (resp as? HTTPURLResponse)?.statusCode ?? 0)
+        } catch {
+            throw OuraError.network(error.localizedDescription)
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `xcodebuild -project Strand.xcodeproj -scheme Strand -destination 'platform=macOS' test -only-testing:StrandTests/OuraAPIClientTests CODE_SIGNING_ALLOWED=NO 2>&1 | tail -20`
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Strand/Oura/OuraAPIClient.swift StrandTests/OuraURLProtocolStub.swift StrandTests/OuraAPIClientTests.swift
+git commit -m "feat(oura): OuraAPIClient — next_token paging, 429 backoff, 401 refresh, sandbox/prod"
+```
+
+---
+
+### Task 5: Wiring — Info.plist redirect scheme + xcconfig credentials
+
+Register the OAuth redirect URL scheme and wire the untracked credentials xcconfig. No unit test (build config); verify the app still generates + builds.
+
+**Files:**
+- Modify: `project.yml` (add `CFBundleURLTypes` to the `Strand` and `NOOPiOS` targets' Info settings + reference the xcconfig)
+- Create: `Strand/Oura/OuraSecrets.example.xcconfig` (committed template)
+- Modify: `.gitignore` (ignore `Strand/Oura/OuraSecrets.xcconfig`)
+
+**Interfaces:** none (configuration). Provides the Info.plist keys `OURA_CLIENT_ID`/`OURA_CLIENT_SECRET`/`OURA_REDIRECT_URI` and the `noop` URL scheme that Tasks 2–3 read.
+
+- [ ] **Step 1: Add the example xcconfig**
+
+Create `Strand/Oura/OuraSecrets.example.xcconfig`:
+
+```
+// Copy to OuraSecrets.xcconfig (gitignored) and fill in your own Oura OAuth app's values.
+// Register a free app at the Oura developer portal; set the redirect URI to noop://oura/callback.
+OURA_CLIENT_ID = your_client_id_here
+OURA_CLIENT_SECRET = your_client_secret_here
+OURA_REDIRECT_URI = noop://oura/callback
+```
+
+- [ ] **Step 2: Ignore the real xcconfig**
+
+Add to `.gitignore` (append):
+
+```
+# Oura BYO-app OAuth credentials (never committed)
+Strand/Oura/OuraSecrets.xcconfig
+```
+
+- [ ] **Step 3: Wire the xcconfig + URL scheme in `project.yml`**
+
+Under the `Strand` target (and the same under `NOOPiOS`), reference the xcconfig via `configFiles` and add the Info.plist keys. Add to the target's `settings` / `info` block:
+
+```yaml
+    # (within target: Strand)
+    configFiles:
+      Debug: Strand/Oura/OuraSecrets.xcconfig
+      Release: Strand/Oura/OuraSecrets.xcconfig
+    info:
+      path: Strand/Resources/Info.plist
+      properties:
+        OURA_CLIENT_ID: $(OURA_CLIENT_ID)
+        OURA_CLIENT_SECRET: $(OURA_CLIENT_SECRET)
+        OURA_REDIRECT_URI: $(OURA_REDIRECT_URI)
+        CFBundleURLTypes:
+          - CFBundleURLSchemes: [noop]
+```
+
+(If `configFiles` already exists on the target, merge these keys in. The exact YAML location must match the existing `project.yml` structure — read it first.)
+
+- [ ] **Step 4: Verify generate + build**
+
+Create an `OuraSecrets.xcconfig` with placeholder values (so the build resolves the variables), then:
+
+Run: `xcodegen generate && xcodebuild -project Strand.xcodeproj -scheme Strand -destination 'platform=macOS' build-for-testing CODE_SIGNING_ALLOWED=NO 2>&1 | tail -15`
+Expected: `** TEST BUILD SUCCEEDED **`. Then confirm the Info.plist keys resolve: the `OuraCredentials.fromBundle` path will read them at runtime.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add project.yml .gitignore Strand/Oura/OuraSecrets.example.xcconfig
+git commit -m "chore(oura): wire OAuth redirect scheme + BYO-app credentials xcconfig"
+```
+
+---
+
+## Plan 2 self-review
+
+- **Spec coverage:** §5 auth (BYO-app, ASWebAuthenticationSession, Keychain, AuthProvider seam) → T1/T2/T3; §6 API client (paging, 429/401, prod/sandbox, bounded) → T4; §5.3 credentials (xcconfig→Info.plist) → T2/T5; redirect scheme → T5. `fetchAllRaw` (T4) is the seam Plan 3's writer consumes for the lossless archive.
+- **Constraints:** networking confined to `Strand/Oura/`; no package touched; tokens Keychain-only; `session` injected everywhere (URLProtocol-testable); no PKCE (secret in the exchange, sourced from the user's own untracked xcconfig).
+- **Interactive boundary is honest:** `OuraOAuthProvider.authorize`'s ASWebAuthenticationSession step is compile-verified + integration-tested, not unit-tested; everything around it (URL/body builders, token parse, exchange POST, paging, backoff, refresh) IS unit-tested via pure functions + the URLProtocol stub.
+- **Type consistency:** `OuraTokens`/`OuraCredentials`/`OuraError` defined in T1/T2 and consumed unchanged in T3/T4; `AuthProvider` defined T2, implemented T3, injected T4; `OuraPage` is intentionally NOT `Equatable` (holds `[[String: Any]]`) — tests assert on fields.
+- **Build reality:** every test step uses `xcodebuild -only-testing:StrandTests/<Class>` (first build full, then incremental); `swift test` is NOT used here (app target, not a package).
+
+## What Plan 3 adds (next)
+
+`OuraSyncCoordinator` (one-time backfill across all ~18 endpoints via `OuraAPIClient.fetchAllRaw` + parse via Plan 1's `OuraApiParser`) → `OuraSyncWriter` (raw archive via `upsertOuraRaw`; normalized via `upsertDailyMetrics`/`upsertSleepSessions`(+stagesJSON via decoded stages, +`persistSessionMotion`)/`upsertMetricSeries`/`insert(hrSample)`/`upsertWorkouts`; register `PairedDevice(sourceKind: .cloudImport)`; **coalesce** per-day rows, prefer readiness RHR, map sleep-score/vo2max onto the daily columns — per the Plan-1 final-review advisories) → the "Connect Oura & Import Everything" UI on `DataSourcesView` + progress/summary/disconnect → doc updates (`PRIVACY_SECURITY.md` second opt-in lane, `DEVICE_SUPPORT_ROADMAP.md`, `DATA_MODEL.md` v24 `ouraRaw`).

--- a/docs/superpowers/plans/2026-06-27-oura-live-api-import-3-orchestration-ui.md
+++ b/docs/superpowers/plans/2026-06-27-oura-live-api-import-3-orchestration-ui.md
@@ -1,0 +1,685 @@
+# Oura Live API Import — Plan 3: Orchestration + Writer + Connect UI
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Turn Plan 1's parsers + Plan 2's client/auth into a working, tappable feature — a one-time backfill that fetches every Oura v2 endpoint, writes the normalized subset + lossless raw into `WhoopStore` under `deviceId = "oura-api"`, and a "Connect Oura & Import Everything" card on Data Sources.
+
+**Architecture:** `OuraSyncCoordinator` (fetch all endpoints via `OuraAPIClient.fetchAllRaw`, parse via Plan 1's `OuraApiParser`, merge per-day rows, hand an assembled `OuraSyncResult` to the writer) → `OuraSyncWriter` (register the `PairedDevice`, then map the result to the existing `WhoopStore` upserts, archiving every raw page). All in the app target `Strand/Oura/`, beside Plan 2. The writer mirrors `Strand/Data/WearableImporter.swift`; the UI mirrors `DataSourcesView`'s existing import cards. Honest-data + no-day-ownership-seizure are structural (see constraints).
+
+**Tech stack:** Swift 5.0 mode (app target), `Foundation` + `AuthenticationServices` + SwiftUI. XCTest in `StrandTests`, run via `xcodebuild -scheme Strand test` (the `TEST_HOST` fix from Plan 2 makes this work). Store-writing tests use `WhoopStore.inMemory()`.
+
+## Global Constraints
+
+- **App-target only.** Files live in `Strand/Oura/` (+ one `WhoopStore` addition in Task 3, + edits in Task 5). No package gains networking.
+- **Provenance = `deviceId "oura-api"`, `sourceKind .cloudImport`.** `.cloudImport` is structurally priority-2 in `DayOwnerResolver` (`IntelligenceEngine.swift:1369`: `isImport = .cloudImport || .fileImport` → priority 2, lowest), so the cloud source **can never seize a day from the active WHOOP or any live BLE device** — this is automatic from the `sourceKind` alone. **Never call `setDayOwner`.**
+- **Honest data.** Oura's own scores go ONLY to `ref_*` / `oura_*` `metricSeries` keys (from the `[OuraDailyExtra]` array), never to `DailyMetric.recovery`/`.strain` (always `nil`). Mirror `WearableImporter`.
+- **Coalesce, prefer readiness RHR.** A single day gets a `WearableDailyRow` from `parseSleep` AND from each `parseDaily(_, endpoint:)`. Merge them into ONE `[String: WearableDailyRow]` with first-non-nil-wins (`??`), merging the **daily endpoints (readiness) BEFORE `sleep`**, so `daily_readiness`'s true `resting_heart_rate` wins over `parseSleep`'s `lowestHr` fallback (Plan-1 final-review advisory).
+- **Lossless raw.** Every fetched page → `upsertOuraRaw` regardless of whether a parser exists for that endpoint (8 of 18 endpoints are raw-only).
+- **Reuse, don't reinvent.** `DailyMetric`/`CachedSleepSession`/`MetricPoint`/`WorkoutRow`/`HRSample`/`Streams` inits are exact (see each task); `WhoopStore.inMemory()`, `store.registryWriter` (public nonisolated), `repo.refresh()`, `repo.storeHandle()` all exist.
+- **Build/test:** `xcodegen generate` (after new files) then `xcodebuild -project Strand.xcodeproj -scheme Strand -destination 'platform=macOS' test -only-testing:StrandTests/<Class> CODE_SIGNING_ALLOWED=NO`.
+
+---
+
+### Task 1: `OuraSyncResult` + `OuraSyncWriter`
+
+The assembled-result model + the persistence mapper. Mirrors `WearableImporter`, adds device registration + `persistSessionMotion` + hrSample + raw archive.
+
+**Files:**
+- Create: `Strand/Oura/OuraSyncResult.swift`
+- Create: `Strand/Oura/OuraSyncWriter.swift`
+- Test: `StrandTests/OuraSyncWriterTests.swift`
+
+**Interfaces:**
+- Consumes (Plan 1, StrandImport): `WearableDailyRow`, `OuraSleepPeriod`, `OuraHRPoint`, `OuraDailyExtra`, `OuraWorkout`, `WearableSleepStageInterval`, `OuraRawRow`. (WhoopStore/WhoopProtocol) `DailyMetric`, `CachedSleepSession`, `MetricPoint`, `WorkoutRow`, `HRSample`, `Streams`, `PairedDevice`, `SourceKind`, `DeviceRegistryStore`, `WhoopStore`.
+- Produces:
+  - `struct OuraSyncResult { var days: [WearableDailyRow]; var sleepPeriods: [OuraSleepPeriod]; var extras: [OuraDailyExtra]; var workouts: [OuraWorkout]; var heartRate: [OuraHRPoint]; var rawPages: [OuraRawRow]; var ringModel: String? }`
+  - `struct OuraSyncSummary: Equatable { var days: Int; var sleeps: Int; var workouts: Int; var hrSamples: Int; var metricPoints: Int; var rawPages: Int }`
+  - `enum OuraSyncWriter { static func persist(_ result: OuraSyncResult, into store: WhoopStore, deviceId: String = "oura-api") async throws -> OuraSyncSummary }`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `StrandTests/OuraSyncWriterTests.swift`:
+
+```swift
+import XCTest
+import WhoopStore
+import WhoopProtocol
+@testable import StrandImport
+@testable import Strand
+
+final class OuraSyncWriterTests: XCTestCase {
+    private func iso(_ s: String) -> Date { ISO8601DateFormatter().date(from: s)! }
+
+    func testPersistWritesAllStoresAndRegistersCloudSource() async throws {
+        let store = try await WhoopStore.inMemory()
+
+        var day = WearableDailyRow(day: "2026-01-02")
+        day.restingHr = 50; day.steps = 9000; day.totalSleepMin = 400
+
+        let session = WearableSleepSession(
+            start: iso("2026-01-01T23:00:00Z"), end: iso("2026-01-02T06:00:00Z"),
+            deepMin: 100, lightMin: 200, remMin: 100, awakeMin: 20, totalSleepMin: 400,
+            efficiencyPct: 92, avgHr: 55, lowestHr: 48, avgHrvMs: 65, respRateBpm: 14,
+            sleepScore: nil, stages: [WearableSleepStageInterval(stage: "deep",
+                start: iso("2026-01-01T23:00:00Z"), end: iso("2026-01-01T23:05:00Z"))])
+        let period = OuraSleepPeriod(session: session, movement30s: [1, 2, 1],
+                                     hr: [OuraHRPoint(ts: Int(iso("2026-01-01T23:00:00Z").timeIntervalSince1970), bpm: 60)])
+
+        let result = OuraSyncResult(
+            days: [day], sleepPeriods: [period],
+            extras: [OuraDailyExtra(day: "2026-01-02", key: "ref_readiness_score", value: 80),
+                     OuraDailyExtra(day: "2026-01-02", key: "vo2max", value: 44)],
+            workouts: [OuraWorkout(start: iso("2026-01-02T07:00:00Z"), end: iso("2026-01-02T07:40:00Z"),
+                                   activity: "running", source: "autodetected", energyKcal: 410, distanceM: 6200)],
+            heartRate: [OuraHRPoint(ts: Int(iso("2026-01-02T07:00:00Z").timeIntervalSince1970), bpm: 120)],
+            rawPages: [OuraRawRow(endpoint: "sleep", documentId: "s1", day: "2026-01-02",
+                                  payloadJSON: "{}", fetchedAt: 100)],
+            ringModel: "Oura Ring Gen3")
+
+        let summary = try await OuraSyncWriter.persist(result, into: store)
+
+        XCTAssertEqual(summary.days, 1)
+        XCTAssertEqual(summary.sleeps, 1)
+        XCTAssertEqual(summary.workouts, 1)
+        XCTAssertGreaterThan(summary.hrSamples, 0)     // in-sleep + whole-day HR
+        XCTAssertGreaterThan(summary.metricPoints, 0)
+        XCTAssertEqual(summary.rawPages, 1)
+
+        // Cloud source registered as .cloudImport (so it never seizes a WHOOP day).
+        let devices = try DeviceRegistryStore(dbQueue: store.registryWriter).all()
+        let oura = devices.first { $0.id == "oura-api" }
+        XCTAssertEqual(oura?.sourceKind, .cloudImport)
+        XCTAssertEqual(oura?.model, "Oura Ring Gen3")
+
+        // Honest data: the reference score is a metricSeries key, never a DailyMetric score column.
+        let refs = try await store.metricSeries(deviceId: "oura-api", key: "ref_readiness_score",
+                                                 from: "2026-01-01", to: "2026-01-03")
+        XCTAssertEqual(refs.first?.value, 80)
+        let vo2 = try await store.metricSeries(deviceId: "oura-api", key: "vo2max",
+                                               from: "2026-01-01", to: "2026-01-03")
+        XCTAssertEqual(vo2.first?.value, 44)          // vo2max parity via extras
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `xcodegen generate && xcodebuild -project Strand.xcodeproj -scheme Strand -destination 'platform=macOS' test -only-testing:StrandTests/OuraSyncWriterTests CODE_SIGNING_ALLOWED=NO 2>&1 | tail -20`
+Expected: FAIL — `OuraSyncResult`/`OuraSyncWriter` undefined.
+
+- [ ] **Step 3: Implement `OuraSyncResult`**
+
+Create `Strand/Oura/OuraSyncResult.swift`:
+
+```swift
+import Foundation
+import StrandImport
+
+/// The fully-assembled, parsed output of one Oura backfill, ready to persist. The coordinator (Task 2)
+/// builds this (merging per-day rows across endpoints); the writer (below) maps it to WhoopStore.
+struct OuraSyncResult {
+    var days: [WearableDailyRow]        // already coalesced per calendar day
+    var sleepPeriods: [OuraSleepPeriod]
+    var extras: [OuraDailyExtra]        // every ref_*/oura_*/vo2max scalar → metricSeries
+    var workouts: [OuraWorkout]
+    var heartRate: [OuraHRPoint]        // from the /heartrate endpoint (whole-day)
+    var rawPages: [OuraRawRow]          // every fetched page, verbatim
+    var ringModel: String?             // from ring_configuration, for the PairedDevice model
+
+    init(days: [WearableDailyRow] = [], sleepPeriods: [OuraSleepPeriod] = [], extras: [OuraDailyExtra] = [],
+         workouts: [OuraWorkout] = [], heartRate: [OuraHRPoint] = [], rawPages: [OuraRawRow] = [],
+         ringModel: String? = nil) {
+        self.days = days; self.sleepPeriods = sleepPeriods; self.extras = extras
+        self.workouts = workouts; self.heartRate = heartRate; self.rawPages = rawPages; self.ringModel = ringModel
+    }
+}
+
+/// Counts written, for the honest import summary.
+struct OuraSyncSummary: Equatable {
+    var days = 0, sleeps = 0, workouts = 0, hrSamples = 0, metricPoints = 0, rawPages = 0
+}
+```
+
+- [ ] **Step 4: Implement `OuraSyncWriter`**
+
+Create `Strand/Oura/OuraSyncWriter.swift`:
+
+```swift
+import Foundation
+import WhoopStore
+import WhoopProtocol
+import StrandImport
+
+/// Maps an assembled `OuraSyncResult` into the on-device WhoopStore under `deviceId = "oura-api"` — the
+/// cloud sibling of `Strand/Data/WearableImporter.swift`. HONEST DATA: Oura's own scores go only to
+/// ref_*/oura_* metricSeries keys; `DailyMetric.recovery`/`.strain` stay nil. The source registers as
+/// `.cloudImport`, which is structurally priority-2 in DayOwnerResolver, so it never seizes a WHOOP day.
+enum OuraSyncWriter {
+
+    @discardableResult
+    static func persist(_ result: OuraSyncResult, into store: WhoopStore,
+                        deviceId: String = "oura-api") async throws -> OuraSyncSummary {
+        var summary = OuraSyncSummary()
+
+        // 0. Register the cloud source (the one thing WearableImporter skips). Idempotent by id.
+        let now = Int(Date().timeIntervalSince1970)
+        let device = PairedDevice(
+            id: deviceId, brand: "Oura", model: result.ringModel ?? "Oura (cloud)",
+            sourceKind: .cloudImport, capabilities: [], status: .active,
+            addedAt: now, lastSeenAt: now)
+        try DeviceRegistryStore(dbQueue: store.registryWriter).add(device)
+
+        // 1. Raw archive — verbatim, every page, lossless.
+        if !result.rawPages.isEmpty {
+            summary.rawPages = try await store.upsertOuraRaw(result.rawPages, deviceId: deviceId)
+        }
+
+        // 2. Days → DailyMetric. recovery/strain ALWAYS nil (never Oura's readiness). Mirrors WearableImporter.
+        let metrics = result.days.map { d in
+            DailyMetric(day: d.day, totalSleepMin: d.totalSleepMin, efficiency: d.efficiencyPct,
+                        deepMin: d.deepMin, remMin: d.remMin, lightMin: d.lightMin, disturbances: nil,
+                        restingHr: d.restingHr, avgHrv: d.avgHrvMs, recovery: nil, strain: nil,
+                        exerciseCount: nil, spo2Pct: d.spo2Pct, skinTempDevC: d.skinTempDevC,
+                        respRateBpm: d.respRateBpm, steps: d.steps, activeKcalEst: d.activeKcal)
+        }
+        summary.days = try await store.upsertDailyMetrics(metrics, deviceId: deviceId)
+
+        // 3. Sleep sessions → CachedSleepSession (+ stagesJSON), then per-session motion via the dedicated setter.
+        var sessions: [CachedSleepSession] = []
+        for p in result.sleepPeriods {
+            let startTs = Int(p.session.start.timeIntervalSince1970)
+            let endTs = Int(p.session.end.timeIntervalSince1970)
+            sessions.append(CachedSleepSession(
+                startTs: startTs, endTs: endTs, efficiency: p.session.efficiencyPct,
+                restingHr: p.session.lowestHr ?? p.session.avgHr, avgHrv: p.session.avgHrvMs,
+                stagesJSON: stagesJSON(p.session.stages)))
+        }
+        summary.sleeps = try await store.upsertSleepSessions(sessions, deviceId: deviceId)
+        for p in result.sleepPeriods where !p.movement30s.isEmpty {   // motionJSON is NOT on the sleep upsert
+            _ = try await store.persistSessionMotion(
+                deviceId: deviceId, sessionStart: Int(p.session.start.timeIntervalSince1970),
+                motionEpochs: p.movement30s.map(Double.init))
+        }
+
+        // 4. HR → hrSample via the Streams insert path (in-sleep HR + the whole-day /heartrate series).
+        var hr: [HRSample] = result.heartRate.map { HRSample(ts: $0.ts, bpm: $0.bpm) }
+        for p in result.sleepPeriods { hr.append(contentsOf: p.hr.map { HRSample(ts: $0.ts, bpm: $0.bpm) }) }
+        if !hr.isEmpty {
+            let counts = try await store.insert(Streams(hr: hr), deviceId: deviceId)
+            summary.hrSamples = counts.hr
+        }
+
+        // 5. Workouts → WorkoutRow.
+        let workouts = result.workouts.map { w in
+            WorkoutRow(startTs: Int(w.start.timeIntervalSince1970), endTs: Int(w.end.timeIntervalSince1970),
+                       sport: w.activity, source: w.source, durationS: w.end.timeIntervalSince(w.start),
+                       energyKcal: w.energyKcal, avgHr: nil, maxHr: nil, strain: nil,
+                       distanceM: w.distanceM, zonesJSON: nil, notes: nil)
+        }
+        summary.workouts = try await store.upsertWorkouts(workouts, deviceId: deviceId)
+
+        // 6. Extras → metricSeries (ref_*/oura_*/vo2max — parity with the file-import lane, sourced from
+        //    the extras array so vo2max/ref_sleep_score are never lost even though DailyMetric lacks them).
+        let points = result.extras.map { MetricPoint(day: $0.day, key: $0.key, value: $0.value) }
+        summary.metricPoints = try await store.upsertMetricSeries(points, deviceId: deviceId)
+
+        return summary
+    }
+
+    /// Serialize decoded stages to the `[{start,end,stage}]` JSON the cache stores (same shape as WearableImporter).
+    private static func stagesJSON(_ stages: [WearableSleepStageInterval]) -> String? {
+        guard !stages.isEmpty else { return nil }
+        let segs = stages.map { ["start": Int($0.start.timeIntervalSince1970),
+                                 "end": Int($0.end.timeIntervalSince1970), "stage": $0.stage] as [String: Any] }
+        return (try? JSONSerialization.data(withJSONObject: segs)).flatMap { String(data: $0, encoding: .utf8) }
+    }
+}
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `xcodebuild -project Strand.xcodeproj -scheme Strand -destination 'platform=macOS' test -only-testing:StrandTests/OuraSyncWriterTests CODE_SIGNING_ALLOWED=NO 2>&1 | tail -20`
+Expected: PASS. (If `PairedDevice`'s `status`/`capabilities` types differ — e.g. `DeviceStatus` has no `.active`, or `capabilities` isn't `Set<Metric>` — read `Packages/WhoopStore/Sources/WhoopStore/PairedDevice.swift` and adjust the enum case / empty-set literal to match; keep behavior identical. Report any such adjustment.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Strand/Oura/OuraSyncResult.swift Strand/Oura/OuraSyncWriter.swift StrandTests/OuraSyncWriterTests.swift
+git commit -m "feat(oura): OuraSyncWriter — persist backfill to WhoopStore as .cloudImport source"
+```
+
+---
+
+### Task 2: `OuraSyncCoordinator`
+
+Fetch every endpoint, parse, merge per-day rows (readiness before sleep), assemble the `OuraSyncResult`, persist, report progress.
+
+**Files:**
+- Create: `Strand/Oura/OuraSyncCoordinator.swift`
+- Test: `StrandTests/OuraSyncCoordinatorTests.swift`
+
+**Interfaces:**
+- Consumes: `OuraAPIClient` (Plan 2), `OuraApiParser` (Plan 1), `OuraSyncWriter`/`OuraSyncResult` (Task 1), `WhoopStore`, `OuraError`.
+- Produces:
+  - `protocol OuraPageFetching { func fetchAllRaw(endpoint: String, query: [String: String]) async throws -> [Data] }` (+ `extension OuraAPIClient: OuraPageFetching {}`)
+  - `struct OuraSyncProgress: Equatable { let endpoint: String; let pages: Int }`
+  - `final class OuraSyncCoordinator` with `init(fetcher: OuraPageFetching, store: WhoopStore)` and `func runFullImport(startDate: String = "2013-01-01", today: String, onProgress: @escaping (OuraSyncProgress) -> Void = { _ in }) async throws -> OuraSyncSummary`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `StrandTests/OuraSyncCoordinatorTests.swift`:
+
+```swift
+import XCTest
+import WhoopStore
+@testable import StrandImport
+@testable import Strand
+
+/// A fetcher that serves canned page bodies per endpoint.
+private final class StubFetcher: OuraPageFetching {
+    var pages: [String: [Data]] = [:]
+    func fetchAllRaw(endpoint: String, query: [String: String]) async throws -> [Data] {
+        pages[endpoint] ?? []
+    }
+}
+
+final class OuraSyncCoordinatorTests: XCTestCase {
+    func testBackfillFetchesParsesAndWrites() async throws {
+        let store = try await WhoopStore.inMemory()
+        let fetcher = StubFetcher()
+        fetcher.pages["daily_readiness"] = [#"{"data":[{"day":"2026-01-02","score":80,"contributors":{"resting_heart_rate":50}}],"next_token":null}"#.data(using: .utf8)!]
+        fetcher.pages["daily_activity"] = [#"{"data":[{"day":"2026-01-02","steps":9000}],"next_token":null}"#.data(using: .utf8)!]
+        fetcher.pages["sleep"] = [#"{"data":[{"id":"s1","day":"2026-01-02","bedtime_start":"2026-01-01T23:00:00+00:00","bedtime_end":"2026-01-02T06:00:00+00:00","total_sleep_duration":24000,"lowest_heart_rate":48,"sleep_phase_5_min":"1234"}],"next_token":null}"#.data(using: .utf8)!]
+
+        var progress: [String] = []
+        let coord = OuraSyncCoordinator(fetcher: fetcher, store: store)
+        let summary = try await coord.runFullImport(today: "2026-02-01") { progress.append($0.endpoint) }
+
+        XCTAssertEqual(summary.days, 1)
+        XCTAssertEqual(summary.sleeps, 1)
+        XCTAssertTrue(summary.rawPages >= 3)
+        XCTAssertTrue(progress.contains("sleep"))
+
+        // Coalesce + RHR precedence: daily_readiness's true RHR (50) wins over sleep's lowestHr (48).
+        let days = try await store.dailyMetrics(deviceId: "oura-api", from: "2026-01-01", to: "2026-01-03")
+        XCTAssertEqual(days.first?.restingHr, 50)
+        XCTAssertEqual(days.first?.steps, 9000)
+        XCTAssertEqual(days.first?.totalSleepMin, 400)
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `xcodegen generate && xcodebuild -project Strand.xcodeproj -scheme Strand -destination 'platform=macOS' test -only-testing:StrandTests/OuraSyncCoordinatorTests CODE_SIGNING_ALLOWED=NO 2>&1 | tail -20`
+Expected: FAIL — `OuraSyncCoordinator`/`OuraPageFetching` undefined. (Note: confirm `WhoopStore.dailyMetrics(deviceId:from:to:)` is the read accessor name — if it differs, read `MetricsCache.swift` and use the actual reader.)
+
+- [ ] **Step 3: Implement `OuraSyncCoordinator`**
+
+Create `Strand/Oura/OuraSyncCoordinator.swift`:
+
+```swift
+import Foundation
+import WhoopStore
+import StrandImport
+
+/// Abstracts the page fetch so the coordinator is testable without a live network (OuraAPIClient conforms).
+protocol OuraPageFetching {
+    func fetchAllRaw(endpoint: String, query: [String: String]) async throws -> [Data]
+}
+extension OuraAPIClient: OuraPageFetching {}
+
+struct OuraSyncProgress: Equatable { let endpoint: String; let pages: Int }
+
+/// One-time backfill across every Oura v2 endpoint → an assembled OuraSyncResult → OuraSyncWriter. Merges
+/// the per-day WearableDailyRows across endpoints (daily endpoints BEFORE sleep, so readiness RHR wins).
+final class OuraSyncCoordinator {
+    private let fetcher: OuraPageFetching
+    private let store: WhoopStore
+    init(fetcher: OuraPageFetching, store: WhoopStore) { self.fetcher = fetcher; self.store = store }
+
+    /// Daily-summary endpoints handed to `parseDaily(_, endpoint:)`. Ordered so `daily_readiness` merges
+    /// before `sleep` (RHR precedence). `daily_sleep` etc. contribute extras only.
+    private static let dailyEndpoints = ["daily_readiness", "daily_activity", "daily_spo2", "daily_sleep",
+                                         "daily_stress", "daily_resilience", "daily_cardiovascular_age", "vO2_max"]
+    /// Endpoints with no Plan-1 parser — archived raw only.
+    private static let rawOnlyEndpoints = ["personal_info", "ring_configuration", "sleep_time", "session",
+                                           "tag", "enhanced_tag", "rest_mode_period", "ring_battery_level"]
+
+    func runFullImport(startDate: String = "2013-01-01", today: String,
+                       onProgress: @escaping (OuraSyncProgress) -> Void = { _ in }) async throws -> OuraSyncSummary {
+        var result = OuraSyncResult()
+        var byDay: [String: WearableDailyRow] = [:]
+
+        func fetchRaw(_ endpoint: String, dateParam: String?) async throws -> [Data] {
+            var q: [String: String] = [:]
+            if let dateParam { q[dateParam] = startDate; q[dateParam == "start_datetime" ? "end_datetime" : "end_date"] = today }
+            let pages = try await fetcher.fetchAllRaw(endpoint: endpoint, query: q)
+            var idx = 0
+            for body in pages {
+                result.rawPages.append(OuraRawRow(endpoint: endpoint, documentId: "\(endpoint)-\(startDate)-\(idx)",
+                                                  day: nil, payloadJSON: String(data: body, encoding: .utf8) ?? "",
+                                                  fetchedAt: Int(Date().timeIntervalSince1970)))
+                idx += 1
+            }
+            onProgress(OuraSyncProgress(endpoint: endpoint, pages: pages.count))
+            return pages
+        }
+
+        func docs(_ pages: [Data]) -> [[String: Any]] {
+            pages.flatMap { (try? JSONSerialization.jsonObject(with: $0) as? [String: Any])?["data"] as? [[String: Any]] ?? [] }
+        }
+        func merge(_ rows: [WearableDailyRow]) {
+            for r in rows {
+                var m = byDay[r.day] ?? WearableDailyRow(day: r.day)
+                m.restingHr = m.restingHr ?? r.restingHr; m.avgHrvMs = m.avgHrvMs ?? r.avgHrvMs
+                m.skinTempDevC = m.skinTempDevC ?? r.skinTempDevC; m.spo2Pct = m.spo2Pct ?? r.spo2Pct
+                m.steps = m.steps ?? r.steps; m.activeKcal = m.activeKcal ?? r.activeKcal
+                m.totalKcal = m.totalKcal ?? r.totalKcal; m.respRateBpm = m.respRateBpm ?? r.respRateBpm
+                m.totalSleepMin = m.totalSleepMin ?? r.totalSleepMin; m.deepMin = m.deepMin ?? r.deepMin
+                m.lightMin = m.lightMin ?? r.lightMin; m.remMin = m.remMin ?? r.remMin
+                m.awakeMin = m.awakeMin ?? r.awakeMin; m.efficiencyPct = m.efficiencyPct ?? r.efficiencyPct
+                byDay[r.day] = m
+            }
+        }
+
+        // Daily endpoints first (readiness RHR precedence), extras accumulate.
+        for endpoint in Self.dailyEndpoints {
+            let pages = try await fetchRaw(endpoint, dateParam: "start_date")
+            let (days, extras) = OuraApiParser.parseDaily(docs(pages), endpoint: endpoint)
+            merge(days); result.extras.append(contentsOf: extras)
+        }
+        // Sleep last (its lowestHr fallback only fills days readiness didn't cover).
+        let sleepPages = try await fetchRaw("sleep", dateParam: "start_date")
+        let (periods, sleepDays) = OuraApiParser.parseSleep(docs(sleepPages))
+        result.sleepPeriods = periods; merge(sleepDays)
+        // Workouts + heart-rate.
+        let workoutPages = try await fetchRaw("workout", dateParam: "start_date")
+        result.workouts = OuraApiParser.parseWorkouts(docs(workoutPages))
+        let hrPages = try await fetchRaw("heartrate", dateParam: "start_datetime")
+        result.heartRate = OuraApiParser.parseHeartRate(docs(hrPages))
+        // Raw-only endpoints (no parser).
+        for endpoint in Self.rawOnlyEndpoints {
+            _ = try await fetchRaw(endpoint, dateParam: Self.rawOnlyEndpoints.contains(endpoint) &&
+                                   ["personal_info", "ring_configuration"].contains(endpoint) ? nil : "start_date")
+        }
+
+        result.days = Array(byDay.values)
+        return try await OuraSyncWriter.persist(result, into: store)
+    }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `xcodebuild -project Strand.xcodeproj -scheme Strand -destination 'platform=macOS' test -only-testing:StrandTests/OuraSyncCoordinatorTests CODE_SIGNING_ALLOWED=NO 2>&1 | tail -20`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Strand/Oura/OuraSyncCoordinator.swift StrandTests/OuraSyncCoordinatorTests.swift
+git commit -m "feat(oura): OuraSyncCoordinator — one-time backfill across all endpoints, coalesced days"
+```
+
+---
+
+### Task 3: `deleteOuraRaw` for clean disconnect
+
+`store.deleteAllData(deviceId:)` does NOT clear `ouraRaw` (it's not in `deviceScopedTables`). Add a targeted delete so Disconnect leaves nothing behind.
+
+**Files:**
+- Modify: `Packages/WhoopStore/Sources/WhoopStore/OuraRawStore.swift`
+- Test: `Packages/WhoopStore/Tests/WhoopStoreTests/OuraRawStoreTests.swift` (extend)
+
+**Interfaces:**
+- Produces: `WhoopStore.deleteOuraRaw(deviceId: String) async throws -> Int`
+
+- [ ] **Step 1: Write the failing test** (append to `OuraRawStoreTests.swift`)
+
+```swift
+    func testDeleteOuraRawRemovesAllForDevice() async throws {
+        let store = try await WhoopStore.inMemory()
+        _ = try await store.upsertOuraRaw([
+            OuraRawRow(endpoint: "sleep", documentId: "a", day: "2026-01-01", payloadJSON: "{}", fetchedAt: 1),
+            OuraRawRow(endpoint: "workout", documentId: "b", day: "2026-01-01", payloadJSON: "{}", fetchedAt: 1),
+        ], deviceId: "oura-api")
+        let deleted = try await store.deleteOuraRaw(deviceId: "oura-api")
+        XCTAssertEqual(deleted, 2)
+        XCTAssertEqual(try await store.ouraRawCount(deviceId: "oura-api", endpoint: "sleep"), 0)
+    }
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `swift test --package-path Packages/WhoopStore --filter OuraRawStoreTests`
+Expected: FAIL — `deleteOuraRaw` undefined.
+
+- [ ] **Step 3: Implement** (add to the `extension WhoopStore` in `OuraRawStore.swift`)
+
+```swift
+    /// Remove every archived Oura payload for a device (used by Disconnect — `deleteAllData` does not
+    /// cover `ouraRaw`). Returns rows deleted.
+    @discardableResult
+    public func deleteOuraRaw(deviceId: String) async throws -> Int {
+        try syncWrite { db in
+            try db.execute(sql: "DELETE FROM ouraRaw WHERE deviceId = ?", arguments: [deviceId])
+            return db.changesCount
+        }
+    }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `swift test --package-path Packages/WhoopStore --filter OuraRawStoreTests`
+Expected: PASS (this is a package test — fast `swift test`, no xcodebuild).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Packages/WhoopStore/Sources/WhoopStore/OuraRawStore.swift Packages/WhoopStore/Tests/WhoopStoreTests/OuraRawStoreTests.swift
+git commit -m "feat(store): deleteOuraRaw(deviceId:) for full Oura cloud-source disconnect"
+```
+
+---
+
+### Task 4: `ASPresentationAnchor` helper + Connect UI
+
+The cross-platform key-window accessor + the "Connect Oura & Import Everything" card. The card is compile-verified + manually tested (SwiftUI + interactive OAuth aren't headless-unit-testable); the anchor helper's logic is the only new unit-testable piece and is trivial, so this task's gate is a clean build.
+
+**Files:**
+- Create: `Strand/Oura/OuraPresentationAnchor.swift`
+- Create: `Strand/Oura/OuraConnectModel.swift` (the `@MainActor` view-model driving connect → backfill → summary)
+- Modify: `Strand/Screens/DataSourcesView.swift` (add the Oura card + wire the model)
+
+**Interfaces:**
+- Consumes: `OuraOAuthProvider`, `OuraCredentials`, `OuraAPIClient`, `OuraSyncCoordinator`, `OuraTokenStore`, `Repository`.
+- Produces: `func ouraPresentationAnchor() -> ASPresentationAnchor`; `@MainActor final class OuraConnectModel: ObservableObject`.
+
+- [ ] **Step 1: Implement the anchor helper**
+
+Create `Strand/Oura/OuraPresentationAnchor.swift` (no unit test — platform window lookup, modeled on `Strand/System/DisplayScreenshot.swift`):
+
+```swift
+import AuthenticationServices
+#if os(iOS)
+import UIKit
+#elseif os(macOS)
+import AppKit
+#endif
+
+/// The app's key window as an ASPresentationAnchor for ASWebAuthenticationSession. Modeled on
+/// DisplayScreenshot's window lookup. Falls back to a bare anchor (OuraOAuthProvider tolerates it).
+@MainActor func ouraPresentationAnchor() -> ASPresentationAnchor {
+    #if os(iOS)
+    let scenes = UIApplication.shared.connectedScenes.compactMap { $0 as? UIWindowScene }
+    let scene = scenes.first { $0.activationState == .foregroundActive } ?? scenes.first
+    return scene?.keyWindow ?? scene?.windows.first ?? ASPresentationAnchor()
+    #elseif os(macOS)
+    return NSApplication.shared.keyWindow ?? NSApplication.shared.windows.first ?? ASPresentationAnchor()
+    #else
+    return ASPresentationAnchor()
+    #endif
+}
+```
+
+- [ ] **Step 2: Implement the connect view-model**
+
+Create `Strand/Oura/OuraConnectModel.swift`:
+
+```swift
+import Foundation
+import Combine
+import AuthenticationServices
+
+/// Drives the Data Sources "Connect Oura" card: connect (OAuth) → one-time backfill → honest summary →
+/// disconnect. @MainActor so all @Published mutations are main-thread; the network/backfill hops off-main.
+@MainActor
+final class OuraConnectModel: ObservableObject {
+    @Published var busy = false
+    @Published var statusText: String?
+    @Published var isConnected = OuraTokenStore.isConnected
+
+    private let repo: Repository
+    init(repo: Repository) { self.repo = repo }
+
+    /// True when the BYO-app credentials are present (else the lane is disabled with guidance).
+    var isConfigured: Bool { OuraCredentials.fromBundle != nil }
+
+    func connectAndImport() {
+        guard let creds = OuraCredentials.fromBundle else {
+            statusText = "Add your Oura app's client_id/secret to OuraSecrets.xcconfig first."; return
+        }
+        busy = true; statusText = "Connecting to Oura…"
+        Task {
+            do {
+                let provider = OuraOAuthProvider(credentials: creds)
+                try await provider.authorize(presentationAnchor: ouraPresentationAnchor())
+                isConnected = true
+                guard let store = await repo.storeHandle() else { fail("No local store."); return }
+                let client = OuraAPIClient(auth: provider, environment: .production)
+                let coord = OuraSyncCoordinator(fetcher: client, store: store)
+                let today = Self.dayFormatter.string(from: Date())
+                statusText = "Importing your Oura history…"
+                let s = try await coord.runFullImport(today: today) { [weak self] p in
+                    Task { @MainActor in self?.statusText = "Importing \(p.endpoint)…" }
+                }
+                await repo.refresh()
+                statusText = "Imported \(s.days) days · \(s.sleeps) sleeps · \(s.workouts) workouts · \(s.hrSamples) HR samples"
+            } catch { fail((error as? LocalizedError)?.errorDescription ?? error.localizedDescription) }
+            busy = false
+        }
+    }
+
+    func disconnect() {
+        busy = true
+        Task {
+            OuraOAuthProvider(credentials: OuraCredentials.fromBundle ?? .init(clientId: "", clientSecret: "", redirectURI: "")).signOut()
+            if let store = await repo.storeHandle() {
+                try? await store.deleteAllData(deviceId: "oura-api")
+                try? await store.deleteOuraRaw(deviceId: "oura-api")
+                await repo.refresh()
+            }
+            isConnected = false; statusText = "Disconnected."; busy = false
+        }
+    }
+
+    private func fail(_ m: String) { statusText = m; busy = false }
+    private static let dayFormatter: DateFormatter = {
+        let f = DateFormatter(); f.calendar = Calendar(identifier: .gregorian)
+        f.locale = Locale(identifier: "en_US_POSIX"); f.timeZone = TimeZone(identifier: "UTC")
+        f.dateFormat = "yyyy-MM-dd"; return f
+    }()
+}
+```
+
+- [ ] **Step 3: Add the Oura card to `DataSourcesView`**
+
+Read `Strand/Screens/DataSourcesView.swift` around the `wearableCard` (~:265) and the shared `card(...)` builder (~:811). Add a `@StateObject private var oura = OuraConnectModel(repo: repo)` (or wire via the existing model), and a card mirroring `wearableCard`, placed next to it:
+
+```swift
+private var ouraCloudCard: some View {
+    card(title: "Oura (cloud)", icon: "circle.circle", tint: StrandPalette.metricPurple,
+         subtitle: "Connect your Oura account and import your full history over the API.") {
+        VStack(alignment: .leading, spacing: 8) {
+            if oura.isConnected {
+                HStack {
+                    Button { oura.connectAndImport() } label: { Label("Sync again", systemImage: "arrow.clockwise") }
+                    Button(role: .destructive) { oura.disconnect() } label: { Label("Disconnect", systemImage: "xmark.circle") }
+                }.disabled(oura.busy)
+            } else {
+                Button { oura.connectAndImport() } label: {
+                    Label(oura.busy ? "Working…" : "Connect Oura & Import Everything", systemImage: "link")
+                }.disabled(oura.busy || !oura.isConfigured)
+                if !oura.isConfigured {
+                    Text("Add your Oura app credentials to OuraSecrets.xcconfig to enable this.")
+                        .font(.caption).foregroundStyle(.secondary)
+                }
+            }
+            if let s = oura.statusText { Text(s).font(.caption).foregroundStyle(.secondary) }
+        }
+    }
+}
+```
+Then render `ouraCloudCard` in the same list/section as `wearableCard`.
+
+- [ ] **Step 4: Verify the build (compile-gate; no headless test for SwiftUI/interactive OAuth)**
+
+Run: `xcodegen generate && xcodebuild -project Strand.xcodeproj -scheme Strand -destination 'platform=macOS' build-for-testing CODE_SIGNING_ALLOWED=NO 2>&1 | tail -15`
+Expected: `** TEST BUILD SUCCEEDED **`. Manually note in the report: the interactive OAuth + backfill flow is live-tested by the user with real credentials, not in CI.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Strand/Oura/OuraPresentationAnchor.swift Strand/Oura/OuraConnectModel.swift Strand/Screens/DataSourcesView.swift
+git commit -m "feat(oura): Connect Oura & Import Everything card + presentation-anchor helper"
+```
+
+---
+
+### Task 5: Scoring source + documentation
+
+Add `"oura-api"` to the import-source list so cloud-only days can be scored, and update the honest-data docs.
+
+**Files:**
+- Modify: `Strand/Data/Repository.swift` (`wearableImportSources`)
+- Modify: `docs/PRIVACY_SECURITY.md`, `docs/DEVICE_SUPPORT_ROADMAP.md`, `docs/DATA_MODEL.md`
+
+**Interfaces:** none.
+
+- [ ] **Step 1: Add the scoring source**
+
+In `Strand/Data/Repository.swift` (~:452):
+```swift
+static let wearableImportSources = ["oura-import", "fitbit-import", "garmin-import", "oura-api", healthConnectSource]
+```
+
+- [ ] **Step 2: Docs**
+
+- `docs/PRIVACY_SECURITY.md` §1: amend "exactly one opt-in exception (the AI Coach)" → "two opt-in exceptions: the AI Coach and the Oura cloud import." Add a short §1.1b describing the Oura lane: off-by-default, user-initiated, inbound (the user's own Oura data under their own OAuth app), tokens in Keychain, no NOOP server, raw data never exfiltrated.
+- `docs/DEVICE_SUPPORT_ROADMAP.md`: change the Oura row from "📋 Researched, not built | Cloud API v2 — off-by-default OAuth import lane only" to "🔬 Built (cloud import) | Cloud API v2 — off-by-default OAuth, one-time backfill; local BLE ring also supported."
+- `docs/DATA_MODEL.md`: note the current migrator version (v24) and add the `ouraRaw` table (deviceId, endpoint, documentId, day, payloadJSON, fetchedAt) to the metric-caches / new-tables section.
+
+- [ ] **Step 3: Verify + commit**
+
+Run: `xcodegen generate && xcodebuild -project Strand.xcodeproj -scheme Strand -destination 'platform=macOS' build-for-testing CODE_SIGNING_ALLOWED=NO 2>&1 | tail -8`
+Expected: `** TEST BUILD SUCCEEDED **`.
+
+```bash
+git add Strand/Data/Repository.swift docs/PRIVACY_SECURITY.md docs/DEVICE_SUPPORT_ROADMAP.md docs/DATA_MODEL.md
+git commit -m "chore(oura): score cloud-import days + document the second opt-in network lane"
+```
+
+---
+
+## Plan 3 self-review
+
+- **Spec coverage:** §7 orchestration → Task 2; §8 writer/mapping (raw + normalized + registry + coalesce + motion + hrSample) → Task 1; §8.4 disconnect (deleteOuraRaw) → Task 3; §9 Connect UI → Task 4; §8.4 scoring + §10 docs → Task 5. The Plan-1 final-review advisories (coalesce, readiness-RHR precedence, sleep-score/vo2max parity via extras) are baked into Tasks 1–2 and the constraints.
+- **Honest data / ownership are structural:** `recovery`/`strain` hardcoded nil; scores only via extras → `ref_*` keys; `.cloudImport` = priority-2 → never seizes a WHOOP day; `setDayOwner` never called.
+- **Testability:** writer + coordinator use `WhoopStore.inMemory()` + a stub fetcher (no network); `deleteOuraRaw` is a fast package test; the UI/OAuth (inherently interactive) is compile-gated + user-live-tested, called out honestly.
+- **Type consistency:** every `WhoopStore` init/method is the exact signature from the v8.5.2 study; `OuraSyncResult`/`OuraSyncSummary` defined Task 1, consumed Task 2; `OuraPageFetching` defined Task 2, `OuraAPIClient` conformance added there.
+- **Risk notes for the implementer (verify against code, adjust minimally, report):** `PairedDevice.status`/`capabilities` enum types; the `dailyMetrics(deviceId:from:to:)` read-accessor name; `StrandPalette`/`card(...)` exact signatures in `DataSourcesView`.
+
+## After Plan 3
+
+The feature is complete and tappable. To use it live, the user registers a free Oura OAuth app (redirect `noop://oura/callback`), drops `client_id`/`secret` into `Strand/Oura/OuraSecrets.xcconfig`, builds, and taps **Connect Oura & Import Everything**. Remaining deferred Minors (from the Plan-1/2 final reviews) — exponential backoff/jitter/pacer in the coordinator, `maxPages` logging, `spo2Daily` scope verification via the sandbox, richer normalization of the 8 raw-only endpoints — are follow-ups, not blockers.

--- a/docs/superpowers/specs/2026-06-27-oura-live-api-import-design.md
+++ b/docs/superpowers/specs/2026-06-27-oura-live-api-import-design.md
@@ -1,0 +1,385 @@
+# Oura live API import — design
+
+- **Date:** 2026-06-27
+- **Status:** Draft for review
+- **Scope:** iOS only (the Swift app). macOS, Android explicitly out (see §13).
+- **Author:** design session (brainstorming → spec)
+- **Supersedes/relates:** the existing offline Oura file-import lane (`WearableExportImporter` / `OuraExportParser`); the roadmap entry [`docs/DEVICE_SUPPORT_ROADMAP.md`](../../DEVICE_SUPPORT_ROADMAP.md) "Oura — Cloud API v2 — off-by-default OAuth import lane only".
+
+---
+
+## 0. v8.5.2 reconciliation (2026-06-30)
+
+This spec was written against v7.2.3; work now targets upstream **v8.5.2** (`ryanbr/noop`, on branch `oura-cloud-import`). Corrections below are verified against current code and **supersede the inline references** further down:
+
+- **Migration number.** The WhoopStore migrator is at **v23** (not v18); the `ouraRaw` table (§4/§8.5/§14) is migration **v24** (not v19 — `v19-step-activity-class`…`v23-daily-spo2-raw` already exist).
+- **Provenance (§8.4).** Register the cloud source as `PairedDevice.sourceKind = .cloudImport` — it already exists (`PairedDevice.swift:42`) and is treated as non-day-owning (`IntelligenceEngine.swift:1369`), so **no new SourceKind is needed**. `deviceId = "oura-api"` stands; `DataSourceKind.ouraApi` is now *optional* (add only if a StrandImport-level provenance tag is actually consumed).
+- **`motionJSON` (§8.2).** Written via the dedicated `persistSessionMotion(deviceId:sessionStart:motionEpochs:[Double])` (`MetricsCache.swift:234`), **not** through `upsertSleepSessions` (`CachedSleepSession` has no `motionJSON` field). Map `movement30s` `[Int]→[Double]`.
+- **New integration points.** Add `"oura-api"` to `Repository.wearableImportSources` (`Repository.swift:452`) if it should join the import-source union; disconnect via the actor `store.deleteAllData(deviceId:)` (`DataSourcesView.swift:598`), not `DeviceRegistryStore` directly (avoids a main-actor stall).
+- **UI (§9).** `DataSourcesView` is entirely file-picker cards today; the live "connect/adopt" precedent is `AddDeviceWizard.swift`. Decide explicitly whether cloud Oura is an *import card* (mirrors the export card) or a *connect-device* flow — the OAuth "Connect" button is a new pattern here.
+- **Confirmed intact (no change):** the `Wearable*` models + initializers, all five upsert APIs and their row structs, every target table shape, and the network-free-packages invariant. The `#862` export-parser hardening **confirmed** our field mapping (incl. the nested `spo2_percentage.average`). The foundation design holds.
+
+---
+
+## 1. Summary
+
+NOOP already imports a user's own Oura data from the **account export file** (a single JSON), parsed by
+[`OuraExportParser`](../../../Packages/StrandImport/Sources/StrandImport/OuraExportParser.swift) into the
+normalized `WearableDailyRow` / `WearableSleepSession` models. That lane is lossy by necessity: the file
+export carries stage **durations** but no hypnogram, no heart-rate/HRV time series, and only a handful of
+daily metrics.
+
+This feature adds a **live Oura API v2 lane** that pulls the user's **full** Oura history once, over the
+network, under the user's own OAuth grant — capturing the rich data the file export can't: the
+`sleep_phase_5_min` hypnogram, `heart_rate`/`hrv` time series, per-night HR series, SpO2, daytime stress,
+resilience, cardiovascular age, VO2 max, workouts, sessions, tags, and ring metadata, across ~18 endpoints.
+
+It is a **one-time, pull-everything** operation (the user's stated use case), behind an off-by-default
+opt-in — NOOP's **second** network exception after the AI Coach. Storage is **lossless**: every raw Oura
+payload is archived verbatim, and a curated subset is normalized into the existing on-device tables so the
+dashboard, Sleep tab, and Metric Explorer light up immediately. A future "Sync again" re-pull is a button,
+not new architecture.
+
+---
+
+## 2. Goals / non-goals
+
+### Goals
+- **G1 — Maximum fidelity.** Pull as much of the Oura v2 surface as the grant allows; never silently drop a
+  field. Raw payloads are retained verbatim so new metrics can be derived later without re-fetching.
+- **G2 — One-time backfill.** A single "Connect Oura & Import Everything" action that authenticates, walks
+  all of history across all endpoints, stores, and reports an honest summary.
+- **G3 — Fit, don't duplicate.** Reuse `OuraExportParser`'s field mapping and the existing `WhoopStore`
+  write path (`dailyMetric`, `sleepSession`, `metricSeries`, `hrSample`, `workout`) and the device registry.
+- **G4 — Honest data.** Oura's own scores (readiness, sleep, activity, resilience) are stored **reference-only**
+  and never become NOOP's Charge/Effort/Rest, exactly as the file lane already does.
+- **G5 — Preserve invariants.** Every Swift package stays network-free; `StrandImport` stays offline-pure;
+  untrusted JSON is treated as hostile; the WHOOP experience never regresses.
+- **G6 — Re-pull seam.** Tokens (incl. refresh) persist so a later re-pull needs no re-auth; auth sits
+  behind an `AuthProvider` protocol so OAuth-with-backend can replace BYO-app later without touching fetch/parse.
+
+### Non-goals (this spec)
+- **NG1 — No background sync / webhooks.** No `BGTaskScheduler`, no incremental "changed since" diffing, no
+  Oura webhook subscriptions (those need a public callback URL / backend).
+- **NG2 — No backend.** No server component. The OAuth `client_secret` is the user's own (BYO app).
+- **NG3 — No macOS / Android.** iOS Swift app only.
+- **NG4 — No new scoring.** NOOP's recovery/strain/sleep math is unchanged; this only feeds it inputs.
+
+---
+
+## 3. Background constraints (verified)
+
+### 3.1 Oura API v2 (verified against the live OpenAPI spec `openapi-1.35.json`, `info.version 2.0`, fetched 2026-06-27)
+- **Personal Access Tokens are deprecated (Dec 2025) and can no longer be created.** OAuth2 is the only path.
+- **OAuth2 is plain authorization-code, no PKCE.** Authorize `https://cloud.ouraring.com/oauth/authorize`;
+  token `https://api.ouraring.com/oauth/token`; bearer header `Authorization: Bearer <token>`. The code→token
+  exchange requires `client_id` + `client_secret`. Refresh tokens are issued by the server-side flow.
+- **Scopes (8):** `email`, `personal`, `daily`, `heartrate`, `workout`, `tag`, `session`, `spo2Daily`
+  (the auth page labels SpO2 as `spo2` — verify against the live consent screen at build time).
+- **Pagination:** every list/time-series response carries `next_token` (repeat with `next_token=` until null).
+- **Rate limit:** 5000 requests / 5-minute window → HTTP 429 on exceed. A multi-year backfill across ~18
+  endpoints fits comfortably with light pacing + backoff.
+- **No `changed_since`.** Incremental sync (future) re-pulls a trailing window and upserts by `id`, because
+  Oura re-scores prior days. Not needed for the one-time pull.
+- **Membership gate:** Gen3 / Ring 4 users without an active Oura Membership get empty/4xx from the API.
+  Handle honestly in the UI (see §9).
+- **Sandbox:** every collection endpoint has a twin at `/v2/sandbox/usercollection/...` returning static demo
+  data with identical schemas — used for development and as a live smoke test without a real account.
+
+### 3.2 NOOP invariants this feature must not break
+- **Offline-by-default privacy posture** ([`docs/PRIVACY_SECURITY.md`](../../PRIVACY_SECURITY.md) §1).
+  The five Swift packages are network-free; the AI Coach (in the **app target**) is the single opt-in network
+  exception. → The Oura networking lives in the **app target**, and is documented as the **second** opt-in
+  exception. The data flow is **inbound** (Oura → device, the user's own data, under the user's own grant);
+  nothing of the user's existing NOOP data leaves the device except the OAuth handshake with Oura.
+- **`StrandImport` is offline-pure** — its banner reads "STAY OFFLINE: nothing here touches the network."
+  → Only **pure** (no-network) Oura-API response parsers are added to `StrandImport`; the fetch happens in the
+  app target. This mirrors the existing split: `StrandImport` parses, `Strand/Data/WearableImporter.swift` writes.
+- **Honest data** — a brand's own scores are reference-only; NOOP recomputes downstream.
+- **Untrusted input is hostile** ([`docs/PRIVACY_SECURITY.md`](../../PRIVACY_SECURITY.md) §3) — byte caps,
+  finite/range-checked numerics, bounded collection counts (reuse `WearableJSON` coercion helpers).
+- **Supply chain** — dependencies are pinned `exact:` and must match across `Packages/*/Package.swift` and
+  `project.yml`. This feature adds **no** third-party dependency (uses `URLSession` + `ASWebAuthenticationSession`
+  + `Security`, all first-party).
+- **WHOOP primacy** — Oura is an additional source; it must not auto-seize day ownership from WHOOP (§8.4).
+
+---
+
+## 4. Architecture overview
+
+```
+┌──────────────────────────── app target: Strand/Oura/ (NETWORK lives here, beside Strand/AI/AICoach) ────────────────────────────┐
+│                                                                                                                                  │
+│  OuraCredentials      OuraAuth (AuthProvider)            OuraAPIClient                 OuraSyncCoordinator        OuraSyncWriter   │
+│  client_id/secret  →  ASWebAuthenticationSession      →  URLSession + paging +      →  one-time backfill:      →  WhoopStore      │
+│  from xcconfig        code → token exchange              rate-limit/backoff +          fan out across all         upserts +       │
+│  (Info.plist)         tokens → Keychain (AIKeyStore)     sandbox/prod base URL         endpoints, page each       registry +      │
+│                                                                                        date-windowed, decode       dayOwnership   │
+│                                                                                        via pure parsers ↓                         │
+└─────────────────────────────────────────────────────────────────────────────────────────────────────┼──────────────────────────┘
+                                                                                                        │ Data (raw JSON)
+┌──────────────── package: StrandImport (PURE, network-free) ─────────────┐                             ▼
+│  OuraApiParser (new)  ── reuses ──▶  OuraExportParser helpers            │     ┌──────────── package: WhoopStore (GRDB/SQLite) ───────────┐
+│  + OuraHypnogram decoder (sleep_phase_5_min / 30_sec, movement_30_sec)   │     │  ouraRaw (NEW, v19)  ·  dailyMetric  ·  sleepSession      │
+│  + rich API model types (time series, sessions, resilience, …)          │     │  metricSeries  ·  hrSample  ·  workout  ·  pairedDevice   │
+│  emits: WearableDailyRow / WearableSleepSession (+ stages) + rich models │     │  dayOwnership                                            │
+└─────────────────────────────────────────────────────────────────────────┘     └───────────────────────────────────────────────────────────┘
+```
+
+**Components (all new unless noted):**
+
+| Component | Location | Responsibility | Networks? |
+|---|---|---|---|
+| `OuraCredentials` | `Strand/Oura/` | Read `client_id` / `client_secret` / redirect from an **untracked xcconfig** surfaced via Info.plist. | no |
+| `AuthProvider` (protocol) + `OuraOAuthProvider` | `Strand/Oura/` | The auth seam. `OuraOAuthProvider` runs `ASWebAuthenticationSession`, exchanges code→tokens, stores/loads/refreshes via Keychain. | yes |
+| `OuraTokenStore` | `Strand/Oura/` | Keychain wrapper for access/refresh tokens + expiry, mirroring `AIKeyStore` (service `com.noop.oura`). | no |
+| `OuraAPIClient` | `Strand/Oura/` | Typed `URLSession` client: per-endpoint GET, `next_token` paging, 429/5xx backoff, base-URL switch (prod vs sandbox), bounded byte reads. | yes |
+| `OuraSyncCoordinator` | `Strand/Oura/` | One-time backfill orchestration: discover account span, fan out across endpoints, window requests, hand pages to the pure parser, drive progress, persist a "last full sync" marker. | yes (via client) |
+| `OuraSyncWriter` | `Strand/Oura/` | Map parsed models → `WhoopStore` upserts; archive raw; register the source; never auto-own days. Mirrors `WearableImporter`. | no |
+| `OuraApiParser` + `OuraHypnogram` + rich model types | `Packages/StrandImport/Sources/StrandImport/` | **Pure** decode of Oura API JSON → normalized + rich models; reuses `OuraExportParser` + `WearableJSON`. | no |
+| `ouraRaw` table (migration **v19**) | `Packages/WhoopStore/.../Database.swift` | Lossless raw payload archive. | no |
+| `DataSourceKind.ouraApi` | `Packages/StrandImport/.../ImportModels.swift` | New provenance case (enum only). | no |
+| Oura card + connect/sync UI | `Strand/Screens/DataSourcesView.swift` (+ small new views) | Connect, progress, summary, membership-gate messaging, disconnect. | no |
+
+---
+
+## 5. Auth design (BYO Oura app, authorization-code, one-time)
+
+### 5.1 Flow
+1. The user registers a **free OAuth application** on Oura's developer portal once (redirect URI =
+   NOOP's custom scheme, e.g. `noop://oura/callback`), then provides its `client_id` + `client_secret`.
+   For the personal/one-time case these go into an **untracked xcconfig** (no in-app credential screen to
+   build); see §5.3. (A paste-credentials screen is a noted alternative — §12 Q2.)
+2. Tapping **Connect** runs `ASWebAuthenticationSession` against
+   `https://cloud.ouraring.com/oauth/authorize?response_type=code&client_id=…&redirect_uri=…&scope=<all 8>&state=<nonce>`.
+3. On redirect, NOOP validates `state`, extracts `code`, and POSTs to
+   `https://api.ouraring.com/oauth/token` with `grant_type=authorization_code`, the code, redirect, and
+   `client_id`/`client_secret` → `{access_token, refresh_token, expires_in}`.
+4. Tokens + expiry are stored in Keychain (`OuraTokenStore`, `kSecAttrAccessibleAfterFirstUnlock`, mirroring
+   [`AIKeyStore`](../../../Strand/AI/AICoach.swift)).
+5. The backfill (§7) runs. On 401 mid-sync, the client refreshes via `grant_type=refresh_token` once and retries.
+
+### 5.2 The `AuthProvider` seam
+```swift
+protocol AuthProvider {                       // Strand/Oura/
+    func validAccessToken() async throws -> String   // returns a fresh token, refreshing if needed
+    func authorize() async throws                    // interactive: runs ASWebAuthenticationSession + exchange
+    func signOut() throws                            // clears Keychain
+    var isConnected: Bool { get }
+}
+```
+`OuraAPIClient` depends only on `AuthProvider`. Shipping BYO-app today vs. a backend-mediated flow later is a
+provider swap; fetch/parse/store are untouched.
+
+### 5.3 Credentials delivery (default: xcconfig)
+- An untracked `Strand/Oura/OuraSecrets.xcconfig` (gitignored) defines `OURA_CLIENT_ID`, `OURA_CLIENT_SECRET`,
+  `OURA_REDIRECT_URI`, referenced from `project.yml` (XcodeGen) and surfaced into Info.plist; `OuraCredentials`
+  reads them at runtime. A committed `OuraSecrets.example.xcconfig` documents the keys.
+- The redirect scheme is registered in `CFBundleURLTypes` (Info.plist via `project.yml`).
+- **No secret is committed**; for a single-user build the secret never leaves that user's machine/binary.
+
+---
+
+## 6. The Oura API client
+
+- **Base URL switch:** `https://api.ouraring.com/v2/usercollection/…` (prod) vs `…/v2/sandbox/usercollection/…`
+  (dev/tests). A single `OuraEnvironment` enum.
+- **Request:** `GET` with `Authorization: Bearer`, `start_date`/`end_date` (or `start_datetime`/`end_datetime`
+  for `heartrate`), and `next_token` when paging.
+- **Paging:** loop until `next_token == nil`, accumulating `data[]`. A per-endpoint hard page cap (e.g. 10⁴
+  pages) is a runaway guard, logged if hit (never silent — §3.2).
+- **Rate-limit & resilience:** on `429`, honor backoff and retry; on `5xx`/transport error, bounded
+  exponential backoff with jitter; on `401`, refresh-once-then-retry. A small global pacer keeps well under
+  5000/5-min.
+- **Bounded reads:** cap per-response bytes (reuse the 256 MB ceiling rationale from `WearableExportImporter`)
+  and decode with `JSONSerialization` through the existing `WearableJSON` finite/range-checked coercion so a
+  hostile/garbled response can't OOM or trap.
+- **Decoding:** the client returns raw `Data` per page to the coordinator, which (a) hands it to `OuraSyncWriter`
+  for verbatim archival and (b) hands it to the pure `OuraApiParser` for normalization. The client itself does
+  not interpret payloads beyond `data`/`next_token` envelope extraction.
+
+---
+
+## 7. Sync orchestration (one-time backfill)
+
+`OuraSyncCoordinator.runFullImport()`:
+1. **Span discovery.** `GET personal_info` (also yields PII to optionally store, §12 Q3) and probe the earliest
+   available day (e.g. widen `start_date` back in coarse windows until a daily endpoint returns empty). Default
+   floor: a fixed early date (e.g. 2013-01-01, before any Oura ring shipped) so we never miss history.
+2. **Fan out across endpoints** (§8.1). For each: page through `[span.start … today]` in date-windowed chunks
+   (e.g. 90-day windows for summaries; shorter for `heartrate`/`sleep` to bound page size), following `next_token`.
+3. **Per page:** archive raw (`ouraRaw` upsert by `(endpoint, documentId)`), then parse + accumulate normalized rows.
+4. **Persist** via `OuraSyncWriter` (§8): batched upserts to `dailyMetric` / `sleepSession` / `metricSeries` /
+   `hrSample` / `workout`; register the `pairedDevice`; set ring model from `ring_configuration`.
+5. **Progress** is reported per endpoint (e.g. "sleep: 1,240 nights", "heartrate: 412k samples") to the UI.
+6. **Completion marker:** store `last_full_sync` (epoch) in `cursors` (`oura:lastFullSync`) so a future re-pull
+   is informed and the UI can show "Last imported …".
+
+Ordering: fetch `ring_configuration` early (sets the device model), then `sleep` + daily summaries (the
+dashboard's core), then `heartrate` (the largest), then the long tail (sessions/tags/rest_mode/etc.). A failure
+in one endpoint is logged and skipped without aborting the whole import (honest partial — surfaced in the summary).
+
+**Future re-pull** (out of scope to build, in scope to not preclude): the same `runFullImport` with a trailing
+window + refreshed token. Idempotent because every store upsert is keyed by natural key / Oura `id`.
+
+---
+
+## 8. Data model & storage
+
+### 8.1 Endpoint → storage mapping
+
+All endpoints are archived verbatim to `ouraRaw`. The normalized columns below are the curated projection that
+drives existing UI. "ref-only" = reference `metricSeries` key, never a NOOP score (G4).
+
+| Oura endpoint | Raw | Normalized target | Notes |
+|---|---|---|---|
+| `personal_info` | ✓ | (optional) profile PII, local only | §12 Q3 decides storing age/sex/height/weight. |
+| `ring_configuration` | ✓ | `pairedDevice.model` (hardware_type → "Oura Ring Gen3/4/…") | Sets the source's display model. |
+| `sleep` (detailed) | ✓ | `sleepSession` (+ **hypnogram** → `stagesJSON`, **movement** → `motionJSON`), daily sleep rollup → `dailyMetric` | The richest object. HR series → `hrSample`; HRV series → raw + `avgHrv`. See §8.2. |
+| `daily_sleep` | ✓ | `ref_sleep_score` (ref-only) + contributor keys | Score is reference. |
+| `daily_readiness` | ✓ | `dailyMetric.restingHr`, `skinTempDevC`; `ref_readiness_score` + contributor keys | Mirrors `OuraExportParser`. |
+| `daily_activity` | ✓ | `dailyMetric.steps`; `metricSeries` steps/active_kcal/total_kcal/met-minutes; `ref_activity_score` | `met`/`class_5_min` series → raw. |
+| `daily_spo2` | ✓ | `dailyMetric.spo2Pct`; `metricSeries` spo2, bdi | |
+| `daily_stress` | ✓ | `metricSeries` stress_high_s, recovery_high_s; day_summary encoded ref | Categorical summary stored ref-only. |
+| `daily_resilience` | ✓ | `metricSeries` resilience contributors (0–100); `ref_resilience_level` | Level encoded 1–5 ref-only. |
+| `daily_cardiovascular_age` | ✓ | `metricSeries` vascular_age, pulse_wave_velocity | |
+| `vO2_max` | ✓ | `metricSeries` vo2max | (no `dailyMetric` column; `appleDaily.vo2max` is Apple-specific). |
+| `sleep_time` | ✓ | `metricSeries` optimal bedtime offsets (ref) | Recommendation enum → raw. |
+| `workout` | ✓ | `workout` table (sport=activity, source, durationS, energyKcal, distanceM, start/end) | |
+| `session` | ✓ | `metricSeries` session counts/day; HR/HRV/motion arrays → raw | Sessions aren't workouts; normalized surface kept minimal v1. |
+| `tag` / `enhanced_tag` | ✓ | raw (annotations surfaced later) | `tag` is deprecated; prefer `enhanced_tag`. |
+| `rest_mode_period` | ✓ | raw | |
+| `ring_battery_level` | ✓ | raw | |
+| `heartrate` (time series) | ✓ | `hrSample(deviceId, ts, bpm)` | `source` enum preserved in raw. Largest payload — see §8.3. |
+
+Reused write APIs (all already exist): `upsertDailyMetrics`, `upsertSleepSessions`, `upsertMetricSeries`
+([`MetricsCache.swift` / `MetricSeriesStore.swift`]), `upsertWorkouts`
+([`JournalWorkoutAppleCache.swift`]), `insert(_ streams:deviceId:)` for `hrSample`
+([`StreamStore.swift`]), and `DeviceRegistryStore.add` / `setDayOwner` / `deleteAllData`.
+
+### 8.2 Sleep hypnogram (the headline win)
+- `OuraHypnogram.decode(_:)` turns `sleep_phase_5_min` (or the finer `sleep_phase_30_sec` when present) into
+  `[{start,end,stage}]` segments, epoch-aligned from `bedtime_start`. Legend (verbatim): `1=deep, 2=light,
+  3=REM, 4=awake` → NOOP stage strings `"deep"/"light"/"rem"/"wake"` (matching `WearableSleepStageInterval`).
+  This populates `sleepSession.stagesJSON`, which the Oura **file** lane always left empty.
+- `movement_30_sec` (legend `1=no motion … 4=active` — a **different** decoder) → `sleepSession.motionJSON`
+  (the v18 per-epoch motion column).
+- `heart_rate` `PublicSample` (interval+items+timestamp) → `hrSample` rows under `deviceId="oura-api"`.
+- `hrv` `PublicSample` → archived raw + per-night `avgHrv` on the session (no good per-sample normalized home;
+  `rrInterval` is RR not rMSSD — noted honestly, not faked).
+- Scalar mapping (`bedtime_start/end`, `total/deep/light/rem_sleep_duration`, `awake_time`, `efficiency`,
+  `average_heart_rate`, `lowest_heart_rate`, `average_hrv`, `average_breath`) reuses `OuraExportParser.sleepSession`
+  semantics (durations are seconds → minutes).
+
+### 8.3 Heart-rate volume
+5-minute cadence ≈ 288 points/day (denser during workouts/sessions) → low-hundreds-of-thousands of rows over
+years; `hrSample` is a compact `(deviceId, ts, bpm)` table and absorbs this fine (tens of MB). Raw `heartrate`
+pages are also archived (lossless). Because raw HR roughly doubles HR storage, **raw heartrate archival is a
+toggle** (default on for "as much as we can get"; off saves the most space) — §12 Q1.
+
+### 8.4 Provenance, registry, day ownership
+- New `DataSourceKind.ouraApi`; partition `deviceId = "oura-api"` (distinct from the file lane's `"oura-import"`,
+  so live and file data coexist as separate sources).
+- Register a `PairedDevice(id:"oura-api", brand:"Oura", model:<from ring_configuration>, sourceKind:<new
+  cloud/api kind>, capabilities:[sleep,hr,hrv,spo2,skinTemp,steps,…], status:.active)` via `DeviceRegistryStore.add`.
+- **Do not auto-set `dayOwnership` to `oura-api`** — WHOOP/primary stays the default owner; Oura is an additional
+  comparable source the user can select. (Respects WHOOP primacy; never blends scores.)
+- **Disconnect** = `DeviceRegistryStore.deleteAllData(deviceId:"oura-api")` + clear Keychain tokens + delete
+  `ouraRaw` rows for the source.
+
+### 8.5 `ouraRaw` schema (migration v19)
+```
+ouraRaw:
+  endpoint     TEXT NOT NULL      -- "sleep" | "daily_readiness" | "heartrate" | …
+  documentId   TEXT NOT NULL      -- Oura `id`; for heartrate pages, a synthesized window key
+  day          TEXT               -- YYYY-MM-DD when the doc is day-keyed (nullable)
+  payloadJSON  TEXT NOT NULL      -- the raw object, verbatim (JSONEncoder .sortedKeys for stable bytes)
+  fetchedAt    INTEGER NOT NULL   -- unix seconds
+  PRIMARY KEY (endpoint, documentId)
+  INDEX (endpoint, day)
+```
+Additive migration only; no existing table touched. (`DATA_MODEL.md` is stale at "v9"; the live migrator is at
+v18 — this is **v19**. The doc's schema table will be updated to reflect v10–v19, including `ouraRaw`.)
+
+---
+
+## 9. UI (iOS)
+
+- **Data Sources screen** ([`Strand/Screens/DataSourcesView.swift`]): add an **Oura (live)** card, sibling to
+  the existing wearable file-import card. Primary action **"Connect Oura & Import Everything."**
+- **Connect:** runs auth (§5) then the backfill (§7) as a foreground operation with **per-endpoint progress**
+  and a cancel. (One-time, foreground — no background task.)
+- **Summary:** honest completion line — counts per category and date span (mirrors `WearableExportImporter.summaryText`),
+  including any endpoints that were skipped/failed (never a silent "complete").
+- **Membership gate:** if the API returns empty/4xx for the membership reason, show a clear, non-alarming
+  message ("Oura returned no data — an active Oura Membership is required for API access") rather than a generic error.
+- **Connected state:** show "Last imported <date>", a **Sync again** button (re-runs §7), and **Disconnect** (§8.4).
+- The card is **off/empty until connected**; no network call happens until the user taps Connect (privacy posture).
+
+---
+
+## 10. Security & privacy
+
+- **Second opt-in network lane.** Update [`docs/PRIVACY_SECURITY.md`](../../PRIVACY_SECURITY.md) §1/§4/§5 to
+  document the Oura lane honestly: off-by-default, user-initiated, **inbound** (the user's own Oura data → device
+  under the user's own OAuth app), tokens in Keychain, no NOOP server, raw data never exfiltrated. §4's "No
+  WHOOP account or API credentials" stays true (this is Oura, the user's own grant) but the blanket "offline by
+  default / one exception" framing is amended to "two opt-in exceptions: AI Coach and Oura import."
+- **Token storage:** Keychain only, `kSecAttrAccessibleAfterFirstUnlock`, service `com.noop.oura`. Never logged
+  (the strap-log redaction policy extends: no tokens, no `code`, no `client_secret` in any log).
+- **Untrusted responses:** bounded byte reads + `WearableJSON` finite/range-checked coercion + per-collection
+  caps (parity with `WearableExportImporter`).
+- **iOS entitlements:** the iOS build permits outbound network (no macOS-style sandbox block); the redirect
+  scheme is registered in `CFBundleURLTypes`. No new ATS exemption expected (Oura is standard TLS) — verify.
+- **macOS note:** the macOS app would need the `com.apple.security.network.client` entitlement to use this lane;
+  out of scope here (iOS-only), and the spec deliberately does not add it.
+
+---
+
+## 11. Testing
+
+- **Pure parsers** (`StrandImportTests`, XCTest, inline-JSON fixtures like `WearableExportImporterTests`):
+  `OuraApiParser` per endpoint; `OuraHypnogram.decode` round-trips (`sleep_phase_5_min`/`30_sec` legends,
+  epoch alignment, the distinct `movement_30_sec` legend); honest-data assertions (Oura scores land only on
+  `ref_*` keys, never `recovery`/`strain`).
+- **Client** (app-target tests): a `URLProtocol` stub feeds canned responses — paging via `next_token`, 429
+  backoff, 401-refresh-once, bounded-bytes, prod/sandbox base URL.
+- **Writer/integration:** in-memory `WhoopStore.inMemory()` → assert `dailyMetric`/`sleepSession`(+stages)/
+  `hrSample`/`metricSeries`/`workout` rows and `pairedDevice` registration; assert day-ownership is **not**
+  seized from WHOOP.
+- **Live smoke (manual/dev):** point the client at the `/v2/sandbox/...` tree (no account) to exercise the real
+  envelope/paging end-to-end.
+
+---
+
+## 12. Open questions for your review
+
+- **Q1 — Raw heart-rate archival.** Default **on** (true lossless) but it roughly doubles HR storage. OK to
+  default on with a toggle, or default off (still keep normalized `hrSample`)?
+- **Q2 — Credentials UX.** Default is an untracked **xcconfig** (no UI to build, best for one-time/personal). Want
+  a small **paste-credentials screen** instead so any user can connect without rebuilding? (Larger scope.)
+- **Q3 — `personal_info` PII.** Store age/sex/height/weight locally (useful for some scores), or archive raw only?
+- **Q4 — Module placement.** Pure parsers in **`StrandImport`** (max reuse, recommended) vs. a new pure package
+  **`StrandOura`** (cleaner home, more scaffolding). This refines the earlier "new networked module" framing:
+  networking is in the app target regardless; only the parser home is in question.
+
+---
+
+## 13. Out of scope
+
+Background sync, webhooks, incremental "changed-since" diffing, a backend/token-proxy, OAuth-for-all-users
+(BYO-app only for now), macOS, Android, and any change to NOOP's scoring math. All are reachable later behind
+the `AuthProvider` seam and the idempotent store upserts without reworking this lane.
+
+---
+
+## 14. Touched files (high level — detailed steps come in the implementation plan)
+
+**New (app target `Strand/Oura/`):** `OuraCredentials.swift`, `OuraAuth.swift` (`AuthProvider` + `OuraOAuthProvider`),
+`OuraTokenStore.swift`, `OuraAPIClient.swift`, `OuraEnvironment.swift`, `OuraSyncCoordinator.swift`, `OuraSyncWriter.swift`,
++ small SwiftUI views for the card/progress/summary.
+**New (package `StrandImport`):** `OuraApiParser.swift`, `OuraHypnogram.swift`, rich API model types (+ tests).
+**Edited:** `Packages/WhoopStore/.../Database.swift` (migration **v19** `ouraRaw`) + a small `OuraRawStore.swift`;
+`Packages/StrandImport/.../ImportModels.swift` (`DataSourceKind.ouraApi`); `Strand/Screens/DataSourcesView.swift`
+(Oura card + flow); `project.yml` (xcconfig ref + `CFBundleURLTypes`); `.gitignore` (`OuraSecrets.xcconfig`);
+docs: `PRIVACY_SECURITY.md`, `DEVICE_SUPPORT_ROADMAP.md` (Oura row → "in progress"), `DATA_MODEL.md` (v10–v19 incl. `ouraRaw`).

--- a/project.yml
+++ b/project.yml
@@ -148,6 +148,11 @@ targets:
     deploymentTarget: "13.0"
     sources:
       - StrandTests
+    # Same wrapper as the app target, so the OURA_CLOUD_IMPORT-gated Oura tests compile exactly
+    # when the app's Oura lane does (flag + creds both come from the untracked OuraSecrets.xcconfig).
+    configFiles:
+      Debug: Strand/Oura/OuraConfig.xcconfig
+      Release: Strand/Oura/OuraConfig.xcconfig
     dependencies:
       - target: Strand
       - package: WhoopProtocol

--- a/project.yml
+++ b/project.yml
@@ -76,6 +76,13 @@ targets:
           # The liquid Today is now cross-platform: its iOS-only chrome (topBarTrailing / navigationBarTitleDisplayMode
           # / presentationCompactAdaptation / two-param onChange / sensoryFeedback) is guarded, so the mac split-view
           # shell hosts LiquidTodayView too. All Liquid/* now compile into the mac target.
+    # Oura BYO-app OAuth credentials. OuraConfig.xcconfig is a tracked wrapper that optionally
+    # includes the untracked, gitignored Strand/Oura/OuraSecrets.xcconfig (template at
+    # OuraSecrets.example.xcconfig) — absent secrets leave the $(OURA_*) references in the
+    # info.properties below empty, which disables the Oura Cloud lane at runtime.
+    configFiles:
+      Debug: Strand/Oura/OuraConfig.xcconfig
+      Release: Strand/Oura/OuraConfig.xcconfig
     info:
       path: Strand/Resources/Info.plist
       properties:
@@ -93,6 +100,15 @@ targets:
         # HTTPS endpoints are unaffected. No arbitrary-loads blanket exemption.
         NSAppTransportSecurity:
           NSAllowsLocalNetworking: true
+        # Oura BYO-app OAuth credentials (values come from configFiles above); read at runtime via
+        # OuraCredentials.fromBundle. Absent/blank values cleanly disable the Connect-Oura lane.
+        OURA_CLIENT_ID: $(OURA_CLIENT_ID)
+        OURA_CLIENT_SECRET: $(OURA_CLIENT_SECRET)
+        OURA_REDIRECT_URI: $(OURA_REDIRECT_URI)
+        # Registers the noop:// URL scheme so ASWebAuthenticationSession's OAuth redirect
+        # (noop://oura/callback) reaches OuraOAuthProvider instead of bouncing off the OS.
+        CFBundleURLTypes:
+          - CFBundleURLSchemes: [noop]
     entitlements:
       path: Strand/Resources/Strand.entitlements
       properties:
@@ -181,6 +197,10 @@ targets:
           - "Resources/Info.plist"
           - "Resources/NOOP.entitlements"
       - path: StrandiOSShared
+    # Same tracked wrapper as the macOS target (Strand/Oura/ is shared, not per-platform).
+    configFiles:
+      Debug: Strand/Oura/OuraConfig.xcconfig
+      Release: Strand/Oura/OuraConfig.xcconfig
     info:
       path: StrandiOS/Resources/Info.plist
       properties:
@@ -243,6 +263,15 @@ targets:
         # Both keys are required for the folder to actually appear in Files.
         UIFileSharingEnabled: true
         LSSupportsOpeningDocumentsInPlace: true
+        # Oura BYO-app OAuth credentials (values come from configFiles above); read at runtime via
+        # OuraCredentials.fromBundle. Absent/blank values cleanly disable the Connect-Oura lane.
+        OURA_CLIENT_ID: $(OURA_CLIENT_ID)
+        OURA_CLIENT_SECRET: $(OURA_CLIENT_SECRET)
+        OURA_REDIRECT_URI: $(OURA_REDIRECT_URI)
+        # Registers the noop:// URL scheme so ASWebAuthenticationSession's OAuth redirect
+        # (noop://oura/callback) reaches OuraOAuthProvider instead of bouncing off the OS.
+        CFBundleURLTypes:
+          - CFBundleURLSchemes: [noop]
     entitlements:
       path: StrandiOS/Resources/NOOP.entitlements
       properties:


### PR DESCRIPTION
Implements the opt-in **Oura Cloud API import** proposed in #252 — please read that first for the scope discussion, since this adds an opt-in network lane and that's a deliberate maintainer call.

## What it does
A one-time (re-runnable) historical backfill pulling a user's **own** Oura data from the v2 API into local SQLite — every endpoint (daily readiness/activity/sleep/spo2/stress/resilience/cardiovascular-age/VO2max; sleep with hypnogram + movement + in-sleep HR; workouts; whole-day heart-rate; raw archival of tags/sessions/ring-config). Lossless raw pages **and** normalized rows.

## Keeps NOOP's offline identity intact
- **Opt-in, inert by default** — no credentials ⇒ the lane is disabled and *no network code runs*. Same shape as the AI Coach's opt-in outbound network already in-tree.
- **BYO Oura app** — `client_id`/`secret` via a gitignored `Strand/Oura/OuraSecrets.xcconfig` (example template committed; registers the `noop://` OAuth redirect). NOOP ships no keys, runs no server, holds no account.
- **Pure parsers stay network-free** — `StrandImport` gains only value-type parsers; all `URLSession`/OAuth lives in the app target (`Strand/Oura/`), preserving the packages' network-free invariant.
- **Honest data** — Oura's own scores land only in `ref_*`/`oura_*` metricSeries keys, never `recovery`/`strain`; the source registers `.cloudImport` (structurally priority-2 in `DayOwnerResolver`), so it never seizes a WHOOP day.
- **Additive schema** — migration `v25-oura-raw` (a new lossless archive table, after upstream's `v24-rr-seq`; no existing row touched).
- **Interruptible** — whole-day heart-rate is fetched in ≤30-day windows (the endpoint's range cap) and persisted per window, so an interrupted import keeps completed progress.

## Try it
1. Register a free Oura app (redirect URI `noop://oura/callback`).
2. `cp Strand/Oura/OuraSecrets.example.xcconfig Strand/Oura/OuraSecrets.xcconfig` and paste your `client_id`/`secret`.
3. Build → **Data Sources → Connect Oura & Import Everything**.

## Verification
- **Device-verified** on iPhone: ~940k HR samples, 493 daily metrics, 595 sleeps, 256 workouts across 2+ years, no data-path regressions.
- **Tests:** parser + coordinator + OAuth + client + store, incl. a durability-through-interruption case. `swift test` (WhoopStore + StrandImport) green; the `StrandTests/Oura*` suite (21 tests) green; macOS app builds.

## Scope notes (flagging honestly)
- **iOS + macOS (Swift) only.** The import is app-target networking, so there's no Android twin here. The one cross-platform surface is the additive `v25-oura-raw` table — for `.noopbak` schema parity it'd want a matching Room migration on Android. I'm iOS/Swift-only (as we discussed on #250), so I've left the Android side to a Kotlin contributor / your call rather than transcribe it blind. Happy to coordinate.
- **Reference docs included.** `PRIVACY_SECURITY.md` gains §1.1b documenting this as the second opt-in network lane (and fixes a stale claim while there — §1.2 still said the `network.client` entitlement was absent, but it's been present since #128). `DATA_MODEL.md` documents the `v25-oura-raw` migration and the `ouraRaw` raw-payload archive table. The full design spec + 3 implementation plans are under `docs/superpowers/`.
