### PR TITLE
i18n: fill in missing Russian (ru) translations

### DIFF
--- a/NOOPWatch/Localizable.xcstrings
+++ b/NOOPWatch/Localizable.xcstrings
@@ -33,6 +33,12 @@
             "value": "%@ resp/min"
           }
         },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ вдохов/мин"
+          }
+        },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
@@ -77,6 +83,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Ritmo %@"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ темп"
           }
         },
         "zh-Hans": {
@@ -125,6 +137,12 @@
             "value": "%@ · %@s inspira / %@s expira"
           }
         },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ · %@с вдох / %@с выдох"
+          }
+        },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
@@ -169,6 +187,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "%@ · %lld kcal"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ · %lld ккал"
           }
         },
         "zh-Hans": {
@@ -217,6 +241,12 @@
             "value": "%lld respirações · %@"
           }
         },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld вдохов · %@"
+          }
+        },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
@@ -261,6 +291,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "%1$lld segundos restantes em %2$@"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Осталось %1$lld секунд, %2$@"
           }
         },
         "zh-Hans": {
@@ -309,6 +345,12 @@
             "value": "Permitir acesso"
           }
         },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Разрешить доступ"
+          }
+        },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
@@ -353,6 +395,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Caixa"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Квадрат"
           }
         },
         "zh-Hans": {
@@ -459,6 +507,12 @@
             "value": "Inspira"
           }
         },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Вдох"
+          }
+        },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
@@ -503,6 +557,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Inspira durante %lld segundos"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Вдох на %lld секунд"
           }
         },
         "zh-Hans": {
@@ -551,6 +611,12 @@
             "value": "Expira"
           }
         },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Выдох"
+          }
+        },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
@@ -595,6 +661,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Expira durante %lld segundos"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Выдох на %lld секунд"
           }
         },
         "zh-Hans": {
@@ -701,6 +773,12 @@
             "value": "Coerência"
           }
         },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Когерентность"
+          }
+        },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
@@ -747,6 +825,12 @@
             "value": "CONCLUÍDO"
           }
         },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ГОТОВО"
+          }
+        },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
@@ -791,6 +875,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Concluído"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Готово"
           }
         },
         "zh-Hans": {
@@ -897,6 +987,12 @@
             "value": "Terminar"
           }
         },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Завершить"
+          }
+        },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
@@ -941,6 +1037,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Terminar treino"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Завершить тренировку"
           }
         },
         "zh-Hans": {
@@ -989,6 +1091,12 @@
             "value": "Força funcional"
           }
         },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Функциональная сила"
+          }
+        },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
@@ -1033,6 +1141,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Conceder acesso à Saúde"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Разрешить доступ к Health"
           }
         },
         "zh-Hans": {
@@ -1139,6 +1253,12 @@
             "value": "FC indisponível"
           }
         },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ЧСС недоступна"
+          }
+        },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
@@ -1183,6 +1303,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Frequência cardíaca e energia em tempo real, registadas no pulso. Ficam no dispositivo."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Пульс и энергия в реальном времени, записанные на запястье. Остаются на устройстве."
           }
         },
         "zh-Hans": {
@@ -1231,6 +1357,12 @@
             "value": "Abre o NOOP no iPhone para sincronizar"
           }
         },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Откройте NOOP на iPhone для синхронизации"
+          }
+        },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
@@ -1275,6 +1407,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "EM PAUSA"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ПАУЗА"
           }
         },
         "zh-Hans": {
@@ -1381,6 +1519,12 @@
             "value": "A GRAVAR"
           }
         },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ЗАПИСЬ"
+          }
+        },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
@@ -1425,6 +1569,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "DESCANSO"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ОТДЫХ"
           }
         },
         "zh-Hans": {
@@ -1473,6 +1623,12 @@
             "value": "Pronto para respirar"
           }
         },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Готовы к дыханию"
+          }
+        },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
@@ -1517,6 +1673,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Relaxa"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Расслабьтесь"
           }
         },
         "zh-Hans": {
@@ -1739,6 +1901,12 @@
             "value": "Retomar"
           }
         },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Продолжить"
