### PR TITLE
fix(workouts): scroll the manual-workout sheet instead of rigidly shifting it

### DIFF
--- a/Strand/Screens/ManualWorkoutSheet.swift
+++ b/Strand/Screens/ManualWorkoutSheet.swift
@@ -65,6 +65,41 @@ struct ManualWorkoutSheet: View {
     }
 
     var body: some View {
+        #if os(macOS)
+        formContent
+            .padding(NoopMetrics.space6)
+            .frame(width: 420)
+            .background(StrandPalette.surfaceOverlay)
+            // Lets the user dismiss the decimal pad (which has no return key) and reach Cancel/Add.
+            .keyboardDoneToolbar($focusedField)
+        #else
+        // #450 raised the sheet to .large so the keyboard had room, but the body was still a bare
+        // fixed-height VStack — with no ScrollView to absorb the squeeze, iOS's own keyboard-avoidance
+        // had no choice but to rigidly shift the WHOLE block up to keep the focused Sport field clear
+        // of the keyboard. That shift could push the header + Sport field (and the top of its floating
+        // suggestion overlay) off the top of the screen entirely — "recents still clip" — and could also
+        // carry the footer's Add/Cancel row up into the same band where the system's own keyboard
+        // "Done" accessory renders, producing the floating Fertig/Hinzufügen overlap. Wrapping in a
+        // ScrollView gives keyboard-avoidance somewhere to scroll INSTEAD of rigidly displacing fixed
+        // content, so nothing needs to leave its own bounds to stay clear of the keyboard.
+        ScrollView {
+            formContent
+                .padding(NoopMetrics.space6)
+        }
+        .scrollDismissesKeyboard(.interactively)
+        // A fixed 420pt is right for the free-floating macOS sheet, but on iPhone it's wider than
+        // the screen, so the Avg HR/Calories row, the Start DatePicker and the footer ran off the
+        // right edge (#185, same fix as WhatsNewView/ScoringGuideView). iOS fills the presented
+        // sheet's width and sizes to content height instead.
+        .frame(maxWidth: .infinity)
+        .noopSheetPresentation(largeFirst: true)
+        .background(StrandPalette.surfaceOverlay)
+        // Lets the user dismiss the decimal pad (which has no return key) and reach Cancel/Add.
+        .keyboardDoneToolbar($focusedField)
+        #endif
+    }
+
+    private var formContent: some View {
         VStack(alignment: .leading, spacing: NoopMetrics.space5) {
             header
             VStack(alignment: .leading, spacing: NoopMetrics.space4) {
@@ -105,25 +140,6 @@ struct ManualWorkoutSheet: View {
             if avgHrEditedNote { noteRow(String(localized: "Avg HR is shown as typed. The HR graph, zones and Effort stay from the recorded session.")) }
             footer
         }
-        .padding(NoopMetrics.space6)
-        // A fixed 420pt is right for the free-floating macOS sheet, but on iPhone it's wider than
-        // the screen, so the Avg HR/Calories row, the Start DatePicker and the footer ran off the
-        // right edge (#185, same fix as WhatsNewView/ScoringGuideView). iOS fills the presented
-        // sheet's width and sizes to content height instead.
-        #if os(macOS)
-        .frame(width: 420)
-        #else
-        .frame(maxWidth: .infinity)
-        // Full height, not .medium: the Sportart field's floating Recent/catalogue overlay (see
-        // sportPicker below) needs headroom below the field once the keyboard is up. At .medium the
-        // fixed-height VStack has no ScrollView to absorb the squeeze, so the keyboard pushed the
-        // header, the Sportart field and the overlay anchored to it off the top of the sheet —
-        // "recents vanish" was really the panel being clipped along with its off-screen anchor.
-        .noopSheetPresentation(largeFirst: true)
-        #endif
-        .background(StrandPalette.surfaceOverlay)
-        // Lets the user dismiss the decimal pad (which has no return key) and reach Cancel/Add. No-op on macOS.
-        .keyboardDoneToolbar($focusedField)
     }
 
     // MARK: - Sport picker


### PR DESCRIPTION
## Problem
Follow-up to #450 (merged). A fresh screen recording shows the reported clipping is still there after that fix: opening **Workouts -> Add workout**, tapping the Sportart field to bring up the keyboard, the Recent/catalogue suggestion panel is still clipped, and additionally the system keyboard's own "Done" ("Fertig") accessory button visibly overlaps the sheet's own "Hinzufügen"/Add button.

## Root cause
#450 moved `ManualWorkoutSheet` from `.medium` to `.large` presentation detent so the keyboard would have more headroom, but the sheet's body stayed a bare fixed-height `VStack` with no `ScrollView`. With nothing to absorb the squeeze, iOS's automatic keyboard-avoidance for the focused Sport field has no choice but to shift the *entire* fixed block up as one rigid unit. That shift can push the header + Sport field (and the top edge of its floating suggestion overlay, anchored via `.overlay(alignment: .bottom)`) off the top of the screen entirely — which is what "recents still clip" actually is. The same rigid shift can also carry the footer's Add/Cancel row up into the exact band where the system's own keyboard accessory ("Done"/"Fertig", added via `.keyboardDoneToolbar`) renders, producing the floating-button overlap.

## Fix
Wrap the sheet's content in a `ScrollView` on iOS (macOS's free-floating 420pt panel has a hardware keyboard and isn't affected, so it's left untouched) so keyboard-avoidance has somewhere to scroll *instead of* displacing fixed content. This matches the pattern `MarkerEditorView` already uses for the same reason. `StartWorkoutSheet` in the same file is untouched — its suggestion list is already an inline bounded `ScrollView`, not an off-layout overlay, and it wasn't reported.

## Test plan
- [x] `xcodegen generate && xcodebuild -scheme Strand -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO build` — succeeds
- [x] `xcodebuild -scheme NOOPiOS -destination 'platform=iOS Simulator,name=iPhone 17' build` — succeeds; app installed and launched in the iPhone 17 simulator
- [ ] Manual: open Add Workout, tap Sportart, confirm the header/field/Recent-panel stay fully on-screen with the keyboard up, and the Add/Cancel row no longer collides with the keyboard's Done button (not run here — no touch-injection tooling such as `idb`/`cliclick` available in this environment to drive the keyboard interaction; needs a hands-on pass before merging, same as the original report)