### PR TITLE
fix(sleep): confirm sleep runs on median HR, not mean (recover dropped nights)

### DIFF
--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/SleepStager.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/SleepStager.swift
@@ -504,8 +504,16 @@ public enum SleepStager {
         guard let baseline = baseline else { return true }
         let seg = rowsBetween(hr, start: p.start, end: p.end) { $0.ts }
         if seg.count < hrRefineMinSamples { return true }
-        let meanHR = Double(seg.reduce(0) { $0 + $1.bpm }) / Double(seg.count)
-        return meanHR <= baseline * hrSleepBaselineMult
+        // Confirm on the run's MEDIAN, not its mean. A real sleep night carries brief arousal / wake HR
+        // spikes (observed to ~190 bpm) that pull the MEAN above baseline × mult and reject the run — and for
+        // a typical single main-sleep run per night that means zero sessions ("no sleep recorded") — while
+        // the spike-robust median stays at the true sleep level. Baseline is itself a median, so both sides
+        // use the same robust statistic; a genuinely elevated (awake) run still has a high median and fails.
+        // Median ≤ mean for the right-skewed HR of a real night, so this only ever RELAXES the gate — every
+        // run the mean already accepted still passes, and runs the mean wrongly dropped are recovered.
+        // Mirrors Kotlin `confirmSleepWithHR`.
+        let medHR = HRVAnalyzer.median(seg.map { Double($0.bpm) })
+        return medHR <= baseline * hrSleepBaselineMult
     }
 
     /// True when the run's CENTER, shifted to LOCAL time by tzOffsetSeconds, lands in the

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/SleepStagerHrConfirmTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/SleepStagerHrConfirmTests.swift
@@ -1,0 +1,71 @@
+import XCTest
+@testable import StrandAnalytics
+import WhoopProtocol
+
+/// Pins the median-vs-mean sleep-run HR confirmation (`SleepStager.confirmSleepWithHR`).
+///
+/// A real sleep night carries brief arousal / wake HR spikes. The old gate compared the run's MEAN HR to
+/// `baseline * hrSleepBaselineMult`, so those spikes could pull the mean over the bar and reject the run
+/// (and, for the usual single main-sleep run, drop the WHOLE night -> "no sleep recorded"). Confirming on
+/// the run MEDIAN is spike-robust and, because median <= mean for right-skewed HR, only ever RELAXES the
+/// gate. These tests pin both halves of that contract. Apple twin of the Android `SleepStagerHrConfirmTest`.
+final class SleepStagerHrConfirmTests: XCTestCase {
+
+    private let start = 1_000_000
+
+    /// A run of `n` HR samples: `spikes` of them at `spikeBpm`, the rest at `baseBpm`, 1 Hz from `start`.
+    private func hr(_ n: Int, baseBpm: Int, spikes: Int = 0, spikeBpm: Int = 190) -> [HRSample] {
+        (0..<n).map { i in HRSample(ts: start + i, bpm: i < spikes ? spikeBpm : baseBpm) }
+    }
+
+    private func period(_ durS: Int) -> SleepStager.Period {
+        SleepStager.Period(stage: "sleep", start: start, end: start + durS)
+    }
+
+    func testSpikyButAsleepRunSurvivesWhereMeanWouldDropIt() {
+        // baseline 50 -> gate bar = 52.5 bpm. 600 s run: 570 s asleep at 48, 30 s of arousal at 190.
+        // MEAN = (570*48 + 30*190)/600 = 55.1 bpm (over the bar -> old logic REJECTS the run).
+        // MEDIAN = 48 bpm (under the bar -> the run is genuinely asleep and is KEPT).
+        let seg = hr(600, baseBpm: 48, spikes: 30, spikeBpm: 190)
+        let mean = Double(seg.reduce(0) { $0 + $1.bpm }) / Double(seg.count)
+        let median = HRVAnalyzer.median(seg.map { Double($0.bpm) })
+        let bar = 50.0 * SleepStager.hrSleepBaselineMult
+        XCTAssertGreaterThan(mean, bar, "fixture: mean must exceed bar")
+        XCTAssertLessThanOrEqual(median, bar, "fixture: median must be at/under bar")
+
+        XCTAssertTrue(
+            SleepStager.confirmSleepWithHR(period(600), hr: seg, baseline: 50.0),
+            "a spiky but truly-asleep run must be confirmed (median under bar)")
+    }
+
+    func testGenuinelyElevatedRunIsStillRejected() {
+        // An awake run: HR sits at 60 throughout (median 60 > 52.5 bar) -> must FAIL confirmation.
+        let seg = hr(600, baseBpm: 60)
+        XCTAssertFalse(
+            SleepStager.confirmSleepWithHR(period(600), hr: seg, baseline: 50.0),
+            "a run whose median HR is above baseline*mult must be rejected")
+    }
+
+    func testRunTheMeanAlreadyAcceptedStillPasses() {
+        // No skew: flat 48 bpm (mean == median == 48 <= 52.5). The fix must not regress the accept path.
+        let seg = hr(600, baseBpm: 48)
+        XCTAssertTrue(
+            SleepStager.confirmSleepWithHR(period(600), hr: seg, baseline: 50.0),
+            "a flat low-HR run accepted under mean must still pass under median")
+    }
+
+    func testTooFewSamplesTrustsGravity() {
+        // Below hrRefineMinSamples the HR refinement is skipped entirely -> trust gravity (return true).
+        let seg = hr(10, baseBpm: 200)
+        XCTAssertTrue(
+            SleepStager.confirmSleepWithHR(period(600), hr: seg, baseline: 50.0),
+            "fewer than hrRefineMinSamples must bypass the HR gate")
+    }
+
+    func testNullBaselineTrustsGravity() {
+        let seg = hr(600, baseBpm: 200)
+        XCTAssertTrue(
+            SleepStager.confirmSleepWithHR(period(600), hr: seg, baseline: nil),
+            "a nil baseline must bypass the HR gate")
+    }
+}