+          }
+        },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
@@ -1783,6 +1951,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Ronda %lld de %lld"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Раунд %lld из %lld"
           }
         },
         "zh-Hans": {
@@ -1831,6 +2005,12 @@
             "value": "SEG"
           }
         },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "СЕК"
+          }
+        },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
@@ -1875,6 +2055,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Sessão concluída"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Сессия завершена"
           }
         },
         "zh-Hans": {
@@ -2039,6 +2225,12 @@
             "value": "Parar"
           }
         },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Стоп"
+          }
+        },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
@@ -2143,6 +2335,12 @@
             "value": "TRABALHO"
           }
         },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "РАБОТА"
+          }
+        },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
@@ -2187,6 +2385,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Treino"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Тренировка"
           }
         },
         "zh-Hans": {
@@ -2235,6 +2439,12 @@
             "value": "Treino guardado"
           }
         },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Тренировка сохранена"
+          }
+        },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
@@ -2279,6 +2489,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "em %@"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "на %@"
           }
         },
         "zh-Hans": {
@@ -2372,6 +2588,12 @@
             "state": "needs_review",
             "value": "cal"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "кал"
+          }
         }
       }
     },
@@ -2405,6 +2627,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "desatualizado · %@"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "устарело · %@"
           }
         },
         "zh-Hans": {

--- a/NOOPWatchComplications/Localizable.xcstrings
+++ b/NOOPWatchComplications/Localizable.xcstrings
@@ -20,6 +20,12 @@
             "state": "needs_review",
             "value": "%@ %lld"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ %lld"
+          }
         }
       }
     },
@@ -42,6 +48,12 @@
             "state": "needs_review",
             "value": "%@ a calibrar"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ калибруется"
+          }
         }
       }
     },
@@ -63,6 +75,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "%@ indisponível"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ недоступно"
           }
         }
       }
@@ -144,6 +162,12 @@
             "state": "needs_review",
             "value": "Carga %lld de 100"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Заряд %lld из 100"
+          }
         }
       }
     },
@@ -165,6 +189,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Carga %lld · %lld bpm%@"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Заряд %lld · %lld уд/мин%@"
           }
         }
       }
@@ -188,6 +218,12 @@
             "state": "needs_review",
             "value": "Carga %lld%@"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Заряд %lld%@"
+          }
         }
       }
     },
@@ -209,6 +245,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Carga a calibrar"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Заряд калибруется"
           }
         }
       }
@@ -232,6 +274,12 @@
             "state": "needs_review",
             "value": "Carga a calibrar, precisa de mais dados"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Заряд калибруется, нужно больше данных"
+          }
         }
       }
     },
@@ -253,6 +301,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Carga desatualizada, última sincronização %@. Abre o NOOP no iPhone."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Заряд устарел, последняя синхронизация %@. Откройте NOOP на iPhone."
           }
         }
       }
@@ -276,6 +330,12 @@
             "state": "needs_review",
             "value": "Carga desatualizada · %@"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Заряд устарел · %@"
+          }
         }
       }
     },
@@ -297,6 +357,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Carga indisponível"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Заряд недоступен"
           }
         }
       }
@@ -320,6 +386,12 @@
             "state": "needs_review",
             "value": "Carga · %@"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Заряд · %@"
+          }
         }
       }
     },
@@ -342,6 +414,12 @@
             "state": "needs_review",
             "value": "Carga · cal"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Заряд · кал"
+          }
         }
       }
     },
@@ -363,6 +441,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Carga –"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Заряд –"
           }
         }
       }
@@ -457,6 +541,12 @@
             "value": "Carga NOOP"
           }
         },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "NOOP Заряд"
+          }
+        },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
@@ -490,6 +580,12 @@
             "state": "needs_review",
             "value": "NOOP · abre no iPhone"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "NOOP · откройте на iPhone"
+          }
         }
       }
     },
