### PR TITLE
fix(testcentre): capture check names the token that MATCHED, not the one we hoped for

### DIFF
--- a/android/app/src/main/java/com/noop/testcentre/ReportCompleteness.kt
+++ b/android/app/src/main/java/com/noop/testcentre/ReportCompleteness.kt
@@ -73,33 +73,53 @@ object ReportCompleteness {
         TestDomain.HRV to "hrv nightSummary",
     )
 
+    /**
+     * The token that actually satisfied [d]'s presence check in [reportText], or null when neither did.
+     * The killer trace is preferred (it is the deeper diagnostic); the evidence token (#127) only answers
+     * when the killer is absent. Exposed so the rendered section names the token that MATCHED rather than
+     * the one we hoped for — #386's export read `sleep: present (gate run=)` off an evidence-only match,
+     * and that label sent the review hunting for gate lines the report never contained.
+     */
+    fun matchedToken(reportText: String, d: TestDomain): String? {
+        val killer = killerTokens[d] ?: return null
+        if (reportText.contains(killer)) return killer
+        return evidenceTokens[d]?.takeIf { reportText.contains(it) }
+    }
+
     /** Per-domain presence map for [reportText], over [checkedDomains]. PRESENT iff the killer token OR the
      *  domain's evidence token (if any, #127) occurs anywhere in the report. Deterministic order. */
     fun statuses(reportText: String, active: Set<TestDomain>): LinkedHashMap<TestDomain, Status> {
         val out = LinkedHashMap<TestDomain, Status>()
         for (d in checkedDomains(active)) {
-            val token = killerTokens[d] ?: continue
-            val present = reportText.contains(token) ||
-                evidenceTokens[d]?.let { reportText.contains(it) } == true
-            out[d] = if (present) Status.PRESENT else Status.MISSING
+            if (killerTokens[d] == null) continue
+            out[d] = if (matchedToken(reportText, d) != null) Status.PRESENT else Status.MISSING
         }
         return out
     }
 
     /**
-     * The "Capture check" section appended to report.txt (byte-identical to the Swift twin): a header,
-     * then one `<domainId>: <present|MISSING> (<token>)` line per checked domain in deterministic order,
-     * then a footer flag when any active domain's trace is MISSING (the at-a-glance "this report carries
-     * no diagnostic for X" signal). Returns the section WITHOUT a leading newline; the assembler joins it.
+     * The "Capture check" section appended to report.txt: a header, then one line per checked domain in
+     * deterministic order, then a footer flag when any active domain's trace is MISSING (the at-a-glance
+     * "this report carries no diagnostic for X" signal). The parenthetical names the token that ACTUALLY
+     * matched, never the one we hoped for (#386's mislabel): a killer-trace match keeps the bare
+     * `(<killer>)`, an evidence-only match (#127) reads `(via <evidence>)`, and MISSING reads
+     * `(expected <killer>)` — the Swift renderer's "expected …" wording for the missing case. Returns
+     * the section WITHOUT a leading newline; the assembler joins it.
      */
     fun captureCheckSection(reportText: String, active: Set<TestDomain>): String {
         val statuses = statuses(reportText, active)
         val sb = StringBuilder()
         sb.append("=== Capture check ===")
         for ((d, status) in statuses) {
+            val matched = matchedToken(reportText, d)
+            val label = when {
+                status == Status.MISSING -> "expected ${killerTokens[d]}"
+                matched == killerTokens[d] -> matched
+                else -> "via $matched"
+            }
             sb.append('\n')
                 .append(d.id).append(": ").append(status.token)
-                .append(" (").append(killerTokens[d]).append(')')
+                .append(" (").append(label).append(')')
         }
         // Only an ACTIVE domain going MISSING is a problem; the universal line is informational. If any
         // active, mapped domain is MISSING, flag it so the maintainer reads it without scanning the list.

--- a/android/app/src/test/java/com/noop/testcentre/ReportCompletenessParityTest.kt
+++ b/android/app/src/test/java/com/noop/testcentre/ReportCompletenessParityTest.kt
@@ -77,6 +77,21 @@ class ReportCompletenessParityTest {
         val section = ReportCompleteness.captureCheckSection(report, active = setOf(TestDomain.SLEEP))
         assertTrue("a computed-sleep capture must read complete, not INCOMPLETE",
             section.endsWith("complete: all active traces present"))
+        // #386 mislabel: the parenthetical must name the token that MATCHED (the evidence line), never
+        // the absent killer trace — `present (gate run=)` over an evidence-only match sent a maintainer
+        // hunting for gate lines the report never contained.
+        assertTrue("an evidence-only match must be labelled `via <evidence>`",
+            section.contains("sleep: present (via sleep day=)"))
+    }
+
+    @Test fun matchedTokenPrefersTheKillerTraceOverTheEvidenceLine() {
+        // When BOTH are present the deeper killer trace is the one named — `via` is reserved for the
+        // rescue path, so its appearance always means "the killer trace is genuinely absent".
+        val both = "[sleep] gate run=1 KEPT\nsleep day=2026-07-09 totalSleepMin=426 matched=1 source=computed"
+        assertEquals("gate run=", ReportCompleteness.matchedToken(both, TestDomain.SLEEP))
+        val evidenceOnly = "sleep day=2026-07-09 totalSleepMin=426 matched=1 source=computed"
+        assertEquals("sleep day=", ReportCompleteness.matchedToken(evidenceOnly, TestDomain.SLEEP))
+        assertEquals(null, ReportCompleteness.matchedToken("nothing sleepy here", TestDomain.SLEEP))
     }
 
     @Test fun sleepStillMissingWhenNoSleepDiagnosticAtAll() {
@@ -108,8 +123,8 @@ class ReportCompletenessParityTest {
         assertEquals(
             "=== Capture check ===\n" +
                 "universal: present (dayOwner day=)\n" +
-                "sleep: MISSING (gate run=)\n" +
-                "connection: MISSING (clockDrift )\n" +
+                "sleep: MISSING (expected gate run=)\n" +
+                "connection: MISSING (expected clockDrift )\n" +
                 "INCOMPLETE: missing sleep, connection",
             section,
         )
@@ -121,7 +136,7 @@ class ReportCompletenessParityTest {
         val section = ReportCompleteness.captureCheckSection("nothing here", active = emptySet())
         assertEquals(
             "=== Capture check ===\n" +
-                "universal: MISSING (dayOwner day=)\n" +
+                "universal: MISSING (expected dayOwner day=)\n" +
                 "complete: all active traces present",
             section,
         )


### PR DESCRIPTION
## Summary

Found while working #386: its export's Capture check certified `sleep: present (gate run=)` — but report.txt contained **zero** `gate run=` lines. The check was honest by its own rules (the #127 evidence-token rescue matched the always-on `sleep day=` line; the Sleep profile had been on for ~40 seconds, so the gate never re-ran), but the label named the killer trace instead of what actually matched, and that sent this review hunting for trace lines the bundle never carried.

## Change (Android-only)

- **`matchedToken(report, domain)`** — killer trace preferred, evidence token only when the killer is absent, null when neither landed. `statuses()` derives from it: same present/MISSING outcomes, so **meta.json is byte-unchanged**.
- **Rendered section**: a killer match keeps the bare `(gate run=)`; an evidence-only match reads `(via sleep day=)` — so `via` in a report always means "the deeper trace is genuinely absent"; MISSING reads `(expected gate run=)`, adopting the Swift renderer's "expected …" wording.
- Swift needs nothing: `CaptureCompleteness.reportSection` already prints the match count and every candidate token, so it never had the mislabel.

On #386's export the section would now read `sleep: present (via sleep day=)` — which tells the maintainer immediately that the gate trace never fired in the capture window, instead of implying it's in the file.

## Verification

`testFullDebugUnitTest` (no build cache): **2706 tests, 0 failures**. New pins: the `via` label on the #127 rescue case, killer-over-evidence preference, and both exact-text section fixtures updated (`expected` wording). Only consumer of the rendered section is `TestBundleAssembler` (string append); the machine-readable contract lives in meta.json and is untouched.