### PR TITLE
fix(sleep): gate the #277 V2 default to 5.0/MG — WHOOP 4.0 keeps V1 (#319)

### DIFF
--- a/Strand/Data/IntelligenceEngine.swift
+++ b/Strand/Data/IntelligenceEngine.swift
@@ -625,7 +625,9 @@ final class IntelligenceEngine: ObservableObject {
                 // #690: read the experimental-V2 toggle ONCE here (off the detached executor, matching the
                 // Repository self-heal call site) and capture the Bool, so the Settings toggle now drives the
                 // NORMAL detected-night staging path , not only the userEdited self-heal restage.
-                let useSleepStagerV2 = PuffinExperiment.experimentalSleepV2Enabled
+                // #319: V2 is the default only on 5.0/MG (where #277 promoted it); WHOOP 4.0 always uses V1.
+                let useSleepStagerV2 = Self.sleepStagerV2(enabled: PuffinExperiment.experimentalSleepV2Enabled,
+                                                          family: skinFamily)
 
                 // Already OFF the main actor , score directly (the prior nested `Task.detached` here only
                 // existed to hop off the main actor; the whole loop now runs off it, so the score is computed
@@ -1453,6 +1455,15 @@ final class IntelligenceEngine: ObservableObject {
     /// The strap family that wrote `owner`'s skin-temp rows (#938), so the nightly funnel converts the raw
     /// register on the right scale. The model-label → family mapping (and the `.whoop5` fallback for
     /// unknowns) lives in `DeviceFamily.forRegistryModel` (#171).
+    /// #319: whether V2 staging should run for a night owned by `family`. V2 is the default only on 5.0/MG
+    /// (where #277 promoted it after a benchmark on NON-WHOOP wrist sensors); WHOOP 4.0 always uses V1 — its
+    /// SPARSE motion makes V2 both inflate the Rest restorative term AND manufacture deep/REM that DEFEATS
+    /// the H9 low-confidence guard, so a poor 4.0 night reads as a confident 85-100. Byte-parity twin of
+    /// Android `IntelligenceEngine.sleepStagerV2ForFamily`.
+    nonisolated static func sleepStagerV2(enabled: Bool, family: DeviceFamily) -> Bool {
+        enabled && family != .whoop4
+    }
+
     nonisolated static func skinTempFamily(forOwner owner: String, devices: [PairedDevice]) -> DeviceFamily {
         DeviceFamily.forRegistryModel(devices.first(where: { $0.id == owner })?.model)
     }

--- a/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
+++ b/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
@@ -39,6 +39,17 @@ import kotlinx.coroutines.withContext
 object IntelligenceEngine {
 
     /**
+     * #319: whether V2 staging should run for a night owned by [family]. V2 is the default only on 5.0/MG
+     * (where #277 promoted it after a benchmark on NON-WHOOP wrist sensors); WHOOP 4.0 always uses V1 —
+     * its SPARSE motion (only ~1 in 5 records carries it) makes V2 both inflate the Rest restorative term
+     * AND manufacture deep/REM that DEFEATS the H9 low-confidence guard, so a poor 4.0 night reads as a
+     * confident 85-100 (issue #319). An explicit toggle still enables/disables V2 on 5.0/MG. Pure;
+     * byte-parity twin of Swift `IntelligenceEngine.sleepStagerV2(enabled:family:)`.
+     */
+    internal fun sleepStagerV2ForFamily(enabled: Boolean, family: DeviceFamily): Boolean =
+        enabled && family != DeviceFamily.WHOOP4
+
+    /**
      * Serialises [analyzeRecent] against itself. The pass is launched from four independent coroutines: the
      * 15-min backstop loop and rescoreAfterEdit (both AppViewModel), the post-offload analyze
      * (WhoopBleClient), plus the one-shot Effort rescore ([runEffortRescoreIfNeeded]). These can overlap:
@@ -546,10 +557,10 @@ object IntelligenceEngine {
                 habitualMidsleepSec = habitualMidsleepSec,
                 bandSleepState = bandSleepState,
                 // #690: thread the V2 toggle into the NORMAL staging path so it affects detected nights,
-                // not just the userEdited self-heal restage (which already reads this same flag at line ~496).
-                // The Context-aware caller (AppViewModel/WhoopBleClient) supplied it from
-                // PuffinExperiment.from(context).experimentalSleepV2.
-                useSleepStagerV2 = useExperimentalSleepV2,
+                // not just the userEdited self-heal restage. The Context-aware caller (AppViewModel/
+                // WhoopBleClient) supplied it from PuffinExperiment.from(context).experimentalSleepV2.
+                // #319: V2 is the default only on 5.0/MG (where #277 promoted it); WHOOP 4.0 always uses V1.
+                useSleepStagerV2 = sleepStagerV2ForFamily(useExperimentalSleepV2, skinFamily),
                 // Sleep & Rest test mode (Test Centre E5): thread the trace sink straight through. null (the
                 // default) keeps analyzeDay's byte-identical untraced path; when the caller passed a non-null
                 // sink (mode on), detectSleep's gate trace + the Rest sub-score line route to the .sleep-tagged

--- a/android/app/src/test/java/com/noop/analytics/SleepV2FamilyGateTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/SleepV2FamilyGateTest.kt
@@ -1,0 +1,29 @@
+package com.noop.analytics
+
+import com.noop.protocol.DeviceFamily
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * #319: the #277 V2-default promotion applies to WHOOP 5.0/MG only. WHOOP 4.0 always uses V1 — its sparse
+ * motion makes V2 inflate the Rest restorative term AND defeat the H9 low-confidence guard, so a poor 4.0
+ * night reads as a confident 85-100. Pins [IntelligenceEngine.sleepStagerV2ForFamily] (byte-parity twin of
+ * Swift `IntelligenceEngine.sleepStagerV2(enabled:family:)`).
+ */
+class SleepV2FamilyGateTest {
+
+    @Test
+    fun `V2 is the default on 5MG, never on WHOOP 4`() {
+        assertTrue("5.0/MG with the toggle on → V2",
+            IntelligenceEngine.sleepStagerV2ForFamily(enabled = true, family = DeviceFamily.WHOOP5))
+        assertFalse("WHOOP 4 → V1 even with the toggle on",
+            IntelligenceEngine.sleepStagerV2ForFamily(enabled = true, family = DeviceFamily.WHOOP4))
+    }
+
+    @Test
+    fun `an explicit-off toggle wins on both families`() {
+        assertFalse(IntelligenceEngine.sleepStagerV2ForFamily(enabled = false, family = DeviceFamily.WHOOP5))
+        assertFalse(IntelligenceEngine.sleepStagerV2ForFamily(enabled = false, family = DeviceFamily.WHOOP4))
+    }
+}


### PR DESCRIPTION
Fixes #319 (WHOOP 4.0: Rest scores 85-100 on poor nights).

## Root cause (from the reporter's strap log)
The offload is healthy but **only 118 of 590 records carry motion (~20%)** — 4.0 banks motion coarsely. The detector's #28 sparse-motion recovery (HR-vouched bridge) counts quiet, low-HR, motion-less periods as asleep → **inflated duration + efficiency** → high Rest.

## Why #277 made it worse on 4.0
#277 made **V2 the default for everyone**. On 4.0:
1. V2 recovers more deep/REM → **raises the restorative term** on the already-inflated duration.
2. V2's manufactured deep/REM **defeats the H9 low-confidence guard** — on V1 a sparse night stages *flat*, so H9 fires and the score reads honestly as low-confidence; V2 fills the stages in, so it reads as a **confident** 85-100. (And V2 was benchmarked on non-WHOOP wrist sensors — never validated on 4.0 sparse motion.)

## Fix
Gate the V2 default by the night's **device family**: V2 stays default on **5.0/MG** (where #277 promoted it), **WHOOP 4.0 always uses V1**.
- Pure `IntelligenceEngine.sleepStagerV2ForFamily(enabled, family) = enabled && family != WHOOP4`, applied at the normal detected-night staging call (`skinFamily` already resolved there).
- **5.0/MG is byte-identical** (`enabled && WHOOP5 != WHOOP4 == enabled`) — #277 intact there.

## Parity & tests
- Byte-parity Kotlin + Swift (`Strand/Data/IntelligenceEngine.swift`), identical gate.
- `SleepV2FamilyGateTest` (JVM) pins it; full `testFullDebugUnitTest` green; Swift via app-build.

## Note / follow-up
The **userEdited self-heal restage** still reads the raw flag, so an *edited* 4.0 night would use V2 — a small follow-up. #319 is about normal detected nights, which this fixes.