### PR TITLE
ci(i18n): audit main pushes, not just PRs into it

### DIFF
--- a/.github/workflows/i18n-coverage.yml
+++ b/.github/workflows/i18n-coverage.yml
@@ -11,6 +11,15 @@ name: i18n Coverage
 on:
   pull_request:
     branches: [main]
+  # Audit main itself too, not just PRs into it. A RELEASE pushes STRAIGHT to main with no PR, and
+  # Tools/appchangelog-gen.py emits the What's New title as a RAW Kotlin literal that has to be
+  # localized by hand afterwards (Compose has no Xcode-style auto-extraction). With a PR-only
+  # trigger that landed completely unaudited, and — because --ci is a whole-tree gate, not a diff —
+  # it then red-checked EVERY contributor's PR on a line none of them touched (9.0.1, fixed by
+  # #514). Auditing the push surfaces it on main the moment it lands, so it is fixed before anyone
+  # else trips over it. Same 8-second job; no new cost.
+  push:
+    branches: [main]
 
 concurrency:
   group: i18n-coverage-${{ github.ref }}
@@ -25,5 +34,8 @@ jobs:
         with:
           fetch-depth: 0
 
+      # `github.base_ref` is set ONLY for pull_request; on a push to main it is empty, which would
+      # pass a bare `origin/`. Fall back to main. (The ref is retained for workflow compatibility —
+      # `--ci` is a whole-tree gate, so the value it resolves to does not change the verdict.)
       - name: i18n audit (regression gate)
-        run: python3 Tools/i18n_audit.py --ci origin/${{ github.base_ref }}
+        run: python3 Tools/i18n_audit.py --ci origin/${{ github.base_ref || 'main' }}


### PR DESCRIPTION
## Why

A **release pushes straight to `main` with no PR**, and `Tools/appchangelog-gen.py` emits the What's New title as a **raw Kotlin literal** that has to be localized by hand afterwards (Compose has no Xcode-style auto-extraction).

With a `pull_request`-only trigger, that literal landed **completely unaudited** — and because `--ci` is a **whole-tree gate, not a diff**, it then red-checked **every open PR** on a line none of them touched.

That's exactly what 9.0.1 did (fixed by #514): **the break was invisible where it was introduced, and highly visible everywhere it wasn't.** #507, #512 and #513 all went red on it. Nothing currently prevents the next release doing the same.

## What

Audit pushes to `main` too, so a release-introduced literal surfaces **on main the moment it lands** and gets fixed before any contributor trips over it.

```yaml
on:
  pull_request:
    branches: [main]
  push:
    branches: [main]
```

`github.base_ref` is set **only** for `pull_request` and is empty on a push (which would pass a bare `origin/`), so it falls back to `main`. The ref is retained for workflow compatibility — `--ci` is a whole-tree gate, so the resolved value doesn't change the verdict.

Same 8-second ubuntu job. No new cost, no behaviour change for PRs.

## Verification

- YAML parses; both triggers resolve (`pull_request` + `push`, both `[main]`).
- The push path's exact command — `python3 Tools/i18n_audit.py --ci origin/main` — passes on current main (`OK no hardcoded literals`).

## Notes

This makes the failure **loud and immediate** rather than preventing it. `appchangelog-gen` can't fully self-solve: it could emit the `uiString(R.string.…)` key + the `en` string, but it can't translate, so `de`/`es`/`fr` would be missing and the coverage half would still fail — the localize step stays manual, which is precisely why it needs a guard. Gating `fork-release.yml` on the audit would be the stronger (release-blocking) step; deliberately left as a separate call.