### PR TITLE
Show dates when inspecting Android trend charts

### DIFF
--- a/android/app/src/main/java/com/noop/ui/Charts.kt
+++ b/android/app/src/main/java/com/noop/ui/Charts.kt
@@ -220,6 +220,9 @@ fun LineChart(
     // Optional per-point unix-second timestamps, index-aligned with [values]: when supplied, the
     // tap/drag pinpoint read-out prefixes the selected sample's local clock time ("14:32 · 87 bpm").
     timestamps: List<Long>? = null,
+    // Optional per-point display labels, index-aligned with [values]. Daily charts use this for a
+    // human-readable date prefix ("16 Jul · 87"); live charts keep using [timestamps].
+    selectionLabels: List<String>? = null,
 ) {
     val cleanValues = remember(values) { values.filter { it.isFinite() } }
     // Timestamps filtered by the SAME finiteness cut as cleanValues so indices stay aligned;
@@ -227,6 +230,10 @@ fun LineChart(
     val cleanTimestamps = remember(values, timestamps) {
         if (timestamps == null || timestamps.size != values.size) null
         else values.indices.filter { values[it].isFinite() }.map { timestamps[it] }
+    }
+    val cleanSelectionLabels = remember(values, selectionLabels) {
+        if (selectionLabels == null || selectionLabels.size != values.size) null
+        else values.indices.filter { values[it].isFinite() }.map { selectionLabels[it] }
     }
     var selectedIndex by remember(cleanValues) { mutableIntStateOf(-1) }
     val interactiveModifier = if (selectionEnabled) {
@@ -381,9 +388,10 @@ fun LineChart(
                             drawCircle(color = color, radius = 4.5f, center = p)
                             drawContext.canvas.nativeCanvas.apply {
                                 val label = lineChartSelectionLabel(
-                                    cleanValues[selectedIndex],
-                                    formatValue,
-                                    cleanTimestamps?.getOrNull(selectedIndex),
+                                    value = cleanValues[selectedIndex],
+                                    formatValue = formatValue,
+                                    epochSec = cleanTimestamps?.getOrNull(selectedIndex),
+                                    pointLabel = cleanSelectionLabels?.getOrNull(selectedIndex),
                                 )
                                 drawText(label, 8f, 32f, markerPaint)
                             }
@@ -455,16 +463,18 @@ private fun nearestIndexForX(count: Int, width: Float, x: Float): Int {
 }
 
 /** The tap/drag pinpoint label: the caller's display formatter when supplied (#463), else the raw
- *  near-integer-collapsing default. When the caller also supplies the sample's [epochSec] the local
- *  clock time PREFIXES the formatted value ("14:32 · 87 bpm"). Split out so both choices are
+ *  near-integer-collapsing default. A non-blank [pointLabel] prefixes the formatted value; otherwise
+ *  [epochSec] prefixes its local clock time ("14:32 · 87 bpm"). Split out so each choice is
  *  JVM-testable. */
 internal fun lineChartSelectionLabel(
     value: Double,
     formatValue: ((Double) -> String)?,
     epochSec: Long? = null,
     zone: ZoneId = ZoneId.systemDefault(),
+    pointLabel: String? = null,
 ): String {
     val base = formatValue?.invoke(value) ?: formatLineValue(value)
+    pointLabel?.takeIf { it.isNotBlank() }?.let { return "$it · $base" }
     if (epochSec == null) return base
     val time = Instant.ofEpochSecond(epochSec).atZone(zone).format(chartTickTimeFormat)
     return "$time · $base"

--- a/android/app/src/main/java/com/noop/ui/TrendsExploreScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/TrendsExploreScreen.kt
@@ -665,6 +665,7 @@ private fun HeroChartCard(
                                 color = metric.accent,
                                 fill = true,
                                 selectionEnabled = true,
+                                selectionLabels = windowed.map { prettyExploreDate(it.day) },
                             )
                             ExploreGlowEndCap(values = values, tipColor = metric.accent)
                         }
@@ -673,10 +674,7 @@ private fun HeroChartCard(
                     Row(modifier = Modifier.fillMaxWidth()) {
                         listOf(days.first(), days.getOrNull(days.lastIndex / 2), days.last()).forEach { d ->
                             Text(
-                                d?.let {
-                                    runCatching { LocalDate.parse(it).format(DateTimeFormatter.ofPattern("d MMM", Locale.US)) }
-                                        .getOrDefault(it)
-                                }.orEmpty(),
+                                prettyExploreDate(d),
                                 style = NoopType.footnote,
                                 color = Palette.textTertiary,
                                 modifier = Modifier.weight(1f),
@@ -714,6 +712,13 @@ private fun HeroChartCard(
         }
     }
 }
+
+/** ISO "yyyy-MM-dd" to the same compact date used by both the axis and selection label. */
+private fun prettyExploreDate(day: String?): String =
+    day?.let {
+        runCatching { LocalDate.parse(it).format(DateTimeFormatter.ofPattern("d MMM", Locale.US)) }
+            .getOrDefault(it)
+    }.orEmpty()
 
 @Composable
 private fun ChartFootItem(label: String, value: String) {

--- a/android/app/src/main/java/com/noop/ui/TrendsScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/TrendsScreen.kt
@@ -826,6 +826,7 @@ private fun ChartWithAxes(
                             // #463: the pinpoint label goes through the SAME formatter as the axis column,
                             // so a tapped Effort day can't print the stored 0-100 value beside a 0-21 axis.
                             formatValue = formatY,
+                            selectionLabels = dates.map(::prettyAxisDate),
                         )
                         GlowEndCap(values = values, tipColor = tipColor)
                     }

--- a/android/app/src/test/java/com/noop/ui/ChartSelectionLabelTest.kt
+++ b/android/app/src/test/java/com/noop/ui/ChartSelectionLabelTest.kt
@@ -6,8 +6,8 @@ import org.junit.Test
 /**
  * The LineChart tap/drag pinpoint label (#463). The overlay used to draw the RAW plotted value
  * unconditionally, so on Trends' Effort chart a tapped day printed the stored 0-100 figure (a bare
- * "13") beside a 0-21 converted axis. Callers can now inject the same formatter the axis uses;
- * with no formatter the raw near-integer-collapsing default is unchanged.
+ * "13") beside a 0-21 converted axis. Callers can inject the same formatter the axis uses and
+ * prefix a selected daily point with its date; with neither, the raw default is unchanged.
  */
 class ChartSelectionLabelTest {
 
@@ -43,5 +43,20 @@ class ChartSelectionLabelTest {
 
     @Test fun withoutATimestampTheLabelIsUnchanged() {
         assertEquals("87", lineChartSelectionLabel(87.0, null, null))
+    }
+
+    @Test fun aSuppliedPointLabelPrefixesTheFormattedValue() {
+        assertEquals(
+            "16 Jul · 87 bpm",
+            lineChartSelectionLabel(
+                value = 87.2,
+                formatValue = { "${it.toInt()} bpm" },
+                pointLabel = "16 Jul",
+            ),
+        )
+    }
+
+    @Test fun aBlankPointLabelLeavesTheValueUnchanged() {
+        assertEquals("87", lineChartSelectionLabel(87.0, null, pointLabel = ""))
     }
 }


### PR DESCRIPTION
## Summary

Addresses item 10 in #492: Android trend-chart selection now shows the selected date alongside the value, for example `16 Jul · 87`.

## Root cause

The shared `LineChart` selection overlay accepted values and optional live timestamps, but the daily Trends and Explore charts did not have a way to pass their already-aligned date lists. Selecting a point therefore showed only its value.

## Changes

- Add optional per-point display labels to `LineChart`.
- Keep labels aligned when non-finite values are filtered from the plotted series.
- Pass the same compact dates used by the x-axis from Trends and Explore.
- Extend `ChartSelectionLabelTest` for date prefixes and blank-label fallback.

The new metadata is optional. Existing callers remain unchanged, and live charts continue using their timestamp-based labels.

## Validation

- `git diff --check`
- `cd android && ./gradlew :app:testFullDebugUnitTest --tests 'com.noop.ui.ChartSelectionLabelTest' :app:compileFullDebugKotlin`
