### PR TITLE
Space the Data Sources section

### DIFF
--- a/android/app/src/main/java/com/noop/ui/TodayScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/TodayScreen.kt
@@ -5880,6 +5880,7 @@ private fun TodaySourcesSection(
     onToggle: () -> Unit = {},
 ) {
     SectionHeader("Data Sources", overline = "Provenance")
+    Spacer(Modifier.height(Metrics.gap))
     val whoopPresent = (footer.whoopDays ?: 0) > 0 || strapBatteryPct != null
     val applePresent = (footer.appleDays ?: 0) > 0 || (footer.appleWorkouts ?: 0) > 0
     val hcPresent = (footer.hcDays ?: 0) > 0 || (footer.hcWorkouts ?: 0) > 0


### PR DESCRIPTION
## Summary

- add the standard 12 dp section gap between the Data Sources header and its card
- apply the spacing to both collapsed and expanded Data Sources states

## Why

`TodaySourcesSection` rendered its `SectionHeader` immediately beside the following card without any vertical spacer. Other Today sections use the shared `Metrics.gap` token between headers and content, so Data Sources appeared visibly cramped by comparison.

This addresses item 2 of #492.

## Validation

- `./gradlew assembleFullDebug testFullDebugUnitTest`
- `python3 Tools/i18n_audit.py --ci upstream/main`
- `git diff --check`
