### PR TITLE
Keep Compare add-metric action readable on narrow screens

### DIFF
--- a/android/app/src/main/java/com/noop/ui/CompareScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/CompareScreen.kt
@@ -476,17 +476,24 @@ fun CompareScreen(vm: AppViewModel) {
             SectionHeader("Metrics", overline = "Overlay 2-4 signals")
             NoopCard {
                 Column(verticalArrangement = Arrangement.spacedBy(Metrics.gap)) {
-                    Row(verticalAlignment = Alignment.CenterVertically) {
-                        SegmentedPillControl(
-                            items = CompareRange.entries.toList(),
-                            selection = range,
-                            label = { it.label },
-                            onSelect = {
-                                range = it
-                                ComparePrefs.writeRange(context, it)
-                            },
-                        )
-                        Spacer(Modifier.weight(1f))
+                    SegmentedPillControl(
+                        items = CompareRange.entries.toList(),
+                        selection = range,
+                        label = { it.label },
+                        onSelect = {
+                            range = it
+                            ComparePrefs.writeRange(context, it)
+                        },
+                    )
+
+                    // #492: this used to share a row with the segmented range picker. On narrow
+                    // screens the picker consumed the width and collapsed "Add metric" into a
+                    // one-character-wide column. Give the action its own trailing-aligned row so
+                    // both controls retain their intended intrinsic width.
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.End,
+                    ) {
                         AddMetricMenu(
                             selectedCount = selected.size,
                             maxSelection = maxSelection,
@@ -626,6 +633,7 @@ private fun AddMetricMenu(
                 if (atMax) "Max 4" else "Add metric",
                 style = NoopType.subhead,
                 color = tint,
+                maxLines = 1,
             )
         }
 


### PR DESCRIPTION
Progresses #492 (item 6).

## What changed

- Move the Android Compare screen's **Add metric** action below the range selector into its own full-width, trailing-aligned row.
- Keep the action label to a single line.
- Preserve the existing metric-selection limit, dropdown, and persistence behavior.

## Why

The range selector and Add metric action previously shared one horizontal row. On narrow screens the segmented control consumed most of the available width, squeezing the action until “Add metric” wrapped one character per line.

Giving each control its own row lets both retain their intrinsic width and keeps the metric card readable across supported Android widths.

## Validation

- `./gradlew compileFullDebugKotlin`
- `./gradlew testFullDebugUnitTest`
- `python3 Tools/i18n_audit.py --platform android --ci upstream/main`
- `git diff --check`

A final narrow-device visual check is recommended because this is a responsive-layout change.
