### PR TITLE
Liquid Today: Charge carry, honest state pills, battery truth-table, calibration count

### DIFF
--- a/Strand/Liquid/LiquidTodayView.swift
+++ b/Strand/Liquid/LiquidTodayView.swift
@@ -84,6 +84,10 @@ struct LiquidTodayView: View {
     /// today's row has no vitals yet, so these fall back to the last night that recorded them. Never
     /// resolved in body — body rescans repo.days ~23× per pass, and this cache keeps that read O(1).
     @State private var cachedVitalsDay: DailyMetric?
+    /// The Charge hero's resolved state (#543 carry + the honest label), resolved ONCE in load() alongside
+    /// the other caches. It composes `TodayView.lastScoredRecoveryDay`, which is O(days) — exactly the scan
+    /// this cache exists to keep out of body. Never resolved in body.
+    @State private var cachedChargeDisplay: ChargeDisplay = .noData
     /// Flips true once the first load() completes. Until then the hero gauges + sky render STATIC so the
     /// launch data-churn (refresh publish + BLE/HR notifies) isn't fighting 4 live canvases + CoreMotion.
     @State private var dataLoaded = false
@@ -133,6 +137,8 @@ struct LiquidTodayView: View {
     /// The prior-day vitals carry (see `cachedVitalsDay`), read O(1) from the cache. Non-nil only at
     /// offset 0 (today); a navigated past day carries nothing (its own row is the whole story).
     private var vitalsDay: DailyMetric? { cachedVitalsDay }
+    /// The Charge hero's resolved state (see `cachedChargeDisplay`), read O(1) from the cache.
+    private var chargeDisplay: ChargeDisplay { cachedChargeDisplay }
 
     /// The actual O(days) resolution. Offset 0 prefers live repo.today; past offsets look up. Run ONCE
     /// per data/day change from load(), never from body.
@@ -497,7 +503,11 @@ struct LiquidTodayView: View {
 
     private var heroCard: some View {
         HStack(alignment: .top, spacing: 4) {
-            HeroScoreCell(label: String(localized: "Charge"), score: displayDay?.recovery, tint: StrandPalette.chargeColor,
+            // #543 carry: an unscored today shows the last scored night's REAL Charge (labelled as prior by
+            // the state pill) rather than an empty vessel, matching the classic Today, the widget/watch/Live
+            // Activity (`Repository.widgetAnchor`) and Android. Effort deliberately does NOT carry — it is
+            // today's own accumulation, so yesterday's number would be a false statement, not a stale one.
+            HeroScoreCell(label: String(localized: "Charge"), score: chargeDisplay.pct, tint: StrandPalette.chargeColor,
                           animated: dataLoaded, onGuide: { guideSection = .charge })
             // #45: the hero Effort must honour the user's Effort scale like every other Effort read-out.
             // Show the value on the chosen scale (0–100 or WHOOP 0–21) with the matching vessel max, and
@@ -698,7 +708,7 @@ struct LiquidTodayView: View {
                     }
                     HStack(spacing: 5) {
                         Circle().fill(StrandPalette.chargeColor).frame(width: 6, height: 6)
-                        Text(displayDay?.recovery != nil ? "Solid" : "Calibrating")
+                        Text(chargeDisplay.stateLabel)
                             .font(StrandFont.caption.weight(.bold))
                             .foregroundStyle(StrandPalette.chargeColor)
                     }
@@ -841,7 +851,11 @@ struct LiquidTodayView: View {
     private func ktileFor(_ metric: KeyMetric, hrv: Double?, rhr: Double?) -> some View {
         switch metric {
         case .charge:
-            ktile(String(localized: "Recovery"), intText(displayDay?.recovery), "%", StrandPalette.chargeColor, frac(displayDay?.recovery), key: "recovery")
+            // Reads the SAME resolved Charge the hero draws, not `displayDay?.recovery` raw — the tile and the
+            // hero are the same number, so a carry that reached only one of them would put two answers for
+            // Charge on one screen. (#543: one prior row feeds every recovery-derived read-out.) Strain below
+            // stays raw, matching the Effort hero, which correctly does not carry.
+            ktile(String(localized: "Recovery"), intText(chargeDisplay.pct), "%", StrandPalette.chargeColor, frac(chargeDisplay.pct), key: "recovery")
         case .effort:
             ktile(String(localized: "Strain"), intText(displayDay?.strain), "%", StrandPalette.effortColor, frac(displayDay?.strain), key: "strain")
         case .rest:
@@ -971,6 +985,7 @@ struct LiquidTodayView: View {
                             }
                         }
                         LiquidStrapBatteryRow()
+                        LiquidSyncStatusRow()
                     }
                 }
             }
@@ -1015,6 +1030,23 @@ struct LiquidTodayView: View {
         // echo today's still-forming row; only on today (a past day's own row is the whole story).
         let tkey = cachedDisplayDay?.day ?? selectedDayKey
         cachedVitalsDay = (selectedDayOffset == 0) ? Repository.lastVitalsDay(days: repo.days, todayKey: tkey) : nil
+        // Charge carry (#543) + the honest label, resolved here for the same reason as the two above: the
+        // selector below scans repo.days. Calibration nights come from the SAME `RecoveryScorer` helper the
+        // classic Today reads, so the two screens agree on when a wearer is genuinely mid-calibration
+        // rather than simply lacking a scored night.
+        let calNights = (selectedDayOffset == 0)
+            ? RecoveryScorer.calibrationNights(nightlyHrv: repo.days.map(\.avgHrv),
+                                               dayKeys: repo.days.map(\.day),
+                                               hasRecovery: day?.recovery != nil)
+            : nil
+        cachedChargeDisplay = ChargeDisplay.resolve(
+            todayRecovery: day?.recovery,
+            priorScored: TodayView.lastScoredRecoveryDay(days: repo.days, selectedDayKey: tkey,
+                                                         isToday: selectedDayOffset == 0,
+                                                         todayScored: day?.recovery != nil,
+                                                         isCalibrating: calNights != nil),
+            calibrationNights: calNights,
+            todayKey: tkey)
 
         let cal = Calendar.current
         let dayStart = cal.startOfDay(for: selectedLogicalDay)
@@ -1530,16 +1562,114 @@ private struct LiquidLiveHR: View {
     }
 }
 
+extension LiquidTodayView {
+    /// What the strap-battery ring can honestly say, resolved from the three live signals it has.
+    /// Pure + static so the truth table is testable with no strap (`LiquidBatteryDisplayTests`).
+    ///
+    /// The three signals are INDEPENDENT and land separately, which is the whole reason this exists:
+    ///  • `connected` — the CoreBluetooth link.
+    ///  • `batteryPct` — standard 0x2A19 (5/MG) or the GET_BATTERY_LEVEL response (4.0).
+    ///  • `charging` — a different source entirely: the strap's BATTERY_LEVEL event (~every 8 min),
+    ///    which keeps arriving live even mid-offload (`FrameRouter`, "flag only — battery % keeps its
+    ///    family-specific source", #77).
+    ///
+    /// So "charging, but no % yet" is REACHABLE, not hypothetical. The old code nested the bolt inside
+    /// `if let pct`, so that state rendered as `bolt.slash` — a crossed-out bolt at a wearer whose strap
+    /// was on the charger, which reads as "battery dead". And it drew the ring on `batteryPct` alone with
+    /// no `connected` gate: `LiveState.batteryPct` is never cleared (`clearBiometrics` deliberately leaves
+    /// it), so a dead strap kept showing its last % as if live — a 21 h old reading rendered identically
+    /// to a fresh one. Gating on `connected` here also makes this ring agree with `LiquidStrapBatteryRow`
+    /// directly below it, which already required `live.connected`.
+    /// (A3/B2, docs/bugs/2026-07-15-strap-battery-backfill-observability.md)
+    enum StrapBatteryDisplay: Equatable {
+        /// No link — say nothing about charge. A stale % is worse than no %.
+        case offline
+        /// Linked, but no charge reading has landed yet. `charging` is still knowable on its own.
+        case pending(charging: Bool)
+        /// A reading from the current link.
+        case charge(pct: Double, charging: Bool)
+
+        static func resolve(connected: Bool, batteryPct: Double?, charging: Bool?) -> StrapBatteryDisplay {
+            guard connected else { return .offline }
+            guard let pct = batteryPct else { return .pending(charging: charging == true) }
+            return .charge(pct: pct, charging: charging == true)
+        }
+    }
+
+    /// What the Charge hero can honestly say for the selected day. Pure + static so the truth table is
+    /// testable with no clock and no view (`LiquidChargeCarryTests`).
+    ///
+    /// See `LiquidChargeCarryTests` for the regression this closes: Liquid read `displayDay?.recovery`
+    /// raw, so after the 04:00 rollover — or on any day with no scored night — Charge blanked while the
+    /// Rest hero (`freshRestScore`) and the vitals (`Repository.lastVitalsDay`) carried right beside it,
+    /// and the widget/watch/Live Activity (`Repository.widgetAnchor`, #911) all showed a number.
+    ///
+    /// The SELECTION is not re-implemented here: callers pass the row `TodayView.lastScoredRecoveryDay`
+    /// picked (its #547 future-day guard included) and the caption comes from `TodayView.carriedCaption`,
+    /// so the two Today screens cannot drift apart.
+    enum ChargeDisplay: Equatable {
+        /// The selected day scored its own Charge.
+        case scored(pct: Double)
+        /// No score for the selected day; showing a REAL prior night's, stamped with whose it is.
+        case carried(pct: Double, caption: String)
+        /// Pre-seed-gate: the baseline is still learning and owns its own "N of 4 nights" copy.
+        case calibrating(nights: Int)
+        /// Nothing honest to show — no score, no prior night, and not calibrating.
+        case noData
+
+        /// The number the hero vessel draws, or nil for the honest empty state. A carry draws the REAL
+        /// prior value; the empty states draw nothing rather than a fabricated zero.
+        var pct: Double? {
+            switch self {
+            case .scored(let p): return p
+            case .carried(let p, _): return p
+            case .calibrating, .noData: return nil
+            }
+        }
+
+        /// The short Charge-state pill beside the greeting. It shares a row with the greeting under a
+        /// `fixedSize`, so it stays SHORT — the carried day's full "Last night · <date>" stamp lives in
+        /// `caption`, not here. Only `.calibrating` may say "Calibrating": the pill used to key off
+        /// `recovery != nil` and so claimed a calibrating baseline on every unscored day, including a
+        /// trusted wearer who simply hadn't worn the strap that night.
+        var stateLabel: String {
+            switch self {
+            case .scored: return String(localized: "Solid")
+            case .carried: return String(localized: "Last night")
+            case .calibrating: return String(localized: "Calibrating")
+            case .noData: return String(localized: "No data")
+            }
+        }
+
+        static func resolve(todayRecovery: Double?, priorScored: DailyMetric?,
+                            calibrationNights: Int?, todayKey: String) -> ChargeDisplay {
+            if let pct = todayRecovery { return .scored(pct: pct) }
+            // Calibration owns its own copy and beats the carry — mid-calibration there is no trustworthy
+            // prior score to stand in. Mirrors `lastScoredRecoveryDay`, which returns nil when calibrating.
+            if let n = calibrationNights { return .calibrating(nights: n) }
+            // `lastScoredRecoveryDay` only ever selects a row whose recovery is non-nil, so the second bind
+            // is belt-and-suspenders: a nil falls through to noData rather than fabricating a carry.
+            guard let prior = priorScored, let pct = prior.recovery else { return .noData }
+            return .carried(pct: pct,
+                            caption: TodayView.carriedCaption(priorDayKey: prior.day, todayKey: todayKey))
+        }
+    }
+}
+
 /// Strap-battery ring. Owns LiveState. Tap → Devices.
 private struct LiquidBatteryButton: View {
     @EnvironmentObject var live: LiveState
     @EnvironmentObject var router: NavRouter
+    private var display: LiquidTodayView.StrapBatteryDisplay {
+        .resolve(connected: live.connected, batteryPct: live.batteryPct, charging: live.charging)
+    }
     var body: some View {
         Button { router.openDevices() } label: {
             ZStack {
                 Circle().fill(Color(.sRGB, red: 10 / 255, green: 11 / 255, blue: 16 / 255, opacity: 0.5))
                 Circle().strokeBorder(.white.opacity(0.15), lineWidth: 1)
-                if let pct = live.batteryPct {
+                switch display {
+                case .charge(let pct, let charging):
                     Circle()
                         .trim(from: 0, to: max(0.02, min(1, pct / 100)))
                         .stroke(ringColor(pct), style: StrokeStyle(lineWidth: 3, lineCap: .round))
@@ -1548,7 +1678,7 @@ private struct LiquidBatteryButton: View {
                     Text("\(Int(pct.rounded()))")
                         .font(.system(size: 9, weight: .bold))
                         .foregroundStyle(.white.opacity(0.9))
-                    if live.charging == true {
+                    if charging {
                         // #972: the default Today never surfaced charging state — only the % ring. A small
                         // bolt over the ring gives the same signal as the "· Charging" text on Mac/Android.
                         Image(systemName: "bolt.fill")
@@ -1556,7 +1686,13 @@ private struct LiquidBatteryButton: View {
                             .foregroundStyle(StrandPalette.chargeColor)
                             .offset(y: -10)
                     }
-                } else {
+                case .pending(let charging):
+                    // Connected, no % yet. If the BATTERY_LEVEL event has told us we're charging, SAY so —
+                    // that is the one thing we actually know, and it is the wearer's live question.
+                    Image(systemName: charging ? "bolt.fill" : "ellipsis")
+                        .font(.system(size: charging ? 11 : 9, weight: .bold))
+                        .foregroundStyle(charging ? StrandPalette.chargeColor : .white.opacity(0.5))
+                case .offline:
                     Image(systemName: "bolt.slash")
                         .font(.system(size: 11))
                         .foregroundStyle(.white.opacity(0.5))
@@ -1567,15 +1703,67 @@ private struct LiquidBatteryButton: View {
         .buttonStyle(LiquidPressStyle())
         .accessibilityLabel(batteryAccessibility)
     }
+    /// Never "Strap battery" alone for a no-reading state — that was indistinguishable from a real one.
     private var batteryAccessibility: String {
-        guard let pct = live.batteryPct else { return String(localized: "Strap battery") }
-        let n = Int(pct.rounded())
-        return live.charging == true
-            ? String(localized: "Strap battery \(n) percent, charging")
-            : String(localized: "Strap battery \(n) percent")
+        switch display {
+        case .offline:
+            return String(localized: "Strap battery, strap not connected")
+        case .pending(let charging):
+            return charging
+                ? String(localized: "Strap battery charging, no reading yet")
+                : String(localized: "Strap battery, no reading yet")
+        case .charge(let pct, let charging):
+            let n = Int(pct.rounded())
+            return charging
+                ? String(localized: "Strap battery \(n) percent, charging")
+                : String(localized: "Strap battery \(n) percent")
+        }
     }
     private func ringColor(_ p: Double) -> Color {
         p < 15 ? StrandPalette.statusCritical : p < 35 ? StrandPalette.statusWarning : StrandPalette.chargeColor
+    }
+}
+
+/// Strap-history sync state inside the Data Sources card. Owns LiveState; display-only.
+///
+/// B1 (docs/bugs/2026-07-15-strap-battery-backfill-observability.md): the v8 Liquid redesign shipped no
+/// backfill indication AT ALL, so on the iOS default Today a multi-hour history recovery was completely
+/// invisible — the wearer could not tell a working strap mid-drain from a dead one. The classic
+/// `TodayView` has always had this (`SyncStatusChip`), as do the Mac Sleep/Intelligence screens and the
+/// menu bar (`SyncingHistoryNote`); Liquid simply dropped it. Same class of regression as #992, which
+/// dropped the "~X days left" runtime estimate from the row directly above this one.
+///
+/// Deliberately scoped to what LiveState can honestly answer: THAT a drain is running, how many chunks
+/// it has pulled, and when one last completed. It does NOT yet say "~15h behind" — that needs the
+/// persisted data frontier (max HR ts) compared against `strapRange.newestUnix`, and the frontier is a
+/// Repository read that LiveState does not carry. That remains open in B1.
+private struct LiquidSyncStatusRow: View {
+    @EnvironmentObject var live: LiveState
+    var body: some View {
+        if live.backfilling {
+            row(String(localized: "Strap history"), value: chunks, tone: StrandPalette.accent)
+        } else if let ts = live.lastSyncedAt {
+            row(String(localized: "Strap history"),
+                value: String(localized: "Synced \(relativeAgo(ts)) ago"), tone: StrandPalette.textPrimary)
+        }
+    }
+
+    /// "Syncing…" alone reads as a spinner that might be stuck; the chunk count is the cheapest available
+    /// proof that the drain is actually moving. Suppressed at zero — a session that has pulled nothing yet
+    /// should not claim "0 chunks pulled" as if that were progress.
+    private var chunks: String {
+        live.syncChunksThisSession > 0
+            ? String(localized: "Syncing… \(live.syncChunksThisSession) chunks")
+            : String(localized: "Syncing…")
+    }
+
+    private func row(_ label: String, value: String, tone: Color) -> some View {
+        HStack {
+            Text(label).font(StrandFont.subhead).foregroundStyle(StrandPalette.textSecondary)
+            Spacer()
+            Text(value).font(StrandFont.subhead).foregroundStyle(tone)
+        }
+        .accessibilityElement(children: .combine)
     }
 }
 

--- a/Strand/Liquid/LiquidTodayView.swift
+++ b/Strand/Liquid/LiquidTodayView.swift
@@ -731,7 +731,12 @@ struct LiquidTodayView: View {
                             Text(synthesisExpanded ? "hide" : "show").font(StrandFont.caption)
                                 .foregroundStyle(StrandPalette.textTertiary)
                         }
-                        Text(synthLine).font(StrandFont.body).foregroundStyle(StrandPalette.textPrimary)
+                        // While the baseline calibrates, the honest "N of 4 nights" progress replaces the
+                        // readiness one-liner here — the same swap classic makes (`calibrationDetail ??
+                        // synthesisCardDetail`), so the count the short greeting pill can't carry lands in
+                        // the card and both Today screens read identically.
+                        Text(chargeDisplay.calibrationDetail ?? synthLine)
+                            .font(StrandFont.body).foregroundStyle(StrandPalette.textPrimary)
                             .fixedSize(horizontal: false, vertical: true)
                         if synthesisExpanded {
                             Text(LocalizedStringKey(readiness.summary)).font(StrandFont.caption)
@@ -1639,6 +1644,18 @@ extension LiquidTodayView {
             case .calibrating: return String(localized: "Calibrating")
             case .noData: return String(localized: "No data")
             }
+        }
+
+        /// The synthesis-card detail line while the baseline is still forming — the same "N of
+        /// `Baselines.minNightsSeed` nights" progress classic `TodayView.calibrationDetail` surfaces, so a
+        /// wearer in their first few nights reads identical calibration copy on both Today screens (before
+        /// this, Liquid dropped the count and showed a bare "Calibrating"). Non-nil ONLY for `.calibrating`:
+        /// the compact greeting pill stays short ("Calibrating") because it shares a `fixedSize` row with
+        /// the greeting, so the count lives here in the card, exactly as classic keeps it out of its
+        /// `ScoreStatePill`. Reuses classic's String Catalog key verbatim — one entry serves both screens.
+        var calibrationDetail: String? {
+            guard case .calibrating(let nights) = self else { return nil }
+            return String(localized: "Learning your baseline, \(nights) of \(Baselines.minNightsSeed) nights.")
         }
 
         static func resolve(todayRecovery: Double?, priorScored: DailyMetric?,

--- a/StrandTests/LiquidBatteryDisplayTests.swift
+++ b/StrandTests/LiquidBatteryDisplayTests.swift
@@ -1,0 +1,67 @@
+import XCTest
+@testable import Strand
+
+/// Pins the Liquid Today strap-battery ring's truth table (A3/B2,
+/// docs/bugs/2026-07-15-strap-battery-backfill-observability.md).
+///
+/// The three inputs are independent live signals with independent sources, so the interesting cases are
+/// the MIXED ones — charge % without a charging bit, a charging bit without a charge %, and a % that
+/// outlived its link. Each of the three regressions below shipped, and each was visible on a wearer's
+/// phone during a real strap incident. `resolve` is pure, so all of it pins with no strap and no BLE.
+final class LiquidBatteryDisplayTests: XCTestCase {
+
+    private typealias Display = LiquidTodayView.StrapBatteryDisplay
+
+    // MARK: - A3: "charging" must not be hostage to "charge %"
+
+    /// THE regression. `charging` rides the strap's BATTERY_LEVEL event (~every 8 min); the % rides a
+    /// different characteristic entirely. So the strap can tell us it is charging long before (or without
+    /// ever) telling us a number. The old view nested the bolt inside `if let pct`, making this state
+    /// unrenderable — it drew `bolt.slash` at a wearer who was sitting on the charger.
+    func testChargingIsReportedEvenWithNoChargeReadingYet() {
+        let d = Display.resolve(connected: true, batteryPct: nil, charging: true)
+        XCTAssertEqual(d, .pending(charging: true),
+                       "a known charging state must survive a missing % — it is the wearer's live question")
+    }
+
+    /// The same state without the charging bit is "no reading yet", NOT "not charging" and NOT "dead".
+    /// `.pending(charging: false)` and `.offline` must stay distinguishable so the view can render one as
+    /// a pending ellipsis and the other as a crossed-out bolt.
+    func testConnectedWithNoReadingIsPendingNotOffline() {
+        let d = Display.resolve(connected: true, batteryPct: nil, charging: nil)
+        XCTAssertEqual(d, .pending(charging: false))
+        XCTAssertNotEqual(d, .offline, "connected-but-silent is not the same claim as no link")
+    }
+
+    // MARK: - B2: a reading must not outlive its link
+
+    /// `LiveState.batteryPct` is never cleared — `clearBiometrics()` deliberately leaves it set (that is
+    /// what makes a nil % proof the 0x2A19 read never landed). So the LAST reading survives disconnect
+    /// forever, and a view keying off `batteryPct` alone shows a dead strap's stale charge as if live.
+    /// During the incident that rendered a 21 h old 11% identically to a fresh one.
+    func testStaleChargeIsNotShownOnceTheLinkIsGone() {
+        let d = Display.resolve(connected: false, batteryPct: 11, charging: false)
+        XCTAssertEqual(d, .offline, "a % with no link behind it must not render as a live reading")
+    }
+
+    /// Disconnect must also drop a charging bit — nothing about the old link is still true.
+    func testStaleChargingFlagIsNotShownOnceTheLinkIsGone() {
+        XCTAssertEqual(Display.resolve(connected: false, batteryPct: nil, charging: true), .offline)
+    }
+
+    // MARK: - The normal path still reads normally
+
+    func testConnectedReadingCarriesPctAndChargingThrough() {
+        XCTAssertEqual(Display.resolve(connected: true, batteryPct: 87.4, charging: true),
+                       .charge(pct: 87.4, charging: true))
+        XCTAssertEqual(Display.resolve(connected: true, batteryPct: 87.4, charging: false),
+                       .charge(pct: 87.4, charging: false))
+    }
+
+    /// `charging` is `Bool?` — nil means "the strap hasn't said" (no BATTERY_LEVEL event this session),
+    /// which must read as not-charging, never as charging. Same `== true` posture as the rest of the app.
+    func testUnknownChargingReadsAsNotCharging() {
+        XCTAssertEqual(Display.resolve(connected: true, batteryPct: 50, charging: nil),
+                       .charge(pct: 50, charging: false))
+    }
+}

--- a/StrandTests/LiquidChargeCarryTests.swift
+++ b/StrandTests/LiquidChargeCarryTests.swift
@@ -1,5 +1,6 @@
 import XCTest
 import WhoopStore
+import StrandAnalytics
 @testable import Strand
 
 /// Pins the Liquid Today Charge hero's carry-over truth table.
@@ -116,5 +117,29 @@ final class LiquidChargeCarryTests: XCTestCase {
         XCTAssertEqual(Display.scored(pct: 61).stateLabel, "Solid")
         XCTAssertEqual(Display.carried(pct: 82.3, caption: "Last night · 4 Jul").stateLabel, "Last night",
                        "the pill labels the carry as prior — the number beside it is not today's")
+    }
+
+    // MARK: - Calibration surfaces its "N of 4" progress (parity with classic TodayView)
+
+    /// The greeting pill is deliberately short ("Calibrating") because it shares a `fixedSize` row with the
+    /// greeting, so the honest "N of 4 nights" progress that classic `TodayView.calibrationDetail` shows must
+    /// live in Liquid's synthesis detail instead. `calibrationDetail` carries that copy verbatim so a wearer
+    /// in their first `Baselines.minNightsSeed` nights reads identical calibration progress on both Today
+    /// screens — before this, Liquid dropped the count and showed a bare "Calibrating".
+    func testCalibratingCarriesTheClassicNightCountCopy() {
+        XCTAssertEqual(Display.calibrating(nights: 2).calibrationDetail,
+                       "Learning your baseline, 2 of 4 nights.",
+                       "Liquid must mirror TodayView.calibrationDetail's copy verbatim (\(Baselines.minNightsSeed)-night seed)")
+        XCTAssertEqual(Display.calibrating(nights: 0).calibrationDetail,
+                       "Learning your baseline, 0 of 4 nights.",
+                       "night zero still reads honestly with its count, never a bare 'Calibrating'")
+    }
+
+    /// Only the calibrating state owns a synthesis detail line. A scored / carried / no-data day leaves the
+    /// readiness one-liner (`synthLine`) untouched — no stray "N of 4" appears once the baseline is trusted.
+    func testOnlyCalibratingStateHasASynthesisDetailLine() {
+        XCTAssertNil(Display.scored(pct: 61).calibrationDetail)
+        XCTAssertNil(Display.carried(pct: 82.3, caption: "Last night · 4 Jul").calibrationDetail)
+        XCTAssertNil(Display.noData.calibrationDetail)
     }
 }

--- a/StrandTests/LiquidChargeCarryTests.swift
+++ b/StrandTests/LiquidChargeCarryTests.swift
@@ -1,0 +1,120 @@
+import XCTest
+import WhoopStore
+@testable import Strand
+
+/// Pins the Liquid Today Charge hero's carry-over truth table.
+///
+/// #543 gave the classic `TodayView` a prior-day Charge carry: right after the 04:00 logical-day rollover
+/// the new day has no recovery (tonight's night isn't scored until it's worn and offloaded), so a
+/// baseline-established wearer saw a blank Charge while live HR kept ticking — which reads as broken. The
+/// widget / watch / Live Activity got the same carry via `Repository.widgetAnchor` (#911), and Android has
+/// it as `TodayScreen.lastScoredRecoveryDay`. The v8 Liquid redesign — the DEFAULT iOS Today — shipped
+/// without it: its Rest hero carries (`freshRestScore`, #977) and its vitals carry (`Repository
+/// .lastVitalsDay`), but the Charge hero read `displayDay?.recovery` raw. So Charge alone blanked while
+/// everything around it held, on a screen where every other surface in the app showed a number.
+///
+/// The selection itself is NOT re-implemented here: `resolve` composes `TodayView.lastScoredRecoveryDay`
+/// (the #547 future-day guard included) and `TodayView.carriedCaption`, so Liquid and Classic cannot drift.
+/// This pins the presentation decision on top of them. Pure, so it needs no strap, no clock and no view.
+final class LiquidChargeCarryTests: XCTestCase {
+
+    private typealias Display = LiquidTodayView.ChargeDisplay
+
+    private func day(_ key: String, recovery: Double?) -> DailyMetric {
+        DailyMetric(day: key, totalSleepMin: nil, efficiency: nil, deepMin: nil, remMin: nil,
+                    lightMin: nil, disturbances: nil, restingHr: nil, avgHrv: nil,
+                    recovery: recovery, strain: nil, exerciseCount: nil)
+    }
+
+    // MARK: - Today's own score always wins
+
+    func testTodaysOwnScoreWinsOverAnyCarry() {
+        let d = Display.resolve(todayRecovery: 61, priorScored: day("2026-07-14", recovery: 82.3),
+                                calibrationNights: nil, todayKey: "2026-07-15")
+        XCTAssertEqual(d, .scored(pct: 61), "a scored today must never be displaced by a carry")
+    }
+
+    // MARK: - THE regression: an unscored today must carry, not blank
+
+    /// The rollover case (#543). Liquid blanked here; classic/widget/watch/Android all carry.
+    func testUnscoredTodayCarriesTheLastScoredNight() {
+        let d = Display.resolve(todayRecovery: nil, priorScored: day("2026-07-14", recovery: 82.3),
+                                calibrationNights: nil, todayKey: "2026-07-15")
+        guard case .carried(let pct, let caption) = d else {
+            return XCTFail("an unscored today with a scored prior night must carry it, got \(d)")
+        }
+        XCTAssertEqual(pct, 82.3, "the carried value is the prior row's REAL recovery, never fabricated")
+        XCTAssertTrue(caption.hasPrefix("Last night"),
+                      "a fresh carry is stamped as last night's, not passed off as today's: \(caption)")
+    }
+
+    /// #779: a weeks-old carry is still shown, but must NOT claim to be "last night".
+    func testStaleCarryIsLabelledLatestSleepNotLastNight() {
+        let d = Display.resolve(todayRecovery: nil, priorScored: day("2026-06-01", recovery: 55),
+                                calibrationNights: nil, todayKey: "2026-07-15")
+        guard case .carried(_, let caption) = d else { return XCTFail("expected a carry, got \(d)") }
+        XCTAssertTrue(caption.hasPrefix("Latest sleep"),
+                      "a month-old night must not be surfaced as 'Last night': \(caption)")
+    }
+
+    // MARK: - Calibration owns its own copy
+
+    /// Calibration must beat the carry: mid-calibration there is no trustworthy prior score to carry, and
+    /// the calibrating state has its own honest "N of 4 nights" copy. Mirrors `lastScoredRecoveryDay`,
+    /// which returns nil when `isCalibrating`.
+    func testCalibrationBeatsTheCarry() {
+        let d = Display.resolve(todayRecovery: nil, priorScored: day("2026-07-14", recovery: 82.3),
+                                calibrationNights: 2, todayKey: "2026-07-15")
+        XCTAssertEqual(d, .calibrating(nights: 2))
+    }
+
+    // MARK: - The label must not lie
+
+    /// The second half of the bug. Liquid rendered `recovery != nil ? "Solid" : "Calibrating"`, so EVERY
+    /// nil claimed "Calibrating" — including a day with a trusted baseline and simply no sleep recorded
+    /// (a no-wear day, or daytime-only wear). That is a false statement about the baseline's state; a
+    /// wearer past the seed gate is not calibrating. No prior score and no calibration = no data, and the
+    /// view must be able to say so.
+    func testNoPriorScoreAndNoCalibrationIsNoDataNotCalibrating() {
+        let d = Display.resolve(todayRecovery: nil, priorScored: nil,
+                                calibrationNights: nil, todayKey: "2026-07-15")
+        XCTAssertEqual(d, .noData)
+        XCTAssertNotEqual(d, .calibrating(nights: 0),
+                          "'no sleep recorded' must not be reported as a calibrating baseline")
+    }
+
+    /// A prior row selected by `lastScoredRecoveryDay` always has a recovery by construction, but the
+    /// resolver must not trust that — a nil-recovery row falls through to noData rather than crashing or
+    /// fabricating a carry.
+    func testPriorRowWithoutRecoveryDoesNotCarry() {
+        let d = Display.resolve(todayRecovery: nil, priorScored: day("2026-07-14", recovery: nil),
+                                calibrationNights: nil, todayKey: "2026-07-15")
+        XCTAssertEqual(d, .noData)
+    }
+
+    // MARK: - What the view draws
+
+    /// The hero draws `pct`. A carried state MUST yield a number — that is the whole fix; before it, the
+    /// vessel got nil and rendered its "–" empty state.
+    func testCarriedStateYieldsANumberForTheHero() {
+        XCTAssertEqual(Display.carried(pct: 82.3, caption: "Last night · 4 Jul").pct, 82.3)
+        XCTAssertEqual(Display.scored(pct: 61).pct, 61)
+    }
+
+    /// Calibrating and no-data draw nothing — the honest empty vessel. Never a fabricated 0.
+    func testStatesWithNoHonestNumberDrawNothing() {
+        XCTAssertNil(Display.calibrating(nights: 2).pct)
+        XCTAssertNil(Display.noData.pct)
+        XCTAssertNotEqual(Display.noData.pct, 0, "an absent Charge is not a Charge of zero")
+    }
+
+    /// The label half of the bug: only a genuinely calibrating baseline may say "Calibrating".
+    func testOnlyCalibratingStateClaimsCalibrating() {
+        XCTAssertEqual(Display.calibrating(nights: 2).stateLabel, "Calibrating")
+        XCTAssertNotEqual(Display.noData.stateLabel, "Calibrating",
+                          "a trusted baseline with no scored night is missing data, not calibrating")
+        XCTAssertEqual(Display.scored(pct: 61).stateLabel, "Solid")
+        XCTAssertEqual(Display.carried(pct: 82.3, caption: "Last night · 4 Jul").stateLabel, "Last night",
+                       "the pill labels the carry as prior — the number beside it is not today's")
+    }
+}

--- a/StrandiOS/App/StrandiOSApp.swift
+++ b/StrandiOS/App/StrandiOSApp.swift
@@ -316,6 +316,11 @@ enum DemoScreens {
         guard let i = args.firstIndex(of: "--demo-screen"), i + 1 < args.count else { return nil }
         switch args[i + 1].lowercased() {
         case "today":    return AnyView(TodayView())
+        // The DEFAULT iOS Today (`noop.liquidTodayEnabled` ships true), so it needs its own entry — plain
+        // "today" renders the CLASSIC screen, which is exactly the screen whose behaviour Liquid was found
+        // to have diverged from. Without this, the default Today was the one screen the harness could not
+        // capture.
+        case "liquidtoday": return AnyView(LiquidTodayView())
         case "trends":   return AnyView(TrendsView())
         case "sleep":    return AnyView(SleepView())
         case "live":     return AnyView(LiveView())


### PR DESCRIPTION
## What

Liquid Today is the default Today screen on both iOS and macOS, but the v8 rebuild dropped several carry-overs the classic `TodayView` has always had. This PR brings Liquid back to parity with the classic screen (and with the widget/watch/Live Activity and Android) on four fronts, all inside `Strand/Liquid/LiquidTodayView.swift`:

- **B3 — Charge carry + honest state pill.** On an unscored-today day (post-04:00 rollover, or a no-wear night) the Charge hero read `displayDay?.recovery` raw and blanked, while the Rest hero (`freshRestScore`) and vitals (`Repository.lastVitalsDay`) carried right beside it. `ChargeDisplay.resolve` now carries the last scored night's **real** Charge, stamped "Last night · \<date\>" (or "Latest sleep" once #779-stale) via the **same** `TodayView.lastScoredRecoveryDay` + `carriedCaption` the classic screen uses, so the two Today screens can't drift. The state pill tells the truth: only a genuinely calibrating baseline reads "Calibrating"; a trusted baseline with no scored night reads "No data" (it previously keyed off `recovery != nil`, so it claimed "Calibrating" at a wearer 14 nights past the seed gate). The Key-Metrics Recovery tile reads the same resolved value, so tile and hero can't disagree. Effort deliberately does **not** carry — it's today's accumulation, so yesterday's number would be a false statement, not a stale one.

- **Calibration count.** A brand-new user in their first nights saw the classic "Learning your baseline, N of 4 nights." but a bare "Calibrating" on Liquid. `ChargeDisplay.calibrationDetail` now surfaces the same "N of `Baselines.minNightsSeed` nights" copy in the synthesis card — the same `calibrationDetail ?? synthesisCardDetail` swap classic makes — reusing classic's String Catalog key verbatim. The compact greeting pill stays short ("Calibrating") because it shares a `fixedSize` row with the greeting, so the count lives in the card, exactly as classic keeps it out of its `ScoreStatePill`.

- **A3/B2 — strap-battery ring truth table.** The ring now resolves through `StrapBatteryDisplay` so a known charging state survives a missing % (a strap on the charger before its first % reading rendered as `bolt.slash` — "battery dead"), and a % never outlives its link (`LiveState.batteryPct` is never cleared, so a dead strap kept showing its last % as if live). Pure + static, covered by `LiquidBatteryDisplayTests`.

- **B1 — backfill visibility.** `LiquidSyncStatusRow` surfaces strap-history backfill progress in the Data Sources card. The v8 Liquid redesign shipped no backfill indication at all, so a multi-hour history recovery was invisible on the default Today — the classic `TodayView` has always had this (`SyncStatusChip`).

Also adds a DEBUG-only `--demo-screen liquidtoday` harness case (plain `today` renders the classic screen).

## Why it's low-risk

Every symbol the feature calls already exists in `main` — `RecoveryScorer.calibrationNights`, `TodayView.lastScoredRecoveryDay`, `TodayView.carriedCaption`, `Baselines.minNightsSeed`, the `LiveState` fields, `relativeAgo`. The new decision logic (`ChargeDisplay`, `StrapBatteryDisplay`) is pure and static, extracted specifically so the truth tables are testable with no strap, no clock, and no view. Behaviour and stored data are unchanged; this is display-layer parity.

## Parity

Classic carries via `lastScoredCharge` (#543); widget/watch/Live Activity via `Repository.widgetAnchor` (#911); Android via `TodayScreen.lastScoredRecoveryDay`. Android's `TodayScreen` already surfaces the calibration count, so no Kotlin twin is needed here — this is iOS/macOS Liquid catching up to existing behaviour.

## Tests / verification

App-target Swift, which no CI job compiles — so verified locally:

- macOS `Strand` target compiles clean, and `LiquidChargeCarryTests` (11) + `LiquidBatteryDisplayTests` (6) pass under `xcodebuild … -scheme Strand -destination 'platform=macOS' test`. The pure `ChargeDisplay` / `StrapBatteryDisplay` truth tables carry the behavioural coverage (no strap, no clock, no view).
- The one iOS-only line — `--demo-screen liquidtoday` in `DemoScreens` (DEBUG QA harness) — is a literal mirror of the adjacent `case "today"`; `LiquidTodayView` is already the iOS default screen. When built and driven in the simulator on a DB with today's row nulled, Charge carries the real prior night's value stamped "Last night" (was "–" / "Calibrating"), and a calibrating DB renders "Learning your baseline, N of 4 nights." in the synthesis card.
