### PR TITLE
diag(skin-temp): raw ADC band + resolved anchor in the funnel; analyze the latest night with data

### DIFF
--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/AnalyticsEngine.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/AnalyticsEngine.swift
@@ -969,23 +969,53 @@ public enum AnalyticsEngine {
         public let minSamples: Int
         /// The nightly mean (°C) the gates produced, or nil when `kept < minSamples` (or no input).
         public let mean: Double?
+        // #skin-diag: raw-ADC visibility so an absent WHOOP 4.0 skin temp explains WHY (anchor mis-map
+        // vs genuinely no worn data). Pure observations of the input — they do NOT affect `mean`/gates.
+        /// Min / median / max of the night's RAW skin-temp ADC values (nil when no samples). The WHOOP
+        /// 4.0 worn band is ~550–2040; this tells whether the strap streamed a plausible worn band at all.
+        public let rawMin: Int?
+        public let rawMedian: Int?
+        public let rawMax: Int?
+        /// Raw samples inside the worn ADC band (`Whoop4SkinTemp.wornMin…wornMaxRaw`). ≥100 lets the
+        /// per-device anchor (#938/#404) learn; below that it falls back to the global 826 anchor.
+        public let inBandCount: Int
+        /// The anchor raw actually used for the °C map — the caller's per-device anchor if supplied, else
+        /// the global 826. nil on 5/MG (centidegree path, no anchor).
+        public let resolvedAnchorRaw: Double?
+        /// What °C the median raw maps to under `resolvedAnchorRaw`. If this sits outside 28–42 °C, EVERY
+        /// worn sample is gated out — the #404 anchor-mismap signature. nil on 5/MG or when no samples.
+        public let medianMappedC: Double?
 
         public init(totalSamples: Int, droppedNotWorn: Int, droppedOutOfWindow: Int,
-                    droppedOutOfRange: Int, kept: Int, minSamples: Int, mean: Double?) {
+                    droppedOutOfRange: Int, kept: Int, minSamples: Int, mean: Double?,
+                    rawMin: Int? = nil, rawMedian: Int? = nil, rawMax: Int? = nil,
+                    inBandCount: Int = 0, resolvedAnchorRaw: Double? = nil, medianMappedC: Double? = nil) {
             self.totalSamples = totalSamples; self.droppedNotWorn = droppedNotWorn
             self.droppedOutOfWindow = droppedOutOfWindow; self.droppedOutOfRange = droppedOutOfRange
             self.kept = kept; self.minSamples = minSamples; self.mean = mean
+            self.rawMin = rawMin; self.rawMedian = rawMedian; self.rawMax = rawMax
+            self.inBandCount = inBandCount; self.resolvedAnchorRaw = resolvedAnchorRaw
+            self.medianMappedC = medianMappedC
         }
 
         /// True when the night produced no usable mean - the case this diagnostic exists to triage.
         public var isAbsent: Bool { mean == nil }
 
-        /// One human-readable line for the caller to LOG. No I/O here - the engine stays pure.
+        /// Human-readable line(s) for the caller to LOG. No I/O here - the engine stays pure. When raw
+        /// samples exist, a second `skin-temp-raw:` line surfaces the ADC band + resolved anchor mapping.
         public var summary: String {
-            "skin-temp-funnel: \(totalSamples) samples → kept \(kept)/\(minSamples) "
-            + "(mean=\(mean.map { String(format: "%.2f°C", $0) } ?? "absent")); "
-            + "dropped[notWorn=\(droppedNotWorn), outOfWindow=\(droppedOutOfWindow), "
-            + "outOfRange=\(droppedOutOfRange)]"
+            var s = "skin-temp-funnel: \(totalSamples) samples → kept \(kept)/\(minSamples) "
+                + "(mean=\(mean.map { String(format: "%.2f°C", $0) } ?? "absent")); "
+                + "dropped[notWorn=\(droppedNotWorn), outOfWindow=\(droppedOutOfWindow), "
+                + "outOfRange=\(droppedOutOfRange)]"
+            if let lo = rawMin, let mid = rawMedian, let hi = rawMax {
+                s += "\nskin-temp-raw: raw[min=\(lo) p50=\(mid) max=\(hi)] inBand=\(inBandCount)/\(totalSamples)"
+                if let a = resolvedAnchorRaw, let mapped = medianMappedC {
+                    s += String(format: "; anchor=%.0f → p50 maps %.1f°C (worn gate 28–42°C, ADC band 550–2040)",
+                                a, mapped)
+                }
+            }
+            return s
         }
     }
 
