### PR TITLE
import: light day Effort from an imported ride's HR on a strap-less day (#137)

### DIFF
--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/DayOwnerReadIntegrationTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/DayOwnerReadIntegrationTests.swift
@@ -22,7 +22,12 @@ final class DayOwnerReadIntegrationTests: XCTestCase {
         var candidates: [DayOwnerResolver.Candidate] = []
         for d in try registry.all() where d.status != .archived {
             let isImport = d.sourceKind == .cloudImport || d.sourceKind == .fileImport
-            let priority = d.id == activeId ? 0 : (isImport ? 2 : 1)
+            // Mirrors IntelligenceEngine.resolveDayOwner: activity-file rides rank BELOW whole-day imports.
+            let priority: Int
+            if d.id == activeId { priority = 0 }
+            else if d.sourceKind == .activityFile { priority = 3 }
+            else if isImport { priority = 2 }
+            else { priority = 1 }
             let hasData = !((try? await store.hrSamples(deviceId: d.id, from: from, to: to, limit: 1)) ?? []).isEmpty
             candidates.append(.init(deviceId: d.id, priority: priority, hasData: hasData))
         }
@@ -81,6 +86,70 @@ final class DayOwnerReadIntegrationTests: XCTestCase {
 
         let read = try await store.hrSamples(deviceId: owner!, from: from, to: to, limit: 200_000)
         XCTAssertTrue(read.allSatisfy { $0.bpm == 99 }, "read must follow the locked owner")
+    }
+
+    /// #137 (B1): on a STRAP-LESS day — the active WHOOP collected NO HR — an imported activity file's
+    /// HR (source "activity-file", an `.activityFile` device) makes it the day owner, so `dayHr` reads the
+    /// ride's HR and the day Effort ring can light. This is the whole point of registering `activity-file`
+    /// as a candidate: with the strap absent it's the only source with data, so priority-3 still wins (an
+    /// owner is the lowest-priority candidate that HAS data, not merely the lowest priority).
+    /// On a day the strap DID collect HR, the strap (priority 0) would win instead — proven by the first
+    /// test above — so imported HR only ever surfaces where there's no strap data to override it.
+    func testActivityFileOwnsStrapLessDayAndReadReturnsItsHR() async throws {
+        let store = try await WhoopStore.inMemory()    // migration v15 seeds active 'my-whoop' (no data yet)
+        let registry = DeviceRegistryStore(dbQueue: store.registryWriter)
+
+        // The activity-file import device, exactly as DataSourcesView registers it (#137 B1).
+        try registry.add(PairedDevice(id: "activity-file", brand: "Workout files", model: "",
+                                      sourceKind: .activityFile, capabilities: [.hr],
+                                      status: .paired, addedAt: 1, lastSeenAt: 1))
+
+        // ONLY the imported ride has HR this day; the active strap has none (strap-less day).
+        let base = dayStart + 3 * 3_600
+        let rideHR = (0..<300).map { HRSample(ts: base + $0, bpm: 132) }
+        _ = try await store.insert(Streams(hr: rideHR), deviceId: "activity-file")
+
+        let from = dayStart - 30 * 3_600, to = dayStart + 12 * 3_600
+        let owner = try await resolveOwner(store: store, registry: registry, from: from, to: to)
+        XCTAssertEqual(owner, "activity-file",
+                       "with no strap HR, the imported file (priority 3, has data) must own the day")
+
+        let read = try await store.hrSamples(deviceId: owner!, from: from, to: to, limit: 200_000)
+        XCTAssertEqual(read.count, rideHR.count)
+        XCTAssertTrue(read.allSatisfy { $0.bpm == 132 }, "the day read must return the imported ride's HR")
+    }
+
+    /// #137 tie-break: on a strap-less day where BOTH a whole-day WHOOP import (priority 2) and an
+    /// activity-file ride (priority 3) have HR, the whole-day import must OWN the day — a 90-minute ride
+    /// can never displace a full-day source. This is why `activity-file` is a distinct `.activityFile`
+    /// kind ranked below `.fileImport`/`.cloudImport`, rather than sharing priority 2 where a stable-sort
+    /// tie would let array order decide.
+    func testWholeDayImportBeatsActivityFileRideOnStrapLessDay() async throws {
+        let store = try await WhoopStore.inMemory()
+        let registry = DeviceRegistryStore(dbQueue: store.registryWriter)
+
+        // A whole-day WHOOP CSV import (priority 2) and the ride (priority 3), both paired, neither active.
+        try registry.add(PairedDevice(id: "whoop-import", brand: "WHOOP", model: "WHOOP (import)",
+                                      sourceKind: .fileImport, capabilities: [.hr],
+                                      status: .paired, addedAt: 1, lastSeenAt: 1))
+        try registry.add(PairedDevice(id: "activity-file", brand: "Workout files", model: "",
+                                      sourceKind: .activityFile, capabilities: [.hr],
+                                      status: .paired, addedAt: 1, lastSeenAt: 1))
+
+        // Both sources carry HR for the SAME strap-less day, distinguishable by bpm.
+        let base = dayStart + 3 * 3_600
+        _ = try await store.insert(Streams(hr: (0..<300).map { HRSample(ts: base + $0, bpm: 132) }),
+                                   deviceId: "activity-file")
+        _ = try await store.insert(Streams(hr: (0..<300).map { HRSample(ts: base + 3_600 + $0, bpm: 58) }),
+                                   deviceId: "whoop-import")
+
+        let from = dayStart - 30 * 3_600, to = dayStart + 12 * 3_600
+        let owner = try await resolveOwner(store: store, registry: registry, from: from, to: to)
+        XCTAssertEqual(owner, "whoop-import",
+                       "a whole-day import (priority 2) must beat the activity-file ride (priority 3)")
+
+        let read = try await store.hrSamples(deviceId: owner!, from: from, to: to, limit: 200_000)
+        XCTAssertTrue(read.allSatisfy { $0.bpm == 58 }, "the day read must follow the whole-day import, not the ride")
     }
 
     /// Single-device install (the default): only the seeded active 'my-whoop' is paired. The owner

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/StrainScorerTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/StrainScorerTests.swift
@@ -34,6 +34,33 @@ final class StrainScorerTests: XCTestCase {
         XCTAssertEqual(s!, 44.27, accuracy: 1e-2)
     }
 
+    /// #137 (partial-day sanity, PR #236 review): an imported ride is a short HR ISLAND — a 1–2 h
+    /// window, not a full day of HR. Prove the day Effort from that island is SENSIBLE: it equals the
+    /// Effort the same ride would score if worn on a strap for a full day. Edwards TRIMP integrates only
+    /// over the samples present, and resting HR (≤ restingHR → zone weight 0) adds zero TRIMP, so a
+    /// strap-less imported ride is neither diluted by the empty hours nor inflated by them — the number
+    /// the user sees is the ride's own honest cardiovascular load, identical to a worn strap.
+    func testImportedRidePartialDayEffortMatchesWornStrap() {
+        // A 90-minute ride @ 150 bpm (moderate), mid-morning, sampled at 1 Hz.
+        let ride = hr(150, 90 * 60, start: 8 * 3_600)
+
+        // Import case (strap-less day): the ride is the ONLY HR on the day.
+        let importEffort = StrainScorer.strain(ride, maxHR: 190, restingHR: 60)
+
+        // Worn-strap case: the SAME ride embedded in a full 24 h of resting HR (60 bpm) around it.
+        let restBefore = hr(60, 8 * 3_600, start: 0)
+        let restAfter  = hr(60, 24 * 3_600 - 8 * 3_600 - 90 * 60, start: 8 * 3_600 + 90 * 60)
+        let wornEffort = StrainScorer.strain(restBefore + ride + restAfter, maxHR: 190, restingHR: 60)
+
+        XCTAssertNotNil(importEffort, "a 90-min HR island clears the minReadings/minSpan gates")
+        // Identical: resting time contributes zero TRIMP, so the island scores the same either way.
+        XCTAssertEqual(importEffort!, wornEffort!, accuracy: 1e-9,
+                       "imported-ride Effort must equal the same ride worn on a strap")
+        // A sensible MODERATE Effort for a 90-min zone-3 ride — not 0 (dark), not saturated (~100).
+        XCTAssertGreaterThan(importEffort!, 20)
+        XCTAssertLessThan(importEffort!, 90)
+    }
+
     func testStrainReturnsNilTooFewReadings() {
         XCTAssertNil(StrainScorer.strain(hr(150, 599), maxHR: 190, restingHR: 60))
     }

--- a/Packages/StrandImport/Sources/StrandImport/ActivityFileImporter.swift
+++ b/Packages/StrandImport/Sources/StrandImport/ActivityFileImporter.swift
@@ -59,6 +59,17 @@ public struct ActivityFile: Sendable, Equatable {
     /// The route as (lat, lon) pairs in order, for the platforms that store a polyline (Android's
     /// `routePolyline`). macOS's shared WorkoutRow has no route column, so it keeps only the summary.
     public var route: [RoutePoint]
+    /// #137: the REAL per-sample HR time series — the (unix-second, bpm) pairs the file actually
+    /// carried. Historically the importer folded these into `avgHr`/`maxHr`/`hrSampleCount` and then
+    /// THREW THE SAMPLES AWAY (deliberately: an imported file never fed the HR-based Effort). We now
+    /// keep them so the app layer can persist them under the `activity-file` source; on a strap-less
+    /// day that lets the imported ride's measured HR light the day Effort ring (the day-owner resolver
+    /// picks `activity-file` as the sole source with HR that day — see IntelligenceEngine.resolveDayOwner).
+    /// This is measured data, not a fabricated strain, so it does not reintroduce the "fabricated
+    /// cardiovascular strain" the WorkoutRow `strain = nil` guard exists to avoid. Only samples that
+    /// carried BOTH a timestamp and a valid HR appear here (a sample with no time can't key into the
+    /// (deviceId, ts) HR store), so `hrSamples.count <= hrSampleCount` in general.
+    public var hrSamples: [ActivityHRSample]
 
     public init(
         kind: Kind,
@@ -72,7 +83,8 @@ public struct ActivityFile: Sendable, Equatable {
         ascentM: Double? = nil,
         gpsPointCount: Int = 0,
         hrSampleCount: Int = 0,
-        route: [RoutePoint] = []
+        route: [RoutePoint] = [],
+        hrSamples: [ActivityHRSample] = []
     ) {
         self.kind = kind
         self.start = start
@@ -86,6 +98,7 @@ public struct ActivityFile: Sendable, Equatable {
         self.gpsPointCount = gpsPointCount
         self.hrSampleCount = hrSampleCount
         self.route = route
+        self.hrSamples = hrSamples
     }
 
     /// Duration in seconds, or nil when start == end (no real interval to claim).
@@ -115,6 +128,21 @@ public struct RoutePoint: Sendable, Equatable {
     public init(lat: Double, lon: Double) {
         self.lat = lat
         self.lon = lon
+    }
+}
+
+/// #137: one persisted HR sample — unix-second timestamp + bpm. Deliberately a LOCAL type (not
+/// WhoopProtocol's `HRSample`) so the pure StrandImport package stays dependency-free; the app layer
+/// maps this 1:1 onto `HRSample` when writing to the HR store. Keep the (ts, bpm) shape in parity with
+/// the Kotlin `ActivityFileImporter.HrSample` twin.
+public struct ActivityHRSample: Sendable, Equatable {
+    /// Wall-clock unix seconds (the sample's own time, from the file).
+    public var ts: Int
+    /// Heart rate in bpm (already range-validated by `validHr` upstream).
+    public var bpm: Int
+    public init(ts: Int, bpm: Int) {
+        self.ts = ts
+        self.bpm = bpm
     }
 }
 
@@ -275,7 +303,11 @@ public enum ActivityFileImporter {
             ascentM: ascent,
             gpsPointCount: route.count,
             hrSampleCount: hrs.count,
-            route: cappedRoute(route)
+            route: cappedRoute(route),
+            // #137: carry the real per-sample HR through (only timestamped+HR samples survive). The
+            // no-timestamp fallback path above intentionally leaves this empty — those samples have no
+            // epoch to key into the HR store.
+            hrSamples: hrSamples(from: samples)
         )
         return ActivityFileImportResult(activity: a, kind: kind, skipped: skipped)
     }
@@ -286,6 +318,32 @@ public enum ActivityFileImporter {
         var point: RoutePoint?
         var elevationM: Double?
         var hr: Int?
+    }
+
+    /// #137: fold the parsed track samples into the persisted HR series. SHARED by every format path
+    /// (GPX/TCX via `build`, FIT via `FitParser.buildResult`) so the three decode to a byte-identical
+    /// HR stream and stay in parity with the Kotlin twin. A sample is kept only when it carried BOTH a
+    /// timestamp and a valid HR: without a time it can't key into the (deviceId, ts) HR store, and
+    /// without HR there's nothing to store. The epoch is finite/range-checked BEFORE the `Int(Double)`
+    /// conversion (never a trapping cast — mirrors the importer's other numeric guards); the upper
+    /// bound is the same 2100-01-01 sanity ceiling `FitParser`/`fitDate` uses, so a crafted file with
+    /// an absurd timestamp is dropped, not stored.
+    ///
+    /// `ts` is `Int(secs)` — a TRUNCATION toward the whole second, not `.rounded()`. This is a
+    /// byte-parity requirement, not a stylistic choice: `ts` is the `(deviceId, ts)` store key, and the
+    /// Kotlin twin derives its timestamp from `OffsetDateTime.toEpochSecond()`, which floors a
+    /// fractional-second timestamp. A GPX/TCX trackpoint like `…T08:00:00.500Z` keeps its fraction in the
+    /// Swift `Date` (parsed via `WhoopTime`'s fractional formatter); rounding it here would store `ts+1`
+    /// on Apple while Android stored `ts` — a 1-second divergence in a stored key. The guard above
+    /// pins `secs > 0`, so truncation-toward-zero equals the floor Kotlin uses. (FIT epochs are already
+    /// whole seconds, so this is a no-op there and only the sub-second XML formats were ever at risk.)
+    static func hrSamples(from samples: [TrackSample]) -> [ActivityHRSample] {
+        samples.compactMap { s in
+            guard let time = s.time, let hr = s.hr else { return nil }
+            let secs = time.timeIntervalSince1970
+            guard secs.isFinite, secs > 0, secs < 4_102_444_800 else { return nil }
+            return ActivityHRSample(ts: Int(secs), bpm: hr)
+        }
     }
 
     // MARK: - Geo / summary math

--- a/Packages/StrandImport/Sources/StrandImport/FitParser.swift
+++ b/Packages/StrandImport/Sources/StrandImport/FitParser.swift
@@ -468,7 +468,10 @@ private struct FitDecoder {
             ascentM: ascent,
             gpsPointCount: gpsPointCount,
             hrSampleCount: hrSampleCount,
-            route: ActivityFileImporter.cappedRoute(route)
+            route: ActivityFileImporter.cappedRoute(route),
+            // #137: the real per-record HR series, via the SHARED extractor so FIT persists a
+            // byte-identical HR stream to the GPX/TCX paths (and the Kotlin twin).
+            hrSamples: ActivityFileImporter.hrSamples(from: samples)
         )
         return ActivityFileImportResult(activity: activity, kind: .fit, skipped: skipped)
     }

--- a/Packages/StrandImport/Tests/StrandImportTests/ActivityFileImporterTests.swift
+++ b/Packages/StrandImport/Tests/StrandImportTests/ActivityFileImporterTests.swift
@@ -47,6 +47,54 @@ final class ActivityFileImporterTests: XCTestCase {
         XCTAssertEqual(dist, 222, accuracy: 30)
         // Ascent: +10 then +5 (both > 1 m hysteresis) = 15 m.
         XCTAssertEqual(a.ascentM ?? 0, 15, accuracy: 0.001)
+        // #137: the REAL per-sample HR series is now carried through (not just the avg/max summary),
+        // so the app layer can persist it under the activity-file source and light a strap-less day's
+        // Effort ring. Values in order, timestamped at each point's own time (start + 0/60/120 s).
+        XCTAssertEqual(a.hrSamples.map { $0.bpm }, [120, 140, 160])
+        let base = Int(a.start.timeIntervalSince1970)
+        XCTAssertEqual(a.hrSamples.map { $0.ts }, [base, base + 60, base + 120])
+    }
+
+    func testHrSamplesRequireBothTimestampAndHr() {
+        // #137: a sample must carry BOTH a timestamp and an HR to be persisted — a point with HR but
+        // no <time> can't key into the (deviceId, ts) HR store, and one with a time but no HR has
+        // nothing to store. Here: point 1 has time+HR (kept), point 2 has time but no HR (excluded),
+        // point 3 has HR but no time (excluded). `hrSampleCount` still counts every HR-bearing point.
+        let gpx = """
+        <gpx><trk><trkseg>
+          <trkpt lat="51.5000" lon="-0.1000"><time>2026-06-01T10:00:00Z</time>
+            <extensions><gpxtpx:TrackPointExtension><gpxtpx:hr>120</gpxtpx:hr></gpxtpx:TrackPointExtension></extensions></trkpt>
+          <trkpt lat="51.5010" lon="-0.1000"><time>2026-06-01T10:01:00Z</time></trkpt>
+          <trkpt lat="51.5020" lon="-0.1000">
+            <extensions><gpxtpx:TrackPointExtension><gpxtpx:hr>160</gpxtpx:hr></gpxtpx:TrackPointExtension></extensions></trkpt>
+        </trkseg></trk></gpx>
+        """
+        let r = ActivityFileImporter.parse(data: Data(gpx.utf8), filename: "mixed.gpx")
+        let a = try! XCTUnwrap(r.activity)
+        XCTAssertEqual(a.hrSampleCount, 2)                        // both HR-bearing points counted
+        XCTAssertEqual(a.hrSamples.map { $0.bpm }, [120])        // only the timestamped-with-HR one persisted
+        XCTAssertEqual(a.hrSamples.first?.ts, Int(a.start.timeIntervalSince1970))
+    }
+
+    func testHrSampleTimestampFloorsFractionalSecondsForKotlinParity() {
+        // #137 byte-parity: `hrSample.ts` is the `(deviceId, ts)` store key, so Apple and Android must
+        // derive the SAME whole second from a fractional timestamp. Kotlin's `OffsetDateTime.toEpochSecond()`
+        // FLOORS the fraction; Swift keeps it in the `Date`, so `hrSamples` must truncate (`Int(secs)`),
+        // NOT round — else `…00.500Z` would store ts+1 on Apple while Android stored ts. Parse the same
+        // trackpoint time both as a whole second and as `.500`, and assert both land on the SAME ts.
+        func ts(forTime t: String) -> Int? {
+            let gpx = """
+            <gpx><trk><trkseg>
+              <trkpt lat="51.5000" lon="-0.1000"><time>\(t)</time>
+                <extensions><gpxtpx:TrackPointExtension><gpxtpx:hr>130</gpxtpx:hr></gpxtpx:TrackPointExtension></extensions></trkpt>
+            </trkseg></trk></gpx>
+            """
+            let r = ActivityFileImporter.parse(data: Data(gpx.utf8), filename: "frac.gpx")
+            return r.activity?.hrSamples.first?.ts
+        }
+        let whole = try! XCTUnwrap(ts(forTime: "2026-06-01T10:00:00Z"))
+        let half = try! XCTUnwrap(ts(forTime: "2026-06-01T10:00:00.500Z"))
+        XCTAssertEqual(half, whole, "a .5-second fraction must FLOOR to the same whole second (Kotlin parity), not round up")
     }
 
     func testGpxRejectsNullIslandAndKeepsValidPoints() {
@@ -162,6 +210,11 @@ final class ActivityFileImporterTests: XCTestCase {
         XCTAssertEqual(a.route.first?.lon ?? 0, lon, accuracy: 1e-4)
         // start from the FIT epoch: 631065600 + 100000.
         XCTAssertEqual(a.start.timeIntervalSince1970, 631_065_600 + 100_000, accuracy: 1)
+        // #137: FIT persists the same real per-record HR series as GPX/TCX (shared extractor). Records
+        // are 0/10/20 s apart from the FIT-epoch start; HR 120/140/160.
+        let fitBase = 631_065_600 + 100_000
+        XCTAssertEqual(a.hrSamples.map { $0.bpm }, [120, 140, 160])
+        XCTAssertEqual(a.hrSamples.map { $0.ts }, [fitBase, fitBase + 10, fitBase + 20])
     }
 
     func testFitDetectionFromMagicBytes() {

--- a/Packages/WhoopStore/Sources/WhoopStore/PairedDevice.swift
+++ b/Packages/WhoopStore/Sources/WhoopStore/PairedDevice.swift
@@ -60,6 +60,12 @@ public enum SourceKind: String, Sendable, CaseIterable {
     /// signal can't be read it stays "-" (Huami precedent), never faked. Additive (no DB migration): only
     /// the experimental add-device wizard's Oura path writes it.
     case oura
+    /// A GPX/TCX/FIT activity file imported under the `activity-file` device (#137). Distinct from
+    /// `fileImport` (a whole-day WHOOP CSV export) so the day-owner resolver can rank it BELOW day-spanning
+    /// imports: a 90-minute ride must never displace a full-day source that has HR for the same day. It
+    /// wins ownership only when nothing else has data (a genuinely strap-less day), where its measured HR
+    /// lights the day Effort. Additive (no DB migration): only the activity-file importer writes it.
+    case activityFile
 }
 
 /// Canonical metric a source can provide. Drives capability-aware UI + the day-owner resolver.

--- a/Strand/Data/IntelligenceEngine.swift
+++ b/Strand/Data/IntelligenceEngine.swift
@@ -1423,7 +1423,14 @@ final class IntelligenceEngine: ObservableObject {
         var candidates: [DayOwnerResolver.Candidate] = []
         for d in liveDevices {
             let isImport = d.sourceKind == .cloudImport || d.sourceKind == .fileImport
-            let priority = d.id == activeId ? 0 : (isImport ? 2 : 1)
+            // #137: an activity-file ride ranks BELOW whole-day imports (priority 3 vs 2), so a full-day
+            // WHOOP CSV/cloud import keeps ownership of a day it has HR for; the ride only wins a day that
+            // nothing else covers (a strap-less day). Kotlin RegistryDayOwnerSource mirrors this ordering.
+            let priority: Int
+            if d.id == activeId { priority = 0 }
+            else if d.sourceKind == .activityFile { priority = 3 }
+            else if isImport { priority = 2 }
+            else { priority = 1 }
             // Cheap presence check: a single HR row for this device in the night window is enough to
             // mark it a candidate. (LIMIT 1 , not the full pull the caller does once an owner is chosen.)
             let hasData = !((try? await store.hrSamples(deviceId: d.id, from: from, to: to, limit: 1)) ?? []).isEmpty

--- a/Strand/Screens/DataSourcesView.swift
+++ b/Strand/Screens/DataSourcesView.swift
@@ -4,6 +4,7 @@ import StrandDesign
 import StrandImport
 import StrandAnalytics
 import WhoopStore
+import WhoopProtocol   // #137: Streams / HRSample, to persist an imported activity's per-sample HR
 
 struct DataSourcesView: View {
     @EnvironmentObject var model: AppModel
@@ -458,7 +459,17 @@ struct DataSourcesView: View {
     /// Parse a single GPX / TCX / FIT activity file and upsert it as one workout (source
     /// "activity-file"). The route polyline isn't persisted on macOS (the shared WorkoutRow has no route
     /// column), but distance / HR / energy / ascent and an honest "N GPS points · M HR samples" note are.
-    /// No `strain` is stored unless the file carried one — imported files never feed the HR-based Effort.
+    ///
+    /// #137: the imported ride's REAL per-sample HR is now ALSO persisted as an HR stream under the
+    /// `activity-file` deviceId, and `activity-file` is registered as an `.activityFile` device. Together
+    /// (A + B1) that lets a strap-less day's ride light the day Effort ring: the per-day owner resolver
+    /// (`IntelligenceEngine.resolveDayOwner`) treats `activity-file` as the LOWEST-ranked candidate
+    /// (priority 3, below whole-day imports at 2) and — being the only source with HR that day — picks it
+    /// as the day owner, so `dayHr` reads the ride's HR and Effort scores from it. On a day the user ALSO
+    /// wore the strap, the strap (priority 0/1) wins ownership and the imported HR is ignored for Effort;
+    /// on a day a whole-day WHOOP import (priority 2) has HR, that import wins over the ride too. The
+    /// workout row itself still stores `strain = nil` (we never fabricate a per-workout strain); the day
+    /// Effort is computed from the measured HR stream, exactly as it is for a worn strap.
     private func importActivityFile(url: URL) {
         activityFileImporting = true
         activityFileSummary = nil
@@ -506,6 +517,37 @@ struct DataSourcesView: View {
                     notes: activity.importNote()
                 )
                 try await store.upsertWorkouts([row], deviceId: ActivityFileImporter.sourceId)
+
+                // #137 (A): persist the ride's real per-sample HR under the activity-file source. The
+                // insert is keyed on (deviceId, ts), so re-importing the same file is idempotent (an
+                // identical ts overwrites, never duplicates). Skipped when the file carried no
+                // timestamped HR (a pure GPS track) — nothing to store, so day Effort stays honestly dark.
+                if !activity.hrSamples.isEmpty {
+                    let hr = activity.hrSamples.map { HRSample(ts: $0.ts, bpm: $0.bpm) }
+                    _ = try? await store.insert(Streams(hr: hr), deviceId: ActivityFileImporter.sourceId)
+                }
+
+                // #137 (B1): register `activity-file` as an `.activityFile` device so the per-day owner
+                // resolver can pick it as the day owner on a strap-less day (it iterates the registry's
+                // paired devices; an unregistered source is invisible to it). The distinct kind ranks it
+                // at priority 3 — below whole-day imports (2) — so a full-day WHOOP import always wins a
+                // day it has HR for. status `.paired`, NEVER `.active`, so it can never displace the live
+                // strap as the active device; capability `.hr` marks what the source CAN provide (presence
+                // per-day is still gated by an actual HR read in the resolver). Idempotent, makeActive: false.
+                model.registerDevice(
+                    PairedDevice(
+                        id: ActivityFileImporter.sourceId,
+                        brand: "Workout files",
+                        model: "",
+                        sourceKind: .activityFile,
+                        capabilities: [.hr],
+                        status: .paired,
+                        addedAt: Int(Date().timeIntervalSince1970),
+                        lastSeenAt: Int(Date().timeIntervalSince1970)
+                    ),
+                    makeActive: false
+                )
+
                 await repo.refresh()
                 activityFileSummary = ActivityFileImporter.summaryText(activity)
                 activityFileFailed = false

--- a/android/app/src/main/java/com/noop/analytics/RegistryDayOwnerSource.kt
+++ b/android/app/src/main/java/com/noop/analytics/RegistryDayOwnerSource.kt
@@ -25,8 +25,12 @@ class RegistryDayOwnerSource(private val registry: DeviceRegistry) : Intelligenc
             .map { d ->
                 val isImport = d.sourceKind == SourceKind.cloudImport.name ||
                     d.sourceKind == SourceKind.fileImport.name
+                // #137: an activity-file ride ranks BELOW whole-day imports (priority 3 vs 2), so a
+                // full-day WHOOP CSV/cloud import keeps ownership of a day it has HR for; the ride only
+                // wins a day nothing else covers. Mirrors Swift IntelligenceEngine.resolveDayOwner.
                 val priority = when {
                     d.id == activeId -> 0
+                    d.sourceKind == SourceKind.activityFile.name -> 3
                     isImport -> 2
                     else -> 1
                 }

--- a/android/app/src/main/java/com/noop/data/PairedDevice.kt
+++ b/android/app/src/main/java/com/noop/data/PairedDevice.kt
@@ -70,7 +70,11 @@ enum class DeviceStatus { active, paired, archived }
  *  encrypted readiness/sleep scores). Carried on string rawValue "oura"; no DB migration (the column is
  *  free-text and existing rows never carry it).
  *  Additive: existing rows never carry [ftms]/[huami]/[oura]; only the respective wizard paths write them. */
-enum class SourceKind { liveBLE, historyBLE, cloudImport, fileImport, ftms, huami, oura }
+// `activityFile` (#137): a GPX/TCX/FIT activity file under the `activity-file` device. Distinct from
+// `fileImport` (a whole-day WHOOP CSV export) so the day-owner resolver ranks it BELOW day-spanning
+// imports — a 90-minute ride must never displace a full-day source with HR for the same day. It owns a
+// day only when nothing else has data (a strap-less day). Additive: only the activity-file importer writes it.
+enum class SourceKind { liveBLE, historyBLE, cloudImport, fileImport, ftms, huami, oura, activityFile }
 
 /** A canonical metric a source can provide — drives capability-aware UI + the day-owner resolver.
  *  Stored as the enum name (Swift `Metric` rawValue) inside the comma-joined `capabilities` string. */

--- a/android/app/src/main/java/com/noop/ingest/ActivityFileImporter.kt
+++ b/android/app/src/main/java/com/noop/ingest/ActivityFileImporter.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.net.Uri
 import android.util.Xml
 import com.noop.analytics.RouteMath
+import com.noop.data.HrSample
 import com.noop.data.ImportSummary
 import com.noop.data.WhoopRepository
 import com.noop.data.WorkoutRow
@@ -60,6 +61,13 @@ object ActivityFileImporter {
 
     data class RoutePoint(val lat: Double, val lon: Double)
 
+    /**
+     * #137: one persisted HR sample — unix-second timestamp + bpm. Mirrors the Swift `ActivityHRSample`
+     * (a LOCAL type, not the Room [com.noop.data.HrSample] entity, so the pure-JVM importer needs no
+     * Room dependency; the app layer maps this 1:1 onto `HrSample` when writing to the HR store).
+     */
+    data class HrPoint(val ts: Long, val bpm: Int)
+
     data class Activity(
         val kind: Kind,
         val startTs: Long,          // unix seconds, UTC
@@ -73,6 +81,16 @@ object ActivityFileImporter {
         val gpsPointCount: Int,
         val hrSampleCount: Int,
         val route: List<RoutePoint>,
+        // #137: the REAL per-sample HR time series the file carried — historically folded into
+        // avg/max/hrSampleCount and then discarded (an imported file never fed the HR-based Effort). We
+        // now keep it so the app layer can persist it under the `activity-file` source; on a strap-less
+        // day that lets the ride's measured HR light the day Effort ring (the day-owner resolver picks
+        // `activity-file` as the sole source with HR that day — see IntelligenceEngine.resolveDayOwner).
+        // Measured data, not a fabricated strain, so it doesn't reintroduce the fabricated-strain the
+        // WorkoutRow `strain = null` guard avoids. Only samples carrying BOTH a timestamp and a valid HR
+        // appear here (a sample with no time can't key into the (deviceId, ts) HR store), so in general
+        // hrSamples.size <= hrSampleCount. Defaulted so the no-data build paths need no change.
+        val hrSamples: List<HrPoint> = emptyList(),
     ) {
         val durationS: Double? get() = (endTs - startTs).takeIf { it > 0 }?.toDouble()
 
@@ -101,6 +119,22 @@ object ActivityFileImporter {
         val elevationM: Double?,
         val hr: Int?,
     )
+
+    /**
+     * #137: fold the parsed track samples into the persisted HR series. SHARED by every format path
+     * (GPX/TCX via [build], FIT via [FitDecoder.build]) so the three decode to a byte-identical HR
+     * stream and stay in parity with the Swift twin. A sample is kept only when it carried BOTH a
+     * timestamp and a valid HR: without a time it can't key into the (deviceId, ts) HR store, and
+     * without HR there's nothing to store. The epoch is range-checked with the same 2100-01-01 sanity
+     * ceiling the FIT decoder uses, so a crafted file with an absurd timestamp is dropped, not stored.
+     */
+    internal fun hrSamples(samples: List<Sample>): List<HrPoint> =
+        samples.mapNotNull { s ->
+            val ts = s.timeS ?: return@mapNotNull null
+            val hr = s.hr ?: return@mapNotNull null
+            if (ts <= 0 || ts >= 4_102_444_800L) return@mapNotNull null
+            HrPoint(ts, hr)
+        }
 
     // MARK: - Format detection
 
@@ -181,6 +215,15 @@ object ActivityFileImporter {
 
         repo.upsertDevice(deviceId, name = "Workout files")
         repo.upsertWorkouts(listOf(row))
+
+        // #137 (A): persist the ride's real per-sample HR under the activity-file source. The insert is
+        // keyed on (deviceId, ts) (OnConflict.REPLACE), so re-importing the same file is idempotent — an
+        // identical ts overwrites, never duplicates. Skipped when the file carried no timestamped HR (a
+        // pure GPS track), leaving day Effort honestly dark. Registering activity-file as a `.fileImport`
+        // owner candidate (B1) happens in the UI caller (DataSourcesScreen), mirroring the Swift lane.
+        if (activity.hrSamples.isNotEmpty()) {
+            repo.insertHr(activity.hrSamples.map { HrSample(deviceId = deviceId, ts = it.ts, bpm = it.bpm) })
+        }
 
         return ImportSummary(
             source = SOURCE_LABEL,
@@ -400,6 +443,9 @@ object ActivityFileImporter {
             gpsPointCount = route.size,
             hrSampleCount = hrs.size,
             route = cappedRoute(route),
+            // #137: carry the real per-sample HR through (only timestamped+HR samples survive). The
+            // no-timestamp path above leaves this empty — those samples have no epoch to key the store.
+            hrSamples = hrSamples(samples),
         )
         return Result(a, kind, skipped)
     }
@@ -774,6 +820,9 @@ internal class FitDecoder(raw: ByteArray) {
             gpsPointCount = gpsPointCount,
             hrSampleCount = hrSampleCount,
             route = ActivityFileImporter.cappedRoute(route),
+            // #137: the real per-record HR series, via the SHARED extractor so FIT persists a
+            // byte-identical HR stream to the GPX/TCX paths (and the Swift twin).
+            hrSamples = ActivityFileImporter.hrSamples(samples),
         )
         return ActivityFileImporter.Result(activity, ActivityFileImporter.Kind.FIT, skipped)
     }

--- a/android/app/src/main/java/com/noop/ui/DataSourcesScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/DataSourcesScreen.kt
@@ -56,7 +56,11 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.health.connect.client.HealthConnectClient
 import androidx.health.connect.client.PermissionController
 import com.noop.data.DataBackup
+import com.noop.data.DeviceStatus
 import com.noop.data.ImportSummary
+import com.noop.data.Metric
+import com.noop.data.PairedDeviceRow
+import com.noop.data.SourceKind
 import com.noop.ingest.AppleHealthImporter
 import com.noop.ingest.HealthConnectImporter
 import com.noop.ingest.HealthConnectWriter
@@ -285,7 +289,36 @@ fun DataSourcesScreen(vm: AppViewModel) {
         ActivityResultContracts.OpenDocument(),
     ) { uri ->
         if (uri != null) runImport {
-            ActivityFileImporter.importExport(context, uri, vm.repo).also { vm.loadWorkouts() }
+            ActivityFileImporter.importExport(context, uri, vm.repo).also { summary ->
+                vm.loadWorkouts()
+                // #137 (B1): on a SUCCESSFUL import, register `activity-file` as an `activityFile` device
+                // so the per-day owner resolver can pick it as the day owner on a strap-less day (it
+                // iterates the registry's paired devices — an unregistered source is invisible to it). The
+                // distinct kind ranks it at priority 3 — below whole-day imports (2) — so a full-day WHOOP
+                // import always wins a day it has HR for. status `paired`, NEVER `active` (makeActive =
+                // false), so it can never displace the live strap; capability `hr` marks what the source
+                // CAN provide (per-day presence is still gated by an actual HR read in the resolver).
+                // Idempotent (OnConflict.REPLACE). Twin of the Swift DataSourcesView `model.registerDevice`
+                // call. See ActivityFileImporter (A) for the matching per-sample HR persist.
+                if (summary.totalRows > 0) {
+                    val now = System.currentTimeMillis() / 1000
+                    vm.registerDevice(
+                        PairedDeviceRow(
+                            id = ActivityFileImporter.SOURCE_ID,
+                            brand = "Workout files",
+                            model = "",
+                            nickname = null,
+                            peripheralId = null,
+                            sourceKind = SourceKind.activityFile.name,
+                            capabilities = Metric.hr.name,
+                            status = DeviceStatus.paired.name,
+                            addedAt = now,
+                            lastSeenAt = now,
+                        ),
+                        makeActive = false,
+                    )
+                }
+            }
         }
     }
 

--- a/android/app/src/test/java/com/noop/analytics/RegistryDayOwnerSourceTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/RegistryDayOwnerSourceTest.kt
@@ -126,6 +126,28 @@ class RegistryDayOwnerSourceTest {
     }
 
     @Test
+    fun activityFileRideRanksBelowWholeDayImport() = runBlocking {
+        // #137: a whole-day WHOOP import (priority 2) and an activity-file ride (priority 3) both have HR
+        // for the same strap-less day. The whole-day import must OWN it — a 90-minute ride can never
+        // displace a full-day source. Parity with the Swift DayOwnerReadIntegrationTests tie-break test.
+        val dao = FakeDao().apply {
+            devices["my-whoop"] = device("my-whoop", "WHOOP", SourceKind.liveBLE, DeviceStatus.active)
+            devices["whoop-import"] = device("whoop-import", "WHOOP", SourceKind.fileImport, DeviceStatus.paired)
+            devices["activity-file"] = device("activity-file", "Workout files", SourceKind.activityFile, DeviceStatus.paired)
+        }
+        val src = RegistryDayOwnerSource(registry(dao))
+
+        val priorities = src.candidatePriorities().toMap()
+        assertEquals(2, priorities["whoop-import"])   // whole-day import
+        assertEquals(3, priorities["activity-file"])  // partial ride, ranked below
+
+        // Strap-less day, both imports have data → the whole-day import wins, not the ride.
+        val owner = resolveWith(src, "2026-06-15",
+            mapOf("my-whoop" to false, "whoop-import" to true, "activity-file" to true))
+        assertEquals("whoop-import", owner)
+    }
+
+    @Test
     fun lockedOwnerWinsOutright() = runBlocking {
         val dao = FakeDao().apply {
             devices["my-whoop"] = device("my-whoop", "WHOOP", SourceKind.liveBLE, DeviceStatus.active)

--- a/android/app/src/test/java/com/noop/ingest/ActivityFileImporterTest.kt
+++ b/android/app/src/test/java/com/noop/ingest/ActivityFileImporterTest.kt
@@ -66,6 +66,53 @@ class ActivityFileImporterTest {
         assertEquals(120.0, a.durationS!!, 1e-6)
         assertEquals(222.0, a.distanceM!!, 30.0)
         assertEquals(15.0, a.ascentM!!, 1e-3)
+        // #137: the REAL per-sample HR series is now carried through (not just avg/max), so the app
+        // layer can persist it under the activity-file source and light a strap-less day's Effort ring.
+        // Values in order, timestamped at each point's own time (start + 0/60/120 s). Parity with Swift.
+        assertEquals(listOf(120, 140, 160), a.hrSamples.map { it.bpm })
+        val base = a.startTs
+        assertEquals(listOf(base, base + 60, base + 120), a.hrSamples.map { it.ts })
+    }
+
+    @Test
+    fun hrSamplesRequireBothTimestampAndHr() {
+        // #137: a sample must carry BOTH a timestamp and an HR to be persisted — a point with HR but no
+        // <time> can't key into the (deviceId, ts) HR store, and one with a time but no HR has nothing to
+        // store. Point 1: time+HR (kept). Point 2: time, no HR (excluded). Point 3: HR, no time
+        // (excluded). `hrSampleCount` still counts every HR-bearing point. Parity with the Swift twin.
+        val gpx = """
+            <gpx><trk><trkseg>
+              <trkpt lat="51.5000" lon="-0.1000"><time>2026-06-01T10:00:00Z</time>
+                <extensions><gpxtpx:TrackPointExtension><gpxtpx:hr>120</gpxtpx:hr></gpxtpx:TrackPointExtension></extensions></trkpt>
+              <trkpt lat="51.5010" lon="-0.1000"><time>2026-06-01T10:01:00Z</time></trkpt>
+              <trkpt lat="51.5020" lon="-0.1000">
+                <extensions><gpxtpx:TrackPointExtension><gpxtpx:hr>160</gpxtpx:hr></gpxtpx:TrackPointExtension></extensions></trkpt>
+            </trkseg></trk></gpx>
+        """.trimIndent()
+        val r = ActivityFileImporter.parse(gpx.toByteArray(Charsets.UTF_8), "mixed.gpx")
+        val a = r.activity!!
+        assertEquals(2, a.hrSampleCount)                    // both HR-bearing points counted
+        assertEquals(listOf(120), a.hrSamples.map { it.bpm }) // only the timestamped-with-HR one persisted
+        assertEquals(a.startTs, a.hrSamples.first().ts)
+    }
+
+    @Test
+    fun hrSampleTimestampFloorsFractionalSecondsForSwiftParity() {
+        // #137 byte-parity anchor: `hrSample.ts` is the `(deviceId, ts)` store key, so Android and Apple
+        // must derive the SAME whole second from a fractional timestamp. Kotlin floors via
+        // OffsetDateTime.toEpochSecond(); Swift truncates its fractional Date to match. Parse the same
+        // trackpoint time as a whole second and as `.500`, and assert both land on the SAME ts (floor).
+        fun ts(time: String): Long {
+            val gpx = """
+                <gpx><trk><trkseg>
+                  <trkpt lat="51.5000" lon="-0.1000"><time>$time</time>
+                    <extensions><gpxtpx:TrackPointExtension><gpxtpx:hr>130</gpxtpx:hr></gpxtpx:TrackPointExtension></extensions></trkpt>
+                </trkseg></trk></gpx>
+            """.trimIndent()
+            return ActivityFileImporter.parse(gpx.toByteArray(Charsets.UTF_8), "frac.gpx").activity!!.hrSamples.first().ts
+        }
+        assertEquals("a .5-second fraction must FLOOR to the same whole second (Swift parity), not round up",
+            ts("2026-06-01T10:00:00Z"), ts("2026-06-01T10:00:00.500Z"))
     }
 
     @Test
@@ -172,6 +219,11 @@ class ActivityFileImporterTest {
         assertEquals(lat, a.route.first().lat, 1e-4)
         assertEquals(lon, a.route.first().lon, 1e-4)
         assertEquals((631_065_600L + 100_000L).toDouble(), a.startTs.toDouble(), 1.0)
+        // #137: FIT persists the same real per-record HR series as GPX/TCX (shared extractor). Records
+        // are 0/10/20 s apart from the FIT-epoch start; HR 120/140/160. Parity with the Swift twin.
+        val fitBase = 631_065_600L + 100_000L
+        assertEquals(listOf(120, 140, 160), a.hrSamples.map { it.bpm })
+        assertEquals(listOf(fitBase, fitBase + 10, fitBase + 20), a.hrSamples.map { it.ts })
     }
 
     @Test


### PR DESCRIPTION
Fixes #137. Supersedes #236 — same A+B1 direction (endorsed in the #137 thread), reimplemented under the project identity with two corrections found in review.

## What it does
A GPX/TCX/FIT import with HR previously folded per-sample HR into avg/max and **discarded the samples**, and the `activity-file` source never reached the day-Effort read. Now:

- **(A)** the ride's **real per-sample HR** is persisted under the `activity-file` source (shared GPX/TCX/FIT extractor; a sample needs BOTH a timestamp and a valid HR; keyed on `(deviceId, ts)` so re-import is idempotent).
- **(B1)** `activity-file` is a registered day-owner candidate, so on a **strap-less day** its measured HR owns the day → `dayHr` reads it → day Effort lights, computed from the measured stream exactly as for a worn strap. Workout row keeps `strain = nil` (no fabricated per-workout strain). **The strap always wins when it has data.**

## Two corrections over the #236 approach
1. **Byte-parity (the #1 rule).** `hrSample.ts` is a stored `(deviceId, ts)` key. Kotlin derives it from `OffsetDateTime.toEpochSecond()` (floors the fraction); Swift kept the fraction in its `Date` and rounded — so `…00.500Z` stored `ts+1` on Apple but `ts` on Android. Swift now **truncates** (`Int(secs)`), matching Kotlin's floor. Pinned by a fractional-timestamp parity test on **both** platforms (whole-second and `.500` must land on the same `ts`).
2. **Tie-break.** `activity-file` is a distinct **`activityFile` source-kind at priority 3** — below whole-day imports (`fileImport`/`cloudImport` at 2) — so a 90-min ride can never displace a full-day WHOOP import that has HR for the same day. Pinned by a resolver test on both platforms (whole-day import beats the ride on a strap-less day).

## Policy
This surfaces **measured** imported HR (not a fabricated strain), consistent with the never-fabricate principle; the strap always overrides, and whole-day imports override the ride. Imported HR only ever lights a day nothing else covers.

## Verification
- Android: `compileFullDebugKotlin` + full `data`/`analytics`/`ingest` suites green (incl. the new resolver tie-break + fractional-floor tests).
- Swift packages (StrandImport, StrandAnalytics, WhoopStore): `swift-packages` CI.
- App-target Swift (`IntelligenceEngine`, `DataSourcesView`, `SourceKind`): app-build.
- On-device (not CI-testable): a real GPX-on-a-strap-less-day import to eyeball the ring.