### PR TITLE
fix(devices): "Connected · not paired" for a WHOOP 5/MG with a refused bond (#221)

### DIFF
--- a/Strand/Screens/DevicesView.swift
+++ b/Strand/Screens/DevicesView.swift
@@ -312,6 +312,30 @@ private struct DevicesContent: View {
     }
 }
 
+// MARK: - Device card pill state (pure, testable)
+
+/// The device card's state-pill label/tone/pulsing, as a priority-ordered pure decision (#221): archived
+/// beats everything; on the active card, reconnecting > bond-refused > live > plain active; a non-active
+/// card is "Paired". Mirrors the Kotlin `devicePillState` in DevicesScreen.kt exactly (see
+/// `DevicePillStateTests` / the Kotlin `DevicePillStateTest`), so a future edit to either side can't
+/// silently reorder "Connected · not paired" vs "Active · Live" without a test catching it.
+struct DevicePillState: Equatable {
+    let label: String
+    let tone: StrandTone
+    var pulsing: Bool = false
+    var showsDot: Bool = true
+
+    static func resolve(isArchived: Bool, isActive: Bool, isReconnecting: Bool,
+                         bondRefused: Bool, isLiveConnected: Bool) -> DevicePillState {
+        if isArchived { return DevicePillState(label: "Removed", tone: .neutral, showsDot: false) }
+        guard isActive else { return DevicePillState(label: "Paired", tone: .neutral) }
+        if isReconnecting { return DevicePillState(label: "Reconnecting…", tone: .warning, pulsing: true) }
+        if bondRefused { return DevicePillState(label: "Connected · not paired", tone: .warning) }
+        if isLiveConnected { return DevicePillState(label: "Active · Live", tone: .positive, pulsing: true) }
+        return DevicePillState(label: "Active", tone: .positive)
+    }
+}
+
 // MARK: - Device card
 
 /// One paired device as a card: name, brand/model, capabilities line, a state pill, last-seen, and a
@@ -534,28 +558,19 @@ private struct DeviceCard: View {
         pct < 15 ? StrandPalette.statusCritical : pct < 35 ? StrandPalette.statusWarning : StrandPalette.chargeColor
     }
 
