### PR TITLE
fix(oura): correct 0x60/0x80 IBI decoders to the ring's real byte layout

### DIFF
--- a/Packages/OuraProtocol/Sources/OuraProtocol/Decoders.swift
+++ b/Packages/OuraProtocol/Sources/OuraProtocol/Decoders.swift
@@ -53,52 +53,66 @@ public enum OuraDecoders {
         return OuraHR(ringTimestamp: ringTimestamp, bpm: bpm, ibiMs: ibi)
     }
 
-    // MARK: - IBI + amplitude, bit-packed (0x60; s6.1)
+    // MARK: - IBI + amplitude, byte-scatter packed (0x60; s6.1)
 
-    /// Decode the 0x60 ibi_and_amplitude_event: 6 IBI+amplitude pairs bit-packed across the body.
-    /// IBI = 11-bit value (ms); amplitude = 7-bit mantissa (byte bits [7:1]) shifted left by the
-    /// exponent; exponent = low nibble of the last body byte (shift = (n==7) ? 0 : n+1). Per
-    /// OURA_PROTOCOL.md s6.1. Returns nil on a short body. A bit-reader walks the body MSB-first.
+    /// Decode the 0x60 ibi_and_amplitude_event: a fixed 14-byte packet holding 6 IBIs (ms) + PPG
+    /// amplitudes. Each 11-bit IBI is gathered from SCATTERED bytes, NOT a linear bitstream — per the
+    /// ring's native `parse_api_ibi_and_amplitude_event`: `ibi[k] = (b[6+k]&1) | (b[k]<<3) | <2 hi bits
+    /// from the b[12]/b[13] nibbles>`. Amplitude = `(b[6+k] >> 1) << shift`, exponent = low nibble of
+    /// b[13] (shift = (n==7) ? 0 : n+1). Returns nil on a short body.
+    ///
+    /// NOTE (#—, decode fix): the previous layout read the body as a linear MSB-first bitstream, which
+    /// only ever recovered the FIRST IBI correctly and scrambled the other five — a real overnight
+    /// capture decoded to an 82% beat-to-beat >200ms "jump" rate (not a heartbeat train). This
+    /// byte-scatter layout, cross-checked against the same capture, yields a coherent ~60 bpm train
+    /// (10% jump rate) that tracks the night's sleep stages and its day/night dip. Validated against
+    /// the `open_oura` decompiled `parse_api_ibi_and_amplitude_event`.
     public static func decodeIBIAmplitude(_ rec: OuraRecord) -> [OuraIBI]? {
         let b = rec.payload
-        // Need at least the 14 packed bytes the spec describes (body bytes 6..19 inclusive = 14 bytes).
-        guard b.count >= 14 else { return nil }
-        let n = Int(b[b.count - 1] & 0x0F)
+        guard b.count >= 14 else { return nil }   // fixed 14-byte packet (body bytes 6..19)
+        let b12 = Int(b[12]), b13 = Int(b[13])
+        let n = b13 & 0x0F
         let shift = (n == 7) ? 0 : (n + 1)
-        var reader = BitReader(b)
+        let ibi = [
+            (Int(b[6])  & 1) | (Int(b[0]) << 3) | ((b12 >> 5) & 6),
+            (Int(b[7])  & 1) | (Int(b[1]) << 3) | ((b12 >> 3) & 6),
+            (Int(b[8])  & 1) | (Int(b[2]) << 3) | ((b12 >> 1) & 6),
+            (Int(b[9])  & 1) | (Int(b[3]) << 3) | ((b12 & 3) << 1),
+            (Int(b[10]) & 1) | (Int(b[4]) << 3) | ((b13 >> 5) & 6),
+            (Int(b[11]) & 1) | (Int(b[5]) << 3) | ((b13 >> 3) & 6),
+        ]
         var out: [OuraIBI] = []
-        for _ in 0..<6 {
-            guard let raw11 = reader.read(11) else { break }
-            guard let mant7 = reader.read(7) else { break }
-            let ibi = raw11                                   // 11-bit value -> ms
-            let amp = mant7 << shift                           // 7-bit mantissa << exponent
-            guard ibi > 0 else { continue }                   // drop a zero IBI, never invent one
-            out.append(OuraIBI(ringTimestamp: rec.ringTimestamp, ibiMs: ibi, amplitude: amp))
+        for k in 0..<6 {
+            guard ibi[k] > 0 else { continue }                 // drop a zero IBI, never invent one
+            let amp = (Int(b[6 + k]) >> 1) << shift            // 7-bit mantissa << exponent
+            out.append(OuraIBI(ringTimestamp: rec.ringTimestamp, ibiMs: ibi[k], amplitude: amp))
         }
         return out.isEmpty ? nil : out
     }
 
     // MARK: - Green IBI quality, 2 bytes/sample (0x80; s6.4)
 
-    /// Decode the 0x80 green_ibi_quality_event: per 16-bit LE sample, bits 0-10 = IBI ms,
-    /// bits 11-13 = qual_a, bits 14-15 = qual_b. Accept a sample only if qual_a <= 1 && qual_b == 0.
-    /// 7 samples per 14-byte record. Per OURA_PROTOCOL.md s6.4. Returns nil on a short/odd body.
+    /// Decode the 0x80 green_ibi_quality_event: per 2-byte sample `ibi_ms = (b1 & 7) | (b0 << 3)`
+    /// (an 11-bit value, high byte first — NOT a little-endian u16), `quality = (b1 >> 3) & 3`. Accept a
+    /// sample only when `quality == 1` (the ring's "good beat" flag) and the IBI is physiological
+    /// (300..2000 ms). Up to 7 samples per 14-byte record. Per the native `parse_api_green_ibi_quality
+    /// _event`. Returns nil on a short body.
     ///
-    /// ROBUSTNESS (s6.4): the record holds at most 7 samples (14 bytes at 2 B/sample). We cap the read
-    /// at 7 samples; any sample bytes beyond the 7th are a misframe and are ignored rather than decoded.
+    /// NOTE (#—, decode fix): the previous layout read a little-endian u16 and masked bits 0-10, placing
+    /// the high byte in the LOW bits — a bit-order error that scrambled the interval (real-capture
+    /// within-record jitter 583ms). This high-byte-first layout with the `quality == 1` gate yields a
+    /// clean beat train (45ms jitter) and keeps MORE good beats. Validated against `open_oura`.
     public static func decodeGreenIBIQuality(_ rec: OuraRecord) -> [OuraIBI]? {
         let b = rec.payload
-        guard b.count >= 2, b.count % 2 == 0 else { return nil }
+        guard b.count >= 2 else { return nil }
         let maxSamples = 7                            // s6.4: 7 samples per 14-byte record
         var out: [OuraIBI] = []
         var i = 0
         var sampleCount = 0
         while i + 1 < b.count && sampleCount < maxSamples {
-            let sample = u16le(b, i)
-            let ibi = sample & 0x07FF                 // bits 0-10
-            let qualA = (sample >> 11) & 0x07         // bits 11-13
-            let qualB = (sample >> 14) & 0x03         // bits 14-15
-            if qualA <= 1 && qualB == 0 && ibi > 0 {
+            let ibi = (Int(b[i + 1]) & 0x07) | (Int(b[i]) << 3)   // high byte first
+            let quality = (Int(b[i + 1]) >> 3) & 0x03
+            if quality == 1 && ibi >= 300 && ibi <= 2000 {
                 out.append(OuraIBI(ringTimestamp: rec.ringTimestamp, ibiMs: ibi))
             }
             i += 2
@@ -396,29 +410,5 @@ public enum OuraDecoders {
             return (raw * 100).rounded() / 100
         }
         return OuraActivityInfo(ringTimestamp: rec.ringTimestamp, state: Int(state), met: met)
-    }
-}
-
-// MARK: - Bit reader (MSB-first), used by the bit-packed decoders (0x60)
-
-/// A minimal MSB-first bit reader over a byte array. Used for the bit-packed IBI+amplitude layout
-/// (OURA_PROTOCOL.md s6.1) where 11-bit IBI and 7-bit amplitude fields straddle byte boundaries.
-/// Returns nil when fewer than the requested bits remain (so the decoder stops cleanly, never guesses).
-struct BitReader {
-    private let bytes: [UInt8]
-    private var bitPos = 0
-    init(_ bytes: [UInt8]) { self.bytes = bytes }
-
-    mutating func read(_ count: Int) -> Int? {
-        guard bitPos + count <= bytes.count * 8 else { return nil }
-        var value = 0
-        for _ in 0..<count {
-            let byteIndex = bitPos >> 3
-            let bitIndex = 7 - (bitPos & 7)               // MSB-first
-            let bit = (Int(bytes[byteIndex]) >> bitIndex) & 1
-            value = (value << 1) | bit
-            bitPos += 1
-        }
-        return value
     }
 }

--- a/Packages/OuraProtocol/Tests/OuraProtocolTests/DecoderGoldenTests.swift
+++ b/Packages/OuraProtocol/Tests/OuraProtocolTests/DecoderGoldenTests.swift
@@ -1,10 +1,12 @@
 import XCTest
 @testable import OuraProtocol
 
-/// Golden per-tag fixture tests: raw TLV record bytes -> expected decoded event(s). Vectors are
-/// SYNTHETIC, built from the byte layouts in docs/OURA_PROTOCOL.md s6 (no real biometric capture is
-/// embedded). The full record is `type len rt(4 LE) payload` with rt = 0x00010002 (counter 2, session
-/// 1) throughout, so every assertion pins ringTimestamp == 65538.
+/// Golden per-tag fixture tests: raw TLV record bytes -> expected decoded event(s). Most vectors are
+/// SYNTHETIC, built from the byte layouts in docs/OURA_PROTOCOL.md s6 — EXCEPT the 0x60 and 0x80 IBI
+/// packets, which are two real captured records (a handful of anonymous inter-beat intervals) used to
+/// pin the byte-scatter decode against a known-good ~60/70 bpm beat train. The full record is
+/// `type len rt(4 LE) payload` with rt = 0x00010002 (counter 2, session 1) throughout, so every
+/// assertion pins ringTimestamp == 65538.
 final class DecoderGoldenTests: XCTestCase {
     private let rt: UInt32 = 0x0001_0002   // 65538
 
@@ -28,23 +30,26 @@ final class DecoderGoldenTests: XCTestCase {
         return rec
     }
 
-    // MARK: - 0x80 green IBI quality (filters on qual; only the good sample passes)
+    // MARK: - 0x80 green IBI quality (high-byte-first 11-bit IBI; quality==1 gate)
 
-    func testGreenIBIQuality0x80FiltersOnQuality() {
-        // body 200b (ibi800, qualA1, qualB0 -> pass) ee42 (ibi750, qualB1 -> reject)
-        let rec = record("800802000100200bee42")
+    func testGreenIBIQuality0x80RealCapture() {
+        // Real 0x80 record from an overnight capture: 7 samples. Six are quality 1 and form a clean
+        // ~70 bpm train; the 7th (846 ms) is quality 3 and must be rejected. Validated against open_oura.
+        let rec = record("801202000100698c660e652a6a09670f6d2b693e")
         let ibis = OuraDecoders.decodeGreenIBIQuality(rec)
-        XCTAssertEqual(ibis, [OuraIBI(ringTimestamp: rt, ibiMs: 800)])
+        XCTAssertEqual(ibis?.map { $0.ibiMs }, [844, 822, 810, 849, 831, 875])
     }
 
-    // MARK: - 0x60 IBI + amplitude (MSB-first bit-packed; n=7 -> shift 0)
+    // MARK: - 0x60 IBI + amplitude (byte-scatter 11-bit IBIs; shift from b13 low nibble)
 
-    func testIBIAmplitude0x60BitPacked() {
-        // first pair ibi1000 amp-mantissa64, last byte low nibble = 7 (shift 0).
-        let rec = record("6012020001007d10000000000000000000000007")
+    func testIBIAmplitude0x60RealCapture() {
+        // Real 0x60 record from an overnight capture: six IBIs forming a coherent ~60 bpm train under
+        // the byte-scatter layout (the old linear-bitstream decode scrambled all but the first).
+        // Validated against open_oura parse_api_ibi_and_amplitude_event.
+        let rec = record("601202000100807b77757a78e4ddccd4e8d79d33")
         let ibis = OuraDecoders.decodeIBIAmplitude(rec)
-        XCTAssertNotNil(ibis)
-        XCTAssertEqual(ibis?.first, OuraIBI(ringTimestamp: rt, ibiMs: 1000, amplitude: 64))
+        XCTAssertEqual(ibis?.map { $0.ibiMs }, [1028, 987, 958, 938, 976, 967])
+        XCTAssertEqual(ibis?.map { $0.amplitude }, [1824, 1760, 1632, 1696, 1856, 1712])
     }
 
     // MARK: - 0x6E SpO2 IBI (REVERSE byte order x8)

--- a/android/app/src/main/java/com/noop/oura/Decoders.kt
+++ b/android/app/src/main/java/com/noop/oura/Decoders.kt
@@ -59,29 +59,41 @@ object OuraDecoders {
         return OuraHR(ringTimestamp = ringTimestamp, bpm = bpm, ibiMs = ibi)
     }
 
-    // MARK: - IBI + amplitude, bit-packed (0x60; s6.1)
+    // MARK: - IBI + amplitude, byte-scatter packed (0x60; s6.1)
 
     /**
-     * Decode the 0x60 ibi_and_amplitude_event: 6 IBI+amplitude pairs bit-packed across the body.
-     * IBI = 11-bit value (ms); amplitude = 7-bit mantissa (byte bits [7:1]) shifted left by the
-     * exponent; exponent = low nibble of the last body byte (shift = (n==7) ? 0 : n+1). Per
-     * OURA_PROTOCOL.md s6.1. Returns null on a short body. A bit-reader walks the body MSB-first.
+     * Decode the 0x60 ibi_and_amplitude_event: a fixed 14-byte packet holding 6 IBIs (ms) + PPG
+     * amplitudes. Each 11-bit IBI is gathered from SCATTERED bytes, NOT a linear bitstream — per the
+     * ring's native `parse_api_ibi_and_amplitude_event`: `ibi[k] = (b[6+k]&1) | (b[k]<<3) | <2 hi bits
+     * from the b[12]/b[13] nibbles>`. Amplitude = `(b[6+k] shr 1) shl shift`, exponent = low nibble of
+     * b[13] (shift = (n==7) ? 0 : n+1). Returns null on a short body.
+     *
+     * NOTE (decode fix): the previous layout read the body as a linear MSB-first bitstream, which only
+     * ever recovered the FIRST IBI correctly and scrambled the other five — a real overnight capture
+     * decoded to an 82% beat-to-beat >200ms "jump" rate (not a heartbeat train). This byte-scatter
+     * layout yields a coherent ~60 bpm train (10% jump rate). Validated against open_oura. Byte-identical
+     * twin of Swift's decodeIBIAmplitude.
      */
     fun decodeIBIAmplitude(rec: OuraRecord): List<OuraIBI>? {
         val b = rec.payload
-        // Need at least the 14 packed bytes the spec describes (body bytes 6..19 inclusive = 14 bytes).
-        if (b.size < 14) return null
-        val n = b[b.size - 1] and 0x0F
+        if (b.size < 14) return null   // fixed 14-byte packet (body bytes 6..19)
+        val b12 = b[12] and 0xFF
+        val b13 = b[13] and 0xFF
+        val n = b13 and 0x0F
         val shift = if (n == 7) 0 else (n + 1)
-        val reader = BitReader(b)
+        val ibi = intArrayOf(
+            (b[6] and 1) or ((b[0] and 0xFF) shl 3) or ((b12 shr 5) and 6),
+            (b[7] and 1) or ((b[1] and 0xFF) shl 3) or ((b12 shr 3) and 6),
+            (b[8] and 1) or ((b[2] and 0xFF) shl 3) or ((b12 shr 1) and 6),
+            (b[9] and 1) or ((b[3] and 0xFF) shl 3) or ((b12 and 3) shl 1),
+            (b[10] and 1) or ((b[4] and 0xFF) shl 3) or ((b13 shr 5) and 6),
+            (b[11] and 1) or ((b[5] and 0xFF) shl 3) or ((b13 shr 3) and 6),
+        )
         val out = ArrayList<OuraIBI>()
         for (k in 0 until 6) {
-            val raw11 = reader.read(11) ?: break
-            val mant7 = reader.read(7) ?: break
-            val ibi = raw11                               // 11-bit value -> ms
-            val amp = mant7 shl shift                      // 7-bit mantissa << exponent
-            if (ibi <= 0) continue                         // drop a zero IBI, never invent one
-            out.add(OuraIBI(ringTimestamp = rec.ringTimestamp, ibiMs = ibi, amplitude = amp))
+            if (ibi[k] <= 0) continue                      // drop a zero IBI, never invent one
+            val amp = ((b[6 + k] and 0xFF) shr 1) shl shift   // 7-bit mantissa << exponent
+            out.add(OuraIBI(ringTimestamp = rec.ringTimestamp, ibiMs = ibi[k], amplitude = amp))
         }
         return if (out.isEmpty()) null else out
     }
@@ -89,26 +101,28 @@ object OuraDecoders {
     // MARK: - Green IBI quality, 2 bytes/sample (0x80; s6.4)
 
     /**
-     * Decode the 0x80 green_ibi_quality_event: per 16-bit LE sample, bits 0-10 = IBI ms,
-     * bits 11-13 = qual_a, bits 14-15 = qual_b. Accept a sample only if qual_a <= 1 && qual_b == 0.
-     * 7 samples per 14-byte record. Per OURA_PROTOCOL.md s6.4. Returns null on a short/odd body.
+     * Decode the 0x80 green_ibi_quality_event: per 2-byte sample `ibi_ms = (b1 & 7) | (b0 << 3)` (an
+     * 11-bit value, high byte first — NOT a little-endian u16), `quality = (b1 >> 3) & 3`. Accept a
+     * sample only when `quality == 1` (the ring's "good beat" flag) and the IBI is physiological
+     * (300..2000 ms). Up to 7 samples per 14-byte record. Per the native `parse_api_green_ibi_quality
+     * _event`. Returns null on a short body.
      *
-     * ROBUSTNESS (s6.4): the record holds at most 7 samples (14 bytes at 2 B/sample). We cap the read
-     * at 7 samples; any sample bytes beyond the 7th are a misframe and are ignored rather than decoded.
+     * NOTE (decode fix): the previous layout read a little-endian u16 and masked bits 0-10, placing the
+     * high byte in the LOW bits — a bit-order error that scrambled the interval (real-capture within-
+     * record jitter 583ms). This high-byte-first layout with the `quality == 1` gate yields a clean beat
+     * train (45ms jitter). Validated against open_oura. Byte-identical twin of Swift's decodeGreenIBIQuality.
      */
     fun decodeGreenIBIQuality(rec: OuraRecord): List<OuraIBI>? {
         val b = rec.payload
-        if (b.size < 2 || b.size % 2 != 0) return null
+        if (b.size < 2) return null
         val maxSamples = 7                              // s6.4: 7 samples per 14-byte record
         val out = ArrayList<OuraIBI>()
         var i = 0
         var sampleCount = 0
         while (i + 1 < b.size && sampleCount < maxSamples) {
-            val sample = u16le(b, i)
-            val ibi = sample and 0x07FF                 // bits 0-10
-            val qualA = (sample shr 11) and 0x07        // bits 11-13
-            val qualB = (sample shr 14) and 0x03        // bits 14-15
-            if (qualA <= 1 && qualB == 0 && ibi > 0) {
+            val ibi = (b[i + 1] and 0x07) or ((b[i] and 0xFF) shl 3)   // high byte first
+            val quality = (b[i + 1] shr 3) and 0x03
+            if (quality == 1 && ibi in 300..2000) {
                 out.add(OuraIBI(ringTimestamp = rec.ringTimestamp, ibiMs = ibi))
             }
             i += 2
@@ -446,30 +460,5 @@ object OuraDecoders {
             met.add(Math.round(raw * 100.0) / 100.0)
         }
         return OuraActivityInfo(ringTimestamp = rec.ringTimestamp, state = b[0], met = met)
-    }
-}
-
-// MARK: - Bit reader (MSB-first), used by the bit-packed decoders (0x60)
-
-/**
- * A minimal MSB-first bit reader over an unsigned-byte IntArray. Used for the bit-packed IBI+amplitude
- * layout (OURA_PROTOCOL.md s6.1) where 11-bit IBI and 7-bit amplitude fields straddle byte boundaries.
- * Returns null when fewer than the requested bits remain (so the decoder stops cleanly, never guesses).
- * Kotlin twin of the Swift BitReader.
- */
-internal class BitReader(private val bytes: IntArray) {
-    private var bitPos = 0
-
-    fun read(count: Int): Int? {
-        if (bitPos + count > bytes.size * 8) return null
-        var value = 0
-        repeat(count) {
-            val byteIndex = bitPos shr 3
-            val bitIndex = 7 - (bitPos and 7)             // MSB-first
-            val bit = (bytes[byteIndex] shr bitIndex) and 1
-            value = (value shl 1) or bit
-            bitPos += 1
-        }
-        return value
     }
 }

--- a/android/app/src/test/java/com/noop/oura/DecoderGoldenTest.kt
+++ b/android/app/src/test/java/com/noop/oura/DecoderGoldenTest.kt
@@ -11,10 +11,11 @@ import org.junit.Test
  *
  * PARITY NOTE: every fixture hex string below is byte-for-byte identical to the Swift
  * DecoderGoldenTests fixtures, so the SAME raw record bytes must decode to the SAME values across the
- * Swift and Kotlin ports (that is the whole point of the twin). Vectors are SYNTHETIC, built from the
- * byte layouts in docs/OURA_PROTOCOL.md s6 (no real biometric capture is embedded). The full record is
- * `type len rt(4 LE) payload` with rt = 0x00010002 (counter 2, session 1) throughout, so every
- * assertion pins ringTimestamp == 65538.
+ * Swift and Kotlin ports (that is the whole point of the twin). Most vectors are SYNTHETIC, built from
+ * the byte layouts in docs/OURA_PROTOCOL.md s6 — EXCEPT the 0x60 and 0x80 IBI packets, which are two
+ * real captured records (a handful of anonymous inter-beat intervals) used to pin the byte-scatter
+ * decode against a known-good beat train. The full record is `type len rt(4 LE) payload` with
+ * rt = 0x00010002 (counter 2, session 1) throughout, so every assertion pins ringTimestamp == 65538.
  */
 class DecoderGoldenTest {
     private val rt: Long = 0x0001_0002   // 65538
@@ -30,24 +31,28 @@ class DecoderGoldenTest {
         return rec
     }
 
-    // MARK: - 0x80 green IBI quality (filters on qual; only the good sample passes)
+    // MARK: - 0x80 green IBI quality (high-byte-first 11-bit IBI; quality==1 gate)
 
     @Test
-    fun testGreenIBIQuality0x80FiltersOnQuality() {
-        // body 200b (ibi800, qualA1, qualB0 -> pass) ee42 (ibi750, qualB1 -> reject)
-        val rec = record("800802000100200bee42")
+    fun testGreenIBIQuality0x80RealCapture() {
+        // Real 0x80 record from an overnight capture: 7 samples. Six are quality 1 and form a clean
+        // ~70 bpm train; the 7th (846 ms) is quality 3 and must be rejected. Validated against open_oura.
+        val rec = record("801202000100698c660e652a6a09670f6d2b693e")
         val ibis = OuraDecoders.decodeGreenIBIQuality(rec)
-        assertEquals(listOf(OuraIBI(ringTimestamp = rt, ibiMs = 800)), ibis)
+        assertEquals(listOf(844, 822, 810, 849, 831, 875), ibis?.map { it.ibiMs })
     }
 
-    // MARK: - 0x60 IBI + amplitude (MSB-first bit-packed; n=7 -> shift 0)
+    // MARK: - 0x60 IBI + amplitude (byte-scatter 11-bit IBIs; shift from b13 low nibble)
 
     @Test
-    fun testIBIAmplitude0x60BitPacked() {
-        // first pair ibi1000 amp-mantissa64, last byte low nibble = 7 (shift 0).
-        val rec = record("6012020001007d10000000000000000000000007")
+    fun testIBIAmplitude0x60RealCapture() {
+        // Real 0x60 record from an overnight capture: six IBIs forming a coherent ~60 bpm train under
+        // the byte-scatter layout (the old linear-bitstream decode scrambled all but the first).
+        // Validated against open_oura parse_api_ibi_and_amplitude_event.
+        val rec = record("601202000100807b77757a78e4ddccd4e8d79d33")
         val ibis = OuraDecoders.decodeIBIAmplitude(rec)
-        assertEquals(OuraIBI(ringTimestamp = rt, ibiMs = 1000, amplitude = 64), ibis?.first())
+        assertEquals(listOf(1028, 987, 958, 938, 976, 967), ibis?.map { it.ibiMs })
+        assertEquals(listOf(1824, 1760, 1632, 1696, 1856, 1712), ibis?.map { it.amplitude })
     }
 
     // MARK: - 0x6E SpO2 IBI (REVERSE byte order x8)

--- a/docs/OURA_PROTOCOL.md
+++ b/docs/OURA_PROTOCOL.md
@@ -292,11 +292,17 @@ Daytime-HR auto-reverts after ~20 s; NOOP re-engages every ~15 s while a live se
 All records share the §2.3 TLV header (`type`, `len`, 4-byte `ringTimestamp`). Body offsets below are **relative to the start of the record** (offset 6 = first body byte). All multi-byte values **little-endian** unless stated. [ringverse]
 
 ### 6.1 IBI + amplitude - `0x60` `ibi_and_amplitude_event` (18 B)
-- 6 IBI+amplitude pairs, **bit-packed** across body bytes 6–19. [ringverse]
-- **Shift exponent** = low nibble `[3:0]` of last body byte; if `n=7` then `shift=0`, else `shift=n+1`. [ringverse]
-- Each **IBI** = 11-bit value (1 LSB bit + an 8-bit byte shifted left 3 + a 2-bit high field) → milliseconds. [ringverse]
-- Each **amplitude** = 7-bit mantissa (byte bits `[7:1]`) shifted left by the exponent. [ringverse]
+- Fixed 14-byte body (bytes 6–19) holding 6 IBIs + amplitudes, **byte-scatter packed** — each IBI is
+  gathered from SCATTERED bytes, NOT a linear bitstream. [oura-rs][ringverse]
+- **Shift exponent** = low nibble `[3:0]` of the last body byte (`b[13]`); if `n=7` then `shift=0`, else `shift=n+1`. [oura-rs]
+- Each **IBI** (ms), for `k` in 0…5: `(b[6+k] & 1) | (b[k] << 3) | <2 high bits from the b[12]/b[13] nibbles>`
+  — i.e. 1 LSB from an amplitude byte, 8 mid bits from `b[k]`, 2 high bits from the pack bytes. [oura-rs]
+- Each **amplitude** = `(b[6+k] >> 1) << shift` (7-bit mantissa `[7:1]` shifted by the exponent). [oura-rs]
 - Per-sample timestamp: walk backward from event UTC by each IBI duration. [ringverse]
+- **Validated (decode fix):** the earlier linear-MSB-first bitstream reading recovered only the FIRST IBI and
+  scrambled the rest (a real overnight capture → 82% non-physiological beat-to-beat jumps). The byte-scatter
+  layout above, cross-checked on the same capture, yields a coherent ~60 bpm train (10% jumps) that tracks the
+  night's sleep stages and day/night dip. Matches `open_oura`'s decompiled `parse_api_ibi_and_amplitude_event`.
 
 ### 6.2 Green-LED IBI+amp - `0x71` `green_ibi_and_amp_event` (18 B)
 - 5 IBI deltas + 6 amplitudes; shift from byte19 bits `[2:0]`; same 11-bit IBI / 7-bit amplitude structure. [ringverse]
@@ -307,14 +313,18 @@ All records share the §2.3 TLV header (`type`, `len`, 4-byte `ringTimestamp`). 
 - 7 amplitudes: first `byte<<3`, rest `byte<<shift`. [ringverse]
 
 ### 6.4 Green IBI quality - `0x80` `green_ibi_quality_event` (4–18 B, 2 B/sample)
-Per 16-bit LE sample: [open_ring][ringverse]
+Per 2-byte sample, **high byte first** (NOT a little-endian u16): [oura-rs][ringverse]
 ```
-bits 0–10  : value_11bit  → IBI in ms
-bits 11–13 : qual_a
-bits 14–15 : qual_b
+ibi_ms  = (b1 & 0x07) | (b0 << 3)   ; 11-bit, b0 = high 8 bits, b1[2:0] = low 3 bits
+quality = (b1 >> 3) & 0x03
+flag    =  b1 >> 5
 ```
-**NOOP filter:** accept sample only if `qual_a ≤ 1 && qual_b == 0`. [open_ring]
-(7 samples per 14-byte record.) [open_ring]
+**NOOP filter:** accept sample only if `quality == 1` (the ring's "good beat" flag) and the IBI is
+physiological (300–2000 ms). (Up to 7 samples per 14-byte record.) [oura-rs]
+**Validated (decode fix):** the earlier reading treated the pair as a little-endian u16 masked to bits 0–10,
+placing the high byte in the LOW bits — a bit-order error (real-capture within-record jitter 583 ms). The
+high-byte-first layout with the `quality == 1` gate yields a clean beat train (45 ms jitter) and keeps more
+good beats. Matches `open_oura`'s `parse_api_green_ibi_quality_event`.
 
 ### 6.5 SpO2 per-sample - `0x6F` `spo2_event` (5–18 B, 1 s spacing)
 - Byte 6: bits `[7:4]` = SpO2 base (<<7); bits `[3:0]` = status flag. [ringverse]


### PR DESCRIPTION
## Problem Statement

The Oura 0x60 (ibi_and_amplitude) and 0x80 (green_ibi_quality) decoders read the wrong bit layout (which was also reported via #287) , so every reconstructed inter-beat interval past the first was scrambled. This wasn't visible in isolation because the median IBI still landed on a plausible number — it only surfaced  when the banked IBIs were assembled into an HR history from a real overnight capture:

  - 82% of consecutive beats jumped >200 ms — not a heartbeat train.
  - Derived HR was flat across every sleep stage (deep = light = rem = wake ≈ 55 bpm) and flat day-vs-night — it tracked no varying input, the classic false-signal trap (#194).

The banked-IBI → HR-history path was consequently shelved as a dead end, when in fact the data was dense (94% overnight minute coverage) and only the decode was wrong.

##  Fix

Re-decoding the same captured bytes both ways pinned the root cause in each decoder:

  - 0x60 was read as a linear MSB-first bitstream. The ring actually scatters each 11-bit IBI across specific bytes (parse_api_ibi_and_amplitude_event): ibi[k] = (b[6+k]&1) | (b[k]<<3) | <2 hi bits from b[12]/b[13]>. The linear read only ever recovered the first IBI. → within-packet  jitter 773 → 57 ms.
  - 0x80 was read as a little-endian u16 masked to bits 0–10, putting the high byte in the low bits. Correct layout is high-byte-first: ibi = (b1&7)|(b0<<3), quality = (b1>>3)&3, accepting only quality==1 & 300–2000 ms. → jitter 583 → 45 ms, and it keeps more good beats.

Both rewritten in Swift and Kotlin as byte-identical twins (parity contract); the now-unused BitReader removed on both platforms. Validated against open_oura's decompiled decoders (present in both Th0rgal upstream and the foodlbs fork).

##  Scope

  - Protocol-package only (Packages/OuraProtocol + Android com.noop.oura). No public API change — signatures and return types are unchanged, so all consumers (driver, live source, analytics) are unaffected.
  - No scoring/data change beyond correctness: these decoders already fed IBI/HRV; they now feed correct intervals. No migration, no .noopbak surface, no UI.
  - docs/OURA_PROTOCOL.md §6.1/§6.4 corrected to the validated layouts.
  - Out of scope (deliberately): building the actual HR-history/HRV instrumentation on top of the corrected decode — that's a follow-on PR now that the decode is trustworthy.

##  Verification

  - Golden tests use two real captured records (a handful of anonymous IBIs) pinning the decode to a known-good beat train: 0x60 → [1028, 987, 958, 938, 976, 967] (~60 bpm), 0x80 → [844, 822, 810, 849, 831, 875] (~70 bpm, with the 7th quality-3 sample correctly rejected).
  - Swift: full OuraProtocol suite green (108 tests).
  - Android: com.noop.oura.* green (DecoderGoldenTest + DriverTest + framing), compiled clean.
  - Full-night replay through the corrected decoders (offline, from the raw capture): beat-to-beat jump rate 82% → 10%, a clear nocturnal dip (evening ~80 → sleep 53–59 bpm), and wake distinguishable from sleep (p75 85 vs tight 51–60) — i.e. it now tracks a varying input, clearing  the #194 bar.