### PR TITLE
whoop5 event log: make the EVENT predicate testable + rotate the live handle

### DIFF
--- a/Strand/BLE/PuffinEventLog.swift
+++ b/Strand/BLE/PuffinEventLog.swift
@@ -23,8 +23,19 @@ final class PuffinEventLog {
     /// day of wear, so 5 MB is years of history.
     private static let softCapBytes = 5 * 1024 * 1024
 
-    /// The WHOOP 5 inner-record type byte for EVENT frames (the inner record starts at offset 8).
+    /// The WHOOP 5/MG inner-record type byte for EVENT frames (type 48). The inner record starts at
+    /// offset 8 (`[type][seq][cmd][data…]`) — the SAME position `BLEManager.isOffloadFrame` /
+    /// `noteWhoop5R22Telemetry` index and the Interpreter reads the canonical type name from.
     private static let eventTypeByte: UInt8 = 0x30
+    private static let innerRecordOffset = 8
+
+    /// Pure predicate: is `frame` a WHOOP 5/MG EVENT (type 48 / 0x30) frame? A reassembled frame's
+    /// inner-record type byte sits at offset 8, so this needs `count > 8` before indexing. Extracted so
+    /// the offset-8 magic number is unit-testable without a strap (BLE paths otherwise have no test).
+    /// Byte-identical to the Kotlin twin `WhoopBleClient.isWhoop5EventFrame`.
+    nonisolated static func isEventFrame(_ frame: [UInt8]) -> Bool {
+        frame.count > innerRecordOffset && frame[innerRecordOffset] == eventTypeByte
+    }
 
     private var handle: FileHandle?
     private var disabled = false
@@ -49,12 +60,23 @@ final class PuffinEventLog {
     /// replays historical EVENTs during a sync, and either path may be the only one that sees a
     /// given record (the official app's trim can empty the strap's history before NOOP syncs).
     func appendIfEvent(frame: [UInt8], char: CBUUID) {
-        guard !disabled, frame.count > 8, frame[8] == Self.eventTypeByte, isEnabled else { return }
+        // Order matters: the EVENT check short-circuits the non-EVENT flood BEFORE the `isEnabled`
+        // UserDefaults read, so the cost for an ordinary frame stays a single length+byte compare.
+        guard !disabled, Self.isEventFrame(frame), isEnabled else { return }
         let tsMs = Int(Date().timeIntervalSince1970 * 1000)
         let hex = frame.map { String(format: "%02x", $0) }.joined()
         let line = "{\"ts_ms\":\(tsMs),\"char\":\"\(char.uuidString.lowercased())\",\"hex\":\"\(hex)\"}\n"
         do {
-            let h = try openHandle()
+            var h = try openHandle()
+            // Rotate a LIVE handle too, not just at open: a long single session (or a first-ever sync
+            // that replays weeks of history in one connection) would otherwise grow the file past the
+            // cap unchecked, since `openHandle` only tests size when it opens. The Android twin tests
+            // `File.length()` on every append — match that so neither platform overshoots. `close()`
+            // drops the handle; the re-open sees the oversize file and rotates it to `.1`, fresh.
+            if try h.offset() > UInt64(Self.softCapBytes) {
+                close()
+                h = try openHandle()
+            }
             try h.write(contentsOf: Data(line.utf8))
         } catch {
             // A diagnostics log must never affect the connection path: disable for this launch.

--- a/StrandTests/PuffinEventLogTests.swift
+++ b/StrandTests/PuffinEventLogTests.swift
@@ -1,0 +1,43 @@
+import XCTest
+@testable import Strand
+
+/// Pins `PuffinEventLog.isEventFrame` — the pure predicate behind the durable EVENT-frame log
+/// (#103/#346). A reassembled WHOOP 5/MG frame carries its inner-record type at offset 8, and EVENT is
+/// type 48 (0x30); the log keys on exactly that. BLE delivery can't be unit-tested, but this offset-8
+/// magic number CAN be, so a future frame-shape change can't silently stop the research log filling.
+/// Twin of the Android `Whoop5EventFramePredicateTest`.
+final class PuffinEventLogTests: XCTestCase {
+
+    func testAcceptsEventTypeAtOffset8() {
+        var f = [UInt8](repeating: 0, count: 12)
+        f[8] = 0x30 // EVENT (type 48)
+        XCTAssertTrue(PuffinEventLog.isEventFrame(f))
+    }
+
+    func testRejectsNonEventTypes() {
+        // Live REALTIME(0x28) and the offload record types (47/49/50, PUFFIN_METADATA 56) plus the
+        // R22-telemetry types (0x24/0x2F) must never be logged as EVENT.
+        let nonEventTypes: [UInt8] = [0x28, 47, 49, 50, 56, 0x2F, 0x24]
+        for t in nonEventTypes {
+            var f = [UInt8](repeating: 0, count: 12)
+            f[8] = t
+            XCTAssertFalse(PuffinEventLog.isEventFrame(f), "type \(t) must not be treated as EVENT")
+        }
+    }
+
+    func testRejectsFramesTooShortToIndexOffset8() {
+        // size <= 8 has no byte at offset 8; the predicate must guard the index (no crash, no match).
+        for n in 0...8 {
+            XCTAssertFalse(PuffinEventLog.isEventFrame([UInt8](repeating: 0x30, count: n)),
+                           "size \(n) is too short to be an EVENT frame")
+        }
+    }
+
+    func testBoundaryExactlyNineBytesWithEventTypeIsAccepted() {
+        // Smallest frame that can carry the offset-8 type byte: size 9 (indices 0...8).
+        var f = [UInt8](repeating: 0, count: 9)
+        f[8] = 0x30
+        XCTAssertTrue(PuffinEventLog.isEventFrame(f))
+        XCTAssertFalse(PuffinEventLog.isEventFrame([UInt8](repeating: 0, count: 8)))
+    }
+}

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -600,6 +600,22 @@ class WhoopBleClient(
         const val WHOOP5_EVENT_LOG_FILE = "whoop5-events.jsonl"
         // EVENT frames are ~40–120 B of hex each, a few KB per day of wear — 5 MB is years.
         private const val WHOOP5_EVENT_LOG_MAX_BYTES = 5L * 1024 * 1024
+
+        /** WHOOP 5/MG inner-record type byte for EVENT frames (type 48). The inner record starts at
+         *  offset 8 ([type][seq][cmd][data…]) — the SAME position [isOffloadFrame]/R22-telemetry index
+         *  and the Interpreter reads the canonical type name from. */
+        const val WHOOP5_EVENT_TYPE = 0x30
+        private const val WHOOP5_INNER_RECORD_OFFSET = 8
+
+        /**
+         * Pure predicate: is [frame] a WHOOP 5/MG EVENT (type 48 / 0x30) frame? A reassembled frame's
+         * inner-record type byte sits at offset 8, so this needs `size > 8` before indexing. Extracted
+         * from [writeWhoop5EventLogIfEvent] so the offset-8 magic number is unit-testable without a strap
+         * (BLE paths otherwise have no test). Byte-identical to the Swift twin `PuffinEventLog.isEventFrame`.
+         */
+        fun isWhoop5EventFrame(frame: ByteArray): Boolean =
+            frame.size > WHOOP5_INNER_RECORD_OFFSET &&
+                (frame[WHOOP5_INNER_RECORD_OFFSET].toInt() and 0xFF) == WHOOP5_EVENT_TYPE
         /** Rotation threshold (~10 MB) and absolute per-file line cap (a full overnight offload is
          *  ~28k frames; 40k leaves headroom — his fork's 20k truncated real sessions, #78 fork). */
         private const val WHOOP5_CAPTURE_MAX_BYTES = 10L * 1024 * 1024
@@ -5598,7 +5614,7 @@ class WhoopBleClient(
      * the cap keeping one previous generation, the backfill capture's idiom.
      */
     private fun writeWhoop5EventLogIfEvent(characteristic: String, frame: ByteArray) {
-        if (eventLogDisabled || frame.size <= 8 || (frame[8].toInt() and 0xFF) != 0x30) return
+        if (eventLogDisabled || !isWhoop5EventFrame(frame)) return
         if (!PuffinExperiment.from(context).isCaptureEnabled) return
         runCatching {
             val f = java.io.File(context.filesDir, WHOOP5_EVENT_LOG_FILE)

--- a/android/app/src/test/java/com/noop/ble/Whoop5EventFramePredicateTest.kt
+++ b/android/app/src/test/java/com/noop/ble/Whoop5EventFramePredicateTest.kt
@@ -1,0 +1,56 @@
+package com.noop.ble
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Pins [WhoopBleClient.isWhoop5EventFrame] — the pure predicate behind the durable EVENT-frame log
+ * (#103/#346). A reassembled WHOOP 5/MG frame carries its inner-record type at offset 8, and EVENT is
+ * type 48 (0x30); the log keys on exactly that. BLE delivery itself can't be unit-tested, but this
+ * offset-8 magic number CAN be, so a future frame-shape change can't silently break the capture (the
+ * failure mode would otherwise be "the research log quietly stops filling"). Mirrors the family-aware
+ * [Whoop5OffloadTest] which pins the sibling frame[8] index for `isOffloadFrame`. Twin of the Swift
+ * `PuffinEventLogTests`.
+ */
+class Whoop5EventFramePredicateTest {
+
+    @Test
+    fun acceptsEventTypeAtOffset8() {
+        val f = ByteArray(12)
+        f[8] = 0x30 // EVENT (type 48)
+        assertTrue(WhoopBleClient.isWhoop5EventFrame(f))
+    }
+
+    @Test
+    fun rejectsNonEventTypes() {
+        // Every other type byte seen at offset 8 on this path — live REALTIME(40) and the offload
+        // record types (47/48-is-event/49/50, PUFFIN_METADATA 56) — must NOT be logged as an EVENT.
+        for (t in intArrayOf(40, 47, 49, 50, 56, 0x2F, 0x24)) {
+            val f = ByteArray(12)
+            f[8] = t.toByte()
+            assertFalse("type $t must not be treated as an EVENT frame",
+                WhoopBleClient.isWhoop5EventFrame(f))
+        }
+    }
+
+    @Test
+    fun rejectsFramesTooShortToIndexOffset8() {
+        // The inner-record type is at offset 8, so a frame with size <= 8 has no type byte to read;
+        // the predicate must guard the index (no crash, no false positive).
+        for (n in 0..8) {
+            assertFalse("size $n is too short to be an EVENT frame",
+                WhoopBleClient.isWhoop5EventFrame(ByteArray(n)))
+        }
+    }
+
+    @Test
+    fun boundaryExactlyNineBytesWithEventTypeIsAccepted() {
+        // The smallest frame that can carry the offset-8 type byte: size 9 (indices 0..8).
+        val f = ByteArray(9)
+        f[8] = 0x30
+        assertTrue(WhoopBleClient.isWhoop5EventFrame(f))
+        // And size 8 (no index 8) is rejected even though it's one byte short.
+        assertFalse(WhoopBleClient.isWhoop5EventFrame(ByteArray(8)))
+    }
+}


### PR DESCRIPTION
Follow-up to the WHOOP 5 EVENT-frame research log (#346, for #103, now merged), closing the two review gaps. Rebased onto `main` — the diff is only the hardening.

## Gaps closed

### 1. The offset-8 EVENT check is now unit-testable (both platforms)
The whole capture keys on one magic number — the WHOOP 5/MG inner-record type byte at `frame[8]` being `0x30` (type 48). If a future frame-shape change moved that, the failure mode is silent: the research log just quietly stops filling. BLE delivery can't be unit-tested, but this predicate is pure, so it's extracted and pinned:

- **Android** — `WhoopBleClient.isWhoop5EventFrame(frame)` (companion), tested by `Whoop5EventFramePredicateTest`. This runs in the **Linux JVM suite**, so the predicate is CI-guarded on every build (mirrors `Whoop5OffloadTest`, which pins the sibling `isOffloadFrame` frame[8] index).
- **Swift** — `PuffinEventLog.isEventFrame(_:)` (`nonisolated static`), tested by `PuffinEventLogTests`.

Both tests pin: accept type-48 at offset 8, reject other types (incl. the offload/telemetry types seen on the same path), reject frames too short to index, and the size-9 boundary. Byte-identical predicate across Swift/Kotlin (parity contract).

### 2. Swift now rotates a LIVE handle, matching Android
`PuffinEventLog.openHandle()` only checked the file size when it *opened* the handle. Within one long connection — or a first-ever sync that replays weeks of history in a single connection — the file could grow past the 5 MB cap unchecked. The Android twin already tests `File.length()` on **every** append; Swift now re-checks `FileHandle.offset()` per append and rotates on the live handle, so neither platform overshoots.

## Unchanged
Passive/read-only capture, self-disable-on-write-failure, the shared existing capture toggle, and the hook position (before the offload branch) are all exactly as in #346. The non-EVENT fast path still short-circuits before the enabled-check, so an ordinary frame is still a single length+byte compare.

## Verification
- Android: `compileFullDebugKotlin` clean; `Whoop5EventFramePredicateTest` passes in `testFullDebugUnitTest`.
- Swift: app-target (`Strand/BLE` + `StrandTests`), so no default CI — needs an `app-build` run to compile; `PuffinEventLogTests` runs under `xcodebuild test` on macOS.
