### PR TITLE
fix(android): self-heal the Today card on resume — catch up a killed overnight re-score (#386)

### DIFF
--- a/android/app/src/main/java/com/noop/ui/AppViewModel.kt
+++ b/android/app/src/main/java/com/noop/ui/AppViewModel.kt
@@ -49,6 +49,9 @@ import com.noop.widget.WidgetSnapshot
 import com.noop.widget.WidgetSnapshotStore
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.withTimeoutOrNull
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
@@ -502,16 +505,30 @@ class AppViewModel(app: Application) : AndroidViewModel(app) {
             .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptyList())
 
     /**
+     * #386 self-heal: a "kick" the app-resume hook emits to wake the 15-min analyze loop early, so an
+     * OEM-killed overnight re-score tick catches up the moment the user opens NOOP instead of showing a
+     * stale Today card until the next sync/tick. The loop re-runs its EXISTING fingerprint-gated
+     * analyzeRecent — a cheap no-op when the HR stream is unchanged, a real catch-up when a kill left
+     * unscored data (the watermark only advances on a completed run). `recentDays` is a reactive Room
+     * flow, so the caught-up rows refresh the card on their own. Buffer 1 + tryEmit coalesces rapid
+     * resumes into a single wake.
+     */
+    private val analyzeKick = MutableSharedFlow<Unit>(extraBufferCapacity = 1)
+
+    /**
      * #78 hole-4: the app-foreground hook for the bond-loop salvage probe. Every activity resume runs
      * [WhoopBleClient.salvageProbeIfBondLoopPaused], which no-ops unless the #747 give-up pause is
      * latched AND its 10-minute floor has passed - so this is one cheap StateFlow read per resume in the
      * healthy case, and the self-heal path for a paused strap the user has since freed. Registered on the
      * Application (no lifecycle-process dependency needed); unregistered in [onCleared]. The iOS twin
-     * observes didBecomeActive inside BLEManager itself.
+     * observes didBecomeActive inside BLEManager itself. Also emits [analyzeKick] (#386 self-heal).
      */
     private val salvageProbeLifecycleCallbacks = object : Application.ActivityLifecycleCallbacks {
         override fun onActivityResumed(activity: android.app.Activity) {
             ble.salvageProbeIfBondLoopPaused()
+            // #386 self-heal: nudge the analyze loop so a night the killed overnight tick never scored is
+            // caught up now. Gated + coalesced downstream, so a healthy resume costs one fingerprint read.
+            analyzeKick.tryEmit(Unit)
         }
         override fun onActivityCreated(activity: android.app.Activity, savedInstanceState: android.os.Bundle?) {}
         override fun onActivityStarted(activity: android.app.Activity) {}
@@ -849,7 +866,10 @@ class AppViewModel(app: Application) : AndroidViewModel(app) {
                 if (_hcWriteback.value) {
                     runCatching { HealthConnectWriter.write(appContext, repository, deviceId) }
                 }
-                delay(ANALYZE_INTERVAL_MS) // 15 min, matches the offload cadence
+                // 15-min backstop cadence, but wake EARLY on an app-resume kick (#386 self-heal) so a
+                // night the overnight tick was killed before scoring catches up the moment the user opens
+                // NOOP. The next iteration's fingerprint gate makes an unnecessary wake a cheap no-op.
+                withTimeoutOrNull(ANALYZE_INTERVAL_MS) { analyzeKick.first() }
             }
         }
 

--- a/android/app/src/main/java/com/noop/ui/AppViewModel.kt
+++ b/android/app/src/main/java/com/noop/ui/AppViewModel.kt
@@ -48,9 +48,8 @@ import com.noop.protocol.CommandNumber
 import com.noop.widget.WidgetSnapshot
 import com.noop.widget.WidgetSnapshotStore
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.delay
-import kotlinx.coroutines.flow.MutableSharedFlow
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.withTimeoutOrNull
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
@@ -505,15 +504,19 @@ class AppViewModel(app: Application) : AndroidViewModel(app) {
             .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptyList())
 
     /**
-     * #386 self-heal: a "kick" the app-resume hook emits to wake the 15-min analyze loop early, so an
+     * #386 self-heal: a "kick" the app-resume hook sends to wake the 15-min analyze loop early, so an
      * OEM-killed overnight re-score tick catches up the moment the user opens NOOP instead of showing a
      * stale Today card until the next sync/tick. The loop re-runs its EXISTING fingerprint-gated
      * analyzeRecent — a cheap no-op when the HR stream is unchanged, a real catch-up when a kill left
      * unscored data (the watermark only advances on a completed run). `recentDays` is a reactive Room
-     * flow, so the caught-up rows refresh the card on their own. Buffer 1 + tryEmit coalesces rapid
-     * resumes into a single wake.
+     * flow, so the caught-up rows refresh the card on their own.
+     *
+     * A CONFLATED Channel, deliberately (NOT a replay=0 SharedFlow): a kick sent while the loop is busy
+     * scoring — outside its `receive()` window — is RETAINED and delivered on the next receive, so a
+     * resume that races the score is never dropped. Conflation coalesces rapid resumes to one wake, and
+     * `trySend` never suspends the main-thread resume callback.
      */
-    private val analyzeKick = MutableSharedFlow<Unit>(extraBufferCapacity = 1)
+    private val analyzeKick = Channel<Unit>(Channel.CONFLATED)
 
     /**
      * #78 hole-4: the app-foreground hook for the bond-loop salvage probe. Every activity resume runs
@@ -528,7 +531,7 @@ class AppViewModel(app: Application) : AndroidViewModel(app) {
             ble.salvageProbeIfBondLoopPaused()
             // #386 self-heal: nudge the analyze loop so a night the killed overnight tick never scored is
             // caught up now. Gated + coalesced downstream, so a healthy resume costs one fingerprint read.
-            analyzeKick.tryEmit(Unit)
+            analyzeKick.trySend(Unit)
         }
         override fun onActivityCreated(activity: android.app.Activity, savedInstanceState: android.os.Bundle?) {}
         override fun onActivityStarted(activity: android.app.Activity) {}
@@ -869,7 +872,7 @@ class AppViewModel(app: Application) : AndroidViewModel(app) {
                 // 15-min backstop cadence, but wake EARLY on an app-resume kick (#386 self-heal) so a
                 // night the overnight tick was killed before scoring catches up the moment the user opens
                 // NOOP. The next iteration's fingerprint gate makes an unnecessary wake a cheap no-op.
-                withTimeoutOrNull(ANALYZE_INTERVAL_MS) { analyzeKick.first() }
+                withTimeoutOrNull(ANALYZE_INTERVAL_MS) { analyzeKick.receive() }
             }
         }
 


### PR DESCRIPTION
The **resilience** half of #386 (the prevention half is #473's whitelist toggle). Default-on, no toggle, no permission, no popup — exactly the "helpful by default, no downside" piece.

## Why

Even with the battery-whitelist, an aggressive OEM can still kill NOOP's overnight 15-min re-score tick — leaving the Today card showing a stale pre-dawn number until the next sync (the exact #386 symptom: 4h 3m on Today vs 8h 36m on the Sleep tab). This makes a kill **harmless**: opening the app catches the night up.

## How (minimal, reuses everything)

- The existing app-resume hook (`salvageProbeLifecycleCallbacks.onActivityResumed`) now emits a `kick`.
- The 15-min analyze loop's `delay(15min)` becomes `withTimeoutOrNull(15min) { analyzeKick.first() }` — so it wakes **early on resume** or after 15 min as before. The scoring body is untouched.
- The loop re-runs its **existing fingerprint-gated `analyzeRecent`**: a cheap no-op when `hrFingerprint()` == the watermark, a real catch-up when a killed tick left unscored data (the watermark advances **only on a completed run**, so an interrupted overnight run leaves `fp != watermark`).
- `recentDays` is a **reactive Room `StateFlow`**, so the caught-up rows refresh the Today card on their own — **no UI change**.

## Why it's safe / cheap

- **Negligible cost:** a healthy resume = one `hrFingerprint()` (a `COUNT` + indexed `MAX(ts)` the loop already runs every 15 min); if unchanged, `analyzeRecent` is skipped.
- **No spam:** rapid resumes coalesce (`MutableSharedFlow(extraBufferCapacity = 1)` + `tryEmit`).
- **No concurrency:** the loop is the *only* caller of `analyzeRecent`; the kick just wakes it — no double-score, no new lock.
- **Cancellation preserved:** `withTimeoutOrNull`/`first()` are cancellable, so `onCleared()` still stops the loop (same as the old `delay`).

## Scope

Android-targeted — the aggressive-OEM overnight kill is Android-specific (Apple doesn't stop background apps this way), and iOS/macOS foreground (`scenePhase == .active`) fires `requestSync(.foreground)`, and `analyzeRecent` runs on sync completion — so iOS's Today refresh on foreground is covered by that sync path. No analytics/stored-value change (this only changes *when* the existing scoring runs). `testFullDebugUnitTest`: **2740 tests, 0 failures**.

Pairs with #473: #473 **prevents** the kill (user-consented whitelist), this **absorbs** one that happens anyway (automatic). Together they close #386 from both sides. The one thing code review can't settle is the live behavior — worth confirming on the next testing build that opening NOOP after a backgrounded overnight refreshes the Today number.