### PR TITLE
fix(compare): restore range + selection pre-render on iOS (no default flash) + test

### DIFF
--- a/Strand/Screens/CompareView.swift
+++ b/Strand/Screens/CompareView.swift
@@ -138,18 +138,23 @@ struct CompareView: View {
 
     // #358 parity (Android ComparePrefs): the time window + the ordered metric selection persist across
     // visits — a UI preference, not `.noopbak` data. Selection is stored as comma-joined descriptor ids
-    // ("source:key"), restored through the same resolve-and-fall-back rule as the Kotlin side.
+    // ("source:key"). Both are restored PRE-render (window straight off @AppStorage, selection via a
+    // static initial value), so Compare opens directly on the saved state — matching Android, with no
+    // default-then-restore flash.
     @AppStorage("compare.rangeRaw") private var savedRangeRaw = CompareRange.year.rawValue
     @AppStorage("compare.selectedIds") private var savedSelectedIds = ""
 
-    /// A range binding that also persists the choice (#358), so the window survives across visits.
+    /// The active window, backed directly by @AppStorage so it is the persisted value from the first
+    /// frame. Read-only; writes go through `rangeBinding`.
+    private var range: CompareRange { CompareRange(rawValue: savedRangeRaw) ?? .year }
     private var rangeBinding: Binding<CompareRange> {
-        Binding(get: { range }, set: { range = $0; savedRangeRaw = $0.rawValue })
+        Binding(get: { CompareRange(rawValue: savedRangeRaw) ?? .year },
+                set: { savedRangeRaw = $0.rawValue })
     }
 
-    @State private var range: CompareRange = .year
-    /// Ordered selection (max 4). Drives both the legend order and color mapping.
-    @State private var selected: [MetricDescriptor] = []
+    /// Ordered selection (max 4). Pre-populated from the persisted ids (else the defaults) at creation,
+    /// so it renders the saved selection immediately. Drives both the legend order and color mapping.
+    @State private var selected: [MetricDescriptor] = CompareView.initialSelection()
     /// Full-history series per selected metric id (ascending by day).
     @State private var fullSeries: [String: [(day: String, value: Double)]] = [:]
     @State private var loadedOnce = false
@@ -193,7 +198,6 @@ struct CompareView: View {
                 }
             }
         }
