### PR TITLE
Baselines: imported rows with nil values no longer shadow computed nights

### DIFF
--- a/Strand/Data/IntelligenceEngine.swift
+++ b/Strand/Data/IntelligenceEngine.swift
@@ -781,9 +781,9 @@ final class IntelligenceEngine: ObservableObject {
             histRhrByDay[d.day] = d.restingHr.map(Double.init)
             histRespByDay[d.day] = d.respRateBpm
         }
-        for (day, v) in nightlyHrvByDay where histHrvByDay[day] == nil { histHrvByDay[day] = v }
-        for (day, v) in nightlyRhrByDay where histRhrByDay[day] == nil { histRhrByDay[day] = v }
-        for (day, v) in nightlyRespByDay where histRespByDay[day] == nil { histRespByDay[day] = v }
+        Self.mergeNightlyIntoHistory(&histHrvByDay, nightlyHrvByDay)
+        Self.mergeNightlyIntoHistory(&histRhrByDay, nightlyRhrByDay)
+        Self.mergeNightlyIntoHistory(&histRespByDay, nightlyRespByDay)
         // rhr/resp/skin honour the Charge-wide recalibration epoch (noop.recoveryBaselineEpoch); 0 = no-op,
         // so this is byte-identical to the plain fold until the user taps Recalibrate, at which point the
         // whole Charge build-up (HRV + resting HR + resp + skin) re-anchors together.
@@ -1774,5 +1774,24 @@ private extension DailyMetric {
                     strain: strain, exerciseCount: exerciseCount, spo2Pct: spo2Pct,
                     skinTempDevC: skinTempDevC, respRateBpm: respRateBpm, steps: steps,
                     activeKcalEst: activeKcalEst, spo2Red: spo2Red, spo2Ir: spo2Ir)
+    }
+}
+
+extension IntelligenceEngine {
+    /// Merge one metric's on-device pass-1 nightly values into the imported-history map.
+    /// Imported (cloud) values WIN per day; the computed estimate only fills days the import
+    /// does not cover at all (key absent). Twin of the Kotlin `mergeNightlyIntoHistory`.
+    nonisolated static func mergeNightlyIntoHistory(
+        _ hist: inout [String: Double?], _ nightly: [String: Double?]
+    ) {
+        // `hist` values are themselves Optional, so `hist[day] == nil` is only
+        // true when the KEY is absent — an imported row with a nil value is
+        // `.some(.none)` and would shadow the real computed night forever,
+        // starving the baseline (the "Needs the strap" bug). Imported non-nil
+        // wins; a nil (or absent) slot is backfilled by the computed value.
+        for (day, v) in nightly {
+            if let existing = hist[day], existing != nil { continue }  // imported non-nil wins
+            hist[day] = v
+        }
     }
 }

