### PR TITLE
feat(ble): decode the captured WHOOP 5/MG IMU buffer inline in the deep-buffer log (#423)

### DIFF
--- a/Strand/BLE/PuffinDeepBufferLog.swift
+++ b/Strand/BLE/PuffinDeepBufferLog.swift
@@ -1,5 +1,7 @@
 import Foundation
 import CoreBluetooth
+import WhoopProtocol
+import StrandAnalytics
 
 /// Durable append-only log of WHOOP 5.0/MG **high-rate deep buffers** — the large type-0x2F (R22)
 /// packets that carry tens-of-Hz sensor data (motion + optical) rather than the 1 Hz historical
@@ -17,9 +19,10 @@ import CoreBluetooth
 ///
 /// Gated on the same Settings toggle as the frame recorder (`PuffinFrameRecorder.enabledKey`) —
 /// capture is passive/read-only with respect to the strap and adds no new setting. One JSONL line per
-/// buffer (`{"ts_ms":…,"strap_ts":…,"size":…,"offload":…,"char":…,"hex":"…"}`); `strap_ts` is the
-/// unix second the strap stamped at payload offset 15 (frame byte 15), the load-bearing key for
-/// aligning a buffer with what the wearer was doing. Rotates at a soft cap keeping one previous
+/// buffer (`{"ts_ms":…,"strap_ts":…,"size":…,"offload":…,"char":…,"hex":"…"[,"imu":{…}]}`); `strap_ts`
+/// is the unix second the strap stamped at payload offset 15 (frame byte 15), the load-bearing key for
+/// aligning a buffer with what the wearer was doing. The optional `imu` object is the decoded activity
+/// summary present only on the 1244-B 6-axis buffer (see `decodedImuField`). Rotates at a soft cap keeping one previous
 /// generation, the same idiom as `PuffinEventLog`. Swift-only for now (experimental #423 instrument);
 /// a Kotlin twin follows if this graduates past reverse-engineering.
 @MainActor
@@ -72,6 +75,19 @@ final class PuffinDeepBufferLog {
         return UInt32(frame[15]) | (UInt32(frame[16]) << 8) | (UInt32(frame[17]) << 16) | (UInt32(frame[18]) << 24)
     }
 
+    /// Decoded-IMU field for the JSONL line: `,"imu":{…features…}` when `frame` is the 1244-B 6-axis
+    /// IMU buffer, else `""` (the 2140-B optical buffer and everything else). Pure and non-throwing —
+    /// a decode miss just omits the field, so a diagnostics-only summary can never disturb the capture
+    /// path. `ImuActivityFeatures` is `Codable`, so this is its canonical JSON.
+    nonisolated static func decodedImuField(_ frame: [UInt8]) -> String {
+        guard frame.count == Whoop5RawImu.bufferLength,
+              let decoded = Whoop5RawImu.decode(frame) else { return "" }
+        let features = ImuFeatureExtractor.extract(decoded.samples, sampleRateHz: decoded.sampleRateHz)
+        guard let data = try? JSONEncoder().encode(features),
+              let json = String(data: data, encoding: .utf8) else { return "" }
+        return ",\"imu\":\(json)"
+    }
+
     /// Append `frame` if it is a WHOOP 5 high-rate deep buffer and capture is enabled. Cheap for every
     /// other frame: a length + single-byte compare, no parse, BEFORE the `isEnabled` read. Call for both
     /// live and offload frames (`isOffload` recorded so the reverse pass can separate a real-time buffer
@@ -81,8 +97,15 @@ final class PuffinDeepBufferLog {
         let tsMs = Int(Date().timeIntervalSince1970 * 1000)
         let strapTs = Self.strapTs(frame).map { String($0) } ?? "null"
         let hex = frame.map { String(format: "%02x", $0) }.joined()
+        // #423/#455: run the raw-IMU decoder on the 1244-B buffer so every captured IMU frame carries
+        // its decoded activity summary (cadence/energy/jerk/gyro) inline beside the raw hex. This is the
+        // first CALLER of `Whoop5RawImu.decode` outside its own tests — it exercises the decoder on real
+        // device captures and makes each JSONL line self-checking (raw ↔ decode) with NO stored table,
+        // migration, or downstream gate. Instrumentation only, per the derived-signal rule; the 2140-B
+        // optical buffer stays raw-only (its layout isn't decoded yet).
+        let imu = Self.decodedImuField(frame)
         let line = "{\"ts_ms\":\(tsMs),\"strap_ts\":\(strapTs),\"size\":\(frame.count),"
-            + "\"offload\":\(isOffload),\"char\":\"\(char.uuidString.lowercased())\",\"hex\":\"\(hex)\"}\n"
+            + "\"offload\":\(isOffload),\"char\":\"\(char.uuidString.lowercased())\",\"hex\":\"\(hex)\"\(imu)}\n"
         do {
             var h = try openHandle()
             if try h.offset() > UInt64(Self.softCapBytes) {

--- a/StrandTests/PuffinDeepBufferLogTests.swift
+++ b/StrandTests/PuffinDeepBufferLogTests.swift
@@ -41,4 +41,42 @@ final class PuffinDeepBufferLogTests: XCTestCase {
             XCTAssertFalse(PuffinDeepBufferLog.isDeepBuffer([UInt8](repeating: 0x2F, count: n)))
         }
     }
+
+    // MARK: - Inline decoded-IMU summary (#423/#455): the log's first caller of Whoop5RawImu.decode
+
+    /// A well-formed 1244-B 6-axis IMU buffer (`Whoop5RawImu` layout): countA/countB = 100, gravity on
+    /// Z, and an X channel that alternates 800/0 so the decoded accel MAGNITUDE actually varies —
+    /// giving non-zero AC energy so the feature extractor exercises its cadence path and stays finite.
+    /// (A ±X swing would not: squaring cancels the sign, leaving magnitude constant.)
+    private func imuBuffer() -> [UInt8] {
+        var f = [UInt8](repeating: 0, count: 1244)
+        f[8] = 0x2F
+        f[24] = 100          // countA (u16 LE) — Whoop5RawImu.decode requires == 100
+        f[630] = 100         // countB (u16 LE)
+        func put(_ off: Int, _ i: Int, _ v: Int16) {
+            f[off + 2 * i] = UInt8(truncatingIfNeeded: v)
+            f[off + 2 * i + 1] = UInt8(truncatingIfNeeded: v >> 8)
+        }
+        for i in 0..<100 {
+            put(28,  i, i % 2 == 0 ? 800 : 0)   // ax @28  — magnitude actually varies
+            put(428, i, 4096)                    // az @428 — ~1 g
+        }
+        return f
+    }
+
+    func testEmitsInlineDecodedImuFieldForImuBuffer() {
+        let field = PuffinDeepBufferLog.decodedImuField(imuBuffer())
+        XCTAssertTrue(field.hasPrefix(",\"imu\":{"), "a 1244-B IMU buffer must emit an inline summary")
+        XCTAssertTrue(field.contains("\"sampleCount\":100"), "summary carries the 100 decoded samples")
+        XCTAssertTrue(field.contains("accelEnergyG"), "summary carries the activity features")
+    }
+
+    func testNoImuFieldForOpticalOrUndecodableBuffers() {
+        // The 2140-B optical buffer is a different, still-undecoded layout — no IMU summary.
+        var optical = [UInt8](repeating: 0, count: 2140); optical[8] = 0x2F
+        XCTAssertEqual(PuffinDeepBufferLog.decodedImuField(optical), "")
+        // A 1244-length frame whose count fields aren't 100 fails decode → field omitted, never a throw.
+        var bogus = [UInt8](repeating: 0, count: 1244); bogus[8] = 0x2F
+        XCTAssertEqual(PuffinDeepBufferLog.decodedImuField(bogus), "")
+    }
 }


### PR DESCRIPTION
## What

The #454 recorder banks the raw 1244-B / 2140-B type-0x2F offload buffers, and #455 landed a hardware-validated 6-axis IMU decoder (`Whoop5RawImu`) + `ImuFeatureExtractor` — but nothing **called** the decoder outside its own tests. This wires it in at the single capture site.

When `PuffinDeepBufferLog` records a **1244-B IMU** buffer it now runs `Whoop5RawImu.decode` + `ImuFeatureExtractor.extract` and inlines the summary (cadence / accel-energy / jerk / gyro) as an `"imu":{…}` field on the existing JSONL line, beside the raw hex.

## Why this and nothing bigger

- **First caller of the #455 decoder outside tests** — it stops being dead code and runs on every real device capture, so a decode regression surfaces on real wear.
- **Each captured line becomes self-checking** — raw hex *and* its decoded features together, so a 5/MG owner running capture validates the decoder without a separate tool. This is the seam a later store-and-consume / classifier PR grows from.
- **No new storage, migration, parity, or downstream gate.** It writes into the JSONL the recorder already owns. Instrumentation only, per the derived-signal rule (CONTRIBUTING). Swift-only, matching the recorder (`PuffinDeepBufferLog` is already Swift-only research tooling).
- **Can't disturb the connection path.** `decodedImuField` is pure and non-throwing — a decode miss (the 2140-B optical buffer, still undecoded; or a frame whose count fields ≠ 100) omits the field. Runs only when capture is already enabled.

## Tests

`PuffinDeepBufferLogTests`: a well-formed 1244-B IMU buffer emits the inline `"imu"` summary with the 100 decoded samples + features; the 2140-B optical buffer and an undecodable 1244-B frame emit nothing (no throw). Pure, no strap.

## Verification

App-target Swift (`Strand/BLE`) has no default CI — validated by dispatching `app-build.yml` on this branch (compile of the Strand macOS + NOOPiOS targets). The pure decoder/extractor it calls are already covered green by `swift-packages.yml` (`WhoopProtocol` / `StrandAnalytics`).