### PR TITLE
Add a recompute action for deleted sleep windows

### DIFF
--- a/android/app/src/main/java/com/noop/data/WhoopRepository.kt
+++ b/android/app/src/main/java/com/noop/data/WhoopRepository.kt
@@ -746,6 +746,16 @@ class WhoopRepository(private val dao: WhoopDao) {
     suspend fun dismissedSleeps(strapDeviceId: String = "my-whoop"): List<DismissedSleep> =
         dao.dismissedSleeps(strapDeviceId) + dao.dismissedSleeps(computedDeviceId(strapDeviceId))
 
+    /** Deleted-sleep tombstones across the active strap + canonical import union (#515). The Sleep screen
+     *  uses this management view so a night deleted before a strap remove/re-add does not lose its
+     *  "Recompute this night" escape hatch. The engine-facing [dismissedSleeps] stays scoped to the source
+     *  it is currently analysing; this read is deliberately broader because it is user-facing history. */
+    suspend fun dismissedSleepsUnion(activeDeviceId: String): List<DismissedSleep> =
+        (importedSourceIds(activeDeviceId) + computedSourceIds(activeDeviceId))
+            .flatMap { dao.dismissedSleeps(it) }
+            .distinctBy { it.deviceId to it.startTs }
+            .sortedByDescending { it.endTs }
+
     /**
      * Persist a retroactive / edited manual workout under the strap source. [replacing] is the row the
      * edit started from:

--- a/android/app/src/main/java/com/noop/ui/AppViewModel.kt
+++ b/android/app/src/main/java/com/noop/ui/AppViewModel.kt
@@ -1276,6 +1276,19 @@ class AppViewModel(app: Application) : AndroidViewModel(app) {
         rescoreAfterEdit()
     }
 
+    /** Re-open one deliberately deleted sleep window (#515): remove its durable tombstone first, then
+     *  immediately run the normal detector/scorer over the stored raw data. Unlike optimistic edits, this
+     *  returns false when the marker could not be removed — rescoring while it is still present would keep
+     *  suppressing the night and make a successful-looking button a no-op. */
+    suspend fun recomputeDeletedSleep(marker: com.noop.data.DismissedSleep): Boolean {
+        val cleared = runCatching {
+            repository.allowSleepReDetection(marker.deviceId, marker.startTs)
+        }.isSuccess
+        if (!cleared) return false
+        rescoreAfterEdit()
+        return true
+    }
+
     /** Manually add a missed nap as its OWN session (#508) — staged from raw, written under the computed
      *  source with userEdited=true so the recompute guard keeps it and it's never folded into main sleep —
      *  then re-score the affected day immediately so the day's aggregates pick up the new session, matching

--- a/android/app/src/main/java/com/noop/ui/SleepScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/SleepScreen.kt
@@ -435,9 +435,9 @@ fun SleepScreen(
                             Toast.makeText(
                                 context,
                                 if (cleared) {
-                                    "Sleep detection reran using the data available for this night."
+                                    uiString(R.string.l10n_sleep_screen_sleep_detection_reran_using_the_data_01757aad)
                                 } else {
-                                    "Couldn't reopen this night. Try again."
+                                    uiString(R.string.l10n_sleep_screen_couldn_t_reopen_this_night_try_88265690)
                                 },
                                 Toast.LENGTH_SHORT,
                             ).show()
@@ -717,9 +717,13 @@ private fun DeletedSleepWindowsCard(
     NoopCard(tint = Palette.restColor) {
         Column(verticalArrangement = Arrangement.spacedBy(Metrics.space12)) {
             Column(verticalArrangement = Arrangement.spacedBy(Metrics.space2)) {
-                Text("Deleted sleep windows", style = NoopType.headline, color = Palette.textPrimary)
                 Text(
-                    "Recompute a night to clear its deletion marker and scan the available raw data again.",
+                    uiString(R.string.l10n_sleep_screen_deleted_sleep_windows_46fea77a),
+                    style = NoopType.headline,
+                    color = Palette.textPrimary,
+                )
+                Text(
+                    uiString(R.string.l10n_sleep_screen_recompute_a_night_to_clear_its_fd9e15c3),
                     style = NoopType.footnote,
                     color = Palette.textSecondary,
                 )
@@ -733,7 +737,11 @@ private fun DeletedSleepWindowsCard(
                     horizontalArrangement = Arrangement.spacedBy(Metrics.space8),
                 ) {
                     Text(
-                        "${dateFmt.format(Date(marker.startTs * 1000L))} – ${dateFmt.format(Date(marker.endTs * 1000L))}",
+                        uiString(
+                            R.string.l10n_sleep_screen_deleted_sleep_window_range_7bc5f027,
+                            dateFmt.format(Date(marker.startTs * 1000L)),
+                            dateFmt.format(Date(marker.endTs * 1000L)),
+                        ),
                         style = NoopType.footnote,
                         color = Palette.textSecondary,
                         modifier = Modifier.weight(1f),
@@ -742,11 +750,17 @@ private fun DeletedSleepWindowsCard(
                         enabled = recomputing == null,
                         onClick = { onRecompute(marker) },
                         modifier = Modifier.semantics {
-                            contentDescription = "Recompute this deleted sleep night"
+                            contentDescription = uiString(
+                                R.string.l10n_sleep_screen_recompute_this_deleted_sleep_night_2d2f46f6,
+                            )
                         },
                     ) {
                         Text(
-                            if (busy) "Recomputing…" else "Recompute this night",
+                            if (busy) {
+                                uiString(R.string.l10n_sleep_screen_recomputing_6f8e54e3)
+                            } else {
+                                uiString(R.string.l10n_sleep_screen_recompute_this_night_5ba0d05c)
+                            },
                             style = NoopType.subhead,
                             color = if (recomputing == null) Palette.restColor else Palette.textTertiary,
                         )
@@ -754,7 +768,7 @@ private fun DeletedSleepWindowsCard(
                 }
             }
             Text(
-                "If this sleep came only from an import and no raw samples are stored, it may not reappear.",
+                uiString(R.string.l10n_sleep_screen_if_this_sleep_came_only_from_d0892088),
                 style = NoopType.footnote,
                 color = Palette.textTertiary,
             )

--- a/android/app/src/main/java/com/noop/ui/SleepScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/SleepScreen.kt
@@ -88,6 +88,7 @@ import com.noop.analytics.SleepDebtLedger
 import com.noop.analytics.SleepEditGuard
 import com.noop.analytics.SleepStageTotals
 import com.noop.data.DailyMetric
+import com.noop.data.DismissedSleep
 import com.noop.data.SleepSession
 import com.noop.data.WhoopRepository
 import kotlinx.coroutines.launch
@@ -160,6 +161,10 @@ fun SleepScreen(
     // mergeSleep but WITHOUT the per-night collapse). Keyed on `days` so a sync/import (which always
     // rewrites dailyMetric too) reloads; these reads have no Flow. (#160, #170)
     var sleeps by remember { mutableStateOf<List<SleepSession>>(emptyList()) }
+    // Durable deleted-night markers. Unlike the 7-second Undo banner these remain reachable after the
+    // session row is gone, giving each suppressed window a "Recompute this night" escape hatch (#515).
+    var dismissedSleeps by remember { mutableStateOf<List<DismissedSleep>>(emptyList()) }
+    var recomputingSleep by remember { mutableStateOf<Pair<String, Long>?>(null) }
     // 0 = latest night, N = N sleep-sessions back. Reset to the newest night only on a REAL data
     // reload (new sync / re-import via `days` changing). The optimistic bed/wake edit rewrites
     // `sleeps` in place WITHOUT touching `days`, so it must not reset the browse — keeping the
@@ -191,6 +196,14 @@ fun SleepScreen(
                 .sortedBy { it.effectiveStartTs }
         }.getOrDefault(emptyList())
         nightOffset = 0
+    }
+
+    // Read the active∪canonical management union so a marker created before a strap re-add remains
+    // visible. Keyed on days because deletes/recomputes both rescore and republish the affected day.
+    LaunchedEffect(days) {
+        dismissedSleeps = runCatching {
+            vm.repo.dismissedSleepsUnion(vm.activeStrapId)
+        }.getOrDefault(dismissedSleeps)
     }
 
     // #65: the transient UNDO banner shown after a suppressing delete. Holds the deleted SleepSession
@@ -405,6 +418,34 @@ fun SleepScreen(
                 )
             }
         }
+        if (dismissedSleeps.isNotEmpty()) {
+            item {
+                DeletedSleepWindowsCard(
+                    windows = dismissedSleeps,
+                    recomputing = recomputingSleep,
+                    onRecompute = { marker ->
+                        val key = marker.deviceId to marker.startTs
+                        recomputingSleep = key
+                        scope.launch {
+                            val cleared = vm.recomputeDeletedSleep(marker)
+                            dismissedSleeps = runCatching {
+                                vm.repo.dismissedSleepsUnion(vm.activeStrapId)
+                            }.getOrDefault(dismissedSleeps)
+                            recomputingSleep = null
+                            Toast.makeText(
+                                context,
+                                if (cleared) {
+                                    "Sleep detection reran using the data available for this night."
+                                } else {
+                                    "Couldn't reopen this night. Try again."
+                                },
+                                Toast.LENGTH_SHORT,
+                            ).show()
+                        }
+                    },
+                )
+            }
+        }
         // #940: the empty state is ONLY for a truly empty history. A newest day that merely fails
         // to merge (the phantom-edit shape) keeps the hero (night != null) and the full-history
         // tiles (tilesModel != null), so intact older nights are never hidden behind "no nights".
@@ -500,7 +541,12 @@ fun SleepScreen(
                     // everything undo needs to restore it into the original namespace.
                     sleeps = sleeps.filterNot { it.deviceId == s.deviceId && it.startTs == s.startTs }
                     sleepUndo = s
-                    scope.launch { vm.deleteSleepSession(s) }
+                    scope.launch {
+                        vm.deleteSleepSession(s)
+                        dismissedSleeps = runCatching {
+                            vm.repo.dismissedSleepsUnion(vm.activeStrapId)
+                        }.getOrDefault(dismissedSleeps)
+                    }
                 },
                 onAddNap = { startTs, endTs ->
                     // Persist the new nap as its OWN session (#508); reload `sleeps` afterwards so the
@@ -654,6 +700,64 @@ private fun SleepUndoBanner(session: SleepSession, onUndo: () -> Unit) {
             ) {
                 Text(uiString(R.string.l10n_sleep_screen_undo_39fc7212), style = NoopType.subhead, color = Palette.restColor)
             }
+        }
+    }
+}
+
+/** Persistent management surface for detected nights whose deletion tombstone outlived the transient
+ * Undo banner. Each row targets one exact marker; clearing it lets the normal analysis pass derive sleep
+ * from the raw data again without weakening the default "deleted means deleted" behaviour (#515). */
+@Composable
+private fun DeletedSleepWindowsCard(
+    windows: List<DismissedSleep>,
+    recomputing: Pair<String, Long>?,
+    onRecompute: (DismissedSleep) -> Unit,
+) {
+    val dateFmt = remember { SimpleDateFormat("MMM d, HH:mm", Locale.getDefault()) }
+    NoopCard(tint = Palette.restColor) {
+        Column(verticalArrangement = Arrangement.spacedBy(Metrics.space12)) {
+            Column(verticalArrangement = Arrangement.spacedBy(Metrics.space2)) {
+                Text("Deleted sleep windows", style = NoopType.headline, color = Palette.textPrimary)
+                Text(
+                    "Recompute a night to clear its deletion marker and scan the available raw data again.",
+                    style = NoopType.footnote,
+                    color = Palette.textSecondary,
+                )
+            }
+            windows.forEach { marker ->
+                val key = marker.deviceId to marker.startTs
+                val busy = recomputing == key
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(Metrics.space8),
+                ) {
+                    Text(
+                        "${dateFmt.format(Date(marker.startTs * 1000L))} – ${dateFmt.format(Date(marker.endTs * 1000L))}",
+                        style = NoopType.footnote,
+                        color = Palette.textSecondary,
+                        modifier = Modifier.weight(1f),
+                    )
+                    TextButton(
+                        enabled = recomputing == null,
+                        onClick = { onRecompute(marker) },
+                        modifier = Modifier.semantics {
+                            contentDescription = "Recompute this deleted sleep night"
+                        },
+                    ) {
+                        Text(
+                            if (busy) "Recomputing…" else "Recompute this night",
+                            style = NoopType.subhead,
+                            color = if (recomputing == null) Palette.restColor else Palette.textTertiary,
+                        )
+                    }
+                }
+            }
+            Text(
+                "If this sleep came only from an import and no raw samples are stored, it may not reappear.",
+                style = NoopType.footnote,
+                color = Palette.textTertiary,
+            )
         }
     }
 }

