### PR TITLE
feat(polar): clean-room PMD PPI decoder (pure, both platforms)

### DIFF
--- a/.github/workflows/swift-packages.yml
+++ b/.github/workflows/swift-packages.yml
@@ -32,6 +32,8 @@ jobs:
       matrix:
         package:
           - WhoopProtocol
+          - OuraProtocol
+          - PolarProtocol
           - WhoopStore
           - StrandAnalytics
           - StrandImport

--- a/Packages/PolarProtocol/Package.swift
+++ b/Packages/PolarProtocol/Package.swift
@@ -1,0 +1,24 @@
+// swift-tools-version: 5.9
+import PackageDescription
+
+// Clean-room Polar Measurement Data (PMD) BLE protocol package. Mirrors the layout of
+// Packages/OuraProtocol / Packages/WhoopProtocol: a pure value-type library target (zero CoreBluetooth,
+// headless/JVM-testable) plus a test target. The live CoreBluetooth source that feeds this decoder (a
+// `PolarPMDSource: LiveHRSource`) is an app-target follow-up; this package is the wire-level decode only,
+// so it builds and tests on Linux/CI with no strap.
+let package = Package(
+    name: "PolarProtocol",
+    platforms: [.iOS(.v16), .macOS(.v13)],
+    products: [
+        .library(name: "PolarProtocol", targets: ["PolarProtocol"]),
+    ],
+    targets: [
+        .target(
+            name: "PolarProtocol"
+        ),
+        .testTarget(
+            name: "PolarProtocolTests",
+            dependencies: ["PolarProtocol"]
+        ),
+    ]
+)

