### PR TITLE
fix(import): store Oura efficiency as a 0-1 fraction, matching the native column

### DIFF
--- a/Packages/StrandImport/Sources/StrandImport/OuraApiParser.swift
+++ b/Packages/StrandImport/Sources/StrandImport/OuraApiParser.swift
@@ -40,7 +40,13 @@ public enum OuraApiParser {
                 remMin: minutes("rem_sleep_duration"),
                 awakeMin: minutes("awake_time"),
                 totalSleepMin: minutes("total_sleep_duration"),
-                efficiencyPct: WearableJSON.posDbl(s, "efficiency"),
+                // Oura's `efficiency` is a 0-100 integer percent. NOOP's own sleep pipeline
+                // (StrandAnalytics) stores `efficiency` as a 0-1 FRACTION everywhere it's computed
+                // (asleep ÷ in-bed — see AnalyticsEngine.swift / SleepStageTotals.swift) and both
+                // sleepSession.efficiency and dailyMetric.efficiency are that same shared column, so
+                // normalize to the fraction convention here, at the parse boundary, rather than
+                // writing Oura's native percent straight through.
+                efficiencyPct: WearableJSON.posDbl(s, "efficiency").map { $0 / 100.0 },
                 avgHr: WearableJSON.posInt(s, "average_heart_rate"),
                 lowestHr: WearableJSON.posInt(s, "lowest_heart_rate"),
                 avgHrvMs: WearableJSON.posDbl(s, "average_hrv"),

--- a/Packages/StrandImport/Sources/StrandImport/WhoopCsvExporter.swift
+++ b/Packages/StrandImport/Sources/StrandImport/WhoopCsvExporter.swift
@@ -160,7 +160,9 @@ public enum WhoopCsvExporter {
                 // disturbance COUNT exported a wrong unit that round-tripped on reimport — PR #97
                 // review, tigercraft4.)
                 num(s["awake_min"]),
-                num(d.efficiency), num(s["sleep_consistency"]), num(s["sleep_need_min"]),
+                // "Sleep efficiency %" is WHOOP's 0–100 column → convert the stored 0–1 fraction up,
+                // mirroring the Day Strain conversion above (importer scales it back down).
+                num(WhoopExportImporter.whoopEfficiencyPctFromFraction(d.efficiency)), num(s["sleep_consistency"]), num(s["sleep_need_min"]),
                 num(s["sleep_debt_min"]),
                 field(sourceByDay[d.day]),
             ]
@@ -195,7 +197,7 @@ public enum WhoopCsvExporter {
                 "false", "", "",
                 num(stages.asleep), num(inBedMin),
                 num(stages.light), num(stages.deep), num(stages.rem), num(stages.awake),
-                num(s.efficiency), "", "", "",
+                num(WhoopExportImporter.whoopEfficiencyPctFromFraction(s.efficiency)), "", "", "",
                 field(sourceBySession(s)),
             ]
             out += cols.joined(separator: ",") + "\r\n"

--- a/Packages/StrandImport/Sources/StrandImport/WhoopExportImporter.swift
+++ b/Packages/StrandImport/Sources/StrandImport/WhoopExportImporter.swift
@@ -46,6 +46,26 @@ public struct WhoopExportImporter {
         return effort / dayStrainToEffortScale
     }
 
+    /// WHOOP CSVs carry "Sleep efficiency %" on a 0–100 scale; NOOP's `efficiency` columns store the
+    /// 0–1 fraction the native pipeline writes (`AnalyticsEngine`: actual-sleep ÷ in-bed). Convert at
+    /// the WRITE boundary (WhoopImporter → store), NOT at parse time, so the verbatim parsed value
+    /// (`sleepEfficiencyPct`) and the CSV round-trip contract are preserved — the same shape as the
+    /// Day Strain ⇄ Effort pair above. Keep byte-identical to the Android importer (WhoopCsvImporter.kt).
+    public static func fractionFromImportedEfficiencyPct(_ pct: Double?) -> Double? {
+        guard let pct else { return nil }
+        return pct / 100.0
+    }
+
+    /// Inverse: the stored 0–1 fraction back onto the CSV's 0–100 "Sleep efficiency %" column, so an
+    /// exported CSV is WHOOP-compatible and a NOOP export → NOOP import round-trip is lossless to
+    /// 4 decimal places of a percent (1e-6 of the fraction). The rounding matters: `num()` prints
+    /// shortest-round-trip Doubles, and a raw `fraction * 100` carries FP dust (0.923 × 100 =
+    /// 92.30000000000001) straight into the CSV cell.
+    public static func whoopEfficiencyPctFromFraction(_ fraction: Double?) -> Double? {
+        guard let fraction else { return nil }
+        return (fraction * 100.0 * 10_000).rounded() / 10_000
+    }
+
     // Recognised CSV filenames (lowercased).
     private static let cyclesName  = "physiological_cycles.csv"
     private static let sleepsName  = "sleeps.csv"

--- a/Packages/StrandImport/Tests/StrandImportTests/OuraApiParserSleepTests.swift
+++ b/Packages/StrandImport/Tests/StrandImportTests/OuraApiParserSleepTests.swift
@@ -71,4 +71,22 @@ final class OuraApiParserSleepTests: XCTestCase {
         let hugeItemPeriod = try XCTUnwrap(hugeItemPeriods.first)
         XCTAssertEqual(hugeItemPeriod.hr.map(\.bpm), [60, 58])
     }
+
+    /// Oura's `efficiency` is a 0-100 integer percent. NOOP's own sleep pipeline stores
+    /// sleepSession.efficiency / dailyMetric.efficiency as a 0-1 FRACTION everywhere else it's
+    /// written (StrandAnalytics: asleep ÷ in-bed), so the importer must normalize at the parse
+    /// boundary rather than passing Oura's native percent straight through — both the individual
+    /// session and the day rollup it folds onto.
+    func testEfficiencyIsNormalizedToZeroToOneFraction() throws {
+        let docs: [[String: Any]] = [[
+            "day": "2026-03-01",
+            "bedtime_start": "2026-02-28T23:00:00+00:00",
+            "bedtime_end": "2026-03-01T07:00:00+00:00",
+            "total_sleep_duration": 27_000, "efficiency": 92,
+        ]]
+        let (periods, days) = OuraApiParser.parseSleep(docs)
+        let p = try XCTUnwrap(periods.first)
+        XCTAssertEqual(p.session.efficiencyPct, 0.92)
+        XCTAssertEqual(days.first?.efficiencyPct, 0.92)
+    }
 }

