### PR TITLE
feat(today): calibration-milestone countdown cards (WHOOP-style timeline)

### DIFF
--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/CalibrationMilestones.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/CalibrationMilestones.swift
@@ -1,0 +1,93 @@
+// Calibration milestones — the WHOOP-familiar countdown timeline surfaced on Today (gamification).
+//
+// PRESENTATION LAYER ONLY. These targets drive the milestone COUNTDOWN CARDS; they do NOT change the
+// baseline math in `Baselines`. NOOP keeps its own honest gates (seed `Baselines.minNightsSeed` = 4,
+// trust `Baselines.minNightsTrust` = 14, with early-adapt) — a milestone reaching "done" here is a UI
+// badge, not a claim the analytics changed. The night count fed in is the SAME valid-HRV-night tally the
+// recovery seed uses (`RecoveryScorer.bankedNights`), so a progress bar can never over-state what the
+// baseline has actually banked.
+//
+// The targets mirror WHOOP's published Calibration Timeline (Day 4 Recovery, Day 7 Sleep, Day 30 full
+// baseline) plus NOOP's own 14-night Trusted gate, so a WHOOP user sees the timeline they expect while
+// NOOP's better statistics run underneath. Mirrors the Kotlin `CalibrationMilestones` byte-for-byte.
+
+public enum CalibrationMilestones {
+
+    /// The 5.0/MG "first week" sleep-coaching milestone (WHOOP Day 7). Not a baseline gate — a card target.
+    public static let sleepBaselineNights: Int = 7
+
+    /// WHOOP's full-baseline / rolling-30-day milestone (Day 30). Not a baseline gate — a card target.
+    public static let fullBaselineNights: Int = 30
+
+    /// A single calibration checkpoint. `nights` is the banked valid-night count at which it unlocks.
+    public struct Milestone: Equatable, Sendable {
+        /// Stable id (persisted / cross-platform / analytics-safe). Never renumber.
+        public let id: String
+        public let title: String
+        public let nights: Int
+        /// One-line "what this unlocks", shown on the active card.
+        public let unlocks: String
+    }
+
+    /// The ordered timeline, soonest first. Targets are pinned to the honest gates where they coincide.
+    public static let all: [Milestone] = [
+        Milestone(id: "firstRecovery", title: "First Recovery",
+                  nights: Baselines.minNightsSeed, // 4 — matches WHOOP Day 4
+                  unlocks: "Charge, Effort and Rest become personal to you."),
+        Milestone(id: "sleepBaseline", title: "Sleep baseline",
+                  nights: sleepBaselineNights, // 7 — WHOOP "after your first week"
+                  unlocks: "Your sleep need and coaching tune to your own nights."),
+        Milestone(id: "trustedBaseline", title: "Trusted baseline",
+                  nights: Baselines.minNightsTrust, // 14 — NOOP's full-confidence gate
+                  unlocks: "Full-confidence baselines — the calibrating tag drops."),
+        Milestone(id: "fullBaseline", title: "30-day baseline",
+                  nights: fullBaselineNights, // 30 — WHOOP full baseline / rolling window
+                  unlocks: "Your complete rolling 30-day baseline is set."),
+    ]
+
+    /// The furthest target. Banked ≥ this ⇒ calibration is fully complete and the card retires.
+    public static var finalNights: Int { all.map(\.nights).max() ?? 0 }
+
+    /// DONE = already reached; ACTIVE = the live countdown (first unreached); LOCKED = still ahead.
+    public enum State: String, Sendable { case done, active, locked }
+
+    /// A milestone paired with its computed progress against a banked-night count.
+    public struct Progress: Equatable, Sendable {
+        public let milestone: Milestone
+        public let state: State
+        /// Nights still needed (0 once done).
+        public let remaining: Int
+        /// 0…1 absolute fill toward this milestone's target (1.0 once done).
+        public let fraction: Double
+    }
+
+    /// Resolve every milestone's `Progress` for a user who has banked `nightsBanked` valid nights. The
+    /// FIRST not-yet-reached milestone is `.active` (the live countdown); earlier ones are `.done`, later
+    /// ones `.locked`. Fraction is absolute (banked ÷ target) so the bar text ("9/14 nights") and the fill
+    /// agree. Pure + unit-tested; mirrors the Kotlin twin.
+    public static func progress(nightsBanked: Int) -> [Progress] {
+        let n = max(0, nightsBanked)
+        var activeAssigned = false
+        return all.map { m in
+            let done = n >= m.nights
+            let state: State
+            if done {
+                state = .done
+            } else if !activeAssigned {
+                activeAssigned = true
+                state = .active
+            } else {
+                state = .locked
+            }
+            return Progress(
+                milestone: m,
+                state: state,
+                remaining: max(0, m.nights - n),
+                fraction: done ? 1.0 : min(max(Double(n) / Double(m.nights), 0), 1)
+            )
+        }
+    }
+
+    /// True while at least one milestone is still unreached (banked < `finalNights`) — the card should show.
+    public static func isCalibrating(nightsBanked: Int) -> Bool { nightsBanked < finalNights }
+}

