### PR TITLE
Alarm: name the "no alarm stored" readback plainly + log SET_ALARM_TIME's result byte (#34)

### DIFF
--- a/Strand/BLE/FrameRouter.swift
+++ b/Strand/BLE/FrameRouter.swift
@@ -153,9 +153,30 @@ public final class FrameRouter {
                             d.set(abs(Int(epoch) - sent) > 120 ? d.integer(forKey: "alarm.rejectStreak") + 1 : 0,
                                   forKey: "alarm.rejectStreak")
                         }
+                    } else if Self.readbackReportsNoAlarm(in: frame) {
+                        // #34 (issue comment 2026-07-12): the strap's "nothing armed" sentinel — the epoch
+                        // field decodes to 0. This is NOT an undocumented layout; it's the strap telling us
+                        // it has no alarm stored, so an arm we just sent did NOT persist. Calling this
+                        // "unrecognised payload" (the old branch) hid the single most diagnostic signal in a
+                        // "didn't buzz" report: SET went out, strap kept nothing. Name it plainly. Log-only.
+                        let raw = Self.commandResponsePayloadHex(in: frame) ?? "empty"
+                        state.append(log: "Alarm: strap reports NO alarm currently stored (epoch 0) — the arm did not persist on the strap (raw \(raw))")
                     } else {
                         state.append(log: "Alarm: strap answered the alarm readback with an unrecognised payload (raw \(Self.commandResponsePayloadHex(in: frame) ?? "empty")) - layout undocumented, log-only")
                     }
+                } else if cmd.hasPrefix("SET_ALARM_TIME") {
+                    // #34 (issue comment 2026-07-12): the strap's OWN answer to the arm we just sent — the
+                    // accept/reject datum that was previously thrown away. armStrapAlarm logs "armed" the
+                    // instant the SET goes out, which only proves NOOP transmitted the frame; if the firmware
+                    // drops it the GET_ALARM_TIME readback then reads back epoch 0 (a silently-unpersisted
+                    // alarm — the exact signature in this report). Logging the raw result byte lets a future
+                    // report distinguish a strap that accepted the arm from one that rejected it. LOG-ONLY,
+                    // never gates behaviour. The WHOOP 4.0 result-code meaning is UNVERIFIED (the 5/MG puffin
+                    // table is 0=FAILURE 1=SUCCESS 2=PENDING 3=UNSUPPORTED, but the 4.0 reboot probe assumed
+                    // 0=accepted), so this claims NO verdict — it surfaces the byte, nothing more.
+                    let r = Self.commandResultByte(in: frame)
+                    let rhex = r.map { String(format: "0x%02x", UInt8(truncatingIfNeeded: $0)) } ?? "none"
+                    state.append(log: "Alarm: strap answered the arm (SET_ALARM_TIME) with result=\(rhex) — log-only, 4.0 result-code meaning unverified")
                 }
             }
 
@@ -282,6 +303,26 @@ public final class FrameRouter {
         if payload.first == 0x01, let e = u32le(at: 1), isPlausibleAlarmEpoch(e) { return e }
         if let e = u32le(at: 0), isPlausibleAlarmEpoch(e) { return e }
         return nil
+    }
+
+    /// True when a GET_ALARM_TIME readback explicitly reports NO alarm stored — the epoch field decodes
+    /// to 0 in the same shapes `armedAlarmEpoch` reads (SET-mirror `[0x01][u32=0]` first, then a bare
+    /// leading `u32=0`). This is the strap's "nothing armed" sentinel, distinct from a genuinely
+    /// unparseable payload: an arm the strap silently dropped reads back as epoch 0, so labelling it
+    /// "unrecognised" hid the real signal (#34). Only consulted AFTER `armedAlarmEpoch` returns nil, so a
+    /// plausible armed epoch never reaches here. Pure/CoreBluetooth-free so AlarmReadbackDecodeTests pin it.
+    nonisolated static func readbackReportsNoAlarm(in frame: [UInt8]) -> Bool {
+        guard let payload = commandResponsePayload(in: frame) else { return false }
+        func u32le(at i: Int) -> UInt32? {
+            guard payload.count >= i + 4 else { return nil }
+            return UInt32(payload[i])
+                | (UInt32(payload[i + 1]) << 8)
+                | (UInt32(payload[i + 2]) << 16)
+                | (UInt32(payload[i + 3]) << 24)
+        }
+        if payload.first == 0x01, let e = u32le(at: 1) { return e == 0 }
+        if let e = u32le(at: 0) { return e == 0 }
+        return false
     }
 
     /// Local wall-clock render for the readback log line, matching armStrapAlarm's "EEE HH:mm zzz"

