### PR TITLE
test(sleep): pin the #277 tuned deep-boundary values directly (the #310 golden didn't lock them)

### DIFF
--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/SleepStagerV2Tests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/SleepStagerV2Tests.swift
@@ -161,7 +161,7 @@ final class SleepStagerV2Tests: XCTestCase {
         XCTAssertTrue(v2Stages.contains("rem"), "V2 night should express REM")
     }
 
-    // MARK: - #277 frozen golden: pin the tuned V2 recipe (deepGateThresh / deep emission / transition row)
+    // MARK: - #277: lock the V2 recipe shape + parity (golden) and the tuned deep-boundary values (directly)
 
     /// Fixed integer "breathing" wave — no float rounding, so Swift + Kotlin build byte-identical samples
     /// (Kotlin `roundToInt` is half-up, Swift `.rounded()` is half-away-from-zero; integers avoid the gap).
@@ -170,13 +170,13 @@ final class SleepStagerV2Tests: XCTestCase {
         return [0, amp, 0, -amp][i % 4]
     }
 
-    /// Byte-parity twin of Kotlin `SleepStagerV2Test.frozenGoldenHypnogramPinsTheTunedRecipe`. A crafted
-    /// 4-phase night (deep-favorable → high-RSA → mild → restless) staged by V2 must reproduce this EXACT
-    /// hypnogram. #277 set the deep boundary (deepGateThresh, the deep emission weights, the deep transition
-    /// row) a-priori, validated only by an OFFLINE 44-subject benchmark — nothing in CI pinned the constants,
-    /// so a later edit or a Swift↔Kotlin drift could shift stages silently. This locks them on both platforms;
-    /// a one-sided constant change fails here or in the Kotlin twin. Integer-only / fixed-literal input so the
-    /// two languages build identical samples. Regenerate deliberately if the recipe is intentionally retuned.
+    /// Byte-parity twin of Kotlin `SleepStagerV2Test.frozenGoldenHypnogramPinsTheRecipeShapeAndParity`. A
+    /// crafted 4-phase night must reproduce this EXACT hypnogram. This locks the recipe's END-TO-END behaviour
+    /// and, asserting the SAME sequence from byte-identical input as the Kotlin twin, proves the full staging
+    /// path stays Swift↔Kotlin parity-identical (the whole Viterbi path). It catches GROSS regressions; it is
+    /// deliberately NOT the guard for the exact #277 tuned VALUES (on this stark input reverting them doesn't
+    /// move a boundary) — those are pinned in `testTunedDeepBoundaryConstantsArePinned`. Integer-only /
+    /// fixed-literal input so both languages build identical samples. Regenerate deliberately if retuned.
     func testFrozenGoldenHypnogram() {
         let start = 1_749_517_200
         let phase = 90 * 60
@@ -209,6 +209,21 @@ final class SleepStagerV2Tests: XCTestCase {
             XCTAssertEqual(segs[k].start, start + golden[k].0, "seg \(k) start")
             XCTAssertEqual(segs[k].end, start + golden[k].1, "seg \(k) end")
             XCTAssertEqual(segs[k].stage, golden[k].2, "seg \(k) stage")
+        }
+    }
+
+    /// Directly pin the #277 deep-boundary tune — the reliable guard the end-to-end golden can't be (a golden
+    /// is only sensitive where the input sits near a decision boundary). Asserts the exact tuned VALUES and
+    /// their Swift↔Kotlin equality (twin: `SleepStagerV2Test.tunedDeepBoundaryConstantsArePinned`), so a
+    /// fat-finger or a one-sided edit to deepGateThresh / the deep transition row fails immediately. The
+    /// row-sum invariant catches a renormalisation typo in the hand-edited matrix. (The inline deep EMISSION
+    /// weights aren't named constants, so they stay guarded only at the gross level by the golden.)
+    func testTunedDeepBoundaryConstantsArePinned() {
+        XCTAssertEqual(SleepStagerV2.deepGateThresh, 0.25)
+        XCTAssertEqual(SleepStagerV2.transition["deep"]!,
+                       ["deep": 0.86, "rem": 0.007, "light": 0.126, "awake": 0.007])
+        for (from, row) in SleepStagerV2.transition {
+            XCTAssertEqual(row.values.reduce(0, +), 1.0, accuracy: 1e-9, "transition row '\(from)' must sum to 1.0")
         }
     }
 }

