### PR TITLE
ble: extract GET_DATA_RANGE newest-parse into WhoopProtocol so both platforms CI-test the parity (#286 follow-up)

### DIFF
--- a/Packages/WhoopProtocol/Sources/WhoopProtocol/DataRange.swift
+++ b/Packages/WhoopProtocol/Sources/WhoopProtocol/DataRange.swift
@@ -1,0 +1,35 @@
+import Foundation
+
+/// GET_DATA_RANGE frame parsing. Pure + byte-identical to the Kotlin twin `com.noop.protocol.DataRange`.
+///
+/// Extracted from `BLEManager`/`WhoopBleClient` (#286 follow-up): the newest-record read gates automatic
+/// sync (`isFutureDatedNewest` → `BackfillPolicy`), so its value must stay byte-identical across platforms.
+/// Living here means both a WhoopProtocol `swift test` and the Kotlin JVM test pin the parity — the app-target
+/// copies were previously testable on the Kotlin side only.
+public enum DataRange {
+    /// The newest plausible unix time banked by the strap, from a GET_DATA_RANGE frame.
+    ///
+    /// Scans EVERY byte offset — the newest-record `u32` isn't on a fixed grid (it sits at byte offset 8 on
+    /// WHOOP 4.0, off the old aligned-from-7 scan, which straddled it and returned nil). Keeps the newest
+    /// word inside a plausible unix window (2023-11…2030-03), preferring the newest that is NOT implausibly
+    /// future (> `wallNowUnix + futureSkewSeconds`) so a garbage future word can't latch and stall auto-sync
+    /// (#451/#928/#1012). Falls back to the newest-any word so a genuinely future-dated RTC is still surfaced
+    /// downstream and the future-date guard still fires. Returns nil only for a too-short frame or no
+    /// plausible word at all.
+    public static func newestUnix(from frame: [UInt8], wallNowUnix: Int, futureSkewSeconds: Int) -> Int? {
+        guard frame.count >= 4 else { return nil }
+        let futureCutoff = wallNowUnix + futureSkewSeconds
+        var newestNotFuture: Int? = nil
+        var newestAny: Int? = nil
+        var i = 0
+        while i + 4 <= frame.count {
+            let w = Int(frame[i]) | Int(frame[i + 1]) << 8 | Int(frame[i + 2]) << 16 | Int(frame[i + 3]) << 24
+            if w >= 1_700_000_000 && w <= 1_900_000_000 {
+                newestAny = max(newestAny ?? 0, w)
+                if w <= futureCutoff { newestNotFuture = max(newestNotFuture ?? 0, w) }
+            }
+            i += 1
+        }
+        return newestNotFuture ?? newestAny
+    }
+}

--- a/Packages/WhoopProtocol/Tests/WhoopProtocolTests/DataRangeTests.swift
+++ b/Packages/WhoopProtocol/Tests/WhoopProtocolTests/DataRangeTests.swift
@@ -1,0 +1,60 @@
+import XCTest
+@testable import WhoopProtocol
+
+/// Byte-parity twin of the Kotlin `DataRangeScanTest`: `DataRange.newestUnix` offset/future-date
+/// correctness (#451/#928/#1012). Same real WHOOP 4.0 GET_DATA_RANGE fixtures, so a Swift-side edit that
+/// drifts from Kotlin fails here (the app-target copies were Kotlin-tested only before this extraction).
+final class DataRangeTests: XCTestCase {
+
+    private let skew48h = 48 * 3600         // AUTO_CONTINUE_FUTURE_SKEW_SECONDS twin
+    private let wallNow = 1_783_786_000      // 2026-07-11 ~16:06, just after the captured newest
+    private let realNewest = 1_783_785_625   // 2026-07-11 16:00:25 (frame a)
+
+    private func hex(_ s: String) -> [UInt8] {
+        stride(from: 0, to: s.count, by: 2).map { off in
+            let start = s.index(s.startIndex, offsetBy: off)
+            let end = s.index(start, offsetBy: 2)
+            return UInt8(s[start..<end], radix: 16)!
+        }
+    }
+
+    /// Little-endian u32 `value` written at `offset` into a `size`-byte frame (rest zero).
+    private func frameWithU32(_ size: Int, _ offset: Int, _ value: Int) -> [UInt8] {
+        var b = [UInt8](repeating: 0, count: size)
+        for k in 0..<4 { b[offset + k] = UInt8((value >> (8 * k)) & 0xFF) }
+        return b
+    }
+
+    func testReadsRealWhoop4NewestAtByteOffset8() {
+        // Three real captured frames → their true newest (offset-8 u32), all 2026-07-11 ~16:00.
+        let expected: [(String, Int)] = [
+            ("aa100057305d22009968526a083900001d2e2263", 1_783_785_625), // 16:00:25
+            ("aa10005730612200a268526ab0290000e87d155d", 1_783_785_634), // 16:00:34
+            ("aa100057307c2200e768526a78760000c997138d", 1_783_785_703), // 16:01:43
+        ]
+        for (h, ts) in expected {
+            XCTAssertEqual(DataRange.newestUnix(from: hex(h), wallNowUnix: wallNow, futureSkewSeconds: skew48h),
+                           ts, "newest for \(h) should be its offset-8 value, not nil")
+        }
+    }
+
+    func testLoneFutureStraddleNeverBecomesFrontier() {
+        let future = wallNow + 400 * 86_400
+        var frame = frameWithU32(16, 4, realNewest)
+        for k in 0..<4 { frame[10 + k] = UInt8((future >> (8 * k)) & 0xFF) }
+        XCTAssertEqual(DataRange.newestUnix(from: frame, wallNowUnix: wallNow, futureSkewSeconds: skew48h),
+                       realNewest)
+    }
+
+    func testAllFutureFrameStillReturnsFutureSoTheGuardFires() {
+        let future = wallNow + 400 * 86_400
+        XCTAssertEqual(DataRange.newestUnix(from: frameWithU32(12, 4, future),
+                                            wallNowUnix: wallNow, futureSkewSeconds: skew48h), future)
+    }
+
+    func testValueJustInsideTheSkewIsPresentNotFuture() {
+        let within = wallNow + 40 * 3600     // 40h ahead, under the 48h skew
+        XCTAssertEqual(DataRange.newestUnix(from: frameWithU32(12, 4, within),
+                                            wallNowUnix: wallNow, futureSkewSeconds: skew48h), within)
+    }
+}

--- a/Strand/BLE/BLEManager.swift
+++ b/Strand/BLE/BLEManager.swift
@@ -3501,25 +3501,11 @@ extension BLEManager: @preconcurrency CBPeripheralDelegate {
     /// frame[7], after [type,seq,cmd]), keep those in the unix range, return the max. nil if none.
     static func dataRangeNewestUnix(from frame: [UInt8],
                                     wallNowUnix: Int = Int(Date().timeIntervalSince1970)) -> Int? {
-        guard frame.count >= 4 else { return nil }
-        // Scan EVERY byte offset (was: 4-byte words from offset 7). The strap's newest-record u32 does not
-        // always land on that grid — on WHOOP 4 it sits at byte offset 8, so the aligned scan straddled it
-        // and returned nil, leaving a stale/garbage word latched in strapNewestTs. Harmless until #228 wired
-        // that value into BackfillPolicy: a FUTURE-reading value now skips the periodic offload, so one bad
-        // read stalls auto-sync (#451/#928/#1012).
-        let futureCutoff = wallNowUnix + BackfillContinuation.defaultFutureSkewSeconds
-        var newestNotFuture: Int? = nil; var newestAny: Int? = nil; var i = 0
-        while i + 4 <= frame.count {
-            let w = Int(frame[i]) | Int(frame[i+1]) << 8 | Int(frame[i+2]) << 16 | Int(frame[i+3]) << 24
-            if w >= 1_700_000_000 && w <= 1_900_000_000 {
-                newestAny = max(newestAny ?? 0, w)
-                if w <= futureCutoff { newestNotFuture = max(newestNotFuture ?? 0, w) }
-            }
-            i += 1
-        }
-        // Prefer the newest word at/behind the wall clock (a device can't record the future); return the
-        // future max only if EVERY plausible word is future — a genuinely future-set RTC (#928).
-        return newestNotFuture ?? newestAny
+        // #286 follow-up: delegate to the pure, twin-tested WhoopProtocol.DataRange (byte-identical to the
+        // Kotlin com.noop.protocol.DataRange) so this parity-critical read — it gates auto-sync via
+        // isFutureDatedNewest → BackfillPolicy — is CI-pinned on BOTH platforms, not the Kotlin side only.
+        DataRange.newestUnix(from: frame, wallNowUnix: wallNowUnix,
+                             futureSkewSeconds: BackfillContinuation.defaultFutureSkewSeconds)
     }
 
     /// The OLDEST plausible record timestamp in a GET_DATA_RANGE frame — the start of the strap's stored

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -797,38 +797,14 @@ class WhoopBleClient(
          * record. Mirrors Swift `BLEManager.dataRangeNewestUnix`: scan u32 LE words in the response
          * body (starts at frame[7], after [type,seq,cmd]), keep those in the unix range, return max.
          */
+        // #286 follow-up: delegate to the pure, twin-tested com.noop.protocol.DataRange (byte-identical to
+        // Swift WhoopProtocol.DataRange) so this parity-critical read — it gates auto-sync via
+        // isFutureDatedNewest → BackfillPolicy — is CI-pinned on BOTH platforms. Thin wrapper so existing
+        // call sites + DataRangeScanTest are unchanged.
         fun dataRangeNewestUnix(
             frame: ByteArray,
             wallNowUnix: Long = System.currentTimeMillis() / 1000L,
-        ): Long? {
-            if (frame.size < 4) return null
-            // Scan EVERY byte offset (was: 4-byte words aligned FROM offset 7). The strap's newest-record
-            // u32 does not always land on that grid — on WHOOP 4 it sits at byte offset 8, so the aligned
-            // scan straddled it and returned null, leaving a stale/garbage word from an earlier misaligned
-            // read latched in [strapNewestTs]. Harmless until #228 wired that value into BackfillPolicy:
-            // a FUTURE-reading strapNewestTs now SKIPS the automatic periodic/strap offload
-            // ([isFutureDatedNewest]), so one bad read stalls auto-sync (#451/#928/#1012).
-            var newestNotFuture: Long? = null
-            var newestAny: Long? = null
-            val futureCutoff = wallNowUnix + AUTO_CONTINUE_FUTURE_SKEW_SECONDS
-            var i = 0
-            while (i + 4 <= frame.size) {
-                val w = (frame[i].toLong() and 0xFFL) or
-                    ((frame[i + 1].toLong() and 0xFFL) shl 8) or
-                    ((frame[i + 2].toLong() and 0xFFL) shl 16) or
-                    ((frame[i + 3].toLong() and 0xFFL) shl 24)
-                if (w in 1_700_000_000L..1_900_000_000L) {
-                    newestAny = maxOf(newestAny ?: 0L, w)
-                    if (w <= futureCutoff) newestNotFuture = maxOf(newestNotFuture ?: 0L, w)
-                }
-                i += 1
-            }
-            // A device cannot record the future: prefer the newest word AT/BEHIND the wall clock (the true
-            // frontier), so a lone future-dated straddle can't hijack it. Only when EVERY plausible word is
-            // future — a genuinely future-set RTC (#928) — return the future max, so [isFutureDatedNewest]
-            // still fires and the auto-continue / periodic guards correctly refuse the range.
-            return newestNotFuture ?: newestAny
-        }
+        ): Long? = com.noop.protocol.DataRange.newestUnix(frame, wallNowUnix, AUTO_CONTINUE_FUTURE_SKEW_SECONDS)
 
         /** OLDEST plausible record timestamp in a GET_DATA_RANGE frame — the start of the strap's stored
          *  history. Same scan as [dataRangeNewestUnix] but keeps the minimum, so one connect can report the

--- a/android/app/src/main/java/com/noop/protocol/DataRange.kt
+++ b/android/app/src/main/java/com/noop/protocol/DataRange.kt
@@ -1,0 +1,38 @@
+package com.noop.protocol
+
+/**
+ * GET_DATA_RANGE frame parsing. Byte-identical twin of Swift `WhoopProtocol.DataRange` — the newest-record
+ * read gates automatic sync (`isFutureDatedNewest` -> BackfillPolicy), so its value must match across
+ * platforms. Extracted from WhoopBleClient (#286 follow-up) so both a Kotlin JVM test and a WhoopProtocol
+ * `swift test` pin the parity.
+ */
+object DataRange {
+    /**
+     * The newest plausible unix time banked by the strap, from a GET_DATA_RANGE frame. Scans EVERY byte
+     * offset (the newest-record u32 isn't on a fixed grid — it sits at byte offset 8 on WHOOP 4, off the
+     * old aligned-from-7 scan), keeps the newest word in a plausible unix window (2023-11..2030-03),
+     * preferring the newest that is NOT implausibly future (> wallNowUnix + futureSkewSeconds) so a garbage
+     * future word can't latch and stall auto-sync (#451/#928/#1012). Falls back to the newest-any word so a
+     * genuinely future-dated RTC is still surfaced downstream. null only for a too-short frame or no
+     * plausible word. Mirrors Swift `DataRange.newestUnix`.
+     */
+    fun newestUnix(frame: ByteArray, wallNowUnix: Long, futureSkewSeconds: Long): Long? {
+        if (frame.size < 4) return null
+        val futureCutoff = wallNowUnix + futureSkewSeconds
+        var newestNotFuture: Long? = null
+        var newestAny: Long? = null
+        var i = 0
+        while (i + 4 <= frame.size) {
+            val w = (frame[i].toLong() and 0xFFL) or
+                ((frame[i + 1].toLong() and 0xFFL) shl 8) or
+                ((frame[i + 2].toLong() and 0xFFL) shl 16) or
+                ((frame[i + 3].toLong() and 0xFFL) shl 24)
+            if (w in 1_700_000_000L..1_900_000_000L) {
+                newestAny = maxOf(newestAny ?: 0L, w)
+                if (w <= futureCutoff) newestNotFuture = maxOf(newestNotFuture ?: 0L, w)
+            }
+            i += 1
+        }
+        return newestNotFuture ?: newestAny
+    }
+}


### PR DESCRIPTION
Follow-up to #286. Closes the same byte-parity CI gap the Oura #306 follow-up did.

## Why
`dataRangeNewestUnix` decodes `strapNewestTs`, which **gates automatic sync** (`isFutureDatedNewest` → `BackfillPolicy`), so it must stay **byte-identical** Swift/Kotlin. #286 left it inline in app-target `BLEManager`/`WhoopBleClient` with a **Kotlin test only** — a Swift-side edit could silently drift the parity.

## What
Move the pure scan into:
- **`WhoopProtocol.DataRange`** (Swift — builds + tests on Linux)
- **`com.noop.protocol.DataRange`** (Kotlin)

Byte-identical twins. `BLEManager` and `WhoopBleClient` keep their signatures as **thin wrappers** passing their own future-skew constant, so all call sites + the existing `DataRangeScanTest` are unchanged. Adds **`DataRangeTests` (Swift)** mirroring the Kotlin fixtures — the real WHOOP 4.0 offset-8 frames + the future/skew cases.

## Verification
- **WhoopProtocol `swift test`: 259/259** incl. 4 new `DataRangeTests` — run **locally on Linux** (WhoopProtocol is pure).
- Android `compileFullDebugKotlin` + `DataRangeScanTest` green (wrapper → pure).
- `BLEManager` compile: app-build.
- Now the parity is pinned by CI on **both** platforms (swift-packages + JVM), not the Kotlin side only.