### PR TITLE
Localize Android workout start UI

### DIFF
--- a/android/app/src/main/java/com/noop/ui/WorkoutStart.kt
+++ b/android/app/src/main/java/com/noop/ui/WorkoutStart.kt
@@ -29,6 +29,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 import androidx.compose.ui.draw.drawWithContent
@@ -38,6 +39,7 @@ import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.noop.R
 import com.noop.analytics.Sport
 import com.noop.analytics.WorkoutSport
 import kotlinx.coroutines.delay
@@ -89,12 +91,12 @@ fun StartWorkoutSheet(vm: AppViewModel, onDismiss: () -> Unit) {
 
     AlertDialog(
         onDismissRequest = onDismiss,
-        title = { Text("Start a workout") },
+        title = { Text(stringResource(R.string.workout_start_title)) },
         text = {
             Column {
                 OutlinedTextField(
                     value = query, onValueChange = { query = it },
-                    label = { Text("Search sport") }, singleLine = true,
+                    label = { Text(stringResource(R.string.workout_search_sport)) }, singleLine = true,
                     modifier = Modifier.fillMaxWidth(),
                 )
                 Column(
@@ -103,13 +105,13 @@ fun StartWorkoutSheet(vm: AppViewModel, onDismiss: () -> Unit) {
                         .verticalScroll(sportScroll),
                 ) {
                     if (recents.isNotEmpty()) {
-                        Overline("Recent", modifier = Modifier.padding(top = 6.dp))
+                        Overline(stringResource(R.string.workout_recent), modifier = Modifier.padding(top = 6.dp))
                         recents.forEach { sp ->
                             StartSportRow(sp, isSelected = sp == selected) {
                                 selected = sp; gpsOn = sp.isDistanceSport
                             }
                         }
-                        Overline("All activities", modifier = Modifier.padding(top = 6.dp))
+                        Overline(stringResource(R.string.workout_all_activities), modifier = Modifier.padding(top = 6.dp))
                     }
                     filtered.forEach { sp ->
                         StartSportRow(sp, isSelected = sp == selected) {
@@ -121,7 +123,7 @@ fun StartWorkoutSheet(vm: AppViewModel, onDismiss: () -> Unit) {
                     verticalAlignment = Alignment.CenterVertically,
                     modifier = Modifier.fillMaxWidth().padding(top = 8.dp),
                 ) {
-                    Text("Track GPS route", style = NoopType.body, color = Palette.textPrimary)
+                    Text(stringResource(R.string.workout_track_gps_route), style = NoopType.body, color = Palette.textPrimary)
                     Spacer(Modifier.weight(1f))
                     Switch(checked = gpsOn, onCheckedChange = { gpsOn = it })
                 }
@@ -139,11 +141,11 @@ fun StartWorkoutSheet(vm: AppViewModel, onDismiss: () -> Unit) {
                     showLiveWorkout = true
                 }
             }) {
-                Text("Start ${selected.name}")
+                Text(stringResource(R.string.workout_start_selected, selected.name))
             }
         },
         dismissButton = {
-            OutlinedButton(onClick = onDismiss) { Text("Cancel") }
+            OutlinedButton(onClick = onDismiss) { Text(stringResource(R.string.action_cancel)) }
         },
     )
 }
@@ -163,7 +165,7 @@ private fun StartSportRow(sp: Sport, isSelected: Boolean, onPick: () -> Unit) {
         )
         if (sp.isDistanceSport) {
             Spacer(Modifier.width(6.dp))
-            Text("· GPS", style = NoopType.footnote, color = Palette.textTertiary)
+            Text(stringResource(R.string.workout_gps_badge), style = NoopType.footnote, color = Palette.textTertiary)
         }
     }
 }
@@ -193,7 +195,11 @@ fun WorkoutStartSection(vm: AppViewModel) {
         val elapsedS = ((nowMs - w.startMs) / 1000).coerceAtLeast(0)
         NoopCard {
             Row(verticalAlignment = Alignment.CenterVertically, modifier = Modifier.fillMaxWidth()) {
-                Text("● ${w.sport.name.uppercase()}", style = NoopType.overline, color = Palette.statusCritical)
+                Text(
+                    stringResource(R.string.workout_active_sport, w.sport.name.uppercase()),
+                    style = NoopType.overline,
+                    color = Palette.statusCritical,
+                )
                 Spacer(Modifier.width(10.dp))
                 Text(
                     String.format("%d:%02d", elapsedS / 60, elapsedS % 60),
@@ -205,7 +211,7 @@ fun WorkoutStartSection(vm: AppViewModel) {
                     onClick = { showLiveWorkout = true },
                     contentPadding = PaddingValues(horizontal = 14.dp, vertical = 8.dp),
                     colors = ButtonDefaults.outlinedButtonColors(contentColor = Palette.accent),
-                ) { Text("Open", style = NoopType.captionNumber) }
+                ) { Text(stringResource(R.string.action_open), style = NoopType.captionNumber) }
                 Spacer(Modifier.width(8.dp))
                 Button(
                     onClick = { vm.endWorkout() },
@@ -213,7 +219,7 @@ fun WorkoutStartSection(vm: AppViewModel) {
                     colors = ButtonDefaults.buttonColors(
                         containerColor = Palette.statusCritical, contentColor = Palette.surfaceBase,
                     ),
-                ) { Text("End", style = NoopType.captionNumber) }
+                ) { Text(stringResource(R.string.action_end), style = NoopType.captionNumber) }
             }
         }
     } else if (live.bonded) {
@@ -224,7 +230,7 @@ fun WorkoutStartSection(vm: AppViewModel) {
             colors = ButtonDefaults.buttonColors(
                 containerColor = Palette.accent, contentColor = Palette.surfaceBase,
             ),
-        ) { Text("Start workout", style = NoopType.captionNumber) }
+        ) { Text(stringResource(R.string.action_start_workout), style = NoopType.captionNumber) }
     }
 
     if (showSportPicker) {

--- a/android/app/src/main/res/values-de/strings.xml
+++ b/android/app/src/main/res/values-de/strings.xml
@@ -50,6 +50,18 @@
     <string name="action_log_journal">Journal notieren</string>
     <string name="action_breathe">Atmen</string>
 
+    <string name="workout_start_title">Workout starten</string>
+    <string name="workout_search_sport">Sportart suchen</string>
+    <string name="workout_recent">Zuletzt</string>
+    <string name="workout_all_activities">Alle Aktivitäten</string>
+    <string name="workout_track_gps_route">GPS-Route aufzeichnen</string>
+    <string name="workout_start_selected">%1$s starten</string>
+    <string name="workout_gps_badge">· GPS</string>
+    <string name="workout_active_sport">● %1$s</string>
+    <string name="action_cancel">Abbrechen</string>
+    <string name="action_open">Öffnen</string>
+    <string name="action_end">Beenden</string>
+
     <!-- Today screen: workouts feed header. Matches the iOS German entry for "Latest Workouts". -->
     <string name="today_latest_workouts">Neueste Workouts</string>
 

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -55,6 +55,20 @@
     <string name="action_log_journal">Log journal</string>
     <string name="action_breathe">Breathe</string>
 
+    <!-- Shared workout-start sheet and active-workout banner. Sport names come from the shared
+         WorkoutSport catalog and are tracked separately from this screen's UI chrome. -->
+    <string name="workout_start_title">Start a workout</string>
+    <string name="workout_search_sport">Search sport</string>
+    <string name="workout_recent">Recent</string>
+    <string name="workout_all_activities">All activities</string>
+    <string name="workout_track_gps_route">Track GPS route</string>
+    <string name="workout_start_selected">Start %1$s</string>
+    <string name="workout_gps_badge">· GPS</string>
+    <string name="workout_active_sport">● %1$s</string>
+    <string name="action_cancel">Cancel</string>
+    <string name="action_open">Open</string>
+    <string name="action_end">End</string>
+
     <!-- Today screen: header of the workouts feed. Renamed from "Last Workouts" ("Last" read as
          "final", #34/#53 follow-up); wording mirrored on iOS in Localizable.xcstrings. -->
     <string name="today_latest_workouts">Latest Workouts</string>


### PR DESCRIPTION
## Summary

Progresses #453 by localizing the Android workout-start sheet and active-workout banner.

## Why

`WorkoutStart.kt` passed its labels directly to Compose as English string literals, so Android could never translate that flow. This moves the screen's UI text through `stringResource()` and adds matching German resources.

## Changes

- Localize the workout picker title, search field, section labels, GPS control, and buttons.
- Localize the selected-sport start action and active-workout banner with formatted resources.
- Reuse the existing localized Start workout action where it already matches.
- Add German translations for every new key.

Sport names come from the shared `WorkoutSport` catalog and remain part of the wider #453 backlog; this PR covers the UI owned by `WorkoutStart.kt` without changing stored sport identifiers.

## Validation

- `git diff --check`
- `xmllint --noout android/app/src/main/res/values/strings.xml android/app/src/main/res/values-de/strings.xml`
- `python3 Tools/i18n_audit.py --platform android --ci upstream/main`
- `cd android && ./gradlew :app:testFullDebugUnitTest --tests 'com.noop.ui.GermanLocalizationTest' :app:compileFullDebugKotlin`
