### PR TITLE
fix(ble): re-arm live R-R after a dropped TOGGLE_REALTIME_HR so HRV recovers (#312)

### DIFF
--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -705,6 +705,18 @@ class WhoopBleClient(
         }
 
         /**
+         * #312: when the write queue DROPS a frame after [MAX_WRITE_RETRIES] busy-retries, should the
+         * realtime stream be re-armed? True ONLY for [CommandNumber.TOGGLE_REALTIME_HR] — that write enables
+         * live R-R (→ HRV / Autonomic), and reconcileRealtime latched `realtimeArmed` optimistically when it
+         * queued the write, so a silent drop leaves R-R off with no re-send (plain HR keeps flowing on the
+         * standard 0x2A37 profile — the exact #312 symptom on a 5/MG whose toggle lost a GATT-write race).
+         * Every other dropped frame (haptics, offload-ack, clock, …) has its own recovery and must NOT poke
+         * the realtime latch. Pure + instance-free so the unit harness can pin it without a live GATT stack.
+         */
+        fun shouldReArmRealtimeAfterDrop(droppedCmd: CommandNumber?): Boolean =
+            droppedCmd == CommandNumber.TOGGLE_REALTIME_HR
+
+        /**
          * The LiveState the teardown path publishes after the link drops (#314). Pure model of the
          * `connected = false` + biometrics-cleared transition so a test can assert the UI flips to
          * disconnected without a live instance. Mirrors what `handleDisconnect` applies via
@@ -1508,7 +1520,7 @@ class WhoopBleClient(
      * leaned on CoreBluetooth's internal queue; here we serialise writes ourselves. Each queued
      * item is the fully-framed byte array + its write type (with/without response).
      */
-    private data class PendingWrite(val frame: ByteArray, val withResponse: Boolean)
+    private data class PendingWrite(val frame: ByteArray, val withResponse: Boolean, val cmd: CommandNumber? = null)
     private val writeQueue = ConcurrentLinkedQueue<PendingWrite>()
     // @Volatile: read on the main looper in drainWriteQueue but CLEARED from the GATT binder thread in the
     // write-completion callbacks - the barrier guarantees the main-thread drain sees the flag flip promptly
@@ -2036,14 +2048,14 @@ class WhoopBleClient(
                 byteArrayOf(0x01, 47, 152.toByte(), 0, 0, 0, 0, 0, 0, 0, 0, 0) else payload
             val s = seq.incrementAndGet() and 0xFF
             val frame = Framing.puffinCommandFrame(cmd = puffinCmd, seq = s, payload = puffinPayload)
-            enqueueWrite(PendingWrite(frame, withResponse))
+            enqueueWrite(PendingWrite(frame, withResponse, cmd))
             val cmdNote = if (isHaptics) " cmd=0x13" else ""
             log("→ ${cmd.name} payload=${puffinPayload.toHex()} (puffin$cmdNote)")
             return
         }
         val s = seq.incrementAndGet() and 0xFF
         val frame = Framing.buildCommand(cmd, payload, s)
-        enqueueWrite(PendingWrite(frame, withResponse))
+        enqueueWrite(PendingWrite(frame, withResponse, cmd))
         log("→ ${cmd.name} payload=${payload.toHex()}")
     }
 
@@ -4313,6 +4325,19 @@ class WhoopBleClient(
             } else {
                 // Genuinely stuck after several tries — drop this one frame so it can't wedge the queue.
                 log("writeCharacteristic rejected by stack; dropping one frame (after $MAX_WRITE_RETRIES retries)")
+                // #312: a dropped TOGGLE_REALTIME_HR would leave live R-R (→ HRV / Autonomic) off FOREVER.
+                // Whoever queued it latched [realtimeArmed] = the value it SENT (reconcileRealtime, or the
+                // direct arm-on-connect / keep-alive paths), so it — and the 30s keep-alive tick that also
+                // reconciles — see no edge (want == armed) and never re-send, while plain HR keeps flowing
+                // over the standard 0x2A37 profile. But the write never reached the strap, so the strap's
+                // TRUE state is the OPPOSITE of the latched value — flip it back, and the next keep-alive
+                // reconcile detects the edge and re-sends the CURRENT want (recovers a dropped ARM *or* a
+                // dropped disarm) within ~30s. Bounded by construction: the re-send rides the keep-alive
+                // cadence, not this drop path, so a persistently-busy stack retries once per tick, never in a loop.
+                if (shouldReArmRealtimeAfterDrop(item.cmd)) {
+                    realtimeArmed = !realtimeArmed
+                    log("realtime toggle dropped — reconciling on the next keep-alive tick (#312)")
+                }
                 writeRetries = 0
                 drainWriteQueue()
             }