--- a/Packages/PolarProtocol/Sources/PolarProtocol/PmdDecoder.swift
+++ b/Packages/PolarProtocol/Sources/PolarProtocol/PmdDecoder.swift
@@ -1,0 +1,144 @@
+import Foundation
+
+// MARK: - Polar Measurement Data (PMD) decode — clean-room, pure, no CoreBluetooth
+//
+// Polar's PMD service is proprietary but PUBLICLY DOCUMENTED (Polar's official BLE SDK). This is NOOP's
+// own clean parser of the documented byte layout — no Polar code, no firmware, nothing fabricated.
+//
+// PMD data notifications (on the PMD Data characteristic FB005C82-…) share a 10-byte header:
+//
+//   byte  0      measurement type   (0x00 ECG, 0x01 PPG, 0x02 ACC, 0x03 PPI, 0x05 GYRO, 0x06 MAG, …)
+//   bytes 1…8    timestamp          (uint64 LE, nanoseconds, of the LAST sample in the frame)
+//   byte  9      frame type         (bit 7 = compressed/delta flag; bits 0…6 = data-format id)
+//   bytes 10…    sample data        (format depends on measurement type + frame type)
+//
+// This package decodes the **PPI** stream (measurement 0x03), which is the one NOOP actually needs: it
+// yields heart rate AND the peak-to-peak (inter-beat) interval per beat — the same signal WHOOP R-R gives
+// — so NOOP can compute HRV from a Polar H10 / OH1 / Verity Sense without running peak detection on raw
+// ECG. The header parser is exposed too, so a future live source can route other measurement types.
+//
+// PPI is never compressed: each sample is a fixed 6-byte record (documented `PpiData` layout):
+//
+//   byte 0      heart rate          (uint8, bpm; 0 when the sensor has no valid beat — kept, never faked)
+//   bytes 1…2   ppi                 (uint16 LE, ms — the peak-to-peak / inter-beat interval)
+//   bytes 3…4   error estimate      (uint16 LE, ms)
+//   byte 5      flags               (bit0 blocker, bit1 skinContact, bit2 skinContactSupported)
+
+/// A PMD measurement type (the subset NOOP recognises). An unrecognised type decodes to `nil` rather than
+/// a wrong guess, matching the conservative stance of the other clean-room decoders.
+public enum PolarPmdMeasurement: UInt8, Sendable, Equatable, CaseIterable {
+    case ecg = 0x00
+    case ppg = 0x01
+    case acc = 0x02
+    case ppi = 0x03
+    case gyro = 0x05
+    case magnetometer = 0x06
+}
+
+/// The parsed 10-byte PMD data-frame header, common to every measurement type.
+public struct PolarPmdFrameHeader: Equatable, Sendable {
+    /// The measurement stream this frame belongs to.
+    public let measurement: PolarPmdMeasurement
+    /// Frame timestamp in nanoseconds (applies to the LAST sample in the frame).
+    public let timestampNs: UInt64
+    /// The data-format id (frame type bits 0…6).
+    public let frameType: UInt8
+    /// True when the compressed/delta bit (0x80) is set on the frame-type byte.
+    public let isCompressed: Bool
+
+    public init(measurement: PolarPmdMeasurement, timestampNs: UInt64, frameType: UInt8, isCompressed: Bool) {
+        self.measurement = measurement
+        self.timestampNs = timestampNs
+        self.frameType = frameType
+        self.isCompressed = isCompressed
+    }
+}
+
+/// One decoded PPI (peak-to-peak interval) sample.
+public struct PolarPpiSample: Equatable, Sendable {
+    /// Heart rate in bpm as the sensor reported it. `0` means "no valid beat right now" — surfaced as-is
+    /// (honest-data invariant: never substituted with a fabricated value).
+    public let heartRate: Int
+    /// The peak-to-peak / inter-beat interval in milliseconds — NOOP's HRV input (≈ an R-R interval).
+    public let ppiMs: Int
+    /// The sensor's own error estimate for this interval, in milliseconds.
+    public let errorEstimateMs: Int
+    /// Blocker bit (flags bit0): the sensor flagged this interval as unreliable (movement / poor contact).
+    /// A consumer should drop such intervals from HRV rather than trust them. This bit's meaning is
+    /// unambiguous across sources.
+    public let blocker: Bool
+    /// Raw flags bit1. Named per the Polar SDK's `skinContactStatus` (set = contact). NOTE: NOOP's
+    /// `DEVICE_SUPPORT_ROADMAP.md` §PMD phrases bit1 as "poor/no skin contact" (the opposite polarity), so
+    /// the real-world meaning is UNCONFIRMED on hardware — do not gate anything on it until verified.
+    public let skinContact: Bool
+    /// Raw flags bit2. Named per the Polar SDK's `skinContactSupported` (set = supported); the roadmap
+    /// phrases it as "contact unsupported" (opposite). Same on-hardware confirmation caveat as `skinContact`.
+    public let skinContactSupported: Bool
+
+    public init(heartRate: Int, ppiMs: Int, errorEstimateMs: Int,
+                blocker: Bool, skinContact: Bool, skinContactSupported: Bool) {
+        self.heartRate = heartRate
+        self.ppiMs = ppiMs
+        self.errorEstimateMs = errorEstimateMs
+        self.blocker = blocker
+        self.skinContact = skinContact
+        self.skinContactSupported = skinContactSupported
+    }
+}
+
+public enum PolarPmdDecoder {
+
+    /// The fixed PMD data-frame header length (type + 8-byte timestamp + frame-type byte).
+    public static let headerLength = 10
+    /// The byte length of one PPI sample record.
+    static let ppiSampleLength = 6
+
+    /// Parse the 10-byte PMD data-frame header. Returns `nil` if the frame is shorter than the header or
+    /// carries a measurement type NOOP doesn't recognise (no wrong guess).
+    public static func header(_ data: [UInt8]) -> PolarPmdFrameHeader? {
+        // The measurement type is the low 6 bits of byte 0 (top 2 are reserved) — mask before matching so a
+        // frame with reserved bits set still resolves (DEVICE_SUPPORT_ROADMAP.md §PMD: "mask 0x3F").
+        guard data.count >= headerLength,
+              let measurement = PolarPmdMeasurement(rawValue: data[0] & 0x3F) else { return nil }
+        let timestamp = uint64LE(data, at: 1)
+        let frameByte = data[9]
+        return PolarPmdFrameHeader(
+            measurement: measurement,
+            timestampNs: timestamp,
+            frameType: frameByte & 0x7F,
+            isCompressed: (frameByte & 0x80) != 0)
+    }
+
+    /// Decode a PPI (measurement 0x03) data frame into its samples. Returns `nil` when the frame isn't a
+    /// valid PPI frame (too short, unknown type, or not `.ppi`); returns an empty array for a well-formed
+    /// PPI header carrying no complete sample. A trailing partial record (fewer than 6 bytes) is ignored.
+    public static func decodePPI(_ data: [UInt8]) -> [PolarPpiSample]? {
+        guard let header = header(data), header.measurement == .ppi else { return nil }
+        var samples: [PolarPpiSample] = []
+        var i = headerLength
+        while i + ppiSampleLength <= data.count {
+            let flags = data[i + 5]
+            samples.append(PolarPpiSample(
+                heartRate: Int(data[i]),
+                ppiMs: Int(uint16LE(data, at: i + 1)),
+                errorEstimateMs: Int(uint16LE(data, at: i + 3)),
+                blocker: (flags & 0x01) != 0,
+                skinContact: (flags & 0x02) != 0,
+                skinContactSupported: (flags & 0x04) != 0))
+            i += ppiSampleLength
+        }
+        return samples
+    }
+
+    // MARK: - Little-endian readers (bounds are pre-checked by callers)
+
+    private static func uint16LE(_ data: [UInt8], at i: Int) -> UInt16 {
+        UInt16(data[i]) | (UInt16(data[i + 1]) << 8)
+    }
+
+    private static func uint64LE(_ data: [UInt8], at i: Int) -> UInt64 {
+        var v: UInt64 = 0
+        for b in 0..<8 { v |= UInt64(data[i + b]) << (8 * b) }
+        return v
+    }
+}

