### PR TITLE
Android: stop writing strap steps/calories to Health Connect (parity with iOS #249)

### DIFF
--- a/android/app/src/main/java/com/noop/ingest/HealthConnectWriter.kt
+++ b/android/app/src/main/java/com/noop/ingest/HealthConnectWriter.kt
@@ -3,7 +3,6 @@ package com.noop.ingest
 import android.content.Context
 import androidx.health.connect.client.HealthConnectClient
 import androidx.health.connect.client.permission.HealthPermission
-import androidx.health.connect.client.records.ActiveCaloriesBurnedRecord
 import androidx.health.connect.client.records.DistanceRecord
 import androidx.health.connect.client.records.ExerciseSessionRecord
 import androidx.health.connect.client.records.HeartRateRecord
@@ -13,9 +12,7 @@ import androidx.health.connect.client.records.Record
 import androidx.health.connect.client.records.RespiratoryRateRecord
 import androidx.health.connect.client.records.RestingHeartRateRecord
 import androidx.health.connect.client.records.SleepSessionRecord
-import androidx.health.connect.client.records.StepsRecord
 import androidx.health.connect.client.records.metadata.Metadata
-import androidx.health.connect.client.units.Energy
 import androidx.health.connect.client.units.Length
 import androidx.health.connect.client.units.Percentage
 import com.noop.data.WhoopRepository
@@ -51,9 +48,6 @@ object HealthConnectWriter {
         HeartRateVariabilityRmssdRecord::class,
         OxygenSaturationRecord::class,
         RespiratoryRateRecord::class,
-        // #528: also share back the strap's raw-derived series + daily totals.
-        ActiveCaloriesBurnedRecord::class,
-        StepsRecord::class,
         HeartRateRecord::class,
         SleepSessionRecord::class,
     )
@@ -118,49 +112,17 @@ object HealthConnectWriter {
             }
         }
 
-        // #528 — Active Energy + Steps: one interval record per day, riding the same 60-day window.
-        // Kept in a SEPARATE list + insert from the vitals above so a revoked steps/energy WRITE
-        // permission can't fail the (already-reliable) vitals insert: HC insertRecords is
-        // all-or-nothing per call.
-        val aggRecords = ArrayList<Record>()
-        val aggs = HealthExportPlan.dailyAggregates(
-            days.map { HealthExportPlan.DayInput(it.day, it.steps, it.activeKcalEst) },
-        ) { day ->
-            val date = runCatching { LocalDate.parse(day) }.getOrNull() ?: return@dailyAggregates null
-            val s = date.atStartOfDay(zone).toEpochSecond()
-            val e = date.plusDays(1).atStartOfDay(zone).toEpochSecond()
-            s to e
-        }
-        for (a in aggs) {
-            val start = Instant.ofEpochSecond(a.startEpochSec)
-            val end = Instant.ofEpochSecond(a.endEpochSec)
-            // Per-endpoint offsets: a day spanning a DST transition has different start/end offsets.
-            val offStart = zone.rules.getOffset(start)
-            val offEnd = zone.rules.getOffset(end)
-            a.activeKcal?.let {
-                aggRecords.add(ActiveCaloriesBurnedRecord(
-                    startTime = start, startZoneOffset = offStart, endTime = end, endZoneOffset = offEnd,
-                    energy = Energy.kilocalories(it),
-                    metadata = meta("energy", a.day, version),
-                ))
-            }
-            a.steps?.let {
-                aggRecords.add(StepsRecord(
-                    startTime = start, startZoneOffset = offStart, endTime = end, endZoneOffset = offEnd,
-                    count = it,
-                    metadata = meta("steps", a.day, version),
-                ))
-            }
-        }
+        // NOTE: steps + active-calories are deliberately NOT written back (was #528). NOOP's strap
+        // step/kcal figures are estimates, and the phone pedometer / a watch already feed Health
+        // Connect the authoritative values — writing ours too would double-count in the OS's daily
+        // totals. iOS (#249) excludes them for the same reason; this keeps the two platforms aligned.
+        // The unique strap signals (vitals, HR, sleep, workouts) are still written below.
 
         // Each export concern inserts independently (own runCatching) so a failure in one — e.g. a
         // revoked per-type WRITE permission — can't suppress the others.
         var total = 0
         if (records.isNotEmpty()) {
             total += runCatching { client.insertRecords(records); records.size }.getOrDefault(0)
-        }
-        if (aggRecords.isNotEmpty()) {
-            total += runCatching { client.insertRecords(aggRecords); aggRecords.size }.getOrDefault(0)
         }
         total += runCatching { writeHeartRate(client, context, repo, deviceId, version) }.getOrDefault(0)
         total += runCatching { writeSleep(client, repo, deviceId) }.getOrDefault(0)

