### PR TITLE
i18n(StrandDesign): fix es/fr workout-count catalog typos (#543 item 6)

### DIFF
--- a/Packages/StrandDesign/Sources/StrandDesign/Resources/Localizable.xcstrings
+++ b/Packages/StrandDesign/Sources/StrandDesign/Resources/Localizable.xcstrings
@@ -248,13 +248,13 @@
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Ejercicios %1$lld"
+            "value": "%lld ejercicios"
           }
         },
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "%1$lld séances d'entraînement"
+            "value": "%lld entraînements"
           }
         }
       }


### PR DESCRIPTION
## Summary

Fixes item 6 of #543 — the one item there that's mechanical rather than a translation or design call. Both `%lld workouts` plurals disagreed with their OWN singular's noun in the same catalog entry:

```
'1 workout'      es = '1 ejercicio'              fr = '1 entraînement'
'%lld workouts'  es = 'Ejercicios %1$lld'        fr = "%1$lld séances d'entraînement"
```

- **es**: capitalized and reordered relative to the singular ("Ejercicios 5" instead of "5 ejercicios"), and switched to the numbered `%1$lld` placeholder where nothing else needs numbering. Fixed to `%lld ejercicios`.
- **fr**: swapped nouns entirely relative to the singular — "séances d'entraînement" means "training sessions", not "workouts". Fixed to `%lld entraînements`.

Both now also match this catalog's own placeholder convention (`%lld`, used by 49 of 60 plural pairs here vs `%1$lld`'s 11).

## Why this is provable, not a translation call

No new vocabulary is invented — each fix reuses the noun already present in that same key's own singular value, the same standard #544 applied to the zh-Hant/pt-PT fixes. Items 1-5 of #543 either need a design decision or a native-speaker call and are handled separately (item 1 in #559).

## Testing
- `python3 Tools/i18n_audit.py --ci origin/main`: clean.
- Catalog parses; diff is 2 value lines, zero structural churn.
