### PR TITLE
feat(analytics): add Recovery Index + Activity Balance terms to Charge

### DIFF
--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/Baselines.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/Baselines.swift
@@ -145,7 +145,16 @@ public enum Baselines {
     /// so the whole Charge build-up restarts cleanly. Same string on iOS UserDefaults + Android prefs.
     public static let recoveryBaselineEpochKey: String = "noop.recoveryBaselineEpoch"
 
-    /// Default per-metric configurations (HRV, resting HR, respiration, skin temp).
+    /// Default per-metric configurations (HRV, resting HR, respiration, skin temp, daily
+    /// Effort/strain).
+    ///
+    /// "strain" backs the RecoveryScorer Activity-Balance / previous-day-Effort term: bounds
+    /// match `StrainScorer.maxStrain`'s 0-100 output scale (the Charge/Effort/Rest redesign's
+    /// rescale of the historical 0-21 axis). floorSpread is wider than the physiological
+    /// metrics above (5.0 vs ~1-2% of range elsewhere) because day-to-day training load is
+    /// EXPECTED to swing hard (a rest day vs a hard day is a normal, large delta) — a tight
+    /// floor would make the z-score hypersensitive to routine training variation. Same
+    /// half-lives as the other metrics for consistency.
     public static let metricCfg: [String: MetricCfg] = [
         "hrv": MetricCfg(minVal: 5.0, maxVal: 250.0, floorSpread: 5.0,
                          halfLifeB: 14.0, halfLifeS: 21.0),
@@ -155,12 +164,16 @@ public enum Baselines {
                           halfLifeB: 14.0, halfLifeS: 21.0),
         "skin_temp": MetricCfg(minVal: 20.0, maxVal: 42.0, floorSpread: 0.3,
                                halfLifeB: 14.0, halfLifeS: 21.0),
+        "strain": MetricCfg(minVal: 0.0, maxVal: 100.0, floorSpread: 5.0,
+                            halfLifeB: 14.0, halfLifeS: 21.0),
     ]
 
     /// Convenience accessors for the standard configs.
     public static var hrvCfg: MetricCfg { metricCfg["hrv"]! }
     public static var restingHRCfg: MetricCfg { metricCfg["resting_hr"]! }
     public static var respCfg: MetricCfg { metricCfg["resp"]! }
+    /// Baseline config for the RecoveryScorer Activity-Balance / previous-day-Effort term.
+    public static var strainCfg: MetricCfg { metricCfg["strain"]! }
 
     /// Convert a half-life in nights to an EWMA smoothing factor.
     static func lambda(halfLife: Double) -> Double {

--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/RecoveryScorer.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/RecoveryScorer.swift
@@ -23,6 +23,20 @@ import WhoopProtocol
 // ONLY when a skin-temp deviation is supplied; when nil the term drops and the
 // weights renormalize, leaving the no-skin-temp score IDENTICAL to before.
 //
+// Two more OPTIONAL, nil-default terms close the gap to Oura Readiness's 8 contributors (an
+// Oura-reference validation found Charge already tracks Oura's readiness at r≈0.71; these are
+// the two components Charge lacked):
+//   overnight resting-HR DECLINE slope ("Recovery Index")      → W_RECOVERY_INDEX    = 0.05
+//   previous-day Effort vs personal baseline ("Activity Balance" /
+//   "Previous Day Activity", collapsed into one term)          → W_ACTIVITY_BALANCE  = 0.05
+// Both are ADDITIVE and NON-BREAKING: each is nil unless the caller supplies it, in which case
+// it folds in with its small weight above; when nil the term drops and the weights renormalize
+// exactly like the skin-temp term, so the default score for every existing caller is
+// BYTE-IDENTICAL to before either term existed. Recovery Index needs no personal baseline (a
+// fixed, documented bpm/hour scale, same style as sleepPerf/skin-temp); Activity Balance needs
+// BOTH the previous-day Effort value AND its EWMA baseline (`Baselines.strainCfg`) — supplying
+// only one drops the term.
+//
 // Each metric is standardized to a robust z-score against the personal baseline
 // (mean + EWMA-abs-dev spread). Missing terms are dropped and the weights
 // renormalized. The composite z is squashed through a logistic anchored so that
@@ -47,6 +61,23 @@ public enum RecoveryScorer {
     /// Skin-temp penalty scale (°C): a 1 °C deviation from baseline costs ≈1 z-unit of
     /// penalty before weighting. Symmetric — sign of the deviation does not matter.
     public static let skinTempScaleC: Double = 1.0
+
+    /// Recovery-Index weight (overnight resting-HR DECLINE slope — Oura's "Recovery Index"
+    /// contributor). Small and additive like wSkinTemp: folds in only when a slope is supplied.
+    public static let wRecoveryIndex: Double = 0.05
+
+    /// Recovery-Index slope scale (bpm/hour): a slope this many bpm/hour steeper than flat (0)
+    /// costs/earns ≈1 z-unit before weighting. Resting HR falling through the night is the
+    /// physiologically expected, good pattern; flat or rising (illness, alcohol, a late
+    /// stimulant, restlessness) is not. The SIGN carries the meaning (negative = declining =
+    /// good), unlike skin-temp's symmetric |deviation| penalty.
+    public static let recoveryIndexScaleBpmPerHr: Double = 2.0
+
+    /// Activity-Balance / previous-day-Effort weight (collapses Oura's "Previous Day Activity"
+    /// and "Activity Balance" readiness contributors into one term). Small and additive like
+    /// wSkinTemp: folds in only when BOTH a previous-day Effort value and its personal EWMA
+    /// baseline (`Baselines.strainCfg`) are supplied.
+    public static let wActivityBalance: Double = 0.05
 
     /// Logistic spread: ±2 z-units ≈ full Red–Green band (15%–95%).
     public static let logisticK: Double = 1.6
@@ -132,6 +163,60 @@ public enum RecoveryScorer {
         return Int(floor.rounded())
     }
 
+    // MARK: - Recovery Index (overnight HR-decline slope)
+
+    /// Minimum 5-minute bins (`restingHR`'s SAME binning) required before a slope is trusted —
+    /// below this, too little of the night has elapsed to fit a trend, and a 1-2-point
+    /// regression is noise, not a night-long pattern. 6 bins = 30 minutes of binned coverage,
+    /// a deliberately low floor so a short/partial night still gets a number rather than a
+    /// routine nil.
+    public static let recoveryIndexMinBins: Int = 6
+
+    /// Overnight resting-HR DECLINE slope (bpm/hour) across the in-bed window — the "Recovery
+    /// Index" component of Oura's Readiness that Charge lacked (it previously only read the
+    /// overnight FLOOR via `restingHR` above, never the trend that reaches it).
+    ///
+    /// Computed as the least-squares slope of the SAME non-overlapping 5-minute HR bin means
+    /// `restingHR` uses (`restingHRWindowS`) against each bin's midpoint time (hours from
+    /// `start`). NEGATIVE = declining (HR falling through the night — the physiologically
+    /// expected, good pattern); POSITIVE = rising (restlessness, illness, alcohol, a late
+    /// stimulant). Returns nil when fewer than `recoveryIndexMinBins` bins have data (too
+    /// little of the window to fit a trend) or there are no samples at all — it never
+    /// fabricates a slope from a sliver of the night.
+    public static func recoveryIndexSlope(_ hr: [HRSample], start: Int, end: Int) -> Double? {
+        let seg = hr.filter { $0.ts >= start && $0.ts <= end }
+        guard !seg.isEmpty else { return nil }
+
+        // Same non-overlapping 5-minute binning as restingHR: both read the identical
+        // underlying series, one as a floor, one as a trend across it.
+        var points: [(tHours: Double, meanBpm: Double)] = []
+        var t = start
+        while t < end {
+            let win = seg.filter { $0.ts >= t && $0.ts < t + restingHRWindowS }
+            if !win.isEmpty {
+                let mean = Double(win.reduce(0) { $0 + $1.bpm }) / Double(win.count)
+                let midpointS = Double(t - start) + Double(restingHRWindowS) / 2.0
+                points.append((tHours: midpointS / 3600.0, meanBpm: mean))
+            }
+            t += restingHRWindowS
+        }
+        guard points.count >= recoveryIndexMinBins else { return nil }
+
+        // Least-squares slope: Σ((t-t̄)(y-ȳ)) / Σ((t-t̄)²), bpm per hour.
+        let n = Double(points.count)
+        let tBar = points.reduce(0.0) { $0 + $1.tHours } / n
+        let yBar = points.reduce(0.0) { $0 + $1.meanBpm } / n
+        var num = 0.0, den = 0.0
+        for p in points {
+            let dt = p.tHours - tBar
+            num += dt * (p.meanBpm - yBar)
+            den += dt * dt
+        }
+        // Degenerate (all bins at the same instant): no time spread to fit against.
+        guard den > 1e-9 else { return 0.0 }
+        return num / den
+    }
+
     // MARK: - Recovery band
 
     /// WHOOP-style color band for a recovery score [0, 100].
@@ -205,6 +290,18 @@ public enum RecoveryScorer {
     ///     no-skin-temp score is identical to before.
     ///   - hrvBaselineUsable: whether the HRV baseline has enough nights
     ///     (BaselineState.usable). When false, returns nil (cold-start).
+    ///   - recoveryIndexSlope: overnight resting-HR DECLINE slope (bpm/hour, from
+    ///     `recoveryIndexSlope(_:start:end:)`). Negative (declining) supports recovery;
+    ///     positive (rising) limits it, weight wRecoveryIndex. nil (the default) drops the
+    ///     term and the weights renormalize, so the no-slope score is IDENTICAL to before
+    ///     this parameter existed.
+    ///   - effortBaseline: personal EWMA baseline of daily Effort/strain (`Baselines.strainCfg`).
+    ///     Needs `priorDayEffort` too — supplying only one drops the term.
+    ///   - priorDayEffort: yesterday's Effort/strain (0-100, `StrainScorer.strain`). Lower vs
+    ///     `effortBaseline` supports recovery, same "lower is better" direction as RHR/resp,
+    ///     weight wActivityBalance. nil (the default, like effortBaseline) drops the term and
+    ///     the weights renormalize, so the no-effort score is IDENTICAL to before either
+    ///     parameter existed.
     public static func recovery(hrv: Double,
                                 rhr: Double,
                                 resp: Double?,
@@ -213,7 +310,10 @@ public enum RecoveryScorer {
                                 respBaseline: DriverBaseline?,
                                 sleepPerf: Double?,
                                 skinTempDev: Double? = nil,
-                                hrvBaselineUsable: Bool = true) -> Double? {
+                                hrvBaselineUsable: Bool = true,
+                                recoveryIndexSlope: Double? = nil,
+                                effortBaseline: DriverBaseline? = nil,
+                                priorDayEffort: Double? = nil) -> Double? {
         // Cold-start gate: HRV is the dominant driver; if its baseline isn't
         // usable, refuse to score (more honest than a fabricated value).
         if !hrvBaselineUsable { return nil }
@@ -241,6 +341,18 @@ public enum RecoveryScorer {
         if let dev = skinTempDev {
             terms.append((-abs(dev) / skinTempScaleC, wSkinTemp))
         }
+        // Recovery-Index term: overnight HR-DECLINE slope (bpm/hour). No baseline needed (a
+        // fixed, documented scale, same style as sleepPerf/skin-temp). Negative (declining)
+        // supports recovery; positive (rising) limits it. Added only when supplied.
+        if let slope = recoveryIndexSlope {
+            terms.append((-slope / recoveryIndexScaleBpmPerHr, wRecoveryIndex))
+        }
+        // Activity-Balance / previous-day-Effort term: lower vs personal baseline is better,
+        // same "lower is better" direction as RHR/resp → (μ − x) / σ. Needs BOTH the value
+        // and a baseline, matching resp's pattern; added only when both are supplied.
+        if let e = priorDayEffort, let b = effortBaseline {
+            terms.append((zScore(b.mean, mean: e, spread: b.spread), wActivityBalance))
+        }
 
         guard !terms.isEmpty else { return nil }
         let totalWeight = terms.reduce(0) { $0 + $1.w }
@@ -260,7 +372,10 @@ public enum RecoveryScorer {
                                 rhrBaseline: BaselineState?,
                                 respBaseline: BaselineState?,
                                 sleepPerf: Double?,
-                                skinTempDev: Double? = nil) -> Double? {
+                                skinTempDev: Double? = nil,
+                                recoveryIndexSlope: Double? = nil,
+                                effortBaseline: BaselineState? = nil,
+                                priorDayEffort: Double? = nil) -> Double? {
         recovery(hrv: hrv,
                  rhr: rhr,
                  resp: resp,
@@ -269,6 +384,9 @@ public enum RecoveryScorer {
                  respBaseline: respBaseline.map(DriverBaseline.init),
                  sleepPerf: sleepPerf,
                  skinTempDev: skinTempDev,
-                 hrvBaselineUsable: hrvBaseline.usable)
+                 hrvBaselineUsable: hrvBaseline.usable,
+                 recoveryIndexSlope: recoveryIndexSlope,
+                 effortBaseline: effortBaseline.map(DriverBaseline.init),
+                 priorDayEffort: priorDayEffort)
     }
 }

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/BaselinesTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/BaselinesTests.swift
@@ -303,4 +303,29 @@ final class BaselinesTests: XCTestCase {
         XCTAssertEqual(after.nValid, 0)
         XCTAssertEqual(after.status, .calibrating)
     }
+
+    // MARK: - "strain" MetricCfg (RecoveryScorer Activity-Balance / previous-day-Effort term)
+
+    func testStrainCfgRegisteredWithEffortScaleBounds() {
+        // Bounds match StrainScorer.maxStrain's 0-100 output scale, keyed "strain" to match the
+        // existing internal metric-key convention (StrainScorer: "Internal metric key stays strain").
+        XCTAssertEqual(Baselines.metricCfg["strain"]!, Baselines.strainCfg)
+        XCTAssertEqual(Baselines.strainCfg.minVal, 0.0, accuracy: 1e-9)
+        XCTAssertEqual(Baselines.strainCfg.maxVal, 100.0, accuracy: 1e-9)
+    }
+
+    func testStrainCfgIsBaselineRelativeOverDailyEffort() {
+        // A week of moderate days then a rest day: the baseline tracks the moderate norm, and
+        // the rest day reads as a clear BELOW-baseline (positive, "lighter than usual") deviation.
+        let moderateWeek: [Double?] = [38, 42, 40, 36, 44, 39, 41]
+        let s = Baselines.foldHistory(moderateWeek, cfg: Baselines.strainCfg)
+        XCTAssertTrue(s.usable)
+        XCTAssertEqual(s.baseline, 40.0, accuracy: 5.0)
+
+        let restDay = Baselines.deviation(10.0, state: s)
+        XCTAssertLessThan(restDay.z, 0, "a much-lighter-than-normal day must read BELOW the effort baseline")
+
+        let hardDay = Baselines.deviation(85.0, state: s)
+        XCTAssertGreaterThan(hardDay.z, 0, "a much-harder-than-normal day must read ABOVE the effort baseline")
+    }
 }

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/RecoveryScorerTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/RecoveryScorerTests.swift
@@ -222,4 +222,179 @@ final class RecoveryScorerTests: XCTestCase {
         let r = RecoveryScorer.restingHR(hr, start: start, end: start + 600)
         XCTAssertEqual(r, 48, "with no qualifying bin, fall back to the lowest bin mean (never nil on data)")
     }
+
+    // MARK: - Recovery Index: recoveryIndexSlope(_:start:end:)
+
+    /// Build a synthetic in-bed HR series with a constant slope (bpm/hour) from `startBpm`,
+    /// sampled every 30 s (a low-cadence strap) over `hours`. Returns the series plus its
+    /// [start, end] window.
+    private func slopeSeries(startBpm: Double, slopePerHour: Double, hours: Double,
+                            originTs: Int = 10_000) -> (hr: [HRSample], start: Int, end: Int) {
+        var hr: [HRSample] = []
+        let totalSeconds = Int(hours * 3600)
+        var t = 0
+        while t < totalSeconds {
+            let bpm = startBpm + slopePerHour * (Double(t) / 3600.0)
+            hr.append(HRSample(ts: originTs + t, bpm: Int(bpm.rounded())))
+            t += 30
+        }
+        return (hr, originTs, originTs + totalSeconds)
+    }
+
+    func testRecoveryIndexSlopeNilWhenNoSamples() {
+        XCTAssertNil(RecoveryScorer.recoveryIndexSlope([], start: 0, end: 1000))
+    }
+
+    func testRecoveryIndexSlopeNilWhenTooFewBins() {
+        // Only 2 five-minute bins (10 minutes) of data — below recoveryIndexMinBins — too
+        // little of the night to fit a trend; must return nil, never a fabricated slope.
+        var hr: [HRSample] = []
+        let start = 5000
+        for i in 0..<300 { hr.append(HRSample(ts: start + i, bpm: 60)) }
+        for i in 0..<300 { hr.append(HRSample(ts: start + 300 + i, bpm: 55)) }
+        XCTAssertNil(RecoveryScorer.recoveryIndexSlope(hr, start: start, end: start + 600))
+    }
+
+    func testRecoveryIndexSlopeRecoversMultipleDistinctInjectedSlopes() {
+        // Derived-signal rule: recover MULTIPLE distinct injected slopes, not one matched case.
+        // Four full-night (6 h) synthetic series: flat, mild decline, steep decline, rising.
+        let flat = slopeSeries(startBpm: 62, slopePerHour: 0.0, hours: 6)
+        let mild = slopeSeries(startBpm: 62, slopePerHour: -1.0, hours: 6)
+        let steep = slopeSeries(startBpm: 68, slopePerHour: -4.0, hours: 6)
+        let rising = slopeSeries(startBpm: 55, slopePerHour: 2.0, hours: 6)
+
+        let flatSlope = RecoveryScorer.recoveryIndexSlope(flat.hr, start: flat.start, end: flat.end)
+        let mildSlope = RecoveryScorer.recoveryIndexSlope(mild.hr, start: mild.start, end: mild.end)
+        let steepSlope = RecoveryScorer.recoveryIndexSlope(steep.hr, start: steep.start, end: steep.end)
+        let risingSlope = RecoveryScorer.recoveryIndexSlope(rising.hr, start: rising.start, end: rising.end)
+
+        XCTAssertNotNil(flatSlope); XCTAssertNotNil(mildSlope)
+        XCTAssertNotNil(steepSlope); XCTAssertNotNil(risingSlope)
+
+        // Each recovered slope is close to its OWN injected value (within integer-bpm rounding
+        // noise from the synthetic series), not just relatively ordered.
+        XCTAssertEqual(flatSlope!, 0.0, accuracy: 0.3)
+        XCTAssertEqual(mildSlope!, -1.0, accuracy: 0.3)
+        XCTAssertEqual(steepSlope!, -4.0, accuracy: 0.3)
+        XCTAssertEqual(risingSlope!, 2.0, accuracy: 0.3)
+
+        // And strictly ordered steep-decline < mild-decline < flat < rising.
+        XCTAssertLessThan(steepSlope!, mildSlope!)
+        XCTAssertLessThan(mildSlope!, flatSlope!)
+        XCTAssertLessThan(flatSlope!, risingSlope!)
+    }
+
+    // MARK: - Recovery Index / Activity-Balance folded into recovery(...)
+
+    func testRecoveryIndexAndActivityBalanceDefaultNilByteIdenticalToBefore() {
+        // Both new terms default to nil; the score must be EXACTLY the same whether the caller
+        // omits them (every pre-existing call site in the app) or supplies nil explicitly —
+        // proving the addition is non-breaking for every caller that does not yet supply the
+        // two new signals. Covers BOTH overloads (BaselineState convenience + raw DriverBaseline).
+        let omitted = RecoveryScorer.recovery(
+            hrv: 55, rhr: 52, resp: 14.0,
+            hrvBaseline: baseline(mean: 50, sigma: 6),
+            rhrBaseline: baseline(mean: 55, sigma: 3),
+            respBaseline: baseline(mean: 14.5, sigma: 1),
+            sleepPerf: 0.9,
+            skinTempDev: 0.4)!
+        let explicitNil = RecoveryScorer.recovery(
+            hrv: 55, rhr: 52, resp: 14.0,
+            hrvBaseline: baseline(mean: 50, sigma: 6),
+            rhrBaseline: baseline(mean: 55, sigma: 3),
+            respBaseline: baseline(mean: 14.5, sigma: 1),
+            sleepPerf: 0.9,
+            skinTempDev: 0.4,
+            recoveryIndexSlope: nil,
+            effortBaseline: nil,
+            priorDayEffort: nil)!
+        XCTAssertEqual(omitted, explicitNil, accuracy: 1e-9)
+
+        let hrvB = RecoveryScorer.DriverBaseline(mean: 50, spread: 6 / 1.253)
+        let rhrB = RecoveryScorer.DriverBaseline(mean: 55, spread: 3 / 1.253)
+        let rawOmitted = RecoveryScorer.recovery(
+            hrv: 55, rhr: 52, resp: nil,
+            hrvBaseline: hrvB, rhrBaseline: rhrB, respBaseline: nil,
+            sleepPerf: 0.9, skinTempDev: 0.4)!
+        let rawExplicitNil = RecoveryScorer.recovery(
+            hrv: 55, rhr: 52, resp: nil,
+            hrvBaseline: hrvB, rhrBaseline: rhrB, respBaseline: nil,
+            sleepPerf: 0.9, skinTempDev: 0.4, hrvBaselineUsable: true,
+            recoveryIndexSlope: nil, effortBaseline: nil, priorDayEffort: nil)!
+        XCTAssertEqual(rawOmitted, rawExplicitNil, accuracy: 1e-9)
+    }
+
+    func testRecoveryIndexSteeperDeclineRaisesChargeMoreThanFlatOrRising() {
+        // Pin HRV/RHR/sleep at neutral so the ONLY thing moving is the slope term.
+        func score(_ slope: Double?) -> Double {
+            RecoveryScorer.recovery(
+                hrv: 50, rhr: 55, resp: nil,
+                hrvBaseline: baseline(mean: 50, sigma: 6),
+                rhrBaseline: baseline(mean: 55, sigma: 3),
+                respBaseline: nil,
+                sleepPerf: RecoveryScorer.sleepPerfCenter,
+                recoveryIndexSlope: slope)!
+        }
+        let flat = score(0.0)
+        let mildDecline = score(-1.0)
+        let steepDecline = score(-4.0)
+        let rising = score(2.0)
+
+        // Multiple distinct slopes recovered in the expected order (derived-signal rule): a
+        // steeper decline raises the Charge contribution more than a flat or rising night.
+        XCTAssertGreaterThan(steepDecline, mildDecline)
+        XCTAssertGreaterThan(mildDecline, flat)
+        XCTAssertGreaterThan(flat, rising)
+    }
+
+    func testActivityBalanceHighEffortYesterdayLowersChargeVsRestDay() {
+        // Baseline drivers pinned ABOVE-center (positive composite z), same rigor as the
+        // skin-temp precedent test, so the effort term's renormalization dilution has a
+        // direction to push against.
+        func score(_ effort: Double?) -> Double {
+            RecoveryScorer.recovery(
+                hrv: 58, rhr: 50, resp: nil,
+                hrvBaseline: baseline(mean: 50, sigma: 6),
+                rhrBaseline: baseline(mean: 55, sigma: 3),
+                respBaseline: nil,
+                sleepPerf: 0.92,
+                effortBaseline: baseline(mean: 40, sigma: 15),
+                priorDayEffort: effort)!
+        }
+        let neutral = score(nil)
+        let atBaseline = score(40.0)     // exactly typical -> present term, z=0, dilutes toward center
+        let restDay = score(10.0)        // well below normal -> supports recovery further
+        let hardDay = score(65.0)        // above normal -> pulls recovery down
+        let veryHardDay = score(90.0)    // far above normal -> pulls down more
+
+        XCTAssertLessThan(atBaseline, neutral,
+            "a present at-baseline effort term still dilutes an above-center composite toward the logistic center")
+        XCTAssertGreaterThan(restDay, atBaseline, "a lighter-than-normal day supports recovery vs a typical day")
+        XCTAssertGreaterThan(atBaseline, hardDay, "a harder-than-normal day pulls recovery down vs a typical day")
+        // Multiple distinct levels recovered in strictly the expected monotonic order
+        // (derived-signal rule): more effort yesterday -> lower Charge contribution.
+        XCTAssertGreaterThan(restDay, hardDay)
+        XCTAssertGreaterThan(hardDay, veryHardDay)
+    }
+
+    func testActivityBalanceDropsTermUnlessBothValueAndBaselineArePresent() {
+        func score(effort: Double?, effortBaseline base: BaselineState?) -> Double {
+            RecoveryScorer.recovery(
+                hrv: 50, rhr: 55, resp: nil,
+                hrvBaseline: baseline(mean: 50, sigma: 6),
+                rhrBaseline: baseline(mean: 55, sigma: 3),
+                respBaseline: nil,
+                sleepPerf: RecoveryScorer.sleepPerfCenter,
+                effortBaseline: base,
+                priorDayEffort: effort)!
+        }
+        let neither = score(effort: nil, effortBaseline: nil)
+        let valueOnly = score(effort: 80.0, effortBaseline: nil)
+        let baselineOnly = score(effort: nil, effortBaseline: baseline(mean: 40, sigma: 15))
+        let both = score(effort: 80.0, effortBaseline: baseline(mean: 40, sigma: 15))
+
+        XCTAssertEqual(neither, valueOnly, accuracy: 1e-9, "a value with no baseline must drop the term")
+        XCTAssertEqual(neither, baselineOnly, accuracy: 1e-9, "a baseline with no value must drop the term")
+        XCTAssertNotEqual(both, neither, "supplying BOTH must actually change the score")
+    }
 }


### PR DESCRIPTION
## Motivation

An Oura-reference validation found that Charge (HRV/RHR-led recovery, `RecoveryScorer.swift`)
already tracks Oura's Readiness well (r≈0.71), covering HRV Balance, RHR, Body Temp, and
Previous-Night Sleep. Oura's Readiness has 8 contributors; two were still missing from Charge,
and both are pure **algorithm** gaps over data NOOP already stores — no new capture needed:

1. **Recovery Index** — how fast resting HR *declines* through the night (a slope). NOOP stores
   the full in-bed HR series but `RecoveryScorer` only ever read the overnight **floor** (the min
   of 5-minute bin means, via `restingHR`), never the trend that reaches it.
2. **Activity Balance / Previous Day Activity** — Charge had no input from yesterday's training
   load; `recovery(...)` took no strain/effort term at all.

## What changed (`Packages/StrandAnalytics` only)

Both new signals are **additive and non-breaking**: they are new **optional, nil-default**
parameters, so every existing call site (`AnalyticsEngine.swift`, `WatchRecovery.swift`, the
app's `IntelligenceEngine.swift`) is unaffected and keeps compiling exactly as-is.

**1. Recovery Index** — `RecoveryScorer.recoveryIndexSlope(_:start:end:)`
- A new pure function computing the least-squares slope (bpm/hour) of the SAME non-overlapping
  5-minute HR bin means `restingHR` already uses, against each bin's midpoint time. Negative =
  declining (the good, expected pattern); positive = rising (illness, alcohol, a late stimulant,
  restlessness). Returns nil below `recoveryIndexMinBins` (6 bins / 30 min) of coverage.
- Folds into `recovery(...)` as `recoveryIndexSlope: Double? = nil`, weight `wRecoveryIndex =
  0.05`, scaled by a documented `recoveryIndexScaleBpmPerHr = 2.0` constant. No personal baseline
  needed — same "fixed, documented scale" style as the existing `sleepPerf`/`skinTempDev` terms.

**2. Activity Balance / Previous Day Activity** — collapsed into one `priorDayEffort` term
- Added a `"strain"` `MetricCfg` to `Baselines.swift` (bounds 0–100, matching
  `StrainScorer.maxStrain`'s post-redesign Effort scale; wider `floorSpread` than the
  physiological metrics since day-to-day training load is expected to swing hard) plus a
  `Baselines.strainCfg` accessor, so a previous-day Effort value can be scored **relative to its
  own EWMA personal baseline** — the same machinery HRV/RHR/resp already use.
- Folds into `recovery(...)` as `priorDayEffort: Double? = nil` + `effortBaseline: DriverBaseline?
  / BaselineState? = nil`, weight `wActivityBalance = 0.05`. Direction mirrors RHR/resp ("lower
  vs baseline is better"): a harder-than-normal day yesterday pulls Charge down, a lighter one
  supports it. Needs BOTH the value and a baseline supplied, matching the existing resp pattern.

Both weights are small (0.05, matching the existing `wSkinTemp` precedent) and are simply new
entries in the same `terms`/renormalization loop `recovery(...)` already runs — when a term is
absent the weights renormalize over what's present, so the score is **byte-identical** to before
either parameter existed. Full parameter docs are in `RecoveryScorer.swift`.

## Non-breaking proof

- Every existing `RecoveryScorer`/`Baselines` test (and the full `StrandAnalytics` suite: **1046
  tests**) passes unchanged — nothing needed updating.
- New explicit tests assert that calling `recovery(...)` **without** the new parameters produces
  the exact same score (`accuracy: 1e-9`) as calling it with them passed as `nil`, on **both**
  overloads (the `BaselineState` convenience overload and the raw `DriverBaseline` overload).

## Tests added (`swift test`, synthetic, multiple injected values per the repo's derived-signal rule)

- `testRecoveryIndexAndActivityBalanceDefaultNilByteIdenticalToBefore` — the non-breaking proof
  above.
- `testRecoveryIndexSlopeRecoversMultipleDistinctInjectedSlopes` — recovers **four** distinct
  injected slopes (flat / mild decline / steep decline / rising) from synthetic in-bed HR series,
  each within 0.3 bpm/hr of its true injected value, strictly ordered.
- `testRecoveryIndexSlopeNilWhenNoSamples` / `testRecoveryIndexSlopeNilWhenTooFewBins` — honesty
  gates (never fabricates a slope from a sliver of the night).
- `testRecoveryIndexSteeperDeclineRaisesChargeMoreThanFlatOrRising` — a steeper decline raises the
  Charge contribution more than a flat or rising night.
- `testActivityBalanceHighEffortYesterdayLowersChargeVsRestDay` — recovers **four** distinct effort
  levels (rest day / at-baseline / hard day / very-hard day) in strict monotonic order, plus the
  same renormalization-dilution rigor as the existing skin-temp test.
- `testActivityBalanceDropsTermUnlessBothValueAndBaselineArePresent` — value-only / baseline-only
  both drop the term, matching resp's "needs BOTH" pattern.
- `testStrainCfgRegisteredWithEffortScaleBounds` / `testStrainCfgIsBaselineRelativeOverDailyEffort`
  — the new `Baselines.strainCfg`.

`cd Packages/StrandAnalytics && swift test`: **all 1046 tests pass, 0 failures.**

## Build

Pure-package change only (`Packages/StrandAnalytics`); no app-target call site changed (both new
parameters default to `nil`), so `project.yml` / `Strand.xcodeproj` are untouched and no
`xcodegen`/`xcodebuild` was needed for this PR.

## Android

`android/app/src/main/java/com/noop/analytics/RecoveryScorer.kt` mirrors today's Swift
`recovery(...)` signature exactly (same parameters, same `skinTempDev` nil-default pattern). The
two new terms are **deferred** to a follow-up PR rather than ported here: the Recovery Index slope
is a new least-squares regression, not a mechanical transcription of existing arithmetic, and I'm
a Swift-only contributor without an Android toolchain — matching the existing Swift/Kotlin
split-PR precedent in this repo. Filed as a clearly scoped follow-up (new `recoveryIndexSlope` in
`RecoveryScorer.kt`, new `"strain"` entry in `Baselines.kt`, the two new `recovery(...)`
parameters, and JUnit coverage mirroring the Swift tests above).