--- a/StrandTests/AlarmReadbackDecodeTests.swift
+++ b/StrandTests/AlarmReadbackDecodeTests.swift
@@ -59,6 +59,38 @@ final class AlarmReadbackDecodeTests: XCTestCase {
         XCTAssertNil(FrameRouter.armedAlarmEpoch(in: frame))
     }
 
+    // MARK: - "No alarm stored" (epoch 0) detection (#34, issue comment 2026-07-12)
+
+    /// The exact payload from the field report `01 00 00 00 00 00 00 00 04 00 20`: the SET-mirror epoch
+    /// field is 0, so this is the strap's "nothing armed" sentinel — armedAlarmEpoch fails (epoch 0 is not
+    /// plausible) AND readbackReportsNoAlarm is true, so the router logs "NO alarm stored", not "unrecognised".
+    func testFieldReportPayload_reportsNoAlarm() {
+        let frame = responseFrame(payload: [0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x04, 0x00, 0x20])
+        XCTAssertNil(FrameRouter.armedAlarmEpoch(in: frame))
+        XCTAssertTrue(FrameRouter.readbackReportsNoAlarm(in: frame))
+    }
+
+    /// A bare leading u32 = 0 (no form byte) is also the "no alarm" sentinel.
+    func testBareZeroU32_reportsNoAlarm() {
+        let frame = responseFrame(payload: [0x00, 0x00, 0x00, 0x00])
+        XCTAssertTrue(FrameRouter.readbackReportsNoAlarm(in: frame))
+    }
+
+    /// A plausible armed epoch is NOT "no alarm" — the two branches are mutually exclusive, so a genuinely
+    /// armed strap never mislogs as "no alarm stored".
+    func testArmedEpoch_isNotReportedAsNoAlarm() {
+        let frame = responseFrame(payload: [0x01, 0x30, 0xD5, 0x35, 0x6A, 0x00, 0x00, 0x00, 0x00])
+        XCTAssertNotNil(FrameRouter.armedAlarmEpoch(in: frame))
+        XCTAssertFalse(FrameRouter.readbackReportsNoAlarm(in: frame))
+    }
+
+    /// A short result-style payload (0x03) is neither an armed epoch NOR the epoch-0 sentinel — it's
+    /// genuinely unparseable, so it still falls through to the raw-hex "unrecognised" branch.
+    func testShortGarbage_isNotReportedAsNoAlarm() {
+        let frame = responseFrame(payload: [0x03])
+        XCTAssertFalse(FrameRouter.readbackReportsNoAlarm(in: frame))
+    }
+
     /// An empty payload (header-only response) decodes nil and yields no hex either.
     func testEmptyPayload_decodesNilAndNoHex() {
         let frame = responseFrame(payload: [])
@@ -125,5 +157,33 @@ final class AlarmReadbackDecodeTests: XCTestCase {
         router.handle(frame: alarmResponseFrame(payload: [0x03, 0xAB]))
         XCTAssertTrue(live.log.contains { $0.contains("unrecognised payload") && $0.contains("03 ab") },
                       "unrecognised readback must log raw hex via handle(): \(live.log)")
+    }
+
+    /// The field-report readback (epoch 0) now fires the "NO alarm stored" branch, NOT the "unrecognised"
+    /// one — proving the reframe is reachable via handle() and that the misleading label is gone.
+    @MainActor
+    func testHandle_noAlarmStoredReadback_logsNoAlarm() {
+        let live = LiveState()
+        let router = FrameRouter(state: live)
+        router.family = .whoop4
+        router.handle(frame: alarmResponseFrame(payload: [0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x04, 0x00, 0x20]))
+        XCTAssertTrue(live.log.contains { $0.contains("NO alarm currently stored") && $0.contains("did not persist") },
+                      "epoch-0 readback must log the 'no alarm stored' line: \(live.log)")
+        XCTAssertFalse(live.log.contains { $0.contains("unrecognised payload") },
+                       "epoch-0 readback must NOT log the misleading 'unrecognised' line: \(live.log)")
+    }
+
+    /// A SET_ALARM_TIME (cmd 66) COMMAND_RESPONSE now logs the strap's raw result byte — the accept/reject
+    /// datum previously thrown away. No verdict is claimed (4.0 result-code meaning is unverified), so the
+    /// test pins only that the raw byte is surfaced.
+    @MainActor
+    func testHandle_setAlarmResponse_logsResultByte() {
+        let live = LiveState()
+        let router = FrameRouter(state: live)
+        router.family = .whoop4
+        // frameFromPayload lays out [origin_seq, result, payload…] as `data`; result byte = 0x03 here.
+        router.handle(frame: frameFromPayload([0x42, 0x03], type: 36, seq: 0x29, cmd: 66))
+        XCTAssertTrue(live.log.contains { $0.contains("SET_ALARM_TIME") && $0.contains("result=0x03") },
+                      "SET_ALARM_TIME response must log the raw result byte: \(live.log)")
     }
 }

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -3731,10 +3731,34 @@ class WhoopBleClient(
                                 .putLong("alarm.lastReportedAt", System.currentTimeMillis())
                                 .apply()
                         }
