### PR TITLE
Oura 0x71 green IBI+amp: demote to Tier B (stop corrupting HRV) (#287)

### DIFF
--- a/Packages/OuraProtocol/Sources/OuraProtocol/EventTags.swift
+++ b/Packages/OuraProtocol/Sources/OuraProtocol/EventTags.swift
@@ -85,7 +85,14 @@ public enum OuraEventTag: UInt8, Sendable, CaseIterable, Codable {
         switch self {
         case .sleepSummary1, .sleepSummaryC, .sleepSummaryD, .sleepSummaryE,
              .sleepSummaryF, .activityInfo, .activitySummary1, .activitySummary2,
-             .realSteps1, .realSteps2, .spo2Smoothed:
+             .realSteps1, .realSteps2, .spo2Smoothed,
+             // #287: 0x71 green_ibi_and_amp is NOT corpus-verified — there is no captured 0x71 fixture,
+             // and OURA_PROTOCOL.md §6.2 documents a DIFFERENT layout (5 IBI deltas + 6 amplitudes,
+             // shift [2:0]) than the 0x60 decoder it was wired to (6 absolute IBIs, 4-bit shift). Decoding
+             // it with the 0x60 layout fabricates a 6th phantom R-R and reads deltas as absolute intervals,
+             // silently corrupting reconstructed HRV. Demote to Tier B so it is gated out of live emission
+             // until a real 0x71 capture lets us write + verify a dedicated decoder. (tierA == corpus-verified.)
+             .greenIbiAmp:
             return .tierB
         default:
             return .tierA

--- a/Packages/OuraProtocol/Sources/OuraProtocol/EventTags.swift
+++ b/Packages/OuraProtocol/Sources/OuraProtocol/EventTags.swift
@@ -26,7 +26,8 @@ public enum OuraEventTag: UInt8, Sendable, CaseIterable, Codable {
 
     // --- HR / IBI (Tier A) ---
     case ibiAmplitude     = 0x60   // ibi_and_amplitude_event (bit-packed), OURA_PROTOCOL.md s6.1
-    case greenIbiAmp      = 0x71   // green_ibi_and_amp_event, OURA_PROTOCOL.md s6.2
+    case greenIbiAmp      = 0x71   // green_ibi_and_amp_event, OURA_PROTOCOL.md s6.2 — Tier B (#287): §6.2
+                                   // layout (5 deltas+6 amps) != 0x60; unverified, gated. See `tier` below.
     case spo2IbiAmplitude = 0x6E   // spo2_ibi_and_amplitude_event (REVERSE byte order), OURA_PROTOCOL.md s6.3
     case greenIbiQuality  = 0x80   // green_ibi_quality_event (bit-packed across bytes), OURA_PROTOCOL.md s6.4
     case ibi              = 0x44   // ibi event (Tier-A IBI tag per the brief), OURA_PROTOCOL.md s6 / s0

--- a/Packages/OuraProtocol/Sources/OuraProtocol/OuraDriver.swift
+++ b/Packages/OuraProtocol/Sources/OuraProtocol/OuraDriver.swift
@@ -274,8 +274,6 @@ public final class OuraDriver {
         case .ibi:
             // The bare 0x44 IBI tag shares the bit-packed layout family; route through the same decoder.
             return (OuraDecoders.decodeIBIAmplitude(record) ?? []).map { OuraEvent.ibi($0) }
-        case .greenIbiAmp:
-            return (OuraDecoders.decodeIBIAmplitude(record) ?? []).map { OuraEvent.ibi($0) }
 
         // --- Tier A: HRV ---
         case .hrvRmssd:
@@ -354,6 +352,14 @@ public final class OuraDriver {
             return []
 
         // --- Tier B (only reached when allowTierB == true; otherwise dropped above) ---
+        case .greenIbiAmp:
+            // #287: 0x71 green_ibi_and_amp. Demoted from Tier A: the 0x60 decoder it used reads 6 ABSOLUTE
+            // IBIs, but §6.2 documents 0x71 as 5 IBI DELTAS + 6 amplitudes with a [2:0] shift, so that
+            // decode fabricated a phantom R-R and corrupted HRV. With no captured 0x71 fixture we cannot
+            // write a verified decoder yet, so emit the raw bytes for inspection (never folded into scoring)
+            // rather than a guessed IBI. Gated above unless allowTierB. Promote once a real 0x71 sample lands.
+            return [.tierB(OuraTierBSummary(tag: record.type, ringTimestamp: record.ringTimestamp,
+                                            rawPayload: record.payload, kind: "green_ibi_amp"))]
         case .sleepSummary1, .sleepSummaryC, .sleepSummaryD, .sleepSummaryE, .sleepSummaryF:
             return [.tierB(OuraTierBSummary(tag: record.type, ringTimestamp: record.ringTimestamp,
                                             rawPayload: record.payload, kind: "sleep_summary"))]

--- a/Packages/OuraProtocol/Tests/OuraProtocolTests/OuraDriverTests.swift
+++ b/Packages/OuraProtocol/Tests/OuraProtocolTests/OuraDriverTests.swift
@@ -313,6 +313,42 @@ final class OuraDriverTests: XCTestCase {
         }
     }
 
+    // MARK: - #287: 0x71 green_ibi_and_amp demoted to Tier B (was corrupting HRV via the 0x60 decoder)
+
+    func testGreenIBIAmp0x71TierIsB() {
+        // tierA == corpus-verified; there is no captured 0x71 fixture, and §6.2 documents a different
+        // layout than the 0x60 decoder it was wired to — so it must NOT be Tier A.
+        XCTAssertEqual(OuraEventTag.greenIbiAmp.tier, .tierB)
+    }
+
+    func testGreenIBIAmp0x71GatedOutOfLiveEmission() {
+        // The SAME body the 0x60 decoder turns into IBIs, but tagged 0x71. Under the old Tier-A routing a
+        // 0x71 record fed fabricated R-R into HRV; now it is Tier B, so by default it yields NOTHING.
+        let d = OuraDriver(ringGen: .gen3, authKey: key)   // allowTierB defaults to false
+        let rec = OuraFraming.parseRecord(bytes("7112020001007d10000000000000000000000007"))!
+        XCTAssertEqual(d.ingest(record: rec), [], "0x71 must not emit IBIs — it is not corpus-verified (#287)")
+        // Control: the same bytes ARE otherwise decodable by the 0x60 decoder, so the [] above is the tier
+        // gate, not a short/garbage body that would have dropped anyway.
+        XCTAssertNotNil(OuraDecoders.decodeIBIAmplitude(rec), "0x60 decoder still yields IBIs for these bytes")
+    }
+
+    func testGreenIBIAmp0x71EmitsRawSummaryNotIBIUnderAllowTierB() {
+        // With Tier B explicitly allowed it surfaces as RAW BYTES for inspection — never a guessed IBI, and
+        // OuraStreamMapping never folds a .tierB into scoring.
+        let d = OuraDriver(ringGen: .gen3, authKey: key, allowTierB: true)
+        let rec = OuraFraming.parseRecord(bytes("7112020001007d10000000000000000000000007"))!
+        let events = d.ingest(record: rec)
+        XCTAssertEqual(events.count, 1)
+        XCTAssertTrue(events[0].isTierB)
+        if case .tierB(let summary) = events[0] {
+            XCTAssertEqual(summary.tag, 0x71)
+            XCTAssertEqual(summary.kind, "green_ibi_amp")
+        } else {
+            XCTFail("expected a tierB raw-bytes summary, not a fabricated IBI")
+        }
+        for e in events { if case .ibi = e { XCTFail("0x71 must never emit .ibi (#287)") } }
+    }
+
     func testSleepPhase0x4BReclassifiedAsTierAHypnogram() {
         // 0x4B was previously a Tier-B "sleep summary" (dropped by default). It is actually a hypnogram
         // alias (open_oura `0x4b | 0x4e | 0x5a => decode_sleep_phases`), so it now decodes with the SAME

--- a/android/app/src/main/java/com/noop/oura/EventTags.kt
+++ b/android/app/src/main/java/com/noop/oura/EventTags.kt
@@ -87,7 +87,14 @@ enum class OuraEventTag(val raw: Int) {
         get() = when (this) {
             SLEEP_SUMMARY_1, SLEEP_SUMMARY_B, SLEEP_SUMMARY_C, SLEEP_SUMMARY_D, SLEEP_SUMMARY_E,
             SLEEP_SUMMARY_F, ACTIVITY_INFO, ACTIVITY_SUMMARY_1, ACTIVITY_SUMMARY_2,
-            REAL_STEPS_1, REAL_STEPS_2, SPO2_SMOOTHED -> TrustTier.TIER_B
+            REAL_STEPS_1, REAL_STEPS_2, SPO2_SMOOTHED,
+            // #287: 0x71 green_ibi_and_amp is NOT corpus-verified — no captured 0x71 fixture, and
+            // OURA_PROTOCOL.md §6.2 documents a DIFFERENT layout (5 IBI deltas + 6 amplitudes, shift
+            // [2:0]) than the 0x60 decoder it was wired to (6 absolute IBIs, 4-bit shift). Decoding it
+            // with the 0x60 layout fabricates a 6th phantom R-R and reads deltas as absolute intervals,
+            // silently corrupting reconstructed HRV. Demote to Tier B (gated out of live emission) until
+            // a real 0x71 capture lets us write + verify a dedicated decoder. (TIER_A == corpus-verified.)
+            GREEN_IBI_AMP -> TrustTier.TIER_B
             else -> TrustTier.TIER_A
         }
 

--- a/android/app/src/main/java/com/noop/oura/EventTags.kt
+++ b/android/app/src/main/java/com/noop/oura/EventTags.kt
@@ -31,7 +31,9 @@ enum class OuraEventTag(val raw: Int) {
 
     // --- HR / IBI (Tier A) ---
     IBI_AMPLITUDE(0x60),      // ibi_and_amplitude_event (bit-packed), OURA_PROTOCOL.md s6.1
-    GREEN_IBI_AMP(0x71),      // green_ibi_and_amp_event, OURA_PROTOCOL.md s6.2
+    // green_ibi_and_amp_event, OURA_PROTOCOL.md s6.2 — Tier B (#287): §6.2 layout (5 deltas+6 amps)
+    // != 0x60; unverified, gated out of live emission. See `tier` below.
+    GREEN_IBI_AMP(0x71),
     SPO2_IBI_AMPLITUDE(0x6E), // spo2_ibi_and_amplitude_event (REVERSE byte order), OURA_PROTOCOL.md s6.3
     GREEN_IBI_QUALITY(0x80),  // green_ibi_quality_event (bit-packed across bytes), OURA_PROTOCOL.md s6.4
     IBI(0x44),                // ibi event (Tier-A IBI tag per the brief), OURA_PROTOCOL.md s6 / s0

--- a/android/app/src/main/java/com/noop/oura/OuraDriver.kt
+++ b/android/app/src/main/java/com/noop/oura/OuraDriver.kt
@@ -364,8 +364,6 @@ class OuraDriver(
             OuraEventTag.IBI ->
                 // The bare 0x44 IBI tag shares the bit-packed layout family; route through the same decoder.
                 (OuraDecoders.decodeIBIAmplitude(record) ?: emptyList()).map { OuraEvent.Ibi(it) }
-            OuraEventTag.GREEN_IBI_AMP ->
-                (OuraDecoders.decodeIBIAmplitude(record) ?: emptyList()).map { OuraEvent.Ibi(it) }
 
             // --- Tier A: HRV ---
             OuraEventTag.HRV_RMSSD ->
@@ -432,6 +430,20 @@ class OuraDriver(
                 emptyList()
 
             // --- Tier B (only reached when allowTierB == true; otherwise dropped above) ---
+            OuraEventTag.GREEN_IBI_AMP ->
+                // #287: 0x71 green_ibi_and_amp. Demoted from Tier A: the 0x60 decoder it used reads 6
+                // ABSOLUTE IBIs, but §6.2 documents 0x71 as 5 IBI DELTAS + 6 amplitudes with a [2:0] shift,
+                // so that decode fabricated a phantom R-R and corrupted HRV. With no captured 0x71 fixture we
+                // cannot write a verified decoder yet, so emit the raw bytes for inspection (never folded into
+                // scoring) rather than a guessed IBI. Gated above unless allowTierB. Promote on a real sample.
+                listOf(
+                    OuraEvent.TierB(
+                        OuraTierBSummary(
+                            tag = record.type, ringTimestamp = record.ringTimestamp,
+                            rawPayload = record.payload, kind = "green_ibi_amp",
+                        ),
+                    ),
+                )
             OuraEventTag.SLEEP_SUMMARY_1, OuraEventTag.SLEEP_SUMMARY_B, OuraEventTag.SLEEP_SUMMARY_C,
             OuraEventTag.SLEEP_SUMMARY_D, OuraEventTag.SLEEP_SUMMARY_E, OuraEventTag.SLEEP_SUMMARY_F ->
                 listOf(

--- a/android/app/src/test/java/com/noop/oura/OuraDriverTest.kt
+++ b/android/app/src/test/java/com/noop/oura/OuraDriverTest.kt
@@ -369,6 +369,44 @@ class OuraDriverTest {
         assertArrayEquals(bytes("01020304"), ev.value.rawPayload)
     }
 
+    // MARK: - #287: 0x71 green_ibi_and_amp demoted to Tier B (twin of the Swift OuraDriverTests)
+
+    @Test
+    fun testGreenIBIAmp0x71TierIsB() {
+        // TIER_A == corpus-verified; no captured 0x71 fixture + §6.2 documents a different layout than the
+        // 0x60 decoder it was wired to, so it must NOT be Tier A.
+        assertEquals(TrustTier.TIER_B, OuraEventTag.GREEN_IBI_AMP.tier)
+    }
+
+    @Test
+    fun testGreenIBIAmp0x71GatedOutOfLiveEmission() {
+        // The SAME body the 0x60 decoder turns into IBIs, but tagged 0x71. Under the old Tier-A routing it
+        // fed fabricated R-R into HRV; now Tier B → by default it yields NOTHING.
+        val d = OuraDriver(ringGen = OuraRingGen.GEN3, authKey = key)   // allowTierB defaults to false
+        val rec = OuraFraming.parseRecord(bytes("7112020001007d10000000000000000000000007"))!!
+        assertEquals(
+            "0x71 must not emit IBIs - it is not corpus-verified (#287)",
+            emptyList<OuraEvent>(), d.ingest(rec),
+        )
+        // Control: the same bytes ARE otherwise decodable, so the [] above is the tier gate, not a short body.
+        assertNotNull("0x60 decoder still yields IBIs for these bytes", OuraDecoders.decodeIBIAmplitude(rec))
+    }
+
+    @Test
+    fun testGreenIBIAmp0x71EmitsRawSummaryNotIBIUnderAllowTierB() {
+        val d = OuraDriver(ringGen = OuraRingGen.GEN3, authKey = key, allowTierB = true)
+        val rec = OuraFraming.parseRecord(bytes("7112020001007d10000000000000000000000007"))!!
+        val events = d.ingest(rec)
+        assertEquals(1, events.size)
+        assertTrue(events[0].isTierB)
+        val ev = events[0]
+        assertTrue("expected a tierB raw-bytes summary, not a fabricated IBI", ev is OuraEvent.TierB)
+        ev as OuraEvent.TierB
+        assertEquals(0x71, ev.value.tag)
+        assertEquals("green_ibi_amp", ev.value.kind)
+        for (e in events) assertFalse("0x71 must never emit Ibi (#287)", e is OuraEvent.Ibi)
+    }
+
     // MARK: - Activity info (0x50, Tier B, third-party formula) - real Gen 3 captures (PR #960)
     //
     // PARITY: the six payloads below are byte-for-byte the real Gen 3 captures pinned in the Swift


### PR DESCRIPTION
Fixes the honest-data bug reported in #287 (thanks @tigercraft4 — confirmed on every point against the code + `OURA_PROTOCOL.md`).

## The bug
`OuraDriver.ingest()` routed EventTag **0x71** (`green_ibi_and_amp`) through `OuraDecoders.decodeIBIAmplitude` — the **0x60** decoder, which reads **6 absolute** IBIs interleaved with 7-bit amps and a 4-bit shift (§6.1). But §6.2 documents 0x71 as **5 IBI deltas + 6 amplitudes** with a **[2:0]** shift. Decoding a real 0x71 record with the 0x60 layout therefore:

1. emits a 6th **phantom** R-R fabricated from amplitude bits (only 5 IBIs exist);
2. treats **delta**-encoded values as **absolute** intervals;
3. applies a shift up to ~15 instead of the correct max 7.

NOOP reconstructs RMSSD/HRV from the IBI stream (§6.9), so those bogus intervals **silently corrupt HRV** — a reachable path: 0x71 was **Tier A** (ships live, ungated) and `OuraLiveSource` feeds decoded IBI to `setRRIntervals`.

**Root cause: mis-tiering.** `tierA` means "verified against the byte-for-byte corpus." There is **no captured 0x71 fixture** anywhere in the tree, so it was never actually verified.

## The fix (interim, no fixture required)
Reclassify `greenIbiAmp` / `GREEN_IBI_AMP` to **Tier B** and emit a **raw-bytes summary** (`kind=green_ibi_amp`) instead of running the wrong decoder:

- Gated out of live emission by default (`allowTierB == false` → `[]`), so no fabricated IBIs reach HRV.
- Even under `allowTierB`, it surfaces as raw bytes for inspection and is **never folded into scoring** (`OuraStreamMapping` ignores `.tierB` — verified both platforms).
- Byte-identical Swift (`OuraProtocol`) + Kotlin (`com.noop.oura`) — full parity twin.

The real fix — a dedicated `decodeGreenIBIAmp` (5 deltas + 6 amps, `[2:0]` shift, accumulate) promoted back to Tier A — waits for a **real captured 0x71 byte fixture**; guessing a binary decoder without ground truth risks making HRV worse, exactly as the reporter noted.

## On 0x44 (deliberately left alone)
The reporter flagged `0x44` (`.ibi`) as "same risk" — it uses the same decoder. It IS also unverified (no fixture). But unlike 0x71, the doc gives 0x44 **no distinct layout**, so there is no positive evidence of a *mismatch* (only absence of verification). Silently gating a possibly-working IBI path on absence-of-evidence is a different call than fixing a documented mismatch, so 0x44 is left as-is here and warrants its own fixture-gated decision.

## Validation
- `OuraProtocol` **108** `swift test` (+3 new: tier is B, gated to `[]` by default, raw summary — never `.ibi` — under `allowTierB`)
- Android `com.noop.oura.*` + `OuraStreamMapping` tests green
- Pure `OuraProtocol` package — Linux-testable, no hardware needed