### PR TITLE
feat(devices): retire the Restart button on WHOOP 4.0 (#275)

### DIFF
--- a/Strand/Screens/DevicesView.swift
+++ b/Strand/Screens/DevicesView.swift
@@ -118,7 +118,13 @@ private struct DevicesContent: View {
                     onMakeActive: { switchTarget = device },
                     onRename: { renameDraft = device.nickname ?? device.displayName; renameTarget = device },
                     onRemove: { removeTarget = device },
-                    onReboot: { rebootTarget = device },
+                    // Restart is offered only for a live-connected WHOOP that is NOT a 4.0: the strap-log
+                    // analysis on #275 showed no safe frame reboots a 4.0 (empty bodies are ignored; any
+                    // non-empty body just wedges the BLE link for ~7s, sensor stays on), so a 4.0 Restart
+                    // button could never work. 5.0/MG reboot on the production frame. nil otherwise.
+                    onReboot: (device.status == .active && live.connected
+                               && SourceCoordinator.isWhoop(device)
+                               && !model.ble.isWhoop4) ? { rebootTarget = device } : nil,
                     // 4.0 reboot probe: only offered when Test Centre → Connection is on AND the live
                     // strap is a WHOOP 4.0 (a 5.0 already reboots on the production frame). nil otherwise.
                     onRebootProbe: (device.status == .active && live.connected
@@ -187,7 +193,7 @@ private struct DevicesContent: View {
             Button("Cancel", role: .cancel) { rebootTarget = nil }
             Button("Restart") { model.rebootStrap(); rebootTarget = nil }
         } message: { device in
-            Text("Restart \(device.displayName)? It disconnects for about 30 seconds while it reboots, then reconnects on its own. Your recorded data is kept. Confirmed on WHOOP 5.0; on WHOOP 4.0 the reboot command isn't confirmed yet — if nothing happens, your strap log helps us pin it down.")
+            Text("Restart \(device.displayName)? It disconnects for about 30 seconds while it reboots, then reconnects on its own. Your recorded data is kept.")
         }
         // WHOOP 4.0 reboot probe (#235): only reachable with Test Centre → Connection on and a 4.0 connected.
         // Tries each candidate frame one at a time so the strap log shows which one actually reboots.

--- a/android/app/src/main/java/com/noop/ui/DevicesScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/DevicesScreen.kt
@@ -192,7 +192,13 @@ fun DevicesScreen(
                 onDisconnect = if (device.brand.equals("WHOOP", ignoreCase = true)) {
                     { Toast.makeText(context, "Disconnecting", Toast.LENGTH_SHORT).show(); viewModel.disconnect() }
                 } else null,
-                onReboot = { rebootTarget = device },
+                // Restart is offered only for a live-connected WHOOP that is NOT a 4.0: the strap-log
+                // analysis on #275 showed no safe frame reboots a 4.0 (empty bodies are ignored; any
+                // non-empty body just wedges the BLE link for ~7s, sensor stays on), so a 4.0 Restart
+                // button could never work. 5.0/MG reboot on the production frame. null otherwise.
+                onReboot = if (device.status == DeviceStatus.active.name && live.connected &&
+                    SourceCoordinator.isWhoop(device) && live.whoop5Detected
+                ) { { rebootTarget = device } } else null,
                 // 4.0 reboot probe: only offered when Test Centre → Connection is on AND the live strap is
                 // a WHOOP 4.0 (a 5.0 already reboots on the production frame). null otherwise.
                 onRebootProbe = if (device.status == DeviceStatus.active.name && live.connected &&
@@ -293,9 +299,7 @@ fun DevicesScreen(
         ConfirmDialog(
             title = "Restart this strap?",
             message = "Restart ${displayName(device)}? It disconnects for about 30 seconds while it " +
-                "reboots, then reconnects on its own. Your recorded data is kept. Confirmed on WHOOP 5.0; " +
-                "on WHOOP 4.0 the reboot command isn't confirmed yet — if nothing happens, your strap log " +
-                "helps us pin it down.",
+                "reboots, then reconnects on its own. Your recorded data is kept.",
             confirmLabel = "Restart",
             destructive = false,
             onConfirm = { viewModel.rebootStrap(); rebootTarget = null },


### PR DESCRIPTION
Closes the loop on #275. The strap-log analysis there (four 4.0 logs, ~15 probe attempts) showed **no safe frame reboots a WHOOP 4.0**:

- Empty-body frames (**A** `REBOOT_STRAP(29)`, **B** `POWER_CYCLE(32)`) are always **ignored** — no disconnect within 12s.
- Any non-empty body (**C/D/E**, opcode 29 or 32, byte `00` or `01`) always **wedges the BLE link**: a ~7s `status=8` supervision-timeout drop with the sensor still on, then auto-reconnect — a dropped link, **not** a power-cycle.

So the production **Restart** button on a 4.0 can never do what it says. Full breakdown: https://github.com/ryanbr/noop/issues/275#issuecomment-4947352187

## Change
- Gate the **“Restart strap…”** menu item to a live-connected WHOOP that is **not** a 4.0 (5.0/MG reboot on the production frame), mirroring how the 4.0 reboot probe is already gated.
  - Swift: `DevicesView` `onReboot` gated on `!ble.isWhoop4`.
  - Android: `DevicesScreen` `onReboot` gated on `live.whoop5Detected` (twin).
- Drop the now-dead *“on WHOOP 4.0 the reboot command isn’t confirmed yet”* hedge from the confirm copy on both platforms.
- The **4.0 reboot probe** (Test Centre → Connection) is **unchanged** — it stays as the RE tool for hunting the real frame.

## Verification
- macOS `Strand` target builds (`xcodebuild … CODE_SIGNING_ALLOWED=NO build`).
- `./gradlew compileFullDebugKotlin` passes.
- UI-only, design-token-clean; the BLE reboot path itself is untouched. On a connected 4.0 the “Restart strap…” item no longer appears; on 5.0/MG it is unchanged.

Depends on nothing; independent of the sibling test fix (#283).