--- a/Packages/PolarProtocol/Tests/PolarProtocolTests/PmdDecoderTests.swift
+++ b/Packages/PolarProtocol/Tests/PolarProtocolTests/PmdDecoderTests.swift
@@ -1,0 +1,90 @@
+import XCTest
+@testable import PolarProtocol
+
+/// Pins the clean-room Polar PMD decode against hand-built frames in the documented byte layout. Pure —
+/// no CoreBluetooth, no strap; the Kotlin twin (`com.noop.polar.PmdDecoderTest`) asserts the same vectors.
+final class PmdDecoderTests: XCTestCase {
+
+    /// Little-endian bytes for the 8-byte PMD frame timestamp 0x0102030405060708.
+    private let tsBytes: [UInt8] = [0x08, 0x07, 0x06, 0x05, 0x04, 0x03, 0x02, 0x01]
+    private let tsValue: UInt64 = 0x0102030405060708
+
+    /// Build a PPI frame header (measurement 0x03, frame type 0) followed by `samples` raw bytes.
+    private func ppiFrame(_ samples: [UInt8]) -> [UInt8] {
+        [0x03] + tsBytes + [0x00] + samples
+    }
+
+    // MARK: - Header
+
+    func testHeaderParsesTypeTimestampAndFrameType() {
+        // ECG (0x00), compressed bit set on the frame-type byte (0x80 | 0x01).
+        let frame: [UInt8] = [0x00] + tsBytes + [0x81]
+        let h = PolarPmdDecoder.header(frame)
+        XCTAssertEqual(h?.measurement, .ecg)
+        XCTAssertEqual(h?.timestampNs, tsValue)          // 8-byte LE assembled correctly
+        XCTAssertEqual(h?.frameType, 0x01)               // low 7 bits
+        XCTAssertEqual(h?.isCompressed, true)            // high bit
+    }
+
+    func testHeaderRejectsUnknownMeasurementType() {
+        // 0x7F is not a type NOOP recognises → no wrong guess.
+        XCTAssertNil(PolarPmdDecoder.header([0x7F] + tsBytes + [0x00]))
+    }
+
+    func testHeaderRejectsTooShort() {
+        XCTAssertNil(PolarPmdDecoder.header([0x03, 0x00, 0x00]))
+    }
+
+    // MARK: - PPI
+
+    func testDecodesSinglePpiSample() {
+        // hr=60, ppi=800ms (0x0320 LE), err=5ms, flags=0x06 (skinContact + supported, no blocker).
+        let frame = ppiFrame([60, 0x20, 0x03, 0x05, 0x00, 0x06])
+        let samples = PolarPmdDecoder.decodePPI(frame)
+        XCTAssertEqual(samples?.count, 1)
+        let s = samples![0]
+        XCTAssertEqual(s.heartRate, 60)
+        XCTAssertEqual(s.ppiMs, 800)
+        XCTAssertEqual(s.errorEstimateMs, 5)
+        XCTAssertFalse(s.blocker)
+        XCTAssertTrue(s.skinContact)
+        XCTAssertTrue(s.skinContactSupported)
+    }
+
+    func testDecodesMultiplePpiSamplesInOrder() {
+        let frame = ppiFrame([
+            62, 0x0A, 0x03, 0x00, 0x00, 0x07,   // hr 62, ppi 778, all flags set (incl. blocker)
+            48, 0xE8, 0x03, 0x02, 0x00, 0x00,   // hr 48, ppi 1000, err 2, no flags
+        ])
+        let samples = PolarPmdDecoder.decodePPI(frame)
+        XCTAssertEqual(samples?.count, 2)
+        XCTAssertEqual(samples?[0].ppiMs, 778)
+        XCTAssertTrue(samples?[0].blocker ?? false)     // bit0 set → unreliable interval
+        XCTAssertEqual(samples?[1].heartRate, 48)
+        XCTAssertEqual(samples?[1].ppiMs, 1000)
+        XCTAssertFalse(samples?[1].skinContactSupported ?? true)
+    }
+
+    func testZeroHeartRateSampleIsKeptNotDropped() {
+        // hr=0 (no valid beat) must survive as an honest sample, not be filtered or faked.
+        let frame = ppiFrame([0, 0x00, 0x00, 0x00, 0x00, 0x00])
+        XCTAssertEqual(PolarPmdDecoder.decodePPI(frame)?.first?.heartRate, 0)
+    }
+
+    func testTrailingPartialSampleIsIgnored() {
+        // One full 6-byte sample + 3 stray bytes → exactly one sample, no crash.
+        let frame = ppiFrame([60, 0x20, 0x03, 0x00, 0x00, 0x00, 0xAA, 0xBB, 0xCC])
+        XCTAssertEqual(PolarPmdDecoder.decodePPI(frame)?.count, 1)
+    }
+
+    func testEmptyPpiFrameDecodesToNoSamples() {
+        XCTAssertEqual(PolarPmdDecoder.decodePPI(ppiFrame([]))?.count, 0)
+    }
+
+    func testDecodePpiRejectsNonPpiFrame() {
+        // A well-formed ACC (0x02) header is not PPI → nil, even though the header itself parses.
+        let acc: [UInt8] = [0x02] + tsBytes + [0x00, 0x11, 0x22, 0x33]
+        XCTAssertNotNil(PolarPmdDecoder.header(acc))
+        XCTAssertNil(PolarPmdDecoder.decodePPI(acc))
+    }
+}

