### PR TITLE
fix(import): parse Apple Health <WorkoutStatistics> for per-workout energy/distance/HR

### DIFF
--- a/Packages/StrandImport/Sources/StrandImport/AppleHealthImporter.swift
+++ b/Packages/StrandImport/Sources/StrandImport/AppleHealthImporter.swift
@@ -269,6 +269,11 @@ final class HealthXMLDelegate: NSObject, XMLParserDelegate {
     // Depth of the current Correlation, if inside one. Records nested inside a
     // Correlation are skipped (they also appear top-level).
     private var correlationDepth = 0
+    // The <Workout> currently being assembled. Built at the `<Workout>` start tag from its legacy
+    // attributes, filled by any nested `<WorkoutStatistics>` children (iOS 16+), and appended to
+    // `workouts` at the `</Workout>` end tag. nil when not inside a workout. Workouts never nest and
+    // never appear inside a Correlation, so a single slot (not a stack) is sufficient.
+    private var pendingWorkout: HealthWorkout?
 
     // Dedupe set over HealthSample dedupeKeys — stored as the key's 64-bit HASH, not the full String
     // (#183). A large Apple Health export has tens of millions of unique samples; retaining a ~50-100 B
@@ -328,6 +333,10 @@ final class HealthXMLDelegate: NSObject, XMLParserDelegate {
             case "Workout":
                 handleWorkout(attributeDict)
 
+            case "WorkoutStatistics":
+                // iOS 16+ nests per-workout energy/distance/HR here (was <Workout> attributes on iOS <=15).
+                handleWorkoutStatistics(attributeDict)
+
             default:
                 break
             }
@@ -342,6 +351,10 @@ final class HealthXMLDelegate: NSObject, XMLParserDelegate {
     ) {
         if elementName == "Correlation", correlationDepth > 0 {
             correlationDepth -= 1
+        }
+        if elementName == "Workout" {
+            // The whole <Workout> sub-tree (including any <WorkoutStatistics>) has now been seen; commit it.
+            finishWorkout()
         }
         if stack.last == elementName {
             stack.removeLast()
@@ -500,20 +513,19 @@ final class HealthXMLDelegate: NSObject, XMLParserDelegate {
             }
         }
 
-        let distanceM = attrs["totalDistance"].flatMap { Double($0) }.map { meters -> Double in
-            let unit = (attrs["totalDistanceUnit"] ?? "km").lowercased()
-            switch unit {
-            case "km": return meters * 1000.0
-            case "mi": return meters * 1609.344
-            case "m":  return meters
-            default:   return meters * 1000.0
-            }
-        }
-
+        // iOS <=15 put per-workout totals on <Workout> as `totalDistance`/`totalEnergyBurned`; iOS 16+
+        // moved them into nested <WorkoutStatistics> children (folded in by `handleWorkoutStatistics`).
+        // Seed the pending workout from the legacy attributes; the children FILL any still absent — a
+        // modern export carries no legacy attributes, so nothing a legacy value set is clobbered.
+        let distanceM = attrs["totalDistance"].flatMap { Double($0) }
+            .map { Self.distanceMeters($0, unit: attrs["totalDistanceUnit"]) }
         let energyKcal = attrs["totalEnergyBurned"].flatMap { Double($0) }
         // Apple exports energy in kcal by default (totalEnergyBurnedUnit "kcal").
 
-        let workout = HealthWorkout(
+        // Defer the append / counts to `finishWorkout()` at `</Workout>`, once any statistics children
+        // have folded in. A truncated workout with no end tag is simply dropped (its tail is counted a
+        // skipped span upstream), never counted as a complete row.
+        pendingWorkout = HealthWorkout(
             activityType: activity,
             durationS: durationS,
             distanceM: distanceM,
@@ -523,13 +535,52 @@ final class HealthXMLDelegate: NSObject, XMLParserDelegate {
             tzOffsetMin: endOffset,
             sourceName: attrs["sourceName"]
         )
+    }
+
+    /// Fold one `<WorkoutStatistics>` child into the workout currently being assembled. iOS 16+ emits
+    /// per-metric totals here: energy/distance as `sum`, heart rate as `average`/`maximum`. Fills only a
+    /// field still absent, so a legacy attribute value already set is never overwritten.
+    private func handleWorkoutStatistics(_ attrs: [String: String]) {
+        guard var workout = pendingWorkout, let rawType = attrs["type"] else { return }
+        let type = Self.stripPrefix(rawType)
+        switch type {
+        case "ActiveEnergyBurned":
+            if workout.energyKcal == nil { workout.energyKcal = attrs["sum"].flatMap { Double($0) } }
+        case "HeartRate":
+            if workout.avgHr == nil { workout.avgHr = attrs["average"].flatMap { Double($0) } }
+            if workout.maxHr == nil { workout.maxHr = attrs["maximum"].flatMap { Double($0) } }
+        default:
+            if type.hasPrefix("Distance"), workout.distanceM == nil {
+                workout.distanceM = attrs["sum"].flatMap { Double($0) }
+                    .map { Self.distanceMeters($0, unit: attrs["unit"]) }
+            }
+        }
+        pendingWorkout = workout
+    }
+
+    /// Commit the assembled workout at `</Workout>`: append it and fold its start into the summary's
+    /// counts + date span (deferred here so any statistics children are already in). No-op when not in a
+    /// workout (a stray end tag) or when the start tag was rejected for bad dates.
+    private func finishWorkout() {
+        guard let workout = pendingWorkout else { return }
+        pendingWorkout = nil
         workouts.append(workout)
         countsByType["Workout", default: 0] += 1
         anyRecordSeen = true
         // Workouts don't go through appendSample, so track their start in the
         // incremental date span too (matches the prior summary).
-        if earliestDate == nil || start < earliestDate! { earliestDate = start }
-        if latestDate == nil || start > latestDate! { latestDate = start }
+        if earliestDate == nil || workout.start < earliestDate! { earliestDate = workout.start }
+        if latestDate == nil || workout.start > latestDate! { latestDate = workout.start }
+    }
+
+    /// Convert a distance value in `km` / `mi` / `m` to metres (defaulting to km, Apple's usual unit).
+    static func distanceMeters(_ value: Double, unit: String?) -> Double {
+        switch (unit ?? "km").lowercased() {
+        case "km": return value * 1000.0
+        case "mi": return value * 1609.344
+        case "m":  return value
+        default:   return value * 1000.0
+        }
     }
 
     // MARK: Result

--- a/Packages/StrandImport/Sources/StrandImport/ImportModels.swift
+++ b/Packages/StrandImport/Sources/StrandImport/ImportModels.swift
@@ -95,6 +95,10 @@ public struct HealthWorkout: Sendable, Equatable {
     public var distanceM: Double?
     /// Total active energy burned in kilocalories, when present.
     public var energyKcal: Double?
+    /// Average heart rate over the workout, when present (iOS 16+ `<WorkoutStatistics>` only).
+    public var avgHr: Double?
+    /// Peak heart rate over the workout, when present (iOS 16+ `<WorkoutStatistics>` only).
+    public var maxHr: Double?
     public var start: Date
     public var end: Date
     public var tzOffsetMin: Int
@@ -105,6 +109,8 @@ public struct HealthWorkout: Sendable, Equatable {
         durationS: Double?,
         distanceM: Double?,
         energyKcal: Double?,
+        avgHr: Double? = nil,
+        maxHr: Double? = nil,
         start: Date,
         end: Date,
         tzOffsetMin: Int,
@@ -114,6 +120,8 @@ public struct HealthWorkout: Sendable, Equatable {
         self.durationS = durationS
         self.distanceM = distanceM
         self.energyKcal = energyKcal
+        self.avgHr = avgHr
+        self.maxHr = maxHr
         self.start = start
         self.end = end
         self.tzOffsetMin = tzOffsetMin

--- a/Packages/StrandImport/Tests/StrandImportTests/AppleHealthImporterTests.swift
+++ b/Packages/StrandImport/Tests/StrandImportTests/AppleHealthImporterTests.swift
@@ -122,6 +122,34 @@ final class AppleHealthImporterTests: XCTestCase {
         XCTAssertEqual(w.tzOffsetMin, 60)
     }
 
+    /// iOS 16+ shape: per-workout energy/distance/HR live in nested <WorkoutStatistics> children, not as
+    /// <Workout> attributes. The parser must fold them in, or every modern-export workout imports as a
+    /// bare shell (no energy/distance/HR) and de-dups noisily. The MetadataEntry child confirms the
+    /// deferred commit ignores non-statistics children. Kotlin twin:
+    /// `AppleHealthImporterToleranceTest.modernWorkoutStatisticsRecoversEnergyDistanceAndHr`.
+    func testWorkoutStatisticsModernExport() throws {
+        let xml = """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <HealthData>
+         <Workout workoutActivityType="HKWorkoutActivityTypeRunning" duration="45" durationUnit="min" sourceName="Watch" startDate="2024-01-02 16:00:00 +0000" endDate="2024-01-02 16:45:00 +0000">
+          <WorkoutStatistics type="HKQuantityTypeIdentifierActiveEnergyBurned" startDate="2024-01-02 16:00:00 +0000" endDate="2024-01-02 16:45:00 +0000" sum="540" unit="Cal"/>
+          <WorkoutStatistics type="HKQuantityTypeIdentifierDistanceWalkingRunning" startDate="2024-01-02 16:00:00 +0000" endDate="2024-01-02 16:45:00 +0000" sum="8.05" unit="km"/>
+          <WorkoutStatistics type="HKQuantityTypeIdentifierHeartRate" startDate="2024-01-02 16:00:00 +0000" endDate="2024-01-02 16:45:00 +0000" average="150" minimum="98" maximum="176" unit="count/min"/>
+          <MetadataEntry key="HKIndoorWorkout" value="0"/>
+         </Workout>
+        </HealthData>
+        """
+        let r = try AppleHealthImporter().importXML(data: Data(xml.utf8))
+        XCTAssertEqual(r.workouts.count, 1)
+        let w = try XCTUnwrap(r.workouts.first)
+        XCTAssertEqual(w.activityType, "Running")
+        XCTAssertEqual(w.durationS, 45 * 60)
+        XCTAssertEqual(try XCTUnwrap(w.energyKcal), 540, accuracy: 1e-9)   // sum, Cal == kcal
+        XCTAssertEqual(try XCTUnwrap(w.distanceM), 8050, accuracy: 0.5)    // 8.05 km -> ~8050 m
+        XCTAssertEqual(try XCTUnwrap(w.avgHr), 150, accuracy: 1e-9)        // WorkoutStatistics average
+        XCTAssertEqual(try XCTUnwrap(w.maxHr), 176, accuracy: 1e-9)        // WorkoutStatistics maximum
+    }
+
     // MARK: - Prefix stripping
 
     func testStripPrefix() {

--- a/Strand/Data/AppleHealthImport.swift
+++ b/Strand/Data/AppleHealthImport.swift
@@ -63,7 +63,8 @@ enum AppleHealthImport {
                        endTs: Int(w.end.timeIntervalSince1970),
                        sport: w.activityType, source: WorkoutSource.appleHealthSource,
                        durationS: w.durationS, energyKcal: w.energyKcal,
-                       avgHr: nil, maxHr: nil, strain: nil,
+                       avgHr: w.avgHr.map { Int($0.rounded()) },
+                       maxHr: w.maxHr.map { Int($0.rounded()) }, strain: nil,
                        distanceM: w.distanceM, zonesJSON: nil, notes: nil)
         }
         let workoutsWritten = try await store.upsertWorkouts(workouts, deviceId: deviceId)

--- a/android/app/src/main/java/com/noop/ingest/AppleHealthImporter.kt
+++ b/android/app/src/main/java/com/noop/ingest/AppleHealthImporter.kt
@@ -309,23 +309,54 @@ object AppleHealthImporter {
             }
         }
 
-        var distanceM: Double? = null
-        val distStr = attr(parser, "totalDistance")
-        if (distStr != null) {
-            val dist = distStr.toDoubleOrNull()
-            if (dist != null) {
-                distanceM = when ((attr(parser, "totalDistanceUnit") ?: "km").lowercase()) {
-                    "km" -> dist * 1000.0
-                    "mi" -> dist * 1609.344
-                    "m" -> dist
-                    else -> dist * 1000.0
+        // Per-workout totals: iOS <=15 put them on the <Workout> element as `totalDistance` /
+        // `totalEnergyBurned` attributes; iOS 16+ moved them into nested <WorkoutStatistics> children
+        // (energy/distance now `type`+`sum`, heart rate `average`/`maximum`). Read the legacy attributes
+        // first, then let the children FILL any still absent — a modern export carries no legacy
+        // attributes so nothing a legacy value set is clobbered. Mirrors HealthXMLDelegate.handleWorkout.
+        var distanceM: Double? = attr(parser, "totalDistance")?.toDoubleOrNull()
+            ?.let { distanceMeters(it, attr(parser, "totalDistanceUnit")) }
+        var energyKcal: Double? = attr(parser, "totalEnergyBurned")?.toDoubleOrNull()
+        var avgHr: Double? = null
+        var maxHr: Double? = null
+
+        // Walk this workout's own sub-tree. A self-closing <WorkoutStatistics/> yields START_TAG then
+        // END_TAG, so relative-depth tracking (1 inside the open <Workout>, back to 0 at </Workout>)
+        // consumes each child exactly once and skips MetadataEntry / WorkoutEvent / WorkoutRoute.
+        var depth = 1
+        while (depth > 0) {
+            val ev = parser.next()
+            if (ev == XmlPullParser.END_DOCUMENT) break
+            if (ev == XmlPullParser.START_TAG) {
+                if (parser.name == "WorkoutStatistics") {
+                    when (val statType = stripPrefix(attr(parser, "type") ?: "")) {
+                        "ActiveEnergyBurned" ->
+                            if (energyKcal == null) energyKcal = attr(parser, "sum")?.toDoubleOrNull()
+                        "HeartRate" -> {
+                            if (avgHr == null) avgHr = attr(parser, "average")?.toDoubleOrNull()
+                            if (maxHr == null) maxHr = attr(parser, "maximum")?.toDoubleOrNull()
+                        }
+                        else -> if (statType.startsWith("Distance") && distanceM == null) {
+                            distanceM = attr(parser, "sum")?.toDoubleOrNull()
+                                ?.let { distanceMeters(it, attr(parser, "unit")) }
+                        }
+                    }
                 }
+                depth += 1
+            } else if (ev == XmlPullParser.END_TAG) {
+                depth -= 1
             }
         }
 
-        val energyKcal = attr(parser, "totalEnergyBurned")?.toDoubleOrNull()
+        agg.addWorkout(activity, durationS, distanceM, energyKcal, avgHr, maxHr, start, end)
+    }
 
-        agg.addWorkout(activity, durationS, distanceM, energyKcal, start, end)
+    /** Convert a distance value in `km` / `mi` / `m` to metres (defaulting to km, Apple's usual unit). */
+    private fun distanceMeters(value: Double, unit: String?): Double = when ((unit ?: "km").lowercase()) {
+        "km" -> value * 1000.0
+        "mi" -> value * 1609.344
+        "m" -> value
+        else -> value * 1000.0
     }
 
     // ------------------------------------------------------------------------
@@ -478,6 +509,8 @@ object AppleHealthImporter {
         /** Finalized per-day aggregates, ascending by day. */
         val days: List<DailyAggView>,
         val workoutCount: Int,
+        /** Finalized workout rows (exposes energy/distance/HR for the WorkoutStatistics tests). */
+        val workouts: List<WorkoutRow>,
         /** Dropped XML spans (sanitizer-scrubbed runs + hard-error-truncated tail). */
         val skippedSpans: Int,
     )
@@ -495,9 +528,11 @@ object AppleHealthImporter {
         val agg = Aggregator()
         parseXml(input, agg)
         val days = agg.finishDays().map { DailyAggView(it.day, it.avgHr, it.maxHr, it.steps) }
+        val workouts = agg.finishWorkouts(DEFAULT_DEVICE_ID)
         return ParseProbe(
             days = days,
-            workoutCount = agg.finishWorkouts(DEFAULT_DEVICE_ID).size,
+            workoutCount = workouts.size,
+            workouts = workouts,
             skippedSpans = agg.skippedSpanCount(),
         )
     }
@@ -731,6 +766,8 @@ private class Aggregator {
         val durationS: Double?,
         val distanceM: Double?,
         val energyKcal: Double?,
+        val avgHr: Double?,
+        val maxHr: Double?,
     )
 
     /** Returns true if [key] was not seen before (i.e. this row should be processed). Dedupes on the
@@ -818,7 +855,7 @@ private class Aggregator {
         a.hasSleep = true
     }
 
-    fun addWorkout(sport: String, durationS: Double?, distanceM: Double?, energyKcal: Double?, start: HealthDate, end: HealthDate) {
+    fun addWorkout(sport: String, durationS: Double?, distanceM: Double?, energyKcal: Double?, avgHr: Double?, maxHr: Double?, start: HealthDate, end: HealthDate) {
         sawAnyRecord = true
         workouts += PendingWorkout(
             sport = sport,
@@ -827,6 +864,8 @@ private class Aggregator {
             durationS = durationS,
             distanceM = distanceM,
             energyKcal = energyKcal,
+            avgHr = avgHr,
+            maxHr = maxHr,
         )
     }
 
@@ -874,8 +913,8 @@ private class Aggregator {
             source = "apple-health",
             durationS = w.durationS ?: (w.endTs - w.startTs).toDouble(),
             energyKcal = w.energyKcal,
-            avgHr = null,
-            maxHr = null,
+            avgHr = w.avgHr?.let { Math.round(it).toInt() },
+            maxHr = w.maxHr?.let { Math.round(it).toInt() },
             strain = null,
             distanceM = w.distanceM,
             zonesJSON = null,

--- a/android/app/src/test/java/com/noop/ingest/AppleHealthImporterToleranceTest.kt
+++ b/android/app/src/test/java/com/noop/ingest/AppleHealthImporterToleranceTest.kt
@@ -169,4 +169,61 @@ class AppleHealthImporterToleranceTest {
         // The sanitized bytes round-trip to the original (no corruption of the split character).
         assertEquals(String(xml, Charsets.UTF_8), String(out, Charsets.UTF_8))
     }
+
+    /**
+     * iOS 16+ shape: per-workout energy/distance/HR live in nested <WorkoutStatistics> children, NOT
+     * as <Workout> attributes. The importer must read them, or every modern-export workout imports as
+     * a bare shell (no energy/distance/HR) and de-dups noisily. MetadataEntry child confirms the
+     * sub-tree walk skips non-stats children. Mirrors the macOS AppleHealthImporterTests twin.
+     */
+    @Test
+    fun modernWorkoutStatisticsRecoversEnergyDistanceAndHr() {
+        val xml = """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <HealthData>
+             <Workout workoutActivityType="HKWorkoutActivityTypeRunning" duration="45" durationUnit="min" sourceName="Watch" startDate="2024-01-02 16:00:00 +0000" endDate="2024-01-02 16:45:00 +0000">
+              <WorkoutStatistics type="HKQuantityTypeIdentifierActiveEnergyBurned" startDate="2024-01-02 16:00:00 +0000" endDate="2024-01-02 16:45:00 +0000" sum="540" unit="Cal"/>
+              <WorkoutStatistics type="HKQuantityTypeIdentifierDistanceWalkingRunning" startDate="2024-01-02 16:00:00 +0000" endDate="2024-01-02 16:45:00 +0000" sum="8.05" unit="km"/>
+              <WorkoutStatistics type="HKQuantityTypeIdentifierHeartRate" startDate="2024-01-02 16:00:00 +0000" endDate="2024-01-02 16:45:00 +0000" average="150" minimum="98" maximum="176" unit="count/min"/>
+              <MetadataEntry key="HKIndoorWorkout" value="0"/>
+             </Workout>
+            </HealthData>
+        """.trimIndent().toByteArray(Charsets.UTF_8)
+
+        val probe = AppleHealthImporter.parseStreamForTest(ByteArrayInputStream(xml))
+
+        assertEquals(1, probe.workouts.size)
+        val w = probe.workouts.single()
+        assertEquals("Running", w.sport)
+        assertEquals(2700.0, w.durationS!!, 1e-9)          // 45 min -> seconds
+        assertEquals(540.0, w.energyKcal!!, 1e-9)          // sum, Cal == kcal
+        assertEquals(8050.0, w.distanceM!!, 0.5)           // 8.05 km -> ~8050 m
+        assertEquals(150, w.avgHr)                          // WorkoutStatistics HeartRate average
+        assertEquals(176, w.maxHr)                          // WorkoutStatistics HeartRate maximum
+        assertEquals(0, probe.skippedSpans)
+    }
+
+    /**
+     * Regression guard: the legacy iOS <=15 shape (totals as <Workout> attributes) must keep parsing.
+     * HR was never an attribute in that shape, so avg/max stay null.
+     */
+    @Test
+    fun legacyWorkoutAttributesStillParse() {
+        val xml = """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <HealthData>
+             <Workout workoutActivityType="HKWorkoutActivityTypeCycling" duration="30" durationUnit="min" totalDistance="10.0" totalDistanceUnit="km" totalEnergyBurned="250" totalEnergyBurnedUnit="kcal" startDate="2024-01-02 16:00:00 +0000" endDate="2024-01-02 16:30:00 +0000"/>
+            </HealthData>
+        """.trimIndent().toByteArray(Charsets.UTF_8)
+
+        val probe = AppleHealthImporter.parseStreamForTest(ByteArrayInputStream(xml))
+
+        assertEquals(1, probe.workouts.size)
+        val w = probe.workouts.single()
+        assertEquals("Cycling", w.sport)
+        assertEquals(250.0, w.energyKcal!!, 1e-9)
+        assertEquals(10000.0, w.distanceM!!, 0.5)
+        assertEquals(null, w.avgHr)
+        assertEquals(null, w.maxHr)
+    }
 }


### PR DESCRIPTION
## What

iOS 16 moved per-workout totals out of `<Workout>` attributes into nested
`<WorkoutStatistics>` children (energy/distance as `sum`, heart rate as
`average`/`maximum`). The importer only read the legacy `totalEnergyBurned` /
`totalDistance` attributes, so on any modern export **every** workout imported with no
energy, distance or heart rate — bare shells that then de-duplicate noisily against the
strap's own sessions.

## Change

Parse `<WorkoutStatistics>` on both platforms, keeping the legacy iOS ≤15 attribute path
as a fallback, and carry avg/max HR through to the workout row.

- **Swift:** a deferred-commit state machine — build the workout at `<Workout>`, fill from
  each `<WorkoutStatistics>` child, append at `</Workout>`.
- **Android:** consume the workout's own sub-tree in `handleWorkout`.
- `HealthWorkout` gains `avgHr`/`maxHr`; `AppleHealthImport` maps them onto `WorkoutRow`.

Daily energy/steps are unaffected (they arrive as standalone top-level `<Record>`s); this
only recovers the per-workout totals.

## Verification

- New tests pin the modern shape on both platforms (energy 540 kcal, distance 8050 m,
  avgHr 150, maxHr 176); the existing legacy-attribute fixtures remain a regression guard.
- Android build + unit tests green (`AppleHealthImporterToleranceTest` 8/8).
- The importer core lives in `Packages/StrandImport` → covered by `swift-packages` CI on macOS.
- One app-target line (`AppleHealthImport.swift` HR mapping) is **not** CI-covered and has
  **not** been compiled on macOS (no Xcode available to the author). A follow-up issue tracks
  the macOS/iOS compile-verification.