### PR TITLE
Whoop5Config: correct enable_sig12 value to ASCII '1' (0x31)

### DIFF
--- a/Packages/WhoopProtocol/Sources/WhoopProtocol/Whoop5Config.swift
+++ b/Packages/WhoopProtocol/Sources/WhoopProtocol/Whoop5Config.swift
@@ -46,6 +46,8 @@ public enum Whoop5Config {
     /// on-strap iOS HCI capture of the official app (WHOOP 5.0, #103), which otherwise reproduced flags
     /// 1–15 byte-for-byte in this exact order. Its effect is undocumented (like `enable_sig11_during_sleep`);
     /// it is included because it is part of what the official app actually writes on every connect.
+    /// `enable_sig12`'s value was corrected 0x32→0x31 (#423): a second real on-strap capture, this time
+    /// spanning a live workout, reproduced flags 1–15 identically but decoded `enable_sig12` as ASCII '1'.
     public static let enableR22Sequence: [Flag] = [
         Flag("enable_r22_packets", 0x32),
         Flag("enable_r22_v2_packets", 0x32),
@@ -62,7 +64,7 @@ public enum Whoop5Config {
         Flag("enable_passive_strap_fit_gen5", 0x31),
         Flag("enable_sig11_during_sleep", 0x32),
         Flag("dorset_inhibit_wpt", 0x32),
-        Flag("enable_sig12", 0x32),   // #103: 16th flag seen in a real on-strap capture, not in judes.club
+        Flag("enable_sig12", 0x31),   // #423: real on-strap capture during a live workout, corrected from 0x32
     ]
 
     /// The 40-byte SET_CONFIG payload body: flag name as UTF-8/ASCII NUL-padded to 32 bytes, value byte

--- a/Packages/WhoopProtocol/Tests/WhoopProtocolTests/Whoop5ConfigTests.swift
+++ b/Packages/WhoopProtocol/Tests/WhoopProtocolTests/Whoop5ConfigTests.swift
@@ -52,20 +52,22 @@ final class Whoop5ConfigTests: XCTestCase {
     }
 
     func testEnableSequenceEndsWithSig12FromRealCapture() {
-        // #103: the 16th flag `enable_sig12` (value ASCII '2') was observed in a real on-strap HCI capture
-        // of the official app, appended after the 15 judes.club-documented flags. It uses the identical
-        // SET_CONFIG encoding, so its frame must build, verify, and carry the exact name+value body.
+        // #103: the 16th flag `enable_sig12` was observed in a real on-strap HCI capture of the official
+        // app, appended after the 15 judes.club-documented flags. It uses the identical SET_CONFIG
+        // encoding, so its frame must build, verify, and carry the exact name+value body.
+        // #423: a second real on-strap capture (this one spanning a live workout) reproduced flags 1–15
+        // identically but decoded enable_sig12's value as ASCII '1' (0x31), not '2' (0x32) — corrected here.
         let seq = Whoop5Config.enableR22Sequence
         XCTAssertEqual(seq.count, 16)
         XCTAssertEqual(seq.last?.name, "enable_sig12")
-        XCTAssertEqual(seq.last?.value, 0x32)
-        let frame = Whoop5Config.frame(flag: Whoop5Config.Flag("enable_sig12", 0x32), seq: 16)
+        XCTAssertEqual(seq.last?.value, 0x31)
+        let frame = Whoop5Config.frame(flag: Whoop5Config.Flag("enable_sig12", 0x31), seq: 16)
         XCTAssertTrue(verifyFrame(frame, family: .whoop5).ok, "enable_sig12 SET_CONFIG must pass CRC")
         // The 40-byte body carried in the frame is name-NUL-padded with the value at offset 32.
-        let body = Whoop5Config.payloadBody(name: "enable_sig12", value: 0x32)
+        let body = Whoop5Config.payloadBody(name: "enable_sig12", value: 0x31)
         XCTAssertEqual(Array(body[0..<12]), Array("enable_sig12".utf8))
         XCTAssertTrue(body[12..<32].allSatisfy { $0 == 0 })
-        XCTAssertEqual(body[32], 0x32)
+        XCTAssertEqual(body[32], 0x31)
     }
 
     /// Broadcast-HR device-config body (#181): key name ASCII NUL-padded to 32 bytes, then the value

--- a/android/app/src/main/java/com/noop/protocol/Whoop5Config.kt
+++ b/android/app/src/main/java/com/noop/protocol/Whoop5Config.kt
@@ -34,7 +34,9 @@ object Whoop5Config {
      *  detection and sleep behaviour. Flags 1–15 are transcribed verbatim from judes.club's frame-builder
      *  FLAGS array; flag 16 `enable_sig12` is NOT in that array — it was observed as a 16th SET_FF_VALUE
      *  write in a real on-strap iOS HCI capture (WHOOP 5.0, #103) that otherwise reproduced flags 1–15
-     *  byte-for-byte in this order. Keep in lockstep with the Swift `Whoop5Config.enableR22Sequence`. */
+     *  byte-for-byte in this order. `enable_sig12`'s value was corrected 0x32→0x31 (#423): a second real
+     *  on-strap capture, this time spanning a live workout, reproduced flags 1–15 identically but decoded
+     *  enable_sig12 as ASCII '1'. Keep in lockstep with the Swift `Whoop5Config.enableR22Sequence`. */
     val enableR22Sequence: List<Flag> = listOf(
         Flag("enable_r22_packets", 0x32),
         Flag("enable_r22_v2_packets", 0x32),
@@ -51,7 +53,7 @@ object Whoop5Config {
         Flag("enable_passive_strap_fit_gen5", 0x31),
         Flag("enable_sig11_during_sleep", 0x32),
         Flag("dorset_inhibit_wpt", 0x32),
-        Flag("enable_sig12", 0x32),   // #103: 16th flag seen in a real on-strap capture, not in judes.club
+        Flag("enable_sig12", 0x31),   // #423: real on-strap capture during a live workout, corrected from 0x32
     )
 
     /** The 40-byte SET_CONFIG payload body: flag name as ASCII NUL-padded to 32 bytes, value byte at

--- a/android/app/src/test/java/com/noop/protocol/Whoop5ConfigTest.kt
+++ b/android/app/src/test/java/com/noop/protocol/Whoop5ConfigTest.kt
@@ -30,13 +30,15 @@ class Whoop5ConfigTest {
         assertEquals(16, seq.size)
         assertEquals("enable_r22_packets", seq[0].name)
         assertEquals(0x32, seq[0].value)
-        // v4 and the passive-strap-fit flag are the only '1' (0x31) values in the documented set.
+        // v4 and the passive-strap-fit flag are the only '1' (0x31) values in the judes.club-documented
+        // 15-flag set (enable_sig12, flag 16, is a third — see below).
         assertEquals(0x31, seq.first { it.name == "enable_r22_v4_packets" }.value)
         assertEquals(0x31, seq.first { it.name == "enable_passive_strap_fit_gen5" }.value)
-        // #103: the 16th flag `enable_sig12` (value '2') was seen in a real on-strap capture, appended
-        // after the 15 judes.club-documented flags. Mirror of the Swift Whoop5ConfigTests guard.
+        // #103: the 16th flag `enable_sig12` was seen in a real on-strap capture, appended after the 15
+        // judes.club-documented flags. #423: a second real on-strap capture (spanning a live workout)
+        // decoded its value as '1' (0x31), not '2' — corrected here. Mirror of the Swift Whoop5ConfigTests guard.
         assertEquals("enable_sig12", seq.last().name)
-        assertEquals(0x32, seq.last().value)
+        assertEquals(0x31, seq.last().value)
     }
 
     @Test


### PR DESCRIPTION
## Summary
- A fresh on-strap HCI capture of the official WHOOP app during a live workout (see [#423](https://github.com/ryanbr/noop/issues/423)) reproduced the R22 enable-flag sequence's first 15 flags byte-for-byte against the existing `enableR22Sequence` table.
- Flag 16, `enable_sig12`, decoded as ASCII `'1'` (0x31) in this capture — not `'2'` (0x32) as transcribed from the single #103 capture the table was originally built from.
- Fixed on both platforms per the byte-parity contract: `Whoop5Config.swift` and its `Whoop5ConfigTests`, `Whoop5Config.kt` and its `Whoop5ConfigTest`.
- The flag's effect is still undocumented (as the existing comments already note) — this is a byte-accuracy correction to match what the official app actually sends, not a behavior change.

## Test plan
- [x] `swift test --filter Whoop5ConfigTests` — 6/6 pass
- [x] `swift test` (full `Packages/WhoopProtocol` suite) — 285/285 pass
- [x] `./gradlew testFullDebugUnitTest --tests "com.noop.protocol.Whoop5ConfigTest"` — 3/3 pass