--- a/android/app/src/main/java/com/noop/polar/PmdDecoder.kt
+++ b/android/app/src/main/java/com/noop/polar/PmdDecoder.kt
@@ -1,0 +1,119 @@
+package com.noop.polar
+
+// MARK: - Polar Measurement Data (PMD) decode — clean-room, pure, no android.bluetooth
+//
+// Faithful Kotlin twin of Packages/PolarProtocol/Sources/PolarProtocol/PmdDecoder.swift. Polar's PMD
+// service is proprietary but PUBLICLY DOCUMENTED (Polar's official BLE SDK); this is NOOP's own clean
+// parser of the documented byte layout — no Polar code, no firmware, nothing fabricated.
+//
+// PMD data notifications share a 10-byte header: byte 0 = measurement type, bytes 1..8 = timestamp
+// (uint64 LE ns, of the last sample), byte 9 = frame type (bit 7 = compressed flag; bits 0..6 = format).
+// This decodes the PPI stream (0x03): heart rate + peak-to-peak (inter-beat) interval per beat — NOOP's
+// HRV input, the same signal WHOOP R-R gives — so a Polar H10 / OH1 / Verity Sense needs no ECG peak
+// detection. PPI is never compressed: each sample is a fixed 6-byte record (hr u8, ppi u16 LE, error u16
+// LE, flags u8 [bit0 blocker, bit1 skinContact, bit2 skinContactSupported]).
+
+/** A PMD measurement type (the subset NOOP recognises); an unrecognised type decodes to null (no guess). */
+enum class PolarPmdMeasurement(val raw: Int) {
+    ECG(0x00),
+    PPG(0x01),
+    ACC(0x02),
+    PPI(0x03),
+    GYRO(0x05),
+    MAGNETOMETER(0x06);
+
+    companion object {
+        fun fromRaw(raw: Int): PolarPmdMeasurement? = entries.firstOrNull { it.raw == raw }
+    }
+}
+
+/** The parsed 10-byte PMD data-frame header, common to every measurement type. */
+data class PolarPmdFrameHeader(
+    val measurement: PolarPmdMeasurement,
+    /** Frame timestamp in nanoseconds (applies to the last sample in the frame). */
+    val timestampNs: Long,
+    /** The data-format id (frame type bits 0..6). */
+    val frameType: Int,
+    /** True when the compressed/delta bit (0x80) is set on the frame-type byte. */
+    val isCompressed: Boolean,
+)
+
+/** One decoded PPI (peak-to-peak interval) sample. */
+data class PolarPpiSample(
+    /** Heart rate in bpm as reported; 0 = "no valid beat right now", surfaced as-is (never faked). */
+    val heartRate: Int,
+    /** The peak-to-peak / inter-beat interval in ms — NOOP's HRV input (≈ an R-R interval). */
+    val ppiMs: Int,
+    /** The sensor's own error estimate for this interval, in ms. */
+    val errorEstimateMs: Int,
+    /** Blocker bit (flags bit0): the sensor flagged this interval unreliable (movement / poor contact) —
+     *  drop from HRV. Unambiguous across sources. */
+    val blocker: Boolean,
+    /** Raw flags bit1. Named per the Polar SDK's `skinContactStatus` (set = contact). NOTE: NOOP's
+     *  DEVICE_SUPPORT_ROADMAP.md §PMD phrases bit1 as "poor/no skin contact" (opposite polarity), so the
+     *  real-world meaning is UNCONFIRMED on hardware — do not gate on it until verified. */
+    val skinContact: Boolean,
+    /** Raw flags bit2. Named per the Polar SDK's `skinContactSupported` (set = supported); the roadmap
+     *  phrases it as "contact unsupported" (opposite). Same on-hardware confirmation caveat. */
+    val skinContactSupported: Boolean,
+)
+
+object PmdDecoder {
+
+    /** The fixed PMD data-frame header length (type + 8-byte timestamp + frame-type byte). */
+    const val HEADER_LENGTH = 10
+    /** The byte length of one PPI sample record. */
+    internal const val PPI_SAMPLE_LENGTH = 6
+
+    /** Parse the 10-byte PMD data-frame header. Returns null if shorter than the header or the measurement
+     *  type is unrecognised (no wrong guess). */
+    fun header(data: ByteArray): PolarPmdFrameHeader? {
+        if (data.size < HEADER_LENGTH) return null
+        // The measurement type is the low 6 bits of byte 0 (top 2 reserved) — mask before matching so a
+        // frame with reserved bits set still resolves (DEVICE_SUPPORT_ROADMAP.md §PMD: "mask 0x3F").
+        val measurement = PolarPmdMeasurement.fromRaw(data[0].toInt() and 0x3F) ?: return null
+        val frameByte = data[9].toInt() and 0xFF
+        return PolarPmdFrameHeader(
+            measurement = measurement,
+            timestampNs = uint64LE(data, 1),
+            frameType = frameByte and 0x7F,
+            isCompressed = (frameByte and 0x80) != 0,
+        )
+    }
+
+    /** Decode a PPI (0x03) frame into its samples. Returns null when the frame isn't a valid PPI frame
+     *  (too short, unknown type, or not PPI); an empty list for a well-formed PPI header with no complete
+     *  sample. A trailing partial record (fewer than 6 bytes) is ignored. */
+    fun decodePPI(data: ByteArray): List<PolarPpiSample>? {
+        val header = header(data) ?: return null
+        if (header.measurement != PolarPmdMeasurement.PPI) return null
+        val samples = ArrayList<PolarPpiSample>()
+        var i = HEADER_LENGTH
+        while (i + PPI_SAMPLE_LENGTH <= data.size) {
+            val flags = data[i + 5].toInt() and 0xFF
+            samples.add(
+                PolarPpiSample(
+                    heartRate = data[i].toInt() and 0xFF,
+                    ppiMs = uint16LE(data, i + 1),
+                    errorEstimateMs = uint16LE(data, i + 3),
+                    blocker = (flags and 0x01) != 0,
+                    skinContact = (flags and 0x02) != 0,
+                    skinContactSupported = (flags and 0x04) != 0,
+                ),
+            )
+            i += PPI_SAMPLE_LENGTH
+        }
+        return samples
+    }
+
+    // MARK: - Little-endian readers (bounds are pre-checked by callers)
+
+    private fun uint16LE(data: ByteArray, i: Int): Int =
+        (data[i].toInt() and 0xFF) or ((data[i + 1].toInt() and 0xFF) shl 8)
+
+    private fun uint64LE(data: ByteArray, i: Int): Long {
+        var v = 0L
+        for (b in 0 until 8) v = v or ((data[i + b].toLong() and 0xFF) shl (8 * b))
+        return v
+    }
+}

