### PR TITLE
fix(sleep): restore pre-#348 V2 staging defaults — DREAMT wake tune over-calls awake in the field (#431)

### DIFF
--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/SleepStagerV2.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/SleepStagerV2.swift
@@ -141,43 +141,31 @@ public enum SleepStagerV2 {
     /// Population sleep-architecture base rates as log-priors (adult TST ≈ light 50 / deep 18 / rem 22 /
     /// waso 10 %). Calibrates the boundary so light wins weak-evidence epochs.
     static let baseLogPrior: [String: Double] = [
-        "light": log(0.50), "deep": log(0.15), "rem": log(0.22), "awake": log(0.34)]
+        "light": log(0.50), "deep": log(0.18), "rem": log(0.22), "awake": log(0.10)]
 
-    /// Deep-eligibility HR-flatness percentile gate. Raised 0.25 -> 0.40 by the DREAMT (n=100 wrist-optical
-    /// + PSG) joint re-tune: a clinical cohort with sparse N3, so deep is admitted only in the flattest
-    /// epochs and the over-call is cut. Held-out validated; AAUWSS + Walch also improved.
-    static let deepGateThresh = 0.40
+    /// Deep is eligible only in the night's lowest ~25 % HR-flatness epochs (≈ deep base rate + margin).
+    /// Widened 0.20 -> 0.25 by the multi-subject (AAUWSS + sleep-accel LOSO) deep-boundary tune, which
+    /// recovers the deep recall the other deep-tightening edits shed while keeping precision up.
+    static let deepGateThresh = 0.25
     static let deepGateSlope = 5.0
 
     /// Motion thresholds are RELATIVE to each night's own quiescent jerk floor (the median per-second
     /// gravity-jerk over the in-bed session), NOT an absolute g. Self-calibrates to the strap's
     /// gravity-decode scale and the wearer's fit.
-    /// DREAMT re-tune: move floor 38 -> 75 (stricter "moving"), gate 55 -> 35 (wake fires easier), boost 2 -> 4.
-    static let jerkFloorMoveMult = 75.0  // a per-second jerk counts as "moving" above floor × this
-    static let jerkFloorGateMult = 35.0  // wake-boost when an epoch's peak jerk exceeds floor × this
-    static let motionGateBoost = 4.0
+    static let jerkFloorMoveMult = 38.0  // a per-second jerk counts as "moving" above floor × this
+    static let jerkFloorGateMult = 55.0  // wake-boost when an epoch's peak jerk exceeds floor × this
+    static let motionGateBoost = 2.0
 
     /// Weight of the RSA respiration-regularity term (regular → deep, irregular → REM).
     static let respWeight = 0.6
 
-    /// Dead-zone (± this z) applied to the cardiac terms of the AWAKE emission: within the band the term is
-    /// zeroed, outside it is shrunk toward 0. Stops small HR / HR-variability wobble from voting wake.
-    /// DREAMT re-tune turned it on at 0.3 (protects Walch REM/wake balance).
-    static let awakeDeadzone = 0.30
-    static func dz(_ z: Double) -> Double {
-        if awakeDeadzone <= 0.0 { return z }
-        if z > awakeDeadzone { return z - awakeDeadzone }
-        if z < -awakeDeadzone { return z + awakeDeadzone }
-        return 0.0
-    }
-
     /// Transition matrix (rows = from, cols = to). Self-transitions dominate; deep↔rem rare; wake mostly
