### PR TITLE
fix(devices): "Clock latched" reads yes on a working WHOOP 5/MG (#261)

### DIFF
--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/ConnectionReadout.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/ConnectionReadout.swift
@@ -190,12 +190,27 @@ public enum ConnectionReadout {
         return nil
     }
 
-    /// #987: the "clock latched" readout value. "yes" once a correlation landed with a plausible (post-
-    /// 1972) device clock; "no (RTC reads 1970/71)" when the strap answered with an epoch-era clock
-    /// (never set, so it banks no history); "no (waiting for the strap clock)" before any reply.
-    public static func clockLatchedLabel(deviceClockUnix: Int?) -> String {
-        guard let d = deviceClockUnix else { return "no (waiting for the strap clock)" }
-        return d < ConnectionTrace.rtcEpochCeilingUnix ? "no (RTC reads 1970/71)" : "yes"
+    /// #987/#261: the "clock latched" readout value. "yes" once EITHER signal lands with a plausible
+    /// (post-1972) timestamp: a GET_CLOCK correlation (`deviceClockUnix`, the WHOOP4 path), or a
+    /// GET_DATA_RANGE reply's newest banked record (`strapNewestUnix`, the fallback). "no (RTC reads
+    /// 1970/71)" when whichever signal landed reads epoch-era; "no (waiting for the strap clock)" before
+    /// either replies.
+    ///
+    /// A WHOOP 5/MG's GET_CLOCK reply rides the puffin notify channel and never reaches the WHOOP4-only
+    /// correlation path that sets `deviceClockUnix` (see `BLEManager`'s connect-handshake comment) — its
+    /// records carry absolute timestamps, so it never NEEDS that correlation to decode history. Without
+    /// this fallback the row read "no (waiting for the strap clock)" forever on every 5/MG, even a fully
+    /// working one, because the one signal it checked structurally never populates for that family. The
+    /// data-range reply is an equal-weight proof the strap answered with a working clock, not a downgrade
+    /// — `rtcWarning` below already trusts it the same way.
+    public static func clockLatchedLabel(deviceClockUnix: Int?, strapNewestUnix: Int? = nil) -> String {
+        if let d = deviceClockUnix {
+            return d < ConnectionTrace.rtcEpochCeilingUnix ? "no (RTC reads 1970/71)" : "yes"
+        }
+        if let n = strapNewestUnix {
+            return n < ConnectionTrace.rtcEpochCeilingUnix ? "no (RTC reads 1970/71)" : "yes"
+        }
+        return "no (waiting for the strap clock)"
     }
 
     /// #987: a plain-words warning when the strap RTC reads epoch-era (~1970/71), from EITHER signal we

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/ConnectionReadoutTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/ConnectionReadoutTests.swift
@@ -179,6 +179,25 @@ final class ConnectionReadoutTests: XCTestCase {
         XCTAssertEqual(ConnectionReadout.clockLatchedLabel(deviceClockUnix: nil), "no (waiting for the strap clock)")
     }
 
+    // #261: a WHOOP 5/MG never populates deviceClockUnix (its GET_CLOCK reply rides the puffin channel,
+    // never the WHOOP4 correlation path) — the data-range fallback is what keeps the row from reading
+    // "waiting" forever on a strap that's actually fine.
+    func testClockLatchedLabelFallsBackToStrapNewestForFiveMG() {
+        XCTAssertEqual(
+            ConnectionReadout.clockLatchedLabel(deviceClockUnix: nil, strapNewestUnix: 1_782_475_600),
+            "yes")
+        XCTAssertEqual(
+            ConnectionReadout.clockLatchedLabel(deviceClockUnix: nil, strapNewestUnix: 40_000_000),
+            "no (RTC reads 1970/71)")
+        XCTAssertEqual(
+            ConnectionReadout.clockLatchedLabel(deviceClockUnix: nil, strapNewestUnix: nil),
+            "no (waiting for the strap clock)")
+        // deviceClockUnix wins when BOTH signals are present (the WHOOP4 correlation is the more direct one).
+        XCTAssertEqual(
+            ConnectionReadout.clockLatchedLabel(deviceClockUnix: 1_782_475_600, strapNewestUnix: 40_000_000),
+            "yes")
+    }
+
     func testRtcWarningFiresOnEpochEraClockOrNewest() {
         XCTAssertNotNil(ConnectionReadout.rtcWarning(deviceClockUnix: 40_000_000, strapNewestUnix: nil))
         XCTAssertNotNil(ConnectionReadout.rtcWarning(deviceClockUnix: nil, strapNewestUnix: 30_000_000))

--- a/Strand/Screens/DevicesView.swift
+++ b/Strand/Screens/DevicesView.swift
@@ -74,7 +74,8 @@ private struct DevicesContent: View {
         guard live.connected else { return nil }
         let deviceClock = ConnectionReadout.clockCorrelatedDevice(logLines: live.log)
         guard deviceClock != nil || live.strapRange != nil || live.lastFrameAtUnix != nil else { return nil }
-        let latched = ConnectionReadout.clockLatchedLabel(deviceClockUnix: deviceClock)
+        let latched = ConnectionReadout.clockLatchedLabel(deviceClockUnix: deviceClock,
+                                                          strapNewestUnix: live.strapRange?.newestUnix)
         let frame = ConnectionReadout.lastFrameLabel(lastFrameUnix: live.lastFrameAtUnix,
                                                      nowUnix: Int(Date().timeIntervalSince1970))
         let warning = ConnectionReadout.rtcWarning(deviceClockUnix: deviceClock,

--- a/Strand/Screens/TestCentreView.swift
+++ b/Strand/Screens/TestCentreView.swift
@@ -536,7 +536,8 @@ private struct ConnectionReadoutPanel: View {
                        value: sessionRows.map(String.init) ?? String(localized: "no offload yet"))
             ReadoutRow(label: String(localized: "Rows drained (all time)"), value: String(allTimeRows))
             ReadoutRow(label: String(localized: "Clock latched"),
-                       value: ConnectionReadout.clockLatchedLabel(deviceClockUnix: deviceClock))
+                       value: ConnectionReadout.clockLatchedLabel(deviceClockUnix: deviceClock,
+                                                                  strapNewestUnix: live.strapRange?.newestUnix))
             ReadoutRow(label: String(localized: "Last frame"),
                        value: ConnectionReadout.lastFrameLabel(lastFrameUnix: live.lastFrameAtUnix, nowUnix: now))
             if let rtcWarning {

--- a/android/app/src/main/java/com/noop/analytics/ConnectionReadout.kt
+++ b/android/app/src/main/java/com/noop/analytics/ConnectionReadout.kt
@@ -182,12 +182,17 @@ object ConnectionReadout {
         return null
     }
 
-    /** #987: the "clock latched" readout value: "yes" once a correlation landed with a plausible
-     *  (post-1972) device clock; "no (RTC reads 1970/71)" on an epoch-era clock; "no (waiting for the
-     *  strap clock)" before any reply. Twin of the Swift labeller. */
-    fun clockLatchedLabel(deviceClockUnix: Long?): String {
-        if (deviceClockUnix == null) return "no (waiting for the strap clock)"
-        return if (deviceClockUnix < ConnectionTrace.RTC_EPOCH_CEILING_UNIX) "no (RTC reads 1970/71)" else "yes"
+    /** #987/#261: the "clock latched" readout value: "yes" once EITHER signal lands with a plausible
+     *  (post-1972) timestamp — a GET_CLOCK correlation (deviceClockUnix, the WHOOP4 path) or a
+     *  GET_DATA_RANGE reply's newest banked record (strapNewestUnix, the fallback a WHOOP 5/MG needs
+     *  since its GET_CLOCK reply never populates deviceClockUnix — see the Swift twin's doc comment for
+     *  why). "no (RTC reads 1970/71)" on an epoch-era signal; "no (waiting for the strap clock)" before
+     *  either replies. Twin of the Swift labeller. */
+    fun clockLatchedLabel(deviceClockUnix: Long?, strapNewestUnix: Long? = null): String {
+        val ceiling = ConnectionTrace.RTC_EPOCH_CEILING_UNIX
+        if (deviceClockUnix != null) return if (deviceClockUnix < ceiling) "no (RTC reads 1970/71)" else "yes"
+        if (strapNewestUnix != null) return if (strapNewestUnix < ceiling) "no (RTC reads 1970/71)" else "yes"
+        return "no (waiting for the strap clock)"
     }
 
     /** #987: a plain-words warning when the strap RTC reads epoch-era (~1970/71), from EITHER signal we

--- a/android/app/src/test/java/com/noop/analytics/ConnectionReadoutTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/ConnectionReadoutTest.kt
@@ -188,6 +188,17 @@ class ConnectionReadoutTest {
         assertEquals("no (waiting for the strap clock)", ConnectionReadout.clockLatchedLabel(null))
     }
 
+    // #261: a WHOOP 5/MG never populates deviceClockUnix (its GET_CLOCK reply rides the puffin channel,
+    // never the WHOOP4 correlation path) — the data-range fallback is what keeps the row from reading
+    // "waiting" forever on a strap that's actually fine.
+    @Test fun clockLatchedLabelFallsBackToStrapNewestForFiveMG() {
+        assertEquals("yes", ConnectionReadout.clockLatchedLabel(null, 1_782_475_600L))
+        assertEquals("no (RTC reads 1970/71)", ConnectionReadout.clockLatchedLabel(null, 40_000_000L))
+        assertEquals("no (waiting for the strap clock)", ConnectionReadout.clockLatchedLabel(null, null))
+        // deviceClockUnix wins when BOTH signals are present (the WHOOP4 correlation is the more direct one).
+        assertEquals("yes", ConnectionReadout.clockLatchedLabel(1_782_475_600L, 40_000_000L))
+    }
+
     @Test fun rtcWarningFiresOnEpochEraClockOrNewest() {
         assertTrue(ConnectionReadout.rtcWarning(40_000_000L, null) != null)
         assertTrue(ConnectionReadout.rtcWarning(null, 30_000_000L) != null)


### PR DESCRIPTION
## Summary

Follow-up to #261 / #262. `ConnectionReadout.clockLatchedLabel` only ever checked `deviceClockUnix`, which is populated from a `GET_CLOCK` correlation (`ClockCorrelation.clockRef`) that is **WHOOP4-only** — a WHOOP 5/MG's `GET_CLOCK` reply rides the puffin notify channel and never reaches that correlation path (`BLEManager.swift:3356`'s own comment: "GET_CLOCK's reply rides the puffin notify chars and never touches the WHOOP4 clockRef correlation path"). The 5/MG doesn't need that correlation either — its records carry absolute timestamps, decoded via the identity fallback.

Net effect: **every WHOOP 5/MG, working or not, shows "Clock latched: no (waiting for the strap clock)" forever** — a structural false negative, not specific to the #261 reporter's actual bug (which #262 already fixed: a migration race on cold background relaunch). #262's own PR body flagged this explicitly as a separate follow-up: *"'Clock latched: no' readout on 5/MG — cosmetic; worth a look at whether a data-range reply should flip it to 'yes.'"* This PR is that follow-up.

## Fix

`clockLatchedLabel` now takes an optional `strapNewestUnix` fallback — the `GET_DATA_RANGE` reply's newest banked record, which `rtcWarning` right next to it already trusts as an equal-weight clock-health signal. When `deviceClockUnix` is nil (structurally the case on every 5/MG) but a plausible (post-1972) `strapNewestUnix` has landed, the row now reads "yes" instead of "waiting" forever. Still reads the epoch-era warning if the range itself looks bad (a genuinely unclocked strap), and still reads "waiting" before either signal has replied.

Both Swift call sites (`DevicesView.swift`, `TestCentreView.swift`) already had `live.strapRange?.newestUnix` in scope (used one line below for `rtcWarning`), so this is a same-scope wiring change, not new plumbing. Mirrored on the Kotlin `ConnectionReadout.kt` twin for parity — worth noting this readout isn't currently wired into any Android screen (`DevicesScreen.kt`/`TestCentreScreen.kt` have no call sites, confirmed by grep), so the Kotlin change only keeps the "Twin of the Swift labeller" promise intact for whenever it is.

## Test plan

- [x] `swift test --filter ConnectionReadoutTests` (StrandAnalytics, pure/database-free) → all pass, including new `testClockLatchedLabelFallsBackToStrapNewestForFiveMG`
- [x] `xcodegen generate && xcodebuild -scheme Strand -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO build` → **BUILD SUCCEEDED**
- [x] `xcodebuild -scheme NOOPiOS -destination 'platform=iOS Simulator,name=iPhone 17' build` → **BUILD SUCCEEDED**
- [x] `./gradlew compileFullDebugKotlin testFullDebugUnitTest` → **BUILD SUCCESSFUL**, all tests pass including new `clockLatchedLabelFallsBackToStrapNewestForFiveMG`
- [ ] **Not verified on a real WHOOP 5/MG** — I don't have one to hand; the logic is a pure function fully covered by unit tests on both platforms, but the on-screen row should be eyeballed on-device to confirm it now reads "yes" on a normally-syncing 5/MG.