### PR TITLE
fix(both): CSV export reads the active-strap union — live-BLE installs no longer export an empty zip (#458)

### DIFF
--- a/Strand/Data/CsvExport.swift
+++ b/Strand/Data/CsvExport.swift
@@ -8,12 +8,18 @@ import UniformTypeIdentifiers
 import WhoopStore
 import StrandImport
 
-/// Settings → Backup & restore → "Export CSV…": serialize the merged "my-whoop" ∪ "my-whoop-noop"
-/// history (imported wins per day — exactly what the dashboards show; Apple Health rows are
-/// deliberately EXCLUDED so a re-import can't mis-attribute them as WHOOP data) into WHOOP's
-/// 4-CSV zip via StrandImport.WhoopCsvExporter. The zip re-imports into NOOP on Mac (Data Sources →
-/// WHOOP Export) and on Android. On-device computed rows are marked "noop (APPROXIMATE)" in the
-/// Source column both importers ignore; the .sqlite backup remains the lossless restore path.
+/// Settings → Backup & restore → "Export CSV…": serialize the merged WHOOP history (imported wins
+/// per day — exactly what the dashboards show; Apple Health rows are deliberately EXCLUDED so a
+/// re-import can't mis-attribute them as WHOOP data) into WHOOP's 4-CSV zip via
+/// StrandImport.WhoopCsvExporter. The zip re-imports into NOOP on Mac (Data Sources → WHOOP Export)
+/// and on Android. On-device computed rows are marked "noop (APPROXIMATE)" in the Source column both
+/// importers ignore; the .sqlite backup remains the lossless restore path.
+///
+/// #458 (the Android twin's bug, mirror-image here): every read goes through the repository's
+/// active∪canonical union ids (`importedReadIds`/`computedReadIds`, #814) — reading the ACTIVE id
+/// alone dropped the canonical "my-whoop" rows (a prior CSV import + the canonical engine history)
+/// after a strap remove+re-add moved the active id to "whoop-<uuid>". Per-row dedup keeps the
+/// active-first copy; a single-canonical install collapses to one id per side, byte-identical.
 ///
 /// Self-contained: it reads through the store handle and reconstructs Repository's merge precedence
 /// inline rather than depending on Repository's private merge helpers, so the export is decoupled
@@ -30,30 +36,72 @@ enum CsvExport {
         guard let store = await repo.storeHandle() else {
             return .failure("Couldn't open the local store.")
         }
-        let deviceId = repo.deviceId
-        // The on-device computed source id (recovery/strain/sleep derived from raw streams). This
-        // mirrors Repository.computedDeviceId, which is private — so we reconstruct the same string.
-        let computedId = deviceId + "-noop"
+        // #458: the active∪canonical union ids (active FIRST, so per-row dedup keeps the live copy);
+        // a single-canonical install collapses to one id per side and reads byte-identically.
+        let importedIds = repo.importedReadIds
+        let computedIds = repo.computedReadIds
         let fromDay = "0000-01-01", toDay = "9999-12-31"
         let hi = Int(Date().timeIntervalSince1970) + 86_400
 
         do {
             // Fetch every source off the WhoopStore actor (each `await store.*` already hops off main).
-            let imported = try await store.dailyMetrics(deviceId: deviceId, from: fromDay, to: toDay)
-            let computed = try await store.dailyMetrics(deviceId: computedId, from: fromDay, to: toDay)
+            // Dailies: per side, the FIRST union id that has a day wins (active first).
+            var importedByDay: [String: DailyMetric] = [:]
+            for id in importedIds {
+                for d in try await store.dailyMetrics(deviceId: id, from: fromDay, to: toDay)
+                where importedByDay[d.day] == nil { importedByDay[d.day] = d }
+            }
+            var computedByDay: [String: DailyMetric] = [:]
+            for id in computedIds {
+                for d in try await store.dailyMetrics(deviceId: id, from: fromDay, to: toDay)
+                where computedByDay[d.day] == nil { computedByDay[d.day] = d }
+            }
+            let imported = importedByDay.values.sorted { $0.day < $1.day }
+            let computed = computedByDay.values.sorted { $0.day < $1.day }
+            // Cycles series: per (key, day) the first union id with a value wins.
             var seriesRaw: [String: [MetricPoint]] = [:]
             for key in ["sleep_performance", "sleep_consistency", "sleep_need_min", "sleep_debt_min",
                         "in_bed_min", "awake_min", "energy_kcal", "avg_hr", "max_hr"] {
-                seriesRaw[key] = try await store.metricSeries(deviceId: deviceId, key: key,
-                                                             from: fromDay, to: toDay)
+                var byDay: [String: MetricPoint] = [:]
+                for id in importedIds {
+                    for p in try await store.metricSeries(deviceId: id, key: key, from: fromDay, to: toDay)
+                    where byDay[p.day] == nil { byDay[p.day] = p }
+                }
+                seriesRaw[key] = byDay.values.sorted { $0.day < $1.day }
             }
-            let impSleep = try await store.sleepSessions(deviceId: deviceId, from: 0, to: hi, limit: 100_000)
-            let compSleep = try await store.sleepSessions(deviceId: computedId, from: 0, to: hi, limit: 100_000)
-            let impWorkouts = try await store.workouts(deviceId: deviceId, from: 0, to: hi, limit: 100_000)
-            let compWorkouts = try await store.workouts(deviceId: computedId, from: 0, to: hi, limit: 100_000)
-            let journal = try await store.journalEntries(deviceId: deviceId, from: fromDay, to: toDay)
+            // Sleeps / workouts: per side, exact-duplicate rows dropped on the natural key,
+            // active-first (mirrors the Kotlin dedupSleepBlocks / dedupWorkoutsByKey unions).
+            var seenSleep = Set<String>(), seenComp = Set<String>()
+            var impSleep: [CachedSleepSession] = [], compSleep: [CachedSleepSession] = []
+            for id in importedIds {
+                for s in try await store.sleepSessions(deviceId: id, from: 0, to: hi, limit: 100_000)
+                where seenSleep.insert("\(s.startTs)|\(s.endTs)").inserted { impSleep.append(s) }
+            }
+            for id in computedIds {
+                for s in try await store.sleepSessions(deviceId: id, from: 0, to: hi, limit: 100_000)
+                where seenComp.insert("\(s.startTs)|\(s.endTs)").inserted { compSleep.append(s) }
+            }
+            var seenImpW = Set<String>(), seenCompW = Set<String>()
+            var impWorkouts: [WorkoutRow] = [], compWorkouts: [WorkoutRow] = []
+            for id in importedIds {
+                for w in try await store.workouts(deviceId: id, from: 0, to: hi, limit: 100_000)
+                where seenImpW.insert("\(w.startTs)|\(w.sport)").inserted { impWorkouts.append(w) }
+            }
+            for id in computedIds {
+                for w in try await store.workouts(deviceId: id, from: 0, to: hi, limit: 100_000)
+                where seenCompW.insert("\(w.startTs)|\(w.sport)").inserted { compWorkouts.append(w) }
+            }
+            // Journal: natural key (day, question), active-first.
+            var seenJournal = Set<String>()
+            var journal: [JournalEntry] = []
+            for id in importedIds {
+                for j in try await store.journalEntries(deviceId: id, from: fromDay, to: toDay)
+                where seenJournal.insert("\(j.day)|\(j.question)").inserted { journal.append(j) }
+            }
+            // Sidecar: every metricSeries row under EVERY NOOP source id, full fidelity (rows keep
+            // their own deviceId, so union entries stay distinguishable on re-import).
             var sidecar: [String: [MetricPoint]] = [:]
-            for id in [deviceId, computedId] {
+            for id in importedIds + computedIds {
                 var points: [MetricPoint] = []
                 for key in (try await store.metricKeys(deviceId: id)) {
                     points += try await store.metricSeries(deviceId: id, key: key, from: fromDay, to: toDay)
@@ -123,7 +171,7 @@ enum CsvExport {
                         cycleStart: { endDay($0) + " 00:00:00" },
                         sourceBySession: { sleepSource[$0.startTs] ?? "" }).utf8)),
                     ("workouts.csv",
-                     Data(WhoopCsvExporter.workoutsCSV(workouts, sourceLabel: { workoutSource($0, computedId: computedId) }).utf8)),
+                     Data(WhoopCsvExporter.workoutsCSV(workouts, sourceLabel: { workoutSource($0, computedIds: computedIds) }).utf8)),
                     ("journal_entries.csv", Data(WhoopCsvExporter.journalCSV(journal).utf8)),
                     ("noop_metric_series.json", WhoopCsvExporter.metricSeriesJSON(sidecar)),
                 ]
@@ -176,10 +224,11 @@ enum CsvExport {
     /// Classify a workout row for the parser-ignored Source column. The strings match how each row
     /// is written on this Mac: WhoopImporter uses source "whoop"; AppModel manual logging uses
     /// "manual"; IntelligenceEngine's on-device detected workouts use the computed source id with
-    /// sport "detected".
-    private static func workoutSource(_ w: WorkoutRow, computedId: String) -> String {
+    /// sport "detected". #458: a detected row's source may be EITHER computed union id (active-noop
+    /// or canonical-noop), so membership replaces the single-id compare.
+    private static func workoutSource(_ w: WorkoutRow, computedIds: [String]) -> String {
         if w.source == "manual" { return "manual" }
-        if w.source == computedId || w.sport == "detected" { return "noop (APPROXIMATE)" }
+        if computedIds.contains(w.source) || w.sport == "detected" { return "noop (APPROXIMATE)" }
         return "import"
     }
 

--- a/Strand/Data/Repository.swift
+++ b/Strand/Data/Repository.swift
@@ -148,12 +148,12 @@ final class Repository: ObservableObject {
     /// The distinct IMPORTED/MEASURED source ids to union for a dashboard read: the active strap (live raw,
     /// #814) and the canonical imported id. Active strap FIRST so per-day dedup lets the measured/live row
     /// win over the imported one. Deduped, so a single-device install (active id == canonical) reads one id.
-    private var importedReadIds: [String] {
+    var importedReadIds: [String] {
         deviceId == canonicalDeviceId ? [deviceId] : [deviceId, canonicalDeviceId]
     }
     /// The distinct COMPUTED ("-noop") source ids to union: the active strap's computed sibling and the
     /// canonical computed sibling. Same dedup rule as `importedReadIds`.
-    private var computedReadIds: [String] {
+    var computedReadIds: [String] {
         computedDeviceId == canonicalComputedId ? [computedDeviceId] : [computedDeviceId, canonicalComputedId]
     }
     private var store: WhoopStore?

--- a/android/app/src/main/java/com/noop/ingest/WhoopCsvExporter.kt
+++ b/android/app/src/main/java/com/noop/ingest/WhoopCsvExporter.kt
@@ -314,18 +314,27 @@ object WhoopCsvExporter {
     }
 
     /**
-     * UI entry point: serialize the merged "my-whoop" ∪ "my-whoop-noop" history (imported wins per
-     * day — exactly what the dashboards show; Apple Health / Health Connect rows are deliberately
-     * EXCLUDED so a re-import can't mis-attribute them as WHOOP data) and write a zip to [uri].
-     * Returns a human summary for the toast.
+     * UI entry point: serialize the merged WHOOP history (imported wins per day — exactly what the
+     * dashboards show; Apple Health / Health Connect rows are deliberately EXCLUDED so a re-import
+     * can't mis-attribute them as WHOOP data) and write a zip to [uri]. Returns a human summary for
+     * the toast.
+     *
+     * [deviceId] is the registry's ACTIVE strap id (SPINE / #814) and has NO default on purpose
+     * (#458): the old `= "my-whoop"` default meant a live-BLE install — whose engine banks computed
+     * scores under `"<strapId>-noop"` — exported `0 days, 0 sleeps, 0 journal entries` while the app
+     * displayed months of history. It survived the #359 sweep because that grep targeted the
+     * hardcoded `"my-whoop-noop"` string, not default parameters. Every read below goes through the
+     * active∪canonical union resolvers ([WhoopRepository.importedSourceIds] /
+     * [WhoopRepository.computedSourceIds]), so BOTH install shapes export in full: live-BLE rows
+     * under the strap id AND canonical `"my-whoop"` rows from a prior CSV import (a single-canonical
+     * install collapses to one id, byte-identical to before).
      */
     suspend fun exportZip(
         context: Context,
         uri: Uri,
         repo: WhoopRepository,
-        deviceId: String = "my-whoop",
+        deviceId: String,
     ): String {
-        val computedId = repo.computedDeviceId(deviceId)
         val hi = System.currentTimeMillis() / 1000 + 86_400
         // physiological_cycles keys each row by the LOCAL calendar day (analyze, #277); the sleeps
         // "Cycle start time" must use the SAME local end-day so the two CSVs reconcile by cycle — else a
@@ -333,37 +342,53 @@ object WhoopCsvExporter {
         // matching how analyze bucketed the stored days.
         val tzOffsetSec = java.time.ZoneId.systemDefault().rules.getOffset(java.time.Instant.now()).totalSeconds.toLong()
 
-        // Daily: the same imported-wins merge the dashboards show; a day present under the imported
-        // source is "import", otherwise it came from the on-device computed source.
+        // The active∪canonical union ids (#458): active strap FIRST, so a per-row dedup keeps the
+        // live/measured copy; a single-canonical install collapses to one id each.
+        val importedIds = repo.importedSourceIds(deviceId)
+        val computedIds = repo.computedSourceIds(deviceId)
+
+        // Daily: the same imported-wins merge the dashboards show (daysMerged resolves the union
+        // internally); a day present under ANY imported source is "import", otherwise it came from
+        // the on-device computed source.
         val daily = repo.daysMerged(deviceId)
-        val importedDays = repo.days(deviceId).map { it.day }.toHashSet()
+        val importedDays = importedIds.flatMap { repo.days(it) }.map { it.day }.toHashSet()
         val sourceByDay = daily.associate { d ->
             d.day to if (d.day in importedDays) "import" else "noop (APPROXIMATE)"
         }
 
         val sleeps = repo.sleepSessionsMerged(deviceId, 0L, hi)
-        // Workouts: imported WHOOP ∪ on-device detected (which carries the "-noop" device id). Apple
-        // Health / Health Connect workouts are intentionally omitted, matching the cycles/sleep cut.
-        // Dedup by (startTs, sport), imported (deviceId) first so it wins — the same session can
-        // exist under both ids (e.g. a reimported export + BLE re-detection), which double-counted
-        // it in the CSV and inflated totals on reimport. (PR #97 review, tigercraft4. Swift parity.)
+        // Workouts: imported WHOOP ∪ on-device detected (which carries the "-noop" device id), each
+        // side read across its union ids (#458). Apple Health / Health Connect workouts are
+        // intentionally omitted, matching the cycles/sleep cut. Dedup by (startTs, sport), imported
+        // first so it wins — the same session can exist under both sides (e.g. a reimported export +
+        // BLE re-detection), which double-counted it in the CSV and inflated totals on reimport.
+        // (PR #97 review, tigercraft4. Swift parity.)
         val seenWorkouts = HashSet<String>()
-        val workouts = (repo.workouts(deviceId, 0L, hi) + repo.workouts(computedId, 0L, hi))
+        val workouts = (repo.workoutsUnion(deviceId, 0L, hi) + repo.detectedWorkoutsUnion(deviceId, 0L, hi))
             .filter { seenWorkouts.add("${it.startTs}|${it.sport}") }
-        // Journal lives under the imported deviceId. Native in-app journal logging (a separate
-        // feature on its own device id) isn't read here, keeping the exporter self-contained; the
-        // imported journal is the WHOOP-sourced history the round-trip targets.
-        val journal = repo.journal(deviceId, "0000-01-01", "9999-12-31")
+        // Journal lives under the imported ids. Native in-app journal logging (a separate feature on
+        // its own device id) isn't read here, keeping the exporter self-contained; the imported
+        // journal is the WHOOP-sourced history the round-trip targets. Dedup by the row's natural key
+        // (day, question), active-first.
+        val seenJournal = HashSet<String>()
+        val journal = importedIds.flatMap { repo.journal(it, "0000-01-01", "9999-12-31") }
+            .filter { seenJournal.add("${it.day}|${it.question}") }
 
+        // Cycles columns recovered from the imported metricSeries: per (day, key) the FIRST union id
+        // that has a value wins (active strap first), mirroring the read-side precedence.
         val seriesByDay = HashMap<String, MutableMap<String, Double>>()
         for (key in listOf("sleep_performance", "sleep_consistency", "sleep_need_min", "sleep_debt_min")) {
-            for (p in repo.metricSeries(deviceId, key, "0000-01-01", "9999-12-31")) {
-                seriesByDay.getOrPut(p.day) { HashMap() }[key] = p.value
+            for (id in importedIds) {
+                for (p in repo.metricSeries(id, key, "0000-01-01", "9999-12-31")) {
+                    val row = seriesByDay.getOrPut(p.day) { HashMap() }
+                    if (key !in row) row[key] = p.value
+                }
             }
         }
-        // Sidecar: every metricSeries row under both NOOP sources, full fidelity.
+        // Sidecar: every metricSeries row under every NOOP source id, full fidelity (rows carry their
+        // own deviceId, so union duplicates stay distinguishable on re-import).
         val sidecarRows = buildList {
-            for (id in listOf(deviceId, computedId)) {
+            for (id in importedIds + computedIds) {
                 for (key in repo.metricKeys(id)) {
                     addAll(repo.metricSeries(id, key, "0000-01-01", "9999-12-31"))
                 }

--- a/android/app/src/main/java/com/noop/ui/SettingsScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/SettingsScreen.kt
@@ -563,7 +563,9 @@ fun SettingsScreen(
         if (uri == null) { backupBusy = false; return@rememberLauncherForActivityResult }
         scope.launch {
             val result = withContext(Dispatchers.IO) {
-                runCatching { WhoopCsvExporter.exportZip(context, uri, vm.repo) }
+                // #458: thread the registry's ACTIVE strap id — the exporter's old "my-whoop" default
+                // exported an empty zip on live-BLE installs (the engine banks under "<strapId>-noop").
+                runCatching { WhoopCsvExporter.exportZip(context, uri, vm.repo, vm.activeStrapId) }
             }
             backupBusy = false
             result.fold(


### PR DESCRIPTION
Closes #458.

## The bug (Android, verified at HEAD exactly as reported)

`WhoopCsvExporter.exportZip` defaulted `deviceId = "my-whoop"`, but a live-BLE install's engine banks computed scores under `"<strapId>-noop"` (IntelligenceEngine.kt:879/1007) — so every read hit ids owning zero rows and the export produced `0 days, 0 sleeps, 0 journal entries` while the app displayed months of history. MasterSMax12's analysis was accurate down to the line numbers, including why it survived #359: that sweep grepped the hardcoded `"my-whoop-noop"` string, and this hardcode hides in a **default parameter**.

## Fix

**Android:**
- The default is **removed** — the compiler now forces every caller to decide, which is what actually kills this bug class. Settings threads `vm.activeStrapId`.
- Every read resolves through the #814 active∪canonical union: `daysMerged`/`sleepSessionsMerged` already did once handed the active id; workouts move to `workoutsUnion`/`detectedWorkoutsUnion`; the imported-days set, journal, cycles series, and sidecar union inline with active-first dedup on natural keys (`(day)`, `(day, question)`, `(startTs, sport)`).
- The new reads are a **strict superset** of the old ones — nothing that previously exported can be lost — and a single-canonical install collapses to one id per side, byte-identical.

**Apple (mirror-image of the same class, found while writing the twin):** `CsvExport` read the *active* id only, so a strap remove+re-add orphaned the canonical `"my-whoop"` history (a prior CSV import + canonical engine rows) from the export — the opposite failure shape. Reads now union `importedReadIds`/`computedReadIds` (two Repository helpers de-privatized, same module) with the same active-first natural-key dedups; `workoutSource` takes the computed-id list since a detected row can carry either union id.

## Not in this PR

The sibling audit MasterSMax12 suggested — 7 more `= "my-whoop"` default parameters on `WhoopRepository` methods (`dismissedDetected`, `dismissedSleeps`, `relabelDetected`, `freshness`, `dataVolumeSnapshot`, +2) — each needs a caller-by-caller review; follow-up issue material rather than a blanket change here.

## Verification

- Android: `compileFullDebugKotlin` + `testFullDebugUnitTest` — **2709 tests, 0 failures**. (No Robolectric/in-memory Room in the JVM suite for an `exportZip` repro; the union resolvers themselves are pinned by `ResolverUnionTest`, and removing the default makes the contract compiler-enforced.)
- Apple: app-target Swift — on-demand `app-build.yml` run **29374455034** gates the merge; result confirmed here.

@MasterSMax12 — taking you up on the verification offer: once this lands in the next testing build, an Export CSV on your live-BLE 4.0 should report the real counts. A second check worth doing if convenient: re-import the produced zip on a fresh install and confirm days/sleeps round-trip.