### PR TITLE
fix(android): smart alarm early-fire schedules a duplicate same-day wake

### DIFF
--- a/android/app/src/main/java/com/noop/alarm/SmartAlarmReceiver.kt
+++ b/android/app/src/main/java/com/noop/alarm/SmartAlarmReceiver.kt
@@ -39,9 +39,11 @@ class SmartAlarmReceiver : BroadcastReceiver() {
         store.scheduledDeadlineMs = 0L
         store.scheduledWindowStartMs = 0L
         // ...then, if the alarm is still enabled, re-arm the GUARANTEED deadline for the NEXT day so
-        // the smart alarm recurs each morning. arm() computes the next occurrence (tomorrow, since
-        // today's just passed). A disabled-but-fired alarm does NOT resurrect itself.
-        runCatching { if (store.enabled) SmartAlarmScheduler.arm(context, store) }
+        // the smart alarm recurs each morning. `afterFire = true` forces tomorrow even on the EARLY
+        // (light-sleep) fire path, where today's hard deadline is still in the future and a plain
+        // re-arm would schedule a SECOND wake the same morning. A disabled-but-fired alarm does NOT
+        // resurrect itself.
+        runCatching { if (store.enabled) SmartAlarmScheduler.arm(context, store, afterFire = true) }
 
         ensureChannel(context)
         // Defensive: a notify() throw (OEM quirk / revoked POST_NOTIFICATIONS) must not crash the

--- a/android/app/src/main/java/com/noop/alarm/SmartAlarmScheduler.kt
+++ b/android/app/src/main/java/com/noop/alarm/SmartAlarmScheduler.kt
@@ -47,7 +47,7 @@ object SmartAlarmScheduler {
      *
      * @return the scheduled hard-deadline epoch (ms), or null if exact alarms aren't permitted.
      */
-    fun arm(context: Context, store: SmartAlarmStore): Long? {
+    fun arm(context: Context, store: SmartAlarmStore, afterFire: Boolean = false): Long? {
         if (!canScheduleExact(context)) return null
 
         val deadlineMin = (store.targetMinutes + store.windowMinutes)
@@ -55,6 +55,16 @@ object SmartAlarmScheduler {
         // occurrence of that absolute minute-of-day, then derive the window-start from it so the two
         // edges stay on the same night even across the midnight boundary.
         val deadline = nextOccurrence(deadlineMin % SmartAlarmStore.MINUTES_PER_DAY)
+        // Re-arm after a fire (audit): when the smart alarm fires EARLY on a light-sleep phase (e.g. 06:35
+        // for a 07:00 deadline), the deadline's next occurrence is still TODAY 07:00 — so a plain re-arm
+        // scheduled a second guaranteed wake the SAME morning, waking the user again. We just woke them
+        // today, so the next wake must be tomorrow: push a same-day deadline forward one day.
+        if (afterFire) {
+            val now = Calendar.getInstance()
+            val sameDay = deadline.get(Calendar.YEAR) == now.get(Calendar.YEAR) &&
+                deadline.get(Calendar.DAY_OF_YEAR) == now.get(Calendar.DAY_OF_YEAR)
+            if (sameDay) deadline.add(Calendar.DAY_OF_YEAR, 1)
+        }
         val windowStartMs = deadline.timeInMillis - store.windowMinutes.toLong() * 60_000L
 
         scheduleExact(context, deadline.timeInMillis)


### PR DESCRIPTION
## Problem

Target 06:30, window 30 → hard deadline 07:00. Overnight the watcher detects light sleep and `SmartAlarmScheduler.advanceTo()` moves the single PendingIntent to 06:35 (`smart=true`). At 06:35 `SmartAlarmReceiver.onReceive` fires, clears the schedule, then calls `SmartAlarmScheduler.arm()` because the alarm is still enabled.

`arm()` computes `nextOccurrence(07:00)` — and since **06:35 is before 07:00 today**, `nextOccurrence` returns **TODAY 07:00** (`SmartAlarmScheduler.kt` only adds a day when the time is `<= now`). So a fresh guaranteed alarm is scheduled for 07:00 the **same day**, and the user just woken at 06:35 is **woken again at 07:00**. The KDoc's assumption ("arm() computes the next occurrence — tomorrow, since today's just passed") is false on the early-fire path.

## Fix

`arm(context, store, afterFire = false)` gains an `afterFire` flag. When re-arming right after a fire, a computed deadline that still lands **today** is pushed forward one day — we just woke the user today, so the next wake must be tomorrow. `SmartAlarmReceiver` passes `afterFire = true`. The normal enable/boot arm path is unchanged (`afterFire` defaults false).

## Testing

Logic change in `arm()` + the receiver call. **Not compiled locally** — the only installed JDK is Homebrew JDK 26, which the project's Kotlin toolchain can't parse (`JavaVersion.parse("26.0.1")` throws); no compatible JDK/JBR present. `arm()` touches `AlarmManager` so it isn't JVM-unit-testable (repo ships no Robolectric). Please verify on a device / in CI: early smart-fire then confirm the next scheduled alarm is tomorrow, not today.

Found by an independent code audit.