### PR TITLE
i18n: localize the Coupled view dashboard card (#484)

### DIFF
--- a/Tools/translate-de.py
+++ b/Tools/translate-de.py
@@ -350,6 +350,10 @@ DE: dict[str, str] = {
     "Recompute": "Neu berechnen",
     "Record puffin frames to a file": "Puffin-Frames in eine Datei aufzeichnen",
     "Recovery": "Erholung",
+    # Coupled view dashboard card (task #43) — was absent from the catalog, so it shipped in English
+    # on non-English devices (#484). Re-uses the catalog's own Erholung / Anstrengung / Schlaf terms.
+    "Coupled view": "Zusammengefasste Ansicht",
+    "Recovery, strain and sleep in one glance": "Erholung, Anstrengung und Schlaf auf einen Blick",
     "Recovery weighs your HRV against your personal baseline (~60%), resting heart rate (~20%), sleep performance (~15%) and respiration (~5%). Day strain is a 0–21 cardiovascular load from time in heart-rate zones. Sleep is staged from movement and heart rate. Everything is computed here from the strap's raw data — it works for any day NOOP collected raw streams.": "Die Erholung gewichtet deine HRV gegenüber deiner persönlichen Basislinie (~60 %), die Ruheherzfrequenz (~20 %), die Schlafleistung (~15 %) und die Atmung (~5 %). Die Tagesbelastung ist eine kardiovaskuläre Last von 0–21 aus der Zeit in Herzfrequenzzonen. Der Schlaf wird aus Bewegung und Herzfrequenz in Phasen eingeteilt. Alles wird hier aus den Rohdaten des Straps berechnet — es funktioniert für jeden Tag, an dem NOOP Rohdaten erfasst hat.",
     "Refresh models": "Modelle aktualisieren",
     "Refresh models from provider": "Modelle vom Anbieter aktualisieren",

--- a/Tools/translate-it.py
+++ b/Tools/translate-it.py
@@ -332,6 +332,10 @@ IT: dict[str, str] = {
     'Recompute': 'Ricalcola',
     'Record puffin frames to a file': 'Registra i frame puffin in un file',
     'Recovery': 'Recupero',
+    # Coupled view dashboard card (task #43) — absent from the catalog, shipped in English on non-English
+    # devices (#484). Re-uses the catalog's own Recupero / sforzo / sonno terms.
+    'Coupled view': 'Vista combinata',
+    'Recovery, strain and sleep in one glance': 'Recupero, sforzo e sonno in un colpo d\'occhio',
     "Recovery weighs your HRV against your personal baseline (~60%), resting heart rate (~20%), sleep performance (~15%) and respiration (~5%). Day strain is a 0–21 cardiovascular load from time in heart-rate zones. Sleep is staged from movement and heart rate. Everything is computed here from the strap's raw data , it works for any day NOOP collected raw streams.": 'Il recupero pesa il tuo HRV rispetto alla tua linea di base personale (~60%), la frequenza cardiaca a riposo (~20%), la prestazione del sonno (~15%) e la respirazione (~5%). Il carico giornaliero è un carico cardiovascolare da 0 a 21 basato sul tempo trascorso nelle zone di frequenza cardiaca. Il sonno viene suddiviso in fasi a partire da movimento e frequenza cardiaca. Tutto viene calcolato qui dai dati grezzi della fascia, funziona per qualsiasi giorno in cui NOOP ha raccolto i flussi grezzi.',
     'Refresh models': 'Aggiorna modelli',
     'Refresh models from provider': 'Aggiorna i modelli dal provider',


### PR DESCRIPTION
Fixes #484.

## What the user saw
On a German iPhone (9.0.0), the **Coupled view** dashboard card showed in English — both its title ("Coupled view") and its subtitle ("Recovery, strain and sleep in one glance").

## Root cause
Those two strings (task #43, `DashboardCard.coupled` in `DashboardCards.swift`) are `String(localized:)` calls but were never seeded into `Localizable.xcstrings`. A `String(localized:)` with no catalog entry falls back to the key text (English) on every non-English device. German coverage of keys that *are* in the catalog is 100% (`i18n_audit` reports `de: 0 gaps`) — this was catalog drift, not a bad translation. The `i18n-coverage.yml` gate intentionally doesn't block on the pre-existing un-seeded backlog, so it slipped through.

## Fix
- Add both keys to `Strand/Resources/Localizable.xcstrings` for **all eight shipped languages** (de/es/fr/it/pt-PT/ru/zh-Hans/zh-Hant) — not just German — so no locale hits the same bug. The subtitle reuses each language's already-shipped Recovery / strain / Sleep terms for consistency.
- Add both keys to `translate-de.py` and `translate-it.py` (the German/Italian source-of-truth dicts) so they persist through a catalog re-seed.
- `i18n_audit.py --platform ios` still reports `de: 0 gaps`; the two keys are no longer in the not-in-catalog list.

## Deliberately out of scope
- **Workout/sport names stay English.** They're persisted verbatim as the cross-platform `WorkoutRow.sport` value (CSV / Apple-Health round-trip); localizing them would split one sport into two (see `WorkoutCatalog.swift`).
- **Android parity:** the `DashboardCard` enum stores *all* 13 card titles/subtitles as hardcoded English literals rendered directly (`TodayScreen.kt`), so the whole dashboard-card set is un-localized on Android — a broader, separate task than this iOS catalog fix.