+                    } else if (whoop4ReadbackReportsNoAlarm(frame)) {
+                        // #34 (issue comment 2026-07-12): the strap's "nothing armed" sentinel — the epoch
+                        // field decodes to 0. This is NOT an undocumented layout; it's the strap telling us
+                        // it has no alarm stored, so an arm we just sent did NOT persist. Calling this
+                        // "unrecognised payload" hid the single most diagnostic signal in a "didn't buzz"
+                        // report: SET went out, strap kept nothing. Name it plainly. Log-only. Twin of Swift.
+                        val raw = whoop4AlarmReadbackPayloadHex(frame) ?: "empty"
+                        log("Alarm: strap reports NO alarm currently stored (epoch 0) — the arm did not persist on the strap (raw $raw)")
                     } else {
                         val raw = whoop4AlarmReadbackPayloadHex(frame) ?: "empty"
                         log("Alarm: strap answered the alarm readback with an unrecognised payload (raw $raw) - layout undocumented, log-only")
                     }
+                }
+                // #34 (issue comment 2026-07-12): the strap's OWN answer to the arm we just sent — the
+                // accept/reject datum previously thrown away. armStrapAlarm logs "armed" the instant the SET
+                // goes out, which only proves NOOP transmitted the frame; if the firmware drops it the
+                // GET_ALARM_TIME readback then reads back epoch 0 (a silently-unpersisted alarm — the exact
+                // signature in this report). Logging the raw result byte lets a future report distinguish a
+                // strap that accepted the arm from one that rejected it. LOG-ONLY, never gates behaviour. The
+                // WHOOP 4.0 result-code meaning is UNVERIFIED (the 5/MG puffin table is 0=FAILURE 1=SUCCESS
+                // 2=PENDING 3=UNSUPPORTED, but the 4.0 reboot probe assumed 0=accepted), so no verdict is
+                // claimed — it surfaces the byte, nothing more. Twin of Swift FrameRouter. WHOOP4-only: the
+                // 4.0 result byte sits at frame[8]; the 5/MG result lives at a different offset (decoded as
+                // the `result` string above) and its alarm path is the Experimental one.
+                if (connectedFamily == DeviceFamily.WHOOP4 && respCmd?.startsWith("SET_ALARM_TIME") == true) {
+                    val r = frame.getOrNull(8)?.toInt()?.and(0xFF)
+                    val rhex = if (r != null) "0x%02x".format(r) else "none"
+                    log("Alarm: strap answered the arm (SET_ALARM_TIME) with result=$rhex — log-only, 4.0 result-code meaning unverified")
                 }
             }
 
@@ -5730,6 +5754,29 @@ internal fun whoop4ArmedAlarmEpoch(frame: ByteArray): Long? {
         u32le(1)?.takeIf { isPlausibleAlarmEpoch(it) }?.let { return it }
     }
     return u32le(0)?.takeIf { isPlausibleAlarmEpoch(it) }
