### PR TITLE
Clarify phone heart-rate broadcast copy

### DIFF
--- a/android/app/src/main/java/com/noop/ui/DataSourcesScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/DataSourcesScreen.kt
@@ -700,7 +700,8 @@ fun DataSourcesScreen(vm: AppViewModel) {
             subtitle = "Re-share your live strap heart rate over Bluetooth as a standard heart-rate " +
                 "sensor, so a gym treadmill, bike, Zwift, Peloton or any fitness app nearby can read " +
                 "it. Works on any WHOOP (4.0 or 5.0/MG) because your phone does the broadcasting. " +
-                "Local Bluetooth only. Nothing leaves your phone. Off by default.",
+                "If your strap or watch already broadcasts HR directly to another device, leave this " +
+                "off. Local Bluetooth only. Nothing leaves your phone. Off by default.",
         ) {
             if (hrBroadcast) {
                 val (label, tone) =
@@ -732,8 +733,7 @@ fun DataSourcesScreen(vm: AppViewModel) {
                 Column(modifier = Modifier.weight(1f)) {
                     Text(uiString(R.string.l10n_data_sources_screen_broadcast_hr_from_this_phone_10e5605c), style = NoopType.subhead, color = Palette.textPrimary)
                     Text(
-                        uiString(R.string.l10n_data_sources_screen_acts_as_a_standard_bluetooth_heart_f8d13439) +
-                            "bike or app to see your strap's heart rate there.",
+                        uiString(R.string.l10n_data_sources_screen_acts_as_a_standard_bluetooth_heart_f8d13439),
                         style = NoopType.footnote,
                         color = Palette.textTertiary,
                     )
@@ -775,9 +775,7 @@ fun DataSourcesScreen(vm: AppViewModel) {
                         modifier = Modifier.size(16.dp),
                     )
                     Text(
-                        uiString(R.string.l10n_data_sources_screen_broadcast_hr_is_on_your_strap_0ad5368a) +
-                            "which keeps its radio hot and drains the battery faster. Turn it off when " +
-                            "you're not using it with another device.",
+                        uiString(R.string.l10n_data_sources_screen_broadcast_hr_is_on_your_strap_0ad5368a),
                         style = NoopType.caption,
                         color = Palette.statusWarning,
                     )

--- a/android/app/src/main/res/values-de/strings.xml
+++ b/android/app/src/main/res/values-de/strings.xml
@@ -340,13 +340,13 @@
     <string name="l10n_coupled_screen_no_sleep_tracked_last_night_cd0dd79e">Letzte Nacht kein Schlaf erfasst</string>
     <string name="l10n_coupled_screen_recovery_b668d988">ERHOLUNG</string>
     <string name="l10n_coupled_screen_sleep_performance_4611539f">SCHLAFLEISTUNG</string>
-    <string name="l10n_data_sources_screen_acts_as_a_standard_bluetooth_heart_f8d13439">Agiert als Standard-Bluetooth-Herzfrequenzband. Paar NOOP von Ihrem Laufband,</string>
+    <string name="l10n_data_sources_screen_acts_as_a_standard_bluetooth_heart_f8d13439">Funktioniert wie ein standardmäßiger Bluetooth-Herzfrequenzsensor. Kopple NOOP mit deinem Laufband, Fahrrad oder deiner App nur, wenn dein Smartphone die Herzfrequenz deines Sensors erneut senden soll.</string>
     <string name="l10n_data_sources_screen_apple_health_b19b87da">Apple Health</string>
     <string name="l10n_data_sources_screen_auto_sync_health_connect_periodically_6f3f4d92">Auto-Sync Health Connect regelmäßig</string>
     <string name="l10n_data_sources_screen_auto_sync_periodically_5f3041e8">Auto-Sync periodisch</string>
     <string name="l10n_data_sources_screen_broadcast_heart_rate_as_a_bluetooth_6a44fdb4">Herzfrequenz als Bluetooth-Sensor senden</string>
     <string name="l10n_data_sources_screen_broadcast_hr_from_this_phone_10e5605c">Broadcast HR von diesem Telefon</string>
-    <string name="l10n_data_sources_screen_broadcast_hr_is_on_your_strap_0ad5368a">Broadcast HR ist an. Dein Riemen wirbt ständig für seine Herzfrequenz,</string>
+    <string name="l10n_data_sources_screen_broadcast_hr_is_on_your_strap_0ad5368a">Herzfrequenzübertragung ist EIN. Dieses Smartphone sendet kontinuierlich die Herzfrequenz, wodurch Bluetooth aktiv bleibt und der Akku schneller entladen wird. Schalte die Funktion aus, wenn du sie nicht mit einem anderen Gerät verwendest.</string>
     <string name="l10n_data_sources_screen_cancel_77dfd213">Abbrechen</string>
     <string name="l10n_data_sources_screen_data_sources_5e43d6bb">Datenquellen</string>
     <string name="l10n_data_sources_screen_every_3560d90b">Alle</string>

--- a/android/app/src/main/res/values-es/strings.xml
+++ b/android/app/src/main/res/values-es/strings.xml
@@ -185,13 +185,13 @@
     <string name="l10n_coupled_screen_no_sleep_tracked_last_night_cd0dd79e">No hay sueño rastreado anoche</string>
     <string name="l10n_coupled_screen_recovery_b668d988">RECOVERY</string>
     <string name="l10n_coupled_screen_sleep_performance_4611539f">SLEEP PERFORMANCE</string>
-    <string name="l10n_data_sources_screen_acts_as_a_standard_bluetooth_heart_f8d13439">Actúa como una correa de frecuencia cardíaca Bluetooth estándar. Par NOOP de su cinta de correr,</string>
+    <string name="l10n_data_sources_screen_acts_as_a_standard_bluetooth_heart_f8d13439">Funciona como un sensor de frecuencia cardíaca Bluetooth estándar. Vincula NOOP desde tu cinta de correr, bicicleta o aplicación solo cuando necesites que el teléfono retransmita la frecuencia cardíaca de tu sensor.</string>
     <string name="l10n_data_sources_screen_apple_health_b19b87da">Apple Health</string>
     <string name="l10n_data_sources_screen_auto_sync_health_connect_periodically_6f3f4d92">Auto-sync Health Connect periodic</string>
     <string name="l10n_data_sources_screen_auto_sync_periodically_5f3041e8">Auto-sinc periódicamente</string>
     <string name="l10n_data_sources_screen_broadcast_heart_rate_as_a_bluetooth_6a44fdb4">Difundir la frecuencia cardíaca como sensor Bluetooth</string>
     <string name="l10n_data_sources_screen_broadcast_hr_from_this_phone_10e5605c">Broadcast HR desde este teléfono</string>
-    <string name="l10n_data_sources_screen_broadcast_hr_is_on_your_strap_0ad5368a">RRHH está encendida. Su correa está publicando su frecuencia cardíaca continuamente,</string>
+    <string name="l10n_data_sources_screen_broadcast_hr_is_on_your_strap_0ad5368a">La transmisión de frecuencia cardíaca está ACTIVADA. Este teléfono transmite la frecuencia cardíaca continuamente, lo que mantiene Bluetooth activo y consume la batería más rápido. Desactívala cuando no la uses con otro dispositivo.</string>
     <string name="l10n_data_sources_screen_cancel_77dfd213">Cancelar</string>
     <string name="l10n_data_sources_screen_data_sources_5e43d6bb">Fuentes de datos</string>
     <string name="l10n_data_sources_screen_every_3560d90b">Cada uno</string>

--- a/android/app/src/main/res/values-fr/strings.xml
+++ b/android/app/src/main/res/values-fr/strings.xml
@@ -185,13 +185,13 @@
     <string name="l10n_coupled_screen_no_sleep_tracked_last_night_cd0dd79e">Pas de sommeil suivi hier soir</string>
     <string name="l10n_coupled_screen_recovery_b668d988">RECOUVREMENT</string>
     <string name="l10n_coupled_screen_sleep_performance_4611539f">PERFORMANCE DOUCE</string>
-    <string name="l10n_data_sources_screen_acts_as_a_standard_bluetooth_heart_f8d13439">Fonctionne comme une sangle de fréquence cardiaque Bluetooth standard. Paire NOOP de votre tapis roulant,</string>
+    <string name="l10n_data_sources_screen_acts_as_a_standard_bluetooth_heart_f8d13439">Fonctionne comme un capteur de fréquence cardiaque Bluetooth standard. Associez NOOP à votre tapis de course, vélo ou application uniquement lorsque le téléphone doit rediffuser la fréquence cardiaque de votre capteur.</string>
     <string name="l10n_data_sources_screen_apple_health_b19b87da">Apple Santé</string>
     <string name="l10n_data_sources_screen_auto_sync_health_connect_periodically_6f3f4d92">Auto-sync Health Connect périodiquement</string>
     <string name="l10n_data_sources_screen_auto_sync_periodically_5f3041e8">Auto-sync périodiquement</string>
     <string name="l10n_data_sources_screen_broadcast_heart_rate_as_a_bluetooth_6a44fdb4">Diffuser la fréquence cardiaque comme capteur Bluetooth</string>
     <string name="l10n_data_sources_screen_broadcast_hr_from_this_phone_10e5605c">Diffusion des ressources humaines de ce téléphone</string>
-    <string name="l10n_data_sources_screen_broadcast_hr_is_on_your_strap_0ad5368a">Diffusion des ressources humaines en direct. Votre sangle annonce son rythme cardiaque en continu,</string>
+    <string name="l10n_data_sources_screen_broadcast_hr_is_on_your_strap_0ad5368a">La diffusion de la fréquence cardiaque est ACTIVÉE. Ce téléphone diffuse la fréquence cardiaque en continu, ce qui maintient le Bluetooth actif et décharge plus vite la batterie. Désactivez-la lorsque vous ne l’utilisez pas avec un autre appareil.</string>
     <string name="l10n_data_sources_screen_cancel_77dfd213">Annuler</string>
     <string name="l10n_data_sources_screen_data_sources_5e43d6bb">Sources de données</string>
     <string name="l10n_data_sources_screen_every_3560d90b">Chaque</string>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -349,13 +349,13 @@
     <string name="l10n_coupled_screen_no_sleep_tracked_last_night_cd0dd79e">No sleep tracked last night</string>
     <string name="l10n_coupled_screen_recovery_b668d988">RECOVERY</string>
     <string name="l10n_coupled_screen_sleep_performance_4611539f">SLEEP PERFORMANCE</string>
-    <string name="l10n_data_sources_screen_acts_as_a_standard_bluetooth_heart_f8d13439">Acts as a standard Bluetooth heart-rate strap. Pair NOOP from your treadmill, </string>
+    <string name="l10n_data_sources_screen_acts_as_a_standard_bluetooth_heart_f8d13439">Acts as a standard Bluetooth heart-rate strap. Pair NOOP from your treadmill, bike or app only when you need the phone to rebroadcast your strap\'s heart rate.</string>
     <string name="l10n_data_sources_screen_apple_health_b19b87da">Apple Health</string>
     <string name="l10n_data_sources_screen_auto_sync_health_connect_periodically_6f3f4d92">Auto-sync Health Connect periodically</string>
     <string name="l10n_data_sources_screen_auto_sync_periodically_5f3041e8">Auto-sync periodically</string>
     <string name="l10n_data_sources_screen_broadcast_heart_rate_as_a_bluetooth_6a44fdb4">Broadcast heart rate as a Bluetooth sensor</string>
     <string name="l10n_data_sources_screen_broadcast_hr_from_this_phone_10e5605c">Broadcast HR from this phone</string>
-    <string name="l10n_data_sources_screen_broadcast_hr_is_on_your_strap_0ad5368a">Broadcast HR is ON. Your strap is advertising its heart rate continuously, </string>
+    <string name="l10n_data_sources_screen_broadcast_hr_is_on_your_strap_0ad5368a">Broadcast HR is ON. This phone is advertising heart rate continuously, which keeps its Bluetooth radio active and drains the battery faster. Turn it off when you\'re not using it with another device.</string>
     <string name="l10n_data_sources_screen_cancel_77dfd213">Cancel</string>
     <string name="l10n_data_sources_screen_data_sources_5e43d6bb">Data Sources</string>
     <string name="l10n_data_sources_screen_every_3560d90b">Every</string>


### PR DESCRIPTION
## What

Clarifies the Android Data Sources copy for the phone heart-rate broadcast feature and keeps the revised copy in the existing localized string resources.

## Why

The card could read like a required strap setting even for users whose WHOOP/watch already broadcasts heart rate directly to another device. The updated copy explains that this is only for making the phone rebroadcast live strap HR as a standard Bluetooth HR sensor, and that users can leave it off when their wearable already handles HR broadcasting natively.

It also fixes the enabled warning to say the phone is advertising continuously, not the strap.

The English, German, French, and Spanish resources carry the same clarified meaning.

Closes #159.

## Validation

- `./gradlew :app:testFullDebugUnitTest --tests 'com.noop.ui.GermanLocalizationTest'`
- full-debug Kotlin compilation completed as part of the test task
- locale resource completeness passed in `Tools/i18n_audit.py`

This replaces #356 with an issue-oriented source branch.
