### PR TITLE
feat: 1D / 2D / 2W ranges on the metric detail timeline (both platforms)

### DIFF
--- a/Strand/Screens/MetricExplorerView.swift
+++ b/Strand/Screens/MetricExplorerView.swift
@@ -107,18 +107,22 @@ private func metricGaugeFraction(_ m: MetricDescriptor, value: Double) -> Double
 
 // MARK: - Range
 
-/// The W/M/3M/6M/1Y/ALL window, driving the single SegmentedPillControl.
+/// The 1D/2D/W/2W/M/3M/6M/1Y/ALL window, driving the single SegmentedPillControl.
 enum ExploreRange: Int, CaseIterable, Identifiable, Hashable {
-    case week = 7, month = 30, quarter = 90, half = 180, year = 365, all = 0
+    case oneDay = 1, twoDays = 2, week = 7, twoWeeks = 14, month = 30, quarter = 90, half = 180, year = 365, all = 0
     var id: Int { rawValue }
     var label: String {
         switch self {
+        case .oneDay: return String(localized: "1D"); case .twoDays: return String(localized: "2D")
+        case .twoWeeks: return String(localized: "2W")
         case .week: return String(localized: "W"); case .month: return String(localized: "M"); case .quarter: return String(localized: "3M")
         case .half: return String(localized: "6M"); case .year: return String(localized: "1Y"); case .all: return String(localized: "ALL")
         }
     }
     var name: String {
         switch self {
+        case .oneDay: return String(localized: "day"); case .twoDays: return String(localized: "2 days")
+        case .twoWeeks: return String(localized: "2 weeks")
         case .week: return String(localized: "week"); case .month: return String(localized: "month"); case .quarter: return String(localized: "quarter")
         case .half: return String(localized: "6 months"); case .year: return String(localized: "year"); case .all: return String(localized: "all time")
         }
@@ -143,8 +147,8 @@ enum ExploreRange: Int, CaseIterable, Identifiable, Hashable {
 enum ExploreRangeGating {
     static func coerced(selection: ExploreRange, isUnlocked: (ExploreRange) -> Bool) -> ExploreRange {
         if isUnlocked(selection) { return selection }
-        return [ExploreRange.year, .half, .quarter, .month, .week]
-            .first { $0.days != nil && $0.rawValue <= selection.rawValue && isUnlocked($0) } ?? .week
+        return [ExploreRange.year, .half, .quarter, .month, .twoWeeks, .week, .twoDays, .oneDay]
+            .first { $0.days != nil && $0.rawValue <= selection.rawValue && isUnlocked($0) } ?? .oneDay
     }
 }
 
@@ -570,17 +574,20 @@ struct MetricDetailView: View {
     /// would actually show more than the range below it. Before that, every window is taken
     /// relative to the latest point, so thin history sat inside all of them and the six chips
     /// drew byte-identical charts (a week of data stretched full-width under a 1Y label).
-    /// W (the shortest) and ALL (the honest everything view) are never gated, so a calibrating
+    /// 1D (the shortest) and ALL (the honest everything view) are never gated, so a calibrating
     /// user always has a selectable range; until the series loads (or with no history at all)
     /// nothing is gated, since the empty state deliberately keeps the full range bar for context.
     private func isUnlocked(_ r: ExploreRange) -> Bool {
         guard loaded, !series.isEmpty else { return true }
         switch r {
-        case .week, .all: return true
-        case .month:   return historySpanDays > ExploreRange.week.rawValue
-        case .quarter: return historySpanDays > ExploreRange.month.rawValue
-        case .half:    return historySpanDays > ExploreRange.quarter.rawValue
-        case .year:    return historySpanDays > ExploreRange.half.rawValue
+        case .oneDay, .all: return true
+        case .twoDays:  return historySpanDays > ExploreRange.oneDay.rawValue
+        case .week:     return historySpanDays > ExploreRange.twoDays.rawValue
+        case .twoWeeks: return historySpanDays > ExploreRange.week.rawValue
+        case .month:    return historySpanDays > ExploreRange.twoWeeks.rawValue
+        case .quarter:  return historySpanDays > ExploreRange.month.rawValue
+        case .half:     return historySpanDays > ExploreRange.quarter.rawValue
+        case .year:     return historySpanDays > ExploreRange.half.rawValue
         }
     }
 

--- a/android/app/src/main/java/com/noop/ui/HealthScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/HealthScreen.kt
@@ -2341,7 +2341,10 @@ private fun asOfLabel(day: String?): String? {
 }
 
 internal enum class VitalDetailRange(val label: String, val days: Long?) {
+    ONE_DAY("1D", 1),
+    TWO_DAY("2D", 2),
     WEEK("W", 7),
+    TWO_WEEK("2W", 14),
     MONTH("M", 30),
     THREE_MONTH("3M", 90),
     SIX_MONTH("6M", 180),
@@ -2361,14 +2364,14 @@ internal fun vitalHistorySpanDays(points: List<Pair<String, Double>>): Long {
  *  LATEST reading, so with under a week of history every window returned the identical full point set
  *  and all six chips drew the same line (a week of data stretched full-width under a "1Y" label). A
  *  range only differs from its predecessor once the data span EXCEEDS the predecessor's window, so the
- *  unlocked set is a contiguous prefix: W always, M once span > 7 days, 3M once > 30, 6M once > 90,
- *  1Y once > 180, ALL once > 365. Locked chips render disabled rather than hidden so a calibrating
- *  user still learns the longer views exist; W staying unconditional means nobody is ever stranded
- *  with zero ranges. */
+ *  unlocked set is a contiguous prefix: 1D always, 2D once span > 1 day, W once > 2, 2W once > 7,
+ *  M once > 14, 3M once > 30, 6M once > 90, 1Y once > 180, ALL once > 365. Locked chips render disabled
+ *  rather than hidden so a calibrating user still learns the longer views exist; 1D (the shortest)
+ *  staying unconditional means nobody is ever stranded with zero ranges. */
 /**
  * The range the chips + caption actually describe, resolved NON-DESTRUCTIVELY (Swift parity with
  * MetricExplorerView.coercedSelection). A locked selection renders as the largest unlocked range with
- * a real finite window that is <= the selection, else WEEK. NOT ALL: coercing a locked default to ALL
+ * a real finite window that is <= the selection, else ONE_DAY. NOT ALL: coercing a locked default to ALL
  * would jump a calibrating user to the everything view. An unlocked selection is used verbatim, so the
  * chip un-coerces on its own once history grows.
  */
@@ -2377,7 +2380,7 @@ internal fun coercedVitalRange(range: VitalDetailRange, unlocked: List<VitalDeta
     return VitalDetailRange.entries
         .filter { it.days != null && it.ordinal <= range.ordinal && it in unlocked }
         .maxByOrNull { it.ordinal }
-        ?: VitalDetailRange.WEEK
+        ?: VitalDetailRange.ONE_DAY
 }
 
 internal fun unlockedVitalRanges(spanDays: Long): List<VitalDetailRange> {

--- a/android/app/src/test/java/com/noop/ui/VitalRangeGatingTest.kt
+++ b/android/app/src/test/java/com/noop/ui/VitalRangeGatingTest.kt
@@ -5,11 +5,12 @@ import org.junit.Test
 
 /**
  * Range-chip gating for the Vital Signs detail (#943, ryanbr). filterVitalPoints windows off the
- * LATEST reading, so with short history every window returns the same full point set and all six
+ * LATEST reading, so with short history every window returns the same full point set and all the
  * chips drew byte-identical charts. A range only shows something NEW once the data span EXCEEDS the
- * previous range's window, so the unlocked chips form a contiguous prefix with W always available
+ * previous range's window, so the unlocked chips form a contiguous prefix with 1D always available
  * (a calibrating user is never stranded with zero ranges). These pin the unlock boundaries: n daily
- * points span n-1 days, so a range unlocks at span > 7 / 30 / 90 / 180; W and ALL are never gated (Swift parity).
+ * points span n-1 days, so a range unlocks at span > 1 / 2 / 7 / 14 / 30 / 90 / 180; 1D and ALL are
+ * never gated (Swift parity).
  */
 class VitalRangeGatingTest {
 
@@ -37,36 +38,66 @@ class VitalRangeGatingTest {
         assertEquals(60L, vitalHistorySpanDays(sparse))
     }
 
-    // ── unlock boundaries (contiguous prefix, W unconditional) ──────────────────
+    // ── unlock boundaries (contiguous prefix, 1D unconditional) ─────────────────
 
-    @Test fun weekIsAlwaysUnlocked() {
-        assertEquals(listOf(VitalDetailRange.WEEK, VitalDetailRange.ALL), unlockedVitalRanges(0L))
+    @Test fun oneDayIsAlwaysUnlocked() {
+        assertEquals(listOf(VitalDetailRange.ONE_DAY, VitalDetailRange.ALL), unlockedVitalRanges(0L))
     }
 
-    @Test fun monthUnlocksWhenSpanExceedsAWeek() {
-        assertEquals(listOf(VitalDetailRange.WEEK, VitalDetailRange.ALL), unlockedVitalRanges(7L))
+    @Test fun twoDayUnlocksWhenSpanExceedsADay() {
+        assertEquals(listOf(VitalDetailRange.ONE_DAY, VitalDetailRange.ALL), unlockedVitalRanges(1L))
         assertEquals(
-            listOf(VitalDetailRange.WEEK, VitalDetailRange.MONTH, VitalDetailRange.ALL),
+            listOf(VitalDetailRange.ONE_DAY, VitalDetailRange.TWO_DAY, VitalDetailRange.ALL),
+            unlockedVitalRanges(2L),
+        )
+    }
+
+    @Test fun weekUnlocksWhenSpanExceedsTwoDays() {
+        assertEquals(3, unlockedVitalRanges(2L).size)
+        assertEquals(
+            listOf(
+                VitalDetailRange.ONE_DAY, VitalDetailRange.TWO_DAY, VitalDetailRange.WEEK,
+                VitalDetailRange.ALL,
+            ),
+            unlockedVitalRanges(3L),
+        )
+    }
+
+    @Test fun twoWeekUnlocksWhenSpanExceedsAWeek() {
+        assertEquals(4, unlockedVitalRanges(7L).size)
+        assertEquals(
+            listOf(
+                VitalDetailRange.ONE_DAY, VitalDetailRange.TWO_DAY, VitalDetailRange.WEEK,
+                VitalDetailRange.TWO_WEEK, VitalDetailRange.ALL,
+            ),
             unlockedVitalRanges(8L),
         )
     }
 
-    @Test fun threeMonthUnlocksWhenSpanExceedsAMonth() {
-        assertEquals(3, unlockedVitalRanges(30L).size)
+    @Test fun monthUnlocksWhenSpanExceedsTwoWeeks() {
+        assertEquals(5, unlockedVitalRanges(14L).size)
         assertEquals(
-            listOf(VitalDetailRange.WEEK, VitalDetailRange.MONTH, VitalDetailRange.THREE_MONTH, VitalDetailRange.ALL),
-            unlockedVitalRanges(31L),
+            listOf(
+                VitalDetailRange.ONE_DAY, VitalDetailRange.TWO_DAY, VitalDetailRange.WEEK,
+                VitalDetailRange.TWO_WEEK, VitalDetailRange.MONTH, VitalDetailRange.ALL,
+            ),
+            unlockedVitalRanges(15L),
         )
     }
 
+    @Test fun threeMonthUnlocksWhenSpanExceedsAMonth() {
+        assertEquals(6, unlockedVitalRanges(30L).size)
+        assertEquals(7, unlockedVitalRanges(31L).size)
+    }
+
     @Test fun sixMonthUnlocksWhenSpanExceedsThreeMonths() {
-        assertEquals(4, unlockedVitalRanges(90L).size)
-        assertEquals(5, unlockedVitalRanges(91L).size)
+        assertEquals(7, unlockedVitalRanges(90L).size)
+        assertEquals(8, unlockedVitalRanges(91L).size)
     }
 
     @Test fun yearUnlocksWhenSpanExceedsSixMonths() {
-        assertEquals(5, unlockedVitalRanges(180L).size)
-        assertEquals(6, unlockedVitalRanges(181L).size)
+        assertEquals(8, unlockedVitalRanges(180L).size)
+        assertEquals(9, unlockedVitalRanges(181L).size)
     }
 
     @Test fun allUnlocksWhenSpanExceedsAYear() {
@@ -77,29 +108,37 @@ class VitalRangeGatingTest {
     @Test fun largestUnlockedRangeIsTheCoercionTarget() {
         // A locked selection coerces DOWN to the largest unlocked range with a real finite window
         // that is <= the selection (never ALL), matching Swift's coercedSelection.
-        val wk1 = unlockedVitalRanges(3L)   // only WEEK + ALL unlocked
-        assertEquals(VitalDetailRange.WEEK, coercedVitalRange(VitalDetailRange.MONTH, wk1))
-        assertEquals(VitalDetailRange.WEEK, coercedVitalRange(VitalDetailRange.YEAR, wk1))
-        val span10 = unlockedVitalRanges(10L)  // WEEK + MONTH + ALL
-        assertEquals(VitalDetailRange.MONTH, coercedVitalRange(VitalDetailRange.YEAR, span10))
+        val span3 = unlockedVitalRanges(3L)   // 1D + 2D + W + ALL
+        assertEquals(VitalDetailRange.WEEK, coercedVitalRange(VitalDetailRange.MONTH, span3))
+        assertEquals(VitalDetailRange.WEEK, coercedVitalRange(VitalDetailRange.YEAR, span3))
+        val span10 = unlockedVitalRanges(10L)  // 1D + 2D + W + 2W + ALL
+        assertEquals(VitalDetailRange.TWO_WEEK, coercedVitalRange(VitalDetailRange.YEAR, span10))
         // An unlocked selection is kept verbatim; ALL is always selectable.
-        assertEquals(VitalDetailRange.WEEK, coercedVitalRange(VitalDetailRange.WEEK, wk1))
-        assertEquals(VitalDetailRange.ALL, coercedVitalRange(VitalDetailRange.ALL, wk1))
+        assertEquals(VitalDetailRange.WEEK, coercedVitalRange(VitalDetailRange.WEEK, span3))
+        assertEquals(VitalDetailRange.ALL, coercedVitalRange(VitalDetailRange.ALL, span3))
+        // With no finite window unlocked below the selection, coerce to the unconditional shortest.
+        assertEquals(VitalDetailRange.ONE_DAY, coercedVitalRange(VitalDetailRange.YEAR, unlockedVitalRanges(0L)))
     }
 
     // ── the gating rule really is the identical-window dedup rule ───────────────
 
     @Test fun lockedRangeWouldHaveDrawnTheSamePointsAsItsPredecessor() {
-        // 10 daily points, span 9: W (7 points) differs from M (all 10), so M is unlocked;
-        // 3M returns the identical set as M, so 3M is locked.
+        // 10 daily points, span 9: W (7 points) differs from 2W (all 10), so 2W is unlocked;
+        // M returns the identical set as 2W, so M is locked.
         val points = dailyPoints(10)
         val unlocked = unlockedVitalRanges(vitalHistorySpanDays(points))
-        assertEquals(listOf(VitalDetailRange.WEEK, VitalDetailRange.MONTH, VitalDetailRange.ALL), unlocked)
-        assertEquals(7, filterVitalPoints(points, VitalDetailRange.WEEK).size)
-        assertEquals(10, filterVitalPoints(points, VitalDetailRange.MONTH).size)
         assertEquals(
+            listOf(
+                VitalDetailRange.ONE_DAY, VitalDetailRange.TWO_DAY, VitalDetailRange.WEEK,
+                VitalDetailRange.TWO_WEEK, VitalDetailRange.ALL,
+            ),
+            unlocked,
+        )
+        assertEquals(7, filterVitalPoints(points, VitalDetailRange.WEEK).size)
+        assertEquals(10, filterVitalPoints(points, VitalDetailRange.TWO_WEEK).size)
+        assertEquals(
+            filterVitalPoints(points, VitalDetailRange.TWO_WEEK),
             filterVitalPoints(points, VitalDetailRange.MONTH),
-            filterVitalPoints(points, VitalDetailRange.THREE_MONTH),
         )
     }
 
@@ -109,5 +148,8 @@ class VitalRangeGatingTest {
         val week = filterVitalPoints(points, VitalDetailRange.WEEK)
         assertEquals(7, week.size)
         assertEquals(points.takeLast(7), week)
+        // The new short windows: 1D = just the latest day's reading, 2D = the last two days.
+        assertEquals(1, filterVitalPoints(points, VitalDetailRange.ONE_DAY).size)
+        assertEquals(2, filterVitalPoints(points, VitalDetailRange.TWO_DAY).size)
     }
 }


### PR DESCRIPTION
Tester request (with screenshot of the Recovery detail): the detail timeline's range selector should offer the short end — **1 day, 2 days, 1 week, 2 weeks** — not start at W.

## What
Both platforms' detail range selectors become **1D / 2D / W / 2W / M / 3M / 6M / 1Y / ALL**:
- **Android** — `VitalDetailRange` gains `ONE_DAY(1)` / `TWO_DAY(2)` / `TWO_WEEK(14)`. The #943 contiguous-prefix gating shifts with it (1D always unlocked; each range unlocks once the span exceeds its predecessor's window); the locked-selection coercion falls back to the unconditional shortest (1D).
- **iOS** — `ExploreRange` gains `oneDay(1)` / `twoDays(2)` / `twoWeeks(14)`: labels, names, the `isUnlocked` chain, and `coerced()`'s descent list + fallback all extended. Windowing is day-count-generic on both platforms, so the chart math needed no changes.

## Notes
- **1D on daily metrics = a single point** (today's reading) — present per the request; 2D is the shortest range that draws a line.
- The selector is now nine chips — worth an on-device look on narrower phones (the `SegmentedPillControl` scales, but 2D/2W labels are compact by design).
- This is the **detail screen's** selector; the Today tile-graph window picker (2d/1w/2w in Edit Key Metrics, #432) is separate and unchanged.

## Verification
- `VitalRangeGatingTest` re-pinned to the new chain + **three new boundary tests** (1D→2D, 2D→W, W→2W) and short-window filter coverage: **15/15** green; `VitalReadingsTableTest` 7/7.
- `compileFullDebugKotlin` clean; **app-build green on both legs** (Swift's exhaustive switches compiler-enforced across the new cases).