--- a/StrandTests/IntelligenceBaselineShadowTests.swift
+++ b/StrandTests/IntelligenceBaselineShadowTests.swift
@@ -1,0 +1,78 @@
+import XCTest
+import StrandAnalytics
+@testable import Strand
+
+/// Pins the baseline-merge precedence in `IntelligenceEngine.mergeNightlyIntoHistory` (the
+/// "Needs the strap" / recovery-No-Data starvation). An imported history row that carries a
+/// nil value for a metric holds no information for that day: it must NOT shadow the real
+/// on-device nightly value into a permanently missing night, or an import whose rows are
+/// blank for avgHrv/restingHr blankets every strap-covered day and the baseline never
+/// crosses `Baselines.minNightsSeed`. Precedence pinned here:
+///
+///   1. imported non-nil  → wins over the computed value (import users unchanged)
+///   2. key absent        → computed value fills (the BLE-only recovery fix)
+///   3. imported nil      → computed value backfills (the shadow fix)
+///   4. imported nil, no computed value → stays a missing night (honest gap)
+///
+/// Twin of the Kotlin `IntelligenceBaselineShadowTest` so both platforms merge identically.
+final class IntelligenceBaselineShadowTests: XCTestCase {
+
+    func testImportedNonNilWinsOverComputed() {
+        var hist: [String: Double?] = ["2026-07-10": 62.0]
+        IntelligenceEngine.mergeNightlyIntoHistory(&hist, ["2026-07-10": 48.0])
+        XCTAssertEqual(hist["2026-07-10"]!, 62.0)
+    }
+
+    func testDayNotImportedComputedFills() {
+        var hist: [String: Double?] = ["2026-07-10": 62.0]
+        IntelligenceEngine.mergeNightlyIntoHistory(&hist, ["2026-07-11": 48.0])
+        XCTAssertEqual(hist["2026-07-11"]!, 48.0)
+        XCTAssertEqual(hist.count, 2)
+    }
+
+    func testImportedNilValueBackfilledByComputed() {
+        // THE bug: the user's import wrote a row for the day with a blank avgHrv while the
+        // strap actually scored the night. The blank row must not shadow the real value.
+        var hist: [String: Double?] = ["2026-07-10": nil]
+        IntelligenceEngine.mergeNightlyIntoHistory(&hist, ["2026-07-10": 48.0])
+        XCTAssertEqual(
+            hist["2026-07-10"]!, 48.0,
+            "an imported row with a nil value must be backfilled by the real computed night")
+    }
+
+    func testImportedNilValueNoComputedStaysMissing() {
+        var hist: [String: Double?] = ["2026-07-10": nil]
+        IntelligenceEngine.mergeNightlyIntoHistory(&hist, [:])
+        XCTAssertNotNil(hist.index(forKey: "2026-07-10"))
+        XCTAssertNil(hist["2026-07-10"]!)
+    }
+
+    func testNilComputedDoesNotDisturbAnything() {
+        // A computed pass that produced no value for a day it emitted (nil estimate) neither
+        // overwrites an imported value nor un-registers an imported-nil day.
+        var hist: [String: Double?] = ["2026-07-10": 62.0, "2026-07-11": nil]
+        IntelligenceEngine.mergeNightlyIntoHistory(
+            &hist, ["2026-07-10": nil, "2026-07-11": nil, "2026-07-12": nil])
+        XCTAssertEqual(hist["2026-07-10"]!, 62.0)
+        XCTAssertNil(hist["2026-07-11"]!)
+        XCTAssertNotNil(hist.index(forKey: "2026-07-12"))
+        XCTAssertNil(hist["2026-07-12"]!)
+    }
+
+    func testStarvationShapeEndToEnd() {
+        // The report's shape: a week of imported rows, ALL blank for HRV, over nights the
+        // strap scored. After the merge the fold input must contain the 7 real values, so
+        // the baseline can cross Baselines.minNightsSeed instead of reading "No Data".
+        var hist: [String: Double?] = [:]
+        var nightly: [String: Double?] = [:]
+        for i in stride(from: 6, through: 0, by: -1) {
+            let day = String(format: "2026-07-%02d", 12 - i)
+            hist[day] = Double?.none
+            nightly[day] = 50.0 + Double(i)
+        }
+        IntelligenceEngine.mergeNightlyIntoHistory(&hist, nightly)
+        let valid = hist.values.compactMap { $0 }
+        XCTAssertEqual(valid.count, 7, "all 7 strap nights must survive the merge")
+        XCTAssertGreaterThanOrEqual(valid.count, Baselines.minNightsSeed)
+    }
+}

--- a/StrandTests/TodayExplainabilityTests.swift
+++ b/StrandTests/TodayExplainabilityTests.swift
@@ -1,5 +1,30 @@
 import XCTest
+import SwiftUI
 @testable import Strand