-        .task { await loadIfNeeded() }
         .task(id: loadTaskID) {
             await loadSelected()
             refreshPairCache(activeSeries)
@@ -281,24 +285,23 @@ struct CompareView: View {
 
     // MARK: - Loading
 
-    private func loadIfNeeded() async {
-        guard selected.isEmpty else { return }
-        // #358: restore the persisted window + selection first. Fall back to the defaults only when
-        // nothing usable was saved (fresh install, or a catalog change dropped the saved ids below the
-        // minimum). Mirrors the Android ComparePrefs restore.
-        if let r = CompareRange(rawValue: savedRangeRaw) { range = r }
-        if let restored = Self.restoreSelection(savedSelectedIds, minSelection: minSelection,
-                                                maxSelection: maxSelection) {
-            selected = restored
-            return
-        }
-        // Seed the default selection from whichever default keys exist.
+    /// The persisted selection (comma-joined descriptor ids) resolved against the catalog, else the
+    /// defaults. Evaluated at view creation (the `selected` initial value) so Compare renders the saved
+    /// selection on the first frame. Twin of the Android `ComparePrefs.readSelection`. The literals
+    /// mirror `minSelection` / `maxSelection` below (a static initial value can't read instance members).
+    static func initialSelection() -> [MetricDescriptor] {
+        let raw = UserDefaults.standard.string(forKey: "compare.selectedIds") ?? ""
+        return restoreSelection(raw, minSelection: 2, maxSelection: 4) ?? defaultSelection()
+    }
+
+    /// The default starter selection from `defaultKeys` (graceful when a key is missing).
+    static func defaultSelection() -> [MetricDescriptor] {
         var picks: [MetricDescriptor] = []
-        for key in Self.defaultKeys {
+        for key in defaultKeys {
             if let m = MetricCatalog.all.first(where: { $0.key == key }) { picks.append(m) }
         }
         if picks.isEmpty { picks = Array(MetricCatalog.all.prefix(2)) }
-        selected = Array(picks.prefix(maxSelection))
+        return Array(picks.prefix(4))   // maxSelection
     }
 
     /// Restore a persisted Compare selection (comma-joined descriptor ids), or nil to fall back to the

--- a/StrandTests/CompareRestoreTests.swift
+++ b/StrandTests/CompareRestoreTests.swift
@@ -1,0 +1,51 @@
+import XCTest
+@testable import Strand
+
+/// #358 parity: `CompareView.restoreSelection` is the twin of the Android `ComparePrefs.parseCompareSelection`
+/// (`ComparePrefsTest.kt`) — restore a deliberate sub-minimum selection when every saved id still resolves,
+/// but fall back to the defaults only when a catalog change dropped the saved ids below the minimum.
+///
+/// NOTE: `StrandTests` runs only under `xcodebuild test` on macOS (no CI leg — `app-build` is compile-only
+/// of the app targets). The identical algorithm is exercised in CI on the Android side; this is the local
+/// regression twin. Ids are the real `MetricDescriptor.id` form ("source:key").
+final class CompareRestoreTests: XCTestCase {
+    private let recovery = "my-whoop:recovery"
+    private let hrv = "my-whoop:hrv"
+    private let sleep = "my-whoop:sleep_performance"
+
+    func testBlankYieldsNilSoTheCallerUsesDefaults() {
+        XCTAssertNil(CompareView.restoreSelection("", minSelection: 2, maxSelection: 4))
+        XCTAssertNil(CompareView.restoreSelection("   ,  ", minSelection: 2, maxSelection: 4))
+    }
+
+    func testRestoresSubMinimumWhenEveryIdResolves() {
+        // A deliberate single-metric selection: every id resolves → restore it, don't reset to defaults.
+        XCTAssertEqual(CompareView.restoreSelection(recovery, minSelection: 2, maxSelection: 4)?.map(\.id),
+                       [recovery])
+    }
+
+    func testFallsBackWhenSurvivorsDropBelowMinimum() {
+        // One real id + one lost to a catalog change → 1 survivor (< min) → nil (defaults).
+        XCTAssertNil(CompareView.restoreSelection("\(recovery),gone:xyz", minSelection: 2, maxSelection: 4))
+    }
+
+    func testRestoresWhenAtLeastMinimumSurvives() {
+        // Two resolve, one lost → 2 >= min → restore the survivors, in saved order.
+        XCTAssertEqual(
+            CompareView.restoreSelection("\(recovery),\(hrv),gone:xyz", minSelection: 2, maxSelection: 4)?.map(\.id),
+            [recovery, hrv])
+    }
+
+    func testCapsAtMaxSelectionInOrder() {
+        // Three valid ids, maxSelection 2 → keep the first two.
+        XCTAssertEqual(
+            CompareView.restoreSelection("\(recovery),\(hrv),\(sleep)", minSelection: 2, maxSelection: 2)?.map(\.id),
+            [recovery, hrv])
+    }
+
+    func testDedupesRepeatedIds() {
+        XCTAssertEqual(
+            CompareView.restoreSelection("\(recovery),\(recovery),\(hrv)", minSelection: 2, maxSelection: 4)?.map(\.id),
+            [recovery, hrv])
+    }
+}


### PR DESCRIPTION
Follow-up polish to the Compare-persistence pair (#385 iOS / #358 Android).

## The flash
iOS restored the persisted window + selection in `loadIfNeeded` — a `.task`, which runs **after** the first render — so opening Compare briefly showed the default state (1Y + the "needs at least two metrics" prompt) before popping to your saved state. Android doesn't flash: it restores in its **initial state**. (This was pre-existing iOS behavior — the old `loadIfNeeded` already seeded defaults in `.task`; #385 only changed *what* it seeded, not the timing.)

## Fix — restore pre-render, matching Android
- **`range`** is now computed directly off `@AppStorage savedRangeRaw`, so it's the saved window from the first frame (writes go through `rangeBinding`).
- **`selected`**'s initial value is `CompareView.initialSelection()` — a static that resolves the persisted ids (else the defaults) at view creation, so the saved selection renders immediately.
- `loadIfNeeded` and its `.task` are removed (no longer needed).

## Test
Adds `StrandTests/CompareRestoreTests` — the local twin of Android's `ComparePrefsTest`: sub-minimum-restore, below-min fallback, ≥min-survives, cap, dedupe.
**CI status (honest):** `StrandTests` runs only under `xcodebuild test` locally — there's no CI leg, and `app-build` is compile-*only* of the app targets, so it won't run (or even compile) this test. The algorithm itself is CI-covered on the Android side; this is the local regression twin.

## Verification
App-target Swift (`CompareView`) → the compile is validated via **app-build** (result posted below). Behavior is otherwise unchanged from #385 — same persistence, same resolve-and-fall-back rule, just restored a frame earlier.
