### PR TITLE
Today + Trends (Android): unclip title, drop bogus Strain %, fix two description typos (#492)

### DIFF
--- a/android/app/src/main/java/com/noop/ui/TodayScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/TodayScreen.kt
@@ -2030,7 +2030,9 @@ private fun LiquidTodayHeader(
         Column(
             modifier = Modifier
                 .weight(1f)
-                .clip(RoundedCornerShape(Metrics.cornerSm))
+                // #492: NO rounded clip here. With indication = null there's no ripple to shape, and the
+                // rounded corners were clipping the title/date text's bottom-left (the "W" of "Wednesday").
+                // iOS's title Button uses a plain contentShape(Rectangle()) with no clip — mirror that.
                 .clickable(
                     interactionSource = remember { MutableInteractionSource() },
                     indication = null,
@@ -4677,7 +4679,10 @@ private fun MetricGrid(
         KeyMetric.EFFORT to KeyTileData(
             label = "Strain",
             value = d?.strain?.let { UnitFormatter.effortDisplay(it, effortScale) } ?: NO_DATA,
-            unit = if (d?.strain != null) "%" else "",
+            // #492: Strain/Effort is a load index (0–21 WHOOP / 0–100 NOOP), NOT a percentage — the "%"
+            // was wrong (esp. on the 0–21 scale). Recovery/Rest ARE 0–100 % and keep it. iOS shows the
+            // strain axis as an "of 21"/"of 100" caption with no % (TodayView effort tile); match that.
+            unit = "",
             tint = d?.strain?.let { Palette.effortTint(it / StrainScorer.maxStrain) } ?: Palette.effortColor,
             frac = d?.strain?.let { (it / 100.0).coerceIn(0.0, 1.0) },
             spark = w.strain,

--- a/android/app/src/main/java/com/noop/ui/TrendsExploreScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/TrendsExploreScreen.kt
@@ -143,7 +143,7 @@ private val builtInMetrics: List<MetricSpec> = listOf(
         key = "recovery", title = "Charge", unit = "%", category = "Charge",
         accent = Palette.accent, higherIsBetter = true, decimals = 0,
         dailyPick = { it.recovery },
-        description = "How recovered you are , led by HRV versus your personal baseline.",
+        description = "How recovered you are, led by HRV versus your personal baseline.",
     ),
     MetricSpec(
         key = "strain", title = "Effort", unit = "/100", category = "Effort",
@@ -167,7 +167,7 @@ private val builtInMetrics: List<MetricSpec> = listOf(
         // sleep_performance / sleep_total_min , to StrandPalette.accent), not a stray metric hue.
         accent = Palette.accent, higherIsBetter = true, decimals = 1,
         dailyPick = { it.totalSleepMin?.let { m -> m / 60.0 } },
-        description = "How restorative your sleep was , duration, efficiency, deep+REM, timing.",
+        description = "How restorative your sleep was: duration, efficiency, deep+REM, timing.",
     ),
     MetricSpec(
         key = "efficiency", title = "Sleep Efficiency", unit = "%", category = "Rest",


### PR DESCRIPTION
Addresses the two **clear bugs** in #492 (items 1 and 8). Both are Android-only — iOS already handles them correctly, so no iOS change.

## #1 — day title clipped ("W" of "Wednesday" cut off)
The tappable title `Column` had `.clip(RoundedCornerShape(Metrics.cornerSm))` with `indication = null` — there's no ripple to shape, but the rounded corners were clipping the title/date text's bottom-left. Removed the clip; the `clickable` still defines the tap area. Mirrors iOS's title `Button`, which uses `contentShape(Rectangle())` with no clip (`LiquidTodayView.swift:388-405`).

## #8 — Strain shows "%"
The Strain Key-Metrics tile hardcoded `unit = "%"`. Strain/Effort is a load index (0–21 WHOOP / 0–100 NOOP), **not** a percentage — most obviously wrong on the 0–21 scale ("5.7%"). Recovery and Rest are genuine 0–100 % readiness scores and keep it. iOS shows the strain axis as an "of 21"/"of 100" caption with no % (`TodayView.swift:3206-3219`); Android now drops the %.

## Verification
- `./gradlew compileFullDebugKotlin` — BUILD SUCCESSFUL.
- Pure display changes (a modifier removal + a unit string); no data/logic touched.

The other 9 items in #492 (spacing consistency, chart x-axis/hover, Compare add-metric wrap, value truncation, terminology) are triaged separately on the issue — they need design judgment / on-device iteration.

Reported by bartmuskala.