### PR TITLE
feat: decode WHOOP 5/MG raw 6-axis IMU offload buffer + activity features (#423)

### DIFF
--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/ImuFeatureExtractor.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/ImuFeatureExtractor.swift
@@ -1,0 +1,95 @@
+import Foundation
+import WhoopProtocol
+
+// ImuFeatureExtractor.swift — activity features from decoded WHOOP 5/MG raw 6-axis IMU (#423).
+//
+// The 5/MG offload buffer decodes (WhoopProtocol.Whoop5RawImu) to 100 Hz 3-axis accel (g) + 3-axis gyro
+// (°/s). At 100 Hz the accelerometer resolves gait cadence, impact/jerk, and rotational energy that the
+// 1 Hz gravity vector physically cannot (a 1.8 Hz step rate is above the 1 Hz stream's Nyquist limit).
+// This turns a window of raw samples into a compact activity-feature vector for coarse sport / HAR
+// classification — the real-IMU upgrade path the coarse `WorkoutTypeClassifier` (1 Hz proxy) was built
+// to accept behind `WorkoutTypeClassifying`.
+//
+// Per the repo's derived-signal rule: cadence here is a `autocorrelation` peak on the accel-magnitude AC
+// over a genuinely high-rate stream (not a fixed-N-per-record buffer), reported with its own strength so
+// a caller can ignore a weak/absent peak; it is a FEATURE, never fed to a physiological gate. Validated
+// to recover MULTIPLE injected cadences, not one lucky match (see ImuFeatureExtractorTests).
+
+/// Compact activity features over a window of raw IMU samples.
+public struct ImuActivityFeatures: Equatable, Sendable, Codable {
+    /// RMS of the accel-magnitude AC (gravity removed), in g — overall movement intensity.
+    public let accelEnergyG: Double
+    /// Mean gyroscope magnitude over the window, in °/s — rotational intensity.
+    public let gyroEnergyDps: Double
+    /// RMS of the accel first-difference (jerk), in g/sample — impact / explosiveness (jumps, foot-strike).
+    public let jerkRms: Double
+    /// Dominant cadence in the gait band (`cadenceBand`), Hz — nil when no rhythmic peak clears
+    /// `minCadenceStrength`. Multiply by 60 for steps/min.
+    public let cadenceHz: Double?
+    /// Normalized strength (0…1) of that cadence peak — high = rhythmic (walk/run/cycle), low = bursty
+    /// (strength) or still.
+    public let cadenceStrength: Double
+    public let sampleCount: Int
+
+    public init(accelEnergyG: Double, gyroEnergyDps: Double, jerkRms: Double,
+                cadenceHz: Double?, cadenceStrength: Double, sampleCount: Int) {
+        self.accelEnergyG = accelEnergyG; self.gyroEnergyDps = gyroEnergyDps; self.jerkRms = jerkRms
+        self.cadenceHz = cadenceHz; self.cadenceStrength = cadenceStrength; self.sampleCount = sampleCount
+    }
+}
+
+public enum ImuFeatureExtractor {
+
+    /// Cadence search band, Hz — human gait/pedal foot rate (≈72–210 steps/min). Below the IMU Nyquist.
+    public static let cadenceBand: ClosedRange<Double> = 1.2...3.5
+    /// A cadence peak below this normalized autocorrelation strength is treated as "no rhythm" (→ nil Hz).
+    public static let minCadenceStrength = 0.20
+
+    /// Extract features from `samples` (from one or more `Whoop5ImuFrame`s, in order) at `sampleRateHz`.
+    public static func extract(_ samples: [RawImuSample], sampleRateHz: Int) -> ImuActivityFeatures {
+        let n = samples.count
+        guard n >= 8, sampleRateHz > 0 else {
+            return ImuActivityFeatures(accelEnergyG: 0, gyroEnergyDps: 0, jerkRms: 0,
+                                       cadenceHz: nil, cadenceStrength: 0, sampleCount: n)
+        }
+        let amag = samples.map { ($0.ax * $0.ax + $0.ay * $0.ay + $0.az * $0.az).squareRoot() }
+        let gmag = samples.map { ($0.gx * $0.gx + $0.gy * $0.gy + $0.gz * $0.gz).squareRoot() }
+
+        let gyroEnergy = gmag.reduce(0, +) / Double(n)
+        // Accel AC: remove the DC (≈gravity) then RMS.
+        let mean = amag.reduce(0, +) / Double(n)
+        let ac = amag.map { $0 - mean }
+        let accelEnergy = (ac.reduce(0) { $0 + $1 * $1 } / Double(n)).squareRoot()
+        // Jerk: RMS of |accel| first difference.
+        var jerkSq = 0.0
+        for i in 1..<n { let d = amag[i] - amag[i - 1]; jerkSq += d * d }
+        let jerk = (jerkSq / Double(n - 1)).squareRoot()
+
+        // Cadence: normalized autocorrelation of the AC series over the gait-band lags; the strongest
+        // peak's frequency + strength. Strength = peak ACF / zero-lag ACF (0…1), so it's amplitude-scale
+        // free (a faint but rhythmic walk and a hard one both read as rhythmic).
+        let ac0 = ac.reduce(0) { $0 + $1 * $1 }
+        var bestFreq: Double? = nil, bestStrength = 0.0
+        if ac0 > 0 {
+            let loLag = max(1, Int((Double(sampleRateHz) / cadenceBand.upperBound).rounded()))
+            let hiLag = min(n - 1, Int((Double(sampleRateHz) / cadenceBand.lowerBound).rounded()))
+            if loLag < hiLag {
+                for lag in loLag...hiLag {
+                    var s = 0.0
+                    for i in 0..<(n - lag) { s += ac[i] * ac[i + lag] }
+                    let strength = s / ac0
+                    if strength > bestStrength { bestStrength = strength; bestFreq = Double(sampleRateHz) / Double(lag) }
+                }
+            }
+        }
+        let cadence = bestStrength >= minCadenceStrength ? bestFreq : nil
+        return ImuActivityFeatures(accelEnergyG: accelEnergy, gyroEnergyDps: gyroEnergy, jerkRms: jerk,
+                                   cadenceHz: cadence, cadenceStrength: max(0, bestStrength), sampleCount: n)
+    }
+
+    /// Convenience: extract over the concatenated samples of decoded IMU frames.
+    public static func extract(frames: [Whoop5ImuFrame]) -> ImuActivityFeatures {
+        let rate = frames.first?.sampleRateHz ?? 100
+        return extract(frames.flatMap { $0.samples }, sampleRateHz: rate)
+    }
+}

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/ImuFeatureExtractorTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/ImuFeatureExtractorTests.swift
@@ -1,0 +1,60 @@
+import XCTest
+@testable import StrandAnalytics
+import WhoopProtocol
+
+/// Pins `ImuFeatureExtractor` — activity features from decoded 5/MG raw IMU (#423). Per the repo's
+/// derived-signal rule, cadence is validated to recover MULTIPLE distinct injected rates (not one lucky
+/// match), and the still/energy/gyro cases are checked independently.
+final class ImuFeatureExtractorTests: XCTestCase {
+
+    /// 100 Hz samples: gravity on Z + a sinusoidal wobble of amplitude `amp` g at `cadence` Hz on Z,
+    /// and an optional constant gyro rotation `gyroDps` on gx.
+    private func gaitSamples(cadence: Double, amp: Double = 0.2, seconds: Double = 6,
+                             gyroDps: Double = 0) -> [RawImuSample] {
+        let rate = 100.0, n = Int(seconds * rate)
+        return (0..<n).map { i in
+            let az = 1.0 + amp * sin(2 * .pi * cadence * Double(i) / rate)
+            return RawImuSample(ax: 0, ay: 0, az: az, gx: gyroDps, gy: 0, gz: 0)
+        }
+    }
+
+    func testRecoversMultipleDistinctCadences() {
+        // The load-bearing test: the extractor must track a VARYING input, not manufacture one rate.
+        for target in [1.4, 1.8, 2.4, 3.0] {
+            let f = ImuFeatureExtractor.extract(gaitSamples(cadence: target), sampleRateHz: 100)
+            XCTAssertNotNil(f.cadenceHz, "cadence \(target) Hz should be detected")
+            XCTAssertEqual(f.cadenceHz ?? -9, target, accuracy: 0.15,
+                           "recovered cadence should match the injected \(target) Hz")
+            XCTAssertGreaterThan(f.cadenceStrength, 0.4, "a clean sinusoid should read as strongly rhythmic")
+        }
+    }
+
+    func testStillHasNoCadenceAndLowEnergy() {
+        // Gravity only, negligible noise.
+        let still = (0..<600).map { _ in RawImuSample(ax: 0, ay: 0, az: 1.0, gx: 0, gy: 0, gz: 0) }
+        let f = ImuFeatureExtractor.extract(still, sampleRateHz: 100)
+        XCTAssertNil(f.cadenceHz, "a still wrist has no gait cadence")
+        XCTAssertLessThan(f.accelEnergyG, 0.01)
+        XCTAssertLessThan(f.gyroEnergyDps, 0.01)
+    }
+
+    func testEnergyAndJerkRiseWithMotion() {
+        let still = ImuFeatureExtractor.extract(gaitSamples(cadence: 2.0, amp: 0.0), sampleRateHz: 100)
+        let moving = ImuFeatureExtractor.extract(gaitSamples(cadence: 2.0, amp: 0.3), sampleRateHz: 100)
+        XCTAssertGreaterThan(moving.accelEnergyG, still.accelEnergyG + 0.05)
+        XCTAssertGreaterThan(moving.jerkRms, still.jerkRms)
+    }
+
+    func testGyroEnergyReflectsRotation() {
+        let f = ImuFeatureExtractor.extract(gaitSamples(cadence: 2.0, gyroDps: 45), sampleRateHz: 100)
+        XCTAssertEqual(f.gyroEnergyDps, 45, accuracy: 1.0, "constant 45 dps rotation should read back")
+    }
+
+    func testExtractFromDecodedFrames() {
+        // End-to-end from the WhoopProtocol decoder: two frames concatenate into one feature window.
+        let frame = Whoop5ImuFrame(baseTs: 0, sampleRateHz: 100, samples: gaitSamples(cadence: 2.2))
+        let f = ImuFeatureExtractor.extract(frames: [frame, frame])
+        XCTAssertEqual(f.sampleCount, frame.samples.count * 2)
+        XCTAssertEqual(f.cadenceHz ?? -9, 2.2, accuracy: 0.15)
+    }
+}

--- a/Packages/WhoopProtocol/Sources/WhoopProtocol/Whoop5RawImu.swift
+++ b/Packages/WhoopProtocol/Sources/WhoopProtocol/Whoop5RawImu.swift
@@ -1,0 +1,86 @@
+import Foundation
+
+// Whoop5RawImu.swift — decoder for the WHOOP 5.0/MG raw 6-axis IMU offload buffer (#423).
+//
+// The 5/MG ships a 1244-byte buffer during the connect-time offload burst that carries a full second
+// of raw inertial data: 100 accelerometer samples + 100 gyroscope samples, stored COLUMNAR (all ax,
+// then all ay, then all az; likewise the gyro), i16 little-endian. This is the SAME shape the WHOOP
+// app captures (documented in Asherlc/dofek `docs/whoop-ble-protocol.md` as the type-0x2B raw packet)
+// and the same columnar convention as the 4.0's 1917 REALTIME_RAW_DATA variant.
+//
+// IMPORTANT: the 5/MG's *live* raw-IMU stream is firmware-refused (TOGGLE_IMU_MODE / cmd 106 acks but
+// never streams), but the OFFLOAD buffer carries full accel AND gyro — so 100 Hz 6-axis IMU IS
+// obtainable on the 5.0 via the historical path.
+//
+// Frame layout (the reassembled BLE frame = 8-byte puffin envelope + payload; offsets are FRAME-absolute):
+//   @15  u32 LE   strap unix seconds for this 1-second frame
+//   @24  u16 LE   countA (accelerometer sample count, = 100)
+//   @28  100×i16  ax   @228 100×i16 ay   @428 100×i16 az     scale 1/4096 g/LSB
+//   @630 u16 LE   countB (gyroscope sample count, = 100)
+//   @640 100×i16  gx   @840 100×i16 gy   @1040 100×i16 gz    scale 2000/32768 (°/s)/LSB (±2000 dps)
+//
+// VALIDATED on 1423 buffers from a real 5.0 (fw 50.40.1.0): accel magnitude is a 1.01 g gravity shell
+// (100 % of samples within ±15 % of the median; 4117 ± 11 LSB across 200 s), and gyro sits near zero at
+// rest, spikes in motion, and correlates 0.79 with accel motion. Pure/deterministic; no I/O, no strap.
+
+/// One raw IMU sample: 3-axis accelerometer (g) + 3-axis gyroscope (°/s).
+public struct RawImuSample: Equatable, Codable, Sendable {
+    public let ax: Double, ay: Double, az: Double   // g
+    public let gx: Double, gy: Double, gz: Double    // deg/s
+    public init(ax: Double, ay: Double, az: Double, gx: Double, gy: Double, gz: Double) {
+        self.ax = ax; self.ay = ay; self.az = az; self.gx = gx; self.gy = gy; self.gz = gz
+    }
+}
+
+/// One decoded 5/MG raw-IMU buffer: a second of 6-axis samples with the strap's base timestamp.
+public struct Whoop5ImuFrame: Equatable, Sendable {
+    public let baseTs: Int              // strap unix seconds for the frame
+    public let sampleRateHz: Int        // 100
+    public let samples: [RawImuSample]
+    public init(baseTs: Int, sampleRateHz: Int, samples: [RawImuSample]) {
+        self.baseTs = baseTs; self.sampleRateHz = sampleRateHz; self.samples = samples
+    }
+    /// Wall-clock unix seconds for sample `i` (samples are evenly spaced across the 1-second frame).
+    public func ts(of i: Int) -> Double { Double(baseTs) + Double(i) / Double(max(1, sampleRateHz)) }
+}
+
+public enum Whoop5RawImu {
+
+    public static let bufferLength = 1244
+    public static let sampleCount = 100
+    public static let accelScale = 1.0 / 4096.0            // g per LSB (WHOOP accel scale)
+    public static let gyroScale = 2000.0 / 32768.0         // deg/s per LSB (±2000 dps, ≈16.4 LSB/dps)
+
+    // FRAME-absolute offsets (8-byte puffin envelope + payload).
+    static let tsOff = 15, countAOff = 24, axOff = 28, ayOff = 228, azOff = 428
+    static let countBOff = 630, gxOff = 640, gyOff = 840, gzOff = 1040
+
+    /// Decode a raw-IMU buffer, or nil if it isn't one. Gates on the exact length + the two in-packet
+    /// sample counts (=100) rather than the type byte, so it can't misfire on a same-type non-IMU frame.
+    public static func decode(_ f: [UInt8]) -> Whoop5ImuFrame? {
+        guard f.count >= bufferLength,
+              u16(f, countAOff) == sampleCount, u16(f, countBOff) == sampleCount,
+              gzOff + 2 * sampleCount <= f.count else { return nil }
+        let baseTs = Int(u32(f, tsOff))
+        var samples = [RawImuSample]()
+        samples.reserveCapacity(sampleCount)
+        for i in 0..<sampleCount {
+            let o = 2 * i
+            samples.append(RawImuSample(
+                ax: Double(i16(f, axOff + o)) * accelScale,
+                ay: Double(i16(f, ayOff + o)) * accelScale,
+                az: Double(i16(f, azOff + o)) * accelScale,
+                gx: Double(i16(f, gxOff + o)) * gyroScale,
+                gy: Double(i16(f, gyOff + o)) * gyroScale,
+                gz: Double(i16(f, gzOff + o)) * gyroScale))
+        }
+        return Whoop5ImuFrame(baseTs: baseTs, sampleRateHz: sampleCount, samples: samples)
+    }
+
+    // MARK: - Little-endian readers (frame-absolute)
+    static func u16(_ f: [UInt8], _ o: Int) -> Int { Int(f[o]) | (Int(f[o + 1]) << 8) }
+    static func u32(_ f: [UInt8], _ o: Int) -> UInt32 {
+        UInt32(f[o]) | (UInt32(f[o + 1]) << 8) | (UInt32(f[o + 2]) << 16) | (UInt32(f[o + 3]) << 24)
+    }
+    static func i16(_ f: [UInt8], _ o: Int) -> Int { let v = u16(f, o); return v >= 32768 ? v - 65536 : v }
+}

--- a/Packages/WhoopProtocol/Tests/WhoopProtocolTests/Whoop5RawImuTests.swift
+++ b/Packages/WhoopProtocol/Tests/WhoopProtocolTests/Whoop5RawImuTests.swift
@@ -1,0 +1,71 @@
+import XCTest
+@testable import WhoopProtocol
+
+/// Pins `Whoop5RawImu.decode` — the WHOOP 5/MG raw 6-axis IMU offload buffer (#423). A synthetic frame
+/// checks the exact columnar offsets + scales; a REAL captured buffer (fw 50.40.1.0) checks the decode
+/// against hardware by asserting the accelerometer forms a ~1 g gravity shell and the gyro is sane.
+final class Whoop5RawImuTests: XCTestCase {
+
+    /// Build a minimal valid frame: counts = 100, and one known accel + gyro sample at index `i`.
+    private func syntheticFrame(i: Int, axLSB: Int, gxLSB: Int) -> [UInt8] {
+        var f = [UInt8](repeating: 0, count: Whoop5RawImu.bufferLength)
+        f[8] = 0x2F
+        func putU16(_ o: Int, _ v: Int) { f[o] = UInt8(v & 0xFF); f[o + 1] = UInt8((v >> 8) & 0xFF) }
+        func putI16(_ o: Int, _ v: Int) { putU16(o, v < 0 ? v + 65536 : v) }
+        putU16(24, 100)                         // countA
+        putU16(630, 100)                        // countB
+        putU16(15, 0x0000_0064); f[16] = 0; f[17] = 0; f[18] = 0  // baseTs low byte only, = 100
+        putI16(28 + 2 * i, axLSB)               // ax[i]
+        putI16(640 + 2 * i, gxLSB)              // gx[i]
+        return f
+    }
+
+    func testDecodesKnownSampleWithCorrectScales() {
+        // ax = 4096 LSB → 1.0 g; gx = 328 LSB → 328 * 2000/32768 = 20.02 °/s.
+        let f = syntheticFrame(i: 3, axLSB: 4096, gxLSB: 328)
+        let frame = Whoop5RawImu.decode(f)
+        XCTAssertNotNil(frame)
+        XCTAssertEqual(frame?.samples.count, 100)
+        XCTAssertEqual(frame?.sampleRateHz, 100)
+        XCTAssertEqual(frame!.samples[3].ax, 1.0, accuracy: 1e-9)
+        XCTAssertEqual(frame!.samples[3].ay, 0.0, accuracy: 1e-9)
+        XCTAssertEqual(frame!.samples[3].gx, 328.0 * 2000.0 / 32768.0, accuracy: 1e-6)
+        XCTAssertEqual(frame!.samples[0].ax, 0.0, accuracy: 1e-9)   // other indices untouched
+    }
+
+    func testRejectsWrongLengthOrCounts() {
+        XCTAssertNil(Whoop5RawImu.decode([UInt8](repeating: 0, count: 500)))   // too short
+        var f = syntheticFrame(i: 0, axLSB: 0, gxLSB: 0)
+        f[24] = 0; f[25] = 0                                                    // countA != 100
+        XCTAssertNil(Whoop5RawImu.decode(f))
+    }
+
+    func testDecodesRealBufferAsGravityShell() {
+        let f = Self.realFrameBytes
+        XCTAssertEqual(f.count, Whoop5RawImu.bufferLength)
+        guard let frame = Whoop5RawImu.decode(f) else { return XCTFail("real buffer did not decode") }
+        XCTAssertEqual(frame.samples.count, 100)
+        XCTAssertEqual(frame.baseTs, 1_784_037_165)   // strap ts @15
+
+        // Accel: every sample must sit in a ~1 g gravity shell (the defining accel signature).
+        let mags = frame.samples.map { ($0.ax * $0.ax + $0.ay * $0.ay + $0.az * $0.az).squareRoot() }
+        let sorted = mags.sorted(); let median = sorted[sorted.count / 2]
+        XCTAssertEqual(median, 1.0, accuracy: 0.15, "median |accel| should be ~1 g")
+        let inShell = mags.filter { $0 > 0.7 * median && $0 < 1.3 * median }.count
+        XCTAssertGreaterThanOrEqual(inShell, 95, "≥95/100 accel samples should be in the gravity shell")
+
+        // Gyro: at (near) rest the mean magnitude is small — far below the ±2000 dps full scale.
+        let gyroMean = frame.samples.map { ($0.gx * $0.gx + $0.gy * $0.gy + $0.gz * $0.gz).squareRoot() }
+            .reduce(0, +) / 100.0
+        XCTAssertLessThan(gyroMean, 200.0, "resting gyro magnitude should be small")
+    }
+
+    /// One real 1244-byte type-0x2F IMU buffer captured off a WHOOP 5.0 (fw 50.40.1.0), #423.
+    static let realFrameBytes: [UInt8] = {
+        let hex = "aa01d40401005c702f1580e520af002d3f566a002004640064000300d308cc08c408c908c208cd08b708c208cc08c908cc08e108d608e408d208c508bd08d708c508d208cc08c908bc08b508a908c008cc08cb08d308e108dc08d408d108c108c208c208b708ce08c608e008c308d208bd08c908bb08b708be08c208cc08ce08c608cf08c408c808ca08cb08cf08cb08d508c708c908cc08bf08c308c408cc08cc08cc08c508c708d108c108c608c808c108c408c308c608cf08c808c608cf08ce08c808d008c008d008c608bb08cb08d208c008cb08c708c008c508c208c608cf08d008d3ffcaffc1ffc8ffcaffc5ffccffd4ffd3ffdeffddffd8ffdbffd6ffc7ffc7ffd0ffd5ffd6ffe2ffd4ffceffd6ffd2ffe2ffdbffdbffc7ffc6ffc9ffc1ffb1ffb7ffb7ffc9ffceffe4ffe7ffe4ffeaffe7ffdbffd7ffe0ffd7ffc4ffccffcdffbbffc2ffbeffb9ffccffd4ffd4ffc6ffcaffd3ffc8ffd6ffceffd7ffdaffdfffddffdaffd6ffddffdaffd3ffe1ffd0ffc9ffcdffd1ffcaffd3ffcfffd3ffd6ffcfffcaffc9ffc7ffcaffd7ffd5ffd0ffdaffd4ffddffd6ffd8ffdcffd8ffd4ffcaffe5ffceffccff690d840d810d760d7f0d7a0d730d7a0d800d8a0d820d8c0d800d750d740d740d620d690d800d7a0d7d0d6e0d710d780d790d890d770d810d7d0d760d7d0d7b0d7a0d890d810d830d7a0d6d0d6c0d6f0d690d6d0d790d6d0d730d760d770d850d790d810d760d7d0d750d720d760d740d720d820d750d890d840d830d7d0d7b0d770d7b0d820d6f0d830d6f0d770d6e0d7b0d820d700d760d7f0d6a0d780d790d7c0d830d780d7a0d840d780d6f0d7f0d740d800d7b0d860d7f0d7a0d840d7d0d820d770d810d7c0d6400640005020000000000000900090004000500060007000a000c000b000d000e000c000d000d000c000b00090008000c000d000d0011000e000c000c000b000b000e000f00130011001100100010000e000e000e000e000c000b000c000c000b000e000d0010000e000e000d000d000c000b000c000a000b000c000c000e000b000b000c000c000d000a000b000b000a000b000c000c000c000d000e000f000b000d000b000b000e000d000c000c000b000b000c000c000c000b000b000a000a000b000b000d000f000d000d000b000b000a00fcfffbfffbfffdfff9fffbfffcfffdfffdfffdfffcfffcfffffffcfffcfffdfffffffdfffcffffff01000000fefffdfffdfffefffeffffff0000ffff0200feffffffffff000000000100fefffffffdfffdfffefffdfffefffbfffdffffff0100fefffefffdfffdfffdfffefffdfffffffefffeff0000fefffdfffffffefffdff0000fefffefffefffdfffefffefffefffefffffffffffffffffffdff00000000fefffdfffffffefffdfffefffdfffdfffffffffffdfffefffffffcfffdfffefffdfffdfffefffdfffbfff9fff9fff8fffcfff9fff8fff9fff7fff7fffafffcfffbfffdfffbfffafffcfffcfffbfff9fff8fffcfff9fff8fffbfff9fff9fffcfffcfffcfffffffbfffcfffafff8fff7fff8fff7fff6fff9fff9fffafffcfffbfffdfffdfffcfffcfffcfffcfffbfffbfffafff9fffcfffafff7fffafffbfff9fffbfffafff8fff7fff8fffafff8fff8fffafffafffafffbfffcfffcfffafffafffbfffcfffafffafff9fffafffafff9fff8fff8fff9fff9fffbfff8fffafffafffafffbfffbfff9fffafffafffafff9ff7ae96eb8"
+        return stride(from: 0, to: hex.count, by: 2).map {
+            let s = hex.index(hex.startIndex, offsetBy: $0)
+            return UInt8(hex[s...hex.index(after: s)], radix: 16)!
+        }
+    }()
+}


### PR DESCRIPTION
## What

Decode the WHOOP 5.0/MG **raw 6-axis IMU** offload buffer and extract activity features from it. Pure, tested, no strap, no decode-gating of any existing score. Follows the capture recorder in #454; coordinates with #423.

- `WhoopProtocol.Whoop5RawImu` — the 1244-byte type-0x2F offload buffer → 100 Hz 3-axis accel (g) + 3-axis gyro (°/s).
- `StrandAnalytics.ImuFeatureExtractor` — a window of samples → `{accelEnergy, gyroEnergy, jerkRms, cadenceHz, cadenceStrength}`, the input a coarse sport / HAR classifier needs (the real-IMU upgrade path behind `WorkoutTypeClassifying`).

## Why

The 5/MG's **live** raw-IMU stream is firmware-refused (`TOGGLE_IMU_MODE`/106 acks but never streams, #423), so this looked like a dead end. But the **offload burst** carries a 1244-byte buffer that is a full second of raw inertial data — **including gyro**. So 100 Hz 6-axis IMU *is* obtainable on the 5.0, via the historical path. At 100 Hz it resolves gait cadence, jerk/impact, and rotational energy the 1 Hz gravity vector physically cannot (a 1.8 Hz step rate is above the 1 Hz stream's Nyquist limit).

