### PR TITLE
l10n(de): translate CoupledView strings missing from the catalog (#342 partial)

### DIFF
--- a/Strand/Screens/CoupledView.swift
+++ b/Strand/Screens/CoupledView.swift
@@ -307,10 +307,13 @@ struct CoupledView: View {
                     // Right: the coupled stat stack, OPTIMAL range (with a liquid tube band), calories, workouts.
                     VStack(alignment: .leading, spacing: 14) {
                         optimalStat
-                        heroStat("Calories",
+                        // heroStat renders `Text(title.uppercased())`, so `title` is a plain String and
+                        // a bare literal would NOT localize — pass the resolved localized value (the
+                        // catalog already carries Calories/Workouts) so German shows KALORIEN, not CALORIES.
+                        heroStat(String(localized: "Calories"),
                                  caloriesText,
                                  tint: StrandPalette.metricAmber)
-                        heroStat("Workouts",
+                        heroStat(String(localized: "Workouts"),
                                  (day?.exerciseCount).map { "\($0)" } ?? "0",
                                  tint: StrandPalette.textPrimary)
                     }


### PR DESCRIPTION
Partial fix for #342 (German gaps on iOS) — the first, cleanest slice, plus a map of the rest.

## Root cause (not what it looks like)
The German catalog is **essentially complete** — `Strand/Resources/Localizable.xcstrings` is 3092/3093 `de`-translated. The reported strings render in English because **they aren't in the catalog at all** (verified: "Coupled view", "Overnight HRV", the HRV-explainer phrases → 0 keys each). Two distinct causes:

- **Catalog drift** (most of it): newer `Text("literal")` strings that were never extracted → English fallback. Confirmed by the alarm area being *partially* translated ("Alarms", the long reminder strings are German; newer ones aren't).
- **Localization bypass** (journal questions): `JournalCatalog.starterQuestions` is `[String]` **data** rendered via `Text(variable)`. SwiftUI only auto-localizes string *literals* / `LocalizedStringKey` — a `String` variable is `Text(verbatim:)` and can **never** localize regardless of the catalog. Needs a code change, not a translation.

## What this PR does
Translates the **five CoupledView strings** from the reporter's screenshots — `RECOVERY`, `OPTIMAL`, "No sleep tracked last night", "Wear the strap overnight to score a night first.", and the screen subtitle. All confirmed direct `Text("literal")` (not variable-bypassed), all absent from the catalog. German matched to the established catalog terms (Recovery→Erholung, strap→Strap). It's a clean, bounded slice **and the template** for the full pass.

## What it deliberately does NOT do
1. **Test Centre / alarm section / HRV-overnight explainer** — same catalog-drift class, but enumerating the full missing set needs a **macOS Xcode string-extraction pass** (I can't run it from Linux). That pass + translating the new keys is the bulk of the remaining work.
2. **Journal questions** — the structural bypass above; separate code change (route the built-in starters through `LocalizedStringKey`, leave custom/imported free-text verbatim).
3. **The other 7 languages** — es/fr/it/pt/ru/zh still fall back to English on these keys until the full re-extract + translation.

## Caveats for the reviewer
- **Not runtime-verified** — no Xcode on my side; the `.xcstrings` re-parses cleanly (+5 keys, 3093→3098) and each key matches its exact source literal, but a build should confirm they render.
- **German wants a native-speaker check** before release — happy to adjust any phrasing.

Full A/B breakdown is on the issue (#342).


---
**Re-review addition (commit 2):** the catalog-only change didn't actually make CoupledView fully German — the stat-stack labels render via `heroStat(_ title: String) → Text(title.uppercased())`, so "Calories"/"Workouts" were shown **verbatim** (bypassing the catalog, which already has `Kalorien`). Fixed by passing `String(localized:)` at the two call sites. Audited the rest: the readiness pill word is already localized and `SectionHeader` takes `LocalizedStringKey`, so `heroStat` was the only bypass. This makes it a mixed catalog+code PR — still one concern (CoupledView German). App-target Swift compile validated via app-build.


---
**Re-review (3rd pass) — scope correction.** An *exhaustive* enumeration of every string in `CoupledView` shows this PR does **not** make even that one screen fully German. Beyond the 5 fixed literals, still missing from the catalog:
- `"Coupled read"` (a section overline)
- `"%@ slept"` / `"%@ needed"` (the interpolated sleep-duration lines)
- `"Today, %@"` (the scaffold subtitle)
- plus interpolated `.accessibilityLabel` strings

The **interpolated** ones can't be safely hand-keyed — SwiftUI generates the exact key (`%@` vs `%lld`, ordering) at *extraction* time, so guessing them risks dead entries. This is the concrete proof that the real fix for #342 is the **macOS Xcode string-extraction pass**, not incremental hand-additions: three review passes each surfaced more, and a single screen already exceeds what's safe to enumerate by hand.

**What this PR should be taken as:** (1) the `heroStat` **bypass fix** — a genuine code-level bug (verbatim `Text(title.uppercased())`) that *no* catalog work could fix, worth landing on its own; and (2) a representative **sample** of the drift translations + the template for the systematic pass. It is explicitly *not* "CoupledView is done." Recommend treating the heroStat fix as the keeper and folding the catalog additions into the eventual full re-extract.
