### PR TITLE
Stress: carry last night's vitals instead of "Calibrating" after an update

### DIFF
--- a/Strand/Screens/StressView.swift
+++ b/Strand/Screens/StressView.swift
@@ -718,19 +718,23 @@ struct StressModel {
     /// Build from oldest→newest daily metrics plus any stored "stress" series.
     /// Returns nil only when there is no usable signal at all.
     init?(days: [DailyMetric], stored: [(day: String, value: Double)]) {
-        // Carry (#543): today's own row is often vitals-less until the overnight is analyzed —
-        // especially right after an app update relaunches and re-runs the pass — so score the NEWEST
-        // day that actually has RHR or HRV (the same last-night carry every other Today vital uses)
-        // instead of calibrating. Falls back to the last row when no day has vitals (cold start).
-        guard let idx = days.lastIndex(where: { $0.restingHr != nil || $0.avgHrv != nil }) ?? days.indices.last
-        else { return nil }   // no days at all
-        let today = days[idx]
-
         // Stored values keyed by day, clamped to 0–3.
         let storedByDay: [String: Double] = Dictionary(
             stored.map { ($0.day, min(max($0.value, 0), 3)) },
             uniquingKeysWith: { _, b in b }
         )
+
+        // Carry (#543): today's own row is often vitals-less until the overnight is analyzed —
+        // especially right after an app update relaunches and re-runs the pass — so score the NEWEST
+        // day that actually carries usable signal (RHR/HRV, or a stored/imported stress value) instead of
+        // calibrating, the same last-night carry every other Today vital uses. The predicate mirrors the
+        // storedToday||derived gate below, so an imported stress-only latest day is still honored (not
+        // skipped). Falls back to the last row when no day has any signal (cold start).
+        guard let idx = days.lastIndex(where: {
+            $0.restingHr != nil || $0.avgHrv != nil || storedByDay[$0.day] != nil
+        }) ?? days.indices.last
+        else { return nil }   // no days at all
+        let today = days[idx]
 
         // Baseline window: up to 30 days ending the day BEFORE the scored day, so it's measured
         // against its own recent past rather than itself.

--- a/Strand/Screens/StressView.swift
+++ b/Strand/Screens/StressView.swift
@@ -718,7 +718,13 @@ struct StressModel {
     /// Build from oldest→newest daily metrics plus any stored "stress" series.
     /// Returns nil only when there is no usable signal at all.
     init?(days: [DailyMetric], stored: [(day: String, value: Double)]) {
-        guard let today = days.last else { return nil }
+        // Carry (#543): today's own row is often vitals-less until the overnight is analyzed —
+        // especially right after an app update relaunches and re-runs the pass — so score the NEWEST
+        // day that actually has RHR or HRV (the same last-night carry every other Today vital uses)
+        // instead of calibrating. Falls back to the last row when no day has vitals (cold start).
+        guard let idx = days.lastIndex(where: { $0.restingHr != nil || $0.avgHrv != nil }) ?? days.indices.last
+        else { return nil }   // no days at all
+        let today = days[idx]
 
         // Stored values keyed by day, clamped to 0–3.
         let storedByDay: [String: Double] = Dictionary(
@@ -726,10 +732,9 @@ struct StressModel {
             uniquingKeysWith: { _, b in b }
         )
 
-        // Baseline window: up to 30 days ending the day BEFORE today, so "today"
-        // is measured against its own recent past rather than itself.
-        let history = Array(days.dropLast())
-        let baseline = Array(history.suffix(30))
+        // Baseline window: up to 30 days ending the day BEFORE the scored day, so it's measured
+        // against its own recent past rather than itself.
+        let baseline = idx > 0 ? Array(days[0..<idx].suffix(30)) : []
 
         let rhrBase = baseline.compactMap { $0.restingHr }.map(Double.init)
         let hrvBase = baseline.compactMap { $0.avgHrv }

--- a/StrandTests/StressModelCarryTests.swift
+++ b/StrandTests/StressModelCarryTests.swift
@@ -1,0 +1,37 @@
+import XCTest
+import WhoopStore
+@testable import Strand
+
+/// StressModel carry (#543). The Today "Stress" metric derives against a 30-day RHR/HRV baseline. Today's
+/// own daily row is often vitals-less until the overnight is analyzed (especially right after an app update
+/// relaunches and re-runs the analyze pass), and every OTHER Today vital carries last night's value — Stress
+/// used to be the one card that didn't, so it dropped to "Calibrating" while the rest showed numbers. These
+/// pin the carry: score the newest day that actually has RHR/HRV. Twin of the Android StressModelTest.
+final class StressModelCarryTests: XCTestCase {
+
+    private func day(_ d: String, rhr: Int?, hrv: Double?) -> DailyMetric {
+        DailyMetric(day: d, totalSleepMin: nil, efficiency: nil, deepMin: nil, remMin: nil,
+                    lightMin: nil, disturbances: nil, restingHr: rhr, avgHrv: hrv, recovery: nil,
+                    strain: nil, exerciseCount: nil)
+    }
+
+    // 31 days that all carry RHR + HRV: a full 30-day baseline plus one more scorable day.
+    private var baseline: [DailyMetric] {
+        (1...30).map { day(String(format: "2026-06-%02d", $0), rhr: 55, hrv: 60) }
+            + [day("2026-07-01", rhr: 55, hrv: 60)]
+    }
+
+    func testVitalsLessTodayCarriesInsteadOfCalibrating() {
+        // Control: today HAS vitals → builds (unchanged).
+        XCTAssertNotNil(StressModel(days: baseline + [day("2026-07-02", rhr: 58, hrv: 45)], stored: []))
+        // The fix: today has NO RHR/HRV yet (the post-update window) but a prior day does → carries, not nil.
+        XCTAssertNotNil(StressModel(days: baseline + [day("2026-07-02", rhr: nil, hrv: nil)], stored: []),
+                        "a vitals-less today must carry the last day with RHR/HRV, not calibrate")
+    }
+
+    func testNoVitalsAnywhereStillCalibrates() {
+        // Genuine cold start: no day has RHR/HRV and nothing stored → honestly calibrating (nil).
+        let days = (1...5).map { day("2026-07-0\($0)", rhr: nil, hrv: nil) }
+        XCTAssertNil(StressModel(days: days, stored: []))
+    }
+}

--- a/StrandTests/StressModelCarryTests.swift
+++ b/StrandTests/StressModelCarryTests.swift
@@ -34,4 +34,15 @@ final class StressModelCarryTests: XCTestCase {
         let days = (1...5).map { day("2026-07-0\($0)", rhr: nil, hrv: nil) }
         XCTAssertNil(StressModel(days: days, stored: []))
     }
+
+    func testStoredStressOnLatestVitalsLessDayIsUsedNotSkipped() {
+        // An imported latest day carries a STORED stress value but no RHR/HRV (e.g. a Xiaomi / Garmin /
+        // WHOOP export). The original gate honoured it; the carry must NOT skip it back to an older vitals
+        // day. The stored 2.5 must win over any derived carry.
+        let days = baseline + [day("2026-07-02", rhr: nil, hrv: nil)]
+        let model = StressModel(days: days, stored: [(day: "2026-07-02", value: 2.5)])
+        XCTAssertNotNil(model)
+        XCTAssertEqual(model?.score ?? -1, 2.5, accuracy: 0.001,
+                       "the latest day's stored stress must win over a carry")
+    }
 }

--- a/android/app/src/main/java/com/noop/ui/StressScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/StressScreen.kt
@@ -1199,10 +1199,13 @@ internal class StressModel private constructor(
         fun build(days: List<DailyMetric>, stored: Map<String, Double>): StressModel? {
             // Carry (#543): today's own row is often vitals-less until the overnight is analyzed —
             // especially right after an app update relaunches and re-runs the pass — so score the NEWEST
-            // day that actually has RHR or HRV (the same last-night carry every other Today vital uses)
-            // instead of calibrating. Falls back to the last row when no day has vitals (cold start).
-            val idx = days.indexOfLast { it.restingHr != null || it.avgHrv != null }
-                .let { if (it >= 0) it else days.size - 1 }
+            // day that actually carries usable signal (RHR/HRV, or a stored/imported stress value) instead
+            // of calibrating, the same last-night carry every other Today vital uses. The predicate mirrors
+            // the storedToday||derived gate below, so an imported stress-only latest day is still honored
+            // (not skipped). Falls back to the last row when no day has any signal (cold start).
+            val idx = days.indexOfLast {
+                it.restingHr != null || it.avgHrv != null || stored.containsKey(it.day)
+            }.let { if (it >= 0) it else days.size - 1 }
             if (idx < 0) return null   // no days at all
             val today = days[idx]
 

--- a/android/app/src/main/java/com/noop/ui/StressScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/StressScreen.kt
@@ -1197,12 +1197,18 @@ internal class StressModel private constructor(
         /** Build from oldest→newest daily metrics plus any stored "stress" series.
          *  Returns null only when there is no usable signal at all. */
         fun build(days: List<DailyMetric>, stored: Map<String, Double>): StressModel? {
-            val today = days.lastOrNull() ?: return null
+            // Carry (#543): today's own row is often vitals-less until the overnight is analyzed —
+            // especially right after an app update relaunches and re-runs the pass — so score the NEWEST
+            // day that actually has RHR or HRV (the same last-night carry every other Today vital uses)
+            // instead of calibrating. Falls back to the last row when no day has vitals (cold start).
+            val idx = days.indexOfLast { it.restingHr != null || it.avgHrv != null }
+                .let { if (it >= 0) it else days.size - 1 }
+            if (idx < 0) return null   // no days at all
+            val today = days[idx]
 
-            // Baseline window: up to 30 days ending the day BEFORE today, so "today" is
-            // measured against its own recent past rather than itself.
-            val history = if (days.size > 1) days.dropLast(1) else emptyList()
-            val baseline = history.takeLast(30)
+            // Baseline window: up to 30 days ending the day BEFORE the scored day, so it's measured
+            // against its own recent past rather than itself.
+            val baseline = if (idx > 0) days.subList(0, idx).takeLast(30) else emptyList()
 
             val rhrBase = baseline.mapNotNull { it.restingHr?.toDouble() }
             val hrvBase = baseline.mapNotNull { it.avgHrv }

--- a/android/app/src/test/java/com/noop/ui/StressModelTest.kt
+++ b/android/app/src/test/java/com/noop/ui/StressModelTest.kt
@@ -1,6 +1,7 @@
 package com.noop.ui
 
 import com.noop.data.DailyMetric
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Test
@@ -38,5 +39,16 @@ class StressModelTest {
         // Genuine cold start: no day has RHR/HRV and nothing stored -> honestly calibrating (null).
         val days = (1..5).map { day("2026-07-0$it", rhr = null, hrv = null) }
         assertNull(StressModel.build(days, emptyMap()))
+    }
+
+    @Test
+    fun storedStressOnLatestVitalsLessDayIsUsedNotSkipped() {
+        // An imported latest day carries a STORED stress value but no RHR/HRV (e.g. a Xiaomi / Garmin /
+        // WHOOP export). The original gate honoured it; the carry must NOT skip it back to an older vitals
+        // day. The stored 2.5 must win over any derived carry.
+        val days = baseline + day("2026-07-02", rhr = null, hrv = null)
+        val model = StressModel.build(days, mapOf("2026-07-02" to 2.5))
+        assertNotNull(model)
+        assertEquals("the latest day's stored stress must win over a carry", 2.5, model!!.score, 0.001)
     }
 }

--- a/android/app/src/test/java/com/noop/ui/StressModelTest.kt
+++ b/android/app/src/test/java/com/noop/ui/StressModelTest.kt
@@ -1,0 +1,42 @@
+package com.noop.ui
+
+import com.noop.data.DailyMetric
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * StressModel.build carry (#543). The Today "Stress" metric derives against a 30-day RHR/HRV baseline.
+ * Today's own daily row is often vitals-less until the overnight is analyzed (especially right after an
+ * app update relaunches and re-runs the analyze pass), and every OTHER Today vital carries last night's
+ * value — Stress used to be the one card that didn't, so it dropped to "Calibrating" while the rest showed
+ * numbers. These pin the carry: score the newest day that actually has RHR/HRV. Twin of the Swift
+ * StressModelCarryTests.
+ */
+class StressModelTest {
+
+    private fun day(d: String, rhr: Int?, hrv: Double?) =
+        DailyMetric(deviceId = "my-whoop", day = d, restingHr = rhr, avgHrv = hrv)
+
+    // 31 days that all carry RHR + HRV: a full 30-day baseline plus one more scorable day.
+    private val baseline = (1..30).map { day("2026-06-%02d".format(it), rhr = 55, hrv = 60.0) } +
+        day("2026-07-01", rhr = 55, hrv = 60.0)
+
+    @Test
+    fun vitalsLessTodayCarriesInsteadOfCalibrating() {
+        // Control: today HAS vitals -> builds (unchanged behaviour).
+        assertNotNull(StressModel.build(baseline + day("2026-07-02", rhr = 58, hrv = 45.0), emptyMap()))
+        // The fix: today has NO RHR/HRV yet (the post-update window) but a prior day does -> carries, not null.
+        assertNotNull(
+            "a vitals-less today must carry the last day with RHR/HRV, not calibrate",
+            StressModel.build(baseline + day("2026-07-02", rhr = null, hrv = null), emptyMap()),
+        )
+    }
+
+    @Test
+    fun noVitalsAnywhereStillCalibrates() {
+        // Genuine cold start: no day has RHR/HRV and nothing stored -> honestly calibrating (null).
+        val days = (1..5).map { day("2026-07-0$it", rhr = null, hrv = null) }
+        assertNull(StressModel.build(days, emptyMap()))
+    }
+}


### PR DESCRIPTION
## The bug
Users report the Today **Stress** metric shows "Calibrating" after every app update, while every other metric is fine.

`StressModel.build` scores today vs a 30-day RHR/HRV baseline off today's daily row, and returns nil ("Calibrating") when that row has no RHR/HRV and nothing's stored:
```
guard let today = days.last else { return nil }
...
guard storedToday != nil || derivedAvailable else { return nil }
```
RHR/HRV come from the **overnight analysis**, so today's row is vitals-less until that runs — and every *other* Today vital carries last night's value via the #543 `carriedDay`/`vitalsDay` fallback. **Stress was the one card that didn't**, reading `days.last` raw. An update reliably hits the window: the relaunch re-runs the analyze pass, which refreshes today's row (strain/steps from live data) *before* the overnight vitals are re-attached — so Stress alone drops to "Calibrating" while HRV/RHR/recovery show carried numbers. (Nothing persists today's stress either — there's no `stress` `metricSeries` write — so it can't fall back to a stored value.)

## The fix
Score the **newest day that carries usable signal** — RHR/HRV **or** a stored/imported stress value (the same last-night carry the other cards use), against *that* day's own prior 30-day baseline, instead of `days.last` raw:
```kotlin
val idx = days.indexOfLast { it.restingHr != null || it.avgHrv != null }.let { if (it >= 0) it else days.size - 1 }
if (idx < 0) return null
val today = days[idx]
val baseline = if (idx > 0) days.subList(0, idx).takeLast(30) else emptyList()
```
- **Normal days unchanged** — today's row has vitals, so the newest-with-vitals index *is* the last day, and the baseline is identical to before (verified by a control test).
- **Only a vitals-less latest row now carries** the previous day's value instead of calibrating.
- **Genuine cold start** (no day has vitals, nothing stored) still calibrates honestly.

## Parity + tests
Byte-identical on both platforms — `StressScreen.kt` (Android) and `StressView.swift` (iOS) — since `StressModel.build` is analytics logic. New twin tests (`StressModelTest` / `StressModelCarryTests`) pin all three cases.

**Verification:** `compileFullDebugKotlin` clean + `StressModelTest` green in `testFullDebugUnitTest`. The Swift `StressModel` is app-target (`StressView.swift` / `StrandTests`), so its test runs under `xcodebuild`/app-build rather than default CI — the change is a trivial index/slice mirror of the Kotlin.

> Re-review refinement: the carry predicate also matches a **stored** stress value (Xiaomi/Garmin/WHOOP imports write a `stress` metricSeries), mirroring build's `storedToday || derived` gate — so an imported stress-only latest day is honored, not skipped back to an older vitals day. Pinned by a fourth twin test.