--- a/android/app/src/main/java/com/noop/ingest/HealthExportPlan.kt
+++ b/android/app/src/main/java/com/noop/ingest/HealthExportPlan.kt
@@ -14,38 +14,6 @@ package com.noop.ingest
  */
 object HealthExportPlan {
 
-    // ---- Daily aggregates: Active Energy + Steps (one record per local calendar day) ----
-
-    data class DayInput(val day: String, val steps: Int?, val activeKcal: Double?)
-
-    data class DailyAgg(
-        val day: String,
-        val startEpochSec: Long,
-        val endEpochSec: Long,
-        val steps: Long?,
-        val activeKcal: Double?,
-    )
-
-    /**
-     * One descriptor per day that has positive steps and/or positive active kcal and resolvable
-     * day bounds. [bounds] maps a "YYYY-MM-DD" day to (startOfDayEpochSec, startOfNextDayEpochSec);
-     * inject it so zone math stays out of this pure function.
-     */
-    fun dailyAggregates(
-        days: List<DayInput>,
-        bounds: (String) -> Pair<Long, Long>?,
-    ): List<DailyAgg> {
-        val out = ArrayList<DailyAgg>()
-        for (d in days) {
-            val steps = d.steps?.toLong()?.takeIf { it > 0 }
-            val kcal = d.activeKcal?.takeIf { it > 0.0 }
-            if (steps == null && kcal == null) continue
-            val b = bounds(d.day) ?: continue
-            out.add(DailyAgg(d.day, b.first, b.second, steps, kcal))
-        }
-        return out
-    }
-
     // ---- Heart-rate series: full-res inside workout/sleep windows, decimated elsewhere ----
 
     data class HrPoint(val tsSec: Long, val bpm: Int)

--- a/android/app/src/test/java/com/noop/ingest/HealthExportPlanTest.kt
+++ b/android/app/src/test/java/com/noop/ingest/HealthExportPlanTest.kt
@@ -6,71 +6,12 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 
 /**
- * #528 — pure planning logic for the Health Connect export (daily steps/active-energy aggregates,
- * HR decimation/windowing/chunking, sleep AWAKE/SLEEPING mapping). All offline-on-JVM; the SDK glue
- * in [HealthConnectWriter] is the thin untestable layer.
+ * Pure planning logic for the Health Connect export (HR decimation/windowing/chunking, sleep
+ * AWAKE/SLEEPING mapping). All offline-on-JVM; the SDK glue in [HealthConnectWriter] is the thin
+ * untestable layer. (Daily steps/active-energy aggregates were removed with the steps/kcal
+ * write-back — see HealthConnectWriter.)
  */
 class HealthExportPlanTest {
-
-    // Fixed bounds: day "D" -> (1000, 2000) so tests are zone-independent.
-    private val bounds: (String) -> Pair<Long, Long>? =
-        { day -> if (day == "D") 1000L to 2000L else null }
-
-    @Test fun dailyAggregate_emitsStepsAndKcalForADayWithBoth() {
-        val out = HealthExportPlan.dailyAggregates(
-            listOf(HealthExportPlan.DayInput(day = "D", steps = 5000, activeKcal = 420.0)),
-            bounds,
-        )
-        assertEquals(1, out.size)
-        assertEquals("D", out[0].day)
-        assertEquals(1000L, out[0].startEpochSec)
-        assertEquals(2000L, out[0].endEpochSec)
-        assertEquals(5000L, out[0].steps)
-        assertEquals(420.0, out[0].activeKcal!!, 0.001)
-    }
-
-    @Test fun dailyAggregate_skipsDayWithNoStepsAndNoKcal() {
-        val out = HealthExportPlan.dailyAggregates(
-            listOf(HealthExportPlan.DayInput("D", steps = null, activeKcal = null)),
-            bounds,
-        )
-        assertTrue(out.isEmpty())
-    }
-
-    @Test fun dailyAggregate_treatsZeroAsAbsent() {
-        val out = HealthExportPlan.dailyAggregates(
-            listOf(HealthExportPlan.DayInput("D", steps = 0, activeKcal = 0.0)),
-            bounds,
-        )
-        assertTrue(out.isEmpty())
-    }
-
-    @Test fun dailyAggregate_skipsDayWithUnresolvableBounds() {
-        val out = HealthExportPlan.dailyAggregates(
-            listOf(HealthExportPlan.DayInput("UNKNOWN", steps = 100, activeKcal = null)),
-            bounds,
-        )
-        assertTrue(out.isEmpty())
-    }
-
-    @Test fun dailyAggregate_emitsStepsOnlyWhenKcalAbsent() {
-        val out = HealthExportPlan.dailyAggregates(
-            listOf(HealthExportPlan.DayInput("D", steps = 100, activeKcal = null)),
-            bounds,
-        )
-        assertEquals(100L, out[0].steps)
-        assertNull(out[0].activeKcal)
-    }
-
-    @Test fun dailyAggregate_emitsKcalWhenStepsZero() {
-        val out = HealthExportPlan.dailyAggregates(
-            listOf(HealthExportPlan.DayInput("D", steps = 0, activeKcal = 300.0)),
-            bounds,
-        )
-        assertEquals(1, out.size)
-        assertNull(out[0].steps)
-        assertEquals(300.0, out[0].activeKcal!!, 0.001)
-    }
 
     // ---- Heart-rate series tests ----
 


### PR DESCRIPTION
Follow-up to #249. Aligns Android's Health Connect write-back with iOS's Apple Health write-back on the one axis that had a real data-quality downside.

## Why
Android's writer sends NOOP's strap-derived **daily steps + active-calories** to Health Connect (#528). Those are *estimates*, and the phone pedometer / a watch already write the authoritative values — so NOOP writing them too **double-counts** in the OS's daily step total / Move goal for any user with another source. iOS #249 deliberately excludes steps/kcal for this exact reason; Android was the outlier.

## What
Minimal removal — the strap's **unique** signals (vitals, HR, sleep, workouts) still write; only the already-covered steps/kcal stop:
- Drop `StepsRecord` + `ActiveCaloriesBurnedRecord` from the writer's records **and** its write-permission set.
- Remove the now-orphaned `HealthExportPlan.dailyAggregates`/`DayInput` pure builder (used only by that write) + its tests.
- Untouched: the importer-side step **de-overlap** (#589) and active-kcal crediting (#117) — those *read* HC and are unrelated.

## Note / tradeoff
A **strap-only** user (no phone pedometer or watch feeding HC) loses their only HC step source. If serving that case matters, the cleaner long-term answer is a dedup-aware or opt-in "write steps to Health" setting rather than an unconditional write — but that's a bigger change; this PR just removes the default double-count to match iOS.

Sleep-stage granularity still differs (iOS full hypnogram vs Android asleep/awake) — that's a cosmetic richness gap with no data harm, left as-is per the review discussion.

## Tests
`compileFullDebugKotlin` clean; `HealthExportPlanTest` 14/0 (HR/sleep planning intact); `HealthConnectStepsDeOverlapTest` / `HealthConnectActiveKcalTest` / `HealthConnectSelfWriteSkipTest` green.