### PR TITLE
ble: extract dataRangeOldestUnix into WhoopProtocol.DataRange + pin the aligned-scan protection (#286 follow-up)

### DIFF
--- a/Packages/WhoopProtocol/Sources/WhoopProtocol/DataRange.swift
+++ b/Packages/WhoopProtocol/Sources/WhoopProtocol/DataRange.swift
@@ -32,4 +32,28 @@ public enum DataRange {
         }
         return newestNotFuture ?? newestAny
     }
+
+    /// The OLDEST plausible unix time banked by the strap (start of stored history), from a GET_DATA_RANGE
+    /// frame — the low end of the banked span (oldest…newest = the backlog DEPTH a deep oldest-first drain
+    /// must cover before recent nights land, #364).
+    ///
+    /// Unlike `newestUnix`, this scans ONLY the 4-byte grid aligned from offset 7, NOT every offset — and
+    /// that asymmetry is DELIBERATE. The minimum is fragile in a way the maximum is not: an any-offset scan
+    /// of a real WHOOP 4.0 frame surfaces a spurious straddle word (offset 6 → 1_754_857_506, ~11 months
+    /// *before* the true newest at offset 8) that would hijack the min and report a bogus deep backlog. The
+    /// max is immune — the real newest dominates it — which is exactly why `newestUnix` can scan every offset.
+    /// The aligned grid skips that straddle, so real frames with no distinct oldest word return nil here.
+    /// Do NOT "make this consistent with `newestUnix`" by scanning every offset without anchoring — see
+    /// `DataRangeTests.testOldestAlignedScanSkipsTheSpuriousOffset6Straddle`.
+    public static func oldestUnix(from frame: [UInt8]) -> Int? {
+        guard frame.count > 7 else { return nil }
+        var oldest: Int? = nil
+        var i = 7
+        while i + 4 <= frame.count {
+            let w = Int(frame[i]) | Int(frame[i + 1]) << 8 | Int(frame[i + 2]) << 16 | Int(frame[i + 3]) << 24
+            if w >= 1_700_000_000 && w <= 1_900_000_000 { oldest = min(oldest ?? .max, w) }
+            i += 4
+        }
+        return oldest
+    }
 }

--- a/Packages/WhoopProtocol/Tests/WhoopProtocolTests/DataRangeTests.swift
+++ b/Packages/WhoopProtocol/Tests/WhoopProtocolTests/DataRangeTests.swift
@@ -57,4 +57,24 @@ final class DataRangeTests: XCTestCase {
         XCTAssertEqual(DataRange.newestUnix(from: frameWithU32(12, 4, within),
                                             wallNowUnix: wallNow, futureSkewSeconds: skew48h), within)
     }
+
+    // MARK: - oldestUnix (aligned-from-7; asymmetric with newestUnix by design)
+
+    /// The whole reason `oldestUnix` scans the aligned grid instead of every offset: the real WHOOP 4.0
+    /// frame carries a spurious plausible straddle at byte offset 6 (1_754_857_506, ~11 months BEFORE the
+    /// true newest at offset 8). An any-offset MIN would return it → a bogus deep backlog. The aligned grid
+    /// skips it, so this frame (no distinct oldest word) → nil. Guards against a future "consistency" refactor.
+    func testOldestAlignedScanSkipsTheSpuriousOffset6Straddle() {
+        XCTAssertNil(DataRange.oldestUnix(from: hex("aa100057305d22009968526a083900001d2e2263")))
+    }
+
+    func testOldestReadsAGridAlignedWord() {
+        XCTAssertEqual(DataRange.oldestUnix(from: frameWithU32(12, 7, 1_750_000_000)), 1_750_000_000)
+    }
+
+    func testOldestKeepsTheMinimumAcrossGridWords() {
+        var frame = frameWithU32(16, 7, 1_800_000_000)              // grid offset 7
+        for k in 0..<4 { frame[11 + k] = UInt8((1_750_000_000 >> (8 * k)) & 0xFF) } // grid offset 11
+        XCTAssertEqual(DataRange.oldestUnix(from: frame), 1_750_000_000)
+    }
 }

