### PR TITLE
feat(ios/macos): Today section reorder parity — persisted order + Arrange sheet

### DIFF
--- a/Strand/Data/TodayLayoutPrefs.swift
+++ b/Strand/Data/TodayLayoutPrefs.swift
@@ -78,9 +78,15 @@ enum TodayLayoutPrefs {
             }
         }
         guard !saved.isEmpty else { return TodaySection.defaultOrder }
-        for missing in TodaySection.defaultOrder where !saved.contains(missing) {
-            let defIdx = TodaySection.defaultOrder.firstIndex(of: missing)!
-            let insertAt = saved.firstIndex { TodaySection.defaultOrder.firstIndex(of: $0)! > defIdx }
+        // Iterate allCases (not defaultOrder) so a future case accidentally left out of defaultOrder can
+        // never be silently hidden; a section without a default index sorts after everything (no crash —
+        // the Kotlin twin's indexOf(-1) degrades the same way). defaultOrder covering allCases is pinned
+        // by TodayLayoutPrefsTests on both platforms.
+        func defIdx(_ s: TodaySection) -> Int {
+            TodaySection.defaultOrder.firstIndex(of: s) ?? TodaySection.defaultOrder.count
+        }
+        for missing in TodaySection.allCases where !saved.contains(missing) {
+            let insertAt = saved.firstIndex { defIdx($0) > defIdx(missing) }
             if let insertAt { saved.insert(missing, at: insertAt) } else { saved.append(missing) }
         }
         return saved

--- a/Strand/Data/TodayLayoutPrefs.swift
+++ b/Strand/Data/TodayLayoutPrefs.swift
@@ -1,0 +1,88 @@
+import Foundation
+import SwiftUI
+
+// MARK: - Reorderable Today sections (#today-layout)
+//
+// The liquid Today's sections — the Charge/Effort/Rest hero, the Start-session entry, Synthesis, Key
+// Metrics, Workouts, Heart Rate, Recovery Vitals, Your Cards — rendered in one fixed order. This lets the
+// user REORDER them, with the default being the original order so nothing changes for anyone who never
+// rearranges. Display-only — no metric is computed or stored differently; this only decides the SEQUENCE
+// the already-built sections render in.
+//
+// Stored as a single comma-joined string of section keys in @AppStorage("today.sectionOrder"), the same
+// mechanism KeyMetricPrefs uses. The Android side mirrors this byte-identically in TodayLayoutPrefs.kt
+// (SharedPreferences "today.sectionOrder"). Every known section ALWAYS renders: unknown tokens are dropped,
+// and any known section missing from the saved order is INSERTED at its default-order position relative to
+// the saved sections — so a section added in a later version surfaces where users expect it rather than
+// teleporting to the bottom of an existing saved order. This reorders, it never hides.
+
+/// One reorderable Today section. The rawValue is the stable persisted identifier — keep it byte-identical
+/// to the Android `TodaySection` enum so a backup/restore reads the same layout on either OS.
+enum TodaySection: String, CaseIterable, Identifiable {
+    case hero
+    case liveSession
+    case synthesis
+    case keyMetrics
+    case workouts
+    case heartRate
+    case recoveryVitals
+    case yourCards
+
+    var id: String { rawValue }
+
+    /// The section's display label in the Arrange sheet — matches the Android `TodaySection.title`.
+    var title: String {
+        switch self {
+        case .hero:           return String(localized: "Charge / Effort / Rest")
+        case .liveSession:    return String(localized: "Start session")
+        case .synthesis:      return String(localized: "Synthesis")
+        case .keyMetrics:     return String(localized: "Key Metrics")
+        case .workouts:       return String(localized: "Workouts")
+        case .heartRate:      return String(localized: "Heart Rate")
+        case .recoveryVitals: return String(localized: "Recovery Vitals")
+        case .yourCards:      return String(localized: "Your Cards")
+        }
+    }
+
+    /// The original, hard-coded section order — the default when the layout isn't customised.
+    static let defaultOrder: [TodaySection] = [
+        .hero, .liveSession, .synthesis, .keyMetrics, .workouts, .heartRate, .recoveryVitals, .yourCards,
+    ]
+}
+
+/// Display-only persistence for the Today section order. Holds the sections in display order; every known
+/// section always renders (a missing one is inserted at its default position), so this reorders but never
+/// hides. Mirrors the Android `TodayLayoutPrefs` (SharedPreferences "today.sectionOrder") byte-for-byte.
+enum TodayLayoutPrefs {
+    /// UserDefaults key — a comma-joined list of `TodaySection` rawValues in display order.
+    static let orderKey = "today.sectionOrder"
+
+    /// Encode an ordered section list into the stored comma-joined string.
+    static func encode(_ sections: [TodaySection]) -> String {
+        sections.map(\.rawValue).joined(separator: ",")
+    }
+
+    /// Decode the stored string into the FULL ordered section list. An empty/unset string yields the
+    /// default order. Unknown tokens are ignored, duplicates collapsed, and any known section missing from
+    /// the saved order is INSERTED at its default-order position relative to the saved sections (before the
+    /// first saved section that follows it in the default order; appended when none does) — so every
+    /// section always renders, and one added in a later app version surfaces where users expect it instead
+    /// of teleporting to the bottom of an existing saved order. Twin of the Kotlin `decodeOrder`.
+    static func decodeOrder(_ raw: String) -> [TodaySection] {
+        let trimmed = raw.trimmingCharacters(in: .whitespaces)
+        guard !trimmed.isEmpty else { return TodaySection.defaultOrder }
+        var saved: [TodaySection] = []
+        for token in trimmed.split(separator: ",") {
+            if let s = TodaySection(rawValue: token.trimmingCharacters(in: .whitespaces)), !saved.contains(s) {
+                saved.append(s)
+            }
+        }
+        guard !saved.isEmpty else { return TodaySection.defaultOrder }
+        for missing in TodaySection.defaultOrder where !saved.contains(missing) {
+            let defIdx = TodaySection.defaultOrder.firstIndex(of: missing)!
+            let insertAt = saved.firstIndex { TodaySection.defaultOrder.firstIndex(of: $0)! > defIdx }
+            if let insertAt { saved.insert(missing, at: insertAt) } else { saved.append(missing) }
+        }
+        return saved
+    }
+}

--- a/Strand/Liquid/LiquidTodayView.swift
+++ b/Strand/Liquid/LiquidTodayView.swift
@@ -47,6 +47,12 @@ struct LiquidTodayView: View {
     /// Live Sessions (silent guardian) beta gate — the SAME key the Settings toggle writes. Default ON
     /// (the entry is BETA-labelled in-UI); off removes the Start-session control entirely.
     @AppStorage(LiveSessionPrefs.betaKey) private var liveSessionsBeta = true
+    // #today-layout (parity with Android): the user-chosen section order, persisted under the byte-identical
+    // "today.sectionOrder" key the Android TodayLayoutPrefs uses. Reordered via the Arrange sheet (native
+    // drag-to-reorder rows); every section always renders (decode inserts a missing one at its default spot).
+    @AppStorage(TodayLayoutPrefs.orderKey) private var sectionOrderRaw = ""
+    @State private var showArrangeSheet = false
+    private var sectionOrder: [TodaySection] { TodayLayoutPrefs.decodeOrder(sectionOrderRaw) }
 
     // day navigation (0 = today, 1 = yesterday, …)
     @State private var selectedDayOffset = 0
@@ -212,15 +218,26 @@ struct LiquidTodayView: View {
                     scene
                     // #105: the live "workout in progress" card, dropped in the liquid Home rewrite. Restored
                     // here as the SAME leaf the classic TodayView renders (and Android's WorkoutInProgressCard),
-                    // sitting right under the hero so an active manual workout is immediately visible and taps
-                    // straight through to Live. Renders nothing when no workout is active.
+                    // pinned above the reorderable block so an active manual workout is immediately visible
+                    // and taps straight through to Live. Renders nothing when no workout is active.
                     ActiveWorkoutIndicatorSection()
-                    synthesisSection
-                    keyMetricsSection
-                    lastWorkoutsSection
-                    heartRateSection
-                    recoveryVitalsSection
-                    yourCardsSection
+                    // #today-layout (parity with Android): every Today section — the Charge/Effort/Rest hero
+                    // and Start-session included — renders in the user's saved order. Reorder via the Arrange
+                    // sheet (the header's up/down button; native drag rows); the order persists under the
+                    // byte-identical "today.sectionOrder" key Android uses. A gated-off Start-session renders
+                    // nothing and keeps its slot in the saved order.
+                    ForEach(sectionOrder) { section in
+                        switch section {
+                        case .hero: heroCard
+                        case .liveSession: if liveSessionsBeta { liveSessionStartRow }
+                        case .synthesis: synthesisSection
+                        case .keyMetrics: keyMetricsSection
+                        case .workouts: lastWorkoutsSection
+                        case .heartRate: heartRateSection
+                        case .recoveryVitals: recoveryVitalsSection
+                        case .yourCards: yourCardsSection
+                        }
+                    }
                     dataSourcesSection
                     Color.clear.frame(height: 90) // floating tab-bar clearance
                 }
@@ -287,6 +304,10 @@ struct LiquidTodayView: View {
         // screen on iOS (nothing should compete with the ring mid-workout), a sheet on macOS where
         // fullScreenCover doesn't exist.
         .liveSessionCover(isPresented: $showLiveSession)
+        // #today-layout: the Arrange sheet — native drag-to-reorder rows over the same persisted order.
+        .sheet(isPresented: $showArrangeSheet) {
+            TodayArrangeSheet(orderRaw: $sectionOrderRaw)
+        }
         #if os(macOS)
         // Hide the mac window toolbar's vibrant material so the full-bleed day-of-sky reads dark + edge-to-edge
         // at the top instead of the white scroll-under-titlebar wash.
@@ -386,16 +407,26 @@ struct LiquidTodayView: View {
                     .accessibilityLabel("Profile and settings")
                     LiquidAddButton()
                     LiquidBatteryButton()
+                    // #today-layout: opens the Arrange sheet (drag rows to reorder the Today sections).
+                    Button { showArrangeSheet = true } label: {
+                        Image(systemName: "arrow.up.arrow.down")
+                            .font(.system(size: 14, weight: .bold))
+                            .foregroundStyle(.white)
+                            .frame(width: 34, height: 34)
+                            .background(Circle().fill(.white.opacity(0.16)))
+                    }
+                    .buttonStyle(LiquidPressStyle())
+                    .accessibilityLabel("Arrange Today sections")
                 }
             }
             // Subtle NOOP wordmark in the sky between header and hero. Perfectly centred (a letter row has
             // no trailing tracking gap the way `Text(...).tracking()` does), with a tap easter egg.
+            // #today-layout: the hero + Start-session row moved OUT of the scene into the reorderable
+            // section block below. The wordmark's bottom pad (10) + the section VStack's 12 spacing keeps
+            // the default hero-under-wordmark gap at the original 22.
             LiquidWordmark()
                 .padding(.top, 30)
-            heroCard.padding(.top, 22)
-            if liveSessionsBeta {
-                liveSessionStartRow.padding(.top, 10)
-            }
+                .padding(.bottom, 10)
         }
     }
 
