### PR TITLE
fix(android): give every notifier a distinct notification id (#297)

### DIFF
--- a/android/app/src/main/java/com/noop/notif/BatteryAlertNotifier.kt
+++ b/android/app/src/main/java/com/noop/notif/BatteryAlertNotifier.kt
@@ -75,9 +75,12 @@ internal object BatteryAlertPolicy {
  */
 object BatteryAlertNotifier {
     private const val CHANNEL_ID = "noop_battery_alert"
-    private const val NOTIF_ID_LOW = 4203
-    private const val NOTIF_ID_FULL = 4204
+    // #297: each notifier posts under a DISTINCT id (notify() is tagless, so a shared id silently
+    // replaces an undismissed notification). Full map: 4201 connection, 4202 illness, 4203 inactivity,
+    // 4204 smart alarm, 4205/4206/4207 battery (runtime/low/full), 4208/4209 scheduled report.
     private const val NOTIF_ID_RUNTIME = 4205
+    private const val NOTIF_ID_LOW = 4206
+    private const val NOTIF_ID_FULL = 4207
 
     /**
      * Predictive twin of [onBatteryUpdate]: run the runtime estimate against

--- a/android/app/src/main/java/com/noop/notif/ScheduledReportNotifier.kt
+++ b/android/app/src/main/java/com/noop/notif/ScheduledReportNotifier.kt
@@ -95,8 +95,10 @@ object ScheduledReportPolicy {
 
 object ScheduledReportNotifier {
     private const val CHANNEL_ID = "noop_scheduled_reports"
-    private const val MORNING_NOTIF_ID = 4203 // 4201 ongoing, 4202 illness
-    private const val WORKOUT_NOTIF_ID = 4204
+    // #297: distinct ids so a report never silently replaces another notifier's (tagless notify()).
+    // Map: 4201 connection, 4202 illness, 4203 inactivity, 4204 smart alarm, 4205/4206/4207 battery.
+    private const val MORNING_NOTIF_ID = 4208
+    private const val WORKOUT_NOTIF_ID = 4209
 
     /**
      * Post the morning recap if enabled and not already posted today. [chargePct]/[restPct] are the


### PR DESCRIPTION
Closes #297. Reimplements #289 with the collision corrected.

## The bug
`notify()` is called tagless, so notifiers sharing an id silently replace each other's undismissed notifications. On main:
- **4203** — InactivityNotifier, BatteryAlertNotifier.`NOTIF_ID_LOW`, ScheduledReportNotifier.`MORNING` (3-way)
- **4204** — SmartAlarmNotifier, BatteryAlertNotifier.`NOTIF_ID_FULL`, ScheduledReportNotifier.`WORKOUT` (3-way)

A low-battery warning could wipe the morning recap, a move reminder wipe the low-battery warning, etc.

## Fix
Fully-distinct map: `4201` connection · `4202` illness · `4203` inactivity · `4204` smart alarm · `4205/4206/4207` battery (runtime/low/full) · `4208/4209` scheduled report (morning/workout). Verified all nine ids are unique.

## Why not #289
#289 moved `NOTIF_ID_LOW` to **4205** — but `NOTIF_ID_RUNTIME` in the *same file* is already 4205, so it traded one collision for another (battery has **three** posters, not two). It also bundled an unrelated 200-line `AUDIT.md`. This drops both problems.

Android-only; `compileFullDebugKotlin` clean; ids verified distinct by grep.