### PR TITLE
hrv diag: add R-R coverage + duplicate-beat count to the always-on log (#257)

### DIFF
--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/HRVAnalyzer.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/HRVAnalyzer.swift
@@ -341,6 +341,32 @@ public enum HRVAnalyzer {
         return out
     }
 
+    // MARK: - R-R integrity diagnostics (#257)
+
+    /// Total heartbeat-time (sum of NN intervals, ms) ÷ wall-clock span of the R-R window (ms). A value
+    /// > ~1.0 is physically impossible — you can't record more beat-time than elapsed time — so it
+    /// directly flags DOUBLE-COUNTED / overlapping R-R (e.g. a live + historical merge storing the same
+    /// beat under two timestamps, which inflates HRV and drags resting HR down, #257). Returns 0 for
+    /// < 2 beats or a zero span. Byte-parity twin of Kotlin `HrvAnalyzer.rrCoverage`.
+    public static func rrCoverage(tsSec: [Int], rrMs: [Double]) -> Double {
+        guard tsSec.count >= 2, !rrMs.isEmpty, let lo = tsSec.min(), let hi = tsSec.max() else { return 0 }
+        let spanMs = Double(hi - lo) * 1000
+        guard spanMs > 0 else { return 0 }
+        return rrMs.reduce(0, +) / spanMs
+    }
+
+    /// How many R-R rows are EXACT duplicates of another — same (ts, rrMs). Extra copies of one beat;
+    /// `total − distinct(ts, rrMs)`. Points at the double-insert mechanism when `rrCoverage` > 1.
+    /// Byte-parity twin of Kotlin `HrvAnalyzer.duplicateBeatCount`.
+    public static func duplicateBeatCount(tsSec: [Int], rrMs: [Double]) -> Int {
+        struct Key: Hashable { let ts: Int; let rr: Double }
+        let n = min(tsSec.count, rrMs.count)
+        var seen = Set<Key>()
+        var dups = 0
+        for i in 0..<n where !seen.insert(Key(ts: tsSec[i], rr: rrMs[i])).inserted { dups += 1 }
+        return dups
+    }
+
     // MARK: - Helpers
 
     /// Median of a non-empty array. (Caller guarantees non-empty.)

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/HRVAnalyzerTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/HRVAnalyzerTests.swift
@@ -186,4 +186,31 @@ final class HRVAnalyzerTests: XCTestCase {
         XCTAssertEqual(result.nClean, 31)
         XCTAssertEqual(result.rmssd!, 0.0, accuracy: 1e-9)  // all 800 → no successive diffs
     }
+
+    // MARK: - #257 R-R integrity diagnostics (byte-parity twin of Kotlin HrvRrCoverageTest)
+
+    func testCoverageCleanStreamIsNearOne() {
+        // 5 beats of 1000 ms spanning ts 100..104 (4 s wall clock). sum=5000, span=4000 → 1.25.
+        XCTAssertEqual(HRVAnalyzer.rrCoverage(tsSec: [100, 101, 102, 103, 104],
+                                              rrMs: [1000, 1000, 1000, 1000, 1000]), 1.25, accuracy: 1e-9)
+    }
+
+    func testCoverageDoubleCountedBeatsExceedsOne() {
+        // Each beat stored TWICE at the same second (#257 over-count): sum=6000 over a 2 s span → 3.0.
+        XCTAssertEqual(HRVAnalyzer.rrCoverage(tsSec: [100, 100, 101, 101, 102, 102],
+                                              rrMs: [1000, 1000, 1000, 1000, 1000, 1000]), 3.0, accuracy: 1e-9)
+    }
+
+    func testCoverageZeroForTooFewBeatsOrZeroSpan() {
+        XCTAssertEqual(HRVAnalyzer.rrCoverage(tsSec: [], rrMs: []), 0, accuracy: 1e-9)
+        XCTAssertEqual(HRVAnalyzer.rrCoverage(tsSec: [100], rrMs: [1000]), 0, accuracy: 1e-9)
+        XCTAssertEqual(HRVAnalyzer.rrCoverage(tsSec: [100, 100], rrMs: [1000, 1000]), 0, accuracy: 1e-9)
+    }
+
+    func testDuplicateBeatsCountsExactRepeats() {
+        XCTAssertEqual(HRVAnalyzer.duplicateBeatCount(tsSec: [100, 101, 102], rrMs: [1000, 1010, 1020]), 0)
+        XCTAssertEqual(HRVAnalyzer.duplicateBeatCount(tsSec: [100, 100, 101], rrMs: [1000, 1000, 1010]), 1)
+        XCTAssertEqual(HRVAnalyzer.duplicateBeatCount(tsSec: [100, 100, 100], rrMs: [1000, 1000, 1000]), 2)
+        XCTAssertEqual(HRVAnalyzer.duplicateBeatCount(tsSec: [100, 100], rrMs: [1000, 1010]), 0)  // diff rr = distinct
+    }
 }

