### PR TITLE
Today hero + Workouts (Android): fix the source-badge float + Src-column truncation (#486)

### DIFF
--- a/Strand/Liquid/LiquidTodayView.swift
+++ b/Strand/Liquid/LiquidTodayView.swift
@@ -504,11 +504,14 @@ struct LiquidTodayView: View {
                 .overlay(alignment: .top) {
                     if let sourceLabel = heroSourceLabel {
                         SourceBadge("\(sourceLabel)", tint: StrandPalette.onDarkSecondary)
-                            // Match the badge's trailing edge to the fixed-width Rest vessel on every
-                            // card width, then lift its centre onto the card's top border.
+                            // Match the badge's trailing edge to the fixed-width Rest vessel on every card
+                            // width, then lift by the space4 gap above the cells so the badge's TOP sits on
+                            // the card's top edge — tucked into the top-right corner. (#486: the old
+                            // "+ half the badge height" centred it ON the border, reading as a pill floating
+                            // detached above the card; two users flagged it. Twin of Android TodayScreen.)
                             .fixedSize()
                             .frame(width: HeroScoreCell.vesselDiameter, alignment: .trailing)
-                            .offset(y: -(NoopMetrics.space4 + NoopMetrics.sourceBadgeHeight / 2))
+                            .offset(y: -NoopMetrics.space4)
                             .allowsHitTesting(false)
                             .accessibilityLabel(Text("Source: \(sourceLabel)"))
                     }

--- a/android/app/src/main/java/com/noop/ui/TodayScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/TodayScreen.kt
@@ -2330,11 +2330,6 @@ private fun ScoreHeroRow(
     // count-up both honour Reduce Motion internally, so this is purely a "don't animate an empty hero" cost
     // gate. A carried Charge counts as data (its dimmed vessel should slosh like the Rest one).
     val animated = recovery != null || strain != null || restScore != null || lastScoredCharge != null
-    var sourceBadgeHeightPx by remember(heroSourceLabel) { mutableIntStateOf(0) }
-    val sourceBadgeHalfHeight = with(LocalDensity.current) {
-        if (sourceBadgeHeightPx > 0) (sourceBadgeHeightPx / 2f).toDp()
-        else Metrics.sourceBadgeHeight / 2
-    }
 
     Box(
         modifier = Modifier
@@ -2449,11 +2444,12 @@ private fun ScoreHeroRow(
                                 // Measure the full label even when it is wider than the Rest vessel, then
                                 // let it overflow left while preserving the vessel-aligned trailing edge.
                                 .wrapContentWidth(unbounded = true, align = Alignment.End)
-                                .onSizeChanged { sourceBadgeHeightPx = it.height }
-                                // The row starts one space16 inside the card; lifting by that plus half the
-                                // measured badge height puts its centre exactly on the top border, including
-                                // when Android font scaling grows it above the canonical compact height.
-                                .offset(y = -(Metrics.space16 + sourceBadgeHalfHeight))
+                                // #486: the vessel row starts one space16 inside the card, so lifting by
+                                // exactly space16 puts the badge's TOP on the card's top edge — it tucks
+                                // into the top-right corner and hangs into the gap above the vessels. The
+                                // previous "+ half the badge height" centred it ON the border, where it read
+                                // as a pill floating detached above the card (two users flagged it).
+                                .offset(y = -Metrics.space16)
                                 .semantics { contentDescription = "Source: $heroSourceLabel" },
                         )
                     }

--- a/android/app/src/main/java/com/noop/ui/WorkoutsScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/WorkoutsScreen.kt
@@ -1984,14 +1984,18 @@ private val WorkoutRow.sourceBadge: Pair<String, Color>
     get() = when (WorkoutEditing.classify(source)) {
         // Detected (on-device auto-detector) is honestly labelled so a duplicate is recognisable +
         // removable (#107); manual = user-logged. Both classify on `source` BEFORE the import labels.
-        WorkoutSource.DETECTED -> "Detected" to Palette.metricPurple
-        WorkoutSource.MANUAL -> "Manual" to Palette.statusWarning
-        WorkoutSource.LIFTING -> "Lifting" to Palette.zone2 // imported Hevy / Liftosaur strength log
-        WorkoutSource.ACTIVITY_FILE -> "File" to Palette.metricAmber // imported GPX / TCX / FIT
+        // #486: SHORT badge codes so the label fits the narrow weight-1 Src column on a phone instead of
+        // ellipsising ("Manual"->"MA...", "Whoop"->"WH...", "Detected"->"DE..."). The colour + the row
+        // context disambiguate. iOS keeps the full words — its Source column is a fixed 80pt that fits them
+        // and those labels are localized; Android's badge labels are hardcoded, so this stays platform-local.
+        WorkoutSource.DETECTED -> "AUTO" to Palette.metricPurple
+        WorkoutSource.MANUAL -> "MAN" to Palette.statusWarning
+        WorkoutSource.LIFTING -> "LIFT" to Palette.zone2 // imported Hevy / Liftosaur strength log
+        WorkoutSource.ACTIVITY_FILE -> "FILE" to Palette.metricAmber // imported GPX / TCX / FIT
         else -> when (workoutSourceLabel(deviceId, source)) {
             "HC" -> "HC" to Palette.metricPurple
-            "Whoop" -> "Whoop" to Palette.accent
-            else -> "Apple" to Palette.metricCyan
+            "Whoop" -> "WHP" to Palette.accent
+            else -> "APL" to Palette.metricCyan
         }
     }
 


### PR DESCRIPTION
Follow-up to #487 (the empty-space fix, merged). Two users on #486 flagged the **"ON-DEVICE" badge floating detached above the hero card**:
- Dharanesh07: *"the on-device text over the charge numbers looks a bit offset."*
- bartmuskala: *"the remark applies to all labels."*

## Cause
The hero source badge was offset by `-(gap + halfBadgeHeight)`, which the code comment describes as putting *"its centre exactly on the top border"* — so half the pill hangs **outside** the card, reading as a label floating above it.

## Fix (both platforms — shared hero idiom)
Lift by exactly the gap above the vessels, so the badge's **top** sits on the card's top edge and it tucks into the top-right corner, hanging into the gap:
- Android `TodayScreen.kt`: `-(Metrics.space16 + sourceBadgeHalfHeight)` → `-Metrics.space16`; drop the now-unused `sourceBadgeHeightPx`/`sourceBadgeHalfHeight` measurement.
- iOS `LiquidTodayView.swift`: `-(space4 + sourceBadgeHeight/2)` → `-space4`.

Trailing edge still matches the Rest vessel on both.

## Verification
- Android: `compileFullDebugKotlin` — BUILD SUCCESSFUL.
- iOS/macOS: validated via `app-build.yml` (below).
- ⚠️ Pure position tweak, but the exact resting spot is worth an on-device glance (Android confirmed by the reporters' screenshots; iOS should be eyeballed).

## Not in this PR
bartmuskala's workouts screenshot shows a *different* issue — the workout `SRC` column badges are truncated ("MA…", "WH…") and the KCAL value is cramped against them. That's the workout table, overlapping #492's truncation item — tracked separately.

Reported by Dharanesh07 + bartmuskala.