### PR TITLE
stress: baseline-relative daytime mode + Oura-comparable high-stress minutes

### DIFF
--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/Baselines.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/Baselines.swift
@@ -158,17 +158,21 @@ public enum Baselines {
 
         // Daytime/waking-hours configs (DaytimeStress baseline-relative mode, added alongside
         // the day-relative default). Distinct from "resting_hr"/"hrv" above, which each fold ONE
-        // NIGHTLY value (sleep). These fold ONE DAYTIME aggregate per day (e.g. that day's own
-        // calm-hour HR / RMSSD reference — see DaytimeStress.calmReference) into a cross-day
+        // NIGHTLY value (sleep). These fold ONE DAYTIME aggregate per day into a cross-day
         // PERSONAL baseline, so a caller can hand the resulting BaselineState to
         // `DaytimeStress.analyze(mode: .baselineRelative(hr:rmssd:))` and z-score each waking
         // hour against "how MY days usually run" rather than "how today's own calm hours ran".
-        // TUNING SEAM: minVal/maxVal/floorSpread/half-life below are a documented first pass —
-        // daytime HR/RMSSD are not yet validated against Oura's own baseline windows. A
-        // validation pass against real Oura export data may refine these. floorSpread is wider
-        // than the nightly "hrv" config for RMSSD: daytime RMSSD carries more incidental noise
-        // (posture changes, talking, movement between "calm" hours) than overnight recumbent
-        // HRV, so its floor tolerates more day-to-day spread before flagging a real deviation.
+        //
+        // VALIDATED (26-day Oura-reference correlation, HR-only, r≈0.6): the per-day value to
+        // fold for "daytime_hr" is that day's 10th-percentile daytime HR (~65 bpm pooled across
+        // the reference set) — NOT the day-relative calmReference's 25th-percentile quartile.
+        // The "high stress" cutoff itself is a validated fixed bpm margin over this baseline,
+        // NOT this config's floorSpread — see DaytimeStress.baselineRelativeHighMarginBPM.
+        // TUNING SEAM: minVal/maxVal/half-life below (and all of "daytime_rmssd" — RMSSD wasn't
+        // part of the validated HR-only comparison) are a documented first pass, refinable once
+        // an HR+HRV comparison exists. floorSpread is wider than the nightly "hrv" config for
+        // RMSSD: daytime RMSSD carries more incidental noise (posture changes, talking, movement
+        // between "calm" hours) than overnight recumbent HRV.
         "daytime_hr": MetricCfg(minVal: 35.0, maxVal: 160.0, floorSpread: 3.0,
                                 halfLifeB: 14.0, halfLifeS: 21.0),
         "daytime_rmssd": MetricCfg(minVal: 5.0, maxVal: 250.0, floorSpread: 7.0,

--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/Baselines.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/Baselines.swift
@@ -155,12 +155,34 @@ public enum Baselines {
                           halfLifeB: 14.0, halfLifeS: 21.0),
         "skin_temp": MetricCfg(minVal: 20.0, maxVal: 42.0, floorSpread: 0.3,
                                halfLifeB: 14.0, halfLifeS: 21.0),
+
+        // Daytime/waking-hours configs (DaytimeStress baseline-relative mode, added alongside
+        // the day-relative default). Distinct from "resting_hr"/"hrv" above, which each fold ONE
+        // NIGHTLY value (sleep). These fold ONE DAYTIME aggregate per day (e.g. that day's own
+        // calm-hour HR / RMSSD reference — see DaytimeStress.calmReference) into a cross-day
+        // PERSONAL baseline, so a caller can hand the resulting BaselineState to
+        // `DaytimeStress.analyze(mode: .baselineRelative(hr:rmssd:))` and z-score each waking
+        // hour against "how MY days usually run" rather than "how today's own calm hours ran".
+        // TUNING SEAM: minVal/maxVal/floorSpread/half-life below are a documented first pass —
+        // daytime HR/RMSSD are not yet validated against Oura's own baseline windows. A
+        // validation pass against real Oura export data may refine these. floorSpread is wider
+        // than the nightly "hrv" config for RMSSD: daytime RMSSD carries more incidental noise
+        // (posture changes, talking, movement between "calm" hours) than overnight recumbent
+        // HRV, so its floor tolerates more day-to-day spread before flagging a real deviation.
+        "daytime_hr": MetricCfg(minVal: 35.0, maxVal: 160.0, floorSpread: 3.0,
+                                halfLifeB: 14.0, halfLifeS: 21.0),
+        "daytime_rmssd": MetricCfg(minVal: 5.0, maxVal: 250.0, floorSpread: 7.0,
+                                   halfLifeB: 14.0, halfLifeS: 21.0),
     ]
 
     /// Convenience accessors for the standard configs.
     public static var hrvCfg: MetricCfg { metricCfg["hrv"]! }
     public static var restingHRCfg: MetricCfg { metricCfg["resting_hr"]! }
     public static var respCfg: MetricCfg { metricCfg["resp"]! }
+    /// Personal daytime/waking HR baseline config — see the `daytime_hr` comment above.
+    public static var daytimeHRCfg: MetricCfg { metricCfg["daytime_hr"]! }
+    /// Personal daytime/waking RMSSD baseline config — see the `daytime_rmssd` comment above.
+    public static var daytimeRMSSDCfg: MetricCfg { metricCfg["daytime_rmssd"]! }
 
     /// Convert a half-life in nights to an EWMA smoothing factor.
     static func lambda(halfLife: Double) -> Double {
@@ -339,12 +361,20 @@ public enum Baselines {
 
     // MARK: - Deviation
 
+    /// Convert a state's EWMA-abs-dev spread to an approximate Gaussian σ: 1.253 × spread,
+    /// floored so a caller never divides by ~0. 1.253 is E[|X−μ|] = σ·√(2/π) inverted
+    /// (E[|X−μ|] ≈ σ/1.253 for a Gaussian). Shared by `deviation()` below and by any other
+    /// z-scoring caller (e.g. `DaytimeStress`'s baseline-relative mode) so the conversion has
+    /// exactly one definition.
+    public static func sigma(_ state: BaselineState) -> Double {
+        max(1.253 * state.spread, 1e-9)
+    }
+
     /// Compute z / delta / ratio / in-normal-range for a value vs a baseline.
-    /// z uses (value − baseline) / (1.253 × spread); 1.253 converts EWMA-abs-dev
-    /// to an approximate Gaussian σ (E[|X−μ|] = σ·√(2/π) ≈ σ/1.253).
+    /// z uses (value − baseline) / sigma(state); see `sigma(_:)` for the 1.253 conversion.
     public static func deviation(_ value: Double, state: BaselineState) -> Deviation {
-        let sigma = max(1.253 * state.spread, 1e-9)
-        let z = (value - state.baseline) / sigma
+        let sig = sigma(state)
+        let z = (value - state.baseline) / sig
         let delta = value - state.baseline
         let ratio = state.baseline != 0 ? (value / state.baseline - 1.0) : 0.0
         return Deviation(z: z, delta: delta, ratio: ratio, inNormalRange: abs(z) <= 1.0)

--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/DaytimeStress.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/DaytimeStress.swift
@@ -42,6 +42,36 @@ public enum DaytimeStress {
     public static let wakingStartHour: Int = 6
     public static let wakingEndHour: Int = 22
 
+    // MARK: - Scoring mode
+
+    /// WHERE each hour's "calm" reference point + spread come from. Every other step —
+    /// bucketing, the waking-hour filter, the squash curve, sustained-high, high-stress-minutes
+    /// — is identical between modes; only the reference differs.
+    public enum ScoringMode: Equatable, Sendable {
+        /// DEFAULT — unchanged from before this mode existed. Each hour is z-scored against
+        /// THIS DAY's own calm-hour reference (`calmReference`): the lower quartile of the
+        /// day's own waking-hour mean HR, the upper quartile of its own waking-hour RMSSD. No
+        /// personal history needed — the day is its own baseline. Byte-identical output to the
+        /// pre-existing single-mode `analyze` for the same hr/rr/tzOffsetSeconds.
+        case dayRelative
+
+        /// Oura-style — each hour is z-scored against the PERSONAL rolling baseline for daytime
+        /// HR (and, when available, daytime RMSSD): the SAME Winsorized-EWMA machinery
+        /// (`Baselines.update` / `Baselines.foldHistory`) that backs the nightly HRV /
+        /// resting-HR baselines elsewhere in the app, using `Baselines.metricCfg["daytime_hr"]`
+        /// / `["daytime_rmssd"]` (see `Baselines.daytimeHRCfg` / `daytimeRMSSDCfg`). A caller
+        /// builds `hr` (and, when it has the history, `rmssd`) by folding this person's past
+        /// daytime aggregates — e.g. day N's `calmReference` output — the same way the nightly
+        /// baselines are folded from past nights.
+        ///
+        /// `rmssd` is `nil` when no personal RMSSD baseline exists yet — e.g. an imported,
+        /// Oura-era day with no R-R stream, so there is no history to fold one from. The
+        /// stressor then honestly falls back to HR-only scoring for the whole read and flags
+        /// `Result.hrOnlyFallback`; this mirrors the per-hour graceful-nil already in
+        /// `rawScore`, just at the whole-baseline grain instead of the single-hour grain.
+        case baselineRelative(hr: BaselineState, rmssd: BaselineState?)
+    }
+
     // MARK: - Output
 
     /// One hour of the daytime timeline. `level` is the shared 0–3 stress proxy, or nil
@@ -82,14 +112,30 @@ public enum DaytimeStress {
         public let dayMean: Double?
         /// Peak scored hour (highest `level`), or nil.
         public let peak: HourPoint?
+        /// ADDITIVE — total minutes across SCORED waking hours at/above `highBandFloor`, the
+        /// Oura-comparable "time in high stress" figure. Each scored hour is one `bucketSeconds`
+        /// bucket, so this is `(# high-band scored hours) * bucketSeconds / 60`. Compare against
+        /// Oura's `stress_high_s / 60` — NOOP's timeline is hourly-grain vs Oura's ~5-minute
+        /// grain, so treat this as a coarse approximation, not a precise match. 0 for `.empty`
+        /// and for any day with no scored hours.
+        public let highStressMinutes: Int
+        /// ADDITIVE — true when `.baselineRelative` mode was requested but had no personal RMSSD
+        /// baseline to score against (e.g. an imported Oura-era day with no R-R history), so the
+        /// whole read honestly fell back to HR-only scoring. Always false in `.dayRelative` mode
+        /// (there, a missing RMSSD is already handled per-hour by `rawScore`, not flagged
+        /// day-wide) and false for `.empty`.
+        public let hrOnlyFallback: Bool
 
         public init(hours: [HourPoint], sustainedHigh: Bool, sustainedRun: Int,
-                    dayMean: Double?, peak: HourPoint?) {
+                    dayMean: Double?, peak: HourPoint?,
+                    highStressMinutes: Int = 0, hrOnlyFallback: Bool = false) {
             self.hours = hours
             self.sustainedHigh = sustainedHigh
             self.sustainedRun = sustainedRun
             self.dayMean = dayMean
             self.peak = peak
+            self.highStressMinutes = highStressMinutes
+            self.hrOnlyFallback = hrOnlyFallback
         }
 
         /// The scored hours only (level non-nil), in time order.
@@ -97,7 +143,8 @@ public enum DaytimeStress {
 
         /// Empty read — used when the day had no usable intraday HR at all.
         public static let empty = Result(hours: [], sustainedHigh: false, sustainedRun: 0,
-                                         dayMean: nil, peak: nil)
+                                         dayMean: nil, peak: nil,
+                                         highStressMinutes: 0, hrOnlyFallback: false)
     }
 
     // MARK: - Shared stress math (identical formula to the daily StressModel)
@@ -144,25 +191,52 @@ public enum DaytimeStress {
     ///   - rr: the day's `[RRInterval]`.
     ///   - tzOffsetSeconds: seconds east of UTC, for placing each bucket on the LOCAL
     ///     clock (so "waking hours" and the hour labels are local). Defaults to UTC.
+    ///   - mode: `.dayRelative` (DEFAULT — unchanged existing behaviour) or
+    ///     `.baselineRelative` (Oura-style, vs a personal rolling baseline). ADDITIVE and
+    ///     opt-in: existing callers that don't pass `mode` keep the exact prior behaviour.
     ///
     /// Returns `.empty` when there isn't a single hour with enough HR to score.
     public static func analyze(hr: [HRSample], rr: [RRInterval],
-                               tzOffsetSeconds: Int = 0) -> Result {
+                               tzOffsetSeconds: Int = 0,
+                               mode: ScoringMode = .dayRelative) -> Result {
         // v7.0.2 perf (#707): buckets the day's full HR + R-R streams into per-hour aggregates and runs an
         // RMSSD per hour — invoked from the Stress view, so a `body` re-evaluation re-buckets the whole day.
-        // Memoize on the streams' fingerprint + tz offset; result is a small `Result`, raw arrays not held.
+        // Memoize on the streams' fingerprint + tz offset + scoring mode; result is a small `Result`, raw
+        // arrays not held. The mode key folds in only (baseline, spread) for baseline-relative — the two
+        // fields that can change the score — not the whole BaselineState (nValid/status/etc. never do).
+        let modeKey: ModeKey
+        switch mode {
+        case .dayRelative:
+            modeKey = .dayRelative
+        case .baselineRelative(let hrBaseline, let rmssdBaseline):
+            modeKey = .baselineRelative(hrBaseline: hrBaseline.baseline, hrSpread: hrBaseline.spread,
+                                        rmssdBaseline: rmssdBaseline?.baseline, rmssdSpread: rmssdBaseline?.spread)
+        }
         let key = StressKey(
             hr: StreamFingerprint.of(hr, ts: { $0.ts }, quant: { Int($0.bpm) }),
             rr: StreamFingerprint.of(rr, ts: { $0.ts }, quant: { Int($0.rrMs) }),
-            tz: tzOffsetSeconds)
-        return analyzeCache.value(key) { analyzeUncached(hr: hr, rr: rr, tzOffsetSeconds: tzOffsetSeconds) }
+            tz: tzOffsetSeconds, mode: modeKey)
+        return analyzeCache.value(key) {
+            analyzeUncached(hr: hr, rr: rr, tzOffsetSeconds: tzOffsetSeconds, mode: mode)
+        }
     }
 
-    private struct StressKey: Hashable { let hr: StreamFingerprint; let rr: StreamFingerprint; let tz: Int }
+    private struct StressKey: Hashable {
+        let hr: StreamFingerprint; let rr: StreamFingerprint; let tz: Int; let mode: ModeKey
+    }
+
+    /// Hashable fingerprint of `ScoringMode` for the memo cache — `BaselineState` itself isn't
+    /// `Hashable`, and only its `baseline`/`spread` can change the score, so those are what get
+    /// folded in (see the `analyze` doc above).
+    private enum ModeKey: Hashable {
+        case dayRelative
+        case baselineRelative(hrBaseline: Double, hrSpread: Double, rmssdBaseline: Double?, rmssdSpread: Double?)
+    }
+
     private static let analyzeCache = AnalyticsMemoCache<StressKey, Result>(capacity: 8)
 
     private static func analyzeUncached(hr: [HRSample], rr: [RRInterval],
-                                        tzOffsetSeconds: Int) -> Result {
+                                        tzOffsetSeconds: Int, mode: ScoringMode) -> Result {
         guard !hr.isEmpty else { return .empty }
 
         // 1) Bucket HR + R-R into LOCAL hour-of-day buckets, keyed by the bucket start
@@ -194,25 +268,57 @@ public enum DaytimeStress {
             aggs.append(HourAgg(bucket: b, meanHR: mHR, rmssd: rrRes.rmssd, nHR: hrs.count))
         }
 
-        // 3) The day's OWN quiet reference: centre on the CALM end (the lower quartile of
-        //    hourly mean HR, the upper quartile of hourly RMSSD), and spread from the
-        //    across-hour SD. This makes a flat day read ~baseline and a spiky day surface
-        //    its tense hours — without any cross-day history. Falls back to the plain mean
-        //    when there are too few scored hours for a quartile.
-        //
-        //    Built from the WAKING hours only — the same hours scored in step 4. Sleep is the
-        //    calmest, lowest-HR / highest-HRV stretch of the day, and the analysis window
-        //    always begins at local midnight, so the current day routinely carries several
-        //    hours of it. Letting those night hours into the reference drags the "calm" anchor
-        //    far beneath every waking hour, inflating an ordinary calm day toward HIGH and
-        //    falsely tripping the sustained-high Breathe nudge.
-        let referenceAggs = aggs.filter { isWakingHour($0.bucket) }
-        let hrMeans = referenceAggs.compactMap { $0.meanHR }
-        let rmssdVals = referenceAggs.compactMap { $0.rmssd }
-        let refHR = calmReference(hrMeans, calmIsLow: true)         // calm HR is LOW
-        let refRMSSD = calmReference(rmssdVals, calmIsLow: false)   // calm HRV is HIGH
-        let sdHR = std(hrMeans, mean: mean(hrMeans))
-        let sdRMSSD = std(rmssdVals, mean: mean(rmssdVals))
+        // 3) The reference point + spread for each signal — WHERE they come from depends on
+        //    `mode`. Every other step (bucketing above, the waking-hour filter, the squash
+        //    curve, sustained-high, high-stress-minutes below) is identical between modes.
+        let refHR: Double?
+        let sdHR: Double
+        let refRMSSD: Double?
+        let sdRMSSD: Double
+        let hrOnlyFallback: Bool
+        switch mode {
+        case .dayRelative:
+            // The day's OWN quiet reference: centre on the CALM end (the lower quartile of
+            // hourly mean HR, the upper quartile of hourly RMSSD), and spread from the
+            // across-hour SD. This makes a flat day read ~baseline and a spiky day surface
+            // its tense hours — without any cross-day history. Falls back to the plain mean
+            // when there are too few scored hours for a quartile.
+            //
+            // Built from the WAKING hours only — the same hours scored in step 4. Sleep is the
+            // calmest, lowest-HR / highest-HRV stretch of the day, and the analysis window
+            // always begins at local midnight, so the current day routinely carries several
+            // hours of it. Letting those night hours into the reference drags the "calm" anchor
+            // far beneath every waking hour, inflating an ordinary calm day toward HIGH and
+            // falsely tripping the sustained-high Breathe nudge.
+            let referenceAggs = aggs.filter { isWakingHour($0.bucket) }
+            let hrMeans = referenceAggs.compactMap { $0.meanHR }
+            let rmssdVals = referenceAggs.compactMap { $0.rmssd }
+            refHR = calmReference(hrMeans, calmIsLow: true)         // calm HR is LOW
+            refRMSSD = calmReference(rmssdVals, calmIsLow: false)   // calm HRV is HIGH
+            sdHR = std(hrMeans, mean: mean(hrMeans))
+            sdRMSSD = std(rmssdVals, mean: mean(rmssdVals))
+            hrOnlyFallback = false
+
+        case .baselineRelative(let hrBaseline, let rmssdBaseline):
+            // The PERSONAL cross-day baseline, folded by the caller from past daytime
+            // aggregates via `Baselines.update`/`foldHistory` (see the `ScoringMode` doc).
+            // `sigma` is the SAME abs-dev-to-Gaussian-σ conversion `Baselines.deviation` uses.
+            refHR = hrBaseline.baseline
+            sdHR = Baselines.sigma(hrBaseline)
+            if let rmssdBaseline {
+                refRMSSD = rmssdBaseline.baseline
+                sdRMSSD = Baselines.sigma(rmssdBaseline)
+                hrOnlyFallback = false
+            } else {
+                // No personal RMSSD baseline exists (e.g. an Oura-era day with no R-R history to
+                // fold one from). `rawScore` already treats a nil meanRMSSD as "skip this term",
+                // so passing nil here gracefully degrades to HR-only scoring — flagged honestly
+                // in the output rather than silently.
+                refRMSSD = nil
+                sdRMSSD = 0
+                hrOnlyFallback = true
+            }
+        }
 
         // 4) Score each waking-hour bucket on the shared 0–3 curve.
         var points: [HourPoint] = []
@@ -235,10 +341,13 @@ public enum DaytimeStress {
         let scored = points.compactMap { p -> (HourPoint, Double)? in p.level.map { (p, $0) } }
         guard !scored.isEmpty else {
             // No scorable waking hour — still return the (unscored) timeline so the UI can
-            // show "not enough data" rather than nothing.
+            // show "not enough data" rather than nothing. `hrOnlyFallback` is a MODE property
+            // (whether a personal RMSSD baseline existed to score against), so it's still worth
+            // reporting even though nothing ended up scored.
             return points.isEmpty ? .empty
                 : Result(hours: points, sustainedHigh: false, sustainedRun: 0,
-                         dayMean: nil, peak: nil)
+                         dayMean: nil, peak: nil,
+                         highStressMinutes: 0, hrOnlyFallback: hrOnlyFallback)
         }
 
         // 5) Sustained-high flag: walk back from the latest SCORED hour while each is HIGH.
@@ -251,8 +360,15 @@ public enum DaytimeStress {
         let dayMean = mean(scored.map { $0.1 })
         let peak = scored.max { $0.1 < $1.1 }?.0
 
+        // 6) Oura-comparable "time in high stress": each scored hour at/above `highBandFloor`
+        //    is one full `bucketSeconds` bucket, converted to minutes. Uses the SAME threshold
+        //    `StressBand.high` (StressView) and the sustained-high check above already use, so
+        //    all three stay in lockstep by construction.
+        let highStressMinutes = scored.filter { $0.1 >= highBandFloor }.count * (bucketSeconds / 60)
+
         return Result(hours: points, sustainedHigh: sustained, sustainedRun: run,
-                      dayMean: dayMean, peak: peak)
+                      dayMean: dayMean, peak: peak,
+                      highStressMinutes: highStressMinutes, hrOnlyFallback: hrOnlyFallback)
     }
 
     // MARK: - Helpers

--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/DaytimeStress.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/DaytimeStress.swift
@@ -42,11 +42,35 @@ public enum DaytimeStress {
     public static let wakingStartHour: Int = 6
     public static let wakingEndHour: Int = 22
 
+    /// VALIDATED (26-day Oura-reference correlation, HR-only): a personal daytime-HR elevation
+    /// of ~15 bpm over a POOLED/ROLLING baseline — the 10th-percentile daytime HR pooled across
+    /// days, ~65 bpm in the reference set — is where elevated HR starts reading as
+    /// Oura-comparable "high" stress (r≈0.6 against Oura's own stress signal). A PER-DAY
+    /// (day-relative) baseline scored WORSE in the same comparison (r 0.43–0.53): an all-day
+    /// elevated day pulls its own floor up and masks the stress, which is exactly why
+    /// `.baselineRelative` leans on `Baselines`' cross-day rolling EWMA instead of a day-local
+    /// reference. TUNING SEAM: this is HR-only; HR+HRV (WHOOP-era, RMSSD included) is expected
+    /// to beat this r≈0.6 ceiling — re-validate this margin once that comparison exists. See
+    /// `marginToSigma` for how it's translated onto the shared 0–3 squash curve.
+    public static let baselineRelativeHighMarginBPM: Double = 15.0
+
     // MARK: - Scoring mode
 
     /// WHERE each hour's "calm" reference point + spread come from. Every other step —
     /// bucketing, the waking-hour filter, the squash curve, sustained-high, high-stress-minutes
     /// — is identical between modes; only the reference differs.
+    ///
+    /// Relationship to the rest of the Stress screen (StressView.swift): the DAILY 0–3 score
+    /// (`StressModel`) already compares last night's NIGHTLY resting-HR/HRV to a plain trailing
+    /// 30-day mean/SD, computed locally in StressView (not via `Baselines`) — that's a
+    /// once-a-day number from SLEEP vitals. The Advanced HRV card (`StressIndex`,
+    /// `HRVFreqDomain`) is a today-only descriptive lens with no baseline at all. `.baselineRelative`
+    /// is neither: it's an HOURLY breakdown of TODAY from DAYTIME/waking-hours HR+RMSSD against a
+    /// PERSONAL cross-day rolling baseline. Daytime HR runs warmer than nocturnal resting HR
+    /// (posture, thermic effect), so it needs its OWN baseline (`daytime_hr`/`daytime_rmssd`,
+    /// below) rather than reusing the nightly `resting_hr`/`hrv` configs — reusing the nightly
+    /// ones would systematically over-read stress. The three surfaces are complementary lenses
+    /// on the same underlying autonomic signal, not competing implementations of one baseline.
     public enum ScoringMode: Equatable, Sendable {
         /// DEFAULT — unchanged from before this mode existed. Each hour is z-scored against
         /// THIS DAY's own calm-hour reference (`calmReference`): the lower quartile of the
@@ -61,14 +85,23 @@ public enum DaytimeStress {
         /// resting-HR baselines elsewhere in the app, using `Baselines.metricCfg["daytime_hr"]`
         /// / `["daytime_rmssd"]` (see `Baselines.daytimeHRCfg` / `daytimeRMSSDCfg`). A caller
         /// builds `hr` (and, when it has the history, `rmssd`) by folding this person's past
-        /// daytime aggregates — e.g. day N's `calmReference` output — the same way the nightly
+        /// daytime aggregates — VALIDATED as each day's 10th-percentile daytime HR (a pooled
+        /// "how low does my HR run when I'm calm and awake" floor), the same way the nightly
         /// baselines are folded from past nights.
+        ///
+        /// The HR reference point is `hr.baseline`, but the HIGH-band threshold does NOT scale
+        /// with this person's own day-to-day `hr.spread` — see `baselineRelativeHighMarginBPM`:
+        /// the validated model is a roughly FIXED bpm margin over the personal floor, not a
+        /// variability-scaled one. `hr.spread` still rides along on the passed-in state for
+        /// other consumers; this mode simply doesn't read it for the HR term.
         ///
         /// `rmssd` is `nil` when no personal RMSSD baseline exists yet — e.g. an imported,
         /// Oura-era day with no R-R stream, so there is no history to fold one from. The
         /// stressor then honestly falls back to HR-only scoring for the whole read and flags
         /// `Result.hrOnlyFallback`; this mirrors the per-hour graceful-nil already in
-        /// `rawScore`, just at the whole-baseline grain instead of the single-hour grain.
+        /// `rawScore`, just at the whole-baseline grain instead of the single-hour grain. The
+        /// RMSSD term (when present) DOES still scale by `rmssd.spread` via `Baselines.sigma` —
+        /// only the HR term has a validated fixed-margin figure so far.
         case baselineRelative(hr: BaselineState, rmssd: BaselineState?)
     }
 
@@ -180,6 +213,19 @@ public enum DaytimeStress {
     static func squash(_ raw: Double) -> Double {
         let s = 3.0 / (1.0 + exp(-raw))
         return min(max(s, 0), 3)
+    }
+
+    /// Solve for the z-score spread `sd` such that a raw elevation of exactly `marginBPM` (or any
+    /// unit — this is unit-agnostic) squashes to exactly `band` on the shared 0–3 curve:
+    /// `band = 3 / (1 + e^(−marginBPM/sd))`. Used to translate `baselineRelativeHighMarginBPM`'s
+    /// validated bpm figure into the `sd` the shared `squash` curve expects, so "baseline +
+    /// margin" lands exactly on `band` by construction rather than by a second, separate
+    /// threshold check. Defensive fallback (never divides by zero/negative-log) if `band` is
+    /// ever configured at or outside the curve's open range (0, 3).
+    static func marginToSigma(marginBPM: Double, atBand band: Double) -> Double {
+        let ratio = 3.0 / band - 1.0
+        guard ratio > 0, marginBPM > 0 else { return max(marginBPM, 1e-9) }
+        return marginBPM / (-log(ratio))
     }
 
     // MARK: - Public API
@@ -302,11 +348,18 @@ public enum DaytimeStress {
         case .baselineRelative(let hrBaseline, let rmssdBaseline):
             // The PERSONAL cross-day baseline, folded by the caller from past daytime
             // aggregates via `Baselines.update`/`foldHistory` (see the `ScoringMode` doc).
-            // `sigma` is the SAME abs-dev-to-Gaussian-σ conversion `Baselines.deviation` uses.
             refHR = hrBaseline.baseline
-            sdHR = Baselines.sigma(hrBaseline)
+            // VALIDATED tuning, not `Baselines.sigma(hrBaseline)`: the correlation study behind
+            // `baselineRelativeHighMarginBPM` found a roughly FIXED bpm margin over the personal
+            // floor — not one scaled by this person's own day-to-day spread — best matched
+            // Oura's stress signal. `marginToSigma` solves for the sd that makes exactly
+            // `refHR + baselineRelativeHighMarginBPM` land on `highBandFloor` on the shared
+            // squash curve, so the validated margin IS the "high" cutoff by construction.
+            sdHR = Self.marginToSigma(marginBPM: baselineRelativeHighMarginBPM, atBand: highBandFloor)
             if let rmssdBaseline {
                 refRMSSD = rmssdBaseline.baseline
+                // No independently validated RMSSD margin yet (see the constant's doc) — this
+                // term still scales by the person's own spread via the shared σ conversion.
                 sdRMSSD = Baselines.sigma(rmssdBaseline)
                 hrOnlyFallback = false
             } else {

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/BaselinesTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/BaselinesTests.swift
@@ -303,4 +303,26 @@ final class BaselinesTests: XCTestCase {
         XCTAssertEqual(after.nValid, 0)
         XCTAssertEqual(after.status, .calibrating)
     }
+
+    // MARK: - sigma() + daytime configs (DaytimeStress baseline-relative mode)
+
+    /// `sigma(_:)` is a pure extraction of `deviation()`'s internal conversion — must match it
+    /// exactly and stay internally consistent (deviation at baseline + sigma is z == 1.0).
+    func testSigmaMatchesDeviationsInternalConversion() {
+        let s = Baselines.foldHistory(Array(repeating: 50.0, count: 14), cfg: Baselines.hrvCfg)
+        let sigma = Baselines.sigma(s)
+        XCTAssertEqual(sigma, max(1.253 * s.spread, 1e-9), accuracy: 1e-9)
+        let dev = Baselines.deviation(s.baseline + sigma, state: s)
+        XCTAssertEqual(dev.z, 1.0, accuracy: 1e-6)
+    }
+
+    /// The new daytime_hr / daytime_rmssd configs exist, are reachable via both the dictionary
+    /// and the convenience accessor, and are distinct from the nightly resting_hr/hrv configs
+    /// they sit alongside (different bounds/floor — daytime HR runs warmer than nocturnal RHR).
+    func testDaytimeConfigsExistAndAreDistinctFromNightlyConfigs() {
+        XCTAssertEqual(Baselines.metricCfg["daytime_hr"], Baselines.daytimeHRCfg)
+        XCTAssertEqual(Baselines.metricCfg["daytime_rmssd"], Baselines.daytimeRMSSDCfg)
+        XCTAssertNotEqual(Baselines.daytimeHRCfg, Baselines.restingHRCfg)
+        XCTAssertNotEqual(Baselines.daytimeRMSSDCfg, Baselines.hrvCfg)
+    }
 }

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/DaytimeStressTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/DaytimeStressTests.swift
@@ -132,4 +132,135 @@ final class DaytimeStressTests: XCTestCase {
         let base = hour * 3_600
         return (0..<n).map { RRInterval(ts: base + $0 * 50, rrMs: rrMs + ($0 % 2 == 0 ? jitter : -jitter)) }
     }
+
+    // MARK: - Additivity: the `mode` parameter is opt-in, day-relative stays the default
+
+    func testDayRelativeDefaultIsByteIdenticalToExplicitMode() {
+        // The additive `mode` parameter defaults to `.dayRelative`. Confirms the implicit call
+        // (every pre-existing call site, unmodified) and the explicit `.dayRelative` case
+        // produce a BYTE-IDENTICAL `Result` — every field, not just the pre-existing ones —
+        // proving the new mode is purely additive and never a silent behaviour change.
+        var hr: [HRSample] = []
+        for h in [8, 9, 10] { hr += hourHR(h, bpm: 58) }
+        hr += hourHR(13, bpm: 120)
+        hr += hourHR(14, bpm: 125)
+        hr += hourHR(15, bpm: 130)
+        var rr: [RRInterval] = []
+        rr += hourRRVariable(9, rrMs: 900, jitter: 40)
+        rr += hourRRVariable(14, rrMs: 900, jitter: 5)
+
+        let implicit = DaytimeStress.analyze(hr: hr, rr: rr, tzOffsetSeconds: 3_600)
+        let explicit = DaytimeStress.analyze(hr: hr, rr: rr, tzOffsetSeconds: 3_600, mode: .dayRelative)
+        XCTAssertEqual(implicit, explicit,
+            "omitting `mode` must be byte-identical to passing `.dayRelative` explicitly")
+    }
+
+    func testHighStressMinutesCountsAllHighBandHoursNotJustTheTrailingRun() {
+        // An isolated morning spike, then a calm run ending the day: sustainedHigh only cares
+        // about the TRAILING run (and must be false here, since the day ends calm), but
+        // highStressMinutes is a day-wide tally and must still count the earlier spike hour —
+        // proving it is computed independently, not derived from sustainedRun.
+        var hr: [HRSample] = []
+        hr += hourHR(7, bpm: 130)   // isolated high spike
+        hr += hourHR(8, bpm: 60)
+        hr += hourHR(9, bpm: 60)
+        hr += hourHR(10, bpm: 60)
+        hr += hourHR(11, bpm: 60)   // trailing hour is calm -> NOT sustained
+        let r = DaytimeStress.analyze(hr: hr, rr: [])
+
+        XCTAssertFalse(r.sustainedHigh, "the trailing hour is calm, so sustained-high must not fire")
+        let expectedHighHours = r.scored.filter { $0.level! >= DaytimeStress.highBandFloor }.count
+        XCTAssertGreaterThan(expectedHighHours, 0, "the isolated morning spike should read as high band")
+        XCTAssertEqual(r.highStressMinutes, expectedHighHours * (DaytimeStress.bucketSeconds / 60))
+        XCTAssertFalse(r.hrOnlyFallback, "day-relative mode never sets the baseline-relative fallback flag")
+    }
+
+    // MARK: - Baseline-relative mode (Oura-style, vs a PERSONAL rolling baseline)
+
+    func testBaselineRelativeModeRecoversMultipleInjectedElevations() {
+        // Personal daytime-HR baseline: 20 constant "days" at 60 bpm converges the EWMA center
+        // to exactly 60 with spread pinned at the daytime_hr floor (no cross-day variability).
+        let hrBaseline = Baselines.foldHistory(Array(repeating: 60.0, count: 20), cfg: Baselines.daytimeHRCfg)
+        XCTAssertEqual(hrBaseline.baseline, 60.0, accuracy: 1e-6)
+        XCTAssertEqual(hrBaseline.spread, Baselines.daytimeHRCfg.floorSpread, accuracy: 1e-9)
+
+        // FOUR distinct injected HR elevations across the SAME day's waking hours — the repo's
+        // derived-signal rule (CLAUDE.md "validate against the artifact, not one match") requires
+        // recovering MULTIPLE injected values, not a single high-vs-low pair.
+        let levels: [(hour: Int, bpm: Int)] = [(8, 60), (10, 64), (13, 68), (16, 72)]
+        var hr: [HRSample] = []
+        for (h, bpm) in levels { hr += hourHR(h, bpm: bpm) }
+
+        let r = DaytimeStress.analyze(hr: hr, rr: [], mode: .baselineRelative(hr: hrBaseline, rmssd: nil))
+        let scores = levels.map { pair in r.scored.first { $0.hour == pair.hour }!.level! }
+
+        // Strictly increasing with the injected elevation — all four levels recovered, in order.
+        for i in 1..<scores.count {
+            XCTAssertGreaterThan(scores[i], scores[i - 1],
+                "hour \(levels[i].hour) (\(levels[i].bpm) bpm) should score higher than hour \(levels[i - 1].hour) (\(levels[i - 1].bpm) bpm)")
+        }
+        // The at-baseline hour reads at the 1.5 midpoint; the most-elevated hour clears HIGH.
+        XCTAssertEqual(scores[0], 1.5, accuracy: 0.05)
+        XCTAssertGreaterThanOrEqual(scores.last!, DaytimeStress.highBandFloor)
+        XCTAssertTrue(r.hrOnlyFallback, "rmssd: nil must flag the HR-only fallback")
+    }
+
+    func testBaselineRelativeCalmDayAtPersonalBaselineReadsLowNotHigh() {
+        let hrBaseline = Baselines.foldHistory(Array(repeating: 60.0, count: 20), cfg: Baselines.daytimeHRCfg)
+        var hr: [HRSample] = []
+        for h in [8, 10, 13, 16] { hr += hourHR(h, bpm: 60) }   // every hour sits exactly at baseline
+        let r = DaytimeStress.analyze(hr: hr, rr: [], mode: .baselineRelative(hr: hrBaseline, rmssd: nil))
+
+        for p in r.scored {
+            XCTAssertEqual(p.level!, 1.5, accuracy: 0.05,
+                "a day flat at the personal baseline should read ~1.5, not elevated")
+        }
+        XCTAssertEqual(r.highStressMinutes, 0)
+        XCTAssertFalse(r.sustainedHigh)
+    }
+
+    func testBaselineRelativeElevatedDayProducesHighStressMinutes() {
+        let hrBaseline = Baselines.foldHistory(Array(repeating: 60.0, count: 20), cfg: Baselines.daytimeHRCfg)
+        var hr: [HRSample] = []
+        for h in 8...16 { hr += hourHR(h, bpm: 95) }   // every waking hour well above the personal baseline
+        let r = DaytimeStress.analyze(hr: hr, rr: [], mode: .baselineRelative(hr: hrBaseline, rmssd: nil))
+
+        XCTAssertGreaterThan(r.highStressMinutes, 0)
+        XCTAssertEqual(r.highStressMinutes,
+                      r.scored.filter { $0.level! >= DaytimeStress.highBandFloor }.count * (DaytimeStress.bucketSeconds / 60))
+        for p in r.scored { XCTAssertGreaterThanOrEqual(p.level!, DaytimeStress.highBandFloor) }
+    }
+
+    func testBaselineRelativeNilRMSSDFallsBackToHROnlyAndFlagsDegraded() {
+        // An imported, Oura-era day: no personal RMSSD baseline exists yet (rmssd: nil) and no
+        // R-R stream is available either. The read must still complete honestly, never crash.
+        let hrBaseline = Baselines.foldHistory(Array(repeating: 60.0, count: 20), cfg: Baselines.daytimeHRCfg)
+        var hr: [HRSample] = []
+        for h in [9, 14] { hr += hourHR(h, bpm: 80) }
+        let r = DaytimeStress.analyze(hr: hr, rr: [], mode: .baselineRelative(hr: hrBaseline, rmssd: nil))
+
+        XCTAssertTrue(r.hrOnlyFallback)
+        XCTAssertFalse(r.scored.isEmpty, "HR-only scoring must still produce a timeline")
+        for p in r.scored { XCTAssertNotNil(p.level) }
+    }
+
+    func testBaselineRelativeUsesRMSSDBaselineWhenAvailable() {
+        // Personal baselines: HR steady at 65 bpm, RMSSD steady at 40 ms (both spread-floored).
+        let hrBaseline = Baselines.foldHistory(Array(repeating: 65.0, count: 20), cfg: Baselines.daytimeHRCfg)
+        let rmssdBaseline = Baselines.foldHistory(Array(repeating: 40.0, count: 20), cfg: Baselines.daytimeRMSSDCfg)
+
+        var hr: [HRSample] = []
+        var rr: [RRInterval] = []
+        for h in [9, 14] { hr += hourHR(h, bpm: 65) }        // HR AT baseline in both hours — isolates RMSSD
+        rr += hourRRVariable(9, rrMs: 900, jitter: 40)        // normal variability
+        rr += hourRRVariable(14, rrMs: 900, jitter: 2)        // suppressed HRV -> more stressed
+
+        let r = DaytimeStress.analyze(hr: hr, rr: rr,
+                                      mode: .baselineRelative(hr: hrBaseline, rmssd: rmssdBaseline))
+        XCTAssertFalse(r.hrOnlyFallback, "an RMSSD baseline was supplied — no fallback")
+        let normal = r.scored.first { $0.hour == 9 }!.level!
+        let suppressed = r.scored.first { $0.hour == 14 }!.level!
+        XCTAssertGreaterThan(suppressed, normal,
+            "suppressed RMSSD vs. the personal baseline should read MORE stressed than normal variability")
+    }
 }

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/DaytimeStressTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/DaytimeStressTests.swift
@@ -176,18 +176,33 @@ final class DaytimeStressTests: XCTestCase {
     }
 
     // MARK: - Baseline-relative mode (Oura-style, vs a PERSONAL rolling baseline)
+    //
+    // Fixtures below use a 65 bpm personal HR baseline (matching the ~65 bpm pooled
+    // 10th-percentile figure from the validated 26-day Oura-reference correlation — see
+    // `DaytimeStress.baselineRelativeHighMarginBPM`) and elevations measured from it in terms of
+    // that validated ~15 bpm margin, so the expected band crossings are exact, not approximate.
+
+    func testMarginToSigmaLandsExactlyOnBand() {
+        // The validated 15 bpm margin over baseline must land EXACTLY on highBandFloor (2.0) on
+        // the shared squash curve — the core identity `.baselineRelative` scoring relies on.
+        let sd = DaytimeStress.marginToSigma(marginBPM: DaytimeStress.baselineRelativeHighMarginBPM,
+                                             atBand: DaytimeStress.highBandFloor)
+        XCTAssertEqual(DaytimeStress.squash(DaytimeStress.baselineRelativeHighMarginBPM / sd),
+                      DaytimeStress.highBandFloor, accuracy: 1e-9)
+    }
 
     func testBaselineRelativeModeRecoversMultipleInjectedElevations() {
-        // Personal daytime-HR baseline: 20 constant "days" at 60 bpm converges the EWMA center
-        // to exactly 60 with spread pinned at the daytime_hr floor (no cross-day variability).
-        let hrBaseline = Baselines.foldHistory(Array(repeating: 60.0, count: 20), cfg: Baselines.daytimeHRCfg)
-        XCTAssertEqual(hrBaseline.baseline, 60.0, accuracy: 1e-6)
-        XCTAssertEqual(hrBaseline.spread, Baselines.daytimeHRCfg.floorSpread, accuracy: 1e-9)
+        // Personal daytime-HR baseline: 20 constant "days" at 65 bpm converges the EWMA center
+        // to exactly 65 (spread is folded but NOT used for the HR high-band threshold — see
+        // baselineRelativeHighMarginBPM).
+        let hrBaseline = Baselines.foldHistory(Array(repeating: 65.0, count: 20), cfg: Baselines.daytimeHRCfg)
+        XCTAssertEqual(hrBaseline.baseline, 65.0, accuracy: 1e-6)
 
         // FOUR distinct injected HR elevations across the SAME day's waking hours — the repo's
         // derived-signal rule (CLAUDE.md "validate against the artifact, not one match") requires
-        // recovering MULTIPLE injected values, not a single high-vs-low pair.
-        let levels: [(hour: Int, bpm: Int)] = [(8, 60), (10, 64), (13, 68), (16, 72)]
+        // recovering MULTIPLE injected values, not a single high-vs-low pair. 65 (at baseline),
+        // 72 (+7, mild), 80 (+15, exactly the validated margin), 95 (+30, well past it).
+        let levels: [(hour: Int, bpm: Int)] = [(8, 65), (10, 72), (13, 80), (16, 95)]
         var hr: [HRSample] = []
         for (h, bpm) in levels { hr += hourHR(h, bpm: bpm) }
 
@@ -199,16 +214,19 @@ final class DaytimeStressTests: XCTestCase {
             XCTAssertGreaterThan(scores[i], scores[i - 1],
                 "hour \(levels[i].hour) (\(levels[i].bpm) bpm) should score higher than hour \(levels[i - 1].hour) (\(levels[i - 1].bpm) bpm)")
         }
-        // The at-baseline hour reads at the 1.5 midpoint; the most-elevated hour clears HIGH.
+        // The at-baseline hour reads at the 1.5 midpoint; +15 bpm (the validated margin) lands
+        // exactly on highBandFloor; the most-elevated hour clears well past it.
         XCTAssertEqual(scores[0], 1.5, accuracy: 0.05)
-        XCTAssertGreaterThanOrEqual(scores.last!, DaytimeStress.highBandFloor)
+        XCTAssertEqual(scores[2], DaytimeStress.highBandFloor, accuracy: 0.01,
+            "the validated +15 bpm margin should land exactly on highBandFloor")
+        XCTAssertGreaterThan(scores.last!, DaytimeStress.highBandFloor)
         XCTAssertTrue(r.hrOnlyFallback, "rmssd: nil must flag the HR-only fallback")
     }
 
     func testBaselineRelativeCalmDayAtPersonalBaselineReadsLowNotHigh() {
-        let hrBaseline = Baselines.foldHistory(Array(repeating: 60.0, count: 20), cfg: Baselines.daytimeHRCfg)
+        let hrBaseline = Baselines.foldHistory(Array(repeating: 65.0, count: 20), cfg: Baselines.daytimeHRCfg)
         var hr: [HRSample] = []
-        for h in [8, 10, 13, 16] { hr += hourHR(h, bpm: 60) }   // every hour sits exactly at baseline
+        for h in [8, 10, 13, 16] { hr += hourHR(h, bpm: 65) }   // every hour sits exactly at baseline
         let r = DaytimeStress.analyze(hr: hr, rr: [], mode: .baselineRelative(hr: hrBaseline, rmssd: nil))
 
         for p in r.scored {
@@ -220,9 +238,9 @@ final class DaytimeStressTests: XCTestCase {
     }
 
     func testBaselineRelativeElevatedDayProducesHighStressMinutes() {
-        let hrBaseline = Baselines.foldHistory(Array(repeating: 60.0, count: 20), cfg: Baselines.daytimeHRCfg)
+        let hrBaseline = Baselines.foldHistory(Array(repeating: 65.0, count: 20), cfg: Baselines.daytimeHRCfg)
         var hr: [HRSample] = []
-        for h in 8...16 { hr += hourHR(h, bpm: 95) }   // every waking hour well above the personal baseline
+        for h in 8...16 { hr += hourHR(h, bpm: 95) }   // +30 bpm — twice the validated high-band margin
         let r = DaytimeStress.analyze(hr: hr, rr: [], mode: .baselineRelative(hr: hrBaseline, rmssd: nil))
 
         XCTAssertGreaterThan(r.highStressMinutes, 0)
@@ -234,9 +252,9 @@ final class DaytimeStressTests: XCTestCase {
     func testBaselineRelativeNilRMSSDFallsBackToHROnlyAndFlagsDegraded() {
         // An imported, Oura-era day: no personal RMSSD baseline exists yet (rmssd: nil) and no
         // R-R stream is available either. The read must still complete honestly, never crash.
-        let hrBaseline = Baselines.foldHistory(Array(repeating: 60.0, count: 20), cfg: Baselines.daytimeHRCfg)
+        let hrBaseline = Baselines.foldHistory(Array(repeating: 65.0, count: 20), cfg: Baselines.daytimeHRCfg)
         var hr: [HRSample] = []
-        for h in [9, 14] { hr += hourHR(h, bpm: 80) }
+        for h in [9, 14] { hr += hourHR(h, bpm: 80) }   // right at the validated +15 bpm margin
         let r = DaytimeStress.analyze(hr: hr, rr: [], mode: .baselineRelative(hr: hrBaseline, rmssd: nil))
 
         XCTAssertTrue(r.hrOnlyFallback)

--- a/android/app/src/main/java/com/noop/analytics/Baselines.kt
+++ b/android/app/src/main/java/com/noop/analytics/Baselines.kt
@@ -110,6 +110,32 @@ object Baselines {
             minVal = 20.0, maxVal = 42.0, floorSpread = 0.3,
             halfLifeB = 14.0, halfLifeS = 21.0,
         ),
+
+        // Daytime/waking-hours configs (DaytimeStress baseline-relative mode, added alongside
+        // the day-relative default). Distinct from "resting_hr"/"hrv" above, which each fold ONE
+        // NIGHTLY value (sleep). These fold ONE DAYTIME aggregate per day into a cross-day
+        // PERSONAL baseline, so a caller can hand the resulting BaselineState to
+        // DaytimeStress.analyze(mode = ScoringMode.BaselineRelative(hr, rmssd)) and z-score each
+        // waking hour against "how MY days usually run" rather than "how today's own calm hours ran".
+        //
+        // VALIDATED (26-day Oura-reference correlation, HR-only, r≈0.6): the per-day value to
+        // fold for "daytime_hr" is that day's 10th-percentile daytime HR (~65 bpm pooled across
+        // the reference set) — NOT the day-relative calmReference's 25th-percentile quartile.
+        // The "high stress" cutoff itself is a validated fixed bpm margin over this baseline,
+        // NOT this config's floorSpread — see DaytimeStress.baselineRelativeHighMarginBPM.
+        // TUNING SEAM: minVal/maxVal/half-life below (and all of "daytime_rmssd" — RMSSD wasn't
+        // part of the validated HR-only comparison) are a documented first pass, refinable once
+        // an HR+HRV comparison exists. floorSpread is wider than the nightly "hrv" config for
+        // RMSSD: daytime RMSSD carries more incidental noise (posture changes, talking, movement
+        // between "calm" hours) than overnight recumbent HRV.
+        "daytime_hr" to MetricCfg(
+            minVal = 35.0, maxVal = 160.0, floorSpread = 3.0,
+            halfLifeB = 14.0, halfLifeS = 21.0,
+        ),
+        "daytime_rmssd" to MetricCfg(
+            minVal = 5.0, maxVal = 250.0, floorSpread = 7.0,
+            halfLifeB = 14.0, halfLifeS = 21.0,
+        ),
     )
 
     /** Convenience accessor for the standard HRV config. */
@@ -120,6 +146,12 @@ object Baselines {
 
     /** Convenience accessor for the standard respiration config. */
     val respCfg: MetricCfg get() = metricCfg.getValue("resp")
+
+    /** Personal daytime/waking HR baseline config — see the `daytime_hr` comment above. */
+    val daytimeHRCfg: MetricCfg get() = metricCfg.getValue("daytime_hr")
+
+    /** Personal daytime/waking RMSSD baseline config — see the `daytime_rmssd` comment above. */
+    val daytimeRMSSDCfg: MetricCfg get() = metricCfg.getValue("daytime_rmssd")
 
     /** Convert a half-life in nights to an EWMA smoothing factor. */
     internal fun lambda(halfLife: Double): Double = 1.0 - 0.5.pow(1.0 / halfLife)
@@ -296,12 +328,20 @@ object Baselines {
     // ─────────────────────────────────────────────────────────────────────────
 
     /**
+     * Convert a state's EWMA-abs-dev spread to an approximate Gaussian σ: 1.253 × spread,
+     * floored so a caller never divides by ~0. 1.253 is E[|X−μ|] = σ·√(2/π) inverted
+     * (E[|X−μ|] ≈ σ/1.253 for a Gaussian). Shared by [deviation] below and by any other
+     * z-scoring caller (e.g. [DaytimeStress]'s baseline-relative mode) so the conversion has
+     * exactly one definition.
+     */
+    fun sigma(state: BaselineState): Double = max(1.253 * state.spread, 1e-9)
+
+    /**
      * Compute z / delta / ratio / in-normal-range for a value vs a baseline.
-     * z uses (value − baseline) / (1.253 × spread); 1.253 converts EWMA-abs-dev
-     * to an approximate Gaussian σ (E[|X−μ|] = σ·√(2/π) ≈ σ/1.253).
+     * z uses (value − baseline) / sigma(state); see [sigma] for the 1.253 conversion.
      */
     fun deviation(value: Double, state: BaselineState): Deviation {
-        val sigma = max(1.253 * state.spread, 1e-9)
+        val sigma = sigma(state)
         val z = (value - state.baseline) / sigma
         val delta = value - state.baseline
         val ratio = if (state.baseline != 0.0) (value / state.baseline - 1.0) else 0.0

--- a/android/app/src/main/java/com/noop/analytics/DaytimeStress.kt
+++ b/android/app/src/main/java/com/noop/analytics/DaytimeStress.kt
@@ -3,6 +3,7 @@ package com.noop.analytics
 import com.noop.data.HrSample
 import com.noop.data.RrInterval
 import kotlin.math.exp
+import kotlin.math.ln
 import kotlin.math.max
 import kotlin.math.min
 import kotlin.math.sqrt
@@ -51,6 +52,69 @@ object DaytimeStress {
     const val wakingStartHour: Int = 6
     const val wakingEndHour: Int = 22
 
+    /**
+     * VALIDATED (26-day Oura-reference correlation, HR-only): a personal daytime-HR elevation
+     * of ~15 bpm over a POOLED/ROLLING baseline — the 10th-percentile daytime HR pooled across
+     * days, ~65 bpm in the reference set — is where elevated HR starts reading as
+     * Oura-comparable "high" stress (r≈0.6 against Oura's own stress signal). A PER-DAY
+     * (day-relative) baseline scored WORSE in the same comparison (r 0.43–0.53): an all-day
+     * elevated day pulls its own floor up and masks the stress, which is exactly why
+     * [ScoringMode.BaselineRelative] leans on [Baselines]' cross-day rolling EWMA instead of a
+     * day-local reference. TUNING SEAM: this is HR-only; HR+HRV (WHOOP-era, RMSSD included) is
+     * expected to beat this r≈0.6 ceiling — re-validate this margin once that comparison exists.
+     * See [marginToSigma] for how it's translated onto the shared 0–3 squash curve.
+     */
+    const val baselineRelativeHighMarginBPM: Double = 15.0
+
+    // MARK: - Scoring mode
+
+    /**
+     * WHERE each hour's "calm" reference point + spread come from. Every other step —
+     * bucketing, the waking-hour filter, the squash curve, sustained-high, high-stress-minutes
+     * — is identical between modes; only the reference differs.
+     *
+     * Relationship to the rest of the Stress screen: the DAILY 0–3 score already compares last
+     * night's NIGHTLY resting-HR/HRV to a plain trailing 30-day mean/SD (a once-a-day number
+     * from SLEEP vitals). The Advanced HRV card ([StressIndex], [HrvFreqDomain]) is a today-only
+     * descriptive lens with no baseline at all. [BaselineRelative] is neither: it's an HOURLY
+     * breakdown of TODAY from DAYTIME/waking-hours HR+RMSSD against a PERSONAL cross-day rolling
+     * baseline. Daytime HR runs warmer than nocturnal resting HR (posture, thermic effect), so it
+     * needs its OWN baseline (`daytime_hr`/`daytime_rmssd`) rather than reusing the nightly
+     * `resting_hr`/`hrv` configs — reusing the nightly ones would systematically over-read stress.
+     * The three surfaces are complementary lenses on the same underlying autonomic signal, not
+     * competing implementations of one baseline.
+     */
+    sealed interface ScoringMode {
+        /**
+         * DEFAULT — unchanged from before this mode existed. Each hour is z-scored against
+         * THIS DAY's own calm-hour reference: the lower quartile of the day's own waking-hour
+         * mean HR, the upper quartile of its own waking-hour RMSSD. No personal history needed —
+         * the day is its own baseline. Byte-identical output to the pre-existing single-mode
+         * `analyze` for the same hr/rr/tzOffsetSeconds.
+         */
+        object DayRelative : ScoringMode
+
+        /**
+         * Oura-style — each hour is z-scored against the PERSONAL rolling baseline for daytime
+         * HR (and, when available, daytime RMSSD): the SAME Winsorized-EWMA machinery
+         * ([Baselines.update] / [Baselines.foldHistory]) that backs the nightly HRV / resting-HR
+         * baselines elsewhere, using [Baselines.daytimeHRCfg] / [Baselines.daytimeRMSSDCfg].
+         *
+         * The HR reference point is [hr]'s baseline, but the HIGH-band threshold does NOT scale
+         * with this person's own day-to-day spread — see [baselineRelativeHighMarginBPM]: the
+         * validated model is a roughly FIXED bpm margin over the personal floor, not a
+         * variability-scaled one.
+         *
+         * [rmssd] is null when no personal RMSSD baseline exists yet — e.g. an imported, Oura-era
+         * day with no R-R stream. The stressor then honestly falls back to HR-only scoring for the
+         * whole read and flags [Result.hrOnlyFallback]; this mirrors the per-hour graceful-null
+         * already in [rawScore], just at the whole-baseline grain. The RMSSD term (when present)
+         * DOES still scale by [rmssd]'s spread via [Baselines.sigma] — only the HR term has a
+         * validated fixed-margin figure so far.
+         */
+        data class BaselineRelative(val hr: BaselineState, val rmssd: BaselineState?) : ScoringMode
+    }
+
     // MARK: - Output
 
     /**
@@ -85,6 +149,23 @@ object DaytimeStress {
         val dayMean: Double?,
         /** Peak scored hour (highest level), or null. */
         val peak: HourPoint?,
+        /**
+         * ADDITIVE — total minutes across SCORED waking hours at/above [highBandFloor], the
+         * Oura-comparable "time in high stress" figure. Each scored hour is one [bucketSeconds]
+         * bucket, so this is `(# high-band scored hours) * bucketSeconds / 60`. Compare against
+         * Oura's `stress_high_s / 60` — NOOP's timeline is hourly-grain vs Oura's ~5-minute grain,
+         * so treat this as a coarse approximation, not a precise match. 0 for [EMPTY] and for any
+         * day with no scored hours.
+         */
+        val highStressMinutes: Int = 0,
+        /**
+         * ADDITIVE — true when [ScoringMode.BaselineRelative] mode was requested but had no
+         * personal RMSSD baseline to score against (e.g. an imported Oura-era day with no R-R
+         * history), so the whole read honestly fell back to HR-only scoring. Always false in
+         * [ScoringMode.DayRelative] mode (there, a missing RMSSD is already handled per-hour by
+         * [rawScore], not flagged day-wide) and false for [EMPTY].
+         */
+        val hrOnlyFallback: Boolean = false,
     ) {
         /** The scored hours only (level non-null), in time order. */
         val scored: List<HourPoint> get() = hours.filter { it.level != null }
@@ -92,7 +173,7 @@ object DaytimeStress {
         companion object {
             /** Empty read — used when the day had no usable intraday HR at all. */
             val EMPTY = Result(emptyList(), sustainedHigh = false, sustainedRun = 0,
-                dayMean = null, peak = null)
+                dayMean = null, peak = null, highStressMinutes = 0, hrOnlyFallback = false)
         }
     }
 
@@ -130,8 +211,23 @@ object DaytimeStress {
      * Logistic squash of the raw z-sum onto 0–3 (baseline 0 → 1.5). Identical to
      * StressMath.squash, so an hourly point shares the daily score's scale and bands.
      */
-    private fun squash(raw: Double): Double =
+    internal fun squash(raw: Double): Double =
         (3.0 / (1.0 + exp(-raw))).coerceIn(0.0, 3.0)
+
+    /**
+     * Solve for the z-score spread `sd` such that a raw elevation of exactly [marginBPM] (or any
+     * unit — this is unit-agnostic) squashes to exactly [band] on the shared 0–3 curve:
+     * `band = 3 / (1 + e^(−marginBPM/sd))`. Used to translate [baselineRelativeHighMarginBPM]'s
+     * validated bpm figure into the `sd` the shared [squash] curve expects, so "baseline + margin"
+     * lands exactly on [band] by construction rather than by a second, separate threshold check.
+     * Defensive fallback (never divides by zero/negative-log) if [band] is ever configured at or
+     * outside the curve's open range (0, 3).
+     */
+    internal fun marginToSigma(marginBPM: Double, band: Double): Double {
+        val ratio = 3.0 / band - 1.0
+        if (ratio <= 0.0 || marginBPM <= 0.0) return max(marginBPM, 1e-9)
+        return marginBPM / (-ln(ratio))
+    }
 
     // MARK: - Public API
 
@@ -142,10 +238,18 @@ object DaytimeStress {
      * @param rr the day's R-R intervals.
      * @param tzOffsetSeconds seconds east of UTC, for placing each bucket on the LOCAL clock
      *   (so "waking hours" and the hour labels are local). Defaults to UTC.
+     * @param mode [ScoringMode.DayRelative] (DEFAULT — unchanged existing behaviour) or
+     *   [ScoringMode.BaselineRelative] (Oura-style, vs a personal rolling baseline). ADDITIVE and
+     *   opt-in: existing callers that don't pass `mode` keep the exact prior behaviour.
      *
      * Returns [Result.EMPTY] when there isn't a single hour with enough HR to score.
      */
-    fun analyze(hr: List<HrSample>, rr: List<RrInterval>, tzOffsetSeconds: Long = 0L): Result {
+    fun analyze(
+        hr: List<HrSample>,
+        rr: List<RrInterval>,
+        tzOffsetSeconds: Long = 0L,
+        mode: ScoringMode = ScoringMode.DayRelative,
+    ): Result {
         if (hr.isEmpty()) return Result.EMPTY
 
         // 1) Bucket HR + R-R into LOCAL hour-of-day buckets, keyed by the bucket start
@@ -176,25 +280,66 @@ object DaytimeStress {
             aggs.add(HourAgg(b, mHr, rrRes.rmssd))
         }
 
-        // 3) The day's OWN quiet reference: centre on the CALM end (the lower quartile of
-        //    hourly mean HR, the upper quartile of hourly RMSSD), and spread from the
-        //    across-hour SD. This makes a flat day read ~baseline and a spiky day surface its
-        //    tense hours — without any cross-day history. Falls back to the plain mean when
-        //    there are too few scored hours for a quartile.
-        //
-        //    Built from the WAKING hours only — the same hours scored in step 4. Sleep is the
-        //    calmest, lowest-HR / highest-HRV stretch of the day, and the analysis window
-        //    always begins at local midnight, so the current day routinely carries several
-        //    hours of it. Letting those night hours into the reference drags the "calm" anchor
-        //    far beneath every waking hour, inflating an ordinary calm day toward HIGH and
-        //    falsely tripping the sustained-high Breathe nudge.
-        val referenceAggs = aggs.filter { isWakingHour(it.bucket) }
-        val hrMeans = referenceAggs.mapNotNull { it.meanHr }
-        val rmssdVals = referenceAggs.mapNotNull { it.rmssd }
-        val refHr = calmReference(hrMeans, calmIsLow = true)         // calm HR is LOW
-        val refRmssd = calmReference(rmssdVals, calmIsLow = false)   // calm HRV is HIGH
-        val sdHr = std(hrMeans, mean(hrMeans))
-        val sdRmssd = std(rmssdVals, mean(rmssdVals))
+        // 3) The reference point + spread for each signal — WHERE they come from depends on
+        //    `mode`. Every other step (bucketing above, the waking-hour filter, the squash
+        //    curve, sustained-high, high-stress-minutes below) is identical between modes.
+        val refHr: Double?
+        val sdHr: Double
+        val refRmssd: Double?
+        val sdRmssd: Double
+        val hrOnlyFallback: Boolean
+        when (mode) {
+            is ScoringMode.DayRelative -> {
+                // The day's OWN quiet reference: centre on the CALM end (the lower quartile of
+                // hourly mean HR, the upper quartile of hourly RMSSD), and spread from the
+                // across-hour SD. This makes a flat day read ~baseline and a spiky day surface its
+                // tense hours — without any cross-day history. Falls back to the plain mean when
+                // there are too few scored hours for a quartile.
+                //
+                // Built from the WAKING hours only — the same hours scored in step 4. Sleep is the
+                // calmest, lowest-HR / highest-HRV stretch of the day, and the analysis window
+                // always begins at local midnight, so the current day routinely carries several
+                // hours of it. Letting those night hours into the reference drags the "calm" anchor
+                // far beneath every waking hour, inflating an ordinary calm day toward HIGH and
+                // falsely tripping the sustained-high Breathe nudge.
+                val referenceAggs = aggs.filter { isWakingHour(it.bucket) }
+                val hrMeans = referenceAggs.mapNotNull { it.meanHr }
+                val rmssdVals = referenceAggs.mapNotNull { it.rmssd }
+                refHr = calmReference(hrMeans, calmIsLow = true)         // calm HR is LOW
+                refRmssd = calmReference(rmssdVals, calmIsLow = false)   // calm HRV is HIGH
+                sdHr = std(hrMeans, mean(hrMeans))
+                sdRmssd = std(rmssdVals, mean(rmssdVals))
+                hrOnlyFallback = false
+            }
+            is ScoringMode.BaselineRelative -> {
+                // The PERSONAL cross-day baseline, folded by the caller from past daytime
+                // aggregates via Baselines.update/foldHistory (see the ScoringMode doc).
+                refHr = mode.hr.baseline
+                // VALIDATED tuning, not Baselines.sigma(mode.hr): the correlation study behind
+                // baselineRelativeHighMarginBPM found a roughly FIXED bpm margin over the personal
+                // floor — not one scaled by this person's own day-to-day spread — best matched
+                // Oura's stress signal. marginToSigma solves for the sd that makes exactly
+                // refHr + baselineRelativeHighMarginBPM land on highBandFloor on the shared squash
+                // curve, so the validated margin IS the "high" cutoff by construction.
+                sdHr = marginToSigma(baselineRelativeHighMarginBPM, highBandFloor)
+                val rmssdBaseline = mode.rmssd
+                if (rmssdBaseline != null) {
+                    refRmssd = rmssdBaseline.baseline
+                    // No independently validated RMSSD margin yet (see the constant's doc) — this
+                    // term still scales by the person's own spread via the shared σ conversion.
+                    sdRmssd = Baselines.sigma(rmssdBaseline)
+                    hrOnlyFallback = false
+                } else {
+                    // No personal RMSSD baseline exists (e.g. an Oura-era day with no R-R history to
+                    // fold one from). rawScore already treats a null meanRmssd as "skip this term",
+                    // so passing null here gracefully degrades to HR-only scoring — flagged honestly
+                    // in the output rather than silently.
+                    refRmssd = null
+                    sdRmssd = 0.0
+                    hrOnlyFallback = true
+                }
+            }
+        }
 
         // 4) Score each waking-hour bucket on the shared 0–3 curve.
         val points = ArrayList<HourPoint>(aggs.size)
@@ -216,9 +361,12 @@ object DaytimeStress {
         val scored = points.mapNotNull { p -> p.level?.let { p to it } }
         if (scored.isEmpty()) {
             // No scorable waking hour — still return the (unscored) timeline so the UI can
-            // show "not enough data" rather than nothing.
+            // show "not enough data" rather than nothing. hrOnlyFallback is a MODE property
+            // (whether a personal RMSSD baseline existed to score against), so it's still worth
+            // reporting even though nothing ended up scored.
             return if (points.isEmpty()) Result.EMPTY
-            else Result(points, sustainedHigh = false, sustainedRun = 0, dayMean = null, peak = null)
+            else Result(points, sustainedHigh = false, sustainedRun = 0, dayMean = null, peak = null,
+                highStressMinutes = 0, hrOnlyFallback = hrOnlyFallback)
         }
 
         // 5) Sustained-high flag: walk back from the latest SCORED hour while each is HIGH.
@@ -231,7 +379,13 @@ object DaytimeStress {
         val dayMean = mean(scored.map { it.second })
         val peak = scored.maxByOrNull { it.second }?.first
 
-        return Result(points, sustained, run, dayMean, peak)
+        // 6) Oura-comparable "time in high stress": each scored hour at/above highBandFloor is one
+        //    full bucketSeconds bucket, converted to minutes. Uses the SAME threshold the
+        //    sustained-high check above already uses, so all stay in lockstep by construction.
+        val highStressMinutes = scored.count { it.second >= highBandFloor } * (bucketSeconds / 60L).toInt()
+
+        return Result(points, sustained, run, dayMean, peak,
+            highStressMinutes = highStressMinutes, hrOnlyFallback = hrOnlyFallback)
     }
 
     // MARK: - Helpers

--- a/android/app/src/test/java/com/noop/analytics/BaselinesSigmaDaytimeTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/BaselinesSigmaDaytimeTest.kt
@@ -1,0 +1,39 @@
+package com.noop.analytics
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Test
+import kotlin.math.max
+
+/**
+ * Kotlin twin of the sigma() + daytime-config additions in BaselinesTests.swift (PR #413).
+ * Pure-function tests; no DB.
+ */
+class BaselinesSigmaDaytimeTest {
+
+    /**
+     * sigma() is a pure extraction of deviation()'s internal conversion — must match it exactly
+     * and stay internally consistent (deviation at baseline + sigma is z == 1.0).
+     */
+    @Test
+    fun sigmaMatchesDeviationsInternalConversion() {
+        val s = Baselines.foldHistory(List(14) { 50.0 }, Baselines.hrvCfg)
+        val sigma = Baselines.sigma(s)
+        assertEquals(max(1.253 * s.spread, 1e-9), sigma, 1e-9)
+        val dev = Baselines.deviation(s.baseline + sigma, s)
+        assertEquals(1.0, dev.z, 1e-6)
+    }
+
+    /**
+     * The new daytime_hr / daytime_rmssd configs exist, are reachable via both the map and the
+     * convenience accessor, and are distinct from the nightly resting_hr/hrv configs they sit
+     * alongside (different bounds/floor — daytime HR runs warmer than nocturnal RHR).
+     */
+    @Test
+    fun daytimeConfigsExistAndAreDistinctFromNightlyConfigs() {
+        assertEquals(Baselines.daytimeHRCfg, Baselines.metricCfg["daytime_hr"])
+        assertEquals(Baselines.daytimeRMSSDCfg, Baselines.metricCfg["daytime_rmssd"])
+        assertNotEquals(Baselines.daytimeHRCfg, Baselines.restingHRCfg)
+        assertNotEquals(Baselines.daytimeRMSSDCfg, Baselines.hrvCfg)
+    }
+}

--- a/android/app/src/test/java/com/noop/analytics/DaytimeStressTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/DaytimeStressTest.kt
@@ -5,6 +5,7 @@ import com.noop.data.RrInterval
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 /**
@@ -17,6 +18,14 @@ class DaytimeStressTest {
     private fun hourHr(hour: Int, bpm: Int, n: Int = DaytimeStress.minHourHrSamples): List<HrSample> {
         val base = hour.toLong() * 3_600L
         return (0 until n).map { HrSample(deviceId = "t", ts = base + it, bpm = bpm) }
+    }
+
+    /** R-R for one hour with a controllable beat-to-beat jitter (drives RMSSD). */
+    private fun hourRrVariable(hour: Int, rrMs: Int, jitter: Int, n: Int = 60): List<RrInterval> {
+        val base = hour.toLong() * 3_600L
+        return (0 until n).map {
+            RrInterval(deviceId = "t", ts = base + it * 50L, rrMs = rrMs + if (it % 2 == 0) jitter else -jitter)
+        }
     }
 
     @Test
@@ -55,6 +64,179 @@ class DaytimeStressTest {
         assertFalse(
             "a calm desk day must not read as sustained high stress",
             withSleep.sustainedHigh,
+        )
+    }
+
+    // MARK: - Additivity: the `mode` parameter is opt-in, day-relative stays the default
+
+    @Test
+    fun dayRelativeDefaultIsByteIdenticalToExplicitMode() {
+        // The additive `mode` parameter defaults to DayRelative. Confirms the implicit call
+        // (every pre-existing call site, unmodified) and the explicit DayRelative case produce a
+        // BYTE-IDENTICAL Result — every field, not just the pre-existing ones — proving the new
+        // mode is purely additive and never a silent behaviour change.
+        val hr = ArrayList<HrSample>()
+        for (h in listOf(8, 9, 10)) hr += hourHr(h, 58)
+        hr += hourHr(13, 120)
+        hr += hourHr(14, 125)
+        hr += hourHr(15, 130)
+        val rr = ArrayList<RrInterval>()
+        rr += hourRrVariable(9, 900, 40)
+        rr += hourRrVariable(14, 900, 5)
+
+        val implicit = DaytimeStress.analyze(hr, rr, tzOffsetSeconds = 3_600L)
+        val explicit = DaytimeStress.analyze(hr, rr, tzOffsetSeconds = 3_600L,
+            mode = DaytimeStress.ScoringMode.DayRelative)
+        assertEquals(
+            "omitting `mode` must be byte-identical to passing DayRelative explicitly",
+            implicit, explicit,
+        )
+    }
+
+    @Test
+    fun highStressMinutesCountsAllHighBandHoursNotJustTheTrailingRun() {
+        // An isolated morning spike, then a calm run ending the day: sustainedHigh only cares about
+        // the TRAILING run (and must be false here, since the day ends calm), but highStressMinutes
+        // is a day-wide tally and must still count the earlier spike hour — proving it is computed
+        // independently, not derived from sustainedRun.
+        val hr = ArrayList<HrSample>()
+        hr += hourHr(7, 130)   // isolated high spike
+        hr += hourHr(8, 60)
+        hr += hourHr(9, 60)
+        hr += hourHr(10, 60)
+        hr += hourHr(11, 60)   // trailing hour is calm -> NOT sustained
+        val r = DaytimeStress.analyze(hr, emptyList())
+
+        assertFalse("the trailing hour is calm, so sustained-high must not fire", r.sustainedHigh)
+        val expectedHighHours = r.scored.count { it.level!! >= DaytimeStress.highBandFloor }
+        assertTrue("the isolated morning spike should read as high band", expectedHighHours > 0)
+        assertEquals(expectedHighHours * (DaytimeStress.bucketSeconds / 60L).toInt(), r.highStressMinutes)
+        assertFalse("day-relative mode never sets the baseline-relative fallback flag", r.hrOnlyFallback)
+    }
+
+    // MARK: - Baseline-relative mode (Oura-style, vs a PERSONAL rolling baseline)
+    //
+    // Fixtures below use a 65 bpm personal HR baseline (matching the ~65 bpm pooled
+    // 10th-percentile figure from the validated 26-day Oura-reference correlation — see
+    // DaytimeStress.baselineRelativeHighMarginBPM) and elevations measured from it in terms of that
+    // validated ~15 bpm margin, so the expected band crossings are exact, not approximate.
+
+    @Test
+    fun marginToSigmaLandsExactlyOnBand() {
+        // The validated 15 bpm margin over baseline must land EXACTLY on highBandFloor (2.0) on the
+        // shared squash curve — the core identity baseline-relative scoring relies on.
+        val sd = DaytimeStress.marginToSigma(DaytimeStress.baselineRelativeHighMarginBPM, DaytimeStress.highBandFloor)
+        assertEquals(
+            DaytimeStress.highBandFloor,
+            DaytimeStress.squash(DaytimeStress.baselineRelativeHighMarginBPM / sd),
+            1e-9,
+        )
+    }
+
+    @Test
+    fun baselineRelativeModeRecoversMultipleInjectedElevations() {
+        // Personal daytime-HR baseline: 20 constant "days" at 65 bpm converges the EWMA center to
+        // exactly 65 (spread is folded but NOT used for the HR high-band threshold).
+        val hrBaseline = Baselines.foldHistory(List(20) { 65.0 }, Baselines.daytimeHRCfg)
+        assertEquals(65.0, hrBaseline.baseline, 1e-6)
+
+        // FOUR distinct injected HR elevations across the SAME day's waking hours — the repo's
+        // derived-signal rule requires recovering MULTIPLE injected values, not a single high-vs-low
+        // pair. 65 (at baseline), 72 (+7, mild), 80 (+15, exactly the validated margin), 95 (+30).
+        val levels = listOf(8 to 65, 10 to 72, 13 to 80, 16 to 95)
+        val hr = ArrayList<HrSample>()
+        for ((h, bpm) in levels) hr += hourHr(h, bpm)
+
+        val r = DaytimeStress.analyze(hr, emptyList(),
+            mode = DaytimeStress.ScoringMode.BaselineRelative(hrBaseline, null))
+        val scores = levels.map { pair -> r.scored.first { it.hour == pair.first }.level!! }
+
+        // Strictly increasing with the injected elevation — all four levels recovered, in order.
+        for (i in 1 until scores.size) {
+            assertTrue(
+                "hour ${levels[i].first} (${levels[i].second} bpm) should score higher than hour " +
+                    "${levels[i - 1].first} (${levels[i - 1].second} bpm)",
+                scores[i] > scores[i - 1],
+            )
+        }
+        // The at-baseline hour reads at the 1.5 midpoint; +15 bpm (the validated margin) lands
+        // exactly on highBandFloor; the most-elevated hour clears well past it.
+        assertEquals(1.5, scores[0], 0.05)
+        assertEquals(
+            "the validated +15 bpm margin should land exactly on highBandFloor",
+            DaytimeStress.highBandFloor, scores[2], 0.01,
+        )
+        assertTrue(scores.last() > DaytimeStress.highBandFloor)
+        assertTrue("rmssd = null must flag the HR-only fallback", r.hrOnlyFallback)
+    }
+
+    @Test
+    fun baselineRelativeCalmDayAtPersonalBaselineReadsLowNotHigh() {
+        val hrBaseline = Baselines.foldHistory(List(20) { 65.0 }, Baselines.daytimeHRCfg)
+        val hr = ArrayList<HrSample>()
+        for (h in listOf(8, 10, 13, 16)) hr += hourHr(h, 65)   // every hour sits exactly at baseline
+        val r = DaytimeStress.analyze(hr, emptyList(),
+            mode = DaytimeStress.ScoringMode.BaselineRelative(hrBaseline, null))
+
+        for (p in r.scored) {
+            assertEquals("a day flat at the personal baseline should read ~1.5, not elevated",
+                1.5, p.level!!, 0.05)
+        }
+        assertEquals(0, r.highStressMinutes)
+        assertFalse(r.sustainedHigh)
+    }
+
+    @Test
+    fun baselineRelativeElevatedDayProducesHighStressMinutes() {
+        val hrBaseline = Baselines.foldHistory(List(20) { 65.0 }, Baselines.daytimeHRCfg)
+        val hr = ArrayList<HrSample>()
+        for (h in 8..16) hr += hourHr(h, 95)   // +30 bpm — twice the validated high-band margin
+        val r = DaytimeStress.analyze(hr, emptyList(),
+            mode = DaytimeStress.ScoringMode.BaselineRelative(hrBaseline, null))
+
+        assertTrue(r.highStressMinutes > 0)
+        assertEquals(
+            r.scored.count { it.level!! >= DaytimeStress.highBandFloor } * (DaytimeStress.bucketSeconds / 60L).toInt(),
+            r.highStressMinutes,
+        )
+        for (p in r.scored) assertTrue(p.level!! >= DaytimeStress.highBandFloor)
+    }
+
+    @Test
+    fun baselineRelativeNilRMSSDFallsBackToHROnlyAndFlagsDegraded() {
+        // An imported, Oura-era day: no personal RMSSD baseline exists yet (rmssd = null) and no R-R
+        // stream is available either. The read must still complete honestly, never crash.
+        val hrBaseline = Baselines.foldHistory(List(20) { 65.0 }, Baselines.daytimeHRCfg)
+        val hr = ArrayList<HrSample>()
+        for (h in listOf(9, 14)) hr += hourHr(h, 80)   // right at the validated +15 bpm margin
+        val r = DaytimeStress.analyze(hr, emptyList(),
+            mode = DaytimeStress.ScoringMode.BaselineRelative(hrBaseline, null))
+
+        assertTrue(r.hrOnlyFallback)
+        assertFalse("HR-only scoring must still produce a timeline", r.scored.isEmpty())
+        for (p in r.scored) assertNotNull(p.level)
+    }
+
+    @Test
+    fun baselineRelativeUsesRMSSDBaselineWhenAvailable() {
+        // Personal baselines: HR steady at 65 bpm, RMSSD steady at 40 ms (both spread-floored).
+        val hrBaseline = Baselines.foldHistory(List(20) { 65.0 }, Baselines.daytimeHRCfg)
+        val rmssdBaseline = Baselines.foldHistory(List(20) { 40.0 }, Baselines.daytimeRMSSDCfg)
+
+        val hr = ArrayList<HrSample>()
+        val rr = ArrayList<RrInterval>()
+        for (h in listOf(9, 14)) hr += hourHr(h, 65)     // HR AT baseline in both hours — isolates RMSSD
+        rr += hourRrVariable(9, 900, 40)                  // normal variability
+        rr += hourRrVariable(14, 900, 2)                  // suppressed HRV -> more stressed
+
+        val r = DaytimeStress.analyze(hr, rr,
+            mode = DaytimeStress.ScoringMode.BaselineRelative(hrBaseline, rmssdBaseline))
+        assertFalse("an RMSSD baseline was supplied — no fallback", r.hrOnlyFallback)
+        val normal = r.scored.first { it.hour == 9 }.level!!
+        val suppressed = r.scored.first { it.hour == 14 }.level!!
+        assertTrue(
+            "suppressed RMSSD vs. the personal baseline should read MORE stressed than normal variability",
+            suppressed > normal,
         )
     }
 }


### PR DESCRIPTION
## Summary

- Adds an additive, opt-in `DaytimeStress.ScoringMode` alongside the existing day-relative default: `.baselineRelative(hr:rmssd:)` z-scores each waking hour against a PERSONAL rolling baseline (Oura-style) instead of the day's own calm-hour reference. Existing callers (`StressView`'s call site is untouched) keep the exact prior day-relative behavior — the default parameter value is `.dayRelative`.
- Adds two new `Baselines.metricCfg` entries (`daytime_hr`, `daytime_rmssd`) so the baseline-relative mode reuses the SAME Winsorized-EWMA machinery (`Baselines.update`/`foldHistory`) that backs the nightly HRV/resting-HR baselines elsewhere in the app, rather than a one-off implementation. Distinct from the nightly configs because daytime HR runs warmer than nocturnal resting HR (posture, thermic effect) — reusing the nightly configs would systematically over-read stress.
- A missing personal RMSSD baseline (e.g. an imported Oura-era day with no R-R history) gracefully falls back to HR-only scoring, honestly flagged via `Result.hrOnlyFallback` — mirrors the existing per-hour graceful-nil in `rawScore`, just at the whole-baseline grain.
- Adds `Result.highStressMinutes`: an Oura-comparable "time in high stress" total (scored waking hours at/above `highBandFloor`, converted to minutes), computed uniformly in both modes — maps onto Oura's `stress_high_s` for comparison (coarser, hourly grain vs Oura's ~5-minute grain).
- Extracted `Baselines.sigma(_:)` (the abs-dev-to-Gaussian-σ conversion) out of `deviation()` so it has one definition, shared by the new baseline-relative RMSSD term.

### Validated tuning (mid-implementation correction)

A 26-day Oura-reference correlation found a **pooled/rolling** personal daytime-HR baseline (10th-percentile daytime HR pooled across days, ~65 bpm) with a **fixed ~15 bpm margin** correlates best with Oura's own stress signal (r≈0.6, HR-only) — clearly better than a **per-day** baseline (r 0.43–0.53, because an all-day-elevated day pulls its own floor up and masks the stress). This confirms the cross-day rolling-EWMA design over a day-local one, and gave a concrete number to calibrate against: `.baselineRelative`'s HR term now uses `DaytimeStress.marginToSigma(marginBPM: baselineRelativeHighMarginBPM, atBand: highBandFloor)` for its spread — solved so that exactly "baseline + 15 bpm" lands on `highBandFloor` on the shared squash curve — rather than scaling by this person's own day-to-day HR spread. The RMSSD term is unchanged (still spread-scaled via `Baselines.sigma`) since RMSSD wasn't part of the validated comparison; that's flagged as an open tuning seam, expected to beat the HR-only r≈0.6 ceiling once an HR+HRV comparison exists. Both constants are named, documented, and cite the validation inline (`DaytimeStress.baselineRelativeHighMarginBPM`, the `daytime_hr`/`daytime_rmssd` config comments).

### Relationship to the existing baseline-relative surface on the Stress screen

Read `StressView.swift` end to end before building this, since the Stress screen already has baseline-relative content:
- **`StressModel`** — the DAILY 0–3 score already compares last night's NIGHTLY resting-HR/HRV to a plain trailing 30-day mean/SD, computed locally in `StressView` (its own private `StressMath`, not routed through `Baselines.swift` at all). Backs the "Stress" tile, the "Resting HR"/"HRV vs 30-day baseline" marker tiles.
- **Advanced HRV card** — Baevsky `StressIndex` + `HRVFreqDomain`, a today-only descriptive lens computed from today's R-R, no baseline at all.
- **This PR's `.baselineRelative`** — an HOURLY breakdown of TODAY from DAYTIME/waking-hours HR+RMSSD against a PERSONAL cross-day rolling baseline. Different grain (hourly vs daily), different signal (daytime waking-hours vs nightly sleep vitals), different underlying baseline (new `daytime_hr`/`daytime_rmssd` vs the existing local ad-hoc trailing mean/SD). Complementary lens on the same underlying autonomic signal, not a duplicate/competing implementation — documented inline in the `ScoringMode` doc comment for future readers.

## Test plan

- [x] `cd Packages/StrandAnalytics && swift test` — **1047/1047 green** (1038 pre-existing + 9 new: 7 in `DaytimeStressTests.swift`, 2 in `BaselinesTests.swift`).
- [x] Day-relative additivity: `testDayRelativeDefaultIsByteIdenticalToExplicitMode` proves the implicit (omitted `mode`) and explicit `.dayRelative` calls produce a byte-identical `Result` (every field), and all pre-existing `DaytimeStressTests`/`BaselinesTests` pass completely unmodified.
- [x] Baseline-relative, multiple injected levels (per CLAUDE.md's derived-signal rule — "recover multiple injected values, not one"): `testBaselineRelativeModeRecoversMultipleInjectedElevations` injects 4 distinct HR elevations (at-baseline, +7, +15 validated margin, +30) and asserts strictly increasing scores, with the +15 bpm hour landing exactly on `highBandFloor`.
- [x] Calm day at baseline reads ~1.5 (not elevated); elevated day produces `highStressMinutes > 0`; `highStressMinutes` counts ALL high-band scored hours (not just the trailing sustained-high run, proven with a fixture where they diverge).
- [x] HRV-missing day: `testBaselineRelativeNilRMSSDFallsBackToHROnlyAndFlagsDegraded` — HR-only fallback fires, produces a non-empty timeline, never crashes.
- [x] Direct unit test of the margin-to-sigma identity (`testMarginToSigmaLandsExactlyOnBand`) and of the new `Baselines.sigma`/`daytime_hr`/`daytime_rmssd` additions.
- [x] `xcodegen generate && xcodebuild -scheme Strand -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO build` — **BUILD SUCCEEDED**, 0 errors. `StressView.swift`'s call site is unchanged (relies on the `.dayRelative` default), so nothing the Stress screen currently shows changes.

## Android

Kotlin twin included + gradle-tested (10 new tests green). The Kotlin twin (`android/app/src/main/java/com/noop/analytics/{DaytimeStress,Baselines}.kt`) mirrors the Swift structure identically: the same two `metricCfg` entries (`daytime_hr`/`daytime_rmssd`), a `ScoringMode` sealed interface (`DayRelative` / `BaselineRelative(hr, rmssd)`) matching the Swift enum, the same `baselineRelativeHighMarginBPM = 15.0` constant, the `marginToSigma` identity, the shared `Baselines.sigma()` extraction, and the new `highStressMinutes` / `hrOnlyFallback` result fields — so Swift and Kotlin yield byte-identical scores. The 9 Swift tests are mirrored as Kotlin tests with identical inputs and expected values (8 in `DaytimeStressTest`, 2 in `BaselinesSigmaDaytimeTest`), all green under `./gradlew :app:testFullDebugUnitTest`.

