### PR TITLE
fix(coach): don't fetch the provider model list on key-save — it egressed before consent (#288)

### DIFF
--- a/Strand/AI/AICoach.swift
+++ b/Strand/AI/AICoach.swift
@@ -355,8 +355,7 @@ final class AICoachEngine: ObservableObject {
     }
 
     /// Store the user's pasted key securely. Clears any prior error. If the Keychain write fails the
-    /// key is NOT saved, so surface that to the UI instead of silently proceeding (#872), and skip the
-    /// model refresh (it would only hit `.noKey`).
+    /// key is NOT saved, so surface that to the UI instead of silently proceeding (#872).
     func setKey(_ key: String) {
         guard AIKeyStore.save(key, owner: provider.rawValue) else {
             errorText = AICoachError.keySaveFailed.errorDescription
@@ -365,8 +364,11 @@ final class AICoachEngine: ObservableObject {
         }
         errorText = nil
         objectWillChange.send() // `hasKey` is computed; nudge SwiftUI to re-read it.
-        // Pull the user's ACTUAL current models from the provider so the picker is never stale.
-        Task { await refreshModels() }
+        // #288: do NOT auto-fetch the provider's model list on key-save. For a cloud provider that GET
+        // egresses to the provider the MOMENT a key is saved (IP + request timing + key-validity) — before
+        // any send, in an app that is zero-network by default. The picker shows the curated models; the LIVE
+        // list is pulled only when the user taps Refresh (an explicit action that is its own consent) or
+        // sends. Local Custom servers still refresh on Connect.
     }
 
     /// Forget the stored key.

--- a/android/app/src/main/java/com/noop/ui/CoachViewModel.kt
+++ b/android/app/src/main/java/com/noop/ui/CoachViewModel.kt
@@ -230,8 +230,11 @@ class CoachViewModel(app: Application) : AndroidViewModel(app) {
         AiKeyStore.save(ctx, key)
         _error.value = null
         _keyVersion.value += 1
-        // Pull the user's ACTUAL current models from the provider so the picker is never stale.
-        refreshModels(ctx)
+        // #288: do NOT auto-fetch the provider's model list on key-save. For a cloud provider that GET hits
+        // the provider the MOMENT a key is saved (leaking IP + request timing + key-validity) — before the
+        // user has sent anything, in an app that is zero-network by default. The picker shows the curated
+        // shipped models (seedModels); the LIVE list is pulled only when the user taps Refresh (an explicit
+        // action that is its own consent) or sends. Local Custom servers still refresh on Connect.
     }
 
     /** Clear the stored key and reset the transcript back to the setup screen. */


### PR DESCRIPTION
Fixes #288 (code-audit finding).

## The bug
`CoachViewModel.saveKey()` / `AICoach.setKey()` called `refreshModels()` → `fetchModels()`, which for a **cloud** provider issues a live `GET …/models` with the key **the moment a key is saved** — leaking IP + request timing + key-validity to the provider **before the user sends anything**, in an app that's zero-network by default. The `_consent` gate only covers the health summary in `send()`; the model-list fetch egressed regardless.

## Minimal fix (both platforms)
Drop the auto-fetch on key-save. The picker already shows the **curated shipped model set** (`seedModels`), and both platforms already expose an explicit **Refresh models** affordance (`CoachScreen:164` / `CoachView:306`) — so the live list is pulled only on an **explicit user action** (its own consent) or a send. No behaviour lost: curated model ids are valid to send with.

- **Kotlin:** `CoachViewModel.saveKey` no longer calls `refreshModels`.
- **Swift twin:** `AICoach.setKey` no longer calls `refreshModels`.
- Local **Custom servers still refresh on Connect** (deliberate connect-to-my-server, LAN not third-party).

## Re-review / scope
Verified the *only* remaining auto-fetch is `connectCustom`; there's no provider-change/init silent fetch. **Follow-up (reporter's secondary point):** `connectCustom` has no locality guard, so a non-LAN cleartext Custom URL still egresses on Connect — worth a separate hardening pass + a scheme/locality check on the Custom base URL (left out to keep this minimal).

## Validation
- Kotlin `compileFullDebugKotlin` + coach tests green; no test asserted a fetch-on-save.
- Swift: app-build. (Removal of a network call — no unit-testable seam without the VM harness the codebase lacks.)