### PR TITLE
Health: say WHY a vital tile is empty on Android, not just "No data"

### DIFF
--- a/android/app/src/main/java/com/noop/ui/HealthScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/HealthScreen.kt
@@ -1591,6 +1591,10 @@ private data class Vital(
     val readingDay: String? = null,
     val asOfLabel: String? = null,
     val rangeCaption: String? = null,
+    /** Metric-specific "no value" line, shown in place of a bare "No data" when nothing resolved, so an
+     *  empty tile still says WHY. Required (no default) so a new vital must state its own reason.
+     *  Kotlin twin of `BodyVitalReading.missingCaption` (VitalSignsSummary.swift) — same wording. */
+    val missingCaption: String,
     /** Personal-baseline banding (population fallback until 14 trusted nights). */
     val banding: VitalBands.Result,
     /** The metric's category colour (used only when in range). */
@@ -1614,9 +1618,13 @@ private data class Vital(
      *  The wording says which yardstick judged it: your baseline vs typical ranges. */
     val stateCaption: String = when {
         // Raw SpO₂ is a device-dependent ADC, not a clinical value — never claim an in/out-of-range
-        // judgment. Show a plain "uncalibrated" note when a value decoded, "No data" otherwise. (#93)
-        key == "spo2raw" -> if (banding.band == VitalBands.Band.NO_DATA) "No data" else "Uncalibrated"
-        banding.band == VitalBands.Band.NO_DATA -> "No data"
+        // judgment. Show a plain "uncalibrated" note when a value decoded. (#93)
+        key == "spo2raw" && banding.band != VitalBands.Band.NO_DATA -> "Uncalibrated"
+        // Nothing resolved: say WHY this tile is empty rather than a bare "No data", which reads as a
+        // bug for metrics NOOP cannot derive from a strap at all (the calibrated SpO₂ % is import-only:
+        // AnalyticsEngine writes spo2Pct = null on purpose, see Spo2ReTrace). Ports the Apple behaviour
+        // (`guard let day else { return missingCaption }`) — Android showed "No data" for every case.
+        banding.band == VitalBands.Band.NO_DATA -> missingCaption
         banding.basis == VitalBands.Basis.PERSONAL ->
             if (banding.band == VitalBands.Band.IN_RANGE) "In your range" else "Off your baseline"
         else ->
@@ -1723,6 +1731,7 @@ private fun vitalsFor(
     return listOf(
         Vital(
             key = "resp", label = uiString(R.string.l10n_health_screen_resp_rate_1c48dbd8), unit = "rpm",
+            missingCaption = "No respiratory-rate value",
             value = d?.respRateBpm, format = { String.format("%.1f", it) },
             deltaText = deltaText(d?.respRateBpm, previous { it.respRateBpm }),
             readingDay = todayKey,
@@ -1734,6 +1743,7 @@ private fun vitalsFor(
         ),
         Vital(
             key = "spo2", label = uiString(R.string.l10n_health_screen_blood_o_9bf5ed9b), unit = "%",
+            missingCaption = "No SpO₂ import or Health value",
             value = d?.spo2Pct, format = { String.format("%.0f", it) },
             deltaText = deltaText(d?.spo2Pct, previous { it.spo2Pct }, decimals = 0),
             readingDay = todayKey,
@@ -1752,6 +1762,7 @@ private fun vitalsFor(
             // full u16 span just keeps the tile cyan (never "off range"); `stateCaption` labels it
             // uncalibrated, so we never assert an in/out-of-range clinical judgment on raw sensor data.
             key = "spo2raw", label = uiString(R.string.l10n_health_screen_raw_spo_ccfe80c1), unit = "ADC",
+            missingCaption = "No raw SpO₂ decode for the night",
             value = d?.let(spo2RawMean), format = { String.format("%.0f", it) },
             deltaText = deltaText(d?.let(spo2RawMean), previous(spo2RawMean), decimals = 0),
             readingDay = todayKey,
@@ -1763,6 +1774,7 @@ private fun vitalsFor(
         ),
         Vital(
             key = "rhr", label = uiString(R.string.l10n_health_screen_resting_hr_26677094), unit = "bpm",
+            missingCaption = "No resting HR value",
             value = d?.restingHr?.toDouble(), format = { it.roundToInt().toString() },
             deltaText = deltaText(d?.restingHr?.toDouble(), previous { it.restingHr?.toDouble() }, decimals = 0),
             readingDay = todayKey,
@@ -1777,6 +1789,7 @@ private fun vitalsFor(
         ),
         Vital(
             key = "hrv", label = "HRV", unit = "ms",
+            missingCaption = "No HRV value",
             value = d?.avgHrv, format = { it.roundToInt().toString() },
             deltaText = deltaText(d?.avgHrv, previous { it.avgHrv }, decimals = 0),
             readingDay = todayKey,
@@ -1788,6 +1801,7 @@ private fun vitalsFor(
         ),
         Vital(
             key = "skin", label = uiString(R.string.l10n_health_screen_skin_temp_a4affc5a), unit = skinUnitLabel,
+            missingCaption = "No nightly skin-temp value",
             value = skin, format = skinFormat,
             deltaText = deltaText(skin, previousSkin),
             readingDay = todayKey,


### PR DESCRIPTION
Closes the Android half of #548.

## Why

Users report SpO₂ and Skin Temp "don't show anything". For SpO₂ that isn't a bug — `AnalyticsEngine` writes `spo2Pct = null` **on purpose** (a calibrated % needs WHOOP's proprietary curve; guessing would manufacture a health number — the #194 trap), so only importers ever populate it. The decision is right. The app just never said so: every empty tile read a bare **"No data"**, which reads as broken.

## Apple already solved this — Android didn't have it

`BodyVitalReading` (VitalSignsSummary.swift) carries a metric-specific `missingCaption` and falls back to it when nothing resolved, so that *"an empty tile still says why instead of a bare dash"*. Android had no equivalent and showed `"No data"` for all six vitals. **This is a port, not a new design** — the wording is byte-identical to the Swift twin, so both platforms now say the same thing:

| tile | before (Android) | after (= Apple) |
|---|---|---|
| `spo2` | No data | **No SpO₂ import or Health value** |
| `spo2raw` | No data | No raw SpO₂ decode for the night |
| `skin` | No data | No nightly skin-temp value |
| `resp` | No data | No respiratory-rate value |
| `rhr` | No data | No resting HR value |
| `hrv` | No data | No HRV value |

The SpO₂ line is the #548 complaint directly: it tells the user the metric is import-sourced instead of implying the app looked and found nothing.

`Vital.missingCaption` is **required** (no default) so a new vital has to state its own reason rather than silently inheriting a generic one. The `spo2raw` branch is reordered (`key == "spo2raw" && band != NO_DATA -> "Uncalibrated"`) so its no-data case reaches `missingCaption` too; the decoded case is unchanged.

## Deliberately NOT localised

All six sibling captions in this same `when` (`"No data"`, `"Uncalibrated"`, `"In your range"`, …) are hardcoded English — as are `rangeCaption`'s `"within X -- Y"` and `CoupledScreen`'s three `a11y` strings. Localising only the new lines while their neighbours stay English would be incoherent. A German user reads English here today and still will — just an *informative* English rather than a misleading one, so no regression.

The caption layer wants localising as one coherent change, and the audit can't see any of it (`ANDROID_PATTERN` only matches literals directly after `Text(`). That's **#540**, and this PR is more evidence for it: the Health screen's entire caption layer plus the Recovery hero's screen-reader text are English-only, and Swift localises its twin (`String(localized:)`) while Android doesn't.

## Scope

**Does not** address the skin-temp half of #548. Showing "Calibrating, N of 4 nights" (the pattern `recoveryCalibrationNights` already established for Charge, #335) needs the nightly skin-temp **mean** the baseline folds — and `DailyMetric` carries only `skinTempDevC`, the deviation *output*, with no `skinCfg` exposed. That needs a persisted mean or a `skinTempSample` re-read plus duplicating `wornNightlySkinTempC`'s wear-gated logic. Not a caption change; tracked in #548.

No Swift change: Apple is the source being ported *from*.

## Verification

- `./gradlew compileFullDebugKotlin` ✓
- `./gradlew testFullDebugUnitTest --no-build-cache` → **2806/2806** (5 skipped)
- `Tools/i18n_audit.py --ci origin/main` → clean
- Wording asserted identical to the Swift twin's six `missingCaption` values

Presentation-only: no decode, schema, analytics, or BLE change.
