### PR TITLE
Instrument the WHOOP 4.0 sleep-onset decision (#271)

### DIFF
--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/AnalyticsEngine.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/AnalyticsEngine.swift
@@ -464,15 +464,16 @@ public enum AnalyticsEngine {
                                           hoursAsleepMin: tstS / 60.0,
                                           sourceRowId: String(mainStart)))
             // #271: the ONSET decision — did HR actually dip when the window opened, or did it open on a
-            // still-but-awake stretch (HR still ~baseline)? Baseline is the DAY median (dayHr when the caller
-            // supplies the full calendar day, else the night window) so a real onset reads BELOW it, matching
-            // the day-median the daytime/re-onset guards use; at-onset HR comes from the night-window `hr`,
-            // which reliably covers the onset instant. Emitted only when both have HR, so a motion-only night
-            // (no usable HR) stays silent rather than logging a 0-ratio.
+            // still-but-awake stretch (HR still ~baseline)? Both the day-median baseline AND the at-onset
+            // window read from the SAME HR that DETECTION ran over (`dayHr ?? hr` — the full calendar day
+            // when the caller supplies it, else the night window), so the onset instant is guaranteed to be
+            // inside it and the baseline reads as a real DAY median (a real onset sits BELOW it, matching the
+            // daytime/re-onset guards). Emitted only when both have HR, so a motion-only night stays silent.
+            let onsetHr = dayHr ?? hr
             if mainStart > 0,