--- a/android/app/src/main/java/com/noop/analytics/SleepStager.kt
+++ b/android/app/src/main/java/com/noop/analytics/SleepStager.kt
@@ -568,8 +568,16 @@ object SleepStager {
         if (baseline == null) return true
         val seg = rowsBetween(hr, p.start, p.end) { it.ts }
         if (seg.size < hrRefineMinSamples) return true
-        val meanHR = seg.sumOf { it.bpm }.toDouble() / seg.size.toDouble()
-        return meanHR <= baseline * hrSleepBaselineMult
+        // Confirm on the run's MEDIAN, not its mean. A real sleep night carries brief arousal / wake HR
+        // spikes (observed to ~190 bpm) that pull the MEAN above baseline × mult and reject the run — and
+        // for a typical single main-sleep run per night that means zero sessions ("no sleep recorded") —
+        // while the spike-robust median stays at the true sleep level. Baseline is itself a median, so both
+        // sides use the same robust statistic; a genuinely elevated (awake) run still has a high median and
+        // fails. Median ≤ mean for the right-skewed HR of a real night, so this only ever RELAXES the gate —
+        // every run the mean already accepted still passes, and runs the mean wrongly dropped are recovered.
+        // Mirrors Swift `confirmSleepWithHR`.
+        val medHR = HrvAnalyzer.median(seg.map { it.bpm.toDouble() })
+        return medHR <= baseline * hrSleepBaselineMult
     }
 
     /**

--- a/android/app/src/test/java/com/noop/analytics/SleepStagerHrConfirmTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/SleepStagerHrConfirmTest.kt
@@ -1,0 +1,89 @@
+package com.noop.analytics
+
+import com.noop.data.HrSample
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Pins the median-vs-mean sleep-run HR confirmation ([SleepStager.confirmSleepWithHR]).
+ *
+ * A real sleep night carries brief arousal / wake HR spikes. The old gate compared the run's MEAN HR to
+ * baseline * hrSleepBaselineMult, so those spikes could pull the mean over the bar and reject the run
+ * (and, for the usual single main-sleep run, drop the WHOLE night -> "no sleep recorded"). Confirming on
+ * the run MEDIAN is spike-robust and, because median <= mean for right-skewed HR, only ever RELAXES the
+ * gate. These tests pin both halves of that contract: the spiky-but-truly-asleep run now survives, and a
+ * genuinely elevated (awake) run is still rejected. Android twin of the Swift `SleepStagerHrConfirmTests`.
+ */
+class SleepStagerHrConfirmTest {
+
+    private val dev = "d"
+    private val start = 1_000_000L
+
+    /** A run of [n] HR samples: [spikes] of them at [spikeBpm], the rest at [baseBpm], 1 Hz from [start]. */
+    private fun hr(n: Int, baseBpm: Int, spikes: Int = 0, spikeBpm: Int = 190): List<HrSample> =
+        (0 until n).map { i ->
+            HrSample(deviceId = dev, ts = start + i, bpm = if (i < spikes) spikeBpm else baseBpm)
+        }
+
+    private fun period(durS: Long) = SleepStager.Period(stage = "sleep", start = start, end = start + durS)
+
+    @Test
+    fun spikyButAsleepRunSurvivesWhereMeanWouldDropIt() {
+        // baseline 50 -> gate bar = 52.5 bpm. 600 s run: 570 s asleep at 48, 30 s of arousal at 190.
+        // MEAN = (570*48 + 30*190)/600 = 55.1 bpm (over the bar -> old logic REJECTS the run).
+        // MEDIAN = 48 bpm (under the bar -> the run is genuinely asleep and is KEPT).
+        val seg = hr(n = 600, baseBpm = 48, spikes = 30, spikeBpm = 190)
+        val mean = seg.sumOf { it.bpm }.toDouble() / seg.size
+        val median = HrvAnalyzer.median(seg.map { it.bpm.toDouble() })
+        val bar = 50.0 * SleepStager.hrSleepBaselineMult
+        // Guard the fixture: this only tests the fix when mean is over the bar and median is under it.
+        assertTrue("fixture: mean ($mean) must exceed bar ($bar)", mean > bar)
+        assertTrue("fixture: median ($median) must be at/under bar ($bar)", median <= bar)
+
+        assertTrue(
+            "a spiky but truly-asleep run must be confirmed (median under bar)",
+            SleepStager.confirmSleepWithHR(period(600), seg, baseline = 50.0),
+        )
+    }
+
+    @Test
+    fun genuinelyElevatedRunIsStillRejected() {
+        // An awake run: HR sits at 60 throughout (median 60 > 52.5 bar) -> must FAIL confirmation.
+        val seg = hr(n = 600, baseBpm = 60)
+        assertFalse(
+            "a run whose median HR is above baseline*mult must be rejected",
+            SleepStager.confirmSleepWithHR(period(600), seg, baseline = 50.0),
+        )
+    }
+
+    @Test
+    fun runTheMeanAlreadyAcceptedStillPasses() {
+        // No skew: flat 48 bpm (mean == median == 48 <= 52.5). The fix must not regress the accept path.
+        val seg = hr(n = 600, baseBpm = 48)
+        assertTrue(
+            "a flat low-HR run accepted under mean must still pass under median",
+            SleepStager.confirmSleepWithHR(period(600), seg, baseline = 50.0),
+        )
+    }
+
+    @Test
+    fun tooFewSamplesTrustsGravity() {
+        // Below hrRefineMinSamples the HR refinement is skipped entirely -> trust gravity (return true),
+        // even with an absurd HR, exactly as before the fix.
+        val seg = hr(n = 10, baseBpm = 200)
+        assertTrue(
+            "fewer than hrRefineMinSamples must bypass the HR gate",
+            SleepStager.confirmSleepWithHR(period(600), seg, baseline = 50.0),
+        )
+    }
+
+    @Test
+    fun nullBaselineTrustsGravity() {
+        val seg = hr(n = 600, baseBpm = 200)
+        assertTrue(
+            "a null baseline must bypass the HR gate",
+            SleepStager.confirmSleepWithHR(period(600), seg, baseline = null),
+        )
+    }
+}


