### PR TITLE
l10n(de): localize the Trends / Explore / Deep Timeline screens (Android)

### DIFF
--- a/android/app/src/main/java/com/noop/ui/FullDayChartScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/FullDayChartScreen.kt
@@ -24,8 +24,10 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import com.noop.R
 import com.noop.analytics.HrvAnalyzer
 import com.noop.protocol.DeviceFamily
 import com.noop.protocol.skinTempCelsius
@@ -167,8 +169,8 @@ fun FullDayChartScreen(vm: AppViewModel, onBack: () -> Unit) {
     }
 
     ScreenScaffold(
-        title = "Deep Timeline",
-        subtitle = "Every second of your day. Drag back up to 3 days.",
+        title = stringResource(R.string.deep_timeline_title),
+        subtitle = stringResource(R.string.timeline_subtitle),
     ) {
         // METRIC PILLS — horizontally scrollable so all six fit on a phone.
         Row(modifier = Modifier.horizontalScroll(rememberScrollState())) {
@@ -182,12 +184,14 @@ fun FullDayChartScreen(vm: AppViewModel, onBack: () -> Unit) {
 
         // SOURCE PILL — the owned strap, with the #574 owned/all scope toggle.
         Row(verticalAlignment = Alignment.CenterVertically) {
-            Text("My WHOOP", style = NoopType.footnote, color = Palette.textSecondary)
+            Text(stringResource(R.string.timeline_my_whoop), style = NoopType.footnote, color = Palette.textSecondary)
             Spacer(Modifier.weight(1f))
+            val ownedLabel = stringResource(R.string.timeline_owned)
+            val allLabel = stringResource(R.string.timeline_all)
             SegmentedPillControl(
                 items = listOf(true, false),
                 selection = ownedOnly,
-                label = { if (it) "Owned" else "All" },
+                label = { if (it) ownedLabel else allLabel },
                 onSelect = { ownedOnly = it },
             )
         }
@@ -232,7 +236,7 @@ fun FullDayChartScreen(vm: AppViewModel, onBack: () -> Unit) {
                 Box(modifier = Modifier.fillMaxWidth().height(280.dp), contentAlignment = Alignment.Center) {
                     when {
                         loading && points.isEmpty() ->
-                            Text("Loading the day…", style = NoopType.footnote, color = Palette.textTertiary)
+                            Text(stringResource(R.string.timeline_loading_day), style = NoopType.footnote, color = Palette.textTertiary)
                         points.isEmpty() -> EmptyTimelineState(metric, ownedOnly)
                         else -> TimelineChart(
                             points = displayPoints,
@@ -249,9 +253,9 @@ fun FullDayChartScreen(vm: AppViewModel, onBack: () -> Unit) {
                 if (displayPoints.isNotEmpty()) {
                     val vals = displayPoints.map { it.value }
                     Row(modifier = Modifier.fillMaxWidth()) {
-                        TimelineStat("MIN", formatValue(metric, vals.minOrNull() ?: 0.0), Modifier.weight(1f))
-                        TimelineStat("AVG", formatValue(metric, vals.average()), Modifier.weight(1f))
-                        TimelineStat("MAX", formatValue(metric, vals.maxOrNull() ?: 0.0), Modifier.weight(1f))
+                        TimelineStat(stringResource(R.string.timeline_min), formatValue(metric, vals.minOrNull() ?: 0.0), Modifier.weight(1f))
+                        TimelineStat(stringResource(R.string.timeline_avg), formatValue(metric, vals.average()), Modifier.weight(1f))
+                        TimelineStat(stringResource(R.string.timeline_max), formatValue(metric, vals.maxOrNull() ?: 0.0), Modifier.weight(1f))
                     }
                 }
             }
@@ -260,13 +264,13 @@ fun FullDayChartScreen(vm: AppViewModel, onBack: () -> Unit) {
         // ZOOM HINT + reset.
         Row(verticalAlignment = Alignment.CenterVertically) {
             Text(
-                if (window == null) "Pinch to zoom · drag to pan" else "Zoomed in - drag to pan",
+                if (window == null) stringResource(R.string.timeline_pinch_to_zoom) else stringResource(R.string.timeline_zoomed_in),
                 style = NoopType.footnote, color = Palette.textTertiary,
             )
             Spacer(Modifier.weight(1f))
             if (window != null) {
                 Text(
-                    "Reset",
+                    stringResource(R.string.timeline_reset),
                     style = NoopType.footnote,
                     color = Palette.accent,
                     modifier = Modifier.clickable { window = null },
@@ -283,11 +287,11 @@ private fun EmptyTimelineState(metric: TimelineMetric, ownedOnly: Boolean) {
         verticalArrangement = Arrangement.spacedBy(6.dp),
         modifier = Modifier.padding(horizontal = 24.dp),
     ) {
-        Text("No ${metric.title.lowercase(Locale.US)} here",
+        Text(stringResource(R.string.timeline_empty_metric, metric.title.lowercase(Locale.US)),
             style = NoopType.body, color = Palette.textSecondary)
         Text(
-            if (ownedOnly) "Nothing offloaded for this window yet."
-            else "Other sources don’t offload raw per-second data on-device.",
+            if (ownedOnly) stringResource(R.string.timeline_nothing_offloaded)
+            else stringResource(R.string.timeline_other_sources_no_offload),
             style = NoopType.footnote, color = Palette.textTertiary, textAlign = TextAlign.Center,
         )
     }

--- a/android/app/src/main/java/com/noop/ui/TrendsExploreScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/TrendsExploreScreen.kt
@@ -39,9 +39,11 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.noop.R
 import com.noop.data.DailyMetric
 import com.noop.data.MoodStore
 import com.noop.data.WhoopRepository
@@ -374,7 +376,7 @@ fun TrendsExploreScreen(vm: AppViewModel) {
     // are accessibility-walked on scroll. Each top-level child is one `item { }` in the same order; the
     // conditional empty-state note uses `if (cond) { item {} }` so it adds no row when hidden. No standalone
     // Spacers here , the LazyColumn's `spacedBy(20.dp)` reproduces the eager column's row spacing exactly.
-    LazyScreenScaffold(title = "Explore", subtitle = "Every signal, one tap deep.") {
+    LazyScreenScaffold(title = stringResource(R.string.nav_explore), subtitle = stringResource(R.string.explore_subtitle)) {
 
         // The headline tap-through (#575): a full-day, full-resolution, zoomable timeline. Sits above the
         // per-metric catalog because it's a different kind of view , every second of one day, not one
@@ -386,9 +388,8 @@ fun TrendsExploreScreen(vm: AppViewModel) {
         if (series.isEmpty()) {
             item {
             DataPendingNote(
-                title = "Import your history first",
-                body = "Import your history first. A WHOOP export in Data Sources fills " +
-                    "every metric you can explore here in about a minute.",
+                title = stringResource(R.string.explore_import_title),
+                body = stringResource(R.string.explore_import_body),
             )
             }
         }
@@ -480,9 +481,9 @@ private fun DeepTimelineEntry(onClick: () -> Unit) {
                 Text("∿", style = NoopType.title2, color = Palette.metricRose)
             }
             Column(modifier = Modifier.weight(1f)) {
-                Text("Deep Timeline", style = NoopType.headline, color = Palette.textPrimary)
+                Text(stringResource(R.string.deep_timeline_title), style = NoopType.headline, color = Palette.textPrimary)
                 Text(
-                    "Every second of your day, zoomable.",
+                    stringResource(R.string.explore_deep_timeline_hint),
                     style = NoopType.footnote,
                     color = Palette.textTertiary,
                 )
@@ -531,7 +532,7 @@ private fun MetricDropdown(
             }
             Icon(
                 if (expanded) Icons.Filled.ArrowDropUp else Icons.Filled.ArrowDropDown,
-                contentDescription = "Pick metric",
+                contentDescription = stringResource(R.string.explore_pick_metric),
                 tint = if (expanded) Palette.accent else Palette.textSecondary,
             )
         }
@@ -694,9 +695,9 @@ private fun HeroChartCard(
                 ) {
                     Text(
                         if (windowed.isEmpty()) {
-                            "No ${metric.title.lowercase()} recorded yet. Sync your strap to populate this trend."
+                            stringResource(R.string.explore_empty_metric, metric.title.lowercase())
                         } else {
-                            "Only one reading in range , widen the window to see a trend."
+                            stringResource(R.string.explore_single_reading)
                         },
                         style = NoopType.subhead,
                         color = Palette.textTertiary,
@@ -706,9 +707,9 @@ private fun HeroChartCard(
 
             // Footer chips, mirroring the macOS ChartFooter (Window / Points / Latest).
             Row(horizontalArrangement = Arrangement.spacedBy(Metrics.sectionGap)) {
-                ChartFootItem("Window", effectiveRange.label)
-                ChartFootItem("Points", "${windowed.size}")
-                ChartFootItem("Latest", heroValue)
+                ChartFootItem(stringResource(R.string.explore_chart_window), effectiveRange.label)
+                ChartFootItem(stringResource(R.string.explore_chart_points), "${windowed.size}")
+                ChartFootItem(stringResource(R.string.explore_latest), heroValue)
             }
         }
     }
@@ -783,31 +784,31 @@ private fun StatRow(
         else if ((delta > 0) == better) Palette.statusPositive else Palette.statusCritical
     }
     val deltaCaption = when {
-        hasDelta -> "vs prev ${effectiveRange.windowName}"
-        effectiveRange == ExploreRange.All -> "all history"
-        else -> "no prior ${effectiveRange.windowName}"
+        hasDelta -> stringResource(R.string.explore_vs_prev_window, effectiveRange.windowName)
+        effectiveRange == ExploreRange.All -> stringResource(R.string.explore_all_history)
+        else -> stringResource(R.string.explore_no_prior_window, effectiveRange.windowName)
     }
 
     Column(verticalArrangement = Arrangement.spacedBy(Metrics.gap)) {
-        SectionHeader("Summary", overline = "Over the visible window", trailing = "${s.n} pts")
+        SectionHeader(stringResource(R.string.explore_summary), overline = stringResource(R.string.explore_over_visible_window), trailing = stringResource(R.string.explore_n_pts, s.n))
 
         Row(horizontalArrangement = Arrangement.spacedBy(Metrics.gap)) {
             StatTile(
                 modifier = Modifier.weight(1f),
-                label = "Average",
+                label = stringResource(R.string.explore_average),
                 value = if (s.n > 0) metric.format(s.mean) else ",",
-                caption = "${s.n} days",
+                caption = stringResource(R.string.explore_n_days, s.n),
                 accent = metric.accent,
             )
             StatTile(
                 modifier = Modifier.weight(1f),
-                label = "Min",
+                label = stringResource(R.string.explore_min),
                 value = if (s.n > 0) metric.format(s.min) else ",",
                 accent = Palette.textPrimary,
             )
             StatTile(
                 modifier = Modifier.weight(1f),
-                label = "Max",
+                label = stringResource(R.string.explore_max),
                 value = if (s.n > 0) metric.format(s.max) else ",",
                 accent = Palette.textPrimary,
             )
@@ -819,14 +820,14 @@ private fun StatRow(
         Row(horizontalArrangement = Arrangement.spacedBy(Metrics.gap)) {
             StatTile(
                 modifier = Modifier.weight(1f),
-                label = "Latest",
+                label = stringResource(R.string.explore_latest),
                 value = latest?.let { metric.format(it.value) } ?: ",",
                 caption = latest?.day,
                 accent = metric.accent,
             )
             StatTile(
                 modifier = Modifier.weight(1f),
-                label = "Δ vs prev",
+                label = stringResource(R.string.explore_delta_vs_prev),
                 value = deltaText,
                 caption = deltaCaption,
                 accent = Palette.textPrimary,

--- a/android/app/src/main/java/com/noop/ui/TrendsScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/TrendsScreen.kt
@@ -36,6 +36,7 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Shadow
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
@@ -43,6 +44,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.noop.R
 import com.noop.analytics.WeeklyDigestEngine
 import com.noop.data.DailyMetric
 import java.time.LocalDate
@@ -147,8 +149,8 @@ fun TrendsScreen(vm: AppViewModel) {
     val recAvg = recovery.values.averageOrNull()
 
     LazyScreenScaffold(
-        title = "Trends",
-        subtitle = "The thread of you over time.",
+        title = stringResource(R.string.nav_trends),
+        subtitle = stringResource(R.string.trends_subtitle),
         // LIQUID SKY BACKDROP (the pilot pattern — LiquidScreenSky.kt): the time-of-day liquid sky settles
         // into the theme canvas behind the header + top rows, full-bleed via the scaffold's topBackground
         // plumbing. Static (LiquidSkyStatic, inside the helper) — never an animated sky behind a scrolling
@@ -224,7 +226,7 @@ fun TrendsScreen(vm: AppViewModel) {
         item {
             ChartCard(
                 modifier = Modifier.staggeredAppear(index = 3),
-                title = "Charge",
+                title = stringResource(R.string.trends_charge),
                 // The range bar above already prints the authoritative reading-count caption;
                 // the hero only names its window so the count isn't doubled in one card height.
                 subtitle = range.subtitle,
@@ -247,10 +249,10 @@ fun TrendsScreen(vm: AppViewModel) {
                 // mirrors the iOS hero's `valueRange: 0...106`.
                 chartHeadroom = 0.06f,
                 footer = listOf(
-                    "Avg" to (recAvg?.let { "${it.roundToInt()}" } ?: EM_DASH),
-                    "Peak" to (recovery.values.maxOrNull()?.let { "${it.roundToInt()}" } ?: EM_DASH),
-                    "Low" to (recovery.values.minOrNull()?.let { "${it.roundToInt()}" } ?: EM_DASH),
-                    "Days" to "${recovery.values.size}",
+                    stringResource(R.string.trends_avg) to (recAvg?.let { "${it.roundToInt()}" } ?: EM_DASH),
+                    stringResource(R.string.trends_peak) to (recovery.values.maxOrNull()?.let { "${it.roundToInt()}" } ?: EM_DASH),
+                    stringResource(R.string.trends_low) to (recovery.values.minOrNull()?.let { "${it.roundToInt()}" } ?: EM_DASH),
+                    stringResource(R.string.trends_days) to "${recovery.values.size}",
                 ),
             )
         }
@@ -263,9 +265,9 @@ fun TrendsScreen(vm: AppViewModel) {
                 modifier = Modifier.staggeredAppear(index = 4),
                 verticalArrangement = Arrangement.spacedBy(Metrics.gap),
             ) {
-                SectionHeader("Daily signals", overline = "Trends")
+                SectionHeader(stringResource(R.string.trends_daily_signals), overline = stringResource(R.string.nav_trends))
                 MetricTrendCard(
-                    title = "Heart rate variability", unit = "ms",
+                    title = stringResource(R.string.trends_hrv_full), unit = "ms",
                     color = Palette.metricPurple,
                     tint = Palette.chargeColor,
                     higherIsBetter = true,
@@ -273,7 +275,7 @@ fun TrendsScreen(vm: AppViewModel) {
                     fmt = { "${it.roundToInt()}" },
                 )
                 MetricTrendCard(
-                    title = "Resting heart rate", unit = "bpm",
+                    title = stringResource(R.string.trends_resting_hr_full), unit = "bpm",
                     color = Palette.metricRose,
                     tint = Palette.chargeColor,
                     higherIsBetter = false,
@@ -283,7 +285,7 @@ fun TrendsScreen(vm: AppViewModel) {
                 MetricTrendCard(
                     // Plotted values stay on the stored 0–100 scale (line shape unchanged); only the displayed
                     // numbers + unit follow the Effort-scale toggle, converted inside `fmt`. (#268)
-                    title = "Effort", unit = "/ ${UnitFormatter.effortScaleMax(effortScale)}",
+                    title = stringResource(R.string.trends_effort), unit = "/ ${UnitFormatter.effortScaleMax(effortScale)}",
                     // WHOOP: Effort/Strain is always BLUE , a deep→bright blue line, not the amber ramp.
                     color = Palette.effortColor,
                     tint = Palette.effortColor,
@@ -364,8 +366,8 @@ private fun WeeklyDigestNav(
         WeekNavBar(weekOffset = weekOffset, minWeekOffset = minWeekOffset, onStep = onStep)
         if (digest.isEmpty) {
             DataPendingNote(
-                title = "No readings this week",
-                body = "Step to another week with the arrows above to see its review.",
+                title = stringResource(R.string.trends_no_readings_this_week),
+                body = stringResource(R.string.trends_no_readings_body),
             )
         } else {
             NoopCard { WeeklyDigestContent(digest = digest, compact = true) }
@@ -382,9 +384,9 @@ private fun WeekNavBar(weekOffset: Int, minWeekOffset: Int, onStep: (Int) -> Uni
     val atOldest = weekOffset <= minWeekOffset
     val atNewest = weekOffset >= 0
     val label = when {
-        weekOffset == 0 -> "This week"
-        weekOffset == -1 -> "Last week"
-        else -> "${-weekOffset} weeks ago"
+        weekOffset == 0 -> stringResource(R.string.trends_this_week)
+        weekOffset == -1 -> stringResource(R.string.trends_last_week)
+        else -> stringResource(R.string.trends_weeks_ago, -weekOffset)
     }
     // liquidPress on the two week-step chevrons (the screen's tappable controls): each settles inward on
     // press, wired to the SAME interactionSource the IconButton uses for its own ripple, matching the pilot.
@@ -402,7 +404,7 @@ private fun WeekNavBar(weekOffset: Int, minWeekOffset: Int, onStep: (Int) -> Uni
         ) {
             Icon(
                 Icons.Filled.ChevronLeft,
-                contentDescription = "Previous week",
+                contentDescription = stringResource(R.string.trends_previous_week),
                 tint = if (atOldest) Palette.textTertiary else Palette.accent,
             )
         }
@@ -412,7 +414,7 @@ private fun WeekNavBar(weekOffset: Int, minWeekOffset: Int, onStep: (Int) -> Uni
             verticalArrangement = Arrangement.spacedBy(2.dp),
         ) {
             Text(label, style = NoopType.headline, color = Palette.textPrimary)
-            Overline("Week in review", color = Palette.textSecondary)
+            Overline(stringResource(R.string.trends_week_in_review), color = Palette.textSecondary)
         }
         Spacer(Modifier.weight(1f))
         IconButton(
@@ -423,7 +425,7 @@ private fun WeekNavBar(weekOffset: Int, minWeekOffset: Int, onStep: (Int) -> Uni
         ) {
             Icon(
                 Icons.Filled.ChevronRight,
-                contentDescription = "Next week",
+                contentDescription = stringResource(R.string.trends_next_week),
                 tint = if (atNewest) Palette.textTertiary else Palette.accent,
             )
         }
@@ -452,10 +454,10 @@ private fun WeekInReviewCard(
 
     NoopCard(modifier = modifier, tint = Palette.chargeColor) {
         Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
-            SectionHeader("Week in review", overline = "Charge · Effort · Rest")
+            SectionHeader(stringResource(R.string.trends_week_in_review), overline = stringResource(R.string.trends_charge_effort_rest))
             if (chargeAvg != null) {
                 PipScoreRow(
-                    label = "Charge", value = chargeAvg, range = 0f..100f,
+                    label = stringResource(R.string.trends_charge), value = chargeAvg, range = 0f..100f,
                     tint = Palette.chargeColor, format = { "${it.roundToInt()}" },
                 )
             }
@@ -467,14 +469,14 @@ private fun WeekInReviewCard(
                 val maxV = UnitFormatter.effortValue(100.0, effortScale)
                 val oneDecimal = effortScale == EffortScale.WHOOP
                 PipScoreRow(
-                    label = "Effort", value = display, range = 0f..maxV.toFloat(),
+                    label = stringResource(R.string.trends_effort), value = display, range = 0f..maxV.toFloat(),
                     tint = Palette.effortColor,
                     format = { if (oneDecimal) String.format(Locale.US, "%.1f", it) else "${it.roundToInt()}" },
                 )
             }
             if (restAvg != null) {
                 PipScoreRow(
-                    label = "Rest", value = restAvg, range = 0f..100f,
+                    label = stringResource(R.string.trends_rest), value = restAvg, range = 0f..100f,
                     tint = Palette.restColor, format = { "${it.roundToInt()}" },
                 )
             }
@@ -883,9 +885,9 @@ private fun MetricTrendCard(
         footer = listOf(
             // Plain "Mean" to match the bare Min/Max columns; the unit moves into the value
             // (e.g. "58 ms") so uppercasing can't render a shouty "MEAN MS".
-            "Mean" to (avg?.let { "${fmt(it)} $unit" } ?: EM_DASH),
-            "Min" to (resolved.values.minOrNull()?.let { fmt(it) } ?: EM_DASH),
-            "Max" to (resolved.values.maxOrNull()?.let { fmt(it) } ?: EM_DASH),
+            stringResource(R.string.trends_mean) to (avg?.let { "${fmt(it)} $unit" } ?: EM_DASH),
+            stringResource(R.string.trends_min) to (resolved.values.minOrNull()?.let { fmt(it) } ?: EM_DASH),
+            stringResource(R.string.trends_max) to (resolved.values.maxOrNull()?.let { fmt(it) } ?: EM_DASH),
         ),
     )
 }
@@ -948,7 +950,7 @@ private fun RecoveryHistoryCard(days: List<DailyMetric>, range: TrendsRange) {
 
     NoopCard(tint = Palette.chargeColor) {
         Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
-            SectionHeader(title, overline = "Calendar", trailing = "${recovery.size} days")
+            SectionHeader(title, overline = stringResource(R.string.trends_calendar), trailing = "${recovery.size} days")
             if (recovery.size >= 2) {
                 BarChart(
                     values = recovery,
@@ -960,8 +962,7 @@ private fun RecoveryHistoryCard(days: List<DailyMetric>, range: TrendsRange) {
             }
             HorizontalDivider(color = Palette.hairline)
             Text(
-                "Each bar is one day's Charge score, low to high. The 53-week calendar " +
-                    "heat-grid is part of the desktop app.",
+                stringResource(R.string.trends_calendar_footnote),
                 style = NoopType.footnote,
                 color = Palette.textTertiary,
             )
@@ -1011,7 +1012,7 @@ private fun SparsePlaceholder(height: Dp = Metrics.chartHeight) {
         contentAlignment = Alignment.Center,
     ) {
         Text(
-            "Not enough data for this window.",
+            stringResource(R.string.trends_not_enough_data),
             style = NoopType.subhead,
             color = Palette.textTertiary,
             textAlign = TextAlign.Center,
@@ -1022,9 +1023,8 @@ private fun SparsePlaceholder(height: Dp = Metrics.chartHeight) {
 @Composable
 private fun EmptyTrends() {
     DataPendingNote(
-        title = "Trends need history to draw",
-        body = "Trends need history to draw. Import your WHOOP export in Data Sources " +
-            "to see weeks, months and years instantly.",
+        title = stringResource(R.string.trends_empty_title),
+        body = stringResource(R.string.trends_empty_body),
     )
 }
 

--- a/android/app/src/main/res/values-de/strings.xml
+++ b/android/app/src/main/res/values-de/strings.xml
@@ -76,4 +76,73 @@
     <string name="terms_attest_liability">Soweit gesetzlich zulässig, mache ich das NOOP-Projekt oder seine Mitwirkenden nicht für Verluste oder Schäden haftbar, die aus meiner Nutzung entstehen.</string>
     <string name="terms_checkbox">Ich habe diese Bedingungen gelesen und akzeptiere sie, und ich nutze NOOP mit meinem eigenen Gerät und meinen eigenen Daten, auf eigenes Risiko.</string>
     <string name="terms_accept">Akzeptieren &amp; fortfahren</string>
+
+    <!-- Trends / Explore / Deep Timeline , see the English values/strings.xml comment for scope.
+         Wording matches the existing iOS/macOS German catalog entries where one exists. -->
+    <string name="trends_subtitle">Der rote Faden deiner Zeit.</string>
+    <string name="trends_charge">Ladung</string>
+    <string name="trends_effort">Anstrengung</string>
+    <string name="trends_rest">Ruhe</string>
+    <string name="trends_hrv_full">Herzfrequenzvariabilität</string>
+    <string name="trends_resting_hr_full">Ruheherzfrequenz</string>
+    <string name="trends_no_readings_this_week">Keine Messwerte diese Woche</string>
+    <string name="trends_no_readings_body">Wechsle mit den Pfeilen oben zu einer anderen Woche, um ihren Rückblick zu sehen.</string>
+    <string name="trends_this_week">Diese Woche</string>
+    <string name="trends_last_week">Letzte Woche</string>
+    <string name="trends_weeks_ago">vor %1$d Wochen</string>
+    <string name="trends_previous_week">Vorherige Woche</string>
+    <string name="trends_next_week">Nächste Woche</string>
+    <string name="trends_daily_signals">Tägliche Signale</string>
+    <string name="trends_week_in_review">Woche im Rückblick</string>
+    <string name="trends_charge_effort_rest">Ladung · Anstrengung · Ruhe</string>
+    <string name="trends_calendar">Kalender</string>
+    <string name="trends_avg">Ø</string>
+    <string name="trends_peak">Spitze</string>
+    <string name="trends_low">Niedrig</string>
+    <string name="trends_days">Tage</string>
+    <string name="trends_mean">Mittelwert</string>
+    <string name="trends_min">Min</string>
+    <string name="trends_max">Max</string>
+    <string name="trends_calendar_footnote">Jeder Balken ist der Ladungswert eines Tages, von niedrig bis hoch. Das 53-Wochen-Kalendergitter ist Teil der Desktop-App.</string>
+    <string name="trends_not_enough_data">Nicht genug Daten für diesen Zeitraum.</string>
+    <string name="trends_empty_title">Trends brauchen Verlauf zum Zeichnen</string>
+    <string name="trends_empty_body">Trends brauchen Verlauf zum Zeichnen. Importiere deinen WHOOP-Export in den Datenquellen, um Wochen, Monate und Jahre sofort zu sehen.</string>
+
+    <string name="explore_subtitle">Jedes Signal, nur einen Tipp entfernt.</string>
+    <string name="explore_import_title">Importiere zuerst deine Historie</string>
+    <string name="explore_import_body">Importiere zuerst deine Historie. Ein WHOOP-Export unter Datenquellen füllt in etwa einer Minute jede Metrik, die du hier erkunden kannst.</string>
+    <string name="deep_timeline_title">Deep Timeline</string>
+    <string name="explore_deep_timeline_hint">Jede Sekunde deines Tages, zoombar.</string>
+    <string name="explore_pick_metric">Metrik wählen</string>
+    <string name="explore_average">Durchschnitt</string>
+    <string name="explore_min">Min</string>
+    <string name="explore_max">Max</string>
+    <string name="explore_latest">Aktuellste</string>
+    <string name="explore_delta_vs_prev">Δ vs. vorher</string>
+    <string name="explore_summary">Zusammenfassung</string>
+    <string name="explore_over_visible_window">Über das sichtbare Fenster</string>
+    <string name="explore_n_days">%1$d Tage</string>
+    <string name="explore_n_pts">%1$d Pkt.</string>
+    <string name="explore_vs_prev_window">vs. vorher %1$s</string>
+    <string name="explore_all_history">gesamte Historie</string>
+    <string name="explore_no_prior_window">kein vorheriger %1$s</string>
+    <string name="explore_empty_metric">Noch kein(e) %1$s aufgezeichnet. Synchronisiere deinen Strap, um diesen Trend zu füllen.</string>
+    <string name="explore_single_reading">Nur ein Messwert im Zeitraum — vergrößere das Fenster, um einen Trend zu sehen.</string>
+    <string name="explore_chart_window">Fenster</string>
+    <string name="explore_chart_points">Punkte</string>
+
+    <string name="timeline_subtitle">Jede Sekunde deines Tages. Bis zu 3 Tage zurückziehen.</string>
+    <string name="timeline_my_whoop">Mein WHOOP</string>
+    <string name="timeline_owned">Im Besitz</string>
+    <string name="timeline_all">Alle</string>
+    <string name="timeline_loading_day">Tag wird geladen…</string>
+    <string name="timeline_pinch_to_zoom">Zum Zoomen aufziehen · zum Verschieben ziehen</string>
+    <string name="timeline_zoomed_in">Herangezoomt · zum Verschieben ziehen</string>
+    <string name="timeline_reset">Zurücksetzen</string>
+    <string name="timeline_min">MIN</string>
+    <string name="timeline_avg">AVG</string>
+    <string name="timeline_max">MAX</string>
+    <string name="timeline_empty_metric">Kein(e) %1$s hier</string>
+    <string name="timeline_nothing_offloaded">Für dieses Fenster wurde noch nichts übertragen.</string>
+    <string name="timeline_other_sources_no_offload">Andere Quellen übertragen keine rohen Sekundendaten auf das Gerät.</string>
 </resources>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -84,4 +84,83 @@
     <string name="terms_attest_liability">To the fullest extent the law allows, I will not hold the NOOP project or its contributors liable for any loss or damage arising from my use of it.</string>
     <string name="terms_checkbox">I have read and accept these terms, and I\'m using NOOP with my own device and my own data, at my own risk.</string>
     <string name="terms_accept">Accept &amp; Continue</string>
+
+    <!-- Trends / Explore / Deep Timeline (#448 follow-up): these three screens were built with
+         hardcoded English literals throughout, never wired to stringResource() at all. This is a
+         first pass covering every literal directly passed to a Compose call in TrendsScreen.kt,
+         TrendsExploreScreen.kt and FullDayChartScreen.kt. NOT covered here: the per-metric names
+         stored in TrendsExploreScreen's MetricSpec data class (HRV, Sleep Efficiency, Blood Oxygen,
+         Respiratory Rate, the knownSeriesMetrics titles/categories) and TimelineMetric's own titles ,
+         those are stored as plain String fields on a data class, not literals at a call site, so
+         localizing them needs a small type change (String -> @StringRes Int) that's out of scope for
+         this pass. Tracked as follow-up work; Tools/i18n_audit.py still flags them.
+         German wording matches the existing iOS/macOS Localizable.xcstrings entries where one exists,
+         so both platforms read the same (see Tools/translate-de.py for precedent: Avg/Peak/Low/Reset/
+         Δ vs prev/etc.). -->
+    <string name="trends_subtitle">The thread of you over time.</string>
+    <string name="trends_charge">Charge</string>
+    <string name="trends_effort">Effort</string>
+    <string name="trends_rest">Rest</string>
+    <string name="trends_hrv_full">Heart rate variability</string>
+    <string name="trends_resting_hr_full">Resting heart rate</string>
+    <string name="trends_no_readings_this_week">No readings this week</string>
+    <string name="trends_no_readings_body">Step to another week with the arrows above to see its review.</string>
+    <string name="trends_this_week">This week</string>
+    <string name="trends_last_week">Last week</string>
+    <string name="trends_weeks_ago">%1$d weeks ago</string>
+    <string name="trends_previous_week">Previous week</string>
+    <string name="trends_next_week">Next week</string>
+    <string name="trends_daily_signals">Daily signals</string>
+    <string name="trends_week_in_review">Week in review</string>
+    <string name="trends_charge_effort_rest">Charge · Effort · Rest</string>
+    <string name="trends_calendar">Calendar</string>
+    <string name="trends_avg">Avg</string>
+    <string name="trends_peak">Peak</string>
+    <string name="trends_low">Low</string>
+    <string name="trends_days">Days</string>
+    <string name="trends_mean">Mean</string>
+    <string name="trends_min">Min</string>
+    <string name="trends_max">Max</string>
+    <string name="trends_calendar_footnote">Each bar is one day\'s Charge score, low to high. The 53-week calendar heat-grid is part of the desktop app.</string>
+    <string name="trends_not_enough_data">Not enough data for this window.</string>
+    <string name="trends_empty_title">Trends need history to draw</string>
+    <string name="trends_empty_body">Trends need history to draw. Import your WHOOP export in Data Sources to see weeks, months and years instantly.</string>
+
+    <string name="explore_subtitle">Every signal, one tap deep.</string>
+    <string name="explore_import_title">Import your history first</string>
+    <string name="explore_import_body">Import your history first. A WHOOP export in Data Sources fills every metric you can explore here in about a minute.</string>
+    <string name="deep_timeline_title">Deep Timeline</string>
+    <string name="explore_deep_timeline_hint">Every second of your day, zoomable.</string>
+    <string name="explore_pick_metric">Pick metric</string>
+    <string name="explore_average">Average</string>
+    <string name="explore_min">Min</string>
+    <string name="explore_max">Max</string>
+    <string name="explore_latest">Latest</string>
+    <string name="explore_delta_vs_prev">Δ vs prev</string>
+    <string name="explore_summary">Summary</string>
+    <string name="explore_over_visible_window">Over the visible window</string>
+    <string name="explore_n_days">%1$d days</string>
+    <string name="explore_n_pts">%1$d pts</string>
+    <string name="explore_vs_prev_window">vs prev %1$s</string>
+    <string name="explore_all_history">all history</string>
+    <string name="explore_no_prior_window">no prior %1$s</string>
+    <string name="explore_empty_metric">No %1$s recorded yet. Sync your strap to populate this trend.</string>
+    <string name="explore_single_reading">Only one reading in range — widen the window to see a trend.</string>
+    <string name="explore_chart_window">Window</string>
+    <string name="explore_chart_points">Points</string>
+
+    <string name="timeline_subtitle">Every second of your day. Drag back up to 3 days.</string>
+    <string name="timeline_my_whoop">My WHOOP</string>
+    <string name="timeline_owned">Owned</string>
+    <string name="timeline_all">All</string>
+    <string name="timeline_loading_day">Loading the day…</string>
+    <string name="timeline_pinch_to_zoom">Pinch to zoom · drag to pan</string>
+    <string name="timeline_zoomed_in">Zoomed in · drag to pan</string>
+    <string name="timeline_reset">Reset</string>
+    <string name="timeline_min">MIN</string>
+    <string name="timeline_avg">AVG</string>
+    <string name="timeline_max">MAX</string>
+    <string name="timeline_empty_metric">No %1$s here</string>
+    <string name="timeline_nothing_offloaded">Nothing offloaded for this window yet.</string>
+    <string name="timeline_other_sources_no_offload">Other sources don\'t offload raw per-second data on-device.</string>
 </resources>


### PR DESCRIPTION
## What

The three Trends-tab screens on Android were built with hardcoded English literals throughout — title / subtitle / labels / empty-states passed straight to a Compose `Text(...)`, never wired to `stringResource()` at all. So on a German device "Charge" / "Effort" / "Reset" (and their neighbours) stayed English regardless of catalog state, because Compose has no SwiftUI-style auto-extraction: a raw string literal is rendered verbatim. This is the Android side of what's been reported repeatedly — #326, #342, and #448.

This routes every literal directly passed to a Compose call in `TrendsScreen.kt`, `TrendsExploreScreen.kt` and `FullDayChartScreen.kt` through `R.string.*`, adds the English base keys plus their German translations, and mirrors the German wording to the existing iOS/macOS `Localizable.xcstrings` entries where one exists (Ladung / Anstrengung / Ruhe / Zurücksetzen …) so the two platforms read the same.

## Deliberately out of scope

The per-metric names held as plain `String` fields on `TrendsExploreScreen`'s `MetricSpec` data class and `TimelineMetric`'s titles (HRV, Sleep Efficiency, Blood Oxygen, Respiratory Rate) are **not** literals at a call site — localizing them needs a `String -> @StringRes Int` type change, a larger refactor than this pass. They're called out in a code comment and still flagged by the audit tool.

## Verification

- `./gradlew compileFullDebugKotlin` — passes
- `./gradlew testFullDebugUnitTest` — passes
- both `strings.xml` validate (`xmllint`); no German key gaps introduced

Only UI-string wiring; no analytics, storage, or BLE paths touched.