### PR TITLE
Add spacing to recovery header

### DIFF
--- a/android/app/src/main/java/com/noop/ui/TodayScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/TodayScreen.kt
@@ -3936,7 +3936,10 @@ private fun RecoveryDriversSection(
 
     Column(verticalArrangement = Arrangement.spacedBy(Metrics.gap)) {
         // Header row: section title + the SURFACED confidence pill (dot + tier tag) on the right.
-        Row(verticalAlignment = Alignment.Top) {
+        Row(
+            verticalAlignment = Alignment.Top,
+            horizontalArrangement = Arrangement.spacedBy(Metrics.space8),
+        ) {
             Box(modifier = Modifier.weight(1f)) {
                 SectionHeader("What shaped it", overline = overline, trailing = "vs your baseline")
             }


### PR DESCRIPTION
## Summary

- add an 8 dp design-token gap between the recovery baseline caption and confidence pill
- keep the existing header hierarchy, copy, and confidence presentation unchanged

## Why

The recovery header row did not define any horizontal spacing between its weighted section header and the confidence pill. As a result, `vs your baseline` rendered directly against the pill border.

This addresses item 11 of #492.

## Validation

- `./gradlew assembleFullDebug testFullDebugUnitTest`
- `python3 Tools/i18n_audit.py --ci upstream/main`
- `git diff --check`