--- a/android/app/src/test/java/com/noop/polar/PmdDecoderTest.kt
+++ b/android/app/src/test/java/com/noop/polar/PmdDecoderTest.kt
@@ -1,0 +1,98 @@
+package com.noop.polar
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Pins the clean-room Polar PMD decode against the SAME hand-built frames as the Swift twin
+ * (PolarProtocolTests.PmdDecoderTests) — byte-parity is the #1 rule. Pure JVM, no android.bluetooth.
+ */
+class PmdDecoderTest {
+
+    /** Byte-literal helper (0xE8 etc. exceed signed Byte, so build from Ints). */
+    private fun bytes(vararg v: Int): ByteArray = ByteArray(v.size) { v[it].toByte() }
+
+    /** Little-endian bytes for the 8-byte PMD frame timestamp 0x0102030405060708. */
+    private val tsBytes = intArrayOf(0x08, 0x07, 0x06, 0x05, 0x04, 0x03, 0x02, 0x01)
+    private val tsValue = 0x0102030405060708L
+
+    /** Build a PPI frame header (measurement 0x03, frame type 0) followed by [samples] raw bytes. */
+    private fun ppiFrame(vararg samples: Int): ByteArray = bytes(0x03, *tsBytes, 0x00, *samples)
+
+    // MARK: - Header
+
+    @Test fun headerParsesTypeTimestampAndFrameType() {
+        // ECG (0x00), compressed bit set on the frame-type byte (0x80 | 0x01).
+        val h = PmdDecoder.header(bytes(0x00, *tsBytes, 0x81))
+        assertNotNull(h)
+        assertEquals(PolarPmdMeasurement.ECG, h!!.measurement)
+        assertEquals(tsValue, h.timestampNs)     // 8-byte LE assembled correctly
+        assertEquals(0x01, h.frameType)          // low 7 bits
+        assertTrue(h.isCompressed)               // high bit
+    }
+
+    @Test fun headerRejectsUnknownMeasurementType() {
+        assertNull(PmdDecoder.header(bytes(0x7F, *tsBytes, 0x00)))
+    }
+
+    @Test fun headerRejectsTooShort() {
+        assertNull(PmdDecoder.header(bytes(0x03, 0x00, 0x00)))
+    }
+
+    // MARK: - PPI
+
+    @Test fun decodesSinglePpiSample() {
+        // hr=60, ppi=800ms (0x0320 LE), err=5ms, flags=0x06 (skinContact + supported, no blocker).
+        val samples = PmdDecoder.decodePPI(ppiFrame(60, 0x20, 0x03, 0x05, 0x00, 0x06))
+        assertNotNull(samples)
+        assertEquals(1, samples!!.size)
+        val s = samples[0]
+        assertEquals(60, s.heartRate)
+        assertEquals(800, s.ppiMs)
+        assertEquals(5, s.errorEstimateMs)
+        assertFalse(s.blocker)
+        assertTrue(s.skinContact)
+        assertTrue(s.skinContactSupported)
+    }
+
+    @Test fun decodesMultiplePpiSamplesInOrder() {
+        val samples = PmdDecoder.decodePPI(
+            ppiFrame(
+                62, 0x0A, 0x03, 0x00, 0x00, 0x07,   // hr 62, ppi 778, all flags set (incl. blocker)
+                48, 0xE8, 0x03, 0x02, 0x00, 0x00,   // hr 48, ppi 1000, err 2, no flags
+            ),
+        )
+        assertNotNull(samples)
+        assertEquals(2, samples!!.size)
+        assertEquals(778, samples[0].ppiMs)
+        assertTrue(samples[0].blocker)              // bit0 set → unreliable interval
+        assertEquals(48, samples[1].heartRate)
+        assertEquals(1000, samples[1].ppiMs)
+        assertFalse(samples[1].skinContactSupported)
+    }
+
+    @Test fun zeroHeartRateSampleIsKeptNotDropped() {
+        val samples = PmdDecoder.decodePPI(ppiFrame(0, 0x00, 0x00, 0x00, 0x00, 0x00))
+        assertEquals(0, samples!!.first().heartRate)
+    }
+
+    @Test fun trailingPartialSampleIsIgnored() {
+        val samples = PmdDecoder.decodePPI(ppiFrame(60, 0x20, 0x03, 0x00, 0x00, 0x00, 0xAA, 0xBB, 0xCC))
+        assertEquals(1, samples!!.size)
+    }
+
+    @Test fun emptyPpiFrameDecodesToNoSamples() {
+        assertEquals(0, PmdDecoder.decodePPI(ppiFrame())!!.size)
+    }
+
+    @Test fun decodePpiRejectsNonPpiFrame() {
+        // A well-formed ACC (0x02) header is not PPI → null, even though the header itself parses.
+        val acc = bytes(0x02, *tsBytes, 0x00, 0x11, 0x22, 0x33)
+        assertNotNull(PmdDecoder.header(acc))
+        assertNull(PmdDecoder.decodePPI(acc))
+    }
+}

