### PR TITLE
i18n: real <plurals> instead of hand-rolled singular/plural pairs

### DIFF
--- a/Tools/i18n_audit.py
+++ b/Tools/i18n_audit.py
@@ -97,7 +97,10 @@ def android_strings_xml_gaps() -> dict[str, set[str]]:
     existing values-<lang>/strings.xml. (Doesn't invent missing locale dirs —
     see the audit summary for languages with NO directory at all.)"""
     base_path = ROOT / "android/app/src/main/res/values/strings.xml"
-    base_keys = set(re.findall(r'<string name="([^"]+)"', base_path.read_text(encoding="utf-8")))
+    # <plurals> count too: converting a hand-rolled singular/plural PAIR into one <plurals> would
+    # otherwise DROP those keys out of this gate's view entirely, so a locale could silently lose them —
+    # fixing the plural model must not open a coverage hole (see #540 for the same class of blind spot).
+    base_keys = set(re.findall(r'<(?:string|plurals) name="([^"]+)"', base_path.read_text(encoding="utf-8")))
     exempt = {"app_name"}  # brand name, deliberately identical everywhere
     gaps: dict[str, set[str]] = {}
     for lang in LANGS:
@@ -105,7 +108,7 @@ def android_strings_xml_gaps() -> dict[str, set[str]]:
         if not lang_path.exists():
             gaps[lang] = {"<entire values-%s/ directory is missing>" % lang}
             continue
-        lang_keys = set(re.findall(r'<string name="([^"]+)"', lang_path.read_text(encoding="utf-8")))
+        lang_keys = set(re.findall(r'<(?:string|plurals) name="([^"]+)"', lang_path.read_text(encoding="utf-8")))
         missing = (base_keys - exempt) - lang_keys
         if missing:
             gaps[lang] = missing

--- a/Tools/i18n_audit.py
+++ b/Tools/i18n_audit.py
@@ -128,10 +128,14 @@ def android_format_gaps() -> dict[str, list[str]]:
     for lang, path in paths.items():
         if not path.exists():
             continue
-        values[lang] = {
-            node.attrib["name"]: node.text or ""
-            for node in ET.parse(path).getroot().findall("string")
-        }
+        root = ET.parse(path).getroot()
+        entries = {node.attrib["name"]: node.text or "" for node in root.findall("string")}
+        # <plurals> carry their format args on the <item> CHILDREN, so a plain findall("string") leaves
+        # every plural's placeholders unchecked — a locale could drop the %1$d from a quantity form and
+        # this gate would not notice. Fold each plural's items into one value so the signature covers them.
+        for node in root.findall("plurals"):
+            entries[node.attrib["name"]] = " ".join((i.text or "") for i in node.findall("item"))
+        values[lang] = entries
 
     def signature(value: str) -> list[str]:
         return sorted(ANDROID_FORMAT_PATTERN.findall(value))

--- a/Tools/i18n_audit.py
+++ b/Tools/i18n_audit.py
@@ -124,21 +124,35 @@ def android_format_gaps() -> dict[str, list[str]]:
         "en": ROOT / "android/app/src/main/res/values/strings.xml",
         **{lang: ROOT / f"android/app/src/main/res/values-{lang}/strings.xml" for lang in LANGS},
     }
+    def signature(value: str) -> list[str]:
+        return sorted(ANDROID_FORMAT_PATTERN.findall(value))
+
     values: dict[str, dict[str, str]] = {}
+    plural_items: dict[str, dict[str, list[str]]] = {}
     for lang, path in paths.items():
         if not path.exists():
             continue
         root = ET.parse(path).getroot()
         entries = {node.attrib["name"]: node.text or "" for node in root.findall("string")}
+        items_by_key: dict[str, list[str]] = {}
         # <plurals> carry their format args on the <item> CHILDREN, so a plain findall("string") leaves
-        # every plural's placeholders unchecked — a locale could drop the %1$d from a quantity form and
-        # this gate would not notice. Fold each plural's items into one value so the signature covers them.
+        # every plural's placeholders unchecked.
+        #
+        # Compare ONE REPRESENTATIVE form across languages, never the concatenated set: the signature is a
+        # MULTISET, so folding would make it depend on how many quantity categories a language HAS —
+        # Polish (one/few/many/other) would read as a format mismatch against English (one/other) purely
+        # for having more forms, and this gate would reject the very thing <plurals> exist to support.
+        # `other` is the CLDR fallback every language defines, so it is the stable representative.
+        # A dropped placeholder in a NON-representative form is caught by the intra-plural check below.
         for node in root.findall("plurals"):
-            entries[node.attrib["name"]] = " ".join((i.text or "") for i in node.findall("item"))
+            items = node.findall("item")
+            texts = [i.text or "" for i in items]
+            rep = next((i.text or "" for i in items if i.attrib.get("quantity") == "other"),
+                       texts[0] if texts else "")
+            entries[node.attrib["name"]] = rep
+            items_by_key[node.attrib["name"]] = texts
         values[lang] = entries
-
-    def signature(value: str) -> list[str]:
-        return sorted(ANDROID_FORMAT_PATTERN.findall(value))
+        plural_items[lang] = items_by_key
 
     gaps: dict[str, list[str]] = {}
     for lang in LANGS:
@@ -148,6 +162,13 @@ def android_format_gaps() -> dict[str, list[str]]:
             key for key, source in values["en"].items()
             if signature(source) != signature(values[lang].get(key, ""))
         ]
+        # Every quantity form of ONE plural must carry the same placeholders as its siblings. This is a
+        # within-language invariant, so it stays correct no matter how many categories the language has —
+        # it catches the "translator dropped %1$d from just the `one` form" case that the representative
+        # comparison above cannot see.
+        for key, texts in plural_items.get(lang, {}).items():
+            if len({tuple(signature(x)) for x in texts}) > 1 and key not in mismatched:
+                mismatched.append(key)
         if mismatched:
             gaps[lang] = mismatched
     return gaps

--- a/android/app/src/main/java/com/noop/NoopApplication.kt
+++ b/android/app/src/main/java/com/noop/NoopApplication.kt
@@ -2,6 +2,7 @@ package com.noop
 
 import android.app.Application
 import android.content.Context
+import androidx.annotation.PluralsRes
 import androidx.annotation.StringRes
 import android.util.Log
 import com.noop.ble.SourceCoordinator
@@ -132,6 +133,14 @@ class NoopApplication : Application() {
         fun localizedString(@StringRes id: Int, vararg formatArgs: Any): String {
             val app = checkNotNull(instance) { "NoopApplication is not attached" }
             return if (formatArgs.isEmpty()) app.getString(id) else app.getString(id, *formatArgs)
+        }
+
+        /** Quantity-aware twin of [localizedString]: resolves a `<plurals>` for [count] under the active
+         *  locale's own plural rules. Same Application-resources path, so it stays locale-aware off the
+         *  composition. */
+        fun localizedPlural(@PluralsRes id: Int, count: Int, vararg formatArgs: Any): String {
+            val app = checkNotNull(instance) { "NoopApplication is not attached" }
+            return app.resources.getQuantityString(id, count, *formatArgs)
         }
     }
 }

--- a/android/app/src/main/java/com/noop/ui/IntelligenceScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/IntelligenceScreen.kt
@@ -138,11 +138,7 @@ fun IntelligenceScreen(vm: AppViewModel) {
             }
             item {
                 Text(
-                    uiString(
-                        if (filtered.size == 1) R.string.intelligence_day_count
-                        else R.string.intelligence_days_count,
-                        filtered.size,
-                    ),
+                    uiPlural(R.plurals.intelligence_days_count, filtered.size, filtered.size),
                     style = NoopType.footnote,
                     color = Palette.textTertiary,
                 )

--- a/android/app/src/main/java/com/noop/ui/LabBookScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/LabBookScreen.kt
@@ -408,11 +408,7 @@ private fun MarkerDetailSheet(
         Column(verticalArrangement = Arrangement.spacedBy(Metrics.sectionGap)) {
             Text(name, style = NoopType.title2, color = Palette.textPrimary)
             Text(
-                uiString(
-                    if (readings.size == 1) R.string.lab_book_reading_count
-                    else R.string.lab_book_readings_count,
-                    readings.size,
-                ),
+                uiPlural(R.plurals.lab_book_readings_count, readings.size, readings.size),
                 style = NoopType.subhead,
                 color = Palette.textSecondary,
             )

--- a/android/app/src/main/java/com/noop/ui/TrendsExploreScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/TrendsExploreScreen.kt
@@ -39,6 +39,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
@@ -802,7 +803,7 @@ private fun StatRow(
                 modifier = Modifier.weight(1f),
                 label = stringResource(R.string.explore_average),
                 value = if (s.n > 0) metric.format(s.mean) else ",",
-                caption = stringResource(R.string.explore_n_days, s.n),
+                caption = pluralStringResource(R.plurals.explore_n_days, s.n, s.n),
                 accent = metric.accent,
             )
             StatTile(

--- a/android/app/src/main/java/com/noop/ui/TrendsScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/TrendsScreen.kt
@@ -36,6 +36,7 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Shadow
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.text.font.FontWeight
@@ -386,7 +387,7 @@ private fun WeekNavBar(weekOffset: Int, minWeekOffset: Int, onStep: (Int) -> Uni
     val label = when {
         weekOffset == 0 -> stringResource(R.string.trends_this_week)
         weekOffset == -1 -> stringResource(R.string.trends_last_week)
-        else -> stringResource(R.string.trends_weeks_ago, -weekOffset)
+        else -> pluralStringResource(R.plurals.trends_weeks_ago, -weekOffset, -weekOffset)
     }
     // liquidPress on the two week-step chevrons (the screen's tappable controls): each settles inward on
     // press, wired to the SAME interactionSource the IconButton uses for its own ripple, matching the pilot.

--- a/android/app/src/main/java/com/noop/ui/UiStrings.kt
+++ b/android/app/src/main/java/com/noop/ui/UiStrings.kt
@@ -1,5 +1,6 @@
 package com.noop.ui
 
+import androidx.annotation.PluralsRes
 import androidx.annotation.StringRes
 import com.noop.NoopApplication
 
@@ -13,3 +14,13 @@ import com.noop.NoopApplication
  */
 internal fun uiString(@StringRes id: Int, vararg formatArgs: Any): String =
     NoopApplication.localizedString(id, *formatArgs)
+
+/**
+ * Quantity-aware twin of [uiString]. Android picks the right `<item quantity=...>` for [count] using the
+ * LOCALE's own plural rules, which is the whole point: hand-rolling `if (n == 1) singular else plural` at
+ * the call site bakes in English's TWO categories. That silently under-serves any language with more —
+ * Polish has one/few/many/other ("1 noc / 2 noce / 5 nocy"), so no amount of special-casing 1 can spell
+ * it correctly. Routed through the Application resources for the same reason as [uiString].
+ */
+internal fun uiPlural(@PluralsRes id: Int, count: Int, vararg formatArgs: Any): String =
+    NoopApplication.localizedPlural(id, count, *formatArgs)

--- a/android/app/src/main/res/values-de/strings.xml
+++ b/android/app/src/main/res/values-de/strings.xml
@@ -89,7 +89,6 @@
     <string name="trends_no_readings_body">Wechsle mit den Pfeilen oben zu einer anderen Woche, um ihren Rückblick zu sehen.</string>
     <string name="trends_this_week">Diese Woche</string>
     <string name="trends_last_week">Letzte Woche</string>
-    <string name="trends_weeks_ago">vor %1$d Wochen</string>
     <string name="trends_previous_week">Vorherige Woche</string>
     <string name="trends_next_week">Nächste Woche</string>
     <string name="trends_daily_signals">Tägliche Signale</string>
@@ -121,7 +120,6 @@
     <string name="explore_delta_vs_prev">Δ vs. vorher</string>
     <string name="explore_summary">Zusammenfassung</string>
     <string name="explore_over_visible_window">Über das sichtbare Fenster</string>
-    <string name="explore_n_days">%1$d Tage</string>
     <string name="explore_n_pts">%1$d Pkt.</string>
     <string name="explore_vs_prev_window">vs. vorher %1$s</string>
     <string name="explore_all_history">gesamte Historie</string>
@@ -1611,11 +1609,7 @@
     <string name="l10n_wheel_picker_accessibility_tap_to_choose_1314c4ed">%1$s. Tippen Sie, um zu wählen.</string>
     <string name="l10n_workouts_screen_minutes_total_100_roundtoint_5bb7c6d8">%1$s%%</string>
     <!-- #453 manually migrated complex Kotlin templates. -->
-    <string name="intelligence_day_count">%1$d Tag</string>
-    <string name="intelligence_days_count">%1$d Tage</string>
     <string name="intervals_range_step">%1$s – %2$s%3$s · Schritt %4$d</string>
-    <string name="lab_book_reading_count">%1$d Messwert · dein eigener Eintrag</string>
-    <string name="lab_book_readings_count">%1$d Messwerte · deine eigenen Einträge</string>
     <string name="live_workout_saved_summary">✓ %1$s gespeichert · %2$s</string>
     <string name="skin_temp_reason_summary">%1$s: %2$s</string>
     <string name="stress_score_accessibility">Stress %1$s von 3, %2$s</string>
@@ -1646,4 +1640,20 @@
     <string name="explore_description_charge">Wie erholt du bist, angeführt von der HRV gegenüber deiner persönlichen Basislinie.</string>
     <string name="explore_description_effort">Herz-Kreislauf-Belastung für den Tag auf einer Skala von 0–100 (zuvor 0–21).</string>
     <string name="explore_description_rest">Wie erholsam dein Schlaf war: Dauer, Effizienz, Tief- und REM-Schlaf sowie Timing.</string>
+    <plurals name="intelligence_days_count">
+        <item quantity="one">%1$d Tag</item>
+        <item quantity="other">%1$d Tage</item>
+    </plurals>
+    <plurals name="lab_book_readings_count">
+        <item quantity="one">%1$d Messwert · dein eigener Eintrag</item>
+        <item quantity="other">%1$d Messwerte · deine eigenen Einträge</item>
+    </plurals>
+    <plurals name="trends_weeks_ago">
+        <item quantity="one">vor %1$d Woche</item>
+        <item quantity="other">vor %1$d Wochen</item>
+    </plurals>
+    <plurals name="explore_n_days">
+        <item quantity="one">%1$d Tag</item>
+        <item quantity="other">%1$d Tage</item>
+    </plurals>
 </resources>

--- a/android/app/src/main/res/values-es/strings.xml
+++ b/android/app/src/main/res/values-es/strings.xml
@@ -1449,11 +1449,7 @@
     <string name="l10n_wheel_picker_accessibility_tap_to_choose_1314c4ed">%1$s. Toca para elegir.</string>
     <string name="l10n_workouts_screen_minutes_total_100_roundtoint_5bb7c6d8">%1$s%%</string>
     <!-- #453 manually migrated complex Kotlin templates. -->
-    <string name="intelligence_day_count">%1$d día</string>
-    <string name="intelligence_days_count">%1$d días</string>
     <string name="intervals_range_step">%1$s – %2$s%3$s · paso %4$d</string>
-    <string name="lab_book_reading_count">%1$d lectura · tu propia entrada</string>
-    <string name="lab_book_readings_count">%1$d lecturas · tus propias entradas</string>
     <string name="live_workout_saved_summary">✓ %1$s guardado · %2$s</string>
     <string name="skin_temp_reason_summary">%1$s: %2$s</string>
     <string name="stress_score_accessibility">Estrés %1$s de 3, %2$s</string>
@@ -1537,7 +1533,6 @@
     <string name="trends_no_readings_body">Pasa a otra semana con las flechas de arriba para ver su resumen.</string>
     <string name="trends_this_week">Esta semana</string>
     <string name="trends_last_week">La semana pasada</string>
-    <string name="trends_weeks_ago">hace %1$d semanas</string>
     <string name="trends_previous_week">Semana anterior</string>
     <string name="trends_next_week">Próxima semana</string>
     <string name="trends_daily_signals">Señales diarias</string>
@@ -1568,7 +1563,6 @@
     <string name="explore_delta_vs_prev">Δ vs ant.</string>
     <string name="explore_summary">Resumen</string>
     <string name="explore_over_visible_window">Sobre la ventana visible</string>
-    <string name="explore_n_days">%1$d días</string>
     <string name="explore_n_pts">%1$d pts</string>
     <string name="explore_vs_prev_window">vs prev %1$s</string>
     <string name="explore_all_history">todo el historial</string>
@@ -1631,4 +1625,20 @@
     <string name="explore_description_charge">Qué tan recuperado estás, según tu VFC frente a tu línea base personal.</string>
     <string name="explore_description_effort">Carga cardiovascular del día, en una escala de 0–100 (antes 0–21).</string>
     <string name="explore_description_rest">Qué tan reparador fue tu sueño: duración, eficiencia, sueño profundo y REM, y horario.</string>
+    <plurals name="intelligence_days_count">
+        <item quantity="one">%1$d día</item>
+        <item quantity="other">%1$d días</item>
+    </plurals>
+    <plurals name="lab_book_readings_count">
+        <item quantity="one">%1$d lectura · tu propia entrada</item>
+        <item quantity="other">%1$d lecturas · tus propias entradas</item>
+    </plurals>
+    <plurals name="trends_weeks_ago">
+        <item quantity="one">hace %1$d semana</item>
+        <item quantity="other">hace %1$d semanas</item>
+    </plurals>
+    <plurals name="explore_n_days">
+        <item quantity="one">%1$d día</item>
+        <item quantity="other">%1$d días</item>
+    </plurals>
 </resources>

--- a/android/app/src/main/res/values-fr/strings.xml
+++ b/android/app/src/main/res/values-fr/strings.xml
@@ -1449,11 +1449,7 @@
     <string name="l10n_wheel_picker_accessibility_tap_to_choose_1314c4ed">%1$s. Appuyez sur pour choisir.</string>
     <string name="l10n_workouts_screen_minutes_total_100_roundtoint_5bb7c6d8">%1$s%%</string>
     <!-- #453 manually migrated complex Kotlin templates. -->
-    <string name="intelligence_day_count">%1$d jour</string>
-    <string name="intelligence_days_count">%1$d jours</string>
     <string name="intervals_range_step">%1$s – %2$s%3$s · pas %4$d</string>
-    <string name="lab_book_reading_count">%1$d mesure · votre propre entrée</string>
-    <string name="lab_book_readings_count">%1$d mesures · vos propres entrées</string>
     <string name="live_workout_saved_summary">✓ %1$s enregistré · %2$s</string>
     <string name="skin_temp_reason_summary">%1$s : %2$s</string>
     <string name="stress_score_accessibility">Stress %1$s sur 3, %2$s</string>
@@ -1537,7 +1533,6 @@
     <string name="trends_no_readings_body">Passez à une autre semaine avec les flèches ci-dessus pour voir son bilan.</string>
     <string name="trends_this_week">Cette semaine</string>
     <string name="trends_last_week">La semaine dernière</string>
-    <string name="trends_weeks_ago">il y a %1$d semaines</string>
     <string name="trends_previous_week">Semaine précédente</string>
     <string name="trends_next_week">Semaine prochaine</string>
     <string name="trends_daily_signals">Signaux quotidiens</string>
@@ -1568,7 +1563,6 @@
     <string name="explore_delta_vs_prev">Δ vs préc.</string>
     <string name="explore_summary">Résumé</string>
     <string name="explore_over_visible_window">Sur la fenêtre visible</string>
-    <string name="explore_n_days">%1$d jours</string>
     <string name="explore_n_pts">%1$d pts</string>
     <string name="explore_vs_prev_window">vs prev %1$s</string>
     <string name="explore_all_history">tout l\'historique</string>
@@ -1631,4 +1625,20 @@
     <string name="explore_description_charge">Votre niveau de récupération, mesuré par la VFC par rapport à votre référence personnelle.</string>
     <string name="explore_description_effort">Charge cardiovasculaire de la journée, sur une échelle de 0 à 100 (auparavant 0 à 21).</string>
     <string name="explore_description_rest">À quel point votre sommeil a été réparateur : durée, efficacité, sommeil profond et paradoxal, et horaires.</string>
+    <plurals name="intelligence_days_count">
+        <item quantity="one">%1$d jour</item>
+        <item quantity="other">%1$d jours</item>
+    </plurals>
+    <plurals name="lab_book_readings_count">
+        <item quantity="one">%1$d mesure · votre propre entrée</item>
+        <item quantity="other">%1$d mesures · vos propres entrées</item>
+    </plurals>
+    <plurals name="trends_weeks_ago">
+        <item quantity="one">il y a %1$d semaine</item>
+        <item quantity="other">il y a %1$d semaines</item>
+    </plurals>
+    <plurals name="explore_n_days">
+        <item quantity="one">%1$d jour</item>
+        <item quantity="other">%1$d jours</item>
+    </plurals>
 </resources>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -98,7 +98,6 @@
     <string name="trends_no_readings_body">Step to another week with the arrows above to see its review.</string>
     <string name="trends_this_week">This week</string>
     <string name="trends_last_week">Last week</string>
-    <string name="trends_weeks_ago">%1$d weeks ago</string>
     <string name="trends_previous_week">Previous week</string>
     <string name="trends_next_week">Next week</string>
     <string name="trends_daily_signals">Daily signals</string>
@@ -130,7 +129,6 @@
     <string name="explore_delta_vs_prev">Δ vs prev</string>
     <string name="explore_summary">Summary</string>
     <string name="explore_over_visible_window">Over the visible window</string>
-    <string name="explore_n_days">%1$d days</string>
     <string name="explore_n_pts">%1$d pts</string>
     <string name="explore_vs_prev_window">vs prev %1$s</string>
     <string name="explore_all_history">all history</string>
@@ -1620,11 +1618,7 @@
     <string name="l10n_wheel_picker_accessibility_tap_to_choose_1314c4ed">%1$s. Tap to choose.</string>
     <string name="l10n_workouts_screen_minutes_total_100_roundtoint_5bb7c6d8">%1$s%%</string>
     <!-- #453 manually migrated complex Kotlin templates. -->
-    <string name="intelligence_day_count">%1$d day</string>
-    <string name="intelligence_days_count">%1$d days</string>
     <string name="intervals_range_step">%1$s – %2$s%3$s · step %4$d</string>
-    <string name="lab_book_reading_count">%1$d reading · your own entry</string>
-    <string name="lab_book_readings_count">%1$d readings · your own entries</string>
     <string name="live_workout_saved_summary">✓ %1$s saved · %2$s</string>
     <string name="skin_temp_reason_summary">%1$s: %2$s</string>
     <string name="stress_score_accessibility">Stress %1$s of 3, %2$s</string>
@@ -1655,4 +1649,20 @@
     <string name="explore_description_charge">How recovered you are, led by HRV versus your personal baseline.</string>
     <string name="explore_description_effort">Cardiovascular load for the day, on a 0-100 scale (was 0-21).</string>
     <string name="explore_description_rest">How restorative your sleep was: duration, efficiency, deep+REM, timing.</string>
+    <plurals name="intelligence_days_count">
+        <item quantity="one">%1$d day</item>
+        <item quantity="other">%1$d days</item>
+    </plurals>
+    <plurals name="lab_book_readings_count">
+        <item quantity="one">%1$d reading · your own entry</item>
+        <item quantity="other">%1$d readings · your own entries</item>
+    </plurals>
+    <plurals name="trends_weeks_ago">
+        <item quantity="one">%1$d week ago</item>
+        <item quantity="other">%1$d weeks ago</item>
+    </plurals>
+    <plurals name="explore_n_days">
+        <item quantity="one">%1$d day</item>
+        <item quantity="other">%1$d days</item>
+    </plurals>
 </resources>


### PR DESCRIPTION
Groundwork for Polish (per the discussion on adding `pl`), and a bug fix for the locales already shipped.

## The problem

NOOP has **no `<plurals>` at all**. Counts were plain strings, pluralised by hand at the call site:

```kotlin
if (filtered.size == 1) R.string.intelligence_day_count
else R.string.intelligence_days_count
```

That bakes in **English's two plural categories**. It's fine for de/es/fr — which also have two — and **structurally cannot spell Polish**, which has four: *1 noc / 2–4 noce / 5+ nocy*. No amount of special-casing `1` gets there. So this had to land **before** any Polish translation, not after: otherwise ~4 count strings would be grammatically wrong in Polish no matter how good the translation.

## What changed

Four count-bearing resources became `<plurals>`, letting each locale's own rules pick the form:

| resource | was |
|---|---|
| `intelligence_days_count` | hand-rolled `if (n==1)` pair |
| `lab_book_readings_count` | hand-rolled `if (n==1)` pair |
| `trends_weeks_ago` | **no singular** — `1` is unreachable today (caller special-cases "This week"/"Last week"), but pl still needs a distinct 2–4 form |
| `explore_n_days` | **no singular**, and `n` *can* be 1 — so **"1 days" is a live bug today, in every locale** |

**It also fixes an existing wart:** de/es/fr rendered **"1 Tage" / "1 días" / "1 jours"** for `explore_n_days`, because one string served every count. They now say "1 Tag" / "1 día" / "1 jour".

Adds `uiPlural` + `NoopApplication.localizedPlural` as quantity-aware twins of `uiString`/`localizedString`, so non-composable call sites keep the same Application-resources path.

## The audit had to learn about plurals in the same change

This is the part worth reviewing. The audit matched only `<string name="…">`:

```python
base_keys = set(re.findall(r'<string name="([^"]+)"', ...))
```

So converting a pair into a `<plurals>` would have **dropped those keys out of the coverage gate entirely** — a locale could silently lose them and the gate would still report clean. Fixing the plural model must not open a coverage hole; that's the same class of blind spot as #540.

Both patterns now match `<(?:string|plurals) name="…">`.

**Verified rather than assumed** — deleted a `<plurals>` from `values-de` and re-ran:

```
FAIL values-de/strings.xml missing 1 key(s): ['explore_n_days']
```

…then restored it and confirmed clean.

## Verification

- `compileFullDebugKotlin` green
- i18n audit **OK** across all focus locales, and now genuinely covers plurals
- no stale references to the six removed keys

## Next

With this in, Polish can add `<item quantity="few">` / `"many"` per resource. The remaining prerequisites for `pl` are unchanged: ~5,000 strings across Android + four xcstrings catalogs, and a **native reviewer** before `pl` joins `LANGS` (the shipped Spanish currently says *"un entrenador con **Géminis**"* — the zodiac sign — which is the bar to beat).

---

## Re-review additions

**The format check was still blind to plurals.** Teaching the key-coverage gate about `<plurals>` was only half the job — `android_format_gaps` builds its map from `findall("string")`, and a plural's format args live on the `<item>` **children**. So every converted plural's `%1$d` was invisible to the placeholder check: a locale could drop it from a quantity form and the gate would still pass. Now folded in, and verified by stripping `%1$d` from a German plural item:

```
FAIL values-de/strings.xml has 2 format mismatch(es): ['intelligence_days_count', 'explore_n_days']
```

## Cross-platform: no Swift twin here (deliberate)

Per the parity contract, the explicit "why not". Swift hand-rolls the **same** two-form plurals, so it has the identical Polish problem:

```swift
IntelligenceView.swift:78   Text(filtered.count == 1 ? "1 day" : "\(filtered.count) days")
MetricExplorerView.swift:981 caption: s.n == 1 ? "1 day" : "\(s.n) days"
LabBookView.swift:340       overline: keys.count == 1 ? "1 marker" : "\(keys.count) markers"
LabBookView.swift:596       subtitle: readings.count == 1 ? "1 reading · your own entries" ...
```

It's a separate PR because the Swift fix is a different mechanism — xcstrings **plural variations** rather than Android `<plurals>` — and app-target Swift has no default CI, so it needs an on-demand `app-build` run to verify. Bundling it would mix two mechanisms and two verification paths in one change.

**Bug found while checking parity** (worth fixing in that follow-up): `LabBookView.swift:596`'s *singular* branch reads **"1 reading · your own entries"** — "entries", plural, for a single reading. The Android twin correctly says "your own **entry**". So that line is both a copy bug and a Swift/Android divergence today.

## Re-review round 3: the fold was self-defeating

`signature()` is a **multiset** (`sorted(findall(...))`), so folding every `<item>` into one value made a plural's signature depend on **how many quantity categories the language has**:

```
en explore_n_days  ->  one/other           ->  ['d','d']
pl explore_n_days  ->  one/few/many/other  ->  ['d','d','d','d']
```

`['d','d'] != ['d','d','d','d']` → **"format mismatch"**. The gate would have rejected *valid* Polish the moment it added `few`/`many` — this groundwork would have red-flagged the exact language it exists to enable.

Now it compares one **representative** form (`other`, the CLDR fallback every language defines), so the check is category-count agnostic — plus an **intra-plural invariant**: every quantity form of one plural must carry the same placeholders as its siblings. That's a *within-language* check, so it stays correct at any category count and still catches a drop the representative compare can't see.

Verified on synthetic XML rather than by mutating the tree:

```
OLD fold:  valid Polish (one/few/many/other)  ->  FALSE POSITIVE ['explore_n_days']
NEW:       valid Polish                       ->  clean
NEW:       Polish, %1$d dropped from `one`    ->  FLAGGED ['explore_n_days']
```

Also ran the **full test suite** for the first time on this branch — the earlier commits only ran `compileFullDebugKotlin`, which doesn't compile tests, a real gap given this PR *removes* six string keys. No test referenced them; suite green.