### PR TITLE
WhoopProtocol: model v20 (2140 B) optical record as a neutral 5-block structure

### DIFF
--- a/Packages/WhoopProtocol/Sources/WhoopProtocol/Interpreter.swift
+++ b/Packages/WhoopProtocol/Sources/WhoopProtocol/Interpreter.swift
@@ -594,15 +594,16 @@ private func decodeWhoop5HistoricalV26(_ frame: [UInt8], fb: FieldBuilder) {
 ///     accelerometer at @28 / @228 / @428 and gyroscope at @640 / @840 / @1040 (200 B apart; countB @630 =
 ///     100). This is 6-axis IMU, not optical: the accel channels sphere-fit to a ~1 g gravity shell on a
 ///     stationary strap (validated by Whoop5RawImu over 1423 real buffers, #423/#493).
-///   • v20 (2140 B): five channel blocks, each preceded by a block-header byte (0x19 = active, 0x00 =
-///     empty / zero-filled); an active block holds two 25-sample i32 channels (~25 Hz). The header bytes
-///     sit at @0x1a / @0x1c0 / @0x366 / @0x50c / @0x6b2; the ten channel slots start at
-///     @0x2f / 0xf7 / 0x1d5 / 0x29d / 0x37b / 0x443 / 0x521 / 0x5e9 / 0x6c7 / 0x78f (see the decode site
-///     for the 25-vs-50 sample-count evidence: samples 25..49 are zero across every captured buffer).
+///   • v20 (2140 B): five repeated 422-byte optical-measurement blocks. Each has a 21-byte header,
+///     two 200-byte channel slots, and one reserved byte. Header byte 0 is the shared sample count; an
+///     active block holds two 25-sample i32 channels (~25 Hz). The two channels share one measurement
+///     header and must not be interpreted as two wavelengths. See `Whoop5RawOptical` for the lossless
+///     structural model and the 25-vs-50 sample-count evidence.
 ///
-/// v21 channels are named accel_/gyro_ per the gravity-shell evidence above; v20 sensor identity is still
-/// OPEN (no labelled/moving v20 capture in the tree) so its channels stay neutrally named. Both are exposed
-/// as raw i16 sample arrays with no scale applied here — Whoop5RawImu.decode applies the physical scales.
+/// v21 channels are named accel_/gyro_ per the gravity-shell evidence above. The v20 record is optical,
+/// but its measurement wavelengths and channel geometry remain OPEN, so those channels stay neutrally
+/// named. This layer exposes raw i16 (v21) or sign-extended i32 (v20) arrays; `Whoop5RawImu.decode`
+/// applies the v21 physical scales.
 private func decodeWhoop5HistoricalV2021(_ frame: [UInt8], fb: FieldBuilder, version: Int, payloadEnd: Int?) {
     if frame.count > 10 {
         fb.add(10, 1, "layout_marker", "meta", value: .int(Int(frame[10])))
@@ -639,8 +640,9 @@ private func decodeWhoop5HistoricalV2021(_ frame: [UInt8], fb: FieldBuilder, ver
         fb.parsed["sensor_channel_samples"] = .int(100)
         return
     }
-    // version == 20: five blocks, each gated by a block-header byte @0x1a/0x1c0/0x366/0x50c/0x6b2 (0x19 =
-    // active, 0x00 = empty / zero-filled). An active block holds two channels of 25 i32 samples (~25 Hz).
+    // version == 20: five repeated optical-measurement blocks. Each block carries one shared header and
+    // two channel slots. This matters semantically: the two channels within a block are a detector/readout
+    // pair for one measurement configuration, not evidence for two different LED wavelengths.
     //
     // EVIDENCE (why 25, not 50): across all 29,203 captured 2140-B buffers, exactly blocks 0/3/4 are active
     // (channel slots @47/247/1313/1513/1735/1935) and, in every active channel, sample slots 25..49 are
@@ -650,33 +652,30 @@ private func decodeWhoop5HistoricalV2021(_ frame: [UInt8], fb: FieldBuilder, ver
     // 12 bits are only ever 0x000/0xFFF — pure sign extension — across all captures), so reading it as i32
     // recovers the correct signed magnitude with no masking.
     //
-    // Channel IDENTITY is NOT proven: no labelled/moving v20 capture exists in the tree, so channels stay
-    // neutrally named (channel_b<block>_<half>). RE notes only, NOT authoritative — see issue #423: the
-    // buffer's config header [19:47] carries an LED-current field @28 and per-photodiode offset DACs @38/@45,
-    // and the six active channels are INFERRED to be optical (green/IR/red/ambient); the red/IR split is
-    // under active dispute, so no wavelength label is encoded here. v20 stays raw i32 with no scale applied.
-    let sampleCount = 25
-    let blocks: [(present: Int, ch0: Int, ch1: Int)] = [
-        (0x1a, 0x2f, 0xf7), (0x1c0, 0x1d5, 0x29d), (0x366, 0x37b, 0x443),
-        (0x50c, 0x521, 0x5e9), (0x6b2, 0x6c7, 0x78f),
-    ]
+    // Wavelength identity remains open. The six active channels in the current corpus are three pairs
+    // (blocks 0/3/4), not six independent colors. In particular, block 4's two channels cannot be named
+    // IR and red without independent evidence because they share the same block-level configuration.
+    guard let optical = Whoop5RawOptical.decode(frame) else { return }
+    fb.parsed["sensor_block_count"] = .int(optical.blocks.count)
     var present = 0
-    for (b, blk) in blocks.enumerated() {
-        guard frame.count > blk.present, frame[blk.present] != 0 else { continue }
-        for (half, start) in [(0, blk.ch0), (1, blk.ch1)] {
-            var samples: [Int] = []
-            for i in 0..<sampleCount {
-                guard let v = readI32(frame, start + i * 4) else { break }
-                samples.append(v)
-            }
-            if samples.count == sampleCount {
-                fb.add(start, sampleCount * 4, "channel_b\(b)_\(half)", "sensor", value: .intArray(samples),
-                       note: "25 raw i32 samples (~25 Hz; 20-bit signed container, no absolute unit)")
-                present += 1
-            }
+    for block in optical.blocks {
+        let start = Whoop5RawOptical.blockStart + block.index * Whoop5RawOptical.blockLength
+        fb.add(start, Whoop5RawOptical.headerLength, "block_b\(block.index)_header", "optical_config",
+               value: .intArray(block.rawHeader.map(Int.init)),
+               note: "raw: sample count + shared metadata + two 7-byte channel descriptors")
+        fb.parsed["block_b\(block.index)_sample_count"] = .int(block.sampleCount)
+        guard block.sampleCount > 0 else { continue }
+        for (channelIndex, channel) in block.channels.enumerated() {
+            let sampleStart = start + Whoop5RawOptical.headerLength
+                + channelIndex * Whoop5RawOptical.channelSlotLength
+            fb.add(sampleStart, block.sampleCount * 4,
+                   "channel_b\(block.index)_\(channelIndex)", "sensor",
+                   value: .intArray(channel.samples.map(Int.init)),
+                   note: "raw signed i32 samples; paired under one block config; no wavelength or absolute unit asserted")
+            present += 1
         }
     }
-    fb.parsed["sensor_channel_samples"] = .int(sampleCount)
+    fb.parsed["sensor_channel_samples"] = .int(optical.blocks.map(\.sampleCount).max() ?? 0)
     fb.parsed["sensor_channels_present"] = .int(present)
 }
 

--- a/Packages/WhoopProtocol/Sources/WhoopProtocol/Whoop5RawImu.swift
+++ b/Packages/WhoopProtocol/Sources/WhoopProtocol/Whoop5RawImu.swift
@@ -58,7 +58,7 @@ public enum Whoop5RawImu {
     /// Decode a raw-IMU buffer, or nil if it isn't one. Gates on the exact length + the two in-packet
     /// sample counts (=100) rather than the type byte, so it can't misfire on a same-type non-IMU frame.
     public static func decode(_ f: [UInt8]) -> Whoop5ImuFrame? {
-        guard f.count >= bufferLength,
+        guard f.count == bufferLength,
               u16(f, countAOff) == sampleCount, u16(f, countBOff) == sampleCount,
               gzOff + 2 * sampleCount <= f.count else { return nil }
         let baseTs = Int(u32(f, tsOff))

--- a/Packages/WhoopProtocol/Sources/WhoopProtocol/Whoop5RawOptical.swift
+++ b/Packages/WhoopProtocol/Sources/WhoopProtocol/Whoop5RawOptical.swift
@@ -1,0 +1,129 @@
+import Foundation
+
+// WHOOP 5.0/MG historical layout-v20 (2,140-byte) optical-buffer decoder.
+//
+// The record body is five repeated 422-byte blocks beginning at frame offset 26. Each block is:
+//
+//   21-byte header | 200-byte channel slot 0 | 200-byte channel slot 1 | 1 reserved byte
+//
+// Header byte 0 is the sample count for both channel slots (0...50). The remaining 20 header bytes
+// split consistently into six block-level bytes and seven bytes per channel. That split is exposed as
+// raw metadata: its register meanings and the LED wavelength assigned to each block are not yet proven.
+//
+// In the 29,203-record corpus used to establish this layout, block counts are always [25, 0, 0, 25,
+// 25]. Active channels contain 25 signed 20-bit readings in sign-extended i32 containers; slots 25...49
+// are zero padding. Two channels in the same block therefore belong to one shared measurement/config,
+// and must not be labelled as two different wavelengths merely because their amplitudes differ.
+
+public struct RawOpticalChannel: Equatable, Codable, Sendable {
+    /// Seven raw per-channel header bytes. Semantics are intentionally not asserted.
+    public let metadata: [UInt8]
+    /// Signed ADC containers, limited by the block's sample-count byte.
+    public let samples: [Int32]
+
+    public init(metadata: [UInt8], samples: [Int32]) {
+        self.metadata = metadata
+        self.samples = samples
+    }
+}
+
+public struct Whoop5OpticalBlock: Equatable, Codable, Sendable {
+    public let index: Int
+    public let sampleCount: Int
+    /// Header bytes 1...6, shared by both channel slots. Semantics are intentionally not asserted.
+    public let sharedMetadata: [UInt8]
+    /// Always two physical slots, even when `sampleCount == 0`.
+    public let channels: [RawOpticalChannel]
+    /// The final byte of the 422-byte block; zero throughout the current corpus.
+    public let reserved: UInt8
+
+    public init(index: Int, sampleCount: Int, sharedMetadata: [UInt8],
+                channels: [RawOpticalChannel], reserved: UInt8) {
+        self.index = index
+        self.sampleCount = sampleCount
+        self.sharedMetadata = sharedMetadata
+        self.channels = channels
+        self.reserved = reserved
+    }
+
+    /// The complete 21-byte header reconstructed losslessly.
+    public var rawHeader: [UInt8] {
+        [UInt8(sampleCount)] + sharedMetadata + channels.flatMap(\.metadata)
+    }
+}
+
+public struct Whoop5OpticalFrame: Equatable, Codable, Sendable {
+    public let recordIndex: Int
+    public let baseTs: Int
+    public let blocks: [Whoop5OpticalBlock]
+
+    public init(recordIndex: Int, baseTs: Int, blocks: [Whoop5OpticalBlock]) {
+        self.recordIndex = recordIndex
+        self.baseTs = baseTs
+        self.blocks = blocks
+    }
+}
+
+public enum Whoop5RawOptical {
+    public static let bufferLength = 2140
+    public static let blockCount = 5
+    public static let blockStart = 26
+    public static let blockLength = 422
+    public static let headerLength = 21
+    public static let channelSlotLength = 200
+    public static let channelCapacity = 50
+
+    /// Decode a complete layout-v20 historical record. This performs strict structural gating; callers
+    /// receiving bytes from the wire should also use the normal envelope CRC verification path.
+    public static func decode(_ frame: [UInt8]) -> Whoop5OpticalFrame? {
+        guard frame.count == bufferLength,
+              frame[0] == 0xAA,
+              frame[8] == 0x2F,
+              frame[9] == 20 else { return nil }
+
+        var blocks: [Whoop5OpticalBlock] = []
+        blocks.reserveCapacity(blockCount)
+
+        for index in 0..<blockCount {
+            let start = blockStart + index * blockLength
+            let sampleCount = Int(frame[start])
+            guard sampleCount <= channelCapacity else { return nil }
+
+            let sharedMetadata = Array(frame[(start + 1)..<(start + 7)])
+            var channels: [RawOpticalChannel] = []
+            channels.reserveCapacity(2)
+            for channelIndex in 0..<2 {
+                let metadataStart = start + 7 + channelIndex * 7
+                let metadata = Array(frame[metadataStart..<(metadataStart + 7)])
+                let sampleStart = start + headerLength + channelIndex * channelSlotLength
+                var samples: [Int32] = []
+                samples.reserveCapacity(sampleCount)
+                for sampleIndex in 0..<sampleCount {
+                    samples.append(i32(frame, sampleStart + sampleIndex * 4))
+                }
+                channels.append(RawOpticalChannel(metadata: metadata, samples: samples))
+            }
+
+            blocks.append(Whoop5OpticalBlock(
+                index: index,
+                sampleCount: sampleCount,
+                sharedMetadata: sharedMetadata,
+                channels: channels,
+                reserved: frame[start + blockLength - 1]))
+        }
+
+        return Whoop5OpticalFrame(
+            recordIndex: Int(u32(frame, 11)),
+            baseTs: Int(u32(frame, 15)),
+            blocks: blocks)
+    }
+
+    @inline(__always) private static func u32(_ frame: [UInt8], _ offset: Int) -> UInt32 {
+        UInt32(frame[offset]) | (UInt32(frame[offset + 1]) << 8)
+            | (UInt32(frame[offset + 2]) << 16) | (UInt32(frame[offset + 3]) << 24)
+    }
+
+    @inline(__always) private static func i32(_ frame: [UInt8], _ offset: Int) -> Int32 {
+        Int32(bitPattern: u32(frame, offset))
+    }
+}

--- a/Packages/WhoopProtocol/Tests/WhoopProtocolTests/Whoop5RawImuTests.swift
+++ b/Packages/WhoopProtocol/Tests/WhoopProtocolTests/Whoop5RawImuTests.swift
@@ -38,6 +38,10 @@ final class Whoop5RawImuTests: XCTestCase {
         var f = syntheticFrame(i: 0, axLSB: 0, gxLSB: 0)
         f[24] = 0; f[25] = 0                                                    // countA != 100
         XCTAssertNil(Whoop5RawImu.decode(f))
+
+        var oversized = syntheticFrame(i: 0, axLSB: 0, gxLSB: 0)
+        oversized.append(0)
+        XCTAssertNil(Whoop5RawImu.decode(oversized))   // exact-length contract, not a valid prefix
     }
 
     func testDecodesRealBufferAsGravityShell() {

--- a/Packages/WhoopProtocol/Tests/WhoopProtocolTests/Whoop5RawOpticalTests.swift
+++ b/Packages/WhoopProtocol/Tests/WhoopProtocolTests/Whoop5RawOpticalTests.swift
@@ -1,0 +1,54 @@
+import XCTest
+@testable import WhoopProtocol
+
+final class Whoop5RawOpticalTests: XCTestCase {
+    func testRealFramePreservesFiveBlockStructure() throws {
+        let raw = Whoop5HistoricalV2021Tests.realFrameV20Bytes
+        let decoded = try XCTUnwrap(Whoop5RawOptical.decode(raw))
+
+        XCTAssertEqual(decoded.recordIndex, 11_494_060)
+        XCTAssertEqual(decoded.baseTs, 1_784_054_004)
+        XCTAssertEqual(decoded.blocks.map(\.sampleCount), [25, 0, 0, 25, 25])
+        XCTAssertTrue(decoded.blocks.allSatisfy { $0.channels.count == 2 })
+        XCTAssertTrue(decoded.blocks.allSatisfy { $0.rawHeader.count == 21 })
+        XCTAssertTrue(decoded.blocks.allSatisfy { $0.reserved == 0 })
+
+        XCTAssertEqual(decoded.blocks[0].rawHeader, [
+            0x19, 0x01, 0x16, 0x0d, 0x04, 0x2c, 0x1a,
+            0x03, 0x20, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x04, 0x20, 0x00, 0x00, 0x00, 0x20, 0x03,
+        ])
+        XCTAssertEqual(decoded.blocks[4].sharedMetadata, [0x02, 0xc8, 0x00, 0x04, 0x00, 0x00])
+        XCTAssertEqual(decoded.blocks[4].channels[0].metadata, [0x03, 0x20, 0, 0, 0, 0, 0])
+        XCTAssertEqual(decoded.blocks[4].channels[1].metadata, [0x01, 0x20, 0, 0, 0, 0, 0])
+        XCTAssertEqual(decoded.blocks[4].channels[0].samples.count, 25)
+        XCTAssertEqual(decoded.blocks[4].channels[1].samples.count, 25)
+        XCTAssertEqual(decoded.blocks[4].channels[1].samples.last, 11_318)
+    }
+
+    func testInterpreterExposesHeadersWithoutWavelengthLabels() {
+        let parsed = parseFrame(Whoop5HistoricalV2021Tests.realFrameV20Bytes, family: .whoop5).parsed
+        XCTAssertEqual(parsed["sensor_block_count"]?.intValue, 5)
+        XCTAssertEqual(parsed["block_b0_sample_count"]?.intValue, 25)
+        XCTAssertEqual(parsed["block_b1_sample_count"]?.intValue, 0)
+        XCTAssertEqual(parsed["block_b4_header"]?.intArrayValue?.count, 21)
+        XCTAssertEqual(parsed["channel_b4_0"]?.intArrayValue?.count, 25)
+        XCTAssertEqual(parsed["channel_b4_1"]?.intArrayValue?.count, 25)
+        XCTAssertNil(parsed["red"])
+        XCTAssertNil(parsed["ir"])
+    }
+
+    func testStrictShapeAndCountGates() {
+        var frame = [UInt8](repeating: 0, count: Whoop5RawOptical.bufferLength)
+        frame[0] = 0xAA
+        frame[8] = 0x2F
+        frame[9] = 20
+        XCTAssertNotNil(Whoop5RawOptical.decode(frame))
+
+        frame[Whoop5RawOptical.blockStart] = UInt8(Whoop5RawOptical.channelCapacity + 1)
+        XCTAssertNil(Whoop5RawOptical.decode(frame))
+        frame[Whoop5RawOptical.blockStart] = 0
+        frame.append(0)
+        XCTAssertNil(Whoop5RawOptical.decode(frame))
+    }
+}

--- a/android/app/src/main/java/com/noop/protocol/Whoop5RawOptical.kt
+++ b/android/app/src/main/java/com/noop/protocol/Whoop5RawOptical.kt
@@ -1,0 +1,100 @@
+package com.noop.protocol
+
+/** A single raw readout channel in a WHOOP 5/MG layout-v20 optical block. */
+data class RawOpticalChannel(
+    /** Seven raw per-channel header bytes. No register or wavelength semantics are asserted. */
+    val metadata: List<Int>,
+    /** Signed ADC containers, limited by the block's sample-count byte. */
+    val samples: List<Int>,
+)
+
+/** One of the five repeated 422-byte blocks in a layout-v20 record. */
+data class Whoop5OpticalBlock(
+    val index: Int,
+    val sampleCount: Int,
+    /** Header bytes 1..6, shared by both channel slots. */
+    val sharedMetadata: List<Int>,
+    /** Always two slots, including when [sampleCount] is zero. */
+    val channels: List<RawOpticalChannel>,
+    /** Final byte of the block; zero throughout the current capture corpus. */
+    val reserved: Int,
+) {
+    val rawHeader: List<Int>
+        get() = listOf(sampleCount) + sharedMetadata + channels.flatMap { it.metadata }
+}
+
+data class Whoop5OpticalFrame(
+    val recordIndex: Long,
+    val baseTs: Long,
+    val blocks: List<Whoop5OpticalBlock>,
+)
+
+/**
+ * Structural decoder for WHOOP 5/MG historical layout v20 (exactly 2,140 bytes).
+ *
+ * The body is five repetitions of:
+ *
+ * `21-byte header | 200-byte channel slot 0 | 200-byte channel slot 1 | 1 reserved byte`.
+ *
+ * Header byte zero is the shared sample count (0..50). The remaining bytes are kept as neutral raw
+ * metadata. In the 29,203-record corpus used to establish this layout, counts are always
+ * `[25, 0, 0, 25, 25]`; active slots contain 25 sign-extended i32 readings followed by zero padding.
+ * The two slots under one header must not be named as two wavelengths without independent evidence.
+ */
+object Whoop5RawOptical {
+    const val BUFFER_LENGTH = 2140
+    const val BLOCK_COUNT = 5
+    const val BLOCK_START = 26
+    const val BLOCK_LENGTH = 422
+    const val HEADER_LENGTH = 21
+    const val CHANNEL_SLOT_LENGTH = 200
+    const val CHANNEL_CAPACITY = 50
+
+    fun decode(frame: ByteArray): Whoop5OpticalFrame? {
+        if (frame.size != BUFFER_LENGTH || frame.u8(0) != 0xAA ||
+            frame.u8(8) != 0x2F || frame.u8(9) != 20
+        ) return null
+
+        val blocks = ArrayList<Whoop5OpticalBlock>(BLOCK_COUNT)
+        for (index in 0 until BLOCK_COUNT) {
+            val start = BLOCK_START + index * BLOCK_LENGTH
+            val sampleCount = frame.u8(start)
+            if (sampleCount !in 0..CHANNEL_CAPACITY) return null
+
+            val sharedMetadata = (start + 1 until start + 7).map { frame.u8(it) }
+            val channels = ArrayList<RawOpticalChannel>(2)
+            for (channelIndex in 0..1) {
+                val metadataStart = start + 7 + channelIndex * 7
+                val metadata = (metadataStart until metadataStart + 7).map { frame.u8(it) }
+                val sampleStart = start + HEADER_LENGTH + channelIndex * CHANNEL_SLOT_LENGTH
+                val samples = (0 until sampleCount).map { frame.i32(sampleStart + it * 4) }
+                channels += RawOpticalChannel(metadata = metadata, samples = samples)
+            }
+            blocks += Whoop5OpticalBlock(
+                index = index,
+                sampleCount = sampleCount,
+                sharedMetadata = sharedMetadata,
+                channels = channels,
+                reserved = frame.u8(start + BLOCK_LENGTH - 1),
+            )
+        }
+
+        return Whoop5OpticalFrame(
+            recordIndex = frame.u32(11),
+            baseTs = frame.u32(15),
+            blocks = blocks,
+        )
+    }
+
+    private fun ByteArray.u8(offset: Int): Int = this[offset].toInt() and 0xFF
+
+    private fun ByteArray.u32(offset: Int): Long =
+        (u8(offset).toLong() or
+            (u8(offset + 1).toLong() shl 8) or
+            (u8(offset + 2).toLong() shl 16) or
+            (u8(offset + 3).toLong() shl 24))
+
+    private fun ByteArray.i32(offset: Int): Int =
+        u8(offset) or (u8(offset + 1) shl 8) or
+            (u8(offset + 2) shl 16) or (u8(offset + 3) shl 24)
+}

--- a/android/app/src/test/java/com/noop/protocol/Whoop5RawOpticalTest.kt
+++ b/android/app/src/test/java/com/noop/protocol/Whoop5RawOpticalTest.kt
@@ -1,0 +1,59 @@
+package com.noop.protocol
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class Whoop5RawOpticalTest {
+    private fun frame(): ByteArray = ByteArray(Whoop5RawOptical.BUFFER_LENGTH).also {
+        it[0] = 0xAA.toByte()
+        it[8] = 0x2F
+        it[9] = 20
+        putU32(it, 11, 11_494_060)
+        putU32(it, 15, 1_784_054_004)
+
+        val block = Whoop5RawOptical.BLOCK_START + 4 * Whoop5RawOptical.BLOCK_LENGTH
+        it[block] = 2
+        listOf(2, 200, 0, 4, 0, 0).forEachIndexed { i, value -> it[block + 1 + i] = value.toByte() }
+        listOf(3, 32, 0, 0, 0, 0, 0).forEachIndexed { i, value -> it[block + 7 + i] = value.toByte() }
+        listOf(1, 32, 0, 0, 0, 0, 0).forEachIndexed { i, value -> it[block + 14 + i] = value.toByte() }
+        putI32(it, block + Whoop5RawOptical.HEADER_LENGTH, -123_456)
+        putI32(it, block + Whoop5RawOptical.HEADER_LENGTH + 4, 234_567)
+        putI32(it, block + Whoop5RawOptical.HEADER_LENGTH + Whoop5RawOptical.CHANNEL_SLOT_LENGTH, 9_876)
+        putI32(it, block + Whoop5RawOptical.HEADER_LENGTH + Whoop5RawOptical.CHANNEL_SLOT_LENGTH + 4, 11_318)
+    }
+
+    @Test fun decodesRepeatedBlockAndPairedChannels() {
+        val decoded = requireNotNull(Whoop5RawOptical.decode(frame()))
+        assertEquals(11_494_060L, decoded.recordIndex)
+        assertEquals(1_784_054_004L, decoded.baseTs)
+        assertEquals(listOf(0, 0, 0, 0, 2), decoded.blocks.map { it.sampleCount })
+
+        val block = decoded.blocks[4]
+        assertEquals(listOf(2, 200, 0, 4, 0, 0), block.sharedMetadata)
+        assertEquals(listOf(3, 32, 0, 0, 0, 0, 0), block.channels[0].metadata)
+        assertEquals(listOf(1, 32, 0, 0, 0, 0, 0), block.channels[1].metadata)
+        assertEquals(listOf(-123_456, 234_567), block.channels[0].samples)
+        assertEquals(listOf(9_876, 11_318), block.channels[1].samples)
+        assertEquals(21, block.rawHeader.size)
+        assertTrue(decoded.blocks.all { it.channels.size == 2 })
+    }
+
+    @Test fun rejectsWrongShapeOrImpossibleCount() {
+        assertNull(Whoop5RawOptical.decode(frame() + byteArrayOf(0)))
+        assertNull(Whoop5RawOptical.decode(frame().also { it[9] = 21 }))
+        assertNull(Whoop5RawOptical.decode(frame().also {
+            it[Whoop5RawOptical.BLOCK_START] = (Whoop5RawOptical.CHANNEL_CAPACITY + 1).toByte()
+        }))
+    }
+
+    private fun putU32(frame: ByteArray, offset: Int, value: Int) {
+        frame[offset] = value.toByte()
+        frame[offset + 1] = (value ushr 8).toByte()
+        frame[offset + 2] = (value ushr 16).toByte()
+        frame[offset + 3] = (value ushr 24).toByte()
+    }
+
+    private fun putI32(frame: ByteArray, offset: Int, value: Int) = putU32(frame, offset, value)
+}


### PR DESCRIPTION
Replaces the inline v20 (2140 B) historical decode with a dedicated, neutral `Whoop5RawOptical` decoder (Swift + Kotlin) that models the record's actual repeated structure. **Supersedes #545** — it subsumes that 50→25 sample-count fix by reading the count from the record instead of hard-coding it.

### The structure (verified on all 29,203 captured records)

The v20 body is **five repeated 422-byte measurement blocks** at `26 + 422·i` (26/448/870/1292/1714 — exactly filling `[26:2136]`, where the CRC32 sits). Each block:

```
21-byte header │ 200-B channel slot 0 │ 200-B channel slot 1 │ 1 reserved byte
```

Header byte 0 is the shared sample count for both slots. Block counts are always `[25, 0, 0, 25, 25]`; active slots carry 25 sign-extended i32 readings (~25 Hz), slots 25–49 are zero padding, reserved bytes are zero. The 21-byte header splits `[count:1][shared:6][chan0:7][chan1:7]` and is preserved as **raw metadata** — no register meanings asserted.

### Why this replaces the old model

The previous decode treated the six active slots as six independent channels. They're really **three measurement blocks of two slots each**. This matters semantically: the two slots under one block header are a **detector/readout pair for one measurement configuration, not two different LED wavelengths**. The decoder therefore exposes neutral `channel_b<block>_<slot>` names and asserts no color — a defensible model until a labeled optical experiment establishes wavelength identity. (Analog Devices' MAX86171 is a structural cross-check for "one measurement → a PPG1/PPG2 detector pair"; it is not claimed to be the actual silicon.)

### Scope

Instrumentation/diagnostics only, **no production consumers** — `extractHistoricalStreams` reads only v18 keys, and the raw 2140-B buffer is persisted separately. The decoder is lossless (reconstructs the full 21-byte header) and strictly gated (`== 2140`, envelope + inner type + version, `sampleCount <= 50` keeps every read in-bounds). Also tightens `Whoop5RawImu` to an exact-length gate (`>=` → `==`) so the two same-type decoders can't cross-misfire.

### Tests

- **Swift** — full `WhoopProtocol` suite green (289 passing). Real captured-frame test asserts `[25,0,0,25,25]`, the exact 21-byte headers, paired-channel sample counts, and that the interpreter exposes **no `red`/`ir` keys**; plus strict shape/count-gate tests.
- **Kotlin** — direct port of the Swift decoder. Compiled with kotlinc 2.4.10 and its decode + reject vectors verified locally against a driver mirroring the test; the JUnit test itself runs in Android CI.

RE background for the structure is tracked in #423.
