### PR TITLE
diag(sleep): emit motion-coverage + stager context in the Sleep & Rest trace (#319)

### DIFF
--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/AnalyticsEngine.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/AnalyticsEngine.swift
@@ -448,6 +448,13 @@ public enum AnalyticsEngine {
                 restorativeSeconds: deepS + remS, needHours: sleepNeedHours,
                 consistency: sleepConsistency, deepSeconds: deepS,
                 groupFragments: mainGroup.count, groupInBedSeconds: inBedS))
+            // #319: the motion-coverage + staging context behind the Rest number, so a high score on a poor
+            // night can be explained from an export (WHOOP 4.0 banks motion coarsely → sparse=true → most
+            // epochs default to sleep → over-counted duration → high Rest). `stager` says whether V1/V2 ran.
+            traceSink(AnalyticsEngine.sleepMotionLine(
+                day: day, grav: gravity.count, hr: hr.count,
+                sparse: SleepStager.isGravitySparse(gravity, hr: hr),
+                useSleepStagerV2: useSleepStagerV2, family: skinTempFamily))
             // CAPTURE-C (#799): append the sleep PROVENANCE so an imported row winning the merge is visible
             // (not silently swapped for the measured night). hoursAsleep = the scored night's tst in minutes;
             // sourceRowId = the main-night's start ts for the measured path (stable per night), else the

--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/RestSubScoreTrace.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/RestSubScoreTrace.swift
@@ -1,4 +1,5 @@
 import Foundation
+import WhoopProtocol   // DeviceFamily (sleepMotionLine)
 
 // RestSubScoreTrace.swift - the Sleep & Rest test-mode diagnostic for the Rest composite.
 //

--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/RestSubScoreTrace.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/RestSubScoreTrace.swift
@@ -37,6 +37,17 @@ extension AnalyticsEngine {
         "sleepProvenance provenance=\(provenance.wire) "
             + "hoursAsleep=\(Int(hoursAsleepMin.rounded())) sourceRowId=\(sourceRowId)"
     }
+
+    /// #319 diagnostic (Sleep & Rest test mode): the motion-coverage + staging context behind the Rest
+    /// number, so a high score on a poor night can be explained straight from an export. `grav`/`hr` are the
+    /// night-window sample counts; `sparse` is the gravity-sparse gate (WHOOP 4.0 banks motion coarsely, so
+    /// most epochs default to sleep → over-counted duration → high Rest); `stager` says which engine ran;
+    /// `family` the day's owner. PURE; byte-identical to Android `AnalyticsEngine.sleepMotionLine`.
+    public static func sleepMotionLine(day: String, grav: Int, hr: Int, sparse: Bool,
+                                       useSleepStagerV2: Bool, family: DeviceFamily) -> String {
+        "sleep-motion day=\(day) grav=\(grav) hr=\(hr) sparse=\(sparse) "
+            + "stager=\(useSleepStagerV2 ? "V2" : "V1") family=\(family.rawValue)"
+    }
 }
 
 extension AnalyticsEngine.Rest {

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/RestSubScoreTraceTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/RestSubScoreTraceTests.swift
@@ -1,4 +1,5 @@
 import XCTest
+import WhoopProtocol
 @testable import StrandAnalytics
 
 final class RestSubScoreTraceTests: XCTestCase {
@@ -49,5 +50,17 @@ final class RestSubScoreTraceTests: XCTestCase {
             restorativeSeconds: restorative, needHours: need, consistency: 0.7, deepSeconds: deep)
         let r2 = (composite * 100.0).rounded() / 100.0
         XCTAssertTrue(line.contains("composite=\(r2)"), line)
+    }
+
+    // #319: byte-parity with Android SleepMotionLineTest — identical expected strings.
+    func testSleepMotionLine() {
+        XCTAssertEqual(
+            AnalyticsEngine.sleepMotionLine(day: "2026-07-12", grav: 118, hr: 590, sparse: true,
+                                            useSleepStagerV2: false, family: .whoop4),
+            "sleep-motion day=2026-07-12 grav=118 hr=590 sparse=true stager=V1 family=whoop4")
+        XCTAssertEqual(
+            AnalyticsEngine.sleepMotionLine(day: "2026-07-12", grav: 800, hr: 590, sparse: false,
+                                            useSleepStagerV2: true, family: .whoop5),
+            "sleep-motion day=2026-07-12 grav=800 hr=590 sparse=false stager=V2 family=whoop5")
     }
 }

--- a/android/app/src/main/java/com/noop/analytics/AnalyticsEngine.kt
+++ b/android/app/src/main/java/com/noop/analytics/AnalyticsEngine.kt
@@ -440,6 +440,11 @@ object AnalyticsEngine {
                 needHours = sleepNeedHours ?: RestScorer.defaultSleepNeedHours,
                 consistency = sleepConsistency, deepSeconds = deepS,
                 groupFragments = mainGroup.size, groupInBedSeconds = inBedS))
