### PR TITLE
fix(today): explain an empty Charge caused by the Deep-sleep HRV window (#233)

### DIFF
--- a/Strand/Screens/ChargeBreakdownFormat.swift
+++ b/Strand/Screens/ChargeBreakdownFormat.swift
@@ -146,6 +146,30 @@ enum ChargeBreakdownFormat {
         case .warmer:  return String(localized: "Warmer than your baseline")
         }
     }
+
+    // MARK: - Deep-sleep HRV window gap (#233)
+
+    /// True when a night's empty Charge is explained by the Deep-sleep HRV window finding no deep-stage
+    /// sleep, rather than a generic missing-data gap. Charge needs a nightly HRV value (`avgHrv`); under
+    /// the Deep window that value pools RMSSD over 5-min deep-stage windows only and is nil when the
+    /// night banks under ~5 minutes of deep sleep (WHOOP 4.0 deep staging is often sparse/absent).
+    /// `deepMin` is the night's OWN already-computed deep-sleep minutes, so this is a read-only
+    /// presentation check over existing fields, not a new analytics path. Pure.
+    static func chargeDeepWindowGap(hrvWindow: HrvWindow, avgHrv: Double?, deepMin: Double?) -> Bool {
+        hrvWindow == .deep && avgHrv == nil && (deepMin ?? 0) < 5
+    }
+
+    /// The short title for the #233 deep-window gap note.
+    static let chargeDeepWindowGapTitle = String(localized: "No deep sleep detected")
+
+    /// The explanatory detail + next step: names the cause (Deep window, no deep sleep that night) and
+    /// the two ways out, rather than leaving an unexplained blank ring.
+    static let chargeDeepWindowGapDetail = String(localized: "The Deep sleep HRV window needs a night with deep-stage sleep to score Charge. Switch to Whole night in Settings, or wait for a night with more deep sleep.")
+
+    /// VoiceOver plain string (title + detail).
+    static var chargeDeepWindowGapAccessibility: String {
+        "\(chargeDeepWindowGapTitle). \(chargeDeepWindowGapDetail)"
+    }
 }
 
 // MARK: - A3: confidence dot + tier tag pill

