### PR TITLE
[draft] Today: compact sync-progress chip in the header, for all users (#245)

### DIFF
--- a/Strand/Screens/TodayView.swift
+++ b/Strand/Screens/TodayView.swift
@@ -1082,6 +1082,11 @@ struct TodayView: View {
 
             Spacer(minLength: 8)
 
+            // #245: a compact "syncing history" chip, visible to EVERY user (not only those still
+            // building scores — the big SyncingHistoryNote below is gated on `recovery == nil`). Renders
+            // nothing when idle; its own LiveState observation ticks the count without re-rendering Today.
+            SyncStatusChip()
+
             // Uniform 36pt circular icon set: recording-status light, updates bell, quick-add (+), menu.
             HStack(spacing: 8) {
                 // Recording status, a colour-coded light (green recording / amber synced / red not
@@ -4394,6 +4399,30 @@ struct TodayDayScopedCache {
 /// The compact 36pt recording-status light in the iOS top bar, a colour-coded dot (green recording,
 /// amber last-synced, red not recording, accent for experimental 5.0 history). Taps to Devices. Owns
 /// the `LiveState` observation so a live-HR tick refreshes only this dot.
+/// #245: a compact sync-progress chip for the Today top bar. The full-width `SyncingHistoryNote` only
+/// renders for users whose scores are still building (`recovery == nil`), so an established user — and
+/// especially a WHOOP 5/MG owner, whose history offloads are already rare — saw no sync feedback on
+/// Today at all, only on the Live screen. This mirrors the Live "SYNCING N" badge into the header for
+/// everyone. Renders nothing when idle. DRAFT (#245): placement/style still to be finalised.
+private struct SyncStatusChip: View {
+    @EnvironmentObject private var live: LiveState
+    var body: some View {
+        if live.backfilling {
+            HStack(spacing: 4) {
+                Image(systemName: "arrow.triangle.2.circlepath")
+                    .font(.system(size: 11, weight: .semibold))
+                Text("\(live.syncChunksThisSession)")
+                    .font(StrandFont.captionNumber)
+            }
+            .foregroundStyle(StrandPalette.accent)
+            .padding(.horizontal, 8)
+            .padding(.vertical, 5)
+            .background(Capsule().fill(StrandPalette.surfaceInset))
+            .accessibilityLabel(Text("Syncing strap history, \(live.syncChunksThisSession) chunks"))
+        }
+    }
+}
+
 private struct RecordingStatusLight: View {
     @EnvironmentObject private var live: LiveState
     let selectedDayOffset: Int

--- a/Strand/Screens/TodayView.swift
+++ b/Strand/Screens/TodayView.swift
@@ -1082,9 +1082,10 @@ struct TodayView: View {
 
             Spacer(minLength: 8)
 
-            // #245: a compact "syncing history" chip, visible to EVERY user (not only those still
-            // building scores — the big SyncingHistoryNote below is gated on `recovery == nil`). Renders
-            // nothing when idle; its own LiveState observation ticks the count without re-rendering Today.
+            // #245: a compact sync-status chip, visible to EVERY user (not only those still building
+            // scores — the big SyncingHistoryNote below is gated on `recovery == nil`). Three states
+            // (syncing / last-synced / experimental), so the absence of active syncing reads as caught-up;
+            // nothing only on a cold start. Owns its LiveState observation so a tick refreshes only it.
             SyncStatusChip()
 
             // Uniform 36pt circular icon set: recording-status light, updates bell, quick-add (+), menu.

--- a/Strand/Screens/TodayView.swift
+++ b/Strand/Screens/TodayView.swift
@@ -4396,33 +4396,61 @@ struct TodayDayScopedCache {
 // ~1 Hz publish re-renders only the affected dot / note / row, never the rings, scene, sparklines,
 // HR chart or cards. They render byte-for-byte what the inline code did before the extraction.
 
-/// The compact 36pt recording-status light in the iOS top bar, a colour-coded dot (green recording,
-/// amber last-synced, red not recording, accent for experimental 5.0 history). Taps to Devices. Owns
-/// the `LiveState` observation so a live-HR tick refreshes only this dot.
-/// #245: a compact sync-progress chip for the Today top bar. The full-width `SyncingHistoryNote` only
-/// renders for users whose scores are still building (`recovery == nil`), so an established user — and
-/// especially a WHOOP 5/MG owner, whose history offloads are already rare — saw no sync feedback on
-/// Today at all, only on the Live screen. This mirrors the Live "SYNCING N" badge into the header for
-/// everyone. Renders nothing when idle. DRAFT (#245): placement/style still to be finalised.
+/// #245: a compact sync-status chip for the Today top bar, shown to EVERY user. The full-width
+/// `SyncingHistoryNote` only renders while scores are still building (`recovery == nil`), so an
+/// established user — and especially a WHOOP 5/MG owner, whose history offloads are rare — saw no sync
+/// feedback on Today, only on the Live screen. THREE states so the ABSENCE of active syncing reads as
+/// "caught up", not "missing indicator" (the real #245 confusion): actively offloading → `⟳ N`; idle
+/// with a known last-sync → `✓ Xm`; a 5/MG whose history sync is experimental (live-connected, no
+/// completed offload yet) → `✓ live`. Nothing shows only on a true cold start (the building-scores note
+/// owns that). Owns its `LiveState` observation so a live tick refreshes only this chip. Twin of Android
+/// `SyncStatusChip`. DRAFT (#245): final styling/wording still to be finalised.
 private struct SyncStatusChip: View {
     @EnvironmentObject private var live: LiveState
+
     var body: some View {
         if live.backfilling {
-            HStack(spacing: 4) {
-                Image(systemName: "arrow.triangle.2.circlepath")
-                    .font(.system(size: 11, weight: .semibold))
-                Text("\(live.syncChunksThisSession)")
-                    .font(StrandFont.captionNumber)
-            }
-            .foregroundStyle(StrandPalette.accent)
-            .padding(.horizontal, 8)
-            .padding(.vertical, 5)
-            .background(Capsule().fill(StrandPalette.surfaceInset))
-            .accessibilityLabel(Text("Syncing strap history, \(live.syncChunksThisSession) chunks"))
+            chip(system: "arrow.triangle.2.circlepath", text: "\(live.syncChunksThisSession)",
+                 tint: StrandPalette.accent,
+                 a11y: "Syncing strap history, \(live.syncChunksThisSession) chunks")
+        } else if let ts = live.lastSyncedAt {
+            chip(system: "checkmark", text: Self.shortAgo(ts), tint: StrandPalette.textSecondary,
+                 a11y: "Strap history synced \(Self.shortAgo(ts)) ago")
+        } else if live.historySyncExperimental {
+            chip(system: "checkmark", text: "live", tint: StrandPalette.textSecondary,
+                 a11y: "Connected; strap history sync is experimental on this strap")
         }
+        // else: cold start — render nothing; the building-scores SyncingHistoryNote covers it.
+    }
+
+    private func chip(system: String, text: String, tint: Color, a11y: String) -> some View {
+        HStack(spacing: 4) {
+            Image(systemName: system).font(.system(size: 11, weight: .semibold))
+            Text(text).font(StrandFont.captionNumber)
+        }
+        .foregroundStyle(tint)
+        .padding(.horizontal, 8)
+        .padding(.vertical, 5)
+        .background(Capsule().fill(StrandPalette.surfaceInset))
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(Text(a11y))
+    }
+
+    /// Compact relative age for the header chip ("now" / "Nm" / "Nh" / "Nd") — deliberately terse.
+    private static func shortAgo(_ ts: TimeInterval) -> String {
+        let secs = max(0, Int(Date().timeIntervalSince1970 - ts))
+        if secs < 60 { return "now" }
+        let mins = secs / 60
+        if mins < 60 { return "\(mins)m" }
+        let hrs = mins / 60
+        if hrs < 24 { return "\(hrs)h" }
+        return "\(hrs / 24)d"
     }
 }
 
+/// The compact 36pt recording-status light in the iOS top bar, a colour-coded dot (green recording,
+/// amber last-synced, red not recording, accent for experimental 5.0 history). Taps to Devices. Owns
+/// the `LiveState` observation so a live-HR tick refreshes only this dot.
 private struct RecordingStatusLight: View {
     @EnvironmentObject private var live: LiveState
     let selectedDayOffset: Int

--- a/android/app/src/main/java/com/noop/ui/TodayScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/TodayScreen.kt
@@ -1975,8 +1975,9 @@ private fun LiquidTodayHeader(
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.spacedBy(8.dp),
         ) {
-            // #245: compact "syncing history" chip, shown for EVERY user while the strap offloads (the
-            // full SyncingHistoryNote is gated on recovery == null). Twin of iOS SyncStatusChip.
+            // #245: compact sync-status chip, shown for EVERY user — syncing / last-synced / experimental,
+            // so the absence of active syncing reads as caught-up (the full SyncingHistoryNote is gated on
+            // recovery == null). Twin of iOS SyncStatusChip.
             SyncStatusChip(
                 backfilling = backfilling, chunks = syncChunksThisSession,
                 lastSyncAt = lastSyncAt, historySyncExperimental = historySyncExperimental,

--- a/android/app/src/main/java/com/noop/ui/TodayScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/TodayScreen.kt
@@ -34,8 +34,10 @@ import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
 import androidx.compose.material.icons.filled.Accessibility
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Air
+import androidx.compose.material.icons.filled.Autorenew
 import androidx.compose.material.icons.automirrored.filled.BatteryUnknown
 import androidx.compose.material.icons.filled.Bedtime
+import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Favorite
 import androidx.compose.material.icons.filled.Functions
@@ -1021,6 +1023,8 @@ fun TodayScreen(
                 batteryPct = if (liveSnap.connected) liveSnap.batteryPct else null,
                 backfilling = liveSnap.backfilling,
                 syncChunksThisSession = liveSnap.syncChunksThisSession,
+                lastSyncAt = liveSnap.lastSyncAt,
+                historySyncExperimental = liveSnap.historySyncExperimental,
                 onPickDay = { offset -> selectedDayOffset = offset },
                 onQuickActions = onQuickActions,
                 onOpenSettings = onOpenSettings,
@@ -1885,9 +1889,11 @@ private fun LiquidTodayHeader(
     humanDate: String,
     selectedDay: LocalDate,
     batteryPct: Double?,
-    // #245: sync-progress for the compact header chip (twin of iOS SyncStatusChip).
+    // #245: sync state for the compact header chip (twin of iOS SyncStatusChip).
     backfilling: Boolean = false,
     syncChunksThisSession: Int = 0,
+    lastSyncAt: Long? = null,
+    historySyncExperimental: Boolean = false,
     onPickDay: (Int) -> Unit,
     onQuickActions: () -> Unit,
     onOpenSettings: () -> Unit,
@@ -1971,7 +1977,10 @@ private fun LiquidTodayHeader(
         ) {
             // #245: compact "syncing history" chip, shown for EVERY user while the strap offloads (the
             // full SyncingHistoryNote is gated on recovery == null). Twin of iOS SyncStatusChip.
-            SyncStatusChip(backfilling = backfilling, chunks = syncChunksThisSession)
+            SyncStatusChip(
+                backfilling = backfilling, chunks = syncChunksThisSession,
+                lastSyncAt = lastSyncAt, historySyncExperimental = historySyncExperimental,
+            )
             // (a) Profile avatar (the photo set in Settings, or the NOOP loop mark) → Settings. Mirrors iOS.
             Box(
                 modifier = Modifier
@@ -1996,13 +2005,36 @@ private fun LiquidTodayHeader(
     }
 }
 
-/** #245: compact "syncing history" chip for the Today top bar, shown for EVERY user while the strap
- *  offloads history — the full-width SyncingHistoryNote is gated on `recovery == null`, so an established
- *  user (and especially a WHOOP 5/MG owner, whose offloads are already rare) saw no sync feedback on
- *  Today. Renders nothing when idle. Twin of iOS SyncStatusChip. DRAFT (#245): placement/style TBD. */
+/** #245: compact sync-status chip for the Today top bar, shown to EVERY user. The full-width
+ *  SyncingHistoryNote is gated on `recovery == null`, so an established user (and especially a WHOOP 5/MG
+ *  owner, whose history offloads are rare) saw no sync feedback on Today. THREE states so the ABSENCE of
+ *  active syncing reads as "caught up", not "missing indicator" (the real #245 confusion): actively
+ *  offloading → ⟳ N; idle with a known last-sync → ✓ Xm; a 5/MG whose history sync is experimental
+ *  (live-connected, no completed offload yet) → ✓ live. Nothing shows only on a true cold start (the
+ *  building-scores note owns that). Twin of iOS SyncStatusChip. DRAFT (#245): final styling/wording TBD. */
 @Composable
-private fun SyncStatusChip(backfilling: Boolean, chunks: Int) {
-    if (!backfilling) return
+private fun SyncStatusChip(
+    backfilling: Boolean,
+    chunks: Int,
+    lastSyncAt: Long?,
+    historySyncExperimental: Boolean,
+) {
+    when {
+        backfilling -> ChipCapsule(
+            Icons.Filled.Autorenew, "$chunks", Palette.accent, "Syncing strap history, $chunks chunks")
+        lastSyncAt != null -> ChipCapsule(
+            Icons.Filled.Check, shortSyncAgo(lastSyncAt), Palette.textSecondary,
+            "Strap history synced ${shortSyncAgo(lastSyncAt)} ago")
+        historySyncExperimental -> ChipCapsule(
+            Icons.Filled.Check, "live", Palette.textSecondary,
+            "Connected; strap history sync is experimental on this strap")
+        // else: cold start — render nothing; the building-scores note covers it.
+    }
+}
+
+/** The shared sync-chip capsule (icon + terse label). Twin of the iOS `SyncStatusChip.chip`. */
+@Composable
+private fun ChipCapsule(icon: ImageVector, text: String, tint: Color, desc: String) {
     Row(
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(4.dp),
@@ -2011,13 +2043,20 @@ private fun SyncStatusChip(backfilling: Boolean, chunks: Int) {
             .background(Palette.surfaceInset)
             .padding(horizontal = 8.dp, vertical = 5.dp),
     ) {
-        Icon(
-            Icons.Filled.History,
-            contentDescription = "Syncing strap history",
-            tint = Palette.accent,
-            modifier = Modifier.size(14.dp),
-        )
-        Text("$chunks", style = NoopType.caption, color = Palette.accent)
+        Icon(icon, contentDescription = desc, tint = tint, modifier = Modifier.size(14.dp))
+        Text(text, style = NoopType.caption, color = tint)
+    }
+}
+
+/** Compact relative age for the header chip ("now" / "Nm" / "Nh" / "Nd") from a unix-SECONDS timestamp —
+ *  deliberately terse. Twin of the iOS `SyncStatusChip.shortAgo`. */
+private fun shortSyncAgo(unixSec: Long): String {
+    val secs = (System.currentTimeMillis() / 1000L - unixSec).coerceAtLeast(0)
+    return when {
+        secs < 60 -> "now"
+        secs < 3600 -> "${secs / 60}m"
+        secs < 86_400 -> "${secs / 3600}h"
+        else -> "${secs / 86_400}d"
     }
 }
 

--- a/android/app/src/main/java/com/noop/ui/TodayScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/TodayScreen.kt
@@ -1019,6 +1019,8 @@ fun TodayScreen(
                 humanDate = humanDate,
                 selectedDay = selectedDay,
                 batteryPct = if (liveSnap.connected) liveSnap.batteryPct else null,
+                backfilling = liveSnap.backfilling,
+                syncChunksThisSession = liveSnap.syncChunksThisSession,
                 onPickDay = { offset -> selectedDayOffset = offset },
                 onQuickActions = onQuickActions,
                 onOpenSettings = onOpenSettings,
@@ -1883,6 +1885,9 @@ private fun LiquidTodayHeader(
     humanDate: String,
     selectedDay: LocalDate,
     batteryPct: Double?,
+    // #245: sync-progress for the compact header chip (twin of iOS SyncStatusChip).
+    backfilling: Boolean = false,
+    syncChunksThisSession: Int = 0,
     onPickDay: (Int) -> Unit,
     onQuickActions: () -> Unit,
     onOpenSettings: () -> Unit,
@@ -1959,11 +1964,14 @@ private fun LiquidTodayHeader(
             )
         }
 
-        // RIGHT: the controls, in order — avatar · + · battery ring. Each ~34dp, 8dp apart.
+        // RIGHT: the controls, in order — [sync chip] · avatar · + · battery ring. Each ~34dp, 8dp apart.
         Row(
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.spacedBy(8.dp),
         ) {
+            // #245: compact "syncing history" chip, shown for EVERY user while the strap offloads (the
+            // full SyncingHistoryNote is gated on recovery == null). Twin of iOS SyncStatusChip.
+            SyncStatusChip(backfilling = backfilling, chunks = syncChunksThisSession)
             // (a) Profile avatar (the photo set in Settings, or the NOOP loop mark) → Settings. Mirrors iOS.
             Box(
                 modifier = Modifier
@@ -1988,8 +1996,33 @@ private fun LiquidTodayHeader(
     }
 }
 
-/** The strap battery ring (iOS LiquidBatteryButton): a 34dp translucent disc with a hairline rim; when a
- *  reading exists it draws a trimmed ring in the charge/warning/critical hue plus the % inside, else a
+/** #245: compact "syncing history" chip for the Today top bar, shown for EVERY user while the strap
+ *  offloads history — the full-width SyncingHistoryNote is gated on `recovery == null`, so an established
+ *  user (and especially a WHOOP 5/MG owner, whose offloads are already rare) saw no sync feedback on
+ *  Today. Renders nothing when idle. Twin of iOS SyncStatusChip. DRAFT (#245): placement/style TBD. */
+@Composable
+private fun SyncStatusChip(backfilling: Boolean, chunks: Int) {
+    if (!backfilling) return
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(4.dp),
+        modifier = Modifier
+            .clip(RoundedCornerShape(50))
+            .background(Palette.surfaceInset)
+            .padding(horizontal = 8.dp, vertical = 5.dp),
+    ) {
+        Icon(
+            Icons.Filled.History,
+            contentDescription = "Syncing strap history",
+            tint = Palette.accent,
+            modifier = Modifier.size(14.dp),
+        )
+        Text("$chunks", style = NoopType.caption, color = Palette.accent)
+    }
+}
+
+/** The liquid header strap-battery ring: when connected + a reading exists it draws a trimmed ring in
+ *  the charge/warning/critical hue plus the % inside, else a
  *  bolt-slash glyph. Tap → Devices. Mirrors the iOS liquid header battery ring. */
 @Composable
 private fun LiquidBatteryRing(batteryPct: Double?, onClick: () -> Unit) {


### PR DESCRIPTION
**Draft** for #245 (sync indicator missing on a 5.0). Skeleton to flesh out — placement/style TBD.

## The gap
The "Syncing strap history…" note (`SyncingHistoryNoteIfBackfilling` / Android `SyncingHistoryNote`) only renders inside the `recovery == null` block on **both** platforms — i.e. only for users whose scores are still building. An **established** user sees no sync feedback on Today at all; it's only on the Live screen. And on a **WHOOP 5.0**, history offloads are rare anyway (experimental), so even the note seldom fires. That's exactly what #245 describes.

## This draft
A compact `SyncStatusChip` in the Today top bar — a small `⟳ N` capsule shown for **every** user while `live.backfilling`, mirroring the Live screen's `SYNCING N` badge into the header. Renders nothing when idle.
- **iOS:** `SyncStatusChip` in `TodayView`, inserted before the top-bar icon cluster.
- **Android:** twin `SyncStatusChip` in `TodayScreen`, threaded through `LiquidTodayHeader` beside the battery ring.
- Additive over existing `LiveState` signals (`backfilling` / `syncChunksThisSession`) — no BLE/state/analytics/stored-data change, design tokens only. Feature-level parity.

## Still to decide (why it's draft)
- Chip-near-battery (current) vs. a top banner (the reporter offered both).
- Whether to also surface a subtle idle state — "Synced Xm ago", or the 5.0 "history sync is experimental" hint — so the *absence* of syncing reads as "nothing to sync" rather than "missing indicator" (the actual 5.0 confusion).
- Exact styling / size.

## Tests
`compileFullDebugKotlin` clean; app-target Swift (`TodayView`) validated via `app-build`. No unit tests (pure UI over existing signals).