### PR TITLE
i18n: teach the Apple audit about xcstrings plural variations

### DIFF
--- a/Tools/i18n_audit.py
+++ b/Tools/i18n_audit.py
@@ -330,6 +330,47 @@ APPLE_FORMAT_PATTERN = re.compile(
 )
 
 
+def _string_units(entry: dict, lang: str) -> list[dict]:
+    """Every stringUnit a localization carries — plain value OR plural variations.
+
+    An xcstrings localization is either
+
+        localizations.<lang>.stringUnit
+
+    or, once the string has plural forms,
+
+        localizations.<lang>.variations.plural.<category>.stringUnit
+
+    (device variations nest the same way, and the two can combine). Reading only the FIRST shape makes
+    every pluralised entry look untranslated to this gate — so converting a hand-rolled ternary into real
+    plural variations would red-flag the string in every language. Walk both shapes.
+    """
+    loc = (entry.get("localizations", {}) or {}).get(lang) or {}
+    units: list[dict] = []
+    unit = loc.get("stringUnit")
+    if isinstance(unit, dict):
+        units.append(unit)
+
+    def walk(node: object) -> None:
+        if not isinstance(node, dict):
+            return
+        for key, value in node.items():
+            if key == "stringUnit" and isinstance(value, dict):
+                units.append(value)
+            elif isinstance(value, dict):
+                walk(value)
+
+    walk(loc.get("variations") or {})
+    return units
+
+
+def _is_translated(entry: dict, lang: str) -> bool:
+    """True when the localization exists AND every one of its stringUnits is translated — so a plural
+    with one category still marked `new` is correctly reported as a gap, not silently accepted."""
+    units = _string_units(entry, lang)
+    return bool(units) and all(u.get("state") == "translated" for u in units)
+
+
 def apple_format_gaps(cat: dict, lang: str) -> list[str]:
     """Catalog keys whose localized printf arguments differ from the source."""
     def signature(value: str) -> list[str]:
@@ -339,9 +380,11 @@ def apple_format_gaps(cat: dict, lang: str) -> list[str]:
     for key, entry in cat.get("strings", {}).items():
         if entry.get("shouldTranslate") is False:
             continue
-        value = ((entry.get("localizations", {}).get(lang) or {}).get("stringUnit", {})
-                 .get("value", ""))
-        if signature(key) != signature(value):
+        # Compare EVERY form independently against the key, never a folded concatenation: folding would
+        # make the signature depend on how many plural categories the language HAS (ru/pl carry four,
+        # zh one), so a correct translation would read as a format mismatch purely for having more forms.
+        values = [u.get("value", "") for u in _string_units(entry, lang)] or [""]
+        if any(signature(key) != signature(v) for v in values):
             mismatched.append(key)
     return mismatched
 
@@ -376,10 +419,8 @@ def scan_ios() -> tuple[list[tuple[str, int, str]], dict[str, list[str]]]:
                         continue
                     if entry.get("shouldTranslate") is False:
                         continue
-                    loc = entry.get("localizations", {})
                     for lang in LANGS:
-                        state = (loc.get(lang) or {}).get("stringUnit", {}).get("state")
-                        if state != "translated":
+                        if not _is_translated(entry, lang):
                             lang_gaps[lang].append(f"{catalog_path.relative_to(ROOT)} :: {literal!r}")
     for lang in lang_gaps:
         lang_gaps[lang] = sorted(set(lang_gaps[lang]))
@@ -475,8 +516,7 @@ def ci_check(base_ref: str) -> int:
         for lang in LANGS:
             missing = sum(
                 1 for v in cat.get("strings", {}).values()
-                if v.get("shouldTranslate") is not False
-                and (v.get("localizations", {}).get(lang) or {}).get("stringUnit", {}).get("state") != "translated"
+                if v.get("shouldTranslate") is not False and not _is_translated(v, lang)
             )
             if missing:
                 failed = True


### PR DESCRIPTION
Prerequisite for pluralising the Swift side (the twin of #541), and a latent trap in its own right.

## The trap

All three places the audit reads an xcstrings localization go straight for `localizations.<lang>.stringUnit`:

```python
value = ((entry.get("localizations", {}).get(lang) or {}).get("stringUnit", {}).get("value", ""))
state = (loc.get(lang) or {}).get("stringUnit", {}).get("state")
```

Once a string has plural forms, the value moves to `localizations.<lang>.variations.plural.<category>.stringUnit` — there's **no top-level `stringUnit` at all**. So all three reads see nothing:

| check | effect |
|---|---|
| `apple_format_gaps` | compares an empty value → a real format mismatch **hides** |
| `scan_ios` | reports the string as an **untranslated gap** |
| `ci_check` | counts it **missing, in every language** |

Net: converting a single hand-rolled ternary into real plural variations would red-flag that string across **all nine** catalog languages and fail the gate. This is exactly the trap #541 hit on the Android side, so it lands **before** the conversion.

## The fix

- `_string_units()` — walks **both** shapes (plain + variations, including nested device variations).
- `_is_translated()` — a localization counts only when it **has** units and **all** are translated, so a plural with one category still `new` is correctly a gap rather than silently accepted.

**The format check compares every form independently against the key, never a folded concatenation.** That's deliberate: the signature is a *multiset*, so folding makes it depend on how many plural categories a language **has** — ru/pl carry four, zh carries one — and a correct translation would read as a format mismatch purely for having more forms. That's the exact bug I shipped and then fixed in #541; not repeating it.

## Verification

Proven on synthetic catalog entries:

```
plain stringUnit          -> translated   (unchanged, no regression)
4-category ru plural      -> translated   (was FALSE before -> gate failure)
plural w/ a form `new`    -> gap          (correctly)
valid 4-form ru vs key    -> clean        (no false positive)
%lld dropped from `one`   -> caught
```

Real tree: audit clean, no regression (17 OK lines, exit 0).

## Why the conversion isn't in this PR

Auditing the catalogs to plan it turned up that **Russian is already wrong today** — it ships with 2-form hand-rolled plurals but needs four:

```
'%lld days'      ru = '%lld дней'         -> "2 дней"  (correct: 2 дня)
'%lld markers'   ru = '%lld маркеров'     -> "2 маркеров" (correct: 2 маркера)
'%lld weeks ago' ru = '%lld недель назад' -> "2 недель назад"
```

So this is a live bug fix, not just Polish groundwork. But each key forces a translation decision, and they split cleanly:

**Mechanical** (`one` = the existing "1 X" value with `1`→`%lld`, `other` = the existing plural, ru gains authored `few`/`many` — *день/дня/дней* is textbook CLDR): `%lld days`, `%lld markers`, `%lld pairs`, `%lld sessions`.

**Forces authoring / a rewrite**, and I'd rather you decide than have me quietly pick:
- `%lld weeks ago` — **no singular exists**; `one` must be authored in all 9 languages.
- `%lld readings · your own entries` — the **English source is wrong** ("entries" for one), and ru uses two different nouns (`показание` vs `измерений`), so the plural forces picking one.
- StrandDesign `%lld workouts` — es is `'Ejercicios %1$lld'` (capitalised *and* reordered vs `'1 ejercicio'`), fr is `"séances d'entraînement"` vs `'1 entraînement'`.

The pre-existing translation bugs are filed separately rather than fixed here.
