### PR TITLE
feat(ble): capture WHOOP 5/MG high-rate R22 deep buffers for research (#423)

### DIFF
--- a/Strand/BLE/BLEManager.swift
+++ b/Strand/BLE/BLEManager.swift
@@ -633,6 +633,10 @@ public final class BLEManager: NSObject, ObservableObject {
     private lazy var puffinRecorder = PuffinFrameRecorder(state: state)
     private lazy var puffinEventLog = PuffinEventLog()
 
+    /// Durable log of the WHOOP 5/MG high-rate R22 deep buffers (type-0x2F ≥ 1 KB) for #423 reverse-
+    /// engineering. Gated on the same capture toggle; no-op otherwise.
+    private lazy var puffinDeepBufferLog = PuffinDeepBufferLog()
+
     /// Force the puffin capture buffer to disk so the Settings export/reveal targets a current file.
     public func flushPuffinCaptures() { puffinRecorder.flush() }
 
@@ -3169,6 +3173,7 @@ extension BLEManager: @preconcurrency CBCentralManagerDelegate {
         resetCharacteristics()
         puffinRecorder.flush()   // persist any buffered puffin capture frames before reconnect
         puffinEventLog.close()   // release the event-log handle so the file is safe to export
+        puffinDeepBufferLog.close()   // same for the high-rate deep-buffer log (#423)
         Task { @MainActor in await collector?.flushStandardHR() }   // persist any buffered 0x2A37 HR
         if autoReconnectPausedForBondLoop {
             // #747: the bond keeps being refused, so auto-reconnect is paused: we stop hammering a strap that
@@ -3870,6 +3875,10 @@ extension BLEManager: @preconcurrency CBPeripheralDelegate {
                     // may be the only one that delivers a given record). Single byte compare when
                     // the frame is not an EVENT; no-op unless the capture toggle is on.
                     puffinEventLog.appendIfEvent(frame: frame, char: characteristic.uuid)
+                    // Durable log of the big high-rate R22 deep buffers (type-0x2F ≥ 1 KB) for #423
+                    // reverse-engineering — its own file the bulk-capture eviction never churns.
+                    // BEFORE the offload branch so it catches the burst; no-op unless capture is on.
+                    puffinDeepBufferLog.appendIfDeepBuffer(frame: frame, char: characteristic.uuid, isOffload: isOffload)
                     if isOffload {
                         // Same policy as WHOOP4: historical offload frames are bulk sync traffic.
                         // Keep them out of the live UI parser during backfill and let Backfiller

--- a/Strand/BLE/PuffinDeepBufferLog.swift
+++ b/Strand/BLE/PuffinDeepBufferLog.swift
@@ -1,0 +1,123 @@
+import Foundation
+import CoreBluetooth
+
+/// Durable append-only log of WHOOP 5.0/MG **high-rate deep buffers** — the large type-0x2F (R22)
+/// packets that carry tens-of-Hz sensor data (motion + optical) rather than the 1 Hz historical
+/// rollup NOOP already decodes (#423).
+///
+/// On-strap probing (#423) established that the 5/MG has no live raw-IMU stream, but it DOES bank
+/// high-rate motion (accel content verified: int16-ish triples sphere-fitting to ~1 g at the 1/4096
+/// scale) and ships it inside big type-0x2F buffers during the connect-time offload burst — 124 B
+/// (≈1 Hz record), 1244 B and 2140 B (≈32 and ≈59 sub-records per timestamped second). NOOP's
+/// historical decoder pulls the 1 Hz gravity vector out and DISCARDS the high-rate remainder. Those
+/// bursts are ephemeral and backlog-gated, so a byte-perfect decoder can't be captured on demand — it
+/// needs many (raw buffer, wall-clock) pairs accumulated across days of ordinary wear + labeled
+/// activity. This log keeps ONLY the big (≥`minBufferBytes`) type-0x2F buffers, in its own file that
+/// the bulk `PuffinFrameRecorder` eviction never touches, so they survive long enough to reverse.
+///
+/// Gated on the same Settings toggle as the frame recorder (`PuffinFrameRecorder.enabledKey`) —
+/// capture is passive/read-only with respect to the strap and adds no new setting. One JSONL line per
+/// buffer (`{"ts_ms":…,"strap_ts":…,"size":…,"offload":…,"char":…,"hex":"…"}`); `strap_ts` is the
+/// unix second the strap stamped at payload offset 15 (frame byte 15), the load-bearing key for
+/// aligning a buffer with what the wearer was doing. Rotates at a soft cap keeping one previous
+/// generation, the same idiom as `PuffinEventLog`. Swift-only for now (experimental #423 instrument);
+/// a Kotlin twin follows if this graduates past reverse-engineering.
+@MainActor
+final class PuffinDeepBufferLog {
+
+    /// The 2140-B buffers are ~4.3 KB of hex each and arrive in bursts, so a bigger cap than the
+    /// EVENT log: 60 MB live keeps roughly a few hours of accumulated high-rate bursts, ample to
+    /// reverse the layout, and rotation bounds total disk at ~120 MB.
+    private static let softCapBytes = 60 * 1024 * 1024
+
+    /// WHOOP 5/MG inner-record type byte for the R22 deep packets (type 47 / 0x2F), at offset 8 (the
+    /// same position `BLEManager.isOffloadFrame` / `PuffinEventLog` index). The 1 Hz historical rollup
+    /// is also type-0x2F but small; `minBufferBytes` keeps only the high-rate buffers.
+    private static let deepTypeByte: UInt8 = 0x2F
+    private static let innerRecordOffset = 8
+    /// Skip the ~124-B ≈1 Hz record; keep the 1244-/2140-B high-rate buffers.
+    private static let minBufferBytes = 1000
+
+    /// Pure predicate: is `frame` a WHOOP 5/MG high-rate deep buffer? A reassembled frame's inner-record
+    /// type byte sits at offset 8, so this needs `count > 8` before indexing. Extracted so the offset-8
+    /// magic number is unit-testable without a strap.
+    nonisolated static func isDeepBuffer(_ frame: [UInt8]) -> Bool {
+        frame.count > innerRecordOffset
+            && frame.count >= minBufferBytes
+            && frame[innerRecordOffset] == deepTypeByte
+    }
+
+    private var handle: FileHandle?
+    private var disabled = false
+
+    private var isEnabled: Bool {
+        UserDefaults.standard.bool(forKey: PuffinFrameRecorder.enabledKey)
+    }
+
+    /// `<AppSupport>/OpenWhoop/puffin-deepbuffers.jsonl` — OUTSIDE `puffin-captures/`, whose soft-cap
+    /// eviction deletes oldest files wholesale.
+    private static func logURL() throws -> URL {
+        let fm = FileManager.default
+        let dir = try fm.url(for: .applicationSupportDirectory, in: .userDomainMask,
+                             appropriateFor: nil, create: true)
+            .appendingPathComponent("OpenWhoop", isDirectory: true)
+        try fm.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir.appendingPathComponent("puffin-deepbuffers.jsonl")
+    }
+
+    /// The strap's own unix-second stamp at frame offset 15 (u32 LE), or nil if the frame is too short.
+    /// This is the timestamp the high-rate records inside the buffer are relative to.
+    private static func strapTs(_ frame: [UInt8]) -> UInt32? {
+        guard frame.count > 18 else { return nil }
+        return UInt32(frame[15]) | (UInt32(frame[16]) << 8) | (UInt32(frame[17]) << 16) | (UInt32(frame[18]) << 24)
+    }
+
+    /// Append `frame` if it is a WHOOP 5 high-rate deep buffer and capture is enabled. Cheap for every
+    /// other frame: a length + single-byte compare, no parse, BEFORE the `isEnabled` read. Call for both
+    /// live and offload frames (`isOffload` recorded so the reverse pass can separate a real-time buffer
+    /// from a replayed historical one).
+    func appendIfDeepBuffer(frame: [UInt8], char: CBUUID, isOffload: Bool) {
+        guard !disabled, Self.isDeepBuffer(frame), isEnabled else { return }
+        let tsMs = Int(Date().timeIntervalSince1970 * 1000)
+        let strapTs = Self.strapTs(frame).map { String($0) } ?? "null"
+        let hex = frame.map { String(format: "%02x", $0) }.joined()
+        let line = "{\"ts_ms\":\(tsMs),\"strap_ts\":\(strapTs),\"size\":\(frame.count),"
+            + "\"offload\":\(isOffload),\"char\":\"\(char.uuidString.lowercased())\",\"hex\":\"\(hex)\"}\n"
+        do {
+            var h = try openHandle()
+            if try h.offset() > UInt64(Self.softCapBytes) {
+                close()
+                h = try openHandle()
+            }
+            try h.write(contentsOf: Data(line.utf8))
+        } catch {
+            // A diagnostics log must never affect the connection path: disable for this launch.
+            disabled = true
+        }
+    }
+
+    /// Close the handle (e.g. on disconnect) so the file is safe to share/export immediately.
+    func close() {
+        try? handle?.close()
+        handle = nil
+    }
+
+    private func openHandle() throws -> FileHandle {
+        if let handle = handle { return handle }
+        let url = try Self.logURL()
+        let fm = FileManager.default
+        if let size = try? url.resourceValues(forKeys: [.fileSizeKey]).fileSize,
+           size > Self.softCapBytes {
+            let old = url.deletingPathExtension().appendingPathExtension("jsonl.1")
+            try? fm.removeItem(at: old)
+            try? fm.moveItem(at: url, to: old)
+        }
+        if !fm.fileExists(atPath: url.path) {
+            fm.createFile(atPath: url.path, contents: nil)
+        }
+        let h = try FileHandle(forWritingTo: url)
+        try h.seekToEnd()
+        handle = h
+        return h
+    }
+}

--- a/StrandTests/PuffinDeepBufferLogTests.swift
+++ b/StrandTests/PuffinDeepBufferLogTests.swift
@@ -1,0 +1,44 @@
+import XCTest
+@testable import Strand
+
+/// Pins `PuffinDeepBufferLog.isDeepBuffer` — the pure predicate behind the durable high-rate deep-buffer
+/// log (#423). A reassembled WHOOP 5/MG frame carries its inner-record type at offset 8; the R22 deep
+/// packets are type 0x2F (47). The 1 Hz historical rollup is the SAME type but small, so the log keeps
+/// only the big (≥ 1 KB) high-rate buffers. BLE delivery can't be unit-tested, but this offset-8 +
+/// size gate CAN be, so a frame-shape change can't silently stop the research log filling. Mirrors
+/// `PuffinEventLogTests`.
+final class PuffinDeepBufferLogTests: XCTestCase {
+
+    func testAcceptsBigType2FAtOffset8() {
+        var f = [UInt8](repeating: 0, count: 2140) // the 2140-B high-rate buffer
+        f[8] = 0x2F
+        XCTAssertTrue(PuffinDeepBufferLog.isDeepBuffer(f))
+        var g = [UInt8](repeating: 0, count: 1244) // the 1244-B high-rate buffer
+        g[8] = 0x2F
+        XCTAssertTrue(PuffinDeepBufferLog.isDeepBuffer(g))
+    }
+
+    func testRejectsSmallType2FRecord() {
+        // The ~124-B type-0x2F frame is the 1 Hz rollup NOOP already decodes — below the size gate,
+        // it must NOT be logged as a high-rate buffer.
+        var f = [UInt8](repeating: 0, count: 124)
+        f[8] = 0x2F
+        XCTAssertFalse(PuffinDeepBufferLog.isDeepBuffer(f))
+    }
+
+    func testRejectsOtherTypesEvenWhenBig() {
+        // Big frames of other inner types (REALTIME 0x28, COMMAND_RESPONSE 0x24, EVENT 0x30,
+        // METADATA 0x31) must never be treated as a deep buffer.
+        for t: UInt8 in [0x28, 0x24, 0x30, 0x31, 0x32, 47 &+ 1] {
+            var f = [UInt8](repeating: 0, count: 2140)
+            f[8] = t
+            XCTAssertFalse(PuffinDeepBufferLog.isDeepBuffer(f), "type \(t) must not be a deep buffer")
+        }
+    }
+
+    func testRejectsTooShortToIndexOffset8() {
+        for n in 0...8 {
+            XCTAssertFalse(PuffinDeepBufferLog.isDeepBuffer([UInt8](repeating: 0x2F, count: n)))
+        }
+    }
+}


### PR DESCRIPTION
## What

Passive capture of the WHOOP 5.0/MG **high-rate R22 "deep" buffers** (the big type-0x2F packets) so they can be reverse-engineered offline. New `PuffinDeepBufferLog` + its hook on the puffin data path + a predicate test. **Capture only — no decode/analytics change, nothing sent off-device.** Coordinates with #423.

## Why

On-strap probing (#423) established the 5.0/MG has **no live raw-IMU stream** (cmds 81/63/106 are accepted-but-inert; the packet-51 IMU stream is firmware-refused). But the strap **does** bank tens-of-Hz sensor data and ships it inside the big type-0x2F R22 packets during the connect-time offload burst:

- **124 B** ≈ the 1 Hz rollup NOOP already decodes (gravity vector).
- **1244 B / 2140 B** ≈ **32 / 59 sub-records per timestamped second** — the high-rate stream. Verified content: int16-ish triples that **sphere-fit to ~1 g at the 1/4096 accel scale** (real accelerometer), plus multiple smooth **optical channels** (PPG / SpO₂ / the MG blood-pressure vascular suite).

Today the historical decoder pulls the **1 Hz gravity vector** out of these and **discards the high-rate remainder.** Byte-perfect reversal of that remainder needs many `(raw buffer, wall-clock)` pairs across days of wear + labeled activity, which a session-scoped bulk capture can't retain. This log keeps only the big buffers, in its own file the bulk-capture eviction never churns.

## How

`PuffinDeepBufferLog` (twin of `PuffinEventLog`): one JSONL line per big (≥ 1 KB) type-0x2F buffer — raw hex + the strap's own `strap_ts` (frame offset 15, the key for aligning a buffer with what the wearer was doing) + the offload flag. Gated on the existing capture toggle (`PuffinFrameRecorder.enabledKey`), read-only w.r.t. the strap, 60 MB soft cap with one-generation rotation.

## Verification

- Predicate unit test (`PuffinDeepBufferLogTests`) mirrors `PuffinEventLogTests` — offset-8 type + the ≥ 1 KB size gate that skips the 1 Hz record.
- Compiled the macOS `Strand` app target locally (CI's `app-build.yml` is disabled).
- **On real hardware (WHOOP 5.0, fw 50.40.1.0):** one offload captured **1424** of the 2140-byte buffers (~23 min of tens-of-Hz data) into the log, pulled clean off-device.

## Notes

- **Android twin deferred:** this is research instrumentation, not a shipped stored value — a Kotlin `PuffinDeepBufferLog` can follow once the buffer layout is reversed (happy to file the follow-up).
- Full probe methodology + findings are in #423. The goal is that any 5/MG owner can flip the capture toggle and accumulate the raw buffers, so the community can crack the layout together.