-               let baselineHr = AnalyticsEngine.medianBpm((dayHr ?? hr).map { $0.bpm }),
+               let baselineHr = AnalyticsEngine.medianBpm(onsetHr.map { $0.bpm }),
                let hrAtOnset = AnalyticsEngine.medianBpm(
-                   hr.filter { $0.ts >= mainStart && $0.ts < mainStart + AnalyticsEngine.onsetTraceWindowSec }
+                   onsetHr.filter { $0.ts >= mainStart && $0.ts < mainStart + AnalyticsEngine.onsetTraceWindowSec }
                      .map { $0.bpm }) {
                 traceSink(AnalyticsEngine.sleepOnsetLine(onsetTs: mainStart,
                                                          hrAtOnsetBpm: hrAtOnset,

--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/AnalyticsEngine.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/AnalyticsEngine.swift
@@ -463,6 +463,21 @@ public enum AnalyticsEngine {
             traceSink(sleepProvenanceLine(provenance: sleepProvenance,
                                           hoursAsleepMin: tstS / 60.0,
                                           sourceRowId: String(mainStart)))
+            // #271: the ONSET decision — did HR actually dip when the window opened, or did it open on a
+            // still-but-awake stretch (HR still ~baseline)? Baseline is the DAY median (dayHr when the caller
+            // supplies the full calendar day, else the night window) so a real onset reads BELOW it, matching
+            // the day-median the daytime/re-onset guards use; at-onset HR comes from the night-window `hr`,
+            // which reliably covers the onset instant. Emitted only when both have HR, so a motion-only night
+            // (no usable HR) stays silent rather than logging a 0-ratio.
+            if mainStart > 0,
+               let baselineHr = AnalyticsEngine.medianBpm((dayHr ?? hr).map { $0.bpm }),
+               let hrAtOnset = AnalyticsEngine.medianBpm(
+                   hr.filter { $0.ts >= mainStart && $0.ts < mainStart + AnalyticsEngine.onsetTraceWindowSec }
+                     .map { $0.bpm }) {
+                traceSink(AnalyticsEngine.sleepOnsetLine(onsetTs: mainStart,
+                                                         hrAtOnsetBpm: hrAtOnset,
+                                                         baselineHrBpm: baselineHr))
+            }
         }
 
         // #525 NOTE: the sleep-DURATION figures above are main-night-only (the headline "your night"),

--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/RestSubScoreTrace.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/RestSubScoreTrace.swift
@@ -49,6 +49,33 @@ extension AnalyticsEngine {
         "sleep-motion day=\(day) grav=\(grav) hr=\(hr) sparse=\(sparse) "
             + "stager=\(useSleepStagerV2 ? "V2" : "V1") family=\(family.rawValue)"
     }
+
+    /// How long AFTER the detected onset to sample HR for the #271 onset trace (seconds). The first
+    /// several minutes of the window: if onset opened on a still-but-awake stretch, HR here is still near
+    /// baseline; a real onset has already dipped. 10 min is long enough to average out beat noise.
+    public static let onsetTraceWindowSec: Int = 600
+
+    /// Median of a bpm list — the deterministic "sorted, element at count/2" rule (upper-middle on an even
+    /// count) so Swift and Kotlin agree byte-for-byte. nil on an empty list. Used to build the #271 onset
+    /// trace's baseline + at-onset HR from the SAME rule on both platforms.
+    public static func medianBpm(_ bpms: [Int]) -> Int? {
+        if bpms.isEmpty { return nil }
+        let s = bpms.sorted()
+        return s[s.count / 2]
+    }
+
+    /// #271 diagnostic (Sleep & Rest test mode): the ONSET decision behind an over-early WHOOP 4.0 bedtime.
+    /// `onsetTs` is where the detected sleep window OPENED; `hrAtOnsetBpm` is the median HR in the first
+    /// `onsetTraceWindowSec` of it; `baselineHrBpm` is the day's median HR. `hrRatio` = atOnset / baseline:
+    /// near 1.0 means HR had NOT dipped when the window opened — the pre-onset-awake over-staging this issue
+    /// tracks (sparse 4.0 motion classifies "lying still, awake" as sleep); a real onset dips well below
+    /// baseline (cf. the wake-side `morningReonsetRestingHRMult` = 0.90). PURE; byte-identical to Android.
+    public static func sleepOnsetLine(onsetTs: Int, hrAtOnsetBpm: Int, baselineHrBpm: Int) -> String {
+        let ratio = baselineHrBpm > 0 ? Double(hrAtOnsetBpm) / Double(baselineHrBpm) : 0.0
+        let r2 = (ratio * 100.0).rounded() / 100.0
+        return "sleep-onset onsetTs=\(onsetTs) hrAtOnset=\(hrAtOnsetBpm) "
+            + "baselineHr=\(baselineHrBpm) hrRatio=\(r2)"
+    }
 }
 
 extension AnalyticsEngine.Rest {

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/RestSubScoreTraceTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/RestSubScoreTraceTests.swift
@@ -63,4 +63,30 @@ final class RestSubScoreTraceTests: XCTestCase {
                                             useSleepStagerV2: true, family: .whoop5),
             "sleep-motion day=2026-07-12 grav=800 hr=590 sparse=false stager=V2 family=whoop5")
     }
+
+    // MARK: - #271 onset trace (over-early WHOOP 4.0 bedtime)
+
+    func testMedianBpm() {
+        XCTAssertNil(AnalyticsEngine.medianBpm([]))
+        XCTAssertEqual(AnalyticsEngine.medianBpm([60]), 60)
+        XCTAssertEqual(AnalyticsEngine.medianBpm([50, 70, 60]), 60)        // sorted 50,60,70 → idx 1
+        XCTAssertEqual(AnalyticsEngine.medianBpm([50, 60, 70, 80]), 70)    // count 4 → idx 2 (upper-middle)
+    }
+
+    func testSleepOnsetLineHrNotDipped() {
+        // HR still near baseline at onset → ratio ~1.0 → suspected pre-onset-awake over-staging.
+        let line = AnalyticsEngine.sleepOnsetLine(onsetTs: 1_700_000_000, hrAtOnsetBpm: 58, baselineHrBpm: 60)
+        XCTAssertEqual(line, "sleep-onset onsetTs=1700000000 hrAtOnset=58 baselineHr=60 hrRatio=0.97")
+    }
+
+    func testSleepOnsetLineHrDipped() {
+        // A real onset: HR dipped well below baseline → ratio < 0.9 (cf. morningReonsetRestingHRMult).
+        let line = AnalyticsEngine.sleepOnsetLine(onsetTs: 1_700_000_000, hrAtOnsetBpm: 48, baselineHrBpm: 64)
+        XCTAssertTrue(line.contains("hrRatio=0.75"), line)
+    }
+
+    func testSleepOnsetLineZeroBaselineIsSafe() {
+        let line = AnalyticsEngine.sleepOnsetLine(onsetTs: 1, hrAtOnsetBpm: 50, baselineHrBpm: 0)
+        XCTAssertTrue(line.contains("hrRatio=0.0"), line)
+    }
 }