+    /// The pure `DevicePillState.resolve` priority (#221): reboot's "Reconnecting…" beats a bond refusal's
+    /// "Connected · not paired", which beats "Active · Live" — pinned by `DevicePillStateTests` instead of
+    /// only verified visually.
+    private var pillState: DevicePillState {
+        DevicePillState.resolve(isArchived: device.status == .archived, isActive: isActive,
+                                 isReconnecting: isReconnecting, bondRefused: bondRefused,
+                                 isLiveConnected: isLiveConnected)
+    }
+
     private var statePill: some View {
-        Group {
-            if device.status == .archived {
-                StatePill("Removed", tone: .neutral, showsDot: false)
-            } else if isActive {
-                // Reboot window (#166): the user's Restart dropped the link and NOOP is auto-reconnecting.
-                // Show it as intentional rather than a silent drop to "Active"; clears to "Active · Live"
-                // the instant the link is back.
-                if isReconnecting {
-                    StatePill("Reconnecting…", tone: .warning, pulsing: true)
-                } else if bondRefused {
-                    // #221: BLE-connected but the encrypted bond was refused — no data flows, so this
-                    // must not read as "Active · Live".
-                    StatePill("Connected · not paired", tone: .warning)
-                } else {
-                    StatePill(isLiveConnected ? "Active · Live" : "Active",
-                              tone: .positive, pulsing: isLiveConnected)
-                }
-            } else {
-                StatePill("Paired", tone: .neutral)
-            }
-        }
+        let state = pillState
+        return StatePill(LocalizedStringKey(state.label), tone: state.tone,
+                          showsDot: state.showsDot, pulsing: state.pulsing)
     }
 
     private var actionsMenu: some View {
@@ -633,7 +648,10 @@ private struct DeviceCard: View {
 
     private var lastSeenLine: String {
         if device.status == .archived { return String(localized: "Removed · data kept") }
-        if bondRefused { return String(localized: "Connected, but not paired — tap ⋯ for help") }
+        // No "tap ⋯" pointer here (#221 review) — the full how-to-fix guidance is already inline on the
+        // card just below, so pointing at the menu would send the user looking for help that's already
+        // on screen.
+        if bondRefused { return String(localized: "Connected, but not paired") }
         if isLiveConnected { return String(localized: "Connected now") }
         return String(localized: "Last seen \(relativeAgo(TimeInterval(device.lastSeenAt)))")
     }

--- a/Strand/Screens/DevicesView.swift
+++ b/Strand/Screens/DevicesView.swift
@@ -94,6 +94,16 @@ private struct DevicesContent: View {
                     device: device,
                     isActive: device.status == .active,
                     isLiveConnected: device.status == .active && live.connected,
+                    // #221: a WHOOP 5/MG can be BLE-connected yet have its ENCRYPTED bond refused (the
+                    // WHOOP app, or a stale iOS pairing, holds the single-app bond) — no HR/biometric data
+                    // flows even though the link is up, so "Active · Live" overstates it. pairingHint is
+                    // set only once that refusal is genuinely detected (#78), never during a normal
+                    // connect, so this can't false-alarm a working 4.0 (its pairingHint stays nil) or a
+                    // fresh 5/MG connect.
+                    bondRefused: device.status == .active && live.connected && live.pairingHint != nil,
+                    // The full #78 how-to-fix guidance, surfaced on the card itself when bondRefused so
+                    // the fix is self-service instead of buried in the strap log.
+                    pairingHint: device.status == .active ? live.pairingHint : nil,
                     // Reboot in flight + link currently down → "Reconnecting…" (#166).
                     isReconnecting: device.status == .active && live.rebootInProgress && !live.connected,
                     // The live battery belongs to whichever device is ACTIVE + connected (the WHOOP, a
@@ -310,6 +320,14 @@ private struct DeviceCard: View {
     let device: PairedDevice
     let isActive: Bool
     let isLiveConnected: Bool
+    /// #221: the active+connected strap is BLE-linked but its encrypted bond was refused (#78 state) —
+    /// no HR/biometric data flows despite the link being up. Drives the "Connected · not paired" pill
+    /// (which takes priority over "Active · Live") and the honest subtitle/footnote. False for every
+    /// non-WHOOP source and for a normal connect.
+    var bondRefused: Bool = false
+    /// #221: the full #78 pairing-refusal guidance (bonded-elsewhere / pairing-mode / Forget This Device
+    /// steps), shown on the card when `bondRefused` so the fix is self-service. nil otherwise.
+    var pairingHint: String? = nil
     /// The active strap's link dropped for a user-initiated reboot and NOOP is auto-reconnecting (#166).
     /// Drives the transient "Reconnecting…" pill; false for every non-reboot state.
     var isReconnecting: Bool = false
@@ -390,6 +408,16 @@ private struct DeviceCard: View {
                         .font(StrandFont.footnote)
                         .foregroundStyle(StrandPalette.textTertiary)
                         .fixedSize(horizontal: false, vertical: true)
+                }
+
+                // #221: the full #78 pairing-refusal guidance, self-service right on the card instead of
+                // buried in the strap log — only when the bond was genuinely refused.
+                if bondRefused, let hint = pairingHint {
+                    Text(hint)
+                        .font(StrandFont.footnote)
+                        .foregroundStyle(StrandPalette.statusWarning)
+                        .fixedSize(horizontal: false, vertical: true)
+                        .accessibilityLabel(hint)
                 }
 
                 // Live battery for the active+connected device, shown as a liquid tube that fills to the
@@ -516,6 +544,10 @@ private struct DeviceCard: View {
                 // the instant the link is back.
                 if isReconnecting {
                     StatePill("Reconnecting…", tone: .warning, pulsing: true)
+                } else if bondRefused {
+                    // #221: BLE-connected but the encrypted bond was refused — no data flows, so this
+                    // must not read as "Active · Live".
+                    StatePill("Connected · not paired", tone: .warning)
                 } else {
                     StatePill(isLiveConnected ? "Active · Live" : "Active",
                               tone: .positive, pulsing: isLiveConnected)
@@ -601,6 +633,7 @@ private struct DeviceCard: View {
 
     private var lastSeenLine: String {
         if device.status == .archived { return String(localized: "Removed · data kept") }
+        if bondRefused { return String(localized: "Connected, but not paired — tap ⋯ for help") }
         if isLiveConnected { return String(localized: "Connected now") }
         return String(localized: "Last seen \(relativeAgo(TimeInterval(device.lastSeenAt)))")
     }
@@ -821,6 +854,15 @@ struct DeviceCardCatalog: View {
                                             Self.whoopCaps.union([.steps])),
                            isActive: false, isLiveConnected: false,
                            onMakeActive: {}, onRename: {}, onRemove: {})
+                // #221: a WHOOP 5/MG that's BLE-connected but whose encrypted bond was refused (#78) — no
+                // data flows despite the link being up. Renders the "Connected · not paired" pill + the
+                // self-service pairing guidance so this can be verified WITHOUT reproducing the bond
+                // refusal on real hardware.
+                DeviceCard(device: Self.dev("whoop-5-refused", "WHOOP", "5.0 MG",
+                                            Self.whoopCaps.union([.steps])),
+                           isActive: true, isLiveConnected: true, bondRefused: true,
+                           pairingHint: "NOOP can see your strap but it's refusing to pair - it's likely still bonded to the official WHOOP app, or your phone is holding an old pairing. To fix it: (1) fully close the WHOOP app, (2) on a 5.0/MG, tap the band repeatedly until the LEDs flash blue (pairing mode), (3) if your strap is listed under iPhone Settings → Bluetooth, tap it and choose Forget This Device, then reconnect in NOOP.",
+                           onMakeActive: {}, onRename: {}, onRemove: {})
                 DeviceCard(device: Self.dev("strap-d", "Polar", "H10", [.hr, .hrv]),
                            isActive: false, isLiveConnected: false,
                            onMakeActive: {}, onRename: {}, onRemove: {})
@@ -858,6 +900,25 @@ struct OuraDeviceDemoScreen: View {
                            isActive: false, isLiveConnected: false,
                            onMakeActive: {}, onRename: {}, onRemove: {})
             }
+        }
+    }
+}
+
+/// DEBUG-only: just the WHOOP 5/MG bond-refused card, so `--demo-screen bondrefused` can screenshot the
+/// "Connected · not paired" pill + the self-service #78 pairing guidance (#221) WITHOUT reproducing the
+/// bond refusal on real hardware. Same file as `DeviceCard` so it can reach it. Stripped from Release.
+struct BondRefusedDemoScreen: View {
+    var body: some View {
+        ScreenScaffold(title: "Devices",
+                       subtitle: "A WHOOP 5/MG whose encrypted bond was refused (#78).",
+                       topBackground: liquidScaffoldSky()) {
+            DeviceCard(device: PairedDevice(id: "whoop-5-refused-solo", brand: "WHOOP", model: "5.0 MG",
+                                            nickname: nil, peripheralId: nil, sourceKind: .liveBLE,
+                                            capabilities: [.hr, .hrv, .spo2, .skinTemp, .sleep, .strainLoad, .steps],
+                                            status: .active, addedAt: 0, lastSeenAt: 0),
+                       isActive: true, isLiveConnected: true, bondRefused: true,
+                       pairingHint: "NOOP can see your strap but it's refusing to pair - it's likely still bonded to the official WHOOP app, or your phone is holding an old pairing. To fix it: (1) fully close the WHOOP app, (2) on a 5.0/MG, tap the band repeatedly until the LEDs flash blue (pairing mode), (3) if your strap is listed under iPhone Settings → Bluetooth, tap it and choose Forget This Device, then reconnect in NOOP.",
+                       onMakeActive: {}, onRename: {}, onRemove: {})
         }
     }
 }

--- a/StrandTests/DevicePillStateTests.swift
+++ b/StrandTests/DevicePillStateTests.swift
@@ -1,0 +1,41 @@
+import XCTest
+@testable import Strand
+
+/// Pins the Devices card's state-pill priority (#221): "Connected · not paired" must beat "Active · Live"
+/// but yield to a reboot's "Reconnecting…". Mirrors the Kotlin `DevicePillStateTest` exactly — a silent
+/// reorder on either platform would otherwise only be caught by eyeballing a screenshot.
+final class DevicePillStateTests: XCTestCase {
+
+    func testBondRefused_beatsActiveLive_butYieldsToReconnecting() {
+        XCTAssertEqual(
+            DevicePillState.resolve(isArchived: false, isActive: true, isReconnecting: false,
+                                     bondRefused: true, isLiveConnected: true).label,
+            "Connected · not paired")
+        XCTAssertEqual(
+            DevicePillState.resolve(isArchived: false, isActive: true, isReconnecting: true,
+                                     bondRefused: true, isLiveConnected: true).label,
+            "Reconnecting…")
+    }
+
+    func testNormalConnect_isUnaffected() {
+        XCTAssertEqual(
+            DevicePillState.resolve(isArchived: false, isActive: true, isReconnecting: false,
+                                     bondRefused: false, isLiveConnected: true).label,
+            "Active · Live")
+        XCTAssertEqual(
+            DevicePillState.resolve(isArchived: false, isActive: true, isReconnecting: false,
+                                     bondRefused: false, isLiveConnected: false).label,
+            "Active")
+    }
+
+    func testNonActiveAndArchived() {
+        XCTAssertEqual(
+            DevicePillState.resolve(isArchived: false, isActive: false, isReconnecting: false,
+                                     bondRefused: false, isLiveConnected: false).label,
+            "Paired")
+        XCTAssertEqual(
+            DevicePillState.resolve(isArchived: true, isActive: false, isReconnecting: false,
+                                     bondRefused: false, isLiveConnected: false).label,
+            "Removed")
+    }
+}

--- a/StrandiOS/App/StrandiOSApp.swift
+++ b/StrandiOS/App/StrandiOSApp.swift
@@ -334,6 +334,10 @@ enum DemoScreens {
         // Oura device card: the locally-adopted Oura ring card (Beta chip + per-gen honest capability copy
         // + battery + local-state note), rendered with mock data, no ring required.
         case "ouradevice": return AnyView(OuraDeviceDemoScreen())
+        // #221: a WHOOP 5/MG whose encrypted bond was refused (#78) — the "Connected · not paired" pill
+        // + self-service pairing guidance, screenshot-able WITHOUT reproducing the bond refusal on real
+        // hardware.
+        case "bondrefused": return AnyView(BondRefusedDemoScreen())
         default:         return nil
         }
     }

--- a/android/app/src/main/java/com/noop/ui/DevicesScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/DevicesScreen.kt
@@ -163,6 +163,15 @@ fun DevicesScreen(
                 device = device,
                 isActive = device.status == DeviceStatus.active.name,
                 isLiveConnected = device.status == DeviceStatus.active.name && live.connected,
+                // #221: a WHOOP 5/MG can be BLE-connected yet have its ENCRYPTED bond refused (the WHOOP
+                // app, or a stale pairing, holds the single-app bond) — no HR/biometric data flows even
+                // though the link is up, so "Active · Live" overstates it. pairingHint is set only once
+                // that refusal is genuinely detected (#78), never during a normal connect, so this can't
+                // false-alarm a working 4.0 (its pairingHint stays null) or a fresh 5/MG connect.
+                bondRefused = device.status == DeviceStatus.active.name && live.connected && live.pairingHint != null,
+                // The full #78 how-to-fix guidance, surfaced on the card itself when bondRefused so the
+                // fix is self-service instead of buried in the strap log.
+                pairingHint = if (device.status == DeviceStatus.active.name) live.pairingHint else null,
                 // Reboot in flight + link currently down → "Reconnecting…" (#166).
                 isReconnecting = device.status == DeviceStatus.active.name && live.rebootInProgress && !live.connected,
                 // The live battery belongs to whichever device is ACTIVE + connected (WHOOP, a generic
@@ -341,6 +350,14 @@ private fun DeviceCard(
     device: PairedDeviceRow,
     isActive: Boolean,
     isLiveConnected: Boolean,
+    /** #221: the active+connected strap is BLE-linked but its encrypted bond was refused (#78 state) — no
+     *  HR/biometric data flows despite the link being up. Drives the "Connected · not paired" pill (which
+     *  takes priority over "Active · Live") and the honest subtitle. False for every non-WHOOP source and
+     *  for a normal connect. */
+    bondRefused: Boolean = false,
+    /** #221: the full #78 pairing-refusal guidance (bonded-elsewhere / pairing-mode / forget-device
+     *  steps), shown on the card when [bondRefused] so the fix is self-service. null otherwise. */
+    pairingHint: String? = null,
     /** The active strap's link dropped for a user-initiated reboot and NOOP is auto-reconnecting (#166).
      *  Drives the transient "Reconnecting…" pill; false for every non-reboot state. */
     isReconnecting: Boolean = false,
@@ -408,7 +425,7 @@ private fun DeviceCard(
                     StatePill("Beta", tone = StrandTone.Warning, showsDot = false)
                     Spacer(Modifier.width(6.dp))
                 }
-                StatePill(device, isActive, isLiveConnected, isReconnecting)
+                StatePill(device, isActive, isLiveConnected, bondRefused, isReconnecting)
             }
 
             // Honest local-takeover state row for an adopted Oura ring that is paired but not the
@@ -432,6 +449,12 @@ private fun DeviceCard(
                 Text(profile.footnote, style = NoopType.footnote, color = Palette.textTertiary)
             }
 
+            // #221: the full #78 pairing-refusal guidance, self-service right on the card instead of
+            // buried in the strap log — only when the bond was genuinely refused.
+            if (bondRefused && pairingHint != null) {
+                Text(pairingHint, style = NoopType.footnote, color = Palette.statusWarning)
+            }
+
             // Live battery as a small liquid TUBE — the active+connected device's reported % (WHOOP, a
             // generic strap or an FTMS machine all funnel into live.batteryPct). A genuine single-value
             // progress bar, so a static (posed) LiquidTube is exactly right; it replaces the "· Battery x%"
@@ -442,7 +465,7 @@ private fun DeviceCard(
 
             Row(verticalAlignment = Alignment.CenterVertically) {
                 Text(
-                    lastSeenLine(device, isLiveConnected) +
+                    lastSeenLine(device, isLiveConnected, bondRefused) +
                         (liveFirmware?.let { " · FW $it" } ?: ""),
                     style = NoopType.footnote,
                     color = Palette.textTertiary,
@@ -518,6 +541,7 @@ private fun StatePill(
     device: PairedDeviceRow,
     isActive: Boolean,
     isLiveConnected: Boolean,
+    bondRefused: Boolean = false,
     isReconnecting: Boolean = false,
 ) {
     when {
@@ -527,6 +551,10 @@ private fun StatePill(
         // as intentional rather than a silent drop to "Active"; clears to "Active · Live" once the link is back.
         isActive && isReconnecting ->
             StatePill("Reconnecting…", tone = StrandTone.Warning, pulsing = true)
+        // #221: BLE-connected but the encrypted bond was refused — no data flows, so this must not read
+        // as "Active · Live".
+        isActive && bondRefused ->
+            StatePill("Connected · not paired", tone = StrandTone.Warning)
         isActive ->
             StatePill(
                 if (isLiveConnected) "Active · Live" else "Active",
@@ -1038,8 +1066,9 @@ private fun OuraLocalStateNote() {
     }
 }
 
-private fun lastSeenLine(device: PairedDeviceRow, isLiveConnected: Boolean): String = when {
+private fun lastSeenLine(device: PairedDeviceRow, isLiveConnected: Boolean, bondRefused: Boolean = false): String = when {
     device.status == DeviceStatus.archived.name -> "Removed · data kept"
+    bondRefused -> "Connected, but not paired — tap ⋯ for help"
     isLiveConnected -> "Connected now"
     else -> "Last seen ${relativeAgo(device.lastSeenAt)}"
 }

--- a/android/app/src/main/java/com/noop/ui/DevicesScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/DevicesScreen.kt
@@ -536,6 +536,39 @@ private fun BatteryTube(pct: Int) {
     }
 }
 
+/**
+ * The device card's state-pill label + tone, as a priority-ordered pure decision (#221): archived beats
+ * everything; on the active card, reconnecting > bond-refused > live > plain active; a non-active card is
+ * "Paired". Mirrors the Swift `DevicePillState.resolve` in DevicesView.swift exactly (see
+ * `DevicePillStateTest` / the Swift `DevicePillStateTests`), so a future edit to either side can't
+ * silently reorder "Connected · not paired" vs "Active · Live" without a test catching it.
+ */
+internal data class DevicePillState(
+    val label: String,
+    val tone: StrandTone,
+    val pulsing: Boolean = false,
+    val showsDot: Boolean = true,
+)
+
+internal fun devicePillState(
+    isArchived: Boolean,
+    isActive: Boolean,
+    isReconnecting: Boolean,
+    bondRefused: Boolean,
+    isLiveConnected: Boolean,
+): DevicePillState = when {
+    isArchived -> DevicePillState("Removed", StrandTone.Neutral, showsDot = false)
+    !isActive -> DevicePillState("Paired", StrandTone.Neutral)
+    // Reboot window (#166): the user's Restart dropped the link and NOOP is auto-reconnecting. Show it
+    // as intentional rather than a silent drop to "Active"; clears to "Active · Live" once the link is back.
+    isReconnecting -> DevicePillState("Reconnecting…", StrandTone.Warning, pulsing = true)
+    // #221: BLE-connected but the encrypted bond was refused — no data flows, so this must not read
+    // as "Active · Live".
+    bondRefused -> DevicePillState("Connected · not paired", StrandTone.Warning)
+    isLiveConnected -> DevicePillState("Active · Live", StrandTone.Positive, pulsing = true)
+    else -> DevicePillState("Active", StrandTone.Positive)
+}
+
 @Composable
 private fun StatePill(
     device: PairedDeviceRow,
@@ -544,25 +577,14 @@ private fun StatePill(
     bondRefused: Boolean = false,
     isReconnecting: Boolean = false,
 ) {
-    when {
-        device.status == DeviceStatus.archived.name ->
-            StatePill("Removed", tone = StrandTone.Neutral, showsDot = false)
-        // Reboot window (#166): the user's Restart dropped the link and NOOP is auto-reconnecting. Show it
-        // as intentional rather than a silent drop to "Active"; clears to "Active · Live" once the link is back.
-        isActive && isReconnecting ->
-            StatePill("Reconnecting…", tone = StrandTone.Warning, pulsing = true)
-        // #221: BLE-connected but the encrypted bond was refused — no data flows, so this must not read
-        // as "Active · Live".
-        isActive && bondRefused ->
-            StatePill("Connected · not paired", tone = StrandTone.Warning)
-        isActive ->
-            StatePill(
-                if (isLiveConnected) "Active · Live" else "Active",
-                tone = StrandTone.Positive,
-                pulsing = isLiveConnected,
-            )
-        else -> StatePill("Paired", tone = StrandTone.Neutral)
-    }
+    val state = devicePillState(
+        isArchived = device.status == DeviceStatus.archived.name,
+        isActive = isActive,
+        isReconnecting = isReconnecting,
+        bondRefused = bondRefused,
+        isLiveConnected = isLiveConnected,
+    )
+    StatePill(state.label, tone = state.tone, showsDot = state.showsDot, pulsing = state.pulsing)
 }
 
 @Composable
@@ -1068,7 +1090,9 @@ private fun OuraLocalStateNote() {
 
 private fun lastSeenLine(device: PairedDeviceRow, isLiveConnected: Boolean, bondRefused: Boolean = false): String = when {
     device.status == DeviceStatus.archived.name -> "Removed · data kept"
-    bondRefused -> "Connected, but not paired — tap ⋯ for help"
+    // No "tap ⋯" pointer here (#221 review) — the full how-to-fix guidance is already inline on the card
+    // just below, so pointing at the menu would send the user looking for help that's already on screen.
+    bondRefused -> "Connected, but not paired"
     isLiveConnected -> "Connected now"
     else -> "Last seen ${relativeAgo(device.lastSeenAt)}"
 }

--- a/android/app/src/test/java/com/noop/ui/DevicePillStateTest.kt
+++ b/android/app/src/test/java/com/noop/ui/DevicePillStateTest.kt
@@ -1,0 +1,66 @@
+package com.noop.ui
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Pins the Devices card's state-pill priority (#221): "Connected · not paired" must beat "Active · Live"
+ * but yield to a reboot's "Reconnecting…". Mirrors the Swift `DevicePillStateTests` exactly — a silent
+ * reorder on either platform would otherwise only be caught by eyeballing a screenshot.
+ */
+class DevicePillStateTest {
+
+    @Test
+    fun bondRefused_beatsActiveLive_butYieldsToReconnecting() {
+        assertEquals(
+            "Connected · not paired",
+            devicePillState(
+                isArchived = false, isActive = true, isReconnecting = false,
+                bondRefused = true, isLiveConnected = true,
+            ).label,
+        )
+        assertEquals(
+            "Reconnecting…",
+            devicePillState(
+                isArchived = false, isActive = true, isReconnecting = true,
+                bondRefused = true, isLiveConnected = true,
+            ).label,
+        )
+    }
+
+    @Test
+    fun normalConnect_isUnaffected() {
+        assertEquals(
+            "Active · Live",
+            devicePillState(
+                isArchived = false, isActive = true, isReconnecting = false,
+                bondRefused = false, isLiveConnected = true,
+            ).label,
+        )
+        assertEquals(
+            "Active",
+            devicePillState(
+                isArchived = false, isActive = true, isReconnecting = false,
+                bondRefused = false, isLiveConnected = false,
+            ).label,
+        )
+    }
+
+    @Test
+    fun nonActiveAndArchived() {
+        assertEquals(
+            "Paired",
+            devicePillState(
+                isArchived = false, isActive = false, isReconnecting = false,
+                bondRefused = false, isLiveConnected = false,
+            ).label,
+        )
+        assertEquals(
+            "Removed",
+            devicePillState(
+                isArchived = true, isActive = false, isReconnecting = false,
+                bondRefused = false, isLiveConnected = false,
+            ).label,
+        )
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #221. A WHOOP 5/MG can be BLE-connected but have its **encrypted bond refused** (the #78 state: the official WHOOP app, or a stale iOS/Android pairing, holds the single-app bond). No HR/biometric data flows in that state, yet the Devices card read "Active · Live" — misleading, since the user reasonably assumes it's working.

- Adds a `bondRefused` state to the device card, gated on the *existing* `live.pairingHint != nil` signal (set only once the bond refusal is genuinely detected, #78) — so it can't false-alarm a normal connect or a working 4.0 (whose `pairingHint` stays nil).
- New pill **"Connected · not paired"** (takes priority over "Active · Live"), honest subtitle ("Connected, but not paired — tap ⋯ for help"), and the full #78 self-service pairing guidance surfaced right on the card (nice-to-have from the issue) instead of buried in the strap log.
- Mirrored on Android (`DevicesScreen.kt`) for feature-level parity: same pill priority, same subtitle, same inline guidance.
- Added a DEBUG-only `--demo-screen bondrefused` screen (iOS) so the new state can be screenshotted/verified without reproducing the bond refusal on real hardware.

## Test plan

- [x] `xcodebuild -scheme Strand -destination 'platform=macOS' build` → **BUILD SUCCEEDED** (app-target Swift; `app-build.yml` is disabled, no default CI covers this)
- [x] `xcodebuild -scheme NOOPiOS -destination 'platform=iOS Simulator' build` → **BUILD SUCCEEDED**
- [x] `./gradlew compileFullDebugKotlin` → **BUILD SUCCESSFUL**
- [x] `./gradlew testFullDebugUnitTest` → all 2435 JVM tests pass (en-US locale), no regressions
- [x] Visually verified in the iOS Simulator via `--demo-screen bondrefused`: pill reads "Connected · not paired" (warning tone), full pairing hint renders, subtitle reads correctly; a normal active+connected card (WHOOP 4.0) is unaffected and still reads "Active · Live"
- [ ] **Not verified on a real WHOOP 5/MG in the actual bond-refused state** — the behavior itself (BLE connect + bond refusal timing) needs on-device confirmation; this PR validates the UI logic exhaustively but can't reproduce the BLE-level refusal without hardware.

