### PR TITLE
whoop5 console logs: pin the text-region hardening edges (both platforms)

### DIFF
--- a/Packages/WhoopProtocol/Tests/WhoopProtocolTests/Whoop5ConsoleLogsTests.swift
+++ b/Packages/WhoopProtocol/Tests/WhoopProtocolTests/Whoop5ConsoleLogsTests.swift
@@ -65,4 +65,44 @@ final class Whoop5ConsoleLogsTests: XCTestCase {
         let f = parseFrame(truncated, family: .whoop5)
         XCTAssertNil(f.parsed["log"])
     }
+
+    // MARK: - Text-region hardening edges (synthetic frames)
+
+    /// A synthetic CONSOLE_LOGS frame carrying `textBytes` at @21. The CRC32 trailer is left zero:
+    /// field decode is CRC-independent (the flag is only reported, never gated on), so these pin the
+    /// trim/cap edges without a real capture — the fixtures above already prove the happy path + CRC.
+    private func consoleFrame(textBytes: [UInt8]) -> [UInt8] {
+        var f = [UInt8](repeating: 0, count: 21)   // envelope + record header (all zero but @0/@1/@8)
+        f[0] = 0xAA
+        f[1] = 0x01
+        f[8] = 0x32                                 // CONSOLE_LOGS (type 50)
+        f.append(contentsOf: textBytes)
+        f.append(contentsOf: [0, 0, 0, 0])          // CRC32 trailer (unchecked)
+        let declaredLength = f.count - 8            // payload + 4-byte CRC32 (u16 LE @2)
+        f[2] = UInt8(declaredLength & 0xFF)
+        f[3] = UInt8((declaredLength >> 8) & 0xFF)
+        return f
+    }
+
+    /// The 2 KB cap (a garbled/malicious peer must not pin arbitrary bytes as a String). A real chunk
+    /// is ~51 bytes and can never reach this from the strap, so it needs a synthetic oversize frame.
+    func testOversizedTextIsCappedAt2048() {
+        let f = consoleFrame(textBytes: [UInt8](repeating: 0x41, count: 2100))  // 'A' × 2100
+        let p = parseFrame(f, family: .whoop5)
+        XCTAssertEqual(p.parsed["log"]?.stringValue?.count, 2048)
+    }
+
+    /// An all-NUL (padding-only) text region trims to empty → no `log` key at all, not an empty string.
+    func testAllNulTextRegionYieldsNoLog() {
+        let f = consoleFrame(textBytes: [0, 0, 0, 0, 0, 0])
+        let p = parseFrame(f, family: .whoop5)
+        XCTAssertNil(p.parsed["log"])
+    }
+
+    /// Only TRAILING NULs are trimmed; the text before them is kept verbatim.
+    func testTrailingNulsAreTrimmed() {
+        let f = consoleFrame(textBytes: Array("AB".utf8) + [0, 0, 0])
+        let p = parseFrame(f, family: .whoop5)
+        XCTAssertEqual(p.parsed["log"]?.stringValue, "AB")
+    }
 }

--- a/android/app/src/test/java/com/noop/protocol/FramingTest.kt
+++ b/android/app/src/test/java/com/noop/protocol/FramingTest.kt
@@ -535,4 +535,46 @@ class FramingTest {
         assertEquals("19, 146552119: BLE: hist transfer start response a", a.parsed["console"])
         assertEquals("ck, start burst\n 19, 146554630: BLE: History burst", b.parsed["console"])
     }
+
+    // MARK: - CONSOLE_LOGS text-region hardening edges (synthetic frames, Swift parity)
+
+    /** A synthetic CONSOLE_LOGS frame carrying [text] at @21. The CRC32 trailer is left zero: field
+     *  decode is CRC-independent (the flag is only reported, never gated on), so these pin the trim/cap
+     *  edges without a real capture. Twin of the Swift `consoleFrame` helper. */
+    private fun consoleFrame(text: ByteArray): ByteArray {
+        val f = ByteArray(21 + text.size + 4)          // envelope + record header + text + CRC32
+        f[0] = 0xAA.toByte()
+        f[1] = 0x01.toByte()
+        f[8] = 0x32.toByte()                            // CONSOLE_LOGS (type 50)
+        text.copyInto(f, 21)
+        val declaredLength = f.size - 8                 // payload + 4-byte CRC32 (u16 LE @2)
+        f[2] = (declaredLength and 0xFF).toByte()
+        f[3] = ((declaredLength shr 8) and 0xFF).toByte()
+        return f
+    }
+
+    /** The 2 KB cap (a garbled/malicious peer must not pin arbitrary bytes as a String). A real chunk
+     *  is ~51 bytes and can never reach this from the strap, so it needs a synthetic oversize frame. */
+    @Test
+    fun whoop5_consoleLogs_oversizedTextCappedAt2048() {
+        val f = consoleFrame(ByteArray(2100) { 'A'.code.toByte() })
+        val p = Framing.parseFrame(f, DeviceFamily.WHOOP5)
+        assertEquals(2048, (p.parsed["console"] as String).length)
+    }
+
+    /** An all-NUL (padding-only) text region trims to empty -> no `console` key, not an empty string. */
+    @Test
+    fun whoop5_consoleLogs_allNulRegionYieldsNoConsole() {
+        val f = consoleFrame(ByteArray(6))
+        val p = Framing.parseFrame(f, DeviceFamily.WHOOP5)
+        assertNull(p.parsed["console"])
+    }
+
+    /** Only TRAILING NULs are trimmed; the text before them is kept verbatim. */
+    @Test
+    fun whoop5_consoleLogs_trailingNulsTrimmed() {
+        val f = consoleFrame("AB".toByteArray() + byteArrayOf(0, 0, 0))
+        val p = Framing.parseFrame(f, DeviceFamily.WHOOP5)
+        assertEquals("AB", p.parsed["console"])
+    }
 }


### PR DESCRIPTION
Follow-up to #344 (WHOOP 5 CONSOLE_LOGS type 50 decoder, for #103, now merged). Rebased onto `main` — tests only.

## What

#344's tests are all real-frame happy paths plus one truncation guard. The text-region hardening it *documents* — the 2 KB cap and the empty/NUL edges — wasn't verified on either platform. This adds byte-parity twin tests for them:

- **the 2 KB cap** — a garbled/malicious peer must not pin arbitrary bytes as a `String`. A real chunk is ~51 bytes and can never reach this from the strap, so it takes a synthetic oversize frame: 2100 `'A'` → capped to exactly 2048 on both platforms.
- **an all-NUL (padding-only) region** → no `log`/`console` key at all, not an empty string.
- **trailing-NUL trim** keeps the preceding text verbatim.

## How

Each side gets a small `consoleFrame(...)` helper that builds a synthetic type-50 frame with the text at @21. Field decode is CRC-independent (`crcOK` is reported, never gated on) and `payloadEnd` derives from the declared-length field (`u16 @2`), so the trim/cap paths are exercised without a real capture or a computed CRC32. The header/offset happy path and CRC are already covered by #344's real fixtures.

## Verification
- Swift: `swift test --filter Whoop5ConsoleLogsTests` → 6/6 (3 new).
- Kotlin: `./gradlew testFullDebugUnitTest --tests com.noop.protocol.FramingTest` → green (3 new).

Both run on Linux CI (`swift-packages` + the Android JVM suite), so these edges are guarded on every build. Decoder code is unchanged — tests only.

