### PR TITLE
feat(android): Kotlin twin of the Recovery Index + Activity Balance Charge terms (#417)

### DIFF
--- a/android/app/src/main/java/com/noop/analytics/Baselines.kt
+++ b/android/app/src/main/java/com/noop/analytics/Baselines.kt
@@ -92,7 +92,18 @@ object Baselines {
      *  Charge build-up restarts cleanly. EXACT same key string as the iOS UserDefaults key. */
     const val recoveryBaselineEpochKey: String = "noop.recoveryBaselineEpoch"
 
-    /** Default per-metric configurations (HRV, resting HR, respiration, skin temp). */
+    /**
+     * Default per-metric configurations (HRV, resting HR, respiration, skin temp, daily
+     * Effort/strain).
+     *
+     * "strain" backs the RecoveryScorer Activity-Balance / previous-day-Effort term: bounds
+     * match `StrainScorer.maxStrain`'s 0-100 output scale (the Charge/Effort/Rest redesign's
+     * rescale of the historical 0-21 axis). floorSpread is wider than the physiological
+     * metrics above (5.0 vs ~1-2% of range elsewhere) because day-to-day training load is
+     * EXPECTED to swing hard (a rest day vs a hard day is a normal, large delta) — a tight
+     * floor would make the z-score hypersensitive to routine training variation. Same
+     * half-lives as the other metrics for consistency.
+     */
     val metricCfg: Map<String, MetricCfg> = mapOf(
         "hrv" to MetricCfg(
             minVal = 5.0, maxVal = 250.0, floorSpread = 5.0,
@@ -110,6 +121,10 @@ object Baselines {
             minVal = 20.0, maxVal = 42.0, floorSpread = 0.3,
             halfLifeB = 14.0, halfLifeS = 21.0,
         ),
+        "strain" to MetricCfg(
+            minVal = 0.0, maxVal = 100.0, floorSpread = 5.0,
+            halfLifeB = 14.0, halfLifeS = 21.0,
+        ),
     )
 
     /** Convenience accessor for the standard HRV config. */
@@ -120,6 +135,9 @@ object Baselines {
 
     /** Convenience accessor for the standard respiration config. */
     val respCfg: MetricCfg get() = metricCfg.getValue("resp")
+
+    /** Baseline config for the RecoveryScorer Activity-Balance / previous-day-Effort term. */
+    val strainCfg: MetricCfg get() = metricCfg.getValue("strain")
 
     /** Convert a half-life in nights to an EWMA smoothing factor. */
     internal fun lambda(halfLife: Double): Double = 1.0 - 0.5.pow(1.0 / halfLife)

--- a/android/app/src/main/java/com/noop/analytics/RecoveryScorer.kt
+++ b/android/app/src/main/java/com/noop/analytics/RecoveryScorer.kt
@@ -31,6 +31,18 @@ import kotlin.math.roundToInt
  * the term drops and the remaining weights renormalize, so the score is IDENTICAL to
  * the pre-skin-temp model (the no-skin-temp path is byte-for-byte unchanged).
  *
+ * Two OPTIONAL Oura-Readiness-style terms (dormant until a caller supplies them):
+ *   overnight resting-HR DECLINE slope ("Recovery Index")      → W_RECOVERY_INDEX    = 0.05
+ *   previous-day Effort vs personal baseline ("Activity Balance" /
+ *   "Previous Day Activity", collapsed into one term)          → W_ACTIVITY_BALANCE  = 0.05
+ * Both are ADDITIVE and NON-BREAKING: each is null unless the caller supplies it, in which
+ * case it folds in with its small weight above; when null the term drops and the weights
+ * renormalize exactly like the skin-temp term, so the default score for every existing caller
+ * is BYTE-IDENTICAL to before either term existed. Recovery Index needs no personal baseline
+ * (a fixed, documented bpm/hour scale, same style as sleepPerf/skin-temp); Activity Balance
+ * needs BOTH the previous-day Effort value AND its EWMA baseline ([Baselines.strainCfg]) —
+ * supplying only one drops the term.
+ *
  * Each metric is standardized to a robust z-score against the personal baseline
  * (mean + EWMA-abs-dev spread). Missing terms are dropped and the weights
  * renormalized. The composite z is squashed through a logistic anchored so that
@@ -69,6 +81,32 @@ object RecoveryScorer {
      * Charge diverged from macOS/iOS by the skin-temp term. (Cross-platform parity.)
      */
     const val skinTempDevScale: Double = 1.0
+
+    /**
+     * Recovery-Index weight (overnight resting-HR DECLINE slope — Oura's "Recovery Index"
+     * contributor). Small and additive like [wSkinTemp]: folds in only when a slope is
+     * supplied. Mirrors Swift `RecoveryScorer.wRecoveryIndex`.
+     */
+    const val wRecoveryIndex: Double = 0.05
+
+    /**
+     * Recovery-Index slope scale (bpm/hour): a slope this many bpm/hour steeper than flat (0)
+     * costs/earns ≈ 1 z-unit before weighting. Resting HR falling through the night is the
+     * physiologically expected, good pattern; flat or rising (illness, alcohol, a late
+     * stimulant, restlessness) is not. The SIGN carries the meaning (negative = declining =
+     * good), unlike skin-temp's symmetric |deviation| penalty. Mirrors Swift
+     * `RecoveryScorer.recoveryIndexScaleBpmPerHr`.
+     */
+    const val recoveryIndexScaleBpmPerHr: Double = 2.0
+
+    /**
+     * Activity-Balance / previous-day-Effort weight (collapses Oura's "Previous Day Activity"
+     * and "Activity Balance" readiness contributors into one term). Small and additive like
+     * [wSkinTemp]: folds in only when BOTH a previous-day Effort value and its personal EWMA
+     * baseline ([Baselines.strainCfg]) are supplied. Mirrors Swift
+     * `RecoveryScorer.wActivityBalance`.
+     */
+    const val wActivityBalance: Double = 0.05
 
     /** Logistic spread: ±2 z-units ≈ full Red–Green band (15%–95%). */
     const val logisticK: Double = 1.6
@@ -163,6 +201,70 @@ object RecoveryScorer {
     }
 
     // ─────────────────────────────────────────────────────────────────────────
+    // Recovery Index (overnight HR-decline slope)
+    // ─────────────────────────────────────────────────────────────────────────
+
+    /**
+     * Minimum 5-minute bins ([restingHR]'s SAME binning) required before a slope is trusted —
+     * below this, too little of the night has elapsed to fit a trend, and a 1-2-point
+     * regression is noise, not a night-long pattern. 6 bins = 30 minutes of binned coverage,
+     * a deliberately low floor so a short/partial night still gets a number rather than a
+     * routine null. Mirrors Swift `RecoveryScorer.recoveryIndexMinBins`.
+     */
+    const val recoveryIndexMinBins: Int = 6
+
+    /**
+     * Overnight resting-HR DECLINE slope (bpm/hour) across the in-bed window — the "Recovery
+     * Index" component of Oura's Readiness that Charge lacked (it previously only read the
+     * overnight FLOOR via [restingHR] above, never the trend that reaches it).
+     *
+     * Computed as the least-squares slope of the SAME non-overlapping 5-minute HR bin means
+     * [restingHR] uses ([restingHRWindowS]) against each bin's midpoint time (hours from
+     * `start`). NEGATIVE = declining (HR falling through the night — the physiologically
+     * expected, good pattern); POSITIVE = rising (restlessness, illness, alcohol, a late
+     * stimulant). Returns null when fewer than [recoveryIndexMinBins] bins have data (too
+     * little of the window to fit a trend) or there are no samples at all — it never
+     * fabricates a slope from a sliver of the night. Mirrors Swift `recoveryIndexSlope`.
+     *
+     * @param start / @param end window bounds, unix SECONDS (Long).
+     */
+    fun recoveryIndexSlope(hr: List<HrSample>, start: Long, end: Long): Double? {
+        val seg = hr.filter { it.ts in start..end }
+        if (seg.isEmpty()) return null
+
+        // Same non-overlapping 5-minute binning as restingHR: both read the identical
+        // underlying series, one as a floor, one as a trend across it.
+        val points = ArrayList<Pair<Double, Double>>() // (tHours, meanBpm)
+        var t = start
+        while (t < end) {
+            val binEnd = t + restingHRWindowS
+            val win = seg.filter { it.ts >= t && it.ts < binEnd }
+            if (win.isNotEmpty()) {
+                val mean = win.sumOf { it.bpm }.toDouble() / win.size.toDouble()
+                val midpointS = (t - start).toDouble() + restingHRWindowS / 2.0
+                points.add((midpointS / 3600.0) to mean)
+            }
+            t += restingHRWindowS
+        }
+        if (points.size < recoveryIndexMinBins) return null
+
+        // Least-squares slope: Σ((t−t̄)(y−ȳ)) / Σ((t−t̄)²), bpm per hour.
+        val n = points.size.toDouble()
+        val tBar = points.sumOf { it.first } / n
+        val yBar = points.sumOf { it.second } / n
+        var num = 0.0
+        var den = 0.0
+        for ((tHours, meanBpm) in points) {
+            val dt = tHours - tBar
+            num += dt * (meanBpm - yBar)
+            den += dt * dt
+        }
+        // Degenerate (all bins at the same instant): no time spread to fit against.
+        if (den <= 1e-9) return 0.0
+        return num / den
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
     // Recovery band
     // ─────────────────────────────────────────────────────────────────────────
 
@@ -212,6 +314,19 @@ object RecoveryScorer {
      *   identical to the pre-skin-temp model).
      * @param hrvBaselineUsable whether the HRV baseline has enough nights
      *   (BaselineState.usable). When false, returns null (cold-start).
+     * @param recoveryIndexSlope overnight resting-HR DECLINE slope (bpm/hour, from
+     *   [recoveryIndexSlope]). Negative (declining) supports recovery; positive (rising)
+     *   limits it, weight [wRecoveryIndex]. null (the default) drops the term and the
+     *   weights renormalize, so the no-slope score is IDENTICAL to before this parameter
+     *   existed.
+     * @param effortBaseline personal EWMA baseline of daily Effort/strain
+     *   ([Baselines.strainCfg]). Needs [priorDayEffort] too — supplying only one drops
+     *   the term.
+     * @param priorDayEffort yesterday's Effort/strain (0–100, StrainScorer.strain). Lower vs
+     *   [effortBaseline] supports recovery, same "lower is better" direction as RHR/resp,
+     *   weight [wActivityBalance]. null (the default, like effortBaseline) drops the term
+     *   and the weights renormalize, so the no-effort score is IDENTICAL to before either
+     *   parameter existed.
      */
     fun recovery(
         hrv: Double,
@@ -223,6 +338,9 @@ object RecoveryScorer {
         sleepPerf: Double?,
         skinTempDev: Double? = null,
         hrvBaselineUsable: Boolean = true,
+        recoveryIndexSlope: Double? = null,
+        effortBaseline: DriverBaseline? = null,
+        priorDayEffort: Double? = null,
     ): Double? {
         // Cold-start gate: HRV is the dominant driver; if its baseline isn't
         // usable, refuse to score (more honest than a fabricated value).
@@ -251,6 +369,20 @@ object RecoveryScorer {
         if (skinTempDev != null) {
             terms.add((-abs(skinTempDev) / skinTempDevScale) to wSkinTemp)
         }
+        // Recovery-Index term: overnight HR-DECLINE slope (bpm/hour). No baseline needed (a
+        // fixed, documented scale, same style as sleepPerf/skin-temp). Negative (declining)
+        // supports recovery; positive (rising) limits it. Added only when supplied.
+        if (recoveryIndexSlope != null) {
+            terms.add((-recoveryIndexSlope / recoveryIndexScaleBpmPerHr) to wRecoveryIndex)
+        }
+        // Activity-Balance / previous-day-Effort term: lower vs personal baseline is better,
+        // same "lower is better" direction as RHR/resp → (μ − x) / σ. Needs BOTH the value
+        // and a baseline, matching resp's pattern; added only when both are supplied.
+        if (priorDayEffort != null && effortBaseline != null) {
+            terms.add(
+                zScore(effortBaseline.mean, priorDayEffort, effortBaseline.spread) to wActivityBalance,
+            )
+        }
 
         if (terms.isEmpty()) return null
         val totalWeight = terms.sumOf { it.second }
@@ -274,6 +406,9 @@ object RecoveryScorer {
         respBaseline: BaselineState?,
         sleepPerf: Double?,
         skinTempDev: Double? = null,
+        recoveryIndexSlope: Double? = null,
+        effortBaseline: BaselineState? = null,
+        priorDayEffort: Double? = null,
     ): Double? = recovery(
         hrv = hrv,
         rhr = rhr,
@@ -284,5 +419,8 @@ object RecoveryScorer {
         sleepPerf = sleepPerf,
         skinTempDev = skinTempDev,
         hrvBaselineUsable = hrvBaseline.usable,
+        recoveryIndexSlope = recoveryIndexSlope,
+        effortBaseline = effortBaseline?.let { DriverBaseline(it) },
+        priorDayEffort = priorDayEffort,
     )
 }

--- a/android/app/src/test/java/com/noop/analytics/RecoveryIndexActivityBalanceTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/RecoveryIndexActivityBalanceTest.kt
@@ -1,0 +1,249 @@
+package com.noop.analytics
+
+import com.noop.data.HrSample
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Tests the two OPTIONAL Oura-Readiness-style Charge terms (#417): the Recovery-Index
+ * overnight HR-decline slope and the Activity-Balance previous-day-Effort term, plus the
+ * "strain" MetricCfg that backs the latter. Faithful Kotlin mirror of the #417 cases in
+ * RecoveryScorerTests.swift / BaselinesTests.swift — same scenarios, same expected values,
+ * byte-identical logic. Both terms are DORMANT (null-default); the central claim pinned here
+ * is that every existing caller's score is byte-identical to before they existed.
+ */
+class RecoveryIndexActivityBalanceTest {
+
+    private val dev = "test"
+
+    private fun hr(ts: Long, bpm: Int) = HrSample(deviceId = dev, ts = ts, bpm = bpm)
+
+    /** A usable baseline with a given mean and Gaussian sigma (spread is internal abs-dev units). */
+    private fun baseline(mean: Double, sigma: Double, nValid: Int = 14): BaselineState =
+        BaselineState(
+            baseline = mean, spread = sigma / 1.253, nValid = nValid, nightsSinceUpdate = 0,
+            status = if (nValid >= 14) BaselineStatus.TRUSTED else BaselineStatus.PROVISIONAL,
+        )
+
+    /**
+     * A synthetic full-night HR series with a KNOWN injected slope: samples every 30 s for
+     * [hours] hours, bpm = startBpm + slopePerHour × elapsed-hours (rounded to the integer bpm
+     * the wire carries). Mirrors the Swift `slopeSeries` helper.
+     */
+    private fun slopeSeries(
+        startBpm: Double,
+        slopePerHour: Double,
+        hours: Int,
+    ): Triple<List<HrSample>, Long, Long> {
+        val originTs = 100_000L
+        val totalSeconds = hours * 3600
+        val samples = ArrayList<HrSample>()
+        var t = 0
+        while (t < totalSeconds) {
+            val bpm = startBpm + slopePerHour * (t.toDouble() / 3600.0)
+            samples.add(hr(originTs + t, Math.round(bpm).toInt()))
+            t += 30
+        }
+        return Triple(samples, originTs, originTs + totalSeconds)
+    }
+
+    // ── recoveryIndexSlope ───────────────────────────────────────────────────────
+
+    @Test
+    fun recoveryIndexSlopeNullWhenNoSamples() {
+        assertNull(RecoveryScorer.recoveryIndexSlope(emptyList(), 0L, 1000L))
+    }
+
+    @Test
+    fun recoveryIndexSlopeNullWhenTooFewBins() {
+        // Only 2 five-minute bins (10 minutes) of data — below recoveryIndexMinBins — too
+        // little of the night to fit a trend; must return null, never a fabricated slope.
+        val start = 5000L
+        val samples = ArrayList<HrSample>()
+        for (i in 0 until 300) samples.add(hr(start + i, 60))
+        for (i in 0 until 300) samples.add(hr(start + 300 + i, 55))
+        assertNull(RecoveryScorer.recoveryIndexSlope(samples, start, start + 600))
+    }
+
+    @Test
+    fun recoveryIndexSlopeRecoversMultipleDistinctInjectedSlopes() {
+        // Derived-signal rule: recover MULTIPLE distinct injected slopes, not one matched case.
+        // Four full-night (6 h) synthetic series: flat, mild decline, steep decline, rising.
+        val flat = slopeSeries(startBpm = 62.0, slopePerHour = 0.0, hours = 6)
+        val mild = slopeSeries(startBpm = 62.0, slopePerHour = -1.0, hours = 6)
+        val steep = slopeSeries(startBpm = 68.0, slopePerHour = -4.0, hours = 6)
+        val rising = slopeSeries(startBpm = 55.0, slopePerHour = 2.0, hours = 6)
+
+        val flatSlope = RecoveryScorer.recoveryIndexSlope(flat.first, flat.second, flat.third)
+        val mildSlope = RecoveryScorer.recoveryIndexSlope(mild.first, mild.second, mild.third)
+        val steepSlope = RecoveryScorer.recoveryIndexSlope(steep.first, steep.second, steep.third)
+        val risingSlope = RecoveryScorer.recoveryIndexSlope(rising.first, rising.second, rising.third)
+
+        assertNotNull(flatSlope); assertNotNull(mildSlope)
+        assertNotNull(steepSlope); assertNotNull(risingSlope)
+
+        // Each recovered slope is close to its OWN injected value (within integer-bpm rounding
+        // noise from the synthetic series), not just relatively ordered.
+        assertEquals(0.0, flatSlope!!, 0.3)
+        assertEquals(-1.0, mildSlope!!, 0.3)
+        assertEquals(-4.0, steepSlope!!, 0.3)
+        assertEquals(2.0, risingSlope!!, 0.3)
+
+        // And strictly ordered steep-decline < mild-decline < flat < rising.
+        assertTrue(steepSlope < mildSlope)
+        assertTrue(mildSlope < flatSlope)
+        assertTrue(flatSlope < risingSlope)
+    }
+
+    // ── Recovery Index / Activity-Balance folded into recovery(...) ──────────────
+
+    @Test
+    fun recoveryIndexAndActivityBalanceDefaultNullByteIdenticalToBefore() {
+        // Both new terms default to null; the score must be EXACTLY the same whether the caller
+        // omits them (every pre-existing call site in the app) or supplies null explicitly —
+        // proving the addition is non-breaking for every caller that does not yet supply the
+        // two new signals. Covers BOTH overloads (BaselineState convenience + raw DriverBaseline).
+        val omitted = RecoveryScorer.recovery(
+            hrv = 55.0, rhr = 52.0, resp = 14.0,
+            hrvBaseline = baseline(50.0, 6.0),
+            rhrBaseline = baseline(55.0, 3.0),
+            respBaseline = baseline(14.5, 1.0),
+            sleepPerf = 0.9,
+            skinTempDev = 0.4,
+        )!!
+        val explicitNull = RecoveryScorer.recovery(
+            hrv = 55.0, rhr = 52.0, resp = 14.0,
+            hrvBaseline = baseline(50.0, 6.0),
+            rhrBaseline = baseline(55.0, 3.0),
+            respBaseline = baseline(14.5, 1.0),
+            sleepPerf = 0.9,
+            skinTempDev = 0.4,
+            recoveryIndexSlope = null,
+            effortBaseline = null,
+            priorDayEffort = null,
+        )!!
+        assertEquals(omitted, explicitNull, 1e-9)
+
+        val hrvB = RecoveryScorer.DriverBaseline(mean = 50.0, spread = 6.0 / 1.253)
+        val rhrB = RecoveryScorer.DriverBaseline(mean = 55.0, spread = 3.0 / 1.253)
+        val rawOmitted = RecoveryScorer.recovery(
+            hrv = 55.0, rhr = 52.0, resp = null,
+            hrvBaseline = hrvB, rhrBaseline = rhrB, respBaseline = null,
+            sleepPerf = 0.9, skinTempDev = 0.4,
+        )!!
+        val rawExplicitNull = RecoveryScorer.recovery(
+            hrv = 55.0, rhr = 52.0, resp = null,
+            hrvBaseline = hrvB, rhrBaseline = rhrB, respBaseline = null,
+            sleepPerf = 0.9, skinTempDev = 0.4, hrvBaselineUsable = true,
+            recoveryIndexSlope = null, effortBaseline = null, priorDayEffort = null,
+        )!!
+        assertEquals(rawOmitted, rawExplicitNull, 1e-9)
+    }
+
+    @Test
+    fun recoveryIndexSteeperDeclineRaisesChargeMoreThanFlatOrRising() {
+        // Pin HRV/RHR/sleep at neutral so the ONLY thing moving is the slope term.
+        fun score(slope: Double?): Double = RecoveryScorer.recovery(
+            hrv = 50.0, rhr = 55.0, resp = null,
+            hrvBaseline = baseline(50.0, 6.0),
+            rhrBaseline = baseline(55.0, 3.0),
+            respBaseline = null,
+            sleepPerf = RecoveryScorer.sleepPerfCenter,
+            recoveryIndexSlope = slope,
+        )!!
+        val flat = score(0.0)
+        val mildDecline = score(-1.0)
+        val steepDecline = score(-4.0)
+        val rising = score(2.0)
+
+        // Multiple distinct slopes recovered in the expected order (derived-signal rule): a
+        // steeper decline raises the Charge contribution more than a flat or rising night.
+        assertTrue(steepDecline > mildDecline)
+        assertTrue(mildDecline > flat)
+        assertTrue(flat > rising)
+    }
+
+    @Test
+    fun activityBalanceHighEffortYesterdayLowersChargeVsRestDay() {
+        // Baseline drivers pinned ABOVE-center (positive composite z), same rigor as the
+        // skin-temp precedent test, so the effort term's renormalization dilution has a
+        // direction to push against.
+        fun score(effort: Double?): Double = RecoveryScorer.recovery(
+            hrv = 58.0, rhr = 50.0, resp = null,
+            hrvBaseline = baseline(50.0, 6.0),
+            rhrBaseline = baseline(55.0, 3.0),
+            respBaseline = null,
+            sleepPerf = 0.92,
+            effortBaseline = baseline(40.0, 15.0),
+            priorDayEffort = effort,
+        )!!
+        val neutral = score(null)
+        val atBaseline = score(40.0)   // exactly typical -> present term, z=0, dilutes toward center
+        val restDay = score(10.0)      // well below normal -> supports recovery further
+        val hardDay = score(65.0)      // above normal -> pulls recovery down
+        val veryHardDay = score(90.0)  // far above normal -> pulls down more
+
+        assertTrue(
+            "a present at-baseline effort term still dilutes an above-center composite toward the logistic center",
+            atBaseline < neutral,
+        )
+        assertTrue("a lighter-than-normal day supports recovery vs a typical day", restDay > atBaseline)
+        assertTrue("a harder-than-normal day pulls recovery down vs a typical day", atBaseline > hardDay)
+        // Multiple distinct levels recovered in strictly the expected monotonic order
+        // (derived-signal rule): more effort yesterday -> lower Charge contribution.
+        assertTrue(restDay > hardDay)
+        assertTrue(hardDay > veryHardDay)
+    }
+
+    @Test
+    fun activityBalanceDropsTermUnlessBothValueAndBaselineArePresent() {
+        fun score(effort: Double?, effortBaseline: BaselineState?): Double = RecoveryScorer.recovery(
+            hrv = 50.0, rhr = 55.0, resp = null,
+            hrvBaseline = baseline(50.0, 6.0),
+            rhrBaseline = baseline(55.0, 3.0),
+            respBaseline = null,
+            sleepPerf = RecoveryScorer.sleepPerfCenter,
+            effortBaseline = effortBaseline,
+            priorDayEffort = effort,
+        )!!
+        val neither = score(effort = null, effortBaseline = null)
+        val valueOnly = score(effort = 80.0, effortBaseline = null)
+        val baselineOnly = score(effort = null, effortBaseline = baseline(40.0, 15.0))
+        val both = score(effort = 80.0, effortBaseline = baseline(40.0, 15.0))
+
+        assertEquals("a value with no baseline must drop the term", neither, valueOnly, 1e-9)
+        assertEquals("a baseline with no value must drop the term", neither, baselineOnly, 1e-9)
+        assertNotEquals("supplying BOTH must actually change the score", neither, both, 1e-9)
+    }
+
+    // ── "strain" MetricCfg (Activity-Balance / previous-day-Effort baseline) ─────
+
+    @Test
+    fun strainCfgRegisteredWithEffortScaleBounds() {
+        // Bounds match StrainScorer.maxStrain's 0-100 output scale, keyed "strain" to match the
+        // existing internal metric-key convention (StrainScorer: "Internal metric key stays strain").
+        assertEquals(Baselines.metricCfg.getValue("strain"), Baselines.strainCfg)
+        assertEquals(0.0, Baselines.strainCfg.minVal, 1e-9)
+        assertEquals(100.0, Baselines.strainCfg.maxVal, 1e-9)
+    }
+
+    @Test
+    fun strainCfgIsBaselineRelativeOverDailyEffort() {
+        // A week of moderate days then a rest day: the baseline tracks the moderate norm, and
+        // the rest day reads as a clear BELOW-baseline ("lighter than usual") deviation.
+        val moderateWeek = listOf<Double?>(38.0, 42.0, 40.0, 36.0, 44.0, 39.0, 41.0)
+        val s = Baselines.foldHistory(moderateWeek, Baselines.strainCfg)
+        assertTrue(s.usable)
+        assertEquals(40.0, s.baseline, 5.0)
+
+        val restDay = Baselines.deviation(10.0, s)
+        assertTrue("a much-lighter-than-normal day must read BELOW the effort baseline", restDay.z < 0)
+
+        val hardDay = Baselines.deviation(85.0, s)
+        assertTrue("a much-harder-than-normal day must read ABOVE the effort baseline", hardDay.z > 0)
+    }
+}


### PR DESCRIPTION
## Summary

The Kotlin twin #417 explicitly deferred. Mirrors the two OPTIONAL, null-default Charge terms into `com.noop.analytics.RecoveryScorer` so both platforms' scorer APIs stay in step for whoever wires the capability later. **Still dormant** — no caller on either platform supplies the new signals, and every existing caller's Charge is byte-identical to before (pinned at 1e-9 by test, both overloads).

## What's mirrored (byte-parity with `StrandAnalytics/RecoveryScorer.swift`)

- **`recoveryIndexSlope(hr, start, end)`** — overnight resting-HR DECLINE slope (bpm/hour): least-squares over the SAME non-overlapping 5-minute bin means `restingHR` uses, bin-midpoint hours as the x-axis, `null` below `recoveryIndexMinBins` (6) populated bins or with no samples, `0.0` on a degenerate fit (`den <= 1e-9`).
- **`recovery(...)`** (both overloads) gains `recoveryIndexSlope` / `effortBaseline` / `priorDayEffort`, all null-default. Slope enters as `-slope / recoveryIndexScaleBpmPerHr` (2.0 bpm/hr per z, weight `wRecoveryIndex` 0.05); prior-day Effort enters lower-is-better vs its personal EWMA baseline (weight `wActivityBalance` 0.05), both-or-neither like the resp term.
- **`Baselines`** — `"strain"` MetricCfg (0–100 Effort scale, floorSpread 5.0 for expected day-to-day training swing, half-lives 14/21) + `strainCfg` accessor. All `metricCfg` consumers on both platforms are lookup-by-key (re-audited this PR: `IntelligenceEngine`, `HealthScreen` — no enumerators), so the new entry is inert.

## Verification

`RecoveryIndexActivityBalanceTest` mirrors the 9 Swift cases 1:1:
- slope: null on no-samples / too-few-bins; **multiple distinct injected slopes** (0 / −1 / −4 / +2 bpm/hr over synthetic 6 h nights) each recovered within 0.3 bpm/hr and strictly ordered (derived-signal rule)
- score: omitted-vs-explicit-null **byte-identity on both overloads** (1e-9); steeper decline > flat > rising through the full logistic; effort monotonic rest-day → very-hard-day ordering incl. at-baseline dilution; both-or-neither term drop
- baselines: strainCfg bounds/registration + baseline-relative rest-day/hard-day deviation signs

`testFullDebugUnitTest` (no build cache): **2684 tests, 0 failures**.

## Wiring requirements (unchanged, from #417)

Wiring these terms into live Charge remains a scoring change to the flagship metric → needs a default-off/experimental toggle or validated marginal impact, and must land on both platforms together. This PR only closes the API gap.