### PR TITLE
Respiratory rate: prefer PPG-derived estimate over RSA when available (#103)

### DIFF
--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/AnalyticsEngine.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/AnalyticsEngine.swift
@@ -280,13 +280,13 @@ public enum AnalyticsEngine {
                                   // Default empty keeps pure-function callers/tests + non-4.0 nights nil.
                                   spo2: [SpO2Sample] = [],
                                   // PPG-derived per-burst respiratory rate from the WHOOP 5.0 v26
-                                  // optical buffer (#103, `PpgResp.deriveRespRate`). Per matched sleep
-                                  // session, tried FIRST for `respRateDaily` below (more accurate per
-                                  // 2-night validation when it has enough burst coverage), falling back
-                                  // to the R-R/RSA estimate when it's empty/insufficient — v26 coverage
-                                  // is a sparse minority of any given night, so NaN here is the common
-                                  // case, not a bug. Default empty keeps pure-function callers/tests +
-                                  // WHOOP4/no-v26 nights on the existing RSA-only path unchanged.
+                                  // optical buffer (#103, `PpgResp.deriveRespRate`). NEVER overrides
+                                  // `respRateDaily` below (that always comes from R-R/RSA, so the
+                                  // illness-detection gate never sees an estimator switch) — when
+                                  // non-empty, it's only computed alongside RSA for a diagnostic
+                                  // comparison logged through `hrvTraceSink`. Default empty keeps
+                                  // pure-function callers/tests + WHOOP4/no-v26/opted-out nights
+                                  // identical (no comparison computed, nothing logged).
                                   ppgResp: [PpgRespSample] = [],
                                   profile: UserProfile,
                                   baselines: ProfileBaselines = ProfileBaselines(),
@@ -581,27 +581,29 @@ public enum AnalyticsEngine {
             hrvTraceSink("hrv nightSummary reported=\(reported) wholeNight=\(meanMs(withR)) deepOnly=\(meanMs(deepW)) lastSWS=\(meanMs(lastSws)) nWin=\(withR.count) nDeep=\(deepW.count)")
         }
 
-        // Nightly APPROXIMATE respiratory rate (breaths/min); NOT a cloud/clinical respiration value.
-        // Per matched in-bed session: PREFER the PPG-derived estimate (SleepStager.respRateFromPpg,
-        // #103, WHOOP5 v26 optical buffer) when it has enough burst coverage — landed within 2-6% of
-        // the WHOOP app's own reading on 2 real overnight captures, vs. the R-R/RSA estimate's 6-11%
-        // low bias on the SAME nights — else fall back to the R-R/RSA estimate (respRateFromRR,
-        // WHOOP5 v18-only, no raw resp ADC on this family). NOT a blend of the two: blending two
-        // estimates of different, uncharacterized accuracy risks being confidently wrong in a new way
-        // neither alone is (see #103 for the full honesty caveat — thin, 2-night, low-variance-subject
-        // evidence). The night's value = median of finite per-session estimates; nil only when no
-        // session yields one. Which estimator fired per session is traced through `hrvTraceSink` (the
-        // existing per-day diagnostic hook) when active, for future debugging/re-tuning.
+        // Nightly APPROXIMATE respiratory rate (breaths/min) from the R-R stream via RSA; NOT a
+        // cloud/clinical respiration value. This is the ONLY estimator that ever reaches
+        // `DailyMetric.respRateBpm` / the ReadinessEngine illness-detection gate — see #103 review:
+        // an earlier version of this preferred a PPG-derived estimate (SleepStager.respRateFromPpg,
+        // WHOOP5 v26 optical buffer) per session when available, but that let the persisted value
+        // silently switch estimator night to night. RSA and PPG read ~1-1.5 bpm apart even when both
+        // are "right," so for a stable sleeper (resp SD ~1 bpm) a night that merely SWITCHES which
+        // estimator fired injects a step large enough to brush the illness WATCH z-threshold — a false
+        // signal from the estimator flipping, not physiology. So the gate-facing value now always
+        // comes from one consistent estimator (RSA), full stop. The night's value = median of finite
+        // per-session RSA estimates; nil only when no session yields one.
+        //
+        // The PPG estimate is still computed for comparison (never stored, never gates anything) when
+        // `ppgResp` is non-empty — i.e. only when the caller's Experimental toggle supplied it — and
+        // logged alongside RSA through `hrvTraceSink` (the existing per-day diagnostic hook) when
+        // active, so opt-in nights keep generating the RSA-vs-PPG evidence #103 needs to eventually
+        // trust PPG on its own.
         let respRateDaily: Double? = {
             let perSession: [Double] = matched.compactMap { session in
-                let ppg = SleepStager.respRateFromPpg(ppgResp, start: session.start, end: session.end)
-                if ppg.isFinite {
-                    hrvTraceSink?("respRate session start=\(session.start) source=ppg value=\(ppg)")
-                    return ppg
-                }
                 let rsa = SleepStager.respRateFromRR(rr, start: session.start, end: session.end)
-                if rsa.isFinite {
-                    hrvTraceSink?("respRate session start=\(session.start) source=rsa value=\(rsa)")
+                if !ppgResp.isEmpty {
+                    let ppg = SleepStager.respRateFromPpg(ppgResp, start: session.start, end: session.end)
+                    hrvTraceSink?("respRate session start=\(session.start) rsa=\(rsa) ppg=\(ppg) used=rsa")
                 }
                 return rsa.isFinite ? rsa : nil
             }

--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/AnalyticsEngine.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/AnalyticsEngine.swift
@@ -279,6 +279,15 @@ public enum AnalyticsEngine {
                                   // calibrated blood-oxygen % (that needs WHOOP's proprietary curve).
                                   // Default empty keeps pure-function callers/tests + non-4.0 nights nil.
                                   spo2: [SpO2Sample] = [],
+                                  // PPG-derived per-burst respiratory rate from the WHOOP 5.0 v26
+                                  // optical buffer (#103, `PpgResp.deriveRespRate`). Per matched sleep
+                                  // session, tried FIRST for `respRateDaily` below (more accurate per
+                                  // 2-night validation when it has enough burst coverage), falling back
+                                  // to the R-R/RSA estimate when it's empty/insufficient — v26 coverage
+                                  // is a sparse minority of any given night, so NaN here is the common
+                                  // case, not a bug. Default empty keeps pure-function callers/tests +
+                                  // WHOOP4/no-v26 nights on the existing RSA-only path unchanged.
+                                  ppgResp: [PpgRespSample] = [],
                                   profile: UserProfile,
                                   baselines: ProfileBaselines = ProfileBaselines(),
                                   maxHROverride: Double? = nil,
@@ -572,15 +581,30 @@ public enum AnalyticsEngine {
             hrvTraceSink("hrv nightSummary reported=\(reported) wholeNight=\(meanMs(withR)) deepOnly=\(meanMs(deepW)) lastSWS=\(meanMs(lastSws)) nWin=\(withR.count) nDeep=\(deepW.count)")
         }
 
-        // Nightly APPROXIMATE respiratory rate (breaths/min) from the R-R stream via
-        // RSA. WHOOP5 v18 carries no raw resp ADC, so this is an on-device estimate,
-        // NOT a cloud/clinical respiration value. Per matched in-bed session, estimate
-        // over [start, end]; the night's value = median of finite per-session
-        // estimates; nil only when no session yields a finite estimate.
+        // Nightly APPROXIMATE respiratory rate (breaths/min); NOT a cloud/clinical respiration value.
+        // Per matched in-bed session: PREFER the PPG-derived estimate (SleepStager.respRateFromPpg,
+        // #103, WHOOP5 v26 optical buffer) when it has enough burst coverage — landed within 2-6% of
+        // the WHOOP app's own reading on 2 real overnight captures, vs. the R-R/RSA estimate's 6-11%
+        // low bias on the SAME nights — else fall back to the R-R/RSA estimate (respRateFromRR,
+        // WHOOP5 v18-only, no raw resp ADC on this family). NOT a blend of the two: blending two
+        // estimates of different, uncharacterized accuracy risks being confidently wrong in a new way
+        // neither alone is (see #103 for the full honesty caveat — thin, 2-night, low-variance-subject
+        // evidence). The night's value = median of finite per-session estimates; nil only when no
+        // session yields one. Which estimator fired per session is traced through `hrvTraceSink` (the
+        // existing per-day diagnostic hook) when active, for future debugging/re-tuning.
         let respRateDaily: Double? = {
-            let perSession = matched
-                .map { SleepStager.respRateFromRR(rr, start: $0.start, end: $0.end) }
-                .filter { $0.isFinite }
+            let perSession: [Double] = matched.compactMap { session in
+                let ppg = SleepStager.respRateFromPpg(ppgResp, start: session.start, end: session.end)
+                if ppg.isFinite {
+                    hrvTraceSink?("respRate session start=\(session.start) source=ppg value=\(ppg)")
+                    return ppg
+                }
+                let rsa = SleepStager.respRateFromRR(rr, start: session.start, end: session.end)
+                if rsa.isFinite {
+                    hrvTraceSink?("respRate session start=\(session.start) source=rsa value=\(rsa)")
+                }
+                return rsa.isFinite ? rsa : nil
+            }
             return perSession.isEmpty ? nil : HRVAnalyzer.median(perSession)
         }()
 

--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/ReadinessEngine.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/ReadinessEngine.swift
@@ -160,19 +160,17 @@ public enum ReadinessEngine {
         if let s = rhrSignal { signals.append(s) }
 
         // Respiratory-rate drift (illness early signal) ----------------------
-        // respRateBpm may be a clean cloud value, a higher-variance on-device RSA estimate, OR (#103) a
-        // PPG-derived estimate preferred over RSA per-session when available — so gate BOTH the latest
-        // value and the baseline mean to the plausible sleeping-RR band (8–25 bpm) and use wider
-        // resp-only z thresholds (WATCH 1.5 / BAD 2.0) than HRV/RHR so a single noisy night can't flip
-        // RUNDOWN. Mirrors the Kotlin reference (#78) for cross-platform parity. The WATCH/BAD
-        // thresholds were sized for RSA's noise floor specifically; #103's real-capture validation (n=2
-        // nights) suggests PPG is tighter, which would make these thresholds conservative on PPG-heavy
-        // nights — not retuned here for lack of data, but worth revisiting once the real-world PPG/RSA
-        // mix ratio is observable.
+        // respRateBpm may be a clean cloud value OR a higher-variance on-device RSA estimate, so gate
+        // BOTH the latest value and the baseline mean to the plausible sleeping-RR band (8–25 bpm) and
+        // use wider resp-only z thresholds (WATCH 1.5 / BAD 2.0) than HRV/RHR so a single noisy night
+        // can't flip RUNDOWN. Mirrors the Kotlin reference (#78) for cross-platform parity.
         //
-        // Bare `Double?`, no provenance — this is deliberate: value-plausibility + rolling-baseline
-        // z-score doesn't need to know WHICH estimator produced the number, and #103 confirmed this
-        // gate doesn't either.
+        // #103 explicitly does NOT reach here: an experimental PPG-derived respiratory-rate estimate
+        // exists (SleepStager.respRateFromPpg) but is deliberately never mixed into respRateBpm — a
+        // series that silently switches estimator night to night injects a ~1-1.5 bpm step that alone
+        // can brush the WATCH threshold for a stable sleeper, a false signal from the estimator
+        // flipping, not physiology. This gate only ever sees one consistent estimator (RSA), by
+        // construction, so it doesn't need — and must not be given — provenance.
         if let rr = latest.respRateBpm, SleepStager.respPlausibleRangeBpm.contains(rr) {
             let base = history.suffix(baselineWindow).compactMap { $0.respRateBpm }
             if base.count >= minBaseline, let m = mean(base),

--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/ReadinessEngine.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/ReadinessEngine.swift
@@ -160,10 +160,19 @@ public enum ReadinessEngine {
         if let s = rhrSignal { signals.append(s) }
 
         // Respiratory-rate drift (illness early signal) ----------------------
-        // respRateBpm may be a clean cloud value OR a higher-variance on-device RSA estimate, so gate
-        // BOTH the latest value and the baseline mean to the plausible sleeping-RR band (8–25 bpm) and
-        // use wider resp-only z thresholds (WATCH 1.5 / BAD 2.0) than HRV/RHR so a single noisy night
-        // can't flip RUNDOWN. Mirrors the Kotlin reference (#78) for cross-platform parity.
+        // respRateBpm may be a clean cloud value, a higher-variance on-device RSA estimate, OR (#103) a
+        // PPG-derived estimate preferred over RSA per-session when available — so gate BOTH the latest
+        // value and the baseline mean to the plausible sleeping-RR band (8–25 bpm) and use wider
+        // resp-only z thresholds (WATCH 1.5 / BAD 2.0) than HRV/RHR so a single noisy night can't flip
+        // RUNDOWN. Mirrors the Kotlin reference (#78) for cross-platform parity. The WATCH/BAD
+        // thresholds were sized for RSA's noise floor specifically; #103's real-capture validation (n=2
+        // nights) suggests PPG is tighter, which would make these thresholds conservative on PPG-heavy
+        // nights — not retuned here for lack of data, but worth revisiting once the real-world PPG/RSA
+        // mix ratio is observable.
+        //
+        // Bare `Double?`, no provenance — this is deliberate: value-plausibility + rolling-baseline
+        // z-score doesn't need to know WHICH estimator produced the number, and #103 confirmed this
+        // gate doesn't either.
         if let rr = latest.respRateBpm, SleepStager.respPlausibleRangeBpm.contains(rr) {
             let base = history.suffix(baselineWindow).compactMap { $0.respRateBpm }
             if base.count >= minBaseline, let m = mean(base),

--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/SleepStager.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/SleepStager.swift
@@ -1518,6 +1518,45 @@ public enum SleepStager {
         return respPlausibleRangeBpm.contains(median) ? median : nan
     }
 
+    // MARK: - Respiration rate from PPG (issue #103) — WHOOP5 v26 optical path
+
+    /// Minimum number of qualifying PPG bursts (see `PpgResp.deriveRespRate`) required in-session
+    /// before trusting a PPG-derived respiratory rate at all — below this, too few bursts for a stable
+    /// top-third-by-confidence median. Tied to observed burst density (~20-25 bursts across a full
+    /// ~7-8h night in the 2 validated real captures, not a theoretical minimum) — tunable, not sacred.
+    static let minPpgBurstsForEstimate = 9
+
+    /// APPROXIMATE respiratory rate (breaths/min) from the PPG-derived per-burst stream (issue #103,
+    /// `PpgResp.deriveRespRate`), for use ALONGSIDE `respRateFromRR` above — see `AnalyticsEngine`'s
+    /// prefer-PPG-else-RSA fusion, which tries this first per session and falls back to the RSA
+    /// estimate when this returns NaN.
+    ///
+    /// Validated (n=2 real overnight captures against the WHOOP app's own reading) to land within
+    /// 2-6%, vs. `respRateFromRR`'s 6-11% low bias on the SAME nights — but that is thin evidence (one
+    /// person, two nights, a person whose own respiratory rate barely moves night to night; see the
+    /// #103 discussion), so treat this as a real quality-filtered signal, not a settled ground truth.
+    /// v26 PPG coverage is a SPARSE minority of any given night (the strap alternates between v18 and
+    /// v26 recording, never both at once), so this returns NaN far more often than `respRateFromRR`
+    /// does — that is expected, not a bug; the fusion falls back to RSA in that case.
+    ///
+    /// Pipeline: filter samples to `[start, end]`; require >= `minPpgBurstsForEstimate` qualifying
+    /// bursts else NaN (honest no-data, mirrors `respRateFromRR`'s own too-little-data gate); take the
+    /// top third by `conf` (floor division — a burst's `conf` is the DSP estimator's own
+    /// spectral-prominence quality signal, not re-derived here); return the median of THEIR `bpm`, not
+    /// a blend of every burst, since a low-confidence burst is more likely motion/off-wrist artifact
+    /// than real respiratory signal.
+    static func respRateFromPpg(_ samples: [PpgRespSample], start: Int, end: Int) -> Double {
+        let nan = Double.nan
+        if end <= start { return nan }
+        let inWindow = samples.filter { $0.ts >= start && $0.ts <= end }
+        guard inWindow.count >= minPpgBurstsForEstimate else { return nan }
+        let topThird = inWindow.sorted { $0.conf > $1.conf }.prefix(max(1, inWindow.count / 3))
+        let median = HRVAnalyzer.median(topThird.map(\.bpm))
+        // Same canonical-band reject as respRateFromRR, so a fused value never silently disagrees
+        // with the illness/readiness plausibility gate regardless of which estimator produced it.
+        return respPlausibleRangeBpm.contains(median) ? median : nan
+    }
+
     // MARK: - Per-epoch features
 
     struct EpochFeatures {

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/AnalyticsEngineTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/AnalyticsEngineTests.swift
@@ -200,11 +200,13 @@ final class AnalyticsEngineTests: XCTestCase {
         XCTAssertGreaterThan(try XCTUnwrap(result.daily.skinTempDevC), 0.2)
     }
 
-    /// #103: when the PPG-derived stream has enough burst coverage, `respRateDaily` must reflect the
-    /// PPG value, NOT the RSA one — the two estimators are given fixtures that recover clearly
-    /// DIFFERENT rates (RSA's planted 15 bpm vs PPG's planted 12 bpm) so a silent fallback to RSA
-    /// would fail this test loudly rather than passing by coincidence.
-    func testAnalyzeDayPrefersPpgRespRateOverRsaWhenAvailable() throws {
+    /// #103 review: `respRateDaily`/`DailyMetric.respRateBpm` must ALWAYS reflect RSA, never the
+    /// PPG-derived estimate, even when PPG has ample high-confidence burst coverage — the two
+    /// estimators are given fixtures that recover clearly DIFFERENT rates (RSA's planted 15 bpm vs
+    /// PPG's planted 12 bpm) so an accidental override would fail this test loudly rather than
+    /// passing by coincidence. Feeding a series that silently switches estimator night to night into
+    /// the illness-detection gate is exactly the bug this pins against (see ReadinessEngine.swift).
+    func testAnalyzeDayRespRateAlwaysUsesRsaEvenWithAmplePpgData() throws {
         let day = "2021-06-21"
         let n = night(endDay: day, hours: 7)
         var rr: [RRInterval] = []
@@ -223,14 +225,13 @@ final class AnalyticsEngineTests: XCTestCase {
             day: day, hr: n.hr, rr: rr, gravity: n.gravity, ppgResp: ppgResp,
             profile: UserProfile(age: 30))
         XCTAssertEqual(result.sleepSessions.count, 1)
-        XCTAssertEqual(try XCTUnwrap(result.daily.respRateBpm), 12.0, accuracy: 0.5,
-                       "expected the PPG estimate (12 bpm) to be preferred over RSA's planted 15 bpm")
+        XCTAssertEqual(try XCTUnwrap(result.daily.respRateBpm), 15.0, accuracy: 3.0,
+                       "respRateBpm must stay RSA-only (~15 bpm) regardless of contradicting PPG data")
     }
 
-    /// #103: with too few PPG bursts to clear `SleepStager.minPpgBurstsForEstimate`, the fusion must
-    /// fall back to RSA exactly as before the feature existed — this is the expected COMMON case
-    /// (v26 PPG coverage is a sparse minority of any given night).
-    func testAnalyzeDayFallsBackToRsaWhenPpgCoverageIsInsufficient() throws {
+    /// The PPG-vs-RSA comparison trace fires only when `ppgResp` is supplied (the caller's toggle-
+    /// gated opt-in) and only through `hrvTraceSink` — never touching `respRateBpm`.
+    func testAnalyzeDayLogsPpgComparisonWithoutAffectingRespRateBpm() throws {
         let day = "2021-06-21"
         let n = night(endDay: day, hours: 7)
         var rr: [RRInterval] = []
@@ -240,15 +241,14 @@ final class AnalyticsEngineTests: XCTestCase {
             tSec += rrMs / 1000.0
             rr.append(RRInterval(ts: n.start + Int(tSec), rrMs: Int(rrMs)))
         }
-        // Only 3 PPG bursts (well below minPpgBurstsForEstimate) — must not override RSA.
-        let sparsePpgResp = (0..<3).map {
-            PpgRespSample(ts: n.start + $0 * 600, bpm: 12.0, conf: 20.0)
-        }
+        let ppgResp = (0..<12).map { PpgRespSample(ts: n.start + $0 * 600, bpm: 12.0, conf: 20.0) }
+        var traceLines: [String] = []
         let result = AnalyticsEngine.analyzeDay(
-            day: day, hr: n.hr, rr: rr, gravity: n.gravity, ppgResp: sparsePpgResp,
-            profile: UserProfile(age: 30))
-        XCTAssertEqual(try XCTUnwrap(result.daily.respRateBpm), 15.0, accuracy: 3.0,
-                       "expected fallback to the RSA estimate (~15 bpm) when PPG coverage is too sparse")
+            day: day, hr: n.hr, rr: rr, gravity: n.gravity, ppgResp: ppgResp,
+            profile: UserProfile(age: 30), hrvTraceSink: { traceLines.append($0) })
+        XCTAssertEqual(try XCTUnwrap(result.daily.respRateBpm), 15.0, accuracy: 3.0)
+        XCTAssertTrue(traceLines.contains { $0.hasPrefix("respRate session") && $0.contains("used=rsa") },
+                      "expected a respRate comparison line logging rsa/ppg/used, got: \(traceLines)")
     }
 
     /// End-to-end for the wake-time-edit feature (#318): the REAL stager detects a night and assigns it

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/AnalyticsEngineTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/AnalyticsEngineTests.swift
@@ -200,6 +200,57 @@ final class AnalyticsEngineTests: XCTestCase {
         XCTAssertGreaterThan(try XCTUnwrap(result.daily.skinTempDevC), 0.2)
     }
 
+    /// #103: when the PPG-derived stream has enough burst coverage, `respRateDaily` must reflect the
+    /// PPG value, NOT the RSA one — the two estimators are given fixtures that recover clearly
+    /// DIFFERENT rates (RSA's planted 15 bpm vs PPG's planted 12 bpm) so a silent fallback to RSA
+    /// would fail this test loudly rather than passing by coincidence.
+    func testAnalyzeDayPrefersPpgRespRateOverRsaWhenAvailable() throws {
+        let day = "2021-06-21"
+        let n = night(endDay: day, hours: 7)
+        var rr: [RRInterval] = []
+        var tSec = 0.0
+        while tSec < Double(n.end - n.start) {
+            let rrMs = 1200.0 + 40.0 * sin(2.0 * Double.pi * 0.25 * tSec)   // planted 15 bpm
+            tSec += rrMs / 1000.0
+            rr.append(RRInterval(ts: n.start + Int(tSec), rrMs: Int(rrMs)))
+        }
+        // 12 high-confidence PPG bursts (well above minPpgBurstsForEstimate) spread across the night,
+        // all agreeing on 12 bpm — clearly distinct from RSA's planted 15 bpm above.
+        let ppgResp = (0..<12).map {
+            PpgRespSample(ts: n.start + $0 * 600, bpm: 12.0, conf: 20.0)
+        }
+        let result = AnalyticsEngine.analyzeDay(
+            day: day, hr: n.hr, rr: rr, gravity: n.gravity, ppgResp: ppgResp,
+            profile: UserProfile(age: 30))
+        XCTAssertEqual(result.sleepSessions.count, 1)
+        XCTAssertEqual(try XCTUnwrap(result.daily.respRateBpm), 12.0, accuracy: 0.5,
+                       "expected the PPG estimate (12 bpm) to be preferred over RSA's planted 15 bpm")
+    }
+
+    /// #103: with too few PPG bursts to clear `SleepStager.minPpgBurstsForEstimate`, the fusion must
+    /// fall back to RSA exactly as before the feature existed — this is the expected COMMON case
+    /// (v26 PPG coverage is a sparse minority of any given night).
+    func testAnalyzeDayFallsBackToRsaWhenPpgCoverageIsInsufficient() throws {
+        let day = "2021-06-21"
+        let n = night(endDay: day, hours: 7)
+        var rr: [RRInterval] = []
+        var tSec = 0.0
+        while tSec < Double(n.end - n.start) {
+            let rrMs = 1200.0 + 40.0 * sin(2.0 * Double.pi * 0.25 * tSec)   // planted 15 bpm
+            tSec += rrMs / 1000.0
+            rr.append(RRInterval(ts: n.start + Int(tSec), rrMs: Int(rrMs)))
+        }
+        // Only 3 PPG bursts (well below minPpgBurstsForEstimate) — must not override RSA.
+        let sparsePpgResp = (0..<3).map {
+            PpgRespSample(ts: n.start + $0 * 600, bpm: 12.0, conf: 20.0)
+        }
+        let result = AnalyticsEngine.analyzeDay(
+            day: day, hr: n.hr, rr: rr, gravity: n.gravity, ppgResp: sparsePpgResp,
+            profile: UserProfile(age: 30))
+        XCTAssertEqual(try XCTUnwrap(result.daily.respRateBpm), 15.0, accuracy: 3.0,
+                       "expected fallback to the RSA estimate (~15 bpm) when PPG coverage is too sparse")
+    }
+
     /// End-to-end for the wake-time-edit feature (#318): the REAL stager detects a night and assigns it
     /// a startTs; a hand-correction keyed by THAT startTs must flow through `dailyAggregateHonoringEdits`
     /// and lower the day's total sleep. Proves the edit's key actually lines up with genuine stager

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/RespRateFromPpgTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/RespRateFromPpgTests.swift
@@ -1,0 +1,80 @@
+import XCTest
+@testable import StrandAnalytics
+import WhoopProtocol
+
+/// Tests `SleepStager.respRateFromPpg` (issue #103) — the top-third-by-confidence aggregation over the
+/// PPG-derived per-burst stream (`PpgResp.deriveRespRate`), used by `AnalyticsEngine`'s prefer-PPG-
+/// else-RSA fusion. Mirrors `RespRateRsaTests.swift`'s style: synthetic sample arrays, not captures.
+final class RespRateFromPpgTests: XCTestCase {
+    private let start = 1_700_000_000
+    private let end = 1_700_030_000
+
+    /// `n` bursts, evenly spaced across [start, end], with bpm/conf from parallel arrays.
+    private func samples(bpm: [Double], conf: [Double]) -> [PpgRespSample] {
+        precondition(bpm.count == conf.count)
+        let n = bpm.count
+        return (0..<n).map { i in
+            PpgRespSample(ts: start + i * ((end - start) / max(n, 1)), bpm: bpm[i], conf: conf[i])
+        }
+    }
+
+    func testRecoversMedianOfTopThirdByConfidence() {
+        // 9 bursts (minPpgBurstsForEstimate): the top 3 by conf are bpm 14/15/16 → median 15.
+        // The other 6 are noisy/low-confidence and must be ignored, not dragged into the result.
+        let bpm  = [14.0, 15.0, 16.0, 5.0, 30.0, 9.0, 25.0, 6.0, 28.0]
+        let conf = [10.0, 12.0, 11.0, 2.0, 1.5, 2.0, 1.5, 2.0, 1.5]
+        let est = SleepStager.respRateFromPpg(samples(bpm: bpm, conf: conf), start: start, end: end)
+        XCTAssertEqual(est, 15.0, accuracy: 0.001)
+    }
+
+    func testTooFewBurstsIsNaN() {
+        // minPpgBurstsForEstimate - 1 bursts, all otherwise well-formed → NaN, not a fabricated median.
+        let n = SleepStager.minPpgBurstsForEstimate - 1
+        let bpm = Array(repeating: 15.0, count: n)
+        let conf = Array(repeating: 10.0, count: n)
+        XCTAssertTrue(SleepStager.respRateFromPpg(samples(bpm: bpm, conf: conf), start: start, end: end).isNaN)
+        XCTAssertTrue(SleepStager.respRateFromPpg([], start: start, end: end).isNaN)
+    }
+
+    func testExactlyMinimumBurstsProducesAnEstimate() {
+        let n = SleepStager.minPpgBurstsForEstimate
+        let bpm = Array(repeating: 15.0, count: n)
+        let conf = Array(repeating: 10.0, count: n)
+        let est = SleepStager.respRateFromPpg(samples(bpm: bpm, conf: conf), start: start, end: end)
+        XCTAssertFalse(est.isNaN)
+    }
+
+    func testFiltersBurstsOutsideTheSessionWindow() {
+        // 9 in-window bursts at 15 bpm, plus 20 far-outside-window bursts at 99 bpm that must not
+        // count toward the minimum OR pollute the median.
+        var recs = samples(bpm: Array(repeating: 15.0, count: 9), conf: Array(repeating: 10.0, count: 9))
+        recs += (0..<20).map { PpgRespSample(ts: start - 100_000 - $0, bpm: 99.0, conf: 50.0) }
+        let est = SleepStager.respRateFromPpg(recs, start: start, end: end)
+        XCTAssertEqual(est, 15.0, accuracy: 0.001)
+    }
+
+    func testMedianOutsidePlausibleBandIsNaN() {
+        // 9 bursts all agreeing on an implausible 3 bpm (below the 8-25 band) — never surfaced.
+        let bpm = Array(repeating: 3.0, count: 9)
+        let conf = Array(repeating: 10.0, count: 9)
+        XCTAssertTrue(SleepStager.respRateFromPpg(samples(bpm: bpm, conf: conf), start: start, end: end).isNaN)
+    }
+
+    func testTopThirdRoundingIsFloorDivision() {
+        // 10 bursts → top third = max(1, 10/3) = 3 (floor division, not rounded/ceiled). The top 3 by
+        // conf are 14/15/16 (median 15); if rounding were ceil (4), bpm 5.0 (conf 9.0) would enter the
+        // top group and pull the median down to 14.5.
+        let bpm  = [14.0, 15.0, 16.0, 5.0, 30.0, 9.0, 25.0, 6.0, 28.0, 2.0]
+        let conf = [10.0, 12.0, 11.0, 9.0, 1.5, 2.0, 1.5, 2.0, 1.5, 1.0]
+        let est = SleepStager.respRateFromPpg(samples(bpm: bpm, conf: conf), start: start, end: end)
+        XCTAssertEqual(est, 15.0, accuracy: 0.001)
+    }
+
+    func testEndNotAfterStartIsNaN() {
+        let bpm = Array(repeating: 15.0, count: 9)
+        let conf = Array(repeating: 10.0, count: 9)
+        let recs = samples(bpm: bpm, conf: conf)
+        XCTAssertTrue(SleepStager.respRateFromPpg(recs, start: end, end: start).isNaN)
+        XCTAssertTrue(SleepStager.respRateFromPpg(recs, start: start, end: start).isNaN)
+    }
+}

--- a/Packages/WhoopProtocol/Sources/WhoopProtocol/HistoricalStreams.swift
+++ b/Packages/WhoopProtocol/Sources/WhoopProtocol/HistoricalStreams.swift
@@ -279,6 +279,9 @@ public func extractHistoricalStreams(_ parsed: [ParsedFrame],
     // Derive per-second HR from the collected v26 PPG bursts (issue #156). Empty when there were no v26
     // records (the WHOOP 4 / v18-only common case), so this is a no-op cost there.
     out.ppgHr = PpgHr.derivePpgHr(records: ppgRecords, subLagInterp: subLagInterp)
+    // Derive per-burst respiratory rate from the SAME v26 PPG bursts (issue #103) — no new buffering,
+    // reuses `ppgRecords`. Empty under the same conditions as `ppgHr` above.
+    out.ppgResp = PpgResp.deriveRespRate(records: ppgRecords)
     out.droppedImplausible = droppedImplausible   // #547 diag count (not persisted, not encoded)
     out.droppedImplausibleOldestTs = droppedOldest   // #324 poisoned-range epoch span (diag only)
     out.droppedImplausibleNewestTs = droppedNewest

--- a/Packages/WhoopProtocol/Sources/WhoopProtocol/PpgResp.swift
+++ b/Packages/WhoopProtocol/Sources/WhoopProtocol/PpgResp.swift
@@ -87,18 +87,32 @@ public enum PpgResp {
         return out
     }
 
-    /// Frequency step (Hz) for the band scan below — 0.004 Hz = 0.24 breaths/min resolution.
+    /// Frequency step (Hz) for the band scan below. Does NOT itself add resolution beyond a ~40 s
+    /// burst's native ~0.025 Hz (~1.5 breaths/min) DFT bin spacing (fs/n) — it only interpolates the
+    /// direct-sum DTFT more finely between those bins, avoiding the ~1.5 bpm quantization steps a
+    /// bin-quantized search would report. Matches the step used by the validated Python
+    /// proof-of-concept this ports.
     static let respFreqStepHz = 0.004
+
+    /// Reject a peak found within this many Hz of the band edge (`loHz`/`hiHz`) — a real breathing
+    /// peak is a local maximum with power falling off on both sides, but low-frequency drift
+    /// (perfusion/posture) that leaked past the high-pass detrend has power that only INCREASES
+    /// toward 0 Hz, so within a bounded search it deterministically "wins" at whichever edge is
+    /// closest to 0 Hz regardless of real physiology. Confirmed on real data (#103 review): without
+    /// this guard, 32%/15% of bursts across the two validation nights landed exactly at the band
+    /// floor (9 breaths/min) — far more than plausible slow breathing — and top-confidence-burst
+    /// aggregation was measurably CLOSER to the WHOOP app's ground truth with the guard than without
+    /// it (14.52 vs 14.04 breaths/min against a 14.6 truth). A rejected edge peak returns nil for that
+    /// channel (RIAV or RIIV), same honest-no-data handling as everywhere else in this estimator.
+    static let bandEdgeGuardHz = 0.02
 
     /// Direct-DFT power spectrum over `[loHz, hiHz]` on a DC-removed, uniformly-sampled (`fs` Hz)
     /// signal — the same hand-rolled, no-FFT-library technique `StrandAnalytics.SleepStagerV2
     /// .respRegularity` uses one layer up (ported here, not imported, since this package can't depend
     /// on StrandAnalytics), but scanned at a FIXED `respFreqStepHz` step rather than bin-quantized to
-    /// the burst's own length: a single ~40 s burst is only ~960 samples, so its native DFT bin spacing
-    /// (fs/n ≈ 1.5 breaths/min) is too coarse to report a meaningful rate. Evaluating the direct-sum
-    /// DTFT at a fixed step instead (independent of n) is still cheap — ~63 frequencies × n samples for
-    /// the full band — and matches the resolution of the validated Python proof-of-concept this ports.
-    /// Returns the peak's (frequencyHz, power/medianPower), or nil when the signal or band is degenerate.
+    /// the burst's own length (see that constant's doc for why). Returns the peak's
+    /// (frequencyHz, power/medianPower), or nil when the signal/band is degenerate or the peak falls
+    /// within `bandEdgeGuardHz` of an edge (see that constant's doc).
     static func bandPeak(_ x: [Double], fs: Double, loHz: Double, hiHz: Double) -> (hz: Double, prominence: Double)? {
         let n = x.count
         guard n > 1, hiHz > loHz else { return nil }
@@ -120,6 +134,7 @@ public enum PpgResp {
         guard let peak = powers.max(by: { $0.p < $1.p }) else { return nil }
         let median = powers.map(\.p).sorted()[powers.count / 2]
         guard median > 0 else { return nil }
+        guard peak.hz >= loHz + bandEdgeGuardHz, peak.hz <= hiHz - bandEdgeGuardHz else { return nil }
         return (hz: peak.hz, prominence: peak.p / median)
     }
 

--- a/Packages/WhoopProtocol/Sources/WhoopProtocol/PpgResp.swift
+++ b/Packages/WhoopProtocol/Sources/WhoopProtocol/PpgResp.swift
@@ -1,0 +1,187 @@
+import Foundation
+
+/// Respiratory rate derived from the WHOOP 5.0 type-47 **v26** optical PPG buffer (issue #103).
+///
+/// v26 records carry a single-wavelength 24 Hz PPG waveform (see `PpgHr.swift` for the per-second HR
+/// sibling estimator on the same buffer). Breathing modulates that waveform two ways — amplitude
+/// (RIAV, respiratory-induced amplitude variation) and baseline (RIIV, respiratory-induced intensity
+/// variation) — so a spectral peak in the respiratory band (0.15–0.40 Hz = 9–24 breaths/min) recovers
+/// the rate without needing a second wavelength (SpO2 is NOT derivable this way — confirmed no second
+/// channel exists on v26, see the #103 discussion).
+///
+/// v26 records arrive in ~40 s bursts: the strap alternates, over the course of a night, between v18
+/// per-second summaries and v26 raw-PPG stretches — never both at once — so v26 coverage is a sparse
+/// minority of any given night. One estimate is produced per consecutive-second run (a "burst"), not
+/// per second like `PpgHr`, since resolving 0.15 Hz needs the whole burst, not a sliding window.
+///
+/// Validated against 2 real overnight captures against the WHOOP app's own respiratory-rate reading:
+/// landed within 2–6% using top-confidence-burst aggregation (see `SleepStager.respRateFromPpg`), vs.
+/// the existing R-R/RSA-based estimator's 6–11% low bias on the same nights. That is thin evidence —
+/// one person, two nights, a person whose own night-to-night respiratory rate barely moves — so treat
+/// `conf` as a real per-burst quality filter, not a reason to trust any single burst in isolation. Also
+/// checked whether `conf` tracks time-of-night (stillness/sleep-stage could otherwise bias WHICH part
+/// of the night the top-confidence bursts sample from): the two nights showed a weak correlation of
+/// opposite sign (-0.22 / +0.22) — no consistent bias, but only 2 data points, so this is worth
+/// re-checking as more nights accumulate rather than treated as settled.
+///
+/// Pure + Foundation-only (mirrors `PpgHr.swift`) so it stays unit-testable and Linux-buildable.
+public struct PpgRespSample: Equatable, Codable, Sendable {
+    public let ts: Int          // wall-clock unix seconds of the burst's FIRST record
+    public let bpm: Double      // breaths/min — NOT rounded (unlike PpgHr's whole-bpm convention;
+                                 // resp-rate precision at ~14-15 bpm is the entire point here)
+    public let conf: Double     // spectral prominence (peak band-power / median band-power) behind
+                                 // `bpm` — >1 when the breathing peak stands out from the band's floor
+    public init(ts: Int, bpm: Double, conf: Double) {
+        self.ts = ts; self.bpm = bpm; self.conf = conf
+    }
+}
+
+public enum PpgResp {
+    public static let sampleRateHz = 24            // v26 carries 24 samples per 1-second record
+    /// Reject a run shorter than this many one-second records (~1.33 s short of a full ~40 s burst) —
+    /// too little data to resolve 0.15 Hz cleanly, so no fabricated estimate from a truncated burst.
+    public static let minBurstRecords = 32
+    public static let respLoHz = 0.15               // 9 breaths/min
+    public static let respHiHz = 0.40               // 24 breaths/min
+    /// ~1 s sliding window for the RIAV amplitude envelope.
+    public static let envelopeWindowSamples = 24
+    /// ~1 s causal moving-average window for the RIIV baseline.
+    public static let baselineWindowSamples = 24
+    /// ~12.5 s causal moving-average window subtracted for the high-pass detrend ahead of the
+    /// spectral search — removes sub-~0.08 Hz drift (perfusion/posture, not breathing).
+    public static let detrendWindowSamples = 300
+
+    /// Causal (trailing) moving average with window `w` samples; window shrinks at the start rather
+    /// than padding, so the first `w-1` outputs are a partial mean, not zero-biased.
+    static func movingAverage(_ x: [Double], window w: Int) -> [Double] {
+        guard w > 1, !x.isEmpty else { return x }
+        var out = [Double](repeating: 0, count: x.count)
+        var sum = 0.0
+        var win = [Double]()
+        win.reserveCapacity(w)
+        for (i, v) in x.enumerated() {
+            win.append(v); sum += v
+            if win.count > w { sum -= win.removeFirst() }
+            out[i] = sum / Double(win.count)
+        }
+        return out
+    }
+
+    /// High-pass detrend: subtract a `window`-sample causal moving average.
+    static func highPassDetrend(_ x: [Double], window: Int) -> [Double] {
+        let m = movingAverage(x, window: window)
+        return zip(x, m).map { $0 - $1 }
+    }
+
+    /// Sliding amplitude envelope (max−min) over a `±window/2`-sample neighbourhood — the RIAV signal.
+    static func amplitudeEnvelope(_ x: [Double], window: Int) -> [Double] {
+        guard !x.isEmpty else { return x }
+        let half = window / 2
+        var out = [Double](repeating: 0, count: x.count)
+        for i in x.indices {
+            let lo = max(0, i - half)
+            let hi = min(x.count, i + half)
+            let slice = x[lo..<hi]
+            out[i] = (slice.max() ?? 0) - (slice.min() ?? 0)
+        }
+        return out
+    }
+
+    /// Frequency step (Hz) for the band scan below — 0.004 Hz = 0.24 breaths/min resolution.
+    static let respFreqStepHz = 0.004
+
+    /// Direct-DFT power spectrum over `[loHz, hiHz]` on a DC-removed, uniformly-sampled (`fs` Hz)
+    /// signal — the same hand-rolled, no-FFT-library technique `StrandAnalytics.SleepStagerV2
+    /// .respRegularity` uses one layer up (ported here, not imported, since this package can't depend
+    /// on StrandAnalytics), but scanned at a FIXED `respFreqStepHz` step rather than bin-quantized to
+    /// the burst's own length: a single ~40 s burst is only ~960 samples, so its native DFT bin spacing
+    /// (fs/n ≈ 1.5 breaths/min) is too coarse to report a meaningful rate. Evaluating the direct-sum
+    /// DTFT at a fixed step instead (independent of n) is still cheap — ~63 frequencies × n samples for
+    /// the full band — and matches the resolution of the validated Python proof-of-concept this ports.
+    /// Returns the peak's (frequencyHz, power/medianPower), or nil when the signal or band is degenerate.
+    static func bandPeak(_ x: [Double], fs: Double, loHz: Double, hiHz: Double) -> (hz: Double, prominence: Double)? {
+        let n = x.count
+        guard n > 1, hiHz > loHz else { return nil }
+        let mean = x.reduce(0, +) / Double(n)
+        let centered = x.map { $0 - mean }
+        var powers = [(hz: Double, p: Double)]()
+        var f = loHz
+        while f <= hiHz {
+            let w = -2.0 * Double.pi * f / fs
+            var re = 0.0, im = 0.0
+            for j in 0..<n {
+                let a = w * Double(j)
+                re += centered[j] * cos(a)
+                im += centered[j] * sin(a)
+            }
+            powers.append((f, re * re + im * im))
+            f += respFreqStepHz
+        }
+        guard let peak = powers.max(by: { $0.p < $1.p }) else { return nil }
+        let median = powers.map(\.p).sorted()[powers.count / 2]
+        guard median > 0 else { return nil }
+        return (hz: peak.hz, prominence: peak.p / median)
+    }
+
+    /// Reject a burst whose best channel's peak isn't at least this many times the band's median power
+    /// — a flat/noisy burst must not fabricate a rate. Mirrors `PpgHr.minConfidence`'s role; the value
+    /// is set well below every real-capture burst observed so far (min ~2.0 across 57 real bursts from
+    /// 2 nights) while still rejecting a genuinely flat band (prominence 1.0 = no peak at all).
+    public static let minProminence = 1.5
+
+    /// Estimate (breaths/min, confidence) for one burst's raw samples via the higher-prominence of the
+    /// RIAV (amplitude envelope) / RIIV (baseline) spectral peak, or nil when the burst is too short,
+    /// neither channel clears the band, or the best peak doesn't clear `minProminence` (flat/garbage
+    /// PPG → no fabricated respiratory rate).
+    static func estimate(_ samples: [Int], fs: Int = sampleRateHz) -> (bpm: Double, conf: Double)? {
+        guard samples.count >= minBurstRecords * fs else { return nil }
+        let x = samples.map(Double.init)
+        let riav = highPassDetrend(amplitudeEnvelope(x, window: envelopeWindowSamples),
+                                    window: detrendWindowSamples)
+        let riiv = highPassDetrend(movingAverage(x, window: baselineWindowSamples),
+                                    window: detrendWindowSamples)
+        let fsD = Double(fs)
+        let a = bandPeak(riav, fs: fsD, loHz: respLoHz, hiHz: respHiHz)
+        let b = bandPeak(riiv, fs: fsD, loHz: respLoHz, hiHz: respHiHz)
+        let best: (hz: Double, prominence: Double)?
+        switch (a, b) {
+        case let (a?, b?): best = a.prominence >= b.prominence ? a : b
+        case let (a?, nil): best = a
+        case let (nil, b?): best = b
+        case (nil, nil): best = nil
+        }
+        guard let picked = best, picked.prominence >= minProminence else { return nil }
+        return (bpm: picked.hz * 60, conf: picked.prominence)
+    }
+
+    /// One respiratory-rate estimate per ~40 s v26 burst (a consecutive-second run of records) — NOT
+    /// per-second like `PpgHr.derivePpgHr`, since resolving 0.15 Hz needs the whole burst. `ts` on the
+    /// returned sample is the run's FIRST record timestamp. Records may be unsorted / contain gaps.
+    public static func deriveRespRate(records: [(ts: Int, samples: [Int])],
+                                      fs: Int = sampleRateHz) -> [PpgRespSample] {
+        guard !records.isEmpty else { return [] }
+        // One waveform per second (last write wins on a duplicate ts).
+        var secs = [Int: [Int]]()
+        for r in records { secs[r.ts] = r.samples }
+        let order = secs.keys.sorted()
+        // Split into consecutive-second runs.
+        var runs = [[Int]]()
+        var cur = [order[0]]
+        for u in order.dropFirst() {
+            if u - cur.last! == 1 { cur.append(u) }
+            else { runs.append(cur); cur = [u] }
+        }
+        runs.append(cur)
+
+        var out = [PpgRespSample]()
+        for run in runs where run.count >= minBurstRecords {
+            var sig = [Int]()
+            for t in run { sig.append(contentsOf: secs[t]!) }
+            if let est = estimate(sig, fs: fs) {
+                out.append(PpgRespSample(ts: run[0], bpm: est.bpm, conf: est.conf))
+            }
+        }
+        out.sort { $0.ts < $1.ts }
+        return out
+    }
+}

--- a/Packages/WhoopProtocol/Sources/WhoopProtocol/Streams.swift
+++ b/Packages/WhoopProtocol/Sources/WhoopProtocol/Streams.swift
@@ -235,6 +235,10 @@ public struct Streams: Equatable, Codable {
     /// samples `ppgHr` is derived FROM. Kept separate so a consumer that only wants the HR estimate
     /// never pays for the 24x-larger raw stream, and so the two can be persisted/pruned independently.
     public var ppgWaveform: [PpgWaveformSample]
+    /// PPG-derived per-burst (~40s) respiratory rate from the same v26 optical buffer (issue #103).
+    /// One sample per burst, not per second — see `PpgResp` for why. Kept separate from `resp` (the
+    /// strap's own, WHOOP4-only, resp_rate_raw stream) — the two never overlap on a given device.
+    public var ppgResp: [PpgRespSample]
     public var events: [WhoopEvent]
     public var battery: [BatterySample]
     /// #547 diagnostic: how many historical records `extractHistoricalStreams` DROPPED this chunk for an
@@ -258,11 +262,12 @@ public struct Streams: Equatable, Codable {
                 resp: [RespSample] = [], gravity: [GravitySample] = [],
                 steps: [StepSample] = [], sleepState: [SleepStateSample] = [],
                 ppgHr: [PpgHrSample] = [], ppgWaveform: [PpgWaveformSample] = [],
+                ppgResp: [PpgRespSample] = [],
                 events: [WhoopEvent] = [], battery: [BatterySample] = []) {
         self.hr = hr; self.rr = rr
         self.spo2 = spo2; self.skinTemp = skinTemp; self.resp = resp; self.gravity = gravity
         self.steps = steps; self.sleepState = sleepState; self.ppgHr = ppgHr
-        self.ppgWaveform = ppgWaveform
+        self.ppgWaveform = ppgWaveform; self.ppgResp = ppgResp
         self.events = events; self.battery = battery
     }
 
@@ -272,7 +277,7 @@ public struct Streams: Equatable, Codable {
     public var isEmpty: Bool {
         hr.isEmpty && rr.isEmpty && spo2.isEmpty && skinTemp.isEmpty && resp.isEmpty
             && gravity.isEmpty && steps.isEmpty && sleepState.isEmpty && ppgHr.isEmpty
-            && ppgWaveform.isEmpty && events.isEmpty && battery.isEmpty
+            && ppgWaveform.isEmpty && ppgResp.isEmpty && events.isEmpty && battery.isEmpty
     }
 
     private enum CodingKeys: String, CodingKey {
@@ -280,6 +285,7 @@ public struct Streams: Equatable, Codable {
         case sleepState = "sleep_state"
         case ppgHr = "ppg_hr"
         case ppgWaveform = "ppg_waveform"
+        case ppgResp = "ppg_resp"
         case events, battery
     }
 
@@ -297,6 +303,7 @@ public struct Streams: Equatable, Codable {
         sleepState = try c.decodeIfPresent([SleepStateSample].self, forKey: .sleepState) ?? []
         ppgHr = try c.decodeIfPresent([PpgHrSample].self, forKey: .ppgHr) ?? []
         ppgWaveform = try c.decodeIfPresent([PpgWaveformSample].self, forKey: .ppgWaveform) ?? []
+        ppgResp = try c.decodeIfPresent([PpgRespSample].self, forKey: .ppgResp) ?? []
         events = try c.decodeIfPresent([WhoopEvent].self, forKey: .events) ?? []
         battery = try c.decodeIfPresent([BatterySample].self, forKey: .battery) ?? []
     }

--- a/Packages/WhoopProtocol/Tests/WhoopProtocolTests/PpgRespTests.swift
+++ b/Packages/WhoopProtocol/Tests/WhoopProtocolTests/PpgRespTests.swift
@@ -42,11 +42,21 @@ final class PpgRespTests: XCTestCase {
     }
 
     func testEstimateRecoversASlowBreathingRate() throws {
-        // Near the low end of the band (10 breaths/min = 0.1667 Hz) — must not fold to the high end.
-        let records = breathingBurst(breathBpm: 10)
+        // Near the low end of the band (11 breaths/min = 0.1833 Hz, clear of the bandEdgeGuardHz
+        // margin around the 9 breaths/min floor) — must not fold to the high end.
+        let records = breathingBurst(breathBpm: 11)
         let sig = records.flatMap { $0.samples }
         let est = try XCTUnwrap(PpgResp.estimate(sig))
-        XCTAssertEqual(est.bpm, 10, accuracy: 1.0)
+        XCTAssertEqual(est.bpm, 11, accuracy: 1.0)
+    }
+
+    func testEstimateRecoversAFastBreathingRate() throws {
+        // Near the high end of the band (19 breaths/min = 0.3167 Hz) — exercises the upper half of
+        // the 0.15-0.40 Hz search, not just the low/mid values the other tests cover.
+        let records = breathingBurst(breathBpm: 19)
+        let sig = records.flatMap { $0.samples }
+        let est = try XCTUnwrap(PpgResp.estimate(sig))
+        XCTAssertEqual(est.bpm, 19, accuracy: 1.0)
     }
 
     func testDeriveRespRateOneSamplePerBurst() {

--- a/Packages/WhoopProtocol/Tests/WhoopProtocolTests/PpgRespTests.swift
+++ b/Packages/WhoopProtocol/Tests/WhoopProtocolTests/PpgRespTests.swift
@@ -1,0 +1,115 @@
+import XCTest
+@testable import WhoopProtocol
+
+/// PPG-derived respiratory rate from the WHOOP 5.0 v26 optical buffer (issue #103).
+///
+/// The estimator is a band-limited spectral peak search (0.15-0.40 Hz) on the RIAV (amplitude
+/// envelope) / RIIV (baseline) channels of a ~40 s burst. These tests drive it with SYNTHETIC bursts
+/// (a carrier pulse amplitude- and baseline-modulated at a known breathing rate → that rate recovered;
+/// a flat/noisy burst → no fabricated estimate) so they are deterministic and need no capture fixtures,
+/// mirroring `PpgHrTests.swift`'s style for the sibling per-second HR estimator on the same buffer.
+final class PpgRespTests: XCTestCase {
+    private let fs = PpgResp.sampleRateHz   // 24
+
+    /// One synthetic burst: a ~1 Hz pulse carrier whose AMPLITUDE and BASELINE are both modulated at
+    /// `breathBpm` breaths/min — RIAV picks up the amplitude modulation, RIIV the baseline shift, so
+    /// either channel alone is enough to recover the planted rate.
+    private func breathingBurst(breathBpm: Double, seconds: Int = 40, base: Int = 1_780_000_000,
+                                pulseHz: Double = 1.1, carrierAmp: Double = 1000, modDepth: Double = 400,
+                                baselineAmp: Double = 300) -> [(ts: Int, samples: [Int])] {
+        let breathHz = breathBpm / 60.0
+        var samples = [Int]()
+        samples.reserveCapacity(seconds * fs)
+        for n in 0..<(seconds * fs) {
+            let t = Double(n) / Double(fs)
+            let breath = sin(2 * Double.pi * breathHz * t)
+            let amplitude = carrierAmp + modDepth * breath
+            let pulse = amplitude * sin(2 * Double.pi * pulseHz * t)
+            let baseline = baselineAmp * breath
+            samples.append(Int(pulse + baseline))
+        }
+        return (0..<seconds).map { s in
+            (ts: base + s, samples: Array(samples[(s * fs)..<((s + 1) * fs)]))
+        }
+    }
+
+    func testEstimateRecoversKnownBreathingRate() throws {
+        let records = breathingBurst(breathBpm: 15)
+        let sig = records.flatMap { $0.samples }
+        let est = try XCTUnwrap(PpgResp.estimate(sig))
+        XCTAssertEqual(est.bpm, 15, accuracy: 1.0)
+        XCTAssertGreaterThanOrEqual(est.conf, PpgResp.minProminence)
+    }
+
+    func testEstimateRecoversASlowBreathingRate() throws {
+        // Near the low end of the band (10 breaths/min = 0.1667 Hz) — must not fold to the high end.
+        let records = breathingBurst(breathBpm: 10)
+        let sig = records.flatMap { $0.samples }
+        let est = try XCTUnwrap(PpgResp.estimate(sig))
+        XCTAssertEqual(est.bpm, 10, accuracy: 1.0)
+    }
+
+    func testDeriveRespRateOneSamplePerBurst() {
+        let series = PpgResp.deriveRespRate(records: breathingBurst(breathBpm: 15))
+        XCTAssertEqual(series.count, 1, "one ~40s burst must yield exactly one estimate, not per-second")
+        let s = try! XCTUnwrap(series.first)
+        XCTAssertEqual(s.ts, 1_780_000_000, "ts must be the burst's FIRST record timestamp")
+        XCTAssertEqual(s.bpm, 15, accuracy: 1.0)
+    }
+
+    func testFlatSignalProducesNoEstimate() {
+        // Constant DC (no variation at all) → after centering, every band bin is exactly zero power →
+        // no fabricated rate. Long enough to clear the minimum-burst-length gate.
+        let records: [(ts: Int, samples: [Int])] = (0..<40).map { s in
+            (ts: 1_780_000_000 + s, samples: Array(repeating: 5000, count: fs))
+        }
+        XCTAssertTrue(PpgResp.deriveRespRate(records: records).isEmpty,
+                      "a flat signal must not produce a fabricated respiratory rate")
+    }
+
+    func testEstimateRejectsTooShortBurst() {
+        // A single ~1 breaths/min-modulated second is nowhere near enough to resolve 0.15 Hz.
+        let oneSecond = breathingBurst(breathBpm: 15, seconds: 1).first!.samples
+        XCTAssertNil(PpgResp.estimate(oneSecond))
+    }
+
+    func testBurstShorterThanMinimumIsDropped() {
+        // minBurstRecords (32) worth of a run is required; 20 records must not yield an estimate even
+        // though each individual second is well-formed.
+        let records = Array(breathingBurst(breathBpm: 15, seconds: 40).prefix(20))
+        XCTAssertTrue(PpgResp.deriveRespRate(records: records).isEmpty)
+    }
+
+    func testGapBreaksRunsIntoSeparateBursts() {
+        // Two full 40 s bursts separated by a gap — both estimate independently, none inside the gap.
+        var recs = breathingBurst(breathBpm: 12, base: 1_780_000_000)
+        recs += breathingBurst(breathBpm: 18, base: 1_780_001_000)
+        let series = PpgResp.deriveRespRate(records: recs)
+        XCTAssertEqual(series.count, 2)
+        XCTAssertEqual(series[0].bpm, 12, accuracy: 1.0)
+        XCTAssertEqual(series[1].bpm, 18, accuracy: 1.0)
+        XCTAssertEqual(series[0].ts, 1_780_000_000)
+        XCTAssertEqual(series[1].ts, 1_780_001_000)
+    }
+
+    func testDeriveRespRateRecordsMayBeUnsorted() {
+        var recs = breathingBurst(breathBpm: 15)
+        recs.shuffle()
+        let series = PpgResp.deriveRespRate(records: recs)
+        XCTAssertEqual(series.count, 1)
+        XCTAssertEqual(series[0].ts, 1_780_000_000)
+    }
+
+    /// Streams decode tolerance: a JSON missing `ppg_resp` still decodes (defaults to empty), and a
+    /// present `ppg_resp` round-trips. Mirrors the equivalent `ppg_hr` guard in `PpgHrTests`.
+    func testStreamsDecodeToleratesMissingAndPresentPpgResp() throws {
+        let dec = JSONDecoder()
+        let s1 = try dec.decode(Streams.self, from: Data(#"{"hr":[]}"#.utf8))
+        XCTAssertTrue(s1.ppgResp.isEmpty)
+        let json = #"{"ppg_resp":[{"ts":1780000000,"bpm":15.0,"conf":3.5}]}"#
+        let s2 = try dec.decode(Streams.self, from: Data(json.utf8))
+        XCTAssertEqual(s2.ppgResp, [PpgRespSample(ts: 1_780_000_000, bpm: 15.0, conf: 3.5)])
+        let round = try dec.decode(Streams.self, from: JSONEncoder().encode(s2))
+        XCTAssertEqual(round.ppgResp, s2.ppgResp)
+    }
+}

--- a/Packages/WhoopStore/Sources/WhoopStore/Database.swift
+++ b/Packages/WhoopStore/Sources/WhoopStore/Database.swift
@@ -552,6 +552,25 @@ extension WhoopStore {
                 t.primaryKey(["deviceId", "ts"])
             }
         }
+
+        // v28-ppg-resp-sample (#103): PPG-derived per-burst (~40s) respiratory rate DERIVED FROM the
+        // same WHOOP 5.0 v26 optical buffer the v27 `ppgWaveformSample` table above now stores raw and
+        // `ppgHrSample` (v12) reads for HR — three streams off one buffer, each in its own table. Same
+        // rationale as v12: never conflated with the strap's own resp_rate_raw (`respSample`,
+        // WHOOP4-only — the two never overlap on a given device). bpm is REAL and NOT rounded (unlike
+        // ppgHrSample's bpm, which rounds to whole HR) — respiratory-rate precision at ~14-15 bpm is
+        // the point. Additive only; no existing row touched. (Renumbered v26 → v27 → v28 as
+        // v26-efficiency-heal and then v27-ppg-waveform landed in the slot first — the #103 review's
+        // coordination note called this collision.)
+        migrator.registerMigration("v28-ppg-resp-sample") { db in
+            try db.create(table: "ppgRespSample") { t in
+                t.column("deviceId", .text).notNull()
+                t.column("ts", .integer).notNull()
+                t.column("bpm", .double).notNull()
+                t.column("conf", .double).notNull()
+                t.primaryKey(["deviceId", "ts"])
+            }
+        }
         return migrator
     }
 }

--- a/Packages/WhoopStore/Sources/WhoopStore/DeviceRegistryStore.swift
+++ b/Packages/WhoopStore/Sources/WhoopStore/DeviceRegistryStore.swift
@@ -95,6 +95,9 @@ public struct DeviceRegistryStore: Sendable {
         // "delete all of this device's data" leaves the raw waveform behind (the same privacy defect
         // this list exists to close).
         "ppgWaveformSample",
+        // v28-ppg-resp-sample (#103): PPG-derived respiratory rate, same deviceId-keyed shape as
+        // ppgHrSample above — added at creation time, not backfilled later like the block above.
+        "ppgRespSample",
     ]
 
     /// Permanently delete every recorded sample/derived row belonging to one device, across all

--- a/Packages/WhoopStore/Sources/WhoopStore/Reads.swift
+++ b/Packages/WhoopStore/Sources/WhoopStore/Reads.swift
@@ -192,6 +192,22 @@ extension WhoopStore {
         }
     }
 
+    /// PPG-derived per-burst respiratory rate from the WHOOP 5.0 v26 optical buffer (#103). Unlike
+    /// `ppgHrSample` (which COALESCEs into the plain `hr` stream at read time, so has no dedicated
+    /// reader), this is consumed as its own typed array by the fusion logic in
+    /// `StrandAnalytics.SleepStager.respRateFromPpg` — it must stay distinguishable from the R-R/RSA
+    /// stream, not silently merged.
+    public func ppgRespSamples(deviceId: String, from: Int, to: Int, limit: Int) async throws -> [PpgRespSample] {
+        try syncRead { db in
+            try Row.fetchAll(db, sql: """
+                SELECT ts, bpm, conf FROM ppgRespSample
+                WHERE deviceId = ? AND ts >= ? AND ts <= ?
+                ORDER BY ts ASC LIMIT ?
+                """, arguments: [deviceId, from, to, limit])
+                .map { PpgRespSample(ts: $0["ts"], bpm: $0["bpm"], conf: $0["conf"]) }
+        }
+    }
+
     public func gravitySamples(deviceId: String, from: Int, to: Int, limit: Int) async throws -> [GravitySample] {
         try syncRead { db in
             try Row.fetchAll(db, sql: """

--- a/Packages/WhoopStore/Sources/WhoopStore/StreamStore.swift
+++ b/Packages/WhoopStore/Sources/WhoopStore/StreamStore.swift
@@ -216,6 +216,17 @@ extension WhoopStore {
                     try stmt.execute(arguments: [deviceId, s.ts, WhoopStore.packPpgSamples(s.samples)])
                 }
             }
+            // PPG-derived respiratory rate from the SAME v26 optical buffer (#103). Same persist-only
+            // shape as ppgHr above — one row per burst, ON CONFLICT DO NOTHING keeps the first estimate.
+            if !streams.ppgResp.isEmpty {
+                let stmt = try db.cachedStatement(sql: """
+                    INSERT INTO ppgRespSample (deviceId, ts, bpm, conf) VALUES (?, ?, ?, ?)
+                    ON CONFLICT(deviceId, ts) DO NOTHING
+                    """)
+                for s in streams.ppgResp {
+                    try stmt.execute(arguments: [deviceId, s.ts, s.bpm, s.conf])
+                }
+            }
             return (hr, rr, ev, bat, spo2, skin, resp, grav)
         }
     }
@@ -225,15 +236,16 @@ extension WhoopStore {
     /// Long-format CSV column order. One stream's columns are filled per row; the rest stay blank.
     private static let rawCSVHeader =
         "unix_s,iso_utc,stream,hr_bpm,rr_ms,grav_x,grav_y,grav_z,step_counter," +
-        "ppg_bpm,ppg_conf,spo2_red,spo2_ir,skintemp_raw,resp_raw,band_sleep_state,event_kind,event_payload"
+        "ppg_bpm,ppg_conf,spo2_red,spo2_ir,skintemp_raw,resp_raw,band_sleep_state,event_kind,event_payload," +
+        "ppgresp_bpm,ppgresp_conf"
 
-    /// One assembled CSV line: the 16 columns AFTER the `unix_s,iso_utc` prefix, joined with commas.
-    /// `cols[0]` is the `stream` name; `cols[1...15]` are the per-stream value slots, only the ones
+    /// One assembled CSV line: the 18 columns AFTER the `unix_s,iso_utc` prefix, joined with commas.
+    /// `cols[0]` is the `stream` name; `cols[1...17]` are the per-stream value slots, only the ones
     /// that belong to this row's stream are non-empty.
     private struct RawCSVRow {
         let ts: Int
         var cols: [String]
-        init(ts: Int) { self.ts = ts; self.cols = Array(repeating: "", count: 16) }
+        init(ts: Int) { self.ts = ts; self.cols = Array(repeating: "", count: 18) }
     }
 
     /// Export the decoded per-sample sensor streams NOOP already stores to ONE combined long-format CSV
@@ -333,6 +345,15 @@ extension WhoopStore {
                 var row = RawCSVRow(ts: r["ts"]); row.cols[0] = "event"
                 row.cols[14] = WhoopStore.csvField(r["kind"] ?? "")
                 row.cols[15] = WhoopStore.csvField(r["payloadJSON"] ?? "")
+                out.append(row)
+            }
+            // ppgresp (#103): stream=ppgresp → ppgresp_bpm/ppgresp_conf (cols 18–19).
+            for r in try Row.fetchAll(db, sql:
+                "SELECT ts, bpm, conf FROM ppgRespSample WHERE deviceId = ? AND ts >= ? ORDER BY ts",
+                arguments: [deviceId, floor]) {
+                var row = RawCSVRow(ts: r["ts"]); row.cols[0] = "ppgresp"
+                row.cols[16] = WhoopStore.dblStr(r["bpm"])
+                row.cols[17] = WhoopStore.dblStr(r["conf"])
                 out.append(row)
             }
 
@@ -456,6 +477,10 @@ extension WhoopStore {
 
     public func ppgWaveformCountForTest() async throws -> Int {
         try syncRead { db in try Int.fetchOne(db, sql: "SELECT COUNT(*) FROM ppgWaveformSample") ?? 0 }
+    }
+
+    public func ppgRespCountForTest() async throws -> Int {
+        try syncRead { db in try Int.fetchOne(db, sql: "SELECT COUNT(*) FROM ppgRespSample") ?? 0 }
     }
 
     public func deviceRowForTest(id: String) async throws -> (mac: String?, name: String?)? {

--- a/Packages/WhoopStore/Sources/WhoopStore/TimestampHeal.swift
+++ b/Packages/WhoopStore/Sources/WhoopStore/TimestampHeal.swift
@@ -47,7 +47,7 @@ extension WhoopStore {
             // REALTIME paths the #547 gate now guards, so the same out-of-bounds predicate cleans them.
             let rawTables = ["hrSample", "rrInterval", "event", "battery",
                              "spo2Sample", "skinTempSample", "respSample",
-                             "gravitySample", "stepSample", "ppgHrSample"]
+                             "gravitySample", "stepSample", "ppgHrSample", "ppgRespSample"]
             var rawDeleted = 0
             for table in rawTables {
                 try db.execute(sql: "DELETE FROM \(table) WHERE ts < ? OR ts > ?",

--- a/Packages/WhoopStore/Tests/WhoopStoreTests/MigrationTests.swift
+++ b/Packages/WhoopStore/Tests/WhoopStoreTests/MigrationTests.swift
@@ -7,7 +7,7 @@ final class MigrationTests: XCTestCase {
     func testInMemoryRunsMigrations() async throws {
         let store = try await WhoopStore.inMemory()
         let tables = try await store.tableNames()
-        for t in ["device", "hrSample", "rrInterval", "event", "battery", "rawBatch"] {
+        for t in ["device", "hrSample", "rrInterval", "event", "battery", "rawBatch", "ppgRespSample"] {
             XCTAssertTrue(tables.contains(t), "missing table \(t)")
         }
     }

--- a/Packages/WhoopStore/Tests/WhoopStoreTests/PpgRespSampleTests.swift
+++ b/Packages/WhoopStore/Tests/WhoopStoreTests/PpgRespSampleTests.swift
@@ -1,0 +1,67 @@
+import XCTest
+import GRDB
+import WhoopProtocol
+@testable import WhoopStore
+
+/// v26-ppg-resp-sample migration + dedicated reader: PPG-derived respiratory rate from the WHOOP 5.0
+/// v26 optical buffer (#103). Unlike `ppgHrSample` (COALESCEd into `hrSample` reads), this stream has
+/// its own reader — see `PpgHrSampleTests.swift` for the sibling HR-side migration tests.
+final class PpgRespSampleTests: XCTestCase {
+    func testV26CreatesPpgRespTable() async throws {
+        let store = try await WhoopStore.inMemory()
+        let tables = try await store.tableNames()
+        XCTAssertTrue(tables.contains("ppgRespSample"))
+    }
+
+    func testPpgRespPrimaryKeyIsDeviceIdTs() async throws {
+        let store = try await WhoopStore.inMemory()
+        let cols = try await store.primaryKeyColumns("ppgRespSample")
+        XCTAssertEqual(cols, ["deviceId", "ts"])
+    }
+
+    func testPpgRespInsertRoundTripAndDedup() async throws {
+        let store = try await WhoopStore.inMemory()
+        let streams = Streams(ppgResp: [
+            PpgRespSample(ts: 1_780_916_150, bpm: 14.5, conf: 8.2),
+            PpgRespSample(ts: 1_780_916_190, bpm: 15.0, conf: 12.1),
+        ])
+        _ = try await store.insert(streams, deviceId: "my-whoop")
+        let n1 = try await store.ppgRespCountForTest()
+        XCTAssertEqual(n1, 2)
+        // Re-inserting the same (deviceId, ts) is idempotent — ON CONFLICT DO NOTHING.
+        _ = try await store.insert(streams, deviceId: "my-whoop")
+        let n2 = try await store.ppgRespCountForTest()
+        XCTAssertEqual(n2, 2)
+    }
+
+    /// The dedicated reader returns rows in `[from, to]`, ascending by ts, un-COALESCEd — this stream
+    /// is consumed as its own distinct array by `SleepStager.respRateFromPpg`, never merged with `resp`.
+    func testPpgRespSamplesReaderFiltersAndOrders() async throws {
+        let store = try await WhoopStore.inMemory()
+        let dev = "my-whoop"
+        let base = 1_780_000_000
+        try await store.insert(Streams(ppgResp: [
+            PpgRespSample(ts: base - 100, bpm: 20.0, conf: 5.0),  // before range
+            PpgRespSample(ts: base + 40, bpm: 14.0, conf: 9.0),
+            PpgRespSample(ts: base, bpm: 15.5, conf: 3.0),
+            PpgRespSample(ts: base + 1000, bpm: 12.0, conf: 4.0), // after range
+        ]), deviceId: dev)
+
+        let samples = try await store.ppgRespSamples(deviceId: dev, from: base, to: base + 100, limit: 10)
+        XCTAssertEqual(samples, [
+            PpgRespSample(ts: base, bpm: 15.5, conf: 3.0),
+            PpgRespSample(ts: base + 40, bpm: 14.0, conf: 9.0),
+        ])
+    }
+
+    func testPpgRespSamplesReaderIsDeviceScoped() async throws {
+        let store = try await WhoopStore.inMemory()
+        let base = 1_780_000_000
+        try await store.insert(Streams(ppgResp: [PpgRespSample(ts: base, bpm: 15.0, conf: 5.0)]),
+                               deviceId: "device-a")
+        try await store.insert(Streams(ppgResp: [PpgRespSample(ts: base, bpm: 99.0, conf: 5.0)]),
+                               deviceId: "device-b")
+        let samples = try await store.ppgRespSamples(deviceId: "device-a", from: base, to: base + 10, limit: 10)
+        XCTAssertEqual(samples, [PpgRespSample(ts: base, bpm: 15.0, conf: 5.0)])
+    }
+}

--- a/Packages/WhoopStore/Tests/WhoopStoreTests/PpgRespSampleTests.swift
+++ b/Packages/WhoopStore/Tests/WhoopStoreTests/PpgRespSampleTests.swift
@@ -3,11 +3,11 @@ import GRDB
 import WhoopProtocol
 @testable import WhoopStore
 
-/// v26-ppg-resp-sample migration + dedicated reader: PPG-derived respiratory rate from the WHOOP 5.0
+/// v28-ppg-resp-sample migration + dedicated reader: PPG-derived respiratory rate from the WHOOP 5.0
 /// v26 optical buffer (#103). Unlike `ppgHrSample` (COALESCEd into `hrSample` reads), this stream has
 /// its own reader — see `PpgHrSampleTests.swift` for the sibling HR-side migration tests.
 final class PpgRespSampleTests: XCTestCase {
-    func testV26CreatesPpgRespTable() async throws {
+    func testV28CreatesPpgRespTable() async throws {
         let store = try await WhoopStore.inMemory()
         let tables = try await store.tableNames()
         XCTAssertTrue(tables.contains("ppgRespSample"))

--- a/Packages/WhoopStore/Tests/WhoopStoreTests/TimestampHealTests.swift
+++ b/Packages/WhoopStore/Tests/WhoopStoreTests/TimestampHealTests.swift
@@ -141,4 +141,21 @@ final class TimestampHealTests: XCTestCase {
         let survivors = try await store.hrSamples(deviceId: "dev1", from: 0, to: Int.max, limit: 1000)
         XCTAssertEqual(survivors.map(\.ts).sorted(), [floor, ceiling])
     }
+
+    /// #103: `ppgRespSample` must be in the raw-tables heal list, same as every other ts-keyed stream —
+    /// pin it directly since `rawTables` itself is a private local, not reflectively guarded like
+    /// `DeviceRegistryStore.deviceScopedTables`.
+    func testPurgesImplausiblePpgRespRows() async throws {
+        let store = try await WhoopStore.inMemory()
+        let good = now - 3600
+        let farPast = 1_250_000_000
+        _ = try await store.insert(Streams(ppgResp: [
+            PpgRespSample(ts: good, bpm: 15.0, conf: 8.0),
+            PpgRespSample(ts: farPast, bpm: 15.0, conf: 8.0),
+        ]), deviceId: "dev1")
+        let result = try await store.healImplausibleTimestamps(now: now, todayLocalDayKey: todayKey)
+        XCTAssertEqual(result.rawRowsDeleted, 1)
+        let survivors = try await store.ppgRespSamples(deviceId: "dev1", from: 0, to: Int.max, limit: 1000)
+        XCTAssertEqual(survivors.map(\.ts), [good])
+    }
 }

--- a/Strand/BLE/PuffinExperiment.swift
+++ b/Strand/BLE/PuffinExperiment.swift
@@ -104,18 +104,22 @@ enum PuffinExperiment {
     /// Test Centre view via @AppStorage on this key. Mirrors the Android `PuffinExperiment.KEY_HRV_READINESS`.
     static let hrvReadinessKey = "noopHrvReadiness"
 
-    /// Opt-in "PPG-derived respiratory rate" (default off, #103): when enabled, `AnalyticsEngine` prefers a
-    /// spectral estimate off the WHOOP5 v26 optical PPG buffer (`PpgResp`, top-confidence-burst aggregation)
-    /// over the shipped R-R/RSA estimate (`SleepStager.respRateFromRR`) per sleep session, feeding
-    /// `DailyMetric.respRateBpm` and the ReadinessEngine illness-detection signal. Validated on only 2 real
-    /// overnight captures from ONE subject whose own night-to-night respiratory rate barely moves (stdev
-    /// ~0.56 bpm) — exactly the single-stable-night validation trap the project's derived-biosignal standard
-    /// warns about (a record-period artifact can coincidentally match a subject on a stable night). Default
-    /// OFF keeps the shipped RSA-only path byte-identical; the app-layer call site (`IntelligenceEngine`)
-    /// reads this flag and only supplies the real `ppgResp` stream to `analyzeDay` when it's on — the pure
-    /// `AnalyticsEngine`/`SleepStager` functions are unaware of the toggle and stay pure. `ppgResp` is still
-    /// decoded + persisted (`ppgRespSample`) unconditionally as instrumentation, so opting in later needs no
-    /// backfill. Mirrors the Android `PuffinExperiment.KEY_PPG_RESP_RATE`.
+    /// Opt-in "PPG-derived respiratory rate diagnostic" (default off, #103): a spectral estimate off
+    /// the WHOOP5 v26 optical PPG buffer (`PpgResp`, top-confidence-burst aggregation), compared
+    /// against the shipped R-R/RSA estimate (`SleepStager.respRateFromRR`) purely for a diagnostic log
+    /// line — it NEVER overrides `DailyMetric.respRateBpm` or reaches the ReadinessEngine
+    /// illness-detection signal, which always reads RSA only. (An earlier version of this preferred
+    /// PPG when available; per #103 review, a persisted value that silently switches estimator night
+    /// to night can inject a step large enough to brush the illness WATCH threshold on its own — a
+    /// false signal from the estimator flipping, not physiology. So the comparison stays diagnostic.)
+    /// Validated on only 2 real overnight captures from ONE subject whose own night-to-night
+    /// respiratory rate barely moves (stdev ~0.56 bpm) — exactly the single-stable-night validation
+    /// trap the project's derived-biosignal standard warns about. Default OFF means the comparison is
+    /// never computed; the app-layer call site (`IntelligenceEngine`) reads this flag and only
+    /// supplies the real `ppgResp` stream to `analyzeDay` when it's on — the pure
+    /// `AnalyticsEngine`/`SleepStager` functions are unaware of the toggle and stay pure. `ppgResp` is
+    /// still decoded + persisted (`ppgRespSample`) unconditionally as instrumentation regardless of
+    /// this flag. Mirrors the Android `PuffinExperiment.KEY_PPG_RESP_RATE`.
     static let ppgRespRateKey = "noopPpgRespRate"
 
     static var ppgRespRateEnabled: Bool { UserDefaults.standard.bool(forKey: ppgRespRateKey) }

--- a/Strand/BLE/PuffinExperiment.swift
+++ b/Strand/BLE/PuffinExperiment.swift
@@ -104,6 +104,22 @@ enum PuffinExperiment {
     /// Test Centre view via @AppStorage on this key. Mirrors the Android `PuffinExperiment.KEY_HRV_READINESS`.
     static let hrvReadinessKey = "noopHrvReadiness"
 
+    /// Opt-in "PPG-derived respiratory rate" (default off, #103): when enabled, `AnalyticsEngine` prefers a
+    /// spectral estimate off the WHOOP5 v26 optical PPG buffer (`PpgResp`, top-confidence-burst aggregation)
+    /// over the shipped R-R/RSA estimate (`SleepStager.respRateFromRR`) per sleep session, feeding
+    /// `DailyMetric.respRateBpm` and the ReadinessEngine illness-detection signal. Validated on only 2 real
+    /// overnight captures from ONE subject whose own night-to-night respiratory rate barely moves (stdev
+    /// ~0.56 bpm) — exactly the single-stable-night validation trap the project's derived-biosignal standard
+    /// warns about (a record-period artifact can coincidentally match a subject on a stable night). Default
+    /// OFF keeps the shipped RSA-only path byte-identical; the app-layer call site (`IntelligenceEngine`)
+    /// reads this flag and only supplies the real `ppgResp` stream to `analyzeDay` when it's on — the pure
+    /// `AnalyticsEngine`/`SleepStager` functions are unaware of the toggle and stay pure. `ppgResp` is still
+    /// decoded + persisted (`ppgRespSample`) unconditionally as instrumentation, so opting in later needs no
+    /// backfill. Mirrors the Android `PuffinExperiment.KEY_PPG_RESP_RATE`.
+    static let ppgRespRateKey = "noopPpgRespRate"
+
+    static var ppgRespRateEnabled: Bool { UserDefaults.standard.bool(forKey: ppgRespRateKey) }
+
     /// Opt-in "Auto-detect workouts": after a sync / on Today appear, scan the last day or two of HR for a
     /// SUSTAINED-ELEVATED window (resting HR + 30 bpm held ≥ 12 min) that doesn't overlap a saved workout,
     /// and surface ONE dismissible Today card offering to save it as a manual-style workout. Pure read +

--- a/Strand/Data/IntelligenceEngine.swift
+++ b/Strand/Data/IntelligenceEngine.swift
@@ -551,8 +551,15 @@ final class IntelligenceEngine: ObservableObject {
                 let spo2 = (try? await store.spo2Samples(deviceId: owner, from: from, to: to, limit: 200_000)) ?? []
                 // #103: PPG-derived per-burst respiratory rate from the WHOOP 5.0 v26 optical buffer.
                 // analyzeDay prefers this over the R-R/RSA estimate per session when it has enough burst
-                // coverage. Empty on a WHOOP 4.0 / v18-only night → falls back to RSA as before.
-                let ppgResp = (try? await store.ppgRespSamples(deviceId: owner, from: from, to: to, limit: 200_000)) ?? []
+                // coverage. Gated behind the default-OFF Experimental toggle (PuffinExperiment.
+                // ppgRespRateEnabled): validated on only 2 real nights from one low-resp-variance subject,
+                // the exact single-stable-night trap the project's derived-biosignal standard warns
+                // about, so the shipped RSA-only path stays byte-identical unless a user opts in. The
+                // stream itself is still decoded + persisted unconditionally as instrumentation — only
+                // whether analyzeDay gets to SEE it here is gated.
+                let ppgResp = PuffinExperiment.ppgRespRateEnabled
+                    ? (try? await store.ppgRespSamples(deviceId: owner, from: from, to: to, limit: 200_000)) ?? []
+                    : []
                 // #938: the strap family that WROTE this owner's skin-temp rows, so analyzeDay converts the raw
                 // register on the right scale (5/MG banks centidegrees, a WHOOP 4.0 v24 banks a raw ADC). The
                 // registry knows each device's model; unknown/non-WHOOP owners fall back to `.whoop5` (the prior

--- a/Strand/Data/IntelligenceEngine.swift
+++ b/Strand/Data/IntelligenceEngine.swift
@@ -550,13 +550,14 @@ final class IntelligenceEngine: ObservableObject {
                 // means on the DailyMetric. Empty on a 5/MG (no v24 spo2 channels) → the raw means stay nil.
                 let spo2 = (try? await store.spo2Samples(deviceId: owner, from: from, to: to, limit: 200_000)) ?? []
                 // #103: PPG-derived per-burst respiratory rate from the WHOOP 5.0 v26 optical buffer.
-                // analyzeDay prefers this over the R-R/RSA estimate per session when it has enough burst
-                // coverage. Gated behind the default-OFF Experimental toggle (PuffinExperiment.
+                // analyzeDay NEVER lets this override DailyMetric.respRateBpm (always RSA, so the
+                // illness-detection gate never sees an estimator switch) — it only logs a comparison
+                // against RSA when both this array is non-empty AND the diagnostic trace is active.
+                // Gated behind the default-OFF Experimental toggle (PuffinExperiment.
                 // ppgRespRateEnabled): validated on only 2 real nights from one low-resp-variance subject,
                 // the exact single-stable-night trap the project's derived-biosignal standard warns
-                // about, so the shipped RSA-only path stays byte-identical unless a user opts in. The
-                // stream itself is still decoded + persisted unconditionally as instrumentation — only
-                // whether analyzeDay gets to SEE it here is gated.
+                // about. The stream itself is still decoded + persisted unconditionally as
+                // instrumentation — only whether analyzeDay gets to SEE it here is gated.
                 let ppgResp = PuffinExperiment.ppgRespRateEnabled
                     ? (try? await store.ppgRespSamples(deviceId: owner, from: from, to: to, limit: 200_000)) ?? []
                     : []

--- a/Strand/Data/IntelligenceEngine.swift
+++ b/Strand/Data/IntelligenceEngine.swift
@@ -549,6 +549,10 @@ final class IntelligenceEngine: ObservableObject {
                 // #93: WHOOP 4.0 raw SpO2 PPG samples for the night; analyzeDay banks the nightly red/IR ADC
                 // means on the DailyMetric. Empty on a 5/MG (no v24 spo2 channels) → the raw means stay nil.
                 let spo2 = (try? await store.spo2Samples(deviceId: owner, from: from, to: to, limit: 200_000)) ?? []
+                // #103: PPG-derived per-burst respiratory rate from the WHOOP 5.0 v26 optical buffer.
+                // analyzeDay prefers this over the R-R/RSA estimate per session when it has enough burst
+                // coverage. Empty on a WHOOP 4.0 / v18-only night → falls back to RSA as before.
+                let ppgResp = (try? await store.ppgRespSamples(deviceId: owner, from: from, to: to, limit: 200_000)) ?? []
                 // #938: the strap family that WROTE this owner's skin-temp rows, so analyzeDay converts the raw
                 // register on the right scale (5/MG banks centidegrees, a WHOOP 4.0 v24 banks a raw ADC). The
                 // registry knows each device's model; unknown/non-WHOOP owners fall back to `.whoop5` (the prior
@@ -686,6 +690,7 @@ final class IntelligenceEngine: ObservableObject {
                                                      skinTempFamily: skinFamily,   // #938
                                                      skinTempAnchorRaw: skinAnchorRaw,   // #938 second capture
                                                      spo2: spo2,                   // #93
+                                                     ppgResp: ppgResp,             // #103
                                                      profile: up, baselines: baselines1, maxHROverride: maxHR,
                                                      tzOffsetSeconds: tzOffset, wristOff: wristOff,
                                                      habitualMidsleepSec: habitualMidsleepSec,

--- a/Strand/Screens/TestCentreView.swift
+++ b/Strand/Screens/TestCentreView.swift
@@ -40,6 +40,7 @@ struct TestCentreView: View {
     // both default OFF.
     @AppStorage(PuffinExperiment.ppgHrSubLagInterpKey) private var ppgHrSubLagInterpEnabled = false
     @AppStorage(PuffinExperiment.hrvReadinessKey) private var hrvReadinessEnabled = false
+    @AppStorage(PuffinExperiment.ppgRespRateKey) private var ppgRespRateEnabled = false
 
     /// True when the connected strap is a 5/MG, so the 5/MG experimental block shows. Mirrors the
     /// SettingsView gate (#22): a confident 4.0 owner never sees controls that cannot touch their strap.
@@ -263,6 +264,17 @@ struct TestCentreView: View {
                 // The toggle's OWN effect, shown in place: when on, the live Plews/Altini reading. Nothing
                 // renders when off, so the flag off is zero behaviour change and feeds no downstream gate.
                 if hrvReadinessEnabled { hrvReadinessReadout }
+
+                Divider().overlay(StrandPalette.hairline)
+
+                Toggle(isOn: $ppgRespRateEnabled) {
+                    Text("PPG-derived respiratory rate (#103)")
+                        .font(StrandFont.subhead).foregroundStyle(StrandPalette.textPrimary)
+                }
+                .toggleStyle(.switch).tint(StrandPalette.accent)
+                Text("Prefer a spectral respiratory-rate estimate off the WHOOP5 v26 optical PPG buffer over the shipped R-R estimate, per sleep session with enough burst coverage. Unlike the read-only toggles above, this changes a stored value: DailyMetric.respRateBpm and the illness-detection signal it feeds. Validated on only 2 real nights from one subject whose own respiratory rate barely varies night to night - not yet proven to track a varying value. Off by default; the R-R estimate stays the shipped default until this earns wider validation.")
+                    .font(StrandFont.caption).foregroundStyle(StrandPalette.textTertiary)
+                    .fixedSize(horizontal: false, vertical: true)
             }
         }
     }

--- a/Strand/Screens/TestCentreView.swift
+++ b/Strand/Screens/TestCentreView.swift
@@ -268,11 +268,11 @@ struct TestCentreView: View {
                 Divider().overlay(StrandPalette.hairline)
 
                 Toggle(isOn: $ppgRespRateEnabled) {
-                    Text("PPG-derived respiratory rate (#103)")
+                    Text("PPG-derived respiratory rate diagnostic (#103)")
                         .font(StrandFont.subhead).foregroundStyle(StrandPalette.textPrimary)
                 }
                 .toggleStyle(.switch).tint(StrandPalette.accent)
-                Text("Prefer a spectral respiratory-rate estimate off the WHOOP5 v26 optical PPG buffer over the shipped R-R estimate, per sleep session with enough burst coverage. Unlike the read-only toggles above, this changes a stored value: DailyMetric.respRateBpm and the illness-detection signal it feeds. Validated on only 2 real nights from one subject whose own respiratory rate barely varies night to night - not yet proven to track a varying value. Off by default; the R-R estimate stays the shipped default until this earns wider validation.")
+                Text("Logs a spectral respiratory-rate estimate off the WHOOP5 v26 optical PPG buffer alongside the shipped R-R estimate, for comparison. Read-only, like HRV readiness above: it never overrides DailyMetric.respRateBpm or the illness-detection signal, which always reads the R-R estimate only - a value that silently switched estimator night to night could fake an illness warning on its own. Validated on only 2 real nights from one subject whose own respiratory rate barely varies night to night. Off by default; the log line only appears when this is on.")
                     .font(StrandFont.caption).foregroundStyle(StrandPalette.textTertiary)
                     .fixedSize(horizontal: false, vertical: true)
             }

--- a/android/app/src/main/java/com/noop/analytics/AnalyticsEngine.kt
+++ b/android/app/src/main/java/com/noop/analytics/AnalyticsEngine.kt
@@ -184,11 +184,11 @@ object AnalyticsEngine {
         // empty keeps pure-function callers/tests + non-4.0 nights null.
         spo2: List<Spo2Sample> = emptyList(),
         // PPG-derived per-burst respiratory rate from the WHOOP 5.0 v26 optical buffer (#103,
-        // com.noop.protocol.PpgResp). Per matched sleep session, tried FIRST for respRateDaily below
-        // (more accurate per 2-night real-capture validation when it has enough burst coverage),
-        // falling back to the R-R/RSA estimate when it's empty/insufficient — v26 coverage is a sparse
-        // minority of any given night, so NaN here is the common case, not a bug. Default empty keeps
-        // pure-function callers/tests + WHOOP4/no-v26 nights on the existing RSA-only path unchanged.
+        // com.noop.protocol.PpgResp). NEVER overrides respRateDaily below (that always comes from
+        // R-R/RSA, so the illness-detection gate never sees an estimator switch) — when non-empty,
+        // it's only computed alongside RSA for a diagnostic comparison logged through hrvTraceSink.
+        // Default empty keeps pure-function callers/tests + WHOOP4/no-v26/opted-out nights identical
+        // (no comparison computed, nothing logged).
         ppgResp: List<PpgRespSample> = emptyList(),
         profile: UserProfile,
         baselines: ProfileBaselines = ProfileBaselines(),
@@ -411,27 +411,29 @@ object AnalyticsEngine {
             )
         }
 
-        // Nightly APPROXIMATE respiratory rate (breaths/min); NOT a cloud/clinical respiration value.
-        // Per matched in-bed session: PREFER the PPG-derived estimate (SleepStager.respRateFromPpg,
-        // #103, WHOOP5 v26 optical buffer) when it has enough burst coverage — landed within 2-6% of
-        // the WHOOP app's own reading on 2 real overnight captures, vs. the R-R/RSA estimate's 6-11%
-        // low bias on the SAME nights — else fall back to the R-R/RSA estimate (respRateFromRR,
-        // WHOOP5 v18-only, no raw resp ADC on this family). NOT a blend of the two: blending two
-        // estimates of different, uncharacterized accuracy risks being confidently wrong in a new way
-        // neither alone is (see #103 for the full honesty caveat — thin, 2-night, low-variance-subject
-        // evidence). The night's value = median of finite per-session estimates; null only when no
-        // session yields one. Which estimator fired per session is traced through hrvTraceSink (the
-        // existing per-day diagnostic hook) when active, for future debugging/re-tuning.
+        // Nightly APPROXIMATE respiratory rate (breaths/min) from the R-R stream via RSA; NOT a
+        // cloud/clinical respiration value. This is the ONLY estimator that ever reaches
+        // DailyMetric.respRateBpm / the ReadinessEngine illness-detection gate — see #103 review: an
+        // earlier version of this preferred a PPG-derived estimate (SleepStager.respRateFromPpg,
+        // WHOOP5 v26 optical buffer) per session when available, but that let the persisted value
+        // silently switch estimator night to night. RSA and PPG read ~1-1.5 bpm apart even when both
+        // are "right," so for a stable sleeper (resp SD ~1 bpm) a night that merely SWITCHES which
+        // estimator fired injects a step large enough to brush the illness WATCH z-threshold — a false
+        // signal from the estimator flipping, not physiology. So the gate-facing value now always
+        // comes from one consistent estimator (RSA), full stop. The night's value = median of finite
+        // per-session RSA estimates; null only when no session yields one.
+        //
+        // The PPG estimate is still computed for comparison (never stored, never gates anything) when
+        // ppgResp is non-empty — i.e. only when the caller's Experimental toggle supplied it — and
+        // logged alongside RSA through hrvTraceSink (the existing per-day diagnostic hook) when
+        // active, so opt-in nights keep generating the RSA-vs-PPG evidence #103 needs to eventually
+        // trust PPG on its own.
         val respRateDaily: Double? = run {
             val perSession = matched.mapNotNull { session ->
-                val ppg = SleepStager.respRateFromPpg(ppgResp, session.start, session.end)
-                if (ppg.isFinite()) {
-                    hrvTraceSink?.invoke("respRate session start=${session.start} source=ppg value=$ppg")
-                    return@mapNotNull ppg
-                }
                 val rsa = SleepStager.respRateFromRR(rr, session.start, session.end)
-                if (rsa.isFinite()) {
-                    hrvTraceSink?.invoke("respRate session start=${session.start} source=rsa value=$rsa")
+                if (ppgResp.isNotEmpty()) {
+                    val ppg = SleepStager.respRateFromPpg(ppgResp, session.start, session.end)
+                    hrvTraceSink?.invoke("respRate session start=${session.start} rsa=$rsa ppg=$ppg used=rsa")
                 }
                 if (rsa.isFinite()) rsa else null
             }

--- a/android/app/src/main/java/com/noop/analytics/AnalyticsEngine.kt
+++ b/android/app/src/main/java/com/noop/analytics/AnalyticsEngine.kt
@@ -4,6 +4,7 @@ import com.noop.data.DailyMetric
 import com.noop.data.EventRow
 import com.noop.data.GravitySample
 import com.noop.data.HrSample
+import com.noop.data.PpgRespSample
 import com.noop.data.SkinTempSample
 import com.noop.data.Spo2Sample
 import com.noop.data.RespSample
@@ -182,6 +183,13 @@ object AnalyticsEngine {
         // decoded" data, NOT a calibrated blood-oxygen % (that needs WHOOP's proprietary curve). Default
         // empty keeps pure-function callers/tests + non-4.0 nights null.
         spo2: List<Spo2Sample> = emptyList(),
+        // PPG-derived per-burst respiratory rate from the WHOOP 5.0 v26 optical buffer (#103,
+        // com.noop.protocol.PpgResp). Per matched sleep session, tried FIRST for respRateDaily below
+        // (more accurate per 2-night real-capture validation when it has enough burst coverage),
+        // falling back to the R-R/RSA estimate when it's empty/insufficient — v26 coverage is a sparse
+        // minority of any given night, so NaN here is the common case, not a bug. Default empty keeps
+        // pure-function callers/tests + WHOOP4/no-v26 nights on the existing RSA-only path unchanged.
+        ppgResp: List<PpgRespSample> = emptyList(),
         profile: UserProfile,
         baselines: ProfileBaselines = ProfileBaselines(),
         maxHROverride: Double? = null,
@@ -403,15 +411,30 @@ object AnalyticsEngine {
             )
         }
 
-        // Nightly APPROXIMATE respiratory rate (breaths/min) from the R-R stream via
-        // RSA. WHOOP5 v18 carries no raw resp ADC, so this is an on-device estimate,
-        // NOT a cloud/clinical respiration value. Per matched in-bed session, estimate
-        // over [start, end]; the night's value = median of finite per-session
-        // estimates; null only when no session yields a finite estimate.
+        // Nightly APPROXIMATE respiratory rate (breaths/min); NOT a cloud/clinical respiration value.
+        // Per matched in-bed session: PREFER the PPG-derived estimate (SleepStager.respRateFromPpg,
+        // #103, WHOOP5 v26 optical buffer) when it has enough burst coverage — landed within 2-6% of
+        // the WHOOP app's own reading on 2 real overnight captures, vs. the R-R/RSA estimate's 6-11%
+        // low bias on the SAME nights — else fall back to the R-R/RSA estimate (respRateFromRR,
+        // WHOOP5 v18-only, no raw resp ADC on this family). NOT a blend of the two: blending two
+        // estimates of different, uncharacterized accuracy risks being confidently wrong in a new way
+        // neither alone is (see #103 for the full honesty caveat — thin, 2-night, low-variance-subject
+        // evidence). The night's value = median of finite per-session estimates; null only when no
+        // session yields one. Which estimator fired per session is traced through hrvTraceSink (the
+        // existing per-day diagnostic hook) when active, for future debugging/re-tuning.
         val respRateDaily: Double? = run {
-            val perSession = matched
-                .map { SleepStager.respRateFromRR(rr, it.start, it.end) }
-                .filter { it.isFinite() }
+            val perSession = matched.mapNotNull { session ->
+                val ppg = SleepStager.respRateFromPpg(ppgResp, session.start, session.end)
+                if (ppg.isFinite()) {
+                    hrvTraceSink?.invoke("respRate session start=${session.start} source=ppg value=$ppg")
+                    return@mapNotNull ppg
+                }
+                val rsa = SleepStager.respRateFromRR(rr, session.start, session.end)
+                if (rsa.isFinite()) {
+                    hrvTraceSink?.invoke("respRate session start=${session.start} source=rsa value=$rsa")
+                }
+                if (rsa.isFinite()) rsa else null
+            }
             if (perSession.isEmpty()) null else HrvAnalyzer.median(perSession)
         }
 

--- a/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
+++ b/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
@@ -472,6 +472,10 @@ object IntelligenceEngine {
             // #93: WHOOP 4.0 raw SpO2 PPG samples for the night; analyzeDay banks the nightly red/IR ADC
             // means on the DailyMetric. Empty on a 5/MG (no v24 spo2 channels) → the raw means stay null.
             val spo2 = repo.spo2Samples(owner, from, to, STREAM_LIMIT)
+            // #103: PPG-derived per-burst respiratory rate from the WHOOP 5.0 v26 optical buffer.
+            // analyzeDay prefers this over the R-R/RSA estimate per session when it has enough burst
+            // coverage. Empty on a WHOOP 4.0 / v18-only night → falls back to RSA as before.
+            val ppgResp = repo.ppgRespSamples(owner, from, to, STREAM_LIMIT)
             // #938: the strap family that WROTE this owner's skin-temp rows, so analyzeDay converts the raw
             // register on the right scale (5/MG banks centidegrees, a WHOOP 4.0 v24 banks a raw ADC). The
             // owner source resolves it from the registry; unknown/non-WHOOP owners fall back to WHOOP5 (the
@@ -558,6 +562,7 @@ object IntelligenceEngine {
                 skinTempFamily = skinFamily,   // #938
                 skinTempAnchorRaw = skinAnchorRaw,   // #938 second capture: per-device worn anchor
                 spo2 = spo2,                   // #93
+                ppgResp = ppgResp,             // #103
                 profile = profile,
                 baselines = baselines1,
                 maxHROverride = maxHROverride,

--- a/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
+++ b/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
@@ -180,6 +180,16 @@ object IntelligenceEngine {
         // OWN observed gravity + step density (see [WakeMotionRefinement]), so existing callers / tests
         // and any night too sparse to trust (e.g. a WHOOP 4.0) are unaffected either way.
         useMotionAwareWake: Boolean = false,
+        // Opt-in "PPG-derived respiratory rate diagnostic" flag (#103, Settings → Experimental). The
+        // analytics layer is Context-free, so the Context-aware caller (AppViewModel / WhoopBleClient)
+        // reads it off SharedPreferences (PuffinExperiment.ppgRespRate) and threads it down here: only
+        // when true does this pass the real ppgRespSample stream into analyzeDay, which computes it
+        // ALONGSIDE the shipped R-R/RSA estimate purely for a diagnostic comparison log line — it never
+        // overrides DailyMetric.respRateBpm or the illness-detection gate, which always reads RSA only.
+        // Default false keeps the comparison uncomputed; validated on only 2 real nights from one
+        // low-resp-variance subject, the exact single-stable-night trap the project's derived-biosignal
+        // standard warns about.
+        ppgRespRateEnabled: Boolean = false,
         // Sleep & Rest test-mode trace sink (Test Centre E5). The analytics layer is Context-free, so the
         // Context-aware caller (AppViewModel / WhoopBleClient) reads TestCentre.active(SLEEP) and passes a
         // non-null sink ONLY when the mode is on, routing each line to the .sleep-tagged strap log. null (the
@@ -227,8 +237,9 @@ object IntelligenceEngine {
         analyzeGate.withLock {
             val (out, healed) = analyzeRecentOnCpu(repo, profile, maxDays, importedDeviceId, maxHROverride,
                 nowSeconds, ownerSource, manualStepCoefficient, persistStepsCalibration, baselineEpoch,
-                recoveryEpoch, diag, useExperimentalSleepV2, useMotionAwareWake, sleepTraceSink, recoveryTraceSink,
-                stepsTraceSink, universalSink, workoutsTraceSink, hrvTraceSink, deepHrvWindow)
+                recoveryEpoch, diag, useExperimentalSleepV2, useMotionAwareWake, ppgRespRateEnabled,
+                sleepTraceSink, recoveryTraceSink, stepsTraceSink, universalSink, workoutsTraceSink,
+                hrvTraceSink, deepHrvWindow)
             if (healed == 0) out
             // #899 heal re-pass: the pass above deleted overlapping duplicate sleep sessions AFTER its days
             // were scored, and the read-side dedup those days consumed had no bank-recency witness (the fresh
@@ -237,8 +248,9 @@ object IntelligenceEngine {
             // are gone), so this can never loop. Mirrors the Swift pendingForcedRescore re-arm.
             else analyzeRecentOnCpu(repo, profile, maxDays, importedDeviceId, maxHROverride,
                 nowSeconds, ownerSource, manualStepCoefficient, persistStepsCalibration, baselineEpoch,
-                recoveryEpoch, diag, useExperimentalSleepV2, useMotionAwareWake, sleepTraceSink, recoveryTraceSink,
-                stepsTraceSink, universalSink, workoutsTraceSink, hrvTraceSink, deepHrvWindow).first
+                recoveryEpoch, diag, useExperimentalSleepV2, useMotionAwareWake, ppgRespRateEnabled,
+                sleepTraceSink, recoveryTraceSink, stepsTraceSink, universalSink, workoutsTraceSink,
+                hrvTraceSink, deepHrvWindow).first
         }
     }
 
@@ -301,6 +313,16 @@ object IntelligenceEngine {
         useExperimentalSleepV2: Boolean = false,
         // Opt-in motion-aware wake refinement (#364 follow-up), threaded the same way. Default false.
         useMotionAwareWake: Boolean = false,
+        // Opt-in "PPG-derived respiratory rate diagnostic" flag (#103, Settings → Experimental). The
+        // analytics layer is Context-free, so the Context-aware caller (AppViewModel / WhoopBleClient)
+        // reads it off SharedPreferences (PuffinExperiment.ppgRespRate) and threads it down here: only
+        // when true does this pass the real ppgRespSample stream into analyzeDay, which computes it
+        // ALONGSIDE the shipped R-R/RSA estimate purely for a diagnostic comparison log line — it never
+        // overrides DailyMetric.respRateBpm or the illness-detection gate, which always reads RSA only.
+        // Default false keeps the comparison uncomputed; validated on only 2 real nights from one
+        // low-resp-variance subject, the exact single-stable-night trap the project's derived-biosignal
+        // standard warns about.
+        ppgRespRateEnabled: Boolean = false,
         // Sleep & Rest test-mode trace sink (Test Centre E5). null = byte-identical default; when non-null
         // each scored day threads it into AnalyticsEngine.analyzeDay so detectSleep's gate trace + the Rest
         // sub-score line forward line-by-line to the .sleep-tagged strap log. Mirrors Swift.
@@ -474,8 +496,10 @@ object IntelligenceEngine {
             val spo2 = repo.spo2Samples(owner, from, to, STREAM_LIMIT)
             // #103: PPG-derived per-burst respiratory rate from the WHOOP 5.0 v26 optical buffer.
             // analyzeDay prefers this over the R-R/RSA estimate per session when it has enough burst
-            // coverage. Empty on a WHOOP 4.0 / v18-only night → falls back to RSA as before.
-            val ppgResp = repo.ppgRespSamples(owner, from, to, STREAM_LIMIT)
+            // coverage. Gated behind ppgRespRateEnabled (default false) — validated on only 2 real
+            // nights from one low-resp-variance subject, so the shipped RSA-only path stays
+            // byte-identical unless a user opts in; the stream is still persisted unconditionally.
+            val ppgResp = if (ppgRespRateEnabled) repo.ppgRespSamples(owner, from, to, STREAM_LIMIT) else emptyList()
             // #938: the strap family that WROTE this owner's skin-temp rows, so analyzeDay converts the raw
             // register on the right scale (5/MG banks centidegrees, a WHOOP 4.0 v24 banks a raw ADC). The
             // owner source resolves it from the registry; unknown/non-WHOOP owners fall back to WHOOP5 (the

--- a/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
+++ b/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
@@ -495,10 +495,11 @@ object IntelligenceEngine {
             // means on the DailyMetric. Empty on a 5/MG (no v24 spo2 channels) → the raw means stay null.
             val spo2 = repo.spo2Samples(owner, from, to, STREAM_LIMIT)
             // #103: PPG-derived per-burst respiratory rate from the WHOOP 5.0 v26 optical buffer.
-            // analyzeDay prefers this over the R-R/RSA estimate per session when it has enough burst
-            // coverage. Gated behind ppgRespRateEnabled (default false) — validated on only 2 real
-            // nights from one low-resp-variance subject, so the shipped RSA-only path stays
-            // byte-identical unless a user opts in; the stream is still persisted unconditionally.
+            // analyzeDay NEVER lets this override DailyMetric.respRateBpm (always RSA, so the
+            // illness-detection gate never sees an estimator switch) — it only logs a comparison
+            // against RSA when both this array is non-empty AND the diagnostic trace is active. Gated
+            // behind ppgRespRateEnabled (default false) — validated on only 2 real nights from one
+            // low-resp-variance subject. The stream is still persisted unconditionally.
             val ppgResp = if (ppgRespRateEnabled) repo.ppgRespSamples(owner, from, to, STREAM_LIMIT) else emptyList()
             // #938: the strap family that WROTE this owner's skin-temp rows, so analyzeDay converts the raw
             // register on the right scale (5/MG banks centidegrees, a WHOOP 4.0 v24 banks a raw ADC). The

--- a/android/app/src/main/java/com/noop/analytics/ReadinessEngine.kt
+++ b/android/app/src/main/java/com/noop/analytics/ReadinessEngine.kt
@@ -190,16 +190,18 @@ object ReadinessEngine {
         if (rhrSignal != null) signals.add(rhrSignal)
 
         // Respiratory-rate drift (illness early signal) ----------------------
-        // respRateBpm may be a clean cloud value, a higher-variance on-device RSA estimate, OR (#103)
-        // a PPG-derived estimate preferred over RSA per-session when available — and carries no source
-        // flag, so gate conservatively for ALL: keep the minBaseline + sd>0 guard, only act on
-        // physiologically plausible sleeping-RR (~8-25 bpm), and use wider resp-only z thresholds
-        // (WATCH 1.5 / BAD 2.0) so a single noisy night can't reach BAD (which would feed
-        // recoveryDown), while a sustained genuine rise still flags. The WATCH/BAD thresholds were
-        // sized for RSA's noise floor specifically; #103's real-capture validation (n=2 nights)
-        // suggests PPG is tighter, which would make these thresholds conservative on PPG-heavy nights
-        // — not retuned here for lack of data, but worth revisiting once the real-world PPG/RSA mix
-        // ratio is observable.
+        // respRateBpm may be a clean cloud value OR a higher-variance on-device RSA estimate, so gate
+        // conservatively: keep the minBaseline + sd>0 guard, only act on physiologically plausible
+        // sleeping-RR (~8-25 bpm), and use wider resp-only z thresholds (WATCH 1.5 / BAD 2.0) so a
+        // single noisy night can't reach BAD (which would feed recoveryDown), while a sustained
+        // genuine rise still flags.
+        //
+        // #103 explicitly does NOT reach here: an experimental PPG-derived respiratory-rate estimate
+        // exists (SleepStager.respRateFromPpg) but is deliberately never mixed into respRateBpm — a
+        // series that silently switches estimator night to night injects a ~1-1.5 bpm step that alone
+        // can brush the WATCH threshold for a stable sleeper, a false signal from the estimator
+        // flipping, not physiology. This gate only ever sees one consistent estimator (RSA), by
+        // construction, so it doesn't need — and must not be given — provenance.
         val rr = latest.respRateBpm
         if (rr != null && rr in respPlausibleRange) {
             val base = history.takeLast(baselineWindow).mapNotNull { it.respRateBpm }

--- a/android/app/src/main/java/com/noop/analytics/ReadinessEngine.kt
+++ b/android/app/src/main/java/com/noop/analytics/ReadinessEngine.kt
@@ -190,11 +190,16 @@ object ReadinessEngine {
         if (rhrSignal != null) signals.add(rhrSignal)
 
         // Respiratory-rate drift (illness early signal) ----------------------
-        // respRateBpm may be a clean cloud value OR a higher-variance on-device RSA estimate
-        // (WHOOP5 BLE-only) and carries no source flag, so gate conservatively for BOTH: keep the
-        // minBaseline + sd>0 guard, only act on physiologically plausible sleeping-RR (~8-25 bpm),
-        // and use wider resp-only z thresholds (WATCH 1.5 / BAD 2.0) so a single noisy night can't
-        // reach BAD (which would feed recoveryDown), while a sustained genuine rise still flags.
+        // respRateBpm may be a clean cloud value, a higher-variance on-device RSA estimate, OR (#103)
+        // a PPG-derived estimate preferred over RSA per-session when available — and carries no source
+        // flag, so gate conservatively for ALL: keep the minBaseline + sd>0 guard, only act on
+        // physiologically plausible sleeping-RR (~8-25 bpm), and use wider resp-only z thresholds
+        // (WATCH 1.5 / BAD 2.0) so a single noisy night can't reach BAD (which would feed
+        // recoveryDown), while a sustained genuine rise still flags. The WATCH/BAD thresholds were
+        // sized for RSA's noise floor specifically; #103's real-capture validation (n=2 nights)
+        // suggests PPG is tighter, which would make these thresholds conservative on PPG-heavy nights
+        // — not retuned here for lack of data, but worth revisiting once the real-world PPG/RSA mix
+        // ratio is observable.
         val rr = latest.respRateBpm
         if (rr != null && rr in respPlausibleRange) {
             val base = history.takeLast(baselineWindow).mapNotNull { it.respRateBpm }

--- a/android/app/src/main/java/com/noop/analytics/SleepStager.kt
+++ b/android/app/src/main/java/com/noop/analytics/SleepStager.kt
@@ -2,6 +2,7 @@ package com.noop.analytics
 
 import com.noop.data.GravitySample
 import com.noop.data.HrSample
+import com.noop.data.PpgRespSample
 import com.noop.data.RespSample
 import com.noop.data.RrInterval
 import kotlin.math.abs
@@ -1690,6 +1691,48 @@ object SleepStager {
         // Reject estimates outside the canonical consumer band (NaN = "no usable estimate") so the
         // persisted value never silently disagrees with ReadinessEngine's plausibility gate. (#78)
         val median = HrvAnalyzer.median(perWindowRates)
+        return if (median in respPlausibleRangeBpm) median else nan
+    }
+
+    // --- Respiration rate from PPG (issue #103) — WHOOP5 v26 optical path ---
+
+    /** Minimum number of qualifying PPG bursts (see com.noop.protocol.PpgResp) required in-session
+     *  before trusting a PPG-derived respiratory rate at all — below this, too few bursts for a
+     *  stable top-third-by-confidence median. Tied to observed burst density (~20-25 bursts across a
+     *  full ~7-8h night in the 2 validated real captures, not a theoretical minimum) — tunable, not
+     *  sacred. Mirrors the Swift SleepStager.minPpgBurstsForEstimate. */
+    internal const val minPpgBurstsForEstimate = 9
+
+    /**
+     * APPROXIMATE respiratory rate (breaths/min) from the PPG-derived per-burst stream (issue #103,
+     * com.noop.protocol.PpgResp), for use ALONGSIDE respRateFromRR above — see AnalyticsEngine's
+     * prefer-PPG-else-RSA fusion, which tries this first per session and falls back to the RSA
+     * estimate when this returns NaN.
+     *
+     * Validated (n=2 real overnight captures against the WHOOP app's own reading) to land within
+     * 2-6%, vs. respRateFromRR's 6-11% low bias on the SAME nights — but that is thin evidence (one
+     * person, two nights, a person whose own respiratory rate barely moves night to night; see the
+     * #103 discussion), so treat this as a real quality-filtered signal, not a settled ground truth.
+     * v26 PPG coverage is a SPARSE minority of any given night (the strap alternates between v18 and
+     * v26 recording, never both at once), so this returns NaN far more often than respRateFromRR
+     * does — that is expected, not a bug; the fusion falls back to RSA in that case.
+     *
+     * Pipeline: filter samples to [start, end]; require >= minPpgBurstsForEstimate qualifying bursts
+     * else NaN (honest no-data, mirrors respRateFromRR's own too-little-data gate); take the top
+     * third by conf (floor division — a burst's conf is the DSP estimator's own spectral-prominence
+     * quality signal, not re-derived here); return the median of THEIR bpm, not a blend of every
+     * burst, since a low-confidence burst is more likely motion/off-wrist artifact than real
+     * respiratory signal. Mirrors the Swift SleepStager.respRateFromPpg value-for-value.
+     */
+    internal fun respRateFromPpg(samples: List<PpgRespSample>, start: Long, end: Long): Double {
+        val nan = Double.NaN
+        if (end <= start) return nan
+        val inWindow = samples.filter { it.ts in start..end }
+        if (inWindow.size < minPpgBurstsForEstimate) return nan
+        val topThird = inWindow.sortedByDescending { it.conf }.take(maxOf(1, inWindow.size / 3))
+        val median = HrvAnalyzer.median(topThird.map { it.bpm })
+        // Same canonical-band reject as respRateFromRR, so a fused value never silently disagrees
+        // with ReadinessEngine's plausibility gate regardless of which estimator produced it.
         return if (median in respPlausibleRangeBpm) median else nan
     }
 

--- a/android/app/src/main/java/com/noop/ble/PuffinExperiment.kt
+++ b/android/app/src/main/java/com/noop/ble/PuffinExperiment.kt
@@ -95,6 +95,26 @@ class PuffinExperiment(private val prefs: SharedPreferences) {
         get() = prefs.getBoolean(KEY_MOTION_AWARE_WAKE, false)
         set(v) = prefs.edit().putBoolean(KEY_MOTION_AWARE_WAKE, v).apply()
 
+    /** True if the user opted in to the "PPG-derived respiratory rate diagnostic" (default false,
+     *  #103): a spectral estimate off the WHOOP5 v26 optical PPG buffer
+     *  ([com.noop.protocol.PpgResp], top-confidence-burst aggregation), compared against the shipped
+     *  R-R/RSA estimate ([com.noop.analytics.SleepStager.respRateFromRR]) purely for a diagnostic log
+     *  line — it NEVER overrides `DailyMetric.respRateBpm` or reaches the ReadinessEngine
+     *  illness-detection signal, which always reads RSA only. (An earlier version of this preferred
+     *  PPG when available; per #103 review, a persisted value that silently switches estimator night
+     *  to night can inject a step large enough to brush the illness WATCH threshold on its own — a
+     *  false signal from the estimator flipping, not physiology. So the comparison stays diagnostic.)
+     *  Validated on only 2 real overnight captures from ONE subject whose own night-to-night
+     *  respiratory rate barely moves (stdev ~0.56 bpm) — exactly the single-stable-night validation
+     *  trap the project's derived-biosignal standard warns about. Default false means the comparison
+     *  is never computed; the app-layer call site ([com.noop.analytics.IntelligenceEngine]) reads this
+     *  flag and only supplies the real ppgResp stream to `analyzeDay` when it's on. `ppgResp` is still
+     *  decoded + persisted (`ppgRespSample`) unconditionally as instrumentation regardless of this
+     *  flag. Mirrors the macOS `PuffinExperiment.ppgRespRateKey`. */
+    var ppgRespRate: Boolean
+        get() = prefs.getBoolean(KEY_PPG_RESP_RATE, false)
+        set(v) = prefs.edit().putBoolean(KEY_PPG_RESP_RATE, v).apply()
+
     companion object {
         /** Persisted preferences file. */
         private const val PREFS = "noop_experiments"
@@ -122,6 +142,9 @@ class PuffinExperiment(private val prefs: SharedPreferences) {
 
         /** "Motion-aware wake refinement" opt-in (mirrors macOS `PuffinExperiment.motionAwareWakeKey`). */
         const val KEY_MOTION_AWARE_WAKE = "noopMotionAwareWake"
+
+        /** "PPG-derived respiratory rate" opt-in (mirrors macOS `PuffinExperiment.ppgRespRateKey`). */
+        const val KEY_PPG_RESP_RATE = "noopPpgRespRate"
 
         fun from(context: Context): PuffinExperiment =
             PuffinExperiment(context.getSharedPreferences(PREFS, Context.MODE_PRIVATE))

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -1657,6 +1657,8 @@ class WhoopBleClient(
                         useExperimentalSleepV2 = PuffinExperiment.from(context).experimentalSleepV2,
                         // Opt-in motion-aware wake refinement (#364 follow-up) — same Context-free threading.
                         useMotionAwareWake = PuffinExperiment.from(context).motionAwareWake,
+                        // Opt-in "PPG-derived respiratory rate" diagnostic (#103) — same Context-free-layer pattern.
+                        ppgRespRateEnabled = PuffinExperiment.from(context).ppgRespRate,
                         // Sleep & Rest test mode (Test Centre E5): when the SLEEP domain is on, route this
                         // post-backfill pass's per-day sleep gate trace into the .sleep-tagged strap log, so a
                         // shared report carries the staging proof from THIS scoring pass too, not only the UI

--- a/android/app/src/main/java/com/noop/data/DeviceRegistry.kt
+++ b/android/app/src/main/java/com/noop/data/DeviceRegistry.kt
@@ -80,10 +80,11 @@ class DeviceRegistry(
      * delete-data op empties recordings; archiving/removing the registry entry is a separate op (I4).
      *
      * The table set is EVERY device-keyed table of [WhoopDatabase]: hrSample, rrInterval, spo2Sample,
-     * skinTempSample, respSample, gravitySample, stepSample, ppgHrSample, ppgWaveformSample, event, battery, dailyMetric,
-     * sleepSession, journal, workout, appleDaily, metricSeries, dayOwnership, sleepStateSample, labMarker,
-     * liveSession, dismissedWorkout, dismissedSleep. DeviceRegistryTest.deleteDeviceDataCallsEveryDaoDeleteMethod
-     * guards completeness (fails if a delete*For DAO method isn't wired in here).
+     * skinTempSample, respSample, gravitySample, stepSample, ppgHrSample, ppgWaveformSample,
+     * ppgRespSample, event, battery, dailyMetric, sleepSession, journal, workout, appleDaily,
+     * metricSeries, dayOwnership, sleepStateSample, labMarker, liveSession, dismissedWorkout,
+     * dismissedSleep. DeviceRegistryTest.deleteDeviceDataCallsEveryDaoDeleteMethod guards
+     * completeness (fails if a delete*For DAO method isn't wired in here).
      */
     suspend fun deleteDeviceData(id: String) {
         transactor.run {
@@ -96,6 +97,7 @@ class DeviceRegistry(
             dao.deleteStepsFor(id)
             dao.deletePpgHrFor(id)
             dao.deletePpgWaveformFor(id)
+            dao.deletePpgRespFor(id)
             dao.deleteEventsFor(id)
             dao.deleteBatteryFor(id)
             dao.deleteDailyMetricsFor(id)

--- a/android/app/src/main/java/com/noop/data/DeviceRegistryDao.kt
+++ b/android/app/src/main/java/com/noop/data/DeviceRegistryDao.kt
@@ -71,6 +71,7 @@ interface DeviceRegistryDao {
     @Query("DELETE FROM stepSample WHERE deviceId = :deviceId") suspend fun deleteStepsFor(deviceId: String)
     @Query("DELETE FROM ppgHrSample WHERE deviceId = :deviceId") suspend fun deletePpgHrFor(deviceId: String)
     @Query("DELETE FROM ppgWaveformSample WHERE deviceId = :deviceId") suspend fun deletePpgWaveformFor(deviceId: String)
+    @Query("DELETE FROM ppgRespSample WHERE deviceId = :deviceId") suspend fun deletePpgRespFor(deviceId: String)
     @Query("DELETE FROM event WHERE deviceId = :deviceId") suspend fun deleteEventsFor(deviceId: String)
     @Query("DELETE FROM battery WHERE deviceId = :deviceId") suspend fun deleteBatteryFor(deviceId: String)
     @Query("DELETE FROM dailyMetric WHERE deviceId = :deviceId") suspend fun deleteDailyMetricsFor(deviceId: String)

--- a/android/app/src/main/java/com/noop/data/Entities.kt
+++ b/android/app/src/main/java/com/noop/data/Entities.kt
@@ -68,6 +68,23 @@ data class PpgHrSample(
     val synced: Int = 0,
 )
 
+/**
+ * Respiratory rate derived from the SAME WHOOP 5/MG **v26** optical PPG buffer `ppgHrSample` above
+ * already reads (#103). Own table, same rationale as `ppgHrSample`: never conflated with the strap's
+ * own resp_rate_raw (`respSample`, WHOOP4-only — the two streams never overlap on a given device).
+ * [bpm] is REAL and NOT rounded (unlike `ppgHrSample.bpm`, which rounds to whole HR) — respiratory-
+ * rate precision at ~14-15 bpm is the point. PK (deviceId, ts) = one estimate per burst-start second.
+ * Deliberately WITHOUT the vestigial `synced` column `ppgHrSample` carries (added for a
+ * since-removed server-upload feature — not propagated into a new table). v18_19 migration.
+ */
+@Entity(tableName = "ppgRespSample", primaryKeys = ["deviceId", "ts"])
+data class PpgRespSample(
+    val deviceId: String,
+    val ts: Long,
+    val bpm: Double,
+    val conf: Double,
+)
+
 /** One downsampled HR point, the bucket's start (unix seconds) + the mean bpm over it. Query
  *  result of [WhoopDao.hrBuckets], not a table. Mirrors the macOS `HRBucket`. */
 data class HrBucket(

--- a/android/app/src/main/java/com/noop/data/WhoopDao.kt
+++ b/android/app/src/main/java/com/noop/data/WhoopDao.kt
@@ -87,6 +87,10 @@ interface WhoopDao : DeviceRegistryDao {
     @Insert(onConflict = OnConflictStrategy.IGNORE)
     suspend fun insertPpgWaveform(rows: List<PpgWaveformSampleEntity>): List<Long>
 
+    /** PPG-derived respiratory rate from the SAME v26 optical waveform. Idempotent by (deviceId, ts). (#103) */
+    @Insert(onConflict = OnConflictStrategy.IGNORE)
+    suspend fun insertPpgResp(rows: List<PpgRespSample>): List<Long>
+
     // MARK: - Server-derived caches (latest value wins)
 
     @Upsert
@@ -235,6 +239,14 @@ interface WhoopDao : DeviceRegistryDao {
     )
     suspend fun ppgWaveformSamples(deviceId: String, from: Long, to: Long, limit: Int):
         List<PpgWaveformSampleEntity>
+
+    /** Raw v26 PPG-derived respiratory-rate samples in [from, to] (ascending), own stream — never
+     *  COALESCEd with `respSample`. (#103) */
+    @Query(
+        "SELECT * FROM ppgRespSample WHERE deviceId = :deviceId AND ts >= :from AND ts <= :to " +
+            "ORDER BY ts ASC LIMIT :limit"
+    )
+    suspend fun ppgRespSamples(deviceId: String, from: Long, to: Long, limit: Int): List<PpgRespSample>
 
     /** Aggregate HR over a window (one indexed (deviceId,ts) range scan — no row materialisation,
      *  no [hrSamples] LIMIT truncation). Backs the imported-workout HR fallback (#77). */
@@ -703,6 +715,9 @@ interface WhoopDao : DeviceRegistryDao {
 
     @Query("DELETE FROM ppgHrSample WHERE ts < :minTs OR ts > :maxTs")
     suspend fun prunePpgHrByTs(minTs: Long, maxTs: Long): Int
+
+    @Query("DELETE FROM ppgRespSample WHERE ts < :minTs OR ts > :maxTs")
+    suspend fun prunePpgRespByTs(minTs: Long, maxTs: Long): Int
 
     @Query("DELETE FROM rrInterval WHERE ts < :minTs OR ts > :maxTs")
     suspend fun pruneRrByTs(minTs: Long, maxTs: Long): Int

--- a/android/app/src/main/java/com/noop/data/WhoopDatabase.kt
+++ b/android/app/src/main/java/com/noop/data/WhoopDatabase.kt
@@ -48,8 +48,9 @@ import androidx.sqlite.db.SupportSQLiteDatabase
         LabMarkerRow::class,
         LiveSessionRow::class,
         PpgWaveformSampleEntity::class,
+        PpgRespSample::class,
     ],
-    version = 20,
+    version = 21,
     exportSchema = false,
 )
 abstract class WhoopDatabase : RoomDatabase() {
@@ -502,11 +503,6 @@ abstract class WhoopDatabase : RoomDatabase() {
          * cross-platform parity contract (stored data must be byte-identical) needs the heal on both
          * platforms, not just the write-boundary fix.
          *
-         * SEQUENCING CAVEAT: this claims Room version 18 -> 19 as the next free slot as of this PR. The
-         * Swift v26 GRDB slot has the identical collision risk against other pending PRs (flagged in the
-         * same review) — if another pending PR also lands a Room migration first, whichever merges
-         * SECOND must renumber. Coordinate before merging both.
-         *
          * The SQL is exposed as [EFFICIENCY_HEAL_MIGRATION_SQL] so a plain-JVM unit test
          * ([com.noop.data.EfficiencyHealMigrationTest]) can pin this shape without Robolectric.
          */
@@ -547,9 +543,40 @@ abstract class WhoopDatabase : RoomDatabase() {
                 "`ts` INTEGER NOT NULL, `samples` BLOB NOT NULL, PRIMARY KEY(`deviceId`, `ts`))",
         )
 
+        /**
+         * v20 -> v21: ADDITIVE, adds the `ppgRespSample` table (#103): respiratory rate DERIVED FROM
+         * the same WHOOP 5/MG v26 optical PPG buffer the v19->v20 `ppgWaveformSample` table above now
+         * stores raw and `ppgHrSample` (v5_6) reads for HR — three streams off one buffer, each in its
+         * own table. Same rationale as v5_6: never conflated with the strap's own resp_rate_raw
+         * (`respSample`, WHOOP4-only — the two never overlap on a given device). `bpm` is REAL and NOT
+         * rounded (unlike `ppgHrSample.bpm`, which rounds to whole HR) — respiratory-rate precision
+         * at ~14-15 bpm is the point. CREATE TABLE only (no existing data touched). The SQL MUST match
+         * Room's generated schema for [PpgRespSample] exactly, every column NOT NULL, composite
+         * PRIMARY KEY (deviceId, ts) in declaration order, and deliberately WITHOUT a `synced` column
+         * (that field on `ppgHrSample` is vestigial, added for a since-removed server-upload feature —
+         * not propagated here). Exposed as [PPG_RESP_SAMPLE_MIGRATION_SQL] so a plain-JVM unit test
+         * can pin the shape without Robolectric.
+         *
+         * SEQUENCING: renumbered v18->v19 → v19->v20 → v20->v21 as efficiency-heal and then
+         * ppg-waveform took the slot first; the GRDB twin is `v28-ppg-resp-sample` (Swift's next slot
+         * after v27-ppg-waveform), so the two platforms' migration counts stay aligned. The #103
+         * review's coordination note called this collision.
+         */
+        internal val PPG_RESP_SAMPLE_MIGRATION_SQL: List<String> = listOf(
+            "CREATE TABLE IF NOT EXISTS `ppgRespSample` (`deviceId` TEXT NOT NULL, " +
+                "`ts` INTEGER NOT NULL, `bpm` REAL NOT NULL, `conf` REAL NOT NULL, " +
+                "PRIMARY KEY(`deviceId`, `ts`))",
+        )
+
         internal val MIGRATION_19_20 = object : Migration(19, 20) {
             override fun migrate(db: SupportSQLiteDatabase) {
                 for (stmt in PPG_WAVEFORM_MIGRATION_SQL) db.execSQL(stmt)
+            }
+        }
+
+        internal val MIGRATION_20_21 = object : Migration(20, 21) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                for (stmt in PPG_RESP_SAMPLE_MIGRATION_SQL) db.execSQL(stmt)
             }
         }
 
@@ -568,7 +595,7 @@ abstract class WhoopDatabase : RoomDatabase() {
                     MIGRATION_5_6, MIGRATION_6_7, MIGRATION_7_8, MIGRATION_8_9, MIGRATION_9_10,
                     MIGRATION_10_11, MIGRATION_11_12, MIGRATION_12_13, MIGRATION_13_14,
                     MIGRATION_14_15, MIGRATION_15_16, MIGRATION_16_17, MIGRATION_17_18,
-                    MIGRATION_18_19, MIGRATION_19_20,
+                    MIGRATION_18_19, MIGRATION_19_20, MIGRATION_20_21,
                 )
                 // #1037: a FRESH install builds the schema straight at the current version and runs NO
                 // migrations, so the MIGRATION_7_8 "my-whoop" registry seed never fires and the WHOOP,

--- a/android/app/src/main/java/com/noop/data/WhoopRepository.kt
+++ b/android/app/src/main/java/com/noop/data/WhoopRepository.kt
@@ -32,6 +32,9 @@ data class StreamBatch(
     val sleepState: List<SleepStateRow> = emptyList(),
     /** HR derived from the WHOOP 5/MG v26 optical PPG waveform (autocorrelation). (#156) */
     val ppgHr: List<PpgHrRow> = emptyList(),
+    /** Respiratory rate derived from the SAME v26 optical PPG buffer as [ppgHr] (#103), one estimate
+     *  per ~40s burst rather than per-second. */
+    val ppgResp: List<PpgRespRow> = emptyList(),
     /**
      * The RAW WHOOP 5/MG v26 optical PPG waveform itself, one record per second (#156 follow-up) — the
      * 24 Hz samples [ppgHr] is derived FROM. Kept separate so a consumer that only wants the HR estimate
@@ -64,7 +67,8 @@ data class StreamBatch(
     val isEmpty: Boolean
         get() = hr.isEmpty() && rr.isEmpty() && events.isEmpty() && battery.isEmpty() &&
             spo2.isEmpty() && skinTemp.isEmpty() && resp.isEmpty() && gravity.isEmpty() &&
-            steps.isEmpty() && sleepState.isEmpty() && ppgHr.isEmpty() && ppgWaveform.isEmpty()
+            steps.isEmpty() && sleepState.isEmpty() && ppgHr.isEmpty() && ppgWaveform.isEmpty() &&
+            ppgResp.isEmpty()
 }
 
 // Device-agnostic decoded rows (deviceId attached when inserted). Mirror Streams.swift shapes.
@@ -123,6 +127,9 @@ data class PpgHrRow(val ts: Long, val bpm: Int, val conf: Double)
  * attached on insert; the samples are packed to a little-endian i16 BLOB by [StreamPersistence.packPpgSamples].
  */
 data class PpgWaveformRow(val ts: Long, val samples: List<Int>)
+/** Respiratory rate derived from the SAME v26 PPG waveform: [ts] burst-start sec, [bpm] NOT rounded,
+ *  [conf] = spectral prominence. (#103) */
+data class PpgRespRow(val ts: Long, val bpm: Double, val conf: Double)
 
 /** Count of rows ACTUALLY inserted per stream (mirrors WhoopStore.insert return tuple). */
 data class InsertCounts(
@@ -263,6 +270,11 @@ class WhoopRepository(private val dao: WhoopDao) {
                     PpgWaveformSampleEntity(deviceId, it.ts, StreamPersistence.packPpgSamples(it.samples))
                 },
             )
+        }
+        // v26 PPG-derived respiratory rate (#103). Persist-only, same as ppgHr's own precedent — not
+        // added to InsertCounts (no consumer reads a count for it); idempotent by (deviceId, ts).
+        if (streams.ppgResp.isNotEmpty()) {
+            dao.insertPpgResp(streams.ppgResp.map { PpgRespSample(deviceId, it.ts, it.bpm, it.conf) })
         }
 
         // OnConflictStrategy.IGNORE returns -1 for skipped (already-present) rows; count the inserts.
@@ -411,6 +423,7 @@ class WhoopRepository(private val dao: WhoopDao) {
         // (a) raw streams (all keyed by ts)
         deleted += dao.pruneHrByTs(minTs, maxTs)
         deleted += dao.prunePpgHrByTs(minTs, maxTs)
+        deleted += dao.prunePpgRespByTs(minTs, maxTs)
         deleted += dao.pruneRrByTs(minTs, maxTs)
         deleted += dao.pruneSkinTempByTs(minTs, maxTs)
         deleted += dao.pruneStepByTs(minTs, maxTs)
@@ -589,6 +602,11 @@ class WhoopRepository(private val dao: WhoopDao) {
         List<PpgWaveformRow> =
         dao.ppgWaveformSamples(deviceId, from, to, limit)
             .map { PpgWaveformRow(it.ts, StreamPersistence.unpackPpgSamples(it.samples)) }
+
+    /** v26 PPG-derived respiratory-rate samples (own stream), consumed as its own distinct list by
+     *  SleepStager.respRateFromPpg's fusion — never merged with the R-R/RSA stream. (#103) */
+    suspend fun ppgRespSamples(deviceId: String, from: Long, to: Long, limit: Int = DEFAULT_LIMIT) =
+        dao.ppgRespSamples(deviceId, from, to, limit)
 
     /** Downsampled HR (mean bpm per [bucketSeconds]) for the strap, for the Today 24h trend chart. */
     suspend fun hrBuckets(deviceId: String, from: Long, to: Long, bucketSeconds: Long = 300L) =

--- a/android/app/src/main/java/com/noop/protocol/HistoricalStreams.kt
+++ b/android/app/src/main/java/com/noop/protocol/HistoricalStreams.kt
@@ -5,6 +5,7 @@ import com.noop.data.EventEntry
 import com.noop.data.GravityRow
 import com.noop.data.HrRow
 import com.noop.data.PpgHrRow
+import com.noop.data.PpgRespRow
 import com.noop.data.PpgWaveformRow
 import com.noop.data.RespRow
 import com.noop.data.RrRow
@@ -735,6 +736,9 @@ fun extractHistoricalStreams(
     // unless the strap sent v26 records; falls back gracefully (no rows) on noise (#156).
     val ppgHr = PpgHr.estimate(ppgSamples, subLagInterp = ppgHrSubLagInterp)
         .map { PpgHrRow(ts = it.ts, bpm = it.bpm, conf = it.conf) }
+    // Derive respiratory rate from the SAME accumulated v26 PPG waveform (#103) — no new buffering,
+    // reuses ppgSamples. Empty under the same conditions as ppgHr above.
+    val ppgResp = PpgResp.deriveRespRate(ppgSamples).map { PpgRespRow(ts = it.ts, bpm = it.bpm, conf = it.conf) }
 
     return StreamBatch(
         hr = hr, rr = rr, events = events, battery = battery,
@@ -742,6 +746,7 @@ fun extractHistoricalStreams(
         sleepState = sleepState,
         ppgHr = ppgHr,
         ppgWaveform = ppgWaveform,
+        ppgResp = ppgResp,
         droppedImplausibleTs = droppedImplausible,
         droppedImplausibleOldestTs = droppedOldest,   // #324 poisoned-range epoch span (diag only)
         droppedImplausibleNewestTs = droppedNewest,

--- a/android/app/src/main/java/com/noop/protocol/PpgResp.kt
+++ b/android/app/src/main/java/com/noop/protocol/PpgResp.kt
@@ -1,0 +1,195 @@
+package com.noop.protocol
+
+import kotlin.math.PI
+import kotlin.math.cos
+import kotlin.math.sin
+
+/**
+ * Respiratory rate derived from the WHOOP 5.0 type-47 **v26** optical PPG buffer (issue #103).
+ *
+ * v26 records carry a single-wavelength 24 Hz PPG waveform (see [PpgHr] for the per-second HR
+ * sibling estimator on the same buffer). Breathing modulates that waveform two ways — amplitude
+ * (RIAV, respiratory-induced amplitude variation) and baseline (RIIV, respiratory-induced intensity
+ * variation) — so a spectral peak in the respiratory band (0.15-0.40 Hz = 9-24 breaths/min) recovers
+ * the rate without needing a second wavelength (SpO2 is NOT derivable this way — confirmed no second
+ * channel exists on v26, see the #103 discussion).
+ *
+ * v26 records arrive in ~40 s bursts: the strap alternates, over the course of a night, between v18
+ * per-second summaries and v26 raw-PPG stretches — never both at once — so v26 coverage is a sparse
+ * minority of any given night. One estimate is produced per consecutive-second run (a "burst"), not
+ * per second like [PpgHr], since resolving 0.15 Hz needs the whole burst, not a sliding window.
+ *
+ * Validated against 2 real overnight captures against the WHOOP app's own respiratory-rate reading:
+ * landed within 2-6% using top-confidence-burst aggregation (see
+ * com.noop.analytics.SleepStager.respRateFromPpg), vs. the existing R-R/RSA-based estimator's 6-11%
+ * low bias on the same nights. That is thin evidence — one person, two nights, a person whose own
+ * night-to-night respiratory rate barely moves — so treat [Estimate.conf] as a real per-burst quality
+ * filter, not a reason to trust any single burst in isolation.
+ *
+ * Byte-for-byte mirror of the Swift estimator (WhoopProtocol/PpgResp.swift, #219-style parity), reusing
+ * [PpgHr.Sample] as the input type since [PpgHr] and [PpgResp] consume the SAME accumulated v26
+ * waveform buffer during historical-stream extraction.
+ */
+object PpgResp {
+    /** v26 carries 24 samples per 1-second record. */
+    const val SAMPLE_RATE_HZ = 24
+
+    /** Reject a run shorter than this many one-second records (~1.33 s short of a full ~40 s burst) —
+     *  too little data to resolve 0.15 Hz cleanly, so no fabricated estimate from a truncated burst. */
+    const val MIN_BURST_RECORDS = 32
+
+    const val RESP_LO_HZ = 0.15 // 9 breaths/min
+    const val RESP_HI_HZ = 0.40 // 24 breaths/min
+
+    /** ~1 s sliding window for the RIAV amplitude envelope. */
+    const val ENVELOPE_WINDOW_SAMPLES = 24
+
+    /** ~1 s causal moving-average window for the RIIV baseline. */
+    const val BASELINE_WINDOW_SAMPLES = 24
+
+    /** ~12.5 s causal moving-average window subtracted for the high-pass detrend ahead of the
+     *  spectral search — removes sub-~0.08 Hz drift (perfusion/posture, not breathing). */
+    const val DETREND_WINDOW_SAMPLES = 300
+
+    /** Frequency step (Hz) for the band scan below — 0.004 Hz = 0.24 breaths/min resolution. */
+    const val RESP_FREQ_STEP_HZ = 0.004
+
+    /** Reject a burst whose best channel's peak isn't at least this many times the band's median
+     *  power — a flat/noisy burst must not fabricate a rate. Mirrors [PpgHr.MIN_CONFIDENCE]'s role;
+     *  set well below every real-capture burst observed so far (min ~2.0 across 57 real bursts from
+     *  2 nights) while still rejecting a genuinely flat band (prominence 1.0 = no peak at all). */
+    const val MIN_PROMINENCE = 1.5
+
+    /** A derived respiratory-rate estimate: [ts] = the burst's FIRST record second, [bpm] (NOT
+     *  rounded — unlike PpgHr's whole-bpm convention, resp-rate precision at ~14-15 bpm is the point),
+     *  [conf] = spectral prominence (peak band-power / median band-power). */
+    data class Estimate(val ts: Long, val bpm: Double, val conf: Double)
+
+    /** Causal (trailing) moving average with window [w] samples; window shrinks at the start rather
+     *  than padding, so the first w-1 outputs are a partial mean, not zero-biased. */
+    private fun movingAverage(x: DoubleArray, w: Int): DoubleArray {
+        if (w <= 1 || x.isEmpty()) return x
+        val out = DoubleArray(x.size)
+        var sum = 0.0
+        val win = ArrayDeque<Double>()
+        for (i in x.indices) {
+            win.addLast(x[i]); sum += x[i]
+            if (win.size > w) sum -= win.removeFirst()
+            out[i] = sum / win.size
+        }
+        return out
+    }
+
+    /** High-pass detrend: subtract a [window]-sample causal moving average. */
+    private fun highPassDetrend(x: DoubleArray, window: Int): DoubleArray {
+        val m = movingAverage(x, window)
+        return DoubleArray(x.size) { x[it] - m[it] }
+    }
+
+    /** Sliding amplitude envelope (max-min) over a `±window/2`-sample neighbourhood — the RIAV signal. */
+    private fun amplitudeEnvelope(x: DoubleArray, window: Int): DoubleArray {
+        if (x.isEmpty()) return x
+        val half = window / 2
+        return DoubleArray(x.size) { i ->
+            val lo = maxOf(0, i - half)
+            val hi = minOf(x.size, i + half)
+            var mn = x[lo]; var mx = x[lo]
+            for (j in lo until hi) { if (x[j] < mn) mn = x[j]; if (x[j] > mx) mx = x[j] }
+            mx - mn
+        }
+    }
+
+    /**
+     * Direct-DFT power spectrum over [loHz, hiHz] on a DC-removed, uniformly-sampled ([fs] Hz)
+     * signal, scanned at a FIXED [RESP_FREQ_STEP_HZ] step rather than bin-quantized to the burst's
+     * own length: a single ~40 s burst is only ~960 samples, so its native DFT bin spacing
+     * (fs/n ≈ 1.5 breaths/min) is too coarse to report a meaningful rate. Evaluating the direct-sum
+     * DTFT at a fixed step instead (independent of n) is still cheap — ~63 frequencies × n samples
+     * for the full band — and matches the resolution of the validated Python proof-of-concept this
+     * mirrors. Returns the peak's (frequencyHz, power/medianPower), or null when degenerate.
+     */
+    private fun bandPeak(x: DoubleArray, fs: Double, loHz: Double, hiHz: Double): Pair<Double, Double>? {
+        val n = x.size
+        if (n <= 1 || hiHz <= loHz) return null
+        var mean = 0.0
+        for (v in x) mean += v
+        mean /= n
+        val centered = DoubleArray(n) { x[it] - mean }
+        val freqs = ArrayList<Double>()
+        val powers = ArrayList<Double>()
+        var f = loHz
+        while (f <= hiHz) {
+            val w = -2.0 * PI * f / fs
+            var re = 0.0; var im = 0.0
+            for (j in 0 until n) {
+                val a = w * j
+                re += centered[j] * cos(a)
+                im += centered[j] * sin(a)
+            }
+            freqs.add(f)
+            powers.add(re * re + im * im)
+            f += RESP_FREQ_STEP_HZ
+        }
+        if (powers.isEmpty()) return null
+        var peakIdx = 0
+        for (i in powers.indices) if (powers[i] > powers[peakIdx]) peakIdx = i
+        val median = powers.sorted()[powers.size / 2]
+        if (median <= 0.0) return null
+        return freqs[peakIdx] to (powers[peakIdx] / median)
+    }
+
+    /**
+     * Estimate (breaths/min, confidence) for one burst's raw samples via the higher-prominence of
+     * the RIAV (amplitude envelope) / RIIV (baseline) spectral peak, or null when the burst is too
+     * short, neither channel clears the band, or the best peak doesn't clear [MIN_PROMINENCE]
+     * (flat/garbage PPG → no fabricated respiratory rate).
+     */
+    internal fun estimate(samples: List<Int>, fs: Int = SAMPLE_RATE_HZ): Pair<Double, Double>? {
+        if (samples.size < MIN_BURST_RECORDS * fs) return null
+        val x = DoubleArray(samples.size) { samples[it].toDouble() }
+        val riav = highPassDetrend(amplitudeEnvelope(x, ENVELOPE_WINDOW_SAMPLES), DETREND_WINDOW_SAMPLES)
+        val riiv = highPassDetrend(movingAverage(x, BASELINE_WINDOW_SAMPLES), DETREND_WINDOW_SAMPLES)
+        val fsD = fs.toDouble()
+        val a = bandPeak(riav, fsD, RESP_LO_HZ, RESP_HI_HZ)
+        val b = bandPeak(riiv, fsD, RESP_LO_HZ, RESP_HI_HZ)
+        val best = when {
+            a != null && b != null -> if (a.second >= b.second) a else b
+            a != null -> a
+            b != null -> b
+            else -> null
+        } ?: return null
+        if (best.second < MIN_PROMINENCE) return null
+        return (best.first * 60) to best.second
+    }
+
+    /**
+     * One respiratory-rate estimate per ~40 s v26 burst (a consecutive-second run of records) — NOT
+     * per-second like [PpgHr.estimate], since resolving 0.15 Hz needs the whole burst. [Estimate.ts]
+     * is the run's FIRST record timestamp. [samples] may be unsorted / contain gaps (mirror of
+     * [PpgHr.estimate]'s own grouping).
+     */
+    fun deriveRespRate(samples: List<PpgHr.Sample>): List<Estimate> {
+        if (samples.isEmpty()) return emptyList()
+        val secs = LinkedHashMap<Long, ArrayList<Int>>()
+        for (s in samples) secs.getOrPut(s.ts) { ArrayList() }.add(s.value)
+        val order = secs.keys.sorted()
+
+        val runs = ArrayList<ArrayList<Long>>()
+        var cur = arrayListOf(order[0])
+        for (i in 1 until order.size) {
+            val u = order[i]
+            if (u - cur.last() == 1L) cur.add(u) else { runs.add(cur); cur = arrayListOf(u) }
+        }
+        runs.add(cur)
+
+        val out = ArrayList<Estimate>()
+        for (run in runs) {
+            if (run.size < MIN_BURST_RECORDS) continue
+            val sig = ArrayList<Int>()
+            for (t in run) sig.addAll(secs[t]!!)
+            estimate(sig)?.let { (bpm, conf) -> out.add(Estimate(ts = run[0], bpm = bpm, conf = conf)) }
+        }
+        out.sortBy { it.ts }
+        return out
+    }
+}

--- a/android/app/src/main/java/com/noop/protocol/PpgResp.kt
+++ b/android/app/src/main/java/com/noop/protocol/PpgResp.kt
@@ -51,8 +51,25 @@ object PpgResp {
      *  spectral search — removes sub-~0.08 Hz drift (perfusion/posture, not breathing). */
     const val DETREND_WINDOW_SAMPLES = 300
 
-    /** Frequency step (Hz) for the band scan below — 0.004 Hz = 0.24 breaths/min resolution. */
+    /** Frequency step (Hz) for the band scan below. Does NOT itself add resolution beyond a ~40 s
+     *  burst's native ~0.025 Hz (~1.5 breaths/min) DFT bin spacing (fs/n) — it only interpolates the
+     *  direct-sum DTFT more finely between those bins, avoiding the ~1.5 bpm quantization steps a
+     *  bin-quantized search would report. Matches the step used by the validated Python
+     *  proof-of-concept this mirrors. */
     const val RESP_FREQ_STEP_HZ = 0.004
+
+    /** Reject a peak found within this many Hz of the band edge (loHz/hiHz) — a real breathing peak
+     *  is a local maximum with power falling off on both sides, but low-frequency drift (perfusion/
+     *  posture) that leaked past the high-pass detrend has power that only INCREASES toward 0 Hz, so
+     *  within a bounded search it deterministically "wins" at whichever edge is closest to 0 Hz
+     *  regardless of real physiology. Confirmed on real data (#103 review): without this guard,
+     *  32%/15% of bursts across the two validation nights landed exactly at the band floor (9
+     *  breaths/min) — far more than plausible slow breathing — and top-confidence-burst aggregation
+     *  was measurably CLOSER to the WHOOP app's ground truth with the guard than without it (14.52 vs
+     *  14.04 breaths/min against a 14.6 truth). A rejected edge peak returns null for that channel
+     *  (RIAV or RIIV), same honest-no-data handling as everywhere else in this estimator. Mirrors the
+     *  Swift PpgResp.bandEdgeGuardHz. */
+    const val BAND_EDGE_GUARD_HZ = 0.02
 
     /** Reject a burst whose best channel's peak isn't at least this many times the band's median
      *  power — a flat/noisy burst must not fabricate a rate. Mirrors [PpgHr.MIN_CONFIDENCE]'s role;
@@ -102,11 +119,9 @@ object PpgResp {
     /**
      * Direct-DFT power spectrum over [loHz, hiHz] on a DC-removed, uniformly-sampled ([fs] Hz)
      * signal, scanned at a FIXED [RESP_FREQ_STEP_HZ] step rather than bin-quantized to the burst's
-     * own length: a single ~40 s burst is only ~960 samples, so its native DFT bin spacing
-     * (fs/n ≈ 1.5 breaths/min) is too coarse to report a meaningful rate. Evaluating the direct-sum
-     * DTFT at a fixed step instead (independent of n) is still cheap — ~63 frequencies × n samples
-     * for the full band — and matches the resolution of the validated Python proof-of-concept this
-     * mirrors. Returns the peak's (frequencyHz, power/medianPower), or null when degenerate.
+     * own length (see that constant's doc for why). Returns the peak's (frequencyHz,
+     * power/medianPower), or null when the signal/band is degenerate or the peak falls within
+     * [BAND_EDGE_GUARD_HZ] of an edge (see that constant's doc).
      */
     private fun bandPeak(x: DoubleArray, fs: Double, loHz: Double, hiHz: Double): Pair<Double, Double>? {
         val n = x.size
@@ -135,7 +150,9 @@ object PpgResp {
         for (i in powers.indices) if (powers[i] > powers[peakIdx]) peakIdx = i
         val median = powers.sorted()[powers.size / 2]
         if (median <= 0.0) return null
-        return freqs[peakIdx] to (powers[peakIdx] / median)
+        val peakHz = freqs[peakIdx]
+        if (peakHz < loHz + BAND_EDGE_GUARD_HZ || peakHz > hiHz - BAND_EDGE_GUARD_HZ) return null
+        return peakHz to (powers[peakIdx] / median)
     }
 
     /**

--- a/android/app/src/main/java/com/noop/ui/AppViewModel.kt
+++ b/android/app/src/main/java/com/noop/ui/AppViewModel.kt
@@ -798,6 +798,8 @@ class AppViewModel(app: Application) : AndroidViewModel(app) {
                         useExperimentalSleepV2 = PuffinExperiment.from(appContext).experimentalSleepV2,
                         // Opt-in motion-aware wake refinement (#364 follow-up) — same Context-free threading.
                         useMotionAwareWake = PuffinExperiment.from(appContext).motionAwareWake,
+                        // Opt-in "PPG-derived respiratory rate" diagnostic (#103) — same Context-free-layer pattern.
+                        ppgRespRateEnabled = PuffinExperiment.from(appContext).ppgRespRate,
                         // Sleep & Rest test mode (Test Centre E5): when the SLEEP domain is on, route the
                         // per-day sleep gate trace into the SAME shareable strap log, tagged .sleep so it
                         // lands under the profile in the export. Zero-cost when off: the gate is one
@@ -1396,6 +1398,8 @@ class AppViewModel(app: Application) : AndroidViewModel(app) {
                 useExperimentalSleepV2 = PuffinExperiment.from(appContext).experimentalSleepV2,
                 // Opt-in motion-aware wake refinement (#364 follow-up) — same flag the 15-min loop reads.
                 useMotionAwareWake = PuffinExperiment.from(appContext).motionAwareWake,
+                // Opt-in "PPG-derived respiratory rate" diagnostic (#103) — same flag the 15-min loop reads.
+                ppgRespRateEnabled = PuffinExperiment.from(appContext).ppgRespRate,
             )
         }.onFailure { if (it is kotlin.coroutines.cancellation.CancellationException) throw it }
     }

--- a/android/app/src/main/java/com/noop/ui/TestCentreScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/TestCentreScreen.kt
@@ -504,14 +504,14 @@ private fun ExperimentalAlgorithmsCard(vm: AppViewModel) {
             // when off, so the flag off is zero behaviour change and feeds no downstream gate.
             if (hrvReadiness) HrvReadinessReadoutTC(recentDays)
             ToggleRowTC(
-                title = "PPG-derived respiratory rate (#103)",
-                description = "Prefer a spectral respiratory-rate estimate off the WHOOP5 v26 optical PPG " +
-                    "buffer over the shipped R-R estimate, per sleep session with enough burst coverage. " +
-                    "Unlike the read-only toggles above, this changes a stored value: DailyMetric.respRateBpm " +
-                    "and the illness-detection signal it feeds. Validated on only 2 real nights from one " +
-                    "subject whose own respiratory rate barely varies night to night - not yet proven to " +
-                    "track a varying value. Off by default; the R-R estimate stays the shipped default until " +
-                    "this earns wider validation.",
+                title = "PPG-derived respiratory rate diagnostic (#103)",
+                description = "Logs a spectral respiratory-rate estimate off the WHOOP5 v26 optical PPG " +
+                    "buffer alongside the shipped R-R estimate, for comparison. Read-only, like HRV " +
+                    "readiness above: it never overrides DailyMetric.respRateBpm or the illness-detection " +
+                    "signal, which always reads the R-R estimate only - a value that silently switched " +
+                    "estimator night to night could fake an illness warning on its own. Validated on only " +
+                    "2 real nights from one subject whose own respiratory rate barely varies night to " +
+                    "night. Off by default; the log line only appears when this is on.",
                 checked = ppgRespRate,
                 onCheckedChange = { ppgRespRate = it; puffin.ppgRespRate = it },
             )

--- a/android/app/src/main/java/com/noop/ui/TestCentreScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/TestCentreScreen.kt
@@ -504,7 +504,7 @@ private fun ExperimentalAlgorithmsCard(vm: AppViewModel) {
             // when off, so the flag off is zero behaviour change and feeds no downstream gate.
             if (hrvReadiness) HrvReadinessReadoutTC(recentDays)
             ToggleRowTC(
-                title = "PPG-derived respiratory rate diagnostic (#103)",
+                title = uiString(R.string.l10n_test_centre_screen_ppg_derived_respiratory_rate_diagnostic_103_7a24fb36),
                 description = "Logs a spectral respiratory-rate estimate off the WHOOP5 v26 optical PPG " +
                     "buffer alongside the shipped R-R estimate, for comparison. Read-only, like HRV " +
                     "readiness above: it never overrides DailyMetric.respRateBpm or the illness-detection " +

--- a/android/app/src/main/java/com/noop/ui/TestCentreScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/TestCentreScreen.kt
@@ -471,6 +471,7 @@ private fun ExperimentalAlgorithmsCard(vm: AppViewModel) {
     val puffin = remember { PuffinExperiment.from(context) }
     var ppgHrSubLag by remember { mutableStateOf(puffin.ppgHrSubLagInterp) }
     var hrvReadiness by remember { mutableStateOf(puffin.hrvReadiness) }
+    var ppgRespRate by remember { mutableStateOf(puffin.ppgRespRate) }
     // The SAME nightly HRV series the recovery UI reads (repo-merged DailyMetric.avgHrv, oldest-first), fed
     // into the pure HRVReadiness engine ONLY to render the toggle's own reading inline below — the default
     // Charge ring / analyzeDay path is never touched, and this feeds no downstream gate.
@@ -502,6 +503,18 @@ private fun ExperimentalAlgorithmsCard(vm: AppViewModel) {
             // The toggle's OWN effect, shown in place: when on, the live Plews/Altini reading. Nothing renders
             // when off, so the flag off is zero behaviour change and feeds no downstream gate.
             if (hrvReadiness) HrvReadinessReadoutTC(recentDays)
+            ToggleRowTC(
+                title = "PPG-derived respiratory rate (#103)",
+                description = "Prefer a spectral respiratory-rate estimate off the WHOOP5 v26 optical PPG " +
+                    "buffer over the shipped R-R estimate, per sleep session with enough burst coverage. " +
+                    "Unlike the read-only toggles above, this changes a stored value: DailyMetric.respRateBpm " +
+                    "and the illness-detection signal it feeds. Validated on only 2 real nights from one " +
+                    "subject whose own respiratory rate barely varies night to night - not yet proven to " +
+                    "track a varying value. Off by default; the R-R estimate stays the shipped default until " +
+                    "this earns wider validation.",
+                checked = ppgRespRate,
+                onCheckedChange = { ppgRespRate = it; puffin.ppgRespRate = it },
+            )
         }
     }
 }

--- a/android/app/src/main/res/values-de/strings.xml
+++ b/android/app/src/main/res/values-de/strings.xml
@@ -843,6 +843,7 @@
     <string name="l10n_test_centre_screen_hrv_readiness_experimental_924f61bc">HRV-Bereitschaft (experimentell)</string>
     <string name="l10n_test_centre_screen_hrv_readiness_experimental_word_a471930e">HRV-Reife (experimentell): %1$s</string>
     <string name="l10n_test_centre_screen_hrv_readiness_plews_altini_bce6578f">HRV-Bereitschaft (Plews/Altini)</string>
+    <string name="l10n_test_centre_screen_ppg_derived_respiratory_rate_diagnostic_103_7a24fb36">PPG-basierte Atemfrequenz-Diagnose (#103)</string>
     <string name="l10n_test_centre_screen_recalibrate_aaa989ea">Neu kalibrieren</string>
     <string name="l10n_test_centre_screen_recalibrate_charge_baseline_52a05a26">Ladungs-Basislinie neu kalibrieren</string>
     <string name="l10n_test_centre_screen_recalibrate_your_charge_baseline_018e3846">Deine Ladungs-Basislinie neu kalibrieren?</string>

--- a/android/app/src/main/res/values-es/strings.xml
+++ b/android/app/src/main/res/values-es/strings.xml
@@ -681,6 +681,7 @@
     <string name="l10n_test_centre_screen_hrv_readiness_experimental_924f61bc">HRV preparedness (experimental)</string>
     <string name="l10n_test_centre_screen_hrv_readiness_experimental_word_a471930e">HRV preparedness (experimental): %1$s</string>
     <string name="l10n_test_centre_screen_hrv_readiness_plews_altini_bce6578f">HRV preparedness (Plews/Altini)</string>
+    <string name="l10n_test_centre_screen_ppg_derived_respiratory_rate_diagnostic_103_7a24fb36">Diagnóstico de frecuencia respiratoria derivada del PPG (#103)</string>
     <string name="l10n_test_centre_screen_recalibrate_aaa989ea">Recalibrar</string>
     <string name="l10n_test_centre_screen_recalibrate_charge_baseline_52a05a26">Recalibrar la línea base de Carga</string>
     <string name="l10n_test_centre_screen_recalibrate_your_charge_baseline_018e3846">¿Recalibrar tu línea base de Carga?</string>

--- a/android/app/src/main/res/values-fr/strings.xml
+++ b/android/app/src/main/res/values-fr/strings.xml
@@ -681,6 +681,7 @@
     <string name="l10n_test_centre_screen_hrv_readiness_experimental_924f61bc">Préparation au VHR (expérience)</string>
     <string name="l10n_test_centre_screen_hrv_readiness_experimental_word_a471930e">Préparation au VHR (expérience): %1$s</string>
     <string name="l10n_test_centre_screen_hrv_readiness_plews_altini_bce6578f">Préparation au VRH (Plews/Altini)</string>
+    <string name="l10n_test_centre_screen_ppg_derived_respiratory_rate_diagnostic_103_7a24fb36">Diagnostic de fréquence respiratoire dérivée du PPG (#103)</string>
     <string name="l10n_test_centre_screen_recalibrate_aaa989ea">Recalibrer</string>
     <string name="l10n_test_centre_screen_recalibrate_charge_baseline_52a05a26">Recalibrer la ligne de base de la Charge</string>
     <string name="l10n_test_centre_screen_recalibrate_your_charge_baseline_018e3846">Recalibrer votre ligne de base de Charge ?</string>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -852,6 +852,7 @@
     <string name="l10n_test_centre_screen_hrv_readiness_experimental_924f61bc">HRV readiness (experimental)</string>
     <string name="l10n_test_centre_screen_hrv_readiness_experimental_word_a471930e">HRV readiness (experimental): %1$s</string>
     <string name="l10n_test_centre_screen_hrv_readiness_plews_altini_bce6578f">HRV readiness (Plews/Altini)</string>
+    <string name="l10n_test_centre_screen_ppg_derived_respiratory_rate_diagnostic_103_7a24fb36">PPG-derived respiratory rate diagnostic (#103)</string>
     <string name="l10n_test_centre_screen_recalibrate_aaa989ea">Recalibrate</string>
     <string name="l10n_test_centre_screen_recalibrate_charge_baseline_52a05a26">Recalibrate Charge baseline</string>
     <string name="l10n_test_centre_screen_recalibrate_your_charge_baseline_018e3846">Recalibrate your Charge baseline?</string>

--- a/android/app/src/test/java/com/noop/analytics/AnalyticsEngineRespRateFusionTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/AnalyticsEngineRespRateFusionTest.kt
@@ -10,9 +10,11 @@ import org.junit.Test
 import kotlin.math.sin
 
 /**
- * [AnalyticsEngine.analyzeDay] end-to-end: the prefer-PPG-else-RSA respiratory-rate fusion (#103).
- * Mirrors the Swift AnalyticsEngineTests.testAnalyzeDayPrefersPpgRespRateOverRsaWhenAvailable /
- * testAnalyzeDayFallsBackToRsaWhenPpgCoverageIsInsufficient.
+ * [AnalyticsEngine.analyzeDay] end-to-end: respRateBpm must always come from RSA, never the PPG
+ * estimate, even with ample contradicting PPG data (#103 review — a silently switching estimator
+ * would corrupt the ReadinessEngine illness gate). Mirrors the Swift
+ * AnalyticsEngineTests.testAnalyzeDayRespRateAlwaysUsesRsaEvenWithAmplePpgData /
+ * testAnalyzeDayLogsPpgComparisonWithoutAffectingRespRateBpm.
  */
 class AnalyticsEngineRespRateFusionTest {
     private val deviceId = "my-whoop"
@@ -40,7 +42,7 @@ class AnalyticsEngineRespRateFusionTest {
     }
 
     @Test
-    fun analyzeDayPrefersPpgRespRateOverRsaWhenAvailable() {
+    fun analyzeDayRespRateAlwaysUsesRsaEvenWithAmplePpgData() {
         val day = "2021-06-21"
         val (start, end, hg) = night(day, 7)
         val (hr, grav) = hg
@@ -56,29 +58,29 @@ class AnalyticsEngineRespRateFusionTest {
         assertEquals(1, result.sleepSessions.size)
         val resp = assertNotNullAndGet(result.daily.respRateBpm)
         assertEquals(
-            "expected the PPG estimate (12 bpm) to be preferred over RSA's planted 15 bpm",
-            12.0, resp, 0.5,
+            "respRateBpm must stay RSA-only (~15 bpm) regardless of contradicting PPG data",
+            15.0, resp, 3.0,
         )
     }
 
     @Test
-    fun analyzeDayFallsBackToRsaWhenPpgCoverageIsInsufficient() {
+    fun analyzeDayLogsPpgComparisonWithoutAffectingRespRateBpm() {
         val day = "2021-06-21"
         val (start, end, hg) = night(day, 7)
         val (hr, grav) = hg
         val rr = plantedRr(start, end)
-        // Only 3 PPG bursts (well below minPpgBurstsForEstimate) — must not override RSA.
-        val sparsePpgResp = (0 until 3).map {
+        val ppgResp = (0 until 12).map {
             PpgRespSample(deviceId = deviceId, ts = start + it * 600, bpm = 12.0, conf = 20.0)
         }
+        val traceLines = ArrayList<String>()
         val result = AnalyticsEngine.analyzeDay(
-            day = day, hr = hr, rr = rr, gravity = grav, ppgResp = sparsePpgResp, profile = UserProfile(),
+            day = day, hr = hr, rr = rr, gravity = grav, ppgResp = ppgResp, profile = UserProfile(),
+            hrvTraceSink = { traceLines.add(it) },
         )
         val resp = assertNotNullAndGet(result.daily.respRateBpm)
-        assertEquals(
-            "expected fallback to the RSA estimate (~15 bpm) when PPG coverage is too sparse",
-            15.0, resp, 3.0,
-        )
+        assertEquals(15.0, resp, 3.0)
+        val hasComparison = traceLines.any { it.startsWith("respRate session") && it.contains("used=rsa") }
+        assertEquals("expected a respRate comparison line logging rsa/ppg/used, got: $traceLines", true, hasComparison)
     }
 
     private fun assertNotNullAndGet(v: Double?): Double {

--- a/android/app/src/test/java/com/noop/analytics/AnalyticsEngineRespRateFusionTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/AnalyticsEngineRespRateFusionTest.kt
@@ -1,0 +1,88 @@
+package com.noop.analytics
+
+import com.noop.data.GravitySample
+import com.noop.data.HrSample
+import com.noop.data.PpgRespSample
+import com.noop.data.RrInterval
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Test
+import kotlin.math.sin
+
+/**
+ * [AnalyticsEngine.analyzeDay] end-to-end: the prefer-PPG-else-RSA respiratory-rate fusion (#103).
+ * Mirrors the Swift AnalyticsEngineTests.testAnalyzeDayPrefersPpgRespRateOverRsaWhenAvailable /
+ * testAnalyzeDayFallsBackToRsaWhenPpgCoverageIsInsufficient.
+ */
+class AnalyticsEngineRespRateFusionTest {
+    private val deviceId = "my-whoop"
+
+    /** A [hours]-long night ending at 06:00 UTC on [endDay], with steady HR=50 + still gravity, and
+     *  an R-R stream RSA-modulated to recover a planted 15 breaths/min. */
+    private fun night(endDay: String, hours: Int): Triple<Long, Long, Pair<List<HrSample>, List<GravitySample>>> {
+        val dayMidnight = java.time.LocalDate.parse(endDay).atStartOfDay(java.time.ZoneOffset.UTC).toEpochSecond()
+        val end = dayMidnight + 6 * 3600
+        val start = end - hours * 3600L
+        val hr = (start until end).map { HrSample(deviceId = deviceId, ts = it, bpm = 50) }
+        val grav = (start until end).map { GravitySample(deviceId = deviceId, ts = it, x = 0.0, y = 0.0, z = 1.0) }
+        return Triple(start, end, hr to grav)
+    }
+
+    private fun plantedRr(start: Long, end: Long): List<RrInterval> {
+        val rr = ArrayList<RrInterval>()
+        var tSec = 0.0
+        while (tSec < (end - start).toDouble()) {
+            val rrMs = 1200.0 + 40.0 * sin(2.0 * Math.PI * 0.25 * tSec) // planted 15 bpm
+            tSec += rrMs / 1000.0
+            rr.add(RrInterval(deviceId = deviceId, ts = start + tSec.toLong(), rrMs = rrMs.toInt()))
+        }
+        return rr
+    }
+
+    @Test
+    fun analyzeDayPrefersPpgRespRateOverRsaWhenAvailable() {
+        val day = "2021-06-21"
+        val (start, end, hg) = night(day, 7)
+        val (hr, grav) = hg
+        val rr = plantedRr(start, end)
+        // 12 high-confidence PPG bursts (well above minPpgBurstsForEstimate) spread across the night,
+        // all agreeing on 12 bpm — clearly distinct from RSA's planted 15 bpm above.
+        val ppgResp = (0 until 12).map {
+            PpgRespSample(deviceId = deviceId, ts = start + it * 600, bpm = 12.0, conf = 20.0)
+        }
+        val result = AnalyticsEngine.analyzeDay(
+            day = day, hr = hr, rr = rr, gravity = grav, ppgResp = ppgResp, profile = UserProfile(),
+        )
+        assertEquals(1, result.sleepSessions.size)
+        val resp = assertNotNullAndGet(result.daily.respRateBpm)
+        assertEquals(
+            "expected the PPG estimate (12 bpm) to be preferred over RSA's planted 15 bpm",
+            12.0, resp, 0.5,
+        )
+    }
+
+    @Test
+    fun analyzeDayFallsBackToRsaWhenPpgCoverageIsInsufficient() {
+        val day = "2021-06-21"
+        val (start, end, hg) = night(day, 7)
+        val (hr, grav) = hg
+        val rr = plantedRr(start, end)
+        // Only 3 PPG bursts (well below minPpgBurstsForEstimate) — must not override RSA.
+        val sparsePpgResp = (0 until 3).map {
+            PpgRespSample(deviceId = deviceId, ts = start + it * 600, bpm = 12.0, conf = 20.0)
+        }
+        val result = AnalyticsEngine.analyzeDay(
+            day = day, hr = hr, rr = rr, gravity = grav, ppgResp = sparsePpgResp, profile = UserProfile(),
+        )
+        val resp = assertNotNullAndGet(result.daily.respRateBpm)
+        assertEquals(
+            "expected fallback to the RSA estimate (~15 bpm) when PPG coverage is too sparse",
+            15.0, resp, 3.0,
+        )
+    }
+
+    private fun assertNotNullAndGet(v: Double?): Double {
+        assertNotNull(v)
+        return v!!
+    }
+}

--- a/android/app/src/test/java/com/noop/analytics/RegistryDayOwnerSourceTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/RegistryDayOwnerSourceTest.kt
@@ -57,6 +57,7 @@ class RegistryDayOwnerSourceTest {
         override suspend fun deleteStepsFor(deviceId: String) {}
         override suspend fun deletePpgHrFor(deviceId: String) {}
         override suspend fun deletePpgWaveformFor(deviceId: String) {}
+        override suspend fun deletePpgRespFor(deviceId: String) {}
         override suspend fun deleteEventsFor(deviceId: String) {}
         override suspend fun deleteBatteryFor(deviceId: String) {}
         override suspend fun deleteDailyMetricsFor(deviceId: String) {}

--- a/android/app/src/test/java/com/noop/analytics/RespRateFromPpgTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/RespRateFromPpgTest.kt
@@ -1,0 +1,92 @@
+package com.noop.analytics
+
+import com.noop.data.PpgRespSample
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Tests [SleepStager.respRateFromPpg] (issue #103) — the top-third-by-confidence aggregation over
+ * the PPG-derived per-burst stream (com.noop.protocol.PpgResp.deriveRespRate), used by
+ * AnalyticsEngine's prefer-PPG-else-RSA fusion. Mirrors [RespRateRsaTest]'s style: synthetic sample
+ * lists, not captures.
+ */
+class RespRateFromPpgTest {
+    private val start = 1_700_000_000L
+    private val end = 1_700_030_000L
+
+    /** [n] bursts, evenly spaced across [start, end], with bpm/conf from parallel lists. */
+    private fun samples(bpm: List<Double>, conf: List<Double>): List<PpgRespSample> {
+        val n = bpm.size
+        val step = (end - start) / maxOf(n, 1)
+        return (0 until n).map { i ->
+            PpgRespSample(deviceId = "my-whoop", ts = start + i * step, bpm = bpm[i], conf = conf[i])
+        }
+    }
+
+    @Test
+    fun recoversMedianOfTopThirdByConfidence() {
+        // 9 bursts (minPpgBurstsForEstimate): the top 3 by conf are bpm 14/15/16 → median 15. The
+        // other 6 are noisy/low-confidence and must be ignored, not dragged into the result.
+        val bpm = listOf(14.0, 15.0, 16.0, 5.0, 30.0, 9.0, 25.0, 6.0, 28.0)
+        val conf = listOf(10.0, 12.0, 11.0, 2.0, 1.5, 2.0, 1.5, 2.0, 1.5)
+        val est = SleepStager.respRateFromPpg(samples(bpm, conf), start, end)
+        assertEquals(15.0, est, 0.001)
+    }
+
+    @Test
+    fun tooFewBurstsIsNaN() {
+        // minPpgBurstsForEstimate - 1 bursts, all otherwise well-formed → NaN, not a fabricated median.
+        val n = SleepStager.minPpgBurstsForEstimate - 1
+        val bpm = List(n) { 15.0 }
+        val conf = List(n) { 10.0 }
+        assertTrue(SleepStager.respRateFromPpg(samples(bpm, conf), start, end).isNaN())
+        assertTrue(SleepStager.respRateFromPpg(emptyList(), start, end).isNaN())
+    }
+
+    @Test
+    fun exactlyMinimumBurstsProducesAnEstimate() {
+        val n = SleepStager.minPpgBurstsForEstimate
+        val bpm = List(n) { 15.0 }
+        val conf = List(n) { 10.0 }
+        assertTrue(!SleepStager.respRateFromPpg(samples(bpm, conf), start, end).isNaN())
+    }
+
+    @Test
+    fun filtersBurstsOutsideTheSessionWindow() {
+        // 9 in-window bursts at 15 bpm, plus 20 far-outside-window bursts at 99 bpm that must not
+        // count toward the minimum OR pollute the median.
+        val inWindow = samples(List(9) { 15.0 }, List(9) { 10.0 })
+        val outside = (0 until 20).map {
+            PpgRespSample(deviceId = "my-whoop", ts = start - 100_000 - it, bpm = 99.0, conf = 50.0)
+        }
+        val est = SleepStager.respRateFromPpg(inWindow + outside, start, end)
+        assertEquals(15.0, est, 0.001)
+    }
+
+    @Test
+    fun medianOutsidePlausibleBandIsNaN() {
+        // 9 bursts all agreeing on an implausible 3 bpm (below the 8-25 band) — never surfaced.
+        val bpm = List(9) { 3.0 }
+        val conf = List(9) { 10.0 }
+        assertTrue(SleepStager.respRateFromPpg(samples(bpm, conf), start, end).isNaN())
+    }
+
+    @Test
+    fun topThirdRoundingIsFloorDivision() {
+        // 10 bursts → top third = max(1, 10/3) = 3 (floor division, not rounded/ceiled). The top 3 by
+        // conf are 14/15/16 (median 15); if rounding were ceil (4), bpm 5.0 (conf 9.0) would enter the
+        // top group and pull the median down to 14.5.
+        val bpm = listOf(14.0, 15.0, 16.0, 5.0, 30.0, 9.0, 25.0, 6.0, 28.0, 2.0)
+        val conf = listOf(10.0, 12.0, 11.0, 9.0, 1.5, 2.0, 1.5, 2.0, 1.5, 1.0)
+        val est = SleepStager.respRateFromPpg(samples(bpm, conf), start, end)
+        assertEquals(15.0, est, 0.001)
+    }
+
+    @Test
+    fun endNotAfterStartIsNaN() {
+        val recs = samples(List(9) { 15.0 }, List(9) { 10.0 })
+        assertTrue(SleepStager.respRateFromPpg(recs, end, start).isNaN())
+        assertTrue(SleepStager.respRateFromPpg(recs, start, start).isNaN())
+    }
+}

--- a/android/app/src/test/java/com/noop/ble/SourceCoordinatorAdoptionTest.kt
+++ b/android/app/src/test/java/com/noop/ble/SourceCoordinatorAdoptionTest.kt
@@ -71,6 +71,7 @@ class SourceCoordinatorAdoptionTest {
         override suspend fun deleteStepsFor(deviceId: String) {}
         override suspend fun deletePpgHrFor(deviceId: String) {}
         override suspend fun deletePpgWaveformFor(deviceId: String) {}
+        override suspend fun deletePpgRespFor(deviceId: String) {}
         override suspend fun deleteEventsFor(deviceId: String) {}
         override suspend fun deleteBatteryFor(deviceId: String) {}
         override suspend fun deleteDailyMetricsFor(deviceId: String) {}

--- a/android/app/src/test/java/com/noop/data/DeviceRegistryTest.kt
+++ b/android/app/src/test/java/com/noop/data/DeviceRegistryTest.kt
@@ -85,6 +85,7 @@ class DeviceRegistryTest {
         override suspend fun deleteStepsFor(deviceId: String) { deletedTables += "stepSample" to deviceId }
         override suspend fun deletePpgHrFor(deviceId: String) { deletedTables += "ppgHrSample" to deviceId }
         override suspend fun deletePpgWaveformFor(deviceId: String) { deletedTables += "ppgWaveformSample" to deviceId }
+        override suspend fun deletePpgRespFor(deviceId: String) { deletedTables += "ppgRespSample" to deviceId }
         override suspend fun deleteEventsFor(deviceId: String) { deletedTables += "event" to deviceId }
         override suspend fun deleteBatteryFor(deviceId: String) { deletedTables += "battery" to deviceId }
         override suspend fun deleteDailyMetricsFor(deviceId: String) { deletedTables += "dailyMetric" to deviceId }
@@ -234,7 +235,8 @@ class DeviceRegistryTest {
         // were missing, leaving raw sleep-state, lab markers, live sessions and dismissed markers behind.
         val expectedTables = setOf(
             "hrSample", "rrInterval", "spo2Sample", "skinTempSample", "respSample", "gravitySample",
-            "stepSample", "ppgHrSample", "ppgWaveformSample", "event", "battery", "dailyMetric", "sleepSession",
+            "stepSample", "ppgHrSample", "ppgWaveformSample", "ppgRespSample", "event", "battery",
+            "dailyMetric", "sleepSession",
             "journal", "workout", "appleDaily", "metricSeries", "dayOwnership",
             "sleepStateSample", "labMarker", "liveSession", "dismissedWorkout", "dismissedSleep",
         )

--- a/android/app/src/test/java/com/noop/data/PpgRespSampleMigrationTest.kt
+++ b/android/app/src/test/java/com/noop/data/PpgRespSampleMigrationTest.kt
@@ -5,8 +5,8 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 
 /**
- * Guards the additive v18 -> v19 Room migration (the `ppgRespSample` table, #103), the Android twin
- * of the Swift WhoopStore v26-ppg-resp-sample migration. This environment has no Robolectric / Room-
+ * Guards the additive v20 -> v21 Room migration (the `ppgRespSample` table, #103), the Android twin
+ * of the Swift WhoopStore v28-ppg-resp-sample migration. This environment has no Robolectric / Room-
  * testing, so the migration's SQL is exposed as an internal constant
  * ([WhoopDatabase.PPG_RESP_SAMPLE_MIGRATION_SQL]) and pinned here to Room's generated shape for
  * [PpgRespSample]:
@@ -43,9 +43,9 @@ class PpgRespSampleMigrationTest {
     }
 
     @Test
-    fun migration_versionPair_is18to19() {
-        assertEquals(18, WhoopDatabase.MIGRATION_18_19.startVersion)
-        assertEquals(19, WhoopDatabase.MIGRATION_18_19.endVersion)
+    fun migration_versionPair_is20to21() {
+        assertEquals(20, WhoopDatabase.MIGRATION_20_21.startVersion)
+        assertEquals(21, WhoopDatabase.MIGRATION_20_21.endVersion)
     }
 
     @Test

--- a/android/app/src/test/java/com/noop/data/PpgRespSampleMigrationTest.kt
+++ b/android/app/src/test/java/com/noop/data/PpgRespSampleMigrationTest.kt
@@ -1,0 +1,59 @@
+package com.noop.data
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Guards the additive v18 -> v19 Room migration (the `ppgRespSample` table, #103), the Android twin
+ * of the Swift WhoopStore v26-ppg-resp-sample migration. This environment has no Robolectric / Room-
+ * testing, so the migration's SQL is exposed as an internal constant
+ * ([WhoopDatabase.PPG_RESP_SAMPLE_MIGRATION_SQL]) and pinned here to Room's generated shape for
+ * [PpgRespSample]:
+ *
+ *  - one CREATE TABLE IF NOT EXISTS statement — deviceId TEXT NOT NULL, ts INTEGER NOT NULL, bpm REAL
+ *    NOT NULL, conf REAL NOT NULL, composite PRIMARY KEY (deviceId, ts) in declaration order.
+ *  - ADDITIVE: CREATE TABLE only; no DROP/DELETE/UPDATE/INSERT/ALTER on existing data.
+ */
+class PpgRespSampleMigrationTest {
+
+    @Test
+    fun migration_isAdditive_onlyCreateTable() {
+        val sql = WhoopDatabase.PPG_RESP_SAMPLE_MIGRATION_SQL
+        assertEquals("one CREATE TABLE statement", 1, sql.size)
+        for (s in sql) {
+            val up = s.trimStart().uppercase()
+            assertTrue("only CREATE TABLE allowed, got: $s", up.startsWith("CREATE TABLE"))
+            for (banned in listOf("DROP ", "DELETE ", "UPDATE ", "INSERT ", "ALTER ")) {
+                assertTrue("additive migration must not contain '$banned': $s", !up.contains(banned))
+            }
+        }
+    }
+
+    @Test
+    fun migration_createsExactTable() {
+        assertEquals(
+            listOf(
+                "CREATE TABLE IF NOT EXISTS `ppgRespSample` (`deviceId` TEXT NOT NULL, " +
+                    "`ts` INTEGER NOT NULL, `bpm` REAL NOT NULL, `conf` REAL NOT NULL, " +
+                    "PRIMARY KEY(`deviceId`, `ts`))",
+            ),
+            WhoopDatabase.PPG_RESP_SAMPLE_MIGRATION_SQL,
+        )
+    }
+
+    @Test
+    fun migration_versionPair_is18to19() {
+        assertEquals(18, WhoopDatabase.MIGRATION_18_19.startVersion)
+        assertEquals(19, WhoopDatabase.MIGRATION_18_19.endVersion)
+    }
+
+    @Test
+    fun ppgRespSample_entity_shape() {
+        val entity = PpgRespSample(deviceId = "my-whoop", ts = 1_780_916_150L, bpm = 14.5, conf = 8.2)
+        assertEquals("my-whoop", entity.deviceId)
+        assertEquals(1_780_916_150L, entity.ts)
+        assertEquals(14.5, entity.bpm, 0.0)
+        assertEquals(8.2, entity.conf, 0.0)
+    }
+}

--- a/android/app/src/test/java/com/noop/protocol/PpgRespTest.kt
+++ b/android/app/src/test/java/com/noop/protocol/PpgRespTest.kt
@@ -50,9 +50,18 @@ class PpgRespTest {
 
     @Test
     fun recoversASlowBreathingRate() {
-        // Near the low end of the band (10 breaths/min = 0.1667 Hz) — must not fold to the high end.
-        val (bpm, _) = PpgResp.estimate(breathingBurst(10.0).map { it.value })!!
-        assertTrue("bpm $bpm not within 10±1", bpm in 9.0..11.0)
+        // Near the low end of the band (11 breaths/min = 0.1833 Hz, clear of the BAND_EDGE_GUARD_HZ
+        // margin around the 9 breaths/min floor) — must not fold to the high end.
+        val (bpm, _) = PpgResp.estimate(breathingBurst(11.0).map { it.value })!!
+        assertTrue("bpm $bpm not within 11±1", bpm in 10.0..12.0)
+    }
+
+    @Test
+    fun recoversAFastBreathingRate() {
+        // Near the high end of the band (19 breaths/min = 0.3167 Hz) — exercises the upper half of
+        // the 0.15-0.40 Hz search, not just the low/mid values the other tests cover.
+        val (bpm, _) = PpgResp.estimate(breathingBurst(19.0).map { it.value })!!
+        assertTrue("bpm $bpm not within 19±1", bpm in 18.0..20.0)
     }
 
     @Test

--- a/android/app/src/test/java/com/noop/protocol/PpgRespTest.kt
+++ b/android/app/src/test/java/com/noop/protocol/PpgRespTest.kt
@@ -1,0 +1,111 @@
+package com.noop.protocol
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import kotlin.math.PI
+import kotlin.math.sin
+import org.junit.Test
+
+/**
+ * [PpgResp] — respiratory rate from the WHOOP 5/MG v26 optical PPG buffer (#103): a band-limited
+ * spectral peak search (0.15-0.40 Hz) on the RIAV (amplitude envelope) / RIIV (baseline) channels of
+ * a ~40 s burst. Independently-written synthetic tests (not shared vectors with the Swift lane),
+ * matching [PpgHrTest]'s style for the sibling per-second HR estimator on the same buffer.
+ */
+class PpgRespTest {
+    private val fs = PpgResp.SAMPLE_RATE_HZ // 24
+
+    /** One synthetic burst: a ~1.1 Hz pulse carrier whose AMPLITUDE and BASELINE are both modulated
+     *  at [breathBpm] breaths/min — RIAV picks up the amplitude modulation, RIIV the baseline shift,
+     *  so either channel alone is enough to recover the planted rate. */
+    private fun breathingBurst(
+        breathBpm: Double,
+        seconds: Int = 40,
+        baseTs: Long = 1_780_000_000L,
+        pulseHz: Double = 1.1,
+        carrierAmp: Double = 1000.0,
+        modDepth: Double = 400.0,
+        baselineAmp: Double = 300.0,
+    ): List<PpgHr.Sample> {
+        val breathHz = breathBpm / 60.0
+        val total = seconds * fs
+        val samples = ArrayList<PpgHr.Sample>(total)
+        for (n in 0 until total) {
+            val t = n.toDouble() / fs
+            val breath = sin(2.0 * PI * breathHz * t)
+            val amplitude = carrierAmp + modDepth * breath
+            val pulse = amplitude * sin(2.0 * PI * pulseHz * t)
+            val baseline = baselineAmp * breath
+            samples.add(PpgHr.Sample(ts = baseTs + (n / fs), value = (pulse + baseline).toInt()))
+        }
+        return samples
+    }
+
+    @Test
+    fun recoversKnownBreathingRate() {
+        val (bpm, conf) = PpgResp.estimate(breathingBurst(15.0).map { it.value })!!
+        assertTrue("bpm $bpm not within 15±1", bpm in 14.0..16.0)
+        assertTrue("conf $conf below gate", conf >= PpgResp.MIN_PROMINENCE)
+    }
+
+    @Test
+    fun recoversASlowBreathingRate() {
+        // Near the low end of the band (10 breaths/min = 0.1667 Hz) — must not fold to the high end.
+        val (bpm, _) = PpgResp.estimate(breathingBurst(10.0).map { it.value })!!
+        assertTrue("bpm $bpm not within 10±1", bpm in 9.0..11.0)
+    }
+
+    @Test
+    fun deriveRespRateOneSamplePerBurst() {
+        val series = PpgResp.deriveRespRate(breathingBurst(15.0))
+        assertEquals("one ~40s burst must yield exactly one estimate, not per-second", 1, series.size)
+        assertEquals("ts must be the burst's FIRST record timestamp", 1_780_000_000L, series[0].ts)
+        assertTrue("bpm ${series[0].bpm} not within 15±1", series[0].bpm in 14.0..16.0)
+    }
+
+    @Test
+    fun flatSignalProducesNoEstimate() {
+        // Constant DC (no variation at all) → after centering, every band bin is exactly zero power →
+        // no fabricated rate. Long enough to clear the minimum-burst-length gate.
+        val samples = (0 until 40 * fs).map { i -> PpgHr.Sample(ts = 1_780_000_000L + i / fs, value = 5000) }
+        assertTrue(
+            "a flat signal must not produce a fabricated respiratory rate",
+            PpgResp.deriveRespRate(samples).isEmpty(),
+        )
+    }
+
+    @Test
+    fun estimateRejectsTooShortBurst() {
+        // A single ~1 second of breathing modulation is nowhere near enough to resolve 0.15 Hz.
+        val oneSecond = breathingBurst(15.0, seconds = 1).map { it.value }
+        assertEquals(null, PpgResp.estimate(oneSecond))
+    }
+
+    @Test
+    fun burstShorterThanMinimumIsDropped() {
+        // MIN_BURST_RECORDS (32) worth of a run is required; 20 records must not yield an estimate
+        // even though each individual second is well-formed.
+        val records = breathingBurst(15.0, seconds = 40).take(20 * fs)
+        assertTrue(PpgResp.deriveRespRate(records).isEmpty())
+    }
+
+    @Test
+    fun gapBreaksRunsIntoSeparateBursts() {
+        // Two full 40 s bursts separated by a gap — both estimate independently, none inside the gap.
+        val recs = breathingBurst(12.0, baseTs = 1_780_000_000L) +
+            breathingBurst(18.0, baseTs = 1_780_001_000L)
+        val series = PpgResp.deriveRespRate(recs)
+        assertEquals(2, series.size)
+        assertTrue("bpm ${series[0].bpm} not within 12±1", series[0].bpm in 11.0..13.0)
+        assertTrue("bpm ${series[1].bpm} not within 18±1", series[1].bpm in 17.0..19.0)
+        assertEquals(1_780_000_000L, series[0].ts)
+        assertEquals(1_780_001_000L, series[1].ts)
+    }
+
+    @Test
+    fun deriveRespRateSamplesMayBeUnsorted() {
+        val series = PpgResp.deriveRespRate(breathingBurst(15.0).shuffled(kotlin.random.Random(7)))
+        assertEquals(1, series.size)
+        assertEquals(1_780_000_000L, series[0].ts)
+    }
+}


### PR DESCRIPTION
## Summary

Follows up on the #103 investigation. That thread ruled out SpO2 and landed
a proof-of-concept: respiratory rate can be recovered from the WHOOP5 v26
single-wavelength 24Hz optical PPG buffer via burst-level spectral analysis
(RIAV/RIIV band search, 0.15–0.40Hz).

NOOP already ships a respiratory-rate estimator for WHOOP5 —
`SleepStager.respRateFromRR` (RSA, from R-R intervals) — feeding
`DailyMetric.respRateBpm` and an illness-detection signal in
`ReadinessEngine`. So this is a **second, more accurate estimator**, added
as a **default-off, diagnostic-only Experimental toggle** (never the shipped
default, per the project's derived-biosignal validation standard):

- **`PpgResp`** (Swift `Packages/WhoopProtocol`, Kotlin
  `com.noop.protocol`): a burst-level estimator on the same v26 buffer
  `PpgHr` already reads, one estimate per ~40s burst. Validated against
  **two real overnight BLE captures** vs. the WHOOP app's own reading:
  within **~2–6%**, vs. the RSA estimator's **6–11% low bias** on the same
  nights. A **band-edge guard** (`bandEdgeGuardHz`) rejects peaks pinned at
  the band floor by residual low-frequency drift — confirmed on real data
  (see the review-response below) and it *improved* accuracy (top-burst
  median 14.04 → 14.52 vs. 14.6 truth).
- **`SleepStager.respRateFromPpg`**: filters bursts to a sleep session,
  requires ≥9 qualifying bursts (else NaN), median of the top-third by
  confidence.
- **Illness gate stays on a single estimator.** `DailyMetric.respRateBpm`
  (and hence the `ReadinessEngine` z-gate) **always** comes from RSA. The
  PPG estimator never overrides it — a value that silently switched
  estimator night to night could inject a ~1–1.5 bpm step and brush the
  illness WATCH threshold on its own (a false signal from the switch, not
  physiology). When the toggle is on, PPG is only computed **alongside** RSA
  and logged (`rsa=… ppg=… used=rsa`) through the existing diagnostic sink —
  the "keep the instrumentation" ask.
- **`PuffinExperiment.ppgRespRate`** (default **false**), mirroring the
  existing `ppgHrSubLagInterp` / `hrvReadiness` pattern, with a Test Centre
  Experimental-algorithms row on both platforms. Default path is
  byte-identical to what's shipped today.
- New migration for the `ppgRespSample` table, wired into device-scoped
  delete, timestamp healing, and the raw-sensor CSV export on both
  platforms. Decoded + persisted **unconditionally** as instrumentation
  regardless of the toggle. **Migration numbers:** GRDB
  `v27-ppg-resp-sample` / Room `MIGRATION_19_20` (schemaVersion 20),
  renumbered from v26/18→19 after `v26-efficiency-heal` landed in that slot
  first (the coordination note in the review — resolved).

## Test plan

- [x] `swift test` — WhoopProtocol (288), WhoopStore (263), StrandAnalytics
      (1048), all green
- [x] `./gradlew compileFullDebugKotlin` + `testFullDebugUnitTest` — green
- [x] Local `xcodebuild` of the macOS `Strand` app target — **BUILD
      SUCCEEDED** (touches app-target files `app-build.yml` CI doesn't cover
      by default)
- [x] End-to-end sanity check against the two real captured nights via the
      actual production code path
- No BLE/hardware surface touched — pure historical-offload + analytics
  path.