### PR TITLE
fix(workouts): open the manual-workout sheet full-height, not .medium

### DIFF
--- a/Strand/Screens/ManualWorkoutSheet.swift
+++ b/Strand/Screens/ManualWorkoutSheet.swift
@@ -114,9 +114,12 @@ struct ManualWorkoutSheet: View {
         .frame(width: 420)
         #else
         .frame(maxWidth: .infinity)
-        // A short 5-field form → open at .medium with .large a drag away; the grabber also gives the
-        // top dismiss affordance the sheet otherwise lacks (only a bottom Cancel).
-        .noopSheetPresentation(largeFirst: false)
+        // Full height, not .medium: the Sportart field's floating Recent/catalogue overlay (see
+        // sportPicker below) needs headroom below the field once the keyboard is up. At .medium the
+        // fixed-height VStack has no ScrollView to absorb the squeeze, so the keyboard pushed the
+        // header, the Sportart field and the overlay anchored to it off the top of the sheet —
+        // "recents vanish" was really the panel being clipped along with its off-screen anchor.
+        .noopSheetPresentation(largeFirst: true)
         #endif
         .background(StrandPalette.surfaceOverlay)
         // Lets the user dismiss the decimal pad (which has no return key) and reach Cancel/Add. No-op on macOS.


### PR DESCRIPTION
## Problem

Opening **Workouts → Workout hinzufügen** and tapping into the Sportart field clipped the sheet's
own header, the "SPORTART" label/field, and the Recent/catalogue suggestion panel (#297/#315) off
the top of the screen once the keyboard appeared — the suggestion list collapsed to a barely-visible
sliver.

## Root cause

`ManualWorkoutSheet` opened at `.medium` detent (`noopSheetPresentation(largeFirst: false)`). Its
content is a plain `VStack` with no `ScrollView`, and the suggestion panel is a floating
`.overlay(alignment: .bottom)` anchored under the Sportart field (intentionally, so it isn't
squeezed to zero height by the fixed fields below it). When the keyboard appears, the sheet stays at
`.medium` height with nothing to absorb the overflow, so the top of the content — including the
field the overlay is anchored to — gets clipped off above the sheet's visible edge, taking the
overlay with it.

Every other short-form sheet in the app already opens at `largeFirst: true`
(`WhatsNewView`, `SettingsView`, `HowNoopWorksView`, `UpdatesInboxView`, `TrendsReportView`,
`ScoringGuideView`, `AppleWatchSetupView`) — `ManualWorkoutSheet` was one of only two holdouts still
using `.medium`, from before the Recent-sports overlay existed.

## Fix

Open `ManualWorkoutSheet` at `.large` instead of `.medium` (one line,
`Strand/Screens/ManualWorkoutSheet.swift`), giving the form + keyboard + floating suggestion panel
enough room to coexist without clipping. `StartWorkoutSheet` in the same file (live-start picker) is
untouched — its suggestion list is an inline bounded `ScrollView`, not an off-screen-anchored
overlay, and it wasn't reported/reproduced.

No Kotlin/Android mirror needed — pure SwiftUI presentation-detent change, no analytics/storage/
migration touched.

## Test plan

- [x] `xcodegen generate && xcodebuild -scheme NOOPiOS -destination 'platform=iOS Simulator,name=iPhone 17' build` — succeeds
- [x] Verified in iOS Simulator with the software keyboard: before the fix, the suggestion panel
      collapsed to a sliver exactly as reported; after the fix, the header, Sportart field, and full
      Recent/catalogue suggestion list stay visible and legible with the keyboard up