### PR TITLE
fix(sleep): flag Rest low-confidence on sparse-motion nights (#345, #319)

### DIFF
--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/AnalyticsEngine.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/AnalyticsEngine.swift
@@ -438,6 +438,9 @@ public enum AnalyticsEngine {
             needHours: sleepNeedHours,
             consistency: sleepConsistency,
             deepSeconds: deepS)
+        // #345: gravity-sparse computed ONCE — reused by the sleep-motion trace below AND the Rest
+        // confidence guard, so the two can never diverge and isGravitySparse runs only once per day.
+        let gravitySparse = SleepStager.isGravitySparse(gravity, hr: hr)
         // Sleep & Rest test mode (E5): emit the Rest sub-score breakdown for this night, reusing the
         // IDENTICAL inputs `restScore` consumed above so the trace can never disagree with the score.
         // `subScoreLine` itself reuses `Rest.composite` for the final value. Side-effect-only; emitted
@@ -453,7 +456,7 @@ public enum AnalyticsEngine {
             // epochs default to sleep → over-counted duration → high Rest). `stager` says whether V1/V2 ran.
             traceSink(AnalyticsEngine.sleepMotionLine(
                 day: day, grav: gravity.count, hr: hr.count,
-                sparse: SleepStager.isGravitySparse(gravity, hr: hr),
+                sparse: gravitySparse,
                 useSleepStagerV2: useSleepStagerV2, family: skinTempFamily))
             // CAPTURE-C (#799): append the sleep PROVENANCE so an imported row winning the merge is visible
             // (not silently swapped for the measured night). hoursAsleep = the scored night's tst in minutes;
@@ -759,7 +762,7 @@ public enum AnalyticsEngine {
         let restConfidence = ScoreConfidence.rest(hasSession: !matched.isEmpty,
                                                   hasStagedSleep: hasStagedSleep,
                                                   asleepSeconds: tstS, restorativeSeconds: deepS + remS,
-                                                  efficiency: efficiency)
+                                                  efficiency: efficiency, gravitySparse: gravitySparse)
 
         return DayResult(daily: daily, sleepSessions: matched, cachedSleep: cachedSleep,
                          workouts: workouts, recovery: recovery, strain: strain,

--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/ScoreConfidence.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/ScoreConfidence.swift
@@ -69,21 +69,29 @@ public enum ScoreConfidence: String, Equatable, Sendable, Codable {
     /// suspicious case — high efficiency (lots of measured sleep) but implausibly little restorative.
     public static let highEfficiencyThreshold: Double = 0.85
 
-    /// Rest confidence WITH the H9 stage-quality check. Starts from `rest(hasSession:hasStagedSleep:)`, then
-    /// DOWNGRADES a `.solid` tier to `.building` (low-confidence) when the night is high-efficiency yet its
-    /// restorative (deep+REM) share is below `restorativeLowConfidenceShare` — a likely staging miss, surfaced
-    /// honestly without inventing stages or distorting the Rest score. `asleepSeconds`/`restorativeSeconds`
-    /// are the night's totals; efficiency is asleep/in-bed in [0,1]. `.calibrating`/`.building` from the base
-    /// call are returned unchanged (you can't downgrade below building, and no-stage nights are already
-    /// flagged). Engine output only; the UI surfaces the tier later. (#H9)
+    /// Rest confidence WITH the H9 stage-quality check AND the sparse-motion guard. Starts from
+    /// `rest(hasSession:hasStagedSleep:)`, then DOWNGRADES a `.solid` tier to `.building` (low-confidence)
+    /// when EITHER:
+    ///  - the night was staged on SPARSE gravity (`gravitySparse`) — a WHOOP 4.0 synced/offload night banks
+    ///    motion coarsely, too sparse to reliably stage sleep (#345), so a confident 85–100 Rest is unearned
+    ///    however the engine filled the stages. This catches the case H9 MISSES: a sparse night whose staging
+    ///    manufactures HIGH efficiency AND HIGH restorative reads SOLID under H9 alone (the #319 signature),
+    ///    yet the underlying data can't support it; OR
+    ///  - the night is high-efficiency yet its restorative (deep+REM) share is below
+    ///    `restorativeLowConfidenceShare` — a likely staging miss (#H9).
+    /// `asleepSeconds`/`restorativeSeconds` are the night's totals; efficiency is asleep/in-bed in [0,1].
+    /// `.calibrating`/`.building` from the base call are returned unchanged. Confidence-only — never changes
+    /// the Rest score or invents stages. Engine output only; the UI surfaces the tier later. (#H9, #345)
     public static func rest(hasSession: Bool, hasStagedSleep: Bool,
                             asleepSeconds: Double, restorativeSeconds: Double,
-                            efficiency: Double) -> ScoreConfidence {
+                            efficiency: Double, gravitySparse: Bool = false) -> ScoreConfidence {
         let base = rest(hasSession: hasSession, hasStagedSleep: hasStagedSleep)
-        guard base == .solid, asleepSeconds > 0 else { return base }
+        if base != .solid { return base }
+        if gravitySparse { return .building }   // #345: sparse-motion staging can't earn a SOLID Rest
+        if asleepSeconds <= 0 { return base }
         let restorativeShare = restorativeSeconds / asleepSeconds
         if efficiency >= highEfficiencyThreshold && restorativeShare < restorativeLowConfidenceShare {
-            return .building   // high-efficiency night with near-zero deep+REM → low-confidence staging
+            return .building   // high-efficiency night with near-zero deep+REM → low-confidence staging (#H9)
         }
         return base
     }

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/AnalyticsEngineTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/AnalyticsEngineTests.swift
@@ -505,6 +505,28 @@ final class AnalyticsEngineTests: XCTestCase {
             .building)
     }
 
+    // #345: a night staged on SPARSE gravity is downgraded to low-confidence WHATEVER the engine filled in —
+    // this catches the #319 case H9 misses: high efficiency AND healthy restorative (V2 manufactured stages
+    // on too little motion) would read .solid under H9, but the coarse motion can't support a confident score.
+    func testRestConfidenceSparseGravityDowngradesEvenHealthyLookingNight() {
+        let asleep = 8.0 * 3600.0
+        XCTAssertEqual(
+            ScoreConfidence.rest(hasSession: true, hasStagedSleep: true,
+                                 asleepSeconds: asleep, restorativeSeconds: asleep * 0.45,
+                                 efficiency: 0.95, gravitySparse: true),
+            .building)
+    }
+
+    func testRestConfidenceSparseGravityDefaultsFalseSoDenseNightsUnchanged() {
+        // Default gravitySparse=false → a dense healthy night stays .solid (byte-identical to old callers).
+        let asleep = 8.0 * 3600.0
+        XCTAssertEqual(
+            ScoreConfidence.rest(hasSession: true, hasStagedSleep: true,
+                                 asleepSeconds: asleep, restorativeSeconds: asleep * 0.45,
+                                 efficiency: 0.95),
+            .solid)
+    }
+
     // MARK: - #525 day with an overnight + a nap reports CONSISTENT totals
     // #525's main-night-not-sum reconciliation is covered deterministically by the SleepStageTotals
     // suite (testOvernightPlusNapReportsConsistentTotalsNotTheSum with explicit stage JSON, plus the

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/SleepStagerTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/SleepStagerTests.swift
@@ -726,6 +726,45 @@ final class SleepStagerTests: XCTestCase {
         XCTAssertEqual(s.restingHR, 50)
     }
 
+    // #345 END-TO-END: a locked synthetic WHOOP-4.0 OFFLOAD night — dense sleep-band HR but clumped/sparse
+    // motion (~the reporter's ~20% coverage) — must flow REAL isGravitySparse → REAL ScoreConfidence.rest →
+    // .building, EVEN when the night ALSO looks healthy (high efficiency + ~45% restorative). That healthy-
+    // looking case is exactly what H9 misses, so without the sparse guard it would read a confident .solid
+    // 85–100 — the #319 signature. The guard validated against a realistic synthetic offload night, since no
+    // real offload capture exists yet.
+    func testSparseOffloadNightForcesRestBuildingEndToEnd() {
+        let start = nightStart(01)
+        let dur = 6 * 60 * 60
+        let grav = sparseStillGravity(start: start, durationS: dur, everyS: 25 * 60)
+        let hr = hrStream(start: start, durationS: dur, bpm: 50)
+        let sparse = SleepStager.isGravitySparse(grav, hr: hr)
+        XCTAssertTrue(sparse, "the locked synthetic 4.0-offload night must read sparse")
+        let asleep = 8.0 * 3600.0
+        XCTAssertEqual(
+            ScoreConfidence.rest(hasSession: true, hasStagedSleep: true,
+                                 asleepSeconds: asleep, restorativeSeconds: asleep * 0.45,
+                                 efficiency: 0.95, gravitySparse: sparse),
+            .building,
+            "a sparse night — even high-efficiency AND healthy restorative (the #319 case H9 misses) — must not earn SOLID")
+    }
+
+    func testDenseNightKeepsRestSolidEndToEnd() {
+        // The dense counterpart: same healthy night on DENSE 1 Hz motion → not sparse → .solid stands.
+        let start = nightStart(02)
+        let dur = 6 * 60 * 60
+        let grav = stillGravity(start: start, durationS: dur)
+        let hr = hrStream(start: start, durationS: dur, bpm: 50)
+        let sparse = SleepStager.isGravitySparse(grav, hr: hr)
+        XCTAssertFalse(sparse, "the dense night must NOT read sparse")
+        let asleep = 8.0 * 3600.0
+        XCTAssertEqual(
+            ScoreConfidence.rest(hasSession: true, hasStagedSleep: true,
+                                 asleepSeconds: asleep, restorativeSeconds: asleep * 0.45,
+                                 efficiency: 0.95, gravitySparse: sparse),
+            .solid,
+            "a dense healthy night keeps SOLID — the sparse guard never touches it")
+    }
+
     func testBuildRunsDenseGravityByteIdenticalToLegacy() {
         // Direct byte-identity proof: buildRuns with the sparse override OFF (the default) returns
         // exactly the same runs as passing sparse:false, on a gravity stream with a real >maxGapMin

--- a/android/app/src/main/java/com/noop/analytics/AnalyticsEngine.kt
+++ b/android/app/src/main/java/com/noop/analytics/AnalyticsEngine.kt
@@ -430,6 +430,9 @@ object AnalyticsEngine {
             sleepNeedHours = sleepNeedHours,
             consistency = sleepConsistency,
         )
+        // #345: gravity-sparse computed ONCE — reused by the sleep-motion trace below AND the Rest
+        // confidence guard, so the two can never diverge and isGravitySparse runs only once per day.
+        val gravitySparse = SleepStager.isGravitySparse(gravity, hr)
         // Sleep & Rest test mode (E11): emit the Rest sub-score breakdown for this night, reusing the
         // IDENTICAL inputs `rest` consumed above so the trace can never disagree with the score. Emitted
         // only when a trace is requested and this day scored a night. Mirrors Swift.
@@ -444,7 +447,7 @@ object AnalyticsEngine {
             // night can be explained from an export — WHOOP 4.0 banks motion coarsely (sparse=true), so most
             // epochs default to sleep → over-counted duration → high Rest; `stager` says whether V1/V2 ran.
             traceSink(RestScorer.sleepMotionLine(day, gravity.size, hr.size,
-                SleepStager.isGravitySparse(gravity, hr), useSleepStagerV2, skinTempFamily))
+                gravitySparse, useSleepStagerV2, skinTempFamily))
             // #271: the ONSET decision — did HR dip when the window opened, or did it open on a still-but-
             // awake stretch (HR still ~baseline)? Both the day-median baseline AND the at-onset window read
             // from the SAME HR that DETECTION ran over (`dayHr ?: hr` — the full calendar day when the caller
@@ -599,15 +602,18 @@ object AnalyticsEngine {
         // ── Per-score confidence tiers (mirror Swift ScoreConfidence.derive decisions) ──
         val chargeConfidence = ScoreConfidence.forCharge(recovery, baselines.hrv)
         val effortConfidence = ScoreConfidence.forEffort(strain, hr.size)
-        // Rest confidence with H9: downgrade a high-efficiency night whose deep+REM share is implausibly low
-        // to low-confidence (likely staging miss) — honest, no faked stages. tstS/efficiency are the
-        // main-group totals computed above; restorative = deepS + remS. Mirrors Swift.
+        // Rest confidence with H9 + the #345 sparse-motion guard: downgrade to low-confidence a night whose
+        // deep+REM share is implausibly low on a high-efficiency night (H9 staging miss) OR that was staged
+        // on sparse gravity (WHOOP 4.0 coarse-banked motion can't reliably stage sleep — a confident 85–100
+        // Rest is unearned however the engine filled it). Confidence-only, no faked stages. tstS/efficiency
+        // are the main-group totals above; restorative = deepS + remS. Mirrors Swift.
         val restConfidence = ScoreConfidence.forRest(
             hasSession = matched.isNotEmpty(),
             hasStagedSleep = (deepS + remS) > 0,
             asleepSeconds = tstS,
             restorativeSeconds = deepS + remS,
             efficiency = efficiency,
+            gravitySparse = gravitySparse,
         )
 
         // ── Per-session per-epoch motion (H8) ─────────────────────────────────

--- a/android/app/src/main/java/com/noop/analytics/ScoreConfidence.kt
+++ b/android/app/src/main/java/com/noop/analytics/ScoreConfidence.kt
@@ -101,12 +101,19 @@ enum class ScoreConfidence(val raw: String) {
         const val highEfficiencyThreshold: Double = 0.85
 
         /**
-         * Rest confidence WITH the H9 stage-quality check. Starts from [forRest], then DOWNGRADES a [SOLID]
-         * tier to [BUILDING] (low-confidence) when the night is high-efficiency yet its restorative
-         * (deep+REM) share is below [restorativeLowConfidenceShare] — a likely staging miss, surfaced
-         * honestly without inventing stages or distorting the Rest score. [CALIBRATING]/[BUILDING] from the
-         * base call are returned unchanged. Engine output only; the UI surfaces the tier later. Mirrors Swift
-         * `rest(hasSession:hasStagedSleep:asleepSeconds:restorativeSeconds:efficiency:)`. (#H9)
+         * Rest confidence WITH the H9 stage-quality check AND the sparse-motion guard. Starts from
+         * [forRest], then DOWNGRADES a [SOLID] tier to [BUILDING] (low-confidence) when EITHER:
+         *  - the night was staged on SPARSE gravity ([gravitySparse]) — a WHOOP 4.0 synced/offload night
+         *    banks motion coarsely, too sparse to reliably stage sleep (#345), so a confident 85–100 Rest
+         *    is unearned however the engine filled the stages. This catches the case H9 MISSES: a sparse
+         *    night whose staging manufactures HIGH efficiency AND HIGH restorative reads SOLID under H9
+         *    alone (the #319 signature), yet the underlying data can't support it; OR
+         *  - the night is high-efficiency yet its restorative (deep+REM) share is below
+         *    [restorativeLowConfidenceShare] — a likely staging miss (#H9).
+         * [CALIBRATING]/[BUILDING] from the base call are returned unchanged. Engine output only; the UI
+         * surfaces the tier later. Confidence-only — it never changes the Rest score or invents stages.
+         * Mirrors Swift `rest(hasSession:hasStagedSleep:asleepSeconds:restorativeSeconds:efficiency:gravitySparse:)`.
+         * (#H9, #345)
          */
         fun forRest(
             hasSession: Boolean,
@@ -114,12 +121,15 @@ enum class ScoreConfidence(val raw: String) {
             asleepSeconds: Double,
             restorativeSeconds: Double,
             efficiency: Double,
+            gravitySparse: Boolean = false,
         ): ScoreConfidence {
             val base = forRest(hasSession, hasStagedSleep)
-            if (base != SOLID || asleepSeconds <= 0.0) return base
+            if (base != SOLID) return base
+            if (gravitySparse) return BUILDING   // #345: sparse-motion staging can't earn a SOLID Rest
+            if (asleepSeconds <= 0.0) return base
             val restorativeShare = restorativeSeconds / asleepSeconds
             return if (efficiency >= highEfficiencyThreshold && restorativeShare < restorativeLowConfidenceShare) {
-                BUILDING   // high-efficiency night with near-zero deep+REM → low-confidence staging
+                BUILDING   // high-efficiency night with near-zero deep+REM → low-confidence staging (#H9)
             } else {
                 base
             }

--- a/android/app/src/test/java/com/noop/analytics/ChargeEffortRestScoringTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/ChargeEffortRestScoringTest.kt
@@ -376,4 +376,34 @@ class ChargeEffortRestScoringTest {
             ),
         )
     }
+
+    // #345: a night staged on SPARSE gravity (WHOOP 4.0 offload banks motion coarsely) is downgraded to
+    // low-confidence WHATEVER the engine filled in — this catches the #319 case H9 misses: high efficiency
+    // AND healthy restorative (V2 manufactured stages on too little motion) would read SOLID under H9, but
+    // the coarse motion can't support a confident 85–100.
+    @Test
+    fun confidence_restSparseGravityDowngradesEvenHealthyLookingNight() {
+        val asleep = 8.0 * 3600.0
+        assertEquals(
+            ScoreConfidence.BUILDING,
+            ScoreConfidence.forRest(
+                hasSession = true, hasStagedSleep = true,
+                asleepSeconds = asleep, restorativeSeconds = asleep * 0.45, efficiency = 0.95,
+                gravitySparse = true,
+            ),
+        )
+    }
+
+    @Test
+    fun confidence_restSparseGravityDefaultsFalseSoDenseNightsUnchanged() {
+        // Default gravitySparse=false → a dense healthy night stays SOLID (byte-identical to old callers).
+        val asleep = 8.0 * 3600.0
+        assertEquals(
+            ScoreConfidence.SOLID,
+            ScoreConfidence.forRest(
+                hasSession = true, hasStagedSleep = true,
+                asleepSeconds = asleep, restorativeSeconds = asleep * 0.45, efficiency = 0.95,
+            ),
+        )
+    }
 }

--- a/android/app/src/test/java/com/noop/analytics/SleepStagerSparseGravityTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/SleepStagerSparseGravityTest.kt
@@ -166,4 +166,47 @@ class SleepStagerSparseGravityTest {
         assertTrue("the bridged session must span both blocks across the dropout",
             (sessions[0].end - sessions[0].start).toDouble() > (2 * block).toDouble())
     }
+
+    // #345 END-TO-END: a locked synthetic WHOOP-4.0 OFFLOAD night — dense sleep-band HR but clumped/sparse
+    // motion (the ~20% coverage the reporter's log showed) — must flow REAL isGravitySparse → REAL forRest
+    // → BUILDING, EVEN when the night ALSO looks healthy (high efficiency + ~45% restorative). That healthy-
+    // looking case is exactly what H9 misses (H9 only fires on LOW restorative), so without the sparse guard
+    // it would read a confident SOLID 85–100 — the #319 signature. This is the guard validated against a
+    // realistic synthetic offload night, in the shipping code, since no real offload capture exists yet.
+    @Test
+    fun sparseOffloadNightForcesRestBuildingEndToEnd() {
+        val start = startAtHour(1)
+        val dur = 6 * 60 * 60
+        val grav = sparseStillGravity(start, dur, 25 * 60) // clumped, each gap > maxGapMin
+        val hr = hrStream(start, dur, 50)
+        val sparse = SleepStager.isGravitySparse(grav, hr)
+        assertTrue("the locked synthetic 4.0-offload night must read sparse", sparse)
+        val asleep = 8.0 * 3600.0
+        assertEquals(
+            "a sparse-motion night — even high-efficiency AND healthy restorative (the #319 case H9 misses)" +
+                " — must NOT earn a confident SOLID Rest",
+            ScoreConfidence.BUILDING,
+            ScoreConfidence.forRest(hasSession = true, hasStagedSleep = true,
+                asleepSeconds = asleep, restorativeSeconds = asleep * 0.45, efficiency = 0.95,
+                gravitySparse = sparse))
+    }
+
+    @Test
+    fun denseNightKeepsRestSolidEndToEnd() {
+        // The dense counterpart: same healthy night on DENSE 1 Hz motion → not sparse → SOLID stands. Proves
+        // the guard is a strict no-op on dense (5.0-live / 4.0-live) nights — no regression there.
+        val start = startAtHour(2)
+        val dur = 6 * 60 * 60
+        val grav = stillGravity(start, dur)
+        val hr = hrStream(start, dur, 50)
+        val sparse = SleepStager.isGravitySparse(grav, hr)
+        assertFalse("the dense night must NOT read sparse", sparse)
+        val asleep = 8.0 * 3600.0
+        assertEquals(
+            "a dense healthy night keeps SOLID — the sparse guard never touches it",
+            ScoreConfidence.SOLID,
+            ScoreConfidence.forRest(hasSession = true, hasStagedSleep = true,
+                asleepSeconds = asleep, restorativeSeconds = asleep * 0.45, efficiency = 0.95,
+                gravitySparse = sparse))
+    }
 }


### PR DESCRIPTION
## Problem (#345, #319)

A WHOOP 4.0 night synced from **band history** banks motion coarsely while keeping HR/R-R dense. From the #319 reporter's own strap log: `session persisted 1260 rows (252 with motion)` → **~20% motion coverage** (also 628/3140, 413/2177 on other nights), with R-R `coverage=0.90`. The gravity-based sleep/wake detector then counts still-but-awake time as asleep → inflated duration/efficiency → a **confident 85–100 Rest on a poor night** (`rest composite=92.23 eff=0.93 restor=1.0` in that log).

The existing H9 guard **misses this**: it only downgrades when restorative is *low*, but a sparse night whose staging manufactures **high efficiency AND high restorative** reads SOLID — exactly the #319 signature.

## Change (confidence-only)

`ScoreConfidence.rest(...)` gains a `gravitySparse` param: a night staged on sparse gravity is downgraded **SOLID → BUILDING**, *whatever engine staged it*. It never changes the Rest score or invents stages — same philosophy as H9. `AnalyticsEngine` passes the already-computed `SleepStager.isGravitySparse(...)`, hoisted so it runs **once** and is shared with the #328 sleep-motion trace.

Keying on the **data** (not on V1 happening to stage flat, as #327 relies on) means it also catches **5.0 sparse-offload** nights, and it's a clean prerequisite for a future 4.0→V2.

## Verification

- **Unit** (both platforms): sparse → BUILDING; dense (default) → SOLID unchanged.
- **End-to-end** (both platforms): real `isGravitySparse` → real `rest(...)` on a synthetic offload night pinned to the #319 ~20% coverage → BUILDING; dense twin → SOLID.
- **Grounded synthetic sweep** (DREAMT PSG, model = noop's own `#28/#308` characterization: dense 1 Hz bursts + >maxGapMin dropouts, `med gap 1s / max gap 23–30m`):

  | coverage | guard fires | V2 κ vs PSG |
  |---|---|---|
  | dense | 0/30 | 0.330 |
  | 30% | 30/30 | 0.199 |
  | 25% | 30/30 | 0.196 |
  | 20% *(#319)* | 30/30 | 0.189 |
  | 15% | 30/30 | 0.175 |
  | 10% | 30/30 | 0.173 |

  The guard fires across the entire realistic 10–30% offload band and **never** on dense; staging accuracy roughly **halves** under sparsity — which is exactly what BUILDING signals.

- Android `com.noop.analytics.*` suite green. Swift lives in `Packages/StrandAnalytics` → covered by `swift-packages.yml`.

## Scope

Confidence tier only — **no score/staging/BLE/schema/migration change**. Deliberately *not* included: de-weighting the *score* on sparse nights, which would benefit from a real captured offload night to tune. No real sparse-offload capture exists yet; the validation above is synthetic but pinned to the #319 report's own numbers and noop's own offload characterization.