--- a/docs/DEVICE_SUPPORT_ROADMAP.md
+++ b/docs/DEVICE_SUPPORT_ROADMAP.md
@@ -11,7 +11,7 @@ source stands and the protocol facts we've verified, so the next build can pick 
 | **Fitness Age / Vitality / Body Age** | ✅ Shipped (v4.0.0) | On-device, from the data above |
 | **Xiaomi Smart Band 8 / 9 / 10** (Mi Band) | ✅ Shipped, **import lane** | Read the Mi Fitness iOS app's own SQLite, on-device (below) |
 | **Xiaomi Smart Band — live BLE sync** | 🔬 Protocol researched, decoder not built | Mi protobuf-v2 over BLE GATT + `encryptKey` handshake (below) — hardware-gated |
-| **Polar deep streams** (ECG / PPG / ACC / PPI) | 🔬 Protocol verified, decoder not built | PMD service (below) — alpha, hardware-gated |
+| **Polar deep streams** (ECG / PPG / ACC / PPI) | 🔬 Pure PPI decoder built (`Packages/PolarProtocol` + `com.noop.polar`, tests green both platforms); live `PolarPMDSource` + ECG/PPG decode still to build | PMD service (below) — alpha, hardware-gated |
 | **Garmin** (sleep / HRV / Body Battery / SpO₂ / FIT) | 📋 Researched, not built | Local BLE re-derive (Gadgetbridge-informed, **never** GPLv3 copy) |
 | **Amazfit / Zepp** (incl. Helio deep) | 📋 Researched, not built | Encrypted Huami BLE — needs a one-time **user-pasted** vendor key (NOOP never logs into the vendor cloud) |
 | **Oura** | 📋 Researched, not built | Cloud API v2 — off-by-default OAuth **import** lane only |
