### PR TITLE
Protocol: decode the WHOOP 5 CONSOLE_LOGS record header + text (#103)

### DIFF
--- a/Packages/WhoopProtocol/Sources/WhoopProtocol/Interpreter.swift
+++ b/Packages/WhoopProtocol/Sources/WhoopProtocol/Interpreter.swift
@@ -305,6 +305,8 @@ private func parseFrameWhoop5(_ frame: [UInt8], collectFields: Bool) -> ParsedFr
             decodeWhoop5CommandResponse(frame, fb: fb, schema: schema, payloadEnd: payloadEnd)
         } else if spec!.post == "event" {
             decodeWhoop5Event(frame, fb: fb, schema: schema)
+        } else if spec!.post == "console_logs" {
+            decodeWhoop5ConsoleLogs(frame, fb: fb, payloadEnd: payloadEnd)
         } else if let payloadEnd = payloadEnd, innerStart + 3 < payloadEnd, payloadEnd <= frame.count {
             // Other types: static fields decoded above; the remaining variable body is kept raw —
             // its 4.0 post-hook awaits per-type 5.0 hardware verification before we apply it at +4.
@@ -749,6 +751,36 @@ private func decodeWhoop5Event(_ frame: [UInt8], fb: FieldBuilder, schema: Schem
     if let ch = readDType(frame, 30, "u8"), ch <= 1 {
         fb.add(30, 1, "battery_charging", "battery", value: .int(ch & 1))
     }
+}
+
+/// Decode a WHOOP 5.0 CONSOLE_LOGS (type 50) frame — the strap firmware's own plaintext diagnostics
+/// channel. The console is one continuous text stream chunked into fixed-size pieces, so a log line
+/// routinely splits mid-sentence across frames; consumers reassemble by `record_index` order before
+/// reading. Lines look like `19, 146552119: BLE: History burst success. Trim: …` (boot-count,
+/// firmware tick ms, tag, message) and narrate the history sync and the sensor pipeline
+/// ("SENSORS: AFE configuration changed", "SIGPROC: generated a valid SPO2 during sleep") — primary
+/// raw material for the deep-data work (#103).
+///
+/// Record header, verified across 3 257 real frames from two nights (all one shape: 76-byte frame,
+/// chunk_len 52, channel 1): `record_index` u16@9 (monotonic per-chunk counter — the frame's u8 seq
+/// slot is its low byte), `unix` u32@12 + `subsec` u16@16 (batch write time), chunk_len u16@18,
+/// channel u8@20, text bytes @21 up to the CRC32 trailer with NUL padding. The Kotlin twin is
+/// `Framing.decodeConsoleLogsWhoop5` (text key "console"), same offsets.
+private func decodeWhoop5ConsoleLogs(_ frame: [UInt8], fb: FieldBuilder, payloadEnd: Int?) {
+    if let idx = readDType(frame, 9, "u16") {
+        fb.add(9, 2, "record_index", "meta", value: .int(idx), note: "per-chunk counter")
+    }
+    if let unix = readDType(frame, 12, "u32") { fb.add(12, 4, "unix", "time", value: .int(unix)) }
+    if let ss = readDType(frame, 16, "u16") { fb.add(16, 2, "subsec", "time", value: .int(ss)) }
+    guard let payloadEnd = payloadEnd, 21 < payloadEnd, payloadEnd <= frame.count else { return }
+    var textBytes = Array(frame[21..<payloadEnd])
+    while textBytes.last == 0 { textBytes.removeLast() }
+    guard !textBytes.isEmpty else { return }
+    let txt = String(decoding: textBytes, as: UTF8.self)
+    fb.region(21, payloadEnd, "console log text", "text", note: String(txt.prefix(80)))
+    // Same 2 KB cap as the 4.0 console post-hook: a garbled/malicious peer must not pin arbitrary
+    // bytes as a String on the parse path. A real chunk is 51 bytes.
+    fb.parsed["log"] = .string(String(txt.prefix(2048)))
 }
 
 @inline(__always)

--- a/Packages/WhoopProtocol/Tests/WhoopProtocolTests/Whoop5ConsoleLogsTests.swift
+++ b/Packages/WhoopProtocol/Tests/WhoopProtocolTests/Whoop5ConsoleLogsTests.swift
@@ -1,0 +1,68 @@
+import XCTest
+@testable import WhoopProtocol
+
+/// WHOOP 5.0 ("puffin") CONSOLE_LOGS (type 50) decode, verified against real captured frames.
+///
+/// The strap streams its firmware console as fixed-size text chunks: record header (`record_index`
+/// u16@9, `unix` u32@12, `subsec` u16@16, chunk_len u16@18, channel u8@20), then the raw text at @21
+/// with NUL padding up to the CRC32 trailer. One log line routinely spans several frames — the two
+/// consecutive fixtures below split "…start response a" / "ck, start burst" mid-word — so consumers
+/// reassemble by `record_index` before reading. All fixtures are real frames from a 2026-07-12
+/// history sync (the strap narrating its own transfer); they carry no device name / serial / token.
+final class Whoop5ConsoleLogsTests: XCTestCase {
+
+    private func bytes(_ s: String) -> [UInt8] {
+        var out = [UInt8](); var i = s.startIndex
+        while i < s.endIndex {
+            let j = s.index(i, offsetBy: 2)
+            out.append(UInt8(s[i..<j], radix: 16)!); i = j
+        }
+        return out
+    }
+
+    /// Real console chunk: a full log line plus the continuation space, NUL-terminated.
+    private let sendHistoricalHex =
+        "aa014400010030b132ac020052b4526a33733400013134363535323131393a20424c455f434d443a2043" +
+        "6f6d6d616e642053656e6420486973746f726963616c20446174610a200018d8fbf6"
+
+    func testConsoleChunkDecodesHeaderAndText() {
+        let f = parseFrame(bytes(sendHistoricalHex), family: .whoop5)
+        XCTAssertEqual(f.typeName, "CONSOLE_LOGS")
+        XCTAssertEqual(f.crcOK, true)
+        XCTAssertEqual(f.parsed["record_index"]?.intValue, 684)
+        XCTAssertEqual(f.parsed["unix"]?.intValue, 1783805010)
+        XCTAssertEqual(f.parsed["subsec"]?.intValue, 29491)
+        XCTAssertEqual(f.parsed["log"]?.stringValue,
+                       "146552119: BLE_CMD: Command Send Historical Data\n ")
+    }
+
+    /// The next two chunks of the same stream: one log line split mid-word ("…response a" | "ck,
+    /// start burst…") across consecutive record_index values — the reassembly contract.
+    private let splitLineAHex =
+        "aa014400010030b132ad020052b4526a337334000131392c203134363535323131393a20424c453a2068" +
+        "697374207472616e7366657220737461727420726573706f6e7365206100324a7906"
+    private let splitLineBHex =
+        "aa014400010030b132ae020052b4526a3373340001636b2c2073746172742062757273740a2031392c20" +
+        "3134363535343633303a20424c453a20486973746f727920627572737400e67d611f"
+
+    func testConsecutiveChunksCarryContiguousIndices() {
+        let a = parseFrame(bytes(splitLineAHex), family: .whoop5)
+        let b = parseFrame(bytes(splitLineBHex), family: .whoop5)
+        XCTAssertEqual(a.crcOK, true)
+        XCTAssertEqual(b.crcOK, true)
+        XCTAssertEqual(a.parsed["record_index"]?.intValue, 685)
+        XCTAssertEqual(b.parsed["record_index"]?.intValue, 686)
+        XCTAssertEqual(a.parsed["log"]?.stringValue,
+                       "19, 146552119: BLE: hist transfer start response a")
+        XCTAssertEqual(b.parsed["log"]?.stringValue,
+                       "ck, start burst\n 19, 146554630: BLE: History burst")
+    }
+
+    /// A truncated frame (header only, no text region) must not decode a log — and must not crash.
+    func testHeaderOnlyFrameYieldsNoLog() {
+        let full = bytes(sendHistoricalHex)
+        let truncated = Array(full[0..<20])
+        let f = parseFrame(truncated, family: .whoop5)
+        XCTAssertNil(f.parsed["log"])
+    }
+}

--- a/android/app/src/main/java/com/noop/protocol/Framing.kt
+++ b/android/app/src/main/java/com/noop/protocol/Framing.kt
@@ -362,9 +362,19 @@ object Framing {
      * diagnostics channel — it narrates history syncs ("BLE: PullStats: Data: N, Events: N…",
      * "RTC timestamp … is invalid; not saving data to flash"), which is how the clock-before-history
      * requirement was discovered. Capped at 2 KB (matches the Swift PostHooks console hardening).
+     *
+     * The record header carries record_index u16@9 (monotonic per-chunk counter — the console is
+     * one continuous stream chunked into fixed-size pieces, and lines split mid-sentence across
+     * frames, so consumers reassemble in record_index order), unix u32@12 and subsec u16@16 (batch
+     * write time). Offsets verified across 3 257 real frames from two nights (all one shape:
+     * 76-byte frame, chunk_len u16@18 = 52, channel u8@20 = 1); the Swift twin is
+     * `decodeWhoop5ConsoleLogs` in Interpreter.swift (its text key is "log").
      * (#78 fork, real-frame verified)
      */
     private fun decodeConsoleLogsWhoop5(frame: ByteArray, parsed: MutableMap<String, Any?>) {
+        frame.u16(9)?.let { parsed["record_index"] = it }
+        frame.u32(12)?.let { parsed["unix"] = it.toInt() }
+        frame.u16(16)?.let { parsed["subsec"] = it }
         val payEnd = frame.size - 4
         if (payEnd <= 21) return
         val text = frame.copyOfRange(21, payEnd)

--- a/android/app/src/test/java/com/noop/protocol/FramingTest.kt
+++ b/android/app/src/test/java/com/noop/protocol/FramingTest.kt
@@ -504,5 +504,35 @@ class FramingTest {
         assertEquals("CONSOLE_LOGS", parsed.typeName)
         assertEquals(true, parsed.crcOk)
         assertEquals("Historical Data\n 55, 2581959: BLE: hist transfer s", parsed.parsed["console"])
+        // Record header (Swift parity: decodeWhoop5ConsoleLogs): per-chunk counter + batch time.
+        assertEquals(671, parsed.parsed["record_index"])
+        assertEquals(1773607251, parsed.parsed["unix"])
+        assertEquals(16041, parsed.parsed["subsec"])
+    }
+
+    @Test
+    fun whoop5_consoleLogs_consecutiveChunksCarryContiguousIndices() {
+        // Two consecutive real chunks of one console stream — a single log line split mid-word
+        // ("…response a" | "ck, start burst") across frames. record_index is the reassembly key.
+        val a = Framing.parseFrame(
+            fromHex(
+                "aa014400010030b132ad020052b4526a337334000131392c203134363535323131393a20424c453a2068" +
+                    "697374207472616e7366657220737461727420726573706f6e7365206100324a7906",
+            ),
+            DeviceFamily.WHOOP5,
+        )
+        val b = Framing.parseFrame(
+            fromHex(
+                "aa014400010030b132ae020052b4526a3373340001636b2c2073746172742062757273740a2031392c20" +
+                    "3134363535343633303a20424c453a20486973746f727920627572737400e67d611f",
+            ),
+            DeviceFamily.WHOOP5,
+        )
+        assertEquals(true, a.crcOk)
+        assertEquals(true, b.crcOk)
+        assertEquals(685, a.parsed["record_index"])
+        assertEquals(686, b.parsed["record_index"])
+        assertEquals("19, 146552119: BLE: hist transfer start response a", a.parsed["console"])
+        assertEquals("ck, start burst\n 19, 146554630: BLE: History burst", b.parsed["console"])
     }
 }


### PR DESCRIPTION
## What

The WHOOP 5 parse path (`parseFrameWhoop5`) left type 50 (CONSOLE_LOGS) as a raw `unknown` region on Swift, while the Kotlin twin already extracted the console text. This adds the missing Swift decoder and brings both platforms to the same, fuller decode of the strap firmware's plaintext diagnostics channel:

- `record_index` u16@9 — monotonic per-chunk counter. The console is one continuous text stream chunked into fixed-size pieces; log lines routinely split mid-word across frames, so this is the reassembly key.
- `unix` u32@12 + `subsec` u16@16 — batch write time.
- text @21 up to the CRC32 trailer, NUL-trimmed, capped at 2 KB (same hardening as the 4.0 console post-hook; Swift key `log`, Kotlin key `console` as before — the existing `WhoopBleClient` consumer is untouched).

## Why

The console narrates the history sync ("BLE: History burst success. Trim: …") and the sensor pipeline ("SENSORS: AFE configuration changed", "SIGPROC: generated a valid SPO2 during sleep") — it is primary raw material for the #103 deep-data work, and until now the Swift/whoop-decode side dropped it entirely.

## Verification

- Offsets verified across **3 257 real CONSOLE_LOGS frames** from two nights of iOS HCI captures (PacketLogger `.pklg` → `hci_extract.py`) of the official app syncing a WHOOP 5.0: every frame one shape (76 bytes, chunk_len u16@18 = 52, channel u8@20 = 1), record_index strictly monotonic within a stream.
- `swift test` (WhoopProtocol, 274 tests) passes; new `Whoop5ConsoleLogsTests` pins two consecutive real chunks whose text splits one line mid-word ("…response a" / "ck, start burst") plus a truncated-frame guard.
- `./gradlew testFullDebugUnitTest --tests com.noop.protocol.FramingTest` passes; the existing Kotlin console test now also pins the header fields, and a new test pins the same split-line pair as Swift (cross-platform fixture parity).
- No app-target code touched; `Packages/**` only on Swift, `protocol/` decoder + test only on Kotlin.