### PR TITLE
fix(sleep): Sleep-tab bedtime no longer skips a real first-sleep fragment (floor + format-agnostic asleep decode)

### DIFF
--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/BridgedNightGroupsTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/BridgedNightGroupsTests.swift
@@ -100,4 +100,25 @@ final class BridgedNightGroupsTests: XCTestCase {
         let nap = B(start: t0 + 14 * 3_600, end: t0 + 15 * 3_600)
         XCTAssertEqual(SleepStageTotals.mainNightGroupIndices([a, b, nap], offsetSec: 0), [0, 1])
     }
+
+    /// REAL NIGHT (2026-07-14, PDT): a 12:16 first-sleep fragment (67 min) then a ~6-min walk then the
+    /// main 1:29 → 7:32 sleep, stored as two rows on `my-whoop-noop` with the main's onset user-edited
+    /// later via `startTsAdjusted` (so its EFFECTIVE start is 1:29). The 6-min effective gap is far under
+    /// `gapBridgeMaxMin`, so the two fragments MUST bridge into ONE group — proving the fragment is NOT
+    /// filtered out of grouping. The bug lives downstream (the display onset walk), not here: the group
+    /// spans the whole night, exactly as the Health write-back folds it (#364). offsetSec = -25200 (PDT).
+    func testRealNightFirstSleepFragmentBridgesIntoMainGroup() {
+        let off = -25_200
+        let fragment = B(start: 1_784_013_364, end: 1_784_017_375)      // 12:16 → 1:22 (67 min)
+        let mainEffective = B(start: 1_784_017_740, end: 1_784_039_558) // 1:29 (edited onset) → 7:32
+        let groups = SleepStageTotals.bridgedNightGroups([fragment, mainEffective], offsetSec: off)
+        XCTAssertEqual(groups.map(\.indices), [[0, 1]], "the 6-min walk must bridge, not split the night")
+        XCTAssertEqual(groups[0].gaps, [Gap(start: fragment.end, end: mainEffective.start)])
+        // The whole bridged group is the main night, and its span opens at the 12:16 fragment.
+        XCTAssertEqual(SleepStageTotals.mainNightGroupIndices([fragment, mainEffective], offsetSec: off),
+                       [0, 1])
+        let span = groups[0].indices
+        XCTAssertEqual([fragment, mainEffective][span[0]].start, 1_784_013_364,
+                       "earliest onset of the bridged night is the 12:16 first-sleep fragment")
+    }
 }

