### PR TITLE
fix: resolve Coupled view / Today HR band to the canonical main-night span

### DIFF
--- a/Strand/Screens/CoupledView.swift
+++ b/Strand/Screens/CoupledView.swift
@@ -41,6 +41,11 @@ struct CoupledView: View {
     /// (the #819 pattern), reading drivers derived from the same displayed row the ring shows.
     @State private var showChargeBreakdown = false
 
+    /// The learned habitual midsleep (local time-of-day seconds), loaded once so the bed→wake span
+    /// resolves the SAME main-night pick the Sleep tab hero and the daily total use (#294). nil under
+    /// the cold-start threshold, which keeps the broad overnight-band bonus.
+    @State private var habitualMidsleepSec: Int? = nil
+
     /// The day the coupled read describes, today's resolved row (the same `resolveToday` #304/#144 boundary
     /// Today anchors on), never a second store read.
     private var day: DailyMetric? { repo.today }
@@ -133,6 +138,11 @@ struct CoupledView: View {
             footerCaption
         }
         .sheet(isPresented: $showChargeBreakdown) { chargeBreakdownSheet }
+        // Loads the SAME learned habitual the Sleep tab hero threads into its main-night pick, so the
+        // bed→wake span below resolves identically (#294). Re-runs on a sync/import refresh.
+        .task(id: repo.refreshSeq) {
+            habitualMidsleepSec = await repo.habitualMidsleepSec()
+        }
     }
 
     // MARK: Header subtitle, "Today, d MMM"
@@ -452,15 +462,19 @@ struct CoupledView: View {
         return Swift.max(450, mean ?? 450)   // 450 min = 7.5h
     }
 
-    /// Last night's bed → wake span, e.g. "23:41 – 07:23", from the freshest banked sleep session, only
-    /// when that session actually touches today's window (a days-old import is not "last night").
+    /// Last night's bed → wake span, e.g. "23:41 – 07:23", from the day's bridged MAIN-night span
+    /// (`SleepView.mainNightSpan`, the SAME resolver the Sleep tab hero and the daily total use), only
+    /// when that night actually touches today's window (a days-old import is not "last night"). Was
+    /// previously the screen's own "freshest-ending session" pick, which could name a different block —
+    /// and so a different span — than the Sleep tab and Today's HR graph for a night stored as more than
+    /// one block (#294).
     private var bedWakeSpanText: String? {
         let dayStart = Calendar.current.startOfDay(for: Repository.logicalDay(Date()))
         let windowStart = Int(dayStart.timeIntervalSince1970)
-        guard let s = repo.sleeps.filter({ $0.endTs > windowStart }).max(by: { $0.endTs < $1.endTs }) else {
-            return nil
-        }
-        return "\(clockString(s.effectiveStartTs)) - \(clockString(s.endTs))"
+        let candidates = repo.sleeps.filter { $0.endTs > windowStart }
+        guard let span = SleepView.mainNightSpan(candidates, habitualMidsleepSec: habitualMidsleepSec)
+        else { return nil }
+        return "\(clockString(span.start)) - \(clockString(span.end))"
     }
 
     // MARK: Footer

--- a/Strand/Screens/SleepView.swift
+++ b/Strand/Screens/SleepView.swift
@@ -1845,6 +1845,18 @@ struct SleepView: View {
         return idx.map { sessions[$0] }.sorted { $0.effectiveStartTs < $1.effectiveStartTs }
     }
 
+    /// The day's main-night bridged SPAN (onset → wake), the same window `mainNightGroup` bridges into
+    /// one continuous night. The ONE canonical bed/wake read every glance screen (Coupled, Today's HR
+    /// band) should show — never a screen-local "freshest" or "longest single block" heuristic, which
+    /// can silently disagree with each other and with the Sleep tab hero on a night stored as more than
+    /// one block (#294). nil only when `sessions` has nothing bridgeable.
+    static func mainNightSpan(_ sessions: [CachedSleepSession],
+                              habitualMidsleepSec: Int? = nil) -> (start: Int, end: Int)? {
+        let group = mainNightGroup(sessions, habitualMidsleepSec: habitualMidsleepSec)
+        guard let first = group.first, let last = group.last else { return nil }
+        return (first.effectiveStartTs, last.endTs)
+    }
+
     /// Soft nap-duration hint retained for callers/tests; the nap CLASSIFICATION is now purely "not the
     /// chosen main block" (see `isNap`), never an independent duration/onset test. (#518/#547)
     static let napMaxHours: Double = 3.0

