### PR TITLE
Backup & Sync: macOS twin of the restore-list diagnostics (#278)

### DIFF
--- a/Strand/Data/BackupSync.swift
+++ b/Strand/Data/BackupSync.swift
@@ -278,6 +278,19 @@ enum FolderBackup {
         await backupNow(checkpoint: checkpoint)
     }
 
+    /// Diagnostic-only snapshot of the restore list's health: the chosen folder's name, its raw entry
+    /// count, and how many of those resolve into recognized `.noopbak` snapshots. Nil when no folder is
+    /// chosen. Lets a "restore shows no files" report (#278) distinguish a genuinely empty folder from a
+    /// resolution problem (e.g. undownloaded iCloud placeholders, see `iCloudPlaceholderRealName`)
+    /// without needing a live repro. Used by `DebugDataDiagnostics`.
+    static func restoreListHealth() -> (folderName: String, rawEntries: Int, snapshots: Int)? {
+        guard let folder = resolveFolder() else { return nil }
+        let scoped = folder.startAccessingSecurityScopedResource()
+        defer { if scoped { folder.stopAccessingSecurityScopedResource() } }
+        let raw = (try? FileManager.default.contentsOfDirectory(atPath: folder.path))?.count ?? 0
+        return (folder.lastPathComponent, raw, listSnapshots().count)
+    }
+
     // MARK: - Restore from the configured folder (must-fix #1)
 
     /// One restorable snapshot in the chosen folder: its display name + a friendly absolute-time line.

--- a/Strand/System/DebugDataDiagnostics.swift
+++ b/Strand/System/DebugDataDiagnostics.swift
@@ -60,6 +60,19 @@ enum DebugDataDiagnostics {
         }
         lines.append("Backup mode:  \(FolderBackup.useInternalFolder ? "NOOP's own folder (#52 fallback)" : (FolderBackup.hasFolder ? "external folder" : "none chosen"))")
         #endif
+        #if os(macOS)
+        // #278: macOS Backup & Sync restore-list health. When a user reports "restore shows no files",
+        // this pins whether a folder is even configured and whether its raw entries are being recognized
+        // as backups — a folder with real snapshots but 0 recognized (e.g. an undownloaded iCloud Drive
+        // placeholder, see `BackupSync.iCloudPlaceholderRealName`) looks very different from a genuinely
+        // empty folder, and neither was visible in a debug export before this.
+        if let health = FolderBackup.restoreListHealth() {
+            lines.append("Backup folder: \(health.folderName)")
+            lines.append("Restore list: \(health.snapshots) snapshot(s) recognized of \(health.rawEntries) folder entrie(s)")
+        } else {
+            lines.append("Backup folder: none chosen")
+        }
+        #endif
         lines.append("Timezone:    \(tzLine())")
         return lines
     }


### PR DESCRIPTION
## Summary

Both #278 and #52 already have merged fixes on `main` (#293 for #278's iCloud-placeholder restore-list bug; #292/the internal-folder fallback for #52's iOS picker issue). While confirming that against current code, I noticed `DebugDataDiagnostics`' Backup & Sync block (added for #52) is `#if os(iOS)`-only — so a macOS "restore shows no files" report (like #278) has no equivalent diagnostic trail to work from in a debug export.

This adds a macOS-side block: the configured folder's name, its raw entry count, and how many of those resolve into recognized `.noopbak` snapshots. A folder with real backups but 0 recognized snapshots (the #278 undownloaded-iCloud-placeholder case) now shows up directly, without needing a live repro from the reporter.

## Changes
- `FolderBackup.restoreListHealth()` (`Strand/Data/BackupSync.swift`) — new, read-only, reuses existing `resolveFolder()`/`listSnapshots()`.
- `DebugDataDiagnostics.strapStateLines()` (`Strand/System/DebugDataDiagnostics.swift`) — new `#if os(macOS)` block, mirroring the existing iOS folder-picker block.

No change to backup, restore, or bookmark behavior on either platform.

## Test plan
- [x] `xcodegen generate && xcodebuild -project Strand.xcodeproj -scheme Strand -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO build` — clean, since `app-build.yml` doesn't run by default.
- [x] Same for `-scheme NOOPiOS -destination 'generic/platform=iOS Simulator'` (shared-file compile check).
- [ ] Not tested against a real iCloud Drive placeholder file on hardware — this only adds read-only diagnostic lines, doesn't change restore/backup logic.