--- a/android/app/src/main/res/values-de/strings.xml
+++ b/android/app/src/main/res/values-de/strings.xml
@@ -1500,7 +1500,11 @@
     <string name="l10n_sleep_screen_delete_f6fdbe48">Löschen</string>
     <string name="l10n_sleep_screen_delete_this_sleep_session_6932e931">Löschen Sie diese Schlafsitzung</string>
     <string name="l10n_sleep_screen_delete_this_sleep_session_c347b909">Diese Schlafsitzung löschen?</string>
+    <string name="l10n_sleep_screen_deleted_sleep_window_range_7bc5f027">%1$s – %2$s</string>
+    <string name="l10n_sleep_screen_deleted_sleep_windows_46fea77a">Gelöschte Schlafzeiträume</string>
     <string name="l10n_sleep_screen_good_morning_33e88869">Guten Morgen!</string>
+    <string name="l10n_sleep_screen_couldn_t_reopen_this_night_try_88265690">Diese Nacht konnte nicht wieder geöffnet werden. Versuche es erneut.</string>
+    <string name="l10n_sleep_screen_if_this_sleep_came_only_from_d0892088">Wenn dieser Schlaf nur aus einem Import stammt und keine Rohdaten gespeichert sind, wird er möglicherweise nicht wieder angezeigt.</string>
     <string name="l10n_sleep_screen_maybe_later_27ad1d83">Vielleicht später</string>
     <string name="l10n_sleep_screen_move_anyway_19ee824d">Bewegt euch sowieso</string>
     <string name="l10n_sleep_screen_move_this_sleep_438dd3b5">Bewegen Sie diesen Schlaf?</string>
