### PR TITLE
feat(ble,ui): power saving keys off the STRAP battery, strap-only (#477)

### DIFF
--- a/Strand/BLE/BLEManager.swift
+++ b/Strand/BLE/BLEManager.swift
@@ -516,17 +516,17 @@ public final class BLEManager: NSObject, ObservableObject {
     /// `LOW_BATTERY_BACKFILL_INTERVAL_MS`.
     static let lowBatteryBackfillIntervalSeconds = 2700
 
-    /// Pure battery-adaptive gate (#477), the twin of Android `WhoopBleClient.idleThrottleActive`.
-    /// Armed by `thresholdPct` > 0; once armed and while discharging it engages at/below `thresholdPct`
-    /// OR when the OS is saving power (`powerSave`). `thresholdPct` <= 0 / charging never engages.
-    static func lowPowerThrottleActive(batteryPct: Int, charging: Bool, thresholdPct: Int, powerSave: Bool) -> Bool {
-        thresholdPct > 0 && !charging && (batteryPct <= thresholdPct || powerSave)
+    /// Pure battery-adaptive gate (#477), the twin of Android `WhoopBleClient.idleThrottleActive`. Keyed
+    /// on the STRAP's battery: armed by `thresholdPct` > 0, engages while the strap is discharging at/below
+    /// `thresholdPct`. The phone's own Low Power Mode deliberately does NOT trigger it. Charging never engages.
+    static func lowPowerThrottleActive(batteryPct: Int, charging: Bool, thresholdPct: Int) -> Bool {
+        thresholdPct > 0 && !charging && batteryPct <= thresholdPct
     }
 
     /// Pure offload-interval decision (#477), the twin of Android `offloadIntervalMsFor`.
     static func offloadInterval(baseSeconds: Int, lowSeconds: Int,
-                                batteryPct: Int, charging: Bool, thresholdPct: Int, powerSave: Bool) -> Int {
-        lowPowerThrottleActive(batteryPct: batteryPct, charging: charging, thresholdPct: thresholdPct, powerSave: powerSave)
+                                batteryPct: Int, charging: Bool, thresholdPct: Int) -> Int {
+        lowPowerThrottleActive(batteryPct: batteryPct, charging: charging, thresholdPct: thresholdPct)
             ? max(baseSeconds, lowSeconds) : baseSeconds
     }
 
@@ -553,13 +553,12 @@ public final class BLEManager: NSObject, ObservableObject {
     /// preference intent; the effective want is window-gated through `continuousCaptureWantsNow()` when
     /// "overnight only" is on, re-derived at every arm site.
     private var keepRealtimeForData = false
-    /// #477 battery (parity with Android): battery-% at/below which the periodic offload cadence stretches
-    /// to `lowBatteryBackfillIntervalSeconds` while low on power (0 = off), and whether to pause the
-    /// background continuous-HRV stream under Low Power Mode. Both are benign (no link risk). Set from
-    /// Settings via `setLowBatteryOffloadThrottle`/`setPauseCaptureOnPowerSave`.
+    /// #477 battery (parity with Android): STRAP battery-% at/below which the periodic offload cadence
+    /// stretches to `lowBatteryBackfillIntervalSeconds` (0 = off), and at/below which the background
+    /// continuous-HRV stream is released. Both key off the STRAP's charge (not the phone's), and both are
+    /// benign (no link risk). Set from Settings via `setLowBatteryOffloadThrottle`/`setPauseCaptureOnPowerSave`.
     private var lowBatteryOffloadPct = 0
-    /// Battery-% at/below which the continuous-HRV pause engages while low on power (0 = off) — like the
-    /// offload lever, it also engages under Low Power Mode.
+    /// STRAP battery-% at/below which the continuous-HRV pause engages (0 = off) — like the offload lever.
     private var pauseCaptureBatteryPct = 0
     /// Derived want: the (heavy) realtime stream should be armed while EITHER a screen wants it OR the
     /// continuous-capture preference wants it. Keep-alive re-arms it; the post-bond branch arms it on
@@ -2067,30 +2066,22 @@ public final class BLEManager: NSObject, ObservableObject {
         lowBatteryOffloadPct = thresholdPct
     }
 
-    /// #477 (Settings): pause the background continuous-HRV stream while power-saving. Battery-%-aware
-    /// like the offload lever — pass the same threshold; engages at/below it OR under Low Power Mode
-    /// (0 = off). Reconciles now.
+    /// #477 (Settings): pause the background continuous-HRV stream when the strap is low. Keyed on the
+    /// STRAP's battery like the offload lever — pass the same threshold; engages at/below it (0 = off).
+    /// Reconciles now.
     public func setPauseCaptureOnPowerSave(_ enabled: Bool, thresholdPct: Int) {
         pauseCaptureBatteryPct = enabled ? thresholdPct : 0
         reconcileRealtime()
     }
 
-    /// #477: is the OS saving power (Low Power Mode)? The iOS analog of Android's Battery Saver; also on
-    /// macOS 12+. An additional trigger for an already-armed lever.
-    private func powerSaveActive() -> Bool { ProcessInfo.processInfo.isLowPowerModeEnabled }
 
-    /// #477: current (battery-%, isCharging). iOS reads `UIDevice`; macOS has no per-app battery API here,
-    /// so it returns (100, false) — the %-threshold then never engages and only Low Power Mode does.
+    /// #477: the connected STRAP's (battery-%, isCharging) — WHOOP, and the same for Oura/Fitbit. Power
+    /// saving keys off the strap, not the phone, because the levers reduce how much the STRAP transmits
+    /// (fewer offloads, no continuous stream) and so extend the strap's life when it wasn't charged in
+    /// time. Unknown (disconnected / not yet read) → (100, false), so it fails SAFE (never throttles
+    /// without a real low reading; a disconnected strap has nothing to throttle anyway).
     private func batteryPctAndCharging() -> (pct: Int, charging: Bool) {
-        #if os(iOS)
-        let dev = UIDevice.current
-        dev.isBatteryMonitoringEnabled = true
-        let lvl = dev.batteryLevel   // 0...1, or -1 when unknown
-        let charging = dev.batteryState == .charging || dev.batteryState == .full
-        return (lvl >= 0 ? Int((lvl * 100).rounded()) : 100, charging)
-        #else
-        return (100, false)
-        #endif
+        (state.batteryPct.map { Int($0.rounded()) } ?? 100, state.charging == true)
     }
 
     /// The next periodic-offload interval — normally `backfillIntervalSeconds`, stretched when low on
@@ -2101,7 +2092,7 @@ public final class BLEManager: NSObject, ObservableObject {
         return BLEManager.offloadInterval(
             baseSeconds: BLEManager.backfillIntervalSeconds,
             lowSeconds: BLEManager.lowBatteryBackfillIntervalSeconds,
-            batteryPct: pct, charging: charging, thresholdPct: lowBatteryOffloadPct, powerSave: powerSaveActive())
+            batteryPct: pct, charging: charging, thresholdPct: lowBatteryOffloadPct)
     }
 
     /// #927: the continuous-capture side of the realtime want, window-gated. True while the "Continuous
@@ -2112,15 +2103,14 @@ public final class BLEManager: NSObject, ObservableObject {
     /// Mirrors the Android `continuousCaptureWantsNow`.
     private func continuousCaptureWantsNow(now: Date = Date()) -> Bool {
         guard keepRealtimeForData else { return false }
-        // #477: while power saving is ACTIVE (battery ≤ threshold or Low Power Mode), release the
-        // held-open background stream — battery-%-aware like the offload lever, via the shared
-        // lowPowerThrottleActive gate. A Live screen still arms it via screenWantsRealtime (checked
-        // separately in reconcileRealtime). The keep-alive re-derives this, so it re-arms automatically
-        // once off power save.
+        // #477: while the STRAP's battery is low (≤ threshold, discharging), release the held-open
+        // background stream — via the shared lowPowerThrottleActive gate. A Live screen still arms it via
+        // screenWantsRealtime (checked separately in reconcileRealtime). The keep-alive re-derives this,
+        // so it re-arms automatically once the strap is charged.
         if pauseCaptureBatteryPct > 0 {
             let (pct, charging) = batteryPctAndCharging()
             if BLEManager.lowPowerThrottleActive(batteryPct: pct, charging: charging,
-                                                 thresholdPct: pauseCaptureBatteryPct, powerSave: powerSaveActive()) {
+                                                 thresholdPct: pauseCaptureBatteryPct) {
                 return false
             }
         }

--- a/Strand/Screens/SettingsView.swift
+++ b/Strand/Screens/SettingsView.swift
@@ -962,7 +962,7 @@ struct SettingsView: View {
         SettingsSection(
             icon: "battery.25",
             title: "Power saving",
-            blurb: "Ease battery use when your phone is low or in Low Power Mode. The strap keeps banking data on its own, so nothing is lost — NOOP just syncs it less often."
+            blurb: "Ease the load on your strap when its battery is running low. The strap keeps banking data on its own, so nothing is lost — NOOP just talks to it less often to help it last until you can charge it."
         ) {
             VStack(alignment: .leading, spacing: 16) {
                 Toggle(isOn: $powerSavingEnabled) {
@@ -973,7 +973,7 @@ struct SettingsView: View {
                 .toggleStyle(.switch)
                 .tint(StrandPalette.accent)
                 .onChangeCompat(of: powerSavingEnabled) { _ in model.applyPowerSaving() }
-                Text("Slows background strap-sync (every 45 min instead of 15) while your battery is low or Low Power Mode is on. No data loss — sync just batches into larger, less frequent pulls.")
+                Text("Slows background strap-sync (every 45 min instead of 15) while your strap's battery is low. No data loss — the strap banks everything, so sync just batches into larger, less frequent pulls.")
                     .font(StrandFont.caption)
                     .foregroundStyle(StrandPalette.textTertiary)
                     .fixedSize(horizontal: false, vertical: true)
@@ -981,7 +981,7 @@ struct SettingsView: View {
                 if powerSavingEnabled {
                     Divider().overlay(StrandPalette.hairline)
                     HStack {
-                        Text("Kick in at")
+                        Text("Kick in at (strap battery)")
                             .font(StrandFont.subhead)
                             .foregroundStyle(StrandPalette.textPrimary)
                         Spacer()
@@ -1006,7 +1006,7 @@ struct SettingsView: View {
                     .toggleStyle(.switch)
                     .tint(StrandPalette.accent)
                     .onChangeCompat(of: pauseHrvDisabled) { _ in model.applyPowerSaving() }
-                    Text("While saving power (battery low or Low Power Mode), stop the always-on background HRV stream — the biggest live drain. A Live screen still shows heart rate, and it re-arms automatically once you're off power saving.")
+                    Text("While your strap's battery is low, stop the always-on background HRV stream — the biggest continuous drain on the strap. A Live screen still shows heart rate, and it re-arms automatically once the strap is charged.")
                         .font(StrandFont.caption)
                         .foregroundStyle(StrandPalette.textTertiary)
                         .fixedSize(horizontal: false, vertical: true)

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -16,12 +16,8 @@ import android.bluetooth.le.ScanFilter
 import android.bluetooth.le.ScanResult
 import android.bluetooth.le.ScanSettings
 import android.content.Context
-import android.content.Intent
-import android.content.IntentFilter
 import android.content.pm.PackageManager
-import android.os.BatteryManager
 import android.os.Build
-import android.os.PowerManager
 import androidx.core.content.ContextCompat
 import android.os.Handler
 import android.os.Looper
@@ -477,30 +473,27 @@ class WhoopBleClient(
             else -> BluetoothGatt.CONNECTION_PRIORITY_BALANCED
         }
 
-        /** Pure battery-adaptive gate for the RISKY idle LOW_POWER throttle (#477), unit-testable without
-         *  a BLE stack. The lever is ARMED by [thresholdPct] > 0 (the Settings picker offers 10/15/20/25/
-         *  30; 0 disables it — safe half only, and NOT even Battery Saver can force it, respecting the
-         *  drop-risk asymmetry). Once armed and while DISCHARGING it engages at/below [thresholdPct] OR
-         *  when the OS Battery Saver is on ([powerSave]) — whichever comes first. Charging never throttles.
-         *  The threshold IS its own hysteresis: battery % moves slowly, so a boundary crossing flips at
-         *  most once per point; Battery Saver has its own hysteresis. */
-        fun idleThrottleActive(batteryPct: Int, charging: Boolean, thresholdPct: Int, powerSave: Boolean): Boolean =
-            thresholdPct > 0 && !charging && (batteryPct <= thresholdPct || powerSave)
+        /** Pure battery-adaptive gate (#477), unit-testable without a BLE stack. Keyed on the STRAP's
+         *  battery (WHOOP/Oura/Fitbit): the lever is ARMED by [thresholdPct] > 0 (the Settings slider is
+         *  10–30; 0 disables it) and engages while the strap is DISCHARGING at/below [thresholdPct]. The
+         *  phone's own Battery Saver deliberately does NOT trigger it — power saving is about the strap's
+         *  charge, not the phone's. A charging strap never throttles. The threshold is its own hysteresis
+         *  (battery % moves slowly, so a boundary crossing flips at most once per point). */
+        fun idleThrottleActive(batteryPct: Int, charging: Boolean, thresholdPct: Int): Boolean =
+            thresholdPct > 0 && !charging && batteryPct <= thresholdPct
 
-        /** Stretched periodic-offload interval when the phone is low on battery (#477). The offload tick
+        /** Stretched periodic-offload interval while the STRAP is low on battery (#477). The offload tick
          *  is a PURE sync timer (the live-stream keep-alive is separate), so stretching it can't affect
-         *  link health — worst case is fresher data arriving in slightly larger batches; the strap banks
+         *  link health — worst case is data arriving in slightly larger batches; the strap banks
          *  everything to flash meanwhile, so no data is lost. Left at [LOW_BATTERY_BACKFILL_INTERVAL_MS]
-         *  while DISCHARGING at/below [thresholdPct], else the normal [baseMs]. [thresholdPct] <= 0 / charging
-         *  never stretches. Pure, unit-testable. */
+         *  while DISCHARGING at/below [thresholdPct], else the normal [baseMs]. Pure, unit-testable. */
         fun offloadIntervalMsFor(
             baseMs: Long,
             lowBatteryMs: Long,
             batteryPct: Int,
             charging: Boolean,
             thresholdPct: Int,
-            powerSave: Boolean,
-        ): Long = if (idleThrottleActive(batteryPct, charging, thresholdPct, powerSave)) maxOf(baseMs, lowBatteryMs) else baseMs
+        ): Long = if (idleThrottleActive(batteryPct, charging, thresholdPct)) maxOf(baseMs, lowBatteryMs) else baseMs
 
         /** Pure keep/teardown decision for [prepareForPresentScan] (#74), unit-testable without a BLE
          *  stack (the [scanModeForReconnectAttempts] idiom). Keep the live link ONLY when one exists AND
@@ -1200,14 +1193,14 @@ class WhoopBleClient(
         lowBatteryOffloadPct = thresholdPct
     }
 
-    /** #477: pause BACKGROUND continuous-HRV capture while the OS Battery Saver is on (own toggle,
+    /** #477: pause BACKGROUND continuous-HRV capture while the STRAP's battery is low (own toggle,
      *  DEFAULT OFF). A visible Live screen is unaffected — only the held-open background stream is
      *  released. Gated through [continuousCaptureWantsNow]. */
     @Volatile private var pauseCaptureBatteryPct: Int = 0
 
-    /** Opt into pausing continuous capture while power-saving (#477). Now battery-%-aware like the other
-     *  levers: pass the same threshold, so it engages at/below it OR under Battery Saver (0 = off).
-     *  Reconciles immediately so the change takes effect without waiting for the next keep-alive tick. */
+    /** Opt into pausing continuous capture when the strap is low (#477). Battery-%-aware like the other
+     *  levers: pass the same threshold, so it engages at/below the STRAP's % (0 = off). Reconciles
+     *  immediately so the change takes effect without waiting for the next keep-alive tick. */
     fun setPauseCaptureOnPowerSave(enabled: Boolean, thresholdPct: Int) {
         pauseCaptureBatteryPct = if (enabled) thresholdPct else 0
         handler.post { reconcileRealtime() }
@@ -1224,25 +1217,17 @@ class WhoopBleClient(
             batteryPct = batteryPct,
             charging = charging,
             thresholdPct = lowBatteryOffloadPct,
-            powerSave = powerSaveActive(),
         )
     }
 
-    /** True when the OS Battery Saver is on — the user's explicit "save power" signal (#477). An extra
-     *  trigger for an already-armed lever; has its own hysteresis + charging-awareness. */
-    private fun powerSaveActive(): Boolean =
-        (context.getSystemService(Context.POWER_SERVICE) as? PowerManager)?.isPowerSaveMode == true
-
-    /** Current (battery-%, isCharging) from the sticky ACTION_BATTERY_CHANGED intent — a cheap synchronous
-     *  read, no persistent receiver. Unknown → (100, false) so the throttle fails SAFE (never engages). */
+    /** The connected STRAP's (battery-%, isCharging) — WHOOP, and the same for Oura/Fitbit. Power saving
+     *  keys off the strap, not the phone: the levers reduce how much the STRAP transmits (fewer offloads,
+     *  no continuous stream), so they extend the strap's life when it wasn't charged in time. Unknown
+     *  (disconnected / not yet read) → (100, false), fails SAFE (a disconnected strap has nothing to
+     *  throttle anyway). */
     private fun batteryPctAndCharging(): Pair<Int, Boolean> {
-        val i = context.registerReceiver(null, IntentFilter(Intent.ACTION_BATTERY_CHANGED))
-        val level = i?.getIntExtra(BatteryManager.EXTRA_LEVEL, -1) ?: -1
-        val scale = i?.getIntExtra(BatteryManager.EXTRA_SCALE, -1) ?: -1
-        val status = i?.getIntExtra(BatteryManager.EXTRA_STATUS, -1) ?: -1
-        val pct = if (level >= 0 && scale > 0) level * 100 / scale else 100
-        val charging = status == BatteryManager.BATTERY_STATUS_CHARGING || status == BatteryManager.BATTERY_STATUS_FULL
-        return pct to charging
+        val s = _state.value
+        return (s.batteryPct?.toInt() ?: 100) to (s.charging == true)
     }
 
     /** (Re)apply the GATT connection priority for the current link state (#477). Idempotent + cheap: OFF
@@ -1254,7 +1239,7 @@ class WhoopBleClient(
         // HIGH-escalation half doesn't need it, so safe-half-only mode issues no battery read.
         val idleThrottle = idleThrottleBatteryPct > 0 && run {
             val (batteryPct, charging) = batteryPctAndCharging()
-            idleThrottleActive(batteryPct, charging, idleThrottleBatteryPct, powerSaveActive())
+            idleThrottleActive(batteryPct, charging, idleThrottleBatteryPct)
         }
         // Read the authoritative INTERNAL flags (both set synchronously on this looper), not the
         // published LiveState mirror, which `exitBackfilling` may update a beat later.
@@ -4354,7 +4339,7 @@ class WhoopBleClient(
         // BACKGROUND capture the user opted into. Re-arms automatically once off power save.
         if (pauseCaptureBatteryPct > 0) {
             val (batteryPct, charging) = batteryPctAndCharging()
-            if (idleThrottleActive(batteryPct, charging, pauseCaptureBatteryPct, powerSaveActive())) return false
+            if (idleThrottleActive(batteryPct, charging, pauseCaptureBatteryPct)) return false
         }
         val cal = java.util.Calendar.getInstance()
         val minuteOfDay = cal.get(java.util.Calendar.HOUR_OF_DAY) * 60 + cal.get(java.util.Calendar.MINUTE)

--- a/android/app/src/main/java/com/noop/ui/AppViewModel.kt
+++ b/android/app/src/main/java/com/noop/ui/AppViewModel.kt
@@ -868,12 +868,7 @@ class AppViewModel(app: Application) : AndroidViewModel(app) {
                 // apps see them. Idempotent (clientRecordId per metric+day), so re-running every
                 // cycle just upserts. Never let an HC hiccup (perm revoked mid-flight, provider
                 // update) break the analysis loop.
-                // #477: defer the writeback while power-saving is active (Android-only sub-option — iOS
-                // Health is Shortcut-driven, so it has no NOOP-scheduled sync to defer). Resumes next
-                // cycle once off power save; a manual Data-Sources sync always writes regardless.
-                if (_hcWriteback.value &&
-                    !(NoopPrefs.deferHealthSync(appContext) && isPowerSavingActiveNow())
-                ) {
+                if (_hcWriteback.value) {
                     runCatching { HealthConnectWriter.write(appContext, repository, deviceId) }
                 }
                 // 15-min backstop cadence, but wake EARLY on an app-resume kick (#386 self-heal) so a
@@ -910,20 +905,6 @@ class AppViewModel(app: Application) : AndroidViewModel(app) {
             on && NoopPrefs.pauseHrvOnPowerSave(appContext),
             NoopPrefs.powerSavingBatteryPct(appContext),
         )
-    }
-
-    /** #477: is power saving CURRENTLY throttling — master on AND (STRAP battery ≤ threshold while the
-     *  strap is discharging OR the phone is in Battery Saver)? Reuses the SAME pure gate as the BLE
-     *  levers so all three agree. Read live per analyze cycle; unknown strap battery fails SAFE (100 %). */
-    private fun isPowerSavingActiveNow(): Boolean {
-        if (!NoopPrefs.powerSaving(appContext)) return false
-        // Key off the connected STRAP's battery (WHOOP/Oura/Fitbit), not the phone — see
-        // WhoopBleClient.batteryPctAndCharging. The phone's own Battery Saver deliberately does NOT
-        // trigger it: power saving is about the strap's charge. Unknown strap battery → 100 (fails safe).
-        val s = ble.state.value
-        val pct = s.batteryPct?.toInt() ?: 100
-        val charging = s.charging == true
-        return WhoopBleClient.idleThrottleActive(pct, charging, NoopPrefs.powerSavingBatteryPct(appContext))
     }
 
     /** Flip "Power saving" (Settings). Persists + applies immediately. */

--- a/android/app/src/main/java/com/noop/ui/AppViewModel.kt
+++ b/android/app/src/main/java/com/noop/ui/AppViewModel.kt
@@ -2,10 +2,6 @@ package com.noop.ui
 
 import android.app.Application
 import android.content.Context
-import android.content.Intent
-import android.content.IntentFilter
-import android.os.BatteryManager
-import android.os.PowerManager
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
 import com.noop.NoopApplication
@@ -916,19 +912,18 @@ class AppViewModel(app: Application) : AndroidViewModel(app) {
         )
     }
 
-    /** #477: is power saving CURRENTLY throttling — master on AND (battery ≤ threshold while discharging
-     *  OR Battery Saver)? Reuses the SAME pure gate as the BLE levers so all three agree. Read live per
-     *  analyze cycle; unknown battery fails SAFE (100 %, never throttles). */
+    /** #477: is power saving CURRENTLY throttling — master on AND (STRAP battery ≤ threshold while the
+     *  strap is discharging OR the phone is in Battery Saver)? Reuses the SAME pure gate as the BLE
+     *  levers so all three agree. Read live per analyze cycle; unknown strap battery fails SAFE (100 %). */
     private fun isPowerSavingActiveNow(): Boolean {
         if (!NoopPrefs.powerSaving(appContext)) return false
-        val i = appContext.registerReceiver(null, IntentFilter(Intent.ACTION_BATTERY_CHANGED))
-        val level = i?.getIntExtra(BatteryManager.EXTRA_LEVEL, -1) ?: -1
-        val scale = i?.getIntExtra(BatteryManager.EXTRA_SCALE, -1) ?: -1
-        val status = i?.getIntExtra(BatteryManager.EXTRA_STATUS, -1) ?: -1
-        val pct = if (level >= 0 && scale > 0) level * 100 / scale else 100
-        val charging = status == BatteryManager.BATTERY_STATUS_CHARGING || status == BatteryManager.BATTERY_STATUS_FULL
-        val powerSave = (appContext.getSystemService(Context.POWER_SERVICE) as? PowerManager)?.isPowerSaveMode ?: false
-        return WhoopBleClient.idleThrottleActive(pct, charging, NoopPrefs.powerSavingBatteryPct(appContext), powerSave)
+        // Key off the connected STRAP's battery (WHOOP/Oura/Fitbit), not the phone — see
+        // WhoopBleClient.batteryPctAndCharging. The phone's own Battery Saver deliberately does NOT
+        // trigger it: power saving is about the strap's charge. Unknown strap battery → 100 (fails safe).
+        val s = ble.state.value
+        val pct = s.batteryPct?.toInt() ?: 100
+        val charging = s.charging == true
+        return WhoopBleClient.idleThrottleActive(pct, charging, NoopPrefs.powerSavingBatteryPct(appContext))
     }
 
     /** Flip "Power saving" (Settings). Persists + applies immediately. */

--- a/android/app/src/main/java/com/noop/ui/MainActivity.kt
+++ b/android/app/src/main/java/com/noop/ui/MainActivity.kt
@@ -217,14 +217,6 @@ object NoopPrefs {
      *  [com.noop.ble.WhoopBleClient.setPauseCaptureOnPowerSave] via [AppViewModel]. */
     const val KEY_PAUSE_HRV_ON_POWER_SAVE = "noop.pauseHrvOnPowerSave"
 
-    /** "Defer Health Connect writeback while power-saving" (#477), a sub-option of Power saving, default
-     *  ON. When power saving is active (battery ≤ threshold or Battery Saver, discharging), skip the
-     *  every-15-min idempotent Health Connect score writeback; it resumes automatically once off power
-     *  save (and a manual sync always runs it). ANDROID-ONLY BY DESIGN — iOS has no NOOP-scheduled Health
-     *  sync to defer (its Apple Health integration is Shortcut-driven because a sideload signing identity
-     *  can't hold the HealthKit entitlement), so there is nothing to gate on the iOS side. */
-    const val KEY_DEFER_HEALTH_SYNC = "noop.deferHealthSyncOnPowerSave"
-
     fun of(context: Context): SharedPreferences =
         context.getSharedPreferences(NAME, Context.MODE_PRIVATE)
 
@@ -250,15 +242,6 @@ object NoopPrefs {
 
     fun setPauseHrvOnPowerSave(context: Context, enabled: Boolean) {
         of(context).edit().putBoolean(KEY_PAUSE_HRV_ON_POWER_SAVE, enabled).apply()
-    }
-
-    /** Defer Health Connect writeback while power-saving is active (sub-option of Power saving). Default
-     *  ON. Android-only (see [KEY_DEFER_HEALTH_SYNC]). */
-    fun deferHealthSync(context: Context): Boolean =
-        of(context).getBoolean(KEY_DEFER_HEALTH_SYNC, true)
-
-    fun setDeferHealthSync(context: Context, enabled: Boolean) {
-        of(context).edit().putBoolean(KEY_DEFER_HEALTH_SYNC, enabled).apply()
     }
 
     /** #836, the raw-HR fingerprint ("count:maxTs") the last COMPLETED idle rescore scored against. The

--- a/android/app/src/main/java/com/noop/ui/SettingsScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/SettingsScreen.kt
@@ -483,7 +483,6 @@ fun SettingsScreen(
     var powerSaving by remember { mutableStateOf(NoopPrefs.powerSaving(context)) }
     var powerSavingBatteryPct by remember { mutableStateOf(NoopPrefs.powerSavingBatteryPct(context)) }
     var pauseHrvOnPowerSave by remember { mutableStateOf(NoopPrefs.pauseHrvOnPowerSave(context)) }
-    var deferHealthSync by remember { mutableStateOf(NoopPrefs.deferHealthSync(context)) }
 
     // --- v5 Health & wellness toggle group. All SharedPreferences-backed (not reactive), so each Switch
     // drives a local mirror that writes straight through to the same keys the v5 engine readers use.
@@ -1628,37 +1627,6 @@ fun SettingsScreen(
                         onCheckedChange = {
                             pauseHrvOnPowerSave = it
                             vm.setPauseHrvOnPowerSave(it)
-                        },
-                        colors = SwitchDefaults.colors(
-                            checkedThumbColor = Palette.surfaceBase,
-                            checkedTrackColor = Palette.accent,
-                            uncheckedThumbColor = Palette.textSecondary,
-                            uncheckedTrackColor = Palette.surfaceInset,
-                            uncheckedBorderColor = Palette.hairline,
-                        ),
-                    )
-                }
-                RowDivider()
-                // Defer Health Connect writeback: a sub-option of power saving, ON by default. Read live
-                // by the analyze loop (no BLE push), so a plain pref write is enough.
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    verticalAlignment = Alignment.CenterVertically,
-                    horizontalArrangement = Arrangement.spacedBy(16.dp),
-                ) {
-                    Column(modifier = Modifier.weight(1f)) {
-                        Text(stringResource(R.string.power_saving_defer_health), style = NoopType.subhead, color = Palette.textPrimary)
-                        Text(
-                            stringResource(R.string.power_saving_defer_health_desc),
-                            style = NoopType.footnote,
-                            color = Palette.textTertiary,
-                        )
-                    }
-                    Switch(
-                        checked = deferHealthSync,
-                        onCheckedChange = {
-                            deferHealthSync = it
-                            NoopPrefs.setDeferHealthSync(context, it)
                         },
                         colors = SwitchDefaults.colors(
                             checkedThumbColor = Palette.surfaceBase,

--- a/android/app/src/main/res/values-de/strings.xml
+++ b/android/app/src/main/res/values-de/strings.xml
@@ -155,6 +155,4 @@
     <string name="power_saving_pct">%1$d %%</string>
     <string name="power_saving_hrv_pause">HFV-Erfassung pausieren</string>
     <string name="power_saving_hrv_pause_desc">Wenn der Akku deines Bandes niedrig ist, wird der dauerhafte HFV-Hintergrundstream gestoppt – der größte Dauerverbraucher am Band. Ein Live-Bildschirm zeigt weiterhin die Herzfrequenz an, und er wird automatisch reaktiviert, sobald das Band geladen ist.</string>
-    <string name="power_saving_defer_health">Health-Connect-Rückschreibung aufschieben</string>
-    <string name="power_saving_defer_health_desc">Während des Energiesparens das Zurückschreiben der Werte an Health Connect aussetzen (sonst alle 15 Minuten). Es wird automatisch fortgesetzt, sobald das Energiesparen endet, und eine manuelle Synchronisierung führt es immer aus.</string>
 </resources>

--- a/android/app/src/main/res/values-de/strings.xml
+++ b/android/app/src/main/res/values-de/strings.xml
@@ -148,13 +148,13 @@
 
     <!-- Power saving (#477) -->
     <string name="power_saving">Energie sparen</string>
-    <string name="power_saving_blurb">Reduziert den Akkuverbrauch, wenn dein Telefon wenig Akku hat oder im Energiesparmodus ist. Der Sensor speichert die Daten selbst, es geht also nichts verloren – NOOP synchronisiert nur seltener.</string>
+    <string name="power_saving_blurb">Entlastet dein Band, wenn sein Akku zur Neige geht. Das Band speichert die Daten selbst, es geht also nichts verloren – NOOP kommuniziert nur seltener mit ihm, damit es durchhält, bis du es laden kannst.</string>
     <string name="power_saving_mode">Energiesparmodus</string>
-    <string name="power_saving_mode_desc">Verlangsamt die Hintergrund-Synchronisierung des Sensors (alle 45 statt 15 Minuten), wenn der Akku niedrig ist oder der Energiesparmodus aktiv ist. Kein Datenverlust – die Synchronisierung erfolgt in größeren, selteneren Schüben.</string>
-    <string name="power_saving_kick_in">Aktiv ab</string>
+    <string name="power_saving_mode_desc">Verlangsamt die Hintergrund-Synchronisierung des Sensors (alle 45 statt 15 Minuten), wenn der Akku deines Bandes niedrig ist. Kein Datenverlust – das Band speichert alles, die Synchronisierung erfolgt nur in größeren, selteneren Schüben.</string>
+    <string name="power_saving_kick_in">Aktiv ab (Band-Akku)</string>
     <string name="power_saving_pct">%1$d %%</string>
     <string name="power_saving_hrv_pause">HFV-Erfassung pausieren</string>
-    <string name="power_saving_hrv_pause_desc">Während des Energiesparens (niedriger Akku oder Energiesparmodus) wird der dauerhafte HFV-Hintergrundstream gestoppt – der größte Live-Verbraucher. Ein Live-Bildschirm zeigt weiterhin die Herzfrequenz an, und er wird automatisch reaktiviert, sobald das Energiesparen endet.</string>
+    <string name="power_saving_hrv_pause_desc">Wenn der Akku deines Bandes niedrig ist, wird der dauerhafte HFV-Hintergrundstream gestoppt – der größte Dauerverbraucher am Band. Ein Live-Bildschirm zeigt weiterhin die Herzfrequenz an, und er wird automatisch reaktiviert, sobald das Band geladen ist.</string>
     <string name="power_saving_defer_health">Health-Connect-Rückschreibung aufschieben</string>
     <string name="power_saving_defer_health_desc">Während des Energiesparens das Zurückschreiben der Werte an Health Connect aussetzen (sonst alle 15 Minuten). Es wird automatisch fortgesetzt, sobald das Energiesparen endet, und eine manuelle Synchronisierung führt es immer aus.</string>
 </resources>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -166,13 +166,13 @@
 
     <!-- Power saving (#477) -->
     <string name="power_saving">Power saving</string>
-    <string name="power_saving_blurb">Ease battery use when your phone is low or in Battery Saver. The strap keeps banking data on its own, so nothing is lost — NOOP just syncs it less often.</string>
+    <string name="power_saving_blurb">Ease the load on your strap when its battery is running low. The strap keeps banking data on its own, so nothing is lost — NOOP just talks to it less often to help it last until you can charge it.</string>
     <string name="power_saving_mode">Power saving mode</string>
-    <string name="power_saving_mode_desc">Slows background strap-sync (every 45 min instead of 15) while your battery is low or Battery Saver is on. No data loss — sync just batches into larger, less frequent pulls.</string>
-    <string name="power_saving_kick_in">Kick in at</string>
+    <string name="power_saving_mode_desc">Slows background strap-sync (every 45 min instead of 15) while your strap\'s battery is low. No data loss — the strap banks everything, so sync just batches into larger, less frequent pulls.</string>
+    <string name="power_saving_kick_in">Kick in at (strap battery)</string>
     <string name="power_saving_pct">%1$d%%</string>
     <string name="power_saving_hrv_pause">Pause HRV capture</string>
-    <string name="power_saving_hrv_pause_desc">While saving power (battery low or Battery Saver), stop the always-on background HRV stream — the biggest live drain. A Live screen still shows heart rate, and it re-arms automatically once you\'re off power saving.</string>
+    <string name="power_saving_hrv_pause_desc">While your strap\'s battery is low, stop the always-on background HRV stream — the biggest continuous drain on the strap. A Live screen still shows heart rate, and it re-arms automatically once the strap is charged.</string>
     <string name="power_saving_defer_health">Defer Health Connect writeback</string>
     <string name="power_saving_defer_health_desc">While saving power, hold off writing scores to Health Connect (they otherwise upsert every 15 minutes). Writeback resumes automatically once you\'re off power saving, and a manual sync always runs it.</string>
 </resources>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -173,6 +173,4 @@
     <string name="power_saving_pct">%1$d%%</string>
     <string name="power_saving_hrv_pause">Pause HRV capture</string>
     <string name="power_saving_hrv_pause_desc">While your strap\'s battery is low, stop the always-on background HRV stream — the biggest continuous drain on the strap. A Live screen still shows heart rate, and it re-arms automatically once the strap is charged.</string>
-    <string name="power_saving_defer_health">Defer Health Connect writeback</string>
-    <string name="power_saving_defer_health_desc">While saving power, hold off writing scores to Health Connect (they otherwise upsert every 15 minutes). Writeback resumes automatically once you\'re off power saving, and a manual sync always runs it.</string>
 </resources>

--- a/android/app/src/test/java/com/noop/ble/ConnectionPriorityTest.kt
+++ b/android/app/src/test/java/com/noop/ble/ConnectionPriorityTest.kt
@@ -48,26 +48,23 @@ class ConnectionPriorityTest {
         )
     }
 
-    // --- battery-adaptive gate for the risky idle throttle (#477) ---
+    // --- battery-adaptive gate, keyed on STRAP battery only (#477) ---
 
     @Test fun idleThrottleEngagesOnlyWhenDischargingAtOrBelowThreshold() {
-        // at/below threshold, discharging, no Battery Saver → engage
-        assertTrue(WhoopBleClient.idleThrottleActive(batteryPct = 20, charging = false, thresholdPct = 20, powerSave = false))
-        assertTrue(WhoopBleClient.idleThrottleActive(batteryPct = 12, charging = false, thresholdPct = 20, powerSave = false))
-        // above threshold, no Battery Saver → do not engage
-        assertFalse(WhoopBleClient.idleThrottleActive(batteryPct = 21, charging = false, thresholdPct = 20, powerSave = false))
+        // strap at/below threshold, discharging → engage
+        assertTrue(WhoopBleClient.idleThrottleActive(batteryPct = 20, charging = false, thresholdPct = 20))
+        assertTrue(WhoopBleClient.idleThrottleActive(batteryPct = 12, charging = false, thresholdPct = 20))
+        // above threshold → do not engage
+        assertFalse(WhoopBleClient.idleThrottleActive(batteryPct = 21, charging = false, thresholdPct = 20))
+        // well above → do not engage (the phone's own Battery Saver is NOT a trigger)
+        assertFalse(WhoopBleClient.idleThrottleActive(batteryPct = 80, charging = false, thresholdPct = 20))
     }
 
     @Test fun idleThrottleNeverEngagesWhenChargingOrDisabled() {
-        // charging → never (battery isn't the concern), even under Battery Saver
-        assertFalse(WhoopBleClient.idleThrottleActive(batteryPct = 5, charging = true, thresholdPct = 30, powerSave = true))
-        // threshold 0 → disabled (safe half only); NOT even Battery Saver forces the risky throttle
-        assertFalse(WhoopBleClient.idleThrottleActive(batteryPct = 1, charging = false, thresholdPct = 0, powerSave = true))
-    }
-
-    @Test fun batterySaverEngagesAnArmedThrottleAboveThreshold() {
-        // armed (threshold 20), battery well above it, but Battery Saver on + discharging → engage
-        assertTrue(WhoopBleClient.idleThrottleActive(batteryPct = 80, charging = false, thresholdPct = 20, powerSave = true))
+        // strap charging → never (its battery isn't the concern)
+        assertFalse(WhoopBleClient.idleThrottleActive(batteryPct = 5, charging = true, thresholdPct = 30))
+        // threshold 0 → disabled
+        assertFalse(WhoopBleClient.idleThrottleActive(batteryPct = 1, charging = false, thresholdPct = 0))
     }
 
     // --- battery-adaptive offload cadence (#477) ---
@@ -76,18 +73,17 @@ class ConnectionPriorityTest {
     private val low = 2_700_000L     // 45 min
 
     @Test fun offloadStretchesOnlyWhenDischargingAtOrBelowThreshold() {
-        // discharging, at/below → stretched
-        assertEquals(low, WhoopBleClient.offloadIntervalMsFor(base, low, batteryPct = 18, charging = false, thresholdPct = 20, powerSave = false))
-        // above threshold, no Battery Saver → normal cadence
-        assertEquals(base, WhoopBleClient.offloadIntervalMsFor(base, low, batteryPct = 40, charging = false, thresholdPct = 20, powerSave = false))
-        // armed + Battery Saver above threshold → stretched
-        assertEquals(low, WhoopBleClient.offloadIntervalMsFor(base, low, batteryPct = 70, charging = false, thresholdPct = 20, powerSave = true))
+        // strap discharging, at/below → stretched
+        assertEquals(low, WhoopBleClient.offloadIntervalMsFor(base, low, batteryPct = 18, charging = false, thresholdPct = 20))
+        // above threshold → normal cadence (no phone-Battery-Saver override)
+        assertEquals(base, WhoopBleClient.offloadIntervalMsFor(base, low, batteryPct = 40, charging = false, thresholdPct = 20))
+        assertEquals(base, WhoopBleClient.offloadIntervalMsFor(base, low, batteryPct = 70, charging = false, thresholdPct = 20))
     }
 
     @Test fun offloadNeverStretchesWhenChargingOrDisabled() {
-        // charging → normal even at low battery / Battery Saver
-        assertEquals(base, WhoopBleClient.offloadIntervalMsFor(base, low, batteryPct = 8, charging = true, thresholdPct = 30, powerSave = true))
-        // threshold 0 → normal cadence always, even under Battery Saver
-        assertEquals(base, WhoopBleClient.offloadIntervalMsFor(base, low, batteryPct = 3, charging = false, thresholdPct = 0, powerSave = true))
+        // strap charging → normal even at low battery
+        assertEquals(base, WhoopBleClient.offloadIntervalMsFor(base, low, batteryPct = 8, charging = true, thresholdPct = 30))
+        // threshold 0 → normal cadence always
+        assertEquals(base, WhoopBleClient.offloadIntervalMsFor(base, low, batteryPct = 3, charging = false, thresholdPct = 0))
     }
 }


### PR DESCRIPTION
Reframes power saving to help the **strap** last when it wasn't charged in time, per on-thread discussion:

- **Keys off the connected strap's battery** (WHOOP, and the same `LiveState` path for Oura/Fitbit), not the phone. `batteryPctAndCharging` on both platforms now reads `state.batteryPct`/`charging` (0–100 whole %); `UIDevice`/`BatteryManager` phone reads removed. Unknown/disconnected → `(100, false)`, fails safe.
- **Triggers ONLY on low strap battery** — dropped the phone Battery Saver / Low Power Mode OR from the pure gates (`idleThrottleActive`/`offloadIntervalMsFor`, `lowPowerThrottleActive`/`offloadInterval`) and removed the now-unused `powerSaveActive` helpers + `PowerManager`/`ProcessInfo` reads + imports.
- **Dropped the defer-Health-writeback lever** — with power saving now about the strap, deferring the phone's Health Connect write (a phone-side CPU/IPC cost, no strap involvement) no longer fits. The section is now coherently strap-only.
- **Copy reworded** (en + de + iOS catalog): "your strap's battery," slider labelled "Kick in at (strap battery)."
- **Tests** updated (`ConnectionPriorityTest` strap-only; Battery-Saver cases removed).

The two remaining levers both genuinely reduce **strap** drain: offload-cadence stretch (less transmission) and HRV pause (less streaming). Charging strap → off; disconnected → fail-safe.

## Verification
- iOS: **app-build green** (Strand macOS + NOOPiOS) — app-target Swift.
- Android: `:app:compileFullDebugKotlin` + `ConnectionPriorityTest` green.
- i18n gate green (both catalogs de-covered, no new literals).