### PR TITLE
workout: confirm before ending an active session (#517)

### DIFF
--- a/Strand/Screens/LiveWorkoutView.swift
+++ b/Strand/Screens/LiveWorkoutView.swift
@@ -34,6 +34,10 @@ struct LiveWorkoutView: View {
     /// the moment it leaves, which is exactly the bounded usage Apple asks for. iOS-only (no-op on Mac).
     @AppStorage("workoutKeepScreenOn") private var keepScreenOn = false
 
+    /// Guards the destructive End action behind a confirm (#517) — a stray tap on the full-width button
+    /// used to end the workout instantly with no way back.
+    @State private var showEndConfirm = false
+
     private var zoneSet: HRZoneSet { HRZones.zones(maxHR: Double(model.profile.hrMax)) }
     private var zone: Int { model.bpm.map { zoneSet.zoneNumber(forBPM: Double($0)) } ?? 0 }
 
@@ -86,6 +90,18 @@ struct LiveWorkoutView: View {
             // Always release on the way out so the system idle timer resumes. Even if the toggle was
             // flipped off mid-workout, this clears any hold we placed.
             ScreenIdle.keepAwake(false)
+        }
+        // Confirm before ending (#517): a stray tap on "End workout" used to stop the session and
+        // discard the in-progress recording with no way back.
+        .alert("End this workout?",
+               isPresented: $showEndConfirm) {
+            Button("Cancel", role: .cancel) { }
+            Button("End workout", role: .destructive) {
+                model.endWorkout()
+                onClose()
+            }
+        } message: {
+            Text("This stops recording and saves what's captured so far. It can't be resumed.")
         }
     }
 
@@ -221,8 +237,7 @@ struct LiveWorkoutView: View {
 
     private var endButton: some View {
         NoopButton("End workout", systemImage: "stop.fill", kind: .destructive, fullWidth: true) {
-            model.endWorkout()
-            onClose()
+            showEndConfirm = true
         }
     }
 

--- a/android/app/src/main/java/com/noop/ui/LiveWorkoutScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/LiveWorkoutScreen.kt
@@ -22,9 +22,11 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.ui.draw.clip
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
@@ -95,6 +97,10 @@ fun LiveWorkoutScreen(vm: AppViewModel, onClose: () -> Unit) {
     val zoneSet = remember(profile.hrMax) { HrZones.zones(maxHR = profile.hrMax.toDouble()) }
     val zone = bpm?.let { zoneSet.zoneNumber(it.toDouble()) } ?: 0
 
+    // Guards the destructive End action behind a confirm (#517) — a stray tap on the full-width
+    // button used to end the workout instantly with no way back.
+    var showEndConfirm by remember { mutableStateOf(false) }
+
     var nowMs by remember { mutableStateOf(System.currentTimeMillis()) }
     LaunchedEffect(w.startMs) {
         while (true) { nowMs = System.currentTimeMillis(); delay(1000) }
@@ -162,7 +168,7 @@ fun LiveWorkoutScreen(vm: AppViewModel, onClose: () -> Unit) {
             Spacer(Modifier.height(12.dp))
 
             Button(
-                onClick = { vm.endWorkout(); onClose() },
+                onClick = { showEndConfirm = true },
                 modifier = Modifier.fillMaxWidth(),
                 contentPadding = PaddingValues(vertical = 14.dp),
                 colors = ButtonDefaults.buttonColors(
@@ -170,6 +176,43 @@ fun LiveWorkoutScreen(vm: AppViewModel, onClose: () -> Unit) {
                 ),
             ) { Text(uiString(R.string.l10n_live_workout_screen_end_workout_3e8d6238), style = NoopType.headline) }
         }
+    }
+
+    // Confirm before ending (#517): a stray tap on "End workout" used to stop the session and
+    // discard the in-progress recording with no way back.
+    if (showEndConfirm) {
+        AlertDialog(
+            onDismissRequest = { showEndConfirm = false },
+            containerColor = Palette.surfaceOverlay,
+            title = {
+                Text(
+                    uiString(R.string.l10n_live_workout_screen_end_this_workout_4869c76a),
+                    style = NoopType.title2, color = Palette.textPrimary,
+                )
+            },
+            text = {
+                Text(
+                    uiString(R.string.l10n_live_workout_screen_this_stops_recording_and_saves_what_3e17a23e),
+                    style = NoopType.subhead, color = Palette.textSecondary,
+                )
+            },
+            confirmButton = {
+                TextButton(onClick = { showEndConfirm = false; vm.endWorkout(); onClose() }) {
+                    Text(
+                        uiString(R.string.l10n_live_workout_screen_end_workout_3e8d6238),
+                        style = NoopType.body, color = Palette.statusCritical,
+                    )
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { showEndConfirm = false }) {
+                    Text(
+                        uiString(R.string.l10n_live_workout_screen_cancel_77dfd213),
+                        style = NoopType.body, color = Palette.textSecondary,
+                    )
+                }
+            },
+        )
     }
 }
 

--- a/android/app/src/main/res/values-de/strings.xml
+++ b/android/app/src/main/res/values-de/strings.xml
@@ -591,11 +591,14 @@
     <string name="l10n_live_session_screen_the_strap_signal_was_gone_for_57a2fead">Das Bandsignal war 10 Minuten lang weg, so dass die Sitzung von selbst endete.</string>
     <string name="l10n_live_workout_screen_avg_cdc93143">Ø</string>
     <string name="l10n_live_workout_screen_cadence_68af11f0">Trittfrequenz</string>
+    <string name="l10n_live_workout_screen_cancel_77dfd213">Abbrechen</string>
     <string name="l10n_live_workout_screen_effort_8c974bc6">Anstrengung</string>
+    <string name="l10n_live_workout_screen_end_this_workout_4869c76a">Workout beenden?</string>
     <string name="l10n_live_workout_screen_end_workout_3e8d6238">Workout beenden</string>
     <string name="l10n_live_workout_screen_peak_c83dbbd3">Spitze</string>
     <string name="l10n_live_workout_screen_power_7548ab52">Leistung</string>
     <string name="l10n_live_workout_screen_speed_2d2cb022">Drehzahl</string>
+    <string name="l10n_live_workout_screen_this_stops_recording_and_saves_what_3e17a23e">Das beendet die Aufzeichnung und speichert, was bisher erfasst wurde. Das lässt sich nicht fortsetzen.</string>
     <string name="l10n_live_workout_screen_z_z_d3991a28">Z%1$s</string>
     <string name="l10n_marker_editor_screen_add_a_reading_ed7708ee">Messwert hinzufügen</string>
     <string name="l10n_marker_editor_screen_date_taken_76edfcab">Datum der Messung</string>

--- a/android/app/src/main/res/values-es/strings.xml
+++ b/android/app/src/main/res/values-es/strings.xml
@@ -431,11 +431,14 @@
     <string name="l10n_live_session_screen_the_strap_signal_was_gone_for_57a2fead">La señal de correa se fue durante 10 minutos, así que la sesión terminó.</string>
     <string name="l10n_live_workout_screen_avg_cdc93143">Prom</string>
     <string name="l10n_live_workout_screen_cadence_68af11f0">Cadence</string>
+    <string name="l10n_live_workout_screen_cancel_77dfd213">Cancelar</string>
     <string name="l10n_live_workout_screen_effort_8c974bc6">Esfuerzo</string>
+    <string name="l10n_live_workout_screen_end_this_workout_4869c76a">¿Finalizar entrenamiento?</string>
     <string name="l10n_live_workout_screen_end_workout_3e8d6238">Finalizar entrenamiento</string>
     <string name="l10n_live_workout_screen_peak_c83dbbd3">Pico</string>
     <string name="l10n_live_workout_screen_power_7548ab52">Poder</string>
     <string name="l10n_live_workout_screen_speed_2d2cb022">Speed</string>
+    <string name="l10n_live_workout_screen_this_stops_recording_and_saves_what_3e17a23e">Esto detiene la grabación y guarda lo registrado hasta ahora. No se puede reanudar.</string>
     <string name="l10n_live_workout_screen_z_z_d3991a28">Z%1$s</string>
     <string name="l10n_marker_editor_screen_add_a_reading_ed7708ee">Añadir una lectura</string>
     <string name="l10n_marker_editor_screen_date_taken_76edfcab">Fecha de la toma</string>

--- a/android/app/src/main/res/values-fr/strings.xml
+++ b/android/app/src/main/res/values-fr/strings.xml
@@ -431,11 +431,14 @@
     <string name="l10n_live_session_screen_the_strap_signal_was_gone_for_57a2fead">Le signal de la sangle a disparu pendant 10 minutes, donc la séance s\'est terminée.</string>
     <string name="l10n_live_workout_screen_avg_cdc93143">Moy.</string>
     <string name="l10n_live_workout_screen_cadence_68af11f0">Cadence</string>
+    <string name="l10n_live_workout_screen_cancel_77dfd213">Annuler</string>
     <string name="l10n_live_workout_screen_effort_8c974bc6">Effort</string>
+    <string name="l10n_live_workout_screen_end_this_workout_4869c76a">Terminer l\'entraînement ?</string>
     <string name="l10n_live_workout_screen_end_workout_3e8d6238">Terminer l\'entraînement</string>
     <string name="l10n_live_workout_screen_peak_c83dbbd3">Pic</string>
     <string name="l10n_live_workout_screen_power_7548ab52">Puissance</string>
     <string name="l10n_live_workout_screen_speed_2d2cb022">Vitesse</string>
+    <string name="l10n_live_workout_screen_this_stops_recording_and_saves_what_3e17a23e">Cela arrête l\'enregistrement et sauvegarde ce qui a été capturé jusqu\'à présent. Impossible de le reprendre.</string>
     <string name="l10n_live_workout_screen_z_z_d3991a28">Z%1$s</string>
     <string name="l10n_marker_editor_screen_add_a_reading_ed7708ee">Ajouter une lecture</string>
     <string name="l10n_marker_editor_screen_date_taken_76edfcab">Date de la mesure</string>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -600,11 +600,14 @@
     <string name="l10n_live_session_screen_the_strap_signal_was_gone_for_57a2fead">The strap signal was gone for 10 minutes, so the session ended itself.</string>
     <string name="l10n_live_workout_screen_avg_cdc93143">Avg</string>
     <string name="l10n_live_workout_screen_cadence_68af11f0">Cadence</string>
+    <string name="l10n_live_workout_screen_cancel_77dfd213">Cancel</string>
     <string name="l10n_live_workout_screen_effort_8c974bc6">Effort</string>
+    <string name="l10n_live_workout_screen_end_this_workout_4869c76a">End this workout?</string>
     <string name="l10n_live_workout_screen_end_workout_3e8d6238">End workout</string>
     <string name="l10n_live_workout_screen_peak_c83dbbd3">Peak</string>
     <string name="l10n_live_workout_screen_power_7548ab52">Power</string>
     <string name="l10n_live_workout_screen_speed_2d2cb022">Speed</string>
+    <string name="l10n_live_workout_screen_this_stops_recording_and_saves_what_3e17a23e">This stops recording and saves what\'s captured so far. It can\'t be resumed.</string>
     <string name="l10n_live_workout_screen_z_z_d3991a28">Z%1$s</string>
     <string name="l10n_marker_editor_screen_add_a_reading_ed7708ee">Add a reading</string>
     <string name="l10n_marker_editor_screen_date_taken_76edfcab">Date taken</string>


### PR DESCRIPTION
Closes #517.

## Problem
Tapping **End workout** on the in-exercise screen stopped the session and saved the (possibly incomplete) recording immediately — one accidental tap could cut a workout short with no way back.

## Fix
Gate the destructive End action behind a confirmation, on both platforms:
- **macOS + iOS** (shared `Strand/Screens/LiveWorkoutView.swift`): SwiftUI `.alert` with Cancel / destructive "End workout", matching the existing confirm pattern in `DevicesView` (restart/remove strap).
- **Android** (`LiveWorkoutScreen.kt`): Compose `AlertDialog` with the same Cancel / destructive "End workout" choice, matching `DevicesScreen`'s `ConfirmDialog`.

`AppModel.endWorkout()` / `AppViewModel.endWorkout()` themselves are untouched — this only adds a confirm step in front of the existing (already purely local, no BLE write) call. No stored-data shape changes.

## i18n
New strings (title + message + Cancel) added to both catalogs with de/es/fr translations (best-effort, for maintainer review) — `Strand/Resources/Localizable.xcstrings` and `android/app/src/main/res/values{,-de,-es,-fr}/strings.xml`. `python3 Tools/i18n_audit.py --ci upstream/main` passes clean.

## Verification
- `python3 Tools/i18n_audit.py --ci upstream/main` — clean (both platforms)
- `cd android && ./gradlew compileFullDebugKotlin` — BUILD SUCCESSFUL, no new warnings
- `xcodegen generate && xcodebuild -project Strand.xcodeproj -scheme Strand -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO build` — BUILD SUCCEEDED
- Not tested on-device/on-strap: this change has no BLE/hardware surface (End workout already didn't send anything to the strap; only local state/DB), so nothing here needs strap validation.