### PR TITLE
fix(sleep): Rest hero tracks the navigated night, not the latest

### DIFF
--- a/Strand/Screens/SleepView.swift
+++ b/Strand/Screens/SleepView.swift
@@ -328,11 +328,40 @@ struct SleepView: View {
         .accessibilityLabel(message)
     }
 
-    /// The fill fraction (0…1) the Rest hero gauge animates to — the night's sleep-performance
-    /// score over 100. 0 when no score exists (the headline-hours hero shows instead). Cheap, so
-    /// it's read every render to drive the draw-in animation.
+    /// A short night-relative label ("Last night" / "1 night ago" / "N nights ago") for the
+    /// ◀/▶-navigated night. Shared by the Rest hero overline and the hypnogram nav header so both
+    /// name the SAME night the hero's score is now resolved for.
+    private var nightRelativeLabel: LocalizedStringKey {
+        nightOffset == 0 ? "Last night"
+            : (nightOffset == 1 ? "1 night ago" : "\(nightOffset) nights ago")
+    }
+
+    /// The night the Rest hero reflects: the ◀/▶-navigated night while browsing (falling back to
+    /// last night only if that navigated night hasn't decoded yet), else last night. Keeps the
+    /// hero's score, vessel fill, state word, provenance badge and overline on the SAME night the
+    /// hypnogram shows — the fix for the score freezing on last night's value during navigation.
+    private func heroNight(_ model: SleepModel) -> Night {
+        (nightOffset == 0 ? model.night : navNight) ?? model.night
+    }
+
+    /// The sleep-performance score (0–100) for a SPECIFIC night: the imported WHOOP figure for that
+    /// night's LOCAL wake-day when the export carried one, else the resolved Rest composite for that
+    /// day. Mirrors `performanceSeries`'s per-day transform exactly (the same single source of truth
+    /// the Today Rest score reads), keyed by the wake-day (sleep is filed under the day you woke) so
+    /// a navigated past night reads ITS OWN score, never last night's. nil when that day has no score.
+    private func performanceScore(for night: Night) -> Double? {
+        let wakeDay = Repository.localDayKey(Date(timeIntervalSince1970: TimeInterval(night.session.endTs)))
+        if let p = repo.importedSleep[wakeDay]?.performancePct { return p }
+        guard let daily = repo.days.last(where: { $0.day == wakeDay }) else { return nil }
+        return AnalyticsEngine.Rest.composite(daily: daily)
+    }
+
+    /// The fill fraction (0…1) the Rest hero gauge animates to — the DISPLAYED night's sleep-
+    /// performance score over 100. 0 when no score exists (the headline-hours hero shows instead).
+    /// Cheap, so it's read every render to drive the draw-in animation; keyed off the navigated
+    /// night so the vessel re-animates as you browse ◀/▶.
     private func heroScoreFraction(_ model: SleepModel?) -> Double {
-        guard let p = model?.performance.latest else { return 0 }
+        guard let model, let p = performanceScore(for: heroNight(model)) else { return 0 }
         return min(max(p / 100.0, 0), 1)
     }
 
