### PR TITLE
fix(sleep): don't let a minor pre-onset fragment hijack the displayed onset (#259)

### DIFF
--- a/Strand/Screens/SleepView.swift
+++ b/Strand/Screens/SleepView.swift
@@ -1904,9 +1904,13 @@ struct SleepView: View {
     private func nightOnsetTs(_ group: [CachedSleepSession]) -> Int {
         // group is ascending by effective onset; first is the earliest fragment.
         guard let first = group.first else { return 0 }
+        // #259: reference size for the "minor relative to the main block" test = the group's largest asleep
+        // span (≈ the main block). A genuine biphasic first sleep is comparable and is kept; a small stray
+        // lead is skipped, so the onset no longer jumps hours early.
+        let refAsleepMin = group.map { decodeStages($0.stagesJSON)?.asleep ?? 0 }.max() ?? 0
         // Walk past any leading spurious pre-onset awake stubs to the first real-sleep fragment.
         for frag in group {
-            if !isPreOnsetAwakeStub(frag) { return frag.effectiveStartTs }
+            if !isPreOnsetAwakeStub(frag, refAsleepMin: refAsleepMin) { return frag.effectiveStartTs }
         }
         // Whole group is stub-like (shouldn't reach the hero, mergeDay gates on stages.asleep > 0): keep the
         // earliest onset rather than inventing one.
@@ -1916,10 +1920,10 @@ struct SleepView: View {
     /// A fragment is a spurious pre-onset awake stub when it's within the lie-in cap (<= `preOnsetStubMaxMin`)
     /// and carries essentially no sleep (asleep minutes <= `preOnsetStubAsleepMaxMin`). Used only to skip such
     /// a stub when it leads the main-night group, so the displayed bedtime tracks where real sleep began. (#736)
-    private func isPreOnsetAwakeStub(_ frag: CachedSleepSession) -> Bool {
+    private func isPreOnsetAwakeStub(_ frag: CachedSleepSession, refAsleepMin: Double = 0) -> Bool {
         let spanMin = Double(frag.endTs - frag.effectiveStartTs) / 60.0
         let asleepMin = decodeStages(frag.stagesJSON)?.asleep ?? 0
-        return SleepView.isPreOnsetAwakeStub(spanMin: spanMin, asleepMin: asleepMin)
+        return SleepView.isPreOnsetAwakeStub(spanMin: spanMin, asleepMin: asleepMin, refAsleepMin: refAsleepMin)
     }
 
     /// Longest a leading block can be and still be treated as a spurious pre-sleep awake stub (lying in bed
@@ -1931,11 +1935,22 @@ struct SleepView: View {
     /// Most asleep minutes a fragment can carry and still count as a (sleepless) pre-onset awake stub. A real
     /// first sleep fragment of a biphasic night carries far more, so it's never mistaken for a stub. (#736)
     static let preOnsetStubAsleepMaxMin: Double = 3
+    /// A leading pre-onset fragment carrying SOME sleep is still spurious when it is minor RELATIVE to the
+    /// night's main block: its asleep minutes are below this fraction of the largest fragment's. A genuine
+    /// biphasic first sleep is comparable to the main block (well above this) and is kept; only a small stray
+    /// lead is dropped. Extends the essentially-sleepless `preOnsetStubAsleepMaxMin` rule (#736), which missed
+    /// a lead carrying a few minutes more than 3. Mirrors Android PRE_ONSET_STUB_MINOR_FRAC. (#259)
+    static let preOnsetStubMinorFrac: Double = 0.15
 
     /// Pure stub test on a fragment's span + asleep minutes, so the rule is unit-testable without decoding
-    /// JSON or building a view. BRIEF and essentially sleepless = a spurious pre-onset awake stub. (#736)
-    static func isPreOnsetAwakeStub(spanMin: Double, asleepMin: Double) -> Bool {
-        spanMin <= preOnsetStubMaxMin && asleepMin <= preOnsetStubAsleepMaxMin
+    /// JSON or building a view. Spurious when BRIEF and EITHER essentially sleepless OR minor relative to the
+    /// main block (`refAsleepMin`, the group's largest asleep span): asleep below `preOnsetStubMinorFrac` of
+    /// it. `refAsleepMin` defaults to 0 (relative test off) so existing callers/tests are byte-identical.
+    /// (#736 / #259)
+    static func isPreOnsetAwakeStub(spanMin: Double, asleepMin: Double, refAsleepMin: Double = 0) -> Bool {
+        guard spanMin <= preOnsetStubMaxMin else { return false }
+        if asleepMin <= preOnsetStubAsleepMaxMin { return true }
+        return refAsleepMin > 0 && asleepMin < preOnsetStubMinorFrac * refAsleepMin
     }
 
     /// The index into an ascending-by-onset group whose fragment supplies the DISPLAYED bedtime: the first
@@ -1943,9 +1958,10 @@ struct SleepView: View {
     /// stub-like. Pure mirror of `nightOnsetTs`'s walk, driven by per-fragment (spanMin, asleepMin) so a
     /// golden test can pin the #736 behaviour without view internals. (#736)
     static func nightOnsetIndex(spansMin: [Double], asleepsMin: [Double]) -> Int {
+        let refAsleepMin = asleepsMin.max() ?? 0
         for i in spansMin.indices {
             let asleep = i < asleepsMin.count ? asleepsMin[i] : 0
-            if !isPreOnsetAwakeStub(spanMin: spansMin[i], asleepMin: asleep) { return i }
+            if !isPreOnsetAwakeStub(spanMin: spansMin[i], asleepMin: asleep, refAsleepMin: refAsleepMin) { return i }
         }
         return 0
     }

--- a/StrandTests/SleepOnsetStubTests.swift
+++ b/StrandTests/SleepOnsetStubTests.swift
@@ -45,6 +45,30 @@ final class SleepOnsetStubTests: XCTestCase {
                                                      asleepMin: SleepView.preOnsetStubAsleepMaxMin + 1))
     }
 
+    /// #259: a leading fragment carrying SOME sleep (over the 3-min sleepless cap) but MINOR relative to the
+    /// main block (below the fraction of the group's largest asleep span) is a spurious lead and IS a stub.
+    /// Without a reference (default 0) the relative test is OFF, so the same fragment is NOT a stub — existing
+    /// callers stay byte-identical.
+    func testMinorRelativeLeadingFragmentIsStub() {
+        // 30 min span, 10 asleep; main block asleep 400 -> 10 < 0.15*400 = 60 -> spurious.
+        XCTAssertTrue(SleepView.isPreOnsetAwakeStub(spanMin: 30, asleepMin: 10, refAsleepMin: 400))
+        XCTAssertFalse(SleepView.isPreOnsetAwakeStub(spanMin: 30, asleepMin: 10))
+    }
+
+    /// #259 guard: a substantial earlier sleep (comparable to the main block) is a genuine biphasic first
+    /// sleep and is NEVER dropped, even with a reference size.
+    func testSubstantialBiphasicFragmentIsNotStubEvenWithRef() {
+        // 90 asleep vs main block 240 -> 90 >= 0.15*240 = 36 -> kept.
+        XCTAssertFalse(SleepView.isPreOnsetAwakeStub(spanMin: 100, asleepMin: 90, refAsleepMin: 240))
+    }
+
+    /// #259 GOLDEN at the walk level: a minor leading SLEEP fragment (10 asleep, over the old 3-min cap but
+    /// tiny next to the 400-asleep main block) is now skipped, so the displayed onset comes from the main
+    /// block (index 1) instead of jumping to the stray 1am lead. Before this rule it returned 0.
+    func testMinorLeadingSleepFragmentSkippedByOnsetIndex() {
+        XCTAssertEqual(SleepView.nightOnsetIndex(spansMin: [30, 420], asleepsMin: [10, 400]), 1)
+    }
+
     // MARK: - nightOnsetIndex (which fragment supplies the displayed bedtime)
 
     /// THE #736 GOLDEN: a two-fragment night where fragment 1 is a brief pre-sleep awake stub. The displayed

--- a/android/app/src/main/java/com/noop/ui/SleepScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/SleepScreen.kt
@@ -2597,7 +2597,15 @@ internal fun selectNight(
     // above, so it is never mislabelled as a nap. `session` (the edit anchor) is already the main block, so
     // the bedtime label and the pencil were aligned — this aligns the chart to that same bedtime. (#736/#555)
     val onsetTsForHero = session.effectiveStartTs
-    val heroGroup = group.dropWhile { it.effectiveStartTs < onsetTsForHero && isPreOnsetAwakeStub(it) }
+    // #259: reference size for the "minor relative to the main block" stub test = the largest asleep span in
+    // the group (≈ the main block). A genuine biphasic first sleep is comparable to it and is kept; only a
+    // small stray lead carrying a few minutes of sleep is dropped, so the onset no longer jumps hours early.
+    val groupRefAsleepMin = group.maxOfOrNull { frag ->
+        parseSessionStages(frag.stagesJSON)?.let { it.light + it.deep + it.rem } ?: 0.0
+    } ?: 0.0
+    val heroGroup = group.dropWhile {
+        it.effectiveStartTs < onsetTsForHero && isPreOnsetAwakeStub(it, groupRefAsleepMin)
+    }
     val utcKey = AnalyticsEngine.dayString(session.endTs)
     val localKey = localDayString(session.endTs)
     val dayKey = listOf(utcKey, localKey).firstOrNull { key ->
@@ -2681,17 +2689,30 @@ private const val PRE_ONSET_STUB_MAX_MIN = 240.0
  *  first sleep fragment of a biphasic night carries far more. Mirrors iOS SleepView.preOnsetStubAsleepMaxMin.
  *  (#736) */
 private const val PRE_ONSET_STUB_ASLEEP_MAX_MIN = 3.0
+/** A leading pre-onset fragment that carries SOME sleep is still spurious when it is minor RELATIVE to the
+ *  night's main block: its asleep minutes are below this fraction of the largest fragment's. A genuine
+ *  biphasic first sleep is comparable in size to the main block (well above this), so it is never dropped;
+ *  only a small stray lead (e.g. a brief early doze hours before the real sleep) is. This extends the
+ *  essentially-sleepless [PRE_ONSET_STUB_ASLEEP_MAX_MIN] rule (#736), which missed a lead carrying a few
+ *  minutes more than 3. Mirrors iOS SleepView.preOnsetStubMinorFrac. (#259) */
+private const val PRE_ONSET_STUB_MINOR_FRAC = 0.15
 
 /** A fragment is a spurious pre-onset awake stub when it is within the lie-in cap (<= [PRE_ONSET_STUB_MAX_MIN])
- *  and carries essentially no sleep (asleep minutes <= [PRE_ONSET_STUB_ASLEEP_MAX_MIN]). Used only to skip such
- *  a stub when it leads the main-night group, so the hero's hypnogram and minutes start at the displayed
- *  bedtime (the main block's onset) rather than before it. Mirrors iOS SleepView.isPreOnsetAwakeStub. (#736) */
-internal fun isPreOnsetAwakeStub(frag: SleepSession): Boolean {
+ *  and EITHER carries essentially no sleep (asleep minutes <= [PRE_ONSET_STUB_ASLEEP_MAX_MIN]) OR is minor
+ *  relative to the night's main block ([refAsleepMin], the group's largest asleep span): asleep minutes below
+ *  [PRE_ONSET_STUB_MINOR_FRAC] of it. Used only to skip such a stub when it leads the main-night group, so the
+ *  hero's hypnogram and minutes start at the displayed bedtime (the main block's onset) rather than before it.
+ *  [refAsleepMin] defaults to 0 (relative test off) so existing callers/tests are byte-identical. Mirrors iOS
+ *  SleepView.isPreOnsetAwakeStub. (#736 / #259) */
+internal fun isPreOnsetAwakeStub(frag: SleepSession, refAsleepMin: Double = 0.0): Boolean {
     val spanMin = (frag.endTs - frag.effectiveStartTs) / 60.0
     if (spanMin > PRE_ONSET_STUB_MAX_MIN) return false
     val stages = parseSessionStages(frag.stagesJSON)
     val asleepMin = stages?.let { it.light + it.deep + it.rem } ?: 0.0
-    return asleepMin <= PRE_ONSET_STUB_ASLEEP_MAX_MIN
+    if (asleepMin <= PRE_ONSET_STUB_ASLEEP_MAX_MIN) return true
+    // #259: also spurious when it carries some sleep but is minor relative to the main block (largest
+    // fragment). A genuine biphasic first sleep is comparable in size, so it stays and its onset stands.
+    return refAsleepMin > 0.0 && asleepMin < PRE_ONSET_STUB_MINOR_FRAC * refAsleepMin
 }
 
 /** SUM the per-stage minutes across a bridged main-night group, so the hero's stage breakdown reflects the

--- a/android/app/src/test/java/com/noop/ui/SleepOnsetStubTest.kt
+++ b/android/app/src/test/java/com/noop/ui/SleepOnsetStubTest.kt
@@ -54,6 +54,27 @@ class SleepOnsetStubTest {
         assertTrue(isPreOnsetAwakeStub(b))
     }
 
+    /** #259: a leading fragment carrying SOME sleep (> the 3-min sleepless cap) but MINOR relative to the
+     *  main block (below the fraction of the group's largest asleep span) is a spurious lead and IS a stub —
+     *  so it no longer hijacks the displayed onset. Without a reference (default) the relative test is OFF,
+     *  so the same fragment is NOT a stub: existing callers stay byte-identical. */
+    @Test
+    fun minorRelativeLeadingFragmentIsStub() {
+        // 30 min span, 10 asleep min; main block asleep 400 -> 10 < 0.15*400 = 60 -> spurious.
+        val b = block(0, 30 * 60, """{"awake":20,"light":10,"deep":0,"rem":0}""")
+        assertTrue(isPreOnsetAwakeStub(b, refAsleepMin = 400.0))
+        assertFalse(isPreOnsetAwakeStub(b))
+    }
+
+    /** #259 guard: a substantial earlier sleep (comparable to the main block) is a genuine biphasic first
+     *  sleep and is NEVER dropped, even with a reference size. */
+    @Test
+    fun substantialBiphasicFragmentIsNotStubEvenWithRef() {
+        // 90 asleep min vs main block 240 -> 90 >= 0.15*240 = 36 -> kept.
+        val b = block(0, 100 * 60, """{"awake":10,"light":60,"deep":30,"rem":0}""")
+        assertFalse(isPreOnsetAwakeStub(b, refAsleepMin = 240.0))
+    }
+
     /**
      * THE #736 GOLDEN at selectNight level: a three-fragment night — a brief pre-sleep awake stub, then two
      * real sleep fragments split by a short wake (biphasic). The hero's reconstructed segments must start at


### PR DESCRIPTION
Fixes #259.

### The bug
On some nights the Sleep tab shows a bedtime hours earlier than the actual sleep (reported: slept at 6am, shown at 1am), while the edit picker shows the correct time and the stage totals look wrong.

### Root cause
The Sleep tab draws the night's bedtime and hypnogram from the earliest fragment in the bridged main-night group (`heroGroup.first`), while the edit picker, the hypnogram axis, and the in-bed math all anchor on the main block. When the gap-bridge folds a spurious early sleep fragment (a brief doze hours before the real sleep) into the group, that fragment sets the displayed onset hours too early and the two surfaces disagree.

`#736` already skips a leading pre-onset stub, but only when it is essentially sleepless (`<= 3` asleep minutes). A stray lead carrying a few minutes more slips through and hijacks the onset.

### The fix
Extend the pre-onset-stub rule with a relative branch: a leading fragment is also spurious when it is minor **relative to the main block**, i.e. its asleep minutes are below a fraction (`PRE_ONSET_STUB_MINOR_FRAC = 0.15`) of the group's largest fragment. A genuine biphasic first sleep is comparable in size to the main block, so it stays and its onset stands; only a small stray lead is dropped. The displayed onset, chart, and totals then match the edit picker.

The relative reference defaults to 0 (test off), so the pure `isPreOnsetAwakeStub` helper's existing callers and tests stay byte-identical; `selectNight` / `nightOnsetTs` pass the group's largest asleep span.

### Tests / parity
Kotlin (`SleepScreen.kt`) + Swift twin (`SleepView.swift`), with unit tests on both (`SleepOnsetStubTest` / `SleepOnsetStubTests`): a minor relative lead is now dropped; a substantial biphasic first sleep is still kept; the existing `#736` and single-block goldens are unchanged. All sleep-UI unit tests pass. Swift package build needs macOS (please confirm the `swift test` leg in CI).

### Note
The `0.15` fraction is a heuristic bound. If the reporter can share the Sleep-tab naps card / export for that night, the exact fragment size would confirm the threshold, but a lead below 15% of the main night is a safe spurious-lead bound that does not touch a normal biphasic night.
