### PR TITLE
iOS Backup & Sync: guard the folder picker against a double-tap (#52)

### DIFF
--- a/Strand/Screens/BackupSyncView.swift
+++ b/Strand/Screens/BackupSyncView.swift
@@ -161,8 +161,12 @@ struct BackupSyncView: View {
         // apart from that dead-button dead-end (both come back nil), so when no folder arrives we show
         // the screen's normal result alert with a concrete workaround instead of staying silent. Mildly
         // chatty on a genuine Cancel; honest and actionable when the picker is actually broken.
+        // `busy` guards against a double-tap stacking a second picker presentation on top of the first.
+        busy = true
         Task {
-            if await FolderBackup.pickFolder() != nil {
+            let picked = await FolderBackup.pickFolder()
+            busy = false
+            if picked != nil {
                 folderLabel = FolderBackup.folderLabel()
             } else if !FolderBackup.useInternalFolder {
                 // Only nag when there's no working destination. If the internal fallback is already


### PR DESCRIPTION
## Summary
- Reviewed the iOS folder-picker plumbing behind #52 (system picker's Open button not firing on some iOS 26 builds). Found no bug in the delegate/security-scoped-resource handling — `startAccessingSecurityScopedResource`/`stopAccessingSecurityScopedResource` are correctly bracketed with `defer`, the coordinator resumes exactly once, and `forOpeningContentTypes: [.folder], asCopy: false` is the right picker configuration. The picker-free "Use NOOP's own folder" fallback shipped in 8.4.0 (#66) remains the working mitigation for the underlying (likely iOS-side) bug.
- Found and fixed one small, unrelated hardening gap while reviewing: `chooseFolder()`'s `Task` never set `busy`, so a fast double-tap on "Choose/Change folder" could stack a second `UIDocumentPickerViewController` presentation on top of the first. Now guarded the same way `backupNow()`/`runRestore()` already guard their own in-flight work.

## Test plan
- [x] `xcodegen generate && xcodebuild -project Strand.xcodeproj -scheme Strand -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO build` succeeds.
- [ ] Manual on-device iOS verification of the double-tap guard (UI-only change; not part of the original #52 report).