### PR TITLE
iOS/macOS BLE: re-read 5/MG battery (0x2A19) post-bond, not just pre-bond (#490)

### DIFF
--- a/Strand/BLE/BLEManager.swift
+++ b/Strand/BLE/BLEManager.swift
@@ -2638,6 +2638,20 @@ public final class BLEManager: NSObject, ObservableObject {
         for c in chars where !c.isNotifying {
             requestNotify(c, on: p, reason: reason)
         }
+        // #490: a 5/MG's 0x2A19 battery READ is refused pre-bond (it fires in didDiscoverCharacteristicsFor,
+        // before the link is encrypted) and is never retried, so `batteryPct` stays nil from connect — and
+        // the 5/MG sends NO unsolicited battery notification (so the notify subscription above never fills
+        // it on its own). Re-issue the read here: every caller is post-bond (CLIENT_HELLO-ack, post-bond,
+        // keep-alive), so the link is encrypted and the read succeeds; the keep-alive caller also RE-polls
+        // it (~every 30 s) so the reading stays current as the strap drains and BatteryEstimator gets its
+        // discharge samples on any screen. This is the iOS parity for Android's post-handshake read +
+        // ~60 s keep-alive poll (WhoopBleClient BATTERY_ON_CONNECT_DELAY_MS / refreshBattery). 4.0 is
+        // EXCLUDED — its 0x2A19 is a stub constant 100 (real value = GET_BATTERY_LEVEL; re-reading the stub
+        // would revert the true reading, #77). The 600 s same-% throttle in LiveState guards the estimator.
+        if let b = batteryCharacteristic, b.properties.contains(.read),
+           selectedModel.deviceFamily != .whoop4 {
+            p.readValue(for: b)
+        }
     }
 
     private func requestNotify(_ c: CBCharacteristic, on p: CBPeripheral, reason: String) {


### PR DESCRIPTION
Fixes #490.

## Defect
A WHOOP 5/MG's `0x2A19` battery read fires once in `didDiscoverCharacteristicsFor` — **before the link is encrypted** — which an MG rejects. The rejection is logged and dropped, and **never retried**, so `LiveState.batteryPct` stays `nil` from connect. The 5/MG sends **no unsolicited battery notification** (confirmed by Android's own `WhoopBleClient.kt:4275`), so the notify subscription never fills it either; the only re-read path (`refreshBattery`) is reachable **only from the Live screen**. A 5/MG user on Today/Devices never sees a battery %.

## Fix (minimal — one block)
Re-issue the read in `enableLiveNotifications`, after the notify loop:
```swift
if let b = batteryCharacteristic, b.properties.contains(.read),
   selectedModel.deviceFamily != .whoop4 {
    p.readValue(for: b)
}
```
Every caller is **post-bond** (CLIENT_HELLO-ack `:3586`, post-bond `:3699`, keep-alive `:2439`), so the link is encrypted and the read succeeds. The value lands through the existing `didUpdateValueFor` → `case batteryChar` → `setBattery` path — no new plumbing.

## Parity with Android (verified, not assumed)
Android does exactly this and needs no change: a one-shot post-handshake read (`BATTERY_ON_CONNECT_DELAY_MS`, `:4705`) **plus** a ~60s keep-alive poll (`:4279`), precisely *because* the 5/MG sends no unsolicited battery. Putting the iOS read in `enableLiveNotifications` covers **both** behaviors in one place — it seeds at bond and re-polls each keep-alive (~30s on iOS), keeping the % current as the strap drains and feeding `BatteryEstimator` its discharge samples on any screen.

## Safety (re-reviewed)
- **4.0 excluded** (`!= .whoop4`) — its `0x2A19` is a stub constant 100 (#77); re-reading it would revert the true `GET_BATTERY_LEVEL` reading. Matches the existing notify-path gate at `:3828`.
- **No estimator flooding** — `LiveState.bankBatterySample` drops a repeat same-% within 600s (`:405`), so the 30s poll can't skew the discharge fit.
- `.read` guard + all-callers-post-bond → idempotent, no pre-bond re-rejection, self-healing (a too-early read just retries next keep-alive).
- Shared `Strand/BLE/BLEManager.swift` → this fixes **macOS** too.

## Deliberately NOT taken
The 5.0 EVENT-path `battery_pct` (deci-percent) — mixing it with `0x2A19` (whole-percent) into one `setBattery` funnel yields a ±0.9pp sawtooth that escapes the 1.0 charge-reset guard yet corrupts the 2.0-min-drop discharge fit (and its ≤24h low-runtime alert). #77's one-source-per-family stance is load-bearing here.

## Out of scope (vishk23 filing separately)
The `bolt.slash`-looks-dead render (charging nested inside `if let pct`) and `batteryPct` not cleared on disconnect.

## Verification
- App-target Swift (`BLEManager`) — no default CI; compile validated via `app-build.yml` on-demand.
- ⚠️ **Needs on-device confirmation on a real 5/MG** (BLE connection-path change; can't be CI/Linux-tested per CLAUDE.md). Reporter has fw 50.40.1.0.

Reported and diagnosed by vishk23.