### PR TITLE
iOS: stop the tab-swipe gesture from breaking NavigationStack's back-swipe

### DIFF
--- a/StrandiOS/App/RootTabView.swift
+++ b/StrandiOS/App/RootTabView.swift
@@ -82,21 +82,13 @@ struct RootTabView: View {
             // Tab crossfade — README §Motion: ~240ms opacity swap between tab roots, global calm
             // easing cubic-bezier(0.22,1,0.36,1).
             .animation(.timingCurve(0.22, 1, 0.36, 1, duration: 0.24), value: selectedTab)
-            // Swipe left/right anywhere to move between tabs (2026-07-02). Simultaneous so vertical
-            // scrolling still works; only a decisive horizontal flick switches tabs.
-            .simultaneousGesture(
-                DragGesture(minimumDistance: 24)
-                    .onEnded { v in
-                        // Today (tab 0) uses horizontal swipe to change DAYS, so tab-swipe is off there.
-                        guard selectedTab != 0 else { return }
-                        let dx = v.translation.width, dy = v.translation.height
-                        guard abs(dx) > 60, abs(dx) > abs(dy) * 1.6 else { return }
-                        let next = min(3, max(0, selectedTab + (dx < 0 ? 1 : -1)))
-                        if next != selectedTab {
-                            withAnimation(.timingCurve(0.22, 1, 0.36, 1, duration: 0.24)) { selectedTab = next }
-                        }
-                    }
-            )
+            // Swipe left/right anywhere to move between tabs (2026-07-02), but ONLY while the current
+            // tab is at its root. Attaching this ancestor drag gesture unconditionally defeated the
+            // edge-restriction of a pushed NavigationStack screen's native interactive-pop gesture —
+            // any More-tab subscreen (Settings, Devices, …) became draggable/rubber-banding from
+            // anywhere, not just the left edge. Removing the recognizer entirely once a push is active
+            // (rather than just gating the onEnded action) is what actually stops the interference.
+            .modifier(TabSwipeGestureModifier(isEnabled: tabPaths[selectedTab].isEmpty, selectedTab: $selectedTab))
 
             FloatingTabBar(selection: $selectedTab, onReselect: { tag in
                 // Re-tapping the active tab refreshes that page's data (2026-07-02) and, from a
@@ -480,6 +472,36 @@ private enum MoreDestination: Hashable {
         case .testCentre:      TestCentreView()
         case .siriShortcuts:   SiriShortcutsSettingsView()
         case .settings:        SettingsView()
+        }
+    }
+}
+
+/// Attaches the anywhere-swipe tab-switch gesture only when `isEnabled` (i.e. the current tab has no
+/// pushed subscreen) — conditionally, not just gating the action, so the `UIPanGestureRecognizer`
+/// itself is absent from the hierarchy while a `NavigationStack` push is active. A `Bool` captured
+/// inside `onEnded` alone wouldn't do this: the recognizer would still be attached and able to compete
+/// with (and defeat) the pushed screen's native interactive-pop gesture before `onEnded` ever fires.
+private struct TabSwipeGestureModifier: ViewModifier {
+    let isEnabled: Bool
+    @Binding var selectedTab: Int
+
+    func body(content: Content) -> some View {
+        if isEnabled {
+            content.simultaneousGesture(
+                DragGesture(minimumDistance: 24)
+                    .onEnded { v in
+                        // Today (tab 0) uses horizontal swipe to change DAYS, so tab-swipe is off there.
+                        guard selectedTab != 0 else { return }
+                        let dx = v.translation.width, dy = v.translation.height
+                        guard abs(dx) > 60, abs(dx) > abs(dy) * 1.6 else { return }
+                        let next = min(3, max(0, selectedTab + (dx < 0 ? 1 : -1)))
+                        if next != selectedTab {
+                            withAnimation(.timingCurve(0.22, 1, 0.36, 1, duration: 0.24)) { selectedTab = next }
+                        }
+                    }
+            )
+        } else {
+            content
         }
     }
 }


### PR DESCRIPTION
## Summary
- Reported via screen recording: on iOS, the Settings screen (reached via More -> Settings, a `NavigationStack` push) could be dragged/rubber-banded left and right from anywhere, cutting off text and revealing blank edges.
- Root cause: the "swipe anywhere to switch tabs" gesture added 2026-07-03 (`RootTabView.swift`) attaches a `simultaneousGesture(DragGesture(...))` to the outer `TabView` unconditionally. That's an ancestor of every pushed `NavigationStack` screen (Settings, Devices, Health, ...), and an ancestor `simultaneousGesture` is a known way to defeat the edge-restriction of a pushed screen's native interactive-pop ("swipe back") gesture, making the whole screen draggable from anywhere instead of just the left edge.
- Fix: gate the gesture's *attachment* (not just the `onEnded` action) on `tabPaths[selectedTab].isEmpty` via a small conditional `ViewModifier`, so the recognizer is entirely absent from the view hierarchy whenever the current tab has a pushed subscreen. Today's own day-swipe carve-out (`selectedTab != 0`) and the flick-decisiveness threshold are unchanged.
- This fixes it structurally for every `MoreDestination` push and any push under Trends/Sleep, not just Settings, since they all sit under the same `TabView`.

## Test plan
- [x] `xcodebuild -scheme NOOPiOS -destination 'platform=iOS Simulator,name=iPhone 17' build` — succeeds
- [x] App installed and launched in the iPhone 17 simulator
- [ ] Manual interactive check (not run here — no touch-injection tooling such as `idb`/`cliclick` available in this environment): More -> Settings, drag from mid-screen -> should no longer rubber-band; edge-swipe-back from the left edge should still pop to More; a decisive horizontal flick at a tab's root (e.g. Trends/Sleep) should still switch tabs; Today should remain unaffected (day-swipe only)