@@ -1003,12 +1033,27 @@ public enum AnalyticsEngine {
                                       anchorRaw: Double? = nil,
                                       minSamples: Int = minSkinTempSamples) -> SkinTempFunnelDiagnostic {
         let total = skinTemp.count
+        // #skin-diag: raw-ADC band + resolved anchor — PURE observation of the input, computed once and
+        // reported on both return paths. Never touches the mean/gate logic below (byte-parity preserved).
+        let sortedRaws = skinTemp.map { $0.raw }.sorted()
+        let rawMin = sortedRaws.first
+        let rawMax = sortedRaws.last
+        let rawMedian = sortedRaws.isEmpty ? nil : sortedRaws[sortedRaws.count / 2]
+        let inBandCount = family == .whoop4
+            ? sortedRaws.filter { $0 >= Whoop4SkinTemp.wornMinRaw && $0 <= Whoop4SkinTemp.wornMaxRaw }.count
+            : total
+        let usedAnchor: Double? = family == .whoop4 ? (anchorRaw ?? Whoop4SkinTemp.anchorRaw) : nil
+        let medianMappedC: Double? = (usedAnchor != nil && rawMedian != nil)
+            ? skinTempCelsius(raw: rawMedian!, family: family, anchorRaw: usedAnchor!) : nil
         // No sessions ⇒ every sample is out of window; no samples ⇒ an empty funnel. Either way the mean is
         // nil, exactly as `wornNightlySkinTempC`'s early return produced before.
         if sessions.isEmpty || skinTemp.isEmpty {
             return SkinTempFunnelDiagnostic(totalSamples: total, droppedNotWorn: 0,
                                             droppedOutOfWindow: sessions.isEmpty ? total : 0,
-                                            droppedOutOfRange: 0, kept: 0, minSamples: minSamples, mean: nil)
+                                            droppedOutOfRange: 0, kept: 0, minSamples: minSamples, mean: nil,
+                                            rawMin: rawMin, rawMedian: rawMedian, rawMax: rawMax,
+                                            inBandCount: inBandCount, resolvedAnchorRaw: usedAnchor,
+                                            medianMappedC: medianMappedC)
         }
         var wornSeconds = Set<Int>(minimumCapacity: hr.count)
         for h in hr where (30...220).contains(h.bpm) { wornSeconds.insert(h.ts) }
@@ -1038,6 +1083,9 @@ public enum AnalyticsEngine {
         let mean = kept >= minSamples ? sum / Double(kept) : nil
         return SkinTempFunnelDiagnostic(totalSamples: total, droppedNotWorn: notWorn,
                                         droppedOutOfWindow: outOfWindow, droppedOutOfRange: outOfRange,
-                                        kept: kept, minSamples: minSamples, mean: mean)
+                                        kept: kept, minSamples: minSamples, mean: mean,
+                                        rawMin: rawMin, rawMedian: rawMedian, rawMax: rawMax,
+                                        inBandCount: inBandCount, resolvedAnchorRaw: usedAnchor,
+                                        medianMappedC: medianMappedC)
     }
 }

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/SkinTempAnalyticsTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/SkinTempAnalyticsTests.swift
@@ -310,4 +310,47 @@ final class SkinTempAnalyticsTests: XCTestCase {
         let dev = Baselines.deviation(34.3, state: base).delta
         XCTAssertGreaterThan(dev, 0.5, "a +0.8 °C night must read as a clear positive deviation")
     }
