### PR TITLE
sleep: clamp edited-night stages to the effective onset so asleep can't exceed time-in-bed (#259)

### DIFF
--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/SleepStageTotals.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/SleepStageTotals.swift
@@ -45,6 +45,35 @@ public enum SleepStageTotals {
         return nil
     }
 
+    /// #259: return `stagesJSON` with its `[{start,end,stage}]` segments trimmed to begin no earlier than
+    /// `onsetSec` — segments fully before the onset are dropped, one straddling it is cut to `[onsetSec, end]`.
+    /// Only the computed segment-array shape carries the timestamps a trim needs, so the `{stage:min}` /
+    /// dict (imported) shape and any unparseable JSON are returned UNCHANGED. A no-op when every segment
+    /// already starts at/after the onset (the common, already-consistent case). The result is re-parsed by
+    /// `minutes` / `dailyAggregate` on the SAME platform, so only the decoded minute totals need
+    /// cross-platform parity, not the exact string. Mirrors Kotlin `clampStagesToOnset`.
+    public static func clampStagesToOnset(_ stagesJSON: String?, onsetSec: Int) -> String? {
+        guard let stagesJSON, let data = stagesJSON.data(using: .utf8),
+              let arr = (try? JSONSerialization.jsonObject(with: data)) as? [[String: Any]] else {
+            return stagesJSON   // dict/imported shape or unparseable → unchanged
+        }
+        var out: [[String: Any]] = []
+        for seg in arr {
+            // Shape check is start+end only (matches Kotlin): a {stage:min} entry has neither → bail
+            // unchanged. A malformed segment missing only `stage` defaults to "" (minutes() ignores it),
+            // exactly as the Kotlin twin's `optString("stage", "")` does.
+            guard let rawS = (seg["start"] as? NSNumber)?.intValue,
+                  let e = (seg["end"] as? NSNumber)?.intValue else { return stagesJSON }
+            let name = seg["stage"] as? String ?? ""
+            let s = max(rawS, onsetSec)
+            guard e > s else { continue }                                        // fully before the onset → drop
+            out.append(["start": s, "end": e, "stage": name])
+        }
+        guard let outData = try? JSONSerialization.data(withJSONObject: out),
+              let str = String(data: outData, encoding: .utf8) else { return stagesJSON }
+        return str
+    }
+
     /// The sleep-derived daily fields for a night made of these blocks' `stagesJSON`, or nil if none
     /// decode. `efficiency` is asleep / in-bed (TST / Σ stage minutes) in [0,1]. For the segment stages
     /// noop stores (which TILE the window, last segment clamped to the wake), Σ stage minutes equals the
