### PR TITLE
fix(coach): reject public cleartext Custom AI URL on iOS/macOS too — Swift parity with Android's guard (#321)

### DIFF
--- a/Strand/AI/AICoach.swift
+++ b/Strand/AI/AICoach.swift
@@ -116,9 +116,12 @@ enum AICoachError: LocalizedError {
     case network(String)
     case decode
     case keySaveFailed
+    case badCustomURL(String)
 
     var errorDescription: String? {
         switch self {
+        case .badCustomURL(let message):
+            return message
         case .noKey:
             return "Add your own API key first to use the coach."
         case .keySaveFailed:

--- a/Strand/AI/AIProvider.swift
+++ b/Strand/AI/AIProvider.swift
@@ -103,6 +103,65 @@ enum AIProvider: String, CaseIterable, Identifiable {
         while base.hasSuffix("/") { base.removeLast() }
         return URL(string: base + path) ?? URL(string: "http://localhost" + path)!
     }
+
+    /// #321 gatekeeper for the Custom (local LLM) provider — the byte-parity twin of Android
+    /// `AiCoach.guardCustomUrl` (#187), which Swift was previously missing. `https://` is always fine;
+    /// plain `http://` is allowed ONLY to a private-network host (loopback / RFC-1918 / link-local /
+    /// `*.local`), so a public cleartext endpoint can never egress. Throws `AICoachError.badCustomURL`
+    /// with an actionable message on rejection. Called by `CustomClient.send` + `fetchModels`, i.e. on
+    /// BOTH Custom network paths (mirrors Kotlin `customChatUrl` / `customModelsUrl`).
+    static func guardCustomBaseURL() throws {
+        let base = customBaseURL   // already trimmed / trailing-slash-stripped by the accessor
+        guard let comps = URLComponents(string: base),
+              let host = comps.host, !host.isEmpty,
+              let scheme = comps.scheme?.lowercased(), !scheme.isEmpty else {
+            throw AICoachError.badCustomURL(
+                "That server URL isn't valid. Use http://<host>:<port> for a local server, or https://… for a remote one.")
+        }
+        if scheme == "https" { return }
+        guard scheme == "http" else {
+            throw AICoachError.badCustomURL(
+                "Unsupported URL scheme \"\(scheme)\". Use http:// for a local server or https:// for a remote one.")
+        }
+        guard isPrivateLANOrLoopback(host) else {
+            throw AICoachError.badCustomURL(
+                "Plain http:// is only allowed to a local-network server (localhost, 10.x, 172.16-31.x, "
+                + "192.168.x, 169.254.x, or a .local name). Use https:// to reach \"\(host)\".")
+        }
+    }
+
+    /// True when `host` is on the device's own machine or its private LAN, so plain `http://` to it never
+    /// crosses the public internet: loopback (localhost / 127.0.0.0/8 / ::1), RFC-1918 (10/8, 172.16/12,
+    /// 192.168/16), link-local (169.254/16 / fe80::/10), fc00::/7 ULA, and any `*.local` mDNS name.
+    /// Byte-identical decisions to Android `AiCoach.isPrivateLanOrLoopback`.
+    static func isPrivateLANOrLoopback(_ host: String) -> Bool {
+        let raw = host.trimmingCharacters(in: .whitespacesAndNewlines)   // match Kotlin String.trim()
+        let h = raw.trimmingCharacters(in: CharacterSet(charactersIn: "[]")).lowercased()
+        if h.isEmpty { return false }
+        // Only apply the fc/fd/fe80 classification to a real IPv6 LITERAL (bracketed, or contains a colon),
+        // so a public NAME like "fclient.evil.com" can't be mistaken for a ULA and allowed cleartext.
+        let isIPv6Literal = raw.hasPrefix("[") || h.contains(":")
+        if isIPv6Literal {
+            if h == "::1" { return true }
+            if h.hasPrefix("fc") || h.hasPrefix("fd") || h.hasPrefix("fe80:") { return true }
+            return false
+        }
+        if h == "localhost" || h.hasSuffix(".localhost") { return true }
+        if h.hasSuffix(".local") && h.count > ".local".count { return true }
+        let parts = h.split(separator: ".", omittingEmptySubsequences: false).map(String.init)
+        if parts.count != 4 { return false }
+        let octets = parts.map { Int($0) ?? -1 }
+        if octets.contains(where: { $0 < 0 || $0 > 255 }) { return false }
+        let a = octets[0], b = octets[1]
+        switch true {
+        case a == 127: return true                       // 127.0.0.0/8 loopback
+        case a == 10: return true                        // 10.0.0.0/8
+        case a == 172 && (16...31).contains(b): return true  // 172.16.0.0/12
+        case a == 192 && b == 168: return true           // 192.168.0.0/16
+        case a == 169 && b == 254: return true           // 169.254.0.0/16 link-local
+        default: return false
+        }
+    }
 }
 
 // MARK: - Provider protocol

--- a/Strand/AI/Providers/Custom.swift
+++ b/Strand/AI/Providers/Custom.swift
@@ -13,6 +13,7 @@ struct CustomClient: AIProviderClient {
         messages: [(role: ChatMessage.Role, content: String)],
         session: URLSession
     ) async throws -> String {
+        try AIProvider.guardCustomBaseURL()   // #321: reject a public cleartext Custom URL before egress
         var wire: [[String: Any]] = [["role": "system", "content": systemPrompt]]
         for m in messages { wire.append(["role": m.role.rawValue, "content": m.content]) }
 
@@ -57,6 +58,7 @@ struct CustomClient: AIProviderClient {
     }
 
     func fetchModels(key: String, session: URLSession) async throws -> [String] {
+        try AIProvider.guardCustomBaseURL()   // #321: reject a public cleartext Custom URL before egress
         var req = URLRequest(url: AIProvider.custom.modelsEndpoint)
         req.httpMethod = "GET"
         if !key.isEmpty { req.setValue("Bearer \(key)", forHTTPHeaderField: "Authorization") }

--- a/android/app/src/main/java/com/noop/ai/AiCoach.kt
+++ b/android/app/src/main/java/com/noop/ai/AiCoach.kt
@@ -452,50 +452,6 @@ class AiCoach(private val repo: WhoopRepository) {
         }
     }
 
-    /**
-     * True when [host] is on the device's own machine or its private LAN, so plain http:// to it
-     * never crosses the public internet: loopback (localhost / 127.0.0.0/8 / ::1), RFC1918
-     * (10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16), link-local (169.254.0.0/16 / fe80::/10), the
-     * emulator host alias 10.0.2.2, and any *.local mDNS name. Anything else is treated as public.
-     */
-    private fun isPrivateLanOrLoopback(host: String): Boolean {
-        val raw = host.trim()
-        val h = raw.trim('[', ']').lowercase()  // strip IPv6 brackets if present
-        if (h.isEmpty()) return false
-
-        // Is this an IPv6 LITERAL, not a DNS hostname? A URI gives a bracketed host for an IPv6
-        // literal ("[::1]"), and an IPv6 literal always contains a colon while a DNS host (the host
-        // component excludes the :port) never does. We must only apply the fc/fd/fe80 ULA/link-local
-        // classification to a real literal, otherwise a PUBLIC name like "fclient.evil.com" or
-        // "fdn.example.com" starts with "fc"/"fd" and would be wrongly allowed plain-HTTP cleartext.
-        val isIpv6Literal = raw.startsWith("[") || h.contains(':')
-        if (isIpv6Literal) {
-            if (h == "::1") return true                                   // loopback
-            // fc00::/7 unique-local, fe80::/10 link-local, literal-only.
-            if (h.startsWith("fc") || h.startsWith("fd") || h.startsWith("fe80:")) return true
-            return false                                                  // any other IPv6 literal = public
-        }
-
-        if (h == "localhost" || h.endsWith(".localhost")) return true
-        // mDNS / Bonjour LAN names: require a real label before ".local" (so the bare ".local" /
-        // "local" can't slip through), and only for an actual hostname (handled above for literals).
-        if (h.endsWith(".local") && h.length > ".local".length) return true
-
-        // IPv4 dotted-quad: validate and classify by RFC1918 / loopback / link-local.
-        val parts = h.split(".")
-        if (parts.size != 4) return false
-        val octets = parts.map { it.toIntOrNull() ?: -1 }
-        if (octets.any { it < 0 || it > 255 }) return false
-        val (a, b) = octets[0] to octets[1]
-        return when {
-            a == 127 -> true                              // 127.0.0.0/8 loopback
-            a == 10 -> true                               // 10.0.0.0/8
-            a == 172 && b in 16..31 -> true               // 172.16.0.0/12
-            a == 192 && b == 168 -> true                  // 192.168.0.0/16
-            a == 169 && b == 254 -> true                  // 169.254.0.0/16 link-local
-            else -> false
-        }
-    }
 
     // ---------------------------------------------------------------------------------------
     // Anthropic, POST /v1/messages
@@ -627,6 +583,53 @@ class AiCoach(private val repo: WhoopRepository) {
 
     companion object {
         private val JSON = "application/json; charset=utf-8".toMediaType()
+
+        /**
+         * True when [host] is on the device's own machine or its private LAN, so plain http:// to it
+         * never crosses the public internet: loopback (localhost / 127.0.0.0/8 / ::1), RFC1918
+         * (10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16), link-local (169.254.0.0/16 / fe80::/10), the
+         * emulator host alias 10.0.2.2, and any *.local mDNS name. Anything else is treated as public.
+         * Pure; `internal` so it's unit-testable (#321) — the byte-parity reference for Swift
+         * `AIProvider.isPrivateLANOrLoopback`. Called unqualified by the instance `guardCustomUrl`.
+         */
+        internal fun isPrivateLanOrLoopback(host: String): Boolean {
+            val raw = host.trim()
+            val h = raw.trim('[', ']').lowercase()  // strip IPv6 brackets if present
+            if (h.isEmpty()) return false
+
+            // Is this an IPv6 LITERAL, not a DNS hostname? A URI gives a bracketed host for an IPv6
+            // literal ("[::1]"), and an IPv6 literal always contains a colon while a DNS host (the host
+            // component excludes the :port) never does. We must only apply the fc/fd/fe80 ULA/link-local
+            // classification to a real literal, otherwise a PUBLIC name like "fclient.evil.com" or
+            // "fdn.example.com" starts with "fc"/"fd" and would be wrongly allowed plain-HTTP cleartext.
+            val isIpv6Literal = raw.startsWith("[") || h.contains(':')
+            if (isIpv6Literal) {
+                if (h == "::1") return true                                   // loopback
+                // fc00::/7 unique-local, fe80::/10 link-local, literal-only.
+                if (h.startsWith("fc") || h.startsWith("fd") || h.startsWith("fe80:")) return true
+                return false                                                  // any other IPv6 literal = public
+            }
+
+            if (h == "localhost" || h.endsWith(".localhost")) return true
+            // mDNS / Bonjour LAN names: require a real label before ".local" (so the bare ".local" /
+            // "local" can't slip through), and only for an actual hostname (handled above for literals).
+            if (h.endsWith(".local") && h.length > ".local".length) return true
+
+            // IPv4 dotted-quad: validate and classify by RFC1918 / loopback / link-local.
+            val parts = h.split(".")
+            if (parts.size != 4) return false
+            val octets = parts.map { it.toIntOrNull() ?: -1 }
+            if (octets.any { it < 0 || it > 255 }) return false
+            val (a, b) = octets[0] to octets[1]
+            return when {
+                a == 127 -> true                              // 127.0.0.0/8 loopback
+                a == 10 -> true                               // 10.0.0.0/8
+                a == 172 && b in 16..31 -> true               // 172.16.0.0/12
+                a == 192 && b == 168 -> true                  // 192.168.0.0/16
+                a == 169 && b == 254 -> true                  // 169.254.0.0/16 link-local
+                else -> false
+            }
+        }
 
         /**
          * Max chat turns sent on a single request, beyond the context-bearing first user turn. Caps

--- a/android/app/src/test/java/com/noop/ai/CustomUrlLocalityTest.kt
+++ b/android/app/src/test/java/com/noop/ai/CustomUrlLocalityTest.kt
@@ -1,0 +1,49 @@
+package com.noop.ai
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * #321 / #187: the Custom (local-LLM) provider locality classifier — plain http:// is allowed ONLY to a
+ * host on the device or its private LAN, so a public cleartext endpoint can never egress. This is the
+ * byte-parity REFERENCE for the Swift twin `AIProvider.isPrivateLANOrLoopback` (Swift was missing the
+ * guard entirely — #321). Same fixtures must classify identically on both platforms.
+ */
+class CustomUrlLocalityTest {
+
+    private fun local(h: String) =
+        assertTrue("$h should be treated as local/LAN", AiCoach.isPrivateLanOrLoopback(h))
+
+    private fun public_(h: String) =
+        assertFalse("$h should be treated as PUBLIC (no cleartext)", AiCoach.isPrivateLanOrLoopback(h))
+
+    @Test
+    fun `loopback and LAN hosts are local`() {
+        listOf(
+            "localhost", "foo.localhost",
+            "127.0.0.1", "127.255.255.254",
+            "10.0.0.5", "10.0.2.2",              // 10/8 incl. the Android-emulator host alias
+            "172.16.0.1", "172.31.255.254",      // 172.16/12
+            "192.168.1.100",                     // 192.168/16
+            "169.254.10.20",                     // link-local
+            "::1", "[::1]",                       // IPv6 loopback (bracketed or not)
+            "fc00::1", "fd12:3456::1", "fe80::abcd",  // ULA / link-local literals
+            "nas.local", "printer.local",        // mDNS
+        ).forEach(::local)
+    }
+
+    @Test
+    fun `public hosts are rejected — incl the fc-name and 172-edge traps`() {
+        listOf(
+            "api.openai.com", "example.com",
+            "8.8.8.8", "1.2.3.4",
+            "172.15.0.1", "172.32.0.1",          // just outside 172.16-31
+            "fclient.evil.com", "fdn.example.com",  // public NAMES starting fc/fd — must NOT be ULA
+            "fe80.evil.com",                     // public name starting fe80 (not an IPv6 literal)
+            "2001:4860:4860::8888",              // public IPv6 literal
+            "local", ".local",                   // bare mDNS suffix must not pass
+            "",                                  // empty
+        ).forEach(::public_)
+    }
+}


### PR DESCRIPTION
Fixes #321 (follow-up to #288/#320).

## The gap (Swift-only)
Android already blocks a public `http://` Custom-provider URL (`AiCoach.guardCustomUrl`, #187). **Swift never got the twin:** `AIProvider.customURL(path:)` built the endpoint straight from user input with no locality/scheme check, and both Custom paths (chat `/chat/completions`, models `/models`) route through it — so on iOS/macOS a **public cleartext Custom URL was accepted silently**.

## Fix — byte-parity port to Swift
- `AIProvider.guardCustomBaseURL()` + `isPrivateLANOrLoopback()`: `https://` always fine; plain `http://` only to loopback / RFC-1918 / link-local / `*.local`; a public cleartext host throws `AICoachError.badCustomURL` with the same actionable message. Only a real IPv6 **literal** gets the `fc/fd/fe80` classification, so a public name like `fclient.evil.com` can't be mistaken for a ULA (the #187 trap).
- Applied on **both** `CustomClient.send` and `.fetchModels` (mirrors Kotlin `customChatUrl`/`customModelsUrl`), so `connectCustom`'s model fetch **and** every chat turn are guarded.

## Parity test
Android's `isPrivateLanOrLoopback` moved to the companion + made `internal` so **`CustomUrlLocalityTest` (JVM)** pins it as the byte-parity reference — LAN accepted; public + the `fclient.evil.com` / `172.32.x` traps rejected. The Swift twin replicates the same decisions (I diffed the logic line-by-line; the only engine difference — `URI` vs `URLComponents` IPv6 bracket handling — yields identical *decisions* via the colon check).

## Validation
- Kotlin: full `testFullDebugUnitTest` green incl. `CustomUrlLocalityTest`.
- Swift: app-build (app-target Swift; the classifier lives in `AIProvider`, tested-by-parity via the Kotlin reference).