--- a/Strand/Screens/TodayView.swift
+++ b/Strand/Screens/TodayView.swift
@@ -209,6 +209,10 @@ struct TodayView: View {
     // Effort display scale (#268), drives the Effort tile's value + caption. Display-only.
     @AppStorage(UnitPrefs.effortScaleKey) private var effortScaleRaw = EffortScale.hundred.rawValue
     private var effortScale: EffortScale { UnitPrefs.resolveEffortScale(effortScaleRaw) }
+    // #233: the HRV window setting, read here only to explain (never recompute) an empty Charge ring
+    // caused by the Deep window finding no deep-stage sleep. Same key/default SettingsView reads.
+    @AppStorage(UnitPrefs.hrvWindowKey) private var hrvWindowRaw = HrvWindow.whole.rawValue
+    private var hrvWindow: HrvWindow { HrvWindow(rawValue: hrvWindowRaw) ?? .whole }
 
     // Editable Key-Metrics layout (#251), an ordered list of the enabled tiles, persisted display-only.
     // Empty/unset shows the full default order. The "Edit" affordance on the section opens a local sheet.
@@ -1629,15 +1633,22 @@ struct TodayView: View {
             // banner sandwiched above the rings. The three clean rings lead the screen directly.
             scoreHeroRow(d: d, score: score)
 
-            // Component 2, when Charge has no real today value, an explained state with its detail +
-            // next step replaces a bare blank, sitting directly under the rings. The CALIBRATING case is
-            // already richly explained by the data-confidence pill + calibration Synthesis card + the ring
-            // overlay below, so the note shows for the two states the existing UI doesn't spell out a next
-            // step for, "Last night · <date>" (carry-over) and "Needs the strap", keeping the hero from
-            // saying "calibrating" twice in two phrasings. `.scored` renders nothing (the ring has the
-            // value). TODAY-only: the "No data for today" copy would be wrong on a navigated past day, and
-            // a past day with no score is missing data the user can't act on now, so it keeps a bare ring.
-            if selectedDayOffset == 0 && !chargeScoreState.isCalibrating {
+            // #233: when THIS specific day's empty Charge is explained by the Deep-sleep HRV window
+            // finding no deep-stage sleep, say so plainly instead of an unexplained blank ring. Checked
+            // BEFORE the generic Component-2 note (and on every day, not just today): unlike an ordinary
+            // "missing data" gap, here the exact cause and the fix are known, so a past day gets the same
+            // honest explanation rather than the usual silent bare ring.
+            if chargeDeepWindowGap {
+                chargeDeepWindowGapNote
+            } else if selectedDayOffset == 0 && !chargeScoreState.isCalibrating {
+                // Component 2, when Charge has no real today value, an explained state with its detail +
+                // next step replaces a bare blank, sitting directly under the rings. The CALIBRATING case is
+                // already richly explained by the data-confidence pill + calibration Synthesis card + the ring
+                // overlay below, so the note shows for the two states the existing UI doesn't spell out a next
+                // step for, "Last night · <date>" (carry-over) and "Needs the strap", keeping the hero from
+                // saying "calibrating" twice in two phrasings. `.scored` renders nothing (the ring has the
+                // value). TODAY-only: the "No data for today" copy would be wrong on a navigated past day, and
+                // a past day with no score is missing data the user can't act on now, so it keeps a bare ring.
                 explainedScoreNote(chargeScoreState)
             }
 
@@ -1662,6 +1673,40 @@ struct TodayView: View {
                     .transition(.opacity.combined(with: .scale(scale: 0.97)))
             }
         }
+    }
+
+    /// #233: whether the SELECTED day's empty Charge is explained by the Deep-sleep HRV window finding no
+    /// deep-stage sleep that night (see `ChargeBreakdownFormat.chargeDeepWindowGap`). Reads only fields
+    /// `displayDay` already carries (`avgHrv`, `deepMin`) — no recompute, no new analytics.
+    private var chargeDeepWindowGap: Bool {
+        guard let d = displayDay, d.recovery == nil else { return false }
+        return ChargeBreakdownFormat.chargeDeepWindowGap(hrvWindow: hrvWindow, avgHrv: d.avgHrv, deepMin: d.deepMin)
+    }
+
+    /// #233: the Deep-sleep HRV-window gap note, shown instead of a bare "-" when this specific day's
+    /// Charge is empty because the Deep window found no deep-stage sleep. Distinct from the generic
+    /// calibrating/needs-strap states because here the exact cause and fix are known, so it says so, on
+    /// today AND a navigated past day alike.
+    private var chargeDeepWindowGapNote: some View {
+        NoopCard(padding: 14, tint: StrandPalette.chargeColor) {
+            HStack(alignment: .top, spacing: 12) {
+                Image(systemName: "moon.zzz")
+                    .font(.system(size: 16, weight: .semibold))
+                    .foregroundStyle(StrandPalette.chargeColor)
+                    .accessibilityHidden(true)
+                VStack(alignment: .leading, spacing: 3) {
+                    Text(ChargeBreakdownFormat.chargeDeepWindowGapTitle)
+                        .font(StrandFont.headline)
+                        .foregroundStyle(StrandPalette.textPrimary)
+                    Text(ChargeBreakdownFormat.chargeDeepWindowGapDetail)
+                        .font(StrandFont.subhead)
+                        .foregroundStyle(StrandPalette.textSecondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+            }
+        }
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(ChargeBreakdownFormat.chargeDeepWindowGapAccessibility)
     }
 
     /// A4 , the Charge calibrating countdown callout. `banked` is the existing `recoveryCalibration`
@@ -1716,9 +1761,13 @@ struct TodayView: View {
                 VStack(alignment: .leading, spacing: NoopMetrics.sectionGap) {
                     let drivers = chargeDrivers
                     if drivers.isEmpty {
-                        // A calibrating / cold-start night has no contributions to attribute: tap through to
-                        // the honest countdown rather than an empty breakdown.
-                        if let banked = recoveryCalibration {
+                        // #233: a night with no deep sleep under the Deep HRV window has a known, specific
+                        // cause, so it tap-throughs to that explanation rather than the generic empty note.
+                        if chargeDeepWindowGap {
+                            chargeDeepWindowGapNote
+                        } else if let banked = recoveryCalibration {
+                            // A calibrating / cold-start night has no contributions to attribute: tap through
+                            // to the honest countdown rather than an empty breakdown.
                             chargeCalibrationCountdown(banked: banked)
                         } else {
                             chargeBreakdownEmptyNote

--- a/StrandTests/ChargeBreakdownFormatTests.swift
+++ b/StrandTests/ChargeBreakdownFormatTests.swift
@@ -130,4 +130,22 @@ final class ChargeBreakdownFormatTests: XCTestCase {
         XCTAssertEqual(ChargeBreakdownFormat.skinTempTierWord(.typical), "Typical for you")
         XCTAssertEqual(ChargeBreakdownFormat.skinTempTierWord(.warmer), "Warmer than your baseline")
     }
+
+    // MARK: - Deep-sleep HRV window gap (#233)
+
+    func testChargeDeepWindowGapTrueOnlyForDeepWindowNilHrvAndNoDeepSleep() {
+        // The gap: Deep window selected, no HRV computed, and under ~5 minutes of deep sleep that night.
+        XCTAssertTrue(ChargeBreakdownFormat.chargeDeepWindowGap(hrvWindow: .deep, avgHrv: nil, deepMin: 0))
+        XCTAssertTrue(ChargeBreakdownFormat.chargeDeepWindowGap(hrvWindow: .deep, avgHrv: nil, deepMin: nil))
+        XCTAssertTrue(ChargeBreakdownFormat.chargeDeepWindowGap(hrvWindow: .deep, avgHrv: nil, deepMin: 4.9))
+
+        // Whole-night window: never the deep-window gap, regardless of HRV/deep-sleep values.
+        XCTAssertFalse(ChargeBreakdownFormat.chargeDeepWindowGap(hrvWindow: .whole, avgHrv: nil, deepMin: 0))
+
+        // HRV present: Charge isn't actually empty, so this isn't the gap.
+        XCTAssertFalse(ChargeBreakdownFormat.chargeDeepWindowGap(hrvWindow: .deep, avgHrv: 55.0, deepMin: 0))
+
+        // Enough deep sleep banked: the nil (if any) has some other cause, not "no deep sleep".
+        XCTAssertFalse(ChargeBreakdownFormat.chargeDeepWindowGap(hrvWindow: .deep, avgHrv: nil, deepMin: 12.0))
+    }
 }


### PR DESCRIPTION
## What this PR does

Fixes #233 per the direction picked on the issue (**option 3, UI-only**): explain an empty Charge ring instead of leaving an unexplained "-".

**Root cause** (posted on the issue first, for maintainer input): Charge needs a nightly HRV value. Under the **Deep sleep** HRV window, that value pools RMSSD over deep-stage windows only and is `nil` when a night banks under ~5 minutes of deep sleep — common on a **WHOOP 4.0**, where deep staging is often sparse/absent. The ring then showed a bare `-` with no explanation, on today *and* on every past night that got re-scored `nil` by the window switch (confirmed by @japothek: "all my past days do not show Charge anymore", and it persisted for them even after switching back to Whole night — consistent with the HRV baseline still rebuilding after a run of `nil` nights).

**The fix:** `ChargeBreakdownFormat.chargeDeepWindowGap` (pure, unit-tested) detects the specific case — Deep window selected, no HRV, under ~5 min of deep sleep — by reading two fields the day's `DailyMetric` already carries (`avgHrv`, `deepMin`). No analytics recompute, no score change, no new engine path. When it fires, Today shows a **"No deep sleep detected"** note with the two ways out (switch back to Whole night, or wait for a deeper night):
- On the hero ring, ahead of the generic calibrating/needs-strap explanation.
- In the Charge breakdown sheet (tap-through), ahead of the generic empty note.
- On **today and on a navigated past day alike** — unlike the existing generic per-day note, which is intentionally silent on past days (a past day with no score is normally just "missing data"), here the exact cause is known, so it's surfaced instead of staying silent.

**No Kotlin change**: this is presentation only. The pure mapper it's built from, and the underlying HRV computation, are untouched on both platforms.

## Type of change

- [x] Bug fix

## How it was tested

- **macOS reference target compiles** (`xcodebuild -project Strand.xcodeproj -scheme Strand -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO build` → BUILD SUCCEEDED). `app-build.yml` is disabled by default, so this app-target Swift isn't covered by CI.
- **New unit test** `ChargeBreakdownFormatTests.testChargeDeepWindowGapTrueOnlyForDeepWindowNilHrvAndNoDeepSleep` covers the pure gate: true only for (Deep window, nil HRV, <5min deep sleep); false for Whole-night window, non-nil HRV, or enough deep sleep. Ran via `xcodebuild … test -only-testing:StrandTests/ChargeBreakdownFormatTests -testLanguage en -testRegion US` → all 13 tests in the file pass.
  - Note for reviewers on another non-English machine: the pre-existing tests in this file (and two unrelated ones in `TodayExplainabilityTests`) fail under a non-en system locale / certain toolchain `LocalizedStringKey` internals — pass `-testLanguage en -testRegion US` (or run on an en-US machine) to get a clean signal. Confirmed pre-existing on `main`, unrelated to this change.
- Not BLE-path work; no hardware testing needed. No `Packages/**` or `android/` change.

## Checklist

- [x] Swift package tests pass for any package I touched — n/a, no `Packages/**` change
- [x] Android unit tests pass if I touched `android/` — n/a, no `android/` change (UI-only)
- [x] No new build warnings introduced
- [x] UI changes use only `StrandDesign` tokens — no hardcoded colors, fonts, or spacing
- [x] No hardcoded hex frame bytes; protocol facts live in the schema / decoders — n/a
- [x] Follows the conventions in [`docs/CONTRIBUTING.md`](../docs/CONTRIBUTING.md)
- [x] I did not commit generated output (`Strand.xcodeproj/`) or any secrets/keystores

## Related issues

Fixes #233
