### PR TITLE
feat(android): make the Charge/Effort/Rest hero + Start-session card draggable too

### DIFF
--- a/android/app/src/main/java/com/noop/ui/TodayLayoutPrefs.kt
+++ b/android/app/src/main/java/com/noop/ui/TodayLayoutPrefs.kt
@@ -4,24 +4,27 @@ import android.content.Context
 
 // MARK: - Reorderable Today sections (#today-layout)
 //
-// The Today screen's below-the-hero sections (Synthesis, Key Metrics, Workouts, Heart Rate, Recovery
-// Vitals, Your Cards) rendered in one fixed order. This lets the user REORDER them, with the default being
-// the original order so nothing changes for anyone who never opens the editor. Display-only — no metric is
-// computed or stored differently; this only decides the SEQUENCE the already-built sections render in. The
-// Charge/Effort/Rest hero + intro/conditional cards stay pinned above this block.
+// The Today screen's sections — the Charge/Effort/Rest hero, the Start-session entry, Synthesis, Key
+// Metrics, Workouts, Heart Rate, Recovery Vitals, Your Cards — rendered in one fixed order. This lets the
+// user REORDER them, with the default being the original order so nothing changes for anyone who never
+// rearranges. Display-only — no metric is computed or stored differently; this only decides the SEQUENCE
+// the already-built sections render in.
 //
 // Stored as a single comma-joined string of section keys in SharedPreferences ("today.sectionOrder"), the
 // same mechanism KeyMetricPrefs/DashboardCards use. Mirrors the macOS TodayLayoutPrefs.swift +
 // @AppStorage("today.sectionOrder"). Every known section ALWAYS renders: unknown tokens are dropped, and
-// any known section missing from the saved order is APPENDED in default-order position — so a newly-added
-// section shows up rather than vanishing. This reorders, it never hides.
+// any known section missing from the saved order is INSERTED at its default-order position relative to the
+// saved sections — so a section added in a later version (e.g. the hero, which joined the reorderable set
+// after the first cut) surfaces where users expect it rather than teleporting to the bottom of an existing
+// saved order. This reorders, it never hides.
 
 /**
- * One reorderable Today section (below the pinned hero). The [raw] is the stable persisted identifier —
- * keep it byte-identical to the macOS `TodaySection` enum so a backup/restore reads the same layout on
- * either OS.
+ * One reorderable Today section. The [raw] is the stable persisted identifier — keep it byte-identical to
+ * the macOS `TodaySection` enum so a backup/restore reads the same layout on either OS.
  */
 enum class TodaySection(val raw: String, val title: String) {
+    HERO("hero", "Charge / Effort / Rest"),
+    LIVE_SESSION("liveSession", "Start session"),
     SYNTHESIS("synthesis", "Synthesis"),
     KEY_METRICS("keyMetrics", "Key Metrics"),
     WORKOUTS("workouts", "Workouts"),
@@ -34,7 +37,7 @@ enum class TodaySection(val raw: String, val title: String) {
 
         /** The original, hard-coded section order — the default when the layout isn't customised. */
         val defaultOrder: List<TodaySection> = listOf(
-            SYNTHESIS, KEY_METRICS, WORKOUTS, HEART_RATE, RECOVERY_VITALS, YOUR_CARDS,
+            HERO, LIVE_SESSION, SYNTHESIS, KEY_METRICS, WORKOUTS, HEART_RATE, RECOVERY_VITALS, YOUR_CARDS,
         )
     }
 }
