### PR TITLE
fix(sleep): select the stager by device family only; remove the V2 toggle

### DIFF
--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/AnalyticsEngine.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/AnalyticsEngine.swift
@@ -319,10 +319,10 @@ public enum AnalyticsEngine {
                                   // pure-function callers/tests free of it; IntelligenceEngine threads the
                                   // night window's persisted band state. (#531 / H8 consume)
                                   bandSleepState: [(ts: Int, state: Int)] = [],
-                                  // Opt-in experimental sleep staging (V2). When true, detected nights are
-                                  // staged by `SleepStagerV2` instead of V1. Default false keeps V1 the
-                                  // byte-identical default for pure-function callers/tests; IntelligenceEngine
-                                  // threads `PuffinExperiment.experimentalSleepV2Enabled`. (V7 / #690)
+                                  // Which staging engine runs: true -> `SleepStagerV2` (5.0/MG), false -> V1
+                                  // (WHOOP 4.0). Default false keeps V1 the byte-identical default for
+                                  // pure-function callers/tests; IntelligenceEngine resolves it by device
+                                  // family (`sleepStagerV2(family:)`). (#319 / #327)
                                   useSleepStagerV2: Bool = false,
                                   // Sleep PROVENANCE for the per-day sleep trace (CAPTURE-C / #799). The
                                   // measured BLE path is `.measured` (the default); the caller passes

--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/SleepStager.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/SleepStager.swift
@@ -683,12 +683,11 @@ public enum SleepStager {
     /// re-onset (#531): a daytime block the strap itself scored predominantly "asleep" is KEPT even on a
     /// borderline HR dip. Default empty keeps pure-function callers/tests free of it; IntelligenceEngine
     /// passes the night window's persisted band state. It can only RESCUE a real-sleep block, never fabricate.
-    /// `useSleepStagerV2` (V7 / #690): when true, each accepted night is staged by the experimental
-    /// cardiorespiratory recipe `SleepStagerV2.stageSession` instead of V1's `stageSession`. DETECTION is
-    /// unchanged (same accepted windows); only the per-epoch hypnogram differs. Default false keeps V1 the
-    /// byte-identical default (the frozen-golden tests stay green). The live call site threads
-    /// `PuffinExperiment.experimentalSleepV2Enabled` so the Settings toggle now affects normal detected
-    /// nights, not just the self-heal restage path.
+    /// `useSleepStagerV2`: when true, each accepted night is staged by the cardiorespiratory recipe
+    /// `SleepStagerV2.stageSession` instead of V1's `stageSession`. DETECTION is unchanged (same accepted
+    /// windows); only the per-epoch hypnogram differs. Default false keeps V1 the byte-identical default
+    /// (the frozen-golden tests stay green). The live call site resolves this by DEVICE FAMILY (V2 on
+    /// 5.0/MG, V1 on WHOOP 4.0 — #319/#327), for both normal detected nights and the self-heal restage path.
     public static func detectSleep(hr: [HRSample] = [],
                                    rr: [RRInterval] = [],
                                    resp: [RespSample] = [],

--- a/Strand/BLE/PuffinExperiment.swift
+++ b/Strand/BLE/PuffinExperiment.swift
@@ -53,20 +53,10 @@ enum PuffinExperiment {
     /// "Experimental sleep staging (V2)": re-stage each detected night with `SleepStagerV2` — a transparent
     /// cardiorespiratory recipe (reimplemented from contributor PR #600) — instead of the older V1 stager.
     /// Pure analysis switch: it changes ONLY which staging engine runs over an already-detected sleep window;
-    /// sleep DETECTION, scoring and the V1 path are all untouched. Model-agnostic (WHOOP 4 and 5). **Default
-    /// ON**: V2 was promoted to the default staging engine after a 44-subject cross-subject benchmark (AAUWSS
-    /// + Walch sleep-accel, leave-one-subject-out) showed V2 strictly dominates V1 (kappa 0.35 vs 0.03, deep
-    /// recall 55 % vs 1 %) — the multi-subject validation this recipe originally lacked. V1 remains available.
-    /// Read at the staging call site (Repository). Mirrors the Android `PuffinExperiment.KEY_EXPERIMENTAL_SLEEP_V2`.
-    static let experimentalSleepV2Key = "noopExperimentalSleepV2"
-
-    /// Default ON when the key is unset (mirrors the Android `getBoolean(KEY, true)`): a `bool(forKey:)` alone
-    /// reads a missing key as false, so an absent preference must resolve to the promoted V2 default explicitly.
-    static var experimentalSleepV2Enabled: Bool {
-        UserDefaults.standard.object(forKey: experimentalSleepV2Key) == nil
-            ? true
-            : UserDefaults.standard.bool(forKey: experimentalSleepV2Key)
-    }
+    // NOTE: the former "Experimental sleep staging (V2)" opt-in was REMOVED. The staging engine is now
+    // selected purely by DEVICE FAMILY (IntelligenceEngine.sleepStagerV2(family:)): V2 on 5.0/MG, V1 on
+    // WHOOP 4.0 (#319 / #327). A per-user override only caused confusion — a 4.0 owner "enabling V2"
+    // changed nothing because 4.0 is gated to V1 (issue #345). No UserDefaults key is read or written for it.
 
     /// Opt-in "Auto-detect workouts": after a sync / on Today appear, scan the last day or two of HR for a
     /// SUSTAINED-ELEVATED window (resting HR + 30 bpm held ≥ 12 min) that doesn't overlap a saved workout,

--- a/Strand/Data/IntelligenceEngine.swift
+++ b/Strand/Data/IntelligenceEngine.swift
@@ -622,12 +622,9 @@ final class IntelligenceEngine: ObservableObject {
                                                                      from: from, to: to, store: store)
                 }
 
-                // #690: read the experimental-V2 toggle ONCE here (off the detached executor, matching the
-                // Repository self-heal call site) and capture the Bool, so the Settings toggle now drives the
-                // NORMAL detected-night staging path , not only the userEdited self-heal restage.
-                // #319: V2 is the default only on 5.0/MG (where #277 promoted it); WHOOP 4.0 always uses V1.
-                let useSleepStagerV2 = Self.sleepStagerV2(enabled: PuffinExperiment.experimentalSleepV2Enabled,
-                                                          family: skinFamily)
+                // #319: V2 is the default on 5.0/MG (where #277 promoted it); WHOOP 4.0 always uses V1. The
+                // selection is purely by device family now (the per-user "experimental V2" toggle is gone).
+                let useSleepStagerV2 = Self.sleepStagerV2(family: skinFamily)
 
                 // Already OFF the main actor , score directly (the prior nested `Task.detached` here only
                 // existed to hop off the main actor; the whole loop now runs off it, so the score is computed
@@ -1455,13 +1452,19 @@ final class IntelligenceEngine: ObservableObject {
     /// The strap family that wrote `owner`'s skin-temp rows (#938), so the nightly funnel converts the raw
     /// register on the right scale. The model-label → family mapping (and the `.whoop5` fallback for
     /// unknowns) lives in `DeviceFamily.forRegistryModel` (#171).
-    /// #319: whether V2 staging should run for a night owned by `family`. V2 is the default only on 5.0/MG
+    /// #319: whether V2 staging should run for a night owned by `family`. V2 is the default on 5.0/MG
     /// (where #277 promoted it after a benchmark on NON-WHOOP wrist sensors); WHOOP 4.0 always uses V1 — its
     /// SPARSE motion makes V2 both inflate the Rest restorative term AND manufacture deep/REM that DEFEATS
-    /// the H9 low-confidence guard, so a poor 4.0 night reads as a confident 85-100. Byte-parity twin of
-    /// Android `IntelligenceEngine.sleepStagerV2ForFamily`.
-    nonisolated static func sleepStagerV2(enabled: Bool, family: DeviceFamily) -> Bool {
-        enabled && family != .whoop4
+    /// the H9 low-confidence guard, so a poor 4.0 night reads as a confident 85-100. This is the SOLE
+    /// staging-engine selector: the former per-user "Experimental sleep V2" toggle was removed, because a
+    /// 4.0 owner "enabling V2" changed nothing yet looked broken (issue #345). Byte-parity twin of Android
+    /// `IntelligenceEngine.sleepStagerV2ForFamily`.
+    ///
+    /// 4.0 FOLLOW-UP — NEEDS REAL 4.0 RAW DATA: a motion-robust V2 that recovers wake from R-R when motion
+    /// is sparse could eventually unify both families, but un-gating this line MUST be validated on real
+    /// WHOOP 4.0 traces first (#271, #319). No 4.0+PSG data exists yet, so 4.0 stays on V1.
+    nonisolated static func sleepStagerV2(family: DeviceFamily) -> Bool {
+        family != .whoop4
     }
 
     nonisolated static func skinTempFamily(forOwner owner: String, devices: [PairedDevice]) -> DeviceFamily {

--- a/Strand/Data/Repository.swift
+++ b/Strand/Data/Repository.swift
@@ -1246,11 +1246,13 @@ final class Repository: ObservableObject {
         let hr = (try? await store.hrSamples(deviceId: deviceId, from: lo, to: hi, limit: 200_000)) ?? []
         let rr = (try? await store.rrIntervals(deviceId: deviceId, from: lo, to: hi, limit: 200_000)) ?? []
         let resp = (try? await store.respSamples(deviceId: deviceId, from: lo, to: hi, limit: 200_000)) ?? []
-        // Opt-in experimental staging (Settings → Experimental · Sleep staging): when the user has flipped
-        // the V2 flag on, re-stage with the cardiorespiratory recipe `SleepStagerV2`; otherwise the default
-        // V1 `SleepStager`. Read once here off the actor; the switch is purely which engine runs over the
-        // already-detected window , V1 stays the default and is untouched. (V7 Pillar 3b)
-        let useV2 = PuffinExperiment.experimentalSleepV2Enabled
+        // #327 follow-up: family-gate the self-heal restage too, so an EDITED WHOOP 4.0 night re-stages with
+        // V1 (matching the normal detected-night path). Resolve the healed strap's OWN family (correct for a
+        // multi-device user running both a 4.0 and a 5.0/MG). Before this the healer read the (now-removed)
+        // per-user toggle, so an edited 4.0 night could still run V2 — the small follow-up #327 noted. 4.0
+        // needs real raw data before V2 can run here (#271, #319).
+        let healFamily = Self.skinTempFamilies(store: store, ids: [deviceId])[deviceId] ?? .whoop5
+        let useV2 = IntelligenceEngine.sleepStagerV2(family: healFamily)
         let segs = await Task.detached(priority: .utility) {
             useV2
                 ? SleepStagerV2.stageSession(start: start, end: end, grav: grav, hr: hr, rr: rr, resp: resp)

--- a/Strand/Screens/SettingsView.swift
+++ b/Strand/Screens/SettingsView.swift
@@ -52,12 +52,6 @@ struct SettingsView: View {
     /// See [PuffinExperiment.continuousHrvOvernightOnlyKey].
     @AppStorage(PuffinExperiment.continuousHrvOvernightOnlyKey) private var continuousHrvOvernightOnly = false
 
-    /// "Experimental sleep staging (V2)" (ON by default, promoted after the 44-subject cross-subject
-    /// benchmark). When on, detected nights are re-staged with `SleepStagerV2` (the transparent
-    /// cardiorespiratory recipe) instead of the older V1 stager. Read at the staging call site in
-    /// `Repository`. See [PuffinExperiment.experimentalSleepV2Key].
-    @AppStorage(PuffinExperiment.experimentalSleepV2Key) private var experimentalSleepV2Enabled = true
-
     // Imperial/Metric display preference (D#103). Stored data is always SI; this only changes how
     // distances/weights/heights/temperatures are SHOWN — and lets the profile fields below take
     // imperial entry. Temperature has a separate override so °C/°F can be picked independently.
@@ -1216,21 +1210,15 @@ struct SettingsView: View {
         SettingsSection(
             icon: "bed.double.fill",
             title: "Sleep staging",
-            blurb: "How NOOP splits a night into light / deep / REM. The V2 recipe is the default; turn it off to fall back to the older V1 staging."
+            blurb: "How NOOP splits a night into light / deep / REM."
         ) {
-            VStack(alignment: .leading, spacing: NoopMetrics.rowSpacing) {
-                Toggle(isOn: $experimentalSleepV2Enabled) {
-                    Text("Sleep staging (V2)")
-                        .font(StrandFont.subhead)
-                        .foregroundStyle(StrandPalette.textPrimary)
-                }
-                .toggleStyle(.switch)
-                .tint(StrandPalette.accent)
-                Text("A transparent cardiorespiratory recipe that recovers deep and REM better than the older V1 staging, and is now the default. It only changes how already-detected nights are split into stages (detection and scores are unchanged); turn it off to fall back to V1. Takes effect on the next nights staged.")
-                    .font(StrandFont.caption)
-                    .foregroundStyle(StrandPalette.textTertiary)
-                    .fixedSize(horizontal: false, vertical: true)
-            }
+            // The per-user "Experimental sleep V2" toggle was removed: the staging engine is selected purely
+            // by device family (V2 on 5.0/MG, V1 on WHOOP 4.0 — #319/#327), so a manual override only caused
+            // confusion (a 4.0 owner "enabling V2" changed nothing, issue #345).
+            Text("NOOP stages WHOOP 5.0/MG nights with the V2 cardiorespiratory recipe and WHOOP 4.0 nights with the V1 recipe, chosen automatically by your strap. There is no manual switch.")
+                .font(StrandFont.caption)
+                .foregroundStyle(StrandPalette.textTertiary)
+                .fixedSize(horizontal: false, vertical: true)
         }
     }
 

--- a/Strand/System/TestCentre.swift
+++ b/Strand/System/TestCentre.swift
@@ -104,7 +104,7 @@ public enum TestCentre {
         // experimental flags, gathered by the IA but not domain activations), so the migration only
         // stamps the guard. The legacy keys are read in place through their existing accessors:
         //   PuffinExperiment.defaultsKey / .deepDataKey / .broadcastHrKey / .keepRealtimeForDataKey /
-        //   .experimentalSleepV2Key / .autoDetectWorkoutsKey, and the ScheduledDebugExport "debugExport.*"
+        //   .autoDetectWorkoutsKey, and the ScheduledDebugExport "debugExport.*"
         //   keys. Nothing is moved; the Test Centre screen reads them where they already live.
         UserDefaults.standard.set(true, forKey: migratedKey)
     }

--- a/android/app/src/main/java/com/noop/analytics/AnalyticsEngine.kt
+++ b/android/app/src/main/java/com/noop/analytics/AnalyticsEngine.kt
@@ -217,9 +217,9 @@ object AnalyticsEngine {
         // empty keeps pure-function callers/tests free of it; IntelligenceEngine threads the night window's
         // persisted band state. Mirrors Swift. (#531 / H8 consume)
         bandSleepState: List<Pair<Long, Int>> = emptyList(),
-        // Opt-in experimental sleep staging (V2). When true, detected nights are staged by [SleepStagerV2]
-        // instead of V1. Default false keeps V1 the byte-identical default for pure-function callers/tests;
-        // IntelligenceEngine threads PuffinExperiment.from(context).experimentalSleepV2. Mirrors Swift. (V7 / #690)
+        // Which staging engine runs for detected nights: true → [SleepStagerV2] (5.0/MG), false → V1 (WHOOP
+        // 4.0). Default false keeps V1 the byte-identical default for pure-function callers/tests;
+        // IntelligenceEngine resolves it by device family (sleepStagerV2ForFamily). Mirrors Swift. (#319/#327)
         useSleepStagerV2: Boolean = false,
         // Sleep & Rest test-mode trace sink (E11). null = byte-identical default. When non-null the gate
         // trace from detectSleep and the Rest sub-score line are forwarded line-by-line. Mirrors Swift.

--- a/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
+++ b/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
@@ -39,15 +39,23 @@ import kotlinx.coroutines.withContext
 object IntelligenceEngine {
 
     /**
-     * #319: whether V2 staging should run for a night owned by [family]. V2 is the default only on 5.0/MG
+     * #319: whether V2 staging should run for a night owned by [family]. V2 is the default on 5.0/MG
      * (where #277 promoted it after a benchmark on NON-WHOOP wrist sensors); WHOOP 4.0 always uses V1 —
      * its SPARSE motion (only ~1 in 5 records carries it) makes V2 both inflate the Rest restorative term
      * AND manufacture deep/REM that DEFEATS the H9 low-confidence guard, so a poor 4.0 night reads as a
-     * confident 85-100 (issue #319). An explicit toggle still enables/disables V2 on 5.0/MG. Pure;
-     * byte-parity twin of Swift `IntelligenceEngine.sleepStagerV2(enabled:family:)`.
+     * confident 85-100 (issue #319). This is the SOLE staging-engine selector: the former per-user
+     * "Experimental sleep V2" toggle was removed, because V2 is objectively right on 5.0/MG and wrong on
+     * 4.0, so a user override only caused confusion (a 4.0 owner "enabling V2" changed nothing yet looked
+     * broken — issue #345). Pure; byte-parity twin of Swift `IntelligenceEngine.sleepStagerV2(family:)`.
+     *
+     * 4.0 FOLLOW-UP — NEEDS REAL 4.0 RAW DATA: a motion-robust V2 that recovers wake from R-R when motion
+     * is sparse could eventually unify both families on one engine, but un-gating this line MUST be
+     * validated on real WHOOP 4.0 traces first (#271, #319). No 4.0+PSG data exists yet (the open datasets
+     * are Empatica/Apple-Watch, not 4.0), so 4.0 stays on V1 until real 4.0 nights confirm V2 does not
+     * reproduce the #319 inflation.
      */
-    internal fun sleepStagerV2ForFamily(enabled: Boolean, family: DeviceFamily): Boolean =
-        enabled && family != DeviceFamily.WHOOP4
+    internal fun sleepStagerV2ForFamily(family: DeviceFamily): Boolean =
+        family != DeviceFamily.WHOOP4
 
     /**
      * Serialises [analyzeRecent] against itself. The pass is launched from four independent coroutines: the
@@ -178,12 +186,6 @@ object IntelligenceEngine {
         // are unaffected; the AppViewModel wires it to the BLE client's strap log (ble.externalLog),
         // which PII-scrubs every line at the sink. Pure-JVM (a closure), matching persistStepsCalibration.
         diag: (String) -> Unit = {},
-        // Opt-in "Experimental sleep staging (V2)" flag (Settings → Experimental · Sleep staging). The
-        // analytics layer is Context-free, so the Context-aware caller (AppViewModel / WhoopBleClient) reads
-        // it off SharedPreferences (PuffinExperiment.experimentalSleepV2) and threads it down to the sleep
-        // self-heal, which re-stages with SleepStagerV2 when true. Default false → V1 (the default, untouched
-        // path), so existing callers / tests are unaffected. (V7 Pillar 3b)
-        useExperimentalSleepV2: Boolean = false,
         // Sleep & Rest test-mode trace sink (Test Centre E5). The analytics layer is Context-free, so the
         // Context-aware caller (AppViewModel / WhoopBleClient) reads TestCentre.active(SLEEP) and passes a
         // non-null sink ONLY when the mode is on, routing each line to the .sleep-tagged strap log. null (the
@@ -231,7 +233,7 @@ object IntelligenceEngine {
         analyzeGate.withLock {
             val (out, healed) = analyzeRecentOnCpu(repo, profile, maxDays, importedDeviceId, maxHROverride,
                 nowSeconds, ownerSource, manualStepCoefficient, persistStepsCalibration, baselineEpoch,
-                recoveryEpoch, diag, useExperimentalSleepV2, sleepTraceSink, recoveryTraceSink, stepsTraceSink,
+                recoveryEpoch, diag, sleepTraceSink, recoveryTraceSink, stepsTraceSink,
                 universalSink, workoutsTraceSink, hrvTraceSink, deepHrvWindow)
             if (healed == 0) out
             // #899 heal re-pass: the pass above deleted overlapping duplicate sleep sessions AFTER its days
@@ -241,7 +243,7 @@ object IntelligenceEngine {
             // are gone), so this can never loop. Mirrors the Swift pendingForcedRescore re-arm.
             else analyzeRecentOnCpu(repo, profile, maxDays, importedDeviceId, maxHROverride,
                 nowSeconds, ownerSource, manualStepCoefficient, persistStepsCalibration, baselineEpoch,
-                recoveryEpoch, diag, useExperimentalSleepV2, sleepTraceSink, recoveryTraceSink, stepsTraceSink,
+                recoveryEpoch, diag, sleepTraceSink, recoveryTraceSink, stepsTraceSink,
                 universalSink, workoutsTraceSink, hrvTraceSink, deepHrvWindow).first
         }
     }
@@ -301,8 +303,6 @@ object IntelligenceEngine {
         baselineEpoch: Double = 0.0,
         recoveryEpoch: Double = 0.0,
         diag: (String) -> Unit = {},
-        // Opt-in experimental staging (V2), threaded down to the sleep self-heal. Default false → V1. (3b)
-        useExperimentalSleepV2: Boolean = false,
         // Sleep & Rest test-mode trace sink (Test Centre E5). null = byte-identical default; when non-null
         // each scored day threads it into AnalyticsEngine.analyzeDay so detectSleep's gate trace + the Rest
         // sub-score line forward line-by-line to the .sleep-tagged strap log. Mirrors Swift.
@@ -556,11 +556,9 @@ object IntelligenceEngine {
                 wristOff = wristOff,
                 habitualMidsleepSec = habitualMidsleepSec,
                 bandSleepState = bandSleepState,
-                // #690: thread the V2 toggle into the NORMAL staging path so it affects detected nights,
-                // not just the userEdited self-heal restage. The Context-aware caller (AppViewModel/
-                // WhoopBleClient) supplied it from PuffinExperiment.from(context).experimentalSleepV2.
-                // #319: V2 is the default only on 5.0/MG (where #277 promoted it); WHOOP 4.0 always uses V1.
-                useSleepStagerV2 = sleepStagerV2ForFamily(useExperimentalSleepV2, skinFamily),
+                // #319: V2 is the default on 5.0/MG (where #277 promoted it); WHOOP 4.0 always uses V1. The
+                // selection is purely by device family now (the per-user "experimental V2" toggle is gone).
+                useSleepStagerV2 = sleepStagerV2ForFamily(skinFamily),
                 // Sleep & Rest test mode (Test Centre E5): thread the trace sink straight through. null (the
                 // default) keeps analyzeDay's byte-identical untraced path; when the caller passed a non-null
                 // sink (mode on), detectSleep's gate trace + the Rest sub-score line route to the .sleep-tagged
@@ -745,13 +743,18 @@ object IntelligenceEngine {
         // daily aggregate this same pass. A no-op for nights already staged from raw (idempotent) and for
         // imported nights (raw never dense). MUST run before `editsByStart` so healed stages flow into
         // Rest/recovery this run. Raw streams are read under the STRAP id; edited rows under COMPUTED.
+        // #327 follow-up: family-gate the self-heal restage too, so an EDITED WHOOP 4.0 night re-stages
+        // with V1 (not V2), matching the normal detected-night path. Resolve the healed strap's OWN family
+        // (correct for a multi-device user running both a 4.0 and a 5.0/MG). Before #327 the healer read the
+        // raw toggle, so an edited 4.0 night could still run V2 — the small follow-up #327 noted.
+        val healStagerFamily = ownerSource?.skinTempFamily(importedDeviceId) ?: DeviceFamily.WHOOP5
         val editedRows = SleepStageHealer.selfHealEditedStages(
             repo = repo,
             computedDeviceId = computedId,
             strapDeviceId = importedDeviceId,
             windowStart = windowStart,
             windowEnd = nowSeconds,
-            useExperimentalSleepV2 = useExperimentalSleepV2,
+            useSleepStagerV2 = sleepStagerV2ForFamily(healStagerFamily),
         )
         // #299: [editsByStart] / [editOnsetByStart] are now built PER DAY inside the scoring loop (scoped to
         // the day each edit belongs to), NOT window-wide here. sleepEditedDaily folds any edited row that

--- a/android/app/src/main/java/com/noop/analytics/SleepStageHealer.kt
+++ b/android/app/src/main/java/com/noop/analytics/SleepStageHealer.kt
@@ -53,10 +53,11 @@ object SleepStageHealer {
         deviceId: String,
         start: Long,
         end: Long,
-        // Opt-in experimental staging (Settings → Experimental · Sleep staging). The analytics layer is
-        // Context-free, so the flag is threaded in from the Context-aware caller (default false → V1, so
-        // existing callers / tests are unaffected). When true, stage with SleepStagerV2; else V1. (V7 3b)
-        useExperimentalSleepV2: Boolean = false,
+        // Which staging engine to run, resolved by DEVICE FAMILY at the caller (IntelligenceEngine
+        // sleepStagerV2ForFamily): true = SleepStagerV2 (5.0/MG), false = V1 (WHOOP 4.0). The former
+        // per-user "experimental V2" toggle is gone; #327 gated the normal path by family and this heals
+        // the follow-up so an edited 4.0 night also stays on V1. Default false → V1 (byte-identical path).
+        useSleepStagerV2: Boolean = false,
     ): String? {
         val lo = start - 3_600L
         val hi = end + 3_600L
@@ -66,7 +67,7 @@ object SleepStageHealer {
         val hr = repo.hrSamples(deviceId, lo, hi, IntelligenceEngine.STREAM_LIMIT)
         val rr = repo.rrIntervals(deviceId, lo, hi, IntelligenceEngine.STREAM_LIMIT)
         val resp = repo.respSamples(deviceId, lo, hi, IntelligenceEngine.STREAM_LIMIT)
-        return restageFromSamples(start, end, grav, hr, rr, resp, useExperimentalSleepV2)
+        return restageFromSamples(start, end, grav, hr, rr, resp, useSleepStagerV2)
     }
 
     /**
@@ -97,12 +98,12 @@ object SleepStageHealer {
         hr: List<HrSample>,
         rr: List<RrInterval>,
         resp: List<RespSample>,
-        // Opt-in experimental staging: V2 cardiorespiratory recipe when true, else default V1 (default false
-        // so existing callers / tests stay on V1 — the V1 path is byte-identical). (V7 Pillar 3b)
-        useExperimentalSleepV2: Boolean = false,
+        // V2 cardiorespiratory recipe when true (5.0/MG), else default V1 (WHOOP 4.0). Resolved by device
+        // family at the caller; default false so callers/tests that don't pass it stay on V1 (byte-identical).
+        useSleepStagerV2: Boolean = false,
     ): String? {
         if (!isDense(grav, start, end)) return null
-        val segs = if (useExperimentalSleepV2) {
+        val segs = if (useSleepStagerV2) {
             SleepStagerV2.stageSession(start = start, end = end, grav = grav, hr = hr, rr = rr, resp = resp)
         } else {
             SleepStager.stageSession(start = start, end = end, grav = grav, hr = hr, rr = rr, resp = resp)
@@ -129,9 +130,9 @@ object SleepStageHealer {
         strapDeviceId: String,
         windowStart: Long,
         windowEnd: Long,
-        // Opt-in experimental staging, threaded from IntelligenceEngine (read off SharedPreferences by the
-        // Context-aware caller). Default false → V1, so callers/tests that don't pass it are unaffected. (3b)
-        useExperimentalSleepV2: Boolean = false,
+        // Family-resolved staging engine, threaded from IntelligenceEngine (sleepStagerV2ForFamily of the
+        // healed strap's own family). Default false → V1, so callers/tests that don't pass it are unaffected.
+        useSleepStagerV2: Boolean = false,
     ): List<SleepSession> {
         suspend fun editedRows(): List<SleepSession> =
             repo.sleepSessions(computedDeviceId, windowStart, windowEnd).filter { it.userEdited }
@@ -144,7 +145,7 @@ object SleepStageHealer {
             // STRAP id (where the sensor streams live), not the computed namespace. Skip when the raw
             // isn't dense yet, or when the result already matches what's stored (steady state — no write).
             val newJSON = restageFromRaw(repo, strapDeviceId, row.effectiveStartTs, row.endTs,
-                useExperimentalSleepV2) ?: continue
+                useSleepStagerV2) ?: continue
             if (newJSON == row.stagesJSON) continue
             // Keyed by the IMMUTABLE detected startTs (never effectiveStartTs) so it lands on the right
             // primary-key row; the DAO scopes the write to userEdited = 1.

--- a/android/app/src/main/java/com/noop/analytics/SleepStager.kt
+++ b/android/app/src/main/java/com/noop/analytics/SleepStager.kt
@@ -822,11 +822,11 @@ object SleepStager {
         // HR dip. Default empty keeps pure-function callers/tests free of it; IntelligenceEngine passes the
         // night window's persisted band state. It can only RESCUE a real-sleep block, never fabricate. Mirrors Swift.
         bandSleepState: List<Pair<Long, Int>> = emptyList(),
-        // V7 / #690: when true, each accepted night is staged by the experimental cardiorespiratory recipe
-        // [SleepStagerV2.stageSession] instead of V1's [stageSession]. DETECTION is unchanged (same accepted
-        // windows); only the per-epoch hypnogram differs. Default false keeps V1 the byte-identical default
-        // (frozen-golden tests stay green). The live call site threads the experimentalSleepV2 flag so the
-        // Settings toggle now affects normal detected nights, not just the self-heal restage path. Mirrors Swift.
+        // When true, each accepted night is staged by the cardiorespiratory recipe [SleepStagerV2.stageSession]
+        // instead of V1's [stageSession]. DETECTION is unchanged (same accepted windows); only the per-epoch
+        // hypnogram differs. Default false keeps V1 the byte-identical default (frozen-golden tests stay green).
+        // The live call site resolves this by DEVICE FAMILY (V2 on 5.0/MG, V1 on WHOOP 4.0 — #319/#327), for
+        // both normal detected nights and the self-heal restage path. Mirrors Swift.
         useSleepStagerV2: Boolean = false,
         // Sleep & Rest test mode (E10): when non-null, each candidate run emits ONE gate verdict line
         // and the sparse-gravity bridge records its result. Side-effect-only; the returned list is

--- a/android/app/src/main/java/com/noop/ble/PuffinExperiment.kt
+++ b/android/app/src/main/java/com/noop/ble/PuffinExperiment.kt
@@ -46,18 +46,10 @@ class PuffinExperiment(private val prefs: SharedPreferences) {
         get() = prefs.getBoolean(KEY_BROADCAST_HR, false)
         set(v) = prefs.edit().putBoolean(KEY_BROADCAST_HR, v).apply()
 
-    /** True if the user opted in to "Experimental sleep staging (V2)": detected nights are re-staged with
-     *  [com.noop.analytics.SleepStagerV2] (the transparent cardiorespiratory recipe, reimplemented from
-     *  contributor PR #600) instead of the default V1 [com.noop.analytics.SleepStager]. Pure analysis switch
-     *  — it changes ONLY which staging engine runs over an already-detected sleep window; detection, scoring
-     *  and the default V1 path are untouched. Model-agnostic (works on WHOOP 4 and 5). **Default true**:
-     *  V2 was promoted to the default staging engine after a 44-subject cross-subject benchmark (AAUWSS +
-     *  Walch sleep-accel, leave-one-subject-out) showed V2 strictly dominates V1 (kappa 0.35 vs 0.03, deep
-     *  recall 55% vs 1%) — the multi-subject validation this recipe originally lacked. V1 remains available.
-     *  Mirrors the macOS `PuffinExperiment.experimentalSleepV2Key`. */
-    var experimentalSleepV2: Boolean
-        get() = prefs.getBoolean(KEY_EXPERIMENTAL_SLEEP_V2, true)
-        set(v) = prefs.edit().putBoolean(KEY_EXPERIMENTAL_SLEEP_V2, v).apply()
+    // NOTE: the former "Experimental sleep staging (V2)" opt-in was REMOVED. The staging engine is now
+    // selected purely by DEVICE FAMILY (IntelligenceEngine.sleepStagerV2ForFamily): V2 on 5.0/MG, V1 on
+    // WHOOP 4.0 (#319 / #327). A per-user override only caused confusion — a 4.0 owner "enabling V2"
+    // changed nothing because 4.0 is gated to V1 (issue #345). No prefs key is read or written for it.
 
     companion object {
         /** Persisted preferences file. */
@@ -74,9 +66,6 @@ class PuffinExperiment(private val prefs: SharedPreferences) {
 
         /** "Broadcast heart rate" opt-in (mirrors macOS `PuffinExperiment.broadcastHrKey`). */
         const val KEY_BROADCAST_HR = "noopBroadcastHr"
-
-        /** "Experimental sleep staging (V2)" opt-in (mirrors macOS `PuffinExperiment.experimentalSleepV2Key`). */
-        const val KEY_EXPERIMENTAL_SLEEP_V2 = "noopExperimentalSleepV2"
 
         fun from(context: Context): PuffinExperiment =
             PuffinExperiment(context.getSharedPreferences(PREFS, Context.MODE_PRIVATE))

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -1314,10 +1314,6 @@ class WhoopBleClient(
                         // the night MEAN (the other app's number) — from the post-backfill scoring pass, not
                         // only the UI's 15-min loop. log() PII-scrubs at the sink. Best-effort + logging only.
                         diag = { s -> log(s) },
-                        // Opt-in experimental sleep staging (V2): stage this post-backfill pass with the same
-                        // engine the user chose in Settings, read off SharedPreferences here (the analytics
-                        // layer is Context-free). Default off → V1. (V7 Pillar 3b)
-                        useExperimentalSleepV2 = PuffinExperiment.from(context).experimentalSleepV2,
                         // Sleep & Rest test mode (Test Centre E5): when the SLEEP domain is on, route this
                         // post-backfill pass's per-day sleep gate trace into the .sleep-tagged strap log, so a
                         // shared report carries the staging proof from THIS scoring pass too, not only the UI

--- a/android/app/src/main/java/com/noop/ui/AppViewModel.kt
+++ b/android/app/src/main/java/com/noop/ui/AppViewModel.kt
@@ -771,9 +771,6 @@ class AppViewModel(app: Application) : AndroidViewModel(app) {
                         // report ships proof of what was computed per day. Mirrors the macOS sink wired to
                         // live.append(log:). (Sleep overhaul §2.5.)
                         diag = { line -> ble.externalLog(line) },
-                        // Opt-in experimental sleep staging (V2) — read off SharedPreferences here (the
-                        // analytics layer is Context-free) and thread it into the sleep self-heal. (V7 3b)
-                        useExperimentalSleepV2 = PuffinExperiment.from(appContext).experimentalSleepV2,
                         // Sleep & Rest test mode (Test Centre E5): when the SLEEP domain is on, route the
                         // per-day sleep gate trace into the SAME shareable strap log, tagged .sleep so it
                         // lands under the profile in the export. Zero-cost when off: the gate is one
@@ -1285,9 +1282,6 @@ class AppViewModel(app: Application) : AndroidViewModel(app) {
                 // would re-score + persist every night's HRV over the WHOLE night, silently overwriting the
                 // deep-window value (the "deep sleep window changes nothing" bug).
                 deepHrvWindow = UnitPrefs.hrvWindow(appContext) == HrvWindow.DEEP_SLEEP,
-                // Opt-in experimental sleep staging (V2) — same flag the 15-min loop reads, so a manual
-                // re-score after an edit stages with the same engine the user chose. (V7 Pillar 3b)
-                useExperimentalSleepV2 = PuffinExperiment.from(appContext).experimentalSleepV2,
             )
         }.onFailure { if (it is kotlin.coroutines.cancellation.CancellationException) throw it }
     }

--- a/android/app/src/main/java/com/noop/ui/SettingsScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/SettingsScreen.kt
@@ -439,9 +439,6 @@ fun SettingsScreen(
     var puffinCapture by remember { mutableStateOf(puffinExperiment.isCaptureEnabled) }
     var deepData by remember { mutableStateOf(puffinExperiment.isDeepDataEnabled) }
     var broadcastHr by remember { mutableStateOf(puffinExperiment.broadcastHr) }
-    // Opt-in "Experimental sleep staging (V2)" (off by default). Model-agnostic, so it lives outside the
-    // 5/MG-only card — it works on WHOOP 4 and 5. Re-stages detected nights with SleepStagerV2; V1 default.
-    var experimentalSleepV2 by remember { mutableStateOf(puffinExperiment.experimentalSleepV2) }
 
     // Whether to surface the WHOOP 5/MG-only probes (puffin / R22 / broadcast-HR / frame-capture). Gated
     // so a confident 4.0 owner never sees 5/MG controls that can't touch their strap (#22). The model
@@ -1657,45 +1654,8 @@ fun SettingsScreen(
             blurb = "A read-only export of the decoded sensor streams NOOP already stores. Works on any strap. Nothing is written to your device, and nothing is uploaded.",
         ) {
             Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
-                // --- Sleep staging (V2) — the DEFAULT engine after the 44-subject benchmark; toggle off to
-                //     fall back to V1. Every model. (V7 Pillar 3b) ---
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    verticalAlignment = Alignment.CenterVertically,
-                    horizontalArrangement = Arrangement.spacedBy(16.dp),
-                ) {
-                    Text(
-                        "Sleep staging (V2)",
-                        style = NoopType.subhead,
-                        color = Palette.textPrimary,
-                        modifier = Modifier.weight(1f),
-                    )
-                    Switch(
-                        checked = experimentalSleepV2,
-                        onCheckedChange = {
-                            experimentalSleepV2 = it
-                            puffinExperiment.experimentalSleepV2 = it
-                        },
-                        colors = SwitchDefaults.colors(
-                            checkedThumbColor = Palette.surfaceBase,
-                            checkedTrackColor = Palette.accent,
-                            uncheckedThumbColor = Palette.textSecondary,
-                            uncheckedTrackColor = Palette.surfaceInset,
-                            uncheckedBorderColor = Palette.hairline,
-                        ),
-                        modifier = Modifier.semantics {
-                            contentDescription = "Sleep staging V2"
-                        },
-                    )
-                }
-                Text(
-                    "A transparent cardiorespiratory recipe that recovers deep and REM better than the older " +
-                        "V1 staging, and is now the default. It only changes how already-detected nights are " +
-                        "split into stages (detection and scores are unchanged); turn it off to fall back to " +
-                        "V1. Takes effect on the next nights staged.",
-                    style = NoopType.caption,
-                    color = Palette.textTertiary,
-                )
+                // Sleep staging (V2) is the default on 5.0/MG and V1 on WHOOP 4.0, selected by device family
+                // (#319 / #327) — there is no longer a user toggle (it only caused confusion, see #345).
 
                 // Diagnostics: dump the decoded per-sample sensor streams (last 24h) to one long-format
                 // CSV so power users / external devs can prototype sleep/activity/VBT algorithms on real

--- a/android/app/src/test/java/com/noop/analytics/SleepStagerV2Test.kt
+++ b/android/app/src/test/java/com/noop/analytics/SleepStagerV2Test.kt
@@ -99,9 +99,9 @@ class SleepStagerV2Test {
 
         val v1 = SleepStageHealer.restageFromSamples(start, end, grav, hr, rr, emptyList())
         val v1Default = SleepStageHealer.restageFromSamples(
-            start, end, grav, hr, rr, emptyList(), useExperimentalSleepV2 = false)
+            start, end, grav, hr, rr, emptyList(), useSleepStagerV2 = false)
         val v2 = SleepStageHealer.restageFromSamples(
-            start, end, grav, hr, rr, emptyList(), useExperimentalSleepV2 = true)
+            start, end, grav, hr, rr, emptyList(), useSleepStagerV2 = true)
 
         assertNotNull("dense raw must stage on both paths", v1)
         assertNotNull(v2)

--- a/android/app/src/test/java/com/noop/analytics/SleepV2FamilyGateTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/SleepV2FamilyGateTest.kt
@@ -8,22 +8,17 @@ import org.junit.Test
 /**
  * #319: the #277 V2-default promotion applies to WHOOP 5.0/MG only. WHOOP 4.0 always uses V1 — its sparse
  * motion makes V2 inflate the Rest restorative term AND defeat the H9 low-confidence guard, so a poor 4.0
- * night reads as a confident 85-100. Pins [IntelligenceEngine.sleepStagerV2ForFamily] (byte-parity twin of
- * Swift `IntelligenceEngine.sleepStagerV2(enabled:family:)`).
+ * night reads as a confident 85-100. The engine is now selected purely by device family (the per-user
+ * "experimental V2" toggle was removed — issue #345). Pins [IntelligenceEngine.sleepStagerV2ForFamily]
+ * (byte-parity twin of Swift `IntelligenceEngine.sleepStagerV2(family:)`).
  */
 class SleepV2FamilyGateTest {
 
     @Test
-    fun `V2 is the default on 5MG, never on WHOOP 4`() {
-        assertTrue("5.0/MG with the toggle on → V2",
-            IntelligenceEngine.sleepStagerV2ForFamily(enabled = true, family = DeviceFamily.WHOOP5))
-        assertFalse("WHOOP 4 → V1 even with the toggle on",
-            IntelligenceEngine.sleepStagerV2ForFamily(enabled = true, family = DeviceFamily.WHOOP4))
-    }
-
-    @Test
-    fun `an explicit-off toggle wins on both families`() {
-        assertFalse(IntelligenceEngine.sleepStagerV2ForFamily(enabled = false, family = DeviceFamily.WHOOP5))
-        assertFalse(IntelligenceEngine.sleepStagerV2ForFamily(enabled = false, family = DeviceFamily.WHOOP4))
+    fun `V2 on 5MG, never on WHOOP 4`() {
+        assertTrue("5.0/MG → V2",
+            IntelligenceEngine.sleepStagerV2ForFamily(family = DeviceFamily.WHOOP5))
+        assertFalse("WHOOP 4 → V1 (the #319 sparse-motion gate; needs real 4.0 raw before V2 can run here)",
+            IntelligenceEngine.sleepStagerV2ForFamily(family = DeviceFamily.WHOOP4))
     }
 }


### PR DESCRIPTION
## What

Removes the per-user "Experimental sleep staging (V2)" toggle and selects the staging engine purely by device family.

V2 is right on 5.0/MG and wrong on WHOOP 4.0 (the #319 sparse-motion inflation, fixed by #327), so the family gate already decided the engine. The toggle only added confusion — a 4.0 owner "enabling V2" changed nothing yet looked broken (issue #345).

## Changes

- Remove `PuffinExperiment.experimentalSleepV2` (+ its key), the Settings toggle UI, and the `AppViewModel` / `WhoopBleClient` threading, on both platforms.
- `sleepStagerV2ForFamily(family)` is now the sole selector (`family != WHOOP4`). **Behaviour-preserving**: the flag already defaulted `true`, so 5.0/MG → V2 and 4.0 → V1 are unchanged.
- **Family-gate the self-heal restage too** — the small follow-up #327 noted. It now resolves the healed strap's *own* family, so an edited 4.0 night stays on V1 (also correct for a user running both a 4.0 and a 5.0/MG).
- In-code notes that unifying 4.0 on a motion-robust V2 needs real 4.0 raw data first (#271, #319).

## Verification

- **Android**: `:app:testFullDebugUnitTest` green — the family-gate `SleepV2FamilyGateTest` and the self-heal `SleepStagerV2Test` are updated and passing.
- **Swift**: mirrored byte-identically. App-target Swift (`IntelligenceEngine` / `Repository` / `SettingsView` / `PuffinExperiment`) has no CI, so it needs a Mac build to confirm compile — flagged for a maintainer with Xcode.

Completes the #327 self-heal follow-up; addresses the #345 confusion.
