### PR TITLE
Coarse workout-type classifier (advisory, opt-in) in StrandAnalytics

### DIFF
--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/WorkoutTypeClassifier.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/WorkoutTypeClassifier.swift
@@ -1,0 +1,399 @@
+import Foundation
+import WhoopProtocol
+
+// WorkoutTypeClassifier.swift — COARSE workout-type classifier over ALREADY-CAPTURED signals.
+//
+// Given a detected workout window (from `WorkoutDetector` or `AutoWorkoutDetector`), this predicts
+// a BROAD activity class — walk / run / strength / cycle / ski / other — plus a confidence, from
+// four signal families that are already decoded and stored, no raw IMU:
+//   1. HR profile over the window (mean/peak/%HRR, HR variability shape) — `HRSample`.
+//   2. Activity-class tick composition — `StepSample.activityClass` (0 still / 1 walk / 2 run,
+//      community finding #316) — the on-device per-tick gait classifier, rolled up to a window.
+//   3. Gravity-derived posture/motion variance — the SAME per-record L2 gravity-delta intensity
+//      `WorkoutDetector.activitySeries` already computes for detection, re-used here as a shape
+//      signal rather than a threshold gate.
+//   4. Duration and calories (from `WorkoutDetector.ExerciseSession` / `Calories`).
+//
+// BROAD ONLY. This deliberately does NOT attempt fine-grained sport discrimination (e.g. basketball
+// vs tennis) — that needs raw high-rate IMU (type-43, ~100 Hz) this app does not capture. `gravity`/
+// `steps` here are the DECODED, already-stored ~1 Hz streams; nothing in this file reads raw motion
+// buffers.
+//
+// NOT a spectral/autocorrelation estimate. The gravity stream this classifier reads is ~1 Hz, well
+// below the Nyquist rate a real gait/pedal cadence would need (~1.5–3 Hz for walk/run strides). Per
+// the CLAUDE.md derived-signal rule (and the withdrawn PPG→HR estimate, #194), autocorrelation or
+// spectral analysis on a fixed low sample rate can manufacture a peak at the RECORD period that looks
+// physiological but isn't — so this file never does that. Where the design doc talks about a "cadence
+// proxy" it means `motionCV` (coefficient of variation of the intensity series — a coarse burstiness/
+// regularity statistic), NOT a frequency estimate. Treat it as "how steady vs. bursty is the motion",
+// nothing more.
+//
+// SHIP STATUS: first-pass HEURISTIC (documented, clamped ramp thresholds below), validated so far
+// ONLY against synthetic fixtures that each recover a distinct injected pattern (see
+// `WorkoutTypeClassifierTests`). This is advisory instrumentation — a caller may use it to LABEL or
+// SUGGEST a class on a detected workout, but it must never override a user's own sport selection and
+// must never gate a downstream score. Real-world accuracy against labeled workouts (e.g. Oura-import
+// `workout.sport` ground truth) is an explicit follow-up, not done here (no on-device labeled data
+// was available while writing this — only the code, not a user's history). The `scores` field on
+// `WorkoutClassPrediction` reports every candidate class's raw match score precisely so a later pass
+// can compute accuracy / top-k / confusion against real labels without re-deriving anything.
+//
+// Pure, database-free, no I/O — classifies from a feature vector. `WorkoutTypeFeatureExtractor`
+// builds that vector from the raw decoded streams; a future ML model (or one fed real IMU-derived
+// features) can conform to `WorkoutTypeClassifying` and slot in behind the same call sites.
+
+// MARK: - Output taxonomy
+
+/// A BROAD workout activity class. Deliberately coarse — see file header for why finer-grained sport
+/// discrimination (e.g. individual court/ball sports) is out of scope without raw IMU.
+public enum CoarseWorkoutClass: String, Equatable, Hashable, Sendable, Codable, CaseIterable {
+    case walk
+    case run
+    case strength
+    case cycle
+    case ski
+    /// No candidate class cleared the plausibility/margin bar — genuinely unclear, or a shape (e.g.
+    /// swim, row, court sport) this MVP doesn't model. Never a wrong specific guess dressed up.
+    case other
+}
+
+// MARK: - Input feature vector
+
+/// The feature vector a classifier scores. Built once per detected workout window so real Oura-era
+/// labeled workouts (or any other backfilled ground truth) can be scored later WITHOUT re-deriving
+/// anything from raw streams — construct this struct directly from a labeled workout's own summary
+/// stats to validate, or run `WorkoutTypeFeatureExtractor` over its stored streams.
+public struct WorkoutClassFeatures: Equatable, Sendable, Codable {
+    /// Window length (`end - start`), seconds.
+    public let durationSec: Double
+
+    // --- HR profile ---
+    public let meanHR: Double
+    public let peakHR: Int
+    /// Mean Karvonen %HRR over the window, 0...100, or nil when resting/max HR couldn't be resolved.
+    public let meanHRRPct: Double?
+    /// Coefficient of variation (stdev/mean) of the window's HR samples. Low = steady sustained
+    /// effort (run/walk/cycle); high = saw-tooth (sets-then-rest strength, or intermittent ski runs).
+    public let hrCV: Double
+
+    // --- Activity-class tick composition (StepSample.activityClass: 0 still / 1 walk / 2 run) ---
+    /// Fraction of ticks WITH a decoded activity class that read "still", "walk", "run" respectively
+    /// (sum to ~1 when `tickCoverage > 0`; all 0 when no tick in the window carried a class).
+    public let stillFraction: Double
+    public let walkFraction: Double
+    public let runFraction: Double
+    /// How much of the window is actually backed by a decoded activity-class tick, clamped [0, 1]
+    /// (classified ticks per second of window). Low/zero on a WHOOP 4.0 or any capture predating the
+    /// @63 decode — the classifier falls back to HR+motion-only scoring below `minTickCoverage`.
+    public let tickCoverage: Double
+
+    // --- Gravity-derived posture / motion shape ---
+    /// Variance of the per-record L2 gravity-delta intensity series over the window (the same series
+    /// `WorkoutDetector.activitySeries` computes) — a coarse posture/impact-variability proxy.
+    public let motionVariance: Double
+    /// Coefficient of variation of that same intensity series — burstiness/regularity, NOT a cadence
+    /// estimate (see file header). Low = smooth continuous motion (cycle); high = stop-start bursts
+    /// (strength sets, or ski runs broken up by lift rides).
+    public let motionCV: Double
+
+    // --- Energy ---
+    /// Estimated kcal / minute over the window (`caloriesKcal / (durationSec/60)`), or nil when no
+    /// calorie estimate was available.
+    public let kcalPerMin: Double?
+
+    public init(durationSec: Double, meanHR: Double, peakHR: Int, meanHRRPct: Double?, hrCV: Double,
+                stillFraction: Double, walkFraction: Double, runFraction: Double, tickCoverage: Double,
+                motionVariance: Double, motionCV: Double, kcalPerMin: Double?) {
+        self.durationSec = durationSec
+        self.meanHR = meanHR; self.peakHR = peakHR; self.meanHRRPct = meanHRRPct; self.hrCV = hrCV
+        self.stillFraction = stillFraction; self.walkFraction = walkFraction; self.runFraction = runFraction
+        self.tickCoverage = tickCoverage
+        self.motionVariance = motionVariance; self.motionCV = motionCV
+        self.kcalPerMin = kcalPerMin
+    }
+}
+
+// MARK: - Output
+
+/// A predicted coarse class + confidence for one workout window. Advisory only — see file header.
+public struct WorkoutClassPrediction: Equatable, Sendable, Codable {
+    public let predictedClass: CoarseWorkoutClass
+    /// 0...1. Reflects BOTH how cleanly the winner beat the runner-up (margin) and how complete the
+    /// inputs were (tick coverage, %HRR availability) — never higher than the evidence supports.
+    public let confidence: Double
+    /// Every scored candidate's raw match score (0...1), keyed by class. Always covers
+    /// `.walk/.run/.strength/.cycle/.ski` — `.other` has no prototype score (see file header) and is
+    /// never a key here; it is only ever `predictedClass`. Kept so a later validation pass can check
+    /// top-k / confusion against real labels, not just the single winner.
+    public let scores: [CoarseWorkoutClass: Double]
+
+    public init(predictedClass: CoarseWorkoutClass, confidence: Double, scores: [CoarseWorkoutClass: Double]) {
+        self.predictedClass = predictedClass; self.confidence = confidence; self.scores = scores
+    }
+}
+
+// MARK: - Pluggable interface (the ML/raw-IMU slot-in seam)
+
+/// Anything that can turn a feature vector into a prediction. `WorkoutTypeClassifier` (the heuristic
+/// below) is the only implementation today; a future ML model — trained on real labels, or fed richer
+/// raw-IMU-derived features through a wider `WorkoutClassFeatures` — conforms to the SAME protocol so
+/// call sites built against `any WorkoutTypeClassifying` don't change.
+public protocol WorkoutTypeClassifying: Sendable {
+    func classify(_ features: WorkoutClassFeatures) -> WorkoutClassPrediction
+}
+
+/// Thin instance adapter over `WorkoutTypeClassifier`'s static heuristic, for callers that want the
+/// protocol seam (dependency injection, swapping in a future model) rather than calling the namespace
+/// directly. Stateless; `WorkoutTypeClassifier.classify(_:)` is equally fine to call directly.
+public struct HeuristicWorkoutClassifier: WorkoutTypeClassifying {
+    public init() {}
+    public func classify(_ features: WorkoutClassFeatures) -> WorkoutClassPrediction {
+        WorkoutTypeClassifier.classify(features)
+    }
+}
+
+// MARK: - The heuristic
+
+public enum WorkoutTypeClassifier {
+
+    // MARK: Constants (first-pass heuristic — see file header; tune against real labels later)
+
+    /// Below this fraction of the window backed by a decoded activity-class tick, walk/run scoring
+    /// falls back to HR+motion-only (ticks are too sparse/absent — e.g. a WHOOP 4.0 capture — to trust).
+    public static let minTickCoverage: Double = 0.15
+    /// A candidate's top raw score must clear this to be reported as anything other than `.other`.
+    public static let minPlausibleScore: Double = 0.40
+    /// The winner must beat the runner-up by at least this much (both 0...1 scores) or the call is
+    /// too close and reports `.other` instead of an arbitrary tie-break.
+    public static let minMargin: Double = 0.05
+
+    // MARK: Public API
+
+    /// Score `features` against every candidate class and return the winner (or `.other` when nothing
+    /// clears `minPlausibleScore`/`minMargin`) plus a confidence that reflects both the margin and how
+    /// complete the inputs were.
+    public static func classify(_ features: WorkoutClassFeatures) -> WorkoutClassPrediction {
+        let scores = allScores(features)
+        let ranked = scores.sorted { $0.value > $1.value }
+        guard let top = ranked.first else {
+            return WorkoutClassPrediction(predictedClass: .other, confidence: 0, scores: scores)
+        }
+        let second = ranked.count > 1 ? ranked[1].value : 0.0
+        let margin = max(0.0, top.value - second)
+        let marginFactor = 0.5 + 0.5 * min(1.0, margin)
+        var confidence = top.value * marginFactor
+
+        // Data-completeness dampener: never let a prediction read more confident than the inputs
+        // backing it. Neither known → floor at 0.70×; both known → no penalty.
+        let hrrKnown = features.meanHRRPct != nil
+        let ticksKnown = features.tickCoverage >= minTickCoverage
+        var completeness = 0.70
+        if hrrKnown { completeness += 0.15 }
+        if ticksKnown { completeness += 0.15 }
+        confidence = min(1.0, max(0.0, confidence * completeness))
+
+        if top.value < minPlausibleScore || margin < minMargin {
+            return WorkoutClassPrediction(predictedClass: .other, confidence: confidence, scores: scores)
+        }
+        return WorkoutClassPrediction(predictedClass: top.key, confidence: confidence, scores: scores)
+    }
+
+    /// Every concrete class's raw [0,1] match score. Exposed (not just the winner) so validation
+    /// against real labels can check top-k, not only top-1.
+    public static func allScores(_ f: WorkoutClassFeatures) -> [CoarseWorkoutClass: Double] {
+        [
+            .walk: walkScore(f),
+            .run: runScore(f),
+            .strength: strengthScore(f),
+            .cycle: cycleScore(f),
+            .ski: skiScore(f),
+        ]
+    }
+
+    // MARK: - Ramp helpers (fuzzy-membership style, matches the plain documented-threshold style
+    // elsewhere in this package rather than an opaque weighted model)
+
+    /// 0 at/below `lo`, 1 at/above `hi`, linear between. `hi <= lo` degenerates to a step at `hi`.
+    static func rampUp(_ x: Double, _ lo: Double, _ hi: Double) -> Double {
+        guard hi > lo else { return x >= hi ? 1 : 0 }
+        return min(1, max(0, (x - lo) / (hi - lo)))
+    }
+    /// Mirror of `rampUp`: 1 at/below `lo`, 0 at/above `hi`.
+    static func rampDown(_ x: Double, _ lo: Double, _ hi: Double) -> Double { 1 - rampUp(x, lo, hi) }
+    /// Trapezoid membership: 0 below `a`, ramps to 1 over [a,b], flat 1 over [b,c], ramps to 0 over
+    /// [c,d], 0 above `d`. Requires `a <= b <= c <= d`.
+    static func plateau(_ x: Double, _ a: Double, _ b: Double, _ c: Double, _ d: Double) -> Double {
+        min(rampUp(x, a, b), rampDown(x, c, d))
+    }
+
+    /// How strongly the activity-class ticks should be trusted vs. falling back to HR+motion-only.
+    /// 0 with no/negligible tick coverage, ramping to 1 once coverage reaches `minTickCoverage`.
+    static func tickReliability(_ f: WorkoutClassFeatures) -> Double {
+        rampUp(f.tickCoverage, minTickCoverage * 0.3, minTickCoverage)
+    }
+
+    /// "No walk/run gait" evidence for the non-foot classes (strength/cycle/ski). When ticks are too
+    /// sparse to trust, this returns a NEUTRAL 0.5 rather than penalizing — an absent signal must not
+    /// read as evidence against a class (a WHOOP 4.0 capture has no @63 activity class at all).
+    static func gaitAbsenceScore(_ f: WorkoutClassFeatures) -> Double {
+        guard f.tickCoverage >= minTickCoverage else { return 0.5 }
+        return rampUp(f.stillFraction, 0.40, 0.75)
+    }
+
+    // MARK: - Per-class scoring
+
+    /// RUN: dominant run-classified ticks when available; else a smooth (low-`hrCV`), elevated-%HRR,
+    /// higher-impact (higher `motionVariance`) fallback signature.
+    static func runScore(_ f: WorkoutClassFeatures) -> Double {
+        let tick = rampUp(f.runFraction, 0.15, 0.55)
+        let hr = rampUp(f.meanHRRPct ?? 55, 45, 75)
+        let motion = plateau(f.motionVariance, 0.05, 0.10, 0.35, 0.60)
+        let smooth = rampDown(f.hrCV, 0.05, 0.12)
+        let tickWeighted = 0.55 * tick + 0.25 * hr + 0.15 * motion + 0.05 * smooth
+        let fallback = 0.45 * hr + 0.35 * motion + 0.20 * smooth
+        let rel = tickReliability(f)
+        return tickWeighted * rel + fallback * (1 - rel)
+    }
+
+    /// WALK: dominant walk-classified ticks when available; else a LOW-moderate %HRR band (walking
+    /// rarely pushes %HRR high) with modest motion variance (rhythmic but low-impact gait).
+    static func walkScore(_ f: WorkoutClassFeatures) -> Double {
+        let tick = rampUp(f.walkFraction, 0.15, 0.55)
+        let hr = plateau(f.meanHRRPct ?? 30, 5, 15, 35, 55)
+        let motion = plateau(f.motionVariance, 0.005, 0.02, 0.07, 0.12)
+        let tickWeighted = 0.60 * tick + 0.25 * hr + 0.15 * motion
+        let fallback = 0.55 * hr + 0.45 * motion
+        let rel = tickReliability(f)
+        return tickWeighted * rel + fallback * (1 - rel)
+    }
+
+    /// STRENGTH: no walk/run gait, BURSTY HR (sets separated by rest reads as high `hrCV`, unlike a
+    /// steady cardio effort), typically a lower sustained kcal/min than continuous cardio, and LOW
+    /// motion variance — a rack of lifts swings the wrist/torso through gravity far less than dynamic
+    /// ski turns or terrain do, which is what separates strength from ski's similarly-bursty-but-more-
+    /// mobile signature.
+    static func strengthScore(_ f: WorkoutClassFeatures) -> Double {
+        let noGait = gaitAbsenceScore(f)
+        let bursty = rampUp(f.hrCV, 0.06, 0.16)
+        let hr = plateau(f.meanHRRPct ?? 45, 15, 30, 80, 100)
+        let lowBurnRate = rampDown(f.kcalPerMin ?? 6, 6, 11)
+        let lowMotion = rampDown(f.motionVariance, 0.05, 0.15)
+        // `bursty` carries the most weight deliberately: it's the one genuinely distinctive signal
+        // here (HR sawtooth from sets-then-rest). hr/lowBurnRate are generic enough (moderate HR,
+        // moderate burn rate) that other steady-effort classes match them too, so a SMOOTH window
+        // (bursty ≈ 0) must not still score as strength just by having plausible HR/motion levels.
+        return 0.45 * bursty + 0.20 * noGait + 0.20 * lowMotion + 0.10 * hr + 0.05 * lowBurnRate
+    }
+
+    /// CYCLE: no walk/run gait, SMOOTH sustained elevated HR (low `hrCV`, unlike strength's sets), and
+    /// low motion variance — the torso/wrist stays comparatively still relative to on-foot gait.
+    static func cycleScore(_ f: WorkoutClassFeatures) -> Double {
+        let noGait = gaitAbsenceScore(f)
+        let smooth = rampDown(f.hrCV, 0.04, 0.10)
+        let hr = rampUp(f.meanHRRPct ?? 55, 35, 65)
+        let stablePosture = rampDown(f.motionVariance, 0.02, 0.08)
+        return 0.30 * noGait + 0.30 * smooth + 0.25 * hr + 0.15 * stablePosture
+    }
+
+    /// SKI: no walk/run gait, HIGHER and more variable posture signal than cycling (turns/terrain,
+    /// standing rather than seated), and a wide, intermittent HR pattern (runs interspersed with
+    /// lift-ride rest — more variable than cycle's steady spin, but not as short-cycle-bursty as
+    /// strength's sets).
+    static func skiScore(_ f: WorkoutClassFeatures) -> Double {
+        let noGait = gaitAbsenceScore(f)
+        let variablePosture = plateau(f.motionVariance, 0.06, 0.14, 0.45, 0.70)
+        let hr = plateau(f.meanHRRPct ?? 45, 20, 35, 85, 100)
+        let intermittent = plateau(f.hrCV, 0.05, 0.09, 0.20, 0.32)
+        return 0.30 * noGait + 0.30 * variablePosture + 0.20 * hr + 0.20 * intermittent
+    }
+}
+
+// MARK: - Feature extraction from the raw decoded stores
+
+/// Builds a `WorkoutClassFeatures` vector for a [start, end] window from the SAME decoded streams
+/// `WorkoutDetector`/`AutoWorkoutDetector` already read (`HRSample`, `GravitySample`, `StepSample`) —
+/// no new store, no new decode. Pure/deterministic; slices the caller's arrays to the window itself so
+/// callers can pass a whole day's streams or an already-sliced window interchangeably.
+public enum WorkoutTypeFeatureExtractor {
+
+    /// - Parameters:
+    ///   - hr: HR samples covering (at least) the window; required — nil result if none fall inside.
+    ///   - gravity: gravity samples covering the window (and a little before, ideally, so the first
+    ///     in-window delta isn't a false 0 — matches `WorkoutDetector.activitySeries` behavior either
+    ///     way).
+    ///   - steps: step/activity-class samples covering the window; may be empty (pre-#316 firmware or
+    ///     a WHOOP 4.0) — `tickCoverage` reports 0 and the classifier falls back to HR+motion.
+    ///   - start/end: window bounds, unix seconds (inclusive), e.g. an `ExerciseSession`'s.
+    ///   - restingHR: day resting-HR baseline; nil → derived from the window's own HR (10th
+    ///     percentile), same fallback `WorkoutDetector.detect` uses.
+    ///   - maxHR: HRmax; nil → `StrainScorer.estimateHRmax` over the window's HR.
+    ///   - caloriesKcal: the window's estimated calories (e.g. `ExerciseSession.caloriesKcal`), if
+    ///     already computed; nil → `kcalPerMin` is nil.
+    public static func extract(hr: [HRSample], gravity: [GravitySample], steps: [StepSample],
+                               start: Int, end: Int,
+                               restingHR: Double? = nil, maxHR: Double? = nil,
+                               caloriesKcal: Double? = nil) -> WorkoutClassFeatures? {
+        guard end > start else { return nil }
+        let hrWindow = hr.filter { $0.ts >= start && $0.ts <= end }.sorted { $0.ts < $1.ts }
+        guard !hrWindow.isEmpty else { return nil }
+
+        let durationSec = Double(end - start)
+        let bpms = hrWindow.map { Double($0.bpm) }
+        let meanHR = mean(bpms)
+        let peakHR = hrWindow.map { $0.bpm }.max() ?? Int(meanHR.rounded())
+        let hrCV = meanHR > 0 ? stddev(bpms) / meanHR : 0
+
+        // %HRR: same fallback ladder as WorkoutDetector.detect — caller-supplied resting/max HR, else
+        // derive from the window's own HR.
+        let restHR = restingHR ?? WorkoutDetector.deriveRestingHR(hrWindow.map { (ts: $0.ts, bpm: Double($0.bpm)) })
+        let effMaxHR: Double? = maxHR ?? {
+            let (est, _) = StrainScorer.estimateHRmax(bpms, age: nil)
+            return est > 0 ? est : nil
+        }()
+        var meanHRRPct: Double? = nil
+        if let m = effMaxHR, m > restHR {
+            let hrReserve = m - restHR
+            meanHRRPct = mean(bpms.map { StrainScorer.pctHRR($0, restingHR: restHR, hrReserve: hrReserve) })
+        }
+
+        // Gravity-derived motion shape, via the SAME intensity series WorkoutDetector uses for detection.
+        let intensitySeries = WorkoutDetector.activitySeries(gravity)
+            .filter { $0.ts >= start && $0.ts <= end }
+            .map { $0.intensity }
+        let motionMean = mean(intensitySeries)
+        let motionVariance = variance(intensitySeries)
+        let motionCV = motionMean > 0 ? stddev(intensitySeries) / motionMean : 0
+
+        // Activity-class tick composition.
+        let stepsWindow = steps.filter { $0.ts >= start && $0.ts <= end }
+        let validTicks = stepsWindow.compactMap { $0.activityClass }
+        let tickCoverage = min(1.0, Double(validTicks.count) / max(1.0, durationSec))
+        var stillFraction = 0.0, walkFraction = 0.0, runFraction = 0.0
+        if !validTicks.isEmpty {
+            let n = Double(validTicks.count)
+            stillFraction = Double(validTicks.filter { $0 == 0 }.count) / n
+            walkFraction = Double(validTicks.filter { $0 == 1 }.count) / n
+            runFraction = Double(validTicks.filter { $0 == 2 }.count) / n
+        }
+
+        let kcalPerMin = caloriesKcal.map { $0 / (durationSec / 60.0) }
+
+        return WorkoutClassFeatures(
+            durationSec: durationSec, meanHR: meanHR, peakHR: peakHR, meanHRRPct: meanHRRPct, hrCV: hrCV,
+            stillFraction: stillFraction, walkFraction: walkFraction, runFraction: runFraction,
+            tickCoverage: tickCoverage, motionVariance: motionVariance, motionCV: motionCV,
+            kcalPerMin: kcalPerMin)
+    }
+
+    // MARK: - Small stats helpers (population variance/stdev; no external dependency)
+
+    static func mean(_ xs: [Double]) -> Double { xs.isEmpty ? 0 : xs.reduce(0, +) / Double(xs.count) }
+
+    static func variance(_ xs: [Double]) -> Double {
+        guard xs.count > 1 else { return 0 }
+        let m = mean(xs)
+        return xs.reduce(0) { $0 + ($1 - m) * ($1 - m) } / Double(xs.count)
+    }
+
+    static func stddev(_ xs: [Double]) -> Double { variance(xs).squareRoot() }
+}

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/WorkoutTypeClassifierTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/WorkoutTypeClassifierTests.swift
@@ -1,0 +1,289 @@
+import XCTest
+@testable import StrandAnalytics
+import WhoopProtocol
+
+/// Synthetic-fixture tests for the coarse `WorkoutTypeClassifier` (and its `WorkoutClassFeatures`
+/// scoring directly). Per the CLAUDE.md derived-signal validation rule, each class is exercised with
+/// MULTIPLE distinct injected patterns rather than one lucky example, plus an ambiguous window that
+/// must NOT get a confident specific label.
+///
+/// Real-world validation against labeled workouts (Oura-import `workout.sport` ground truth) is an
+/// explicit, separate follow-up — these fixtures only prove the heuristic recovers the shapes it was
+/// designed around.
+final class WorkoutTypeClassifierTests: XCTestCase {
+
+    // MARK: - Feature-vector builder (keeps test cases terse and readable)
+
+    private func features(durationMin: Double = 30,
+                          meanHR: Double, peakHR: Int, meanHRRPct: Double?, hrCV: Double,
+                          stillFraction: Double = 0, walkFraction: Double = 0, runFraction: Double = 0,
+                          tickCoverage: Double = 0,
+                          motionVariance: Double, motionCV: Double = 0.5,
+                          kcalPerMin: Double?) -> WorkoutClassFeatures {
+        WorkoutClassFeatures(
+            durationSec: durationMin * 60, meanHR: meanHR, peakHR: peakHR, meanHRRPct: meanHRRPct,
+            hrCV: hrCV, stillFraction: stillFraction, walkFraction: walkFraction, runFraction: runFraction,
+            tickCoverage: tickCoverage, motionVariance: motionVariance, motionCV: motionCV,
+            kcalPerMin: kcalPerMin)
+    }
+
+    // MARK: - RUN: two distinct injected patterns
+
+    func testRunShapedWindow_dominantRunTicks_isClassifiedRun() {
+        // Dominant run-classified ticks, elevated %HRR, higher-impact motion, smooth (low-CV) HR.
+        let f = features(meanHR: 155, peakHR: 168, meanHRRPct: 70, hrCV: 0.04,
+                         stillFraction: 0.05, walkFraction: 0.1, runFraction: 0.8, tickCoverage: 0.9,
+                         motionVariance: 0.20, kcalPerMin: 11)
+        let out = WorkoutTypeClassifier.classify(f)
+        XCTAssertEqual(out.predictedClass, .run, "scores: \(out.scores)")
+        XCTAssertGreaterThan(out.confidence, 0.4)
+    }
+
+    func testRunShapedWindow_noTicks_fallsBackToHRAndMotion() {
+        // No activity-class ticks at all (e.g. a WHOOP 4.0 capture) — must still read RUN from the
+        // HR+motion fallback alone (high %HRR, smooth HR, high-impact motion).
+        let f = features(meanHR: 160, peakHR: 172, meanHRRPct: 72, hrCV: 0.03,
+                         tickCoverage: 0, motionVariance: 0.25, kcalPerMin: 12)
+        let out = WorkoutTypeClassifier.classify(f)
+        XCTAssertEqual(out.predictedClass, .run, "scores: \(out.scores)")
+    }
+
+    // MARK: - WALK: two distinct injected patterns, incl. the "low-HR walk" from the brief
+
+    func testLowHRWalk_isClassifiedWalk() {
+        // The brief's canonical case: a low-HR walk. Dominant walk ticks, LOW %HRR, modest motion.
+        let f = features(meanHR: 96, peakHR: 104, meanHRRPct: 22, hrCV: 0.05,
+                         stillFraction: 0.1, walkFraction: 0.85, runFraction: 0.05, tickCoverage: 0.9,
+                         motionVariance: 0.03, kcalPerMin: 3.5)
+        let out = WorkoutTypeClassifier.classify(f)
+        XCTAssertEqual(out.predictedClass, .walk, "scores: \(out.scores)")
+        XCTAssertGreaterThan(out.confidence, 0.4)
+    }
+
+    func testBriskWalk_higherHR_stillClassifiedWalk() {
+        // A brisker walk: higher (but not run-level) %HRR, still dominant walk ticks.
+        let f = features(meanHR: 118, peakHR: 128, meanHRRPct: 38, hrCV: 0.04,
+                         stillFraction: 0.05, walkFraction: 0.9, runFraction: 0.05, tickCoverage: 0.85,
+                         motionVariance: 0.05, kcalPerMin: 5)
+        let out = WorkoutTypeClassifier.classify(f)
+        XCTAssertEqual(out.predictedClass, .walk, "scores: \(out.scores)")
+    }
+
+    // MARK: - STRENGTH: two distinct injected patterns, incl. the "high-HR low-cadence" case
+
+    func testHighHRLowCadenceWindow_isClassifiedStrength() {
+        // The brief's canonical case: high HR, no walk/run gait ("low cadence"), bursty sets-then-rest
+        // HR pattern, lower sustained burn rate than continuous cardio.
+        let f = features(meanHR: 140, peakHR: 172, meanHRRPct: 65, hrCV: 0.18,
+                         stillFraction: 0.85, walkFraction: 0.05, runFraction: 0.05, tickCoverage: 0.9,
+                         motionVariance: 0.03, kcalPerMin: 5)
+        let out = WorkoutTypeClassifier.classify(f)
+        XCTAssertEqual(out.predictedClass, .strength, "scores: \(out.scores)")
+        XCTAssertGreaterThan(out.confidence, 0.3)
+    }
+
+    func testModerateHRBurstySets_isClassifiedStrength() {
+        // A gentler lifting session: moderate %HRR (not a cardio spike), still bursty HR, no gait ticks.
+        let f = features(meanHR: 110, peakHR: 145, meanHRRPct: 42, hrCV: 0.14,
+                         stillFraction: 0.8, walkFraction: 0.1, runFraction: 0.1, tickCoverage: 0.7,
+                         motionVariance: 0.02, kcalPerMin: 4)
+        let out = WorkoutTypeClassifier.classify(f)
+        XCTAssertEqual(out.predictedClass, .strength, "scores: \(out.scores)")
+    }
+
+    // MARK: - CYCLE: two distinct injected patterns
+
+    func testSteadyCycle_isClassifiedCycle() {
+        // No gait ticks, smooth (low-CV) sustained elevated HR, low motion variance (stable torso).
+        let f = features(meanHR: 145, peakHR: 158, meanHRRPct: 60, hrCV: 0.03,
+                         stillFraction: 0.9, walkFraction: 0.05, runFraction: 0.05, tickCoverage: 0.9,
+                         motionVariance: 0.015, kcalPerMin: 9)
+        let out = WorkoutTypeClassifier.classify(f)
+        XCTAssertEqual(out.predictedClass, .cycle, "scores: \(out.scores)")
+        XCTAssertGreaterThan(out.confidence, 0.3)
+    }
+
+    func testEasySpin_noTicksAtAll_isClassifiedCycle() {
+        // No activity-class data whatsoever (tickCoverage 0) — must not be penalized as if "no gait"
+        // were disproven; HR+motion alone should still read CYCLE (smooth, stable, moderate HR).
+        let f = features(meanHR: 120, peakHR: 132, meanHRRPct: 40, hrCV: 0.04,
+                         tickCoverage: 0, motionVariance: 0.01, kcalPerMin: 6)
+        let out = WorkoutTypeClassifier.classify(f)
+        XCTAssertEqual(out.predictedClass, .cycle, "scores: \(out.scores)")
+    }
+
+    // MARK: - SKI: two distinct injected patterns
+
+    func testDownhillSkiSession_isClassifiedSki() {
+        // No gait ticks, high posture/motion variance (turns/terrain), wide intermittent HR (runs
+        // interspersed with lift-ride rest) — more variable than cycle's steady spin.
+        let f = features(durationMin: 120, meanHR: 128, peakHR: 165, meanHRRPct: 55, hrCV: 0.16,
+                         stillFraction: 0.85, walkFraction: 0.1, runFraction: 0.05, tickCoverage: 0.6,
+                         motionVariance: 0.25, kcalPerMin: 7)
+        let out = WorkoutTypeClassifier.classify(f)
+        XCTAssertEqual(out.predictedClass, .ski, "scores: \(out.scores)")
+    }
+
+    func testSkiSession_lighterDay_isClassifiedSki() {
+        // A gentler ski day: lower average HRR (more time on lifts / easy runs) but the same
+        // high-variance, intermittent signature.
+        let f = features(durationMin: 150, meanHR: 108, peakHR: 150, meanHRRPct: 38, hrCV: 0.14,
+                         stillFraction: 0.85, walkFraction: 0.1, runFraction: 0.05, tickCoverage: 0.5,
+                         motionVariance: 0.20, kcalPerMin: 5)
+        let out = WorkoutTypeClassifier.classify(f)
+        XCTAssertEqual(out.predictedClass, .ski, "scores: \(out.scores)")
+    }
+
+    // MARK: - Ambiguous → low confidence / other
+
+    func testAmbiguousWindow_isOtherOrLowConfidence() {
+        // Deliberately doesn't match any prototype well: moderate-elevated HR with essentially no
+        // gait ticks, low motion variance, but ALSO not smooth enough to read as cycle and not bursty
+        // enough to read as strength — sits in the crack between bands.
+        let f = features(meanHR: 118, peakHR: 135, meanHRRPct: 45, hrCV: 0.08,
+                         tickCoverage: 0, motionVariance: 0.045, kcalPerMin: 5.2)
+        let out = WorkoutTypeClassifier.classify(f)
+        XCTAssertTrue(out.predictedClass == .other || out.confidence < 0.4,
+                      "expected .other or low confidence, got \(out.predictedClass) @ \(out.confidence), scores: \(out.scores)")
+    }
+
+    func testVeryThinData_lowConfidence() {
+        // Minimal window, no ticks, no resolvable %HRR (nil) — whatever the guess, confidence must be
+        // damped by the missing inputs, never reading as fully confident.
+        let f = features(meanHR: 100, peakHR: 110, meanHRRPct: nil, hrCV: 0.05,
+                         tickCoverage: 0, motionVariance: 0.02, kcalPerMin: nil)
+        let out = WorkoutTypeClassifier.classify(f)
+        XCTAssertLessThan(out.confidence, 0.7, "confidence should be damped by missing HRR/tick data")
+    }
+
+    // MARK: - Confidence sanity: a clean signature should outrank an ambiguous one
+
+    func testCleanSignatureIsMoreConfidentThanAmbiguous() {
+        let clean = features(meanHR: 96, peakHR: 104, meanHRRPct: 22, hrCV: 0.05,
+                             stillFraction: 0.1, walkFraction: 0.85, runFraction: 0.05, tickCoverage: 0.9,
+                             motionVariance: 0.03, kcalPerMin: 3.5)
+        let ambiguous = features(meanHR: 118, peakHR: 135, meanHRRPct: 45, hrCV: 0.08,
+                                 tickCoverage: 0, motionVariance: 0.045, kcalPerMin: 5.2)
+        let cleanOut = WorkoutTypeClassifier.classify(clean)
+        let ambiguousOut = WorkoutTypeClassifier.classify(ambiguous)
+        XCTAssertGreaterThan(cleanOut.confidence, ambiguousOut.confidence)
+    }
+
+    // MARK: - `scores` always covers all five concrete classes, never `.other`
+
+    func testScoresCoverAllConcreteClassesNeverOther() {
+        let f = features(meanHR: 120, peakHR: 140, meanHRRPct: 40, hrCV: 0.06, motionVariance: 0.05,
+                         kcalPerMin: 5)
+        let out = WorkoutTypeClassifier.classify(f)
+        XCTAssertEqual(Set(out.scores.keys), Set([.walk, .run, .strength, .cycle, .ski]))
+        XCTAssertNil(out.scores[.other])
+        for (_, v) in out.scores {
+            XCTAssertGreaterThanOrEqual(v, 0)
+            XCTAssertLessThanOrEqual(v, 1)
+        }
+    }
+
+    // MARK: - HeuristicWorkoutClassifier (protocol seam) matches the static namespace
+
+    func testHeuristicWorkoutClassifierMatchesStaticClassify() {
+        let f = features(meanHR: 96, peakHR: 104, meanHRRPct: 22, hrCV: 0.05,
+                         stillFraction: 0.1, walkFraction: 0.85, runFraction: 0.05, tickCoverage: 0.9,
+                         motionVariance: 0.03, kcalPerMin: 3.5)
+        let viaProtocol: any WorkoutTypeClassifying = HeuristicWorkoutClassifier()
+        XCTAssertEqual(viaProtocol.classify(f), WorkoutTypeClassifier.classify(f))
+    }
+}
+
+/// Tests for `WorkoutTypeFeatureExtractor` — building a `WorkoutClassFeatures` from raw decoded
+/// streams (`HRSample`, `GravitySample`, `StepSample`), the same stores `WorkoutDetector` reads.
+final class WorkoutTypeFeatureExtractorTests: XCTestCase {
+
+    private func hrBlock(_ start: Int, _ durS: Int, _ bpm: Int) -> [HRSample] {
+        (0..<durS).map { HRSample(ts: start + $0, bpm: bpm) }
+    }
+
+    private func gravityBlock(_ start: Int, _ durS: Int, deltaMag: Double) -> [GravitySample] {
+        // Alternate x between 0 and deltaMag each second so activitySeries' L2 delta ≈ deltaMag per step.
+        (0..<durS).map { i in
+            GravitySample(ts: start + i, x: (i % 2 == 0) ? 0 : deltaMag, y: 0, z: 1)
+        }
+    }
+
+    private func stepBlock(_ start: Int, _ durS: Int, activityClass: Int) -> [StepSample] {
+        (0..<durS).map { StepSample(ts: start + $0, counter: $0, activityClass: activityClass) }
+    }
+
+    func testExtractRunWindow_recoversRunDominantComposition() {
+        let start = 1_000_000, dur = 20 * 60
+        let hr = hrBlock(start, dur, 160)
+        let gravity = gravityBlock(start, dur, deltaMag: 0.4)
+        let steps = stepBlock(start, dur, activityClass: 2)  // 2 = run
+        let f = WorkoutTypeFeatureExtractor.extract(hr: hr, gravity: gravity, steps: steps,
+                                                     start: start, end: start + dur,
+                                                     restingHR: 60, maxHR: 190, caloriesKcal: 240)
+        XCTAssertNotNil(f)
+        guard let f else { return }
+        XCTAssertEqual(f.runFraction, 1.0, accuracy: 0.001)
+        XCTAssertEqual(f.tickCoverage, 1.0, accuracy: 0.05)
+        XCTAssertGreaterThan(f.meanHRRPct ?? 0, 50)
+        XCTAssertGreaterThan(f.motionVariance, 0)
+        XCTAssertEqual(f.kcalPerMin ?? 0, 12.0, accuracy: 0.01)
+        // Round-trips into a RUN classification end-to-end.
+        XCTAssertEqual(WorkoutTypeClassifier.classify(f).predictedClass, .run, "scores: \(WorkoutTypeClassifier.classify(f).scores)")
+    }
+
+    func testExtractWalkWindow_recoversWalkDominantComposition() {
+        let start = 2_000_000, dur = 30 * 60
+        let hr = hrBlock(start, dur, 95)
+        let gravity = gravityBlock(start, dur, deltaMag: 0.05)
+        let steps = stepBlock(start, dur, activityClass: 1)  // 1 = walk
+        let f = WorkoutTypeFeatureExtractor.extract(hr: hr, gravity: gravity, steps: steps,
+                                                     start: start, end: start + dur,
+                                                     restingHR: 60, maxHR: 180, caloriesKcal: 105)
+        XCTAssertNotNil(f)
+        guard let f else { return }
+        XCTAssertEqual(f.walkFraction, 1.0, accuracy: 0.001)
+        XCTAssertEqual(WorkoutTypeClassifier.classify(f).predictedClass, .walk, "scores: \(WorkoutTypeClassifier.classify(f).scores)")
+    }
+
+    func testExtractWithNoStepData_tickCoverageIsZero() {
+        // No StepSample rows at all in the window (pre-#316 firmware / WHOOP 4.0) — tickCoverage must
+        // read 0, not crash or divide-by-zero, and the fractions must be 0 (not NaN).
+        let start = 3_000_000, dur = 15 * 60
+        let hr = hrBlock(start, dur, 150)
+        let gravity = gravityBlock(start, dur, deltaMag: 0.3)
+        let f = WorkoutTypeFeatureExtractor.extract(hr: hr, gravity: gravity, steps: [],
+                                                     start: start, end: start + dur)
+        XCTAssertNotNil(f)
+        guard let f else { return }
+        XCTAssertEqual(f.tickCoverage, 0)
+        XCTAssertEqual(f.stillFraction, 0)
+        XCTAssertEqual(f.walkFraction, 0)
+        XCTAssertEqual(f.runFraction, 0)
+        XCTAssertFalse(f.hrCV.isNaN)
+        XCTAssertFalse(f.motionVariance.isNaN)
+    }
+
+    func testExtractWithNoHRInWindow_returnsNil() {
+        let start = 4_000_000
+        XCTAssertNil(WorkoutTypeFeatureExtractor.extract(hr: [], gravity: [], steps: [],
+                                                         start: start, end: start + 600))
+    }
+
+    func testExtractDegenerateWindow_returnsNil() {
+        let hr = hrBlock(5_000_000, 10, 100)
+        XCTAssertNil(WorkoutTypeFeatureExtractor.extract(hr: hr, gravity: [], steps: [],
+                                                         start: 5_000_000, end: 5_000_000))
+        XCTAssertNil(WorkoutTypeFeatureExtractor.extract(hr: hr, gravity: [], steps: [],
+                                                         start: 5_000_100, end: 5_000_000))
+    }
+
+    func testExtractWithNoCaloriesInput_kcalPerMinIsNil() {
+        let start = 6_000_000, dur = 600
+        let hr = hrBlock(start, dur, 130)
+        let f = WorkoutTypeFeatureExtractor.extract(hr: hr, gravity: [], steps: [],
+                                                     start: start, end: start + dur)
+        XCTAssertNotNil(f)
+        XCTAssertNil(f?.kcalPerMin)
+    }
+}


