### PR TITLE
Fix/297

### DIFF
--- a/Strand/Data/RecentSportsPrefs.swift
+++ b/Strand/Data/RecentSportsPrefs.swift
@@ -1,0 +1,56 @@
+import Foundation
+
+// MARK: - Recently selected workout types (#297)
+//
+// Picking a workout type meant scanning/searching the full catalogue every time, even though most
+// people cycle through the same 2-3 activities. Both sport pickers (the manual add/edit field and the
+// live "Start a workout" sheet) now surface the user's most recent selections above the full list.
+//
+// Stored as a single comma-joined string of sport names in UserDefaults, most-recent-first, capped at
+// three, deduplicated case-insensitively — the same mechanism as the other display prefs
+// (KeyMetricPrefs / MoreSectionPrefs). The Android side mirrors this exactly in RecentSportsPrefs.kt
+// (SharedPreferences "workout.recentSports"). Display-only: no WorkoutRow, analytics value or
+// migration changes, so like the other layout prefs it stays OUT of the .noopbak settings whitelist.
+
+/// Persistence for the "Recent" section of the sport pickers. The stored value is an ordered,
+/// comma-joined list of sport-name strings exactly as selected — free-typed, off-catalogue sports
+/// included (each picker decides what it can display; see the callers).
+enum RecentSportsPrefs {
+    /// UserDefaults key. The Android twin persists the same "workout.recentSports" name.
+    static let key = "workout.recentSports"
+
+    /// Most-recent-first cap — the issue asks for "2-3"; three keeps the section one glance tall.
+    static let maxCount = 3
+
+    /// Encode an ordered list of names into the stored comma-joined string.
+    static func encode(_ names: [String]) -> String { names.joined(separator: ",") }
+
+    /// Decode the stored string back to the ordered name list. Blank tokens are dropped; an
+    /// empty/unset string yields no recents (the section simply doesn't render).
+    static func decode(_ raw: String) -> [String] {
+        raw.split(separator: ",").map { $0.trimmingCharacters(in: .whitespaces) }.filter { !$0.isEmpty }
+    }
+
+    /// Pure fold of one selection into the list: front-inserted, deduplicated case-insensitively
+    /// (a re-selection moves the entry to the front and adopts the new casing), capped at `maxCount`.
+    /// A blank name is a no-op; so is a name containing a comma — it can't ride the comma-joined
+    /// encoding, and skipping the record beats corrupting the whole list for a theoretical edge case.
+    static func recording(_ name: String, into current: [String]) -> [String] {
+        let trimmed = name.trimmingCharacters(in: .whitespaces)
+        guard !trimmed.isEmpty, !trimmed.contains(",") else { return current }
+        var list = current.filter { $0.caseInsensitiveCompare(trimmed) != .orderedSame }
+        list.insert(trimmed, at: 0)
+        return Array(list.prefix(maxCount))
+    }
+
+    /// The persisted recents, most-recent-first.
+    static func recent(_ defaults: UserDefaults = .standard) -> [String] {
+        decode(defaults.string(forKey: key) ?? "")
+    }
+
+    /// Fold a confirmed selection into the persisted list. Called on confirm (Save / Start / Merge),
+    /// never on keystrokes or list taps, so an abandoned sheet leaves the recents untouched.
+    static func recordSelection(_ name: String, in defaults: UserDefaults = .standard) {
+        defaults.set(encode(recording(name, into: recent(defaults))), forKey: key)
+    }
+}

--- a/Strand/Screens/ManualWorkoutSheet.swift
+++ b/Strand/Screens/ManualWorkoutSheet.swift
@@ -127,6 +127,15 @@ struct ManualWorkoutSheet: View {
         sportFocused && !sportSuggestions.isEmpty && WorkoutCatalog.sport(named: sport) == nil
     }
 
