### PR TITLE
Add heart-rate recovery after intense workouts

### DIFF
--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/HeartRateRecovery.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/HeartRateRecovery.swift
@@ -1,0 +1,103 @@
+import Foundation
+import WhoopProtocol
+
+/// Heart-rate recovery after a sufficiently intense workout (#516).
+///
+/// The engine deliberately works from the recorded HR stream rather than the workout's editable summary
+/// fields. It looks for sustained Zone-3-or-higher effort near the end of the session, takes the highest
+/// recorded HR in the final 30 seconds as the cessation value, then compares it with robust median readings
+/// around 1, 2 and 5 minutes after the workout ended.
+///
+/// Missing post-workout coverage stays nil. The engine never interpolates across a gap or turns a missing
+/// reading into zero, which is important when a strap disconnects as the workout ends.
+public enum HeartRateRecovery {
+    public struct Result: Equatable, Sendable {
+        public let endHR: Int
+        public let after1Minute: Int?
+        public let after2Minutes: Int?
+        public let after5Minutes: Int?
+
+        public init(endHR: Int, after1Minute: Int?, after2Minutes: Int?, after5Minutes: Int?) {
+            self.endHR = endHR
+            self.after1Minute = after1Minute
+            self.after2Minutes = after2Minutes
+            self.after5Minutes = after5Minutes
+        }
+
+        public var hasMeasurement: Bool {
+            after1Minute != nil || after2Minutes != nil || after5Minutes != nil
+        }
+    }
+
+    /// Zone 3 starts at 70% HRmax in NOOP's display-zone model.
+    public static let eligibilityFractionOfMaxHR = 0.70
+    /// The high-intensity effort must be sustained, not a single optical spike.
+    public static let minimumHighIntensitySeconds = 120
+    /// Eligibility is intentionally tied to the end of the workout: HRR is meaningful only when exercise
+    /// cessation, rather than a long cool-down, anchors the recovery clock.
+    public static let eligibilityLookbackSeconds = 300
+    public static let cessationWindowSeconds = 30
+    public static let measurementToleranceSeconds = 15
+    public static let minimumSamplesPerReading = 3
+    public static let maximumContinuousGapSeconds = 10
+
+    public static func calculate(samples: [HRSample], workoutStart: Int, workoutEnd: Int,
+                                 maxHR: Double) -> Result? {
+        guard workoutStart > 0, workoutEnd > workoutStart, maxHR > 0 else { return nil }
+        let lowerBound = max(workoutStart, workoutEnd - eligibilityLookbackSeconds)
+        let upperBound = workoutEnd + 5 * 60 + measurementToleranceSeconds
+        let sorted = samples
+            .filter { $0.ts >= lowerBound && $0.ts <= upperBound && (30...250).contains($0.bpm) }
+            .sorted { lhs, rhs in lhs.ts == rhs.ts ? lhs.bpm < rhs.bpm : lhs.ts < rhs.ts }
+        guard sorted.count >= minimumSamplesPerReading else { return nil }
+
+        let beforeEnd = sorted.filter { $0.ts <= workoutEnd }
+        let threshold = maxHR * eligibilityFractionOfMaxHR
+        guard sustainedSeconds(atOrAbove: threshold, in: beforeEnd) >= minimumHighIntensitySeconds else {
+            return nil
+        }
+
+        let cessation = beforeEnd
+            .filter { $0.ts >= workoutEnd - cessationWindowSeconds }
+            .map(\.bpm)
+        guard cessation.count >= minimumSamplesPerReading, let endHR = cessation.max() else { return nil }
+
+        func recovery(at minutes: Int) -> Int? {
+            let target = workoutEnd + minutes * 60
+            let values = sorted
+                .filter { abs($0.ts - target) <= measurementToleranceSeconds }
+                .map(\.bpm)
+            guard values.count >= minimumSamplesPerReading, let reading = median(values) else { return nil }
+            return endHR - reading
+        }
+
+        let result = Result(
+            endHR: endHR,
+            after1Minute: recovery(at: 1),
+            after2Minutes: recovery(at: 2),
+            after5Minutes: recovery(at: 5)
+        )
+        return result.hasMeasurement ? result : nil
+    }
+
+    private static func sustainedSeconds(atOrAbove threshold: Double, in samples: [HRSample]) -> Int {
+        guard samples.count >= 2 else { return 0 }
+        var seconds = 0
+        for i in 0..<(samples.count - 1) {
+            let gap = samples[i + 1].ts - samples[i].ts
+            guard gap > 0, gap <= maximumContinuousGapSeconds else { continue }
+            if Double(samples[i].bpm) >= threshold { seconds += gap }
+        }
+        return seconds
+    }
+
+    private static func median(_ values: [Int]) -> Int? {
+        guard !values.isEmpty else { return nil }
+        let sorted = values.sorted()
+        let middle = sorted.count / 2
+        if sorted.count.isMultiple(of: 2) {
+            return Int((Double(sorted[middle - 1] + sorted[middle]) / 2.0).rounded())
+        }
+        return sorted[middle]
+    }
+}

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/HeartRateRecoveryTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/HeartRateRecoveryTests.swift
@@ -1,0 +1,72 @@
+import XCTest
+import WhoopProtocol
+@testable import StrandAnalytics
+
+final class HeartRateRecoveryTests: XCTestCase {
+    private let end = 10_000
+
+    private func denseEligible(endHR: Int = 170) -> [HRSample] {
+        // Five minutes of continuous Zone-3+ effort, ending at the requested cessation HR.
+        (end - 300...end).map { HRSample(ts: $0, bpm: $0 >= end - 30 ? endHR : 145) }
+    }
+
+    private func window(minutes: Int, values: [Int]) -> [HRSample] {
+        let target = end + minutes * 60
+        return values.enumerated().map { i, bpm in HRSample(ts: target - values.count / 2 + i, bpm: bpm) }
+    }
+
+    func testCalculatesOneTwoAndFiveMinuteDropsFromRobustReadings() {
+        let samples = denseEligible()
+            + window(minutes: 1, values: [146, 146, 220, 146, 146]) // optical spike cannot own the reading
+            + window(minutes: 2, values: [132, 132, 132])
+            + window(minutes: 5, values: [112, 112, 112])
+
+        let result = HeartRateRecovery.calculate(samples: samples.shuffled(), workoutStart: end - 300,
+                                                 workoutEnd: end, maxHR: 200)
+        XCTAssertEqual(result, .init(endHR: 170, after1Minute: 24, after2Minutes: 38, after5Minutes: 58))
+    }
+
+    func testRequiresSustainedHighIntensityRatherThanOnePeak() {
+        var samples = (end - 300...end).map { HRSample(ts: $0, bpm: 120) }
+        samples.append(HRSample(ts: end, bpm: 190))
+        samples += window(minutes: 1, values: [140, 140, 140])
+        XCTAssertNil(HeartRateRecovery.calculate(samples: samples, workoutStart: end - 300,
+                                                 workoutEnd: end, maxHR: 200))
+    }
+
+    func testRejectsDisconnectedHighIntensityFragments() {
+        // Plenty of nominally-high points, but each is separated by more than the continuity cap.
+        let sparse = stride(from: end - 300, through: end, by: 15).map { HRSample(ts: $0, bpm: 170) }
+        let samples = sparse + window(minutes: 1, values: [140, 140, 140])
+        XCTAssertNil(HeartRateRecovery.calculate(samples: samples, workoutStart: end - 300,
+                                                 workoutEnd: end, maxHR: 200))
+    }
+
+    func testDoesNotCreditPreWorkoutHeartRateTowardEligibility() {
+        let samples = denseEligible() + window(minutes: 1, values: [140, 140, 140])
+        // Only the final minute belongs to this workout. The preceding high HR must not make it eligible.
+        XCTAssertNil(HeartRateRecovery.calculate(samples: samples, workoutStart: end - 60,
+                                                 workoutEnd: end, maxHR: 200))
+    }
+
+    func testReturnsOnlyMeasurementsWithRealCoverage() {
+        let samples = denseEligible()
+            + window(minutes: 1, values: [150, 150, 150])
+            + window(minutes: 5, values: [110, 110]) // fewer than the coverage gate
+        let result = HeartRateRecovery.calculate(samples: samples, workoutStart: end - 300,
+                                                 workoutEnd: end, maxHR: 200)
+        XCTAssertEqual(result, .init(endHR: 170, after1Minute: 20, after2Minutes: nil, after5Minutes: nil))
+    }
+
+    func testNoPostWorkoutCoverageReturnsNil() {
+        XCTAssertNil(HeartRateRecovery.calculate(samples: denseEligible(), workoutStart: end - 300,
+                                                 workoutEnd: end, maxHR: 200))
+    }
+
+    func testAHeartRateRiseRemainsSignedInsteadOfBeingClamped() {
+        let samples = denseEligible(endHR: 160) + window(minutes: 1, values: [165, 165, 165])
+        let result = HeartRateRecovery.calculate(samples: samples, workoutStart: end - 300,
+                                                 workoutEnd: end, maxHR: 200)
+        XCTAssertEqual(result?.after1Minute, -5)
+    }
+}

