### PR TITLE
sleep: present a wake-split night as one night — Health export + hypnogram seams (#364)

### DIFF
--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/SleepStageTotals.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/SleepStageTotals.swift
@@ -305,26 +305,29 @@ public enum SleepStageTotals {
         return out
     }
 
-    /// The indices (into the ORIGINAL `blocks`) of the MAIN-NIGHT GROUP: the main night plus any adjacent
-    /// fragments bridged into it. A biphasic / briefly-interrupted main sleep that reaches the selector still
-    /// split into two blocks (a wake gap shorter than `gapBridgeMaxMin` between them) is scored as ONE night
-    /// rather than two competing fragments, then the winning bridged group's fragments are ALL returned so the
-    /// caller can SUM their stages for the day's headline figure. (#561)
-    ///
-    /// Pipeline:
-    ///   1. `bridgeAdjacent` merges blocks whose gap is in `[0, gapBridgeMaxMin*60)` into bridged spans, in
-    ///      `start` order, recording which original indices fell into each bridged group.
-    ///   2. `mainNightIndex` scores the BRIDGED spans (so a two-fragment night's combined span out-scores a
-    ///      lone nap) and picks the winning bridged group.
-    ///   3. The original indices of that winning group are returned, ascending.
-    ///
-    /// Returns nil only for an empty list. A day with no bridgeable gap collapses to the single-block group the
-    /// bare `mainNightIndex` would pick — byte-identical to the old behaviour for the common case. Pure +
-    /// deterministic; shares `bridgeAdjacent` + `mainNightIndex` so the bridged pick stays cross-platform
-    /// stable. (#561)
-    public static func mainNightGroupIndices(_ blocks: [NightBlock], offsetSec: Int,
-                                             habitualMidsleepSec: Int? = nil) -> [Int]? {
-        guard !blocks.isEmpty else { return nil }
+    /// One bridged night group over the whole input: the fragments (as ORIGINAL indices, ascending)
+    /// plus the group's inter-fragment wake seams. Produced by `bridgedNightGroups` for the consumers
+    /// that must present a briefly-interrupted night as ONE night — the Health write-back and the
+    /// sleep screens — so they group exactly as the day totals do and can fold each seam in as an
+    /// explicit `wake` segment. (#364)
+    public struct BridgedNightGroup: Equatable {
+        public let indices: [Int]
+        public let gaps: [GapSpan]
+        /// One inter-fragment seam: (previous bridged end, next fragment start), end > start always.
+        public struct GapSpan: Equatable {
+            public let start: Int, end: Int
+            public init(start: Int, end: Int) { self.start = start; self.end = end }
+        }
+        public init(indices: [Int], gaps: [GapSpan]) { self.indices = indices; self.gaps = gaps }
+    }
+
+    /// EVERY bridged group over `blocks` — the same two-tier bridge `mainNightGroupIndices` applies
+    /// (#561 short-wake, plus the #861 overnight night-tail widening), WITHOUT the winner pick. A
+    /// negative gap (a block starting inside the previous span) does not bridge — pinned legacy
+    /// semantics, `gap >= 0` — and never fabricates a seam. Groups ordered by start; pure and
+    /// deterministic; Kotlin twin `bridgedNightGroups`. (#364)
+    public static func bridgedNightGroups(_ blocks: [NightBlock], offsetSec: Int) -> [BridgedNightGroup] {
+        guard !blocks.isEmpty else { return [] }
         // Sort indices by onset so bridging sees neighbours, exactly as `bridgeAdjacent` sorts the blocks.
         let order = blocks.indices.sorted { blocks[$0].start < blocks[$1].start }
         let bridgeS = gapBridgeMaxMin * 60
@@ -332,6 +335,7 @@ public enum SleepStageTotals {
         // Build the bridged spans AND the original indices that compose each one, in one pass over `order`.
         var bridged: [NightBlock] = []
         var groups: [[Int]] = []
+        var gaps: [[BridgedNightGroup.GapSpan]] = []
         for idx in order {
             let b = blocks[idx]
             if let last = bridged.last {
@@ -346,6 +350,9 @@ public enum SleepStageTotals {
                     && (gap < bridgeS
                         || (gap < nightTailBridgeS && isOvernightOnset(b.start, offsetSec: offsetSec)))
                 if bridges {
+                    if gap > 0 {
+                        gaps[gaps.count - 1].append(.init(start: last.end, end: b.start))
+                    }
                     bridged[bridged.count - 1] = NightBlock(start: last.start, end: max(last.end, b.end))
                     groups[groups.count - 1].append(idx)
                     continue
@@ -353,10 +360,41 @@ public enum SleepStageTotals {
             }
             bridged.append(b)
             groups.append([idx])
+            gaps.append([])
         }
-        guard let winner = mainNightIndex(bridged, offsetSec: offsetSec,
+        return zip(groups, gaps).map { BridgedNightGroup(indices: $0.sorted(), gaps: $1) }
+    }
+
+    /// The indices (into the ORIGINAL `blocks`) of the MAIN-NIGHT GROUP: the main night plus any adjacent
+    /// fragments bridged into it. A biphasic / briefly-interrupted main sleep that reaches the selector still
+    /// split into two blocks (a wake gap shorter than `gapBridgeMaxMin` between them) is scored as ONE night
+    /// rather than two competing fragments, then the winning bridged group's fragments are ALL returned so the
+    /// caller can SUM their stages for the day's headline figure. (#561)
+    ///
+    /// Pipeline:
+    ///   1. `bridgedNightGroups` merges blocks whose gap is in `[0, gapBridgeMaxMin*60)` (or the #861
+    ///      night-tail window) into bridged groups, in `start` order.
+    ///   2. `mainNightIndex` scores the BRIDGED spans (so a two-fragment night's combined span out-scores a
+    ///      lone nap) and picks the winning bridged group.
+    ///   3. The original indices of that winning group are returned, ascending.
+    ///
+    /// Returns nil only for an empty list. A day with no bridgeable gap collapses to the single-block group the
+    /// bare `mainNightIndex` would pick — byte-identical to the old behaviour for the common case. Pure +
+    /// deterministic; shares the `bridgedNightGroups` pass + `mainNightIndex` so the bridged pick stays
+    /// cross-platform stable. (#561)
+    public static func mainNightGroupIndices(_ blocks: [NightBlock], offsetSec: Int,
+                                             habitualMidsleepSec: Int? = nil) -> [Int]? {
+        guard !blocks.isEmpty else { return nil }
+        let all = bridgedNightGroups(blocks, offsetSec: offsetSec)
+        // Rebuild each group's bridged span for scoring: sorted-ascending fragments make the span
+        // (first start, running-max end) — identical to the span the one-pass loop accumulated.
+        let bridgedSpans = all.map { g -> NightBlock in
+            NightBlock(start: g.indices.map { blocks[$0].start }.min() ?? 0,
+                       end: g.indices.map { blocks[$0].end }.max() ?? 0)
+        }
+        guard let winner = mainNightIndex(bridgedSpans, offsetSec: offsetSec,
                                           habitualMidsleepSec: habitualMidsleepSec) else { return nil }
-        return groups[winner].sorted()
+        return all[winner].indices
     }
 
     /// Index of the day's MAIN night among `blocks`, by the LEARNED-TIMING SCORE (replaces the old hard

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/BridgedNightGroupsTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/BridgedNightGroupsTests.swift
@@ -1,0 +1,103 @@
+import XCTest
+@testable import StrandAnalytics
+
+/// Pins the all-groups bridge (#364): the SAME two-tier gap bridge the main-night selector applies
+/// (#561 short-wake + #861 overnight night-tail), returned for EVERY group with each group's
+/// inter-fragment wake seams explicit — so the Health write-back and the sleep screens can present
+/// a briefly-interrupted night as ONE night without re-deriving (or diverging from) the bridge.
+final class BridgedNightGroupsTests: XCTestCase {
+    private typealias B = SleepStageTotals.NightBlock
+    private typealias Gap = SleepStageTotals.BridgedNightGroup.GapSpan
+    /// 2026-01-02 00:00:00 UTC — fixtures read as local clock times with offsetSec 0.
+    private let t0 = 1_767_312_000
+
+    func testShortWakeBridgesTwoFragmentsWithOneGap() {
+        // The #364 example shape: 23:00→02:00, a 16-minute wake, 02:16→06:00.
+        let a = B(start: t0 - 3_600, end: t0 + 2 * 3_600)
+        let b = B(start: t0 + 2 * 3_600 + 16 * 60, end: t0 + 6 * 3_600)
+        let groups = SleepStageTotals.bridgedNightGroups([a, b], offsetSec: 0)
+        XCTAssertEqual(groups.count, 1)
+        XCTAssertEqual(groups[0].indices, [0, 1])
+        XCTAssertEqual(groups[0].gaps, [Gap(start: a.end, end: b.start)])
+    }
+
+    func testDaytimeNapStaysItsOwnGroup() {
+        let night = B(start: t0 - 3_600, end: t0 + 6 * 3_600)          // 23:00→06:00
+        let nap = B(start: t0 + 14 * 3_600, end: t0 + 15 * 3_600)      // 14:00→15:00
+        let groups = SleepStageTotals.bridgedNightGroups([night, nap], offsetSec: 0)
+        XCTAssertEqual(groups.map(\.indices), [[0], [1]])
+        XCTAssertTrue(groups.allSatisfy { $0.gaps.isEmpty })
+    }
+
+    func testNightTailBridgesOvernightGapOverSixtyMinutes() {
+        // 75-min gap with the second fragment's onset at 04:15 local (overnight band): folded in by
+        // the #861 night-tail bridge, so a longer real mid-night wake still reads as one night.
+        let a = B(start: t0 - 3_600, end: t0 + 3 * 3_600)
+        let b = B(start: t0 + 3 * 3_600 + 75 * 60, end: t0 + 7 * 3_600)
+        let groups = SleepStageTotals.bridgedNightGroups([a, b], offsetSec: 0)
+        XCTAssertEqual(groups.map(\.indices), [[0, 1]])
+        XCTAssertEqual(groups[0].gaps, [Gap(start: a.end, end: b.start)])
+    }
+
+    func testDaytimeGapOverSixtyMinutesDoesNotBridge() {
+        // Same 75-min gap but the second fragment begins at 13:15 local (daytime): the night-tail
+        // widening must NOT apply, so the blocks stay separate groups (a real afternoon nap).
+        let a = B(start: t0 + 9 * 3_600, end: t0 + 12 * 3_600)
+        let b = B(start: t0 + 12 * 3_600 + 75 * 60, end: t0 + 14 * 3_600)
+        let groups = SleepStageTotals.bridgedNightGroups([a, b], offsetSec: 0)
+        XCTAssertEqual(groups.map(\.indices), [[0], [1]])
+    }
+
+    func testThreeFragmentNightYieldsTwoGaps() {
+        let a = B(start: t0, end: t0 + 3_600)
+        let b = B(start: t0 + 3_600 + 600, end: t0 + 2 * 3_600)
+        let c = B(start: t0 + 2 * 3_600 + 900, end: t0 + 3 * 3_600)
+        let groups = SleepStageTotals.bridgedNightGroups([a, b, c], offsetSec: 0)
+        XCTAssertEqual(groups.map(\.indices), [[0, 1, 2]])
+        XCTAssertEqual(groups[0].gaps, [Gap(start: a.end, end: b.start),
+                                        Gap(start: b.end, end: c.start)])
+    }
+
+    func testOverlappingFragmentStartsItsOwnGroup() {
+        // Legacy semantics pinned: a negative gap (fragment starting inside the previous span) does
+        // NOT bridge — `mainNightGroupIndices` has always required gap >= 0, and the refactor must
+        // not change the pick. No seam is fabricated either.
+        let a = B(start: t0, end: t0 + 4 * 3_600)
+        let b = B(start: t0 + 3_600, end: t0 + 2 * 3_600)
+        let groups = SleepStageTotals.bridgedNightGroups([a, b], offsetSec: 0)
+        XCTAssertEqual(groups.map(\.indices), [[0], [1]])
+        XCTAssertTrue(groups.allSatisfy { $0.gaps.isEmpty })
+    }
+
+    func testZeroGapBridgesWithoutSeam() {
+        // Touching fragments (gap == 0) bridge, and no zero-length seam is emitted.
+        let a = B(start: t0, end: t0 + 3_600)
+        let b = B(start: t0 + 3_600, end: t0 + 2 * 3_600)
+        let groups = SleepStageTotals.bridgedNightGroups([a, b], offsetSec: 0)
+        XCTAssertEqual(groups.map(\.indices), [[0, 1]])
+        XCTAssertTrue(groups[0].gaps.isEmpty)
+    }
+
+    func testUnsortedInputIndicesReferToOriginalPositions() {
+        // Input order reversed: indices still point into the ORIGINAL array (late = 0, early = 1),
+        // returned ascending within the group.
+        let late = B(start: t0 + 2 * 3_600 + 16 * 60, end: t0 + 6 * 3_600)
+        let early = B(start: t0 - 3_600, end: t0 + 2 * 3_600)
+        let groups = SleepStageTotals.bridgedNightGroups([late, early], offsetSec: 0)
+        XCTAssertEqual(groups.map(\.indices), [[0, 1]])
+        XCTAssertEqual(groups[0].gaps, [Gap(start: early.end, end: late.start)])
+    }
+
+    func testEmptyInputYieldsNoGroups() {
+        XCTAssertTrue(SleepStageTotals.bridgedNightGroups([], offsetSec: 0).isEmpty)
+    }
+
+    /// The refactor guard: the main-night pick over the all-groups pass stays byte-identical for a
+    /// biphasic night + nap day (the #561/#861 golden suite pins the rest of the behaviour).
+    func testMainNightGroupIndicesUnchangedForBiphasicPlusNap() {
+        let a = B(start: t0 - 3_600, end: t0 + 2 * 3_600)
+        let b = B(start: t0 + 2 * 3_600 + 16 * 60, end: t0 + 6 * 3_600)
+        let nap = B(start: t0 + 14 * 3_600, end: t0 + 15 * 3_600)
+        XCTAssertEqual(SleepStageTotals.mainNightGroupIndices([a, b, nap], offsetSec: 0), [0, 1])
+    }
+}

--- a/Packages/StrandImport/Sources/StrandImport/HealthWriteback.swift
+++ b/Packages/StrandImport/Sources/StrandImport/HealthWriteback.swift
@@ -6,9 +6,11 @@ import Foundation
 public enum HealthWriteback {
 
     /// A HealthKit-agnostic sleep stage. The bridge maps these onto `HKCategoryValueSleepAnalysis`
-    /// (`awake → .awake`, `light → .asleepCore`, `deep → .asleepDeep`, `rem → .asleepREM`).
+    /// (`awake → .awake`, `light → .asleepCore`, `deep → .asleepDeep`, `rem → .asleepREM`,
+    /// `unspecified → .asleepUnspecified` — the honest block for a fragment whose `stagesJSON`
+    /// carries no timing).
     public enum StageKind: String, Equatable {
-        case awake, light, deep, rem
+        case awake, light, deep, rem, unspecified
     }
 
     public struct StageInterval: Equatable {
@@ -70,5 +72,86 @@ public enum HealthWriteback {
         case let d as Double: return Int(d)
         default: return nil
         }
+    }
+
+    // MARK: - Merged nights (#364)
+
+    /// One stored sleep fragment, as the write-back sees it: the immutable detected key (`startTs`),
+    /// the edited onset when present (`effectiveStartTs` — drives the span, never the key, #318),
+    /// the wake, and the persisted stage JSON.
+    public struct SleepFragment: Equatable {
+        public let startTs: Int
+        public let effectiveStartTs: Int
+        public let endTs: Int
+        public let stagesJSON: String?
+        public init(startTs: Int, effectiveStartTs: Int, endTs: Int, stagesJSON: String?) {
+            self.startTs = startTs; self.effectiveStartTs = effectiveStartTs
+            self.endTs = endTs; self.stagesJSON = stagesJSON
+        }
+    }
+
+    /// One bridged night, folded for the write-back: the `.inBed` span, the merged stage timeline,
+    /// the representative dedup key, and the COMPLETE per-fragment key set for deletion.
+    public struct MergedSleepEntry: Equatable {
+        /// The group's dedup key: the EARLIEST fragment's immutable detected `startTs` (a user edit
+        /// moves the span via `effectiveStartTs`, never this key, so the entry keeps its identity).
+        public let keyStartTs: Int
+        /// Earliest edited onset → latest wake across the group: the one `.inBed` span.
+        public let spanStart: Int
+        public let spanEnd: Int
+        /// The fragments' stage intervals in time order — a fragment with no decodable timing
+        /// contributes one honest `.unspecified` block over its own window — with every
+        /// inter-fragment seam as an explicit `.awake` interval.
+        public let intervals: [StageInterval]
+        /// EVERY fragment's immutable `startTs`, ascending. The delete predicate must carry all of
+        /// them: a night previously exported as two entries would otherwise orphan the absorbed
+        /// fragment's old entry when it becomes one.
+        public let allKeyStartTs: [Int]
+        public init(keyStartTs: Int, spanStart: Int, spanEnd: Int,
+                    intervals: [StageInterval], allKeyStartTs: [Int]) {
+            self.keyStartTs = keyStartTs; self.spanStart = spanStart; self.spanEnd = spanEnd
+            self.intervals = intervals; self.allKeyStartTs = allKeyStartTs
+        }
+    }
+
+    /// Fold bridged night groups (#364) into write-back entries — one `.inBed` span per night with
+    /// the mid-night wake seams as explicit `.awake` intervals, matching what the daily totals
+    /// already score (#561/#777) and what Oura / Apple Watch write into Health. `groups` comes from
+    /// `SleepStageTotals.bridgedNightGroups` (this package deliberately doesn't depend on the
+    /// analytics package, so the grouping happens in the caller). Fragments are re-sorted by
+    /// effective onset defensively; a zero/negative-length fragment contributes no interval but
+    /// keeps its key in the delete set; a group with no positive span is skipped entirely.
+    public static func mergedSleepPlan(groups: [[SleepFragment]]) -> [MergedSleepEntry] {
+        var out: [MergedSleepEntry] = []
+        for group in groups where !group.isEmpty {
+            let frags = group.sorted { $0.effectiveStartTs < $1.effectiveStartTs }
+            var intervals: [StageInterval] = []
+            var prevEnd: Int? = nil
+            var spanStart: Int? = nil
+            for f in frags {
+                guard f.endTs > f.effectiveStartTs else { continue }
+                if spanStart == nil { spanStart = f.effectiveStartTs }
+                if let p = prevEnd, f.effectiveStartTs > p {
+                    intervals.append(StageInterval(start: p, end: f.effectiveStartTs, kind: .awake))
+                }
+                let stages = stageIntervals(stagesJSON: f.stagesJSON,
+                                            sessionStart: f.effectiveStartTs, sessionEnd: f.endTs)
+                if stages.isEmpty {
+                    intervals.append(StageInterval(start: f.effectiveStartTs, end: f.endTs,
+                                                   kind: .unspecified))
+                } else {
+                    intervals.append(contentsOf: stages)
+                }
+                prevEnd = max(prevEnd ?? f.endTs, f.endTs)
+            }
+            guard let start = spanStart, let end = prevEnd, end > start else { continue }
+            out.append(MergedSleepEntry(
+                keyStartTs: frags.map(\.startTs).min() ?? 0,
+                spanStart: start,
+                spanEnd: end,
+                intervals: intervals,
+                allKeyStartTs: frags.map(\.startTs).sorted()))
+        }
+        return out
     }
 }

--- a/Packages/StrandImport/Tests/StrandImportTests/HealthWritebackTests.swift
+++ b/Packages/StrandImport/Tests/StrandImportTests/HealthWritebackTests.swift
@@ -87,4 +87,100 @@ final class HealthWritebackTests: XCTestCase {
         """
         XCTAssertEqual(intervals(json), [.init(start: start, end: start + 60, kind: .deep)])
     }
+
+    // MARK: - mergedSleepPlan (#364 night-stitch)
+    //
+    // One write-back entry per BRIDGED night: the caller (HealthKitBridge) groups fragments with
+    // SleepStageTotals.bridgedNightGroups; this pure layer folds each group into one span + one
+    // merged stage timeline with every inter-fragment seam as an explicit `wake`, keyed by the
+    // earliest fragment's immutable startTs, carrying the COMPLETE per-fragment key set so a night
+    // previously exported as two entries deletes both before the merged write.
+
+    private func frag(_ start: Int, _ end: Int, stages: String? = nil,
+                      eff: Int? = nil) -> HealthWriteback.SleepFragment {
+        .init(startTs: start, effectiveStartTs: eff ?? start, endTs: end, stagesJSON: stages)
+    }
+    private func stagesJSON(_ segs: [(Int, Int, String)]) -> String {
+        "[" + segs.map { "{\"start\":\($0.0),\"end\":\($0.1),\"stage\":\"\($0.2)\"}" }
+            .joined(separator: ",") + "]"
+    }
+
+    func testMergedPlanFoldsTwoFragmentsWithWakeSeam() {
+        let t = 1_767_312_000
+        let a = frag(t, t + 7_200, stages: stagesJSON([(t, t + 7_200, "light")]))
+        let b = frag(t + 7_200 + 960, t + 14_400,
+                     stages: stagesJSON([(t + 7_200 + 960, t + 14_400, "deep")]))
+        let plan = HealthWriteback.mergedSleepPlan(groups: [[a, b]])
+        XCTAssertEqual(plan.count, 1)
+        let e = plan[0]
+        XCTAssertEqual(e.keyStartTs, t)
+        XCTAssertEqual(e.spanStart, t)
+        XCTAssertEqual(e.spanEnd, t + 14_400)
+        XCTAssertEqual(e.allKeyStartTs, [t, t + 7_200 + 960])
+        // The seam sits EXACTLY on [prev.end, next.effectiveStart] as .awake.
+        XCTAssertEqual(e.intervals, [
+            .init(start: t, end: t + 7_200, kind: .light),
+            .init(start: t + 7_200, end: t + 7_200 + 960, kind: .awake),
+            .init(start: t + 7_200 + 960, end: t + 14_400, kind: .deep),
+        ])
+    }
+
+    func testMergedPlanSingleFragmentMatchesLegacyShape() {
+        let t = 1_767_312_000
+        let a = frag(t, t + 7_200,
+                     stages: stagesJSON([(t, t + 3_600, "light"), (t + 3_600, t + 7_200, "rem")]))
+        let e = HealthWriteback.mergedSleepPlan(groups: [[a]])[0]
+        XCTAssertEqual(e.keyStartTs, t)
+        XCTAssertEqual(e.spanStart, t)
+        XCTAssertEqual(e.spanEnd, t + 7_200)
+        XCTAssertEqual(e.allKeyStartTs, [t])
+        XCTAssertEqual(e.intervals, HealthWriteback.stageIntervals(
+            stagesJSON: a.stagesJSON, sessionStart: t, sessionEnd: t + 7_200))
+    }
+
+    func testMergedPlanUnstagedFragmentsDegradeToUnspecifiedPlusSeam() {
+        let t = 1_767_312_000
+        let a = frag(t, t + 7_200)                       // no stagesJSON → honest unspecified block
+        let b = frag(t + 7_200 + 960, t + 14_400)
+        let e = HealthWriteback.mergedSleepPlan(groups: [[a, b]])[0]
+        XCTAssertEqual(e.intervals, [
+            .init(start: t, end: t + 7_200, kind: .unspecified),
+            .init(start: t + 7_200, end: t + 7_200 + 960, kind: .awake),
+            .init(start: t + 7_200 + 960, end: t + 14_400, kind: .unspecified),
+        ])
+    }
+
+    func testMergedPlanMixedStagedAndUnstagedFragments() {
+        let t = 1_767_312_000
+        let a = frag(t, t + 7_200, stages: stagesJSON([(t, t + 7_200, "light")]))
+        let b = frag(t + 7_200 + 960, t + 14_400)        // second fragment carries no timing
+        let e = HealthWriteback.mergedSleepPlan(groups: [[a, b]])[0]
+        XCTAssertEqual(e.intervals, [
+            .init(start: t, end: t + 7_200, kind: .light),
+            .init(start: t + 7_200, end: t + 7_200 + 960, kind: .awake),
+            .init(start: t + 7_200 + 960, end: t + 14_400, kind: .unspecified),
+        ])
+    }
+
+    func testMergedPlanEditedOnsetMovesSpanButNotKey() {
+        let t = 1_767_312_000
+        let a = frag(t, t + 7_200, eff: t + 600)         // user moved bedtime 10 min later
+        let e = HealthWriteback.mergedSleepPlan(groups: [[a]])[0]
+        XCTAssertEqual(e.keyStartTs, t)                  // immutable key
+        XCTAssertEqual(e.spanStart, t + 600)             // edited onset drives the span
+        XCTAssertEqual(e.intervals, [.init(start: t + 600, end: t + 7_200, kind: .unspecified)])
+    }
+
+    func testMergedPlanSkipsDegenerateFragmentsAndEmptyGroups() {
+        let t = 1_767_312_000
+        let bad = frag(t, t)                             // zero-length → contributes no interval
+        let good = frag(t + 600, t + 7_200)
+        let plan = HealthWriteback.mergedSleepPlan(groups: [[], [bad, good]])
+        XCTAssertEqual(plan.count, 1)
+        XCTAssertEqual(plan[0].spanStart, t + 600)
+        // The degenerate fragment still contributes its key to the delete set (its old export, if
+        // any, must clear), but produces no interval.
+        XCTAssertEqual(plan[0].allKeyStartTs, [t, t + 600])
+        XCTAssertEqual(plan[0].intervals, [.init(start: t + 600, end: t + 7_200, kind: .unspecified)])
+    }
 }

--- a/Strand/Screens/SleepView.swift
+++ b/Strand/Screens/SleepView.swift
@@ -2000,14 +2000,34 @@ struct SleepView: View {
             if let seg = decodeSegments(frag.stagesJSON, sessionStart: frag.effectiveStartTs), seg.stages.total > 0 {
                 stages.awake += seg.stages.awake; stages.light += seg.stages.light
                 stages.deep  += seg.stages.deep;  stages.rem   += seg.stages.rem
+                // decodeSegments yields intervals relative to THAT fragment's onset; rebase them to
+                // NIGHT-relative (seconds from the displayed onset) so a later fragment's bars land
+                // after the first fragment instead of overlapping it — the same coordinate space
+                // sleepHRChart maps HR into (rel = ts - nightStart). No-op for the first fragment
+                // of a night (shift 0), so single-block nights are byte-identical. (#364)
+                let shift = TimeInterval(frag.effectiveStartTs - onset)
                 for iv in seg.intervals {
-                    segs.append(SleepInterval(stage: iv.stage, start: iv.start, end: iv.end))
+                    segs.append(SleepInterval(stage: iv.stage, start: iv.start + shift, end: iv.end + shift))
                 }
             } else if let st = decodeStages(frag.stagesJSON), st.total > 0 {
                 stages.awake += st.awake; stages.light += st.light
                 stages.deep  += st.deep;  stages.rem   += st.rem
             }
             if let m = motionByStart[frag.startTs] { motion.append(contentsOf: m) }
+        }
+        // #364: the inter-fragment wake seams belong to the night — draw each as a wake SEGMENT so
+        // the hero hypnogram has no hole where the user was up, matching what the Health export now
+        // writes. The stage MINUTES deliberately stay fragment-only (the seam is not added to
+        // `stages.awake`): the hero's in-bed/efficiency accounting sums fragment windows, mirroring
+        // the Android groupInBedMin rule, so asleep ≤ in-bed stays coherent. Seams are
+        // night-relative like the rebased segments above.
+        let orderedFrags = Array(group)
+        for (prev, next) in zip(orderedFrags, orderedFrags.dropFirst()) {
+            let gapStart = prev.endTs, gapEnd = next.effectiveStartTs
+            guard gapEnd > gapStart else { continue }
+            segs.append(SleepInterval(stage: .awake,
+                                      start: TimeInterval(gapStart - onset),
+                                      end: TimeInterval(gapEnd - onset)))
         }
         guard stages.asleep > 0 else { return nil }
         let eff = stages.total > 0 ? stages.asleep / stages.total : nil

--- a/StrandiOS/Health/HealthKitBridge.swift
+++ b/StrandiOS/Health/HealthKitBridge.swift
@@ -2,6 +2,7 @@
 import Foundation
 import HealthKit
 import WhoopStore
+import StrandAnalytics
 import StrandImport
 
 /// Two-way Apple Health bridge for the iOS app.
@@ -562,52 +563,56 @@ final class HealthKitBridge: ObservableObject {
         try await self.store.save(candidates.map { $0.sample })
     }
 
-    /// Write each sleep session as one `.inBed` sample spanning `effectiveStartTs → endTs` plus one
-    /// category sample per stage segment (`deep → .asleepDeep`, `rem → .asleepREM`,
-    /// `light → .asleepCore`, `wake → .awake`) — the same shape Oura and Apple Watch write, so
-    /// Health renders the full hypnogram. Sessions whose `stagesJSON` carries no timing (the legacy
-    /// aggregate-minutes shapes) get one honest `.asleepUnspecified` block instead of fabricated
-    /// stage placement.
+    /// Write each BRIDGED NIGHT (#364) as one `.inBed` sample plus one category sample per stage
+    /// segment (`deep → .asleepDeep`, `rem → .asleepREM`, `light → .asleepCore`, `wake → .awake`) —
+    /// the same shape Oura and Apple Watch write, so Health renders the full hypnogram. A night the
+    /// detector split on a brief mid-night wake exports as ONE entry whose gap is an explicit
+    /// `.awake` segment (grouped by `SleepStageTotals.bridgedNightGroups`, the SAME bridge the daily
+    /// totals score with, #561); naps never bridge and stay their own entries. Fragments whose
+    /// `stagesJSON` carries no timing (the legacy aggregate-minutes shapes) get one honest
+    /// `.asleepUnspecified` block instead of fabricated stage placement.
     ///
-    /// Dedup: every sample of a session carries `HKMetadataKeyExternalUUID =
-    /// noop:<deviceId>:sleep:<startTs>` (the immutable detected onset, so a user-edited session
-    /// keeps its identity); delete-then-write scoped to our own `HKSource`, like the vitals.
+    /// Dedup: every sample of a night carries `HKMetadataKeyExternalUUID =
+    /// noop:<deviceId>:sleep:<startTs>` keyed by the group's EARLIEST fragment's immutable detected
+    /// onset (a user edit moves the span, never the key). The delete predicate carries EVERY
+    /// fragment's key, so a night previously written as two entries fully clears when it becomes
+    /// one; delete-then-write scoped to our own `HKSource`, like the vitals.
     private func writeSleep(sessions: [CachedSleepSession]) async throws {
         guard let type = HKObjectType.categoryType(forIdentifier: .sleepAnalysis),
               store.authorizationStatus(for: type) == .sharingAuthorized else { return }
+        let blocks = sessions.map { SleepStageTotals.NightBlock(start: $0.effectiveStartTs, end: $0.endTs) }
+        let groups = SleepStageTotals.bridgedNightGroups(blocks, offsetSec: TimeZone.current.secondsFromGMT())
+            .map { g in
+                g.indices.map { i -> HealthWriteback.SleepFragment in
+                    let s = sessions[i]
+                    return .init(startTs: s.startTs, effectiveStartTs: s.effectiveStartTs,
+                                 endTs: s.endTs, stagesJSON: s.stagesJSON)
+                }
+            }
         var samples: [HKCategorySample] = []
         var keys: [String] = []
-        for s in sessions {
-            let startTs = s.effectiveStartTs
-            guard s.endTs > startTs else { continue }
-            let start = Date(timeIntervalSince1970: TimeInterval(startTs))
-            let end = Date(timeIntervalSince1970: TimeInterval(s.endTs))
-            let key = "noop:\(noopDeviceId):sleep:\(s.startTs)"
-            keys.append(key)
+        for entry in HealthWriteback.mergedSleepPlan(groups: groups) {
+            let key = "noop:\(noopDeviceId):sleep:\(entry.keyStartTs)"
             let meta = [HKMetadataKeyExternalUUID: key]
+            keys.append(contentsOf: entry.allKeyStartTs.map { "noop:\(noopDeviceId):sleep:\($0)" })
             samples.append(HKCategorySample(type: type, value: HKCategoryValueSleepAnalysis.inBed.rawValue,
-                                            start: start, end: end, metadata: meta))
-            let stages = HealthWriteback.stageIntervals(stagesJSON: s.stagesJSON,
-                                                        sessionStart: startTs, sessionEnd: s.endTs)
-            if stages.isEmpty {
-                samples.append(HKCategorySample(type: type,
-                                                value: HKCategoryValueSleepAnalysis.asleepUnspecified.rawValue,
-                                                start: start, end: end, metadata: meta))
-            } else {
-                for seg in stages {
-                    let value: HKCategoryValueSleepAnalysis
-                    switch seg.kind {
-                    case .awake: value = .awake
-                    case .light: value = .asleepCore
-                    case .deep:  value = .asleepDeep
-                    case .rem:   value = .asleepREM
-                    }
-                    samples.append(HKCategorySample(
-                        type: type, value: value.rawValue,
-                        start: Date(timeIntervalSince1970: TimeInterval(seg.start)),
-                        end: Date(timeIntervalSince1970: TimeInterval(seg.end)),
-                        metadata: meta))
+                                            start: Date(timeIntervalSince1970: TimeInterval(entry.spanStart)),
+                                            end: Date(timeIntervalSince1970: TimeInterval(entry.spanEnd)),
+                                            metadata: meta))
+            for seg in entry.intervals {
+                let value: HKCategoryValueSleepAnalysis
+                switch seg.kind {
+                case .awake:       value = .awake
+                case .light:       value = .asleepCore
+                case .deep:        value = .asleepDeep
+                case .rem:         value = .asleepREM
+                case .unspecified: value = .asleepUnspecified
                 }
+                samples.append(HKCategorySample(
+                    type: type, value: value.rawValue,
+                    start: Date(timeIntervalSince1970: TimeInterval(seg.start)),
+                    end: Date(timeIntervalSince1970: TimeInterval(seg.end)),
+                    metadata: meta))
             }
         }
         guard !samples.isEmpty else { return }

--- a/android/app/src/main/java/com/noop/analytics/SleepStageTotals.kt
+++ b/android/app/src/main/java/com/noop/analytics/SleepStageTotals.kt
@@ -248,25 +248,20 @@ object SleepStageTotals {
         return out
     }
 
-    /** The indices (into the ORIGINAL [blocks]) of the MAIN-NIGHT GROUP: the main night plus any adjacent
-     *  fragments bridged into it. A biphasic / briefly-interrupted main sleep that reaches the selector still
-     *  split into two blocks (a wake gap shorter than [GAP_BRIDGE_MAX_MIN] between them) is scored as ONE
-     *  night rather than two competing fragments, then the winning bridged group's fragments are ALL returned
-     *  so the caller can SUM their stages for the day's headline figure. (#561)
-     *
-     *  Pipeline:
-     *   1. [bridgeAdjacent]-style merge of blocks whose gap is in `[0, GAP_BRIDGE_MAX_MIN*60)` into bridged
-     *      spans, in `start` order, recording which original indices fell into each bridged group;
-     *   2. [mainNightIndex] scores the BRIDGED spans (so a two-fragment night's combined span out-scores a
-     *      lone nap) and picks the winning bridged group;
-     *   3. the original indices of that winning group are returned, ascending.
-     *
-     *  Null only for an empty list. A day with no bridgeable gap collapses to the single-block group the bare
-     *  [mainNightIndex] would pick — byte-identical to the old behaviour for the common case. Pure +
-     *  deterministic; shares the bridge logic + [mainNightIndex] so the pick stays cross-platform stable.
-     *  Mirrors Swift `mainNightGroupIndices`. (#561) */
-    fun mainNightGroupIndices(blocks: List<NightBlock>, offsetSec: Long, habitualMidsleepSec: Long? = null): List<Int>? {
-        if (blocks.isEmpty()) return null
+    /** One bridged night group over the whole input: the fragments (as ORIGINAL indices, ascending) plus
+     *  the group's inter-fragment wake seams (start, end) pairs. Produced by [bridgedNightGroups] for the
+     *  consumers that must present a briefly-interrupted night as ONE night — the Health Connect export
+     *  and the Sleep screen — so they group exactly as the day totals do and can fold each seam in as an
+     *  explicit wake segment. Mirrors Swift `BridgedNightGroup`. (#364) */
+    data class BridgedNightGroup(val indices: List<Int>, val gaps: List<Pair<Long, Long>>)
+
+    /** EVERY bridged group over [blocks] — the same two-tier bridge [mainNightGroupIndices] applies (#561
+     *  short-wake, plus the #861 overnight night-tail widening), WITHOUT the winner pick. A negative gap
+     *  (a block starting inside the previous span) does not bridge — pinned legacy semantics, `gap >= 0` —
+     *  and never fabricates a seam. Groups ordered by start; pure and deterministic. Mirrors Swift
+     *  `bridgedNightGroups`. (#364) */
+    fun bridgedNightGroups(blocks: List<NightBlock>, offsetSec: Long): List<BridgedNightGroup> {
+        if (blocks.isEmpty()) return emptyList()
         // Sort indices by onset so bridging sees neighbours, exactly as `bridgeAdjacent` sorts the blocks.
         val order = blocks.indices.sortedBy { blocks[it].start }
         val bridgeS = GAP_BRIDGE_MAX_MIN * 60L
@@ -274,6 +269,7 @@ object SleepStageTotals {
         // Build the bridged spans AND the original indices that compose each one, in one pass over `order`.
         val bridged = ArrayList<NightBlock>()
         val groups = ArrayList<MutableList<Int>>()
+        val gaps = ArrayList<MutableList<Pair<Long, Long>>>()
         for (idx in order) {
             val b = blocks[idx]
             val last = bridged.lastOrNull()
@@ -289,6 +285,7 @@ object SleepStageTotals {
                     (gap < bridgeS ||
                         (gap < nightTailBridgeS && isOvernightOnset(b.start, offsetSec)))
                 if (bridges) {
+                    if (gap > 0) gaps[gaps.size - 1].add(last.end to b.start)
                     bridged[bridged.size - 1] = NightBlock(last.start, maxOf(last.end, b.end))
                     groups[groups.size - 1].add(idx)
                     continue
@@ -296,9 +293,38 @@ object SleepStageTotals {
             }
             bridged.add(b)
             groups.add(mutableListOf(idx))
+            gaps.add(mutableListOf())
         }
-        val winner = mainNightIndex(bridged, offsetSec, habitualMidsleepSec) ?: return null
-        return groups[winner].sorted()
+        return groups.zip(gaps).map { (g, gp) -> BridgedNightGroup(g.sorted(), gp) }
+    }
+
+    /** The indices (into the ORIGINAL [blocks]) of the MAIN-NIGHT GROUP: the main night plus any adjacent
+     *  fragments bridged into it. A biphasic / briefly-interrupted main sleep that reaches the selector still
+     *  split into two blocks (a wake gap shorter than [GAP_BRIDGE_MAX_MIN] between them) is scored as ONE
+     *  night rather than two competing fragments, then the winning bridged group's fragments are ALL returned
+     *  so the caller can SUM their stages for the day's headline figure. (#561)
+     *
+     *  Pipeline:
+     *   1. [bridgedNightGroups] merges blocks whose gap is in `[0, GAP_BRIDGE_MAX_MIN*60)` (or the #861
+     *      night-tail window) into bridged groups, in `start` order;
+     *   2. [mainNightIndex] scores the BRIDGED spans (so a two-fragment night's combined span out-scores a
+     *      lone nap) and picks the winning bridged group;
+     *   3. the original indices of that winning group are returned, ascending.
+     *
+     *  Null only for an empty list. A day with no bridgeable gap collapses to the single-block group the bare
+     *  [mainNightIndex] would pick — byte-identical to the old behaviour for the common case. Pure +
+     *  deterministic; shares the [bridgedNightGroups] pass + [mainNightIndex] so the pick stays
+     *  cross-platform stable. Mirrors Swift `mainNightGroupIndices`. (#561) */
+    fun mainNightGroupIndices(blocks: List<NightBlock>, offsetSec: Long, habitualMidsleepSec: Long? = null): List<Int>? {
+        if (blocks.isEmpty()) return null
+        val all = bridgedNightGroups(blocks, offsetSec)
+        // Rebuild each group's bridged span for scoring: sorted-ascending fragments make the span
+        // (first start, running-max end) — identical to the span the one-pass loop accumulated.
+        val bridgedSpans = all.map { g ->
+            NightBlock(g.indices.minOf { blocks[it].start }, g.indices.maxOf { blocks[it].end })
+        }
+        val winner = mainNightIndex(bridgedSpans, offsetSec, habitualMidsleepSec) ?: return null
+        return all[winner].indices
     }
 
     /** Index of the day's MAIN night among [blocks], by the LEARNED-TIMING SCORE (replaces the old hard

--- a/android/app/src/main/java/com/noop/ingest/HealthConnectWriter.kt
+++ b/android/app/src/main/java/com/noop/ingest/HealthConnectWriter.kt
@@ -194,14 +194,19 @@ object HealthConnectWriter {
      * split yet — only the validated asleep-vs-awake distinction is shared so we don't over-claim the
      * stager's precision). Uses the MERGED view (imported wins, on-device-computed gap-fills) so a
      * strap-only user's locally-computed nights (stored under the "-noop" computed id) are included.
-     * The clientRecordId keys off the immutable detected startTs so a re-write upserts in place.
+     * #364 — fragments are grouped into BRIDGED NIGHTS (the same #561 bridge the daily totals score
+     * with), so a night split by a brief mid-night wake exports as ONE record whose gap is an AWAKE
+     * stage; the clientRecordId keys off the group's earliest fragment's immutable detected startTs,
+     * and the absorbed fragments' old per-fragment records are DELETED (HC upserts by id but never
+     * removes an id we stop writing).
      */
     private suspend fun writeSleep(client: HealthConnectClient, repo: WhoopRepository, deviceId: String): Int {
         val now = System.currentTimeMillis() / 1000
         val floor = now - WINDOW_DAYS * 86_400
         val sessions = repo.sleepSessionsMerged(deviceId, from = floor, to = now)
-            .map { HealthExportPlan.SleepInput(it.startTs, it.endTs, it.stagesJSON) }
-        val plans = HealthExportPlan.sleepSessions(sessions, now)
+            .map { HealthExportPlan.SleepInput(it.startTs, it.effectiveStartTs, it.endTs, it.stagesJSON) }
+        val offsetSec = (java.util.TimeZone.getDefault().getOffset(now * 1000) / 1000).toLong()
+        val plans = HealthExportPlan.sleepSessions(sessions, now, offsetSec)
         if (plans.isEmpty()) return 0
 
         val zone = ZoneId.systemDefault()
@@ -222,6 +227,15 @@ object HealthConnectWriter {
                 },
                 metadata = Metadata(clientRecordId = p.clientId, clientRecordVersion = p.endSec),
             )
+        }
+        // Clear absorbed fragments' old records BEFORE the merged upsert, so a night previously
+        // exported as two entries never lingers as one merged + one stale fragment. (#364)
+        val absorbed = plans.flatMap { it.absorbedClientIds }
+        if (absorbed.isNotEmpty()) {
+            runCatching {
+                client.deleteRecords(SleepSessionRecord::class,
+                    recordIdsList = emptyList(), clientRecordIdsList = absorbed)
+            }
         }
         return insertChunked(client, records)
     }

--- a/android/app/src/main/java/com/noop/ingest/HealthExportPlan.kt
+++ b/android/app/src/main/java/com/noop/ingest/HealthExportPlan.kt
@@ -76,22 +76,56 @@ object HealthExportPlan {
 
     // ---- Sleep sessions: AWAKE vs SLEEPING only (fine stages deferred until stager validated) ----
 
-    data class SleepInput(val startTs: Long, val endTs: Long, val stagesJSON: String?)
+    /** One stored fragment as the export sees it: [keyStartTs] is the immutable detected onset (the
+     *  dedup identity — a user edit must never change it), [startTs] the EFFECTIVE onset that drives
+     *  the exported span (`startTsAdjusted ?: startTs`, iOS parity #318). */
+    data class SleepInput(val keyStartTs: Long, val startTs: Long, val endTs: Long, val stagesJSON: String?)
     data class StagePlan(val startSec: Long, val endSec: Long, val asleep: Boolean)
     data class SleepPlan(
         val clientId: String,
         val startSec: Long,
         val endSec: Long,
         val stages: List<StagePlan>,
+        /** The non-representative fragments' old per-fragment ids (`noop-sleep-<keyStartTs>`). Health
+         *  Connect upserts by clientRecordId but never removes an id we stop writing, so a night that
+         *  previously exported as two records would orphan the second when it becomes one — the
+         *  writer deletes these explicitly. Empty for a single-fragment night. (#364) */
+        val absorbedClientIds: List<String> = emptyList(),
     )
 
-    /** Finalized sessions (endTs <= [nowSec]) only; never the currently-open night. */
-    fun sleepSessions(sessions: List<SleepInput>, nowSec: Long): List<SleepPlan> {
+    /** Finalized sessions (endTs <= [nowSec]) only; never the currently-open night. Fragments are
+     *  grouped into BRIDGED NIGHTS (#364) via [SleepStageTotals.bridgedNightGroups] — the SAME
+     *  two-tier bridge the daily totals score with (#561/#861) — so a night the detector split on a
+     *  brief mid-night wake exports as ONE session whose gap is an explicit AWAKE stage; naps never
+     *  bridge and stay their own records. The clientRecordId keys off the group's EARLIEST fragment's
+     *  immutable detected onset. [offsetSec] is seconds EAST of UTC (the night-tail bridge reads the
+     *  local clock). */
+    fun sleepSessions(sessions: List<SleepInput>, nowSec: Long, offsetSec: Long): List<SleepPlan> {
+        val finalized = sessions.filter { it.endTs > it.startTs && it.endTs <= nowSec }
+        if (finalized.isEmpty()) return emptyList()
+        val blocks = finalized.map { com.noop.analytics.SleepStageTotals.NightBlock(it.startTs, it.endTs) }
         val out = ArrayList<SleepPlan>()
-        for (s in sessions) {
-            if (s.endTs <= s.startTs) continue
-            if (s.endTs > nowSec) continue
-            out.add(SleepPlan("noop-sleep-${s.startTs}", s.startTs, s.endTs, parseStages(s.stagesJSON)))
+        for (group in com.noop.analytics.SleepStageTotals.bridgedNightGroups(blocks, offsetSec)) {
+            val frags = group.indices.map { finalized[it] }.sortedBy { it.startTs }
+            val stages = ArrayList<StagePlan>()
+            var prevEnd: Long? = null
+            for (f in frags) {
+                val p = prevEnd
+                // The inter-fragment seam is time the user was demonstrably awake — export it as an
+                // explicit AWAKE stage so the merged night carries the wake instead of a silent hole.
+                if (p != null && f.startTs > p) stages.add(StagePlan(p, f.startTs, asleep = false))
+                stages.addAll(parseStages(f.stagesJSON))
+                prevEnd = maxOf(prevEnd ?: f.endTs, f.endTs)
+            }
+            val rep = frags.minOf { it.keyStartTs }
+            out.add(SleepPlan(
+                clientId = "noop-sleep-$rep",
+                startSec = frags.first().startTs,
+                endSec = frags.maxOf { it.endTs },
+                stages = stages,
+                absorbedClientIds = frags.map { it.keyStartTs }.filter { it != rep }
+                    .sorted().map { "noop-sleep-$it" },
+            ))
         }
         return out
     }

--- a/android/app/src/main/java/com/noop/ui/SleepScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/SleepScreen.kt
@@ -2824,13 +2824,25 @@ internal fun selectNight(
     // #259: clamp each fragment's timeline to its effective onset too (matching the stage-minute clamp
     // and the iOS decodeSegments clamp), so the hypnogram starts where the edited bedtime does instead of
     // drawing pre-onset bars that contradict the clamped asleep total. No-op for non-edited nights.
-    val groupSegments = if (heroGroup.size > 1) {
+    val groupSegmentsRaw = if (heroGroup.size > 1) {
         heroGroup.flatMap { parsePersistedSegments(SleepStageTotals.clampStagesToOnset(it.stagesJSON, it.effectiveStartTs)).orEmpty() }
             .sortedBy { it.start }
             .takeIf { it.size >= 2 }
     } else null
+    // #364: draw each inter-fragment wake seam as an explicit wake segment in the full-night
+    // hypnogram, so the merged night has no silent hole where the user was up — matching what the
+    // Health Connect export now writes. TIMELINE only: the seam is deliberately NOT added to the
+    // stage MINUTES (sumGroupStages) or groupInBedMin below — those keep the fragment-only
+    // accounting (asleep ≤ in-bed, see the #561 comment), and iOS mergeDay applies the same split.
+    val groupSegments = groupSegmentsRaw?.let { segs ->
+        val seams = heroGroup.zipWithNext().mapNotNull { (prev, next) ->
+            if (next.effectiveStartTs > prev.endTs)
+                PersistedSegment(prev.endTs, next.effectiveStartTs, "wake") else null
+        }
+        (segs + seams).sortedBy { it.start }
+    }
     val groupStages = if (heroGroup.size > 1) sumGroupStages(heroGroup) else null
-    val segments = (groupSegments ?: parsePersistedSegments(SleepStageTotals.clampStagesToOnset(session.stagesJSON, session.effectiveStartTs)))
+    val segments = (groupSegmentsRaw ?: parsePersistedSegments(SleepStageTotals.clampStagesToOnset(session.stagesJSON, session.effectiveStartTs)))
         ?.map { seg -> seg.stage to ((seg.end - seg.start) / 60f) }
     // #407: lay the GROUP's per-epoch motion fragment-by-fragment in `heroGroup` order (the same order
     // `groupSegments` lays the stage timeline), reading the already-chosen group's stored series. The

--- a/android/app/src/test/java/com/noop/analytics/BridgedNightGroupsTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/BridgedNightGroupsTest.kt
@@ -1,0 +1,119 @@
+package com.noop.analytics
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Pins the all-groups bridge (#364): the SAME two-tier gap bridge the main-night selector applies
+ * (#561 short-wake + #861 overnight night-tail), returned for EVERY group with each group's
+ * inter-fragment wake seams explicit — so the Health Connect export and the Sleep screen can present
+ * a briefly-interrupted night as ONE night without re-deriving (or diverging from) the bridge.
+ *
+ * Faithful Kotlin mirror of BridgedNightGroupsTests.swift: same fixtures, same expected values.
+ */
+class BridgedNightGroupsTest {
+
+    /** 2026-01-02 00:00:00 UTC — fixtures read as local clock times with offsetSec 0. */
+    private val t0 = 1_767_312_000L
+    private fun b(start: Long, end: Long) = SleepStageTotals.NightBlock(start, end)
+
+    @Test
+    fun shortWakeBridgesTwoFragmentsWithOneGap() {
+        // The #364 example shape: 23:00→02:00, a 16-minute wake, 02:16→06:00.
+        val a = b(t0 - 3_600, t0 + 2 * 3_600)
+        val c = b(t0 + 2 * 3_600 + 16 * 60, t0 + 6 * 3_600)
+        val groups = SleepStageTotals.bridgedNightGroups(listOf(a, c), 0L)
+        assertEquals(1, groups.size)
+        assertEquals(listOf(0, 1), groups[0].indices)
+        assertEquals(listOf(a.end to c.start), groups[0].gaps)
+    }
+
+    @Test
+    fun daytimeNapStaysItsOwnGroup() {
+        val night = b(t0 - 3_600, t0 + 6 * 3_600)              // 23:00→06:00
+        val nap = b(t0 + 14 * 3_600, t0 + 15 * 3_600)          // 14:00→15:00
+        val groups = SleepStageTotals.bridgedNightGroups(listOf(night, nap), 0L)
+        assertEquals(listOf(listOf(0), listOf(1)), groups.map { it.indices })
+        assertTrue(groups.all { it.gaps.isEmpty() })
+    }
+
+    @Test
+    fun nightTailBridgesOvernightGapOverSixtyMinutes() {
+        // 75-min gap with the second fragment's onset at 04:15 local (overnight band): folded in by
+        // the #861 night-tail bridge, so a longer real mid-night wake still reads as one night.
+        val a = b(t0 - 3_600, t0 + 3 * 3_600)
+        val c = b(t0 + 3 * 3_600 + 75 * 60, t0 + 7 * 3_600)
+        val groups = SleepStageTotals.bridgedNightGroups(listOf(a, c), 0L)
+        assertEquals(listOf(listOf(0, 1)), groups.map { it.indices })
+        assertEquals(listOf(a.end to c.start), groups[0].gaps)
+    }
+
+    @Test
+    fun daytimeGapOverSixtyMinutesDoesNotBridge() {
+        // Same 75-min gap but the second fragment begins at 13:15 local (daytime): the night-tail
+        // widening must NOT apply, so the blocks stay separate groups (a real afternoon nap).
+        val a = b(t0 + 9 * 3_600, t0 + 12 * 3_600)
+        val c = b(t0 + 12 * 3_600 + 75 * 60, t0 + 14 * 3_600)
+        val groups = SleepStageTotals.bridgedNightGroups(listOf(a, c), 0L)
+        assertEquals(listOf(listOf(0), listOf(1)), groups.map { it.indices })
+    }
+
+    @Test
+    fun threeFragmentNightYieldsTwoGaps() {
+        val a = b(t0, t0 + 3_600)
+        val c = b(t0 + 3_600 + 600, t0 + 2 * 3_600)
+        val d = b(t0 + 2 * 3_600 + 900, t0 + 3 * 3_600)
+        val groups = SleepStageTotals.bridgedNightGroups(listOf(a, c, d), 0L)
+        assertEquals(listOf(listOf(0, 1, 2)), groups.map { it.indices })
+        assertEquals(listOf(a.end to c.start, c.end to d.start), groups[0].gaps)
+    }
+
+    @Test
+    fun overlappingFragmentStartsItsOwnGroup() {
+        // Legacy semantics pinned: a negative gap (fragment starting inside the previous span) does
+        // NOT bridge — `mainNightGroupIndices` has always required gap >= 0, and the refactor must
+        // not change the pick. No seam is fabricated either.
+        val a = b(t0, t0 + 4 * 3_600)
+        val c = b(t0 + 3_600, t0 + 2 * 3_600)
+        val groups = SleepStageTotals.bridgedNightGroups(listOf(a, c), 0L)
+        assertEquals(listOf(listOf(0), listOf(1)), groups.map { it.indices })
+        assertTrue(groups.all { it.gaps.isEmpty() })
+    }
+
+    @Test
+    fun zeroGapBridgesWithoutSeam() {
+        // Touching fragments (gap == 0) bridge, and no zero-length seam is emitted.
+        val a = b(t0, t0 + 3_600)
+        val c = b(t0 + 3_600, t0 + 2 * 3_600)
+        val groups = SleepStageTotals.bridgedNightGroups(listOf(a, c), 0L)
+        assertEquals(listOf(listOf(0, 1)), groups.map { it.indices })
+        assertTrue(groups[0].gaps.isEmpty())
+    }
+
+    @Test
+    fun unsortedInputIndicesReferToOriginalPositions() {
+        // Input order reversed: indices still point into the ORIGINAL list (late = 0, early = 1),
+        // returned ascending within the group.
+        val late = b(t0 + 2 * 3_600 + 16 * 60, t0 + 6 * 3_600)
+        val early = b(t0 - 3_600, t0 + 2 * 3_600)
+        val groups = SleepStageTotals.bridgedNightGroups(listOf(late, early), 0L)
+        assertEquals(listOf(listOf(0, 1)), groups.map { it.indices })
+        assertEquals(listOf(early.end to late.start), groups[0].gaps)
+    }
+
+    @Test
+    fun emptyInputYieldsNoGroups() {
+        assertTrue(SleepStageTotals.bridgedNightGroups(emptyList(), 0L).isEmpty())
+    }
+
+    /** The refactor guard: the main-night pick over the all-groups pass stays byte-identical for a
+     *  biphasic night + nap day (MainNightConsistencyTest pins the rest of the behaviour). */
+    @Test
+    fun mainNightGroupIndicesUnchangedForBiphasicPlusNap() {
+        val a = b(t0 - 3_600, t0 + 2 * 3_600)
+        val c = b(t0 + 2 * 3_600 + 16 * 60, t0 + 6 * 3_600)
+        val nap = b(t0 + 14 * 3_600, t0 + 15 * 3_600)
+        assertEquals(listOf(0, 1), SleepStageTotals.mainNightGroupIndices(listOf(a, c, nap), 0L))
+    }
+}

--- a/android/app/src/test/java/com/noop/ingest/HealthExportPlanTest.kt
+++ b/android/app/src/test/java/com/noop/ingest/HealthExportPlanTest.kt
@@ -83,20 +83,25 @@ class HealthExportPlanTest {
 
     // ---- Sleep session tests ----
 
+    /** Unedited fragment: key == effective onset (the common case). */
+    private fun input(start: Long, end: Long, json: String? = null) =
+        HealthExportPlan.SleepInput(keyStartTs = start, startTs = start, endTs = end, stagesJSON = json)
+
     @Test fun sleep_excludesUnfinalizedSessions() {
-        val sessions = listOf(HealthExportPlan.SleepInput(startTs = 100, endTs = 900, stagesJSON = null))
-        val out = HealthExportPlan.sleepSessions(sessions, nowSec = 500L) // ends in the future
+        val sessions = listOf(input(100, 900))
+        val out = HealthExportPlan.sleepSessions(sessions, nowSec = 500L, offsetSec = 0L) // ends in the future
         assertTrue(out.isEmpty())
     }
 
     @Test fun sleep_emitsFinalizedSessionWithClientId() {
-        val sessions = listOf(HealthExportPlan.SleepInput(100, 900, null))
-        val out = HealthExportPlan.sleepSessions(sessions, nowSec = 1000L)
+        val sessions = listOf(input(100, 900))
+        val out = HealthExportPlan.sleepSessions(sessions, nowSec = 1000L, offsetSec = 0L)
         assertEquals(1, out.size)
         assertEquals("noop-sleep-100", out[0].clientId)
         assertEquals(100L, out[0].startSec)
         assertEquals(900L, out[0].endSec)
         assertTrue(out[0].stages.isEmpty()) // null stagesJSON -> session bounds only
+        assertTrue(out[0].absorbedClientIds.isEmpty())
     }
 
     @Test fun sleep_mapsWakeVsAsleepAndCoalesces() {
@@ -108,7 +113,7 @@ class HealthExportPlanTest {
              {"start":500,"end":600,"stage":"rem"}]
         """.trimIndent()
         val out = HealthExportPlan.sleepSessions(
-            listOf(HealthExportPlan.SleepInput(100, 600, json)), nowSec = 1000L)
+            listOf(input(100, 600, json)), nowSec = 1000L, offsetSec = 0L)
         val stages = out[0].stages
         // light+deep coalesce -> asleep[100,300); wake+awake coalesce -> awake[300,500); rem -> asleep[500,600)
         assertEquals(3, stages.size)
@@ -119,7 +124,7 @@ class HealthExportPlanTest {
 
     @Test fun sleep_malformedJsonYieldsNoStagesButKeepsSession() {
         val out = HealthExportPlan.sleepSessions(
-            listOf(HealthExportPlan.SleepInput(100, 900, "not json")), nowSec = 1000L)
+            listOf(input(100, 900, "not json")), nowSec = 1000L, offsetSec = 0L)
         assertEquals(1, out.size)
         assertTrue(out[0].stages.isEmpty())
     }
@@ -127,7 +132,7 @@ class HealthExportPlanTest {
     @Test fun sleep_includesSessionEndingExactlyAtNow() {
         // endTs == nowSec is finalized (the session has ended); locks in the boundary contract.
         val out = HealthExportPlan.sleepSessions(
-            listOf(HealthExportPlan.SleepInput(100, 1000, null)), nowSec = 1000L)
+            listOf(input(100, 1000)), nowSec = 1000L, offsetSec = 0L)
         assertEquals(1, out.size)
     }
 
@@ -140,7 +145,7 @@ class HealthExportPlanTest {
              {"start":300,"end":400,"stage":"deep"}]
         """.trimIndent()
         val out = HealthExportPlan.sleepSessions(
-            listOf(HealthExportPlan.SleepInput(100, 400, json)), nowSec = 1000L)
+            listOf(input(100, 400, json)), nowSec = 1000L, offsetSec = 0L)
         val stages = out[0].stages
         // light[100,200) and deep[300,400) both asleep but NOT contiguous (gap 200..300) -> 2 segments.
         assertEquals(2, stages.size)
@@ -151,11 +156,53 @@ class HealthExportPlanTest {
     @Test fun sleep_skipsInvertedOrZeroLengthSession() {
         val out = HealthExportPlan.sleepSessions(
             listOf(
-                HealthExportPlan.SleepInput(500, 500, null), // zero-length
-                HealthExportPlan.SleepInput(900, 400, null), // inverted
+                input(500, 500), // zero-length
+                input(900, 400), // inverted
             ),
             nowSec = 10_000L,
+            offsetSec = 0L,
         )
         assertTrue(out.isEmpty())
+    }
+
+    // ---- #364: bridged-night grouping (twin of the Swift mergedSleepPlan tests) ----
+
+    @Test fun sleep_foldsBridgedFragmentsWithAwakeSeam() {
+        // 2026-01-02 00:00 UTC. Two fragments split by a 16-minute wake -> ONE record whose seam is
+        // an explicit AWAKE stage; the clientRecordId keys off the earliest fragment; the absorbed
+        // fragment's old per-fragment id is surfaced for deletion.
+        val t = 1_767_312_000L
+        val a = input(t - 3_600, t + 2 * 3_600, """[{"start":${t - 3_600},"end":${t + 2 * 3_600},"stage":"light"}]""")
+        val b = input(t + 2 * 3_600 + 960, t + 6 * 3_600,
+            """[{"start":${t + 2 * 3_600 + 960},"end":${t + 6 * 3_600},"stage":"deep"}]""")
+        val plans = HealthExportPlan.sleepSessions(listOf(a, b), nowSec = t + 86_400, offsetSec = 0L)
+        assertEquals(1, plans.size)
+        val p = plans[0]
+        assertEquals("noop-sleep-${t - 3_600}", p.clientId)
+        assertEquals(t - 3_600, p.startSec)
+        assertEquals(t + 6 * 3_600, p.endSec)
+        assertEquals(listOf("noop-sleep-${t + 2 * 3_600 + 960}"), p.absorbedClientIds)
+        assertTrue(p.stages.contains(
+            HealthExportPlan.StagePlan(t + 2 * 3_600, t + 2 * 3_600 + 960, asleep = false)))
+    }
+
+    @Test fun sleep_napStaysItsOwnPlanWithNoAbsorbedIds() {
+        val t = 1_767_312_000L
+        val night = input(t - 3_600, t + 6 * 3_600)
+        val nap = input(t + 14 * 3_600, t + 15 * 3_600)      // 14:00 local, hours away -> own record
+        val plans = HealthExportPlan.sleepSessions(listOf(night, nap), nowSec = t + 86_400, offsetSec = 0L)
+        assertEquals(2, plans.size)
+        assertTrue(plans.all { it.absorbedClientIds.isEmpty() })
+        assertEquals("noop-sleep-${t - 3_600}", plans[0].clientId)
+        assertEquals("noop-sleep-${t + 14 * 3_600}", plans[1].clientId)
+    }
+
+    @Test fun sleep_editedOnsetMovesSpanButClientIdStaysImmutable() {
+        val t = 1_767_312_000L
+        val edited = HealthExportPlan.SleepInput(
+            keyStartTs = t, startTs = t + 600, endTs = t + 7_200, stagesJSON = null)
+        val p = HealthExportPlan.sleepSessions(listOf(edited), nowSec = t + 86_400, offsetSec = 0L)[0]
+        assertEquals("noop-sleep-$t", p.clientId)   // immutable detected key
+        assertEquals(t + 600, p.startSec)           // edited onset drives the span
     }
 }


### PR DESCRIPTION
Lands the #364 sleep-stitch under the NoopApp identity (reimplemented from the community PR #374, which is closed unmerged per the repo's contribution flow). Reuses the existing #561/#861 bridge at display time; detector/stored sessions untouched, no migration.

Fully validated: Swift package CI green (StrandAnalytics golden + StrandImport HealthWriteback), Android golden + BridgedNightGroups + HealthExportPlan tests green locally, and app-build green on Strand (macOS) + NOOPiOS (iOS). See #374 for the detailed review.