### PR TITLE
Today pull-to-sync: iOS/macOS twin of #426 + fix Android stale enabled-gate

### DIFF
--- a/Strand/App/StrandApp.swift
+++ b/Strand/App/StrandApp.swift
@@ -33,6 +33,7 @@ struct StrandApp: App {
         WindowGroup {
             ContentView()
                 .environmentObject(model)
+                .environmentObject(model.ble)   // #334: Today pull-to-sync reads BLEManager (no HR churn)
                 .environmentObject(model.live)
                 .environmentObject(model.repo)
                 .environmentObject(model.profile)

--- a/Strand/Liquid/LiquidTodayView.swift
+++ b/Strand/Liquid/LiquidTodayView.swift
@@ -20,6 +20,11 @@ struct LiquidTodayView: View {
     @EnvironmentObject var repo: Repository
     @EnvironmentObject var router: NavRouter
     @EnvironmentObject var profile: ProfileStore
+    // For the pull-to-sync gesture (#334): a pull kicks a manual strap history offload via ble.syncNow().
+    // Observe BLEManager, NOT AppModel — AppModel @Publishes `bpm` on the ~1 Hz HR tick, so observing it
+    // would re-render all of Today every second (the exact churn the LiveState leaves isolate). BLEManager
+    // only publishes connect/discovery state, never HR. Injected at the app roots beside .environmentObject(model).
+    @EnvironmentObject var ble: BLEManager
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     /// Shared with the real Today's card-customise editor so the two stay in sync.
@@ -375,6 +380,11 @@ struct LiquidTodayView: View {
             refreshArmed = false
             refreshing = true
             Task {
+                // #334 (iOS twin of Android #426): a pull requests a fresh strap history offload, not just
+                // a UI reload. syncNow() is internally gated (connected + bonded + not-already-backfilling),
+                // so a pull while disconnected or mid-offload safely no-ops. The sync status chip owns the
+                // ongoing offload progress; the pull spinner stays short (the reload below).
+                ble.syncNow()
                 await repo.refresh()
                 await load()
                 try? await Task.sleep(nanoseconds: 350_000_000)   // let the fill read as "done"

--- a/StrandiOS/App/StrandiOSApp.swift
+++ b/StrandiOS/App/StrandiOSApp.swift
@@ -63,6 +63,7 @@ struct StrandiOSApp: App {
         WindowGroup {
             iOSRootView()
                 .environmentObject(model)
+                .environmentObject(model.ble)   // #334: Today pull-to-sync reads BLEManager (no HR churn)
                 .environmentObject(model.live)
                 .environmentObject(model.repo)
                 .environmentObject(model.profile)

--- a/android/app/src/main/java/com/noop/ui/TodayScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/TodayScreen.kt
@@ -1050,7 +1050,15 @@ fun TodayScreen(
         )
     }
     val canPullToSync = todayPullToSyncEnabled(liveSnap.connected, liveSnap.bonded, liveSnap.backfilling)
-    val pullToSyncState = rememberPullToRefreshState(enabled = { canPullToSync })
+    // material3 1.2.1's rememberPullToRefreshState CAPTURES the `enabled` lambda ONCE (rememberSaveable,
+    // no rememberUpdatedState), so `{ canPullToSync }` would freeze the plain Boolean from the FIRST
+    // composition — and Today usually first composes before the strap has (re)connected, leaving the
+    // gesture permanently disabled for the session. Read the stable `liveSnap` State live inside the lambda
+    // instead, so each gesture check sees the current connected/bonded/backfilling. (syncNow is triple-gated
+    // anyway; this just makes the gesture actually enable once the strap is ready.)
+    val pullToSyncState = rememberPullToRefreshState(
+        enabled = { todayPullToSyncEnabled(liveSnap.connected, liveSnap.bonded, liveSnap.backfilling) },
+    )
     LaunchedEffect(pullToSyncState.isRefreshing, canPullToSync) {
         if (pullToSyncState.isRefreshing) {
             if (canPullToSync) viewModel.syncNow()


### PR DESCRIPTION
iOS twin of #426 (Android Today pull-to-sync), which just merged.

## The gap
iOS `LiquidTodayView` **already had a pull gesture** (`handlePull`), but on release it only reloaded UI data (`repo.refresh() + load()`) — it **never requested a fresh strap history sync**. So an Apple user pulling on Today got a UI refresh, not the strap offload Android's pull kicks.

## Fix (minimal — hook the existing gesture)
Wire `model.ble.syncNow()` into the existing refresh action in `handlePull`. Now a pull requests a manual strap offload *and* reloads, matching Android.

- **Same safety as Android:** `syncNow()` is internally gated — it guards `connected && bonded` and no-ops if already `backfilling` (`BLEManager:2535`), the exact guard Android routes through `WhoopBleClient.canRequestSync`. A pull while disconnected or mid-offload safely does nothing.
- **No perf regression:** added `@EnvironmentObject var model: AppModel` to the top view — but AppModel (unlike `LiveState`) doesn't publish on the ~1 Hz HR tick, so it doesn't reintroduce the per-tick Today re-render the LiveState leaves deliberately avoid.
- **Shared file** → fixes **macOS** too. All 3 render sites (`RootView`, `RootTabView`) are under `StrandApp`'s `model` injection, so the environment object always resolves.

## Verification
- App-target Swift (no default CI) → validated via `app-build` (below).
- ⚠️ It's a BLE + gesture path — compile-green, but the pull-triggers-a-real-offload behavior should be confirmed on a real strap (Linux/CI can't).

Fixes #334 for Apple; Android side shipped in #426.