### PR TITLE
Settings: finish the iOS-only scheduled-export dedup + compile-verify #336's Swift legs (#335)

### DIFF
--- a/Strand/Screens/SettingsView.swift
+++ b/Strand/Screens/SettingsView.swift
@@ -129,11 +129,6 @@ struct SettingsView: View {
     @State private var rawCsvBusy = false
     @State private var lastRawCsvURL: URL?
 
-    /// Scheduled daily debug auto-export (#510, parity with Android). Seeded from the persisted store;
-    /// the toggle + time picker write back through `ScheduledDebugExport`. Opt-in, default OFF.
-    @State private var debugExportOn = ScheduledDebugExport.isEnabled
-    @State private var debugExportMinutes = ScheduledDebugExport.timeMinutes
-
     /// Confirm gate for the "Recalibrate Charge baseline" action (it re-learns the HRV anchor from tonight).
     @State private var showRecalibrateConfirm = false
 
@@ -1444,97 +1439,8 @@ struct SettingsView: View {
                     .font(StrandFont.caption)
                     .foregroundStyle(StrandPalette.textTertiary)
                     .fixedSize(horizontal: false, vertical: true)
-
-                Divider().overlay(StrandPalette.hairline)
-
-                scheduledExportControls
             }
         }
-        // Re-arm / catch-up the daily export whenever Settings appears (self-heals after a relaunch).
-        .onAppear { ScheduledDebugExport.activateIfEnabled() }
-    }
-
-    /// Daily auto-export of the strap log (#510 — parity with Android's DebugExportScheduler). Opt-in,
-    /// default OFF: a toggle + a time-of-day picker + a "Run now". Honest about iOS background timing —
-    /// the macOS drop is reliable (the app is usually running), the iOS one fires when iOS next wakes
-    /// NOOP near the chosen time, never guaranteed to the minute.
-    @ViewBuilder private var scheduledExportControls: some View {
-        Toggle(isOn: $debugExportOn) {
-            Text("Daily auto-export of the strap log")
-                .font(StrandFont.subhead)
-                .foregroundStyle(StrandPalette.textPrimary)
-        }
-        .toggleStyle(.switch)
-        .tint(StrandPalette.accent)
-        .onChangeCompat(of: debugExportOn) { on in ScheduledDebugExport.setEnabled(on) }
-
-        if debugExportOn {
-            HStack {
-                Text("Time of day")
-                    .font(StrandFont.subhead)
-                    .foregroundStyle(StrandPalette.textPrimary)
-                Spacer()
-                DatePicker("", selection: debugExportTimeBinding, displayedComponents: .hourAndMinute)
-                    .labelsHidden()
-                    .accessibilityLabel("Daily auto-export time")
-            }
-
-            NoopButton("Run now", systemImage: "square.and.arrow.down.on.square", kind: .secondary) {
-                runScheduledExportNow()
-            }
-        }
-
-        Text(debugExportCaption)
-            .font(StrandFont.caption)
-            .foregroundStyle(StrandPalette.textTertiary)
-            .fixedSize(horizontal: false, vertical: true)
-    }
-
-    /// Honest caption — the drop location plus the platform-specific timing reality.
-    private var debugExportCaption: String {
-        #if os(iOS)
-        return String(localized: "Writes a timestamped copy of your strap log to NOOP's folder in the Files app, once a day. Handy for a bug report without remembering to grab it. On iPhone it fires when iOS next wakes NOOP near your chosen time, not guaranteed to the minute (keep NOOP open overnight for the best chance). Everything stays on \(Platform.deviceNounPhrase); nothing is uploaded.")
-        #else
-        return String(localized: "Writes a timestamped copy of your strap log to your Documents folder, once a day. Handy for a bug report without remembering to grab it. On Mac it runs while NOOP is open (and catches up on launch if the time passed while it was closed). Everything stays on \(Platform.deviceNounPhrase); nothing is uploaded.")
-        #endif
-    }
-
-    /// Bridges the minutes-since-midnight store to the DatePicker, persisting + rescheduling on change
-    /// (mirrors SmartAlarmView's wakeBinding).
-    private var debugExportTimeBinding: Binding<Date> {
-        Binding(
-            get: {
-                var c = DateComponents()
-                c.hour = debugExportMinutes / 60
-                c.minute = debugExportMinutes % 60
-                return Calendar.current.date(from: c) ?? Date()
-            },
-            set: { date in
-                let c = Calendar.current.dateComponents([.hour, .minute], from: date)
-                let m = (c.hour ?? 7) * 60 + (c.minute ?? 0)
-                debugExportMinutes = m
-                ScheduledDebugExport.setTimeMinutes(m)
-            }
-        )
-    }
-
-    /// "Run now": write an immediate timestamped strap-log drop (with the raw capture beside it, if a
-    /// session has recorded one) and tell the user where it landed.
-    private func runScheduledExportNow() {
-        model.ble.flushPuffinCaptures()
-        let url = ScheduledDebugExport.runNow(captureURL: live.puffinCaptureURL)
-        if let url {
-            backupAlertTitle = String(localized: "Strap log exported")
-            #if os(iOS)
-            backupAlertMessage = String(localized: "Saved \(url.lastPathComponent) to NOOP's folder in the Files app.")
-            #else
-            backupAlertMessage = String(localized: "Saved \(url.lastPathComponent) to your Documents folder.")
-            #endif
-        } else {
-            backupAlertTitle = String(localized: "Export failed")
-            backupAlertMessage = String(localized: "Couldn't write the strap log right now.")
-        }
-        showBackupAlert = true
     }
 
     /// Export the last 24h of decoded sensor streams for the connected strap to a CSV, then save (macOS