--- a/android/app/src/main/java/com/noop/analytics/AnalyticsEngine.kt
+++ b/android/app/src/main/java/com/noop/analytics/AnalyticsEngine.kt
@@ -446,15 +446,16 @@ object AnalyticsEngine {
             traceSink(RestScorer.sleepMotionLine(day, gravity.size, hr.size,
                 SleepStager.isGravitySparse(gravity, hr), useSleepStagerV2, skinTempFamily))
             // #271: the ONSET decision — did HR dip when the window opened, or did it open on a still-but-
-            // awake stretch (HR still ~baseline)? Baseline is the DAY median (dayHr when the caller supplies
-            // the full calendar day, else the night window) so a real onset reads BELOW it, matching the
-            // day-median the daytime/re-onset guards use; at-onset HR comes from the night-window `hr`, which
-            // reliably covers the onset instant. Emitted only when both have HR, so a motion-only night stays
-            // silent rather than logging a 0-ratio.
+            // awake stretch (HR still ~baseline)? Both the day-median baseline AND the at-onset window read
+            // from the SAME HR that DETECTION ran over (`dayHr ?: hr` — the full calendar day when the caller
+            // supplies it, else the night window), so the onset instant is guaranteed inside it and the
+            // baseline reads as a real DAY median (a real onset sits BELOW it, matching the daytime/re-onset
+            // guards). Emitted only when both have HR, so a motion-only night stays silent.
+            val onsetHr = dayHr ?: hr
             val onsetTs = (mainGroup.minOfOrNull { it.start } ?: matched.minOfOrNull { it.start }) ?: 0L
-            val baselineHr = RestScorer.medianBpm((dayHr ?: hr).map { it.bpm })
+            val baselineHr = RestScorer.medianBpm(onsetHr.map { it.bpm })
             val hrAtOnset = RestScorer.medianBpm(
-                hr.filter { it.ts >= onsetTs && it.ts < onsetTs + RestScorer.onsetTraceWindowSec }.map { it.bpm })
+                onsetHr.filter { it.ts >= onsetTs && it.ts < onsetTs + RestScorer.onsetTraceWindowSec }.map { it.bpm })
             if (onsetTs > 0 && baselineHr != null && hrAtOnset != null) {
                 traceSink(RestScorer.sleepOnsetLine(onsetTs, hrAtOnset, baselineHr))
             }

--- a/android/app/src/main/java/com/noop/analytics/AnalyticsEngine.kt
+++ b/android/app/src/main/java/com/noop/analytics/AnalyticsEngine.kt
@@ -445,6 +445,19 @@ object AnalyticsEngine {
             // epochs default to sleep → over-counted duration → high Rest; `stager` says whether V1/V2 ran.
             traceSink(RestScorer.sleepMotionLine(day, gravity.size, hr.size,
                 SleepStager.isGravitySparse(gravity, hr), useSleepStagerV2, skinTempFamily))
+            // #271: the ONSET decision — did HR dip when the window opened, or did it open on a still-but-
+            // awake stretch (HR still ~baseline)? Baseline is the DAY median (dayHr when the caller supplies
+            // the full calendar day, else the night window) so a real onset reads BELOW it, matching the
+            // day-median the daytime/re-onset guards use; at-onset HR comes from the night-window `hr`, which
+            // reliably covers the onset instant. Emitted only when both have HR, so a motion-only night stays
+            // silent rather than logging a 0-ratio.
+            val onsetTs = (mainGroup.minOfOrNull { it.start } ?: matched.minOfOrNull { it.start }) ?: 0L
+            val baselineHr = RestScorer.medianBpm((dayHr ?: hr).map { it.bpm })
+            val hrAtOnset = RestScorer.medianBpm(
+                hr.filter { it.ts >= onsetTs && it.ts < onsetTs + RestScorer.onsetTraceWindowSec }.map { it.bpm })
+            if (onsetTs > 0 && baselineHr != null && hrAtOnset != null) {
+                traceSink(RestScorer.sleepOnsetLine(onsetTs, hrAtOnset, baselineHr))
+            }
         }
 
         // ── Recovery / Charge ─────────────────────────────────────────────────
