### PR TITLE
ble: surface unauthorized/off/unsupported Bluetooth instead of a silent no-op (#280)

### DIFF
--- a/Strand/BLE/BLEManager.swift
+++ b/Strand/BLE/BLEManager.swift
@@ -2775,10 +2775,13 @@ extension BLEManager: @preconcurrency CBCentralManagerDelegate {
             // iOS+macOS up to that parity rather than adding a new behaviour.
             switch central.state {
             case .unauthorized:
+                // #295: an unsigned/ad-hoc build's code identity changes on every release, so a Bluetooth
+                // toggle that already reads "on" from a PRIOR build's grant may not carry over — the
+                // message needs to tell the user to re-toggle it, not just check that it's on.
                 #if os(macOS)
-                state.lastSyncError = "NOOP isn't allowed to use Bluetooth. Turn it on in System Settings → Privacy & Security → Bluetooth, then reopen NOOP."
+                state.lastSyncError = "NOOP isn't allowed to use Bluetooth. Open System Settings → Privacy & Security → Bluetooth — if NOOP is already listed there, toggle it off and back on (a new NOOP build needs a fresh grant), then quit and reopen NOOP."
                 #else
-                state.lastSyncError = "NOOP isn't allowed to use Bluetooth. Turn it on in iPhone Settings → NOOP → Bluetooth, then reopen NOOP."
+                state.lastSyncError = "NOOP isn't allowed to use Bluetooth. Open iPhone Settings → NOOP → Bluetooth — if it's already on, toggle it off and back on, then quit and reopen NOOP."
                 #endif
                 log("Bluetooth permission not granted (unauthorized) — cannot scan or connect")
                 radioStateErrorShown = true

--- a/Strand/BLE/BLEManager.swift
+++ b/Strand/BLE/BLEManager.swift
@@ -651,6 +651,10 @@ public final class BLEManager: NSObject, ObservableObject {
     /// Non-nil signals that `centralManagerDidUpdateState` should reconnect this
     /// specific peripheral rather than starting a fresh scan.
     private var restoredPeripheral: CBPeripheral?
+    /// #280: true while `lastSyncError` currently holds a radio-state message (off / unauthorized /
+    /// unsupported) that `centralManagerDidUpdateState` set. Lets the poweredOn transition clear ONLY
+    /// that message, never a genuine mid-sync error (e.g. "Sync interrupted").
+    private var radioStateErrorShown = false
     private var cmdCharacteristic: CBCharacteristic?
     private var cmdNotifyCharacteristic: CBCharacteristic?
     private var eventNotifyCharacteristic: CBCharacteristic?
@@ -2759,7 +2763,44 @@ public final class BLEManager: NSObject, ObservableObject {
 extension BLEManager: @preconcurrency CBCentralManagerDelegate {
     public func centralManagerDidUpdateState(_ central: CBCentralManager) {
         log("Central state: \(central.state.rawValue) (5 = poweredOn)")
-        guard central.state == .poweredOn else { return }
+        guard central.state == .poweredOn else {
+            // #280: a non-poweredOn radio state used to be a SILENT return — the strap log showed only
+            // "Central state: 3" and the UI just read "not connected", so a user whose Mac had denied NOOP
+            // Bluetooth (.unauthorized == raw 3) had nothing explaining why no strap was ever found. This is
+            // the #280 case: an unsigned universal rebuild (8.4.0) gets a new code identity, so the earlier
+            // macOS Bluetooth TCC grant no longer applied and CoreBluetooth reported .unauthorized before
+            // any scan/connect. Surface the actionable states via lastSyncError (shown in Live + Today);
+            // leave .unknown/.resetting alone — they're transient and the next state update resolves them.
+            // Android already surfaces all three (WhoopBleClient: no-LE / off / permission), so this brings
+            // iOS+macOS up to that parity rather than adding a new behaviour.
+            switch central.state {
+            case .unauthorized:
+                #if os(macOS)
+                state.lastSyncError = "NOOP isn't allowed to use Bluetooth. Turn it on in System Settings → Privacy & Security → Bluetooth, then reopen NOOP."
+                #else
+                state.lastSyncError = "NOOP isn't allowed to use Bluetooth. Turn it on in iPhone Settings → NOOP → Bluetooth, then reopen NOOP."
+                #endif
+                log("Bluetooth permission not granted (unauthorized) — cannot scan or connect")
+                radioStateErrorShown = true
+            case .poweredOff:
+                state.lastSyncError = "Bluetooth is off. Turn it on to connect to your strap."
+                log("Bluetooth is off — cannot scan or connect")
+                radioStateErrorShown = true
+            case .unsupported:
+                state.lastSyncError = "This device can't use Bluetooth Low Energy."
+                log("Bluetooth LE unsupported on this device")
+                radioStateErrorShown = true
+            default:
+                break
+            }
+            return
+        }
+        // #280: radio is back — clear a stale radio-state banner (only one WE set), so a "Bluetooth is off"
+        // message doesn't outlive the radio coming on. A genuine sync error is left untouched.
+        if radioStateErrorShown {
+            state.lastSyncError = nil
+            radioStateErrorShown = false
+        }
         // Bootstrap the async store once on first poweredOn (idempotent if already set).
         Task { @MainActor in await bootstrapStore() }
         if let p = restoredPeripheral {


### PR DESCRIPTION
## Summary
- `centralManagerDidUpdateState` guarded on `.poweredOn` and returned **silently** for every other radio state — the reporter's strap log on #280 showed only `Central state: 3` (`CBManagerState.unauthorized`) and nothing else, with no explanation in the UI for why no strap was ever found.
- Root cause of the #280 regression: 8.4.0 shipped the macOS app as an unsigned **universal** binary (#51/#276-era change), which changed the app's code identity (cdhash). macOS ties the Bluetooth TCC grant to that identity, so the 8.3.4 grant no longer applied and CoreBluetooth denied access before any scan/connect could happen.
- This PR surfaces the three actionable radio states (`.unauthorized` / `.poweredOff` / `.unsupported`) via `state.lastSyncError` (already shown in Live + Today), with platform-correct settings copy (macOS: System Settings → Privacy & Security → Bluetooth; iOS: iPhone Settings → NOOP → Bluetooth). A small `radioStateErrorShown` flag lets the `poweredOn` transition clear only the banner this code set, never a genuine mid-sync error.
- **Parity:** Android's `WhoopBleClient` already surfaces all three equivalent states (no-LE / off / permission denied) — this brings iOS+macOS up to that existing behavior rather than adding something new. No Android change needed, and nothing byte-parity-relevant is touched (pure status-string UI).
- Does **not** fix the underlying signing issue (that's a separate build/release concern — happy to open a follow-up) — this is the diagnostic fix that turns a silent dead end into an actionable message for the user hitting #280 today.

## Verification
- Bisected `v8.3.4..v8.4.0`: no connect/bond logic change exists anywhere in that range (only `#47`/`#56`/`#57`/`#34`/`#67`, none touching connect/scan/`createBond`).
- Confirmed root cause against the reporter's own strap-log exports attached to #280: 8.3.4 → `Central state: 5` → connects + bonds normally; 8.4.0 → `Central state: 3` and nothing after (158-byte log vs. 49KB).
- macOS app compiled locally (`xcodebuild -scheme Strand -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO build` → `BUILD SUCCEEDED`) since `app-build.yml` is disabled by default and doesn't cover app-target Swift changes.
- Not yet validated on real hardware against the `.unauthorized` state specifically — that requires a macOS Bluetooth permission revoke/re-grant cycle, which the #280 reporter is positioned to reproduce.

Closes #280 (diagnostic portion — see note above about the underlying signing cause).