### PR TITLE
fix(sleep): scope userEdited/manual sleep corrections to their own day so one edit can't pin every night (#299)

### DIFF
--- a/Strand/Data/IntelligenceEngine.swift
+++ b/Strand/Data/IntelligenceEngine.swift
@@ -845,7 +845,11 @@ final class IntelligenceEngine: ObservableObject {
         // already staged from raw (idempotent) and for imported nights (raw never dense). This MUST run
         // before the scoring loop so the healed stages flow into Rest/recovery this same pass.
         let editedRows = await repo.selfHealEditedStages(from: windowStart, to: now)
-        let editsByStart = Dictionary(editedRows.map { ($0.startTs, $0) }, uniquingKeysWith: { a, _ in a })
+        // #299: `editsByStart` is now built PER DAY inside the scoring loop (scoped to the day each edit
+        // belongs to), NOT window-wide here. sleepEditedDaily folds any edited row that isn't a twin of THIS
+        // day's detected sessions in as a "manual" block, so a window-wide edit set let ONE user edit /
+        // hand-logged nap substitute its total onto EVERY night in the window (incl. no-sleep nights) —
+        // pinning totalSleepMin to a constant. See the loop below.
 
         // Provenance sets for the honest By-Day badge + the per-day diagnostic source token. `hist` is the
         // imported daily rows under `deviceId` (the WHOLE imported history, read above for the baseline) ,
@@ -878,6 +882,13 @@ final class IntelligenceEngine: ObservableObject {
         // "auto workout appeared then vanished" could not be explained from an export. Diagnostic only.
         let workoutsTraceActive = TestCentre.active(.workouts)
         for night in scoredNights {
+            // #299: scope the edits to THIS day before folding. A userEdited row / hand-logged nap belongs
+            // to exactly ONE day — the day its night ENDS on, matching the daily's end-day bucket. `endTs`
+            // is stable under a bedtime edit (only the onset/`startTsAdjusted` moves), so end-day is the
+            // right key. Filtering here keeps a single-night edit overriding only its OWN night instead of
+            // every night. `effectiveStartTs` (the #318 user-corrected onset) is preserved on the row.
+            let dayEditedRows = Self.editedRowsForDay(editedRows, day: night.daily.day, tzOffsetSeconds: tzOffset)
+            let editsByStart = Dictionary(dayEditedRows.map { ($0.startTs, $0) }, uniquingKeysWith: { a, _ in a })
             let daily = sleepEditedDaily(night.daily, detected: night.cachedSleep, editsByStart: editsByStart,
                                          habitualMidsleepSec: habitualMidsleepSec)
             let recovery = recomputeRecovery(daily, baselines2)
@@ -1587,6 +1598,18 @@ final class IntelligenceEngine: ObservableObject {
     /// detected twin and recomputes totalSleep / efficiency / stage minutes from the reshaped stages, so
     /// the Rest composite and recovery score the corrected sleep , not the auto-detected window. No edit
     /// touching the night → the detected daily is returned unchanged. (#318)
+    /// #299: the edited / hand-logged sleep rows that belong to `day` — the ones whose edits may be folded
+    /// into THAT day's sleep total. An edit belongs to the day its night ENDS on (`dayString(endTs)`),
+    /// matching AnalyticsEngine's end-day session bucket; `endTs` is stable under a bedtime edit (only the
+    /// onset moves). Scoping this per day is the fix: the edit set was built window-wide and
+    /// `sleepEditedDaily` folds any row that isn't a twin of a day's detected sessions in as a "manual"
+    /// block, so one edit / nap leaked its total onto EVERY night. Byte-identical twin of Android
+    /// `IntelligenceEngine.editedRowsForDay`.
+    static func editedRowsForDay(_ editedRows: [CachedSleepSession], day: String,
+                                 tzOffsetSeconds: Int) -> [CachedSleepSession] {
+        editedRows.filter { AnalyticsEngine.dayString($0.endTs, offsetSec: tzOffsetSeconds) == day }
+    }
+
     private func sleepEditedDaily(_ daily: DailyMetric, detected: [CachedSleepSession],
                                  editsByStart: [Int: CachedSleepSession],
                                  habitualMidsleepSec: Int?) -> DailyMetric {

--- a/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
+++ b/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
@@ -742,13 +742,11 @@ object IntelligenceEngine {
             windowEnd = nowSeconds,
             useExperimentalSleepV2 = useExperimentalSleepV2,
         )
-        val editsByStart: Map<Long, String?> = editedRows.associate { it.startTs to it.stagesJSON }
-        // #547 (audit finding C / #8): each edited block's EFFECTIVE onset (startTsAdjusted ?: startTs)
-        // keyed by its stable detected startTs, so the seam's main-night pick reads the user-CORRECTED
-        // bedtime , a bedtime edit crossing the overnight boundary would otherwise make the seam and the
-        // Sleep tab pick different blocks. Detected-but-unedited blocks have no adjustment (DetectedSleep
-        // carries only the detected start), so sleepEditedDaily falls back to their detected onset.
-        val editOnsetByStart: Map<Long, Long> = editedRows.associate { it.startTs to it.effectiveStartTs }
+        // #299: [editsByStart] / [editOnsetByStart] are now built PER DAY inside the scoring loop (scoped to
+        // the day each edit belongs to), NOT window-wide here. sleepEditedDaily folds any edited row that
+        // isn't a twin of THIS day's detected sessions in as a "manual" block, so a window-wide edit set let
+        // ONE user edit / hand-logged nap substitute its total onto EVERY night in the window (incl.
+        // matched=0 nights) — pinning totalSleepMin to a constant. See the loop below.
 
         // Provenance sets for the per-day diagnostic source token (Sleep overhaul §2.5). `hist` is the
         // imported daily rows under [importedDeviceId] (the WHOLE imported history, read above for the
@@ -763,6 +761,16 @@ object IntelligenceEngine {
             .map { it.day }.toHashSet()
 
         for (res in scoredNights) {
+            // #299: scope the edits to THIS day before folding. A userEdited row / hand-logged nap belongs
+            // to exactly ONE day — the day its night ENDS on, matching the daily's end-day bucket
+            // (AnalyticsEngine's `matched` filters sleep sessions by end-day). endTs is stable under a
+            // bedtime edit (only the onset/startTsAdjusted moves), so end-day is the right key. Filtering
+            // here keeps a single-night edit overriding only its OWN night instead of every night. The
+            // #547 effective-onset detail is preserved: editOnsetByStart still carries the user-CORRECTED
+            // bedtime (startTsAdjusted ?: startTs) for this day's edited/manual blocks.
+            val dayEditedRows = editedRowsForDay(editedRows, res.daily.day, tzOffsetSeconds)
+            val editsByStart: Map<Long, String?> = dayEditedRows.associate { it.startTs to it.stagesJSON }
+            val editOnsetByStart: Map<Long, Long> = dayEditedRows.associate { it.startTs to it.effectiveStartTs }
             // Substitute an edited block's (reshaped) stages for its detected twin before the daily
             // sleep aggregate feeds Rest + recovery. No edit touching this night → `daily` is unchanged.
             val daily = sleepEditedDaily(
@@ -1402,6 +1410,21 @@ object IntelligenceEngine {
      * window. No edit touching the night → the detected daily is returned unchanged. Faithful twin of
      * Swift `IntelligenceEngine.sleepEditedDaily`. (#318 / PR #395)
      */
+    /**
+     * #299: the edited / hand-logged sleep rows that belong to [day] — the ones whose edits may be folded
+     * into THAT day's sleep total. An edit belongs to the day its night ENDS on (`dayString(endTs)`),
+     * matching AnalyticsEngine's end-day session bucket; `endTs` is stable under a bedtime edit (only the
+     * onset moves). Scoping this per day is the fix: the edit set was built window-wide and
+     * [sleepEditedDaily] folds any row that isn't a twin of a day's detected sessions in as a "manual"
+     * block, so one edit / nap leaked its total onto EVERY night. Pure + internal so it's unit-testable.
+     * Byte-identical twin of Swift `IntelligenceEngine.editedRowsForDay`.
+     */
+    internal fun editedRowsForDay(
+        editedRows: List<SleepSession>,
+        day: String,
+        tzOffsetSeconds: Long,
+    ): List<SleepSession> = editedRows.filter { AnalyticsEngine.dayString(it.endTs, tzOffsetSeconds) == day }
+
     private fun sleepEditedDaily(
         daily: DailyMetric,
         detected: List<DetectedSleep>,

--- a/android/app/src/test/java/com/noop/analytics/Issue299EditDayScopeTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/Issue299EditDayScopeTest.kt
@@ -1,0 +1,46 @@
+package com.noop.analytics
+
+import com.noop.data.SleepSession
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * #299: "sleep always 85%". A single userEdited night / hand-logged nap was folded into EVERY night in the
+ * recompute window because the edit set was built window-wide — so one edit's total (e.g. 453 min) was
+ * substituted onto every night, including nights that detected no sleep at all. The fix scopes edits to the
+ * day their night ENDS on. Pins [IntelligenceEngine.editedRowsForDay] (byte-identical twin of Swift
+ * `IntelligenceEngine.editedRowsForDay`); the full analyzeRecent fold needs a live Room repo the JVM harness
+ * can't build, so — matching the existing sleep-analytics test pattern — this pins the pure day-scoping.
+ */
+class Issue299EditDayScopeTest {
+
+    private val tz = 0L
+    private val base = 1_783_620_000L    // 18:00 UTC — so base and base+1h share a day, base+24h is the next
+
+    private fun edit(startTs: Long, endTs: Long) =
+        SleepSession(deviceId = "my-whoop", startTs = startTs, endTs = endTs, userEdited = true)
+
+    @Test
+    fun `an edit folds only into the day its night ends on, not every night`() {
+        val dayX = AnalyticsEngine.dayString(base, tz)
+        val dayNext = AnalyticsEngine.dayString(base + 86_400L, tz)
+
+        val e1 = edit(base - 6 * 3600, base)                        // ends dayX
+        val e2 = edit(base - 5 * 3600, base + 3600)                 // ends dayX, an hour later
+        val e3 = edit(base + 86_400 - 6 * 3600, base + 86_400)      // ends dayNext
+        val all = listOf(e1, e2, e3)
+
+        assertEquals("dayX gets only its own edits", listOf(e1, e2),
+            IntelligenceEngine.editedRowsForDay(all, dayX, tz))
+        assertEquals("dayNext gets only its own edit (not the whole window)", listOf(e3),
+            IntelligenceEngine.editedRowsForDay(all, dayNext, tz))
+    }
+
+    @Test
+    fun `a day with no edit of its own gets none — the matched=0 night stays null, not 453`() {
+        val e = edit(base - 6 * 3600, base)                         // a single edit on dayX
+        val emptyDay = AnalyticsEngine.dayString(base + 5 * 86_400L, tz)   // 5 days on, no edit
+        assertEquals(emptyList<SleepSession>(),
+            IntelligenceEngine.editedRowsForDay(listOf(e), emptyDay, tz))
+    }
+}


### PR DESCRIPTION
Fixes #299 (WHOOP 5.0: Rest/sleep score stuck at ~85% every live night; export shows `totalSleepMin=453` identical on every night, incl. `matched=0` nights).

## Root cause (both platforms)
`analyzeRecent` built the `editsByStart`/`editOnsetByStart` maps **window-wide** (every `userEdited`/hand-logged-nap sleep row across the whole recompute window) and passed them to `sleepEditedDaily` for **every** day. `sleepEditedDaily` folds any edited row that isn't a twin of *that* day's detected sessions in as a **"manual" block** — so a single bed/wake edit or nap (`startTs=T`, total 453) was "twinless" for every *other* day and had its total folded into all of them, including `matched=0` nights whose `totalSleepMin` was otherwise `null`. One correction silently overrode the whole window → the same number every night.

- **Kotlin:** `IntelligenceEngine.kt:745`/`1425`
- **Swift twin:** `IntelligenceEngine.swift:848`/`1600` (same bug, byte-parity)

## Fix
Scope the edits to the day each belongs to — the day its night **ends** on (`dayString(endTs)`), matching AnalyticsEngine's end-day session bucket. `endTs` is stable under a bedtime edit (only the onset/`startTsAdjusted` moves), so end-day is the right key. A single-night edit still overrides its **own** night; it just stops leaking. Extracted into a pure `IntelligenceEngine.editedRowsForDay` on both platforms.

## Byte-parity & scope
- Identical logic Kotlin + Swift.
- The window-wide `editedWindows` **skip set** is deliberately left window-wide (it must span the scan to skip re-detecting all edited nights) — only the *fold* is day-scoped.
- Single-night-edit + nap behaviour preserved (existing `SleepEditDurabilityTest`/`ManualNapTest`/`MainNightConsistencyTest`/`Issue547` all pass).

## Tests
- **Kotlin:** `Issue299EditDayScopeTest` pins the day-scoping (an edit folds only into the day its night ends on; a no-edit day gets none). Full `testFullDebugUnitTest` green.
- **Swift:** compile via app-build. The full `analyzeRecent` integration needs a live store the unit harness can't build (matching the existing pure-function test pattern), so the pure scoping is pinned + the twin logic is byte-identical.