+
+    /// #skin-diag: WHOOP 4.0 raw-band + resolved-anchor visibility. A worn night whose raws sit at 1290
+    /// (in the 550–2040 worn band) maps to ~56 °C under the GLOBAL 826 anchor → every worn sample fails the
+    /// 28–42 °C gate (absent), but to 33 °C under the per-device anchor → kept. The new fields surface the
+    /// raw band + which anchor resolved. Twin of Kotlin funnelSurfacesRawBandAndResolvedAnchorWhoop4.
+    func testFunnelSurfacesRawBandAndResolvedAnchorWhoop4() {
+        let start = 10_000_000
+        let sess = [session(start: start, durSec: 600)]
+        let hrs = (0..<600).map { hr(start + $0) }
+        let temps = (0..<600).map { skin(start + $0, rawX100: 1290) }
+
+        // Global 826 fallback (no anchor passed): p50 1290 → ~56 °C → all out of range, mean absent.
+        let g = AnalyticsEngine.skinTempFunnel(sess, hr: hrs, skinTemp: temps, family: .whoop4)
+        XCTAssertEqual(g.rawMin, 1290)
+        XCTAssertEqual(g.rawMedian, 1290)
+        XCTAssertEqual(g.rawMax, 1290)
+        XCTAssertEqual(g.inBandCount, 600)
+        XCTAssertEqual(g.resolvedAnchorRaw, Whoop4SkinTemp.anchorRaw)
+        XCTAssertGreaterThan(g.medianMappedC ?? 0, 42.0)
+        XCTAssertEqual(g.droppedOutOfRange, 600)
+        XCTAssertTrue(g.isAbsent)
+        XCTAssertTrue(g.summary.contains("skin-temp-raw: raw[min=1290 p50=1290 max=1290]"), g.summary)
+
+        // Per-device anchor 1290: p50 → 33 °C → in range → kept, mean present.
+        let d = AnalyticsEngine.skinTempFunnel(sess, hr: hrs, skinTemp: temps, family: .whoop4, anchorRaw: 1290)
+        XCTAssertEqual(d.resolvedAnchorRaw, 1290)
+        XCTAssertEqual(d.medianMappedC ?? 0, 33.0, accuracy: 0.01)
+        XCTAssertEqual(d.kept, 600)
+        XCTAssertFalse(d.isAbsent)
+    }
+
+    /// #skin-diag: the new observation fields never perturb the gate/mean — a kept-path night's mean stays
+    /// byte-identical to `wornNightlySkinTempC`, and 5/MG carries no anchor.
+    func testFunnelRawBandFieldsDoNotChangeMean() {
+        let start = 11_000_000
+        let sess = [session(start: start, durSec: 600)]
+        let hrs = (0..<600).map { hr(start + $0) }
+        let temps = (0..<600).map { skin(start + $0, rawX100: 3400) }
+        let f = AnalyticsEngine.skinTempFunnel(sess, hr: hrs, skinTemp: temps)  // whoop5 default
+        XCTAssertEqual(AnalyticsEngine.wornNightlySkinTempC(sess, hr: hrs, skinTemp: temps), f.mean)
+        XCTAssertNil(f.resolvedAnchorRaw, "5/MG centidegree path has no anchor")
+        XCTAssertEqual(f.rawMedian, 3400)
+    }
 }