@@ -38,6 +38,15 @@ Polar H10 / Verity Sense / OH1 the user owns, account-free, on top of the standa
   - **PPG** type-0: three 24-bit channels + ambient.
 - **Per-model streams:** **H10** = ECG (130 Hz) + ACC + HR + RR (no PPG); **Verity Sense / OH1** =
   PPG + PPI + ACC + GYRO + HR (no ECG).
+
+**Decoder status.** The pure PPI decoder is built and tested on both platforms
+(`Packages/PolarProtocol` / `com.noop.polar.PmdDecoder`): frame header (type `& 0x3F`, ns timestamp,
+frame-type/compressed bit) + PPI samples (HR + peak-to-peak interval + error estimate + flags). PPI is
+the one NOOP needs — HR + inter-beat interval for HRV, no ECG peak detection required. **Still to build:**
+the live `PolarPMDSource: LiveHRSource` (CoreBluetooth / android.bluetooth — hardware-gated, validate on
+an H10/Verity), and ECG/PPG/ACC decode if ever needed. **Confirm on hardware:** the PPI flags' bit1/bit2
+skin-contact polarity — the decoder names them per the Polar SDK, but this doc phrases them oppositely, so
+no consumer should gate on them until a real device settles it.
 
 **Open item — #421** ("Polar H10 paired, no live data", Android): the generic-HR plumbing is correct
 (CCCD write + both notification callbacks); the leading theory is the WHOOP auto-reconnect reclaiming


