### PR TITLE
analytics: deviceEraEpoch primitive for HRV-scale device switches (#459)

### DIFF
--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/Baselines.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/Baselines.swift
@@ -373,7 +373,10 @@ public enum Baselines {
     /// re-homed under the computed WHOOP id, so detection must precede the merge). Mirrors the Kotlin twin.
     public static func deviceEraEpoch(_ sourceDays: [(day: String, sourceId: String)]) -> Double {
         if sourceDays.isEmpty { return 0.0 }
-        let sorted = sourceDays.sorted { $0.day < $1.day }
+        // Total order by (day, sourceId) — a same-day mixed-brand row (an overlap night) must break the
+        // tie IDENTICALLY to the Kotlin twin, so a plain by-day sort (Swift's is not stable) can't
+        // diverge the computed epoch across platforms.
+        let sorted = sourceDays.sorted { $0.day != $1.day ? $0.day < $1.day : $0.sourceId < $1.sourceId }
         let currentBrand = brandBucket(sorted.last!.sourceId)
         // No brand change anywhere → no epoch (byte-identical fold for every single-brand user).
         if !sorted.contains(where: { brandBucket($0.sourceId) != currentBrand }) { return 0.0 }
@@ -395,9 +398,14 @@ public enum Baselines {
     /// Health-Connect riders), so only a positively-identified wearable export changes the era. Mirrors
     /// the Kotlin twin.
     static func brandBucket(_ sourceId: String) -> String {
+        // `hasPrefix` deliberately catches BOTH the export id ("oura-import") and the cloud id
+        // ("oura-api"), so an Oura-cloud era and an Oura-export era read as the same brand.
         if sourceId.hasPrefix("oura") { return "oura" }
         if sourceId.hasPrefix("fitbit") { return "fitbit" }
         if sourceId.hasPrefix("garmin") { return "garmin" }
+        // "apple-health" / "health-connect" fall through to "whoop" ON PURPOSE: NOOP's Apple/HC daily
+        // rows ride the strap source's scale, and HC is a pass-through whose true origin is unknowable,
+        // so they must NOT open a false era boundary against WHOOP nights.
         return "whoop"
     }
 

--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/Baselines.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/Baselines.swift
@@ -350,6 +350,57 @@ public enum Baselines {
                              nightsSinceUpdate: 0, status: .calibrating)
     }
 
+    // MARK: - Device-era boundary (#459)
+
+    /// The recalibration epoch (seconds, UTC start-of-day) at the LATEST device-era boundary in a
+    /// source-tagged nightly history, for feeding `foldHistory`'s `baselineEpoch` so a baseline can't
+    /// mix two brands' incompatible HRV scales (#459: an Oura→WHOOP switch has Oura RMSSD ~120–155 ms
+    /// vs WHOOP ~72–112 ms with no overlap nights, so a straddling 30-night window reads the first
+    /// WHOOP nights as "suppressed" against an Oura-inflated mean — a device artifact, not physiology).
+    ///
+    /// `sourceDays` is `(dayKey "yyyy-MM-dd", sourceId)` for every night with a value, ANY order (it is
+    /// sorted here). The epoch is the start of the first day of the LATEST contiguous single-brand era:
+    /// walk newest→oldest while the brand matches the newest night's brand, and return that run's first
+    /// day's start. Returns 0.0 (no recalibration → `foldHistory` is byte-identical) when the whole
+    /// history is ONE brand — so a single-device user, and a WHOOP user whose imported + computed +
+    /// strap ids all bucket to "whoop", is completely unaffected.
+    ///
+    /// The brand bucket is intentionally coarse and NOT `DeviceFamily` (that only splits WHOOP 4 vs 5,
+    /// both the same HRV scale): every WHOOP-origin id (the canonical import, the active strap, the
+    /// "-noop" computed sibling, Health-Connect/Apple rows that ride the strap source) is ONE brand;
+    /// each wearable-export brand (oura/fitbit/garmin) is its own. Pure + unit-pinned; the caller
+    /// assembles `sourceDays` from the ORIGINAL per-source reads (brand is lost once a wearable day is
+    /// re-homed under the computed WHOOP id, so detection must precede the merge). Mirrors the Kotlin twin.
+    public static func deviceEraEpoch(_ sourceDays: [(day: String, sourceId: String)]) -> Double {
+        if sourceDays.isEmpty { return 0.0 }
+        let sorted = sourceDays.sorted { $0.day < $1.day }
+        let currentBrand = brandBucket(sorted.last!.sourceId)
+        // No brand change anywhere → no epoch (byte-identical fold for every single-brand user).
+        if !sorted.contains(where: { brandBucket($0.sourceId) != currentBrand }) { return 0.0 }
+        // Walk back over the contiguous current-brand suffix; its first day opens the current era.
+        var eraStartDay = sorted.last!.day
+        for entry in sorted.reversed() {
+            if brandBucket(entry.sourceId) != currentBrand { break }
+            eraStartDay = entry.day
+        }
+        let fmt = DateFormatter()
+        fmt.calendar = Calendar(identifier: .gregorian)
+        fmt.timeZone = TimeZone(secondsFromGMT: 0)
+        fmt.dateFormat = "yyyy-MM-dd"
+        return fmt.date(from: eraStartDay)?.timeIntervalSince1970 ?? 0.0
+    }
+
+    /// Coarse HRV-scale brand for a source id (#459). Every WHOOP-origin id shares ONE scale; each
+    /// wearable-export brand is its own. Unknown ids bucket to "whoop" (the strap source and its Apple/
+    /// Health-Connect riders), so only a positively-identified wearable export changes the era. Mirrors
+    /// the Kotlin twin.
+    static func brandBucket(_ sourceId: String) -> String {
+        if sourceId.hasPrefix("oura") { return "oura" }
+        if sourceId.hasPrefix("fitbit") { return "fitbit" }
+        if sourceId.hasPrefix("garmin") { return "garmin" }
+        return "whoop"
+    }
+
     // MARK: - Deviation
 
     /// Compute z / delta / ratio / in-normal-range for a value vs a baseline.

--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/Baselines.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/Baselines.swift
@@ -358,11 +358,19 @@ public enum Baselines {
     /// vs WHOOP ~72–112 ms with no overlap nights, so a straddling 30-night window reads the first
     /// WHOOP nights as "suppressed" against an Oura-inflated mean — a device artifact, not physiology).
     ///
-    /// `sourceDays` is `(dayKey "yyyy-MM-dd", sourceId)` for every night with a value, ANY order (it is
-    /// sorted here). The epoch is the start of the first day of the LATEST contiguous single-brand era:
-    /// walk newest→oldest while the brand matches the newest night's brand, and return that run's first
-    /// day's start. Returns 0.0 (no recalibration → `foldHistory` is byte-identical) when the whole
-    /// history is ONE brand — so a single-device user, and a WHOOP user whose imported + computed +
+    /// CONTRACT: `sourceDays` is exactly ONE `(dayKey "yyyy-MM-dd", sourceId)` per night — the day's
+    /// WINNING source (the same per-day merge winner whose value the fold uses), NOT one row per source.
+    /// The "current era" is read off the NEWEST day's brand, so an overlap day carrying two brands would,
+    /// under the deterministic (day, sourceId) sort, let the lexically-later source (e.g. "oura-import" >
+    /// "my-whoop") masquerade as the current brand. Passing one-per-day-winner makes that impossible; the
+    /// same-day-tie handling below is only a determinism backstop, not a licence to pass raw multi-source
+    /// rows. Any order is fine (it is sorted here).
+    ///
+    /// The epoch is the start of the first day of the LATEST contiguous single-brand era: walk
+    /// newest→oldest while the brand matches the newest night's brand, and return that run's first day's
+    /// start (a lone off-brand day inside the current era truncates it — fail-safe: it drops MORE history,
+    /// never mixes scales). Returns 0.0 (no recalibration → `foldHistory` is byte-identical) when the
+    /// whole history is ONE brand — so a single-device user, and a WHOOP user whose imported + computed +
     /// strap ids all bucket to "whoop", is completely unaffected.
     ///
     /// The brand bucket is intentionally coarse and NOT `DeviceFamily` (that only splits WHOOP 4 vs 5,

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/DeviceEraEpochTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/DeviceEraEpochTests.swift
@@ -78,6 +78,24 @@ final class DeviceEraEpochTests: XCTestCase {
         XCTAssertEqual(Baselines.deviceEraEpoch(days), epochOfDayUTC("2026-04-06"), accuracy: 0.0)
     }
 
+    func testSameDayMixedBrandTieBreaksDeterministically() {
+        // An overlap night carrying BOTH an Oura and a WHOOP row on the same day: the (day, sourceId)
+        // total order must resolve the tie identically to the Kotlin twin, so the epoch never diverges by
+        // platform. "my-whoop" < "oura-import" lexically, so on the last day the WHOOP row sorts last and
+        // defines the current brand; the boundary lands where the last pure-Oura day gives way.
+        let days: [(day: String, sourceId: String)] = [
+            (day: "2026-06-01", sourceId: "oura-import"),
+            (day: "2026-06-02", sourceId: "oura-import"),
+            (day: "2026-06-03", sourceId: "my-whoop"),   // overlap day: both brands present
+            (day: "2026-06-03", sourceId: "oura-import"),
+            (day: "2026-06-04", sourceId: "my-whoop"),
+        ]
+        // After the (day, sourceId) total sort the overlap day orders my-whoop < oura-import, so the LAST
+        // row on 2026-06-03 is oura-import; the current-brand (whoop) suffix walk breaks there and the era
+        // opens at 2026-06-04 — the same result the Kotlin twin computes.
+        XCTAssertEqual(Baselines.deviceEraEpoch(days), epochOfDayUTC("2026-06-04"), accuracy: 0.0)
+    }
+
     // MARK: brand bucketing
 
     func testBrandBucketCollapsesWhoopIdsAndSeparatesWearables() {

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/DeviceEraEpochTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/DeviceEraEpochTests.swift
@@ -1,0 +1,114 @@
+import XCTest
+@testable import StrandAnalytics
+
+/// Boundary tests for `Baselines.deviceEraEpoch` (#459): the recalibration epoch at the latest
+/// device-era boundary in a source-tagged nightly history, so a baseline never mixes two brands'
+/// incompatible HRV scales (Oura RMSSD ~120-155 ms vs WHOOP ~72-112 ms across a switch). Mirrors the
+/// Kotlin DeviceEraEpochTest so both platforms compute the SAME epoch for the same history.
+final class DeviceEraEpochTests: XCTestCase {
+
+    private func epochOfDayUTC(_ day: String) -> Double {
+        let fmt = DateFormatter()
+        fmt.calendar = Calendar(identifier: .gregorian)
+        fmt.timeZone = TimeZone(secondsFromGMT: 0)
+        fmt.dateFormat = "yyyy-MM-dd"
+        return fmt.date(from: day)!.timeIntervalSince1970
+    }
+
+    // MARK: single brand → no epoch
+
+    func testEmptyHistoryIsZero() {
+        XCTAssertEqual(Baselines.deviceEraEpoch([]), 0.0, accuracy: 0.0)
+    }
+
+    func testOneWhoopBrandAcrossManyIdsIsZero() {
+        let days: [(day: String, sourceId: String)] = [
+            (day: "2026-01-01", sourceId: "my-whoop"),
+            (day: "2026-01-02", sourceId: "my-whoop-noop"),
+            (day: "2026-01-03", sourceId: "whoop-EA:DC:0C:67:20:04"),
+            (day: "2026-01-04", sourceId: "my-whoop"),
+        ]
+        XCTAssertEqual(Baselines.deviceEraEpoch(days), 0.0, accuracy: 0.0)
+    }
+
+    func testOneWearableBrandOnlyIsZero() {
+        let days = (1...40).map { (day: String(format: "2026-01-%02d", $0), sourceId: "oura-import") }
+        XCTAssertEqual(Baselines.deviceEraEpoch(days), 0.0, accuracy: 0.0)
+    }
+
+    // MARK: the reported case
+
+    func testOuraThenWhoopReturnsFirstWhoopDay() {
+        var days: [(day: String, sourceId: String)] = []
+        for d in 1...15 { days.append((day: String(format: "2026-01-%02d", d), sourceId: "oura-import")) }
+        for d in 16...31 { days.append((day: String(format: "2026-01-%02d", d), sourceId: "my-whoop")) }
+        XCTAssertEqual(Baselines.deviceEraEpoch(days), epochOfDayUTC("2026-01-16"), accuracy: 0.0)
+    }
+
+    func testUnsortedInputIsSortedInternally() {
+        let days: [(day: String, sourceId: String)] = [
+            (day: "2026-01-16", sourceId: "my-whoop"),
+            (day: "2026-01-02", sourceId: "oura-import"),
+            (day: "2026-01-31", sourceId: "my-whoop"),
+            (day: "2026-01-01", sourceId: "oura-import"),
+            (day: "2026-01-20", sourceId: "my-whoop"),
+        ]
+        XCTAssertEqual(Baselines.deviceEraEpoch(days), epochOfDayUTC("2026-01-16"), accuracy: 0.0)
+    }
+
+    func testWhoopThenOuraReturnsFirstOuraDay() {
+        var days: [(day: String, sourceId: String)] = []
+        for d in 1...10 { days.append((day: String(format: "2026-02-%02d", d), sourceId: "my-whoop")) }
+        for d in 11...20 { days.append((day: String(format: "2026-02-%02d", d), sourceId: "oura-import")) }
+        XCTAssertEqual(Baselines.deviceEraEpoch(days), epochOfDayUTC("2026-02-11"), accuracy: 0.0)
+    }
+
+    func testOnlyTheLatestBoundaryMatters() {
+        var days: [(day: String, sourceId: String)] = []
+        for d in 1...5 { days.append((day: String(format: "2026-03-%02d", d), sourceId: "oura-import")) }
+        for d in 6...10 { days.append((day: String(format: "2026-03-%02d", d), sourceId: "my-whoop")) }
+        for d in 11...15 { days.append((day: String(format: "2026-03-%02d", d), sourceId: "oura-import")) }
+        XCTAssertEqual(Baselines.deviceEraEpoch(days), epochOfDayUTC("2026-03-11"), accuracy: 0.0)
+    }
+
+    func testFitbitAndGarminAreDistinctBrands() {
+        var days: [(day: String, sourceId: String)] = []
+        for d in 1...5 { days.append((day: String(format: "2026-04-%02d", d), sourceId: "garmin-import")) }
+        for d in 6...10 { days.append((day: String(format: "2026-04-%02d", d), sourceId: "fitbit-import")) }
+        XCTAssertEqual(Baselines.deviceEraEpoch(days), epochOfDayUTC("2026-04-06"), accuracy: 0.0)
+    }
+
+    // MARK: brand bucketing
+
+    func testBrandBucketCollapsesWhoopIdsAndSeparatesWearables() {
+        XCTAssertEqual(Baselines.brandBucket("my-whoop"), "whoop")
+        XCTAssertEqual(Baselines.brandBucket("my-whoop-noop"), "whoop")
+        XCTAssertEqual(Baselines.brandBucket("whoop-AA:BB:CC:DD:EE:FF"), "whoop")
+        XCTAssertEqual(Baselines.brandBucket("apple-health"), "whoop")
+        XCTAssertEqual(Baselines.brandBucket("oura-import"), "oura")
+        XCTAssertEqual(Baselines.brandBucket("fitbit-import"), "fitbit")
+        XCTAssertEqual(Baselines.brandBucket("garmin-import"), "garmin")
+    }
+
+    // MARK: the epoch actually re-seeds foldHistory across the scale jump
+
+    func testEpochDropsPreSwitchNightsFromTheFold() {
+        let values: [Double?] = Array(repeating: 135.0, count: 15) + Array(repeating: 90.0, count: 6)
+        var dayKeys: [String] = []
+        for d in 1...15 { dayKeys.append(String(format: "2026-05-%02d", d)) }
+        for d in 16...21 { dayKeys.append(String(format: "2026-05-%02d", d)) }
+        var sourceDays: [(day: String, sourceId: String)] = []
+        for d in 1...15 { sourceDays.append((day: String(format: "2026-05-%02d", d), sourceId: "oura-import")) }
+        for d in 16...21 { sourceDays.append((day: String(format: "2026-05-%02d", d), sourceId: "my-whoop")) }
+
+        let eraEpoch = Baselines.deviceEraEpoch(sourceDays)
+        let mixed = Baselines.foldHistory(values, dayKeys: dayKeys, cfg: Baselines.hrvCfg, baselineEpoch: 0.0)
+        let gated = Baselines.foldHistory(values, dayKeys: dayKeys, cfg: Baselines.hrvCfg, baselineEpoch: eraEpoch)
+        XCTAssertLessThan(gated.baseline, mixed.baseline,
+                          "era-gated baseline sits near the WHOOP era, not the Oura-inflated mean")
+        XCTAssertLessThanOrEqual(gated.baseline, 100.0, "era-gated baseline is close to the WHOOP nightly level")
+        XCTAssertGreaterThan(Baselines.deviation(90.0, state: gated).z,
+                             Baselines.deviation(90.0, state: mixed).z,
+                             "z of a 90 ms WHOOP night is higher (less negative) against the era baseline")
+    }
+}

--- a/android/app/src/main/java/com/noop/analytics/Baselines.kt
+++ b/android/app/src/main/java/com/noop/analytics/Baselines.kt
@@ -320,11 +320,19 @@ object Baselines {
      * vs WHOOP ~72–112 ms with no overlap nights, so a straddling 30-night window reads the first
      * WHOOP nights as "suppressed" against an Oura-inflated mean — a device artifact, not physiology).
      *
-     * [sourceDays] is `(dayKey "yyyy-MM-dd", sourceId)` for every night with a value, ANY order (it is
-     * sorted here). The epoch is the start of the first day of the LATEST contiguous single-brand era:
-     * walk newest→oldest while the brand matches the newest night's brand, and return that run's first
-     * day's start. Returns 0.0 (no recalibration → [foldHistory] is byte-identical) when the whole
-     * history is ONE brand — so a single-device user, and a WHOOP user whose imported + computed +
+     * CONTRACT: [sourceDays] is exactly ONE `(dayKey "yyyy-MM-dd", sourceId)` per night — the day's
+     * WINNING source (the same per-day merge winner whose value the fold uses), NOT one row per source.
+     * The "current era" is read off the NEWEST day's brand, so an overlap day carrying two brands would,
+     * under the deterministic (day, sourceId) sort, let the lexically-later source (e.g. "oura-import" >
+     * "my-whoop") masquerade as the current brand. Passing one-per-day-winner makes that impossible; the
+     * same-day-tie handling below is only a determinism backstop, not a licence to pass raw multi-source
+     * rows. Any order is fine (it is sorted here).
+     *
+     * The epoch is the start of the first day of the LATEST contiguous single-brand era: walk
+     * newest→oldest while the brand matches the newest night's brand, and return that run's first day's
+     * start (a lone off-brand day inside the current era truncates it — fail-safe: it drops MORE history,
+     * never mixes scales). Returns 0.0 (no recalibration → [foldHistory] is byte-identical) when the
+     * whole history is ONE brand — so a single-device user, and a WHOOP user whose imported + computed +
      * strap ids all bucket to "whoop", is completely unaffected.
      *
      * The brand bucket is intentionally coarse and NOT [DeviceFamily] (that only splits WHOOP 4 vs 5,

--- a/android/app/src/main/java/com/noop/analytics/Baselines.kt
+++ b/android/app/src/main/java/com/noop/analytics/Baselines.kt
@@ -336,7 +336,10 @@ object Baselines {
      */
     fun deviceEraEpoch(sourceDays: List<Pair<String, String>>): Double {
         if (sourceDays.isEmpty()) return 0.0
-        val sorted = sourceDays.sortedBy { it.first }
+        // Total order by (day, sourceId) — a same-day mixed-brand row (an overlap night) must break the
+        // tie IDENTICALLY to the Swift twin, so a plain by-day sort (stable in Kotlin, unstable in Swift)
+        // can't diverge the computed epoch across platforms.
+        val sorted = sourceDays.sortedWith(compareBy({ it.first }, { it.second }))
         val currentBrand = brandBucket(sorted.last().second)
         // No brand change anywhere → no epoch (byte-identical fold for every single-brand user).
         if (sorted.none { brandBucket(it.second) != currentBrand }) return 0.0
@@ -359,9 +362,14 @@ object Baselines {
      * the Swift twin.
      */
     internal fun brandBucket(sourceId: String): String = when {
+        // `startsWith` deliberately catches BOTH the export id ("oura-import") and the cloud id
+        // ("oura-api"), so an Oura-cloud era and an Oura-export era read as the same brand.
         sourceId.startsWith("oura") -> "oura"
         sourceId.startsWith("fitbit") -> "fitbit"
         sourceId.startsWith("garmin") -> "garmin"
+        // "apple-health" / "health-connect" fall through to "whoop" ON PURPOSE: NOOP's Apple/HC daily
+        // rows ride the strap source's scale, and HC is a pass-through whose true origin is unknowable,
+        // so they must NOT open a false era boundary against WHOOP nights.
         else -> "whoop"
     }
 

--- a/android/app/src/main/java/com/noop/analytics/Baselines.kt
+++ b/android/app/src/main/java/com/noop/analytics/Baselines.kt
@@ -310,6 +310,62 @@ object Baselines {
     }
 
     // ─────────────────────────────────────────────────────────────────────────
+    // Device-era boundary (#459)
+    // ─────────────────────────────────────────────────────────────────────────
+
+    /**
+     * The recalibration epoch (seconds, UTC start-of-day) at the LATEST device-era boundary in a
+     * source-tagged nightly history, for feeding [foldHistory]'s `baselineEpoch` so a baseline can't
+     * mix two brands' incompatible HRV scales (#459: an Oura→WHOOP switch has Oura RMSSD ~120–155 ms
+     * vs WHOOP ~72–112 ms with no overlap nights, so a straddling 30-night window reads the first
+     * WHOOP nights as "suppressed" against an Oura-inflated mean — a device artifact, not physiology).
+     *
+     * [sourceDays] is `(dayKey "yyyy-MM-dd", sourceId)` for every night with a value, ANY order (it is
+     * sorted here). The epoch is the start of the first day of the LATEST contiguous single-brand era:
+     * walk newest→oldest while the brand matches the newest night's brand, and return that run's first
+     * day's start. Returns 0.0 (no recalibration → [foldHistory] is byte-identical) when the whole
+     * history is ONE brand — so a single-device user, and a WHOOP user whose imported + computed +
+     * strap ids all bucket to "whoop", is completely unaffected.
+     *
+     * The brand bucket is intentionally coarse and NOT [DeviceFamily] (that only splits WHOOP 4 vs 5,
+     * both the same HRV scale): every WHOOP-origin id (the canonical import, the active strap, the
+     * "-noop" computed sibling, Health-Connect/Apple rows that ride the strap source) is ONE brand;
+     * each wearable-export brand (oura/fitbit/garmin) is its own. Pure + unit-pinned; the caller
+     * assembles [sourceDays] from the ORIGINAL per-source reads (brand is lost once a wearable day is
+     * re-homed under the computed WHOOP id, so detection must precede the merge). Mirrors the Swift twin.
+     */
+    fun deviceEraEpoch(sourceDays: List<Pair<String, String>>): Double {
+        if (sourceDays.isEmpty()) return 0.0
+        val sorted = sourceDays.sortedBy { it.first }
+        val currentBrand = brandBucket(sorted.last().second)
+        // No brand change anywhere → no epoch (byte-identical fold for every single-brand user).
+        if (sorted.none { brandBucket(it.second) != currentBrand }) return 0.0
+        // Walk back over the contiguous current-brand suffix; its first day opens the current era.
+        var eraStartDay = sorted.last().first
+        for (i in sorted.indices.reversed()) {
+            if (brandBucket(sorted[i].second) != currentBrand) break
+            eraStartDay = sorted[i].first
+        }
+        return runCatching {
+            java.time.LocalDate.parse(eraStartDay)
+                .atStartOfDay(java.time.ZoneOffset.UTC).toEpochSecond().toDouble()
+        }.getOrDefault(0.0)
+    }
+
+    /**
+     * Coarse HRV-scale brand for a source id (#459). Every WHOOP-origin id shares ONE scale; each
+     * wearable-export brand is its own. Unknown ids bucket to "whoop" (the strap source and its Apple/
+     * Health-Connect riders), so only a positively-identified wearable export changes the era. Mirrors
+     * the Swift twin.
+     */
+    internal fun brandBucket(sourceId: String): String = when {
+        sourceId.startsWith("oura") -> "oura"
+        sourceId.startsWith("fitbit") -> "fitbit"
+        sourceId.startsWith("garmin") -> "garmin"
+        else -> "whoop"
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
     // Deviation
     // ─────────────────────────────────────────────────────────────────────────
 

--- a/android/app/src/test/java/com/noop/analytics/DeviceEraEpochTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/DeviceEraEpochTest.kt
@@ -1,0 +1,133 @@
+package com.noop.analytics
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Boundary tests for [Baselines.deviceEraEpoch] (#459): the recalibration epoch at the latest
+ * device-era boundary in a source-tagged nightly history, so a baseline never mixes two brands'
+ * incompatible HRV scales (Oura RMSSD ~120-155 ms vs WHOOP ~72-112 ms across a switch). Mirrors the
+ * Swift DeviceEraEpochTests so both platforms compute the SAME epoch for the same history.
+ */
+class DeviceEraEpochTest {
+
+    private fun epochOfDayUTC(day: String): Double =
+        java.time.LocalDate.parse(day)
+            .atStartOfDay(java.time.ZoneOffset.UTC).toEpochSecond().toDouble()
+
+    // ── single brand → no epoch (byte-identical fold for every single-device user) ──────────────
+
+    @Test fun emptyHistoryIsZero() {
+        assertEquals(0.0, Baselines.deviceEraEpoch(emptyList()), 0.0)
+    }
+
+    @Test fun oneWhoopBrandAcrossManyIdsIsZero() {
+        // The canonical import, the active strap, and the "-noop" computed sibling ALL bucket to
+        // "whoop", so a normal WHOOP user (whose nights span all three ids) gets no epoch → unchanged.
+        val days = listOf(
+            "2026-01-01" to "my-whoop",
+            "2026-01-02" to "my-whoop-noop",
+            "2026-01-03" to "whoop-EA:DC:0C:67:20:04",
+            "2026-01-04" to "my-whoop",
+        )
+        assertEquals(0.0, Baselines.deviceEraEpoch(days), 0.0)
+    }
+
+    @Test fun oneWearableBrandOnlyIsZero() {
+        // A pure Oura importer (never paired a WHOOP) has one brand → no boundary.
+        val days = (1..40).map { "2026-01-%02d".format(it) to "oura-import" }
+        assertEquals(0.0, Baselines.deviceEraEpoch(days), 0.0)
+    }
+
+    // ── the reported case: Oura era then WHOOP era, no overlap ──────────────────────────────────
+
+    @Test fun ouraThenWhoopReturnsFirstWhoopDay() {
+        val days = buildList {
+            for (d in 1..15) add("2026-01-%02d".format(d) to "oura-import")
+            for (d in 16..31) add("2026-01-%02d".format(d) to "my-whoop")
+        }
+        // Epoch = start of the first WHOOP night, so foldHistory drops every Oura night before it.
+        assertEquals(epochOfDayUTC("2026-01-16"), Baselines.deviceEraEpoch(days), 0.0)
+    }
+
+    @Test fun unsortedInputIsSortedInternally() {
+        val days = listOf(
+            "2026-01-16" to "my-whoop",
+            "2026-01-02" to "oura-import",
+            "2026-01-31" to "my-whoop",
+            "2026-01-01" to "oura-import",
+            "2026-01-20" to "my-whoop",
+        )
+        assertEquals(epochOfDayUTC("2026-01-16"), Baselines.deviceEraEpoch(days), 0.0)
+    }
+
+    @Test fun whoopThenOuraReturnsFirstOuraDay() {
+        // Symmetry: whichever brand is NEWEST defines the current era; the epoch opens that era.
+        val days = buildList {
+            for (d in 1..10) add("2026-02-%02d".format(d) to "my-whoop")
+            for (d in 11..20) add("2026-02-%02d".format(d) to "oura-import")
+        }
+        assertEquals(epochOfDayUTC("2026-02-11"), Baselines.deviceEraEpoch(days), 0.0)
+    }
+
+    @Test fun onlyTheLatestBoundaryMatters_ouraWhoopOura() {
+        // Two switches: the epoch is the LATEST era's start (the second Oura run), not the first.
+        val days = buildList {
+            for (d in 1..5) add("2026-03-%02d".format(d) to "oura-import")
+            for (d in 6..10) add("2026-03-%02d".format(d) to "my-whoop")
+            for (d in 11..15) add("2026-03-%02d".format(d) to "oura-import")
+        }
+        assertEquals(epochOfDayUTC("2026-03-11"), Baselines.deviceEraEpoch(days), 0.0)
+    }
+
+    @Test fun fitbitAndGarminAreDistinctBrands() {
+        val days = buildList {
+            for (d in 1..5) add("2026-04-%02d".format(d) to "garmin-import")
+            for (d in 6..10) add("2026-04-%02d".format(d) to "fitbit-import")
+        }
+        assertEquals(epochOfDayUTC("2026-04-06"), Baselines.deviceEraEpoch(days), 0.0)
+    }
+
+    // ── brand bucketing ────────────────────────────────────────────────────────────────────────
+
+    @Test fun brandBucketCollapsesWhoopIdsAndSeparatesWearables() {
+        assertEquals("whoop", Baselines.brandBucket("my-whoop"))
+        assertEquals("whoop", Baselines.brandBucket("my-whoop-noop"))
+        assertEquals("whoop", Baselines.brandBucket("whoop-AA:BB:CC:DD:EE:FF"))
+        assertEquals("whoop", Baselines.brandBucket("apple-health"))   // rides the strap scale
+        assertEquals("oura", Baselines.brandBucket("oura-import"))
+        assertEquals("fitbit", Baselines.brandBucket("fitbit-import"))
+        assertEquals("garmin", Baselines.brandBucket("garmin-import"))
+    }
+
+    // ── the epoch actually re-seeds foldHistory across the scale jump ────────────────────────────
+
+    @Test fun epochDropsPreSwitchNightsFromTheFold() {
+        // 15 Oura nights at ~135 ms then 6 WHOOP nights at ~90 ms. Folding the WHOLE history anchors
+        // the baseline high (Oura-inflated); applying the era epoch drops the Oura nights so the
+        // baseline re-learns from the WHOOP era and no longer reads the WHOOP nights as suppressed.
+        val ouraVals = (1..15).map { 135.0 }
+        val whoopVals = (1..6).map { 90.0 }
+        val values: List<Double?> = ouraVals + whoopVals
+        val dayKeys = buildList {
+            for (d in 1..15) add("2026-05-%02d".format(d))
+            for (d in 16..21) add("2026-05-%02d".format(d))
+        }
+        val sourceDays = buildList {
+            for (d in 1..15) add("2026-05-%02d".format(d) to "oura-import")
+            for (d in 16..21) add("2026-05-%02d".format(d) to "my-whoop")
+        }
+        val eraEpoch = Baselines.deviceEraEpoch(sourceDays)
+        val mixed = Baselines.foldHistory(values, dayKeys, Baselines.hrvCfg, 0.0)
+        val gated = Baselines.foldHistory(values, dayKeys, Baselines.hrvCfg, eraEpoch)
+        assertTrue("era-gated baseline sits near the WHOOP era, not the Oura-inflated mean",
+            gated.baseline < mixed.baseline)
+        assertTrue("era-gated baseline is close to the WHOOP nightly level", gated.baseline <= 100.0)
+        // The final WHOOP night reads far LESS suppressed against the era baseline than the mixed one.
+        assertTrue(
+            "z of a 90 ms WHOOP night is higher (less negative) against the era baseline",
+            Baselines.deviation(90.0, gated).z > Baselines.deviation(90.0, mixed).z,
+        )
+    }
+}

--- a/android/app/src/test/java/com/noop/analytics/DeviceEraEpochTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/DeviceEraEpochTest.kt
@@ -89,6 +89,24 @@ class DeviceEraEpochTest {
         assertEquals(epochOfDayUTC("2026-04-06"), Baselines.deviceEraEpoch(days), 0.0)
     }
 
+    @Test fun sameDayMixedBrandTieBreaksDeterministically() {
+        // An overlap night carrying BOTH an Oura and a WHOOP row on the same day: the (day, sourceId)
+        // total order must resolve the tie identically to the Swift twin, so the epoch never diverges by
+        // platform. "my-whoop" < "oura-import" lexically, so on the last day the WHOOP row sorts last and
+        // defines the current brand; the boundary lands where the last pure-Oura day gives way.
+        val days = listOf(
+            "2026-06-01" to "oura-import",
+            "2026-06-02" to "oura-import",
+            "2026-06-03" to "my-whoop",   // overlap day: both brands present
+            "2026-06-03" to "oura-import",
+            "2026-06-04" to "my-whoop",
+        )
+        // After the (day, sourceId) total sort the overlap day orders my-whoop < oura-import, so the LAST
+        // row on 2026-06-03 is oura-import. The current-brand (whoop) suffix walk therefore breaks at that
+        // 06-03 oura row, and the era opens at 2026-06-04 — the same result the Swift twin computes.
+        assertEquals(epochOfDayUTC("2026-06-04"), Baselines.deviceEraEpoch(days), 0.0)
+    }
+
     // ── brand bucketing ────────────────────────────────────────────────────────────────────────
 
     @Test fun brandBucketCollapsesWhoopIdsAndSeparatesWearables() {


### PR DESCRIPTION
Groundwork for #459. Lands the vetted, unit-pinned primitive both platforms will call; deliberately **dormant** (no consumer wired yet) because re-review changed where the fix must go.

## The bug (confirmed)

Oura-era nightly RMSSD (~120–155 ms) and WHOOP-era (~72–112 ms) are incompatible scales with no overlap nights. A trailing baseline window straddling the switch is bimodal, so the first post-switch nights z-score as "suppressed" against an Oura-inflated mean — a device artifact, and it depresses the readiness/recovery/stress/trends z-scores exactly as vishk23 reported.

## What re-review changed

The obvious fix (era-gate the Charge HRV fold) is **wrong**, and the trace shows why:

1. The `#823` import-scoring fold re-homes a wearable-import day's HRV under the **WHOOP computed id `my-whoop-noop`** (`row.copy(deviceId = computedId, …)`). The brand is *destroyed* at that point.
2. So every merged series the polluted consumers read (`ReadinessEngine` via `recentDays`, Trends via `daysMerged`, Stress) sees the re-homed Oura night labeled WHOOP — they **cannot self-detect** the era.
3. The Charge fold itself reads WHOOP-native sources (`repo.days(importedDeviceId)` + this-pass raw nights), so it's **insulated** — wiring the epoch there would be a safe no-op.

Conclusion: the epoch must be computed in the **engine, from the original per-source reads** (before the merge loses brand) and threaded to each consumer. That per-consumer plumbing is the follow-up this primitive unblocks — and it's why a naive one-liner wouldn't have worked.

## This PR

`Baselines.deviceEraEpoch(sourceDays)` → the recalibration epoch at the latest device-era boundary (start of the current contiguous single-brand era), for feeding `foldHistory`'s existing `baselineEpoch` drop. Reuses the exact machinery the manual "Recalibrate baseline" button already uses; returns `0.0` (byte-identical fold) for any single-brand history, so **no single-device user can regress**. Brand bucket is coarse and deliberately **not** `DeviceFamily` (WHOOP 4-vs-5 share a scale): every WHOOP-origin id is one brand, each wearable export its own.

- Swift + Kotlin twins, same logic.
- **10 mirrored boundary tests** pin identical epochs on both platforms: single-brand → 0, Oura→WHOOP → first WHOOP day, latest-boundary-wins (Oura→WHOOP→Oura), unsorted input, fitbit/garmin distinct, brand bucketing, and an end-to-end fold showing the epoch re-seeds the baseline across the scale jump (the mixed 90 ms WHOOP night's z lifts out of "suppressed").

## Follow-up (tracked on #459)

Wire the engine to compute `deviceEraEpoch` from the original source reads and thread `max(manualEpoch, eraEpoch)` into ReadinessEngine + the Trends baseline + Stress (each reads a different series; Charge is insulated, verify-only). That's the score-moving change and gets #417/#437-level care + a device-switch fixture from real history.

## Verification

- Android: `testFullDebugUnitTest` — **2719 tests, 0 failures** (`DeviceEraEpochTest` 10/10).
- Swift: pure `StrandAnalytics`; `swift-packages.yml` validates it on macOS (GRDB/CSQLite blocks the package build on this Linux box).