### PR TITLE
Fitness Age / Vitality permanently "not ready" on live-BLE straps (#349)

### DIFF
--- a/android/app/src/main/java/com/noop/data/DemoSeeder.kt
+++ b/android/app/src/main/java/com/noop/data/DemoSeeder.kt
@@ -30,10 +30,11 @@ object DemoSeeder {
     private const val WHOOP = "my-whoop"
     private const val APPLE = "apple-health"
     // The NOOP-COMPUTED strap source ("<strap>-noop") the IntelligenceEngine persists its derived weekly
-    // scores under (fitness_age / vo2max_est / vitality / body_age). The Health screen reads these from this
-    // source verbatim (HealthScreen.COMPUTED_SOURCE), and the Today "Your cards" + Trends resolve them off
-    // it too — so the demo MUST seed them here, not under the imported "my-whoop" source, or those surfaces
-    // read empty ("No Data") while the rest of the demo is full. Mirrors the real engine's write target.
+    // scores under (fitness_age / vo2max_est / vitality / body_age). The Health screen + Today "Your cards"
+    // + Trends resolve these through the computed UNION (WhoopRepository.metricSeriesComputedUnion), which in
+    // the demo (activeStrapId "my-whoop") reads "my-whoop-noop" — so the demo MUST seed them here, not under
+    // the imported "my-whoop" source, or those surfaces read empty ("No Data") while the rest of the demo is
+    // full. Mirrors the real engine's write target.
     private const val WHOOP_NOOP = "$WHOOP-noop"
     private const val DAYS = 120
 
@@ -254,8 +255,8 @@ object DemoSeeder {
             if (date.dayOfWeek.value != 6) continue // 6 = Saturday
             val day = date.toString()
             // Seed under the NOOP-COMPUTED source (WHOOP_NOOP), exactly where the IntelligenceEngine writes
-            // these derived weekly scores in the real app — so the Health screen (reads COMPUTED_SOURCE), the
-            // Today "Your cards" Fitness age / Vitality cards and Trends all resolve them in the demo instead
+            // these derived weekly scores in the real app — so the Health screen, the Today "Your cards"
+            // Fitness age / Vitality cards and Trends (all via the computed union) resolve them in the demo instead
             // of showing "No Data". Trends ~42 → ~34 (younger) for Fitness age; vitality climbs ~55 → ~80.
             series.add(MetricSeriesRow(WHOOP_NOOP, day, "fitness_age",
                 round1((fitnessAge + gauss(rng, 0.0, 0.3)).coerceIn(34.0, 44.0))))

--- a/android/app/src/main/java/com/noop/data/WhoopRepository.kt
+++ b/android/app/src/main/java/com/noop/data/WhoopRepository.kt
@@ -849,6 +849,26 @@ class WhoopRepository(private val dao: WhoopDao) {
     suspend fun metricSeries(deviceId: String, key: String, from: String, to: String) =
         dao.metricSeries(deviceId, key, from, to)
 
+    /**
+     * Computed ("-noop") [key] series across the active-strap UNION (the active strap's own computed
+     * sibling + the canonical "my-whoop-noop"), deduped per day with the active strap winning. This is
+     * how the weekly computed scores (fitness_age / vo2max_est / vitality / body_age) MUST be read:
+     * IntelligenceEngine writes them under "<activeStrapId>-noop", so a live-BLE strap banks them under
+     * "whoop-<mac>-noop", NOT the canonical "my-whoop-noop" a hardcoded read assumes (#349). Import users
+     * (activeStrapId == "my-whoop") collapse to the single canonical id, unchanged. Mirrors the computed
+     * layer of Swift Repository.exploreSeries.
+     */
+    suspend fun metricSeriesComputedUnion(
+        activeStrapId: String,
+        key: String,
+        from: String,
+        to: String,
+    ): List<MetricSeriesRow> {
+        val ids = computedSourceIds(activeStrapId)
+        if (ids.size == 1) return metricSeries(ids[0], key, from, to)
+        return mergeComputedSeriesUnion(ids.map { metricSeries(it, key, from, to) })
+    }
+
     /** Distinct metric keys present for a [deviceId]/source, sorted ascending. */
     suspend fun metricKeys(deviceId: String): List<String> = dao.metricKeys(deviceId)
 
@@ -1341,6 +1361,20 @@ class WhoopRepository(private val dao: WhoopDao) {
          *  scores under "<importedDeviceId>-noop"). */
         fun computedSourceIdsFor(activeDeviceId: String): List<String> =
             importedSourceIdsFor(activeDeviceId).map { "$it-noop" }
+
+        /** Merge per-source computed ("-noop") metricSeries rows into one series, DEDUPED per day: the
+         *  ACTIVE strap's value wins over the canonical import's on a shared day. [perSource] is in
+         *  [computedSourceIdsFor] order (active-strap first), so keeping the FIRST row seen per day
+         *  preserves the active value — the same active-first idiom as [dedupSleepBlocks]. Result is
+         *  day-sorted ascending. Pure companion for [ResolverUnionTest]. Mirrors the computed-union layer
+         *  of Swift Repository.exploreSeries. (#349) */
+        internal fun mergeComputedSeriesUnion(perSource: List<List<MetricSeriesRow>>): List<MetricSeriesRow> {
+            val byDay = LinkedHashMap<String, MetricSeriesRow>()
+            for (rows in perSource) {
+                for (row in rows) byDay.putIfAbsent(row.day, row)   // active-first: first seen per day wins
+            }
+            return byDay.values.sortedBy { it.day }
+        }
 
         /** Drop sleep blocks sharing an identical (startTs, endTs) , the same physical night recorded
          *  under two #814 union ids , keeping the FIRST seen (the callers pass active-strap-first lists,

--- a/android/app/src/main/java/com/noop/ui/HealthScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/HealthScreen.kt
@@ -578,10 +578,6 @@ private fun ContributorBar(
 // "Unlocks your VO₂max", never as if they sharpen the age. When no value exists yet we show the
 // readiness checklist instead, so the user knows exactly what's still needed.
 
-/** The computed ("-noop") source the IntelligenceEngine persists fitness_age + vo2max_est under, the
- *  same convention every screen uses for on-device-computed series (imported is plain "my-whoop"). */
-private const val COMPUTED_SOURCE = "my-whoop-noop"
-
 /** Fitness Age readiness from what a screen can see: RHR coverage over the last 7 merged daily rows
  *  (drives the "N more nights" countdown), a scored-strain day as the activity signal, and the profile
  *  basics. Shared by the Health hub's [FitnessAgeSection] and the Today card's [VitalDetailScreen]
@@ -617,10 +613,10 @@ private fun FitnessAgeSection(vm: AppViewModel, days: List<DailyMetric>, profile
     var refreshing by remember { mutableStateOf(false) }
     LaunchedEffect(days, refreshTick) {
         val fa = runCatching {
-            vm.repo.metricSeries(COMPUTED_SOURCE, "fitness_age", "0000-01-01", "9999-12-31")
+            vm.repo.metricSeriesComputedUnion(vm.activeStrapId, "fitness_age", "0000-01-01", "9999-12-31")
         }.getOrDefault(emptyList()).lastOrNull()?.value
         val vo2 = runCatching {
-            vm.repo.metricSeries(COMPUTED_SOURCE, "vo2max_est", "0000-01-01", "9999-12-31")
+            vm.repo.metricSeriesComputedUnion(vm.activeStrapId, "vo2max_est", "0000-01-01", "9999-12-31")
         }.getOrDefault(emptyList()).lastOrNull()?.value
         fitnessAge = fa
         vo2max = vo2
@@ -684,10 +680,10 @@ private fun VitalitySection(vm: AppViewModel, days: List<DailyMetric>, profile: 
     var bodyAge by remember { mutableStateOf<Double?>(null) }
     LaunchedEffect(days) {
         vitality = runCatching {
-            vm.repo.metricSeries(COMPUTED_SOURCE, "vitality", "0000-01-01", "9999-12-31")
+            vm.repo.metricSeriesComputedUnion(vm.activeStrapId, "vitality", "0000-01-01", "9999-12-31")
         }.getOrDefault(emptyList()).lastOrNull()?.value
         bodyAge = runCatching {
-            vm.repo.metricSeries(COMPUTED_SOURCE, "body_age", "0000-01-01", "9999-12-31")
+            vm.repo.metricSeriesComputedUnion(vm.activeStrapId, "body_age", "0000-01-01", "9999-12-31")
         }.getOrDefault(emptyList()).lastOrNull()?.value
     }
     val contributions = remember(days, profile.age) {
@@ -2484,7 +2480,7 @@ private suspend fun buildSeriesVitalDetail(vm: AppViewModel, key: String): Vital
         title = "Fitness Age",
         unit = "yrs",
         color = Palette.chargeColor,
-        readings = vm.repo.metricSeries(COMPUTED_SOURCE, "fitness_age", "0000-01-01", "9999-12-31")
+        readings = vm.repo.metricSeriesComputedUnion(vm.activeStrapId, "fitness_age", "0000-01-01", "9999-12-31")
             .map { VitalReading(it.day, it.value, it.deviceId) },
         format = { it.roundToInt().toString() },
     )
@@ -2493,7 +2489,7 @@ private suspend fun buildSeriesVitalDetail(vm: AppViewModel, key: String): Vital
         title = "Vitality",
         unit = "",
         color = Palette.metricPurple,
-        readings = vm.repo.metricSeries(COMPUTED_SOURCE, "vitality", "0000-01-01", "9999-12-31")
+        readings = vm.repo.metricSeriesComputedUnion(vm.activeStrapId, "vitality", "0000-01-01", "9999-12-31")
             .map { VitalReading(it.day, it.value, it.deviceId) },
         format = { it.roundToInt().toString() },
     )

--- a/android/app/src/main/java/com/noop/ui/TodayScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/TodayScreen.kt
@@ -391,10 +391,10 @@ fun TodayScreen(
         // Read each pinned card from the SAME source its own detail screen reads, the proven path that
         // already shows real numbers there (and the resolution iOS's exploreSeries uses). Stress is derived
         // from the imported strap data (StressScreen reads "my-whoop"); Fitness age + Vitality are
-        // NOOP-COMPUTED weekly scores the IntelligenceEngine writes under the "-noop" source (HealthScreen
-        // reads COMPUTED_SOURCE = "my-whoop-noop"). The earlier resolvedSeries("…","my-whoop") read resolved
-        // empty in the demo because those two scores never live under the imported "my-whoop" source. Take
-        // the latest value (series are day-ascending), null → the card shows a dash, never a fabricated number.
+        // NOOP-COMPUTED weekly scores the IntelligenceEngine writes under "<activeStrapId>-noop". Read them
+        // through the computed UNION (active strap's sibling + canonical "my-whoop-noop"), the same helper
+        // HealthScreen uses — a hardcoded "my-whoop-noop" misses a live-BLE strap's "whoop-<mac>-noop" (#349).
+        // Take the latest value (series are day-ascending), null → the card shows a dash, never a fabricated number.
         // #753: build the SAME StressModel the detail screen (StressScreen) shows and take `model.score`,
         // rather than the stress series' last banked row. StressModel.build prefers today's stored stress row
         // but otherwise DERIVES today's score from the live `days` RHR/HRV baseline; the old `.lastOrNull()`
@@ -409,10 +409,12 @@ fun TodayScreen(
             StressModel.build(days, stored)?.score
         }.getOrNull()
         fitnessAgeToday = runCatching {
-            viewModel.repo.metricSeries("my-whoop-noop", "fitness_age", "0000-01-01", "9999-12-31").lastOrNull()?.value
+            viewModel.repo.metricSeriesComputedUnion(viewModel.activeStrapId, "fitness_age", "0000-01-01", "9999-12-31")
+                .lastOrNull()?.value
         }.getOrNull()
         vitalityToday = runCatching {
-            viewModel.repo.metricSeries("my-whoop-noop", "vitality", "0000-01-01", "9999-12-31").lastOrNull()?.value
+            viewModel.repo.metricSeriesComputedUnion(viewModel.activeStrapId, "vitality", "0000-01-01", "9999-12-31")
+                .lastOrNull()?.value
         }.getOrNull()
         // Cache the computed triple + signature so a later re-mount with unchanged data restores them and
         // short-circuits the history-wide read above.

--- a/android/app/src/test/java/com/noop/data/ResolverUnionTest.kt
+++ b/android/app/src/test/java/com/noop/data/ResolverUnionTest.kt
@@ -138,4 +138,41 @@ class ResolverUnionTest {
         )
         assertEquals(2, deduped.size)
     }
+
+    // --- mergeComputedSeriesUnion: the computed metricSeries day-union (#349) ---
+
+    private fun row(source: String, day: String, value: Double) =
+        MetricSeriesRow(deviceId = source, day = day, key = "fitness_age", value = value)
+
+    /** #349: the weekly computed scores (fitness_age / vitality / …) live under "<activeStrapId>-noop",
+     *  so a live-BLE strap banks them under "whoop-<mac>-noop". The union read must surface them (the
+     *  reported bug: a hardcoded "my-whoop-noop" read missed them → Fitness Age stuck "not ready"). The
+     *  active strap wins per shared day; the canonical import fills days it doesn't cover; day-sorted.
+     *  [perSource] is active-strap-first, exactly as computedSourceIds orders it. */
+    @Test
+    fun computedUnionActiveWinsPerDayAndCanonicalFillsGaps() {
+        val merged = WhoopRepository.mergeComputedSeriesUnion(
+            listOf(
+                listOf(row("$reAdded-noop", "2026-07-11", 20.0), row("$reAdded-noop", "2026-07-04", 21.0)),
+                listOf(row("my-whoop-noop", "2026-07-11", 40.0), row("my-whoop-noop", "2026-06-27", 42.0)),
+            ),
+        )
+        assertEquals(listOf("2026-06-27", "2026-07-04", "2026-07-11"), merged.map { it.day })
+        // The shared day: the ACTIVE strap's value + id win over the canonical import's.
+        val shared = merged.first { it.day == "2026-07-11" }
+        assertEquals(20.0, shared.value, 0.0)
+        assertEquals("$reAdded-noop", shared.deviceId)
+        // A canonical-only day still fills the gap.
+        assertEquals(42.0, merged.first { it.day == "2026-06-27" }.value, 0.0)
+    }
+
+    /** A single-WHOOP install passes its one source list through (the instance method short-circuits to a
+     *  single read); the merge just day-sorts it, byte-identical to the pre-fix single-source read. */
+    @Test
+    fun computedUnionSingleSourcePassesThroughSorted() {
+        val merged = WhoopRepository.mergeComputedSeriesUnion(
+            listOf(listOf(row("my-whoop-noop", "2026-07-04", 21.0), row("my-whoop-noop", "2026-07-11", 20.0))),
+        )
+        assertEquals(listOf(21.0, 20.0), merged.map { it.value })
+    }
 }


### PR DESCRIPTION
Fixes #349.

## The bug
Fitness Age / Vitality / Body Age stay permanently on the "not ready" checklist (every item green), and the Vitality/Body Age tile shows **No Data**, for anyone paired over **live Bluetooth**. Tapping refresh even toasts "Fitness Age updated." — because `recomputeFitnessAgeOnly` genuinely *did* write; the screen just never reads the source it wrote to.

Excellent diagnosis in the issue (DB proof + exact lines), confirmed against the code:
- `IntelligenceEngine` writes the weekly computed scores under `"<activeStrapId>-noop"`.
- `HealthScreen` (`COMPUTED_SOURCE`) and the Today "Your cards" tiles read a **hardcoded `"my-whoop-noop"`**.
- Import installs match by luck (`activeStrapId == "my-whoop"`). A live-BLE strap's registry id is `"whoop-<mac>"`, so the engine writes `"whoop-<mac>-noop"` and every read misses it.

## The fix
Read the computed series through the **active-strap union** — the active strap's `"-noop"` sibling **+** the canonical `"my-whoop-noop"`, deduped per day with the active strap winning:

```kotlin
suspend fun metricSeriesComputedUnion(activeStrapId, key, from, to): List<MetricSeriesRow>
```

This is the same resolver (`computedSourceIds`) every other read already uses, and mirrors the layering iOS's `Repository.exploreSeries` already does — so **iOS was never affected**; this brings Android back in line. Import users (`activeStrapId == "my-whoop"`) collapse to the single canonical id, byte-identical to before.

## Scope — the report cited HealthScreen; the Today card had it too
Grepping the whole bug class (hardcoded `"my-whoop-noop"` reads) surfaced the same bug in the pinned Today cards, so both are fixed:
- **HealthScreen** — 6 read sites (`fitness_age` / `vo2max_est` / `vitality` / `body_age` + the two vital-detail tables). Removed the now-dead `COMPUTED_SOURCE` constant.
- **TodayScreen** — the pinned Fitness age / Vitality cards.
- (`FusionTypes.NOOP_COMPUTED` is an arbitration label, not a read source; `AndroidDiagnostics` already unions — both left as-is.)

## Verification
- New pure companion `mergeComputedSeriesUnion` + `ResolverUnionTest` cases (active strap wins per shared day, canonical fills gaps, single-source passthrough).
- `compileFullDebugKotlin` clean; **full `testFullDebugUnitTest` suite green**.
- Android-only; no app-target Swift touched.

A live-BLE 4.0 reporter should confirm on-device, but the resolver + tests prove the id now resolves.
