### PR TITLE
perf(workouts): bucket cross-source dedup by sport — O(n²) to near-linear

### DIFF
--- a/Strand/Data/WorkoutSource.swift
+++ b/Strand/Data/WorkoutSource.swift
@@ -162,7 +162,13 @@ enum WorkoutSource: Equatable {
     /// touching) keeps two genuinely back-to-back same-sport sessions distinct while still catching the
     /// small start/end drift between a live capture and its import.
     static func sameActivity(_ a: WorkoutRow, _ b: WorkoutRow) -> Bool {
-        guard sportKey(a.sport) == sportKey(b.sport) else { return false }
+        sportKey(a.sport) == sportKey(b.sport) && overlapsInTime(a, b)
+    }
+
+    /// The time-overlap half of `sameActivity`: the two windows overlap by more than half of the shorter
+    /// session. Sport equality is checked separately — `collapseCrossSource` buckets rows by sport, so within
+    /// a bucket only this (allocation-free) half remains, which is what makes the collapse walk near-linear.
+    private static func overlapsInTime(_ a: WorkoutRow, _ b: WorkoutRow) -> Bool {
         let overlap = min(a.endTs, b.endTs) - max(a.startTs, b.startTs)
         guard overlap > 0 else { return false }
         let shorter = max(1, min(a.endTs - a.startTs, b.endTs - b.startTs))
@@ -223,15 +229,42 @@ enum WorkoutSource: Equatable {
     /// #975: a DETECTED bout that shadows a real logged session is dropped FIRST so the transient
     /// live+detected duplicate never shows and can't pollute the Effort/HR read-out.
     static func dedupCrossSource(_ rows: [WorkoutRow]) -> [WorkoutRow] {
+        collapseCrossSource(dropDetectedShadows(rows))
+    }
+
+    /// The shared cross-source collapse walk behind `dedupCrossSource` and `dedupCrossSourceTrace`. Byte-
+    /// identical to the naive "compare every kept row" walk — same first match (kept insertion order), same
+    /// `preferred` winner, same resulting list — but near-linear instead of O(n²): `sportKey` is computed
+    /// ONCE per row (not twice per comparison), rows are bucketed by it, and a candidate only ever compares
+    /// against kept rows of the SAME sport (a cross-sport pair can never be `sameActivity`). That removes the
+    /// per-comparison string-normalisation that made a large imported history freeze the workout screens.
+    /// `onMerge` is invoked with (winner, loser) for each collapsed pair so the trace path can record it.
+    private static func collapseCrossSource(
+        _ input: [WorkoutRow],
+        onMerge: ((_ winner: WorkoutRow, _ loser: WorkoutRow) -> Void)? = nil
+    ) -> [WorkoutRow] {
         var kept: [WorkoutRow] = []
-        let input = dropDetectedShadows(rows)
         kept.reserveCapacity(input.count)
-        outer: for row in input {
-            for i in kept.indices where sameActivity(kept[i], row) {
-                kept[i] = preferred(kept[i], row)
-                continue outer
+        // sportKey -> indices into `kept` for that sport, in insertion order (preserves first-match semantics).
+        var bySport: [String: [Int]] = [:]
+        for row in input {
+            let key = sportKey(row.sport)
+            var merged = false
+            for idx in bySport[key, default: []] where overlapsInTime(kept[idx], row) {
+                let winner = preferred(kept[idx], row)
+                if let onMerge {
+                    // Identify the loser by the REAL keep decision (== against the winner). When the two rows
+                    // are byte-identical the label is interchangeable, so == is correct in every case.
+                    onMerge(winner, winner == kept[idx] ? row : kept[idx])
+                }
+                kept[idx] = winner
+                merged = true
+                break
             }
-            kept.append(row)
+            if !merged {
+                bySport[key, default: []].append(kept.count)
+                kept.append(row)
+            }
         }
         return kept
     }
@@ -257,7 +290,6 @@ enum WorkoutSource: Equatable {
     /// plain path runs) and emits one `detectedBout verdict=droppedShadow` line per drop, so the export shows
     /// exactly which detected twin was suppressed to keep the live/manual session single.
     static func dedupCrossSourceTrace(_ rows: [WorkoutRow]) -> (kept: [WorkoutRow], trace: [String]) {
-        var kept: [WorkoutRow] = []
         var lines: [String] = []
         // Detected-shadow drop first (byte-identical to dedupCrossSource's `dropDetectedShadows`), tracing each.
         let reals = rows.filter { classify($0.source) != .detected }
@@ -274,25 +306,14 @@ enum WorkoutSource: Equatable {
             }
             input.append(row)
         }
-        kept.reserveCapacity(input.count)
-        outer: for row in input {
-            for i in kept.indices where sameActivity(kept[i], row) {
-                // L8: identify kept-vs-dropped by the REAL keep decision, not by a (startTs, source) tuple
-                // that collides when row and kept[i] share both fields (e.g. a same-start same-source pair
-                // differing only in richness). preferred() returns one of the two rows; a full-row ==
-                // against kept[i] tells us which side won. When the two rows are byte-identical the label is
-                // interchangeable, so == is correct in every case.
-                let keptWins = preferred(kept[i], row) == kept[i]
-                let winner = keptWins ? kept[i] : row
-                let loser = keptWins ? row : kept[i]
-                lines.append(WorkoutsTrace.dedupLine(
-                    sportKey: traceSportKey(row.sport),   // PRIVACY: catalogue key or "custom", never free text
-                    keptSource: sourceLabel(winner), droppedSource: sourceLabel(loser),
-                    keptRichness: richness(winner), droppedRichness: richness(loser)))
-                kept[i] = winner
-                continue outer
-            }
-            kept.append(row)
+        // Same bucketed collapse as the plain path, so the kept list can never diverge from what the screen
+        // shows; the callback records one dedup line per collapsed pair. traceSportKey reads the winner's
+        // sport — same sportKey as the loser (they matched), so the emitted token is stable either way.
+        let kept = collapseCrossSource(input) { winner, loser in
+            lines.append(WorkoutsTrace.dedupLine(
+                sportKey: traceSportKey(winner.sport),   // PRIVACY: catalogue key or "custom", never free text
+                keptSource: sourceLabel(winner), droppedSource: sourceLabel(loser),
+                keptRichness: richness(winner), droppedRichness: richness(loser)))
         }
         return (kept, lines)
     }

--- a/android/app/src/main/java/com/noop/ui/WorkoutEditing.kt
+++ b/android/app/src/main/java/com/noop/ui/WorkoutEditing.kt
@@ -142,8 +142,15 @@ object WorkoutEditing {
      * genuinely back-to-back same-sport sessions distinct while still catching the small start/end drift
      * between a live capture and its import.
      */
-    fun sameActivity(a: WorkoutRow, b: WorkoutRow): Boolean {
-        if (sportKey(a.sport) != sportKey(b.sport)) return false
+    fun sameActivity(a: WorkoutRow, b: WorkoutRow): Boolean =
+        sportKey(a.sport) == sportKey(b.sport) && overlapsInTime(a, b)
+
+    /**
+     * The time-overlap half of [sameActivity]: the two windows overlap by more than half of the shorter
+     * session. Sport equality is checked separately — [collapseCrossSource] buckets rows by sport, so within
+     * a bucket only this (allocation-free) half remains, which is what makes the collapse walk near-linear.
+     */
+    private fun overlapsInTime(a: WorkoutRow, b: WorkoutRow): Boolean {
         val overlap = minOf(a.endTs, b.endTs) - maxOf(a.startTs, b.startTs)
         if (overlap <= 0) return false
         val shorter = maxOf(1L, minOf(a.endTs - a.startTs, b.endTs - b.startTs))
@@ -209,17 +216,41 @@ object WorkoutEditing {
      * #975: a DETECTED bout that shadows a real logged session is dropped FIRST so the transient
      * live+detected duplicate never shows and can't pollute the Effort/HR read-out.
      */
-    fun dedupCrossSource(rows: List<WorkoutRow>): List<WorkoutRow> {
-        val input = dropDetectedShadows(rows)
+    fun dedupCrossSource(rows: List<WorkoutRow>): List<WorkoutRow> =
+        collapseCrossSource(dropDetectedShadows(rows))
+
+    /**
+     * The shared cross-source collapse walk behind [dedupCrossSource] and [dedupCrossSourceTrace]. Byte-
+     * identical to the naive "compare every kept row" walk — same first match (kept insertion order), same
+     * [preferred] winner, same resulting list — but near-linear instead of O(n²): [sportKey] is computed
+     * ONCE per row (not twice per comparison), rows are bucketed by it, and a candidate only ever compares
+     * against kept rows of the SAME sport (a cross-sport pair can never be [sameActivity]). That removes the
+     * per-comparison string-normalisation that made a large imported history freeze the workout screens.
+     * [onMerge] is invoked with (winner, loser) for each collapsed pair so the trace path can record it.
+     */
+    private fun collapseCrossSource(
+        input: List<WorkoutRow>,
+        onMerge: ((winner: WorkoutRow, loser: WorkoutRow) -> Unit)? = null,
+    ): List<WorkoutRow> {
         val kept = ArrayList<WorkoutRow>(input.size)
-        outer@ for (row in input) {
-            for (i in kept.indices) {
-                if (sameActivity(kept[i], row)) {
-                    kept[i] = preferred(kept[i], row)
-                    continue@outer
+        // sportKey -> indices into `kept` for that sport, in insertion order (preserves first-match semantics).
+        val bySport = HashMap<String, ArrayList<Int>>()
+        for (row in input) {
+            val bucket = bySport.getOrPut(sportKey(row.sport)) { ArrayList() }
+            var merged = false
+            for (idx in bucket) {
+                if (overlapsInTime(kept[idx], row)) { // same sport guaranteed by the bucket
+                    val winner = preferred(kept[idx], row)
+                    if (onMerge != null) onMerge(winner, if (winner === kept[idx]) row else kept[idx])
+                    kept[idx] = winner
+                    merged = true
+                    break
                 }
             }
-            kept.add(row)
+            if (!merged) {
+                bucket.add(kept.size)
+                kept.add(row)
+            }
         }
         return kept
     }
@@ -261,30 +292,18 @@ object WorkoutEditing {
             }
             input.add(row)
         }
-        val kept = ArrayList<WorkoutRow>(input.size)
-        outer@ for (row in input) {
-            for (i in kept.indices) {
-                if (sameActivity(kept[i], row)) {
-                    // L8: identify kept-vs-dropped by the REAL keep decision, not by a (startTs, source)
-                    // tuple that collides when row and kept[i] share both fields (e.g. a same-start same-
-                    // source pair differing only in richness). preferred() returns one of the two rows; a
-                    // full-row == against kept[i] tells us which side won. When the two rows are byte-
-                    // identical the label is interchangeable, so == is correct in every case.
-                    val keptWins = preferred(kept[i], row) == kept[i]
-                    val winner = if (keptWins) kept[i] else row
-                    val loser = if (keptWins) row else kept[i]
-                    lines.add(
-                        WorkoutsTrace.dedupLine(
-                            sportKey = traceSportKey(row.sport), // PRIVACY: catalogue key or "custom", never free text
-                            keptSource = sourceLabel(winner), droppedSource = sourceLabel(loser),
-                            keptRichness = richness(winner), droppedRichness = richness(loser),
-                        ),
-                    )
-                    kept[i] = winner
-                    continue@outer
-                }
-            }
-            kept.add(row)
+        // Same bucketed collapse as the plain path, so the kept list can never diverge from what the screen
+        // shows; the callback records one dedup line per collapsed pair. winner/loser come from the REAL
+        // [preferred] decision (identity, not a startTs+source tuple that collides on a same-start same-source
+        // pair). traceSportKey reads the winner's sport — same sportKey as the loser, so the token is stable.
+        val kept = collapseCrossSource(input) { winner, loser ->
+            lines.add(
+                WorkoutsTrace.dedupLine(
+                    sportKey = traceSportKey(winner.sport), // PRIVACY: catalogue key or "custom", never free text
+                    keptSource = sourceLabel(winner), droppedSource = sourceLabel(loser),
+                    keptRichness = richness(winner), droppedRichness = richness(loser),
+                ),
+            )
         }
         return kept to lines
     }

--- a/android/app/src/test/java/com/noop/ui/WorkoutEditingTest.kt
+++ b/android/app/src/test/java/com/noop/ui/WorkoutEditingTest.kt
@@ -501,4 +501,67 @@ class WorkoutEditingTest {
         assertEquals("my-whoop", WorkoutMerge.merge(listOf(a, b))?.deviceId)
         assertEquals("dev2", WorkoutMerge.merge(listOf(a, b), strapDeviceId = "dev2")?.deviceId)
     }
+
+    // MARK: - dedup perf refactor: bucketed collapse == naive walk (byte-identical)
+
+    /** The ORIGINAL O(n²) collapse, kept here verbatim as the oracle the bucketed version must match. */
+    private fun naiveDedupCrossSource(rows: List<WorkoutRow>): List<WorkoutRow> {
+        val input = WorkoutEditing.dropDetectedShadows(rows)
+        val kept = ArrayList<WorkoutRow>(input.size)
+        outer@ for (row in input) {
+            for (i in kept.indices) {
+                if (WorkoutEditing.sameActivity(kept[i], row)) {
+                    kept[i] = WorkoutEditing.preferred(kept[i], row)
+                    continue@outer
+                }
+            }
+            kept.add(row)
+        }
+        return kept
+    }
+
+    /**
+     * The bucketed [WorkoutEditing.dedupCrossSource] must be BYTE-IDENTICAL to the naive walk it replaced —
+     * same kept set, same order, same [WorkoutEditing.preferred] winner per collapse — over thousands of
+     * randomised inputs. Sport strings include case/space variants that fold to the same sportKey (so the
+     * bucket key is exercised) and detected/real mixes (so dropDetectedShadows runs). This is what lets the
+     * O(n²)->near-linear change ship without a device: correctness is proven against the old behaviour.
+     */
+    @Test
+    fun dedupCrossSource_bucketedMatchesNaiveOverRandomInputs() {
+        val sports = listOf(
+            "Running", "running", "Cycling", "yoga", "custom", "Walking",
+            "TraditionalStrengthTraining", "Traditional Strength Training", "detected",
+        )
+        val sources = listOf("apple-health", "whoop", "my-whoop", "manual", "my-whoop-noop", "lifting", "activity-file")
+        val rnd = java.util.Random(20260713L)
+        repeat(2000) {
+            val n = rnd.nextInt(14)
+            val rows = ArrayList<WorkoutRow>(n)
+            repeat(n) {
+                val start = 1_000L + rnd.nextInt(20) * 300L          // clustered starts -> real overlaps
+                val dur = 300L + rnd.nextInt(12) * 300L
+                rows.add(
+                    WorkoutRow(
+                        deviceId = "dev",
+                        startTs = start,
+                        endTs = start + dur,
+                        sport = sports[rnd.nextInt(sports.size)],
+                        source = sources[rnd.nextInt(sources.size)],
+                        durationS = dur.toDouble(),
+                        energyKcal = if (rnd.nextBoolean()) rnd.nextInt(800).toDouble() else null,
+                        avgHr = if (rnd.nextBoolean()) 90 + rnd.nextInt(80) else null,
+                        maxHr = if (rnd.nextBoolean()) 120 + rnd.nextInt(80) else null,
+                        strain = if (rnd.nextBoolean()) rnd.nextDouble() * 21.0 else null,
+                        distanceM = if (rnd.nextBoolean()) rnd.nextInt(15000).toDouble() else null,
+                    ),
+                )
+            }
+            val expected = naiveDedupCrossSource(rows)
+            val actual = WorkoutEditing.dedupCrossSource(rows)
+            assertEquals("bucketed dedup diverged from naive for input: $rows", expected, actual)
+            // The trace twin must return the exact same kept list the plain path does.
+            assertEquals(actual, WorkoutEditing.dedupCrossSourceTrace(rows).first)
+        }
+    }
 }


### PR DESCRIPTION
## What

`WorkoutSource.dedupCrossSource` (the cross-source workout collapse behind the Workouts /
Today / Insights / Coach screens) is O(n²): for every pair it calls `sameActivity`, which
normalises `sportKey` — allocating two strings — per comparison. On a large imported
history (Apple Health keeps many near-duplicate workouts), `workoutRows` / `loadWorkouts`
runs that n²-string-allocating walk on the main thread on every screen, lagging / freezing
the UI after an import.

## Change

Bucket kept rows by a once-per-row `sportKey`. A candidate only ever compares against kept
rows of the **same sport** (a cross-sport pair can never be `sameActivity`), so the
per-comparison string normalisation is gone and the walk is near-linear. The plain and
trace paths now share one `collapseCrossSource` core, so the trace kept list can never
drift from what the screen shows.

Output is unchanged: **same first match** (kept insertion order), **same `preferred()`
winner**, **same kept list**.

## Verification

- **Byte-identical to the old walk**, proven by a 2000-case fuzz test
  (`WorkoutEditingTest.dedupCrossSource_bucketedMatchesNaiveOverRandomInputs`) over
  randomised inputs incl. case/space sport variants and detected/real mixes.
- Android build + unit tests green (`WorkoutEditingTest` 39/39).
- The Swift twin (`WorkoutSource.swift`) mirrors the Kotlin exactly. It is **app-target
  Swift → not covered by CI** and has **not** been compiled on macOS (no Xcode available to
  the author). A follow-up issue tracks the macOS/iOS compile-verification.