@@ -510,6 +606,12 @@
         "pt-PT": {
           "stringUnit": {
             "state": "needs_review",
+            "value": "NOOP. %@, %@, %@."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
             "value": "NOOP. %@, %@, %@."
           }
         }
@@ -534,6 +636,12 @@
             "state": "needs_review",
             "value": "NOOP. Sem dados ainda, abre o NOOP no iPhone para sincronizar."
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "NOOP. Данных пока нет, откройте NOOP на iPhone для синхронизации."
+          }
         }
       }
     },
@@ -555,6 +663,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "NOOP. Pontuações desatualizadas, última sincronização %@. Abre o NOOP no iPhone para atualizar."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "NOOP. Показатели устарели, последняя синхронизация %@. Откройте NOOP на iPhone, чтобы обновить."
           }
         }
       }
@@ -578,6 +692,12 @@
             "state": "needs_review",
             "value": "Sem dados, abre o NOOP no iPhone"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Нет данных, откройте NOOP на iPhone"
+          }
         }
       }
     },
@@ -599,6 +719,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Abrir NOOP"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Открыть NOOP"
           }
         }
       }
@@ -693,6 +819,12 @@
             "value": "A tua Carga (recuperação) no mostrador, com Esforço e Descanso no cartão retangular."
           }
         },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ваш заряд (восстановление) на циферблате, с показателями «Усилие» и «Отдых» в прямоугольной карточке."
+          }
+        },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
@@ -726,6 +858,12 @@
             "state": "needs_review",
             "value": "há algum tempo"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "некоторое время назад"
+          }
         }
       }
     },
@@ -747,6 +885,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "cal"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "кал"
           }
         }
       }
@@ -770,6 +914,12 @@
             "state": "needs_review",
             "value": "desatualizado"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "устарело"
+          }
         }
       }
     },
@@ -792,6 +942,12 @@
             "state": "needs_review",
             "value": "abrir iPhone"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "открыть iPhone"
+          }
         }
       }
     },
@@ -813,6 +969,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "desatualizado"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "устарело"
           }
         }
       }

--- a/Packages/StrandDesign/Sources/StrandDesign/Resources/Localizable.xcstrings
+++ b/Packages/StrandDesign/Sources/StrandDesign/Resources/Localizable.xcstrings
@@ -20,6 +20,12 @@
             "state": "needs_review",
             "value": "há %lld dias"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld дн. назад"
+          }
         }
       }
     },
@@ -55,6 +61,12 @@
             "value": "%lld horas"
           }
         },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld часов"
+          }
+        },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
@@ -88,6 +100,12 @@
             "state": "needs_review",
             "value": "%lld minutos"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld минут"
+          }
         }
       }
     },
@@ -109,6 +127,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "%lld pontos, média %@, intervalo de %@ a %@"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld точек, среднее %@, диапазон от %@ до %@"
           }
         }
       }
@@ -132,6 +156,12 @@
             "state": "needs_review",
             "value": "%lld leituras"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld измерений"
+          }
         }
       }
     },
@@ -154,6 +184,12 @@
             "state": "needs_review",
             "value": "%lld treinos"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld тренировок"
+          }
         }
       }
     },
@@ -175,6 +211,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "há %lldd"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lldд назад"
           }
         }
       }
@@ -211,6 +253,12 @@
             "value": "há %lldh"
           }
         },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lldч назад"
+          }
+        },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
@@ -243,6 +291,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "há %lldm"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lldм назад"
           }
         }
       }
@@ -279,6 +333,12 @@
             "value": "1 hora"
           }
         },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1 час"
+          }
+        },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
@@ -312,6 +372,12 @@
             "state": "needs_review",
             "value": "1 minuto"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1 минута"
+          }
         }
       }
     },
@@ -334,6 +400,12 @@
             "state": "needs_review",
             "value": "1 treino"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1 тренировка"
+          }
         }
       }
     },
@@ -355,6 +427,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "MÁXIMO"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "НА ПРЕДЕЛЕ"
           }
         }
       }
@@ -436,6 +514,12 @@
             "state": "needs_review",
             "value": "Clássico"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Классический"