@@ -907,6 +920,38 @@ object RestScorer {
         day: String, grav: Int, hr: Int, sparse: Boolean, useSleepStagerV2: Boolean, family: DeviceFamily,
     ): String = "sleep-motion day=$day grav=$grav hr=$hr sparse=$sparse " +
         "stager=${if (useSleepStagerV2) "V2" else "V1"} family=${family.name.lowercase()}"
+
+    /**
+     * How long AFTER the detected onset to sample HR for the #271 onset trace (seconds). The first several
+     * minutes of the window: if onset opened on a still-but-awake stretch, HR here is still near baseline; a
+     * real onset has already dipped. 10 min is long enough to average out beat noise. Long for `ts` math.
+     */
+    const val onsetTraceWindowSec: Long = 600L
+
+    /**
+     * Median of a bpm list — the deterministic "sorted, element at size/2" rule (upper-middle on an even
+     * count) so Swift and Kotlin agree byte-for-byte. null on an empty list. Byte-identical to Swift
+     * `AnalyticsEngine.medianBpm`.
+     */
+    fun medianBpm(bpms: List<Int>): Int? {
+        if (bpms.isEmpty()) return null
+        val s = bpms.sorted()
+        return s[s.size / 2]
+    }
+
+    /**
+     * #271 diagnostic (Sleep & Rest test mode): the ONSET decision behind an over-early WHOOP 4.0 bedtime.
+     * `onsetTs` is where the detected window OPENED; `hrAtOnsetBpm` is the median HR in the first
+     * `onsetTraceWindowSec` of it; `baselineHrBpm` is the day's median HR. `hrRatio` = atOnset / baseline:
+     * near 1.0 means HR had NOT dipped when the window opened — the pre-onset-awake over-staging this tracks
+     * (sparse 4.0 motion classifies "lying still, awake" as sleep); a real onset dips well below baseline
+     * (cf. the wake-side `morningReonsetRestingHRMult` = 0.90). Byte-identical to Swift `sleepOnsetLine`.
+     */
+    fun sleepOnsetLine(onsetTs: Long, hrAtOnsetBpm: Int, baselineHrBpm: Int): String {
+        val ratio = if (baselineHrBpm > 0) hrAtOnsetBpm.toDouble() / baselineHrBpm.toDouble() else 0.0
+        val r2 = Math.round(ratio * 100.0) / 100.0
+        return "sleep-onset onsetTs=$onsetTs hrAtOnset=$hrAtOnsetBpm baselineHr=$baselineHrBpm hrRatio=$r2"
+    }
 
     fun subScoreLine(
         tstSeconds: Double, inBedSeconds: Double, efficiency: Double, restorativeSeconds: Double,

--- a/android/app/src/test/java/com/noop/analytics/SleepMotionLineTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/SleepMotionLineTest.kt
@@ -28,4 +28,35 @@ class SleepMotionLineTest {
                 day = "2026-07-12", grav = 800, hr = 590, sparse = false,
                 useSleepStagerV2 = true, family = DeviceFamily.WHOOP5))
     }