-    /// to/from light. A priori, not fit. DREAMT re-tuned self-loops + renormalised off-diagonals.
+    /// to/from light. A priori, not fit.
     static let transition: [String: [String: Double]] = [
-        "deep":  ["deep": 0.76, "rem": 0.012, "light": 0.216, "awake": 0.012],
-        "rem":   ["deep": 0.00333, "rem": 0.92, "light": 0.06667, "awake": 0.01],
-        "light": ["deep": 0.08, "rem": 0.08, "light": 0.80, "awake": 0.04],
-        "awake": ["deep": 0.0, "rem": 0.0, "light": 0.10, "awake": 0.90]]
+        "deep":  ["deep": 0.86, "rem": 0.007, "light": 0.126, "awake": 0.007],
+        "rem":   ["deep": 0.005, "rem": 0.88, "light": 0.10, "awake": 0.015],
+        "light": ["deep": 0.06, "rem": 0.06, "light": 0.85, "awake": 0.03],
+        "awake": ["deep": 0.01, "rem": 0.02, "light": 0.27, "awake": 0.70]]
 
     /// One 30 s epoch's recipe features. Optionals are "no measurement"; the z-score / percentile treat a
     /// missing value as the neutral centre so a sparse channel never blocks a stage.
@@ -390,6 +378,8 @@ public enum SleepStagerV2 {
     /// uniform start. Ties resolve to the earlier stage in `stageNames`.
     static func viterbi(_ emSeq: [[String: Double]]) -> [String] {
         if emSeq.isEmpty { return [] }
+        // Floor before ln so a zeroed transition entry (a legal hand-edit) can never hit ln(0) = -Inf
+        // and poison the lattice. Inert for the current matrix (no zero entries). Kept from #348.
         let logT = transition.mapValues { row in row.mapValues { log(max($0, 1e-9)) } }
         var V = emSeq[0]   // uniform start
         var back: [[String: String]] = []
@@ -448,10 +438,10 @@ public enum SleepStagerV2 {
             let zhrv = zhr(f.hr), zhvv = zhv(f.hrVar), zmvv = zmv(f.moveFrac)
             let gate = deepGateSlope * max(0.0, fpct(f.hrFlat11) - deepGateThresh)
             var em: [String: Double] = [
-                "deep": -0.8 * zhvv + 0.5 * zhrv - 0.1 * zmvv - gate + baseLogPrior["deep"]!,
-                "rem": 0.8 * zhvv - 0.4 * zmvv + 0.4 * zhrv + baseLogPrior["rem"]!,
+                "deep": -1.1 * zhvv - 0.5 * zmvv - gate + baseLogPrior["deep"]!,
+                "rem": 0.6 * zhvv - 0.6 * zmvv + 0.4 * zhrv + baseLogPrior["rem"]!,
                 "light": baseLogPrior["light"]!,
-                "awake": 1.0 * zmvv + 0.5 * dz(zhvv) + 0.6 * dz(zhrv) + baseLogPrior["awake"]!,
+                "awake": 1.0 * zmvv + 0.8 * zhvv + 0.4 * zhrv + baseLogPrior["awake"]!,
             ]
             let pr = cyclePrior(f.clock)
             for s in stageNames { em[s]! += pr[s]! }

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/SleepStagerV2Tests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/SleepStagerV2Tests.swift
@@ -202,7 +202,7 @@ final class SleepStagerV2Tests: XCTestCase {
         }
         let segs = SleepStagerV2.stageSession(start: start, end: start + dur, grav: grav, hr: hr, rr: rr, resp: [])
         let golden: [(Int, Int, String)] = [
-            (0, 5070, "deep"), (5070, 5280, "light"), (5280, 5550, "rem"),
+            (0, 5070, "deep"), (5070, 5310, "light"), (5310, 5550, "rem"),
             (5550, 10740, "light"), (10740, 16290, "rem"), (16290, 21600, "wake")]
         XCTAssertEqual(segs.count, golden.count, "segment count")
         for k in 0..<min(segs.count, golden.count) {
@@ -219,9 +219,9 @@ final class SleepStagerV2Tests: XCTestCase {
     /// row-sum invariant catches a renormalisation typo in the hand-edited matrix. (The inline deep EMISSION
     /// weights aren't named constants, so they stay guarded only at the gross level by the golden.)
     func testTunedDeepBoundaryConstantsArePinned() {
-        XCTAssertEqual(SleepStagerV2.deepGateThresh, 0.40)
+        XCTAssertEqual(SleepStagerV2.deepGateThresh, 0.25)
         XCTAssertEqual(SleepStagerV2.transition["deep"]!,
-                       ["deep": 0.76, "rem": 0.012, "light": 0.216, "awake": 0.012])
+                       ["deep": 0.86, "rem": 0.007, "light": 0.126, "awake": 0.007])
         for (from, row) in SleepStagerV2.transition {
             XCTAssertEqual(row.values.reduce(0, +), 1.0, accuracy: 1e-9, "transition row '\(from)' must sum to 1.0")
         }

--- a/android/app/src/main/java/com/noop/analytics/SleepStagerV2.kt
+++ b/android/app/src/main/java/com/noop/analytics/SleepStagerV2.kt
@@ -161,42 +161,30 @@ object SleepStagerV2 {
     /** Population sleep-architecture base rates as log-priors (adult TST ≈ light 50 / deep 18 / rem 22 /
      *  waso 10 %). Calibrates the boundary so light wins weak-evidence epochs. */
     private val baseLogPrior: Map<String, Double> = mapOf(
-        "light" to ln(0.50), "deep" to ln(0.15), "rem" to ln(0.22), "awake" to ln(0.34))
+        "light" to ln(0.50), "deep" to ln(0.18), "rem" to ln(0.22), "awake" to ln(0.10))
 
-    /** Deep-eligibility HR-flatness percentile gate. Raised 0.25 -> 0.40 by the DREAMT (n=100 wrist-optical
-     *  + PSG) joint re-tune: a clinical cohort with sparse N3, so deep is admitted only in the flattest
-     *  epochs and the over-call is cut. Held-out validated; AAUWSS + Walch also improved. */
-    internal const val deepGateThresh = 0.40
+    /** Deep is eligible only in the night's lowest ~25 % HR-flatness epochs (≈ deep base rate + margin).
+     *  Widened 0.20 -> 0.25 by the multi-subject (AAUWSS + sleep-accel LOSO) deep-boundary tune, which
+     *  recovers the deep recall the other deep-tightening edits shed while keeping precision up. */
+    internal const val deepGateThresh = 0.25
     private const val deepGateSlope = 5.0
 
     /** Motion thresholds are RELATIVE to each night's own quiescent jerk floor (median per-second jerk over
-     *  the session), NOT an absolute g — self-calibrates to the strap's gravity-decode scale + the fit.
-     *  DREAMT re-tune: move floor 38 -> 75 (stricter "moving"), gate 55 -> 35 (wake fires easier), boost 2 -> 4. */
-    private const val jerkFloorMoveMult = 75.0  // a per-second jerk counts as "moving" above floor × this
-    private const val jerkFloorGateMult = 35.0  // wake-boost when an epoch's peak jerk exceeds floor × this
-    private const val motionGateBoost = 4.0
+     *  the session), NOT an absolute g — self-calibrates to the strap's gravity-decode scale + the fit. */
+    private const val jerkFloorMoveMult = 38.0  // a per-second jerk counts as "moving" above floor × this
+    private const val jerkFloorGateMult = 55.0  // wake-boost when an epoch's peak jerk exceeds floor × this
+    private const val motionGateBoost = 2.0
 
     /** Weight of the RSA respiration-regularity term (regular → deep, irregular → REM). */
     private const val respWeight = 0.6
 
-    /** Dead-zone (± this z) applied to the cardiac terms of the AWAKE emission: within the band the term is
-     *  zeroed, outside it is shrunk toward 0. Stops small HR / HR-variability wobble from voting wake.
-     *  DREAMT re-tune turned it on at 0.3 (protects Walch REM/wake balance). */
-    private const val awakeDeadzone = 0.30
-    private fun dz(z: Double): Double = when {
-        awakeDeadzone <= 0.0 -> z
-        z > awakeDeadzone -> z - awakeDeadzone
-        z < -awakeDeadzone -> z + awakeDeadzone
-        else -> 0.0
-    }
-
     /** Transition matrix (rows = from, cols = to). Self-transitions dominate; deep↔rem rare; wake mostly
      *  to/from light. A priori, not fit. */
     internal val transition: Map<String, Map<String, Double>> = mapOf(
-        "deep" to mapOf("deep" to 0.76, "rem" to 0.012, "light" to 0.216, "awake" to 0.012),
-        "rem" to mapOf("deep" to 0.00333, "rem" to 0.92, "light" to 0.06667, "awake" to 0.01),
-        "light" to mapOf("deep" to 0.08, "rem" to 0.08, "light" to 0.80, "awake" to 0.04),
-        "awake" to mapOf("deep" to 0.0, "rem" to 0.0, "light" to 0.10, "awake" to 0.90))
+        "deep" to mapOf("deep" to 0.86, "rem" to 0.007, "light" to 0.126, "awake" to 0.007),
+        "rem" to mapOf("deep" to 0.005, "rem" to 0.88, "light" to 0.10, "awake" to 0.015),
+        "light" to mapOf("deep" to 0.06, "rem" to 0.06, "light" to 0.85, "awake" to 0.03),
+        "awake" to mapOf("deep" to 0.01, "rem" to 0.02, "light" to 0.27, "awake" to 0.70))
 
     /** One 30 s epoch's recipe features. Nullable means "no measurement"; the z-score / percentile treat a
      *  missing value as the neutral centre so a sparse channel never blocks a stage. */
@@ -423,6 +411,8 @@ object SleepStagerV2 {
      *  uniform start. Ties resolve to the earlier stage in [stageNames]. */
     private fun viterbi(emSeq: List<Map<String, Double>>): List<String> {
         if (emSeq.isEmpty()) return emptyList()
+        // Floor before ln so a zeroed transition entry (a legal hand-edit) can never hit ln(0) = -Inf
+        // and poison the lattice. Inert for the current matrix (no zero entries). Kept from #348.
         val logT = transition.mapValues { (_, row) -> row.mapValues { (_, v) -> ln(maxOf(v, 1e-9)) } }
         var v = emSeq[0]   // uniform start
         val back = ArrayList<Map<String, String>>()
@@ -481,10 +471,10 @@ object SleepStagerV2 {
             val zhrv = zhr(f.hr); val zhvv = zhv(f.hrVar); val zmvv = zmv(f.moveFrac)
             val gate = deepGateSlope * maxOf(0.0, fpct(f.hrFlat11) - deepGateThresh)
             val em = HashMap<String, Double>()
-            em["deep"] = -0.8 * zhvv + 0.5 * zhrv - 0.1 * zmvv - gate + baseLogPrior["deep"]!!
-            em["rem"] = 0.8 * zhvv - 0.4 * zmvv + 0.4 * zhrv + baseLogPrior["rem"]!!
+            em["deep"] = -1.1 * zhvv - 0.5 * zmvv - gate + baseLogPrior["deep"]!!
+            em["rem"] = 0.6 * zhvv - 0.6 * zmvv + 0.4 * zhrv + baseLogPrior["rem"]!!
             em["light"] = baseLogPrior["light"]!!
-            em["awake"] = 1.0 * zmvv + 0.5 * dz(zhvv) + 0.6 * dz(zhrv) + baseLogPrior["awake"]!!
+            em["awake"] = 1.0 * zmvv + 0.8 * zhvv + 0.4 * zhrv + baseLogPrior["awake"]!!
             val pr = cyclePrior(f.clock)
             for (s in stageNames) em[s] = em[s]!! + pr[s]!!
             if (f.jerkMax > f.jerkScale * jerkFloorGateMult) em["awake"] = em["awake"]!! + motionGateBoost

--- a/android/app/src/test/java/com/noop/analytics/SleepStagerV2Test.kt
+++ b/android/app/src/test/java/com/noop/analytics/SleepStagerV2Test.kt
@@ -201,8 +201,8 @@ class SleepStagerV2Test {
         val segs = SleepStagerV2.stageSession(start, start + dur, grav, hr, rr, emptyList())
         val golden = listOf(
             Triple(0L, 5070L, "deep"),
-            Triple(5070L, 5280L, "light"),
-            Triple(5280L, 5550L, "rem"),
+            Triple(5070L, 5310L, "light"),
+            Triple(5310L, 5550L, "rem"),
             Triple(5550L, 10740L, "light"),
             Triple(10740L, 16290L, "rem"),
             Triple(16290L, 21600L, "wake"))
@@ -224,9 +224,9 @@ class SleepStagerV2Test {
      */
     @Test
     fun tunedDeepBoundaryConstantsArePinned() {
-        assertEquals(0.40, SleepStagerV2.deepGateThresh, 0.0)
+        assertEquals(0.25, SleepStagerV2.deepGateThresh, 0.0)
         assertEquals(
-            mapOf("deep" to 0.76, "rem" to 0.012, "light" to 0.216, "awake" to 0.012),
+            mapOf("deep" to 0.86, "rem" to 0.007, "light" to 0.126, "awake" to 0.007),
             SleepStagerV2.transition["deep"])
         for ((from, row) in SleepStagerV2.transition) {
             assertEquals("transition row '$from' must sum to 1.0", 1.0, row.values.sum(), 1e-9)


### PR DESCRIPTION
## Summary

Reverts the #348 DREAMT re-tune's **parameter values** on both platforms, returning `SleepStagerV2` byte-for-byte to its v8.7.0 behavior. Keeps #348's one pure robustness fix: the Viterbi `ln(max(v, 1e-9))` floor (inert for the restored matrix — no zero entries — but protects any future hand-edit from `ln(0)`).

## Why

First healthy-sleeper field datapoint (#431, second report): the same night, same raw detected runs (identical `spanS` in both strap logs), re-scored from **awake 6% → 23%** (30 min → 1h 47m), efficiency **94% → 77%** — and the same pattern on every historical night in the log (per-run efficiencies 0.92→0.74, 0.88→0.69, 0.91→0.65). Rest composite dropped ~11 points, and Rest feeds Charge's sleep term, so scores moved too.

The mechanism is cohort-bias, not noise: DREAMT is a clinical **OSA** cohort (fragmented sleep, very high true WASO), and the tune absorbed that base rate into the population prior — the shipped `awake = ln(0.34)` sits beside a doc comment still reading *"waso 10 %"*. Combined with the 0.90 awake self-loop and the doubled motion wake-boost, a healthy night starts every epoch from a 34%-wake prior. The tune's no-regression guardrail was kappa (AAUWSS +0.03, Walch +0.006), and kappa doesn't guard **stage-fraction calibration** — a systematic wake-fraction bias sails through it.

## What this is not

Not a rejection of the DREAMT work. The cfg can return behind a **default-off Experimental toggle** (the #351 V1/V2 precedent) once validated against healthy-sleeper ground truth — the cheapest source being WHOOP-app awake-time comparisons from exactly the kind of report in #431. Happy to coordinate that follow-up on #348's thread.

## Verification

- Net diff vs v8.7.0 on the two engine files is **only the ln-floor line + comment** (`git diff v8.7.0...HEAD`) — staging output is provably back to the 8.7.0 recipe.
- Android `testFullDebugUnitTest` (no build cache): **2684 tests, 0 failures**; `SleepStagerV2Test` golden + constant pins restored to pre-#348 values and passing.
- Swift twin is the symmetric revert; `swift-packages.yml` covers StrandAnalytics on this PR.

Fixes the staging regression in #431 (the original "sleep date" report in that issue looks unrelated and stays open).