--- a/android/app/src/main/java/com/noop/analytics/SleepStagerV2.kt
+++ b/android/app/src/main/java/com/noop/analytics/SleepStagerV2.kt
@@ -166,7 +166,7 @@ object SleepStagerV2 {
     /** Deep is eligible only in the night's lowest ~25 % HR-flatness epochs (≈ deep base rate + margin).
      *  Widened 0.20 -> 0.25 by the multi-subject (AAUWSS + sleep-accel LOSO) deep-boundary tune, which
      *  recovers the deep recall the other deep-tightening edits shed while keeping precision up. */
-    private const val deepGateThresh = 0.25
+    internal const val deepGateThresh = 0.25
     private const val deepGateSlope = 5.0
 
     /** Motion thresholds are RELATIVE to each night's own quiescent jerk floor (median per-second jerk over
@@ -180,7 +180,7 @@ object SleepStagerV2 {
 
     /** Transition matrix (rows = from, cols = to). Self-transitions dominate; deep↔rem rare; wake mostly
      *  to/from light. A priori, not fit. */
-    private val transition: Map<String, Map<String, Double>> = mapOf(
+    internal val transition: Map<String, Map<String, Double>> = mapOf(
         "deep" to mapOf("deep" to 0.86, "rem" to 0.007, "light" to 0.126, "awake" to 0.007),
         "rem" to mapOf("deep" to 0.005, "rem" to 0.88, "light" to 0.10, "awake" to 0.015),
         "light" to mapOf("deep" to 0.06, "rem" to 0.06, "light" to 0.85, "awake" to 0.03),

--- a/android/app/src/test/java/com/noop/analytics/SleepStagerV2Test.kt
+++ b/android/app/src/test/java/com/noop/analytics/SleepStagerV2Test.kt
@@ -166,15 +166,16 @@ class SleepStagerV2Test {
 
     /**
      * A crafted 4-phase night (deep-favorable → high-RSA → mild → restless) staged by V2 must reproduce this
-     * EXACT hypnogram. #277 set the deep boundary (deepGateThresh, the deep emission weights, the deep
-     * transition row) a-priori, validated only by an OFFLINE 44-subject benchmark — nothing in CI pinned the
-     * constants, so a later edit or a Swift↔Kotlin parity drift could shift stages silently. This golden locks
-     * them on BOTH platforms (the Swift twin `SleepStagerV2Tests.testFrozenGoldenHypnogram` asserts the same
-     * sequence), so a one-sided constant change fails here. Input is integer-only / fixed-literal so the two
-     * languages build identical samples. Regenerate deliberately if the recipe is intentionally retuned.
+     * EXACT hypnogram. This locks the recipe's END-TO-END behaviour and — because the Swift twin
+     * (`SleepStagerV2Tests.testFrozenGoldenHypnogram`) asserts the SAME sequence from byte-identical input —
+     * proves the full staging path stays Swift↔Kotlin parity-identical (the whole Viterbi path, not just the
+     * constants). It catches GROSS regressions; it is deliberately NOT the guard for the exact #277 tuned
+     * VALUES — on this stark input reverting deepGateThresh/emission/transition doesn't move a boundary — those
+     * are pinned directly in [tunedDeepBoundaryConstantsArePinned]. Input is integer-only / fixed-literal so the
+     * two languages build identical samples. Regenerate deliberately if the recipe is intentionally retuned.
      */
     @Test
-    fun frozenGoldenHypnogramPinsTheTunedRecipe() {
+    fun frozenGoldenHypnogramPinsTheRecipeShapeAndParity() {
         val start = refMidnight + 3_600L
         val phase = 90 * 60
         val dur = phase * 4
@@ -210,6 +211,25 @@ class SleepStagerV2Test {
             assertEquals("seg $k start", start + golden[k].first, segs[k].start)
             assertEquals("seg $k end", start + golden[k].second, segs[k].end)
             assertEquals("seg $k stage", golden[k].third, segs[k].stage)
+        }
+    }
+
+    /**
+     * Directly pin the #277 deep-boundary tune — the reliable guard the end-to-end golden can't be (a golden is
+     * only sensitive where the input sits near a decision boundary). Asserts the exact tuned VALUES and their
+     * Swift↔Kotlin equality (twin: `SleepStagerV2Tests.testTunedDeepBoundaryConstantsArePinned`), so a fat-finger
+     * or a one-sided edit to deepGateThresh / the deep transition row fails immediately. The row-sum invariant
+     * catches a renormalisation typo in the hand-edited matrix. (The inline deep EMISSION weights aren't named
+     * constants, so they stay guarded only at the gross level by the golden — retune deliberately.)
+     */
+    @Test
+    fun tunedDeepBoundaryConstantsArePinned() {
+        assertEquals(0.25, SleepStagerV2.deepGateThresh, 0.0)
+        assertEquals(
+            mapOf("deep" to 0.86, "rem" to 0.007, "light" to 0.126, "awake" to 0.007),
+            SleepStagerV2.transition["deep"])
+        for ((from, row) in SleepStagerV2.transition) {
+            assertEquals("transition row '$from' must sum to 1.0", 1.0, row.values.sum(), 1e-9)
         }
     }
 }


### PR DESCRIPTION
Re-review follow-up to #310.

## The finding
#310's frozen golden **does not** guard the #277 tuned constants. Reverting **deepGateThresh 0.25→0.20**, the **deep emission weights**, OR the **deep transition row** all still reproduce the exact golden hypnogram — only a gross change (e.g. forcing deep out) fails it. The crafted night's phases are stark enough that the fine tune moves no boundary; a golden only discriminates where the input sits near a decision boundary. So the golden's real value is locking the recipe's end-to-end **shape + full-path Swift/Kotlin parity**, not the exact values.

## The fix
A direct, input-independent guard on **both** platforms (`tunedDeepBoundaryConstantsArePinned` / `testTunedDeepBoundaryConstantsArePinned`):
- asserts `deepGateThresh == 0.25` and the exact deep transition row,
- a **row-sum == 1.0** invariant over the whole matrix (catches a renormalisation typo in the hand-edited row),
- widens the two Kotlin constants `private`→`internal` to match Swift's already-internal statics (byte-parity-neutral).

**Verified sensitive:** reverting deepGateThresh (→1 failure) or breaking the transition row now fails the direct test — the guarantee the golden couldn't give. The golden's doc comment is corrected to state what it actually locks, and its Kotlin name changed to `frozenGoldenHypnogramPinsTheRecipeShapeAndParity`.

The inline deep **emission** weights aren't named constants, so they remain guarded only at the gross level by the golden (noted in-test) — pinning them would mean extracting them to constants, a separate hot-path change.

## Verification
- **Kotlin**: `testFullDebugUnitTest` green; sensitivity confirmed by reverting each constant.
- **Swift**: `SleepStagerV2Tests` runs in **swift-packages** CI (StrandAnalytics needs macOS).