+
+    // #271 onset trace — byte-identical to the Swift RestSubScoreTraceTests.
+
+    @Test
+    fun `medianBpm sorted middle`() {
+        assertEquals(null, RestScorer.medianBpm(emptyList()))
+        assertEquals(60, RestScorer.medianBpm(listOf(60)))
+        assertEquals(60, RestScorer.medianBpm(listOf(50, 70, 60)))        // sorted 50,60,70 -> idx 1
+        assertEquals(70, RestScorer.medianBpm(listOf(50, 60, 70, 80)))    // count 4 -> idx 2 (upper-middle)
+    }
+
+    @Test
+    fun `onset line HR not dipped is suspected pre-onset-awake`() {
+        assertEquals(
+            "sleep-onset onsetTs=1700000000 hrAtOnset=58 baselineHr=60 hrRatio=0.97",
+            RestScorer.sleepOnsetLine(onsetTs = 1_700_000_000L, hrAtOnsetBpm = 58, baselineHrBpm = 60))
+    }
+
+    @Test
+    fun `onset line HR dipped is a real onset`() {
+        assertEquals(
+            "sleep-onset onsetTs=1700000000 hrAtOnset=48 baselineHr=64 hrRatio=0.75",
+            RestScorer.sleepOnsetLine(onsetTs = 1_700_000_000L, hrAtOnsetBpm = 48, baselineHrBpm = 64))
+    }
+
+    @Test
+    fun `onset line zero baseline is safe`() {
+        assertEquals(
+            "sleep-onset onsetTs=1 hrAtOnset=50 baselineHr=0 hrRatio=0.0",
+            RestScorer.sleepOnsetLine(onsetTs = 1L, hrAtOnsetBpm = 50, baselineHrBpm = 0))
+    }
 }


### PR DESCRIPTION
Instrument-first step for #271 (WHOOP 4.0 over-stages the low-motion pre-onset stretch → detected onset lands hours early). No tuning here — this makes the failure measurable from a strap-log so any future onset gate can be validated against real 4.0 raw.

## Why instrument, not tune
#271 is the **detection-side** of the same 4.0 sparse-motion root as #319/#327 (staging side): a still-but-awake pre-onset stretch classifies as sleep (Cole-Kripke `SI<1` on a no-motion epoch), so the window opens ~3 still epochs early. The codebase already hardens the **wake** edge — `isMorningReonset` requires HR to dip below `morningReonsetRestingHRMult` (0.90) × day-baseline plus band-state confirm — but the **onset** edge has no equivalent guard, and `isPreOnsetAwakeStub` (#736) is **display-only**, so the stored/scored window still opens early. Picking an onset threshold blind risks clipping genuine early sleep (the #319 lesson), so measure first.

## What this adds
A `sleep-onset` line on the existing #328 Sleep & Rest trace sink:

```
sleep-onset onsetTs=<unix> hrAtOnset=<bpm> baselineHr=<bpm> hrRatio=<atOnset/baseline>
```

- `onsetTs` — where the detected window opened (main-night group start).
- `hrAtOnset` — median HR in the first `onsetTraceWindowSec` (10 min) of the window.
- `baselineHr` — the **day** median (`dayHr` when the caller supplies the full calendar day, else the night window), matching the day-median the daytime/re-onset guards use.
- `hrRatio` — near/above 1.0 ⇒ HR had **not** dipped when the window opened (suspected pre-onset-awake over-staging); a real onset sits well below the day median.

The next over-early 4.0 strap-log then shows exactly how early onset fired and whether an HR-dip gate (say 0.90×, mirroring the wake side) would trim it **without** clipping — the #688/#328 instrument-then-tune pattern.

## Scope / safety
- **Trace-only** — gated on `traceSink`; the `DayResult` is byte-identical (no scoring/detection change). Production (no sink) never runs it.
- Pure `sleepOnsetLine` + `medianBpm` (deterministic sorted-middle), **byte-identical Swift/Kotlin**, pinned by twin tests.
- Emitted only when both a day baseline and an at-onset window have HR, so a motion-only 4.0 night stays silent rather than logging a 0-ratio.

## Validation
- Android `compileFullDebugKotlin` + `SleepMotionLineTest` (median + onset-line twins) green
- `sleepOnsetLine` / `medianBpm` strings pinned identical on both platforms
- StrandAnalytics (Swift) validated via `swift-packages` (GRDB-linked; no Linux build)