+
+/// Renders a `LocalizedStringKey` to its user-visible string so tests can keep pinning verbatim copy.
+///
+/// The production `title` keys are deliberately built with interpolation ("Last night · \(date)") so the
+/// string-catalog extractor sees the "Last night · %@" format key (#779). `LocalizedStringKey` equality
+/// compares the key pattern + formatting flag, so an interpolated key never equals a literal one — tests
+/// must compare the rendered text instead. Mirror is the only supported-ish way to get at the key and its
+/// arguments; if SwiftUI's internals shift, this fails loudly (nil) rather than passing vacuously.
+private func rendered(_ key: LocalizedStringKey?) -> String? {
+    guard let key else { return nil }
+    let mirror = Mirror(reflecting: key)
+    guard let pattern = mirror.descendant("key") as? String else { return nil }
+    guard let args = mirror.descendant("arguments") as? [Any], !args.isEmpty else { return pattern }
+    var cvarArgs: [CVarArg] = []
+    for arg in args {
+        // FormatArgument(storage: .value(CVarArg, Formatter?)) — descend to the first leaf value.
+        let storage = Mirror(reflecting: arg).descendant("storage") ?? arg
+        guard let payload = Mirror(reflecting: storage).children.first?.value else { return nil }
+        let leaf = Mirror(reflecting: payload).children.first?.value ?? payload
+        guard let cvar = leaf as? CVarArg else { return nil }
+        cvarArgs.append(cvar)
+    }
+    return String(format: pattern, arguments: cvarArgs)
+}
 
 /// Sleep & Recovery guidance / explainability layer — the Today lane pure mappers (spec 2026-06-20).
 ///
@@ -42,7 +67,7 @@ final class TodayExplainabilityTests: XCTestCase {
                                    carriedDate: "14 Jun",
                                    carriedStale: false)
         XCTAssertEqual(s, .carriedLastNight(date: "14 Jun", stale: false))
-        XCTAssertEqual(s.title, "Last night · 14 Jun")
+        XCTAssertEqual(rendered(s.title), "Last night · 14 Jun")
     }
 
     func testScoreState_staleCarry_relabelsLatestSleep() {
@@ -53,7 +78,7 @@ final class TodayExplainabilityTests: XCTestCase {
                                    carriedDate: "14 May",
                                    carriedStale: true)
         XCTAssertEqual(s, .carriedLastNight(date: "14 May", stale: true))
-        XCTAssertEqual(s.title, "Latest sleep · 14 May")
+        XCTAssertEqual(rendered(s.title), "Latest sleep · 14 May")
         XCTAssertEqual(s.accessibilityText,
                        "Latest sleep, 14 May. This is your last scored session. Wear the strap overnight for a fresh score.")
     }

