### PR TITLE
feat: Key Metrics iOS parity + selectable trend window (2d/1w/2w) on both platforms

### DIFF
--- a/Strand/Liquid/LiquidTodayView.swift
+++ b/Strand/Liquid/LiquidTodayView.swift
@@ -53,6 +53,14 @@ struct LiquidTodayView: View {
     @AppStorage(TodayLayoutPrefs.orderKey) private var sectionOrderRaw = ""
     @State private var showArrangeSheet = false
     private var sectionOrder: [TodaySection] { TodayLayoutPrefs.decodeOrder(sectionOrderRaw) }
+    // #430 parity: the Key-Metrics grid honours the SAME editor selection/order + Detailed-tiles switch as
+    // Android (byte-identical @AppStorage keys). `kSparks` holds the trailing-14-day series the detailed
+    // tiles graph (keyed by metric-catalog key), filled by the loader alongside everything else.
+    @AppStorage(KeyMetricPrefs.layoutKey) private var keyMetricsRaw = ""
+    @AppStorage("today.keyMetricsDetailed") private var keyMetricsDetailed = false
+    @State private var showKeyMetricsEditor = false
+    @State private var kSparks: [String: [Double]] = [:]
+    private var enabledKeyMetrics: [KeyMetric] { KeyMetricPrefs.decodeEnabled(keyMetricsRaw) }
 
     // day navigation (0 = today, 1 = yesterday, …)
     @State private var selectedDayOffset = 0
@@ -307,6 +315,11 @@ struct LiquidTodayView: View {
         // #today-layout: the Arrange sheet — native drag-to-reorder rows over the same persisted order.
         .sheet(isPresented: $showArrangeSheet) {
             TodayArrangeSheet(orderRaw: $sectionOrderRaw)
+        }
+        // #430 parity: the Key-Metrics editor (selection + order + the Detailed-tiles switch), the same
+        // sheet the classic macOS grid uses, bound to the same persisted layout string.
+        .sheet(isPresented: $showKeyMetricsEditor) {
+            KeyMetricsEditorSheet(layoutRaw: $keyMetricsRaw)
         }
         #if os(macOS)
         // Hide the mac window toolbar's vibrant material so the full-bleed day-of-sky reads dark + edge-to-edge
@@ -746,19 +759,30 @@ struct LiquidTodayView: View {
     // MARK: - Key metrics grid
 
     private var keyMetricsSection: some View {
-        // HRV / Rest HR tiles share the recovery vitals' per-field today-first carry so they don't blank at
-        // the rollover while Recovery/Strain/Sleep stay strictly today's own (they are scored surfaces).
+        // HRV / Rest HR (+ Blood Oxygen / Respiratory) tiles share the recovery vitals' per-field
+        // today-first carry so they don't blank at the rollover while Recovery/Strain/Rest stay strictly
+        // today's own (they are scored surfaces).
         let hrv = displayDay?.avgHrv ?? vitalsDay?.avgHrv
         let rhr = (displayDay?.restingHr ?? vitalsDay?.restingHr).map(Double.init)
         return VStack(spacing: 8) {
-            sectionHead("KEY METRICS", trailing: "14-day trend")
+            HStack(alignment: .firstTextBaseline, spacing: 8) {
+                sectionHead("KEY METRICS", trailing: "14-day trend")
+                // #430 parity: the SAME editor the classic grid uses — selection + order + Detailed tiles.
+                Button { showKeyMetricsEditor = true } label: {
+                    Image(systemName: "slider.horizontal.3")
+                        .font(.system(size: 12, weight: .semibold))
+                        .foregroundStyle(StrandPalette.accent)
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("Edit Key Metrics")
+            }
+            // #430 parity: the grid honours the Key-Metrics editor (selection + order, all ten metrics)
+            // instead of a hard-coded six — the bespoke Sleep-hours ktile gives way to the shared REST
+            // score tile, aligning the liquid grid with the classic macOS grid and Android.
             LazyVGrid(columns: Array(repeating: GridItem(.flexible(), spacing: 8), count: 3), spacing: 8) {
-                ktile(String(localized: "Recovery"), intText(displayDay?.recovery), "%", StrandPalette.chargeColor, frac(displayDay?.recovery))
-                ktile(String(localized: "Strain"), intText(displayDay?.strain), "%", StrandPalette.effortColor, frac(displayDay?.strain))
-                ktile(String(localized: "Sleep"), sleepText, "", StrandPalette.restColor, fracOver(displayDay?.totalSleepMin, 480))
-                ktile(String(localized: "HRV"), intText(hrv), "ms", StrandPalette.metricCyan, fracOver(hrv, 120))
-                ktile(String(localized: "Rest HR"), intText(rhr), "bpm", StrandPalette.metricRose, fracOver(rhr, 100))
-                ktile(String(localized: "Steps"), stepsText, "", StrandPalette.chargeColor, fracOver(stepCount, 10000))
+                ForEach(enabledKeyMetrics) { metric in
+                    ktileFor(metric, hrv: hrv, rhr: rhr)
+                }
             }
             NavigationLink(value: TabRoute.metricExplorer) {
                 Text("Show all metrics").font(StrandFont.subhead).foregroundStyle(StrandPalette.accent)
@@ -768,8 +792,41 @@ struct LiquidTodayView: View {
         }
     }
 
-    private func ktile(_ label: String, _ value: String, _ unit: String, _ tint: Color, _ frac: Double?) -> some View {
-        VStack(alignment: .leading, spacing: 6) {
+    /// One editor-selected Key-Metric tile: the metric's value/tint/fill exactly as the old hard-coded
+    /// tiles read them (Android's descriptor map is the twin), plus the metric-catalog `key` that names
+    /// both its 14-day spark series and its tap-through detail. Weight has no liquid value source yet —
+    /// its tile reads "—" but still taps through to the weight trend detail (which has its own series).
+    @ViewBuilder
+    private func ktileFor(_ metric: KeyMetric, hrv: Double?, rhr: Double?) -> some View {
+        switch metric {
+        case .charge:
+            ktile(String(localized: "Recovery"), intText(displayDay?.recovery), "%", StrandPalette.chargeColor, frac(displayDay?.recovery), key: "recovery")
+        case .effort:
+            ktile(String(localized: "Strain"), intText(displayDay?.strain), "%", StrandPalette.effortColor, frac(displayDay?.strain), key: "strain")
+        case .rest:
+            ktile(String(localized: "Rest"), intText(restScore), "%", StrandPalette.restColor, frac(restScore), key: "sleep_performance")
+        case .hrv:
+            ktile("HRV", intText(hrv), "ms", StrandPalette.metricCyan, fracOver(hrv, 120), key: "hrv")
+        case .restingHr:
+            ktile(String(localized: "Rest HR"), intText(rhr), "bpm", StrandPalette.metricRose, fracOver(rhr, 100), key: "rhr")
+        case .bloodOxygen:
+            let spo2 = displayDay?.spo2Pct ?? vitalsDay?.spo2Pct
+            ktile(String(localized: "Blood Oxygen"), intText(spo2), "%", StrandPalette.metricCyan, fracOver(spo2, 100), key: "spo2")
+        case .respiratory:
+            let resp = displayDay?.respRateBpm ?? vitalsDay?.respRateBpm
+            ktile(String(localized: "Respiratory"), resp.map { String(format: "%.1f", $0) } ?? "—", "rpm", StrandPalette.accent, fracOver(resp, 24), key: "resp_rate")
+        case .steps:
+            ktile(String(localized: "Steps"), stepsText, "", StrandPalette.chargeColor, fracOver(stepCount, 10000), key: "steps")
+        case .weight:
+            ktile(String(localized: "Weight"), "—", "", StrandPalette.metricAmber, nil, key: "weight")
+        case .calories:
+            ktile(String(localized: "Calories"), intText(displayDay?.activeKcalEst), "kcal", StrandPalette.metricAmber, fracOver(displayDay?.activeKcalEst, 800), key: "energy_kcal")
+        }
+    }
+
+    private func ktile(_ label: String, _ value: String, _ unit: String, _ tint: Color, _ frac: Double?,
+                       key: String? = nil) -> some View {
+        let tile = VStack(alignment: .leading, spacing: 6) {
             Text(label.uppercased()).font(StrandFont.overlineScaled(9)).tracking(1.2)
                 .foregroundStyle(StrandPalette.textTertiary)
             (Text(value).font(StrandFont.number(17))
@@ -778,6 +835,20 @@ struct LiquidTodayView: View {
                 .lineLimit(1)
                 .minimumScaleFactor(0.7)
             LiquidTube(frac: frac ?? 0, tint: tint, height: 8, animated: false)
+            // #430 parity: DETAILED tiles grow the 14-day trend graph under the bar, tinted to the metric
+            // (the Android twin). A metric with no windowed series keeps a clear placeholder of the same
+            // height so every tile in a detailed row stays equal-height with its bars aligned.
+            if keyMetricsDetailed {
+                if let key, let spark = kSparks[key], spark.count >= 2 {
+                    Sparkline(values: Array(spark.suffix(14)),
+                              gradient: Gradient(colors: [tint.opacity(0.5), tint]))
+                        .frame(height: 22)
+                        .padding(.top, 6)
+                        .accessibilityHidden(true)
+                } else {
+                    Color.clear.frame(height: 22).padding(.top, 6)
+                }
+            }
         }
         .padding(.horizontal, 12)
         .padding(.vertical, 11)
@@ -789,6 +860,16 @@ struct LiquidTodayView: View {
                     .strokeBorder(StrandPalette.hairline, lineWidth: 1))
                 .opacity(cardOpacity)
         )
+        // #430 parity: tap -> the metric's trend detail (the same Explore dossier its MetricRow pushes,
+        // closure-based NavigationLink per #38). A metric with no catalog entry stays inert.
+        return Group {
+            if let key, let metric = MetricCatalog.all.first(where: { $0.key == key }) {
+                NavigationLink { MetricDetailView(metric: metric) } label: { tile }
+                    .buttonStyle(.plain)
+            } else {
+                tile
+            }
+        }
     }
 
     // MARK: - Last workouts
@@ -933,6 +1014,27 @@ struct LiquidTodayView: View {
         // history doesn't stutter the UI. Snapshot the inputs (value types) into the detached task.
         let storedStress = await stressA
         let daysSnapshot = repo.days
+
+        // #430 parity: the trailing-14-day series the DETAILED Key-Metrics tiles graph — a trailing
+        // CALENDAR window ending on the selected day (not the last-N stored rows, which on an old import
+        // showed months-old data as a "14-day trend", issue #23). Keys mirror the metric catalog so a
+        // tile's graph, its tap-through detail and Android's Window all read the same signal. Rest reuses
+        // the already-loaded sleep_performance series (the same one the Rest score reads).
+        let sparkDF = DateFormatter()
+        sparkDF.locale = Locale(identifier: "en_US_POSIX")
+        sparkDF.dateFormat = "yyyy-MM-dd"
+        let sparkCutoff = sparkDF.string(from: cal.date(byAdding: .day, value: -13, to: dayStart) ?? dayStart)
+        let sparkRows = daysSnapshot.filter { $0.day >= sparkCutoff && $0.day <= selectedDayKey }
+        kSparks = [
+            "recovery": sparkRows.compactMap { $0.recovery },
+            "strain": sparkRows.compactMap { $0.strain },
+            "hrv": sparkRows.compactMap { $0.avgHrv },
+            "rhr": sparkRows.compactMap { $0.restingHr.map(Double.init) },
+            "spo2": sparkRows.compactMap { $0.spo2Pct },
+            "resp_rate": sparkRows.compactMap { $0.respRateBpm },
+            "sleep_performance": restSeries.filter { $0.day >= sparkCutoff && $0.day <= selectedDayKey }
+                .map { $0.value },
+        ]
         stress = await Task.detached(priority: .utility) {
             StressModel(days: daysSnapshot, stored: storedStress)?.score
         }.value

--- a/Strand/Liquid/LiquidTodayView.swift
+++ b/Strand/Liquid/LiquidTodayView.swift
@@ -58,8 +58,11 @@ struct LiquidTodayView: View {
     // tiles graph (keyed by metric-catalog key), filled by the loader alongside everything else.
     @AppStorage(KeyMetricPrefs.layoutKey) private var keyMetricsRaw = ""
     @AppStorage("today.keyMetricsDetailed") private var keyMetricsDetailed = false
+    /// The detailed graphs' trailing window — 2 days / 1 week / 2 weeks (shared key with Android). The
+    /// loader banks a day-keyed 14-day superset; render filters down, so a window change applies instantly.
+    @AppStorage("today.keyMetricsWindowDays") private var keyMetricsWindowDays = 14
     @State private var showKeyMetricsEditor = false
-    @State private var kSparks: [String: [Double]] = [:]
+    @State private var kSparks: [String: [(String, Double)]] = [:]
     private var enabledKeyMetrics: [KeyMetric] { KeyMetricPrefs.decodeEnabled(keyMetricsRaw) }
 
     // day navigation (0 = today, 1 = yesterday, …)
@@ -758,6 +761,31 @@ struct LiquidTodayView: View {
 
     // MARK: - Key metrics grid
 
+    /// The chosen detailed-graph window's oldest day key (2 days / 1 week / 2 weeks ending on the
+    /// selected day). The loader banks a 14-day superset; render filters down so a window change in the
+    /// editor applies instantly, no reload.
+    private var sparkWindowCutoffKey: String {
+        let days = (keyMetricsWindowDays == 2 || keyMetricsWindowDays == 7) ? keyMetricsWindowDays : 14
+        let cal = Calendar.current
+        let anchor = cal.startOfDay(for: selectedLogicalDay)
+        return Repository.localDayKey(cal.date(byAdding: .day, value: -(days - 1), to: anchor) ?? anchor)
+    }
+
+    /// A metric's spark values inside the chosen window, oldest → newest.
+    private func windowedSpark(_ key: String) -> [Double] {
+        let cutoff = sparkWindowCutoffKey
+        return (kSparks[key] ?? []).filter { $0.0 >= cutoff }.map { $0.1 }
+    }
+
+    /// The Key-Metrics header's trailing label for the chosen detailed-graph window (Android twin).
+    private var trendWindowLabel: String {
+        switch keyMetricsWindowDays {
+        case 2: return String(localized: "2-day trend")
+        case 7: return String(localized: "7-day trend")
+        default: return String(localized: "14-day trend")
+        }
+    }
+
     private var keyMetricsSection: some View {
         // HRV / Rest HR (+ Blood Oxygen / Respiratory) tiles share the recovery vitals' per-field
         // today-first carry so they don't blank at the rollover while Recovery/Strain/Rest stay strictly
@@ -766,7 +794,7 @@ struct LiquidTodayView: View {
         let rhr = (displayDay?.restingHr ?? vitalsDay?.restingHr).map(Double.init)
         return VStack(spacing: 8) {
             HStack(alignment: .firstTextBaseline, spacing: 8) {
-                sectionHead("KEY METRICS", trailing: "14-day trend")
+                sectionHead("KEY METRICS", trailing: trendWindowLabel)
                 // #430 parity: the SAME editor the classic grid uses — selection + order + Detailed tiles.
                 Button { showKeyMetricsEditor = true } label: {
                     Image(systemName: "slider.horizontal.3")
@@ -835,12 +863,14 @@ struct LiquidTodayView: View {
                 .lineLimit(1)
                 .minimumScaleFactor(0.7)
             LiquidTube(frac: frac ?? 0, tint: tint, height: 8, animated: false)
-            // #430 parity: DETAILED tiles grow the 14-day trend graph under the bar, tinted to the metric
-            // (the Android twin). A metric with no windowed series keeps a clear placeholder of the same
-            // height so every tile in a detailed row stays equal-height with its bars aligned.
+            // #430 parity: DETAILED tiles grow the trend graph under the bar, tinted to the metric and
+            // windowed to the editor's 2-day / 1-week / 2-week choice (the Android twin). A metric with no
+            // windowed series keeps a clear placeholder of the same height so every tile in a detailed row
+            // stays equal-height with its bars aligned.
             if keyMetricsDetailed {
-                if let key, let spark = kSparks[key], spark.count >= 2 {
-                    Sparkline(values: Array(spark.suffix(14)),
+                let spark = key.map { windowedSpark($0) } ?? []
+                if spark.count >= 2 {
+                    Sparkline(values: spark,
                               gradient: Gradient(colors: [tint.opacity(0.5), tint]))
                         .frame(height: 22)
                         .padding(.top, 6)
@@ -1015,25 +1045,23 @@ struct LiquidTodayView: View {
         let storedStress = await stressA
         let daysSnapshot = repo.days
 
-        // #430 parity: the trailing-14-day series the DETAILED Key-Metrics tiles graph — a trailing
-        // CALENDAR window ending on the selected day (not the last-N stored rows, which on an old import
-        // showed months-old data as a "14-day trend", issue #23). Keys mirror the metric catalog so a
-        // tile's graph, its tap-through detail and Android's Window all read the same signal. Rest reuses
-        // the already-loaded sleep_performance series (the same one the Rest score reads).
-        let sparkDF = DateFormatter()
-        sparkDF.locale = Locale(identifier: "en_US_POSIX")
-        sparkDF.dateFormat = "yyyy-MM-dd"
-        let sparkCutoff = sparkDF.string(from: cal.date(byAdding: .day, value: -13, to: dayStart) ?? dayStart)
+        // #430 parity: the day-keyed series the DETAILED Key-Metrics tiles graph — a trailing CALENDAR
+        // window ending on the selected day (not the last-N stored rows, which on an old import showed
+        // months-old data as a fresh trend, issue #23). The loader banks the 14-day SUPERSET; the chosen
+        // 2-day/1-week/2-week window filters at render (windowedSpark), so a picker change applies without
+        // a reload. Keys mirror the metric catalog so a tile's graph, its tap-through detail and Android's
+        // Window all read the same signal. Rest reuses the already-loaded sleep_performance series.
+        let sparkCutoff = Repository.localDayKey(cal.date(byAdding: .day, value: -13, to: dayStart) ?? dayStart)
         let sparkRows = daysSnapshot.filter { $0.day >= sparkCutoff && $0.day <= selectedDayKey }
         kSparks = [
-            "recovery": sparkRows.compactMap { $0.recovery },
-            "strain": sparkRows.compactMap { $0.strain },
-            "hrv": sparkRows.compactMap { $0.avgHrv },
-            "rhr": sparkRows.compactMap { $0.restingHr.map(Double.init) },
-            "spo2": sparkRows.compactMap { $0.spo2Pct },
-            "resp_rate": sparkRows.compactMap { $0.respRateBpm },
+            "recovery": sparkRows.compactMap { r in r.recovery.map { (r.day, $0) } },
+            "strain": sparkRows.compactMap { r in r.strain.map { (r.day, $0) } },
+            "hrv": sparkRows.compactMap { r in r.avgHrv.map { (r.day, $0) } },
+            "rhr": sparkRows.compactMap { r in r.restingHr.map { (r.day, Double($0)) } },
+            "spo2": sparkRows.compactMap { r in r.spo2Pct.map { (r.day, $0) } },
+            "resp_rate": sparkRows.compactMap { r in r.respRateBpm.map { (r.day, $0) } },
             "sleep_performance": restSeries.filter { $0.day >= sparkCutoff && $0.day <= selectedDayKey }
-                .map { $0.value },
+                .map { ($0.day, $0.value) },
         ]
         stress = await Task.detached(priority: .utility) {
             StressModel(days: daysSnapshot, stored: storedStress)?.score

--- a/Strand/Screens/KeyMetricsEditorSheet.swift
+++ b/Strand/Screens/KeyMetricsEditorSheet.swift
@@ -14,9 +14,12 @@ struct KeyMetricsEditorSheet: View {
     /// to the Today screen's @AppStorage so an edit takes effect live and survives relaunch.
     @Binding var layoutRaw: String
 
-    /// Detailed tiles (#430 parity with Android): squarer Key-Metric tiles with a 14-day trend graph under
-    /// the fill bar. Same persisted key as Android's editor switch ("today.keyMetricsDetailed"), applied live.
+    /// Detailed tiles (#430 parity with Android): squarer Key-Metric tiles with a trend graph under the
+    /// fill bar. Same persisted key as Android's editor switch ("today.keyMetricsDetailed"), applied live.
     @AppStorage("today.keyMetricsDetailed") private var detailed = false
+
+    /// The detailed graphs' trailing window — 2 days / 1 week / 2 weeks (shared key with Android).
+    @AppStorage("today.keyMetricsWindowDays") private var windowDays = 14
 
     @Environment(\.dismiss) private var dismiss
 
@@ -63,14 +66,14 @@ struct KeyMetricsEditorSheet: View {
     private var editorContent: some View {
         VStack(alignment: .leading, spacing: 18) {
             header
-            // Detailed tiles: the tile-style option (compact ktile vs squarer tile + 14-day graph). Twin
+            // Detailed tiles: the tile-style option (compact ktile vs squarer tile + trend graph). Twin
             // of the Android editor's switch; applies live via the shared @AppStorage key.
             Toggle(isOn: $detailed) {
                 VStack(alignment: .leading, spacing: 2) {
                     Text("Detailed tiles")
                         .font(StrandFont.body)
                         .foregroundStyle(StrandPalette.textPrimary)
-                    Text("Squarer tiles with a 14-day trend graph under the bar.")
+                    Text("Squarer tiles with a trend graph under the bar.")
                         .font(StrandFont.caption)
                         .foregroundStyle(StrandPalette.textSecondary)
                 }
@@ -78,6 +81,17 @@ struct KeyMetricsEditorSheet: View {
             .toggleStyle(.switch)
             .tint(StrandPalette.accent)
             .accessibilityLabel("Detailed tiles")
+            // The detailed graphs' trailing window, only shown while Detailed is on (Android twin).
+            if detailed {
+                Picker("Trend window", selection: $windowDays) {
+                    Text("2 days").tag(2)
+                    Text("1 week").tag(7)
+                    Text("2 weeks").tag(14)
+                }
+                .pickerStyle(.segmented)
+                .labelsHidden()
+                .accessibilityLabel("Trend window")
+            }
             // Each tile is its own frosted row, tinted by that metric's own accent, so the editor
             // reads like a stack of the cards it controls rather than a flat settings list.
             VStack(spacing: 8) {

--- a/Strand/Screens/KeyMetricsEditorSheet.swift
+++ b/Strand/Screens/KeyMetricsEditorSheet.swift
@@ -44,6 +44,23 @@ struct KeyMetricsEditorSheet: View {
     }
 
     var body: some View {
+        // #430 parity: the sheet is now ALSO presented from the liquid Today on iPhone — the macOS-shaped
+        // fixed 420pt width would overflow a 390pt phone, and ten rows + the toggle outgrow a sheet's
+        // height, so the phone presentation scrolls and sizes to the screen instead.
+        #if os(macOS)
+        editorContent
+            .padding(24)
+            .frame(width: 420)
+            .background(StrandPalette.surfaceOverlay)
+        #else
+        ScrollView {
+            editorContent.padding(20)
+        }
+        .background(StrandPalette.surfaceOverlay)
+        #endif
+    }
+
+    private var editorContent: some View {
         VStack(alignment: .leading, spacing: 18) {
             header
             // Detailed tiles: the tile-style option (compact ktile vs squarer tile + 14-day graph). Twin
@@ -70,9 +87,6 @@ struct KeyMetricsEditorSheet: View {
             }
             footer
         }
-        .padding(24)
-        .frame(width: 420)
-        .background(StrandPalette.surfaceOverlay)
     }
 
     // MARK: Rows

--- a/Strand/Screens/KeyMetricsEditorSheet.swift
+++ b/Strand/Screens/KeyMetricsEditorSheet.swift
@@ -14,6 +14,10 @@ struct KeyMetricsEditorSheet: View {
     /// to the Today screen's @AppStorage so an edit takes effect live and survives relaunch.
     @Binding var layoutRaw: String
 
+    /// Detailed tiles (#430 parity with Android): squarer Key-Metric tiles with a 14-day trend graph under
+    /// the fill bar. Same persisted key as Android's editor switch ("today.keyMetricsDetailed"), applied live.
+    @AppStorage("today.keyMetricsDetailed") private var detailed = false
+
     @Environment(\.dismiss) private var dismiss
 
     /// Working copy: the full ordered list with an enabled flag per tile. Enabled tiles come first in
@@ -42,6 +46,21 @@ struct KeyMetricsEditorSheet: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 18) {
             header
+            // Detailed tiles: the tile-style option (compact ktile vs squarer tile + 14-day graph). Twin
+            // of the Android editor's switch; applies live via the shared @AppStorage key.
+            Toggle(isOn: $detailed) {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Detailed tiles")
+                        .font(StrandFont.body)
+                        .foregroundStyle(StrandPalette.textPrimary)
+                    Text("Squarer tiles with a 14-day trend graph under the bar.")
+                        .font(StrandFont.caption)
+                        .foregroundStyle(StrandPalette.textSecondary)
+                }
+            }
+            .toggleStyle(.switch)
+            .tint(StrandPalette.accent)
+            .accessibilityLabel("Detailed tiles")
             // Each tile is its own frosted row, tinted by that metric's own accent, so the editor
             // reads like a stack of the cards it controls rather than a flat settings list.
             VStack(spacing: 8) {

--- a/Strand/Screens/MetricExplorerView.swift
+++ b/Strand/Screens/MetricExplorerView.swift
@@ -465,8 +465,10 @@ struct MetricDetailView: View {
     @EnvironmentObject var repo: Repository
     /// #430 parity: the detail carries the SAME backdrop as the screen that pushed it — the day-cycle sky
     /// when the setting is on, the plain canvas when off — so a Key-Metrics tile tap doesn't jar from the
-    /// liquid Today's sky to a flat page. Same key TodayView/LiquidTodayView gate on.
+    /// liquid Today's sky to a flat page. Same keys TodayView/LiquidTodayView gate on; "Sky behind cards"
+    /// extends the sky to the full viewport (softer settle) so the transparent cards reveal it throughout.
     @AppStorage(SceneBackgroundPrefs.enabledKey) private var showDayCycleBackground = true
+    @AppStorage(SkyBehindCardsPrefs.enabledKey) private var skyBehindCards = false
     // Profile basics for the Fitness Age not-ready countdown (age/sex gate its readiness lead). Injected
     // app-wide at the root; previews supply their own. Only read on the fitness_age empty-state path.
     @EnvironmentObject var profile: ProfileStore
@@ -685,12 +687,20 @@ struct MetricDetailView: View {
             .padding(NoopMetrics.screenPadding)
             .frame(maxWidth: .infinity, alignment: .leading)
         }
-        // Day-cycle-aware backdrop (#430 parity): the same top sky band every liquid screen uses when
-        // the setting is on; the plain canvas when off.
+        // Day-cycle-aware backdrop (#430 parity): the top sky band every liquid screen uses when the
+        // setting is on — or the FULL-viewport sky with the softer settle when "Sky behind cards" is also
+        // on (the LiquidTodayView treatment, so the transparent cards reveal it the whole way down); the
+        // plain canvas when off.
         .background(alignment: .top) {
             ZStack(alignment: .top) {
                 StrandPalette.surfaceBase
-                if showDayCycleBackground { liquidScaffoldSky() }
+                if showDayCycleBackground {
+                    LiquidSkyStatic(hour: nil, settleStrength: skyBehindCards ? 0.78 : 1)
+                        .frame(maxWidth: .infinity)
+                        .frame(height: skyBehindCards ? nil : 240, alignment: .top)
+                        .allowsHitTesting(false)
+                        .accessibilityHidden(true)
+                }
             }
             .ignoresSafeArea()
         }

--- a/Strand/Screens/MetricExplorerView.swift
+++ b/Strand/Screens/MetricExplorerView.swift
@@ -463,6 +463,10 @@ private struct MetricRow: View {
 struct MetricDetailView: View {
     let metric: MetricDescriptor
     @EnvironmentObject var repo: Repository
+    /// #430 parity: the detail carries the SAME backdrop as the screen that pushed it — the day-cycle sky
+    /// when the setting is on, the plain canvas when off — so a Key-Metrics tile tap doesn't jar from the
+    /// liquid Today's sky to a flat page. Same key TodayView/LiquidTodayView gate on.
+    @AppStorage(SceneBackgroundPrefs.enabledKey) private var showDayCycleBackground = true
     // Profile basics for the Fitness Age not-ready countdown (age/sex gate its readiness lead). Injected
     // app-wide at the root; previews supply their own. Only read on the fitness_age empty-state path.
     @EnvironmentObject var profile: ProfileStore
@@ -681,7 +685,15 @@ struct MetricDetailView: View {
             .padding(NoopMetrics.screenPadding)
             .frame(maxWidth: .infinity, alignment: .leading)
         }
-        .background(StrandPalette.surfaceBase)
+        // Day-cycle-aware backdrop (#430 parity): the same top sky band every liquid screen uses when
+        // the setting is on; the plain canvas when off.
+        .background(alignment: .top) {
+            ZStack(alignment: .top) {
+                StrandPalette.surfaceBase
+                if showDayCycleBackground { liquidScaffoldSky() }
+            }
+            .ignoresSafeArea()
+        }
         .navigationTitle(metric.title)
         .task(id: loadTaskID) { await load() }
         // Range changes the window, hence the correlation inputs — recompute the

--- a/android/app/src/main/java/com/noop/ui/HealthScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/HealthScreen.kt
@@ -1986,9 +1986,11 @@ fun VitalDetailScreen(vm: AppViewModel, key: String) {
     // reading -> that reading (trend to follow); two+ -> the trend. Pre-load falls through to trend.
     val loadedPoints = if (seriesLoaded) (detail?.points?.size ?: 0) else -1
     // #430 parity: the detail carries the SAME backdrop as the screen that pushed it — the day-cycle sky
-    // when the setting is on, the plain canvas when off — so a Key-Metrics tile tap doesn't jar from the
-    // liquid Today's sky to a flat page. Same gate every other liquid screen uses.
+    // when the setting is on (full-viewport when "Sky behind cards" is also on, so the transparent cards
+    // reveal it the whole way down; the top band otherwise), the plain canvas when off. Same gates the
+    // Today screen uses.
     val showDayCycleBackground = remember { NoopPrefs.showDayCycleBackground(context) }
+    val skyBehindCards = remember { NoopPrefs.skyBehindCards(context) }
     ScreenScaffold(
         title = detail?.title ?: "Vital Signs",
         subtitle = when {
@@ -1996,7 +1998,7 @@ fun VitalDetailScreen(vm: AppViewModel, key: String) {
             loadedPoints == 1 -> "Your latest reading — trend to follow."
             else -> "Historical trend from cached daily metrics."
         },
-        topBackground = if (showDayCycleBackground) { { LiquidScreenSky() } } else null,
+        topBackground = if (showDayCycleBackground) { { LiquidScreenSky(fillHeight = skyBehindCards) } } else null,
     ) {
         if (isSeriesBacked && !seriesLoaded) {
             DataPendingNote(

--- a/android/app/src/main/java/com/noop/ui/HealthScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/HealthScreen.kt
@@ -1985,6 +1985,10 @@ fun VitalDetailScreen(vm: AppViewModel, key: String) {
     // view isn't showing: Fitness Age with no reading yet -> what it still needs; ANY metric with a single
     // reading -> that reading (trend to follow); two+ -> the trend. Pre-load falls through to trend.
     val loadedPoints = if (seriesLoaded) (detail?.points?.size ?: 0) else -1
+    // #430 parity: the detail carries the SAME backdrop as the screen that pushed it — the day-cycle sky
+    // when the setting is on, the plain canvas when off — so a Key-Metrics tile tap doesn't jar from the
+    // liquid Today's sky to a flat page. Same gate every other liquid screen uses.
+    val showDayCycleBackground = remember { NoopPrefs.showDayCycleBackground(context) }
     ScreenScaffold(
         title = detail?.title ?: "Vital Signs",
         subtitle = when {
@@ -1992,6 +1996,7 @@ fun VitalDetailScreen(vm: AppViewModel, key: String) {
             loadedPoints == 1 -> "Your latest reading — trend to follow."
             else -> "Historical trend from cached daily metrics."
         },
+        topBackground = if (showDayCycleBackground) { { LiquidScreenSky() } } else null,
     ) {
         if (isSeriesBacked && !seriesLoaded) {
             DataPendingNote(

--- a/android/app/src/main/java/com/noop/ui/KeyMetricPrefs.kt
+++ b/android/app/src/main/java/com/noop/ui/KeyMetricPrefs.kt
@@ -61,6 +61,17 @@ object KeyMetricPrefs {
         NoopPrefs.of(context).edit().putBoolean(KEY_DETAILED, value).apply()
     }
 
+    private const val KEY_WINDOW = "today.keyMetricsWindowDays"
+
+    /** Trailing trend window (calendar days) the DETAILED tiles graph: 2, 7 or 14 (default). Shared key
+     *  with the iOS twin; an unknown stored value coerces to 14 so a bad pref can't skew the window math. */
+    fun detailWindowDays(context: Context): Int =
+        NoopPrefs.of(context).getInt(KEY_WINDOW, 14).let { if (it == 2 || it == 7 || it == 14) it else 14 }
+
+    fun setDetailWindowDays(context: Context, value: Int) {
+        NoopPrefs.of(context).edit().putInt(KEY_WINDOW, value).apply()
+    }
+
     /** The enabled tiles in display order. An empty/unset string yields the full default order. */
     fun enabled(context: Context): List<KeyMetric> =
         decodeEnabled(NoopPrefs.of(context).getString(KEY_LAYOUT, null))

--- a/android/app/src/main/java/com/noop/ui/TodayScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/TodayScreen.kt
@@ -4866,7 +4866,9 @@ private fun LiquidKeyTile(
                     color = data.tint,
                     modifier = Modifier
                         .fillMaxWidth()
-                        .padding(top = 2.dp)
+                        // A touch more air between the fill bar and the graph (tester feedback: the two
+                        // read as one element when they nearly touch).
+                        .padding(top = 6.dp)
                         .height(Metrics.sparkHeight),
                 )
             }

--- a/android/app/src/main/java/com/noop/ui/TodayScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/TodayScreen.kt
@@ -382,8 +382,10 @@ fun TodayScreen(
     // SharedPreferences isn't reactive, so it's mirrored into local state and re-read when the editor saves.
     var showMetricsEditor by remember { mutableStateOf(false) }
     var enabledKeyMetrics by remember { mutableStateOf(KeyMetricPrefs.enabled(context)) }
-    // Detailed Key-Metrics tiles (squarer + 14-day trend graph), set from the same editor.
+    // Detailed Key-Metrics tiles (squarer + trend graph), set from the same editor, plus the chosen
+    // trend window (2 days / 1 week / 2 weeks) the detailed graphs cover.
     var keyMetricsDetailed by remember { mutableStateOf(KeyMetricPrefs.detailed(context)) }
+    var keyMetricsWindowDays by remember { mutableStateOf(KeyMetricPrefs.detailWindowDays(context)) }
     // #today-layout: the user-ordered below-hero section list + its editor dialog flag. Read once (prefs
     // aren't reactive) and re-read on the editor's save, exactly like enabledKeyMetrics above.
     var showLayoutEditor by remember { mutableStateOf(false) }
@@ -784,13 +786,13 @@ fun TodayScreen(
     // day (oldest → newest, nulls dropped, mirrors remember14's windowing of the DailyMetric series), and
     // feed it to the Rest tile instead. Now the sparkline tracks the Rest score. Empty until loaded.
     var restCompositeSpark by remember { mutableStateOf<List<Double>>(emptyList()) }
-    LaunchedEffect(days, selectedDay) {
+    LaunchedEffect(days, selectedDay, keyMetricsWindowDays) {
         val byDay = runCatching {
             viewModel.repo.resolvedSeries("sleep_performance", "my-whoop", "0000-00-00", "9999-99-99",
                 strapDeviceId = viewModel.activeStrapId)
                 .values.associate { it.first to it.second }
         }.getOrDefault(emptyMap())
-        val cutoff = selectedDay.minusDays(13).toString()
+        val cutoff = selectedDay.minusDays((keyMetricsWindowDays - 1).toLong()).toString()
         val end = selectedDay.toString()
         restCompositeSpark = byDay.entries
             .filter { it.key in cutoff..end }
@@ -952,7 +954,7 @@ fun TodayScreen(
 
     // 14-day trailing calendar window ending on the phone's actual local day.
     // Old imports stay in history, but they do not fill the Today trend tiles.
-    val window = remember14(days, selectedDay)
+    val window = rememberTrendWindow(days, selectedDay, keyMetricsWindowDays)
 
     LaunchedEffect(days) {
         // #849: this footer pass is the heavy one. It derives HR per imported workout from raw strap samples
@@ -1361,7 +1363,7 @@ fun TodayScreen(
                         ) {
                             Row(verticalAlignment = Alignment.CenterVertically) {
                                 Box(modifier = Modifier.weight(1f)) {
-                                    SectionHeader("Key Metrics", overline = dayLabel, trailing = "14-day trend")
+                                    SectionHeader("Key Metrics", overline = dayLabel, trailing = trendWindowLabel(keyMetricsWindowDays))
                                 }
                                 TextButton(
                                     onClick = { showMetricsEditor = true },
@@ -1534,12 +1536,15 @@ fun TodayScreen(
         KeyMetricsEditorDialog(
             initial = enabledKeyMetrics,
             initialDetailed = keyMetricsDetailed,
+            initialWindowDays = keyMetricsWindowDays,
             onDismiss = { showMetricsEditor = false },
-            onSave = { metrics, detailed ->
+            onSave = { metrics, detailed, windowDays ->
                 KeyMetricPrefs.setEnabled(context, metrics)
                 KeyMetricPrefs.setDetailed(context, detailed)
+                KeyMetricPrefs.setDetailWindowDays(context, windowDays)
                 enabledKeyMetrics = metrics
                 keyMetricsDetailed = detailed
+                keyMetricsWindowDays = windowDays
                 showMetricsEditor = false
             },
         )
@@ -6214,15 +6219,20 @@ private data class Window(
 )
 
 /**
- * Build the 14-day windows from `recentDays`. Each series drops null days from the
- * trailing calendar window only, so stale imports do not draw a current-day trend.
+ * Build the trailing trend windows from `recentDays` over the chosen span (2 / 7 / 14 calendar days —
+ * the editor's detailed-graph window). Each series drops null days from the trailing calendar window
+ * only, so stale imports do not draw a current-day trend.
  */
 @Composable
-private fun remember14(days: List<com.noop.data.DailyMetric>, anchorDay: LocalDate): Window =
-    androidx.compose.runtime.remember(days, anchorDay) {
-        // Trailing 14 CALENDAR days ending today, NOT the last 14 stored rows, which on an old import
-        // were months-old data shown as a "14-day trend" (issue #23). ISO yyyy-MM-dd sorts chronologically.
-        val cutoff = anchorDay.minusDays(13).toString()
+private fun rememberTrendWindow(
+    days: List<com.noop.data.DailyMetric>,
+    anchorDay: LocalDate,
+    windowDays: Int,
+): Window =
+    androidx.compose.runtime.remember(days, anchorDay, windowDays) {
+        // Trailing CALENDAR days ending today, NOT the last N stored rows, which on an old import
+        // were months-old data shown as a fresh trend (issue #23). ISO yyyy-MM-dd sorts chronologically.
+        val cutoff = anchorDay.minusDays((windowDays - 1).toLong()).toString()
         val end = anchorDay.toString()
         val recent = days.filter { it.day >= cutoff && it.day <= end }
         fun series(pick: (DailyMetric) -> Double?): List<Double> = recent.mapNotNull(pick)
@@ -6458,6 +6468,13 @@ private fun grouped(value: Int): String =
 // reorder it, explicit arrows rather than drag so it behaves the same on every device. Mirrors the macOS
 // KeyMetricsEditorSheet.
 
+/** The Key-Metrics header's trailing label for the chosen detailed-graph window. */
+private fun trendWindowLabel(days: Int): String = when (days) {
+    2 -> "2-day trend"
+    7 -> "7-day trend"
+    else -> "14-day trend"
+}
+
 /** One editor row: a tile with its current enabled flag. The working list is rebuilt on each edit. */
 private data class EditableMetric(val metric: KeyMetric, val enabled: Boolean)
 
@@ -6465,11 +6482,14 @@ private data class EditableMetric(val metric: KeyMetric, val enabled: Boolean)
 private fun KeyMetricsEditorDialog(
     initial: List<KeyMetric>,
     initialDetailed: Boolean = false,
+    initialWindowDays: Int = 14,
     onDismiss: () -> Unit,
-    onSave: (List<KeyMetric>, Boolean) -> Unit,
+    onSave: (List<KeyMetric>, Boolean, Int) -> Unit,
 ) {
-    // Detailed tiles: taller/squarer with a 14-day trend graph under the fill bar (display-only).
+    // Detailed tiles: taller/squarer with a trend graph under the fill bar (display-only), over the
+    // chosen trailing window (2 days / 1 week / 2 weeks).
     var detailed by remember { mutableStateOf(initialDetailed) }
+    var windowDays by remember { mutableStateOf(initialWindowDays) }
     // Working copy: enabled tiles first (saved order), then the disabled remainder in the default order,     // so toggling one on drops it at the end of the visible set, and every known tile is listed once.
     val items = remember {
         val enabledSet = initial.toHashSet()
@@ -6512,7 +6532,7 @@ private fun KeyMetricsEditorDialog(
                     Column(modifier = Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(2.dp)) {
                         Text("Detailed tiles", style = NoopType.body, color = Palette.textPrimary)
                         Text(
-                            "Squarer tiles with a 14-day trend graph under the bar.",
+                            "Squarer tiles with a trend graph under the bar.",
                             style = NoopType.caption,
                             color = Palette.textSecondary,
                         )
@@ -6528,6 +6548,17 @@ private fun KeyMetricsEditorDialog(
                             uncheckedBorderColor = Palette.hairline,
                         ),
                         modifier = Modifier.semantics { contentDescription = "Detailed tiles" },
+                    )
+                }
+                // The detailed graphs' trailing window — 2 days / 1 week / 2 weeks (the NOOP signature
+                // segmented pill, same control the trend screens use). Only shown while Detailed is on.
+                if (detailed) {
+                    SegmentedPillControl(
+                        items = listOf(2, 7, 14),
+                        selection = windowDays,
+                        label = { when (it) { 2 -> "2 days"; 7 -> "1 week"; else -> "2 weeks" } },
+                        onSelect = { windowDays = it },
+                        modifier = Modifier.fillMaxWidth(),
                     )
                 }
                 HorizontalDivider(color = Palette.hairline, thickness = 1.dp)
@@ -6603,7 +6634,7 @@ private fun KeyMetricsEditorDialog(
                     ) { Text("Reset", style = NoopType.body) }
                     Spacer(Modifier.weight(1f))
                     Button(
-                        onClick = { onSave(items.filter { it.enabled }.map { it.metric }, detailed) },
+                        onClick = { onSave(items.filter { it.enabled }.map { it.metric }, detailed, windowDays) },
                         // At least one tile must stay visible, an empty grid reads as a bug, not a choice.
                         enabled = items.any { it.enabled },
                         colors = ButtonDefaults.buttonColors(


### PR DESCRIPTION
The iOS twin of #430, plus the trend-window option and the theme-backdrop carry-over on both platforms.

## iOS / macOS — Key Metrics parity (#430 twin)
- **Editor-driven liquid grid** (all ten metrics, selection + order, `today.keyMetrics`) via a new header edit affordance; the bespoke Sleep-hours ktile gives way to the shared Rest score tile.
- **Detailed tiles** switch (`today.keyMetricsDetailed`, shared key, live) — trend Sparkline per tile, day-keyed trailing-calendar series (issue-#23-safe), equal-height rows.
- **Tap → detail** — every tile pushes its Explore metric dossier.
- **iPhone-safe editor sheet** (re-review catch: it was macOS-shaped — fixed 420pt, no scroll).

## Both platforms — selectable trend window
Segmented **2 days / 1 week / 2 weeks** picker in the editor (shown while Detailed is on; shared key `today.keyMetricsWindowDays`, unknown → 14). Android re-windows the calendar series + Rest spark + header label; iOS filters a day-keyed superset at render (instant switch).

## Both platforms — the details carry the theme backdrop
- **Day-cycle background**: the detail screens (Android `VitalDetailScreen`, iOS `MetricDetailView`) now use the same sky slot/gates every liquid screen uses — sky band when on, plain canvas when off.
- **Sky behind cards**: when that mode is on, the details extend the sky to the **full viewport** with the softer settle (the exact Today treatment) so the **transparency slider reveals it under every card** — verified: both details' cards are the standard frosted components that read the card-appearance pref globally.

## Android polish
+4dp air between the fill bar and the detailed graph (tester feedback on 281).

## Verification
- **app-build green on both legs × five runs** (parity base → sheet fix → window → backdrop → sky-behind-cards).
- Android `compileFullDebugKotlin` + Today tests green throughout.
- On-device eyeball list: iPhone editor sheet, detailed-tile legibility per window, tap-throughs, and the three backdrop states (band / full-bleed / off) with the transparency slider.