--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/RecoveryScorer.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/RecoveryScorer.swift
@@ -157,11 +157,21 @@ public enum RecoveryScorer {
                                          seed: Int = Baselines.minNightsSeed,
                                          cfg: MetricCfg = Baselines.hrvCfg) -> Int? {
         guard !hasRecovery else { return nil }
-        let n = nightlyHrv.compactMap { $0 }.filter { $0 >= cfg.minVal && $0 <= cfg.maxVal }.count
+        let n = bankedNights(nightlyHrv: nightlyHrv, cfg: cfg)
         // Include 0: a brand-new user (no banked nights yet) should read "Calibrating — 0 of N" on the
         // Charge ring, not a bare "No data" that looks broken (#335). Past days are gated to nil by the
         // caller; >= seed (recovery should exist) still returns nil.
         return (0..<seed).contains(n) ? n : nil
+    }
+
+    /// The UNCAPPED count of nights carrying a usable nightly HRV — the signal that seeds every baseline.
+    /// Uses the SAME validity predicate as `Baselines.update` (value within the metric config bounds), not
+    /// just non-nil, so an implausible out-of-range night is excluded and this can never over-state nValid.
+    /// `calibrationNights` gates this to the cold-start seed window; the calibration-milestone countdown
+    /// cards count it all the way to 30. Mirrors Android `TodayScreen.bankedCalibrationNights`.
+    public static func bankedNights(nightlyHrv: [Double?],
+                                    cfg: MetricCfg = Baselines.hrvCfg) -> Int {
+        nightlyHrv.compactMap { $0 }.filter { $0 >= cfg.minVal && $0 <= cfg.maxVal }.count
     }
 
     // MARK: - Recovery score

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/CalibrationMilestonesTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/CalibrationMilestonesTests.swift
@@ -1,0 +1,82 @@
+import XCTest
+@testable import StrandAnalytics
+
+/// Pins the pure calibration-milestone timeline that drives the Today countdown cards. The targets are a
+/// PRESENTATION overlay (they never touch `Baselines`); these tests lock the ordering, the exactly-one
+/// ACTIVE invariant, the done/locked partition, the absolute-fraction contract the card text relies on,
+/// and the retire-at-final gate. Mirrors the Kotlin CalibrationMilestonesTest.
+final class CalibrationMilestonesTests: XCTestCase {
+
+    func testTimelineIsTheWhoopFamiliarSetInOrder() {
+        XCTAssertEqual(CalibrationMilestones.all.map(\.nights), [4, 7, 14, 30])
+        // The soonest/last targets stay pinned to the honest baseline gates + WHOOP's day-30 full baseline.
+        XCTAssertEqual(CalibrationMilestones.all.first?.nights, Baselines.minNightsSeed)
+        XCTAssertEqual(CalibrationMilestones.all[2].nights, Baselines.minNightsTrust)
+        XCTAssertEqual(CalibrationMilestones.finalNights, 30)
+    }
+
+    func testBrandNewUserFirstActiveRestLockedNoneDone() {
+        let p = CalibrationMilestones.progress(nightsBanked: 0)
+        XCTAssertEqual(p[0].state, .active)
+        XCTAssertTrue(p.dropFirst().allSatisfy { $0.state == .locked })
+        XCTAssertFalse(p.contains { $0.state == .done })
+        XCTAssertEqual(p[0].remaining, 4)
+        XCTAssertEqual(p[0].fraction, 0.0, accuracy: 1e-9)
+    }
+
+    func testExactlyOneActiveUntilFullyCalibrated() {
+        for n in 0..<30 {
+            let active = CalibrationMilestones.progress(nightsBanked: n).filter { $0.state == .active }.count
+            XCTAssertEqual(active, 1, "banked=\(n) should have exactly one live countdown")
+        }
+    }
+
+    func testMidCalibrationPartitionsAndCountsDown() {
+        // 9 nights banked: 4 & 7 DONE, 14 the live countdown, 30 locked (matches the card mockup).
+        let p = CalibrationMilestones.progress(nightsBanked: 9)
+        XCTAssertEqual(p[0].state, .done)   // 4
+        XCTAssertEqual(p[1].state, .done)   // 7
+        XCTAssertEqual(p[2].state, .active) // 14
+        XCTAssertEqual(p[3].state, .locked) // 30
+        XCTAssertEqual(p[2].remaining, 5)   // "5 nights to go"
+        XCTAssertEqual(p[3].remaining, 21)  // "21 nights to go"
+        // Absolute fill so the "9/14" / "9/30" labels agree with the bars.
+        XCTAssertEqual(p[2].fraction, 9.0 / 14.0, accuracy: 1e-9)
+        XCTAssertEqual(p[3].fraction, 9.0 / 30.0, accuracy: 1e-9)
+        XCTAssertEqual(p[0].fraction, 1.0, accuracy: 1e-9)
+    }
+
+    func testOnTheDotCountsAsDone() {
+        // Reaching the target exactly (>=) flips it DONE with zero remaining, not a lingering "1 to go".
+        let p = CalibrationMilestones.progress(nightsBanked: 14)
+        XCTAssertEqual(p[2].state, .done)
+        XCTAssertEqual(p[2].remaining, 0)
+        XCTAssertEqual(p[3].state, .active) // 30 is now the live one
+    }
+
+    func testFullyCalibratedRetiresTheCard() {
+        XCTAssertTrue(CalibrationMilestones.isCalibrating(nightsBanked: 0))
+        XCTAssertTrue(CalibrationMilestones.isCalibrating(nightsBanked: 29))
+        XCTAssertFalse(CalibrationMilestones.isCalibrating(nightsBanked: 30))
+        XCTAssertFalse(CalibrationMilestones.isCalibrating(nightsBanked: 45))
+        let p = CalibrationMilestones.progress(nightsBanked: 30)
+        XCTAssertTrue(p.allSatisfy { $0.state == .done })
+    }
+
+    func testNegativeCountClampsToZero() {
+        // Defensive: a bad caller count never produces a negative fraction/remaining.
+        let p = CalibrationMilestones.progress(nightsBanked: -3)
+        XCTAssertEqual(p[0].fraction, 0.0, accuracy: 1e-9)
+        XCTAssertEqual(p[0].remaining, 4)
+        XCTAssertEqual(p[0].state, .active)
+    }
+
+    /// The banked-night predicate the cards feed from excludes out-of-range nights (parity with Android's
+    /// `bankedCalibrationNights`), so a wild reading can't inflate the countdown.
+    func testBankedNightsMatchesBaselineValidityPredicate() {
+        let cfg = Baselines.hrvCfg
+        let good = (cfg.minVal + cfg.maxVal) / 2.0
+        let nightly: [Double?] = [good, nil, cfg.maxVal + 1000, good, good]
+        XCTAssertEqual(RecoveryScorer.bankedNights(nightlyHrv: nightly, cfg: cfg), 3)
+    }
+}

