### PR TITLE
Sleep: hero reads the Rest composite, not the hours-vs-need proxy (#298)

### DIFF
--- a/android/app/src/main/java/com/noop/ui/SleepScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/SleepScreen.kt
@@ -2887,11 +2887,14 @@ internal fun buildSleepModel(
     // Per-tile metrics — each a full pass over the FULL day history (asleep totals, no in-bed
     // substitution), latest = the most-recent day. Mirrors iOS SleepView, where every tile series
     // is `metric { … }` over repo.days. Where the WHOOP export carried the figure verbatim
-    // (metricSeries), it wins per day; the on-device recomputation is the APPROXIMATE fallback.
+    // (metricSeries), it wins per day; the on-device recomputation fills the rest.
     val performance = metric(days) { d ->
-        imported.performance[d.day]   // WHOOP's own 0–100 figure wins per day
-            ?: d.totalSleepMin?.takeIf { it > 0.0 && needMin > 0.0 }
-                ?.let { minOf(100.0, it / needMin * 100.0) }   // APPROXIMATE fallback
+        imported.performance[d.day]                       // WHOOP's own 0–100 figure wins per day
+            // else the REAL Rest composite (RestScorer.restFromDaily) — the SAME single source of
+            // truth the Today Rest score, the metric-detail overlay (below) and iOS SleepView
+            // (AnalyticsEngine.Rest.composite(daily:)) read. The old hours-vs-need proxy ceilinged
+            // live 5.0 nights at 100% here while every other surface showed the ~85% composite (#298).
+            ?: com.noop.analytics.RestScorer.restFromDaily(d)
     }
     val efficiency = metric(days) { d ->
         d.efficiency?.let { if (it <= 1.0) it * 100.0 else it }

--- a/android/app/src/test/java/com/noop/ui/SleepImportedFiguresTest.kt
+++ b/android/app/src/test/java/com/noop/ui/SleepImportedFiguresTest.kt
@@ -1,16 +1,18 @@
 package com.noop.ui
 
+import com.noop.analytics.RestScorer
 import com.noop.data.DailyMetric
 import com.noop.data.SleepSession
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 /**
  * Pins the Sleep screen's prefer-imported logic: where the WHOOP export carried a figure
  * verbatim (sleep_performance / sleep_consistency / sleep_need_min / sleep_debt_min in
  * metricSeries), the headline tiles must pass it through unscaled; days the export does
- * not cover keep the on-device APPROXIMATE fallback so sparklines stay continuous across
+ * not cover fall back to the on-device RECOMPUTATION so sparklines stay continuous across
  * the import horizon.
  */
 class SleepImportedFiguresTest {
@@ -45,15 +47,42 @@ class SleepImportedFiguresTest {
     }
 
     @Test
-    fun uncoveredDaysFallBackToApproximation() {
-        // Imported covers only day 1; day 2 (the latest) must use the on-device fallback
-        // (asleep / personal need, capped 100; need = max(450, mean asleep) = 450 here).
+    fun uncoveredDaysUseTheRestComposite() {
+        // Imported covers only day 1; day 2 (the latest) must use the REAL Rest composite
+        // (RestScorer.restFromDaily) — the SAME single source of truth the Today Rest score,
+        // the metric-detail overlay and iOS SleepView read — NOT the old hours-vs-need proxy
+        // that ceilinged live 5.0 nights at ~100% while every other surface showed ~85% (#298).
         val days = listOf(day("2026-06-01", 420.0), day("2026-06-02", 410.0))
         val imported = ImportedSleepSeries(performance = mapOf("2026-06-01" to 85.0))
         val m = buildSleepModel(days, session = null, imported = imported)!!
-        assertEquals(410.0 / 450.0 * 100.0, m.performance.latest!!, 1e-9)
+        assertEquals(RestScorer.restFromDaily(days[1])!!, m.performance.latest!!, 1e-9)
+        // …and it is NOT the retired asleep/need approximation.
+        assertNotEquals(410.0 / 450.0 * 100.0, m.performance.latest!!, 1e-6)
         // …and the imported day still carries the verbatim figure inside the series.
         assertEquals(85.0, m.performance.series.first(), 1e-9)
+    }
+
+    /** #298 regression: a live night long enough to CEILING the old asleep/need proxy at 100%
+     *  must instead show the Rest composite (< 100 once efficiency / restorative pull it down),
+     *  matching the tap-through metric-detail overlay and the Today Rest score. */
+    @Test
+    fun longLiveNightShowsCompositeNotCeilingedProxy() {
+        // 8 h asleep, 82% efficiency, modest deep+REM → asleep ≥ personal need, so the OLD proxy
+        // would read min(100, 480/450·100) = 100%. The composite scores the quality, landing < 100.
+        val night = DailyMetric(
+            deviceId = "my-whoop", day = "2026-06-02", totalSleepMin = 480.0,
+            deepMin = 70.0, remMin = 80.0, lightMin = 330.0, efficiency = 0.82,
+        )
+        val days = listOf(
+            DailyMetric(deviceId = "my-whoop", day = "2026-06-01", totalSleepMin = 420.0,
+                deepMin = 70.0, remMin = 80.0, lightMin = 270.0, efficiency = 0.85),
+            night,
+        )
+        val m = buildSleepModel(days, session = null)!!
+        val composite = RestScorer.restFromDaily(night)!!
+        assertEquals(composite, m.performance.latest!!, 1e-9)
+        assertTrue("composite should be below the 100% proxy ceiling", composite < 100.0)
+        assertNotEquals(100.0, m.performance.latest!!, 1e-6)
     }
 
     @Test


### PR DESCRIPTION
## What & why

Fixes #298 — on the Sleep tab, the hero score read **100%** while the tap-through metric-detail overlay, the Today Rest score, and the home screen all showed the real **~85%** for the same night (reported on a live WHOOP 5.0).

Root cause: the Sleep-tab hero takes its performance value from `buildSleepModel`, whose fallback for days the WHOOP export doesn't cover was a rough hours-vs-need proxy `min(100, asleep/need*100)`. On a live 5.0 night (no imported figure) a long sleep ceilings that proxy at ~100%, while every other surface reads the real Rest composite (`RestScorer.restFromDaily` / `AnalyticsEngine.Rest.composite(daily:)`) — so the top of the tab disagreed with the overlay and Today.

The fix points the hero fallback at `RestScorer.restFromDaily(d)` too — the single source of truth already used by:
- the metric-detail overlay (`SleepScreen.kt`, `sleep_performance` branch),
- `CoupledScreen.kt`,
- the Today Rest tile (`AppViewModel`),
- and **iOS `SleepView.swift`** (`AnalyticsEngine.Rest.composite(daily:)`).

## Cross-platform parity

Android-only change that **removes** divergence from iOS — iOS already reads the composite here (its #614 follow-up); the Android hero was simply never migrated. Not a stored-data or analytics-math change, so no schema/byte-parity migration.

## Testing

- `./gradlew compileFullDebugKotlin` — BUILD SUCCESSFUL (app-target Kotlin isn't in default CI, so compiled locally).
- `./gradlew testFullDebugUnitTest --tests com.noop.ui.SleepImportedFiguresTest` — green. Updated the one case that pinned the retired proxy to assert the composite, and added `longLiveNightShowsCompositeNotCeilingedProxy`: a night long enough to ceiling the old proxy at 100% now shows the sub-100 composite.
- ⚠️ Not driven on a real strap — the value path is unit-covered, but the live-BLE display on a physical WHOOP 5.0 is only verifiable on hardware.

## Not in scope

#299 (the same reporter's "Rest always ~85% on live 5.0 nights") is a **separate** problem — the known 5.0 live sleep-staging gap, where the stager's inputs are near-constant so the composite barely varies. It needs an export + strap log and the ongoing staging RE, not a wiring change, so it's intentionally left out of this PR.
