### PR TITLE
feat: defer Health Connect writeback while power-saving (Android) (#477)

### DIFF
--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -1203,12 +1203,13 @@ class WhoopBleClient(
     /** #477: pause BACKGROUND continuous-HRV capture while the OS Battery Saver is on (own toggle,
      *  DEFAULT OFF). A visible Live screen is unaffected — only the held-open background stream is
      *  released. Gated through [continuousCaptureWantsNow]. */
-    @Volatile private var pauseCaptureOnPowerSave: Boolean = false
+    @Volatile private var pauseCaptureBatteryPct: Int = 0
 
-    /** Opt into pausing continuous capture under Battery Saver (#477). Reconciles immediately so the
-     *  change takes effect without waiting for the next keep-alive tick. */
-    fun setPauseCaptureOnPowerSave(enabled: Boolean) {
-        pauseCaptureOnPowerSave = enabled
+    /** Opt into pausing continuous capture while power-saving (#477). Now battery-%-aware like the other
+     *  levers: pass the same threshold, so it engages at/below it OR under Battery Saver (0 = off).
+     *  Reconciles immediately so the change takes effect without waiting for the next keep-alive tick. */
+    fun setPauseCaptureOnPowerSave(enabled: Boolean, thresholdPct: Int) {
+        pauseCaptureBatteryPct = if (enabled) thresholdPct else 0
         handler.post { reconcileRealtime() }
     }
 
@@ -4345,12 +4346,16 @@ class WhoopBleClient(
      *  Mirrors the Swift `continuousCaptureWantsNow`. */
     private fun continuousCaptureWantsNow(): Boolean {
         if (!keepStreamForData) return false
-        // #477: optional power-saving pause — while the OS Battery Saver is on, release the held-open
-        // continuous-capture stream (its own toggle, default off). The realtime stream is one of the
-        // larger drains; a Live screen still arms it on demand (screenWantsRealtime is checked separately
-        // in reconcileRealtime), so this only drops the BACKGROUND capture the user opted into. Re-arms
-        // automatically when Battery Saver turns off.
-        if (pauseCaptureOnPowerSave && powerSaveActive()) return false
+        // #477: optional power-saving pause — while power saving is ACTIVE (battery ≤ threshold or Battery
+        // Saver, discharging), release the held-open continuous-capture stream (its own toggle, default
+        // off). Battery-%-aware like the offload/defer levers, via the shared idleThrottleActive gate. The
+        // realtime stream is one of the larger drains; a Live screen still arms it on demand
+        // (screenWantsRealtime is checked separately in reconcileRealtime), so this only drops the
+        // BACKGROUND capture the user opted into. Re-arms automatically once off power save.
+        if (pauseCaptureBatteryPct > 0) {
+            val (batteryPct, charging) = batteryPctAndCharging()
+            if (idleThrottleActive(batteryPct, charging, pauseCaptureBatteryPct, powerSaveActive())) return false
+        }
         val cal = java.util.Calendar.getInstance()
         val minuteOfDay = cal.get(java.util.Calendar.HOUR_OF_DAY) * 60 + cal.get(java.util.Calendar.MINUTE)
         return continuousHrvStreamWanted(

--- a/android/app/src/main/java/com/noop/ui/AppViewModel.kt
+++ b/android/app/src/main/java/com/noop/ui/AppViewModel.kt
@@ -1,6 +1,11 @@
 package com.noop.ui
 
 import android.app.Application
+import android.content.Context
+import android.content.Intent
+import android.content.IntentFilter
+import android.os.BatteryManager
+import android.os.PowerManager
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
 import com.noop.NoopApplication
@@ -38,6 +43,7 @@ import com.noop.data.WhoopRepository
 import com.noop.data.WorkoutRow
 import com.noop.ingest.ActivityFileImporter
 import com.noop.ingest.HealthConnectImporter
+import com.noop.ble.WhoopBleClient
 import com.noop.ingest.HealthConnectWriter
 import com.noop.ingest.LiftingImporter
 import com.noop.notif.IllnessAlertNotifier
@@ -866,7 +872,12 @@ class AppViewModel(app: Application) : AndroidViewModel(app) {
                 // apps see them. Idempotent (clientRecordId per metric+day), so re-running every
                 // cycle just upserts. Never let an HC hiccup (perm revoked mid-flight, provider
                 // update) break the analysis loop.
-                if (_hcWriteback.value) {
+                // #477: defer the writeback while power-saving is active (Android-only sub-option — iOS
+                // Health is Shortcut-driven, so it has no NOOP-scheduled sync to defer). Resumes next
+                // cycle once off power save; a manual Data-Sources sync always writes regardless.
+                if (_hcWriteback.value &&
+                    !(NoopPrefs.deferHealthSync(appContext) && isPowerSavingActiveNow())
+                ) {
                     runCatching { HealthConnectWriter.write(appContext, repository, deviceId) }
                 }
                 // 15-min backstop cadence, but wake EARLY on an app-resume kick (#386 self-heal) so a
@@ -899,6 +910,21 @@ class AppViewModel(app: Application) : AndroidViewModel(app) {
         ble.setLowBatteryOffloadThrottle(if (on) NoopPrefs.powerSavingBatteryPct(appContext) else 0)
         // HRV pause is a sub-option: only effective while the master is on (defaults on when it is).
         ble.setPauseCaptureOnPowerSave(on && NoopPrefs.pauseHrvOnPowerSave(appContext))
+    }
+
+    /** #477: is power saving CURRENTLY throttling — master on AND (battery ≤ threshold while discharging
+     *  OR Battery Saver)? Reuses the SAME pure gate as the BLE levers so all three agree. Read live per
+     *  analyze cycle; unknown battery fails SAFE (100 %, never throttles). */
+    private fun isPowerSavingActiveNow(): Boolean {
+        if (!NoopPrefs.powerSaving(appContext)) return false
+        val i = appContext.registerReceiver(null, IntentFilter(Intent.ACTION_BATTERY_CHANGED))
+        val level = i?.getIntExtra(BatteryManager.EXTRA_LEVEL, -1) ?: -1
+        val scale = i?.getIntExtra(BatteryManager.EXTRA_SCALE, -1) ?: -1
+        val status = i?.getIntExtra(BatteryManager.EXTRA_STATUS, -1) ?: -1
+        val pct = if (level >= 0 && scale > 0) level * 100 / scale else 100
+        val charging = status == BatteryManager.BATTERY_STATUS_CHARGING || status == BatteryManager.BATTERY_STATUS_FULL
+        val powerSave = (appContext.getSystemService(Context.POWER_SERVICE) as? PowerManager)?.isPowerSaveMode ?: false
+        return WhoopBleClient.idleThrottleActive(pct, charging, NoopPrefs.powerSavingBatteryPct(appContext), powerSave)
     }
 
     /** Flip "Power saving" (Settings). Persists + applies immediately. */

--- a/android/app/src/main/java/com/noop/ui/AppViewModel.kt
+++ b/android/app/src/main/java/com/noop/ui/AppViewModel.kt
@@ -908,8 +908,12 @@ class AppViewModel(app: Application) : AndroidViewModel(app) {
     private fun applyPowerSaving() {
         val on = NoopPrefs.powerSaving(appContext)
         ble.setLowBatteryOffloadThrottle(if (on) NoopPrefs.powerSavingBatteryPct(appContext) else 0)
-        // HRV pause is a sub-option: only effective while the master is on (defaults on when it is).
-        ble.setPauseCaptureOnPowerSave(on && NoopPrefs.pauseHrvOnPowerSave(appContext))
+        // HRV pause is a sub-option: only effective while the master is on (defaults on when it is), and
+        // now battery-%-aware like the offload lever — pass the same threshold.
+        ble.setPauseCaptureOnPowerSave(
+            on && NoopPrefs.pauseHrvOnPowerSave(appContext),
+            NoopPrefs.powerSavingBatteryPct(appContext),
+        )
     }
 
     /** #477: is power saving CURRENTLY throttling — master on AND (battery ≤ threshold while discharging

--- a/android/app/src/main/java/com/noop/ui/MainActivity.kt
+++ b/android/app/src/main/java/com/noop/ui/MainActivity.kt
@@ -217,6 +217,14 @@ object NoopPrefs {
      *  [com.noop.ble.WhoopBleClient.setPauseCaptureOnPowerSave] via [AppViewModel]. */
     const val KEY_PAUSE_HRV_ON_POWER_SAVE = "noop.pauseHrvOnPowerSave"
 
+    /** "Defer Health Connect writeback while power-saving" (#477), a sub-option of Power saving, default
+     *  ON. When power saving is active (battery ≤ threshold or Battery Saver, discharging), skip the
+     *  every-15-min idempotent Health Connect score writeback; it resumes automatically once off power
+     *  save (and a manual sync always runs it). ANDROID-ONLY BY DESIGN — iOS has no NOOP-scheduled Health
+     *  sync to defer (its Apple Health integration is Shortcut-driven because a sideload signing identity
+     *  can't hold the HealthKit entitlement), so there is nothing to gate on the iOS side. */
+    const val KEY_DEFER_HEALTH_SYNC = "noop.deferHealthSyncOnPowerSave"
+
     fun of(context: Context): SharedPreferences =
         context.getSharedPreferences(NAME, Context.MODE_PRIVATE)
 
@@ -242,6 +250,15 @@ object NoopPrefs {
 
     fun setPauseHrvOnPowerSave(context: Context, enabled: Boolean) {
         of(context).edit().putBoolean(KEY_PAUSE_HRV_ON_POWER_SAVE, enabled).apply()
+    }
+
+    /** Defer Health Connect writeback while power-saving is active (sub-option of Power saving). Default
+     *  ON. Android-only (see [KEY_DEFER_HEALTH_SYNC]). */
+    fun deferHealthSync(context: Context): Boolean =
+        of(context).getBoolean(KEY_DEFER_HEALTH_SYNC, true)
+
+    fun setDeferHealthSync(context: Context, enabled: Boolean) {
+        of(context).edit().putBoolean(KEY_DEFER_HEALTH_SYNC, enabled).apply()
     }
 
     /** #836, the raw-HR fingerprint ("count:maxTs") the last COMPLETED idle rescore scored against. The

--- a/android/app/src/main/java/com/noop/ui/SettingsScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/SettingsScreen.kt
@@ -483,6 +483,7 @@ fun SettingsScreen(
     var powerSaving by remember { mutableStateOf(NoopPrefs.powerSaving(context)) }
     var powerSavingBatteryPct by remember { mutableStateOf(NoopPrefs.powerSavingBatteryPct(context)) }
     var pauseHrvOnPowerSave by remember { mutableStateOf(NoopPrefs.pauseHrvOnPowerSave(context)) }
+    var deferHealthSync by remember { mutableStateOf(NoopPrefs.deferHealthSync(context)) }
 
     // --- v5 Health & wellness toggle group. All SharedPreferences-backed (not reactive), so each Switch
     // drives a local mirror that writes straight through to the same keys the v5 engine readers use.
@@ -1627,6 +1628,37 @@ fun SettingsScreen(
                         onCheckedChange = {
                             pauseHrvOnPowerSave = it
                             vm.setPauseHrvOnPowerSave(it)
+                        },
+                        colors = SwitchDefaults.colors(
+                            checkedThumbColor = Palette.surfaceBase,
+                            checkedTrackColor = Palette.accent,
+                            uncheckedThumbColor = Palette.textSecondary,
+                            uncheckedTrackColor = Palette.surfaceInset,
+                            uncheckedBorderColor = Palette.hairline,
+                        ),
+                    )
+                }
+                RowDivider()
+                // Defer Health Connect writeback: a sub-option of power saving, ON by default. Read live
+                // by the analyze loop (no BLE push), so a plain pref write is enough.
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(16.dp),
+                ) {
+                    Column(modifier = Modifier.weight(1f)) {
+                        Text(stringResource(R.string.power_saving_defer_health), style = NoopType.subhead, color = Palette.textPrimary)
+                        Text(
+                            stringResource(R.string.power_saving_defer_health_desc),
+                            style = NoopType.footnote,
+                            color = Palette.textTertiary,
+                        )
+                    }
+                    Switch(
+                        checked = deferHealthSync,
+                        onCheckedChange = {
+                            deferHealthSync = it
+                            NoopPrefs.setDeferHealthSync(context, it)
                         },
                         colors = SwitchDefaults.colors(
                             checkedThumbColor = Palette.surfaceBase,

--- a/android/app/src/main/res/values-de/strings.xml
+++ b/android/app/src/main/res/values-de/strings.xml
@@ -155,4 +155,6 @@
     <string name="power_saving_pct">%1$d %%</string>
     <string name="power_saving_hrv_pause">HFV-Erfassung im Energiesparmodus pausieren</string>
     <string name="power_saving_hrv_pause_desc">Solange der Android-Energiesparmodus aktiv ist, wird der dauerhafte HFV-Hintergrundstream gestoppt (der größte Live-Verbraucher). Beim Öffnen eines Live-Bildschirms wird weiterhin die Herzfrequenz angezeigt, und er wird automatisch reaktiviert, wenn der Energiesparmodus endet.</string>
+    <string name="power_saving_defer_health">Health-Connect-Rückschreibung aufschieben</string>
+    <string name="power_saving_defer_health_desc">Während des Energiesparens das Zurückschreiben der Werte an Health Connect aussetzen (sonst alle 15 Minuten). Es wird automatisch fortgesetzt, sobald das Energiesparen endet, und eine manuelle Synchronisierung führt es immer aus.</string>
 </resources>

--- a/android/app/src/main/res/values-de/strings.xml
+++ b/android/app/src/main/res/values-de/strings.xml
@@ -153,8 +153,8 @@
     <string name="power_saving_mode_desc">Verlangsamt die Hintergrund-Synchronisierung des Sensors (alle 45 statt 15 Minuten), wenn der Akku niedrig ist oder der Energiesparmodus aktiv ist. Kein Datenverlust – die Synchronisierung erfolgt in größeren, selteneren Schüben.</string>
     <string name="power_saving_kick_in">Aktiv ab</string>
     <string name="power_saving_pct">%1$d %%</string>
-    <string name="power_saving_hrv_pause">HFV-Erfassung im Energiesparmodus pausieren</string>
-    <string name="power_saving_hrv_pause_desc">Solange der Android-Energiesparmodus aktiv ist, wird der dauerhafte HFV-Hintergrundstream gestoppt (der größte Live-Verbraucher). Beim Öffnen eines Live-Bildschirms wird weiterhin die Herzfrequenz angezeigt, und er wird automatisch reaktiviert, wenn der Energiesparmodus endet.</string>
+    <string name="power_saving_hrv_pause">HFV-Erfassung pausieren</string>
+    <string name="power_saving_hrv_pause_desc">Während des Energiesparens (niedriger Akku oder Energiesparmodus) wird der dauerhafte HFV-Hintergrundstream gestoppt – der größte Live-Verbraucher. Ein Live-Bildschirm zeigt weiterhin die Herzfrequenz an, und er wird automatisch reaktiviert, sobald das Energiesparen endet.</string>
     <string name="power_saving_defer_health">Health-Connect-Rückschreibung aufschieben</string>
     <string name="power_saving_defer_health_desc">Während des Energiesparens das Zurückschreiben der Werte an Health Connect aussetzen (sonst alle 15 Minuten). Es wird automatisch fortgesetzt, sobald das Energiesparen endet, und eine manuelle Synchronisierung führt es immer aus.</string>
 </resources>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -171,8 +171,8 @@
     <string name="power_saving_mode_desc">Slows background strap-sync (every 45 min instead of 15) while your battery is low or Battery Saver is on. No data loss — sync just batches into larger, less frequent pulls.</string>
     <string name="power_saving_kick_in">Kick in at</string>
     <string name="power_saving_pct">%1$d%%</string>
-    <string name="power_saving_hrv_pause">Pause HRV capture in Battery Saver</string>
-    <string name="power_saving_hrv_pause_desc">While Android Battery Saver is on, stop the always-on background HRV stream (the biggest live drain). Opening a Live screen still shows heart rate, and it re-arms automatically when Battery Saver turns off.</string>
+    <string name="power_saving_hrv_pause">Pause HRV capture</string>
+    <string name="power_saving_hrv_pause_desc">While saving power (battery low or Battery Saver), stop the always-on background HRV stream — the biggest live drain. A Live screen still shows heart rate, and it re-arms automatically once you\'re off power saving.</string>
     <string name="power_saving_defer_health">Defer Health Connect writeback</string>
     <string name="power_saving_defer_health_desc">While saving power, hold off writing scores to Health Connect (they otherwise upsert every 15 minutes). Writeback resumes automatically once you\'re off power saving, and a manual sync always runs it.</string>
 </resources>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -173,4 +173,6 @@
     <string name="power_saving_pct">%1$d%%</string>
     <string name="power_saving_hrv_pause">Pause HRV capture in Battery Saver</string>
     <string name="power_saving_hrv_pause_desc">While Android Battery Saver is on, stop the always-on background HRV stream (the biggest live drain). Opening a Live screen still shows heart rate, and it re-arms automatically when Battery Saver turns off.</string>
+    <string name="power_saving_defer_health">Defer Health Connect writeback</string>
+    <string name="power_saving_defer_health_desc">While saving power, hold off writing scores to Health Connect (they otherwise upsert every 15 minutes). Writeback resumes automatically once you\'re off power saving, and a manual sync always runs it.</string>
 </resources>


### PR DESCRIPTION
A default-on sub-option of **Settings → Power saving**: while power saving is *active* (battery ≤ the chosen % or Battery Saver, discharging), NOOP skips its every-15-min idempotent **Health Connect** score writeback. It resumes automatically the next analyze cycle once you're off power save, and a manual Data-Sources sync always writes regardless.

## Why Android-only (commented in the code)
iOS has **no NOOP-scheduled Health sync to defer** — its Apple Health integration is entirely **Shortcut-driven** (a sideload signing identity can't hold the HealthKit entitlement), so there's nothing on the iOS side to gate. Documented in `NoopPrefs.KEY_DEFER_HEALTH_SYNC` and at the gate in `AppViewModel`.

## How
- `isPowerSavingActiveNow()` reuses the **same** `WhoopBleClient.idleThrottleActive` pure gate as the BLE levers, so all three agree; read live per analyze cycle. Battery is read only when writeback **and** defer are on, and the helper early-returns before any read when the master is off — so it's free when the feature is off.
- The writeback at `AppViewModel:~870` is gated; the per-workout write and the manual sync are untouched.
- Settings sub-toggle in the Power saving section (shown when the master is on), default **on**.

## Honest scope
This is a **modest** saver: the analyze loop wakes every 15 min regardless (for scoring); this only skips the idempotent HC upsert inside it, and only for users who've enabled HC writeback + power saving + are low/Battery-Saver. Real but small — flagged plainly rather than oversold.

## Verification
- `:app:compileFullDebugKotlin` — compiles.
- i18n gate green (2 new strings + German).