### PR TITLE
store: serialize open+migrate so concurrent openers can't race the migrator (#261)

### DIFF
--- a/Packages/WhoopStore/Sources/WhoopStore/WhoopStore.swift
+++ b/Packages/WhoopStore/Sources/WhoopStore/WhoopStore.swift
@@ -9,6 +9,40 @@ public enum WhoopStoreInfo {
     public static let schemaVersion = 18
 }
 
+/// Serializes `DatabasePool` creation + migration so two concurrent opens of the SAME file can never
+/// run their GRDB migrators at once (#261).
+///
+/// `WhoopStore(path:)` is opened from more than one place on the same file — the BLEManager's backfill
+/// store and the app's MetricsRepository (see the `init(path:)` note). On the first launch after an
+/// update that adds a migration, a cold *background* relaunch (iOS CoreBluetooth state restoration) can
+/// fire both opens at once. Each `DatabaseMigrator` reads "migration N unapplied", both apply it, and
+/// the loser's bookkeeping `INSERT` collides: `UNIQUE constraint failed: grdb_migrations.identifier`
+/// (SQLITE_CONSTRAINT). That open throws — on iOS the backfill sees "store not ready" and the offload
+/// is deferred to the next tick. It self-heals once one migrator commits, but the failed open is a
+/// real, user-visible sync stall.
+///
+/// `openAndMigrate` is actor-isolated and fully synchronous (no `await` inside), so the actor's serial
+/// executor runs exactly one open+migrate to completion before starting the next — closing the race at
+/// the source, for every opener present and future, not just the two we know about. Opens are
+/// launch-time-rare and a fully-migrated DB migrates nothing, so the serial gate costs nothing in
+/// practice. Each caller still gets its OWN pool; only the open+migrate step is serialized.
+private actor StoreOpenGate {
+    static let shared = StoreOpenGate()
+
+    func openAndMigrate(path: String, configuration config: Configuration) throws -> DatabasePool {
+        // Self-heal a foreign DB left in place by a bad cross-platform restore (#222): an Android
+        // (Room) backup that slipped past the import guard replaces our file with one that has our
+        // data tables but NO `grdb_migrations` bookkeeping. The migrator then thinks nothing is
+        // applied, re-runs v1, and crashes with `table "device" already exists` on every open — the
+        // store never bootstraps. Quarantine such a file BEFORE opening so we start fresh instead of
+        // looping forever. (A normal GRDB backup carries grdb_migrations and is left untouched.)
+        WhoopStore.quarantineIncompatibleDatabase(at: path)
+        let pool = try DatabasePool(path: path, configuration: config)
+        try WhoopStore.makeMigrator().migrate(pool)
+        return pool
+    }
+}
+
 /// WhoopStore is an `actor`: its public API is `async`, and all GRDB work runs on the
 /// actor's serial executor rather than the caller's (the main actor).
 ///
@@ -35,18 +69,21 @@ public actor WhoopStore {
         try WhoopStore.makeMigrator().migrate(dbWriter)
     }
 
+    /// Store an already-open, already-migrated writer WITHOUT re-running the migrator: the
+    /// `StoreOpenGate` (below) opened the pool and migrated it under the process-wide open lock, so
+    /// re-migrating here would be a redundant (and, if it raced a sibling opener, failing) second run.
+    /// (#261)
+    private init(preMigrated dbWriter: any DatabaseWriter) {
+        self.dbWriter = dbWriter
+    }
+
     /// Open (creating if needed) a database at `path` and run migrations.
     /// Uses a `DatabasePool`, which enables WAL automatically, plus a 5-second busy timeout so two
     /// handles to the same file (BLEManager + MetricsRepository) don't deadlock on write contention.