### PR DESCRIPTION
## What & why

The first decoder aimed at the new `LiveHRSource` abstraction (#238). Adds a **pure, CoreBluetooth-free** decoder for Polar's **Measurement Data (PMD)** protocol — `Packages/PolarProtocol` (Swift, mirroring `OuraProtocol`) + `com.noop.polar.PmdDecoder` (Kotlin):

- **Frame header** — measurement type (masked `0x3F` per the roadmap), 64-bit ns timestamp, frame-type + compressed bit.
- **PPI stream** — HR + peak-to-peak (inter-beat) interval + error estimate + flags per beat.

PPI is the stream NOOP actually needs: **HR plus the inter-beat interval for HRV** — the same signal WHOOP R-R gives — so a Polar H10 / OH1 / Verity Sense contributes recovery/HRV **without** running peak detection on raw ECG.

Clean-room: parsed from Polar's **publicly documented** PMD layout (already captured in `docs/DEVICE_SUPPORT_ROADMAP.md`); no Polar code, no firmware, nothing fabricated.

## Scope

Wire-level decode only. The live `PolarPMDSource: LiveHRSource` (CoreBluetooth / android.bluetooth) is a **hardware-gated follow-up** — it needs an H10/Verity to validate on-device, so it's intentionally not in this PR. ECG/PPG/ACC decode likewise deferred until needed.

## Honesty / correctness notes

- An `hr = 0` sample (no valid beat) is **kept as-is**, never dropped or faked.
- The PPI **skin-contact flag polarity** (bits 1/2) is **flagged as unconfirmed on hardware**: the decoder names them per the Polar SDK, but the roadmap phrases them oppositely — so the doc + code both say "don't gate on these until a real device settles it."

## Verification

- ✅ `swift test` — `PolarProtocol` **9/9** green.
- ✅ Android `testFullDebugUnitTest --tests com.noop.polar.PmdDecoderTest` — **9/9** green. Same hand-built frame vectors on both platforms (byte-parity).
- ➕ Registers `PolarProtocol` **and** the previously-unlisted `OuraProtocol` in the `swift-packages` CI matrix so their pure tests run in CI.
- ⚠️ No hardware exercised — by design; the live/BLE path is the documented follow-up.