### PR DESCRIPTION
## What

A pure, coarse workout-type classifier in `Packages/StrandAnalytics` — given a detected
workout window's features, it predicts a BROAD activity class (`walk` / `run` / `strength`
/ `cycle` / `ski` / `other`) plus a confidence. Deliberately coarse: it does not attempt
fine-grained sport discrimination (e.g. basketball vs tennis), which would need raw
high-rate IMU this app doesn't capture.

New files only:
- `Packages/StrandAnalytics/Sources/StrandAnalytics/WorkoutTypeClassifier.swift`
- `Packages/StrandAnalytics/Tests/StrandAnalyticsTests/WorkoutTypeClassifierTests.swift`

Nothing else changes — no `project.yml`, no app-layer code, no UIKit/CoreBluetooth.

## Signals used (already captured, no raw IMU)

- **HR profile** over the window — mean/peak, Karvonen %HRR (reuses `StrainScorer.pctHRR`
  / `estimateHRmax`), and HR coefficient-of-variation as a "steady vs. sawtooth" shape signal.
- **Activity-class tick composition** — `StepSample.activityClass` (0 still / 1 walk / 2 run,
  community finding #316), rolled up to still/walk/run fractions + a tick-coverage measure so
  the classifier knows how much to trust them.
- **Gravity-derived motion variance** — reuses the exact same per-record L2 gravity-delta
  intensity series `WorkoutDetector.activitySeries` already computes for detection, read here
  as a shape signal (posture variance / burstiness) rather than a threshold gate.
- **Duration and calories** (kcal/min), when available.

The gravity stream is ~1 Hz, well below the Nyquist rate a real gait/pedal cadence needs. Per
the repo's derived-signal rule (and the withdrawn PPG→HR estimate, #194), this file
deliberately does **not** do autocorrelation/spectral analysis on that fixed low rate to claim
a cadence estimate — the "cadence proxy" in `WorkoutClassFeatures.motionCV` is a coefficient-
of-variation burstiness statistic, documented as such, not a frequency estimate.

## Design: a clean interface for a future ML/raw-IMU upgrade

- `WorkoutClassFeatures` — the scored feature vector. Construct it directly from a labeled
  workout's own summary stats (e.g. an Oura-import `workout` row) to validate later, or build
  it from raw streams via `WorkoutTypeFeatureExtractor.extract(hr:gravity:steps:start:end:...)`.
- `WorkoutTypeClassifying` protocol + `HeuristicWorkoutClassifier` adapter — the heuristic here
  is the only implementation today; a future ML model (or one fed richer raw-IMU features)
  conforms to the same protocol so call sites don't change.
- `WorkoutClassPrediction.scores` reports every candidate class's raw match score (not just the
  winner), so a later validation pass can compute top-k/confusion against real labels without
  re-deriving anything.

