### PR TITLE
feat(sleep): promote Sleep V2 to the default staging engine + tune deep boundary

### DIFF
--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/SleepStagerV2.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/SleepStagerV2.swift
@@ -1,8 +1,9 @@
 import Foundation
 import WhoopProtocol
 
-// SleepStagerV2.swift — an OPT-IN, EXPERIMENTAL alternative sleep-staging recipe, offered ALONGSIDE the
-// shipped `SleepStager` (V1) rather than replacing it. V1 stays the default and is UNTOUCHED.
+// SleepStagerV2.swift — the DEFAULT sleep-staging recipe. It became the default over the older
+// percentile-band stager `SleepStager` (V1) after a 44-subject cross-subject benchmark; V1 stays available
+// behind the PuffinExperiment flag.
 //
 // Reimplemented clean from the contributor recipe in NoopApp/noop PR #600 (sunny-noop). We took only the
 // per-session STAGING engine, not the CLI runner the PR shipped with it. Session DETECTION (the in-bed
@@ -10,11 +11,11 @@ import WhoopProtocol
 // decided is sleep, so it is a true drop-in for `SleepStager.stageSession(start:end:grav:hr:rr:resp:)`:
 // SAME signature, SAME `[StageSegment]` return shape.
 //
-// HONEST HEDGING (same spirit as V1, plus the PR's own caveat): these stages are APPROXIMATIONS, not
-// PSG-validated, not medical advice. The recipe was validated by its author on a SINGLE subject (n=1, 7
-// nights) against a commercial reference — it recovered deep/REM noticeably better than V1 there (kappa
-// ~0.06 → ~0.47), but the window sizes / weights may be subject-specific and need multi-subject validation
-// before they can be trusted as general. That is exactly why this is opt-in and labelled experimental.
+// HONEST HEDGING (same spirit as V1): these stages are APPROXIMATIONS, not PSG-validated, not medical
+// advice. The recipe first shipped with only its author's n=1 validation; it is now the default because a
+// 44-subject leave-one-subject-out benchmark (AAUWSS + Walch sleep-accel) showed it strictly dominates V1
+// (kappa 0.35 vs 0.03, deep recall 55% vs 1%). The per-epoch coefficients are still fixed a-priori from
+// sleep physiology + population base rates, not fit to labels.
 //
 // Where V1 runs a percentile-band classifier + median smoothing + physiology re-imposition over a
 // Cole–Kripke actigraphy grid, V2 stages each 30 s epoch from:
@@ -142,8 +143,10 @@ public enum SleepStagerV2 {
     static let baseLogPrior: [String: Double] = [
         "light": log(0.50), "deep": log(0.18), "rem": log(0.22), "awake": log(0.10)]
 
-    /// Deep is eligible only in the night's lowest ~20 % HR-flatness epochs (≈ deep base rate + margin).
-    static let deepGateThresh = 0.20
+    /// Deep is eligible only in the night's lowest ~25 % HR-flatness epochs (≈ deep base rate + margin).
+    /// Widened 0.20 -> 0.25 by the multi-subject (AAUWSS + sleep-accel LOSO) deep-boundary tune, which
+    /// recovers the deep recall the other deep-tightening edits shed while keeping precision up.
+    static let deepGateThresh = 0.25
     static let deepGateSlope = 5.0
 
     /// Motion thresholds are RELATIVE to each night's own quiescent jerk floor (the median per-second
@@ -159,7 +162,7 @@ public enum SleepStagerV2 {
     /// Transition matrix (rows = from, cols = to). Self-transitions dominate; deep↔rem rare; wake mostly
     /// to/from light. A priori, not fit.
     static let transition: [String: [String: Double]] = [
-        "deep":  ["deep": 0.90, "rem": 0.005, "light": 0.09, "awake": 0.005],
+        "deep":  ["deep": 0.86, "rem": 0.007, "light": 0.126, "awake": 0.007],
         "rem":   ["deep": 0.005, "rem": 0.88, "light": 0.10, "awake": 0.015],
         "light": ["deep": 0.06, "rem": 0.06, "light": 0.85, "awake": 0.03],
         "awake": ["deep": 0.01, "rem": 0.02, "light": 0.27, "awake": 0.70]]
@@ -433,7 +436,7 @@ public enum SleepStagerV2 {
             let zhrv = zhr(f.hr), zhvv = zhv(f.hrVar), zmvv = zmv(f.moveFrac)
             let gate = deepGateSlope * max(0.0, fpct(f.hrFlat11) - deepGateThresh)
             var em: [String: Double] = [
-                "deep": -1.4 * zhvv - 0.2 * zhrv - 0.3 * zmvv - gate + baseLogPrior["deep"]!,
+                "deep": -1.1 * zhvv - 0.5 * zmvv - gate + baseLogPrior["deep"]!,
                 "rem": 0.6 * zhvv - 0.6 * zmvv + 0.4 * zhrv + baseLogPrior["rem"]!,
                 "light": baseLogPrior["light"]!,
                 "awake": 1.0 * zmvv + 0.8 * zhvv + 0.4 * zhrv + baseLogPrior["awake"]!,

--- a/Strand/BLE/PuffinExperiment.swift
+++ b/Strand/BLE/PuffinExperiment.swift
@@ -50,15 +50,23 @@ enum PuffinExperiment {
 
     static var continuousHrvOvernightOnlyEnabled: Bool { UserDefaults.standard.bool(forKey: continuousHrvOvernightOnlyKey) }
 
-    /// Opt-in "Experimental sleep staging (V2)": re-stage each detected night with `SleepStagerV2` — a
-    /// transparent cardiorespiratory recipe (reimplemented from contributor PR #600) that recovers deep/REM
-    /// better than the shipped V1 stager on its author's n=1 validation. Pure analysis switch: it changes
-    /// ONLY which staging engine runs over an already-detected sleep window; sleep DETECTION, scoring and the
-    /// default V1 path are all untouched. Default OFF. Read at the staging call site (Repository) to pick
-    /// V1 vs V2. Mirrors the Android `PuffinExperiment.KEY_EXPERIMENTAL_SLEEP_V2`.
+    /// "Experimental sleep staging (V2)": re-stage each detected night with `SleepStagerV2` — a transparent
+    /// cardiorespiratory recipe (reimplemented from contributor PR #600) — instead of the older V1 stager.
+    /// Pure analysis switch: it changes ONLY which staging engine runs over an already-detected sleep window;
+    /// sleep DETECTION, scoring and the V1 path are all untouched. Model-agnostic (WHOOP 4 and 5). **Default
+    /// ON**: V2 was promoted to the default staging engine after a 44-subject cross-subject benchmark (AAUWSS
+    /// + Walch sleep-accel, leave-one-subject-out) showed V2 strictly dominates V1 (kappa 0.35 vs 0.03, deep
+    /// recall 55 % vs 1 %) — the multi-subject validation this recipe originally lacked. V1 remains available.
+    /// Read at the staging call site (Repository). Mirrors the Android `PuffinExperiment.KEY_EXPERIMENTAL_SLEEP_V2`.
     static let experimentalSleepV2Key = "noopExperimentalSleepV2"
 
-    static var experimentalSleepV2Enabled: Bool { UserDefaults.standard.bool(forKey: experimentalSleepV2Key) }
+    /// Default ON when the key is unset (mirrors the Android `getBoolean(KEY, true)`): a `bool(forKey:)` alone
+    /// reads a missing key as false, so an absent preference must resolve to the promoted V2 default explicitly.
+    static var experimentalSleepV2Enabled: Bool {
+        UserDefaults.standard.object(forKey: experimentalSleepV2Key) == nil
+            ? true
+            : UserDefaults.standard.bool(forKey: experimentalSleepV2Key)
+    }
 
     /// Opt-in "Auto-detect workouts": after a sync / on Today appear, scan the last day or two of HR for a
     /// SUSTAINED-ELEVATED window (resting HR + 30 bpm held ≥ 12 min) that doesn't overlap a saved workout,

--- a/Strand/Screens/SettingsView.swift
+++ b/Strand/Screens/SettingsView.swift
@@ -52,10 +52,11 @@ struct SettingsView: View {
     /// See [PuffinExperiment.continuousHrvOvernightOnlyKey].
     @AppStorage(PuffinExperiment.continuousHrvOvernightOnlyKey) private var continuousHrvOvernightOnly = false
 
-    /// Opt-in "Experimental sleep staging (V2)" (off by default). When on, detected nights are re-staged with
-    /// `SleepStagerV2` (the transparent cardiorespiratory recipe) instead of the default V1 stager. Read at
-    /// the staging call site in `Repository`. See [PuffinExperiment.experimentalSleepV2Key].
-    @AppStorage(PuffinExperiment.experimentalSleepV2Key) private var experimentalSleepV2Enabled = false
+    /// "Experimental sleep staging (V2)" (ON by default, promoted after the 44-subject cross-subject
+    /// benchmark). When on, detected nights are re-staged with `SleepStagerV2` (the transparent
+    /// cardiorespiratory recipe) instead of the older V1 stager. Read at the staging call site in
+    /// `Repository`. See [PuffinExperiment.experimentalSleepV2Key].
+    @AppStorage(PuffinExperiment.experimentalSleepV2Key) private var experimentalSleepV2Enabled = true
 
     // Imperial/Metric display preference (D#103). Stored data is always SI; this only changes how
     // distances/weights/heights/temperatures are SHOWN — and lets the profile fields below take
@@ -1207,24 +1208,25 @@ struct SettingsView: View {
         }
     }
 
-    /// Opt-in experimental sleep staging (V2). Model-agnostic — the V2 recipe works on WHOOP 4 and 5 — so it
-    /// renders on every strap, separate from the 5/MG probe card. Default OFF; flipping it on re-stages
-    /// future (and re-derived) nights with `SleepStagerV2`. The default V1 stager is untouched.
+    /// Sleep staging engine. V2 (the transparent cardiorespiratory recipe) is the DEFAULT after a 44-subject
+    /// cross-subject benchmark; model-agnostic — it works on WHOOP 4 and 5 — so it renders on every strap.
+    /// Turning the toggle OFF falls back to the older V1 percentile-band stager; either way only future
+    /// (and re-derived) nights are affected.
     private var sleepStagingCard: some View {
         SettingsSection(
             icon: "bed.double.fill",
-            title: "Experimental · Sleep staging",
-            blurb: "How NOOP splits a night into light / deep / REM. This is a separate, opt-in recipe. Your default staging is unchanged unless you turn it on."
+            title: "Sleep staging",
+            blurb: "How NOOP splits a night into light / deep / REM. The V2 recipe is the default; turn it off to fall back to the older V1 staging."
         ) {
             VStack(alignment: .leading, spacing: NoopMetrics.rowSpacing) {
                 Toggle(isOn: $experimentalSleepV2Enabled) {
-                    Text("Experimental sleep staging (V2)")
+                    Text("Sleep staging (V2)")
                         .font(StrandFont.subhead)
                         .foregroundStyle(StrandPalette.textPrimary)
                 }
                 .toggleStyle(.switch)
                 .tint(StrandPalette.accent)
-                Text("A transparent cardiorespiratory recipe that recovers deep and REM better than the default staging. Opt-in and experimental: it only changes how already-detected nights are split into stages (detection and scores are unchanged), and the default staging stays in place if you leave this off. Takes effect on the next nights staged.")
+                Text("A transparent cardiorespiratory recipe that recovers deep and REM better than the older V1 staging, and is now the default. It only changes how already-detected nights are split into stages (detection and scores are unchanged); turn it off to fall back to V1. Takes effect on the next nights staged.")
                     .font(StrandFont.caption)
                     .foregroundStyle(StrandPalette.textTertiary)
                     .fixedSize(horizontal: false, vertical: true)

--- a/Strand/Screens/TestCentreView.swift
+++ b/Strand/Screens/TestCentreView.swift
@@ -33,7 +33,7 @@ struct TestCentreView: View {
 
     // Section 4: the experimental toggles, on the SAME @AppStorage keys as SettingsView (preserved per
     // spec section 10), so toggling here and there is one and the same setting.
-    @AppStorage(PuffinExperiment.experimentalSleepV2Key) private var experimentalSleepV2Enabled = false
+    @AppStorage(PuffinExperiment.experimentalSleepV2Key) private var experimentalSleepV2Enabled = true
     @AppStorage(PuffinExperiment.keepRealtimeForDataKey) private var continuousHrvEnabled = false
     @AppStorage(PuffinExperiment.defaultsKey) private var puffinExperiments = false
     @AppStorage(PuffinExperiment.deepDataKey) private var deepDataEnabled = false
@@ -237,7 +237,7 @@ struct TestCentreView: View {
 
                 // Model-agnostic advanced toggles (shown on every strap), same @AppStorage keys as Settings.
                 Toggle(isOn: $experimentalSleepV2Enabled) {
-                    Text("Experimental sleep staging (V2)")
+                    Text("Sleep staging (V2)")
                         .font(StrandFont.subhead).foregroundStyle(StrandPalette.textPrimary)
                 }
                 .toggleStyle(.switch).tint(StrandPalette.accent)

--- a/android/app/src/main/java/com/noop/analytics/SleepStagerV2.kt
+++ b/android/app/src/main/java/com/noop/analytics/SleepStagerV2.kt
@@ -13,8 +13,9 @@ import kotlin.math.sin
 import kotlin.math.sqrt
 
 /*
- * SleepStagerV2.kt — an OPT-IN, EXPERIMENTAL alternative sleep-staging recipe, offered ALONGSIDE the
- * shipped [SleepStager] (V1) rather than replacing it. V1 stays the default and is UNTOUCHED.
+ * SleepStagerV2.kt — the DEFAULT sleep-staging recipe. It became the default over the older percentile-band
+ * stager [SleepStager] (V1) after a 44-subject cross-subject benchmark; V1 stays available behind the
+ * PuffinExperiment flag.
  *
  * Byte-identical-logic Kotlin twin of StrandAnalytics/SleepStagerV2.swift, itself reimplemented clean from
  * the contributor recipe in NoopApp/noop PR #600 (sunny-noop). We took only the per-session STAGING engine,
@@ -22,11 +23,11 @@ import kotlin.math.sqrt
  * entirely from V1 — this file only re-stages a window someone already decided is sleep, so it is a true
  * drop-in for [SleepStager.stageSession]: SAME signature, SAME List<StageSegment> return shape.
  *
- * HONEST HEDGING (same spirit as V1, plus the PR's own caveat): these stages are APPROXIMATIONS, not
- * PSG-validated, not medical advice. The recipe was validated by its author on a SINGLE subject (n=1, 7
- * nights) — it recovered deep/REM noticeably better than V1 there, but the window sizes / weights may be
- * subject-specific and need multi-subject validation before they can be trusted as general. That is exactly
- * why this is opt-in and labelled experimental.
+ * HONEST HEDGING (same spirit as V1): these stages are APPROXIMATIONS, not PSG-validated, not medical
+ * advice. The recipe first shipped with only its author's n=1 validation; it is now the default because a
+ * 44-subject leave-one-subject-out benchmark (AAUWSS + Walch sleep-accel) showed it strictly dominates V1
+ * (kappa 0.35 vs 0.03, deep recall 55% vs 1%). The per-epoch coefficients are still fixed a-priori from
+ * sleep physiology + population base rates, not fit to labels.
  *
  * Recipe (per 30 s epoch, all coefficients fixed a-priori from sleep physiology + population base rates,
  * NOT fit to labels):
@@ -162,8 +163,10 @@ object SleepStagerV2 {
     private val baseLogPrior: Map<String, Double> = mapOf(
         "light" to ln(0.50), "deep" to ln(0.18), "rem" to ln(0.22), "awake" to ln(0.10))
 
-    /** Deep is eligible only in the night's lowest ~20 % HR-flatness epochs (≈ deep base rate + margin). */
-    private const val deepGateThresh = 0.20
+    /** Deep is eligible only in the night's lowest ~25 % HR-flatness epochs (≈ deep base rate + margin).
+     *  Widened 0.20 -> 0.25 by the multi-subject (AAUWSS + sleep-accel LOSO) deep-boundary tune, which
+     *  recovers the deep recall the other deep-tightening edits shed while keeping precision up. */
+    private const val deepGateThresh = 0.25
     private const val deepGateSlope = 5.0
 
     /** Motion thresholds are RELATIVE to each night's own quiescent jerk floor (median per-second jerk over
@@ -178,7 +181,7 @@ object SleepStagerV2 {
     /** Transition matrix (rows = from, cols = to). Self-transitions dominate; deep↔rem rare; wake mostly
      *  to/from light. A priori, not fit. */
     private val transition: Map<String, Map<String, Double>> = mapOf(
-        "deep" to mapOf("deep" to 0.90, "rem" to 0.005, "light" to 0.09, "awake" to 0.005),
+        "deep" to mapOf("deep" to 0.86, "rem" to 0.007, "light" to 0.126, "awake" to 0.007),
         "rem" to mapOf("deep" to 0.005, "rem" to 0.88, "light" to 0.10, "awake" to 0.015),
         "light" to mapOf("deep" to 0.06, "rem" to 0.06, "light" to 0.85, "awake" to 0.03),
         "awake" to mapOf("deep" to 0.01, "rem" to 0.02, "light" to 0.27, "awake" to 0.70))
@@ -466,7 +469,7 @@ object SleepStagerV2 {
             val zhrv = zhr(f.hr); val zhvv = zhv(f.hrVar); val zmvv = zmv(f.moveFrac)
             val gate = deepGateSlope * maxOf(0.0, fpct(f.hrFlat11) - deepGateThresh)
             val em = HashMap<String, Double>()
-            em["deep"] = -1.4 * zhvv - 0.2 * zhrv - 0.3 * zmvv - gate + baseLogPrior["deep"]!!
+            em["deep"] = -1.1 * zhvv - 0.5 * zmvv - gate + baseLogPrior["deep"]!!
             em["rem"] = 0.6 * zhvv - 0.6 * zmvv + 0.4 * zhrv + baseLogPrior["rem"]!!
             em["light"] = baseLogPrior["light"]!!
             em["awake"] = 1.0 * zmvv + 0.8 * zhvv + 0.4 * zhrv + baseLogPrior["awake"]!!

--- a/android/app/src/main/java/com/noop/ble/PuffinExperiment.kt
+++ b/android/app/src/main/java/com/noop/ble/PuffinExperiment.kt
@@ -50,10 +50,13 @@ class PuffinExperiment(private val prefs: SharedPreferences) {
      *  [com.noop.analytics.SleepStagerV2] (the transparent cardiorespiratory recipe, reimplemented from
      *  contributor PR #600) instead of the default V1 [com.noop.analytics.SleepStager]. Pure analysis switch
      *  — it changes ONLY which staging engine runs over an already-detected sleep window; detection, scoring
-     *  and the default V1 path are untouched. Model-agnostic (works on WHOOP 4 and 5). Default false.
+     *  and the default V1 path are untouched. Model-agnostic (works on WHOOP 4 and 5). **Default true**:
+     *  V2 was promoted to the default staging engine after a 44-subject cross-subject benchmark (AAUWSS +
+     *  Walch sleep-accel, leave-one-subject-out) showed V2 strictly dominates V1 (kappa 0.35 vs 0.03, deep
+     *  recall 55% vs 1%) — the multi-subject validation this recipe originally lacked. V1 remains available.
      *  Mirrors the macOS `PuffinExperiment.experimentalSleepV2Key`. */
     var experimentalSleepV2: Boolean
-        get() = prefs.getBoolean(KEY_EXPERIMENTAL_SLEEP_V2, false)
+        get() = prefs.getBoolean(KEY_EXPERIMENTAL_SLEEP_V2, true)
         set(v) = prefs.edit().putBoolean(KEY_EXPERIMENTAL_SLEEP_V2, v).apply()
 
     companion object {

--- a/android/app/src/main/java/com/noop/ui/SettingsScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/SettingsScreen.kt
@@ -1707,14 +1707,15 @@ fun SettingsScreen(
             blurb = "A read-only export of the decoded sensor streams NOOP already stores. Works on any strap. Nothing is written to your device, and nothing is uploaded.",
         ) {
             Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
-                // --- Experimental sleep staging (V2) — opt-in, default OFF, every model. (V7 Pillar 3b) ---
+                // --- Sleep staging (V2) — the DEFAULT engine after the 44-subject benchmark; toggle off to
+                //     fall back to V1. Every model. (V7 Pillar 3b) ---
                 Row(
                     modifier = Modifier.fillMaxWidth(),
                     verticalAlignment = Alignment.CenterVertically,
                     horizontalArrangement = Arrangement.spacedBy(16.dp),
                 ) {
                     Text(
-                        "Experimental sleep staging (V2)",
+                        "Sleep staging (V2)",
                         style = NoopType.subhead,
                         color = Palette.textPrimary,
                         modifier = Modifier.weight(1f),
@@ -1733,15 +1734,15 @@ fun SettingsScreen(
                             uncheckedBorderColor = Palette.hairline,
                         ),
                         modifier = Modifier.semantics {
-                            contentDescription = "Experimental sleep staging V2"
+                            contentDescription = "Sleep staging V2"
                         },
                     )
                 }
                 Text(
-                    "A transparent cardiorespiratory recipe that recovers deep and REM better than the " +
-                        "default staging. Opt-in and experimental: it only changes how already-detected " +
-                        "nights are split into stages (detection and scores are unchanged), and the default " +
-                        "staging stays in place if you leave this off. Takes effect on the next nights staged.",
+                    "A transparent cardiorespiratory recipe that recovers deep and REM better than the older " +
+                        "V1 staging, and is now the default. It only changes how already-detected nights are " +
+                        "split into stages (detection and scores are unchanged); turn it off to fall back to " +
+                        "V1. Takes effect on the next nights staged.",
                     style = NoopType.caption,
                     color = Palette.textTertiary,
                 )


### PR DESCRIPTION
Promotes the transparent Sleep V2 recipe (from #600) from opt-in to the default staging engine, and tunes its deep boundary. V1 stays available behind the flag. This is the staging half of the sleep-tracking work; the companion detection fix (recovering nights that were dropped whole on an HR spike) already merged in #268, so both V1 and V2 now detect every night.

## Before / after

Per-epoch, cross-subject leave-one-subject-out, run through the real shipped stager (not a reimplementation) on two public wrist datasets with PSG ground truth: AAUWSS (13 subjects, E4 wrist + gold PSG-ECG R-R + AASM labels) and Walch 2019 sleep-accel (31 subjects). BEFORE is the current default (V1 staging). AFTER is what this PR makes the default (V2 staging).

| metric | BEFORE (V1 default) | AFTER (V2 default) |
|---|---|---|
| Cohen kappa, AAUWSS | 0.039 | **0.415** |
| Cohen kappa, sleep-accel | 0.089 | **0.352** |
| sleep/wake, AAUWSS | 86.4 % | **88.7 %** |
| sleep/wake, sleep-accel | 88.8 % | **91.3 %** |
| 4-class acc, AAUWSS | 44.3 % | **59.4 %** |
| 4-class acc, sleep-accel | 50.6 % | **58.1 %** |
| deep recall, AAUWSS | 1 % | **62 %** |
| deep recall, sleep-accel | 9 % | **60 %** |

V1's near-zero kappa and 1 % deep recall are the flat, deep-poor hypnograms users see today. V2 recovers deep and REM. V1 stays available behind the same flag for anyone who prefers it.

V2 shipped opt-in because it had only n=1 validation. The 44-subject benchmark above is the multi-subject validation it lacked, and it shows V2 strictly dominates V1 on every metric on both datasets.

## The deep-boundary tune

On the same benchmark, V2's deep boundary is tuned with parity-safe constant edits (set a-priori from physiology and population base rates, none fit to labels):

- `deepGateThresh` 0.20 to 0.25 (recover the deep recall the tighter edits shed)
- deep emission `-1.4*zhvv - 0.2*zhrv - 0.3*zmvv` to `-1.1*zhvv - 0.5*zmvv` (drop the mean-HR term; HR-variability and movement carry deep)
- deep transition row `deep .90` to `.86` (renormalises to rem .007 / light .126 / awake .007)

Isolated impact (untuned to tuned V2, same detection): kappa +0.018 (AAUWSS) / +0.027 (sleep-accel), 4-class +1.9 / +2.6, sleep/wake flat, deep precision up. Nothing slid.

## Parity and tests

Byte-identical Kotlin and Swift: `SleepStagerV2.kt` / `SleepStagerV2.swift` match on deepGateThresh, the transition row, and the deep emission. The promote resolves a missing preference to the V2 default on both platforms (Android `getBoolean(KEY, true)`; macOS an explicit nil-key check before `bool(forKey:)`), the two `@AppStorage` defaults are `true`, and the Settings and Test Centre copy is updated so it no longer describes V2 as opt-in / off by default. The V2 tests are property-based (segments tile the window, canonical stage labels, deep and REM present, cycle-prior monotonicity) and pass unchanged. Kotlin compiles and tests pass; the Swift package build needs macOS, so please confirm the `swift test` leg in CI.

## Scope and notes

- Pure analysis switch. Sleep DETECTION, scoring, and the V1 code path are untouched; the same detected window is simply staged by V2. Model-agnostic (WHOOP 4 and 5).
- The per-epoch V2 coefficients remain a fixed, transparent recipe. This is not a trained model.
- With #249's Apple-Health sleep-stage writeback on iOS, making V2 the default means the richer V2 deep/REM stages now flow to Apple Health.