--- a/Strand/Screens/TodayView.swift
+++ b/Strand/Screens/TodayView.swift
@@ -3899,11 +3899,19 @@ struct TodayView: View {
         // Sleep session overlapping the window. Uses `allSleepSessions` (BOTH the imported and the
         // on-device COMPUTED source), a Bluetooth-only user's sleep lives under the computed source,
         // so the imported-only `sleepSessions` returns nothing. Keep blocks that actually overlap the
-        // displayed window, then pick the LONGEST, the main night, not an afternoon nap. Drives the
-        // HR sleep band + the recovery marker's wake anchor.
-        let sleepTodayLocal = await repo.allSleepSessions(days: selectedDayOffset + 2)
+        // displayed window, then resolve the day's bridged MAIN-night span via `SleepView.mainNightSpan`
+        // (offloaded to the Sleep tab hero and `AnalyticsEngine`'s daily total), not an ad hoc "longest
+        // single block" pick — that could disagree with the Sleep tab and the Coupled view's bed→wake
+        // read for a night stored as more than one block (#294). Drives the HR sleep band + the recovery
+        // marker's wake anchor.
+        let overlapping = await repo.allSleepSessions(days: selectedDayOffset + 2)
             .filter { $0.endTs > windowStart && $0.startTs < windowEnd }
-            .max(by: { ($0.endTs - $0.startTs) < ($1.endTs - $1.startTs) })
+        let habitualMidsleepSecLocal = await repo.habitualMidsleepSec()
+        let sleepTodayLocal = SleepView.mainNightSpan(overlapping, habitualMidsleepSec: habitualMidsleepSecLocal)
+            .map { span in
+                CachedSleepSession(startTs: span.start, endTs: span.end,
+                                   efficiency: nil, restingHr: nil, avgHrv: nil, stagesJSON: nil)
+            }
         sleepToday = sleepTodayLocal
 
         // #932: snapshot everything just computed onto the long-lived `repo`, keyed by the (seq, day) this

--- a/android/app/src/main/java/com/noop/ui/CoupledScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/CoupledScreen.kt
@@ -101,6 +101,13 @@ fun CoupledScreen(
         }.getOrDefault(emptyList())
     }
 
+    // The learned habitual midsleep the Sleep tab hero threads into its main-night pick, so the bed-wake
+    // span below resolves the IDENTICAL block (#294) instead of a screen-local heuristic.
+    var habitualMidsleepSec by remember { mutableStateOf<Long?>(null) }
+    LaunchedEffect(days) {
+        habitualMidsleepSec = runCatching { vm.repo.habitualMidsleepSec("my-whoop") }.getOrNull()
+    }
+
     // Imported export-verbatim sleep figures (sleep_performance / need), preferred over the on-device
     // approximation, mirroring SleepScreen. Keyed on `days` (metricSeries has no Flow).
     var importedPerf by remember { mutableStateOf<Map<String, Double>>(emptyMap()) }