### PR DESCRIPTION
### The bug
On some real sleep nights `detectSleep` returns zero sessions, so the whole night reads "no sleep recorded" even though the wearer slept normally. The nights this hits are the ones with brief arousals or short wakes that spike HR (observed up to ~190 bpm).

### Root cause
`SleepStager.confirmSleepWithHR` gates each candidate sleep run by comparing the run's **mean** HR to the day baseline (a median) times `hrSleepBaselineMult` (1.05). HR over a night is right skewed: a handful of arousal or wake epochs at 150 to 190 bpm pull the **mean** above `median x 1.05` while the median stays down at the true sleep level. So a genuinely low HR sleep night trips the guard and the run is rejected. For the usual single main-sleep run per night, no run left means `detectSleep` returns nothing and the entire night is dropped.

### The fix
Confirm on the run's **median** instead of its mean. The baseline is already a median, so both sides now use the same spike robust statistic. A genuinely elevated (awake) run still has a high median and is still rejected, so the guard keeps doing its job.

The change is monotonic in the safe direction: for the right skewed HR of a real night `median <= mean`, so every run the mean already accepted still passes. It only ever relaxes the gate, never tightens it, so no currently detected night can regress. Only the wrongly dropped runs are recovered.

Why median and not the resting-HR floor (lowest rolling mean): the floor is near-minimal for almost any run, so it would gut the guard's ability to reject a genuinely awake run. The median keeps that rejection while dropping the spike sensitivity.

