### PR TITLE
feat(store): persist the WHOOP 5.0 v26 raw PPG waveform (#156 follow-up)

### DIFF
--- a/Packages/WhoopProtocol/Sources/WhoopProtocol/HistoricalStreams.swift
+++ b/Packages/WhoopProtocol/Sources/WhoopProtocol/HistoricalStreams.swift
@@ -55,8 +55,11 @@ public func isPlausibleHistoricalUnix(_ ts: Int, wallNow: Int,
 ///
 /// Console (type-50, `frame[typeIndex] == 0x32`) frames are strap-side debug-log text that decode to
 /// zero rows BY DESIGN and are never returned. 5/MG v26 (raw PPG block, hist_version 26) is also
-/// skipped: it is known-and-unstored by design, not lost biometric data. Only genuine type-47
-/// record frames whose payload would otherwise be silently dropped are returned.
+/// skipped unconditionally (even on a CRC failure): a v26 record's payload is the optical waveform,
+/// which `extractHistoricalStreams` now persists durably in its OWN stream (`Streams.ppgWaveform` /
+/// WhoopStore's `ppgWaveformSample` table, issue #156 follow-up) whenever it decodes — this reject
+/// archive exists for genuinely-undecodable records, and a decoded v26 record was never one of those.
+/// Only genuine type-47 record frames whose payload would otherwise be silently dropped are returned.
 ///
 /// Used by the Backfiller/BLEManager to archive undecodable history BEFORE acking the trim. Mirrors
 /// the Android rejectedHistoricalRecords so one mapping toolchain re-ingests both archives.
@@ -70,7 +73,7 @@ public func rejectedHistoricalRecords(_ rawFrames: [[UInt8]], family: DeviceFami
         // Only genuine HISTORICAL_DATA records (47). Console (50) and METADATA frames have a
         // different type byte, so they never pass this gate — they are excluded by construction.
         guard f.count > typeIndex, Int(f[typeIndex]) == 47 else { return false }
-        if family == .whoop5, f.count > versionIndex, Int(f[versionIndex]) == 26 { return false }  // v26 PPG: skipped by design
+        if family == .whoop5, f.count > versionIndex, Int(f[versionIndex]) == 26 { return false }  // v26 PPG: has its own durable stream (ppgWaveform), not this reject archive
         let p = parseFrame(f, family: family)
         // Envelope/CRC reject: parse failed outright or the CRC32 trailer mismatched.
         if !p.ok || p.crcOK == false { return true }
@@ -176,6 +179,8 @@ public func extractHistoricalStreams(_ parsed: [ParsedFrame],
     // v26 optical-PPG records (issue #156): no measured HR/motion, just the 24 Hz waveform. Collect
     // (corrected-wall ts, samples) here and derive a per-second HR after the loop (PpgHr.derivePpgHr),
     // so the timeline stays continuous through the v26-heavy stretches that have no v18 HR summary.
+    // The SAME (ts, samples) are also appended to `out.ppgWaveform` below (issue #156 follow-up) so the
+    // raw waveform is durable too, not just the derived estimate this local buffer exists to produce.
     var ppgRecords: [(ts: Int, samples: [Int])] = []
     for r in parsed {
         if !r.ok || r.crcOK == false { continue }
@@ -187,10 +192,13 @@ public func extractHistoricalStreams(_ parsed: [ParsedFrame],
             // `correctedWall` returns nil for an implausible ts (covers the v26 PPG baseTs too, since the
             // v26 waveform rides this same `unix`) — skip the whole record so no garbage-ts row is banked.
             guard let rawTs = p["unix"]?.intValue, let ts = correctedWall(rawTs) else { continue }
-            // v26 PPG buffer: stash the waveform for the post-loop HR estimator. A v26 record carries
-            // no heart_rate/spo2/gravity, so it adds nothing to the branches below — handled here only.
+            // v26 PPG buffer: stash the waveform for the post-loop HR estimator AND persist the raw
+            // samples themselves (issue #156 follow-up — previously ONLY the derived estimate survived,
+            // the waveform that produced it was discarded here). A v26 record carries no
+            // heart_rate/spo2/gravity, so it adds nothing to the branches below — handled here only.
             if let samples = p["ppg_waveform"]?.intArrayValue, !samples.isEmpty {
                 ppgRecords.append((ts: ts, samples: samples))
+                out.ppgWaveform.append(PpgWaveformSample(ts: ts, samples: samples))
             }
             if let bpm = p["heart_rate"]?.intValue, bpm != 0 {  // skip startup hr=0
                 out.hr.append(HRSample(ts: ts, bpm: bpm))

--- a/Packages/WhoopProtocol/Sources/WhoopProtocol/Streams.swift
+++ b/Packages/WhoopProtocol/Sources/WhoopProtocol/Streams.swift
@@ -202,6 +202,20 @@ public struct SleepStateSample: Equatable, Codable {
     public init(ts: Int, state: Int) { self.ts = ts; self.state = state }
 }
 
+/// The WHOOP 5.0 v26 optical PPG buffer's RAW waveform, one record per second (issue #156 follow-up).
+/// `PpgHr.derivePpgHr` already turns these into a per-second HR estimate (`ppgHr`), but until now the
+/// 24 Hz samples themselves were discarded the moment that estimate was taken — HistoricalStreams
+/// collected them into a transient `ppgRecords` buffer purely to feed the estimator, and nothing else
+/// ever saw them. Persisted here (and, in WhoopStore, its own table) so a future re-analysis — a better
+/// HR estimator, HRV-from-PPG, a waveform viewer — can run over the ORIGINAL samples, not just the
+/// derived bpm. `samples` are raw AC-coupled ADC counts, no invented scale (see
+/// `decodeWhoop5HistoricalV26`); a truncated frame can yield fewer than 24.
+public struct PpgWaveformSample: Equatable, Codable, Sendable {
+    public let ts: Int          // wall-clock unix seconds (one record per second)
+    public let samples: [Int]   // raw i16 ADC counts @24 Hz, verbatim from `ppg_waveform` (usually 24)
+    public init(ts: Int, samples: [Int]) { self.ts = ts; self.samples = samples }
+}
+
 public struct Streams: Equatable, Codable {
     public var hr: [HRSample]
     public var rr: [RRInterval]
@@ -217,6 +231,10 @@ public struct Streams: Equatable, Codable {
     /// PPG-derived per-second HR from the WHOOP 5.0 v26 optical buffer (issue #156). Kept separate from
     /// `hr` (the measured stream) so consumers can COALESCE without conflating the two sources.
     public var ppgHr: [PpgHrSample]
+    /// The RAW v26 optical PPG waveform itself (issue #156 follow-up), one record per second — the
+    /// samples `ppgHr` is derived FROM. Kept separate so a consumer that only wants the HR estimate
+    /// never pays for the 24x-larger raw stream, and so the two can be persisted/pruned independently.
+    public var ppgWaveform: [PpgWaveformSample]
     public var events: [WhoopEvent]
     public var battery: [BatterySample]
     /// #547 diagnostic: how many historical records `extractHistoricalStreams` DROPPED this chunk for an
@@ -239,11 +257,12 @@ public struct Streams: Equatable, Codable {
                 spo2: [SpO2Sample] = [], skinTemp: [SkinTempSample] = [],
                 resp: [RespSample] = [], gravity: [GravitySample] = [],
                 steps: [StepSample] = [], sleepState: [SleepStateSample] = [],
-                ppgHr: [PpgHrSample] = [],
+                ppgHr: [PpgHrSample] = [], ppgWaveform: [PpgWaveformSample] = [],
                 events: [WhoopEvent] = [], battery: [BatterySample] = []) {
         self.hr = hr; self.rr = rr
         self.spo2 = spo2; self.skinTemp = skinTemp; self.resp = resp; self.gravity = gravity
         self.steps = steps; self.sleepState = sleepState; self.ppgHr = ppgHr
+        self.ppgWaveform = ppgWaveform
         self.events = events; self.battery = battery
     }
 
@@ -253,13 +272,14 @@ public struct Streams: Equatable, Codable {
     public var isEmpty: Bool {
         hr.isEmpty && rr.isEmpty && spo2.isEmpty && skinTemp.isEmpty && resp.isEmpty
             && gravity.isEmpty && steps.isEmpty && sleepState.isEmpty && ppgHr.isEmpty
-            && events.isEmpty && battery.isEmpty
+            && ppgWaveform.isEmpty && events.isEmpty && battery.isEmpty
     }
 
     private enum CodingKeys: String, CodingKey {
         case hr, rr, spo2, skinTemp = "skin_temp", resp, gravity, steps
         case sleepState = "sleep_state"
         case ppgHr = "ppg_hr"
+        case ppgWaveform = "ppg_waveform"
         case events, battery
     }
 
@@ -276,6 +296,7 @@ public struct Streams: Equatable, Codable {
         steps = try c.decodeIfPresent([StepSample].self, forKey: .steps) ?? []
         sleepState = try c.decodeIfPresent([SleepStateSample].self, forKey: .sleepState) ?? []
         ppgHr = try c.decodeIfPresent([PpgHrSample].self, forKey: .ppgHr) ?? []
+        ppgWaveform = try c.decodeIfPresent([PpgWaveformSample].self, forKey: .ppgWaveform) ?? []
         events = try c.decodeIfPresent([WhoopEvent].self, forKey: .events) ?? []
         battery = try c.decodeIfPresent([BatterySample].self, forKey: .battery) ?? []
     }

--- a/Packages/WhoopProtocol/Tests/WhoopProtocolTests/Whoop5PpgWaveformTests.swift
+++ b/Packages/WhoopProtocol/Tests/WhoopProtocolTests/Whoop5PpgWaveformTests.swift
@@ -86,4 +86,50 @@ final class Whoop5PpgWaveformTests: XCTestCase {
         let meanStep = zip(w, w.dropFirst()).map { abs($1 - $0) }.reduce(0, +) / (w.count - 1)
         XCTAssertLessThan(meanStep * 4, range)
     }
+
+    // MARK: - Durable waveform persistence (issue #156 follow-up)
+    //
+    // Until now `extractHistoricalStreams` collected a v26 record's waveform into a transient local
+    // buffer ONLY to derive a per-second HR estimate (`ppgHr`); the samples themselves were discarded
+    // once that estimate was taken. These tests prove the raw waveform now survives as its OWN stream
+    // (`Streams.ppgWaveform`), independently of whether the HR estimator had enough context to run.
+
+    /// A single v26 record is one second of samples — nowhere near the >=3-consecutive-second run
+    /// `PpgHr.derivePpgHr` requires, so `ppgHr` stays empty. Before this change that meant the ENTIRE
+    /// record vanished (nothing else read `ppg_waveform`); now the raw waveform is still captured.
+    func testExtractHistoricalStreamsPersistsRawPpgWaveform() {
+        let f = parseFrame(bytes(v26Hex), family: .whoop5)
+        let streams = extractHistoricalStreams([f], deviceClockRef: 1_780_917_232, wallClockRef: 1_780_917_232)
+        XCTAssertEqual(streams.ppgWaveform, [PpgWaveformSample(ts: 1_780_917_232, samples: expectedWaveform)])
+        XCTAssertTrue(streams.ppgHr.isEmpty, "a lone 1 s record is too short for a confident HR estimate")
+        // Not "no rows at all" — the Backfiller's silent-data-loss diagnostic must see this as decoded.
+        XCTAssertFalse(streams.isEmpty)
+    }
+
+    /// `Streams.isEmpty` must count a waveform-only decode as non-empty even when `ppgHr` (derived FROM
+    /// it) is empty — otherwise the Backfiller's #77 "this chunk carried no sensor records" diagnostic
+    /// would misfire on a chunk that in fact persisted a raw waveform.
+    func testStreamsIsEmptyConsidersPpgWaveform() {
+        var s = Streams()
+        XCTAssertTrue(s.isEmpty)
+        s.ppgWaveform = [PpgWaveformSample(ts: 1, samples: [1, 2, 3])]
+        XCTAssertFalse(s.isEmpty)
+    }
+
+    /// Streams decode tolerance: a JSON missing `ppg_waveform` still decodes (defaults to empty), and a
+    /// present `ppg_waveform` round-trips, including negative (AC-coupled) sample values. Mirrors the
+    /// decodeIfPresent guard for the other biometric keys (see PpgHrTests' ppg_hr analogue).
+    func testStreamsDecodeToleratesMissingAndPresentPpgWaveform() throws {
+        let dec = JSONDecoder()
+        // Missing key → empty.
+        let s1 = try dec.decode(Streams.self, from: Data(#"{"hr":[]}"#.utf8))
+        XCTAssertTrue(s1.ppgWaveform.isEmpty)
+        // Present key → decoded under the snake_case CodingKey.
+        let json = #"{"ppg_waveform":[{"ts":1780917232,"samples":[-1432,-1332,12]}]}"#
+        let s2 = try dec.decode(Streams.self, from: Data(json.utf8))
+        XCTAssertEqual(s2.ppgWaveform, [PpgWaveformSample(ts: 1_780_917_232, samples: [-1432, -1332, 12])])
+        // Round-trip encode → decode is identity.
+        let round = try dec.decode(Streams.self, from: JSONEncoder().encode(s2))
+        XCTAssertEqual(round.ppgWaveform, s2.ppgWaveform)
+    }
 }

--- a/Packages/WhoopStore/Sources/WhoopStore/Database.swift
+++ b/Packages/WhoopStore/Sources/WhoopStore/Database.swift
@@ -525,6 +525,33 @@ extension WhoopStore {
                 WHERE efficiency > 1.5
                 """)
         }
+
+        // v27 (issue #156 follow-up): durable storage for the WHOOP 5.0 v26 optical PPG waveform. The
+        // strap's 24 Hz buffer was fully DECODED (`ppg_waveform`, 24 i16 ADC samples/record) but only
+        // ever used to derive a per-second HR estimate (`ppgHrSample`, v12) — the waveform itself was
+        // discarded right after, and `rejectedHistoricalRecords` explicitly excludes v26 from the
+        // undecodable-record reject archive ("known-and-unstored by design"), so it had no home at all.
+        //
+        // One row per (deviceId, ts) — the SAME shape as every other per-second decoded stream (hrSample,
+        // spo2Sample, ppgHrSample, …) — but the 24 samples are packed into a compact BLOB (2 bytes/sample,
+        // little-endian i16, `WhoopStore.packPpgSamples`/`unpackPpgSamples`) instead of 24 scalar rows.
+        // That keeps a v26-heavy night to roughly the same order of magnitude as ONE extra per-second
+        // stream (≈50 bytes/row), not 24x that. Additive only, a NEW table, no existing row touched.
+        //
+        // Retention: no pruning, matching every other durable per-second table (hrSample, spo2Sample, …
+        // are never pruned either) — this is decoded biometric history, not the transient raw outbox.
+        // `PrunePolicy`'s ~50 MB cap governs ONLY `rawBatch` (raw, pre-decode frames kept for re-decode /
+        // re-sync); it is untouched by and unrelated to this table. Growth here is bounded by how much
+        // v26 data a strap actually emits (firmware chooses v26 vs v18 per second, not every night is
+        // v26-heavy), not by an artificial cap.
+        migrator.registerMigration("v27-ppg-waveform") { db in
+            try db.create(table: "ppgWaveformSample") { t in
+                t.column("deviceId", .text).notNull()
+                t.column("ts", .integer).notNull()
+                t.column("samples", .blob).notNull()
+                t.primaryKey(["deviceId", "ts"])
+            }
+        }
         return migrator
     }
 }

--- a/Packages/WhoopStore/Sources/WhoopStore/DeviceRegistryStore.swift
+++ b/Packages/WhoopStore/Sources/WhoopStore/DeviceRegistryStore.swift
@@ -90,6 +90,11 @@ public struct DeviceRegistryStore: Sendable {
         // v25-oura-raw: the opt-in Oura cloud-import raw archive is deviceId-keyed too, so "delete this
         // device's data" must clear it — else an imported Oura source's payloads would survive deletion.
         "ouraRaw",
+        // v27-ppg-waveform (issue #156 follow-up): the durable raw v26 optical PPG waveform is
+        // deviceId-keyed exactly like every other per-second stream above — must be cleared too, or a
+        // "delete all of this device's data" leaves the raw waveform behind (the same privacy defect
+        // this list exists to close).
+        "ppgWaveformSample",
     ]
 
     /// Permanently delete every recorded sample/derived row belonging to one device, across all

--- a/Packages/WhoopStore/Sources/WhoopStore/StreamStore.swift
+++ b/Packages/WhoopStore/Sources/WhoopStore/StreamStore.swift
@@ -12,6 +12,35 @@ extension WhoopStore {
         return String(decoding: data, as: UTF8.self)
     }
 
+    /// Pack a decoded v26 PPG waveform's samples as little-endian i16 (2 bytes/sample) — a single
+    /// compact BLOB per (deviceId, ts) row instead of 24 scalar rows (issue #156 follow-up, v27). Any
+    /// sample count is handled (a truncated frame can decode fewer than 24); each value is truncated to
+    /// Int16's range, matching the wire format it came from (`readI16` in the decoder never produces
+    /// anything wider).
+    static func packPpgSamples(_ samples: [Int]) -> Data {
+        var buf = Data(capacity: samples.count * 2)
+        for s in samples {
+            let v = Int16(truncatingIfNeeded: s)
+            buf.append(UInt8(truncatingIfNeeded: v))
+            buf.append(UInt8(truncatingIfNeeded: v >> 8))
+        }
+        return buf
+    }
+
+    /// Inverse of `packPpgSamples`. A trailing odd byte (a corrupt/truncated blob) is dropped rather
+    /// than thrown — a read path never crashes on a malformed row.
+    static func unpackPpgSamples(_ data: Data) -> [Int] {
+        let bytes = [UInt8](data)
+        var out = [Int](); out.reserveCapacity(bytes.count / 2)
+        var i = 0
+        while i + 1 < bytes.count {
+            let u = UInt16(bytes[i]) | (UInt16(bytes[i + 1]) << 8)
+            out.append(Int(Int16(bitPattern: u)))
+            i += 2
+        }
+        return out
+    }
+
     /// Insert or update a device row (natural key = id).
     public func upsertDevice(id: String, mac: String?, name: String?) async throws {
         let now = Int(Date().timeIntervalSince1970)
@@ -171,6 +200,20 @@ extension WhoopStore {
                     """)
                 for s in streams.ppgHr {
                     try stmt.execute(arguments: [deviceId, s.ts, s.bpm, s.conf])
+                }
+            }
+            // RAW v26 optical PPG waveform (#156 follow-up) — the samples `ppgHr` above is derived FROM.
+            // Persist-only, same as steps/sleepState/ppgHr: not added to the 8-field return tuple. ON
+            // CONFLICT DO NOTHING keeps the FIRST-seen waveform for a second, matching every other
+            // per-second stream's dedupe rule. Packed into one compact BLOB per row (see
+            // `packPpgSamples`) rather than 24 scalar rows, so this insert is O(records), not O(samples).
+            if !streams.ppgWaveform.isEmpty {
+                let stmt = try db.cachedStatement(sql: """
+                    INSERT INTO ppgWaveformSample (deviceId, ts, samples) VALUES (?, ?, ?)
+                    ON CONFLICT(deviceId, ts) DO NOTHING
+                    """)
+                for s in streams.ppgWaveform {
+                    try stmt.execute(arguments: [deviceId, s.ts, WhoopStore.packPpgSamples(s.samples)])
                 }
             }
             return (hr, rr, ev, bat, spo2, skin, resp, grav)
@@ -393,6 +436,26 @@ extension WhoopStore {
 
     public func ppgHrCountForTest() async throws -> Int {
         try syncRead { db in try Int.fetchOne(db, sql: "SELECT COUNT(*) FROM ppgHrSample") ?? 0 }
+    }
+
+    /// The RAW v26 optical PPG waveform (#156 follow-up), one record per second, in `[from, to]` for one
+    /// device, ascending by ts. `samples` are the raw i16 ADC counts the strap sent, unpacked from the
+    /// compact on-disk BLOB (`packPpgSamples`/`unpackPpgSamples`). Empty when the strap never emitted
+    /// v26 (the WHOOP 4.0 / v18-only common case) or the window has no v26-heavy stretch.
+    public func ppgWaveformSamples(deviceId: String, from: Int, to: Int, limit: Int = 200_000) async throws
+        -> [PpgWaveformSample] {
+        try syncRead { db in
+            try Row.fetchAll(db, sql: """
+                SELECT ts, samples FROM ppgWaveformSample
+                WHERE deviceId = ? AND ts >= ? AND ts <= ?
+                ORDER BY ts LIMIT ?
+                """, arguments: [deviceId, from, to, limit])
+                .map { PpgWaveformSample(ts: $0["ts"], samples: WhoopStore.unpackPpgSamples($0["samples"])) }
+        }
+    }
+
+    public func ppgWaveformCountForTest() async throws -> Int {
+        try syncRead { db in try Int.fetchOne(db, sql: "SELECT COUNT(*) FROM ppgWaveformSample") ?? 0 }
     }
 
     public func deviceRowForTest(id: String) async throws -> (mac: String?, name: String?)? {

--- a/Packages/WhoopStore/Tests/WhoopStoreTests/PpgWaveformSampleTests.swift
+++ b/Packages/WhoopStore/Tests/WhoopStoreTests/PpgWaveformSampleTests.swift
@@ -1,0 +1,110 @@
+import XCTest
+import GRDB
+import WhoopProtocol
+@testable import WhoopStore
+
+/// v27 migration: durable storage for the WHOOP 5.0 v26 optical PPG waveform (issue #156 follow-up).
+/// The strap's 24 Hz buffer was fully decoded but only ever used to derive `ppgHrSample` (v12); the
+/// waveform itself was discarded right after. This proves the new table exists, its key/shape, that
+/// insert/read round-trips (including negative AC-coupled samples), and that the packed-BLOB encoding
+/// survives a write + read cycle intact.
+final class PpgWaveformSampleTests: XCTestCase {
+    // Real captured v26 waveform (Whoop5PpgWaveformTests fixture, WhoopProtocol): a clean PPG upstroke,
+    // all-negative AC-coupled ADC counts — exercises the signed packing end to end.
+    private let realSamples = [
+        -1432, -1332, -1139, -954, -629, -436, -326, -294, -147, -170, -43, -5,
+        -201, -918, -1563, -1833, -1313, -930, -616, -293, -422, -380, -235, -164,
+    ]
+
+    func testV27CreatesPpgWaveformTable() async throws {
+        let store = try await WhoopStore.inMemory()
+        let tables = try await store.tableNames()
+        XCTAssertTrue(tables.contains("ppgWaveformSample"))
+    }
+
+    func testPpgWaveformPrimaryKeyIsDeviceIdTs() async throws {
+        let store = try await WhoopStore.inMemory()
+        let cols = try await store.primaryKeyColumns("ppgWaveformSample")
+        XCTAssertEqual(cols, ["deviceId", "ts"])
+    }
+
+    func testPpgWaveformTableShape() async throws {
+        let store = try await WhoopStore.inMemory()
+        let cols = try await store.columnNamesForTest(table: "ppgWaveformSample")
+        XCTAssertEqual(Set(cols), ["deviceId", "ts", "samples"])
+    }
+
+    func testPpgWaveformInsertRoundTripAndDedup() async throws {
+        let store = try await WhoopStore.inMemory()
+        let streams = Streams(ppgWaveform: [PpgWaveformSample(ts: 1_780_917_232, samples: realSamples)])
+        _ = try await store.insert(streams, deviceId: "my-whoop")
+        let n1 = try await store.ppgWaveformCountForTest()
+        XCTAssertEqual(n1, 1)
+        let read = try await store.ppgWaveformSamples(deviceId: "my-whoop",
+                                                       from: 1_780_917_232, to: 1_780_917_232)
+        XCTAssertEqual(read, [PpgWaveformSample(ts: 1_780_917_232, samples: realSamples)])
+        // Re-inserting the same (deviceId, ts) is idempotent, ON CONFLICT DO NOTHING (mirrors every
+        // other per-second stream's dedupe rule).
+        _ = try await store.insert(streams, deviceId: "my-whoop")
+        let n2 = try await store.ppgWaveformCountForTest()
+        XCTAssertEqual(n2, 1)
+    }
+
+    /// Multiple consecutive-second records for the same device round-trip in ts order and stay scoped
+    /// to their own device (mirrors the range/scope discipline the other per-second readers follow).
+    func testPpgWaveformReadRespectsRangeAndDeviceScope() async throws {
+        let store = try await WhoopStore.inMemory()
+        let base = 1_780_000_000
+        let streams = Streams(ppgWaveform: (0..<5).map {
+            PpgWaveformSample(ts: base + $0, samples: [$0, $0 * 2, -$0])
+        })
+        _ = try await store.insert(streams, deviceId: "dev-a")
+        _ = try await store.insert(
+            Streams(ppgWaveform: [PpgWaveformSample(ts: base, samples: [99])]), deviceId: "dev-b")
+
+        let read = try await store.ppgWaveformSamples(deviceId: "dev-a", from: base + 1, to: base + 3)
+        XCTAssertEqual(read.map(\.ts), [base + 1, base + 2, base + 3])
+        XCTAssertEqual(read.map(\.samples), [[1, 2, -1], [2, 4, -2], [3, 6, -3]])
+
+        let otherDevice = try await store.ppgWaveformSamples(deviceId: "dev-b", from: base, to: base)
+        XCTAssertEqual(otherDevice, [PpgWaveformSample(ts: base, samples: [99])])
+    }
+
+    /// A record with fewer than 24 samples (a truncated/short frame) still round-trips exactly —
+    /// the pack/unpack format isn't hardcoded to a fixed sample count.
+    func testPpgWaveformHandlesShortSampleArray() async throws {
+        let store = try await WhoopStore.inMemory()
+        let streams = Streams(ppgWaveform: [PpgWaveformSample(ts: 1_780_000_500, samples: [7, -8])])
+        _ = try await store.insert(streams, deviceId: "my-whoop")
+        let read = try await store.ppgWaveformSamples(deviceId: "my-whoop",
+                                                       from: 1_780_000_500, to: 1_780_000_500)
+        XCTAssertEqual(read, [PpgWaveformSample(ts: 1_780_000_500, samples: [7, -8])])
+    }
+
+    /// An empty-sample record is never inserted (mirrors HistoricalStreams' `!samples.isEmpty` guard
+    /// upstream) — this is a store-level belt-and-suspenders check on the insert path itself.
+    func testPpgWaveformEmptySamplesStillInsertsRow() async throws {
+        // The store layer itself doesn't filter empty arrays (that's HistoricalStreams' job); prove the
+        // pack/unpack round-trips a zero-length payload cleanly rather than crashing either way.
+        let store = try await WhoopStore.inMemory()
+        let streams = Streams(ppgWaveform: [PpgWaveformSample(ts: 1_780_000_600, samples: [])])
+        _ = try await store.insert(streams, deviceId: "my-whoop")
+        let read = try await store.ppgWaveformSamples(deviceId: "my-whoop",
+                                                       from: 1_780_000_600, to: 1_780_000_600)
+        XCTAssertEqual(read, [PpgWaveformSample(ts: 1_780_000_600, samples: [])])
+    }
+
+    func testPackUnpackPpgSamplesRoundTrips() {
+        let samples = [0, 1, -1, 32767, -32768, -1432, 12345]
+        let packed = WhoopStore.packPpgSamples(samples)
+        XCTAssertEqual(packed.count, samples.count * 2, "2 bytes/sample, no per-record overhead")
+        XCTAssertEqual(WhoopStore.unpackPpgSamples(packed), samples)
+    }
+
+    func testUnpackPpgSamplesDropsTrailingOddByte() {
+        // A corrupt/truncated blob (odd byte count) must not crash the read path.
+        var data = WhoopStore.packPpgSamples([1, 2, 3])
+        data.append(0xFF)
+        XCTAssertEqual(WhoopStore.unpackPpgSamples(data), [1, 2, 3])
+    }
+}

--- a/android/app/src/main/java/com/noop/data/DeviceRegistry.kt
+++ b/android/app/src/main/java/com/noop/data/DeviceRegistry.kt
@@ -80,7 +80,7 @@ class DeviceRegistry(
      * delete-data op empties recordings; archiving/removing the registry entry is a separate op (I4).
      *
      * The table set is EVERY device-keyed table of [WhoopDatabase]: hrSample, rrInterval, spo2Sample,
-     * skinTempSample, respSample, gravitySample, stepSample, ppgHrSample, event, battery, dailyMetric,
+     * skinTempSample, respSample, gravitySample, stepSample, ppgHrSample, ppgWaveformSample, event, battery, dailyMetric,
      * sleepSession, journal, workout, appleDaily, metricSeries, dayOwnership, sleepStateSample, labMarker,
      * liveSession, dismissedWorkout, dismissedSleep. DeviceRegistryTest.deleteDeviceDataCallsEveryDaoDeleteMethod
      * guards completeness (fails if a delete*For DAO method isn't wired in here).
@@ -95,6 +95,7 @@ class DeviceRegistry(
             dao.deleteGravityFor(id)
             dao.deleteStepsFor(id)
             dao.deletePpgHrFor(id)
+            dao.deletePpgWaveformFor(id)
             dao.deleteEventsFor(id)
             dao.deleteBatteryFor(id)
             dao.deleteDailyMetricsFor(id)

--- a/android/app/src/main/java/com/noop/data/DeviceRegistryDao.kt
+++ b/android/app/src/main/java/com/noop/data/DeviceRegistryDao.kt
@@ -70,6 +70,7 @@ interface DeviceRegistryDao {
     @Query("DELETE FROM gravitySample WHERE deviceId = :deviceId") suspend fun deleteGravityFor(deviceId: String)
     @Query("DELETE FROM stepSample WHERE deviceId = :deviceId") suspend fun deleteStepsFor(deviceId: String)
     @Query("DELETE FROM ppgHrSample WHERE deviceId = :deviceId") suspend fun deletePpgHrFor(deviceId: String)
+    @Query("DELETE FROM ppgWaveformSample WHERE deviceId = :deviceId") suspend fun deletePpgWaveformFor(deviceId: String)
     @Query("DELETE FROM event WHERE deviceId = :deviceId") suspend fun deleteEventsFor(deviceId: String)
     @Query("DELETE FROM battery WHERE deviceId = :deviceId") suspend fun deleteBatteryFor(deviceId: String)
     @Query("DELETE FROM dailyMetric WHERE deviceId = :deviceId") suspend fun deleteDailyMetricsFor(deviceId: String)

--- a/android/app/src/main/java/com/noop/data/Entities.kt
+++ b/android/app/src/main/java/com/noop/data/Entities.kt
@@ -479,6 +479,42 @@ data class AppleDaily(
 )
 
 /**
+ * The RAW WHOOP 5.0 v26 optical PPG waveform, one record per second (v27 / MIGRATION_18_19, issue #156
+ * follow-up). Swift `ppgWaveformSample` (WhoopStore Database.swift `v27-ppg-waveform` migration). The
+ * strap's 24 Hz buffer was fully decoded but only ever used to derive [PpgHrSample]; the samples
+ * themselves were discarded right after. Persisted here so a future re-analysis (a better HR estimator,
+ * HRV-from-PPG, a waveform viewer) can run over the ORIGINAL samples, not just the derived bpm.
+ *
+ * The 24 raw i16 ADC samples are packed into a compact BLOB (2 bytes/sample, little-endian i16, see
+ * [StreamPersistence.packPpgSamples]/[StreamPersistence.unpackPpgSamples]) instead of 24 scalar rows,
+ * keeping a v26-heavy night to roughly the same order of magnitude as ONE extra per-second stream. The
+ * BLOB format is byte-identical to the Swift GRDB `WhoopStore.packPpgSamples` so a `.noopbak` round-trips.
+ * PK (deviceId, ts) mirrors every other per-second stream; a truncated frame can decode fewer than 24
+ * samples. Fields are declared in the SAME order as the GRDB schema (deviceId, ts, samples) so the
+ * migration's CREATE TABLE column order matches Room's generated shape.
+ */
+@Entity(tableName = "ppgWaveformSample", primaryKeys = ["deviceId", "ts"])
+data class PpgWaveformSampleEntity(
+    val deviceId: String,
+    val ts: Long,
+    val samples: ByteArray,
+) {
+    // ByteArray needs structural equals/hashCode (the generated identity ones break round-trip asserts).
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is PpgWaveformSampleEntity) return false
+        return deviceId == other.deviceId && ts == other.ts && samples.contentEquals(other.samples)
+    }
+
+    override fun hashCode(): Int {
+        var result = deviceId.hashCode()
+        result = 31 * result + ts.hashCode()
+        result = 31 * result + samples.contentHashCode()
+        return result
+    }
+}
+
+/**
  * One Live Session (silent guardian) record (v22 / MIGRATION_15_16). Natural key (deviceId, startTs).
  * `endTs` is null while the session is still in progress. Fields are declared in the SAME order as the
  * Swift WhoopStore `liveSession` schema so the migration SQL matches Room's generated shape. Twin of the

--- a/android/app/src/main/java/com/noop/data/StreamPersistence.kt
+++ b/android/app/src/main/java/com/noop/data/StreamPersistence.kt
@@ -39,6 +39,38 @@ object StreamPersistence {
     )
 
     /**
+     * Pack a decoded v26 PPG waveform's samples as little-endian i16 (2 bytes/sample) — a single compact
+     * BLOB per (deviceId, ts) row instead of 24 scalar rows (issue #156 follow-up, MIGRATION_19_20). Port
+     * of Swift `WhoopStore.packPpgSamples`, BYTE-IDENTICAL so a `.noopbak` round-trips across platforms.
+     * Any sample count is handled (a truncated frame can decode fewer than 24); each value is truncated to
+     * Int16's range (`toShort()`), matching the i16 wire format the decoder read it from.
+     */
+    fun packPpgSamples(samples: List<Int>): ByteArray {
+        val buf = ByteArray(samples.size * 2)
+        for ((i, s) in samples.withIndex()) {
+            val v = s.toShort().toInt()              // truncate to 16 bits, then read low/high bytes
+            buf[i * 2] = (v and 0xFF).toByte()       // little-endian: low byte first
+            buf[i * 2 + 1] = ((v shr 8) and 0xFF).toByte()
+        }
+        return buf
+    }
+
+    /**
+     * Inverse of [packPpgSamples]. A trailing odd byte (a corrupt/truncated blob) is dropped rather than
+     * thrown — a read path never crashes on a malformed row. Port of Swift `WhoopStore.unpackPpgSamples`.
+     */
+    fun unpackPpgSamples(data: ByteArray): List<Int> {
+        val out = ArrayList<Int>(data.size / 2)
+        var i = 0
+        while (i + 1 < data.size) {
+            val u = (data[i].toInt() and 0xFF) or ((data[i + 1].toInt() and 0xFF) shl 8)
+            out.add(u.toShort().toInt())             // sign-extend the 16-bit value back to Int
+            i += 2
+        }
+        return out
+    }
+
+    /**
      * Deterministic sorted-keys JSON for an event payload. Port of `WhoopStore.encodePayload`.
      *
      * `org.json.JSONObject` does NOT guarantee key order, so we build the JSON manually with keys

--- a/android/app/src/main/java/com/noop/data/WhoopDao.kt
+++ b/android/app/src/main/java/com/noop/data/WhoopDao.kt
@@ -83,6 +83,10 @@ interface WhoopDao : DeviceRegistryDao {
     @Insert(onConflict = OnConflictStrategy.IGNORE)
     suspend fun insertPpgHr(rows: List<PpgHrSample>): List<Long>
 
+    /** RAW v26 optical PPG waveform (packed i16 BLOB). Idempotent by (deviceId, ts). (#156 follow-up) */
+    @Insert(onConflict = OnConflictStrategy.IGNORE)
+    suspend fun insertPpgWaveform(rows: List<PpgWaveformSampleEntity>): List<Long>
+
     // MARK: - Server-derived caches (latest value wins)
 
     @Upsert
@@ -223,6 +227,14 @@ interface WhoopDao : DeviceRegistryDao {
             "ORDER BY ts ASC LIMIT :limit"
     )
     suspend fun ppgHrSamples(deviceId: String, from: Long, to: Long, limit: Int): List<PpgHrSample>
+
+    /** RAW v26 optical PPG waveform rows in [from, to] (ascending), packed i16 BLOB. (#156 follow-up) */
+    @Query(
+        "SELECT * FROM ppgWaveformSample WHERE deviceId = :deviceId AND ts >= :from AND ts <= :to " +
+            "ORDER BY ts ASC LIMIT :limit"
+    )
+    suspend fun ppgWaveformSamples(deviceId: String, from: Long, to: Long, limit: Int):
+        List<PpgWaveformSampleEntity>
 
     /** Aggregate HR over a window (one indexed (deviceId,ts) range scan — no row materialisation,
      *  no [hrSamples] LIMIT truncation). Backs the imported-workout HR fallback (#77). */

--- a/android/app/src/main/java/com/noop/data/WhoopDatabase.kt
+++ b/android/app/src/main/java/com/noop/data/WhoopDatabase.kt
@@ -47,8 +47,9 @@ import androidx.sqlite.db.SupportSQLiteDatabase
         DayOwnershipRow::class,
         LabMarkerRow::class,
         LiveSessionRow::class,
+        PpgWaveformSampleEntity::class,
     ],
-    version = 19,
+    version = 20,
     exportSchema = false,
 )
 abstract class WhoopDatabase : RoomDatabase() {
@@ -520,6 +521,38 @@ abstract class WhoopDatabase : RoomDatabase() {
             }
         }
 
+        /**
+         * v19 -> v20: ADDITIVE, adds the `ppgWaveformSample` table (issue #156 follow-up), the Android twin
+         * of the Swift WhoopStore `v27-ppg-waveform` GRDB migration. Durable storage for the WHOOP 5.0 v26
+         * optical PPG waveform: the strap's 24 Hz buffer was fully DECODED but only ever used to derive
+         * `ppgHrSample` (v6) — the waveform itself was discarded right after. One row per (deviceId, ts),
+         * the SAME shape as every other per-second decoded stream, but the samples are packed into a compact
+         * BLOB (2 bytes/sample, little-endian i16, [StreamPersistence.packPpgSamples]) rather than 24 scalar
+         * rows.
+         *
+         * CREATE TABLE only (no existing data touched), so already-offloaded raw streams survive. The SQL MUST
+         * match Room's generated schema for [PpgWaveformSampleEntity] exactly: deviceId TEXT NOT NULL, ts
+         * INTEGER NOT NULL, samples BLOB NOT NULL (all Kotlin non-null, no SQL DEFAULT), composite PRIMARY KEY
+         * (deviceId, ts) in declaration order — matching the GRDB `t.column(...).notNull()` order deviceId, ts,
+         * samples. No destructive fallback (see the class doc). Exposed as [PPG_WAVEFORM_MIGRATION_SQL] so a
+         * plain-JVM unit test can pin the shape without Robolectric.
+         *
+         * SEQUENCING: this claims Room 19 -> 20 because MIGRATION_18_19 (efficiency-heal, Swift v26) already
+         * took slot 19 on this branch; the GRDB twin is `v27-ppg-waveform` (Swift's next slot after v26), so
+         * the two platforms' migration COUNTS stay aligned even though the table shape, not the number, is the
+         * contract.
+         */
+        internal val PPG_WAVEFORM_MIGRATION_SQL: List<String> = listOf(
+            "CREATE TABLE IF NOT EXISTS `ppgWaveformSample` (`deviceId` TEXT NOT NULL, " +
+                "`ts` INTEGER NOT NULL, `samples` BLOB NOT NULL, PRIMARY KEY(`deviceId`, `ts`))",
+        )
+
+        internal val MIGRATION_19_20 = object : Migration(19, 20) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                for (stmt in PPG_WAVEFORM_MIGRATION_SQL) db.execSQL(stmt)
+            }
+        }
+
         private fun build(appContext: Context): WhoopDatabase =
             Room.databaseBuilder(appContext, WhoopDatabase::class.java, DB_NAME)
                 // #1014: replace ONLY the corruption handling of the default open-helper. The
@@ -535,7 +568,7 @@ abstract class WhoopDatabase : RoomDatabase() {
                     MIGRATION_5_6, MIGRATION_6_7, MIGRATION_7_8, MIGRATION_8_9, MIGRATION_9_10,
                     MIGRATION_10_11, MIGRATION_11_12, MIGRATION_12_13, MIGRATION_13_14,
                     MIGRATION_14_15, MIGRATION_15_16, MIGRATION_16_17, MIGRATION_17_18,
-                    MIGRATION_18_19,
+                    MIGRATION_18_19, MIGRATION_19_20,
                 )
                 // #1037: a FRESH install builds the schema straight at the current version and runs NO
                 // migrations, so the MIGRATION_7_8 "my-whoop" registry seed never fires and the WHOOP,

--- a/android/app/src/main/java/com/noop/data/WhoopRepository.kt
+++ b/android/app/src/main/java/com/noop/data/WhoopRepository.kt
@@ -33,6 +33,12 @@ data class StreamBatch(
     /** HR derived from the WHOOP 5/MG v26 optical PPG waveform (autocorrelation). (#156) */
     val ppgHr: List<PpgHrRow> = emptyList(),
     /**
+     * The RAW WHOOP 5/MG v26 optical PPG waveform itself, one record per second (#156 follow-up) — the
+     * 24 Hz samples [ppgHr] is derived FROM. Kept separate so a consumer that only wants the HR estimate
+     * never pays for the 24x-larger raw stream. Persisted into `ppgWaveformSample` as a packed i16 BLOB.
+     */
+    val ppgWaveform: List<PpgWaveformRow> = emptyList(),
+    /**
      * #547: how many historical records this batch DROPPED because their timestamp was implausible
      * (older than 2023-11 or more than a day ahead of now) , a bad strap clock/flash artefact. A
      * diagnostic counter only, NOT decoded data, so it is deliberately excluded from [isEmpty]. The
@@ -58,7 +64,7 @@ data class StreamBatch(
     val isEmpty: Boolean
         get() = hr.isEmpty() && rr.isEmpty() && events.isEmpty() && battery.isEmpty() &&
             spo2.isEmpty() && skinTemp.isEmpty() && resp.isEmpty() && gravity.isEmpty() &&
-            steps.isEmpty() && sleepState.isEmpty() && ppgHr.isEmpty()
+            steps.isEmpty() && sleepState.isEmpty() && ppgHr.isEmpty() && ppgWaveform.isEmpty()
 }
 
 // Device-agnostic decoded rows (deviceId attached when inserted). Mirror Streams.swift shapes.
@@ -111,6 +117,12 @@ data class RespRow(val ts: Long, val raw: Int)
 data class GravityRow(val ts: Long, val x: Double, val y: Double, val z: Double)
 /** HR derived from the v26 PPG waveform: [ts] window-centre sec, [bpm], [conf] in 0…1. (#156) */
 data class PpgHrRow(val ts: Long, val bpm: Int, val conf: Double)
+/**
+ * The RAW v26 optical PPG waveform for one strap-second (#156 follow-up): [ts] the record's wall-clock
+ * unix second, [samples] the raw i16 ADC counts (usually 24, fewer on a truncated frame). deviceId is
+ * attached on insert; the samples are packed to a little-endian i16 BLOB by [StreamPersistence.packPpgSamples].
+ */
+data class PpgWaveformRow(val ts: Long, val samples: List<Int>)
 
 /** Count of rows ACTUALLY inserted per stream (mirrors WhoopStore.insert return tuple). */
 data class InsertCounts(
@@ -241,6 +253,17 @@ class WhoopRepository(private val dao: WhoopDao) {
         // backfill "persisted N" summary reflects HR recovered from the optical waveform too.
         val ppgHrIds = if (streams.ppgHr.isEmpty()) emptyList() else
             dao.insertPpgHr(streams.ppgHr.map { PpgHrSample(deviceId, it.ts, it.bpm, it.conf) })
+        // RAW v26 optical PPG waveform (#156 follow-up) — the samples ppgHr above is derived FROM.
+        // Persist-only, same as steps/sleepState: not added to the InsertCounts return. Idempotent by
+        // (deviceId, ts), IGNORE-on-conflict keeps the FIRST-seen waveform for a second (mirrors every
+        // other per-second stream). Packed into one compact i16 BLOB per row (see packPpgSamples).
+        if (streams.ppgWaveform.isNotEmpty()) {
+            dao.insertPpgWaveform(
+                streams.ppgWaveform.map {
+                    PpgWaveformSampleEntity(deviceId, it.ts, StreamPersistence.packPpgSamples(it.samples))
+                },
+            )
+        }
 
         // OnConflictStrategy.IGNORE returns -1 for skipped (already-present) rows; count the inserts.
         return InsertCounts(
@@ -554,6 +577,18 @@ class WhoopRepository(private val dao: WhoopDao) {
     /** v26 PPG-derived HR samples (own stream) for the raw-sensor diagnostic export. (#156) */
     suspend fun ppgHrSamples(deviceId: String, from: Long, to: Long, limit: Int = DEFAULT_LIMIT) =
         dao.ppgHrSamples(deviceId, from, to, limit)
+
+    /**
+     * The RAW v26 optical PPG waveform (#156 follow-up), one record per second, in [from, to] for one
+     * device, ascending by ts. [PpgWaveformRow.samples] are the raw i16 ADC counts the strap sent,
+     * unpacked from the compact on-disk BLOB ([StreamPersistence.packPpgSamples]/[unpackPpgSamples]).
+     * Empty when the strap never emitted v26 (the WHOOP 4.0 / v18-only case) or the window has no
+     * v26-heavy stretch. Kotlin twin of the Swift `WhoopStore.ppgWaveformSamples(deviceId:from:to:)`.
+     */
+    suspend fun ppgWaveformSamples(deviceId: String, from: Long, to: Long, limit: Int = DEFAULT_LIMIT):
+        List<PpgWaveformRow> =
+        dao.ppgWaveformSamples(deviceId, from, to, limit)
+            .map { PpgWaveformRow(it.ts, StreamPersistence.unpackPpgSamples(it.samples)) }
 
     /** Downsampled HR (mean bpm per [bucketSeconds]) for the strap, for the Today 24h trend chart. */
     suspend fun hrBuckets(deviceId: String, from: Long, to: Long, bucketSeconds: Long = 300L) =

--- a/android/app/src/main/java/com/noop/protocol/HistoricalStreams.kt
+++ b/android/app/src/main/java/com/noop/protocol/HistoricalStreams.kt
@@ -5,6 +5,7 @@ import com.noop.data.EventEntry
 import com.noop.data.GravityRow
 import com.noop.data.HrRow
 import com.noop.data.PpgHrRow
+import com.noop.data.PpgWaveformRow
 import com.noop.data.RespRow
 import com.noop.data.RrRow
 import com.noop.data.SkinTempRow
@@ -597,6 +598,10 @@ fun extractHistoricalStreams(
     val battery = ArrayList<BatteryRow>()
     // v26 PPG samples accumulate across the chunk, then get turned into HR after the loop (#156).
     val ppgSamples = ArrayList<PpgHr.Sample>()
+    // The RAW v26 waveform kept PER RECORD (one row per strap-second) for durable storage (#156
+    // follow-up) — the same (ts, samples) the estimator above consumes, but grouped per second so it
+    // persists as its own `ppgWaveformSample` stream rather than being flattened into the HR buffer.
+    val ppgWaveform = ArrayList<PpgWaveformRow>()
 
     for (frame in rawFrames) {
         // Packet type byte: WHOOP 5/MG's longer puffin envelope puts it at frame[8]; WHOOP 4 at frame[4].
@@ -619,6 +624,10 @@ fun extractHistoricalStreams(
                         val baseTs = correctedWall(rec.unix.toLong() and 0xFFFFFFFFL)
                         if (baseTs != null) {
                             for (v in rec.samples) ppgSamples.add(PpgHr.Sample(ts = baseTs, value = v))
+                            // Persist the raw waveform itself too (#156 follow-up), keyed on the record's
+                            // corrected wall-second. Guard on non-empty so a truncated frame that decoded
+                            // zero samples never banks an empty row (mirrors the Swift `!samples.isEmpty`).
+                            if (rec.samples.isNotEmpty()) ppgWaveform.add(PpgWaveformRow(baseTs, rec.samples))
                         }
                     }
                 }
@@ -732,6 +741,7 @@ fun extractHistoricalStreams(
         spo2 = spo2, skinTemp = skinTemp, resp = resp, gravity = gravity, steps = steps,
         sleepState = sleepState,
         ppgHr = ppgHr,
+        ppgWaveform = ppgWaveform,
         droppedImplausibleTs = droppedImplausible,
         droppedImplausibleOldestTs = droppedOldest,   // #324 poisoned-range epoch span (diag only)
         droppedImplausibleNewestTs = droppedNewest,

--- a/android/app/src/test/java/com/noop/analytics/RegistryDayOwnerSourceTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/RegistryDayOwnerSourceTest.kt
@@ -56,6 +56,7 @@ class RegistryDayOwnerSourceTest {
         override suspend fun deleteGravityFor(deviceId: String) {}
         override suspend fun deleteStepsFor(deviceId: String) {}
         override suspend fun deletePpgHrFor(deviceId: String) {}
+        override suspend fun deletePpgWaveformFor(deviceId: String) {}
         override suspend fun deleteEventsFor(deviceId: String) {}
         override suspend fun deleteBatteryFor(deviceId: String) {}
         override suspend fun deleteDailyMetricsFor(deviceId: String) {}

--- a/android/app/src/test/java/com/noop/ble/SourceCoordinatorAdoptionTest.kt
+++ b/android/app/src/test/java/com/noop/ble/SourceCoordinatorAdoptionTest.kt
@@ -70,6 +70,7 @@ class SourceCoordinatorAdoptionTest {
         override suspend fun deleteGravityFor(deviceId: String) {}
         override suspend fun deleteStepsFor(deviceId: String) {}
         override suspend fun deletePpgHrFor(deviceId: String) {}
+        override suspend fun deletePpgWaveformFor(deviceId: String) {}
         override suspend fun deleteEventsFor(deviceId: String) {}
         override suspend fun deleteBatteryFor(deviceId: String) {}
         override suspend fun deleteDailyMetricsFor(deviceId: String) {}

--- a/android/app/src/test/java/com/noop/data/DeviceRegistryTest.kt
+++ b/android/app/src/test/java/com/noop/data/DeviceRegistryTest.kt
@@ -84,6 +84,7 @@ class DeviceRegistryTest {
         override suspend fun deleteGravityFor(deviceId: String) { deletedTables += "gravitySample" to deviceId }
         override suspend fun deleteStepsFor(deviceId: String) { deletedTables += "stepSample" to deviceId }
         override suspend fun deletePpgHrFor(deviceId: String) { deletedTables += "ppgHrSample" to deviceId }
+        override suspend fun deletePpgWaveformFor(deviceId: String) { deletedTables += "ppgWaveformSample" to deviceId }
         override suspend fun deleteEventsFor(deviceId: String) { deletedTables += "event" to deviceId }
         override suspend fun deleteBatteryFor(deviceId: String) { deletedTables += "battery" to deviceId }
         override suspend fun deleteDailyMetricsFor(deviceId: String) { deletedTables += "dailyMetric" to deviceId }
@@ -233,7 +234,7 @@ class DeviceRegistryTest {
         // were missing, leaving raw sleep-state, lab markers, live sessions and dismissed markers behind.
         val expectedTables = setOf(
             "hrSample", "rrInterval", "spo2Sample", "skinTempSample", "respSample", "gravitySample",
-            "stepSample", "ppgHrSample", "event", "battery", "dailyMetric", "sleepSession",
+            "stepSample", "ppgHrSample", "ppgWaveformSample", "event", "battery", "dailyMetric", "sleepSession",
             "journal", "workout", "appleDaily", "metricSeries", "dayOwnership",
             "sleepStateSample", "labMarker", "liveSession", "dismissedWorkout", "dismissedSleep",
         )

--- a/android/app/src/test/java/com/noop/data/PpgWaveformMigrationTest.kt
+++ b/android/app/src/test/java/com/noop/data/PpgWaveformMigrationTest.kt
@@ -1,0 +1,123 @@
+package com.noop.data
+
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.lang.reflect.Proxy
+
+/**
+ * Guards the additive v19 -> v20 Room migration (the `ppgWaveformSample` table, issue #156 follow-up), the
+ * Android twin of the Swift WhoopStore `v27-ppg-waveform` GRDB migration (PR #415), plus the packed-BLOB
+ * encoding that must be byte-identical to Swift `WhoopStore.packPpgSamples` for a `.noopbak` to round-trip.
+ *
+ * This environment has no Robolectric Room, so the migration SQL is exposed as an internal constant
+ * ([WhoopDatabase.PPG_WAVEFORM_MIGRATION_SQL]) and pinned here to Room's generated shape for
+ * [PpgWaveformSampleEntity]; the store-write plumbing is exercised through a Proxy [WhoopDao] (no DB).
+ */
+class PpgWaveformMigrationTest {
+
+    // MARK: - Migration schema
+
+    @Test
+    fun migration_isAdditive_onlyCreateTable() {
+        val sql = WhoopDatabase.PPG_WAVEFORM_MIGRATION_SQL
+        assertEquals("one CREATE TABLE statement", 1, sql.size)
+        for (s in sql) {
+            val up = s.trimStart().uppercase()
+            assertTrue("only CREATE TABLE allowed, got: $s", up.startsWith("CREATE TABLE"))
+            for (banned in listOf("DROP ", "DELETE ", "UPDATE ", "INSERT ", "ALTER ")) {
+                assertTrue("additive migration must not contain '$banned': $s", !up.contains(banned))
+            }
+        }
+    }
+
+    @Test
+    fun migration_createsExactTable() {
+        // deviceId TEXT, ts INTEGER, samples BLOB — column order == entity field order, matching the GRDB
+        // schema's t.column(deviceId/ts/samples) order and PRIMARY KEY(deviceId, ts).
+        assertEquals(
+            listOf(
+                "CREATE TABLE IF NOT EXISTS `ppgWaveformSample` (`deviceId` TEXT NOT NULL, " +
+                    "`ts` INTEGER NOT NULL, `samples` BLOB NOT NULL, PRIMARY KEY(`deviceId`, `ts`))",
+            ),
+            WhoopDatabase.PPG_WAVEFORM_MIGRATION_SQL,
+        )
+    }
+
+    @Test
+    fun migration_versionPair_is19to20() {
+        assertEquals(19, WhoopDatabase.MIGRATION_19_20.startVersion)
+        assertEquals(20, WhoopDatabase.MIGRATION_19_20.endVersion)
+    }
+
+    // MARK: - Packed-BLOB encoding (byte-identical to Swift WhoopStore.packPpgSamples)
+
+    @Test
+    fun packUnpackRoundTrips() {
+        // Includes the i16 extremes and real AC-coupled negatives — exercises signed packing end to end.
+        val samples = listOf(0, 1, -1, 32767, -32768, -1432, 12345)
+        val packed = StreamPersistence.packPpgSamples(samples)
+        assertEquals("2 bytes/sample, no per-record overhead", samples.size * 2, packed.size)
+        assertEquals(samples, StreamPersistence.unpackPpgSamples(packed))
+    }
+
+    @Test
+    fun packIsLittleEndianI16() {
+        // -1432 == 0xFA68: little-endian low byte 0x68 first, high byte 0xFA second (matches GRDB blob bytes).
+        val packed = StreamPersistence.packPpgSamples(listOf(-1432))
+        assertArrayEquals(byteArrayOf(0x68.toByte(), 0xFA.toByte()), packed)
+    }
+
+    @Test
+    fun unpackDropsTrailingOddByte() {
+        // A corrupt/truncated blob (odd byte count) must not crash the read path.
+        val data = StreamPersistence.packPpgSamples(listOf(1, 2, 3)) + byteArrayOf(0xFF.toByte())
+        assertEquals(listOf(1, 2, 3), StreamPersistence.unpackPpgSamples(data))
+    }
+
+    @Test
+    fun packHandlesShortAndEmptyArrays() {
+        assertEquals(listOf(7, -8), StreamPersistence.unpackPpgSamples(StreamPersistence.packPpgSamples(listOf(7, -8))))
+        assertEquals(emptyList<Int>(), StreamPersistence.unpackPpgSamples(StreamPersistence.packPpgSamples(emptyList())))
+    }
+
+    // MARK: - Store-write plumbing (repository packs + inserts through the DAO)
+
+    @Test
+    fun repositoryInsertPacksWaveformAndCallsDao() = runBlocking {
+        val realSamples = listOf(
+            -1432, -1332, -1139, -954, -629, -436, -326, -294, -147, -170, -43, -5,
+            -201, -918, -1563, -1833, -1313, -930, -616, -293, -422, -380, -235, -164,
+        )
+        var captured: List<PpgWaveformSampleEntity>? = null
+        val dao = Proxy.newProxyInstance(
+            WhoopDao::class.java.classLoader,
+            arrayOf(WhoopDao::class.java),
+        ) { _, method, args ->
+            when (method.name) {
+                "insertPpgWaveform" -> {
+                    @Suppress("UNCHECKED_CAST")
+                    captured = args[0] as List<PpgWaveformSampleEntity>
+                    listOf(1L)
+                }
+                else -> throw UnsupportedOperationException("waveform-only insert must not call ${method.name}")
+            }
+        } as WhoopDao
+
+        WhoopRepository(dao).insert(
+            StreamBatch(ppgWaveform = listOf(PpgWaveformRow(ts = 1_780_917_232L, samples = realSamples))),
+            deviceId = "my-whoop",
+        )
+
+        val rows = captured ?: error("insertPpgWaveform was never called")
+        assertEquals(1, rows.size)
+        assertEquals("my-whoop", rows[0].deviceId)
+        assertEquals(1_780_917_232L, rows[0].ts)
+        // The stored BLOB is exactly packPpgSamples(samples) — the byte-identical contract vs GRDB.
+        assertArrayEquals(StreamPersistence.packPpgSamples(realSamples), rows[0].samples)
+        // And it unpacks back to the original samples.
+        assertEquals(realSamples, StreamPersistence.unpackPpgSamples(rows[0].samples))
+    }
+}

--- a/android/app/src/test/java/com/noop/protocol/Whoop5PpgWaveformStreamTest.kt
+++ b/android/app/src/test/java/com/noop/protocol/Whoop5PpgWaveformStreamTest.kt
@@ -1,0 +1,69 @@
+package com.noop.protocol
+
+import com.noop.data.PpgWaveformRow
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Durable v26 optical-PPG waveform persistence (issue #156 follow-up, PR #415 Android twin). Until now
+ * [extractHistoricalStreams] accumulated a v26 record's waveform ONLY to derive a per-second HR estimate
+ * (`ppgHr`); the raw samples were discarded once that estimate was taken. This proves the raw waveform now
+ * survives as its OWN stream ([com.noop.data.StreamBatch.ppgWaveform]), independently of whether the HR
+ * estimator had enough context to run.
+ *
+ * The fixture is the SAME real captured v26 frame the Swift `Whoop5PpgWaveformTests` uses (a clean PPG
+ * upstroke, all-negative AC-coupled ADC counts), so the decoded waveform is cross-platform ground truth.
+ */
+class Whoop5PpgWaveformStreamTest {
+
+    private fun bytes(s: String): ByteArray =
+        ByteArray(s.length / 2) { ((Character.digit(s[it * 2], 16) shl 4) + Character.digit(s[it * 2 + 1], 16)).toByte() }
+
+    // Real captured WHOOP 5.0 v26 optical-PPG frame (unix @15 == 1780917232), 24 i16 samples @ [27:75].
+    private val v26Hex =
+        "aa015000010035412f1a80ad418401f0a3266aae470100c3c5050068faccfa8dfb46fc8bfd4c" +
+            "febafedafe6dff56ffd5fffbff37ff6afce5f9d7f8dffa5efc98fddbfe5afe84fe15ff5cff40" +
+            "5fb33c50080101006cb67c17"
+
+    private val expectedWaveform = listOf(
+        -1432, -1332, -1139, -954, -629, -436, -326, -294, -147, -170, -43, -5,
+        -201, -918, -1563, -1833, -1313, -930, -616, -293, -422, -380, -235, -164,
+    )
+
+    /**
+     * A single v26 record is one second of samples — nowhere near the run [PpgHr] needs for a confident HR
+     * estimate, so `ppgHr` stays empty. Before this change that meant the ENTIRE record vanished (nothing
+     * else read the waveform); now the raw waveform is still captured as its own stream.
+     */
+    @Test
+    fun extractPersistsRawPpgWaveform() {
+        val streams = extractHistoricalStreams(
+            listOf(bytes(v26Hex)),
+            deviceClockRef = 1_780_917_232,
+            wallClockRef = 1_780_917_232,
+            family = DeviceFamily.WHOOP5,
+        )
+        assertEquals(
+            listOf(PpgWaveformRow(ts = 1_780_917_232L, samples = expectedWaveform)),
+            streams.ppgWaveform,
+        )
+        assertTrue("a lone 1 s record is too short for a confident HR estimate", streams.ppgHr.isEmpty())
+        // Not "no rows at all" — a waveform-only decode must read as non-empty so the Backfiller's
+        // silent-data-loss diagnostic counts it as decoded.
+        assertFalse(streams.isEmpty)
+    }
+
+    /** [com.noop.data.StreamBatch.isEmpty] must count a waveform-only decode as non-empty even when the
+     *  derived `ppgHr` (produced FROM it) is empty, or the "chunk carried no records" diagnostic misfires. */
+    @Test
+    fun streamBatchIsEmptyConsidersPpgWaveform() {
+        val empty = com.noop.data.StreamBatch()
+        assertTrue(empty.isEmpty)
+        val waveformOnly = com.noop.data.StreamBatch(
+            ppgWaveform = listOf(PpgWaveformRow(ts = 1L, samples = listOf(1, 2, 3))),
+        )
+        assertFalse(waveformOnly.isEmpty)
+    }
+}


### PR DESCRIPTION
## Summary

The WHOOP 5.0 strap sends a ~24 Hz raw optical PPG waveform in type-47 v26 records during v26-heavy stretches of a night. NOOP already fully decodes it (`ppg_waveform`, 24 little-endian i16 ADC samples/record — see `decodeWhoop5HistoricalV26` in `Interpreter.swift`), but the samples were only ever used to derive a per-second HR estimate (`PpgHr.derivePpgHr` → `ppgHrSample`, v12) and then discarded. `rejectedHistoricalRecords` even explicitly excludes v26 from the undecodable-record reject archive as "known-and-unstored by design" — so a fully-decoded biometric signal had no durable home at all.

This is a **storage-only** change: no BLE subscription/command is added or modified. The waveform is already received and decoded; this just stops throwing it away.

## Storage approach

A **new table** (`ppgWaveformSample`), not the reject archive:

- The reject archive (`RawHistoryArchive` / `rejectedHistoricalRecords`) exists for genuinely-**undecodable** frames (CRC failure, unmapped layout). A v26 record that decodes fine was never one of those, so re-routing it there would be a category error — and it's why v26 is excluded from that path unconditionally (even on a CRC failure), independent of this change.
- A **queryable table** is more useful than an opaque archive blob: it can be read back per-device/time-range (`ppgWaveformSamples(deviceId:from:to:)`) for a future re-analysis (a better HR estimator, HRV-from-PPG, a waveform viewer) without re-parsing raw frames.
- **Shape**: one row per `(deviceId, ts)` — the same key as every sibling per-second stream (`hrSample`, `spo2Sample`, `ppgHrSample`, ...) — but the 24 samples are packed into a compact BLOB (little-endian i16, 2 bytes/sample) instead of 24 scalar rows. That keeps a v26-heavy night to roughly the same order of magnitude as **one extra per-second stream** (~50 bytes/row), not 24x that.

### Retention

No new pruning — this matches every other durable per-second table (`hrSample`, `spo2Sample`, etc. are never pruned either); it's decoded biometric history, not the transient raw outbox. `PrunePolicy`'s ~50 MB cap governs only `rawBatch` (pre-decode raw frames kept for re-sync) and is untouched by and unrelated to this table. Growth is bounded by how much v26 data a strap actually emits (firmware picks v26 vs v18 per second; not every night is v26-heavy), not by an artificial cap, and the compact packed-BLOB encoding keeps the per-record cost small regardless.

## Changes

- **`Packages/WhoopProtocol`**: `Streams` gains `ppgWaveform: [PpgWaveformSample]` (`ts` + raw `samples: [Int]`). `extractHistoricalStreams` populates it alongside the existing `ppgHr` derivation — same `(ts, samples)` the HR estimator already collects, just no longer discarded after. `isEmpty`/`CodingKeys`/the custom decoder are updated so a waveform-only decode (too little context for a confident HR estimate — `PpgHr.derivePpgHr` needs >= 3 consecutive seconds) still counts as decoded data for the Backfiller's silent-data-loss diagnostic, and older JSON fixtures without the key still decode (`decodeIfPresent ... ?? []`, mirroring every prior stream addition).
- **`Packages/WhoopStore`**: new migration `v27-ppg-waveform` creates `ppgWaveformSample` (`deviceId`, `ts`, `samples` BLOB, PK `(deviceId, ts)`). `packPpgSamples`/`unpackPpgSamples` do the little-endian i16 packing (handles any sample count — a truncated frame can decode fewer than 24 — and drops a corrupt trailing odd byte on read rather than throwing). Wired into the existing `insert(_:deviceId:)` choke point as a persist-only block (mirrors `steps`/`sleepState`/`ppgHr`: not added to the 8-field return tuple), so `Collector`/`Backfiller`/`RawHistoryArchive.replay` all pick it up with **no changes of their own** — they already just pass `Streams` straight through to `store.insert`.
- Added `ppgWaveformSample` to `DeviceRegistryStore.deviceScopedTables` — caught by the existing `testDeviceScopedTablesCoversEveryDeviceIdKeyedTable` coverage test, since without it "delete all of this device's data" would silently leave orphaned waveform rows behind.
- Updated the now-stale "known-and-unstored by design" comments in `HistoricalStreams.swift` (`rejectedHistoricalRecords`) to reflect that the waveform now has its own durable stream.

## Android parity

**Kotlin twin included + gradle-tested.** Android straps connect, so this twins BOTH the schema and the store-write plumbing:

- Room migration **v19→v20** + `PpgWaveformSampleEntity` (`deviceId`, `ts`, `samples` BLOB; PK `(deviceId, ts)`; column order == entity field order) mirror the GRDB `v27-ppg-waveform` table so the `.noopbak` schema stays byte-identical, pinned by `PpgWaveformMigrationTest`. (On the Android branch v19 is already the efficiency-heal migration = Swift v26, so the PPG table takes v20 = Swift's v27 — the migration *shape*, not the number, is the contract.)
- `StreamPersistence.packPpgSamples`/`unpackPpgSamples` do the little-endian i16 packing, **byte-identical** to the Swift packer, so the stored BLOB round-trips a `.noopbak` across platforms.
- `extractHistoricalStreams` now also collects the raw per-second waveform into `StreamBatch.ppgWaveform`; `WhoopRepository.insert` packs + persists it (IGNORE-dedupe by `(deviceId, ts)`); `ppgWaveformSamples(...)` reads it back. `ppgWaveformSample` is added to the device-data wipe (privacy parity).

Tests: `PpgWaveformMigrationTest` (schema + pack/unpack + insert wiring) and `Whoop5PpgWaveformStreamTest` (extraction over the **same real v26 fixture** the Swift `Whoop5PpgWaveformTests` uses). `./gradlew :app:testFullDebugUnitTest` green.

## Tests

- `Packages/WhoopProtocol/Tests/WhoopProtocolTests/Whoop5PpgWaveformTests.swift`: `extractHistoricalStreams` populates `ppgWaveform` from a real captured v26 frame even when the HR estimator has too little context to produce anything (proving the fix — before this change that record would have vanished entirely); `Streams.isEmpty` correctly treats a waveform-only decode as non-empty; JSON decode tolerates a missing/present `ppg_waveform` key and round-trips (including negative AC-coupled samples).
- `Packages/WhoopStore/Tests/WhoopStoreTests/PpgWaveformSampleTests.swift`: the v27 migration creates the table with the right PK/columns; insert + read round-trips a real captured waveform exactly; re-insert is idempotent (`ON CONFLICT DO NOTHING`); range/device-scoping is respected; a short (< 24) sample array round-trips (the format isn't hardcoded to a fixed count); the pack/unpack codec round-trips signed extremes (`-32768`/`32767`) and drops a corrupt trailing odd byte instead of crashing.
- `swift test` is green in both packages: WhoopProtocol 281 tests, WhoopStore 266 tests (0 failures).
- macOS: `xcodegen generate && xcodebuild -scheme Strand -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO build` → **BUILD SUCCEEDED**, no errors. (No app-target/Collect code needed to change — the Collector/Backfiller already pass `Streams` generically to `store.insert`.)

## Test plan

- [x] `cd Packages/WhoopProtocol && swift test` — 281 tests, 0 failures
- [x] `cd Packages/WhoopStore && swift test` — 266 tests, 0 failures
- [x] `xcodegen generate && xcodebuild -scheme Strand -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO build` — BUILD SUCCEEDED
- [ ] On-device verification of a real v26-heavy offload populating `ppgWaveformSample` (this PR was built/tested in an isolated worktree without a paired strap; welcome for a maintainer or follow-up to confirm on hardware)
