### PR TITLE
Add Today pull-to-sync

### DIFF
--- a/android/app/src/main/java/com/noop/ui/TodayScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/TodayScreen.kt
@@ -58,6 +58,7 @@ import androidx.compose.material.icons.filled.Warning
 import androidx.compose.material.icons.outlined.Info
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -66,6 +67,8 @@ import androidx.compose.material3.Switch
 import androidx.compose.material3.SwitchDefaults
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
+import androidx.compose.material3.pulltorefresh.PullToRefreshContainer
+import androidx.compose.material3.pulltorefresh.rememberPullToRefreshState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
@@ -98,6 +101,7 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.withFrameNanos
 import kotlinx.coroutines.launch
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.input.pointer.PointerEventPass
 import androidx.compose.ui.input.pointer.PointerInputScope
 import androidx.compose.ui.input.pointer.pointerInput
@@ -147,6 +151,7 @@ import com.noop.analytics.RestScorer
 import com.noop.analytics.ScoreConfidence
 import com.noop.analytics.StepsEstimateEngine
 import com.noop.analytics.StrainScorer
+import com.noop.ble.WhoopBleClient
 import com.noop.data.AppleDaily
 import com.noop.data.DailyMetric
 import com.noop.data.HrBucket
@@ -224,6 +229,7 @@ private val LIQUID_PURPLE: Color = Color(red = 0x9b / 255f, green = 0x7b / 255f,
  */
 private data class TodayLiveSnapshot(
     val connected: Boolean,
+    val bonded: Boolean,
     val hrStreaming: Boolean,
     val lastSyncAt: Long?,
     val backfilling: Boolean,
@@ -238,6 +244,7 @@ private data class TodayLiveSnapshot(
     val charging: Boolean?,
 )
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun TodayScreen(
     viewModel: AppViewModel,
@@ -289,6 +296,7 @@ fun TodayScreen(
             val s = live
             TodayLiveSnapshot(
                 connected = s.connected,
+                bonded = s.bonded,
                 hrStreaming = s.heartRate != null,
                 lastSyncAt = s.lastSyncAt,
                 backfilling = s.backfilling,
@@ -1041,7 +1049,21 @@ fun TodayScreen(
             onHorizontalDrag = { _, dragAmount -> accumulatedX += dragAmount },
         )
     }
+    val canPullToSync = todayPullToSyncEnabled(liveSnap.connected, liveSnap.bonded, liveSnap.backfilling)
+    val pullToSyncState = rememberPullToRefreshState(enabled = { canPullToSync })
+    LaunchedEffect(pullToSyncState.isRefreshing, canPullToSync) {
+        if (pullToSyncState.isRefreshing) {
+            if (canPullToSync) viewModel.syncNow()
+            // Historical offloads can run for a while; the existing sync chip/note owns ongoing progress.
+            pullToSyncState.endRefresh()
+        }
+    }
 
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .nestedScroll(pullToSyncState.nestedScrollConnection),
+    ) {
     LazyScreenScaffold(
         modifier = daySwipeModifier,
         // title = null suppresses the big scaffold header (the nullable-title path); the compact
@@ -1491,6 +1513,11 @@ fun TodayScreen(
                 onToggle = { sourcesExpanded = !sourcesExpanded },
             )
         }
+    }
+        PullToRefreshContainer(
+            state = pullToSyncState,
+            modifier = Modifier.align(Alignment.TopCenter),
+        )
     }
 
     // Scoring guide sheet, full-screen Dialog, mirroring Settings' What's-new presentation. Opened
@@ -4585,6 +4612,14 @@ internal fun scoreHeroSourceLabel(
         deviceId = deviceId,
     )
 }
+
+/** Today pull-to-sync mirrors the BLE client's manual-sync guard, so the gesture never starts a sync while
+ *  disconnected, still bonding, or already offloading. Kept pure for the UI-specific contract test. */
+internal fun todayPullToSyncEnabled(
+    connected: Boolean,
+    bonded: Boolean,
+    backfilling: Boolean,
+): Boolean = WhoopBleClient.canRequestSync(connected, bonded, backfilling)
 
 /** The tint for a per-metric provenance badge, keyed on the resolved LABEL, gold for Whoop, cyan for
  *  Apple Health, the positive status hue for on-device (and anything else). Matches the Data Sources

--- a/android/app/src/test/java/com/noop/ui/TodayExplainabilityTest.kt
+++ b/android/app/src/test/java/com/noop/ui/TodayExplainabilityTest.kt
@@ -3,6 +3,7 @@ package com.noop.ui
 import com.noop.analytics.FusionSource
 import com.noop.data.DailyMetric
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -362,5 +363,14 @@ class TodayExplainabilityTest {
                 usesCarriedRecovery = false,
             ),
         )
+    }
+
+    @Test
+    fun pullToSync_onlyEnabledWhenConnectedBondedAndIdle() {
+        assertTrue(todayPullToSyncEnabled(connected = true, bonded = true, backfilling = false))
+
+        assertFalse(todayPullToSyncEnabled(connected = false, bonded = true, backfilling = false))
+        assertFalse(todayPullToSyncEnabled(connected = true, bonded = false, backfilling = false))
+        assertFalse(todayPullToSyncEnabled(connected = true, bonded = true, backfilling = true))
     }
 }


### PR DESCRIPTION
## Summary

- Add pull-to-refresh on Android Today to request a manual strap history sync.
- Gate the gesture with the same connected + bonded + not-backfilling rule used by the BLE client.
- Keep the refresh spinner short-lived and let the existing syncing note/chip show longer offload progress.
- Add a focused Today explainability test for the pull-to-sync gate.

## Why

Fixes #334.

Today already surfaces sync progress, but the user had to leave the home screen and find another explicit sync action to request fresh strap history. The backend entry point already exists (`AppViewModel.syncNow()` -> `WhoopBleClient.syncNow()`); this wires the Today gesture to that safe manual-sync path.

The UI does not try to bypass BLE readiness. If the strap is disconnected, not fully bonded yet, or already backfilling, pulling does not start a new sync or leave a spinner hanging.

## Test

- `cd android && ./gradlew :app:testFullDebugUnitTest --tests 'com.noop.ui.TodayExplainabilityTest'`
