### PR TITLE
fix(sleep): displaySmoothed(minDuration<=0) coalesces like Swift instead of returning raw fragments (#240 follow-up)

### DIFF
--- a/android/app/src/main/java/com/noop/ui/SleepScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/SleepScreen.kt
@@ -3482,7 +3482,12 @@ internal fun displaySmoothed(
     intervals: List<StageInterval>,
     minDurationSec: Double,
 ): List<StageInterval> {
-    if (intervals.size <= 2 || minDurationSec <= 0.0) return intervals   // Swift: guard count > 2
+    // Match Swift `Hypnogram.displaySmoothed`: guard ONLY on count. A minDurationSec <= 0 ("raw") must
+    // still fall through to coalesce() — Swift returns the coalesced timeline, not the un-merged epoch
+    // fragments. Short-circuiting on <= 0 here returned 60-100 raw fragments (the "comb"), diverging from
+    // the port. With minDurationSec = 0 the absorb loop's `duration < 0` filter is empty, so it breaks
+    // right after the first coalesce — same result as Swift.
+    if (intervals.size <= 2) return intervals   // Swift: guard count > 2
 
     // Coalesce adjacent same-stage runs (also bridges the zero-length seams between epochs).
     fun coalesce(ivs: List<StageInterval>): MutableList<StageInterval> {

--- a/android/app/src/test/java/com/noop/ui/StageDisplaySmoothingTest.kt
+++ b/android/app/src/test/java/com/noop/ui/StageDisplaySmoothingTest.kt
@@ -103,8 +103,13 @@ class StageDisplaySmoothingTest {
 
     @Test
     fun zeroFloorReturnsCoalescedInputUnsmoothed() {
-        val raw = listOf(iv("light", 0.0, 10.0), iv("deep", 10.0, 20.0), iv("rem", 20.0, 30.0))
-        assertEquals(raw, displaySmoothed(raw, 0.0))   // smoothingSeconds: 0 → raw timeline
+        // minDurationSec = 0 ("raw") must still COALESCE adjacent same-stage runs (Swift parity) — NOT
+        // return the un-merged epoch fragments. Fixture has an adjacent light/light seam so it actually
+        // exercises the coalesce (the previous [light, deep, rem] fixture had none, so it passed even
+        // when the impl short-circuited to raw).
+        val raw = listOf(iv("light", 0.0, 10.0), iv("light", 10.0, 20.0), iv("deep", 20.0, 30.0))
+        val coalesced = listOf(iv("light", 0.0, 20.0), iv("deep", 20.0, 30.0))
+        assertEquals(coalesced, displaySmoothed(raw, 0.0))
     }
 
     @Test


### PR DESCRIPTION
Follow-up to #240 (merged). Fixes the one port-fidelity divergence the review found.

## The divergence
The Android port of Swift `Hypnogram.displaySmoothed` added `if (intervals.size <= 2 || minDurationSec <= 0.0) return intervals`. Swift guards **only on count** and lets `minDuration = 0` ("raw") fall through to `coalesce()` — so Swift returns the **coalesced** timeline, whereas Android returned the 60–100 **un-merged epoch fragments** (the "comb" the smoothing exists to remove). Everything else in the port matches Swift line-for-line.

## Severity
Production-inert: the only caller passes `STAGE_ROW_SMOOTH_SEC = 90.0`, so the divergent `<= 0` path never runs in shipping. This is a latent fidelity fix — it makes the "straight port" true and protects any future `0`-caller.

## Fix
- Drop the `|| minDurationSec <= 0.0` short-circuit. With `minDuration = 0`, the absorb loop's `duration < 0` filter is empty, so it breaks right after the first `coalesce()` — exactly Swift's result.
- **Strengthen the test:** `zeroFloorReturnsCoalescedInputUnsmoothed` previously used `[light, deep, rem]` (no adjacent same-stage → `coalesce` a no-op), so it passed even with the short-circuit. New fixture has a `light/light` seam and asserts the coalesced output. **Verified sensitive:** it fails against the old short-circuit, passes with the fix.

Android-only; `testFullDebugUnitTest` green.