+    ///
+    /// Open + migrate runs through `StoreOpenGate` so two concurrent openers of the SAME file never
+    /// run their GRDB migrators at once (#261) — see that actor's note for the failure it prevents.
     public init(path: String) async throws {
-        // Self-heal a foreign DB left in place by a bad cross-platform restore (#222): an Android
-        // (Room) backup that slipped past the import guard replaces our file with one that has our
-        // data tables but NO `grdb_migrations` bookkeeping. The migrator then thinks nothing is
-        // applied, re-runs v1, and crashes with `table "device" already exists` on every open — the
-        // store never bootstraps. Quarantine such a file BEFORE opening so we start fresh instead of
-        // looping forever. (A normal GRDB backup carries grdb_migrations and is left untouched.)
-        WhoopStore.quarantineIncompatibleDatabase(at: path)
-
         var config = Configuration()
         config.prepareDatabase { db in
             // `DatabasePool` puts the database in WAL mode itself (reads run as concurrent snapshots
@@ -60,7 +97,8 @@ public actor WhoopStore {
             try db.execute(sql: "PRAGMA temp_store = MEMORY")
         }
         config.busyMode = .timeout(5)
-        try self.init(dbWriter: try DatabasePool(path: path, configuration: config))
+        let pool = try await StoreOpenGate.shared.openAndMigrate(path: path, configuration: config)
+        self.init(preMigrated: pool)
     }
 
     /// Move aside a database file that has our data tables but no GRDB migration bookkeeping — the

--- a/Packages/WhoopStore/Tests/WhoopStoreTests/DatabasePoolConcurrencyTests.swift
+++ b/Packages/WhoopStore/Tests/WhoopStoreTests/DatabasePoolConcurrencyTests.swift
@@ -137,5 +137,34 @@ final class DatabasePoolConcurrencyTests: XCTestCase {
         XCTAssertEqual(journalMode.lowercased(), "wal", "DatabasePool must put the file in WAL mode")
     }
 
+    /// #261: two openers hit the SAME file at once (BLEManager's backfill store + the MetricsRepository)
+    /// on a cold background relaunch right after an update adds a migration. Before the `StoreOpenGate`,
+    /// both migrators read "migration unapplied", both applied it, and the loser's bookkeeping INSERT
+    /// threw `UNIQUE constraint failed: grdb_migrations.identifier` — that open failed and the offload
+    /// stalled. This opens the same FRESH (unmigrated) path from many tasks concurrently — the exact
+    /// window — and asserts every open succeeds AND lands on a usable, fully-migrated store. Serialized
+    /// open+migrate makes this deterministic; without it the concurrent migrators race and some throw.
+    func testConcurrentOpensOfSameFreshFileAllSucceed() async throws {
+        let path = tempPath()
+        defer { removeDB(path) }
+
+        // Open the same not-yet-created file from 16 tasks at once. Each gets its own pool; the gate
+        // ensures their migrators never overlap. All 16 must open without throwing.
+        try await withThrowingTaskGroup(of: Void.self) { group in
+            for _ in 0..<16 {
+                group.addTask {
+                    let store = try await WhoopStore(path: path)
+                    // A trivial read proves the returned store is migrated and usable, not a half-open
+                    // handle that merely dodged the throw.
+                    let applied = try await store.registryWriter.read { db in
+                        try Int.fetchOne(db, sql: "SELECT COUNT(*) FROM grdb_migrations") ?? 0
+                    }
+                    XCTAssertGreaterThan(applied, 0, "each concurrent open must land on a fully-migrated store")
+                }
+            }
+            try await group.waitForAll()
+        }
+    }
+
     private enum ConcurrencyTimeout: Error { case readBlockedOnWriter }
 }


### PR DESCRIPTION
## What #261 actually is

The reporter titled it "Clock latched: no," but that readout is a cosmetic 5/MG symptom (records still date correctly via the IDENTITY fallback — the strap's timestamps are absolute). The real defect is three lines down in their log:

```
Backfill: bootstrap FAILED opening store — GRDB.DatabaseError code=1555:
SQLite error 19: UNIQUE constraint failed: grdb_migrations.identifier
```

## Root cause

`WhoopStore(path:)` is opened from **two** places on the same file — `BLEManager` (backfill store) and `Repository` (`MetricsRepository`). `Repository.ensureStore()` already single-flights its own opens (the 2026-07-01 "thundering herd" guard), but the two openers are independent objects opening independent `DatabasePool`s on the same file.

On the first launch after an update that **adds a migration**, a cold **background** relaunch (iOS CoreBluetooth state restoration — the reporter's log opens with `Restored CONNECTED peripheral`) fires both opens at once. Each `DatabaseMigrator` reads "migration N unapplied," both apply it, and the loser's `INSERT INTO grdb_migrations` collides on the UNIQUE constraint. That open throws → backfill logs `store not ready` and defers the offload. It self-heals once one migrator commits (the reporter's later offload landed 1002 rows), so there's **no data loss** — but the failed open is a real, user-visible sync stall.

## Fix

Serialize open+migrate at the source, in `WhoopStore`, so it covers **every** opener present and future — not just the two we know about. `StoreOpenGate.openAndMigrate` is actor-isolated and fully synchronous (no `await` inside), so the actor's serial executor runs exactly one open+migrate to completion before the next. Each caller still gets its own pool; a fully-migrated DB migrates nothing, so single opens are unchanged. The foreign-DB quarantine (#222) moves inside the gate so it's serialized too.

## Parity

iOS-specific. Android's Room database is a synchronized singleton (`instance ?: synchronized(this)`), so there's no second concurrent opener and no migrator race — no Android twin needed. This is an init-race, not an analytics/stored-value divergence, so the byte-parity contract isn't touched.

## Test

`testConcurrentOpensOfSameFreshFileAllSucceed` opens the same fresh (unmigrated) path from 16 tasks at once — the exact window — and asserts every open succeeds and lands on a fully-migrated store. Serialized open+migrate makes this deterministic; without the gate the concurrent migrators race and some throw. Covered by `swift-packages` CI (WhoopStore, macos-15).

## Not addressed here (separate follow-ups)
- **"Clock latched: no" readout** on 5/MG — cosmetic; worth a look at whether a data-range reply should flip it to "yes," but it's not this bug.
- **"Rest stuck on 89"** — the reporter's side-note; nothing in the log shows 89 (RHR floors are 43–54). Its own issue with a screenshot.
- **Capture check INCOMPLETE** — the `connection`/`universal` diagnostic traces produced no output despite the mode being on; separate diagnostic-wiring gap.