### PR TITLE
Localize the Android 9.0.1 changelog title

### DIFF
--- a/android/app/src/main/java/com/noop/ui/AppChangelog.kt
+++ b/android/app/src/main/java/com/noop/ui/AppChangelog.kt
@@ -39,7 +39,7 @@ object AppChangelog {
     val releases: List<Release> = listOf(
         Release(
             version = "9.0.1",
-            title = "German, French & Spanish, pull-to-sync on Today, and a wave of polish",
+            title = uiString(R.string.l10n_app_changelog_german_french_spanish_pull_to_sync_1109bda2),
             date = "July 2026",
             items = listOf(
                 "**NOOP now speaks German, French and Spanish (#453).** The whole app — every screen and label — is translated across iPhone, Mac and Android, so it reads in your language end to end.",

--- a/android/app/src/main/res/values-de/strings.xml
+++ b/android/app/src/main/res/values-de/strings.xml
@@ -1086,6 +1086,7 @@
     <string name="l10n_app_changelog_fixes_the_experimental_sleep_toggle_now_fc281b7d">Fixes: der experimentelle Schlafschalter funktioniert jetzt, Schrittkalibrierung, manuelle Workouts auf WHOOP 5/MG und eine gesunde HRV-Messung</string>
     <string name="l10n_app_changelog_fixes_the_insights_tab_crash_plus_042d1702">Behebt den Absturz des Insights-Tabs sowie eine genauere HRV</string>
     <string name="l10n_app_changelog_french_whoop_exports_now_import_db598ea4">Französisch WHOOP exportiert jetzt Import</string>
+    <string name="l10n_app_changelog_german_french_spanish_pull_to_sync_1109bda2">Deutsch, Französisch und Spanisch, Pull-to-Sync auf „Heute“ und jede Menge Feinschliff</string>
     <string name="l10n_app_changelog_gps_tracked_workouts_android_1cf07bd1">GPS-Tracked Workouts (Android)</string>
     <string name="l10n_app_changelog_gps_workout_crash_fix_android_698ee690">GPS Workout Crash Fix (Android)</string>
     <string name="l10n_app_changelog_hand_correct_your_sleep_times_smaller_6154b854">Handkorrigieren Sie Ihre Schlafzeiten + kleinere Backups</string>

--- a/android/app/src/main/res/values-es/strings.xml
+++ b/android/app/src/main/res/values-es/strings.xml
@@ -931,6 +931,7 @@
     <string name="l10n_app_changelog_fixes_the_experimental_sleep_toggle_now_fc281b7d">Fijaciones: el sueño experimental funciona ahora, calibración de pasos, ejercicios manuales en WHOOP 5/MG, y una lectura de HRV sana</string>
     <string name="l10n_app_changelog_fixes_the_insights_tab_crash_plus_042d1702">Arregla el fallo de la marca Insights, más el HRV más preciso</string>
     <string name="l10n_app_changelog_french_whoop_exports_now_import_db598ea4">Exportaciones WHOOP francesas importan ahora</string>
+    <string name="l10n_app_changelog_german_french_spanish_pull_to_sync_1109bda2">Alemán, francés y español, deslizar para sincronizar en Hoy y muchas mejoras</string>
     <string name="l10n_app_changelog_gps_tracked_workouts_android_1cf07bd1">Ejercicios GPS (Android)</string>
     <string name="l10n_app_changelog_gps_workout_crash_fix_android_698ee690">GPS solución de bloqueo de entrenamiento (Android)</string>
     <string name="l10n_app_changelog_hand_correct_your_sleep_times_smaller_6154b854">Corregir el tiempo de sueño + copias de seguridad más pequeñas</string>

--- a/android/app/src/main/res/values-fr/strings.xml
+++ b/android/app/src/main/res/values-fr/strings.xml
@@ -931,6 +931,7 @@
     <string name="l10n_app_changelog_fixes_the_experimental_sleep_toggle_now_fc281b7d">Corrections: le somnifère expérimental fonctionne maintenant, l\'étalonnage des étapes, des séances d\'entraînement manuelles sur WHOOP 5/MG, et une lecture de HRV sensée</string>
     <string name="l10n_app_changelog_fixes_the_insights_tab_crash_plus_042d1702">Correction de l\'accident Insights-tab, plus plus précis HRV</string>
     <string name="l10n_app_changelog_french_whoop_exports_now_import_db598ea4">Les exportations françaises de WHOOP importent désormais</string>
+    <string name="l10n_app_changelog_german_french_spanish_pull_to_sync_1109bda2">Allemand, français et espagnol, tirer pour synchroniser dans Aujourd’hui et de nombreuses améliorations</string>
     <string name="l10n_app_changelog_gps_tracked_workouts_android_1cf07bd1">entraînement suivi par GPS (Android)</string>
     <string name="l10n_app_changelog_gps_workout_crash_fix_android_698ee690">Correction d\'accident GPS (Android)</string>
     <string name="l10n_app_changelog_hand_correct_your_sleep_times_smaller_6154b854">Correction manuelle de votre temps de sommeil + petites sauvegardes</string>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -1095,6 +1095,7 @@
     <string name="l10n_app_changelog_fixes_the_experimental_sleep_toggle_now_fc281b7d">Fixes: the experimental sleep toggle now works, steps calibration, manual workouts on WHOOP 5/MG, and a sane HRV reading</string>
     <string name="l10n_app_changelog_fixes_the_insights_tab_crash_plus_042d1702">Fixes the Insights-tab crash, plus more accurate HRV</string>
     <string name="l10n_app_changelog_french_whoop_exports_now_import_db598ea4">French WHOOP exports now import</string>
+    <string name="l10n_app_changelog_german_french_spanish_pull_to_sync_1109bda2">German, French &amp; Spanish, pull-to-sync on Today, and a wave of polish</string>
     <string name="l10n_app_changelog_gps_tracked_workouts_android_1cf07bd1">GPS-tracked workouts (Android)</string>
     <string name="l10n_app_changelog_gps_workout_crash_fix_android_698ee690">GPS workout crash fix (Android)</string>
     <string name="l10n_app_changelog_hand_correct_your_sleep_times_smaller_6154b854">Hand-correct your sleep times + smaller backups</string>


### PR DESCRIPTION
## What changed

- Route the Android 9.0.1 changelog title through `uiString`.
- Add the title to the English, German, Spanish, and French Android string resources.

## Why

The 9.0.1 release added this title as a hardcoded Kotlin literal on `main`. The i18n Coverage workflow audits the full merged tree, so that baseline violation caused every pull request to fail even when its diff was unrelated.

This removes the hardcoded literal and restores a clean i18n baseline without adding the unrelated fix to each affected pull request.

## Validation

- `python3 Tools/i18n_audit.py --ci upstream/main`
- `./gradlew :app:compileFullDebugKotlin :app:testFullDebugUnitTest --tests com.noop.ui.GermanLocalizationTest`
- `git diff --check`
