### PR TITLE
Keep Android Stress marker values readable

### DIFF
--- a/android/app/src/main/java/com/noop/ui/Components.kt
+++ b/android/app/src/main/java/com/noop/ui/Components.kt
@@ -494,9 +494,9 @@ fun StatTile(
     deltaColor: Color = Palette.textTertiary,
     tint: Color? = null,
     // When true, the trailing delta chip yields width to the value instead of taking its full
-    // intrinsic size. Used by the workout tiles, where a wide kcal chip (e.g. "1234 kcal") was
-    // starving the duration column and clipping it to "4…"/"2…" on narrow phones (#332). The
-    // default keeps the sparkline key-metric tiles (Rest/Respiratory/HRV) exactly as they were.
+    // intrinsic size. Used by narrow two-column tiles where a wide chip (e.g. "1234 kcal" or
+    // "+10 vs base") would otherwise starve the reading column and clip its value. The default
+    // keeps callers that have enough width exactly as they were.
     compactDelta: Boolean = false,
 ) {
     // Each tile borrows its accent as a faint card wash, so a metric reads as part of its
@@ -522,7 +522,7 @@ fun StatTile(
                     Spacer(Modifier.width(8.dp))
                     // In compact mode the chip shares the row's remaining space (fill = false, so it
                     // never grows past its content) — this guarantees the weighted value column keeps
-                    // its half and the duration reads in full beside the kcal chip (#332).
+                    // its half and the primary reading remains intact beside a wide chip (#332/#492).
                     TrendChip(
                         text = delta,
                         color = deltaColor,

--- a/android/app/src/main/java/com/noop/ui/StressScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/StressScreen.kt
@@ -953,6 +953,10 @@ private fun MarkerTile(
         accent = accent,
         delta = deltaText,
         deltaColor = deltaColor,
+        // #492 item 5: on narrow two-column cards the intrinsic-width "vs base" chip used to consume
+        // nearly the whole row and leave the reading as "4…" / "73…". Share the row evenly so the real
+        // physiological value stays intact; the explanatory chip is the element allowed to ellipsize.
+        compactDelta = true,
     )
 }
 


### PR DESCRIPTION
## What changed

- opt the two Android Stress baseline marker cards into `StatTile`'s balanced value/delta layout
- update the shared component documentation to describe the narrow-card behavior

## Why

On narrow two-column cards, the intrinsic-width `vs base` chip consumed nearly the entire value row. Real readings such as `48` and `73` were consequently rendered as `4…` and `73…`.

The balanced mode gives the primary value half of the row and allows the explanatory chip to compress. Other `StatTile` callers retain their existing layout.

Addresses #492, item 5.

## Validation

- `./gradlew :app:testFullDebugUnitTest --tests 'com.noop.ui.StressModelTest'`
- full-debug Kotlin compilation completed as part of the test task
- `git diff --check`
