### PR TITLE
Oura: fix #91 on the clean stack - (lost when refactoring the oura ble stack)

### DIFF
--- a/Packages/OuraProtocol/Sources/OuraProtocol/Framing.swift
+++ b/Packages/OuraProtocol/Sources/OuraProtocol/Framing.swift
@@ -47,15 +47,22 @@ public enum OuraFraming {
     /// caller fails to special-case it.
     public static let batteryResponseOp: UInt8 = 0x0D
 
-    /// Parse a 0x11 GetEvents response body: `status:1 sub_status:1 last_ring_timestamp:4LE pad:2`
-    /// (OURA_PROTOCOL.md s5.2). `status` 0x00 = empty/no more; any other value = data follows. The
-    /// `last_ring_timestamp` is the new cursor to resume the fetch from. Returns nil on a short body
-    /// (never guesses a cursor).
-    public static func parseGetEventsResponse(_ body: [UInt8]) -> (cursor: UInt32, moreData: Bool)? {
+    /// Parse a 0x11 GetEvents response body per open_oura's `EventBatchSummary`:
+    /// `events_received:1  sleep_analysis_progress:1  bytes_left:4LE  [pad:2]`. The drain loop runs
+    /// until `bytes_left == 0`; there is NO resume cursor in this packet — the resume position is a
+    /// CLIENT-managed event-envelope ring-time, never read back from here. Returns nil on a short body.
+    ///
+    /// #91 (was re-broken on main; observed on-device 2026-07-11): bytes[2..5] were decoded as a
+    /// `last_ring_timestamp` cursor and body[0] as a "more data" status. Both are wrong: body[0] is
+    /// `events_received` (a batch COUNT — treating 0 as "done" stopped a drain with 400,873 bytes still
+    /// left, losing the newest data), and bytes[2..5] is `bytes_left` (a remaining-BYTE count — persisting
+    /// it and comparing across sessions as clocks minted a phantom "ring-time regression" → reset-to-0 →
+    /// full history re-dump on every connect).
+    public static func parseGetEventsResponse(_ body: [UInt8]) -> (eventsReceived: UInt8, bytesLeft: UInt32, moreData: Bool)? {
         guard body.count >= 6 else { return nil }
-        let status = body[0]
-        let cursor = UInt32(body[2]) | (UInt32(body[3]) << 8) | (UInt32(body[4]) << 16) | (UInt32(body[5]) << 24)
-        return (cursor, status != 0x00)
+        let eventsReceived = body[0]
+        let bytesLeft = UInt32(body[2]) | (UInt32(body[3]) << 8) | (UInt32(body[4]) << 16) | (UInt32(body[5]) << 24)
+        return (eventsReceived, bytesLeft, bytesLeft > 0)
     }
 
     /// Parse one outer frame from the front of `bytes`. Returns nil on a short buffer (header or body

--- a/Packages/OuraProtocol/Tests/OuraProtocolTests/FramingTests.swift
+++ b/Packages/OuraProtocol/Tests/OuraProtocolTests/FramingTests.swift
@@ -55,21 +55,35 @@ final class FramingTests: XCTestCase {
 
     // MARK: - GetEvents response (0x11, s5.2)
 
-    func testParseGetEventsResponseMoreDataFollows() {
-        // 11 08 <status=ff> <sub_status=00> <last_rt:4LE=78563412> <pad:2>
-        let outer = OuraFraming.parseOuterFrame(bytes("1108ff00785634120000"))
+    func testParseGetEventsResponseMoreDataWhileBytesLeft() {
+        // REAL on-device capture (2026-07-11 07:04, full-pull first summary):
+        // 11 08 <events=ff> <progress=00> <bytes_left:4LE = a6 a1 1a 00 = 1,745,318> <pad 03 00>.
+        let outer = OuraFraming.parseOuterFrame(bytes("1108ff00a6a11a000300"))
         XCTAssertEqual(outer?.op, OuraFraming.getEventsResponseOp)
         let summary = OuraFraming.parseGetEventsResponse(outer!.body)
-        XCTAssertEqual(summary?.cursor, 0x1234_5678)
+        XCTAssertEqual(summary?.eventsReceived, 0xFF)
+        XCTAssertEqual(summary?.bytesLeft, 1_745_318)
         XCTAssertEqual(summary?.moreData, true)
     }
 
-    func testParseGetEventsResponseNoMoreData() {
-        // status 0x00 -> caught up, no more data.
-        let outer = OuraFraming.parseOuterFrame(bytes("11080000785634120000"))
+    func testParseGetEventsResponseCompleteAtZeroBytesLeft() {
+        // REAL on-device capture (final summary of a completed drain): bytes_left == 0 -> caught up.
+        let outer = OuraFraming.parseOuterFrame(bytes("11080000000000000300"))
         let summary = OuraFraming.parseGetEventsResponse(outer!.body)
-        XCTAssertEqual(summary?.cursor, 0x1234_5678)
+        XCTAssertEqual(summary?.eventsReceived, 0)
+        XCTAssertEqual(summary?.bytesLeft, 0)
         XCTAssertEqual(summary?.moreData, false)
+    }
+
+    func testParseGetEventsResponseZeroEventsButBytesLeftIsMoreData() {
+        // THE #91 regression case, byte-for-byte from the 2026-07-11 18:53 log: events_received == 0 but
+        // bytes_left = e9 1d 06 00 = 400,873. The old parse read body[0] as a status and STOPPED here,
+        // abandoning the newest 400 KB of the log (the previous night's hypnogram). moreData must be true.
+        let outer = OuraFraming.parseOuterFrame(bytes("11080000e91d06000300"))
+        let summary = OuraFraming.parseGetEventsResponse(outer!.body)
+        XCTAssertEqual(summary?.eventsReceived, 0)
+        XCTAssertEqual(summary?.bytesLeft, 400_873)
+        XCTAssertEqual(summary?.moreData, true, "bytes_left > 0 means the drain MUST continue")
     }
 
     func testParseGetEventsResponseShortBodyReturnsNil() {

--- a/Strand/BLE/OuraLiveSource.swift
+++ b/Strand/BLE/OuraLiveSource.swift
@@ -252,10 +252,35 @@ public final class OuraLiveSource: NSObject, ObservableObject {
     // arrive by. Neither temp nor SpO2 is ever pushed live on this hardware; both are banked overnight and
     // retrievable only by asking the ring for its history.
 
-    /// The GetEvents cursor to resume from, loaded from `OuraHistoryCursorStore` on connect and advanced
-    /// as `0x11` summaries arrive. 0 = fetch everything the ring has banked (first-ever connect for this
-    /// ring; OURA_PROTOCOL.md s5.1).
+    /// The GetEvents resume cursor — a CLIENT-managed event-envelope ring-time (open_oura
+    /// `nextEventToSync`), loaded from `OuraHistoryCursorStore` on connect and COMMITTED only when a
+    /// drain completes (from `maxStoredRingTime`). 0 = fetch everything the ring has banked.
+    ///
+    /// #91: the `0x11` response carries NO cursor — only `bytes_left` (a remaining-byte count). NOOP
+    /// previously persisted that byte-count as a "cursor" and compared it across sessions as a clock,
+    /// minting a phantom "ring-time regression" → reset-to-0 → full re-dump on every connect.
     private var historyCursor: UInt32 = 0
+    /// Absolute ceiling for a plausible resume ring-time: ~1.6 years of ticks. Observed real envelope
+    /// ring-times are ~1.7M (days of uptime); anything above this is a corrupt value that must never be
+    /// seeked to or persisted. Bounds the cursor at the source.
+    private static let maxPlausibleResumeTicks: UInt32 = 500_000_000
+    /// The cursor we resumed FROM at the start of the current fetch, kept to detect a genuine ring
+    /// reboot: a real stored sample OLDER than where we sought means the ring's clock reset (or it
+    /// ignored the seek), so the persisted cursor is stale → full pull next connect.
+    private var resumeCursorAtFetchStart: UInt32 = 0
+    private var sawPreResumeData = false
+    /// Newest STORED history sample's ring-time this drain — the value the resume cursor commits to at
+    /// completion. Advanced only by samples that resolved a REAL anchored time (never wall-clock guesses).
+    private var maxStoredRingTime: UInt32 = 0
+    // Drain safety guards (backstops only — a healthy drain ends at bytes_left == 0):
+    /// Wall-clock start of the current drain; a drain running past `maxDrainSeconds` is force-stopped.
+    private var drainStartedAt: Date?
+    /// Smallest bytes_left seen this drain + how many consecutive summaries made no progress against it.
+    /// `bytes_left` not shrinking for `maxStallSummaries` straight summaries = the ring is looping, stop.
+    private var minBytesLeftSeen: UInt32 = .max
+    private var drainStallCount = 0
+    private let maxDrainSeconds: TimeInterval = 300
+    private let maxStallSummaries = 3
     /// Periodic re-fetch while connected, so an overnight-connected session (or one left open after a nap)
     /// picks up freshly-banked sleep data without needing a reconnect. Mirrors BLEManager's ~15 min
     /// periodic WHOOP history-offload floor.
@@ -267,7 +292,15 @@ public final class OuraLiveSource: NSObject, ObservableObject {
     /// both right after reaching `.streaming` and from the periodic timer).
     private func fetchHistoryIfIdle() {
         guard let driver, driver.phase == .streaming else { return }
-        log("Oura: fetching history from cursor \(historyCursor) (\(describeCursor(historyCursor)))")
+        // Arm the per-drain state: where we sought from (reboot detection), the stored-sample high-water
+        // mark the cursor will commit from, and the stall/deadline guards.
+        resumeCursorAtFetchStart = historyCursor
+        sawPreResumeData = false
+        maxStoredRingTime = 0
+        drainStartedAt = Date()
+        minBytesLeftSeen = .max
+        drainStallCount = 0
+        log("Oura: fetching history from cursor \(historyCursor) (\(describeCursor(historyCursor))) [cursor-fix v1]")
         advance(.startHistoryFetch(cursor: historyCursor))
     }
 
@@ -284,37 +317,78 @@ public final class OuraLiveSource: NSObject, ObservableObject {
         historyFetchTimer = nil
     }
 
-    /// Handle a `0x11` GetEvents response (OURA_PROTOCOL.md s5.2): persist the advanced cursor (so a LATER
-    /// connection resumes rather than re-fetching everything) and drive the driver's cursor-loop state
-    /// machine, which asks for another ack-fetch while `moreData` or returns to `.streaming` once caught up.
+    /// Handle a `0x11` GetEvents summary (open_oura `EventBatchSummary`): the drain continues while
+    /// `bytes_left > 0` and is complete at `bytes_left == 0`. The response's byte-count is NEVER persisted
+    /// — persisting it and comparing byte-counts across sessions as clocks was the #91 re-dump loop.
     ///
-    /// The ring's terminal "no more data" response (moreData=false, status 0x00) zero-fills the cursor
-    /// field, whereas a mid-fetch response (moreData=true) carries a real advancing nonzero cursor. So the
-    /// cursor is only trusted/persisted while the response is actually carrying new data - persisting the
-    /// terminal zero would reset the cursor to 0 on every fetch and force a full backlog re-fetch forever.
-    ///
-    /// A cursor persisted from one BLE connection can come back SMALLER on the next connection's first real
-    /// cursor: `ringTimestamp = (session << 16) | counter` (OURA_PROTOCOL.md s2.3), and the ring's internal
-    /// `session` component can shift across reconnects/restarts. This is the same class of problem s5.5
-    /// documents for the UTC anchor (ring-start with rt regression -> invalidate anchor). Resuming from a
-    /// cursor whose session no longer matches the ring's current one is not a real resume - the ring just
-    /// re-dumps its whole backlog anyway - so we detect the regression and reset to an honest, explicit 0
-    /// rather than feed the ring a now-meaningless reference.
-    private func handleHistorySummary(_ summary: (cursor: UInt32, moreData: Bool)) {
-        if summary.moreData {
-            if summary.cursor < historyCursor {
-                log("Oura: ring-time regression detected (fetch cursor \(summary.cursor) [\(describeCursor(summary.cursor))] < persisted \(historyCursor) [\(describeCursor(historyCursor))]) - the ring's session likely reset; resetting our cursor to 0")
-                historyCursor = 0
-                OuraHistoryCursorStore.save(0, deviceId: deviceId)
+    /// The durable resume point (open_oura `nextEventToSync`) is the newest STORED history sample's
+    /// ring-time (`maxStoredRingTime`), committed here when the drain completes. A genuine ring reboot is
+    /// caught by `sawPreResumeData` — a stored sample OLDER than where we sought means the ring's clock
+    /// reset (or it ignored the seek), so next connect does a full pull rather than resume from a
+    /// now-stale ring-time. Stall/deadline guards are backstops only; they force-stop the drain but keep
+    /// whatever forward progress was banked (never reset to 0 — that re-arms the loop).
+    private func handleHistorySummary(_ summary: (eventsReceived: UInt8, bytesLeft: UInt32, moreData: Bool)) {
+        var continueDrain = summary.moreData
+        if continueDrain {
+            // Stall guard: bytes_left must shrink across summaries. A ring that keeps answering with no
+            // progress is looping; stop after maxStallSummaries flat reads instead of draining forever.
+            if summary.bytesLeft < minBytesLeftSeen {
+                minBytesLeftSeen = summary.bytesLeft
+                drainStallCount = 0
             } else {
-                historyCursor = summary.cursor
-                OuraHistoryCursorStore.save(summary.cursor, deviceId: deviceId)
+                drainStallCount += 1
+                if drainStallCount >= maxStallSummaries {
+                    log("Oura: history drain force-stopped - bytes_left stalled at \(summary.bytesLeft) for \(drainStallCount) summaries (guard)")
+                    continueDrain = false
+                }
             }
-        } else {
-            log("Oura: history fetch caught up (cursor \(historyCursor) [\(describeCursor(historyCursor))])")
+            // Deadline guard: a healthy full pull completes in ~1-2 min; past maxDrainSeconds something
+            // is wrong upstream - stop, keep progress, let the periodic re-fetch try again later.
+            if continueDrain, let started = drainStartedAt, Date().timeIntervalSince(started) > maxDrainSeconds {
+                log("Oura: history drain force-stopped - exceeded \(Int(maxDrainSeconds))s deadline with bytes_left \(summary.bytesLeft) (guard)")
+                continueDrain = false
+            }
+        }
+        if !continueDrain {
+            commitResumeCursor(drainCompleted: !summary.moreData)
             logActivityEstimateSummary()
         }
-        advance(.historyCursorAdvanced(cursor: summary.cursor, moreData: summary.moreData))
+        // The continuation cursor is the resume point; the ring streams the remainder (maxEvents=0 ack).
+        advance(.historyCursorAdvanced(cursor: historyCursor, moreData: continueDrain))
+    }
+
+    /// Commit the durable resume cursor at drain end. Only a cursor that (a) moved forward, (b) is below
+    /// the plausibility ceiling, and (c) resolves to a real time under the CURRENT anchor is persisted;
+    /// a reboot (`sawPreResumeData`) resets to 0 so next connect does an honest full pull.
+    private func commitResumeCursor(drainCompleted: Bool) {
+        let how = drainCompleted ? "caught up (bytes_left 0)" : "stopped early"
+        if sawPreResumeData {
+            log("Oura: history \(how) but the ring served data older than cursor \(resumeCursorAtFetchStart) - clock reset/seek ignored; next connect does a full pull")
+            historyCursor = 0
+            OuraHistoryCursorStore.save(0, deviceId: deviceId)
+            return
+        }
+        let resolves = maxStoredRingTime > 0 && (driver?.unixSeconds(forRingTimestamp: maxStoredRingTime) != nil)
+        if maxStoredRingTime > historyCursor, resolves {
+            historyCursor = maxStoredRingTime
+            OuraHistoryCursorStore.save(maxStoredRingTime, deviceId: deviceId)
+            log("Oura: history \(how) - resume cursor advanced to \(historyCursor) [\(describeCursor(historyCursor))]")
+        } else if maxStoredRingTime > historyCursor {
+            log("Oura: history \(how) but resume candidate \(maxStoredRingTime) does not resolve under the current anchor - keeping cursor \(historyCursor)")
+        } else {
+            log("Oura: history \(how) (resume cursor unchanged \(historyCursor) [\(describeCursor(historyCursor))])")
+        }
+    }
+
+    /// Record a STORED history sample's ring-time toward the resume cursor (open_oura `nextEventToSync`).
+    /// Called only where a sample resolved a REAL anchored time and was enqueued — never for a no-anchor
+    /// wall-clock fallback. Also flags a reboot: a real sample older than where we sought this fetch.
+    private func noteStoredHistoryRingTime(_ rt: UInt32) {
+        // A ring-time above the plausibility ceiling is corrupt; letting it set the resume cursor would
+        // seek the next session into nonsense. Bounds the cursor at the source.
+        guard rt <= Self.maxPlausibleResumeTicks else { return }
+        if rt > maxStoredRingTime { maxStoredRingTime = rt }
+        if resumeCursorAtFetchStart > 0, rt < resumeCursorAtFetchStart { sawPreResumeData = true }
     }
 
     /// Log the per-day MET-derived activity estimate + the empirical cadence cross-check at drain-end.
@@ -481,6 +555,12 @@ public final class OuraLiveSource: NSObject, ObservableObject {
         activityCadenceObs.removeAll()
         lastActivityUtc = nil
         lastActivitySampleCount = 0
+        maxStoredRingTime = 0
+        resumeCursorAtFetchStart = 0
+        sawPreResumeData = false
+        drainStartedAt = nil
+        minBytesLeftSeen = .max
+        drainStallCount = 0
         reachedStreaming = false
         pendingInstallKey = nil
         adoptPhase = .idle
@@ -631,8 +711,12 @@ public final class OuraLiveSource: NSObject, ObservableObject {
         guard !pendingAnchorEvents.isEmpty, let driver else { return }
         let now = Int(Date().timeIntervalSince1970)
         for pending in pendingAnchorEvents {
-            let ts = driver.unixSeconds(forRingTimestamp: pending.ringTimestamp) ?? now
-            enqueue([pending.event], ts: ts)
+            if let ts = driver.unixSeconds(forRingTimestamp: pending.ringTimestamp) {
+                enqueue([pending.event], ts: ts)
+                noteStoredHistoryRingTime(pending.ringTimestamp)   // parked sample placed → advance resume cursor
+            } else {
+                enqueue([pending.event], ts: now)   // honest wall-clock fallback; NEVER advances the cursor
+            }
         }
         pendingAnchorEvents.removeAll()
     }
@@ -688,6 +772,7 @@ public final class OuraLiveSource: NSObject, ObservableObject {
                 }
                 if let ts = driver.unixSeconds(forRingTimestamp: t.ringTimestamp) {
                     enqueue([e], ts: ts)
+                    noteStoredHistoryRingTime(t.ringTimestamp)
                 } else {
                     pendingAnchorEvents.append((e, t.ringTimestamp))
                 }
@@ -699,6 +784,7 @@ public final class OuraLiveSource: NSObject, ObservableObject {
                 }
                 if let ts = driver.unixSeconds(forRingTimestamp: s.ringTimestamp) {
                     enqueue([e], ts: ts)
+                    noteStoredHistoryRingTime(s.ringTimestamp)
                 } else {
                     pendingAnchorEvents.append((e, s.ringTimestamp))
                 }
@@ -706,6 +792,7 @@ public final class OuraLiveSource: NSObject, ObservableObject {
             case .hrv(let v):
                 if let ts = driver.unixSeconds(forRingTimestamp: v.ringTimestamp) {
                     enqueue([e], ts: ts)
+                    noteStoredHistoryRingTime(v.ringTimestamp)
                 } else {
                     pendingAnchorEvents.append((e, v.ringTimestamp))
                 }
@@ -713,6 +800,7 @@ public final class OuraLiveSource: NSObject, ObservableObject {
             case .sleepPhase(let v):
                 if let ts = driver.unixSeconds(forRingTimestamp: v.ringTimestamp) {
                     enqueue([e], ts: ts)
+                    noteStoredHistoryRingTime(v.ringTimestamp)
                 } else {
                     pendingAnchorEvents.append((e, v.ringTimestamp))
                 }
@@ -938,9 +1026,23 @@ extension OuraLiveSource: @preconcurrency CBCentralManagerDelegate {
         pendingInstallKey = nil
         adoptPhase = .idle
         reassembler.reset()
+        // Per-drain cursor state starts clean each session (fetchHistoryIfIdle re-arms it per drain).
+        maxStoredRingTime = 0
+        resumeCursorAtFetchStart = 0
+        sawPreResumeData = false
+        drainStartedAt = nil
+        minBytesLeftSeen = .max
+        drainStallCount = 0
         // Resume the GetEvents cursor from where the LAST connection to this ring left off (s5.1/5.3), so
-        // a routine reconnect doesn't re-fetch the ring's entire banked history every time.
+        // a routine reconnect doesn't re-fetch the ring's entire banked history every time. A persisted
+        // value above the plausibility ceiling is garbage banked by a pre-fix build (a bytes_left count or
+        // a misframe-era ring-time) - seeking to it would starve the fetch; reset to a full pull instead.
         historyCursor = OuraHistoryCursorStore.read(deviceId: deviceId)
+        if historyCursor > Self.maxPlausibleResumeTicks {
+            log("Oura: persisted resume cursor \(historyCursor) exceeds the plausibility ceiling (pre-fix garbage) - full pull")
+            historyCursor = 0
+            OuraHistoryCursorStore.save(0, deviceId: deviceId)
+        }
         peripheral.discoverServices([Self.service])
     }
 


### PR DESCRIPTION
I forgot that fix when refactoring the BLE Oura stack

App (OuraLiveSource):
- The drain now runs until bytes_left == 0. The response byte-count is NEVER persisted.
- The durable resume point (open_oura nextEventToSync) is the newest STORED history sample's ring-time (maxStoredRingTime), advanced only by samples that resolved a REAL anchored time (incl. drained pending-anchor parks; never wall-clock fallbacks), bounded by a plausibility ceiling, and committed only at drain end when it resolves under the current anchor.
- Genuine ring reboot detection: a stored sample OLDER than the seek cursor (sawPreResumeData) -> full pull next connect.
- Backstop guards only (a healthy drain ends at 0): bytes_left stall (3 flat summaries) and a 300s wall deadline; a forced stop keeps banked forward progress, never resets to 0.
- A persisted cursor above the ceiling (pre-fix garbage) resets to a full pull at load.
- Log marker [cursor-fix v1] so the running build is identifiable.

swift test: 91/91. macOS app builds (BUILD SUCCEEDED). To validate on-device: connect twice - 1st drain should end "caught up (bytes_left 0)" + "resume cursor advanced", 2nd should fetch only the delta (no phantom regression, no full re-dump), and the previous night's sleep data should finally arrive.

Both logs are a textbook pass — the fix works exactly as designed:

  1st connect:
  - ✓ [cursor-fix v1] running, no phantom "regression detected"
  - ✓ Drain ran to bytes_left 0 and recovered the previously-abandoned tail — today's data appeared for the first time (15:23 → 19:07, the post-charger afternoon)
  - ✓ resume cursor advanced to 3453828 [2026-07-11 19:13:46] — a real ring-time resolving to the fetch moment
  - ✓ Estimate now has day=2026-07-11 through 19:07 (17 active min — plausible for your afternoon)

  2nd connect (2 min later):
  - ✓ Resumed from 3453828, summary 43 00 00 00 00 00 = 67 events, bytes_left 0 — an instant incremental delta, no full re-dump. That's the first true incremental sync the Oura path has ever done.
