### PR TITLE
protocol: Kotlin decoder for the WHOOP 5/MG v20 (2140 B) deep buffer

### DIFF
--- a/android/app/src/main/java/com/noop/protocol/Whoop5RawV20.kt
+++ b/android/app/src/main/java/com/noop/protocol/Whoop5RawV20.kt
@@ -122,7 +122,13 @@ object Whoop5RawV20 {
      * neither heart_rate nor gravity), so the Backfiller archives their raw bytes before acking the trim —
      * which is what preserves them. Teaching [decodeHistorical] to return a v20 map would silently drop
      * them out of that archive while storing nothing, i.e. lose the data, and would also let a v20 frame
-     * win `Backfiller`'s observed-`hist_version` probe. Decode first, consume later (#423).
+     * win `Backfiller`'s observed-`hist_version` probe.
+     *
+     * Nor is being callerless the house pattern — [Whoop5RawImu] shipped WITH its PuffinDeepBufferLog
+     * caller in one commit (#481), as did its Swift side (#455). The reason is narrower: no parity-safe
+     * consumer exists yet. v20 channel identity is unproven, and Swift deliberately keeps the 2140-B
+     * buffer raw-only in its deep-buffer log, so wiring one on Android alone would re-open the parity gap
+     * from the other side. A consumer wants both platforms at once, once #423 settles identity.
      */
     fun decode(f: ByteArray): Whoop5V20Frame? {
         if (f.size < bufferLength) return null

--- a/android/app/src/main/java/com/noop/protocol/Whoop5RawV20.kt
+++ b/android/app/src/main/java/com/noop/protocol/Whoop5RawV20.kt
@@ -15,8 +15,10 @@ package com.noop.protocol
 //   @15  u32 LE  strap unix seconds for this record
 //   then FIVE channel blocks, each preceded by a block-header byte (0x19 = active, 0x00 = empty):
 //     header @0x1a / @0x1c0 / @0x366 / @0x50c / @0x6b2
-//     an active block holds TWO channels of 25 i32 LE samples (~25 Hz), at slot pairs
+//     an active block holds TWO channels of 25 i32 LE samples, at slot pairs
 //     @0x2f/@0xf7, @0x1d5/@0x29d, @0x37b/@0x443, @0x521/@0x5e9, @0x6c7/@0x78f
+//
+// The record's TIME SPAN is not established (so neither is a sample rate) — see [Whoop5V20Frame].
 //
 // WHY 25 SAMPLES, NOT 50: across all 29,203 captured 2140-B buffers, exactly blocks 0/3/4 are active
 // (channel slots @47/247/1313/1513/1735/1935) and, in every active channel, sample slots 25..49 are
@@ -48,17 +50,25 @@ data class Whoop5V20Channel(
     val name: String get() = "channel_b${block}_$half"
 }
 
-/** One decoded 2140-B v20 buffer: the record header plus whichever channel blocks were active. */
+/**
+ * One decoded 2140-B v20 buffer: the record header plus whichever channel blocks were active.
+ *
+ * Carries a sample COUNT and NO sample rate — deliberately, and unlike [Whoop5ImuFrame]. The v21 IMU
+ * buffer earns its `sampleRateHz`/`ts(i)`: it is documented as a full second of inertial data and was
+ * validated over 1423 real buffers. v20's record SPAN has never been established — "~25 Hz" is only an
+ * inference from "25 samples, probably ~1 s", and PuffinDeepBufferLog's own note (2140 B = "~59
+ * sub-records per timestamped second") would imply a far shorter span. The Swift decoder likewise emits
+ * only `sensor_channel_samples`, never a rate. Publishing a rate here would let a future consumer bank
+ * per-sample wall-clock timestamps derived from an unproven constant, so the span stays undecided until
+ * a capture settles it (derived-signal rule; #423).
+ */
 data class Whoop5V20Frame(
     val baseTs: Long,               // strap unix seconds (@15; full u32 — Swift reads it into a 64-bit Int)
     val recordIndex: Long,          // monotonic lifetime record index (@11; full u32)
     val layoutMarker: Int,          // @10 (0x81 on every captured v20 buffer)
-    val sampleRateHz: Int,          // 25 — one buffer is ~1 s of 25 Hz samples per channel
+    val sampleCount: Int,           // 25 per active channel — the Swift `sensor_channel_samples` twin
     val channels: List<Whoop5V20Channel>,
-) {
-    /** Wall-clock unix seconds for sample [i] (samples are evenly spaced across the 1-second record). */
-    fun ts(i: Int): Double = baseTs.toDouble() + i.toDouble() / maxOf(1, sampleRateHz).toDouble()
-}
+)
 
 object Whoop5RawV20 {
 
@@ -89,6 +99,11 @@ object Whoop5RawV20 {
      * Gates on the exact buffer length + the in-packet type (47) and layout version (20) bytes, NOT the
      * marker: the Swift decoder reports @10 rather than gating on it, so a buffer with an unexpected
      * marker must still decode identically here.
+     *
+     * Takes no [DeviceFamily] (matching [Whoop5RawImu.decode]) but reads WHOOP5-ABSOLUTE offsets — a 4.0
+     * carries its type byte at @4, not @8. The 2140-B length gate makes a 4.0 misfire unreachable in
+     * practice (its records are ~84-124 B), but a future caller should still resolve the family through
+     * `DeviceFamily.forRegistryModel` and only reach here for WHOOP5, never string-compare a model label.
      *
      * DELIBERATE, DOCUMENTED DIVERGENCE from Swift on MALFORMED input only: Swift's field layer decodes a
      * truncated v20 frame into however many channels fit, whereas this returns null for anything shorter
@@ -126,7 +141,7 @@ object Whoop5RawV20 {
             baseTs = u32(f, tsOff),
             recordIndex = u32(f, recordIndexOff),
             layoutMarker = u8(f, markerOff),
-            sampleRateHz = sampleCount,
+            sampleCount = sampleCount,
             channels = channels,
         )
     }

--- a/android/app/src/main/java/com/noop/protocol/Whoop5RawV20.kt
+++ b/android/app/src/main/java/com/noop/protocol/Whoop5RawV20.kt
@@ -1,0 +1,146 @@
+package com.noop.protocol
+
+// Whoop5RawV20.kt — decoder for the WHOOP 5.0/MG 2140-byte "v20" deep-buffer offload record (#423).
+// Kotlin twin of the v20 branch of WhoopProtocol's `decodeWhoop5HistoricalV2021` (Interpreter.swift) —
+// byte-identical offsets, sample count, and block gating (parity contract).
+//
+// WHOOP 5.0/MG ONLY. v20 is a 5/MG concept: the 4.0 speaks v24/v25 and its type-0x2F frames are a
+// different layout entirely (see WhoopBleClient: "R22 deep-data is a WHOOP 5/MG concept only").
+//
+// Frame layout (reassembled BLE frame = 8-byte puffin envelope + payload; offsets are FRAME-absolute):
+//   @8   u8      packet type (47 = HISTORICAL_DATA)
+//   @9   u8      layout version (20)
+//   @10  u8      layout marker (0x81 on v20; 0x80 on the 1244-B v21 IMU buffer)
+//   @11  u32 LE  monotonic lifetime record index (the same counter v18 carries)
+//   @15  u32 LE  strap unix seconds for this record
+//   then FIVE channel blocks, each preceded by a block-header byte (0x19 = active, 0x00 = empty):
+//     header @0x1a / @0x1c0 / @0x366 / @0x50c / @0x6b2
+//     an active block holds TWO channels of 25 i32 LE samples (~25 Hz), at slot pairs
+//     @0x2f/@0xf7, @0x1d5/@0x29d, @0x37b/@0x443, @0x521/@0x5e9, @0x6c7/@0x78f
+//
+// WHY 25 SAMPLES, NOT 50: across all 29,203 captured 2140-B buffers, exactly blocks 0/3/4 are active
+// (channel slots @47/247/1313/1513/1735/1935) and, in every active channel, sample slots 25..49 are
+// exactly 0 — only samples 0..24 carry data. Reading 50 emits arrays that are half zeros; the Swift
+// decoder carried that bug until #545. The block-header byte itself reads 0x19 = 25 on every active
+// block, consistent with a live per-block sample count. Each sample is a 4-byte LE container holding a
+// 20-bit signed value (its upper 12 bits are only ever 0x000/0xFFF — pure sign extension — across all
+// captures), so reading it as i32 recovers the correct signed magnitude with no masking.
+//
+// CHANNEL IDENTITY IS NOT PROVEN. No labelled/moving v20 capture exists in the tree, so channels stay
+// neutrally named (`channel_b<block>_<half>`) and NO scale is applied — these are raw i32 counts with no
+// absolute unit. RE notes only, NOT authoritative (issue #423): the buffer's config header [19:47] carries
+// an LED-current field @28 and per-photodiode offset DACs @38/@45, and the six active channels are
+// INFERRED to be optical (green/IR/red/ambient); the red/IR split is under active dispute, so no
+// wavelength label is encoded here. Per the derived-signal rule this is decode-only instrumentation: it
+// feeds no stored table, no migration, and no downstream gate.
+//
+// Pure/deterministic; no I/O, no strap. Deliberately has NO callers — see the class doc on [decode].
+
+/** One decoded v20 channel: 25 raw i32 samples from one half of one active block. */
+data class Whoop5V20Channel(
+    val block: Int,             // 0..4 — which block header gated it
+    val half: Int,              // 0 or 1 — which of the block's two channel slots
+    val startOffset: Int,       // frame-absolute byte offset of sample 0
+    val samples: List<Int>,     // 25 raw i32 counts; no scale, no unit (identity unproven)
+) {
+    /** The field name the Swift interpreter emits for this channel (`channel_b3_1`), so a Kotlin decode
+     *  and a `whoop-decode` dump of the same buffer can be diffed key-for-key. */
+    val name: String get() = "channel_b${block}_$half"
+}
+
+/** One decoded 2140-B v20 buffer: the record header plus whichever channel blocks were active. */
+data class Whoop5V20Frame(
+    val baseTs: Long,               // strap unix seconds (@15; full u32 — Swift reads it into a 64-bit Int)
+    val recordIndex: Long,          // monotonic lifetime record index (@11; full u32)
+    val layoutMarker: Int,          // @10 (0x81 on every captured v20 buffer)
+    val sampleRateHz: Int,          // 25 — one buffer is ~1 s of 25 Hz samples per channel
+    val channels: List<Whoop5V20Channel>,
+) {
+    /** Wall-clock unix seconds for sample [i] (samples are evenly spaced across the 1-second record). */
+    fun ts(i: Int): Double = baseTs.toDouble() + i.toDouble() / maxOf(1, sampleRateHz).toDouble()
+}
+
+object Whoop5RawV20 {
+
+    const val bufferLength = 2140
+    const val sampleCount = 25
+    const val layoutVersion = 20
+    const val historicalDataType = 47
+
+    // FRAME-absolute offsets (8-byte puffin envelope + payload).
+    private const val typeOff = 8
+    private const val versionOff = 9
+    private const val markerOff = 10
+    private const val recordIndexOff = 11
+    private const val tsOff = 15
+
+    /** The five (block-header, channel-0, channel-1) offset triples, verbatim from the Swift decoder. */
+    private val blocks = listOf(
+        Triple(0x1a, 0x2f, 0xf7),
+        Triple(0x1c0, 0x1d5, 0x29d),
+        Triple(0x366, 0x37b, 0x443),
+        Triple(0x50c, 0x521, 0x5e9),
+        Triple(0x6b2, 0x6c7, 0x78f),
+    )
+
+    /**
+     * Decode a v20 deep buffer, or null if [f] isn't one.
+     *
+     * Gates on the exact buffer length + the in-packet type (47) and layout version (20) bytes, NOT the
+     * marker: the Swift decoder reports @10 rather than gating on it, so a buffer with an unexpected
+     * marker must still decode identically here.
+     *
+     * DELIBERATE, DOCUMENTED DIVERGENCE from Swift on MALFORMED input only: Swift's field layer decodes a
+     * truncated v20 frame into however many channels fit, whereas this returns null for anything shorter
+     * than 2140 B (the [Whoop5RawImu] gate idiom — the strap's v20 buffer is always exactly 2140 B). On
+     * every real buffer the two agree byte-for-byte; the length gate only makes the Kotlin side stricter
+     * about frames that could never come off a strap.
+     *
+     * NOTE: this decoder intentionally has NO production caller, and wiring one is NOT a free change.
+     * v20 records currently reach `rejectedHistoricalRecords` on BOTH platforms (they carry `unix` but
+     * neither heart_rate nor gravity), so the Backfiller archives their raw bytes before acking the trim —
+     * which is what preserves them. Teaching [decodeHistorical] to return a v20 map would silently drop
+     * them out of that archive while storing nothing, i.e. lose the data, and would also let a v20 frame
+     * win `Backfiller`'s observed-`hist_version` probe. Decode first, consume later (#423).
+     */
+    fun decode(f: ByteArray): Whoop5V20Frame? {
+        if (f.size < bufferLength) return null
+        if (u8(f, typeOff) != historicalDataType) return null
+        if (u8(f, versionOff) != layoutVersion) return null
+
+        val channels = ArrayList<Whoop5V20Channel>(blocks.size * 2)
+        for ((b, blk) in blocks.withIndex()) {
+            val (presentOff, ch0Off, ch1Off) = blk
+            // Block-header byte: 0x19 = active, 0x00 = empty/zero-filled. Matches Swift's `!= 0` test
+            // rather than an == 0x19 equality, so an active block with an unexpected count byte still
+            // decodes instead of vanishing.
+            if (u8(f, presentOff) == 0) continue
+            for ((half, start) in listOf(0 to ch0Off, 1 to ch1Off)) {
+                if (start + 4 * sampleCount > f.size) continue
+                val samples = ArrayList<Int>(sampleCount)
+                for (i in 0 until sampleCount) samples.add(i32(f, start + i * 4))
+                channels.add(Whoop5V20Channel(block = b, half = half, startOffset = start, samples = samples))
+            }
+        }
+        return Whoop5V20Frame(
+            baseTs = u32(f, tsOff),
+            recordIndex = u32(f, recordIndexOff),
+            layoutMarker = u8(f, markerOff),
+            sampleRateHz = sampleCount,
+            channels = channels,
+        )
+    }
+
+    // Little-endian readers (frame-absolute).
+    private fun u8(f: ByteArray, o: Int): Int = f[o].toInt() and 0xFF
+
+    private fun u32(f: ByteArray, o: Int): Long =
+        (f[o].toLong() and 0xFF) or ((f[o + 1].toLong() and 0xFF) shl 8) or
+            ((f[o + 2].toLong() and 0xFF) shl 16) or ((f[o + 3].toLong() and 0xFF) shl 24)
+
+    /** Full 32-bit signed read — the sample container is 4 bytes holding a sign-extended 20-bit value,
+     *  so no masking is applied (matching Swift `readI32`). */
+    private fun i32(f: ByteArray, o: Int): Int =
+        (f[o].toInt() and 0xFF) or ((f[o + 1].toInt() and 0xFF) shl 8) or
+            ((f[o + 2].toInt() and 0xFF) shl 16) or ((f[o + 3].toInt() and 0xFF) shl 24)
+}

--- a/android/app/src/main/java/com/noop/protocol/Whoop5RawV20.kt
+++ b/android/app/src/main/java/com/noop/protocol/Whoop5RawV20.kt
@@ -105,6 +105,12 @@ object Whoop5RawV20 {
      * practice (its records are ~84-124 B), but a future caller should still resolve the family through
      * `DeviceFamily.forRegistryModel` and only reach here for WHOOP5, never string-compare a model label.
      *
+     * Does NOT verify the envelope CRC, and that is the parity-faithful split rather than an omission:
+     * Swift's `parseFrame` likewise decodes v20 fields on a CRC-bad frame and merely REPORTS `crcOK`,
+     * leaving the gate to its callers (`rejectedHistoricalRecords` / `extractHistoricalStreams` both drop
+     * on `crcOK == false`). A Kotlin caller must do the same — CRC-gate via `Framing.parseFrame` before
+     * trusting or storing anything decoded here (BLE safety contract: CRC-gate every inbound frame).
+     *
      * DELIBERATE, DOCUMENTED DIVERGENCE from Swift on MALFORMED input only: Swift's field layer decodes a
      * truncated v20 frame into however many channels fit, whereas this returns null for anything shorter
      * than 2140 B (the [Whoop5RawImu] gate idiom — the strap's v20 buffer is always exactly 2140 B). On

--- a/android/app/src/test/java/com/noop/protocol/Whoop5RawV20Test.kt
+++ b/android/app/src/test/java/com/noop/protocol/Whoop5RawV20Test.kt
@@ -125,8 +125,15 @@ class Whoop5RawV20Test {
         assertNull(channel(d, "channel_b1_0"))
     }
 
-    /** A block header is gated on != 0, not on == 0x19, so an active block with an unexpected count byte
-     *  still decodes (mirrors the Swift `frame[blk.present] != 0` test). */
+    /**
+     * A block header is gated on != 0, not on == 0x19 (mirrors the Swift `frame[blk.present] != 0` test).
+     *
+     * This pins PARITY WITH SWIFT, not a claim about what a non-0x19 header means. The header byte reads
+     * 0x19 = 25 on every active block in all 29,203 captures, which is consistent with it being a live
+     * per-block sample count — if that's what it is, a hypothetical 0x07 block would carry 7 samples, not
+     * the 25 both decoders would read. No such buffer has ever been seen, so the case stays synthetic and
+     * the two platforms stay identical on it; if one ever turns up, fix BOTH decoders together.
+     */
     @Test fun anyNonZeroBlockHeaderCountsAsActive() {
         val f = syntheticFrame { f ->
             f[0x1a] = 0x07                                            // not 0x19, but non-zero

--- a/android/app/src/test/java/com/noop/protocol/Whoop5RawV20Test.kt
+++ b/android/app/src/test/java/com/noop/protocol/Whoop5RawV20Test.kt
@@ -1,0 +1,208 @@
+package com.noop.protocol
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Pins [Whoop5RawV20.decode] — the WHOOP 5/MG 2140-byte v20 deep buffer (#423). Kotlin twin of the v20
+ * half of the Swift Whoop5HistoricalV2021Tests, asserted against the SAME real captured buffer so the two
+ * decoders are proven byte-identical on real hardware bytes rather than merely similar in shape.
+ *
+ * Asserts STRUCTURE only, never channel identity: no labelled/moving v20 capture exists, so the channels
+ * stay neutrally named and unscaled (see [Whoop5RawV20]).
+ */
+class Whoop5RawV20Test {
+
+    /** Build a valid-length v20 frame; the closure fills the body. Only the bytes [Whoop5RawV20] gates on
+     *  (type\@8, version\@9) are pre-set — this decoder reads the record, not the CRC envelope. */
+    private fun syntheticFrame(build: (ByteArray) -> Unit): ByteArray {
+        val f = ByteArray(Whoop5RawV20.bufferLength)
+        f[8] = 0x2F.toByte()          // type 47 = HISTORICAL_DATA
+        f[9] = 20                     // layout version
+        f[10] = 0x81.toByte()         // marker
+        build(f)
+        return f
+    }
+
+    private fun putI32(f: ByteArray, o: Int, v: Int) {
+        f[o] = (v and 0xFF).toByte(); f[o + 1] = ((v shr 8) and 0xFF).toByte()
+        f[o + 2] = ((v shr 16) and 0xFF).toByte(); f[o + 3] = ((v shr 24) and 0xFF).toByte()
+    }
+
+    private fun putU32(f: ByteArray, o: Int, v: Long) {
+        f[o] = (v and 0xFF).toByte(); f[o + 1] = ((v shr 8) and 0xFF).toByte()
+        f[o + 2] = ((v shr 16) and 0xFF).toByte(); f[o + 3] = ((v shr 24) and 0xFF).toByte()
+    }
+
+    private fun channel(d: Whoop5V20Frame, name: String): Whoop5V20Channel? = d.channels.firstOrNull { it.name == name }
+
+    // --- the real captured buffer (the parity assertion that matters) ---
+
+    /**
+     * Real 2140-B v20 buffer off a WHOOP 5.0, one line of the 29,203-buffer set behind the sample-count
+     * fix (#423/#545). Every expected value below is copied from the Swift test's assertions on this exact
+     * frame — if Kotlin and Swift ever diverge on real bytes, this fails.
+     */
+    @Test fun realFrameDecodesHeaderAndSixActiveChannels() {
+        val f = hexToBytes(realFrameV20Hex)
+        assertEquals(2140, f.size)
+        val d = Whoop5RawV20.decode(f)
+        assertNotNull("real v20 buffer must decode", d)
+        d!!
+        assertEquals(0x81, d.layoutMarker)
+        assertEquals(11494060L, d.recordIndex)
+        assertEquals(1784054004L, d.baseTs)
+        assertEquals(25, d.sampleRateHz)
+
+        // Exactly blocks 0/3/4 active on every captured buffer -> six channels; blocks 1/2 emit nothing.
+        assertEquals(6, d.channels.size)
+        assertEquals(
+            listOf("channel_b0_0", "channel_b0_1", "channel_b3_0", "channel_b3_1", "channel_b4_0", "channel_b4_1"),
+            d.channels.map { it.name },
+        )
+        assertNull(channel(d, "channel_b1_0"))
+        assertNull(channel(d, "channel_b2_0"))
+
+        // The six proven active channel slots, each decoding exactly 25 samples (the count #545 is about).
+        assertEquals(listOf(47, 247, 1313, 1513, 1735, 1935), d.channels.map { it.startOffset })
+        for (c in d.channels) assertEquals("${c.name} must decode 25 samples, not 50", 25, c.samples.size)
+
+        // Spot-check decoded values against the Swift assertions on the same artifact.
+        assertEquals(118434, channel(d, "channel_b0_0")!!.samples.first())
+        assertEquals(147258, channel(d, "channel_b0_0")!!.samples.last())    // sample 24, not sample 49
+        assertEquals(-22101, channel(d, "channel_b0_1")!!.samples.first())   // negative -> sign-extension check
+        assertEquals(11318, channel(d, "channel_b4_1")!!.samples.last())
+    }
+
+    /**
+     * The decisive artifact fact behind the 25-vs-50 fix: at each active channel start the i32 slots for
+     * samples 25..49 are exactly 0 in the RAW frame, while sample 24 is a real value. Reading 50 was
+     * reading padding. Asserted against the raw bytes, independent of the decoder.
+     */
+    @Test fun realFrameTailSlotsAreZeroPadding() {
+        val f = hexToBytes(realFrameV20Hex)
+        fun rawI32(o: Int): Int =
+            (f[o].toInt() and 0xFF) or ((f[o + 1].toInt() and 0xFF) shl 8) or
+                ((f[o + 2].toInt() and 0xFF) shl 16) or ((f[o + 3].toInt() and 0xFF) shl 24)
+        for (start in listOf(47, 247, 1313, 1513, 1735, 1935)) {
+            assertTrue("sample 24 at channel @$start is a real value", rawI32(start + 24 * 4) != 0)
+            for (i in 25 until 50) {
+                assertEquals("sample $i at channel @$start must be zero padding", 0, rawI32(start + i * 4))
+            }
+        }
+    }
+
+    // --- decode mechanics on synthetic frames ---
+
+    /** Fill ALL 50 slots with a monotone sentinel so the test proves the decoder keeps only samples 0..24
+     *  and DROPS 25..49 — the half-zeros bug a 50-sample read reintroduces. */
+    @Test fun keepsFirst25SamplesAndDropsPaddingSlots() {
+        val f = syntheticFrame { f ->
+            putU32(f, 11, 0x01A8CF26L)
+            putU32(f, 15, 1781556372L)
+            f[0x1a] = 0x19                                                  // block 0 active
+            for (i in 0 until 50) putI32(f, 0x2f + i * 4, 100000 + i)       // ch b0_0
+            for (i in 0 until 50) putI32(f, 0xf7 + i * 4, 200000 - i)       // ch b0_1
+            f[0x1c0] = 0x00                                                 // block 1 empty
+            f[0x50c] = 0x19                                                 // block 3 active
+            for (i in 0 until 50) putI32(f, 0x521 + i * 4, 140 + i)
+            for (i in 0 until 50) putI32(f, 0x5e9 + i * 4, 130 + i)
+        }
+        val d = Whoop5RawV20.decode(f)!!
+        assertEquals(0x01A8CF26L, d.recordIndex)
+        assertEquals(1781556372L, d.baseTs)
+        // Active blocks 0 and 3 -> 4 channels; the empty block 1 contributes none.
+        assertEquals(4, d.channels.size)
+        val b00 = channel(d, "channel_b0_0")!!.samples
+        assertEquals(25, b00.size)                     // 25, not 50
+        assertEquals(100000, b00.first())
+        assertEquals(100024, b00.last())               // sample 24, not sample 49
+        assertEquals(200000, channel(d, "channel_b0_1")!!.samples.first())
+        assertEquals(140, channel(d, "channel_b3_0")!!.samples.first())
+        assertNull(channel(d, "channel_b1_0"))
+    }
+
+    /** A block header is gated on != 0, not on == 0x19, so an active block with an unexpected count byte
+     *  still decodes (mirrors the Swift `frame[blk.present] != 0` test). */
+    @Test fun anyNonZeroBlockHeaderCountsAsActive() {
+        val f = syntheticFrame { f ->
+            f[0x1a] = 0x07                                            // not 0x19, but non-zero
+            for (i in 0 until 25) putI32(f, 0x2f + i * 4, 7 + i)
+        }
+        val d = Whoop5RawV20.decode(f)!!
+        assertEquals(2, d.channels.size)                              // both halves of block 0
+        assertEquals(7, channel(d, "channel_b0_0")!!.samples.first())
+    }
+
+    /** An all-empty buffer decodes its header and zero channels — never null (the record is still real). */
+    @Test fun allBlocksEmptyYieldsHeaderAndNoChannels() {
+        val d = Whoop5RawV20.decode(syntheticFrame { putU32(it, 15, 1784054004L) })!!
+        assertEquals(0, d.channels.size)
+        assertEquals(1784054004L, d.baseTs)
+    }
+
+    /** Gating: wrong version, wrong packet type, or a short frame must all decline rather than misread.
+     *  Notably the 1244-B v21 IMU buffer — the other deep buffer on the same wire — must not decode here. */
+    @Test fun rejectsNonV20Buffers() {
+        assertNull("v21 IMU buffer is not v20", Whoop5RawV20.decode(ByteArray(1244).also { it[8] = 0x2F; it[9] = 21 }))
+        assertNull("wrong layout version", Whoop5RawV20.decode(syntheticFrame { it[9] = 18 }))
+        assertNull("wrong packet type", Whoop5RawV20.decode(syntheticFrame { it[8] = 0x31 }))
+        assertNull("short frame", Whoop5RawV20.decode(ByteArray(2139).also { it[8] = 0x2F; it[9] = 20 }))
+    }
+
+    /** Sample timestamps spread evenly across the record's second at 25 Hz. */
+    @Test fun sampleTimestampsSpreadAcrossTheSecond() {
+        val d = Whoop5RawV20.decode(syntheticFrame { putU32(it, 15, 1784054004L) })!!
+        assertEquals(1784054004.0, d.ts(0), 1e-9)
+        assertEquals(1784054004.96, d.ts(24), 1e-9)
+    }
+
+    private fun hexToBytes(hex: String): ByteArray =
+        ByteArray(hex.length / 2) { ((Character.digit(hex[it * 2], 16) shl 4) + Character.digit(hex[it * 2 + 1], 16)).toByte() }
+
+    companion object {
+        /** One real 2140-byte type-0x2F v20 buffer captured off a WHOOP 5.0 (fw 50.x), issue #423 — the
+         *  same artifact the Swift Whoop5HistoricalV2021Tests uses. Kept as hex so the test is
+         *  self-contained (no fixture file, runs on any machine with no strap). */
+        private const val realFrameV20Hex =
+            "aa0154080100b5b32f1481ac62af00f480566ab85e04001900001901160d042c1a0320000000000004200000002003a2ce0100abcb0100daca010004" +
+            "cd0100ffd00100ded50100fedb010019e001003be201004ae50100d0e90100d9ef0100acf601004afd01005d040200ce0e0200db180200622402005f" +
+            "2e020075320200be34020037390200e03c02004a3f02003a3f0200000000000000000000000000000000000000000000000000000000000000000000" +
+            "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000" +
+            "00000000000000aba9ffff57a8ffff09a7ffff8ca5ffff25a3ffffeca1ffff30a1ffffe6a0ffff8fa1fffff6a3ffffeaa7fffffaacffff0db3ffffde" +
+            "baffff78c0ffff70c5fffffdd6ffff3fe1ffffeae3ffff6eedffff0debffff64e0ffff17d9ffffbad4ffff39cfffff00000000000000000000000000" +
+            "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000" +
+            "000000000000000000000000000000000000000000000000000000000003ce3104000001100000000000021000000000000000000000000000000000" +
+            "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000" +
+            "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000" +
+            "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000" +
+            "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000" +
+            "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000" +
+            "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000" +
+            "0000000000000000000000000000000000000000000000000000000000000002fa190400000120000000400602200000006009000000000000000000" +
+            "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000" +
+            "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000" +
+            "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000" +
+            "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000" +
+            "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000" +
+            "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000" +
+            "0000000000000000000000000000000000000000000000000000000000000000190200000400000320000000000004200000000000b9000000c00000" +
+            "00ae000000bd000000b3000000b0000000ba000000bc000000c6000000a0000000b7000000b9000000b0000000bb000000af000000a6000000aa0000" +
+            "00b9000000b8000000b7000000bb0000009f000000ae000000ac000000ab000000000000000000000000000000000000000000000000000000000000" +
+            "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000" +
+            "00000000000000000000000000c3000000b7000000c8000000bb000000a9000000bb000000c7000000ac000000ca000000a2000000bd000000bc0000" +
+            "00b9000000bf000000b7000000bc000000b5000000b8000000ae000000b7000000c0000000b6000000ba000000be000000aa00000000000000000000" +
+            "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000" +
+            "000000000000000000000000000000000000000000000000000000000000000000001902c8000400000320000000000001200000000000b0860100ca" +
+            "8601001d87010018880100b5880100c08801005d8901006c89010016890100f688010010890100b4890100b18a0100fe8b01003d8d0100be8f0100e5" +
+            "920100c29501001e980100ab9a0100bb9e010010a201008ba301002fa40100fba3010000000000000000000000000000000000000000000000000000" +
+            "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000" +
+            "000000000000000000000000000000f82600000f2700002d27000058270000a2270000b5270000cb270000c6270000a727000090270000892700009c" +
+            "270000c0270000e7270000172800008a280000ca280000f8280000822900005f2a00008d2b00003f2c00008d2c0000942c0000362c00000000000000" +
+            "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000" +
+            "000000000000000000000000000000000000000000000000000000000000000000000000a9a4a5c0"
+    }
+}

--- a/android/app/src/test/java/com/noop/protocol/Whoop5RawV20Test.kt
+++ b/android/app/src/test/java/com/noop/protocol/Whoop5RawV20Test.kt
@@ -55,7 +55,7 @@ class Whoop5RawV20Test {
         assertEquals(0x81, d.layoutMarker)
         assertEquals(11494060L, d.recordIndex)
         assertEquals(1784054004L, d.baseTs)
-        assertEquals(25, d.sampleRateHz)
+        assertEquals(25, d.sampleCount)      // a COUNT; v20 publishes no rate (span unproven)
 
         // Exactly blocks 0/3/4 active on every captured buffer -> six channels; blocks 1/2 emit nothing.
         assertEquals(6, d.channels.size)
@@ -151,13 +151,6 @@ class Whoop5RawV20Test {
         assertNull("wrong layout version", Whoop5RawV20.decode(syntheticFrame { it[9] = 18 }))
         assertNull("wrong packet type", Whoop5RawV20.decode(syntheticFrame { it[8] = 0x31 }))
         assertNull("short frame", Whoop5RawV20.decode(ByteArray(2139).also { it[8] = 0x2F; it[9] = 20 }))
-    }
-
-    /** Sample timestamps spread evenly across the record's second at 25 Hz. */
-    @Test fun sampleTimestampsSpreadAcrossTheSecond() {
-        val d = Whoop5RawV20.decode(syntheticFrame { putU32(it, 15, 1784054004L) })!!
-        assertEquals(1784054004.0, d.ts(0), 1e-9)
-        assertEquals(1784054004.96, d.ts(24), 1e-9)
     }
 
     private fun hexToBytes(hex: String): ByteArray =


### PR DESCRIPTION
Draft — closes a decode-capability gap, but deliberately ships **no consumer**. Opening as draft because the thing it decodes still has an unproven identity, and I don't think it should be wired to anything until that changes.

## The gap

`v20` is a **WHOOP 5.0/MG** layout (the 4.0 speaks v24/v25; its type-0x2F frames are a different thing entirely). Swift decodes the 2140-B v20 deep buffer in `Interpreter.decodeWhoop5HistoricalV2021`; Kotlin had nothing. So the same capture is readable through `whoop-decode` but opaque on Android.

For contrast, the neighbouring buffers are already at parity: v18 (`HistoricalStreams`), v21 (`Whoop5RawImu.kt`), v26 (`PpgHr.kt`).

## What this adds

`Whoop5RawV20` — a pure decoder for:

- the record header — marker @10 (`0x81`), monotonic record index @11, unix @15
- five channel blocks, each gated by a header byte (`0x19` = active, `0x00` = empty), each active block holding **two 25-sample i32 channels**

Offsets, sample count, and gating are verbatim from the Swift decoder, including the `!= 0` block test (not `== 0x19`) and the unmasked i32 read of the sign-extended 20-bit container.

## No sample rate (re-review fix)

`Whoop5V20Frame` publishes a sample **count**, not a rate, and has no `ts(i)`. The first cut had `sampleRateHz = 25` + a `ts(i)` spreading samples across "the record's second" — neither is established. Swift emits `sensor_channel_samples` (a count) and never a rate; "~25 Hz" is only a tilde'd aside inferred from "25 samples, probably ~1 s". v21 *earns* its `sampleRateHz` (documented full second, validated over 1423 buffers); v20's span has never been measured, and `PuffinDeepBufferLog`'s own note (2140 B = "~59 sub-records per timestamped second") would imply a much shorter one. `ts(i)` would have turned that unproven constant into per-sample wall-clock timestamps — the exact derived-signal trap a future consumer would bank rows from.

## Channel identity stays OPEN

No labelled/moving v20 capture exists, so channels keep Swift's neutral `channel_b<block>_<half>` names and **no scale is applied**. The `[19:47]` config header hints optical (LED-current @28, per-photodiode offset DACs @38/@45) and the red/IR split is still disputed (#423) — so no wavelength label is encoded. Decode-only instrumentation per the derived-signal rule: no stored table, no migration, no downstream gate.

## Why there is no caller (the part worth reviewing)

Wiring this into `decodeHistorical` looks like the obvious next step and is **not** a free change:

- v20 records hit `rejectedHistoricalRecords` on **both** platforms today — they carry `unix` but neither `heart_rate` nor `gravity_x`, so Swift's gate rejects them too. That's what makes the Backfiller archive their raw bytes before acking the trim.
- Returning a v20 map from `decodeHistorical` would drop them **out of that archive while storing nothing** — i.e. actually lose the buffers.
- It would also let a v20 frame win `Backfiller`'s observed-`hist_version` probe (`firstNotNullOfOrNull`), flipping the Devices screen's reported layout off v18.

So storage behaviour is already at parity and stays byte-identical here.

**Correction to an earlier version of this description**, which claimed this follows the shape `Whoop5RawImu` landed in ("decoder first, consumer later"). It does not, and I should have checked before writing it: `Whoop5RawImu.kt` shipped **with** its `PuffinDeepBufferLog` caller in the same commit (`091b3c6e`, #481), and the Swift side (#455) landed decoder + `ImuFeatureExtractor` + caller together. Neither ever sat callerless. **This PR would be the protocol package's first callerless decoder**, so it does not match the house pattern — that's a reason to weigh it on its own merits as banked groundwork, not to wave it through on a precedent that doesn't exist.

One documented divergence, on malformed input only: Swift's field layer decodes a *truncated* v20 frame into however many channels fit; this returns null below 2140 B (the `Whoop5RawImu` gate idiom). On every real buffer they agree byte-for-byte.

## Verification

6 new tests asserted against the **same real captured 2140-B buffer** the Swift test uses, so the two decoders are proven byte-identical on real hardware bytes rather than merely similar in shape — `118434` / `147258` / `-22101` (sign extension) / `11318` all match Swift's assertions, plus the raw-bytes proof that slots 25..49 are zero padding (the 25-vs-50 fact behind #545).

```
./gradlew testFullDebugUnitTest --tests "com.noop.protocol.*" --no-build-cache
tests=168 skipped=0 failures=0 errors=0
```

No strap needed — pure decoder, no I/O, no BLE path touched.


---

## Merge readiness — my own honest read

The code is sound: proven byte-for-byte against the same real captured buffer Swift asserts on, explicit about every unknown (identity, span, header-byte semantics), no behaviour change, no callers, so regression risk is nil.

But **soundness isn't a reason to merge.** v20 has no consumer on either platform and can't get a parity-safe one until #423 settles channel identity — Swift deliberately keeps the 2140-B buffer raw-only in `PuffinDeepBufferLog`, so wiring one on Android alone would re-open the parity gap from the other side. Merging this banks ~350 lines that nothing calls, against the repo's own "smallest change that's correct" preference.

Reasonable to leave in draft until either (a) #423 produces a labelled/moving v20 capture and the channels get identities, or (b) someone wants a v20 summary in the deep-buffer log on **both** platforms, which this would then serve. The tests pin it to a real artifact, so it won't rot silently in the meantime.