### PR TITLE
feat: Test Center "Experimental Algorithms" tab — opt-in HR-PPG sub-lag interpolation + HRV-readiness

### DIFF
--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/HRVReadiness.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/HRVReadiness.swift
@@ -1,0 +1,157 @@
+import Foundation
+
+// HRVReadiness.swift — OPT-IN experimental "HRV readiness (Plews/Altini)" tier readout.
+//
+// The Kotlin twin is android/.../analytics/HRVReadiness.kt. Cross-platform parity is the contract: every
+// constant, gate, and formula here must stay byte-identical to that source.
+//
+// This is a PURE, deterministic, DB-free engine and it does NOT change the default Charge/ring in any way
+// — it is only surfaced (read-only) behind the PuffinExperiment `noopHrvReadiness` flag (off by default)
+// and feeds NO downstream gate. It reimplements the endurance-science "smallest worthwhile change" (SWC)
+// reading of nightly HRV popularised by Plews et al. and Marco Altini: work in the LOG domain (ln RMSSD is
+// closer to normal and stabilises variance), compare a short 7-night rolling baseline against a longer
+// personal normal band (±0.5 SD), and read the tier off where the short baseline sits relative to that
+// band. A single bad night barely moves the 7-night baseline, so the reading is far more robust than a raw
+// single-night z.
+//
+// INPUT: the SAME nightly RMSSD series RecoveryScorer / ReadinessEngine consume — DailyMetric.avgHrv[] in
+// ms, oldest -> newest (nils allowed for missing nights). Physiologically implausible nights are dropped
+// through the shared Baselines.hrvCfg bounds (5..250 ms) so one decode glitch can't skew it.
+//
+// OUTPUT (HRVReadinessResult): the tier (primed / normal / suppressed), the 7-night baseline and the
+// personal normal band (all back in ms via exp), and an informational overreaching-watch flag. Returns nil
+// (the honest ".calibrating" edge) below `minNights` valid nights: never a fabricated number. Mirrors the
+// WatchRecovery nil+.calibrating honesty pattern.
+//
+// This is a rough / early experiment: it is NOT yet validated against varying real data (n=1). Outputs are
+// APPROXIMATE wellness estimates, not medical advice.
+
+/// Where tonight's 7-night HRV baseline sits vs the personal normal band. Mirrors Kotlin `ReadinessTier`.
+public enum ReadinessTier: String, Equatable, Sendable {
+    case primed
+    case normal
+    case suppressed
+}
+
+/// Result of an `HRVReadiness.evaluate` pass. All `*Ms` fields are back in milliseconds (exp of the log
+/// domain the engine works in). Mirrors Kotlin `HRVReadinessResult`.
+public struct HRVReadinessResult: Equatable, Sendable {
+    /// Tier from the SWC comparison of the 7-night baseline against the personal normal band.
+    public let tier: ReadinessTier
+    /// 7-night rolling HRV baseline (ms) = exp(mean of ln RMSSD over the trailing rollWindow nights).
+    public let baseline7Ms: Double
+    /// Lower edge of the personal normal band (ms) = exp(longMean − 0.5·longSD).
+    public let normalLowMs: Double
+    /// Upper edge of the personal normal band (ms) = exp(longMean + 0.5·longSD).
+    public let normalHighMs: Double
+    /// Informational only (does NOT change the tier): a sustained falling CV trend while the 7-night
+    /// baseline sits below the long mean — the classic parasympathetic-overreaching signature.
+    public let overreachingWatch: Bool
+
+    public init(tier: ReadinessTier, baseline7Ms: Double, normalLowMs: Double, normalHighMs: Double,
+                overreachingWatch: Bool) {
+        self.tier = tier
+        self.baseline7Ms = baseline7Ms
+        self.normalLowMs = normalLowMs
+        self.normalHighMs = normalHighMs
+        self.overreachingWatch = overreachingWatch
+    }
+}
+
+/// OPT-IN experimental HRV-readiness (Plews/Altini SWC) engine. Mirrors Kotlin `HRVReadiness`.
+public enum HRVReadiness {
+
+    // MARK: - Constants (name them; mirror Kotlin exactly)
+
+    /// Short rolling baseline window (nights) — the Plews/Altini 7-night HRV baseline.
+    public static let rollWindow: Int = 7
+    /// Long personal-normal window (nights) when enough valid nights exist.
+    public static let longWindow: Int = 60
+    /// Long-window fallback (nights) when fewer than `longWindow` valid nights are banked.
+    public static let longWindowFallback: Int = 30
+    /// Smallest-worthwhile-change half-width factor: the normal band is longMean ± swcK·longSD.
+    public static let swcK: Double = 0.5
+    /// Minimum VALID nights before a reading is offered (else nil + the honest calibrating edge). Its OWN
+    /// constant — deliberately NOT aliased to `WatchRecovery.minBaselineNights`: the SWC band needs a longer
+    /// warm-up than the watch-recovery gate. It only mirrors WatchRecovery's nil+.calibrating HONESTY
+    /// pattern, not its value.
+    public static let minNights: Int = 14
+    /// Trailing nights over which the CV trend (overreaching watch) is fit.
+    public static let cvTrendWindow: Int = 28
+    /// Floor on the long-window SD so a flat history yields a deterministic, tiny non-degenerate normal band
+    /// instead of an ULP-fragile zero-width one (baseline7 and longMean are both the mean of the same
+    /// constant here, but can differ by a float ULP, which a zero-width band would flip to primed/suppressed).
+    public static let longSDFloor: Double = 1e-9
+
+    // MARK: - Evaluate
+
+    /// Compute the Plews/Altini HRV-readiness reading. Returns nil (calibrating) below `minNights` valid
+    /// nights — never a fabricated value.
+    ///
+    /// - Parameter avgHrv: nightly RMSSD (ms), oldest -> newest; nils = missing nights. Out-of-range nights
+    ///   (outside `Baselines.hrvCfg` 5..250 ms) are dropped as decode artefacts.
+    public static func evaluate(avgHrv: [Double?]) -> HRVReadinessResult? {
+        let cfg = Baselines.hrvCfg
+        // Drop nils + physiologically implausible nights (shared bounds), keep order oldest -> newest.
+        let valid = avgHrv.compactMap { v -> Double? in
+            guard let v = v, cfg.minVal <= v && v <= cfg.maxVal else { return nil }
+            return v
+        }
+        // Honesty gate: below minNights valid nights we refuse to score (calibrating). Never fabricate.
+        guard valid.count >= minNights else { return nil }
+
+        // Log domain: ln RMSSD (Plews/Altini). max(.,1.0) guards ln of a sub-1 value; bounds already keep it >=5.
+        let ell = valid.map { log(max($0, 1.0)) }
+
+        // 7-night rolling baseline (the short, robust HRV baseline).
+        let baseline7 = RecoveryForecaster.mean(Array(ell.suffix(rollWindow)))
+
+        // Long personal-normal window: longWindow if we have that many valid nights, else the 30-night fallback.
+        let longWin = valid.count >= longWindow ? longWindow : longWindowFallback
+        let longEll = Array(ell.suffix(longWin))
+        let longMean = RecoveryForecaster.mean(longEll)
+        // SD over the long window; if fewer than 2 long nights, fall back to the 7-night SD; floored so a
+        // flat history gives a deterministic tiny band rather than an ULP-fragile zero-width one.
+        let longSDraw = longEll.count >= 2 ? RecoveryForecaster.sampleSD(longEll)
+                                           : RecoveryForecaster.sampleSD(Array(ell.suffix(rollWindow)))
+        let longSD = max(longSDraw, longSDFloor)
+
+        // Smallest-worthwhile-change band (±0.5 SD in the log domain).
+        let swcHalf = swcK * longSD
+        let normalLow = longMean - swcHalf
+        let normalHigh = longMean + swcHalf
+
+        // Tier: above the band -> primed; inside (inclusive of the low edge) -> normal; below -> suppressed.
+        let tier: ReadinessTier
+        if baseline7 > normalHigh {
+            tier = .primed
+        } else if baseline7 >= normalLow {
+            tier = .normal
+        } else {
+            tier = .suppressed
+        }
+
+        // Overreaching watch (INFORMATIONAL — never changes the tier): a sustained FALLING coefficient-of-
+        // variation trend while the 7-night baseline sits below the long mean (parasympathetic overreach).
+        // Build a rolling CV series (one point per night with a full trailing-7 window) over the last
+        // cvTrendWindow nights, then OLS its slope.
+        var cvSeries: [Double] = []
+        let cvStart = max(rollWindow - 1, ell.count - cvTrendWindow)
+        var i = cvStart
+        while i < ell.count {
+            let w = Array(ell[(i - rollWindow + 1)...i])
+            let m = RecoveryForecaster.mean(w)
+            let cv = m != 0.0 ? 100.0 * RecoveryForecaster.sampleSD(w) / m : 0.0
+            cvSeries.append(cv)
+            i += 1
+        }
+        let cvSlope = RecoveryForecaster.leastSquaresSlope(cvSeries)
+        let overreachingWatch = cvSlope < 0.0 && baseline7 < longMean
+
+        return HRVReadinessResult(tier: tier,
+                                  baseline7Ms: exp(baseline7),
+                                  normalLowMs: exp(normalLow),
+                                  normalHighMs: exp(normalHigh),
+                                  overreachingWatch: overreachingWatch)
+    }
+}

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/HRVReadinessTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/HRVReadinessTests.swift
@@ -1,0 +1,69 @@
+import XCTest
+@testable import StrandAnalytics
+
+/// HRVReadiness (Plews/Altini SWC) — the OPT-IN experimental HRV-readiness tier readout. The oracle for the
+/// Android HRVReadinessTest; keep the two in lockstep (same fixtures, same assertions). Pins each tier on a
+/// fixture series and the < minNights calibrating/nil edge (including that physiologically implausible
+/// nights are dropped BEFORE the gate). Read-only variant: it feeds no downstream gate, so there is nothing
+/// else to assert.
+final class HRVReadinessTests: XCTestCase {
+
+    // A high-then-primed history: 53 nights at 50 ms, the last 7 at 75 ms — the 7-night baseline sits
+    // well above the personal normal band, so the tier reads .primed.
+    private let primedHistory: [Double?] =
+        Array(repeating: 50.0, count: 53) + Array(repeating: 75.0, count: 7)
+
+    // The mirror: 53 nights at 50 ms, the last 7 at 38 ms — the 7-night baseline sits below the band, .suppressed.
+    private let suppressedHistory: [Double?] =
+        Array(repeating: 50.0, count: 53) + Array(repeating: 38.0, count: 7)
+
+    // A perfectly flat history: baseline7 == longMean exactly, so the band collapses to the mean → .normal.
+    private let flatHistory: [Double?] = Array(repeating: 60.0, count: 60)
+
+    // MARK: - Tier
+
+    func testPrimedFixtureTier() {
+        let r = HRVReadiness.evaluate(avgHrv: primedHistory)
+        XCTAssertNotNil(r)
+        XCTAssertEqual(r!.tier, .primed)
+        // The 7-night baseline is the last-7 mean, exp back to ms: exp(ln 75) = 75.
+        XCTAssertEqual(r!.baseline7Ms, 75.0, accuracy: 1e-6)
+        // Baseline above the long mean → the overreaching (falling-CV-while-below-mean) watch cannot fire.
+        XCTAssertFalse(r!.overreachingWatch)
+    }
+
+    func testSuppressedFixtureTier() {
+        let r = HRVReadiness.evaluate(avgHrv: suppressedHistory)
+        XCTAssertNotNil(r)
+        XCTAssertEqual(r!.tier, .suppressed)
+        XCTAssertEqual(r!.baseline7Ms, 38.0, accuracy: 1e-6)
+    }
+
+    func testFlatHistoryIsNormalAndBandCollapsesToMean() {
+        let r = HRVReadiness.evaluate(avgHrv: flatHistory)
+        XCTAssertNotNil(r)
+        XCTAssertEqual(r!.tier, .normal)
+        // baseline7 == longMean and longSD == 0 → the band collapses to the mean, all reading back to 60 ms.
+        XCTAssertEqual(r!.baseline7Ms, 60.0, accuracy: 1e-6)
+        XCTAssertEqual(r!.normalLowMs, 60.0, accuracy: 1e-6)
+        XCTAssertEqual(r!.normalHighMs, 60.0, accuracy: 1e-6)
+    }
+
+    // MARK: - Calibrating / nil edge (< minNights valid nights)
+
+    func testBelowMinNightsIsNil() {
+        // 13 valid nights is one short of the gate → nil (honest calibrating, never fabricated).
+        XCTAssertNil(HRVReadiness.evaluate(avgHrv: Array(repeating: 60.0, count: HRVReadiness.minNights - 1)))
+        // Exactly minNights valid nights → a reading appears.
+        XCTAssertNotNil(HRVReadiness.evaluate(avgHrv: Array(repeating: 60.0, count: HRVReadiness.minNights)))
+    }
+
+    func testOutOfRangeNightsAreDroppedBeforeGate() {
+        // 13 in-range + 5 implausible (300 ms > hrvCfg.maxVal) → only 13 valid → still calibrating (nil).
+        let mixed: [Double?] = Array(repeating: 60.0, count: 13) + Array(repeating: 300.0, count: 5)
+        XCTAssertNil(HRVReadiness.evaluate(avgHrv: mixed))
+        // Add one more in-range night → 14 valid → a reading appears (the implausible nights never count).
+        let ok: [Double?] = Array(repeating: 60.0, count: 14) + Array(repeating: 300.0, count: 5)
+        XCTAssertNotNil(HRVReadiness.evaluate(avgHrv: ok))
+    }
+}

