### PR TITLE
perf(android): scalar counts + LIMIT-1 latest reads instead of materialized histories

### DIFF
--- a/android/app/src/main/java/com/noop/data/WhoopDao.kt
+++ b/android/app/src/main/java/com/noop/data/WhoopDao.kt
@@ -315,6 +315,10 @@ interface WhoopDao : DeviceRegistryDao {
     @Query("SELECT * FROM dailyMetric WHERE deviceId = :deviceId ORDER BY day ASC")
     suspend fun days(deviceId: String): List<DailyMetric>
 
+    /** Scalar COUNT twin of [days], for count badges that were materializing every row for `.size`. */
+    @Query("SELECT COUNT(*) FROM dailyMetric WHERE deviceId = :deviceId")
+    suspend fun daysCount(deviceId: String): Int
+
     /** Reactive stream of all daily metrics for a device, oldest first. */
     @Query("SELECT * FROM dailyMetric WHERE deviceId = :deviceId ORDER BY day ASC")
     fun daysFlow(deviceId: String): Flow<List<DailyMetric>>
@@ -406,6 +410,18 @@ interface WhoopDao : DeviceRegistryDao {
     /** Distinct metric keys present for a device, sorted ascending (Swift metricKeys, v9). */
     @Query("SELECT DISTINCT key FROM metricSeries WHERE deviceId = :deviceId ORDER BY key ASC")
     suspend fun metricKeys(deviceId: String): List<String>
+
+    /** Row count for one (deviceId, key) series — the scalar COUNT twin of [metricSeries], for count
+     *  badges (Data Sources) that were materializing the full history just to call `.size`. */
+    @Query("SELECT COUNT(*) FROM metricSeries WHERE deviceId = :deviceId AND key = :key")
+    suspend fun metricSeriesKeyCount(deviceId: String, key: String): Int
+
+    /** The NEWEST row of a (deviceId, key) series, or null — the ORDER BY day DESC LIMIT 1 twin of
+     *  [metricSeries] for latest-value tiles (day is yyyy-MM-dd, so lexicographic MAX(day) = newest).
+     *  Rides the same idx_metricSeries_device_key_day index, so the read stops at one row instead of
+     *  materializing the whole series for a `.lastOrNull()`. */
+    @Query("SELECT * FROM metricSeries WHERE deviceId = :deviceId AND key = :key ORDER BY day DESC LIMIT 1")
+    suspend fun latestMetricSeriesRow(deviceId: String, key: String): MetricSeriesRow?
 
     /** Delete one projected day for a key (used when a Lab Book reading's last numeric value
      *  for a (markerKey, day) cell is removed). Swift LabMarkerStore.reprojectCells delete branch. */
@@ -566,6 +582,11 @@ interface WhoopDao : DeviceRegistryDao {
     )
     suspend fun workouts(deviceId: String, from: Long, to: Long, limit: Int): List<WorkoutRow>
 
+    /** Scalar COUNT twin of [workouts] (no row limit — a count badge wants the exact total), for
+     *  badges that were materializing the row list for `.size`. */
+    @Query("SELECT COUNT(*) FROM workout WHERE deviceId = :deviceId AND startTs >= :from AND startTs <= :to")
+    suspend fun workoutsCount(deviceId: String, from: Long, to: Long): Int
+
     /**
      * Apple-Health daily aggregates for days in [from, to] (lexicographic compare), oldest first.
      * Port of JournalWorkoutAppleCache.swift appleDaily(deviceId:from:to:).
@@ -575,6 +596,10 @@ interface WhoopDao : DeviceRegistryDao {
             "ORDER BY day ASC"
     )
     suspend fun appleDaily(deviceId: String, from: String, to: String): List<AppleDaily>
+
+    /** Scalar COUNT twin of [appleDaily], for badges that were materializing the rows for `.size`. */
+    @Query("SELECT COUNT(*) FROM appleDaily WHERE deviceId = :deviceId AND day >= :from AND day <= :to")
+    suspend fun appleDailyCount(deviceId: String, from: String, to: String): Int
 
     /** Delete a computed source's workouts of a given [sport] whose startTs is in [from, to]
      *  (makes detected-workout re-derivation idempotent). (#78) */

--- a/android/app/src/main/java/com/noop/data/WhoopRepository.kt
+++ b/android/app/src/main/java/com/noop/data/WhoopRepository.kt
@@ -869,12 +869,32 @@ class WhoopRepository(private val dao: WhoopDao) {
         return mergeComputedSeriesUnion(ids.map { metricSeries(it, key, from, to) })
     }
 
+    /**
+     * The LATEST computed ("-noop") [key] row across the active-strap union, or null — the LIMIT-1
+     * twin of [metricSeriesComputedUnion] for "latest value" tiles (Today pinned cards, the Health
+     * hub heroes), which were materializing the FULL series just to take `.lastOrNull()`. Reads one
+     * indexed row per source id; the newest day wins, and on a shared newest day the ACTIVE strap
+     * wins (ids are active-first) — byte-identical to `metricSeriesComputedUnion(...).lastOrNull()`.
+     */
+    suspend fun latestMetricComputedUnion(activeStrapId: String, key: String): MetricSeriesRow? =
+        latestFromPerSourceLatest(
+            computedSourceIds(activeStrapId).map { dao.latestMetricSeriesRow(it, key) },
+        )
+
+    /** Scalar row count for one (deviceId, key) series — the COUNT twin of [metricSeries]. */
+    suspend fun metricSeriesKeyCount(deviceId: String, key: String): Int =
+        dao.metricSeriesKeyCount(deviceId, key)
+
     /** Distinct metric keys present for a [deviceId]/source, sorted ascending. */
     suspend fun metricKeys(deviceId: String): List<String> = dao.metricKeys(deviceId)
 
     /** Workouts whose startTs falls in [from, to] (unix seconds), oldest first, row-limited. */
     suspend fun workouts(deviceId: String, from: Long, to: Long, limit: Int = DEFAULT_LIMIT): List<WorkoutRow> =
         dao.workouts(deviceId, from, to, limit)
+
+    /** Scalar COUNT twin of [workouts] (exact total, no row limit) for count badges. */
+    suspend fun workoutsCount(deviceId: String, from: Long, to: Long): Int =
+        dao.workoutsCount(deviceId, from, to)
 
     /** Journal entries for the inclusive day range [from, to] (YYYY-MM-DD), oldest first. */
     suspend fun journal(deviceId: String, from: String, to: String): List<JournalEntry> =
@@ -895,8 +915,15 @@ class WhoopRepository(private val dao: WhoopDao) {
     suspend fun appleDaily(deviceId: String, from: String, to: String): List<AppleDaily> =
         dao.appleDaily(deviceId, from, to)
 
+    /** Scalar COUNT twin of [appleDaily] for count badges. */
+    suspend fun appleDailyCount(deviceId: String, from: String, to: String): Int =
+        dao.appleDailyCount(deviceId, from, to)
+
     /** All cached daily metrics for a device, oldest first. Feeds com.noop.analytics.IllnessWatch. */
     suspend fun days(deviceId: String): List<DailyMetric> = dao.days(deviceId)
+
+    /** Scalar COUNT twin of [days] for count badges. */
+    suspend fun daysCount(deviceId: String): Int = dao.daysCount(deviceId)
 
     /** Every distinct source id with at least one cached daily row. Feeds the Health Connect
      *  backfill's strap-coverage gate (see HealthConnectImporter.isStrapNativeSourceId). */
@@ -1361,6 +1388,20 @@ class WhoopRepository(private val dao: WhoopDao) {
          *  scores under "<importedDeviceId>-noop"). */
         fun computedSourceIdsFor(activeDeviceId: String): List<String> =
             importedSourceIdsFor(activeDeviceId).map { "$it-noop" }
+
+        /** Pick the winner among per-source LATEST rows ([computedSourceIdsFor] order, active-strap
+         *  first): the strictly newest day wins; a shared newest day keeps the FIRST seen (the active
+         *  strap) — byte-identical to what `mergeComputedSeriesUnion(...).lastOrNull()` yields on the
+         *  full series, computed from one LIMIT-1 row per source instead of materializing the whole
+         *  history (perf: the Today/Health latest-value tiles). Pure companion for [ResolverUnionTest]. */
+        internal fun latestFromPerSourceLatest(perSource: List<MetricSeriesRow?>): MetricSeriesRow? {
+            var best: MetricSeriesRow? = null
+            for (row in perSource) {
+                if (row == null) continue
+                if (best == null || row.day > best.day) best = row   // strictly newer wins; ties keep first (active)
+            }
+            return best
+        }
 
         /** Merge per-source computed ("-noop") metricSeries rows into one series, DEDUPED per day: the
          *  ACTIVE strap's value wins over the canonical import's on a shared day. [perSource] is in

--- a/android/app/src/main/java/com/noop/ui/DataSourcesScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/DataSourcesScreen.kt
@@ -138,50 +138,36 @@ fun DataSourcesScreen(vm: AppViewModel) {
     // Imported Oura / Fitbit / Garmin exports write daily metrics under their own per-brand source.
     var wearableDays by remember { mutableStateOf<Int?>(null) }
 
-    LaunchedEffect(Unit) {
-        val now = System.currentTimeMillis() / 1000
-        whoopDays = vm.repo.days("my-whoop").size
-        whoopWorkouts = vm.repo.workouts("my-whoop", 0L, now).size
+    // Count-badge refresh, shared by the initial load below and every importer's post-run refresh.
+    // PERF: scalar SQL COUNTs (and one LIMIT-1 existence probe), NOT materialized row lists — the old
+    // shape loaded every row of every source's history just to call `.size` on it, ~14 full-range
+    // reads per screen visit. Workout counts are now exact (the row read was capped at DEFAULT_LIMIT).
+    suspend fun refreshCounts() {
+        val nowS = System.currentTimeMillis() / 1000
+        whoopDays = vm.repo.daysCount("my-whoop")
+        whoopWorkouts = vm.repo.workoutsCount("my-whoop", 0L, nowS)
         whoopHasHr = vm.repo.latestHrSampleTs("my-whoop") != null
-        appleDays = vm.repo.appleDaily("apple-health", "0000-01-01", "9999-12-31").size
-        appleWorkouts = vm.repo.workouts("apple-health", 0L, now).size
-        hcDays = vm.repo.appleDaily("health-connect", "0000-01-01", "9999-12-31").size
-        hcWorkouts = vm.repo.workouts("health-connect", 0L, now).size
-        nutritionDays = vm.repo.metricSeries(NutritionCsvImporter.SOURCE_ID, "calories_in", "0000-01-01", "9999-12-31").size
-        nutritionWeighIns = vm.repo.metricSeries(NutritionCsvImporter.SOURCE_ID, "weight", "0000-01-01", "9999-12-31").size
-        xiaomiDays = vm.repo.metricSeries(XiaomiBandImporter.DEFAULT_DEVICE_ID, "steps", "0000-01-01", "9999-12-31").size
-        liftingWorkouts = vm.repo.workouts(LiftingImporter.SOURCE_ID, 0L, now).size
-        activityFiles = vm.repo.workouts(ActivityFileImporter.SOURCE_ID, 0L, now).size
+        appleDays = vm.repo.appleDailyCount("apple-health", "0000-01-01", "9999-12-31")
+        appleWorkouts = vm.repo.workoutsCount("apple-health", 0L, nowS)
+        hcDays = vm.repo.appleDailyCount("health-connect", "0000-01-01", "9999-12-31")
+        hcWorkouts = vm.repo.workoutsCount("health-connect", 0L, nowS)
+        nutritionDays = vm.repo.metricSeriesKeyCount(NutritionCsvImporter.SOURCE_ID, "calories_in")
+        nutritionWeighIns = vm.repo.metricSeriesKeyCount(NutritionCsvImporter.SOURCE_ID, "weight")
+        liftingWorkouts = vm.repo.workoutsCount(LiftingImporter.SOURCE_ID, 0L, nowS)
+        activityFiles = vm.repo.workoutsCount(ActivityFileImporter.SOURCE_ID, 0L, nowS)
+        xiaomiDays = vm.repo.metricSeriesKeyCount(XiaomiBandImporter.DEFAULT_DEVICE_ID, "steps")
         wearableDays = WearableExportImporter.Brand.values().sumOf {
-            vm.repo.metricSeries(it.sourceId, "rhr", "0000-01-01", "9999-12-31").size +
-                vm.repo.metricSeries(it.sourceId, "sleep_total_min", "0000-01-01", "9999-12-31").size
+            vm.repo.metricSeriesKeyCount(it.sourceId, "rhr") +
+                vm.repo.metricSeriesKeyCount(it.sourceId, "sleep_total_min")
         }
     }
+
+    LaunchedEffect(Unit) { refreshCounts() }
 
     // Busy flag shared by every importer's Export/Import buttons.
     var busy by remember { mutableStateOf(false) }
     // ah-delete (#616): drives the "Remove Apple Health imported data" confirm dialog.
     var confirmDeleteApple by remember { mutableStateOf(false) }
-
-    suspend fun refreshCounts() {
-        val nowS = System.currentTimeMillis() / 1000
-        whoopDays = vm.repo.days("my-whoop").size
-        whoopWorkouts = vm.repo.workouts("my-whoop", 0L, nowS).size
-        whoopHasHr = vm.repo.latestHrSampleTs("my-whoop") != null
-        appleDays = vm.repo.appleDaily("apple-health", "0000-01-01", "9999-12-31").size
-        appleWorkouts = vm.repo.workouts("apple-health", 0L, nowS).size
-        hcDays = vm.repo.appleDaily("health-connect", "0000-01-01", "9999-12-31").size
-        hcWorkouts = vm.repo.workouts("health-connect", 0L, nowS).size
-        nutritionDays = vm.repo.metricSeries(NutritionCsvImporter.SOURCE_ID, "calories_in", "0000-01-01", "9999-12-31").size
-        nutritionWeighIns = vm.repo.metricSeries(NutritionCsvImporter.SOURCE_ID, "weight", "0000-01-01", "9999-12-31").size
-        liftingWorkouts = vm.repo.workouts(LiftingImporter.SOURCE_ID, 0L, nowS).size
-        activityFiles = vm.repo.workouts(ActivityFileImporter.SOURCE_ID, 0L, nowS).size
-        xiaomiDays = vm.repo.metricSeries(XiaomiBandImporter.DEFAULT_DEVICE_ID, "steps", "0000-01-01", "9999-12-31").size
-        wearableDays = WearableExportImporter.Brand.values().sumOf {
-            vm.repo.metricSeries(it.sourceId, "rhr", "0000-01-01", "9999-12-31").size +
-                vm.repo.metricSeries(it.sourceId, "sleep_total_min", "0000-01-01", "9999-12-31").size
-        }
-    }
 
     // Run an importer off the main thread, refresh the counts, then toast the result.
     fun runImport(block: suspend () -> ImportSummary) {

--- a/android/app/src/main/java/com/noop/ui/HealthScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/HealthScreen.kt
@@ -612,12 +612,13 @@ private fun FitnessAgeSection(vm: AppViewModel, days: List<DailyMetric>, profile
     var refreshTick by remember { mutableStateOf(0) }
     var refreshing by remember { mutableStateOf(false) }
     LaunchedEffect(days, refreshTick) {
+        // Latest-value reads (LIMIT-1 per source) — the full-series `.lastOrNull()` scan is gone (perf).
         val fa = runCatching {
-            vm.repo.metricSeriesComputedUnion(vm.activeStrapId, "fitness_age", "0000-01-01", "9999-12-31")
-        }.getOrDefault(emptyList()).lastOrNull()?.value
+            vm.repo.latestMetricComputedUnion(vm.activeStrapId, "fitness_age")?.value
+        }.getOrNull()
         val vo2 = runCatching {
-            vm.repo.metricSeriesComputedUnion(vm.activeStrapId, "vo2max_est", "0000-01-01", "9999-12-31")
-        }.getOrDefault(emptyList()).lastOrNull()?.value
+            vm.repo.latestMetricComputedUnion(vm.activeStrapId, "vo2max_est")?.value
+        }.getOrNull()
         fitnessAge = fa
         vo2max = vo2
     }
@@ -679,12 +680,13 @@ private fun VitalitySection(vm: AppViewModel, days: List<DailyMetric>, profile: 
     var vitality by remember { mutableStateOf<Double?>(null) }
     var bodyAge by remember { mutableStateOf<Double?>(null) }
     LaunchedEffect(days) {
+        // Latest-value reads (LIMIT-1 per source) — the full-series `.lastOrNull()` scan is gone (perf).
         vitality = runCatching {
-            vm.repo.metricSeriesComputedUnion(vm.activeStrapId, "vitality", "0000-01-01", "9999-12-31")
-        }.getOrDefault(emptyList()).lastOrNull()?.value
+            vm.repo.latestMetricComputedUnion(vm.activeStrapId, "vitality")?.value
+        }.getOrNull()
         bodyAge = runCatching {
-            vm.repo.metricSeriesComputedUnion(vm.activeStrapId, "body_age", "0000-01-01", "9999-12-31")
-        }.getOrDefault(emptyList()).lastOrNull()?.value
+            vm.repo.latestMetricComputedUnion(vm.activeStrapId, "body_age")?.value
+        }.getOrNull()
     }
     val contributions = remember(days, profile.age) {
         val last7 = days.takeLast(7)

--- a/android/app/src/main/java/com/noop/ui/TodayScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/TodayScreen.kt
@@ -409,12 +409,10 @@ fun TodayScreen(
             StressModel.build(days, stored)?.score
         }.getOrNull()
         fitnessAgeToday = runCatching {
-            viewModel.repo.metricSeriesComputedUnion(viewModel.activeStrapId, "fitness_age", "0000-01-01", "9999-12-31")
-                .lastOrNull()?.value
+            viewModel.repo.latestMetricComputedUnion(viewModel.activeStrapId, "fitness_age")?.value
         }.getOrNull()
         vitalityToday = runCatching {
-            viewModel.repo.metricSeriesComputedUnion(viewModel.activeStrapId, "vitality", "0000-01-01", "9999-12-31")
-                .lastOrNull()?.value
+            viewModel.repo.latestMetricComputedUnion(viewModel.activeStrapId, "vitality")?.value
         }.getOrNull()
         // Cache the computed triple + signature so a later re-mount with unchanged data restores them and
         // short-circuits the history-wide read above.

--- a/android/app/src/test/java/com/noop/data/ResolverUnionTest.kt
+++ b/android/app/src/test/java/com/noop/data/ResolverUnionTest.kt
@@ -175,4 +175,46 @@ class ResolverUnionTest {
         )
         assertEquals(listOf(21.0, 20.0), merged.map { it.value })
     }
+
+    // --- latestFromPerSourceLatest: the LIMIT-1 twin of the union's .lastOrNull() (perf) ---
+
+    /** The latest-value pick must be BYTE-IDENTICAL to mergeComputedSeriesUnion(...).lastOrNull():
+     *  strictly newest day wins across sources; a shared newest day keeps the ACTIVE strap's row
+     *  (first in list order). Uses the same fixtures as the merge test so the equivalence is literal. */
+    @Test
+    fun latestPickMatchesFullMergeLastOrNull() {
+        val perSourceFull = listOf(
+            listOf(row("$reAdded-noop", "2026-07-11", 20.0), row("$reAdded-noop", "2026-07-04", 21.0)),
+            listOf(row("my-whoop-noop", "2026-07-11", 40.0), row("my-whoop-noop", "2026-06-27", 42.0)),
+        )
+        val viaMerge = WhoopRepository.mergeComputedSeriesUnion(perSourceFull).lastOrNull()
+        // Per-source LATEST rows, as the LIMIT-1 DAO read returns them (max day per source).
+        val viaLatest = WhoopRepository.latestFromPerSourceLatest(
+            listOf(row("$reAdded-noop", "2026-07-11", 20.0), row("my-whoop-noop", "2026-07-11", 40.0)),
+        )
+        assertEquals(viaMerge, viaLatest)
+        assertEquals("$reAdded-noop", viaLatest?.deviceId)   // shared newest day → active wins
+    }
+
+    /** The canonical import's row wins when it is STRICTLY newer than the active strap's. */
+    @Test
+    fun latestPickNewerCanonicalBeatsOlderActive() {
+        val picked = WhoopRepository.latestFromPerSourceLatest(
+            listOf(row("$reAdded-noop", "2026-07-04", 21.0), row("my-whoop-noop", "2026-07-11", 40.0)),
+        )
+        assertEquals("my-whoop-noop", picked?.deviceId)
+        assertEquals(40.0, picked!!.value, 0.0)
+    }
+
+    /** Null sources (no rows banked for that id) are skipped; all-null → null (no fabricated value). */
+    @Test
+    fun latestPickSkipsNullsAndReturnsNullWhenEmpty() {
+        assertEquals(
+            "$reAdded-noop",
+            WhoopRepository.latestFromPerSourceLatest(
+                listOf(null, row("$reAdded-noop", "2026-07-04", 21.0)),
+            )?.deviceId,
+        )
+        assertNull(WhoopRepository.latestFromPerSourceLatest(listOf(null, null)))
+    }
 }


### PR DESCRIPTION
Perf review follow-up (Android half; the Swift half is a separate PR). Two UI read patterns loaded **full table histories to extract one number**:

## 1. Data Sources count badges materialized every row of every source
`DataSourcesScreen` ran ~14 full-range reads (`days`, `workouts`, `appleDaily`, and 6+ `metricSeries(src, key, "0000-01-01", "9999-12-31")`) just to call `.size` — **twice**, because the initial `LaunchedEffect(Unit)` duplicated the `refreshCounts()` body verbatim. Every screen visit + every import re-ran the lot.

- New scalar COUNT twins on the DAO/repo: `daysCount` / `workoutsCount` / `appleDailyCount` / `metricSeriesKeyCount`.
- The two duplicated blocks are deduped into one `refreshCounts()` (the effect now calls it).
- Side-effect fix: workout counts are now **exact** — the old `.size` was silently capped at `DEFAULT_LIMIT`.

## 2. "Latest value" tiles read the full computed series for `.lastOrNull()`
The Today pinned Fitness age / Vitality cards and the Health hub heroes (fitness_age / vo2max_est / vitality / body_age) read the whole `metricSeriesComputedUnion` history and took the last row. New `latestMetricComputedUnion` reads **one indexed `ORDER BY day DESC LIMIT 1` row per source id** and picks the winner (newest day; a shared newest day keeps the active strap — ids are active-first).

**Equivalence is pinned, not assumed:** `latestPickMatchesFullMergeLastOrNull` asserts the LIMIT-1 pick equals `mergeComputedSeriesUnion(...).lastOrNull()` on the same fixtures the #349 union tests use. The Health vital-detail tables keep the full-series read (they chart it).

## Scope / verification
- Behaviour-preserving by construction (equivalence test + the COUNT swaps).
- Pure companion `latestFromPerSourceLatest` + 3 new `ResolverUnionTest` cases (merge equivalence, newer-canonical-wins, null-skip/all-null).
- `compileFullDebugKotlin` clean; **full `testFullDebugUnitTest` green**. Android-only, no schema change, no migration.
