### PR TITLE
test(sleep): frozen-golden V2 hypnogram pins the #277 deep-boundary constants on both platforms

### DIFF
--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/SleepStagerV2Tests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/SleepStagerV2Tests.swift
@@ -160,4 +160,55 @@ final class SleepStagerV2Tests: XCTestCase {
         XCTAssertTrue(v2Stages.contains("deep"), "V2 night should express deep")
         XCTAssertTrue(v2Stages.contains("rem"), "V2 night should express REM")
     }
+
+    // MARK: - #277 frozen golden: pin the tuned V2 recipe (deepGateThresh / deep emission / transition row)
+
+    /// Fixed integer "breathing" wave — no float rounding, so Swift + Kotlin build byte-identical samples
+    /// (Kotlin `roundToInt` is half-up, Swift `.rounded()` is half-away-from-zero; integers avoid the gap).
+    private func rsaWave(_ ph: Int, _ i: Int) -> Int {
+        let amp = [12, 60, 30, 20][ph]
+        return [0, amp, 0, -amp][i % 4]
+    }
+
+    /// Byte-parity twin of Kotlin `SleepStagerV2Test.frozenGoldenHypnogramPinsTheTunedRecipe`. A crafted
+    /// 4-phase night (deep-favorable → high-RSA → mild → restless) staged by V2 must reproduce this EXACT
+    /// hypnogram. #277 set the deep boundary (deepGateThresh, the deep emission weights, the deep transition
+    /// row) a-priori, validated only by an OFFLINE 44-subject benchmark — nothing in CI pinned the constants,
+    /// so a later edit or a Swift↔Kotlin drift could shift stages silently. This locks them on both platforms;
+    /// a one-sided constant change fails here or in the Kotlin twin. Integer-only / fixed-literal input so the
+    /// two languages build identical samples. Regenerate deliberately if the recipe is intentionally retuned.
+    func testFrozenGoldenHypnogram() {
+        let start = 1_749_517_200
+        let phase = 90 * 60
+        let dur = phase * 4
+        var grav: [GravitySample] = []
+        var hr: [HRSample] = []
+        var rr: [RRInterval] = []
+        for i in 0..<dur {
+            let ts = start + i
+            let ph = i / phase
+            let restless = ph == 3 && (i % 20) < 6
+            grav.append(restless ? GravitySample(ts: ts, x: 0.2, y: 0.15, z: 0.96)
+                                  : GravitySample(ts: ts, x: 0, y: 0, z: 1.0))
+            let bpm: Int
+            switch ph {
+            case 0: bpm = 50
+            case 1: bpm = 54 + [0, 1, 2, 3, 2, 1][(i / 20) % 6]
+            case 2: bpm = 56 + ((i / 60) % 4)
+            default: bpm = 66 + ((i / 30) % 6)
+            }
+            hr.append(HRSample(ts: ts, bpm: bpm))
+            rr.append(RRInterval(ts: ts, rrMs: (60_000 / bpm) + rsaWave(ph, i)))
+        }
+        let segs = SleepStagerV2.stageSession(start: start, end: start + dur, grav: grav, hr: hr, rr: rr, resp: [])
+        let golden: [(Int, Int, String)] = [
+            (0, 5070, "deep"), (5070, 5310, "light"), (5310, 5550, "rem"),
+            (5550, 10740, "light"), (10740, 16290, "rem"), (16290, 21600, "wake")]
+        XCTAssertEqual(segs.count, golden.count, "segment count")
+        for k in 0..<min(segs.count, golden.count) {
+            XCTAssertEqual(segs[k].start, start + golden[k].0, "seg \(k) start")
+            XCTAssertEqual(segs[k].end, start + golden[k].1, "seg \(k) end")
+            XCTAssertEqual(segs[k].stage, golden[k].2, "seg \(k) stage")
+        }
+    }
 }

--- a/android/app/src/test/java/com/noop/analytics/SleepStagerV2Test.kt
+++ b/android/app/src/test/java/com/noop/analytics/SleepStagerV2Test.kt
@@ -154,4 +154,62 @@ class SleepStagerV2Test {
         assertTrue("V2 night should express deep", "deep" in v2Stages)
         assertTrue("V2 night should express REM", "rem" in v2Stages)
     }
