### PR TITLE
i18n: localize the 9.0.1 What's New title (unblock the coverage gate)

### DIFF
--- a/android/app/src/main/java/com/noop/ui/AppChangelog.kt
+++ b/android/app/src/main/java/com/noop/ui/AppChangelog.kt
@@ -39,7 +39,7 @@ object AppChangelog {
     val releases: List<Release> = listOf(
         Release(
             version = "9.0.1",
-            title = "German, French & Spanish, pull-to-sync on Today, and a wave of polish",
+            title = uiString(R.string.l10n_app_changelog_german_french_spanish_pull_to_sync_1109bda2),
             date = "July 2026",
             items = listOf(
                 "**NOOP now speaks German, French and Spanish (#453).** The whole app — every screen and label — is translated across iPhone, Mac and Android, so it reads in your language end to end.",

--- a/android/app/src/main/res/values-de/strings.xml
+++ b/android/app/src/main/res/values-de/strings.xml
@@ -1141,6 +1141,7 @@
     <string name="l10n_app_changelog_optional_inactivity_nudge_3f4ca05a">Optionaler Inaktivitäts-Nudge</string>
     <string name="l10n_app_changelog_personal_vital_baselines_mac_analytics_parity_744972d1">Persönliche Vital Baselines + Mac Analytics Parität</string>
     <string name="l10n_app_changelog_polish_matched_to_the_iphone_mac_cc34126b">Polnisch - abgestimmt auf das iPhone &amp; Mac Design</string>
+    <string name="l10n_app_changelog_german_french_spanish_pull_to_sync_1109bda2">Deutsch, Französisch und Spanisch, Pull-to-Sync auf Today und viele Verbesserungen</string>
     <string name="l10n_app_changelog_power_saving_that_protects_your_strap_57a32503">Energieeinsparung, die Ihren Riemen schützt, ein Gemini-powered Coach auf Android und reichere metrische Details</string>
     <string name="l10n_app_changelog_raw_spo_honest_units_and_a_55e83a59">Raw SpO2, ehrliche Einheiten und eine leichtere App</string>
     <string name="l10n_app_changelog_re_scan_actually_scans_on_android_22198c8c">Re-Scan tatsächlich scannt auf Android</string>

--- a/android/app/src/main/res/values-es/strings.xml
+++ b/android/app/src/main/res/values-es/strings.xml
@@ -986,6 +986,7 @@
     <string name="l10n_app_changelog_optional_inactivity_nudge_3f4ca05a">Juicio de inactividad opcional</string>
     <string name="l10n_app_changelog_personal_vital_baselines_mac_analytics_parity_744972d1">Bases vitales personales + Paridad analítica de Mac</string>
     <string name="l10n_app_changelog_polish_matched_to_the_iphone_mac_cc34126b">Polaco - compatible con el diseño iPhone &amp;amp; Mac</string>
+    <string name="l10n_app_changelog_german_french_spanish_pull_to_sync_1109bda2">Alemán, francés y español, deslizar para sincronizar en Today y una oleada de mejoras</string>
     <string name="l10n_app_changelog_power_saving_that_protects_your_strap_57a32503">Ahorro de energía que protege su correa, un entrenador con Géminis en Android, y detalles métricos más ricos</string>
     <string name="l10n_app_changelog_raw_spo_honest_units_and_a_55e83a59">Raw SpO2, unidades honestas y una aplicación más ligera</string>
     <string name="l10n_app_changelog_re_scan_actually_scans_on_android_22198c8c">Re-scan en realidad escanea en Android</string>

--- a/android/app/src/main/res/values-fr/strings.xml
+++ b/android/app/src/main/res/values-fr/strings.xml
@@ -986,6 +986,7 @@
     <string name="l10n_app_changelog_optional_inactivity_nudge_3f4ca05a">Inactivité optionnelle</string>
     <string name="l10n_app_changelog_personal_vital_baselines_mac_analytics_parity_744972d1">Bases vitales personnelles + parité d\'analyse Mac</string>
     <string name="l10n_app_changelog_polish_matched_to_the_iphone_mac_cc34126b">Polonais - adapté au design iPhone &amp; Mac</string>
+    <string name="l10n_app_changelog_german_french_spanish_pull_to_sync_1109bda2">Allemand, français et espagnol, glisser pour synchroniser sur Today et une vague d\'améliorations</string>
     <string name="l10n_app_changelog_power_saving_that_protects_your_strap_57a32503">Économie d\'énergie qui protège votre sangle, un entraîneur Gemini sur Android, et plus riche détail métrique</string>
     <string name="l10n_app_changelog_raw_spo_honest_units_and_a_55e83a59">Raw SpO2, des unités honnêtes, et une application plus légère</string>
     <string name="l10n_app_changelog_re_scan_actually_scans_on_android_22198c8c">Re-scan scanne réellement sur Android</string>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -1150,6 +1150,7 @@
     <string name="l10n_app_changelog_optional_inactivity_nudge_3f4ca05a">Optional inactivity nudge</string>
     <string name="l10n_app_changelog_personal_vital_baselines_mac_analytics_parity_744972d1">Personal vital baselines + Mac analytics parity</string>
     <string name="l10n_app_changelog_polish_matched_to_the_iphone_mac_cc34126b">Polish - matched to the iPhone &amp; Mac design</string>
+    <string name="l10n_app_changelog_german_french_spanish_pull_to_sync_1109bda2">German, French &amp; Spanish, pull-to-sync on Today, and a wave of polish</string>
     <string name="l10n_app_changelog_power_saving_that_protects_your_strap_57a32503">Power saving that protects your strap, a Gemini-powered coach on Android, and richer metric detail</string>
     <string name="l10n_app_changelog_raw_spo_honest_units_and_a_55e83a59">Raw SpO₂, honest units, and a lighter app</string>
     <string name="l10n_app_changelog_re_scan_actually_scans_on_android_22198c8c">Re-scan actually scans on Android</string>


### PR DESCRIPTION
## Why

The **9.0.1 release** generated its What's New title into `AppChangelog.kt` as a **raw Kotlin literal**:

```kotlin
title = "German, French & Spanish, pull-to-sync on Today, and a wave of polish",   // ← raw
```

Every other entry uses a localized resource (`uiString(R.string.l10n_app_changelog_…)`). The full-tree i18n audit (`Tools/i18n_audit.py`) flags the raw `title = "…"` — and because **i18n-coverage runs only on `pull_request`, never on the release's push to `main`**, it landed unaudited and now **red-checks every open PR** (#507, #512, #513) on a line none of them touched.

## Fix

Localize the title exactly like the prior entries:
- `AppChangelog.kt` → `title = uiString(R.string.l10n_app_changelog_german_french_spanish_pull_to_sync_1109bda2)`
- add that string to `values/` (en) **and** the `de` / `es` / `fr` focus locales (the coverage half of the gate needs all three).

The key follows the established scheme — first-6-word slug + `sha1(title)[:8]` — verified to reproduce the existing 9.0.0 / 8.7.0 / 8.6.2 keys.

## Verification

- `python3 Tools/i18n_audit.py --ci origin/main` → **OK no hardcoded literals** (exit 0)
- `./gradlew compileFullDebugKotlin` → **BUILD SUCCESSFUL** (R.string resolves, XML well-formed)

## Scope / follow-ups (not in this PR)

- **Apple unaffected**: SwiftUI auto-extracts string literals, so the Swift changelog title passes the Apple audit as-is.
- **Prevent recurrence**: either run the i18n audit on the release push, or have `appchangelog-gen.py` emit the localized key directly — otherwise the next release re-breaks the gate for all PRs the same way.