--- a/Strand/Screens/TodayView.swift
+++ b/Strand/Screens/TodayView.swift
@@ -360,6 +360,9 @@ struct TodayView: View {
     // into the inbox (restorable) like the cards above, rather than nagging a returning user every day. Same
     // card id as Android ("calibratingBaseline") so a dismissed flag round-trips an export/import.
     @AppStorage(TodayCardDismissal.flagKey("calibratingBaseline")) private var calibratingDismissed = false
+    // The calibration-milestone countdown stack's dismissed flag; same card id as Android
+    // ("calibrationMilestones") so a dismissed flag round-trips an export/import.
+    @AppStorage(TodayCardDismissal.flagKey("calibrationMilestones")) private var milestonesDismissed = false
 
     // Memoized repo-derived values that are expensive (a full-history sort + per-call
     // `repo.days.map`) yet INDEPENDENT of the ~1 Hz live-HR ticks that re-evaluate `body`
@@ -941,6 +944,18 @@ struct TodayView: View {
         return "Learning your baseline, \(n) of \(Baselines.minNightsSeed) nights."
     }
 
+    /// The gamified calibration-milestone countdown (WHOOP-style timeline), today-only and only while at
+    /// least one milestone is unreached. Uses the UNCAPPED banked-night tally (unlike `recoveryCalibration`,
+    /// which nils past the 4-night seed) so the 4 → 7 → 14 → 30 cards keep counting after the first score.
+    /// Same analytics-layer source as the seed gate (`RecoveryScorer.bankedNights`), so the two can't
+    /// diverge. Presentation-only — the `Baselines` math is untouched. Mirrors Android `calibrationMilestones`.
+    private var calibrationMilestones: [CalibrationMilestones.Progress]? {
+        guard selectedDayOffset == 0 else { return nil }
+        let banked = RecoveryScorer.bankedNights(nightlyHrv: repo.days.map(\.avgHrv))
+        guard CalibrationMilestones.isCalibrating(nightsBanked: banked) else { return nil }
+        return CalibrationMilestones.progress(nightsBanked: banked)
+    }
+
     /// The iOS tab is already labelled "Today", and "Control Center" collides with the OS feature of
     /// that name (on both platforms). Match the tab on iOS; keep the established name on macOS.
     private var screenTitle: LocalizedStringKey {
@@ -1425,6 +1440,7 @@ struct TodayView: View {
         case "scoresBuilding":      scoresBuildingDismissed = false
         case "newHere":             newHereDismissed = false
         case "calibratingBaseline": calibratingDismissed = false
+        case "calibrationMilestones": milestonesDismissed = false
         default:                    break
         }
     }
@@ -1437,6 +1453,7 @@ struct TodayView: View {
         case "scoresBuilding":      scoresBuildingDismissed = true
         case "newHere":             newHereDismissed = true
         case "calibratingBaseline": calibratingDismissed = true
+        case "calibrationMilestones": milestonesDismissed = true
         default:                    break
         }
         updateStore.post(UpdateItem(
@@ -1697,6 +1714,23 @@ struct TodayView: View {
                     }
                     .transition(.opacity.combined(with: .scale(scale: 0.97)))
             }
+
+            // CALIBRATION MILESTONES (gamification): the WHOOP-style countdown stack under the rings, so a
+            // new user sees exactly how many nights until each milestone unlocks. Today only, only while
+            // unreached, and dismissible into the inbox. Presentation-only; the Baselines math is untouched.
+            if selectedDayOffset == 0, !milestonesDismissed, let milestones = calibrationMilestones {
+                calibrationMilestonesCard(progress: milestones)
+                    .overlay(alignment: .topTrailing) {
+                        todayCardDismissButton {
+                            dismissTodayCard(
+                                id: "calibrationMilestones",
+                                title: String(localized: "Calibration milestones"),
+                                message: String(localized: "Your countdown to personal Charge, Sleep and a full 30-day baseline.")
+                            )
+                        }
+                    }
+                    .transition(.opacity.combined(with: .scale(scale: 0.97)))
+            }
         }
     }
 
@@ -1770,6 +1804,112 @@ struct TodayView: View {
         }
         .accessibilityElement(children: .ignore)
         .accessibilityLabel("Charge baseline calibrating. \(countdown), \(unlock). \(progress).")