@@ -1512,7 +1516,12 @@
     <string name="l10n_sleep_screen_no_stage_data_recorded_for_this_93a86806">Keine Phasendaten für diese Nacht aufgezeichnet.</string>
     <string name="l10n_sleep_screen_open_journal_4bf0daee">Offenes Journal</string>
     <string name="l10n_sleep_screen_previous_night_9f339047">Vorherige Nacht</string>
+    <string name="l10n_sleep_screen_recompute_a_night_to_clear_its_fd9e15c3">Berechne eine Nacht neu, um ihre Löschmarkierung zu entfernen und die verfügbaren Rohdaten erneut zu prüfen.</string>
+    <string name="l10n_sleep_screen_recompute_this_deleted_sleep_night_2d2f46f6">Diese gelöschte Schlafaufzeichnung neu berechnen</string>
+    <string name="l10n_sleep_screen_recompute_this_night_5ba0d05c">Diese Nacht neu berechnen</string>
+    <string name="l10n_sleep_screen_recomputing_6f8e54e3">Wird neu berechnet…</string>
     <string name="l10n_sleep_screen_sleep_3cac34e6">Schlaf</string>
+    <string name="l10n_sleep_screen_sleep_detection_reran_using_the_data_01757aad">Die Schlaferkennung wurde mit den für diese Nacht verfügbaren Daten erneut ausgeführt.</string>
     <string name="l10n_sleep_screen_stage_breakdown_e9b714f9">Phasen-Aufschlüsselung</string>
     <string name="l10n_sleep_screen_this_moves_the_night_to_a_fac2fb46">Dies bewegt die Nacht zu einer Zeit ohne aufgezeichnete Daten. Stufen können dort nicht abgeleitet werden, so dass sie als leer angezeigt werden können, bis die Daten sie abdecken.</string>
     <string name="l10n_sleep_screen_your_night_data_is_in_logging_ec461720">Ihre nachtdaten sind in. Protokollieren, wie Sie sich gefühlt haben, hilft NOOP zu lernen, was Ihre beste Genesung antreibt.</string>