--- a/Strand/Data/IntelligenceEngine.swift
+++ b/Strand/Data/IntelligenceEngine.swift
@@ -667,8 +667,8 @@ final class IntelligenceEngine: ObservableObject {
                 // shipped windowed avgHrv. Built here (loop 1) where `rr` is in scope, but EMITTED in the
                 // main-actor replay loop below (diagnosticSink is main-actor isolated), carried on `hrvDiag`.
                 // Byte-identical to the Kotlin line.
-                let sleepRr = rr.filter { r in res.cachedSleep.contains { r.ts >= $0.startTs && r.ts < $0.endTs } }
-                    .map { Double($0.rrMs) }
+                let sleepRrRows = rr.filter { r in res.cachedSleep.contains { r.ts >= $0.startTs && r.ts < $0.endTs } }
+                let sleepRr = sleepRrRows.map { Double($0.rrMs) }
                 let hrvDiag: String?
                 if sleepRr.isEmpty {
                     hrvDiag = nil
@@ -676,8 +676,14 @@ final class IntelligenceEngine: ObservableObject {
                     let h = HRVAnalyzer.analyze(rawRR: sleepRr)
                     func ms(_ v: Double?) -> String { v.map { String(format: "%.0f", $0) } ?? "nil" }
                     let rej = h.nInput > 0 ? String(format: "%.0f", 100 * (1 - Double(h.nClean) / Double(h.nInput))) : "0"
+                    // #257: coverage (sum of NN ÷ wall-clock span; > 1.0 is impossible without double-counted
+                    // R-R) + exact-duplicate beat count, so a "reads ~2x too high" report is self-diagnosing
+                    // from the always-on log instead of hand-computing beat density.
+                    let ts = sleepRrRows.map { $0.ts }
+                    let cov = String(format: "%.2f", HRVAnalyzer.rrCoverage(tsSec: ts, rrMs: sleepRr))
+                    let dup = HRVAnalyzer.duplicateBeatCount(tsSec: ts, rrMs: sleepRr)
                     hrvDiag = "hrv diag day=\(res.daily.day) rmssd=\(ms(h.rmssd))ms sdnn=\(ms(h.sdnn))ms "
-                        + "meanNN=\(ms(h.meanNN))ms rr=\(h.nInput)/\(h.nClean) rejected=\(rej)%"
+                        + "meanNN=\(ms(h.meanNN))ms rr=\(h.nInput)/\(h.nClean) rejected=\(rej)% coverage=\(cov) dupBeats=\(dup)"
                 }
                 // ── Steps test mode: 5/MG raw-counter trace ──────────────────────────────────────────────
                 // Only built when the Steps mode is on (the gate was read once before the loop). Recomputes

--- a/android/app/src/main/java/com/noop/analytics/HrvAnalyzer.kt
+++ b/android/app/src/main/java/com/noop/analytics/HrvAnalyzer.kt
@@ -309,6 +309,31 @@ object HrvAnalyzer {
             nInput = nInput, nClean = clean.size)
     }
 
+    /** #257: total heartbeat-time (sum of NN intervals, ms) ÷ wall-clock span of the R-R window (ms).
+     *  A value > ~1.0 is physically impossible — you can't record more beat-time than elapsed time — so
+     *  it directly flags DOUBLE-COUNTED / overlapping R-R (e.g. a live + historical merge storing the same
+     *  beat under two timestamps, which inflates HRV and drags resting HR down, #257). Returns 0.0 for
+     *  < 2 beats or a zero span. Byte-parity twin of Swift `HRVAnalyzer.rrCoverage`. */
+    fun rrCoverage(tsSec: List<Long>, rrMs: List<Double>): Double {
+        if (tsSec.size < 2 || rrMs.isEmpty()) return 0.0
+        val hi = tsSec.maxOrNull() ?: return 0.0
+        val lo = tsSec.minOrNull() ?: return 0.0
+        val spanMs = (hi - lo) * 1000.0
+        if (spanMs <= 0.0) return 0.0
+        return rrMs.sum() / spanMs
+    }
+
+    /** #257: how many R-R rows are EXACT duplicates of another — same (ts, rrMs). Extra copies of one
+     *  beat; `total − distinct(ts, rrMs)`. Points at the double-insert mechanism when [rrCoverage] > 1.
+     *  Byte-parity twin of Swift `HRVAnalyzer.duplicateBeatCount`. */
+    fun duplicateBeatCount(tsSec: List<Long>, rrMs: List<Double>): Int {
+        val n = minOf(tsSec.size, rrMs.size)
+        val seen = HashSet<Pair<Long, Double>>()
+        var dups = 0
+        for (i in 0 until n) if (!seen.add(tsSec[i] to rrMs[i])) dups++
+        return dups
+    }
+
     // ── Rolling / windowed rMSSD (#803) ──────────────────────────────────────
     //
     // The Deep Timeline's "HRV" trace used to plot RAW RR-interval values (ms) and label them "HRV",

--- a/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
+++ b/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
@@ -569,14 +569,20 @@ object IntelligenceEngine {
             // `nInput` is set before the min-beats gate, so a sparse night still shows its count with
             // rmssd=nil). A SEPARATE analyzeRaw pass over the in-sleep R-R — does NOT touch the shipped
             // windowed avgHrv. Emitted here where `rr` is in scope; byte-identical to the Swift line.
-            val sleepRr = rr.filter { r -> res.sleepSessions.any { r.ts >= it.start && r.ts < it.end } }
-                .map { it.rrMs.toDouble() }
+            val sleepRrRows = rr.filter { r -> res.sleepSessions.any { r.ts >= it.start && r.ts < it.end } }
+            val sleepRr = sleepRrRows.map { it.rrMs.toDouble() }
             if (sleepRr.isNotEmpty()) {
                 val h = HrvAnalyzer.analyzeRaw(sleepRr)
                 val ms = { v: Double? -> v?.let { String.format(java.util.Locale.US, "%.0f", it) } ?: "nil" }
                 val rej = if (h.nInput > 0) String.format(java.util.Locale.US, "%.0f", 100.0 * (1.0 - h.nClean.toDouble() / h.nInput)) else "0"
+                // #257: coverage (sum of NN ÷ wall-clock span; > 1.0 is impossible without double-counted
+                // R-R) + exact-duplicate beat count, so a "reads ~2x too high" report is self-diagnosing
+                // from the always-on log instead of hand-computing beat density.
+                val ts = sleepRrRows.map { it.ts }
+                val cov = String.format(java.util.Locale.US, "%.2f", HrvAnalyzer.rrCoverage(ts, sleepRr))
+                val dup = HrvAnalyzer.duplicateBeatCount(ts, sleepRr)
                 diag("hrv diag day=${res.daily.day} rmssd=${ms(h.rmssd)}ms sdnn=${ms(h.sdnn)}ms meanNN=${ms(h.meanNN)}ms " +
-                    "rr=${h.nInput}/${h.nClean} rejected=$rej%")
+                    "rr=${h.nInput}/${h.nClean} rejected=$rej% coverage=$cov dupBeats=$dup")
             }
 
             // Steps test mode: emit the 5/MG raw-counter trace for this day (cumulative @57 series +

--- a/android/app/src/test/java/com/noop/analytics/HrvRrCoverageTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/HrvRrCoverageTest.kt
@@ -1,0 +1,49 @@
+package com.noop.analytics
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * #257 — the R-R integrity diagnostics ([HrvAnalyzer.rrCoverage] / [HrvAnalyzer.duplicateBeatCount])
+ * that surface a heartbeat OVER-COUNT (the "HRV reads ~2x too high" class of bug) in the always-on
+ * `hrv diag` log. Byte-parity twin of `HRVAnalyzerTests` on the Swift side.
+ */
+class HrvRrCoverageTest {
+
+    @Test fun coverage_cleanStreamIsNearOne() {
+        // 5 beats of 1000 ms spanning ts 100..104 (4 s wall clock). sum=5000 ms, span=4000 ms → 1.25.
+        val cov = HrvAnalyzer.rrCoverage(
+            listOf(100L, 101L, 102L, 103L, 104L),
+            listOf(1000.0, 1000.0, 1000.0, 1000.0, 1000.0),
+        )
+        assertEquals(1.25, cov, 1e-9)
+    }
+
+    @Test fun coverage_doubleCountedBeatsExceedsOne() {
+        // Each beat stored TWICE at the same second (the #257 over-count): sum=6000 ms over a 2 s span → 3.0.
+        val cov = HrvAnalyzer.rrCoverage(
+            listOf(100L, 100L, 101L, 101L, 102L, 102L),
+            listOf(1000.0, 1000.0, 1000.0, 1000.0, 1000.0, 1000.0),
+        )
+        assertEquals(3.0, cov, 1e-9)
+    }
+
+    @Test fun coverage_zeroForTooFewBeatsOrZeroSpan() {
+        assertEquals(0.0, HrvAnalyzer.rrCoverage(emptyList(), emptyList()), 1e-9)
+        assertEquals(0.0, HrvAnalyzer.rrCoverage(listOf(100L), listOf(1000.0)), 1e-9)
+        assertEquals(0.0, HrvAnalyzer.rrCoverage(listOf(100L, 100L), listOf(1000.0, 1000.0)), 1e-9) // span 0
+    }
+
+    @Test fun duplicateBeats_zeroWhenAllDistinct() {
+        assertEquals(0, HrvAnalyzer.duplicateBeatCount(listOf(100L, 101L, 102L), listOf(1000.0, 1010.0, 1020.0)))
+    }
+
+    @Test fun duplicateBeats_countsExactRepeats() {
+        // (100,1000) appears twice → 1 extra copy; (101,1010) distinct.
+        assertEquals(1, HrvAnalyzer.duplicateBeatCount(listOf(100L, 100L, 101L), listOf(1000.0, 1000.0, 1010.0)))
+        // three identical beats → 2 extra copies.
+        assertEquals(2, HrvAnalyzer.duplicateBeatCount(listOf(100L, 100L, 100L), listOf(1000.0, 1000.0, 1000.0)))
+        // same ts but DIFFERENT rrMs are distinct beats, not duplicates.
+        assertEquals(0, HrvAnalyzer.duplicateBeatCount(listOf(100L, 100L), listOf(1000.0, 1010.0)))
+    }
+}


### PR DESCRIPTION
Instrument-first for #257 (HRV reads ~2× too high on a WHOOP 4.0). Diagnosing that report meant hand-computing beat density from the per-window trace; these two numbers make the next one self-diagnosing.

## What
Two fields added to the always-on `hrv diag` line:
- **`coverage`** = `sum(NN intervals, ms) ÷ wall-clock span (ms)`. A value **> ~1.0 is physically impossible** — you can't record more heartbeat-time than elapsed time — so it directly detects double-counted / overlapping R-R. #257's night reads ~**1.78** (48386 beats × 1109 ms ≈ 14.9 h of beat-time over an ~8.35 h sleep).
- **`dupBeats`** = count of exact-duplicate `(ts, rrMs)` rows — points at the double-insert mechanism when coverage > 1.

So `hrv diag … rr=X/Y rejected=Z%` becomes `… rejected=Z% coverage=1.78 dupBeats=N`.

## Why this shape
- **Instrumentation only** — no scored/stored value changes; pure additions to the diagnostic line.
- Pure helpers `rrCoverage` / `duplicateBeatCount` on `HrvAnalyzer` (Kotlin) + `HRVAnalyzer` (Swift), **byte-parity**, unit-tested both sides (`HrvRrCoverageTest` / `HRVAnalyzerTests`).
- It confirms/refutes the double-insert theory the moment the #257 reporter re-syncs, and guards **every future** HRV report — then the actual ingest fix lands measured against these numbers.

One thing it deliberately doesn't do: split **live-vs-historical source** (that needs a `source` column on `rrInterval` — a schema+ingest change). `coverage` catches the over-count regardless of mechanism; the source split is a follow-up if needed.

## Tests
`compileFullDebugKotlin` + `HrvRrCoverageTest` (5) green; `StrandAnalytics` `HRVAnalyzerTests` twin via `swift-packages` CI; app-target Swift via `app-build`.