--- a/Strand/System/DebugDataDiagnostics.swift
+++ b/Strand/System/DebugDataDiagnostics.swift
@@ -125,9 +125,11 @@ enum DebugDataDiagnostics {
         let det = SleepSession(start: cs.startTs, end: cs.endTs, efficiency: cs.efficiency ?? 0,
                                stages: [], restingHR: cs.restingHr, avgHRV: cs.avgHrv)
         let family: DeviceFamily = (UserDefaults.standard.string(forKey: "selectedWhoopModel") == "whoop5") ? .whoop5 : .whoop4
-        // Mirror the real per-device anchor (#404): learn it from this night's raws so the funnel's mean +
-        // mapping match what analyzeDay banks (nil → the global 826 fallback, exactly like the engine).
-        let devAnchor = family == .whoop4 ? Whoop4SkinTemp.deviceAnchorRaw(skin.map { $0.raw }) : nil
+        // Mirror the real per-device anchor (#404): learn it from the WHOLE recent window's raws — not just
+        // this night — so a single sparse night (<100 in-band) can't misreport under the global fallback when
+        // the window as a whole has enough in-band samples for analyzeDay to learn a device anchor.
+        let windowSkin = (try? await store.skinTempSamples(deviceId: did, from: nowSec - 14 * 86400, to: nowSec, limit: 200_000)) ?? []
+        let devAnchor = family == .whoop4 ? Whoop4SkinTemp.deviceAnchorRaw(windowSkin.map { $0.raw }) : nil
         lines.append(AnalyticsEngine.skinTempFunnel([det], hr: hr, skinTemp: skin,
                                                     family: family, anchorRaw: devAnchor).summary)
         return lines

--- a/Strand/System/DebugDataDiagnostics.swift
+++ b/Strand/System/DebugDataDiagnostics.swift
@@ -89,20 +89,29 @@ enum DebugDataDiagnostics {
         lines.append(String(repeating: "─", count: 40))
         lines.append("Analytics funnels (latest night, best-effort)")
         let nowSec = Int(Date().timeIntervalSince1970)
-        guard let cs = await repo.sleepSessions(from: nowSec - 14 * 86400, to: nowSec, limit: 1).last else {
-            lines.append("(no sleep session in the last 14 days to analyze)")
-            return lines
-        }
         guard let store = await repo.storeHandle() else {
             lines.append("(on-device store not open yet)")
             return lines
         }
         let did = repo.deviceId
+        // Pick the MOST RECENT night that actually carries skin-temp — not the OLDEST in the window. The old
+        // `sleepSessions(…, limit: 1).last` returned the oldest session (ASC order), so a fresh gap night read
+        // "skin=0" and the funnel never saw a real night. Walk newest→oldest and stop at the first with skin.
+        let recent = await repo.sleepSessions(from: nowSec - 14 * 86400, to: nowSec, limit: 200)
+        guard let newest = recent.last else {
+            lines.append("(no sleep session in the last 14 days to analyze)")
+            return lines
+        }
+        var cs = newest
+        var skin: [SkinTempSample] = []
+        for s in recent.reversed() {
+            let sk = (try? await store.skinTempSamples(deviceId: did, from: s.startTs, to: s.endTs, limit: 200_000)) ?? []
+            if !sk.isEmpty { cs = s; skin = sk; break }
+        }
         let grav = (try? await store.gravitySamples(deviceId: did, from: cs.startTs, to: cs.endTs, limit: 200_000)) ?? []
         let hr = await repo.hrSamples(from: cs.startTs, to: cs.endTs, limit: 200_000)
         let rr = (try? await store.rrIntervals(deviceId: did, from: cs.startTs, to: cs.endTs, limit: 200_000)) ?? []
         let resp = (try? await store.respSamples(deviceId: did, from: cs.startTs, to: cs.endTs, limit: 200_000)) ?? []
-        let skin = (try? await store.skinTempSamples(deviceId: did, from: cs.startTs, to: cs.endTs, limit: 200_000)) ?? []
         lines.append("Night \(dayStamp(cs.startTs)): grav=\(grav.count) hr=\(hr.count) rr=\(rr.count) resp=\(resp.count) skin=\(skin.count)")
         if grav.isEmpty && hr.isEmpty {
             lines.append("(no raw biometric samples under '\(did)' for this night — expected on a freshly re-added strap; reconnect + let a history sync run, then re-export)")
@@ -116,7 +125,11 @@ enum DebugDataDiagnostics {
         let det = SleepSession(start: cs.startTs, end: cs.endTs, efficiency: cs.efficiency ?? 0,
                                stages: [], restingHR: cs.restingHr, avgHRV: cs.avgHrv)
         let family: DeviceFamily = (UserDefaults.standard.string(forKey: "selectedWhoopModel") == "whoop5") ? .whoop5 : .whoop4
-        lines.append(AnalyticsEngine.skinTempFunnel([det], hr: hr, skinTemp: skin, family: family).summary)
+        // Mirror the real per-device anchor (#404): learn it from this night's raws so the funnel's mean +
+        // mapping match what analyzeDay banks (nil → the global 826 fallback, exactly like the engine).
+        let devAnchor = family == .whoop4 ? Whoop4SkinTemp.deviceAnchorRaw(skin.map { $0.raw }) : nil
+        lines.append(AnalyticsEngine.skinTempFunnel([det], hr: hr, skinTemp: skin,
+                                                    family: family, anchorRaw: devAnchor).summary)
         return lines
     }
 

--- a/android/app/src/main/java/com/noop/analytics/AnalyticsEngine.kt
+++ b/android/app/src/main/java/com/noop/analytics/AnalyticsEngine.kt
@@ -751,16 +751,42 @@ object AnalyticsEngine {
         val kept: Int,
         val minSamples: Int,
         val mean: Double?,
+        // #skin-diag: raw-ADC visibility so an absent WHOOP 4.0 skin temp explains WHY (anchor mis-map
+        // vs genuinely no worn data). Pure observations of the input — they do NOT affect mean/gates.
+        /** Min / median / max of the night's RAW skin-temp ADC values (null when no samples). */
+        val rawMin: Int? = null,
+        val rawMedian: Int? = null,
+        val rawMax: Int? = null,
+        /** Raw samples inside the worn ADC band (WORN_MIN..WORN_MAX_RAW); ≥100 lets the per-device anchor learn. */
+        val inBandCount: Int = 0,
+        /** The anchor raw actually used for the °C map (caller's per-device anchor, else the global 826). null on 5/MG. */
+        val resolvedAnchorRaw: Double? = null,
+        /** What °C the median raw maps to under [resolvedAnchorRaw]; outside 28–42 °C ⇒ every worn sample gated out. */
+        val medianMappedC: Double? = null,
     ) {
         /** True when the night produced no usable mean - the case this diagnostic exists to triage. */
         val isAbsent: Boolean get() = mean == null
 
-        /** One human-readable line for the caller to LOG. No I/O here - the engine stays pure. */
+        /** Human-readable line(s) for the caller to LOG. No I/O here - the engine stays pure. When raw
+         *  samples exist, a second `skin-temp-raw:` line surfaces the ADC band + resolved anchor mapping. */
         val summary: String
-            get() = "skin-temp-funnel: $totalSamples samples → kept $kept/$minSamples " +
-                "(mean=${mean?.let { String.format(java.util.Locale.US, "%.2f°C", it) } ?: "absent"}); " +
-                "dropped[notWorn=$droppedNotWorn, outOfWindow=$droppedOutOfWindow, " +
-                "outOfRange=$droppedOutOfRange]"
+            get() {
+                var s = "skin-temp-funnel: $totalSamples samples → kept $kept/$minSamples " +
+                    "(mean=${mean?.let { String.format(java.util.Locale.US, "%.2f°C", it) } ?: "absent"}); " +
+                    "dropped[notWorn=$droppedNotWorn, outOfWindow=$droppedOutOfWindow, " +
+                    "outOfRange=$droppedOutOfRange]"
+                if (rawMin != null && rawMedian != null && rawMax != null) {
+                    s += "\nskin-temp-raw: raw[min=$rawMin p50=$rawMedian max=$rawMax] inBand=$inBandCount/$totalSamples"
+                    if (resolvedAnchorRaw != null && medianMappedC != null) {
+                        s += String.format(
+                            java.util.Locale.US,
+                            "; anchor=%.0f → p50 maps %.1f°C (worn gate 28–42°C, ADC band 550–2040)",
+                            resolvedAnchorRaw, medianMappedC,
+                        )
+                    }
+                }
+                return s
+            }
     }
 
     /**
@@ -780,6 +806,23 @@ object AnalyticsEngine {
         minSamples: Int = MIN_SKIN_TEMP_SAMPLES_INLINE,
     ): SkinTempFunnelDiagnostic {
         val total = skinTemp.size
+        // #skin-diag: raw-ADC band + resolved anchor — PURE observation of the input, computed once and
+        // reported on both return paths. Never touches the mean/gate logic below (byte-parity preserved).
+        val sortedRaws = skinTemp.map { it.raw }.sorted()
+        val rawMin = sortedRaws.firstOrNull()
+        val rawMax = sortedRaws.lastOrNull()
+        val rawMedian = if (sortedRaws.isEmpty()) null else sortedRaws[sortedRaws.size / 2]
+        val inBandCount = if (family == DeviceFamily.WHOOP4) {
+            sortedRaws.count { it in Whoop4SkinTemp.WORN_MIN_RAW..Whoop4SkinTemp.WORN_MAX_RAW }
+        } else {
+            total
+        }
+        val usedAnchor: Double? = if (family == DeviceFamily.WHOOP4) (anchorRaw ?: Whoop4SkinTemp.ANCHOR_RAW) else null
+        val medianMappedC: Double? = if (usedAnchor != null && rawMedian != null) {
+            skinTempCelsius(rawMedian, family, usedAnchor)
+        } else {
+            null
+        }
         // No sessions ⇒ every sample is out of window; no samples ⇒ an empty funnel. Either way the mean is
         // null, exactly as [wornNightlySkinTempC]'s early return produced before.
         if (sessions.isEmpty() || skinTemp.isEmpty()) {
@@ -787,6 +830,8 @@ object AnalyticsEngine {
                 totalSamples = total, droppedNotWorn = 0,
                 droppedOutOfWindow = if (sessions.isEmpty()) total else 0,
                 droppedOutOfRange = 0, kept = 0, minSamples = minSamples, mean = null,
+                rawMin = rawMin, rawMedian = rawMedian, rawMax = rawMax,
+                inBandCount = inBandCount, resolvedAnchorRaw = usedAnchor, medianMappedC = medianMappedC,
             )
         }
         val wornSeconds = HashSet<Long>(hr.size)
@@ -819,6 +864,8 @@ object AnalyticsEngine {
         return SkinTempFunnelDiagnostic(
             totalSamples = total, droppedNotWorn = notWorn, droppedOutOfWindow = outOfWindow,
             droppedOutOfRange = outOfRange, kept = kept, minSamples = minSamples, mean = mean,
+            rawMin = rawMin, rawMedian = rawMedian, rawMax = rawMax,
+            inBandCount = inBandCount, resolvedAnchorRaw = usedAnchor, medianMappedC = medianMappedC,
         )
     }
 }

--- a/android/app/src/main/java/com/noop/testcentre/AndroidDiagnostics.kt
+++ b/android/app/src/main/java/com/noop/testcentre/AndroidDiagnostics.kt
@@ -112,10 +112,12 @@ object AndroidDiagnostics {
             )
             val family = if (com.noop.ui.NoopPrefs.lastDevice(context)?.second == com.noop.ble.WhoopModel.WHOOP5_MG)
                 com.noop.protocol.DeviceFamily.WHOOP5 else com.noop.protocol.DeviceFamily.WHOOP4
-            // Mirror the real per-device anchor (#404): learn it from this night's raws so the funnel's mean +
-            // mapping match what analyzeDay banks (null → the global 826 fallback, exactly like the engine).
+            // Mirror the real per-device anchor (#404): learn it from the WHOLE recent window's raws — not
+            // just this night — so a single sparse night (<100 in-band) can't misreport under the global
+            // fallback when the window as a whole has enough in-band samples for analyzeDay to learn one.
+            val windowSkin = repo.skinTempSamples(id, nowSec - 14L * 86400L, nowSec, Int.MAX_VALUE)
             val devAnchor = if (family == com.noop.protocol.DeviceFamily.WHOOP4)
-                com.noop.protocol.Whoop4SkinTemp.deviceAnchorRaw(skin.map { it.raw }) else null
+                com.noop.protocol.Whoop4SkinTemp.deviceAnchorRaw(windowSkin.map { it.raw }) else null
             add(com.noop.analytics.AnalyticsEngine.skinTempFunnel(listOf(det), hr, skin, family, devAnchor).summary)
         }.onFailure { add("(funnels unavailable: ${it.message})") }
     }

--- a/android/app/src/main/java/com/noop/testcentre/AndroidDiagnostics.kt
+++ b/android/app/src/main/java/com/noop/testcentre/AndroidDiagnostics.kt
@@ -78,16 +78,26 @@ object AndroidDiagnostics {
             val repo = com.noop.data.WhoopRepository.from(context)
             val id = "my-whoop"
             val nowSec = System.currentTimeMillis() / 1000L
-            val session = repo.sleepSessions(id, nowSec - 14L * 86400L, nowSec, 1).lastOrNull()
-            if (session == null) {
+            // Pick the MOST RECENT night that actually carries skin-temp — not the OLDEST. The old
+            // `sleepSessions(…, 1).lastOrNull()` returned the oldest session in the window (ASC order), so a
+            // fresh gap night read "skin=0" and the funnel never saw a real night. Walk newest→oldest.
+            val recent = repo.sleepSessions(id, nowSec - 14L * 86400L, nowSec, 200)
+            if (recent.isEmpty()) {
                 add("(no sleep session in the last 14 days to analyze)")
                 return@runCatching
+            }
+            var session = recent.last()   // non-null (list checked non-empty), newest by ASC start order
+            var skin = repo.skinTempSamples(id, session.startTs, session.endTs, Int.MAX_VALUE)
+            if (skin.isEmpty()) {
+                for (s in recent.asReversed()) {
+                    val sk = repo.skinTempSamples(id, s.startTs, s.endTs, Int.MAX_VALUE)
+                    if (sk.isNotEmpty()) { session = s; skin = sk; break }
+                }
             }
             val grav = repo.gravitySamples(id, session.startTs, session.endTs, Int.MAX_VALUE)
             val hr = repo.hrSamples(id, session.startTs, session.endTs, Int.MAX_VALUE)
             val rr = repo.rrIntervals(id, session.startTs, session.endTs, Int.MAX_VALUE)
             val resp = repo.respSamples(id, session.startTs, session.endTs, Int.MAX_VALUE)
-            val skin = repo.skinTempSamples(id, session.startTs, session.endTs, Int.MAX_VALUE)
             add("Night ${dayStamp(session.startTs)}: grav=${grav.size} hr=${hr.size} rr=${rr.size} resp=${resp.size} skin=${skin.size}")
             if (grav.isEmpty() && hr.isEmpty()) {
                 add("(no raw biometric samples under '$id' for this night — expected on a freshly re-added strap; reconnect + let a history sync run, then re-export)")
@@ -102,7 +112,11 @@ object AndroidDiagnostics {
             )
             val family = if (com.noop.ui.NoopPrefs.lastDevice(context)?.second == com.noop.ble.WhoopModel.WHOOP5_MG)
                 com.noop.protocol.DeviceFamily.WHOOP5 else com.noop.protocol.DeviceFamily.WHOOP4
-            add(com.noop.analytics.AnalyticsEngine.skinTempFunnel(listOf(det), hr, skin, family).summary)
+            // Mirror the real per-device anchor (#404): learn it from this night's raws so the funnel's mean +
+            // mapping match what analyzeDay banks (null → the global 826 fallback, exactly like the engine).
+            val devAnchor = if (family == com.noop.protocol.DeviceFamily.WHOOP4)
+                com.noop.protocol.Whoop4SkinTemp.deviceAnchorRaw(skin.map { it.raw }) else null
+            add(com.noop.analytics.AnalyticsEngine.skinTempFunnel(listOf(det), hr, skin, family, devAnchor).summary)
         }.onFailure { add("(funnels unavailable: ${it.message})") }
     }
 

--- a/android/app/src/test/java/com/noop/analytics/SkinTempAnalyticsTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/SkinTempAnalyticsTest.kt
@@ -336,4 +336,50 @@ class SkinTempAnalyticsTest {
         val dev = Baselines.deviation(34.3, base).delta
         assertTrue("a +0.8 °C night must read as a clear positive deviation, was $dev", dev > 0.5)
     }
+
+    /** #skin-diag: WHOOP 4.0 raw-band + resolved-anchor visibility. A worn night whose raws sit at 1290
+     *  (in the 550–2040 worn band) maps to ~56 °C under the GLOBAL 826 anchor → every worn sample fails the
+     *  28–42 °C gate (absent), but to 33 °C under the per-device anchor → kept. The new fields surface the
+     *  raw band + which anchor resolved, so an absent 4.0 skin temp explains WHY. Mirrors the Swift twin. */
+    @Test
+    fun funnelSurfacesRawBandAndResolvedAnchorWhoop4() {
+        val start = 10_000_000L
+        val sess = listOf(session(start, 600))
+        val hrs = (0 until 600).map { hr(start + it) }
+        val temps = (0 until 600).map { skin(start + it, 1290) }
+
+        // Global 826 fallback (no anchor passed): p50 1290 → ~56 °C → all out of range, mean absent.
+        val g = AnalyticsEngine.skinTempFunnel(sess, hrs, temps, DeviceFamily.WHOOP4)
+        assertEquals(1290, g.rawMin)
+        assertEquals(1290, g.rawMedian)
+        assertEquals(1290, g.rawMax)
+        assertEquals(600, g.inBandCount)
+        assertEquals(Whoop4SkinTemp.ANCHOR_RAW, g.resolvedAnchorRaw!!, 1e-9)
+        assertTrue("p50 must map above the 42 °C gate: ${g.medianMappedC}", g.medianMappedC!! > 42.0)
+        assertEquals(600, g.droppedOutOfRange)
+        assertTrue(g.isAbsent)
+        assertTrue("summary carries the raw line: ${g.summary}",
+            g.summary.contains("skin-temp-raw: raw[min=1290 p50=1290 max=1290]"))
+
+        // Per-device anchor 1290: p50 → 33 °C → in range → kept, mean present.
+        val d = AnalyticsEngine.skinTempFunnel(sess, hrs, temps, DeviceFamily.WHOOP4, 1290.0)
+        assertEquals(1290.0, d.resolvedAnchorRaw!!, 1e-9)
+        assertEquals(33.0, d.medianMappedC!!, 0.01)
+        assertEquals(600, d.kept)
+        assertFalse(d.isAbsent)
+    }
+
+    /** #skin-diag: the new observation fields never perturb the gate/mean — a kept-path night's mean stays
+     *  byte-identical to [AnalyticsEngine.wornNightlySkinTempC], and 5/MG carries no anchor. */
+    @Test
+    fun funnelRawBandFieldsDoNotChangeMean() {
+        val start = 11_000_000L
+        val sess = listOf(session(start, 600))
+        val hrs = (0 until 600).map { hr(start + it) }
+        val temps = (0 until 600).map { skin(start + it, 3400) }
+        val f = AnalyticsEngine.skinTempFunnel(sess, hrs, temps) // WHOOP5 default
+        assertEquals(AnalyticsEngine.wornNightlySkinTempC(sess, hrs, temps), f.mean)
+        assertNull("5/MG centidegree path has no anchor", f.resolvedAnchorRaw)
+        assertEquals(3400, f.rawMedian)
+    }
 }


### PR DESCRIPTION
## What
Two diagnostic fixes for triaging a WHOOP 4.0 Skin Temp "No Data":

1. **Analyze the right night.** The debug export analyzed the *oldest* session in the 14-day window (`sleepSessions(…, limit: 1).last`/`lastOrNull()` on an ASC query), so a fresh gap night read `skin=0` and the funnel never saw a real night. Now it walks newest→oldest and picks the latest night that actually carries skin-temp.
2. **Say WHY samples drop.** The funnel reported drop buckets but not the cause. Added pure observation fields — raw ADC band (`min/p50/max`), in-band count, the resolved anchor, and what °C the median maps to — plus a second `skin-temp-raw:` log line. The debug caller now also passes the **per-device anchor** so the funnel mirrors what `analyzeDay` banks (#404).

Example new line:
```
skin-temp-raw: raw[min=1102 p50=1290 max=1611] inBand=1590/1614; anchor=826 → p50 maps 56.2°C (worn gate 28–42°C, ADC band 550–2040)
```
That immediately shows the #404 anchor-mismap signature (worn band mapping out of range).

## Safety
**Diagnostic-only.** The gate/mean logic is untouched — the new fields are pure observations of the input, and `wornNightlySkinTempC` still equals `funnel.mean` (byte-parity preserved). No decode/score/schema change.

## Tests / verification
- Swift + Kotlin twin tests: raw-band + anchor mapping (1290 → ~56°C global / 33°C device), and a mean-unchanged guard. Android `SkinTempAnalyticsTest` **23/23** green locally.
- swift-packages CI covers the `StrandAnalytics` funnel + tests; app-build covers the app-target `DebugDataDiagnostics.swift`.