### PR TITLE
Strip the iOS widget extension from the sideload .ipa (AltStore install reliability)

### DIFF
--- a/.github/workflows/fork-release.yml
+++ b/.github/workflows/fork-release.yml
@@ -238,7 +238,7 @@ jobs:
           -derivedDataPath build/dd
           CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY=""
           build
-      - name: Package unsigned .ipa (strip the embedded watch app) + attach
+      - name: Package unsigned .ipa (strip the embedded watch app + widget extension) + attach
         env:
           GH_TOKEN: ${{ github.token }}
           VER: ${{ needs.bump.outputs.ver }}
@@ -246,6 +246,12 @@ jobs:
           APP=$(find build/dd/Build/Products/Release-iphoneos -maxdepth 1 -name '*.app' -type d | head -1)
           test -n "$APP" || { echo ".app (iphoneos) not found"; exit 1; }
           rm -rf "$APP/Watch"
+          # Also drop the widget extension (NOOPWidgets.appex). On a re-signed sideload it forces a free
+          # Apple ID to register a SECOND app id (com.noopapp.noop.widgets) plus the app group, and free
+          # accounts get only 10 app ids / 7 days — so repeated AltStore attempts exhaust the quota and
+          # return a generic "failed". The main app installs + runs fine without it (the home-screen widget
+          # is the only thing lost), same rationale as the watch-app strip above.
+          rm -rf "$APP/PlugIns"
           rm -rf Payload && mkdir Payload && cp -R "$APP" Payload/
           zip -qr "NOOP-ios-unsigned-v${VER}.ipa" Payload
           gh release upload "${{ needs.bump.outputs.tag }}" "NOOP-ios-unsigned-v${VER}.ipa" --repo "$GITHUB_REPOSITORY" --clobber

--- a/.github/workflows/fork-testing-build.yml
+++ b/.github/workflows/fork-testing-build.yml
@@ -45,7 +45,7 @@ jobs:
           - **Android (release)** — \`NOOP-android-v${VER}.apk\` — optimized, non-debuggable build; installs beside the official app. \`com.noop.whoop.staging\`.
           - **Android (debug)** — \`NOOP-android-debug-v${VER}.apk\` — debuggable build. \`com.noop.whoop.debug\`.
           - **macOS** — \`NOOP-macos-v${VER}.zip\` — unzip, then **right-click → Open** (unsigned; Gatekeeper warns once).
-          - **iOS** — \`NOOP-ios-unsigned-v${VER}.ipa\` — sideload via **AltStore / Sideloadly** (re-signs on-device); embedded watch app stripped.
+          - **iOS** — \`NOOP-ios-unsigned-v${VER}.ipa\` — sideload via **AltStore / Sideloadly** (re-signs on-device); embedded watch app + widget extension stripped for free-account install reliability.
 
           Base app version ${VER} · built ${DATE} · \`${SHA}\`."
 
@@ -138,7 +138,7 @@ jobs:
           -derivedDataPath build/dd
           CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY=""
           build
-      - name: Package unsigned .ipa (strip the embedded watch app) + attach
+      - name: Package unsigned .ipa (strip the embedded watch app + widget extension) + attach
         env:
           GH_TOKEN: ${{ github.token }}
           VER: ${{ needs.meta.outputs.ver }}
@@ -146,6 +146,12 @@ jobs:
           APP=$(find build/dd/Build/Products/Release-iphoneos -maxdepth 1 -name '*.app' -type d | head -1)
           test -n "$APP" || { echo ".app (iphoneos) not found"; exit 1; }
           rm -rf "$APP/Watch"
+          # Also drop the widget extension (NOOPWidgets.appex). On a re-signed sideload it forces a free
+          # Apple ID to register a SECOND app id (com.noopapp.noop.widgets) plus the app group, and free
+          # accounts get only 10 app ids / 7 days — so repeated AltStore attempts exhaust the quota and
+          # return a generic "failed". The main app installs + runs fine without it (the home-screen widget
+          # is the only thing lost), same rationale as the watch-app strip above.
+          rm -rf "$APP/PlugIns"
           rm -rf Payload && mkdir Payload && cp -R "$APP" Payload/
           zip -qr "NOOP-ios-unsigned-v${VER}.ipa" Payload
           gh release upload "${{ needs.meta.outputs.tag }}" "NOOP-ios-unsigned-v${VER}.ipa" --repo "$GITHUB_REPOSITORY" --clobber


### PR DESCRIPTION
## What
Strip the widget extension (`PlugIns/NOOPWidgets.appex`) from the unsigned sideload `.ipa` in both the release and testing-build workflows, alongside the existing watch-app strip.

## Why
Users report the iOS build "keeps failing to download to AltStore … returns failed." Diagnosed from the actual `v8.7.0.ipa`:

- The app is built with the **iOS 26.5 SDK** (macos-26, for Liquid Glass), but the one iOS-26 API — `glassEffect` — is **`#available(iOS 26.0)`-guarded** (`RootTabView.swift:696`). So the app genuinely runs on **iOS 17+** and `MinimumOSVersion 17.0` is honest — **the SDK / iOS version is *not* the cause.**
- The real cause is the **widget extension**. A re-signed sideload with a widget forces a free Apple ID to register a *second* app id (`com.noopapp.noop.widgets`) plus the app group, on top of the main app. Free accounts get **10 app ids / 7 days**, so repeated install attempts exhaust the quota → generic "failed". That matches the "**keeps** failing on retries" symptom (a one-off OS gate wouldn't degrade with retries).

## Change
`rm -rf "$APP/PlugIns"` in the package step of `fork-release.yml` and `fork-testing-build.yml` (same rationale + pattern as `rm -rf "$APP/Watch"`), and the iOS asset note updated to say so.

The main app installs and runs identically — only the home-screen widget is lost on sideloaded builds (widgets barely function on a re-signed sideload anyway).

## Scope / notes
- Workflow-only; affects **future** releases. The already-published `v8.7.0.ipa` still contains the widget — re-run the release (or manually re-strip + re-upload that asset) to fix it for current users.
- Optional further hardening (not included): drop the now-unused `application-groups` entitlement from the release build so a free-account install registers just the one app id.
