### PR TITLE
Fix WHOOP 4 skin-temp anchor reuse

### DIFF
--- a/Strand/Data/IntelligenceEngine.swift
+++ b/Strand/Data/IntelligenceEngine.swift
@@ -500,6 +500,12 @@ final class IntelligenceEngine: ObservableObject {
         let stepsTraceActive = TestCentre.active(.steps)
         let scanned: [DayScan] = await Task.detached(priority: .utility) {
             var out: [DayScan] = []
+            // #938: the WHOOP 4.0 ADC offset is per-device, not per-night. Learn one anchor per owner
+            // from the whole scan window and reuse it for every night so cross-night deviations survive.
+            let skinAnchorScanFrom = nowLocalMidnight - (maxDays - 1) * 86_400 - 30 * 3_600
+            let skinAnchorScanTo = nowLocalMidnight + 18 * 3_600
+            var skinAnchorByOwner: [String: Double] = [:]
+            var skinAnchorResolvedOwners = Set<String>()
             for offset in 0..<maxDays {
                 let dayStart = nowLocalMidnight - offset * 86_400
                 let day = AnalyticsEngine.dayString(dayStart, offsetSec: tzOffset)
@@ -548,7 +554,22 @@ final class IntelligenceEngine: ObservableObject {
                 // nightly means every run, so this constant offset cancels in the deviation. nil for a non-4.0
                 // owner (`.whoop5` ignores the anchor) or when <100 in-band samples exist → the conversion
                 // falls back to the global anchor (byte-identical to today).
-                let skinAnchorRaw = skinFamily == .whoop4 ? Whoop4SkinTemp.deviceAnchorRaw(skin.map { $0.raw }) : nil
+                let skinAnchorRaw: Double?
+                if skinFamily == .whoop4 {
+                    if !skinAnchorResolvedOwners.contains(owner) {
+                        let windowSkin = (try? await store.skinTempSamples(deviceId: owner,
+                                                                           from: skinAnchorScanFrom,
+                                                                           to: skinAnchorScanTo,
+                                                                           limit: 200_000)) ?? []
+                        if let anchor = Whoop4SkinTemp.deviceAnchorRaw(windowSkin.map { $0.raw }) {
+                            skinAnchorByOwner[owner] = anchor
+                        }
+                        skinAnchorResolvedOwners.insert(owner)
+                    }
+                    skinAnchorRaw = skinAnchorByOwner[owner]
+                } else {
+                    skinAnchorRaw = nil
+                }
                 // Wrist-wear events in the night window, paired into off-wrist [start, end) intervals for the
                 // off-wrist sleep backstop (#500). The HR-gap proxy in the stager is the always-on guard;
                 // these explicit intervals sharpen it under the FRACTIONAL rule (#504) , a session is dropped

--- a/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
+++ b/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
@@ -419,6 +419,12 @@ object IntelligenceEngine {
         // registry is stable for the run (same assumption [candidatePriorities] above already makes), so
         // every day sees the exact value the per-day call would have returned: byte-identical scoring.
         val skinFamilyByOwner = HashMap<String, DeviceFamily>()
+        // #938: the WHOOP 4.0 ADC offset is per-device, not per-night. Learn one anchor per owner from the
+        // whole scan window and reuse it for every night so cross-night deviations survive.
+        val skinAnchorScanFrom = nowLocalMidnight - (maxDays - 1).toLong() * SECONDS_PER_DAY - 30 * 3_600L
+        val skinAnchorScanTo = nowLocalMidnight + 18 * 3_600L
+        val skinAnchorByOwner = HashMap<String, Double>()
+        val skinAnchorResolvedOwners = HashSet<String>()
 
         for (offset in 0 until maxDays) {
             val dayStart = nowLocalMidnight - offset * SECONDS_PER_DAY
@@ -477,7 +483,12 @@ object IntelligenceEngine {
             // or when <100 in-band samples exist → the conversion falls back to the global anchor (byte-
             // identical to today). Computed here once per owner alongside the family resolution.
             val skinAnchorRaw = if (skinFamily == DeviceFamily.WHOOP4) {
-                Whoop4SkinTemp.deviceAnchorRaw(skin.map { it.raw })
+                if (!skinAnchorResolvedOwners.contains(owner)) {
+                    val windowSkin = repo.skinTempSamples(owner, skinAnchorScanFrom, skinAnchorScanTo, STREAM_LIMIT)
+                    Whoop4SkinTemp.deviceAnchorRaw(windowSkin.map { it.raw })?.let { skinAnchorByOwner[owner] = it }
+                    skinAnchorResolvedOwners.add(owner)
+                }
+                skinAnchorByOwner[owner]
             } else {
                 null
             }


### PR DESCRIPTION
## Summary

Fix WHOOP 4.0 skin-temperature analysis by learning the per-device skin-temp ADC anchor once per owner over the full analysis window, then reusing that anchor for every scored night.

## Context

I still only have skin temperature from my original WHOOP import. The local BLE/computed path was not producing usable ongoing skin-temp deviation, even though WHOOP 4.0-specific raw conversion already existed.

The likely reason is that the analysis caller was learning the WHOOP 4.0 `anchorRaw` from each individual night. That effectively re-centered each night around the same temperature and could erase the cross-night deviation that `skinTempDevC` is supposed to represent.

The comments already said the anchor must be window-wide, not per-night. This PR makes the implementation match that invariant.

## What Changed

- Swift: cache one WHOOP 4.0 skin-temp anchor per owner across the analysis scan window.
- Android: apply the same per-owner/window-wide anchor behavior for parity.
- Preserve the existing fallback behavior when there are fewer than 100 in-band WHOOP 4.0 samples.

## Why This Should Fix It

For a WHOOP 4.0 strap, the raw skin-temp register has a per-device offset. If NOOP recalculates the anchor separately each night, each night gets normalized independently, so meaningful changes from night to night can disappear.

Using one anchor across the scan window keeps the device offset correction stable. That should allow BLE-computed nightly skin-temp means to seed a baseline and produce `skinTempDevC`, instead of relying only on the original imported WHOOP skin-temp values.

## Known Limitation

WHOOP 4.0 v25 historical records currently decode timestamp and gravity, but not `skin_temp_raw`. If a strap emits v25 frames, this PR cannot create skin-temp samples until the v25 temperature field is mapped from captures.

## Verification

- Passed Android focused unit tests:

`./gradlew testFullDebugUnitTest --tests com.noop.analytics.SkinTempAnalyticsTest --tests com.noop.protocol.SkinTempConversionTest --tests com.noop.protocol.Whoop4HistoricalV25Test`

- I don't have the Apple toolchains installed in this environment, so I couldn't run the Swift/iOS build locally.
