### PR TITLE
fix(recovery): seed HRV/RHR baseline from on-device nights the import left blank (#393)

### DIFF
--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/NightlyBaselineMerge.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/NightlyBaselineMerge.swift
@@ -1,0 +1,26 @@
+import Foundation
+
+/// Seed-merge policy for the recovery baselines (#393). Swift twin of the Kotlin NightlyBaselineMerge,
+/// kept byte-identical (same rule, same three drivers).
+///
+/// A REAL imported (cloud) nightly value WINS per day, so a WHOOP-cloud user whose days carry genuine
+/// HRV/RHR is unchanged. But a day the import left BLANK must take the on-device value: for a strap user
+/// whose daily rows exist only from a Health-Connect SLEEP import (HC never carries WHOOP HRV, so every one
+/// of those days is present-but-nil), the on-device HRV/RHR the strap computes from raw HR has to be allowed
+/// to seed the baseline, or nValid starves below `Baselines.minNightsSeed` and Charge never calibrates. That
+/// was #393: the fill keyed on the KEY being absent (`dict[day] == nil` is true only for a missing key on a
+/// `[String: Double?]`), so a present-but-nil day was treated as "covered" and blocked forever.
+///
+/// Pure + side-effect-free (no clock, no I/O), so a fixture pins the exact merge on both platforms. The HRV,
+/// RHR and resp merges all route through this so the three dominant Charge drivers stay aligned.
+public enum NightlyBaselineMerge {
+
+    /// Fill `hist` in place: any day whose current value is nil — key ABSENT or present-but-nil — takes the
+    /// matching `nightly` value; a non-nil `hist` value (a real imported reading) is left untouched.
+    public static func fillBlankNights(_ hist: inout [String: Double?], _ nightly: [String: Double?]) {
+        for (day, v) in nightly {
+            guard (hist[day] ?? nil) == nil, let value = v else { continue }
+            hist[day] = value
+        }
+    }
+}

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/NightlyBaselineMergeTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/NightlyBaselineMergeTests.swift
@@ -1,0 +1,60 @@
+import XCTest
+@testable import StrandAnalytics
+
+/// #393 twin of the Kotlin NightlyBaselineMergeTest. On-device nightly HRV/RHR must seed the recovery
+/// baseline on days the import left BLANK (present-but-nil), not only on days with no daily row at all.
+/// Before the fix, a strap user whose daily rows came from a Health-Connect SLEEP import (avgHrv always nil)
+/// had the on-device HRV blocked, so the baseline starved below the 4-night seed and Charge never
+/// calibrated. Pure: no DB, no strap.
+final class NightlyBaselineMergeTests: XCTestCase {
+
+    private let hrvCfg = Baselines.metricCfg["hrv"]!
+
+    func testFillBlankNights_fillsAbsentAndPresentNil_neverOverwritesReal() {
+        // Use updateValue so "2026-06-02" is present-but-nil (subscript-assigning nil would drop the key).
+        var hist: [String: Double?] = ["2026-06-01": 50.0]   // real imported value -> must WIN
+        hist.updateValue(nil, forKey: "2026-06-02")          // present-but-nil -> must be filled (#393)
+        let nightly: [String: Double?] = [
+            "2026-06-01": 99.0,   // must NOT overwrite the real 50.0
+            "2026-06-02": 40.0,   // fills the present-nil day
+            "2026-06-03": 42.0,   // absent day -> added
+        ]
+        NightlyBaselineMerge.fillBlankNights(&hist, nightly)
+        XCTAssertEqual(hist["2026-06-01"] ?? nil, 50.0)   // real value preserved
+        XCTAssertEqual(hist["2026-06-02"] ?? nil, 40.0)   // present-nil filled
+        XCTAssertEqual(hist["2026-06-03"] ?? nil, 42.0)   // absent filled
+    }
+
+    func testBlankImportedNights_seedFromOnDeviceHrv_crossSeed_andTrackLevel() {
+        // A strap + Health-Connect user: every daily row exists (HC sleep) but carries avgHrv = nil.
+        let days = ["2026-06-01", "2026-06-02", "2026-06-03", "2026-06-04", "2026-06-05"]
+
+        func foldWithInjected(_ level: Double) -> BaselineState {
+            var hist: [String: Double?] = [:]
+            for d in days { hist.updateValue(nil, forKey: d) }   // present-but-nil (HC sleep-only)
+            var nightly: [String: Double?] = [:]
+            for d in days { nightly[d] = level }
+            NightlyBaselineMerge.fillBlankNights(&hist, nightly)
+            let seq = hist.keys.sorted().map { hist[$0]! }
+            return Baselines.foldHistory(seq, cfg: hrvCfg)
+        }
+
+        // Regression: pre-fix these 5 present-nil days would have stayed nil -> nValid 0 -> never usable.
+        let lowBase = foldWithInjected(35.0)
+        let highBase = foldWithInjected(70.0)
+        XCTAssertTrue(lowBase.usable, "5 filled HRV nights must cross the seed gate")
+        XCTAssertTrue(highBase.usable, "5 filled HRV nights must cross the seed gate")
+
+        // Varying input (CLAUDE.md): the baseline must TRACK the injected level, not coincidentally match one.
+        XCTAssertLessThan(lowBase.baseline, highBase.baseline)
+        XCTAssertEqual(lowBase.baseline, 35.0, accuracy: 3.0)
+        XCTAssertEqual(highBase.baseline, 70.0, accuracy: 3.0)
+
+        // End-to-end: recovery is non-nil once the filled baseline is usable.
+        let rhrBase = Baselines.foldHistory([52.0, 51.0, 53.0, 52.0], cfg: Baselines.restingHRCfg)
+        let score = RecoveryScorer.recovery(
+            hrv: 35.0, rhr: 52.0, resp: nil,
+            hrvBaseline: lowBase, rhrBaseline: rhrBase, respBaseline: nil, sleepPerf: 0.9)
+        XCTAssertNotNil(score, "recovery must be non-nil once the filled baseline is usable")
+    }
+}

--- a/Strand/Data/IntelligenceEngine.swift
+++ b/Strand/Data/IntelligenceEngine.swift
@@ -770,9 +770,9 @@ final class IntelligenceEngine: ObservableObject {
         // ── Seed the baseline from the UNION of imported nightly history + the values just computed.
         // THIS is the BLE-only recovery fix: the "-noop" nightly avgHrv/restingHr finally feed the
         // baseline so a strap-only user crosses Baselines.minNightsSeed and recovery lights up.
-        // IMPORTED values win per day: write them first, then fill ONLY days the import doesn't cover
-        // (Swift has no putIfAbsent , `dict[day] == nil` is true only when the KEY is absent, so a day
-        // imported with a nil avgHrv stays imported, not overwritten by the computed value).
+        // A REAL imported value wins per day; a day the import left BLANK (key absent OR present-but-nil)
+        // takes the on-device value so a strap+Health-Connect user's computed HRV/RHR can seed the baseline
+        // (#393). See NightlyBaselineMerge for the rule; byte-identical to the Kotlin twin.
         var histHrvByDay: [String: Double?] = [:]
         var histRhrByDay: [String: Double?] = [:]
         var histRespByDay: [String: Double?] = [:]
@@ -781,9 +781,9 @@ final class IntelligenceEngine: ObservableObject {
             histRhrByDay[d.day] = d.restingHr.map(Double.init)
             histRespByDay[d.day] = d.respRateBpm
         }
-        for (day, v) in nightlyHrvByDay where histHrvByDay[day] == nil { histHrvByDay[day] = v }
-        for (day, v) in nightlyRhrByDay where histRhrByDay[day] == nil { histRhrByDay[day] = v }
-        for (day, v) in nightlyRespByDay where histRespByDay[day] == nil { histRespByDay[day] = v }
+        NightlyBaselineMerge.fillBlankNights(&histHrvByDay, nightlyHrvByDay)
+        NightlyBaselineMerge.fillBlankNights(&histRhrByDay, nightlyRhrByDay)
+        NightlyBaselineMerge.fillBlankNights(&histRespByDay, nightlyRespByDay)
         // rhr/resp/skin honour the Charge-wide recalibration epoch (noop.recoveryBaselineEpoch); 0 = no-op,
         // so this is byte-identical to the plain fold until the user taps Recalibrate, at which point the
         // whole Charge build-up (HRV + resting HR + resp + skin) re-anchors together.

--- a/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
+++ b/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
@@ -649,17 +649,12 @@ object IntelligenceEngine {
             histRhrByDay[d.day] = d.restingHr?.toDouble()
             histRespByDay[d.day] = d.respRateBpm
         }
-        // Imported (cloud) nightly values WIN per day: the on-device estimate only fills days the
-        // import doesn't cover AT ALL, so an import user's baseline is unchanged. Use a key-absence
-        // check, NOT putIfAbsent: Java's putIfAbsent treats a key mapped to NULL as absent, so an
-        // imported day whose avgHrv/restingHr is blank would be REPLACED by the computed estimate —
-        // diverging from the Swift mirror (`histHrvByDay[day] == nil` is true only when the KEY is
-        // absent), which keeps that imported day as a missing night. HRV/RHR are the dominant
-        // recovery drivers (~60%/~20%), so this substitution skewed Charge vs iOS. (The author already
-        // fixed this for the low-weight resp term below; HRV/RHR were missed.)
-        for ((day, v) in nightlyHrvByDay) if (day !in histHrvByDay) histHrvByDay[day] = v
-        for ((day, v) in nightlyRhrByDay) if (day !in histRhrByDay) histRhrByDay[day] = v
-        for ((day, v) in nightlyRespByDay) if (day !in histRespByDay) histRespByDay[day] = v
+        // A REAL imported (cloud) nightly value WINS per day; a day the import left BLANK (key absent OR
+        // present-but-null) takes the on-device value so a strap+Health-Connect user's computed HRV/RHR can
+        // seed the baseline (#393). See NightlyBaselineMerge for the rule; byte-identical to the Swift twin.
+        NightlyBaselineMerge.fillBlankNights(histHrvByDay, nightlyHrvByDay)
+        NightlyBaselineMerge.fillBlankNights(histRhrByDay, nightlyRhrByDay)
+        NightlyBaselineMerge.fillBlankNights(histRespByDay, nightlyRespByDay)
         // Sort once so the HRV values + their "yyyy-MM-dd" day keys stay parallel (same order/length) for
         // the recalibration-aware foldHistory below.
         val hrvSorted = histHrvByDay.entries.sortedBy { it.key }

--- a/android/app/src/main/java/com/noop/analytics/NightlyBaselineMerge.kt
+++ b/android/app/src/main/java/com/noop/analytics/NightlyBaselineMerge.kt
@@ -1,0 +1,27 @@
+package com.noop.analytics
+
+/**
+ * Seed-merge policy for the recovery baselines (#393). Kotlin twin of the Swift NightlyBaselineMerge,
+ * kept byte-identical (same rule, same three drivers).
+ *
+ * A REAL imported (cloud) nightly value WINS per day, so a WHOOP-cloud user whose days carry genuine
+ * HRV/RHR is unchanged. But a day the import left BLANK must take the on-device value: for a strap user
+ * whose daily rows exist only from a Health-Connect SLEEP import (HC never carries WHOOP HRV, so every
+ * one of those days is present-but-null), the on-device HRV/RHR the strap computes from raw HR has to be
+ * allowed to seed the baseline, or nValid starves below Baselines.minNightsSeed and Charge never
+ * calibrates. That was #393: the fill was keyed on the KEY being absent, so a present-but-null day was
+ * treated as "covered" and blocked forever.
+ *
+ * Pure + side-effect-free (no clock, no I/O), so a fixture pins the exact merge on both platforms. The
+ * HRV, RHR and resp merges all route through this so the three dominant Charge drivers stay aligned.
+ */
+object NightlyBaselineMerge {
+
+    /**
+     * Fill [hist] in place: any day whose current value is null — key ABSENT or present-but-null — takes
+     * the matching [nightly] value; a non-null [hist] value (a real imported reading) is left untouched.
+     */
+    fun fillBlankNights(hist: MutableMap<String, Double?>, nightly: Map<String, Double?>) {
+        for ((day, v) in nightly) if (hist[day] == null && v != null) hist[day] = v
+    }
+}

--- a/android/app/src/test/java/com/noop/analytics/NightlyBaselineMergeTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/NightlyBaselineMergeTest.kt
@@ -1,0 +1,72 @@
+package com.noop.analytics
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * #393: on-device nightly HRV/RHR must seed the recovery baseline on days the import left BLANK
+ * (present-but-null), not only on days with no daily row at all. Before the fix, a strap user whose daily
+ * rows came from a Health-Connect SLEEP import (avgHrv always null) had the on-device HRV blocked, so the
+ * baseline starved below the 4-night seed and Charge never calibrated. Byte-identical to the Swift
+ * NightlyBaselineMergeTests. Pure: no DB, no strap.
+ */
+class NightlyBaselineMergeTest {
+
+    private val hrvCfg = Baselines.metricCfg.getValue("hrv")
+
+    @Test
+    fun fillBlankNights_fillsAbsentAndPresentNull_neverOverwritesReal() {
+        val hist = linkedMapOf<String, Double?>(
+            "2026-06-01" to 50.0,   // real imported value -> must WIN
+            "2026-06-02" to null,   // present-but-null -> must be filled (the #393 case)
+        )
+        val nightly = mapOf<String, Double?>(
+            "2026-06-01" to 99.0,   // must NOT overwrite the real 50.0
+            "2026-06-02" to 40.0,   // fills the present-null day
+            "2026-06-03" to 42.0,   // absent day -> added
+        )
+        NightlyBaselineMerge.fillBlankNights(hist, nightly)
+        assertEquals(50.0, hist["2026-06-01"])   // real value preserved
+        assertEquals(40.0, hist["2026-06-02"])   // present-null filled
+        assertEquals(42.0, hist["2026-06-03"])   // absent filled
+    }
+
+    @Test
+    fun blankImportedNights_seedFromOnDeviceHrv_crossSeed_andTrackLevel() {
+        // A strap + Health-Connect user: every daily row exists (HC sleep) but carries avgHrv = null.
+        val days = listOf("2026-06-01", "2026-06-02", "2026-06-03", "2026-06-04", "2026-06-05")
+
+        fun foldWithInjected(level: Double): BaselineState {
+            val hist = LinkedHashMap<String, Double?>()
+            for (d in days) hist[d] = null                 // present-but-null (HC sleep-only)
+            val nightly: Map<String, Double?> = days.associateWith { level }
+            NightlyBaselineMerge.fillBlankNights(hist, nightly)
+            val seq = hist.entries.sortedBy { it.key }.map { it.value }
+            return Baselines.foldHistory(seq, hrvCfg)
+        }
+
+        // Regression: pre-fix these 5 present-null days would have stayed null -> nValid 0 -> never usable.
+        val lowBase = foldWithInjected(35.0)
+        val highBase = foldWithInjected(70.0)
+        assertTrue("5 filled HRV nights must cross the seed gate", lowBase.usable)
+        assertTrue("5 filled HRV nights must cross the seed gate", highBase.usable)
+
+        // Varying input (CLAUDE.md): the baseline must TRACK the injected level, not coincidentally match one.
+        assertTrue(
+            "baseline must track the injected HRV level (${lowBase.baseline} < ${highBase.baseline})",
+            lowBase.baseline < highBase.baseline,
+        )
+        assertEquals(35.0, lowBase.baseline, 3.0)
+        assertEquals(70.0, highBase.baseline, 3.0)
+
+        // End-to-end: recovery is non-null once the filled baseline is usable.
+        val rhrBase = Baselines.foldHistory(listOf(52.0, 51.0, 53.0, 52.0), Baselines.restingHRCfg)
+        val score = RecoveryScorer.recovery(
+            hrv = 35.0, rhr = 52.0, resp = null,
+            hrvBaseline = lowBase, rhrBaseline = rhrBase, respBaseline = null, sleepPerf = 0.9,
+        )
+        assertNotNull("recovery must be non-null once the filled baseline is usable", score)
+    }
+}


### PR DESCRIPTION
Fixes #393.

## The bug
A strap user whose daily rows come from a **Health Connect sleep import** (HC never carries WHOOP HRV, so every one of those days is `avgHrv = null`) had the on-device HRV/RHR the strap computes from raw HR **blocked from seeding the recovery baseline**. The union merge in `IntelligenceEngine` filled only days whose **key was absent**; a day that already existed as a persisted row with a null value was treated as "covered" and never filled. So the HRV baseline starved below the 4-night seed (`nValid` stuck at 2), recovery never calibrated, and Charge stayed blank even on worn, sleep-recorded nights.

Confirmed from the reporters `report.txt`:
```
charge day=2026-06-30 nilScore reason=hrvBaselineNotUsable hrvStatus=calibrating hrvNValid=2 (need nValid>=4)
hrv day=2026-06-30 avgHrv=34.7   hrv day=2026-06-27 avgHrv=41.4   ...   (6+ valid nights)
```
~6 nights carry a perfectly good computed HRV, yet the baseline counted only 2.

## The fix
Fill a day whose stored value is null (**absent OR present-but-null**) with a real on-device value, and **never** override a real imported value — so the "imported cloud value wins" intent holds while a strap+HealthConnect users computed HRV/RHR can finally seed the baseline. Extracted into a shared `NightlyBaselineMerge.fillBlankNights` routed by both engines, so production and tests share one rule; this also removes a latent Swift/Kotlin divergence on the `(absent, nil)` case.

- Cross-platform, byte-identical: `Strand/Data/IntelligenceEngine.swift` + `android/.../analytics/IntelligenceEngine.kt`, new `NightlyBaselineMerge.{swift,kt}`. HRV/RHR/resp all routed through it.
- One concern only. (A separate follow-up: Today shows "Needs the strap" instead of "Calibrating" while a baseline is genuinely mid-calibration — filed separately.)

## Verification
- `swift test --filter NightlyBaselineMergeTests` (StrandAnalytics) — pass
- `./gradlew testFullDebugUnitTest` (`NightlyBaselineMergeTest`, `BaselineSeedingTest`) — pass; Android app compiles
- macOS `xcodebuild -scheme Strand … build` — **BUILD SUCCEEDED** (app-target `IntelligenceEngine.swift`, which no default CI covers)
- Tests prove the filled baseline crosses the seed and **tracks a varying injected HRV level** (35 vs 70 ms), not one coincidental match (per CONTRIBUTING's derive-a-signal rule).

Note for the reporters specific strap: their most recent nights have no raw samples yet (freshly re-added 4.0, history not fully synced), so "last night" still needs a completed history sync to score; this fix restores Charge for the older nights that already carry HRV.