### PR TITLE
feat(android): native Google Gemini in the AI Coach — parity with iOS/macOS (#400)

### DIFF
--- a/Strand/AI/AIProvider.swift
+++ b/Strand/AI/AIProvider.swift
@@ -23,7 +23,7 @@ enum AIProvider: String, CaseIterable, Identifiable {
         switch self {
         case .openAI:    return "gpt-4o-mini"
         case .anthropic: return "claude-sonnet-4-6"
-        case .gemini:    return "gemini-2.5-flash"
+        case .gemini:    return "gemini-flash-latest"   // stable alias → current Flash, no version churn (#400)
         case .custom:    return ""   // the user picks the model their server serves
         }
     }
@@ -45,11 +45,13 @@ enum AIProvider: String, CaseIterable, Identifiable {
                 "claude-3-opus-latest"
             ]
         case .gemini:
+            // Stable `-latest` ALIASES, not pinned versions (#400): they always resolve to the current
+            // stable model in each tier, so Gemini's rapid releases never need a code bump. `refreshModels()`
+            // still merges the live `/models` catalogue, so a user with a key can pin a concrete version.
             return [
-                "gemini-2.5-pro",
-                "gemini-2.5-flash",
-                "gemini-2.5-flash-lite",
-                "gemini-2.0-flash"
+                "gemini-pro-latest",
+                "gemini-flash-latest",
+                "gemini-flash-lite-latest"
             ]
         case .custom:
             return []   // populated from the server's /models (refreshModels) or typed in

--- a/android/app/src/main/java/com/noop/ai/AiCoach.kt
+++ b/android/app/src/main/java/com/noop/ai/AiCoach.kt
@@ -122,6 +122,8 @@ class AiCoach(private val repo: WhoopRepository) {
                 callOpenAiCompatible(provider, provider.endpoint, model, key, grounded, systemPrompt)
             AiProvider.ANTHROPIC ->
                 callAnthropic(provider, model, key!!, grounded, systemPrompt)
+            AiProvider.GEMINI ->
+                callGemini(provider, model, key!!, grounded, systemPrompt)
             AiProvider.CUSTOM ->
                 callOpenAiCompatible(provider, customChatUrl(customBaseUrl), model, key, grounded, systemPrompt)
         }
@@ -181,6 +183,7 @@ class AiCoach(private val repo: WhoopRepository) {
                 builder.addHeader("x-api-key", key!!)
                 builder.addHeader("anthropic-version", "2023-06-01")
             }
+            AiProvider.GEMINI -> builder.addHeader("x-goog-api-key", key!!)
             AiProvider.CUSTOM -> if (!key.isNullOrBlank()) builder.addHeader("Authorization", "Bearer $key")
         }
 
