### PR TITLE
fix(recovery): calibrating N tracks real baseline nValid, not a bounds count (#393 follow-up, Bug B)

### DIFF
--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/RecoveryScorer.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/RecoveryScorer.swift
@@ -228,21 +228,31 @@ public enum RecoveryScorer {
 
     // MARK: - Cold-start calibration progress
 
-    /// Nights carrying a usable nightly HRV — the signal that seeds the recovery baseline. While
-    /// recovery is still nil and this count is in [1, seed), it is the honest
-    /// "Calibrating — N of <seed> nights" progress the dashboard shows in place of a bare empty
-    /// state; nil once recovery exists or no night has data yet. Matches the baseline's validity
-    /// predicate, not just non-nil: `Baselines.update` only advances the recovery seed (nValid)
-    /// for nights whose value is within the metric config bounds, so an implausible out-of-range
-    /// night must NOT be counted here either — else the displayed N could over-state nValid.
-    /// Never claims "calibrating" at/above the seed gate (a nil recovery there is some other gap).
-    /// Mirrors Android TodayScreen.recoveryCalibrationNights (RecoveryCalibrationTest is the oracle).
+    /// The recovery baseline's real seed count while it still cold-starts — the honest
+    /// "Calibrating — N of <seed> nights" progress the dashboard shows in place of a bare empty state;
+    /// nil once recovery exists or the baseline has crossed the seed gate. N is the HRV baseline's
+    /// `nValid` from folding the SAME day-keyed, epoch-aware history the recovery engine folds
+    /// (`Baselines.foldHistory(_:dayKeys:cfg:baselineEpoch:)`), NOT a looser per-night bounds count.
+    ///
+    /// The old count advanced on every in-range night, including nights the engine's fold DROPS after a
+    /// manual "Recalibrate HRV baseline" (each night dated before the epoch is discarded, not
+    /// skip-and-held). A genuinely-calibrating user who had ≥ seed old in-range nights therefore read
+    /// `count ≥ seed → nil` here, and the Today score side fell through to "Needs the strap" while the
+    /// post-recalibration baseline was still seeding (Bug B, #393 follow-up). `nValid` is the exact count
+    /// `Baselines.computeStatus` gates CALIBRATING on, so N now tracks the baseline the Charge ring rides
+    /// and can never over-state it. Never claims "calibrating" at/above the seed gate (a nil recovery
+    /// there is some other gap). `baselineEpoch` nil reads the persisted HRV epoch from UserDefaults,
+    /// exactly like the engine's fold. Mirrors Android TodayScreen.recoveryCalibrationNights
+    /// (RecoveryCalibrationTest is the oracle).
     public static func calibrationNights(nightlyHrv: [Double?],
+                                         dayKeys: [String],
                                          hasRecovery: Bool,
                                          seed: Int = Baselines.minNightsSeed,
-                                         cfg: MetricCfg = Baselines.hrvCfg) -> Int? {
+                                         cfg: MetricCfg = Baselines.hrvCfg,
+                                         baselineEpoch: Double? = nil) -> Int? {
         guard !hasRecovery else { return nil }
-        let n = nightlyHrv.compactMap { $0 }.filter { $0 >= cfg.minVal && $0 <= cfg.maxVal }.count
+        let n = Baselines.foldHistory(nightlyHrv, dayKeys: dayKeys, cfg: cfg,
+                                      baselineEpoch: baselineEpoch).nValid
         // Include 0: a brand-new user (no banked nights yet) should read "Calibrating — 0 of N" on the
         // Charge ring, not a bare "No data" that looks broken (#335). Past days are gated to nil by the
         // caller; >= seed (recovery should exist) still returns nil.

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/RecoveryCalibrationTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/RecoveryCalibrationTests.swift
@@ -4,44 +4,92 @@ import XCTest
 /// Unit tests for `RecoveryScorer.calibrationNights`, the pure helper behind the Today recovery
 /// cold-start "Calibrating — N of 4 nights" affordance. Recovery is nil until the HRV baseline
 /// crosses the seed gate (Baselines.minNightsSeed valid nights); this surfaces honest progress
-/// instead of a bare empty state. Mirrors the Android RecoveryCalibrationTest case-for-case.
+/// instead of a bare empty state. N is the HRV baseline's real `nValid` from folding the SAME
+/// day-keyed, epoch-aware history the recovery engine folds. Mirrors the Android
+/// RecoveryCalibrationTest case-for-case.
 final class RecoveryCalibrationTests: XCTestCase {
 
     private let seed = Baselines.minNightsSeed // 4
 
+    /// Consecutive "yyyy-MM-dd" keys (2026-01-01 …), parallel to a nightly-value array. The values
+    /// drive the fold; the keys only matter once a recalibration epoch drops the pre-epoch tail.
+    private func keys(_ count: Int) -> [String] {
+        (0..<count).map { i in String(format: "2026-01-%02d", i + 1) }
+    }
+
+    /// The UTC day-start epoch (seconds) for a "yyyy-MM-dd" key, computed exactly as
+    /// `Baselines.foldHistory(_:dayKeys:cfg:baselineEpoch:)` does, so a test epoch lands on a real boundary.
+    private func epoch(_ dayKey: String) -> Double {
+        let fmt = DateFormatter()
+        fmt.calendar = Calendar(identifier: .gregorian)
+        fmt.timeZone = TimeZone(secondsFromGMT: 0)
+        fmt.dateFormat = "yyyy-MM-dd"
+        return fmt.date(from: dayKey)!.timeIntervalSince1970
+    }
+
+    /// Call helper pinning `baselineEpoch: 0` (no recalibration) so the plain fold is deterministic
+    /// regardless of any UserDefaults `hrvBaselineEpoch` set by another test in the process.
+    private func nights(_ hrv: [Double?], hasRecovery: Bool) -> Int? {
+        RecoveryScorer.calibrationNights(nightlyHrv: hrv, dayKeys: keys(hrv.count),
+                                         hasRecovery: hasRecovery, baselineEpoch: 0)
+    }
+
     func testNilWhenRecoveryAlreadyExists() {
-        XCTAssertNil(RecoveryScorer.calibrationNights(nightlyHrv: [55.0, 60.0], hasRecovery: true))
+        XCTAssertNil(nights([55.0, 60.0], hasRecovery: true))
     }
 
     func testZeroWhenNoNightHasHrvYet() {
         // Brand-new user (no valid HRV nights yet) → 0, so Charge reads "Calibrating — 0 of N"
         // rather than a bare "No data" (#335).
-        XCTAssertEqual(RecoveryScorer.calibrationNights(nightlyHrv: [nil, nil], hasRecovery: false), 0)
+        XCTAssertEqual(nights([nil, nil], hasRecovery: false), 0)
     }
 
     func testCountsNightsCarryingHrvBelowSeed() {
-        XCTAssertEqual(RecoveryScorer.calibrationNights(nightlyHrv: [55.0, nil, 61.0], hasRecovery: false), 2)
+        XCTAssertEqual(nights([55.0, nil, 61.0], hasRecovery: false), 2)
     }
 
     func testOneNightReportsOne() {
-        XCTAssertEqual(RecoveryScorer.calibrationNights(nightlyHrv: [58.0], hasRecovery: false), 1)
+        XCTAssertEqual(nights([58.0], hasRecovery: false), 1)
     }
 
     func testNilAtOrAboveSeedDoesNotClaimCalibrating() {
         // At/above the seed gate the baseline should be usable; if recovery is still nil it's
         // some other gap, so we must NOT show a misleading "calibrating 4 of 4".
-        let nights: [Double?] = (1...seed).map { 55.0 + Double($0) }
-        XCTAssertNil(RecoveryScorer.calibrationNights(nightlyHrv: nights, hasRecovery: false))
+        let hrv: [Double?] = (1...seed).map { 55.0 + Double($0) }
+        XCTAssertNil(nights(hrv, hasRecovery: false))
     }
 
     func testIgnoresNilHrvNights() {
-        XCTAssertEqual(RecoveryScorer.calibrationNights(nightlyHrv: [55.0, nil, nil, 60.0], hasRecovery: false), 2)
+        XCTAssertEqual(nights([55.0, nil, nil, 60.0], hasRecovery: false), 2)
     }
 
     func testIgnoresOutOfRangeHrvNights() {
         // A physiologically implausible avgHrv (outside the HRV config bounds 5...250) does not
         // advance the recovery seed in Baselines.update, so it must not be counted here either —
         // only the in-range night does. Keeps the displayed N in step with the real nValid.
-        XCTAssertEqual(RecoveryScorer.calibrationNights(nightlyHrv: [55.0, 4.0, 999.0], hasRecovery: false), 1)
+        XCTAssertEqual(nights([55.0, 4.0, 999.0], hasRecovery: false), 1)
+    }
+
+    // MARK: - Bug B (#393 follow-up): recalibration must not strand a calibrating user on "Needs the strap"
+
+    func testRecalibrationDropsPreEpochNightsSoNTracksTheRealBaseline() {
+        // Six in-range nights, then a manual "Recalibrate HRV baseline" epoch dated at 2026-01-05:
+        // the engine's fold DROPS the four pre-epoch nights, so the real nValid is the 2 post-epoch
+        // nights — a genuinely-calibrating baseline. The old per-night bounds count was 6 (>= seed)
+        // and returned nil, which stranded the score side on "Needs the strap". N must now read 2.
+        let hrv: [Double?] = Array(repeating: 55.0, count: 6)
+        let result = RecoveryScorer.calibrationNights(
+            nightlyHrv: hrv, dayKeys: keys(6), hasRecovery: false, baselineEpoch: epoch("2026-01-05"))
+        XCTAssertEqual(result, 2)
+    }
+
+    func testRecalibrationThatLeavesSeededBaselineStillReturnsNil() {
+        // If enough post-epoch nights remain to cross the seed gate, the baseline is usable again and a
+        // nil recovery is some OTHER gap — so we must not claim "calibrating" (mirrors the non-recalibrated
+        // at/above-seed case). Epoch at 2026-01-02 drops one night; five post-epoch nights → nValid 5.
+        let hrv: [Double?] = Array(repeating: 55.0, count: 6)
+        let result = RecoveryScorer.calibrationNights(
+            nightlyHrv: hrv, dayKeys: keys(6), hasRecovery: false, baselineEpoch: epoch("2026-01-02"))
+        XCTAssertNil(result)
     }
 }

--- a/Strand/Screens/CoupledView.swift
+++ b/Strand/Screens/CoupledView.swift
@@ -57,6 +57,7 @@ struct CoupledView: View {
     /// exists. The SAME pure helper Today's ring reads, so the two screens can't disagree.
     private var calibrationNights: Int? {
         RecoveryScorer.calibrationNights(nightlyHrv: repo.days.map(\.avgHrv),
+                                         dayKeys: repo.days.map(\.day),
                                          hasRecovery: day?.recovery != nil)
     }
 

--- a/Strand/Screens/TodayView.swift
+++ b/Strand/Screens/TodayView.swift
@@ -924,6 +924,7 @@ struct TodayView: View {
     private func computeCalibration() -> Int? {
         guard selectedDayOffset == 0 else { return nil }
         return RecoveryScorer.calibrationNights(nightlyHrv: repo.days.map(\.avgHrv),
+                                                dayKeys: repo.days.map(\.day),
                                                 hasRecovery: repo.today?.recovery != nil)
     }
 

--- a/android/app/src/main/java/com/noop/ui/CoupledScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/CoupledScreen.kt
@@ -32,6 +32,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Shadow
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
@@ -153,9 +154,12 @@ fun CoupledScreen(
     }
 
     // Recovery cold-start nights (the SAME pure helper Today's ring reads), for the honest calibrating
-    // caption + accessibility copy while the HRV baseline still seeds.
-    val calibrationNights = remember(days, todayRow) {
-        recoveryCalibrationNights(days, hasRecovery = todayRow?.recovery != null)
+    // caption + accessibility copy while the HRV baseline still seeds. Threads the persisted
+    // "Recalibrate HRV baseline" epoch so N folds the SAME epoch-aware history the engine folds (Bug B).
+    val context = LocalContext.current
+    val hrvEpoch = remember { NoopPrefs.of(context).getLong(Baselines.hrvBaselineEpochKey, 0L).toDouble() }
+    val calibrationNights = remember(days, todayRow, hrvEpoch) {
+        recoveryCalibrationNights(days, hasRecovery = todayRow?.recovery != null, hrvBaselineEpoch = hrvEpoch)
     }
 
     // The Charge breakdown (the hero's tap target, the EXISTING Today sheet) + the scoring guide it

--- a/android/app/src/main/java/com/noop/ui/TodayScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/TodayScreen.kt
@@ -860,7 +860,11 @@ fun TodayScreen(
     // (Baselines.minNightsSeed valid nights). Show honest "calibrating, N of 4 nights" progress
     // instead of a bare "No Data" so a new BLE-only user knows scores are coming, not broken. (PR #85)
     val recoveryCalibration: Int? = if (selectedDayOffset == 0) {
-        recoveryCalibrationNights(days, displayMetric?.recovery != null)
+        // Thread the persisted "Recalibrate HRV baseline" epoch (0 = none) so N folds the SAME
+        // epoch-aware history the recovery engine folds — otherwise a post-recalibration user's pre-epoch
+        // nights inflate the count past the seed gate and the score side wrongly reads NeedsStrap (Bug B).
+        val hrvEpoch = NoopPrefs.of(context).getLong(Baselines.hrvBaselineEpochKey, 0L).toDouble()
+        recoveryCalibrationNights(days, displayMetric?.recovery != null, hrvEpoch)
     } else {
         null
     }
@@ -4050,25 +4054,34 @@ private fun ContributorBar(label: String, readout: String, fraction: Double?, co
 }
 
 /**
- * Recent nights carrying a usable nightly HRV, the signal that seeds the recovery baseline. While
- * recovery is still null and this count is in [1, seed), it is the honest "calibrating N of <seed>"
- * progress shown in place of "No Data"; null once recovery exists or no night has data yet. Pure +
- * unit-tested (RecoveryCalibrationTest). Mirrors Baselines.minNightsSeed as the seed gate. (PR #85)
+ * The recovery baseline's real seed count while it still cold-starts, the honest "calibrating N of
+ * <seed>" progress shown in place of "No Data"; null once recovery exists or the baseline has crossed
+ * the seed gate. N is the HRV baseline's `nValid` from folding the SAME day-keyed, epoch-aware history
+ * the recovery engine folds ([Baselines.foldHistory] with [hrvBaselineEpoch]), NOT a looser per-night
+ * bounds count.
+ *
+ * The old count advanced on every in-range night, including nights the engine's fold DROPS after a
+ * manual "Recalibrate HRV baseline" (each night dated before the epoch is discarded, not skip-and-held).
+ * A genuinely-calibrating user who had >= seed old in-range nights therefore read `count >= seed → null`,
+ * and the Today score side fell through to [ScoreState.NeedsStrap] while the post-recalibration baseline
+ * was still seeding (Bug B, #393 follow-up). `nValid` is the exact count Baselines.computeStatus gates
+ * CALIBRATING on, so N now tracks the baseline the Charge ring rides and can never over-state it.
+ * [days] is oldest→newest (same order the engine folds). Pure + unit-tested (RecoveryCalibrationTest).
+ * (PR #85)
  */
 internal fun recoveryCalibrationNights(
     days: List<DailyMetric>,
     hasRecovery: Boolean,
+    hrvBaselineEpoch: Double,
     seed: Int = Baselines.minNightsSeed,
 ): Int? {
     if (hasRecovery) return null
-    // Match the baseline's validity predicate, not just non-null: Baselines.update only advances the
-    // recovery seed (nValid) for nights whose avgHrv is within the HRV config bounds, so an implausible
-    // out-of-range night must NOT be counted here either, else the displayed N could over-state nValid.
-    val cfg = Baselines.hrvCfg
+    val n = Baselines.foldHistory(
+        days.map { it.avgHrv }, days.map { it.day }, Baselines.hrvCfg, hrvBaselineEpoch,
+    ).nValid
     // Include 0: a brand-new user (no banked nights) reads "Calibrating, 0 of N" on Charge, not a
     // bare "No data" that looks broken (#335). Caller gates past days to null; >= seed → null.
-    return days.count { val v = it.avgHrv; v != null && v in cfg.minVal..cfg.maxVal }
-        .takeIf { it in 0 until seed }
+    return n.takeIf { it in 0 until seed }
 }
 
 /**

--- a/android/app/src/test/java/com/noop/ui/RecoveryCalibrationTest.kt
+++ b/android/app/src/test/java/com/noop/ui/RecoveryCalibrationTest.kt
@@ -2,6 +2,8 @@ package com.noop.ui
 
 import com.noop.analytics.Baselines
 import com.noop.data.DailyMetric
+import java.time.LocalDate
+import java.time.ZoneOffset
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Test
@@ -9,7 +11,9 @@ import org.junit.Test
 /**
  * Unit tests for [recoveryCalibrationNights], the pure helper behind the Today recovery cold-start
  * "Calibrating — N of 4 nights" affordance. Recovery is null until the HRV baseline crosses the seed
- * gate (Baselines.minNightsSeed valid nights); this surfaces honest progress instead of "No Data".
+ * gate (Baselines.minNightsSeed valid nights); this surfaces honest progress instead of "No Data". N
+ * is the HRV baseline's real `nValid` from folding the SAME day-keyed, epoch-aware history the recovery
+ * engine folds. Mirrors the Swift RecoveryCalibrationTests case-for-case.
  */
 class RecoveryCalibrationTest {
 
@@ -17,10 +21,19 @@ class RecoveryCalibrationTest {
 
     private fun day(d: String, hrv: Double?) = DailyMetric(deviceId = "my-whoop-noop", day = d, avgHrv = hrv)
 
+    /** The UTC day-start epoch (seconds) for a "yyyy-MM-dd" key, computed exactly as
+     *  [Baselines.foldHistory] does, so a test epoch lands on a real night boundary. */
+    private fun epoch(dayKey: String): Double =
+        LocalDate.parse(dayKey).atStartOfDay(ZoneOffset.UTC).toEpochSecond().toDouble()
+
+    /** Call helper pinning `hrvBaselineEpoch = 0.0` (no recalibration → plain fold). */
+    private fun nights(days: List<DailyMetric>, hasRecovery: Boolean): Int? =
+        recoveryCalibrationNights(days, hasRecovery = hasRecovery, hrvBaselineEpoch = 0.0)
+
     @Test
     fun nullWhenRecoveryAlreadyExists() {
         val days = listOf(day("2026-01-01", 55.0), day("2026-01-02", 60.0))
-        assertNull(recoveryCalibrationNights(days, hasRecovery = true))
+        assertNull(nights(days, hasRecovery = true))
     }
 
     @Test
@@ -28,18 +41,18 @@ class RecoveryCalibrationTest {
         // Brand-new user (no valid HRV nights yet) → 0, so Charge reads "Calibrating — 0 of N"
         // rather than a bare "No data" (#335).
         val days = listOf(day("2026-01-01", null), day("2026-01-02", null))
-        assertEquals(0, recoveryCalibrationNights(days, hasRecovery = false))
+        assertEquals(0, nights(days, hasRecovery = false))
     }
 
     @Test
     fun countsNightsCarryingHrvBelowSeed() {
         val days = listOf(day("2026-01-01", 55.0), day("2026-01-02", null), day("2026-01-03", 61.0))
-        assertEquals(2, recoveryCalibrationNights(days, hasRecovery = false))
+        assertEquals(2, nights(days, hasRecovery = false))
     }
 
     @Test
     fun oneNightReportsOne() {
-        assertEquals(1, recoveryCalibrationNights(listOf(day("2026-01-01", 58.0)), hasRecovery = false))
+        assertEquals(1, nights(listOf(day("2026-01-01", 58.0)), hasRecovery = false))
     }
 
     @Test
@@ -47,7 +60,7 @@ class RecoveryCalibrationTest {
         // At/above the seed gate, the baseline should be usable; if recovery is still null it's some
         // other gap, so we must NOT show a misleading "calibrating 4 of 4".
         val days = (1..seed).map { day("2026-01-0$it", 55.0 + it) }
-        assertNull(recoveryCalibrationNights(days, hasRecovery = false))
+        assertNull(nights(days, hasRecovery = false))
     }
 
     @Test
@@ -56,7 +69,7 @@ class RecoveryCalibrationTest {
             day("2026-01-01", 55.0), day("2026-01-02", null),
             day("2026-01-03", null), day("2026-01-04", 60.0),
         )
-        assertEquals(2, recoveryCalibrationNights(days, hasRecovery = false))
+        assertEquals(2, nights(days, hasRecovery = false))
     }
 
     @Test
@@ -69,6 +82,27 @@ class RecoveryCalibrationTest {
             day("2026-01-02", 4.0),     // below minVal (5.0) → not a seed night
             day("2026-01-03", 999.0),   // above maxVal (250.0) → not a seed night
         )
-        assertEquals(1, recoveryCalibrationNights(days, hasRecovery = false))
+        assertEquals(1, nights(days, hasRecovery = false))
+    }
+
+    // Bug B (#393 follow-up): recalibration must not strand a calibrating user on "Needs the strap".
+
+    @Test
+    fun recalibrationDropsPreEpochNights_soNTracksTheRealBaseline() {
+        // Six in-range nights, then a manual "Recalibrate HRV baseline" epoch dated 2026-01-05: the
+        // engine's fold DROPS the four pre-epoch nights, so the real nValid is the 2 post-epoch nights.
+        // The old per-night bounds count was 6 (>= seed) and returned null, stranding the score side on
+        // "Needs the strap"; N must now read 2 (a genuinely-calibrating baseline).
+        val days = (1..6).map { day("2026-01-0$it", 55.0) }
+        assertEquals(2, recoveryCalibrationNights(days, hasRecovery = false, hrvBaselineEpoch = epoch("2026-01-05")))
+    }
+
+    @Test
+    fun recalibrationLeavingSeededBaseline_stillReturnsNull() {
+        // If enough post-epoch nights remain to cross the seed gate, the baseline is usable again and a
+        // null recovery is some OTHER gap — so we must not claim "calibrating". Epoch 2026-01-02 drops one
+        // night; five post-epoch nights → nValid 5.
+        val days = (1..6).map { day("2026-01-0$it", 55.0) }
+        assertNull(recoveryCalibrationNights(days, hasRecovery = false, hrvBaselineEpoch = epoch("2026-01-02")))
     }
 }


### PR DESCRIPTION
## Bug B (#393 follow-up)

While the recovery HRV baseline is genuinely still calibrating (`nValid < Baselines.minNightsSeed`), the Today screen could show **"Needs the strap / Was your strap worn?"** instead of **"Calibrating N of 4"**.

### Cause

The recovery engine folds the HRV baseline with the **epoch-aware** `Baselines.foldHistory(_:dayKeys:cfg:baselineEpoch:)` (in `IntelligenceEngine`), which **drops every night dated before a manual "Recalibrate HRV baseline" epoch**. But the calibrating helper — `RecoveryScorer.calibrationNights` / `recoveryCalibrationNights` — counted *all* in-range nights.

After a recalibration, a user's old pre-epoch nights pushed that per-night bounds count past `minNightsSeed`, so the helper returned `nil`. `scoreStateForToday` / `MetricTileState.resolve` then fell through to `NeedsStrap`, even though the *post-recalibration* baseline (`nValid < 4`) was genuinely still cold-starting.

### Fix

Compute N as the baseline's **real `nValid`** by folding the *same day-keyed, epoch-aware history the engine folds*. N can then never over-state the seed count, and `NeedsStrap` is reserved for a truly-established baseline (`nValid ≥ seed`) with no data today.

- **Swift** (`RecoveryScorer.calibrationNights`): gains `dayKeys:` + `baselineEpoch:`, returns `foldHistory(...).nValid`. `TodayView` / `CoupledView` pass `repo.days.map(\.day)` (epoch defaults to the persisted `UserDefaults` value, like the engine).
- **Android** (`recoveryCalibrationNights`): gains `hrvBaselineEpoch: Double`. `TodayScreen` / `CoupledScreen` thread `NoopPrefs.of(context).getLong(Baselines.hrvBaselineEpochKey, 0L)`.
- No structural change to `ScoreState` / `scoreStateForToday` / `MetricTileState` — the fix flows through the single calibration-count source.

Byte-identical Swift/Kotlin logic; user-facing strings unchanged (byte-parity contract holds). Kept separate from #421 (one concern per PR).

### Tests

Extended `RecoveryCalibrationTest(s)` on both platforms: existing cases pinned to `epoch = 0` (byte-identical to before), plus two recalibration cases each — N reads `2 of 4` after the epoch drops the pre-epoch tail, and stays `nil` when enough post-epoch nights cross the seed gate.

### Verification

App-target Swift + Android UI have no default CI, so built/tested locally on top of `upstream/main`:

- `swift test --filter RecoveryCalibrationTests` → **9/9 pass**
- `./gradlew testFullDebugUnitTest --tests com.noop.ui.RecoveryCalibrationTest` → **BUILD SUCCESSFUL** (also compiles the app module)
- `xcodebuild -scheme Strand -destination 'platform=macOS' build` → **BUILD SUCCEEDED**

No hardware path touched (pure analytics + UI wiring).