--- a/android/app/src/main/res/values-es/strings.xml
+++ b/android/app/src/main/res/values-es/strings.xml
@@ -1345,7 +1345,11 @@
     <string name="l10n_sleep_screen_delete_f6fdbe48">Eliminar</string>
     <string name="l10n_sleep_screen_delete_this_sleep_session_6932e931">Suprímase esta sesión de sueño</string>
     <string name="l10n_sleep_screen_delete_this_sleep_session_c347b909">¿Eliminar esta sesión de sueño?</string>
+    <string name="l10n_sleep_screen_deleted_sleep_window_range_7bc5f027">%1$s – %2$s</string>
+    <string name="l10n_sleep_screen_deleted_sleep_windows_46fea77a">Periodos de sueño eliminados</string>
     <string name="l10n_sleep_screen_good_morning_33e88869">¡Buenos días!</string>
+    <string name="l10n_sleep_screen_couldn_t_reopen_this_night_try_88265690">No se pudo volver a abrir esta noche. Inténtalo de nuevo.</string>
+    <string name="l10n_sleep_screen_if_this_sleep_came_only_from_d0892088">Si este sueño procede únicamente de una importación y no hay muestras sin procesar guardadas, es posible que no vuelva a aparecer.</string>
     <string name="l10n_sleep_screen_maybe_later_27ad1d83">Quizás más tarde.</string>
     <string name="l10n_sleep_screen_move_anyway_19ee824d">Muévete.</string>
     <string name="l10n_sleep_screen_move_this_sleep_438dd3b5">¿A dormir?</string>
