### PR TITLE
feat(ble): wire the FOREGROUND backfill trigger on all three platforms (#267)

### DIFF
--- a/Strand/App/StrandApp.swift
+++ b/Strand/App/StrandApp.swift
@@ -21,6 +21,9 @@ struct StrandApp: App {
     /// Shared cross-screen navigation hook (e.g. Live → Devices). The macOS shell (`RootView`)
     /// observes it and drives the sidebar selection.
     @StateObject private var router = NavRouter()
+    /// #267: drives a foreground sync kick when the window becomes active (no scenePhase hook
+    /// existed on macOS before this).
+    @Environment(\.scenePhase) private var scenePhase
     /// Appearance preference (System/Light/Dark). Default follows the OS; the Settings picker writes it.
     @AppStorage(AppearanceMode.storageKey) private var appearanceRaw = AppearanceMode.system.rawValue
     /// Chart data-colour style (Titanium / Classic throwback). Re-colours gauges + charts.
@@ -48,6 +51,15 @@ struct StrandApp: App {
                 // fixed-geometry tiles/gauges stay legible at the largest accessibility sizes rather than
                 // clipping; the common Larger-Text range still scales fully.
                 .dynamicTypeSize(...DynamicTypeSize.accessibility1)
+                // #267: pull a reasonably fresh sync when the window comes to the foreground rather than
+                // waiting for the 900s periodic timer or an incidental reconnect. Floored at 90s and never
+                // clock/empty-streak-suppressed (BackfillPolicy.shouldRun's .foreground case), so this is
+                // a safe no-op on rapid re-focusing. Mirrors the iOS scenePhase == .active handler.
+                // Single-param form (not the two-param `{ _, phase in }`) — that overload needs macOS 14,
+                // this target is macOS 13.
+                .onChange(of: scenePhase) { phase in
+                    if phase == .active { model.ble.requestSync(.foreground) }
+                }
         }
         .windowStyle(.hiddenTitleBar)
         .defaultSize(width: 1180, height: 820)

--- a/StrandiOS/App/StrandiOSApp.swift
+++ b/StrandiOS/App/StrandiOSApp.swift
@@ -184,6 +184,10 @@ struct StrandiOSApp: App {
                 // Re-arm the strap's smart alarm on foreground: the firmware alarm is a single instant
                 // and iOS can't re-arm it while suspended, so it would otherwise fire once and stop.
                 model.applySmartAlarm()
+                // #267: pull a reasonably fresh sync on open rather than waiting for the 900s periodic
+                // timer or an incidental reconnect. Floored at 90s and never clock/empty-streak-suppressed
+                // (BackfillPolicy.shouldRun's .foreground case), so this is a safe no-op on rapid re-opens.
+                model.ble.requestSync(.foreground)
                 Task {
                     health.refreshAuthIfPreviouslyGranted()
                     await health.sync()

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -4709,6 +4709,17 @@ class WhoopBleClient(
         handler.post { requestSync(BackfillTrigger.MANUAL) }
     }
 
+    /**
+     * App-active entry point (#267): call when NOOP comes to the foreground so opening the app pulls a
+     * reasonably fresh sync instead of relying on the 900s periodic timer or an incidental reconnect.
+     * Forwards to the SAME gated [requestSync] every other trigger uses — floored at the 90s event floor
+     * and never empty-streak/clock-suppressed (see [BackfillPolicy.shouldRun]'s `.FOREGROUND` case) — so
+     * it's a safe, cheap no-op no matter how often the caller invokes it.
+     */
+    fun onForeground() {
+        handler.post { requestSync(BackfillTrigger.FOREGROUND) }
+    }
+
     /** Periodic-timer callback: re-runs the type-47 offload (the primary metric sync). */
     private fun triggerPeriodicBackfill() {
         requestSync(BackfillTrigger.PERIODIC)

--- a/android/app/src/main/java/com/noop/ui/MainActivity.kt
+++ b/android/app/src/main/java/com/noop/ui/MainActivity.kt
@@ -772,6 +772,20 @@ fun NoopRoot() {
     val prefs = remember { NoopPrefs.of(context) }
     val appViewModel: AppViewModel = viewModel()
 
+    // #267: app-wide "came to foreground" hook, mirrors the iOS/macOS scenePhase == .active trigger.
+    // requestSync(FOREGROUND) is a safe no-op when nothing's connected/bonded yet (e.g. during
+    // onboarding), so this is placed above the onboarding/terms gates rather than duplicated below them.
+    val lifecycleOwner = androidx.lifecycle.compose.LocalLifecycleOwner.current
+    androidx.compose.runtime.DisposableEffect(lifecycleOwner, appViewModel) {
+        val observer = androidx.lifecycle.LifecycleEventObserver { _, event ->
+            if (event == androidx.lifecycle.Lifecycle.Event.ON_RESUME) {
+                appViewModel.ble.onForeground()
+            }
+        }
+        lifecycleOwner.lifecycle.addObserver(observer)
+        onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
+    }
+
     var onboarded by remember {
         mutableStateOf(prefs.getBoolean(NoopPrefs.KEY_ONBOARDED, false))
     }


### PR DESCRIPTION
## Summary

Fixes #267. `BackfillTrigger.FOREGROUND` / `.foreground` was defined and handled in `BackfillPolicy.shouldRun` on both platforms, but nothing ever called `requestSync` with it — a repo-wide search for `requestSync(.foreground)` / `requestSync(BackfillTrigger.FOREGROUND)` had no call sites. So "open the app to pull the latest" wasn't actually wired; users relied on the 900s periodic timer, an incidental reconnect, or the manual "Sync now" button.

Wired app-active → `requestSync(FOREGROUND)` on all three targets:

- **Android** (`WhoopBleClient.kt`): added a public `onForeground()`, mirroring the existing `syncNow()` pattern exactly (posts to the handler, forwards to the same gated `requestSync`). `requestSync` itself is `private`, so external callers need this wrapper. Wired it to `ON_RESUME` via a `LifecycleEventObserver` added at the top of `NoopRoot()` in `MainActivity.kt` — there was no app-wide foreground choke point on Android before this (the only existing `LifecycleEventObserver` was screen-scoped, in `InsightsScreen.kt`, for an unrelated day-rollover check). Placed above the onboarding/terms gates since `requestSync` is already a safe no-op when nothing's connected/bonded.
- **iOS** (`StrandiOSApp.swift`): one line, `model.ble.requestSync(.foreground)`, added inside the existing `scenePhase == .active` handler, alongside `model.applySmartAlarm()`.
- **macOS** (`StrandApp.swift`): no `scenePhase` hook existed at all — added one from scratch (`@Environment(\.scenePhase)` + `.onChange`). Used the **single-parameter** `onChange` closure form deliberately: the two-parameter `{ _, phase in }` overload requires macOS 14, and this target's deployment floor is macOS 13 (confirmed by an existing `#if os(iOS)` gate elsewhere in the codebase that keeps the two-param form off macOS for the same reason).

It's already floored at the 90s event floor and never empty-streak/clock-suppressed (per `BackfillPolicy.shouldRun`'s `.foreground`/`FOREGROUND` case on both platforms), so this is a cheap, self-throttling "refresh on open" — no extra battery cost on a warm link, and can't fire more than once per 90s regardless of how often the app is foregrounded.

## Test plan

- [x] `xcodegen generate && xcodebuild -scheme Strand -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO build` → **BUILD SUCCEEDED**
- [x] `xcodebuild -scheme NOOPiOS -destination 'platform=iOS Simulator,name=iPhone 17' build` → **BUILD SUCCEEDED**
- [x] `./gradlew compileFullDebugKotlin` → **BUILD SUCCESSFUL**
- [x] `./gradlew testFullDebugUnitTest` (en-US locale) → all tests pass, no regressions
- [ ] **Not verified end-to-end on a real strap** — confirming a foreground/background/foreground cycle actually kicks a sync (vs. relying on the periodic timer) needs on-device observation of the strap log; the wiring itself is covered by compile success + code review, since `BackfillPolicy`'s trigger-gating logic is unchanged and already covered by `BackfillPolicyTest.kt`/`BackfillPolicyTests.swift`.