@@ -64,19 +67,25 @@ object TodayLayoutPrefs {
     /**
      * Decode the stored string into the FULL ordered section list. An empty/unset string yields the
      * default order. Unknown tokens are ignored, duplicates collapsed, and any known section missing from
-     * the saved order is APPENDED in default-order position — so every section always renders and a newly
-     * added section can never be lost.
+     * the saved order is INSERTED at its default-order position relative to the saved sections (before the
+     * first saved section that follows it in the default order; appended when none does) — so every
+     * section always renders, and one added in a later app version surfaces where users expect it instead
+     * of teleporting to the bottom of an existing saved order (the hero joined the set after the first cut).
      */
     fun decodeOrder(raw: String?): List<TodaySection> {
         val trimmed = raw?.trim().orEmpty()
         if (trimmed.isEmpty()) return TodaySection.defaultOrder
-        val seen = LinkedHashSet<TodaySection>()
+        val saved = ArrayList<TodaySection>()
         trimmed.split(",").forEach { token ->
-            TodaySection.fromRaw(token.trim())?.let { seen.add(it) }
+            TodaySection.fromRaw(token.trim())?.let { if (it !in saved) saved.add(it) }
         }
-        // Append any known section not named in the saved order (e.g. one added in a later app version) so
-        // nothing vanishes — the reorder is order-only, never a hide.
-        TodaySection.defaultOrder.forEach { seen.add(it) }
-        return seen.toList()
+        if (saved.isEmpty()) return TodaySection.defaultOrder
+        for (missing in TodaySection.defaultOrder) {
+            if (missing in saved) continue
+            val defIdx = TodaySection.defaultOrder.indexOf(missing)
+            val insertAt = saved.indexOfFirst { TodaySection.defaultOrder.indexOf(it) > defIdx }
+            if (insertAt == -1) saved.add(missing) else saved.add(insertAt, missing)
+        }
+        return saved
     }
 }

