### PR TITLE
feat(today/ios): active history-sync pulse on the header status light (#245)

### DIFF
--- a/Strand/Screens/TodayView.swift
+++ b/Strand/Screens/TodayView.swift
@@ -4306,6 +4306,9 @@ private struct RecordingStatusLight: View {
     let selectedDayOffset: Int
     let onTap: () -> Void
 
+    /// Drives the syncing pulse; toggled in `.task` while an offload runs (never during body eval).
+    @State private var pulsing = false
+
     /// Colour for the light: green recording, amber last-synced, red not recording, accent for
     /// experimental history. Mirrors the prior `TodayView.recordingHue` semantics verbatim.
     private func hue(_ state: RecordingState) -> Color {
@@ -4322,17 +4325,50 @@ private struct RecordingStatusLight: View {
         // A live recording state colours the dot (green / amber / red); a past day (no state) shows a muted
         // dot and the chip is non-actionable, recording status only means something for today.
         let state = TodayView.recordingState(live: live, selectedDayOffset: selectedDayOffset)
+        // #245: while the strap is actively offloading history, surface a visible SYNC indicator right in
+        // the header (users otherwise only saw progress under More → Live). This reads `live.backfilling`
+        // directly rather than adding a `RecordingState` case, so the pure mapper + its Kotlin twin stay
+        // untouched — a UI-only accent pulse, gated to today (a past day never syncs). The dot keeps its
+        // recording hue underneath; an expanding accent ring says "handing over history now".
+        let syncing = live.backfilling && selectedDayOffset == 0
         Button(action: onTap) {
             Circle().fill(StrandPalette.surfaceInset)
                 .frame(width: 36, height: 36)
-                .overlay(Circle()
-                    .fill(state.map(hue) ?? StrandPalette.textTertiary.opacity(0.4))
-                    .frame(width: 10, height: 10))
+                .overlay {
+                    if syncing {
+                        // Expanding, fading accent ring behind a steady accent dot — a "pulling data" beat.
+                        Circle()
+                            .stroke(StrandPalette.accent, lineWidth: 2)
+                            .frame(width: 10, height: 10)
+                            .scaleEffect(pulsing ? 2.6 : 1.0)
+                            .opacity(pulsing ? 0.0 : 0.9)
+                        Circle().fill(StrandPalette.accent).frame(width: 10, height: 10)
+                    } else {
+                        Circle()
+                            .fill(state.map(hue) ?? StrandPalette.textTertiary.opacity(0.4))
+                            .frame(width: 10, height: 10)
+                    }
+                }
                 .contentShape(Circle())
         }
         .buttonStyle(.plain)
-        .disabled(state == nil)
-        .accessibilityLabel(state?.accessibilityText ?? String(localized: "Recording status, not shown for a past day"))
+        .disabled(state == nil && !syncing)
+        .accessibilityLabel(syncing ? syncingAccessibilityLabel
+            : (state?.accessibilityText ?? String(localized: "Recording status, not shown for a past day")))
+        // Run the repeating pulse only while syncing; the `.task(id:)` auto-cancels when the flag flips,
+        // so there is no timer left running once the offload ends (or Today goes away).
+        .task(id: syncing) {
+            guard syncing else { pulsing = false; return }
+            withAnimation(.easeOut(duration: 1.1).repeatForever(autoreverses: false)) { pulsing = true }
+        }
+    }
+
+    /// VoiceOver read-out while offloading: names the running chunk count so it matches the Live badge.
+    private var syncingAccessibilityLabel: String {
+        let n = live.syncChunksThisSession
+        return n > 0
+            ? String(localized: "Syncing strap history, chunk \(n)")
+            : String(localized: "Syncing strap history")
     }
 }
 


### PR DESCRIPTION
## What this PR does

Adds a visible **active history-sync indicator** to the iOS Today header, addressing #245.

Previously the only place a running offload showed progress was **More → Live**. On the Today header the `RecordingStatusLight` stayed on its static hue, so users had no in-context signal that a sync was happening — especially on a **WHOOP 5.0**, where offloads are rare and easy to miss.

While `LiveState.backfilling` is true (today only), the 36pt header status light now shows an **expanding, fading accent ring** behind a steady accent dot — a "pulling history now" beat. VoiceOver reads **"Syncing strap history, chunk N"** from `syncChunksThisSession`, matching the Live "SYNCING N" badge.

Deliberately minimal: it reads `live.backfilling` **directly in the view** rather than adding a `RecordingState` case, so the pure mapper and its **Kotlin twin stay untouched** — this is UI-only, no analytics/parity change. The pulse runs under `.task(id:)` so it auto-cancels when the offload ends (no leaked timer), and is gated to `selectedDayOffset == 0` so a past day never pulses.

## Type of change

- [x] New feature

## How it was tested

- **macOS reference target compiles** (`xcodebuild -project Strand.xcodeproj -scheme Strand -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO build` → **BUILD SUCCEEDED**). `RecordingStatusLight` lives in shared `TodayView.swift`, so the macOS build type-checks the change; note the default `app-build.yml` is disabled, so this app-target Swift isn't covered by CI.
- **Not yet confirmed on hardware:** the pulse is driven by the live BLE backfill flag, which can't be exercised without a real strap offloading history. Needs an on-device confirmation during an actual history offload (ideally a WHOOP 4.0, which offloads on every reconnect).

## Checklist

- [x] Swift package tests pass for any package I touched — n/a, no `Packages/**` change
- [x] Android unit tests pass if I touched `android/` — n/a, no `android/` change (UI-only, mapper + Kotlin twin untouched)
- [x] No new build warnings introduced
- [x] UI changes use only `StrandDesign` tokens — no hardcoded colors, fonts, or spacing
- [x] No hardcoded hex frame bytes; protocol facts live in the schema / decoders — n/a
- [x] Follows the conventions in [`docs/CONTRIBUTING.md`](../docs/CONTRIBUTING.md)
- [x] I did not commit generated output (`Strand.xcodeproj/`) or any secrets/keystores

## Related issues

Addresses #245
