### PR TITLE
Workouts: read HR under the recording strap's id, not a hardcoded default (multi-WHOOP)

### DIFF
--- a/android/app/src/main/java/com/noop/data/WhoopRepository.kt
+++ b/android/app/src/main/java/com/noop/data/WhoopRepository.kt
@@ -628,6 +628,11 @@ class WhoopRepository(private val dao: WhoopDao) {
      */
     suspend fun fillWorkoutHrFromStrap(
         rows: List<WorkoutRow>,
+        // HR read key for IMPORTED rows ONLY (Apple/HC/CSV/activity file): they carry no strap HR of their
+        // own, so #77 derives it from the worn strap. STRAP-NATIVE rows ignore this and key on their OWN
+        // recording strap (see [workoutHrDeviceId]). The canonical "my-whoop" default is the worn strap on a
+        // single-WHOOP install (and every current caller uses it); which strap was worn during an imported
+        // session on a MULTI-strap install is undetermined, so that case is left as-is (not the active strap).
         strapDeviceId: String = "my-whoop",
         minSamples: Long = 60,
         cap: Int = 300,
@@ -645,19 +650,23 @@ class WhoopRepository(private val dao: WhoopDao) {
             // Strap-native rows are graphed/zoned/scored from the strap trace, so their Avg HR must come
             // from that same trace (recompute, overriding any stored/edited value). Imported rows keep
             // their own avg/max and are only filled when missing.
-            val src = row.source.lowercase()
-            val strapNative = src == "manual" || src.endsWith("-noop")
+            val strapNative = isStrapNativeWorkout(row.source)
             // #961: a strap-native row still missing a strain is a fill target even when its avgHr is present.
             val needsStrainFill = strapNative && row.strain == null && strainMaxHR != null
             if (!strapNative && row.avgHr != null && !needsStrainFill) return@map row
             budget -= 1
-            val stats = dao.hrWindowStats(strapDeviceId, row.startTs, row.endTs)
+            // #510: read the HR window under the device that ACTUALLY recorded this workout — its OWN strap
+            // for a strap-native row (never a hardcoded id), the [strapDeviceId] worn-strap default for an
+            // imported one. A 2nd WHOOP (id "whoop-<mac>") used to read the empty "my-whoop" window, so its
+            // strap-native workouts' Avg HR wasn't reconciled from the trace and a null Effort wasn't recomputed.
+            val hrDeviceId = workoutHrDeviceId(row.source, row.deviceId, strapDeviceId)
+            val stats = dao.hrWindowStats(hrDeviceId, row.startTs, row.endTs)
             if (stats.n < minSamples || stats.avg == null || stats.max == null) return@map row
             // #961: recompute Effort from the SAME samples the graph/zones use. Read the raw window ONLY when
             // this row actually needs a strain (keeps the common no-fill path a single aggregate query), and
             // let StrainScorer return null on a still-too-thin window (never a fabricated number).
             val filledStrain = if (needsStrainFill && strainMaxHR != null) {
-                val samples = dao.hrSamples(strapDeviceId, row.startTs, row.endTs, 8000)
+                val samples = dao.hrSamples(hrDeviceId, row.startTs, row.endTs, 8000)
                 com.noop.analytics.StrainScorer.strain(samples, maxHR = strainMaxHR, sex = strainSex)
             } else null
             if (strapNative) {
@@ -1404,6 +1413,25 @@ class WhoopRepository(private val dao: WhoopDao) {
     suspend fun latestBattery(deviceId: String): BatterySample? = dao.latestBattery(deviceId)
 
     companion object {
+        /** A workout row is STRAP-NATIVE when NOOP recorded/scored it from a strap trace: a "manual"
+         *  session or a detected bout (source "<id>-noop"). Everything else (Apple Health / Health Connect /
+         *  WHOOP CSV / activity file) is IMPORTED and carries its own avg/max. Single source of truth for the
+         *  classification shared by [fillWorkoutHrFromStrap] and [workoutHrDeviceId]. */
+        fun isStrapNativeWorkout(source: String): Boolean {
+            val s = source.lowercase()
+            return s == "manual" || s.endsWith("-noop")
+        }
+
+        /** #510: the device id whose `hrSample` rows back a workout's Avg HR / calories / Effort recompute.
+         *  A STRAP-NATIVE row was charted from its OWN strap's trace, so read HR under that strap — strip the
+         *  computed "-noop" suffix to reach the raw hrSample id (a detected row lives under "<id>-noop", its
+         *  HR under "<id>"). An IMPORTED row has no strap HR of its own; #77 fills it from the WORN strap, i.e.
+         *  the active strap [activeStrapId]. Before this both keyed on a hardcoded "my-whoop", so a strap-native
+         *  workout on a SECOND WHOOP ("whoop-<mac>") read an empty window — its Avg HR went un-reconciled and a
+         *  null Effort un-recomputed. (This fill only sets avgHr/maxHr/strain; calories come from the detector.) */
+        fun workoutHrDeviceId(source: String, rowDeviceId: String, activeStrapId: String): String =
+            if (isStrapNativeWorkout(source)) rowDeviceId.removeSuffix("-noop") else activeStrapId
+
         /** Default row cap on range reads. Matches the Swift call sites' bounded scans. */
         const val DEFAULT_LIMIT = 100_000
 

--- a/android/app/src/main/java/com/noop/ui/TodayScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/TodayScreen.kt
@@ -1019,6 +1019,8 @@ fun TodayScreen(
         val hcDaysCount = viewModel.repo.appleDaily("health-connect", "0000-01-01", "9999-12-31").size
         footer = TodayFooterState(
             // fillWorkoutHrFromStrap: imported sessions carry no HR, derive it from strap samples (#77).
+            // #510: strap-native rows now read HR under their OWN recording strap (inside the fill), so a 2nd
+            // WHOOP's workouts reconcile Avg HR + Effort from their own trace; imported rows keep the default.
             recentWorkouts = viewModel.repo.fillWorkoutHrFromStrap(recentUnion),
             whoopDays = days.size,
             whoopWorkouts = whoopWorkouts.size,

--- a/android/app/src/test/java/com/noop/data/WorkoutHrDeviceKeyTest.kt
+++ b/android/app/src/test/java/com/noop/data/WorkoutHrDeviceKeyTest.kt
@@ -1,0 +1,72 @@
+package com.noop.data
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * #510: `fillWorkoutHrFromStrap` used to read every workout's HR window under a hardcoded "my-whoop",
+ * so a workout recorded on a SECOND WHOOP (id "whoop-<mac>", its HR banked under that id) read an empty
+ * window and lost its Avg HR / calories / Effort. [WhoopRepository.workoutHrDeviceId] now resolves the
+ * correct read key per row; this pins that resolution and the strap-native classification it rides on.
+ */
+class WorkoutHrDeviceKeyTest {
+
+    @Test fun `strap-native sources are classified as strap-native`() {
+        assertTrue(WhoopRepository.isStrapNativeWorkout("manual"))
+        assertTrue(WhoopRepository.isStrapNativeWorkout("MANUAL"))          // case-insensitive
+        assertTrue(WhoopRepository.isStrapNativeWorkout("my-whoop-noop"))   // detected (canonical)
+        assertTrue(WhoopRepository.isStrapNativeWorkout("whoop-aabbcc-noop")) // detected (2nd WHOOP)
+    }
+
+    @Test fun `imported sources are NOT strap-native`() {
+        assertFalse(WhoopRepository.isStrapNativeWorkout("apple-health"))
+        assertFalse(WhoopRepository.isStrapNativeWorkout("Apple Health"))
+        assertFalse(WhoopRepository.isStrapNativeWorkout("Health Connect"))
+        assertFalse(WhoopRepository.isStrapNativeWorkout("activity-file"))
+        assertFalse(WhoopRepository.isStrapNativeWorkout("lifting"))
+        assertFalse(WhoopRepository.isStrapNativeWorkout("my-whoop"))       // WHOOP CSV import (ends -whoop, not -noop)
+    }
+
+    @Test fun `detected row reads HR under its own base strap, not the active strap`() {
+        // A detected bout on a SECOND WHOOP lives under "whoop-aabbcc-noop"; its HR is banked under
+        // "whoop-aabbcc". The active strap being something else must NOT redirect the read.
+        assertEquals(
+            "whoop-aabbcc",
+            WhoopRepository.workoutHrDeviceId("whoop-aabbcc-noop", "whoop-aabbcc-noop", activeStrapId = "my-whoop"),
+        )
+        // Canonical single-WHOOP detected row is unchanged from the old "my-whoop" behaviour.
+        assertEquals(
+            "my-whoop",
+            WhoopRepository.workoutHrDeviceId("my-whoop-noop", "my-whoop-noop", activeStrapId = "my-whoop"),
+        )
+    }
+
+    @Test fun `manual row reads HR under its own strap id`() {
+        assertEquals(
+            "whoop-aabbcc",
+            WhoopRepository.workoutHrDeviceId("manual", "whoop-aabbcc", activeStrapId = "my-whoop"),
+        )
+    }
+
+    @Test fun `imported row reads HR under the active strap (the worn strap), preserving the #77 fill`() {
+        // An Apple/HC/activity-file row carries no strap HR; #77 fills it from the worn strap = active strap.
+        assertEquals(
+            "whoop-aabbcc",
+            WhoopRepository.workoutHrDeviceId("apple-health", "apple-health", activeStrapId = "whoop-aabbcc"),
+        )
+        assertEquals(
+            "my-whoop",
+            WhoopRepository.workoutHrDeviceId("activity-file", "activity-file", activeStrapId = "my-whoop"),
+        )
+    }
+
+    @Test fun `a bare strap id with no -noop suffix is returned unchanged`() {
+        // removeSuffix is a no-op when the suffix is absent — a manual/base id must not be truncated.
+        assertEquals(
+            "whoop-aabbcc",
+            WhoopRepository.workoutHrDeviceId("manual", "whoop-aabbcc", activeStrapId = "ignored"),
+        )
+    }
+}


### PR DESCRIPTION
## What

`fillWorkoutHrFromStrap` (the Today/Workouts display fill from #77) read every workout's HR window under a **hardcoded `"my-whoop"`** default. A **strap-native** workout recorded on a **second** WHOOP — registered under `whoop-<mac>`, with its `hrSample` rows banked under that id — therefore read an **empty** window, so `stats.n < minSamples` returned the row **unchanged**: its Avg HR / Max HR were never reconciled from the strap trace, and a **null Effort (strain) was never recomputed**.

Single-WHOOP installs keep the canonical `my-whoop` id, which matched the default. **This only bit multi-WHOOP users.**

> **Not calories.** This fill only writes `avgHr` / `maxHr` / `strain`; `energyKcal` is computed by the detector under the day owner (which already resolves multi-device correctly). And because failure returns the row *unchanged*, detected rows keep their stored Avg/Max — the user-visible win here is the **Effort recompute** (and Avg-HR reconcile / manual-row HR fill) landing on the correct strap.

## Fix

Resolve the HR read key **per row**, from the device that actually recorded the workout:

- **Strap-native** rows (`source == "manual"` or a detected `"<id>-noop"`) were charted/zoned/scored from their **own** strap trace → key on that strap. Strip the computed `-noop` suffix to reach the raw `hrSample` id (a detected bout lives under `"<id>-noop"`; its HR under `"<id>"`).
- **Imported** rows (Apple / HC / WHOOP CSV / activity file) carry no strap HR; #77 fills them from the `strapDeviceId` default (`my-whoop`), **byte-identical to today**. Which strap was worn during an imported session on a multi-strap install is undetermined, so that case is deliberately left as-is.

Classification lives in one place (`isStrapNativeWorkout`) shared by the fill and the new `workoutHrDeviceId` helper.

## Why it's safe

- **Single-device behaviour is byte-identical**: a detected `my-whoop-noop` row strips to `my-whoop` (== the old default); imported rows still read `my-whoop`.
- The fill never *nulls* a present value (failure returns the row unchanged); no change to the strain math, the `minSamples`/`cap` accounting, or the imported-fill path.

## Test

`WorkoutHrDeviceKeyTest` (JVM, 6 cases): pins the strap-native vs imported classification and the per-row key resolution — including that a 2nd-WHOOP detected row reads its **own** strap and that imported rows follow the supplied strap (preserving #77). `compileFullDebugKotlin` + the test pass locally.

## Scope / follow-ups

- **Kotlin only.** The Swift twin `reconcileWorkoutHrWithTrace` reads under the Repository's single active `deviceId`, and its read-model `WorkoutRow` (WhoopStore, `Codable`) carries **no** `deviceId` — parity means threading the source device through the workout fetch → dedup → reconcile pipeline. Separate, app-compile-verified follow-up (app-target Swift has no default CI).
- **Surfaced by #510** (a *single*-WHOOP report — so this is **not** confirmed to be that reporter's root cause, which is still under investigation via a debug export). This PR fixes the multi-WHOOP class the review turned up.