@@ -511,15 +540,25 @@ public enum SleepStageTotals {
             // effective span is `[onset, onset + decoded in-bed]`; the gap between consecutive fragments is
             // awake the fragments' own stages don't cover.
             if let group {
-                let spans: [(start: Int, end: Int)] = group.map { i in
-                    let b = blocks[i]
-                    let onset = onsetByStart[b.startTs] ?? b.startTs
-                    let inBedSec = Int((minutes(fromStagesJSON: b.stagesJSON)?.inBed ?? 0) * 60.0)
+                // #259: trim each SELECTED block's stages to its EFFECTIVE onset before summing. A hand-edited
+                // or onset-trimmed bedtime that the raw was too sparse to re-stage (WHOOP 4.0) leaves pre-onset
+                // segments in the stored stagesJSON; summing them in full pushes asleep past time-in-bed (the
+                // impossible "6h41m asleep / 4h33m in bed" card). Selection above ran on the ORIGINAL blocks,
+                // so no #525/#547 pick regression — only the SUMMED main-night total is clamped. A block
+                // already staged from its onset (the common case) is unchanged. Mirrors Kotlin.
+                let clampedStages: [String?] = group.map { i in
+                    if let onset = onsetByStart[blocks[i].startTs] {
+                        return clampStagesToOnset(blocks[i].stagesJSON, onsetSec: onset)
+                    }
+                    return blocks[i].stagesJSON
+                }
+                let spans: [(start: Int, end: Int)] = group.enumerated().map { (gi, i) in
+                    let onset = onsetByStart[blocks[i].startTs] ?? blocks[i].startTs
+                    let inBedSec = Int((minutes(fromStagesJSON: clampedStages[gi])?.inBed ?? 0) * 60.0)
                     return (start: onset, end: onset + inBedSec)
                 }
                 let gapAwakeS = interFragmentAwakeSeconds(spans)
-                if let agg = dailyAggregate(group.map { blocks[$0].stagesJSON },
-                                            interFragmentAwakeSeconds: gapAwakeS) {
+                if let agg = dailyAggregate(clampedStages, interFragmentAwakeSeconds: gapAwakeS) {
                     return (agg, applied)
                 }
             }

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/SleepStageTotalsTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/SleepStageTotalsTests.swift
@@ -87,6 +87,34 @@ final class SleepStageTotalsTests: XCTestCase {
         XCTAssertEqual(r.sleep.totalSleepMin, 392, accuracy: 0.001)
     }
 
+    func testHonoringEditsClampsPreOnsetStagesSoAsleepNeverExceedsTimeInBed() throws {
+        // #259: WHOOP 4.0 over-staged a long low-motion pre-onset stretch as sleep. The detected block is
+        // one contiguous 8h49m "light" span [0, 31740], but the user's EFFECTIVE onset is 15300 (they
+        // actually slept 4h34m from there). Before the fix the aggregate summed the full 8h49m, so asleep
+        // exceeded the 4h34m the card shows as "in bed". After: pre-onset segments are trimmed to the onset.
+        // Byte-parity twin of Kotlin Issue259PreOnsetClampTest.
+        let json = #"[{"start":0,"end":31740,"stage":"light"}]"#
+        let r = try XCTUnwrap(SleepStageTotals.dailyAggregateHonoringEdits(
+            detected: [detected(0, json)],
+            edited: [0: json],               // an edit is present (onset moved); stages not re-staged
+            onsetByStart: [0: 15300]))
+        let inBedMin = Double(31740 - 15300) / 60.0   // 274 min — time-in-bed the card shows
+        XCTAssertEqual(r.sleep.totalSleepMin, inBedMin, accuracy: 0.001, "asleep clamped to the post-onset window")
+        XCTAssertLessThanOrEqual(r.sleep.totalSleepMin, inBedMin + 1e-6, "asleep must never exceed time-in-bed (#259)")
+        XCTAssertLessThan(r.sleep.totalSleepMin, Double(31740) / 60.0, "must not sum the pre-onset stretch")
+    }
+
+    func testHonoringEditsNonEditedNightUnchangedByClamp() throws {
+        // Onset == start → clamping to its own onset is a no-op, so the aggregate is identical to before
+        // the fix (no regression for the common, already-consistent case).
+        let json = #"[{"start":1000,"end":28000,"stage":"light"}]"#   // 27000 s = 450 min
+        let r = try XCTUnwrap(SleepStageTotals.dailyAggregateHonoringEdits(
+            detected: [detected(1000, json)],
+            edited: [:],
+            onsetByStart: [1000: 1000]))
+        XCTAssertEqual(r.sleep.totalSleepMin, 450, accuracy: 0.001)
+    }
+
     func testHonoringEditsMultiBlockSubstitutesOnlyTheEditedBlock() throws {
         // A nap (startTs 100, untouched) + a main sleep (startTs 1000, edited shorter).
         let r = try XCTUnwrap(SleepStageTotals.dailyAggregateHonoringEdits(

--- a/Strand/Screens/SleepView.swift
+++ b/Strand/Screens/SleepView.swift
@@ -2403,9 +2403,14 @@ struct SleepView: View {
         var stages = Stages(awake: 0, light: 0, deep: 0, rem: 0)
         var intervals: [SleepInterval] = []
         for seg in arr {
-            guard let start = (seg["start"] as? NSNumber)?.intValue,
-                  let end = (seg["end"] as? NSNumber)?.intValue, end > start,
+            guard let rawStart = (seg["start"] as? NSNumber)?.intValue,
+                  let end = (seg["end"] as? NSNumber)?.intValue,
                   let name = seg["stage"] as? String else { continue }
+            // #259: trim each segment to the effective onset (`sessionStart`) so a hand-edited bedtime the
+            // raw was too sparse to re-stage (WHOOP 4.0) can't sum pre-onset stages past time-in-bed — nor
+            // draw bars before the onset. No-op when segments already start at/after it (the common case).
+            let start = max(rawStart, sessionStart)
+            guard end > start else { continue }
             let minutes = Double(end - start) / 60.0
             let stage: SleepStage
             switch name {

--- a/android/app/src/main/java/com/noop/analytics/SleepStageTotals.kt
+++ b/android/app/src/main/java/com/noop/analytics/SleepStageTotals.kt
@@ -93,6 +93,30 @@ object SleepStageTotals {
         return if (m.inBed > 0.0) m else null
     }
 
+    /**
+     * #259: return `stagesJSON` with its `[{start,end,stage}]` segments trimmed to begin no earlier than
+     * [onsetSec] — segments fully before the onset are dropped, one straddling it is cut to `[onsetSec, end]`.
+     * Only the computed segment-array shape carries the timestamps a trim needs, so the `{stage,min}` /
+     * dict (imported) shapes and any unparseable JSON are returned UNCHANGED. A no-op when every segment
+     * already starts at/after the onset (the common, already-consistent case). The result is re-parsed by
+     * [minutes] / [dailyAggregate] on the SAME platform, so only the decoded minute totals need
+     * cross-platform parity, not the exact string. Mirrors Swift `clampStagesToOnset`.
+     */
+    internal fun clampStagesToOnset(stagesJSON: String?, onsetSec: Long): String? {
+        val json = stagesJSON ?: return null
+        val arr = try { JSONArray(json) } catch (_: Throwable) { return stagesJSON }
+        val out = JSONArray()
+        for (i in 0 until arr.length()) {
+            val seg = arr.optJSONObject(i) ?: continue
+            if (!seg.has("start") || !seg.has("end")) return stagesJSON   // {stage,min} shape → unchanged
+            val e = seg.optLong("end")
+            val s = maxOf(seg.optLong("start"), onsetSec)
+            if (e <= s) continue                                          // fully before the onset → drop
+            out.put(JSONObject().put("start", s).put("end", e).put("stage", seg.optString("stage", "")))
+        }
+        return out.toString()
+    }
+
     // ── Canonical main-night selection (#525 / #547 — learned-timing scored pick) ────────────────────
 
     /** Broad overnight band used ONLY for the cold-start alignment bonus (NOT a gate). The band is
@@ -505,18 +529,27 @@ object SleepStageTotals {
             // night `analyzeDay` does. Naps outside the group remain their own rows. Mirrors Swift.
             val group = mainNightGroupIndicesByStages(blocks, onsetByStart, offsetSec, habitualMidsleepSec)
                 ?: return null
+            // #259: trim each SELECTED block's stages to its EFFECTIVE onset before summing. A hand-edited
+            // or onset-trimmed bedtime that the raw was too sparse to re-stage (WHOOP 4.0) leaves pre-onset
+            // segments in the stored stagesJSON; summing them in full pushes asleep past time-in-bed (the
+            // impossible "6h41m asleep / 4h33m in bed" card). Selection above ran on the ORIGINAL blocks, so
+            // no #525/#547 pick regression — only the SUMMED main-night total is clamped. A block already
+            // staged from its onset (the common case) is unchanged. Mirrors Swift.
+            val clampedStages = group.map { i ->
+                val onset = onsetByStart[blocks[i].first]
+                if (onset != null) clampStagesToOnset(blocks[i].second, onset) else blocks[i].second
+            }
             // OUT-OF-BED time between the bridged fragments counts as AWAKE (#777/#705), using the SAME
             // single definition `analyzeDay` applies so the seam can't double-count it. Each fragment's
             // effective span is `[onset, onset + decoded in-bed]`; the gap between consecutive fragments is
             // awake the fragments' own stages don't cover. Mirrors Swift.
-            val spans = group.map { i ->
-                val b = blocks[i]
-                val onset = onsetByStart[b.first] ?: b.first
-                val inBedSec = ((minutes(b.second)?.inBed ?: 0.0) * 60.0).toLong()
+            val spans = group.mapIndexed { gi, i ->
+                val onset = onsetByStart[blocks[i].first] ?: blocks[i].first
+                val inBedSec = ((minutes(clampedStages[gi])?.inBed ?: 0.0) * 60.0).toLong()
                 onset to (onset + inBedSec)
             }
             val gapAwakeS = interFragmentAwakeSeconds(spans)
-            val agg = dailyAggregate(group.map { blocks[it].second }, gapAwakeS) ?: return null
+            val agg = dailyAggregate(clampedStages, gapAwakeS) ?: return null
             return HonoredAggregate(agg, applied)
         }
         val agg = dailyAggregate(blocks.map { it.second }) ?: return null

--- a/android/app/src/main/java/com/noop/ui/SleepScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/SleepScreen.kt
@@ -2700,7 +2700,8 @@ internal fun isPreOnsetAwakeStub(frag: SleepSession): Boolean {
 private fun sumGroupStages(group: List<SleepSession>): StageMins? {
     var aw = 0.0; var li = 0.0; var dp = 0.0; var rm = 0.0; var any = false
     for (frag in group) {
-        val s = parseSessionStages(frag.stagesJSON) ?: continue
+        // #259: each fragment's stages trimmed to its effective onset before summing (see buildSleepModel).
+        val s = parseSessionStages(SleepStageTotals.clampStagesToOnset(frag.stagesJSON, frag.effectiveStartTs)) ?: continue
         aw += s.awake; li += s.light; dp += s.deep; rm += s.rem; any = true
     }
     return if (any) StageMins(aw, li, dp, rm) else null
@@ -2823,7 +2824,10 @@ internal fun buildSleepModel(
     // (StagesVsTypical, Hypnogram footer) immediately without waiting on a rescore.
     val sessionStageMins = session
         ?.takeIf { AnalyticsEngine.dayString(it.endTs) == latest.day || localDayString(it.endTs) == latest.day }
-        ?.let { parseSessionStages(it.stagesJSON) }
+        // #259: trim to the EFFECTIVE onset before summing, so a hand-edited bedtime the raw was too sparse
+        // to re-stage (WHOOP 4.0) can't show pre-onset stages that push asleep past time-in-bed. No-op when
+        // the session already starts at its onset (the common case). Matches the analytics-side clamp.
+        ?.let { parseSessionStages(SleepStageTotals.clampStagesToOnset(it.stagesJSON, it.effectiveStartTs)) }
     val deep = heroStages?.deep ?: sessionStageMins?.deep ?: latest.deepMin ?: 0.0
     val rem = heroStages?.rem ?: sessionStageMins?.rem ?: latest.remMin ?: 0.0
     val light = heroStages?.light ?: sessionStageMins?.light ?: latest.lightMin ?: 0.0

--- a/android/app/src/main/java/com/noop/ui/SleepScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/SleepScreen.kt
@@ -2607,13 +2607,16 @@ internal fun selectNight(
     // hypnogram, and SUM their stage minutes for the hero. Built from `heroGroup` (the group minus a leading
     // spurious stub, #736) so the chart and minutes start at the displayed bedtime. Null for a single-block
     // hero → prior behaviour.
+    // #259: clamp each fragment's timeline to its effective onset too (matching the stage-minute clamp
+    // and the iOS decodeSegments clamp), so the hypnogram starts where the edited bedtime does instead of
+    // drawing pre-onset bars that contradict the clamped asleep total. No-op for non-edited nights.
     val groupSegments = if (heroGroup.size > 1) {
-        heroGroup.flatMap { parsePersistedSegments(it.stagesJSON).orEmpty() }
+        heroGroup.flatMap { parsePersistedSegments(SleepStageTotals.clampStagesToOnset(it.stagesJSON, it.effectiveStartTs)).orEmpty() }
             .sortedBy { it.start }
             .takeIf { it.size >= 2 }
     } else null
     val groupStages = if (heroGroup.size > 1) sumGroupStages(heroGroup) else null
-    val segments = (groupSegments ?: parsePersistedSegments(session.stagesJSON))
+    val segments = (groupSegments ?: parsePersistedSegments(SleepStageTotals.clampStagesToOnset(session.stagesJSON, session.effectiveStartTs)))
         ?.map { seg -> seg.stage to ((seg.end - seg.start) / 60f) }
     // #407: lay the GROUP's per-epoch motion fragment-by-fragment in `heroGroup` order (the same order
     // `groupSegments` lays the stage timeline), reading the already-chosen group's stored series. The

--- a/android/app/src/test/java/com/noop/analytics/Issue259PreOnsetClampTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/Issue259PreOnsetClampTest.kt
@@ -1,0 +1,64 @@
+package com.noop.analytics
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * #259: on WHOOP 4.0 a long low-motion pre-onset stretch was over-staged as sleep, so the detected
+ * block spanned a much wider window than the user actually slept. After a bed edit (or onset trim) the
+ * raw was too sparse to re-stage, leaving those pre-onset segments in the stored stagesJSON. The daily
+ * aggregate then summed the FULL window, making "asleep" exceed "time-in-bed" (the impossible
+ * "6h41m asleep / 4h33m in bed" card). [SleepStageTotals.dailyAggregateHonoringEdits] now trims each
+ * selected block's stages to its effective onset before summing. Byte-parity twin of the Swift test.
+ */
+class Issue259PreOnsetClampTest {
+
+    private fun stages(start: Long, end: Long, stage: String): String =
+        AnalyticsEngine.encodeStages(listOf(StageSegment(start = start, end = end, stage = stage)))!!
+
+    @Test
+    fun preOnsetStagesAreClampedSoAsleepNeverExceedsTimeInBed() {
+        // Detected block staged as one contiguous 8h49m "light" span [0, 31740]; the user's EFFECTIVE
+        // onset is 15300 (they actually slept from there, 4h34m). Before the fix the aggregate summed the
+        // full 8h49m; after, the pre-onset half is dropped and asleep == the post-onset window.
+        val startTs = 0L
+        val onset = 15_300L            // effective onset — 4h15m after the (over-detected) start
+        val end = 31_740L              // wake — 8h49m after the detected start
+        val json = stages(startTs, end, "light")
+
+        val r = SleepStageTotals.dailyAggregateHonoringEdits(
+            detected = listOf(startTs to json),
+            edited = mapOf(startTs to json),          // an edit is present (onset moved); stages not re-staged
+            onsetByStart = mapOf(startTs to onset),
+            offsetSec = 0L,
+        )
+        assertNotNull(r)
+
+        val inBedMin = (end - onset) / 60.0           // 274 min — time-in-bed the card shows
+        assertEquals("asleep is clamped to the post-onset window", inBedMin, r!!.sleep.totalSleepMin, 1e-6)
+        assertTrue("asleep must never exceed time-in-bed (#259)", r.sleep.totalSleepMin <= inBedMin + 1e-6)
+        // Guard: without the clamp this would be the full 8h49m (529 min).
+        assertNotEquals("must not sum the pre-onset stretch", (end - startTs) / 60.0, r.sleep.totalSleepMin, 1e-6)
+    }
+
+    @Test
+    fun nonEditedNightIsUnchangedByTheClamp() {
+        // A normally-detected night whose onset equals its start: clamping to its own onset is a no-op, so
+        // the aggregate is identical to before the fix (no regression for the common case).
+        val startTs = 1_000L
+        val end = 1_000L + 27_000L     // 7h30m
+        val json = stages(startTs, end, "light")
+
+        val r = SleepStageTotals.dailyAggregateHonoringEdits(
+            detected = listOf(startTs to json),
+            edited = emptyMap(),
+            onsetByStart = mapOf(startTs to startTs),  // onset == start → clamp is a no-op
+            offsetSec = 0L,
+        )
+        assertNotNull(r)
+        assertEquals(27_000.0 / 60.0, r!!.sleep.totalSleepMin, 1e-6)
+    }
+}


### PR DESCRIPTION
Fixes #259.

## The bug
A WHOOP 4.0 morning sleep showed **"6h 41m asleep" over "4h 33m in bed"** — physically impossible — plus an inflated 100/Optimal score. (Not a timezone bug: 01:58→06:15 is 4h17m, not a clean offset.)

## Root cause
The card mixes two windows: **time-in-bed** = `endTs − effectiveStartTs` (the edited onset, 06:15), while **asleep** is summed from the stored stage segments. The user edited bedtime to 06:15, but WHOOP 4.0's raw motion was too sparse for `SleepStageHealer.restageFromRaw` to re-derive (it skips on sparse raw), so the stored `stagesJSON` kept its **pre-onset segments** (01:58→06:15, staged as sleep). `dailyAggregateHonoringEdits` then summed the full window → asleep > in-bed, and the same inflated total fed Rest/score.

## Fix
In `SleepStageTotals.dailyAggregateHonoringEdits`, trim each **selected** block's stages to its effective onset before summing (`clampStagesToOnset` drops/trims segments starting before `onsetByStart[startTs]`). Main-night **selection** still runs on the original blocks, so no #525/#547 pick change — only the summed total is clamped.

- **No-op for the common case:** a block already staged from its onset — and every non-edited night, where `onset == start` — is returned unchanged.
- **Scope is exactly right:** `startTsAdjusted` is set *only* by a user edit (every assignment pairs with `userEdited = true`), so `effectiveStartTs ≠ startTs` ⟺ an edited night ⟺ this path. The reported card (in-bed at 06:15 ≠ detected 01:58) is necessarily edited.
- **Byte-parity:** identical clamp in Swift + Kotlin (only decoded minute totals cross-check; the re-serialized JSON is re-parsed same-platform).

## Deliberately NOT here (deferred root cause)
Why 4.0 over-stages a long low-motion pre-onset stretch as sleep at all — the sparse-motion staging problem (same family as #28/#688). That needs real 4.0 raw to tune and shouldn't block this correctness guard. Worth its own issue.

## Verification
- **Android:** `compileFullDebugKotlin` + full `com.noop.analytics.*` suite green, incl. new `Issue259PreOnsetClampTest` (pre-onset trim + non-edited no-op).
- **Swift packages:** `SleepStageTotalsTests` twins — `swift-packages` CI (StrandAnalytics).
- Pure analytics, no app-target Swift, no stored-data mutation.