+            // #319: the motion-coverage + staging context behind the Rest number, so a high score on a poor
+            // night can be explained from an export — WHOOP 4.0 banks motion coarsely (sparse=true), so most
+            // epochs default to sleep → over-counted duration → high Rest; `stager` says whether V1/V2 ran.
+            traceSink(RestScorer.sleepMotionLine(day, gravity.size, hr.size,
+                SleepStager.isGravitySparse(gravity, hr), useSleepStagerV2, skinTempFamily))
         }
 
         // ── Recovery / Charge ─────────────────────────────────────────────────
@@ -891,6 +896,18 @@ object RestScorer {
      * disagree with the score. `groupFragments` / `groupInBedSeconds` describe the main-night GROUP
      * composition (#525/#561). Pure, side-effect-free, no em-dashes. Mirrors Swift exactly.
      */
+    /**
+     * #319 diagnostic (Sleep & Rest test mode): the motion-coverage + staging context behind the Rest
+     * number, so a high score on a poor night can be explained straight from an export. `grav`/`hr` are the
+     * night-window sample counts; `sparse` is the gravity-sparse gate (WHOOP 4.0 banks motion coarsely, so
+     * most epochs default to sleep → over-counted duration → high Rest); `stager` says which engine ran;
+     * `family` the day's owner. Pure, no em-dashes; byte-identical to Swift `AnalyticsEngine.sleepMotionLine`.
+     */
+    fun sleepMotionLine(
+        day: String, grav: Int, hr: Int, sparse: Boolean, useSleepStagerV2: Boolean, family: DeviceFamily,
+    ): String = "sleep-motion day=$day grav=$grav hr=$hr sparse=$sparse " +
+        "stager=${if (useSleepStagerV2) "V2" else "V1"} family=${family.name.lowercase()}"
+
     fun subScoreLine(
         tstSeconds: Double, inBedSeconds: Double, efficiency: Double, restorativeSeconds: Double,
         needHours: Double, consistency: Double?, deepSeconds: Double?,

--- a/android/app/src/test/java/com/noop/analytics/SleepMotionLineTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/SleepMotionLineTest.kt
@@ -1,0 +1,31 @@
+package com.noop.analytics
+
+import com.noop.protocol.DeviceFamily
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * #319 diagnostic: [AnalyticsEngine.sleepMotionLine] exposes the motion-coverage + staging context behind a
+ * Rest score in the Sleep & Rest test-mode export. Pins the exact wire string as the byte-parity reference
+ * for the Swift twin `AnalyticsEngine.sleepMotionLine` (StrandAnalytics), tested identically in swift-packages.
+ */
+class SleepMotionLineTest {
+
+    @Test
+    fun `sparse WHOOP4 night on V1`() {
+        assertEquals(
+            "sleep-motion day=2026-07-12 grav=118 hr=590 sparse=true stager=V1 family=whoop4",
+            RestScorer.sleepMotionLine(
+                day = "2026-07-12", grav = 118, hr = 590, sparse = true,
+                useSleepStagerV2 = false, family = DeviceFamily.WHOOP4))
+    }
+
+    @Test
+    fun `dense 5MG night on V2`() {
+        assertEquals(
+            "sleep-motion day=2026-07-12 grav=800 hr=590 sparse=false stager=V2 family=whoop5",
+            RestScorer.sleepMotionLine(
+                day = "2026-07-12", grav = 800, hr = 590, sparse = false,
+                useSleepStagerV2 = true, family = DeviceFamily.WHOOP5))
+    }
+}


### PR DESCRIPTION
Instrument-first for #319 (WHOOP 4.0 Rest scores stuck at 85-100).

## Why
#319 is over-counted sleep **duration** — 4.0 banks motion coarsely (the reporter's log: only 118/590 records carry motion), so the detector's sparse-motion recovery counts quiet, low-HR periods as asleep. The Sleep & Rest test mode already logs the Rest **sub-scores** (duration/efficiency/restorative/consistency → composite) but nothing about *why* they're inflated, or which stager ran.

## What
One diagnostic line, emitted alongside the sub-score line (same trace sink, **zero-cost when the mode is off**):
```
sleep-motion day=2026-07-12 grav=118 hr=590 sparse=true stager=V1 family=whoop4
```
- **grav/hr** — night-window motion-vs-HR sample counts (the coverage signal).
- **sparse** — the `isGravitySparse` gate (the 4.0 coarse-motion condition).
- **stager** — V1 or V2 (answers the #277/#319 gate question for this reporter's build).
- **family** — the day's owner (whoop4/whoop5).

So a stuck-high score can be explained straight from an export: `sparse=true` + a near-need duration pins it to the coarse-motion over-count.

## Parity & tests
Byte-identical wire string: `RestScorer.sleepMotionLine` (Kotlin) / `AnalyticsEngine.sleepMotionLine` (StrandAnalytics). Pinned by `SleepMotionLineTest` (JVM) and `RestSubScoreTraceTests.testSleepMotionLine` (swift-packages) with **identical expected strings**. No em-dashes. Full `testFullDebugUnitTest` green; Swift via swift-packages CI (StrandAnalytics hits the GRDB/Linux wall locally).