@@ -1357,7 +1361,12 @@
     <string name="l10n_sleep_screen_no_stage_data_recorded_for_this_93a86806">No se registraron datos de fases para esta noche.</string>
     <string name="l10n_sleep_screen_open_journal_4bf0daee">Open Journal</string>
     <string name="l10n_sleep_screen_previous_night_9f339047">Noche anterior</string>
+    <string name="l10n_sleep_screen_recompute_a_night_to_clear_its_fd9e15c3">Vuelve a calcular una noche para borrar su marcador de eliminación y analizar de nuevo los datos sin procesar disponibles.</string>
+    <string name="l10n_sleep_screen_recompute_this_deleted_sleep_night_2d2f46f6">Volver a calcular esta noche de sueño eliminada</string>
+    <string name="l10n_sleep_screen_recompute_this_night_5ba0d05c">Volver a calcular esta noche</string>
+    <string name="l10n_sleep_screen_recomputing_6f8e54e3">Recalculando…</string>
     <string name="l10n_sleep_screen_sleep_3cac34e6">Sueño</string>
+    <string name="l10n_sleep_screen_sleep_detection_reran_using_the_data_01757aad">La detección del sueño se volvió a ejecutar con los datos disponibles para esta noche.</string>
     <string name="l10n_sleep_screen_stage_breakdown_e9b714f9">Desglose de fases</string>
     <string name="l10n_sleep_screen_this_moves_the_night_to_a_fac2fb46">Esto mueve la noche a un tiempo sin datos registrados. Las etapas no se pueden derivar allí, por lo que puede mostrar como vacía hasta que los datos lo cubren.</string>
     <string name="l10n_sleep_screen_your_night_data_is_in_logging_ec461720">Tus datos nocturnos están dentro. Logging how you felt helps NOOP learn what drives your best recovery.</string>

--- a/android/app/src/main/res/values-fr/strings.xml
+++ b/android/app/src/main/res/values-fr/strings.xml
@@ -1345,7 +1345,11 @@
     <string name="l10n_sleep_screen_delete_f6fdbe48">Supprimer</string>
     <string name="l10n_sleep_screen_delete_this_sleep_session_6932e931">Supprimer cette séance de sommeil</string>
     <string name="l10n_sleep_screen_delete_this_sleep_session_c347b909">Supprimer cette session de sommeil ?</string>