@@ -1209,6 +1240,51 @@ private struct HeroScoreCell: View {
 // MARK: - Scene controls (LiveState-isolated leaves)
 
 /// Quick-actions "+" button. Tap → the shell's quick-action menu.
+/// #today-layout: the Arrange sheet — reorder the Today sections by dragging rows (SwiftUI's native
+/// `onMove`; the always-active edit mode on iOS shows the reorder handles without an Edit button). Writes
+/// straight through to the persisted order, so Today re-lays-out live behind the sheet. Reset restores the
+/// default order. Twin of the Android TodayLayoutEditorDialog over the byte-identical "today.sectionOrder".
+private struct TodayArrangeSheet: View {
+    @Binding var orderRaw: String
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        let order = TodayLayoutPrefs.decodeOrder(orderRaw)
+        NavigationStack {
+            List {
+                ForEach(order) { section in
+                    Text(section.title)
+                        .font(StrandFont.body)
+                        .foregroundStyle(StrandPalette.textPrimary)
+                }
+                .onMove { from, to in
+                    var next = order
+                    next.move(fromOffsets: from, toOffset: to)
+                    orderRaw = TodayLayoutPrefs.encode(next)
+                }
+            }
+            .navigationTitle("Arrange Today")
+            #if os(iOS)
+            .navigationBarTitleDisplayMode(.inline)
+            // Always-active edit mode: the rows carry their reorder handles immediately — hold and drag —
+            // with no Edit-button dance. (macOS Lists drag-reorder natively with onMove.)
+            .environment(\.editMode, .constant(.active))
+            #endif
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Reset") { orderRaw = "" }
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Done") { dismiss() }
+                }
+            }
+        }
+        #if os(macOS)
+        .frame(minWidth: 340, minHeight: 420)
+        #endif
+    }
+}
+
 private struct LiquidAddButton: View {
     @EnvironmentObject var router: NavRouter
     var body: some View {

--- a/StrandTests/TodayLayoutPrefsTests.swift
+++ b/StrandTests/TodayLayoutPrefsTests.swift
@@ -1,0 +1,63 @@
+import XCTest
+@testable import Strand
+
+/// Twin of the Android `TodayLayoutPrefsTest` (#today-layout): default order, encode/decode round-trip,
+/// reorder, and the never-hide "insert missing section at its default position" invariant — pinned on both
+/// platforms so the byte-identical "today.sectionOrder" wire format can't drift.
+final class TodayLayoutPrefsTests: XCTestCase {
+
+    func testEmptyOrUnsetYieldsDefaultOrder() {
+        XCTAssertEqual(TodayLayoutPrefs.decodeOrder(""), TodaySection.defaultOrder)
+        XCTAssertEqual(TodayLayoutPrefs.decodeOrder("   "), TodaySection.defaultOrder)
+    }
+
+    func testEncodeDecodeRoundTripsAReorderedList() {
+        let reordered: [TodaySection] = [
+            .heartRate, .hero, .yourCards, .liveSession, .synthesis, .keyMetrics, .workouts, .recoveryVitals,
+        ]
+        let encoded = TodayLayoutPrefs.encode(reordered)
+        XCTAssertEqual(encoded, "heartRate,hero,yourCards,liveSession,synthesis,keyMetrics,workouts,recoveryVitals")
+        XCTAssertEqual(TodayLayoutPrefs.decodeOrder(encoded), reordered)
+    }
+
+    /// The v1 upgrade path: an order saved by the FIRST cut (6 sections — no hero/liveSession, which were
+    /// pinned then) must surface the two new sections at the TOP (their default position), not teleport
+    /// them to the bottom of the user's saved order.
+    func testSavedOrderFromFirstCutInsertsHeroAndSessionAtTheirDefaultPosition() {
+        let firstCut = "synthesis,keyMetrics,workouts,heartRate,recoveryVitals,yourCards"
+        XCTAssertEqual(
+            TodayLayoutPrefs.decodeOrder(firstCut),
+            [.hero, .liveSession, .synthesis, .keyMetrics, .workouts, .heartRate, .recoveryVitals, .yourCards]
+        )
+    }
+
+    func testInsertsAnyMissingSectionAtItsDefaultPositionRelativeToSaved() {
+        let partial = "heartRate,synthesis,keyMetrics,recoveryVitals"
+        XCTAssertEqual(
+            TodayLayoutPrefs.decodeOrder(partial),
+            [.hero, .liveSession, .workouts, .heartRate, .synthesis, .keyMetrics, .recoveryVitals, .yourCards]
+        )
+    }
+
+    func testDropsUnknownTokensAndCollapsesDuplicates() {
+        let messy = "yourCards,BOGUS,yourCards,heartRate, ,heartRate"
+        XCTAssertEqual(
+            TodayLayoutPrefs.decodeOrder(messy),
+            [.hero, .liveSession, .synthesis, .keyMetrics, .workouts, .recoveryVitals, .yourCards, .heartRate]
+        )
+    }
+
+    func testAllJunkYieldsDefaultOrder() {
+        XCTAssertEqual(TodayLayoutPrefs.decodeOrder("nope,,zzz"), TodaySection.defaultOrder)
+    }
+
+    func testSectionRawKeysAreStableAndUnique() {
+        let raws = TodaySection.allCases.map(\.rawValue)
+        XCTAssertEqual(raws.count, Set(raws).count, "raw keys must be unique (they're the persisted identity)")
+        // Pin the exact wire strings — they must match the Android TodaySection byte-for-byte.
+        XCTAssertEqual(
+            raws,
+            ["hero", "liveSession", "synthesis", "keyMetrics", "workouts", "heartRate", "recoveryVitals", "yourCards"]
+        )
+    }
+}

--- a/StrandTests/TodayLayoutPrefsTests.swift
+++ b/StrandTests/TodayLayoutPrefsTests.swift
@@ -51,6 +51,13 @@ final class TodayLayoutPrefsTests: XCTestCase {
         XCTAssertEqual(TodayLayoutPrefs.decodeOrder("nope,,zzz"), TodaySection.defaultOrder)
     }
 
+    /// defaultOrder must cover EVERY case: the never-hide merge iterates it, so a case missing from the
+    /// default order could otherwise be dropped from render (Android) or mis-sorted (iOS).
+    func testDefaultOrderCoversEveryCase() {
+        XCTAssertEqual(Set(TodaySection.defaultOrder), Set(TodaySection.allCases))
+        XCTAssertEqual(TodaySection.defaultOrder.count, TodaySection.allCases.count)
+    }
+
     func testSectionRawKeysAreStableAndUnique() {
         let raws = TodaySection.allCases.map(\.rawValue)
         XCTAssertEqual(raws.count, Set(raws).count, "raw keys must be unique (they're the persisted identity)")

--- a/android/app/src/main/java/com/noop/ui/TodayLayoutPrefs.kt
+++ b/android/app/src/main/java/com/noop/ui/TodayLayoutPrefs.kt
@@ -80,10 +80,14 @@ object TodayLayoutPrefs {
             TodaySection.fromRaw(token.trim())?.let { if (it !in saved) saved.add(it) }
         }
         if (saved.isEmpty()) return TodaySection.defaultOrder
-        for (missing in TodaySection.defaultOrder) {
+        // Iterate entries (not defaultOrder) so a future enum case accidentally left out of defaultOrder
+        // can never be silently hidden; a section without a default index sorts after everything. Twin of
+        // the Swift decodeOrder's degraded path; defaultOrder covering every entry is pinned by the tests.
+        fun defIdx(s: TodaySection): Int =
+            TodaySection.defaultOrder.indexOf(s).let { if (it == -1) TodaySection.defaultOrder.size else it }
+        for (missing in TodaySection.entries) {
             if (missing in saved) continue
-            val defIdx = TodaySection.defaultOrder.indexOf(missing)
-            val insertAt = saved.indexOfFirst { TodaySection.defaultOrder.indexOf(it) > defIdx }
+            val insertAt = saved.indexOfFirst { defIdx(it) > defIdx(missing) }
             if (insertAt == -1) saved.add(missing) else saved.add(insertAt, missing)
         }
         return saved

--- a/android/app/src/test/java/com/noop/ui/TodayLayoutPrefsTest.kt
+++ b/android/app/src/test/java/com/noop/ui/TodayLayoutPrefsTest.kt
@@ -92,6 +92,14 @@ class TodayLayoutPrefsTest {
         assertEquals(TodaySection.defaultOrder, TodayLayoutPrefs.decodeOrder("nope,,zzz"))
     }
 
+    /** defaultOrder must cover EVERY entry: the never-hide merge sorts by default index, so an entry
+     *  missing from the default order could otherwise be dropped or mis-sorted. Twin of the Swift test. */
+    @Test
+    fun defaultOrderCoversEveryEntry() {
+        assertEquals(TodaySection.entries.toSet(), TodaySection.defaultOrder.toSet())
+        assertEquals(TodaySection.entries.size, TodaySection.defaultOrder.size)
+    }
+
     @Test
     fun sectionRawKeysAreStableAndUnique() {
         val raws = TodaySection.entries.map { it.raw }


### PR DESCRIPTION
Apple twin of the Android Today reorder (#420/#425/#427): every liquid Today section — the **Charge/Effort/Rest hero and Start-session included** — renders in a user-chosen, persisted order.

## What
- **`TodayLayoutPrefs.swift`** — `TodaySection` enum + the positional insert-missing merge, **byte-identical wire keys** (`hero`,`liveSession`,…) and the same `today.sectionOrder` key as Android, so a future backup/restore reads one layout on either OS.
- **`LiquidTodayView`** renders the sections from the saved order (hero + Start-session moved out of the pinned scene; header/wordmark + workout-in-progress strip + data sources stay pinned; the wordmark's bottom pad keeps the default hero gap at the original 22).
- **Arrange** — a header button opens a sheet with **native drag-to-reorder rows** (`List.onMove`; always-active edit mode on iOS shows the handles immediately; macOS Lists drag natively). Applies live; Reset restores default.
- **Crash-proofed merge on BOTH platforms** (re-review catch): a future enum case forgotten from `defaultOrder` would have crashed iOS (force-unwrap) / silently hidden the section on Android — both now degrade identically (after-everything sort), pinned by a new twin completeness test.
- `StrandTests/TodayLayoutPrefsTests.swift` — value-for-value twin of the Kotlin tests.

## Parity scope (honest)
Feature-level parity: same sections, same persistence, same migration, hold-drag reorder. The one gap: **on-feed card drag stays Android-only** — hand-rolling drag inside a SwiftUI ScrollView is unverifiable headless (the Android feel took three on-device iterations); the sheet's native drag rows are the platform pattern. Follow-up if the sheet feels inferior in practice. Backup-whitelist entry for the key = separate PR (byte-identical .noopbak contract).

## Verification
- app-build **green on both legs** (Strand macOS + NOOPiOS iOS) on the final commit.
- Android twin logic verified by running tests: `TodayLayoutPrefsTest` **8/8** (the Swift twin tests mirror them value-for-value; StrandTests run only under xcodebuild test).
- No `TodaySection` name collision; ForEach identity-stable (state survives reorder).
- Sheet UX needs an on-device eyeball (drag handles, macOS sheet sizing).