### PR TITLE
Add Ice Hockey to Android sport picker

### DIFF
--- a/android/app/src/main/java/com/noop/ingest/ExerciseTypes.kt
+++ b/android/app/src/main/java/com/noop/ingest/ExerciseTypes.kt
@@ -30,6 +30,7 @@ object ExerciseTypes {
         EX.EXERCISE_TYPE_BASKETBALL to "Basketball",
         EX.EXERCISE_TYPE_SOCCER to "Soccer",
         EX.EXERCISE_TYPE_BASEBALL to "Baseball",
+        EX.EXERCISE_TYPE_ICE_HOCKEY to "Ice Hockey",
         EX.EXERCISE_TYPE_BADMINTON to "Badminton",
         EX.EXERCISE_TYPE_TENNIS to "Tennis",
         EX.EXERCISE_TYPE_SQUASH to "Squash",


### PR DESCRIPTION
## What

Adds Ice Hockey to the Android workout sport picker using Health Connect's native EXERCISE_TYPE_ICE_HOCKEY type.

## Why

Imported Health Connect workouts can already display Ice Hockey, but the live workout picker omitted it, forcing hockey sessions to be logged as Other.

Closes #350.

## Validation

- ./gradlew :app:compileFullDebugKotlin