### PR TITLE
Show WHOOP history layout on devices

### DIFF
--- a/Strand/Screens/DevicesView.swift
+++ b/Strand/Screens/DevicesView.swift
@@ -117,6 +117,9 @@ private struct DevicesContent: View {
                     // Firmware version belongs to the active + connected strap only; nil otherwise (and
                     // for a non-WHOOP source that never reports one).
                     liveFirmware: (device.status == .active && live.connected) ? live.strapFirmware : nil,
+                    // Historical record layout (v24/v25 on WHOOP 4.0) observed from this connection's
+                    // backfill. Distinct from the strap firmware build shown as FW.
+                    liveHistoryLayout: (device.status == .active && live.connected) ? live.strapRange?.firmwareLayout : nil,
                     // #987: clock latch + frame freshness + the 1970/71 RTC warning, active card only.
                     liveClockLine: device.status == .active ? strapClockState?.line : nil,
                     liveClockWarning: device.status == .active ? strapClockState?.warning : nil,
@@ -376,6 +379,8 @@ private struct DeviceCard: View {
     /// The active+connected strap's firmware version (from the connect handshake). nil when not the
     /// active/connected device, or for a source that reports no firmware (e.g. a non-WHOOP strap).
     var liveFirmware: String? = nil
+    /// The active+connected strap's observed banked-history record layout (`hist_version`).
+    var liveHistoryLayout: Int? = nil
     /// #987: the active+connected strap's clock-state line ("Clock latched: yes · last frame 12s ago"),
     /// nil for every other card. Built by the parent off the same pure ConnectionReadout parsers the
     /// Test Centre Connection panel binds, so the two readouts can never disagree.
@@ -492,6 +497,13 @@ private struct DeviceCard: View {
                             .font(StrandFont.footnote)
                             .foregroundStyle(StrandPalette.textSecondary)
                             .accessibilityLabel("Firmware version \(fw)")
+                    }
+                    if let layout = liveHistoryLayout {
+                        Text("·").font(StrandFont.footnote).foregroundStyle(StrandPalette.textTertiary)
+                        Text("v\(layout) history")
+                            .font(StrandFont.footnote)
+                            .foregroundStyle(StrandPalette.textSecondary)
+                            .accessibilityLabel("Historical record layout v\(layout)")
                     }
                     // The whole-card tap hint sits on the left; the ⋮ menu is a bottom-trailing overlay above
                     // the press button (so its own taps win). No hint on the active card (no make-active),

--- a/android/app/src/main/java/com/noop/ble/Backfiller.kt
+++ b/android/app/src/main/java/com/noop/ble/Backfiller.kt
@@ -115,6 +115,8 @@ class Backfiller(
      * (always-off) keeps the untraced/test path byte-identical. Mirrors the Swift Backfiller extract seam.
      */
     private val ppgHrSubLagInterp: () -> Boolean = { false },
+    /** Live UI/export observation of the historical record layout (`hist_version`). */
+    private val firmwareLayout: (Int) -> Unit = {},
 ) {
 
     /**
@@ -362,6 +364,7 @@ class Backfiller(
                 ?.let { v ->
                     if (loggedLayoutVersions.add(v)) {
                         log("Backfill: historical records use layout v$v")
+                        firmwareLayout(v)
                         // Connection test mode: the firmware layout as a compact tagged line. A layout that
                         // decoded a signature field (heart_rate / gravity_x / ppg_waveform) is decodable.
                         // Gated zero-cost. Twin of the Swift Backfiller emit.

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -124,6 +124,10 @@ data class LiveState(
      *  Devices card. Null until the handshake response decodes. The Swift WhoopProtocol decodes the
      *  same fields; this is the Android send → state → UI wiring. */
     val strapFirmware: String? = null,
+    /** Historical record layout version (`hist_version`, e.g. v24/v25 on WHOOP 4.0) observed from the
+     *  active connection's backfill. This is distinct from [strapFirmware]: FW 41.17.6.0 is the strap
+     *  firmware build, while v24/v25 is the binary layout used by banked history records. */
+    val historyLayoutVersion: Int? = null,
     /** True while a user-initiated reboot (#166) is in flight — from sending REBOOT_STRAP until the strap
      *  reconnects (or the settle timeout gives up). With `!connected` it drives the Devices card's
      *  transient "Reconnecting…" pill. Twin of macOS LiveState.rebootInProgress. */
@@ -745,8 +749,8 @@ class WhoopBleClient(
             previous.clearedBiometrics().copy(
                 connected = false, bonded = false, encryptedBond = false,
                 backfilling = false, syncChunksThisSession = 0, charging = null,
-                // A stale firmware version must not outlive the dropped link.
-                strapFirmware = null,
+                // Stale firmware/layout readouts must not outlive the dropped link.
+                strapFirmware = null, historyLayoutVersion = null,
                 // #580: the 5/MG "history experimental" note is per-link — a fresh connect re-derives it
                 // from the next offload, so it must not outlive the dropped link.
                 historySyncExperimental = false,
@@ -791,7 +795,8 @@ class WhoopBleClient(
         fun releasedLiveState(previous: LiveState): LiveState =
             previous.clearedBiometrics().copy(
                 connected = false, bonded = false, encryptedBond = false,
-                charging = null, strapFirmware = null, pairingHint = null, scanning = false,
+                charging = null, strapFirmware = null, historyLayoutVersion = null,
+                pairingHint = null, scanning = false,
                 statusNote = null,
             )
 
@@ -1279,6 +1284,7 @@ class WhoopBleClient(
         // Test Centre → Experimental algorithms: the opt-in v26 PPG-HR sub-lag interpolation variant, read
         // live each chunk so a mid-session toggle takes effect. Default OFF (byte-identical to today).
         ppgHrSubLagInterp = { puffinExperiment.ppgHrSubLagInterp },
+        firmwareLayout = { v -> _state.update { it.copy(historyLayoutVersion = v) } },
     )
 
     /**
@@ -5333,7 +5339,8 @@ class WhoopBleClient(
             connected = false, bonded = false, encryptedBond = false,
             backfilling = false, syncChunksThisSession = 0,
             charging = null,        // a stale charging flag must not outlive the link
-            strapFirmware = null,   // nor a stale firmware version
+            strapFirmware = null,   // nor stale firmware/layout versions
+            historyLayoutVersion = null,
         ) }
         // Multi-WHOOP: the link is down — clear the published connected address so SourceCoordinator's
         // adoption sink can't re-fire on a stale strap id (twin of macOS clearing connectedPeripheralUUID).

--- a/android/app/src/main/java/com/noop/ui/DevicesScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/DevicesScreen.kt
@@ -181,6 +181,9 @@ fun DevicesScreen(
                 // Firmware version from the connect handshake: only for the active, connected strap.
                 liveFirmware = if (device.status == DeviceStatus.active.name && live.connected)
                     live.strapFirmware else null,
+                // Historical record layout from the current backfill, distinct from strap firmware.
+                liveHistoryLayout = if (device.status == DeviceStatus.active.name && live.connected)
+                    live.historyLayoutVersion else null,
                 onMakeActive = { switchTarget = device },
                 onRename = { renameTarget = device },
                 onRemove = { removeTarget = device },
@@ -372,6 +375,8 @@ private fun DeviceCard(
     /** The active+connected strap's firmware version (from the connect handshake). null when not
      *  active/connected, or for a source that reports no firmware (e.g. a non-WHOOP strap). */
     liveFirmware: String? = null,
+    /** The active+connected strap's observed banked-history record layout (`hist_version`). */
+    liveHistoryLayout: Int? = null,
     onMakeActive: () -> Unit,
     onRename: () -> Unit,
     onRemove: (() -> Unit)?,
@@ -470,7 +475,8 @@ private fun DeviceCard(
             Row(verticalAlignment = Alignment.CenterVertically) {
                 Text(
                     lastSeenLine(device, isLiveConnected, bondRefused) +
-                        (liveFirmware?.let { " · FW $it" } ?: ""),
+                        (liveFirmware?.let { " · FW $it" } ?: "") +
+                        (historyLayoutLine(liveHistoryLayout)?.let { " · $it" } ?: ""),
                     style = NoopType.footnote,
                     color = Palette.textTertiary,
                     modifier = Modifier.weight(1f),
@@ -1103,6 +1109,9 @@ private fun lastSeenLine(device: PairedDeviceRow, isLiveConnected: Boolean, bond
     isLiveConnected -> "Connected now"
     else -> "Last seen ${relativeAgo(device.lastSeenAt)}"
 }
+
+internal fun historyLayoutLine(version: Int?): String? =
+    version?.let { "v$it history" }
 
 /** Best-effort brand from the advertised name. Falls back to a neutral label. Mirrors Swift brandGuess.
  *  Delegates to the pure [com.noop.data.DeviceBrandCatalog] (single source of truth) so the token table

--- a/android/app/src/test/java/com/noop/ble/ChargingAndReleaseTest.kt
+++ b/android/app/src/test/java/com/noop/ble/ChargingAndReleaseTest.kt
@@ -34,6 +34,7 @@ class ChargingAndReleaseTest {
             connected = true, bonded = true, encryptedBond = true,
             heartRate = 72, rr = listOf(800, 810), rrRecent = listOf(800, 810),
             charging = true, pairingHint = "still bonded to the official app",
+            strapFirmware = "41.17.6.0", historyLayoutVersion = 25,
             scanning = true, statusNote = "Searching…",
         )
         val released = WhoopBleClient.releasedLiveState(live)
@@ -44,6 +45,8 @@ class ChargingAndReleaseTest {
         assertTrue(released.rr.isEmpty())
         assertTrue(released.rrRecent.isEmpty())
         assertNull(released.charging)
+        assertNull(released.strapFirmware)
+        assertNull(released.historyLayoutVersion)
         assertNull(released.pairingHint)
         assertFalse(released.scanning)
         assertNull(released.statusNote)

--- a/android/app/src/test/java/com/noop/ble/GattCrashSafetyTest.kt
+++ b/android/app/src/test/java/com/noop/ble/GattCrashSafetyTest.kt
@@ -78,6 +78,8 @@ class GattCrashSafetyTest {
             rrRecent = listOf(820, 815, 810),
             batteryPct = 64.0,
             charging = true,
+            strapFirmware = "41.17.6.0",
+            historyLayoutVersion = 25,
             backfilling = true,
             syncChunksThisSession = 12,
         )
@@ -97,6 +99,8 @@ class GattCrashSafetyTest {
         assertEquals(0, after.syncChunksThisSession)
         // A stale charging flag must not outlive the link.
         assertNull(after.charging)
+        assertNull(after.strapFirmware)
+        assertNull(after.historyLayoutVersion)
     }
 
     @Test

--- a/android/app/src/test/java/com/noop/ui/DevicePillStateTest.kt
+++ b/android/app/src/test/java/com/noop/ui/DevicePillStateTest.kt
@@ -1,6 +1,7 @@
 package com.noop.ui
 
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
 import org.junit.Test
 
 /**
@@ -62,5 +63,11 @@ class DevicePillStateTest {
                 bondRefused = false, isLiveConnected = false,
             ).label,
         )
+    }
+
+    @Test
+    fun historyLayoutLine_formatsObservedHistoricalRecordVersion() {
+        assertEquals("v25 history", historyLayoutLine(25))
+        assertNull(historyLayoutLine(null))
     }
 }


### PR DESCRIPTION
## What changed

- Shows the active connected strap's observed history layout next to the Devices card firmware readout, for example: `Connected now · FW 41.17.6.0 · v24 history`.
- Wires Android's existing backfill layout detection into `LiveState`, matching the Swift side that already banks the layout in `LiveState.strapRange`.
- Clears the Android history-layout readout on disconnect/release so an old `v24` or `v25` label cannot outlive the current link.

## Why

`FW 41.17.6.0` is the strap firmware build. The `v24` / `v25` value we keep talking about is different: it is the `hist_version` layout used by the banked history records NOOP is decoding.

The app already detected that layout during backfill and wrote it to the strap log/diagnostics. This PR puts that same live signal where users are already looking for firmware details: beside `Connected now · FW ...` in Manage Devices.

This should make reports easier to triage without asking people to dig through logs. If someone says they are on FW 41.17.6.0, the card can also show whether their current history sync is handing NOOP v24 or v25 records.

## Notes

- The label appears for the active connected strap once the current connection has seen history records in a backfill.
- This does not change decoding or persistence. It only surfaces the layout NOOP already observes.

## Checks

- `git diff --check`
- `./gradlew :app:testFullDebugUnitTest --tests 'com.noop.ui.DevicePillStateTest' --tests 'com.noop.ble.GattCrashSafetyTest' --tests 'com.noop.ble.ChargingAndReleaseTest'`

I don't have the Apple toolchains installed in this environment, so I couldn't run the Swift/iOS build locally.
