### PR TITLE
feat(ble): battery-adaptive BLE — connection-priority + offload-cadence, dormant default-off (#477)

### DIFF
--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -21,6 +21,7 @@ import android.content.IntentFilter
 import android.content.pm.PackageManager
 import android.os.BatteryManager
 import android.os.Build
+import android.os.PowerManager
 import androidx.core.content.ContextCompat
 import android.os.Handler
 import android.os.Looper
@@ -477,12 +478,14 @@ class WhoopBleClient(
         }
 
         /** Pure battery-adaptive gate for the RISKY idle LOW_POWER throttle (#477), unit-testable without
-         *  a BLE stack. Engages ONLY while DISCHARGING and at/below [thresholdPct] (the Settings picker
-         *  offers 10/15/20/25/30). [thresholdPct] <= 0 disables it (safe half only); charging never
-         *  throttles (battery isn't the concern then). The threshold IS its own hysteresis: battery %
-         *  moves slowly (minutes per point), so a boundary crossing flips at most once per point. */
-        fun idleThrottleActive(batteryPct: Int, charging: Boolean, thresholdPct: Int): Boolean =
-            thresholdPct > 0 && !charging && batteryPct <= thresholdPct
+         *  a BLE stack. The lever is ARMED by [thresholdPct] > 0 (the Settings picker offers 10/15/20/25/
+         *  30; 0 disables it — safe half only, and NOT even Battery Saver can force it, respecting the
+         *  drop-risk asymmetry). Once armed and while DISCHARGING it engages at/below [thresholdPct] OR
+         *  when the OS Battery Saver is on ([powerSave]) — whichever comes first. Charging never throttles.
+         *  The threshold IS its own hysteresis: battery % moves slowly, so a boundary crossing flips at
+         *  most once per point; Battery Saver has its own hysteresis. */
+        fun idleThrottleActive(batteryPct: Int, charging: Boolean, thresholdPct: Int, powerSave: Boolean): Boolean =
+            thresholdPct > 0 && !charging && (batteryPct <= thresholdPct || powerSave)
 
         /** Stretched periodic-offload interval when the phone is low on battery (#477). The offload tick
          *  is a PURE sync timer (the live-stream keep-alive is separate), so stretching it can't affect
@@ -496,7 +499,8 @@ class WhoopBleClient(
             batteryPct: Int,
             charging: Boolean,
             thresholdPct: Int,
-        ): Long = if (idleThrottleActive(batteryPct, charging, thresholdPct)) maxOf(baseMs, lowBatteryMs) else baseMs
+            powerSave: Boolean,
+        ): Long = if (idleThrottleActive(batteryPct, charging, thresholdPct, powerSave)) maxOf(baseMs, lowBatteryMs) else baseMs
 
         /** Pure keep/teardown decision for [prepareForPresentScan] (#74), unit-testable without a BLE
          *  stack (the [scanModeForReconnectAttempts] idiom). Keep the live link ONLY when one exists AND
@@ -1207,8 +1211,14 @@ class WhoopBleClient(
             batteryPct = batteryPct,
             charging = charging,
             thresholdPct = lowBatteryOffloadPct,
+            powerSave = powerSaveActive(),
         )
     }
+
+    /** True when the OS Battery Saver is on — the user's explicit "save power" signal (#477). An extra
+     *  trigger for an already-armed lever; has its own hysteresis + charging-awareness. */
+    private fun powerSaveActive(): Boolean =
+        (context.getSystemService(Context.POWER_SERVICE) as? PowerManager)?.isPowerSaveMode == true
 
     /** Current (battery-%, isCharging) from the sticky ACTION_BATTERY_CHANGED intent — a cheap synchronous
      *  read, no persistent receiver. Unknown → (100, false) so the throttle fails SAFE (never engages). */
@@ -1231,7 +1241,7 @@ class WhoopBleClient(
         // HIGH-escalation half doesn't need it, so safe-half-only mode issues no battery read.
         val idleThrottle = idleThrottleBatteryPct > 0 && run {
             val (batteryPct, charging) = batteryPctAndCharging()
-            idleThrottleActive(batteryPct, charging, idleThrottleBatteryPct)
+            idleThrottleActive(batteryPct, charging, idleThrottleBatteryPct, powerSaveActive())
         }
         // Read the authoritative INTERNAL flags (both set synchronously on this looper), not the
         // published LiveState mirror, which `exitBackfilling` may update a beat later.

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -1200,6 +1200,18 @@ class WhoopBleClient(
         lowBatteryOffloadPct = thresholdPct
     }
 
+    /** #477: pause BACKGROUND continuous-HRV capture while the OS Battery Saver is on (own toggle,
+     *  DEFAULT OFF). A visible Live screen is unaffected — only the held-open background stream is
+     *  released. Gated through [continuousCaptureWantsNow]. */
+    @Volatile private var pauseCaptureOnPowerSave: Boolean = false
+
+    /** Opt into pausing continuous capture under Battery Saver (#477). Reconciles immediately so the
+     *  change takes effect without waiting for the next keep-alive tick. */
+    fun setPauseCaptureOnPowerSave(enabled: Boolean) {
+        pauseCaptureOnPowerSave = enabled
+        handler.post { reconcileRealtime() }
+    }
+
     /** The delay before the next periodic offload — normally [BACKFILL_INTERVAL_MS], stretched when low on
      *  battery (#477). Reads the battery snapshot at re-arm time. */
     private fun nextBackfillDelayMs(): Long {
@@ -4333,6 +4345,12 @@ class WhoopBleClient(
      *  Mirrors the Swift `continuousCaptureWantsNow`. */
     private fun continuousCaptureWantsNow(): Boolean {
         if (!keepStreamForData) return false
+        // #477: optional power-saving pause — while the OS Battery Saver is on, release the held-open
+        // continuous-capture stream (its own toggle, default off). The realtime stream is one of the
+        // larger drains; a Live screen still arms it on demand (screenWantsRealtime is checked separately
+        // in reconcileRealtime), so this only drops the BACKGROUND capture the user opted into. Re-arms
+        // automatically when Battery Saver turns off.
+        if (pauseCaptureOnPowerSave && powerSaveActive()) return false
         val cal = java.util.Calendar.getInstance()
         val minuteOfDay = cal.get(java.util.Calendar.HOUR_OF_DAY) * 60 + cal.get(java.util.Calendar.MINUTE)
         return continuousHrvStreamWanted(

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -1164,7 +1164,14 @@ class WhoopBleClient(
             liveHrActive = realtimeArmed,
             idleThrottleEnabled = idleThrottleEnabled,
         )
-        safeGatt("requestConnectionPriority") { ops.requestConnectionPriorityCompat(priority) }
+        // Deliberately NOT via safeGatt: a battery HINT must never tear the link down. safeGatt's policy
+        // is "any throw ⇒ teardown", right for load-bearing writes/subscriptions but wrong here — a dead
+        // binder is handled by the next real op, and skipping a priority request costs nothing. Swallow.
+        try {
+            ops.requestConnectionPriorityCompat(priority)
+        } catch (t: Throwable) {
+            log("connection-priority request failed (${t.javaClass.simpleName}); skipped")
+        }
     }
     /** @Volatile: set on the GATT binder thread at service discovery, but read in send() on the main
      *  thread (user actions) - the barrier makes a main-thread send see the current characteristic. */

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -278,6 +278,9 @@ interface GattOps {
     fun requestMtuCompat(mtu: Int): Boolean
     fun readRemoteRssiCompat(): Boolean
     fun discoverServicesCompat(): Boolean
+    /** Request a GATT connection priority (battery, #477). Mirrors `BluetoothGatt`'s boolean contract;
+     *  the stack no-ops a request equal to the current interval. */
+    fun requestConnectionPriorityCompat(priority: Int): Boolean
 }
 
 /**
@@ -328,6 +331,7 @@ class RealGattOps(private val gatt: BluetoothGatt) : GattOps {
     override fun requestMtuCompat(mtu: Int): Boolean = gatt.requestMtu(mtu)
     override fun readRemoteRssiCompat(): Boolean = gatt.readRemoteRssi()
     override fun discoverServicesCompat(): Boolean = gatt.discoverServices()
+    override fun requestConnectionPriorityCompat(priority: Int): Boolean = gatt.requestConnectionPriority(priority)
 }
 
 class WhoopBleClient(
@@ -445,6 +449,29 @@ class WhoopBleClient(
         fun scanModeForReconnectAttempts(attempts: Int): Int =
             if (attempts >= SCAN_POWER_BACKOFF_THRESHOLD) ScanSettings.SCAN_MODE_BALANCED
             else ScanSettings.SCAN_MODE_LOW_LATENCY
+
+        /** Pure GATT connection-priority decision (battery, #477), unit-testable without a BLE stack
+         *  (the [scanModeForReconnectAttempts] idiom). TWO independent halves, split by risk:
+         *   - SAFE (always, once management is on): escalate to HIGH during an offload burst or a
+         *     live-HR session. HIGH is a SHORTER interval than BALANCED, so it CANNOT cause a
+         *     supervision-timeout drop (it makes the link more robust, not less) and it shortens the
+         *     radio-on window - faster sync, net battery win.
+         *   - RISKY ([idleThrottleEnabled], default OFF): when idle, drop to LOW_POWER (a LONGER
+         *     interval - the real all-day saving, but a too-long interval can drop the link, so it is
+         *     opt-in and must be validated on a real strap, #477). When off, idle stays BALANCED -
+         *     byte-for-byte today's default.
+         *  Android-only by necessity: CoreBluetooth exposes no app-side connection-priority equivalent
+         *  (the peripheral proposes the GAP connection parameters, iOS negotiates), so there is no Swift
+         *  twin — a deliberate platform divergence, not a parity gap (#477). */
+        fun connectionPriorityFor(
+            offloadActive: Boolean,
+            liveHrActive: Boolean,
+            idleThrottleEnabled: Boolean,
+        ): Int = when {
+            offloadActive || liveHrActive -> BluetoothGatt.CONNECTION_PRIORITY_HIGH
+            idleThrottleEnabled -> BluetoothGatt.CONNECTION_PRIORITY_LOW_POWER
+            else -> BluetoothGatt.CONNECTION_PRIORITY_BALANCED
+        }
 
         /** Pure keep/teardown decision for [prepareForPresentScan] (#74), unit-testable without a BLE
          *  stack (the [scanModeForReconnectAttempts] idiom). Keep the live link ONLY when one exists AND
@@ -1107,6 +1134,38 @@ class WhoopBleClient(
     /** Injectable indirection over [gatt]'s raw GATT calls (see [GattOps]). Rebuilt whenever [gatt] is
      *  (re)assigned in [connectToDevice], cleared in the teardown path alongside `gatt = null`. */
     private var gattOps: GattOps? = null
+
+    /** #477 battery: gates GATT connection-priority management. DEFAULT OFF, so this whole feature ships
+     *  DORMANT - [refreshConnectionPriority] early-returns and issues ZERO new BLE ops, leaving the link
+     *  at the stack default (BALANCED) exactly as before. Flip on ONLY after on-strap validation (see
+     *  #477); a follow-up wires it to a persisted Settings toggle. [connectionPriorityEnabled] enables the
+     *  SAFE half (HIGH during offload/live-HR); [idleThrottleEnabled] additionally enables the RISKY half
+     *  (LOW_POWER when idle). Written from the main looper via [setConnectionPriorityManagement]. */
+    @Volatile private var connectionPriorityEnabled: Boolean = false
+    @Volatile private var idleThrottleEnabled: Boolean = false
+
+    /** Opt into connection-priority management (#477). No-op by default; see the fields above. Runs the
+     *  reconcile on the GATT looper so it can't race the connection callbacks. */
+    fun setConnectionPriorityManagement(enabled: Boolean, idleThrottle: Boolean) {
+        connectionPriorityEnabled = enabled
+        idleThrottleEnabled = idleThrottle && enabled
+        handler.post { refreshConnectionPriority() }
+    }
+
+    /** (Re)apply the GATT connection priority for the current link state (#477). Idempotent + cheap: OFF
+     *  or disconnected -> no BLE op. Called on connect-established and whenever offload / live-HR toggles. */
+    private fun refreshConnectionPriority() {
+        if (!connectionPriorityEnabled) return
+        val ops = gattOps ?: return
+        // Read the authoritative INTERNAL flags (both set synchronously on this looper), not the
+        // published LiveState mirror, which `exitBackfilling` may update a beat later.
+        val priority = connectionPriorityFor(
+            offloadActive = backfilling,
+            liveHrActive = realtimeArmed,
+            idleThrottleEnabled = idleThrottleEnabled,
+        )
+        safeGatt("requestConnectionPriority") { ops.requestConnectionPriorityCompat(priority) }
+    }
     /** @Volatile: set on the GATT binder thread at service discovery, but read in send() on the main
      *  thread (user actions) - the barrier makes a main-thread send see the current characteristic. */
     @Volatile private var cmdCharacteristic: BluetoothGattCharacteristic? = null
@@ -4224,6 +4283,7 @@ class WhoopBleClient(
         // Both families arm/disarm via TOGGLE_REALTIME_HR; send() frames it correctly per family (puffin
         // for 5/MG). A screen re-entry blanks its own smoothing window in the view-model, not here.
         send(CommandNumber.TOGGLE_REALTIME_HR, byteArrayOf(if (want) 1.toByte() else 0.toByte()))
+        refreshConnectionPriority()   // #477: live-HR on → HIGH, off → back to idle. No-op unless enabled.
     }
 
     /**
@@ -4706,6 +4766,7 @@ class WhoopBleClient(
         offloadFramesThisSession = 0
         historicalKickSent = false
         _state.update { it.copy(backfilling = true, syncChunksThisSession = 0) }
+        refreshConnectionPriority()   // #477: escalate to HIGH for the offload burst (faster sync). No-op unless enabled.
         // Opt-in raw capture (research aid): pref read fresh per session, like the probes gate.
         if (connectedFamily == DeviceFamily.WHOOP5 && PuffinExperiment.from(context).isCaptureEnabled) {
             startWhoop5BackfillCapture()
@@ -4882,6 +4943,7 @@ class WhoopBleClient(
     private fun exitBackfilling(reason: String) {
         if (!backfilling) return
         backfilling = false
+        refreshConnectionPriority()   // #477: offload done — drop back to idle priority. No-op unless enabled.
         // #174: a backfill just ended. Start (or extend) the deep-packet cooldown from this instant so
         // any type-0x2F records the strap flushes in the seconds after the session aren't miscounted as
         // the live R22 stream — they're the offload's tail.

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -16,7 +16,10 @@ import android.bluetooth.le.ScanFilter
 import android.bluetooth.le.ScanResult
 import android.bluetooth.le.ScanSettings
 import android.content.Context
+import android.content.Intent
+import android.content.IntentFilter
 import android.content.pm.PackageManager
+import android.os.BatteryManager
 import android.os.Build
 import androidx.core.content.ContextCompat
 import android.os.Handler
@@ -472,6 +475,14 @@ class WhoopBleClient(
             idleThrottleEnabled -> BluetoothGatt.CONNECTION_PRIORITY_LOW_POWER
             else -> BluetoothGatt.CONNECTION_PRIORITY_BALANCED
         }
+
+        /** Pure battery-adaptive gate for the RISKY idle LOW_POWER throttle (#477), unit-testable without
+         *  a BLE stack. Engages ONLY while DISCHARGING and at/below [thresholdPct] (the Settings picker
+         *  offers 10/15/20/25/30). [thresholdPct] <= 0 disables it (safe half only); charging never
+         *  throttles (battery isn't the concern then). The threshold IS its own hysteresis: battery %
+         *  moves slowly (minutes per point), so a boundary crossing flips at most once per point. */
+        fun idleThrottleActive(batteryPct: Int, charging: Boolean, thresholdPct: Int): Boolean =
+            thresholdPct > 0 && !charging && batteryPct <= thresholdPct
 
         /** Pure keep/teardown decision for [prepareForPresentScan] (#74), unit-testable without a BLE
          *  stack (the [scanModeForReconnectAttempts] idiom). Keep the live link ONLY when one exists AND
@@ -1139,17 +1150,33 @@ class WhoopBleClient(
      *  DORMANT - [refreshConnectionPriority] early-returns and issues ZERO new BLE ops, leaving the link
      *  at the stack default (BALANCED) exactly as before. Flip on ONLY after on-strap validation (see
      *  #477); a follow-up wires it to a persisted Settings toggle. [connectionPriorityEnabled] enables the
-     *  SAFE half (HIGH during offload/live-HR); [idleThrottleEnabled] additionally enables the RISKY half
-     *  (LOW_POWER when idle). Written from the main looper via [setConnectionPriorityManagement]. */
+     *  SAFE half (HIGH during offload/live-HR). The RISKY half (LOW_POWER when idle) is BATTERY-ADAPTIVE:
+     *  it engages only when the phone is discharging AND at/below [idleThrottleBatteryPct] (0 = never), so
+     *  the drop-risk is confined to when the user actually wants power saving. Set on the main looper via
+     *  [setConnectionPriorityManagement]. */
     @Volatile private var connectionPriorityEnabled: Boolean = false
-    @Volatile private var idleThrottleEnabled: Boolean = false
+    /** Battery-% at/below which the LOW_POWER idle throttle engages while discharging; 0 = never (safe
+     *  half only). The Settings picker offers 10/15/20/25/30. */
+    @Volatile private var idleThrottleBatteryPct: Int = 0
 
-    /** Opt into connection-priority management (#477). No-op by default; see the fields above. Runs the
-     *  reconcile on the GATT looper so it can't race the connection callbacks. */
-    fun setConnectionPriorityManagement(enabled: Boolean, idleThrottle: Boolean) {
+    /** Opt into connection-priority management (#477). No-op by default; see the fields above.
+     *  [idleThrottleBatteryPct] 0 disables the risky idle throttle (safe half only). */
+    fun setConnectionPriorityManagement(enabled: Boolean, idleThrottleBatteryPct: Int) {
         connectionPriorityEnabled = enabled
-        idleThrottleEnabled = idleThrottle && enabled
+        this.idleThrottleBatteryPct = if (enabled) idleThrottleBatteryPct else 0
         handler.post { refreshConnectionPriority() }
+    }
+
+    /** Current (battery-%, isCharging) from the sticky ACTION_BATTERY_CHANGED intent — a cheap synchronous
+     *  read, no persistent receiver. Unknown → (100, false) so the throttle fails SAFE (never engages). */
+    private fun batteryPctAndCharging(): Pair<Int, Boolean> {
+        val i = context.registerReceiver(null, IntentFilter(Intent.ACTION_BATTERY_CHANGED))
+        val level = i?.getIntExtra(BatteryManager.EXTRA_LEVEL, -1) ?: -1
+        val scale = i?.getIntExtra(BatteryManager.EXTRA_SCALE, -1) ?: -1
+        val status = i?.getIntExtra(BatteryManager.EXTRA_STATUS, -1) ?: -1
+        val pct = if (level >= 0 && scale > 0) level * 100 / scale else 100
+        val charging = status == BatteryManager.BATTERY_STATUS_CHARGING || status == BatteryManager.BATTERY_STATUS_FULL
+        return pct to charging
     }
 
     /** (Re)apply the GATT connection priority for the current link state (#477). Idempotent + cheap: OFF
@@ -1157,12 +1184,13 @@ class WhoopBleClient(
     private fun refreshConnectionPriority() {
         if (!connectionPriorityEnabled) return
         val ops = gattOps ?: return
+        val (batteryPct, charging) = batteryPctAndCharging()
         // Read the authoritative INTERNAL flags (both set synchronously on this looper), not the
         // published LiveState mirror, which `exitBackfilling` may update a beat later.
         val priority = connectionPriorityFor(
             offloadActive = backfilling,
             liveHrActive = realtimeArmed,
-            idleThrottleEnabled = idleThrottleEnabled,
+            idleThrottleEnabled = idleThrottleActive(batteryPct, charging, idleThrottleBatteryPct),
         )
         // Deliberately NOT via safeGatt: a battery HINT must never tear the link down. safeGatt's policy
         // is "any throw ⇒ teardown", right for load-bearing writes/subscriptions but wrong here — a dead

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -484,6 +484,20 @@ class WhoopBleClient(
         fun idleThrottleActive(batteryPct: Int, charging: Boolean, thresholdPct: Int): Boolean =
             thresholdPct > 0 && !charging && batteryPct <= thresholdPct
 
+        /** Stretched periodic-offload interval when the phone is low on battery (#477). The offload tick
+         *  is a PURE sync timer (the live-stream keep-alive is separate), so stretching it can't affect
+         *  link health — worst case is fresher data arriving in slightly larger batches; the strap banks
+         *  everything to flash meanwhile, so no data is lost. Left at [LOW_BATTERY_BACKFILL_INTERVAL_MS]
+         *  while DISCHARGING at/below [thresholdPct], else the normal [baseMs]. [thresholdPct] <= 0 / charging
+         *  never stretches. Pure, unit-testable. */
+        fun offloadIntervalMsFor(
+            baseMs: Long,
+            lowBatteryMs: Long,
+            batteryPct: Int,
+            charging: Boolean,
+            thresholdPct: Int,
+        ): Long = if (idleThrottleActive(batteryPct, charging, thresholdPct)) maxOf(baseMs, lowBatteryMs) else baseMs
+
         /** Pure keep/teardown decision for [prepareForPresentScan] (#74), unit-testable without a BLE
          *  stack (the [scanModeForReconnectAttempts] idiom). Keep the live link ONLY when one exists AND
          *  the wizard is scanning the SAME model; Android [WhoopModel] has exactly two members (one per
@@ -527,6 +541,10 @@ class WhoopBleClient(
         // MARK: Historical-offload timers (ported from BLEManager.swift, same constants).
         /** Periodic re-offload of the type-47 store while connected+bonded. 900s = 15 min (matches WHOOP). */
         private const val BACKFILL_INTERVAL_MS = 900_000L
+        /** #477 battery: stretched offload cadence while low on battery (45 min). The strap banks to flash
+         *  meanwhile, so this only delays sync (larger batches), never loses data. Gated on the discharging
+         *  battery-% threshold; 0 = disabled → always [BACKFILL_INTERVAL_MS]. */
+        private const val LOW_BATTERY_BACKFILL_INTERVAL_MS = 2_700_000L
         /** How far back the inactivity check reads gravity on each offload completion (4 h comfortably
          *  spans the threshold + re-nudge cadence and a separating Active break for bout continuity). */
         private const val INACTIVITY_LOOKBACK_S = 4 * 3600L
@@ -1165,6 +1183,31 @@ class WhoopBleClient(
         connectionPriorityEnabled = enabled
         this.idleThrottleBatteryPct = if (enabled) idleThrottleBatteryPct else 0
         handler.post { refreshConnectionPriority() }
+    }
+
+    /** Battery-% at/below which the periodic offload cadence stretches to
+     *  [LOW_BATTERY_BACKFILL_INTERVAL_MS] while discharging; 0 = never (normal 15-min cadence). DEFAULT
+     *  OFF, so this ships dormant. The Settings picker offers 10/15/20/25/30. */
+    @Volatile private var lowBatteryOffloadPct: Int = 0
+
+    /** Opt into the low-battery offload-cadence stretch (#477). Applies on the NEXT re-arm; a live sync
+     *  in flight is never interrupted. */
+    fun setLowBatteryOffloadThrottle(thresholdPct: Int) {
+        lowBatteryOffloadPct = thresholdPct
+    }
+
+    /** The delay before the next periodic offload — normally [BACKFILL_INTERVAL_MS], stretched when low on
+     *  battery (#477). Reads the battery snapshot at re-arm time. */
+    private fun nextBackfillDelayMs(): Long {
+        if (lowBatteryOffloadPct <= 0) return BACKFILL_INTERVAL_MS   // dormant: no battery read, unchanged cadence
+        val (batteryPct, charging) = batteryPctAndCharging()
+        return offloadIntervalMsFor(
+            baseMs = BACKFILL_INTERVAL_MS,
+            lowBatteryMs = LOW_BATTERY_BACKFILL_INTERVAL_MS,
+            batteryPct = batteryPct,
+            charging = charging,
+            thresholdPct = lowBatteryOffloadPct,
+        )
     }
 
     /** Current (battery-%, isCharging) from the sticky ACTION_BATTERY_CHANGED intent — a cheap synchronous
@@ -4897,13 +4940,14 @@ class WhoopBleClient(
     /** Periodic-timer callback: re-runs the type-47 offload (the primary metric sync). */
     private fun triggerPeriodicBackfill() {
         requestSync(BackfillTrigger.PERIODIC)
-        // Re-arm regardless so the cadence continues for the life of the connection.
-        handler.postDelayed(periodicBackfillRunnable, BACKFILL_INTERVAL_MS)
+        // Re-arm regardless so the cadence continues for the life of the connection. #477: the delay is
+        // battery-adaptive (stretched when low), read fresh at each re-arm.
+        handler.postDelayed(periodicBackfillRunnable, nextBackfillDelayMs())
     }
 
     private fun startBackfillTimer() {
         handler.removeCallbacks(periodicBackfillRunnable)
-        handler.postDelayed(periodicBackfillRunnable, BACKFILL_INTERVAL_MS)
+        handler.postDelayed(periodicBackfillRunnable, nextBackfillDelayMs())
     }
 
     private fun stopBackfillTimer() {

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -1227,13 +1227,18 @@ class WhoopBleClient(
     private fun refreshConnectionPriority() {
         if (!connectionPriorityEnabled) return
         val ops = gattOps ?: return
-        val (batteryPct, charging) = batteryPctAndCharging()
+        // Only read the battery when the RISKY idle throttle is actually armed (threshold > 0); the SAFE
+        // HIGH-escalation half doesn't need it, so safe-half-only mode issues no battery read.
+        val idleThrottle = idleThrottleBatteryPct > 0 && run {
+            val (batteryPct, charging) = batteryPctAndCharging()
+            idleThrottleActive(batteryPct, charging, idleThrottleBatteryPct)
+        }
         // Read the authoritative INTERNAL flags (both set synchronously on this looper), not the
         // published LiveState mirror, which `exitBackfilling` may update a beat later.
         val priority = connectionPriorityFor(
             offloadActive = backfilling,
             liveHrActive = realtimeArmed,
-            idleThrottleEnabled = idleThrottleActive(batteryPct, charging, idleThrottleBatteryPct),
+            idleThrottleEnabled = idleThrottle,
         )
         // Deliberately NOT via safeGatt: a battery HINT must never tear the link down. safeGatt's policy
         // is "any throw ⇒ teardown", right for load-bearing writes/subscriptions but wrong here — a dead

--- a/android/app/src/main/java/com/noop/ui/AppViewModel.kt
+++ b/android/app/src/main/java/com/noop/ui/AppViewModel.kt
@@ -882,9 +882,40 @@ class AppViewModel(app: Application) : AndroidViewModel(app) {
         // want would be meaningless. Pushed BEFORE autoReconnectOnLaunch so a launch reconnect arms it.
         ble.setKeepStreamForData(continuousHrvEffective())
 
+        // #477: push the persisted Power-saving prefs so the battery-adaptive levers apply from launch.
+        applyPowerSaving()
+
         // Reconnect to the strap we last bonded to, so the user doesn't have to tap Connect after an
         // app update / restart (#67). Self-gates on the keep-connected pref + a saved strap + permission.
         autoReconnectOnLaunch()
+    }
+
+    /** Push the persisted #477 Power-saving prefs to the BLE client. The offload-cadence stretch uses the
+     *  battery-% threshold (0 = off when the master is off); the HRV pause is its own Battery-Saver toggle.
+     *  The riskier connection-priority idle throttle is deliberately NOT exposed here — it stays dormant
+     *  pending on-strap validation (#478). */
+    private fun applyPowerSaving() {
+        val pct = if (NoopPrefs.powerSaving(appContext)) NoopPrefs.powerSavingBatteryPct(appContext) else 0
+        ble.setLowBatteryOffloadThrottle(pct)
+        ble.setPauseCaptureOnPowerSave(NoopPrefs.pauseHrvOnPowerSave(appContext))
+    }
+
+    /** Flip "Power saving" (Settings). Persists + applies immediately. */
+    fun setPowerSaving(enabled: Boolean) {
+        NoopPrefs.setPowerSaving(appContext, enabled)
+        applyPowerSaving()
+    }
+
+    /** Set the power-saving battery-% threshold (Settings). Persists + applies immediately. */
+    fun setPowerSavingBatteryPct(pct: Int) {
+        NoopPrefs.setPowerSavingBatteryPct(appContext, pct)
+        applyPowerSaving()
+    }
+
+    /** Flip "Pause HRV capture in Battery Saver" (Settings). Persists + applies immediately. */
+    fun setPauseHrvOnPowerSave(enabled: Boolean) {
+        NoopPrefs.setPauseHrvOnPowerSave(appContext, enabled)
+        applyPowerSaving()
     }
 
     /** The effective continuous-HRV want: the user's "Continuous HRV capture" preference AND

--- a/android/app/src/main/java/com/noop/ui/AppViewModel.kt
+++ b/android/app/src/main/java/com/noop/ui/AppViewModel.kt
@@ -895,9 +895,10 @@ class AppViewModel(app: Application) : AndroidViewModel(app) {
      *  The riskier connection-priority idle throttle is deliberately NOT exposed here — it stays dormant
      *  pending on-strap validation (#478). */
     private fun applyPowerSaving() {
-        val pct = if (NoopPrefs.powerSaving(appContext)) NoopPrefs.powerSavingBatteryPct(appContext) else 0
-        ble.setLowBatteryOffloadThrottle(pct)
-        ble.setPauseCaptureOnPowerSave(NoopPrefs.pauseHrvOnPowerSave(appContext))
+        val on = NoopPrefs.powerSaving(appContext)
+        ble.setLowBatteryOffloadThrottle(if (on) NoopPrefs.powerSavingBatteryPct(appContext) else 0)
+        // HRV pause is a sub-option: only effective while the master is on (defaults on when it is).
+        ble.setPauseCaptureOnPowerSave(on && NoopPrefs.pauseHrvOnPowerSave(appContext))
     }
 
     /** Flip "Power saving" (Settings). Persists + applies immediately. */

--- a/android/app/src/main/java/com/noop/ui/MainActivity.kt
+++ b/android/app/src/main/java/com/noop/ui/MainActivity.kt
@@ -203,8 +203,44 @@ object NoopPrefs {
 
     const val KEY_ANALYZE_WATERMARK = "noop.analyzeWatermark"
 
+    /** "Power saving" (#477): when on, NOOP stretches its periodic strap-sync cadence (15 → 45 min) while
+     *  the phone is discharging at/below [KEY_POWER_SAVING_BATTERY_PCT] OR the OS Battery Saver is on.
+     *  Benign — the strap banks to flash meanwhile, so sync just batches; no data loss, no link risk.
+     *  Default OFF. Drives [com.noop.ble.WhoopBleClient.setLowBatteryOffloadThrottle] via [AppViewModel]. */
+    const val KEY_POWER_SAVING = "noop.powerSaving"
+    /** Battery-% threshold for [KEY_POWER_SAVING] (10/15/20/25/30). Default 20. */
+    const val KEY_POWER_SAVING_BATTERY_PCT = "noop.powerSavingBatteryPct"
+    /** "Pause HRV capture in Battery Saver" (#477): when on, NOOP releases the held-open background
+     *  continuous-HRV stream while the OS Battery Saver is on (a Live screen still arms it on demand).
+     *  Default OFF. Drives [com.noop.ble.WhoopBleClient.setPauseCaptureOnPowerSave] via [AppViewModel]. */
+    const val KEY_PAUSE_HRV_ON_POWER_SAVE = "noop.pauseHrvOnPowerSave"
+
     fun of(context: Context): SharedPreferences =
         context.getSharedPreferences(NAME, Context.MODE_PRIVATE)
+
+    /** "Power saving" master (battery-adaptive sync cadence). Default off. */
+    fun powerSaving(context: Context): Boolean =
+        of(context).getBoolean(KEY_POWER_SAVING, false)
+
+    fun setPowerSaving(context: Context, enabled: Boolean) {
+        of(context).edit().putBoolean(KEY_POWER_SAVING, enabled).apply()
+    }
+
+    /** Battery-% threshold for power saving (default 20). */
+    fun powerSavingBatteryPct(context: Context): Int =
+        of(context).getInt(KEY_POWER_SAVING_BATTERY_PCT, 20)
+
+    fun setPowerSavingBatteryPct(context: Context, pct: Int) {
+        of(context).edit().putInt(KEY_POWER_SAVING_BATTERY_PCT, pct).apply()
+    }
+
+    /** Pause continuous-HRV capture while Battery Saver is on. Default off. */
+    fun pauseHrvOnPowerSave(context: Context): Boolean =
+        of(context).getBoolean(KEY_PAUSE_HRV_ON_POWER_SAVE, false)
+
+    fun setPauseHrvOnPowerSave(context: Context, enabled: Boolean) {
+        of(context).edit().putBoolean(KEY_PAUSE_HRV_ON_POWER_SAVE, enabled).apply()
+    }
 
     /** #836, the raw-HR fingerprint ("count:maxTs") the last COMPLETED idle rescore scored against. The
      *  15-min backstop tick skips when the current fingerprint equals this; cleared implicitly by any HR

--- a/android/app/src/main/java/com/noop/ui/MainActivity.kt
+++ b/android/app/src/main/java/com/noop/ui/MainActivity.kt
@@ -212,7 +212,9 @@ object NoopPrefs {
     const val KEY_POWER_SAVING_BATTERY_PCT = "noop.powerSavingBatteryPct"
     /** "Pause HRV capture in Battery Saver" (#477): when on, NOOP releases the held-open background
      *  continuous-HRV stream while the OS Battery Saver is on (a Live screen still arms it on demand).
-     *  Default OFF. Drives [com.noop.ble.WhoopBleClient.setPauseCaptureOnPowerSave] via [AppViewModel]. */
+     *  A sub-option of [KEY_POWER_SAVING] — only effective while the master is on. Default ON (so enabling
+     *  Power saving pauses capture by default; the user can turn it off). Drives
+     *  [com.noop.ble.WhoopBleClient.setPauseCaptureOnPowerSave] via [AppViewModel]. */
     const val KEY_PAUSE_HRV_ON_POWER_SAVE = "noop.pauseHrvOnPowerSave"
 
     fun of(context: Context): SharedPreferences =
@@ -234,9 +236,9 @@ object NoopPrefs {
         of(context).edit().putInt(KEY_POWER_SAVING_BATTERY_PCT, pct).apply()
     }
 
-    /** Pause continuous-HRV capture while Battery Saver is on. Default off. */
+    /** Pause continuous-HRV capture while Battery Saver is on (sub-option of Power saving). Default ON. */
     fun pauseHrvOnPowerSave(context: Context): Boolean =
-        of(context).getBoolean(KEY_PAUSE_HRV_ON_POWER_SAVE, false)
+        of(context).getBoolean(KEY_PAUSE_HRV_ON_POWER_SAVE, true)
 
     fun setPauseHrvOnPowerSave(context: Context, enabled: Boolean) {
         of(context).edit().putBoolean(KEY_PAUSE_HRV_ON_POWER_SAVE, enabled).apply()

--- a/android/app/src/main/java/com/noop/ui/SettingsScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/SettingsScreen.kt
@@ -1605,35 +1605,36 @@ fun SettingsScreen(
                         ),
                     )
                 }
-            }
-            RowDivider()
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.spacedBy(16.dp),
-            ) {
-                Column(modifier = Modifier.weight(1f)) {
-                    Text("Pause HRV capture in Battery Saver", style = NoopType.subhead, color = Palette.textPrimary)
-                    Text(
-                        "While Android Battery Saver is on, stop the always-on background HRV stream (the biggest live drain). Opening a Live screen still shows heart rate, and it re-arms automatically when Battery Saver turns off.",
-                        style = NoopType.footnote,
-                        color = Palette.textTertiary,
+                RowDivider()
+                // HRV pause: a sub-option of power saving, ON by default when the master is on.
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(16.dp),
+                ) {
+                    Column(modifier = Modifier.weight(1f)) {
+                        Text("Pause HRV capture in Battery Saver", style = NoopType.subhead, color = Palette.textPrimary)
+                        Text(
+                            "While Android Battery Saver is on, stop the always-on background HRV stream (the biggest live drain). Opening a Live screen still shows heart rate, and it re-arms automatically when Battery Saver turns off.",
+                            style = NoopType.footnote,
+                            color = Palette.textTertiary,
+                        )
+                    }
+                    Switch(
+                        checked = pauseHrvOnPowerSave,
+                        onCheckedChange = {
+                            pauseHrvOnPowerSave = it
+                            vm.setPauseHrvOnPowerSave(it)
+                        },
+                        colors = SwitchDefaults.colors(
+                            checkedThumbColor = Palette.surfaceBase,
+                            checkedTrackColor = Palette.accent,
+                            uncheckedThumbColor = Palette.textSecondary,
+                            uncheckedTrackColor = Palette.surfaceInset,
+                            uncheckedBorderColor = Palette.hairline,
+                        ),
                     )
                 }
-                Switch(
-                    checked = pauseHrvOnPowerSave,
-                    onCheckedChange = {
-                        pauseHrvOnPowerSave = it
-                        vm.setPauseHrvOnPowerSave(it)
-                    },
-                    colors = SwitchDefaults.colors(
-                        checkedThumbColor = Palette.surfaceBase,
-                        checkedTrackColor = Palette.accent,
-                        uncheckedThumbColor = Palette.textSecondary,
-                        uncheckedTrackColor = Palette.surfaceInset,
-                        uncheckedBorderColor = Palette.hairline,
-                    ),
-                )
             }
         }
 

--- a/android/app/src/main/java/com/noop/ui/SettingsScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/SettingsScreen.kt
@@ -87,6 +87,7 @@ import androidx.compose.ui.draw.rotate
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.stateDescription
@@ -101,6 +102,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.noop.BuildConfig
 import com.noop.analytics.Baselines
 import com.noop.analytics.Zones
+import com.noop.R
 import com.noop.ble.PuffinExperiment
 import com.noop.ble.WhoopModel
 import com.noop.data.DataBackup
@@ -1549,8 +1551,8 @@ fun SettingsScreen(
         // deliberately not surfaced here — it stays dormant pending on-strap validation (#478).
         SettingsSection(
             icon = Icons.Filled.BatteryStd,
-            title = "Power saving",
-            blurb = "Ease battery use when your phone is low or in Battery Saver. The strap keeps banking data on its own, so nothing is lost — NOOP just syncs it less often.",
+            title = stringResource(R.string.power_saving),
+            blurb = stringResource(R.string.power_saving_blurb),
         ) {
             Row(
                 modifier = Modifier.fillMaxWidth(),
@@ -1558,9 +1560,9 @@ fun SettingsScreen(
                 horizontalArrangement = Arrangement.spacedBy(16.dp),
             ) {
                 Column(modifier = Modifier.weight(1f)) {
-                    Text("Power saving mode", style = NoopType.subhead, color = Palette.textPrimary)
+                    Text(stringResource(R.string.power_saving_mode), style = NoopType.subhead, color = Palette.textPrimary)
                     Text(
-                        "Slows background strap-sync (every 45 min instead of 15) while your battery is low or Battery Saver is on. No data loss — sync just batches into larger, less frequent pulls.",
+                        stringResource(R.string.power_saving_mode_desc),
                         style = NoopType.footnote,
                         color = Palette.textTertiary,
                     )
@@ -1588,8 +1590,8 @@ fun SettingsScreen(
                         horizontalArrangement = Arrangement.SpaceBetween,
                         verticalAlignment = Alignment.CenterVertically,
                     ) {
-                        Text("Kick in at", style = NoopType.subhead, color = Palette.textPrimary)
-                        Text("$powerSavingBatteryPct%", style = NoopType.subhead, color = Palette.accent)
+                        Text(stringResource(R.string.power_saving_kick_in), style = NoopType.subhead, color = Palette.textPrimary)
+                        Text(stringResource(R.string.power_saving_pct, powerSavingBatteryPct), style = NoopType.subhead, color = Palette.accent)
                     }
                     Slider(
                         value = powerSavingBatteryPct.toFloat(),
@@ -1613,9 +1615,9 @@ fun SettingsScreen(
                     horizontalArrangement = Arrangement.spacedBy(16.dp),
                 ) {
                     Column(modifier = Modifier.weight(1f)) {
-                        Text("Pause HRV capture in Battery Saver", style = NoopType.subhead, color = Palette.textPrimary)
+                        Text(stringResource(R.string.power_saving_hrv_pause), style = NoopType.subhead, color = Palette.textPrimary)
                         Text(
-                            "While Android Battery Saver is on, stop the always-on background HRV stream (the biggest live drain). Opening a Live screen still shows heart rate, and it re-arms automatically when Battery Saver turns off.",
+                            stringResource(R.string.power_saving_hrv_pause_desc),
                             style = NoopType.footnote,
                             color = Palette.textTertiary,
                         )

--- a/android/app/src/main/java/com/noop/ui/SettingsScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/SettingsScreen.kt
@@ -35,6 +35,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
 import androidx.compose.material.icons.filled.Autorenew
 import androidx.compose.material.icons.filled.Bolt
+import androidx.compose.material.icons.filled.BatteryStd
 import androidx.compose.material.icons.filled.BugReport
 import androidx.compose.material.icons.filled.Brightness6
 import androidx.compose.material.icons.filled.Campaign
@@ -475,6 +476,11 @@ fun SettingsScreen(
     // "Overnight only" (#927): arm the continuous stream only inside the nightly quiet-hours window
     // instead of 24/7. Default OFF so existing users keep the always-on behaviour. Local mirror.
     var continuousHrvOvernight by remember { mutableStateOf(NoopPrefs.continuousHrvOvernight(context)) }
+
+    // #477 Power saving: battery-adaptive strap-sync cadence + optional HRV-capture pause. Local mirrors.
+    var powerSaving by remember { mutableStateOf(NoopPrefs.powerSaving(context)) }
+    var powerSavingBatteryPct by remember { mutableStateOf(NoopPrefs.powerSavingBatteryPct(context)) }
+    var pauseHrvOnPowerSave by remember { mutableStateOf(NoopPrefs.pauseHrvOnPowerSave(context)) }
 
     // --- v5 Health & wellness toggle group. All SharedPreferences-backed (not reactive), so each Switch
     // drives a local mirror that writes straight through to the same keys the v5 engine readers use.
@@ -1535,6 +1541,87 @@ fun SettingsScreen(
                         Text("›", style = NoopType.title2, color = Palette.accent)
                     }
                 }
+            }
+        }
+
+        // #477 Power saving. Two BENIGN battery levers only: the offload-cadence stretch (%-gated) and
+        // the HRV-capture pause (Battery-Saver-gated). The riskier connection-priority idle throttle is
+        // deliberately not surfaced here — it stays dormant pending on-strap validation (#478).
+        SettingsSection(
+            icon = Icons.Filled.BatteryStd,
+            title = "Power saving",
+            blurb = "Ease battery use when your phone is low or in Battery Saver. The strap keeps banking data on its own, so nothing is lost — NOOP just syncs it less often.",
+        ) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(16.dp),
+            ) {
+                Column(modifier = Modifier.weight(1f)) {
+                    Text("Power saving mode", style = NoopType.subhead, color = Palette.textPrimary)
+                    Text(
+                        "Slows background strap-sync (every 45 min instead of 15) while your battery is low or Battery Saver is on. No data loss — sync just batches into larger, less frequent pulls.",
+                        style = NoopType.footnote,
+                        color = Palette.textTertiary,
+                    )
+                }
+                Switch(
+                    checked = powerSaving,
+                    onCheckedChange = {
+                        powerSaving = it
+                        vm.setPowerSaving(it)
+                    },
+                    colors = SwitchDefaults.colors(
+                        checkedThumbColor = Palette.surfaceBase,
+                        checkedTrackColor = Palette.accent,
+                        uncheckedThumbColor = Palette.textSecondary,
+                        uncheckedTrackColor = Palette.surfaceInset,
+                        uncheckedBorderColor = Palette.hairline,
+                    ),
+                )
+            }
+            if (powerSaving) {
+                RowDivider()
+                FormRow(label = "Kick in at") {
+                    SegmentedPillControl(
+                        items = listOf(10, 15, 20, 25, 30),
+                        selection = powerSavingBatteryPct,
+                        label = { "$it%" },
+                        onSelect = {
+                            powerSavingBatteryPct = it
+                            vm.setPowerSavingBatteryPct(it)
+                        },
+                    )
+                }
+            }
+            RowDivider()
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(16.dp),
+            ) {
+                Column(modifier = Modifier.weight(1f)) {
+                    Text("Pause HRV capture in Battery Saver", style = NoopType.subhead, color = Palette.textPrimary)
+                    Text(
+                        "While Android Battery Saver is on, stop the always-on background HRV stream (the biggest live drain). Opening a Live screen still shows heart rate, and it re-arms automatically when Battery Saver turns off.",
+                        style = NoopType.footnote,
+                        color = Palette.textTertiary,
+                    )
+                }
+                Switch(
+                    checked = pauseHrvOnPowerSave,
+                    onCheckedChange = {
+                        pauseHrvOnPowerSave = it
+                        vm.setPauseHrvOnPowerSave(it)
+                    },
+                    colors = SwitchDefaults.colors(
+                        checkedThumbColor = Palette.surfaceBase,
+                        checkedTrackColor = Palette.accent,
+                        uncheckedThumbColor = Palette.textSecondary,
+                        uncheckedTrackColor = Palette.surfaceInset,
+                        uncheckedBorderColor = Palette.hairline,
+                    ),
+                )
             }
         }
 

--- a/android/app/src/main/java/com/noop/ui/SettingsScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/SettingsScreen.kt
@@ -1582,15 +1582,27 @@ fun SettingsScreen(
             }
             if (powerSaving) {
                 RowDivider()
-                FormRow(label = "Kick in at") {
-                    SegmentedPillControl(
-                        items = listOf(10, 15, 20, 25, 30),
-                        selection = powerSavingBatteryPct,
-                        label = { "$it%" },
-                        onSelect = {
-                            powerSavingBatteryPct = it
-                            vm.setPowerSavingBatteryPct(it)
-                        },
+                Column(modifier = Modifier.fillMaxWidth()) {
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.SpaceBetween,
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        Text("Kick in at", style = NoopType.subhead, color = Palette.textPrimary)
+                        Text("$powerSavingBatteryPct%", style = NoopType.subhead, color = Palette.accent)
+                    }
+                    Slider(
+                        value = powerSavingBatteryPct.toFloat(),
+                        // 10–30% snapping to 5% steps (10/15/20/25/30). steps = the 3 stops BETWEEN ends.
+                        onValueChange = { powerSavingBatteryPct = it.roundToInt() },
+                        onValueChangeFinished = { vm.setPowerSavingBatteryPct(powerSavingBatteryPct) },
+                        valueRange = 10f..30f,
+                        steps = 3,
+                        colors = SliderDefaults.colors(
+                            thumbColor = Palette.accent,
+                            activeTrackColor = Palette.accent,
+                            inactiveTrackColor = Palette.surfaceInset,
+                        ),
                     )
                 }
             }

--- a/android/app/src/main/res/values-de/strings.xml
+++ b/android/app/src/main/res/values-de/strings.xml
@@ -145,4 +145,14 @@
     <string name="timeline_empty_metric">Kein(e) %1$s hier</string>
     <string name="timeline_nothing_offloaded">Für dieses Fenster wurde noch nichts übertragen.</string>
     <string name="timeline_other_sources_no_offload">Andere Quellen übertragen keine rohen Sekundendaten auf das Gerät.</string>
+
+    <!-- Power saving (#477) -->
+    <string name="power_saving">Energie sparen</string>
+    <string name="power_saving_blurb">Reduziert den Akkuverbrauch, wenn dein Telefon wenig Akku hat oder im Energiesparmodus ist. Der Sensor speichert die Daten selbst, es geht also nichts verloren – NOOP synchronisiert nur seltener.</string>
+    <string name="power_saving_mode">Energiesparmodus</string>
+    <string name="power_saving_mode_desc">Verlangsamt die Hintergrund-Synchronisierung des Sensors (alle 45 statt 15 Minuten), wenn der Akku niedrig ist oder der Energiesparmodus aktiv ist. Kein Datenverlust – die Synchronisierung erfolgt in größeren, selteneren Schüben.</string>
+    <string name="power_saving_kick_in">Aktiv ab</string>
+    <string name="power_saving_pct">%1$d %%</string>
+    <string name="power_saving_hrv_pause">HFV-Erfassung im Energiesparmodus pausieren</string>
+    <string name="power_saving_hrv_pause_desc">Solange der Android-Energiesparmodus aktiv ist, wird der dauerhafte HFV-Hintergrundstream gestoppt (der größte Live-Verbraucher). Beim Öffnen eines Live-Bildschirms wird weiterhin die Herzfrequenz angezeigt, und er wird automatisch reaktiviert, wenn der Energiesparmodus endet.</string>
 </resources>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -163,4 +163,14 @@
     <string name="timeline_empty_metric">No %1$s here</string>
     <string name="timeline_nothing_offloaded">Nothing offloaded for this window yet.</string>
     <string name="timeline_other_sources_no_offload">Other sources don\'t offload raw per-second data on-device.</string>
+
+    <!-- Power saving (#477) -->
+    <string name="power_saving">Power saving</string>
+    <string name="power_saving_blurb">Ease battery use when your phone is low or in Battery Saver. The strap keeps banking data on its own, so nothing is lost — NOOP just syncs it less often.</string>
+    <string name="power_saving_mode">Power saving mode</string>
+    <string name="power_saving_mode_desc">Slows background strap-sync (every 45 min instead of 15) while your battery is low or Battery Saver is on. No data loss — sync just batches into larger, less frequent pulls.</string>
+    <string name="power_saving_kick_in">Kick in at</string>
+    <string name="power_saving_pct">%1$d%%</string>
+    <string name="power_saving_hrv_pause">Pause HRV capture in Battery Saver</string>
+    <string name="power_saving_hrv_pause_desc">While Android Battery Saver is on, stop the always-on background HRV stream (the biggest live drain). Opening a Live screen still shows heart rate, and it re-arms automatically when Battery Saver turns off.</string>
 </resources>

--- a/android/app/src/test/java/com/noop/ble/ConnectionPriorityTest.kt
+++ b/android/app/src/test/java/com/noop/ble/ConnectionPriorityTest.kt
@@ -51,18 +51,23 @@ class ConnectionPriorityTest {
     // --- battery-adaptive gate for the risky idle throttle (#477) ---
 
     @Test fun idleThrottleEngagesOnlyWhenDischargingAtOrBelowThreshold() {
-        // at/below threshold, discharging → engage
-        assertTrue(WhoopBleClient.idleThrottleActive(batteryPct = 20, charging = false, thresholdPct = 20))
-        assertTrue(WhoopBleClient.idleThrottleActive(batteryPct = 12, charging = false, thresholdPct = 20))
-        // above threshold → do not engage
-        assertFalse(WhoopBleClient.idleThrottleActive(batteryPct = 21, charging = false, thresholdPct = 20))
+        // at/below threshold, discharging, no Battery Saver → engage
+        assertTrue(WhoopBleClient.idleThrottleActive(batteryPct = 20, charging = false, thresholdPct = 20, powerSave = false))
+        assertTrue(WhoopBleClient.idleThrottleActive(batteryPct = 12, charging = false, thresholdPct = 20, powerSave = false))
+        // above threshold, no Battery Saver → do not engage
+        assertFalse(WhoopBleClient.idleThrottleActive(batteryPct = 21, charging = false, thresholdPct = 20, powerSave = false))
     }
 
     @Test fun idleThrottleNeverEngagesWhenChargingOrDisabled() {
-        // charging → never (battery isn't the concern)
-        assertFalse(WhoopBleClient.idleThrottleActive(batteryPct = 5, charging = true, thresholdPct = 30))
-        // threshold 0 → disabled (safe half only), even at 1%
-        assertFalse(WhoopBleClient.idleThrottleActive(batteryPct = 1, charging = false, thresholdPct = 0))
+        // charging → never (battery isn't the concern), even under Battery Saver
+        assertFalse(WhoopBleClient.idleThrottleActive(batteryPct = 5, charging = true, thresholdPct = 30, powerSave = true))
+        // threshold 0 → disabled (safe half only); NOT even Battery Saver forces the risky throttle
+        assertFalse(WhoopBleClient.idleThrottleActive(batteryPct = 1, charging = false, thresholdPct = 0, powerSave = true))
+    }
+
+    @Test fun batterySaverEngagesAnArmedThrottleAboveThreshold() {
+        // armed (threshold 20), battery well above it, but Battery Saver on + discharging → engage
+        assertTrue(WhoopBleClient.idleThrottleActive(batteryPct = 80, charging = false, thresholdPct = 20, powerSave = true))
     }
 
     // --- battery-adaptive offload cadence (#477) ---
@@ -72,15 +77,17 @@ class ConnectionPriorityTest {
 
     @Test fun offloadStretchesOnlyWhenDischargingAtOrBelowThreshold() {
         // discharging, at/below → stretched
-        assertEquals(low, WhoopBleClient.offloadIntervalMsFor(base, low, batteryPct = 18, charging = false, thresholdPct = 20))
-        // above threshold → normal cadence
-        assertEquals(base, WhoopBleClient.offloadIntervalMsFor(base, low, batteryPct = 40, charging = false, thresholdPct = 20))
+        assertEquals(low, WhoopBleClient.offloadIntervalMsFor(base, low, batteryPct = 18, charging = false, thresholdPct = 20, powerSave = false))
+        // above threshold, no Battery Saver → normal cadence
+        assertEquals(base, WhoopBleClient.offloadIntervalMsFor(base, low, batteryPct = 40, charging = false, thresholdPct = 20, powerSave = false))
+        // armed + Battery Saver above threshold → stretched
+        assertEquals(low, WhoopBleClient.offloadIntervalMsFor(base, low, batteryPct = 70, charging = false, thresholdPct = 20, powerSave = true))
     }
 
     @Test fun offloadNeverStretchesWhenChargingOrDisabled() {
-        // charging → normal even at low battery
-        assertEquals(base, WhoopBleClient.offloadIntervalMsFor(base, low, batteryPct = 8, charging = true, thresholdPct = 30))
-        // threshold 0 → normal cadence always
-        assertEquals(base, WhoopBleClient.offloadIntervalMsFor(base, low, batteryPct = 3, charging = false, thresholdPct = 0))
+        // charging → normal even at low battery / Battery Saver
+        assertEquals(base, WhoopBleClient.offloadIntervalMsFor(base, low, batteryPct = 8, charging = true, thresholdPct = 30, powerSave = true))
+        // threshold 0 → normal cadence always, even under Battery Saver
+        assertEquals(base, WhoopBleClient.offloadIntervalMsFor(base, low, batteryPct = 3, charging = false, thresholdPct = 0, powerSave = true))
     }
 }

--- a/android/app/src/test/java/com/noop/ble/ConnectionPriorityTest.kt
+++ b/android/app/src/test/java/com/noop/ble/ConnectionPriorityTest.kt
@@ -2,6 +2,8 @@ package com.noop.ble
 
 import android.bluetooth.BluetoothGatt
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 /**
@@ -44,5 +46,22 @@ class ConnectionPriorityTest {
             BluetoothGatt.CONNECTION_PRIORITY_LOW_POWER,
             WhoopBleClient.connectionPriorityFor(offloadActive = false, liveHrActive = false, idleThrottleEnabled = true),
         )
+    }
+
+    // --- battery-adaptive gate for the risky idle throttle (#477) ---
+
+    @Test fun idleThrottleEngagesOnlyWhenDischargingAtOrBelowThreshold() {
+        // at/below threshold, discharging → engage
+        assertTrue(WhoopBleClient.idleThrottleActive(batteryPct = 20, charging = false, thresholdPct = 20))
+        assertTrue(WhoopBleClient.idleThrottleActive(batteryPct = 12, charging = false, thresholdPct = 20))
+        // above threshold → do not engage
+        assertFalse(WhoopBleClient.idleThrottleActive(batteryPct = 21, charging = false, thresholdPct = 20))
+    }
+
+    @Test fun idleThrottleNeverEngagesWhenChargingOrDisabled() {
+        // charging → never (battery isn't the concern)
+        assertFalse(WhoopBleClient.idleThrottleActive(batteryPct = 5, charging = true, thresholdPct = 30))
+        // threshold 0 → disabled (safe half only), even at 1%
+        assertFalse(WhoopBleClient.idleThrottleActive(batteryPct = 1, charging = false, thresholdPct = 0))
     }
 }

--- a/android/app/src/test/java/com/noop/ble/ConnectionPriorityTest.kt
+++ b/android/app/src/test/java/com/noop/ble/ConnectionPriorityTest.kt
@@ -1,0 +1,48 @@
+package com.noop.ble
+
+import android.bluetooth.BluetoothGatt
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Pins [WhoopBleClient.connectionPriorityFor] — the pure GATT connection-priority decision (#477),
+ * unit-testable without a BLE stack (the [ScanPowerBackoffTest] idiom).
+ *
+ * SAFE half: HIGH during an offload burst OR a live-HR session — a SHORTER interval than BALANCED, so
+ * it can't cause a supervision-timeout drop and it shortens the radio-on window. RISKY half
+ * ([idleThrottleEnabled], default off): LOW_POWER when idle. Off → BALANCED, today's default.
+ */
+class ConnectionPriorityTest {
+
+    @Test fun activeWorkIsAlwaysHigh() {
+        // offload OR live-HR → HIGH, and the idle throttle can't override active work
+        assertEquals(
+            BluetoothGatt.CONNECTION_PRIORITY_HIGH,
+            WhoopBleClient.connectionPriorityFor(offloadActive = true, liveHrActive = false, idleThrottleEnabled = false),
+        )
+        assertEquals(
+            BluetoothGatt.CONNECTION_PRIORITY_HIGH,
+            WhoopBleClient.connectionPriorityFor(offloadActive = false, liveHrActive = true, idleThrottleEnabled = false),
+        )
+        assertEquals(
+            BluetoothGatt.CONNECTION_PRIORITY_HIGH,
+            WhoopBleClient.connectionPriorityFor(offloadActive = true, liveHrActive = false, idleThrottleEnabled = true),
+        )
+    }
+
+    @Test fun idleWithThrottleOffStaysBalanced() {
+        // The whole point of the safe half shipping default-on: idle == today's behaviour when the
+        // risky throttle is off.
+        assertEquals(
+            BluetoothGatt.CONNECTION_PRIORITY_BALANCED,
+            WhoopBleClient.connectionPriorityFor(offloadActive = false, liveHrActive = false, idleThrottleEnabled = false),
+        )
+    }
+
+    @Test fun idleWithThrottleOnDropsToLowPower() {
+        assertEquals(
+            BluetoothGatt.CONNECTION_PRIORITY_LOW_POWER,
+            WhoopBleClient.connectionPriorityFor(offloadActive = false, liveHrActive = false, idleThrottleEnabled = true),
+        )
+    }
+}

--- a/android/app/src/test/java/com/noop/ble/ConnectionPriorityTest.kt
+++ b/android/app/src/test/java/com/noop/ble/ConnectionPriorityTest.kt
@@ -64,4 +64,23 @@ class ConnectionPriorityTest {
         // threshold 0 → disabled (safe half only), even at 1%
         assertFalse(WhoopBleClient.idleThrottleActive(batteryPct = 1, charging = false, thresholdPct = 0))
     }
+
+    // --- battery-adaptive offload cadence (#477) ---
+
+    private val base = 900_000L      // 15 min
+    private val low = 2_700_000L     // 45 min
+
+    @Test fun offloadStretchesOnlyWhenDischargingAtOrBelowThreshold() {
+        // discharging, at/below → stretched
+        assertEquals(low, WhoopBleClient.offloadIntervalMsFor(base, low, batteryPct = 18, charging = false, thresholdPct = 20))
+        // above threshold → normal cadence
+        assertEquals(base, WhoopBleClient.offloadIntervalMsFor(base, low, batteryPct = 40, charging = false, thresholdPct = 20))
+    }
+
+    @Test fun offloadNeverStretchesWhenChargingOrDisabled() {
+        // charging → normal even at low battery
+        assertEquals(base, WhoopBleClient.offloadIntervalMsFor(base, low, batteryPct = 8, charging = true, thresholdPct = 30))
+        // threshold 0 → normal cadence always
+        assertEquals(base, WhoopBleClient.offloadIntervalMsFor(base, low, batteryPct = 3, charging = false, thresholdPct = 0))
+    }
 }


### PR DESCRIPTION
Implements the Android battery lever coordinated in #477, shipped **dormant (default-off)** so it merges completely inert and the behaviour change waits for on-strap validation.

## What

Request `CONNECTION_PRIORITY_HIGH` during an offload burst / live-HR session, and — behind an opt-in idle throttle — `CONNECTION_PRIORITY_LOW_POWER` when the connection is idle. Today the WHOOP link runs at the default `BALANCED` for its whole lifetime (`requestConnectionPriority` is never called), even though it's idle most of the day.

## Safe / risky split (per #477)

- **SAFE — HIGH during offload/live-HR:** HIGH is a *shorter* interval than BALANCED, so it **cannot** cause a supervision-timeout drop (it makes the link more robust) and it shortens the radio-on window → faster sync, net battery win.
- **RISKY — LOW_POWER idle** (`idleThrottleEnabled`, off): a *longer* interval — the real all-day saving, but a too-long interval can drop the link, so it's opt-in and must be validated on hardware.

## Dormant by default

`connectionPriorityEnabled` defaults **false**, so `refreshConnectionPriority()` early-returns and issues **zero new BLE ops** — the link stays at the stack default exactly as before. Merging changes nothing. `setConnectionPriorityManagement(enabled, idleThrottle)` is the seam a follow-up wires to a persisted Settings toggle, after the validation in #477.

## Implementation

- Pure `connectionPriorityFor(offloadActive, liveHrActive, idleThrottleEnabled)` in the companion — the `scanModeForReconnectAttempts` (#588) idiom, unit-testable with no BLE stack.
- `GattOps.requestConnectionPriorityCompat` added to the existing injectable seam (`RealGattOps` delegates to `gatt.requestConnectionPriority`).
- Wired at the real transitions: offload `begin` → HIGH, `exitBackfilling` → idle, `reconcileRealtime` → HIGH/idle. Reads the authoritative **internal** flags (`backfilling`/`realtimeArmed`), not the published `LiveState` mirror which updates a beat later.

## Parity

**Android-only by necessity.** CoreBluetooth exposes no app-side connection-priority equivalent (the peripheral proposes the GAP connection parameters, iOS negotiates), so there's no Swift twin — a deliberate platform divergence documented in the `connectionPriorityFor` doc, not a parity gap. (#477)

## Verification

- `:app:compileFullDebugKotlin` — compiles.
- `ConnectionPriorityTest` (4 cases: active→HIGH incl. over the throttle, idle+off→BALANCED, idle+on→LOW_POWER) — green.
- **On-strap validation is pending and gates *enabling*, not this dormant merge** — per #477: safe half first (connect → offload → confirm sync completes, zero new involuntary drops), then a multi-day idle-throttle trial (battery delta + drop count). Compile/unit tests prove the logic, nothing about BLE behaviour.

Do **not** flip the toggle on / promote to default-on until that hardware trial is done.