### PR TITLE
Sleep accuracy: self-consistency, Rest weighting, sparse deep/REM, stress night floor

### DIFF
--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/AnalyticsEngine.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/AnalyticsEngine.swift
@@ -804,10 +804,9 @@ public enum AnalyticsEngine {
     /// but almost no DEEP still earn near-full restorative credit (so Rest read 95+ with little deep).
     /// When the caller supplies the DEEP split (`deepSeconds`), the restorative sub-score is scaled by
     /// a gentle deep-adequacy factor: full credit once deep ≥ `deepShareTarget` (~13% of asleep is the
-    /// healthy floor), ramping to `deepFloorFactor` (0.5 — never zeroed) as deep → 0. So a near-zero-deep
-    /// night loses up to half the 0.20 restorative term (~10 pts) — honest, not tanking, no fabricated
-    /// stages. Deep unknown (`deepSeconds == nil`, e.g. an imported night with only a pooled total) →
-    /// factor 1.0, identical to the prior pooled behaviour.
+    /// healthy floor), ramping toward `deepFloorFactor` (0.25 — never zeroed) as deep → 0, with a
+    /// steeper limb below half-target. Duration is also quality-gated when restorative share is thin
+    /// so raw hours alone cannot read Rest "Strong" on a near-zero deep/REM night (13 Jul screenshot).
     public enum Rest {
         /// Default personal sleep need (hours) before the caller refines it.
         public static let defaultNeedHours: Double = 8.0
@@ -816,16 +815,44 @@ public enum AnalyticsEngine {
         /// Deep-sleep share of asleep time that earns FULL restorative credit (~13% is the healthy
         /// floor for adults; below it the restorative term is scaled down toward `deepFloorFactor`).
         public static let deepShareTarget: Double = 0.13
-        /// The most the restorative term is scaled down by when deep is ~absent — half, never zero,
-        /// so a low-deep night reads honestly without the whole night tanking.
-        public static let deepFloorFactor: Double = 0.5
+        /// Floor on the restorative deep-adequacy multiplier when deep → 0 (was 0.5).
+        public static let deepFloorFactor: Double = 0.25
+        /// Below this restorative share, duration credit is discounted.
+        public static let durationQualityShareGate: Double = 0.12
+        /// Minimum duration multiplier at zero restorative share.
+        public static let durationQualityFloor: Double = 0.70
         /// Neutral consistency when the caller supplies no regularity signal.
         public static let neutralConsistency: Double = 0.5
 
-        public static let wDuration: Double = 0.50
+        public static let wDuration: Double = 0.45
         public static let wEfficiency: Double = 0.20
-        public static let wRestorative: Double = 0.20
+        public static let wRestorative: Double = 0.25
         public static let wConsistency: Double = 0.10
+
+        /// Deep-adequacy multiplier; steeper below half of `deepShareTarget`.
+        public static func deepAdequacyFactor(deepSeconds: Double, asleepSeconds: Double) -> Double {
+            guard asleepSeconds > 0, deepShareTarget > 0 else { return 1.0 }
+            let adequacy = max(0.0, min(1.0, (deepSeconds / asleepSeconds) / deepShareTarget))
+            if adequacy >= 0.5 {
+                return deepFloorFactor + (1.0 - deepFloorFactor) * adequacy
+            }
+            let steepFloor = deepFloorFactor * 0.4
+            return steepFloor + (deepFloorFactor - steepFloor) * (adequacy / 0.5)
+        }
+
+        public static func durationQualityFactor(restorativeShare: Double) -> Double {
+            guard restorativeShare < durationQualityShareGate else { return 1.0 }
+            let t = max(0.0, min(1.0, restorativeShare / durationQualityShareGate))
+            return durationQualityFloor + (1.0 - durationQualityFloor) * t
+        }
+
+        /// Prefer light+deep+REM when present so Rest agrees with the hypnogram.
+        public static func canonicalAsleepMin(_ d: DailyMetric) -> Double? {
+            let stageSum = (d.deepMin ?? 0) + (d.remMin ?? 0) + (d.lightMin ?? 0)
+            if stageSum > 0 { return stageSum }
+            guard let tst = d.totalSleepMin, tst > 0 else { return nil }
+            return tst
+        }
 
         /// Build the composite. `tstSeconds` = total sleep time, `restorativeSeconds` = deep+REM
         /// seconds, `deepSeconds` = deep-stage seconds (nil → no deep-adequacy adjustment, pooled
@@ -840,17 +867,15 @@ public enum AnalyticsEngine {
             func clamp01(_ x: Double) -> Double { max(0.0, min(1.0, x)) }
 
             let needSeconds = max(needHours, 0.1) * 3600.0
-            let durationScore = clamp01(tstSeconds / needSeconds)
+            let restorativeShare = tstSeconds > 0 ? restorativeSeconds / tstSeconds : 0.0
+            let durationScore = clamp01(tstSeconds / needSeconds) * durationQualityFactor(restorativeShare: restorativeShare)
             let efficiencyScore = clamp01(efficiency)
-            // Deep-adequacy factor in [deepFloorFactor, 1]: 1.0 once deep ≥ target share, ramping
-            // down to the floor as deep → 0. nil deep (unknown split) ⇒ 1.0 (no adjustment).
             let deepFactor: Double = {
-                guard let deep = deepSeconds, tstSeconds > 0, deepShareTarget > 0 else { return 1.0 }
-                let adequacy = clamp01((deep / tstSeconds) / deepShareTarget)
-                return deepFloorFactor + (1.0 - deepFloorFactor) * adequacy
+                guard let deep = deepSeconds, tstSeconds > 0 else { return 1.0 }
+                return deepAdequacyFactor(deepSeconds: deep, asleepSeconds: tstSeconds)
             }()
             let restorativeScore = tstSeconds > 0
-                ? clamp01((restorativeSeconds / tstSeconds) / restorativeTarget) * deepFactor
+                ? clamp01(restorativeShare / restorativeTarget) * deepFactor
                 : 0.0
             let consistencyScore = clamp01(consistency ?? neutralConsistency)
 
@@ -868,7 +893,7 @@ public enum AnalyticsEngine {
         /// "Rest quality" term agree. `consistency` is the caller's regularity signal (nil → neutral).
         public static func composite(daily d: DailyMetric, needHours: Double = defaultNeedHours,
                                      consistency: Double? = nil) -> Double? {
-            guard let tstMin = d.totalSleepMin, tstMin > 0, let eff = d.efficiency else { return nil }
+            guard let tstMin = canonicalAsleepMin(d), tstMin > 0, let eff = d.efficiency else { return nil }
             let tstSec = tstMin * 60.0
             let deepSec = (d.deepMin ?? 0) * 60.0
             let restorativeSec = (d.deepMin ?? 0) * 60.0 + (d.remMin ?? 0) * 60.0

--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/RestSubScoreTrace.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/RestSubScoreTrace.swift
@@ -92,15 +92,15 @@ extension AnalyticsEngine.Rest {
         func r2(_ x: Double) -> Double { (x * 100.0).rounded() / 100.0 }
 
         let needSeconds = max(needHours, 0.1) * 3600.0
-        let durationScore = clamp01(tstSeconds / needSeconds)
+        let restorativeShare = tstSeconds > 0 ? restorativeSeconds / tstSeconds : 0.0
+        let durationScore = clamp01(tstSeconds / needSeconds) * durationQualityFactor(restorativeShare: restorativeShare)
         let efficiencyScore = clamp01(efficiency)
         let deepFactor: Double = {
-            guard let deep = deepSeconds, tstSeconds > 0, deepShareTarget > 0 else { return 1.0 }
-            let adequacy = clamp01((deep / tstSeconds) / deepShareTarget)
-            return deepFloorFactor + (1.0 - deepFloorFactor) * adequacy
+            guard let deep = deepSeconds, tstSeconds > 0 else { return 1.0 }
+            return deepAdequacyFactor(deepSeconds: deep, asleepSeconds: tstSeconds)
         }()
         let restorativeScore = tstSeconds > 0
-            ? clamp01((restorativeSeconds / tstSeconds) / restorativeTarget) * deepFactor
+            ? clamp01(restorativeShare / restorativeTarget) * deepFactor
             : 0.0
         let consistencyScore = clamp01(consistency ?? neutralConsistency)
         let composite = AnalyticsEngine.Rest.composite(

--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/SleepStager.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/SleepStager.swift
@@ -159,7 +159,7 @@ public enum SleepStager {
     /// Skip HR refinement (trust gravity) when fewer than this many HR samples.
     public static let hrRefineMinSamples: Int = 30
     /// Consecutive sleep epochs required to declare onset.
-    public static let onsetPersistEpochs: Int = 3
+    public static let onsetPersistEpochs: Int = 4
 
     // MARK: - Off-wrist backstop (#500)
 
@@ -1557,11 +1557,15 @@ public enum SleepStager {
         // over-promotes still sleep to wake. (#705)
         if moving && (cardiacActivatedForWake || !hasHR) { return "wake" }
         // DEEP: still + low HR + regular respiration, with high parasympathetic tone when measurable.
+        // Sparse cardiac: still + low HR alone when RRV missing (screenshot deep collapse).
         if still && parasympOK && hrLow && rrvRegular { return "deep" }
+        if cardiacSparse && still && hrLow && !f.rrv.isFinite { return "deep" }
         // REM: still body + activated cardiac + irregular respiration.
         if still && cardiacActivated && rrvIrregular { return "rem" }
         // REM fallback when respiration unavailable: require BOTH cardiac signals.
         if still && hrHigh && hrvarHigh && !f.rrv.isFinite { return "rem" }
+        // Sparse late-night REM: still + elevated HR after the first third (0% REM screenshot reopen).
+        if cardiacSparse && still && hrHigh && !f.rrv.isFinite && f.clock > deepFirstFraction { return "rem" }
         return "light"
     }
 
@@ -1702,9 +1706,13 @@ public enum SleepStager {
         // An epoch that wins WAKE or DEEP was never a REM candidate.
         if moving && (cardiacActivatedForWake || !hasHR) { return .wonOtherStage }     // → wake
         if still && parasympOK && hrLow && rrvRegular { return .wonOtherStage } // → deep
+        if cardiacSparse && still && hrLow && !f.rrv.isFinite { return .wonOtherStage } // → sparse deep
         // From here the epoch did NOT win wake/deep; it is either REM or falls through to LIGHT.
         if still && cardiacActivated && rrvIrregular { return .remEligible }
         if still && hrHigh && hrvarHigh && !f.rrv.isFinite { return .remEligible }
+        if cardiacSparse && still && hrHigh && !f.rrv.isFinite && f.clock > deepFirstFraction {
+            return .remEligible
+        }
         // Not REM → attribute to the FIRST unmet REM precondition (in REM-rule order).
         if !still { return .notStill }
         if !cardiacActivated { return .noCardiacActivation }

--- a/android/app/src/main/java/com/noop/analytics/AnalyticsEngine.kt
+++ b/android/app/src/main/java/com/noop/analytics/AnalyticsEngine.kt
@@ -889,10 +889,17 @@ object AnalyticsEngine {
  */
 object RestScorer {
 
-    /** Component weights (sum 1.0 when all present). Byte-identical to Swift. */
-    const val wDuration: Double = 0.50
+    /**
+     * Component weights (sum 1.0 when all present). Byte-identical to Swift.
+     *
+     * 2026-07-14 screenshot pass (WHOOP Sleep 64% vs NOOP Rest 73 "Strong" on a 2% deep / 0% REM
+     * night): duration was carrying half the composite while restorative could not fall far enough,
+     * so a mediocre staged night still read Strong. Shift weight toward restorative and lower the
+     * deep floor; duration still matters most, but no longer alone.
+     */
+    const val wDuration: Double = 0.45
     const val wEfficiency: Double = 0.20
-    const val wRestorative: Double = 0.20
+    const val wRestorative: Double = 0.25
     const val wConsistency: Double = 0.10
 
     /** Default personal sleep need (hours) before any recent-average refinement. */
@@ -913,12 +920,61 @@ object RestScorer {
      */
     const val deepShareTarget: Double = 0.13
 
-    /** Most the restorative term is scaled down when deep is ~absent — half, never zeroed, so a
-     *  low-deep night reads honestly without the whole night tanking. Swift parity. */
-    const val deepFloorFactor: Double = 0.5
+    /**
+     * Floor on the restorative deep-adequacy multiplier when deep → 0. Was 0.5 (half credit even with
+     * almost no deep); screenshot nights with ~2% deep still scored Rest "Strong". 0.25 keeps a
+     * non-zero floor (honest, not tanking) while letting near-zero deep pull Rest down. Swift parity.
+     */
+    const val deepFloorFactor: Double = 0.25
+
+    /**
+     * Below this restorative (deep+REM) share of asleep time, duration credit is discounted so raw
+     * hours alone cannot carry Rest into "Strong" when staging found almost no restorative sleep.
+     * At/above the gate, duration is unscathed. Grounded in the 13 Jul night (≈2% restorative).
+     */
+    const val durationQualityShareGate: Double = 0.12
+
+    /** Minimum duration multiplier at zero restorative share (never zero — duration still counts). */
+    const val durationQualityFloor: Double = 0.70
 
     /** Neutral consistency (fraction) used when the caller supplies no regularity signal. Swift parity. */
     const val NEUTRAL_CONSISTENCY: Double = 0.5
+
+    /**
+     * Single asleep-minutes source of truth for Rest / debt / trends.
+     *
+     * Prefer light+deep+REM when any stage minutes exist — those are what the hypnogram and stage
+     * cards show. [DailyMetric.totalSleepMin] can diverge (HC blend, stale bank, pre-heal) and was
+     * the root of Sleep hero "8h 37m" vs stages "7h 19m" on the same night. Never invents stages.
+     */
+    fun canonicalAsleepMin(daily: DailyMetric): Double? {
+        val stageSum = (daily.deepMin ?: 0.0) + (daily.remMin ?: 0.0) + (daily.lightMin ?: 0.0)
+        if (stageSum > 0.0) return stageSum
+        return daily.totalSleepMin?.takeIf { it > 0.0 }
+    }
+
+    /**
+     * Deep-adequacy multiplier in [[deepFloorFactor], 1]. Below half of [deepShareTarget] the ramp
+     * is steeper (near-zero deep is not "a little short"), still never zeroed.
+     */
+    fun deepAdequacyFactor(deepSeconds: Double, asleepSeconds: Double): Double {
+        if (asleepSeconds <= 0.0 || deepShareTarget <= 0.0) return 1.0
+        val adequacy = ((deepSeconds / asleepSeconds) / deepShareTarget).coerceIn(0.0, 1.0)
+        return if (adequacy >= 0.5) {
+            deepFloorFactor + (1.0 - deepFloorFactor) * adequacy
+        } else {
+            // Steep limb: 0 → deepFloorFactor*0.4, half-target → deepFloorFactor mid-ramp start.
+            val steepFloor = deepFloorFactor * 0.4
+            steepFloor + (deepFloorFactor - steepFloor) * (adequacy / 0.5)
+        }
+    }
+
+    /** Duration multiplier when restorative share is thin — see [durationQualityShareGate]. */
+    fun durationQualityFactor(restorativeShare: Double): Double {
+        if (restorativeShare >= durationQualityShareGate) return 1.0
+        val t = (restorativeShare / durationQualityShareGate).coerceIn(0.0, 1.0)
+        return durationQualityFloor + (1.0 - durationQualityFloor) * t
+    }
 
     /**
      * Rest composite [0,100], or null when there is no asleep time.
@@ -943,17 +999,13 @@ object RestScorer {
         val asleepHours = asleepSeconds / 3600.0
         val needHours = (sleepNeedHours ?: defaultSleepNeedHours).coerceAtLeast(1e-9)
 
-        // Duration vs personal need (clamped at 100 — sleeping past need does not over-credit).
-        val durationScore = min(100.0, asleepHours / needHours * 100.0)
+        val restorativeShare = (deepSeconds + remSeconds) / asleepSeconds
+        // Duration vs personal need (clamped at 100), then quality-gated when restorative is thin.
+        val durationScore = min(100.0, asleepHours / needHours * 100.0) *
+            durationQualityFactor(restorativeShare)
         // Efficiency (0..1 → 0..100), clamped.
         val efficiencyScore = (efficiency * 100.0).coerceIn(0.0, 100.0)
-        // Restorative share vs healthy target (clamped at 100), then scaled by a gentle deep-adequacy
-        // factor in [deepFloorFactor, 1]: full once deep ≥ target share, ramping to the floor as
-        // deep → 0, so a near-zero-deep night loses up to half this term (~10 pts) — honest, not
-        // tanking, no fabricated stages. Mirrors Swift Rest.composite EXACTLY.
-        val restorativeShare = (deepSeconds + remSeconds) / asleepSeconds
-        val deepAdequacy = ((deepSeconds / asleepSeconds) / deepShareTarget).coerceIn(0.0, 1.0)
-        val deepFactor = deepFloorFactor + (1.0 - deepFloorFactor) * deepAdequacy
+        val deepFactor = deepAdequacyFactor(deepSeconds, asleepSeconds)
         val restorativeScore = min(100.0, restorativeShare / restorativeTargetShare * 100.0) * deepFactor
 
         // Consistency uses a NEUTRAL 0.5 (→50) when the caller supplies none — matching the Swift
@@ -1026,14 +1078,14 @@ object RestScorer {
         fun clamp01(x: Double) = maxOf(0.0, minOf(1.0, x))
         fun r2(x: Double) = Math.round(x * 100.0) / 100.0
         val needSeconds = maxOf(needHours, 0.1) * 3600.0
-        val durationScore = clamp01(tstSeconds / needSeconds)
+        val restorativeShare = if (tstSeconds > 0) restorativeSeconds / tstSeconds else 0.0
+        val durationScore = clamp01(tstSeconds / needSeconds) * durationQualityFactor(restorativeShare)
         val efficiencyScore = clamp01(efficiency)
-        val deepFactor = if (deepSeconds != null && tstSeconds > 0 && deepShareTarget > 0) {
-            val adequacy = clamp01((deepSeconds / tstSeconds) / deepShareTarget)
-            deepFloorFactor + (1.0 - deepFloorFactor) * adequacy
+        val deepFactor = if (deepSeconds != null && tstSeconds > 0) {
+            deepAdequacyFactor(deepSeconds, tstSeconds)
         } else 1.0
         val restorativeScore = if (tstSeconds > 0)
-            clamp01((restorativeSeconds / tstSeconds) / restorativeTargetShare) * deepFactor else 0.0
+            clamp01(restorativeShare / restorativeTargetShare) * deepFactor else 0.0
         val consistencyScore = clamp01(consistency ?: NEUTRAL_CONSISTENCY)
         // Reuse the real scorer for the composite (cannot diverge). `rest()` takes deep + REM separately;
         // restorative = deep + REM, so REM = restorative - deep. null deep -> 0 deep (no-adequacy path).
@@ -1056,9 +1108,12 @@ object RestScorer {
      * streams are gone but the night's totals remain). null when there's no sleep. Single source of
      * truth so the persisted sleep_performance series and the Charge "Rest quality" term agree. Mirrors
      * Swift `AnalyticsEngine.Rest.composite(daily:)`.
+     *
+     * Asleep minutes come from [canonicalAsleepMin] (stage sum preferred) so Rest cannot disagree with
+     * the hypnogram cards on the same night.
      */
     fun restFromDaily(daily: DailyMetric, consistency: Double? = null): Double? {
-        val tstMin = daily.totalSleepMin ?: return null
+        val tstMin = canonicalAsleepMin(daily) ?: return null
         val eff = daily.efficiency ?: return null
         if (tstMin <= 0.0) return null
         return rest(

--- a/android/app/src/main/java/com/noop/analytics/DaytimeStress.kt
+++ b/android/app/src/main/java/com/noop/analytics/DaytimeStress.kt
@@ -50,6 +50,13 @@ object DaytimeStress {
     /** First/last local hour-of-day treated as "waking" for the timeline (06:00–22:00). */
     const val wakingStartHour: Int = 6
     const val wakingEndHour: Int = 22
+    /**
+     * Soft raw damp when a waking-band hour sits inside a detected sleep window (late sleepers
+     * whose night runs past [wakingStartHour]). WHOOP keeps a night floor through ~1pm on the
+     * 13 Jul screenshot night; without this, those hours pollute the calm reference. Not a tip
+     * retune from a single calibrating tip.
+     */
+    const val sleepWindowCalmBias: Double = 1.20
 
     // MARK: - Output
 
@@ -142,11 +149,22 @@ object DaytimeStress {
      * @param rr the day's R-R intervals.
      * @param tzOffsetSeconds seconds east of UTC, for placing each bucket on the LOCAL clock
      *   (so "waking hours" and the hour labels are local). Defaults to UTC.
+     * @param sleepWindows wall-clock [start, end) pairs for detected sleep this day. Hours
+     *   overlapping a window are excluded from the waking calm reference and get a night-floor
+     *   damp when scored — late sleepers stay honest vs WHOOP Stress Monitor shape.
      *
      * Returns [Result.EMPTY] when there isn't a single hour with enough HR to score.
      */
-    fun analyze(hr: List<HrSample>, rr: List<RrInterval>, tzOffsetSeconds: Long = 0L): Result {
+    fun analyze(
+        hr: List<HrSample>,
+        rr: List<RrInterval>,
+        tzOffsetSeconds: Long = 0L,
+        sleepWindows: List<Pair<Long, Long>> = emptyList(),
+    ): Result {
         if (hr.isEmpty()) return Result.EMPTY
+
+        fun inSleep(wallMid: Long): Boolean =
+            sleepWindows.any { (a, b) -> wallMid in a until b }
 
         // 1) Bucket HR + R-R into LOCAL hour-of-day buckets, keyed by the bucket start
         //    (floored to the hour on the local clock).
@@ -176,19 +194,13 @@ object DaytimeStress {
             aggs.add(HourAgg(b, mHr, rrRes.rmssd))
         }
 
-        // 3) The day's OWN quiet reference: centre on the CALM end (the lower quartile of
-        //    hourly mean HR, the upper quartile of hourly RMSSD), and spread from the
-        //    across-hour SD. This makes a flat day read ~baseline and a spiky day surface its
-        //    tense hours — without any cross-day history. Falls back to the plain mean when
-        //    there are too few scored hours for a quartile.
-        //
-        //    Built from the WAKING hours only — the same hours scored in step 4. Sleep is the
-        //    calmest, lowest-HR / highest-HRV stretch of the day, and the analysis window
-        //    always begins at local midnight, so the current day routinely carries several
-        //    hours of it. Letting those night hours into the reference drags the "calm" anchor
-        //    far beneath every waking hour, inflating an ordinary calm day toward HIGH and
-        //    falsely tripping the sustained-high Breathe nudge.
-        val referenceAggs = aggs.filter { isWakingHour(it.bucket) }
+        // 3) Quiet reference from waking hours that are NOT inside a sleep window — late sleep
+        //    past 06:00 must not drag the calm anchor (13 Jul WHOOP night floor through ~1pm).
+        val referenceAggs = aggs.filter { agg ->
+            if (!isWakingHour(agg.bucket)) return@filter false
+            val wallMid = (agg.bucket - tzOffsetSeconds) + bucketSeconds / 2
+            !inSleep(wallMid)
+        }
         val hrMeans = referenceAggs.mapNotNull { it.meanHr }
         val rmssdVals = referenceAggs.mapNotNull { it.rmssd }
         val refHr = calmReference(hrMeans, calmIsLow = true)         // calm HR is LOW
@@ -196,24 +208,30 @@ object DaytimeStress {
         val sdHr = std(hrMeans, mean(hrMeans))
         val sdRmssd = std(rmssdVals, mean(rmssdVals))
 
-        // 4) Score each waking-hour bucket on the shared 0–3 curve.
+        // 4) Score waking-band hours; sleep-window overlaps get a night-floor damp.
         val points = ArrayList<HourPoint>(aggs.size)
         for (a in aggs) {
             if (!isWakingHour(a.bucket)) continue
             val hourOfDay = (floorDiv(a.bucket, bucketSeconds) % 24).toInt()
-            // The wall-clock bucket start (undo the local shift applied above).
             val wallStart = a.bucket - tzOffsetSeconds
-            // Score only when HR cleared the count gate (HR is the always-available anchor;
-            // RMSSD enriches it when beats allow).
+            val wallMid = wallStart + bucketSeconds / 2
+            val asleep = inSleep(wallMid)
             val level: Double? = if (a.meanHr != null) {
-                squash(rawScore(a.meanHr, refHr, sdHr, a.rmssd, refRmssd, sdRmssd))
+                var raw = rawScore(a.meanHr, refHr, sdHr, a.rmssd, refRmssd, sdRmssd)
+                if (asleep) raw -= sleepWindowCalmBias
+                squash(raw)
             } else {
                 null
             }
             points.add(HourPoint(hourOfDay, wallStart, level, a.meanHr, a.rmssd))
         }
 
-        val scored = points.mapNotNull { p -> p.level?.let { p to it } }
+        val scored = points.mapNotNull { p ->
+            val lvl = p.level ?: return@mapNotNull null
+            val wallMid = p.startTs + bucketSeconds / 2
+            if (inSleep(wallMid)) return@mapNotNull null
+            p to lvl
+        }
         if (scored.isEmpty()) {
             // No scorable waking hour — still return the (unscored) timeline so the UI can
             // show "not enough data" rather than nothing.

--- a/android/app/src/main/java/com/noop/analytics/SleepStager.kt
+++ b/android/app/src/main/java/com/noop/analytics/SleepStager.kt
@@ -169,8 +169,11 @@ object SleepStager {
     /** Skip HR refinement (trust gravity) when fewer than this many HR samples. */
     const val hrRefineMinSamples: Int = 30
 
-    /** Consecutive sleep epochs required to declare onset. */
-    const val onsetPersistEpochs: Int = 3
+    /** Consecutive sleep epochs required to declare onset.
+     *  Was 3 (≈90s on the 30s grid). Screenshot nights opened ~77 min early vs WHOOP when a brief
+     *  pre-sleep HR dip satisfied the short persist bar; 4 epochs (≈2 min) still opens on a real
+     *  descent without inventing stages. */
+    const val onsetPersistEpochs: Int = 4
 
     // ── Off-wrist backstop (#500) ─────────────────────────────────────────────
     //
@@ -1782,11 +1785,19 @@ object SleepStager {
         // over-promotes still sleep to wake. (#705)
         if (moving && (cardiacActivatedForWake || !hasHR)) return "wake"
         // DEEP: still + low HR + regular respiration, with high parasympathetic tone when measurable.
+        // On cardiac-sparse nights (missing RMSSD / RRV common on BLE-offload / "no movement detail"),
+        // also accept still + low HR alone — the screenshot collapse to 2% deep was mostly light because
+        // the full deep gate rarely cleared without motion+resp channels. Never invents deep from HC.
         if (still && parasympOK && hrLow && rrvRegular) return "deep"
+        if (cardiacSparse && still && hrLow && !f.rrv.isFinite()) return "deep"
         // REM: still body + activated cardiac + irregular respiration.
         if (still && cardiacActivated && rrvIrregular) return "rem"
         // REM fallback when respiration unavailable: require BOTH cardiac signals.
         if (still && hrHigh && hrvarHigh && !f.rrv.isFinite()) return "rem"
+        // Sparse / no-resp late-night REM: still + elevated HR alone after the first third of the night
+        // (clock > deepFirstFraction). WHOOP showed ~16% REM on the same night NOOP staged 0% REM when
+        // hrVar was noisy/missing; this is a directed reopen of the funnel, not invented minutes.
+        if (cardiacSparse && still && hrHigh && !f.rrv.isFinite() && f.clock > deepFirstFraction) return "rem"
         return "light"
     }
 
@@ -1925,9 +1936,13 @@ object SleepStager {
         // An epoch that wins WAKE or DEEP was never a REM candidate.
         if (moving && (cardiacActivatedForWake || !hasHR)) return REMRejectReason.WON_OTHER_STAGE  // → wake
         if (still && parasympOK && hrLow && rrvRegular) return REMRejectReason.WON_OTHER_STAGE // → deep
+        if (cardiacSparse && still && hrLow && !f.rrv.isFinite()) return REMRejectReason.WON_OTHER_STAGE // → sparse deep
         // From here the epoch did NOT win wake/deep; it is either REM or falls through to LIGHT.
         if (still && cardiacActivated && rrvIrregular) return REMRejectReason.REM_ELIGIBLE
         if (still && hrHigh && hrvarHigh && !f.rrv.isFinite()) return REMRejectReason.REM_ELIGIBLE
+        if (cardiacSparse && still && hrHigh && !f.rrv.isFinite() && f.clock > deepFirstFraction) {
+            return REMRejectReason.REM_ELIGIBLE
+        }
         // Not REM → attribute to the FIRST unmet REM precondition (in REM-rule order).
         if (!still) return REMRejectReason.NOT_STILL
         if (!cardiacActivated) return REMRejectReason.NO_CARDIAC_ACTIVATION

--- a/android/app/src/main/java/com/noop/ui/SleepScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/SleepScreen.kt
@@ -81,6 +81,7 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.noop.analytics.AnalyticsEngine
+import com.noop.analytics.RestScorer
 import com.noop.analytics.SleepDebt
 import com.noop.analytics.SleepDebtLedger
 import com.noop.analytics.SleepEditGuard
@@ -2452,7 +2453,16 @@ private fun DurationTrend(m: SleepModel) {
         ChartCard(
             title = "Sleep Debt",
             subtitle = "Hours of sleep debt per day",
-            trailing = m.trendDebtHours.lastOrNull()?.let { String.format(Locale.US, "%.1f h", it) },
+            // Trailing = rolling ledger balance (same source as Sleep Debt ledger card), not the
+            // latest night's one-sided deficit — avoids "0.0 h" vs "≈7h 31m" on the same window.
+            trailing = run {
+                val balH = m.sleepDebtLedger.balanceMin / 60.0
+                when {
+                    m.sleepDebtLedger.magnitudeMin < SleepDebt.ON_TARGET_BAND_MIN -> "0.0 h"
+                    m.sleepDebtLedger.isDebt -> String.format(Locale.US, "%.1f h", -balH)
+                    else -> String.format(Locale.US, "+%.1f h", balH)
+                }
+            },
             tint = Palette.restColor,
             footer = {
                 ChartFooter(
@@ -3107,18 +3117,23 @@ internal fun buildSleepModel(
     val rem = heroStages?.rem ?: sessionStageMins?.rem ?: latest.remMin ?: 0.0
     val light = heroStages?.light ?: sessionStageMins?.light ?: latest.lightMin ?: 0.0
 
-    // Hero awake estimate works off ASLEEP minutes (totalSleepMin), never the in-bed window. The
-    // old code substituted the edited session's (wake − onset) duration — TIME IN BED — for the
-    // asleep figure here and across every per-tile pass, which inflated awake / hours-vs-needed /
-    // debt vs the actual sleep. iOS never did this (it derives awake straight from the decoded
-    // stage segments). Dropped for parity (#1/#7); a sleep edit now reaches the tiles via the
-    // re-score path, not a display-time in-bed swap.
-    val asleep = latest.totalSleepMin ?: (deep + rem + light)
-    // Awake estimate: prefer (time-in-bed − asleep) implied by efficiency; else from
-    // disturbances; matches the macOS "awake minutes" carried in the stagesJSON.
+    // Hero asleep: prefer light+deep+REM (what the stage cards show) over totalSleepMin so the
+    // hero cannot disagree with the hypnogram on the same night (13 Jul: 8h37m banked vs 7h19m
+    // stages). totalSleepMin is the fallback when stages are missing. Never invents stages.
+    val stageAsleep = deep + rem + light
+    val asleep = when {
+        heroStages != null -> heroStages.light + heroStages.deep + heroStages.rem
+        stageAsleep > 0.0 -> stageAsleep
+        else -> latest.totalSleepMin ?: 0.0
+    }
+    // Awake: prefer explicit session awake when present; else efficiency back-calc against the
+    // SAME asleep figure (never against a stale totalSleepMin that disagrees with stages).
     val effFrac = latest.efficiency?.let { if (it > 1.0) it / 100.0 else it }
     val awake = when {
-        effFrac != null && effFrac in 0.01..0.999 -> max(0.0, asleep / effFrac - asleep)
+        heroStages != null -> heroStages.awake
+        sessionStageMins != null && sessionStageMins.awake > 0.0 -> sessionStageMins.awake
+        effFrac != null && effFrac in 0.01..0.999 && asleep > 0.0 ->
+            max(0.0, asleep / effFrac - asleep)
         latest.disturbances != null -> latest.disturbances * 6.0
         else -> 0.0
     }
@@ -3163,29 +3178,33 @@ internal fun buildSleepModel(
     }
     val hoursVsNeeded = metric(days) { d ->
         val need = imported.needMin[d.day] ?: needMin   // imported need wins per day
-        d.totalSleepMin?.takeIf { it > 0.0 && need > 0.0 }?.let { it / need * 100.0 }
+        RestScorer.canonicalAsleepMin(d)?.takeIf { it > 0.0 && need > 0.0 }?.let { it / need * 100.0 }
     }
     val restorative = metric(days) { d ->
-        val dp = d.deepMin; val rm = d.remMin; val sl = d.totalSleepMin
+        val dp = d.deepMin; val rm = d.remMin
+        val sl = RestScorer.canonicalAsleepMin(d)
         if (dp != null && rm != null && sl != null && sl > 0.0) (dp + rm) / sl * 100.0 else null
     }
     val respiratory = metric(days) { it.respRateBpm }
     val sleepDebt = run {
         val series = days.mapNotNull { d ->
             imported.debtMin[d.day]   // minutes, export-verbatim
-                ?: d.totalSleepMin?.takeIf { it > 0.0 && needMin > 0.0 }
+                ?: RestScorer.canonicalAsleepMin(d)?.takeIf { it > 0.0 && needMin > 0.0 }
                     ?.let { max(0.0, needMin - it) }   // APPROXIMATE fallback
         }
         Metric(series.lastOrNull(), mean(series), series)
     }
 
-    // Trend set = the most-recent nights with data (asleep totals, full history — latest-anchored,
-    // not the browsed night). Mirrors iOS's trailing trend over repo.days.
-    val trendRows = days.filter { (it.totalSleepMin ?: 0.0) > 0.0 }.takeLast(14)
-    val trendHours = trendRows.mapNotNull { it.totalSleepMin?.let { minutes -> minutes / 60.0 } }
+    // Trend set = the most-recent nights with canonical asleep (stage sum preferred), full history —
+    // latest-anchored, not the browsed night. Mirrors iOS's trailing trend over repo.days.
+    val trendRows = days.filter { (RestScorer.canonicalAsleepMin(it) ?: 0.0) > 0.0 }.takeLast(14)
+    val trendHours = trendRows.mapNotNull { RestScorer.canonicalAsleepMin(it)?.let { minutes -> minutes / 60.0 } }
     val trendNeedHours = trendRows.map { row -> ((imported.needMin[row.day] ?: needMin) / 60.0) }
+    // Per-night POSITIVE debt hours for the bar chart (same shape as before). Trailing headline
+    // below uses the ledger balance so Trends cannot show "0.0 h" while Sleep Debt ledger shows
+    // "≈7h 31m" for the same window (13 Jul screenshot SELF-CONSISTENCY).
     val trendDebtHours = trendRows.map { row ->
-        val sleptMin = row.totalSleepMin ?: 0.0
+        val sleptMin = RestScorer.canonicalAsleepMin(row) ?: 0.0
         val neededMin = imported.needMin[row.day] ?: needMin
         ((imported.debtMin[row.day] ?: max(0.0, neededMin - sleptMin)) / 60.0)
     }
@@ -3211,7 +3230,7 @@ internal fun buildSleepModel(
     // matches the debt TILE (both now read asleep totals over `days`), and mirrors iOS's
     // debtLedger over repo.days. (#242, #5)
     val sleepDebtLedger = SleepDebt.ledger(
-        series = days.map { it.day to it.totalSleepMin },
+        series = days.map { it.day to RestScorer.canonicalAsleepMin(it) },
         needHours = needMin / 60.0,
     )
 

--- a/android/app/src/main/java/com/noop/ui/StressScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/StressScreen.kt
@@ -177,7 +177,13 @@ private suspend fun loadDaytimeStress(vm: AppViewModel): DaytimeReadout {
         return DaytimeReadout(DaytimeStress.Result.EMPTY, null, null)
     }
     val rr = vm.repo.rrIntervals("my-whoop", from, nowSeconds, limit = 200_000)
-    val daytime = DaytimeStress.analyze(hr, rr, tzOffsetSeconds)
+    // Main-night sleep window(s) for night-floor shaping — late sleep past 06:00 must not
+    // pollute the waking calm reference (WHOOP Stress Monitor moon band through ~1pm).
+    val sleepWindows = runCatching {
+        vm.repo.sleepSessions("my-whoop", from, nowSeconds, limit = 64)
+            .map { it.effectiveStartTs to it.endTs }
+    }.getOrDefault(emptyList())
+    val daytime = DaytimeStress.analyze(hr, rr, tzOffsetSeconds, sleepWindows = sleepWindows)
     // ADDITIVE advanced readouts from the SAME `rr`. Each engine self-gates and returns null when
     // its requirement is not met, in which case its row is simply hidden in the UI.
     val si = StressIndex.components(rr)

--- a/android/app/src/test/java/com/noop/analytics/ChargeEffortRestScoringTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/ChargeEffortRestScoringTest.kt
@@ -198,12 +198,15 @@ class ChargeEffortRestScoringTest {
 
     @Test
     fun rest_weightConstants() {
-        assertEquals(0.50, RestScorer.wDuration, 0.0)
+        assertEquals(0.45, RestScorer.wDuration, 0.0)
         assertEquals(0.20, RestScorer.wEfficiency, 0.0)
-        assertEquals(0.20, RestScorer.wRestorative, 0.0)
+        assertEquals(0.25, RestScorer.wRestorative, 0.0)
         assertEquals(0.10, RestScorer.wConsistency, 0.0)
         assertEquals(8.0, RestScorer.defaultSleepNeedHours, 0.0)
         assertEquals(0.50, RestScorer.restorativeTargetShare, 0.0)
+        assertEquals(0.25, RestScorer.deepFloorFactor, 0.0)
+        assertEquals(0.12, RestScorer.durationQualityShareGate, 0.0)
+        assertEquals(0.70, RestScorer.durationQualityFloor, 0.0)
     }
 
     @Test
@@ -214,16 +217,16 @@ class ChargeEffortRestScoringTest {
     @Test
     fun rest_compositeWithoutConsistencyUsesNeutral() {
         // 8h asleep (dur 100), eff 0.92 (92), deep 1.5h + REM 2h = 3.5h restorative,
-        // share 0.4375 / 0.50 → 87.5. No consistency → NEUTRAL 50 at full weight (Swift parity: the
-        // term is NOT dropped/renormalized). Weights 0.50/0.20/0.20/0.10 sum to 1.0.
+        // share 0.4375 / 0.50 → 87.5. Deep share 18.75% ≥ target → deepFactor 1.0.
+        // No consistency → NEUTRAL 50. Weights 0.45/0.20/0.25/0.10. Scorer rounds to 2dp.
         val score = RestScorer.rest(
             asleepSeconds = 8 * 3600.0,
             efficiency = 0.92,
             deepSeconds = 1.5 * 3600.0,
             remSeconds = 2.0 * 3600.0,
         )!!
-        val expected = 100.0 * 0.50 + 92.0 * 0.20 + 87.5 * 0.20 + 50.0 * 0.10
-        assertEquals(expected, score, EPS)
+        // 100*0.45 + 92*0.20 + 87.5*0.25 + 50*0.10 = 90.275 → scorer rounds to 90.28
+        assertEquals(90.28, score, EPS)
     }
 
     @Test
@@ -235,21 +238,21 @@ class ChargeEffortRestScoringTest {
             remSeconds = 2.0 * 3600.0,
             consistency = 0.80,
         )!!
-        val expected = (100.0 * 0.50 + 92.0 * 0.20 + 87.5 * 0.20 + 80.0 * 0.10) / 1.0
-        assertEquals(expected, score, EPS)
+        // 100*0.45 + 92*0.20 + 87.5*0.25 + 80*0.10 = 93.275 → 93.28
+        assertEquals(93.28, score, EPS)
     }
 
     @Test
     fun rest_durationDominatesShortNight() {
         // 4h asleep against the 8h default → duration 50; eff 0.95 (95); restorative share 0.5 → 100.
-        // No consistency → neutral 50 at full weight (Swift parity). Weights sum to 1.0.
+        // Deep 1h / 4h = 25% ≥ target → deepFactor 1.0. Weights 0.45/0.20/0.25/0.10.
         val score = RestScorer.rest(
             asleepSeconds = 4 * 3600.0,
             efficiency = 0.95,
             deepSeconds = 1.0 * 3600.0,
             remSeconds = 1.0 * 3600.0,
         )!!
-        val expected = 50.0 * 0.50 + 95.0 * 0.20 + 100.0 * 0.20 + 50.0 * 0.10
+        val expected = 50.0 * 0.45 + 95.0 * 0.20 + 100.0 * 0.25 + 50.0 * 0.10
         assertEquals(expected, score, EPS)
     }
 
@@ -264,10 +267,9 @@ class ChargeEffortRestScoringTest {
     @Test
     fun rest_oversleepDurationClampsAtHundred() {
         // 10h asleep against an 8h need does not over-credit: duration clamps at 100.
+        // Deep 2h/10h = 20% ≥ target → deepFactor 1.0; restorative share 0.45 → score 90.
         val score = RestScorer.rest(10 * 3600.0, 0.90, 2.0 * 3600.0, 2.5 * 3600.0)!!
-        val restShare = (2.0 + 2.5) / 10.0 // 0.45 → /0.5 → 90
-        // No consistency → neutral 50 at full weight (Swift parity). Weights sum to 1.0.
-        val expected = 100.0 * 0.50 + 90.0 * 0.20 + (restShare / 0.50 * 100.0) * 0.20 + 50.0 * 0.10
+        val expected = 100.0 * 0.45 + 90.0 * 0.20 + 90.0 * 0.25 + 50.0 * 0.10
         assertEquals(expected, score, EPS)
     }
 

--- a/android/app/src/test/java/com/noop/analytics/DaytimeStressTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/DaytimeStressTest.kt
@@ -57,4 +57,28 @@ class DaytimeStressTest {
             withSleep.sustainedHigh,
         )
     }
+
+    @Test
+    fun lateSleepWindow_excludesMorningFromWakingReference() {
+        // 13 Jul shape: sleep through ~13:00. Without sleepWindows, hours 6–12 (low HR) pollute
+        // the waking calm reference. With a sleep window covering those hours, afternoon tip
+        // should not be inflated relative to a day that never included them in the reference.
+        val morningSleep = (6..12).flatMap { h -> hourHr(h, 52) }
+        val afternoon = listOf(14, 15, 16, 17, 18, 19).flatMap { h -> hourHr(h, 72) }
+        val noRr = emptyList<RrInterval>()
+        // Sleep window 06:00–13:00 wall clock (tz 0).
+        val window = listOf(6L * 3600L to 13L * 3600L)
+        val withWindow = DaytimeStress.analyze(morningSleep + afternoon, noRr, sleepWindows = window)
+        val afternoonOnly = DaytimeStress.analyze(afternoon, noRr)
+
+        val tipWith = withWindow.scored.lastOrNull { it.hour == 19 }?.level
+        val tipOnly = afternoonOnly.scored.lastOrNull { it.hour == 19 }?.level
+        assertNotNull(tipWith)
+        assertNotNull(tipOnly)
+        // Sleep-window shaping should keep the afternoon tip close to the afternoon-only day
+        // (not dragged high by treating morning sleep as waking calm).
+        assertEquals(tipOnly!!, tipWith!!, 0.35)
+        // Morning sleep hours may appear but must not drive sustained-high.
+        assertFalse(withWindow.sustainedHigh)
+    }
 }

--- a/android/app/src/test/java/com/noop/analytics/RestSleepSelfConsistencyTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/RestSleepSelfConsistencyTest.kt
@@ -1,0 +1,119 @@
+package com.noop.analytics
+
+import com.noop.data.DailyMetric
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Screenshot-grounded Rest / asleep self-consistency (13 Jul WHOOP vs NOOP).
+ *
+ * Hero "8h 37m" vs stages "7h 19m", Rest 73 "Strong" on 2% deep / 0% REM, and
+ * debt ledger vs Trends "0.0 h" all share one root: totalSleepMin diverging from
+ * stage sums, plus Rest overweighting duration when restorative collapses.
+ */
+class RestSleepSelfConsistencyTest {
+
+    private val eps = 1e-6
+
+    @Test
+    fun canonicalAsleepMin_prefersStageSumOverStaleTotal() {
+        val daily = DailyMetric(
+            deviceId = "t",
+            day = "2026-07-13",
+            totalSleepMin = 517.0, // "8h 37m" banked / fused
+            efficiency = 0.69,
+            deepMin = 10.0,
+            remMin = 0.0,
+            lightMin = 429.0, // 7h 19m stage sum
+        )
+        assertEquals(439.0, RestScorer.canonicalAsleepMin(daily)!!, eps)
+    }
+
+    @Test
+    fun canonicalAsleepMin_fallsBackToTotalWhenStagesMissing() {
+        val daily = DailyMetric(
+            deviceId = "t",
+            day = "2026-07-13",
+            totalSleepMin = 426.0,
+            efficiency = 0.76,
+        )
+        assertEquals(426.0, RestScorer.canonicalAsleepMin(daily)!!, eps)
+    }
+
+    @Test
+    fun restFromDaily_usesStageSumWhenTotalDisagrees() {
+        val daily = DailyMetric(
+            deviceId = "t",
+            day = "2026-07-13",
+            totalSleepMin = 517.0,
+            efficiency = 0.69,
+            deepMin = 10.0,
+            remMin = 0.0,
+            lightMin = 429.0,
+        )
+        val fromStages = RestScorer.rest(
+            asleepSeconds = 439.0 * 60.0,
+            efficiency = 0.69,
+            deepSeconds = 10.0 * 60.0,
+            remSeconds = 0.0,
+            sleepNeedHours = 7.5,
+        )!!
+        val fromDaily = RestScorer.restFromDaily(daily)!!
+        // restFromDaily uses default 8h need; compare shape via same need.
+        val fromDailyNeed = RestScorer.rest(
+            asleepSeconds = RestScorer.canonicalAsleepMin(daily)!! * 60.0,
+            efficiency = 0.69,
+            deepSeconds = 600.0,
+            remSeconds = 0.0,
+            sleepNeedHours = 8.0,
+        )!!
+        assertEquals(fromDailyNeed, fromDaily, eps)
+        assertTrue("stage-sum Rest must be below the old Strong/73 band ($fromStages)", fromStages < 65.0)
+        assertTrue("must stay above a total tank ($fromStages)", fromStages > 40.0)
+    }
+
+    @Test
+    fun rest_lowDeepNightDoesNotReadStrong() {
+        // Screenshot night: ~7h19m asleep, 69% eff, 10m deep, 0 REM, need 7.5h.
+        val score = RestScorer.rest(
+            asleepSeconds = 439.0 * 60.0,
+            efficiency = 0.69,
+            deepSeconds = 10.0 * 60.0,
+            remSeconds = 0.0,
+            sleepNeedHours = 7.5,
+        )
+        assertNotNull(score)
+        assertTrue("Rest=$score must not read Strong (≥70) on 2% deep / 0% REM", score!! < 65.0)
+        assertTrue("Rest=$score should not crater below Fair territory", score > 45.0)
+    }
+
+    @Test
+    fun rest_wellStructuredNightStillScoresHigh() {
+        val score = RestScorer.rest(
+            asleepSeconds = 8 * 3600.0,
+            efficiency = 0.90,
+            deepSeconds = 1.5 * 3600.0,
+            remSeconds = 2.0 * 3600.0,
+        )!!
+        assertTrue("healthy night Rest=$score should stay high", score >= 85.0)
+    }
+
+    @Test
+    fun sleepDebtLedger_matchesCanonicalSeries() {
+        val nights = listOf(
+            "2026-07-04" to DailyMetric("t", "2026-07-04", totalSleepMin = 500.0, deepMin = 40.0, remMin = 40.0, lightMin = 300.0),
+            "2026-07-05" to DailyMetric("t", "2026-07-05", totalSleepMin = 200.0, deepMin = 10.0, remMin = 10.0, lightMin = 180.0),
+            "2026-07-13" to DailyMetric("t", "2026-07-13", totalSleepMin = 517.0, deepMin = 10.0, remMin = 0.0, lightMin = 429.0),
+        )
+        val ledger = SleepDebt.ledger(
+            series = nights.map { it.first to RestScorer.canonicalAsleepMin(it.second) },
+            needHours = 7.5,
+        )
+        // Stage sums: 380 + 200 + 439 = 1019; need 3×450 = 1350; balance = −331 min ≈ −5.5h
+        assertEquals(3, ledger.nightCount)
+        assertTrue("ledger should show net debt (balance=${ledger.balanceMin})", ledger.isDebt)
+        assertEquals(439.0, ledger.nights.last().sleptMin, eps)
+    }
+}

--- a/android/app/src/test/java/com/noop/analytics/SleepStagerSparseDeepRemTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/SleepStagerSparseDeepRemTest.kt
@@ -1,0 +1,78 @@
+package com.noop.analytics
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Sparse-cardiac deep/REM reopen grounded in the 13 Jul screenshot (Deep 2%/10m, REM 0%
+ * vs WHOOP Deep 33% / REM 16%, "No movement detail for this night").
+ */
+class SleepStagerSparseDeepRemTest {
+
+    /** EpochFeatures: index, midTs, count, moveFrac, ckSleep, hr, hrVar, rmssd, sdnn, respRate, rrv, clock. */
+    private fun feat(
+        hr: Double,
+        moveFrac: Double = 0.0,
+        rmssd: Double = Double.NaN,
+        hrVar: Double = Double.NaN,
+        rrv: Double = Double.NaN,
+        clock: Double = 0.2,
+    ) = SleepStager.EpochFeatures(
+        index = 0, midTs = 0.0, count = 0.0, moveFrac = moveFrac, ckSleep = true,
+        hr = hr, hrVar = hrVar, rmssd = rmssd, sdnn = Double.NaN,
+        respRate = Double.NaN, rrv = rrv, clock = clock,
+    )
+
+    @Test
+    fun sparseCardiac_stillLowHr_classifiesDeepWithoutResp() {
+        val label = SleepStager.classifyOne(
+            feat(hr = 48.0, clock = 0.15),
+            hrLo = 52.0, hrHi = 70.0,
+            rmssdHi = 50.0, hrvarHi = 120.0,
+            rrvHi = 1.0, rrvLo = 0.5,
+            cardiacSparse = true,
+        )
+        assertEquals("deep", label)
+    }
+
+    @Test
+    fun sparseCardiac_lateStillHighHr_classifiesRemWithoutHrVar() {
+        val label = SleepStager.classifyOne(
+            feat(hr = 72.0, clock = 0.55),
+            hrLo = 52.0, hrHi = 70.0,
+            rmssdHi = 50.0, hrvarHi = 120.0,
+            rrvHi = 1.0, rrvLo = 0.5,
+            cardiacSparse = true,
+        )
+        assertEquals("rem", label)
+    }
+
+    @Test
+    fun denseNight_stillLowHr_classifiesDeep() {
+        val label = SleepStager.classifyOne(
+            feat(hr = 48.0, clock = 0.15),
+            hrLo = 52.0, hrHi = 70.0,
+            rmssdHi = 50.0, hrvarHi = 120.0,
+            rrvHi = 1.0, rrvLo = 0.5,
+            cardiacSparse = false,
+        )
+        assertEquals("deep", label)
+    }
+
+    @Test
+    fun denseNight_lateHighHrWithoutHrVarStaysLight() {
+        val label = SleepStager.classifyOne(
+            feat(hr = 72.0, clock = 0.55),
+            hrLo = 52.0, hrHi = 70.0,
+            rmssdHi = 50.0, hrvarHi = 120.0,
+            rrvHi = 1.0, rrvLo = 0.5,
+            cardiacSparse = false,
+        )
+        assertEquals("light", label)
+    }
+
+    @Test
+    fun onsetPersistEpochs_tightenedToFour() {
+        assertEquals(4, SleepStager.onsetPersistEpochs)
+    }
+}


### PR DESCRIPTION
## Summary
Screenshot-grounded sleep/stress algorithm pass (13 Jul WHOOP vs NOOP exports). Fold powered off — desk unit tests only.

- **Self-consistency:** `RestScorer.canonicalAsleepMin` prefers light+deep+REM over stale `totalSleepMin`; Sleep hero / debt / trends use it. Trends Sleep Debt trailing now shows the ledger balance (fixes 8h37m vs 7h19m and −7h31m vs 0.0h).
- **Rest weighting:** duration 0.45 / restorative 0.25, `deepFloorFactor` 0.25, steeper deep adequacy below half-target, duration quality gate when restorative share <12% — mediocre staged nights no longer read Rest Strong.
- **Staging:** `onsetPersistEpochs` 3→4; sparse-cardiac deep (still+low HR) and late REM (still+high HR) reopen without inventing stages from HC TIB.
- **Stress shape:** `DaytimeStress.sleepWindows` night-floor damp so late sleep past 06:00 does not pollute the waking calm reference; StressScreen wires session windows. Tip logistic not retuned from the single 1.4 vs 1.8 calibrating tip.
- **Swift parity:** Rest + SleepStager mirrored in StrandAnalytics.

## Test plan
- [x] `./gradlew :app:testFullDebugUnitTest --tests RestSleepSelfConsistencyTest --tests SleepStagerSparseDeepRemTest --tests DaytimeStressTest --tests ChargeEffortRestScoringTest --tests SleepDebtTest` (BUILD SUCCESSFUL)
- [ ] Fold on-device replay when phone is powered on
- [ ] Optional desk sleep-stage train/eval when bank pull is available

AI-assisted.