### PR TITLE
feat(android): Kotlin twin of the WHOOP 5/MG R22 deep-buffer + 6-axis IMU decode (#423)

### DIFF
--- a/android/app/src/main/java/com/noop/analytics/ImuFeatureExtractor.kt
+++ b/android/app/src/main/java/com/noop/analytics/ImuFeatureExtractor.kt
@@ -1,0 +1,97 @@
+package com.noop.analytics
+
+import com.noop.protocol.RawImuSample
+import com.noop.protocol.Whoop5ImuFrame
+import kotlin.math.roundToInt
+import kotlin.math.sqrt
+
+// ImuFeatureExtractor.kt — activity features from decoded WHOOP 5/MG raw 6-axis IMU (#423). Kotlin twin
+// of StrandAnalytics/ImuFeatureExtractor.swift (parity contract).
+//
+// The 5/MG offload buffer decodes (Whoop5RawImu) to 100 Hz 3-axis accel (g) + 3-axis gyro (deg/s). At
+// 100 Hz the accelerometer resolves gait cadence, impact/jerk, and rotational energy the 1 Hz gravity
+// vector physically cannot (a 1.8 Hz step rate is above the 1 Hz stream's Nyquist limit). This turns a
+// window of raw samples into a compact activity-feature vector for coarse sport / HAR classification.
+//
+// Per the repo's derived-signal rule: cadence here is an autocorrelation peak on the accel-magnitude AC
+// over a genuinely high-rate stream (not a fixed-N-per-record buffer), reported with its own strength so
+// a caller can ignore a weak/absent peak; it is a FEATURE, never fed to a physiological gate. Validated
+// to recover MULTIPLE injected cadences, not one lucky match (see ImuFeatureExtractorTest).
+
+/** Compact activity features over a window of raw IMU samples. */
+data class ImuActivityFeatures(
+    /** RMS of the accel-magnitude AC (gravity removed), in g — overall movement intensity. */
+    val accelEnergyG: Double,
+    /** Mean gyroscope magnitude over the window, in deg/s — rotational intensity. */
+    val gyroEnergyDps: Double,
+    /** RMS of the accel first-difference (jerk), in g/sample — impact / explosiveness. */
+    val jerkRms: Double,
+    /** Dominant cadence in the gait band, Hz — null when no rhythmic peak clears [minCadenceStrength].
+     *  Multiply by 60 for steps/min. */
+    val cadenceHz: Double?,
+    /** Normalized strength (0..1) of that cadence peak — high = rhythmic, low = bursty or still. */
+    val cadenceStrength: Double,
+    val sampleCount: Int,
+)
+
+object ImuFeatureExtractor {
+
+    /** Cadence search band, Hz — human gait/pedal foot rate (~72-210 steps/min). Below the IMU Nyquist. */
+    val cadenceBand: ClosedFloatingPointRange<Double> = 1.2..3.5
+
+    /** A cadence peak below this normalized autocorrelation strength is treated as "no rhythm" (→ null Hz). */
+    const val minCadenceStrength = 0.20
+
+    /** Extract features from [samples] (from one or more [Whoop5ImuFrame]s, in order) at [sampleRateHz]. */
+    fun extract(samples: List<RawImuSample>, sampleRateHz: Int): ImuActivityFeatures {
+        val n = samples.size
+        if (n < 8 || sampleRateHz <= 0) {
+            return ImuActivityFeatures(0.0, 0.0, 0.0, null, 0.0, n)
+        }
+        val amag = samples.map { sqrt(it.ax * it.ax + it.ay * it.ay + it.az * it.az) }
+        val gmag = samples.map { sqrt(it.gx * it.gx + it.gy * it.gy + it.gz * it.gz) }
+
+        val gyroEnergy = gmag.sum() / n
+        // Accel AC: remove the DC (~gravity) then RMS.
+        val mean = amag.sum() / n
+        val ac = amag.map { it - mean }
+        val accelEnergy = sqrt(ac.sumOf { it * it } / n)
+        // Jerk: RMS of |accel| first difference.
+        var jerkSq = 0.0
+        for (i in 1 until n) { val d = amag[i] - amag[i - 1]; jerkSq += d * d }
+        val jerk = sqrt(jerkSq / (n - 1))
+
+        // Cadence: normalized autocorrelation of the AC series over the gait-band lags; the strongest
+        // peak's frequency + strength. Strength = peak ACF / zero-lag ACF (0..1), so it's amplitude-scale
+        // free (a faint but rhythmic walk and a hard one both read as rhythmic).
+        val ac0 = ac.sumOf { it * it }
+        var bestFreq: Double? = null
+        var bestStrength = 0.0
+        if (ac0 > 0) {
+            val loLag = maxOf(1, (sampleRateHz / cadenceBand.endInclusive).roundToInt())
+            val hiLag = minOf(n - 1, (sampleRateHz / cadenceBand.start).roundToInt())
+            if (loLag < hiLag) {
+                for (lag in loLag..hiLag) {
+                    var s = 0.0
+                    for (i in 0 until (n - lag)) s += ac[i] * ac[i + lag]
+                    val strength = s / ac0
+                    if (strength > bestStrength) {
+                        bestStrength = strength
+                        bestFreq = sampleRateHz.toDouble() / lag.toDouble()
+                    }
+                }
+            }
+        }
+        val cadence = if (bestStrength >= minCadenceStrength) bestFreq else null
+        return ImuActivityFeatures(
+            accelEnergyG = accelEnergy, gyroEnergyDps = gyroEnergy, jerkRms = jerk,
+            cadenceHz = cadence, cadenceStrength = maxOf(0.0, bestStrength), sampleCount = n,
+        )
+    }
+
+    /** Convenience: extract over the concatenated samples of decoded IMU frames. */
+    fun extract(frames: List<Whoop5ImuFrame>): ImuActivityFeatures {
+        val rate = frames.firstOrNull()?.sampleRateHz ?: 100
+        return extract(frames.flatMap { it.samples }, rate)
+    }
+}

--- a/android/app/src/main/java/com/noop/ble/PuffinDeepBufferLog.kt
+++ b/android/app/src/main/java/com/noop/ble/PuffinDeepBufferLog.kt
@@ -1,0 +1,79 @@
+package com.noop.ble
+
+import com.noop.analytics.ImuActivityFeatures
+import com.noop.analytics.ImuFeatureExtractor
+import com.noop.protocol.Whoop5RawImu
+
+/**
+ * Pure predicates + inline-IMU summary for the durable WHOOP 5.0/MG **high-rate deep-buffer** research
+ * log (#423) — the large type-0x2F (R22) packets that carry tens-of-Hz sensor data (motion + optical)
+ * rather than the 1 Hz historical rollup NOOP already decodes. Kotlin twin of the Swift
+ * `PuffinDeepBufferLog` (its pure, unit-testable core); the file I/O + capture-toggle gating live in
+ * [WhoopBleClient.writeWhoop5DeepBufferIfBig], mirroring the existing `whoop5-events.jsonl` writer.
+ *
+ * On-strap probing (#423) established that the 5/MG has no live raw-IMU stream, but it DOES bank
+ * high-rate motion and ships it inside big type-0x2F buffers during the connect-time offload burst —
+ * 124 B (~1 Hz record), 1244 B and 2140 B (~32 and ~59 sub-records per timestamped second). NOOP's
+ * historical decoder pulls the 1 Hz gravity vector out and DISCARDS the high-rate remainder. Keeping the
+ * big (>= [minBufferBytes]) type-0x2F buffers raw, in their own file, lets a byte-perfect decoder be
+ * reversed offline from many (raw buffer, wall-clock) pairs across days of ordinary wear.
+ */
+object PuffinDeepBufferLog {
+
+    /** WHOOP 5/MG inner-record type byte for the R22 deep packets (type 47 / 0x2F), at offset 8 (the
+     *  same position [WhoopBleClient.isOffloadFrame] / the event log index). The 1 Hz rollup is also
+     *  type-0x2F but small; [minBufferBytes] keeps only the high-rate buffers. */
+    private const val deepTypeByte = 0x2F
+    private const val innerRecordOffset = 8
+
+    /** Skip the ~124-B ~1 Hz record; keep the 1244-/2140-B high-rate buffers. */
+    private const val minBufferBytes = 1000
+
+    /** Pure predicate: is [frame] a WHOOP 5/MG high-rate deep buffer? A reassembled frame's inner-record
+     *  type byte sits at offset 8, so this needs `size > 8` before indexing. */
+    fun isDeepBuffer(frame: ByteArray): Boolean =
+        frame.size > innerRecordOffset &&
+            frame.size >= minBufferBytes &&
+            (frame[innerRecordOffset].toInt() and 0xFF) == deepTypeByte
+
+    /** The strap's own unix-second stamp at frame offset 15 (u32 LE), or null if the frame is too short.
+     *  This is the timestamp the high-rate records inside the buffer are relative to. */
+    fun strapTs(frame: ByteArray): Long? {
+        if (frame.size <= 18) return null
+        return (frame[15].toLong() and 0xFF) or ((frame[16].toLong() and 0xFF) shl 8) or
+            ((frame[17].toLong() and 0xFF) shl 16) or ((frame[18].toLong() and 0xFF) shl 24)
+    }
+
+    /** Decoded-IMU field for the JSONL line: `,"imu":{...features...}` when [frame] is the 1244-B 6-axis
+     *  IMU buffer, else `""` (the 2140-B optical buffer and everything else). Pure and non-throwing — a
+     *  decode miss just omits the field, so a diagnostics-only summary can never disturb the capture path.
+     *  The first CALLER of [Whoop5RawImu.decode] outside its own tests. */
+    fun decodedImuField(frame: ByteArray): String {
+        if (frame.size != Whoop5RawImu.bufferLength) return ""
+        val decoded = Whoop5RawImu.decode(frame) ?: return ""
+        val f = ImuFeatureExtractor.extract(decoded.samples, decoded.sampleRateHz)
+        val json = encodeFeatures(f) ?: return ""
+        return ",\"imu\":$json"
+    }
+
+    /** Canonical JSON for [ImuActivityFeatures] — same keys, same declaration order as the Swift `Codable`
+     *  output; `cadenceHz` is OMITTED when null (Swift's synthesized `encodeIfPresent`). Returns null if any
+     *  value is non-finite (Swift's JSONEncoder throws on non-conforming floats → the field is dropped),
+     *  matching parity. VALUE-parity, not byte-text-parity: a near-zero Double serializes as e.g. `5.0E-4`
+     *  here vs `0.0005` from Swift's JSONEncoder — both valid JSON that parse to the identical number (this
+     *  is a research JSONL the analysis tool parses, not a byte-stable stored value crossing `.noopbak`). */
+    private fun encodeFeatures(f: ImuActivityFeatures): String? {
+        val nums = listOfNotNull(f.accelEnergyG, f.gyroEnergyDps, f.jerkRms, f.cadenceHz, f.cadenceStrength)
+        if (nums.any { !it.isFinite() }) return null
+        return buildString {
+            append('{')
+            append("\"accelEnergyG\":").append(f.accelEnergyG).append(',')
+            append("\"gyroEnergyDps\":").append(f.gyroEnergyDps).append(',')
+            append("\"jerkRms\":").append(f.jerkRms)
+            if (f.cadenceHz != null) { append(",\"cadenceHz\":").append(f.cadenceHz) }
+            append(",\"cadenceStrength\":").append(f.cadenceStrength)
+            append(",\"sampleCount\":").append(f.sampleCount)
+            append('}')
+        }
+    }
+}

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -665,6 +665,13 @@ class WhoopBleClient(
         // EVENT frames are ~40–120 B of hex each, a few KB per day of wear — 5 MB is years.
         private const val WHOOP5_EVENT_LOG_MAX_BYTES = 5L * 1024 * 1024
 
+        /** High-rate R22 deep-buffer research log (#423) — the big type-0x2F buffers (1244/2140 B) that
+         *  carry tens-of-Hz motion/optical, kept raw in their own file so they survive long enough to
+         *  reverse. The 2140-B buffers are ~4.3 KB of hex and arrive in bursts, so a bigger cap than the
+         *  EVENT log: 60 MB live (~a few hours of accumulated bursts), rotation bounds disk at ~120 MB. */
+        const val WHOOP5_DEEPBUFFER_FILE = "whoop5-deepbuffers.jsonl"
+        private const val WHOOP5_DEEPBUFFER_MAX_BYTES = 60L * 1024 * 1024
+
         /** WHOOP 5/MG inner-record type byte for EVENT frames (type 48). The inner record starts at
          *  offset 8 ([type][seq][cmd][data…]) — the SAME position [isOffloadFrame]/R22-telemetry index
          *  and the Interpreter reads the canonical type name from. */
@@ -3730,6 +3737,10 @@ class WhoopBleClient(
                     // the frame is not an EVENT; no-op unless the capture toggle is on.
                     if (connectedFamily == DeviceFamily.WHOOP5) {
                         writeWhoop5EventLogIfEvent(uuid.toString(), frame)
+                        // Durable log of the big high-rate R22 deep buffers (type-0x2F ≥ 1 KB) for #423
+                        // reverse-engineering — its own file the bulk-capture eviction never churns.
+                        // BEFORE the offload branch so it catches the burst; no-op unless capture is on.
+                        writeWhoop5DeepBufferIfBig(uuid.toString(), frame, isOffloadFrame(frame, connectedFamily))
                     }
                     if (backfilling) {
                         // Opt-in raw capture: record EVERY frame of the session (offload AND live
@@ -5839,6 +5850,50 @@ class WhoopBleClient(
             // A diagnostics log must never affect the connection path: disable for this process.
             eventLogDisabled = true
             log("Capture: event log write failed (${it.message}) — event log disabled")
+        }
+    }
+
+    @Volatile private var deepBufferDisabled = false
+
+    /**
+     * Durable append-only log of WHOOP 5.0/MG **high-rate R22 deep buffers** (#423) — the big type-0x2F
+     * buffers (>= 1 KB: the 1244-B 6-axis IMU and 2140-B optical) that carry tens-of-Hz sensor data,
+     * kept RAW in their own file so a byte-perfect decoder can be reversed offline from many
+     * (raw buffer, wall-clock) pairs. NOOP's historical decoder pulls only the 1 Hz gravity vector out
+     * of these and discards the high-rate remainder. Gated on the same capture pref as the backfill
+     * capture; one JSONL line per buffer (`{"ts_ms":…,"strap_ts":…,"size":…,"offload":…,"char":…,
+     * "hex":"…"[,"imu":{…}]}`, same keys as the Swift twin `PuffinDeepBufferLog`). `strap_ts` is the unix
+     * second the strap stamped at frame offset 15 — the load-bearing key for aligning a buffer with what
+     * the wearer was doing. The optional `imu` object is the decoded activity summary present only on the
+     * 1244-B 6-axis buffer ([PuffinDeepBufferLog.decodedImuField], #455). Rotates at a soft cap keeping
+     * one previous generation. Cheap for every other frame: a length + single-byte compare BEFORE the
+     * pref read; no-op unless the capture toggle is on.
+     */
+    private fun writeWhoop5DeepBufferIfBig(characteristic: String, frame: ByteArray, isOffload: Boolean) {
+        if (deepBufferDisabled || !PuffinDeepBufferLog.isDeepBuffer(frame)) return
+        if (!PuffinExperiment.from(context).isCaptureEnabled) return
+        runCatching {
+            val f = java.io.File(context.filesDir, WHOOP5_DEEPBUFFER_FILE)
+            if (f.exists() && f.length() > WHOOP5_DEEPBUFFER_MAX_BYTES) {
+                val old = java.io.File(context.filesDir, "$WHOOP5_DEEPBUFFER_FILE.1")
+                old.delete()
+                f.renameTo(old)
+            }
+            val strapTs = PuffinDeepBufferLog.strapTs(frame)?.toString() ?: "null"
+            val hex = frame.toHex()
+            // #423/#455: decode the 1244-B IMU buffer inline so each captured line carries its activity
+            // summary (cadence/energy/jerk/gyro) beside the raw hex — self-checking (raw ↔ decode) with
+            // no stored table, migration, or downstream gate. Instrumentation only; the 2140-B optical
+            // buffer stays raw (its layout isn't decoded yet).
+            val imu = PuffinDeepBufferLog.decodedImuField(frame)
+            f.appendText(
+                "{\"ts_ms\":${System.currentTimeMillis()},\"strap_ts\":$strapTs,\"size\":${frame.size}," +
+                    "\"offload\":$isOffload,\"char\":\"$characteristic\",\"hex\":\"$hex\"$imu}\n",
+            )
+        }.onFailure {
+            // A diagnostics log must never affect the connection path: disable for this process.
+            deepBufferDisabled = true
+            log("Capture: deep-buffer log write failed (${it.message}) — deep-buffer log disabled")
         }
     }
 

--- a/android/app/src/main/java/com/noop/protocol/Whoop5RawImu.kt
+++ b/android/app/src/main/java/com/noop/protocol/Whoop5RawImu.kt
@@ -1,0 +1,96 @@
+package com.noop.protocol
+
+// Whoop5RawImu.kt — decoder for the WHOOP 5.0/MG raw 6-axis IMU offload buffer (#423). Kotlin twin of
+// WhoopProtocol/Whoop5RawImu.swift — byte-identical layout, scales, and gating (parity contract).
+//
+// The 5/MG ships a 1244-byte buffer during the connect-time offload burst that carries a full second
+// of raw inertial data: 100 accelerometer samples + 100 gyroscope samples, stored COLUMNAR (all ax,
+// then all ay, then all az; likewise the gyro), i16 little-endian. This is the SAME shape the WHOOP
+// app captures (Asherlc/dofek docs/whoop-ble-protocol.md type-0x2B raw packet) and the same columnar
+// convention as the 4.0's 1917 REALTIME_RAW_DATA variant.
+//
+// IMPORTANT: the 5/MG's *live* raw-IMU stream is firmware-refused (TOGGLE_IMU_MODE / cmd 106 acks but
+// never streams), but the OFFLOAD buffer carries full accel AND gyro — so 100 Hz 6-axis IMU IS
+// obtainable on the 5.0 via the historical path.
+//
+// Frame layout (reassembled BLE frame = 8-byte puffin envelope + payload; offsets are FRAME-absolute):
+//   @15  u32 LE   strap unix seconds for this 1-second frame
+//   @24  u16 LE   countA (accelerometer sample count, = 100)
+//   @28  100×i16  ax   @228 100×i16 ay   @428 100×i16 az     scale 1/4096 g/LSB
+//   @630 u16 LE   countB (gyroscope sample count, = 100)
+//   @640 100×i16  gx   @840 100×i16 gy   @1040 100×i16 gz    scale 2000/32768 (°/s)/LSB (±2000 dps)
+//
+// VALIDATED on 1423 buffers from a real 5.0 (fw 50.40.1.0): accel magnitude is a 1.01 g gravity shell
+// (100 % of samples within ±15 % of the median; 4117 ± 11 LSB across 200 s), gyro near zero at rest,
+// spikes in motion, correlates 0.79 with accel motion. Pure/deterministic; no I/O, no strap.
+
+/** One raw IMU sample: 3-axis accelerometer (g) + 3-axis gyroscope (deg/s). */
+data class RawImuSample(
+    val ax: Double, val ay: Double, val az: Double,   // g
+    val gx: Double, val gy: Double, val gz: Double,   // deg/s
+)
+
+/** One decoded 5/MG raw-IMU buffer: a second of 6-axis samples with the strap's base timestamp. */
+data class Whoop5ImuFrame(
+    val baseTs: Long,           // strap unix seconds for the frame (Swift `Int` = 64-bit; holds full u32)
+    val sampleRateHz: Int,      // 100
+    val samples: List<RawImuSample>,
+) {
+    /** Wall-clock unix seconds for sample [i] (samples are evenly spaced across the 1-second frame). */
+    fun ts(i: Int): Double = baseTs.toDouble() + i.toDouble() / maxOf(1, sampleRateHz).toDouble()
+}
+
+object Whoop5RawImu {
+
+    const val bufferLength = 1244
+    const val sampleCount = 100
+    const val accelScale = 1.0 / 4096.0            // g per LSB (WHOOP accel scale)
+    const val gyroScale = 2000.0 / 32768.0         // deg/s per LSB (±2000 dps, ~16.4 LSB/dps)
+
+    // FRAME-absolute offsets (8-byte puffin envelope + payload).
+    private const val tsOff = 15
+    private const val countAOff = 24
+    private const val axOff = 28
+    private const val ayOff = 228
+    private const val azOff = 428
+    private const val countBOff = 630
+    private const val gxOff = 640
+    private const val gyOff = 840
+    private const val gzOff = 1040
+
+    /** Decode a raw-IMU buffer, or null if it isn't one. Gates on the exact length + the two in-packet
+     *  sample counts (=100) rather than the type byte, so it can't misfire on a same-type non-IMU frame. */
+    fun decode(f: ByteArray): Whoop5ImuFrame? {
+        if (f.size < bufferLength) return null
+        if (u16(f, countAOff) != sampleCount || u16(f, countBOff) != sampleCount) return null
+        if (gzOff + 2 * sampleCount > f.size) return null
+        val baseTs = u32(f, tsOff)   // full u32 (matches Swift `Int(u32(...))` on 64-bit — no truncation)
+        val samples = ArrayList<RawImuSample>(sampleCount)
+        for (i in 0 until sampleCount) {
+            val o = 2 * i
+            samples.add(
+                RawImuSample(
+                    ax = i16(f, axOff + o) * accelScale,
+                    ay = i16(f, ayOff + o) * accelScale,
+                    az = i16(f, azOff + o) * accelScale,
+                    gx = i16(f, gxOff + o) * gyroScale,
+                    gy = i16(f, gyOff + o) * gyroScale,
+                    gz = i16(f, gzOff + o) * gyroScale,
+                ),
+            )
+        }
+        return Whoop5ImuFrame(baseTs = baseTs, sampleRateHz = sampleCount, samples = samples)
+    }
+
+    // Little-endian readers (frame-absolute).
+    private fun u16(f: ByteArray, o: Int): Int =
+        (f[o].toInt() and 0xFF) or ((f[o + 1].toInt() and 0xFF) shl 8)
+
+    private fun u32(f: ByteArray, o: Int): Long =
+        (f[o].toLong() and 0xFF) or ((f[o + 1].toLong() and 0xFF) shl 8) or
+            ((f[o + 2].toLong() and 0xFF) shl 16) or ((f[o + 3].toLong() and 0xFF) shl 24)
+
+    private fun i16(f: ByteArray, o: Int): Int {
+        val v = u16(f, o); return if (v >= 32768) v - 65536 else v
+    }
+}

--- a/android/app/src/test/java/com/noop/analytics/ImuFeatureExtractorTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/ImuFeatureExtractorTest.kt
@@ -1,0 +1,78 @@
+package com.noop.analytics
+
+import com.noop.protocol.RawImuSample
+import com.noop.protocol.Whoop5ImuFrame
+import kotlin.math.sin
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Pins [ImuFeatureExtractor] — activity features from decoded 5/MG raw IMU (#423). Kotlin twin of the
+ * Swift ImuFeatureExtractorTests. Per the repo's derived-signal rule, cadence is validated to recover
+ * MULTIPLE distinct injected rates (not one lucky match); still/energy/gyro checked independently.
+ */
+class ImuFeatureExtractorTest {
+
+    /** 100 Hz samples: gravity on Z + a sinusoidal wobble of amplitude [amp] g at [cadence] Hz on Z,
+     *  and an optional constant gyro rotation [gyroDps] on gx. */
+    private fun gaitSamples(
+        cadence: Double,
+        amp: Double = 0.2,
+        seconds: Double = 6.0,
+        gyroDps: Double = 0.0,
+    ): List<RawImuSample> {
+        val rate = 100.0
+        val n = (seconds * rate).toInt()
+        return (0 until n).map { i ->
+            val az = 1.0 + amp * sin(2 * Math.PI * cadence * i.toDouble() / rate)
+            RawImuSample(ax = 0.0, ay = 0.0, az = az, gx = gyroDps, gy = 0.0, gz = 0.0)
+        }
+    }
+
+    @Test
+    fun recoversMultipleDistinctCadences() {
+        // The load-bearing test: the extractor must track a VARYING input, not manufacture one rate.
+        for (target in listOf(1.4, 1.8, 2.4, 3.0)) {
+            val f = ImuFeatureExtractor.extract(gaitSamples(cadence = target), sampleRateHz = 100)
+            assertNotNull("cadence $target Hz should be detected", f.cadenceHz)
+            assertEquals("recovered cadence should match the injected $target Hz", target, f.cadenceHz!!, 0.15)
+            assertTrue("a clean sinusoid should read as strongly rhythmic", f.cadenceStrength > 0.4)
+        }
+    }
+
+    @Test
+    fun stillHasNoCadenceAndLowEnergy() {
+        val still = (0 until 600).map { RawImuSample(ax = 0.0, ay = 0.0, az = 1.0, gx = 0.0, gy = 0.0, gz = 0.0) }
+        val f = ImuFeatureExtractor.extract(still, sampleRateHz = 100)
+        assertNull("a still wrist has no gait cadence", f.cadenceHz)
+        assertTrue(f.accelEnergyG < 0.01)
+        assertTrue(f.gyroEnergyDps < 0.01)
+    }
+
+    @Test
+    fun energyAndJerkRiseWithMotion() {
+        val still = ImuFeatureExtractor.extract(gaitSamples(cadence = 2.0, amp = 0.0), sampleRateHz = 100)
+        val moving = ImuFeatureExtractor.extract(gaitSamples(cadence = 2.0, amp = 0.3), sampleRateHz = 100)
+        assertTrue(moving.accelEnergyG > still.accelEnergyG + 0.05)
+        assertTrue(moving.jerkRms > still.jerkRms)
+    }
+
+    @Test
+    fun gyroEnergyReflectsRotation() {
+        val f = ImuFeatureExtractor.extract(gaitSamples(cadence = 2.0, gyroDps = 45.0), sampleRateHz = 100)
+        assertEquals("constant 45 dps rotation should read back", 45.0, f.gyroEnergyDps, 1.0)
+    }
+
+    @Test
+    fun extractFromDecodedFrames() {
+        // End-to-end from the decoder shape: two frames concatenate into one feature window.
+        val frame = Whoop5ImuFrame(baseTs = 0, sampleRateHz = 100, samples = gaitSamples(cadence = 2.2))
+        val f = ImuFeatureExtractor.extract(listOf(frame, frame))
+        assertEquals(frame.samples.size * 2, f.sampleCount)
+        assertNotNull(f.cadenceHz)
+        assertEquals(2.2, f.cadenceHz!!, 0.15)
+    }
+}

--- a/android/app/src/test/java/com/noop/ble/PuffinDeepBufferLogTest.kt
+++ b/android/app/src/test/java/com/noop/ble/PuffinDeepBufferLogTest.kt
@@ -1,0 +1,83 @@
+package com.noop.ble
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Pins [PuffinDeepBufferLog] — the pure predicates + inline-IMU summary behind the durable high-rate
+ * deep-buffer log (#423). Kotlin twin of the Swift PuffinDeepBufferLogTests. BLE delivery can't be
+ * unit-tested, but the offset-8 + size gate CAN be, so a frame-shape change can't silently stop the
+ * research log filling.
+ */
+class PuffinDeepBufferLogTest {
+
+    @Test
+    fun acceptsBigType2FAtOffset8() {
+        val f = ByteArray(2140).also { it[8] = 0x2F.toByte() }   // the 2140-B high-rate buffer
+        assertTrue(PuffinDeepBufferLog.isDeepBuffer(f))
+        val g = ByteArray(1244).also { it[8] = 0x2F.toByte() }   // the 1244-B high-rate buffer
+        assertTrue(PuffinDeepBufferLog.isDeepBuffer(g))
+    }
+
+    @Test
+    fun rejectsSmallType2FRecord() {
+        // The ~124-B type-0x2F frame is the 1 Hz rollup NOOP already decodes — below the size gate.
+        val f = ByteArray(124).also { it[8] = 0x2F.toByte() }
+        assertFalse(PuffinDeepBufferLog.isDeepBuffer(f))
+    }
+
+    @Test
+    fun rejectsOtherTypesEvenWhenBig() {
+        // Big frames of other inner types must never be treated as a deep buffer.
+        for (t in listOf(0x28, 0x24, 0x30, 0x31, 0x32, 48)) {
+            val f = ByteArray(2140).also { it[8] = t.toByte() }
+            assertFalse("type $t must not be a deep buffer", PuffinDeepBufferLog.isDeepBuffer(f))
+        }
+    }
+
+    @Test
+    fun rejectsTooShortToIndexOffset8() {
+        for (n in 0..8) {
+            assertFalse(PuffinDeepBufferLog.isDeepBuffer(ByteArray(n) { 0x2F.toByte() }))
+        }
+    }
+
+    /** A well-formed 1244-B 6-axis IMU buffer (Whoop5RawImu layout): countA/countB = 100, gravity on Z,
+     *  and an X channel that alternates 800/0 so the decoded accel MAGNITUDE varies (non-zero AC energy
+     *  so the feature extractor exercises its cadence path and stays finite). */
+    private fun imuBuffer(): ByteArray {
+        val f = ByteArray(1244)
+        f[8] = 0x2F.toByte()
+        f[24] = 100.toByte()         // countA (u16 LE) — Whoop5RawImu.decode requires == 100
+        f[630] = 100.toByte()        // countB (u16 LE)
+        fun put(off: Int, i: Int, v: Int) {
+            f[off + 2 * i] = (v and 0xFF).toByte()
+            f[off + 2 * i + 1] = ((v shr 8) and 0xFF).toByte()
+        }
+        for (i in 0 until 100) {
+            put(28, i, if (i % 2 == 0) 800 else 0)   // ax @28  — magnitude actually varies
+            put(428, i, 4096)                         // az @428 — ~1 g
+        }
+        return f
+    }
+
+    @Test
+    fun emitsInlineDecodedImuFieldForImuBuffer() {
+        val field = PuffinDeepBufferLog.decodedImuField(imuBuffer())
+        assertTrue("a 1244-B IMU buffer must emit an inline summary", field.startsWith(",\"imu\":{"))
+        assertTrue("summary carries the 100 decoded samples", field.contains("\"sampleCount\":100"))
+        assertTrue("summary carries the activity features", field.contains("accelEnergyG"))
+    }
+
+    @Test
+    fun noImuFieldForOpticalOrUndecodableBuffers() {
+        // The 2140-B optical buffer is a different, still-undecoded layout — no IMU summary.
+        val optical = ByteArray(2140).also { it[8] = 0x2F.toByte() }
+        assertEquals("", PuffinDeepBufferLog.decodedImuField(optical))
+        // A 1244-length frame whose count fields aren't 100 fails decode → field omitted, never a throw.
+        val bogus = ByteArray(1244).also { it[8] = 0x2F.toByte() }
+        assertEquals("", PuffinDeepBufferLog.decodedImuField(bogus))
+    }
+}

--- a/android/app/src/test/java/com/noop/protocol/Whoop5RawImuTest.kt
+++ b/android/app/src/test/java/com/noop/protocol/Whoop5RawImuTest.kt
@@ -1,0 +1,82 @@
+package com.noop.protocol
+
+import kotlin.math.sqrt
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Pins [Whoop5RawImu.decode] — the WHOOP 5/MG raw 6-axis IMU offload buffer (#423). Kotlin twin of the
+ * Swift Whoop5RawImuTests. A synthetic frame checks the exact columnar offsets + scales; a REAL captured
+ * buffer (fw 50.40.1.0) checks the decode against hardware (accel forms a ~1 g gravity shell, gyro sane).
+ */
+class Whoop5RawImuTest {
+
+    /** Build a minimal valid frame: counts = 100, and one known accel + gyro sample at index [i]. */
+    private fun syntheticFrame(i: Int, axLSB: Int, gxLSB: Int): ByteArray {
+        val f = ByteArray(Whoop5RawImu.bufferLength)
+        f[8] = 0x2F.toByte()
+        fun putU16(o: Int, v: Int) { f[o] = (v and 0xFF).toByte(); f[o + 1] = ((v shr 8) and 0xFF).toByte() }
+        fun putI16(o: Int, v: Int) { putU16(o, if (v < 0) v + 65536 else v) }
+        putU16(24, 100)                    // countA
+        putU16(630, 100)                   // countB
+        putU16(15, 100)                    // baseTs = 100 (f[17..18] stay 0 → u32 = 100)
+        putI16(28 + 2 * i, axLSB)          // ax[i]
+        putI16(640 + 2 * i, gxLSB)         // gx[i]
+        return f
+    }
+
+    @Test
+    fun decodesKnownSampleWithCorrectScales() {
+        // ax = 4096 LSB → 1.0 g; gx = 328 LSB → 328 * 2000/32768 = 20.02 °/s.
+        val frame = Whoop5RawImu.decode(syntheticFrame(i = 3, axLSB = 4096, gxLSB = 328))
+        assertNotNull(frame)
+        assertEquals(100, frame!!.samples.size)
+        assertEquals(100, frame.sampleRateHz)
+        assertEquals(1.0, frame.samples[3].ax, 1e-9)
+        assertEquals(0.0, frame.samples[3].ay, 1e-9)
+        assertEquals(328.0 * 2000.0 / 32768.0, frame.samples[3].gx, 1e-6)
+        assertEquals(0.0, frame.samples[0].ax, 1e-9)   // other indices untouched
+    }
+
+    @Test
+    fun rejectsWrongLengthOrCounts() {
+        assertNull(Whoop5RawImu.decode(ByteArray(500)))            // too short
+        val f = syntheticFrame(i = 0, axLSB = 0, gxLSB = 0)
+        f[24] = 0.toByte(); f[25] = 0.toByte()                     // countA != 100
+        assertNull(Whoop5RawImu.decode(f))
+    }
+
+    @Test
+    fun decodesRealBufferAsGravityShell() {
+        val f = hexToBytes(REAL_FRAME_HEX)
+        assertEquals(Whoop5RawImu.bufferLength, f.size)
+        val frame = Whoop5RawImu.decode(f)
+        assertNotNull("real buffer did not decode", frame)
+        assertEquals(100, frame!!.samples.size)
+        assertEquals(1_784_037_165L, frame.baseTs)   // strap ts @15
+
+        // Accel: every sample must sit in a ~1 g gravity shell (the defining accel signature).
+        val mags = frame.samples.map { sqrt(it.ax * it.ax + it.ay * it.ay + it.az * it.az) }
+        val sorted = mags.sorted()
+        val median = sorted[sorted.size / 2]
+        assertEquals("median |accel| should be ~1 g", 1.0, median, 0.15)
+        val inShell = mags.count { it > 0.7 * median && it < 1.3 * median }
+        assertTrue("≥95/100 accel samples should be in the gravity shell", inShell >= 95)
+
+        // Gyro: at (near) rest the mean magnitude is small — far below the ±2000 dps full scale.
+        val gyroMean = frame.samples.map { sqrt(it.gx * it.gx + it.gy * it.gy + it.gz * it.gz) }.sum() / 100.0
+        assertTrue("resting gyro magnitude should be small", gyroMean < 200.0)
+    }
+
+    private fun hexToBytes(hex: String): ByteArray =
+        ByteArray(hex.length / 2) { ((hex[it * 2].digitToInt(16) shl 4) or hex[it * 2 + 1].digitToInt(16)).toByte() }
+
+    companion object {
+        /** One real 1244-byte type-0x2F IMU buffer captured off a WHOOP 5.0 (fw 50.40.1.0), #423. */
+        private const val REAL_FRAME_HEX =
+            "aa01d40401005c702f1580e520af002d3f566a002004640064000300d308cc08c408c908c208cd08b708c208cc08c908cc08e108d608e408d208c508bd08d708c508d208cc08c908bc08b508a908c008cc08cb08d308e108dc08d408d108c108c208c208b708ce08c608e008c308d208bd08c908bb08b708be08c208cc08ce08c608cf08c408c808ca08cb08cf08cb08d508c708c908cc08bf08c308c408cc08cc08cc08c508c708d108c108c608c808c108c408c308c608cf08c808c608cf08ce08c808d008c008d008c608bb08cb08d208c008cb08c708c008c508c208c608cf08d008d3ffcaffc1ffc8ffcaffc5ffccffd4ffd3ffdeffddffd8ffdbffd6ffc7ffc7ffd0ffd5ffd6ffe2ffd4ffceffd6ffd2ffe2ffdbffdbffc7ffc6ffc9ffc1ffb1ffb7ffb7ffc9ffceffe4ffe7ffe4ffeaffe7ffdbffd7ffe0ffd7ffc4ffccffcdffbbffc2ffbeffb9ffccffd4ffd4ffc6ffcaffd3ffc8ffd6ffceffd7ffdaffdfffddffdaffd6ffddffdaffd3ffe1ffd0ffc9ffcdffd1ffcaffd3ffcfffd3ffd6ffcfffcaffc9ffc7ffcaffd7ffd5ffd0ffdaffd4ffddffd6ffd8ffdcffd8ffd4ffcaffe5ffceffccff690d840d810d760d7f0d7a0d730d7a0d800d8a0d820d8c0d800d750d740d740d620d690d800d7a0d7d0d6e0d710d780d790d890d770d810d7d0d760d7d0d7b0d7a0d890d810d830d7a0d6d0d6c0d6f0d690d6d0d790d6d0d730d760d770d850d790d810d760d7d0d750d720d760d740d720d820d750d890d840d830d7d0d7b0d770d7b0d820d6f0d830d6f0d770d6e0d7b0d820d700d760d7f0d6a0d780d790d7c0d830d780d7a0d840d780d6f0d7f0d740d800d7b0d860d7f0d7a0d840d7d0d820d770d810d7c0d6400640005020000000000000900090004000500060007000a000c000b000d000e000c000d000d000c000b00090008000c000d000d0011000e000c000c000b000b000e000f00130011001100100010000e000e000e000e000c000b000c000c000b000e000d0010000e000e000d000d000c000b000c000a000b000c000c000e000b000b000c000c000d000a000b000b000a000b000c000c000c000d000e000f000b000d000b000b000e000d000c000c000b000b000c000c000c000b000b000a000a000b000b000d000f000d000d000b000b000a00fcfffbfffbfffdfff9fffbfffcfffdfffdfffdfffcfffcfffffffcfffcfffdfffffffdfffcffffff01000000fefffdfffdfffefffeffffff0000ffff0200feffffffffff000000000100fefffffffdfffdfffefffdfffefffbfffdffffff0100fefffefffdfffdfffdfffefffdfffffffefffeff0000fefffdfffffffefffdff0000fefffefffefffdfffefffefffefffefffffffffffffffffffdff00000000fefffdfffffffefffdfffefffdfffdfffffffffffdfffefffffffcfffdfffefffdfffdfffefffdfffbfff9fff9fff8fffcfff9fff8fff9fff7fff7fffafffcfffbfffdfffbfffafffcfffcfffbfff9fff8fffcfff9fff8fffbfff9fff9fffcfffcfffcfffffffbfffcfffafff8fff7fff8fff7fff6fff9fff9fffafffcfffbfffdfffdfffcfffcfffcfffcfffbfffbfffafff9fffcfffafff7fffafffbfff9fffbfffafff8fff7fff8fffafff8fff8fffafffafffafffbfffcfffcfffafffafffbfffcfffafffafff9fffafffafff9fff8fff8fff9fff9fffbfff8fffafffafffafffbfffbfff9fffafffafffafff9ff7ae96eb8"
+    }
+}


### PR DESCRIPTION
## What

The **Android/Kotlin twin** of the WHOOP 5/MG R22 deep-buffer + raw 6-axis IMU work (#423), completing
cross-platform parity: the Swift side already landed as #455 (decode + activity features), #454 (deep-buffer
capture) and #476 (inline decode) — this adds the equivalent Kotlin so the Android app reaches the same
capability under the parity contract.

- **`Whoop5RawImu`** (`com.noop.protocol`) — decodes the 1244-byte 5/MG raw 6-axis IMU offload buffer:
  100 Hz accelerometer (1/4096 g) + gyroscope (2000/32768 °/s), columnar i16 LE at the frame-absolute
  offsets `15/24/28/228/428/630/640/840/1040`. Gates on the exact length + both in-packet sample counts
  (=100), not the type byte, so it can't misfire on a same-type non-IMU frame. `baseTs` is `Long` (holds
  the full u32). Twin of `WhoopProtocol/Whoop5RawImu.swift` (#455).
- **`ImuFeatureExtractor`** (`com.noop.analytics`) — activity features over a window of decoded samples:
  accel-AC energy, gyro energy, jerk RMS, and an autocorrelation cadence + strength in the gait band
  (1.2–3.5 Hz). Per the derived-signal rule, cadence is a **feature reported with its own strength**,
  never fed to a physiological gate. Twin of `StrandAnalytics/ImuFeatureExtractor.swift` (#455).
- **`PuffinDeepBufferLog`** (`com.noop.ble`) + `WhoopBleClient` wiring — durable append-only JSONL of the
  big (≥ 1 KB) type-0x2F R22 deep buffers (1244/2140 B) in their own file the bulk capture never churns,
  for offline layout RE. The 1244-B IMU buffer carries its decoded activity summary inline. Passive /
  read-only w.r.t. the strap, **gated on the existing `PuffinExperiment.isCaptureEnabled` toggle — no new
  setting**. Twin of `Strand/BLE/PuffinDeepBufferLog.swift` (#454/#476).

## Parity

Byte-identical to the Swift decode/features, checked against the **same synthetic vectors** as the Swift
tests **plus a real 1244-byte buffer** captured off a WHOOP 5.0 (fw 50.40.1.0): `baseTs 1784037165`, accel
forms a ~1 g gravity shell (≥95/100 samples in-shell), gyro sane at rest. The inline-IMU JSON is
value-parity (a near-zero Double may format as `5.0E-4` vs Swift's `0.0005` — both valid JSON that parse to
the identical number; this is a research JSONL the analysis tool parses, not a byte-stable stored value).

## Test plan

- [x] `:app:testFullDebugUnitTest` — 14 new tests: `Whoop5RawImuTest` (synthetic scales/offsets + real
  buffer + rejects), `ImuFeatureExtractorTest` (recovers 4 distinct injected cadences, still/energy/jerk/
  gyro), `PuffinDeepBufferLogTest` (offset-8 + size gate, inline-IMU emission, optical/bogus omission).
- [x] `:app:compileFullDebugKotlin` + full `:app:testFullDebugUnitTest` green.
- [ ] BLE capture path is hardware-only (passive read of the offload burst); the pure decode/gate/log
  predicates are unit-covered, delivery is not CI-testable.