--- a/Strand/Data/Repository.swift
+++ b/Strand/Data/Repository.swift
@@ -2484,6 +2484,19 @@ final class Repository: ObservableObject {
         return minutes.contains(where: { $0 > 0 }) ? minutes : nil
     }
 
+    /// HRR for one workout (#516), derived from the final five minutes of recorded effort plus the five
+    /// post-workout minutes. This is a narrow read (at most ~10 minutes), not a whole-workout scan, and the
+    /// pure engine owns every eligibility/coverage guard. Missing post-workout HR therefore returns nil
+    /// instead of fabricating a recovery value. Kotlin twin: `AppViewModel.workoutHeartRateRecovery`.
+    func workoutHeartRateRecovery(from: Int, to: Int, maxHR: Double) async -> HeartRateRecovery.Result? {
+        guard to > from, maxHR > 0 else { return nil }
+        let readFrom = max(from, to - HeartRateRecovery.eligibilityLookbackSeconds)
+        let readTo = to + 5 * 60 + HeartRateRecovery.measurementToleranceSeconds
+        let samples = await hrSamples(from: readFrom, to: readTo, limit: 2_000)
+        return HeartRateRecovery.calculate(samples: samples, workoutStart: from, workoutEnd: to,
+                                           maxHR: maxHR)
+    }
+
     /// Apple Health daily aggregates (steps/energy/vo2/hr).
     func appleDailyRows(days: Int = 4000) async -> [AppleDaily] {
         guard let store = await ensureStore() else { return [] }

--- a/Strand/Screens/WorkoutDetailView.swift
+++ b/Strand/Screens/WorkoutDetailView.swift
@@ -47,6 +47,9 @@ struct WorkoutDetailView: View {
     /// True when the zones bar came from imported WHOOP percentages (vs derived from raw strap HR).
     @State private var zonesFromImport = false
     @State private var loaded = false
+    /// #516: computed from the recorded workout-end + post-workout HR window. nil when the workout was
+    /// not intense enough or the strap did not record enough post-workout coverage.
+    @State private var heartRateRecovery: HeartRateRecovery.Result?
 
     /// The GPS route captured for this session on-device (#524), if any. Decoded from `RouteStore` by the
     /// row's natural key. nil = no route was recorded (honest — the map only shows when points exist).
@@ -76,6 +79,7 @@ struct WorkoutDetailView: View {
             routeCard
             hrCurveCard
             zonesCard
+            heartRateRecoveryCard
             if let strain = row.strain {
                 effortCard(strain: strain)
             }
@@ -122,6 +126,9 @@ struct WorkoutDetailView: View {
             minutes = await repo.workoutZoneMinutes(from: row.startTs, to: row.endTs, age: profile.age)
         }
 
+        let hrr = await repo.workoutHeartRateRecovery(
+            from: row.startTs, to: row.endTs, maxHR: Double(profile.hrMax))
+
         // Steps for an on-foot session (#398), computed at display time over the exact window so it
         // "fills in after sync": prefer the strap's own counter (MG/5.0) once it has offloaded the window,
         // else the phone pedometer (any strap, incl. WHOOP 4.0 / CSV-import). Never shown for non-foot
@@ -145,9 +152,53 @@ struct WorkoutDetailView: View {
             self.hrPoints = points
             self.zoneMinutes = minutes
             self.zonesFromImport = fromImport
+            self.heartRateRecovery = hrr
             self.steps = stepReadout
             self.loaded = true
         }
+    }
+
+    // MARK: - Heart-rate recovery (#516)
+
+    @ViewBuilder private var heartRateRecoveryCard: some View {
+        if let recovery = heartRateRecovery {
+            VStack(alignment: .leading, spacing: NoopMetrics.gap) {
+                SectionHeader("Heart Rate Recovery", overline: "After high-intensity effort",
+                              trailing: String(localized: "Peak \(recovery.endHR) bpm"))
+                NoopCard(tint: StrandPalette.metricRose) {
+                    VStack(alignment: .leading, spacing: 14) {
+                        HStack(spacing: 0) {
+                            recoveryStat(String(localized: "1 min"), value: recovery.after1Minute)
+                            recoveryStat(String(localized: "2 min"), value: recovery.after2Minutes)
+                            recoveryStat(String(localized: "5 min"), value: recovery.after5Minutes)
+                        }
+                        Divider().overlay(StrandPalette.hairline)
+                        Text("The change from your heart rate at the end of exercise. Positive values mean your heart rate fell; a dash means the strap did not record enough data around that minute.")
+                            .font(StrandFont.footnote)
+                            .foregroundStyle(StrandPalette.textTertiary)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+                }
+            }
+        }
+    }
+
+    private func recoveryStat(_ label: String, value: Int?) -> some View {
+        VStack(alignment: .leading, spacing: 3) {
+            Text(label).strandOverline()
+            Text(value.map { "\($0)" } ?? "–")
+                .font(StrandFont.number(24))
+                .foregroundStyle(value.map { $0 >= 0 ? StrandPalette.statusPositive
+                                                     : StrandPalette.statusWarning }
+                                 ?? StrandPalette.textTertiary)
+            Text("bpm")
+                .font(StrandFont.footnote)
+                .foregroundStyle(StrandPalette.textTertiary)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(value.map { String(localized: "Heart rate recovery at \(label), \($0) beats per minute") }
+                            ?? String(localized: "Heart rate recovery at \(label), not available"))
     }
 
     // MARK: - Header

--- a/Strand/Screens/WorkoutsView.swift
+++ b/Strand/Screens/WorkoutsView.swift
@@ -1,8 +1,15 @@
 import SwiftUI
+import Charts
 import StrandDesign
 import StrandAnalytics
 import WhoopStore
 import Foundation
+
+private struct WorkoutRecoveryTrendPoint: Identifiable, Equatable {
+    let startTs: Int
+    let result: HeartRateRecovery.Result
+    var id: Int { startTs }
+}
 
 // MARK: - Workouts
 //
@@ -74,6 +81,11 @@ struct WorkoutsView: View {
     /// A transient one-line note shown after a manual save / relabel for a sport that already has a
     /// solid/building ActivityCost entry — "Sessions like this usually …" (#439). Auto-clears.
     @State private var postLogNote: String?
+
+    /// #516: eligible workouts in the visible 7/30/90-day window, calculated from recorded HR. Wider
+    /// workout ranges intentionally keep this trend capped at 90 days so opening a deep history never
+    /// launches hundreds of raw-HR reads.
+    @State private var recoveryTrend: [WorkoutRecoveryTrendPoint] = []
 
     // MARK: - Filters + selection (#64)
 
@@ -163,6 +175,7 @@ struct WorkoutsView: View {
                 if let z = zonesSummary {
                     zonesSection(z, totalSessions: windowRows.count)
                 }
+                recoveryTrendSection
                 sessionsSection(rows: windowRows)
             }
         }
@@ -191,6 +204,9 @@ struct WorkoutsView: View {
         // full read is needed to show the older sessions.
         .onChange(of: range) { newRange in
             Task { await expandWindowIfNeeded(for: newRange == .all ? .all : effectiveRange) }
+        }
+        .task(id: recoveryTrendInputKey) {
+            await loadRecoveryTrend()
         }
         .sheet(item: $sheet) { target in
             ManualWorkoutSheet(editing: target.editing) { row, replacing in
@@ -258,6 +274,76 @@ struct WorkoutsView: View {
     /// (`effectiveRange`) still covers a now-empty window.
     private func reload() async {
         allRows = await repo.workoutRows(days: loadedWindowDays ?? 4000)
+    }
+
+    // MARK: - Heart-rate recovery trend (#516)
+
+    /// Apply the screen's active filter + range, capped to the latest 90 days as promised by the feature.
+    private var recoveryTrendRows: [WorkoutRow] {
+        let visible = sessions(for: effectiveRange)
+        guard let last = latestTs else { return [] }
+        let cutoff = last - 90 * 86_400
+        return visible.filter { $0.startTs >= cutoff }.sorted { $0.startTs < $1.startTs }
+    }
+
+    /// Stable task identity: changing the range/filter/rows or HRmax cancels and rebuilds the trend.
+    private var recoveryTrendInputKey: String {
+        let rows = recoveryTrendRows
+        return "\(repo.refreshSeq)|\(model.profile.hrMax)|"
+            + rows.map { "\($0.startTs):\($0.endTs)" }.joined(separator: ",")
+    }
+
+    private var recoveryTrendCaption: String {
+        if let days = effectiveRange.days, days <= 90 { return effectiveRange.caption }
+        return String(localized: "last 90 days")
+    }
+
+    private func loadRecoveryTrend() async {
+        guard !usesPreviewRows else { recoveryTrend = []; return }
+        var built: [WorkoutRecoveryTrendPoint] = []
+        for row in recoveryTrendRows {
+            if Task.isCancelled { return }
+            if let result = await repo.workoutHeartRateRecovery(
+                from: row.startTs, to: row.endTs, maxHR: Double(model.profile.hrMax)) {
+                built.append(WorkoutRecoveryTrendPoint(startTs: row.startTs, result: result))
+            }
+        }
+        guard !Task.isCancelled else { return }
+        recoveryTrend = built
+    }
+
+    @ViewBuilder private var recoveryTrendSection: some View {
+        if !recoveryTrend.isEmpty {
+            VStack(alignment: .leading, spacing: NoopMetrics.gap) {
+                SectionHeader("Recovery Trend", overline: "Heart-rate recovery · \(recoveryTrendCaption)",
+                              trailing: recoveryTrend.count == 1
+                                ? String(localized: "1 workout")
+                                : String(localized: "\(recoveryTrend.count) workouts"))
+                NoopCard(tint: StrandPalette.metricRose) {
+                    VStack(alignment: .leading, spacing: 12) {
+                        WorkoutRecoveryTrendChart(points: recoveryTrend)
+                            .frame(height: NoopMetrics.chartHeight)
+                        HStack(spacing: 16) {
+                            recoveryLegend("1 min", color: StrandPalette.metricRose)
+                            recoveryLegend("2 min", color: StrandPalette.metricCyan)
+                            recoveryLegend("5 min", color: StrandPalette.metricPurple)
+                        }
+                        Divider().overlay(StrandPalette.hairline)
+                        Text("Each line shows how many beats per minute your heart rate changed after exercise. Only high-intensity workouts with recorded post-workout heart rate are included.")
+                            .font(StrandFont.footnote)
+                            .foregroundStyle(StrandPalette.textTertiary)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+                }
+            }
+        }
+    }
+
+    private func recoveryLegend(_ label: LocalizedStringKey, color: Color) -> some View {
+        HStack(spacing: 5) {
+            Circle().fill(color).frame(width: 8, height: 8)
+            Text(label).font(StrandFont.footnote).foregroundStyle(StrandPalette.textSecondary)
+        }
     }
 
     /// #797: page the FULL workout history in when the user selects a range wider than the bounded
@@ -1580,6 +1666,79 @@ struct WorkoutsView: View {
         static let effort: CGFloat = 64   // #796 per-session Effort column
         static let source: CGFloat = 80
         static let action: CGFloat = 36   // trailing "•••" per-row actions menu
+    }
+}
+
+/// Three raw-bpm HRR lines on one shared axis (#516). Unlike Compare's normalized overlay, these values
+/// share a unit and scale, so their vertical distance remains meaningful. Point marks keep a single eligible
+/// workout visible even when there is not yet enough history to draw a line.
+private struct WorkoutRecoveryTrendChart: View {
+    let points: [WorkoutRecoveryTrendPoint]
+
+    private struct Plot: Identifiable {
+        let startTs: Int
+        let interval: String
+        let value: Int
+        var id: String { "\(interval)@\(startTs)" }
+        var date: Date { Date(timeIntervalSince1970: TimeInterval(startTs)) }
+    }
+
+    private var plots: [Plot] {
+        points.flatMap { point in
+            var out: [Plot] = []
+            if let value = point.result.after1Minute {
+                out.append(Plot(startTs: point.startTs, interval: String(localized: "1 min"), value: value))
+            }
+            if let value = point.result.after2Minutes {
+                out.append(Plot(startTs: point.startTs, interval: String(localized: "2 min"), value: value))
+            }
+            if let value = point.result.after5Minutes {
+                out.append(Plot(startTs: point.startTs, interval: String(localized: "5 min"), value: value))
+            }
+            return out
+        }
+    }
+
+    var body: some View {
+        let one = String(localized: "1 min")
+        let two = String(localized: "2 min")
+        let five = String(localized: "5 min")
+        Chart(plots) { point in
+            LineMark(
+                x: .value("Workout", point.date),
+                y: .value("Recovery", point.value)
+            )
+            .foregroundStyle(by: .value("Recovery interval", point.interval))
+            .interpolationMethod(.catmullRom)
+            PointMark(
+                x: .value("Workout", point.date),
+                y: .value("Recovery", point.value)
+            )
+            .foregroundStyle(by: .value("Recovery interval", point.interval))
+            .symbolSize(28)
+        }
+        .chartForegroundStyleScale(
+            domain: [one, two, five],
+            range: [StrandPalette.metricRose, StrandPalette.metricCyan, StrandPalette.metricPurple]
+        )
+        .chartLegend(.hidden)
+        .chartXAxis {
+            AxisMarks(values: .automatic(desiredCount: 4)) { value in
+                AxisGridLine().foregroundStyle(StrandPalette.hairline)
+                AxisValueLabel(format: .dateTime.month(.abbreviated).day())
+                    .foregroundStyle(StrandPalette.textTertiary)
+            }
+        }
+        .chartYAxis {
+            AxisMarks(position: .leading, values: .automatic(desiredCount: 5)) { value in
+                AxisGridLine().foregroundStyle(StrandPalette.hairline)
+                AxisValueLabel {
+                    if let bpm = value.as(Int.self) { Text("\(bpm)") }
+                }
+                .foregroundStyle(StrandPalette.textTertiary)
+            }
+        }
+        .accessibilityLabel("Heart-rate recovery trend in beats per minute")
     }
 }
 

--- a/android/app/src/main/java/com/noop/analytics/HeartRateRecovery.kt
+++ b/android/app/src/main/java/com/noop/analytics/HeartRateRecovery.kt
@@ -1,0 +1,89 @@
+package com.noop.analytics
+
+import com.noop.data.HrSample
+import kotlin.math.abs
+import kotlin.math.roundToInt
+
+/**
+ * Heart-rate recovery after a sufficiently intense workout (#516). Kotlin twin of
+ * `StrandAnalytics/HeartRateRecovery.swift`.
+ *
+ * Missing post-workout coverage stays null: the engine never interpolates across a disconnect or turns
+ * a missing reading into zero.
+ */
+object HeartRateRecovery {
+    data class Result(
+        val endHr: Int,
+        val after1Minute: Int?,
+        val after2Minutes: Int?,
+        val after5Minutes: Int?,
+    ) {
+        val hasMeasurement: Boolean
+            get() = after1Minute != null || after2Minutes != null || after5Minutes != null
+    }
+
+    const val eligibilityFractionOfMaxHr = 0.70
+    const val minimumHighIntensitySeconds = 120L
+    const val eligibilityLookbackSeconds = 300L
+    const val cessationWindowSeconds = 30L
+    const val measurementToleranceSeconds = 15L
+    const val minimumSamplesPerReading = 3
+    const val maximumContinuousGapSeconds = 10L
+
+    fun calculate(samples: List<HrSample>, workoutStart: Long, workoutEnd: Long, maxHr: Double): Result? {
+        if (workoutStart <= 0L || workoutEnd <= workoutStart || maxHr <= 0.0) return null
+        val lowerBound = maxOf(workoutStart, workoutEnd - eligibilityLookbackSeconds)
+        val upperBound = workoutEnd + 5 * 60 + measurementToleranceSeconds
+        val sorted = samples
+            .filter { it.ts in lowerBound..upperBound && it.bpm in 30..250 }
+            .sortedWith(compareBy<HrSample> { it.ts }.thenBy { it.bpm })
+        if (sorted.size < minimumSamplesPerReading) return null
+
+        val beforeEnd = sorted.filter { it.ts <= workoutEnd }
+        val threshold = maxHr * eligibilityFractionOfMaxHr
+        if (sustainedSeconds(threshold, beforeEnd) < minimumHighIntensitySeconds) return null
+
+        val cessation = beforeEnd
+            .filter { it.ts >= workoutEnd - cessationWindowSeconds }
+            .map { it.bpm }
+        if (cessation.size < minimumSamplesPerReading) return null
+        val endHr = cessation.maxOrNull() ?: return null
+
+        fun recovery(minutes: Int): Int? {
+            val target = workoutEnd + minutes * 60L
+            val values = sorted.filter { abs(it.ts - target) <= measurementToleranceSeconds }.map { it.bpm }
+            if (values.size < minimumSamplesPerReading) return null
+            return endHr - (median(values) ?: return null)
+        }
+
+        return Result(
+            endHr = endHr,
+            after1Minute = recovery(1),
+            after2Minutes = recovery(2),
+            after5Minutes = recovery(5),
+        ).takeIf { it.hasMeasurement }
+    }
+
+    private fun sustainedSeconds(threshold: Double, samples: List<HrSample>): Long {
+        if (samples.size < 2) return 0L
+        var seconds = 0L
+        for (i in 0 until samples.lastIndex) {
+            val gap = samples[i + 1].ts - samples[i].ts
+            if (gap in 1..maximumContinuousGapSeconds && samples[i].bpm.toDouble() >= threshold) {
+                seconds += gap
+            }
+        }
+        return seconds
+    }
+
+    private fun median(values: List<Int>): Int? {
+        if (values.isEmpty()) return null
+        val sorted = values.sorted()
+        val middle = sorted.size / 2
+        return if (sorted.size % 2 == 0) {
+            ((sorted[middle - 1] + sorted[middle]) / 2.0).roundToInt()
+        } else {
+            sorted[middle]
+        }
+    }
+}

--- a/android/app/src/main/java/com/noop/ui/AppViewModel.kt
+++ b/android/app/src/main/java/com/noop/ui/AppViewModel.kt
@@ -57,6 +57,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
@@ -310,6 +311,11 @@ class AppViewModel(app: Application) : AndroidViewModel(app) {
 
     /** Live connection + biometric snapshot, surfaced straight from the BLE client. */
     val live: StateFlow<LiveState> = ble.state
+    /** Low-frequency projection for history consumers that need to refresh after an offload without
+     *  collecting the full live state (which republishes every heart-rate packet). */
+    val lastHistorySyncAt: StateFlow<Long?> = live
+        .map { it.lastSyncAt }
+        .stateIn(viewModelScope, SharingStarted.Eagerly, live.value.lastSyncAt)
 
     /** Which strap the user is pairing — drives the scan filter in [connect]. Defaults to WHOOP 4.0. */
     private val _selectedModel = MutableStateFlow(WhoopModel.WHOOP4)
@@ -1519,6 +1525,24 @@ class AppViewModel(app: Application) : AndroidViewModel(app) {
         val tiz = com.noop.analytics.HrZones.timeInZone(samples, zoneSet)
         val minutes = tiz.seconds.map { it / 60.0 }
         return if (minutes.any { it > 0.0 }) minutes else null
+    }
+
+    /** HRR for one workout (#516), derived from a narrow workout-end + post-workout HR read. The pure
+     *  engine owns the intensity and coverage gates, so a disconnect after exercise returns null rather
+     *  than an interpolated value. Mirrors macOS Repository.workoutHeartRateRecovery. */
+    suspend fun workoutHeartRateRecovery(from: Long, to: Long): com.noop.analytics.HeartRateRecovery.Result? {
+        if (to <= from) return null
+        val readFrom = maxOf(from, to - com.noop.analytics.HeartRateRecovery.eligibilityLookbackSeconds)
+        val readTo = to + 5 * 60 + com.noop.analytics.HeartRateRecovery.measurementToleranceSeconds
+        val samples = runCatching {
+            repository.hrSamplesUnion(activeStrapId, readFrom, readTo, limit = 2_000)
+        }.getOrDefault(emptyList())
+        return com.noop.analytics.HeartRateRecovery.calculate(
+            samples = samples,
+            workoutStart = from,
+            workoutEnd = to,
+            maxHr = profileStore.hrMax.toDouble(),
+        )
     }
 
     /** Steps over a manual-workout window `[from, to]` from the strap's own `step_motion_counter@57`

--- a/android/app/src/main/java/com/noop/ui/WorkoutsScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/WorkoutsScreen.kt
@@ -4,6 +4,7 @@ import com.noop.R
 import androidx.compose.ui.res.stringResource
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
+import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
@@ -80,7 +81,11 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Path
 import androidx.compose.ui.graphics.Shadow
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.graphics.StrokeJoin
+import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.semantics.clearAndSetSemantics
@@ -92,6 +97,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.noop.analytics.WorkoutSport
+import com.noop.analytics.HeartRateRecovery
 import com.noop.data.WorkoutRow
 import java.time.Instant
 import java.time.ZoneId
@@ -126,6 +132,7 @@ fun WorkoutsScreen(vm: AppViewModel) {
     // The ViewModel owns the loaded rows now (ALL sources incl. detected, dismissed-filtered) so a
     // mutation (add / edit / relabel / dismiss / delete) republishes the list and the screen updates.
     val allRows by vm.workouts.collectAsState()
+    val lastHistorySyncAt by vm.lastHistorySyncAt.collectAsStateWithLifecycle()
     // Cached daily metrics — the Charge side of the post-log activity-cost note (#439).
     val recentDays by vm.recentDays.collectAsStateWithLifecycle()
     var loaded by remember { mutableStateOf(false) }
@@ -162,6 +169,7 @@ fun WorkoutsScreen(vm: AppViewModel) {
     // A transient one-line note shown after a manual save / relabel for a sport that already has a
     // solid/building ActivityCost entry — "Sessions like this usually …" (#439). Auto-clears.
     var postLogNote by remember { mutableStateOf<String?>(null) }
+    var recoveryTrend by remember { mutableStateOf<List<WorkoutRecoveryTrendPoint>>(emptyList()) }
     // The sport whose recovery-cost note to surface once the reloaded sessions land. saveManualWorkout
     // / relabelDetected reload `vm.workouts` asynchronously, so we wait for `allRows` to update before
     // computing the note (otherwise it would read the pre-save list). Cleared once consumed.
@@ -177,6 +185,26 @@ fun WorkoutsScreen(vm: AppViewModel) {
             kotlinx.coroutines.delay(7_000)
             postLogNote = null
         }
+    }
+
+    // #516: use the same active filter/range as the workout page, capped to 90 days. The cap keeps a deep
+    // imported history from launching hundreds of raw-HR reads; 7D/30D/90D are the promised trend views.
+    val recoveryRange = run {
+        val resolved = effectiveRange(allRows, range, filter)
+        if (resolved.days == null || resolved.days > 90) WorkoutRange.Quarter else resolved
+    }
+    val recoveryRows = filter.apply(sessions(allRows, recoveryRange)).sortedBy { it.startTs }
+    val recoveryInputKey = buildString {
+        append(recoveryRange.name)
+        recoveryRows.forEach { append('|').append(it.startTs).append(':').append(it.endTs) }
+    }
+    LaunchedEffect(recoveryInputKey, vm.activeStrapId, lastHistorySyncAt) {
+        val built = ArrayList<WorkoutRecoveryTrendPoint>()
+        for (row in recoveryRows) {
+            val result = vm.workoutHeartRateRecovery(row.startTs, row.endTs) ?: continue
+            built += WorkoutRecoveryTrendPoint(row.startTs, result)
+        }
+        recoveryTrend = built
     }
 
     LaunchedEffect(Unit) {
@@ -259,6 +287,9 @@ fun WorkoutsScreen(vm: AppViewModel) {
             item { SummarySection(rows = windowRows, effectiveRange = resolved, groups = groups) }
             item { BreakdownSection(groups = groups, rows = windowRows) }
             item { ZonesSection(windowRows) }
+            if (recoveryTrend.isNotEmpty()) {
+                item { RecoveryTrendSection(recoveryTrend, recoveryRange.localizedCaption()) }
+            }
             item {
             SessionsSection(
                 vm = vm,
@@ -325,6 +356,11 @@ fun WorkoutsScreen(vm: AppViewModel) {
 
 /** Drives the manual add/edit dialog. [editing] null = add a new workout, non-null = edit it. */
 private data class DialogTarget(val editing: WorkoutRow?)
+
+private data class WorkoutRecoveryTrendPoint(
+    val startTs: Long,
+    val result: HeartRateRecovery.Result,
+)
 
 // MARK: - Empty / loading state
 
@@ -1254,6 +1290,7 @@ private fun WorkoutDetailSheet(vm: AppViewModel, row: WorkoutRow, onDismiss: () 
     var hrCurve by remember(row.startTs) { mutableStateOf<List<Double>>(emptyList()) }
     var zoneMinutes by remember(row.startTs) { mutableStateOf<List<Double>?>(null) }
     var zonesFromImport by remember(row.startTs) { mutableStateOf(false) }
+    var heartRateRecovery by remember(row.startTs) { mutableStateOf<HeartRateRecovery.Result?>(null) }
     // Steps for an on-foot sport (#398): the strap's own counter over the window, computed at display time
     // so it "fills in after sync". null for non-foot sports or when no strap counter covers the window.
     var steps by remember(row.startTs) { mutableStateOf<Int?>(null) }
@@ -1272,6 +1309,7 @@ private fun WorkoutDetailSheet(vm: AppViewModel, row: WorkoutRow, onDismiss: () 
             zoneMinutes = vm.workoutZoneMinutes(row.startTs, row.endTs)
             zonesFromImport = false
         }
+        heartRateRecovery = vm.workoutHeartRateRecovery(row.startTs, row.endTs)
     }
 
     ModalBottomSheet(
@@ -1389,7 +1427,194 @@ private fun WorkoutDetailSheet(vm: AppViewModel, row: WorkoutRow, onDismiss: () 
                     )
                 }
             }
+
+            heartRateRecovery?.let {
+                CardDivider()
+                HeartRateRecoveryCard(it)
+            }
         }
+    }
+}
+
+/** Per-workout HRR readout (#516). Values are signed bpm changes from the exercise-end HR; missing
+ *  minute windows remain dashes rather than being interpolated across a strap disconnect. */
+@Composable
+private fun HeartRateRecoveryCard(result: HeartRateRecovery.Result) {
+    Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+        SectionHeader(
+            title = uiString(R.string.l10n_workouts_screen_heart_rate_recovery_516),
+            overline = uiString(R.string.l10n_workouts_screen_after_high_intensity_effort_516),
+            trailing = uiString(R.string.l10n_workouts_screen_peak_hr_bpm_516, result.endHr),
+        )
+        NoopCard(tint = Palette.metricRose) {
+            Column(verticalArrangement = Arrangement.spacedBy(14.dp)) {
+                Row(modifier = Modifier.fillMaxWidth()) {
+                    RecoveryStat(
+                        uiString(R.string.l10n_workouts_screen_hrr_one_minute_516),
+                        result.after1Minute,
+                        Modifier.weight(1f),
+                    )
+                    RecoveryStat(
+                        uiString(R.string.l10n_workouts_screen_hrr_two_minutes_516),
+                        result.after2Minutes,
+                        Modifier.weight(1f),
+                    )
+                    RecoveryStat(
+                        uiString(R.string.l10n_workouts_screen_hrr_five_minutes_516),
+                        result.after5Minutes,
+                        Modifier.weight(1f),
+                    )
+                }
+                CardDivider()
+                Text(
+                    uiString(R.string.l10n_workouts_screen_hrr_explanation_516),
+                    style = NoopType.footnote,
+                    color = Palette.textTertiary,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun RecoveryStat(label: String, value: Int?, modifier: Modifier = Modifier) {
+    Column(
+        modifier = modifier.semantics {
+            contentDescription = uiString(
+                R.string.l10n_workouts_screen_hrr_accessibility_516,
+                label,
+                value?.toString() ?: uiString(R.string.l10n_workouts_screen_hrr_not_available_516),
+            )
+        },
+        verticalArrangement = Arrangement.spacedBy(3.dp),
+    ) {
+        Overline(label)
+        Text(
+            value?.toString() ?: "–",
+            style = NoopType.number(24f),
+            color = value?.let { if (it >= 0) Palette.statusPositive else Palette.statusWarning }
+                ?: Palette.textTertiary,
+        )
+        Text(
+            uiString(R.string.l10n_workouts_screen_hrr_bpm_516),
+            style = NoopType.footnote,
+            color = Palette.textTertiary,
+        )
+    }
+}
+
+/** Shared-axis 1/2/5-minute HRR trend (#516). These are raw bpm changes, not normalized values, so the
+ *  distance between lines remains meaningful. Missing minute windows are omitted from that series. */
+@Composable
+private fun RecoveryTrendSection(points: List<WorkoutRecoveryTrendPoint>, rangeCaption: String) {
+    val oneColor = Palette.metricRose
+    val twoColor = Palette.metricCyan
+    val fiveColor = Palette.metricPurple
+    Column(verticalArrangement = Arrangement.spacedBy(Metrics.gap)) {
+        SectionHeader(
+            title = uiString(R.string.l10n_workouts_screen_recovery_trend_516),
+            overline = uiString(R.string.l10n_workouts_screen_hrr_range_516, rangeCaption),
+            trailing = uiPlural(
+                R.plurals.l10n_workouts_screen_hrr_workout_count_516,
+                points.size,
+                points.size,
+            ),
+        )
+        NoopCard(tint = Palette.metricRose) {
+            Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                RecoveryTrendChart(
+                    points = points,
+                    oneColor = oneColor,
+                    twoColor = twoColor,
+                    fiveColor = fiveColor,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(Metrics.chartHeight),
+                )
+                Row(modifier = Modifier.fillMaxWidth()) {
+                    Text(dateLabel(points.first().startTs), style = NoopType.footnote, color = Palette.textTertiary)
+                    Spacer(Modifier.weight(1f))
+                    Text(dateLabel(points.last().startTs), style = NoopType.footnote, color = Palette.textTertiary)
+                }
+                Row(horizontalArrangement = Arrangement.spacedBy(16.dp)) {
+                    RecoveryLegend(uiString(R.string.l10n_workouts_screen_hrr_one_minute_516), oneColor)
+                    RecoveryLegend(uiString(R.string.l10n_workouts_screen_hrr_two_minutes_516), twoColor)
+                    RecoveryLegend(uiString(R.string.l10n_workouts_screen_hrr_five_minutes_516), fiveColor)
+                }
+                CardDivider()
+                Text(
+                    uiString(R.string.l10n_workouts_screen_hrr_trend_explanation_516),
+                    style = NoopType.footnote,
+                    color = Palette.textTertiary,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun RecoveryLegend(label: String, color: Color) {
+    Row(horizontalArrangement = Arrangement.spacedBy(5.dp), verticalAlignment = Alignment.CenterVertically) {
+        Box(Modifier.size(8.dp).clip(androidx.compose.foundation.shape.CircleShape).background(color))
+        Text(label, style = NoopType.footnote, color = Palette.textSecondary)
+    }
+}
+
+@Composable
+private fun RecoveryTrendChart(
+    points: List<WorkoutRecoveryTrendPoint>,
+    oneColor: Color,
+    twoColor: Color,
+    fiveColor: Color,
+    modifier: Modifier = Modifier,
+) {
+    val allValues = points.flatMap {
+        listOfNotNull(it.result.after1Minute, it.result.after2Minutes, it.result.after5Minutes)
+    }
+    if (allValues.isEmpty()) return
+    val low = allValues.minOrNull() ?: 0
+    val high = allValues.maxOrNull() ?: low
+    val padding = maxOf(4.0, (high - low) * 0.12)
+    val yMin = low - padding
+    val yMax = high + padding
+    val xMin = points.first().startTs
+    val xMax = points.last().startTs
+    val chartDescription = uiString(R.string.l10n_workouts_screen_hrr_chart_accessibility_516)
+
+    Canvas(modifier = modifier.semantics { contentDescription = chartDescription }) {
+        val gridColor = Palette.hairline
+        repeat(4) { index ->
+            val y = size.height * index / 3f
+            drawLine(gridColor, Offset(0f, y), Offset(size.width, y), strokeWidth = 1f)
+        }
+
+        fun x(ts: Long): Float = if (xMax == xMin) size.width / 2f
+            else ((ts - xMin).toDouble() / (xMax - xMin).toDouble() * size.width).toFloat()
+        fun y(value: Int): Float =
+            (size.height - ((value - yMin) / (yMax - yMin) * size.height)).toFloat()
+
+        fun drawSeries(color: Color, pick: (HeartRateRecovery.Result) -> Int?) {
+            val series = points.mapNotNull { point -> pick(point.result)?.let { point.startTs to it } }
+            if (series.isEmpty()) return
+            val path = Path()
+            series.forEachIndexed { index, (ts, value) ->
+                val px = x(ts)
+                val py = y(value)
+                if (index == 0) path.moveTo(px, py) else path.lineTo(px, py)
+            }
+            if (series.size > 1) {
+                drawPath(
+                    path = path,
+                    color = color,
+                    style = Stroke(width = 3.dp.toPx(), cap = StrokeCap.Round, join = StrokeJoin.Round),
+                )
+            }
+            series.forEach { (ts, value) -> drawCircle(color, radius = 3.5.dp.toPx(), center = Offset(x(ts), y(value))) }
+        }
+
+        drawSeries(oneColor) { it.after1Minute }
+        drawSeries(twoColor) { it.after2Minutes }
+        drawSeries(fiveColor) { it.after5Minutes }
     }
 }
 
@@ -1847,6 +2072,14 @@ private enum class WorkoutRange(val label: String, val caption: String, val days
     Quarter("90D", "last 90 days", 90, "quarter"),
     Year("1Y", "last year", 365, "year"),
     All("All", "all time", null, "log"),
+}
+
+/** The HRR card must not interpolate the range enum's legacy English-only caption into localized copy. */
+private fun WorkoutRange.localizedCaption(): String = when (this) {
+    WorkoutRange.Week -> uiString(R.string.l10n_workouts_screen_hrr_last_7_days_516)
+    WorkoutRange.Month -> uiString(R.string.l10n_workouts_screen_hrr_last_30_days_516)
+    WorkoutRange.Quarter, WorkoutRange.Year, WorkoutRange.All ->
+        uiString(R.string.l10n_workouts_screen_hrr_last_90_days_516)
 }
 
 /** This range plus every larger range, ascending — the auto-expand search order. */

--- a/android/app/src/main/res/values-de/strings.xml
+++ b/android/app/src/main/res/values-de/strings.xml
@@ -1640,6 +1640,23 @@
     <string name="explore_description_charge">Wie erholt du bist, angeführt von der HRV gegenüber deiner persönlichen Basislinie.</string>
     <string name="explore_description_effort">Herz-Kreislauf-Belastung für den Tag auf einer Skala von 0–100 (zuvor 0–21).</string>
     <string name="explore_description_rest">Wie erholsam dein Schlaf war: Dauer, Effizienz, Tief- und REM-Schlaf sowie Timing.</string>
+    <string name="l10n_workouts_screen_heart_rate_recovery_516">Herzfrequenzerholung</string>
+    <string name="l10n_workouts_screen_after_high_intensity_effort_516">Nach hochintensiver Belastung</string>
+    <string name="l10n_workouts_screen_peak_hr_bpm_516">Spitze %1$d bpm</string>
+    <string name="l10n_workouts_screen_hrr_one_minute_516">1 Min.</string>
+    <string name="l10n_workouts_screen_hrr_two_minutes_516">2 Min.</string>
+    <string name="l10n_workouts_screen_hrr_five_minutes_516">5 Min.</string>
+    <string name="l10n_workouts_screen_hrr_bpm_516">bpm</string>
+    <string name="l10n_workouts_screen_hrr_not_available_516">nicht verfügbar</string>
+    <string name="l10n_workouts_screen_hrr_accessibility_516">Herzfrequenzerholung nach %1$s: %2$s Schläge pro Minute</string>
+    <string name="l10n_workouts_screen_hrr_explanation_516">Die Veränderung gegenüber deiner Herzfrequenz am Ende der Belastung. Positive Werte bedeuten, dass deine Herzfrequenz gesunken ist; ein Strich bedeutet, dass das Band um diese Minute herum nicht genügend Daten aufgezeichnet hat.</string>
+    <string name="l10n_workouts_screen_recovery_trend_516">Erholungstrend</string>
+    <string name="l10n_workouts_screen_hrr_range_516">Herzfrequenzerholung · %1$s</string>
+    <string name="l10n_workouts_screen_hrr_trend_explanation_516">Jede Linie zeigt, um wie viele Schläge pro Minute sich deine Herzfrequenz nach der Belastung verändert hat. Berücksichtigt werden nur hochintensive Workouts mit aufgezeichneter Herzfrequenz nach der Belastung.</string>
+    <string name="l10n_workouts_screen_hrr_chart_accessibility_516">Trend der Herzfrequenzerholung in Schlägen pro Minute</string>
+    <string name="l10n_workouts_screen_hrr_last_7_days_516">letzte 7 Tage</string>
+    <string name="l10n_workouts_screen_hrr_last_30_days_516">letzte 30 Tage</string>
+    <string name="l10n_workouts_screen_hrr_last_90_days_516">letzte 90 Tage</string>
     <plurals name="intelligence_days_count">
         <item quantity="one">%1$d Tag</item>
         <item quantity="other">%1$d Tage</item>
@@ -1655,5 +1672,9 @@
     <plurals name="explore_n_days">
         <item quantity="one">%1$d Tag</item>
         <item quantity="other">%1$d Tage</item>
+    </plurals>
+    <plurals name="l10n_workouts_screen_hrr_workout_count_516">
+        <item quantity="one">%1$d Workout</item>
+        <item quantity="other">%1$d Workouts</item>
     </plurals>
 </resources>

--- a/android/app/src/main/res/values-es/strings.xml
+++ b/android/app/src/main/res/values-es/strings.xml
@@ -1625,6 +1625,23 @@
     <string name="explore_description_charge">Qué tan recuperado estás, según tu VFC frente a tu línea base personal.</string>
     <string name="explore_description_effort">Carga cardiovascular del día, en una escala de 0–100 (antes 0–21).</string>
     <string name="explore_description_rest">Qué tan reparador fue tu sueño: duración, eficiencia, sueño profundo y REM, y horario.</string>
+    <string name="l10n_workouts_screen_heart_rate_recovery_516">Recuperación de la frecuencia cardíaca</string>
+    <string name="l10n_workouts_screen_after_high_intensity_effort_516">Después de un esfuerzo de alta intensidad</string>
+    <string name="l10n_workouts_screen_peak_hr_bpm_516">Pico de %1$d lpm</string>
+    <string name="l10n_workouts_screen_hrr_one_minute_516">1 min</string>
+    <string name="l10n_workouts_screen_hrr_two_minutes_516">2 min</string>
+    <string name="l10n_workouts_screen_hrr_five_minutes_516">5 min</string>
+    <string name="l10n_workouts_screen_hrr_bpm_516">lpm</string>
+    <string name="l10n_workouts_screen_hrr_not_available_516">no disponible</string>
+    <string name="l10n_workouts_screen_hrr_accessibility_516">Recuperación de la frecuencia cardíaca a los %1$s: %2$s latidos por minuto</string>
+    <string name="l10n_workouts_screen_hrr_explanation_516">El cambio respecto a tu frecuencia cardíaca al terminar el ejercicio. Los valores positivos indican que la frecuencia cardíaca bajó; un guion indica que la pulsera no registró suficientes datos alrededor de ese minuto.</string>
+    <string name="l10n_workouts_screen_recovery_trend_516">Tendencia de recuperación</string>
+    <string name="l10n_workouts_screen_hrr_range_516">Recuperación cardíaca · %1$s</string>
+    <string name="l10n_workouts_screen_hrr_trend_explanation_516">Cada línea muestra cuántos latidos por minuto cambió tu frecuencia cardíaca después del ejercicio. Solo se incluyen entrenamientos de alta intensidad con frecuencia cardíaca registrada después del ejercicio.</string>
+    <string name="l10n_workouts_screen_hrr_chart_accessibility_516">Tendencia de recuperación de la frecuencia cardíaca en latidos por minuto</string>
+    <string name="l10n_workouts_screen_hrr_last_7_days_516">últimos 7 días</string>
+    <string name="l10n_workouts_screen_hrr_last_30_days_516">últimos 30 días</string>
+    <string name="l10n_workouts_screen_hrr_last_90_days_516">últimos 90 días</string>
     <plurals name="intelligence_days_count">
         <item quantity="one">%1$d día</item>
         <item quantity="other">%1$d días</item>
@@ -1640,5 +1657,9 @@
     <plurals name="explore_n_days">
         <item quantity="one">%1$d día</item>
         <item quantity="other">%1$d días</item>
+    </plurals>
+    <plurals name="l10n_workouts_screen_hrr_workout_count_516">
+        <item quantity="one">%1$d entrenamiento</item>
+        <item quantity="other">%1$d entrenamientos</item>
     </plurals>
 </resources>

--- a/android/app/src/main/res/values-fr/strings.xml
+++ b/android/app/src/main/res/values-fr/strings.xml
@@ -1625,6 +1625,23 @@
     <string name="explore_description_charge">Votre niveau de récupération, mesuré par la VFC par rapport à votre référence personnelle.</string>
     <string name="explore_description_effort">Charge cardiovasculaire de la journée, sur une échelle de 0 à 100 (auparavant 0 à 21).</string>
     <string name="explore_description_rest">À quel point votre sommeil a été réparateur : durée, efficacité, sommeil profond et paradoxal, et horaires.</string>
+    <string name="l10n_workouts_screen_heart_rate_recovery_516">Récupération de la fréquence cardiaque</string>
+    <string name="l10n_workouts_screen_after_high_intensity_effort_516">Après un effort intense</string>
+    <string name="l10n_workouts_screen_peak_hr_bpm_516">Pic à %1$d bpm</string>
+    <string name="l10n_workouts_screen_hrr_one_minute_516">1 min</string>
+    <string name="l10n_workouts_screen_hrr_two_minutes_516">2 min</string>
+    <string name="l10n_workouts_screen_hrr_five_minutes_516">5 min</string>
+    <string name="l10n_workouts_screen_hrr_bpm_516">bpm</string>
+    <string name="l10n_workouts_screen_hrr_not_available_516">indisponible</string>
+    <string name="l10n_workouts_screen_hrr_accessibility_516">Récupération de la fréquence cardiaque à %1$s : %2$s battements par minute</string>
+    <string name="l10n_workouts_screen_hrr_explanation_516">La variation par rapport à votre fréquence cardiaque à la fin de l’exercice. Une valeur positive indique que la fréquence cardiaque a baissé ; un tiret signifie que le bracelet n’a pas enregistré assez de données autour de cette minute.</string>
+    <string name="l10n_workouts_screen_recovery_trend_516">Tendance de récupération</string>
+    <string name="l10n_workouts_screen_hrr_range_516">Récupération cardiaque · %1$s</string>
+    <string name="l10n_workouts_screen_hrr_trend_explanation_516">Chaque ligne indique de combien de battements par minute votre fréquence cardiaque a changé après l’effort. Seuls les entraînements intenses avec une fréquence cardiaque enregistrée après l’effort sont inclus.</string>
+    <string name="l10n_workouts_screen_hrr_chart_accessibility_516">Tendance de récupération de la fréquence cardiaque en battements par minute</string>
+    <string name="l10n_workouts_screen_hrr_last_7_days_516">7 derniers jours</string>
+    <string name="l10n_workouts_screen_hrr_last_30_days_516">30 derniers jours</string>
+    <string name="l10n_workouts_screen_hrr_last_90_days_516">90 derniers jours</string>
     <plurals name="intelligence_days_count">
         <item quantity="one">%1$d jour</item>
         <item quantity="other">%1$d jours</item>
@@ -1640,5 +1657,9 @@
     <plurals name="explore_n_days">
         <item quantity="one">%1$d jour</item>
         <item quantity="other">%1$d jours</item>
+    </plurals>
+    <plurals name="l10n_workouts_screen_hrr_workout_count_516">
+        <item quantity="one">%1$d entraînement</item>
+        <item quantity="other">%1$d entraînements</item>
     </plurals>
 </resources>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -1649,6 +1649,23 @@
     <string name="explore_description_charge">How recovered you are, led by HRV versus your personal baseline.</string>
     <string name="explore_description_effort">Cardiovascular load for the day, on a 0-100 scale (was 0-21).</string>
     <string name="explore_description_rest">How restorative your sleep was: duration, efficiency, deep+REM, timing.</string>
+    <string name="l10n_workouts_screen_heart_rate_recovery_516">Heart Rate Recovery</string>
+    <string name="l10n_workouts_screen_after_high_intensity_effort_516">After high-intensity effort</string>
+    <string name="l10n_workouts_screen_peak_hr_bpm_516">Peak %1$d bpm</string>
+    <string name="l10n_workouts_screen_hrr_one_minute_516">1 min</string>
+    <string name="l10n_workouts_screen_hrr_two_minutes_516">2 min</string>
+    <string name="l10n_workouts_screen_hrr_five_minutes_516">5 min</string>
+    <string name="l10n_workouts_screen_hrr_bpm_516">bpm</string>
+    <string name="l10n_workouts_screen_hrr_not_available_516">not available</string>
+    <string name="l10n_workouts_screen_hrr_accessibility_516">Heart rate recovery at %1$s, %2$s beats per minute</string>
+    <string name="l10n_workouts_screen_hrr_explanation_516">The change from your heart rate at the end of exercise. Positive values mean your heart rate fell; a dash means the strap did not record enough data around that minute.</string>
+    <string name="l10n_workouts_screen_recovery_trend_516">Recovery Trend</string>
+    <string name="l10n_workouts_screen_hrr_range_516">Heart-rate recovery · %1$s</string>
+    <string name="l10n_workouts_screen_hrr_trend_explanation_516">Each line shows how many beats per minute your heart rate changed after exercise. Only high-intensity workouts with recorded post-workout heart rate are included.</string>
+    <string name="l10n_workouts_screen_hrr_chart_accessibility_516">Heart-rate recovery trend in beats per minute</string>
+    <string name="l10n_workouts_screen_hrr_last_7_days_516">last 7 days</string>
+    <string name="l10n_workouts_screen_hrr_last_30_days_516">last 30 days</string>
+    <string name="l10n_workouts_screen_hrr_last_90_days_516">last 90 days</string>
     <plurals name="intelligence_days_count">
         <item quantity="one">%1$d day</item>
         <item quantity="other">%1$d days</item>
@@ -1664,5 +1681,9 @@
     <plurals name="explore_n_days">
         <item quantity="one">%1$d day</item>
         <item quantity="other">%1$d days</item>
+    </plurals>
+    <plurals name="l10n_workouts_screen_hrr_workout_count_516">
+        <item quantity="one">%1$d workout</item>
+        <item quantity="other">%1$d workouts</item>
     </plurals>
 </resources>

--- a/android/app/src/test/java/com/noop/analytics/HeartRateRecoveryTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/HeartRateRecoveryTest.kt
@@ -1,0 +1,72 @@
+package com.noop.analytics
+
+import com.noop.data.HrSample
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class HeartRateRecoveryTest {
+    private val end = 10_000L
+
+    private fun denseEligible(endHr: Int = 170): List<HrSample> =
+        (end - 300..end).map { ts -> HrSample("strap", ts, if (ts >= end - 30) endHr else 145) }
+
+    private fun window(minutes: Int, values: List<Int>): List<HrSample> {
+        val target = end + minutes * 60L
+        return values.mapIndexed { i, bpm -> HrSample("strap", target - values.size / 2 + i, bpm) }
+    }
+
+    @Test
+    fun calculatesOneTwoAndFiveMinuteDropsFromRobustReadings() {
+        val samples = denseEligible() +
+            window(1, listOf(146, 146, 220, 146, 146)) +
+            window(2, listOf(132, 132, 132)) +
+            window(5, listOf(112, 112, 112))
+
+        assertEquals(
+            HeartRateRecovery.Result(170, 24, 38, 58),
+            HeartRateRecovery.calculate(samples.shuffled(), end - 300, end, 200.0),
+        )
+    }
+
+    @Test
+    fun requiresSustainedHighIntensityRatherThanOnePeak() {
+        val samples = (end - 300..end).map { HrSample("strap", it, 120) } +
+            HrSample("strap", end, 190) + window(1, listOf(140, 140, 140))
+        assertNull(HeartRateRecovery.calculate(samples, end - 300, end, 200.0))
+    }
+
+    @Test
+    fun rejectsDisconnectedHighIntensityFragments() {
+        val sparse = (end - 300..end step 15).map { HrSample("strap", it, 170) }
+        assertNull(HeartRateRecovery.calculate(sparse + window(1, listOf(140, 140, 140)), end - 300, end, 200.0))
+    }
+
+    @Test
+    fun doesNotCreditPreWorkoutHeartRateTowardEligibility() {
+        val samples = denseEligible() + window(1, listOf(140, 140, 140))
+        assertNull(HeartRateRecovery.calculate(samples, end - 60, end, 200.0))
+    }
+
+    @Test
+    fun returnsOnlyMeasurementsWithRealCoverage() {
+        val samples = denseEligible() + window(1, listOf(150, 150, 150)) + window(5, listOf(110, 110))
+        assertEquals(
+            HeartRateRecovery.Result(170, 20, null, null),
+            HeartRateRecovery.calculate(samples, end - 300, end, 200.0),
+        )
+    }
+
+    @Test
+    fun noPostWorkoutCoverageReturnsNull() {
+        assertNull(HeartRateRecovery.calculate(denseEligible(), end - 300, end, 200.0))
+    }
+
+    @Test
+    fun aHeartRateRiseRemainsSignedInsteadOfBeingClamped() {
+        val result = HeartRateRecovery.calculate(
+            denseEligible(160) + window(1, listOf(165, 165, 165)), end - 300, end, 200.0,
+        )
+        assertEquals(-5, result?.after1Minute)
+    }
+}


### PR DESCRIPTION
## Summary

- add byte-mirrored Swift/Kotlin heart-rate recovery engines for 1, 2, and 5 minutes after exercise
- require two continuous minutes at or above 70% of profile max HR in the workout's final five minutes, so a lone optical spike or a long cooldown does not qualify
- use the workout-end HR and robust median post-workout windows, preserving signed values and leaving missing coverage empty instead of interpolating
- show an HRR card in workout detail and a shared-axis 1/2/5-minute trend on the Workouts screen for its existing 7D/30D/90D ranges
- refresh trends after history offloads and localize the new surfaces in German, Spanish, and French

## Why

NOOP already stores the workout-adjacent heart-rate stream but did not turn it into a post-exercise recovery readout. The implementation derives HRR on demand from narrow workout-end windows, so it needs no schema migration and historical workouts can gain the metric as soon as their post-workout HR is present.

The UI remains informational and trend-focused. It does not apply the issue's proposed clinical category labels; unavailable minute windows remain dashes and only genuinely eligible workouts enter the trend.

## Validation

- `./gradlew :app:assembleFullDebug :app:testFullDebugUnitTest`
- `./gradlew :app:testFullDebugUnitTest --tests com.noop.analytics.HeartRateRecoveryTest`
- `python Tools/i18n_audit.py --ci upstream/main`
- `git diff --check`
- `jq empty Strand/Resources/Localizable.xcstrings`

Swift tooling is not installed on the CachyOS development host. The PR's macOS Swift Packages CI compiled the mirrored engine and passed the full StrandAnalytics suite; the repository's full Apple app-build workflow is disabled by default, so the SwiftUI surface was reviewed statically rather than built locally.

Closes #516
