### PR TITLE
fix(oura): export-file importer — stop storing the readiness resting_heart_rate SCORE as bpm (Swift + Kotlin twin of #365)

### DIFF
--- a/Packages/StrandImport/Sources/StrandImport/OuraExportParser.swift
+++ b/Packages/StrandImport/Sources/StrandImport/OuraExportParser.swift
@@ -14,7 +14,9 @@ import Foundation
 //                        a per-segment hypnogram, so the session carries the breakdown without a stage
 //                        timeline (we never fake one).
 //   daily_readiness    : day, score (Oura's OWN readiness, REFERENCE only, never NOOP Charge),
-//                        temperature_deviation (°C from baseline), contributors.resting_heart_rate.
+//                        temperature_deviation (°C from baseline). `contributors.resting_heart_rate`
+//                        is a 0-100 readiness contributor SCORE, not bpm — never read as resting HR;
+//                        the real RHR comes only from a sleep period's lowest_heart_rate.
 //   daily_activity     : day, steps, active_calories, total_calories, equivalent_walking_distance (m).
 //   daily_sleep        : day, score (sleep score, reference only).
 //   daily_spo2         : day, spo2_percentage.average (%); note the value is NESTED under that key, not
@@ -72,14 +74,14 @@ enum OuraExportParser {
                 byDay[key] = row
             }
 
-            // Daily readiness → RHR + temperature deviation + reference readiness score.
+            // Daily readiness → temperature deviation + reference readiness score.
+            // `contributors.resting_heart_rate` (and a flattened `resting_heart_rate` alongside it) is a
+            // 0-100 readiness contributor SCORE, not bpm — it must never land on row.restingHr (the API
+            // lane had the same bug; the old code here also clobbered the sleep-derived value above).
+            // The real resting HR comes only from the sleep loop's `lowest_heart_rate`.
             for r in categoryArray(root, "daily_readiness") ?? categoryArray(root, "readiness") ?? [] {
                 guard let key = WearableJSON.str(r, "day") else { continue }
                 var row = day(key)
-                if let contrib = r["contributors"] as? [String: Any] {
-                    row.restingHr = WearableJSON.posInt(contrib, "resting_heart_rate") ?? row.restingHr
-                }
-                row.restingHr = WearableJSON.posInt(r, "resting_heart_rate") ?? row.restingHr
                 row.skinTempDevC = WearableJSON.dbl(r, "temperature_deviation") ?? row.skinTempDevC
                 row.readinessScore = WearableJSON.posInt(r, "score") ?? row.readinessScore
                 byDay[key] = row

--- a/Packages/StrandImport/Tests/StrandImportTests/OuraExportParserTests.swift
+++ b/Packages/StrandImport/Tests/StrandImportTests/OuraExportParserTests.swift
@@ -1,0 +1,69 @@
+import XCTest
+@testable import StrandImport
+
+/// Pins the account-export ("Export Data" file) lane's resting-HR semantics — the file-import twin of
+/// `OuraApiParserDailyTests`. Oura's daily_readiness `contributors.resting_heart_rate` is a 0-100
+/// readiness contributor SCORE, not bpm; the real resting HR comes only from a sleep period's
+/// `lowest_heart_rate`.
+final class OuraExportParserTests: XCTestCase {
+
+    private func bytes(_ s: String) -> Data { s.data(using: .utf8)! }
+
+    /// Regression test (twin of the API-lane fix): a prior bug stored the readiness contributor score
+    /// directly as the user's resting HR. With no sleep period in the export, restingHr must stay nil —
+    /// never the 0-100 score — while the readiness score itself stays reference-only.
+    func testReadinessContributorRhrScoreDoesNotBecomeRestingHr() {
+        let json = """
+        { "daily_readiness": [ { "day": "2026-01-02", "score": 80,
+            "contributors": { "resting_heart_rate": 99 } } ] }
+        """
+        let (days, _) = OuraExportParser.parse(["export.json": bytes(json)])
+        XCTAssertEqual(days.count, 1)
+        XCTAssertNil(days.first?.restingHr)
+        XCTAssertEqual(days.first?.readinessScore, 80)
+    }
+
+    /// A flat `resting_heart_rate` key on the readiness record is the same contributor score in a
+    /// flattened shape — it must not land on restingHr either.
+    func testFlatReadinessRestingHeartRateKeyDoesNotBecomeRestingHr() {
+        let json = """
+        { "daily_readiness": [ { "day": "2026-01-02", "score": 80, "resting_heart_rate": 97 } ] }
+        """
+        let (days, _) = OuraExportParser.parse(["export.json": bytes(json)])
+        XCTAssertNil(days.first?.restingHr)
+        XCTAssertEqual(days.first?.readinessScore, 80)
+    }
+
+    /// Sleep's `lowest_heart_rate` is the sole resting-HR source. The old code let the readiness loop
+    /// overwrite the sleep-derived 48 bpm with the contributor score (96 here) whenever both categories
+    /// were present — regardless of file iteration order, since the overwrite didn't check for nil.
+    func testSleepLowestHeartRateIsTheSoleRestingHrSource() {
+        let json = """
+        {
+          "sleep": [
+            { "day": "2026-01-02", "bedtime_start": "2026-01-01T23:00:00+00:00",
+              "bedtime_end": "2026-01-02T06:30:00+00:00", "total_sleep_duration": 25200,
+              "lowest_heart_rate": 48 } ],
+          "daily_readiness": [
+            { "day": "2026-01-02", "score": 80,
+              "contributors": { "resting_heart_rate": 96 } } ]
+        }
+        """
+        let (days, _) = OuraExportParser.parse(["export.json": bytes(json)])
+        let day = days.first { $0.day == "2026-01-02" }
+        XCTAssertEqual(day?.restingHr, 48)
+        XCTAssertEqual(day?.readinessScore, 80)
+    }
+
+    /// The `readiness` category alias (older API-shaped exports) runs through the same loop and must
+    /// obey the same rule.
+    func testReadinessAliasCategoryDoesNotWriteRestingHr() {
+        let json = """
+        { "readiness": [ { "day": "2026-01-03", "score": 74,
+            "contributors": { "resting_heart_rate": 100 } } ] }
+        """
+        let (days, _) = OuraExportParser.parse(["export.json": bytes(json)])
+        XCTAssertNil(days.first?.restingHr)
+        XCTAssertEqual(days.first?.readinessScore, 74)
+    }
+}

--- a/Packages/StrandImport/Tests/StrandImportTests/WearableExportImporterTests.swift
+++ b/Packages/StrandImport/Tests/StrandImportTests/WearableExportImporterTests.swift
@@ -12,8 +12,9 @@ final class WearableExportImporterTests: XCTestCase {
     // MARK: - Oura
 
     func testOuraSleepReadinessActivityFold() {
-        // Sleep period: 7h asleep (25200s) with stage durations + HRV/RHR; readiness gives RHR + temp
-        // deviation + a readiness SCORE (reference); activity gives steps + calories.
+        // Sleep period: 7h asleep (25200s) with stage durations + HRV/RHR; readiness gives temp
+        // deviation + a readiness SCORE (reference) — its contributors.resting_heart_rate is a 0-100
+        // SCORE, not bpm, and must never become the day's RHR; activity gives steps + calories.
         let json = """
         {
           "sleep": [
@@ -35,7 +36,7 @@ final class WearableExportImporterTests: XCTestCase {
           ],
           "daily_readiness": [
             { "day": "2026-06-01", "score": 81, "temperature_deviation": -0.2,
-              "contributors": { "resting_heart_rate": 49 } }
+              "contributors": { "resting_heart_rate": 96 } }
           ],
           "daily_activity": [
             { "day": "2026-06-01", "steps": 8421, "active_calories": 520, "total_calories": 2450 }
@@ -59,7 +60,7 @@ final class WearableExportImporterTests: XCTestCase {
         XCTAssertEqual(r.days.count, 1)
         let d = r.days[0]
         XCTAssertEqual(d.day, "2026-06-01")
-        XCTAssertEqual(d.restingHr, 49)                          // readiness contributor wins
+        XCTAssertEqual(d.restingHr, 48)                          // sleep lowest_heart_rate, never the 96 score
         XCTAssertEqual(d.skinTempDevC!, -0.2, accuracy: 1e-6)
         XCTAssertEqual(d.steps, 8421)
         XCTAssertEqual(d.activeKcal!, 520, accuracy: 1e-6)
@@ -155,9 +156,15 @@ final class WearableExportImporterTests: XCTestCase {
 
     func testOuraJSONStillWinsOverCSVForSameDay() {
         // A mixed export (JSON + CSV) for the same day: the richer JSON value must win, CSV fills gaps.
+        // The JSON's RHR comes from the sleep period's lowest_heart_rate; the readiness
+        // contributors.resting_heart_rate is a 0-100 SCORE and never competes at all.
         let json = """
-        { "daily_readiness": [ { "day": "2026-06-01", "score": 81,
-            "contributors": { "resting_heart_rate": 49 } } ] }
+        { "sleep": [
+            { "day": "2026-06-01", "bedtime_start": "2026-05-31T23:15:00+00:00",
+              "bedtime_end": "2026-06-01T06:30:00+00:00", "total_sleep_duration": 25200,
+              "lowest_heart_rate": 49 } ],
+          "daily_readiness": [ { "day": "2026-06-01", "score": 81,
+            "contributors": { "resting_heart_rate": 96 } } ] }
         """
         let csv = """
         date,Average Resting Heart Rate,Steps
@@ -166,7 +173,7 @@ final class WearableExportImporterTests: XCTestCase {
         let files: [String: Data] = ["oura.json": bytes(json), "oura_daily.csv": bytes(csv)]
         let r = WearableExportImporter.parse(brand: .oura, files: files)
         let d = r.days.first { $0.day == "2026-06-01" }!
-        XCTAssertEqual(d.restingHr, 49)   // JSON readiness RHR wins over the CSV's 77
+        XCTAssertEqual(d.restingHr, 49)   // JSON sleep lowest HR wins over the CSV's 77
         XCTAssertEqual(d.steps, 8421)     // CSV fills the step gap JSON lacked
     }
 

--- a/android/app/src/main/java/com/noop/ingest/WearableExportImporter.kt
+++ b/android/app/src/main/java/com/noop/ingest/WearableExportImporter.kt
@@ -26,7 +26,9 @@ import java.util.zip.ZipInputStream
  *
  *   • Oura   : the Account -> Export Data per-category files (CSV, `;`-delimited; or an older JSON
  *              variant): sleep periods (durations/HRV/RHR/breath; a `deleted` type is skipped), daily
- *              readiness (RHR, temperature deviation, score), daily activity (steps/calories/distance),
+ *              readiness (temperature deviation, score — its `contributors.resting_heart_rate` is a
+ *              0-100 SCORE, not bpm, never read as resting HR; the real RHR comes only from a sleep
+ *              period's lowest_heart_rate), daily activity (steps/calories/distance),
  *              daily SpO2 (`spo2_percentage.average`), VO2max (`vo2_max`). Field names verified against a
  *              REAL Oura export schema (issue #862). The many health types NOOP doesn't model
  *              (bloodglucose, contraception, medication, ring config, raw sample streams, ...) are skipped
@@ -258,13 +260,16 @@ object WearableExportImporter {
                     if (d.restingHr == null) d.restingHr = session.lowestHr
                 }
             }
+            // Daily readiness → temperature deviation + reference readiness score.
+            // `contributors.resting_heart_rate` (and a flattened `resting_heart_rate` alongside it) is a
+            // 0-100 readiness contributor SCORE, not bpm — it must never land on d.restingHr (the old code
+            // clobbered the sleep-derived value above). The real resting HR comes only from the sleep
+            // loop's `lowest_heart_rate`. Twin of the Swift OuraExportParser fix.
             (categoryArray(root, "daily_readiness") ?: categoryArray(root, "readiness"))?.let { arr ->
                 for (i in 0 until arr.length()) {
                     val r = arr.optJSONObject(i) ?: continue
                     val key = r.strOpt("day") ?: continue
                     val d = day(key)
-                    r.optJSONObject("contributors")?.let { d.restingHr = it.posInt("resting_heart_rate") ?: d.restingHr }
-                    d.restingHr = r.posInt("resting_heart_rate") ?: d.restingHr
                     d.skinTempDevC = r.dblOpt("temperature_deviation") ?: d.skinTempDevC
                     d.readinessScore = r.posInt("score") ?: d.readinessScore
                 }

--- a/android/app/src/test/java/com/noop/ingest/WearableExportImporterTest.kt
+++ b/android/app/src/test/java/com/noop/ingest/WearableExportImporterTest.kt
@@ -30,7 +30,7 @@ class WearableExportImporterTest {
                   "average_hrv": 65 } ],
               "daily_readiness": [
                 { "day": "2026-06-01", "score": 81, "temperature_deviation": -0.2,
-                  "contributors": { "resting_heart_rate": 49 } } ],
+                  "contributors": { "resting_heart_rate": 96 } } ],
               "daily_activity": [
                 { "day": "2026-06-01", "steps": 8421, "active_calories": 520 } ]
             }
@@ -50,13 +50,76 @@ class WearableExportImporterTest {
         assertEquals(1, p.days.size)
         val d = p.days[0]
         assertEquals("2026-06-01", d.day)
-        assertEquals(49, d.restingHr)                   // readiness contributor wins
+        assertEquals(48, d.restingHr)                   // sleep lowest_heart_rate, never the 96 score
         assertEquals(-0.2, d.skinTempDevC!!, 1e-6)
         assertEquals(8421, d.steps)
         assertEquals(520.0, d.activeKcal!!, 1e-6)
         assertEquals(420.0, d.totalSleepMin!!, 1e-6)
         // Oura's OWN readiness score is kept as REFERENCE only — never a NOOP score.
         assertEquals(81, d.readinessScore)
+    }
+
+    @Test
+    fun readinessContributorRhrScoreDoesNotBecomeRestingHr() {
+        // Regression (twin of the Swift OuraExportParserTests): Oura's daily_readiness
+        // `contributors.resting_heart_rate` is a 0-100 readiness contributor SCORE, not bpm. A prior
+        // bug stored it directly as the day's resting HR. With no sleep period in the export,
+        // restingHr must stay null — never the score — while the score itself stays reference-only.
+        val json = """
+            { "daily_readiness": [ { "day": "2026-01-02", "score": 80,
+                "contributors": { "resting_heart_rate": 99 } } ] }
+        """
+        val p = WearableExportImporter.parseOura(mapOf("export.json" to bytes(json)))
+        assertEquals(1, p.days.size)
+        assertNull(p.days[0].restingHr)
+        assertEquals(80, p.days[0].readinessScore)
+    }
+
+    @Test
+    fun flatReadinessRestingHeartRateKeyDoesNotBecomeRestingHr() {
+        // A flat `resting_heart_rate` on the readiness record is the same contributor score in a
+        // flattened shape — it must not land on restingHr either.
+        val json = """
+            { "daily_readiness": [ { "day": "2026-01-02", "score": 80, "resting_heart_rate": 97 } ] }
+        """
+        val p = WearableExportImporter.parseOura(mapOf("export.json" to bytes(json)))
+        assertNull(p.days[0].restingHr)
+        assertEquals(80, p.days[0].readinessScore)
+    }
+
+    @Test
+    fun sleepLowestHeartRateIsTheSoleRestingHrSource() {
+        // Sleep's `lowest_heart_rate` is the sole resting-HR source. The old code let the readiness
+        // loop overwrite the sleep-derived 48 bpm with the contributor score (96 here) whenever both
+        // categories were present.
+        val json = """
+            {
+              "sleep": [
+                { "day": "2026-01-02", "bedtime_start": "2026-01-01T23:00:00+00:00",
+                  "bedtime_end": "2026-01-02T06:30:00+00:00", "total_sleep_duration": 25200,
+                  "lowest_heart_rate": 48 } ],
+              "daily_readiness": [
+                { "day": "2026-01-02", "score": 80,
+                  "contributors": { "resting_heart_rate": 96 } } ]
+            }
+        """
+        val p = WearableExportImporter.parseOura(mapOf("export.json" to bytes(json)))
+        val d = p.days.first { it.day == "2026-01-02" }
+        assertEquals(48, d.restingHr)
+        assertEquals(80, d.readinessScore)
+    }
+
+    @Test
+    fun readinessAliasCategoryDoesNotWriteRestingHr() {
+        // The `readiness` category alias (older API-shaped exports) runs through the same loop and
+        // must obey the same rule.
+        val json = """
+            { "readiness": [ { "day": "2026-01-03", "score": 74,
+                "contributors": { "resting_heart_rate": 100 } } ] }
+        """
+        val p = WearableExportImporter.parseOura(mapOf("export.json" to bytes(json)))
+        assertNull(p.days[0].restingHr)
+        assertEquals(74, p.days[0].readinessScore)
     }
 
     @Test


### PR DESCRIPTION
#365 fixed the readiness score-as-bpm corruption on the Oura **API** lane. The **account-export file** lane ("Account → Export Data" import) has the identical bug on both platforms: `daily_readiness` `contributors.resting_heart_rate` — a 0-100 readiness contributor score, not bpm — is written into the day's resting HR. Because the readiness loop runs after the sleep fold and overwrites unconditionally, the score clobbers the genuine `lowest_heart_rate`-derived value whenever both categories are present, and fabricates an "RHR" (e.g. 96-100) when only readiness is present.

**Swift** (`OuraExportParser.parse`): the two score assignments (nested `contributors.resting_heart_rate`, plus a flattened `resting_heart_rate` on the readiness record) are removed; a sleep period's `lowest_heart_rate` is the sole resting-HR source, exactly as in #365. The readiness `score` itself stays reference-only, unchanged.

**Kotlin** (`WearableExportImporter.parseOura`): the same two assignments removed — the Android file importer had the identical bug. #365 had no Kotlin leg because the API lane is Swift-only; the export importer exists on both platforms, so this PR carries both twins to keep stored data identical (parity contract).

**CSV lane audited, deliberately unchanged**: the CSV cell accessors match normalized headers by exact key on both platforms, so a trends CSV's "Resting Heart Rate Score" (normalizes to `resting_heart_rate_score`) can never match the `resting_heart_rate` alias, and the real per-category `dailyreadiness.csv` (schema verified against a real export, #862) carries contributors as a single JSON-blob `contributors` column with no flat RHR column. The bpm-named columns (`average_`/`lowest_resting_heart_rate`) are genuine bpm. No score can reach `restingHr` via the CSV path.

## Verification

- **Swift**: `swift test --package-path Packages/StrandImport` — 198 tests, 0 failures. New `OuraExportParserTests` pin the regression (contributor score never lands on `restingHr`; flat key never lands; sleep `lowest_heart_rate` survives a readiness overwrite attempt; the `readiness` alias category obeys the same rule). The two existing fixtures that encoded the old behaviour now assert the sleep-derived value.
- **Kotlin**: red/green on Android CI (fork): a tests-only run fails on exactly the five resting-HR assertions ([run](https://github.com/vishk23/noop/actions/runs/29226266650)), the tests+fix run is fully green including `assembleFullDebug` ([run](https://github.com/vishk23/noop/actions/runs/29226286751)).
