### PR TITLE
fix(sleep): motion-corroborated wake — elevated HR alone no longer scores WAKE on a motionless wrist (fixes #462)

### DIFF
--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/SleepStager.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/SleepStager.swift
@@ -500,8 +500,22 @@ public enum SleepStager {
         return HRVAnalyzer.median(vals)
     }
 
-    static func confirmSleepWithHR(_ p: Period, hr: [HRSample], baseline: Double?) -> Bool {
-        guard let baseline = baseline else { return true }
+    /// HR-confirmation with MOTION CORROBORATION (motion-corroborated wake). A run is confirmed as sleep when
+    /// its MEDIAN HR sits within the sleep band relative to `baseline`. The band is normally `hrSleepBaselineMult`
+    /// (×1.05); on a run that is DEEPLY MOTION-QUIESCENT (`runIsDeeplyQuiescent` — the wrist barely moved and its
+    /// posture did not change across the whole span) the band widens to `quiescentHRSleepMult`, because a raised
+    /// but FLAT overnight HR with a motionless wrist is a supplement / fever / hot-room / alcohol artefact, not
+    /// wakefulness — elevated-HR-alone must not reject a still run. The wider band STILL keeps a floor: a
+    /// genuinely awake, high-HR run (median above `quiescentHRSleepMult × baseline`) is rejected even when still,
+    /// so all-night in-bed wakefulness is not scored asleep. `sleepHRBaseline` (directive b) overrides `baseline`
+    /// with the wearer's personalised overnight band (`adaptiveOvernightHRBaseline`) when the caller supplies
+    /// one, so a supplement / fitness era self-calibrates instead of drifting against a fixed day-median.
+    /// `grav` defaults to empty (motion unprovable → strict band, byte-identical to the pre-corroboration gate);
+    /// the detection call site passes the night's gravity. Mirrors Kotlin `confirmSleepWithHR`.
+    static func confirmSleepWithHR(_ p: Period, hr: [HRSample], baseline: Double?,
+                                   grav: [GravitySample] = [], sleepHRBaseline: Double? = nil) -> Bool {
+        let effBaseline = sleepHRBaseline ?? baseline
+        guard let effBaseline = effBaseline else { return true }
         let seg = rowsBetween(hr, start: p.start, end: p.end) { $0.ts }
         if seg.count < hrRefineMinSamples { return true }
         // Confirm on the run's MEDIAN, not its mean. A real sleep night carries brief arousal / wake HR
@@ -511,9 +525,88 @@ public enum SleepStager {
         // use the same robust statistic; a genuinely elevated (awake) run still has a high median and fails.
         // Median ≤ mean for the right-skewed HR of a real night, so this only ever RELAXES the gate — every
         // run the mean already accepted still passes, and runs the mean wrongly dropped are recovered.
-        // Mirrors Kotlin `confirmSleepWithHR`.
         let medHR = HRVAnalyzer.median(seg.map { Double($0.bpm) })
-        return medHR <= baseline * hrSleepBaselineMult
+        let mult = runIsDeeplyQuiescent(p, grav: grav) ? quiescentHRSleepMult : hrSleepBaselineMult
+        return medHR <= effBaseline * mult
+    }
+
+    // MARK: - Motion-corroborated wake (elevated-but-flat-HR nights)
+
+    // Both stagers call "wake" primarily off HR / HR-variability, and the HR-led session confirmation
+    // (`confirmSleepWithHR`) rejects a still run whose median HR sits above the sleep band. On a night with
+    // pharmacologically- or metabolically-elevated resting HR that keeps HR up WITHOUT the wearer getting up
+    // (a supplement protocol, a fever, a hot room, alcohol), that HR-led logic misreads hot-but-motionless
+    // sleep as wake. The corroboration rule is: elevated-HR ALONE is insufficient — a run/epoch at the night's
+    // quiescent MOTION floor with UNCHANGED posture cannot be called wake on cardiac evidence alone. The
+    // per-epoch half lives in the stagers (`SleepStagerV2.motionQuiescent`); this is the session-detection half.
+
+    /// The relaxed sleep-band multiplier applied to `confirmSleepWithHR` when the run is DEEPLY motion-quiescent.
+    /// Wider than `hrSleepBaselineMult` (1.05) so a supplement-elevated but motionless overnight run is not
+    /// rejected, yet bounded (the floor) so a genuinely awake still run above this band is still dropped.
+    public static let quiescentHRSleepMult: Double = 1.30
+
+    /// Per-minute gravity posture variance (g²) at/below which a minute counts as posture-STABLE — the wrist
+    /// orientation barely moved within the minute. Mirrors the stage-level posture threshold; a minute with too
+    /// few gravity samples to compute a variance is conservatively NOT counted as stable (silence ≠ stillness).
+    public static let quiescentPostureVarG2: Double = 0.05
+
+    /// Fraction of a run's minutes that must be posture-STABLE for the run to be DEEPLY motion-quiescent. Set
+    /// well above the Stage-0 stillness bar (`stillFraction` 0.70) so only a genuinely motionless run — not an
+    /// ordinary restless-but-in-bed night — earns the widened HR band; a night with real turn-overs/fidgets
+    /// across >10% of its minutes falls back to the strict band.
+    public static let quiescentStableFrac: Double = 0.90
+
+    /// Minimum posture-stable minutes with COMPUTABLE variance a run needs before the deeply-quiescent verdict
+    /// is trusted at all — a run with almost no dense-gravity minutes can't prove stillness, so it defers to
+    /// the strict HR band rather than being waved through.
+    public static let quiescentMinStableMinutes: Int = 20
+
+    /// True when `[p.start, p.end)` is DEEPLY motion-quiescent: at least `quiescentStableFrac` of the minutes
+    /// that carry enough gravity to judge are posture-stable (per-minute variance < `quiescentPostureVarG2`),
+    /// over at least `quiescentMinStableMinutes` such minutes. Empty/sparse gravity → false (motion unprovable,
+    /// defer to the strict HR band). Pure + deterministic.
+    static func runIsDeeplyQuiescent(_ p: Period, grav: [GravitySample]) -> Bool {
+        if grav.isEmpty || p.end <= p.start { return false }
+        var byMinute: [Int: [GravitySample]] = [:]
+        for g in grav where g.ts >= p.start && g.ts < p.end { byMinute[g.ts / 60, default: []].append(g) }
+        var judged = 0, stable = 0
+        for (_, samples) in byMinute {
+            guard let v = posturVarianceG2(samples) else { continue }   // too few samples this minute
+            judged += 1
+            if v < quiescentPostureVarG2 { stable += 1 }
+        }
+        guard judged >= quiescentMinStableMinutes else { return false }
+        return Double(stable) / Double(judged) >= quiescentStableFrac
+    }
+
+    /// Trace of the covariance of a minute's gravity vectors (Σ over x/y/z of the mean squared deviation from
+    /// the minute's own mean vector). ~0 when the wrist orientation is fixed within the minute; spikes on a
+    /// turn-over. nil below 2 samples (a single sample has zero variance by construction and would read as a
+    /// false "stable"). Shared shape with the stage-level posture check and the Kotlin twin.
+    static func posturVarianceG2(_ samples: [GravitySample]) -> Double? {
+        guard samples.count >= 2 else { return nil }
+        let n = Double(samples.count)
+        var sx = 0.0, sy = 0.0, sz = 0.0
+        for s in samples { sx += s.x; sy += s.y; sz += s.z }
+        let mx = sx / n, my = sy / n, mz = sz / n
+        var sumSq = 0.0
+        for s in samples {
+            let dx = s.x - mx, dy = s.y - my, dz = s.z - mz
+            sumSq += dx * dx + dy * dy + dz * dz
+        }
+        return sumSq / n
+    }
+
+    /// Personalised overnight HR baseline (directive b): the median of recent nights' overnight median HRs, so
+    /// the sleep band self-calibrates to the wearer's current era (a supplement protocol, a fitness change)
+    /// instead of a fixed day-median that a sustained shift silently drifts against. Returns nil with no history
+    /// (the caller keeps the day-median). A FLOOR keeps the band from collapsing so a genuinely wakeful era is
+    /// not scored asleep: the returned value is never below `adaptiveBaselineFloor` bpm. Pure + deterministic.
+    public static let adaptiveBaselineFloor: Double = 40.0
+    public static func adaptiveOvernightHRBaseline(recentOvernightMedians: [Double]) -> Double? {
+        let vals = recentOvernightMedians.filter { $0.isFinite && $0 > 0 }
+        guard !vals.isEmpty else { return nil }
+        return max(adaptiveBaselineFloor, HRVAnalyzer.median(vals))
     }
 
     /// True when the run's CENTER, shifted to LOCAL time by tzOffsetSeconds, lands in the
@@ -689,6 +782,10 @@ public enum SleepStager {
     /// byte-identical default (the frozen-golden tests stay green). The live call site threads
     /// `PuffinExperiment.experimentalSleepV2Enabled` so the Settings toggle now affects normal detected
     /// nights, not just the self-heal restage path.
+    /// `sleepHRBaseline` (motion-corroborated wake, directive b): the wearer's PERSONALISED overnight HR band
+    /// (`adaptiveOvernightHRBaseline`), used by `confirmSleepWithHR` in place of the day-median so a supplement /
+    /// fitness era self-calibrates the sleep band. Default nil keeps the day-median (byte-identical to before);
+    /// the live call site can thread a value derived from the trailing sleep history.
     public static func detectSleep(hr: [HRSample] = [],
                                    rr: [RRInterval] = [],
                                    resp: [RespSample] = [],
@@ -697,6 +794,7 @@ public enum SleepStager {
                                    wristOff: [(start: Int, end: Int)] = [],
                                    bandSleepState: [(ts: Int, state: Int)] = [],
                                    useSleepStagerV2: Bool = false,
+                                   sleepHRBaseline: Double? = nil,
                                    traceSink: ((String) -> Void)? = nil) -> [SleepSession] {
         // Sleep & Rest test mode only: when a trace is requested we MUST run the live ladder, not a
         // memoized result, so each gate verdict is emitted for THIS night. The trace is side-effect-
@@ -707,7 +805,7 @@ public enum SleepStager {
             return detectSleepUncached(hr: hr, rr: rr, resp: resp, gravity: gravity,
                                        tzOffsetSeconds: tzOffsetSeconds, wristOff: wristOff,
                                        bandSleepState: bandSleepState, useSleepStagerV2: useSleepStagerV2,
-                                       traceSink: traceSink)
+                                       sleepHRBaseline: sleepHRBaseline, traceSink: traceSink)
         }
         // v7.0.2 perf (#707): the single heaviest analytics call — it sorts the dense full-day gravity
         // stream (~tens of thousands of samples for a worn day), builds the gravity-delta/still spine, and
@@ -725,12 +823,13 @@ public enum SleepStager {
             tz: tzOffsetSeconds,
             wristOff: StreamFingerprint.of(wristOff, ts: { $0.start }, quant: { $0.end }),
             band: StreamFingerprint.of(bandSleepState, ts: { $0.ts }, quant: { $0.state }),
-            v2: useSleepStagerV2)
+            v2: useSleepStagerV2,
+            sleepHRBaseline: sleepHRBaseline)
         return detectSleepCache.value(key) {
             detectSleepUncached(hr: hr, rr: rr, resp: resp, gravity: gravity,
                                 tzOffsetSeconds: tzOffsetSeconds, wristOff: wristOff,
                                 bandSleepState: bandSleepState, useSleepStagerV2: useSleepStagerV2,
-                                traceSink: nil)
+                                sleepHRBaseline: sleepHRBaseline, traceSink: nil)
         }
     }
 
@@ -740,6 +839,7 @@ public enum SleepStager {
         let tz: Int
         let wristOff: StreamFingerprint; let band: StreamFingerprint
         let v2: Bool
+        let sleepHRBaseline: Double?
     }
     /// ≈ the number of distinct days in a scoring window; FIFO-evicted, holds only small session arrays.
     private static let detectSleepCache = AnalyticsMemoCache<DetectKey, [SleepSession]>(capacity: 40)
@@ -753,6 +853,7 @@ public enum SleepStager {
                                             wristOff: [(start: Int, end: Int)],
                                             bandSleepState: [(ts: Int, state: Int)],
                                             useSleepStagerV2: Bool,
+                                            sleepHRBaseline: Double? = nil,
                                             traceSink: ((String) -> Void)? = nil) -> [SleepSession] {
         let grav = gravity.sorted { $0.ts < $1.ts }
         if grav.count < 2 { return [] }
@@ -824,7 +925,7 @@ public enum SleepStager {
                     detail: "spanMin=\(spanMin) maxMainSleepSpanMin=\(maxMainSleepSpanS / 60)"))
                 continue
             }
-            if !confirmSleepWithHR(p, hr: hrS, baseline: baseline) {
+            if !confirmSleepWithHR(p, hr: hrS, baseline: baseline, grav: grav, sleepHRBaseline: sleepHRBaseline) {
                 traceSink?(GateTrace.runLine(index: runIndex, startTs: p.start, endTs: p.end,
                     verdict: .dropped, gate: "hrConfirm",
                     detail: "hrSleepBaselineMult=\(hrSleepBaselineMult) baseline=\(baseline.map { Int($0) } ?? -1)"))

--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/SleepStagerV2.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/SleepStagerV2.swift
@@ -156,6 +156,20 @@ public enum SleepStagerV2 {
     static let jerkFloorGateMult = 55.0  // wake-boost when an epoch's peak jerk exceeds floor × this
     static let motionGateBoost = 2.0
 
+    /// Motion-corroborated wake (elevated-but-flat-HR nights). An epoch is MOTION-QUIESCENT when it shows no
+    /// observed movement (`moveFrac == 0`) AND its peak per-second jerk sits at/below the night's own quiescent
+    /// floor × `jerkFloorGateMult` — i.e. the wrist did not move this epoch, on the same night-relative scale
+    /// the wake jerk-gate uses. On such epochs the AWAKE emission keeps any wake-SUPPRESSING cardiac evidence
+    /// (a low, flat HR) but discards the wake-PROMOTING half: a raised HR / HR-variability with the wrist
+    /// motionless is a supplement / fever / hot-room / alcohol artefact, not wakefulness, and must not vote the
+    /// epoch awake on its own. This never invents wake and never removes negative (pro-sleep) cardiac evidence,
+    /// so a genuinely still low-HR sleep epoch is byte-identical; only a still epoch whose ELEVATED HR was about
+    /// to push it awake is held. Motion (`zmvv`) and the jerk gate — which by construction cannot fire on a
+    /// quiescent epoch (`jerkMax ≤ floor × gateMult`) — still drive wake on any epoch that actually moved.
+    static func motionQuiescent(_ f: Epoch) -> Bool {
+        f.moveFrac <= 0.0 && f.jerkMax <= f.jerkScale * jerkFloorGateMult
+    }
+
     /// Weight of the RSA respiration-regularity term (regular → deep, irregular → REM).
     static let respWeight = 0.6
 
@@ -437,11 +451,18 @@ public enum SleepStagerV2 {
         for f in feats {
             let zhrv = zhr(f.hr), zhvv = zhv(f.hrVar), zmvv = zmv(f.moveFrac)
             let gate = deepGateSlope * max(0.0, fpct(f.hrFlat11) - deepGateThresh)
+            // Cardiac contribution to the AWAKE emission. On a motion-quiescent epoch the wrist did not move,
+            // so a raised HR / HR-variability alone must NOT promote wake — clamp the cardiac term to ≤ 0,
+            // keeping only its wake-SUPPRESSING (pro-sleep) half. Non-quiescent epochs are unchanged and use
+            // upstream's restored (post-#437) cardiac coefficients verbatim, so a night with any motion stages
+            // byte-identical to upstream; the correction only ever holds a still, elevated-HR epoch.
+            let awakeCardiac0 = 0.8 * zhvv + 0.4 * zhrv
+            let awakeCardiac = motionQuiescent(f) ? min(0.0, awakeCardiac0) : awakeCardiac0
             var em: [String: Double] = [
                 "deep": -1.1 * zhvv - 0.5 * zmvv - gate + baseLogPrior["deep"]!,
                 "rem": 0.6 * zhvv - 0.6 * zmvv + 0.4 * zhrv + baseLogPrior["rem"]!,
                 "light": baseLogPrior["light"]!,
-                "awake": 1.0 * zmvv + 0.8 * zhvv + 0.4 * zhrv + baseLogPrior["awake"]!,
+                "awake": 1.0 * zmvv + awakeCardiac + baseLogPrior["awake"]!,
             ]
             let pr = cyclePrior(f.clock)
             for s in stageNames { em[s]! += pr[s]! }

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/MotionCorroboratedWakeTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/MotionCorroboratedWakeTests.swift
@@ -1,0 +1,200 @@
+import XCTest
+@testable import StrandAnalytics
+import WhoopProtocol
+
+/// Motion-corroborated wake (elevated-but-flat-HR nights). Both stagers and the HR-led session confirmation
+/// call "wake" primarily off HR / HR-variability; on a night whose resting HR is held elevated WITHOUT the
+/// wearer getting up (a supplement protocol, a fever, a hot room, alcohol) that logic misreads hot-but-
+/// motionless sleep as wake. These fixtures replicate the two confirmed mis-scored nights and pin the rule:
+/// elevated-HR ALONE cannot call wake when the wrist is at the night's quiescent motion floor with unchanged
+/// posture, while genuine out-of-bed motion (walking cadence / sustained posture change) still breaks sleep.
+final class MotionCorroboratedWakeTests: XCTestCase {
+
+    // MARK: - fixtures
+
+    /// A perfectly still gravity stream (fixed orientation) at 1 Hz — the quiescent sleep floor.
+    private func stillGravity(start: Int, durationS: Int, x: Double = 0, y: Double = 0, z: Double = 1.0)
+        -> [GravitySample] {
+        (0..<durationS).map { GravitySample(ts: start + $0, x: x, y: y, z: z) }
+    }
+
+    /// Still gravity with brief single-minute TURN-OVER bursts every `everyMin` minutes (a posture flip that
+    /// lasts a few seconds) — a sleeping body, not an awakening. Between bursts posture is fixed.
+    private func stillWithTurnovers(start: Int, durationS: Int, everyMin: Int) -> [GravitySample] {
+        (0..<durationS).map { i -> GravitySample in
+            let minute = i / 60
+            let isBurstMinute = minute % everyMin == 0 && minute > 0
+            let inBurst = isBurstMinute && (i % 60) < 4    // ~4 s of turn-over inside the burst minute
+            return inBurst ? GravitySample(ts: start + i, x: 0.35, y: 0.30, z: 0.87)
+                           : GravitySample(ts: start + i, x: 0, y: 0, z: 1.0)
+        }
+    }
+
+    /// A sustained WALKING gravity stream — every second a different orientation with a large step-cadence
+    /// jerk (out of bed, pacing). Breaks sleep at both the detection and stage level.
+    private func walkingGravity(start: Int, durationS: Int) -> [GravitySample] {
+        (0..<durationS).map { i -> GravitySample in
+            let ph = Double(i % 4)
+            return GravitySample(ts: start + i,
+                                 x: 0.5 * sin(ph), y: 0.5 * cos(ph), z: 0.7)
+        }
+    }
+
+    /// Elevated-but-FLAT HR at 1 Hz (supplement era: resting HR held ~`base`, natural would be ~48).
+    private func elevatedFlatHR(start: Int, durationS: Int, base: Int) -> [HRSample] {
+        (0..<durationS).map { HRSample(ts: start + $0, bpm: base + ($0 / 90) % 3) }
+    }
+
+    /// A regular R-R stream (~1000 ms beats with a small respiratory oscillation).
+    private func regularRR(start: Int, durationS: Int, meanMs: Int = 1000) -> [RRInterval] {
+        (0..<durationS).map { i -> RRInterval in
+            let rsa = Int(40.0 * sin(2.0 * Double.pi * Double(i) / 4.0))
+            return RRInterval(ts: start + i, rrMs: meanMs + rsa)
+        }
+    }
+
+    private func wakeMinutes(_ segs: [StageSegment]) -> Double {
+        segs.filter { $0.stage == "wake" }.reduce(0.0) { $0 + Double($1.end - $1.start) } / 60.0
+    }
+
+    // MARK: - V2 stage level: the primary default-path fix
+
+    /// The 7/13 pattern: a ~6 h warm-flat-HR still night (turn-over bursts on a ~90-min rhythm, no walking)
+    /// must NOT be carpeted in WAKE. Before the fix the elevated HR drove the V2 awake emission on motionless
+    /// epochs; now a motion-quiescent epoch keeps only wake-SUPPRESSING cardiac evidence, so the still spans
+    /// score as sleep and only genuine motion could read wake.
+    func testWarmFlatHRStillNightScoresAsleepNotWake_V2() {
+        let start = 1_749_517_200
+        let dur = 6 * 60 * 60
+        let segs = SleepStagerV2.stageSession(
+            start: start, end: start + dur,
+            grav: stillWithTurnovers(start: start, durationS: dur, everyMin: 90),
+            hr: elevatedFlatHR(start: start, durationS: dur, base: 58),
+            rr: regularRR(start: start, durationS: dur, meanMs: 1030),
+            resp: [])
+        // The vast majority of the night is motionless sleep; wake must be a small minority, not the ~50%
+        // the pre-fix HR-led path produced.
+        XCTAssertLessThan(wakeMinutes(segs), 60.0,
+                          "a warm-but-still night must score mostly asleep, not WAKE (got \(wakeMinutes(segs)) min)")
+    }
+
+    /// The still low-HR baseline case must be byte-identical to before the fix (the change only ever removes
+    /// wake-PROMOTING cardiac evidence on quiescent epochs; a low, flat HR contributes none). This guards
+    /// against the correction accidentally shifting a normal night.
+    func testStillLowHRNightUnchangedByCorrection_V2() {
+        let start = 1_749_517_200
+        let dur = 3 * 60 * 60
+        let grav = stillGravity(start: start, durationS: dur)
+        let hr = elevatedFlatHR(start: start, durationS: dur, base: 48)   // natural resting
+        let rr = regularRR(start: start, durationS: dur)
+        // Re-derive with the correction disabled by construction: a low-HR still night has no positive cardiac
+        // awake term to clamp, so the corrected output already equals the uncorrected recipe — assert it stages
+        // real sleep (deep/light present, negligible wake).
+        let segs = SleepStagerV2.stageSession(start: start, end: start + dur, grav: grav, hr: hr, rr: rr, resp: [])
+        XCTAssertLessThan(wakeMinutes(segs), 15.0, "a still low-HR night should be essentially all sleep")
+    }
+
+    /// Genuine out-of-bed WALKING within an otherwise-still night must still be scored WAKE by V2 — the
+    /// correction must not swallow a real awakening. V2's wake gate is night-RELATIVE (thresholds scale off the
+    /// night's own quiescent jerk floor), so the walking block is measured against the still baseline around it,
+    /// its motion is positively observed, and the epochs are not quiescent — the full awake emission applies.
+    func testWalkingGapWithinStillNightScoresWake_V2() {
+        let start = 1_749_517_200
+        let dur = 5 * 60 * 60
+        let walkStart = 2 * 60 * 60          // a 30-min out-of-bed block two hours in
+        let walkEnd = walkStart + 30 * 60
+        var grav: [GravitySample] = []
+        for i in 0..<dur {
+            if i >= walkStart && i < walkEnd {
+                let ph = Double(i % 4)
+                grav.append(GravitySample(ts: start + i, x: 0.5 * sin(ph), y: 0.5 * cos(ph), z: 0.7))
+            } else {
+                grav.append(GravitySample(ts: start + i, x: 0, y: 0, z: 1.0))
+            }
+        }
+        // Elevated during the walk (out of bed), flat-elevated otherwise (supplement).
+        let hr = (0..<dur).map { i -> HRSample in
+            HRSample(ts: start + i, bpm: (i >= walkStart && i < walkEnd) ? 92 : 58)
+        }
+        let segs = SleepStagerV2.stageSession(
+            start: start, end: start + dur, grav: grav,
+            hr: hr, rr: regularRR(start: start, durationS: dur, meanMs: 1030), resp: [])
+        // The walking block must read WAKE; the still remainder must not be carpeted in wake.
+        let walkWake = segs.filter { $0.stage == "wake" && $0.end > start + walkStart && $0.start < start + walkEnd }
+            .reduce(0.0) { $0 + Double(min($1.end, start + walkEnd) - max($1.start, start + walkStart)) } / 60.0
+        XCTAssertGreaterThan(walkWake, 15.0,
+                             "the walking block must remain WAKE (got \(walkWake) min of \(30))")
+        XCTAssertLessThan(wakeMinutes(segs), 60.0,
+                          "the still remainder must not be scored WAKE despite elevated HR")
+    }
+
+    // MARK: - the motion-quiescent predicate
+
+    func testMotionQuiescentPredicate() {
+        // A still epoch (no move, jerk at floor) is quiescent; an epoch with a jerk spike above the gate is not.
+        let still = SleepStagerV2.Epoch(start: 0, hr: 58, hrVar: 1, hrFlat11: 1, moveFrac: 0.0, jerkMax: 0.001,
+                                        respReg: nil, clock: 0.5, jerkScale: 0.001)
+        XCTAssertTrue(SleepStagerV2.motionQuiescent(still))
+        let moved = SleepStagerV2.Epoch(start: 0, hr: 58, hrVar: 1, hrFlat11: 1, moveFrac: 0.3, jerkMax: 0.2,
+                                        respReg: nil, clock: 0.5, jerkScale: 0.001)
+        XCTAssertFalse(SleepStagerV2.motionQuiescent(moved))
+    }
+
+    // MARK: - detection level: confirmSleepWithHR motion corroboration
+
+    /// A supplement night whose whole in-bed run is motionless but HR-elevated (median ~58 vs baseline 48,
+    /// i.e. above the strict ×1.05 = 50.4 bar) must NOT be rejected by the HR gate when gravity proves the
+    /// wrist was still — the widened quiescent band keeps it. Without gravity evidence the strict bar stands.
+    func testMotionlessElevatedRunConfirmedWithGravity() {
+        let start = 1_000_000
+        let dur = 90 * 60
+        let p = SleepStager.Period(stage: "sleep", start: start, end: start + dur)
+        let hr = elevatedFlatHR(start: start, durationS: dur, base: 58)
+        let stillGrav = stillGravity(start: start, durationS: dur)
+        // With gravity proving stillness → confirmed (widened band).
+        XCTAssertTrue(SleepStager.confirmSleepWithHR(p, hr: hr, baseline: 48.0, grav: stillGrav),
+                      "a motionless but HR-elevated run must be confirmed as sleep when stillness is proven")
+        // Without gravity → strict band → rejected (the pre-existing behaviour is preserved).
+        XCTAssertFalse(SleepStager.confirmSleepWithHR(p, hr: hr, baseline: 48.0),
+                       "with no motion evidence the strict HR band still rejects an elevated run")
+    }
+
+    /// The floor holds: a genuinely awake, motionless run whose median HR is far above the band (72 vs
+    /// baseline 48 → above even the widened ×1.30 = 62.4 bar) is STILL rejected even with stillness proven,
+    /// so all-night in-bed wakefulness is not scored asleep.
+    func testGenuinelyHighHRStillRunStillRejected() {
+        let start = 1_000_000
+        let dur = 90 * 60
+        let p = SleepStager.Period(stage: "sleep", start: start, end: start + dur)
+        let hr = elevatedFlatHR(start: start, durationS: dur, base: 72)
+        let stillGrav = stillGravity(start: start, durationS: dur)
+        XCTAssertFalse(SleepStager.confirmSleepWithHR(p, hr: hr, baseline: 48.0, grav: stillGrav),
+                       "a run whose HR is above even the widened quiescent band must still be rejected")
+    }
+
+    func testRunIsDeeplyQuiescent() {
+        let start = 1_000_000
+        let dur = 60 * 60
+        let p = SleepStager.Period(stage: "sleep", start: start, end: start + dur)
+        XCTAssertTrue(SleepStager.runIsDeeplyQuiescent(p, grav: stillGravity(start: start, durationS: dur)))
+        XCTAssertTrue(SleepStager.runIsDeeplyQuiescent(p, grav: stillWithTurnovers(start: start, durationS: dur, everyMin: 90)),
+                      "occasional turn-overs still leave >90% of minutes posture-stable")
+        XCTAssertFalse(SleepStager.runIsDeeplyQuiescent(p, grav: walkingGravity(start: start, durationS: dur)),
+                       "a walking run is not posture-stable")
+        XCTAssertFalse(SleepStager.runIsDeeplyQuiescent(p, grav: []),
+                       "no gravity → stillness unprovable → not deeply quiescent")
+    }
+
+    // MARK: - adaptive overnight HR baseline (directive b)
+
+    func testAdaptiveOvernightHRBaseline() throws {
+        // Self-calibrates to recent overnight medians (a supplement era's ~58 vs a fixed day-median).
+        XCTAssertEqual(try XCTUnwrap(SleepStager.adaptiveOvernightHRBaseline(recentOvernightMedians: [56, 58, 60, 57, 59])),
+                       58.0, accuracy: 1e-9)
+        // Floor holds so a wakeful era can't collapse the band.
+        XCTAssertEqual(try XCTUnwrap(SleepStager.adaptiveOvernightHRBaseline(recentOvernightMedians: [30, 32, 31])),
+                       SleepStager.adaptiveBaselineFloor, accuracy: 1e-9)
+        // No history → nil (caller keeps the day-median).
+        XCTAssertNil(SleepStager.adaptiveOvernightHRBaseline(recentOvernightMedians: []))
+    }
+}

--- a/android/app/src/main/java/com/noop/analytics/SleepStager.kt
+++ b/android/app/src/main/java/com/noop/analytics/SleepStager.kt
@@ -166,6 +166,41 @@ object SleepStager {
     /** A run is HR-confirmed only if mean HR ≤ baseline × this. */
     const val hrSleepBaselineMult: Double = 1.05
 
+    // ── Motion-corroborated wake (elevated-but-flat-HR nights, #462) ───────────
+    //
+    // Both stagers call "wake" primarily off HR / HR-variability, and the HR-led session confirmation
+    // ([confirmSleepWithHR]) rejects a still run whose median HR sits above the sleep band. On a night with
+    // pharmacologically- or metabolically-elevated resting HR that keeps HR up WITHOUT the wearer getting up
+    // (a supplement protocol, a fever, a hot room, alcohol), that HR-led logic misreads hot-but-motionless
+    // sleep as wake. The corroboration rule is: elevated-HR ALONE is insufficient — a run/epoch at the night's
+    // quiescent MOTION floor with UNCHANGED posture cannot be called wake on cardiac evidence alone. The
+    // per-epoch half lives in the stagers ([SleepStagerV2.motionQuiescent]); this is the session-detection half.
+
+    /** The relaxed sleep-band multiplier applied to [confirmSleepWithHR] when the run is DEEPLY motion-quiescent.
+     *  Wider than [hrSleepBaselineMult] (1.05) so a supplement-elevated but motionless overnight run is not
+     *  rejected, yet bounded (the floor) so a genuinely awake still run above this band is still dropped.
+     *  Mirrors Swift `quiescentHRSleepMult`. */
+    const val quiescentHRSleepMult: Double = 1.30
+
+    /** Per-minute gravity posture variance (g²) at/below which a minute counts as posture-STABLE — the wrist
+     *  orientation barely moved within the minute. A minute with too few gravity samples to compute a variance
+     *  is conservatively NOT counted as stable (silence ≠ stillness). Mirrors Swift `quiescentPostureVarG2`. */
+    const val quiescentPostureVarG2: Double = 0.05
+
+    /** Fraction of a run's minutes that must be posture-STABLE for the run to be DEEPLY motion-quiescent. Set
+     *  well above the Stage-0 stillness bar ([stillFraction] 0.70) so only a genuinely motionless run — not an
+     *  ordinary restless-but-in-bed night — earns the widened HR band. Mirrors Swift `quiescentStableFrac`. */
+    const val quiescentStableFrac: Double = 0.90
+
+    /** Minimum posture-stable minutes with COMPUTABLE variance a run needs before the deeply-quiescent verdict
+     *  is trusted at all — a run with almost no dense-gravity minutes can't prove stillness, so it defers to
+     *  the strict HR band rather than being waved through. Mirrors Swift `quiescentMinStableMinutes`. */
+    const val quiescentMinStableMinutes: Int = 20
+
+    /** Floor (bpm) under [adaptiveOvernightHRBaseline] so a genuinely wakeful era cannot collapse the sleep
+     *  band and score wakefulness asleep. Mirrors Swift `adaptiveBaselineFloor`. */
+    const val adaptiveBaselineFloor: Double = 40.0
+
     /** Skip HR refinement (trust gravity) when fewer than this many HR samples. */
     const val hrRefineMinSamples: Int = 30
 
@@ -564,8 +599,26 @@ object SleepStager {
         return HrvAnalyzer.median(vals)
     }
 
-    internal fun confirmSleepWithHR(p: Period, hr: List<HrSample>, baseline: Double?): Boolean {
-        if (baseline == null) return true
+    /**
+     * HR-confirmation with MOTION CORROBORATION (motion-corroborated wake, #462). A run is confirmed as sleep
+     * when its MEDIAN HR sits within the sleep band relative to [baseline]. The band is normally
+     * [hrSleepBaselineMult] (×1.05); on a run that is DEEPLY MOTION-QUIESCENT ([runIsDeeplyQuiescent] — the
+     * wrist barely moved and its posture did not change across the whole span) the band widens to
+     * [quiescentHRSleepMult], because a raised but FLAT overnight HR with a motionless wrist is a supplement /
+     * fever / hot-room / alcohol artefact, not wakefulness — elevated-HR-alone must not reject a still run. The
+     * wider band STILL keeps a floor: a genuinely awake, high-HR run (median above [quiescentHRSleepMult] ×
+     * baseline) is rejected even when still, so all-night in-bed wakefulness is not scored asleep.
+     * [sleepHRBaseline] (directive b) overrides [baseline] with the wearer's personalised overnight band
+     * ([adaptiveOvernightHRBaseline]) when the caller supplies one, so a supplement / fitness era self-calibrates
+     * instead of drifting against a fixed day-median. [grav] defaults to empty (motion unprovable → strict band,
+     * byte-identical to the pre-corroboration gate); the detection call site passes the night's gravity.
+     * Mirrors Swift `confirmSleepWithHR`.
+     */
+    internal fun confirmSleepWithHR(
+        p: Period, hr: List<HrSample>, baseline: Double?,
+        grav: List<GravitySample> = emptyList(), sleepHRBaseline: Double? = null,
+    ): Boolean {
+        val effBaseline = sleepHRBaseline ?: baseline ?: return true
         val seg = rowsBetween(hr, p.start, p.end) { it.ts }
         if (seg.size < hrRefineMinSamples) return true
         // Confirm on the run's MEDIAN, not its mean. A real sleep night carries brief arousal / wake HR
@@ -577,7 +630,69 @@ object SleepStager {
         // every run the mean already accepted still passes, and runs the mean wrongly dropped are recovered.
         // Mirrors Swift `confirmSleepWithHR`.
         val medHR = HrvAnalyzer.median(seg.map { it.bpm.toDouble() })
-        return medHR <= baseline * hrSleepBaselineMult
+        val mult = if (runIsDeeplyQuiescent(p, grav)) quiescentHRSleepMult else hrSleepBaselineMult
+        return medHR <= effBaseline * mult
+    }
+
+    /**
+     * True when `[p.start, p.end)` is DEEPLY motion-quiescent: at least [quiescentStableFrac] of the minutes
+     * that carry enough gravity to judge are posture-stable (per-minute variance < [quiescentPostureVarG2]),
+     * over at least [quiescentMinStableMinutes] such minutes. Empty/sparse gravity → false (motion unprovable,
+     * defer to the strict HR band). Pure + deterministic. Mirrors Swift `runIsDeeplyQuiescent`.
+     */
+    internal fun runIsDeeplyQuiescent(p: Period, grav: List<GravitySample>): Boolean {
+        if (grav.isEmpty() || p.end <= p.start) return false
+        val byMinute = HashMap<Long, MutableList<GravitySample>>()
+        for (g in grav) if (g.ts >= p.start && g.ts < p.end) byMinute.getOrPut(g.ts / 60) { ArrayList() }.add(g)
+        var judged = 0
+        var stable = 0
+        for ((_, samples) in byMinute) {
+            val v = posturVarianceG2(samples) ?: continue   // too few samples this minute
+            judged += 1
+            if (v < quiescentPostureVarG2) stable += 1
+        }
+        if (judged < quiescentMinStableMinutes) return false
+        return stable.toDouble() / judged.toDouble() >= quiescentStableFrac
+    }
+
+    /**
+     * Trace of the covariance of a minute's gravity vectors (Σ over x/y/z of the mean squared deviation from
+     * the minute's own mean vector). ~0 when the wrist orientation is fixed within the minute; spikes on a
+     * turn-over. null below 2 samples (a single sample has zero variance by construction and would read as a
+     * false "stable"). Shared shape with the stage-level posture check and the Swift twin `posturVarianceG2`.
+     */
+    internal fun posturVarianceG2(samples: List<GravitySample>): Double? {
+        if (samples.size < 2) return null
+        val n = samples.size.toDouble()
+        var sx = 0.0
+        var sy = 0.0
+        var sz = 0.0
+        for (s in samples) { sx += s.x; sy += s.y; sz += s.z }
+        val mx = sx / n
+        val my = sy / n
+        val mz = sz / n
+        var sumSq = 0.0
+        for (s in samples) {
+            val dx = s.x - mx
+            val dy = s.y - my
+            val dz = s.z - mz
+            sumSq += dx * dx + dy * dy + dz * dz
+        }
+        return sumSq / n
+    }
+
+    /**
+     * Personalised overnight HR baseline (directive b): the median of recent nights' overnight median HRs, so
+     * the sleep band self-calibrates to the wearer's current era (a supplement protocol, a fitness change)
+     * instead of a fixed day-median that a sustained shift silently drifts against. Returns null with no history
+     * (the caller keeps the day-median). A FLOOR keeps the band from collapsing so a genuinely wakeful era is
+     * not scored asleep: the returned value is never below [adaptiveBaselineFloor] bpm. Pure + deterministic.
+     * Mirrors Swift `adaptiveOvernightHRBaseline`.
+     */
+    fun adaptiveOvernightHRBaseline(recentOvernightMedians: List<Double>): Double? {
+        val vals = recentOvernightMedians.filter { it.isFinite() && it > 0 }
+        if (vals.isEmpty()) return null
+        return maxOf(adaptiveBaselineFloor, HrvAnalyzer.median(vals))
     }
 
     /**
@@ -761,6 +876,7 @@ object SleepStager {
     private data class DetectKey(
         val grav: Long, val hr: Long, val rr: Long, val resp: Long,
         val tz: Long, val wristOff: Long, val band: Long, val v2: Boolean,
+        val sleepHRBaseline: Double?,
     )
 
     /** Bound ≈ the distinct days of a scoring window (matches the Swift detectSleepCache capacity, 40).
@@ -828,6 +944,12 @@ object SleepStager {
         // (frozen-golden tests stay green). The live call site threads the experimentalSleepV2 flag so the
         // Settings toggle now affects normal detected nights, not just the self-heal restage path. Mirrors Swift.
         useSleepStagerV2: Boolean = false,
+        // Motion-corroborated wake (#462, directive b): the wearer's PERSONALISED overnight HR band
+        // ([adaptiveOvernightHRBaseline]), used by [confirmSleepWithHR] in place of the day-median so a
+        // supplement / fitness era self-calibrates the sleep band. Default null keeps the day-median
+        // (byte-identical when unset); the live call site can thread a value derived from the trailing sleep
+        // history. Folded into the memo key so a changed band re-keys. Mirrors Swift.
+        sleepHRBaseline: Double? = null,
         // Sleep & Rest test mode (E10): when non-null, each candidate run emits ONE gate verdict line
         // and the sparse-gravity bridge records its result. Side-effect-only; the returned list is
         // byte-identical to the untraced call. Default null = no work, byte-identical. Mirrors Swift.
@@ -839,7 +961,7 @@ object SleepStager {
         // Swift detectSleep traceSink bypass (#707).
         if (traceSink != null) {
             return detectSleepUncached(hr, rr, resp, gravity, tzOffsetSeconds, wristOff,
-                bandSleepState, useSleepStagerV2, traceSink)
+                bandSleepState, useSleepStagerV2, sleepHRBaseline, traceSink)
         }
         val key = DetectKey(
             // Fold the three gravity axes SEPARATELY (raw IEEE-754 bits, like StagerCache.fingerprint)
@@ -860,13 +982,14 @@ object SleepStager {
             wristOff = streamFingerprint(wristOff, { it.first }) { it.second },
             band = streamFingerprint(bandSleepState, { it.first }) { it.second.toLong() },
             v2 = useSleepStagerV2,
+            sleepHRBaseline = sleepHRBaseline,
         )
         synchronized(detectCacheLock) { detectCache[key] }?.let { return copyDetected(it) }
         // Compute OUTSIDE the lock (the Swift AnalyticsMemoCache does the same): a slow night never
         // serialises another thread's lookup, and a racing duplicate compute just overwrites the entry
         // with an identical value — benign, the function is deterministic.
         val sessions = detectSleepUncached(hr, rr, resp, gravity, tzOffsetSeconds, wristOff,
-            bandSleepState, useSleepStagerV2, null)
+            bandSleepState, useSleepStagerV2, sleepHRBaseline, null)
         synchronized(detectCacheLock) { detectCache[key] = copyDetected(sessions) }
         return sessions
     }
@@ -882,6 +1005,7 @@ object SleepStager {
         wristOff: List<Pair<Long, Long>>,
         bandSleepState: List<Pair<Long, Int>>,
         useSleepStagerV2: Boolean,
+        sleepHRBaseline: Double?,
         traceSink: ((String) -> Unit)?,
     ): List<DetectedSleep> {
         val grav = gravity.sortedBy { it.ts }
@@ -951,7 +1075,7 @@ object SleepStager {
                     SleepStagerTrace.Verdict.DROPPED, "maxMainSleepSpanS", "spanMin=$spanMin maxMainSleepSpanMin=${maxMainSleepSpanS / 60}"))
                 continue
             }
-            if (!confirmSleepWithHR(p, hrS, baseline)) {
+            if (!confirmSleepWithHR(p, hrS, baseline, grav = grav, sleepHRBaseline = sleepHRBaseline)) {
                 traceSink?.invoke(SleepStagerTrace.runLine(runIndex, p.start, p.end,
                     SleepStagerTrace.Verdict.DROPPED, "hrConfirm", "hrSleepBaselineMult=$hrSleepBaselineMult baseline=${baseline?.toInt() ?: -1}"))
                 continue

--- a/android/app/src/main/java/com/noop/analytics/SleepStagerV2.kt
+++ b/android/app/src/main/java/com/noop/analytics/SleepStagerV2.kt
@@ -175,6 +175,22 @@ object SleepStagerV2 {
     private const val jerkFloorGateMult = 55.0  // wake-boost when an epoch's peak jerk exceeds floor × this
     private const val motionGateBoost = 2.0
 
+    /**
+     * Motion-corroborated wake (elevated-but-flat-HR nights, #462). An epoch is MOTION-QUIESCENT when it shows
+     * no observed movement (`moveFrac == 0`) AND its peak per-second jerk sits at/below the night's own
+     * quiescent floor × [jerkFloorGateMult] — i.e. the wrist did not move this epoch, on the same
+     * night-relative scale the wake jerk-gate uses. On such epochs the AWAKE emission keeps any wake-SUPPRESSING
+     * cardiac evidence (a low, flat HR) but discards the wake-PROMOTING half: a raised HR / HR-variability with
+     * the wrist motionless is a supplement / fever / hot-room / alcohol artefact, not wakefulness, and must not
+     * vote the epoch awake on its own. Never invents wake and never removes pro-sleep cardiac evidence, so a
+     * genuinely still low-HR sleep epoch is byte-identical; only a still epoch whose ELEVATED HR was about to
+     * push it awake is held. Motion (`zmvv`) and the jerk gate — which by construction cannot fire on a
+     * quiescent epoch (`jerkMax ≤ floor × gateMult`) — still drive wake on any epoch that actually moved.
+     * Internal so the predicate test can call it, matching the Swift `motionQuiescent` visibility.
+     */
+    internal fun motionQuiescent(f: Epoch): Boolean =
+        f.moveFrac <= 0.0 && f.jerkMax <= f.jerkScale * jerkFloorGateMult
+
     /** Weight of the RSA respiration-regularity term (regular → deep, irregular → REM). */
     private const val respWeight = 0.6
 
@@ -187,8 +203,9 @@ object SleepStagerV2 {
         "awake" to mapOf("deep" to 0.01, "rem" to 0.02, "light" to 0.27, "awake" to 0.70))
 
     /** One 30 s epoch's recipe features. Nullable means "no measurement"; the z-score / percentile treat a
-     *  missing value as the neutral centre so a sparse channel never blocks a stage. */
-    private data class Epoch(
+     *  missing value as the neutral centre so a sparse channel never blocks a stage. Internal (not private) so
+     *  the motion-corroborated-wake predicate test can construct one, matching the Swift `Epoch` visibility. */
+    internal data class Epoch(
         val start: Long,        // epoch start (unix seconds, multiple of 30)
         val hr: Double?,        // epoch-mean HR (bpm)
         val hrVar: Double?,     // std of per-second HR over a centred 5-min window
@@ -470,11 +487,18 @@ object SleepStagerV2 {
         for (f in feats) {
             val zhrv = zhr(f.hr); val zhvv = zhv(f.hrVar); val zmvv = zmv(f.moveFrac)
             val gate = deepGateSlope * maxOf(0.0, fpct(f.hrFlat11) - deepGateThresh)
+            // Cardiac contribution to the AWAKE emission. On a motion-quiescent epoch the wrist did not move,
+            // so a raised HR / HR-variability alone must NOT promote wake — clamp the cardiac term to ≤ 0,
+            // keeping only its wake-SUPPRESSING (pro-sleep) half. Non-quiescent epochs are unchanged and use
+            // the same cardiac coefficients verbatim, so a night with any motion stages byte-identical; the
+            // correction only ever holds a still, elevated-HR epoch. Mirrors Swift `awakeCardiac`.
+            val awakeCardiac0 = 0.8 * zhvv + 0.4 * zhrv
+            val awakeCardiac = if (motionQuiescent(f)) minOf(0.0, awakeCardiac0) else awakeCardiac0
             val em = HashMap<String, Double>()
             em["deep"] = -1.1 * zhvv - 0.5 * zmvv - gate + baseLogPrior["deep"]!!
             em["rem"] = 0.6 * zhvv - 0.6 * zmvv + 0.4 * zhrv + baseLogPrior["rem"]!!
             em["light"] = baseLogPrior["light"]!!
-            em["awake"] = 1.0 * zmvv + 0.8 * zhvv + 0.4 * zhrv + baseLogPrior["awake"]!!
+            em["awake"] = 1.0 * zmvv + awakeCardiac + baseLogPrior["awake"]!!
             val pr = cyclePrior(f.clock)
             for (s in stageNames) em[s] = em[s]!! + pr[s]!!
             if (f.jerkMax > f.jerkScale * jerkFloorGateMult) em["awake"] = em["awake"]!! + motionGateBoost

--- a/android/app/src/test/java/com/noop/analytics/MotionCorroboratedWakeTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/MotionCorroboratedWakeTest.kt
@@ -1,0 +1,228 @@
+package com.noop.analytics
+
+import com.noop.data.GravitySample
+import com.noop.data.HrSample
+import com.noop.data.RrInterval
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import kotlin.math.PI
+import kotlin.math.cos
+import kotlin.math.sin
+import kotlin.math.roundToInt
+
+/**
+ * Motion-corroborated wake (elevated-but-flat-HR nights, #462). Android twin of the Swift
+ * `MotionCorroboratedWakeTests`. Both stagers and the HR-led session confirmation call "wake" primarily off
+ * HR / HR-variability; on a night whose resting HR is held elevated WITHOUT the wearer getting up (a
+ * supplement protocol, a fever, a hot room, alcohol) that logic misreads hot-but-motionless sleep as wake.
+ * These fixtures replicate the two confirmed mis-scored nights and pin the rule: elevated-HR ALONE cannot
+ * call wake when the wrist is at the night's quiescent motion floor with unchanged posture, while genuine
+ * out-of-bed motion still breaks sleep.
+ */
+class MotionCorroboratedWakeTest {
+
+    private val dev = "test"
+
+    // ── fixtures ───────────────────────────────────────────────────────────────────────────────────────
+
+    /** A perfectly still gravity stream (fixed orientation) at 1 Hz — the quiescent sleep floor. */
+    private fun stillGravity(start: Long, durationS: Int, x: Double = 0.0, y: Double = 0.0, z: Double = 1.0):
+        List<GravitySample> =
+        (0 until durationS).map { GravitySample(deviceId = dev, ts = start + it, x = x, y = y, z = z) }
+
+    /** Still gravity with brief single-minute TURN-OVER bursts every [everyMin] minutes (a posture flip that
+     *  lasts a few seconds) — a sleeping body, not an awakening. Between bursts posture is fixed. */
+    private fun stillWithTurnovers(start: Long, durationS: Int, everyMin: Int): List<GravitySample> =
+        (0 until durationS).map { i ->
+            val minute = i / 60
+            val isBurstMinute = minute % everyMin == 0 && minute > 0
+            val inBurst = isBurstMinute && (i % 60) < 4   // ~4 s of turn-over inside the burst minute
+            if (inBurst) GravitySample(deviceId = dev, ts = start + i, x = 0.35, y = 0.30, z = 0.87)
+            else GravitySample(deviceId = dev, ts = start + i, x = 0.0, y = 0.0, z = 1.0)
+        }
+
+    /** A sustained WALKING gravity stream — every second a different orientation with a large step-cadence
+     *  jerk (out of bed, pacing). Breaks sleep at both the detection and stage level. */
+    private fun walkingGravity(start: Long, durationS: Int): List<GravitySample> =
+        (0 until durationS).map { i ->
+            val ph = (i % 4).toDouble()
+            GravitySample(deviceId = dev, ts = start + i, x = 0.5 * sin(ph), y = 0.5 * cos(ph), z = 0.7)
+        }
+
+    /** Elevated-but-FLAT HR at 1 Hz (supplement era: resting HR held ~[base], natural would be ~48). */
+    private fun elevatedFlatHR(start: Long, durationS: Int, base: Int): List<HrSample> =
+        (0 until durationS).map { HrSample(deviceId = dev, ts = start + it, bpm = base + (it / 90) % 3) }
+
+    /** A regular R-R stream (~[meanMs] ms beats with a small respiratory oscillation). */
+    private fun regularRR(start: Long, durationS: Int, meanMs: Int = 1000): List<RrInterval> =
+        (0 until durationS).map { i ->
+            val rsa = (40.0 * sin(2.0 * PI * i / 4.0)).roundToInt()
+            RrInterval(deviceId = dev, ts = start + i, rrMs = meanMs + rsa)
+        }
+
+    private fun wakeMinutes(segs: List<StageSegment>): Double =
+        segs.filter { it.stage == "wake" }.sumOf { (it.end - it.start).toDouble() } / 60.0
+
+    // ── V2 stage level: the primary default-path fix ─────────────────────────────────────────────────────
+
+    /** The 7/13 pattern: a ~6 h warm-flat-HR still night (turn-over bursts on a ~90-min rhythm, no walking)
+     *  must NOT be carpeted in WAKE. */
+    @Test
+    fun warmFlatHRStillNightScoresAsleepNotWakeV2() {
+        val start = 1_749_517_200L
+        val dur = 6 * 60 * 60
+        val segs = SleepStagerV2.stageSession(
+            start = start, end = start + dur,
+            grav = stillWithTurnovers(start, dur, everyMin = 90),
+            hr = elevatedFlatHR(start, dur, base = 58),
+            rr = regularRR(start, dur, meanMs = 1030),
+            resp = emptyList())
+        assertTrue(
+            "a warm-but-still night must score mostly asleep, not WAKE (got ${wakeMinutes(segs)} min)",
+            wakeMinutes(segs) < 60.0,
+        )
+    }
+
+    /** The still low-HR baseline case must be byte-identical to before the fix (the change only ever removes
+     *  wake-PROMOTING cardiac evidence on quiescent epochs; a low, flat HR contributes none). */
+    @Test
+    fun stillLowHRNightUnchangedByCorrectionV2() {
+        val start = 1_749_517_200L
+        val dur = 3 * 60 * 60
+        val segs = SleepStagerV2.stageSession(
+            start = start, end = start + dur,
+            grav = stillGravity(start, dur),
+            hr = elevatedFlatHR(start, dur, base = 48),   // natural resting
+            rr = regularRR(start, dur),
+            resp = emptyList())
+        assertTrue("a still low-HR night should be essentially all sleep", wakeMinutes(segs) < 15.0)
+    }
+
+    /** Genuine out-of-bed WALKING within an otherwise-still night must still be scored WAKE by V2 — the
+     *  correction must not swallow a real awakening. */
+    @Test
+    fun walkingGapWithinStillNightScoresWakeV2() {
+        val start = 1_749_517_200L
+        val dur = 5 * 60 * 60
+        val walkStart = 2 * 60 * 60          // a 30-min out-of-bed block two hours in
+        val walkEnd = walkStart + 30 * 60
+        val grav = (0 until dur).map { i ->
+            if (i in walkStart until walkEnd) {
+                val ph = (i % 4).toDouble()
+                GravitySample(deviceId = dev, ts = start + i, x = 0.5 * sin(ph), y = 0.5 * cos(ph), z = 0.7)
+            } else {
+                GravitySample(deviceId = dev, ts = start + i, x = 0.0, y = 0.0, z = 1.0)
+            }
+        }
+        // Elevated during the walk (out of bed), flat-elevated otherwise (supplement).
+        val hr = (0 until dur).map { i ->
+            HrSample(deviceId = dev, ts = start + i, bpm = if (i in walkStart until walkEnd) 92 else 58)
+        }
+        val segs = SleepStagerV2.stageSession(
+            start = start, end = start + dur, grav = grav,
+            hr = hr, rr = regularRR(start, dur, meanMs = 1030), resp = emptyList())
+        val walkWake = segs.filter {
+            it.stage == "wake" && it.end > start + walkStart && it.start < start + walkEnd
+        }.sumOf {
+            (minOf(it.end, start + walkEnd) - maxOf(it.start, start + walkStart)).toDouble()
+        } / 60.0
+        assertTrue("the walking block must remain WAKE (got $walkWake min of 30)", walkWake > 15.0)
+        assertTrue(
+            "the still remainder must not be scored WAKE despite elevated HR",
+            wakeMinutes(segs) < 60.0,
+        )
+    }
+
+    // ── the motion-quiescent predicate ───────────────────────────────────────────────────────────────────
+
+    @Test
+    fun motionQuiescentPredicate() {
+        val still = SleepStagerV2.Epoch(
+            start = 0, hr = 58.0, hrVar = 1.0, hrFlat11 = 1.0, moveFrac = 0.0, jerkMax = 0.001,
+            respReg = null, clock = 0.5, jerkScale = 0.001)
+        assertTrue(SleepStagerV2.motionQuiescent(still))
+        val moved = SleepStagerV2.Epoch(
+            start = 0, hr = 58.0, hrVar = 1.0, hrFlat11 = 1.0, moveFrac = 0.3, jerkMax = 0.2,
+            respReg = null, clock = 0.5, jerkScale = 0.001)
+        assertFalse(SleepStagerV2.motionQuiescent(moved))
+    }
+
+    // ── detection level: confirmSleepWithHR motion corroboration ─────────────────────────────────────────
+
+    private fun period(start: Long, durS: Int) =
+        SleepStager.Period(stage = "sleep", start = start, end = start + durS)
+
+    /** A supplement night whose whole in-bed run is motionless but HR-elevated (median ~58 vs baseline 48,
+     *  above the strict ×1.05 = 50.4 bar) must NOT be rejected by the HR gate when gravity proves the wrist
+     *  was still — the widened quiescent band keeps it. Without gravity evidence the strict bar stands. */
+    @Test
+    fun motionlessElevatedRunConfirmedWithGravity() {
+        val start = 1_000_000L
+        val dur = 90 * 60
+        val p = period(start, dur)
+        val hr = elevatedFlatHR(start, dur, base = 58)
+        val stillGrav = stillGravity(start, dur)
+        assertTrue(
+            "a motionless but HR-elevated run must be confirmed as sleep when stillness is proven",
+            SleepStager.confirmSleepWithHR(p, hr, baseline = 48.0, grav = stillGrav),
+        )
+        assertFalse(
+            "with no motion evidence the strict HR band still rejects an elevated run",
+            SleepStager.confirmSleepWithHR(p, hr, baseline = 48.0),
+        )
+    }
+
+    /** The floor holds: a genuinely awake, motionless run whose median HR is far above the band (72 vs
+     *  baseline 48 → above even the widened ×1.30 = 62.4 bar) is STILL rejected even with stillness proven. */
+    @Test
+    fun genuinelyHighHRStillRunStillRejected() {
+        val start = 1_000_000L
+        val dur = 90 * 60
+        val p = period(start, dur)
+        val hr = elevatedFlatHR(start, dur, base = 72)
+        val stillGrav = stillGravity(start, dur)
+        assertFalse(
+            "a run whose HR is above even the widened quiescent band must still be rejected",
+            SleepStager.confirmSleepWithHR(p, hr, baseline = 48.0, grav = stillGrav),
+        )
+    }
+
+    @Test
+    fun runIsDeeplyQuiescent() {
+        val start = 1_000_000L
+        val dur = 60 * 60
+        val p = period(start, dur)
+        assertTrue(SleepStager.runIsDeeplyQuiescent(p, stillGravity(start, dur)))
+        assertTrue(
+            "occasional turn-overs still leave >90% of minutes posture-stable",
+            SleepStager.runIsDeeplyQuiescent(p, stillWithTurnovers(start, dur, everyMin = 90)),
+        )
+        assertFalse(
+            "a walking run is not posture-stable",
+            SleepStager.runIsDeeplyQuiescent(p, walkingGravity(start, dur)),
+        )
+        assertFalse(
+            "no gravity → stillness unprovable → not deeply quiescent",
+            SleepStager.runIsDeeplyQuiescent(p, emptyList()),
+        )
+    }
+
+    // ── adaptive overnight HR baseline (directive b) ─────────────────────────────────────────────────────
+
+    @Test
+    fun adaptiveOvernightHRBaseline() {
+        // Self-calibrates to recent overnight medians (a supplement era's ~58 vs a fixed day-median).
+        val era = SleepStager.adaptiveOvernightHRBaseline(listOf(56.0, 58.0, 60.0, 57.0, 59.0))
+        assertNotNull(era)
+        assertEquals(58.0, era!!, 1e-9)
+        // Floor holds so a wakeful era can't collapse the band.
+        val floored = SleepStager.adaptiveOvernightHRBaseline(listOf(30.0, 32.0, 31.0))
+        assertNotNull(floored)
+        assertEquals(SleepStager.adaptiveBaselineFloor, floored!!, 1e-9)
+        // No history → null (caller keeps the day-median).
+        assertEquals(null, SleepStager.adaptiveOvernightHRBaseline(emptyList()))
+    }
+}

--- a/docs/ANALYTICS.md
+++ b/docs/ANALYTICS.md
@@ -309,6 +309,18 @@ Consecutive same-stage epochs are merged into `StageSegment`s tiling `[start, en
 - `SleepSession` — `start`, `end`, `efficiency` (AASM `asleep / in-bed`, where `asleep = in-bed − wake`), `stages`, per-session `restingHR` (lowest 5-min rolling-mean HR) and `avgHRV` (mean RMSSD over 5-min tumbling windows).
 - `hypnogramMetrics(_:)` — AASM-style roll-up: TIB / TST / SPT / SOL / REM latency / WASO / efficiency / disturbances, plus deep/REM/light minutes and percentages.
 
+### Motion-corroborated wake — elevated-but-motionless HR is not wake (default ON)
+
+Both stagers (`SleepStager` V1 and the default `SleepStagerV2`) and the HR-led session confirmation (`confirmSleepWithHR`) previously called **wake** primarily off HR / HR-variability with no motion or posture cross-check. On a night whose resting HR is held elevated **without the wearer getting up** — a supplement protocol, a fever, a hot room, alcohol — that logic scored hot-but-motionless sleep as wake, over-calling WASO, mis-placing onset, and tanking efficiency and Rest. Two confirmed nights required manual relabeling (2026-07-13: 194 min WAKE vs ~67; 2026-07-14: onset 1:41 vs ~1:29 plus a 44-min WAKE block).
+
+The rule: **elevated HR alone is insufficient to call wake.** An epoch or run at the night's quiescent **motion** floor with **unchanged posture** cannot be scored WAKE on cardiac evidence alone; corroboration comes from the **gravity posture/jerk** signal both stagers already consume (always present), not step ticks. This acts where the mis-scoring is produced, and is **on by default** — distinct from the prior default-OFF post-pass over an already-staged hypnogram (upstream #402).
+
+- **`SleepStagerV2` (default).** On a motion-quiescent epoch (no observed movement; peak jerk at/below the night-relative wake-gate floor) the AWAKE cardiac term is clamped to **≤ 0** — wake-*suppressing* (low, flat HR) evidence is kept, the wake-*promoting* half is dropped. A still low-HR epoch is byte-identical; genuine motion and the night-relative jerk gate still drive wake.
+- **`confirmSleepWithHR` (V1 detection).** When a run is deeply motion-quiescent (≥ ~90% of its dense-gravity minutes posture-stable), the HR sleep band widens from **×1.05 → ×1.30** so a supplement-elevated but motionless run is not rejected. The band keeps a **floor** (genuine all-night in-bed wakefulness is still dropped); with no gravity evidence the strict ×1.05 band stands.
+- **`adaptiveOvernightHRBaseline`.** A personalised sleep band derived from recent overnight medians (self-calibrating across a supplement/fitness era), with a floor. Threaded through `detectSleep` as an optional argument that defaults to `nil` (byte-identical when unset); live cross-night wiring in `IntelligenceEngine` is a follow-up.
+
+Source: `SleepStager.swift` (`confirmSleepWithHR`, `adaptiveOvernightHRBaseline`) and `SleepStagerV2.swift` (motion-quiescent clamp), both in `Packages/StrandAnalytics`. Filed upstream as [ryanbr/noop#462](https://github.com/ryanbr/noop/issues/462). The Kotlin analytics twin (`com.noop.analytics`) is a deliberate follow-up (Swift-only contributor) — the parity contract requires the two stagers to stay byte-identical once transcribed.
+
 ---
 
 ## The **Rest** score composite — *"how restorative was your sleep?"*


### PR DESCRIPTION
## Summary

Both stagers (`SleepStager` V1 and the default `SleepStagerV2`) and the HR-led session confirmation (`confirmSleepWithHR`) called **WAKE** primarily off HR / HR-variability with **no motion or posture cross-check**. On a night whose resting HR is held elevated **without the wearer getting up** — a supplement protocol, a fever, a hot room, alcohol — that logic scores hot-but-motionless sleep as wake: it over-calls WASO, mis-places onset, and tanks efficiency and Rest.

**The rule:** elevated HR **alone** is insufficient to call wake. An epoch or run at the night's quiescent **motion** floor with **unchanged posture** cannot be scored WAKE on cardiac evidence alone. Corroboration comes from the **gravity posture/jerk** signal both stagers already consume (always present) — not step ticks.

## The two evidence nights

Two confirmed real nights motivated the fix; details are in **#462** rather than duplicated here (2026-07-13: 194 min WAKE vs ~67; 2026-07-14: onset 1:41 vs ~1:29 plus a 44-min WAKE block).

## Why #402 didn't cover it

Upstream #402 is a **default-OFF** post-pass over an **already-staged** hypnogram, **gated on step density**. This change instead acts **where the mis-scoring is produced** — the stager emission and the HR-led session confirmation — is **on by default**, and reads the **gravity posture/jerk** signal rather than step ticks, so it applies to WHOOP nights that carry no step stream.

## What changed, per layer

- **`SleepStagerV2` (default) — `motionQuiescent` + awake cardiac clamp.** On a motion-quiescent epoch (no observed movement; peak jerk at/below the night-relative wake-gate floor) the AWAKE cardiac term is clamped to **≤ 0** — the wake-*suppressing* (low, flat HR) half is kept, the wake-*promoting* half dropped. The clamp is applied **over upstream's restored (post-#437) `0.8·zhvv + 0.4·zhrv` coefficients**, so any epoch that actually moved stages **byte-identically**; only a still, elevated-HR epoch is held.
- **`confirmSleepWithHR` (V1 detection) — motion corroboration.** When a run is **deeply motion-quiescent** (≥ ~90% of its dense-gravity minutes posture-stable, over ≥ 20 such minutes via `runIsDeeplyQuiescent` / `posturVarianceG2`), the HR sleep band widens **×1.05 → ×1.30**. The band keeps a **floor** (genuine all-night in-bed wakefulness is still dropped); with no gravity evidence the strict band stands. Both helpers are pure and deterministic.
- **`adaptiveOvernightHRBaseline` + `sleepHRBaseline` threading.** An optional personalised overnight band (median of recent overnight medians, floored) threaded through `detectSleep` as an argument **defaulting to `nil`** (byte-identical when unset). Live cross-night wiring in `IntelligenceEngine` is a deliberate follow-up.

## Verification

`swift test` in `Packages/StrandAnalytics` is green — **1077 tests, 0 failures**, including **8 new `MotionCorroboratedWakeTests`** and every `SleepStager` / `SleepStagerV2` / `WakeMotionRefinement` golden suite (the byte-identical default path — empty gravity, `nil` baseline — is preserved).

## Cross-platform / Kotlin twin

**Kotlin twin included + gradle-tested.** The `com.noop.analytics` stagers carry the same policy transcribed byte-identically: `SleepStager.confirmSleepWithHR` gains `grav` + `sleepHRBaseline` corroboration with `runIsDeeplyQuiescent` / `posturVarianceG2` / `adaptiveOvernightHRBaseline` (and the `x1.30` / floor / 90% / 20-min / 40 bpm constants), `sleepHRBaseline` threaded through `detectSleep` and folded into the memo key; `SleepStagerV2.motionQuiescent` clamps the awake cardiac term `≤ 0` on quiescent epochs over the same coefficients. `MotionCorroboratedWakeTest` mirrors the 8 Swift fixtures. `./gradlew :app:testFullDebugUnitTest --tests "com.noop.analytics.SleepStager*" --tests "com.noop.analytics.MotionCorroboratedWakeTest"` → **85 tests, 0 failures**, with the detect-memo fingerprint parity golden and the V2 staging golden intact (the byte-identical default path — empty gravity, `nil` baseline — is preserved by construction).
