### PR TITLE
Fix carried Charge source label

### DIFF
--- a/android/app/src/main/java/com/noop/ui/TodayScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/TodayScreen.kt
@@ -864,6 +864,20 @@ fun TodayScreen(
             prior.recovery?.let { LastCharge(it, carriedCaption(prior.day, carryOverTodayKey)) }
         }
     }
+    var carriedRecoverySource by remember { mutableStateOf<String?>(null) }
+    LaunchedEffect(lastScoredRecoveryDay?.day, viewModel.activeStrapId) {
+        val carriedDay = lastScoredRecoveryDay?.day
+        carriedRecoverySource = if (carriedDay == null) {
+            null
+        } else {
+            runCatching {
+                viewModel.repo.resolvedSeries("recovery", "my-whoop", carriedDay, carriedDay,
+                    strapDeviceId = viewModel.activeStrapId)
+                    .points.lastOrNull { it.day == carriedDay }
+                    ?.source
+            }.getOrNull()
+        }
+    }
 
     // Explainability (COMPONENT 2): the honest state of the score side for TODAY, scored / calibrating /
     // carried-last-night / needs-strap. One state, never a bare blank, and never a fabricated number. Only
@@ -883,10 +897,11 @@ fun TodayScreen(
 
     // One honest card-level badge, matching LiquidTodayView: identical winners collapse to one label;
     // mixed winners show at most two sources in Charge / Effort / Rest order so the pill stays compact.
-    val heroSourceLabel = remember(provenanceByMetric, viewModel.activeStrapId) {
-        heroSourceLabel(
-            rawSources = listOf("recovery", "strain", "sleep_performance")
-                .mapNotNull { provenanceByMetric[it] },
+    val heroSourceLabel = remember(provenanceByMetric, carriedRecoverySource, displayMetric?.recovery, lastScoredCharge, viewModel.activeStrapId) {
+        scoreHeroSourceLabel(
+            provenanceByMetric = provenanceByMetric,
+            carriedRecoverySource = carriedRecoverySource,
+            usesCarriedRecovery = displayMetric?.recovery == null && lastScoredCharge != null,
             deviceId = viewModel.activeStrapId,
         )
     }
@@ -4145,6 +4160,30 @@ internal fun heroSourceLabel(
         if (labels.size == 2) break
     }
     return labels.takeIf { it.isNotEmpty() }?.joinToString(" + ")
+}
+
+/**
+ * Source label for the three visible hero scores. Today can show a carried Charge from the previous
+ * scored night while today's recovery is still absent (#543); in that state the selected-day
+ * "recovery" provenance is also absent, so use the carried night's resolved recovery source instead of
+ * letting the card badge omit or misrepresent the visible Charge (#390).
+ */
+internal fun scoreHeroSourceLabel(
+    provenanceByMetric: Map<String, String>,
+    carriedRecoverySource: String?,
+    usesCarriedRecovery: Boolean,
+    deviceId: String = WhoopRepository.WHOOP_SOURCE,
+): String? {
+    val recoverySource = provenanceByMetric["recovery"]
+        ?: if (usesCarriedRecovery) carriedRecoverySource else null
+    return heroSourceLabel(
+        rawSources = listOfNotNull(
+            recoverySource,
+            provenanceByMetric["strain"],
+            provenanceByMetric["sleep_performance"],
+        ),
+        deviceId = deviceId,
+    )
 }
 
 /** The tint for a per-metric provenance badge, keyed on the resolved LABEL, gold for Whoop, cyan for

--- a/android/app/src/test/java/com/noop/ui/TodayExplainabilityTest.kt
+++ b/android/app/src/test/java/com/noop/ui/TodayExplainabilityTest.kt
@@ -328,4 +328,39 @@ class TodayExplainabilityTest {
     fun liquidHeroSourceLabel_hidesWhenNoScoreHasAResolvedSource() {
         assertNull(heroSourceLabel(emptyList()))
     }
+
+    @Test
+    fun liquidHeroSourceLabel_usesCarriedChargeSourceWhenTodayRecoveryIsAbsent() {
+        assertEquals(
+            "On-device",
+            scoreHeroSourceLabel(
+                provenanceByMetric = emptyMap(),
+                carriedRecoverySource = "my-whoop-noop",
+                usesCarriedRecovery = true,
+            ),
+        )
+    }
+
+    @Test
+    fun liquidHeroSourceLabel_keepsCurrentDayRecoveryAheadOfCarriedFallback() {
+        assertEquals(
+            "Whoop",
+            scoreHeroSourceLabel(
+                provenanceByMetric = mapOf("recovery" to "my-whoop"),
+                carriedRecoverySource = "my-whoop-noop",
+                usesCarriedRecovery = true,
+            ),
+        )
+    }
+
+    @Test
+    fun liquidHeroSourceLabel_ignoresCarriedSourceWhenChargeIsNotCarried() {
+        assertNull(
+            scoreHeroSourceLabel(
+                provenanceByMetric = emptyMap(),
+                carriedRecoverySource = "my-whoop-noop",
+                usesCarriedRecovery = false,
+            ),
+        )
+    }
 }


### PR DESCRIPTION
## Summary

- Resolve the Today hero source label for carried Charge from the prior scored recovery day.
- Reuse the existing per-metric provenance label path so `*-noop` recovery sources display as `On-device`.
- Add focused Today explainability tests for carried Charge source labels.

## Why

Fixes #390.

Today can show a carried Charge while the current day has no recovery score yet. In that state, the current-day `recovery` provenance is also absent, so the hero source label could omit or misrepresent the source behind the visible Charge value.

This PR looks up the carried night's resolved recovery source and uses it only for that carried Charge case. Current-day recovery provenance still wins when it exists, so imported WHOOP data continues to display as `Whoop`; a NOOP-computed carried Charge displays as `On-device`.

## Test

- `cd android && ./gradlew :app:testFullDebugUnitTest --tests 'com.noop.ui.TodayExplainabilityTest'`