+    <string name="l10n_sleep_screen_deleted_sleep_window_range_7bc5f027">%1$s – %2$s</string>
+    <string name="l10n_sleep_screen_deleted_sleep_windows_46fea77a">Périodes de sommeil supprimées</string>
     <string name="l10n_sleep_screen_good_morning_33e88869">Bonjour !</string>
+    <string name="l10n_sleep_screen_couldn_t_reopen_this_night_try_88265690">Impossible de rouvrir cette nuit. Réessayez.</string>
+    <string name="l10n_sleep_screen_if_this_sleep_came_only_from_d0892088">Si ce sommeil provient uniquement d’un import et qu’aucun échantillon brut n’est enregistré, il peut ne pas réapparaître.</string>
     <string name="l10n_sleep_screen_maybe_later_27ad1d83">Peut-être plus tard</string>
     <string name="l10n_sleep_screen_move_anyway_19ee824d">Bouge de toute façon</string>
     <string name="l10n_sleep_screen_move_this_sleep_438dd3b5">Bouge ce sommeil ?</string>
@@ -1357,7 +1361,12 @@
     <string name="l10n_sleep_screen_no_stage_data_recorded_for_this_93a86806">Aucune donnée de stade enregistrée pour cette nuit.</string>
     <string name="l10n_sleep_screen_open_journal_4bf0daee">Journal ouvert</string>
     <string name="l10n_sleep_screen_previous_night_9f339047">Nuit précédente</string>
+    <string name="l10n_sleep_screen_recompute_a_night_to_clear_its_fd9e15c3">Recalculez une nuit pour effacer son marqueur de suppression et analyser à nouveau les données brutes disponibles.</string>
+    <string name="l10n_sleep_screen_recompute_this_deleted_sleep_night_2d2f46f6">Recalculer cette nuit de sommeil supprimée</string>
+    <string name="l10n_sleep_screen_recompute_this_night_5ba0d05c">Recalculer cette nuit</string>
+    <string name="l10n_sleep_screen_recomputing_6f8e54e3">Recalcul en cours…</string>
     <string name="l10n_sleep_screen_sleep_3cac34e6">Sommeil</string>
+    <string name="l10n_sleep_screen_sleep_detection_reran_using_the_data_01757aad">La détection du sommeil a été relancée avec les données disponibles pour cette nuit.</string>
     <string name="l10n_sleep_screen_stage_breakdown_e9b714f9">Répartition des stades</string>
     <string name="l10n_sleep_screen_this_moves_the_night_to_a_fac2fb46">Cela déplace la nuit à une heure sans données enregistrées. Les étapes ne peuvent pas être dérivées là, donc il peut apparaître comme vide jusqu\'à ce que les données le couvrent.</string>
     <string name="l10n_sleep_screen_your_night_data_is_in_logging_ec461720">Vos données de nuit sont dedans. L\'exploitation de vos sentiments aide NOOP à apprendre ce qui motive votre meilleure récupération.</string>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -1509,7 +1509,11 @@
     <string name="l10n_sleep_screen_delete_f6fdbe48">Delete</string>
     <string name="l10n_sleep_screen_delete_this_sleep_session_6932e931">Delete this sleep session</string>
     <string name="l10n_sleep_screen_delete_this_sleep_session_c347b909">Delete this sleep session?</string>
+    <string name="l10n_sleep_screen_deleted_sleep_window_range_7bc5f027">%1$s – %2$s</string>
+    <string name="l10n_sleep_screen_deleted_sleep_windows_46fea77a">Deleted sleep windows</string>
     <string name="l10n_sleep_screen_good_morning_33e88869">Good morning!</string>
+    <string name="l10n_sleep_screen_couldn_t_reopen_this_night_try_88265690">Couldn\'t reopen this night. Try again.</string>
+    <string name="l10n_sleep_screen_if_this_sleep_came_only_from_d0892088">If this sleep came only from an import and no raw samples are stored, it may not reappear.</string>
     <string name="l10n_sleep_screen_maybe_later_27ad1d83">Maybe later</string>
     <string name="l10n_sleep_screen_move_anyway_19ee824d">Move anyway</string>
     <string name="l10n_sleep_screen_move_this_sleep_438dd3b5">Move this sleep?</string>
