### PR TITLE
fix(oura): readiness resting_heart_rate contributor is a 0-100 score, not bpm

### DIFF
--- a/Packages/StrandImport/Sources/StrandImport/OuraApiParser+Daily.swift
+++ b/Packages/StrandImport/Sources/StrandImport/OuraApiParser+Daily.swift
@@ -3,8 +3,11 @@ import Foundation
 public extension OuraApiParser {
 
     /// Parse a day-keyed summary endpoint's documents. `endpoint` selects the field mapping. Writes to
-    /// `WearableDailyRow` columns only where the on-device schema already has a home (RHR, skin-temp dev,
+    /// `WearableDailyRow` columns only where the on-device schema already has a home (skin-temp dev,
     /// steps, calories, SpO2); everything else — and ALL of Oura's own scores — becomes `OuraDailyExtra`.
+    /// Resting HR is deliberately NOT written here: `contributors.resting_heart_rate` on `daily_readiness`
+    /// is a 0-100 readiness contributor SCORE, not bpm. The real resting HR comes from sleep's
+    /// `lowest_heart_rate` (`OuraApiParser.parseSleep`).
     static func parseDaily(_ docs: [[String: Any]], endpoint: String) -> (days: [WearableDailyRow], extras: [OuraDailyExtra]) {
         var byDay: [String: WearableDailyRow] = [:]
         var extras: [OuraDailyExtra] = []
@@ -19,7 +22,9 @@ public extension OuraApiParser {
             case "daily_readiness":
                 var r = byDay[day] ?? WearableDailyRow(day: day)
                 if let c = doc["contributors"] as? [String: Any] {
-                    r.restingHr = WearableJSON.posInt(c, "resting_heart_rate") ?? r.restingHr
+                    // `resting_heart_rate` here is a 0-100 readiness contributor SCORE, not bpm — do not
+                    // assign it to r.restingHr (that caused scores like 99/100/1 to be stored as "RHR").
+                    // It still surfaces honestly below as the `oura_readiness_resting_heart_rate` extra.
                     for (k, _) in c { extra(day, "oura_readiness_\(k)", WearableJSON.posDbl(c, k)) }
                 }
                 r.skinTempDevC = WearableJSON.dbl(doc, "temperature_deviation") ?? r.skinTempDevC

--- a/Packages/StrandImport/Tests/StrandImportTests/OuraApiParserDailyTests.swift
+++ b/Packages/StrandImport/Tests/StrandImportTests/OuraApiParserDailyTests.swift
@@ -2,16 +2,31 @@ import XCTest
 @testable import StrandImport
 
 final class OuraApiParserDailyTests: XCTestCase {
-    func testReadinessMapsRhrSkinTempAndRefScore() {
+    func testReadinessMapsSkinTempAndRefScoreButNotRhr() {
         let (days, extras) = OuraApiParser.parseDaily([[
             "day": "2026-01-02", "score": 80, "temperature_deviation": -0.2,
             "contributors": ["resting_heart_rate": 50, "hrv_balance": 70]
         ]], endpoint: "daily_readiness")
-        XCTAssertEqual(days.first?.restingHr, 50)
+        // contributors.resting_heart_rate is a 0-100 readiness SCORE, not bpm — must not land on restingHr.
+        XCTAssertNil(days.first?.restingHr)
         XCTAssertEqual(days.first?.skinTempDevC, -0.2)
         XCTAssertEqual(days.first?.readinessScore, 80)
         XCTAssertTrue(extras.contains(OuraDailyExtra(day: "2026-01-02", key: "ref_readiness_score", value: 80)))
         XCTAssertTrue(extras.contains(OuraDailyExtra(day: "2026-01-02", key: "oura_readiness_hrv_balance", value: 70)))
+    }
+
+    /// Regression test: `contributors.resting_heart_rate` is a 0-100 readiness contributor SCORE, not bpm.
+    /// A prior bug stored it directly as the user's resting HR (scores like 99/100/1/10/43 as "RHR" across
+    /// ~493 imported days). It must stay nil here — the real resting HR comes from sleep's
+    /// `lowest_heart_rate` (see `OuraApiParser.parseSleep`) — while the raw score still surfaces honestly
+    /// as an extra under its own name.
+    func testReadinessContributorRhrScoreDoesNotBecomeRestingHr() {
+        let (days, extras) = OuraApiParser.parseDaily([[
+            "day": "2026-01-02", "score": 80,
+            "contributors": ["resting_heart_rate": 99]
+        ]], endpoint: "daily_readiness")
+        XCTAssertNil(days.first?.restingHr)
+        XCTAssertTrue(extras.contains(OuraDailyExtra(day: "2026-01-02", key: "oura_readiness_resting_heart_rate", value: 99)))
     }
 
     func testActivityMapsStepsAndScoreIsReferenceOnly() {

--- a/Strand/Oura/OuraSyncCoordinator.swift
+++ b/Strand/Oura/OuraSyncCoordinator.swift
@@ -21,14 +21,16 @@ struct OuraSyncProgress: Equatable {
 }
 
 /// One-time backfill across every Oura v2 endpoint → an assembled OuraSyncResult → OuraSyncWriter. Merges
-/// the per-day WearableDailyRows across endpoints (daily endpoints BEFORE sleep, so readiness RHR wins).
+/// the per-day WearableDailyRows across endpoints (daily endpoints BEFORE sleep). Resting HR comes
+/// exclusively from sleep's `lowest_heart_rate` — no daily endpoint sets it (see `OuraApiParser.parseDaily`).
 final class OuraSyncCoordinator {
     private let fetcher: OuraPageFetching
     private let store: WhoopStore
     init(fetcher: OuraPageFetching, store: WhoopStore) { self.fetcher = fetcher; self.store = store }
 
-    /// Daily-summary endpoints handed to `parseDaily(_, endpoint:)`. Ordered so `daily_readiness` merges
-    /// before `sleep` (RHR precedence). `daily_sleep` etc. contribute extras only.
+    /// Daily-summary endpoints handed to `parseDaily(_, endpoint:)`. Merge order doesn't affect resting HR
+    /// (only `sleep`, merged separately below, ever sets it); `daily_readiness`, `daily_sleep` etc.
+    /// contribute their other fields / extras only.
     private static let dailyEndpoints = ["daily_readiness", "daily_activity", "daily_spo2", "daily_sleep",
                                          "daily_stress", "daily_resilience", "daily_cardiovascular_age", "vO2_max"]
     /// Endpoints with no Plan-1 parser — archived raw only.
@@ -84,7 +86,7 @@ final class OuraSyncCoordinator {
         // and the run continues; the UI surfaces the skips from the summary.
         var skipped: [String] = []
 
-        // Daily endpoints first (readiness RHR precedence), extras accumulate.
+        // Daily endpoints first, extras accumulate. None of them set resting HR (see parseDaily).
         for endpoint in Self.dailyEndpoints {
             do {
                 let pages = try await fetchRaw(endpoint, dateParam: "start_date")
@@ -92,7 +94,7 @@ final class OuraSyncCoordinator {
                 merge(days); result.extras.append(contentsOf: extras)
             } catch { skipped.append(endpoint) }
         }
-        // Sleep last (its lowestHr fallback only fills days readiness didn't cover).
+        // Sleep last: its lowestHr is the sole resting-HR source (no daily endpoint sets one).
         do {
             let sleepPages = try await fetchRaw("sleep", dateParam: "start_date")
             let (periods, sleepDays) = OuraApiParser.parseSleep(docs(sleepPages))

--- a/StrandTests/OuraSyncCoordinatorTests.swift
+++ b/StrandTests/OuraSyncCoordinatorTests.swift
@@ -41,9 +41,10 @@ final class OuraSyncCoordinatorTests: XCTestCase {
         XCTAssertTrue(summary.rawPages >= 3)
         XCTAssertTrue(progress.contains("sleep"))
 
-        // Coalesce + RHR precedence: daily_readiness's true RHR (50) wins over sleep's lowestHr (48).
+        // Coalesce: daily_readiness's contributors.resting_heart_rate (50) is a 0-100 readiness SCORE, not
+        // bpm, so it must NOT become restingHr — sleep's lowest_heart_rate (48) is the real resting HR.
         let days = try await store.dailyMetrics(deviceId: "oura-api", from: "2026-01-01", to: "2026-01-03")
-        XCTAssertEqual(days.first?.restingHr, 50)
+        XCTAssertEqual(days.first?.restingHr, 48)
         XCTAssertEqual(days.first?.steps, 9000)
         XCTAssertEqual(days.first?.totalSleepMin, 400)
     }


### PR DESCRIPTION
**Bug.** The Oura cloud import stores `daily_readiness.contributors.resting_heart_rate` as the day's resting HR. That field is a **0–100 readiness contributor score, not beats-per-minute** — like every other key in the `contributors` dict ([Oura: Readiness Contributors](https://support.ouraring.com/hc/en-us/articles/360057791533-Readiness-Contributors), [API docs](https://cloud.ouraring.com/v2/docs)). On a real import this produced impossible stored values (`restingHr` of 99, 100, then 1, 10 across a 493-day history — observed live) because the score, not the bpm, won the merge; the true resting HR (mid-40s–50s here) only survived on days without a readiness score.

**Fix.** Drop the score→`restingHr` hoist in `OuraApiParser.parseDaily`. The score remains available under its honest name (the `oura_readiness_resting_heart_rate` extra the contributors loop already emits), and the real resting HR now comes exclusively from sleep's `lowest_heart_rate` — a genuine bpm field the parser already used as fallback. `OuraSyncCoordinator`'s "readiness RHR wins" precedence comments are rewritten to match; no logic change was needed there (the existing `??` merge becomes correct once the daily row stops setting the field).

**Tests.** The coordinator test that pinned the buggy precedence (contributor 50 beating sleep's 48) now asserts sleep's 48 wins, with a comment explaining why; a new parser regression test pins contributor-99 → `restingHr` nil + extra still emitted. All three changed/added assertions fail against the pre-fix code.

**Verification.** `swift test` StrandImport: 194 tests, 0 failures. `StrandTests/OuraSyncCoordinatorTests` via xcodebuild: 4/4 (note: that suite is `OURA_CLOUD_IMPORT`-gated, so default CI won't re-run it — it needs a locally configured Oura xcconfig, per the lane's design). macOS app target builds.

**For anyone already affected:** data imported before this fix carries score-values in `restingHr` under the `oura-api` source; re-running "Connect Oura & Import Everything" after updating re-fetches and overwrites with correct values (the import is idempotent by day).

**Related:** the manual file-import lane (`OuraExportParser`) has the same score-as-bpm mapping; a separate one-concern PR will follow for that.
