### PR TITLE
Menu cleanup: dedupe duplicate surfaces, remove dead toggles, relocate debug controls

### DIFF
--- a/Strand/Screens/AutomationsView.swift
+++ b/Strand/Screens/AutomationsView.swift
@@ -233,11 +233,6 @@ struct AutomationsView: View {
                     stepperRow(label: String(localized: "Buzz strength"), help: String(localized: "How strong the buzz is."),
                                value: $inactivity.buzzLoops, suffix: "×", range: 1...4, step: 1)
                     rowDivider
-                    // Reuses the shared notification only-when-worn gate (notif.onlyWhenWorn).
-                    ToggleRow(label: String(localized: "Only when worn"),
-                              help: String(localized: "Don't buzz when the strap is off your wrist."),
-                              isOn: onlyWhenWornBinding)
-                    rowDivider
                     ToggleRow(label: String(localized: "Only during active hours"),
                               help: String(localized: "Only nudge during your active hours."),
                               isOn: $inactivity.activeHoursEnabled)
@@ -265,12 +260,6 @@ struct AutomationsView: View {
     /// warning so enabling the reminder while master is off isn't silently a no-op.
     private var notifMasterOn: Bool {
         UserDefaults.standard.object(forKey: "notif.masterEnabled") as? Bool ?? false
-    }
-    /// The reused only-when-worn gate (notif.onlyWhenWorn, default ON) — the SAME key the notifications
-    /// screen and the engine read, so the two screens stay in sync.
-    private var onlyWhenWornBinding: Binding<Bool> {
-        Binding(get: { UserDefaults.standard.object(forKey: "notif.onlyWhenWorn") as? Bool ?? true },
-                set: { UserDefaults.standard.set($0, forKey: "notif.onlyWhenWorn") })
     }
     private var activeStartBinding: Binding<Date> {
         Binding(get: { Self.date(fromMinutes: inactivity.activeStartMinutes) },

--- a/Strand/Screens/DataSourcesView.swift
+++ b/Strand/Screens/DataSourcesView.swift
@@ -781,12 +781,12 @@ struct DataSourcesView: View {
                         tone: hrBroadcaster.advertising ? .positive : .warning,
                         pulsing: !hrBroadcaster.advertising)
             : nil
-        return card(title: String(localized: "Broadcast heart rate"), icon: "dot.radiowaves.up.forward",
+        return card(title: String(localized: "Broadcast HR from this phone"), icon: "dot.radiowaves.up.forward",
              tint: DomainTheme.effort.color,
              status: status ?? StatePill("Off", tone: .neutral, showsDot: false),
              subtitle: String(localized: "Re-share your live strap heart rate over Bluetooth as a standard heart-rate sensor, so a gym treadmill, bike, Zwift, Peloton or any fitness app nearby can read it. Local Bluetooth only. Nothing leaves \(Platform.deviceNounPhrase). Off by default.")) {
             Toggle(isOn: $broadcastHrEnabled) {
-                Text("Broadcast heart rate")
+                Text("Broadcast HR from this phone")
                     .font(StrandFont.subhead)
                     .foregroundStyle(StrandPalette.textPrimary)
             }

--- a/Strand/Screens/SettingsView.swift
+++ b/Strand/Screens/SettingsView.swift
@@ -1330,7 +1330,7 @@ struct SettingsView: View {
 
                 // MARK: Broadcast HR — make the strap a standard BLE HR sensor (Garmin/Zwift/gym).
                 Toggle(isOn: $broadcastHrEnabled) {
-                    Text("Broadcast heart rate (Garmin/ANT)")
+                    Text("Broadcast strap HR (Garmin/ANT)")
                         .font(StrandFont.subhead)
                         .foregroundStyle(StrandPalette.textPrimary)
                 }

--- a/Strand/Screens/TestCentreView.swift
+++ b/Strand/Screens/TestCentreView.swift
@@ -31,15 +31,6 @@ struct TestCentreView: View {
     @State private var debugExportOn = ScheduledDebugExport.isEnabled
     @State private var debugExportMinutes = ScheduledDebugExport.timeMinutes
 
-    // Section 4: the experimental toggles, on the SAME @AppStorage keys as SettingsView (preserved per
-    // spec section 10), so toggling here and there is one and the same setting.
-    @AppStorage(PuffinExperiment.experimentalSleepV2Key) private var experimentalSleepV2Enabled = true
-    @AppStorage(PuffinExperiment.keepRealtimeForDataKey) private var continuousHrvEnabled = false
-    @AppStorage(PuffinExperiment.defaultsKey) private var puffinExperiments = false
-    @AppStorage(PuffinExperiment.deepDataKey) private var deepDataEnabled = false
-    @AppStorage(PuffinExperiment.broadcastHrKey) private var broadcastHrEnabled = false
-    @AppStorage(PuffinFrameRecorder.enabledKey) private var puffinCapture = false
-
     /// The strap model the user last picked, the same key SettingsView's showFiveMGControls gate reads.
     @AppStorage("selectedWhoopModel") private var selectedWhoopModelRaw = WhoopModel.whoop4.rawValue
 
@@ -61,7 +52,6 @@ struct TestCentreView: View {
                 domainModesCard.staggeredAppear(index: 0)
                 diagnosticToolsCard.staggeredAppear(index: 1)
                 exportCard.staggeredAppear(index: 2)
-                advancedCard.staggeredAppear(index: 3)
             }
         }
         .id(refreshToken)
@@ -222,68 +212,6 @@ struct TestCentreView: View {
                         .font(StrandFont.caption).foregroundStyle(StrandPalette.textTertiary)
                         .fixedSize(horizontal: false, vertical: true)
                 }
-            }
-        }
-    }
-
-    // MARK: - Section 4: Advanced / experimental
-
-    @ViewBuilder private var advancedCard: some View {
-        NoopCard {
-            VStack(alignment: .leading, spacing: NoopMetrics.space3) {
-                Text("ADVANCED")
-                    .font(StrandFont.overline).tracking(StrandFont.overlineTracking)
-                    .foregroundStyle(StrandPalette.textSecondary)
-
-                // Model-agnostic advanced toggles (shown on every strap), same @AppStorage keys as Settings.
-                Toggle(isOn: $experimentalSleepV2Enabled) {
-                    Text("Sleep staging (V2)")
-                        .font(StrandFont.subhead).foregroundStyle(StrandPalette.textPrimary)
-                }
-                .toggleStyle(.switch).tint(StrandPalette.accent)
-
-                Toggle(isOn: $continuousHrvEnabled) {
-                    Text("Continuous HRV capture")
-                        .font(StrandFont.subhead).foregroundStyle(StrandPalette.textPrimary)
-                }
-                .toggleStyle(.switch).tint(StrandPalette.accent)
-                .onChangeCompat(of: continuousHrvEnabled) { on in model.ble.setKeepRealtimeForData(on) }
-
-                // 5/MG-only probes, hidden off a 4.0 strap (the #22 gate, same as SettingsView).
-                if is5MG {
-                    Divider().overlay(StrandPalette.hairline)
-                    Text("WHOOP 5 / MG").font(StrandFont.overline).tracking(StrandFont.overlineTracking)
-                        .foregroundStyle(StrandPalette.textSecondary)
-
-                    Toggle(isOn: $puffinExperiments) {
-                        Text("Try WHOOP 5/MG protocol probes")
-                            .font(StrandFont.subhead).foregroundStyle(StrandPalette.textPrimary)
-                    }
-                    .toggleStyle(.switch).tint(StrandPalette.accent)
-
-                    Toggle(isOn: $deepDataEnabled) {
-                        Text("Unlock WHOOP 5/MG deep data (R22)")
-                            .font(StrandFont.subhead).foregroundStyle(StrandPalette.textPrimary)
-                    }
-                    .toggleStyle(.switch).tint(StrandPalette.accent)
-
-                    Toggle(isOn: $broadcastHrEnabled) {
-                        Text("Broadcast heart rate (Garmin/ANT)")
-                            .font(StrandFont.subhead).foregroundStyle(StrandPalette.textPrimary)
-                    }
-                    .toggleStyle(.switch).tint(StrandPalette.accent)
-                    .onChangeCompat(of: broadcastHrEnabled) { on in model.ble.setBroadcastHr(on) }
-
-                    Toggle(isOn: $puffinCapture) {
-                        Text("Record puffin frames to a file")
-                            .font(StrandFont.subhead).foregroundStyle(StrandPalette.textPrimary)
-                    }
-                    .toggleStyle(.switch).tint(StrandPalette.accent)
-                }
-
-                Text("These are experimental probes, off by default. The fuller WHOOP 5/MG controls and the raw-sensor CSV export still live in Settings under Diagnostics.")
-                    .font(StrandFont.caption).foregroundStyle(StrandPalette.textTertiary)
-                    .fixedSize(horizontal: false, vertical: true)
             }
         }
     }

--- a/android/app/src/main/java/com/noop/ui/AutomationsScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/AutomationsScreen.kt
@@ -97,7 +97,6 @@ fun AutomationsScreen(viewModel: AppViewModel) {
     var inactivityActiveHours by remember { mutableStateOf(InactivityPrefs.activeHoursEnabled(ctx)) }
     var inactivityActiveStart by remember { mutableStateOf(InactivityPrefs.activeStartMinutes(ctx)) }
     var inactivityActiveEnd by remember { mutableStateOf(InactivityPrefs.activeEndMinutes(ctx)) }
-    var inactivityOnlyWorn by remember { mutableStateOf(NotifPrefs.getBool(ctx, NotifPrefs.WORN, true)) }
     // The engine also requires the global notification master (default OFF); surface that dependency so
     // enabling the reminder while master is off isn't silently inert.
     val notifMasterOn = NotifPrefs.getBool(ctx, NotifPrefs.MASTER, false)
@@ -232,17 +231,6 @@ fun AutomationsScreen(viewModel: AppViewModel) {
                     onChange = {
                         inactivityBuzzLoops = it
                         InactivityPrefs.setInt(ctx, InactivityPrefs.BUZZ_LOOPS, it)
-                    },
-                )
-                RowDivider()
-                ToggleRow(
-                    label = "Only when worn",
-                    help = "Don't buzz when the strap is off your wrist.",
-                    checked = inactivityOnlyWorn,
-                    onChange = {
-                        inactivityOnlyWorn = it
-                        // Reuses the shared notification only-when-worn gate (NotifPrefs.WORN).
-                        NotifPrefs.setBool(ctx, NotifPrefs.WORN, it)
                     },
                 )
                 RowDivider()

--- a/android/app/src/main/java/com/noop/ui/AutomationsScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/AutomationsScreen.kt
@@ -57,8 +57,7 @@ import kotlin.math.roundToInt
 /**
  * Automations — turn the strap's physical inputs (double-tap, wrist on/off) and live
  * biometrics into on-device actions and haptic coaching. HR-zone coaching, the smart alarm
- * and the illness watch are real + persisted (ViewModel-backed); the remaining toggles
- * (stress nudge, auto-lock) are still local UI placeholders mirroring AutomationsView.swift.
+ * and the illness watch are real + persisted (ViewModel-backed).
  */
 @Composable
 fun AutomationsScreen(viewModel: AppViewModel) {
@@ -68,8 +67,6 @@ fun AutomationsScreen(viewModel: AppViewModel) {
     // dispatch runs in the ViewModel on a fresh strap DOUBLE_TAP event; this card just edits the choice.
     val doubleTapAction by viewModel.doubleTapAction.collectAsStateWithLifecycle()
 
-    var stressNudge by remember { mutableStateOf(false) }
-    var autoLockOnWristOff by remember { mutableStateOf(false) }
     // (#766) The strap firmware wake-alarm state used to be read here; it moved to SmartAlarmScreen with
     // the rest of the alarm UI.
     // Illness watch is real + persisted (opt-OUT — the watch has always run on Android).
@@ -157,7 +154,7 @@ fun AutomationsScreen(viewModel: AppViewModel) {
             icon = Icons.Filled.Bolt,
             title = "Haptic coaching",
             blurb = "Train by feel. The strap buzzes so you don't have to watch a screen.",
-            active = zoneCoaching || stressNudge,
+            active = zoneCoaching,
         ) {
             ToggleRow(
                 label = "HR-zone coaching",
@@ -174,30 +171,6 @@ fun AutomationsScreen(viewModel: AppViewModel) {
                     onChange = { viewModel.setZoneCoachRecovery(it) },
                 )
             }
-            RowDivider()
-            ToggleRow(
-                label = "Resting stress nudge (experimental)",
-                help = "A gentle buzz when your HRV drops while your heart rate is calm, a cue to take a paced breath. Rate-limited to once every 15 minutes; off by default.",
-                checked = stressNudge,
-                onChange = { stressNudge = it },
-            )
-        }
-        }
-
-        // Wear & presence.
-        item {
-        SettingsSection(
-            icon = Icons.Filled.TouchApp,
-            title = "Wear & presence",
-            blurb = "React when the strap comes off or goes on.",
-            active = autoLockOnWristOff,
-        ) {
-            ToggleRow(
-                label = "Lock the device when I take the strap off",
-                help = "Fires the moment the strap leaves your wrist.",
-                checked = autoLockOnWristOff,
-                onChange = { autoLockOnWristOff = it },
-            )
         }
         }
 

--- a/android/app/src/main/java/com/noop/ui/DataSourcesScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/DataSourcesScreen.kt
@@ -745,7 +745,7 @@ fun DataSourcesScreen(vm: AppViewModel) {
         // --- Broadcast heart rate (NOOP as a standard BLE HR peripheral) ---
         item {
         SourceCard(
-            title = "Broadcast heart rate",
+            title = "Broadcast HR from this phone",
             icon = Icons.Filled.MonitorHeart,
             tint = DomainTheme.Effort.color,
             subtitle = "Re-share your live strap heart rate over Bluetooth as a standard heart-rate " +
@@ -781,7 +781,7 @@ fun DataSourcesScreen(vm: AppViewModel) {
                 horizontalArrangement = Arrangement.spacedBy(16.dp),
             ) {
                 Column(modifier = Modifier.weight(1f)) {
-                    Text("Broadcast heart rate", style = NoopType.subhead, color = Palette.textPrimary)
+                    Text("Broadcast HR from this phone", style = NoopType.subhead, color = Palette.textPrimary)
                     Text(
                         "Acts as a standard Bluetooth heart-rate strap. Pair NOOP from your treadmill, " +
                             "bike or app to see your strap's heart rate there.",

--- a/android/app/src/main/java/com/noop/ui/DataSourcesScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/DataSourcesScreen.kt
@@ -158,49 +158,10 @@ fun DataSourcesScreen(vm: AppViewModel) {
         }
     }
 
-    // Whole-store backup: export to a user-created document; import from a picked one.
+    // Busy flag shared by every importer's Export/Import buttons.
     var busy by remember { mutableStateOf(false) }
-    var restartNeeded by remember { mutableStateOf(false) }
     // ah-delete (#616): drives the "Remove Apple Health imported data" confirm dialog.
     var confirmDeleteApple by remember { mutableStateOf(false) }
-
-    val exportLauncher = rememberLauncherForActivityResult(
-        ActivityResultContracts.CreateDocument("application/octet-stream"),
-    ) { uri ->
-        if (uri == null) return@rememberLauncherForActivityResult
-        busy = true
-        scope.launch {
-            val message = withContext(Dispatchers.IO) {
-                runCatching { DataBackup.exportTo(context, uri) }
-                    .fold({ "Backup saved." }, { "Backup failed: ${it.message}" })
-            }
-            busy = false
-            Toast.makeText(context, message, Toast.LENGTH_LONG).show()
-        }
-    }
-
-    val importLauncher = rememberLauncherForActivityResult(
-        ActivityResultContracts.OpenDocument(),
-    ) { uri ->
-        if (uri == null) return@rememberLauncherForActivityResult
-        busy = true
-        scope.launch {
-            val result = withContext(Dispatchers.IO) { DataBackup.importFrom(context, uri) }
-            busy = false
-            when (result) {
-                is DataBackup.ImportResult.NeedsRestart -> {
-                    restartNeeded = true
-                    Toast.makeText(
-                        context,
-                        "Imported. Fully close and reopen NOOP to load it.",
-                        Toast.LENGTH_LONG,
-                    ).show()
-                }
-                is DataBackup.ImportResult.Failed ->
-                    Toast.makeText(context, result.message, Toast.LENGTH_LONG).show()
-            }
-        }
-    }
 
     suspend fun refreshCounts() {
         val nowS = System.currentTimeMillis() / 1000
@@ -853,44 +814,6 @@ fun DataSourcesScreen(vm: AppViewModel) {
         }
         }
 
-        // --- Whole-store backup (the real Android migration path) ---
-        item {
-        SourceCard(
-            title = "Backup & Move",
-            icon = Icons.Filled.FileDownload,
-            subtitle = "Your whole history is one file on this phone. Export it to keep a copy " +
-                "or move to a new phone, then import it there. Nothing leaves the device " +
-                "except through the file you choose.",
-        ) {
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.spacedBy(10.dp),
-            ) {
-                BackupButton(
-                    label = "Export…",
-                    icon = Icons.Filled.FileDownload,
-                    enabled = !busy,
-                    modifier = Modifier.weight(1f),
-                ) { exportLauncher.launch("noop-backup-${java.time.LocalDate.now()}.noopbak") }
-                BackupButton(
-                    label = "Import…",
-                    icon = Icons.Filled.FileUpload,
-                    enabled = !busy,
-                    modifier = Modifier.weight(1f),
-                ) { importLauncher.launch(arrayOf("*/*")) }
-            }
-            if (busy) {
-                Text("Working…", style = NoopType.footnote, color = Palette.textTertiary)
-            }
-            if (restartNeeded) {
-                Text(
-                    "Import staged. Fully close and reopen NOOP to load the new data.",
-                    style = NoopType.subhead,
-                    color = Palette.statusWarning,
-                )
-            }
-        }
-        }
     }
 
     // ah-delete (#616): strongly-worded confirm before purging the "apple-health" source. On confirm,

--- a/android/app/src/main/java/com/noop/ui/SettingsScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/SettingsScreen.kt
@@ -469,9 +469,6 @@ fun SettingsScreen(
     // instead of 24/7. Default OFF so existing users keep the always-on behaviour. Local mirror.
     var continuousHrvOvernight by remember { mutableStateOf(NoopPrefs.continuousHrvOvernight(context)) }
 
-    // "Debug logging" — mirror the strap log to logcat (adb). Default OFF so normal users don't.
-    var debugLogging by remember { mutableStateOf(NoopPrefs.debugLogging(context)) }
-
     // --- v5 Health & wellness toggle group. All SharedPreferences-backed (not reactive), so each Switch
     // drives a local mirror that writes straight through to the same keys the v5 engine readers use.
     // Illness watch routes through the ViewModel so the banner recomputes live; the rest are pref writes
@@ -493,13 +490,6 @@ fun SettingsScreen(
     // Live Sessions (beta) — gates the Today "Start session" entry. Unlike its section-mates this is a
     // BETA feature flag, default ON (`live_sessions_beta`, see LiveSessionPrefs); off hides the entry.
     var liveSessionsBeta by remember { mutableStateOf(LiveSessionPrefs.enabled(context)) }
-
-    // Scheduled debug export (#510) — the daily auto-export toggle + time-of-day. The settings object is
-    // its own SharedPreferences store; SharedPreferences isn't reactive, so the Switch + TimeChip mirror
-    // into local state and write straight through, then (re)schedule via DebugExportScheduler.
-    val debugExportSettings = remember { DebugExportSettings.from(context) }
-    var debugExportEnabled by remember { mutableStateOf(debugExportSettings.enabled) }
-    var debugExportMinutes by remember { mutableStateOf(debugExportSettings.timeMinutes) }
 
     // Imperial/Metric display preference (D#103). Display-only — stored data stays SI. The system drives
     // the profile fields below (imperial entry) too, so it's local state the whole screen reads.
@@ -1386,46 +1376,6 @@ fun SettingsScreen(
                     color = Palette.textTertiary,
                 )
 
-                // Diagnostics: "Debug logging" mirrors the strap log to logcat (adb). Default OFF — a
-                // normal user never needs to write the connection log to the system log; the in-app log
-                // (and the "Share strap log" export below) work regardless. Developers flip this on to
-                // watch the connection live over `adb logcat -s WhoopBleClient`.
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    verticalAlignment = Alignment.CenterVertically,
-                    horizontalArrangement = Arrangement.spacedBy(16.dp),
-                ) {
-                    Column(modifier = Modifier.weight(1f)) {
-                        Text(
-                            "Debug logging",
-                            style = NoopType.subhead,
-                            color = Palette.textPrimary,
-                        )
-                        Text(
-                            "Also write the strap log to the system log (logcat) for development over adb. Off by default; the in-app log and “Share strap log” below work either way.",
-                            style = NoopType.footnote,
-                            color = Palette.textTertiary,
-                        )
-                    }
-                    Switch(
-                        checked = debugLogging,
-                        onCheckedChange = {
-                            debugLogging = it
-                            vm.setDebugLogging(it)
-                        },
-                        colors = SwitchDefaults.colors(
-                            checkedThumbColor = Palette.surfaceBase,
-                            checkedTrackColor = Palette.accent,
-                            uncheckedThumbColor = Palette.textSecondary,
-                            uncheckedTrackColor = Palette.surfaceInset,
-                            uncheckedBorderColor = Palette.hairline,
-                        ),
-                        modifier = Modifier.semantics {
-                            contentDescription = "Debug logging"
-                        },
-                    )
-                }
-
                 // Diagnostics: export the strap connection log so people can attach it to a bug report.
                 NoopButton(
                     text = "Share strap log (for bug reports)",
@@ -1780,105 +1730,6 @@ fun SettingsScreen(
                     "Feel the current time as a sequence of buzzes (#460). Does nothing unless your strap is connected.",
                     style = NoopType.caption,
                     color = Palette.textTertiary,
-                )
-            }
-        }
-
-        // --- Scheduled debug export (#510, maddognik) --- a daily, no-UI drop of the timestamped strap
-        // log (+ raw .bin when a 5/MG capture exists) into the app's export folder at a time you choose, so
-        // an intermittent overnight fault leaves a dated log waiting instead of needing a manual share. The
-        // feature core lives in DebugExportScheduler/DebugExportSettings; this is just the controls. OFF by
-        // default. SharedPreferences isn't reactive, so the Switch + time mirror into local state.
-        SettingsSection(
-            icon = Icons.Filled.Storage,
-            title = "Scheduled debug export (#510)",
-            blurb = "Once a day at a time you choose, NOOP writes a timestamped strap log (plus the raw 5/MG capture, if you have one) to its export folder. No sharing, nothing leaves the phone. Useful for chasing an intermittent overnight fault. Off by default.",
-        ) {
-            Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    verticalAlignment = Alignment.CenterVertically,
-                    horizontalArrangement = Arrangement.spacedBy(16.dp),
-                ) {
-                    Column(modifier = Modifier.weight(1f)) {
-                        Text(
-                            "Daily auto-export",
-                            style = NoopType.subhead,
-                            color = Palette.textPrimary,
-                        )
-                        Text(
-                            "Writes a timestamped strap log (and the raw .bin if a 5/MG capture exists) to the app's export folder once a day at the time below.",
-                            style = NoopType.footnote,
-                            color = Palette.textTertiary,
-                        )
-                    }
-                    Switch(
-                        checked = debugExportEnabled,
-                        onCheckedChange = {
-                            debugExportEnabled = it
-                            debugExportSettings.enabled = it
-                            DebugExportScheduler.reschedule(context)
-                        },
-                        colors = SwitchDefaults.colors(
-                            checkedThumbColor = Palette.surfaceBase,
-                            checkedTrackColor = Palette.accent,
-                            uncheckedThumbColor = Palette.textSecondary,
-                            uncheckedTrackColor = Palette.surfaceInset,
-                            uncheckedBorderColor = Palette.hairline,
-                        ),
-                        modifier = Modifier.semantics {
-                            contentDescription = "Daily auto-export"
-                        },
-                    )
-                }
-
-                if (debugExportEnabled) {
-                    Row(
-                        modifier = Modifier.fillMaxWidth(),
-                        verticalAlignment = Alignment.CenterVertically,
-                        horizontalArrangement = Arrangement.spacedBy(16.dp),
-                    ) {
-                        Column(modifier = Modifier.weight(1f)) {
-                            Text("Export time", style = NoopType.subhead, color = Palette.textPrimary)
-                            Text(
-                                "The daily export runs at this time.",
-                                style = NoopType.footnote,
-                                color = Palette.textTertiary,
-                            )
-                        }
-                        TimeChip(
-                            minutes = debugExportMinutes,
-                            accessibilityLabel = "Daily export time",
-                            onPicked = {
-                                debugExportMinutes = it
-                                debugExportSettings.timeMinutes = it
-                                DebugExportScheduler.applyTimeChange(context)
-                            },
-                        )
-                    }
-                }
-
-                // "Export now" writes the dated file immediately (off the main thread, like the CSV export
-                // above) and confirms with a Toast naming the folder, so the user sees the feature work
-                // without waiting for the scheduled run.
-                NoopButton(
-                    text = "Export now",
-                    leadingIcon = Icons.Filled.SaveAlt,
-                    kind = NoopButtonKind.Secondary,
-                    fullWidth = true,
-                    onClick = {
-                        scope.launch {
-                            val files = withContext(Dispatchers.IO) {
-                                LogExport.writeScheduledExport(context, vm.ble.exportLogText())
-                            }
-                            Toast.makeText(
-                                context,
-                                if (files.isNotEmpty()) "Wrote a dated debug export (${files.size} file${if (files.size == 1) "" else "s"}) to the app's export folder."
-                                else "Couldn't write the debug export.",
-                                Toast.LENGTH_LONG,
-                            ).show()
-                        }
-                    },
                 )
             }
         }

--- a/android/app/src/main/java/com/noop/ui/SettingsScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/SettingsScreen.kt
@@ -1539,7 +1539,7 @@ fun SettingsScreen(
                     horizontalArrangement = Arrangement.spacedBy(16.dp),
                 ) {
                     Text(
-                        "Broadcast heart rate (Garmin/ANT)",
+                        "Broadcast strap HR (Garmin/ANT)",
                         style = NoopType.subhead,
                         color = Palette.textPrimary,
                         modifier = Modifier.weight(1f),

--- a/android/app/src/main/java/com/noop/ui/TestCentreScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/TestCentreScreen.kt
@@ -335,14 +335,6 @@ private fun DiagnosticToolsCard(vm: AppViewModel) {
                 fullWidth = true,
                 onClick = { showRecalibrate = true },
             )
-            // Environment dump: the strap log already carries the AndroidDiagnostics header (spec 3.4).
-            NoopButton(
-                text = "Copy environment dump",
-                leadingIcon = Icons.Filled.Info,
-                kind = NoopButtonKind.Secondary,
-                fullWidth = true,
-                onClick = { scope.launch { LogExport.shareStrapLog(context, vm.ble.exportLogText()) } },
-            )
         }
     }
     if (showRecalibrate) {

--- a/android/app/src/main/java/com/noop/ui/TestCentreScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/TestCentreScreen.kt
@@ -162,9 +162,6 @@ fun TestCentreScreen(vm: AppViewModel) {
                 scope.launch { pendingReport = buildPending(context, MASTER_REPORT_MODE, vm.ble.exportLogText(), vm) }
             },
         )
-
-        // --- Section 4: Advanced / experimental ---
-        AdvancedCard(vm, is5MG)
     }
 
     pendingReport?.let { p ->
@@ -437,50 +434,6 @@ private fun ExportCard(vm: AppViewModel, onReport: () -> Unit) {
 }
 
 @Composable
-private fun AdvancedCard(vm: AppViewModel, is5MG: Boolean) {
-    val context = LocalContext.current
-    val puffin = remember { PuffinExperiment.from(context) }
-    var v2 by remember { mutableStateOf(puffin.experimentalSleepV2) }
-    // Re-hosted Continuous-HRV toggle, bound to the SAME NoopPrefs key (noop.continuousHrv) the Settings
-    // card uses, so flipping it here or there is one and the same setting (mirrors the iOS Test Centre).
-    var continuousHrv by remember { mutableStateOf(NoopPrefs.continuousHrv(context)) }
-    var probes by remember { mutableStateOf(puffin.isEnabled) }
-    var deepData by remember { mutableStateOf(puffin.isDeepDataEnabled) }
-    var broadcast by remember { mutableStateOf(puffin.broadcastHr) }
-    var capture by remember { mutableStateOf(puffin.isCaptureEnabled) }
-    SettingsSectionTC(
-        icon = Icons.Filled.Info,
-        title = "Advanced",
-        blurb = "Experimental probes, off by default. The fuller WHOOP 5/MG controls and the raw-sensor CSV export still live in Settings under Diagnostics.",
-    ) {
-        Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
-            ToggleRowTC("Experimental sleep staging (V2)", v2) {
-                v2 = it; puffin.experimentalSleepV2 = it
-            }
-            // Same write path as Settings: vm.setContinuousHrv persists noop.continuousHrv and re-applies
-            // keep-stream-for-data, so the live capture follows the toggle from either screen.
-            ToggleRowTC("Continuous HRV capture", continuousHrv) {
-                continuousHrv = it; vm.setContinuousHrv(it)
-            }
-            if (is5MG) {
-                ToggleRowTC("Try WHOOP 5/MG protocol probes", probes) {
-                    probes = it; puffin.isEnabled = it
-                }
-                ToggleRowTC("Unlock WHOOP 5/MG deep data (R22)", deepData) {
-                    deepData = it; puffin.isDeepDataEnabled = it
-                }
-                ToggleRowTC("Broadcast heart rate (Garmin/ANT)", broadcast) {
-                    broadcast = it; puffin.broadcastHr = it; vm.ble.setBroadcastHr(it)
-                }
-                ToggleRowTC("Record puffin frames to a file", capture) {
-                    capture = it; puffin.isCaptureEnabled = it
-                }
-            }
-        }
-    }
-}
-
-@Composable
 private fun ReportReviewDialog(
     previewText: String,
     modeInactive: Boolean,
@@ -557,18 +510,6 @@ private fun SettingsSectionTC(
             Text(blurb, style = NoopType.subhead, color = Palette.textSecondary)
             content()
         }
-    }
-}
-
-@Composable
-private fun ToggleRowTC(title: String, checked: Boolean, onCheckedChange: (Boolean) -> Unit) {
-    Row(
-        modifier = Modifier.fillMaxWidth(),
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.spacedBy(16.dp),
-    ) {
-        Text(title, style = NoopType.subhead, color = Palette.textPrimary, modifier = Modifier.weight(1f))
-        Switch(checked = checked, onCheckedChange = onCheckedChange, colors = settingsSwitchColors())
     }
 }
 

--- a/android/app/src/main/java/com/noop/ui/TestCentreScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/TestCentreScreen.kt
@@ -313,6 +313,8 @@ private fun DiagnosticToolsCard(vm: AppViewModel) {
     val context = LocalContext.current
     val scope = rememberCoroutineScope()
     var showRecalibrate by remember { mutableStateOf(false) }
+    // "Debug logging" moved here from Settings: dev-only, mirrors the strap log to logcat over adb.
+    var debugLogging by remember { mutableStateOf(NoopPrefs.debugLogging(context)) }
     SettingsSectionTC(
         icon = Icons.Filled.Info,
         title = "Diagnostic tools",
@@ -335,6 +337,27 @@ private fun DiagnosticToolsCard(vm: AppViewModel) {
                 fullWidth = true,
                 onClick = { showRecalibrate = true },
             )
+            // Debug logging (moved here from Settings): mirror the strap log to logcat for adb
+            // development. Dev-only, off by default; the in-app log and "Share strap log" above work either way.
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(16.dp),
+            ) {
+                Column(modifier = Modifier.weight(1f)) {
+                    Text("Debug logging", style = NoopType.subhead, color = Palette.textPrimary)
+                    Text(
+                        "Also write the strap log to the system log (logcat) for development over adb. Off by default.",
+                        style = NoopType.footnote,
+                        color = Palette.textTertiary,
+                    )
+                }
+                Switch(
+                    checked = debugLogging,
+                    onCheckedChange = { debugLogging = it; vm.setDebugLogging(it) },
+                    colors = settingsSwitchColors(),
+                )
+            }
         }
     }
     if (showRecalibrate) {


### PR DESCRIPTION
## What

Menu de-clutter across Settings, Test Centre, Automations, Notifications and Data Sources. Removes duplicate surfaces (the same storage key rendered in two places), deletes dead placeholder toggles, fixes a mislabeled action, disambiguates a colliding label, and relocates developer/diagnostic controls into the Test Centre. No real feature loses functionality; every removed control's function stays reachable at a single home. All 32 nav destinations remain reachable.

## Commits

1. **Drop the Test Centre "Advanced" mirror** — six toggles (Sleep V2, Continuous HRV, and the four 5/MG probes) were re-hosted in Test Centre on the SAME storage keys as Settings. The duplicate surface is removed; the toggles stay in Settings.
2. **Remove dead Automations placeholders + a mislabeled dup** (Android) — "Resting stress nudge" and "Lock the device when I take the strap off" were inert `remember { mutableStateOf(false) }` with no backing store; and Test Centre "Copy environment dump" invoked the exact same `shareStrapLog` as "Share strap log".
3. **Disambiguate the two "Broadcast heart rate" toggles** — same label, two different features. Renamed to "Broadcast strap HR (Garmin/ANT)" (the strap firmware advertises 0x180D, 5.0/MG) vs "Broadcast HR from this phone" (the phone re-advertises as a BLE HR peripheral, any WHOOP).
4. **Dedupe backup + worn-gate** (Android) — Data Sources "Backup & Move" duplicated Settings "Backup & restore" (same `DataBackup.exportTo/importFrom`); removed it and its now-orphaned launchers. Automations "Only when worn" wrote the same `notif.onlyWhenWorn` key as Notifications "Only buzz when worn"; removed the duplicate (Notifications is the single owner; the engine still reads the key).
5. **Move debug controls into Test Centre** (Android) — removed the Settings "Scheduled debug export" duplicate (Test Centre section 3 keeps it) and moved "Debug logging" (mirror the strap log to logcat over adb) from Settings into Test Centre. Developer-only.
6. **iOS parity: remove the duplicate "Only when worn" toggle** (`AutomationsView`).

## Verification

- **Android:** `:app:assembleFullDebug` green after every commit, and on this branch standalone.
- **iOS / macOS:** the Swift legs (commits 1, 3, 6) are **compile-unverified** (built on a machine with no Xcode; app-target Swift has no CI). They need a `Strand` + `NOOPiOS` build. Tracked in #335.

## Out of scope (tracked separately)

- One iOS-only duplicate is intentionally left out: `SettingsView`'s "Scheduled debug export" (twin of the Test Centre one) has scattered SwiftUI hooks and no CI, so it is safest finished with a Mac compile. See **#335**.
- The legacy iOS "Resting stress nudge" (wired, redundant with the v5 Stress check-in) is a separate cleanup at **#330**.