+    }
+
+    /// The gamified calibration-milestone countdown stack (WHOOP-style "Calibration Timeline"). One row per
+    /// milestone: DONE reads as a compact "Unlocked" check, the single ACTIVE milestone is the live
+    /// countdown (a PipBar of nights + "N nights to go" + what it unlocks), and LOCKED milestones sit muted
+    /// below. `progress` is the pure, unit-tested `CalibrationMilestones.progress` output; this view is
+    /// presentation only. Design-system tokens only. Mirrors Android `CalibrationMilestonesCard`.
+    @ViewBuilder
+    private func calibrationMilestonesCard(progress: [CalibrationMilestones.Progress]) -> some View {
+        // Charge-tinted like every other Today card (and the sibling chargeCalibrationCountdown it sits
+        // beside) — the milestones ride the HRV/recovery baseline, so the Charge theme is apt. Android's
+        // note lane (ScoreStateNote) is neutral, so it stays neutral there; each platform matches its own
+        // Today-card convention (feature-level parity, not pixel-level).
+        NoopCard(padding: 14, tint: StrandPalette.chargeColor) {
+            VStack(alignment: .leading, spacing: 12) {
+                HStack(spacing: 10) {
+                    Image(systemName: "slider.horizontal.3")
+                        .font(.system(size: 16, weight: .semibold))
+                        .foregroundStyle(StrandPalette.accent)
+                        .accessibilityHidden(true)
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text("Calibration milestones")
+                            .font(StrandFont.headline)
+                            .foregroundStyle(StrandPalette.textPrimary)
+                        Text("Wear the strap overnight to unlock each one.")
+                            .font(StrandFont.subhead)
+                            .foregroundStyle(StrandPalette.textSecondary)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+                    Spacer(minLength: 0)
+                }
+                ForEach(progress, id: \.milestone.id) { p in
+                    calibrationMilestoneRow(p)
+                }
+            }
+        }
+    }
+
+    /// One milestone row inside `calibrationMilestonesCard`, drawn by its `CalibrationMilestones.State`.
+    @ViewBuilder
+    private func calibrationMilestoneRow(_ p: CalibrationMilestones.Progress) -> some View {
+        let m = p.milestone
+        let banked = max(0, m.nights - p.remaining)
+        let nightsWord = p.remaining == 1 ? String(localized: "night") : String(localized: "nights")
+        switch p.state {
+        case .done:
+            // A cleared milestone: a compact green check + "Unlocked", no bar (it's full by definition).
+            HStack(spacing: 8) {
+                Image(systemName: "checkmark.circle.fill")
+                    .font(.system(size: 16, weight: .semibold))
+                    .foregroundStyle(StrandPalette.statusPositive)
+                Text(m.title)
+                    .font(StrandFont.subhead)
+                    .foregroundStyle(StrandPalette.textSecondary)
+                Spacer(minLength: 0)
+                Text("Unlocked")
+                    .font(StrandFont.footnote)
+                    .foregroundStyle(StrandPalette.statusPositive)
+            }
+            .accessibilityElement(children: .ignore)
+            .accessibilityLabel("\(m.title) unlocked")
+        case .active:
+            // The live countdown: accent open-lock, "N nights to go", a nights PipBar, and what it unlocks.
+            VStack(alignment: .leading, spacing: 6) {
+                HStack(spacing: 8) {
+                    Image(systemName: "lock.open.fill")
+                        .font(.system(size: 16, weight: .semibold))
+                        .foregroundStyle(StrandPalette.accent)
+                    Text(m.title)
+                        .font(StrandFont.headline)
+                        .foregroundStyle(StrandPalette.textPrimary)
+                    Spacer(minLength: 0)
+                    Text("\(p.remaining) \(nightsWord) to go")
+                        .font(StrandFont.footnote)
+                        .foregroundStyle(StrandPalette.accent)
+                }
+                PipBar(value: Double(banked), range: 0...Double(m.nights), segments: m.nights,
+                       tint: StrandPalette.accent)
+                Text("\(banked)/\(m.nights) nights · \(m.unlocks)")
+                    .font(StrandFont.footnote)
+                    .foregroundStyle(StrandPalette.textSecondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            .accessibilityElement(children: .ignore)
+            .accessibilityLabel("\(m.title), \(banked) of \(m.nights) nights, \(p.remaining) \(nightsWord) to go. \(m.unlocks)")
+        case .locked:
+            // Still ahead: a muted closed-lock, dimmed bar, and the raw gap — no unlocks copy (keeps it quiet).
+            VStack(alignment: .leading, spacing: 6) {
+                HStack(spacing: 8) {
+                    Image(systemName: "lock.fill")
+                        .font(.system(size: 16, weight: .semibold))
+                        .foregroundStyle(StrandPalette.textTertiary)
+                    Text(m.title)
+                        .font(StrandFont.subhead)
+                        .foregroundStyle(StrandPalette.textSecondary)
+                    Spacer(minLength: 0)
+                    Text("\(p.remaining) \(nightsWord) to go")
+                        .font(StrandFont.footnote)
+                        .foregroundStyle(StrandPalette.textTertiary)
+                }
+                PipBar(value: Double(banked), range: 0...Double(m.nights), segments: m.nights,
+                       tint: StrandPalette.textTertiary)
+            }
+            .accessibilityElement(children: .ignore)
+            .accessibilityLabel("\(m.title), \(banked) of \(m.nights) nights, \(p.remaining) \(nightsWord) to go")
+        }
     }
 
     // MARK: A1/S4 Charge breakdown sheet (the Charge-ring tap target)

--- a/android/app/src/main/java/com/noop/analytics/CalibrationMilestones.kt
+++ b/android/app/src/main/java/com/noop/analytics/CalibrationMilestones.kt
@@ -1,0 +1,107 @@
+package com.noop.analytics
+
+/**
+ * Calibration milestones — the WHOOP-familiar countdown timeline surfaced on Today (gamification).
+ *
+ * PRESENTATION LAYER ONLY. These targets drive the milestone COUNTDOWN CARDS; they do NOT change the
+ * baseline math in [Baselines]. noop keeps its own honest gates (seed [Baselines.minNightsSeed] = 4,
+ * trust [Baselines.minNightsTrust] = 14, with early-adapt) — a milestone reaching "done" here is a UI
+ * badge, not a claim the analytics changed. The night count fed in is the SAME valid-HRV-night tally the
+ * recovery seed uses (see `bankedCalibrationNights` in TodayScreen), so a progress bar can never
+ * over-state what the baseline has actually banked.
+ *
+ * The targets mirror WHOOP's published Calibration Timeline (Day 4 Recovery, Day 7 Sleep, Day 30 full
+ * baseline) plus noop's own 14-night Trusted gate, so a WHOOP user sees the timeline they expect while
+ * noop's better statistics run underneath. Mirrors the Swift `CalibrationMilestones`.
+ */
+object CalibrationMilestones {
+
+    /** The 5.0/MG "first week" sleep-coaching milestone (WHOOP Day 7). Not a baseline gate — a card target. */
+    const val sleepBaselineNights: Int = 7
+
+    /** WHOOP's full-baseline / rolling-30-day milestone (Day 30). Not a baseline gate — a card target. */
+    const val fullBaselineNights: Int = 30
+
+    /** A single calibration checkpoint. [nights] is the banked valid-night count at which it unlocks. */
+    data class Milestone(
+        /** Stable id (persisted / cross-platform / analytics-safe). Never renumber. */
+        val id: String,
+        val title: String,
+        val nights: Int,
+        /** One-line "what this unlocks", shown on the active card. */
+        val unlocks: String,
+    )
+
+    /** The ordered timeline, soonest first. Targets are pinned to the honest gates where they coincide. */
+    val all: List<Milestone> = listOf(
+        Milestone(
+            id = "firstRecovery",
+            title = "First Recovery",
+            nights = Baselines.minNightsSeed, // 4 — matches WHOOP Day 4
+            unlocks = "Charge, Effort and Rest become personal to you.",
+        ),
+        Milestone(
+            id = "sleepBaseline",
+            title = "Sleep baseline",
+            nights = sleepBaselineNights, // 7 — WHOOP "after your first week"
+            unlocks = "Your sleep need and coaching tune to your own nights.",
+        ),
+        Milestone(
+            id = "trustedBaseline",
+            title = "Trusted baseline",
+            nights = Baselines.minNightsTrust, // 14 — noop's full-confidence gate
+            unlocks = "Full-confidence baselines — the calibrating tag drops.",
+        ),
+        Milestone(
+            id = "fullBaseline",
+            title = "30-day baseline",
+            nights = fullBaselineNights, // 30 — WHOOP full baseline / rolling window
+            unlocks = "Your complete rolling 30-day baseline is set.",
+        ),
+    )
+
+    /** The furthest target. Banked ≥ this ⇒ calibration is fully complete and the card retires.
+     *  `maxOfOrNull ?: 0` matches the Swift twin's empty-safe default (never throws on an empty list). */
+    val finalNights: Int get() = all.maxOfOrNull { it.nights } ?: 0
+
+    /** DONE = already reached; ACTIVE = the live countdown (first unreached); LOCKED = still ahead. */
+    enum class State { DONE, ACTIVE, LOCKED }
+
+    /** A milestone paired with its computed progress against a banked-night count. */
+    data class Progress(
+        val milestone: Milestone,
+        val state: State,
+        /** Nights still needed (0 once done). */
+        val remaining: Int,
+        /** 0..1 absolute fill toward this milestone's target (1.0 once done). */
+        val fraction: Double,
+    )
+
+    /**
+     * Resolve every milestone's [Progress] for a user who has banked [nightsBanked] valid nights. The
+     * FIRST not-yet-reached milestone is [State.ACTIVE] (the live countdown); earlier ones are DONE,
+     * later ones LOCKED. Fraction is absolute (banked ÷ target) so the bar text ("9/14 nights") and the
+     * fill agree. Pure + unit-tested; mirrors the Swift twin.
+     */
+    fun progress(nightsBanked: Int): List<Progress> {
+        val n = nightsBanked.coerceAtLeast(0)
+        var activeAssigned = false
+        return all.map { m ->
+            val done = n >= m.nights
+            val state = when {
+                done -> State.DONE
+                !activeAssigned -> { activeAssigned = true; State.ACTIVE }
+                else -> State.LOCKED
+            }
+            Progress(
+                milestone = m,
+                state = state,
+                remaining = (m.nights - n).coerceAtLeast(0),
+                fraction = if (done) 1.0 else (n.toDouble() / m.nights).coerceIn(0.0, 1.0),
+            )
+        }
+    }
+
+    /** True while at least one milestone is still unreached (banked < [finalNights]) — the card should show. */
+    fun isCalibrating(nightsBanked: Int): Boolean = nightsBanked < finalNights
+}

--- a/android/app/src/main/java/com/noop/analytics/RecoveryScorer.kt
+++ b/android/app/src/main/java/com/noop/analytics/RecoveryScorer.kt
@@ -115,6 +115,21 @@ object RecoveryScorer {
     const val restingHRMinPlausibleBpm: Double = 25.0
 
     // ─────────────────────────────────────────────────────────────────────────
+    // Cold-start calibration progress
+    // ─────────────────────────────────────────────────────────────────────────
+
+    /**
+     * The UNCAPPED count of nights carrying a usable nightly HRV — the signal that seeds every
+     * baseline. Uses the SAME validity predicate as [Baselines.update] (value within the metric config
+     * bounds), not just non-null, so an implausible out-of-range night is excluded and this can never
+     * over-state nValid. The recovery cold-start gate uses it capped to the seed window; the
+     * calibration-milestone countdown cards ([CalibrationMilestones]) count it all the way to 30. Pure +
+     * unit-tested. Mirrors Swift `RecoveryScorer.bankedNights`.
+     */
+    fun bankedNights(nightlyHrv: List<Double?>, cfg: MetricCfg = Baselines.hrvCfg): Int =
+        nightlyHrv.count { it != null && it in cfg.minVal..cfg.maxVal }
+
+    // ─────────────────────────────────────────────────────────────────────────
     // Resting HR
     // ─────────────────────────────────────────────────────────────────────────
 

--- a/android/app/src/main/java/com/noop/ui/TodayScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/TodayScreen.kt
@@ -38,12 +38,15 @@ import androidx.compose.material.icons.filled.Autorenew
 import androidx.compose.material.icons.automirrored.filled.BatteryUnknown
 import androidx.compose.material.icons.filled.Bedtime
 import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.CheckCircle
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Favorite
 import androidx.compose.material.icons.filled.Functions
 import androidx.compose.material.icons.filled.History
 import androidx.compose.material.icons.filled.Info
 import androidx.compose.material.icons.filled.KeyboardArrowDown
+import androidx.compose.material.icons.filled.Lock
+import androidx.compose.material.icons.filled.LockOpen
 import androidx.compose.material.icons.filled.MonitorHeart
 import androidx.compose.material.icons.filled.KeyboardArrowUp
 import androidx.compose.material.icons.filled.TrackChanges
@@ -118,6 +121,7 @@ import com.noop.R
 import com.noop.analytics.BaselineState
 import com.noop.analytics.Baselines
 import com.noop.analytics.BatteryEstimator
+import com.noop.analytics.CalibrationMilestones
 import com.noop.analytics.ChargeDriver
 import com.noop.analytics.HydrationGoal
 import com.noop.analytics.HydrationStore
@@ -165,6 +169,11 @@ private const val CARD_NEW_HERE = "newHere"
 // the other Today info-cards, so a returning user who has read it once isn't nagged with it every day
 // through the multi-night calibration window. Same id on both platforms so it round-trips an export/import.
 private const val CARD_CALIBRATING = "calibratingBaseline"
+// The gamified calibration-milestone countdown stack (First Recovery → Sleep → Trusted → 30-day baseline).
+// Dismissible-into-the-inbox like the other Today info-cards so a returning user isn't nagged for the full
+// 30-night run; a "Restore to Today" tap brings it back. Same id on both platforms so it round-trips an
+// export/import. Presentation only — the targets never touch the Baselines math (CalibrationMilestones).
+private const val CARD_CALIBRATION_MILESTONES = "calibrationMilestones"
 // The "Latest sleep · <date>" / "Last night · <date>" carry-over note (ScoreState.CarriedLastNight). iOS
 // has nothing in this slot, so on Android it's dismissible-into-the-inbox like the other Today info-cards:
 // a small × tucks it into Updates (restorable), so it never sits permanently between the header and the
@@ -558,6 +567,10 @@ fun TodayScreen(
     var calibratingDismissed by remember {
         mutableStateOf(TodayCardDismissal.isDismissed(context, CARD_CALIBRATING))
     }
+    // The calibration-milestone countdown stack's dismissed flag, read once from the same shared store.
+    var milestonesDismissed by remember {
+        mutableStateOf(TodayCardDismissal.isDismissed(context, CARD_CALIBRATION_MILESTONES))
+    }
     // The carried "Latest sleep · <date>" note's dismissed flag (iOS has no such card; on Android it's
     // dismissible so it doesn't sit permanently above the hero and break the compact look). Read once.
     var carriedSleepDismissed by remember {
@@ -571,6 +584,7 @@ fun TodayScreen(
             CARD_SCORES_BUILDING -> scoresBuildingDismissed = true
             CARD_NEW_HERE -> newHereDismissed = true
             CARD_CALIBRATING -> calibratingDismissed = true
+            CARD_CALIBRATION_MILESTONES -> milestonesDismissed = true
             CARD_CARRIED_SLEEP -> carriedSleepDismissed = true
         }
         updateStore?.post(
@@ -592,6 +606,7 @@ fun TodayScreen(
                 CARD_SCORES_BUILDING -> scoresBuildingDismissed = false
                 CARD_NEW_HERE -> newHereDismissed = false
                 CARD_CALIBRATING -> calibratingDismissed = false
+                CARD_CALIBRATION_MILESTONES -> milestonesDismissed = false
                 CARD_CARRIED_SLEEP -> carriedSleepDismissed = false
             }
             updateStore.restoreRequest = null
@@ -802,6 +817,19 @@ fun TodayScreen(
     } else {
         null
     }
+
+    // Calibration-milestone gamification: the UNCAPPED banked-night tally (unlike recoveryCalibration,
+    // which nulls out past the 4-night seed) drives the WHOOP-style countdown cards (First Recovery 4 →
+    // Sleep 7 → Trusted 14 → 30-day baseline). Same analytics-layer source as the seed gate
+    // (RecoveryScorer.bankedNights), so the two can't diverge. Today only, and only while at least one
+    // milestone is still unreached; presentation-only — the targets never touch the Baselines math.
+    val calibrationMilestones: List<CalibrationMilestones.Progress>? =
+        if (selectedDayOffset == 0) {
+            val banked = RecoveryScorer.bankedNights(days.map { it.avgHrv })
+            if (CalibrationMilestones.isCalibrating(banked)) CalibrationMilestones.progress(banked) else null
+        } else {
+            null
+        }
 
     // The most recent fully-SCORED recovery day to carry over on TODAY while tonight's recovery hasn't
     // been scored yet (#543). Right after the logical-day rollover the new day has no recovery (the new
@@ -1182,6 +1210,30 @@ fun TodayScreen(
                 onChargeTap = { showChargeBreakdown = true },
             )
         }
+        }
+
+        // CALIBRATION MILESTONES (gamification): the WHOOP-style countdown stack, directly under the hero
+        // rings so a new user sees their (still-calibrating) score and then exactly how many nights until
+        // each milestone unlocks. Today only, only while unreached, and dismissible into the inbox so it
+        // never nags across the full 30-night run. Presentation-only; the Baselines math is untouched.
+        if (calibrationMilestones != null && !milestonesDismissed) {
+            item {
+                Box(modifier = Modifier.fillMaxWidth().staggeredAppear(3)) {
+                    CalibrationMilestonesCard(progress = calibrationMilestones)
+                    if (updateStore != null) {
+                        TodayCardDismissButton(
+                            modifier = Modifier.align(Alignment.TopEnd),
+                            onClick = {
+                                dismissTodayCard(
+                                    CARD_CALIBRATION_MILESTONES,
+                                    "Calibration milestones",
+                                    "Your countdown to personal Charge, Sleep and a full 30-day baseline.",
+                                )
+                            },
+                        )
+                    }
+                }
+            }
         }
 
         // LIVE SESSIONS (beta): the compact "Start session · BETA" entry, directly under the hero. Today
@@ -3720,14 +3772,11 @@ internal fun recoveryCalibrationNights(
     seed: Int = Baselines.minNightsSeed,
 ): Int? {
     if (hasRecovery) return null
-    // Match the baseline's validity predicate, not just non-null: Baselines.update only advances the
-    // recovery seed (nValid) for nights whose avgHrv is within the HRV config bounds, so an implausible
-    // out-of-range night must NOT be counted here either, else the displayed N could over-state nValid.
-    val cfg = Baselines.hrvCfg
     // Include 0: a brand-new user (no banked nights) reads "Calibrating, 0 of N" on Charge, not a
-    // bare "No data" that looks broken (#335). Caller gates past days to null; >= seed → null.
-    return days.count { val v = it.avgHrv; v != null && v in cfg.minVal..cfg.maxVal }
-        .takeIf { it in 0 until seed }
+    // bare "No data" that looks broken (#335). Caller gates past days to null; >= seed → null. The
+    // uncapped valid-HRV tally lives in the analytics layer (RecoveryScorer.bankedNights) so this seed
+    // gate and the calibration-milestone cards can't diverge; mirrors Swift RecoveryScorer.calibrationNights.
+    return RecoveryScorer.bankedNights(days.map { it.avgHrv }).takeIf { it in 0 until seed }
 }
 
 /**
@@ -3950,6 +3999,134 @@ internal fun scoreStateForToday(
     // "Latest sleep" so a weeks-old import is never passed off as "Last night".
     carriedDay != null -> ScoreState.CarriedLastNight(lastChargeDateLabel(carriedDay.day), isCarryStale(carriedDay.day, today))
     else -> ScoreState.NeedsStrap
+}
+
+/**
+ * The gamified calibration-milestone countdown stack (WHOOP-style "Calibration Timeline"). Renders one
+ * row per milestone: DONE milestones read as a compact "Unlocked" check, the single ACTIVE milestone is
+ * the live countdown with an accent liquid progress bar + "N nights to go" + what it unlocks, and LOCKED
+ * milestones sit muted below with their own dimmed bar. [progress] is the pure, unit-tested
+ * [CalibrationMilestones.progress] output; this composable is presentation only. Design-system tokens
+ * only (Palette / Metrics / NoopType). Mirrors the iOS CalibrationMilestonesCard.
+ */
+@Composable
+private fun CalibrationMilestonesCard(progress: List<CalibrationMilestones.Progress>) {
+    NoopCard {
+        Column(verticalArrangement = Arrangement.spacedBy(Metrics.space12)) {
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(Metrics.space10),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Icon(
+                    Icons.Filled.Tune,
+                    contentDescription = null,
+                    tint = Palette.accent,
+                    modifier = Modifier.size(Metrics.iconSmall),
+                )
+                Column(verticalArrangement = Arrangement.spacedBy(Metrics.space2)) {
+                    Text("Calibration milestones", style = NoopType.headline, color = Palette.textPrimary)
+                    Text(
+                        "Wear the strap overnight to unlock each one.",
+                        style = NoopType.subhead,
+                        color = Palette.textSecondary,
+                    )
+                }
+            }
+            progress.forEach { p -> CalibrationMilestoneRow(p) }
+        }
+    }
+}
+
+/** One milestone row inside [CalibrationMilestonesCard], drawn by its [CalibrationMilestones.State]. */
+@Composable
+private fun CalibrationMilestoneRow(p: CalibrationMilestones.Progress) {
+    val m = p.milestone
+    val banked = (m.nights - p.remaining).coerceAtLeast(0)
+    val nightsWord = if (p.remaining == 1) "night" else "nights"
+    when (p.state) {
+        // A cleared milestone: a compact green check + "Unlocked", no progress bar (it's full by definition).
+        CalibrationMilestones.State.DONE -> Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .semantics { contentDescription = "${m.title} unlocked" },
+            horizontalArrangement = Arrangement.spacedBy(Metrics.space8),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Icon(
+                Icons.Filled.CheckCircle,
+                contentDescription = null,
+                tint = Palette.statusPositive,
+                modifier = Modifier.size(Metrics.iconSmall),
+            )
+            Text(m.title, style = NoopType.subhead, color = Palette.textSecondary, modifier = Modifier.weight(1f))
+            Text("Unlocked", style = NoopType.footnote, color = Palette.statusPositive)
+        }
+
+        // The live countdown: accent open-lock, "N nights to go", an accent bar, and what it unlocks.
+        CalibrationMilestones.State.ACTIVE -> Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .semantics {
+                    contentDescription =
+                        "${m.title}, $banked of ${m.nights} nights, ${p.remaining} $nightsWord to go. ${m.unlocks}"
+                },
+            verticalArrangement = Arrangement.spacedBy(Metrics.space6),
+        ) {
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(Metrics.space8),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Icon(
+                    Icons.Filled.LockOpen,
+                    contentDescription = null,
+                    tint = Palette.accent,
+                    modifier = Modifier.size(Metrics.iconSmall),
+                )
+                Text(m.title, style = NoopType.headline, color = Palette.textPrimary, modifier = Modifier.weight(1f))
+                Text("${p.remaining} $nightsWord to go", style = NoopType.footnote, color = Palette.accent)
+            }
+            // Status bar, not a hero surface — posed (animated=false) so it costs nothing per scroll frame.
+            LiquidTube(
+                frac = p.fraction,
+                tint = Palette.accent,
+                height = Metrics.progressHeight,
+                animated = false,
+                modifier = Modifier.fillMaxWidth(),
+            )
+            Text("$banked/${m.nights} nights · ${m.unlocks}", style = NoopType.footnote, color = Palette.textSecondary)
+        }
+
+        // Still ahead: a muted closed-lock, dimmed bar, and the raw gap — no unlocks copy (keeps it quiet).
+        CalibrationMilestones.State.LOCKED -> Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .semantics {
+                    contentDescription = "${m.title}, $banked of ${m.nights} nights, ${p.remaining} $nightsWord to go"
+                },
+            verticalArrangement = Arrangement.spacedBy(Metrics.space6),
+        ) {
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(Metrics.space8),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Icon(
+                    Icons.Filled.Lock,
+                    contentDescription = null,
+                    tint = Palette.textTertiary,
+                    modifier = Modifier.size(Metrics.iconSmall),
+                )
+                Text(m.title, style = NoopType.subhead, color = Palette.textSecondary, modifier = Modifier.weight(1f))
+                Text("${p.remaining} $nightsWord to go", style = NoopType.footnote, color = Palette.textTertiary)
+            }
+            LiquidTube(
+                frac = p.fraction,
+                tint = Palette.textTertiary,
+                height = Metrics.progressHeight,
+                animated = false,
+                modifier = Modifier.fillMaxWidth(),
+            )
+        }
+    }
 }
 
 /** The honest score-state note shown in the Today flow when there is no own number to render, the

--- a/android/app/src/test/java/com/noop/analytics/CalibrationMilestonesTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/CalibrationMilestonesTest.kt
@@ -1,0 +1,101 @@
+package com.noop.analytics
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Pins the pure calibration-milestone timeline that drives the Today countdown cards. The targets are a
+ * PRESENTATION overlay (they never touch [Baselines]); these tests lock the ordering, the exactly-one
+ * ACTIVE invariant, the done/locked partition, the absolute-fraction contract the card text relies on,
+ * and the retire-at-final gate. Mirrors the Swift CalibrationMilestonesTests.
+ */
+class CalibrationMilestonesTest {
+
+    @Test
+    fun timeline_isTheWhoopFamiliarSetInOrder() {
+        val nights = CalibrationMilestones.all.map { it.nights }
+        assertEquals(listOf(4, 7, 14, 30), nights)
+        // The soonest/last targets stay pinned to the honest baseline gates + WHOOP's day-30 full baseline.
+        assertEquals(Baselines.minNightsSeed, CalibrationMilestones.all.first().nights)
+        assertEquals(Baselines.minNightsTrust, CalibrationMilestones.all[2].nights)
+        assertEquals(30, CalibrationMilestones.finalNights)
+    }
+
+    @Test
+    fun brandNewUser_firstMilestoneIsActive_restLocked_noneDone() {
+        val p = CalibrationMilestones.progress(0)
+        assertEquals(CalibrationMilestones.State.ACTIVE, p[0].state)
+        assertTrue(p.drop(1).all { it.state == CalibrationMilestones.State.LOCKED })
+        assertFalse(p.any { it.state == CalibrationMilestones.State.DONE })
+        // "N nights to go" is the raw gap; the first bar starts empty.
+        assertEquals(4, p[0].remaining)
+        assertEquals(0.0, p[0].fraction, 1e-9)
+    }
+
+    @Test
+    fun exactlyOneActive_untilFullyCalibrated() {
+        for (n in 0..29) {
+            val active = CalibrationMilestones.progress(n).count { it.state == CalibrationMilestones.State.ACTIVE }
+            assertEquals("banked=$n should have exactly one live countdown", 1, active)
+        }
+    }
+
+    @Test
+    fun midCalibration_partitionsAndCountsDown() {
+        // 9 nights banked: 4 & 7 are DONE, 14 is the live countdown, 30 is locked (matches the card mockup).
+        val p = CalibrationMilestones.progress(9)
+        assertEquals(CalibrationMilestones.State.DONE, p[0].state)   // 4
+        assertEquals(CalibrationMilestones.State.DONE, p[1].state)   // 7
+        assertEquals(CalibrationMilestones.State.ACTIVE, p[2].state) // 14
+        assertEquals(CalibrationMilestones.State.LOCKED, p[3].state) // 30
+        assertEquals(5, p[2].remaining)   // "5 nights to go"
+        assertEquals(21, p[3].remaining)  // "21 nights to go"
+        // Absolute fill so the "9/14" / "9/30" labels agree with the bars.
+        assertEquals(9.0 / 14.0, p[2].fraction, 1e-9)
+        assertEquals(9.0 / 30.0, p[3].fraction, 1e-9)
+        // A DONE milestone is always full, never over/under-filled.
+        assertEquals(1.0, p[0].fraction, 1e-9)
+    }
+
+    @Test
+    fun onTheDot_countsAsDone() {
+        // Reaching the target exactly (>=) flips it DONE with zero remaining, not a lingering "1 to go".
+        val p = CalibrationMilestones.progress(14)
+        assertEquals(CalibrationMilestones.State.DONE, p[2].state)
+        assertEquals(0, p[2].remaining)
+        assertEquals(CalibrationMilestones.State.ACTIVE, p[3].state) // 30 is now the live one
+    }
+
+    @Test
+    fun fullyCalibrated_retiresTheCard() {
+        assertTrue(CalibrationMilestones.isCalibrating(0))
+        assertTrue(CalibrationMilestones.isCalibrating(29))
+        assertFalse(CalibrationMilestones.isCalibrating(30))
+        assertFalse(CalibrationMilestones.isCalibrating(45))
+        // At/after the final target everything is DONE, nothing is left ACTIVE.
+        val p = CalibrationMilestones.progress(30)
+        assertTrue(p.all { it.state == CalibrationMilestones.State.DONE })
+    }
+
+    @Test
+    fun negativeCountClampsToZero() {
+        // Defensive: a bad caller count never throws or produces a negative fraction/remaining.
+        val p = CalibrationMilestones.progress(-3)
+        assertEquals(0.0, p[0].fraction, 1e-9)
+        assertEquals(4, p[0].remaining)
+        assertEquals(CalibrationMilestones.State.ACTIVE, p[0].state)
+    }
+
+    @Test
+    fun bankedNightsMatchesBaselineValidityPredicate() {
+        // The uncapped banked-night predicate the cards feed from (used all the way to 30) excludes
+        // out-of-range nights, so a wild reading can't inflate the countdown. Parity with Swift
+        // RecoveryScorer.bankedNights (CalibrationMilestonesTests.testBankedNightsMatchesBaselineValidityPredicate).
+        val cfg = Baselines.hrvCfg
+        val good = (cfg.minVal + cfg.maxVal) / 2.0
+        val nightly = listOf<Double?>(good, null, cfg.maxVal + 1000, good, good)
+        assertEquals(3, RecoveryScorer.bankedNights(nightly, cfg))
+    }
+}


