### PR TITLE
BLE: stop the false "re-grant Bluetooth" banner during macOS cold-start settling (#391)

### DIFF
--- a/Strand/BLE/BLEManager.swift
+++ b/Strand/BLE/BLEManager.swift
@@ -2824,6 +2824,18 @@ extension BLEManager: @preconcurrency CBCentralManagerDelegate {
             // iOS+macOS up to that parity rather than adding a new behaviour.
             switch central.state {
             case .unauthorized:
+                // #391: CoreBluetooth on macOS can transiently report `.unauthorized` during the cold-start
+                // settling window (before the central finishes connecting to bluetoothd) even when the TCC
+                // grant is fine — the state then advances to .poweredOff/.poweredOn on the next callback and
+                // the strap connects. `central.authorization` reads the grant DIRECTLY, independent of that
+                // transient state, so use it to tell a genuine denial (#280/#295) from the settling case.
+                // Only a real .denied/.restricted should latch the re-grant banner; a granted-but-transient
+                // `.unauthorized` is left alone like .unknown/.resetting below, and the next state update
+                // resolves it. (#391: users were pushed to toggle Bluetooth off/on to clear a false banner.)
+                guard central.authorization == .denied || central.authorization == .restricted else {
+                    log("Central reported unauthorized but Bluetooth is granted — transient cold-start state; waiting for the radio to settle")
+                    break
+                }
                 // #295: an unsigned/ad-hoc build's code identity changes on every release, so a Bluetooth
                 // toggle that already reads "on" from a PRIOR build's grant may not carry over — the
                 // message needs to tell the user to re-toggle it, not just check that it's on.


### PR DESCRIPTION
Closes #391.

## Symptom

On macOS the strap stays **Disconnected** on launch and the log reads `Bluetooth permission not granted (unauthorized) — cannot scan or connect` **even though permission is granted and the app wasn't updated**. Toggling Bluetooth off/on clears it (a second reporter confirmed). The reporter's own log shows the state was only *transiently* unauthorized:

```
[14:51:44] Central state: 3 (5 = poweredOn)     ← .unauthorized (transient)
[14:51:44] Bluetooth permission not granted (unauthorized) — cannot scan or connect
[14:52:24] Central state: 4 (5 = poweredOn)     ← .poweredOff
[14:52:25] Central state: 5 (5 = poweredOn)     ← .poweredOn → connects fine
```

## Root cause

CoreBluetooth on macOS can report `.unauthorized` during the cold-start settling window — before the `CBCentralManager` finishes connecting to `bluetoothd` — even when the TCC grant is `.allowedAlways`. It then advances to `.poweredOff`/`.poweredOn` and connects. But `centralManagerDidUpdateState` latched the #280/#295 "re-grant Bluetooth / toggle it off and on" banner on **any** `.unauthorized`, discriminating only on `central.state` — so it couldn't tell a genuine denial from the transient settling case, and pushed users to toggle Bluetooth needlessly.

## Fix

In the `.unauthorized` case, discriminate on `central.authorization` (the `CBManager` property that reads the TCC grant directly, independent of the transient central state):

- `.denied` / `.restricted` → genuine denial; keep the #280/#295 re-grant banner unchanged.
- `.allowedAlways` / `.notDetermined` → transient cold-start state; log a soft line and wait, exactly like the existing silent `.unknown`/`.resetting` handling. The next `.poweredOn` callback runs `connectFromSystem()` as before — no new retry/timer.

macOS-facing but the path is shared iOS+macOS and is correct on both. CoreBluetooth-specific cold-start quirk with no Android analogue, so no byte-parity twin; no analytics/stored-data/migrations touched; no UI/token changes.

## Verification

Xcode 26.6 (iOS 26.5 SDK), `CODE_SIGNING_ALLOWED=NO`:

| Target | Destination | Result |
|---|---|---|
| `Strand` | `platform=macOS` | **BUILD SUCCEEDED** |
| `NOOPiOS` | `platform=iOS Simulator,name=iPhone 17 Pro` | **BUILD SUCCEEDED** |

**On-hardware caveat:** the cold-start race is TCC/timing-dependent and not reproducible in a unit test or the simulator, so the runtime behaviour hasn't been reproduced on a Mac here. Please confirm on a Mac where NOOP's Bluetooth grant is ON that launch no longer shows the "not allowed / toggle Bluetooth" banner and connects without a manual toggle — and that genuinely denying NOOP Bluetooth in System Settings still shows the re-grant message.