### PR TITLE
ble: don't report a dropped link as a confirmed WHOOP 4.0 reboot (#275)

### DIFF
--- a/Strand/BLE/BLEManager.swift
+++ b/Strand/BLE/BLEManager.swift
@@ -2886,7 +2886,15 @@ extension BLEManager: @preconcurrency CBCentralManagerDelegate {
         if let t = rebootRequestedAt {
             let ms = Int(Double(DispatchTime.now().uptimeNanoseconds &- t.uptimeNanoseconds) / 1_000_000)
             rebootTimeoutWork?.cancel(); rebootTimeoutWork = nil
-            log("reboot: link dropped \(ms)ms after send — reboot took effect; awaiting reconnect")
+            // #275: a dropped LINK only proves a reboot on WHOOP 5.0 (verified fw). On WHOOP 4.0 the frame
+            // is unconfirmed — opcode 29/payload01 was observed to drop the BLE link WITHOUT power-cycling
+            // the strap (the sensor stayed on) — so don't claim a reboot; report the drop honestly. Twin of
+            // Kotlin handleDisconnect.
+            if selectedModel.deviceFamily == .whoop5 {
+                log("reboot: link dropped \(ms)ms after send — reboot took effect; awaiting reconnect")
+            } else {
+                log("reboot: link dropped \(ms)ms after send — but a WHOOP 4.0 reboot isn't confirmed; a dropped link alone isn't proof (a real reboot also switches the sensor light off). Awaiting reconnect")
+            }
         }
         // #80 marginal-radio detection: judge this drop BEFORE the state resets below clobber the
         // arm timestamp. A drop that is unintentional, error-bearing, and lands shortly after we armed

--- a/Strand/BLE/Commands.swift
+++ b/Strand/BLE/Commands.swift
@@ -232,26 +232,49 @@ public enum RebootProbeVariant: String, CaseIterable, Sendable {
     /// B — opcode 32 POWER_CYCLE_STRAP, empty body: a harder restart, never tried.
     case powerCycle32Empty
     /// C — opcode 29 REBOOT_STRAP, payload [0x01]: same opcode with a non-empty sub-command byte.
+    /// On a real 4.0 this DROPPED THE LINK but did NOT power-cycle (sensor stayed on) — a BLE
+    /// disconnect, not a reboot (#275). So the sub-command byte reaches the strap; D/E try it on the
+    /// harder power-cycle opcode and a different byte on reboot.
     case reboot29Payload1
+    /// D — opcode 32 POWER_CYCLE_STRAP, payload [0x01]: the "harder restart" opcode with the sub-command
+    /// byte that made 29 react (#275). Best remaining safe candidate for a genuine power-cycle.
+    case powerCycle32Payload1
+    /// E — opcode 29 REBOOT_STRAP, payload [0x00]: the zero-byte sub-command (vs empty vs 0x01).
+    case reboot29Payload0
 
-    var command: WhoopCommand { self == .powerCycle32Empty ? .powerCycleStrap : .rebootStrap }
-    var payload: [UInt8] { self == .reboot29Payload1 ? [0x01] : [] }
+    var command: WhoopCommand {
+        switch self {
+        case .powerCycle32Empty, .powerCycle32Payload1: return .powerCycleStrap
+        default:                                         return .rebootStrap
+        }
+    }
+    var payload: [UInt8] {
+        switch self {
+        case .reboot29Payload1, .powerCycle32Payload1: return [0x01]
+        case .reboot29Payload0:                        return [0x00]
+        default:                                       return []
+        }
+    }
 
     /// Short menu label, e.g. "A · REBOOT_STRAP(29) empty".
     public var menuLabel: String {
         switch self {
-        case .reboot29Empty:     return "A · REBOOT_STRAP(29) empty"
-        case .powerCycle32Empty: return "B · POWER_CYCLE(32) empty"
-        case .reboot29Payload1:  return "C · REBOOT_STRAP(29) payload=01"
+        case .reboot29Empty:        return "A · REBOOT_STRAP(29) empty"
+        case .powerCycle32Empty:    return "B · POWER_CYCLE(32) empty"
+        case .reboot29Payload1:     return "C · REBOOT_STRAP(29) payload=01"
+        case .powerCycle32Payload1: return "D · POWER_CYCLE(32) payload=01"
+        case .reboot29Payload0:     return "E · REBOOT_STRAP(29) payload=00"
         }
     }
 
     /// Tag written to the strap log so each attempt is correlatable (byte-identical to Kotlin).
     public var logTag: String {
         switch self {
-        case .reboot29Empty:     return "A/reboot29-empty"
-        case .powerCycle32Empty: return "B/powercycle32-empty"
-        case .reboot29Payload1:  return "C/reboot29-payload01"
+        case .reboot29Empty:        return "A/reboot29-empty"
+        case .powerCycle32Empty:    return "B/powercycle32-empty"
+        case .reboot29Payload1:     return "C/reboot29-payload01"
+        case .powerCycle32Payload1: return "D/powercycle32-payload01"
+        case .reboot29Payload0:     return "E/reboot29-payload00"
         }
     }
 }

--- a/Strand/Screens/DevicesView.swift
+++ b/Strand/Screens/DevicesView.swift
@@ -201,7 +201,7 @@ private struct DevicesContent: View {
             }
             Button("Cancel", role: .cancel) { probeTarget = nil }
         } message: { _ in
-            Text("The WHOOP 4.0 reboot frame isn't confirmed — a normal Restart is ignored (#235). Send each candidate and watch the strap log: “link dropped” means it worked; “no disconnect within 12s” means the strap ignored it. Non-destructive — your data is kept. Please share the log so we can pin the real frame.")
+            Text("The WHOOP 4.0 reboot frame isn't confirmed — a normal Restart is ignored (#235). Send each candidate and watch BOTH the strap log and the strap itself. “no disconnect within 12s” means the strap ignored the frame. A “link dropped” line means the frame reached the strap — but a dropped link alone isn't a reboot: a real reboot also switches the strap's sensor light off for a few seconds, so if the light stayed on it was just a dropped connection, not a reboot. Non-destructive — your data is kept. Please share the log so we can pin the real frame.")
         }
         // Second, strongly-worded delete-data confirm (reached from the Remove card's secondary control)
         .alert("Delete all of this device's data?",

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -5158,7 +5158,15 @@ class WhoopBleClient(
         // the handshake can compute the round-trip. Twin of macOS didDisconnectPeripheral.
         rebootRequestedAtMs?.let { t ->
             rebootWatchdog?.let { handler.removeCallbacks(it) }; rebootWatchdog = null
-            log("reboot: link dropped ${SystemClock.elapsedRealtime() - t}ms after send — reboot took effect; awaiting reconnect")
+            val ms = SystemClock.elapsedRealtime() - t
+            // #275: a dropped LINK only proves a reboot on WHOOP 5.0 (verified fw). On WHOOP 4.0 the frame
+            // is unconfirmed — opcode 29/payload01 was observed to drop the BLE link WITHOUT power-cycling
+            // the strap (the sensor stayed on) — so don't claim a reboot; report the drop honestly. Twin of
+            // Swift didDisconnectPeripheral.
+            log(if (connectedFamily == DeviceFamily.WHOOP5)
+                "reboot: link dropped ${ms}ms after send — reboot took effect; awaiting reconnect"
+            else
+                "reboot: link dropped ${ms}ms after send — but a WHOOP 4.0 reboot isn't confirmed; a dropped link alone isn't proof (a real reboot also switches the sensor light off). Awaiting reconnect")
         }
         // Connection test mode: capture whether THIS attempt ever reached STATE_CONNECTED before the
         // state copy below clears `connected`. Android delivers BOTH a post-connect involuntary drop AND a

--- a/android/app/src/main/java/com/noop/protocol/Enums.kt
+++ b/android/app/src/main/java/com/noop/protocol/Enums.kt
@@ -171,6 +171,16 @@ enum class RebootProbeVariant(
     POWER_CYCLE_32_EMPTY(CommandNumber.POWER_CYCLE_STRAP, byteArrayOf(),
         "B · POWER_CYCLE(32) empty", "B/powercycle32-empty"),
     // C — opcode 29 REBOOT_STRAP, payload [0x01]: same opcode with a non-empty sub-command byte.
+    // On a real 4.0 this DROPPED THE LINK but did NOT power-cycle (sensor stayed on) — a BLE
+    // disconnect, not a reboot (#275). So the sub-command byte reaches the strap; the next two try it
+    // on the harder power-cycle opcode and a different byte on reboot.
     REBOOT_29_PAYLOAD1(CommandNumber.REBOOT_STRAP, byteArrayOf(0x01),
         "C · REBOOT_STRAP(29) payload=01", "C/reboot29-payload01"),
+    // D — opcode 32 POWER_CYCLE_STRAP, payload [0x01]: the "harder restart" opcode with the sub-command
+    // byte that made 29 react (#275). Best remaining safe candidate for a genuine power-cycle.
+    POWER_CYCLE_32_PAYLOAD1(CommandNumber.POWER_CYCLE_STRAP, byteArrayOf(0x01),
+        "D · POWER_CYCLE(32) payload=01", "D/powercycle32-payload01"),
+    // E — opcode 29 REBOOT_STRAP, payload [0x00]: the zero-byte sub-command (vs empty vs 0x01).
+    REBOOT_29_PAYLOAD0(CommandNumber.REBOOT_STRAP, byteArrayOf(0x00),
+        "E · REBOOT_STRAP(29) payload=00", "E/reboot29-payload00"),
 }

--- a/android/app/src/main/java/com/noop/ui/DevicesScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/DevicesScreen.kt
@@ -767,8 +767,11 @@ private fun RebootProbeDialog(
             Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
                 Text(
                     "The WHOOP 4.0 reboot frame isn't confirmed — a normal Restart is ignored (#235). " +
-                        "Send each candidate and watch the strap log: “link dropped” means it worked; " +
-                        "“no disconnect within 12s” means the strap ignored it. Non-destructive — your data " +
+                        "Send each candidate and watch BOTH the strap log and the strap itself. " +
+                        "“no disconnect within 12s” means the strap ignored the frame. A “link dropped” line " +
+                        "means the frame reached the strap — but a dropped link alone isn't a reboot: a real " +
+                        "reboot also switches the strap's sensor light off for a few seconds, so if the light " +
+                        "stayed on it was just a dropped connection, not a reboot. Non-destructive — your data " +
                         "is kept. Please share the log so we can pin the real frame.",
                     style = NoopType.subhead,
                     color = Palette.textSecondary,


### PR DESCRIPTION
Fixes #275.

## The report
A reporter ran the WHOOP 4.0 reboot probe (#235) on 8.6.2 and shared a strap log + screenshot. Option C showed "Reconnecting," but the strap **didn't actually reboot** — the heart-rate sensor stayed on and it was back in ~5s.

## What the log shows (exactly the data #235 needed)
| Probe | Frame | Result |
|---|---|---|
| A | `REBOOT_STRAP(29)` empty | **ignored** ("no disconnect within 12s") |
| B | `POWER_CYCLE(32)` empty | **ignored** |
| C | `REBOOT_STRAP(29)` payload=01 | **link dropped ~7s after send**, ~7s outage, reconnect — reproducible |

But the reporter's physical observation is the key tell: the **sensor LED stayed on**. A genuine reboot power-cycles the strap (LED dark) and drops within ~1–2s when idle; C's ~7s-delayed drop with the sensor still running is a **BLE link disconnect, not a reboot**. So all three candidates are ruled out — the real WHOOP 4.0 reboot frame is still unknown.

The problem: the app treated *any* disconnect as success — the log said **"reboot took effect"** and the probe dialog said a **"link dropped"** line **"means it worked."** A mere link drop read as a reboot.

## The fix (honesty only — no BLE behaviour change)
A dropped link only proves a reboot on **WHOOP 5.0** (verified fw). On WHOOP 4.0 the frame is unconfirmed, so:

- **Disconnect log** now claims "reboot took effect" only for WHOOP 5.0; on 4.0 it reports the drop honestly — *"a dropped link alone isn't proof (a real reboot also switches the sensor light off)."* Byte-identical Swift/Kotlin, gated on the **same `deviceFamily == whoop5` check the existing no-disconnect message already uses**.
- **Reboot-probe dialog** stops calling a "link dropped" line proof and tells the tester to watch the strap's **sensor light** (off for a few seconds = real reboot; stayed on = just a dropped connection). Both platforms.

## Scope / verification
- **No behaviour change** — frames, watchdog, and reconnect path are untouched; this is log-message + dialog-text honesty.
- The shipped Restart dialog was already caveated for 4.0 ("the reboot command isn't confirmed yet"), so it's left as-is.
- Android `compileFullDebugKotlin` clean; app-target Swift (`BLEManager`, `DevicesView`) validated by app-build.
- Byte-parity: the two gated log messages are identical across platforms; the dialog text matches.
- The real WHOOP 4.0 reboot frame remains **unfound** — #235 stays open with the three candidates now ruled out.