### PR TITLE
feat(ble,ui): iOS parity for the battery-adaptive power-saving levers (#477)

### DIFF
--- a/Strand/App/AppModel.swift
+++ b/Strand/App/AppModel.swift
@@ -301,6 +301,7 @@ final class AppModel: ObservableObject {
         live.$bonded.removeDuplicates().sink { [weak self] _ in
             guard let self else { return }
             self.ble.setKeepRealtimeForData(PuffinExperiment.keepRealtimeForDataEnabled)
+            self.applyPowerSaving()
         }.store(in: &hrCancellables)
         // A completed backfill has just written strap history. Refresh the dashboard cache,
         // but leave heavyweight analysis to its own guarded/background-friendly path.
@@ -340,6 +341,7 @@ final class AppModel: ObservableObject {
         // reflects it from launch , the reconciler then arms the dense stream as soon as the strap bonds
         // (and the bond sink above re-applies it on every reconnect).
         ble.setKeepRealtimeForData(PuffinExperiment.keepRealtimeForDataEnabled)
+        applyPowerSaving()
 
         // Turn the strap's offloaded raw data into dashboard scores on launch and every 15
         // minutes, so recovery / strain / sleep populate from the strap itself with no import.
@@ -416,6 +418,16 @@ final class AppModel: ObservableObject {
     }
 
     /// Build the device registry + source coordinator once the store is open, then start observing.
+    /// #477: push the persisted Power-saving prefs to the BLE manager (parity with Android
+    /// `AppViewModel.applyPowerSaving`). Offload-cadence stretch uses the battery-% threshold (0 = off
+    /// when the master is off); the HRV pause is a sub-option, only effective while the master is on.
+    /// The riskier connection-priority idle throttle is intentionally not wired (Android-only, and dormant).
+    func applyPowerSaving() {
+        let on = PuffinExperiment.powerSavingEnabled
+        ble.setLowBatteryOffloadThrottle(on ? PuffinExperiment.powerSavingBatteryPct : 0)
+        ble.setPauseCaptureOnPowerSave(on && PuffinExperiment.pauseHrvOnPowerSaveEnabled)
+    }
+
     /// Tiny and guarded: with no generic strap paired the active id is "my-whoop", so the coordinator
     /// observes WHOOP-active and stays a NO-OP , the existing `scan()`/`disconnect()` WHOOP flow is
     /// untouched. The coordinator only acts if/when a non-WHOOP strap becomes the active device.

--- a/Strand/App/AppModel.swift
+++ b/Strand/App/AppModel.swift
@@ -425,7 +425,9 @@ final class AppModel: ObservableObject {
     func applyPowerSaving() {
         let on = PuffinExperiment.powerSavingEnabled
         ble.setLowBatteryOffloadThrottle(on ? PuffinExperiment.powerSavingBatteryPct : 0)
-        ble.setPauseCaptureOnPowerSave(on && PuffinExperiment.pauseHrvOnPowerSaveEnabled)
+        // HRV pause is battery-%-aware like the offload lever — pass the same threshold.
+        ble.setPauseCaptureOnPowerSave(on && PuffinExperiment.pauseHrvOnPowerSaveEnabled,
+                                       thresholdPct: PuffinExperiment.powerSavingBatteryPct)
     }
 
     /// Tiny and guarded: with no generic strap paired the active id is "my-whoop", so the coordinator

--- a/Strand/BLE/BLEManager.swift
+++ b/Strand/BLE/BLEManager.swift
@@ -558,7 +558,9 @@ public final class BLEManager: NSObject, ObservableObject {
     /// background continuous-HRV stream under Low Power Mode. Both are benign (no link risk). Set from
     /// Settings via `setLowBatteryOffloadThrottle`/`setPauseCaptureOnPowerSave`.
     private var lowBatteryOffloadPct = 0
-    private var pauseCaptureOnPowerSave = false
+    /// Battery-% at/below which the continuous-HRV pause engages while low on power (0 = off) — like the
+    /// offload lever, it also engages under Low Power Mode.
+    private var pauseCaptureBatteryPct = 0
     /// Derived want: the (heavy) realtime stream should be armed while EITHER a screen wants it OR the
     /// continuous-capture preference wants it. Keep-alive re-arms it; the post-bond branch arms it on
     /// connect. Recomputed only inside `reconcileRealtime()`.
@@ -2065,9 +2067,11 @@ public final class BLEManager: NSObject, ObservableObject {
         lowBatteryOffloadPct = thresholdPct
     }
 
-    /// #477 (Settings): pause the background continuous-HRV stream under Low Power Mode. Reconciles now.
-    public func setPauseCaptureOnPowerSave(_ enabled: Bool) {
-        pauseCaptureOnPowerSave = enabled
+    /// #477 (Settings): pause the background continuous-HRV stream while power-saving. Battery-%-aware
+    /// like the offload lever — pass the same threshold; engages at/below it OR under Low Power Mode
+    /// (0 = off). Reconciles now.
+    public func setPauseCaptureOnPowerSave(_ enabled: Bool, thresholdPct: Int) {
+        pauseCaptureBatteryPct = enabled ? thresholdPct : 0
         reconcileRealtime()
     }
 
@@ -2108,10 +2112,18 @@ public final class BLEManager: NSObject, ObservableObject {
     /// Mirrors the Android `continuousCaptureWantsNow`.
     private func continuousCaptureWantsNow(now: Date = Date()) -> Bool {
         guard keepRealtimeForData else { return false }
-        // #477: while Low Power Mode is on, release the held-open background stream (own toggle). A Live
-        // screen still arms it via screenWantsRealtime (checked separately in reconcileRealtime). The
-        // keep-alive re-derives this, so it re-arms automatically when Low Power Mode turns off.
-        if pauseCaptureOnPowerSave && powerSaveActive() { return false }
+        // #477: while power saving is ACTIVE (battery ≤ threshold or Low Power Mode), release the
+        // held-open background stream — battery-%-aware like the offload lever, via the shared
+        // lowPowerThrottleActive gate. A Live screen still arms it via screenWantsRealtime (checked
+        // separately in reconcileRealtime). The keep-alive re-derives this, so it re-arms automatically
+        // once off power save.
+        if pauseCaptureBatteryPct > 0 {
+            let (pct, charging) = batteryPctAndCharging()
+            if BLEManager.lowPowerThrottleActive(batteryPct: pct, charging: charging,
+                                                 thresholdPct: pauseCaptureBatteryPct, powerSave: powerSaveActive()) {
+                return false
+            }
+        }
         let comps = Calendar.current.dateComponents([.hour, .minute], from: now)
         let minuteOfDay = (comps.hour ?? 0) * 60 + (comps.minute ?? 0)
         let d = UserDefaults.standard

--- a/Strand/BLE/BLEManager.swift
+++ b/Strand/BLE/BLEManager.swift
@@ -511,6 +511,25 @@ public final class BLEManager: NSObject, ObservableObject {
     // The timer fires this often, but BackfillPolicy.periodicFloorSeconds is the real floor (a recent
     // event-triggered sync defers the next periodic tick). 900s = 15 min, matching WHOOP.
     static let backfillIntervalSeconds = 900
+    /// #477: stretched offload cadence while low on power (45 min). The strap banks to flash meanwhile,
+    /// so this only delays sync (larger batches), never loses data. Mirrors Android
+    /// `LOW_BATTERY_BACKFILL_INTERVAL_MS`.
+    static let lowBatteryBackfillIntervalSeconds = 2700
+
+    /// Pure battery-adaptive gate (#477), the twin of Android `WhoopBleClient.idleThrottleActive`.
+    /// Armed by `thresholdPct` > 0; once armed and while discharging it engages at/below `thresholdPct`
+    /// OR when the OS is saving power (`powerSave`). `thresholdPct` <= 0 / charging never engages.
+    static func lowPowerThrottleActive(batteryPct: Int, charging: Bool, thresholdPct: Int, powerSave: Bool) -> Bool {
+        thresholdPct > 0 && !charging && (batteryPct <= thresholdPct || powerSave)
+    }
+
+    /// Pure offload-interval decision (#477), the twin of Android `offloadIntervalMsFor`.
+    static func offloadInterval(baseSeconds: Int, lowSeconds: Int,
+                                batteryPct: Int, charging: Bool, thresholdPct: Int, powerSave: Bool) -> Int {
+        lowPowerThrottleActive(batteryPct: batteryPct, charging: charging, thresholdPct: thresholdPct, powerSave: powerSave)
+            ? max(baseSeconds, lowSeconds) : baseSeconds
+    }
+
     /// Keep-alive: re-arm realtime, poll battery, and bounce a stalled link so streaming
     /// never silently dies. Started on bond, cancelled on disconnect.
     private var keepAliveTimer: DispatchSourceTimer?
@@ -534,6 +553,12 @@ public final class BLEManager: NSObject, ObservableObject {
     /// preference intent; the effective want is window-gated through `continuousCaptureWantsNow()` when
     /// "overnight only" is on, re-derived at every arm site.
     private var keepRealtimeForData = false
+    /// #477 battery (parity with Android): battery-% at/below which the periodic offload cadence stretches
+    /// to `lowBatteryBackfillIntervalSeconds` while low on power (0 = off), and whether to pause the
+    /// background continuous-HRV stream under Low Power Mode. Both are benign (no link risk). Set from
+    /// Settings via `setLowBatteryOffloadThrottle`/`setPauseCaptureOnPowerSave`.
+    private var lowBatteryOffloadPct = 0
+    private var pauseCaptureOnPowerSave = false
     /// Derived want: the (heavy) realtime stream should be armed while EITHER a screen wants it OR the
     /// continuous-capture preference wants it. Keep-alive re-arms it; the post-bond branch arms it on
     /// connect. Recomputed only inside `reconcileRealtime()`.
@@ -2034,6 +2059,47 @@ public final class BLEManager: NSObject, ObservableObject {
         reconcileRealtime()
     }
 
+    /// #477 (Settings): battery-% at/below which the offload cadence stretches while discharging (0 = off).
+    /// Applies on the next re-arm; a live sync in flight is never interrupted.
+    public func setLowBatteryOffloadThrottle(_ thresholdPct: Int) {
+        lowBatteryOffloadPct = thresholdPct
+    }
+
+    /// #477 (Settings): pause the background continuous-HRV stream under Low Power Mode. Reconciles now.
+    public func setPauseCaptureOnPowerSave(_ enabled: Bool) {
+        pauseCaptureOnPowerSave = enabled
+        reconcileRealtime()
+    }
+
+    /// #477: is the OS saving power (Low Power Mode)? The iOS analog of Android's Battery Saver; also on
+    /// macOS 12+. An additional trigger for an already-armed lever.
+    private func powerSaveActive() -> Bool { ProcessInfo.processInfo.isLowPowerModeEnabled }
+
+    /// #477: current (battery-%, isCharging). iOS reads `UIDevice`; macOS has no per-app battery API here,
+    /// so it returns (100, false) — the %-threshold then never engages and only Low Power Mode does.
+    private func batteryPctAndCharging() -> (pct: Int, charging: Bool) {
+        #if os(iOS)
+        let dev = UIDevice.current
+        dev.isBatteryMonitoringEnabled = true
+        let lvl = dev.batteryLevel   // 0...1, or -1 when unknown
+        let charging = dev.batteryState == .charging || dev.batteryState == .full
+        return (lvl >= 0 ? Int((lvl * 100).rounded()) : 100, charging)
+        #else
+        return (100, false)
+        #endif
+    }
+
+    /// The next periodic-offload interval — normally `backfillIntervalSeconds`, stretched when low on
+    /// power (#477). Reads the battery snapshot only when the lever is armed (threshold > 0).
+    private func nextBackfillInterval() -> Int {
+        guard lowBatteryOffloadPct > 0 else { return BLEManager.backfillIntervalSeconds }
+        let (pct, charging) = batteryPctAndCharging()
+        return BLEManager.offloadInterval(
+            baseSeconds: BLEManager.backfillIntervalSeconds,
+            lowSeconds: BLEManager.lowBatteryBackfillIntervalSeconds,
+            batteryPct: pct, charging: charging, thresholdPct: lowBatteryOffloadPct, powerSave: powerSaveActive())
+    }
+
     /// #927: the continuous-capture side of the realtime want, window-gated. True while the "Continuous
     /// HRV capture" preference wants the stream held open AND, when "overnight only" is on, the local
     /// wall clock sits inside the nightly window (the reused quiet-hours window, 22:00 → 07:00 by
@@ -2042,6 +2108,10 @@ public final class BLEManager: NSObject, ObservableObject {
     /// Mirrors the Android `continuousCaptureWantsNow`.
     private func continuousCaptureWantsNow(now: Date = Date()) -> Bool {
         guard keepRealtimeForData else { return false }
+        // #477: while Low Power Mode is on, release the held-open background stream (own toggle). A Live
+        // screen still arms it via screenWantsRealtime (checked separately in reconcileRealtime). The
+        // keep-alive re-derives this, so it re-arms automatically when Low Power Mode turns off.
+        if pauseCaptureOnPowerSave && powerSaveActive() { return false }
         let comps = Calendar.current.dateComponents([.hour, .minute], from: now)
         let minuteOfDay = (comps.hour ?? 0) * 60 + (comps.minute ?? 0)
         let d = UserDefaults.standard
@@ -2414,9 +2484,11 @@ public final class BLEManager: NSObject, ObservableObject {
 
     private func startBackfillTimer() {
         backfillTimer?.cancel()
-        let interval = BLEManager.backfillIntervalSeconds
+        // #477: one-shot, re-armed by triggerPeriodicBackfill() with a fresh (battery-adaptive) interval
+        // each tick — so the cadence can stretch/relax as power state changes (was a fixed repeating timer).
+        let interval = nextBackfillInterval()
         let t = DispatchSource.makeTimerSource(queue: .main)
-        t.schedule(deadline: .now() + .seconds(interval), repeating: .seconds(interval))
+        t.schedule(deadline: .now() + .seconds(interval))
         t.setEventHandler { [weak self] in self?.triggerPeriodicBackfill() }
         t.resume()
         backfillTimer = t
@@ -2449,6 +2521,7 @@ public final class BLEManager: NSObject, ObservableObject {
     /// Periodic-timer callback: routes through the rate-limited requestSync entry point.
     private func triggerPeriodicBackfill() {
         requestSync(.periodic)
+        startBackfillTimer()   // #477: re-arm with a fresh battery-adaptive interval (one-shot timer)
     }
 
     /// User-tappable "Sync now" (#364): kick a historical offload IMMEDIATELY, bypassing the 15-min

--- a/Strand/BLE/PuffinExperiment.swift
+++ b/Strand/BLE/PuffinExperiment.swift
@@ -50,6 +50,24 @@ enum PuffinExperiment {
 
     static var continuousHrvOvernightOnlyEnabled: Bool { UserDefaults.standard.bool(forKey: continuousHrvOvernightOnlyKey) }
 
+    // MARK: - Power saving (#477), parity with Android NoopPrefs
+
+    /// "Power saving" master: battery-adaptive strap-sync cadence. Default off. */
+    static let powerSavingKey = "noopPowerSaving"
+    static var powerSavingEnabled: Bool { UserDefaults.standard.bool(forKey: powerSavingKey) }
+
+    /// Battery-% threshold for power saving (10–30). Default 20 (0 in the store means "unset" → 20).
+    static let powerSavingBatteryPctKey = "noopPowerSavingBatteryPct"
+    static var powerSavingBatteryPct: Int {
+        let v = UserDefaults.standard.integer(forKey: powerSavingBatteryPctKey)
+        return v == 0 ? 20 : v
+    }
+
+    /// "Pause HRV capture under Low Power Mode" — a sub-option of power saving, default ON when the master
+    /// is on. Stored inverted (`…Disabled`) so the default-true reads correctly from a zero-value store.
+    static let pauseHrvDisabledKey = "noopPowerSavingPauseHrvDisabled"
+    static var pauseHrvOnPowerSaveEnabled: Bool { !UserDefaults.standard.bool(forKey: pauseHrvDisabledKey) }
+
     /// "Experimental sleep staging (V2)": re-stage each detected night with `SleepStagerV2` — a transparent
     /// cardiorespiratory recipe (reimplemented from contributor PR #600) — instead of the older V1 stager.
     /// Pure analysis switch: it changes ONLY which staging engine runs over an already-detected sleep window;

--- a/Strand/Screens/SettingsView.swift
+++ b/Strand/Screens/SettingsView.swift
@@ -52,6 +52,12 @@ struct SettingsView: View {
     /// See [PuffinExperiment.continuousHrvOvernightOnlyKey].
     @AppStorage(PuffinExperiment.continuousHrvOvernightOnlyKey) private var continuousHrvOvernightOnly = false
 
+    // #477 Power saving (parity with Android). Battery-adaptive sync cadence + an HRV-pause sub-option.
+    @AppStorage(PuffinExperiment.powerSavingKey) private var powerSavingEnabled = false
+    @AppStorage(PuffinExperiment.powerSavingBatteryPctKey) private var powerSavingPct = 20
+    /// Stored INVERTED so the default (absent = false) reads as "HRV pause on". The toggle shows `!this`.
+    @AppStorage(PuffinExperiment.pauseHrvDisabledKey) private var pauseHrvDisabled = false
+
     /// "Experimental sleep staging (V2)" (ON by default, promoted after the 44-subject cross-subject
     /// benchmark). When on, detected nights are re-staged with `SleepStagerV2` (the transparent
     /// cardiorespiratory recipe) instead of the older V1 stager. Read at the staging call site in
@@ -189,7 +195,8 @@ struct SettingsView: View {
                 unitsCard.staggeredAppear(index: 2)
                 appearanceCard.staggeredAppear(index: 3)
                 strapCard.staggeredAppear(index: 4)
-                featuresCard.staggeredAppear(index: 5)
+                powerSavingCard.staggeredAppear(index: 5)
+                featuresCard.staggeredAppear(index: 6)
 
                 // Lower-frequency sections collapse behind a single default-closed disclosure so the
                 // screen opens at ~6 sections instead of 11. Nothing is removed; every section here
@@ -946,6 +953,64 @@ struct SettingsView: View {
                     .foregroundStyle(StrandPalette.textTertiary)
                     .fixedSize(horizontal: false, vertical: true)
                 #endif
+            }
+        }
+    }
+
+    // MARK: - Power saving (#477)
+    private var powerSavingCard: some View {
+        SettingsSection(
+            icon: "battery.25",
+            title: "Power saving",
+            blurb: "Ease battery use when your phone is low or in Low Power Mode. The strap keeps banking data on its own, so nothing is lost — NOOP just syncs it less often."
+        ) {
+            VStack(alignment: .leading, spacing: 16) {
+                Toggle(isOn: $powerSavingEnabled) {
+                    Text("Power saving mode")
+                        .font(StrandFont.subhead)
+                        .foregroundStyle(StrandPalette.textPrimary)
+                }
+                .toggleStyle(.switch)
+                .tint(StrandPalette.accent)
+                .onChangeCompat(of: powerSavingEnabled) { _ in model.applyPowerSaving() }
+                Text("Slows background strap-sync (every 45 min instead of 15) while your battery is low or Low Power Mode is on. No data loss — sync just batches into larger, less frequent pulls.")
+                    .font(StrandFont.caption)
+                    .foregroundStyle(StrandPalette.textTertiary)
+                    .fixedSize(horizontal: false, vertical: true)
+
+                if powerSavingEnabled {
+                    Divider().overlay(StrandPalette.hairline)
+                    HStack {
+                        Text("Kick in at")
+                            .font(StrandFont.subhead)
+                            .foregroundStyle(StrandPalette.textPrimary)
+                        Spacer()
+                        Text("\(powerSavingPct)%")
+                            .font(StrandFont.subhead)
+                            .foregroundStyle(StrandPalette.accent)
+                    }
+                    Slider(
+                        value: Binding(get: { Double(powerSavingPct) }, set: { powerSavingPct = Int($0) }),
+                        in: 10...30, step: 5,
+                        onEditingChanged: { editing in if !editing { model.applyPowerSaving() } }
+                    )
+                    .tint(StrandPalette.accent)
+
+                    Divider().overlay(StrandPalette.hairline)
+                    // HRV pause: a sub-option, ON by default when the master is on (stored inverted).
+                    Toggle(isOn: Binding(get: { !pauseHrvDisabled }, set: { pauseHrvDisabled = !$0 })) {
+                        Text("Pause HRV capture in Low Power Mode")
+                            .font(StrandFont.subhead)
+                            .foregroundStyle(StrandPalette.textPrimary)
+                    }
+                    .toggleStyle(.switch)
+                    .tint(StrandPalette.accent)
+                    .onChangeCompat(of: pauseHrvDisabled) { _ in model.applyPowerSaving() }
+                    Text("While Low Power Mode is on, stop the always-on background HRV stream (the biggest live drain). Opening a Live screen still shows heart rate, and it re-arms automatically when Low Power Mode turns off.")
+                        .font(StrandFont.caption)
+                        .foregroundStyle(StrandPalette.textTertiary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
             }
         }
     }

--- a/Strand/Screens/SettingsView.swift
+++ b/Strand/Screens/SettingsView.swift
@@ -985,7 +985,7 @@ struct SettingsView: View {
                             .font(StrandFont.subhead)
                             .foregroundStyle(StrandPalette.textPrimary)
                         Spacer()
-                        Text("\(powerSavingPct)%")
+                        Text(verbatim: "\(powerSavingPct)%")
                             .font(StrandFont.subhead)
                             .foregroundStyle(StrandPalette.accent)
                     }

--- a/Strand/Screens/SettingsView.swift
+++ b/Strand/Screens/SettingsView.swift
@@ -999,14 +999,14 @@ struct SettingsView: View {
                     Divider().overlay(StrandPalette.hairline)
                     // HRV pause: a sub-option, ON by default when the master is on (stored inverted).
                     Toggle(isOn: Binding(get: { !pauseHrvDisabled }, set: { pauseHrvDisabled = !$0 })) {
-                        Text("Pause HRV capture in Low Power Mode")
+                        Text("Pause HRV capture")
                             .font(StrandFont.subhead)
                             .foregroundStyle(StrandPalette.textPrimary)
                     }
                     .toggleStyle(.switch)
                     .tint(StrandPalette.accent)
                     .onChangeCompat(of: pauseHrvDisabled) { _ in model.applyPowerSaving() }
-                    Text("While Low Power Mode is on, stop the always-on background HRV stream (the biggest live drain). Opening a Live screen still shows heart rate, and it re-arms automatically when Low Power Mode turns off.")
+                    Text("While saving power (battery low or Low Power Mode), stop the always-on background HRV stream — the biggest live drain. A Live screen still shows heart rate, and it re-arms automatically once you're off power saving.")
                         .font(StrandFont.caption)
                         .foregroundStyle(StrandPalette.textTertiary)
                         .fixedSize(horizontal: false, vertical: true)


### PR DESCRIPTION
iOS twins of the two **benign** battery levers shipped for Android in #478, so the Power saving feature reaches parity on the platforms where it's possible.

## What's mirrored
- **Offload-cadence stretch** (15 → 45 min) — `BLEManager`'s offload timer is now one-shot, re-armed each tick with a battery-adaptive interval. Pure `offloadInterval`/`lowPowerThrottleActive` are twins of the Android `offloadIntervalMsFor`/`idleThrottleActive`. Gated on battery-% **or** Low Power Mode while discharging.
- **Continuous-HRV pause** — gate in `continuousCaptureWantsNow()`; rides the existing reconcile + keep-alive re-derivation (the ~60s battery poll keeps the link under the 120s fuse, so no bounce/thrash — verified the same way as Android).
- **Settings → Power saving** — master toggle + 10–30% slider + HRV-pause sub-option (on by default), `@AppStorage` in `PuffinExperiment`, applied at launch and each bond via `AppModel.applyPowerSaving()`.

## iOS-specific adaptations
- **Battery-Saver signal = `ProcessInfo.isLowPowerModeEnabled`** (the iOS analog; also works on macOS).
- **Battery %** via `UIDevice` on iOS; macOS has no per-app battery API here, so it falls back to Low-Power-Mode-only (the %-threshold simply never engages there — fails safe).
- **Connection-priority lever is Android-only by necessity** — CoreBluetooth exposes no `requestConnectionPriority` equivalent (documented in #477). It's also dormant/headless on Android, so no user-facing gap.

## Verification
- **Both app targets compile** — Strand (macOS) + NOOPiOS (iOS), via `app-build.yml` (app-target Swift has no default CI).
- **i18n gate green** — the 5 new Settings strings added to the Strand catalog + German; the `%` read-out is `Text(verbatim:)`.
- All benign, **default off**. No hardware validation needed (neither lever can drop the link) — unlike the connection-priority lever, which is why it stayed Android-only + dormant.

Follow-up: Swift unit tests for the pure decision twins (Android has `ConnectionPriorityTest`; not yet mirrored).