### PR TITLE
fix(android/i18n): German strings for the compact widget (fixes Android CI on main)

### DIFF
--- a/android/app/src/main/res/values-de/strings.xml
+++ b/android/app/src/main/res/values-de/strings.xml
@@ -3,6 +3,8 @@
     <!-- German (de). App name stays untranslated (brand). Nav terms mirror the iOS German pass where
          one exists, so the two platforms read the same. -->
     <string name="widget_description">Ruhe, Ladung und Anstrengung von heute, mit Live-Herzfrequenz und Band-Akku auf einen Blick.</string>
+    <string name="widget_compact_name">NOOP Kompakt</string>
+    <string name="widget_compact_description">Kompaktes Widget für Ruhe, Ladung und Anstrengung, mit Live-Herzfrequenz und Band-Akku.</string>
     <string name="widget_error">Das NOOP-Widget konnte nicht gezeichnet werden. Es erholt sich beim nächsten Update.</string>
 
     <string name="nav_today">Heute</string>


### PR DESCRIPTION
Android CI on main fails since the compact widget (#77):
`GermanLocalizationTest.germanResourcesResolveForEveryLocalizedKey` — `widget_compact_name` and `widget_compact_description` were added to `values/strings.xml` but not `values-de/`.

This adds the two German strings, reusing the established terms from `widget_description` (Ruhe/Ladung/Anstrengung, Live-Herzfrequenz, Band-Akku):

- `widget_compact_name` → "NOOP Kompakt"
- `widget_compact_description` → "Kompaktes Widget für Ruhe, Ladung und Anstrengung, mit Live-Herzfrequenz und Band-Akku."

Verified the test's key-parity check passes with the same XML parse it uses (every non-`app_name` key in `values/` now resolves in `values-de/`, none blank, `app_name` not redeclared). I can't run the Gradle suite locally (no Android toolchain), so CI here is the proof.