### PR TITLE
Today: fold the wordmark + Arrange into the header cluster (#486)

### DIFF
--- a/android/app/src/main/java/com/noop/ui/TodayScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/TodayScreen.kt
@@ -1095,7 +1095,16 @@ fun TodayScreen(
             val keyDate = runCatching { LocalDate.parse(selectedDayKey) }.getOrNull() ?: selectedDay
             keyDate.format(DateTimeFormatter.ofPattern("EEEE, d MMMM", Locale.US))
         }
-        Box(modifier = Modifier.fillMaxWidth().staggeredAppear(0)) {
+        // #486: header + wordmark + Arrange fold into ONE compact top cluster. Previously the decorative
+        // "N O O P" wordmark and the pinned "Arrange" affordance were each their own full-width list item,
+        // so the scaffold's 12dp rowSpacing left two near-empty sky bands stacked under the header ("empty
+        // space below NOOP"). Grouping them here removes those section gaps: the wordmark hangs 2dp under
+        // the title, and Arrange rides the SAME row as the wordmark (wordmark dead-centre, Arrange trailing)
+        // instead of claiming its own band.
+        Column(
+            modifier = Modifier.fillMaxWidth().staggeredAppear(0),
+            verticalArrangement = Arrangement.spacedBy(2.dp),
+        ) {
             LiquidTodayHeader(
                 dayTitle = dayTitle,
                 humanDate = humanDate,
@@ -1110,16 +1119,28 @@ fun TodayScreen(
                 onOpenSettings = onOpenSettings,
                 onOpenDevices = onOpenDevices,
             )
-        }
-        }
-
-        // WORDMARK, a subtle centred "N O O P" on the sky between the header and the hero (iOS LiquidWordmark
-        // parity). White @ ~50% opacity, letter-spaced, perfectly centred; a tap plays a small random wiggle
-        // easter egg. The old Android Today had NO wordmark; this adds it. Staggered in just after the header.
-        item {
-            Box(modifier = Modifier.fillMaxWidth().staggeredAppear(0)) {
+            // WORDMARK (iOS LiquidWordmark parity): a subtle centred "N O O P" @ ~50% opacity, with a
+            // tap easter egg. Shares its row with the Arrange affordance — wordmark centred, Arrange
+            // aligned to the trailing edge — so neither needs its own empty band.
+            Box(modifier = Modifier.fillMaxWidth(), contentAlignment = Alignment.Center) {
                 LiquidWordmark()
+                // #today-layout: a small affordance to REORDER the sections below (an alternative to
+                // holding + dragging the cards directly). Opens a Today-local dialog — no nav destination.
+                TextButton(
+                    onClick = { showLayoutEditor = true },
+                    colors = ButtonDefaults.textButtonColors(contentColor = Palette.textTertiary),
+                    modifier = Modifier.align(Alignment.CenterEnd),
+                ) {
+                    Icon(
+                        Icons.Filled.SwapVert,
+                        contentDescription = "Arrange Today sections",
+                        modifier = Modifier.size(Metrics.iconSmall),
+                    )
+                    Spacer(Modifier.width(4.dp))
+                    Text("Arrange", style = NoopType.footnote)
+                }
             }
+        }
         }
 
         // A "workout in progress" indicator whenever a manual workout is active (iOS parity: the Today
@@ -1222,24 +1243,8 @@ fun TodayScreen(
 
         if (alert != null) item { IllnessBanner(alert!!) }
 
-        // #today-layout: a small right-aligned affordance to REORDER the sections below (an alternative to
-        // holding + dragging the cards directly). Opens a Today-local dialog — no new nav destination.
-        item {
-            Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.End) {
-                TextButton(
-                    onClick = { showLayoutEditor = true },
-                    colors = ButtonDefaults.textButtonColors(contentColor = Palette.textTertiary),
-                ) {
-                    Icon(
-                        Icons.Filled.SwapVert,
-                        contentDescription = "Arrange Today sections",
-                        modifier = Modifier.size(Metrics.iconSmall),
-                    )
-                    Spacer(Modifier.width(4.dp))
-                    Text("Arrange", style = NoopType.footnote)
-                }
-            }
-        }
+        // #486: the "Arrange" affordance moved UP into the header/wordmark cluster (see above) so it no
+        // longer sits alone in its own full-width band here. It stays pinned; only its position changed.
 
         // #today-layout: EVERY Today section — including the Charge/Effort/Rest hero and the Start-session
         // entry — renders in the user's saved order (TodayLayoutPrefs); only the top bar + this Arrange


### PR DESCRIPTION
Addresses the main complaint in #486: **excess empty space below the "NOOP" wordmark** on the Android home screen.

## Cause
The decorative `LiquidWordmark` ("N O O P") and the pinned **Arrange** affordance were each their own full-width `LazyColumn` item. `LazyScreenScaffold` applies a uniform `rowSpacing = 12.dp`, so each of those thin rows carried a 12dp section gap *above and below* — stacking two near-empty bands of sky between the compact header and the hero card. That stack of gaps around two sparse rows is the dead space the reporter circled.

## Fix
Fold the header, wordmark, and Arrange into **one** list item:
- the wordmark now hangs 2dp under the title instead of a full section gap away, and
- the Arrange button shares the wordmark's row (wordmark dead-centre, Arrange trailing) instead of claiming its own full-width band.

No function lost — the wordmark keeps its tap easter-egg and iOS-`LiquidWordmark` parity; Arrange stays pinned and still opens the layout editor. Net effect is ~three section-gaps of empty sky removed, tightening the top into the compact liquid look.

## Not in this PR
- **ON-DEVICE badge alignment** (the reporter's secondary "moreover" note) — left alone; it needs on-device eyeballing and is a separate nit.
- **Remove the `+` icon** — declined: it opens the quick-actions sheet that hosts the Updates inbox (relocated off the header), not a duplicate of "More"; also iOS parity.
- **Pull-to-refresh** — reasonable feature request, tracked separately (auto-reconnect on Bluetooth-on already exists via `WhoopConnectionService`).

## Verification
- `./gradlew compileFullDebugKotlin` — BUILD SUCCESSFUL (no new warnings).
- Layout/rendering to be validated on-device via the 9.0.1 staging build.

Reported by Dharaneshwar Sasidharan.