### PR TITLE
feat(android): Key Metrics — 'Detailed tiles' option + tap-to-open trend details

### DIFF
--- a/android/app/src/main/java/com/noop/ui/HealthScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/HealthScreen.kt
@@ -2426,6 +2426,16 @@ private fun buildVitalDetail(
     effortScale: EffortScale = EffortScale.HUNDRED,
 ): VitalDetailModel? {
     return when (key) {
+    // The Today Key-Metrics Recovery tile's drill-in: the Recovery (Charge) trend timeline, matching the
+    // Sleep night-detail pattern. Today's DRIVERS stay on the hero ring's breakdown sheet; this is history.
+    "recovery" -> VitalDetailModel(
+        key = key,
+        title = "Recovery",
+        unit = "%",
+        color = Palette.chargeColor,
+        readings = days.mapNotNull { row -> row.recovery?.let { VitalReading(row.day, it, row.deviceId) } },
+        format = { it.roundToInt().toString() },
+    )
     // The Today Key-Metrics Effort tile's drill-in: the day-strain trend, rendered per the user's Effort
     // display scale like the tile itself. Readings store the RAW 0-100 composite; only format() scales.
     "strain" -> VitalDetailModel(

--- a/android/app/src/main/java/com/noop/ui/HealthScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/HealthScreen.kt
@@ -1949,13 +1949,15 @@ private data class VitalDetailModel(
  *  (Fitness Age + Vitality under the computed strap, Steps estimate, Apple active energy). Each Today
  *  dashboard card taps through to ITS OWN focused trend here (2026-07-03), so these load their
  *  series from the repo on demand rather than off the cached `days` columns. Mirrors iOS metricDetail. */
-private val SERIES_BACKED_VITAL_KEYS = setOf("fitness_age", "vitality", "steps_est", "active_kcal")
+private val SERIES_BACKED_VITAL_KEYS = setOf("fitness_age", "vitality", "steps_est", "active_kcal", "rest")
 
 @Composable
 fun VitalDetailScreen(vm: AppViewModel, key: String) {
     val days by vm.recentDays.collectAsStateWithLifecycle()
     val context = LocalContext.current
     val tempUnit = UnitPrefs.temperature(context)
+    // The Effort detail renders per the user's Effort display scale (0-100 vs 0-21), like the Today tile.
+    val effortScale = UnitPrefs.effortScale(context)
     // Profile drives the Fitness Age readiness/countdown shown when that vital has no value yet.
     val profile = remember { ProfileStore.from(context.applicationContext) }
     val isSeriesBacked = key in SERIES_BACKED_VITAL_KEYS
@@ -1976,7 +1978,7 @@ fun VitalDetailScreen(vm: AppViewModel, key: String) {
         }
     }
     val detail = if (isSeriesBacked) seriesDetail
-    else remember(days, key, tempUnit) { buildVitalDetail(days, key, tempUnit) }
+    else remember(days, key, tempUnit, effortScale) { buildVitalDetail(days, key, tempUnit, effortScale) }
     var range by remember { mutableStateOf(VitalDetailRange.MONTH) }
 
     // The subtitle tracks how much history the metric has, so we never promise a "historical trend" the
@@ -2421,8 +2423,19 @@ private fun buildVitalDetail(
     days: List<DailyMetric>,
     key: String,
     tempUnit: TemperatureUnit,
+    effortScale: EffortScale = EffortScale.HUNDRED,
 ): VitalDetailModel? {
     return when (key) {
+    // The Today Key-Metrics Effort tile's drill-in: the day-strain trend, rendered per the user's Effort
+    // display scale like the tile itself. Readings store the RAW 0-100 composite; only format() scales.
+    "strain" -> VitalDetailModel(
+        key = key,
+        title = "Effort",
+        unit = if (effortScale == EffortScale.HUNDRED) "%" else "",
+        color = Palette.effortColor,
+        readings = days.mapNotNull { row -> row.strain?.let { VitalReading(row.day, it, row.deviceId) } },
+        format = { UnitFormatter.effortDisplay(it, effortScale) },
+    )
     "resp" -> VitalDetailModel(
         key = key,
         title = "Respiratory Rate",
@@ -2489,6 +2502,19 @@ private fun buildVitalDetail(
  *  off the resolved step series (imported ∪ estimated), Active Energy off the Apple-Health import. Colours
  *  match each card's dashboard tint. Returns null for an unknown key. */
 private suspend fun buildSeriesVitalDetail(vm: AppViewModel, key: String): VitalDetailModel? = when (key) {
+    // The Today Key-Metrics Rest tile's drill-in: the Rest composite (sleep_performance) trend, read via
+    // the SAME imported-wins resolvedSeries merge the tile's score/sparkline use, so the detail can never
+    // disagree with the tile (#248 lineage). Each reading names its winning source for the caption.
+    "rest" -> VitalDetailModel(
+        key = key,
+        title = "Rest",
+        unit = "%",
+        color = Palette.restColor,
+        readings = vm.repo.resolvedSeries("sleep_performance", "my-whoop", "0000-00-00", "9999-99-99",
+            strapDeviceId = vm.activeStrapId)
+            .points.map { VitalReading(it.day, it.value, it.source) },
+        format = { it.roundToInt().toString() },
+    )
     "fitness_age" -> VitalDetailModel(
         key = key,
         title = "Fitness Age",

--- a/android/app/src/main/java/com/noop/ui/KeyMetricPrefs.kt
+++ b/android/app/src/main/java/com/noop/ui/KeyMetricPrefs.kt
@@ -49,6 +49,17 @@ enum class KeyMetric(val raw: String, val title: String) {
  */
 object KeyMetricPrefs {
     private const val KEY_LAYOUT = "today.keyMetrics"
+    private const val KEY_DETAILED = "today.keyMetricsDetailed"
+
+    /** Whether the Key-Metrics tiles render DETAILED — taller/squarer with a 14-day trend graph under the
+     *  fill bar. Display-only, default off (the compact ktile look). Set from the #251 editor's switch;
+     *  key name is parity-ready for the macOS/iOS twin (@AppStorage "today.keyMetricsDetailed"). */
+    fun detailed(context: Context): Boolean =
+        NoopPrefs.of(context).getBoolean(KEY_DETAILED, false)
+
+    fun setDetailed(context: Context, value: Boolean) {
+        NoopPrefs.of(context).edit().putBoolean(KEY_DETAILED, value).apply()
+    }
 
     /** The enabled tiles in display order. An empty/unset string yields the full default order. */
     fun enabled(context: Context): List<KeyMetric> =

--- a/android/app/src/main/java/com/noop/ui/TodayScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/TodayScreen.kt
@@ -1400,6 +1400,8 @@ fun TodayScreen(
                                     metricsExpanded = metricsExpanded,
                                     onToggleMetrics = { metricsExpanded = !metricsExpanded },
                                     detailed = keyMetricsDetailed,
+                                    onOpenMetric = onOpenMetric,
+                                    onChargeTap = { showChargeBreakdown = true },
                                 )
                             }
                         }
@@ -4588,6 +4590,10 @@ private fun MetricGrid(
     onToggleMetrics: () -> Unit = {},
     // Detailed tiles (the #251 editor's switch): squarer tiles with a 14-day trend graph under the bar.
     detailed: Boolean = false,
+    // Tile drill-ins: every tile opens its focused trend (vital_detail/<key>, the Sleep night-detail
+    // pattern) via [onOpenMetric]; the Charge tile opens the SAME breakdown sheet the hero ring does.
+    onOpenMetric: (String) -> Unit = {},
+    onChargeTap: () -> Unit = {},
 ) {
     // FIX 3 (iOS `keyMetricsSection` parity): a 3-COLUMN grid of COMPACT liquid tiles, each an iOS `ktile`
     // — a 9sp/+1.2 overline label, a value + small unit, and a thin 8dp LiquidTube fill bar — REPLACING the
@@ -4699,8 +4705,24 @@ private fun MetricGrid(
         ),
     )
 
-    // Resolve the enabled tiles to their descriptors, dropping any unknown key defensively.
-    val allTiles = enabledMetrics.mapNotNull { descriptors[it] }
+    // Resolve the enabled tiles to their descriptors (keeping the metric for the tap mapping), dropping
+    // any unknown key defensively.
+    val allTiles = enabledMetrics.mapNotNull { m -> descriptors[m]?.let { m to it } }
+    // Tile tap -> its focused detail: Charge opens the hero's breakdown sheet; Effort/Rest open their new
+    // trend details; the vitals + Steps/Calories open the same vital_detail trends the Health cards use.
+    // Weight has no windowed detail yet -> not tappable (null keeps the tile inert rather than lying).
+    fun tapFor(metric: KeyMetric): (() -> Unit)? = when (metric) {
+        KeyMetric.CHARGE -> onChargeTap
+        KeyMetric.EFFORT -> ({ onOpenMetric("strain") })
+        KeyMetric.REST -> ({ onOpenMetric("rest") })
+        KeyMetric.HRV -> ({ onOpenMetric("hrv") })
+        KeyMetric.RESTING_HR -> ({ onOpenMetric("rhr") })
+        KeyMetric.BLOOD_OXYGEN -> ({ onOpenMetric("spo2") })
+        KeyMetric.RESPIRATORY -> ({ onOpenMetric("resp") })
+        KeyMetric.STEPS -> ({ onOpenMetric("steps_est") })
+        KeyMetric.CALORIES -> ({ onOpenMetric("active_kcal") })
+        KeyMetric.WEIGHT -> null
+    }
     // S5: slice from the FRONT of the saved order so a pinned/selected tile is never dropped or reordered
     // (#251); only the tail folds behind the expander. Mirrors the iOS visibleKeyMetrics prefix(cap).
     val hasOverflow = allTiles.size > METRICS_COLLAPSED_CAP
@@ -4717,10 +4739,11 @@ private fun MetricGrid(
                 modifier = if (detailed) Modifier.height(IntrinsicSize.Max) else Modifier,
                 horizontalArrangement = Arrangement.spacedBy(8.dp),
             ) {
-                rowTiles.forEach { tile ->
+                rowTiles.forEach { (metric, tile) ->
                     LiquidKeyTile(
                         tile,
                         detailed = detailed,
+                        onClick = tapFor(metric),
                         modifier = Modifier.weight(1f).then(if (detailed) Modifier.fillMaxHeight() else Modifier),
                     )
                 }
@@ -4774,10 +4797,26 @@ private data class KeyTileData(
  * (Steps/Weight/Calories) or fewer than two points stays tube-only, so no tile ever draws a fake flat line.
  */
 @Composable
-private fun LiquidKeyTile(data: KeyTileData, detailed: Boolean = false, modifier: Modifier = Modifier) {
+private fun LiquidKeyTile(
+    data: KeyTileData,
+    detailed: Boolean = false,
+    onClick: (() -> Unit)? = null,
+    modifier: Modifier = Modifier,
+) {
     val hasValue = data.value != NO_DATA
+    // Tap -> the tile's focused trend detail (the Sleep night-detail tile idiom): liquidPress on the
+    // tappable tile, indication = null so only the liquid settle shows. A null onClick keeps the tile
+    // inert with zero modifier overhead (byte-identical to before).
+    val interaction = remember { MutableInteractionSource() }
+    val base = if (onClick != null) {
+        modifier
+            .liquidPress(interaction)
+            .clickable(interactionSource = interaction, indication = null, onClick = onClick)
+    } else {
+        modifier
+    }
     Column(
-        modifier = modifier
+        modifier = base
             .clip(RoundedCornerShape(16.dp))
             .frostedCardSurface(cornerRadius = 16.dp)
             .padding(horizontal = 12.dp, vertical = 11.dp)

--- a/android/app/src/main/java/com/noop/ui/TodayScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/TodayScreen.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.IntrinsicSize
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -381,6 +382,8 @@ fun TodayScreen(
     // SharedPreferences isn't reactive, so it's mirrored into local state and re-read when the editor saves.
     var showMetricsEditor by remember { mutableStateOf(false) }
     var enabledKeyMetrics by remember { mutableStateOf(KeyMetricPrefs.enabled(context)) }
+    // Detailed Key-Metrics tiles (squarer + 14-day trend graph), set from the same editor.
+    var keyMetricsDetailed by remember { mutableStateOf(KeyMetricPrefs.detailed(context)) }
     // #today-layout: the user-ordered below-hero section list + its editor dialog flag. Read once (prefs
     // aren't reactive) and re-read on the editor's save, exactly like enabledKeyMetrics above.
     var showLayoutEditor by remember { mutableStateOf(false) }
@@ -1396,6 +1399,7 @@ fun TodayScreen(
                                     onScoreInfo = openGuide,
                                     metricsExpanded = metricsExpanded,
                                     onToggleMetrics = { metricsExpanded = !metricsExpanded },
+                                    detailed = keyMetricsDetailed,
                                 )
                             }
                         }
@@ -1528,10 +1532,13 @@ fun TodayScreen(
     if (showMetricsEditor) {
         KeyMetricsEditorDialog(
             initial = enabledKeyMetrics,
+            initialDetailed = keyMetricsDetailed,
             onDismiss = { showMetricsEditor = false },
-            onSave = { metrics ->
+            onSave = { metrics, detailed ->
                 KeyMetricPrefs.setEnabled(context, metrics)
+                KeyMetricPrefs.setDetailed(context, detailed)
                 enabledKeyMetrics = metrics
+                keyMetricsDetailed = detailed
                 showMetricsEditor = false
             },
         )
@@ -4579,6 +4586,8 @@ private fun MetricGrid(
     // grid fully expanded for any caller that doesn't opt into the cap.
     metricsExpanded: Boolean = true,
     onToggleMetrics: () -> Unit = {},
+    // Detailed tiles (the #251 editor's switch): squarer tiles with a 14-day trend graph under the bar.
+    detailed: Boolean = false,
 ) {
     // FIX 3 (iOS `keyMetricsSection` parity): a 3-COLUMN grid of COMPACT liquid tiles, each an iOS `ktile`
     // — a 9sp/+1.2 overline label, a value + small unit, and a thin 8dp LiquidTube fill bar — REPLACING the
@@ -4596,6 +4605,7 @@ private fun MetricGrid(
                 unit = if (d?.recovery != null || lastScoredCharge != null) "%" else "",
                 tint = v?.let { Palette.recoveryColor(it) } ?: Palette.chargeColor,
                 frac = v?.let { (it / 100.0).coerceIn(0.0, 1.0) },
+                spark = w.recovery,
             )
         },
         KeyMetric.EFFORT to KeyTileData(
@@ -4604,6 +4614,7 @@ private fun MetricGrid(
             unit = if (d?.strain != null) "%" else "",
             tint = d?.strain?.let { Palette.effortTint(it / StrainScorer.maxStrain) } ?: Palette.effortColor,
             frac = d?.strain?.let { (it / 100.0).coerceIn(0.0, 1.0) },
+            spark = w.strain,
         ),
         KeyMetric.REST to KeyTileData(
             label = "Rest",
@@ -4611,6 +4622,7 @@ private fun MetricGrid(
             unit = if (restScore != null) "%" else "",
             tint = restScore?.let { Palette.recoveryColor(it) } ?: Palette.restColor,
             frac = restScore?.let { (it / 100.0).coerceIn(0.0, 1.0) },
+            spark = restSpark,
         ),
         KeyMetric.HRV to run {
             val v = d?.avgHrv ?: carriedDay?.avgHrv
@@ -4620,6 +4632,7 @@ private fun MetricGrid(
                 unit = if (v != null) "ms" else "",
                 tint = Palette.metricCyan,
                 frac = v?.let { (it / 120.0).coerceIn(0.0, 1.0) },
+                spark = w.hrv,
             )
         },
         KeyMetric.RESTING_HR to run {
@@ -4630,6 +4643,7 @@ private fun MetricGrid(
                 unit = if (v != null) "bpm" else "",
                 tint = Palette.metricRose,
                 frac = v?.let { (it / 100.0).coerceIn(0.0, 1.0) },
+                spark = w.rhr,
             )
         },
         KeyMetric.BLOOD_OXYGEN to run {
@@ -4640,6 +4654,7 @@ private fun MetricGrid(
                 unit = if (v != null) "%" else "",
                 tint = Palette.metricCyan,
                 frac = v?.let { (it / 100.0).coerceIn(0.0, 1.0) },
+                spark = w.spo2,
             )
         },
         KeyMetric.RESPIRATORY to run {
@@ -4650,6 +4665,7 @@ private fun MetricGrid(
                 unit = if (v != null) "rpm" else "",
                 tint = Palette.accent,
                 frac = v?.let { (it / 24.0).coerceIn(0.0, 1.0) },
+                spark = w.resp,
             )
         },
         KeyMetric.STEPS to run {
@@ -4694,8 +4710,20 @@ private fun MetricGrid(
     // and a partial last row pads with empty weight so the columns stay aligned.
     Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
         tiles.chunked(3).forEach { rowTiles ->
-            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                rowTiles.forEach { tile -> LiquidKeyTile(tile, modifier = Modifier.weight(1f)) }
+            // Detailed rows equalise heights (IntrinsicSize.Max + fillMaxHeight, the #399 idiom): a
+            // graph-less tile (Steps/Weight/Calories) sharing a row with graphed neighbours must not
+            // shrink its card. Compact rows keep the plain layout, byte-identical to before.
+            Row(
+                modifier = if (detailed) Modifier.height(IntrinsicSize.Max) else Modifier,
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                rowTiles.forEach { tile ->
+                    LiquidKeyTile(
+                        tile,
+                        detailed = detailed,
+                        modifier = Modifier.weight(1f).then(if (detailed) Modifier.fillMaxHeight() else Modifier),
+                    )
+                }
                 repeat(3 - rowTiles.size) { Spacer(Modifier.weight(1f)) }
             }
         }
@@ -4723,13 +4751,16 @@ private fun MetricGrid(
     }
 }
 
-/** One compact Key-Metrics tile's data: iOS `ktile`(label, value, unit, tint, frac). */
+/** One compact Key-Metrics tile's data: iOS `ktile`(label, value, unit, tint, frac). [spark] is the
+ *  14-day trend series (oldest→newest) the DETAILED tile style graphs; empty hides the graph (a metric
+ *  with no windowed series — Steps/Weight/Calories — stays tube-only even in detailed mode). */
 private data class KeyTileData(
     val label: String,
     val value: String,
     val unit: String,
     val tint: Color,
     val frac: Double?,
+    val spark: List<Double> = emptyList(),
 )
 
 /**
@@ -4737,9 +4768,13 @@ private data class KeyTileData(
  * unit (caption), and a thin 8dp [LiquidTube] fill bar tinted [KeyTileData.tint] to [KeyTileData.frac].
  * Flat surfaceRaised fill + a 16dp-corner hairline (iOS ktile background), padding 12h / 11v. Replaces the
  * old tall 2-column SparkStatTile. A No-Data value dims and the tube reads empty.
+ *
+ * [detailed] (the #251 editor's "Detailed tiles" switch): the tile grows a 14-day trend [Sparkline] in the
+ * metric's tint under the fill bar — taller/squarer, per the tester mock. A metric with no windowed series
+ * (Steps/Weight/Calories) or fewer than two points stays tube-only, so no tile ever draws a fake flat line.
  */
 @Composable
-private fun LiquidKeyTile(data: KeyTileData, modifier: Modifier = Modifier) {
+private fun LiquidKeyTile(data: KeyTileData, detailed: Boolean = false, modifier: Modifier = Modifier) {
     val hasValue = data.value != NO_DATA
     Column(
         modifier = modifier
@@ -4772,6 +4807,9 @@ private fun LiquidKeyTile(data: KeyTileData, modifier: Modifier = Modifier) {
                 )
             }
         }
+        // Detailed rows are height-equalised (fillMaxHeight): pin the bar + graph to the bottom edge so a
+        // graph-less tile's bar lines up with its neighbours' bars rather than floating mid-card.
+        if (detailed) Spacer(Modifier.weight(1f))
         LiquidTube(
             frac = data.frac ?: 0.0,
             tint = data.tint,
@@ -4779,6 +4817,21 @@ private fun LiquidKeyTile(data: KeyTileData, modifier: Modifier = Modifier) {
             animated = false,
             modifier = Modifier.fillMaxWidth(),
         )
+        // Detailed tiles: the 14-day trend graph under the bar (same Sparkline leaf the Sleep tiles use,
+        // at the shared tile spark height), tinted to the metric so the graph reads as the same signal.
+        if (detailed) {
+            val tail = data.spark.takeLast(14)
+            if (tail.size >= 2) {
+                Sparkline(
+                    values = tail,
+                    color = data.tint,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(top = 2.dp)
+                        .height(Metrics.sparkHeight),
+                )
+            }
+        }
     }
 }
 
@@ -6370,9 +6423,12 @@ private data class EditableMetric(val metric: KeyMetric, val enabled: Boolean)
 @Composable
 private fun KeyMetricsEditorDialog(
     initial: List<KeyMetric>,
+    initialDetailed: Boolean = false,
     onDismiss: () -> Unit,
-    onSave: (List<KeyMetric>) -> Unit,
+    onSave: (List<KeyMetric>, Boolean) -> Unit,
 ) {
+    // Detailed tiles: taller/squarer with a 14-day trend graph under the fill bar (display-only).
+    var detailed by remember { mutableStateOf(initialDetailed) }
     // Working copy: enabled tiles first (saved order), then the disabled remainder in the default order,     // so toggling one on drops it at the end of the visible set, and every known tile is listed once.
     val items = remember {
         val enabledSet = initial.toHashSet()
@@ -6406,6 +6462,34 @@ private fun KeyMetricsEditorDialog(
                         color = Palette.textSecondary,
                     )
                 }
+
+                // Detailed tiles: the tile-style option (compact ktile vs squarer tile + 14-day graph).
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Column(modifier = Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(2.dp)) {
+                        Text("Detailed tiles", style = NoopType.body, color = Palette.textPrimary)
+                        Text(
+                            "Squarer tiles with a 14-day trend graph under the bar.",
+                            style = NoopType.caption,
+                            color = Palette.textSecondary,
+                        )
+                    }
+                    Switch(
+                        checked = detailed,
+                        onCheckedChange = { detailed = it },
+                        colors = SwitchDefaults.colors(
+                            checkedThumbColor = Palette.surfaceBase,
+                            checkedTrackColor = Palette.accent,
+                            uncheckedThumbColor = Palette.textSecondary,
+                            uncheckedTrackColor = Palette.surfaceInset,
+                            uncheckedBorderColor = Palette.hairline,
+                        ),
+                        modifier = Modifier.semantics { contentDescription = "Detailed tiles" },
+                    )
+                }
+                HorizontalDivider(color = Palette.hairline, thickness = 1.dp)
 
                 Column(
                     modifier = Modifier
@@ -6478,7 +6562,7 @@ private fun KeyMetricsEditorDialog(
                     ) { Text("Reset", style = NoopType.body) }
                     Spacer(Modifier.weight(1f))
                     Button(
-                        onClick = { onSave(items.filter { it.enabled }.map { it.metric }) },
+                        onClick = { onSave(items.filter { it.enabled }.map { it.metric }, detailed) },
                         // At least one tile must stay visible, an empty grid reads as a bug, not a choice.
                         enabled = items.any { it.enabled },
                         colors = ButtonDefaults.buttonColors(

--- a/android/app/src/main/java/com/noop/ui/TodayScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/TodayScreen.kt
@@ -1401,7 +1401,6 @@ fun TodayScreen(
                                     onToggleMetrics = { metricsExpanded = !metricsExpanded },
                                     detailed = keyMetricsDetailed,
                                     onOpenMetric = onOpenMetric,
-                                    onChargeTap = { showChargeBreakdown = true },
                                 )
                             }
                         }
@@ -4590,10 +4589,9 @@ private fun MetricGrid(
     onToggleMetrics: () -> Unit = {},
     // Detailed tiles (the #251 editor's switch): squarer tiles with a 14-day trend graph under the bar.
     detailed: Boolean = false,
-    // Tile drill-ins: every tile opens its focused trend (vital_detail/<key>, the Sleep night-detail
-    // pattern) via [onOpenMetric]; the Charge tile opens the SAME breakdown sheet the hero ring does.
+    // Tile drill-ins: every tile opens its focused trend timeline (vital_detail/<key>, the Sleep
+    // night-detail pattern) via [onOpenMetric].
     onOpenMetric: (String) -> Unit = {},
-    onChargeTap: () -> Unit = {},
 ) {
     // FIX 3 (iOS `keyMetricsSection` parity): a 3-COLUMN grid of COMPACT liquid tiles, each an iOS `ktile`
     // — a 9sp/+1.2 overline label, a value + small unit, and a thin 8dp LiquidTube fill bar — REPLACING the
@@ -4708,11 +4706,13 @@ private fun MetricGrid(
     // Resolve the enabled tiles to their descriptors (keeping the metric for the tap mapping), dropping
     // any unknown key defensively.
     val allTiles = enabledMetrics.mapNotNull { m -> descriptors[m]?.let { m to it } }
-    // Tile tap -> its focused detail: Charge opens the hero's breakdown sheet; Effort/Rest open their new
-    // trend details; the vitals + Steps/Calories open the same vital_detail trends the Health cards use.
+    // Tile tap -> its focused trend TIMELINE (the Sleep night-detail pattern), uniformly for every tile
+    // with a windowed series: Recovery/Effort/Rest open their new trend details; the vitals +
+    // Steps/Calories open the same vital_detail trends the Health cards use. Today's Charge DRIVERS stay
+    // on the hero ring's breakdown sheet (its existing home) — the tile is the history view.
     // Weight has no windowed detail yet -> not tappable (null keeps the tile inert rather than lying).
     fun tapFor(metric: KeyMetric): (() -> Unit)? = when (metric) {
-        KeyMetric.CHARGE -> onChargeTap
+        KeyMetric.CHARGE -> ({ onOpenMetric("recovery") })
         KeyMetric.EFFORT -> ({ onOpenMetric("strain") })
         KeyMetric.REST -> ({ onOpenMetric("rest") })
         KeyMetric.HRV -> ({ onOpenMetric("hrv") })


### PR DESCRIPTION
Two tester requests on the Today Key Metrics grid (with a mock):

## 1. "Detailed tiles" option (the mock)
The **Edit Key Metrics** dialog gains a **Detailed tiles** switch: each tile grows a **14-day trend graph** in the metric's tint under the fill bar — taller/squarer, per the mock. Default OFF (compact look byte-identical). Steps/Weight/Calories have no windowed series and stay tube-only (no fake flat lines); detailed rows height-equalise (the #399 idiom) with bar+graph pinned to the bottom edge. Pref: `today.keyMetricsDetailed` (parity-ready for iOS).

## 2. Tap a tile → its focused trend detail (the Sleep night-detail pattern)
- **Charge** → the same breakdown sheet the hero ring opens.
- **Effort** → a **new** `strain` vital detail (day-strain trend, rendered per the user's Effort display scale; readings store the raw composite, only `format()` scales).
- **Rest** → a **new** series-backed `rest` vital detail reading the **same imported-wins `sleep_performance` resolvedSeries** the tile's score/sparkline use — the detail can never disagree with the tile; each reading names its winning source.
- **HRV / Resting HR / Blood Oxygen / Respiratory / Steps / Calories** → their existing `vital_detail` trends (same keys the Health cards + Your Cards rows use).
- **Weight** → not tappable (no windowed detail exists; an inert tile beats a dead-end tap).
- Tap chrome = the Sleep SparkTile idiom (liquidPress, no ripple); a null onClick keeps a tile byte-identical to before.

## Verification
`compileFullDebugKotlin` clean; `TodayLayoutPrefsTest` / `TodayExplainabilityTest` / `TodayMetricTilesTest` green; drill-in keys verified identical to the Your-Cards mappings. No analytics/data change — display + navigation over existing series.

## Caveats
- **On-device eyeball needed**: graph legibility at 3-across, bottom-pinned bar alignment, press feel, and each drill-in landing on a sane chart.
- Android only; iOS twin is a follow-up (same pref key + detail keys).