--- a/Packages/StrandImport/Tests/StrandImportTests/WhoopCsvExporterTests.swift
+++ b/Packages/StrandImport/Tests/StrandImportTests/WhoopCsvExporterTests.swift
@@ -9,7 +9,8 @@ import WhoopStore
 final class WhoopCsvExporterTests: XCTestCase {
 
     func testCyclesRoundTripThroughRealImporter() throws {
-        let day = DailyMetric(day: "2026-06-01", totalSleepMin: 420, efficiency: 92.3, deepMin: 95,
+        // efficiency is stored as the native 0-1 fraction; the exporter lifts it onto the CSV's % scale.
+        let day = DailyMetric(day: "2026-06-01", totalSleepMin: 420, efficiency: 0.923, deepMin: 95,
                               remMin: 115, lightMin: 210, disturbances: nil, restingHr: 52,
                               avgHrv: 68.4, recovery: 72, strain: 12.5, exerciseCount: nil,
                               spo2Pct: 96.0, skinTempDevC: 33.1, respRateBpm: 14.2)
@@ -74,10 +75,10 @@ final class WhoopCsvExporterTests: XCTestCase {
     func testSleepsRoundTripAllStageShapes() {
         // macOS-import minutes dict, Android [{stage,min}], and the stager's segment array.
         let dictNight = CachedSleepSession(startTs: 1_750_000_000, endTs: 1_750_027_300,
-                                           efficiency: 92.3, restingHr: nil, avgHrv: nil,
+                                           efficiency: 0.923, restingHr: nil, avgHrv: nil,
                                            stagesJSON: #"{"light":210,"deep":95,"rem":115,"awake":35}"#)
         let arrayNight = CachedSleepSession(startTs: 1_760_000_000, endTs: 1_760_025_500,
-                                            efficiency: 90, restingHr: nil, avgHrv: nil,
+                                            efficiency: 0.9, restingHr: nil, avgHrv: nil,
                                             stagesJSON: #"[{"stage":"light","min":200.0},{"stage":"deep","min":80.0}]"#)
         let segNight = CachedSleepSession(startTs: 2_000_000_000, endTs: 2_000_007_200,
                                           efficiency: nil, restingHr: nil, avgHrv: nil,
@@ -118,6 +119,17 @@ final class WhoopCsvExporterTests: XCTestCase {
         XCTAssertEqual(back[1].notes, "one, big \"mug\"")
     }
 
+    func testEfficiencyPctFractionPairIsLosslessAndNilSafe() {
+        // Store fraction → CSV % → store fraction round-trips exactly; nil passes through both ways.
+        XCTAssertEqual(WhoopExportImporter.whoopEfficiencyPctFromFraction(0.923) ?? -1, 92.3, accuracy: 1e-9)
+        XCTAssertEqual(WhoopExportImporter.fractionFromImportedEfficiencyPct(92.3) ?? -1, 0.923, accuracy: 1e-9)
+        let roundTripped = WhoopExportImporter.fractionFromImportedEfficiencyPct(
+            WhoopExportImporter.whoopEfficiencyPctFromFraction(0.6569))
+        XCTAssertEqual(roundTripped ?? -1, 0.6569, accuracy: 1e-9)
+        XCTAssertNil(WhoopExportImporter.whoopEfficiencyPctFromFraction(nil))
+        XCTAssertNil(WhoopExportImporter.fractionFromImportedEfficiencyPct(nil))
+    }
+
     func testNumbersAreLocaleProof() {
         XCTAssertEqual(WhoopCsvExporter.num(72.0), "72")
         XCTAssertEqual(WhoopCsvExporter.num(68.4), "68.4")
@@ -132,7 +144,7 @@ final class WhoopCsvExporterTests: XCTestCase {
         defer { try? FileManager.default.removeItem(at: dir) }
         let zipURL = dir.appendingPathComponent("noop-export.zip")
 
-        let day = DailyMetric(day: "2026-06-01", totalSleepMin: 420, efficiency: 92.3, deepMin: 95,
+        let day = DailyMetric(day: "2026-06-01", totalSleepMin: 420, efficiency: 0.923, deepMin: 95,
                               remMin: 115, lightMin: 210, disturbances: 35, restingHr: 52,
                               avgHrv: 68.4, recovery: 72, strain: 12.5, exerciseCount: nil,
                               spo2Pct: 96.0, skinTempDevC: 33.1, respRateBpm: 14.2)

--- a/Packages/WhoopStore/Sources/WhoopStore/Database.swift
+++ b/Packages/WhoopStore/Sources/WhoopStore/Database.swift
@@ -500,6 +500,29 @@ extension WhoopStore {
             try db.create(index: "idx_ouraRaw_device_endpoint_day",
                           on: "ouraRaw", columns: ["deviceId", "endpoint", "day"])
         }
+
+        // v26 (Oura efficiency unit heal): the Oura API importer (OuraApiParser.swift) wrote Oura's
+        // native 0-100 integer `efficiency` straight into sleepSession.efficiency / dailyMetric.efficiency,
+        // but NOOP's own sleep pipeline (StrandAnalytics) stores that shared column as a 0-1 FRACTION
+        // everywhere it computes it (asleep ÷ in-bed) — same column, two scales for oura-api rows written
+        // before the importer fix. UPDATE-only, NO schema change: divides `efficiency` by 100 for every
+        // `deviceId = 'oura-api'` row where it's > 1.5 — a threshold no genuine fraction can exceed (max
+        // 1.0) and no genuine Oura percent can fall under (Oura's lowest real efficiency is well above
+        // 1.5%), so the predicate can't touch an already-correct row. Idempotent: a second run finds
+        // nothing left above the threshold. Scoped to deviceId so WHOOP-native and other-brand rows are
+        // never touched. No Android migration twin: this only heals data written by the Swift-only,
+        // OURA_CLOUD_IMPORT-gated cloud importer — android/ has no equivalent Oura REST/API import path
+        // (its `com.noop.oura` package is the BLE ring driver, unrelated).
+        migrator.registerMigration("v26-oura-efficiency-heal") { db in
+            try db.execute(sql: """
+                UPDATE sleepSession SET efficiency = efficiency / 100.0
+                WHERE deviceId = 'oura-api' AND efficiency > 1.5
+                """)
+            try db.execute(sql: """
+                UPDATE dailyMetric SET efficiency = efficiency / 100.0
+                WHERE deviceId = 'oura-api' AND efficiency > 1.5
+                """)
+        }
         return migrator
     }
 }

--- a/Packages/WhoopStore/Sources/WhoopStore/Database.swift
+++ b/Packages/WhoopStore/Sources/WhoopStore/Database.swift
@@ -506,21 +506,23 @@ extension WhoopStore {
         // but NOOP's own sleep pipeline (StrandAnalytics) stores that shared column as a 0-1 FRACTION
         // everywhere it computes it (asleep ÷ in-bed) — same column, two scales for oura-api rows written
         // before the importer fix. UPDATE-only, NO schema change: divides `efficiency` by 100 for every
-        // `deviceId = 'oura-api'` row where it's > 1.5 — a threshold no genuine fraction can exceed (max
-        // 1.0) and no genuine Oura percent can fall under (Oura's lowest real efficiency is well above
-        // 1.5%), so the predicate can't touch an already-correct row. Idempotent: a second run finds
-        // nothing left above the threshold. Scoped to deviceId so WHOOP-native and other-brand rows are
-        // never touched. No Android migration twin: this only heals data written by the Swift-only,
-        // OURA_CLOUD_IMPORT-gated cloud importer — android/ has no equivalent Oura REST/API import path
-        // (its `com.noop.oura` package is the BLE ring driver, unrelated).
-        migrator.registerMigration("v26-oura-efficiency-heal") { db in
+        // row where it's > 1.5 — a threshold no genuine fraction can exceed (the column's convention
+        // caps at 1.0: `AnalyticsEngine` writes actual-sleep ÷ in-bed) and no genuine percent-scale
+        // leftover can fall under (no real night is ≤1.5% efficient), so the predicate can't touch an
+        // already-correct row and a second run finds nothing left: idempotent. Deliberately NOT
+        // deviceId-scoped: both known percent writers are healed by the same predicate — the Oura API
+        // importer ('oura-api' rows) and the WHOOP CSV importer (rows under whatever strap deviceId the
+        // user imported into). No Android Room migration twin in this PR: the Kotlin CSV importer gets
+        // the same write-boundary fix, but healing Android's historical rows needs a Room migration a
+        // maintainer should own (schema-version bump + column-order pinning).
+        migrator.registerMigration("v26-efficiency-heal") { db in
             try db.execute(sql: """
                 UPDATE sleepSession SET efficiency = efficiency / 100.0
-                WHERE deviceId = 'oura-api' AND efficiency > 1.5
+                WHERE efficiency > 1.5
                 """)
             try db.execute(sql: """
                 UPDATE dailyMetric SET efficiency = efficiency / 100.0
-                WHERE deviceId = 'oura-api' AND efficiency > 1.5
+                WHERE efficiency > 1.5
                 """)
         }
         return migrator

--- a/Packages/WhoopStore/Tests/WhoopStoreTests/MigrationTests.swift
+++ b/Packages/WhoopStore/Tests/WhoopStoreTests/MigrationTests.swift
@@ -97,10 +97,11 @@ final class MigrationTests: XCTestCase {
         XCTAssertTrue(cols.contains("peripheralId"), "pairedDevice missing v16 peripheralId column")
     }
 
-    /// v26 heals `deviceId = 'oura-api'` rows written with Oura's native 0-100 `efficiency` (before the
-    /// OuraApiParser fix) back to NOOP's 0-1 fraction convention. UPDATE-only: seed rows at the v25
-    /// schema (i.e. BEFORE v26 has run), then apply the rest of the migrator and confirm the heal.
-    func testV26HealsOuraEfficiencyPercentToFraction() async throws {
+    /// v26 heals `efficiency` values stored on the 0-100 percent scale (written by the pre-fix Oura API
+    /// importer AND the pre-fix WHOOP CSV importer, under any deviceId) back to NOOP's 0-1 fraction
+    /// convention. UPDATE-only: seed rows at the v25 schema (i.e. BEFORE v26 has run), then apply the
+    /// rest of the migrator and confirm the heal.
+    func testV26HealsEfficiencyPercentToFraction() async throws {
         let dbQueue = try DatabaseQueue()
         try WhoopStore.makeMigrator().migrate(dbQueue, upTo: "v25-oura-raw")
         try await dbQueue.write { db in
@@ -118,9 +119,14 @@ final class MigrationTests: XCTestCase {
             try db.execute(sql: """
                 INSERT INTO dailyMetric (deviceId, day, efficiency) VALUES ('oura-api', '2026-01-02', 0.9)
                 """)
-            // A non-Oura row above the threshold must be left alone — the heal is deviceId-scoped.
+            // A WHOOP-CSV-imported percent row (arbitrary strap deviceId) must ALSO be healed — the
+            // pre-fix WhoopImporter wrote "Sleep efficiency %" straight through, same bug class.
             try db.execute(sql: """
                 INSERT INTO sleepSession (deviceId, startTs, endTs, efficiency) VALUES ('my-whoop', 500, 600, 90)
+                """)
+            // A native fraction row under a strap deviceId must be left unchanged.
+            try db.execute(sql: """
+                INSERT INTO sleepSession (deviceId, startTs, endTs, efficiency) VALUES ('my-whoop', 700, 800, 0.66)
                 """)
         }
 
@@ -130,8 +136,10 @@ final class MigrationTests: XCTestCase {
         try await dbQueue.read { db in
             XCTAssertEqual(try Double.fetchOne(db, sql: "SELECT efficiency FROM sleepSession WHERE startTs = 100"), 0.9)
             XCTAssertEqual(try Double.fetchOne(db, sql: "SELECT efficiency FROM sleepSession WHERE startTs = 300"), 0.9)
-            XCTAssertEqual(try Double.fetchOne(db, sql: "SELECT efficiency FROM sleepSession WHERE startTs = 500"), 90,
-                           "a non-oura-api row must not be touched by the deviceId-scoped heal")
+            XCTAssertEqual(try Double.fetchOne(db, sql: "SELECT efficiency FROM sleepSession WHERE startTs = 500"), 0.9,
+                           "a CSV-imported percent row must be healed regardless of deviceId")
+            XCTAssertEqual(try Double.fetchOne(db, sql: "SELECT efficiency FROM sleepSession WHERE startTs = 700"), 0.66,
+                           "a native fraction row must never be touched")
             XCTAssertEqual(try Double.fetchOne(db, sql: "SELECT efficiency FROM dailyMetric WHERE day = '2026-01-01'"), 0.9)
             XCTAssertEqual(try Double.fetchOne(db, sql: "SELECT efficiency FROM dailyMetric WHERE day = '2026-01-02'"), 0.9)
         }

--- a/Packages/WhoopStore/Tests/WhoopStoreTests/MigrationTests.swift
+++ b/Packages/WhoopStore/Tests/WhoopStoreTests/MigrationTests.swift
@@ -96,4 +96,44 @@ final class MigrationTests: XCTestCase {
         let cols = try await store.columnNamesForTest(table: "pairedDevice")
         XCTAssertTrue(cols.contains("peripheralId"), "pairedDevice missing v16 peripheralId column")
     }
+
+    /// v26 heals `deviceId = 'oura-api'` rows written with Oura's native 0-100 `efficiency` (before the
+    /// OuraApiParser fix) back to NOOP's 0-1 fraction convention. UPDATE-only: seed rows at the v25
+    /// schema (i.e. BEFORE v26 has run), then apply the rest of the migrator and confirm the heal.
+    func testV26HealsOuraEfficiencyPercentToFraction() async throws {
+        let dbQueue = try DatabaseQueue()
+        try WhoopStore.makeMigrator().migrate(dbQueue, upTo: "v25-oura-raw")
+        try await dbQueue.write { db in
+            // oura-api, bad (percent) → must be healed to a fraction.
+            try db.execute(sql: """
+                INSERT INTO sleepSession (deviceId, startTs, endTs, efficiency) VALUES ('oura-api', 100, 200, 90)
+                """)
+            try db.execute(sql: """
+                INSERT INTO dailyMetric (deviceId, day, efficiency) VALUES ('oura-api', '2026-01-01', 90)
+                """)
+            // oura-api, already a fraction → must be left unchanged (idempotent predicate: efficiency > 1.5).
+            try db.execute(sql: """
+                INSERT INTO sleepSession (deviceId, startTs, endTs, efficiency) VALUES ('oura-api', 300, 400, 0.9)
+                """)
+            try db.execute(sql: """
+                INSERT INTO dailyMetric (deviceId, day, efficiency) VALUES ('oura-api', '2026-01-02', 0.9)
+                """)
+            // A non-Oura row above the threshold must be left alone — the heal is deviceId-scoped.
+            try db.execute(sql: """
+                INSERT INTO sleepSession (deviceId, startTs, endTs, efficiency) VALUES ('my-whoop', 500, 600, 90)
+                """)
+        }
+
+        // Apply the FULL migrator: GRDB resumes from the already-applied v25, so only v26 runs here.
+        try WhoopStore.makeMigrator().migrate(dbQueue)
+
+        try await dbQueue.read { db in
+            XCTAssertEqual(try Double.fetchOne(db, sql: "SELECT efficiency FROM sleepSession WHERE startTs = 100"), 0.9)
+            XCTAssertEqual(try Double.fetchOne(db, sql: "SELECT efficiency FROM sleepSession WHERE startTs = 300"), 0.9)
+            XCTAssertEqual(try Double.fetchOne(db, sql: "SELECT efficiency FROM sleepSession WHERE startTs = 500"), 90,
+                           "a non-oura-api row must not be touched by the deviceId-scoped heal")
+            XCTAssertEqual(try Double.fetchOne(db, sql: "SELECT efficiency FROM dailyMetric WHERE day = '2026-01-01'"), 0.9)
+            XCTAssertEqual(try Double.fetchOne(db, sql: "SELECT efficiency FROM dailyMetric WHERE day = '2026-01-02'"), 0.9)
+        }
+    }
 }

--- a/Strand/Data/WhoopImporter.swift
+++ b/Strand/Data/WhoopImporter.swift
@@ -23,7 +23,8 @@ enum WhoopImporter {
             metrics.append(DailyMetric(
                 day: day,
                 totalSleepMin: c.asleepDurationMin,
-                efficiency: c.sleepEfficiencyPct,
+                // CSV "Sleep efficiency %" (0–100) → the store's native 0–1 fraction at the boundary.
+                efficiency: WhoopExportImporter.fractionFromImportedEfficiencyPct(c.sleepEfficiencyPct),
                 deepMin: c.deepSleepDurationMin,
                 remMin: c.remDurationMin,
                 lightMin: c.lightSleepDurationMin,
@@ -54,7 +55,7 @@ enum WhoopImporter {
             sessions.append(CachedSleepSession(
                 startTs: Int(onset.timeIntervalSince1970),
                 endTs: Int(wake.timeIntervalSince1970),
-                efficiency: s.sleepEfficiencyPct,
+                efficiency: WhoopExportImporter.fractionFromImportedEfficiencyPct(s.sleepEfficiencyPct),
                 restingHr: nil, avgHrv: nil, stagesJSON: json))
         }
 

--- a/android/app/src/main/java/com/noop/data/WhoopDatabase.kt
+++ b/android/app/src/main/java/com/noop/data/WhoopDatabase.kt
@@ -48,7 +48,7 @@ import androidx.sqlite.db.SupportSQLiteDatabase
         LabMarkerRow::class,
         LiveSessionRow::class,
     ],
-    version = 18,
+    version = 19,
     exportSchema = false,
 )
 abstract class WhoopDatabase : RoomDatabase() {
@@ -480,6 +480,46 @@ abstract class WhoopDatabase : RoomDatabase() {
             }
         }
 
+        /**
+         * v18 -> v19: Oura/WHOOP efficiency-unit HEAL, the Room twin of the Swift WhoopStore v26
+         * `v26-efficiency-heal` GRDB migration (#376). UPDATE-only, NO schema change: the Oura API
+         * importer and (pre-fix) the WHOOP CSV importer wrote a 0-100 integer efficiency straight into
+         * `sleepSession.efficiency` / `dailyMetric.efficiency`, but NOOP's own sleep pipeline stores that
+         * shared column as a 0-1 FRACTION everywhere it computes it (asleep ÷ in-bed) — same column, two
+         * scales for rows written before the importer fix. Divides `efficiency` by 100 for every row
+         * where it's > 1.5 — a threshold no genuine fraction can exceed (the column's convention caps at
+         * 1.0) and no genuine percent-scale leftover can fall under (no real night is ≤1.5% efficient),
+         * so the predicate can't touch an already-correct row and a second run finds nothing left:
+         * idempotent. Deliberately NOT deviceId-scoped, matching the Swift heal: both known percent
+         * writers (the Oura API importer's 'oura-api' rows and the WHOOP CSV importer's rows under
+         * whatever strap deviceId the user imported into) are healed by the same predicate.
+         *
+         * This is REQUIRED, not optional (flagged in review): the Android CSV exporter does
+         * `efficiency * 100` at write time, so an unhealed percent row (92) would export as 9200; and
+         * without this heal, an iOS user and an Android user who imported the SAME WHOOP CSV would have
+         * permanently different stored efficiency (iOS 0.92 after v26, Android 92 unhealed) — the
+         * cross-platform parity contract (stored data must be byte-identical) needs the heal on both
+         * platforms, not just the write-boundary fix.
+         *
+         * SEQUENCING CAVEAT: this claims Room version 18 -> 19 as the next free slot as of this PR. The
+         * Swift v26 GRDB slot has the identical collision risk against other pending PRs (flagged in the
+         * same review) — if another pending PR also lands a Room migration first, whichever merges
+         * SECOND must renumber. Coordinate before merging both.
+         *
+         * The SQL is exposed as [EFFICIENCY_HEAL_MIGRATION_SQL] so a plain-JVM unit test
+         * ([com.noop.data.EfficiencyHealMigrationTest]) can pin this shape without Robolectric.
+         */
+        internal val EFFICIENCY_HEAL_MIGRATION_SQL: List<String> = listOf(
+            "UPDATE `sleepSession` SET `efficiency` = `efficiency` / 100.0 WHERE `efficiency` > 1.5",
+            "UPDATE `dailyMetric` SET `efficiency` = `efficiency` / 100.0 WHERE `efficiency` > 1.5",
+        )
+
+        internal val MIGRATION_18_19 = object : Migration(18, 19) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                for (stmt in EFFICIENCY_HEAL_MIGRATION_SQL) db.execSQL(stmt)
+            }
+        }
+
         private fun build(appContext: Context): WhoopDatabase =
             Room.databaseBuilder(appContext, WhoopDatabase::class.java, DB_NAME)
                 // #1014: replace ONLY the corruption handling of the default open-helper. The
@@ -495,6 +535,7 @@ abstract class WhoopDatabase : RoomDatabase() {
                     MIGRATION_5_6, MIGRATION_6_7, MIGRATION_7_8, MIGRATION_8_9, MIGRATION_9_10,
                     MIGRATION_10_11, MIGRATION_11_12, MIGRATION_12_13, MIGRATION_13_14,
                     MIGRATION_14_15, MIGRATION_15_16, MIGRATION_16_17, MIGRATION_17_18,
+                    MIGRATION_18_19,
                 )
                 // #1037: a FRESH install builds the schema straight at the current version and runs NO
                 // migrations, so the MIGRATION_7_8 "my-whoop" registry seed never fires and the WHOOP,

--- a/android/app/src/main/java/com/noop/ingest/WhoopCsvExporter.kt
+++ b/android/app/src/main/java/com/noop/ingest/WhoopCsvExporter.kt
@@ -17,6 +17,7 @@ import java.util.zip.ZipEntry
 import java.util.zip.ZipOutputStream
 import kotlin.math.abs
 import kotlin.math.floor
+import kotlin.math.round
 
 /**
  * Serializes NOOP's own cached rows back into WHOOP's 4-CSV export shape so NOOP's OWN importer
@@ -188,7 +189,12 @@ object WhoopCsvExporter {
                     // the cell empty. (Writing the disturbance COUNT here exported a wrong unit
                     // that round-tripped on reimport — PR #97 review, tigercraft4. Swift parity.)
                     "",
-                    num(d.efficiency), num(s["sleep_consistency"]), num(s["sleep_need_min"]),
+                    // "Sleep efficiency %" is WHOOP's 0–100 column → lift the stored 0–1 fraction,
+                    // rounded to 4 decimals of a percent so num()'s shortest-round-trip Double
+                    // printing can't leak FP dust into the cell. Keep byte-identical to Swift
+                    // (WhoopExportImporter.whoopEfficiencyPctFromFraction).
+                    num(d.efficiency?.let { round(it * 100.0 * 10_000) / 10_000 }),
+                    num(s["sleep_consistency"]), num(s["sleep_need_min"]),
                     num(s["sleep_debt_min"]), csvField(sourceByDay[d.day]),
                 ).joinToString(","),
             ).append("\r\n")
@@ -228,7 +234,8 @@ object WhoopCsvExporter {
                     "false", "", "",
                     num(stages.asleep), num(inBedMin),
                     num(stages.light), num(stages.deep), num(stages.rem), num(stages.awake),
-                    num(s.efficiency), "", "", "", csvField(sourceBySession(s)),
+                    num(s.efficiency?.let { round(it * 100.0 * 10_000) / 10_000 }), "", "", "",
+                    csvField(sourceBySession(s)),
                 ).joinToString(","),
             ).append("\r\n")
         }

--- a/android/app/src/main/java/com/noop/ingest/WhoopCsvImporter.kt
+++ b/android/app/src/main/java/com/noop/ingest/WhoopCsvImporter.kt
@@ -68,6 +68,14 @@ object WhoopCsvImporter {
      */
     private const val DAY_STRAIN_TO_EFFORT_SCALE = 100.0 / 21.0
 
+    /**
+     * WHOOP CSVs carry "Sleep efficiency %" on a 0–100 scale, but NOOP's `efficiency` columns store
+     * the 0–1 fraction the native pipeline writes (AnalyticsEngine: actual-sleep ÷ in-bed). Divide at
+     * the WRITE boundary — the verbatim parsed value stays untouched, same shape as the Day Strain
+     * rescale above. Keep byte-identical to Swift (WhoopExportImporter.fractionFromImportedEfficiencyPct).
+     */
+    private fun efficiencyFractionFromPct(pct: Double?): Double? = pct?.let { it / 100.0 }
+
     private val DAY_FMT: DateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd")
 
     /**
@@ -353,7 +361,7 @@ object WhoopCsvImporter {
                     deviceId = deviceId,
                     day = day,
                     totalSleepMin = asleepMin,
-                    efficiency = efficiency,
+                    efficiency = efficiencyFractionFromPct(efficiency),
                     deepMin = deepMin,
                     remMin = remMin,
                     lightMin = lightMin,
@@ -443,7 +451,7 @@ object WhoopCsvImporter {
                         deviceId = deviceId,
                         startTs = startTs,
                         endTs = if (endTs >= startTs) endTs else startTs,
-                        efficiency = efficiency,
+                        efficiency = efficiencyFractionFromPct(efficiency),
                         restingHr = null, // resting HR is a cycles/recovery field, not in sleeps.csv
                         avgHrv = null,    // HRV likewise is a recovery field, not in sleeps.csv
                         stagesJSON = stagesJson(lightMin, deepMin, remMin, awakeMin),
@@ -467,7 +475,7 @@ object WhoopCsvImporter {
                             deviceId = deviceId,
                             day = epochSecondsToDay(dayTs, tz),
                             totalSleepMin = asleepMin,
-                            efficiency = efficiency,
+                            efficiency = efficiencyFractionFromPct(efficiency),
                             deepMin = deepMin,
                             remMin = remMin,
                             lightMin = lightMin,

--- a/android/app/src/test/java/com/noop/data/EfficiencyHealMigrationTest.kt
+++ b/android/app/src/test/java/com/noop/data/EfficiencyHealMigrationTest.kt
@@ -1,0 +1,73 @@
+package com.noop.data
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Guards the v18 -> v19 Room migration (#376): the Oura/WHOOP efficiency-unit HEAL, the byte-parity twin
+ * of the Swift WhoopStore `v26-efficiency-heal` GRDB migration. UPDATE-only, NO schema change — divides
+ * `sleepSession.efficiency` / `dailyMetric.efficiency` by 100 for every row where it's > 1.5 (a
+ * percent-scale leftover from before the importer write-boundary fix), the threshold no genuine 0-1
+ * fraction can exceed and no genuine percent can fall under, so the predicate is idempotent.
+ *
+ * This environment has no Robolectric / Room-testing / JDBC-SQLite (see the other migration tests in this
+ * package), so the migration SQL is pinned as a string, the same convention as every other Room migration
+ * test here. Unlike the additive migrations elsewhere in this suite (which assert the SQL is ONLY
+ * ALTER/CREATE, never UPDATE/DELETE/INSERT), this migration is intentionally UPDATE-only with no schema
+ * mutation, so the polarity of the "what's allowed" check is inverted here on purpose.
+ */
+class EfficiencyHealMigrationTest {
+
+    @Test
+    fun migration_versionPair_is18to19() {
+        assertEquals(18, WhoopDatabase.MIGRATION_18_19.startVersion)
+        assertEquals(19, WhoopDatabase.MIGRATION_18_19.endVersion)
+    }
+
+    @Test
+    fun migration_healsBothTables_exactSql() {
+        assertEquals(
+            listOf(
+                "UPDATE `sleepSession` SET `efficiency` = `efficiency` / 100.0 WHERE `efficiency` > 1.5",
+                "UPDATE `dailyMetric` SET `efficiency` = `efficiency` / 100.0 WHERE `efficiency` > 1.5",
+            ),
+            WhoopDatabase.EFFICIENCY_HEAL_MIGRATION_SQL,
+        )
+    }
+
+    @Test
+    fun migration_isUpdateOnly_noSchemaMutation() {
+        // Opposite of the additive migrations' guard: this one must be ONLY an UPDATE (no ALTER/CREATE/
+        // DROP/INSERT/DELETE — no schema change, no row added or removed, just an in-place value rescale).
+        val sql = WhoopDatabase.EFFICIENCY_HEAL_MIGRATION_SQL
+        assertEquals("one UPDATE per healed table", 2, sql.size)
+        for (s in sql) {
+            val up = s.trimStart().uppercase()
+            assertTrue("must be an UPDATE, got: $s", up.startsWith("UPDATE"))
+            for (banned in listOf("ALTER ", "CREATE ", "DROP ", "INSERT ", "DELETE ", "RENAME ")) {
+                assertTrue("heal migration must not contain '$banned': $s", !up.contains(banned))
+            }
+        }
+    }
+
+    @Test
+    fun migration_targetsOnlySleepSessionAndDailyMetric() {
+        val tables = WhoopDatabase.EFFICIENCY_HEAL_MIGRATION_SQL.map { sql ->
+            sql.substringAfter("UPDATE `").substringBefore("`")
+        }
+        assertEquals(listOf("sleepSession", "dailyMetric"), tables)
+    }
+
+    @Test
+    fun migration_thresholdAndDivisorMatchTheSwiftHeal() {
+        // Same predicate as WhoopStore's v26-efficiency-heal (Database.swift): `> 1.5` / `/ 100.0`, not
+        // deviceId-scoped, so both the Oura API importer's and the WHOOP CSV importer's percent-scale rows
+        // are healed by the same UPDATE regardless of which strap/brand deviceId they were imported under.
+        for (s in WhoopDatabase.EFFICIENCY_HEAL_MIGRATION_SQL) {
+            assertTrue("must divide by exactly 100.0: $s", s.contains("/ 100.0"))
+            assertTrue("must gate on > 1.5: $s", s.contains("> 1.5"))
+            assertTrue("must not scope to a deviceId: $s", !s.uppercase().contains("DEVICEID"))
+        }
+    }
+}

--- a/android/app/src/test/java/com/noop/ingest/WhoopCsvExporterTest.kt
+++ b/android/app/src/test/java/com/noop/ingest/WhoopCsvExporterTest.kt
@@ -26,7 +26,7 @@ class WhoopCsvExporterTest {
     fun cyclesRoundTripThroughRealParser() {
         val daily = listOf(
             DailyMetric(
-                deviceId = "my-whoop", day = "2026-06-01", totalSleepMin = 420.0, efficiency = 92.3,
+                deviceId = "my-whoop", day = "2026-06-01", totalSleepMin = 420.0, efficiency = 0.923,
                 deepMin = 95.0, remMin = 115.0, lightMin = 210.0, disturbances = 35, restingHr = 52,
                 avgHrv = 68.4, recovery = 72.0, strain = 12.5, exerciseCount = null,
                 spo2Pct = 96.0, skinTempDevC = 33.1, respRateBpm = 14.2,
@@ -101,7 +101,7 @@ class WhoopCsvExporterTest {
         // Android-import shape [{stage,min}] — minutes survive exactly.
         val imported = SleepSession(
             deviceId = "my-whoop", startTs = 1_750_000_000L, endTs = 1_750_030_000L,
-            efficiency = 91.0, restingHr = null, avgHrv = null,
+            efficiency = 0.91, restingHr = null, avgHrv = null,
             stagesJSON = """[{"stage":"light","min":210.0},{"stage":"deep","min":95.0},""" +
                 """{"stage":"rem","min":115.0},{"stage":"awake","min":35.0}]""",
         )


### PR DESCRIPTION
## What

**Scope (updated — this PR grew beyond the original title):** normalizes the `efficiency` column to a
single 0-1 fraction convention across **both** import lanes and **both** platforms:

1. The **Oura API importer** wrote Oura's native `efficiency` field — a 0-100 integer percent — straight
   into `sleepSession.efficiency` / `dailyMetric.efficiency` (`OuraApiParser.swift`).
2. The **WHOOP CSV importer** had the identical bug: "Sleep efficiency %" (0-100) written straight into
   the same 0-1 fraction columns, on both Swift and Kotlin.

NOOP's own sleep pipeline stores that shared column as a **0-1 fraction** everywhere it computes it, so
rows from either importer ended up in the same column at two different scales, on both platforms.

## Native convention (verified, not assumed)

`Packages/StrandAnalytics/Sources/StrandAnalytics/AnalyticsEngine.swift:425`
computes `let efficiency = inBedS > 0 ? effWeighted / inBedS : 0.0` — a
ratio of two second-counts, always in `[0,1]` — and writes it directly
into both `DailyMetric.efficiency` (`AnalyticsEngine.swift:698`) and
`CachedSleepSession.efficiency` (`AnalyticsEngine.swift:721`).
`Packages/StrandAnalytics/Sources/StrandAnalytics/SleepStageTotals.swift:112`
computes the same ratio (`total.asleep / total.inBed`) independently. Real
WHOOP-era rows in an actual on-device database sit at **0.36-0.94**; real
imported Oura rows sat at **83-96** — same column, two scales.

This inconsistency already left fingerprints in the UI, which is how it
was traced back to the importer rather than assumed:

- `Strand/Screens/SleepView.swift:1173` — `if e > 1.5 { e /= 100 }   //
  efficiency arrives as % on some import paths`
- `Strand/Screens/SleepView.swift:2378-2380` — `efficiencyPct(_:)`
  defensively does `stored <= 1.0 ? stored * 100 : stored`
- `Strand/Data/WatchSessionBridge.swift:198-202` — explicit comment:
  "efficiency is stored as a fraction in [0,1] in some paths and as a
  percent in others"

Both shims treat `<= 1.0` as the correct/expected case, confirming the
fraction is the native convention, not the percent.

## Fix

**Oura API lane:** normalize at the parse boundary in `OuraApiParser.swift`: divide by 100 where
`efficiency` is read off the session (`WearableJSON.posDbl(s, "efficiency").map { $0 / 100.0 }`). The day
rollup's `efficiencyPct` is derived from that same session value, so both the per-session row and the
daily rollup come out as fractions from one change.

**WHOOP CSV lane (both platforms):** the importer's "Sleep efficiency %" (0-100) is now divided at the
WRITE boundary — `WhoopExportImporter.fractionFromImportedEfficiencyPct` (Swift, used by
`Strand/Data/WhoopImporter.swift`) and `WhoopCsvImporter.efficiencyFractionFromPct` (Kotlin) — the same
shape as the existing Day Strain ⇄ Effort rescale, so the verbatim parsed percent value is preserved and
only the store boundary changes. The CSV **exporters** apply the inverse
(`WhoopExportImporter.whoopEfficiencyPctFromFraction` / the Kotlin twin in `WhoopCsvExporter.kt`) so an
exported CSV stays genuinely WHOOP-format and a NOOP→NOOP round-trip is lossless — rounded to 4 decimals
of a percent at emission, because `num()` prints shortest-round-trip Doubles and a raw `fraction * 100`
leaks FP dust (e.g. `92.30000000000001`) into the cell otherwise.

`OuraExportParser.swift` (the separate Oura file-based account-export lane) reads the same raw
`efficiency` field independently and is **not** touched by this PR — it's a third lane with its own
percent/fraction question, left for a follow-up.

## Data heal (migration, not just re-import) — now on BOTH platforms

Re-running an import wouldn't fix already-stored bad rows on its own: `dailyMetric`/`sleepSession` are
upserted with the importer's value on conflict, so simply re-syncing would overwrite a bad row with
another bad row until the parser fix above landed — a schema-level heal is required.

**iOS/macOS (GRDB):** `Packages/WhoopStore/Sources/WhoopStore/Database.swift`, migration
`v26-efficiency-heal` (appended after `v25-oura-raw`):

```sql
UPDATE sleepSession SET efficiency = efficiency / 100.0 WHERE efficiency > 1.5;
UPDATE dailyMetric  SET efficiency = efficiency / 100.0 WHERE efficiency > 1.5;
```

- **UPDATE-only, no schema change.**
- **Unambiguous, idempotent threshold:** no genuine fraction exceeds 1.0, and no genuine percent-scale
  value falls at or below 1.5, so the predicate can never touch an already-correct row, and a second run
  is a no-op.
- **Not deviceId-scoped** (broadened from the original `deviceId = 'oura-api'` version): both known
  percent writers — the Oura API importer's `oura-api` rows AND the WHOOP CSV importer's rows under
  whatever strap deviceId the user imported into — are healed by the same predicate.

**Android (Room) — added in this PR, was previously missing:** without this, an Android user's stored
efficiency would permanently diverge from an iOS user's for the same imported CSV (iOS heals via v26,
Android wouldn't), and worse, the new Android CSV exporter's `efficiency * 100` would turn an unhealed
percent row (`92`) into `9200` in an exported CSV. `android/app/src/main/java/com/noop/data/WhoopDatabase.kt`,
migration `MIGRATION_18_19` (bumps `@Database(version = 18)` → `19`), the byte-parity twin of the GRDB
heal — same tables, same threshold, same non-scoped predicate:

```sql
UPDATE `sleepSession` SET `efficiency` = `efficiency` / 100.0 WHERE `efficiency` > 1.5
UPDATE `dailyMetric` SET `efficiency` = `efficiency` / 100.0 WHERE `efficiency` > 1.5
```

UPDATE-only, no schema/column change, so no schema-export/column-order concern (Room's `exportSchema =
false`, no `android/schemas/` in this repo). Pinned by a new plain-JVM test,
`android/app/src/test/java/com/noop/data/EfficiencyHealMigrationTest.kt`, following this codebase's
existing Room-migration-test convention (string-pinned SQL + version-pair assertions — there's no
Robolectric/JDBC-SQLite harness here to execute the migration against a real database).

**Sequencing caveat (flagged in review, not this PR's fault):** `v26` (GRDB) collides with two other
pending PRs that also want the next GRDB slot, and Room's `18→19` slot likewise collides with another
pending Room migration. Whichever of the colliding PRs lands second will need to renumber — worth
sequencing deliberately rather than merging blind.

## Android parity

The WHOOP CSV importer/exporter write-boundary fix and the Room heal above are now BOTH on Android in this
PR (see `android/app/src/main/java/com/noop/ingest/WhoopCsvImporter.kt`,
`android/app/src/main/java/com/noop/ingest/WhoopCsvExporter.kt`, and
`android/app/src/main/java/com/noop/data/WhoopDatabase.kt`).

The Oura **API** importer specifically has no Android equivalent to fix: `android/`'s `com.noop.oura`
package (`OuraDriver.kt`, `OuraGatt.kt`, `Framing.kt`, `Decoders.kt`, `Auth.kt`, `RingGen.kt`) is the BLE
ring protocol driver (headless, no `android.bluetooth` in the package itself) — a parallel, unrelated
feature for pairing directly with an Oura ring over Bluetooth, not a cloud API import path. No
`ouraring.com`/OAuth/cloud-import references exist in `android/` outside that BLE driver, so there is no
Oura-API-shaped data on Android for the Room heal to worry about — only the WHOOP-CSV-shaped percent rows,
which the heal above covers.

**Caveat — I have no Android toolchain in this environment** (no JDK; `./gradlew` can't even report
`--version`). The Kotlin write-boundary fix (`efficiencyFractionFromPct` / the exporter's `round(it *
100.0 * 10_000) / 10_000`) and the `MIGRATION_18_19` heal + its test are careful transcriptions of the
Swift logic and this codebase's existing Room-migration style, reviewed closely but **not compiled or
executed**. `testFullDebugUnitTest` needs to run on a real toolchain before merge.

## Tests

- `Packages/StrandImport/Tests/StrandImportTests/OuraApiParserSleepTests.swift`:
  `testEfficiencyIsNormalizedToZeroToOneFraction` — a raw `"efficiency": 92`
  input yields `0.92` on both the session and the day rollup.
- `Packages/StrandImport/Tests/StrandImportTests/WhoopCsvExporterTests.swift`:
  `testEfficiencyPctFractionPairIsLosslessAndNilSafe` — the fraction↔percent round-trip is lossless
  (including the FP-dust rounding), and the existing round-trip tests' fixtures now seed `efficiency` as
  the native 0-1 fraction.
- `Packages/WhoopStore/Tests/WhoopStoreTests/MigrationTests.swift`:
  `testV26HealsEfficiencyPercentToFraction` — seeds rows at the pre-v26 (`v25-oura-raw`) schema state via
  `WhoopStore.makeMigrator().migrate(_:upTo:)`, then applies the rest of the migrator and confirms: an
  `oura-api` percent row heals, an already-fraction `oura-api` row is untouched (idempotent), a
  WHOOP-CSV-imported percent row under an arbitrary strap deviceId (`my-whoop`) ALSO heals (no longer
  deviceId-scoped), and a native fraction row under a strap deviceId is left alone.
- `android/app/src/test/java/com/noop/ingest/WhoopCsvExporterTest.kt` — its existing round-trip fixtures
  (`cyclesRoundTripThroughRealParser` etc.) now seed `efficiency` as the native 0-1 fraction too.
- **New in this PR:** `android/app/src/test/java/com/noop/data/EfficiencyHealMigrationTest.kt` — pins
  `MIGRATION_18_19`'s version pair, exact SQL for both tables, that it's UPDATE-only (no schema
  mutation), and that the threshold/divisor/lack-of-deviceId-scoping matches the Swift heal.

Verification:

```
cd Packages/StrandImport && swift build && swift test
# Build complete
# Executed 200 tests, with 1 test skipped (unrelated, gated behind XIAOMI_REAL_DB) and 0 failures

cd Packages/WhoopStore && swift build && swift test
# Build complete
# Executed 257 tests, with 0 failures
```

No regressions in either package (re-verified on the current branch tip). Android: no toolchain available
here — `testFullDebugUnitTest` (including the new `EfficiencyHealMigrationTest`) needs to run on a real
build machine before merge; flagging honestly rather than claiming untested Kotlin as tested.

## Honest verification

- The native-convention claim is grounded in the four file:line citations
  above (StrandAnalytics writer + two independent UI shims), not assumed
  from the bug description.
- `TodayView.swift:4234`'s `restCaption` fallback formats
  `d.efficiency` with `%.0f%% eff` with no normalization at all (unlike
  the two shims cited above) — a narrower, rare-path inconsistency (it
  only fires when `totalSleepMin` is nil but `efficiency` isn't) left
  alone here as out of scope.
- The Android Room heal migration and its test are transcribed, not compiled/run locally — see the
  caveat under "Android parity" above.
