### PR TITLE
Persist Compare metric selections

### DIFF
--- a/android/app/src/main/java/com/noop/ui/CompareScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/CompareScreen.kt
@@ -225,6 +225,24 @@ private enum class CompareRange(val label: String, val days: Int?, val phrase: S
 
 private val defaultCompareMetricKeys = listOf("recovery", "sleep_performance", "weight")
 
+internal fun parseCompareSelection(raw: String?, minSelection: Int, maxSelection: Int): List<CompareMetric>? {
+    if (raw == null) return null
+
+    val tokens = raw.split(",")
+        .map { it.trim() }
+        .filter { it.isNotEmpty() }
+    val parsed = tokens
+        .mapNotNull { CompareCatalog.byId(it) }
+        .distinctBy { it.id }
+        .take(maxSelection)
+
+    return if (parsed.size == tokens.distinct().size || parsed.size >= minSelection) {
+        parsed
+    } else {
+        null
+    }
+}
+
 private object ComparePrefs {
     private const val KEY_RANGE = "compare.range"
     private const val KEY_SELECTED = "compare.selectedMetrics"
@@ -240,13 +258,7 @@ private object ComparePrefs {
 
     fun readSelection(context: Context, minSelection: Int, maxSelection: Int): List<CompareMetric> {
         val raw = NoopPrefs.of(context).getString(KEY_SELECTED, null)
-        if (raw != null) {
-            val parsed = raw.split(",")
-                .mapNotNull { CompareCatalog.byId(it.trim()) }
-                .distinctBy { it.id }
-                .take(maxSelection)
-            if (parsed.size >= minSelection) return parsed
-        }
+        parseCompareSelection(raw, minSelection, maxSelection)?.let { return it }
 
         val picks = defaultCompareMetricKeys.mapNotNull { CompareCatalog.byKey(it) }
         return (if (picks.isEmpty()) CompareCatalog.all.take(2) else picks).take(maxSelection)

--- a/android/app/src/main/java/com/noop/ui/CompareScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/CompareScreen.kt
@@ -238,13 +238,14 @@ private object ComparePrefs {
         NoopPrefs.of(context).edit().putString(KEY_RANGE, range.name).apply()
     }
 
-    fun readSelection(context: Context, maxSelection: Int): List<CompareMetric> {
+    fun readSelection(context: Context, minSelection: Int, maxSelection: Int): List<CompareMetric> {
         val raw = NoopPrefs.of(context).getString(KEY_SELECTED, null)
         if (raw != null) {
-            return raw.split(",")
+            val parsed = raw.split(",")
                 .mapNotNull { CompareCatalog.byId(it.trim()) }
                 .distinctBy { it.id }
                 .take(maxSelection)
+            if (parsed.size >= minSelection) return parsed
         }
 
         val picks = defaultCompareMetricKeys.mapNotNull { CompareCatalog.byKey(it) }
@@ -376,7 +377,7 @@ fun CompareScreen(vm: AppViewModel) {
     // Ordered selection (max 4). Drives both the legend order and color mapping.
     val selected = remember {
         mutableStateListOf<CompareMetric>().apply {
-            addAll(ComparePrefs.readSelection(context, maxSelection))
+            addAll(ComparePrefs.readSelection(context, minSelection, maxSelection))
         }
     }
     // Full-history series per selected metric id (ascending by day).

--- a/android/app/src/main/java/com/noop/ui/CompareScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/CompareScreen.kt
@@ -1,5 +1,6 @@
 package com.noop.ui
 
+import android.content.Context
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
@@ -186,6 +187,8 @@ private object CompareCatalog {
 
     fun byKey(key: String): CompareMetric? = all.firstOrNull { it.key == key }
 
+    fun byId(id: String): CompareMetric? = all.firstOrNull { it.id == id }
+
     /** Map a my-whoop metric key to the matching DailyMetric column accessor, if any. */
     fun dailyPick(key: String): ((DailyMetric) -> Double?)? = when (key) {
         "recovery" -> { d -> d.recovery }
@@ -218,6 +221,41 @@ private enum class CompareRange(val label: String, val days: Int?, val phrase: S
     /** This range plus every LARGER range, ascending — the auto-expand search order. */
     val widening: List<CompareRange>
         get() = entries.subList(ordinal, entries.size)
+}
+
+private val defaultCompareMetricKeys = listOf("recovery", "sleep_performance", "weight")
+
+private object ComparePrefs {
+    private const val KEY_RANGE = "compare.range"
+    private const val KEY_SELECTED = "compare.selectedMetrics"
+
+    fun readRange(context: Context): CompareRange {
+        val raw = NoopPrefs.of(context).getString(KEY_RANGE, null) ?: return CompareRange.Year
+        return CompareRange.entries.firstOrNull { it.name == raw } ?: CompareRange.Year
+    }
+
+    fun writeRange(context: Context, range: CompareRange) {
+        NoopPrefs.of(context).edit().putString(KEY_RANGE, range.name).apply()
+    }
+
+    fun readSelection(context: Context, maxSelection: Int): List<CompareMetric> {
+        val raw = NoopPrefs.of(context).getString(KEY_SELECTED, null)
+        if (raw != null) {
+            return raw.split(",")
+                .mapNotNull { CompareCatalog.byId(it.trim()) }
+                .distinctBy { it.id }
+                .take(maxSelection)
+        }
+
+        val picks = defaultCompareMetricKeys.mapNotNull { CompareCatalog.byKey(it) }
+        return (if (picks.isEmpty()) CompareCatalog.all.take(2) else picks).take(maxSelection)
+    }
+
+    fun writeSelection(context: Context, selected: List<CompareMetric>) {
+        NoopPrefs.of(context).edit()
+            .putString(KEY_SELECTED, selected.joinToString(",") { it.id })
+            .apply()
+    }
 }
 
 // MARK: - Per-series model
@@ -334,15 +372,12 @@ fun CompareScreen(vm: AppViewModel) {
     val maxSelection = 4
     val minSelection = 2
 
-    // Default starter selection (falls back gracefully if a key is missing).
-    val defaultKeys = listOf("recovery", "sleep_performance", "weight")
-
-    var range by remember { mutableStateOf(CompareRange.Year) }
+    var range by remember { mutableStateOf(ComparePrefs.readRange(context)) }
     // Ordered selection (max 4). Drives both the legend order and color mapping.
     val selected = remember {
-        val picks = defaultKeys.mapNotNull { CompareCatalog.byKey(it) }
-        val seed = if (picks.isEmpty()) CompareCatalog.all.take(2) else picks.take(maxSelection)
-        mutableStateListOf<CompareMetric>().apply { addAll(seed) }
+        mutableStateListOf<CompareMetric>().apply {
+            addAll(ComparePrefs.readSelection(context, maxSelection))
+        }
     }
     // Full-history series per selected metric id (ascending by day).
     val fullSeries = remember { mutableStateMapOf<String, List<Pair<String, Double>>>() }
@@ -427,7 +462,10 @@ fun CompareScreen(vm: AppViewModel) {
                             items = CompareRange.entries.toList(),
                             selection = range,
                             label = { it.label },
-                            onSelect = { range = it },
+                            onSelect = {
+                                range = it
+                                ComparePrefs.writeRange(context, it)
+                            },
                         )
                         Spacer(Modifier.weight(1f))
                         AddMetricMenu(
@@ -441,6 +479,7 @@ fun CompareScreen(vm: AppViewModel) {
                                 } else if (selected.size < maxSelection) {
                                     selected.add(m)
                                 }
+                                ComparePrefs.writeSelection(context, selected)
                             },
                         )
                     }
@@ -466,7 +505,10 @@ fun CompareScreen(vm: AppViewModel) {
                                 val i = selected.indexOfFirst { it.id == m.id }
                                 if (i < 0) Palette.textSecondary else seriesPalette[i % seriesPalette.size]
                             },
-                            onRemove = { m -> selected.removeAll { it.id == m.id } },
+                            onRemove = { m ->
+                                selected.removeAll { it.id == m.id }
+                                ComparePrefs.writeSelection(context, selected)
+                            },
                         )
                     }
                 }

--- a/android/app/src/test/java/com/noop/ui/ComparePrefsTest.kt
+++ b/android/app/src/test/java/com/noop/ui/ComparePrefsTest.kt
@@ -1,0 +1,70 @@
+package com.noop.ui
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class ComparePrefsTest {
+
+    @Test
+    fun parseSelection_nullWhenNothingStored() {
+        assertNull(parseCompareSelection(null, minSelection = 2, maxSelection = 4))
+    }
+
+    @Test
+    fun parseSelection_restoresSubMinimumWhenAllIdsResolve() {
+        val parsed = parseCompareSelection(
+            raw = "my-whoop:recovery",
+            minSelection = 2,
+            maxSelection = 4,
+        )
+
+        assertEquals(listOf("my-whoop:recovery"), parsed?.map { it.id })
+    }
+
+    @Test
+    fun parseSelection_fallsBackWhenResolvedIdsDropBelowMinimum() {
+        assertNull(
+            parseCompareSelection(
+                raw = "my-whoop:missing_metric,my-whoop:removed_metric",
+                minSelection = 2,
+                maxSelection = 4,
+            ),
+        )
+    }
+
+    @Test
+    fun parseSelection_restoresResolvedIdsWhenAtLeastMinimumSurvives() {
+        val parsed = parseCompareSelection(
+            raw = "my-whoop:recovery,my-whoop:removed_metric,my-whoop:sleep_performance",
+            minSelection = 2,
+            maxSelection = 4,
+        )
+
+        assertEquals(
+            listOf("my-whoop:recovery", "my-whoop:sleep_performance"),
+            parsed?.map { it.id },
+        )
+    }
+
+    @Test
+    fun parseSelection_dedupsAndCapsAtMaxSelection() {
+        val parsed = parseCompareSelection(
+            raw = listOf(
+                "my-whoop:recovery",
+                "my-whoop:recovery",
+                "my-whoop:sleep_performance",
+                "apple-health:weight",
+                "my-whoop:strain",
+                "my-whoop:hrv",
+            ).joinToString(","),
+            minSelection = 2,
+            maxSelection = 4,
+        )
+
+        assertEquals(
+            listOf("my-whoop:recovery", "my-whoop:sleep_performance", "apple-health:weight", "my-whoop:strain"),
+            parsed?.map { it.id },
+        )
+    }
+}


### PR DESCRIPTION
## What

Persists the Android Compare screen selected metric list and range in local preferences.

## Why

Issue #300 notes that choosing Effort and Charge should be sticky instead of jumping back to the default metrics every time the user returns to Compare. The screen previously kept both values in plain Compose state, so recreating the screen restored the defaults.

This keeps the existing default selection for first-time users, then writes user changes to NoopPrefs and restores them on the next visit.

Refs #300.

## Validation

- ./gradlew :app:compileFullDebugKotlin