### PR TITLE
diag(sleep): per-day line carries the banked stage split + efficiency

### DIFF
--- a/Strand/Data/IntelligenceEngine.swift
+++ b/Strand/Data/IntelligenceEngine.swift
@@ -44,6 +44,17 @@ final class IntelligenceEngine: ObservableObject {
     /// that won the per-day merge (imports win field-by-field over computed , see Repository.mergeDaily).
     /// We resolve the REAL provenance so the card's badge tells a strap-scored night apart from an
     /// imported one, instead of always claiming "NOOP-computed". (Sleep overhaul §2.6 honesty fix.)
+    /// The `stages=` token of the per-day sleep diagnostic line (#386): `<deep>+<rem>+<light>=<sum>` in
+    /// rounded minutes when the day carries a full banked stage split, `nil` when any component is
+    /// absent (an unstaged night, or an imported day that only brought a total). The sum is printed
+    /// rather than left to the reader so a rollup-vs-stages divergence — the exact identity a "homepage
+    /// disagrees with the Sleep tab" report hinges on — is a one-line visual check against the
+    /// `totalSleepMin=` field beside it. Pure; mirrors the Android `sleepStagesLogToken` byte-for-byte.
+    static func sleepStagesLogToken(deep: Double?, rem: Double?, light: Double?) -> String {
+        guard let deep, let rem, let light else { return "nil" }
+        return "\(Int(deep.rounded()))+\(Int(rem.rounded()))+\(Int(light.rounded()))=\(Int((deep + rem + light).rounded()))"
+    }
+
     enum DaySource: Equatable {
         /// NOOP scored this day itself from the raw strap streams; no import covers it.
         case computed
@@ -956,7 +967,15 @@ final class IntelligenceEngine: ObservableObject {
             // day (the project's log-failures-not-successes blind spot) and lets us settle the "Rest repeats
             // across days" question with data rather than a guess. Gated by the existing strap-log export.
             let tsmLog = daily.totalSleepMin.map { String(Int($0.rounded())) } ?? "nil"
+            // #386: the banked stage split + efficiency ride beside the rollup, so a "homepage disagrees
+            // with the Sleep tab" report is self-diagnosing from the export alone — totalSleepMin vs the
+            // deep+rem+light sum is the identity both screens must agree on, now verifiable per pass, per
+            // day, without screenshots. Rounded minutes only (same privacy class as the rest of the line);
+            // stages=nil when the day has no banked stage split (an unstaged or imported-total-only day).
+            let effLog = daily.efficiency.map { String(format: "%.2f", $0) } ?? "nil"
             diagnosticSink?("sleep day=\(daily.day) totalSleepMin=\(tsmLog) "
+                            + "stages=\(Self.sleepStagesLogToken(deep: daily.deepMin, rem: daily.remMin, light: daily.lightMin)) "
+                            + "eff=\(effLog) "
                             + "matched=\(night.cachedSleep.count) source=\(source.logToken)", nil)
             // #195: one always-on line per scored night with the computed HRV value + the window it used,
             // so an "HRV reads high / deep-sleep window not changing" report is self-diagnosing straight

--- a/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
+++ b/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
@@ -835,8 +835,16 @@ object IntelligenceEngine {
             // day (the project's log-failures-not-successes blind spot) and lets us settle the "Rest repeats
             // across days" question with data. Gated by the existing strap-log export. Mirrors the Swift line.
             val tsmLog = daily.totalSleepMin?.let { Math.round(it).toString() } ?: "nil"
+            // #386: the banked stage split + efficiency ride beside the rollup, so a "homepage disagrees
+            // with the Sleep tab" report is self-diagnosing from the export alone — totalSleepMin vs the
+            // deep+rem+light sum is the identity both screens must agree on, now verifiable per pass, per
+            // day, without screenshots. Rounded minutes only (same privacy class as the rest of the line);
+            // stages=nil when the day has no banked stage split (an unstaged or imported-total-only day).
+            val effLog = daily.efficiency?.let { String.format(java.util.Locale.US, "%.2f", it) } ?: "nil"
             diag(
                 "sleep day=${daily.day} totalSleepMin=$tsmLog " +
+                    "stages=${sleepStagesLogToken(daily.deepMin, daily.remMin, daily.lightMin)} " +
+                    "eff=$effLog " +
                     "matched=${res.sleepSessions.size} " +
                     "source=${daySourceToken(daily.day, importedWhoopDays, appleHealthDays)}",
             )
@@ -1669,6 +1677,19 @@ object IntelligenceEngine {
         day in importedWhoopDays -> "imported:whoop"
         day in appleHealthDays -> "imported:apple"
         else -> "computed"
+    }
+
+    /**
+     * The `stages=` token of the per-day sleep diagnostic line (#386): `<deep>+<rem>+<light>=<sum>` in
+     * rounded minutes when the day carries a full banked stage split, `nil` when any component is
+     * absent (an unstaged night, or an imported day that only brought a total). The sum is printed
+     * rather than left to the reader so a rollup-vs-stages divergence — the exact identity a "homepage
+     * disagrees with the Sleep tab" report hinges on — is a one-line visual check against the
+     * `totalSleepMin=` field beside it. Pure + unit-tested; mirrors the Swift twin.
+     */
+    internal fun sleepStagesLogToken(deep: Double?, rem: Double?, light: Double?): String {
+        if (deep == null || rem == null || light == null) return "nil"
+        return "${Math.round(deep)}+${Math.round(rem)}+${Math.round(light)}=${Math.round(deep + rem + light)}"
     }
 
     /**

--- a/android/app/src/test/java/com/noop/analytics/IntelligenceDaySourceTokenTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/IntelligenceDaySourceTokenTest.kt
@@ -53,12 +53,44 @@ class IntelligenceDaySourceTokenTest {
     @Test
     fun diagnosticLineFormat_isStableAndParsable() {
         // The exact line shape the engine builds, assembled from the same parts, so the format stays
-        // pinned: counts + a rounded minute only (no HR/HRV/timestamps), no em-dash.
+        // pinned: counts + a rounded minute only (no HR/HRV/timestamps), no em-dash. `stages=`/`eff=`
+        // (#386) sit between the rollup and the counts so the rollup-vs-stages identity reads in place.
         val totalSleepMin = 423.6
         val tsm = Math.round(totalSleepMin).toString()
-        val line = "sleep day=$day totalSleepMin=$tsm matched=2 " +
+        val stages = IntelligenceEngine.sleepStagesLogToken(120.4, 77.2, 226.0)
+        val line = "sleep day=$day totalSleepMin=$tsm stages=$stages eff=0.91 matched=2 " +
             "source=${IntelligenceEngine.daySourceToken(day, setOf(day), emptySet())}"
-        assertEquals("sleep day=2026-06-12 totalSleepMin=424 matched=2 source=imported:whoop", line)
+        assertEquals(
+            "sleep day=2026-06-12 totalSleepMin=424 stages=120+77+226=424 eff=0.91 matched=2 source=imported:whoop",
+            line,
+        )
         assertEquals(false, line.contains("—"))
+    }
+
+    // ── stages= token (#386) ────────────────────────────────────────────────────
+
+    @Test
+    fun stagesToken_fullSplitPrintsComponentsAndSum() {
+        // The sum is PRINTED (not left to the reader) so a rollup-vs-stages divergence is a one-line
+        // visual check against totalSleepMin — the identity #386's screens must agree on.
+        assertEquals("160+77+279=516", IntelligenceEngine.sleepStagesLogToken(159.6, 77.4, 279.2))
+    }
+
+    @Test
+    fun stagesToken_componentsRoundIndividually_sumRoundsTheRawTotal() {
+        // The printed sum rounds the RAW deep+rem+light (31.2 -> 31), not the rounded components
+        // (10+10+10 = 30), so it matches how totalSleepMin itself is rounded and the two fields stay
+        // comparable digit-for-digit.
+        assertEquals("10+10+10=31", IntelligenceEngine.sleepStagesLogToken(10.4, 10.4, 10.4))
+    }
+
+    @Test
+    fun stagesToken_nilWhenAnyComponentMissing() {
+        // An unstaged night (or an imported day that only brought a total) must read nil, never a
+        // fabricated 0-minute stage.
+        assertEquals("nil", IntelligenceEngine.sleepStagesLogToken(null, 77.0, 279.0))
+        assertEquals("nil", IntelligenceEngine.sleepStagesLogToken(160.0, null, 279.0))
+        assertEquals("nil", IntelligenceEngine.sleepStagesLogToken(160.0, 77.0, null))
+        assertEquals("nil", IntelligenceEngine.sleepStagesLogToken(null, null, null))
     }
 }


### PR DESCRIPTION
## Summary

Diagnostic-only, from the #386 investigation: the whole "homepage disagrees with the Sleep tab" question reduced to one identity — `DailyMetric.totalSleepMin` vs the `deepMin+remMin+lightMin` stage sum — and the per-day diagnostic line only carried the rollup, so answering it took the reporter's screenshots plus timeline reconstruction. Now every scored day logs both sides of that identity in place:

```
sleep day=2026-07-13 totalSleepMin=516 stages=160+77+279=516 eff=0.91 matched=1 source=computed
```

## Details

- `stages=` prints the components AND the sum. The sum rounds the **raw** deep+rem+light total (not the rounded components), so it compares digit-for-digit with how `totalSleepMin` itself is rounded — a divergence between the two fields is a one-glance read.
- `stages=nil` when the day has no full banked split (an unstaged night, or an imported day that only brought a total) — never a fabricated 0-minute stage. `eff=` is the engine's 0..1 efficiency at 2dp, `nil` when absent.
- Same privacy class as the existing line: rounded counts only, no timestamps.
- **Byte-identical emit on both platforms**: Kotlin `IntelligenceEngine.sleepStagesLogToken` + the Swift `Strand/Data/IntelligenceEngine` twin (same null-rule, same rounding pairing as the existing `tsmLog`).
- Existing consumers unaffected: `CaptureAccumulator` / `ReportCompleteness` match by the leading `sleep day=` substring; nothing parses the middle fields (checked `SleepReadout`, the accumulator, and the completeness tokens).

## Verification

- Android `testFullDebugUnitTest` (no build cache): **2708 tests, 0 failures** — stages token pinned (full split, raw-total rounding, nil-on-any-missing) + the line-format pin updated.
- Swift side is app-target (CI-blind by default): on-demand `app-build.yml` run 29332968190 in flight on this exact commit; result will be confirmed here before merge.

Pairs conceptually with #442 (capture-check labeling) — both are "the next #386-shaped report answers itself from the export" fixes.