### PR TITLE
feat(android): hold-and-drag the live Today cards to reorder them, persisted

### DIFF
--- a/android/app/src/main/java/com/noop/ui/Components.kt
+++ b/android/app/src/main/java/com/noop/ui/Components.kt
@@ -21,6 +21,8 @@ import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListScope
+import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
@@ -1265,6 +1267,10 @@ fun LazyScreenScaffold(
     // When true, the [topBackground] fills the WHOLE scaffold (viewport) instead of the top band — the
     // "sky behind cards" mode, so a full-height backdrop shows behind every scrolling row.
     fullBleedBackground: Boolean = false,
+    // #today-layout: the list state, hoisted so a caller can read item positions / scroll programmatically
+    // (Today's hold-to-drag section reorder needs layoutInfo + scrollBy). Defaulted, so every existing
+    // caller is byte-for-byte untouched.
+    listState: LazyListState = rememberLazyListState(),
     content: LazyListScope.() -> Unit,
 ) {
     // The header row: optional leading action, the title/subtitle, optional trailing action. Omitted
@@ -1309,6 +1315,7 @@ fun LazyScreenScaffold(
     val list: @Composable () -> Unit = {
         LazyColumn(
             modifier = listModifier,
+            state = listState,
             contentPadding = PaddingValues(start = 28.dp, top = topPadding, end = 28.dp, bottom = 28.dp),
             // #765: the shared inter-card spacing token by default (Today/Explore + the eager screens share
             // one uniform card rhythm); a caller may pass a tighter [rowSpacing] (the liquid Today does, for

--- a/android/app/src/main/java/com/noop/ui/TodayLayoutPrefs.kt
+++ b/android/app/src/main/java/com/noop/ui/TodayLayoutPrefs.kt
@@ -1,0 +1,82 @@
+package com.noop.ui
+
+import android.content.Context
+
+// MARK: - Reorderable Today sections (#today-layout)
+//
+// The Today screen's below-the-hero sections (Synthesis, Key Metrics, Workouts, Heart Rate, Recovery
+// Vitals, Your Cards) rendered in one fixed order. This lets the user REORDER them, with the default being
+// the original order so nothing changes for anyone who never opens the editor. Display-only — no metric is
+// computed or stored differently; this only decides the SEQUENCE the already-built sections render in. The
+// Charge/Effort/Rest hero + intro/conditional cards stay pinned above this block.
+//
+// Stored as a single comma-joined string of section keys in SharedPreferences ("today.sectionOrder"), the
+// same mechanism KeyMetricPrefs/DashboardCards use. Mirrors the macOS TodayLayoutPrefs.swift +
+// @AppStorage("today.sectionOrder"). Every known section ALWAYS renders: unknown tokens are dropped, and
+// any known section missing from the saved order is APPENDED in default-order position — so a newly-added
+// section shows up rather than vanishing. This reorders, it never hides.
+
+/**
+ * One reorderable Today section (below the pinned hero). The [raw] is the stable persisted identifier —
+ * keep it byte-identical to the macOS `TodaySection` enum so a backup/restore reads the same layout on
+ * either OS.
+ */
+enum class TodaySection(val raw: String, val title: String) {
+    SYNTHESIS("synthesis", "Synthesis"),
+    KEY_METRICS("keyMetrics", "Key Metrics"),
+    WORKOUTS("workouts", "Workouts"),
+    HEART_RATE("heartRate", "Heart Rate"),
+    RECOVERY_VITALS("recoveryVitals", "Recovery Vitals"),
+    YOUR_CARDS("yourCards", "Your Cards");
+
+    companion object {
+        fun fromRaw(raw: String?): TodaySection? = entries.firstOrNull { it.raw == raw }
+
+        /** The original, hard-coded section order — the default when the layout isn't customised. */
+        val defaultOrder: List<TodaySection> = listOf(
+            SYNTHESIS, KEY_METRICS, WORKOUTS, HEART_RATE, RECOVERY_VITALS, YOUR_CARDS,
+        )
+    }
+}
+
+/**
+ * Display-only persistence for the Today section order. Holds the sections in display order; every known
+ * section always renders (a missing one is appended), so this reorders but never hides. SharedPreferences
+ * isn't reactive, so Today reads this once into remembered state (like the other prefs) and re-reads on the
+ * recomposition the editor's write triggers. Mirrors the macOS TodayLayoutPrefs (@AppStorage
+ * "today.sectionOrder").
+ */
+object TodayLayoutPrefs {
+    private const val KEY_ORDER = "today.sectionOrder"
+
+    /** Every known section in display order (saved order first, then any newly-added section appended). */
+    fun order(context: Context): List<TodaySection> =
+        decodeOrder(NoopPrefs.of(context).getString(KEY_ORDER, null))
+
+    /** Persist the section order. */
+    fun setOrder(context: Context, sections: List<TodaySection>) {
+        NoopPrefs.of(context).edit().putString(KEY_ORDER, encode(sections)).apply()
+    }
+
+    /** Encode an ordered list of sections into the stored comma-joined string. */
+    fun encode(sections: List<TodaySection>): String = sections.joinToString(",") { it.raw }
+
+    /**
+     * Decode the stored string into the FULL ordered section list. An empty/unset string yields the
+     * default order. Unknown tokens are ignored, duplicates collapsed, and any known section missing from
+     * the saved order is APPENDED in default-order position — so every section always renders and a newly
+     * added section can never be lost.
+     */
+    fun decodeOrder(raw: String?): List<TodaySection> {
+        val trimmed = raw?.trim().orEmpty()
+        if (trimmed.isEmpty()) return TodaySection.defaultOrder
+        val seen = LinkedHashSet<TodaySection>()
+        trimmed.split(",").forEach { token ->
+            TodaySection.fromRaw(token.trim())?.let { seen.add(it) }
+        }
+        // Append any known section not named in the saved order (e.g. one added in a later app version) so
+        // nothing vanishes — the reorder is order-only, never a hide.
+        TodaySection.defaultOrder.forEach { seen.add(it) }
+        return seen.toList()
+    }
+}

--- a/android/app/src/main/java/com/noop/ui/TodayScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/TodayScreen.kt
@@ -392,7 +392,7 @@ fun TodayScreen(
     LaunchedEffect(sectionDragActive) {
         while (sectionDrag.key != null) {
             withFrameNanos { }
-            swapTargetForDraggedSection(todayListState, sectionDrag)?.let { (dragged, target) ->
+            swapTargetForDraggedSection(todayListState, sectionDrag, sectionOrder)?.let { (dragged, target) ->
                 sectionOrder = sectionOrder.movedTodaySection(dragged, target)
             }
             if (sectionDrag.autoScrollPxPerFrame != 0f) {
@@ -3430,12 +3430,19 @@ private fun List<TodaySection>.movedTodaySection(section: TodaySection, target: 
  * The (dragged, target) pair to swap right now, or null. The lifted card's finger-anchored middle
  * (`pickedUpAt + distance + size/2`, viewport space) must sit over another section item AND have crossed
  * that item's CENTRE in the direction of travel — the centre gate stops a tall card over a short one from
- * ping-ponging (an immediate swap-back would require crossing back over the centre). Pure read of
- * [LazyListState.layoutInfo]; the caller applies the move.
+ * ping-ponging (an immediate swap-back would require crossing back over the centre).
+ *
+ * The direction is derived from [order] (the section list, the source of truth), NOT from layout offsets:
+ * after a swap the state updates immediately but layoutInfo lags one frame, and an offset-derived direction
+ * on that stale frame re-derives the SAME swap and undoes it (a visible oscillation). Order-derived
+ * direction flips with the swap, so the stale re-check fails the centre gate and the move sticks; a
+ * genuine user reversal still passes once the finger crosses back over the centre. Pure read; the caller
+ * applies the move.
  */
 private fun swapTargetForDraggedSection(
     listState: LazyListState,
     drag: TodaySectionDragState,
+    order: List<TodaySection>,
 ): Pair<TodaySection, TodaySection>? {
     val key = drag.key ?: return null
     val info = listState.layoutInfo
@@ -3445,12 +3452,12 @@ private fun swapTargetForDraggedSection(
         item.key != key && (item.key as? String)?.startsWith(TODAY_SECTION_KEY_PREFIX) == true &&
             middle >= item.offset && middle <= item.offset + item.size
     } ?: return null
+    val dragged = TodaySection.fromRaw(key.removePrefix(TODAY_SECTION_KEY_PREFIX)) ?: return null
+    val tgt = TodaySection.fromRaw((target.key as String).removePrefix(TODAY_SECTION_KEY_PREFIX)) ?: return null
     val targetCentre = target.offset + target.size / 2f
-    val movingDown = target.offset > current.offset
+    val movingDown = order.indexOf(tgt) > order.indexOf(dragged)
     if (movingDown && middle < targetCentre) return null
     if (!movingDown && middle > targetCentre) return null
-    val dragged = TodaySection.fromRaw((key).removePrefix(TODAY_SECTION_KEY_PREFIX)) ?: return null
-    val tgt = TodaySection.fromRaw((target.key as String).removePrefix(TODAY_SECTION_KEY_PREFIX)) ?: return null
     return dragged to tgt
 }
 

--- a/android/app/src/main/java/com/noop/ui/TodayScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/TodayScreen.kt
@@ -48,6 +48,7 @@ import androidx.compose.material.icons.filled.KeyboardArrowDown
 import androidx.compose.material.icons.filled.MonitorHeart
 import androidx.compose.material.icons.filled.KeyboardArrowUp
 import androidx.compose.material.icons.filled.TrackChanges
+import androidx.compose.material.icons.filled.DragHandle
 import androidx.compose.material.icons.filled.SwapVert
 import androidx.compose.material.icons.filled.Tune
 import androidx.compose.material.icons.filled.Warning
@@ -86,6 +87,10 @@ import androidx.compose.ui.graphics.PathEffect
 import androidx.compose.ui.graphics.Shadow
 import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
+import androidx.compose.ui.platform.LocalHapticFeedback
+import androidx.compose.ui.zIndex
+import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.input.pointer.PointerEventPass
 import androidx.compose.ui.input.pointer.PointerInputScope
@@ -96,6 +101,7 @@ import androidx.compose.foundation.gestures.awaitFirstDown
 import androidx.compose.foundation.gestures.calculateCentroid
 import androidx.compose.foundation.gestures.calculatePan
 import androidx.compose.foundation.gestures.calculateZoom
+import androidx.compose.foundation.gestures.detectDragGesturesAfterLongPress
 import androidx.compose.foundation.gestures.detectHorizontalDragGestures
 import androidx.compose.ui.layout.Layout
 import androidx.compose.ui.layout.onSizeChanged
@@ -3360,9 +3366,10 @@ private data class EditableDashboardCard(val card: DashboardCard, val enabled: B
 
 /**
  * #today-layout: reorder the below-hero Today sections (Synthesis / Key Metrics / Workouts / Heart Rate /
- * Recovery Vitals / Your Cards) with up/down arrows — a Today-local dialog, no new nav destination. Every
- * section always shows (this reorders, never hides), so there are no toggles, only order. Mirrors the
- * Key-Metrics / Your-Cards editors (arrow buttons, no reorder lib) and the macOS TodayLayoutEditor.
+ * Recovery Vitals / Your Cards) by LONG-PRESSING a row and dragging it — a Today-local dialog, no new nav
+ * destination. Every section always shows (this reorders, never hides), so there are no toggles, only order.
+ * Hand-rolled fixed-height drag (no reorder lib, matching the project's "no reorder lib" stance). Twin of
+ * the macOS TodayLayoutEditor.
  */
 @Composable
 private fun TodayLayoutEditorDialog(
@@ -3371,13 +3378,15 @@ private fun TodayLayoutEditorDialog(
     onSave: (List<TodaySection>) -> Unit,
 ) {
     val items = remember { mutableStateListOf<TodaySection>().apply { addAll(initial) } }
-
-    fun move(from: Int, to: Int) {
-        if (from in items.indices && to in items.indices) {
-            val item = items.removeAt(from)
-            items.add(to, item)
-        }
-    }
+    val haptics = LocalHapticFeedback.current
+    val density = LocalDensity.current
+    // Fixed row height makes the long-press drag deterministic: the dragged row swaps with its neighbour
+    // once its accumulated offset crosses HALF a row, then the offset resets by one row so it keeps
+    // tracking the finger. `draggingIndex` is the dragged section's CURRENT index (updated on each swap).
+    val rowHeight = 52.dp
+    val rowHeightPx = with(density) { rowHeight.toPx() }
+    var draggingIndex by remember { mutableStateOf<Int?>(null) }
+    var dragOffsetY by remember { mutableFloatStateOf(0f) }
 
     Dialog(onDismissRequest = onDismiss) {
         Surface(color = Palette.surfaceOverlay, shape = RoundedCornerShape(16.dp)) {
@@ -3388,56 +3397,78 @@ private fun TodayLayoutEditorDialog(
                 Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
                     Text("Arrange Today", style = NoopType.title2, color = Palette.textPrimary)
                     Text(
-                        "Reorder the sections below your Charge / Effort / Rest scores with the arrows. " +
-                            "The scores stay pinned at the top.",
+                        "Hold a section and drag it to reorder. Your Charge / Effort / Rest scores stay " +
+                            "pinned at the top.",
                         style = NoopType.subhead,
                         color = Palette.textSecondary,
                     )
                 }
 
-                Column(
-                    modifier = Modifier
-                        .heightIn(max = 360.dp)
-                        .verticalScroll(rememberScrollState()),
-                ) {
+                // 6 fixed-height rows fit without scrolling (drag + inner scroll would fight); each row is
+                // picked up on long-press and follows the finger, swapping neighbours as it crosses them.
+                Column {
                     items.forEachIndexed { index, section ->
+                        val isDragging = draggingIndex == index
                         Row(
-                            modifier = Modifier.fillMaxWidth().padding(vertical = 6.dp),
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .height(rowHeight)
+                                .zIndex(if (isDragging) 1f else 0f)
+                                .graphicsLayer {
+                                    if (isDragging) {
+                                        translationY = dragOffsetY
+                                        shadowElevation = 8f
+                                        scaleX = 1.02f
+                                        scaleY = 1.02f
+                                    }
+                                }
+                                .background(
+                                    if (isDragging) Palette.surfaceRaised else Color.Transparent,
+                                    RoundedCornerShape(10.dp),
+                                )
+                                .pointerInput(section) {
+                                    detectDragGesturesAfterLongPress(
+                                        onDragStart = {
+                                            draggingIndex = index
+                                            dragOffsetY = 0f
+                                            haptics.performHapticFeedback(HapticFeedbackType.LongPress)
+                                        },
+                                        onDragEnd = { draggingIndex = null; dragOffsetY = 0f },
+                                        onDragCancel = { draggingIndex = null; dragOffsetY = 0f },
+                                        onDrag = { change, amount ->
+                                            change.consume()
+                                            dragOffsetY += amount.y
+                                            val cur = draggingIndex
+                                            if (cur != null) {
+                                                if (dragOffsetY > rowHeightPx / 2f && cur < items.lastIndex) {
+                                                    items.add(cur + 1, items.removeAt(cur))
+                                                    draggingIndex = cur + 1
+                                                    dragOffsetY -= rowHeightPx
+                                                } else if (dragOffsetY < -rowHeightPx / 2f && cur > 0) {
+                                                    items.add(cur - 1, items.removeAt(cur))
+                                                    draggingIndex = cur - 1
+                                                    dragOffsetY += rowHeightPx
+                                                }
+                                            }
+                                        },
+                                    )
+                                }
+                                .padding(horizontal = 8.dp),
                             verticalAlignment = Alignment.CenterVertically,
                         ) {
+                            Icon(
+                                Icons.Filled.DragHandle,
+                                contentDescription = null,
+                                tint = Palette.textTertiary,
+                                modifier = Modifier.size(Metrics.iconSmall),
+                            )
+                            Spacer(Modifier.width(12.dp))
                             Text(
                                 section.title,
                                 style = NoopType.body,
                                 color = Palette.textPrimary,
                                 modifier = Modifier.weight(1f),
                             )
-                            IconButton(
-                                onClick = { move(index, index - 1) },
-                                enabled = index > 0,
-                                modifier = Modifier.size(Metrics.iconButton),
-                            ) {
-                                Icon(
-                                    Icons.Filled.KeyboardArrowUp,
-                                    contentDescription = "Move ${section.title} up",
-                                    tint = if (index > 0) Palette.textSecondary else Palette.textTertiary,
-                                    modifier = Modifier.size(Metrics.iconSmall),
-                                )
-                            }
-                            IconButton(
-                                onClick = { move(index, index + 1) },
-                                enabled = index < items.lastIndex,
-                                modifier = Modifier.size(Metrics.iconButton),
-                            ) {
-                                Icon(
-                                    Icons.Filled.KeyboardArrowDown,
-                                    contentDescription = "Move ${section.title} down",
-                                    tint = if (index < items.lastIndex) Palette.textSecondary else Palette.textTertiary,
-                                    modifier = Modifier.size(Metrics.iconSmall),
-                                )
-                            }
-                        }
-                        if (index < items.lastIndex) {
-                            HorizontalDivider(color = Palette.hairline, thickness = 1.dp)
                         }
                     }
                 }

--- a/android/app/src/main/java/com/noop/ui/TodayScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/TodayScreen.kt
@@ -48,6 +48,7 @@ import androidx.compose.material.icons.filled.KeyboardArrowDown
 import androidx.compose.material.icons.filled.MonitorHeart
 import androidx.compose.material.icons.filled.KeyboardArrowUp
 import androidx.compose.material.icons.filled.TrackChanges
+import androidx.compose.material.icons.filled.SwapVert
 import androidx.compose.material.icons.filled.Tune
 import androidx.compose.material.icons.filled.Warning
 import androidx.compose.material.icons.outlined.Info
@@ -364,6 +365,10 @@ fun TodayScreen(
     // SharedPreferences isn't reactive, so it's mirrored into local state and re-read when the editor saves.
     var showMetricsEditor by remember { mutableStateOf(false) }
     var enabledKeyMetrics by remember { mutableStateOf(KeyMetricPrefs.enabled(context)) }
+    // #today-layout: the user-ordered below-hero section list + its editor dialog flag. Read once (prefs
+    // aren't reactive) and re-read on the editor's save, exactly like enabledKeyMetrics above.
+    var showLayoutEditor by remember { mutableStateOf(false) }
+    var sectionOrder by remember { mutableStateOf(TodayLayoutPrefs.order(context)) }
 
     // "Your cards" customisable dashboard (WHOOP "My Dashboard"), a persisted, reorderable selection of
     // metric cards. Empty/unset shows the sensible default set (Stress / Fitness age / Vitality + HRV +
@@ -1199,36 +1204,12 @@ fun TodayScreen(
             }
         }
 
-        // The plain-English read-out, the Charge-tinted Synthesis card with a WHITE headline, carries the
-        // greeting + the SOLID/CALIBRATING data-confidence pill in its top-right. Mirrors the iOS Synthesis
-        // InsightCard. Carries the last scored day's read at the rollover (#543) so it doesn't blank to
-        // "No Data". Staggered in as index 2.
-        item {
-        Box(modifier = Modifier.fillMaxWidth().staggeredAppear(2)) {
-            SynthesisHeroCard(
-                day = displayMetric,
-                recoveryCalibration = recoveryCalibration,
-                carriedDay = lastScoredRecoveryDay,
-                days = days,
-                synthesisExpanded = synthesisExpanded,
-                onToggleSynthesis = { synthesisExpanded = !synthesisExpanded },
-                onOpenReadiness = { showChargeBreakdown = true },
-            )
-        }
-        }
-
-        // Provenance (COMPONENT 4) now rides UNDER each hero ring as a per-metric badge (Charge names the
-        // recovery winner, Rest names the sleep_performance winner), resolved field-by-field per
-        // WhoopRepository.mergeDaily, so an imported metric on an otherwise-computed day is labelled
-        // honestly rather than under one blanket day-level deviceId. See ScoreHeroRow + HeroRingColumn.
-        // Mirrors the iOS Today lane, which badges each ring's real winner and has no separate day badge.
-
-        // Honest "why is Effort 0?" caption (#482/#480), only when today's Effort is a real
-        // near-zero (HR present but never crossed the cardio zone), so a calm day reads as explained
-        // rather than broken. Mirrors the iOS effortZeroNote. A low-HR day honestly earns ~0.
-        // Effort accrues over a day and must never visibly drop: floor the in-progress value at the day's
-        // already-earned strain (#489/#506). displayMetric for today is today's row or null, never a prior
-        // day, so this can't resurrect a stale day, it only stops the gauge dropping below what's earned.
+        // Honest "why is Effort 0?" caption (#482/#480) — PINNED under the hero (NOT part of the
+        // reorderable block below): only when today's Effort is a real near-zero (HR present but never
+        // crossed the cardio zone), so a calm day reads as explained rather than broken. Mirrors the iOS
+        // effortZeroNote. Effort accrues over a day and must never visibly drop: floor the in-progress
+        // value at the day's already-earned strain (#489/#506). displayMetric for today is today's row or
+        // null, so this can't resurrect a stale day, only stop the gauge dropping below what's earned.
         item {
         val todayEffort = if (selectedDayOffset == 0) {
             val liveStrain = liveTodayStrain; val stored = displayMetric?.strain
@@ -1256,149 +1237,153 @@ fun TodayScreen(
         }
         }
 
-        // A1/S4: the WHAT SHAPED IT breakdown, the Contributors bars and the READINESS card all folded into
-        // the Charge-ring TAP (the showChargeBreakdown dialog below), collapsing the home screen. They are
-        // NOT deleted, only moved behind a tap; a one-word readiness read (Push / Maintain / Rest, #205)
-        // stays on the hero via SynthesisHeroCard. Mirrors the iOS chargeBreakdownSheet + readiness fold.
-
-        // METRICS, uniform tile grid (two columns), each tile with a 14-day sparkline.
-        // #765: no ad-hoc Spacer row before this header. The lone `selectorTopUp` spacer here (a device the
-        // Health/Sleep screens use to tug a SEGMENTED SELECTOR up toward the section above) had no selector
-        // to tug on Today; it just injected an extra gap that, on top of the scaffold's per-row spacing on
-        // both sides of the spacer item, made the gap before Key Metrics visibly larger than every other
-        // inter-card gap. Removing it lets Key Metrics sit on the SAME shared screenRowSpacing as the rest.
-        // Section header + an Edit affordance to open the local layout editor (#251). No new nav
-        // destination, a dialog over Today. The Box lets the SectionHeader keep its trailing label while
-        // the Edit control sits to its right.
+        // #today-layout: a small right-aligned affordance to REORDER the sections below. Opens a Today-local
+        // dialog (up/down arrows, like the Key-Metrics / Your-Cards editors) — no new nav destination.
         item {
-        Row(verticalAlignment = Alignment.CenterVertically) {
-            Box(modifier = Modifier.weight(1f)) {
-                SectionHeader("Key Metrics", overline = dayLabel, trailing = "14-day trend")
-            }
-            TextButton(
-                onClick = { showMetricsEditor = true },
-                colors = ButtonDefaults.textButtonColors(contentColor = Palette.accent),
-            ) {
-                Icon(
-                    Icons.Filled.Tune,
-                    contentDescription = "Edit Key Metrics",
-                    modifier = Modifier.size(Metrics.iconSmall),
-                )
-                Spacer(Modifier.width(4.dp))
-                Text("Edit", style = NoopType.footnote)
+            Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.End) {
+                TextButton(
+                    onClick = { showLayoutEditor = true },
+                    colors = ButtonDefaults.textButtonColors(contentColor = Palette.textTertiary),
+                ) {
+                    Icon(
+                        Icons.Filled.SwapVert,
+                        contentDescription = "Arrange Today sections",
+                        modifier = Modifier.size(Metrics.iconSmall),
+                    )
+                    Spacer(Modifier.width(4.dp))
+                    Text("Arrange", style = NoopType.footnote)
+                }
             }
         }
-        }
-        // Key Metrics grid (3), Workouts (4), HR trend (5), vitals (6), Your Cards stagger in order.
-        item {
-        Box(modifier = Modifier.fillMaxWidth().staggeredAppear(3)) {
-            MetricGrid(
-                d = displayMetric,
-                w = window,
-                recoveryCalibration = recoveryCalibration,
-                lastScoredCharge = lastScoredCharge,
-                carriedDay = lastScoredRecoveryDay,
-                spo2CarryDay = lastSpo2Day,
-                unitSystem = unitSystem,
-                effortScale = effortScale,
-                latestWeightKg = weightKg,
-                profileWeightKg = profileWeightKg,
-                importedStepsForDay = importedStepsForDay,
-                estimatedStepsForDay = stepsEstForDay,
-                stepActivityClassForDay = stepActivityClassForDay,
-                stepsEstimateCaption = stepsEstimateCaption(profileStore),
-                restScore = restScoreForDay,
-                restSpark = restCompositeSpark,
-                enabledMetrics = enabledKeyMetrics,
-                isToday = selectedDayOffset == 0,
-                onScoreInfo = openGuide,
-                metricsExpanded = metricsExpanded,
-                onToggleMetrics = { metricsExpanded = !metricsExpanded },
-            )
-        }
-        }
-        item {
-        // #991: same fix as the HR card — TodayWorkoutsSection emits header + card as two siblings, so a
-        // Box overlaid them. Stack them in a spaced Column.
-        Column(
-            modifier = Modifier.fillMaxWidth().staggeredAppear(4),
-            verticalArrangement = Arrangement.spacedBy(8.dp),
-        ) {
-            TodayWorkoutsSection(footer.recentWorkouts)
-        }
-        }
 
-        // HEART RATE, the live HR thread / trend card. Mirrors iOS heartRateSection below key metrics.
-        // Carries its own live-HR thread + the banked 5-minute fallback + the "connect your strap" empty
-        // state, all self-contained (its own data loads).
-        item {
-        // #991: HeartRateTrendCard emits its SectionHeader + card as two siblings; a Box overlaid them
-        // (the header showed THROUGH the card in the v8 layout). A spaced Column stacks them instead.
-        Column(
-            modifier = Modifier.fillMaxWidth().staggeredAppear(5),
-            verticalArrangement = Arrangement.spacedBy(8.dp),
-        ) {
-            HeartRateTrendCard(viewModel, days, selectedDay, todayDate, displayMetric, effortScale)
-        }
-        }
-
-        // The three hero vitals, HRV / Resting HR / Respiratory. Mirrors the iOS recoveryVitalsSection
-        // below the HR card. Carries the last scored day's vitals (with a "Last night · <date>" footnote)
-        // at the rollover so they don't blank to "No Data" while live HR ticks (#543). Staggered in as index 6.
-        item {
-        Box(modifier = Modifier.fillMaxWidth().staggeredAppear(6)) {
-            HeroMetricRows(day = displayMetric, carriedDay = lastScoredRecoveryDay, vitalsDay = lastVitalsDay)
-        }
-        }
-
-        // YOUR CARDS, the user-customisable dashboard (WHOOP "My Dashboard"). Surfaces a persisted,
-        // reorderable selection of metric cards as flat WHOOP metric rows (leading icon + UPPERCASE label +
-        // sublabel on the left, big value + unit + chevron on the right). Default = Stress / Fitness age /
-        // Vitality + HRV + Resting HR. TODAY only; a card with no value yet renders a dash rather than
-        // vanishing. The "CUSTOMISE" link opens a local toggle/reorder dialog. Mirrors iOS yourCardsSection.
-        // When Hydration tracking is OFF the card is hidden even if it sits in the saved selection (the
-        // editor still offers it, so the choice persists), keeping the opt-in feature fully invisible until
-        // enabled. Mirrors the iOS yourCardsSection hydration gate.
-        item {
-        val visibleDashboardCards = enabledDashboardCards.filter {
-            it != DashboardCard.HYDRATION || hydrationEnabled
-        }
-        if (selectedDayOffset == 0 && visibleDashboardCards.isNotEmpty()) {
-            YourCardsSection(
-                cards = visibleDashboardCards,
-                day = displayMetric,
-                // The SAME carried-over last-scored row the OLD hero vital rows + Key-Metrics tiles read
-                // (#543): right after the logical-day rollover today's row carries no vitals yet, so without
-                // this the HRV / Resting HR / Respiratory / SpO₂ / Sleep cards all blank to "No Data" while
-                // the rest of Today shows last night's carried values. Routing the cards through the same
-                // `carriedDay ?: day` source the HeroMetricRows + MetricGrid already use brings them to parity.
-                carriedDay = lastScoredRecoveryDay,
-                // The recovery-INDEPENDENT vitals carry (#543 follow-up): the overnight HRV / Resting HR /
-                // Respiratory cards read PER-FIELD today-first with THIS fallback, so a night whose recovery
-                // was nulled post-update still surfaces its OWN preserved vitals (not an older scored day's).
-                vitalsDay = lastVitalsDay,
-                // PER-FIELD SpO₂ / skin-temp carries: lastVitalsDay's predicate only checks HRV/RHR/resp,
-                // so these two fields resolve independently to the last row that actually has them
-                // (imported rows; computed "-noop" rows never carry spo2Pct). Mirrors iOS per-field
-                // carry (TodayView.lastSpo2Day / lastSkinTempDay via carriedVital).
-                spo2Day = lastSpo2Day,
-                skinTempDay = lastSkinTempDay,
-                stress = stressToday,
-                fitnessAge = fitnessAgeToday,
-                vitality = vitalityToday,
-                importedStepsForDay = importedStepsForDay,
-                estimatedStepsForDay = stepsEstForDay,
-                latestActiveKcal = latestActiveKcal,
-                hydrationTotalMl = hydrationTotalMl,
-                hydrationGoalMl = hydrationGoalMl,
-                onOpenHydration = onOpenHydration,
-                onOpenStress = onOpenStress,
-                onOpenMetric = onOpenMetric,
-                onOpenSleep = onOpenSleep,
-                onOpenCoupled = onOpenCoupled,
-                onCustomise = { showDashboardEditor = true },
-            )
-        }
+        // #today-layout: the below-hero sections render in the user's saved order (TodayLayoutPrefs); the
+        // Charge/Effort/Rest hero + intro/conditional cards above stay pinned. Each branch is the SAME
+        // section content as before — only the SEQUENCE is now data-driven, and the stagger index follows
+        // the section's live position rather than a hard-coded slot.
+        sectionOrder.forEachIndexed { pos, section ->
+            val stagger = pos + 2
+            when (section) {
+                // The plain-English read-out, the Charge-tinted Synthesis card. Mirrors the iOS Synthesis
+                // InsightCard; carries the last scored day's read at the rollover (#543).
+                TodaySection.SYNTHESIS -> item {
+                    Box(modifier = Modifier.fillMaxWidth().staggeredAppear(stagger)) {
+                        SynthesisHeroCard(
+                            day = displayMetric,
+                            recoveryCalibration = recoveryCalibration,
+                            carriedDay = lastScoredRecoveryDay,
+                            days = days,
+                            synthesisExpanded = synthesisExpanded,
+                            onToggleSynthesis = { synthesisExpanded = !synthesisExpanded },
+                            onOpenReadiness = { showChargeBreakdown = true },
+                        )
+                    }
+                }
+                // METRICS: section header + the Key-Metrics Edit affordance (#251), then the tile grid.
+                TodaySection.KEY_METRICS -> {
+                    item {
+                        Row(verticalAlignment = Alignment.CenterVertically) {
+                            Box(modifier = Modifier.weight(1f)) {
+                                SectionHeader("Key Metrics", overline = dayLabel, trailing = "14-day trend")
+                            }
+                            TextButton(
+                                onClick = { showMetricsEditor = true },
+                                colors = ButtonDefaults.textButtonColors(contentColor = Palette.accent),
+                            ) {
+                                Icon(
+                                    Icons.Filled.Tune,
+                                    contentDescription = "Edit Key Metrics",
+                                    modifier = Modifier.size(Metrics.iconSmall),
+                                )
+                                Spacer(Modifier.width(4.dp))
+                                Text("Edit", style = NoopType.footnote)
+                            }
+                        }
+                    }
+                    item {
+                        Box(modifier = Modifier.fillMaxWidth().staggeredAppear(stagger)) {
+                            MetricGrid(
+                                d = displayMetric,
+                                w = window,
+                                recoveryCalibration = recoveryCalibration,
+                                lastScoredCharge = lastScoredCharge,
+                                carriedDay = lastScoredRecoveryDay,
+                                spo2CarryDay = lastSpo2Day,
+                                unitSystem = unitSystem,
+                                effortScale = effortScale,
+                                latestWeightKg = weightKg,
+                                profileWeightKg = profileWeightKg,
+                                importedStepsForDay = importedStepsForDay,
+                                estimatedStepsForDay = stepsEstForDay,
+                                stepActivityClassForDay = stepActivityClassForDay,
+                                stepsEstimateCaption = stepsEstimateCaption(profileStore),
+                                restScore = restScoreForDay,
+                                restSpark = restCompositeSpark,
+                                enabledMetrics = enabledKeyMetrics,
+                                isToday = selectedDayOffset == 0,
+                                onScoreInfo = openGuide,
+                                metricsExpanded = metricsExpanded,
+                                onToggleMetrics = { metricsExpanded = !metricsExpanded },
+                            )
+                        }
+                    }
+                }
+                // #991: TodayWorkoutsSection emits header + card as two siblings; stack in a spaced Column.
+                TodaySection.WORKOUTS -> item {
+                    Column(
+                        modifier = Modifier.fillMaxWidth().staggeredAppear(stagger),
+                        verticalArrangement = Arrangement.spacedBy(8.dp),
+                    ) {
+                        TodayWorkoutsSection(footer.recentWorkouts)
+                    }
+                }
+                // HEART RATE, the live HR thread / trend card. #991: header + card stacked in a Column.
+                TodaySection.HEART_RATE -> item {
+                    Column(
+                        modifier = Modifier.fillMaxWidth().staggeredAppear(stagger),
+                        verticalArrangement = Arrangement.spacedBy(8.dp),
+                    ) {
+                        HeartRateTrendCard(viewModel, days, selectedDay, todayDate, displayMetric, effortScale)
+                    }
+                }
+                // The three hero vitals, HRV / Resting HR / Respiratory. Carries the last scored day (#543).
+                TodaySection.RECOVERY_VITALS -> item {
+                    Box(modifier = Modifier.fillMaxWidth().staggeredAppear(stagger)) {
+                        HeroMetricRows(day = displayMetric, carriedDay = lastScoredRecoveryDay, vitalsDay = lastVitalsDay)
+                    }
+                }
+                // YOUR CARDS, the user-customisable dashboard (WHOOP "My Dashboard"). Hydration is hidden
+                // when its tracking is OFF (the editor still offers it, so the choice persists). Per-field
+                // carried-day fallbacks (#543) keep the cards from blanking to "No Data" at the rollover.
+                TodaySection.YOUR_CARDS -> item {
+                    val visibleDashboardCards = enabledDashboardCards.filter {
+                        it != DashboardCard.HYDRATION || hydrationEnabled
+                    }
+                    if (selectedDayOffset == 0 && visibleDashboardCards.isNotEmpty()) {
+                        YourCardsSection(
+                            cards = visibleDashboardCards,
+                            day = displayMetric,
+                            carriedDay = lastScoredRecoveryDay,
+                            vitalsDay = lastVitalsDay,
+                            spo2Day = lastSpo2Day,
+                            skinTempDay = lastSkinTempDay,
+                            stress = stressToday,
+                            fitnessAge = fitnessAgeToday,
+                            vitality = vitalityToday,
+                            importedStepsForDay = importedStepsForDay,
+                            estimatedStepsForDay = stepsEstForDay,
+                            latestActiveKcal = latestActiveKcal,
+                            hydrationTotalMl = hydrationTotalMl,
+                            hydrationGoalMl = hydrationGoalMl,
+                            onOpenHydration = onOpenHydration,
+                            onOpenStress = onOpenStress,
+                            onOpenMetric = onOpenMetric,
+                            onOpenSleep = onOpenSleep,
+                            onOpenCoupled = onOpenCoupled,
+                            onCustomise = { showDashboardEditor = true },
+                        )
+                    }
+                }
+            }
         }
         // Auto-detect workouts (MVP, opt-in, default OFF), a NON-DESTRUCTIVE "looks like a workout?"
         // card that suggests logging a detected sustained-elevated-HR bout. Renders nothing when the
@@ -1501,6 +1486,20 @@ fun TodayScreen(
                 DashboardCardPrefs.setEnabled(context, cards)
                 enabledDashboardCards = cards
                 showDashboardEditor = false
+            },
+        )
+    }
+
+    // #today-layout: the section-order editor (reorder the below-hero sections). Saves the order and
+    // re-reads it into local state so Today re-lays-out immediately and survives relaunch.
+    if (showLayoutEditor) {
+        TodayLayoutEditorDialog(
+            initial = sectionOrder,
+            onDismiss = { showLayoutEditor = false },
+            onSave = { order ->
+                TodayLayoutPrefs.setOrder(context, order)
+                sectionOrder = order
+                showLayoutEditor = false
             },
         )
     }
@@ -3358,6 +3357,112 @@ private fun DashboardCardsEditorDialog(
 
 /** One row's working state in the dashboard editor: the card + whether it's currently enabled. */
 private data class EditableDashboardCard(val card: DashboardCard, val enabled: Boolean)
+
+/**
+ * #today-layout: reorder the below-hero Today sections (Synthesis / Key Metrics / Workouts / Heart Rate /
+ * Recovery Vitals / Your Cards) with up/down arrows — a Today-local dialog, no new nav destination. Every
+ * section always shows (this reorders, never hides), so there are no toggles, only order. Mirrors the
+ * Key-Metrics / Your-Cards editors (arrow buttons, no reorder lib) and the macOS TodayLayoutEditor.
+ */
+@Composable
+private fun TodayLayoutEditorDialog(
+    initial: List<TodaySection>,
+    onDismiss: () -> Unit,
+    onSave: (List<TodaySection>) -> Unit,
+) {
+    val items = remember { mutableStateListOf<TodaySection>().apply { addAll(initial) } }
+
+    fun move(from: Int, to: Int) {
+        if (from in items.indices && to in items.indices) {
+            val item = items.removeAt(from)
+            items.add(to, item)
+        }
+    }
+
+    Dialog(onDismissRequest = onDismiss) {
+        Surface(color = Palette.surfaceOverlay, shape = RoundedCornerShape(16.dp)) {
+            Column(
+                modifier = Modifier.padding(20.dp),
+                verticalArrangement = Arrangement.spacedBy(16.dp),
+            ) {
+                Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
+                    Text("Arrange Today", style = NoopType.title2, color = Palette.textPrimary)
+                    Text(
+                        "Reorder the sections below your Charge / Effort / Rest scores with the arrows. " +
+                            "The scores stay pinned at the top.",
+                        style = NoopType.subhead,
+                        color = Palette.textSecondary,
+                    )
+                }
+
+                Column(
+                    modifier = Modifier
+                        .heightIn(max = 360.dp)
+                        .verticalScroll(rememberScrollState()),
+                ) {
+                    items.forEachIndexed { index, section ->
+                        Row(
+                            modifier = Modifier.fillMaxWidth().padding(vertical = 6.dp),
+                            verticalAlignment = Alignment.CenterVertically,
+                        ) {
+                            Text(
+                                section.title,
+                                style = NoopType.body,
+                                color = Palette.textPrimary,
+                                modifier = Modifier.weight(1f),
+                            )
+                            IconButton(
+                                onClick = { move(index, index - 1) },
+                                enabled = index > 0,
+                                modifier = Modifier.size(Metrics.iconButton),
+                            ) {
+                                Icon(
+                                    Icons.Filled.KeyboardArrowUp,
+                                    contentDescription = "Move ${section.title} up",
+                                    tint = if (index > 0) Palette.textSecondary else Palette.textTertiary,
+                                    modifier = Modifier.size(Metrics.iconSmall),
+                                )
+                            }
+                            IconButton(
+                                onClick = { move(index, index + 1) },
+                                enabled = index < items.lastIndex,
+                                modifier = Modifier.size(Metrics.iconButton),
+                            ) {
+                                Icon(
+                                    Icons.Filled.KeyboardArrowDown,
+                                    contentDescription = "Move ${section.title} down",
+                                    tint = if (index < items.lastIndex) Palette.textSecondary else Palette.textTertiary,
+                                    modifier = Modifier.size(Metrics.iconSmall),
+                                )
+                            }
+                        }
+                        if (index < items.lastIndex) {
+                            HorizontalDivider(color = Palette.hairline, thickness = 1.dp)
+                        }
+                    }
+                }
+
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    TextButton(
+                        onClick = {
+                            items.clear()
+                            items.addAll(TodaySection.defaultOrder)
+                        },
+                        colors = ButtonDefaults.textButtonColors(contentColor = Palette.textSecondary),
+                    ) { Text("Reset", style = NoopType.body) }
+                    Spacer(Modifier.weight(1f))
+                    Button(
+                        onClick = { onSave(items.toList()) },
+                        colors = ButtonDefaults.buttonColors(
+                            containerColor = Palette.accent,
+                            contentColor = Palette.surfaceBase,
+                        ),
+                    ) { Text("Done", style = NoopType.captionNumber) }
+                }
+            }
+        }
+    }
+}
 
 /**
  * A1/S4: the Charge breakdown sheet opened by tapping the hero Charge ring. A full-screen surface with a

--- a/android/app/src/main/java/com/noop/ui/TodayScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/TodayScreen.kt
@@ -91,6 +91,7 @@ import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.zIndex
 import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.withFrameNanos
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.input.pointer.PointerEventPass
 import androidx.compose.ui.input.pointer.PointerInputScope
@@ -101,8 +102,13 @@ import androidx.compose.foundation.gestures.awaitFirstDown
 import androidx.compose.foundation.gestures.calculateCentroid
 import androidx.compose.foundation.gestures.calculatePan
 import androidx.compose.foundation.gestures.calculateZoom
+import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.gestures.detectDragGesturesAfterLongPress
 import androidx.compose.foundation.gestures.detectHorizontalDragGestures
+import androidx.compose.foundation.gestures.scrollBy
+import androidx.compose.foundation.lazy.LazyItemScope
+import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.ui.layout.Layout
 import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalContext
@@ -375,6 +381,25 @@ fun TodayScreen(
     // aren't reactive) and re-read on the editor's save, exactly like enabledKeyMetrics above.
     var showLayoutEditor by remember { mutableStateOf(false) }
     var sectionOrder by remember { mutableStateOf(TodayLayoutPrefs.order(context)) }
+    // #today-layout (hold-to-drag): the hoisted list state (the drag math needs layoutInfo + scrollBy) and
+    // the live drag state. The frame loop below runs ONLY while a section is lifted: each frame it retries
+    // the swap (so a card held still at a viewport edge keeps reordering as the list scrolls under it —
+    // onDrag alone only fires while the finger moves) and applies the edge auto-scroll velocity that
+    // TodayReorderableSection's onDrag computed.
+    val todayListState = rememberLazyListState()
+    val sectionDrag = remember { TodaySectionDragState() }
+    val sectionDragActive = sectionDrag.key != null
+    LaunchedEffect(sectionDragActive) {
+        while (sectionDrag.key != null) {
+            withFrameNanos { }
+            swapTargetForDraggedSection(todayListState, sectionDrag)?.let { (dragged, target) ->
+                sectionOrder = sectionOrder.movedTodaySection(dragged, target)
+            }
+            if (sectionDrag.autoScrollPxPerFrame != 0f) {
+                todayListState.scrollBy(sectionDrag.autoScrollPxPerFrame)
+            }
+        }
+    }
 
     // "Your cards" customisable dashboard (WHOOP "My Dashboard"), a persisted, reorderable selection of
     // metric cards. Empty/unset shows the sensible default set (Stress / Fitness age / Vitality + HRV +
@@ -985,6 +1010,8 @@ fun TodayScreen(
         // rhythm rather than the app-wide 20dp row gap, so the whole screen reads as compact/slick as iOS.
         // Scoped to this scaffold — no other screen's rhythm changes.
         rowSpacing = 12.dp,
+        // #today-layout (hold-to-drag): the hoisted list state the section drag reads (layoutInfo/scrollBy).
+        listState = todayListState,
         // LIQUID SKY BACKDROP (the pilot pattern — LiquidScreenSky.kt): the time-of-day liquid sky sits
         // behind the WHOLE top region, the liquid header + wordmark AND the hero vessels, full-bleed (full-width, up
         // behind the status bar via the scaffold's topBackground plumbing), top-aligned, settling into the
@@ -1263,130 +1290,134 @@ fun TodayScreen(
         }
 
         // #today-layout: the below-hero sections render in the user's saved order (TodayLayoutPrefs); the
-        // Charge/Effort/Rest hero + intro/conditional cards above stay pinned. Each branch is the SAME
-        // section content as before — only the SEQUENCE is now data-driven, and the stagger index follows
-        // the section's live position rather than a hard-coded slot.
+        // Charge/Effort/Rest hero + intro/conditional cards above stay pinned. Each section is ONE keyed
+        // item wrapped in [TodayReorderableSection]: LONG-PRESS anywhere on a section and drag — it lifts
+        // (haptic), follows the finger, swaps neighbours as it crosses their centres (the screen-level
+        // frame loop also auto-scrolls at the viewport edges and keeps swapping while it does), and the
+        // order persists on drop. The stagger index follows the section's live position.
         sectionOrder.forEachIndexed { pos, section ->
             val stagger = pos + 2
-            when (section) {
-                // The plain-English read-out, the Charge-tinted Synthesis card. Mirrors the iOS Synthesis
-                // InsightCard; carries the last scored day's read at the rollover (#543).
-                TodaySection.SYNTHESIS -> item {
-                    Box(modifier = Modifier.fillMaxWidth().staggeredAppear(stagger)) {
-                        SynthesisHeroCard(
-                            day = displayMetric,
-                            recoveryCalibration = recoveryCalibration,
-                            carriedDay = lastScoredRecoveryDay,
-                            days = days,
-                            synthesisExpanded = synthesisExpanded,
-                            onToggleSynthesis = { synthesisExpanded = !synthesisExpanded },
-                            onOpenReadiness = { showChargeBreakdown = true },
-                        )
-                    }
-                }
-                // METRICS: section header + the Key-Metrics Edit affordance (#251), then the tile grid.
-                TodaySection.KEY_METRICS -> {
-                    item {
-                        Row(verticalAlignment = Alignment.CenterVertically) {
-                            Box(modifier = Modifier.weight(1f)) {
-                                SectionHeader("Key Metrics", overline = dayLabel, trailing = "14-day trend")
-                            }
-                            TextButton(
-                                onClick = { showMetricsEditor = true },
-                                colors = ButtonDefaults.textButtonColors(contentColor = Palette.accent),
-                            ) {
-                                Icon(
-                                    Icons.Filled.Tune,
-                                    contentDescription = "Edit Key Metrics",
-                                    modifier = Modifier.size(Metrics.iconSmall),
-                                )
-                                Spacer(Modifier.width(4.dp))
-                                Text("Edit", style = NoopType.footnote)
-                            }
-                        }
-                    }
-                    item {
-                        Box(modifier = Modifier.fillMaxWidth().staggeredAppear(stagger)) {
-                            MetricGrid(
-                                d = displayMetric,
-                                w = window,
+            item(key = TODAY_SECTION_KEY_PREFIX + section.raw) {
+                TodayReorderableSection(
+                    section = section,
+                    listState = todayListState,
+                    drag = sectionDrag,
+                    onDrop = { TodayLayoutPrefs.setOrder(context, sectionOrder) },
+                ) {
+                    when (section) {
+                        // The plain-English read-out, the Charge-tinted Synthesis card. Mirrors the iOS
+                        // Synthesis InsightCard; carries the last scored day's read at the rollover (#543).
+                        TodaySection.SYNTHESIS -> Box(modifier = Modifier.fillMaxWidth().staggeredAppear(stagger)) {
+                            SynthesisHeroCard(
+                                day = displayMetric,
                                 recoveryCalibration = recoveryCalibration,
-                                lastScoredCharge = lastScoredCharge,
                                 carriedDay = lastScoredRecoveryDay,
-                                spo2CarryDay = lastSpo2Day,
-                                unitSystem = unitSystem,
-                                effortScale = effortScale,
-                                latestWeightKg = weightKg,
-                                profileWeightKg = profileWeightKg,
-                                importedStepsForDay = importedStepsForDay,
-                                estimatedStepsForDay = stepsEstForDay,
-                                stepActivityClassForDay = stepActivityClassForDay,
-                                stepsEstimateCaption = stepsEstimateCaption(profileStore),
-                                restScore = restScoreForDay,
-                                restSpark = restCompositeSpark,
-                                enabledMetrics = enabledKeyMetrics,
-                                isToday = selectedDayOffset == 0,
-                                onScoreInfo = openGuide,
-                                metricsExpanded = metricsExpanded,
-                                onToggleMetrics = { metricsExpanded = !metricsExpanded },
+                                days = days,
+                                synthesisExpanded = synthesisExpanded,
+                                onToggleSynthesis = { synthesisExpanded = !synthesisExpanded },
+                                onOpenReadiness = { showChargeBreakdown = true },
                             )
                         }
-                    }
-                }
-                // #991: TodayWorkoutsSection emits header + card as two siblings; stack in a spaced Column.
-                TodaySection.WORKOUTS -> item {
-                    Column(
-                        modifier = Modifier.fillMaxWidth().staggeredAppear(stagger),
-                        verticalArrangement = Arrangement.spacedBy(8.dp),
-                    ) {
-                        TodayWorkoutsSection(footer.recentWorkouts)
-                    }
-                }
-                // HEART RATE, the live HR thread / trend card. #991: header + card stacked in a Column.
-                TodaySection.HEART_RATE -> item {
-                    Column(
-                        modifier = Modifier.fillMaxWidth().staggeredAppear(stagger),
-                        verticalArrangement = Arrangement.spacedBy(8.dp),
-                    ) {
-                        HeartRateTrendCard(viewModel, days, selectedDay, todayDate, displayMetric, effortScale)
-                    }
-                }
-                // The three hero vitals, HRV / Resting HR / Respiratory. Carries the last scored day (#543).
-                TodaySection.RECOVERY_VITALS -> item {
-                    Box(modifier = Modifier.fillMaxWidth().staggeredAppear(stagger)) {
-                        HeroMetricRows(day = displayMetric, carriedDay = lastScoredRecoveryDay, vitalsDay = lastVitalsDay)
-                    }
-                }
-                // YOUR CARDS, the user-customisable dashboard (WHOOP "My Dashboard"). Hydration is hidden
-                // when its tracking is OFF (the editor still offers it, so the choice persists). Per-field
-                // carried-day fallbacks (#543) keep the cards from blanking to "No Data" at the rollover.
-                TodaySection.YOUR_CARDS -> item {
-                    val visibleDashboardCards = enabledDashboardCards.filter {
-                        it != DashboardCard.HYDRATION || hydrationEnabled
-                    }
-                    if (selectedDayOffset == 0 && visibleDashboardCards.isNotEmpty()) {
-                        YourCardsSection(
-                            cards = visibleDashboardCards,
-                            day = displayMetric,
-                            carriedDay = lastScoredRecoveryDay,
-                            vitalsDay = lastVitalsDay,
-                            spo2Day = lastSpo2Day,
-                            skinTempDay = lastSkinTempDay,
-                            stress = stressToday,
-                            fitnessAge = fitnessAgeToday,
-                            vitality = vitalityToday,
-                            importedStepsForDay = importedStepsForDay,
-                            estimatedStepsForDay = stepsEstForDay,
-                            latestActiveKcal = latestActiveKcal,
-                            hydrationTotalMl = hydrationTotalMl,
-                            hydrationGoalMl = hydrationGoalMl,
-                            onOpenHydration = onOpenHydration,
-                            onOpenStress = onOpenStress,
-                            onOpenMetric = onOpenMetric,
-                            onOpenSleep = onOpenSleep,
-                            onOpenCoupled = onOpenCoupled,
-                            onCustomise = { showDashboardEditor = true },
-                        )
+                        // METRICS: header + Edit affordance (#251) + the tile grid. Previously two
+                        // LazyColumn items; merged into ONE (a section must be a single keyed item for the
+                        // drag), spaced by the scaffold's 12dp row gap so the rhythm is pixel-identical.
+                        TodaySection.KEY_METRICS -> Column(
+                            modifier = Modifier.fillMaxWidth(),
+                            verticalArrangement = Arrangement.spacedBy(12.dp),
+                        ) {
+                            Row(verticalAlignment = Alignment.CenterVertically) {
+                                Box(modifier = Modifier.weight(1f)) {
+                                    SectionHeader("Key Metrics", overline = dayLabel, trailing = "14-day trend")
+                                }
+                                TextButton(
+                                    onClick = { showMetricsEditor = true },
+                                    colors = ButtonDefaults.textButtonColors(contentColor = Palette.accent),
+                                ) {
+                                    Icon(
+                                        Icons.Filled.Tune,
+                                        contentDescription = "Edit Key Metrics",
+                                        modifier = Modifier.size(Metrics.iconSmall),
+                                    )
+                                    Spacer(Modifier.width(4.dp))
+                                    Text("Edit", style = NoopType.footnote)
+                                }
+                            }
+                            Box(modifier = Modifier.fillMaxWidth().staggeredAppear(stagger)) {
+                                MetricGrid(
+                                    d = displayMetric,
+                                    w = window,
+                                    recoveryCalibration = recoveryCalibration,
+                                    lastScoredCharge = lastScoredCharge,
+                                    carriedDay = lastScoredRecoveryDay,
+                                    spo2CarryDay = lastSpo2Day,
+                                    unitSystem = unitSystem,
+                                    effortScale = effortScale,
+                                    latestWeightKg = weightKg,
+                                    profileWeightKg = profileWeightKg,
+                                    importedStepsForDay = importedStepsForDay,
+                                    estimatedStepsForDay = stepsEstForDay,
+                                    stepActivityClassForDay = stepActivityClassForDay,
+                                    stepsEstimateCaption = stepsEstimateCaption(profileStore),
+                                    restScore = restScoreForDay,
+                                    restSpark = restCompositeSpark,
+                                    enabledMetrics = enabledKeyMetrics,
+                                    isToday = selectedDayOffset == 0,
+                                    onScoreInfo = openGuide,
+                                    metricsExpanded = metricsExpanded,
+                                    onToggleMetrics = { metricsExpanded = !metricsExpanded },
+                                )
+                            }
+                        }
+                        // #991: TodayWorkoutsSection emits header + card as two siblings; spaced Column.
+                        TodaySection.WORKOUTS -> Column(
+                            modifier = Modifier.fillMaxWidth().staggeredAppear(stagger),
+                            verticalArrangement = Arrangement.spacedBy(8.dp),
+                        ) {
+                            TodayWorkoutsSection(footer.recentWorkouts)
+                        }
+                        // HEART RATE, the live HR thread / trend card. #991: header + card in a Column.
+                        TodaySection.HEART_RATE -> Column(
+                            modifier = Modifier.fillMaxWidth().staggeredAppear(stagger),
+                            verticalArrangement = Arrangement.spacedBy(8.dp),
+                        ) {
+                            HeartRateTrendCard(viewModel, days, selectedDay, todayDate, displayMetric, effortScale)
+                        }
+                        // The three hero vitals, HRV / Resting HR / Respiratory. Carried day (#543).
+                        TodaySection.RECOVERY_VITALS -> Box(modifier = Modifier.fillMaxWidth().staggeredAppear(stagger)) {
+                            HeroMetricRows(day = displayMetric, carriedDay = lastScoredRecoveryDay, vitalsDay = lastVitalsDay)
+                        }
+                        // YOUR CARDS, the user-customisable dashboard (WHOOP "My Dashboard"). Hydration is
+                        // hidden when its tracking is OFF (the editor still offers it, so the choice
+                        // persists). Per-field carried-day fallbacks (#543) stop rollover "No Data" blanks.
+                        TodaySection.YOUR_CARDS -> {
+                            val visibleDashboardCards = enabledDashboardCards.filter {
+                                it != DashboardCard.HYDRATION || hydrationEnabled
+                            }
+                            if (selectedDayOffset == 0 && visibleDashboardCards.isNotEmpty()) {
+                                YourCardsSection(
+                                    cards = visibleDashboardCards,
+                                    day = displayMetric,
+                                    carriedDay = lastScoredRecoveryDay,
+                                    vitalsDay = lastVitalsDay,
+                                    spo2Day = lastSpo2Day,
+                                    skinTempDay = lastSkinTempDay,
+                                    stress = stressToday,
+                                    fitnessAge = fitnessAgeToday,
+                                    vitality = vitalityToday,
+                                    importedStepsForDay = importedStepsForDay,
+                                    estimatedStepsForDay = stepsEstForDay,
+                                    latestActiveKcal = latestActiveKcal,
+                                    hydrationTotalMl = hydrationTotalMl,
+                                    hydrationGoalMl = hydrationGoalMl,
+                                    onOpenHydration = onOpenHydration,
+                                    onOpenStress = onOpenStress,
+                                    onOpenMetric = onOpenMetric,
+                                    onOpenSleep = onOpenSleep,
+                                    onOpenCoupled = onOpenCoupled,
+                                    onCustomise = { showDashboardEditor = true },
+                                )
+                            }
+                        }
                     }
                 }
             }
@@ -3364,12 +3395,158 @@ private fun DashboardCardsEditorDialog(
 /** One row's working state in the dashboard editor: the card + whether it's currently enabled. */
 private data class EditableDashboardCard(val card: DashboardCard, val enabled: Boolean)
 
+// #today-layout (hold-to-drag): LazyColumn key prefix for the reorderable section items, so the drag can
+// tell a section item from the pinned rows around it.
+private const val TODAY_SECTION_KEY_PREFIX = "todaySection:"
+
+/**
+ * Live drag state for the Today hold-to-drag section reorder (#today-layout). One instance per screen.
+ * `key`/`distance` are snapshot state (they drive the lifted card's translation each frame); the rest are
+ * plain fields written by the gesture and read on the same (main) thread.
+ */
+private class TodaySectionDragState {
+    /** LazyColumn key of the section being dragged; null when idle. */
+    var key by mutableStateOf<String?>(null)
+
+    /** Accumulated finger travel since pickup (px). */
+    var distance by mutableFloatStateOf(0f)
+
+    /** The dragged item's viewport offset at pickup (px) — with [distance], the finger-anchored position. */
+    var pickedUpAt = 0f
+
+    /** Edge auto-scroll velocity (px/frame), set by onDrag from edge proximity; 0 outside the edge zones. */
+    var autoScrollPxPerFrame = 0f
+}
+
+/** This order with [section] moved to [target]'s position (the classic list move). */
+private fun List<TodaySection>.movedTodaySection(section: TodaySection, target: TodaySection): List<TodaySection> {
+    val from = indexOf(section)
+    val to = indexOf(target)
+    if (from == -1 || to == -1 || from == to) return this
+    return toMutableList().apply { add(to, removeAt(from)) }
+}
+
+/**
+ * The (dragged, target) pair to swap right now, or null. The lifted card's finger-anchored middle
+ * (`pickedUpAt + distance + size/2`, viewport space) must sit over another section item AND have crossed
+ * that item's CENTRE in the direction of travel — the centre gate stops a tall card over a short one from
+ * ping-ponging (an immediate swap-back would require crossing back over the centre). Pure read of
+ * [LazyListState.layoutInfo]; the caller applies the move.
+ */
+private fun swapTargetForDraggedSection(
+    listState: LazyListState,
+    drag: TodaySectionDragState,
+): Pair<TodaySection, TodaySection>? {
+    val key = drag.key ?: return null
+    val info = listState.layoutInfo
+    val current = info.visibleItemsInfo.firstOrNull { it.key == key } ?: return null
+    val middle = drag.pickedUpAt + drag.distance + current.size / 2f
+    val target = info.visibleItemsInfo.firstOrNull { item ->
+        item.key != key && (item.key as? String)?.startsWith(TODAY_SECTION_KEY_PREFIX) == true &&
+            middle >= item.offset && middle <= item.offset + item.size
+    } ?: return null
+    val targetCentre = target.offset + target.size / 2f
+    val movingDown = target.offset > current.offset
+    if (movingDown && middle < targetCentre) return null
+    if (!movingDown && middle > targetCentre) return null
+    val dragged = TodaySection.fromRaw((key).removePrefix(TODAY_SECTION_KEY_PREFIX)) ?: return null
+    val tgt = TodaySection.fromRaw((target.key as String).removePrefix(TODAY_SECTION_KEY_PREFIX)) ?: return null
+    return dragged to tgt
+}
+
+/**
+ * #today-layout (hold-to-drag): the per-section drag wrapper. LONG-PRESS anywhere on the section lifts it
+ * (haptic; the card raises + follows the finger via graphicsLayer, translation computed against the item's
+ * CURRENT layout offset so a mid-drag reorder or auto-scroll can't teleport it). onDrag only accumulates
+ * finger travel + the edge auto-scroll velocity — the screen-level frame loop owns the swap + scroll, one
+ * code path whether the finger is moving or parked at an edge. Taps/scrolls pass through untouched (the
+ * detector waits for a long press), so every card keeps its own tap behaviour. No reorder library.
+ */
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+private fun LazyItemScope.TodayReorderableSection(
+    section: TodaySection,
+    listState: LazyListState,
+    drag: TodaySectionDragState,
+    onDrop: () -> Unit,
+    content: @Composable () -> Unit,
+) {
+    val key = TODAY_SECTION_KEY_PREFIX + section.raw
+    val isDragging = drag.key == key
+    val haptics = LocalHapticFeedback.current
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .zIndex(if (isDragging) 1f else 0f)
+            .then(
+                if (isDragging) {
+                    Modifier.graphicsLayer {
+                        // Finger-anchored viewport position minus wherever layout currently placed the item.
+                        val current = listState.layoutInfo.visibleItemsInfo.firstOrNull { it.key == key }
+                        translationY = if (current != null) drag.pickedUpAt + drag.distance - current.offset else 0f
+                        shadowElevation = 12f
+                        scaleX = 1.01f
+                        scaleY = 1.01f
+                    }
+                } else {
+                    // Non-dragged sections animate to their new slot as the lifted card crosses them.
+                    Modifier.animateItemPlacement()
+                },
+            )
+            .pointerInput(key) {
+                detectDragGesturesAfterLongPress(
+                    onDragStart = {
+                        drag.key = key
+                        drag.distance = 0f
+                        drag.pickedUpAt = listState.layoutInfo.visibleItemsInfo
+                            .firstOrNull { it.key == key }?.offset?.toFloat() ?: 0f
+                        drag.autoScrollPxPerFrame = 0f
+                        haptics.performHapticFeedback(HapticFeedbackType.LongPress)
+                    },
+                    onDragEnd = {
+                        onDrop()
+                        drag.key = null
+                        drag.distance = 0f
+                        drag.autoScrollPxPerFrame = 0f
+                    },
+                    onDragCancel = {
+                        // The list already reordered live; persist what the user sees rather than
+                        // silently reverting on a system-cancelled gesture.
+                        onDrop()
+                        drag.key = null
+                        drag.distance = 0f
+                        drag.autoScrollPxPerFrame = 0f
+                    },
+                    onDrag = onDrag@{ change, amount ->
+                        change.consume()
+                        drag.distance += amount.y
+                        val info = listState.layoutInfo
+                        val current = info.visibleItemsInfo.firstOrNull { it.key == key } ?: return@onDrag
+                        // Edge auto-scroll velocity from the lifted card's proximity to the viewport edges;
+                        // ramps linearly across the zone. The frame loop applies it (and keeps swapping).
+                        val zone = 96.dp.toPx()
+                        val maxV = 18.dp.toPx()
+                        val top = drag.pickedUpAt + drag.distance
+                        val bottom = top + current.size
+                        drag.autoScrollPxPerFrame = when {
+                            bottom > info.viewportEndOffset - zone ->
+                                maxV * ((bottom - (info.viewportEndOffset - zone)) / zone).coerceAtMost(1f)
+                            top < info.viewportStartOffset + zone ->
+                                -maxV * (((info.viewportStartOffset + zone) - top) / zone).coerceAtMost(1f)
+                            else -> 0f
+                        }
+                    },
+                )
+            },
+    ) { content() }
+}
+
 /**
  * #today-layout: reorder the below-hero Today sections (Synthesis / Key Metrics / Workouts / Heart Rate /
  * Recovery Vitals / Your Cards) by LONG-PRESSING a row and dragging it — a Today-local dialog, no new nav
  * destination. Every section always shows (this reorders, never hides), so there are no toggles, only order.
  * Hand-rolled fixed-height drag (no reorder lib, matching the project's "no reorder lib" stance). Twin of
- * the macOS TodayLayoutEditor.
+ * the macOS TodayLayoutEditor. The sheet remains as the tap-based alternative to the live on-feed drag.
  */
 @Composable
 private fun TodayLayoutEditorDialog(

--- a/android/app/src/test/java/com/noop/ui/TodayLayoutPrefsTest.kt
+++ b/android/app/src/test/java/com/noop/ui/TodayLayoutPrefsTest.kt
@@ -1,0 +1,82 @@
+package com.noop.ui
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Pure-logic coverage for the Today section-order persistence (#today-layout): default order, encode/decode
+ * round-trip, reorder, and the never-hide "append missing section" invariant. No Android context — these
+ * are the pure functions the editor + Today render rely on. Mirrors the macOS TodayLayoutPrefs tests.
+ */
+class TodayLayoutPrefsTest {
+
+    @Test
+    fun emptyOrUnset_yieldsDefaultOrder() {
+        assertEquals(TodaySection.defaultOrder, TodayLayoutPrefs.decodeOrder(null))
+        assertEquals(TodaySection.defaultOrder, TodayLayoutPrefs.decodeOrder(""))
+        assertEquals(TodaySection.defaultOrder, TodayLayoutPrefs.decodeOrder("   "))
+    }
+
+    @Test
+    fun encodeDecode_roundTripsAReorderedList() {
+        val reordered = listOf(
+            TodaySection.YOUR_CARDS, TodaySection.HEART_RATE, TodaySection.SYNTHESIS,
+            TodaySection.KEY_METRICS, TodaySection.WORKOUTS, TodaySection.RECOVERY_VITALS,
+        )
+        val encoded = TodayLayoutPrefs.encode(reordered)
+        assertEquals("yourCards,heartRate,synthesis,keyMetrics,workouts,recoveryVitals", encoded)
+        assertEquals(reordered, TodayLayoutPrefs.decodeOrder(encoded))
+    }
+
+    @Test
+    fun decode_appendsAnyKnownSectionMissingFromSavedOrder_neverHides() {
+        // A saved order that omits WORKOUTS + YOUR_CARDS (e.g. saved by an older build) must still surface
+        // them — appended in default-order position — so no section ever vanishes.
+        val partial = "heartRate,synthesis,keyMetrics,recoveryVitals"
+        val decoded = TodayLayoutPrefs.decodeOrder(partial)
+        assertEquals(TodaySection.entries.size, decoded.size)
+        assertEquals(
+            listOf(
+                TodaySection.HEART_RATE, TodaySection.SYNTHESIS, TodaySection.KEY_METRICS,
+                TodaySection.RECOVERY_VITALS,
+                // appended (missing) in default order:
+                TodaySection.WORKOUTS, TodaySection.YOUR_CARDS,
+            ),
+            decoded,
+        )
+    }
+
+    @Test
+    fun decode_dropsUnknownTokensAndCollapsesDuplicates() {
+        val messy = "yourCards,BOGUS,yourCards,heartRate, ,heartRate"
+        val decoded = TodayLayoutPrefs.decodeOrder(messy)
+        // yourCards + heartRate resolved once each (first occurrence), then the remaining defaults appended.
+        assertEquals(
+            listOf(
+                TodaySection.YOUR_CARDS, TodaySection.HEART_RATE,
+                TodaySection.SYNTHESIS, TodaySection.KEY_METRICS,
+                TodaySection.WORKOUTS, TodaySection.RECOVERY_VITALS,
+            ),
+            decoded,
+        )
+    }
+
+    @Test
+    fun allJunk_yieldsDefaultOrder() {
+        assertEquals(TodaySection.defaultOrder, TodayLayoutPrefs.decodeOrder("nope,,zzz").let {
+            // all-unknown tokens leave `seen` empty, then every default is appended → default order
+            it
+        })
+    }
+
+    @Test
+    fun sectionRawKeysAreStableAndUnique() {
+        val raws = TodaySection.entries.map { it.raw }
+        assertEquals("raw keys must be unique (they're the persisted identity)", raws.size, raws.toSet().size)
+        // Pin the exact wire strings — they cross the .noopbak boundary and must match macOS byte-for-byte.
+        assertEquals(
+            listOf("synthesis", "keyMetrics", "workouts", "heartRate", "recoveryVitals", "yourCards"),
+            raws,
+        )
+    }
+}


### PR DESCRIPTION
## What
**Long-press any section card on the Today feed itself and drag it** — e.g. hold the Heart Rate card and slide it to the top. The card lifts (haptic), follows your finger, swaps neighbours as it crosses their centres, **auto-scrolls when you reach the viewport edges**, and the order **persists** on drop. Reorderable: Synthesis, Key Metrics, Workouts, Heart Rate, Recovery Vitals, Your Cards. The **Charge/Effort/Rest hero stays pinned** at the top (so "top" = directly under your scores). The **Arrange sheet remains** as a tap-based alternative (also drag-based).

## How (no reorder library — matching the project's stance)
- `TodayLayoutPrefs` (`today.sectionOrder`): ordered section list, default = current order, never-hide append-missing merge; parity-ready keys for a macOS twin.
- `LazyScreenScaffold` gains a **defaulted hoisted `listState`** — every other caller byte-untouched; Today passes its own so the drag can read `layoutInfo` + `scrollBy`.
- Each section is **one keyed LazyColumn item** (Key Metrics' header+grid merged into a single 12dp-spaced Column — pixel-identical rhythm) wrapped in `TodayReorderableSection`: long-press pickup, `graphicsLayer` translation computed against the item's **current** layout offset (mid-drag reorders/auto-scroll can't teleport it), `zIndex` lift, `animateItemPlacement` on the others.
- A **screen-level frame loop** owns the swap + edge auto-scroll while a card is lifted — so a card parked at the edge keeps reordering as the list scrolls under it. Swaps are **centre-gated in the direction of travel**, so a tall card over a short one can't ping-pong.
- Taps/scrolls pass through (the detector waits for long-press): every card keeps its own tap behaviour.

## Verification
- `compileFullDebugKotlin` clean; `TodayLayoutPrefsTest` (6) + `TodayExplainabilityTest` green; each section verified to render **exactly once**; nothing else in Today depends on item positions.

## Honest caveats
- **Gesture feel needs on-device confirmation** — pickup timing, swap thresholds, edge auto-scroll speed, and interplay with card-internal gestures (HR chart scrub, tile presses) can't be verified headless. The logic is deterministic; the *feel* is what to check.
- A long-press-then-release without movement may still fire the card's own tap (Compose gesture semantics) — cosmetic, worth checking on-device.
- **Android only**; iOS twin is a fast-follow. Pref key local-only until then.