### PR TITLE
i18n_audit: catch UI literals hidden behind if/else, when, and .let (#540)

### DIFF
--- a/Tools/i18n_audit.py
+++ b/Tools/i18n_audit.py
@@ -26,7 +26,6 @@ from __future__ import annotations
 import argparse
 import json
 import re
-import subprocess
 import sys
 import xml.etree.ElementTree as ET
 from pathlib import Path
@@ -43,6 +42,12 @@ UNIVERSAL = {
     "NOOP", "bpm", "BPM", "HRV", "SpO2", "SpO₂", "OK", "ID",
 }
 
+# A bare printf/String.format conversion specifier, e.g. "%.1f" or "%02d" — a
+# format string, not translatable copy. `re.search(r"[A-Za-z]", s)` alone
+# can't tell these apart from real text, since the conversion character
+# itself (f/d/s/...) counts as a letter.
+PURE_FORMAT_SPEC = re.compile(r"^%[-+0 #,(]*\d*(?:\.\d+)?[sdifoxXeEgGcC]$")
+
 
 def is_probably_ui_text(s: str) -> bool:
     """Filter out obvious non-UI-text matches (identifiers, tags, formats)."""
@@ -50,6 +55,8 @@ def is_probably_ui_text(s: str) -> bool:
         return False
     if not re.search(r"[A-Za-z]", s):
         return False  # pure symbols/numbers/format specifiers
+    if PURE_FORMAT_SPEC.fullmatch(s):
+        return False
     # snake_case / dotted / slashed identifiers (testTags, routes, keys) —
     # real UI copy almost always has a space or is a capitalized single word.
     if re.fullmatch(r"[a-z][a-z0-9_./]*", s) and " " not in s:
@@ -57,6 +64,181 @@ def is_probably_ui_text(s: str) -> bool:
     if s.startswith("http://") or s.startswith("https://"):
         return False
     return True
+
+
+# ---------------------------------------------------------------------------
+# Balanced-span scanning helpers (shared by Android and Apple below)
+# ---------------------------------------------------------------------------
+#
+# A flat regex that requires the literal to sit immediately after the opening
+# paren/`=` only sees `Text("Save")`. `Text(if (saved) "Saved" else "Save")` —
+# a real, shipped shape (#540) — slides straight past: `Text(` is followed by
+# `if`, not `"`. These walk the actual bracket structure instead, so a literal
+# anywhere inside a call/kwarg's OWN argument expression is visible regardless
+# of what control-flow construct (if/else, when, ?:, .let) puts it there —
+# without also sweeping into an unrelated NESTED composable's own slot lambda
+# (a `title = { Column { /* a separate, separately-scanned subtree */ } }`),
+# which is a different bug (489 spurious findings, not 7) than the one this
+# is fixing.
+
+
+def _skip_string_literal(text: str, i: int) -> int:
+    """`text[i]` is the opening `"` of a string literal; return the index just
+    past its closing `"`, honoring backslash escapes AND Kotlin/Swift string-
+    template interpolation (`${expr}` / `\\(expr)`), which can itself contain
+    a nested string literal (e.g. the pluralization idiom
+    `"${if (n == 1) "day" else "days"}"`) — a naive scan for the next `"`
+    would end the OUTER literal early on the interpolated one's opening quote."""
+    i += 1
+    while i < len(text):
+        ch = text[i]
+        if ch == "\\" and i + 1 < len(text):
+            i += 2
+            continue
+        if ch == "$" and i + 1 < len(text) and text[i + 1] == "{":
+            i += 2
+            depth = 1
+            while i < len(text) and depth:
+                c2 = text[i]
+                if c2 == '"':
+                    i = _skip_string_literal(text, i)
+                    continue
+                if c2 == "{":
+                    depth += 1
+                elif c2 == "}":
+                    depth -= 1
+                i += 1
+            continue
+        if ch == '"':
+            return i + 1
+        i += 1
+    return i
+
+
+def _argument_span_end(text: str, start: int) -> int:
+    """`start` is just after a call's `(` or a kwarg's `=`; return the index
+    where that single argument's expression ends — the next top-level comma,
+    or the bracket that closes the enclosing call/lambda."""
+    depth = 0
+    i = start
+    while i < len(text):
+        ch = text[i]
+        if ch == '"':
+            i = _skip_string_literal(text, i)
+            continue
+        if ch in "({[":
+            depth += 1
+        elif ch in ")}]":
+            if depth == 0:
+                return i
+            depth -= 1
+        elif ch == "," and depth == 0:
+            return i
+        i += 1
+    return i
+
+
+_TRANSPARENT_BARE_KEYWORDS = {"else", "try", "finally", "when"}
+_TRANSPARENT_PAREN_KEYWORDS = {"if", "when", "catch"}
+
+
+def _word_before(text: str, end: int, limit: int) -> tuple[str, int]:
+    """The identifier/keyword ending just before `end` (not before `limit`),
+    and the index of its first character."""
+    start = end
+    while start > limit and (text[start - 1].isalnum() or text[start - 1] == "_"):
+        start -= 1
+    return text[start:end], start
+
+
+def _brace_is_transparent(text: str, brace_idx: int, span_start: int) -> bool:
+    """Should the literal-extraction walk look INSIDE `text[brace_idx]` (a
+    `{`), or skip its whole balanced body untouched?
+
+    Transparent for the Kotlin idioms that this codebase actually uses to
+    conditionally pick a string: `if (...) { }`, `when (...) { }` / bare
+    `when { }`, `catch (...) { }`, bare `else`/`try`/`finally`, and
+    `.let { }` / `?.let { }` (used as a null-coalescing ternary substitute
+    here, typically paired with `?:`). Opaque for everything else — an
+    assignment's trailing lambda, a `Column { }` or other composable slot —
+    because that is a SEPARATE, independently-composed subtree that the
+    file-wide call/kwarg scan discovers and scans on its own when it reaches
+    the calls nested inside it directly; sweeping it again from here is how
+    the first cut at this fix produced 489 findings instead of a few dozen.
+
+    Deliberately no fixed lookback window (an early draft's 60-char window
+    sat exactly on the edge of a real `when (...)` subject in this codebase
+    — see RhythmScreen.kt:309): walks backward through at most one balanced
+    `(...)` and checks the keyword immediately behind it.
+    """
+    i = brace_idx - 1
+    while i >= span_start and text[i].isspace():
+        i -= 1
+    if i < span_start:
+        return False
+    if text[i] == ")":
+        depth = 1
+        j = i - 1
+        while j >= span_start and depth:
+            if text[j] == ")":
+                depth += 1
+            elif text[j] == "(":
+                depth -= 1
+            j -= 1
+        k = j
+        while k >= span_start and text[k].isspace():
+            k -= 1
+        word, _ = _word_before(text, k + 1, span_start)
+        return word in _TRANSPARENT_PAREN_KEYWORDS
+    word, word_start = _word_before(text, i + 1, span_start)
+    if word in _TRANSPARENT_BARE_KEYWORDS:
+        return True
+    if word == "let" and word_start > span_start and text[word_start - 1] == ".":
+        return True
+    return False
+
+
+def _extract_literals(text: str, start: int, end: int) -> list[tuple[int, str]]:
+    """(offset, content) for every literal directly reachable within
+    text[start:end] — descending transparently through `(`/`[` and through
+    any `{` that `_brace_is_transparent` calls a control-flow block, skipping
+    the whole balanced body of any other `{` untouched. Skips a literal whose
+    nearest preceding non-whitespace token is `+`: string concatenation
+    (typically `uiString(R.string.x) + "hardcoded suffix"`) is a real but
+    DIFFERENT, larger bug (partial localization via an engineered prefix) —
+    deliberately out of scope here, tracked separately."""
+    out: list[tuple[int, str]] = []
+    i = start
+    while i < end:
+        ch = text[i]
+        if ch == '"':
+            j = _skip_string_literal(text, i)
+            prev = i - 1
+            while prev >= start and text[prev].isspace():
+                prev -= 1
+            if prev < start or text[prev] != "+":
+                out.append((i, text[i + 1:j - 1]))
+            i = j
+            continue
+        if ch == "{":
+            if _brace_is_transparent(text, i, start):
+                i += 1
+                continue
+            depth = 1
+            i += 1
+            while i < end and depth:
+                c2 = text[i]
+                if c2 == '"':
+                    i = _skip_string_literal(text, i)
+                    continue
+                if c2 in "({[":
+                    depth += 1
+                elif c2 in ")}]":
+                    depth -= 1
+                i += 1
+            continue
+        i += 1
+    return out
 
 
 # ---------------------------------------------------------------------------
@@ -68,12 +250,57 @@ ANDROID_DIRS = [
     ROOT / "android/app/src/main/java/com/noop/widget",
 ]
 
-# First positional/named string-literal argument to a UI-text-bearing call.
-ANDROID_PATTERN = re.compile(
-    r"\b(?:Text|Snackbar|AlertDialog|TopAppBar)\s*\(\s*\"((?:[^\"\\]|\\.)*)\""
-    r"|"
-    r"\b(?:title|label|text|contentDescription|placeholder)\s*=\s*\"((?:[^\"\\]|\\.)*)\""
-)
+# `AlertDialog` is deliberately NOT in this list: confirmed (all 22 call sites
+# in this codebase) it never takes its text as a positional argument, only as
+# `title=`/`text=` kwargs — those are covered by ANDROID_KWARG_PATTERN below.
+# `Snackbar(`/`TopAppBar(` do not currently appear anywhere in this codebase;
+# kept for whatever future call sites use them, since `Text(` always does
+# take its content as the first argument here.
+ANDROID_CALL_PATTERN = re.compile(r"\b(?:Text|Snackbar|TopAppBar)\s*\(")
+ANDROID_KWARG_PATTERN = re.compile(r"\b(?:title|label|text|contentDescription|placeholder)\s*=\s*")
+
+
+def _mask_comments(text: str) -> str:
+    """`text` with `//...` and `/* ... */` comment BODIES blanked out (same
+    length, spaces, newlines preserved) so a quoted-looking phrase inside a
+    comment can never be mistaken for a real string literal — and so a stray
+    bracket inside a comment can't confuse the depth-tracking helpers above.
+    String-literal-aware: a `//`/`/*` that appears inside an actual string
+    isn't a comment start."""
+    out = list(text)
+    i = 0
+    n = len(text)
+    while i < n:
+        ch = text[i]
+        if ch == '"':
+            i = _skip_string_literal(text, i)
+            continue
+        if ch == "/" and i + 1 < n and text[i + 1] == "/":
+            j = i
+            while j < n and text[j] != "\n":
+                out[j] = " "
+                j += 1
+            i = j
+            continue
+        if ch == "/" and i + 1 < n and text[i + 1] == "*":
+            j = i
+            while j < n and not (text[j] == "*" and j + 1 < n and text[j + 1] == "/"):
+                if text[j] != "\n":
+                    out[j] = " "
+                j += 1
+            if j < n:
+                out[j] = out[j + 1] = " "
+                j += 2
+            i = j
+            continue
+        i += 1
+    return "".join(out)
+
+
+# Only an argument in actual call-argument position (right after `(` or `,`,
+# modulo whitespace) — excludes `val text = when { "Awake" -> ...; ... }`,
+# a plain local declaration this keyword list would otherwise also match.
+_PRECEDED_BY_ARG_BOUNDARY = re.compile(r"[(,]\s*\Z")
 
 
 def scan_android() -> list[tuple[str, int, str]]:
@@ -82,13 +309,34 @@ def scan_android() -> list[tuple[str, int, str]]:
         if not base.exists():
             continue
         for path in sorted(base.rglob("*.kt")):
-            text = path.read_text(encoding="utf-8", errors="replace")
-            for m in ANDROID_PATTERN.finditer(text):
-                literal = m.group(1) or m.group(2)
-                if literal is None or not is_probably_ui_text(literal):
+            raw = path.read_text(encoding="utf-8", errors="replace")
+            text = _mask_comments(raw)
+            seen: set[int] = set()
+
+            def record(span_start: int, span_end: int) -> None:
+                for offset, literal in _extract_literals(text, span_start, span_end):
+                    if offset in seen or not is_probably_ui_text(literal):
+                        continue
+                    seen.add(offset)
+                    line_no = text.count("\n", 0, offset) + 1
+                    findings.append((str(path.relative_to(ROOT)), line_no, literal))
+
+            # The call's own first (content) argument only — catches
+            # `Text(if (x) "a" else "b")` — never the whole call span, which
+            # would also sweep in an unrelated later argument's own nested
+            # composables (see module docstring above `_extract_literals`).
+            for m in ANDROID_CALL_PATTERN.finditer(text):
+                open_paren = m.end() - 1
+                record(open_paren + 1, _argument_span_end(text, open_paren + 1))
+
+            # `title = if (x) "a" else "b"` / `AlertDialog(text = { Text(if
+            # (x) "a" else "b") })` — any call this scanner doesn't otherwise
+            # recognize by name, including AlertDialog's named slots.
+            for m in ANDROID_KWARG_PATTERN.finditer(text):
+                if not _PRECEDED_BY_ARG_BOUNDARY.search(text, 0, m.start()):
                     continue
-                line_no = text.count("\n", 0, m.start()) + 1
-                findings.append((str(path.relative_to(ROOT)), line_no, literal))
+                record(m.end(), _argument_span_end(text, m.end()))
+
     return findings
 
 
@@ -198,9 +446,9 @@ CATALOGS = [
 ]
 
 SWIFT_CALL_START_PATTERN = re.compile(
-    r"\b(?:Text|Button|Label|Toggle|Menu|Picker|ProgressView|SectionHeader)\s*\(\s*\""
+    r"\b(?:Text|Button|Label|Toggle|Menu|Picker|ProgressView|SectionHeader)\s*\("
     r"|"
-    r"\.(?:navigationTitle|confirmationDialog|alert)\s*\(\s*\""
+    r"\.(?:navigationTitle|confirmationDialog|alert|accessibilityLabel|help)\s*\("
 )
 
 # A placeholder generated by Swift's LocalizedStringKey interpolation. The
@@ -210,49 +458,100 @@ SWIFT_CALL_START_PATTERN = re.compile(
 CATALOG_PLACEHOLDER_PATTERN = r"%(?:(?:\d+)\$)?(?:@|[-+0 #']*(?:\d+|\*)?(?:\.\d+|\.\*)?(?:hh|h|ll|l|q|z|t|j)?[diuoxXfFeEgGaAcCsSp])"
 
 
-def swift_string_literals(text: str):
-    """Yield (match offset, literal contents) for localized SwiftUI calls.
+def _skip_swift_string_literal(text: str, i: int) -> int:
+    """`text[i]` is the opening `"` of a Swift string literal; return the
+    index just past its closing `"`, honoring backslash escapes AND
+    `\\(expr)` interpolation, which can itself contain a nested string
+    literal (`Text("\\(String(format: "%.1f", value)) bpm")`) — a naive scan
+    for the next `"` would end the OUTER literal early on that one."""
+    i += 1
+    while i < len(text):
+        ch = text[i]
+        if ch == "\\" and i + 1 < len(text):
+            if text[i + 1] == "(":
+                i += 2
+                depth = 1
+                while i < len(text) and depth:
+                    c2 = text[i]
+                    if c2 == '"':
+                        i = _skip_swift_string_literal(text, i)
+                        continue
+                    if c2 == "(":
+                        depth += 1
+                    elif c2 == ")":
+                        depth -= 1
+                    i += 1
+                continue
+            i += 2
+            continue
+        if ch == '"':
+            return i + 1
+        i += 1
+    return i
 
-    A regex that stops at the next quote breaks on interpolation expressions
-    such as ``Text("\\(String(format: "%.1f", value)) bpm")``. This small
-    scanner understands balanced ``\\(...)`` expressions and quoted strings
-    inside them, while leaving the literal in source form for catalog lookup.
+
+def _swift_argument_span_end(text: str, start: int) -> int:
+    """`start` is just after a call's `(`; return the index where its first
+    argument's expression ends — the next top-level comma, or the bracket
+    that closes the call."""
+    depth = 0
+    i = start
+    while i < len(text):
+        ch = text[i]
+        if ch == '"':
+            i = _skip_swift_string_literal(text, i)
+            continue
+        if ch in "({[":
+            depth += 1
+        elif ch in ")}]":
+            if depth == 0:
+                return i
+            depth -= 1
+        elif ch == "," and depth == 0:
+            return i
+        i += 1
+    return i
+
+
+def swift_string_literals(text: str):
+    """Yield (offset, literal contents) for every literal directly reachable
+    in a localized SwiftUI call's FIRST argument — descends transparently
+    through `(`/`[` (so `cond ? "a" : "b"` and nested calls are visible) but
+    skips any `{...}` untouched (a SwiftUI trailing closure, e.g.
+    `Button(action: { ... }) { Text("...") }`'s `action:` closure — not text,
+    and whatever real text a trailing closure DOES carry, like that
+    example's `Text("...")`, is found independently when the file-wide scan
+    reaches it directly). Previously required the literal immediately after
+    the call's `(`, so `Text(cond ? "Off" : "On")` was invisible — not just
+    to this audit, but functionally: that ternary resolves to SwiftUI's
+    non-localizing `Text<S: StringProtocol>` overload, so it was always
+    English regardless of device language (#540).
     """
     for match in SWIFT_CALL_START_PATTERN.finditer(text):
-        start = match.end() - 1
-        i = start + 1
-        interpolation_depth = 0
-        while i < len(text):
+        open_paren = match.end() - 1
+        end = _swift_argument_span_end(text, open_paren + 1)
+        i = open_paren + 1
+        while i < end:
             ch = text[i]
-            if interpolation_depth == 0:
-                if ch == '"':
-                    yield match.start(), text[start + 1:i]
-                    break
-                if ch == "\\" and i + 1 < len(text):
-                    if text[i + 1] == "(":
-                        interpolation_depth = 1
-                    i += 2
-                    continue
-                i += 1
-                continue
-
-            # Inside an interpolation expression, ignore parentheses in a
-            # nested Swift string and otherwise balance the expression.
             if ch == '"':
-                i += 1
-                while i < len(text):
-                    if text[i] == "\\" and i + 1 < len(text):
-                        i += 2
-                    elif text[i] == '"':
-                        i += 1
-                        break
-                    else:
-                        i += 1
+                j = _skip_swift_string_literal(text, i)
+                yield i, text[i + 1:j - 1]
+                i = j
                 continue
-            if ch == "(":
-                interpolation_depth += 1
-            elif ch == ")":
-                interpolation_depth -= 1
+            if ch == "{":
+                depth = 1
+                i += 1
+                while i < end and depth:
+                    c2 = text[i]
+                    if c2 == '"':
+                        i = _skip_swift_string_literal(text, i)
+                        continue
+                    if c2 in "({[":
+                        depth += 1
+                    elif c2 in ")}]":
+                        depth -= 1
+                    i += 1
+                continue
             i += 1
 
 
@@ -427,67 +726,67 @@ def scan_ios() -> tuple[list[tuple[str, int, str]], dict[str, list[str]]]:
     return hardcoded, lang_gaps
 
 
-def git_show(ref: str, rel_path: str) -> str | None:
-    """File content at `ref`, or None if the path didn't exist there."""
-    result = subprocess.run(
-        ["git", "show", f"{ref}:{rel_path}"],
-        cwd=ROOT, capture_output=True, text=True,
+BASELINE_PATH = ROOT / "Tools/i18n_audit_baseline.json"
+
+
+def load_baseline() -> dict[str, set[tuple[str, str]]]:
+    """Pre-existing hardcoded-literal findings, keyed by (path, literal) —
+    not line number, which drifts on any unrelated edit to the same file.
+
+    #540's scanner fix went from missing whole classes of conditionally-
+    hidden literals (7 known Android sites) to correctly finding 248 real
+    ones once it could see through if/else, when, and .let — far more than
+    one PR can respect while writing careful, non-machine-slop translations
+    for (see #543 on what rushing that produces). This baseline lets the
+    scanner itself land immediately — CI blocks any NEW hardcoded literal
+    from this point on — while the pre-existing backlog is closed
+    incrementally in separate, appropriately-sized follow-up PRs. Regenerate
+    with `--update-baseline` after closing some of it; an entry that no
+    longer appears in a fresh scan is simply inert, not an error."""
+    if not BASELINE_PATH.exists():
+        return {"android": set(), "ios": set()}
+    data = json.loads(BASELINE_PATH.read_text(encoding="utf-8"))
+    return {
+        "android": {(p, lit) for p, lit in data.get("android", [])},
+        "ios": {(p, lit) for p, lit in data.get("ios", [])},
+    }
+
+
+def write_baseline() -> None:
+    android = sorted({(p, lit) for p, _line, lit in scan_android()})
+    ios_hardcoded, _gaps = scan_ios()
+    ios = sorted({(p, lit) for p, _line, lit in ios_hardcoded})
+    BASELINE_PATH.write_text(
+        json.dumps({"android": android, "ios": ios}, indent=2, ensure_ascii=False) + "\n",
+        encoding="utf-8",
     )
-    return result.stdout if result.returncode == 0 else None
-
-
-def literals_at_ref(ref: str) -> tuple[set[tuple[str, str]], set[tuple[str, str]]]:
-    """(android, ios) sets of (relative_path, literal) hardcoded findings as they
-    stood at `ref`, using the CURRENT file list (a file added by the PR simply
-    reads as empty at the base ref, which correctly counts its literals as new)."""
-    android: set[tuple[str, str]] = set()
-    for base in ANDROID_DIRS:
-        if not base.exists():
-            continue
-        for path in sorted(base.rglob("*.kt")):
-            rel = str(path.relative_to(ROOT))
-            text = git_show(ref, rel) or ""
-            for m in ANDROID_PATTERN.finditer(text):
-                literal = m.group(1) or m.group(2)
-                if literal is None or not is_probably_ui_text(literal):
-                    continue
-                android.add((rel, literal))
-
-    ios: set[tuple[str, str]] = set()
-    for dirs, catalog_path in CATALOGS:
-        cat_text = git_show(ref, str(catalog_path.relative_to(ROOT)))
-        cat = json.loads(cat_text) if cat_text else {"strings": {}}
-        for base in dirs:
-            if not base.exists():
-                continue
-            for path in sorted(base.rglob("*.swift")):
-                rel = str(path.relative_to(ROOT))
-                text = git_show(ref, rel) or ""
-                for _offset, literal in swift_string_literals(text):
-                    if not is_probably_ui_text(literal):
-                        continue
-                    if swift_catalog_lookup(cat, literal) is None:
-                        ios.add((rel, literal))
-    return android, ios
+    print(f"Wrote {len(android)} android + {len(ios)} ios entries to {BASELINE_PATH.relative_to(ROOT)}")
 
 
 def ci_check(base_ref: str) -> int:
-    """Strict CI gate: the #453 backlog is closed, so every focus language and
-    every audited UI literal must remain complete. ``base_ref`` remains in the
-    CLI for workflow compatibility but coverage is now a standing invariant,
-    not a diff-scoped allowance.
+    """Strict CI gate: the #453 backlog is closed, so every focus language
+    translation must remain complete, and no NEW hardcoded literal may land
+    (pre-existing ones are tracked in the baseline — see load_baseline()).
+    ``base_ref`` remains in the CLI for workflow compatibility but coverage
+    is now a standing invariant, not a diff-scoped allowance.
     """
     failed = False
+    baseline = load_baseline()
 
-    print("--- Android: no hardcoded UI copy and complete focus locales ---")
+    print("--- Android: no NEW hardcoded UI copy, and complete focus locales ---")
     android_literals = scan_android()
-    if android_literals:
+    android_found = {(p, lit) for p, _line, lit in android_literals}
+    android_new = [f for f in android_literals if (f[0], f[2]) not in baseline["android"]]
+    if android_new:
         failed = True
-        print(f"FAIL {len(android_literals)} hardcoded literal(s):")
-        for path, line, literal in android_literals[:30]:
+        print(f"FAIL {len(android_new)} NEW hardcoded literal(s) (not in {BASELINE_PATH.relative_to(ROOT)}):")
+        for path, line, literal in android_new[:30]:
             print(f"  {path}:{line}: {literal!r}")
     else:
-        print("  OK no hardcoded literals")
+        print(f"  OK no new hardcoded literals ({len(android_found)} pre-existing, tracked in the baseline)")
+    android_fixed = baseline["android"] - android_found
+    if android_fixed:
+        print(f"  {len(android_fixed)} baseline entr(y/ies) no longer found — run --update-baseline to shrink the backlog")
     android_gaps = android_strings_xml_gaps()
     android_formats = android_format_gaps()
     for lang in LANGS:
@@ -502,15 +801,20 @@ def ci_check(base_ref: str) -> int:
             failed = True
             print(f"FAIL values-{lang}/strings.xml has {len(format_gaps)} format mismatch(es): {format_gaps[:30]}")
 
-    print("\n--- Apple: no un-extracted UI copy and complete focus locales ---")
+    print("\n--- Apple: no NEW un-extracted UI copy, and complete focus locales ---")
     ios_literals, _source_gaps = scan_ios()
-    if ios_literals:
+    ios_found = {(p, lit) for p, _line, lit in ios_literals}
+    ios_new = [f for f in ios_literals if (f[0], f[2]) not in baseline["ios"]]
+    if ios_new:
         failed = True
-        print(f"FAIL {len(ios_literals)} literal(s) absent from their target catalog:")
-        for path, line, literal in ios_literals[:30]:
+        print(f"FAIL {len(ios_new)} NEW literal(s) absent from their target catalog:")
+        for path, line, literal in ios_new[:30]:
             print(f"  {path}:{line}: {literal!r}")
     else:
-        print("  OK no un-extracted literals")
+        print(f"  OK no new un-extracted literals ({len(ios_found)} pre-existing, tracked in the baseline)")
+    ios_fixed = baseline["ios"] - ios_found
+    if ios_fixed:
+        print(f"  {len(ios_fixed)} baseline entr(y/ies) no longer found — run --update-baseline to shrink the backlog")
     for _dirs, catalog_path in CATALOGS:
         cat = load_catalog(catalog_path)
         for lang in LANGS:
@@ -555,7 +859,12 @@ def main() -> int:
     ap.add_argument("--platform", choices=["ios", "android", "all"], default="all")
     ap.add_argument("--full", action="store_true", help="print every finding, not just counts")
     ap.add_argument("--ci", metavar="BASE_REF", help="strict coverage gate (BASE_REF is retained for workflow compatibility); see ci_check() docstring")
+    ap.add_argument("--update-baseline", action="store_true", help="rewrite Tools/i18n_audit_baseline.json from the current hardcoded-literal scan (see load_baseline() docstring)")
     args = ap.parse_args()
+
+    if args.update_baseline:
+        write_baseline()
+        return 0
 
     if args.ci:
         return ci_check(args.ci)

--- a/Tools/i18n_audit_baseline.json
+++ b/Tools/i18n_audit_baseline.json
@@ -1,0 +1,942 @@
+{
+  "android": [
+    [
+      "android/app/src/main/java/com/noop/ui/AddDeviceWizard.kt",
+      "The most common cause is the ring was not fully reset in the Oura app, or the Oura "
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/BackupSyncScreen.kt",
+      "Back up now"
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/BackupSyncScreen.kt",
+      "Change folder"
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/BackupSyncScreen.kt",
+      "Choose folder"
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/BackupSyncScreen.kt",
+      "Last backup: ${DateUtils.getRelativeTimeSpanString(lastMs)}"
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/BackupSyncScreen.kt",
+      "No backup yet."
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/BackupSyncScreen.kt",
+      "No folder chosen yet. Pick one your cloud app already syncs, or any local folder."
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/BackupSyncScreen.kt",
+      "Saving to: ${folderLabel(it)}"
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/BackupSyncScreen.kt",
+      "Working…"
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/BreatheScreen.kt",
+      "%.1f br/min"
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/BreatheScreen.kt",
+      "Start session"
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/BreatheScreen.kt",
+      "Stop session"
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/BreatheScreen.kt",
+      "Sweeping…"
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/CaffeineLog.kt",
+      "About ${it.roundToInt()} mg may still be active"
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/CaffeineLog.kt",
+      "Caffeine may still be active"
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/CaffeineLog.kt",
+      "Estimated mostly cleared. Nothing logged is likely still active."
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/CaffeineLog.kt",
+      "No caffeine logged. Log an intake to see an estimate."
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/CoachScreen.kt",
+      "Bring your own API key. It is stored encrypted on this device and only used to "
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/CoachScreen.kt",
+      "Customised. Your edited instructions frame every reply."
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/CoachScreen.kt",
+      "Edit how the coach thinks and talks. Takes effect on your next message."
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/CoachScreen.kt",
+      "Fetching…"
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/CoachScreen.kt",
+      "Off: the coach answers generally and sends none of your metrics."
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/CoachScreen.kt",
+      "On: your recovery, sleep, HRV and workouts are shared with the provider for tailored coaching."
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/CoachScreen.kt",
+      "Only if your server requires one"
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/CoachScreen.kt",
+      "Paste your ${provider.displayName} key"
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/CoachScreen.kt",
+      "Point the coach at any OpenAI-compatible server: a local model (Ollama, LM "
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/CoachScreen.kt",
+      "Private by default: only your question and a short metrics summary are sent, "
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/CoachScreen.kt",
+      "Refresh models"
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/CoachScreen.kt",
+      "The coach talks only to the server URL you set. Point it at a local model to "
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/CompareScreen.kt",
+      "Add metric"
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/CompareScreen.kt",
+      "Each line min-max normalized within ${range.phrase}"
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/CompareScreen.kt",
+      "Each line min-max normalized · sparse series widened past ${range.phrase}"
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/CompareScreen.kt",
+      "Max 4"
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/CoupledScreen.kt",
+      "A classic one-glance read of NOOP's own scores. Same data, different lens."
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/DataSourcesScreen.kt",
+      "Imported"
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/DataSourcesScreen.kt",
+      "No samples yet"
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/DataSourcesScreen.kt",
+      "Nothing imported"
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/DataSourcesScreen.kt",
+      "Streaming locally"
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/DataSourcesScreen.kt",
+      "not yet"
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/DevicesScreen.kt",
+      " · $it"
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/DevicesScreen.kt",
+      " · FW $it"
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/HealthScreen.kt",
+      "$displayHr bpm"
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/HealthScreen.kt",
+      "${detail.format(it)} ${detail.unit}"
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/HealthScreen.kt",
+      "${kotlin.math.abs(delta)} ${yearWord(delta)} ${if (younger) \"younger\" else \"older\"}"
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/HealthScreen.kt",
+      "Awaiting strap"
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/HealthScreen.kt",
+      "CALIBRATING"
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/HealthScreen.kt",
+      "Estimated from R-R interval"
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/HealthScreen.kt",
+      "Pairing…"
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/HealthScreen.kt",
+      "Ready to sync"
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/HealthScreen.kt",
+      "SOLID"
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/HealthScreen.kt",
+      "Streaming live"
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/HealthScreen.kt",
+      "Sync now"
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/HealthScreen.kt",
+      "Syncing…"
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/HealthScreen.kt",
+      "Vital Signs"
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/HealthScreen.kt",
+      "about your age"
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/HrvSnapshotScreen.kt",
+      "Save"
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/HrvSnapshotScreen.kt",
+      "Saved"
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/HydrationScreen.kt",
+      "of %.1f L"
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/InsightsHubScreen.kt",
+      "d = %.2f"
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/InsightsScreen.kt",
+      "d = %.2f"
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/InsightsScreen.kt",
+      "r = %+.2f"
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/IntervalsScreen.kt",
+      " $it"
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/IntervalsScreen.kt",
+      "Pause"
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/IntervalsScreen.kt",
+      "Restart"
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/IntervalsScreen.kt",
+      "Start"
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/JournalLog.kt",
+      "Answers are about the night and day leading into this morning, the "
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/JournalLog.kt",
+      "Change to Number"
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/JournalLog.kt",
+      "Change to Yes/No"
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/JournalLog.kt",
+      "Delete"
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/JournalLog.kt",
+      "Hide"
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/JournalLog.kt",
+      "Logging ahead for tomorrow: today's activities inform tomorrow's "
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/JournalLog.kt",
+      "Rename, regroup, or remove an item to tidy your list. Renaming keeps the "
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/LabBookScreen.kt",
+      "$n reading${if (n == 1) \"\" else \"s\"} line up so far, not enough to read a trend yet "
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/LabBookScreen.kt",
+      "Choose a signal"
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/LabBookScreen.kt",
+      "No overlap yet between this marker and ${signal.title.lowercase()}. Log a few more readings "
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/LiveScreen.kt",
+      "Connect"
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/LiveScreen.kt",
+      "Re-scan"
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/LiveScreen.kt",
+      "Recent intervals: "
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/LiveScreen.kt",
+      "Scan & Connect"
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/LiveScreen.kt",
+      "Searching…"
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/LiveScreen.kt",
+      "Strap buzzes when you climb into Zone 5 (≥ $zone5Bpm bpm). Manage it in Automations → Haptic coaching."
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/LiveScreen.kt",
+      "Sync now"
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/LiveScreen.kt",
+      "Syncing your strap history…"
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/LiveScreen.kt",
+      "Syncing your strap history… ${live.syncChunksThisSession} chunks pulled"
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/LiveScreen.kt",
+      "Syncing…"
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/LiveScreen.kt",
+      "Turn on HR-zone coaching in Automations for a wrist buzz when you reach Zone 5 (≥ $zone5Bpm bpm)."
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/LiveScreen.kt",
+      "Waiting for R-R intervals."
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/LiveSessionScreen.kt",
+      "Guarding your session. Silence means you're on track."
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/LiveSessionScreen.kt",
+      "Signal lost — coaching paused."
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/LiveWorkoutScreen.kt",
+      "%d:%02d"
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/LiveWorkoutScreen.kt",
+      "Below Zone 1"
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/LiveWorkoutScreen.kt",
+      "Warming up - keep moving to climb into Zone 1."
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/LiveWorkoutScreen.kt",
+      "Zone $zone · ${zoneName(zone)}"
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/LiveWorkoutScreen.kt",
+      "Zone $zone: ${band.lower.toInt()} - ${band.upper.toInt()} bpm (${(band.lowerPct * 100).toInt()} - ${(band.upperPct * 100).toInt()}% max HR)"
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/MindSection.kt",
+      "r = %+.2f"
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/NotificationsSettingsScreen.kt",
+      "Buzzes your wrist"
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/NotificationsSettingsScreen.kt",
+      "Off"
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/OnboardingScreen.kt",
+      "Deep blue accent on a dark blue-grey canvas."
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/OnboardingScreen.kt",
+      "Deep blue accent on warm paper."
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/OnboardingScreen.kt",
+      "Following your phone's light/dark setting."
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/OnboardingScreen.kt",
+      "Re-scan"
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/OnboardingScreen.kt",
+      "Scan again"
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/OnboardingScreen.kt",
+      "Your strap is bonded and ready to stream."
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/OnboardingScreen.kt",
+      "Your strap is bonded · ${it.toInt()}% battery."
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/SettingsScreen.kt",
+      " · Charging"
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/SettingsScreen.kt",
+      "Adds your VO₂max estimate"
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/SettingsScreen.kt",
+      "Auto · ${profile.hrMaxAuto} bpm (Tanaka)"
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/SettingsScreen.kt",
+      "Change photo"
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/SettingsScreen.kt",
+      "Choose photo"
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/SettingsScreen.kt",
+      "Manual override"
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/SettingsScreen.kt",
+      "Needs the full encrypted bond: close the official WHOOP app and pair the strap to NOOP first (a live-HR-only link can't carry the unlock)."
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/SettingsScreen.kt",
+      "Optional · adds your VO₂max estimate"
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/SettingsScreen.kt",
+      "Put the strap on first. The deep stream is on-wrist only."
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/SettingsScreen.kt",
+      "Re-scan"
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/SettingsScreen.kt",
+      "Searching…"
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/SettingsScreen.kt",
+      "Strap accepted ${live.r22FlagsAccepted}/15 R22 flags…"
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/SettingsScreen.kt",
+      "Wear the strap, tap once, then let it sync and share your strap log."
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/SettingsScreen.kt",
+      "✓ Strap accepted all 15 R22 flags"
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/SkinTempCardsScreen.kt",
+      "Plan a trip or shift"
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/SkinTempCardsScreen.kt",
+      "View the full plan"
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/SleepScreen.kt",
+      "Edit nap times"
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/SleepScreen.kt",
+      "Edit nap times (edited)"
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/SleepScreen.kt",
+      "Removes this recorded sleep and recomputes the day without it. NOOP won't re-detect sleep in this window. You can undo for a few seconds after."
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/SleepScreen.kt",
+      "Removes this sleep and recomputes the day without it. You can undo for a few seconds after."
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/SmartAlarmScreen.kt",
+      "Armed on the strap itself with the experimental 5/MG command. A strap-driven wake is still unconfirmed on 5/MG on our side (confirmed only on WHOOP 4.0), so keep a backup alarm for anything you truly can't miss."
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/SmartAlarmScreen.kt",
+      "Armed on the strap itself, so it can buzz at your wake time even if your phone is asleep or NOOP is closed. Sends the exact alarm command the official app sends, confirmed buzzing on a real WHOOP 4.0 (community wire capture + on-device test, #535). Keep a backup alarm for anything you truly can't miss."
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/SmartAlarmScreen.kt",
+      "Connect your strap to arm this; it's set on the strap's own firmware alarm. Confirmed working on WHOOP 4.0; still experimental on 5.0 and MG. Keep a backup alarm for anything you truly can't miss."
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/StepsCalibrationScreen.kt",
+      "%+.0f%%"
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/StepsCalibrationScreen.kt",
+      "Auto"
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/StepsCalibrationScreen.kt",
+      "fit from your phone"
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/StepsCalibrationScreen.kt",
+      "steps / motion unit"
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/StressScreen.kt",
+      "Stress is derived from two autonomic signals."
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/StressScreen.kt",
+      "Today's value is your recorded daily stress score (0-3)."
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/TodayScreen.kt",
+      "CALIBRATING"
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/TodayScreen.kt",
+      "Calibrating , no heart rate banked yet today. Your curve fills in as the strap offloads."
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/TodayScreen.kt",
+      "No heart rate for this day. Step back to a day the strap was worn."
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/TodayScreen.kt",
+      "No heart rate in the last ${hrWindow.label}. Try a wider window or Today."
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/TodayScreen.kt",
+      "Not connected"
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/TodayScreen.kt",
+      "Pinch to zoom · drag to pan"
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/TodayScreen.kt",
+      "SOLID"
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/TodayScreen.kt",
+      "Show all metrics ($hidden)"
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/TodayScreen.kt",
+      "Show fewer"
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/TodayScreen.kt",
+      "Zoomed in · drag to pan"
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/UpdateStore.kt",
+      "What's new in NOOP $version"
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/WorkoutStart.kt",
+      "%d:%02d"
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/WorkoutsScreen.kt",
+      "Add"
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/WorkoutsScreen.kt",
+      "Add Workout"
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/WorkoutsScreen.kt",
+      "All sources"
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/WorkoutsScreen.kt",
+      "All sports"
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/WorkoutsScreen.kt",
+      "Done"
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/WorkoutsScreen.kt",
+      "Edit Workout"
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/WorkoutsScreen.kt",
+      "Effort (0-100)"
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/WorkoutsScreen.kt",
+      "From strap HR"
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/WorkoutsScreen.kt",
+      "Logged sessions across ${effectiveRange.caption}."
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/WorkoutsScreen.kt",
+      "Mostly ${WorkoutEditing.displaySport(modal.sport)} (${effectiveRange.caption})."
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/WorkoutsScreen.kt",
+      "Save"
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/WorkoutsScreen.kt",
+      "Select"
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/WorkoutsScreen.kt",
+      "Time in each %HRmax zone, derived from the strap's heart rate over this window (approximate)."
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/WorkoutsScreen.kt",
+      "WHOOP's imported per-zone split for this session."
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/WorkoutsScreen.kt",
+      "Whoop import"
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/WorkoutsScreen.kt",
+      "strain (0-21)"
+    ],
+    [
+      "android/app/src/main/java/com/noop/widget/NoopCompactGlanceWidget.kt",
+      "$it%"
+    ],
+    [
+      "android/app/src/main/java/com/noop/widget/NoopCompactGlanceWidget.kt",
+      "Connected"
+    ],
+    [
+      "android/app/src/main/java/com/noop/widget/NoopCompactGlanceWidget.kt",
+      "Open NOOP to connect"
+    ],
+    [
+      "android/app/src/main/java/com/noop/widget/NoopCompactGlanceWidget.kt",
+      "♥ $it"
+    ],
+    [
+      "android/app/src/main/java/com/noop/widget/NoopGlanceWidget.kt",
+      "$it%"
+    ],
+    [
+      "android/app/src/main/java/com/noop/widget/NoopGlanceWidget.kt",
+      "Connected"
+    ],
+    [
+      "android/app/src/main/java/com/noop/widget/NoopGlanceWidget.kt",
+      "Open NOOP to connect"
+    ],
+    [
+      "android/app/src/main/java/com/noop/widget/NoopGlanceWidget.kt",
+      "♥ $it"
+    ],
+    [
+      "android/app/src/main/java/com/noop/widget/NoopGlanceWidget.kt",
+      "⚡ $it%"
+    ]
+  ],
+  "ios": [
+    [
+      "Packages/StrandDesign/Sources/StrandDesign/ChartHover.swift",
+      "\\(value), \\(label!)"
+    ],
+    [
+      "Packages/StrandDesign/Sources/StrandDesign/DayNavBar.swift",
+      "Next day"
+    ],
+    [
+      "Packages/StrandDesign/Sources/StrandDesign/DayNavBar.swift",
+      "Pick a date"
+    ],
+    [
+      "Packages/StrandDesign/Sources/StrandDesign/DayNavBar.swift",
+      "Previous day"
+    ],
+    [
+      "Packages/StrandDesign/Sources/StrandDesign/TrendChart.swift",
+      "Trend"
+    ],
+    [
+      "Packages/StrandDesign/Sources/StrandDesign/YearHeatStrip.swift",
+      "\\(DateFormatterCache.day.string(from: day.date)) · recovery \\(Int(score.rounded()))"
+    ],
+    [
+      "Strand/Liquid/LiquidPrimitives.swift",
+      "%.\\(decimals)f"
+    ],
+    [
+      "Strand/Liquid/LiquidTodayView.swift",
+      " \\(unit)"
+    ],
+    [
+      "Strand/Liquid/LiquidTodayView.swift",
+      "Arrange Today sections"
+    ],
+    [
+      "Strand/Screens/AddDeviceWizard.swift",
+      "The most common cause is the ring was not fully reset in the Oura app, or the Oura app is still running. Reset the ring again, force-quit Oura, then try once more. If it keeps failing, your ring may be a generation NOOP cannot adopt yet. The ring is not bricked: re-pair it in the Oura app to recover it. You can still use file import."
+    ],
+    [
+      "Strand/Screens/BreathingView.swift",
+      "%.1f br/min"
+    ],
+    [
+      "Strand/Screens/DataSourcesView.swift",
+      "Import your Oura history"
+    ],
+    [
+      "Strand/Screens/DevicesView.swift",
+      "Historical record layout v\\(layout)"
+    ],
+    [
+      "Strand/Screens/FullDayChartView.swift",
+      "Pinch to zoom · drag to pan · hold to read"
+    ],
+    [
+      "Strand/Screens/FullDayChartView.swift",
+      "Zoomed in. Drag to pan · hold to read"
+    ],
+    [
+      "Strand/Screens/HealthView.swift",
+      "Refresh Fitness Age now"
+    ],
+    [
+      "Strand/Screens/HealthView.swift",
+      "Vitality \\(Int(v.rounded())) out of 100"
+    ],
+    [
+      "Strand/Screens/HydrationView.swift",
+      "Progress toward today's goal"
+    ],
+    [
+      "Strand/Screens/InsightsHubView.swift",
+      "d = %.2f"
+    ],
+    [
+      "Strand/Screens/InsightsView.swift",
+      "d = %.2f"
+    ],
+    [
+      "Strand/Screens/InsightsView.swift",
+      "r = %+.2f"
+    ],
+    [
+      "Strand/Screens/JournalLogCard.swift",
+      "Clear \\(item.display)"
+    ],
+    [
+      "Strand/Screens/JournalLogCard.swift",
+      "Decrease"
+    ],
+    [
+      "Strand/Screens/JournalLogCard.swift",
+      "Delete this custom item"
+    ],
+    [
+      "Strand/Screens/JournalLogCard.swift",
+      "Edit \\(item.display)"
+    ],
+    [
+      "Strand/Screens/JournalLogCard.swift",
+      "Hide this item"
+    ],
+    [
+      "Strand/Screens/JournalLogCard.swift",
+      "Increase"
+    ],
+    [
+      "Strand/Screens/JournalLogCard.swift",
+      "New item group"
+    ],
+    [
+      "Strand/Screens/JournalLogCard.swift",
+      "Rename, regroup, or remove an item to tidy your list. Renaming keeps the original question behind the scenes, so a WHOOP import still lines up. Custom items are deleted; built-in ones are hidden and can be restored below."
+    ],
+    [
+      "Strand/Screens/JournalLogCard.swift",
+      "\\(group.title), \\(groupItems.count) items, \\(collapsed ? \"collapsed\" : \"expanded\")"
+    ],
+    [
+      "Strand/Screens/LabBookView.swift",
+      "Choose CSV…"
+    ],
+    [
+      "Strand/Screens/LabBookView.swift",
+      "Choose a markers CSV file to import"
+    ],
+    [
+      "Strand/Screens/LabBookView.swift",
+      "Choose a signal"
+    ],
+    [
+      "Strand/Screens/LabBookView.swift",
+      "the signal"
+    ],
+    [
+      "Strand/Screens/MetricExplorerView.swift",
+      "\\(row.time), \\(row.value), \\(row.source)"
+    ],
+    [
+      "Strand/Screens/SettingsView.swift",
+      "%+.0f%%"
+    ],
+    [
+      "Strand/Screens/SettingsView.swift",
+      "Date of birth, age \\(profile.age) years"
+    ],
+    [
+      "Strand/Screens/SettingsView.swift",
+      "NOOP estimates your steps from your WHOOP's motion, calibrated to your phone's step count. It's an estimate, not a step counter — a WHOOP 5.0 / MG streams motion (not a step count) only with deep data on."
+    ],
+    [
+      "Strand/Screens/SettingsView.swift",
+      "Trend chart style"
+    ],
+    [
+      "Strand/Screens/SettingsView.swift",
+      "WHOOP 5.0 / MG · motion → steps"
+    ],
+    [
+      "Strand/Screens/SleepView.swift",
+      "Removes this recorded sleep and recomputes the day without it. NOOP won't re-detect sleep in this window. You can undo for a few seconds after."
+    ],
+    [
+      "Strand/Screens/SleepView.swift",
+      "Removes this sleep and recomputes the day without it. You can undo for a few seconds after."
+    ],
+    [
+      "Strand/Screens/SleepView.swift",
+      "Undo sleep deletion"
+    ],
+    [
+      "Strand/Screens/SmartAlarmView.swift",
+      "Notifications are off"
+    ],
+    [
+      "Strand/Screens/SmartAlarmView.swift",
+      "Open Settings"
+    ],
+    [
+      "Strand/Screens/StressView.swift",
+      "Stress \\(String(format: \"%.1f\", score)) of 3"
+    ],
+    [
+      "Strand/Screens/StressView.swift",
+      "Today's value is your recorded daily stress score (0-3)."
+    ],
+    [
+      "Strand/Screens/TodayView.swift",
+      "Acute (7-day) vs chronic (28-day) training load. 0.8-1.3 is the sweet spot."
+    ],
+    [
+      "Strand/Screens/TrendsView.swift",
+      "Opens the full Charge metric."
+    ],
+    [
+      "Strand/Screens/TrendsView.swift",
+      "Opens the full \\(accessibilityTitle) metric."
+    ],
+    [
+      "Strand/Screens/WorkoutDetailView.swift",
+      "Effort \\(UnitFormatter.effortDisplay(strain, scale: effortScale)) \\(effortScale == .whoop ? \"of 21\" : \"of 100\")"
+    ],
+    [
+      "Strand/Screens/WorkoutDetailView.swift",
+      "of 21"
+    ],
+    [
+      "Strand/Screens/WorkoutsView.swift",
+      "All sources"
+    ],
+    [
+      "Strand/Screens/WorkoutsView.swift",
+      "All sports"
+    ],
+    [
+      "Strand/Screens/WorkoutsView.swift",
+      "Clear filters"
+    ],
+    [
+      "Strand/Screens/WorkoutsView.swift",
+      "Clear search"
+    ],
+    [
+      "Strand/Screens/WorkoutsView.swift",
+      "Delete (\\(chosen.count))"
+    ],
+    [
+      "Strand/Screens/WorkoutsView.swift",
+      "Finish selecting"
+    ],
+    [
+      "Strand/Screens/WorkoutsView.swift",
+      "Merge (\\(chosen.count))"
+    ],
+    [
+      "Strand/Screens/WorkoutsView.swift",
+      "Select"
+    ],
+    [
+      "Strand/Screens/WorkoutsView.swift",
+      "Select sessions to merge or delete"
+    ],
+    [
+      "Strand/Screens/WorkoutsView.swift",
+      "Typical effort \\(UnitFormatter.effortDisplay(avgStrain, scale: effortScale))"
+    ],
+    [
+      "Strand/Screens/WorkoutsView.swift",
+      "Typical effort, no data"
+    ],
+    [
+      "Strand/Screens/WorkoutsView.swift",
+      "of 21"
+    ]
+  ]
+}

--- a/Tools/test_i18n_audit.py
+++ b/Tools/test_i18n_audit.py
@@ -1,0 +1,207 @@
+"""Tests for the #540 fix: i18n_audit.py must see UI-text literals hidden
+behind if/else, when, and .let — not just literals sitting immediately after
+Text(/title=/etc — without also sweeping unrelated nested composable subtrees
+(the bug in the first draft of this fix, which produced 489 findings instead
+of a few dozen).
+
+Run: python3 -m unittest Tools.test_i18n_audit -v   (from the repo root)
+     or: cd Tools && python3 -m unittest test_i18n_audit -v
+"""
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+import i18n_audit as ia
+
+
+def literals(text: str) -> list[str]:
+    """Every literal `_extract_literals` finds across the whole snippet,
+    content only (offsets aren't interesting for these tests)."""
+    return [lit for _offset, lit in ia._extract_literals(text, 0, len(text))]
+
+
+class AndroidLiteralExtraction(unittest.TestCase):
+    def test_plain_literal(self):
+        self.assertEqual(literals('Text("Save")'), ["Save"])
+
+    def test_ternary_if_else_expression(self):
+        # The issue's exact reported bug (HrvSnapshotScreen.kt:290).
+        self.assertEqual(literals('Text(if (saved) "Saved" else "Save")'), ["Saved", "Save"])
+
+    def test_block_bodied_if_else(self):
+        # SleepScreen.kt:2249-shaped: braces around each branch.
+        text = 'Text(if (session.userEdited) { "Removes edited" } else { "Removes recorded" })'
+        self.assertEqual(literals(text), ["Removes edited", "Removes recorded"])
+
+    def test_let_as_null_coalescing_ternary(self):
+        # CaffeineLog.kt:297-shaped.
+        text = 'Text(estimate?.let { "About it" } ?: "Caffeine may still be active")'
+        self.assertEqual(literals(text), ["About it", "Caffeine may still be active"])
+
+    def test_when_with_subject(self):
+        text = 'Text(when (stage) { "Awake" -> "Awake now" else -> "Unknown" })'
+        self.assertIn("Awake now", literals(text))
+        self.assertIn("Unknown", literals(text))
+
+    def test_bare_when(self):
+        text = 'Text(when { cond1 -> "a" else -> "b" })'
+        self.assertEqual(literals(text), ["a", "b"])
+
+    def test_nested_composable_slot_not_swept(self):
+        # A trailing lambda that is NOT if/when/.let is a separate,
+        # independently-composed subtree (the 489-finding regression this
+        # fix must not reintroduce) — nothing should be found INSIDE it from
+        # here; the nested Text(...) is discovered on its own, separate pass.
+        text = 'AlertDialog(text = { Column { Text("Unrelated deep content") } })'
+        kwarg_start = text.index("{ Column")
+        span_end = ia._argument_span_end(text, text.index("=", text.index("text")) + 1)
+        self.assertEqual(literals(text[kwarg_start:span_end]), [])
+
+    def test_plus_concatenation_skipped(self):
+        # uiString(R.string.x) + "hardcoded suffix" is a real, but explicitly
+        # DIFFERENT and out-of-scope bug (partial localization via an
+        # engineered prefix) — tracked separately, not by this scanner.
+        text = 'Text(uiString(R.string.x) + "hardcoded suffix")'
+        self.assertEqual(literals(text), [])
+
+    def test_plus_concatenation_does_not_swallow_a_real_conditional(self):
+        # LiveScreen.kt:1068-shaped: the first branch is a real, standalone
+        # conditional literal; only the +-joined unit-suffix is excluded.
+        text = 'Text(if (empty) "Waiting." else "Recent: " + values.joinToString() + " ms")'
+        self.assertEqual(literals(text), ["Waiting.", "Recent: "])
+
+    def test_string_template_interpolation_not_corrupted(self):
+        # MindSection.kt:167-shaped pluralization idiom: a nested literal
+        # inside ${...} must not be mistaken for the end of the outer one.
+        text = 'Text("$left more ${if (left == 1) "day" else "days"} to go.")'
+        self.assertEqual(literals(text), ['$left more ${if (left == 1) "day" else "days"} to go.'])
+
+
+class MaskComments(unittest.TestCase):
+    def test_line_comment_blanked(self):
+        text = 'val x = 1 // "Take over this ring?"\nText("Real")'
+        masked = ia._mask_comments(text)
+        self.assertNotIn("Take over", masked)
+        self.assertIn('Text("Real")', masked)
+        self.assertEqual(len(masked), len(text))  # offsets/line numbers preserved
+
+    def test_block_comment_blanked(self):
+        text = 'Text(/* "fake" */ "Real")'
+        masked = ia._mask_comments(text)
+        self.assertNotIn("fake", masked)
+        self.assertIn("Real", masked)
+
+    def test_comment_marker_inside_string_not_treated_as_comment(self):
+        text = 'Text("http://example.com // not a comment")'
+        masked = ia._mask_comments(text)
+        self.assertIn("not a comment", masked)
+
+
+class FormatSpecExclusion(unittest.TestCase):
+    def test_pure_format_spec_excluded(self):
+        self.assertFalse(ia.is_probably_ui_text("%.1f"))
+        self.assertFalse(ia.is_probably_ui_text("%02d"))
+        self.assertFalse(ia.is_probably_ui_text("%+.2f"))
+
+    def test_format_spec_with_real_text_kept(self):
+        self.assertTrue(ia.is_probably_ui_text("%.1f br/min"))
+
+
+class ScanAndroidEndToEnd(unittest.TestCase):
+    """Exercises scan_android() against real files on disk (its actual
+    contract), not just the pure-function helpers above."""
+
+    def setUp(self):
+        # Must live under ia.ROOT: scan_android() reports paths via
+        # `path.relative_to(ROOT)`, which raises for anything outside it.
+        self.tmp = tempfile.TemporaryDirectory(dir=ia.ROOT)
+        self.addCleanup(self.tmp.cleanup)
+        self.ui_dir = Path(self.tmp.name) / "ui"
+        self.ui_dir.mkdir()
+        self._orig_dirs = ia.ANDROID_DIRS
+        ia.ANDROID_DIRS = [self.ui_dir]
+        self.addCleanup(setattr, ia, "ANDROID_DIRS", self._orig_dirs)
+
+    def write(self, name: str, content: str) -> None:
+        (self.ui_dir / name).write_text(content, encoding="utf-8")
+
+    def test_conditional_literal_found(self):
+        self.write("Screen.kt", 'Text(if (saved) "Saved" else "Save")')
+        found = {lit for _p, _l, lit in ia.scan_android()}
+        self.assertEqual(found, {"Saved", "Save"})
+
+    def test_alert_dialog_kwarg_conditional_found(self):
+        self.write(
+            "Screen.kt",
+            'AlertDialog(onDismissRequest = {}, title = { Text(if (x) "A" else "B") })',
+        )
+        found = {lit for _p, _l, lit in ia.scan_android()}
+        self.assertEqual(found, {"A", "B"})
+
+    def test_local_val_declaration_not_scanned_as_kwarg(self):
+        # `val text = when { ... }` is a local declaration, not a composable
+        # kwarg — ANDROID_KWARG_PATTERN's `text=` must not treat its `when`
+        # branch match-keys as UI-text findings.
+        self.write(
+            "Screen.kt",
+            'val text = when (stage) {\n    "Awake" -> "Awake now"\n    else -> "Unknown"\n}\n',
+        )
+        found = {lit for _p, _l, lit in ia.scan_android()}
+        self.assertEqual(found, set())
+
+    def test_no_explosion_from_nested_slot_lambda(self):
+        # The 489-finding regression guard: a huge, unrelated nested
+        # composable subtree inside a title=/text= slot must not get swept.
+        self.write(
+            "Wizard.kt",
+            "AlertDialog(\n"
+            "    onDismissRequest = {},\n"
+            "    text = {\n"
+            "        Column {\n"
+            '            Text("First deep child")\n'
+            '            Text("Second deep child")\n'
+            "        }\n"
+            "    },\n"
+            ")",
+        )
+        found = [lit for _p, _l, lit in ia.scan_android()]
+        # Both literals are still found — but because the file-wide scan
+        # reaches each nested Text(...) call directly, not because the
+        # outer AlertDialog's text= span was swept.
+        self.assertEqual(sorted(found), ["First deep child", "Second deep child"])
+
+
+class Baseline(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        self._orig_path = ia.BASELINE_PATH
+        ia.BASELINE_PATH = Path(self.tmp.name) / "baseline.json"
+        self.addCleanup(setattr, ia, "BASELINE_PATH", self._orig_path)
+
+    def test_missing_baseline_is_empty(self):
+        self.assertEqual(ia.load_baseline(), {"android": set(), "ios": set()})
+
+    def test_round_trip(self):
+        ia.BASELINE_PATH.write_text(
+            json.dumps({"android": [["Screen.kt", "Old"]], "ios": []}), encoding="utf-8"
+        )
+        baseline = ia.load_baseline()
+        self.assertEqual(baseline["android"], {("Screen.kt", "Old")})
+        self.assertEqual(baseline["ios"], set())
+
+    def test_baseline_keyed_by_path_and_literal_not_line(self):
+        # A baseline entry must keep suppressing a finding whose line number
+        # shifted from an unrelated edit elsewhere in the same file.
+        ia.BASELINE_PATH.write_text(
+            json.dumps({"android": [["Screen.kt", "Save"]], "ios": []}), encoding="utf-8"
+        )
+        baseline = ia.load_baseline()
+        finding = ("Screen.kt", 999, "Save")  # line number drifted
+        self.assertIn((finding[0], finding[2]), baseline["android"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Fixes #540: `Tools/i18n_audit.py`'s Android regex only matched a literal sitting immediately after `Text(`/`title=`/etc, so `Text(if (saved) "Saved" else "Save")` slid straight past and the audit reported "clean" while shipping English regardless of device language.

While fixing this I checked the Apple side for parity and found the identical blind spot — and there it's a real functional bug, not just a tooling gap: `Text(cond ? "a" : "b")` resolves to SwiftUI's non-localizing `Text<S: StringProtocol>` overload, so those sites are always-English on-device too, independent of this audit.

## What changed

Both scanners now walk each call's/kwarg's own argument span instead of matching a literal at a fixed position:
- Transparent through `(`/`[` always (so ternaries and nested calls are visible).
- Transparent through `{` only for the Kotlin idioms this codebase actually uses to conditionally pick a string (`if`/`when`/`catch`/`else`/`try`/`finally`, and `.let {}` as a null-coalescing ternary substitute paired with `?:`). Opaque for everything else, so an unrelated nested composable slot lambda (e.g. `AlertDialog(text = { Column { /* a separate, unrelated subtree */ } })`) doesn't get swept into the same scan — that nested content is still found, just on its own independent pass when the file-wide scan reaches it directly.

An early draft that didn't distinguish those two cases produced 489 spurious findings instead of the real backlog. Two more bugs surfaced along the way, fixed in the same pass since they'd otherwise produce un-actionable noise:
- Kotlin's `${...}` string-template interpolation (the `"${if (n==1) "day" else "days"}"` pluralization idiom) corrupted the naive quote-matching.
- `title=`/`text=`/etc. also matched a plain local `val text = when {...}` declaration, not just an actual call argument.

Deliberately does **not** flag `+`-concatenated literals (typically `uiString(R.string.x) + "hardcoded suffix"`) — found 86 of those across 28 files, but it's a different, larger bug (partial localization via an engineered prefix, needs real new translation content per site rather than reusing an existing value) — filed separately as #557.

## The backlog problem, and the baseline

The corrected scanners find real, previously-invisible findings: **170 distinct Android literals, 64 distinct Apple ones**. Far more than one PR should close with rushed translations (see #543 on what that produces when strings get "fixed" without native review).

Since `i18n-coverage.yml`'s `--ci` is a whole-tree gate (not diff-scoped), the fix and *some* resolution of what it newly surfaces have to land together or every subsequent PR breaks. Rather than rush ~234 translations, this ships with `Tools/i18n_audit_baseline.json`: a snapshot of the pre-existing findings, keyed by `(path, literal)` so it survives unrelated line-number drift. `--ci` now only fails on a **new** hardcoded literal from this point forward; the baseline backlog is closed incrementally in separate, appropriately-sized follow-up PRs, chipped away by area. `--update-baseline` regenerates the file — an entry that stops appearing in a fresh scan is simply inert, not an error, so it naturally shrinks as follow-ups land.

## Testing

- `Tools/test_i18n_audit.py` (new): the conditional shapes above (ternary, block-if/else, `when`, `.let`), the nested-slot-lambda non-explosion regression guard, the interpolation and local-declaration fixes, comment/format-spec false-positive exclusion, and the baseline diff logic (missing file, round-trip, line-number-drift resilience).
- `python3 -m unittest test_i18n_audit -v` — 22/22 pass.
- `python3 Tools/i18n_audit.py --ci origin/main` — exit 0 (clean against the new baseline).
- Manually verified a genuinely new hardcoded literal (not in the baseline) fails `--ci` with a clear message, then confirmed the repo is unaffected (temporary local-only edit, reverted, `git status` clean before this PR).
- No app-target Swift/Kotlin source touched (`Tools/i18n_audit.py` isn't part of any Xcode/Gradle target) — only the Python audit tool, its new baseline snapshot, and its test file. `xcodebuild`/`./gradlew compile*` weren't needed for this change.

## Follow-ups tracked separately
- #557 — the 86-site `uiString(...) + "hardcoded suffix"` concatenation bug found while investigating this.
- Closing `Tools/i18n_audit_baseline.json`'s 234 pre-existing entries, screen/area by screen/area.