+          }
         }
       }
     },
@@ -458,6 +542,12 @@
             "state": "needs_review",
             "value": "ESGOTADO"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "РАЗРЯЖЕН"
+          }
         }
       }
     },
@@ -479,6 +569,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Escuro"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Тёмная"
           }
         }
       }
@@ -573,6 +669,12 @@
             "value": "Predefinição"
           }
         },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "По умолчанию"
+          }
+        },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
@@ -619,6 +721,12 @@
             "value": "ALTO"
           }
         },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ВЫСОКИЙ"
+          }
+        },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
@@ -651,6 +759,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "LEVE"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ЛЁГКИЙ"
           }
         }
       }
@@ -685,6 +799,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "BAIXO"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "НИЗКИЙ"
           }
         },
         "zh-Hans": {
@@ -778,6 +898,12 @@
             "state": "needs_review",
             "value": "MODERADO"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "УМЕРЕННЫЙ"
+          }
         }
       }
     },
@@ -858,6 +984,12 @@
             "state": "needs_review",
             "value": "Sem dados de frequência cardíaca"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Нет данных о пульсе"
+          }
         }
       }
     },
@@ -893,6 +1025,12 @@
             "value": "PICO"
           }
         },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ПИК"
+          }
+        },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
@@ -926,6 +1064,12 @@
             "state": "needs_review",
             "value": "PREPARADO"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ЗАРЯЖЕН"
+          }
         }
       }
     },
@@ -947,6 +1091,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Calendário de recuperação, %lld dias, média %lld, mín %lld, máx %lld"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Календарь восстановления, %lld дней, среднее %lld, минимум %lld, максимум %lld"
           }
         }
       }
@@ -970,6 +1120,12 @@
             "state": "needs_review",
             "value": "Calendário de recuperação, sem dados"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Календарь восстановления, нет данных"
+          }
         }
       }
     },
@@ -991,6 +1147,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "EXTENUANTE"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ИНТЕНСИВНЫЙ"
           }
         }
       }
@@ -1014,6 +1176,12 @@
             "state": "needs_review",
             "value": "Fases do sono, %@"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Стадии сна, %@"
+          }
         }
       }
     },
@@ -1036,6 +1204,12 @@
             "state": "needs_review",
             "value": "Fases do sono, sem dados"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Стадии сна, нет данных"
+          }
         }
       }
     },
@@ -1057,6 +1231,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "Sistema"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Системная"
           }
         }
       }
@@ -1138,6 +1318,12 @@
             "state": "needs_review",
             "value": "Tendência, %lld pontos, mais recente %@, mín %@, máx %@"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Тренд, %lld точек, последнее %@, минимум %@, максимум %@"
+          }
         }
       }
     },
@@ -1173,6 +1359,12 @@
             "value": "Ontem"
           }
         },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Вчера"
+          }
+        },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
@@ -1206,6 +1398,12 @@
             "state": "needs_review",
             "value": "a dormir %@"
           }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "во сне %@"
+          }
         }
       }
     },
@@ -1227,6 +1425,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "média %@ bpm"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "среднее %@ уд/мин"
           }
         }
       }
@@ -1263,6 +1467,12 @@
             "value": "agora mesmo"
           }
         },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "только что"
+          }
+        },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
@@ -1295,6 +1505,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "intervalo de %@ a %@"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "диапазон от %@ до %@"
           }
         }
       }


### PR DESCRIPTION
Russian (ru) was far behind every other shipped locale: Strand main catalog 465/3104, NOOPWatch 12/50, NOOPWatchComplications 3/30, StrandDesign 5/41 — so untranslated English fragments surfaced across sleep, chart, correlation, journal, and watch-complication screens for any Russian-locale user.

Fill in all 2,690 missing strings (2,740 catalog entries total) across the four Localizable.xcstrings files, reusing the terminology already established in the existing ru entries so it stays consistent with what's already shipped (Strain → Нагрузка, Recovery → Восстановление, HRV → ВСР, Baseline → норма, etc.).