--- a/android/app/src/test/java/com/noop/ble/RealtimeReArmOnDropTest.kt
+++ b/android/app/src/test/java/com/noop/ble/RealtimeReArmOnDropTest.kt
@@ -1,0 +1,43 @@
+package com.noop.ble
+
+import com.noop.protocol.CommandNumber
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * #312: when the GATT write queue drops a frame after MAX_WRITE_RETRIES busy-retries, only a dropped
+ * TOGGLE_REALTIME_HR should clear the realtime latch so the keep-alive re-arms live R-R (→ HRV / Autonomic).
+ * A 5/MG whose toggle lost a write race would otherwise stream plain HR forever while HRV stayed dark.
+ *
+ * Pins the pure decision [WhoopBleClient.shouldReArmRealtimeAfterDrop] — the full drop→re-arm behaviour
+ * needs a live GATT stack the unit harness can't fake (no Robolectric; see GattCrashSafetyTest's INFRA NOTE),
+ * so, matching that file's pattern, this pins the predicate the drop path is built on.
+ */
+class RealtimeReArmOnDropTest {
+
+    @Test
+    fun `dropped realtime toggle re-arms`() {
+        assertTrue(WhoopBleClient.shouldReArmRealtimeAfterDrop(CommandNumber.TOGGLE_REALTIME_HR))
+    }
+
+    @Test
+    fun `other dropped commands never poke the realtime latch`() {
+        // Each has its own recovery; clearing realtimeArmed for them would spuriously re-send the toggle.
+        for (cmd in listOf(
+            CommandNumber.RUN_HAPTICS_PATTERN,
+            CommandNumber.SEND_HISTORICAL_DATA,
+            CommandNumber.HISTORICAL_DATA_RESULT,
+            CommandNumber.SET_CLOCK,
+            CommandNumber.SET_ALARM_TIME,
+            CommandNumber.GET_BATTERY_LEVEL,
+        )) {
+            assertFalse("$cmd must not re-arm realtime", WhoopBleClient.shouldReArmRealtimeAfterDrop(cmd))
+        }
+    }
+
+    @Test
+    fun `an untagged (null-command) dropped frame does not re-arm`() {
+        assertFalse(WhoopBleClient.shouldReArmRealtimeAfterDrop(null))
+    }
+}


### PR DESCRIPTION
Fixes #312 (Android / WHOOP 5.0 / 8.6.2-staging: HRV & Autonomic shows no live data while the Live section streams HR).

## Root cause (Android-only)
Plain HR rides the standard unbonded `0x2A37` profile, but live **R-R** (→ HRV / Autonomic) needs the `TOGGLE_REALTIME_HR` write to land. Every path that arms it (`reconcileRealtime` + the direct arm-on-connect / keep-alive paths) latches `realtimeArmed = <sent value>` **before** the write is confirmed. Android GATT allows one write in flight, so under contention the toggle can exhaust `MAX_WRITE_RETRIES` (12) and be **dropped** — but `realtimeArmed` is already latched, so `reconcileRealtime` and the 30s keep-alive tick see **no edge** (`want == armed`) and never re-send. R-R stays dark forever while HR keeps flowing.

The reporter's log shows exactly this: `→ TOGGLE_REALTIME_HR` → `writeCharacteristic busy; retry 1/12`. The drop path even documents that a dropped `TOGGLE_REALTIME_HR` *"silently breaks live HR"* (#77) but only mitigates with the 12 retries — no re-arm.

## Fix
When the write queue drops a frame and it was `TOGGLE_REALTIME_HR`, **flip `realtimeArmed`**. The write never reached the strap, so its true state is the *opposite* of the optimistically-latched value; flipping makes the next keep-alive reconcile detect the edge and re-send the **current** want — recovering a dropped **arm _or_ disarm** within ~30s.
- **Bounded, no loop:** the re-send rides the keep-alive cadence (not the drop path), so a persistently-busy stack retries once per tick.
- `PendingWrite` now carries its `CommandNumber` so the drop site can identify the toggle; a pure predicate `shouldReArmRealtimeAfterDrop` gates it.

## Parity
**Android-only.** iOS CoreBluetooth serialises writes internally and has no "drop after N GATT retries" path (its `realtimeArmedAt` is the separate marginal-radio detector), so no Swift twin.

## Tests / validation
- `RealtimeReArmOnDropTest` pins the predicate (toggle re-arms; every other command + `null` does not). The full drop→re-arm needs a live GATT stack the JVM harness can't fake (no Robolectric — same limit + pure-predicate pattern as `GattCrashSafetyTest`).
- `compileFullDebugKotlin` + `testFullDebugUnitTest` green.
- ⚠️ **Needs on-strap confirmation by the reporter** — 5/MG live R-R is hardware-only-testable. The reporter's truncated log ("retry 1/12") is consistent with, but doesn't prove, a 12-retry exhaustion; the fix hardens the genuine hole regardless.