--- a/android/app/src/main/java/com/noop/ui/TodayScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/TodayScreen.kt
@@ -1186,100 +1186,8 @@ fun TodayScreen(
 
         if (alert != null) item { IllnessBanner(alert!!) }
 
-        // HERO, three equal Charge / Effort / Rest liquid vessels in the compact pinned-dark card used by
-        // LiquidTodayView. Effort prefers today's live in-progress strain and falls back to the stored value
-        // (#402); the single floating badge names the real score sources without consuming card spacing.
-        // Staggered in as the score hero (index 1, after the header); each number counts up over its vessel.
-        // The day-cycle SCENE now sits at SCREEN level (the scaffold's `topBackground`, behind the header +
-        // these rings + bled full-width up behind the status bar), so the rings float DIRECTLY on the scene
-        // rather than in a card-clipped scene of their own, mirroring iOS, where TodayView moved the scene
-        // to a screen-level `SceneScreenBackground` and the hero dropped `.sceneHeroBackground()`.
-        item {
-        // The liquid hero CARD: a translucent near-black that floats over the day-of-sky so the vessels +
-        // white count-up numbers stay crisp — the card does the contrast work, not a muted sky. A rounded
-        // 26 corner + a faint white hairline give it the frosted-glass edge of the iOS liquid heroCard
-        // (heroFill = rgba(13,14,20,.80), stroke white@0.11). Mirrors the iOS LiquidTodayView heroCard.
-        Box(
-            modifier = Modifier
-                .fillMaxWidth()
-                // The shaped background stays clipped, while the source badge may straddle its top edge.
-                .background(
-                    LIQUID_HERO_FILL.copy(alpha = LIQUID_HERO_FILL.alpha * CardAppearance.opacity),
-                    RoundedCornerShape(LIQUID_HERO_RADIUS),
-                )
-                .border(1.dp, Color.White.copy(alpha = 0.11f * CardAppearance.opacity), RoundedCornerShape(LIQUID_HERO_RADIUS))
-                .staggeredAppear(1),
-        ) {
-            ScoreHeroRow(
-                day = displayMetric,
-                restScore = restScoreForDay,
-                recoveryCalibration = recoveryCalibration,
-                lastScoredCharge = lastScoredCharge,
-                effortScale = effortScale,
-                liveTodayStrain = if (selectedDayOffset == 0) liveTodayStrain else null,
-                heroSourceLabel = heroSourceLabel,
-                onScoreInfo = openGuide,
-                onChargeTap = { showChargeBreakdown = true },
-            )
-        }
-        }
-
-        // LIVE SESSIONS (beta): the compact "Start session · BETA" entry, directly under the hero. Today
-        // only (offset 0 — a session is a now-thing), gated on the Settings beta flag; a RUNNING session
-        // keeps the card visible regardless (it is the designed way back into the dismissed session dialog,
-        // see LiveSessionRunner's lifetime note). The card swaps itself to "Session running" / "Session
-        // ended" (it scopes the runner's per-second snapshot internally, like WorkoutInProgressCard's clock).
-        if (selectedDayOffset == 0 && (liveSessionsEnabled || activeLiveSession != null)) {
-            item {
-                LiveSessionEntryCard(
-                    onOpen = {
-                        // Only BEGIN when nothing is in flight: an active runner (running, or ended and
-                        // holding its unseen summary) is simply re-presented, never displaced — so a tap
-                        // can't silently discard a running session or a summary awaiting its "Done".
-                        if (LiveSessionRunner.active.value == null) {
-                            startOrResumeLiveSession(viewModel, context)
-                        }
-                        showLiveSession = true
-                    },
-                )
-            }
-        }
-
-        // Honest "why is Effort 0?" caption (#482/#480) — PINNED under the hero (NOT part of the
-        // reorderable block below): only when today's Effort is a real near-zero (HR present but never
-        // crossed the cardio zone), so a calm day reads as explained rather than broken. Mirrors the iOS
-        // effortZeroNote. Effort accrues over a day and must never visibly drop: floor the in-progress
-        // value at the day's already-earned strain (#489/#506). displayMetric for today is today's row or
-        // null, so this can't resurrect a stale day, only stop the gauge dropping below what's earned.
-        item {
-        val todayEffort = if (selectedDayOffset == 0) {
-            val liveStrain = liveTodayStrain; val stored = displayMetric?.strain
-            if (liveStrain != null && stored != null) maxOf(liveStrain, stored) else (liveStrain ?: stored)
-        } else null
-        if (todayEffort != null && todayEffort < 1.0) {
-            Row(
-                modifier = Modifier.padding(horizontal = 2.dp),
-                horizontalArrangement = Arrangement.spacedBy(6.dp),
-                verticalAlignment = Alignment.Top,
-            ) {
-                Icon(
-                    Icons.Filled.Info,
-                    contentDescription = null,
-                    tint = Palette.effortColor,
-                    modifier = Modifier.size(Metrics.iconSmall),
-                )
-                Text(
-                    "No cardio load yet. Effort builds once your heart rate climbs into your effort " +
-                        "zone (around 50% of your heart-rate reserve). A calm day honestly reads near zero.",
-                    style = NoopType.footnote,
-                    color = Palette.textTertiary,
-                )
-            }
-        }
-        }
-
-        // #today-layout: a small right-aligned affordance to REORDER the sections below. Opens a Today-local
-        // dialog (up/down arrows, like the Key-Metrics / Your-Cards editors) — no new nav destination.
+        // #today-layout: a small right-aligned affordance to REORDER the sections below (an alternative to
+        // holding + dragging the cards directly). Opens a Today-local dialog — no new nav destination.
         item {
             Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.End) {
                 TextButton(
@@ -1297,14 +1205,15 @@ fun TodayScreen(
             }
         }
 
-        // #today-layout: the below-hero sections render in the user's saved order (TodayLayoutPrefs); the
-        // Charge/Effort/Rest hero + intro/conditional cards above stay pinned. Each section is ONE keyed
-        // item wrapped in [TodayReorderableSection]: LONG-PRESS anywhere on a section and drag — it lifts
-        // (haptic), follows the finger, swaps neighbours as it crosses their centres (the screen-level
-        // frame loop also auto-scrolls at the viewport edges and keeps swapping while it does), and the
-        // order persists on drop. The stagger index follows the section's live position.
+        // #today-layout: EVERY Today section — including the Charge/Effort/Rest hero and the Start-session
+        // entry — renders in the user's saved order (TodayLayoutPrefs); only the top bar + this Arrange
+        // affordance stay pinned. Each section is ONE keyed item wrapped in [TodayReorderableSection]:
+        // LONG-PRESS anywhere on a section and drag — it lifts (haptic), follows the finger, swaps
+        // neighbours as it crosses their centres (the screen-level frame loop also auto-scrolls at the
+        // viewport edges and keeps swapping while it does), and the order persists on drop. The stagger
+        // index follows the section's live position.
         sectionOrder.forEachIndexed { pos, section ->
-            val stagger = pos + 2
+            val stagger = pos + 1
             item(key = TODAY_SECTION_KEY_PREFIX + section.raw) {
                 TodayReorderableSection(
                     section = section,
@@ -1313,6 +1222,92 @@ fun TodayScreen(
                     onDrop = { TodayLayoutPrefs.setOrder(context, sectionOrder) },
                 ) {
                     when (section) {
+                        // HERO, three equal Charge / Effort / Rest liquid vessels in the compact pinned-dark
+                        // card used by LiquidTodayView. Effort prefers today's live in-progress strain and
+                        // falls back to the stored value (#402); the floating badge names the real score
+                        // sources. The honest "why is Effort 0?" caption (#482/#480) travels WITH the hero
+                        // (folded into this section) so wherever the vessels sit, their explanation follows.
+                        TodaySection.HERO -> Column(
+                            modifier = Modifier.fillMaxWidth(),
+                            verticalArrangement = Arrangement.spacedBy(12.dp),
+                        ) {
+                            // The liquid hero CARD: a translucent near-black that floats over the day-of-sky
+                            // so the vessels + white count-up numbers stay crisp. A rounded 26 corner + a
+                            // faint white hairline give it the frosted-glass edge of the iOS liquid heroCard
+                            // (heroFill = rgba(13,14,20,.80), stroke white@0.11).
+                            Box(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .background(
+                                        LIQUID_HERO_FILL.copy(alpha = LIQUID_HERO_FILL.alpha * CardAppearance.opacity),
+                                        RoundedCornerShape(LIQUID_HERO_RADIUS),
+                                    )
+                                    .border(1.dp, Color.White.copy(alpha = 0.11f * CardAppearance.opacity), RoundedCornerShape(LIQUID_HERO_RADIUS))
+                                    .staggeredAppear(stagger),
+                            ) {
+                                ScoreHeroRow(
+                                    day = displayMetric,
+                                    restScore = restScoreForDay,
+                                    recoveryCalibration = recoveryCalibration,
+                                    lastScoredCharge = lastScoredCharge,
+                                    effortScale = effortScale,
+                                    liveTodayStrain = if (selectedDayOffset == 0) liveTodayStrain else null,
+                                    heroSourceLabel = heroSourceLabel,
+                                    onScoreInfo = openGuide,
+                                    onChargeTap = { showChargeBreakdown = true },
+                                )
+                            }
+                            // Honest "why is Effort 0?" caption — only when today's Effort is a real
+                            // near-zero (HR present but never crossed the cardio zone). Effort accrues over
+                            // a day and must never visibly drop: floor the in-progress value at the day's
+                            // already-earned strain (#489/#506).
+                            val todayEffort = if (selectedDayOffset == 0) {
+                                val liveStrain = liveTodayStrain
+                                val stored = displayMetric?.strain
+                                if (liveStrain != null && stored != null) maxOf(liveStrain, stored) else (liveStrain ?: stored)
+                            } else null
+                            if (todayEffort != null && todayEffort < 1.0) {
+                                Row(
+                                    modifier = Modifier.padding(horizontal = 2.dp),
+                                    horizontalArrangement = Arrangement.spacedBy(6.dp),
+                                    verticalAlignment = Alignment.Top,
+                                ) {
+                                    Icon(
+                                        Icons.Filled.Info,
+                                        contentDescription = null,
+                                        tint = Palette.effortColor,
+                                        modifier = Modifier.size(Metrics.iconSmall),
+                                    )
+                                    Text(
+                                        "No cardio load yet. Effort builds once your heart rate climbs into your effort " +
+                                            "zone (around 50% of your heart-rate reserve). A calm day honestly reads near zero.",
+                                        style = NoopType.footnote,
+                                        color = Palette.textTertiary,
+                                    )
+                                }
+                            }
+                        }
+                        // LIVE SESSIONS (beta): the compact "Start session · BETA" entry. Today only
+                        // (offset 0 — a session is a now-thing), gated on the Settings beta flag; a RUNNING
+                        // session keeps the card visible regardless (it is the designed way back into the
+                        // dismissed session dialog, see LiveSessionRunner's lifetime note). Renders nothing
+                        // when gated off — the section keeps its slot in the saved order.
+                        TodaySection.LIVE_SESSION -> {
+                            if (selectedDayOffset == 0 && (liveSessionsEnabled || activeLiveSession != null)) {
+                                LiveSessionEntryCard(
+                                    onOpen = {
+                                        // Only BEGIN when nothing is in flight: an active runner (running, or
+                                        // ended and holding its unseen summary) is simply re-presented, never
+                                        // displaced — so a tap can't silently discard a running session or a
+                                        // summary awaiting its "Done".
+                                        if (LiveSessionRunner.active.value == null) {
+                                            startOrResumeLiveSession(viewModel, context)
+                                        }
+                                        showLiveSession = true
+                                    },
+                                )
+                            }
+                        }
                         // The plain-English read-out, the Charge-tinted Synthesis card. Mirrors the iOS
                         // Synthesis InsightCard; carries the last scored day's read at the rollover (#543).
                         TodaySection.SYNTHESIS -> Box(modifier = Modifier.fillMaxWidth().staggeredAppear(stagger)) {
@@ -3598,8 +3593,7 @@ private fun TodayLayoutEditorDialog(
                 Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
                     Text("Arrange Today", style = NoopType.title2, color = Palette.textPrimary)
                     Text(
-                        "Hold a section and drag it to reorder. Your Charge / Effort / Rest scores stay " +
-                            "pinned at the top.",
+                        "Hold a section and drag it to reorder — here, or directly on the Today cards.",
                         style = NoopType.subhead,
                         color = Palette.textSecondary,
                     )

--- a/android/app/src/main/java/com/noop/ui/TodayScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/TodayScreen.kt
@@ -1214,6 +1214,22 @@ fun TodayScreen(
         // index follows the section's live position.
         sectionOrder.forEachIndexed { pos, section ->
             val stagger = pos + 1
+            // A gated-off section (Start session outside today / beta-off; Your Cards outside today or
+            // empty) emits NO item at all: an always-present zero-height item would double the 12dp row
+            // gap around its slot — visible on the DEFAULT layout, where Start session sits right under
+            // the hero and the beta flag is off for most users. The section keeps its place in the saved
+            // order; its item simply reappears when eligible.
+            val visibleDashboardCards = enabledDashboardCards.filter {
+                it != DashboardCard.HYDRATION || hydrationEnabled
+            }
+            val sectionVisible = when (section) {
+                TodaySection.LIVE_SESSION ->
+                    selectedDayOffset == 0 && (liveSessionsEnabled || activeLiveSession != null)
+                TodaySection.YOUR_CARDS ->
+                    selectedDayOffset == 0 && visibleDashboardCards.isNotEmpty()
+                else -> true
+            }
+            if (!sectionVisible) return@forEachIndexed
             item(key = TODAY_SECTION_KEY_PREFIX + section.raw) {
                 TodayReorderableSection(
                     section = section,
@@ -1290,24 +1306,20 @@ fun TodayScreen(
                         // LIVE SESSIONS (beta): the compact "Start session · BETA" entry. Today only
                         // (offset 0 — a session is a now-thing), gated on the Settings beta flag; a RUNNING
                         // session keeps the card visible regardless (it is the designed way back into the
-                        // dismissed session dialog, see LiveSessionRunner's lifetime note). Renders nothing
-                        // when gated off — the section keeps its slot in the saved order.
-                        TodaySection.LIVE_SESSION -> {
-                            if (selectedDayOffset == 0 && (liveSessionsEnabled || activeLiveSession != null)) {
-                                LiveSessionEntryCard(
-                                    onOpen = {
-                                        // Only BEGIN when nothing is in flight: an active runner (running, or
-                                        // ended and holding its unseen summary) is simply re-presented, never
-                                        // displaced — so a tap can't silently discard a running session or a
-                                        // summary awaiting its "Done".
-                                        if (LiveSessionRunner.active.value == null) {
-                                            startOrResumeLiveSession(viewModel, context)
-                                        }
-                                        showLiveSession = true
-                                    },
-                                )
-                            }
-                        }
+                        // dismissed session dialog, see LiveSessionRunner's lifetime note). The gate lives
+                        // at the loop level (sectionVisible) so a gated-off section emits no item.
+                        TodaySection.LIVE_SESSION -> LiveSessionEntryCard(
+                            onOpen = {
+                                // Only BEGIN when nothing is in flight: an active runner (running, or ended
+                                // and holding its unseen summary) is simply re-presented, never displaced —
+                                // so a tap can't silently discard a running session or a summary awaiting
+                                // its "Done".
+                                if (LiveSessionRunner.active.value == null) {
+                                    startOrResumeLiveSession(viewModel, context)
+                                }
+                                showLiveSession = true
+                            },
+                        )
                         // The plain-English read-out, the Charge-tinted Synthesis card. Mirrors the iOS
                         // Synthesis InsightCard; carries the last scored day's read at the rollover (#543).
                         TodaySection.SYNTHESIS -> Box(modifier = Modifier.fillMaxWidth().staggeredAppear(stagger)) {
@@ -1392,35 +1404,30 @@ fun TodayScreen(
                         // YOUR CARDS, the user-customisable dashboard (WHOOP "My Dashboard"). Hydration is
                         // hidden when its tracking is OFF (the editor still offers it, so the choice
                         // persists). Per-field carried-day fallbacks (#543) stop rollover "No Data" blanks.
-                        TodaySection.YOUR_CARDS -> {
-                            val visibleDashboardCards = enabledDashboardCards.filter {
-                                it != DashboardCard.HYDRATION || hydrationEnabled
-                            }
-                            if (selectedDayOffset == 0 && visibleDashboardCards.isNotEmpty()) {
-                                YourCardsSection(
-                                    cards = visibleDashboardCards,
-                                    day = displayMetric,
-                                    carriedDay = lastScoredRecoveryDay,
-                                    vitalsDay = lastVitalsDay,
-                                    spo2Day = lastSpo2Day,
-                                    skinTempDay = lastSkinTempDay,
-                                    stress = stressToday,
-                                    fitnessAge = fitnessAgeToday,
-                                    vitality = vitalityToday,
-                                    importedStepsForDay = importedStepsForDay,
-                                    estimatedStepsForDay = stepsEstForDay,
-                                    latestActiveKcal = latestActiveKcal,
-                                    hydrationTotalMl = hydrationTotalMl,
-                                    hydrationGoalMl = hydrationGoalMl,
-                                    onOpenHydration = onOpenHydration,
-                                    onOpenStress = onOpenStress,
-                                    onOpenMetric = onOpenMetric,
-                                    onOpenSleep = onOpenSleep,
-                                    onOpenCoupled = onOpenCoupled,
-                                    onCustomise = { showDashboardEditor = true },
-                                )
-                            }
-                        }
+                        // The today/non-empty gate lives at the loop level (sectionVisible) so a gated-off
+                        // section emits no item; visibleDashboardCards is the loop-level filtered list.
+                        TodaySection.YOUR_CARDS -> YourCardsSection(
+                            cards = visibleDashboardCards,
+                            day = displayMetric,
+                            carriedDay = lastScoredRecoveryDay,
+                            vitalsDay = lastVitalsDay,
+                            spo2Day = lastSpo2Day,
+                            skinTempDay = lastSkinTempDay,
+                            stress = stressToday,
+                            fitnessAge = fitnessAgeToday,
+                            vitality = vitalityToday,
+                            importedStepsForDay = importedStepsForDay,
+                            estimatedStepsForDay = stepsEstForDay,
+                            latestActiveKcal = latestActiveKcal,
+                            hydrationTotalMl = hydrationTotalMl,
+                            hydrationGoalMl = hydrationGoalMl,
+                            onOpenHydration = onOpenHydration,
+                            onOpenStress = onOpenStress,
+                            onOpenMetric = onOpenMetric,
+                            onOpenSleep = onOpenSleep,
+                            onOpenCoupled = onOpenCoupled,
+                            onCustomise = { showDashboardEditor = true },
+                        )
                     }
                 }
             }

--- a/android/app/src/test/java/com/noop/ui/TodayLayoutPrefsTest.kt
+++ b/android/app/src/test/java/com/noop/ui/TodayLayoutPrefsTest.kt
@@ -5,8 +5,9 @@ import org.junit.Test
 
 /**
  * Pure-logic coverage for the Today section-order persistence (#today-layout): default order, encode/decode
- * round-trip, reorder, and the never-hide "append missing section" invariant. No Android context — these
- * are the pure functions the editor + Today render rely on. Mirrors the macOS TodayLayoutPrefs tests.
+ * round-trip, reorder, and the never-hide "insert missing section at its default position" invariant. No
+ * Android context — these are the pure functions the editor + Today render rely on. Mirrors the macOS
+ * TodayLayoutPrefs tests.
  */
 class TodayLayoutPrefsTest {
 
@@ -20,27 +21,50 @@ class TodayLayoutPrefsTest {
     @Test
     fun encodeDecode_roundTripsAReorderedList() {
         val reordered = listOf(
-            TodaySection.YOUR_CARDS, TodaySection.HEART_RATE, TodaySection.SYNTHESIS,
-            TodaySection.KEY_METRICS, TodaySection.WORKOUTS, TodaySection.RECOVERY_VITALS,
+            TodaySection.HEART_RATE, TodaySection.HERO, TodaySection.YOUR_CARDS,
+            TodaySection.LIVE_SESSION, TodaySection.SYNTHESIS, TodaySection.KEY_METRICS,
+            TodaySection.WORKOUTS, TodaySection.RECOVERY_VITALS,
         )
         val encoded = TodayLayoutPrefs.encode(reordered)
-        assertEquals("yourCards,heartRate,synthesis,keyMetrics,workouts,recoveryVitals", encoded)
+        assertEquals(
+            "heartRate,hero,yourCards,liveSession,synthesis,keyMetrics,workouts,recoveryVitals",
+            encoded,
+        )
         assertEquals(reordered, TodayLayoutPrefs.decodeOrder(encoded))
     }
 
+    /** The v1 upgrade path: an order saved by the FIRST cut (6 sections — no hero/liveSession, which were
+     *  pinned then) must surface the two new sections at the TOP (their default position), not teleport
+     *  them to the bottom of the user's saved order. */
     @Test
-    fun decode_appendsAnyKnownSectionMissingFromSavedOrder_neverHides() {
-        // A saved order that omits WORKOUTS + YOUR_CARDS (e.g. saved by an older build) must still surface
-        // them — appended in default-order position — so no section ever vanishes.
+    fun decode_savedOrderFromFirstCut_insertsHeroAndSessionAtTheirDefaultPosition() {
+        val firstCut = "synthesis,keyMetrics,workouts,heartRate,recoveryVitals,yourCards"
+        assertEquals(
+            listOf(
+                TodaySection.HERO, TodaySection.LIVE_SESSION,
+                TodaySection.SYNTHESIS, TodaySection.KEY_METRICS, TodaySection.WORKOUTS,
+                TodaySection.HEART_RATE, TodaySection.RECOVERY_VITALS, TodaySection.YOUR_CARDS,
+            ),
+            TodayLayoutPrefs.decodeOrder(firstCut),
+        )
+    }
+
+    @Test
+    fun decode_insertsAnyMissingSectionAtItsDefaultPositionRelativeToSaved_neverHides() {
+        // A saved order that omits WORKOUTS + YOUR_CARDS (and the newer hero/liveSession) must still
+        // surface all of them, each before the first saved section that follows it in the default order.
         val partial = "heartRate,synthesis,keyMetrics,recoveryVitals"
         val decoded = TodayLayoutPrefs.decodeOrder(partial)
         assertEquals(TodaySection.entries.size, decoded.size)
         assertEquals(
             listOf(
+                // hero(0), liveSession(1), workouts(4) all precede heartRate(5) in default order, so all
+                // insert before the saved heartRate, in default order among themselves:
+                TodaySection.HERO, TodaySection.LIVE_SESSION, TodaySection.WORKOUTS,
                 TodaySection.HEART_RATE, TodaySection.SYNTHESIS, TodaySection.KEY_METRICS,
                 TodaySection.RECOVERY_VITALS,
-                // appended (missing) in default order:
-                TodaySection.WORKOUTS, TodaySection.YOUR_CARDS,
+                // yourCards(7) follows everything saved → appended:
+                TodaySection.YOUR_CARDS,
             ),
             decoded,
         )
@@ -50,12 +74,14 @@ class TodayLayoutPrefsTest {
     fun decode_dropsUnknownTokensAndCollapsesDuplicates() {
         val messy = "yourCards,BOGUS,yourCards,heartRate, ,heartRate"
         val decoded = TodayLayoutPrefs.decodeOrder(messy)
-        // yourCards + heartRate resolved once each (first occurrence), then the remaining defaults appended.
+        assertEquals(TodaySection.entries.size, decoded.size)
         assertEquals(
             listOf(
+                // Every missing section's default index precedes yourCards(7), so each inserts before it,
+                // accumulating in default order; the saved yourCards→heartRate order is preserved at the end.
+                TodaySection.HERO, TodaySection.LIVE_SESSION, TodaySection.SYNTHESIS,
+                TodaySection.KEY_METRICS, TodaySection.WORKOUTS, TodaySection.RECOVERY_VITALS,
                 TodaySection.YOUR_CARDS, TodaySection.HEART_RATE,
-                TodaySection.SYNTHESIS, TodaySection.KEY_METRICS,
-                TodaySection.WORKOUTS, TodaySection.RECOVERY_VITALS,
             ),
             decoded,
         )
@@ -63,10 +89,7 @@ class TodayLayoutPrefsTest {
 
     @Test
     fun allJunk_yieldsDefaultOrder() {
-        assertEquals(TodaySection.defaultOrder, TodayLayoutPrefs.decodeOrder("nope,,zzz").let {
-            // all-unknown tokens leave `seen` empty, then every default is appended → default order
-            it
-        })
+        assertEquals(TodaySection.defaultOrder, TodayLayoutPrefs.decodeOrder("nope,,zzz"))
     }
 
     @Test
@@ -75,7 +98,10 @@ class TodayLayoutPrefsTest {
         assertEquals("raw keys must be unique (they're the persisted identity)", raws.size, raws.toSet().size)
         // Pin the exact wire strings — they cross the .noopbak boundary and must match macOS byte-for-byte.
         assertEquals(
-            listOf("synthesis", "keyMetrics", "workouts", "heartRate", "recoveryVitals", "yourCards"),
+            listOf(
+                "hero", "liveSession", "synthesis", "keyMetrics",
+                "workouts", "heartRate", "recoveryVitals", "yourCards",
+            ),
             raws,
         )
     }


### PR DESCRIPTION
Extends the Today hold-to-drag reorder (#420, feel-tuned in #424) to the last two fixed sections, per tester request: **the Charge/Effort/Rest hero and the Start-session entry are now their own draggable sections** — hold and drag them anywhere; order persists. Only the top bar + the small Arrange affordance stay pinned.

## How
- `TodaySection` gains **HERO** + **LIVE_SESSION** (raw keys `hero`/`liveSession`); default order = the current visual order, so nothing moves for anyone who hasn't rearranged.
- **Saved-order migration:** `decodeOrder` now *inserts* a missing section at its default position relative to the saved sections instead of appending — an order saved by the first cut (6 sections) surfaces the hero at the **top** where users expect it, not teleported to the bottom. Pinned by a new migration test.
- The **"why is Effort 0?" caption travels with the hero** (folded into its section), so the explanation follows the vessels wherever they sit.
- LIVE_SESSION renders empty when gated off (beta flag / non-today) and keeps its slot — same pattern as Your Cards.
- The Arrange sheet lists all 8; its subtitle updated (the scores no longer 'stay pinned').

## Verification
`compileFullDebugKotlin` green; `TodayLayoutPrefsTest` **7/7** (incl. the first-cut migration) + `TodayExplainabilityTest` green; all 8 sections verified to render exactly once; drag machinery untouched (this only adds branches + the enum).

## Caveats
- The Arrange button now sits between the top bar and the (movable) hero — it can't live 'below the hero' when the hero can move. Visual check on-device.
- Android only; iOS twin still the fast-follow.