### PR TITLE
Personalize the Today view greeting

### DIFF
--- a/Packages/WhoopStore/Sources/WhoopStore/BackupSettings.swift
+++ b/Packages/WhoopStore/Sources/WhoopStore/BackupSettings.swift
@@ -3,7 +3,7 @@ import Foundation
 /// The `settings.json` payload inside a `.noopbak` backup (#1000).
 ///
 /// A `.noopbak` is a ZIP whose first entry is the SQLite database. That round-trips every row, but the
-/// user's profile (age / sex / weight / height / HR-max override) and display preferences live in
+/// user's profile (optional name / age / sex / weight / height / HR-max override) and display preferences live in
 /// UserDefaults (SharedPreferences on Android), so a restore onto a fresh device silently reset them —
 /// the "restore doesn't bring back settings/weight/height" half of #1000. This adds a SECOND, optional
 /// ZIP entry — `settings.json`, a flat JSON object — carrying exactly one WHITELISTED set of keys.
@@ -33,14 +33,16 @@ public enum BackupSettings {
     /// THE whitelist — the only keys `settings.json` may carry, keyed by their CANONICAL
     /// (platform-neutral) names. Mirrored exactly by Android's `BackupSettingsCodec.WHITELIST`.
     ///
-    /// Profile: the body metrics that power HR zones / calories / recovery baselines, plus the manual
-    /// HR-max override (`profile.hrMax`, 0 = auto/Tanaka). Display: the metric/imperial system, the
+    /// Profile: the optional Today-greeting name, the body metrics that power HR zones / calories /
+    /// recovery baselines, plus the manual HR-max override (`profile.hrMax`, 0 = auto/Tanaka). Display:
+    /// the metric/imperial system, the
     /// separate temperature override ("" = match the system), and the Effort axis (#268) — the three
     /// display prefs that exist with identical semantics on both platforms. Deliberately EXCLUDED:
     /// step calibration (per-strap, not per-person), the avatar blob (bulky, and not "settings"),
     /// steps-engine fitted outputs (derived), and every noop.* toggle that is device- or
     /// install-specific.
     public static let whitelist: [String: Kind] = [
+        "profile.name": .string,
         "profile.age": .int,
         "profile.sex": .string,
         "profile.weightKg": .double,
@@ -56,6 +58,7 @@ public enum BackupSettings {
     /// `profile.hrMax`, which UserDefaults stores as `profile.hrMaxOverride` (see `ProfileStore.K`).
     /// Android maps the same canonical keys onto its own SharedPreferences names.
     public static let appleDefaultsKey: [String: String] = [
+        "profile.name": "profile.name",
         "profile.age": "profile.age",
         "profile.sex": "profile.sex",
         "profile.weightKg": "profile.weightKg",

--- a/Packages/WhoopStore/Tests/WhoopStoreTests/BackupSettingsTests.swift
+++ b/Packages/WhoopStore/Tests/WhoopStoreTests/BackupSettingsTests.swift
@@ -11,6 +11,7 @@ final class BackupSettingsTests: XCTestCase {
 
     func testEncodeDecodeRoundTripsEveryWhitelistedKey() throws {
         let values: [String: Any] = [
+            "profile.name": "Alex",
             "profile.age": 34,
             "profile.sex": "female",
             "profile.weightKg": 62.5,
@@ -24,6 +25,7 @@ final class BackupSettingsTests: XCTestCase {
         let data = try XCTUnwrap(BackupSettings.encode(values))
         let back = BackupSettings.decode(data)
 
+        XCTAssertEqual(back["profile.name"] as? String, "Alex")
         XCTAssertEqual(back["profile.age"] as? Int, 34)
         XCTAssertEqual(back["profile.sex"] as? String, "female")
         XCTAssertEqual(back["profile.weightKg"] as? Double, 62.5)
@@ -103,11 +105,13 @@ final class BackupSettingsTests: XCTestCase {
     func testSnapshotOmitsUnsetKeysAndMapsHrMaxOverride() throws {
         let defaults = try freshDefaults()
         defaults.set(29, forKey: "profile.age")
+        defaults.set("Alex", forKey: "profile.name")
         defaults.set(82.5, forKey: "profile.weightKg")
         defaults.set(198, forKey: "profile.hrMaxOverride") // storage key, not the canonical name
         defaults.set("imperial", forKey: "units.system")
 
         let snap = BackupSettings.snapshot(from: defaults)
+        XCTAssertEqual(snap["profile.name"] as? String, "Alex")
         XCTAssertEqual(snap["profile.age"] as? Int, 29)
         XCTAssertEqual(snap["profile.weightKg"] as? Double, 82.5)
         XCTAssertEqual(snap["profile.hrMax"] as? Int, 198, "hrMaxOverride surfaces under the canonical key")
@@ -121,11 +125,13 @@ final class BackupSettingsTests: XCTestCase {
         defaults.set(175.0, forKey: "profile.heightCm") // pre-existing target value, not in payload
 
         BackupSettings.apply([
+            "profile.name": "Sam",
             "profile.age": 41,
             "profile.hrMax": 187,
             "units.temperature": "fahrenheit",
         ], to: defaults)
 
+        XCTAssertEqual(defaults.string(forKey: "profile.name"), "Sam")
         XCTAssertEqual(defaults.object(forKey: "profile.age") as? Int, 41)
         XCTAssertEqual(defaults.object(forKey: "profile.hrMaxOverride") as? Int, 187,
                        "Canonical profile.hrMax lands on the profile.hrMaxOverride storage key")
@@ -166,6 +172,7 @@ final class BackupSettingsTests: XCTestCase {
         // Device A: user-set values → snapshot → encode (what export writes into the zip).
         let deviceA = try freshDefaults()
         deviceA.set(52, forKey: "profile.age")
+        deviceA.set("Taylor", forKey: "profile.name")
         deviceA.set("nonbinary", forKey: "profile.sex")
         deviceA.set(90.25, forKey: "profile.weightKg")
         deviceA.set(0, forKey: "profile.hrMaxOverride") // explicit "auto" is still a value
@@ -175,6 +182,7 @@ final class BackupSettingsTests: XCTestCase {
         let deviceB = try freshDefaults()
         BackupSettings.apply(BackupSettings.decode(payload), to: deviceB)
 
+        XCTAssertEqual(deviceB.string(forKey: "profile.name"), "Taylor")
         XCTAssertEqual(deviceB.object(forKey: "profile.age") as? Int, 52)
         XCTAssertEqual(deviceB.string(forKey: "profile.sex"), "nonbinary")
         XCTAssertEqual(deviceB.object(forKey: "profile.weightKg") as? Double, 90.25)

--- a/Strand/Data/DataBackup.swift
+++ b/Strand/Data/DataBackup.swift
@@ -15,7 +15,7 @@ import ZIPFoundation
 /// `-wal`/`-shm` WAL sidecars while the store is open). Export checkpoints the WAL (so the
 /// single file is whole), then wraps the SQLite in a ZIP written as `.noopbak`, alongside a
 /// small `settings.json` entry (#1000) carrying the whitelisted profile/display settings (see
-/// `BackupSettings`) so a restore also brings back weight/height/units, not just the rows.
+/// `BackupSettings`) so a restore also brings back the optional name, weight/height/units, not just rows.
 /// ZIP deflate typically cuts a 100 MB+ SQLite backup to 10–20 MB. The format is a standard
 /// ZIP — users can rename `.noopbak` → `.zip` and extract the SQLite manually on any OS.
 ///
@@ -143,7 +143,7 @@ enum DataBackup {
 
     /// Write the live SQLite at `dbURL` into a fresh deflate ZIP at `dest`: the DB under the canonical
     /// entry name `noop-backup.sqlite`, plus (#1000) an optional second entry `settings.json` carrying
-    /// the whitelisted profile/display settings, so a restore brings back weight/height/units and not
+    /// the whitelisted profile/display settings, so a restore brings back name/weight/height/units and not
     /// just the rows. Entry names, entry ORDER (DB first — older importers stop at the first `.sqlite`
     /// entry) and deflate compression match the Android exporter byte-for-byte at the container level,
     /// so a `.noopbak` produced on either platform imports on the other. `settingsJSON == nil` writes
@@ -406,7 +406,7 @@ enum DataBackup {
                 restoreSidecar(from: source, toMainPath: dbPath, suffix: "-shm")
             }
 
-            // #1000: re-apply the backup's whitelisted profile/display settings (weight, height, age,
+            // #1000: re-apply the backup's whitelisted profile/display settings (name, weight, height, age,
             // sex, HR-max override, unit prefs) — but only NOW, after the DB swap landed. A failed or
             // rolled-back restore returns above and never touches settings. Legacy single-entry ZIPs
             // and plain-SQLite backups have no `settings.json` (extractedDir nil / entry absent) and

--- a/Strand/Data/Profile.swift
+++ b/Strand/Data/Profile.swift
@@ -2,10 +2,27 @@ import Foundation
 import Combine
 import SwiftUI
 
-/// User profile (age/sex/body metrics/HR-max) persisted in UserDefaults.
+/// User profile (optional preferred name, age/sex/body metrics/HR-max) persisted in UserDefaults.
 /// Powers HR zones, calories and recovery baselines.
 @MainActor
 final class ProfileStore: ObservableObject {
+    /// Optional name used only to personalise the Today greeting. Empty means the user opted out.
+    /// The short cap keeps the one-line header usable with Dynamic Type and survives backup restores.
+    @Published var preferredName: String {
+        didSet {
+            let bounded = String(preferredName.prefix(Self.preferredNameMaxLength))
+            if bounded != preferredName {
+                preferredName = bounded
+                return
+            }
+            if let normalized = Self.normalizedPreferredName(bounded) {
+                d.set(normalized, forKey: K.preferredName)
+            } else {
+                d.removeObject(forKey: K.preferredName)
+            }
+        }
+    }
+
     /// Canonical source of truth for age (#146): a date of birth, so age advances on its own instead
     /// of silently going stale until the user remembers to bump a number. `age` is derived from this.
     @Published var dateOfBirth: Date {
@@ -63,6 +80,7 @@ final class ProfileStore: ObservableObject {
 
     private let d = UserDefaults.standard
     private enum K {
+        static let preferredName = "profile.name"
         static let dateOfBirth = "profile.dateOfBirth"
         /// Pre-#146 age key. No longer the source of truth; kept mirrored from `dateOfBirth` so the
         /// cross-platform `.noopbak` whitelist keeps round-tripping an Int age unchanged.
@@ -80,6 +98,7 @@ final class ProfileStore: ObservableObject {
     }
 
     init() {
+        preferredName = Self.normalizedPreferredName(d.string(forKey: K.preferredName) ?? "") ?? ""
         // #146 age migration. `dateOfBirth` is authoritative whenever it exists, so age advances on
         // its own. A pre-#146 install — or a `.noopbak` restore, which writes only the legacy Int age
         // and clears any stale DOB (see `BackupSettings.apply`) — has no DOB yet, so derive one from
@@ -113,6 +132,23 @@ final class ProfileStore: ObservableObject {
         stepsCalibrationManual = d.object(forKey: K.stepsManualFlag) as? Bool ?? false
         stepsManualCoefficient = max(0, d.object(forKey: K.stepsManualCoeff) as? Double ?? 0)
         avatarImageData = d.data(forKey: K.avatar)
+    }
+
+    /// The trimmed name used in a greeting, or nil when the user left the optional field empty.
+    var greetingName: String? { Self.normalizedPreferredName(preferredName) }
+
+    nonisolated static let preferredNameMaxLength = 40
+
+    /// Pure normalisation shared by the UI and tests. Internal whitespace is preserved so real names
+    /// are not rewritten; only surrounding whitespace and an empty opt-out are normalised.
+    nonisolated static func normalizedPreferredName(_ value: String) -> String? {
+        let bounded = boundedPreferredName(value)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        return bounded.isEmpty ? nil : bounded
+    }
+
+    private nonisolated static func boundedPreferredName(_ value: String) -> String {
+        String(value.prefix(preferredNameMaxLength))
     }
 
     // MARK: - Profile picture

--- a/Strand/Liquid/LiquidTodayView.swift
+++ b/Strand/Liquid/LiquidTodayView.swift
@@ -4,7 +4,7 @@
 //  This is the FULL Today, re-created faithfully from the locked mockup
 //  (scratchpad/liquid-metal-home.html): sky title + record/add/battery controls,
 //  the three scores as liquid vessels with a card-level source badge, the live heart-rate
-//  thread, the five "your cards" as liquid chips, a greeting + readiness pills,
+//  thread, the five "your cards" as liquid chips, a personalised greeting + readiness pills,
 //  Synthesis, Recovery Vitals, a Key Metrics grid (incl. steps), Last Workouts
 //  and Data Sources. Every value binds to the SAME real data the classic
 //  TodayView reads (accessors verified against TodayView.swift), and every tap
@@ -160,14 +160,14 @@ struct LiquidTodayView: View {
         Self.maxDayOffset(earliestDayKey: repo.freshness.earliestDay,
                           todayKey: Repository.logicalDayKey(Date()))
     }
-    /// The big header title: Today / Yesterday / weekday for older days.
+    /// The big header title: a personalised greeting for today, then Yesterday / weekday for older days.
     private var dayTitle: String {
         switch selectedDayOffset {
-        // #1013: these must localize — the header showed English "Today"/"Yesterday"/weekday even when the
-        // system UI (tab bar etc.) was another language. "Today"/"Yesterday" go through String(localized:)
-        // (matching the classic TodayView.dayNavLabel), and the weekday name is formatted in the user's
-        // locale, not the en_US_POSIX one used only for machine day-keys.
-        case 0: return String(localized: "Today")
+        // #1013: these must localize — the header previously showed English labels even when the system UI
+        // used another language. Today's header composes localized greeting parts, "Yesterday" goes through
+        // String(localized:), and weekday names use the user's locale rather than the en_US_POSIX locale used
+        // only for machine day-keys.
+        case 0: return todayGreeting
         case 1: return String(localized: "Yesterday")
         default:
             return selectedLogicalDay.formatted(.dateTime.weekday(.wide).locale(Locale.autoupdatingCurrent))
@@ -276,7 +276,7 @@ struct LiquidTodayView: View {
                     Color.clear.frame(height: 90) // floating tab-bar clearance
                 }
                 .padding(.horizontal, 16)
-                .padding(.top, 30) // sit the title lower into the sky, not jammed under the status bar
+                .padding(.top, NoopMetrics.space4)
             }
             #if os(macOS)
             // Keep the phone-shaped column readable + centred on the wide mac detail pane. The sky is a
@@ -409,6 +409,8 @@ struct LiquidTodayView: View {
                         Text(dayTitle)
                             .font(StrandFont.rounded(28))
                             .foregroundStyle(.white)
+                            .lineLimit(2)
+                            .minimumScaleFactor(0.8)
                             .shadow(color: .black.opacity(0.4), radius: 10, y: 1)
                         Text(dateLine)
                             .font(StrandFont.caption)
@@ -462,7 +464,7 @@ struct LiquidTodayView: View {
             // section block below. The wordmark's bottom pad (10) + the section VStack's 12 spacing keeps
             // the default hero-under-wordmark gap at the original 22.
             LiquidWordmark()
-                .padding(.top, 30)
+                .padding(.top, NoopMetrics.space4)
                 .padding(.bottom, 10)
         }
     }
@@ -697,7 +699,7 @@ struct LiquidTodayView: View {
         .buttonStyle(LiquidPressStyle())
     }
 
-    // MARK: - Synthesis (greeting + readiness pills + one-liner)
+    // MARK: - Synthesis (Today label + readiness pills + one-liner)
 
     /// Liquid parity with classic `effortZeroNote`: the "no cardio load yet" line shown in the synthesis
     /// card when today's Effort is ~0, so a calm day explains itself instead of a bare 0. Reuses classic's
@@ -710,7 +712,9 @@ struct LiquidTodayView: View {
     private var synthesisSection: some View {
         VStack(spacing: 8) {
             HStack {
-                Text(greeting).font(StrandFont.rounded(19)).foregroundStyle(StrandPalette.textPrimary)
+                Text(String(localized: "Today"))
+                    .font(StrandFont.rounded(19))
+                    .foregroundStyle(StrandPalette.textPrimary)
                     .lineLimit(1).minimumScaleFactor(0.6)   // yield to the pills rather than push them to wrap
                 Spacer(minLength: 8)
                 HStack(spacing: 8) {
@@ -1285,11 +1289,16 @@ struct LiquidTodayView: View {
         }
     }
 
-    private var greeting: String {
+    private var timeGreeting: String {
         let h = Calendar.current.component(.hour, from: Date())
         return h < 12 ? String(localized: "Good morning")
             : h < 17 ? String(localized: "Good afternoon")
             : String(localized: "Good evening")
+    }
+
+    private var todayGreeting: String {
+        guard let name = profile.greetingName else { return timeGreeting }
+        return String(format: String(localized: "%@, %@"), timeGreeting, name)
     }
 
     // Measured strap count ?: imported Apple Health count ?: motion estimate — the same precedence the

--- a/Strand/Onboarding/OnboardingWizard.swift
+++ b/Strand/Onboarding/OnboardingWizard.swift
@@ -745,6 +745,23 @@ private struct ProfileStep: View {
             VStack(spacing: 16) {
                 StrandCard {
                     VStack(spacing: 18) {
+                        HStack {
+                            Text("Name").strandOverline()
+                            Spacer()
+                            TextField("Optional", text: $profile.preferredName)
+                                .textFieldStyle(.plain)
+                                .font(StrandFont.body)
+                                .foregroundStyle(StrandPalette.textPrimary)
+                                .multilineTextAlignment(.trailing)
+                                .lineLimit(1)
+                                .accessibilityLabel(String(
+                                    format: String(localized: "%@, %@"),
+                                    String(localized: "Name"), String(localized: "Optional")
+                                ))
+                        }
+
+                        Divider().overlay(StrandPalette.hairline)
+
                         // #146: capture a date of birth so age advances on its own instead of going stale.
                         DatePicker(selection: $profile.dateOfBirth,
                                    in: ProfileStore.dateOfBirthRange,

--- a/Strand/Screens/SettingsView.swift
+++ b/Strand/Screens/SettingsView.swift
@@ -371,6 +371,19 @@ struct SettingsView: View {
             blurb: "These power your heart-rate zones, calorie estimates and recovery baselines. Keep them accurate."
         ) {
             VStack(spacing: 0) {
+                FormRow(label: "Name") {
+                    TextField("Optional", text: $profile.preferredName)
+                        .textFieldStyle(.plain)
+                        .font(StrandFont.body)
+                        .foregroundStyle(StrandPalette.textPrimary)
+                        .multilineTextAlignment(.trailing)
+                        .lineLimit(1)
+                        .accessibilityLabel(String(
+                            format: String(localized: "%@, %@"),
+                            String(localized: "Name"), String(localized: "Optional")
+                        ))
+                }
+                rowDivider
                 FormRow(label: "Date of birth") {
                     HStack(spacing: 12) {
                         Text("\(profile.age)")

--- a/StrandTests/ProfileGreetingTests.swift
+++ b/StrandTests/ProfileGreetingTests.swift
@@ -1,0 +1,21 @@
+import XCTest
+@testable import Strand
+
+final class ProfileGreetingTests: XCTestCase {
+    func testBlankPreferredNameOptsOut() {
+        XCTAssertNil(ProfileStore.normalizedPreferredName(""))
+        XCTAssertNil(ProfileStore.normalizedPreferredName("  \n "))
+    }
+
+    func testPreferredNameTrimsEdgesWithoutRewritingTheName() {
+        XCTAssertEqual(ProfileStore.normalizedPreferredName("  Mary Jane  "), "Mary Jane")
+    }
+
+    func testPreferredNameIsBoundedForTheTodayHeader() {
+        let longName = String(repeating: "A", count: ProfileStore.preferredNameMaxLength + 10)
+        XCTAssertEqual(
+            ProfileStore.normalizedPreferredName(longName)?.count,
+            ProfileStore.preferredNameMaxLength
+        )
+    }
+}

--- a/android/app/src/main/java/com/noop/data/BackupSettings.kt
+++ b/android/app/src/main/java/com/noop/data/BackupSettings.kt
@@ -11,7 +11,7 @@ import org.json.JSONObject
  * `BackupSettings` in Packages/WhoopStore.
  *
  * A `.noopbak` is a ZIP whose first entry is the SQLite database. That round-trips every row, but the
- * user's profile (age / sex / weight / height / HR-max override) and display preferences live in
+ * user's profile (optional name / age / sex / weight / height / HR-max override) and display preferences live in
  * SharedPreferences (UserDefaults on Apple), so a restore onto a fresh device silently reset them —
  * the "restore doesn't bring back settings/weight/height" half of #1000. This adds a SECOND, optional
  * ZIP entry — `settings.json`, a flat JSON object — carrying exactly one WHITELISTED set of keys.
@@ -38,13 +38,15 @@ object BackupSettingsCodec {
      * THE whitelist — the only keys `settings.json` may carry, keyed by their CANONICAL
      * (platform-neutral) names. Mirrors the Apple `BackupSettings.whitelist` exactly.
      *
-     * Profile: the body metrics that power HR zones / calories / recovery baselines, plus the manual
-     * HR-max override (`profile.hrMax`, 0 = auto/Tanaka). Display: the metric/imperial system, the
+     * Profile: the optional Today-greeting name, the body metrics that power HR zones / calories /
+     * recovery baselines, plus the manual HR-max override (`profile.hrMax`, 0 = auto/Tanaka). Display:
+     * the metric/imperial system, the
      * separate temperature override ("" = match the system), and the Effort axis (#268). Deliberately
      * EXCLUDED: step calibration (per-strap, not per-person), the steps-engine fitted outputs
      * (derived), and every noop.* toggle that is device- or install-specific.
      */
     val WHITELIST: Map<String, Kind> = linkedMapOf(
+        "profile.name" to Kind.STRING,
         "profile.age" to Kind.INT,
         "profile.sex" to Kind.STRING,
         "profile.weightKg" to Kind.DOUBLE,

--- a/android/app/src/main/java/com/noop/ui/OnboardingScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/OnboardingScreen.kt
@@ -50,6 +50,8 @@ import androidx.compose.material.icons.filled.Storage
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Icon
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.OutlinedTextFieldDefaults
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
@@ -687,6 +689,36 @@ private fun ProfileStep() {
     ) {
         NoopCard(padding = 18.dp) {
             Column(verticalArrangement = Arrangement.spacedBy(14.dp)) {
+                ProfileFieldRow(label = uiString(R.string.profile_preferred_name)) {
+                    OutlinedTextField(
+                        value = profile.preferredName,
+                        onValueChange = { mutate { profile.preferredName = it } },
+                        singleLine = true,
+                        placeholder = {
+                            Text(
+                                uiString(R.string.profile_name_placeholder),
+                                style = NoopType.body,
+                                color = Palette.textTertiary,
+                            )
+                        },
+                        textStyle = NoopType.body,
+                        modifier = Modifier
+                            .fillMaxWidth(0.58f)
+                            .semantics {
+                                contentDescription = uiString(R.string.profile_name_accessibility)
+                            },
+                        colors = OutlinedTextFieldDefaults.colors(
+                            focusedTextColor = Palette.textPrimary,
+                            unfocusedTextColor = Palette.textPrimary,
+                            focusedBorderColor = Palette.accent,
+                            unfocusedBorderColor = Palette.hairline,
+                            cursorColor = Palette.accent,
+                            focusedContainerColor = Palette.surfaceInset,
+                            unfocusedContainerColor = Palette.surfaceInset,
+                        ),
+                    )
+                }
+                ThinDivider()
                 ProfileFieldRow(label = uiString(R.string.l10n_onboarding_screen_age_ff9f1ff3)) {
                     WheelPickerField(
                         value = "${profile.age}",

--- a/android/app/src/main/java/com/noop/ui/SettingsScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/SettingsScreen.kt
@@ -146,14 +146,28 @@ import kotlin.math.roundToInt
 // MARK: - Profile store (SharedPreferences-backed; the macOS ProfileStore equivalent)
 
 /**
- * The user's body profile — age / sex / weight / height plus an optional manual
- * HR-max override. Persisted to SharedPreferences so the values survive restarts
+ * The user's profile — optional preferred name, age / sex / weight / height plus an optional
+ * manual HR-max override. Persisted to SharedPreferences so the values survive restarts
  * and other screens (HealthScreen, Coach zones) can read the same source of truth.
  *
  * Mirrors the macOS `ProfileStore` fields and ranges exactly. `hrMaxOverride == 0`
  * means "auto" — fall back to the Tanaka estimate from [age].
  */
 class ProfileStore(private val prefs: SharedPreferences) {
+
+    /** Optional name used only to personalise the Today greeting. Blank means the user opted out. */
+    var preferredName: String
+        get() = prefs.getString(KEY_NAME, "")
+            ?.take(PREFERRED_NAME_MAX_LENGTH)
+            .orEmpty()
+        set(v) {
+            val bounded = v.take(PREFERRED_NAME_MAX_LENGTH)
+            if (bounded.isBlank()) prefs.edit().remove(KEY_NAME).apply()
+            else prefs.edit().putString(KEY_NAME, bounded).apply()
+        }
+
+    /** Trimmed greeting name, or null for the optional blank state. */
+    val greetingName: String? get() = preferredName.trim().ifEmpty { null }
 
     /**
      * Current age in whole years (#146), DERIVED from [dateOfBirthMillis] so it advances on its own
@@ -278,6 +292,7 @@ class ProfileStore(private val prefs: SharedPreferences) {
     /** The user-SET profile fields, keyed canonically, for the backup exporter. */
     fun backupSnapshot(): Map<String, Any> {
         val out = LinkedHashMap<String, Any>()
+        if (prefs.contains(KEY_NAME)) greetingName?.let { out["profile.name"] = it }
         // #146: age is now derived from a DOB; export the current derived Int under the legacy
         // `profile.age` key (the whitelist carries an Int, not a Date). A never-touched profile
         // (neither key set) still stays out of the snapshot.
@@ -299,6 +314,7 @@ class ProfileStore(private val prefs: SharedPreferences) {
         // #146: a restore carries only an Int age. Route it through setAge so the restored age
         // re-anchors this device's DOB (clearing any stale local DOB) and then advances on its own —
         // the deterministic twin of the Apple side clearing `profile.dateOfBirth` on apply.
+        (values["profile.name"] as? String)?.let { preferredName = it }
         (values["profile.age"] as? Number)?.let { setAge(it.toInt()) }
         (values["profile.sex"] as? String)?.let { sex = it }
         (values["profile.weightKg"] as? Number)?.let { weightKg = it.toDouble() }
@@ -309,6 +325,7 @@ class ProfileStore(private val prefs: SharedPreferences) {
 
     companion object {
         private const val PREFS = "noop_profile"
+        private const val KEY_NAME = "preferred_name"
         /** Date of birth as epoch millis — the #146 source of truth for [age]. */
         private const val KEY_DOB = "date_of_birth"
         /** Pre-#146 age key, now kept mirrored from the DOB so the `.noopbak` whitelist (Int age)
@@ -335,6 +352,7 @@ class ProfileStore(private val prefs: SharedPreferences) {
         private const val WAIST_MAX = 200.0
         private const val STEP_SCALE_MIN = 0.5
         private const val STEP_SCALE_MAX = 30.0
+        private const val PREFERRED_NAME_MAX_LENGTH = 40
 
         /**
          * Variable step for the calibration stepper so high values stay reachable: fine near the
@@ -775,6 +793,36 @@ fun SettingsScreen(
             blurb = "These power your heart-rate zones, calorie estimates and recovery baselines. Keep them accurate.",
         ) {
             Column {
+                FormRow(label = uiString(R.string.profile_preferred_name)) {
+                    OutlinedTextField(
+                        value = profile.preferredName,
+                        onValueChange = { mutate { profile.preferredName = it } },
+                        singleLine = true,
+                        placeholder = {
+                            Text(
+                                uiString(R.string.profile_name_placeholder),
+                                style = NoopType.body,
+                                color = Palette.textTertiary,
+                            )
+                        },
+                        textStyle = NoopType.body,
+                        modifier = Modifier
+                            .fillMaxWidth(0.58f)
+                            .semantics {
+                                contentDescription = uiString(R.string.profile_name_accessibility)
+                            },
+                        colors = OutlinedTextFieldDefaults.colors(
+                            focusedTextColor = Palette.textPrimary,
+                            unfocusedTextColor = Palette.textPrimary,
+                            focusedBorderColor = Palette.accent,
+                            unfocusedBorderColor = Palette.hairline,
+                            cursorColor = Palette.accent,
+                            focusedContainerColor = Palette.surfaceInset,
+                            unfocusedContainerColor = Palette.surfaceInset,
+                        ),
+                    )
+                }
+                RowDivider()
                 FormRow(label = uiString(R.string.l10n_settings_screen_age_ff9f1ff3)) {
                     StepperField(
                         value = profile.age.toString(),

--- a/android/app/src/main/java/com/noop/ui/TodayScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/TodayScreen.kt
@@ -1144,7 +1144,13 @@ fun TodayScreen(
         // the Updates inbox is relocated into the "+" quick-actions sheet (AppRoot), so the feature stays one
         // tap away without sitting in the Today header. Staggered in as the first section (index 0).
         val dayTitle = when (selectedDayOffset) {
-            0 -> "Today"
+            0 -> personalizedGreeting(
+                greeting = greetingWord(),
+                preferredName = profileStore.greetingName,
+                formatWithName = { greeting, name ->
+                    uiString(R.string.today_greeting_with_name, greeting, name)
+                },
+            )
             1 -> "Yesterday"
             else -> {
                 val keyDate = runCatching { LocalDate.parse(selectedDayKey) }.getOrNull() ?: selectedDay
@@ -2077,7 +2083,7 @@ private fun LiquidTodayHeader(
                 style = NoopType.number(28f, weight = FontWeight.Bold)
                     .copy(shadow = Shadow(color = Color.Black.copy(alpha = 0.4f), offset = Offset(0f, 1f), blurRadius = 10f)),
                 color = Color.White,
-                maxLines = 1,
+                maxLines = 2,
                 overflow = TextOverflow.Ellipsis,
             )
             Text(
@@ -2607,7 +2613,7 @@ private fun HeroScoreVessel(
 /**
  * The plain-English Synthesis card, the Charge-tinted [InsightCard] read-out under the ring hero, with a
  * WHITE headline (the key iOS Design-Reset change, `statusColor: textPrimary`, not the recovery/charge
- * colour), carrying the greeting + the SOLID / CALIBRATING data-confidence pill in its top-right. Mirrors
+ * colour), carrying the Today label + the SOLID / CALIBRATING data-confidence pill in its top-right. Mirrors
  * the iOS Synthesis InsightCard (which moved here when the big RecoveryRing hero that owned the pill went).
  */
 @Composable
@@ -2630,7 +2636,7 @@ private fun SynthesisHeroCard(
     val readDay = carriedDay ?: day
     val recovery = readDay?.recovery
     Column(modifier = Modifier.fillMaxWidth(), verticalArrangement = Arrangement.spacedBy(Metrics.gap)) {
-        // The greeting + SOLID/CALIBRATING data-confidence pill ride in their OWN header row ABOVE the
+        // The Today label + SOLID/CALIBRATING data-confidence pills ride in their OWN header row ABOVE the
         // card, not as a top-end overlay over it (#527). The old overlay sat over the card's "SYNTHESIS"
         // overline + big status word and, on a narrow phone, collided with them, and squeezing the
         // status into the leftover width force-broke a single word ("Calibrating" → "Calibrati/ng").
@@ -2641,9 +2647,9 @@ private fun SynthesisHeroCard(
             horizontalArrangement = Arrangement.spacedBy(8.dp),
             verticalAlignment = Alignment.CenterVertically,
         ) {
-            // The greeting yields/ellipsises first; the pill keeps its full width (#527).
+            // The time greeting moved into the large day title; its former position now carries "Today".
             Text(
-                greetingWord(),
+                uiString(R.string.nav_today),
                 style = NoopType.subhead,
                 color = Palette.textSecondary,
                 maxLines = 1,
@@ -5865,10 +5871,19 @@ private fun rememberTrendWindow(
 private fun greetingWord(): String {
     val h = java.util.Calendar.getInstance().get(java.util.Calendar.HOUR_OF_DAY)
     return when {
-        h < 12 -> "Good morning"
-        h < 17 -> "Good afternoon"
-        else -> "Good evening"
+        h < 12 -> uiString(R.string.today_greeting_morning)
+        h < 17 -> uiString(R.string.today_greeting_afternoon)
+        else -> uiString(R.string.today_greeting_evening)
     }
+}
+
+internal fun personalizedGreeting(
+    greeting: String,
+    preferredName: String?,
+    formatWithName: (String, String) -> String,
+): String {
+    val name = preferredName?.trim().orEmpty()
+    return if (name.isEmpty()) greeting else formatWithName(greeting, name)
 }
 
 private fun synthesisWord(score: Double?): String {

--- a/android/app/src/main/res/values-de/strings.xml
+++ b/android/app/src/main/res/values-de/strings.xml
@@ -1872,4 +1872,12 @@
     <string name="onboarding_theme_follow_system">Die Hell-/Dunkel-Einstellung deines Smartphones wird übernommen.</string>
     <string name="onboarding_theme_light_description">Tiefblaue Akzente auf einem warmen, hellen Hintergrund.</string>
     <string name="onboarding_theme_dark_description">Tiefblaue Akzente auf einem dunklen, blaugrauen Hintergrund.</string>
+    <!-- Optional profile name used to personalize the Today greeting. -->
+    <string name="profile_preferred_name">Name</string>
+    <string name="profile_name_placeholder">Optional</string>
+    <string name="profile_name_accessibility">Name, optional</string>
+    <string name="today_greeting_morning">Guten Morgen</string>
+    <string name="today_greeting_afternoon">Guten Nachmittag</string>
+    <string name="today_greeting_evening">Guten Abend</string>
+    <string name="today_greeting_with_name">%1$s, %2$s</string>
 </resources>

--- a/android/app/src/main/res/values-es/strings.xml
+++ b/android/app/src/main/res/values-es/strings.xml
@@ -1857,4 +1857,12 @@
     <string name="onboarding_theme_follow_system">Se usa el ajuste claro u oscuro de tu teléfono.</string>
     <string name="onboarding_theme_light_description">Acentos azul oscuro sobre un fondo cálido y claro.</string>
     <string name="onboarding_theme_dark_description">Acentos azul oscuro sobre un fondo azul grisáceo oscuro.</string>
+    <!-- Optional profile name used to personalize the Today greeting. -->
+    <string name="profile_preferred_name">Nombre</string>
+    <string name="profile_name_placeholder">Opcional</string>
+    <string name="profile_name_accessibility">Nombre, opcional</string>
+    <string name="today_greeting_morning">Buenos días</string>
+    <string name="today_greeting_afternoon">Buenas tardes</string>
+    <string name="today_greeting_evening">Buenas noches</string>
+    <string name="today_greeting_with_name">%1$s, %2$s</string>
 </resources>

--- a/android/app/src/main/res/values-fr/strings.xml
+++ b/android/app/src/main/res/values-fr/strings.xml
@@ -1857,4 +1857,12 @@
     <string name="onboarding_theme_follow_system">Le réglage clair ou sombre de votre téléphone est utilisé.</string>
     <string name="onboarding_theme_light_description">Des accents bleu profond sur un fond clair et chaleureux.</string>
     <string name="onboarding_theme_dark_description">Des accents bleu profond sur un fond bleu-gris sombre.</string>
+    <!-- Optional profile name used to personalize the Today greeting. -->
+    <string name="profile_preferred_name">Nom</string>
+    <string name="profile_name_placeholder">Facultatif</string>
+    <string name="profile_name_accessibility">Nom, facultatif</string>
+    <string name="today_greeting_morning">Bonjour</string>
+    <string name="today_greeting_afternoon">Bon après-midi</string>
+    <string name="today_greeting_evening">Bonsoir</string>
+    <string name="today_greeting_with_name">%1$s, %2$s</string>
 </resources>

--- a/android/app/src/main/res/values-pt-rPT/strings.xml
+++ b/android/app/src/main/res/values-pt-rPT/strings.xml
@@ -1851,4 +1851,13 @@
     <string name="onboarding_theme_follow_system">É utilizada a definição de tema claro ou escuro do teu telemóvel.</string>
     <string name="onboarding_theme_light_description">Destaques em azul-escuro sobre um fundo claro e acolhedor.</string>
     <string name="onboarding_theme_dark_description">Destaques em azul-escuro sobre um fundo azul-acinzentado escuro.</string>
+
+    <!-- Saudação do Hoje + nome preferido opcional. -->
+    <string name="profile_preferred_name">Nome</string>
+    <string name="profile_name_placeholder">Opcional</string>
+    <string name="profile_name_accessibility">Nome, opcional</string>
+    <string name="today_greeting_morning">Bom dia</string>
+    <string name="today_greeting_afternoon">Boa tarde</string>
+    <string name="today_greeting_evening">Boa noite</string>
+    <string name="today_greeting_with_name">%1$s, %2$s</string>
 </resources>

--- a/android/app/src/main/res/values-zh/strings.xml
+++ b/android/app/src/main/res/values-zh/strings.xml
@@ -1785,4 +1785,13 @@
     <string name="onboarding_theme_follow_system">跟随手机的浅色或深色设置。</string>
     <string name="onboarding_theme_light_description">深蓝色点缀搭配温暖的浅色背景。</string>
     <string name="onboarding_theme_dark_description">深蓝色点缀搭配深色蓝灰背景。</string>
+
+    <!-- Today 问候语与可选的称呼。问候语与名字之间使用全角逗号。 -->
+    <string name="profile_preferred_name">姓名</string>
+    <string name="profile_name_placeholder">可选</string>
+    <string name="profile_name_accessibility">姓名，可选</string>
+    <string name="today_greeting_morning">早上好</string>
+    <string name="today_greeting_afternoon">下午好</string>
+    <string name="today_greeting_evening">晚上好</string>
+    <string name="today_greeting_with_name">%1$s，%2$s</string>
 </resources>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -1883,4 +1883,12 @@
     <string name="onboarding_theme_follow_system">Following your phone\'s light/dark setting.</string>
     <string name="onboarding_theme_light_description">Deep blue accent on warm paper.</string>
     <string name="onboarding_theme_dark_description">Deep blue accent on a dark blue-grey canvas.</string>
+    <!-- Optional profile name used to personalize the Today greeting. -->
+    <string name="profile_preferred_name">Name</string>
+    <string name="profile_name_placeholder">Optional</string>
+    <string name="profile_name_accessibility">Name, optional</string>
+    <string name="today_greeting_morning">Good morning</string>
+    <string name="today_greeting_afternoon">Good afternoon</string>
+    <string name="today_greeting_evening">Good evening</string>
+    <string name="today_greeting_with_name">%1$s, %2$s</string>
 </resources>

--- a/android/app/src/test/java/com/noop/data/BackupSettingsCodecTest.kt
+++ b/android/app/src/test/java/com/noop/data/BackupSettingsCodecTest.kt
@@ -29,6 +29,7 @@ class BackupSettingsCodecTest {
 
     @Test fun encodeDecodeRoundTripsEveryWhitelistedKey() {
         val values = mapOf(
+            "profile.name" to "Alex",
             "profile.age" to 34,
             "profile.sex" to "female",
             "profile.weightKg" to 62.5,
@@ -42,6 +43,7 @@ class BackupSettingsCodecTest {
         val json = requireNotNull(BackupSettingsCodec.encode(values))
         val back = BackupSettingsCodec.decode(json)
 
+        assertEquals("Alex", back["profile.name"])
         assertEquals(34, back["profile.age"])
         assertEquals("female", back["profile.sex"])
         assertEquals(62.5, back["profile.weightKg"])
@@ -56,8 +58,9 @@ class BackupSettingsCodecTest {
 
     @Test fun crossPlatformShapedJsonDecodes() {
         // What the Apple exporter writes (JSONSerialization, sorted keys, integral doubles possible).
-        val appleJson = """{"profile.age":34.0,"profile.hrMax":191,"profile.sex":"male","profile.weightKg":80,"units.system":"metric"}"""
+        val appleJson = """{"profile.age":34.0,"profile.hrMax":191,"profile.name":"Sam","profile.sex":"male","profile.weightKg":80,"units.system":"metric"}"""
         val back = BackupSettingsCodec.decode(appleJson)
+        assertEquals("Sam", back["profile.name"])
         assertEquals("Integral JSON numbers must land as Int for int-kind keys", 34, back["profile.age"])
         assertEquals(191, back["profile.hrMax"])
         assertEquals("A bare JSON int must land as Double for double-kind keys", 80.0, back["profile.weightKg"])

--- a/android/app/src/test/java/com/noop/ui/ProfileStoreAgeMigrationTest.kt
+++ b/android/app/src/test/java/com/noop/ui/ProfileStoreAgeMigrationTest.kt
@@ -20,6 +20,33 @@ import org.junit.Test
  */
 class ProfileStoreAgeMigrationTest {
 
+    @Test fun optionalPreferredNameTrimsForGreetingAndRoundTripsThroughBackup() {
+        val prefs = FakeSharedPreferences()
+        val profile = ProfileStore(prefs)
+
+        assertNull(profile.greetingName)
+        profile.preferredName = "  Alex  "
+        assertEquals("Alex", profile.greetingName)
+        assertEquals("Alex", profile.backupSnapshot()["profile.name"])
+
+        profile.preferredName = "   "
+        assertNull(profile.greetingName)
+        assertNull(profile.backupSnapshot()["profile.name"])
+    }
+
+    @Test fun restoredBackupWithoutNameKeepsOptionalNameEmpty() {
+        val profile = ProfileStore(FakeSharedPreferences())
+        profile.applyBackup(mapOf("profile.age" to 41))
+        assertNull(profile.greetingName)
+    }
+
+    @Test fun personalizedGreetingAddsCommaOnlyWhenNameExists() {
+        val formatWithName = { greeting: String, name: String -> "$greeting, $name" }
+        assertEquals("Good morning", personalizedGreeting("Good morning", null, formatWithName))
+        assertEquals("Good morning", personalizedGreeting("Good morning", "   ", formatWithName))
+        assertEquals("Good morning, Alex", personalizedGreeting("Good morning", " Alex ", formatWithName))
+    }
+
     @Test
     fun freshInstall_defaultsTo30_andPersistsADob() {
         val prefs = FakeSharedPreferences()


### PR DESCRIPTION
## What this PR does

This PR makes the Today view more welcoming, personal, and space-efficient across iOS and Android.

The time-based greeting previously shown above Synthesis is moved into the main header, replacing the generic “Today” title. Users can optionally provide their name during onboarding or later in Settings, producing greetings such as “Good evening, Alex.” When no name is provided, the localized greeting is shown without a comma.

The “Today” label is moved to the Synthesis section, where it now reads naturally alongside the current recovery and status indicators—for example, “Today · Rest · Solid.”

The top spacing is also reduced slightly. Because Today is the app’s primary screen, this makes more useful information visible immediately without making the layout feel cramped.

The existing Today quick-action button remains in place. This PR is standalone and does not depend on #397; that PR can replace the entry point independently if it is merged.

The optional name is included in backups while remaining compatible with existing backups that do not contain the new field.

## Type of change

- [x] New feature
- [x] Refactor / cleanup

## How it was tested

- Rebased onto the current upstream `main` and confirmed that the PR is mergeable without Quick Launch files.
- Built the `NOOPiOS` app successfully for the iOS Simulator with code signing disabled.
- Manually tested the Today view in the iOS Simulator using example data.
- Verified greetings with and without a preferred name.
- Ran the focused `ProfileGreetingTests` — 3 tests passed.
- Ran `swift test` in `Packages/WhoopStore` — 266 tests passed.
- Ran `./gradlew testFullDebugUnitTest` successfully.
- Ran `python3 Tools/i18n_audit.py --ci upstream/main` successfully; Android and Apple UI-copy checks and the German, Spanish, and French catalog checks passed.
- A broader `StrandTests` run executed 906 tests. The touched greeting tests passed; 26 unrelated `BugReportTemplateTests` assertions failed because the sandboxed test process could not read `.github/ISSUE_TEMPLATE/bug_report.yml`.
- Android was implemented and unit-tested, but not manually tested on an Android device.
- No BLE, protocol, or analytics behavior was changed.

## Checklist

- [x] Swift package tests pass for any package I touched (`swift test` in `Packages/<name>`)
- [x] Android unit tests pass if I touched `android/` (`./gradlew testFullDebugUnitTest`)
- [x] No new build warnings introduced
- [x] UI changes use only `StrandDesign` tokens — no hardcoded colors, fonts, or spacing
- [x] No hardcoded hex frame bytes; protocol facts live in the schema / decoders
- [x] Follows the conventions in [`docs/CONTRIBUTING.md`](../docs/CONTRIBUTING.md)
- [x] I did not commit generated output (`Strand.xcodeproj/`) or any secrets/keystores

## Related issues

Independent of #397. That PR may later replace the existing Today quick-action entry point, but it is not required for this change.

<img width="1170" height="2532" alt="image" src="https://github.com/user-attachments/assets/a5789dd6-9efc-49d4-b89d-58c183e3a8d4" />
