### PR TITLE
Workouts: step count in the on-foot activity summary (#398)

### DIFF
--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/AnalyticsEngine.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/AnalyticsEngine.swift
@@ -654,23 +654,16 @@ public enum AnalyticsEngine {
         // only — not cloud/clinical parity.
         let stepsTotal: Int? = {
             // Prefer the full-calendar-day stream for the additive total; fall back to the
-            // night-window stream when the caller didn't supply one (pure-function callers/tests).
-            let sorted = (daySteps ?? steps).filter { tsInDay($0.ts) }.sorted { $0.ts < $1.ts }
-            if sorted.count < 2 { return nil }
-            // A delta this large is a big time-gap / disconnect boundary between sync sessions (or a
-            // firmware reboot, byte-indistinguishable from a wrap), NOT real steps — drop it so gaps
-            // don't inflate the total. Real 1 Hz motion never ticks this fast between adjacent records.
-            let maxStepDelta = 512
-            var total = 0
-            for i in 1..<sorted.count {
-                let delta = (sorted[i].counter - sorted[i - 1].counter) & 0xFFFF  // wrap-aware u16 increment
-                if delta >= 1 && delta < maxStepDelta { total += delta }  // ignore a delta >= 512 (gap/reset)
-            }
-            if total <= 0 { return nil }
+            // night-window stream when the caller didn't supply one (pure-function callers/tests). The
+            // day's read window may include adjacent-day samples, so filter to the LOCAL-day key first
+            // (#277); the wrap-aware tick math itself lives in the shared StepsCounter kernel so the daily
+            // and per-workout (#398) totals can never disagree.
+            let inDay = (daySteps ?? steps).filter { tsInDay($0.ts) }
+            guard let ticks = StepsCounter.stepsInWindow(inDay) else { return nil }
             // @57 counts motion ticks, not validated steps — the 5/MG counter overcounts. Divide
             // by the user-calibrated ticks-per-step (default 1.0 = raw pass-through; floor 0.5 so
             // a bad pref can at most double, never explode, the total). (#139)
-            let scaled = Int((Double(total) / max(profile.stepTicksPerStep, 0.5)).rounded())
+            let scaled = Int((Double(ticks) / max(profile.stepTicksPerStep, 0.5)).rounded())
             return scaled > 0 ? scaled : nil
         }()
 

--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/StepsCounter.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/StepsCounter.swift
@@ -1,0 +1,37 @@
+import Foundation
+import WhoopProtocol
+
+/// Wrap-aware step derivation from the strap's cumulative `step_motion_counter@57`, shared by the daily
+/// total (`AnalyticsEngine.analyzeDay`) and any windowed total (a manual workout's `[start, end]`, #398).
+///
+/// `step_motion_counter@57` is a CUMULATIVE u16 running counter: it climbs while you move, holds flat when
+/// still, and wraps at 65536. The number of motion ticks over a set of time-ordered records is the SUM of
+/// WRAP-AWARE increments of that counter — `delta = (cur - prev) & 0xFFFF` — with a per-user
+/// `stepTicksPerStep` calibration applied by the caller AFTERWARDS (this returns the raw pre-calibration
+/// tick total, so the two callers can never disagree on the counter math). The raw total is an ESTIMATE
+/// (@57 counts motion ticks, not validated steps), not cloud/clinical parity.
+///
+/// Kept byte-for-byte in lockstep with the Kotlin twin `StepsCounter.stepsInWindow`.
+public enum StepsCounter {
+    /// The largest wrap-aware increment treated as real motion between two adjacent 1 Hz records. A delta
+    /// at/above this is a big time-gap / disconnect boundary between sync sessions (or a firmware reboot,
+    /// byte-indistinguishable from a u16 wrap), NOT real steps — dropped so gaps don't inflate the total.
+    /// Real 1 Hz motion never ticks this fast between adjacent records. (#132/#276/#316)
+    public static let maxStepDelta = 512
+
+    /// Raw wrap-aware motion-tick total across `samples` — the sum of positive consecutive
+    /// `step_motion_counter@57` increments in `[1, maxStepDelta)`. Sorts by `ts` internally, so the caller
+    /// may pass an unsorted window (already filtered to the range it cares about). Returns `nil` when there
+    /// are fewer than two samples or no forward movement (so "no data" stays distinct from a real zero).
+    /// The caller applies its `stepTicksPerStep` calibration to the returned ticks.
+    public static func stepsInWindow(_ samples: [StepSample]) -> Int? {
+        let sorted = samples.sorted { $0.ts < $1.ts }
+        if sorted.count < 2 { return nil }
+        var total = 0
+        for i in 1..<sorted.count {
+            let delta = (sorted[i].counter - sorted[i - 1].counter) & 0xFFFF  // wrap-aware u16 increment
+            if delta >= 1 && delta < maxStepDelta { total += delta }  // ignore a delta >= 512 (gap/reset)
+        }
+        return total > 0 ? total : nil
+    }
+}

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/StepsCounterTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/StepsCounterTests.swift
@@ -1,0 +1,50 @@
+import XCTest
+@testable import StrandAnalytics
+import WhoopProtocol
+
+/// Unit tests for the shared windowed step kernel `StepsCounter.stepsInWindow` (#398). The same
+/// wrap-aware positive-delta math the daily total uses (see StepsDailyTests), but exercised directly and
+/// order-independently so a manual-workout window can reuse it. Returns the RAW motion-tick total (before
+/// the caller's `stepTicksPerStep` calibration). Mirrors the Android StepsCounterTest vectors value-for-value.
+final class StepsCounterTests: XCTestCase {
+
+    private func step(_ ts: Int, _ counter: Int) -> StepSample { StepSample(ts: ts, counter: counter) }
+
+    func testSumsPositiveConsecutiveDeltas() {
+        // counters 100 -> 150 -> 220 => deltas 50 + 70 = 120
+        XCTAssertEqual(StepsCounter.stepsInWindow([step(0, 100), step(60, 150), step(120, 220)]), 120)
+    }
+
+    func testSortsUnorderedInput() {
+        // Same three samples shuffled — the kernel sorts by ts, so the result is identical (120).
+        XCTAssertEqual(StepsCounter.stepsInWindow([step(120, 220), step(0, 100), step(60, 150)]), 120)
+    }
+
+    func testHandlesU16Wraparound() {
+        // 65500 -> 20 wraps: (20 - 65500) & 0xFFFF = 56, a small real increment; then 20 -> 80 => 60.
+        XCTAssertEqual(StepsCounter.stepsInWindow([step(0, 65_500), step(60, 20), step(120, 80)]), 116)
+    }
+
+    func testFewerThanTwoSamplesIsNil() {
+        XCTAssertNil(StepsCounter.stepsInWindow([]))
+        XCTAssertNil(StepsCounter.stepsInWindow([step(0, 100)]))
+    }
+
+    func testNoForwardMovementIsNil() {
+        // Flat counter across the window => no positive delta => nil (not 0).
+        XCTAssertNil(StepsCounter.stepsInWindow([step(0, 500), step(60, 500), step(120, 500)]))
+    }
+
+    func testDropsBigGapDeltaAsBoundary() {
+        // A jump >= 512 (sync-gap / reboot boundary) is dropped; the real 40 + 30 survive.
+        // 100 -> 140 (=40) -> 5000 (=4860, dropped) -> 5030 (=30) => 70.
+        XCTAssertEqual(StepsCounter.stepsInWindow(
+            [step(0, 100), step(60, 140), step(120, 5_000), step(180, 5_030)]), 70)
+    }
+
+    func testMaxStepDeltaBoundaryIsExclusive() {
+        // Exactly maxStepDelta (512) is dropped; 511 counts.
+        XCTAssertEqual(StepsCounter.stepsInWindow([step(0, 0), step(60, 512)]), nil)   // 512 dropped => no movement
+        XCTAssertEqual(StepsCounter.stepsInWindow([step(0, 0), step(60, 511)]), 511)   // 511 kept
+    }
+}

--- a/Strand/Data/Repository.swift
+++ b/Strand/Data/Repository.swift
@@ -911,6 +911,21 @@ final class Repository: ObservableObject {
         return Self.latestActivityClass(perId)
     }
 
+    /// Raw strap step TICKS over `[from, to]` for a manual-workout summary (#398): the wrap-aware
+    /// `step_motion_counter@57` delta-sum (shared `StepsCounter` kernel) from the FIRST id that has a
+    /// countable window — the active strap wins, mirroring `stepActivityClassLatest`. Never MERGED across
+    /// ids: two devices' cumulative counters must not be interleaved (that would fabricate huge deltas).
+    /// `nil` when no strap counter covers the window — a WHOOP 4.0 (no @57 counter) or an MG/5.0 that hasn't
+    /// offloaded the window yet. The caller applies `stepTicksPerStep` and reconciles with the phone pedometer.
+    func strapStepTicks(from: Int, to: Int) async -> Int? {
+        guard let store = await ensureStore() else { return nil }
+        for id in importedReadIds {   // active strap FIRST
+            let samples = (try? await store.stepSamples(deviceId: id, from: from, to: to, limit: 200_000)) ?? []
+            if let ticks = StepsCounter.stepsInWindow(samples) { return ticks }
+        }
+        return nil
+    }
+
     /// Pure pick of the latest classed activity across the union's per-id step lists: the non-nil
     /// `activityClass` on the sample with the greatest ts, resolving a ts tie in favour of the FIRST list (the
     /// active strap, mirroring the union's active-wins rule). Static + pure so it's unit-testable without a

--- a/Strand/Data/WorkoutCatalog.swift
+++ b/Strand/Data/WorkoutCatalog.swift
@@ -91,4 +91,19 @@ enum WorkoutCatalog {
         guard !q.isEmpty else { return all }
         return all.filter { $0.name.range(of: q, options: .caseInsensitive) != nil }
     }
+
+    /// Sports where a step count is meaningful , feet on the ground , so the workout summary can show
+    /// steps (#398). Deliberately narrow: outdoor + treadmill run/walk and hiking, NOT cycling/rowing/
+    /// swimming (no footfalls) or gym/court sports (a step tally would be noise). Kept in lockstep with
+    /// the Android `WorkoutCatalog.ON_FOOT_SPORTS`.
+    static let onFootSportNames: Set<String> = [
+        "Running", "Walking", "Hiking", "Treadmill run", "Treadmill walk",
+    ]
+
+    /// Whether `sportName` (a catalogue name, possibly free-typed) is an on-foot sport that should show a
+    /// step count. Case-insensitive, whitespace-trimmed.
+    static func isOnFoot(_ sportName: String) -> Bool {
+        let q = sportName.trimmingCharacters(in: .whitespaces)
+        return onFootSportNames.contains { $0.caseInsensitiveCompare(q) == .orderedSame }
+    }
 }

--- a/Strand/Data/WorkoutPedometer.swift
+++ b/Strand/Data/WorkoutPedometer.swift
@@ -1,0 +1,39 @@
+import Foundation
+#if os(iOS)
+import CoreMotion
+#endif
+
+/// One-shot HISTORICAL phone step count for a finished workout window `[start, end]` (#398).
+///
+/// CoreMotion's `CMPedometer` retains ~7 days of step history on-device, so a manual-workout summary can
+/// show the phone's own step tally for a walk WITHOUT any live motion updates or a persistent sensor
+/// subscription — a single historical query at display time, reconciled against the strap's own counter.
+/// iOS only (`CMPedometer` is unavailable on macOS); the macOS build gets `nil` and falls back to strap
+/// steps. `nil` always means "no phone steps" (unavailable / not authorized / query failed), never a
+/// fabricated zero.
+enum WorkoutPedometer {
+    #if os(iOS)
+    private static let pedometer = CMPedometer()
+
+    /// The phone's step count between two unix-second bounds, or `nil` when steps can't be counted, Motion
+    /// access is denied/restricted, the window is empty, or the query fails. The first call on a fresh
+    /// install triggers the Motion & Fitness permission prompt (see `NSMotionUsageDescription`).
+    static func steps(fromSec: Int, toSec: Int) async -> Int? {
+        guard fromSec < toSec, CMPedometer.isStepCountingAvailable() else { return nil }
+        switch CMPedometer.authorizationStatus() {
+        case .denied, .restricted: return nil
+        default: break
+        }
+        let start = Date(timeIntervalSince1970: TimeInterval(fromSec))
+        let end = Date(timeIntervalSince1970: TimeInterval(toSec))
+        return await withCheckedContinuation { (cont: CheckedContinuation<Int?, Never>) in
+            pedometer.queryPedometerData(from: start, to: end) { data, _ in
+                cont.resume(returning: data?.numberOfSteps.intValue)
+            }
+        }
+    }
+    #else
+    /// macOS has no pedometer — steps come from the strap counter only.
+    static func steps(fromSec: Int, toSec: Int) async -> Int? { nil }
+    #endif
+}

--- a/Strand/Screens/WorkoutDetailView.swift
+++ b/Strand/Screens/WorkoutDetailView.swift
@@ -52,6 +52,12 @@ struct WorkoutDetailView: View {
     /// row's natural key. nil = no route was recorded (honest — the map only shows when points exist).
     @State private var route: [RouteMath.LatLng] = []
 
+    /// Steps over the session window for an on-foot sport (#398): the count plus whether it came from the
+    /// strap's own counter (MG/5.0) or the phone pedometer (fallback for WHOOP 4.0 / not-yet-synced / CSV
+    /// import). nil = not an on-foot sport, or no step source had data for the window.
+    private struct StepReadout { let count: Int; let fromStrap: Bool }
+    @State private var steps: StepReadout?
+
     var body: some View {
         ScreenScaffold(title: "\(WorkoutSource.displaySport(row.sport))",
                        subtitle: "\(dateLabel(row.startTs))",
@@ -116,11 +122,30 @@ struct WorkoutDetailView: View {
             minutes = await repo.workoutZoneMinutes(from: row.startTs, to: row.endTs, age: profile.age)
         }
 
+        // Steps for an on-foot session (#398), computed at display time over the exact window so it
+        // "fills in after sync": prefer the strap's own counter (MG/5.0) once it has offloaded the window,
+        // else the phone pedometer (any strap, incl. WHOOP 4.0 / CSV-import). Never shown for non-foot
+        // sports (cycling/rowing/… have no footfalls). Both sources return nil for "no data", so an empty
+        // window stays "–" rather than a fabricated 0.
+        var stepReadout: StepReadout? = nil
+        if WorkoutCatalog.isOnFoot(row.sport) {
+            if let ticks = await repo.strapStepTicks(from: row.startTs, to: row.endTs) {
+                // Same per-user ticks-per-step calibration the daily total applies (#139), floor 0.5.
+                let scaled = Int((Double(ticks) / max(profile.stepTicksPerStep, 0.5)).rounded())
+                if scaled > 0 { stepReadout = StepReadout(count: scaled, fromStrap: true) }
+            }
+            if stepReadout == nil,
+               let ped = await WorkoutPedometer.steps(fromSec: row.startTs, toSec: row.endTs), ped > 0 {
+                stepReadout = StepReadout(count: ped, fromStrap: false)
+            }
+        }
+
         await MainActor.run {
             self.route = routePoints
             self.hrPoints = points
             self.zoneMinutes = minutes
             self.zonesFromImport = fromImport
+            self.steps = stepReadout
             self.loaded = true
         }
     }
@@ -178,6 +203,15 @@ struct WorkoutDetailView: View {
                          value: distanceLabel(row.distanceM),
                          caption: String(localized: "covered"),
                          accent: StrandPalette.metricCyan)
+            }
+            // Steps for an on-foot sport (#398). Shown for the on-foot set even before the value lands, so
+            // the tile doesn't pop in; "–" until a source has data. Caption is honest about the source.
+            if WorkoutCatalog.isOnFoot(row.sport) {
+                StatTile(label: "Steps",
+                         value: steps.map { grouped(Double($0.count)) } ?? "–",
+                         caption: steps.map { $0.fromStrap ? String(localized: "strap")
+                                                          : String(localized: "phone") },
+                         accent: steps != nil ? StrandPalette.metricCyan : StrandPalette.textTertiary)
             }
         }
     }