--- a/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
+++ b/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
@@ -657,9 +657,9 @@ object IntelligenceEngine {
         // absent), which keeps that imported day as a missing night. HRV/RHR are the dominant
         // recovery drivers (~60%/~20%), so this substitution skewed Charge vs iOS. (The author already
         // fixed this for the low-weight resp term below; HRV/RHR were missed.)
-        for ((day, v) in nightlyHrvByDay) if (day !in histHrvByDay) histHrvByDay[day] = v
-        for ((day, v) in nightlyRhrByDay) if (day !in histRhrByDay) histRhrByDay[day] = v
-        for ((day, v) in nightlyRespByDay) if (day !in histRespByDay) histRespByDay[day] = v
+        mergeNightlyIntoHistory(histHrvByDay, nightlyHrvByDay)
+        mergeNightlyIntoHistory(histRhrByDay, nightlyRhrByDay)
+        mergeNightlyIntoHistory(histRespByDay, nightlyRespByDay)
         // Sort once so the HRV values + their "yyyy-MM-dd" day keys stay parallel (same order/length) for
         // the recalibration-aware foldHistory below.
         val hrvSorted = histHrvByDay.entries.sortedBy { it.key }
@@ -1601,6 +1601,23 @@ object IntelligenceEngine {
      * Floor a unix-seconds timestamp to 00:00:00 of its UTC calendar day. AnalyticsEngine.dayString
      * uses UTC, so UTC midnight = ts - floorMod(ts, 86400). floorMod is correct for any sign.
      */
+    /**
+     * Merge one metric's on-device pass-1 nightly values into the imported-history map.
+     * Imported (cloud) values WIN per day; the computed estimate only fills days the import
+     * does not cover at all (key absent). Mirrors the Swift `mergeNightlyIntoHistory`.
+     */
+    internal fun mergeNightlyIntoHistory(
+        hist: LinkedHashMap<String, Double?>,
+        nightly: Map<String, Double?>,
+    ) {
+        // `day !in hist` only checks KEY presence — an imported row with a null
+        // value would shadow the real computed night forever, starving the
+        // baseline (the "Needs the strap" bug). `hist[day] == null` is true for
+        // both absent keys and null values: imported non-null wins, a null (or
+        // absent) slot is backfilled by the computed value.
+        for ((day, v) in nightly) if (hist[day] == null) hist[day] = v
+    }
+
     internal fun midnightUtc(ts: Long): Long = ts - Math.floorMod(ts, SECONDS_PER_DAY)
 
     /**

--- a/android/app/src/test/java/com/noop/analytics/IntelligenceBaselineShadowTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/IntelligenceBaselineShadowTest.kt
@@ -1,0 +1,91 @@
+package com.noop.analytics
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Pins the baseline-merge precedence in `IntelligenceEngine.mergeNightlyIntoHistory` (the
+ * "Needs the strap" / recovery-No-Data starvation). An imported history row that carries a
+ * NULL value for a metric holds no information for that day: it must NOT shadow the real
+ * on-device nightly value into a permanently missing night, or an import whose rows are
+ * blank for avgHrv/restingHr blankets every strap-covered day and the baseline never
+ * crosses Baselines.minNightsSeed. Precedence pinned here:
+ *
+ *   1. imported non-null  → wins over the computed value (import users unchanged)
+ *   2. key absent         → computed value fills (the BLE-only recovery fix)
+ *   3. imported NULL      → computed value backfills (the shadow fix)
+ *   4. imported NULL, no computed value → stays a missing night (honest gap)
+ *
+ * Mirrors the Swift `IntelligenceBaselineShadowTests` so the two platforms merge identically.
+ */
+class IntelligenceBaselineShadowTest {
+
+    @Test
+    fun importedNonNull_winsOverComputed() {
+        val hist = linkedMapOf<String, Double?>("2026-07-10" to 62.0)
+        IntelligenceEngine.mergeNightlyIntoHistory(hist, mapOf("2026-07-10" to 48.0))
+        assertEquals(62.0, hist["2026-07-10"]!!, 1e-9)
+    }
+
+    @Test
+    fun dayNotImported_computedFills() {
+        val hist = linkedMapOf<String, Double?>("2026-07-10" to 62.0)
+        IntelligenceEngine.mergeNightlyIntoHistory(hist, mapOf("2026-07-11" to 48.0))
+        assertEquals(48.0, hist["2026-07-11"]!!, 1e-9)
+        assertEquals(2, hist.size)
+    }
+
+    @Test
+    fun importedNullValue_backfilledByComputed() {
+        // THE bug: the user's Health Connect import wrote a row for the day with a blank
+        // avgHrv; the strap actually scored the night. The blank row must not shadow it.
+        val hist = linkedMapOf<String, Double?>("2026-07-10" to null)
+        IntelligenceEngine.mergeNightlyIntoHistory(hist, mapOf("2026-07-10" to 48.0))
+        assertEquals(
+            "an imported row with a null value must be backfilled by the real computed night",
+            48.0, hist["2026-07-10"]!!, 1e-9,
+        )
+    }
+
+    @Test
+    fun importedNullValue_noComputed_staysMissing() {
+        val hist = linkedMapOf<String, Double?>("2026-07-10" to null)
+        IntelligenceEngine.mergeNightlyIntoHistory(hist, emptyMap())
+        assertTrue("2026-07-10" in hist)
+        assertNull(hist["2026-07-10"])
+    }
+
+    @Test
+    fun nullComputed_doesNotDisturbAnything() {
+        // A computed pass that produced no value for a day it emitted (nil estimate) neither
+        // overwrites an imported value nor un-registers an imported-null day.
+        val hist = linkedMapOf<String, Double?>("2026-07-10" to 62.0, "2026-07-11" to null)
+        IntelligenceEngine.mergeNightlyIntoHistory(
+            hist, mapOf("2026-07-10" to null, "2026-07-11" to null, "2026-07-12" to null),
+        )
+        assertEquals(62.0, hist["2026-07-10"]!!, 1e-9)
+        assertNull(hist["2026-07-11"])
+        assertTrue("2026-07-12" in hist)
+        assertNull(hist["2026-07-12"])
+    }
+
+    @Test
+    fun starvationShape_endToEnd() {
+        // The report's shape: a week of imported rows, ALL blank for HRV, over nights the
+        // strap scored. After the merge the fold input must contain the 7 real values, so
+        // the baseline can cross Baselines.minNightsSeed instead of reading "No Data".
+        val hist = LinkedHashMap<String, Double?>()
+        val nightly = LinkedHashMap<String, Double?>()
+        for (i in 6 downTo 0) {
+            val day = "2026-07-%02d".format(12 - i)
+            hist[day] = null
+            nightly[day] = 50.0 + i
+        }
+        IntelligenceEngine.mergeNightlyIntoHistory(hist, nightly)
+        val valid = hist.values.filterNotNull()
+        assertEquals("all 7 strap nights must survive the merge", 7, valid.size)
+        assertTrue(valid.size >= Baselines.minNightsSeed)
+    }
+}


### PR DESCRIPTION
## What this PR does

Fixes a "Needs the strap" / "No Data" false negative on Today and Recovery when the user *does* have sleep data for the day.

When a day had both an imported row (e.g. a Whoop/backup import) and an on-device computed row, the merge in `IntelligenceEngine` let the imported row win the whole day even when its individual fields were `nil`. Those `nil` fields then shadowed real computed values, so recovery/sleep scoring saw an empty night and the UI fell back to "Needs the strap" / "No Data" despite a scored sleep session existing.

The merge now treats imported precedence per-field: an imported `nil` no longer blanket-wins the day, and computed values fill any fields the import doesn't actually carry. Applied identically to the Swift engine (`Strand/Data/IntelligenceEngine.swift`) and its Kotlin twin (`android/.../com/noop/analytics/IntelligenceEngine.kt`) so the two lanes stay in step.

Also updates `TodayExplainabilityTests` to render `LocalizedStringKey` titles instead of comparing keys: the carried-night titles are built with interpolation (`"Last night · %@"`) so the string-catalog extractor sees the format key, which makes literal-key equality always false. The tests now resolve the key + arguments and pin the exact user-visible copy.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] CI / tooling

## How it was tested

Analytics/merge change only — no BLE path touched.

- New regression tests on both lanes covering the shadow scenario (imported row with `nil` fields + computed sibling for the same day): `StrandTests/IntelligenceBaselineShadowTests.swift` and `android/.../IntelligenceBaselineShadowTest.kt`.
- Swift: `xcodebuild test -project Strand.xcodeproj -scheme Strand -destination 'platform=macOS,arch=arm64'` — `IntelligenceBaselineShadowTests` and the full `TodayExplainabilityTests` suite pass (TEST SUCCEEDED).
- Android: `./gradlew :app:testDemoDebugUnitTest` (the demo flavor is the unit-test variant in this checkout) — shadow test plus the existing baseline/recalibration tests pass, BUILD SUCCESSFUL.
- Reproduced the original report first: engine-level harness showed the imported `nil` row blocking the computed night before the fix and the recovered score after it.

## Checklist

- [ ] N/A — Swift package tests (`Packages/<name>` not touched; change is in the `Strand` app target)
- [x] Android unit tests pass if I touched `android/` (ran `:app:testDemoDebugUnitTest`; no `testFullDebugUnitTest` task in this project's flavor setup)
- [x] No new build warnings introduced
- [ ] N/A — no UI changes (copy/layout untouched; test-only change on the Today explainability side)
- [ ] N/A — no protocol changes, no frame bytes involved
- [x] Follows the conventions in [`docs/CONTRIBUTING.md`](../docs/CONTRIBUTING.md)
- [x] I did not commit generated output (`Strand.xcodeproj/`) or any secrets/keystores

## Related issues

No upstream issue filed — fix comes from a user report (screenshots showed "Needs the strap" + Recovery "No Data" on a day with a 5h 24m scored sleep in the same backup).
