### PR TITLE
test(android): pin reboot-probe table to A–E (fixes failing RebootProbeVariantTest)

### DIFF
--- a/android/app/src/test/java/com/noop/protocol/RebootProbeVariantTest.kt
+++ b/android/app/src/test/java/com/noop/protocol/RebootProbeVariantTest.kt
@@ -14,9 +14,15 @@ class RebootProbeVariantTest {
     private fun ByteArray.hex() = joinToString("") { "%02x".format(it.toInt() and 0xFF) }
 
     @Test fun tableOrderAndTagsPinned() {
-        assertEquals(3, RebootProbeVariant.entries.size)
+        assertEquals(5, RebootProbeVariant.entries.size)
         assertEquals(
-            listOf("A/reboot29-empty", "B/powercycle32-empty", "C/reboot29-payload01"),
+            listOf(
+                "A/reboot29-empty",
+                "B/powercycle32-empty",
+                "C/reboot29-payload01",
+                "D/powercycle32-payload01",
+                "E/reboot29-payload00",
+            ),
             RebootProbeVariant.entries.map { it.logTag },
         )
         assertEquals(
@@ -24,6 +30,8 @@ class RebootProbeVariantTest {
                 "A · REBOOT_STRAP(29) empty",
                 "B · POWER_CYCLE(32) empty",
                 "C · REBOOT_STRAP(29) payload=01",
+                "D · POWER_CYCLE(32) payload=01",
+                "E · REBOOT_STRAP(29) payload=00",
             ),
             RebootProbeVariant.entries.map { it.menuLabel },
         )
@@ -47,11 +55,25 @@ class RebootProbeVariantTest {
         assertEquals("01", c.payload.hex())
     }
 
-    /** The two restart candidates carry the real, distinct wire opcodes (29 reboot, 32 power-cycle) — a
-     *  guard against a candidate silently pointing at the wrong CommandNumber. */
+    @Test fun candidateD_powerCycle32Payload1() {
+        val d = RebootProbeVariant.POWER_CYCLE_32_PAYLOAD1
+        assertEquals(CommandNumber.POWER_CYCLE_STRAP, d.command)
+        assertEquals("01", d.payload.hex())
+    }
+
+    @Test fun candidateE_reboot29Payload0() {
+        val e = RebootProbeVariant.REBOOT_29_PAYLOAD0
+        assertEquals(CommandNumber.REBOOT_STRAP, e.command)
+        assertEquals("00", e.payload.hex())
+    }
+
+    /** Each candidate carries the real, distinct wire opcode (29 reboot, 32 power-cycle) — a guard
+     *  against a candidate silently pointing at the wrong CommandNumber. */
     @Test fun candidatesUseExpectedWireOpcodes() {
         assertEquals(29, RebootProbeVariant.REBOOT_29_EMPTY.command.rawValue)
         assertEquals(32, RebootProbeVariant.POWER_CYCLE_32_EMPTY.command.rawValue)
         assertEquals(29, RebootProbeVariant.REBOOT_29_PAYLOAD1.command.rawValue)
+        assertEquals(32, RebootProbeVariant.POWER_CYCLE_32_PAYLOAD1.command.rawValue)
+        assertEquals(29, RebootProbeVariant.REBOOT_29_PAYLOAD0.command.rawValue)
     }
 }


### PR DESCRIPTION
The WHOOP 4.0 reboot-probe candidate table grew from 3 (A–C) to 5 (A–E) when **D** (`POWER_CYCLE(32)` payload=`01`) and **E** (`REBOOT_STRAP(29)` payload=`00`) were added, but `RebootProbeVariantTest` still asserted `entries.size == 3` and listed only A–C. So `testFullDebugUnitTest` was failing — and because `android.yml` is disabled by default, no CI caught it.

## Change
- Update the pinned `logTag` / `menuLabel` lists to A–E.
- Add candidate D/E payload + opcode assertions.
- Extend the wire-opcode guard to all five candidates.

Keeps the byte-identical cross-platform contract with Swifts `RebootProbeVariant` (`Strand/BLE/Commands.swift`), which already ships A–E.

## Verification
`./gradlew testFullDebugUnitTest --tests "com.noop.protocol.RebootProbeVariantTest"` → green (JDK 17). Test-only change; no runtime code touched.