### Verification (method + data)
Cross subject leave-one-subject-out over two public wrist datasets with PSG ground truth (AAUWSS, 13 subjects, E4 wrist + gold PSG-ECG R-R + AASM labels; Walch 2019 sleep-accel, 31 subjects). The real shipped stager was run, not a reimplementation, before and after the one-line change on this branch.

Exactly the 4 of 44 subjects whose `mean/median` HR ratio exceeds 1.05 were being dropped whole. After the fix all four detect normally and the other 40 subjects are byte identical, as the monotonic argument predicts.

Per-epoch scores, before (this base) to after (this branch):

| engine · dataset | sleep/wake | Cohen kappa | 4-class acc |
|---|---|---|---|
| V1 · AAUWSS (default) | 76.4 → 86.4 % | 0.034 → 0.039 | 39.6 → 44.3 % |
| V1 · sleep-accel (default) | 83.6 → 88.8 % | 0.072 → 0.089 | 47.6 → 50.6 % |
| V2 · AAUWSS (opt-in) | 78.1 → 88.7 % | 0.338 → 0.396 | 51.6 → 57.5 % |
| V2 · sleep-accel (opt-in) | 85.8 → 91.3 % | 0.294 → 0.318 | 52.5 → 55.1 % |

Every metric up on both engines and both datasets, nothing slid. The fix is in shared detection (`detectSleep`), so it lifts both the default V1 path and the experimental V2 path.

### Tests / parity
Byte-identical on both platforms in the same commit (Kotlin `SleepStager.kt`, Swift `SleepStager.swift`), both calling the shared `median` helper (verified identical, including even-length averaging). New unit tests on both platforms (`SleepStagerHrConfirmTest` / `SleepStagerHrConfirmTests`) pin the contract: a spiky-but-truly-asleep run survives; a genuinely elevated run is still rejected. Existing sleep detection/staging tests pass unchanged. Kotlin compiles and tests pass; the Swift package build needs macOS (please confirm the `swift test` leg in CI).

### Scope
One line of logic per platform plus a comment and a test. Detection only; staging, scoring, and the other gates are untouched. One concern.