--- a/StrandiOS/Resources/Info.plist
+++ b/StrandiOS/Resources/Info.plist
@@ -65,6 +65,8 @@
 	<string>NOOP writes the metrics it computes from your strap back into Apple Health, on-device and only when you allow it.</string>
 	<key>NSLocationWhenInUseUsageDescription</key>
 	<string>NOOP records your route during an outdoor workout to show distance, pace, and a map, and keeps recording while the screen is off. The route stays on your device. Nothing leaves it.</string>
+	<key>NSMotionUsageDescription</key>
+	<string>NOOP reads your iPhone's step count for a walking or running workout to show steps in the activity summary. It stays on your device. Nothing leaves it.</string>
 	<key>NSSupportsLiveActivities</key>
 	<true/>
 	<key>OURA_CLIENT_ID</key>

--- a/android/app/src/main/java/com/noop/analytics/AnalyticsEngine.kt
+++ b/android/app/src/main/java/com/noop/analytics/AnalyticsEngine.kt
@@ -524,23 +524,16 @@ object AnalyticsEngine {
         // only — not cloud/clinical parity.
         val stepsTotal: Int? = run {
             // Prefer the full-calendar-day stream for the additive total; fall back to the
-            // night-window stream when the caller didn't supply one (pure-function callers/tests).
-            val sorted = (daySteps ?: steps).filter { dayString(it.ts, tzOffsetSeconds) == day }.sortedBy { it.ts }
-            if (sorted.size < 2) return@run null
-            // A delta this large is a big time-gap / disconnect boundary between sync sessions (or a
-            // firmware reboot, byte-indistinguishable from a wrap), NOT real steps — drop it so gaps
-            // don't inflate the total. Real 1 Hz motion never ticks this fast between adjacent records.
-            val maxStepDelta = 512
-            var total = 0L
-            for (i in 1 until sorted.size) {
-                val delta = (sorted[i].counter - sorted[i - 1].counter) and 0xFFFF // wrap-aware u16 increment
-                if (delta in 1 until maxStepDelta) total += delta // ignore a delta >= 512 (gap/reset)
-            }
-            if (total <= 0L) return@run null
+            // night-window stream when the caller didn't supply one (pure-function callers/tests). The
+            // day's read window may include adjacent-day samples, so filter to the LOCAL-day key first
+            // (#277); the wrap-aware tick math itself lives in the shared StepsCounter kernel so the daily
+            // and per-workout (#398) totals can never disagree.
+            val inDay = (daySteps ?: steps).filter { dayString(it.ts, tzOffsetSeconds) == day }
+            val ticks = StepsCounter.stepsInWindow(inDay) ?: return@run null
             // @57 counts motion ticks, not validated steps — the 5/MG counter overcounts. Divide
             // by the user-calibrated ticks-per-step (default 1.0 = raw pass-through; floor 0.5 so
             // a bad pref can at most double, never explode, the total). (#139)
-            val scaled = (total.toDouble() / max(profile.stepTicksPerStep, 0.5)).roundToLong()
+            val scaled = (ticks.toDouble() / max(profile.stepTicksPerStep, 0.5)).roundToLong()
                 .coerceAtMost(Int.MAX_VALUE.toLong()).toInt()
             if (scaled > 0) scaled else null
         }

--- a/android/app/src/main/java/com/noop/analytics/StepsCounter.kt
+++ b/android/app/src/main/java/com/noop/analytics/StepsCounter.kt
@@ -1,0 +1,44 @@
+package com.noop.analytics
+
+import com.noop.data.StepSample
+
+/**
+ * Wrap-aware step derivation from the strap's cumulative `step_motion_counter@57`, shared by the daily
+ * total ([AnalyticsEngine.analyzeDay]) and any windowed total (a manual workout's `[start, end]`, #398).
+ *
+ * `step_motion_counter@57` is a CUMULATIVE u16 running counter: it climbs while you move, holds flat when
+ * still, and wraps at 65536. The motion-tick total over a set of records is the SUM of WRAP-AWARE
+ * increments of that counter — `delta = (cur - prev) and 0xFFFF` — with a per-user `stepTicksPerStep`
+ * calibration applied by the caller AFTERWARDS (this returns the raw pre-calibration tick total, so the two
+ * callers can never disagree on the counter math). The raw total is an ESTIMATE (@57 counts motion ticks,
+ * not validated steps), not cloud/clinical parity.
+ *
+ * Byte-for-byte twin of the Swift `StepsCounter.stepsInWindow`.
+ */
+object StepsCounter {
+    /**
+     * The largest wrap-aware increment treated as real motion between two adjacent 1 Hz records. A delta
+     * at/above this is a big time-gap / disconnect boundary between sync sessions (or a firmware reboot,
+     * byte-indistinguishable from a u16 wrap), NOT real steps — dropped so gaps don't inflate the total.
+     * Real 1 Hz motion never ticks this fast between adjacent records. (#132/#276/#316)
+     */
+    const val MAX_STEP_DELTA = 512
+
+    /**
+     * Raw wrap-aware motion-tick total across [samples] — the sum of positive consecutive
+     * `step_motion_counter@57` increments in `[1, MAX_STEP_DELTA)`. Sorts by `ts` internally, so the caller
+     * may pass an unsorted window (already filtered to the range it cares about). Returns `null` when there
+     * are fewer than two samples or no forward movement (so "no data" stays distinct from a real zero). The
+     * caller applies its `stepTicksPerStep` calibration to the returned ticks.
+     */
+    fun stepsInWindow(samples: List<StepSample>): Int? {
+        val sorted = samples.sortedBy { it.ts }
+        if (sorted.size < 2) return null
+        var total = 0
+        for (i in 1 until sorted.size) {
+            val delta = (sorted[i].counter - sorted[i - 1].counter) and 0xFFFF // wrap-aware u16 increment
+            if (delta in 1 until MAX_STEP_DELTA) total += delta // ignore a delta >= 512 (gap/reset)
+        }
+        return if (total > 0) total else null
+    }
+}

--- a/android/app/src/main/java/com/noop/analytics/WorkoutSport.kt
+++ b/android/app/src/main/java/com/noop/analytics/WorkoutSport.kt
@@ -26,4 +26,17 @@ object WorkoutSport {
 
     /** The default when none is chosen ("Other"). */
     val default: Sport get() = all.first { it.name == "Other" }
+
+    /** Sports where a step count is meaningful — feet on the ground — so the workout summary can show
+     *  steps (#398). Deliberately narrow: outdoor + treadmill run/walk and hiking, NOT cycling/rowing/
+     *  swimming (no footfalls) or gym/court sports (a step tally would be noise). Kept in lockstep with
+     *  the Swift `WorkoutCatalog.onFootSportNames`. */
+    val ON_FOOT_SPORTS: Set<String> = setOf("Running", "Walking", "Hiking", "Treadmill run", "Treadmill walk")
+
+    /** Whether [sportName] (a catalogue name, possibly free-typed) is an on-foot sport that should show a
+     *  step count. Case-insensitive, whitespace-trimmed. Mirrors Swift `WorkoutCatalog.isOnFoot`. */
+    fun isOnFoot(sportName: String): Boolean {
+        val q = sportName.trim()
+        return ON_FOOT_SPORTS.any { it.equals(q, ignoreCase = true) }
+    }
 }

--- a/android/app/src/main/java/com/noop/ui/AppViewModel.kt
+++ b/android/app/src/main/java/com/noop/ui/AppViewModel.kt
@@ -1413,6 +1413,20 @@ class AppViewModel(app: Application) : AndroidViewModel(app) {
         return if (minutes.any { it > 0.0 }) minutes else null
     }
 
+    /** Steps over a manual-workout window `[from, to]` from the strap's own `step_motion_counter@57`
+     *  (#398): the shared wrap-aware `StepsCounter` delta-sum, then the per-user `stepTicksPerStep`
+     *  calibration the daily total applies (#139, floor 0.5). null when no strap counter covers the window
+     *  — a WHOOP 4.0 (no @57 counter) or an MG/5.0 that hasn't offloaded the window yet. Mirrors Swift
+     *  `Repository.strapStepTicks` + the WorkoutDetailView scaling; the phone-pedometer fallback iOS adds is
+     *  not available on Android (no cheap windowed step source), so a 4.0 window simply shows no steps. */
+    suspend fun workoutSteps(from: Long, to: Long): Int? {
+        if (to <= from) return null
+        val samples = runCatching { repository.stepSamples(deviceId, from, to) }.getOrDefault(emptyList())
+        val ticks = com.noop.analytics.StepsCounter.stepsInWindow(samples) ?: return null
+        val scaled = (ticks.toDouble() / maxOf(profileStore.stepTicksPerStep, 0.5)).roundToInt()
+        return if (scaled > 0) scaled else null
+    }
+
     /** Save a retroactive / edited manual workout, then reload. [replacing] is the original on edit. */
     fun saveManualWorkout(row: WorkoutRow, replacing: WorkoutRow? = null) {
         viewModelScope.launch {

--- a/android/app/src/main/java/com/noop/ui/WorkoutsScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/WorkoutsScreen.kt
@@ -1244,8 +1244,12 @@ private fun WorkoutDetailSheet(vm: AppViewModel, row: WorkoutRow, onDismiss: () 
     var hrCurve by remember(row.startTs) { mutableStateOf<List<Double>>(emptyList()) }
     var zoneMinutes by remember(row.startTs) { mutableStateOf<List<Double>?>(null) }
     var zonesFromImport by remember(row.startTs) { mutableStateOf(false) }
+    // Steps for an on-foot sport (#398): the strap's own counter over the window, computed at display time
+    // so it "fills in after sync". null for non-foot sports or when no strap counter covers the window.
+    var steps by remember(row.startTs) { mutableStateOf<Int?>(null) }
     LaunchedEffect(row.startTs, row.endTs) {
         hrCurve = vm.workoutHrBuckets(row.startTs, row.endTs).map { it.avgBpm }
+        steps = if (WorkoutSport.isOnFoot(row.sport)) vm.workoutSteps(row.startTs, row.endTs) else null
         val imported = parseZonePercents(row.zonesJSON)
         if (imported != null) {
             val durMin = (row.durationS ?: (row.endTs - row.startTs).toDouble()) / 60.0
@@ -1298,6 +1302,7 @@ private fun WorkoutDetailSheet(vm: AppViewModel, row: WorkoutRow, onDismiss: () 
                 val unitSystem = UnitPrefs.system(LocalContext.current)
                 DetailRow("Distance", UnitFormatter.distanceFromKilometers(row.distanceM / 1000.0, unitSystem))
             }
+            steps?.let { DetailRow("Steps", "${grouped(it.toDouble())} steps") }  // #398, on-foot sports
             if (!row.notes.isNullOrBlank()) DetailRow("Notes", row.notes)
 
             // #796 - per-session Effort contribution. The session's captured strain re-homed from a plain

--- a/android/app/src/test/java/com/noop/analytics/StepsCounterTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/StepsCounterTest.kt
@@ -1,0 +1,54 @@
+package com.noop.analytics
+
+import com.noop.data.StepSample
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * Unit tests for the shared windowed step kernel [StepsCounter.stepsInWindow] (#398). The same wrap-aware
+ * positive-delta math the daily total uses (see StepsAnalyticsTest), but exercised directly and
+ * order-independently so a manual-workout window can reuse it. Returns the RAW motion-tick total (before
+ * the caller's `stepTicksPerStep` calibration). Byte-for-byte twin of the Swift StepsCounterTests.
+ */
+class StepsCounterTest {
+
+    private fun step(ts: Long, counter: Int) = StepSample(deviceId = "my-whoop", ts = ts, counter = counter)
+
+    @Test fun sumsPositiveConsecutiveDeltas() {
+        // counters 100 -> 150 -> 220 => deltas 50 + 70 = 120
+        assertEquals(120, StepsCounter.stepsInWindow(listOf(step(0, 100), step(60, 150), step(120, 220))))
+    }
+
+    @Test fun sortsUnorderedInput() {
+        // Same three samples shuffled — the kernel sorts by ts, so the result is identical (120).
+        assertEquals(120, StepsCounter.stepsInWindow(listOf(step(120, 220), step(0, 100), step(60, 150))))
+    }
+
+    @Test fun handlesU16Wraparound() {
+        // 65500 -> 20 wraps: (20 - 65500) and 0xFFFF = 56; then 20 -> 80 => 60. Total 116.
+        assertEquals(116, StepsCounter.stepsInWindow(listOf(step(0, 65_500), step(60, 20), step(120, 80))))
+    }
+
+    @Test fun fewerThanTwoSamplesIsNull() {
+        assertNull(StepsCounter.stepsInWindow(emptyList()))
+        assertNull(StepsCounter.stepsInWindow(listOf(step(0, 100))))
+    }
+
+    @Test fun noForwardMovementIsNull() {
+        // Flat counter across the window => no positive delta => null (not 0).
+        assertNull(StepsCounter.stepsInWindow(listOf(step(0, 500), step(60, 500), step(120, 500))))
+    }
+
+    @Test fun dropsBigGapDeltaAsBoundary() {
+        // A jump >= 512 is dropped; the real 40 + 30 survive => 70.
+        assertEquals(70, StepsCounter.stepsInWindow(
+            listOf(step(0, 100), step(60, 140), step(120, 5_000), step(180, 5_030))))
+    }
+
+    @Test fun maxStepDeltaBoundaryIsExclusive() {
+        // Exactly MAX_STEP_DELTA (512) is dropped; 511 counts.
+        assertNull(StepsCounter.stepsInWindow(listOf(step(0, 0), step(60, 512))))
+        assertEquals(511, StepsCounter.stepsInWindow(listOf(step(0, 0), step(60, 511))))
+    }
+}

--- a/project.yml
+++ b/project.yml
@@ -257,6 +257,7 @@ targets:
         NSLocationWhenInUseUsageDescription: "NOOP records your route during an outdoor workout to show distance, pace, and a map, and keeps recording while the screen is off. The route stays on your device. Nothing leaves it."
         NSHealthShareUsageDescription: "NOOP reads your own Apple Health data on-device to compute recovery, strain, and sleep. Nothing leaves your device."
         NSHealthUpdateUsageDescription: "NOOP writes the metrics it computes from your strap back into Apple Health, on-device and only when you allow it."
+        NSMotionUsageDescription: "NOOP reads your iPhone's step count for a walking or running workout to show steps in the activity summary. It stays on your device. Nothing leaves it."
         # #187: the opt-in AI Coach's "Custom (OpenAI-compatible)" provider can point at a LOCAL LLM on
         # the LAN (Ollama / LM Studio at http://192.168.x.x:11434). ATS blocks cleartext by default;
         # NSAllowsLocalNetworking exempts loopback/.local/private-LAN hosts ONLY — public HTTPS endpoints


### PR DESCRIPTION
Closes #398.

## What

A Walking / On-Foot workout captured HR and Effort but never **steps**. This surfaces them in the saved-workout summary (`WorkoutDetailView` / Android workout detail), computed **at display time** over the session window `[startTs, endTs]` — so it "fills in after sync" with **no schema migration**.

Only for on-foot sports {Running, Walking, Hiking, Treadmill run, Treadmill walk} — cycling/rowing/etc. have no footfalls and are untouched.

## How

**Shared kernel (byte-parity).** Extracted the wrap-aware counter→steps math from `AnalyticsEngine.analyzeDay` into a pure `StepsCounter.stepsInWindow` (sum of positive consecutive `step_motion_counter@57` deltas, u16 wrap-aware, 512 jump-guard; `nil` for <2 samples / no movement). `analyzeDay` now calls it, so the daily and per-workout totals **can never disagree** — the existing `StepsDailyTests` stay green (behaviour-preserving refactor). Kotlin twin `StepsCounter.kt` + JVM test mirror the Swift vectors value-for-value.

**iOS — hybrid source (per the issue's data path).** `WorkoutDetailView` prefers the strap's own counter (`Repository.strapStepTicks`, active-strap-first, **never merged** across devices — two cumulative counters must not be interleaved) and falls back to a **one-shot historical** `CMPedometer` query (`WorkoutPedometer`) for a WHOOP 4.0 / CSV-import / not-yet-synced window. Renders a STEPS `StatTile` (`metricCyan`) with an honest strap/phone caption, mirroring TodayView's real-vs-est treatment. Adds `NSMotionUsageDescription` for the pedometer.

**Android twin.** `WorkoutSport.isOnFoot` + `AppViewModel.workoutSteps` surface the strap-counter steps in the workout detail via the same shared kernel and the same `stepTicksPerStep` calibration.

## Parity note (deliberate asymmetry)

The **phone-pedometer fallback is iOS-only** — `CMPedometer` has no cheap windowed Android analogue (Android's phone steps come from Health Connect per-*day* calibration, not a queryable window). So on Android a WHOOP-4 / CSV-import window simply shows no steps. The **shared analytics kernel and strap data stay byte-identical** across platforms (the parity contract); the phone fallback is a platform-capability difference, which the "UI parity is feature-level" rule permits. A Health-Connect windowed read would be a separate follow-up.

## Verification

No CI covers app-target Swift, so built/tested locally (Xcode 26.6 / JDK 17):

| Check | Result |
|---|---|
| `swift test StrandAnalytics` (Steps) | **61 passed** (new `StepsCounterTests` + `StepsDailyTests` unchanged) |
| `./gradlew compileFullDebugKotlin` + `StepsCounterTest`/`StepsAnalyticsTest` | **BUILD SUCCESSFUL** |
| `Strand` (macOS) | **BUILD SUCCEEDED** |
| `NOOPiOS` (iOS Simulator) | **BUILD SUCCEEDED** |

**On-device caveat:** the reconciled number depends on the Motion permission grant and the strap having offloaded the window — neither is reproducible in a unit test or the simulator. Please confirm on an iPhone: record a real Walking activity, open the saved workout, and verify a sane step count appears (pedometer immediately; strap count once an MG syncs), and that non-foot sports show no steps row.