### PR TITLE
fix(sleep): Asleep/Woke row + hypnogram axis span the whole split night (#345)

### DIFF
--- a/android/app/src/main/java/com/noop/ui/SleepScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/SleepScreen.kt
@@ -521,6 +521,8 @@ fun SleepScreen(
                 habitualMidsleepSec = habitualMidsleep,
                 motionEpochs = night?.groupMotion ?: emptyList(),
                 groupInBedMin = night?.groupInBedMin,
+                windowOnsetTs = night?.heroOnsetTs,
+                windowWakeTs = night?.heroWakeTs,
             )
             }
             // Tiles / ledger / trends read the FULL-history model (#940): they stay up when only the
@@ -798,6 +800,12 @@ private fun Hero(
     // excluded, computed by `selectNight`. Null for single-block days → the session-window /
     // stage-total fallbacks below apply unchanged.
     groupInBedMin: Double? = null,
+    // The whole bridged night's clock window (#345, HeroNight.heroOnsetTs/heroWakeTs): on a split
+    // night `session` is one fragment, so its endTs is NOT the night's wake — the Asleep/Woke row
+    // and the hypnogram axis read these instead. Null (single-block days, older callers) falls back
+    // to the session window below, byte-identical to before.
+    windowOnsetTs: Long? = null,
+    windowWakeTs: Long? = null,
 ) {
     Column(verticalArrangement = Arrangement.spacedBy(Metrics.gap)) {
         NightNavHeader(nightOffset, lastIndex, clock, onNavigate, session, onUpdateTimes, onDeleteSession, onAddNap, onPickNightDate)
@@ -806,7 +814,9 @@ private fun Hero(
         // between the two chevrons on a phone, so in practice the two times people look for first
         // were effectively hidden. Shown for every night that has a session (including the stage-less
         // stub, where it's the only thing the hero can say). Mirrors iOS SleepView.sleepWindowRow.
-        session?.let { SleepWindowRow(it) }
+        // #345: the row shows the WHOLE night's window — on a split night the session (edit anchor)
+        // ends mid-night and its endTs contradicted the header pill two lines above.
+        session?.let { SleepWindowRow(windowOnsetTs ?: it.effectiveStartTs, windowWakeTs ?: it.endTs) }
         if (display == null) {
             // Honest fallback: this night recorded no usable stage data — never silently
             // substitute another night's hypnogram. (#160)
@@ -844,8 +854,11 @@ private fun Hero(
                     StageTimeline(
                         realSegments = real,
                         s = s,
-                        onsetTs = session?.effectiveStartTs,
-                        wakeTs = session?.endTs,
+                        // #345: the axis spans the WHOLE night. The group hypnogram (#364 seams) runs to
+                        // the group's last wake; labelling the axis off the session fragment's endTs cut
+                        // the clock labels short on a split night.
+                        onsetTs = windowOnsetTs ?: session?.effectiveStartTs,
+                        wakeTs = windowWakeTs ?: session?.endTs,
                         motionEpochs = motionEpochs,
                     )
                 }
@@ -1637,9 +1650,9 @@ private fun stageColorFor(name: String): Color = when (name.trim().lowercase()) 
  * combined into one TalkBack element. Mirrors iOS SleepView.sleepWindowRow (PR #289).
  */
 @Composable
-private fun SleepWindowRow(session: SleepSession) {
-    val asleep = clockTimeLabel(session.effectiveStartTs)
-    val woke = clockTimeLabel(session.endTs)
+private fun SleepWindowRow(onsetTs: Long, wakeTs: Long) {
+    val asleep = clockTimeLabel(onsetTs)
+    val woke = clockTimeLabel(wakeTs)
     // A frosted Rest-tinted card (was a flat surfaceRaised block) so the window row sits in the
     // same colour world as the rest of the screen. Bevel treatment — content unchanged.
     NoopCard(
@@ -2755,6 +2768,15 @@ internal data class HeroNight(
     // the efficiency shown beside it stays coherent. Null for a single-block day → the hero keeps
     // its session-window / stage-total fallbacks.
     val groupInBedMin: Double? = null,
+    // The whole bridged night's clock WINDOW (#345): the displayed bedtime (first non-stub fragment's
+    // onset, #736) to the group's latest wake — the same pair `clockLabel` above is built from, carried
+    // as timestamps so the Asleep/Woke row + the hypnogram axis can use them. On a split night `session`
+    // (the single WINNING fragment, kept as the edit anchor) can end mid-night, so reading ITS endTs
+    // made the WOKE time + the axis contradict the header pill and the group hypnogram. iOS needs no
+    // analogue: its merged Night synthesizes a group-spanning session (mergeDay's `synth`), so its
+    // window row and axis were already whole-night. Null only via the default → session fallback.
+    val heroOnsetTs: Long? = null,
+    val heroWakeTs: Long? = null,
 )
 
 /** What the hero card draws for the selected night — null means no usable stage data
@@ -2874,7 +2896,7 @@ internal fun selectNight(
         heroGroup.sumOf { (it.endTs - it.effectiveStartTs).coerceAtLeast(0L) } / 60.0
     } else null
     return HeroNight(session, dayKey, segments, clockLabelFor(heroOnsetTs, heroWakeTs), napBlocks, groupStages,
-        groupSegments, groupMotion, groupInBedMin)
+        groupSegments, groupMotion, groupInBedMin, heroOnsetTs, heroWakeTs)
 }
 
 /**

--- a/android/app/src/test/java/com/noop/ui/SleepOnsetStubTest.kt
+++ b/android/app/src/test/java/com/noop/ui/SleepOnsetStubTest.kt
@@ -116,6 +116,13 @@ class SleepOnsetStubTest {
         assertTrue("biphasic night must keep both real fragments", hero.groupSegments!!.size >= 4)
         // The stub is not a nap — it stays inside the main-night group.
         assertTrue(hero.napBlocks.none { it.startTs == stubStart })
+        // #345: the hero's clock WINDOW spans the whole night — displayed bedtime (fragment A's onset,
+        // the stub dropped) to the GROUP's latest wake (fragment B's end). The winning session is
+        // fragment B (the longest), so reading ITS window would show B's onset/wake and the Asleep/Woke
+        // row + hypnogram axis would contradict the header pill on exactly this biphasic shape.
+        assertTrue("session (edit anchor) is fragment B", hero.session.startTs == bStart)
+        assertTrue("window opens at the displayed bedtime (fragment A)", hero.heroOnsetTs == aStart)
+        assertTrue("window closes at the group's latest wake (fragment B end)", hero.heroWakeTs == bEnd)
     }
 
     /** A genuine single-block night is unchanged: the session is that block. */


### PR DESCRIPTION
## Summary

From #345's Jul-13 re-test (pilleuspulcher): on a split night the Sleep hero mixed scopes. The header pill said `22:41 - 07:05` and the hypnogram drew the whole night (the #364 group segments including the wake seam) — but the **Asleep/Woke card read WOKE 03:56** (the winning fragment's end) and the **stage timeline's clock labels stopped there too**, contradicting the pill two lines above and mislabeling the very drawing they sit under.

## Fix (Android-only)

- `HeroNight` now carries the group window (`heroOnsetTs`/`heroWakeTs`) — the exact pair `selectNight` already computed for the pill's label, kept as timestamps: displayed bedtime (first non-stub fragment, #736) → the group's latest wake.
- `SleepWindowRow` and `StageTimeline`'s axis read that window. Single-block nights fall back to the session window byte-identically (nullable defaults), and `session` stays untouched as the edit anchor — the pencil still edits the real winning block.
- Verified end-to-end consistency: the drawn hypnogram weights come from `night.groupSegments` (seam-inclusive, SleepScreen.kt:347 → :3221), so the drawing's width already spanned the full night — the labels now match it.

## Why there is no iOS twin

Verified rather than assumed: iOS `mergeDay` **synthesizes a group-spanning session** (`synth = CachedSleepSession(startTs: onset, endTs: wake)`, SleepView.swift:1986/2035) — so `onsetText`/`wakeText` (:2735), the axis `onsetDate` (:2711), and `spanLabel` were already whole-night, on every path (offset-0 hero, browse via `navDays` per-day merge, and single-session stubs). This PR is Android catching up to that design.

## Verification

- Extended the #736 biphasic golden (`SleepOnsetStubTest`): pins session = fragment B (edit anchor), window opens at fragment A's onset, closes at fragment B's end — the exact shape from the report.
- `testFullDebugUnitTest` (no build cache): **2709 tests, 0 failures**.
- UI-only Kotlin; no app-target Swift, no analytics/stored values.

With #378 + #437 + #395 already in staging, this completes the set for the next side-by-side re-test on #345.