--- a/Packages/WhoopProtocol/Sources/WhoopProtocol/HistoricalStreams.swift
+++ b/Packages/WhoopProtocol/Sources/WhoopProtocol/HistoricalStreams.swift
@@ -96,7 +96,13 @@ public func extractHistoricalStreams(_ parsed: [ParsedFrame],
                                      // oldest/newest markers for THIS sync. nil on the replay/import/no-range
                                      // paths — the gate then falls back to the absolute-only floor (unchanged).
                                      sessionOldestUnix: Int? = nil,
-                                     sessionNewestUnix: Int? = nil) -> Streams {
+                                     sessionNewestUnix: Int? = nil,
+                                     // Opt-in "HR-from-PPG sub-lag interpolation" (Test Centre → Experimental
+                                     // algorithms, default false): threaded into the v26 PPG-HR estimator below.
+                                     // The pure package can't read prefs, so the app-layer caller (Backfiller /
+                                     // archive replay) reads PuffinExperiment.ppgHrSubLagInterpEnabled and passes
+                                     // it. Default false = byte-identical to today. Mirrors the Android arg.
+                                     subLagInterp: Bool = false) -> Streams {
     func wall(_ deviceTs: Int?) -> Int? {
         guard let d = deviceTs else { return nil }
         return wallClockRef + (d - deviceClockRef)
@@ -264,7 +270,7 @@ public func extractHistoricalStreams(_ parsed: [ParsedFrame],
     }
     // Derive per-second HR from the collected v26 PPG bursts (issue #156). Empty when there were no v26
     // records (the WHOOP 4 / v18-only common case), so this is a no-op cost there.
-    out.ppgHr = PpgHr.derivePpgHr(records: ppgRecords)
+    out.ppgHr = PpgHr.derivePpgHr(records: ppgRecords, subLagInterp: subLagInterp)
     out.droppedImplausible = droppedImplausible   // #547 diag count (not persisted, not encoded)
     out.droppedImplausibleOldestTs = droppedOldest   // #324 poisoned-range epoch span (diag only)
     out.droppedImplausibleNewestTs = droppedNewest

--- a/Packages/WhoopProtocol/Sources/WhoopProtocol/PpgHr.swift
+++ b/Packages/WhoopProtocol/Sources/WhoopProtocol/PpgHr.swift
@@ -102,7 +102,8 @@ public enum PpgHr {
                                 fs: Int = sampleRateHz,
                                 loBpm: Double = hrLoBpm,
                                 hiBpm: Double = hrHiBpm,
-                                minConf: Double = minConfidence) -> (bpm: Double, conf: Double)? {
+                                minConf: Double = minConfidence,
+                                subLagInterp: Bool = false) -> (bpm: Double, conf: Double)? {
         guard samples.count >= fs * 3 else { return nil }   // need >= 3 s to resolve a low HR
         // De-artifact (#194) THEN linear-detrend, so the autocorrelation sees the pulse, not the
         // record-rate comb that would peg a low HR at 60 bpm.
@@ -133,9 +134,23 @@ public enum PpgHr {
             }
         }
         let lag = bestLag ?? (vals.max { $0.value < $1.value }!.key)
-        // Round to whole bpm (matching Android's Math.round) — the lag is integer so sub-bpm precision
-        // isn't real signal, and whole bpm keeps the value + type in lockstep with Android (#219).
-        let bpm = (fsD * 60 / Double(lag)).rounded()
+        // Sub-lag parabolic interpolation (Variant A, opt-in): refine the integer `lag` by fitting a
+        // parabola to the ACF peak and its two neighbours, so a true HR sitting BETWEEN two integer lags is
+        // not quantized (integer lags step ~16 bpm near 150 bpm, so the estimate can be off up to ~±8 bpm).
+        // Guarded to interior lags; a non-concave fit (denom >= 0) or a clamp-defended one falls back to the
+        // integer lag. Default OFF is byte-identical to the integer-lag estimate. Mirror of the Kotlin branch.
+        var refinedLag = Double(lag)
+        if subLagInterp, lag - 1 >= loLag, lag + 1 <= hiLag {
+            let y0 = vals[lag - 1]!, y1 = vals[lag]!, y2 = vals[lag + 1]!
+            let denom = y0 - 2 * y1 + y2
+            if denom < 0 {
+                let delta = min(1.0, max(-1.0, 0.5 * (y0 - y2) / denom))
+                refinedLag = min(Double(hiLag), max(Double(loLag), Double(lag) + delta))
+            }
+        }
+        // Round to whole bpm (matching Android's Math.round) — whole bpm keeps the value + type in lockstep
+        // with Android (#219). conf stays the integer `lag`'s peak (refinement moves frequency, not confidence).
+        let bpm = (fsD * 60 / refinedLag).rounded()
         let conf = (vals[lag]! * 1000).rounded() / 1000
         return (bpm, conf)
     }
@@ -147,7 +162,8 @@ public enum PpgHr {
     /// yielded a confident estimate, ascending by ts. Records may be unsorted / contain gaps.
     public static func derivePpgHr(records: [(ts: Int, samples: [Int])],
                                    fs: Int = sampleRateHz,
-                                   windowSeconds: Int = windowSeconds) -> [PpgHrSample] {
+                                   windowSeconds: Int = windowSeconds,
+                                   subLagInterp: Bool = false) -> [PpgHrSample] {
         guard !records.isEmpty else { return [] }
         // One waveform per second (last write wins on a duplicate ts).
         var secs = [Int: [Int]]()
@@ -173,7 +189,7 @@ public enum PpgHr {
                 guard win.count >= 3 else { continue }
                 var sig = [Int]()
                 for u in win { sig.append(contentsOf: secs[u]!) }
-                if let est = estimate(sig, fs: fs) {
+                if let est = estimate(sig, fs: fs, subLagInterp: subLagInterp) {
                     out.append(PpgHrSample(ts: t, bpm: Int(est.bpm), conf: est.conf))
                 }
             }

--- a/Packages/WhoopProtocol/Tests/WhoopProtocolTests/PpgHrTests.swift
+++ b/Packages/WhoopProtocol/Tests/WhoopProtocolTests/PpgHrTests.swift
@@ -109,6 +109,28 @@ final class PpgHrTests: XCTestCase {
         if let est { XCTAssertEqual(est.bpm, 60, accuracy: 2.0) }
     }
 
+    func testSubLagInterpolationRecoversHrsThatIntegerLagQuantizes() throws {
+        // Derived-biosignal standard (CLAUDE.md): recover MULTIPLE injected values, not one. Each true HR
+        // here sits BETWEEN integer autocorrelation lags at 24 Hz (period = 1440/bpm samples), so the nearest
+        // integer lag is > 2 bpm off and the default integer-lag estimator quantizes AWAY from the truth,
+        // while the opt-in parabolic sub-lag interpolation (Variant A) refines the ACF peak and recovers it
+        // within +-2 bpm. Twin of the Kotlin PpgHrTest case. (Exact-integer-lag rates 120/160/180 are avoided.)
+        for trueBpm in [137.0, 150.0, 163.0, 170.0] {
+            var sig = [Int]()
+            for s in 0..<16 { sig.append(contentsOf: sineSecond(bpm: trueBpm, startSample: s * fs)) }
+
+            // Default OFF = byte-identical to today: integer-lag quantization, not within +-2 of the truth.
+            let off = try XCTUnwrap(PpgHr.estimate(sig))
+            XCTAssertGreaterThan(abs(off.bpm - trueBpm), 2,
+                                 "default path should quantize away from \(trueBpm) (got \(off.bpm))")
+
+            // Variant ON: parabolic sub-lag interpolation lands within +-2 bpm of the true rate.
+            let on = try XCTUnwrap(PpgHr.estimate(sig, subLagInterp: true))
+            XCTAssertEqual(on.bpm, trueBpm, accuracy: 2.0,
+                           "sub-lag interp should recover \(trueBpm)+-2 (got \(on.bpm))")
+        }
+    }
+
     /// Streams decode tolerance: a JSON missing `ppg_hr` still decodes (defaults to empty), and a
     /// present `ppg_hr` round-trips. Mirrors the decodeIfPresent guard for the other biometric keys.
     func testStreamsDecodeToleratesMissingAndPresentPpgHr() throws {

--- a/Strand/BLE/PuffinExperiment.swift
+++ b/Strand/BLE/PuffinExperiment.swift
@@ -68,6 +68,17 @@ enum PuffinExperiment {
             : UserDefaults.standard.bool(forKey: experimentalSleepV2Key)
     }
 
+    /// Opt-in "HR-from-PPG sub-lag interpolation" (default off): the v26 optical-PPG gap-fill HR estimator
+    /// (`PpgHr`) refines its integer autocorrelation lag with a parabolic (Variant A) interpolation of the
+    /// ACF peak, removing the ~±8 bpm lag-quantization near a high HR. Pure opt-in research variant: default
+    /// OFF is byte-identical to the integer-lag estimate, and it only ever fills seconds the strap never
+    /// reported an HR for (it NEVER overrides a WHOOP-stored HR). The pure `PpgHr` package cannot read prefs,
+    /// so the app-layer call site (the Backfiller / archive replay) reads this flag and threads it into the
+    /// estimator. Mirrors the Android `PuffinExperiment.KEY_PPG_HR_SUBLAG_INTERP`.
+    static let ppgHrSubLagInterpKey = "noopPpgHrSubLagInterp"
+
+    static var ppgHrSubLagInterpEnabled: Bool { UserDefaults.standard.bool(forKey: ppgHrSubLagInterpKey) }
+
     /// Opt-in "Auto-detect workouts": after a sync / on Today appear, scan the last day or two of HR for a
     /// SUSTAINED-ELEVATED window (resting HR + 30 bpm held ≥ 12 min) that doesn't overlap a saved workout,
     /// and surface ONE dismissible Today card offering to save it as a manual-style workout. Pure read +

--- a/Strand/BLE/PuffinExperiment.swift
+++ b/Strand/BLE/PuffinExperiment.swift
@@ -79,6 +79,13 @@ enum PuffinExperiment {
 
     static var ppgHrSubLagInterpEnabled: Bool { UserDefaults.standard.bool(forKey: ppgHrSubLagInterpKey) }
 
+    /// Opt-in experimental "HRV readiness (Plews/Altini)" tier readout (default off): a read-only Test Centre
+    /// readout of the SWC log-HRV tier (`HRVReadiness`). It changes NOTHING downstream — the Charge ring stays
+    /// byte-identical whether on or off; it only surfaces the tier + baseline band in the Experimental
+    /// algorithms card. Rough / early (n=1, not yet validated against varying real data). Read directly by the
+    /// Test Centre view via @AppStorage on this key. Mirrors the Android `PuffinExperiment.KEY_HRV_READINESS`.
+    static let hrvReadinessKey = "noopHrvReadiness"
+
     /// Opt-in "Auto-detect workouts": after a sync / on Today appear, scan the last day or two of HR for a
     /// SUSTAINED-ELEVATED window (resting HR + 30 bpm held ≥ 12 min) that doesn't overlap a saved workout,
     /// and surface ONE dismissible Today card offering to save it as a manual-style workout. Pure read +

--- a/Strand/Collect/Backfiller.swift
+++ b/Strand/Collect/Backfiller.swift
@@ -182,8 +182,12 @@ final class Backfiller {
          connectionActive: @escaping () -> Bool = { false },
          connectionLog: ((String) -> Void)? = nil,
          firmwareLayout: ((Int) -> Void)? = nil,
+         // The default (prod) Extractor reads the opt-in HR-from-PPG sub-lag interpolation flag (Test Centre →
+         // Experimental algorithms) at decode time and threads it into the pure decoder, so the pure package
+         // never reaches for UserDefaults. Default OFF = byte-identical to today. Tests inject their own seam.
          extract: @escaping Extractor = { extractHistoricalStreams($0, deviceClockRef: $1, wallClockRef: $2,
-                                                                    sessionOldestUnix: $3, sessionNewestUnix: $4) }) {
+                                                                    sessionOldestUnix: $3, sessionNewestUnix: $4,
+                                                                    subLagInterp: PuffinExperiment.ppgHrSubLagInterpEnabled) }) {
         self.store = store
         self.deviceId = deviceId
         self.ackTrim = ackTrim

--- a/Strand/Collect/RawHistoryArchive.swift
+++ b/Strand/Collect/RawHistoryArchive.swift
@@ -243,8 +243,11 @@ struct RawHistoryArchive {
         for family in Set(archived.map(\.family)) {
             let parsed = archived.filter { $0.family == family }.map { parseFrame($0.frame, family: family) }
             // type-47 records carry their own real-unix ts (clock offset ignored), so an identity
-            // clock ref is correct here — the same fallback the Backfiller uses when clockRef is nil.
-            let streams = extractHistoricalStreams(parsed, deviceClockRef: 0, wallClockRef: 0)
+            // clock ref is correct here — the same fallback the Backfiller uses when clockRef is nil. Thread
+            // the opt-in HR-from-PPG sub-lag interpolation flag (Test Centre → Experimental algorithms) so the
+            // archive replay re-derives v26 HR with the same variant the live offload uses. Default OFF.
+            let streams = extractHistoricalStreams(parsed, deviceClockRef: 0, wallClockRef: 0,
+                                                   subLagInterp: PuffinExperiment.ppgHrSubLagInterpEnabled)
             // Count rows ACTUALLY inserted, not decoded: under the per-app-version gate the archive
             // replays every release, and dedupe makes those re-runs insert 0 — counting decoded rows
             // would log a false "retro-decoded N" success on every update. (#152)

--- a/Strand/Screens/TestCentreView.swift
+++ b/Strand/Screens/TestCentreView.swift
@@ -34,6 +34,10 @@ struct TestCentreView: View {
     /// The strap model the user last picked, the same key SettingsView's showFiveMGControls gate reads.
     @AppStorage("selectedWhoopModel") private var selectedWhoopModelRaw = WhoopModel.whoop4.rawValue
 
+    // Section 4: Experimental algorithms. Bound to the SAME PuffinExperiment key the Android card writes, so
+    // the platforms stay in lockstep. The PPG-HR sub-lag interpolation variant, default OFF.
+    @AppStorage(PuffinExperiment.ppgHrSubLagInterpKey) private var ppgHrSubLagInterpEnabled = false
+
     /// True when the connected strap is a 5/MG, so the 5/MG experimental block shows. Mirrors the
     /// SettingsView gate (#22): a confident 4.0 owner never sees controls that cannot touch their strap.
     private var is5MG: Bool { selectedWhoopModelRaw == WhoopModel.whoop5mg.rawValue }
@@ -52,6 +56,7 @@ struct TestCentreView: View {
                 domainModesCard.staggeredAppear(index: 0)
                 diagnosticToolsCard.staggeredAppear(index: 1)
                 exportCard.staggeredAppear(index: 2)
+                experimentalAlgorithmsCard.staggeredAppear(index: 3)
             }
         }
         .id(refreshToken)
@@ -212,6 +217,34 @@ struct TestCentreView: View {
                         .font(StrandFont.caption).foregroundStyle(StrandPalette.textTertiary)
                         .fixedSize(horizontal: false, vertical: true)
                 }
+            }
+        }
+    }
+
+    // MARK: - Section 4: Experimental algorithms (opt-in, off-by-default research variants)
+
+    /// The single home for OPT-IN, non-clinical research variants that swap which model computes a metric
+    /// (never detection, never a stored WHOOP value). Each toggle writes the SAME PuffinExperiment key its
+    /// Android twin reads. Hosts the HR-from-PPG sub-lag interpolation variant. Twin of the Android
+    /// ExperimentalAlgorithmsCard.
+    @ViewBuilder private var experimentalAlgorithmsCard: some View {
+        NoopCard {
+            VStack(alignment: .leading, spacing: NoopMetrics.space3) {
+                Text("EXPERIMENTAL ALGORITHMS")
+                    .font(StrandFont.overline).tracking(StrandFont.overlineTracking)
+                    .foregroundStyle(StrandPalette.textSecondary)
+                Text("Research-grade alternatives / precision tweaks. Opt-in, off by default, non-clinical.")
+                    .font(StrandFont.caption).foregroundStyle(StrandPalette.textTertiary)
+                    .fixedSize(horizontal: false, vertical: true)
+
+                Toggle(isOn: $ppgHrSubLagInterpEnabled) {
+                    Text("HR-from-PPG sub-lag interpolation (v26 gap-fill)")
+                        .font(StrandFont.subhead).foregroundStyle(StrandPalette.textPrimary)
+                }
+                .toggleStyle(.switch).tint(StrandPalette.accent)
+                Text("When NOOP reconstructs heart rate from the WHOOP 5/MG v26 optical waveform (the seconds the strap stored no HR), refine the autocorrelation peak with a parabolic sub-lag fit so the estimate is not quantized to roughly 16 bpm steps near a high HR. It only fills seconds the strap never reported; it never overrides a stored HR. 5/MG only, off by default.")
+                    .font(StrandFont.caption).foregroundStyle(StrandPalette.textTertiary)
+                    .fixedSize(horizontal: false, vertical: true)
             }
         }
     }

--- a/Strand/Screens/TestCentreView.swift
+++ b/Strand/Screens/TestCentreView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 import StrandDesign
 import StrandAnalytics
 import StrandImport
+import WhoopStore
 
 /// Settings -> Test Centre. The single home for every diagnostic, log and test control (spec section 7).
 ///
@@ -34,9 +35,11 @@ struct TestCentreView: View {
     /// The strap model the user last picked, the same key SettingsView's showFiveMGControls gate reads.
     @AppStorage("selectedWhoopModel") private var selectedWhoopModelRaw = WhoopModel.whoop4.rawValue
 
-    // Section 4: Experimental algorithms. Bound to the SAME PuffinExperiment key the Android card writes, so
-    // the platforms stay in lockstep. The PPG-HR sub-lag interpolation variant, default OFF.
+    // Section 4: Experimental algorithms. Bound to the SAME PuffinExperiment keys the Android card writes, so
+    // the platforms stay in lockstep. The PPG-HR sub-lag interpolation variant and the HRV-readiness readout,
+    // both default OFF.
     @AppStorage(PuffinExperiment.ppgHrSubLagInterpKey) private var ppgHrSubLagInterpEnabled = false
+    @AppStorage(PuffinExperiment.hrvReadinessKey) private var hrvReadinessEnabled = false
 
     /// True when the connected strap is a 5/MG, so the 5/MG experimental block shows. Mirrors the
     /// SettingsView gate (#22): a confident 4.0 owner never sees controls that cannot touch their strap.
@@ -245,7 +248,71 @@ struct TestCentreView: View {
                 Text("When NOOP reconstructs heart rate from the WHOOP 5/MG v26 optical waveform (the seconds the strap stored no HR), refine the autocorrelation peak with a parabolic sub-lag fit so the estimate is not quantized to roughly 16 bpm steps near a high HR. It only fills seconds the strap never reported; it never overrides a stored HR. 5/MG only, off by default.")
                     .font(StrandFont.caption).foregroundStyle(StrandPalette.textTertiary)
                     .fixedSize(horizontal: false, vertical: true)
+
+                Divider().overlay(StrandPalette.hairline)
+
+                Toggle(isOn: $hrvReadinessEnabled) {
+                    Text("HRV readiness (Plews/Altini)")
+                        .font(StrandFont.subhead).foregroundStyle(StrandPalette.textPrimary)
+                }
+                .toggleStyle(.switch).tint(StrandPalette.accent)
+                Text("A read-only Plews/Altini smallest-worthwhile-change reading of your nightly HRV: it shows whether your 7-night HRV baseline sits above, inside, or below your personal normal band. It changes nothing else - the Charge ring is identical whether this is on or off. This is rough / early testing, not yet validated against varying real data (n=1).")
+                    .font(StrandFont.caption).foregroundStyle(StrandPalette.textTertiary)
+                    .fixedSize(horizontal: false, vertical: true)
+
+                // The toggle's OWN effect, shown in place: when on, the live Plews/Altini reading. Nothing
+                // renders when off, so the flag off is zero behaviour change and feeds no downstream gate.
+                if hrvReadinessEnabled { hrvReadinessReadout }
             }
+        }
+    }
+
+    /// The inline, opt-in HRV-readiness reading rendered under the "HRV readiness (Plews/Altini)" toggle when
+    /// the flag is on, so the toggle's own effect is visible in place. Reads the SAME repo-merged nightly
+    /// `DailyMetric.avgHrv` series (oldest-first) the recovery UI has and runs it through the pure
+    /// `HRVReadiness` engine; it never touches the default Charge ring or analyzeDay. Below
+    /// `HRVReadiness.minNights` valid nights it shows the honest calibrating count, never a fabricated tier.
+    /// Twin of the Android `HrvReadinessReadoutTC`.
+    @ViewBuilder private var hrvReadinessReadout: some View {
+        let result = HRVReadiness.evaluate(avgHrv: model.repo.days.map { $0.avgHrv })
+        VStack(alignment: .leading, spacing: 2) {
+            if let r = result {
+                let label = hrvTierLabel(r.tier)
+                Text("HRV readiness (experimental): \(label.word)")
+                    .font(StrandFont.subhead).foregroundStyle(label.color)
+                let base = Int(r.baseline7Ms.rounded())
+                let lo = Int(r.normalLowMs.rounded())
+                let hi = Int(r.normalHighMs.rounded())
+                let watch = r.overreachingWatch ? ", overreaching watch" : ""
+                Text("7-night baseline \(base) ms, normal \(lo) to \(hi) ms\(watch)")
+                    .font(StrandFont.caption).foregroundStyle(StrandPalette.textTertiary)
+                    .fixedSize(horizontal: false, vertical: true)
+            } else {
+                Text("HRV readiness (experimental)")
+                    .font(StrandFont.subhead).foregroundStyle(StrandPalette.textTertiary)
+                Text("Calibrating (\(hrvValidNightCount)/\(HRVReadiness.minNights) nights)")
+                    .font(StrandFont.caption).foregroundStyle(StrandPalette.textTertiary)
+            }
+        }
+    }
+
+    /// Tier -> (label word, colour). A plain function (NOT a result-builder switch) so the readiness switch
+    /// never lands inside the `@ViewBuilder` body above. Twin of the Android `when (result.tier)` mapping.
+    private func hrvTierLabel(_ tier: ReadinessTier) -> (word: String, color: Color) {
+        switch tier {
+        case .primed:     return ("primed", StrandPalette.statusPositive)
+        case .normal:     return ("normal", StrandPalette.textPrimary)
+        case .suppressed: return ("suppressed", StrandPalette.statusWarning)
+        }
+    }
+
+    /// Valid-night count for the calibrating readout, counted the same way the engine's gate does (the shared
+    /// `Baselines.hrvCfg` bounds) so the "N/minNights" it shows matches when a reading will first appear.
+    private var hrvValidNightCount: Int {
+        let cfg = Baselines.hrvCfg
+        return model.repo.days.reduce(0) { acc, d in
+            if let v = d.avgHrv, cfg.minVal <= v && v <= cfg.maxVal { return acc + 1 }
+            return acc
         }
     }
 

--- a/android/app/src/main/java/com/noop/analytics/HRVReadiness.kt
+++ b/android/app/src/main/java/com/noop/analytics/HRVReadiness.kt
@@ -1,0 +1,160 @@
+package com.noop.analytics
+
+import kotlin.math.exp
+import kotlin.math.ln
+import kotlin.math.max
+
+/*
+ * HRVReadiness.kt — OPT-IN experimental "HRV readiness (Plews/Altini)" tier readout.
+ *
+ * Faithful Kotlin twin of StrandAnalytics/HRVReadiness.swift. Cross-platform parity is the contract:
+ * every constant, gate, and formula here must stay byte-identical to the Swift source.
+ *
+ * This is a PURE, deterministic, DB-free engine and it does NOT change the default Charge/ring in any
+ * way — it is only surfaced (read-only) behind the [com.noop.ble.PuffinExperiment] `noopHrvReadiness`
+ * flag (off by default) and feeds NO downstream gate. It reimplements the endurance-science "smallest
+ * worthwhile change" (SWC) reading of nightly HRV popularised by Plews et al. and Marco Altini: work in
+ * the LOG domain (ln RMSSD is closer to normal and stabilises variance), compare a short 7-night rolling
+ * baseline against a longer personal normal band (±0.5 SD), and read the tier off where the short baseline
+ * sits relative to that band. A single bad night barely moves the 7-night baseline, so the reading is far
+ * more robust than a raw single-night z.
+ *
+ * INPUT: the SAME nightly RMSSD series RecoveryScorer / ReadinessEngine consume — DailyMetric.avgHrv[]
+ * in ms, oldest -> newest (nulls allowed for missing nights). Physiologically implausible nights are
+ * dropped through the shared [Baselines.hrvCfg] bounds (5..250 ms) so one decode glitch can't skew it.
+ *
+ * OUTPUT ([HRVReadinessResult]): the tier (primed / normal / suppressed), the 7-night baseline and the
+ * personal normal band (all back in ms via exp), and an informational overreaching-watch flag. Returns
+ * null (the honest ".calibrating" edge) below [MIN_NIGHTS] valid nights: never a fabricated number.
+ * Mirrors the WatchRecovery nil+.calibrating honesty pattern.
+ *
+ * This is a rough / early experiment: it is NOT yet validated against varying real data (n=1). Outputs
+ * are APPROXIMATE wellness estimates, not medical advice.
+ */
+
+/** Where tonight's 7-night HRV baseline sits vs the personal normal band. Mirrors Swift `ReadinessTier`. */
+enum class ReadinessTier { PRIMED, NORMAL, SUPPRESSED }
+
+/** Result of an [HRVReadiness.evaluate] pass. All *Ms fields are back in milliseconds (exp of the log
+ *  domain the engine works in). Mirrors Swift `HRVReadinessResult`. */
+data class HRVReadinessResult(
+    /** Tier from the SWC comparison of the 7-night baseline against the personal normal band. */
+    val tier: ReadinessTier,
+    /** 7-night rolling HRV baseline (ms) = exp(mean of ln RMSSD over the trailing ROLL_WINDOW nights). */
+    val baseline7Ms: Double,
+    /** Lower edge of the personal normal band (ms) = exp(longMean − 0.5·longSD). */
+    val normalLowMs: Double,
+    /** Upper edge of the personal normal band (ms) = exp(longMean + 0.5·longSD). */
+    val normalHighMs: Double,
+    /** Informational only (does NOT change the tier): a sustained falling CV trend while the 7-night
+     *  baseline sits below the long mean — the classic parasympathetic-overreaching signature. */
+    val overreachingWatch: Boolean,
+)
+
+/** OPT-IN experimental HRV-readiness (Plews/Altini SWC) engine. Mirrors Swift `HRVReadiness`. */
+object HRVReadiness {
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Constants (name them; mirror Swift exactly)
+    // ─────────────────────────────────────────────────────────────────────────
+
+    /** Short rolling baseline window (nights) — the Plews/Altini 7-night HRV baseline. */
+    const val ROLL_WINDOW: Int = 7
+
+    /** Long personal-normal window (nights) when enough valid nights exist. */
+    const val LONG_WINDOW: Int = 60
+
+    /** Long-window fallback (nights) when fewer than [LONG_WINDOW] valid nights are banked. */
+    const val LONG_WINDOW_FALLBACK: Int = 30
+
+    /** Smallest-worthwhile-change half-width factor: the normal band is longMean ± SWC_K·longSD. */
+    const val SWC_K: Double = 0.5
+
+    /**
+     * Minimum VALID nights before a reading is offered (else null + the honest calibrating edge). Its OWN
+     * constant — deliberately NOT aliased to [WatchRecovery.minBaselineNights]: the SWC band needs a longer
+     * warm-up than the watch-recovery gate. It only mirrors WatchRecovery's nil+.calibrating HONESTY
+     * pattern, not its value.
+     */
+    const val MIN_NIGHTS: Int = 14
+
+    /** Trailing nights over which the CV trend (overreaching watch) is fit. */
+    const val CV_TREND_WINDOW: Int = 28
+
+    /** Floor on the long-window SD so a flat history yields a deterministic, tiny non-degenerate normal
+     *  band instead of an ULP-fragile zero-width one (baseline7 and longMean are both the mean of the same
+     *  constant here, but can differ by a float ULP, which a zero-width band would flip to primed/suppressed). */
+    const val LONG_SD_FLOOR: Double = 1e-9
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Evaluate
+    // ─────────────────────────────────────────────────────────────────────────
+
+    /**
+     * Compute the Plews/Altini HRV-readiness reading. Returns null (calibrating) below [MIN_NIGHTS]
+     * valid nights — never a fabricated value.
+     *
+     * @param avgHrv nightly RMSSD (ms), oldest -> newest; nulls = missing nights. Out-of-range nights
+     *   (outside [Baselines.hrvCfg] 5..250 ms) are dropped as decode artefacts.
+     */
+    fun evaluate(avgHrv: List<Double?>): HRVReadinessResult? {
+        val cfg = Baselines.hrvCfg
+        // Drop nulls + physiologically implausible nights (shared bounds), keep order oldest -> newest.
+        val valid = avgHrv.mapNotNull { v ->
+            if (v != null && cfg.minVal <= v && v <= cfg.maxVal) v else null
+        }
+        // Honesty gate: below MIN_NIGHTS valid nights we refuse to score (calibrating). Never fabricate.
+        if (valid.size < MIN_NIGHTS) return null
+
+        // Log domain: ln RMSSD (Plews/Altini). max(.,1.0) guards ln of a sub-1 value; bounds already keep it >=5.
+        val ell = valid.map { ln(max(it, 1.0)) }
+
+        // 7-night rolling baseline (the short, robust HRV baseline).
+        val baseline7 = RecoveryForecaster.mean(ell.takeLast(ROLL_WINDOW))
+
+        // Long personal-normal window: LONG_WINDOW if we have that many valid nights, else the 30-night fallback.
+        val longWin = if (valid.size >= LONG_WINDOW) LONG_WINDOW else LONG_WINDOW_FALLBACK
+        val longEll = ell.takeLast(longWin)
+        val longMean = RecoveryForecaster.mean(longEll)
+        // SD over the long window; if fewer than 2 long nights, fall back to the 7-night SD; floored so a
+        // flat history gives a deterministic tiny band rather than an ULP-fragile zero-width one.
+        val longSDraw = if (longEll.size >= 2) RecoveryForecaster.sampleSD(longEll)
+        else RecoveryForecaster.sampleSD(ell.takeLast(ROLL_WINDOW))
+        val longSD = max(longSDraw, LONG_SD_FLOOR)
+
+        // Smallest-worthwhile-change band (±0.5 SD in the log domain).
+        val swcHalf = SWC_K * longSD
+        val normalLow = longMean - swcHalf
+        val normalHigh = longMean + swcHalf
+
+        // Tier: above the band -> primed; inside (inclusive of the low edge) -> normal; below -> suppressed.
+        val tier = when {
+            baseline7 > normalHigh -> ReadinessTier.PRIMED
+            baseline7 >= normalLow -> ReadinessTier.NORMAL
+            else -> ReadinessTier.SUPPRESSED
+        }
+
+        // Overreaching watch (INFORMATIONAL — never changes the tier): a sustained FALLING coefficient-of-
+        // variation trend while the 7-night baseline sits below the long mean (parasympathetic overreach).
+        // Build a rolling CV series (one point per night with a full trailing-7 window) over the last
+        // CV_TREND_WINDOW nights, then OLS its slope.
+        val cvSeries = ArrayList<Double>()
+        val cvStart = max(ROLL_WINDOW - 1, ell.size - CV_TREND_WINDOW)
+        for (i in cvStart until ell.size) {
+            val w = ell.subList(i - ROLL_WINDOW + 1, i + 1)
+            val m = RecoveryForecaster.mean(w)
+            val cv = if (m != 0.0) 100.0 * RecoveryForecaster.sampleSD(w) / m else 0.0
+            cvSeries.add(cv)
+        }
+        val cvSlope = RecoveryForecaster.leastSquaresSlope(cvSeries)
+        val overreachingWatch = cvSlope < 0.0 && baseline7 < longMean
+
+        return HRVReadinessResult(
+            tier = tier,
+            baseline7Ms = exp(baseline7),
+            normalLowMs = exp(normalLow),
+            normalHighMs = exp(normalHigh),
+            overreachingWatch = overreachingWatch,
+        )
+    }
+}

--- a/android/app/src/main/java/com/noop/ble/Backfiller.kt
+++ b/android/app/src/main/java/com/noop/ble/Backfiller.kt
@@ -108,6 +108,13 @@ class Backfiller(
      */
     private val connectionActive: () -> Boolean = { false },
     private val connectionLog: (String) -> Unit = {},
+    /**
+     * Opt-in "HR-from-PPG sub-lag interpolation" (Test Centre → Experimental algorithms, default OFF).
+     * Read as a live provider so a toggle flip mid-session takes effect on the next decoded chunk. Passed
+     * straight into [extractHistoricalStreams] so the pure decoder never reaches for prefs. Default inert
+     * (always-off) keeps the untraced/test path byte-identical. Mirrors the Swift Backfiller extract seam.
+     */
+    private val ppgHrSubLagInterp: () -> Boolean = { false },
 ) {
 
     /**
@@ -345,6 +352,7 @@ class Backfiller(
             val decoded = extractHistoricalStreams(
                 frames, ref.device, ref.wall, family,
                 sessionOldestUnix = sessionOldestUnix, sessionNewestUnix = sessionNewestUnix,
+                ppgHrSubLagInterp = ppgHrSubLagInterp(),
             )
             // Observability (PR #241): which historical layout does this strap emit? Only the unmapped/
             // reject path logged a version before, so a healthy sync never revealed v24/v25 (4.0) or

--- a/android/app/src/main/java/com/noop/ble/PuffinExperiment.kt
+++ b/android/app/src/main/java/com/noop/ble/PuffinExperiment.kt
@@ -71,6 +71,15 @@ class PuffinExperiment(private val prefs: SharedPreferences) {
         get() = prefs.getBoolean(KEY_PPG_HR_SUBLAG_INTERP, false)
         set(v) = prefs.edit().putBoolean(KEY_PPG_HR_SUBLAG_INTERP, v).apply()
 
+    /** True if the user opted in to the experimental "HRV readiness (Plews/Altini)" tier readout (default
+     *  false): a read-only Test Centre readout of the SWC log-HRV tier ([com.noop.analytics.HRVReadiness]).
+     *  It changes NOTHING downstream — the Charge ring stays byte-identical whether on or off; it only
+     *  surfaces the tier + baseline band in the Experimental algorithms card. Rough / early (n=1, not yet
+     *  validated against varying real data). Mirrors the macOS `PuffinExperiment.hrvReadinessKey`. */
+    var hrvReadiness: Boolean
+        get() = prefs.getBoolean(KEY_HRV_READINESS, false)
+        set(v) = prefs.edit().putBoolean(KEY_HRV_READINESS, v).apply()
+
     companion object {
         /** Persisted preferences file. */
         private const val PREFS = "noop_experiments"
@@ -92,6 +101,9 @@ class PuffinExperiment(private val prefs: SharedPreferences) {
 
         /** "HR-from-PPG sub-lag interpolation" opt-in (mirrors macOS `PuffinExperiment.ppgHrSubLagInterpKey`). */
         const val KEY_PPG_HR_SUBLAG_INTERP = "noopPpgHrSubLagInterp"
+
+        /** "HRV readiness (Plews/Altini)" readout opt-in (mirrors macOS `PuffinExperiment.hrvReadinessKey`). */
+        const val KEY_HRV_READINESS = "noopHrvReadiness"
 
         fun from(context: Context): PuffinExperiment =
             PuffinExperiment(context.getSharedPreferences(PREFS, Context.MODE_PRIVATE))

--- a/android/app/src/main/java/com/noop/ble/PuffinExperiment.kt
+++ b/android/app/src/main/java/com/noop/ble/PuffinExperiment.kt
@@ -59,6 +59,18 @@ class PuffinExperiment(private val prefs: SharedPreferences) {
         get() = prefs.getBoolean(KEY_EXPERIMENTAL_SLEEP_V2, true)
         set(v) = prefs.edit().putBoolean(KEY_EXPERIMENTAL_SLEEP_V2, v).apply()
 
+    /** True if the user opted in to "HR-from-PPG sub-lag interpolation" (default false): the v26 optical-PPG
+     *  gap-fill HR estimator ([com.noop.protocol.PpgHr]) refines its integer autocorrelation lag with a
+     *  parabolic (Variant A) interpolation of the ACF peak, removing the ~+-8 bpm lag-quantization near a
+     *  high HR. Pure OPT-IN research variant: default OFF is byte-identical to the integer-lag estimate, and
+     *  it only ever fills seconds the strap never reported an HR for (it NEVER overrides a WHOOP-stored HR).
+     *  The pure [com.noop.protocol.PpgHr] package cannot read prefs, so this flag is read at the app-layer
+     *  call site (the Backfiller / archive replay / capture import) and threaded into the estimator. Mirrors
+     *  the macOS `PuffinExperiment.ppgHrSubLagInterpKey`. */
+    var ppgHrSubLagInterp: Boolean
+        get() = prefs.getBoolean(KEY_PPG_HR_SUBLAG_INTERP, false)
+        set(v) = prefs.edit().putBoolean(KEY_PPG_HR_SUBLAG_INTERP, v).apply()
+
     companion object {
         /** Persisted preferences file. */
         private const val PREFS = "noop_experiments"
@@ -77,6 +89,9 @@ class PuffinExperiment(private val prefs: SharedPreferences) {
 
         /** "Experimental sleep staging (V2)" opt-in (mirrors macOS `PuffinExperiment.experimentalSleepV2Key`). */
         const val KEY_EXPERIMENTAL_SLEEP_V2 = "noopExperimentalSleepV2"
+
+        /** "HR-from-PPG sub-lag interpolation" opt-in (mirrors macOS `PuffinExperiment.ppgHrSubLagInterpKey`). */
+        const val KEY_PPG_HR_SUBLAG_INTERP = "noopPpgHrSubLagInterp"
 
         fun from(context: Context): PuffinExperiment =
             PuffinExperiment(context.getSharedPreferences(PREFS, Context.MODE_PRIVATE))

--- a/android/app/src/main/java/com/noop/ble/RawHistoryArchive.kt
+++ b/android/app/src/main/java/com/noop/ble/RawHistoryArchive.kt
@@ -143,8 +143,13 @@ class RawHistoryArchive(
         for (family in archived.map { it.second }.toSet()) {
             val frames = archived.filter { it.second == family }.map { it.first }
             // type-47 records carry their own real-unix ts (clock offset ignored), so an identity clock
-            // ref is correct here — the same fallback the Backfiller uses when clockRef is nil.
-            val decoded = extractHistoricalStreams(frames, 0, 0, family)
+            // ref is correct here — the same fallback the Backfiller uses when clockRef is nil. Thread the
+            // opt-in HR-from-PPG sub-lag interpolation flag (Test Centre → Experimental algorithms) so the
+            // archive replay re-derives v26 HR with the same variant the live offload uses. Default OFF.
+            val decoded = extractHistoricalStreams(
+                frames, 0, 0, family,
+                ppgHrSubLagInterp = PuffinExperiment.from(context).ppgHrSubLagInterp,
+            )
             // Count rows ACTUALLY inserted, not decoded: under the per-app-version gate the archive
             // replays every release, and dedupe makes those re-runs insert 0 — counting decoded rows
             // would log a false "retro-decoded N" success on every update. (#152)

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -1276,6 +1276,9 @@ class WhoopBleClient(
         // is emitted (or built) when the mode is off. Twin of the macOS Backfiller wiring.
         connectionActive = { testCentre.active(com.noop.testcentre.TestDomain.CONNECTION) },
         connectionLog = { s -> log(s, com.noop.testcentre.TestDomain.CONNECTION) },
+        // Test Centre → Experimental algorithms: the opt-in v26 PPG-HR sub-lag interpolation variant, read
+        // live each chunk so a mid-session toggle takes effect. Default OFF (byte-identical to today).
+        ppgHrSubLagInterp = { puffinExperiment.ppgHrSubLagInterp },
     )
 
     /**

--- a/android/app/src/main/java/com/noop/ingest/CaptureImporter.kt
+++ b/android/app/src/main/java/com/noop/ingest/CaptureImporter.kt
@@ -2,6 +2,7 @@ package com.noop.ingest
 
 import android.content.Context
 import android.net.Uri
+import com.noop.ble.PuffinExperiment
 import com.noop.ble.RawHistoryArchive
 import com.noop.ble.WhoopBleClient
 import com.noop.data.ImportSummary
@@ -151,8 +152,14 @@ object CaptureImporter {
      * Filter each family's frames to offload frames (drops realtime/control), then decode in a single
      * pass per family via extractHistoricalStreams with clockRef 0/0 — historical records carry an
      * embedded unix, exactly as RawHistoryArchive.replayIfNeeded decodes archived frames.
+     *
+     * [ppgHrSubLagInterp] threads the opt-in "HR-from-PPG sub-lag interpolation" flag (Test Centre →
+     * Experimental algorithms) into the v26 PPG-HR estimator, so an imported capture re-derives v26 HR
+     * with the same variant the live offload / archive replay use. Kept a pure param (not a prefs read
+     * inside this pure decode) so it stays JVM unit-testable; the importCapture caller supplies it.
+     * Default false = byte-identical to today.
      */
-    fun decode(parsed: Parsed): Decoded {
+    fun decode(parsed: Parsed, ppgHrSubLagInterp: Boolean = false): Decoded {
         val batches = LinkedHashMap<DeviceFamily, StreamBatch>()
         val rejects = LinkedHashMap<DeviceFamily, List<ByteArray>>()
         var offload = 0
@@ -160,7 +167,10 @@ object CaptureImporter {
             val offloadFrames = frames.filter { WhoopBleClient.isOffloadFrame(it, family) }
             if (offloadFrames.isEmpty()) continue
             offload += offloadFrames.size
-            val batch = extractHistoricalStreams(offloadFrames, 0, 0, family)
+            val batch = extractHistoricalStreams(
+                offloadFrames, 0, 0, family,
+                ppgHrSubLagInterp = ppgHrSubLagInterp,
+            )
             if (!batch.isEmpty) batches[family] = batch
             val rej = rejectedHistoricalRecords(offloadFrames, family)
             if (rej.isNotEmpty()) rejects[family] = rej
@@ -269,7 +279,9 @@ object CaptureImporter {
             return ImportSummary.failure(SOURCE_LABEL, "Could not read the file: ${e.message ?: "unknown error"}")
         }
 
-        val decoded = decode(parsed)
+        // Test Centre → Experimental algorithms: re-derive v26 PPG-HR with the opt-in sub-lag interpolation
+        // variant when the user has it on, matching the live offload / archive replay. Default OFF.
+        val decoded = decode(parsed, ppgHrSubLagInterp = PuffinExperiment.from(context).ppgHrSubLagInterp)
 
         // Reject-archive undecodable offload frames FIRST — before the empty-batch early return — so a
         // capture the current decoder can't map yet (e.g. a future record layout) is still preserved

--- a/android/app/src/main/java/com/noop/protocol/HistoricalStreams.kt
+++ b/android/app/src/main/java/com/noop/protocol/HistoricalStreams.kt
@@ -508,6 +508,11 @@ fun extractHistoricalStreams(
     // (unchanged). Kept in lockstep with the Swift extractHistoricalStreams session args.
     sessionOldestUnix: Long? = null,
     sessionNewestUnix: Long? = null,
+    // Opt-in "HR-from-PPG sub-lag interpolation" (Test Centre → Experimental algorithms, default false):
+    // threaded straight into the v26 PPG-HR estimator below. The pure protocol package can't read prefs, so
+    // the app-layer caller (Backfiller / archive replay / capture import) reads PuffinExperiment.ppgHrSubLagInterp
+    // and passes it. Default false = byte-identical to today. Mirrors the Swift extractHistoricalStreams arg.
+    ppgHrSubLagInterp: Boolean = false,
 ): StreamBatch {
     // Count of records dropped by the #547 plausibility gate this batch, surfaced on the returned
     // StreamBatch so the Backfiller can log "bad strap clock" once per session via its existing seam.
@@ -719,7 +724,8 @@ fun extractHistoricalStreams(
 
     // Derive HR from the accumulated v26 PPG waveform (8 s / 24 Hz autocorrelation, conf>=0.3). Empty
     // unless the strap sent v26 records; falls back gracefully (no rows) on noise (#156).
-    val ppgHr = PpgHr.estimate(ppgSamples).map { PpgHrRow(ts = it.ts, bpm = it.bpm, conf = it.conf) }
+    val ppgHr = PpgHr.estimate(ppgSamples, subLagInterp = ppgHrSubLagInterp)
+        .map { PpgHrRow(ts = it.ts, bpm = it.bpm, conf = it.conf) }
 
     return StreamBatch(
         hr = hr, rr = rr, events = events, battery = battery,

--- a/android/app/src/main/java/com/noop/protocol/PpgHr.kt
+++ b/android/app/src/main/java/com/noop/protocol/PpgHr.kt
@@ -58,7 +58,7 @@ object PpgHr {
      * split into consecutive-second runs, and a centred window is autocorrelated for each second.
      * Returns one [Estimate] per second that yielded a confident estimate, ascending by ts.
      */
-    fun estimate(samples: List<Sample>): List<Estimate> {
+    fun estimate(samples: List<Sample>, subLagInterp: Boolean = false): List<Estimate> {
         if (samples.isEmpty()) return emptyList()
         // One waveform per second, in first-seen sample order (last record wins on a duplicate ts).
         val secs = LinkedHashMap<Long, ArrayList<Int>>()
@@ -101,7 +101,7 @@ object PpgHr {
                 val sig = DoubleArray(total)
                 var idx = 0
                 for (w in win) for (v in secs[w]!!) sig[idx++] = v.toDouble()
-                estimateWindow(sig, t)?.let { out.add(it) }
+                estimateWindow(sig, t, subLagInterp)?.let { out.add(it) }
             }
         }
         out.sortBy { it.ts }
@@ -181,7 +181,7 @@ object PpgHr {
         return DoubleArray(n) { i -> x[i] - colMean[i % fs] }
     }
 
-    private fun estimateWindow(values: DoubleArray, ts: Long): Estimate? {
+    private fun estimateWindow(values: DoubleArray, ts: Long, subLagInterp: Boolean = false): Estimate? {
         if (values.size < SAMPLE_RATE_HZ * 3) return null // need >= 3 s to resolve a low HR
         // De-artifact (#194) THEN detrend, so the autocorrelation sees the pulse, not a record-rate comb.
         val x = detrend(removeRecordRateComponent(values, SAMPLE_RATE_HZ))
@@ -223,9 +223,25 @@ object PpgHr {
             bestLag = argmax
         }
 
-        // Round to whole bpm (the lag is integer, so sub-bpm precision isn't real signal) and round
-        // conf to 3 dp — both matching the Swift estimator and the measured-HR Int domain (#219).
-        val bpm = Math.round(fsD * 60 / bestLag).toInt()
+        // Sub-lag parabolic interpolation (Variant A, opt-in): refine the integer bestLag by fitting a
+        // parabola to the ACF peak and its two neighbours, so a true HR sitting BETWEEN two integer lags is
+        // not quantized (integer lags step ~16 bpm near 150 bpm, so the estimate can be off up to ~±8 bpm).
+        // Guarded to interior lags; a non-concave fit (denom >= 0) or a clamp-defended one falls back to the
+        // integer lag. Default OFF is byte-identical to the integer-lag estimate. Mirror of the Swift branch.
+        var refinedLag = bestLag.toDouble()
+        if (subLagInterp && bestLag - 1 >= loLag && bestLag + 1 <= hiLag) {
+            val y0 = vals[bestLag - 1]!!
+            val y1 = vals[bestLag]!!
+            val y2 = vals[bestLag + 1]!!
+            val denom = y0 - 2.0 * y1 + y2
+            if (denom < 0.0) {
+                val delta = (0.5 * (y0 - y2) / denom).coerceIn(-1.0, 1.0)
+                refinedLag = (bestLag.toDouble() + delta).coerceIn(loLag.toDouble(), hiLag.toDouble())
+            }
+        }
+        // Round to whole bpm (the ppgHrSample column is Int; #219) — conf stays the integer bestLag's peak
+        // (the refinement moves only the frequency, not the confidence). Matches the Swift estimator.
+        val bpm = Math.round(fsD * 60 / refinedLag).toInt()
         val conf = Math.round(vals[bestLag]!! * 1000) / 1000.0
         return Estimate(ts = ts, bpm = bpm, conf = conf)
     }

--- a/android/app/src/main/java/com/noop/ui/TestCentreScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/TestCentreScreen.kt
@@ -36,8 +36,11 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.noop.BuildConfig
 import com.noop.analytics.Baselines
+import com.noop.analytics.HRVReadiness
+import com.noop.analytics.ReadinessTier
 import com.noop.ble.PuffinExperiment
 import com.noop.ble.WhoopModel
+import com.noop.data.DailyMetric
 import com.noop.testcentre.CaptureAccumulator
 import com.noop.testcentre.CaptureKind
 import com.noop.testcentre.DisplayPerformanceMonitor
@@ -51,6 +54,7 @@ import com.noop.testcentre.TestModeRegistry
 import com.noop.testcentre.TestReportFlow
 import com.noop.testcentre.TestReportLink
 import kotlinx.coroutines.launch
+import kotlin.math.roundToInt
 
 /**
  * Settings -> Test Centre (spec section 7), the Android twin of TestCentreView. Four sections: domain
@@ -165,7 +169,7 @@ fun TestCentreScreen(vm: AppViewModel) {
         )
 
         // --- Section 4: Experimental algorithms ---
-        ExperimentalAlgorithmsCard()
+        ExperimentalAlgorithmsCard(vm)
     }
 
     pendingReport?.let { p ->
@@ -456,13 +460,19 @@ private fun ExportCard(vm: AppViewModel, onReport: () -> Unit) {
  * Test Centre → Experimental algorithms. The single home for OPT-IN, off-by-default, non-clinical research
  * variants that swap which model computes a metric (never detection, never a stored WHOOP value). Each toggle
  * writes the SAME [PuffinExperiment] key its Swift twin reads, so the platforms stay in lockstep. Hosts the
- * HR-from-PPG sub-lag interpolation variant. Twin of the Swift TestCentreView experimentalAlgorithmsCard.
+ * HR-from-PPG sub-lag interpolation variant and the read-only HRV-readiness (Plews/Altini) tier readout.
+ * Twin of the Swift TestCentreView experimentalAlgorithmsCard.
  */
 @Composable
-private fun ExperimentalAlgorithmsCard() {
+private fun ExperimentalAlgorithmsCard(vm: AppViewModel) {
     val context = LocalContext.current
     val puffin = remember { PuffinExperiment.from(context) }
     var ppgHrSubLag by remember { mutableStateOf(puffin.ppgHrSubLagInterp) }
+    var hrvReadiness by remember { mutableStateOf(puffin.hrvReadiness) }
+    // The SAME nightly HRV series the recovery UI reads (repo-merged DailyMetric.avgHrv, oldest-first), fed
+    // into the pure HRVReadiness engine ONLY to render the toggle's own reading inline below — the default
+    // Charge ring / analyzeDay path is never touched, and this feeds no downstream gate.
+    val recentDays by vm.recentDays.collectAsStateWithLifecycle()
     SettingsSectionTC(
         icon = Icons.Filled.Science,
         title = "Experimental algorithms",
@@ -477,6 +487,62 @@ private fun ExperimentalAlgorithmsCard() {
                     "seconds the strap never reported; it never overrides a stored HR. 5/MG only, off by default.",
                 checked = ppgHrSubLag,
                 onCheckedChange = { ppgHrSubLag = it; puffin.ppgHrSubLagInterp = it },
+            )
+            ToggleRowTC(
+                title = "HRV readiness (Plews/Altini)",
+                description = "A read-only Plews/Altini smallest-worthwhile-change reading of your nightly HRV: " +
+                    "it shows whether your 7-night HRV baseline sits above, inside, or below your personal " +
+                    "normal band. It changes nothing else - the Charge ring is identical whether this is on or " +
+                    "off. This is rough / early testing, not yet validated against varying real data (n=1).",
+                checked = hrvReadiness,
+                onCheckedChange = { hrvReadiness = it; puffin.hrvReadiness = it },
+            )
+            // The toggle's OWN effect, shown in place: when on, the live Plews/Altini reading. Nothing renders
+            // when off, so the flag off is zero behaviour change and feeds no downstream gate.
+            if (hrvReadiness) HrvReadinessReadoutTC(recentDays)
+        }
+    }
+}
+
+/**
+ * Inline, opt-in HRV-readiness readout. Renders directly under the "HRV readiness (Plews/Altini)" toggle when
+ * the flag is on, so the toggle's own effect is visible in place. Reads the SAME repo-merged nightly
+ * [DailyMetric.avgHrv] series (oldest-first) the recovery UI has and runs it through the pure [HRVReadiness]
+ * engine — it never touches the default Charge ring or analyzeDay. Below [HRVReadiness.MIN_NIGHTS] valid
+ * nights it shows the honest calibrating count instead of a fabricated tier. Twin of the Swift
+ * `hrvReadinessReadout`.
+ */
+@Composable
+private fun HrvReadinessReadoutTC(days: List<DailyMetric>) {
+    // Memoize the pure evaluate + valid-night count against the day-list identity so it only recomputes when
+    // the series actually changes (not on every recomposition).
+    val (result, validCount) = remember(days) {
+        val cfg = Baselines.hrvCfg
+        val series = days.map { it.avgHrv }
+        val valid = series.count { v -> v != null && v >= cfg.minVal && v <= cfg.maxVal }
+        HRVReadiness.evaluate(series) to valid
+    }
+    Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
+        if (result != null) {
+            val (word, color) = when (result.tier) {
+                ReadinessTier.PRIMED -> "primed" to Palette.statusPositive
+                ReadinessTier.NORMAL -> "normal" to Palette.textPrimary
+                ReadinessTier.SUPPRESSED -> "suppressed" to Palette.statusWarning
+            }
+            Text("HRV readiness (experimental): $word", style = NoopType.subhead, color = color)
+            val base = result.baseline7Ms.roundToInt()
+            val lo = result.normalLowMs.roundToInt()
+            val hi = result.normalHighMs.roundToInt()
+            val watch = if (result.overreachingWatch) ", overreaching watch" else ""
+            Text(
+                "7-night baseline $base ms, normal $lo to $hi ms$watch",
+                style = NoopType.footnote, color = Palette.textTertiary,
+            )
+        } else {
+            Text("HRV readiness (experimental)", style = NoopType.subhead, color = Palette.textTertiary)
+            Text(
+                "Calibrating ($validCount/${HRVReadiness.MIN_NIGHTS} nights)",
+                style = NoopType.footnote, color = Palette.textTertiary,
             )
         }
     }

--- a/android/app/src/main/java/com/noop/ui/TestCentreScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/TestCentreScreen.kt
@@ -14,6 +14,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Autorenew
 import androidx.compose.material.icons.filled.BugReport
 import androidx.compose.material.icons.filled.Info
+import androidx.compose.material.icons.filled.Science
 import androidx.compose.material.icons.filled.Upload
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Switch
@@ -162,6 +163,9 @@ fun TestCentreScreen(vm: AppViewModel) {
                 scope.launch { pendingReport = buildPending(context, MASTER_REPORT_MODE, vm.ble.exportLogText(), vm) }
             },
         )
+
+        // --- Section 4: Experimental algorithms ---
+        ExperimentalAlgorithmsCard()
     }
 
     pendingReport?.let { p ->
@@ -445,6 +449,62 @@ private fun ExportCard(vm: AppViewModel, onReport: () -> Unit) {
                 }
             }
         }
+    }
+}
+
+/**
+ * Test Centre → Experimental algorithms. The single home for OPT-IN, off-by-default, non-clinical research
+ * variants that swap which model computes a metric (never detection, never a stored WHOOP value). Each toggle
+ * writes the SAME [PuffinExperiment] key its Swift twin reads, so the platforms stay in lockstep. Hosts the
+ * HR-from-PPG sub-lag interpolation variant. Twin of the Swift TestCentreView experimentalAlgorithmsCard.
+ */
+@Composable
+private fun ExperimentalAlgorithmsCard() {
+    val context = LocalContext.current
+    val puffin = remember { PuffinExperiment.from(context) }
+    var ppgHrSubLag by remember { mutableStateOf(puffin.ppgHrSubLagInterp) }
+    SettingsSectionTC(
+        icon = Icons.Filled.Science,
+        title = "Experimental algorithms",
+        blurb = "Research-grade alternatives / precision tweaks. Opt-in, off by default, non-clinical.",
+    ) {
+        Column(verticalArrangement = Arrangement.spacedBy(16.dp)) {
+            ToggleRowTC(
+                title = "HR-from-PPG sub-lag interpolation (v26 gap-fill)",
+                description = "When NOOP reconstructs heart rate from the WHOOP 5/MG v26 optical waveform (the " +
+                    "seconds the strap stored no HR), refine the autocorrelation peak with a parabolic sub-lag " +
+                    "fit so the estimate is not quantized to roughly 16 bpm steps near a high HR. It only fills " +
+                    "seconds the strap never reported; it never overrides a stored HR. 5/MG only, off by default.",
+                checked = ppgHrSubLag,
+                onCheckedChange = { ppgHrSubLag = it; puffin.ppgHrSubLagInterp = it },
+            )
+        }
+    }
+}
+
+/** A titled toggle + caption row for the Experimental algorithms card (same NoopType/Palette tokens + switch
+ *  colours as the other Test Centre rows). Local to Test Centre so it never reaches into SettingsScreen. */
+@Composable
+private fun ToggleRowTC(
+    title: String,
+    description: String,
+    checked: Boolean,
+    onCheckedChange: (Boolean) -> Unit,
+) {
+    Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(16.dp),
+        ) {
+            Text(title, style = NoopType.subhead, color = Palette.textPrimary, modifier = Modifier.weight(1f))
+            Switch(
+                checked = checked,
+                onCheckedChange = onCheckedChange,
+                colors = settingsSwitchColors(),
+            )
+        }
+        Text(description, style = NoopType.footnote, color = Palette.textTertiary)
     }
 }
 

--- a/android/app/src/test/java/com/noop/analytics/HRVReadinessTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/HRVReadinessTest.kt
@@ -1,0 +1,79 @@
+package com.noop.analytics
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * HRVReadiness (Plews/Altini SWC) — the OPT-IN experimental HRV-readiness tier readout.
+ *
+ * The oracle for the Swift HRVReadinessTests; keep the two in lockstep (same fixtures, same assertions).
+ * Pins each tier on a fixture series and the < MIN_NIGHTS calibrating/null edge (including that
+ * physiologically implausible nights are dropped BEFORE the gate). Read-only variant: it feeds no
+ * downstream gate, so there is nothing else to assert.
+ */
+class HRVReadinessTest {
+
+    // A high-then-primed history: 53 nights at 50 ms, the last 7 at 75 ms — the 7-night baseline sits
+    // well above the personal normal band, so the tier reads PRIMED.
+    private val primedHistory: List<Double?> = List(53) { 50.0 } + List(7) { 75.0 }
+
+    // The mirror: 53 nights at 50 ms, the last 7 at 38 ms — the 7-night baseline sits below the band, SUPPRESSED.
+    private val suppressedHistory: List<Double?> = List(53) { 50.0 } + List(7) { 38.0 }
+
+    // A perfectly flat history: baseline7 == longMean exactly, so the band collapses to the mean → NORMAL.
+    private val flatHistory: List<Double?> = List(60) { 60.0 }
+
+    // ── Tier ────────────────────────────────────────────────────────────────
+
+    @Test
+    fun primedFixtureTier() {
+        val r = HRVReadiness.evaluate(primedHistory)
+        assertNotNull(r)
+        assertEquals(ReadinessTier.PRIMED, r!!.tier)
+        // The 7-night baseline is the last-7 mean, exp back to ms: exp(ln 75) = 75.
+        assertEquals(75.0, r.baseline7Ms, 1e-6)
+        // Baseline above the long mean → the overreaching (falling-CV-while-below-mean) watch cannot fire.
+        assertFalse(r.overreachingWatch)
+    }
+
+    @Test
+    fun suppressedFixtureTier() {
+        val r = HRVReadiness.evaluate(suppressedHistory)
+        assertNotNull(r)
+        assertEquals(ReadinessTier.SUPPRESSED, r!!.tier)
+        assertEquals(38.0, r.baseline7Ms, 1e-6)
+    }
+
+    @Test
+    fun flatHistoryIsNormalAndBandCollapsesToMean() {
+        val r = HRVReadiness.evaluate(flatHistory)
+        assertNotNull(r)
+        assertEquals(ReadinessTier.NORMAL, r!!.tier)
+        // baseline7 == longMean and longSD == 0 → the band collapses to the mean, all reading back to 60 ms.
+        assertEquals(60.0, r.baseline7Ms, 1e-6)
+        assertEquals(60.0, r.normalLowMs, 1e-6)
+        assertEquals(60.0, r.normalHighMs, 1e-6)
+    }
+
+    // ── Calibrating / null edge (< MIN_NIGHTS valid nights) ───────────────────
+
+    @Test
+    fun belowMinNightsIsNull() {
+        // 13 valid nights is one short of the gate → null (honest calibrating, never fabricated).
+        assertNull(HRVReadiness.evaluate(List(HRVReadiness.MIN_NIGHTS - 1) { 60.0 }))
+        // Exactly MIN_NIGHTS valid nights → a reading appears.
+        assertNotNull(HRVReadiness.evaluate(List(HRVReadiness.MIN_NIGHTS) { 60.0 }))
+    }
+
+    @Test
+    fun outOfRangeNightsAreDroppedBeforeGate() {
+        // 13 in-range + 5 implausible (300 ms > hrvCfg.maxVal) → only 13 valid → still calibrating (null).
+        val mixed: List<Double?> = List(13) { 60.0 } + List(5) { 300.0 }
+        assertNull(HRVReadiness.evaluate(mixed))
+        // Add one more in-range night → 14 valid → a reading appears (the implausible nights never count).
+        assertNotNull(HRVReadiness.evaluate(List(14) { 60.0 } + List(5) { 300.0 }))
+    }
+}

--- a/android/app/src/test/java/com/noop/protocol/PpgHrTest.kt
+++ b/android/app/src/test/java/com/noop/protocol/PpgHrTest.kt
@@ -3,6 +3,7 @@ package com.noop.protocol
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import kotlin.math.PI
+import kotlin.math.abs
 import kotlin.math.sin
 import kotlin.random.Random
 import org.junit.Test
@@ -117,5 +118,38 @@ class PpgHrTest {
         val est = PpgHr.estimate(sine(bpm = 60.0, seconds = 10))
         assertTrue("true 60 bpm must not be notched away", est.isNotEmpty())
         for (e in est) assertTrue("bpm ${e.bpm} not near 60", e.bpm in 57..63)
+    }
+
+    @Test
+    fun subLagInterpolationRecoversHrsThatIntegerLagQuantizes() {
+        // Derived-biosignal standard (CLAUDE.md): recover MULTIPLE injected values, not one. Each true HR
+        // here sits BETWEEN integer autocorrelation lags at 24 Hz (period = 1440/bpm samples), so the nearest
+        // integer lag is > 2 bpm off and the default integer-lag estimator quantizes AWAY from the truth,
+        // while the opt-in parabolic sub-lag interpolation (Variant A) refines the ACF peak and recovers it
+        // within ±2 bpm. Twin of the Swift PpgHrTests case. (Exact-integer-lag rates 120/160/180 are avoided.)
+        for (trueBpm in listOf(137.0, 150.0, 163.0, 170.0)) {
+            val samples = sine(bpm = trueBpm, seconds = 16)
+
+            // Default OFF = byte-identical to today: integer-lag quantization, never within ±2 of the truth.
+            val off = PpgHr.estimate(samples)
+            assertTrue("expected estimates from a clean $trueBpm bpm sine", off.isNotEmpty())
+            for (e in off) {
+                assertTrue(
+                    "default path should quantize away from $trueBpm (got ${e.bpm})",
+                    abs(e.bpm - trueBpm) > 2,
+                )
+            }
+
+            // Variant ON: parabolic sub-lag interpolation lands within ±2 bpm of the true rate.
+            val on = PpgHr.estimate(samples, subLagInterp = true)
+            assertTrue("expected estimates with the variant on for $trueBpm", on.isNotEmpty())
+            for (e in on) {
+                assertTrue(
+                    "sub-lag interp should recover $trueBpm±2 (got ${e.bpm})",
+                    abs(e.bpm - trueBpm) <= 2,
+                )
+                assertTrue("confidence ${e.conf} below gate", e.conf >= PpgHr.MIN_CONFIDENCE)
+            }
+        }
     }
 }


### PR DESCRIPTION
Two **opt-in, default-off** analysis variants under a new Test Center **Experimental Algorithms** section.
Both comply with the derived-biosignal validation standard (default-off Experimental tier; synthetic tests
recover *multiple* injected values). No default behaviour changes — every default score/engine is untouched
and byte-identical when the flags are off.

## Commit 1 — HR-from-PPG sub-lag interpolation (`noopPpgHrSubLagInterp`)
The v26 gap-fill HR estimator picks an integer autocorrelation lag, so it can only emit `round(1440/lag)` —
a coarse grid (…131, 144, 160, 180, 206…) that quantizes HR in **13–26 bpm steps at high HR**. This adds an
opt-in parabolic sub-lag refinement (`vals[bestLag-1..+1]` → interpolated lag) that fills the in-between
values. Never overrides a WHOOP-stored HR; only refines seconds the strap stored no HR for; byte-identical
when off.

**Evidence (two independent WHOOP 5.0 bands):** on two users' real backups, **100% of stored v26 gap-fill HR
values sit exactly on the integer-lag grid** (zero off-grid) — confirming the quantization is real and worst
during exertion. On raw v26 PPG captures the refined estimator recovers the in-between values the integer-lag
path skips.

- Wired on every v26-HR path (`Backfiller`, `RawHistoryArchive`, and `CaptureImporter`).
- Test: `PpgHrTest` / `PpgHrTests` parametrized over 137/150/163/170 bpm — ON recovers each within ±2 bpm;
  OFF stays quantized (unchanged).

## Commit 2 — HRV-readiness (Plews/Altini SWC) tier readout (`noopHrvReadiness`)
A default-off readout: 7-night rolling mean of `ln(RMSSD)` vs a Smallest-Worthwhile-Change band
(long-window mean ± 0.5·SD) → **primed / normal / suppressed** + baseline, or "Calibrating (N/14 nights)".
Reuses `RecoveryForecaster` helpers + `Baselines.hrvCfg`. **Feeds no downstream gate** — the Charge ring is
byte-identical. Labelled **rough/early testing** — its tiering has only n=1 varying-input validation so far,
which is exactly why it ships as a default-off readout, not a default or a gate.

## Test plan
- [x] `./gradlew :app:compileFullDebugKotlin` — clean
- [x] `./gradlew :app:testFullDebugUnitTest` — **324 classes, 2619 tests, 0 failures, 0 errors, 0 skipped**
- [x] `./gradlew :app:assembleFullDebug` — **BUILD SUCCESSFUL** (app-full-debug.apk)
- [ ] **iOS/macOS Swift — compile-UNVERIFIED.** The Swift twins (`PpgHr.swift`, `HRVReadiness.swift`,
  `TestCentreView.swift`, `PuffinExperiment.swift`, `Backfiller.swift`, `RawHistoryArchive.swift`) are
  byte-identical translations of the Android logic (same flag keys, constants, formulas, copy) but were not
  compiled — no macOS/Xcode on the build host, and `app-build.yml` doesn't cover app-target Swift by default.
  **Needs an `xcodebuild` of the `Strand` (macOS) + `NOOPiOS` targets before merge** — follow-up issue to file.

## Scope notes
- Off clean `main`. Does **not** touch sleep-V2, Settings, or the respiratory-rate path (a spectral-RSA
  resp-rate variant was intentionally dropped in favour of the PPG-derived work in #339).
- Non-clinical wellness estimates throughout; both variants are opt-in and off by default.