@@ -188,7 +195,7 @@ fun CoupledScreen(
             sleepPerformance = sleepPerformance,
             asleepMin = todayRow?.totalSleepMin,
             needMin = sleepNeedForDay(todayRow, days, importedNeed),
-            bedWakeSpan = bedWakeSpan(sleeps),
+            bedWakeSpan = bedWakeSpan(sleeps, habitualMidsleepSec),
             onOpenSleep = onOpenSleep,
         )
         Text(
@@ -569,12 +576,19 @@ private fun sleepNeedForDay(day: DailyMetric?, days: List<DailyMetric>, imported
     return maxOf(450.0, mean ?: 450.0) // 450 min = 7.5h
 }
 
-/** Last night's bed -> wake span, only when the freshest session touches last night, not a days-old import. */
-private fun bedWakeSpan(sleeps: List<SleepSession>): String? {
+/**
+ * Last night's bed -> wake span, from the day's bridged MAIN-night span ([mainSleepSpan], the SAME
+ * resolver the Sleep tab hero and the daily total use), only when that night actually touches the last
+ * 36h (a days-old import is not "last night"). Was previously this screen's own "freshest-ending
+ * session" pick, which could name a different block -- and so a different span -- than the Sleep tab and
+ * Today's HR graph for a night stored as more than one block (#294).
+ */
+private fun bedWakeSpan(sleeps: List<SleepSession>, habitualMidsleepSec: Long?): String? {
     val windowStart = System.currentTimeMillis() / 1000L - 36 * 3600L // within the last 36h counts as last night
-    val s = sleeps.filter { it.endTs > windowStart }.maxByOrNull { it.endTs } ?: return null
+    val candidates = sleeps.filter { it.endTs > windowStart }
+    val span = mainSleepSpan(candidates, habitualMidsleepSec) ?: return null
     val fmt = SimpleDateFormat("HH:mm", Locale.getDefault())
-    return "${fmt.format(Date(s.effectiveStartTs * 1000L))} - ${fmt.format(Date(s.endTs * 1000L))}"
+    return "${fmt.format(Date(span.first * 1000L))} - ${fmt.format(Date(span.second * 1000L))}"
 }
 
 // MARK: - OPTIMAL strain range (task #43) — pure display-only recovery->strain mapping

--- a/android/app/src/main/java/com/noop/ui/SleepScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/SleepScreen.kt
@@ -2682,6 +2682,20 @@ internal fun mainSleepGroup(blocks: List<SleepSession>, habitualMidsleepSec: Lon
     return idx.map { blocks[it] }.sortedBy { it.effectiveStartTs }
 }
 
+/**
+ * The day's main-night bridged SPAN (onset -> wake), the same window [mainSleepGroup] bridges into one
+ * continuous night. The ONE canonical bed/wake read every glance screen (Coupled, Today's HR band) should
+ * show -- never a screen-local "freshest" or "longest single block" heuristic, which can silently disagree
+ * with each other and with the Sleep tab hero on a night stored as more than one block (#294). null only
+ * when `blocks` has nothing bridgeable. Mirrors iOS SleepView.mainNightSpan.
+ */
+internal fun mainSleepSpan(blocks: List<SleepSession>, habitualMidsleepSec: Long? = null): Pair<Long, Long>? {
+    val group = mainSleepGroup(blocks, habitualMidsleepSec)
+    val first = group.firstOrNull() ?: return null
+    val last = group.lastOrNull() ?: return null
+    return first.effectiveStartTs to last.endTs
+}
+
 /** Longest a leading block can be and still be treated as a spurious pre-sleep awake stub (lying in bed
  *  before sleep). Generous (a few hours) because the reporter's stub ran 21:41 → 00:27 — ~2h45m of pre-sleep
  *  awake — so a tight cap missed it (#736). The real guard against swallowing a genuine first sleep fragment

--- a/android/app/src/main/java/com/noop/ui/TodayScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/TodayScreen.kt
@@ -4450,10 +4450,17 @@ private fun HeartRateTrendCard(
         buckets = viewModel.repo.hrBucketsUnion(viewModel.activeStrapId, start, end, 300L)
         // The sleep that ended within the chart window (the night before / this morning), anchors
         // the band + the Charge-at-wake marker. A wide lower bound catches an onset before midnight.
+        // Resolves the day's bridged MAIN-night span via `mainSleepSpan` (the SAME resolver the Sleep
+        // tab hero and AnalyticsEngine's daily total use), not an ad hoc "freshest-ending block" pick --
+        // that could disagree with the Sleep tab and the Coupled view's bed-wake read for a night stored
+        // as more than one block (#294).
         sleepToday = runCatching {
-            viewModel.repo.sleepSessions("my-whoop", start - 18 * 3600L, end)
+            val overlapping = viewModel.repo.sleepSessions("my-whoop", start - 18 * 3600L, end)
                 .filter { it.startTs <= end && it.endTs >= start }   // overlaps the window
-                .maxByOrNull { it.endTs }
+            val habitualMidsleepSec = viewModel.repo.habitualMidsleepSec("my-whoop")
+            mainSleepSpan(overlapping, habitualMidsleepSec)?.let { (spanStart, spanEnd) ->
+                SleepSession(deviceId = "my-whoop", startTs = spanStart, endTs = spanEnd)
+            }
         }.getOrNull()
         // Workouts overlapping the window, each gets a sport glyph at its in-window HR peak.
         // Union every source (not just "my-whoop"): Health-Connect-imported sessions are stored

--- a/android/app/src/test/java/com/noop/ui/MainSleepSpanTest.kt
+++ b/android/app/src/test/java/com/noop/ui/MainSleepSpanTest.kt
@@ -1,0 +1,56 @@
+package com.noop.ui
+
+import com.noop.data.SleepSession
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * #294: the Coupled view's bed-wake span and Today's HR-graph sleep band each invented their own pick
+ * for "last night" instead of using the canonical bridged main-night resolver ([mainSleepGroup]) the
+ * Sleep tab hero and the daily total already agree on. A night recorded as two stored fragments (a
+ * brief mid-night wake, gap < [com.noop.analytics.SleepStageTotals.GAP_BRIDGE_MAX_MIN]) then showed a
+ * DIFFERENT span on each screen: Coupled's old "freshest-ending block" pick and Today's old "longest
+ * single block" pick both landed on the SECOND fragment alone, silently dropping the first fragment
+ * from the reported bedtime. [mainSleepSpan] is the shared fix.
+ */
+class MainSleepSpanTest {
+
+    private val fragment1 = SleepSession(
+        deviceId = "my-whoop",
+        startTs = 1_800_000_000L,                                    // onset
+        endTs = 1_800_000_000L + 2 * 3600 + 14 * 60,                 // 2h14m asleep, then a brief wake
+    )
+
+    // A 20-minute mid-night wake -- well under GAP_BRIDGE_MAX_MIN (60 min) -- so this is ONE
+    // interrupted night, not a nap followed by a separate main sleep.
+    private val fragment2 = SleepSession(
+        deviceId = "my-whoop",
+        startTs = fragment1.endTs + 20 * 60,
+        endTs = fragment1.endTs + 20 * 60 + 4 * 3600 + 41 * 60,      // 4h41m asleep, then wake
+    )
+
+    @Test
+    fun bridgesBothFragmentsIntoOneSpan() {
+        val span = mainSleepSpan(listOf(fragment1, fragment2))
+        assertEquals(fragment1.effectiveStartTs to fragment2.endTs, span)
+    }
+
+    @Test
+    fun oldFreshestEndingPickWouldHaveTruncatedTheNight() {
+        // The bug this guards: picking by "latest endTs" alone (Coupled view's old heuristic) names
+        // only the second fragment, silently dropping the first fragment of the night.
+        val freshestEndingPick = listOf(fragment1, fragment2).maxByOrNull { it.endTs }!!
+        val span = mainSleepSpan(listOf(fragment1, fragment2))!!
+        assertTrue(span.first < freshestEndingPick.effectiveStartTs)
+    }
+
+    @Test
+    fun oldLongestSingleBlockPickWouldHaveTruncatedTheNight() {
+        // Today's old heuristic (longest single overlapping block) also names only the second
+        // fragment here, since it out-lasts the first alone.
+        val longestSinglePick = listOf(fragment1, fragment2).maxByOrNull { it.endTs - it.startTs }!!
+        val span = mainSleepSpan(listOf(fragment1, fragment2))!!
+        assertTrue(span.first < longestSinglePick.effectiveStartTs)
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #294 ("Three views - 3 different values"): on a night stored as more than one sleep block (e.g. a brief mid-night wake), the Coupled view's bed→wake caption, Today's HR-graph sleep band, and the Sleep tab each showed a *different* span for the same night.

**Root cause:** three independent, ad hoc "pick last night's sleep" heuristics, only one of which was correct:
- **Sleep tab (correct)** — the canonical, fragment-bridging resolver (`mainNightGroupIndices`/`mainNightIndex`), the same one `AnalyticsEngine`'s daily total is built on.
- **Coupled view** — picked the block with the *latest end*, ignoring fragmentation.
- **Today's HR graph** — picked the *longest single* overlapping block, a third, different heuristic.

When a night is split into fragments (a short overnight wake between them), these three picks can each land on a different block, showing three different bed/wake times for the same night.

**Fix:** both screens, on both platforms, now resolve the bed→wake span through the SAME bridged-group resolver the Sleep tab already uses:
- iOS: new `SleepView.mainNightSpan(_:habitualMidsleepSec:)`, built on the existing `mainNightGroup`.
- Android: new `mainSleepSpan(...)` in `SleepScreen.kt`, built on the existing `mainSleepGroup`.

Display-only change — no analytics formula, stored value, or migration touched.

## Test plan

- [x] Swift: `xcodebuild -project Strand.xcodeproj -scheme Strand -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO build` → **BUILD SUCCEEDED** (covers the app-target Swift changes in `Strand/Screens/*.swift`, which `swift-packages.yml` does not build).
- [x] Android: `./gradlew compileFullDebugKotlin` → **BUILD SUCCESSFUL**.
- [x] Android: `./gradlew testFullDebugUnitTest --tests "com.noop.ui.*"` → all green, including a new `MainSleepSpanTest` that pins the regression (a two-fragment night bridges into one full span, rather than truncating to the second fragment the way both old heuristics did).
- [ ] Not tested on a real strap — this only changes which already-stored block(s) a display label reads, no BLE path touched.