### PR TITLE
Import FIT activity steps

### DIFF
--- a/Packages/StrandImport/Sources/StrandImport/ActivityFileImporter.swift
+++ b/Packages/StrandImport/Sources/StrandImport/ActivityFileImporter.swift
@@ -27,9 +27,9 @@ import Foundation
 
 // MARK: - Normalized model
 
-/// One imported activity (the shape the app layer maps 1:1 onto a `WorkoutRow`). Distances are
-/// metres, HR is bpm, energy is kcal. Times are UTC `Date`s. A field is `nil` when the file didn't
-/// carry it — never fabricated.
+/// One imported activity (the shape the app layer maps onto a `WorkoutRow`, plus optional
+/// activity-file daily metrics when present). Distances are metres, HR is bpm, energy is kcal.
+/// Times are UTC `Date`s. A field is `nil` when the file didn't carry it — never fabricated.
 public struct ActivityFile: Sendable, Equatable {
     /// Which interchange format the file was.
     public enum Kind: String, Sendable, Equatable { case gpx, tcx, fit }
@@ -46,6 +46,8 @@ public struct ActivityFile: Sendable, Equatable {
     public var distanceM: Double?
     /// Total active energy in kilocalories, when present.
     public var energyKcal: Double?
+    /// Activity step count when the file carries one.
+    public var steps: Int?
     /// Average heart rate (bpm), when present (a summary value, else the mean of sampled HR).
     public var avgHr: Int?
     /// Maximum heart rate (bpm), when present.
@@ -78,6 +80,7 @@ public struct ActivityFile: Sendable, Equatable {
         sport: String? = nil,
         distanceM: Double? = nil,
         energyKcal: Double? = nil,
+        steps: Int? = nil,
         avgHr: Int? = nil,
         maxHr: Int? = nil,
         ascentM: Double? = nil,
@@ -92,6 +95,7 @@ public struct ActivityFile: Sendable, Equatable {
         self.sport = sport
         self.distanceM = distanceM
         self.energyKcal = energyKcal
+        self.steps = steps
         self.avgHr = avgHr
         self.maxHr = maxHr
         self.ascentM = ascentM
@@ -117,6 +121,7 @@ public struct ActivityFile: Sendable, Equatable {
         }
         if gpsPointCount > 0 { parts.append("\(gpsPointCount) GPS points") }
         if hrSampleCount > 0 { parts.append("\(hrSampleCount) HR samples") }
+        if let steps, steps > 0 { parts.append("\(steps) steps") }
         return parts.joined(separator: " · ")
     }
 }
@@ -276,7 +281,7 @@ public enum ActivityFileImporter {
             let a = ActivityFile(
                 kind: kind, start: now, end: now, sport: sportHint,
                 distanceM: dist, energyKcal: summaryEnergyKcal,
-                avgHr: summaryAvgHr, maxHr: summaryMaxHr,
+                steps: nil, avgHr: summaryAvgHr, maxHr: summaryMaxHr,
                 ascentM: summaryAscentM, gpsPointCount: route.count,
                 hrSampleCount: 0, route: cappedRoute(route)
             )
@@ -298,6 +303,7 @@ public enum ActivityFileImporter {
             sport: sportHint,
             distanceM: distance,
             energyKcal: summaryEnergyKcal,
+            steps: nil,
             avgHr: avg,
             maxHr: mx,
             ascentM: ascent,

--- a/Packages/StrandImport/Sources/StrandImport/FitParser.swift
+++ b/Packages/StrandImport/Sources/StrandImport/FitParser.swift
@@ -128,12 +128,14 @@ private struct FitDecoder {
     private var sessionElapsed: Double?
     private var sessionDistance: Double?
     private var sessionCalories: Double?
+    private var sessionSteps: Int?
     private var sessionAscent: Double?
     private var sessionAvgHr: Int?
     private var sessionMaxHr: Int?
 
     private var lapDistanceSum = 0.0
     private var lapCalorieSum = 0.0
+    private var lapStepSum = 0
     private var lapAscentSum = 0.0
     private var lapMaxHr: Int?
 
@@ -303,6 +305,11 @@ private struct FitDecoder {
                 if let v = uintField(at: offset, size: f.size, bigEndian: def.bigEndian), v != 0xFFFF {
                     lapCalorieSum += Double(v)
                 }
+            case 10: // total_cycles; converted to steps only for foot activities in buildResult().
+                if let v = uintField(at: offset, size: f.size, bigEndian: def.bigEndian),
+                   let steps = Self.validSteps(v, size: f.size) {
+                    lapStepSum += steps
+                }
             case 21: // total_ascent (u16 metres)
                 if let v = uintField(at: offset, size: f.size, bigEndian: def.bigEndian), v != 0xFFFF {
                     lapAscentSum += Double(v)
@@ -339,6 +346,10 @@ private struct FitDecoder {
             case 11: // total_calories (u16 kcal)
                 if let v = uintField(at: offset, size: f.size, bigEndian: def.bigEndian), v != 0xFFFF {
                     sessionCalories = Double(v)
+                }
+            case 10: // total_cycles; converted to steps only for foot activities in buildResult().
+                if let v = uintField(at: offset, size: f.size, bigEndian: def.bigEndian) {
+                    sessionSteps = Self.validSteps(v, size: f.size)
                 }
             case 22: // total_ascent (u16 metres)
                 if let v = uintField(at: offset, size: f.size, bigEndian: def.bigEndian), v != 0xFFFF {
@@ -424,6 +435,19 @@ private struct FitDecoder {
         }
     }
 
+    static func validSteps(_ v: UInt64, size: Int) -> Int? {
+        let invalid = size >= 8 ? UInt64.max : ((UInt64(1) << UInt64(size * 8)) - 1)
+        guard v != invalid, v > 0, v <= 1_000_000 else { return nil }
+        return Int(v)
+    }
+
+    static func isFootSport(_ sport: String?) -> Bool {
+        switch sport?.lowercased() {
+        case "running", "walking", "hiking": return true
+        default: return false
+        }
+    }
+
     // MARK: - Build
 
     func buildResult() -> ActivityFileImportResult {
@@ -438,6 +462,7 @@ private struct FitDecoder {
         let distance = sessionDistance
             ?? (lapDistanceSum > 0 ? lapDistanceSum : (route.count >= 2 ? ActivityFileImporter.routeDistanceM(route) : nil))
         let calories = sessionCalories ?? (lapCalorieSum > 0 ? lapCalorieSum : nil)
+        let steps = Self.isFootSport(sessionSport) ? (sessionSteps ?? (lapStepSum > 0 ? lapStepSum : nil)) : nil
         let ascent = sessionAscent
             ?? (lapAscentSum > 0 ? lapAscentSum : ActivityFileImporter.ascentM(from: samples))
 
@@ -463,6 +488,7 @@ private struct FitDecoder {
             sport: sessionSport,
             distanceM: distance,
             energyKcal: calories,
+            steps: steps,
             avgHr: avgHr,
             maxHr: maxHr,
             ascentM: ascent,

--- a/Packages/StrandImport/Tests/StrandImportTests/ActivityFileImporterTests.swift
+++ b/Packages/StrandImport/Tests/StrandImportTests/ActivityFileImporterTests.swift
@@ -168,12 +168,14 @@ final class ActivityFileImporterTests: XCTestCase {
         //                      total_calories(11,u16), avg_hr(16,u8), max_hr(17,u8)
         let sessionStart: UInt32 = 100_000           // FIT seconds
         fit.definition(local: 0, global: 18, fields: [
-            (2, 4, 0x86), (5, 1, 0x00), (9, 4, 0x86), (11, 2, 0x84), (16, 1, 0x02), (17, 1, 0x02),
+            (2, 4, 0x86), (5, 1, 0x00), (9, 4, 0x86), (10, 4, 0x86),
+            (11, 2, 0x84), (16, 1, 0x02), (17, 1, 0x02),
         ])
         fit.dataHeader(local: 0)
         fit.u32(sessionStart)
         fit.u8(1)                                    // sport = running
         fit.u32(523)                                 // total_distance = 5.23 m? scale 100 → 5.23m; use 523 → 5.23 m
+        fit.u32(1175)                                // total_cycles: Suunto walking/running step total
         fit.u16(300)                                 // total_calories
         fit.u8(150)                                  // avg_hr
         fit.u8(182)                                  // max_hr
@@ -203,6 +205,7 @@ final class ActivityFileImporterTests: XCTestCase {
         XCTAssertEqual(a.hrSampleCount, 3)
         XCTAssertEqual(a.distanceM ?? 0, 5.23, accuracy: 0.001)   // session summary
         XCTAssertEqual(a.energyKcal, 300)
+        XCTAssertEqual(a.steps, 1175)
         XCTAssertEqual(a.avgHr, 150)                 // session avg wins over the sampled mean
         XCTAssertEqual(a.maxHr, 182)
         // Coordinates round-trip through semicircles (~1e-7° precision).

--- a/Packages/WhoopStore/Sources/WhoopStore/MetricsCache.swift
+++ b/Packages/WhoopStore/Sources/WhoopStore/MetricsCache.swift
@@ -59,7 +59,7 @@ public struct DailyMetric: Equatable, Codable {
     public let respRateBpm: Double?    // mean respiration rate (breaths/min) during sleep
     // On-device daily activity totals (v11 columns, APPROXIMATE estimates). Both nullable, so
     // imported/cloud rows that never carry them stay nil and old call sites are unaffected.
-    public let steps: Int?             // daily step total from the cumulative @57 counter
+    public let steps: Int?             // daily/file step total from the cumulative @57 counter or activity import
     public let activeKcalEst: Double?  // whole-day HR-only calorie estimate (kcal)
     // WHOOP 4.0 raw SpO2 PPG ADC means over detected sleep (v23 columns, #93). These are the RAW
     // red/IR optical channels banked on the v24 historical layout (spo2_red@68 / spo2_ir@70), NOT a

--- a/Strand/Data/Repository.swift
+++ b/Strand/Data/Repository.swift
@@ -457,6 +457,7 @@ final class Repository: ObservableObject {
     static let whoopSource = "my-whoop"
     static let appleHealthSource = "apple-health"
     static let healthConnectSource = "health-connect"
+    static let activityFileSource = "activity-file"
 
     /// Imported wearable-export sources whose DAILY aggregates (HRV / resting HR / sleep) can be scored
     /// for a NOOP Charge/Rest on an import-only day, exactly like a live day (#823). These carry no raw HR
@@ -694,6 +695,7 @@ final class Repository: ObservableObject {
         let imported = await unionDailyMetrics(store: store, from: fromDay, to: toDay)
         let computed = await unionComputedDailyMetrics(store: store, from: fromDay, to: toDay)
         let apple = (try? await store.dailyMetrics(deviceId: Self.appleHealthSource, from: fromDay, to: toDay)) ?? []
+        let activityFile = (try? await store.dailyMetrics(deviceId: Self.activityFileSource, from: fromDay, to: toDay)) ?? []
         let impSleep = await unionSleepSessions(store: store, from: lo, to: hi)
         let compSleep = await unionComputedSleepSessions(store: store, from: lo, to: hi)
 
@@ -720,7 +722,10 @@ final class Repository: ObservableObject {
             let editedDays = Self.userEditedDays(compSleep)
             return MergedCaches(
                 importedSleep: fig,
-                days: Self.mergeDaily(imported: imported, computed: computed, userEditedDays: editedDays),
+                days: Self.mergeActivityFileSteps(
+                    into: Self.mergeDaily(imported: imported, computed: computed, userEditedDays: editedDays),
+                    activityFile
+                ),
                 sleeps: Self.mergeSleep(imported: impSleep, computed: compSleep),
                 vitalRows: Self.sourceRows(imported: imported, computed: computed, apple: apple),
                 freshness: Self.computeFreshness(imported: imported, computed: computed, apple: apple,
@@ -792,6 +797,43 @@ final class Repository: ObservableObject {
                     : merged
             } else {
                 byDay[d.day] = d
+            }
+        }
+        return byDay.values.sorted { $0.day < $1.day }
+    }
+
+    nonisolated static func mergeActivityFileSteps(into base: [DailyMetric],
+                                                   _ activityFile: [DailyMetric]) -> [DailyMetric] {
+        guard !activityFile.isEmpty else { return base }
+        var byDay = Dictionary(uniqueKeysWithValues: base.map { ($0.day, $0) })
+        for row in activityFile {
+            guard let steps = row.steps, steps > 0 else { continue }
+            if let existing = byDay[row.day] {
+                if existing.steps == nil {
+                    byDay[row.day] = DailyMetric(
+                        day: existing.day,
+                        totalSleepMin: existing.totalSleepMin,
+                        efficiency: existing.efficiency,
+                        deepMin: existing.deepMin,
+                        remMin: existing.remMin,
+                        lightMin: existing.lightMin,
+                        disturbances: existing.disturbances,
+                        restingHr: existing.restingHr,
+                        avgHrv: existing.avgHrv,
+                        recovery: existing.recovery,
+                        strain: existing.strain,
+                        exerciseCount: existing.exerciseCount,
+                        spo2Pct: existing.spo2Pct,
+                        skinTempDevC: existing.skinTempDevC,
+                        respRateBpm: existing.respRateBpm,
+                        steps: steps,
+                        activeKcalEst: existing.activeKcalEst,
+                        spo2Red: existing.spo2Red,
+                        spo2Ir: existing.spo2Ir
+                    )
+                }
+            } else {
+                byDay[row.day] = row
             }
         }
         return byDay.values.sorted { $0.day < $1.day }

--- a/Strand/Screens/DataSourcesView.swift
+++ b/Strand/Screens/DataSourcesView.swift
@@ -23,7 +23,8 @@ struct DataSourcesView: View {
     @State private var liftingSummary: String?
     @State private var liftingFailed = false
     // Activity-file (GPX / TCX / FIT) import state — same lightweight, self-contained pattern: parse the
-    // file, upsert one workout row under the "activity-file" source, refresh. No HR Effort is touched.
+    // file, upsert one workout row under the "activity-file" source, and persist optional measured
+    // summaries like file steps under that source, refresh. No HR Effort is touched.
     @State private var activityFileImporting = false
     @State private var activityFileSummary: String?
     @State private var activityFileFailed = false
@@ -571,6 +572,25 @@ struct DataSourcesView: View {
                 if !activity.hrSamples.isEmpty {
                     let hr = activity.hrSamples.map { HRSample(ts: $0.ts, bpm: $0.bpm) }
                     _ = try? await store.insert(Streams(hr: hr), deviceId: ActivityFileImporter.sourceId)
+                }
+                if let steps = activity.steps, steps > 0 {
+                    let day = Repository.localDayKey(activity.start)
+                    let metric = DailyMetric(
+                        day: day,
+                        totalSleepMin: nil,
+                        efficiency: nil,
+                        deepMin: nil,
+                        remMin: nil,
+                        lightMin: nil,
+                        disturbances: nil,
+                        restingHr: nil,
+                        avgHrv: nil,
+                        recovery: nil,
+                        strain: nil,
+                        exerciseCount: nil,
+                        steps: steps
+                    )
+                    try? await store.upsertDailyMetrics([metric], deviceId: ActivityFileImporter.sourceId)
                 }
 
                 // #137 (B1): register `activity-file` as an `.activityFile` device so the per-day owner

--- a/StrandTests/VitalSourceResolutionTests.swift
+++ b/StrandTests/VitalSourceResolutionTests.swift
@@ -39,6 +39,24 @@ final class VitalSourceResolutionTests: XCTestCase {
         XCTAssertEqual(merged[0].steps, 9_240)
     }
 
+    func testActivityFileStepsFillMissingStepDaysOnly() {
+        let base = [
+            daily(day: "2026-06-14", recovery: 70, steps: nil),
+            daily(day: "2026-06-15", steps: 9000),
+        ]
+        let activity = [
+            daily(day: "2026-06-14", steps: 1175),
+            daily(day: "2026-06-15", steps: 2222),
+            daily(day: "2026-06-16", steps: 3333),
+        ]
+
+        let merged = Repository.mergeActivityFileSteps(into: base, activity)
+
+        XCTAssertEqual(merged.first { $0.day == "2026-06-14" }?.steps, 1175)
+        XCTAssertEqual(merged.first { $0.day == "2026-06-15" }?.steps, 9000)
+        XCTAssertEqual(merged.first { $0.day == "2026-06-16" }?.steps, 3333)
+    }
+
     func testAppleHealthCanFillBloodOxygenWhenStrapSourcesAreMissing() {
         let readings = BodyVitalSigns.readings(
             sourceRows: [

--- a/android/app/src/main/java/com/noop/data/Entities.kt
+++ b/android/app/src/main/java/com/noop/data/Entities.kt
@@ -239,8 +239,9 @@ data class DailyMetric(
     val spo2Pct: Double? = null,        // mean SpO2 (%) during sleep
     val skinTempDevC: Double? = null,   // skin-temperature deviation (°C) from baseline
     val respRateBpm: Double? = null,    // mean respiration rate (breaths/min) during sleep
-    // On-device derived daily step total from the WHOOP5 step_motion_counter@57 (sum of positive
-    // consecutive u16-counter deltas over the day). APPROXIMATE, not cloud/clinical parity. (#78)
+    // On-device derived or imported step total. WHOOP5 days use step_motion_counter@57 (sum of
+    // positive u16-counter deltas); activity-file imports can fill missing steps from file summaries.
+    // APPROXIMATE, not cloud/clinical parity. (#78)
     val steps: Int? = null,
     // On-device APPROXIMATE whole-day active+resting energy estimate (kcal), computed from HR alone
     // by AnalyticsEngine (Keytel active + Harris–Benedict BMR). Null when the day has no scored HR

--- a/android/app/src/main/java/com/noop/data/WhoopRepository.kt
+++ b/android/app/src/main/java/com/noop/data/WhoopRepository.kt
@@ -1085,11 +1085,15 @@ class WhoopRepository(private val dao: WhoopDao) {
     suspend fun daysMerged(deviceId: String): List<DailyMetric> {
         val imported = unionByDay(importedSourceIds(deviceId).map { dao.days(it) })
         val computed = unionByDay(computedSourceIds(deviceId).map { dao.days(it) })
+        val activityFile = dao.days(ACTIVITY_FILE_SOURCE)
         // H5 (#509): days the user hand-edited the sleep of (the edit lives under the computed source); on
         // those days the computed sleep fields win over a re-imported night. Pool the edited sessions across
         // every computed source in the union so a re-add doesn't lose an earlier-id edit's precedence.
         val editedSessions = computedSourceIds(deviceId).flatMap { dao.editedSleepSessions(it) }
-        return mergeDaily(imported = imported, computed = computed, userEditedDays = userEditedDays(editedSessions))
+        return mergeActivityFileSteps(
+            mergeDaily(imported = imported, computed = computed, userEditedDays = userEditedDays(editedSessions)),
+            activityFile,
+        )
     }
 
     /**
@@ -1118,9 +1122,13 @@ class WhoopRepository(private val dao: WhoopDao) {
         combine(
             unionDaysFlow(importedSourceIds(deviceId).map { dao.daysFlow(it) }),
             unionDaysFlow(computedSourceIds(deviceId).map { dao.daysFlow(it) }),
+            dao.daysFlow(ACTIVITY_FILE_SOURCE),
             editedSleepSessionsFlow(deviceId),
-        ) { imported, computed, edited ->
-            mergeDaily(imported = imported, computed = computed, userEditedDays = userEditedDays(edited))
+        ) { imported, computed, activityFile, edited ->
+            mergeActivityFileSteps(
+                mergeDaily(imported = imported, computed = computed, userEditedDays = userEditedDays(edited)),
+                activityFile,
+            )
         }
 
     /**
@@ -1142,11 +1150,15 @@ class WhoopRepository(private val dao: WhoopDao) {
         combine(
             unionDaysFlow(importedSourceIds(deviceId).map { dao.recentDaysFlow(it, RECENT_DAYS_CAP) }),
             unionDaysFlow(computedSourceIds(deviceId).map { dao.recentDaysFlow(it, RECENT_DAYS_CAP) }),
+            dao.recentDaysFlow(ACTIVITY_FILE_SOURCE, RECENT_DAYS_CAP),
             editedSleepSessionsFlow(deviceId),
-        ) { imported, computed, edited ->
+        ) { imported, computed, activityFile, edited ->
             // recentDaysFlow returns newest-first (DESC LIMIT); mergeDaily re-sorts ascending by day, so the
             // emitted order matches daysMergedFlow exactly.
-            mergeDaily(imported = imported, computed = computed, userEditedDays = userEditedDays(edited))
+            mergeActivityFileSteps(
+                mergeDaily(imported = imported, computed = computed, userEditedDays = userEditedDays(edited)),
+                activityFile,
+            )
         }
 
     /** Pooled user-edited sleep sessions across every computed source in the active∪canonical union, so a
@@ -1405,6 +1417,7 @@ class WhoopRepository(private val dao: WhoopDao) {
         const val WHOOP_SOURCE = "my-whoop"
         const val APPLE_HEALTH_SOURCE = "apple-health"
         const val HEALTH_CONNECT_SOURCE = "health-connect"
+        const val ACTIVITY_FILE_SOURCE = "activity-file"
 
         /**
          * The IMPORTED daily-source ids to read for an [activeDeviceId]: the UNION of the active strap id
@@ -1813,6 +1826,26 @@ class WhoopRepository(private val dao: WhoopDao) {
                     )
                 } else {
                     merged
+                }
+            }
+            return byDay.values.sortedBy { it.day }
+        }
+
+        internal fun mergeActivityFileSteps(
+            base: List<DailyMetric>,
+            activityFile: List<DailyMetric>,
+        ): List<DailyMetric> {
+            if (activityFile.isEmpty()) return base
+            val byDay = LinkedHashMap<String, DailyMetric>()
+            for (row in base) byDay[row.day] = row
+            for (row in activityFile) {
+                val steps = row.steps ?: continue
+                if (steps <= 0) continue
+                val existing = byDay[row.day]
+                byDay[row.day] = if (existing == null) row else if (existing.steps == null) {
+                    existing.copy(steps = steps)
+                } else {
+                    existing
                 }
             }
             return byDay.values.sortedBy { it.day }

--- a/android/app/src/main/java/com/noop/ingest/ActivityFileImporter.kt
+++ b/android/app/src/main/java/com/noop/ingest/ActivityFileImporter.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.net.Uri
 import android.util.Xml
 import com.noop.analytics.RouteMath
+import com.noop.data.DailyMetric
 import com.noop.data.HrSample
 import com.noop.data.ImportSummary
 import com.noop.data.WhoopRepository
@@ -75,6 +76,7 @@ object ActivityFileImporter {
         val sport: String?,
         val distanceM: Double?,
         val energyKcal: Double?,
+        val steps: Int?,
         val avgHr: Int?,
         val maxHr: Int?,
         val ascentM: Double?,
@@ -104,6 +106,7 @@ object ActivityFileImporter {
             }
             if (gpsPointCount > 0) parts.add("$gpsPointCount GPS points")
             if (hrSampleCount > 0) parts.add("$hrSampleCount HR samples")
+            if (steps != null && steps > 0) parts.add("$steps steps")
             return parts.joinToString(" · ")
         }
     }
@@ -224,10 +227,17 @@ object ActivityFileImporter {
         if (activity.hrSamples.isNotEmpty()) {
             repo.insertHr(activity.hrSamples.map { HrSample(deviceId = deviceId, ts = it.ts, bpm = it.bpm) })
         }
+        if (activity.steps != null && activity.steps > 0) {
+            repo.upsertDailyMetrics(
+                listOf(DailyMetric(deviceId = deviceId, day = localDayString(activity.startTs), steps = activity.steps)),
+            )
+        }
 
+        val counts = linkedMapOf("workouts" to 1)
+        if (activity.steps != null && activity.steps > 0) counts["dailyMetric"] = 1
         return ImportSummary(
             source = SOURCE_LABEL,
-            counts = linkedMapOf("workouts" to 1),
+            counts = counts,
             firstDay = dayString(activity.startTs),
             lastDay = dayString(activity.endTs),
             message = summaryText(activity),
@@ -416,7 +426,7 @@ object ActivityFileImporter {
             // A pure coordinate track (no timestamps): keep it but with no interval.
             if (route.isEmpty()) return Result(null, kind, skipped)
             val dist = summaryDistanceM ?: routeDistanceM(route)
-            val a = Activity(kind, 0L, 0L, sportHint, dist, summaryEnergyKcal, summaryAvgHr, summaryMaxHr,
+            val a = Activity(kind, 0L, 0L, sportHint, dist, summaryEnergyKcal, null, summaryAvgHr, summaryMaxHr,
                 summaryAscentM, route.size, 0, cappedRoute(route))
             return Result(a, kind, skipped)
         }
@@ -437,6 +447,7 @@ object ActivityFileImporter {
             sport = sportHint,
             distanceM = distance,
             energyKcal = summaryEnergyKcal,
+            steps = null,
             avgHr = avg,
             maxHr = mx,
             ascentM = ascent,
@@ -540,11 +551,15 @@ object ActivityFileImporter {
         if (a.gpsPointCount > 0) parts.add("${a.gpsPointCount} GPS points")
         if (a.hrSampleCount > 0) parts.add("${a.hrSampleCount} HR samples")
         if (a.avgHr != null) parts.add("avg ${a.avgHr} bpm")
+        if (a.steps != null && a.steps > 0) parts.add("${a.steps} steps")
         return parts.joinToString(" · ")
     }
 
     private fun dayString(ts: Long): String =
         Instant.ofEpochSecond(ts).atOffset(ZoneOffset.UTC).toLocalDate().toString()
+
+    private fun localDayString(ts: Long): String =
+        Instant.ofEpochSecond(ts).atZone(java.time.ZoneId.systemDefault()).toLocalDate().toString()
 
     private fun displayName(context: Context, uri: Uri): String? = runCatching {
         context.contentResolver.query(uri, null, null, null, null)?.use { c ->
@@ -583,12 +598,14 @@ internal class FitDecoder(raw: ByteArray) {
     private var sessionElapsedS: Double? = null
     private var sessionDistance: Double? = null
     private var sessionCalories: Double? = null
+    private var sessionSteps: Int? = null
     private var sessionAscent: Double? = null
     private var sessionAvgHr: Int? = null
     private var sessionMaxHr: Int? = null
 
     private var lapDistanceSum = 0.0
     private var lapCalorieSum = 0.0
+    private var lapStepSum = 0
     private var lapAscentSum = 0.0
     private var lapMaxHr: Int? = null
 
@@ -710,6 +727,7 @@ internal class FitDecoder(raw: ByteArray) {
             when (f.num) {
                 9 -> u(off, f.size, def.bigEndian)?.let { if (it != 0xFFFFFFFFL) lapDistanceSum += it.toDouble() / 100.0 }
                 11 -> u(off, f.size, def.bigEndian)?.let { if (it != 0xFFFFL) lapCalorieSum += it.toDouble() }
+                10 -> u(off, f.size, def.bigEndian)?.let { validSteps(it, f.size)?.let { steps -> lapStepSum += steps } }
                 21 -> u(off, f.size, def.bigEndian)?.let { if (it != 0xFFFFL) lapAscentSum += it.toDouble() }
                 16 -> u(off, f.size, def.bigEndian)?.let { v -> ActivityFileImporter.validHr(v.toDouble())?.let { lapMaxHr = maxOf(lapMaxHr ?: 0, it) } }
             }
@@ -726,6 +744,7 @@ internal class FitDecoder(raw: ByteArray) {
                 7 -> u(off, f.size, def.bigEndian)?.let { if (it != 0xFFFFFFFFL) sessionElapsedS = it.toDouble() / 1000.0 }
                 9 -> u(off, f.size, def.bigEndian)?.let { if (it != 0xFFFFFFFFL) sessionDistance = it.toDouble() / 100.0 }
                 11 -> u(off, f.size, def.bigEndian)?.let { if (it != 0xFFFFL) sessionCalories = it.toDouble() }
+                10 -> u(off, f.size, def.bigEndian)?.let { sessionSteps = validSteps(it, f.size) }
                 22 -> u(off, f.size, def.bigEndian)?.let { if (it != 0xFFFFL) sessionAscent = it.toDouble() }
                 16 -> u(off, f.size, def.bigEndian)?.let { sessionAvgHr = ActivityFileImporter.validHr(it.toDouble()) }
                 17 -> u(off, f.size, def.bigEndian)?.let { sessionMaxHr = ActivityFileImporter.validHr(it.toDouble()) }
@@ -788,6 +807,16 @@ internal class FitDecoder(raw: ByteArray) {
         else -> null
     }
 
+    private fun validSteps(v: Long, size: Int): Int? {
+        val invalid = if (size >= 8) -1L else (1L shl (size * 8)) - 1L
+        return if (v != invalid && v in 1..1_000_000L) v.toInt() else null
+    }
+
+    private fun isFootSport(sport: String?): Boolean = when (sport?.lowercase(Locale.US)) {
+        "running", "walking", "hiking" -> true
+        else -> false
+    }
+
     private fun build(): ActivityFileImporter.Result {
         if (samples.isEmpty() && sessionStartS == null) return fail()
         val route = samples.mapNotNull { it.point }
@@ -796,6 +825,11 @@ internal class FitDecoder(raw: ByteArray) {
         val distance = sessionDistance
             ?: if (lapDistanceSum > 0) lapDistanceSum else if (route.size >= 2) ActivityFileImporter.routeDistanceM(route) else null
         val calories = sessionCalories ?: if (lapCalorieSum > 0) lapCalorieSum else null
+        val steps = if (isFootSport(sessionSport)) {
+            sessionSteps ?: if (lapStepSum > 0) lapStepSum else null
+        } else {
+            null
+        }
         val ascent = sessionAscent ?: if (lapAscentSum > 0) lapAscentSum else ActivityFileImporter.ascentM(samples)
 
         val sampledHrs = samples.mapNotNull { it.hr }
@@ -814,6 +848,7 @@ internal class FitDecoder(raw: ByteArray) {
             sport = sessionSport,
             distanceM = distance,
             energyKcal = calories,
+            steps = steps,
             avgHr = avgHr,
             maxHr = maxHr,
             ascentM = ascent,

--- a/android/app/src/test/java/com/noop/data/RecentDaysMergeOrderTest.kt
+++ b/android/app/src/test/java/com/noop/data/RecentDaysMergeOrderTest.kt
@@ -71,4 +71,23 @@ class RecentDaysMergeOrderTest {
         val merged = WhoopRepository.mergeDaily(imported = importedDesc, computed = computedDesc)
         assertEquals(471.0, merged.first { it.day == "2026-06-14" }.totalSleepMin)
     }
+
+    @Test
+    fun activityFileStepsFillMissingStepDaysOnly() {
+        val base = listOf(
+            DailyMetric(deviceId = "my-whoop", day = "2026-06-14", recovery = 70.0),
+            DailyMetric(deviceId = "apple-health", day = "2026-06-15", steps = 9000),
+        )
+        val activity = listOf(
+            DailyMetric(deviceId = "activity-file", day = "2026-06-14", steps = 1175),
+            DailyMetric(deviceId = "activity-file", day = "2026-06-15", steps = 2222),
+            DailyMetric(deviceId = "activity-file", day = "2026-06-16", steps = 3333),
+        )
+
+        val merged = WhoopRepository.mergeActivityFileSteps(base, activity)
+
+        assertEquals(1175, merged.first { it.day == "2026-06-14" }.steps)
+        assertEquals(9000, merged.first { it.day == "2026-06-15" }.steps)
+        assertEquals(3333, merged.first { it.day == "2026-06-16" }.steps)
+    }
 }

--- a/android/app/src/test/java/com/noop/ingest/ActivityFileImporterTest.kt
+++ b/android/app/src/test/java/com/noop/ingest/ActivityFileImporterTest.kt
@@ -181,13 +181,14 @@ class ActivityFileImporterTest {
         val fit = FitFixture()
         val sessionStart = 100_000L
         fit.definition(0, 18, listOf(
-            Triple(2, 4, 0x86), Triple(5, 1, 0x00), Triple(9, 4, 0x86),
+            Triple(2, 4, 0x86), Triple(5, 1, 0x00), Triple(9, 4, 0x86), Triple(10, 4, 0x86),
             Triple(11, 2, 0x84), Triple(16, 1, 0x02), Triple(17, 1, 0x02),
         ))
         fit.dataHeader(0)
         fit.u32(sessionStart)
         fit.u8(1)            // sport = running
         fit.u32(523)         // total_distance → 5.23 m
+        fit.u32(1175)        // total_cycles: Suunto walking/running step total
         fit.u16(300)         // total_calories
         fit.u8(150)          // avg_hr
         fit.u8(182)          // max_hr
@@ -214,6 +215,7 @@ class ActivityFileImporterTest {
         assertEquals(3, a.hrSampleCount)
         assertEquals(5.23, a.distanceM!!, 1e-3)
         assertEquals(300.0, a.energyKcal!!, 1e-6)
+        assertEquals(1175, a.steps)
         assertEquals(150, a.avgHr)
         assertEquals(182, a.maxHr)
         assertEquals(lat, a.route.first().lat, 1e-4)


### PR DESCRIPTION
## Summary

Fixes #483.

This adds activity-step import for FIT workout files when the file represents a foot sport. The Suunto sample attached to #483 stores the walking step total in FIT session field 10 (`total_cycles`) with a value of 1175. The previous importer ignored that field, so the workout and HR data could import while the app had no daily step row to show.

## What changed

- Parse FIT `total_cycles` from session/lap records as `steps` only for running, walking, and hiking.
- Persist imported activity-file steps under the existing `activity-file` source.
- Merge `activity-file` steps into daily metrics only when the day has no existing step count, so Whoop/Apple/Health Connect/computed step data is not overwritten.
- Add Swift and Android parser/merge tests for the new behavior.

## Why this should fix it

The attached Suunto FIT file has sport = walking and `total_cycles = 1175` on the session. With this PR, that value becomes the imported activity's step count, then a step-only daily metric is written for the activity's local day. The Today/steps views read from merged daily metrics, so a day that previously had no step value from the import should now have one.

The foot-sport gate is intentional: FIT uses `total_cycles` for other concepts too, like cycling pedal cycles, so the importer should not treat every FIT cycle count as steps.

## Validation

- `git diff --check`
- `cd android && /usr/bin/bash -lc './gradlew :app:testFullDebugUnitTest --tests '\''com.noop.ingest.ActivityFileImporterTest'\'' --tests '\''com.noop.data.RecentDaysMergeOrderTest'\'''`
- Swift tests not run locally; I don't have Apple toolchains here.
