### PR TITLE
Fix Today steps analytics source

### DIFF
--- a/Strand/Data/MetricCatalog.swift
+++ b/Strand/Data/MetricCatalog.swift
@@ -156,6 +156,9 @@ enum MetricCatalog {
         // ── Effort (was Strain)
         d("strain", String(localized: "Effort"), "Effort", "/100", "my-whoop", "flame", 1, nil,
           String(localized: "Cardiovascular load for the day, on a 0-100 scale (was 0-21).")),
+        // WHOOP 5.0 / MG exposes a measured daily step count. Keep it separate from Apple Health's
+        // identically-keyed series so Today can open the same source it used for the displayed value.
+        d("steps", String(localized: "Steps"), "Effort", "steps", "my-whoop", "figure.walk", 0, true),
         d("steps", String(localized: "Steps"), "Effort", "", "apple-health", "figure.walk", 0, true),
         // On-device steps ESTIMATE for a WHOOP 4.0 (no real step count over BLE): the strap's daily
         // motion volume scaled by a personal calibration. Stored under the computed "-noop" source, so
@@ -205,6 +208,17 @@ enum MetricCatalog {
     ]
 
     static func inCategory(_ c: String) -> [MetricDescriptor] { all.filter { $0.category == c } }
+
+    static func metric(key: String, source: String) -> MetricDescriptor? {
+        all.first { $0.key == key && $0.source == source }
+    }
+
+    /// The Today screen prefers the measured WHOOP 5.0 / MG count and falls back to the WHOOP 4.0
+    /// motion estimate. Apple Health remains an independent catalog metric and is never substituted
+    /// for a WHOOP value after the tile has already chosen what to display.
+    static func todayStepsMetric(hasMeasuredSteps: Bool) -> MetricDescriptor? {
+        metric(key: hasMeasuredSteps ? "steps" : "steps_est", source: "my-whoop")
+    }
 
     /// Localized display name for a catalog category, mapped AT THE RENDER SITE only. The
     /// catalog's `category` VALUES stay English identifiers on purpose (`inCategory` and the

--- a/Strand/Liquid/LiquidTodayView.swift
+++ b/Strand/Liquid/LiquidTodayView.swift
@@ -623,7 +623,7 @@ struct LiquidTodayView: View {
                      value: unitText(displayDay?.respRateBpm, card.unit, decimals: 1),
                      tint: StrandPalette.accent, frac: fracOver(displayDay?.respRateBpm, 24))
         case .steps:
-            cardLink(.metric("steps_est"), title: card.title, sub: card.subtitle,
+            cardLink(.metric(stepsDetailKey), title: card.title, sub: card.subtitle,
                      value: stepsText, tint: StrandPalette.metricCyan, frac: fracOver(stepCount, 10000))
         case .bloodOxygen:
             // Not wired to a real read yet — render EMPTY (not half-full) so it doesn't imply a reading.
@@ -857,7 +857,8 @@ struct LiquidTodayView: View {
             let resp = displayDay?.respRateBpm ?? vitalsDay?.respRateBpm
             ktile(String(localized: "Respiratory"), resp.map { String(format: "%.1f", $0) } ?? "—", "rpm", StrandPalette.accent, fracOver(resp, 24), key: "resp_rate")
         case .steps:
-            ktile(String(localized: "Steps"), stepsText, "", StrandPalette.chargeColor, fracOver(stepCount, 10000), key: "steps")
+            ktile(String(localized: "Steps"), stepsText, "", StrandPalette.chargeColor,
+                  fracOver(stepCount, 10000), key: stepsDetailKey, detailMetric: stepsDetailMetric)
         case .weight:
             ktile(String(localized: "Weight"), "—", "", StrandPalette.metricAmber, nil, key: "weight")
         case .calories:
@@ -866,7 +867,7 @@ struct LiquidTodayView: View {
     }
 
     private func ktile(_ label: String, _ value: String, _ unit: String, _ tint: Color, _ frac: Double?,
-                       key: String? = nil) -> some View {
+                       key: String? = nil, detailMetric: MetricDescriptor? = nil) -> some View {
         let tile = VStack(alignment: .leading, spacing: 6) {
             Text(label.uppercased()).font(StrandFont.overlineScaled(9)).tracking(1.2)
                 .foregroundStyle(StrandPalette.textTertiary)
@@ -906,7 +907,9 @@ struct LiquidTodayView: View {
         // #430 parity: tap -> the metric's trend detail (the same Explore dossier its MetricRow pushes,
         // closure-based NavigationLink per #38). A metric with no catalog entry stays inert.
         return Group {
-            if let key, let metric = MetricCatalog.all.first(where: { $0.key == key }) {
+            if let metric = detailMetric ?? key.flatMap({ key in
+                MetricCatalog.all.first(where: { $0.key == key })
+            }) {
                 NavigationLink { MetricDetailView(metric: metric) } label: { tile }
                     .buttonStyle(.plain)
             } else {
@@ -1043,6 +1046,7 @@ struct LiquidTodayView: View {
                                                     days: sourceLookback)
 
         let restSeries = await restA
+        let stepsSeries = await stepsA
         let restByDay = Dictionary(restSeries.map { ($0.day, $0.value) }, uniquingKeysWith: { _, last in last })
         // Selected day's Rest; tail fallback only at offset 0 (a past day with no row shows nothing) AND
         // only when the tail night is still fresh. #977: a live 5.0 whose sleep never scores (no overnight
@@ -1073,6 +1077,9 @@ struct LiquidTodayView: View {
             "rhr": sparkRows.compactMap { r in r.restingHr.map { (r.day, Double($0)) } },
             "spo2": sparkRows.compactMap { r in r.spo2Pct.map { (r.day, $0) } },
             "resp_rate": sparkRows.compactMap { r in r.respRateBpm.map { (r.day, $0) } },
+            "steps": sparkRows.compactMap { r in r.steps.map { (r.day, Double($0)) } },
+            "steps_est": stepsSeries.filter { $0.day >= sparkCutoff && $0.day <= selectedDayKey }
+                .map { ($0.day, $0.value) },
             "sleep_performance": restSeries.filter { $0.day >= sparkCutoff && $0.day <= selectedDayKey }
                 .map { ($0.day, $0.value) },
         ]
@@ -1084,7 +1091,6 @@ struct LiquidTodayView: View {
         // Steps is a DAILY metric, so key it to the SELECTED day (like restScore above), not the history-wide
         // latest. Without this, swiping to a past day with no strap step count showed today's estimate (the
         // `.last` value) instead of that day's. Mirrors the classic Today's stepsEstByDay[selectedDayKey].
-        let stepsSeries = await stepsA
         let stepsByDay = Dictionary(stepsSeries.map { ($0.day, $0.value) }, uniquingKeysWith: { _, last in last })
         stepsEst = stepsByDay[selectedDayKey] ?? (selectedDayOffset == 0 ? stepsSeries.last?.value : nil)
         hrValues = (await hrA).map { $0.bpm }
@@ -1166,6 +1172,12 @@ struct LiquidTodayView: View {
     }
 
     private var stepCount: Double? { displayDay?.steps.map(Double.init) ?? stepsEst }
+
+    private var stepsDetailMetric: MetricDescriptor? {
+        MetricCatalog.todayStepsMetric(hasMeasuredSteps: displayDay?.steps != nil)
+    }
+
+    private var stepsDetailKey: String { stepsDetailMetric?.key ?? "steps_est" }
 
     private var liveHour: Double {
         let c = Calendar.current.dateComponents([.hour, .minute], from: Date())

--- a/StrandTests/MetricCatalogStepsTests.swift
+++ b/StrandTests/MetricCatalogStepsTests.swift
@@ -1,0 +1,25 @@
+import XCTest
+@testable import Strand
+
+final class MetricCatalogStepsTests: XCTestCase {
+    func testTodayStepsUsesMeasuredWhoopSeriesWhenAvailable() {
+        let metric = MetricCatalog.todayStepsMetric(hasMeasuredSteps: true)
+
+        XCTAssertEqual(metric?.key, "steps")
+        XCTAssertEqual(metric?.source, "my-whoop")
+        XCTAssertEqual(MetricCatalog.all.first(where: { $0.key == "steps" })?.source, "my-whoop")
+    }
+
+    func testTodayStepsUsesWhoopFourEstimateWhenMeasuredSeriesIsUnavailable() {
+        let metric = MetricCatalog.todayStepsMetric(hasMeasuredSteps: false)
+
+        XCTAssertEqual(metric?.key, "steps_est")
+        XCTAssertEqual(metric?.source, "my-whoop")
+    }
+
+    func testAppleHealthStepsRemainsAnIndependentCatalogMetric() {
+        let metric = MetricCatalog.metric(key: "steps", source: "apple-health")
+
+        XCTAssertEqual(metric?.id, "apple-health:steps")
+    }
+}


### PR DESCRIPTION
## What changed

- add a measured `my-whoop/steps` catalog metric for WHOOP 5.0 / MG
- route Today step cards to the source that supplied the displayed value
- keep WHOOP 4.0 motion estimates on `my-whoop/steps_est`
- keep Apple Health steps as an independent catalog metric
- populate detailed Today sparklines for measured and estimated steps
- add regression coverage for WHOOP and Apple Health source selection

## Why

The Today screen displayed the measured daily step count from a WHOOP 5.0 / MG, but tapping the tile resolved the first catalog entry with the `steps` key. That entry belonged to Apple Health, so the detail screen queried `apple-health/steps` and appeared empty when only WHOOP data existed. A separate dashboard card always routed to `steps_est`, even when its displayed value was measured.

The destination now follows the value shown by the tile: measured WHOOP steps when available, otherwise the WHOOP 4.0 estimate. Apple Health data remains available through its own catalog entry.

## Validation

- `git diff --check`
- Swift syntax parse of the modified source and test files
- regression tests added in `MetricCatalogStepsTests`

Full XCTest execution was not available locally because the machine has Command Line Tools but not a full Xcode installation; the PR CI should run the generated Xcode project build.
