### PR TITLE
Future-dated strap (#324): surface a banner + bad-clock diagnostics

### DIFF
--- a/Packages/WhoopProtocol/Sources/WhoopProtocol/BadClockDiagnostics.swift
+++ b/Packages/WhoopProtocol/Sources/WhoopProtocol/BadClockDiagnostics.swift
@@ -1,0 +1,38 @@
+import Foundation
+
+/// #324 bad-clock strap diagnostics: pure formatters for the Backfiller's strap-log lines about a strap
+/// whose RTC reset to a wrong base (future- or far-past-dated banking). Kept here (not in the app target)
+/// so the formatting is `swift test`-able on Linux and mirrored byte-for-byte by the Kotlin twin. No state,
+/// no `Date()` inside — callers inject `now` so the output is deterministic and testable.
+public enum BadClockDiagnostics {
+
+    /// UTC `yyyy-MM-dd` for a unix-seconds timestamp — the human-readable day a dropped record CLAIMED,
+    /// which on a bad-clock strap is the wrong base its RTC jumped to.
+    public static func isoDay(_ unix: Int) -> String {
+        let f = DateFormatter()
+        f.calendar = Calendar(identifier: .gregorian)
+        f.timeZone = TimeZone(identifier: "UTC")
+        f.locale = Locale(identifier: "en_US_POSIX")
+        f.dateFormat = "yyyy-MM-dd"
+        return f.string(from: Date(timeIntervalSince1970: TimeInterval(unix)))
+    }
+
+    /// Signed hour offset of `unix` from `now`, worded for a log: "26445h ahead" / "512h behind" / "~now"
+    /// (within an hour). The magnitude is what tells a future-clock strap (#928) from a stale-clock one.
+    public static func hoursOffset(_ unix: Int, now: Int) -> String {
+        let h = (unix - now) / 3600
+        if h > 0 { return "\(h)h ahead" }
+        if h < 0 { return "\(-h)h behind" }
+        return "~now"
+    }
+
+    /// The parenthetical span clause appended to the dropped-record log: " (dated 2028-06-24 -> 2029-07-15,
+    /// 26445h ahead)". Empty string when nothing was dropped (both nil), so the base sentence reads normally.
+    /// When oldest == newest a single date is shown. `now` words the offset of the NEWEST (frontier) record.
+    public static func droppedSpanClause(oldest: Int?, newest: Int?, now: Int) -> String {
+        guard let o = oldest, let n = newest else { return "" }
+        let offset = hoursOffset(n, now: now)
+        if o == n { return " (dated \(isoDay(n)), \(offset))" }
+        return " (dated \(isoDay(o)) -> \(isoDay(n)), \(offset))"
+    }
+}

--- a/Packages/WhoopProtocol/Sources/WhoopProtocol/HistoricalStreams.swift
+++ b/Packages/WhoopProtocol/Sources/WhoopProtocol/HistoricalStreams.swift
@@ -152,6 +152,10 @@ public func extractHistoricalStreams(_ parsed: [ParsedFrame],
                                         sessionOldestUnix: sessionOldestUnix,
                                         sessionNewestUnix: sessionNewestUnix) else {
             droppedImplausible += 1
+            // #324: track the epoch SPAN of the dropped (bad-clock) records — the strap's OWN dated value,
+            // so the Backfiller can log whether the whole poisoned range is future-dated or mixed.
+            droppedOldest = min(droppedOldest ?? candidate, candidate)
+            droppedNewest = max(droppedNewest ?? candidate, candidate)
             return nil
         }
         return candidate
@@ -159,6 +163,9 @@ public func extractHistoricalStreams(_ parsed: [ParsedFrame],
     // #547: how many records this chunk dropped for an implausible ts. Surfaced to the Backfiller via
     // `Streams.droppedImplausible` so the strap log can show a bad-clock strap (observability only).
     var droppedImplausible = 0
+    // #324: oldest/newest own-timestamp among the dropped records (the poisoned-range epoch span).
+    var droppedOldest: Int? = nil
+    var droppedNewest: Int? = nil
     var out = Streams()
     // v26 optical-PPG records (issue #156): no measured HR/motion, just the 24 Hz waveform. Collect
     // (corrected-wall ts, samples) here and derive a per-second HR after the loop (PpgHr.derivePpgHr),
@@ -231,8 +238,18 @@ public func extractHistoricalStreams(_ parsed: [ParsedFrame],
             // EVENT carries the strap RTC's real-unix seconds. Correct for a grossly-stale RTC
             // (FIX #72); a normal strap is unchanged (offset < threshold). #547 gate: skip the event
             // when `correctedWall` rejects an implausible ts so no future/far-past event is banked.
-            guard let rawTs = p["event_timestamp"]?.intValue, let ts = correctedWall(rawTs) else { continue }
+            guard let rawTs = p["event_timestamp"]?.intValue else { continue }
             let kind = p["event"]?.stringValue ?? ""
+            guard let ts = correctedWall(rawTs) else {
+                // #324: the #547 gate just dropped this event for an implausible ts. If it's an RTC-STATE
+                // event (RTC_LOST / BOOT / SET_RTC), that IS the ground truth that the clock reset — capture
+                // (kind, rawTs) for the strap log before discarding, so a future-dated strap's cause isn't
+                // silently swallowed by the very gate the bad clock trips.
+                if DroppedRtcEvent.isRtcStateKind(kind) {
+                    out.droppedRtcEvents.append(DroppedRtcEvent(kind: kind, rawTs: rawTs))
+                }
+                continue
+            }
             if kind.hasPrefix("BATTERY_LEVEL") { appendBattery(&out, ts: ts, p: p) }  // "BATTERY_LEVEL(3)"
             var payload = p
             payload.removeValue(forKey: "event")
@@ -249,5 +266,7 @@ public func extractHistoricalStreams(_ parsed: [ParsedFrame],
     // records (the WHOOP 4 / v18-only common case), so this is a no-op cost there.
     out.ppgHr = PpgHr.derivePpgHr(records: ppgRecords)
     out.droppedImplausible = droppedImplausible   // #547 diag count (not persisted, not encoded)
+    out.droppedImplausibleOldestTs = droppedOldest   // #324 poisoned-range epoch span (diag only)
+    out.droppedImplausibleNewestTs = droppedNewest
     return out
 }

--- a/Packages/WhoopProtocol/Sources/WhoopProtocol/Streams.swift
+++ b/Packages/WhoopProtocol/Sources/WhoopProtocol/Streams.swift
@@ -224,6 +224,17 @@ public struct Streams: Equatable, Codable {
     /// and NOT round-tripped through Codable (excluded from `CodingKeys`) — it is a transient observability
     /// count the Backfiller surfaces to the strap log. Defaults to 0 so it never affects golden fixtures.
     public var droppedImplausible: Int = 0
+    /// #324 diagnostic: the OLDEST / NEWEST own-timestamp (unix seconds, the strap's OWN dated value) among
+    /// records DROPPED this chunk for an implausible ts. Lets the Backfiller log the epoch SPAN of a bad-clock
+    /// strap's poisoned range - so a future-dated strap shows "2028-06-24 -> 2029-07" and we can tell a
+    /// WHOLE-range-future strap (safe to fast-forward-discard) from one mixed with real data. Transient (not
+    /// in CodingKeys), nil when nothing dropped. Defaults keep golden fixtures byte-identical.
+    public var droppedImplausibleOldestTs: Int? = nil
+    public var droppedImplausibleNewestTs: Int? = nil
+    /// #324 diagnostic: strap RTC-STATE events (RTC_LOST / BOOT / SET_RTC) DROPPED for an implausible own-ts.
+    /// The #547 gate discards them like any bad-ts record, but these are the GROUND TRUTH that the clock reset
+    /// - so we capture (kind, rawTs) for the strap log before dropping. Transient, empty by default, not encoded.
+    public var droppedRtcEvents: [DroppedRtcEvent] = []
     public init(hr: [HRSample] = [], rr: [RRInterval] = [],
                 spo2: [SpO2Sample] = [], skinTemp: [SkinTempSample] = [],
                 resp: [RespSample] = [], gravity: [GravitySample] = [],
@@ -271,6 +282,21 @@ public struct Streams: Equatable, Codable {
 }
 
 extension Streams { public static let empty = Streams() }
+
+/// #324 diagnostic record: a strap RTC-STATE event (RTC_LOST / BOOT / SET_RTC) that the #547 plausibility
+/// gate dropped for an implausible own-timestamp. `rawTs` is the event's OWN dated value (unix seconds) - on
+/// a future-dated strap this is the bad epoch the RTC jumped to, the single most useful signal for #324.
+public struct DroppedRtcEvent: Equatable, Codable, Sendable {
+    public let kind: String
+    public let rawTs: Int
+    public init(kind: String, rawTs: Int) { self.kind = kind; self.rawTs = rawTs }
+
+    /// The RTC-state event kinds worth capturing when dropped. Kinds are formatted "NAME(n)" (e.g.
+    /// "RTC_LOST(13)"), matched by prefix - "BOOT" covers both BOOT and BOOT_REPORT.
+    public static func isRtcStateKind(_ kind: String) -> Bool {
+        kind.hasPrefix("RTC_LOST") || kind.hasPrefix("SET_RTC") || kind.hasPrefix("BOOT")
+    }
+}
 
 /// Map a device-epoch timestamp to wall-clock unix seconds via a pure linear offset.
 /// Assumes strap clock and wall clock tick at the same rate (no skew/drift). Port of _to_wall.

--- a/Packages/WhoopProtocol/Tests/WhoopProtocolTests/BadClockDiagnosticsTests.swift
+++ b/Packages/WhoopProtocol/Tests/WhoopProtocolTests/BadClockDiagnosticsTests.swift
@@ -1,0 +1,36 @@
+import XCTest
+@testable import WhoopProtocol
+
+/// #324 — the pure strap-log formatters for a bad-clock strap. Deterministic (now is injected), so the
+/// Kotlin twin (`BadClockDiagnostics` in WhoopBleClient) must produce byte-identical strings.
+final class BadClockDiagnosticsTests: XCTestCase {
+
+    func testIsoDayIsUTC() {
+        // 1_735_084_800 == 2024-12-25 00:00 UTC (the #547 tests' documented badYule anchor).
+        XCTAssertEqual(BadClockDiagnostics.isoDay(1_735_084_800), "2024-12-25")
+    }
+
+    func testHoursOffsetWording() {
+        let now = 1_783_843_824
+        XCTAssertEqual(BadClockDiagnostics.hoursOffset(now + 26_445 * 3600, now: now), "26445h ahead")
+        XCTAssertEqual(BadClockDiagnostics.hoursOffset(now - 512 * 3600, now: now), "512h behind")
+        XCTAssertEqual(BadClockDiagnostics.hoursOffset(now + 60, now: now), "~now")   // within an hour
+    }
+
+    func testDroppedSpanClause() {
+        let now = 1_783_843_824
+        // Nothing dropped → empty clause so the base sentence reads normally.
+        XCTAssertEqual(BadClockDiagnostics.droppedSpanClause(oldest: nil, newest: nil, now: now), "")
+        // A range → "oldest -> newest, offset(newest)". Build the expected from the same pinned primitives
+        // (isoDay/hoursOffset are covered above) so the test pins the ASSEMBLY, not hand-computed dates.
+        let o = 1_845_000_000, n = 1_876_000_000
+        let expected = " (dated \(BadClockDiagnostics.isoDay(o)) -> \(BadClockDiagnostics.isoDay(n)), "
+            + "\(BadClockDiagnostics.hoursOffset(n, now: now)))"
+        XCTAssertEqual(BadClockDiagnostics.droppedSpanClause(oldest: o, newest: n, now: now), expected)
+        XCTAssertTrue(expected.contains("->"))
+        // oldest == newest → single date, no arrow.
+        let single = BadClockDiagnostics.droppedSpanClause(oldest: n, newest: n, now: now)
+        XCTAssertFalse(single.contains("->"), single)
+        XCTAssertEqual(single, " (dated \(BadClockDiagnostics.isoDay(n)), \(BadClockDiagnostics.hoursOffset(n, now: now)))")
+    }
+}

--- a/Packages/WhoopProtocol/Tests/WhoopProtocolTests/HistoricalTimestampGateTests.swift
+++ b/Packages/WhoopProtocol/Tests/WhoopProtocolTests/HistoricalTimestampGateTests.swift
@@ -28,6 +28,15 @@ final class HistoricalTimestampGateTests: XCTestCase {
         )
     }
 
+    /// Build a synthetic EVENT ParsedFrame carrying `event` (kind, "NAME(n)") + `event_timestamp`.
+    private func eventFrame(kind: String, unix: Int) -> ParsedFrame {
+        ParsedFrame(
+            ok: true, typeName: "EVENT", seq: 48, cmdName: nil, crcOK: true,
+            lenBytes: 0, rawHex: "", fields: [],
+            parsed: ["event": .string(kind), "event_timestamp": .int(unix)]
+        )
+    }
+
     // MARK: - bounds parity
 
     func testBoundsMatchAndroid() {
@@ -153,6 +162,61 @@ final class HistoricalTimestampGateTests: XCTestCase {
             sessionOldestUnix: 12_345, sessionNewestUnix: newest)   // oldest < MIN_PLAUSIBLE_UNIX → malformed
         XCTAssertEqual(st.hr.count, 1, "a malformed (below-floor) oldest marker must not reject real data")
         XCTAssertEqual(st.droppedImplausible, 0)
+    }
+
+    // MARK: - #324 bad-clock diagnostics capture (epoch span + dropped RTC-state events)
+
+    func testCapturesDroppedEpochSpan() {
+        // Three dropped bad-clock records — the returned span must bracket their OWN dated values so the
+        // strap log can show whether the whole poisoned range is future-dated.
+        let frames = [histFrame(unix: 1_250_000_000), histFrame(unix: FAR_FUTURE), histFrame(unix: 1_827_642_881)]
+        let st = extractHistoricalStreams(frames, deviceClockRef: wallNow, wallClockRef: wallNow)
+        XCTAssertEqual(st.droppedImplausible, 3)
+        XCTAssertEqual(st.droppedImplausibleOldestTs, 1_250_000_000)
+        XCTAssertEqual(st.droppedImplausibleNewestTs, FAR_FUTURE)
+    }
+
+    func testNoDropLeavesSpanNil() {
+        let st = extractHistoricalStreams([histFrame(unix: wallNow)], deviceClockRef: wallNow, wallClockRef: wallNow)
+        XCTAssertNil(st.droppedImplausibleOldestTs)
+        XCTAssertNil(st.droppedImplausibleNewestTs)
+        XCTAssertTrue(st.droppedRtcEvents.isEmpty)
+    }
+
+    func testCapturesDroppedRtcStateEvent() {
+        // A future-dated RTC_LOST: the #547 gate still DROPS it from persistence (bad ts), but #324 captures
+        // it (kind + rawTs) as the ground-truth signal that the clock reset.
+        let st = extractHistoricalStreams([eventFrame(kind: "RTC_LOST(13)", unix: FAR_FUTURE)],
+                                          deviceClockRef: wallNow, wallClockRef: wallNow)
+        XCTAssertEqual(st.events.count, 0, "the future-dated event is still dropped from persistence")
+        XCTAssertEqual(st.droppedRtcEvents.count, 1)
+        XCTAssertEqual(st.droppedRtcEvents.first?.kind, "RTC_LOST(13)")
+        XCTAssertEqual(st.droppedRtcEvents.first?.rawTs, FAR_FUTURE)
+    }
+
+    func testPlausibleRtcEventKeptNotCaptured() {
+        // A plausible RTC_LOST is a normal kept event — never captured as "dropped".
+        let st = extractHistoricalStreams([eventFrame(kind: "RTC_LOST(13)", unix: wallNow)],
+                                          deviceClockRef: wallNow, wallClockRef: wallNow)
+        XCTAssertEqual(st.droppedRtcEvents.count, 0)
+        XCTAssertEqual(st.events.count, 1)
+    }
+
+    func testNonRtcDroppedEventNotCaptured() {
+        // A future-dated NON-rtc event (WRIST_ON) is dropped + counted, but NOT captured (only RTC-state kinds).
+        let st = extractHistoricalStreams([eventFrame(kind: "WRIST_ON(9)", unix: FAR_FUTURE)],
+                                          deviceClockRef: wallNow, wallClockRef: wallNow)
+        XCTAssertEqual(st.droppedRtcEvents.count, 0)
+        XCTAssertEqual(st.droppedImplausible, 1, "still counted as a dropped implausible record")
+    }
+
+    func testRtcStateKindMatch() {
+        XCTAssertTrue(DroppedRtcEvent.isRtcStateKind("RTC_LOST(13)"))
+        XCTAssertTrue(DroppedRtcEvent.isRtcStateKind("SET_RTC(16)"))
+        XCTAssertTrue(DroppedRtcEvent.isRtcStateKind("BOOT(15)"))
+        XCTAssertTrue(DroppedRtcEvent.isRtcStateKind("BOOT_REPORT(30)"))
+        XCTAssertFalse(DroppedRtcEvent.isRtcStateKind("WRIST_ON(9)"))
+        XCTAssertFalse(DroppedRtcEvent.isRtcStateKind("BATTERY_LEVEL(3)"))
     }
 
     func testIdentityRefTrustsRealRawTimestamp() {

--- a/Strand/BLE/BLEManager.swift
+++ b/Strand/BLE/BLEManager.swift
@@ -1729,6 +1729,15 @@ public final class BLEManager: NSObject, ObservableObject {
                 state.lastSyncError = sustainedEmpty
                     ? "Synced, but your strap had no stored history to hand over - only its diagnostic output. This usually means its clock has lost sync, so it isn't saving data to flash. Fully charge it to 100%, then reconnect, and it should start banking again."
                     : nil
+            } else if let futureBanner = BLEManager.futureDatedStrapBanner(
+                          strapNewestTs: strapNewestTs, wallNowUnix: Int(Date().timeIntervalSince1970)) {
+                // #324/#928: the strap banked records but its newest is dated implausibly in the FUTURE
+                // (RTC relatched ahead). #773 drops the future-dated samples so nothing is misfiled, but
+                // the "banked something" path above would otherwise report a clean sync and leave the
+                // user with no data and no reason. Name the real cause + the strap-side remedy.
+                let aheadH = ((strapNewestTs ?? 0) - Int(Date().timeIntervalSince1970)) / 3600
+                log("Backfill: completed but the strap's newest banked record is \(aheadH)h AHEAD of the wall clock (#324/#928) - clock set in the future; showing the future-clock banner and importing nothing from this range.")
+                state.lastSyncError = futureBanner
             } else {
                 state.lastSyncError = nil
             }
@@ -1928,6 +1937,23 @@ public final class BLEManager: NSObject, ObservableObject {
         let bankedSensorRecords = decodedChunks > 0 || archivedFrames > 0 || unarchivedFrames > 0
         let bankedNothing = !bankedSensorRecords && (consoleChunks >= 3 || rowsPersisted == 0)
         return (bankedSensorRecords, bankedNothing)
+    }
+
+    /// #324/#928: the post-sync banner for a strap whose clock is set in the FUTURE. Unlike the
+    /// "clock lost / not banking" case (`bankedNothing`), this strap DOES bank records every pass — but
+    /// its RTC relatched to a future base, so every banked timestamp reads ahead of the wall clock and
+    /// NOOP won't import them (importing would misfile the night days or years ahead). The existing
+    /// clock-lost banner is gated on empty syncs and never fires here, so this failure mode was silent
+    /// (#324). Returns the user-facing string when the strap-reported newest record is future-dated
+    /// beyond the 48 h skew allowance (`BackfillContinuation.isFutureDatedNewest`), else nil. Pure and
+    /// deterministic — one detection is decisive (nothing legitimate banks 48 h ahead), so no streak
+    /// gate is needed. Mirrors Android `futureDatedStrapBanner`.
+    nonisolated static func futureDatedStrapBanner(strapNewestTs: Int?, wallNowUnix: Int) -> String? {
+        guard BackfillContinuation.isFutureDatedNewest(strapNewestTs, wallNowUnix: wallNowUnix) else { return nil }
+        return "Synced, but your strap's clock is set in the future - its banked history is dated ahead of "
+            + "today, so NOOP can't trust those timestamps and didn't import them (importing them would "
+            + "misfile your data days or years ahead). Fully charge the strap to 100% and power-cycle it so "
+            + "its clock re-syncs, then reconnect."
     }
 
     /// Start (or restart) the periodic backfill timer. Each tick re-runs the type-47 historical

--- a/Strand/BLE/BLEManager.swift
+++ b/Strand/BLE/BLEManager.swift
@@ -1679,6 +1679,16 @@ public final class BLEManager: NSObject, ObservableObject {
         let currentTrim = backfiller?.lastAckedTrim
         let trimAdvanced = currentTrim != nil && currentTrim != lastSessionEndTrim
         lastSessionEndTrim = currentTrim
+        // #324/#928: a strap whose newest banked record is dated in the FUTURE (RTC relatched ahead) is
+        // future-dated regardless of HOW this offload ended — a deep future-dated backlog TIMES OUT as
+        // readily as it completes (the reporter's #324 session ended on timeout, not HISTORY_COMPLETE).
+        // Compute the banner once so BOTH outcomes name the real cause instead of "strap went quiet".
+        let futureClockBanner = BLEManager.futureDatedStrapBanner(
+            strapNewestTs: strapNewestTs, wallNowUnix: Int(Date().timeIntervalSince1970))
+        if futureClockBanner != nil {
+            let aheadH = ((strapNewestTs ?? 0) - Int(Date().timeIntervalSince1970)) / 3600
+            log("Backfill: the strap's newest banked record is \(aheadH)h AHEAD of the wall clock (#324/#928) - clock set in the future; showing the future-clock banner and importing nothing from this range.")
+        }
         // Honest sync outcome for a cloud-free user (mirrors Android exitBackfilling, ed6a31d):
         // HISTORY_COMPLETE stamps lastSyncedAt + clears any error; the idle-watchdog timeout surfaces
         // a non-silent error. A disconnect mid-sync bypasses this path (didDisconnectPeripheral resets
@@ -1729,14 +1739,11 @@ public final class BLEManager: NSObject, ObservableObject {
                 state.lastSyncError = sustainedEmpty
                     ? "Synced, but your strap had no stored history to hand over - only its diagnostic output. This usually means its clock has lost sync, so it isn't saving data to flash. Fully charge it to 100%, then reconnect, and it should start banking again."
                     : nil
-            } else if let futureBanner = BLEManager.futureDatedStrapBanner(
-                          strapNewestTs: strapNewestTs, wallNowUnix: Int(Date().timeIntervalSince1970)) {
+            } else if let futureBanner = futureClockBanner {
                 // #324/#928: the strap banked records but its newest is dated implausibly in the FUTURE
                 // (RTC relatched ahead). #773 drops the future-dated samples so nothing is misfiled, but
                 // the "banked something" path above would otherwise report a clean sync and leave the
                 // user with no data and no reason. Name the real cause + the strap-side remedy.
-                let aheadH = ((strapNewestTs ?? 0) - Int(Date().timeIntervalSince1970)) / 3600
-                log("Backfill: completed but the strap's newest banked record is \(aheadH)h AHEAD of the wall clock (#324/#928) - clock set in the future; showing the future-clock banner and importing nothing from this range.")
                 state.lastSyncError = futureBanner
             } else {
                 state.lastSyncError = nil
@@ -1780,7 +1787,11 @@ public final class BLEManager: NSObject, ObservableObject {
                     state.lastSyncError = nil
                 }
             } else {
-                state.lastSyncError = "Sync interrupted - the strap went quiet. It will retry on the next sync."
+                // #324/#928: a future-dated strap TIMES OUT on its deep future-dated backlog — that's not
+                // "the strap went quiet", it's the clock being set ahead. Prefer the honest future-clock
+                // banner so the reporter's timeout case (the common one) names the real cause + remedy.
+                state.lastSyncError = futureClockBanner
+                    ?? "Sync interrupted - the strap went quiet. It will retry on the next sync."
             }
         }
         checkStrapLiveness()         // safety-net: strap ahead of us AND our frontier frozen ⇒ stuck?

--- a/Strand/BLE/BLEManager.swift
+++ b/Strand/BLE/BLEManager.swift
@@ -1683,10 +1683,11 @@ public final class BLEManager: NSObject, ObservableObject {
         // future-dated regardless of HOW this offload ended — a deep future-dated backlog TIMES OUT as
         // readily as it completes (the reporter's #324 session ended on timeout, not HISTORY_COMPLETE).
         // Compute the banner once so BOTH outcomes name the real cause instead of "strap went quiet".
+        let wallNowForBanner = Int(Date().timeIntervalSince1970)
         let futureClockBanner = BLEManager.futureDatedStrapBanner(
-            strapNewestTs: strapNewestTs, wallNowUnix: Int(Date().timeIntervalSince1970))
+            strapNewestTs: strapNewestTs, wallNowUnix: wallNowForBanner)
         if futureClockBanner != nil {
-            let aheadH = ((strapNewestTs ?? 0) - Int(Date().timeIntervalSince1970)) / 3600
+            let aheadH = ((strapNewestTs ?? 0) - wallNowForBanner) / 3600
             log("Backfill: the strap's newest banked record is \(aheadH)h AHEAD of the wall clock (#324/#928) - clock set in the future; showing the future-clock banner and importing nothing from this range.")
         }
         // Honest sync outcome for a cloud-free user (mirrors Android exitBackfilling, ed6a31d):

--- a/Strand/Collect/Backfiller.swift
+++ b/Strand/Collect/Backfiller.swift
@@ -492,8 +492,23 @@ final class Backfiller {
                 let wasZero = sessionDroppedImplausible == 0
                 sessionDroppedImplausible += decoded.droppedImplausible
                 if wasZero {
-                    log?("Backfill: dropped record(s) with an implausible timestamp (trim=\(trim)) — the strap's clock is wrong (records dated far in the past or future), so those samples were skipped rather than misfiled onto the wrong day. Fully charge and reconnect the strap so its clock re-syncs.")
+                    // #324: append the epoch SPAN of the dropped block + how far off it sits, so the strap log
+                    // shows WHETHER the whole banked range is future-dated (safe to fast-forward-discard) or
+                    // just a slice. `droppedImplausibleOldestTs/NewestTs` are the records' OWN dated values
+                    // (the strap's wrong clock), captured by the #547 gate as it dropped them.
+                    let span = BadClockDiagnostics.droppedSpanClause(
+                        oldest: decoded.droppedImplausibleOldestTs,
+                        newest: decoded.droppedImplausibleNewestTs,
+                        now: Int(Date().timeIntervalSince1970))
+                    log?("Backfill: dropped record(s) with an implausible timestamp (trim=\(trim))\(span) — the strap's clock is wrong (records dated far in the past or future), so those samples were skipped rather than misfiled onto the wrong day. Fully charge and reconnect the strap so its clock re-syncs.")
                 }
+            }
+            // #324: the strap RTC-state events (RTC_LOST / BOOT / SET_RTC) the #547 gate dropped for a bad
+            // own-timestamp — the GROUND TRUTH that the clock reset. Sparse (not per-record), so log each as
+            // it appears; the bad `rawTs` is the future/past base the RTC jumped to.
+            let nowForRtc = Int(Date().timeIntervalSince1970)
+            for ev in decoded.droppedRtcEvents {
+                log?("Backfill: strap reported \(ev.kind) with an implausible own-timestamp \(BadClockDiagnostics.isoDay(ev.rawTs)) (\(BadClockDiagnostics.hoursOffset(ev.rawTs, now: nowForRtc)) vs now) — the strap's RTC reset to a wrong base (#324/#928); this is the ground-truth cause of the future-dated banking, not a NOOP decode bug.")
             }
             // Diagnostic (#77): the AGGREGATE silent-loss case — frames arrived but produced no rows at
             // all (CRC fail / unmapped layout / out-of-range timestamp), so this chunk persists nothing

--- a/StrandTests/EmptyBankingClassifierTests.swift
+++ b/StrandTests/EmptyBankingClassifierTests.swift
@@ -76,6 +76,41 @@ final class EmptyBankingClassifierTests: XCTestCase {
                       "#214 + #126: three consecutive metadata-only completions trip the guidance")
     }
 
+    // MARK: - #324/#928 future-dated strap banner
+
+    // A strap whose newest banked record is far in the FUTURE gets the "clock set in the future" banner.
+    // This strap BANKS records (bankedNothing = false), so the clock-lost banner never covers it (#324).
+    func testFutureDatedNewestSurfacesBanner() {
+        let now = 1_783_843_824                     // ~2026-07-12, the reporter's wall clock
+        let newest = now + 26_445 * 3600            // 26445 h ahead — the #324 log's banked frontier
+        let banner = BLEManager.futureDatedStrapBanner(strapNewestTs: newest, wallNowUnix: now)
+        XCTAssertNotNil(banner)
+        XCTAssertTrue(banner?.contains("set in the future") == true, banner ?? "nil")
+        XCTAssertTrue(banner?.contains("power-cycle") == true, banner ?? "nil")
+    }
+
+    // A healthy strap (newest at/behind the wall clock) gets NO future-clock banner.
+    func testCurrentStrapNoFutureBanner() {
+        let now = 1_783_843_824
+        XCTAssertNil(BLEManager.futureDatedStrapBanner(strapNewestTs: now - 3600, wallNowUnix: now))
+        XCTAssertNil(BLEManager.futureDatedStrapBanner(strapNewestTs: now, wallNowUnix: now))
+    }
+
+    // Inside the 48 h skew allowance (timezone confusion / mild drift) stays silent — matches the gate
+    // shared with shouldAutoContinue so the banner and the backfill decision never disagree.
+    func testWithinSkewAllowanceNoFutureBanner() {
+        let now = 1_783_843_824
+        XCTAssertNil(BLEManager.futureDatedStrapBanner(strapNewestTs: now + 24 * 3600, wallNowUnix: now),
+                     "24 h ahead is within the 48 h allowance — not flagged")
+        XCTAssertNotNil(BLEManager.futureDatedStrapBanner(strapNewestTs: now + 49 * 3600, wallNowUnix: now),
+                        "just past 48 h is future-dated")
+    }
+
+    // An unknown (nil) strap frontier is UNKNOWN, not future-dated — no banner.
+    func testNilNewestNoFutureBanner() {
+        XCTAssertNil(BLEManager.futureDatedStrapBanner(strapNewestTs: nil, wallNowUnix: 1_783_843_824))
+    }
+
     // A banking cycle between metadata-only completions resets the streak — no false alarm for a strap
     // that's genuinely caught up after banking earlier.
     func testBankingCycleResetsTheMetadataOnlyStreak() {

--- a/android/app/src/main/java/com/noop/ble/Backfiller.kt
+++ b/android/app/src/main/java/com/noop/ble/Backfiller.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import com.noop.data.InsertCounts
 import com.noop.data.StreamBatch
 import com.noop.data.WhoopRepository
+import com.noop.protocol.BadClockDiagnostics
 import com.noop.protocol.DeviceFamily
 import com.noop.protocol.Framing
 import com.noop.protocol.HistoricalMeta
@@ -400,11 +401,32 @@ class Backfiller(
             sessionDroppedImplausible += decoded.droppedImplausibleTs
             if (decoded.droppedImplausibleTs > 0 && !loggedImplausibleClock) {
                 loggedImplausibleClock = true
+                // #324: append the epoch SPAN of the dropped block + how far off it sits, so the strap log
+                // shows WHETHER the whole banked range is future-dated (safe to fast-forward-discard) or a slice.
+                val span = BadClockDiagnostics.droppedSpanClause(
+                    decoded.droppedImplausibleOldestTs,
+                    decoded.droppedImplausibleNewestTs,
+                    System.currentTimeMillis() / 1000L,
+                )
                 log(
                     "Backfill: WARNING dropped ${decoded.droppedImplausibleTs} record(s) with an " +
-                        "implausible timestamp (bad strap clock — far-past or future-dated); they are " +
+                        "implausible timestamp$span (bad strap clock — far-past or future-dated); they are " +
                         "excluded so they can't misdate history.",
                 )
+            }
+            // #324: the strap RTC-state events (RTC_LOST / BOOT / SET_RTC) the #547 gate dropped for a bad
+            // own-timestamp — the GROUND TRUTH that the clock reset. Sparse (not per-record), so log each as
+            // it appears; the bad rawTs is the future/past base the RTC jumped to.
+            if (decoded.droppedRtcEvents.isNotEmpty()) {
+                val nowForRtc = System.currentTimeMillis() / 1000L
+                for (ev in decoded.droppedRtcEvents) {
+                    log(
+                        "Backfill: strap reported ${ev.kind} with an implausible own-timestamp " +
+                            "${BadClockDiagnostics.isoDay(ev.rawTs)} (${BadClockDiagnostics.hoursOffset(ev.rawTs, nowForRtc)} " +
+                            "vs now) — the strap's RTC reset to a wrong base (#324/#928); this is the ground-truth " +
+                            "cause of the future-dated banking, not a NOOP decode bug.",
+                    )
+                }
             }
             // #77 / #91: HISTORICAL_DATA record frames that fail decode (CRC failure, or an unmapped
             // layout the v24 fallback's plausibility gate also rejects) used to be acked anyway — the

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -853,6 +853,24 @@ class WhoopBleClient(
         ): Boolean = strapNewestTs != null && strapNewestTs > wallNowUnix + futureSkewSeconds
 
         /**
+         * #324/#928: the post-sync banner for a strap whose clock is set in the FUTURE. Unlike the
+         * "clock lost / not banking" case ([classifyCompletedOffload]'s bankedNothing), this strap DOES
+         * bank records every pass — but its RTC relatched to a future base, so every banked timestamp
+         * reads ahead of the wall clock and NOOP won't import them (importing would misfile the night
+         * days or years ahead). The clock-lost banner is gated on empty syncs and never fires here, so
+         * this failure mode was silent (#324). Returns the user-facing string when the strap-reported
+         * newest is future-dated beyond the 48 h skew allowance ([isFutureDatedNewest]), else null. Pure
+         * and deterministic — one detection is decisive (nothing legitimate banks 48 h ahead), so no
+         * streak gate is needed. Mirrors the Swift `BLEManager.futureDatedStrapBanner`.
+         */
+        fun futureDatedStrapBanner(strapNewestTs: Long?, wallNowUnix: Long): String? =
+            if (!isFutureDatedNewest(strapNewestTs, wallNowUnix)) null
+            else "Synced, but your strap's clock is set in the future - its banked history is dated ahead of " +
+                "today, so NOOP can't trust those timestamps and didn't import them (importing them would " +
+                "misfile your data days or years ahead). Fully charge the strap to 100% and power-cycle it so " +
+                "its clock re-syncs, then reconnect."
+
+        /**
          * Decides whether a backfill session that ended on the 60s IDLE cap (NOT a true HISTORY_COMPLETE)
          * should immediately re-kick another offload instead of tearing down to wait the 900s periodic
          * floor (#364). The strap offloads OLDEST-first at ~60s/session with no auto-continue, so on a
@@ -4848,6 +4866,14 @@ class WhoopBleClient(
                     "consecutive empty syncs = ${emptySyncTracker.consecutiveEmptySyncs}.",
             )
         }
+        // #324/#928: parity with the Swift log — a completed sync that banked records dated implausibly in
+        // the future (RTC relatched ahead) shows the future-clock banner below; name it in the export too.
+        if (reason == "HISTORY_COMPLETE" && !bankedNothing &&
+            futureDatedStrapBanner(strapNewestTs, nowSec) != null
+        ) {
+            val aheadH = ((strapNewestTs ?: 0L) - nowSec) / 3600
+            log("Backfill: completed but the strap's newest banked record is ${aheadH}h AHEAD of the wall clock (#324/#928) - clock set in the future; showing the future-clock banner and importing nothing from this range.")
+        }
         // PR #556 reimpl: persist the HISTORY_COMPLETE instant so "Last synced N ago" survives a BLE-client
         // recreation / process restart and stops reverting to "Never".
         if (reason == "HISTORY_COMPLETE") NoopPrefs.setLastSyncAt(context, nowSec)
@@ -4890,7 +4916,10 @@ class WhoopBleClient(
                 lastSyncAt = nowSec,
                 lastSyncError = if (bankedNothing && sustainedEmpty)
                     "Synced, but your strap had no stored history to hand over - only its diagnostic output. This usually means its clock has lost sync, so it isn't saving data to flash. Fully charge it to 100%, then reconnect, and it should start banking again."
-                else null,
+                // #324/#928: the strap banked records but its newest is dated implausibly in the future
+                // (RTC relatched ahead). #773 drops the samples so nothing is misfiled, but this path would
+                // otherwise report a clean sync and leave the user with no data and no reason. Name it.
+                else futureDatedStrapBanner(strapNewestTs, nowSec),
                 historySyncExperimental = whoop5HistoryExperimental,
             )
             "timeout" -> it.copy(

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -4866,13 +4866,14 @@ class WhoopBleClient(
                     "consecutive empty syncs = ${emptySyncTracker.consecutiveEmptySyncs}.",
             )
         }
-        // #324/#928: parity with the Swift log — a completed sync that banked records dated implausibly in
-        // the future (RTC relatched ahead) shows the future-clock banner below; name it in the export too.
-        if (reason == "HISTORY_COMPLETE" && !bankedNothing &&
-            futureDatedStrapBanner(strapNewestTs, nowSec) != null
-        ) {
+        // #324/#928: a strap whose newest banked record is dated in the FUTURE (RTC relatched ahead) is
+        // future-dated regardless of HOW this offload ended — a deep future-dated backlog TIMES OUT as
+        // readily as it completes (the reporter's #324 session ended on timeout, not HISTORY_COMPLETE).
+        // Compute the banner once so BOTH outcomes name the real cause instead of "strap went quiet".
+        val futureClockBanner = futureDatedStrapBanner(strapNewestTs, nowSec)
+        if (futureClockBanner != null) {
             val aheadH = ((strapNewestTs ?: 0L) - nowSec) / 3600
-            log("Backfill: completed but the strap's newest banked record is ${aheadH}h AHEAD of the wall clock (#324/#928) - clock set in the future; showing the future-clock banner and importing nothing from this range.")
+            log("Backfill: the strap's newest banked record is ${aheadH}h AHEAD of the wall clock (#324/#928) - clock set in the future; showing the future-clock banner and importing nothing from this range.")
         }
         // PR #556 reimpl: persist the HISTORY_COMPLETE instant so "Last synced N ago" survives a BLE-client
         // recreation / process restart and stops reverting to "Never".
@@ -4919,7 +4920,7 @@ class WhoopBleClient(
                 // #324/#928: the strap banked records but its newest is dated implausibly in the future
                 // (RTC relatched ahead). #773 drops the samples so nothing is misfiled, but this path would
                 // otherwise report a clean sync and leave the user with no data and no reason. Name it.
-                else futureDatedStrapBanner(strapNewestTs, nowSec),
+                else futureClockBanner,
                 historySyncExperimental = whoop5HistoryExperimental,
             )
             "timeout" -> it.copy(
@@ -4927,8 +4928,10 @@ class WhoopBleClient(
                 syncChunksThisSession = ackedChunksThisSession,
                 // #580: on a history-experimental 5/MG this isn't a sync failure — suppress the "went quiet"
                 // error (it's just the empty offload), and surface the experimental flag instead.
+                // #324/#928: a future-dated WHOOP-4 TIMES OUT on its deep future-dated backlog — prefer the
+                // honest future-clock banner over "strap went quiet" (the reporter's #324 case timed out).
                 lastSyncError = if (isWhoop5) null
-                    else "Sync interrupted - the strap went quiet. It will retry on the next sync.",
+                    else futureClockBanner ?: "Sync interrupted - the strap went quiet. It will retry on the next sync.",
                 historySyncExperimental = whoop5HistoryExperimental,
             )
             else -> it.copy(

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -4915,12 +4915,18 @@ class WhoopBleClient(
                 backfilling = false,
                 syncChunksThisSession = ackedChunksThisSession,
                 lastSyncAt = nowSec,
-                lastSyncError = if (bankedNothing && sustainedEmpty)
-                    "Synced, but your strap had no stored history to hand over - only its diagnostic output. This usually means its clock has lost sync, so it isn't saving data to flash. Fully charge it to 100%, then reconnect, and it should start banking again."
-                // #324/#928: the strap banked records but its newest is dated implausibly in the future
-                // (RTC relatched ahead). #773 drops the samples so nothing is misfiled, but this path would
-                // otherwise report a clean sync and leave the user with no data and no reason. Name it.
-                else futureClockBanner,
+                // bankedNothing keeps its own sustained-empty precedence (#126/#214) — future-dated is
+                // checked ONLY on the banked-something path, matching the Swift else-if order exactly so
+                // the two platforms never disagree on which banner a given sync shows.
+                lastSyncError = when {
+                    bankedNothing && sustainedEmpty ->
+                        "Synced, but your strap had no stored history to hand over - only its diagnostic output. This usually means its clock has lost sync, so it isn't saving data to flash. Fully charge it to 100%, then reconnect, and it should start banking again."
+                    bankedNothing -> null   // banked nothing but not yet sustained — stay silent (matches Swift)
+                    // #324/#928: the strap banked records but its newest is dated implausibly in the future
+                    // (RTC relatched ahead). #773 drops the samples so nothing is misfiled, but this path
+                    // would otherwise report a clean sync and leave the user with no data + no reason.
+                    else -> futureClockBanner
+                },
                 historySyncExperimental = whoop5HistoryExperimental,
             )
             "timeout" -> it.copy(

--- a/android/app/src/main/java/com/noop/data/WhoopRepository.kt
+++ b/android/app/src/main/java/com/noop/data/WhoopRepository.kt
@@ -1,6 +1,7 @@
 package com.noop.data
 
 import android.content.Context
+import com.noop.protocol.DroppedRtcEvent
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
 import kotlin.math.roundToInt
@@ -39,6 +40,20 @@ data class StreamBatch(
      * visible in a shared log. Defaulted so every existing constructor/copy call site is unchanged.
      */
     val droppedImplausibleTs: Int = 0,
+    /**
+     * #324 diagnostic: the OLDEST / NEWEST own-timestamp (unix seconds, the strap's OWN dated value) among
+     * records dropped this batch for an implausible ts. Lets the Backfiller log the epoch SPAN of a bad-clock
+     * strap's poisoned range, so a whole-range-future strap can be told from one mixed with real data. Diag
+     * only (excluded from [isEmpty]); null when nothing dropped. Mirrors Swift `Streams.droppedImplausible*Ts`.
+     */
+    val droppedImplausibleOldestTs: Long? = null,
+    val droppedImplausibleNewestTs: Long? = null,
+    /**
+     * #324 diagnostic: strap RTC-STATE events (RTC_LOST / BOOT / SET_RTC) dropped for an implausible own-ts.
+     * The #547 gate discards them like any bad-ts record, but they are the GROUND TRUTH that the clock reset,
+     * so they are captured here for the strap log. Diag only; empty when none. Mirrors Swift `droppedRtcEvents`.
+     */
+    val droppedRtcEvents: List<DroppedRtcEvent> = emptyList(),
 ) {
     val isEmpty: Boolean
         get() = hr.isEmpty() && rr.isEmpty() && events.isEmpty() && battery.isEmpty() &&

--- a/android/app/src/main/java/com/noop/protocol/BadClockDiagnostics.kt
+++ b/android/app/src/main/java/com/noop/protocol/BadClockDiagnostics.kt
@@ -1,0 +1,50 @@
+package com.noop.protocol
+
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+import java.util.TimeZone
+
+/**
+ * #324 bad-clock strap diagnostics: pure formatters for the Backfiller's strap-log lines about a strap
+ * whose RTC reset to a wrong base (future- or far-past-dated banking). Kept in the protocol layer so the
+ * formatting mirrors the Swift `BadClockDiagnostics` byte-for-byte. No state, no `now` inside - callers
+ * inject `now` so the output is deterministic and unit-testable.
+ */
+object BadClockDiagnostics {
+
+    /**
+     * UTC `yyyy-MM-dd` for a unix-seconds timestamp - the human-readable day a dropped record CLAIMED,
+     * which on a bad-clock strap is the wrong base its RTC jumped to.
+     */
+    fun isoDay(unix: Long): String {
+        val f = SimpleDateFormat("yyyy-MM-dd", Locale.US)
+        f.timeZone = TimeZone.getTimeZone("UTC")
+        return f.format(Date(unix * 1000L))
+    }
+
+    /**
+     * Signed hour offset of [unix] from [now], worded for a log: "26445h ahead" / "512h behind" / "~now"
+     * (within an hour). The magnitude is what tells a future-clock strap (#928) from a stale-clock one.
+     */
+    fun hoursOffset(unix: Long, now: Long): String {
+        val h = (unix - now) / 3600
+        return when {
+            h > 0 -> "${h}h ahead"
+            h < 0 -> "${-h}h behind"
+            else -> "~now"
+        }
+    }
+
+    /**
+     * The parenthetical span clause appended to the dropped-record log: " (dated 2028-06-24 -> 2029-07-15,
+     * 26445h ahead)". Empty string when nothing was dropped (both null), so the base sentence reads normally.
+     * When oldest == newest a single date is shown. [now] words the offset of the NEWEST (frontier) record.
+     */
+    fun droppedSpanClause(oldest: Long?, newest: Long?, now: Long): String {
+        if (oldest == null || newest == null) return ""
+        val offset = hoursOffset(newest, now)
+        return if (oldest == newest) " (dated ${isoDay(newest)}, $offset)"
+        else " (dated ${isoDay(oldest)} -> ${isoDay(newest)}, $offset)"
+    }
+}

--- a/android/app/src/main/java/com/noop/protocol/HistoricalStreams.kt
+++ b/android/app/src/main/java/com/noop/protocol/HistoricalStreams.kt
@@ -512,6 +512,12 @@ fun extractHistoricalStreams(
     // Count of records dropped by the #547 plausibility gate this batch, surfaced on the returned
     // StreamBatch so the Backfiller can log "bad strap clock" once per session via its existing seam.
     var droppedImplausible = 0
+    // #324: oldest/newest own-timestamp among the dropped records (the poisoned-range epoch span), and the
+    // dropped RTC-state events (RTC_LOST / BOOT / SET_RTC) — the ground truth that the clock reset. Declared
+    // before correctedWall so the local function can capture them (Kotlin: no forward reference to locals).
+    var droppedOldest: Long? = null
+    var droppedNewest: Long? = null
+    val droppedRtcEvents = ArrayList<DroppedRtcEvent>()
 
     // The plausible-timestamp window for this batch (#547): the absolute floor [MIN_PLAUSIBLE_UNIX,
     // wallNow + FUTURE_MARGIN] PLUS, when the strap's GET_DATA_RANGE markers are known AND well-formed
@@ -565,6 +571,10 @@ fun extractHistoricalStreams(
         }
         if (!plausible(candidate)) {
             droppedImplausible++
+            // #324: track the epoch SPAN of the dropped (bad-clock) records — the strap's OWN dated value,
+            // so the Backfiller can log whether the whole poisoned range is future-dated or mixed.
+            droppedOldest = minOf(droppedOldest ?: candidate, candidate)
+            droppedNewest = maxOf(droppedNewest ?: candidate, candidate)
             return null
         }
         return candidate
@@ -677,10 +687,18 @@ fun extractHistoricalStreams(
                 // suppressed, so the offload extractor MUST handle these.
                 val parsed = Framing.parseFrame(frame, family)
                 if (!parsed.ok || parsed.crcOk == false) continue
-                // #547: correctedWall now nullable — an EVENT with an implausible event_timestamp is
-                // skipped via `?: continue` so a bad-clock wrist/charge/battery event can't enter the DB.
-                val ts = (parsed.parsed.intOrNull("event_timestamp")?.toLong())?.let { correctedWall(it) } ?: continue
+                val rawTs = parsed.parsed.intOrNull("event_timestamp")?.toLong() ?: continue
                 val kind = (parsed.parsed["event"] as? String) ?: ""
+                // #547: correctedWall now nullable — an EVENT with an implausible event_timestamp is
+                // skipped so a bad-clock wrist/charge/battery event can't enter the DB.
+                val ts = correctedWall(rawTs)
+                if (ts == null) {
+                    // #324: the #547 gate just dropped this event for an implausible ts. If it's an RTC-STATE
+                    // event (RTC_LOST / BOOT / SET_RTC), that IS the ground truth that the clock reset —
+                    // capture (kind, rawTs) for the strap log before discarding.
+                    if (DroppedRtcEvent.isRtcStateKind(kind)) droppedRtcEvents.add(DroppedRtcEvent(kind, rawTs))
+                    continue
+                }
                 if (kind.startsWith("BATTERY_LEVEL")) appendHistBattery(battery, ts, parsed.parsed)
                 val payload = LinkedHashMap(parsed.parsed)
                 payload.remove("event")
@@ -709,6 +727,9 @@ fun extractHistoricalStreams(
         sleepState = sleepState,
         ppgHr = ppgHr,
         droppedImplausibleTs = droppedImplausible,
+        droppedImplausibleOldestTs = droppedOldest,   // #324 poisoned-range epoch span (diag only)
+        droppedImplausibleNewestTs = droppedNewest,
+        droppedRtcEvents = droppedRtcEvents,
     )
 }
 

--- a/android/app/src/main/java/com/noop/protocol/Streams.kt
+++ b/android/app/src/main/java/com/noop/protocol/Streams.kt
@@ -154,6 +154,23 @@ fun skinTempCelsius(
 data class WhoopEvent(val ts: Int, val kind: String, val payload: Map<String, Any?>)
 
 /**
+ * #324 diagnostic record: a strap RTC-STATE event (RTC_LOST / BOOT / SET_RTC) that the #547 plausibility
+ * gate dropped for an implausible own-timestamp. [rawTs] is the event's OWN dated value (unix seconds) - on
+ * a future-dated strap this is the bad epoch the RTC jumped to, the single most useful signal for #324.
+ * Mirrors the Swift `DroppedRtcEvent`.
+ */
+data class DroppedRtcEvent(val kind: String, val rawTs: Long) {
+    companion object {
+        /**
+         * The RTC-state event kinds worth capturing when dropped. Kinds are formatted "NAME(n)" (e.g.
+         * "RTC_LOST(13)"), matched by prefix - "BOOT" covers both BOOT and BOOT_REPORT.
+         */
+        fun isRtcStateKind(kind: String): Boolean =
+            kind.startsWith("RTC_LOST") || kind.startsWith("SET_RTC") || kind.startsWith("BOOT")
+    }
+}
+
+/**
  * A battery reading. [ts] is event RTC for BATTERY_LEVEL events, else the wall-clock reference.
  * [charging] is a real Boolean only when the frame reported it (BATTERY_LEVEL events); `null`
  * otherwise (command responses).

--- a/android/app/src/test/java/com/noop/ble/EmptyBankingClassifierTest.kt
+++ b/android/app/src/test/java/com/noop/ble/EmptyBankingClassifierTest.kt
@@ -2,6 +2,7 @@ package com.noop.ble
 
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -74,6 +75,39 @@ class EmptyBankingClassifierTest {
         assertFalse(recordMetadataOnly())
         assertTrue("#214 + #126: three consecutive metadata-only completions trip the guidance",
             recordMetadataOnly())
+    }
+
+    // #324/#928 future-dated strap banner — Kotlin twin of the macOS futureDatedStrapBanner tests.
+
+    @Test
+    fun futureDatedNewestSurfacesBanner() {
+        val now = 1_783_843_824L                    // ~2026-07-12, the reporter's wall clock
+        val newest = now + 26_445L * 3600L          // 26445 h ahead — the #324 log's banked frontier
+        val banner = WhoopBleClient.futureDatedStrapBanner(newest, now)
+        assertNotNull(banner)
+        assertTrue(banner!!.contains("set in the future"))
+        assertTrue(banner.contains("power-cycle"))
+    }
+
+    @Test
+    fun currentStrapNoFutureBanner() {
+        val now = 1_783_843_824L
+        assertEquals(null, WhoopBleClient.futureDatedStrapBanner(now - 3600L, now))
+        assertEquals(null, WhoopBleClient.futureDatedStrapBanner(now, now))
+    }
+
+    @Test
+    fun withinSkewAllowanceNoFutureBanner() {
+        val now = 1_783_843_824L
+        assertEquals("24 h ahead is within the 48 h allowance — not flagged",
+            null, WhoopBleClient.futureDatedStrapBanner(now + 24L * 3600L, now))
+        assertTrue("just past 48 h is future-dated",
+            WhoopBleClient.futureDatedStrapBanner(now + 49L * 3600L, now) != null)
+    }
+
+    @Test
+    fun nilNewestNoFutureBanner() {
+        assertEquals(null, WhoopBleClient.futureDatedStrapBanner(null, 1_783_843_824L))
     }
 
     @Test

--- a/android/app/src/test/java/com/noop/protocol/BadClockDiagnosticsTest.kt
+++ b/android/app/src/test/java/com/noop/protocol/BadClockDiagnosticsTest.kt
@@ -1,0 +1,44 @@
+package com.noop.protocol
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * #324 — the pure strap-log formatters for a bad-clock strap. Deterministic (now is injected). MUST produce
+ * byte-identical strings to the Swift `BadClockDiagnostics` (BadClockDiagnosticsTests.swift) — same dates,
+ * same wording — so a shared strap log reads identically on both platforms.
+ */
+class BadClockDiagnosticsTest {
+
+    @Test fun isoDayIsUtc() {
+        // 1_735_084_800 == 2024-12-25 00:00 UTC (the #547 tests' documented badYule anchor).
+        assertEquals("2024-12-25", BadClockDiagnostics.isoDay(1_735_084_800L))
+    }
+
+    @Test fun hoursOffsetWording() {
+        val now = 1_783_843_824L
+        assertEquals("26445h ahead", BadClockDiagnostics.hoursOffset(now + 26_445L * 3600L, now))
+        assertEquals("512h behind", BadClockDiagnostics.hoursOffset(now - 512L * 3600L, now))
+        assertEquals("~now", BadClockDiagnostics.hoursOffset(now + 60L, now))   // within an hour
+    }
+
+    @Test fun droppedSpanClause() {
+        val now = 1_783_843_824L
+        // Nothing dropped → empty clause so the base sentence reads normally.
+        assertEquals("", BadClockDiagnostics.droppedSpanClause(null, null, now))
+        // A range → "oldest -> newest, offset(newest)". Built from the same pinned primitives (isoDay/
+        // hoursOffset covered above) so this pins the ASSEMBLY, not hand-computed dates.
+        val o = 1_845_000_000L
+        val n = 1_876_000_000L
+        val expected = " (dated ${BadClockDiagnostics.isoDay(o)} -> ${BadClockDiagnostics.isoDay(n)}, " +
+            "${BadClockDiagnostics.hoursOffset(n, now)})"
+        assertEquals(expected, BadClockDiagnostics.droppedSpanClause(o, n, now))
+        assertTrue(expected.contains("->"))
+        // oldest == newest → single date, no arrow.
+        val single = BadClockDiagnostics.droppedSpanClause(n, n, now)
+        assertFalse(single.contains("->"))
+        assertEquals(" (dated ${BadClockDiagnostics.isoDay(n)}, ${BadClockDiagnostics.hoursOffset(n, now)})", single)
+    }
+}

--- a/android/app/src/test/java/com/noop/protocol/HistoricalStreamsClockCorrectionTest.kt
+++ b/android/app/src/test/java/com/noop/protocol/HistoricalStreamsClockCorrectionTest.kt
@@ -185,4 +185,40 @@ class HistoricalStreamsClockCorrectionTest {
         assertEquals(realRecent, st.hr.first().ts)
         assertEquals(0, st.droppedImplausibleTs)
     }
+
+    // ── #324 bad-clock diagnostics: dropped-record epoch span ─────────────────────────────────────────
+    // The EVENT-frame RTC-state capture (RTC_LOST / BOOT / SET_RTC → droppedRtcEvents) is exercised by the
+    // Swift twin HistoricalTimestampGateTests (ParsedFrame fixtures); here we pin the HISTORICAL_DATA span
+    // capture + the pure kind gate, which don't need a synthetic EVENT byte frame.
+
+    @Test fun capturesDroppedEpochSpanForFutureDatedRecords() {
+        val now = 1_780_916_150L
+        val older = now + 100L * 86_400        // ~100 days ahead — future-dated, dropped
+        val newer = now + 300L * 86_400        // ~300 days ahead — future-dated, dropped
+        val st = extractHistoricalStreams(
+            listOf(wornV18WithUnix(newer), wornV18WithUnix(older)), 0, 0, DeviceFamily.WHOOP5, wallNow = now,
+        )
+        assertEquals(2, st.droppedImplausibleTs)
+        assertEquals(older, st.droppedImplausibleOldestTs)   // span brackets both, regardless of arrival order
+        assertEquals(newer, st.droppedImplausibleNewestTs)
+        assertTrue(st.droppedRtcEvents.isEmpty())
+    }
+
+    @Test fun noDropLeavesSpanNull() {
+        val st = extractHistoricalStreams(
+            listOf(wornV18WithUnix(1_780_916_150L)), 0, 0, DeviceFamily.WHOOP5, wallNow = 1_780_916_150L + 3_600,
+        )
+        assertEquals(null, st.droppedImplausibleOldestTs)
+        assertEquals(null, st.droppedImplausibleNewestTs)
+        assertTrue(st.droppedRtcEvents.isEmpty())
+    }
+
+    @Test fun rtcStateKindMatch() {
+        assertTrue(DroppedRtcEvent.isRtcStateKind("RTC_LOST(13)"))
+        assertTrue(DroppedRtcEvent.isRtcStateKind("SET_RTC(16)"))
+        assertTrue(DroppedRtcEvent.isRtcStateKind("BOOT(15)"))
+        assertTrue(DroppedRtcEvent.isRtcStateKind("BOOT_REPORT(30)"))
+        assertTrue(!DroppedRtcEvent.isRtcStateKind("WRIST_ON(9)"))
+        assertTrue(!DroppedRtcEvent.isRtcStateKind("BATTERY_LEVEL(3)"))
+    }
 }


### PR DESCRIPTION
Addresses #324 (WHOOP 4.0 whose RTC relatched to a future base: banked history dated years ahead, offload silently importing nothing). Two clearly-separated concerns, both on the shared cross-platform seam.

## Root cause
The reporter's strap live-clock correlates fine (~2026) but its flash-banked history spans 2028-2029 and its alarm reads back epoch 2052 — the RTC relatched to a future base. The existing `#928/#1012/#773` guards correctly REFUSE to misfile that data 3 years ahead. But two gaps made the failure illegible:

## 1. User-facing banner (the fix)
Because a future-dated strap DOES bank records, the existing "clock lost / not banking" banner (gated on empty syncs) never fired — so the sync reported clean (or the misleading "strap went quiet" on timeout) while importing nothing, with no reason shown.

- New pure `futureDatedStrapBanner` (Swift `BLEManager` + Kotlin `WhoopBleClient`, byte-identical string), driven by the existing `isFutureDatedNewest` predicate.
- Wired into BOTH the `HISTORY_COMPLETE` and the WHOOP-4 `timeout` outcomes (a deep future-dated backlog TIMES OUT as readily as it completes — the reporter's session ended on timeout).
- Names the strap-side remedy: full charge + power-cycle to relatch the clock.

## 2. Bad-clock diagnostics (dev logs, log-only)
No behavior change — the `#547` gate still drops exactly what it dropped before; these just make the cause legible in a strap-log export.

- **RTC-state events** (`RTC_LOST` / `BOOT` / `SET_RTC`) that the gate drops for their OWN implausible timestamp are now captured (`Streams.droppedRtcEvents`) before being discarded — the catch-22 fix, since the one event that explains the reset was silently dropped because ITS ts is bad. Logged with the bad epoch the RTC jumped to.
- **Dropped-record epoch span** (oldest -> newest own-timestamp + hours-ahead skew), so a future strap-log can tell a whole-range-future strap from one mixed with real data.
- Capture lives in pure `WhoopProtocol.extractHistoricalStreams`; formatting in a pure, byte-identical `BadClockDiagnostics` (Swift + Kotlin twins).

## Not in scope (deliberate)
- Does NOT recover the already-banked future-dated data (still correctly refused).
- Does NOT add a strap-side reset/history-clear (the BLE safety contract forbids destructive `TRIM_ALL_DATA`).
- A follow-up **fast-forward-discard** (drain the poisoned backlog quickly, informed by the new span log) is the next step, and is hardware-gated.

## Validation
- WhoopProtocol 271 `swift test` (+12 new: capture + formatter twins)
- Android `compileFullDebugKotlin` + `testFullDebugUnitTest` green
- app-build macOS `Strand` + iOS `NOOPiOS` green (the app-target `BLEManager`/`Backfiller` changes have no default CI)
- Banner + RTC-log strings verified byte-identical Swift<->Kotlin

BLE-path behavior (the banner firing on a real future-dated strap) is validated by the reporter on-strap; compile + the pure-predicate tests prove the wiring.