### PR TITLE
Align Today edit actions

### DIFF
--- a/android/app/src/main/java/com/noop/ui/TodayScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/TodayScreen.kt
@@ -1417,22 +1417,15 @@ fun TodayScreen(
                             modifier = Modifier.fillMaxWidth(),
                             verticalArrangement = Arrangement.spacedBy(12.dp),
                         ) {
-                            Row(verticalAlignment = Alignment.CenterVertically) {
+                            Row(verticalAlignment = Alignment.Top) {
                                 Box(modifier = Modifier.weight(1f)) {
                                     SectionHeader("Key Metrics", overline = dayLabel, trailing = trendWindowLabel(keyMetricsWindowDays))
                                 }
-                                TextButton(
+                                TodayEditAction(
                                     onClick = { showMetricsEditor = true },
-                                    colors = ButtonDefaults.textButtonColors(contentColor = Palette.accent),
-                                ) {
-                                    Icon(
-                                        Icons.Filled.Tune,
-                                        contentDescription = uiString(R.string.l10n_today_screen_edit_key_metrics_f95e61a4),
-                                        modifier = Modifier.size(Metrics.iconSmall),
-                                    )
-                                    Spacer(Modifier.width(4.dp))
-                                    Text(uiString(R.string.l10n_today_screen_edit_5301648d), style = NoopType.footnote)
-                                }
+                                    contentDescription = uiString(R.string.l10n_today_screen_edit_key_metrics_f95e61a4),
+                                    contentAlignment = Alignment.TopCenter,
+                                )
                             }
                             Box(modifier = Modifier.fillMaxWidth().staggeredAppear(stagger)) {
                                 MetricGrid(
@@ -2927,6 +2920,41 @@ private fun HeroVitalRow(label: String, value: String, tint: Color, fraction: Do
 // big white value + small unit + chevron on the right. A card with no value yet renders a dash rather than
 // vanishing. Mirrors iOS TodayView.yourCardsSection / pinnedCardRow / dashboardValue / dashboardTint.
 
+/** Shared Today section edit affordance. The 48dp box keeps the whole control easy to tap while its
+ *  visible content stays pinned to the overline instead of centring against a two-line header. */
+@Composable
+private fun TodayEditAction(
+    contentDescription: String,
+    onClick: () -> Unit,
+    contentAlignment: Alignment = Alignment.Center,
+) {
+    Box(
+        modifier = Modifier
+            .height(48.dp)
+            .clickable(onClick = onClick)
+            .semantics { this.contentDescription = contentDescription }
+            .padding(horizontal = Metrics.space12),
+    ) {
+        Row(
+            modifier = Modifier.align(contentAlignment),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Icon(
+                Icons.Filled.Tune,
+                contentDescription = null,
+                tint = Palette.accent,
+                modifier = Modifier.size(14.dp),
+            )
+            Spacer(Modifier.width(Metrics.space4))
+            Text(
+                uiString(R.string.l10n_today_screen_edit_5301648d).uppercase(Locale.getDefault()),
+                style = NoopType.overline.copy(letterSpacing = 0.4.sp),
+                color = Palette.accent,
+            )
+        }
+    }
+}
+
 @Composable
 private fun YourCardsSection(
     cards: List<DashboardCard>,
@@ -2952,26 +2980,13 @@ private fun YourCardsSection(
 ) {
     Box(modifier = Modifier.fillMaxWidth().staggeredAppear(2)) {
         Column(verticalArrangement = Arrangement.spacedBy(Metrics.gap)) {
-            // Header: "YOUR CARDS" overline + a right-aligned blue CUSTOMISE action (the WHOOP ✎ affordance).
+            // Header: "YOUR CARDS" overline + a right-aligned blue EDIT action (the WHOOP ✎ affordance).
             Row(verticalAlignment = Alignment.CenterVertically) {
                 Overline("Your cards", modifier = Modifier.weight(1f))
-                TextButton(
+                TodayEditAction(
                     onClick = onCustomise,
-                    colors = ButtonDefaults.textButtonColors(contentColor = Palette.accent),
-                    modifier = Modifier.semantics { contentDescription = uiString(R.string.l10n_today_screen_customise_your_cards_2428d761) },
-                ) {
-                    Icon(
-                        Icons.Filled.Tune,
-                        contentDescription = null,
-                        modifier = Modifier.size(14.dp),
-                    )
-                    Spacer(Modifier.width(4.dp))
-                    Text(
-                        uiString(R.string.l10n_today_screen_customise_b378dddc),
-                        style = NoopType.overline.copy(letterSpacing = 0.4.sp),
-                        color = Palette.accent,
-                    )
-                }
+                    contentDescription = uiString(R.string.l10n_today_screen_customise_your_cards_2428d761),
+                )
             }
             cards.forEach { card ->
                 DashboardCardRow(


### PR DESCRIPTION
## Summary

- align the Key Metrics edit action with the header overline instead of the full two-line header
- use one shared uppercase `EDIT` treatment for Key Metrics and Your Cards
- preserve 48 dp touch targets and the action-specific accessibility descriptions

## Why

Key Metrics used a standard mixed-case text button centred against its complete section header, while Your Cards used a compact uppercase overline action. That made the two equivalent controls look and align differently.

The shared action keeps the visible icon and label aligned to each section's overline without reducing the tappable area. Localized edit labels are uppercased at display time rather than replaced with hardcoded copy.

This addresses item 4 of #492.

## Validation

- `./gradlew assembleFullDebug testFullDebugUnitTest`
- `python3 Tools/i18n_audit.py --ci upstream/main`
- `git diff --check`
