### PR TITLE
CI: ad-hoc codesign the macOS .app so it can hold a Bluetooth TCC grant (#429)

### DIFF
--- a/.github/workflows/fork-release.yml
+++ b/.github/workflows/fork-release.yml
@@ -213,6 +213,14 @@ jobs:
         run: |
           APP=$(find build/dd/Build/Products -maxdepth 3 -name '*.app' -type d | head -1)
           test -n "$APP" || { echo ".app not found"; exit 1; }
+          # #429: ad-hoc sign the BUNDLE so it has a stable per-build code identity. macOS 26 (Tahoe) won't
+          # bind a Bluetooth TCC grant to an UNSIGNED bundle, so users wedge at CBManagerState .unauthorized
+          # even after a fresh `tccutil reset` + approve. `--sign -` gives a real cdhash-based designated
+          # requirement TCC can grant to. No --entitlements / --options runtime: stays non-sandboxed so BT
+          # goes through plain TCC + the Info.plist usage string. (cdhash still changes per build, so a
+          # future UPDATE still needs the re-toggle the in-app #429/#295 banner already describes.)
+          codesign --force --deep --sign - "$APP"
+          codesign -dvv "$APP" 2>&1 | grep -Ei 'identifier|signature|flags' || true
           ditto -c -k --keepParent "$APP" "NOOP-macos-v${VER}.zip"
           gh release upload "${{ needs.bump.outputs.tag }}" "NOOP-macos-v${VER}.zip" --repo "$GITHUB_REPOSITORY" --clobber
 

--- a/.github/workflows/fork-testing-build.yml
+++ b/.github/workflows/fork-testing-build.yml
@@ -44,7 +44,7 @@ jobs:
 
           - **Android (release)** — \`NOOP-android-v${VER}.apk\` — optimized, non-debuggable build; installs beside the official app. \`com.noop.whoop.staging\`.
           - **Android (debug)** — \`NOOP-android-debug-v${VER}.apk\` — debuggable build. \`com.noop.whoop.debug\`.
-          - **macOS** — \`NOOP-macos-v${VER}.zip\` — unzip, then **right-click → Open** (unsigned; Gatekeeper warns once).
+          - **macOS** — \`NOOP-macos-v${VER}.zip\` — unzip, then **right-click → Open** (ad-hoc signed, not notarized; Gatekeeper warns once). If it says *\"damaged\"*, run \`xattr -dr com.apple.quarantine /Applications/NOOP.app\`.
           - **iOS** — \`NOOP-ios-unsigned-v${VER}.ipa\` — sideload via **AltStore / Sideloadly** (re-signs on-device); embedded watch app + widget extension stripped for free-account install reliability.
 
           Base app version ${VER} · built ${DATE} · \`${SHA}\`."
@@ -115,6 +115,14 @@ jobs:
         run: |
           APP=$(find build/dd/Build/Products -maxdepth 3 -name '*.app' -type d | head -1)
           test -n "$APP" || { echo ".app not found"; exit 1; }
+          # #429: ad-hoc sign the BUNDLE so it has a stable per-build code identity. macOS 26 (Tahoe) won't
+          # bind a Bluetooth TCC grant to an UNSIGNED bundle, so users wedge at CBManagerState .unauthorized
+          # even after a fresh `tccutil reset` + approve. `--sign -` gives a real cdhash-based designated
+          # requirement TCC can grant to. No --entitlements / --options runtime: stays non-sandboxed so BT
+          # goes through plain TCC + the Info.plist usage string. (cdhash still changes per build, so a
+          # future UPDATE still needs the re-toggle the in-app #429/#295 banner already describes.)
+          codesign --force --deep --sign - "$APP"
+          codesign -dvv "$APP" 2>&1 | grep -Ei 'identifier|signature|flags' || true
           ditto -c -k --keepParent "$APP" "NOOP-macos-v${VER}.zip"
           gh release upload "${{ needs.meta.outputs.tag }}" "NOOP-macos-v${VER}.zip" --repo "$GITHUB_REPOSITORY" --clobber
 


### PR DESCRIPTION
Fixes #429 (pending on-device confirmation).

## Problem
The macOS testing + release builds ship the `.app` **fully unsigned** (`CODE_SIGN_IDENTITY=""`, no post-build `codesign`). On **macOS 26 (Tahoe)** TCC won't bind a Bluetooth grant to a bundle with **no code identity**, so the central wedges at `CBManagerState .unauthorized` — the user gets "Strap disconnected / Offline," and crucially a **fresh** `tccutil reset Bluetooth` + re-approve **doesn't stick**, because there's no designated requirement for the grant to attach to.

That's the case AussieFries hit on **macOS 26.5.2** in #429 — distinct from the "grant lost on update" churn already handled in-app (the re-toggle banner), which is why the standard workaround didn't help.

## Fix
Ad-hoc sign the bundle right after the build, before packaging, in **both** `fork-testing-build.yml` and `fork-release.yml`:
```bash
codesign --force --deep --sign - "$APP"
```
The bundle now has a real cdhash-based **designated requirement** that macOS 26's TCC can grant Bluetooth to.

- **No `--entitlements` / no `--options runtime`** — deliberately keeps it non-sandboxed (matching today's build), so BT goes through plain TCC + the `NSBluetoothAlwaysUsageDescription` already in the Info.plist. Adding the sandbox entitlement would *require* the BT entitlement and complicate it.
- The cdhash still changes per build, so a future **update** still needs the Settings → Bluetooth re-toggle the in-app #429/#295 banner already describes. This fixes the *fresh-grant-never-sticks* case the re-toggle can't.

## Verification
- Both workflow YAMLs parse (validated).
- ⚠️ **Needs on-device confirmation on macOS 26** — I can't exercise TCC from CI. The plan: merge → cut a staging build → have AussieFries install it and confirm the central reaches `state 5` after approving the prompt.

Reported by AussieFries.