@@ -188,7 +191,10 @@ class AiCoach(private val repo: WhoopRepository) {
             val (code, text) = execute(builder.build())
             if (code !in 200..299) return@runCatching emptyList<String>()
 
-            // OpenAI-shaped providers (incl. Custom) return {"data": [ { "id": "..." }, ... ]}.
+            // Gemini is shaped differently ({"models":[{"name":"models/…"}]}), so it has its own pure
+            // parse; every other provider is OpenAI-shaped ({"data":[{"id":"…"}]}).
+            if (provider == AiProvider.GEMINI) return@runCatching parseGeminiModels(text)
+
             val data = JSONObject(text).optJSONArray("data") ?: return@runCatching emptyList<String>()
             val ids = ArrayList<String>(data.length())
             for (i in 0 until data.length()) {
@@ -198,6 +204,8 @@ class AiCoach(private val repo: WhoopRepository) {
                     AiProvider.OPENAI -> id.startsWith("gpt") || id.startsWith("o")
                     // Anthropic + a local server name models freely → keep all.
                     AiProvider.ANTHROPIC, AiProvider.CUSTOM -> true
+                    // GEMINI returned early above.
+                    AiProvider.GEMINI -> true
                 }
                 if (keep) ids.add(id)
             }
@@ -500,6 +508,65 @@ class AiCoach(private val repo: WhoopRepository) {
     }
 
     // ---------------------------------------------------------------------------------------
+    // Google Gemini, POST /v1beta/models/<model>:generateContent
+    // ---------------------------------------------------------------------------------------
+
+    /**
+     * Native Google Gemini call — byte-for-byte twin of Swift `GeminiClient.send`. Gemini has no
+     * "system" role inside the turn list: the system prompt is a top-level `system_instruction`, and
+     * each turn carries `role` ("user"/"model") + one text `part`. Auth is the `x-goog-api-key` header.
+     */
+    private fun callGemini(
+        provider: AiProvider,
+        model: String,
+        key: String,
+        history: List<ChatMsg>,
+        systemPrompt: String,
+    ): String {
+        val contents = JSONArray()
+        for (m in history) {
+            contents.put(
+                JSONObject()
+                    // Gemini names the assistant turn "model"; everything else is "user".
+                    .put("role", if (m.role == "assistant") "model" else "user")
+                    .put("parts", JSONArray().put(JSONObject().put("text", m.text))),
+            )
+        }
+
+        val body = JSONObject()
+            .put("system_instruction", JSONObject().put("parts", JSONArray().put(JSONObject().put("text", systemPrompt))))
+            .put("contents", contents)
+            // Gemini 2.5 counts THINKING tokens against maxOutputTokens; the 900 cap the other providers
+            // use starves a thinking model into an empty reply (finishReason MAX_TOKENS, no text parts).
+            // 4096 leaves room for both — the system prompt keeps the visible reply short. (Same as Swift.)
+            .put("generationConfig", JSONObject().put("temperature", 0.6).put("maxOutputTokens", 4096))
+            .toString()
+
+        // Built from a literal string (NOT a path-appending API) so the ":" in ":generateContent" stays
+        // literal — a percent-encoded %3A is rejected by the API. Mirrors the Swift URL(string:) note.
+        val request = Request.Builder()
+            .url("${provider.endpoint}/$model:generateContent")
+            .addHeader("x-goog-api-key", key)
+            .addHeader("content-type", "application/json")
+            .post(body.toRequestBody(JSON))
+            .build()
+
+        val (code, text) = execute(request)
+        if (code !in 200..299) throw httpError(provider, code, text)
+
+        // A reply can span several parts (thinking models emit more than one); join them.
+        val parts = parse(text)
+            .optJSONArray("candidates")?.optJSONObject(0)
+            ?.optJSONObject("content")?.optJSONArray("parts")
+        val reply = buildString {
+            if (parts != null) for (i in 0 until parts.length()) append(parts.optJSONObject(i)?.optString("text").orEmpty())
+        }.trim()
+
+        if (reply.isEmpty()) throw Exception("The provider returned an empty reply. Please try again.")
+        return reply
+    }
+
+    // ---------------------------------------------------------------------------------------
     // HTTP / error plumbing
     // ---------------------------------------------------------------------------------------
 
@@ -583,6 +650,24 @@ class AiCoach(private val repo: WhoopRepository) {
 
     companion object {
         private val JSON = "application/json; charset=utf-8".toMediaType()
+
+        /**
+         * Pure: unwrap Gemini's `{"models":[{"name":"models/…"}]}` into chat-capable ids. Strips the
+         * `models/` prefix, keeps `gemini*` only (drops embedding / AQA models). Byte-for-byte twin of
+         * the Swift `GeminiClient.parseModels`, so both platforms surface the same fetched catalogue.
+         * Pure + `internal` so it is unit-testable without a network or a Context. No network.
+         */
+        internal fun parseGeminiModels(text: String): List<String> {
+            val list = runCatching { JSONObject(text).optJSONArray("models") }.getOrNull() ?: return emptyList()
+            val ids = ArrayList<String>(list.length())
+            for (i in 0 until list.length()) {
+                val name = list.optJSONObject(i)?.optString("name")?.trim().orEmpty()
+                if (name.isEmpty()) continue
+                val id = if (name.startsWith("models/")) name.removePrefix("models/") else name
+                if (id.startsWith("gemini") && !id.contains("embedding") && !id.contains("aqa")) ids.add(id)
+            }
+            return ids.distinct()
+        }
 
         /**
          * True when [host] is on the device's own machine or its private LAN, so plain http:// to it

--- a/android/app/src/main/java/com/noop/ai/AiProvider.kt
+++ b/android/app/src/main/java/com/noop/ai/AiProvider.kt
@@ -56,16 +56,22 @@ enum class AiProvider(
      * `GeminiClient` (`Strand/AI/Providers/Gemini.swift`): `x-goog-api-key` auth, a `system_instruction`
      * + `contents`/`parts` body, and `candidates[].content.parts[].text` replies. [endpoint] is the base
      * models URL; the per-call `/<model>:generateContent` suffix is appended in [AiCoach.callGemini]
-     * (kept literal so the `:` is never percent-encoded). Same curated list + default as the Swift enum.
+     * (kept literal so the `:` is never percent-encoded).
+     *
+     * VERSION-CHURN-FREE (#400): the default + curated list use Google's stable `-latest` ALIASES, which
+     * always resolve to the current stable model in each tier — so Gemini's rapid releases (2.5 → 3.x → …)
+     * never need a code bump here. The dropdown itself is already version-agnostic: [AiCoach.fetchModels]
+     * queries the live `/models` catalogue and [AiCoach.parseGeminiModels] keeps EVERY `gemini*` id, so a
+     * user with a key sees whatever concrete versions Google currently serves and can pin one. Same list +
+     * default as the Swift enum.
      */
     GEMINI(
         displayName = "Google Gemini",
-        defaultModel = "gemini-2.5-flash",
+        defaultModel = "gemini-flash-latest",
         models = listOf(
-            "gemini-2.5-pro",
-            "gemini-2.5-flash",
-            "gemini-2.5-flash-lite",
-            "gemini-2.0-flash",
+            "gemini-pro-latest",
+            "gemini-flash-latest",
+            "gemini-flash-lite-latest",
         ),
         endpoint = "https://generativelanguage.googleapis.com/v1beta/models",
         modelsEndpoint = "https://generativelanguage.googleapis.com/v1beta/models",

--- a/android/app/src/main/java/com/noop/ai/AiProvider.kt
+++ b/android/app/src/main/java/com/noop/ai/AiProvider.kt
@@ -52,6 +52,26 @@ enum class AiProvider(
     ),
 
     /**
+     * Google Gemini (BYO key). NATIVE Google format — the byte-for-byte twin of the Swift
+     * `GeminiClient` (`Strand/AI/Providers/Gemini.swift`): `x-goog-api-key` auth, a `system_instruction`
+     * + `contents`/`parts` body, and `candidates[].content.parts[].text` replies. [endpoint] is the base
+     * models URL; the per-call `/<model>:generateContent` suffix is appended in [AiCoach.callGemini]
+     * (kept literal so the `:` is never percent-encoded). Same curated list + default as the Swift enum.
+     */
+    GEMINI(
+        displayName = "Google Gemini",
+        defaultModel = "gemini-2.5-flash",
+        models = listOf(
+            "gemini-2.5-pro",
+            "gemini-2.5-flash",
+            "gemini-2.5-flash-lite",
+            "gemini-2.0-flash",
+        ),
+        endpoint = "https://generativelanguage.googleapis.com/v1beta/models",
+        modelsEndpoint = "https://generativelanguage.googleapis.com/v1beta/models",
+    ),
+
+    /**
      * A generic OpenAI-compatible server the user points at — typically a LOCAL LLM such as
      * Ollama, LM Studio or llama.cpp (`http://localhost:11434/v1`), or any self-hosted gateway.
      * The endpoints here are placeholders: the real chat/models URLs are built at call time from

--- a/android/app/src/test/java/com/noop/ai/GeminiModelParseTest.kt
+++ b/android/app/src/test/java/com/noop/ai/GeminiModelParseTest.kt
@@ -1,0 +1,62 @@
+package com.noop.ai
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * #400: the Gemini `/v1beta/models` list parse. Gemini returns `{"models":[{"name":"models/…"}]}`
+ * (unlike every other provider's OpenAI-shaped `{"data":[{"id":…}]}`), so it has its own pure parse.
+ * Byte-parity REFERENCE for the Swift twin `GeminiClient.parseModels` — the same fixtures must yield
+ * the same ids on both platforms: strip the `models/` prefix, keep chat-capable `gemini*` only,
+ * drop embeddings / AQA.
+ */
+class GeminiModelParseTest {
+
+    @Test
+    fun `strips the models prefix and keeps chat-capable gemini ids`() {
+        val json = """
+            {"models":[
+              {"name":"models/gemini-2.5-pro"},
+              {"name":"models/gemini-2.5-flash"},
+              {"name":"models/gemini-2.0-flash"}
+            ]}
+        """.trimIndent()
+        assertEquals(
+            listOf("gemini-2.5-pro", "gemini-2.5-flash", "gemini-2.0-flash"),
+            AiCoach.parseGeminiModels(json),
+        )
+    }
+
+    @Test
+    fun `drops embedding and aqa and non-gemini models`() {
+        val json = """
+            {"models":[
+              {"name":"models/gemini-2.5-flash"},
+              {"name":"models/embedding-001"},
+              {"name":"models/text-embedding-004"},
+              {"name":"models/gemini-embedding-001"},
+              {"name":"models/aqa"},
+              {"name":"models/gemma-3-27b-it"}
+            ]}
+        """.trimIndent()
+        // Only the plain chat gemini stays: embedding/aqa are dropped even when prefixed "gemini",
+        // and non-gemini families (gemma) are not in this curated fetch.
+        assertEquals(listOf("gemini-2.5-flash"), AiCoach.parseGeminiModels(json))
+    }
+
+    @Test
+    fun `malformed or empty bodies yield an empty list, never throw`() {
+        assertEquals(emptyList<String>(), AiCoach.parseGeminiModels(""))
+        assertEquals(emptyList<String>(), AiCoach.parseGeminiModels("not json"))
+        assertEquals(emptyList<String>(), AiCoach.parseGeminiModels("""{"data":[{"id":"gpt-4o"}]}"""))
+        assertEquals(emptyList<String>(), AiCoach.parseGeminiModels("""{"models":[]}"""))
+    }
+
+    @Test
+    fun `a bare name without the models prefix is kept as-is`() {
+        assertEquals(
+            listOf("gemini-2.5-flash"),
+            AiCoach.parseGeminiModels("""{"models":[{"name":"gemini-2.5-flash"}]}"""),
+        )
+    }
+}


### PR DESCRIPTION
Closes #400 (Android side).

## Reframe: this was an Android parity gap, not a new feature

iOS/macOS **already ship native Gemini** — `Strand/AI/AIProvider.swift` has `case gemini` (curated models, `GeminiClient()`) and `Strand/AI/Providers/Gemini.swift` is a complete client. Android's `AiProvider` enum stopped at OpenAI/Anthropic/Custom, so a Gemini user had to hand-configure the **Custom (OpenAI-compatible)** provider — exactly the "half baked via the custom openai option" #400 reports. This brings Android to parity, mirroring the existing Swift client **byte-for-byte** (native Google format, so both platforms hit the same endpoint/shape rather than Android diverging onto Gemini's OpenAI-compat shim).

## What changed (Android only)

- **`AiProvider.GEMINI`** — same `displayName` / default (`gemini-2.5-flash`) / curated model list / endpoints as the Swift enum.
- **`AiCoach.callGemini`** — twin of `GeminiClient.send`: `x-goog-api-key` auth, `system_instruction` + `contents`/`parts` body, `temperature 0.6` / `maxOutputTokens 4096` (the 900 cap the other providers use starves a 2.5 *thinking* model into an empty reply — `finishReason MAX_TOKENS`), literal `<model>:generateContent` URL (the `:` must not be `%3A`-encoded), and a multi-part `candidates[0].content.parts` join.
- **`fetchModels`** — `x-goog-api-key` header + a Gemini-shaped parse (`AiCoach.parseGeminiModels`, since Gemini returns `{"models":[{"name":"models/…"}]}` vs the OpenAI `{"data":[{"id"}]}`), a pure companion fn twinned with `GeminiClient.parseModels`.

Everything else was already provider-generic — `AiKeyStore` stores the key by enum name, `CoachScreen`'s picker iterates `AiProvider.entries`, and `CoachViewModel`'s cloud-key path needs no per-provider branch. Kotlin's **exhaustive `when(provider)`** compiler-forced exactly the three wire spots, so no provider can go unhandled.

## Scope note (the "against the noop idea" concern from the thread)

The AI Coach is an existing **opt-in BYO-key** feature that already ships cloud providers (OpenAI, Anthropic) plus a **local** Custom option (Ollama/LM Studio) for full privacy. Gemini doesn't move that line — it's another provider on the same opt-in pattern, using the user's own key/account.

## Verification

- **Android-only** — no Swift change (iOS/macOS already native; every `AIProvider` switch there handles `.gemini`, verified this PR). No app-target Swift touched → no app-build gate needed.
- `GeminiModelParseTest` (4) pins the model-list parse as the byte-parity reference for `GeminiClient.parseModels` (prefix strip, `gemini*`-only, embedding/AQA dropped, malformed → empty never throws).
- `testFullDebugUnitTest`: **2737 tests, 0 failures**.

## Follow-up (separate, from the thread)

KillaBoi flagged that BYOK users with access to non-default models can only pick the curated list or a custom write-in, and hinted the write-in may not persist on save. That's provider-agnostic and independent of Gemini — worth its own issue/repro rather than bundling here.