### PR TITLE
feat(android): 'Keep NOOP alive overnight' toggle — battery-whitelist against OEM background kill (#386)

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -69,6 +69,10 @@
     <uses-permission android:name="android.permission.USE_EXACT_ALARM" />
     <!-- Re-arm the guaranteed alarm after a reboot so an overnight restart can't silently drop it. -->
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
+    <!-- Sideload-only (Play restricts this; NOOP doesn't ship there): the Settings "Keep NOOP alive
+         overnight" toggle uses it to pop the one-tap battery-optimisation whitelist dialog, so the
+         overnight foreground service + 15-min re-score tick aren't killed on aggressive-OEM phones (#386). -->
+    <uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS" />
     <!-- Promote the fired alarm to a true full-screen wake on a locked screen (Android 14+ gates the
          full-screen-intent path behind this; CATEGORY_ALARM is an allowed use. Without it the alarm
          still sounds as a high-priority heads-up, but the lock-screen takeover is downgraded). -->

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -122,6 +122,16 @@
         <!-- So the connection helper can detect the official WHOOP app and deep-link to its
              info screen (a strap only pairs with one app at a time). Android 11+ visibility. -->
         <package android:name="com.whoop.android" />
+        <!-- #386: OEM security-centre packages, so BackgroundHealth.oemAutostartIntent's
+             resolveActivity can SEE their auto-start screens under Android 11+ package-visibility
+             filtering (targetSdk 34) — without these the deep-link would silently never resolve on
+             exactly the aggressive-OEM phones (Xiaomi/Oppo/Vivo/Huawei/Meizu) that need it. -->
+        <package android:name="com.miui.securitycenter" />
+        <package android:name="com.coloros.safecenter" />
+        <package android:name="com.oppo.safe" />
+        <package android:name="com.vivo.permissionmanager" />
+        <package android:name="com.huawei.systemmanager" />
+        <package android:name="com.meizu.safe" />
     </queries>
 
     <application

--- a/android/app/src/main/java/com/noop/ble/BackgroundHealth.kt
+++ b/android/app/src/main/java/com/noop/ble/BackgroundHealth.kt
@@ -1,0 +1,91 @@
+package com.noop.ble
+
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import android.os.Build
+import android.os.PowerManager
+import android.provider.Settings
+
+/**
+ * Android background-survival helpers (#386). NOOP already runs a foreground service + exact alarms,
+ * but aggressive OEM battery managers kill even those, so the reliable lever is a USER action:
+ * whitelist NOOP from battery optimisation (and, on the worst vendors, enable auto-start). This
+ * centralises the detection and the intents that fix it, so the Settings "Keep NOOP alive overnight"
+ * toggle and the Test Centre diagnostics share ONE source of truth for the vendor set + exempt check.
+ *
+ * POPUP DISCIPLINE: nothing here ever fires a system dialog on its own. [batteryExemptionIntent] and
+ * [oemAutostartIntent] only build Intents — the caller starts one exactly when the user taps, and the
+ * toggle reflects live [isBatteryExempt] state so an already-exempt user is never prompted again.
+ *
+ * The whitelist adds NO battery cost of its own: it removes a premature kill, it does not add work.
+ * The real cost is the existing "Keep connected in the background" / "Continuous HRV" / "Overnight only"
+ * toggles; this only makes the overnight work the user already enabled actually survive the night.
+ */
+object BackgroundHealth {
+
+    /**
+     * Manufacturers whose proprietary battery managers kill background work regardless of the AOSP
+     * foreground-service contract (the dontkillmyapp.com set). ONE canonical list — [AndroidDiagnostics]
+     * and the Settings toggle both read it here so the two can never drift. Pure.
+     */
+    val AGGRESSIVE_VENDORS: List<String> =
+        listOf("xiaomi", "oppo", "vivo", "huawei", "oneplus", "realme", "meizu")
+
+    /** True when [manufacturer] is one whose ROM aggressively kills background apps. Pure + Context-free
+     *  so it unit-tests without Robolectric. Defaults to this device's manufacturer. */
+    fun isAggressiveVendor(manufacturer: String = Build.MANUFACTURER): Boolean {
+        val m = manufacturer.lowercase()
+        return AGGRESSIVE_VENDORS.any { m.contains(it) }
+    }
+
+    /** True when NOOP is exempt from Doze / battery optimisation — the #1 predictor of overnight survival. */
+    fun isBatteryExempt(context: Context): Boolean =
+        (context.getSystemService(Context.POWER_SERVICE) as? PowerManager)
+            ?.isIgnoringBatteryOptimizations(context.packageName) == true
+
+    /**
+     * The one-tap system dialog to whitelist NOOP from battery optimisation. Sideload-only intent
+     * (Play restricts it; NOOP doesn't ship there). Build-only — the caller starts it on a user tap and
+     * falls back to [appBatterySettingsIntent] if a ROM hides this action.
+     */
+    fun batteryExemptionIntent(context: Context): Intent =
+        Intent(Settings.ACTION_REQUEST_IGNORE_BATTERY_OPTIMIZATIONS)
+            .setData(Uri.parse("package:${context.packageName}"))
+
+    /** Always-resolvable fallback: NOOP's per-app system settings page (Battery lives under it). */
+    fun appBatterySettingsIntent(context: Context): Intent =
+        Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS)
+            .setData(Uri.parse("package:${context.packageName}"))
+
+    /**
+     * Best-effort deep-link to the OEM's proprietary auto-start / protected-app screen — the setting the
+     * generic exemption can't reach on these ROMs. Component names DRIFT per ROM version, so each is tried
+     * with [packageManager.resolveActivity] and the first that resolves wins; null → the caller uses the
+     * generic battery screen. This is a SECOND, separate action (never chained onto the exemption dialog),
+     * so a single user tap never spawns two popups. Never throws.
+     */
+    fun oemAutostartIntent(context: Context): Intent? {
+        val m = Build.MANUFACTURER.lowercase()
+        val candidates: List<Pair<String, String>> = when {
+            m.contains("xiaomi") -> listOf(
+                "com.miui.securitycenter" to "com.miui.permcenter.autostart.AutoStartManagementActivity")
+            m.contains("oppo") || m.contains("realme") -> listOf(
+                "com.coloros.safecenter" to "com.coloros.safecenter.startupapp.StartupAppListActivity",
+                "com.oppo.safe" to "com.oppo.safe.permission.startup.StartupAppListActivity")
+            m.contains("vivo") -> listOf(
+                "com.vivo.permissionmanager" to "com.vivo.permissionmanager.activity.BgStartUpManagerActivity")
+            m.contains("huawei") -> listOf(
+                "com.huawei.systemmanager" to "com.huawei.systemmanager.startupmgr.ui.StartupNormalAppListActivity")
+            m.contains("meizu") -> listOf(
+                "com.meizu.safe" to "com.meizu.safe.permission.SmartBGActivity")
+            // OnePlus / recent OxygenOS honours the standard exemption → no dedicated screen.
+            else -> emptyList()
+        }
+        for ((pkg, cls) in candidates) {
+            val intent = Intent().setClassName(pkg, cls)
+            if (context.packageManager.resolveActivity(intent, 0) != null) return intent
+        }
+        return null
+    }
+}

--- a/android/app/src/main/java/com/noop/testcentre/AndroidDiagnostics.kt
+++ b/android/app/src/main/java/com/noop/testcentre/AndroidDiagnostics.kt
@@ -274,12 +274,12 @@ object AndroidDiagnostics {
 
     /** A coarse OEM-kill heuristic by manufacturer (the aggressive-background-kill vendors). Pure and
      *  internal so it unit-tests without a Context (the suite stays Robolectric-free). */
-    internal fun oemKillHeuristic(manufacturer: String): String {
-        val m = manufacturer.lowercase()
-        val aggressive = listOf("xiaomi", "oppo", "vivo", "huawei", "oneplus", "realme", "meizu")
-        return if (aggressive.any { m.contains(it) }) "aggressive vendor ($m), whitelist NOOP to keep it alive"
+    internal fun oemKillHeuristic(manufacturer: String): String =
+        // Single source of truth for the aggressive-vendor set (#386): the same list the Settings
+        // "Keep NOOP alive overnight" toggle gates on, so the diagnostic and the fix never disagree.
+        if (com.noop.ble.BackgroundHealth.isAggressiveVendor(manufacturer))
+            "aggressive vendor (${manufacturer.lowercase()}), whitelist NOOP to keep it alive"
         else "standard"
-    }
 
     /** Charging state from the sticky battery intent / BatteryManager. */
     private fun chargingText(context: Context): String = runCatching {

--- a/android/app/src/main/java/com/noop/ui/SettingsScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/SettingsScreen.kt
@@ -1347,10 +1347,15 @@ fun SettingsScreen(
                             // only ever REQUESTS it, and when already exempt the switch is inert (no re-prompt).
                             onCheckedChange = { wantOn ->
                                 if (wantOn && !batteryExempt) {
+                                    // The whole feature exists for ROMs that strip things — so the fallback
+                                    // is guarded too: if BOTH the exemption dialog and the app-settings page
+                                    // are missing, no-op rather than crash (the OEM link below is another path).
                                     runCatching {
                                         context.startActivity(com.noop.ble.BackgroundHealth.batteryExemptionIntent(context))
                                     }.onFailure {
-                                        context.startActivity(com.noop.ble.BackgroundHealth.appBatterySettingsIntent(context))
+                                        runCatching {
+                                            context.startActivity(com.noop.ble.BackgroundHealth.appBatterySettingsIntent(context))
+                                        }
                                     }
                                 }
                             },

--- a/android/app/src/main/java/com/noop/ui/SettingsScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/SettingsScreen.kt
@@ -73,6 +73,7 @@ import androidx.compose.material3.SwitchDefaults
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -92,6 +93,9 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.noop.BuildConfig
 import com.noop.analytics.Baselines
@@ -1277,7 +1281,23 @@ fun SettingsScreen(
                 // adds no battery cost of its own — it stops a premature kill; the real cost is the two
                 // toggles below.
                 if (backgroundConnection) {
-                    val batteryExempt = com.noop.ble.BackgroundHealth.isBatteryExempt(context)
+                    // Re-read the LIVE exempt state on every ON_RESUME so the toggle flips to on the moment
+                    // the user returns from the system whitelist dialog. Reading it plainly in composition
+                    // wouldn't recompose on resume — it'd show a stale "off", look like it failed, and invite
+                    // a SECOND (duplicate) popup, defeating the popup discipline.
+                    val lifecycleOwner = LocalLifecycleOwner.current
+                    var batteryExempt by remember {
+                        mutableStateOf(com.noop.ble.BackgroundHealth.isBatteryExempt(context))
+                    }
+                    DisposableEffect(lifecycleOwner) {
+                        val obs = LifecycleEventObserver { _, event ->
+                            if (event == Lifecycle.Event.ON_RESUME) {
+                                batteryExempt = com.noop.ble.BackgroundHealth.isBatteryExempt(context)
+                            }
+                        }
+                        lifecycleOwner.lifecycle.addObserver(obs)
+                        onDispose { lifecycleOwner.lifecycle.removeObserver(obs) }
+                    }
                     val oemAutostart = remember { com.noop.ble.BackgroundHealth.oemAutostartIntent(context) }
                     // Only NAME the manufacturer as a killer when it actually is one — a Pixel/Samsung
                     // shouldn't read "especially Google". The whitelist still helps everyone (it also

--- a/android/app/src/main/java/com/noop/ui/SettingsScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/SettingsScreen.kt
@@ -1268,6 +1268,83 @@ fun SettingsScreen(
                     )
                 }
 
+                // "Keep NOOP alive overnight" (#386): the battery-optimisation whitelist. Shown ONLY while
+                // background connection is on (meaningless otherwise), so it never adds noise on a
+                // foreground-only setup. `checked` reflects the LIVE system exempt state, so an already-exempt
+                // phone shows it on and is never prompted again. POPUP DISCIPLINE: turning it ON fires exactly
+                // ONE system dialog; the OEM auto-start screen (aggressive vendors only) is a SEPARATE
+                // text-link, never chained onto that dialog, so one tap can't spawn two popups. The whitelist
+                // adds no battery cost of its own — it stops a premature kill; the real cost is the two
+                // toggles below.
+                if (backgroundConnection) {
+                    val batteryExempt = com.noop.ble.BackgroundHealth.isBatteryExempt(context)
+                    val oemAutostart = remember { com.noop.ble.BackgroundHealth.oemAutostartIntent(context) }
+                    // Only NAME the manufacturer as a killer when it actually is one — a Pixel/Samsung
+                    // shouldn't read "especially Google". The whitelist still helps everyone (it also
+                    // exempts from Doze deferral), so the row still shows; only the copy is vendor-aware.
+                    val aggressiveVendor = remember { com.noop.ble.BackgroundHealth.isAggressiveVendor() }
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(16.dp),
+                    ) {
+                        Column(modifier = Modifier.weight(1f)) {
+                            Text(
+                                "Keep NOOP alive overnight",
+                                style = NoopType.subhead,
+                                color = Palette.textPrimary,
+                            )
+                            Text(
+                                if (batteryExempt) {
+                                    "Allowed — your phone won't stop NOOP's overnight sync to save battery. This " +
+                                        "doesn't use extra battery on its own; it just lets the settings above run reliably."
+                                } else {
+                                    val who = if (aggressiveVendor) "Your phone (${android.os.Build.MANUFACTURER})" else "Some phones"
+                                    "$who can stop background apps to save battery, which can make NOOP miss overnight " +
+                                        "sleep and recovery data. Turn this on to whitelist NOOP. It doesn't use extra " +
+                                        "battery on its own — it only lets the overnight sync you've enabled above actually finish."
+                                },
+                                style = NoopType.footnote,
+                                color = Palette.textTertiary,
+                            )
+                            // Aggressive-OEM only, and only while not yet exempt: a SEPARATE, explicit link to
+                            // the vendor's auto-start screen (which the generic whitelist can't reach). One
+                            // extra tap by choice — never auto-opened alongside the whitelist dialog.
+                            if (!batteryExempt && oemAutostart != null) {
+                                Text(
+                                    "Some phones also need auto-start enabled — open that screen",
+                                    style = NoopType.footnote,
+                                    color = Palette.accent,
+                                    modifier = Modifier
+                                        .padding(top = 6.dp)
+                                        .clickable { runCatching { context.startActivity(oemAutostart) } },
+                                )
+                            }
+                        }
+                        Switch(
+                            checked = batteryExempt,
+                            // A system grant can't be toggled OFF from here (that's a system action): a tap
+                            // only ever REQUESTS it, and when already exempt the switch is inert (no re-prompt).
+                            onCheckedChange = { wantOn ->
+                                if (wantOn && !batteryExempt) {
+                                    runCatching {
+                                        context.startActivity(com.noop.ble.BackgroundHealth.batteryExemptionIntent(context))
+                                    }.onFailure {
+                                        context.startActivity(com.noop.ble.BackgroundHealth.appBatterySettingsIntent(context))
+                                    }
+                                }
+                            },
+                            colors = SwitchDefaults.colors(
+                                checkedThumbColor = Palette.surfaceBase,
+                                checkedTrackColor = Palette.accent,
+                                uncheckedThumbColor = Palette.textSecondary,
+                                uncheckedTrackColor = Palette.surfaceInset,
+                                uncheckedBorderColor = Palette.hairline,
+                            ),
+                        )
+                    }
+                }
+
                 // Continuous HRV capture: keep the dense beat-to-beat (R-R) stream armed even with no Live
                 // screen open, so the strap banks far more data overnight for better HRV/recovery/sleep.
                 // Honest battery framing — continuous HR streaming uses more battery. Needs background

--- a/android/app/src/test/java/com/noop/ble/BackgroundHealthTest.kt
+++ b/android/app/src/test/java/com/noop/ble/BackgroundHealthTest.kt
@@ -1,0 +1,43 @@
+package com.noop.ble
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * #386: the aggressive-OEM vendor classifier that gates the Settings "Keep NOOP alive overnight" toggle
+ * and (via delegation) the Test Centre `oemKillHeuristic`. Pure + Context-free — the ONE canonical set,
+ * so a phone that actually kills background apps is offered the whitelist. Case-insensitive, substring
+ * match (real `Build.MANUFACTURER` values vary in casing and extra words).
+ */
+class BackgroundHealthTest {
+
+    @Test
+    fun `known aggressive vendors match, case-insensitively`() {
+        // Real Build.MANUFACTURER values (a Redmi/Poco device reports "Xiaomi", not "Redmi").
+        listOf(
+            "Xiaomi", "xiaomi",
+            "OPPO", "oppo", "realme", "Realme",
+            "vivo", "Vivo",
+            "HUAWEI", "Huawei",
+            "OnePlus", "oneplus",
+            "Meizu",
+        ).forEach { assertTrue("$it should be aggressive", BackgroundHealth.isAggressiveVendor(it)) }
+    }
+
+    @Test
+    fun `standard vendors do not match`() {
+        listOf("Google", "samsung", "Samsung", "motorola", "Nothing", "Sony", "Fairphone", "")
+            .forEach { assertFalse("$it should NOT be aggressive", BackgroundHealth.isAggressiveVendor(it)) }
+    }
+
+    @Test
+    fun `the canonical set is exactly the dontkillmyapp vendors`() {
+        // Pin the list so a future edit is a deliberate, reviewed change (it drives who gets prompted).
+        assertEquals(
+            listOf("xiaomi", "oppo", "vivo", "huawei", "oneplus", "realme", "meizu"),
+            BackgroundHealth.AGGRESSIVE_VENDORS,
+        )
+    }
+}


### PR DESCRIPTION
The reliable half of the #386 background-kill discussion: give the user the one lever that actually works, without a nag-popup storm.

## Why

#386's root cause was an aggressive-OEM battery manager (OnePlus, per the reporter's log) killing the overnight foreground service / 15-min re-score tick. NOOP already runs a foreground service + exact alarms + boot re-arm, and already *detects* the non-exempt state in Test Centre diagnostics — but it never offered to **fix** it. Aggressive OEMs (the dontkillmyapp.com set) kill even foreground services, so the only reliable guard is a user-granted battery-optimisation whitelist (+ OEM auto-start on the worst vendors).

## What changed (Android only)

- **`BackgroundHealth` (`com.noop.ble`)** — the canonical aggressive-vendor set, `isBatteryExempt`, and **build-only** intents: the one-tap battery-exemption dialog, an always-resolvable app-settings fallback, and a resolve-checked OEM auto-start deep-link (Xiaomi/Oppo/Vivo/Huawei/Meizu; OnePlus/OxygenOS honours the standard exemption). `AndroidDiagnostics.oemKillHeuristic` now delegates here, so the diagnostic and the fix share **one** vendor list.
- **Settings toggle** under "Keep connected in the background" (shown only when that's on — meaningless otherwise): reflects the **live** system exempt state, vendor-aware copy (names the manufacturer only when it actually kills — a Pixel won't read "especially Google"), and the honest framing that the whitelist **adds no battery of its own** — it stops a premature kill; the real cost is the existing stream/overnight toggles.

## Popup discipline (per the "limit too many popups" ask)

- **No auto-prompt** anywhere — nothing fires a system dialog on launch/resume.
- Turning the toggle **on fires exactly one** dialog; the OEM auto-start is a **separate** text-link, never chained, so one tap can't spawn two popups.
- **Already-exempt → inert switch** (shows on, tapping is a no-op) — never re-prompted.
- A system grant can't be revoked from here (that's a system action), so "off" is honestly a no-op; the copy doesn't pretend otherwise.

## Scope / verification

- **Android-only** — no iOS analogue (Apple doesn't kill background apps this way); no Swift change, no app-build gate.
- `minSdk 26` clears the API-23 floor for `isIgnoringBatteryOptimizations` / `ACTION_REQUEST_IGNORE_BATTERY_OPTIMIZATIONS`.
- Manifest: `REQUEST_IGNORE_BATTERY_OPTIMIZATIONS` (sideload-only — Play restricts it, NOOP doesn't ship there).
- `BackgroundHealthTest` pins the classifier (case-insensitive substring on real `Build.MANUFACTURER` values, incl. a Redmi-reports-"Xiaomi" note) + the canonical set as the reviewed contract. `testFullDebugUnitTest`: **2740 tests, 0 failures**.

This **prevents** the kill. The other half — self-heal on resume so the Today card refreshes after a catch-up re-score even when a kill did slip through — is the separate #386 follow-up, gated on the reporter confirming whether the card currently self-heals or needs a restart.

On-device note worth a look in the next testing build: the whitelist dialog + (on an aggressive vendor) the auto-start deep-link resolving to a real screen.