@@ -1521,7 +1525,12 @@
     <string name="l10n_sleep_screen_no_stage_data_recorded_for_this_93a86806">No stage data recorded for this night.</string>
     <string name="l10n_sleep_screen_open_journal_4bf0daee">Open Journal</string>
     <string name="l10n_sleep_screen_previous_night_9f339047">Previous night</string>
+    <string name="l10n_sleep_screen_recompute_a_night_to_clear_its_fd9e15c3">Recompute a night to clear its deletion marker and scan the available raw data again.</string>
+    <string name="l10n_sleep_screen_recompute_this_deleted_sleep_night_2d2f46f6">Recompute this deleted sleep night</string>
+    <string name="l10n_sleep_screen_recompute_this_night_5ba0d05c">Recompute this night</string>
+    <string name="l10n_sleep_screen_recomputing_6f8e54e3">Recomputing…</string>
     <string name="l10n_sleep_screen_sleep_3cac34e6">Sleep</string>
+    <string name="l10n_sleep_screen_sleep_detection_reran_using_the_data_01757aad">Sleep detection reran using the data available for this night.</string>
     <string name="l10n_sleep_screen_stage_breakdown_e9b714f9">Stage breakdown</string>
     <string name="l10n_sleep_screen_this_moves_the_night_to_a_fac2fb46">This moves the night to a time with no recorded data. Stages can\'t be derived there, so it may show as empty until data covers it.</string>
     <string name="l10n_sleep_screen_your_night_data_is_in_logging_ec461720">Your night data is in. Logging how you felt helps NOOP learn what drives your best recovery.</string>

--- a/android/app/src/test/java/com/noop/ui/SleepEditRescoreTest.kt
+++ b/android/app/src/test/java/com/noop/ui/SleepEditRescoreTest.kt
@@ -55,6 +55,17 @@ class SleepEditRescoreTest {
         rescoreAfterSleepEdit(analyzeRecent)
     }
 
+    /** Pure mirror of recomputeDeletedSleep: the marker must be cleared before analysis, and a failed
+     *  clear must not run a detector that would still suppress the same night. */
+    private suspend fun recomputeDeletedSleep(
+        clearMarker: suspend () -> Unit,
+        analyzeRecent: suspend () -> Unit,
+    ): Boolean {
+        if (runCatching { clearMarker() }.isFailure) return false
+        rescoreAfterSleepEdit(analyzeRecent)
+        return true
+    }
+
     @Test
     fun rescoreRunsAfterAPersist() = runTest {
         val rec = Recorder()
@@ -99,5 +110,27 @@ class SleepEditRescoreTest {
         } catch (e: CancellationException) {
             assertEquals("VM cleared", e.message)
         }
+    }
+
+    @Test
+    fun deletedSleepMarkerIsClearedBeforeRedetection() = runTest {
+        val rec = Recorder()
+        val accepted = recomputeDeletedSleep(
+            clearMarker = { rec.events += "clear" },
+            analyzeRecent = { rec.events += "redetect" },
+        )
+        assertTrue(accepted)
+        assertEquals(listOf("clear", "redetect"), rec.events)
+    }
+
+    @Test
+    fun failedMarkerClearDoesNotRunRedetection() = runTest {
+        val rec = Recorder()
+        val accepted = recomputeDeletedSleep(
+            clearMarker = { throw IllegalStateException("DB write failed") },
+            analyzeRecent = { rec.events += "redetect" },
+        )
+        assertTrue(!accepted)
+        assertTrue(rec.events.isEmpty())
     }
 }


### PR DESCRIPTION
## Summary

- show durable deleted-sleep windows on the Android Sleep screen after the transient Undo banner expires
- add a **Recompute this night** action that clears only the selected deletion tombstone and immediately reruns sleep detection/scoring
- read markers across the active-strap and canonical source union so the escape hatch survives a strap remove/re-add
- keep the marker visible and skip the misleading rescore when its database removal fails

This addresses the deleted-night dead end described in item 4 of #515. Normal deletion behavior is unchanged: detected nights remain suppressed until the user explicitly chooses to recompute one.

## Validation

- `cd android && ./gradlew :app:testFullDebugUnitTest`
- focused deleted-sleep guard, tombstone-policy, and recompute control-flow tests