--- a/Strand/BLE/BLEManager.swift
+++ b/Strand/BLE/BLEManager.swift
@@ -3513,15 +3513,9 @@ extension BLEManager: @preconcurrency CBPeripheralDelegate {
     /// full banked SPAN (oldest…newest). For the recurring "last night didn't sync" reports (#364) that
     /// span is the backlog DEPTH at a glance: a strap that banked weeks of un-synced history has a wide
     /// span and simply needs time to drain oldest-first, vs. a narrow span that should clear quickly.
+    // #286 follow-up: delegate to the pure, twin-tested WhoopProtocol.DataRange (byte-identical Swift/Kotlin).
     static func dataRangeOldestUnix(from frame: [UInt8]) -> Int? {
-        guard frame.count > 7 else { return nil }
-        let body = Array(frame[7...]); var oldest: Int? = nil; var i = 0
-        while i + 4 <= body.count {
-            let w = Int(body[i]) | Int(body[i+1]) << 8 | Int(body[i+2]) << 16 | Int(body[i+3]) << 24
-            if w >= 1_700_000_000 && w <= 1_900_000_000 { oldest = min(oldest ?? .max, w) }
-            i += 4
-        }
-        return oldest
+        DataRange.oldestUnix(from: frame)
     }
 
     public func peripheral(_ peripheral: CBPeripheral,

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -810,20 +810,8 @@ class WhoopBleClient(
          *  history. Same scan as [dataRangeNewestUnix] but keeps the minimum, so one connect can report the
          *  full banked SPAN (oldest…newest) = the backlog DEPTH a deep oldest-first drain must cover before
          *  recent nights land (#364). Mirrors Swift `BLEManager.dataRangeOldestUnix`. */
-        fun dataRangeOldestUnix(frame: ByteArray): Long? {
-            if (frame.size <= 7) return null
-            var oldest: Long? = null
-            var i = 7
-            while (i + 4 <= frame.size) {
-                val w = (frame[i].toLong() and 0xFFL) or
-                    ((frame[i + 1].toLong() and 0xFFL) shl 8) or
-                    ((frame[i + 2].toLong() and 0xFFL) shl 16) or
-                    ((frame[i + 3].toLong() and 0xFFL) shl 24)
-                if (w in 1_700_000_000L..1_900_000_000L) oldest = minOf(oldest ?: Long.MAX_VALUE, w)
-                i += 4
-            }
-            return oldest
-        }
+        // #286 follow-up: delegate to the pure, twin-tested com.noop.protocol.DataRange (byte-identical Swift).
+        fun dataRangeOldestUnix(frame: ByteArray): Long? = com.noop.protocol.DataRange.oldestUnix(frame)
 
         /** #364 auto-continue cap: consecutive immediate re-kicks per connection before falling back to
          *  the 900s periodic timer. 6 × ~60s ≈ 6 min of back-to-back draining without letting a

--- a/android/app/src/main/java/com/noop/protocol/DataRange.kt
+++ b/android/app/src/main/java/com/noop/protocol/DataRange.kt
@@ -35,4 +35,33 @@ object DataRange {
         }
         return newestNotFuture ?: newestAny
     }
+
+    /**
+     * The OLDEST plausible unix time banked by the strap (start of stored history), from a GET_DATA_RANGE
+     * frame — the low end of the banked span (oldest…newest = the backlog DEPTH a deep oldest-first drain
+     * must cover before recent nights land, #364).
+     *
+     * Unlike [newestUnix], scans ONLY the 4-byte grid aligned from offset 7, NOT every offset — and that
+     * asymmetry is DELIBERATE. The minimum is fragile in a way the maximum is not: an any-offset scan of a
+     * real WHOOP 4.0 frame surfaces a spurious straddle word (offset 6 -> 1_754_857_506, ~11 months *before*
+     * the true newest at offset 8) that would hijack the min and report a bogus deep backlog. The max is
+     * immune — the real newest dominates it — which is why [newestUnix] can scan every offset. The aligned
+     * grid skips that straddle, so real frames with no distinct oldest word return null here. Do NOT "make
+     * this consistent with newestUnix" by scanning every offset without anchoring — see DataRangeScanTest.
+     * Mirrors Swift `DataRange.oldestUnix`.
+     */
+    fun oldestUnix(frame: ByteArray): Long? {
+        if (frame.size <= 7) return null
+        var oldest: Long? = null
+        var i = 7
+        while (i + 4 <= frame.size) {
+            val w = (frame[i].toLong() and 0xFFL) or
+                ((frame[i + 1].toLong() and 0xFFL) shl 8) or
+                ((frame[i + 2].toLong() and 0xFFL) shl 16) or
+                ((frame[i + 3].toLong() and 0xFFL) shl 24)
+            if (w in 1_700_000_000L..1_900_000_000L) oldest = minOf(oldest ?: Long.MAX_VALUE, w)
+            i += 4
+        }
+        return oldest
+    }
 }

--- a/android/app/src/test/java/com/noop/ble/DataRangeScanTest.kt
+++ b/android/app/src/test/java/com/noop/ble/DataRangeScanTest.kt
@@ -67,4 +67,29 @@ class DataRangeScanTest {
         val within = WALL_NOW + 40L * 3600L   // 40h ahead, under the 48h AUTO_CONTINUE_FUTURE_SKEW
         assertEquals(within, WhoopBleClient.dataRangeNewestUnix(frameWithU32(12, 4, within), WALL_NOW))
     }
+
+    // oldestUnix — aligned-from-7 (asymmetric with dataRangeNewestUnix by design)
+
+    /**
+     * The whole reason [WhoopBleClient.dataRangeOldestUnix] scans the aligned grid, not every offset: the
+     * real WHOOP 4.0 frame carries a spurious plausible straddle at byte offset 6 (1_754_857_506, ~11 months
+     * BEFORE the true newest at offset 8). An any-offset MIN would return it → a bogus deep backlog. The
+     * aligned grid skips it, so this frame (no distinct oldest word) → null. Guards a future "consistency" refactor.
+     */
+    @Test
+    fun `oldest aligned scan skips the spurious offset-6 straddle`() {
+        assertEquals(null, WhoopBleClient.dataRangeOldestUnix(hex("aa100057305d22009968526a083900001d2e2263")))
+    }
+
+    @Test
+    fun `oldest reads a grid-aligned word`() {
+        assertEquals(1_750_000_000L, WhoopBleClient.dataRangeOldestUnix(frameWithU32(12, 7, 1_750_000_000L)))
+    }
+
+    @Test
+    fun `oldest keeps the minimum across grid words`() {
+        val frame = frameWithU32(16, 7, 1_800_000_000L)                 // grid offset 7
+        for (k in 0..3) frame[11 + k] = ((1_750_000_000L shr (8 * k)) and 0xFF).toByte() // grid offset 11
+        assertEquals(1_750_000_000L, WhoopBleClient.dataRangeOldestUnix(frame))
+    }
 }


### PR DESCRIPTION
Follow-up to #307. Second (and last) sibling in the GET_DATA_RANGE parser.

## Why
Like `dataRangeNewestUnix` (extracted in #307), `dataRangeOldestUnix` was inline in app-target `BLEManager`/`WhoopBleClient` with **no test on either platform** — yet it's parity-critical: it reports the banked **span = backlog DEPTH** a deep oldest-first drain must cover (#364).

## The re-review catch (why this isn't a mechanical copy of #307)
The oldest read must **NOT** be "made consistent" with the newest by scanning every offset. **The minimum is fragile where the maximum is not.** On a real WHOOP 4.0 frame:

```
aa100057305d22009968526a083900001d2e2263
any-offset plausible words: offset6 -> 1754857506 (2025-08-10)   <- spurious straddle
                            offset8 -> 1783785625 (2026-07-11)   <- true newest
```

- `newestUnix` keeps the **max** → the real newest dominates; the straddle is ignored. That's why it can scan every offset (the #307 fix).
- `oldestUnix` keeps the **min** → an any-offset scan would return the offset-6 straddle → a **bogus ~11-month backlog**. The **aligned-from-7 grid skips it** (real frame → nil).

## What
- Extract the aligned scan **verbatim** (no behaviour change) into **`WhoopProtocol.DataRange.oldestUnix`** (Swift) + **`com.noop.protocol.DataRange.oldestUnix`** (Kotlin), byte-identical twins.
- App-target methods become thin wrappers — call sites unchanged.
- Add Swift + Kotlin tests that **pin the protection**: real frame → nil (straddle skipped), grid-aligned words → min. So a future "consistency" refactor can't silently reintroduce the false-backlog bug. The asymmetry with `newestUnix` is documented in both sources.

## Verification
- **WhoopProtocol `swift test`: 262/262** (+3 oldest) — run locally on Linux.
- Android `compileFullDebugKotlin` + `DataRangeScanTest` green (wrapper → pure).
- `BLEManager` compile: app-build.
- No BLE behaviour change (pure verbatim extraction) — nothing new to test on hardware.