### PR DESCRIPTION
## What
Gamified "Calibration Timeline" cards on Today, mirroring WHOOP's published calibration milestones: a countdown to **First Recovery (4 nights)**, **Sleep baseline (7)**, **Trusted baseline (14)**, and the full **30-day baseline**. Each unreached milestone shows a progress bar + "N nights to go"; cleared ones collapse to a compact done row; the card retires once fully calibrated (≥30 banked nights). Dismissible into the Updates inbox.

## Approach — presentation overlay, no analytics change
Presentation layer only. It does **not** touch `Baselines` — the honest seed (4) / trust (14) gates and cold-start behaviour are unchanged. Milestone targets are pinned to those gates where they coincide (4, 14), plus WHOOP's Day-7 sleep and Day-30 full-baseline points. The banked-night source is the same valid-HRV tally the recovery seed already uses, extracted into the analytics layer (`RecoveryScorer.bankedNights`) so the seed gate and the cards can't diverge.

## Cross-platform
- Pure model `CalibrationMilestones` (Kotlin + Swift, byte-identical: same targets, same done/active/locked partition, same absolute banked÷target fraction, same retire-at-30 gate), each covered by unit tests.
- Android uses `LiquidTube` for progress; iOS uses `PipBar` (one pip per night). Card id `calibrationMilestones`; round-trips an export/import.
- Design-system tokens only (Palette/Metrics/NoopType on Android; StrandPalette/StrandFont on iOS).

## Verification
- **Android:** `compileFullDebugKotlin` + `testFullDebugUnitTest` (`CalibrationMilestonesTest`, `RecoveryCalibrationTest`) green.
- **Swift:** pure `CalibrationMilestones` + `RecoveryScorer` are covered by `swift-packages` CI. The **app-target Swift (`TodayView.swift`) is not compiled by default CI** and needs a Mac `xcodebuild` before merge — an iOS-verify issue will follow.