+}
+
+/**
+ * True when a GET_ALARM_TIME readback explicitly reports NO alarm stored — the epoch field decodes to
+ * 0 in the same shapes [whoop4ArmedAlarmEpoch] reads (SET-mirror `[0x01][u32=0]` first, then a bare
+ * leading `u32=0`). This is the strap's "nothing armed" sentinel, distinct from a genuinely unparseable
+ * payload: an arm the strap silently dropped reads back as epoch 0, so labelling it "unrecognised" hid
+ * the real signal (#34). Only consulted AFTER [whoop4ArmedAlarmEpoch] returns null. Twin of the Swift
+ * `FrameRouter.readbackReportsNoAlarm`; pinned by `AlarmReadbackDecodeTest`.
+ */
+internal fun whoop4ReadbackReportsNoAlarm(frame: ByteArray): Boolean {
+    val payload = whoop4CommandResponsePayload(frame) ?: return false
+    fun u32le(at: Int): Long? {
+        if (payload.size < at + 4) return null
+        return (payload[at].toLong() and 0xFFL) or
+            ((payload[at + 1].toLong() and 0xFFL) shl 8) or
+            ((payload[at + 2].toLong() and 0xFFL) shl 16) or
+            ((payload[at + 3].toLong() and 0xFFL) shl 24)
+    }
+    if (payload.isNotEmpty() && payload[0] == 0x01.toByte()) {
+        return u32le(1)?.let { it == 0L } ?: false
+    }
+    return u32le(0)?.let { it == 0L } ?: false
 }
 
 /** Local wall-clock render for the readback log line ("EEE HH:mm zzz", the armStrapAlarm idiom on the

--- a/android/app/src/test/java/com/noop/ble/AlarmReadbackDecodeTest.kt
+++ b/android/app/src/test/java/com/noop/ble/AlarmReadbackDecodeTest.kt
@@ -102,4 +102,38 @@ class AlarmReadbackDecodeTest {
         assertTrue(isPlausibleAlarmEpoch(4_102_444_800L))
         assertFalse(isPlausibleAlarmEpoch(4_102_444_801L))
     }
+
+    // "No alarm stored" (epoch 0) detection (#34, issue comment 2026-07-12)
+
+    /**
+     * The exact payload from the field report `01 00 00 00 00 00 00 00 04 00 20`: the SET-mirror epoch
+     * field is 0, so this is the strap's "nothing armed" sentinel — [whoop4ArmedAlarmEpoch] fails (epoch 0
+     * is not plausible) AND [whoop4ReadbackReportsNoAlarm] is true, so handleFrame logs "NO alarm stored".
+     */
+    @Test
+    fun fieldReportPayload_reportsNoAlarm() {
+        val frame = responseFrame(payload = bytes(0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x04, 0x00, 0x20))
+        assertNull(whoop4ArmedAlarmEpoch(frame))
+        assertTrue(whoop4ReadbackReportsNoAlarm(frame))
+    }
+
+    /** A bare leading u32 = 0 (no form byte) is also the "no alarm" sentinel. */
+    @Test
+    fun bareZeroU32_reportsNoAlarm() {
+        assertTrue(whoop4ReadbackReportsNoAlarm(responseFrame(payload = bytes(0x00, 0x00, 0x00, 0x00))))
+    }
+
+    /** A plausible armed epoch is NOT "no alarm" — the two branches are mutually exclusive. */
+    @Test
+    fun armedEpoch_isNotReportedAsNoAlarm() {
+        val frame = responseFrame(payload = bytes(0x01, 0x30, 0xD5, 0x35, 0x6A, 0x00, 0x00, 0x00, 0x00))
+        assertEquals(1_781_912_880L, whoop4ArmedAlarmEpoch(frame))
+        assertFalse(whoop4ReadbackReportsNoAlarm(frame))
+    }
+
+    /** A short result-style payload (0x03) is neither an armed epoch NOR the epoch-0 sentinel. */
+    @Test
+    fun shortGarbage_isNotReportedAsNoAlarm() {
+        assertFalse(whoop4ReadbackReportsNoAlarm(responseFrame(payload = bytes(0x03))))
+    }
 }


### PR DESCRIPTION
## Summary
- A `GET_ALARM_TIME` readback of epoch 0 was logged as "unrecognised payload — layout undocumented," which hid the most diagnostic signal in a "didn't buzz" report on #34: the strap explicitly telling us it has **no alarm stored** (i.e. a `SET_ALARM_TIME` that silently failed to persist). That case is now named plainly instead.
- `SET_ALARM_TIME`'s own COMMAND_RESPONSE result byte (WHOOP 4.0) is now logged — previously thrown away on both platforms. Log-only, no verdict claimed: the 4.0 result-code meaning is unverified (the 5/MG puffin table is `0=FAILURE 1=SUCCESS 2=PENDING 3=UNSUPPORTED`, but the existing 4.0 reboot-probe code assumes `0=accepted` — the two contradict, so this just surfaces the raw byte).
- Both changes are log-only diagnostics; no BLE arm/disarm behavior changes. Mirrored in Swift (`Strand/BLE/FrameRouter.swift`) and Kotlin (`android/.../ble/WhoopBleClient.kt`) per the cross-platform parity contract.

Context: [issue #34 comment](https://github.com/ryanbr/noop/issues/34#issuecomment-4952151667) from a WHOOP 4.0 owner on v8.7.0 — the strap ACKs the arm and the alarm logs "armed," but every readback comes back as epoch 0, and the alarm never buzzes. This surfaces exactly why.

## Test plan
- [x] `swift test` equivalent: `xcodebuild -scheme Strand -destination 'platform=macOS' -only-testing:StrandTests/AlarmReadbackDecodeTests test` — 17/17 passed (also validates the app-target `FrameRouter` compiles, since `swift-packages.yml` doesn't cover `Strand/`)
- [x] Android: `./gradlew testFullDebugUnitTest --tests "com.noop.ble.AlarmReadbackDecodeTest"` — all green
- [ ] Not tested on hardware (no strap available in this environment) — this is a log-only change with no BLE write path affected, so on-device verification is limited to confirming the new log lines appear on a real 4.0 strap