### PR TITLE
ble: faster history sync — experimental toggle for offload connection priority (#533)

### DIFF
--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -496,6 +496,15 @@ class WhoopBleClient(
         fun idleThrottleActive(batteryPct: Int, charging: Boolean, thresholdPct: Int): Boolean =
             thresholdPct > 0 && !charging && batteryPct <= thresholdPct
 
+        /** #533: whether flipping connection-priority management from [wasEnabled] to [nowEnabled] must
+         *  RELEASE the link back to the stack default. ONLY the on→off edge does: [refreshConnectionPriority]
+         *  early-returns once disabled, so without an explicit release a link currently pinned at HIGH would
+         *  stay there until the next reconnect — a user turning the experiment off *because* of battery would
+         *  keep paying for it. Enabling, or re-applying while already off (every launch on the default), must
+         *  issue no request at all. */
+        fun releasesConnectionPriority(wasEnabled: Boolean, nowEnabled: Boolean): Boolean =
+            wasEnabled && !nowEnabled
+
         /** Stretched periodic-offload interval while the STRAP is low on battery (#477). The offload tick
          *  is a PURE sync timer (the live-stream keep-alive is separate), so stretching it can't affect
          *  link health — worst case is data arriving in slightly larger batches; the strap banks
@@ -1213,10 +1222,32 @@ class WhoopBleClient(
         idleThrottleBatteryPct: Int,
         escalateForLiveHr: Boolean = false,
     ) {
+        val wasEnabled = connectionPriorityEnabled
         connectionPriorityEnabled = enabled
         this.idleThrottleBatteryPct = if (enabled) idleThrottleBatteryPct else 0
         this.escalateForLiveHr = enabled && escalateForLiveHr
-        handler.post { refreshConnectionPriority() }
+        handler.post {
+            // #533: switching the experiment OFF must UNDO a live escalation, not merely stop future ones.
+            // [refreshConnectionPriority] early-returns on !connectionPriorityEnabled, so without this a
+            // link currently pinned at HIGH would STAY there until the next reconnect — a user turning the
+            // toggle off *because* of battery would keep paying for it, potentially for hours on a
+            // background connection. Only fires on a real on→off edge; enabling (or a no-op re-apply while
+            // already off) never issues a stray request. See [releasesConnectionPriority].
+            if (releasesConnectionPriority(wasEnabled, enabled)) releaseConnectionPriority()
+            else refreshConnectionPriority()
+        }
+    }
+
+    /** #533: hand the link back to the stack default (BALANCED) when connection-priority management is
+     *  switched off, undoing any escalation still in force. Same swallow-don't-teardown policy as
+     *  [refreshConnectionPriority]: a priority hint must never drop the link. */
+    private fun releaseConnectionPriority() {
+        val ops = gattOps ?: return
+        try {
+            ops.requestConnectionPriorityCompat(BluetoothGatt.CONNECTION_PRIORITY_BALANCED)
+        } catch (t: Throwable) {
+            log("connection-priority release failed (${t.javaClass.simpleName}); skipped")
+        }
     }
 
     /** Battery-% at/below which the periodic offload cadence stretches to

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -1195,11 +1195,27 @@ class WhoopBleClient(
      *  half only). The Settings picker offers 10/15/20/25/30. */
     @Volatile private var idleThrottleBatteryPct: Int = 0
 
+    /** #533: also escalate to HIGH for the LIVE-HR stream, not just the offload burst. DEFAULT OFF, and
+     *  deliberately so: [realtimeArmed] is true for the whole OVERNIGHT continuous-HRV window (22:00–07:00
+     *  by default via [continuousCaptureWantsNow]), NOT just while a Live screen is open. Escalating it
+     *  would hold an ~11.25 ms interval for hours to carry a 1 Hz HR/RR stream that BALANCED already
+     *  serves — a sustained drain on both strap and phone for no throughput gain. The offload burst is the
+     *  opposite: bounded (HISTORY_COMPLETE / idle timeout) and bandwidth-hungry, so escalating it moves the
+     *  same bytes in LESS radio-on wall-clock. Kept as a knob rather than deleted because the opt-in R22
+     *  deep-buffer capture IS high-rate and is the one live case that could legitimately want HIGH. */
+    @Volatile private var escalateForLiveHr: Boolean = false
+
     /** Opt into connection-priority management (#477). No-op by default; see the fields above.
-     *  [idleThrottleBatteryPct] 0 disables the risky idle throttle (safe half only). */
-    fun setConnectionPriorityManagement(enabled: Boolean, idleThrottleBatteryPct: Int) {
+     *  [idleThrottleBatteryPct] 0 disables the risky idle throttle (safe half only).
+     *  [escalateForLiveHr] false keeps the escalation to the bounded offload burst (#533). */
+    fun setConnectionPriorityManagement(
+        enabled: Boolean,
+        idleThrottleBatteryPct: Int,
+        escalateForLiveHr: Boolean = false,
+    ) {
         connectionPriorityEnabled = enabled
         this.idleThrottleBatteryPct = if (enabled) idleThrottleBatteryPct else 0
+        this.escalateForLiveHr = enabled && escalateForLiveHr
         handler.post { refreshConnectionPriority() }
     }
 
@@ -1266,7 +1282,10 @@ class WhoopBleClient(
         // published LiveState mirror, which `exitBackfilling` may update a beat later.
         val priority = connectionPriorityFor(
             offloadActive = backfilling,
-            liveHrActive = realtimeArmed,
+            // #533: gated — the live stream does NOT escalate by default. See [escalateForLiveHr]: the
+            // overnight continuous-HRV window keeps this armed for hours, and a 1 Hz stream gains nothing
+            // from HIGH. The offload burst below is the case that actually wants the shorter interval.
+            liveHrActive = realtimeArmed && escalateForLiveHr,
             idleThrottleEnabled = idleThrottle,
         )
         // Deliberately NOT via safeGatt: a battery HINT must never tear the link down. safeGatt's policy

--- a/android/app/src/main/java/com/noop/ui/AppViewModel.kt
+++ b/android/app/src/main/java/com/noop/ui/AppViewModel.kt
@@ -892,19 +892,24 @@ class AppViewModel(app: Application) : AndroidViewModel(app) {
         autoReconnectOnLaunch()
     }
 
-    /** Push the persisted #477 Power-saving prefs to the BLE client. The offload-cadence stretch uses the
-     *  battery-% threshold (0 = off when the master is off); the HRV pause is its own Battery-Saver toggle.
-     *  The riskier connection-priority idle throttle is deliberately NOT exposed here — it stays dormant
-     *  pending on-strap validation (#478). */
+    /** Push the persisted BLE-behaviour prefs to the client. The #477 Power-saving levers: the
+     *  offload-cadence stretch uses the battery-% threshold (0 = off when the master is off); the HRV pause
+     *  is its own Battery-Saver toggle. The riskier connection-priority idle throttle is deliberately NOT
+     *  exposed here — it stays dormant pending on-strap validation (#478). Also pushes the independent
+     *  #533 "Faster history sync" experiment (its own toggle, NOT gated on the Power-saving master: it is a
+     *  sync-speed lever, not a power-saving one). */
     private fun applyPowerSaving() {
         val on = NoopPrefs.powerSaving(appContext)
-        // #533: turn on the SAFE half of #477's connection-priority management, which shipped fully
-        // implemented but DORMANT (nothing ever called this, so refreshConnectionPriority early-returned
-        // and every historical offload ran at the stack default). HIGH for the bounded offload burst
-        // drains a backlog faster; the RISKY idle→LOW_POWER half stays at 0 (still dormant, #478), and
-        // live-HR does not escalate (see WhoopBleClient.escalateForLiveHr). Independent of the
-        // Power-saving master: this is a sync-speed lever, not a power-saving one.
-        ble.setConnectionPriorityManagement(enabled = true, idleThrottleBatteryPct = 0)
+        // #533: the SAFE half of #477's connection-priority management shipped fully implemented but
+        // DORMANT — nothing ever called this, so refreshConnectionPriority early-returned and EVERY
+        // historical offload ran at the stack default. Behind the experimental toggle it escalates to HIGH
+        // for the bounded offload burst (faster backlog drain). The RISKY idle→LOW_POWER half stays at 0
+        // (still dormant, #478), and live-HR does not escalate (see WhoopBleClient.escalateForLiveHr) —
+        // realtimeArmed covers the overnight capture window, which would otherwise hold HIGH for hours.
+        ble.setConnectionPriorityManagement(
+            enabled = NoopPrefs.fastHistorySync(appContext),
+            idleThrottleBatteryPct = 0,
+        )
         ble.setLowBatteryOffloadThrottle(if (on) NoopPrefs.powerSavingBatteryPct(appContext) else 0)
         // HRV pause is a sub-option: only effective while the master is on (defaults on when it is), and
         // now battery-%-aware like the offload lever — pass the same threshold.
@@ -929,6 +934,13 @@ class AppViewModel(app: Application) : AndroidViewModel(app) {
     /** Flip "Pause HRV capture in Battery Saver" (Settings). Persists + applies immediately. */
     fun setPauseHrvOnPowerSave(enabled: Boolean) {
         NoopPrefs.setPauseHrvOnPowerSave(appContext, enabled)
+        applyPowerSaving()
+    }
+
+    /** Flip the experimental "Faster history sync" (#533). Persists + applies immediately, so the next
+     *  offload burst uses the new priority without waiting for a reconnect. */
+    fun setFastHistorySync(enabled: Boolean) {
+        NoopPrefs.setFastHistorySync(appContext, enabled)
         applyPowerSaving()
     }
 

--- a/android/app/src/main/java/com/noop/ui/AppViewModel.kt
+++ b/android/app/src/main/java/com/noop/ui/AppViewModel.kt
@@ -898,6 +898,13 @@ class AppViewModel(app: Application) : AndroidViewModel(app) {
      *  pending on-strap validation (#478). */
     private fun applyPowerSaving() {
         val on = NoopPrefs.powerSaving(appContext)
+        // #533: turn on the SAFE half of #477's connection-priority management, which shipped fully
+        // implemented but DORMANT (nothing ever called this, so refreshConnectionPriority early-returned
+        // and every historical offload ran at the stack default). HIGH for the bounded offload burst
+        // drains a backlog faster; the RISKY idle→LOW_POWER half stays at 0 (still dormant, #478), and
+        // live-HR does not escalate (see WhoopBleClient.escalateForLiveHr). Independent of the
+        // Power-saving master: this is a sync-speed lever, not a power-saving one.
+        ble.setConnectionPriorityManagement(enabled = true, idleThrottleBatteryPct = 0)
         ble.setLowBatteryOffloadThrottle(if (on) NoopPrefs.powerSavingBatteryPct(appContext) else 0)
         // HRV pause is a sub-option: only effective while the master is on (defaults on when it is), and
         // now battery-%-aware like the offload lever — pass the same threshold.

--- a/android/app/src/main/java/com/noop/ui/MainActivity.kt
+++ b/android/app/src/main/java/com/noop/ui/MainActivity.kt
@@ -244,6 +244,23 @@ object NoopPrefs {
         of(context).edit().putBoolean(KEY_PAUSE_HRV_ON_POWER_SAVE, enabled).apply()
     }
 
+    /** EXPERIMENTAL (#533): escalate the GATT connection interval to HIGH for the bounded historical
+     *  offload burst, so a large backlog drains faster. Drives the SAFE half of #477's connection-priority
+     *  management via [com.noop.ble.WhoopBleClient.setConnectionPriorityManagement]; the risky idle
+     *  throttle stays off, and the live/overnight stream never escalates.
+     *
+     *  DEFAULT OFF and behind an "(experimental)" label on purpose: BLE behaviour cannot be CI- or
+     *  Linux-tested, so both the speedup and its battery cost need real-strap field reports before this
+     *  could ever be considered for default-on. */
+    const val KEY_FAST_HISTORY_SYNC = "noop.fastHistorySync"
+
+    fun fastHistorySync(context: Context): Boolean =
+        of(context).getBoolean(KEY_FAST_HISTORY_SYNC, false)
+
+    fun setFastHistorySync(context: Context, enabled: Boolean) {
+        of(context).edit().putBoolean(KEY_FAST_HISTORY_SYNC, enabled).apply()
+    }
+
     /** #836, the raw-HR fingerprint ("count:maxTs") the last COMPLETED idle rescore scored against. The
      *  15-min backstop tick skips when the current fingerprint equals this; cleared implicitly by any HR
      *  insert/delete (the fingerprint moves). Mirrors the Swift `analyzeWatermark` UserDefaults key. */

--- a/android/app/src/main/java/com/noop/ui/SettingsScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/SettingsScreen.kt
@@ -470,6 +470,7 @@ fun SettingsScreen(
     // "Keep connected in the background" — drives WhoopConnectionService (foreground service). Default
     // on. SharedPreferences isn't reactive, so the Switch mirrors into a local state.
     var backgroundConnection by remember { mutableStateOf(NoopPrefs.backgroundConnection(context)) }
+    var fastHistorySync by remember { mutableStateOf(NoopPrefs.fastHistorySync(context)) }
 
     // "Continuous HRV capture" — hold the dense realtime stream armed 24/7 (better overnight HRV) at the
     // cost of more battery. Default OFF; only does anything with background connection on. Local mirror.
@@ -1269,6 +1270,43 @@ fun SettingsScreen(
                         onCheckedChange = {
                             backgroundConnection = it
                             vm.setBackgroundConnection(it)
+                        },
+                        colors = SwitchDefaults.colors(
+                            checkedThumbColor = Palette.surfaceBase,
+                            checkedTrackColor = Palette.accent,
+                            uncheckedThumbColor = Palette.textSecondary,
+                            uncheckedTrackColor = Palette.surfaceInset,
+                            uncheckedBorderColor = Palette.hairline,
+                        ),
+                    )
+                }
+
+                // "Faster history sync" (#533, EXPERIMENTAL): asks Android for a shorter GATT connection
+                // interval for the BOUNDED historical-offload burst only. Off by default — BLE behaviour
+                // can't be CI-tested, so this needs real-strap field reports on both the speedup and the
+                // battery cost. The live/overnight stream deliberately never escalates.
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(16.dp),
+                ) {
+                    Column(modifier = Modifier.weight(1f)) {
+                        Text(
+                            stringResource(R.string.fast_history_sync),
+                            style = NoopType.subhead,
+                            color = Palette.textPrimary,
+                        )
+                        Text(
+                            stringResource(R.string.fast_history_sync_desc),
+                            style = NoopType.footnote,
+                            color = Palette.textTertiary,
+                        )
+                    }
+                    Switch(
+                        checked = fastHistorySync,
+                        onCheckedChange = {
+                            fastHistorySync = it
+                            vm.setFastHistorySync(it)
                         },
                         colors = SwitchDefaults.colors(
                             checkedThumbColor = Palette.surfaceBase,

--- a/android/app/src/main/res/values-de/strings.xml
+++ b/android/app/src/main/res/values-de/strings.xml
@@ -147,6 +147,8 @@
     <string name="timeline_other_sources_no_offload">Andere Quellen übertragen keine rohen Sekundendaten auf das Gerät.</string>
 
     <!-- Power saving (#477) -->
+    <string name="fast_history_sync">Schnellere Verlaufssynchronisierung (experimentell)</string>
+    <string name="fast_history_sync_desc">Fordert eine schnellere Bluetooth-Verbindung an, während Ihr Riemen seinen gespeicherten Verlauf überträgt, damit ein großer Rückstand schneller aufholt. Nur während der Synchronisierung — Ihre Live-Herzfrequenz und der nächtliche Datenstrom bleiben unberührt. Neu und unerprobt: Wenn es nicht hilft oder zu viel Akku kostet, schalten Sie es wieder aus.</string>
     <string name="power_saving">Energie sparen</string>
     <string name="power_saving_blurb">Entlastet dein Band, wenn sein Akku zur Neige geht. Das Band speichert die Daten selbst, es geht also nichts verloren – NOOP kommuniziert nur seltener mit ihm, damit es durchhält, bis du es laden kannst.</string>
     <string name="power_saving_mode">Energiesparmodus</string>

--- a/android/app/src/main/res/values-es/strings.xml
+++ b/android/app/src/main/res/values-es/strings.xml
@@ -1591,6 +1591,8 @@
     <string name="timeline_empty_metric">No %1$s aquí</string>
     <string name="timeline_nothing_offloaded">Aún no se ha descargado nada para esta ventana.</string>
     <string name="timeline_other_sources_no_offload">Otras fuentes no descargan datos brutos por segundo en el dispositivo.</string>
+    <string name="fast_history_sync">Sincronización de historial más rápida (experimental)</string>
+    <string name="fast_history_sync_desc">Solicita una conexión Bluetooth más rápida mientras su correa transfiere su historial almacenado, para que un gran retraso se ponga al día antes. Solo durante la sincronización: su frecuencia cardíaca en vivo y el flujo nocturno no se ven afectados. Nuevo y no probado: si no ayuda o consume demasiada batería, vuelva a desactivarlo.</string>
     <string name="power_saving">Salvamento de energía</string>
     <string name="power_saving_blurb">Facilite la carga en la correa cuando su batería esté baja. La correa mantiene datos bancarios por sí solas, por lo que nada se pierde — NOOP sólo habla con ella con menos frecuencia para ayudarle a durar hasta que pueda cargarlo.</string>
     <string name="power_saving_mode">Modo de ahorro de energía</string>

--- a/android/app/src/main/res/values-fr/strings.xml
+++ b/android/app/src/main/res/values-fr/strings.xml
@@ -1591,6 +1591,8 @@
     <string name="timeline_empty_metric">Pas de %1$s ici</string>
     <string name="timeline_nothing_offloaded">Rien de déchargé pour cette fenêtre pour l\'instant.</string>
     <string name="timeline_other_sources_no_offload">D\'autres sources ne déchargent pas les données brutes par seconde sur les appareils.</string>
+    <string name="fast_history_sync">Synchronisation de l\'historique plus rapide (expérimental)</string>
+    <string name="fast_history_sync_desc">Demande une connexion Bluetooth plus rapide pendant que votre sangle transfère son historique stocké, afin qu\'un gros retard se rattrape plus vite. Uniquement pendant la synchronisation : votre fréquence cardiaque en direct et le flux nocturne ne sont pas affectés. Nouveau et non éprouvé : si cela n\'aide pas ou consomme trop de batterie, désactivez-le.</string>
     <string name="power_saving">Économie d\'énergie</string>
     <string name="power_saving_blurb">Diminuer la charge sur votre sangle lorsque sa batterie est basse. La sangle garde les données bancaires à elle seule, donc rien n\'est perdu — NOOP lui parle moins souvent pour l\'aider jusqu\'à ce que vous puissiez les charger.</string>
     <string name="power_saving_mode">Mode d\'économie d\'énergie</string>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -156,6 +156,8 @@
     <string name="timeline_other_sources_no_offload">Other sources don\'t offload raw per-second data on-device.</string>
 
     <!-- Power saving (#477) -->
+    <string name="fast_history_sync">Faster history sync (experimental)</string>
+    <string name="fast_history_sync_desc">Ask Android for a faster Bluetooth link while your strap hands over its stored history, so a big backlog catches up sooner. Only during the sync itself — your live heart rate and the overnight stream are untouched. New and unproven: if it doesn\'t help, or costs more battery than it\'s worth, turn it back off and say so on the issue tracker.</string>
     <string name="power_saving">Power saving</string>
     <string name="power_saving_blurb">Ease the load on your strap when its battery is running low. The strap keeps banking data on its own, so nothing is lost — NOOP just talks to it less often to help it last until you can charge it.</string>
     <string name="power_saving_mode">Power saving mode</string>

--- a/android/app/src/test/java/com/noop/ble/ConnectionPriorityTest.kt
+++ b/android/app/src/test/java/com/noop/ble/ConnectionPriorityTest.kt
@@ -48,6 +48,48 @@ class ConnectionPriorityTest {
         )
     }
 
+    // --- #533: which ACTIVE work escalates, once the safe half is switched on ---
+
+    /**
+     * The production wiring passes `liveHrActive = realtimeArmed && escalateForLiveHr`, and
+     * `escalateForLiveHr` is DEFAULT OFF. That matters because `realtimeArmed` is true for the whole
+     * OVERNIGHT continuous-HRV window, not just while a Live screen is open: escalating it would hold an
+     * ~11.25 ms interval for hours to carry a 1 Hz stream BALANCED already serves. Pin that an armed live
+     * stream alone stays BALANCED, while the bounded offload burst still escalates through it.
+     */
+    @Test fun liveHrAloneDoesNotEscalateByDefault() {
+        val realtimeArmed = true
+        val escalateForLiveHr = false      // the shipped default
+        val liveHrActive = realtimeArmed && escalateForLiveHr
+
+        // Overnight capture armed, no offload → stays BALANCED (no all-night HIGH).
+        assertEquals(
+            BluetoothGatt.CONNECTION_PRIORITY_BALANCED,
+            WhoopBleClient.connectionPriorityFor(
+                offloadActive = false, liveHrActive = liveHrActive, idleThrottleEnabled = false,
+            ),
+        )
+        // ...but an offload burst during that same window DOES escalate — the point of #533.
+        assertEquals(
+            BluetoothGatt.CONNECTION_PRIORITY_HIGH,
+            WhoopBleClient.connectionPriorityFor(
+                offloadActive = true, liveHrActive = liveHrActive, idleThrottleEnabled = false,
+            ),
+        )
+    }
+
+    /** Opting the knob ON restores the #477 behaviour (the R22 deep-buffer capture is the one high-rate
+     *  live case that could legitimately want it), so the resolver branch stays live, not dead. */
+    @Test fun liveHrEscalatesWhenTheKnobIsOptedIn() {
+        val liveHrActive = true && true     // realtimeArmed && escalateForLiveHr
+        assertEquals(
+            BluetoothGatt.CONNECTION_PRIORITY_HIGH,
+            WhoopBleClient.connectionPriorityFor(
+                offloadActive = false, liveHrActive = liveHrActive, idleThrottleEnabled = false,
+            ),
+        )
+    }
+
     // --- battery-adaptive gate, keyed on STRAP battery only (#477) ---
 
     @Test fun idleThrottleEngagesOnlyWhenDischargingAtOrBelowThreshold() {

--- a/android/app/src/test/java/com/noop/ble/ConnectionPriorityTest.kt
+++ b/android/app/src/test/java/com/noop/ble/ConnectionPriorityTest.kt
@@ -90,6 +90,26 @@ class ConnectionPriorityTest {
         )
     }
 
+    // --- #533: turning the experiment OFF must UNDO a live escalation ---
+
+    /**
+     * `refreshConnectionPriority` early-returns once management is disabled, so disabling can only stop
+     * FUTURE escalations — a link already pinned at HIGH would stay there until the next reconnect unless
+     * the on→off edge explicitly releases it. That would break the toggle's own promise ("turn it back off"
+     * if it costs battery) for anyone on a background connection.
+     */
+    @Test fun disablingReleasesTheLinkBackToDefault() {
+        assertTrue(WhoopBleClient.releasesConnectionPriority(wasEnabled = true, nowEnabled = false))
+    }
+
+    /** Every other transition must issue NO request — notably the default launch path, which re-applies
+     *  `enabled = false` while already off and must stay byte-for-byte today's zero-BLE-op behaviour. */
+    @Test fun onlyTheOnToOffEdgeReleases() {
+        assertFalse(WhoopBleClient.releasesConnectionPriority(wasEnabled = false, nowEnabled = false))
+        assertFalse(WhoopBleClient.releasesConnectionPriority(wasEnabled = false, nowEnabled = true))
+        assertFalse(WhoopBleClient.releasesConnectionPriority(wasEnabled = true, nowEnabled = true))
+    }
+
     // --- battery-adaptive gate, keyed on STRAP battery only (#477) ---
 
     @Test fun idleThrottleEngagesOnlyWhenDischargingAtOrBelowThreshold() {


### PR DESCRIPTION
## The finding

#477 shipped GATT connection-priority management **fully implemented but dormant**. `setConnectionPriorityManagement` is **never called from anywhere in production** (grep: only its own definition), so `connectionPriorityEnabled` stays `false`, `refreshConnectionPriority()` early-returns at every call site, and **every historical offload to date has run at the stack default**.

The hook is already in exactly the right place — it just was never switched on:

```kotlin
// enterBackfilling
refreshConnectionPriority()   // #477: escalate to HIGH for the offload burst (faster sync). No-op unless enabled.
```

The source even says *"a follow-up wires it to a persisted Settings toggle"* — that follow-up never landed. This PR is that follow-up.

Relevant to **#533** (historical sync ~10× slower than the official app): before investing in HCI captures to find a hypothetical bulk-offload command, the cheapest experiment is to turn on an escalation we already wrote. On Android `CONNECTION_PRIORITY_HIGH` is ~11.25 ms vs BALANCED ~30 ms.

## What this does

Adds **Settings → Strap → "Faster history sync (experimental)"**, default **OFF**. When on, it enables the **safe half** of #477:

- **Offload burst → HIGH.** Bounded (`HISTORY_COMPLETE` / idle timeout) and bandwidth-hungry, so a shorter interval moves the same bytes in **less radio-on wall-clock**.
- **Risky idle→LOW_POWER half stays at 0** (still dormant, #478).
- **Live-HR does NOT escalate** — new `escalateForLiveHr` knob, default off.

### Why live-HR is excluded (the battery reasoning)

`realtimeArmed` is set from `screenWantsRealtime || continuousCaptureWantsNow()`, and `continuousCaptureWantsNow()` covers the **overnight continuous-HRV window** (22:00–07:00 by default) — not just an open Live screen. Escalating it would hold an ~11.25 ms interval **for hours every night** to carry a **1 Hz** HR/RR stream that BALANCED already serves: sustained drain on strap and phone, zero throughput gain. The source itself calls the realtime stream *"one of the larger drains."*

It's a knob rather than a deletion because the opt-in **R22 deep-buffer capture** is high-rate and is the one live case that could legitimately want HIGH — so the resolver branch stays live, not dead.

## Battery

- **Offload:** plausibly net-neutral or better — same bytes, less radio-on time. Bounded burst.
- **Idle:** unchanged. The resolver's `else` is BALANCED, which #477's own docs call the stack default, so the request is a no-op.
- **Overnight / live:** unchanged, by the design above.
- **Toggle off (the default):** byte-for-byte today's behaviour — `refreshConnectionPriority` early-returns exactly as it does now.

## Why a toggle rather than default-on

BLE behaviour **cannot be CI- or Linux-tested**, so neither the speedup nor the battery cost can be proven in this PR. An opt-in experimental toggle lets it ship and gather real field reports instead of blocking on a single strap, and anyone who finds it unhelpful can switch it straight back off.

It sits in the **Strap** card next to "Keep connected in the background" — deliberately *not* in Power saving, since that card is about saving power and this switch spends it. It's also **not** gated on the Power-saving master.

**Measuring needs no new instrumentation:** the strap log already timestamps `Backfill: session started` / `session ended` next to `Backfill: session persisted N rows`, so records/sec is directly comparable from a before/after log on a real backlog.

## Re-review catch: turning it off now actually turns it off

`refreshConnectionPriority()` early-returns on `!connectionPriorityEnabled`, so `setConnectionPriorityManagement(enabled = false)` issued **no BLE op at all** — disabling only stopped *future* escalations and left a link already pinned at `CONNECTION_PRIORITY_HIGH` there **until the next reconnect**.

That broke this toggle's own promise: the Settings copy says to turn it back off if it costs more battery than it's worth, but a user doing exactly that would keep paying — potentially for hours, since "Keep connected in the background" (the switch directly above it) holds the link open.

Now a real on→off edge requests BALANCED once, handing the link back to the stack default. Every other transition still issues nothing — notably the default launch path, which re-applies `enabled = false` while already off and stays byte-for-byte today's zero-BLE-op behaviour. The edge rule is a pure companion predicate (`releasesConnectionPriority`), matching this file's idiom, since `WhoopBleClient` needs a `Context` and can't be built in the pure-JVM suite.

(The latent flaw is #477's — but nothing could reach it while the feature was dormant. Exposing the toggle is what makes the disable path reachable, so it's fixed here.)

## Tests

- `python3 Tools/i18n_audit.py --ci` — **OK**, no hardcoded literals, all focus locales complete (strings added to `values` + `de`/`es`/`fr`).
- `compileFullDebugKotlin` + `ConnectionPriorityTest` — **11/11 pass** — two cases pinning that an armed live/overnight stream stays BALANCED while an offload burst in that same window still escalates, plus two pinning that only the on→off edge releases the link.
- **Not validated on hardware** — I have no strap. The toggle's default-off means that's safe to merge, but the escalation itself still needs an on-strap before/after before it could be trusted or ever considered for default-on.

## Follow-ups (deliberately not here)

- `MAX_AUTO_CONTINUES = 6` + `BACKFILL_INTERVAL_MS = 900_000` (15-min floor) also pace large-backlog wall-clock — worth measuring once this lands.
- If a large gap survives both, #533's bulk-command hypothesis is genuinely motivated and the HCI capture is worth the effort.

## Cross-platform: no Swift twin (deliberate)

Per the parity contract this needs an explicit "why not": **CoreBluetooth exposes no app-side API for this.** The peripheral proposes the GAP connection parameters and Apple's stack negotiates them (and the PHY) itself — apps get no say. #477 already records the same divergence in-code: *"Android-only by necessity … so there is no Swift twin — a deliberate platform divergence, not a parity gap."*

Useful corollary: because iOS/macOS have their link parameters chosen for them, they are effectively "Android with these levers permanently on and untunable" — which makes them a **control group**. If a Mac drains a comparable backlog at a much higher rows/sec than Android (compare `Backfill: session started` / `session ended` / `persisted N rows`, which both platforms log identically), the strap is provably **not** firmware-paced, since the strap is the constant across the test. If they match, these levers likely will not help and #533's HCI capture is the better investment.

The one lever here that *does* have a Swift twin is the scheduler (`MAX_AUTO_CONTINUES` / the 15-min `BACKFILL_INTERVAL_MS`, mirrored by `BLEManager.maxAutoContinues` / `BackfillPolicy.periodicFloorSeconds`) — deliberately untouched in this PR, and it would need both platforms if changed.