### PR TITLE
i18n: fill in missing German (de) translations across Apple targets

### DIFF
--- a/NOOPWatch/Localizable.xcstrings
+++ b/NOOPWatch/Localizable.xcstrings
@@ -3,6 +3,12 @@
   "strings": {
     "%@ br/min": {
       "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ Atemzüge/Min"
+          }
+        },
         "en": {
           "stringUnit": {
             "state": "translated",
@@ -43,6 +49,12 @@
     },
     "%@ pace": {
       "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ Tempo"
+          }
+        },
         "en": {
           "stringUnit": {
             "state": "translated",
@@ -83,6 +95,12 @@
     },
     "%@ · %@s in / %@s out": {
       "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ · %@s ein / %@s aus"
+          }
+        },
         "en": {
           "stringUnit": {
             "state": "translated",
@@ -123,6 +141,12 @@
     },
     "%@ · %lld kcal": {
       "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ · %lld kcal"
+          }
+        },
         "en": {
           "stringUnit": {
             "state": "translated",
@@ -163,6 +187,12 @@
     },
     "%lld breaths · %@": {
       "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld Atemzüge · %@"
+          }
+        },
         "en": {
           "stringUnit": {
             "state": "translated",
@@ -203,6 +233,12 @@
     },
     "%lld seconds remaining in %@": {
       "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld Sekunden verbleibend in %@"
+          }
+        },
         "en": {
           "stringUnit": {
             "state": "new",
@@ -243,6 +279,12 @@
     },
     "Allow access": {
       "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zugriff erlauben"
+          }
+        },
         "en": {
           "stringUnit": {
             "state": "translated",
@@ -283,6 +325,12 @@
     },
     "Box": {
       "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Box"
+          }
+        },
         "en": {
           "stringUnit": {
             "state": "translated",
@@ -381,6 +429,12 @@
     },
     "Breathe in": {
       "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Einatmen"
+          }
+        },
         "en": {
           "stringUnit": {
             "state": "translated",
@@ -421,6 +475,12 @@
     },
     "Breathe in for %lld seconds": {
       "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Einatmen für %lld Sekunden"
+          }
+        },
         "en": {
           "stringUnit": {
             "state": "translated",
@@ -461,6 +521,12 @@
     },
     "Breathe out": {
       "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ausatmen"
+          }
+        },
         "en": {
           "stringUnit": {
             "state": "translated",
@@ -501,6 +567,12 @@
     },
     "Breathe out for %lld seconds": {
       "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ausatmen für %lld Sekunden"
+          }
+        },
         "en": {
           "stringUnit": {
             "state": "translated",
@@ -599,6 +671,12 @@
     },
     "Coherence": {
       "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kohärenz"
+          }
+        },
         "en": {
           "stringUnit": {
             "state": "translated",
@@ -639,6 +717,12 @@
     },
     "DONE": {
       "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "FERTIG"
+          }
+        },
         "en": {
           "stringUnit": {
             "state": "translated",
@@ -679,6 +763,12 @@
     },
     "Done": {
       "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fertig"
+          }
+        },
         "en": {
           "stringUnit": {
             "state": "translated",
@@ -777,6 +867,12 @@
     },
     "End": {
       "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ende"
+          }
+        },
         "en": {
           "stringUnit": {
             "state": "translated",
@@ -817,6 +913,12 @@
     },
     "End workout": {
       "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Workout beenden"
+          }
+        },
         "en": {
           "stringUnit": {
             "state": "translated",
@@ -857,6 +959,12 @@
     },
     "Functional strength": {
       "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Funktionelles Krafttraining"
+          }
+        },
         "en": {
           "stringUnit": {
             "state": "translated",
@@ -897,6 +1005,12 @@
     },
     "Grant Health access": {
       "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Health-Zugriff gewähren"
+          }
+        },
         "en": {
           "stringUnit": {
             "state": "translated",
@@ -995,6 +1109,12 @@
     },
     "HR unavailable": {
       "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "HF nicht verfügbar"
+          }
+        },
         "en": {
           "stringUnit": {
             "state": "translated",
@@ -1035,6 +1155,12 @@
     },
     "Live heart rate and energy, recorded on your wrist. Stays on device.": {
       "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Live-Herzfrequenz und -Energie, aufgezeichnet an deinem Handgelenk. Bleibt auf dem Gerät."
+          }
+        },
         "en": {
           "stringUnit": {
             "state": "translated",
@@ -1075,6 +1201,12 @@
     },
     "Open NOOP on your iPhone to sync": {
       "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Öffne NOOP auf deinem iPhone zum Synchronisieren"
+          }
+        },
         "en": {
           "stringUnit": {
             "state": "translated",
@@ -1115,6 +1247,12 @@
     },
     "PAUSED": {
       "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "PAUSIERT"
+          }
+        },
         "en": {
           "stringUnit": {
             "state": "translated",
@@ -1213,6 +1351,12 @@
     },
     "RECORDING": {
       "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "AUFNAHME"
+          }
+        },
         "en": {
           "stringUnit": {
             "state": "translated",
@@ -1253,6 +1397,12 @@
     },
     "REST": {
       "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "RUHE"
+          }
+        },
         "en": {
           "stringUnit": {
             "state": "translated",
@@ -1293,6 +1443,12 @@
     },
     "Ready to breathe": {
       "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bereit zum Atmen"
+          }
+        },
         "en": {
           "stringUnit": {
             "state": "translated",
@@ -1333,6 +1489,12 @@
     },
     "Relax": {
       "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Entspannen"
+          }
+        },
         "en": {
           "stringUnit": {
             "state": "translated",
@@ -1547,6 +1709,12 @@
     },
     "Resume": {
       "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fortsetzen"
+          }
+        },
         "en": {
           "stringUnit": {
             "state": "translated",
@@ -1587,6 +1755,12 @@
     },
     "Round %lld of %lld": {
       "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Runde %lld von %lld"
+          }
+        },
         "en": {
           "stringUnit": {
             "state": "translated",
@@ -1627,6 +1801,12 @@
     },
     "SEC": {
       "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SEK"
+          }
+        },
         "en": {
           "stringUnit": {
             "state": "translated",
@@ -1667,6 +1847,12 @@
     },
     "Session done": {
       "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sitzung beendet"
+          }
+        },
         "en": {
           "stringUnit": {
             "state": "translated",
@@ -1823,6 +2009,12 @@
     },
     "Stop": {
       "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stopp"
+          }
+        },
         "en": {
           "stringUnit": {
             "state": "translated",
@@ -1921,6 +2113,12 @@
     },
     "WORK": {
       "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "AKTIV"
+          }
+        },
         "en": {
           "stringUnit": {
             "state": "translated",
@@ -1961,6 +2159,12 @@
     },
     "Workout": {
       "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Workout"
+          }
+        },
         "en": {
           "stringUnit": {
             "state": "translated",
@@ -2001,6 +2205,12 @@
     },
     "Workout saved": {
       "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Workout gespeichert"
+          }
+        },
         "en": {
           "stringUnit": {
             "state": "translated",
@@ -2041,6 +2251,12 @@
     },
     "as of %@": {
       "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stand: %@"
+          }
+        },
         "en": {
           "stringUnit": {
             "state": "translated",
@@ -2139,6 +2355,12 @@
     },
     "cal": {
       "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "cal"
+          }
+        },
         "en": {
           "stringUnit": {
             "state": "translated",
@@ -2155,6 +2377,12 @@
     },
     "stale · %@": {
       "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "veraltet · %@"
+          }
+        },
         "en": {
           "stringUnit": {
             "state": "translated",

--- a/NOOPWatchComplications/Localizable.xcstrings
+++ b/NOOPWatchComplications/Localizable.xcstrings
@@ -3,6 +3,12 @@
   "strings": {
     "%@ %lld": {
       "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ %lld"
+          }
+        },
         "en": {
           "stringUnit": {
             "state": "translated",
@@ -19,6 +25,12 @@
     },
     "%@ calibrating": {
       "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ wird kalibriert"
+          }
+        },
         "en": {
           "stringUnit": {
             "state": "translated",
@@ -35,6 +47,12 @@
     },
     "%@ unavailable": {
       "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ nicht verfügbar"
+          }
+        },
         "en": {
           "stringUnit": {
             "state": "translated",
@@ -109,6 +127,12 @@
     },
     "Charge %lld out of 100": {
       "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ladung %lld von 100"
+          }
+        },
         "en": {
           "stringUnit": {
             "state": "translated",
@@ -125,6 +149,12 @@
     },
     "Charge %lld · %lld bpm%@": {
       "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ladung %lld · %lld bpm%@"
+          }
+        },
         "en": {
           "stringUnit": {
             "state": "translated",
@@ -141,6 +171,12 @@
     },
     "Charge %lld%@": {
       "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ladung %lld%@"
+          }
+        },
         "en": {
           "stringUnit": {
             "state": "translated",
@@ -157,6 +193,12 @@
     },
     "Charge calibrating": {
       "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ladung wird kalibriert"
+          }
+        },
         "en": {
           "stringUnit": {
             "state": "translated",
@@ -173,6 +215,12 @@
     },
     "Charge calibrating, needs more data": {
       "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ladung wird kalibriert, mehr Daten nötig"
+          }
+        },
         "en": {
           "stringUnit": {
             "state": "translated",
@@ -189,6 +237,12 @@
     },
     "Charge out of date, last synced %@. Open NOOP on iPhone.": {
       "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ladung veraltet, zuletzt synchronisiert %@. Öffne NOOP auf dem iPhone."
+          }
+        },
         "en": {
           "stringUnit": {
             "state": "translated",
@@ -205,6 +259,12 @@
     },
     "Charge stale · %@": {
       "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ladung veraltet · %@"
+          }
+        },
         "en": {
           "stringUnit": {
             "state": "translated",
@@ -221,6 +281,12 @@
     },
     "Charge unavailable": {
       "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ladung nicht verfügbar"
+          }
+        },
         "en": {
           "stringUnit": {
             "state": "translated",
@@ -237,6 +303,12 @@
     },
     "Charge · %@": {
       "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ladung · %@"
+          }
+        },
         "en": {
           "stringUnit": {
             "state": "translated",
@@ -253,6 +325,12 @@
     },
     "Charge · cal": {
       "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ladung · cal"
+          }
+        },
         "en": {
           "stringUnit": {
             "state": "translated",
@@ -269,6 +347,12 @@
     },
     "Charge –": {
       "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ladung –"
+          }
+        },
         "en": {
           "stringUnit": {
             "state": "translated",
@@ -343,6 +427,12 @@
     },
     "NOOP Charge": {
       "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "NOOP Ladung"
+          }
+        },
         "en": {
           "stringUnit": {
             "state": "translated",
@@ -383,6 +473,12 @@
     },
     "NOOP · open on iPhone": {
       "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "NOOP · auf iPhone öffnen"
+          }
+        },
         "en": {
           "stringUnit": {
             "state": "translated",
@@ -399,6 +495,12 @@
     },
     "NOOP. %@, %@, %@.": {
       "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "NOOP. %@, %@, %@."
+          }
+        },
         "en": {
           "stringUnit": {
             "state": "translated",
@@ -415,6 +517,12 @@
     },
     "NOOP. No data yet, open NOOP on your iPhone to sync.": {
       "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "NOOP. Noch keine Daten, öffne NOOP auf deinem iPhone zum Synchronisieren."
+          }
+        },
         "en": {
           "stringUnit": {
             "state": "translated",
@@ -431,6 +539,12 @@
     },
     "NOOP. Scores out of date, last synced %@. Open NOOP on iPhone to refresh.": {
       "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "NOOP. Werte veraltet, zuletzt synchronisiert %@. Öffne NOOP auf dem iPhone zum Aktualisieren."
+          }
+        },
         "en": {
           "stringUnit": {
             "state": "translated",
@@ -447,6 +561,12 @@
     },
     "No data, open NOOP on iPhone": {
       "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keine Daten, öffne NOOP auf dem iPhone"
+          }
+        },
         "en": {
           "stringUnit": {
             "state": "translated",
@@ -463,6 +583,12 @@
     },
     "Open NOOP": {
       "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "NOOP öffnen"
+          }
+        },
         "en": {
           "stringUnit": {
             "state": "translated",
@@ -537,6 +663,12 @@
     },
     "Your Charge (recovery) on the watch face, with Effort and Rest in the rectangular card.": {
       "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Deine Ladung (Erholung) auf dem Zifferblatt, mit Anstrengung und Ruhe in der rechteckigen Karte."
+          }
+        },
         "en": {
           "stringUnit": {
             "state": "translated",
@@ -577,6 +709,12 @@
     },
     "a while ago": {
       "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "vor einer Weile"
+          }
+        },
         "en": {
           "stringUnit": {
             "state": "translated",
@@ -593,6 +731,12 @@
     },
     "cal": {
       "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "cal"
+          }
+        },
         "en": {
           "stringUnit": {
             "state": "translated",
@@ -609,6 +753,12 @@
     },
     "old": {
       "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "alt"
+          }
+        },
         "en": {
           "stringUnit": {
             "state": "translated",
@@ -625,6 +775,12 @@
     },
     "open iPhone": {
       "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "iPhone öffnen"
+          }
+        },
         "en": {
           "stringUnit": {
             "state": "translated",
@@ -641,6 +797,12 @@
     },
     "stale": {
       "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "veraltet"
+          }
+        },
         "en": {
           "stringUnit": {
             "state": "translated",

--- a/Packages/StrandDesign/Sources/StrandDesign/DayNavBar.swift
+++ b/Packages/StrandDesign/Sources/StrandDesign/DayNavBar.swift
@@ -60,7 +60,7 @@ public struct DayNavBar: View {
             // Centre accent block — the selected day's label + full date, tappable to jump.
             Button { showingPicker = true } label: {
                 VStack(spacing: 2) {
-                    Text(label)
+                    Text(label, bundle: .module)
                         .font(StrandFont.caption)
                         .foregroundStyle(StrandPalette.textPrimary)
                         .lineLimit(1)

--- a/Packages/StrandDesign/Sources/StrandDesign/Resources/Localizable.xcstrings
+++ b/Packages/StrandDesign/Sources/StrandDesign/Resources/Localizable.xcstrings
@@ -3,6 +3,12 @@
   "strings": {
     "%lld days ago": {
       "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "vor %lld Tagen"
+          }
+        },
         "en": {
           "stringUnit": {
             "state": "translated",
@@ -19,6 +25,12 @@
     },
     "%lld hours": {
       "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld Stunden"
+          }
+        },
         "en": {
           "stringUnit": {
             "state": "translated",
@@ -59,6 +71,12 @@
     },
     "%lld minutes": {
       "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld Minuten"
+          }
+        },
         "en": {
           "stringUnit": {
             "state": "translated",
@@ -75,6 +93,12 @@
     },
     "%lld points, mean %@, range %@ to %@": {
       "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld Punkte, Mittelwert %@, Bereich %@ bis %@"
+          }
+        },
         "en": {
           "stringUnit": {
             "state": "translated",
@@ -91,6 +115,12 @@
     },
     "%lld readings": {
       "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld Messwerte"
+          }
+        },
         "en": {
           "stringUnit": {
             "state": "translated",
@@ -107,6 +137,12 @@
     },
     "%lld workouts": {
       "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld Workouts"
+          }
+        },
         "en": {
           "stringUnit": {
             "state": "translated",
@@ -123,6 +159,12 @@
     },
     "%lldd ago": {
       "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "vor %lld T"
+          }
+        },
         "en": {
           "stringUnit": {
             "state": "translated",
@@ -139,6 +181,12 @@
     },
     "%lldh ago": {
       "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "vor %lld Std."
+          }
+        },
         "en": {
           "stringUnit": {
             "state": "translated",
@@ -179,6 +227,12 @@
     },
     "%lldm ago": {
       "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "vor %lld Min."
+          }
+        },
         "en": {
           "stringUnit": {
             "state": "translated",
@@ -195,6 +249,12 @@
     },
     "1 hour": {
       "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1 Stunde"
+          }
+        },
         "en": {
           "stringUnit": {
             "state": "translated",
@@ -235,6 +295,12 @@
     },
     "1 minute": {
       "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1 Minute"
+          }
+        },
         "en": {
           "stringUnit": {
             "state": "translated",
@@ -251,6 +317,12 @@
     },
     "1 workout": {
       "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1 Workout"
+          }
+        },
         "en": {
           "stringUnit": {
             "state": "translated",
@@ -267,6 +339,12 @@
     },
     "ALL-OUT": {
       "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "MAXIMAL"
+          }
+        },
         "en": {
           "stringUnit": {
             "state": "translated",
@@ -341,6 +419,12 @@
     },
     "Classic": {
       "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Klassisch"
+          }
+        },
         "en": {
           "stringUnit": {
             "state": "translated",
@@ -357,6 +441,12 @@
     },
     "DEPLETED": {
       "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ERSCHÖPFT"
+          }
+        },
         "en": {
           "stringUnit": {
             "state": "translated",
@@ -373,6 +463,12 @@
     },
     "Dark": {
       "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dunkel"
+          }
+        },
         "en": {
           "stringUnit": {
             "state": "translated",
@@ -447,6 +543,12 @@
     },
     "Default": {
       "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Standard"
+          }
+        },
         "en": {
           "stringUnit": {
             "state": "translated",
@@ -487,6 +589,12 @@
     },
     "HIGH": {
       "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "HOCH"
+          }
+        },
         "en": {
           "stringUnit": {
             "state": "translated",
@@ -527,6 +635,12 @@
     },
     "LIGHT": {
       "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "LEICHT"
+          }
+        },
         "en": {
           "stringUnit": {
             "state": "translated",
@@ -543,6 +657,12 @@
     },
     "LOW": {
       "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "NIEDRIG"
+          }
+        },
         "en": {
           "stringUnit": {
             "state": "translated",
@@ -641,6 +761,12 @@
     },
     "MODERATE": {
       "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "MODERAT"
+          }
+        },
         "en": {
           "stringUnit": {
             "state": "translated",
@@ -715,6 +841,12 @@
     },
     "No heart-rate data": {
       "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keine Herzfrequenzdaten"
+          }
+        },
         "en": {
           "stringUnit": {
             "state": "translated",
@@ -731,6 +863,12 @@
     },
     "PEAK": {
       "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SPITZE"
+          }
+        },
         "en": {
           "stringUnit": {
             "state": "translated",
@@ -771,6 +909,12 @@
     },
     "PRIMED": {
       "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "BEREIT"
+          }
+        },
         "en": {
           "stringUnit": {
             "state": "translated",
@@ -787,6 +931,12 @@
     },
     "Recovery calendar, %lld days, average %lld, low %lld, high %lld": {
       "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Erholungskalender, %lld Tage, Durchschnitt %lld, niedrigster Wert %lld, höchster Wert %lld"
+          }
+        },
         "en": {
           "stringUnit": {
             "state": "translated",
@@ -803,6 +953,12 @@
     },
     "Recovery calendar, no data": {
       "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Erholungskalender, keine Daten"
+          }
+        },
         "en": {
           "stringUnit": {
             "state": "translated",
@@ -819,6 +975,12 @@
     },
     "STRENUOUS": {
       "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ANSTRENGEND"
+          }
+        },
         "en": {
           "stringUnit": {
             "state": "translated",
@@ -835,6 +997,12 @@
     },
     "Sleep stages, %@": {
       "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Schlafphasen, %@"
+          }
+        },
         "en": {
           "stringUnit": {
             "state": "translated",
@@ -851,6 +1019,12 @@
     },
     "Sleep stages, no data": {
       "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Schlafphasen, keine Daten"
+          }
+        },
         "en": {
           "stringUnit": {
             "state": "translated",
@@ -867,6 +1041,12 @@
     },
     "System": {
       "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "System"
+          }
+        },
         "en": {
           "stringUnit": {
             "state": "translated",
@@ -941,6 +1121,12 @@
     },
     "Trend, %lld points, latest %@, low %@, high %@": {
       "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Trend, %lld Punkte, zuletzt %@, niedrigster Wert %@, höchster Wert %@"
+          }
+        },
         "en": {
           "stringUnit": {
             "state": "translated",
@@ -957,6 +1143,12 @@
     },
     "Yesterday": {
       "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gestern"
+          }
+        },
         "en": {
           "stringUnit": {
             "state": "translated",
@@ -997,6 +1189,12 @@
     },
     "asleep %@": {
       "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ geschlafen"
+          }
+        },
         "en": {
           "stringUnit": {
             "state": "translated",
@@ -1013,6 +1211,12 @@
     },
     "average %@ bpm": {
       "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "durchschnittlich %@ bpm"
+          }
+        },
         "en": {
           "stringUnit": {
             "state": "translated",
@@ -1029,6 +1233,12 @@
     },
     "just now": {
       "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "gerade eben"
+          }
+        },
         "en": {
           "stringUnit": {
             "state": "translated",
@@ -1069,6 +1279,12 @@
     },
     "range %@ to %@": {
       "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bereich %@ bis %@"
+          }
+        },
         "en": {
           "stringUnit": {
             "state": "translated",


### PR DESCRIPTION
## Summary

Closes #326. The reported strings ("Slept", "needed", "hours of sleep", "effort", "rest", …) were symptoms of a much bigger gap than a few missed screens — traced the actual coverage of every `.xcstrings` catalog on the Apple side:

| Catalog | Keys | Missing `de` (before) |
|---|---|---|
| `Strand/Resources/Localizable.xcstrings` (main app) | 3093 | 2 |
| `Packages/StrandDesign/…/Localizable.xcstrings` (shared design system) | 41 | **36** |
| `NOOPWatch/Localizable.xcstrings` | 50 | **38** |
| `NOOPWatchComplications/Localizable.xcstrings` | 30 | **27** |

`StrandDesign` is the shared chart/component package used on nearly every screen (sleep-stage hypnogram, trend charts, recovery calendar, HR chart, the Settings → Appearance picker), so its near-total lack of German translation explains why untranslated fragments kept surfacing across *unrelated* screens rather than in one place. The Watch app and its complications were likewise almost entirely untranslated.

- Filled in all missing `de` entries in the 4 catalogs above, matching the terminology already established in the main catalog (Recovery→Erholung, Charge→Ladung, Peak→Spitze, Depleted→Erschöpft, etc.)
- Fixed [`DayNavBar.swift`](Packages/StrandDesign/Sources/StrandDesign/DayNavBar.swift): `Text(label)` passed no `bundle`, so a `LocalizedStringKey` built in a computed property (not a literal at the call site) can't have its module inferred by the compiler and silently falls back to `Bundle.main`. It only read correctly today because "Today"/"Yesterday" happen to be duplicated in the app's own catalog — every other package-only string wouldn't have had that safety net.

Scope: German (`de`) only, matching the reported issue. Other under-translated languages in these catalogs (the same files have gaps in `es`/`it`/`pt-PT`/etc.) are out of scope here.

## Test plan

- [x] `swift build` for `StrandDesign` — green
- [x] `xcodebuild -scheme Strand -destination 'platform=macOS'` — **BUILD SUCCEEDED**
- [x] `xcodebuild -scheme NOOPWatch -destination 'platform=watchOS Simulator,name=Apple Watch Series 11 (46mm)'` — **BUILD SUCCEEDED**
- [x] `xcodebuild -scheme NOOPWatchComplications -destination 'platform=watchOS Simulator,name=Apple Watch Series 11 (46mm)'` (builds the `NOOPiOS` host too) — **BUILD SUCCEEDED**
- [ ] Not verified: live device with German system language (no on-device pass done for this PR)