## Layout (validated)

Reference: [Asherlc/dofek](https://github.com/Asherlc/dofek) `docs/whoop-ble-protocol.md` documents this raw packet; same **columnar** convention as the 4.0 `1917` variant.
```
frame = 8-byte puffin envelope + payload:
  @15  u32 LE  strap unix seconds
  @24  u16 LE  countA (=100)
  @28  ax[100]  @228 ay[100]  @428 az[100]   (i16 LE)   1/4096 g/LSB
  @630 u16 LE  countB (=100)
  @640 gx[100]  @840 gy[100]  @1040 gz[100]  (i16 LE)   2000/32768 (°/s)/LSB
```

## Verification

- `swift test` — `Whoop5RawImuTests` + `ImuFeatureExtractorTests` (pure packages, run in CI's `swift-packages`).
- **Real hardware**: a test decodes an **actual buffer captured off a WHOOP 5.0 (fw 50.40.1.0)** and asserts the accelerometer forms a ~1 g gravity shell (≥95/100 samples in-shell, median 1.01 g); gyro sits near zero at rest and correlates 0.79 with accel motion across 1423 captured buffers.
- Per the derived-signal rule, cadence is a **feature, never a physiological gate**, and its test recovers **four distinct injected cadences** (1.4/1.8/2.4/3.0 Hz), not one match. On 23 min of real captured wear the same method found a **1.79 Hz ≈ 107 steps/min** walking cadence.

## Notes

- Decode + features only — no store/UI/classifier wiring here (that follows, gated on labeled training data).
- **The other big offload buffer (2140 B) is a separate optical suite** (PPG/SpO₂ and, on MG, blood-pressure vascular channels) — still undecoded; not in this PR.
- Android twins deferred (research instrumentation; can follow once wired to a shipped path).
