### PR TITLE
fix(steps): Steps detail resolves the real count, not the estimate (#377)

### DIFF
--- a/android/app/src/main/java/com/noop/ui/HealthScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/HealthScreen.kt
@@ -1920,6 +1920,18 @@ internal data class VitalReading(
     val source: String,
 )
 
+/** #377: merge the three step stores into one per-day series with the SAME precedence as the Today
+ *  Steps tile — a REAL on-device count ([real], WHOOP 5/MG @57 → DailyMetric.steps) wins, else an
+ *  [imported] Health Connect / Apple Health count, else the motion-model [est] (`steps_est`). The three
+ *  are disjoint stores so the `?:` chain never double-counts. Ascending by day. Pure for testability. */
+internal fun mergeStepsReadings(
+    real: Map<String, VitalReading>,
+    imported: Map<String, VitalReading>,
+    est: Map<String, VitalReading>,
+): List<VitalReading> =
+    (real.keys + imported.keys + est.keys).toSortedSet()
+        .mapNotNull { d -> real[d] ?: imported[d] ?: est[d] }
+
 private data class VitalDetailModel(
     val key: String,
     val title: String,
@@ -2495,16 +2507,38 @@ private suspend fun buildSeriesVitalDetail(vm: AppViewModel, key: String): Vital
             .map { VitalReading(it.day, it.value, it.deviceId) },
         format = { it.roundToInt().toString() },
     )
-    "steps_est" -> VitalDetailModel(
-        key = key,
-        title = "Steps",
-        unit = "steps",
-        color = Palette.metricCyan,
-        readings = vm.repo.resolvedSeries("steps_est", "my-whoop", "0000-00-00", "9999-99-99",
+    "steps_est" -> {
+        // #377: the Today Steps tile resolves a REAL step count FIRST — the WHOOP 5/MG on-device @57
+        // counter (DailyMetric.steps) ?: imported Health Connect / Apple Health ?: the motion-model
+        // estimate (TodayScreen: `day?.steps ?: importedStepsForDay ?: estimatedStepsForDay`). This
+        // detail read the estimate ALONE, so a WHOOP 5.0 with a real count saw the estimate history —
+        // clamped flat at StepsEstimateEngine.MAX_DAILY_STEPS = 60,000 when the motion fit over-shoots —
+        // instead of its real steps. Resolve per day with the SAME precedence so the graph + Readings
+        // match the card. iOS already routes this detail through the real "steps" metric (not the
+        // estimate); this brings Android to parity. Real strap steps live in DailyMetric.steps; imported
+        // steps in AppleDaily; the estimate in the "steps_est" series — three disjoint stores, so the
+        // per-day `?:` chain never double-counts.
+        val real = vm.repo.resolvedSeries("steps", "my-whoop", "0000-00-00", "9999-99-99",
             strapDeviceId = vm.activeStrapId)
-            .points.map { VitalReading(it.day, it.value, it.source) },
-        format = { it.roundToInt().toString() },
-    )
+            .points.associateBy({ it.day }, { VitalReading(it.day, it.value, it.source) })
+        val imported = LinkedHashMap<String, VitalReading>()
+        for (r in vm.repo.appleDaily("apple-health", "0000-01-01", "9999-12-31") +
+            vm.repo.appleDaily("health-connect", "0000-01-01", "9999-12-31")) {
+            val s = r.steps
+            if (s != null && s > 0) imported.putIfAbsent(r.day, VitalReading(r.day, s.toDouble(), r.deviceId))
+        }
+        val est = vm.repo.resolvedSeries("steps_est", "my-whoop", "0000-00-00", "9999-99-99",
+            strapDeviceId = vm.activeStrapId)
+            .points.associateBy({ it.day }, { VitalReading(it.day, it.value, it.source) })
+        VitalDetailModel(
+            key = key,
+            title = "Steps",
+            unit = "steps",
+            color = Palette.metricCyan,
+            readings = mergeStepsReadings(real, imported, est),
+            format = { it.roundToInt().toString() },
+        )
+    }
     "active_kcal" -> {
         // Read active energy from the SAME apple-health ∪ health-connect union the Today Calories card uses.
         // Health Connect (the common Android source) writes activeKcal only into the AppleDaily table under

--- a/android/app/src/test/java/com/noop/ui/StepsReadingsMergeTest.kt
+++ b/android/app/src/test/java/com/noop/ui/StepsReadingsMergeTest.kt
@@ -1,0 +1,42 @@
+package com.noop.ui
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * #377: the Steps detail must resolve steps with the SAME precedence as the Today Steps tile —
+ * a REAL on-device count wins over the motion-model estimate, which previously flat-lined at the
+ * StepsEstimateEngine.MAX_DAILY_STEPS (60,000) clamp for a WHOOP 5.0 that had real steps.
+ */
+class StepsReadingsMergeTest {
+
+    private fun r(day: String, v: Double, src: String) = VitalReading(day, v, src)
+
+    @Test
+    fun realWinsOverEstimateAndImportedPerDay() {
+        val real = mapOf("2026-07-13" to r("2026-07-13", 9_000.0, "whoop-x-noop"))          // real @57 count
+        val imported = mapOf(
+            "2026-07-13" to r("2026-07-13", 8_000.0, "health-connect"),                    // loses to real
+            "2026-07-10" to r("2026-07-10", 7_000.0, "apple-health"),                      // fills (no real)
+        )
+        val est = mapOf(
+            "2026-07-13" to r("2026-07-13", 60_000.0, "whoop-x-noop"),                     // the buggy clamp — must lose
+            "2026-07-11" to r("2026-07-11", 60_000.0, "whoop-x-noop"),                     // est-only day keeps est
+        )
+        val out = mergeStepsReadings(real, imported, est)
+
+        // Ascending by day, one reading per day across the union.
+        assertEquals(listOf("2026-07-10", "2026-07-11", "2026-07-13"), out.map { it.day })
+        // The bug: the 60k estimate no longer wins a day that has a real count.
+        assertEquals(9_000.0, out.first { it.day == "2026-07-13" }.value, 0.0)
+        // Imported fills a day with no real count.
+        assertEquals(7_000.0, out.first { it.day == "2026-07-10" }.value, 0.0)
+        // The estimate still shows where there is genuinely nothing else (matches the card's "est." fallback).
+        assertEquals(60_000.0, out.first { it.day == "2026-07-11" }.value, 0.0)
+    }
+
+    @Test
+    fun emptyInputsYieldEmpty() {
+        assertEquals(emptyList<VitalReading>(), mergeStepsReadings(emptyMap(), emptyMap(), emptyMap()))
+    }
+}


### PR DESCRIPTION
Fixes #377 — Steps detail flat-lining at exactly 60,000 on WHOOP 5.0.

## Root cause
The Steps **card** shows the correct live count; the **detail/trends** flat-lines at 60k because it read **`resolvedSeries("steps_est")` alone**. `steps_est` is the WHOOP-4 *motion-model* estimate (`motion × fitted-k`, clamped to `StepsEstimateEngine.MAX_DAILY_STEPS = 60,000`); when the fit over-shoots, every recent day pins to the cap. The reporter's logged `scaledSteps=9–15k` is a *different* computation (the real strap step count), which is what the card shows.

The card never has this problem — the Today Steps tile resolves `day?.steps ?: importedStepsForDay ?: estimatedStepsForDay`, i.e. the **real on-device @57 count (`DailyMetric.steps`) first**. But `DashboardCard.STEPS` routes to the `steps_est` detail, which applied no such precedence. The read layer was faithful — it was just reading the wrong series.

## Fix
The detail resolves per day with the **same precedence as the tile**: real `"steps"` (via the computed-source union — verified `sourceCandidates` includes `<strap>-noop` where `DailyMetric.steps` lives) → imported Apple Health / Health Connect (`AppleDaily`) → the `steps_est` estimate. The three are **disjoint stores**, so the `?:` chain never double-counts; the estimate still shows on days that genuinely have nothing else, matching the card's "est." fallback.

Extracted the precedence into a pure `mergeStepsReadings` + a test that pins the exact bug (a 60k estimate no longer wins a day that has a real count; imported fills; est-only days keep est).

## Scope / parity
**Android-only.** iOS routes this detail through the real `"steps"` metric already (not `steps_est`), so this brings Android to parity. No stored-analytics change — display-read only.

## Verification
`compileFullDebugKotlin` + full `testFullDebugUnitTest` green. Not fixed here (separate, noted on the issue): *why* the `steps_est` fit clamps to 60k for this user — a calibration-robustness question — but it's now correctly de-prioritised behind the real count.