+    /// #297: the user's last selections, one tap away above the full catalogue. Raw stored names —
+    /// this picker allows free text, so an off-catalogue recent stays selectable here (it just
+    /// carries no GPS hint). Only rendered while the field is empty (typing means searching).
+    private var recentSports: [String] { RecentSportsPrefs.recent() }
+
+    private var showRecentSports: Bool {
+        sport.trimmingCharacters(in: .whitespaces).isEmpty && !recentSports.isEmpty
+    }
+
     private var sportPicker: some View {
         VStack(alignment: .leading, spacing: 6) {
             TextField("e.g. Running", text: $sport)
@@ -141,27 +150,17 @@ struct ManualWorkoutSheet: View {
             if showSportSuggestions {
                 ScrollView {
                     VStack(alignment: .leading, spacing: 0) {
-                        ForEach(sportSuggestions) { sp in
-                            Button {
-                                sport = sp.name
-                                sportFocused = false
-                            } label: {
-                                HStack(spacing: 6) {
-                                    Text(sp.name)
-                                        .font(StrandFont.body)
-                                        .foregroundStyle(StrandPalette.textPrimary)
-                                    if sp.isDistanceSport {
-                                        Text("· GPS")
-                                            .font(StrandFont.footnote)
-                                            .foregroundStyle(StrandPalette.textTertiary)
-                                    }
-                                    Spacer(minLength: 0)
-                                }
-                                .contentShape(Rectangle())
-                                .padding(.horizontal, 12).padding(.vertical, 8)
+                        if showRecentSports {
+                            Text("Recent").strandOverline()
+                                .padding(.horizontal, 12).padding(.top, 8)
+                            ForEach(recentSports, id: \.self) { name in
+                                suggestionRow(name, isDistance: WorkoutCatalog.sport(named: name)?.isDistanceSport == true)
                             }
-                            .buttonStyle(.plain)
-                            .accessibilityLabel("Pick \(sp.name)")
+                            Text("All activities").strandOverline()
+                                .padding(.horizontal, 12).padding(.top, 8)
+                        }
+                        ForEach(sportSuggestions) { sp in
+                            suggestionRow(sp.name, isDistance: sp.isDistanceSport)
                         }
                     }
                 }
@@ -170,6 +169,30 @@ struct ManualWorkoutSheet: View {
                 .overlay(inputShape.strokeBorder(StrandPalette.hairline, lineWidth: 1))
             }
         }
+    }
+
+    /// One tappable suggestion row — shared by the #297 Recent block and the full catalogue list.
+    private func suggestionRow(_ name: String, isDistance: Bool) -> some View {
+        Button {
+            sport = name
+            sportFocused = false
+        } label: {
+            HStack(spacing: 6) {
+                Text(name)
+                    .font(StrandFont.body)
+                    .foregroundStyle(StrandPalette.textPrimary)
+                if isDistance {
+                    Text("· GPS")
+                        .font(StrandFont.footnote)
+                        .foregroundStyle(StrandPalette.textTertiary)
+                }
+                Spacer(minLength: 0)
+            }
+            .contentShape(Rectangle())
+            .padding(.horizontal, 12).padding(.vertical, 8)
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel("Pick \(name)")
     }
 
     // MARK: - Sections
@@ -299,6 +322,8 @@ struct ManualWorkoutSheet: View {
 
     private func save() {
         guard let row = builtRow else { return }
+        // #297: a confirmed save is a real selection — fold the (validated) sport into the recents.
+        RecentSportsPrefs.recordSelection(row.sport)
         onSave(row, editing)
         dismiss()
     }
@@ -342,6 +367,17 @@ struct StartWorkoutSheet: View {
     private var filtered: [WorkoutCatalog.Sport] { WorkoutCatalog.matching(query) }
     private var inputShape: RoundedRectangle { RoundedRectangle(cornerRadius: 10, style: .continuous) }
 
+    /// #297: the user's last selections, one tap away above the full catalogue. Only catalogue-resolvable
+    /// recents show here — a live start is catalogue-only by design (no free text), and the shared store
+    /// can hold free-typed names from the manual sheet. Hidden once the user starts searching.
+    private var recentSports: [WorkoutCatalog.Sport] {
+        RecentSportsPrefs.recent().compactMap { WorkoutCatalog.sport(named: $0) }
+    }
+
+    private var showRecentSports: Bool {
+        query.trimmingCharacters(in: .whitespaces).isEmpty && !recentSports.isEmpty
+    }
+
     var body: some View {
         VStack(alignment: .leading, spacing: NoopMetrics.space4) {
             HStack(alignment: .top, spacing: NoopMetrics.space3) {
@@ -375,28 +411,17 @@ struct StartWorkoutSheet: View {
 
             ScrollView {
                 VStack(alignment: .leading, spacing: 0) {
-                    ForEach(filtered) { sp in
-                        Button {
-                            selected = sp.name
-                        } label: {
-                            HStack(spacing: 6) {
-                                Text(sp.name)
-                                    .font(StrandFont.body)
-                                    .foregroundStyle(sp.name == selected
-                                                     ? StrandPalette.accent : StrandPalette.textPrimary)
-                                if sp.isDistanceSport {
-                                    Text("· GPS")
-                                        .font(StrandFont.footnote)
-                                        .foregroundStyle(StrandPalette.textTertiary)
-                                }
-                                Spacer(minLength: 0)
-                            }
-                            .contentShape(Rectangle())
-                            .padding(.horizontal, 12).padding(.vertical, 9)
+                    if showRecentSports {
+                        Text("Recent").strandOverline()
+                            .padding(.horizontal, 12).padding(.top, 8)
+                        ForEach(recentSports) { sp in
+                            sportRow(sp)
                         }
-                        .buttonStyle(.plain)
-                        .accessibilityLabel("Pick \(sp.name)")
-                        .accessibilityAddTraits(sp.name == selected ? [.isSelected] : [])
+                        Text("All activities").strandOverline()
+                            .padding(.horizontal, 12).padding(.top, 8)
+                    }
+                    ForEach(filtered) { sp in
+                        sportRow(sp)
                     }
                 }
             }
@@ -408,6 +433,8 @@ struct StartWorkoutSheet: View {
                 NoopButton("Cancel", kind: .tertiary) { dismiss() }
                 Spacer()
                 NoopButton("\(actionVerb) \(selected)", systemImage: "figure.run", kind: .primary) {
+                    // #297: a confirmed start (or merge-name) is a real selection — fold it into the recents.
+                    RecentSportsPrefs.recordSelection(selected)
                     onStart(selected)
                     dismiss()
                 }
@@ -422,6 +449,31 @@ struct StartWorkoutSheet: View {
         .noopSheetPresentation(largeFirst: false)
         #endif
         .background(StrandPalette.surfaceOverlay)
+    }
+
+    /// One tappable sport row — shared by the #297 Recent block and the full catalogue list.
+    private func sportRow(_ sp: WorkoutCatalog.Sport) -> some View {
+        Button {
+            selected = sp.name
+        } label: {
+            HStack(spacing: 6) {
+                Text(sp.name)
+                    .font(StrandFont.body)
+                    .foregroundStyle(sp.name == selected
+                                     ? StrandPalette.accent : StrandPalette.textPrimary)
+                if sp.isDistanceSport {
+                    Text("· GPS")
+                        .font(StrandFont.footnote)
+                        .foregroundStyle(StrandPalette.textTertiary)
+                }
+                Spacer(minLength: 0)
+            }
+            .contentShape(Rectangle())
+            .padding(.horizontal, 12).padding(.vertical, 9)
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel("Pick \(sp.name)")
+        .accessibilityAddTraits(sp.name == selected ? [.isSelected] : [])
     }
 }
 

--- a/Strand/Screens/ManualWorkoutSheet.swift
+++ b/Strand/Screens/ManualWorkoutSheet.swift
@@ -2,6 +2,13 @@ import SwiftUI
 import StrandDesign
 import WhoopStore
 
+/// Carries the measured natural height of the Sport picker's floating suggestion panel up to the
+/// view, so the overlay can size itself to its content (capped) rather than to the text field.
+private struct SuggestionsHeightKey: PreferenceKey {
+    static let defaultValue: CGFloat = 0
+    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) { value = max(value, nextValue()) }
+}
+
 // MARK: - Manual workout sheet
 //
 // Add a workout you tracked elsewhere, or edit one you already logged. Five inputs — sport,
@@ -38,6 +45,10 @@ struct ManualWorkoutSheet: View {
     /// (a settled choice), so the form isn't permanently half-covered.
     @FocusState private var sportFocused: Bool
 
+    /// Measured natural height of the floating suggestion panel's content, so the overlay can size
+    /// itself (capped at 168) instead of being squeezed to the text field's height. See `suggestionList`.
+    @State private var suggestionsHeight: CGFloat = 0
+
     init(editing: WorkoutRow? = nil,
          onSave: @escaping (_ row: WorkoutRow, _ replacing: WorkoutRow?) -> Void) {
         self.editing = editing
@@ -60,6 +71,9 @@ struct ManualWorkoutSheet: View {
                 field(String(localized: "Sport")) {
                     sportPicker
                 }
+                // Raise the Sport field above the following rows so its floating suggestion dropdown
+                // (an overlay, see `sportPicker`) draws ON TOP of Start / Duration instead of behind them.
+                .zIndex(1)
                 field(String(localized: "Start")) {
                     DatePicker("", selection: $start, in: ...Date(),
                                displayedComponents: [.date, .hourAndMinute])
@@ -137,38 +151,60 @@ struct ManualWorkoutSheet: View {
     }
 
     private var sportPicker: some View {
-        VStack(alignment: .leading, spacing: 6) {
-            TextField("e.g. Running", text: $sport)
-                .textFieldStyle(.plain)
-                .font(StrandFont.body)
-                .foregroundStyle(StrandPalette.textPrimary)
-                .focused($sportFocused)
-                .padding(.horizontal, 12).padding(.vertical, 9)
-                .background(StrandPalette.surfaceInset, in: inputShape)
-                .overlay(inputShape.strokeBorder(StrandPalette.hairline, lineWidth: 1))
-                .accessibilityLabel("Sport")
-            if showSportSuggestions {
-                ScrollView {
-                    VStack(alignment: .leading, spacing: 0) {
-                        if showRecentSports {
-                            Text("Recent").strandOverline()
-                                .padding(.horizontal, 12).padding(.top, 8)
-                            ForEach(recentSports, id: \.self) { name in
-                                suggestionRow(name, isDistance: WorkoutCatalog.sport(named: name)?.isDistanceSport == true)
-                            }
-                            Text("All activities").strandOverline()
-                                .padding(.horizontal, 12).padding(.top, 8)
-                        }
-                        ForEach(sportSuggestions) { sp in
-                            suggestionRow(sp.name, isDistance: sp.isDistanceSport)
-                        }
-                    }
+        TextField("e.g. Running", text: $sport)
+            .textFieldStyle(.plain)
+            .font(StrandFont.body)
+            .foregroundStyle(StrandPalette.textPrimary)
+            .focused($sportFocused)
+            .padding(.horizontal, 12).padding(.vertical, 9)
+            .background(StrandPalette.surfaceInset, in: inputShape)
+            .overlay(inputShape.strokeBorder(StrandPalette.hairline, lineWidth: 1))
+            .accessibilityLabel("Sport")
+            // The suggestion list FLOATS below the field as an overlay instead of sitting inline in the
+            // form. Inline it was the only height-flexible element, so on iPhone with the keyboard up
+            // the fixed-height fields below won the vertical space and squeezed it to nothing — the
+            // #297 Recent block (and even the catalogue matches) never showed. As an overlay it doesn't
+            // take part in the form's layout, so it renders at full height over the rows below; the
+            // parent raises this field's zIndex so it draws on top of them.
+            .overlay(alignment: .bottom) {
+                if showSportSuggestions {
+                    suggestionList
+                        // Pin the panel's TOP to the field's BOTTOM (its own top stands in as the
+                        // bottom-alignment anchor), then nudge it down for a small gap.
+                        .alignmentGuide(.bottom) { $0[.top] }
+                        .offset(y: 6)
                 }
-                .frame(maxHeight: 168)
-                .background(StrandPalette.surfaceInset, in: inputShape)
-                .overlay(inputShape.strokeBorder(StrandPalette.hairline, lineWidth: 1))
             }
+    }
+
+    /// The floating suggestion panel (Recent + full catalogue). An overlay proposes the field's small
+    /// height to its content, which would re-squeeze a plain `.frame(maxHeight:)` ScrollView — so we
+    /// MEASURE the content's natural height and set an explicit frame capped at 168, letting it scroll
+    /// only past that. This is the same list the inline version rendered, just floated + self-sized.
+    private var suggestionList: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 0) {
+                if showRecentSports {
+                    Text("Recent").strandOverline()
+                        .padding(.horizontal, 12).padding(.top, 8)
+                    ForEach(recentSports, id: \.self) { name in
+                        suggestionRow(name, isDistance: WorkoutCatalog.sport(named: name)?.isDistanceSport == true)
+                    }
+                    Text("All activities").strandOverline()
+                        .padding(.horizontal, 12).padding(.top, 8)
+                }
+                ForEach(sportSuggestions) { sp in
+                    suggestionRow(sp.name, isDistance: sp.isDistanceSport)
+                }
+            }
+            .background(GeometryReader { geo in
+                Color.clear.preference(key: SuggestionsHeightKey.self, value: geo.size.height)
+            })
         }
+        .frame(height: min(max(suggestionsHeight, 1), 168))
+        .onPreferenceChange(SuggestionsHeightKey.self) { suggestionsHeight = $0 }
+        .background(StrandPalette.surfaceInset, in: inputShape)
+        .overlay(inputShape.strokeBorder(StrandPalette.hairline, lineWidth: 1))
     }
 
     /// One tappable suggestion row — shared by the #297 Recent block and the full catalogue list.

--- a/StrandTests/RecentSportsPrefsTests.swift
+++ b/StrandTests/RecentSportsPrefsTests.swift
@@ -1,0 +1,73 @@
+import XCTest
+@testable import Strand
+
+/// Pins the #297 "recently selected activities" persistence. The behaviour that must never regress: the
+/// sport pickers surface up to three distinct recents, most-recent-first, deduplicated case-insensitively,
+/// updated only on a confirmed selection. These exercise the pure encode/decode/recording model the
+/// UserDefaults-backed sheets read and write through, and lock it in lockstep with the Android
+/// `RecentSportsPrefs` twin (same key, same comma-joined encoding, same cap/dedup/no-op rules).
+final class RecentSportsPrefsTests: XCTestCase {
+
+    func testKeyAndCapMatchAndroid() {
+        // Both platforms persist "workout.recentSports", capped at three entries.
+        XCTAssertEqual(RecentSportsPrefs.key, "workout.recentSports")
+        XCTAssertEqual(RecentSportsPrefs.maxCount, 3)
+    }
+
+    func testEncodeDecodeRoundTrips() {
+        for list in [[String](), ["Running"], ["Running", "Yoga"], ["Running", "Yoga", "Padel"]] {
+            XCTAssertEqual(RecentSportsPrefs.decode(RecentSportsPrefs.encode(list)), list)
+        }
+    }
+
+    func testDecodeDropsBlankAndStrayTokens() {
+        XCTAssertEqual(RecentSportsPrefs.decode("Running, ,Yoga,"), ["Running", "Yoga"])
+        XCTAssertEqual(RecentSportsPrefs.decode("  Padel  "), ["Padel"])
+        XCTAssertEqual(RecentSportsPrefs.decode(""), [])
+    }
+
+    func testRecordingFrontInserts() {
+        XCTAssertEqual(RecentSportsPrefs.recording("Running", into: []), ["Running"])
+        XCTAssertEqual(RecentSportsPrefs.recording("Yoga", into: ["Running"]), ["Yoga", "Running"])
+    }
+
+    func testRecordingDedupsCaseInsensitivelyAndMovesToFront() {
+        // A re-selection moves the entry to the front (no duplicate) and adopts the new casing.
+        XCTAssertEqual(RecentSportsPrefs.recording("running", into: ["Yoga", "Running", "Padel"]),
+                       ["running", "Yoga", "Padel"])
+    }
+
+    func testRecordingCapsAtThree() {
+        XCTAssertEqual(RecentSportsPrefs.recording("HIIT", into: ["Running", "Yoga", "Padel"]),
+                       ["HIIT", "Running", "Yoga"])
+    }
+
+    func testRecordingIgnoresBlankAndCommaNames() {
+        // Blank can't be a sport; a comma can't ride the comma-joined encoding — both are no-ops.
+        XCTAssertEqual(RecentSportsPrefs.recording("   ", into: ["Running"]), ["Running"])
+        XCTAssertEqual(RecentSportsPrefs.recording("Run, walk", into: ["Running"]), ["Running"])
+    }
+
+    func testRecordingTrimsWhitespace() {
+        XCTAssertEqual(RecentSportsPrefs.recording("  Yoga  ", into: []), ["Yoga"])
+    }
+
+    func testSelectionsPersistThroughUserDefaults() {
+        // The end-to-end persistence the sheets rely on: recorded selections read back most-recent-first
+        // (here via a throwaway UserDefaults suite, as the sheets use .standard).
+        let suite = "RecentSportsPrefsTests"
+        let defaults = UserDefaults(suiteName: suite)!
+        defaults.removePersistentDomain(forName: suite)
+
+        XCTAssertEqual(RecentSportsPrefs.recent(defaults), [])
+        RecentSportsPrefs.recordSelection("Running", in: defaults)
+        RecentSportsPrefs.recordSelection("Yoga", in: defaults)
+        XCTAssertEqual(RecentSportsPrefs.recent(defaults), ["Yoga", "Running"])
+
+        // Re-selecting an existing recent moves it to the front instead of duplicating.
+        RecentSportsPrefs.recordSelection("Running", in: defaults)
+        XCTAssertEqual(RecentSportsPrefs.recent(defaults), ["Running", "Yoga"])
+
+        defaults.removePersistentDomain(forName: suite)
+    }
+}

--- a/android/app/src/main/java/com/noop/ui/RecentSportsPrefs.kt
+++ b/android/app/src/main/java/com/noop/ui/RecentSportsPrefs.kt
@@ -1,0 +1,68 @@
+package com.noop.ui
+
+import android.content.Context
+import android.content.SharedPreferences
+
+// MARK: - Recently selected workout types (#297)
+//
+// Picking a workout type meant scanning/searching the full catalogue every time, even though most
+// people cycle through the same 2-3 activities. Both sport pickers (the manual add/edit field and the
+// live "Start a workout" sheet) now surface the user's most recent selections above the full list.
+//
+// Stored as a single comma-joined string of sport names in SharedPreferences, most-recent-first,
+// capped at three, deduplicated case-insensitively — the same mechanism as the other display prefs
+// (KeyMetricPrefs / MoreSectionPrefs). Mirrors the macOS/iOS RecentSportsPrefs.swift (UserDefaults
+// "workout.recentSports"). Display-only: no WorkoutRow, analytics value or migration changes, so like
+// the other layout prefs it stays OUT of the .noopbak settings whitelist.
+
+/**
+ * Persistence for the "Recent" section of the sport pickers. The stored value is an ordered,
+ * comma-joined list of sport-name strings exactly as selected — free-typed, off-catalogue sports
+ * included (each picker decides what it can display; see the callers).
+ */
+object RecentSportsPrefs {
+    /** SharedPreferences key. The macOS/iOS twin persists the same "workout.recentSports" name. */
+    const val KEY = "workout.recentSports"
+
+    /** Most-recent-first cap — the issue asks for "2-3"; three keeps the section one glance tall. */
+    const val MAX_COUNT = 3
+
+    /** Encode an ordered list of names into the stored comma-joined string. */
+    fun encode(names: List<String>): String = names.joinToString(",")
+
+    /**
+     * Decode the stored string back to the ordered name list. Blank tokens are dropped; an
+     * empty/unset string yields no recents (the section simply doesn't render).
+     */
+    fun decode(raw: String?): List<String> =
+        raw?.split(",")?.map { it.trim() }?.filter { it.isNotEmpty() } ?: emptyList()
+
+    /**
+     * Pure fold of one selection into the list: front-inserted, deduplicated case-insensitively
+     * (a re-selection moves the entry to the front and adopts the new casing), capped at [MAX_COUNT].
+     * A blank name is a no-op; so is a name containing a comma — it can't ride the comma-joined
+     * encoding, and skipping the record beats corrupting the whole list for a theoretical edge case.
+     */
+    fun recording(name: String, current: List<String>): List<String> {
+        val trimmed = name.trim()
+        if (trimmed.isEmpty() || trimmed.contains(",")) return current
+        val list = current.filterNot { it.equals(trimmed, ignoreCase = true) }.toMutableList()
+        list.add(0, trimmed)
+        return list.take(MAX_COUNT)
+    }
+
+    /** The persisted recents, most-recent-first. */
+    fun recent(context: Context): List<String> = recent(NoopPrefs.of(context))
+
+    fun recent(prefs: SharedPreferences): List<String> = decode(prefs.getString(KEY, null))
+
+    /**
+     * Fold a confirmed selection into the persisted list. Called on confirm (Save / Start / Merge),
+     * never on keystrokes or list taps, so an abandoned sheet leaves the recents untouched.
+     */
+    fun record(context: Context, name: String) = record(NoopPrefs.of(context), name)
+
+    fun record(prefs: SharedPreferences, name: String) {
+        prefs.edit().putString(KEY, encode(recording(name, recent(prefs)))).apply()
+    }
+}

--- a/android/app/src/main/java/com/noop/ui/WorkoutStart.kt
+++ b/android/app/src/main/java/com/noop/ui/WorkoutStart.kt
@@ -28,6 +28,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 import androidx.compose.ui.draw.drawWithContent
@@ -51,10 +52,20 @@ import kotlinx.coroutines.delay
  */
 @Composable
 fun StartWorkoutSheet(vm: AppViewModel, onDismiss: () -> Unit) {
+    val context = LocalContext.current
     var query by remember { mutableStateOf("") }
     var selected by remember { mutableStateOf<Sport>(WorkoutSport.default) }
     var gpsOn by remember(selected) { mutableStateOf(selected.isDistanceSport) }
     val filtered = WorkoutSport.all.filter { it.name.contains(query, ignoreCase = true) }
+    // #297: the user's last selections, one tap away above the full catalogue. Only catalogue-resolvable
+    // recents show here — a live start selects a typed [Sport], and the shared store can hold free-typed
+    // names from the manual add/edit picker. Hidden once the user starts searching.
+    val recents = if (query.isBlank()) {
+        RecentSportsPrefs.recent(context)
+            .mapNotNull { n -> WorkoutSport.all.firstOrNull { it.name.equals(n, ignoreCase = true) } }
+    } else {
+        emptyList()
+    }
     val sportScroll = rememberScrollState()
     // Live workout mode (#238): once a workout begins, the sheet transitions IN PLACE into the full
     // in-exercise screen — staying mounted so its state survives — and only tells the parent to close
@@ -91,21 +102,18 @@ fun StartWorkoutSheet(vm: AppViewModel, onDismiss: () -> Unit) {
                         .simpleVerticalScrollbar(sportScroll)
                         .verticalScroll(sportScroll),
                 ) {
-                    filtered.forEach { sp ->
-                        Row(
-                            verticalAlignment = Alignment.CenterVertically,
-                            modifier = Modifier.fillMaxWidth()
-                                .clickable { selected = sp; gpsOn = sp.isDistanceSport }
-                                .padding(vertical = 10.dp),
-                        ) {
-                            Text(
-                                sp.name, style = NoopType.body,
-                                color = if (sp == selected) Palette.accent else Palette.textPrimary,
-                            )
-                            if (sp.isDistanceSport) {
-                                Spacer(Modifier.width(6.dp))
-                                Text("· GPS", style = NoopType.footnote, color = Palette.textTertiary)
+                    if (recents.isNotEmpty()) {
+                        Overline("Recent", modifier = Modifier.padding(top = 6.dp))
+                        recents.forEach { sp ->
+                            StartSportRow(sp, isSelected = sp == selected) {
+                                selected = sp; gpsOn = sp.isDistanceSport
                             }
+                        }
+                        Overline("All activities", modifier = Modifier.padding(top = 6.dp))
+                    }
+                    filtered.forEach { sp ->
+                        StartSportRow(sp, isSelected = sp == selected) {
+                            selected = sp; gpsOn = sp.isDistanceSport
                         }
                     }
                 }
@@ -121,6 +129,9 @@ fun StartWorkoutSheet(vm: AppViewModel, onDismiss: () -> Unit) {
         },
         confirmButton = {
             Button(onClick = {
+                // #297: a confirmed start is a real selection — fold it into the recents (recorded even
+                // if the GPS permission is then denied; the workout still starts route-less, #101).
+                RecentSportsPrefs.record(context, selected.name)
                 if (gpsOn) {
                     startWithGps() // requests location, then starts + opens live workout in the callback (#101)
                 } else {
@@ -135,6 +146,26 @@ fun StartWorkoutSheet(vm: AppViewModel, onDismiss: () -> Unit) {
             OutlinedButton(onClick = onDismiss) { Text("Cancel") }
         },
     )
+}
+
+/** One tappable sport row — shared by the #297 Recent block and the full catalogue list. */
+@Composable
+private fun StartSportRow(sp: Sport, isSelected: Boolean, onPick: () -> Unit) {
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = Modifier.fillMaxWidth()
+            .clickable(onClick = onPick)
+            .padding(vertical = 10.dp),
+    ) {
+        Text(
+            sp.name, style = NoopType.body,
+            color = if (isSelected) Palette.accent else Palette.textPrimary,
+        )
+        if (sp.isDistanceSport) {
+            Spacer(Modifier.width(6.dp))
+            Text("· GPS", style = NoopType.footnote, color = Palette.textTertiary)
+        }
+    }
 }
 
 /**

--- a/android/app/src/main/java/com/noop/ui/WorkoutsScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/WorkoutsScreen.kt
@@ -577,7 +577,15 @@ private fun MergeSportDialog(onDismiss: () -> Unit, onPick: (String) -> Unit) {
             }
         },
         confirmButton = {
-            TextButton(onClick = { if (sport.isNotBlank()) onPick(sport.trim()) }, enabled = sport.isNotBlank()) {
+            val context = LocalContext.current
+            TextButton(onClick = {
+                if (sport.isNotBlank()) {
+                    // #297: naming a merge is a real selection too — parity with the macOS/iOS sheet,
+                    // whose reused StartWorkoutSheet records on its action button.
+                    RecentSportsPrefs.record(context, sport.trim())
+                    onPick(sport.trim())
+                }
+            }, enabled = sport.isNotBlank()) {
                 Text("Merge", style = NoopType.body, color = if (sport.isNotBlank()) Palette.accent else Palette.textTertiary)
             }
         },
@@ -1633,7 +1641,14 @@ private fun ManualWorkoutDialog(
                 val c = WorkoutEditing.classify(it.source)
                 c == WorkoutSource.MANUAL || c == WorkoutSource.DETECTED
             }
-            TextButton(onClick = { built?.let { onSave(it, replacing) } }, enabled = built != null) {
+            val context = LocalContext.current
+            TextButton(onClick = {
+                built?.let {
+                    // #297: a confirmed save is a real selection — fold the (validated) sport into the recents.
+                    RecentSportsPrefs.record(context, it.sport)
+                    onSave(it, replacing)
+                }
+            }, enabled = built != null) {
                 Text(if (editing == null) "Add" else "Save",
                     style = NoopType.body, color = if (built != null) Palette.accent else Palette.textTertiary)
             }
@@ -1704,6 +1719,7 @@ private fun StartTimeField(millis: Long, onPick: (Long) -> Unit) {
 
 @Composable
 private fun SportPickerField(value: String, onChange: (String) -> Unit) {
+    val context = LocalContext.current
     val sportScroll = rememberScrollState()
     val q = value.trim()
     val matches = if (q.isEmpty()) WorkoutSport.all
@@ -1712,6 +1728,10 @@ private fun SportPickerField(value: String, onChange: (String) -> Unit) {
     // free-typed sport with no partial matches — so the dialog isn't permanently half-covered.
     val exact = WorkoutSport.all.any { it.name.equals(q, ignoreCase = true) }
     val showList = matches.isNotEmpty() && !exact
+    // #297: the user's last selections, one tap away above the full catalogue. Raw stored names —
+    // this picker allows free text, so an off-catalogue recent stays selectable here (it just
+    // carries no GPS hint). Only rendered while the field is empty (typing means searching).
+    val recents = if (q.isEmpty()) RecentSportsPrefs.recent(context) else emptyList()
 
     DialogField("Sport", value, onChange = onChange, placeholder = "e.g. Running")
     if (showList) {
@@ -1722,21 +1742,39 @@ private fun SportPickerField(value: String, onChange: (String) -> Unit) {
                 .verticalScroll(sportScroll),
             verticalArrangement = Arrangement.spacedBy(2.dp),
         ) {
-            matches.forEach { sp ->
-                Row(
-                    verticalAlignment = Alignment.CenterVertically,
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .clickable { onChange(sp.name) }
-                        .padding(vertical = 8.dp),
-                ) {
-                    Text(sp.name, style = NoopType.body, color = Palette.textPrimary)
-                    if (sp.isDistanceSport) {
-                        Spacer(Modifier.width(6.dp))
-                        Text("· GPS", style = NoopType.footnote, color = Palette.textTertiary)
-                    }
+            if (recents.isNotEmpty()) {
+                Overline("Recent", modifier = Modifier.padding(top = 6.dp))
+                recents.forEach { name ->
+                    SportSuggestionRow(
+                        name = name,
+                        isDistance = WorkoutSport.all
+                            .firstOrNull { it.name.equals(name, ignoreCase = true) }?.isDistanceSport == true,
+                        onPick = { onChange(name) },
+                    )
                 }
+                Overline("All activities", modifier = Modifier.padding(top = 6.dp))
             }
+            matches.forEach { sp ->
+                SportSuggestionRow(name = sp.name, isDistance = sp.isDistanceSport, onPick = { onChange(sp.name) })
+            }
+        }
+    }
+}
+
+/** One tappable suggestion row — shared by the #297 Recent block and the full catalogue list. */
+@Composable
+private fun SportSuggestionRow(name: String, isDistance: Boolean, onPick: () -> Unit) {
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onPick)
+            .padding(vertical = 8.dp),
+    ) {
+        Text(name, style = NoopType.body, color = Palette.textPrimary)
+        if (isDistance) {
+            Spacer(Modifier.width(6.dp))
+            Text("· GPS", style = NoopType.footnote, color = Palette.textTertiary)
         }
     }
 }

--- a/android/app/src/test/java/com/noop/ui/RecentSportsPrefsTest.kt
+++ b/android/app/src/test/java/com/noop/ui/RecentSportsPrefsTest.kt
@@ -1,0 +1,132 @@
+package com.noop.ui
+
+import android.content.SharedPreferences
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Pins the #297 "recently selected activities" persistence - the Android twin of the iOS
+ * `RecentSportsPrefsTests`. The behaviour that must never regress: the sport pickers surface up to three
+ * distinct recents, most-recent-first, deduplicated case-insensitively, updated only on a confirmed
+ * selection. These exercise the REAL [RecentSportsPrefs] over an in-memory [FakeSharedPreferences] (the
+ * project ships no Robolectric), and lock it in lockstep with the iOS twin (same key, same comma-joined
+ * encoding, same cap/dedup/no-op rules).
+ */
+class RecentSportsPrefsTest {
+
+    @Test
+    fun keyAndCapMatchIos() {
+        // Both platforms persist "workout.recentSports", capped at three entries.
+        assertEquals("workout.recentSports", RecentSportsPrefs.KEY)
+        assertEquals(3, RecentSportsPrefs.MAX_COUNT)
+    }
+
+    @Test
+    fun encodeDecodeRoundTrips() {
+        for (list in listOf(
+            emptyList(),
+            listOf("Running"),
+            listOf("Running", "Yoga"),
+            listOf("Running", "Yoga", "Padel"),
+        )) {
+            assertEquals(list, RecentSportsPrefs.decode(RecentSportsPrefs.encode(list)))
+        }
+    }
+
+    @Test
+    fun decodeDropsBlankAndStrayTokens() {
+        assertEquals(listOf("Running", "Yoga"), RecentSportsPrefs.decode("Running, ,Yoga,"))
+        assertEquals(listOf("Padel"), RecentSportsPrefs.decode("  Padel  "))
+        assertEquals(emptyList<String>(), RecentSportsPrefs.decode(""))
+        assertEquals(emptyList<String>(), RecentSportsPrefs.decode(null))
+    }
+
+    @Test
+    fun recordingFrontInserts() {
+        assertEquals(listOf("Running"), RecentSportsPrefs.recording("Running", emptyList()))
+        assertEquals(listOf("Yoga", "Running"), RecentSportsPrefs.recording("Yoga", listOf("Running")))
+    }
+
+    @Test
+    fun recordingDedupsCaseInsensitivelyAndMovesToFront() {
+        // A re-selection moves the entry to the front (no duplicate) and adopts the new casing.
+        assertEquals(
+            listOf("running", "Yoga", "Padel"),
+            RecentSportsPrefs.recording("running", listOf("Yoga", "Running", "Padel")),
+        )
+    }
+
+    @Test
+    fun recordingCapsAtThree() {
+        assertEquals(
+            listOf("HIIT", "Running", "Yoga"),
+            RecentSportsPrefs.recording("HIIT", listOf("Running", "Yoga", "Padel")),
+        )
+    }
+
+    @Test
+    fun recordingIgnoresBlankAndCommaNames() {
+        // Blank can't be a sport; a comma can't ride the comma-joined encoding - both are no-ops.
+        assertEquals(listOf("Running"), RecentSportsPrefs.recording("   ", listOf("Running")))
+        assertEquals(listOf("Running"), RecentSportsPrefs.recording("Run, walk", listOf("Running")))
+    }
+
+    @Test
+    fun recordingTrimsWhitespace() {
+        assertEquals(listOf("Yoga"), RecentSportsPrefs.recording("  Yoga  ", emptyList()))
+    }
+
+    @Test
+    fun selectionsPersistThroughSharedPreferences() {
+        // The end-to-end persistence the sheets rely on: recorded selections read back most-recent-first.
+        val prefs = FakeSharedPreferences()
+
+        assertEquals(emptyList<String>(), RecentSportsPrefs.recent(prefs))
+        RecentSportsPrefs.record(prefs, "Running")
+        RecentSportsPrefs.record(prefs, "Yoga")
+        assertEquals(listOf("Yoga", "Running"), RecentSportsPrefs.recent(prefs))
+
+        // Re-selecting an existing recent moves it to the front instead of duplicating.
+        RecentSportsPrefs.record(prefs, "Running")
+        assertEquals(listOf("Running", "Yoga"), RecentSportsPrefs.recent(prefs))
+    }
+
+    /** A minimal in-memory SharedPreferences: enough of the read/write contract for the helper above. */
+    private class FakeSharedPreferences : SharedPreferences {
+        val map = HashMap<String, Any?>()
+
+        override fun getBoolean(key: String, defValue: Boolean): Boolean = map[key] as? Boolean ?: defValue
+        override fun getLong(key: String, defValue: Long): Long = map[key] as? Long ?: defValue
+        override fun getString(key: String, defValue: String?): String? = map[key] as? String ?: defValue
+        override fun getInt(key: String, defValue: Int): Int = map[key] as? Int ?: defValue
+        override fun getFloat(key: String, defValue: Float): Float = map[key] as? Float ?: defValue
+        @Suppress("UNCHECKED_CAST")
+        override fun getStringSet(key: String, defValues: MutableSet<String>?): MutableSet<String>? =
+            map[key] as? MutableSet<String> ?: defValues
+        override fun getAll(): MutableMap<String, *> = HashMap(map)
+        override fun contains(key: String): Boolean = map.containsKey(key)
+        override fun registerOnSharedPreferenceChangeListener(l: SharedPreferences.OnSharedPreferenceChangeListener?) {}
+        override fun unregisterOnSharedPreferenceChangeListener(l: SharedPreferences.OnSharedPreferenceChangeListener?) {}
+
+        override fun edit(): SharedPreferences.Editor = FakeEditor(this)
+
+        private class FakeEditor(private val prefs: FakeSharedPreferences) : SharedPreferences.Editor {
+            private val pending = HashMap<String, Any?>()
+            private val removals = HashSet<String>()
+            override fun putString(key: String, value: String?): SharedPreferences.Editor { pending[key] = value; return this }
+            override fun putStringSet(key: String, values: MutableSet<String>?): SharedPreferences.Editor { pending[key] = values; return this }
+            override fun putInt(key: String, value: Int): SharedPreferences.Editor { pending[key] = value; return this }
+            override fun putLong(key: String, value: Long): SharedPreferences.Editor { pending[key] = value; return this }
+            override fun putFloat(key: String, value: Float): SharedPreferences.Editor { pending[key] = value; return this }
+            override fun putBoolean(key: String, value: Boolean): SharedPreferences.Editor { pending[key] = value; return this }
+            override fun remove(key: String): SharedPreferences.Editor { removals.add(key); return this }
+            override fun clear(): SharedPreferences.Editor { prefs.map.clear(); return this }
+            override fun commit(): Boolean { flush(); return true }
+            override fun apply() { flush() }
+            private fun flush() {
+                for (k in removals) prefs.map.remove(k)
+                prefs.map.putAll(pending)
+            }
+        }
+    }
+}


### PR DESCRIPTION
## What this PR does

<!-- A short description of the change and why it's needed. -->

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] CI / tooling

## How it was tested

<!--
For anything on the BLE path, say what you tested on real hardware and which
strap (4.0 / 5.0 / MG). For protocol or analytics changes, point to the test
that covers it. "Builds and unit tests pass" alone is not enough for BLE work.
-->

## Checklist

- [ ] Swift package tests pass for any package I touched (`swift test` in `Packages/<name>`)
- [ ] Android unit tests pass if I touched `android/` (`./gradlew testFullDebugUnitTest`)
- [ ] No new build warnings introduced
- [ ] UI changes use only `StrandDesign` tokens — no hardcoded colors, fonts, or spacing
- [ ] No hardcoded hex frame bytes; protocol facts live in the schema / decoders
- [ ] Follows the conventions in [`docs/CONTRIBUTING.md`](../docs/CONTRIBUTING.md)
- [ ] I did not commit generated output (`Strand.xcodeproj/`) or any secrets/keystores

## Related issues

<!-- Closes #N -->