--- a/Strand/Screens/SleepView.swift
+++ b/Strand/Screens/SleepView.swift
@@ -1954,15 +1954,29 @@ struct SleepView: View {
     /// a lead carrying a few minutes more than 3. Mirrors Android PRE_ONSET_STUB_MINOR_FRAC. (#259)
     static let preOnsetStubMinorFrac: Double = 0.15
 
+    /// Absolute floor (ASLEEP minutes) under the #259 relative "minor lead" test: a leading fragment that
+    /// carries at least this much real sleep is a genuine first sleep — a real sleep episode — and is NEVER
+    /// a spurious pre-onset lead, however large the main block is. Without it a long main sleep inflates the
+    /// 15% relative bar (a 6h night → ~54 min) so a genuine ~34-min first sleep was swallowed and the shown
+    /// bedtime jumped hours late, hiding the real onset the bridged night (and the Health write-back, #364)
+    /// already spans. 20 min ≈ the shortest standalone sleep episode; below it a handful of asleep minutes
+    /// beside a long night is a stray lead. Mirrors Android PRE_ONSET_STUB_MINOR_ASLEEP_FLOOR_MIN.
+    /// (bridged-night headline: a real 2026-07-14 12:16 first sleep hidden behind the 1:29 main block)
+    static let preOnsetStubMinorAsleepFloorMin: Double = 20
+
     /// Pure stub test on a fragment's span + asleep minutes, so the rule is unit-testable without decoding
     /// JSON or building a view. Spurious when BRIEF and EITHER essentially sleepless OR minor relative to the
     /// main block (`refAsleepMin`, the group's largest asleep span): asleep below `preOnsetStubMinorFrac` of
-    /// it. `refAsleepMin` defaults to 0 (relative test off) so existing callers/tests are byte-identical.
-    /// (#736 / #259)
+    /// it AND below the absolute `preOnsetStubMinorAsleepFloorMin` real-sleep-episode floor. `refAsleepMin`
+    /// defaults to 0 (relative test off) so existing callers/tests are byte-identical. (#736 / #259)
     static func isPreOnsetAwakeStub(spanMin: Double, asleepMin: Double, refAsleepMin: Double = 0) -> Bool {
         guard spanMin <= preOnsetStubMaxMin else { return false }
         if asleepMin <= preOnsetStubAsleepMaxMin { return true }
-        return refAsleepMin > 0 && asleepMin < preOnsetStubMinorFrac * refAsleepMin
+        // #259 relative "minor lead" test, floored: a real sleep episode (>= the floor) is never a stray
+        // lead, so a long main block can't inflate the 15% bar past a genuine short first sleep.
+        return refAsleepMin > 0
+            && asleepMin < preOnsetStubMinorFrac * refAsleepMin
+            && asleepMin < preOnsetStubMinorAsleepFloorMin
     }
 
     /// The index into an ascending-by-onset group whose fragment supplies the DISPLAYED bedtime: the first

--- a/Strand/Screens/SleepView.swift
+++ b/Strand/Screens/SleepView.swift
@@ -1919,7 +1919,9 @@ struct SleepView: View {
         // #259: reference size for the "minor relative to the main block" test = the group's largest asleep
         // span (≈ the main block). A genuine biphasic first sleep is comparable and is kept; a small stray
         // lead is skipped, so the onset no longer jumps hours early.
-        let refAsleepMin = group.map { decodeStages($0.stagesJSON)?.asleep ?? 0 }.max() ?? 0
+        let refAsleepMin = group.map {
+            SleepView.decodedAsleepMinutes($0.stagesJSON, effectiveStartTs: $0.effectiveStartTs)
+        }.max() ?? 0
         // Walk past any leading spurious pre-onset awake stubs to the first real-sleep fragment.
         for frag in group {
             if !isPreOnsetAwakeStub(frag, refAsleepMin: refAsleepMin) { return frag.effectiveStartTs }
@@ -1934,7 +1936,8 @@ struct SleepView: View {
     /// a stub when it leads the main-night group, so the displayed bedtime tracks where real sleep began. (#736)
     private func isPreOnsetAwakeStub(_ frag: CachedSleepSession, refAsleepMin: Double = 0) -> Bool {
         let spanMin = Double(frag.endTs - frag.effectiveStartTs) / 60.0
-        let asleepMin = decodeStages(frag.stagesJSON)?.asleep ?? 0
+        let asleepMin = SleepView.decodedAsleepMinutes(frag.stagesJSON,
+                                                       effectiveStartTs: frag.effectiveStartTs)
         return SleepView.isPreOnsetAwakeStub(spanMin: spanMin, asleepMin: asleepMin, refAsleepMin: refAsleepMin)
     }
 
@@ -2011,7 +2014,7 @@ struct SleepView: View {
         // contributes nothing; if NO fragment has one, `motionEpochs` stays empty → honest empty state.
         var motion: [Double] = []
         for frag in group {
-            if let seg = decodeSegments(frag.stagesJSON, sessionStart: frag.effectiveStartTs), seg.stages.total > 0 {
+            if let seg = Self.decodeSegments(frag.stagesJSON, sessionStart: frag.effectiveStartTs), seg.stages.total > 0 {
                 stages.awake += seg.stages.awake; stages.light += seg.stages.light
                 stages.deep  += seg.stages.deep;  stages.rem   += seg.stages.rem
                 // decodeSegments yields intervals relative to THAT fragment's onset; rebase them to
@@ -2023,7 +2026,7 @@ struct SleepView: View {
                 for iv in seg.intervals {
                     segs.append(SleepInterval(stage: iv.stage, start: iv.start + shift, end: iv.end + shift))
                 }
-            } else if let st = decodeStages(frag.stagesJSON), st.total > 0 {
+            } else if let st = Self.decodeStages(frag.stagesJSON), st.total > 0 {
                 stages.awake += st.awake; stages.light += st.light
                 stages.deep  += st.deep;  stages.rem   += st.rem
             }
@@ -2437,8 +2440,27 @@ struct SleepView: View {
 
     // MARK: - Stage decoding
 
+    /// Asleep minutes decoded from a stored `stagesJSON` in EITHER of the two formats that exist in the
+    /// DB: on-device COMPUTED nights store a SEGMENT ARRAY `[{"start":epoch,"end":epoch,"stage":…}]`
+    /// (`AnalyticsEngine.encodeStages`); imported nights store a dict of MINUTES
+    /// `{"light","deep","rem","awake"}`. The displayed-onset stub test (`nightOnsetTs` /
+    /// `isPreOnsetAwakeStub`) MUST read asleep minutes format-agnostically: it previously used the
+    /// dict-only `decodeStages`, which returns nil for a computed night's segment array, so every
+    /// fragment of an on-device night read as 0 asleep minutes — a real ~54-min first sleep tripped the
+    /// "essentially sleepless stub" branch and the shown bedtime jumped from the true 12:16 onset to the
+    /// 1:29 main block, bypassing the #259 real-sleep-episode floor entirely (the 2026-07-14 night).
+    /// `effectiveStartTs` threads the fragment's effective onset into the segment decode's #259
+    /// pre-onset trim. Internal (not private) so the golden test pins the DECODE PATH itself, not a
+    /// pre-computed minute count. Android twin: SleepScreen's onset stub-test caller needs the same
+    /// both-format decode.
+    static func decodedAsleepMinutes(_ json: String?, effectiveStartTs: Int) -> Double {
+        decodeStages(json)?.asleep
+            ?? decodeSegments(json, sessionStart: effectiveStartTs)?.stages.asleep
+            ?? 0
+    }
+
     /// Decode the imported stagesJSON dict of MINUTES {"light","deep","rem","awake"}.
-    private func decodeStages(_ json: String?) -> Stages? {
+    private static func decodeStages(_ json: String?) -> Stages? {
         guard let json, let data = json.data(using: .utf8) else { return nil }
         guard let obj = try? JSONSerialization.jsonObject(with: data),
               let dict = obj as? [String: Any] else { return nil }
@@ -2456,7 +2478,7 @@ struct SleepView: View {
     /// Decode the COMPUTED stagesJSON segment array [{"start":epoch,"end":epoch,"stage":"wake"|
     /// "light"|"deep"|"rem"}] into stage totals plus the real timeline (seconds relative to the
     /// session start, the Hypnogram's domain). The on-device SleepStager calls awake "wake". (#77)
-    private func decodeSegments(
+    private static func decodeSegments(
         _ json: String?, sessionStart: Int
     ) -> (stages: Stages, intervals: [SleepInterval])? {
         guard let json, let data = json.data(using: .utf8),

--- a/StrandTests/SleepOnsetDecodeTests.swift
+++ b/StrandTests/SleepOnsetDecodeTests.swift
@@ -1,0 +1,91 @@
+import XCTest
+@testable import Strand
+
+/// The 2026-07-14 "shown bedtime 1:29 instead of 12:16" regression, pinned at the DECODE PATH.
+///
+/// TWO stagesJSON formats exist in the sleepSession table: imported nights store a dict of MINUTES
+/// `{"light","deep","rem","awake"}`; on-device COMPUTED nights store a SEGMENT ARRAY
+/// `[{"start":epoch,"end":epoch,"stage":…}]` (`AnalyticsEngine.encodeStages`). The displayed-onset
+/// stub test (`nightOnsetTs` / `isPreOnsetAwakeStub`) read asleep minutes via the dict-only
+/// `decodeStages`, which returns nil for the array format — so every fragment of an on-device night
+/// counted as 0 asleep minutes, the real ~54-min first sleep (12:16 → 1:22) tripped the "essentially
+/// sleepless stub" branch (0 <= 3), and the shown bedtime jumped to the 1:29 main block. The #259
+/// real-sleep-episode floor (`preOnsetStubMinorAsleepFloorMin`) — added for this exact night — never
+/// engaged because its input was zeroed before the comparison. `SleepOnsetStubTests` pins the rule on
+/// PRE-COMPUTED minutes; these tests pin `SleepView.decodedAsleepMinutes`, the format-agnostic seam
+/// the onset walk now reads, using the night's REAL stored JSON.
+///
+/// Android twin: SleepScreen's onset stub-test caller needs the same both-format decode.
+final class SleepOnsetDecodeTests: XCTestCase {
+
+    /// The REAL 12:16 → 1:22 first-sleep fragment (deviceId my-whoop-noop, startTs 1784013364),
+    /// byte-for-byte as stored on the device: an on-device computed night's SEGMENT ARRAY.
+    /// Non-wake sum: light 926 s + deep 1320 s + rem 990 s = 3236 s ≈ 53.9 asleep minutes.
+    private static let fragmentStagesJSON = """
+        [{"end":1784013450,"stage":"light","start":1784013364},{"end":1784013540,"stage":"wake","start":1784013450},{"end":1784013600,"stage":"light","start":1784013540},{"end":1784013720,"stage":"wake","start":1784013600},{"end":1784013930,"stage":"light","start":1784013720},{"end":1784015250,"stage":"deep","start":1784013930},{"end":1784015580,"stage":"light","start":1784015250},{"end":1784015640,"stage":"wake","start":1784015580},{"end":1784015880,"stage":"light","start":1784015640},{"end":1784016180,"stage":"wake","start":1784015880},{"end":1784017170,"stage":"rem","start":1784016180},{"end":1784017375,"stage":"wake","start":1784017170}]
+        """
+    private static let fragmentEffectiveStartTs = 1_784_013_364
+    private static let fragmentEndTs = 1_784_017_375
+
+    /// The REAL 1:29 → 7:32 main block (startTs 1784018465, hand-edited onset startTsAdjusted
+    /// 1784017740), same night, same stored format. Non-wake sum ≈ 277.6 asleep minutes.
+    private static let mainStagesJSON = """
+        [{"end":1784018820,"start":1784017740,"stage":"light"},{"end":1784018940,"start":1784018820,"stage":"wake"},{"start":1784018940,"end":1784020140,"stage":"light"},{"end":1784021220,"start":1784020140,"stage":"wake"},{"stage":"light","start":1784021220,"end":1784021670},{"end":1784021910,"start":1784021670,"stage":"wake"},{"stage":"light","end":1784022150,"start":1784021910},{"start":1784022150,"stage":"deep","end":1784023260},{"start":1784023260,"end":1784023380,"stage":"light"},{"start":1784023380,"stage":"wake","end":1784023890},{"stage":"light","start":1784023890,"end":1784024250},{"stage":"wake","end":1784024520,"start":1784024250},{"end":1784024910,"stage":"light","start":1784024520},{"start":1784024910,"end":1784025120,"stage":"deep"},{"end":1784025330,"start":1784025120,"stage":"light"},{"start":1784025330,"end":1784025450,"stage":"rem"},{"start":1784025450,"end":1784025780,"stage":"wake"},{"stage":"light","start":1784025780,"end":1784026050},{"start":1784026050,"end":1784026710,"stage":"deep"},{"stage":"light","start":1784026710,"end":1784027040},{"end":1784027220,"stage":"wake","start":1784027040},{"stage":"light","start":1784027220,"end":1784027670},{"end":1784028510,"stage":"rem","start":1784027670},{"start":1784028510,"stage":"light","end":1784029080},{"stage":"wake","start":1784029080,"end":1784029620},{"end":1784029980,"stage":"light","start":1784029620},{"start":1784029980,"stage":"wake","end":1784030070},{"stage":"light","end":1784031600,"start":1784030070},{"end":1784031690,"stage":"wake","start":1784031600},{"start":1784031690,"stage":"light","end":1784032530},{"end":1784033400,"stage":"rem","start":1784032530},{"start":1784033400,"end":1784033940,"stage":"wake"},{"start":1784033940,"end":1784034300,"stage":"light"},{"stage":"wake","start":1784034300,"end":1784034330},{"end":1784035680,"stage":"light","start":1784034330},{"start":1784035680,"end":1784036100,"stage":"wake"},{"end":1784036160,"stage":"light","start":1784036100},{"start":1784036160,"end":1784037900,"stage":"rem"},{"end":1784038620,"stage":"wake","start":1784037900},{"start":1784038620,"end":1784038650,"stage":"light"},{"start":1784038650,"stage":"rem","end":1784039558}]
+        """
+    private static let mainEffectiveStartTs = 1_784_017_740
+    private static let mainEndTs = 1_784_039_558
+
+    // MARK: - decodedAsleepMinutes (the format-agnostic seam)
+
+    /// THE BUG: the segment-array format (an on-device computed night) must decode to its real asleep
+    /// minutes. Before the fix the dict-only decode returned nil here and the caller substituted 0 —
+    /// the zero that made a real 54-min first sleep read as a "sleepless" stub.
+    func testSegmentArrayFormatDecodesRealAsleepMinutes() {
+        let asleep = SleepView.decodedAsleepMinutes(Self.fragmentStagesJSON,
+                                                    effectiveStartTs: Self.fragmentEffectiveStartTs)
+        XCTAssertEqual(asleep, 3236.0 / 60.0, accuracy: 0.01)
+        // Above the #259 floor — the whole point: a real sleep episode must clear it.
+        XCTAssertGreaterThanOrEqual(asleep, SleepView.preOnsetStubMinorAsleepFloorMin)
+    }
+
+    /// The imported dict-of-minutes format still decodes (asleep = light + deep + rem, awake excluded).
+    func testDictFormatStillDecodes() {
+        let asleep = SleepView.decodedAsleepMinutes(#"{"light":200,"deep":80,"rem":60,"awake":30}"#,
+                                                    effectiveStartTs: 0)
+        XCTAssertEqual(asleep, 340, accuracy: 0.001)
+    }
+
+    /// nil / empty / garbage stay 0 — the degenerate inputs keep the old behaviour.
+    func testDegenerateInputsAreZero() {
+        XCTAssertEqual(SleepView.decodedAsleepMinutes(nil, effectiveStartTs: 0), 0)
+        XCTAssertEqual(SleepView.decodedAsleepMinutes("", effectiveStartTs: 0), 0)
+        XCTAssertEqual(SleepView.decodedAsleepMinutes("not json", effectiveStartTs: 0), 0)
+        XCTAssertEqual(SleepView.decodedAsleepMinutes("[]", effectiveStartTs: 0), 0)
+    }
+
+    /// The segment decode threads the #259 pre-onset trim: segments before `effectiveStartTs` don't
+    /// count, exactly as the hero's stage totals trim them.
+    func testSegmentDecodeTrimsPreOnset() {
+        // One 10-min light segment, but the effective onset sits 5 min into it.
+        let json = #"[{"start":1000,"end":1600,"stage":"light"}]"#
+        XCTAssertEqual(SleepView.decodedAsleepMinutes(json, effectiveStartTs: 1300), 5, accuracy: 0.001)
+    }
+
+    // MARK: - The golden: the real night's onset comes from the 12:16 fragment
+
+    /// END-TO-END through the decode path: both REAL blocks of the 2026-07-14 night, decoded from their
+    /// stored segment-array JSON (NOT pre-computed minutes), walk to onset index 0 — the 12:16 fragment.
+    /// Before the fix both decoded to 0 asleep, the fragment classified as a sleepless stub, and the
+    /// index was 1 (the 1:29 main block) — the "last night's sleep 1:29" VK saw on the Sleep tab hero.
+    func testRealNightOnsetIndexIsTheFirstSleepFragment() {
+        let frags: [(json: String, effStart: Int, end: Int)] = [
+            (Self.fragmentStagesJSON, Self.fragmentEffectiveStartTs, Self.fragmentEndTs),
+            (Self.mainStagesJSON, Self.mainEffectiveStartTs, Self.mainEndTs),
+        ]
+        let spansMin = frags.map { Double($0.end - $0.effStart) / 60.0 }
+        let asleepsMin = frags.map {
+            SleepView.decodedAsleepMinutes($0.json, effectiveStartTs: $0.effStart)
+        }
+        XCTAssertEqual(SleepView.nightOnsetIndex(spansMin: spansMin, asleepsMin: asleepsMin), 0)
+    }
+}

--- a/StrandTests/SleepOnsetStubTests.swift
+++ b/StrandTests/SleepOnsetStubTests.swift
@@ -102,4 +102,37 @@ final class SleepOnsetStubTests: XCTestCase {
     func testAllStubGroupFallsBackToZero() {
         XCTAssertEqual(SleepView.nightOnsetIndex(spansMin: [5, 10], asleepsMin: [0, 0]), 0)
     }
+
+    // MARK: - Real-night regression: a genuine short first sleep is NOT a spurious lead
+
+    /// THE BUG (real 2026-07-14 night): a 67-min first-sleep fragment (12:16 → 1:22, ~34 asleep min) then a
+    /// ~6-min walk then the main 1:29 → 7:32 sleep (~340 asleep). The two bridge into ONE night, and the
+    /// Health write-back spans 12:16 → 7:32. But the #259 relative "minor lead" test compared 34 asleep min
+    /// against 15% of the ~340-min main (≈51 min) and wrongly classified the real first sleep as a spurious
+    /// lead, so the displayed onset jumped to the 1:29 main and HID the true 12:16 bedtime. The absolute
+    /// asleep floor keeps a real sleep episode as the onset: index 0, the 12:16 fragment.
+    func testRealFirstSleepFragmentIsTheDisplayedOnset() {
+        // fragment: 66.8 span / 34 asleep. main: 363.6 span / 340 asleep.
+        XCTAssertEqual(SleepView.nightOnsetIndex(spansMin: [66.8, 363.6], asleepsMin: [34, 340]), 0)
+    }
+
+    /// The per-fragment rule: a real 34-min sleep episode beside a 340-min main is NOT a stub, even though
+    /// it is under 15% of the main (the old relative test's flaw for long nights). The floor is what keeps it.
+    func testRealFirstSleepFragmentIsNotStub() {
+        XCTAssertFalse(SleepView.isPreOnsetAwakeStub(spanMin: 66.8, asleepMin: 34, refAsleepMin: 340))
+    }
+
+    /// Floor boundary: a fragment carrying at least `preOnsetStubMinorAsleepFloorMin` asleep minutes is a
+    /// real sleep episode and never a spurious lead, whatever the main block's size.
+    func testAtMinorAsleepFloorIsNotStub() {
+        XCTAssertFalse(SleepView.isPreOnsetAwakeStub(spanMin: 40,
+                                                     asleepMin: SleepView.preOnsetStubMinorAsleepFloorMin,
+                                                     refAsleepMin: 1000))
+    }
+
+    /// The floor does NOT reopen #736/#259: a tiny stray sleep lead (10 asleep, under the floor AND under
+    /// 15% of a big main) is still a spurious lead, so those goldens above stay green.
+    func testTinyStrayLeadStillStubUnderFloor() {
+        XCTAssertTrue(SleepView.isPreOnsetAwakeStub(spanMin: 30, asleepMin: 10, refAsleepMin: 400))
+    }
 }

--- a/android/app/src/main/java/com/noop/ui/SleepScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/SleepScreen.kt
@@ -2849,7 +2849,7 @@ internal fun selectNight(
     // the group (≈ the main block). A genuine biphasic first sleep is comparable to it and is kept; only a
     // small stray lead carrying a few minutes of sleep is dropped, so the onset no longer jumps hours early.
     val groupRefAsleepMin = group.maxOfOrNull { frag ->
-        parseSessionStages(frag.stagesJSON)?.let { it.light + it.deep + it.rem } ?: 0.0
+        decodedAsleepMinutes(frag.stagesJSON, frag.effectiveStartTs)
     } ?: 0.0
     val heroGroup = group.dropWhile {
         it.effectiveStartTs < onsetTsForHero && isPreOnsetAwakeStub(it, groupRefAsleepMin)
@@ -2979,22 +2979,48 @@ private const val PRE_ONSET_STUB_ASLEEP_MAX_MIN = 3.0
  *  minutes more than 3. Mirrors iOS SleepView.preOnsetStubMinorFrac. (#259) */
 private const val PRE_ONSET_STUB_MINOR_FRAC = 0.15
 
+/** Absolute floor (ASLEEP minutes) under the #259 relative "minor lead" test: a leading fragment that carries
+ *  at least this much real sleep is a genuine first sleep — a real sleep episode — and is NEVER a spurious
+ *  pre-onset lead, however large the main block is. Without it a long main sleep inflates the 15% relative bar
+ *  (a 6 h night → ~54 min) so a genuine ~34-min first sleep was swallowed and the shown bedtime jumped hours
+ *  late, hiding the real onset the bridged night (and the Health write-back) already spans. 20 min ≈ the
+ *  shortest standalone sleep episode; below it a handful of asleep minutes beside a long night is a stray lead.
+ *  Mirrors iOS SleepView.preOnsetStubMinorAsleepFloorMin. (#259 / bridged-night headline) */
+internal const val PRE_ONSET_STUB_MINOR_ASLEEP_FLOOR_MIN = 20.0
+
+/**
+ * Asleep minutes decoded from a stored [stagesJSON] in EITHER of the two formats that exist in the DB:
+ * on-device COMPUTED nights store a SEGMENT ARRAY `[{start,end,stage}]`; imported nights store a dict of
+ * MINUTES `{light,deep,rem,awake}`. [parseSessionStages] already reads both; this additionally threads the
+ * fragment's [effectiveStartTs] through [SleepStageTotals.clampStagesToOnset] so a segment array is trimmed to
+ * the effective onset (the #259 pre-onset trim) exactly as the hero's stage totals trim it — a no-op for a
+ * minute dict and for a segment array that already starts at its onset. The displayed-onset stub test reads
+ * asleep minutes through this seam so a computed night's segment array is never counted as 0 asleep minutes.
+ * Internal so the onset golden pins the DECODE PATH itself. Mirrors iOS SleepView.decodedAsleepMinutes.
+ */
+internal fun decodedAsleepMinutes(stagesJSON: String?, effectiveStartTs: Long): Double =
+    parseSessionStages(SleepStageTotals.clampStagesToOnset(stagesJSON, effectiveStartTs))
+        ?.let { it.light + it.deep + it.rem } ?: 0.0
+
 /** A fragment is a spurious pre-onset awake stub when it is within the lie-in cap (<= [PRE_ONSET_STUB_MAX_MIN])
  *  and EITHER carries essentially no sleep (asleep minutes <= [PRE_ONSET_STUB_ASLEEP_MAX_MIN]) OR is minor
  *  relative to the night's main block ([refAsleepMin], the group's largest asleep span): asleep minutes below
- *  [PRE_ONSET_STUB_MINOR_FRAC] of it. Used only to skip such a stub when it leads the main-night group, so the
- *  hero's hypnogram and minutes start at the displayed bedtime (the main block's onset) rather than before it.
- *  [refAsleepMin] defaults to 0 (relative test off) so existing callers/tests are byte-identical. Mirrors iOS
+ *  [PRE_ONSET_STUB_MINOR_FRAC] of it AND below the absolute [PRE_ONSET_STUB_MINOR_ASLEEP_FLOOR_MIN] real-sleep-
+ *  episode floor. Used only to skip such a stub when it leads the main-night group, so the hero's hypnogram and
+ *  minutes start at the displayed bedtime (the main block's onset) rather than before it. [refAsleepMin]
+ *  defaults to 0 (relative test off) so existing callers/tests are byte-identical. Mirrors iOS
  *  SleepView.isPreOnsetAwakeStub. (#736 / #259) */
 internal fun isPreOnsetAwakeStub(frag: SleepSession, refAsleepMin: Double = 0.0): Boolean {
     val spanMin = (frag.endTs - frag.effectiveStartTs) / 60.0
     if (spanMin > PRE_ONSET_STUB_MAX_MIN) return false
-    val stages = parseSessionStages(frag.stagesJSON)
-    val asleepMin = stages?.let { it.light + it.deep + it.rem } ?: 0.0
+    val asleepMin = decodedAsleepMinutes(frag.stagesJSON, frag.effectiveStartTs)
     if (asleepMin <= PRE_ONSET_STUB_ASLEEP_MAX_MIN) return true
-    // #259: also spurious when it carries some sleep but is minor relative to the main block (largest
-    // fragment). A genuine biphasic first sleep is comparable in size, so it stays and its onset stands.
-    return refAsleepMin > 0.0 && asleepMin < PRE_ONSET_STUB_MINOR_FRAC * refAsleepMin
+    // #259 relative "minor lead" test, floored: a real sleep episode (>= the floor) is never a stray lead, so
+    // a long main block can't inflate the 15% bar past a genuine short first sleep. A genuine biphasic first
+    // sleep is comparable in size, so it stays and its onset stands.
+    return refAsleepMin > 0.0 &&
+        asleepMin < PRE_ONSET_STUB_MINOR_FRAC * refAsleepMin &&
+        asleepMin < PRE_ONSET_STUB_MINOR_ASLEEP_FLOOR_MIN
 }
 
 /** SUM the per-stage minutes across a bridged main-night group, so the hero's stage breakdown reflects the

--- a/android/app/src/test/java/com/noop/ui/SleepOnsetStubTest.kt
+++ b/android/app/src/test/java/com/noop/ui/SleepOnsetStubTest.kt
@@ -125,6 +125,71 @@ class SleepOnsetStubTest {
         assertTrue("window closes at the group's latest wake (fragment B end)", hero.heroWakeTs == bEnd)
     }
 
+    // ── Real-night regression (#259 / bridged-night headline): a genuine short first sleep is NOT a lead ──
+
+    /**
+     * THE BUG (real 2026-07-14 night): a 67-min first-sleep fragment (~34 asleep min) leading a 1:29 → 7:32
+     * main sleep (~340 asleep). The #259 relative "minor lead" test compared 34 asleep min against 15% of the
+     * ~340-min main (≈51 min) and wrongly classified the real first sleep as a spurious lead, hiding the true
+     * 12:16 bedtime. The absolute asleep floor keeps a real sleep episode: 34 ≥ 20, so it is NOT a stub.
+     */
+    @Test
+    fun realFirstSleepFragmentIsNotStub() {
+        // 66.8 min span, 34 asleep min, main block asleep 340. Old test: 34 < 0.15*340 (≈51) → wrongly a stub.
+        val b = block(0, 4008, """{"awake":33,"light":34,"deep":0,"rem":0}""")
+        assertFalse("a real 34-min first sleep beside a 340-min main is NOT a spurious lead",
+            isPreOnsetAwakeStub(b, refAsleepMin = 340.0))
+    }
+
+    /** Floor boundary: a fragment carrying at least [PRE_ONSET_STUB_MINOR_ASLEEP_FLOOR_MIN] asleep minutes is a
+     *  real sleep episode and never a spurious lead, whatever the main block's size. */
+    @Test
+    fun atMinorAsleepFloorIsNotStub() {
+        val b = block(0, 40 * 60, """{"awake":5,"light":20,"deep":0,"rem":0}""")   // exactly 20 asleep min
+        assertFalse(isPreOnsetAwakeStub(b, refAsleepMin = 1000.0))
+    }
+
+    /** The floor does NOT reopen #736/#259: a tiny stray sleep lead (10 asleep, under the floor AND under 15%
+     *  of a big main) is still a spurious lead, so the existing minor-lead goldens stay green. */
+    @Test
+    fun tinyStrayLeadStillStubUnderFloor() {
+        val b = block(0, 30 * 60, """{"awake":20,"light":10,"deep":0,"rem":0}""")
+        assertTrue(isPreOnsetAwakeStub(b, refAsleepMin = 400.0))
+    }
+
+    // ── Decode-format regression: a computed night's SEGMENT ARRAY first sleep is not read as 0 asleep ──
+
+    /**
+     * The real 12:16 → 1:22 first-sleep fragment (deviceId my-whoop-noop, startTs 1784013364), byte-for-byte
+     * as stored on the device: an on-device COMPUTED night's SEGMENT ARRAY. Non-wake sum: light 926 s + deep
+     * 1320 s + rem 990 s = 3236 s ≈ 53.9 asleep minutes. The displayed-onset stub test must read this
+     * format-agnostically ([decodedAsleepMinutes]) — a dict-only decode would return 0 asleep min, trip the
+     * "essentially sleepless stub" branch, and the shown bedtime would jump to the 1:29 main block.
+     */
+    private val fragmentSegmentJson =
+        """[{"end":1784013450,"stage":"light","start":1784013364},{"end":1784013540,"stage":"wake","start":1784013450},{"end":1784013600,"stage":"light","start":1784013540},{"end":1784013720,"stage":"wake","start":1784013600},{"end":1784013930,"stage":"light","start":1784013720},{"end":1784015250,"stage":"deep","start":1784013930},{"end":1784015580,"stage":"light","start":1784015250},{"end":1784015640,"stage":"wake","start":1784015580},{"end":1784015880,"stage":"light","start":1784015640},{"end":1784016180,"stage":"wake","start":1784015880},{"end":1784017170,"stage":"rem","start":1784016180},{"end":1784017375,"stage":"wake","start":1784017170}]"""
+
+    /** THE DECODE BUG, guarded: the segment-array format (an on-device computed night) decodes to its real
+     *  asleep minutes — not 0. Before a format-agnostic decode a dict-only reader returned 0 here. */
+    @Test
+    fun segmentArrayFormatDecodesRealAsleepMinutes() {
+        val asleep = decodedAsleepMinutes(fragmentSegmentJson, effectiveStartTs = 1_784_013_364L)
+        assertEquals(3236.0 / 60.0, asleep, 0.01)
+        // Above the #259 floor — the whole point: a real sleep episode must clear it.
+        assertTrue(asleep >= PRE_ONSET_STUB_MINOR_ASLEEP_FLOOR_MIN)
+    }
+
+    /** END-TO-END: a real first-sleep fragment stored as a SEGMENT ARRAY, beside a large main block, is NOT
+     *  skipped as a pre-onset stub — the both-format decode populates its asleep minutes and the floor keeps
+     *  it. Before the fix (dict-only decode → 0 asleep) it tripped the sleepless-stub branch and the displayed
+     *  bedtime jumped to the main block. */
+    @Test
+    fun segmentArrayFirstSleepFragmentIsNotSkipped() {
+        val frag = block(1_784_013_364L, 1_784_017_375L, fragmentSegmentJson)
+        assertFalse("a real segment-array first sleep must not be skipped as a stub",
+            isPreOnsetAwakeStub(frag, refAsleepMin = 340.0))
+    }
+
     /** A genuine single-block night is unchanged: the session is that block. */
     @Test
     fun singleBlockNightUnchanged() {

--- a/docs/ANALYTICS.md
+++ b/docs/ANALYTICS.md
@@ -309,6 +309,12 @@ Consecutive same-stage epochs are merged into `StageSegment`s tiling `[start, en
 - `SleepSession` — `start`, `end`, `efficiency` (AASM `asleep / in-bed`, where `asleep = in-bed − wake`), `stages`, per-session `restingHR` (lowest 5-min rolling-mean HR) and `avgHRV` (mean RMSSD over 5-min tumbling windows).
 - `hypnogramMetrics(_:)` — AASM-style roll-up: TIB / TST / SPT / SOL / REM latency / WASO / efficiency / disturbances, plus deep/REM/light minutes and percentages.
 
+### Displayed sleep onset — the headline "Asleep at" spans the whole bridged night
+
+The Sleep screen headline ("Asleep at …") reports the onset of the **whole bridged night**, not the main session's start. A night stored as a short first-sleep fragment + a brief walk + the main session bridges into one group when the gap is under `gapBridgeMaxMin` (60 min). The display onset walk (`SleepView.nightOnsetTs` → `isPreOnsetAwakeStub`) previously mis-classified such a fragment as a spurious pre-onset lead through two stacked defects: (1) the #259 relative "minor lead" test compared the fragment's asleep minutes against 15% of the main block, so on a long main sleep a genuine short first sleep was skipped and the headline jumped forward to the main session's start; (2) the stub test read asleep minutes via the dict-only `decodeStages`, which returns nil for the segment-array `stagesJSON` an on-device **computed** night stores — so every fragment counted as 0 asleep minutes and tripped the "essentially sleepless stub" branch, bypassing defect (1)'s floor entirely.
+
+Fix: an **absolute floor** `preOnsetStubMinorAsleepFloorMin = 20` (min) under the #259 relative test — a leading fragment carrying **≥ 20 asleep minutes** is never treated as a spurious lead, whatever the main block's size — plus a format-agnostic `decodedAsleepMinutes` (dict-of-minutes decode with a segment-array fallback) used at both onset call sites, so the floor's input is populated on computed nights too. The relaxation is strict (it can only un-skip a real first sleep, never newly skip one), so the displayed onset now equals the bridged night's first sleep and agrees with the Apple Health write-back span (bridged night groups, #294/#364). The #736 sleepless-stub skip and the #259 tiny-stray-lead (≤ 10 min) behavior are unchanged. The constant and decode seam live in `Strand/Screens/SleepView.swift`; a Kotlin twin of the constant, the onset-walk rule, and the both-format decode is deferred (Swift-only contributor).
+
 ---
 
 ## The **Rest** score composite — *"how restorative was your sleep?"*


### PR DESCRIPTION
## Summary

On the Sleep tab, the headline **"Asleep at …"** reports the onset of the **whole bridged night** — a short first-sleep fragment + a brief walk + the main session bridge into one group when the gap is under `gapBridgeMaxMin` (60 min). On a real 2026-07-14 night (**12:16** first sleep → ~1:22, brief gap, **1:29** main → 7:32) the headline showed **1:29 AM**, hiding the true 12:16 bedtime — and disagreeing with the Apple Health write-back, which already spans 12:16 → 7:32 (bridged night groups, #294/#364).

The onset walk (`SleepView.nightOnsetTs` → `isPreOnsetAwakeStub`) mis-classified the genuine first sleep as a spurious pre-onset lead through **two stacked defects**:

**Defect 1 — the #259 relative bar was unfloored.** The "minor lead" test compared the fragment's asleep minutes against **15%** of the main block. On a long main sleep (~6 h) that bar inflates to ~54 min, so a genuine ~34-min first sleep was swallowed and the shown onset jumped hours late.

**Defect 2 — the stub test only decoded dict-format `stagesJSON`.** It read asleep minutes via the dict-only `decodeStages`, which returns `nil` for the **segment-array** `stagesJSON` an on-device **computed** night stores (`AnalyticsEngine.encodeStages`). So every fragment of a computed night counted as **0** asleep minutes, tripped the "essentially sleepless stub" branch, and bypassed Defect 1's floor entirely — the floor's own input was zeroed before the comparison.

## What changed

- **Absolute floor** `preOnsetStubMinorAsleepFloorMin = 20` (min) under the #259 relative test, in `isPreOnsetAwakeStub` — a leading fragment carrying ≥ 20 asleep minutes (a real sleep episode) is never a spurious lead, whatever the main block's size. Strict relaxation: it can only **un-skip** a real first sleep, never newly skip one. `nightOnsetIndex`/`nightOnsetTs` walk unchanged otherwise.
- **Format-agnostic `decodedAsleepMinutes`** (dict-of-minutes decode with a segment-array fallback, threading the #259 pre-onset trim via `effectiveStartTs`), used at **both** onset call sites; `decodeStages`/`decodeSegments` become `static` (they were already pure) so the seam and the golden test can reach them.
- The #736 sleepless-stub skip and the #259 tiny-stray-lead (≤ 10 min) behavior are unchanged.

## Verification

- **Package tests:** `swift test` in `Packages/StrandAnalytics` green — 1070 tests, 0 failures, including the `BridgedNightGroupsTests` fixture pinning the real night bridging into one group (fragment not filtered).
- **App-target tests (macOS):** `xcodebuild … test` for the touched classes green — `SleepOnsetStubTests` (18) + `SleepOnsetDecodeTests` (5) = **23 tests, 0 failures, ** TEST SUCCEEDED **`**. `SleepOnsetDecodeTests` pins the decode path itself with the night's real stored JSON: the segment array decodes to ~53.9 asleep minutes (above the floor) and the two-block night walks to onset index 0 (the 12:16 fragment).
- **App compiles:** `xcodegen generate` + `xcodebuild -scheme Strand -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO build` → **BUILD SUCCEEDED** (`SleepView.swift` is app-target Swift, which has **no default CI** here — `app-build.yml` is disabled — so it was compiled locally).
- **Real-device render:** the change was verified in the iOS Simulator over a real on-device DB — the Sleep hero renders **"ASLEEP 12:16 AM / WOKE 7:32 AM"** (previously "1:29 AM"). (Described, not attached — no device data is included in the PR.)

## Cross-platform / Kotlin twin

**Kotlin twin included + gradle-tested.** The `com.noop.ui` `SleepScreen` onset-stub logic carries the same policy:

- `PRE_ONSET_STUB_MINOR_ASLEEP_FLOOR_MIN = 20.0` floors the #259 relative "minor lead" test in `isPreOnsetAwakeStub` (a leading fragment with ≥ 20 asleep min is never a spurious lead), byte-identical to Swift's `preOnsetStubMinorAsleepFloorMin`.
- Both onset call sites (`isPreOnsetAwakeStub` and the group ref-asleep max) now read a new `decodedAsleepMinutes(stagesJSON, effectiveStartTs)` — the twin of Swift's `decodedAsleepMinutes`. Android's `parseSessionStages` already decoded both the minute-dict and segment-array formats, so the segment-array-reads-as-0 defect never existed here; the helper additionally threads the fragment's `effectiveStartTs` through `clampStagesToOnset` so a computed night's segment timeline is trimmed to onset exactly as Swift's `decodeSegments(sessionStart:)` does — a no-op for a dict and for a segment array already starting at its onset.

`SleepOnsetStubTest` gains 5 tests (floor case, floor boundary, tiny-stray guard, and a segment-array decode-format case proving a real first-sleep fragment stored as a segment array decodes its real asleep minutes and is NOT skipped). `./gradlew :app:testFullDebugUnitTest --tests "com.noop.ui.*"` → **573 tests, 0 failures** (`SleepOnsetStubTest`: 14 = 9 original + 5 new). This PR is pure UI/display policy so the displayed-onset behavior stays behavior-identical across platforms.