### PR DESCRIPTION
Closes #335. Follow-up to the merged menu-cleanup PR (#336).

## What

Two things #335 asked for, on a Mac with Xcode:

1. **Finish the one iOS-only dedup deferred from #336.** `SettingsView` still rendered a "Scheduled debug export" card that duplicated Test Centre section 3 — same `ScheduledDebugExport` store. Removed it and unwound its scattered state: `debugExportOn` / `debugExportMinutes` `@State`, the `scheduledExportControls` builder, `debugExportCaption`, `debugExportTimeBinding`, `runScheduledExportNow`, and the Settings `.onAppear` re-arm. The raw-sensor CSV export in the same Diagnostics card is left untouched.

2. **Compile-verify #336's Swift legs**, which were written without Xcode and had no CI. All present and clean in the tree, now built:
   - commit 1 — Test Centre "Advanced" mirror removal
   - commit 3 — "Broadcast heart rate" → "Broadcast strap HR (Garmin/ANT)" rename
   - commit 6 — `AutomationsView` "Only when worn" removal

## Why it's safe

Test Centre stays reachable on **both** platforms (macOS `RootView` + the Settings nav link; iOS `RootTabView`) and keeps its own section-3 export, so the feature keeps a **single home** on Apple platforms — matching the Android dedup already shipped in #336. macOS re-arm now homes on `TestCentreView.onAppear`; iOS also re-arms at launch via `ScheduledDebugExport.register()`.

App-target Swift only — no analytics, stored data, or migrations, so no byte-parity twin is needed. Deletion only, no new design tokens.

## Verification

Xcode 26.6 (iOS 26.5 SDK), `CODE_SIGNING_ALLOWED=NO`:

| Target | Destination | Result |
|---|---|---|
| `Strand` | `platform=macOS` | **BUILD SUCCEEDED** |
| `NOOPiOS` | `platform=iOS Simulator,name=iPhone 17 Pro` | **BUILD SUCCEEDED** |

`grep` for `debugExport*` / `scheduledExportControls` / `runScheduledExportNow` in `SettingsView.swift` returns nothing; diff is SettingsView-only (94 deletions). Settings still shows the raw-CSV Diagnostics card and the Test Centre nav link.