+
+    // ── #277 frozen golden: pin the tuned V2 recipe (deepGateThresh / deep emission / transition row) ──────
+
+    /** Fixed integer "breathing" wave — no float rounding, so Swift + Kotlin build byte-identical samples
+     *  (Kotlin roundToInt is half-up, Swift .rounded() is half-away-from-zero; integers avoid the gap). */
+    private fun rsaWave(ph: Int, i: Int): Int {
+        val amp = intArrayOf(12, 60, 30, 20)[ph]
+        return intArrayOf(0, amp, 0, -amp)[i % 4]
+    }
+
+    /**
+     * A crafted 4-phase night (deep-favorable → high-RSA → mild → restless) staged by V2 must reproduce this
+     * EXACT hypnogram. #277 set the deep boundary (deepGateThresh, the deep emission weights, the deep
+     * transition row) a-priori, validated only by an OFFLINE 44-subject benchmark — nothing in CI pinned the
+     * constants, so a later edit or a Swift↔Kotlin parity drift could shift stages silently. This golden locks
+     * them on BOTH platforms (the Swift twin `SleepStagerV2Tests.testFrozenGoldenHypnogram` asserts the same
+     * sequence), so a one-sided constant change fails here. Input is integer-only / fixed-literal so the two
+     * languages build identical samples. Regenerate deliberately if the recipe is intentionally retuned.
+     */
+    @Test
+    fun frozenGoldenHypnogramPinsTheTunedRecipe() {
+        val start = refMidnight + 3_600L
+        val phase = 90 * 60
+        val dur = phase * 4
+        val grav = ArrayList<GravitySample>()
+        val hr = ArrayList<HrSample>()
+        val rr = ArrayList<RrInterval>()
+        for (i in 0 until dur) {
+            val ts = start + i
+            val ph = i / phase
+            val restless = ph == 3 && (i % 20) < 6
+            grav.add(
+                if (restless) GravitySample(dev, ts, x = 0.2, y = 0.15, z = 0.96)
+                else GravitySample(dev, ts, x = 0.0, y = 0.0, z = 1.0))
+            val bpm = when (ph) {
+                0 -> 50
+                1 -> 54 + intArrayOf(0, 1, 2, 3, 2, 1)[(i / 20) % 6]
+                2 -> 56 + ((i / 60) % 4)
+                else -> 66 + ((i / 30) % 6)
+            }
+            hr.add(HrSample(dev, ts, bpm = bpm))
+            rr.add(RrInterval(dev, ts, rrMs = (60_000 / bpm) + rsaWave(ph, i)))
+        }
+        val segs = SleepStagerV2.stageSession(start, start + dur, grav, hr, rr, emptyList())
+        val golden = listOf(
+            Triple(0L, 5070L, "deep"),
+            Triple(5070L, 5310L, "light"),
+            Triple(5310L, 5550L, "rem"),
+            Triple(5550L, 10740L, "light"),
+            Triple(10740L, 16290L, "rem"),
+            Triple(16290L, 21600L, "wake"))
+        assertEquals("segment count", golden.size, segs.size)
+        for (k in golden.indices) {
+            assertEquals("seg $k start", start + golden[k].first, segs[k].start)
+            assertEquals("seg $k end", start + golden[k].second, segs[k].end)
+            assertEquals("seg $k stage", golden[k].third, segs[k].stage)
+        }
+    }
 }


### PR DESCRIPTION
Follow-up to #277 (merged). Closes the CI gap it left: nothing pinned the tuned constants.

## Why
#277 promoted `SleepStagerV2` to the default and retuned the deep boundary — `deepGateThresh` 0.20→0.25, deep emission `-1.1*zhvv-0.5*zmvv`, deep transition row `0.86/0.007/0.126/0.007` — validated only by an **offline** 44-subject benchmark. The existing V2 tests are property-based (tiling, canonical labels, deep+REM present), so a constant typo or a **one-sided Swift/Kotlin edit** could shift real stages **without failing CI**.

## What
A frozen-golden test on **both** platforms: a crafted 4-phase night (deep-favorable → high-RSA → mild → restless) must reproduce one exact hypnogram:

```
deep  0–5070 · light 5070–5310 · rem 5310–5550 · light 5550–10740 · rem 10740–16290 · wake 16290–21600
```

- Input is **integer-only / fixed-literal** so Swift and Kotlin build byte-identical samples (Kotlin `roundToInt` half-up vs Swift `.rounded()` half-away-from-zero would otherwise diverge on negatives).
- Golden generated from the Kotlin stager, asserted identically in the Swift twin — a change to any tuned constant on either platform fails the golden.

## Verification
- **Kotlin**: `testFullDebugUnitTest` green locally (`--no-build-cache`).
- **Swift**: `SleepStagerV2Tests` runs in **swift-packages** CI (StrandAnalytics needs macOS) — this PR relies on that leg to confirm the Swift stager reproduces the same golden (i.e. no cross-platform boundary drift). If CI surfaces a mismatch, that's the golden doing its job — a real Swift↔Kotlin divergence to resolve.