### PR TITLE
Test Centre Recovery reads "no score" while Charge is fine (#343)

### DIFF
--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/SleepReadout.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/SleepReadout.swift
@@ -50,23 +50,39 @@ public enum SleepReadout {
 /// breakdown or HRV computation. No state, no side effects, no em-dashes.
 public enum TestReadout {
 
-    /// The most recent Charge score + band line from the `.recovery`-tagged tail, or nil. The emitter
-    /// writes "[recovery] charge day=... score=<n> band=<b> ..." (or a "nilScore reason=..." line when the
-    /// night could not be scored). Returns the score/band fragment so the panel reads the same number the
-    /// dashboard shows; falls back to the nil-reason when there is no score yet.
+    /// The Charge outcome for the MOST RECENT day from the `.recovery`-tagged tail, or nil. The emitter
+    /// writes "[recovery] charge day=<yyyy-MM-dd> ... score=<n> band=<b> ..." (or a "nilScore reason=..."
+    /// line when that day could not be scored). Returns the score/band fragment so the panel reads the same
+    /// number the dashboard shows; falls back to the nil-reason only when the NEWEST day genuinely has none.
+    ///
+    /// #343: the engine emits days NEWEST-FIRST (and may replay several passes), so the LAST line in the
+    /// tail is the OLDEST window-edge day — which is routinely a cold-start `nilScore missingInput` (no
+    /// baseline history at the window's far edge). Scanning the tail in reverse therefore surfaced that
+    /// stale edge day and read "no score (input missing)" even when today's Charge was a healthy green.
+    /// Instead select by the newest `day=` (ISO dates compare lexicographically), order-independently, and
+    /// prefer the last pass for that day. Mirrors the Kotlin twin `TestReadout.lastChargeBreakdown`.
     public static func lastChargeBreakdown(taggedTail: [String]) -> String? {
-        for line in taggedTail.reversed() {
+        var bestDay = ""
+        var outcome: String?
+        for line in taggedTail {
+            guard let dr = line.range(of: "day=") else { continue }
+            let day = String(line[dr.upperBound...].prefix(10))
+            guard day.count == 10, day >= bestDay else { continue }
+            let parsed: String?
             if let r = line.range(of: "score=") {
-                let rest = line[r.lowerBound...]   // "score=.. band=.. (..)"
-                let upto = rest.prefix { $0 != "(" }.trimmingCharacters(in: .whitespaces)
-                if !upto.isEmpty { return String(upto) }
-            }
-            if let r = line.range(of: "nilScore reason=") {
+                let upto = line[r.lowerBound...].prefix { $0 != "(" }.trimmingCharacters(in: .whitespaces)
+                parsed = upto.isEmpty ? nil : String(upto)
+            } else if let r = line.range(of: "nilScore reason=") {
                 let token = line[r.upperBound...].prefix { $0 != " " }
-                if !token.isEmpty { return "no score (\(token))" }
+                parsed = token.isEmpty ? nil : "no score (\(token))"
+            } else {
+                parsed = nil   // a baseline/term line for this day carries no outcome — skip it
             }
+            guard let parsed else { continue }
+            if day > bestDay { bestDay = day }   // a strictly newer day with an outcome resets the winner
+            outcome = parsed                     // newest day (or a later pass of it) → its outcome wins
         }
-        return nil
+        return outcome
     }
 
     /// The most recent HRV result fragment from the `.hrv`-tagged tail, or nil. The emitter writes

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/SleepReadoutTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/SleepReadoutTests.swift
@@ -68,6 +68,39 @@ final class TestReadoutTests: XCTestCase {
         XCTAssertNil(TestReadout.lastChargeBreakdown(taggedTail: ["[sleep] gate run=0 ... gate=accepted"]))
     }
 
+    func testLastChargeBreakdownPicksNewestDayNotLastEmitted() {
+        // #343: the engine emits days NEWEST-FIRST, so the LAST line is the OLDEST window-edge day — a
+        // cold-start nilScore. The panel must show the NEWEST day's real score, not that trailing nilScore.
+        let tail = [
+            "[recovery] charge day=2026-07-12 baseline hrv mean=44.8 spread=7.2 nValid=20 status=trusted",
+            "[recovery] charge day=2026-07-12 score=99.78 band=green (logistic k=1.6 z0=-0.2)",
+            "[recovery] charge day=2026-07-11 score=99.36 band=green (logistic k=1.6 z0=-0.2)",
+            "[recovery] charge day=2026-07-09 nilScore reason=missingInput (hrv/rhr/hrvBaseline required)",
+        ]
+        XCTAssertEqual(TestReadout.lastChargeBreakdown(taggedTail: tail), "score=99.78 band=green")
+    }
+
+    func testLastChargeBreakdownReportsNilWhenNewestDayGenuinelyMissing() {
+        // If the NEWEST day itself has no score (real missing input today), report THAT — don't fall
+        // through to an older day's score and present a stale number as current.
+        let tail = [
+            "[recovery] charge day=2026-07-12 nilScore reason=missingInput (hrv/rhr/hrvBaseline required)",
+            "[recovery] charge day=2026-07-11 score=88.0 band=green (logistic k=1.6 z0=-0.2)",
+        ]
+        XCTAssertEqual(TestReadout.lastChargeBreakdown(taggedTail: tail), "no score (missingInput)")
+    }
+
+    func testLastChargeBreakdownPrefersLastPassForNewestDay() {
+        // Several recompute passes may be in the tail; the newest day's latest pass wins.
+        let tail = [
+            "[recovery] charge day=2026-07-12 score=50.0 band=yellow (..)",  // pass 1
+            "[recovery] charge day=2026-07-11 score=40.0 band=yellow (..)",
+            "[recovery] charge day=2026-07-12 score=72.0 band=green (..)",   // pass 2, newest day refreshed
+            "[recovery] charge day=2026-07-11 score=41.0 band=yellow (..)",
+        ]
+        XCTAssertEqual(TestReadout.lastChargeBreakdown(taggedTail: tail), "score=72.0 band=green")
+    }
+
     func testLastHrvComputationParsesRmssdFragment() {
         let tail = [
             "[hrv] hrv path=spot nInput=60 nClean=58 rejectedFraction=0.03",

--- a/android/app/src/main/java/com/noop/analytics/SleepReadout.kt
+++ b/android/app/src/main/java/com/noop/analytics/SleepReadout.kt
@@ -49,26 +49,42 @@ object SleepReadout {
 object TestReadout {
 
     /**
-     * The most recent Charge score + band fragment from the RECOVERY-tagged tail, or null. The emitter
-     * writes "[recovery] charge day=... score=<n> band=<b> ..." (or a "nilScore reason=..." line when the
-     * night could not be scored). Returns the score/band fragment so the panel reads the same number the
-     * dashboard shows; falls back to the nil-reason when there is no score yet. Mirrors the Swift parser.
+     * The Charge outcome for the MOST RECENT day from the RECOVERY-tagged tail, or null. The emitter writes
+     * "[recovery] charge day=<yyyy-MM-dd> ... score=<n> band=<b> ..." (or a "nilScore reason=..." line when
+     * that day could not be scored). Returns the score/band fragment so the panel reads the same number the
+     * dashboard shows; falls back to the nil-reason only when the NEWEST day genuinely has none.
+     *
+     * #343: the engine emits days NEWEST-FIRST (and may replay several passes), so the LAST line in the tail
+     * is the OLDEST window-edge day — routinely a cold-start `nilScore missingInput` (no baseline history at
+     * the window's far edge). Scanning in reverse therefore surfaced that stale edge day and read "no score
+     * (input missing)" even when today's Charge was a healthy green. Instead select by the newest `day=`
+     * (ISO dates compare lexicographically), order-independently, preferring the last pass. Mirrors Swift.
      */
     fun lastChargeBreakdown(taggedTail: List<String>): String? {
-        for (line in taggedTail.asReversed()) {
-            val si = line.indexOf("score=")
-            if (si >= 0) {
-                val rest = line.substring(si)            // "score=.. band=.. (..)"
-                val upto = rest.takeWhile { it != '(' }.trim()
-                if (upto.isNotEmpty()) return upto
-            }
-            val ni = line.indexOf("nilScore reason=")
-            if (ni >= 0) {
-                val token = line.substring(ni + "nilScore reason=".length).takeWhile { it != ' ' }
-                if (token.isNotEmpty()) return "no score ($token)"
-            }
+        var bestDay = ""
+        var outcome: String? = null
+        for (line in taggedTail) {
+            val di = line.indexOf("day=")
+            if (di < 0) continue
+            val day = line.substring(di + 4).take(10)
+            if (day.length != 10 || day < bestDay) continue
+            val parsed: String? = run {
+                val si = line.indexOf("score=")
+                if (si >= 0) {
+                    val upto = line.substring(si).takeWhile { it != '(' }.trim()
+                    if (upto.isNotEmpty()) return@run upto
+                }
+                val ni = line.indexOf("nilScore reason=")
+                if (ni >= 0) {
+                    val token = line.substring(ni + "nilScore reason=".length).takeWhile { it != ' ' }
+                    if (token.isNotEmpty()) return@run "no score ($token)"
+                }
+                null   // a baseline/term line for this day carries no outcome — skip it
+            } ?: continue
+            if (day > bestDay) bestDay = day   // a strictly newer day with an outcome resets the winner
+            outcome = parsed                    // newest day (or a later pass of it) → its outcome wins
         }
-        return null
+        return outcome
     }
 
     /**

--- a/android/app/src/test/java/com/noop/analytics/TestReadoutTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/TestReadoutTest.kt
@@ -31,6 +31,39 @@ class TestReadoutTest {
         assertNull(TestReadout.lastChargeBreakdown(listOf("[sleep] gate run=0 ... gate=accepted")))
     }
 
+    @Test fun lastChargeBreakdownPicksNewestDayNotLastEmitted() {
+        // #343: the engine emits days NEWEST-FIRST, so the LAST line is the OLDEST window-edge day — a
+        // cold-start nilScore. The panel must show the NEWEST day's real score, not that trailing nilScore.
+        val tail = listOf(
+            "[recovery] charge day=2026-07-12 baseline hrv mean=44.8 spread=7.2 nValid=20 status=trusted",
+            "[recovery] charge day=2026-07-12 score=99.78 band=green (logistic k=1.6 z0=-0.2)",
+            "[recovery] charge day=2026-07-11 score=99.36 band=green (logistic k=1.6 z0=-0.2)",
+            "[recovery] charge day=2026-07-09 nilScore reason=missingInput (hrv/rhr/hrvBaseline required)",
+        )
+        assertEquals("score=99.78 band=green", TestReadout.lastChargeBreakdown(tail))
+    }
+
+    @Test fun lastChargeBreakdownReportsNilWhenNewestDayGenuinelyMissing() {
+        // If the NEWEST day itself has no score (real missing input today), report THAT — don't fall
+        // through to an older day's score and present a stale number as current.
+        val tail = listOf(
+            "[recovery] charge day=2026-07-12 nilScore reason=missingInput (hrv/rhr/hrvBaseline required)",
+            "[recovery] charge day=2026-07-11 score=88.0 band=green (logistic k=1.6 z0=-0.2)",
+        )
+        assertEquals("no score (missingInput)", TestReadout.lastChargeBreakdown(tail))
+    }
+
+    @Test fun lastChargeBreakdownPrefersLastPassForNewestDay() {
+        // Several recompute passes may be in the tail; the newest day's latest pass wins.
+        val tail = listOf(
+            "[recovery] charge day=2026-07-12 score=50.0 band=yellow (..)",  // pass 1
+            "[recovery] charge day=2026-07-11 score=40.0 band=yellow (..)",
+            "[recovery] charge day=2026-07-12 score=72.0 band=green (..)",   // pass 2, newest day refreshed
+            "[recovery] charge day=2026-07-11 score=41.0 band=yellow (..)",
+        )
+        assertEquals("score=72.0 band=green", TestReadout.lastChargeBreakdown(tail))
+    }
+
     @Test fun lastHrvComputationParsesRmssdFragment() {
         val tail = listOf(
             "[hrv] hrv path=spot nInput=60 nClean=58 rejectedFraction=0.03",


### PR DESCRIPTION
Fixes #343.

## The bug
Test Centre → Recovery (Charge) shows **"no score (input missing)"** for a WHOOP 4.0 / iOS user — but the score isn't actually missing. Their attached report proves Charge computes fine:
```
[recovery] charge day=2026-07-12 ... score=99.78 band=green   ← baseline status=trusted
[recovery] charge day=2026-07-11 ... score=99.36
[recovery] charge day=2026-07-09 nilScore reason=missingInput (hrv/rhr/hrvBaseline required)
```

## Root cause
`TestReadout.lastChargeBreakdown` walked the recovery-tagged tail with `reversed()` and returned the first match — i.e. the **last-emitted** charge line. But the engine emits days **newest-first** (and replays several passes), so the last line is the **oldest** day in the analyze-recent window. That far-edge day has no prior HRV history to build a baseline from, so it's routinely a cold-start `nilScore missingInput` — and the panel surfaced *that* instead of today's real score.

So it always showed the oldest window day, and when that day was a cold-start miss (common), it read "no score (input missing)".

## The fix
Select the outcome for the newest `day=` instead (ISO dates compare lexicographically), **order-independently**, preferring the last pass for that day. When the newest day itself genuinely has no score, that nil-reason is still reported — so a real missing-input *today* isn't masked by a stale older score.

## Scope
- **Cross-platform**: the Android twin `SleepReadout.kt` had the identical `asReversed()`/first-match bug — fixed byte-identically.
- New twin tests pin: the newest-first multi-day tail (the reported case), the genuinely-missing-today case, and multi-pass. The old fixtures only put the score line *last* (a newest-*last* assumption), which is why this slipped through.

## Not in scope (noted for follow-up)
The sibling readouts in the same file (`lastHrvComputation`, the sleep-gate readout) use the same `reversed()`-assumes-chronological idiom. Their emit semantics differ (per-window / per-run, not per-day), so I've left them out of this fix, but they're worth a separate audit.

## Verification
- Android: `compileFullDebugKotlin` clean; `TestReadoutTest` green (3 new cases).
- Swift: `SleepReadoutTests` (StrandAnalytics, `swift-packages` CI) — 3 new cases mirroring Android.

Diagnostic-only — does not affect the Charge score or the Today ring, but it misreads as "no score" and generates false bug reports like this one.
