### PR TITLE
Workouts (iOS/macOS): read HR under the recording strap, not the active id (#512 twin)

### DIFF
--- a/Strand/Data/Repository.swift
+++ b/Strand/Data/Repository.swift
@@ -2106,8 +2106,13 @@ final class Repository: ObservableObject {
                     // so the child task crosses only Sendable scalars.
                     let cls = WorkoutSource.classify(rows[idx].source)
                     let wantStrain = (cls == .manual || cls == .detected) && rows[idx].strain == nil
-                    group.addTask { [deviceId] in
-                        let samples = (try? await store.hrSamples(deviceId: deviceId,
+                    // #510: read HR under the workout's OWN recording strap, not a single active id. A detected
+                    // row's `source` IS its computed strap id ("<base>-noop"), so a bout auto-detected on a 2nd
+                    // WHOOP reads "<base>" instead of the active strap's empty window. Resolved on the main actor;
+                    // only the resulting Sendable String crosses into the task.
+                    let hrDeviceId = Self.workoutHrDeviceId(source: rows[idx].source, activeStrapId: deviceId)
+                    group.addTask { [hrDeviceId] in
+                        let samples = (try? await store.hrSamples(deviceId: hrDeviceId,
                                                                   from: startTs, to: endTs,
                                                                   limit: 8000)) ?? []
                         guard samples.count >= minSamples else { return nil }
@@ -2148,6 +2153,20 @@ final class Repository: ObservableObject {
                               avgHr: r.avg, maxHr: newMax, strain: newStrain, distanceM: row.distanceM,
                               zonesJSON: row.zonesJSON, notes: row.notes)
         }
+    }
+
+    /// #510 (Kotlin twin: `WhoopRepository.workoutHrDeviceId`). The device id whose `hrSample` rows back a
+    /// workout's Avg HR / Effort reconcile. A DETECTED row's own `source` IS its computed strap id
+    /// ("<base>-noop"), so strip the suffix to read HR under the raw "<base>" — a bout auto-detected on a
+    /// SECOND WHOOP no longer reads the active strap's empty window (which blanked its reconcile). MANUAL and
+    /// IMPORTED rows carry no strap id in `source`, so they reconcile against the active strap [activeStrapId]
+    /// as before; on a single-device install a detected "<base>-noop" strips to the active id, so the read is
+    /// byte-identical. (The Kotlin twin also keys MANUAL rows on their stored deviceId; the Swift read-model
+    /// `WorkoutRow` carries no deviceId, so a manual session created on a NON-active strap reconciles here
+    /// against the active strap instead — a minor, display-only divergence, never persisted.)
+    nonisolated static func workoutHrDeviceId(source: String, activeStrapId: String) -> String {
+        guard WorkoutSource.classify(source) == .detected else { return activeStrapId }
+        return source.hasSuffix("-noop") ? String(source.dropLast(5)) : source
     }
 
     /// #833: the per-workout HR reduction (mean bpm → rounded Int, peak bpm), pulled OUT of the @MainActor

--- a/StrandTests/WorkoutHrDeviceKeyTests.swift
+++ b/StrandTests/WorkoutHrDeviceKeyTests.swift
@@ -1,0 +1,49 @@
+import XCTest
+@testable import Strand
+
+/// #510: `reconcileWorkoutHrWithTrace` used to read every workout's HR window under the Repository's single
+/// active `deviceId`, so a bout auto-detected on a SECOND WHOOP (its `hrSample` rows banked under that strap)
+/// read the active strap's empty window and its Avg HR / Effort went un-reconciled. `Repository.workoutHrDeviceId`
+/// now resolves the read key per row from the workout's own `source`. Kotlin twin: `WorkoutHrDeviceKeyTest`.
+///
+/// NB the Swift read-model `WorkoutRow` carries no `deviceId`, so only DETECTED rows (whose `source` IS their
+/// computed strap id "<base>-noop") can key on their own strap here; MANUAL/IMPORTED rows reconcile against the
+/// active strap. This mirrors the Kotlin fix for the dominant (detected) multi-WHOOP case.
+final class WorkoutHrDeviceKeyTests: XCTestCase {
+
+    /// A bout detected on a 2nd WHOOP lives under "whoop-aabbcc-noop"; its HR is banked under "whoop-aabbcc".
+    /// The active strap being something else must NOT redirect the read to an empty window.
+    func testDetectedReadsItsOwnBaseStrap_notActive() {
+        XCTAssertEqual(
+            Repository.workoutHrDeviceId(source: "whoop-aabbcc-noop", activeStrapId: "my-whoop"),
+            "whoop-aabbcc")
+    }
+
+    /// Single-WHOOP: the canonical detected id strips to the active id, so the read is byte-identical to the
+    /// old `self.deviceId` behaviour.
+    func testDetectedCanonicalIsByteIdenticalToActive() {
+        XCTAssertEqual(
+            Repository.workoutHrDeviceId(source: "my-whoop-noop", activeStrapId: "my-whoop"),
+            "my-whoop")
+    }
+
+    /// Manual rows carry no strap id in `source`, so they reconcile against the active strap (the documented
+    /// display-only divergence from the Kotlin twin, which keys manual rows on their stored deviceId).
+    func testManualReadsActiveStrap() {
+        XCTAssertEqual(
+            Repository.workoutHrDeviceId(source: "manual", activeStrapId: "whoop-aabbcc"),
+            "whoop-aabbcc")
+    }
+
+    /// Imported rows (Apple / activity file / lifting / WHOOP CSV) reconcile against the active strap — the
+    /// worn-strap fill (#77) is unchanged. Includes the legacy `apple_health` spelling and the CSV `my-whoop`
+    /// source (contains "whoop" but not "-noop", so it classifies non-detected and is NOT stripped).
+    func testImportedReadsActiveStrap() {
+        for src in ["apple-health", "apple_health", "activity-file", "lifting", "my-whoop", "Health Connect"] {
+            XCTAssertEqual(
+                Repository.workoutHrDeviceId(source: src, activeStrapId: "whoop-aabbcc"),
+                "whoop-aabbcc",
+                "imported source \(src) should reconcile against the active strap")
+        }
+    }
+}


### PR DESCRIPTION
## What

Swift/iOS+macOS twin of **#512**. `reconcileWorkoutHrWithTrace` (the display-time Avg-HR/Effort reconcile) read every workout's HR window under the Repository's **single active `deviceId`**. A bout **auto-detected on a second WHOOP** — its `hrSample` rows banked under that strap's id — therefore read the active strap's **empty** window (`samples.count < minSamples`), so its Avg HR went un-reconciled from the trace and a null Effort wasn't recomputed. Single-WHOOP installs matched the active id, so **only multi-WHOOP users were affected**.

## Fix

New `nonisolated static Repository.workoutHrDeviceId(source:activeStrapId:)` resolves the read key per row:

- **Detected** rows: their own `source` **is** the computed strap id (`"<base>-noop"`), so strip the suffix and read HR under the raw `"<base>"`. A bout detected on a 2nd WHOOP now reads its own strap instead of the active one's empty window.
- **Manual / imported** rows carry no strap id in `source`, so they reconcile against the active strap **as before**.

Phase 2 of the reconcile computes the key on the main actor (via `WorkoutSource.classify`) and captures only the resulting `Sendable` `String` into each `withTaskGroup` child — no new actor-crossing.

## Why it's safe

- **Single-device: byte-identical.** A detected `"my-whoop-noop"` strips to `"my-whoop"` == the old active `deviceId`; manual/imported unchanged.
- **Display-only projection**, never persisted (the reconcile is recomputed on every load) — worst case for a multi-strap user is a transient on-screen value, never a bad write.

## Parity note (vs the Kotlin #512 twin)

Kotlin keys **manual** rows on their stored `deviceId` too; the Swift read-model `WorkoutRow` (WhoopStore, `Codable`) carries **no** `deviceId`, so a manual session created on a *non-active* strap reconciles here against the active strap — a minor, display-only divergence. The **detected**-dominant multi-WHOOP bug is fixed on both platforms; closing the manual-row gap would mean threading the source id through the workout fetch/dedup, deferred as not worth the risk to the single-device path.

## Test / verification

`WorkoutHrDeviceKeyTests` (StrandTests) mirrors the Kotlin `WorkoutHrDeviceKeyTest`. App-target compile (macOS + iOS) verified via an on-demand `app-build.yml` run (app-target Swift has no default CI).
