### PR TITLE
Capture: durable WHOOP 5 EVENT-frame log for deep-data research (#103)

### DIFF
--- a/Strand/BLE/BLEManager.swift
+++ b/Strand/BLE/BLEManager.swift
@@ -631,6 +631,7 @@ public final class BLEManager: NSObject, ObservableObject {
     /// WHOOP 4.0 and when the toggle is off. Lazy so it shares `state` after init. (Cherry-picked from
     /// @j0b-dev's PR #20.)
     private lazy var puffinRecorder = PuffinFrameRecorder(state: state)
+    private lazy var puffinEventLog = PuffinEventLog()
 
     /// Force the puffin capture buffer to disk so the Settings export/reveal targets a current file.
     public func flushPuffinCaptures() { puffinRecorder.flush() }
@@ -3089,6 +3090,7 @@ extension BLEManager: @preconcurrency CBCentralManagerDelegate {
         keepAliveTimer = nil
         resetCharacteristics()
         puffinRecorder.flush()   // persist any buffered puffin capture frames before reconnect
+        puffinEventLog.close()   // release the event-log handle so the file is safe to export
         Task { @MainActor in await collector?.flushStandardHR() }   // persist any buffered 0x2A37 HR
         if autoReconnectPausedForBondLoop {
             // #747: the bond keeps being refused, so auto-reconnect is paused: we stop hammering a strap that
@@ -3785,6 +3787,11 @@ extension BLEManager: @preconcurrency CBPeripheralDelegate {
                 for frame in reassembler.feed(bytes) {
                     let isOffload = backfilling && BLEManager.isOffloadFrame(frame, family: .whoop5)
                     noteWhoop5R22Telemetry(frame, duringOffload: isOffload)   // #174 deep-data telemetry
+                    // Durable EVENT-frame log for deep-data research (#103) — BEFORE the offload
+                    // branch, so it sees both live events and their history replays (either path
+                    // may be the only one that delivers a given record). Single byte compare when
+                    // the frame is not an EVENT; no-op unless the capture toggle is on.
+                    puffinEventLog.appendIfEvent(frame: frame, char: characteristic.uuid)
                     if isOffload {
                         // Same policy as WHOOP4: historical offload frames are bulk sync traffic.
                         // Keep them out of the live UI parser during backfill and let Backfiller

--- a/Strand/BLE/PuffinEventLog.swift
+++ b/Strand/BLE/PuffinEventLog.swift
@@ -1,0 +1,90 @@
+import Foundation
+import CoreBluetooth
+
+/// Durable append-only log of WHOOP 5.0/MG EVENT (type 48 / 0x30) frames, for deep-data protocol
+/// research (#103).
+///
+/// EVENT frames are the strap's rare, still mostly uncatalogued records — e.g. the bi-hourly 56-byte
+/// record that tracks the nightly sleep-SpO₂ measurement cycle. Decoding them needs many
+/// (raw bytes, ground-truth value) pairs collected across weeks, which the session-scoped
+/// `PuffinFrameRecorder` cannot provide: its bulk capture files churn under a directory cap, so
+/// rare frames age out. This log keeps ONLY the ~150 tiny EVENT frames a day, in its own file that
+/// the bulk-capture eviction never touches, so they survive long enough to correlate.
+///
+/// Gated on the same Settings toggle as the frame recorder (`PuffinFrameRecorder.enabledKey`) —
+/// capture is passive/read-only with respect to the strap, and this adds no new setting. One JSONL
+/// line per frame (`{"ts_ms":…,"char":…,"hex":"…"}` — the same key names as `PuffinCaptureRecord`,
+/// so existing tooling reads it). Rotates at a soft cap keeping one previous generation, the same
+/// idiom as the Android twin (`WhoopBleClient.writeWhoop5EventLog`, `whoop5-events.jsonl`).
+@MainActor
+final class PuffinEventLog {
+
+    /// Rotate when the live file exceeds this. EVENT frames are ~40–120 B of hex each; a few KB per
+    /// day of wear, so 5 MB is years of history.
+    private static let softCapBytes = 5 * 1024 * 1024
+
+    /// The WHOOP 5 inner-record type byte for EVENT frames (the inner record starts at offset 8).
+    private static let eventTypeByte: UInt8 = 0x30
+
+    private var handle: FileHandle?
+    private var disabled = false
+
+    private var isEnabled: Bool {
+        UserDefaults.standard.bool(forKey: PuffinFrameRecorder.enabledKey)
+    }
+
+    /// `<AppSupport>/OpenWhoop/puffin-events.jsonl` — deliberately OUTSIDE `puffin-captures/`, whose
+    /// soft-cap eviction deletes oldest files wholesale.
+    private static func logURL() throws -> URL {
+        let fm = FileManager.default
+        let dir = try fm.url(for: .applicationSupportDirectory, in: .userDomainMask,
+                             appropriateFor: nil, create: true)
+            .appendingPathComponent("OpenWhoop", isDirectory: true)
+        try fm.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir.appendingPathComponent("puffin-events.jsonl")
+    }
+
+    /// Append `frame` if it is a WHOOP 5 EVENT frame and capture is enabled. Cheap for every other
+    /// frame: a single byte compare, no parse. Call for BOTH live and offload frames — the strap
+    /// replays historical EVENTs during a sync, and either path may be the only one that sees a
+    /// given record (the official app's trim can empty the strap's history before NOOP syncs).
+    func appendIfEvent(frame: [UInt8], char: CBUUID) {
+        guard !disabled, frame.count > 8, frame[8] == Self.eventTypeByte, isEnabled else { return }
+        let tsMs = Int(Date().timeIntervalSince1970 * 1000)
+        let hex = frame.map { String(format: "%02x", $0) }.joined()
+        let line = "{\"ts_ms\":\(tsMs),\"char\":\"\(char.uuidString.lowercased())\",\"hex\":\"\(hex)\"}\n"
+        do {
+            let h = try openHandle()
+            try h.write(contentsOf: Data(line.utf8))
+        } catch {
+            // A diagnostics log must never affect the connection path: disable for this launch.
+            disabled = true
+        }
+    }
+
+    /// Close the handle (e.g. on disconnect) so the file is safe to share/export immediately.
+    func close() {
+        try? handle?.close()
+        handle = nil
+    }
+
+    private func openHandle() throws -> FileHandle {
+        if let handle = handle { return handle }
+        let url = try Self.logURL()
+        let fm = FileManager.default
+        // Rotate at the cap: keep one previous generation, then start fresh (Android twin's idiom).
+        if let size = try? url.resourceValues(forKeys: [.fileSizeKey]).fileSize,
+           size > Self.softCapBytes {
+            let old = url.deletingPathExtension().appendingPathExtension("jsonl.1")
+            try? fm.removeItem(at: old)
+            try? fm.moveItem(at: url, to: old)
+        }
+        if !fm.fileExists(atPath: url.path) {
+            fm.createFile(atPath: url.path, contents: nil)
+        }
+        let h = try FileHandle(forWritingTo: url)
+        try h.seekToEnd()
+        handle = h
+        return h
+    }
+}

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -597,6 +597,9 @@ class WhoopBleClient(
 
         /** 5/MG raw-capture file (app filesDir; shared via Settings → "Share 5/MG capture"). */
         const val WHOOP5_CAPTURE_FILE = "whoop5-backfill-capture.jsonl"
+        const val WHOOP5_EVENT_LOG_FILE = "whoop5-events.jsonl"
+        // EVENT frames are ~40–120 B of hex each, a few KB per day of wear — 5 MB is years.
+        private const val WHOOP5_EVENT_LOG_MAX_BYTES = 5L * 1024 * 1024
         /** Rotation threshold (~10 MB) and absolute per-file line cap (a full overnight offload is
          *  ~28k frames; 40k leaves headroom — his fork's 20k truncated real sessions, #78 fork). */
         private const val WHOOP5_CAPTURE_MAX_BYTES = 10L * 1024 * 1024
@@ -3530,6 +3533,13 @@ class WhoopBleClient(
                     }
 
                     // PERSISTENCE / OFFLOAD ROUTING — port of the didUpdateValueFor tail block.
+                    // Durable EVENT-frame log for deep-data research (#103) — BEFORE the offload
+                    // branch, so it sees both live events and their history replays (either path
+                    // may be the only one that delivers a given record). Single byte compare when
+                    // the frame is not an EVENT; no-op unless the capture toggle is on.
+                    if (connectedFamily == DeviceFamily.WHOOP5) {
+                        writeWhoop5EventLogIfEvent(uuid.toString(), frame)
+                    }
                     if (backfilling) {
                         // Opt-in raw capture: record EVERY frame of the session (offload AND live
                         // flood — the offload flag lets analysis filter), BEFORE routing so frames
@@ -5571,6 +5581,38 @@ class WhoopBleClient(
             captureDisabled = true
             closeWhoop5BackfillCapture(flushSummary = false)
             log("Capture: write failed (${it.message}) — capture disabled")
+        }
+    }
+
+    @Volatile private var eventLogDisabled = false
+
+    /**
+     * Durable append-only log of WHOOP 5.0/MG EVENT (type 48 / 0x30) frames, for deep-data protocol
+     * research (#103). EVENT frames are the strap's rare, still mostly uncatalogued records — e.g.
+     * the bi-hourly 56-byte record that tracks the nightly sleep-SpO2 measurement cycle. Decoding
+     * them needs (raw bytes, ground-truth value) pairs collected across weeks, which the
+     * session-scoped backfill capture cannot provide (its file churns under its own cap). This log
+     * keeps ONLY the ~150 tiny EVENT frames a day in its own file so they survive long enough to
+     * correlate. Gated on the same capture pref as the backfill capture; one JSONL line per frame
+     * (`{"ts_ms":…,"char":…,"hex":"…"}`, same keys as the Swift twin `PuffinEventLog`); rotates at
+     * the cap keeping one previous generation, the backfill capture's idiom.
+     */
+    private fun writeWhoop5EventLogIfEvent(characteristic: String, frame: ByteArray) {
+        if (eventLogDisabled || frame.size <= 8 || (frame[8].toInt() and 0xFF) != 0x30) return
+        if (!PuffinExperiment.from(context).isCaptureEnabled) return
+        runCatching {
+            val f = java.io.File(context.filesDir, WHOOP5_EVENT_LOG_FILE)
+            if (f.exists() && f.length() > WHOOP5_EVENT_LOG_MAX_BYTES) {
+                val old = java.io.File(context.filesDir, "$WHOOP5_EVENT_LOG_FILE.1")
+                old.delete()
+                f.renameTo(old)
+            }
+            val hex = frame.toHex()
+            f.appendText("{\"ts_ms\":${System.currentTimeMillis()},\"char\":\"$characteristic\",\"hex\":\"$hex\"}\n")
+        }.onFailure {
+            // A diagnostics log must never affect the connection path: disable for this process.
+            eventLogDisabled = true
+            log("Capture: event log write failed (${it.message}) — event log disabled")
         }
     }
 


### PR DESCRIPTION
## What

A tiny, durable, append-only JSONL log of WHOOP 5.0/MG **EVENT (type 48 / 0x30) frames** on both platforms, as a research aid for #103.

- **macOS/iOS**: new `PuffinEventLog` (`Strand/BLE`), fed from the whoop5 notify loop **before** the offload branch, so it records both live events and their history replays (either path may be the only one that delivers a given record — another client's trim can empty the strap's history first). File: `AppSupport/OpenWhoop/puffin-events.jsonl`, deliberately outside `puffin-captures/` whose eviction deletes oldest files wholesale.
- **Android**: `writeWhoop5EventLogIfEvent` in `WhoopBleClient`, same hook position. File: `filesDir/whoop5-events.jsonl`.

Both sides: gated on the platform's **existing** puffin capture toggle (no new setting, passive/read-only with respect to the strap), same line shape (`{"ts_ms":…,"char":…,"hex":"…"}` — the `PuffinCaptureRecord` keys, so existing tooling reads it), 5 MB rotation keeping one previous generation (the Android backfill capture's idiom), and self-disable on the first write failure so a diagnostics path can never affect the connection. A non-EVENT frame costs a single byte compare.

## Why

EVENT frames are the strap's rare, still mostly uncatalogued records — e.g. the bi-hourly 56-byte record that tracks the nightly sleep-SpO₂ measurement cycle (two nights of iOS HCI captures show the strap attempting SpO₂ every 2 h during sleep — "SENSORS: AFE configuration changed" → "SIGPROC: generated a valid SPO2 during sleep" on the console — followed ~80 s later by exactly this event). Cracking their encoding needs (raw bytes, ground-truth value) pairs collected across **weeks**. The existing captures are session-scoped and size-capped for bulk traffic (macOS directory cap 50 MB, Android file rotation at 10 MB), so the ~150 tiny EVENT frames a day age out long before enough nights accumulate. This log keeps only those frames, for years at 5 MB.

## Verification

- `xcodebuild` **Strand (macOS)** and **NOOPiOS (iOS)** both build (app-target Swift; default CI doesn't cover it).
- `./gradlew compileFullDebugKotlin` passes.
- Passive capture only — no strap writes, no change to routing/ack behavior; the hook is a guarded early call in the existing frame loop. On-hardware validation is the accumulation itself over the coming nights; the file format round-trips through the existing `whoop-decode` tooling (`hex`/`char`/`ts_ms` keys).