### PR TITLE
Android BLE: escalate reconnect to PASSIVE by link state, not attempt count (#313)

### DIFF
--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -450,6 +450,20 @@ class WhoopBleClient(
             if (attempts >= SCAN_POWER_BACKOFF_THRESHOLD) ScanSettings.SCAN_MODE_BALANCED
             else ScanSettings.SCAN_MODE_LOW_LATENCY
 
+        /** #313: escalate a reconnect to PASSIVE (autoConnect=true) by WHY the link is down, not just the
+         *  attempt count. A strap the OS still holds ACL-connected — co-resident with the official WHOOP
+         *  app — never re-emits the advertisement / connection-complete that autoConnect waits for, so
+         *  PASSIVE STALLS it (frozen keep-alive battery poll + stopped offload) no matter how high the
+         *  attempt count climbs; only fast DIRECT reconnect recovers it. So keep an ACL-held band on DIRECT;
+         *  only a genuinely-out-of-range band (not ACL-held) falls back to PASSIVE past [threshold], where
+         *  autoConnect is the correct power-efficient choice (#61). This replaces the old plain
+         *  `failedAttempts >= 3` — which #265 kept alive only because a co-resident band usually flaps
+         *  through STATE_CONNECTED and zeroes the counter; a band that fails BEFORE STATE_CONNECTED for
+         *  [threshold]+ attempts hit the same stall. Pure, so the discrimination is pinned without a BLE
+         *  stack (the [scanModeForReconnectAttempts] idiom). */
+        fun passiveReconnectDecision(failedAttempts: Int, aclHeld: Boolean, threshold: Int = 3): Boolean =
+            failedAttempts >= threshold && !aclHeld
+
         /** Pure GATT connection-priority decision (battery, #477), unit-testable without a BLE stack
          *  (the [scanModeForReconnectAttempts] idiom). TWO independent halves, split by risk:
          *   - SAFE (always, once management is on): escalate to HIGH during an offload burst or a
@@ -2841,15 +2855,27 @@ class WhoopBleClient(
         }
     }
 
-    /** The OS-bonded 5/MG-family strap, if any (name "WHOOP …" but not "WHOOP 4…" — MG-named units
-     *  match too). Fails open to a scan on any lookup problem. (#78 fork) */
+    /** #313: does the OS still hold [address]'s ACL? getConnectedDevices returns a band the OS keeps
+     *  GATT-connected — co-resident with the official WHOOP app — even after it stops advertising, so this
+     *  is the "contended, not out of range" signal. Model-agnostic (4.0 + 5.0), matched by exact address.
+     *  Fails SAFE to false (→ normal attempt-count escalation, the pre-#313 behaviour) on any lookup issue,
+     *  so a detection gap can never be worse than before. */
     @SuppressLint("MissingPermission")
-    /**
+    private fun isStrapAclHeld(address: String): Boolean = try {
+        bluetoothManager?.getConnectedDevices(BluetoothProfile.GATT)
+            ?.any { it.address.equals(address, ignoreCase = true) } == true
+    } catch (se: SecurityException) {
+        false
+    }
+
+    /** The OS-bonded 5/MG-family strap, if any (name "WHOOP …" but not "WHOOP 4…" — MG-named units
+     *  match too). Fails open to a scan on any lookup problem. (#78 fork)
+     *
      * A WHOOP 5/MG the OS already holds GATT-connected. Android multiplexes one ACL across GATT clients, so
      * a band connected to another app is still returned by getConnectedDevices even after it stops
      * advertising, and a client can attach to it without a scan. Uses the same 5/MG name filter and
-     * multi-strap pin selection as [bondedWhoopDevice]; a WHOOP 4 is excluded and left to the scan.
-     */
+     * multi-strap pin selection as [bondedWhoopDevice]; a WHOOP 4 is excluded and left to the scan. */
+    @SuppressLint("MissingPermission")
     private fun getConnectedWhoopDevice(): BluetoothDevice? = try {
         val connected = bluetoothManager?.getConnectedDevices(BluetoothProfile.GATT)?.filter { d ->
             val n = try { d.name } catch (se: SecurityException) { null } ?: return@filter false
@@ -5633,8 +5659,12 @@ class WhoopBleClient(
                 // so the passive mode stalls. Fall back to autoConnect=true from the third attempt for a
                 // strap that is genuinely out of range (#61: reconnect once it returns to range, with no
                 // scan or advertisement needed).
-                val passiveReconnect = failedReconnectAttempts >= 3
-                log("Disconnected (status=$status); reconnecting ${if (passiveReconnect) "passively" else "directly"} in ${directDelay / 1000}s (attempt $failedReconnectAttempts)")
+                // #313: don't escalate to PASSIVE on attempt count alone. A band the OS still holds
+                // ACL-connected (co-resident with the WHOOP app) stalls under autoConnect regardless of
+                // count — keep it DIRECT; only a genuinely-out-of-range band escalates to PASSIVE for power.
+                val aclHeld = isStrapAclHeld(dev.address)
+                val passiveReconnect = passiveReconnectDecision(failedReconnectAttempts, aclHeld)
+                log("Disconnected (status=$status); reconnecting ${if (passiveReconnect) "passively" else "directly"} in ${directDelay / 1000}s (attempt $failedReconnectAttempts${if (aclHeld) ", ACL-held" else ""})")
                 // #1030 (ryanbr): cancellable backoff timer (see scheduleReconnect).
                 scheduleReconnect(directDelay) { connectToDevice(dev, autoConnect = passiveReconnect) }
             } else {

--- a/android/app/src/test/java/com/noop/ble/PassiveReconnectDecisionTest.kt
+++ b/android/app/src/test/java/com/noop/ble/PassiveReconnectDecisionTest.kt
@@ -1,0 +1,47 @@
+package com.noop.ble
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * The reconnect DIRECT-vs-PASSIVE escalation (#313). PASSIVE (autoConnect=true) is correct + power-efficient
+ * for a strap that's genuinely OUT OF RANGE, but it STALLS on a band the OS still holds ACL-connected
+ * (co-resident with the official WHOOP app) — it never re-emits the advert/connection-complete autoConnect
+ * waits for, so the keep-alive battery poll + offload freeze. #265 masked this only when a co-resident band
+ * flapped through STATE_CONNECTED (zeroing the counter); a band that fails BEFORE STATE_CONNECTED for 3+
+ * attempts hit the same stall. These pin [WhoopBleClient.passiveReconnectDecision] so the ACL-held → stay
+ * DIRECT rule can't silently regress. The by-address ACL lookup itself needs a live BLE stack; the decision
+ * is pure.
+ */
+class PassiveReconnectDecisionTest {
+
+    @Test
+    fun staysDirect_belowThreshold() {
+        // Early attempts are always fast DIRECT (unchanged from the old `>= 3`).
+        assertFalse(WhoopBleClient.passiveReconnectDecision(failedAttempts = 0, aclHeld = false))
+        assertFalse(WhoopBleClient.passiveReconnectDecision(failedAttempts = 2, aclHeld = false))
+    }
+
+    @Test
+    fun escalatesToPassive_atThreshold_whenOutOfRange() {
+        // Genuinely out of range (not ACL-held): PASSIVE autoConnect is correct — reconnect once back
+        // in range, no scan, power-efficient.
+        assertTrue(WhoopBleClient.passiveReconnectDecision(failedAttempts = 3, aclHeld = false))
+        assertTrue(WhoopBleClient.passiveReconnectDecision(failedAttempts = 9, aclHeld = false))
+    }
+
+    @Test
+    fun staysDirect_whenAclHeld_evenPastThreshold() {
+        // THE #313 fix: a co-resident/ACL-held band NEVER goes PASSIVE, no matter how high the count —
+        // PASSIVE stalls it; only DIRECT recovers.
+        assertFalse(WhoopBleClient.passiveReconnectDecision(failedAttempts = 3, aclHeld = true))
+        assertFalse(WhoopBleClient.passiveReconnectDecision(failedAttempts = 50, aclHeld = true))
+    }
+
+    @Test
+    fun thresholdIsConfigurable() {
+        assertFalse(WhoopBleClient.passiveReconnectDecision(failedAttempts = 4, aclHeld = false, threshold = 5))
+        assertTrue(WhoopBleClient.passiveReconnectDecision(failedAttempts = 5, aclHeld = false, threshold = 5))
+    }
+}


### PR DESCRIPTION
Fixes #313 (pending on-strap validation).

## Problem
The reconnect escalation in `WhoopBleClient.handleDisconnect` was purely count-based:
```kotlin
val passiveReconnect = failedReconnectAttempts >= 3
```
That conflates two states:
- **genuinely out of range** → PASSIVE `autoConnect` is correct + power-efficient;
- **ACL-held / co-resident** (the official WHOOP app holds the band) → PASSIVE **stalls** (the band never re-emits the advert/connection-complete `autoConnect` waits for), freezing the keep-alive battery poll + offload.

#265 only masked this because a co-resident band *usually* flaps through `STATE_CONNECTED` and zeroes the counter. A band that **fails before reaching `STATE_CONNECTED`** for 3+ attempts still climbs to 3 → PASSIVE → the same stall.

## Fix — escalate by *why* the link is down
- New pure, unit-tested `WhoopBleClient.passiveReconnectDecision(failedAttempts, aclHeld, threshold=3)` = `failedAttempts >= threshold && !aclHeld`.
- New by-address `isStrapAclHeld(address)` built on `getConnectedDevices(BluetoothProfile.GATT)` — which returns a band the OS still holds ACL-connected **even after it stops advertising** (the file's own `getConnectedWhoopDevice` comment already relies on this). Model-agnostic (4.0 + 5.0), by exact address.
- An **ACL-held band stays DIRECT** (recovers fast); a **genuinely out-of-range band still escalates to PASSIVE at 3** (unchanged, power-efficient).

**Self-correcting:** if an ACL-held band later drops its ACL (goes out of range), `getConnectedDevices` stops returning it → `aclHeld=false` → it escalates to PASSIVE. And `isStrapAclHeld` **fails safe to `false`** (→ the pre-#313 attempt-count behaviour), so a detection gap can never be worse than before.

## Scope
- **Android-only** — iOS `BLEManager` has plain capped-exponential backoff with no DIRECT/PASSIVE escalation, so there's no analogue.
- Out-of-range behaviour is byte-identical to before; the only change is ACL-held bands no longer wrongly escalate to PASSIVE.

## Verification
- `compileFullDebugKotlin` + `PassiveReconnectDecisionTest` (4 cases) green.
- ⚠️ **BLE lifecycle is hardware-only-testable** — the pure decision is pinned, but the actual recovery needs on-strap validation with the **WHOOP app co-resident on both a 4.0 and a 5.0** before merge (as the issue notes). I can't do that from here.