### PR TITLE
fix(android): sky-behind-cards reaches the lower cards on the detail timelines

### DIFF
--- a/android/app/src/main/java/com/noop/ui/Components.kt
+++ b/android/app/src/main/java/com/noop/ui/Components.kt
@@ -1146,6 +1146,12 @@ fun ScreenScaffold(
     // Mirrors the iOS ScreenScaffold `topBackground` slot — the scene is a SCREEN-level backdrop the
     // cards float OVER, not a card-clipped hero atmosphere.
     topBackground: (@Composable () -> Unit)? = null,
+    // When true, the [topBackground] fills the WHOLE viewport instead of the top band — the
+    // "sky behind cards" mode, identical to [LazyScreenScaffold]'s flag. The band container's
+    // status-bar offset would otherwise shift a full-height backdrop up and leave the bottom of
+    // the screen on plain canvas (the "sky doesn't reach the lower cards" report on the vital
+    // details). Defaulted, so every existing caller is byte-for-byte untouched.
+    fullBleedBackground: Boolean = false,
     content: @Composable ColumnScope.() -> Unit,
 ) {
     // The scrolling content column. Its OUTER modifier differs by path: with no topBackground it is the
@@ -1212,10 +1218,19 @@ fun ScreenScaffold(
         val statusBarTop = WindowInsets.statusBars.asPaddingValues().calculateTopPadding()
         Box(modifier = modifier.fillMaxSize().background(Palette.surfaceBase)) {
             Box(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .align(Alignment.TopCenter)
-                    .offset(y = -statusBarTop)
+                modifier = (
+                    if (fullBleedBackground) {
+                        // Sky-behind-cards: the backdrop fills the whole viewport (no band offset), so
+                        // the transparent content scrolls OVER a full-height sky. Identical to the lazy
+                        // twin's fullBleedBackground container.
+                        Modifier.fillMaxSize()
+                    } else {
+                        Modifier
+                            .fillMaxWidth()
+                            .align(Alignment.TopCenter)
+                            .offset(y = -statusBarTop)
+                    }
+                    )
                     // PERF (#scroll-jank): promote the static scene backdrop to its OWN compositing layer so
                     // its gradient + bitmap rasterise ONCE into a render node and are reused as a texture on
                     // every scroll frame, instead of the parent re-issuing the scene's `drawBehind` draw each

--- a/android/app/src/main/java/com/noop/ui/HealthScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/HealthScreen.kt
@@ -1999,6 +1999,9 @@ fun VitalDetailScreen(vm: AppViewModel, key: String) {
             else -> "Historical trend from cached daily metrics."
         },
         topBackground = if (showDayCycleBackground) { { LiquidScreenSky(fillHeight = skyBehindCards) } } else null,
+        // Sky-behind-cards needs the full-viewport container too — the band container's status-bar
+        // offset left the lower cards on plain canvas (tester report).
+        fullBleedBackground = showDayCycleBackground && skyBehindCards,
     ) {
         if (isSeriesBacked && !seriesLoaded) {
             DataPendingNote(


### PR DESCRIPTION
Tester report on 282: *"the backgrounds don't honor the sky behind the cards on the timelines."*

## Root cause
The **eager `ScreenScaffold`** only had the *band* backdrop container — top-aligned and **offset up by the status-bar inset**. #432 passed a full-height sky into that band container, so the sky shifted up and the **bottom of the screen stayed on plain canvas** — exactly where the readings/lower cards sit. The lazy twin (`LazyScreenScaffold`, which Today uses) grew an explicit `fullBleedBackground` container for precisely this reason (`fillMaxSize`, no offset).

## Fix
- The eager scaffold gains the **identical `fullBleedBackground` flag** (defaulted — every existing caller byte-for-byte untouched; the band path is unchanged).
- `VitalDetailScreen` passes `fullBleedBackground = showDayCycleBackground && skyBehindCards` alongside the full-height sky, matching Today's proven wiring exactly.

## Verification
`compileFullDebugKotlin` clean; `VitalRangeGatingTest` + `TodayLayoutPrefsTest` green. Android-only (the iOS detail reuses `LiquidTodayView`'s proven backdrop block, which has no band offset). **Needs the on-device look**: detail timeline with Sky behind cards on → sky under the readings card at the bottom.