### PR TITLE
Remove redundant legacy stress nudge

### DIFF
--- a/Strand/App/AppModel.swift
+++ b/Strand/App/AppModel.swift
@@ -147,10 +147,6 @@ final class AppModel: ObservableObject {
     // via BiofeedbackPrefs so a relaunch can't re-fire), carried verbatim between evaluations.
     private var rrBuf: [Int] = []
     private var stressState = BiofeedbackPrefs.loadStressState()
-    // Legacy experimental stress-nudge state (the older `behavior.stressNudge` buzz path) , a slow HRV
-    // baseline + a rate limiter, kept so that toggle still works independently of the L3 check-in.
-    private var hrvBaseline: Double = 0
-    private var lastStressBuzzAt: Date = .distantPast
 
     /// Import source currently writing to the local store, if any.
     @Published private var activeImportSource: DataSourceImportKind?
@@ -750,39 +746,19 @@ final class AppModel: ObservableObject {
         bpm = nil
     }
 
-    /// Stress evaluation, two independent layers (each opt-in, each off by default):
-    ///   • the legacy experimental `behavior.stressNudge` buzz (a fresh HRV dip → one confirming buzz);
-    ///   • the v5 L3 closed-loop check-in , the unit-tested `StressOnsetDetector` decides, at the moment
-    ///     it matters, whether to offer a 60-s guided breath. On a fresh, non-metabolic HRV dip while the
-    ///     user is still it fires a single confirming buzz AND posts a passive nudge to `stressNudgeCenter`
-    ///     (the dismissible Stress check-in card surfaces it). The detector carries its own replay-safe
-    ///     state (de-dup + slow baseline + rate limit), persisted via `BiofeedbackPrefs` so a relaunch
-    ///     can't re-fire. Honest / non-clinical: "stress" is an autonomic proxy vs the user's own
-    ///     baseline, never a diagnosis.
+    /// The unit-tested `StressOnsetDetector` decides whether to offer a 60-s guided breath. On a fresh,
+    /// non-metabolic HRV dip while the user is still, it fires a single confirming buzz and posts a
+    /// passive nudge to `stressNudgeCenter`. The detector carries replay-safe state (de-dup + slow
+    /// baseline + rate limit), persisted via `BiofeedbackPrefs` so a relaunch can't re-fire. Honest /
+    /// non-clinical: "stress" is an autonomic proxy vs the user's own baseline, never a diagnosis.
     private func evaluateStress() {
         let fresh = live.rr.filter { $0 > 300 && $0 < 2000 }   // plausible R-R (30–200 bpm)
         guard !fresh.isEmpty else { return }
         rrBuf.append(contentsOf: fresh)
         if rrBuf.count > 120 { rrBuf.removeFirst(rrBuf.count - 120) }
 
-        // ── Legacy experimental nudge (behavior.stressNudge) , unchanged behaviour, kept separate.
-        if behavior.stressNudge, live.bonded, live.worn, rrBuf.count >= 20 {
-            let rmssd = AppModel.rmssd(Array(rrBuf.suffix(60)))
-            if rmssd > 0 {
-                hrvBaseline = hrvBaseline == 0 ? rmssd : hrvBaseline * 0.98 + rmssd * 0.02   // slow EMA
-                if let hr = bpm, hr >= 55, hr <= 100 {            // resting band , not a workout
-                    let now = Date()
-                    if rmssd < hrvBaseline * 0.6, now.timeIntervalSince(lastStressBuzzAt) > 900 {
-                        lastStressBuzzAt = now
-                        buzz(loops: 1)
-                        live.append(log: "Stress nudge , take a paced breath")
-                    }
-                }
-            }
-        }
-
-        // ── v5 L3 closed-loop check-in (StressOnsetDetector). Inert unless the master toggle is on; the
-        // engine itself owns every gate (auto-nudge, exercise gate, quiet hours, rate limit, edge).
+        // Inert unless the master toggle is on; the engine owns every gate (auto-nudge, exercise gate,
+        // quiet hours, rate limit, edge).
         let cfg = BiofeedbackPrefs.stressConfig()
         guard cfg.enabled, live.bonded, live.worn else { return }
         let decision = StressOnsetDetector.evaluate(
@@ -805,13 +781,6 @@ final class AppModel: ObservableObject {
     /// Whether the encrypted channel is up so a confirming buzz can actually fire (the command
     /// characteristic is gated on bond; an un-encrypted live-HR-only link can't buzz).
     private var canBuzz: Bool { live.bonded && live.encryptedBond }
-
-    static func rmssd(_ rr: [Int]) -> Double {
-        guard rr.count >= 2 else { return 0 }
-        var sum = 0.0, n = 0
-        for i in 1..<rr.count { let d = Double(rr[i] - rr[i - 1]); sum += d * d; n += 1 }
-        return n > 0 ? (sum / Double(n)).squareRoot() : 0
-    }
 
     /// Start scanning for the strap. When no model is given, use the one the user
     /// picked (persisted under "selectedWhoopModel"), so every scan entry point ,

--- a/Strand/Data/BehaviorStore.swift
+++ b/Strand/Data/BehaviorStore.swift
@@ -21,8 +21,6 @@ final class BehaviorStore: ObservableObject {
 
     // MARK: HR-zone haptic coaching (during a live session)
     @Published var zoneCoaching: Bool { didSet { d.set(zoneCoaching, forKey: K.zoneCoaching) } }
-    /// Experimental: gentle buzz when a resting stress spike is detected (HRV drops while HR is calm).
-    @Published var stressNudge: Bool { didSet { d.set(stressNudge, forKey: K.stress) } }
 
     // MARK: Haptic biofeedback — Stress check-ins (L3)
     //
@@ -62,7 +60,6 @@ final class BehaviorStore: ObservableObject {
         static let wristOffShortcut = "behavior.wristOffShortcut"
         static let wristOnShortcut = "behavior.wristOnShortcut"
         static let zoneCoaching = "behavior.zoneCoaching"
-        static let stress = "behavior.stressNudge"
         // Haptic biofeedback L3 — keys MATCH BiofeedbackPrefs (one source of truth, two readers).
         static let stressCheckIn = "biofeedback.stressCheckIn"
         static let stressAutoNudge = "biofeedback.stressAutoNudge"
@@ -86,7 +83,6 @@ final class BehaviorStore: ObservableObject {
         wristOffShortcut = d.string(forKey: K.wristOffShortcut) ?? ""
         wristOnShortcut = d.string(forKey: K.wristOnShortcut) ?? ""
         zoneCoaching = d.object(forKey: K.zoneCoaching) as? Bool ?? false
-        stressNudge = d.object(forKey: K.stress) as? Bool ?? false
         stressCheckIn = d.object(forKey: K.stressCheckIn) as? Bool ?? false
         stressAutoNudge = d.object(forKey: K.stressAutoNudge) as? Bool ?? false
         stressQuietHours = d.object(forKey: K.stressQuietHours) as? Bool ?? true

--- a/Strand/Screens/AutomationsView.swift
+++ b/Strand/Screens/AutomationsView.swift
@@ -172,15 +172,11 @@ struct AutomationsView: View {
     private var coachingCard: some View {
         Section2(icon: "bolt.heart.fill", title: String(localized: "Haptic coaching"),
                  blurb: String(localized: "Train by feel. The strap buzzes so you don't have to watch a screen."),
-                 active: behavior.zoneCoaching || behavior.stressNudge || behavior.stressCheckIn) {
+                 active: behavior.zoneCoaching || behavior.stressCheckIn) {
             VStack(spacing: 0) {
                 ToggleRow(label: String(localized: "HR-zone coaching"),
                           help: String(localized: "Buzz when you hit your top zone (ease off) and again when you recover. Uses your max HR from Settings."),
                           isOn: $behavior.zoneCoaching)
-                rowDivider
-                ToggleRow(label: String(localized: "Resting stress nudge (experimental)"),
-                          help: String(localized: "A gentle buzz when your HRV drops while your heart rate is calm, a cue to take a paced breath. Rate-limited to once every 15 minutes; off by default."),
-                          isOn: $behavior.stressNudge)
                 rowDivider
                 // v5 L3 closed-loop check-in (master + sub toggles). Default OFF, manual-first. The keys
                 // mirror BiofeedbackPrefs, which the central detector (AppModel.evaluateStress) reads.

--- a/docs/ANALYTICS.md
+++ b/docs/ANALYTICS.md
@@ -36,7 +36,7 @@ The package contains more analytics than the app currently surfaces. This sectio
 
 | Engine | File | Status in the app |
 |---|---|---|
-| `HRVAnalyzer` | `HRVAnalyzer.swift` | **Library-only** as a type. The app computes RMSSD inline via `AppModel.rmssd(_:)` (same Task-Force formula) for the live stress nudge. |
+| `HRVAnalyzer` | `HRVAnalyzer.swift` | **Library-only** as a type. Live stress check-ins use the dedicated `StressOnsetDetector`. |
 | `RecoveryScorer` | `RecoveryScorer.swift` | **Live.** Computes the **Charge** score. Runs inside `AnalyticsEngine.analyzeDay` via `Strand/Data/IntelligenceEngine.swift`; computed values are persisted under the `"<deviceId>-noop"` source and merged **under** any imported `recovery_score_pct` (imports always win). APPROXIMATE. |
 | `StrainScorer` | `StrainScorer.swift` | **Live.** Computes the **Effort** score (0–100). Day load is computed on-device for nights the strap offloaded; the imported `day_strain` column still wins for imported days. APPROXIMATE. |
 | `SleepStager` | `SleepStager.swift` | **Live.** Stages each offloaded night inside `analyzeDay`; the per-night stages feed the **Rest** composite. Computed sessions are persisted under the `"-noop"` source, with imported sleeps taking precedence. APPROXIMATE. |
@@ -74,30 +74,7 @@ bpm = vals.isEmpty ? nil : Int(vals[vals.count / 2].rounded())
 
 Median (not mean) is deliberate: it rejects single-beat outliers without lagging the signal.
 
-### 2. RMSSD for the stress nudge (`rmssd` + `evaluateStress`)
-
-The live RMSSD uses the classic Task-Force successive-difference formula over a rolling R-R buffer:
-
-```swift
-static func rmssd(_ rr: [Int]) -> Double {
-    guard rr.count >= 2 else { return 0 }
-    var sum = 0.0, n = 0
-    for i in 1..<rr.count { let d = Double(rr[i] - rr[i - 1]); sum += d * d; n += 1 }
-    return n > 0 ? (sum / Double(n)).squareRoot() : 0
-}
-```
-
-`evaluateStress()` is an **experimental, off-by-default** resting-stress nudge:
-
-- Only runs when `behavior.stressNudge` is on **and** the strap is bonded **and** worn.
-- Filters R-R to plausible beats (`300 < rr < 2000` ms, i.e. 30–200 bpm), keeps the last 60, needs ≥ 20.
-- Tracks a **slow HRV baseline** as an EWMA: `hrvBaseline = hrvBaseline * 0.98 + rmssd * 0.02`.
-- Only fires when HR is in a **resting band** (`55…100` bpm — not a workout) and current RMSSD has dropped **below 60% of baseline**.
-- Rate-limited to **once per 15 minutes** (`> 900` s). On fire it buzzes the strap once and logs "take a paced breath."
-
-It is intentionally conservative so it rarely false-fires.
-
-### 3. HR-zone haptic coaching (`coachZone`)
+### 2. HR-zone haptic coaching (`coachZone`)
 
 Watches the smoothed `bpm`, computes `%HRmax` from `profile.hrMax`, and buckets into 5 zones at `0.6 / 0.7 / 0.8 / 0.9` of max:
 

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -452,9 +452,8 @@ React when the strap comes off or goes on:
 ### Haptic coaching
 - **HR-zone coaching** — buzz when you hit your top zone (ease off) and again when you recover,
   using your max HR from Settings.
-- **Resting stress nudge (experimental)** — a gentle buzz when your HRV drops while your heart
-  rate is calm — a cue to take a paced breath. Conservative, rate-limited to **once every
-  15 minutes**, off by default.
+- **Stress check-ins (haptic)** — offer a guided breathing check-in after a fresh HRV dip while
+  you are still. Off by default, with optional auto-nudges, quiet hours, and your resonance pace.
 
 ### Smart alarm
 Wake to a wrist buzz. This arms the strap's **own firmware alarm**, so it still fires even if the


### PR DESCRIPTION
## Summary

Fixes #330.

Remove the older "Resting stress nudge (experimental)" from the Apple app and keep the newer Stress check-in as the only resting-HRV haptic flow.

## Why

Both paths watched for a resting HRV dip and could buzz the strap. The legacy path maintained its own baseline and 15-minute rate limit, while the newer `StressOnsetDetector` already handles the same job with replay protection, exercise and quiet-hours gates, and the guided-breathing card. Leaving both enabled could produce duplicate behavior from one trigger.

## Changes

- Remove the legacy toggle and its `BehaviorStore` preference.
- Remove the legacy baseline, rate limiter, RMSSD helper, and buzz branch from `AppModel.evaluateStress()`.
- Keep `StressOnsetDetector`, `BiofeedbackPrefs`, and the Stress check-in UI unchanged.
- Remove the retired localization entries and update the feature and analytics docs.

The old `behavior.stressNudge` UserDefaults value is intentionally left alone. Nothing reads it after this change, so existing installs do not need a migration.

## Validation

- `git diff --check`
- `jq empty Strand/Resources/Localizable.xcstrings`
- `python3 Tools/i18n_audit.py --platform ios --ci upstream/main`
- Confirmed no remaining legacy references outside the archived design spec.

Swift build not run locally; I don't have Apple toolchains here.
