### PR TITLE
fix(android/ble): recompute clockUntrusted per requestSync, not cache it (#266)

### DIFF
--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -1494,11 +1494,6 @@ class WhoopBleClient(
      *  kicks — the Android side of the Swift `BLEManager.lastBackfillAt`. */
     @Volatile private var lastBackfillAtMs: Long? = null
 
-    /** True while the strap's own RTC reads future-dated (#928/#1012): its offloads bank real rows but the
-     *  range is un-trustworthy, so [BackfillPolicy] SKIPS the automatic periodic/strap kicks (the per-connect
-     *  pass still re-checks). Refreshed from [isFutureDatedNewest] at each completed offload's continue
-     *  decision, so a clock that self-corrects clears it. Twin of the Swift `clockUntrusted` shouldRun arg. */
-    @Volatile private var clockUntrusted: Boolean = false
     private val backfillTimeoutRunnable = Runnable { onBackfillTimeout() }
 
     /** Live-stream keep-alive (port of BLEManager.keepAliveTimer): re-arms realtime, polls battery,
@@ -4674,10 +4669,16 @@ class WhoopBleClient(
      * AUTOMATIC periodic/strap kicks are floored, empty-streak-backed-off, and skipped on an untrusted
      * clock, while manual/connect/foreground run at the 90s event floor. Previously the fixed 900s timer
      * was the only coarse limit, so a not-banking strap was re-offloaded every 15 min forever.
+     *
+     * #266: clockUntrusted is recomputed HERE from the live [strapNewestTs] and wall clock on every call
+     * (never cached) — a strap that stays connected with a self-correcting RTC is re-evaluated on the very
+     * next sync attempt of any kind, not just at the next disconnect/reconnect. Twin of the Swift
+     * `BLEManager.requestSync`, which recomputes inline the same way.
      */
     private fun requestSync(trigger: BackfillTrigger) {
         val s = _state.value
         if (!canRequestSync(s.connected, s.bonded, backfilling)) return
+        val clockUntrusted = isFutureDatedNewest(strapNewestTs, System.currentTimeMillis() / 1000L)
         if (!BackfillPolicy.shouldRun(
                 trigger = trigger,
                 nowSeconds = System.currentTimeMillis() / 1000.0,
@@ -4995,9 +4996,10 @@ class WhoopBleClient(
         ioScope.launch {
             val frontier = runCatching { repository.latestHrSampleTs(deviceId) }.getOrNull()
             val wallNow = System.currentTimeMillis() / 1000L   // #928: real wall clock, at decision time
-            // Refresh the clock-trust state for BackfillPolicy: a future-dated newest (#1012) makes the
-            // AUTOMATIC periodic/strap kicks near-useless, so the policy skips them until it self-corrects.
-            clockUntrusted = isFutureDatedNewest(newest, wallNow)
+            // #266: local only — NOT cached on the instance. A future-dated newest (#1012) makes the
+            // AUTOMATIC periodic/strap kicks near-useless for THIS decision; [requestSync] recomputes its
+            // own verdict fresh from [strapNewestTs] on every call, so a stale value here can't leak forward.
+            val clockUntrusted = isFutureDatedNewest(newest, wallNow)
             val stillConnected = _state.value.connected && _state.value.bonded
             if (!shouldAutoContinue(
                     stillConnected = stillConnected,
@@ -5395,10 +5397,6 @@ class WhoopBleClient(
         backfillDraining = false
         backfillFrameQueue.clear()
         strapNewestTs = null
-        // clockUntrusted is DERIVED from strapNewestTs (set in maybeAutoContinueBackfill); clear it with its
-        // source so a torn-down connection can't carry a stale future-clock verdict into the next one and
-        // wrongly skip that connection's automatic periodic/strap kicks before its own offload refreshes it.
-        clockUntrusted = false
         offloadFramesThisSession = 0
         lastOffloadFrameAtMs = 0L   // #174: don't carry a stale cooldown reference into the next session
         historicalKickSent = false


### PR DESCRIPTION
## Summary

Fixes #266. `clockUntrusted` (`WhoopBleClient.kt`) was a stored `@Volatile` field, only ever refreshed inside `maybeAutoContinueBackfill` after a backfill session ended. `requestSync` — the single gated entry point for every historical-offload kick — read that stale field instead of recomputing it.

The mechanism of the permanent stall: `BackfillPolicy.shouldRun` gates `PERIODIC`/`STRAP` triggers on `!clockUntrusted`. Once the flag latched `true` (strap RTC read future-dated), every later `PERIODIC` (900s timer) or `STRAP` call into `requestSync` was blocked by the stale flag *before* it could reach a backfill session that would refresh it — so a strap whose clock later self-corrected could never resume automatic sync while staying connected. Only a full disconnect/reconnect (which reset the field) or a `CONNECT`/`MANUAL`/`FOREGROUND` trigger (not gated by the flag) could unstick it.

The Swift side (`Strand/BLE/BLEManager.swift`) never had this bug — it has no stored `clockUntrusted` property at all; `requestSync` computes it inline from `strapNewestTs` and `Date()` on every call.

- `requestSync` now computes `clockUntrusted` as a local `val`, inline from the live `strapNewestTs` and current wall clock, on every call — mirroring the Swift side exactly.
- `maybeAutoContinueBackfill`'s own use is now a local `val` too (it was already correct there — the field write happened right before the read in the same scope — but keeping the field around as otherwise-unused mutable state was the footgun).
- Removed the now-unnecessary `@Volatile private var clockUntrusted` field and its disconnect-path reset in `exitBackfilling`.

No Swift-side change needed — Swift already behaves this way, so this is Android-only and doesn't touch stored/analytics data (no byte-parity concern).

## Test plan

- [x] `./gradlew compileFullDebugKotlin` → **BUILD SUCCESSFUL**
- [x] `./gradlew testFullDebugUnitTest` (en-US locale) → all tests pass, no regressions
- [ ] **Not verified on a real strap with an intentionally future-dated RTC** — the existing test suite pins the pure `BackfillPolicy.shouldRun`/`isFutureDatedNewest` predicates (unchanged by this fix), but the caching bug itself lived in `WhoopBleClient`'s private instance state, which (like the rest of the class, see `SyncNowGateTest`'s own note) needs a live GATT stack to exercise end-to-end and isn't unit-testable without one.