### PR TITLE
feat: detail timeline ranges become W / 2W / 3W / M / 3M / 6M / 1Y / ALL

### DIFF
--- a/Strand/Screens/MetricExplorerView.swift
+++ b/Strand/Screens/MetricExplorerView.swift
@@ -107,22 +107,20 @@ private func metricGaugeFraction(_ m: MetricDescriptor, value: Double) -> Double
 
 // MARK: - Range
 
-/// The 1D/2D/W/2W/M/3M/6M/1Y/ALL window, driving the single SegmentedPillControl.
+/// The W/2W/3W/M/3M/6M/1Y/ALL window, driving the single SegmentedPillControl.
 enum ExploreRange: Int, CaseIterable, Identifiable, Hashable {
-    case oneDay = 1, twoDays = 2, week = 7, twoWeeks = 14, month = 30, quarter = 90, half = 180, year = 365, all = 0
+    case week = 7, twoWeeks = 14, threeWeeks = 21, month = 30, quarter = 90, half = 180, year = 365, all = 0
     var id: Int { rawValue }
     var label: String {
         switch self {
-        case .oneDay: return String(localized: "1D"); case .twoDays: return String(localized: "2D")
-        case .twoWeeks: return String(localized: "2W")
+        case .twoWeeks: return String(localized: "2W"); case .threeWeeks: return String(localized: "3W")
         case .week: return String(localized: "W"); case .month: return String(localized: "M"); case .quarter: return String(localized: "3M")
         case .half: return String(localized: "6M"); case .year: return String(localized: "1Y"); case .all: return String(localized: "ALL")
         }
     }
     var name: String {
         switch self {
-        case .oneDay: return String(localized: "day"); case .twoDays: return String(localized: "2 days")
-        case .twoWeeks: return String(localized: "2 weeks")
+        case .twoWeeks: return String(localized: "2 weeks"); case .threeWeeks: return String(localized: "3 weeks")
         case .week: return String(localized: "week"); case .month: return String(localized: "month"); case .quarter: return String(localized: "quarter")
         case .half: return String(localized: "6 months"); case .year: return String(localized: "year"); case .all: return String(localized: "all time")
         }
@@ -147,8 +145,8 @@ enum ExploreRange: Int, CaseIterable, Identifiable, Hashable {
 enum ExploreRangeGating {
     static func coerced(selection: ExploreRange, isUnlocked: (ExploreRange) -> Bool) -> ExploreRange {
         if isUnlocked(selection) { return selection }
-        return [ExploreRange.year, .half, .quarter, .month, .twoWeeks, .week, .twoDays, .oneDay]
-            .first { $0.days != nil && $0.rawValue <= selection.rawValue && isUnlocked($0) } ?? .oneDay
+        return [ExploreRange.year, .half, .quarter, .month, .threeWeeks, .twoWeeks, .week]
+            .first { $0.days != nil && $0.rawValue <= selection.rawValue && isUnlocked($0) } ?? .week
     }
 }
 
@@ -574,20 +572,19 @@ struct MetricDetailView: View {
     /// would actually show more than the range below it. Before that, every window is taken
     /// relative to the latest point, so thin history sat inside all of them and the six chips
     /// drew byte-identical charts (a week of data stretched full-width under a 1Y label).
-    /// 1D (the shortest) and ALL (the honest everything view) are never gated, so a calibrating
+    /// W (the shortest) and ALL (the honest everything view) are never gated, so a calibrating
     /// user always has a selectable range; until the series loads (or with no history at all)
     /// nothing is gated, since the empty state deliberately keeps the full range bar for context.
     private func isUnlocked(_ r: ExploreRange) -> Bool {
         guard loaded, !series.isEmpty else { return true }
         switch r {
-        case .oneDay, .all: return true
-        case .twoDays:  return historySpanDays > ExploreRange.oneDay.rawValue
-        case .week:     return historySpanDays > ExploreRange.twoDays.rawValue
-        case .twoWeeks: return historySpanDays > ExploreRange.week.rawValue
-        case .month:    return historySpanDays > ExploreRange.twoWeeks.rawValue
-        case .quarter:  return historySpanDays > ExploreRange.month.rawValue
-        case .half:     return historySpanDays > ExploreRange.quarter.rawValue
-        case .year:     return historySpanDays > ExploreRange.half.rawValue
+        case .week, .all: return true
+        case .twoWeeks:   return historySpanDays > ExploreRange.week.rawValue
+        case .threeWeeks: return historySpanDays > ExploreRange.twoWeeks.rawValue
+        case .month:      return historySpanDays > ExploreRange.threeWeeks.rawValue
+        case .quarter:    return historySpanDays > ExploreRange.month.rawValue
+        case .half:       return historySpanDays > ExploreRange.quarter.rawValue
+        case .year:       return historySpanDays > ExploreRange.half.rawValue
         }
     }
 

--- a/android/app/src/main/java/com/noop/ui/HealthScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/HealthScreen.kt
@@ -2344,10 +2344,9 @@ private fun asOfLabel(day: String?): String? {
 }
 
 internal enum class VitalDetailRange(val label: String, val days: Long?) {
-    ONE_DAY("1D", 1),
-    TWO_DAY("2D", 2),
     WEEK("W", 7),
     TWO_WEEK("2W", 14),
+    THREE_WEEK("3W", 21),
     MONTH("M", 30),
     THREE_MONTH("3M", 90),
     SIX_MONTH("6M", 180),
@@ -2367,14 +2366,15 @@ internal fun vitalHistorySpanDays(points: List<Pair<String, Double>>): Long {
  *  LATEST reading, so with under a week of history every window returned the identical full point set
  *  and all six chips drew the same line (a week of data stretched full-width under a "1Y" label). A
  *  range only differs from its predecessor once the data span EXCEEDS the predecessor's window, so the
- *  unlocked set is a contiguous prefix: 1D always, 2D once span > 1 day, W once > 2, 2W once > 7,
- *  M once > 14, 3M once > 30, 6M once > 90, 1Y once > 180, ALL once > 365. Locked chips render disabled
- *  rather than hidden so a calibrating user still learns the longer views exist; 1D (the shortest)
+ *  unlocked set is a contiguous prefix: W always, 2W once span > 7 days, 3W once > 14, M once > 21,
+ *  3M once > 30, 6M once > 90, 1Y once > 180, ALL once > 365. (The 1D/2D experiment was dropped: daily
+ *  metrics hold at most one point per day, so those windows could never draw a line.) Locked chips render
+ *  disabled rather than hidden so a calibrating user still learns the longer views exist; W (the shortest)
  *  staying unconditional means nobody is ever stranded with zero ranges. */
 /**
  * The range the chips + caption actually describe, resolved NON-DESTRUCTIVELY (Swift parity with
  * MetricExplorerView.coercedSelection). A locked selection renders as the largest unlocked range with
- * a real finite window that is <= the selection, else ONE_DAY. NOT ALL: coercing a locked default to ALL
+ * a real finite window that is <= the selection, else WEEK. NOT ALL: coercing a locked default to ALL
  * would jump a calibrating user to the everything view. An unlocked selection is used verbatim, so the
  * chip un-coerces on its own once history grows.
  */
@@ -2383,7 +2383,7 @@ internal fun coercedVitalRange(range: VitalDetailRange, unlocked: List<VitalDeta
     return VitalDetailRange.entries
         .filter { it.days != null && it.ordinal <= range.ordinal && it in unlocked }
         .maxByOrNull { it.ordinal }
-        ?: VitalDetailRange.ONE_DAY
+        ?: VitalDetailRange.WEEK
 }
 
 internal fun unlockedVitalRanges(spanDays: Long): List<VitalDetailRange> {

--- a/android/app/src/test/java/com/noop/ui/VitalRangeGatingTest.kt
+++ b/android/app/src/test/java/com/noop/ui/VitalRangeGatingTest.kt
@@ -7,10 +7,11 @@ import org.junit.Test
  * Range-chip gating for the Vital Signs detail (#943, ryanbr). filterVitalPoints windows off the
  * LATEST reading, so with short history every window returns the same full point set and all the
  * chips drew byte-identical charts. A range only shows something NEW once the data span EXCEEDS the
- * previous range's window, so the unlocked chips form a contiguous prefix with 1D always available
+ * previous range's window, so the unlocked chips form a contiguous prefix with W always available
  * (a calibrating user is never stranded with zero ranges). These pin the unlock boundaries: n daily
- * points span n-1 days, so a range unlocks at span > 1 / 2 / 7 / 14 / 30 / 90 / 180; 1D and ALL are
- * never gated (Swift parity).
+ * points span n-1 days, so a range unlocks at span > 7 / 14 / 21 / 30 / 90 / 180; W and ALL are
+ * never gated (Swift parity). The 1D/2D experiment was dropped — daily metrics hold at most one
+ * point per day, so those windows could never draw a line.
  */
 class VitalRangeGatingTest {
 
@@ -38,66 +39,55 @@ class VitalRangeGatingTest {
         assertEquals(60L, vitalHistorySpanDays(sparse))
     }
 
-    // ── unlock boundaries (contiguous prefix, 1D unconditional) ─────────────────
+    // ── unlock boundaries (contiguous prefix, W unconditional) ──────────────────
 
-    @Test fun oneDayIsAlwaysUnlocked() {
-        assertEquals(listOf(VitalDetailRange.ONE_DAY, VitalDetailRange.ALL), unlockedVitalRanges(0L))
-    }
-
-    @Test fun twoDayUnlocksWhenSpanExceedsADay() {
-        assertEquals(listOf(VitalDetailRange.ONE_DAY, VitalDetailRange.ALL), unlockedVitalRanges(1L))
-        assertEquals(
-            listOf(VitalDetailRange.ONE_DAY, VitalDetailRange.TWO_DAY, VitalDetailRange.ALL),
-            unlockedVitalRanges(2L),
-        )
-    }
-
-    @Test fun weekUnlocksWhenSpanExceedsTwoDays() {
-        assertEquals(3, unlockedVitalRanges(2L).size)
-        assertEquals(
-            listOf(
-                VitalDetailRange.ONE_DAY, VitalDetailRange.TWO_DAY, VitalDetailRange.WEEK,
-                VitalDetailRange.ALL,
-            ),
-            unlockedVitalRanges(3L),
-        )
+    @Test fun weekIsAlwaysUnlocked() {
+        assertEquals(listOf(VitalDetailRange.WEEK, VitalDetailRange.ALL), unlockedVitalRanges(0L))
     }
 
     @Test fun twoWeekUnlocksWhenSpanExceedsAWeek() {
-        assertEquals(4, unlockedVitalRanges(7L).size)
+        assertEquals(listOf(VitalDetailRange.WEEK, VitalDetailRange.ALL), unlockedVitalRanges(7L))
         assertEquals(
-            listOf(
-                VitalDetailRange.ONE_DAY, VitalDetailRange.TWO_DAY, VitalDetailRange.WEEK,
-                VitalDetailRange.TWO_WEEK, VitalDetailRange.ALL,
-            ),
+            listOf(VitalDetailRange.WEEK, VitalDetailRange.TWO_WEEK, VitalDetailRange.ALL),
             unlockedVitalRanges(8L),
         )
     }
 
-    @Test fun monthUnlocksWhenSpanExceedsTwoWeeks() {
-        assertEquals(5, unlockedVitalRanges(14L).size)
+    @Test fun threeWeekUnlocksWhenSpanExceedsTwoWeeks() {
+        assertEquals(3, unlockedVitalRanges(14L).size)
         assertEquals(
             listOf(
-                VitalDetailRange.ONE_DAY, VitalDetailRange.TWO_DAY, VitalDetailRange.WEEK,
-                VitalDetailRange.TWO_WEEK, VitalDetailRange.MONTH, VitalDetailRange.ALL,
+                VitalDetailRange.WEEK, VitalDetailRange.TWO_WEEK, VitalDetailRange.THREE_WEEK,
+                VitalDetailRange.ALL,
             ),
             unlockedVitalRanges(15L),
         )
     }
 
+    @Test fun monthUnlocksWhenSpanExceedsThreeWeeks() {
+        assertEquals(4, unlockedVitalRanges(21L).size)
+        assertEquals(
+            listOf(
+                VitalDetailRange.WEEK, VitalDetailRange.TWO_WEEK, VitalDetailRange.THREE_WEEK,
+                VitalDetailRange.MONTH, VitalDetailRange.ALL,
+            ),
+            unlockedVitalRanges(22L),
+        )
+    }
+
     @Test fun threeMonthUnlocksWhenSpanExceedsAMonth() {
-        assertEquals(6, unlockedVitalRanges(30L).size)
-        assertEquals(7, unlockedVitalRanges(31L).size)
+        assertEquals(5, unlockedVitalRanges(30L).size)
+        assertEquals(6, unlockedVitalRanges(31L).size)
     }
 
     @Test fun sixMonthUnlocksWhenSpanExceedsThreeMonths() {
-        assertEquals(7, unlockedVitalRanges(90L).size)
-        assertEquals(8, unlockedVitalRanges(91L).size)
+        assertEquals(6, unlockedVitalRanges(90L).size)
+        assertEquals(7, unlockedVitalRanges(91L).size)
     }
 
     @Test fun yearUnlocksWhenSpanExceedsSixMonths() {
-        assertEquals(8, unlockedVitalRanges(180L).size)
-        assertEquals(9, unlockedVitalRanges(181L).size)
+        assertEquals(7, unlockedVitalRanges(180L).size)
+        assertEquals(8, unlockedVitalRanges(181L).size)
     }
 
     @Test fun allUnlocksWhenSpanExceedsAYear() {
@@ -108,37 +98,32 @@ class VitalRangeGatingTest {
     @Test fun largestUnlockedRangeIsTheCoercionTarget() {
         // A locked selection coerces DOWN to the largest unlocked range with a real finite window
         // that is <= the selection (never ALL), matching Swift's coercedSelection.
-        val span3 = unlockedVitalRanges(3L)   // 1D + 2D + W + ALL
+        val span3 = unlockedVitalRanges(3L)   // W + ALL only
         assertEquals(VitalDetailRange.WEEK, coercedVitalRange(VitalDetailRange.MONTH, span3))
         assertEquals(VitalDetailRange.WEEK, coercedVitalRange(VitalDetailRange.YEAR, span3))
-        val span10 = unlockedVitalRanges(10L)  // 1D + 2D + W + 2W + ALL
-        assertEquals(VitalDetailRange.TWO_WEEK, coercedVitalRange(VitalDetailRange.YEAR, span10))
+        val span16 = unlockedVitalRanges(16L)  // W + 2W + 3W + ALL
+        assertEquals(VitalDetailRange.THREE_WEEK, coercedVitalRange(VitalDetailRange.YEAR, span16))
         // An unlocked selection is kept verbatim; ALL is always selectable.
         assertEquals(VitalDetailRange.WEEK, coercedVitalRange(VitalDetailRange.WEEK, span3))
         assertEquals(VitalDetailRange.ALL, coercedVitalRange(VitalDetailRange.ALL, span3))
-        // With no finite window unlocked below the selection, coerce to the unconditional shortest.
-        assertEquals(VitalDetailRange.ONE_DAY, coercedVitalRange(VitalDetailRange.YEAR, unlockedVitalRanges(0L)))
     }
 
     // ── the gating rule really is the identical-window dedup rule ───────────────
 
     @Test fun lockedRangeWouldHaveDrawnTheSamePointsAsItsPredecessor() {
         // 10 daily points, span 9: W (7 points) differs from 2W (all 10), so 2W is unlocked;
-        // M returns the identical set as 2W, so M is locked.
+        // 3W returns the identical set as 2W, so 3W is locked.
         val points = dailyPoints(10)
         val unlocked = unlockedVitalRanges(vitalHistorySpanDays(points))
         assertEquals(
-            listOf(
-                VitalDetailRange.ONE_DAY, VitalDetailRange.TWO_DAY, VitalDetailRange.WEEK,
-                VitalDetailRange.TWO_WEEK, VitalDetailRange.ALL,
-            ),
+            listOf(VitalDetailRange.WEEK, VitalDetailRange.TWO_WEEK, VitalDetailRange.ALL),
             unlocked,
         )
         assertEquals(7, filterVitalPoints(points, VitalDetailRange.WEEK).size)
         assertEquals(10, filterVitalPoints(points, VitalDetailRange.TWO_WEEK).size)
         assertEquals(
             filterVitalPoints(points, VitalDetailRange.TWO_WEEK),
-            filterVitalPoints(points, VitalDetailRange.MONTH),
+            filterVitalPoints(points, VitalDetailRange.THREE_WEEK),
         )
     }
 
@@ -148,8 +133,7 @@ class VitalRangeGatingTest {
         val week = filterVitalPoints(points, VitalDetailRange.WEEK)
         assertEquals(7, week.size)
         assertEquals(points.takeLast(7), week)
-        // The new short windows: 1D = just the latest day's reading, 2D = the last two days.
-        assertEquals(1, filterVitalPoints(points, VitalDetailRange.ONE_DAY).size)
-        assertEquals(2, filterVitalPoints(points, VitalDetailRange.TWO_DAY).size)
+        // The new 3W window: the last 21 daily points.
+        assertEquals(21, filterVitalPoints(points, VitalDetailRange.THREE_WEEK).size)
     }
 }


### PR DESCRIPTION
Tester verdict on 283: **1D/2D can never draw a line on daily metrics** (at most one point per day — 1D always fell into 'not enough history', 2D needed a gapless pair of days). Replaced with the requested graduated week-based set.

## What
Both platforms' detail selectors become **W / 2W / 3W / M / 3M / 6M / 1Y / ALL**:
- Dropped `ONE_DAY`/`TWO_DAY` (`oneDay`/`twoDays`), added `THREE_WEEK`/`threeWeeks` (21 days).
- The contiguous-prefix gating, coercion descent lists + fallbacks, and every exhaustive switch shifted accordingly; windowing stays day-count-generic.
- 1Y + ALL kept (ALL is the never-gated honest-everything view).

## Verification
- `VitalRangeGatingTest` re-pinned to the week chain: **14/14** green (+ readings-table 7/7).
- `compileFullDebugKotlin` clean; **app-build green on both legs**.