### PR TITLE
WhoopProtocol: v21 historical channels are IMU (accel+gyro), not optical (#493)

### DIFF
--- a/Packages/WhoopProtocol/Sources/WhoopProtocol/Interpreter.swift
+++ b/Packages/WhoopProtocol/Sources/WhoopProtocol/Interpreter.swift
@@ -590,16 +590,18 @@ private func decodeWhoop5HistoricalV26(_ frame: [UInt8], fb: FieldBuilder) {
 /// Both versions reuse the v18 record header — layout version @9, a marker byte @10 (0x81 on v20, 0x80 on
 /// v21), the monotonic u32 record index @11 (the same lifetime counter as v18), and the u32 unix second
 /// @15. Their bodies are blocks of fixed-length sample channels, established from captured frames:
-///   • v21 (1244 B): a (100, 100, 3) descriptor near @22, then three 100-sample i16 channels at @28 /
-///     @228 / @428 (200 B apart), each a bounded pulsatile waveform at its own DC baseline.
+///   • v21 (1244 B): a (100, 100, 3) descriptor near @22, then SIX 100-sample i16 channels in two blocks —
+///     accelerometer at @28 / @228 / @428 and gyroscope at @640 / @840 / @1040 (200 B apart; countB @630 =
+///     100). This is 6-axis IMU, not optical: the accel channels sphere-fit to a ~1 g gravity shell on a
+///     stationary strap (validated by Whoop5RawImu over 1423 real buffers, #423/#493).
 ///   • v20 (2140 B): five channel blocks, each preceded by a presence byte (0x19 = active, 0x00 =
 ///     empty / zero-filled); an active block holds two 50-sample i32 channels. The presence bytes sit at
 ///     @0x1a / @0x1c0 / @0x366 / @0x50c / @0x6b2; the ten channel slots start at
 ///     @0x2f / 0xf7 / 0x1d5 / 0x29d / 0x37b / 0x443 / 0x521 / 0x5e9 / 0x6c7 / 0x78f.
 ///
-/// Channels are exposed as raw sample arrays with NO invented scale or unit (an optical waveform has no
-/// absolute unit). Which channel maps to which optical LED — and which carries motion — needs a labelled
-/// capture (e.g. a deliberate moving window), so no per-channel identity is asserted here.
+/// v21 channels are named accel_/gyro_ per the gravity-shell evidence above; v20 sensor identity is still
+/// OPEN (no labelled/moving v20 capture in the tree) so its channels stay neutrally named. Both are exposed
+/// as raw i16 sample arrays with no scale applied here — Whoop5RawImu.decode applies the physical scales.
 private func decodeWhoop5HistoricalV2021(_ frame: [UInt8], fb: FieldBuilder, version: Int, payloadEnd: Int?) {
     if frame.count > 10 {
         fb.add(10, 1, "layout_marker", "meta", value: .int(Int(frame[10])))
@@ -611,16 +613,26 @@ private func decodeWhoop5HistoricalV2021(_ frame: [UInt8], fb: FieldBuilder, ver
         fb.add(15, 4, "unix", "time", value: .int(unix), note: "real unix seconds")
     }
     if version == 21 {
-        // Three 100-sample i16 channels, 200 B apart.
-        for (ch, start) in [(0, 28), (1, 228), (2, 428)] {
+        // TWO blocks of three 100-sample i16 channels: accelerometer (@28/@228/@428) then gyroscope
+        // (@640/@840/@1040), matching the (100,100,3) header @22 and countB @630. NOT optical: on a
+        // stationary strap the three accel channels sphere-fit to a ~1 g gravity shell (median |a| =
+        // 1.006 g, 100/100 samples in-shell on the real fixture) — a gravity vector, which PPG cannot
+        // produce. Validated as 6-axis IMU by Whoop5RawImu over 1423 real buffers (#423/#493). Emitted as
+        // raw i16 arrays (this field layer applies no scale); the physical scales — 1/4096 g/LSB (accel),
+        // 2000/32768 (°/s)/LSB (gyro) — are applied by Whoop5RawImu.decode.
+        let channels: [(name: String, start: Int)] = [
+            ("accel_x", 28), ("accel_y", 228), ("accel_z", 428),
+            ("gyro_x", 640), ("gyro_y", 840), ("gyro_z", 1040),
+        ]
+        for (name, start) in channels {
             var samples: [Int] = []
             for i in 0..<100 {
                 guard let v = readI16(frame, start + i * 2) else { break }
                 samples.append(v)
             }
             if samples.count == 100 {
-                fb.add(start, 200, "optical_ch\(ch)", "ppg", value: .intArray(samples),
-                       note: "raw i16 channel samples (no absolute unit)")
+                fb.add(start, 200, name, "imu", value: .intArray(samples),
+                       note: "raw i16 samples (scale via Whoop5RawImu: 1/4096 g accel, 2000/32768 dps gyro)")
             }
         }
         fb.parsed["sensor_channel_samples"] = .int(100)

--- a/Packages/WhoopProtocol/Tests/WhoopProtocolTests/Whoop5HistoricalV2021Tests.swift
+++ b/Packages/WhoopProtocol/Tests/WhoopProtocolTests/Whoop5HistoricalV2021Tests.swift
@@ -6,10 +6,11 @@ import XCTest
 /// back to "unmapped layout" and stored nothing.
 ///
 /// Both versions reuse the v18 record header (layout version @9, marker @10, record index u32 @11, unix
-/// u32 @15). v21 (1244 B) carries three 100-sample i16 channels at @28/@228/@428; v20 (2140 B) carries
-/// five blocks of two 50-sample i32 channels, each block gated by a presence byte (0x19 = active,
-/// 0x00 = empty). The layout was established from captured v20/v21 frames; these tests exercise the
-/// decode mechanics on frames assembled with valid header-CRC16 and trailer-CRC32 envelopes.
+/// u32 @15). v21 (1244 B) carries six 100-sample i16 IMU channels — accelerometer @28/@228/@428 and
+/// gyroscope @640/@840/@1040 (#493); v20 (2140 B) carries five blocks of two 50-sample i32 channels, each
+/// block gated by a presence byte (0x19 = active, 0x00 = empty). The layout was established from captured
+/// v20/v21 frames; these tests exercise the decode mechanics on frames assembled with valid header-CRC16
+/// and trailer-CRC32 envelopes — plus one real captured v21 buffer for the gravity-shell identity check.
 final class Whoop5HistoricalV2021Tests: XCTestCase {
 
     /// Assemble a valid WHOOP 5.0 type-47 frame of the given total length and layout version.
@@ -46,15 +47,18 @@ final class Whoop5HistoricalV2021Tests: XCTestCase {
         f[off + 2] = UInt8((u >> 16) & 0xff); f[off + 3] = UInt8((u >> 24) & 0xff)
     }
 
-    func testV21HeaderAndThreeOpticalChannels() {
+    func testV21HeaderAndSixImuChannels() {
         let unix: UInt32 = 1781556371, idx: UInt32 = 0x01A8CF25
         let frame = makeFrame(total: 1244, version: 21) { f in
             f[10] = 0x80                     // marker
             putU32(&f, 11, idx)              // record index
             putU32(&f, 15, unix)             // unix
-            for i in 0..<100 { putI16(&f, 28 + i * 2, Int16(1800 + (i % 7))) }   // ch0
-            for i in 0..<100 { putI16(&f, 228 + i * 2, Int16(700 + (i % 5))) }   // ch1
-            for i in 0..<100 { putI16(&f, 428 + i * 2, Int16(3600 + (i % 3))) }  // ch2
+            for i in 0..<100 { putI16(&f, 28 + i * 2, Int16(1800 + (i % 7))) }    // accel_x
+            for i in 0..<100 { putI16(&f, 228 + i * 2, Int16(700 + (i % 5))) }    // accel_y
+            for i in 0..<100 { putI16(&f, 428 + i * 2, Int16(3600 + (i % 3))) }   // accel_z
+            for i in 0..<100 { putI16(&f, 640 + i * 2, Int16(10 + (i % 4))) }     // gyro_x (the block v21 used to drop)
+            for i in 0..<100 { putI16(&f, 840 + i * 2, Int16(-20 + (i % 3))) }    // gyro_y
+            for i in 0..<100 { putI16(&f, 1040 + i * 2, Int16(5 + (i % 2))) }     // gyro_z
         }
         let p = parseFrame(frame, family: .whoop5)
         XCTAssertTrue(p.ok); XCTAssertEqual(p.typeName, "HISTORICAL_DATA"); XCTAssertEqual(p.crcOK, true)
@@ -63,10 +67,43 @@ final class Whoop5HistoricalV2021Tests: XCTestCase {
         XCTAssertEqual(p.parsed["record_index"]?.intValue, Int(idx))
         XCTAssertEqual(p.parsed["unix"]?.intValue, Int(unix))
         XCTAssertEqual(p.parsed["sensor_channel_samples"]?.intValue, 100)
-        let ch0 = p.parsed["optical_ch0"]?.intArrayValue ?? []
-        XCTAssertEqual(ch0.count, 100)
-        XCTAssertEqual(ch0.first, 1800); XCTAssertEqual(ch0[3], 1803)
-        XCTAssertEqual(p.parsed["optical_ch2"]?.intArrayValue?.first, 3600)
+        // Accelerometer block: renamed off the old optical_ch* labels (#493).
+        let ax = p.parsed["accel_x"]?.intArrayValue ?? []
+        XCTAssertEqual(ax.count, 100)
+        XCTAssertEqual(ax.first, 1800); XCTAssertEqual(ax[3], 1803)
+        XCTAssertEqual(p.parsed["accel_z"]?.intArrayValue?.first, 3600)
+        // Gyroscope block: previously dropped entirely — now decoded.
+        let gx = p.parsed["gyro_x"]?.intArrayValue ?? []
+        XCTAssertEqual(gx.count, 100); XCTAssertEqual(gx.first, 10)
+        XCTAssertEqual(p.parsed["gyro_z"]?.intArrayValue?.first, 5)
+        // The old optical labels must be gone.
+        XCTAssertNil(p.parsed["optical_ch0"])
+    }
+
+    /// Real captured v21 buffer (shared with `Whoop5RawImuTests`): the accelerometer channels the historical
+    /// decoder emits must form a ~1 g gravity shell — the physical assertion a synthetic frame cannot make,
+    /// and the one that pins the accel (not optical) identity so a future re-mislabel fails loudly (#493).
+    func testV21RealFrameAccelIsGravityShell() {
+        let f = Whoop5RawImuTests.realFrameBytes
+        let p = parseFrame(f, family: .whoop5)
+        XCTAssertEqual(p.parsed["hist_version"]?.intValue, 21)
+        guard let ax = p.parsed["accel_x"]?.intArrayValue,
+              let ay = p.parsed["accel_y"]?.intArrayValue,
+              let az = p.parsed["accel_z"]?.intArrayValue,
+              ax.count == 100, ay.count == 100, az.count == 100 else {
+            return XCTFail("real v21 frame did not decode three 100-sample accel channels")
+        }
+        let scale = 1.0 / 4096.0   // g per LSB, per Whoop5RawImu
+        let mags = (0..<100).map { i -> Double in
+            let x = Double(ax[i]) * scale, y = Double(ay[i]) * scale, z = Double(az[i]) * scale
+            return (x * x + y * y + z * z).squareRoot()
+        }
+        let sorted = mags.sorted(); let median = sorted[sorted.count / 2]
+        XCTAssertEqual(median, 1.0, accuracy: 0.15, "median |accel| should be ~1 g, not an optical waveform")
+        let inShell = mags.filter { $0 > 0.85 && $0 < 1.15 }.count
+        XCTAssertGreaterThanOrEqual(inShell, 95, "≥95/100 accel samples should sit in the gravity shell")
+        // The gyro block must be present too (the historical path used to discard it).
+        XCTAssertEqual(p.parsed["gyro_x"]?.intArrayValue?.count, 100)
     }
 
     func testV20HeaderActiveAndEmptyBlocks() {

--- a/docs/BLE_REVERSE_ENGINEERING.md
+++ b/docs/BLE_REVERSE_ENGINEERING.md
@@ -528,22 +528,29 @@ captured frame of both versions, which is what lets the body offsets be trusted.
 
 The bodies are blocks of fixed-length **sample channels**:
 
-- **v21 (1244 B):** a `(100, 100, 3)` descriptor near `@22`, then **three 100-sample i16 channels at
-  `@28` / `@228` / `@428`** (200 B apart). Each is a bounded pulsatile waveform at its own DC baseline
-  (≈1820 / 720 / 3630) — the signature of optical (PPG) channels.
+- **v21 (1244 B):** a `(100, 100, 3)` descriptor near `@22`, then **six 100-sample i16 channels** in two
+  blocks — **accelerometer at `@28` / `@228` / `@428`** and **gyroscope at `@640` / `@840` / `@1040`**
+  (200 B apart; the second block's count sits at `@630` = 100). This is **6-axis IMU, not optical**: on a
+  stationary strap the three accel channels sphere-fit to a **~1 g gravity shell** (median |a| = 1.006 g,
+  100/100 samples in-shell on the real fixture) — a gravity vector, which a PPG channel cannot produce.
+  (The DC "baselines" ≈1820 / 720 / 3630 a stationary capture shows are exactly that gravity vector:
+  √(1820²+720²+3630²)/4096 = 1.007 g.) Validated as 6-axis IMU by `Whoop5RawImu` over 1423 real buffers.
 - **v20 (2140 B):** **five channel blocks**, each preceded by a **presence byte** (`0x19` = active,
   `0x00` = empty/zero-filled). An active block holds **two 50-sample i32 channels**. Presence bytes at
   `@0x1a / 0x1c0 / 0x366 / 0x50c / 0x6b2`; the ten channel slots start at
   `@0x2f / 0xf7 / 0x1d5 / 0x29d / 0x37b / 0x443 / 0x521 / 0x5e9 / 0x6c7 / 0x78f`. i32 LE is the correct
   width (only that alignment yields smooth waveforms; an empty block's 200-byte slots are all-zero across
-  every frame, matching its `0x00` presence byte). So v20 carries the same sensor set as v21 at i32 /
-  50-sample resolution.
+  every frame, matching its `0x00` presence byte). **v20 sensor identity is OPEN**: there is no labelled
+  or moving v20 capture in the tree, and the earlier "same sensor set as v21" claim was the only basis for
+  calling it optical — now that v21 is inertial, that inference no longer supports an optical reading. Do
+  not treat v20 as an SpO₂/BP optical substrate pending a labelled **moving** capture.
 
-`decodeWhoop5HistoricalV2021` exposes `layout_marker`, `record_index`, `unix`, and the active channels as
-**raw sample arrays with no invented scale** (an optical waveform has no absolute unit). Which channel is
-which optical LED — and which carries motion/accelerometer — is **not** determinable from a stationary
-capture and needs a **labelled (e.g. deliberately moving) window**, so no per-channel identity is asserted.
-Tests: `Whoop5HistoricalV2021Tests.swift`.
+`decodeWhoop5HistoricalV2021` exposes `layout_marker`, `record_index`, `unix`, and the channels as **raw
+i16 sample arrays with no scale applied at this layer**. For **v21** the channels are named `accel_x/y/z`
+and `gyro_x/y/z` per the gravity-shell evidence above (`Whoop5RawImu.decode` applies the physical scales —
+1/4096 g/LSB accel, 2000/32768 (°/s)/LSB gyro). For **v20** the channels stay neutrally named because its
+sensor identity is still open (needs a labelled/moving capture). Tests: `Whoop5HistoricalV2021Tests.swift`
+(incl. a real-frame gravity-shell assertion) and `Whoop5RawImuTests.swift`.
 
 > The v18 per-second record's own optical region (bytes [57:120]) carries **no simple summary of this
 > PPG** (no field tracks its DC or AC amplitude), and its SpO₂ / skin-temp channels have no internal


### PR DESCRIPTION
Fixes #493.

## The bug (verified against the real fixture)
The v21 historical decoder (`Interpreter.swift`) read @28/@228/@428 as `optical_ch0..2` / category `"ppg"`, while `Whoop5RawImu` reads the **same offsets** as accelerometer axes. Reproduced every number in the report against the in-tree real 1244-byte fixture:

| | value |
|---|---|
| median \|a\| (@28/@228/@428 as accel) | **1.0058 g** |
| samples in 0.85–1.15 g | **100/100** (range 0.999–1.012) |
| header @22 / countA@24 / countB@630 | **(100,100,3)** / 100 / 100 |
| docs' "optical baselines" 1820/720/3630 as accel | **1.0068 g** |

A stationary strap whose three channels sphere-fit to 1 g is an accelerometer reading gravity — PPG can't. The `(100,100,3)` header + `countB@630`=100 mean two blocks × three axes = 6-axis IMU, so the v21 path was also **silently dropping the gyroscope block**.

## Minimal fix
- **Rename** `optical_ch0..2` → `accel_x/y/z`, category `ppg` → `imu`.
- **Emit the gyro block** `gyro_x/y/z` @640/@840/@1040 — no longer discarded.
- **Real-frame test** asserting the gravity shell (median |a| ≈ 1 g, ≥95/100 in-shell) — the physical check a synthetic frame can't make; `Whoop5HistoricalV2021Tests` was synthetic-only. Reuses the real fixture already in `Whoop5RawImuTests`.
- **Docs** (`BLE_REVERSE_ENGINEERING.md`): v21 corrected to 6-axis IMU; v20 identity marked **OPEN** (the "v20 = same sensor set as v21" line was the sole basis for calling v20 optical — now that v21 is inertial it no longer supports an optical/SpO₂ reading).

## Scope / parity
- **No Kotlin twin change:** the Android historical decoder never emitted `optical_ch` labels and already decodes 5/MG IMU via the correct `Whoop5RawImu.kt`.
- **No live consumer** computes SpO₂ from these channels (SpO₂ is plumbed-but-unmapped); the mislabel was load-bearing for the *narrative* of treating 5/MG buffers as an optical substrate, which this corrects.
- v20 channels intentionally left neutrally named (identity genuinely unknown).

## Verification
`swift test` (WhoopProtocol, Linux): **285 passed, 0 failed**, incl. the new `testV21RealFrameAccelIsGravityShell`.

Reported and diagnosed by vishk23.