## Advisory / opt-in, per the derived-signal rule

This is instrumentation, matching `AutoWorkoutDetector`'s existing opt-in, non-destructive
pattern: it labels/scores a detected window, it never overrides a user's own sport selection,
and it must never gate a downstream score (recovery, strain, etc.). It's shipped as a
first-pass heuristic — documented, clamped ramp thresholds (see the constants + per-class
scoring comments in the file) — because it has only been validated against synthetic
fixtures so far, not real labeled data.

**Deferred (explicitly, not silently dropped):**
- **Real-label validation** against Oura-import `workout.sport` ground truth
  (walking/strengthTraining/downhillSkiing/running/etc.) — I have the code, not a user's
  import history, so this run happens separately against real imported workouts.
- **Raw-IMU / ML upgrade** — the `WorkoutTypeClassifying` protocol and the `scores`-per-class
  output exist specifically so a future model (or a version fed real high-rate IMU features,
  if that's ever captured) can slot in without changing callers.

## Android

No `com.noop.analytics` Kotlin twin in this PR. This is net-new, still-unvalidated MVP code —
not a change to an existing byte-identical decoder/formula/stored value — so porting now would
double the tuning surface before real-label validation settles the thresholds on the Swift
side first. Also consistent with prior direction on this fork (#250) that Kotlin twins for
Swift-only contributions here are transcription-only or deferred. Happy to open a follow-up
once the heuristic is validated, or if a Kotlin contributor wants to pick it up sooner.

## Tests

`cd Packages/StrandAnalytics && swift test` — 21 new tests
(`WorkoutTypeClassifierTests`, `WorkoutTypeFeatureExtractorTests`), full package suite 1058
passed / 0 failed. Per the derived-signal validation rule, each class is exercised with
**multiple distinct injected patterns**, not one lucky example:

- Run: dominant run-ticks signature, and a no-ticks HR+motion-only fallback signature.
- Walk: the brief's low-HR walk, and a brisker higher-HR walk.
- Strength: the brief's high-HR/low-cadence (bursty sets, no gait) signature, and a gentler
  moderate-HR bursty-sets signature.
- Cycle: a steady dominant-tick-coverage signature, and a no-activity-class-data-at-all
  fallback signature (proving absent ticks aren't scored as evidence against a class).
- Ski: two distinct sessions (harder/higher-HR day, lighter/lower-HR day) sharing the
  high-variance/intermittent signature that separates it from cycle and strength.
- Ambiguous window → `.other` or low confidence (never a confident wrong specific guess).
- Confidence sanity (clean signature outranks ambiguous), scores always cover all five
  concrete classes and never include `.other`, and the protocol adapter matches the static
  namespace's output.
- Extractor edge cases: no step data (tick coverage 0, no NaNs), no HR in window (nil), and a
  degenerate/zero-or-negative-length window (nil).