### PR TITLE
Backup & Sync: resolve iCloud Drive placeholder files in the restore list (#278)

### DIFF
--- a/Strand/Data/BackupSync.swift
+++ b/Strand/Data/BackupSync.swift
@@ -60,6 +60,20 @@ enum BackupSync {
         name.lowercased().hasSuffix(suffix)
     }
 
+    /// A `.noopbak` sitting in an iCloud Drive folder that hasn't been downloaded to THIS Mac/iPhone
+    /// yet is listed by the filesystem under a placeholder name - a leading dot plus an `.icloud`
+    /// suffix, e.g. `noop-backup-....noopbak` becomes `.noop-backup-....noopbak.icloud` - instead of
+    /// its real name. Unresolved, that placeholder silently fails `isBackupFile` and the restore list
+    /// shows nothing even though Finder shows the file (#278: cross-device restore via iCloud Drive,
+    /// the workflow the folder-picker screen itself recommends). Returns the real name, or nil if
+    /// `name` isn't a placeholder.
+    static func iCloudPlaceholderRealName(_ name: String) -> String? {
+        let iCloudSuffix = ".icloud"
+        guard name.hasPrefix("."), name.hasSuffix(iCloudSuffix),
+              name.count > 1 + iCloudSuffix.count else { return nil }
+        return String(name.dropFirst().dropLast(iCloudSuffix.count))
+    }
+
     /// Newest snapshot by encoded time (non-snapshots ignored), or nil.
     static func latestSnapshot(_ names: [String]) -> String? {
         names.filter(isSnapshot).max { (snapshotTimeMs($0) ?? 0) < (snapshotTimeMs($1) ?? 0) }
@@ -283,9 +297,15 @@ enum FolderBackup {
         guard let folder = resolveFolder() else { return [] }
         let scoped = folder.startAccessingSecurityScopedResource()
         defer { if scoped { folder.stopAccessingSecurityScopedResource() } }
-        let names = (try? FileManager.default.contentsOfDirectory(atPath: folder.path)) ?? []
+        let rawNames = (try? FileManager.default.contentsOfDirectory(atPath: folder.path)) ?? []
+        // #278: a `.noopbak` iCloud hasn't downloaded to this Mac/iPhone yet is listed under a
+        // placeholder name; resolve it back to its real name so it still shows in the restore list
+        // (see `BackupSync.iCloudPlaceholderRealName`). `restore(snapshotNamed:)` resolves the same
+        // way and kicks off the download if the user picks one that's still a placeholder on disk.
+        let names = rawNames.map { BackupSync.iCloudPlaceholderRealName($0) ?? $0 }
         let fileDateMs: (String) -> Int = { name in
-            let url = folder.appendingPathComponent(name)
+            let onDisk = rawNames.contains(name) ? name : ("." + name + ".icloud")
+            let url = folder.appendingPathComponent(onDisk)
             let modified = (try? url.resourceValues(forKeys: [.contentModificationDateKey]))?.contentModificationDate
             guard let modified else { return 0 }
             return Int((modified.timeIntervalSince1970 * 1000.0).rounded())
@@ -306,8 +326,26 @@ enum FolderBackup {
         let scoped = folder.startAccessingSecurityScopedResource()
         defer { if scoped { folder.stopAccessingSecurityScopedResource() } }
         let source = folder.appendingPathComponent(name)
+        var wasPlaceholder = false
+        if !FileManager.default.fileExists(atPath: source.path) {
+            // #278: `name` came from the (already de-placeholdered) restore list, so if it's not on
+            // disk under its real name it may still be an undownloaded iCloud placeholder. Kick off
+            // the download and give it a short window to land - this runs off the main thread (the
+            // screen calls `restore` from a detached Task), so blocking here doesn't freeze the UI.
+            let placeholder = folder.appendingPathComponent("." + name + ".icloud")
+            if FileManager.default.fileExists(atPath: placeholder.path) {
+                wasPlaceholder = true
+                try? FileManager.default.startDownloadingUbiquitousItem(at: placeholder)
+                let deadline = Date().addingTimeInterval(15)
+                while !FileManager.default.fileExists(atPath: source.path), Date() < deadline {
+                    Thread.sleep(forTimeInterval: 0.5)
+                }
+            }
+        }
         guard FileManager.default.fileExists(atPath: source.path) else {
-            return .failure("That backup is no longer in your folder.")
+            return .failure(wasPlaceholder
+                ? "That backup is still downloading from iCloud - wait a moment and try again."
+                : "That backup is no longer in your folder.")
         }
         return DataBackup.restore(from: source)
     }

--- a/StrandTests/BackupSyncTests.swift
+++ b/StrandTests/BackupSyncTests.swift
@@ -86,6 +86,30 @@ final class BackupSyncTests: XCTestCase {
         XCTAssertFalse(pruned.contains(dateOnly))   // hand-named backup never auto-deleted
     }
 
+    // MARK: - iCloud Drive not-yet-downloaded placeholder names resolve to the real name (#278)
+
+    func testICloudPlaceholderRealName() {
+        XCTAssertEqual(
+            BackupSync.iCloudPlaceholderRealName(".noop-backup-20260710-093000.noopbak.icloud"),
+            "noop-backup-20260710-093000.noopbak")
+        XCTAssertEqual(BackupSync.iCloudPlaceholderRealName(".whatever-i-named-it.noopbak.icloud"),
+                        "whatever-i-named-it.noopbak")
+        XCTAssertNil(BackupSync.iCloudPlaceholderRealName("noop-backup-20260710-093000.noopbak")) // not a placeholder
+        XCTAssertNil(BackupSync.iCloudPlaceholderRealName(".DS_Store"))                            // dotfile, no .icloud suffix
+        XCTAssertNil(BackupSync.iCloudPlaceholderRealName("photo.jpg.icloud"))                     // .icloud suffix, no leading dot
+        XCTAssertNil(BackupSync.iCloudPlaceholderRealName(".icloud"))                               // nothing but the marker itself
+    }
+
+    func testRestorablesResolveICloudPlaceholders() {
+        // The I/O layer (FolderBackup.listSnapshots) maps raw names through iCloudPlaceholderRealName
+        // before handing them to this pure function - simulate that here so a not-yet-downloaded
+        // backup still appears in the restore list under its real name.
+        let placeholder = ".noop-backup-20260710-093000.noopbak.icloud"
+        let resolved = BackupSync.iCloudPlaceholderRealName(placeholder) ?? placeholder
+        let out = BackupSync.restorablesNewestFirst([resolved], fileDateMs: { _ in 0 })
+        XCTAssertEqual(out.map(\.name), ["noop-backup-20260710-093000.noopbak"])
+    }
+
     func testRestorablesTieBreakOnNameWhenTimesEqual() {
         // Two hand-named files that resolve to the SAME time (identical file-modification date) must order
         // deterministically by name asc - the same tie-break Kotlin uses - so equal-time rows list


### PR DESCRIPTION
## Summary
- A `.noopbak` sitting in an iCloud Drive backup folder that hasn't been downloaded to this Mac/iPhone yet (default "Optimize storage" eviction, or the first time a device sees a backup made elsewhere) is listed by the filesystem under a placeholder name - a leading dot plus an `.icloud` suffix - instead of its real name. `isBackupFile`'s plain `.hasSuffix(".noopbak")` check silently dropped those entries, so the restore picker showed nothing even though the files are visible in Finder. This is exactly the cross-device workflow the folder-picker screen itself recommends.
- `BackupSync.iCloudPlaceholderRealName` (pure, unit-tested) recovers the real name from a placeholder. `FolderBackup.listSnapshots()` resolves every raw directory entry through it before filtering, so undownloaded backups now show up in the restore list.
- `FolderBackup.restore(snapshotNamed:)` mirrors the same resolution and, if the picked snapshot is still a placeholder on disk, calls `startDownloadingUbiquitousItem` and gives it a short window (15s, polled) to materialize before restoring - this already runs off the main thread (the screen calls `restore` from a detached `Task`), so the wait doesn't block the UI. Falls back to the original "no longer in your folder" message if it's genuinely gone rather than just not-yet-downloaded.

This is a hypothesis for #278 based on code review, not a confirmed repro - the original report has no reproduction steps or folder details. [Commented on the issue](https://github.com/ryanbr/noop/issues/278#issuecomment-4948176395) asking the reporter to confirm their backup folder is on iCloud Drive.

## Test plan
- [x] `xcodebuild -project Strand.xcodeproj -scheme Strand -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO test -only-testing:StrandTests/BackupSyncTests` - 12/12 pass, including two new cases for the placeholder-name resolution.
- [ ] Reporter confirmation that their folder is on iCloud Drive and the files show as not-yet-downloaded in Finder.