@@ -341,12 +370,14 @@ struct SleepView: View {
     /// counting up over it (the SAME hero language Today's score cells and the Trends headline use);
     /// otherwise a big SF-Rounded hours-slept headline over the same backdrop. A `SourceBadge` states
     /// whether the score is WHOOP's own imported figure or NOOP's on-device estimate. Presentation-only
-    /// — the number comes straight from the existing `model.performance.latest` / hours computation.
+    /// — the score is `performanceScore(for:)` on the ◀/▶-navigated `heroNight`, so the hero tracks the
+    /// same night the hypnogram shows (was pinned to `performance.latest` = last night regardless).
     @ViewBuilder
     private func restHero(_ model: SleepModel) -> some View {
-        let score = model.performance.latest
+        let night = heroNight(model)
+        let score = performanceScore(for: night)
         VStack(alignment: .leading, spacing: NoopMetrics.gap) {
-            SectionHeader("Sleep performance", overline: "Last night", trailing: String(localized: "Rest"))
+            SectionHeader("Sleep performance", overline: nightRelativeLabel, trailing: String(localized: "Rest"))
             // A subtle night atmosphere sits behind the sleep hero ONLY (the Rest world's whisper:
             // faint indigo wash + crescent moon over the near-black canvas, no glow), clipped to the
             // card. Replaces the now-flat ScenicHeroBackground here.
@@ -386,7 +417,7 @@ struct SleepView: View {
                     // whose minutes tick up on appear (the same count-up the scored hero gets).
                     VStack(spacing: NoopMetrics.space1) {
                         CountUpText(
-                            value: model.night.stages.asleep,
+                            value: night.stages.asleep,
                             format: { durationText($0) },
                             font: StrandFont.number(46),
                             color: StrandPalette.restBright
@@ -398,7 +429,7 @@ struct SleepView: View {
                     .padding(.vertical, NoopMetrics.space5)
                     .accessibilityElement(children: .combine)
                 }
-                SourceBadge(score != nil ? sleepScoreSource(model) : "On-device", tint: StrandPalette.restColor)
+                SourceBadge(score != nil ? heroSource(for: night) : "On-device", tint: StrandPalette.restColor)
             }
             .padding(NoopMetrics.cardInnerPadding + NoopMetrics.space1)
             .frame(maxWidth: .infinity)
@@ -417,13 +448,13 @@ struct SleepView: View {
         }
     }
 
-    /// Whether the night's sleep-performance score is WHOOP's own imported figure or NOOP's
-    /// on-device approximation — so the hero is honest about provenance, like Today's badges.
-    private func sleepScoreSource(_ model: SleepModel) -> LocalizedStringKey {
-        if let lastDay = repo.days.last?.day, repo.importedSleep[lastDay]?.performancePct != nil {
-            return "Whoop"
-        }
-        return "On-device"
+    /// Whether a SPECIFIC night's sleep-performance score is WHOOP's own imported figure or NOOP's
+    /// on-device approximation — so the hero is honest about provenance, like Today's badges. Keyed
+    /// by the night's wake-day (matching `performanceScore(for:)`) so a navigated night's badge
+    /// tracks ITS OWN score's provenance, not last night's. LocalizedStringKey to match `SourceBadge`.
+    private func heroSource(for night: Night) -> LocalizedStringKey {
+        let wakeDay = Repository.localDayKey(Date(timeIntervalSince1970: TimeInterval(night.session.endTs)))
+        return repo.importedSleep[wakeDay]?.performancePct != nil ? "Whoop" : "On-device"
     }
 
     // MARK: - Provenance for the displayed night (COMPONENT 4, spec 2026-06-20)
@@ -2099,8 +2130,7 @@ struct SleepView: View {
     @ViewBuilder
     private func nightNavHeader(trailing: String) -> some View {
         let lastIndex = max(navDays.count - 1, 0)
-        let title: LocalizedStringKey = nightOffset == 0 ? "Last night"
-            : (nightOffset == 1 ? "1 night ago" : "\(nightOffset) nights ago")
+        let title = nightRelativeLabel
         VStack(alignment: .leading, spacing: NoopMetrics.cardInnerSpacing) {
             HStack(spacing: NoopMetrics.cardInnerSpacing) {
                 Button { if nightOffset < lastIndex { nightOffset += 1 } } label: {

--- a/android/app/src/main/java/com/noop/ui/SleepScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/SleepScreen.kt
@@ -422,9 +422,15 @@ fun SleepScreen(
             // the selected day's model failed to build (#940): real data over a zeroed gauge.
             item {
                 RestHero(
-                    score = (model ?: tilesModel)?.performance?.latest,
+                    // The DISPLAYED night's score (keyed by its wake-day), so the hero tracks the
+                    // ◀/▶-navigated night instead of freezing on the full-history latest. When no night
+                    // resolves but history exists (#940), keep the old "real data over a zeroed gauge"
+                    // fallback to the latest score.
+                    score = if (night != null) heroPerformanceScore(night, days, imported)
+                            else tilesModel?.performance?.latest,
                     asleepMin = model?.stages?.asleep,
-                    source = restHeroSource(imported, days),
+                    source = restHeroSource(imported, night?.dayKey ?: days.lastOrNull()?.day),
+                    overline = nightRelativeLabel(nightOffset),
                 )
             }
             item { Spacer(Modifier.height(Metrics.selectorTopUp)) }
@@ -677,9 +683,9 @@ private val LIQUID_HERO_RADIUS: Dp = 26.dp
 // figures, fraction math and Rest tint are UNCHANGED from the BevelGauge this replaced — presentation-only.
 
 @Composable
-private fun RestHero(score: Double?, asleepMin: Double?, source: String) {
+private fun RestHero(score: Double?, asleepMin: Double?, source: String, overline: String) {
     Column(verticalArrangement = Arrangement.spacedBy(Metrics.gap)) {
-        SectionHeader("Sleep performance", overline = "Last night", trailing = "Rest")
+        SectionHeader("Sleep performance", overline = overline, trailing = "Rest")
         Box(
             modifier = Modifier
                 .fillMaxWidth()
@@ -772,14 +778,41 @@ private fun sleepScoreWord(score: Double): String = when {
 }
 
 /**
- * Whether the night's sleep-performance score is WHOOP's own imported figure or NOOP's on-device
- * approximation — so the hero is honest about provenance, like Today's badges. Mirrors the macOS
- * SleepView.sleepScoreSource.
+ * Short night-relative label ("Last night" / "1 night ago" / "N nights ago") for the ◀/▶-navigated
+ * night. Shared by the Rest hero overline and the hypnogram nav header so both name the SAME night
+ * the hero's score is resolved for. Mirrors iOS SleepView.nightRelativeLabel.
  */
-private fun restHeroSource(imported: ImportedSleepSeries, days: List<DailyMetric>): String {
-    val lastDay = days.lastOrNull()?.day
-    return if (lastDay != null && imported.performance[lastDay] != null) "Whoop" else "On-device"
+internal fun nightRelativeLabel(offset: Int): String = when (offset) {
+    0 -> "Last night"
+    1 -> "1 night ago"
+    else -> "$offset nights ago"
 }
+
+/**
+ * The sleep-performance score (0–100) for a SPECIFIC navigated night: the imported WHOOP figure for
+ * that night's wake-day when the export carried one, else the resolved Rest composite for that day.
+ * Mirrors the per-day transform in [buildSleepModel]'s `performance` series (and iOS
+ * SleepView.performanceScore), keyed by [HeroNight.dayKey], so a navigated past night reads ITS OWN
+ * score rather than the full-history latest. Null when there is no navigated night or that day has
+ * no score.
+ */
+private fun heroPerformanceScore(
+    night: HeroNight?, days: List<DailyMetric>, imported: ImportedSleepSeries,
+): Double? {
+    val wakeDay = night?.dayKey ?: return null
+    imported.performance[wakeDay]?.let { return it }
+    val daily = days.lastOrNull { it.day == wakeDay } ?: return null
+    return com.noop.analytics.RestScorer.restFromDaily(daily)
+}
+
+/**
+ * Whether a SPECIFIC night's sleep-performance score is WHOOP's own imported figure or NOOP's
+ * on-device approximation — so the hero is honest about provenance, like Today's badges. Keyed by the
+ * night's wake-day (matching [heroPerformanceScore]) so a navigated night's badge tracks ITS OWN
+ * score's provenance, not last night's. Mirrors the macOS SleepView.heroSource.
+ */
+private fun restHeroSource(imported: ImportedSleepSeries, wakeDay: String?): String =
+    if (wakeDay != null && imported.performance[wakeDay] != null) "Whoop" else "On-device"
 
 // MARK: - 1. HERO — stage breakdown for the navigated night
 
@@ -2004,11 +2037,7 @@ private fun NightNavHeader(
         )
     }
 
-    val nightLabel = when (offset) {
-        0 -> "Last night"
-        1 -> "1 night ago"
-        else -> "$offset nights ago"
-    }
+    val nightLabel = nightRelativeLabel(offset)
     val blockShape = RoundedCornerShape(Metrics.cornerSm)
     val clockParts = clock?.split(" · ", limit = 2)
     val dateLabel = clockParts?.getOrNull(0)


### PR DESCRIPTION
## The bug

On the Sleep tab, the Rest performance hero (the big `LiquidVessel` with the 0–100 score) read the **full-history latest** sleep-performance value (`model.performance.latest` on iOS, `performance.latest` on Android). The hypnogram card below it browses nights via `nightOffset`, so tapping ◀/▶ changed the hypnogram — but the big score, the vessel fill, the "Good / Optimal" word, the `SourceBadge`, and the "Last night" overline all stayed frozen on the most recent night. Every navigated night appeared to score the same.

## The fix

Resolve the score for the **displayed** night by its local wake-day, through the same source of truth the series already uses — the imported WHOOP figure for that day, else the on-device Rest composite (`AnalyticsEngine.Rest.composite(daily:)` / `RestScorer.restFromDaily`). The hero's score, fill, word and provenance badge now match the night the hypnogram shows. The overline and the nav header share one night-relative label ("Last night" / "N nights ago").

Mirrored in the Android twin (`SleepScreen.kt`) per the cross-platform parity contract.

## Scope / safety

- **Presentation-only.** No analytics formula, stored value, migration, or BLE path changes — the per-night lookup reuses the exact transform in `performanceSeries` / `buildSleepModel`'s `performance` series. Full-history tiles, the debt ledger, and trends are unchanged.
- Design tokens only; no hardcoded colours/fonts/spacing.
- The `nightOffset == null but history exists` (#940 stage-less newest day) fallback to the latest score is preserved on Android.

## Verification

App-target Swift/Kotlin (no default CI coverage), compiled locally:

- `xcodebuild -scheme Strand -destination 'platform=macOS' … build` → **BUILD SUCCEEDED**
- `./gradlew compileFullDebugKotlin` → **BUILD SUCCESSFUL**

Behaviour confirmed against real data: browsing ◀ now walks the hero through each night's own score instead of repeating the latest.
