### PR TITLE
Today steps: route by source, not catalog order (completes #551)

### DIFF
--- a/Strand/App/TabRoute.swift
+++ b/Strand/App/TabRoute.swift
@@ -22,6 +22,11 @@ enum TabRoute: Hashable {
     /// Trends' small-multiples share. Each card opens ITS metric (2026-07-02: not the shared
     /// Health screen).
     case metric(String)
+    /// One metric's detail by BOTH key and source. `steps` exists under several sources (my-whoop,
+    /// apple-health, xiaomi-band); routing by bare key alone resolves whichever catalog entry is
+    /// declared first, so a card's tap-through would silently depend on declaration order. This pins
+    /// the exact source, so the catalog's ordering can never decide where a card taps through.
+    case metricSourced(key: String, source: String)
     case metricExplorer
     case workouts
     case dataSources
@@ -45,6 +50,15 @@ extension View {
                 // catch-all vitals surface. (Pre-#198 Trends fell back to the Explorer instead —
                 // unified here rather than carrying two never-taken branches.)
                 if let m = MetricCatalog.all.first(where: { $0.key == key }) {
+                    MetricDetailView(metric: m)
+                } else {
+                    HealthView()
+                }
+            case .metricSourced(let key, let source):
+                // Exact (key, source) resolution, order-independent. Fall back to the bare-key entry,
+                // then Health, so a stale route can never dead-end.
+                if let m = MetricCatalog.metric(key: key, source: source)
+                    ?? MetricCatalog.all.first(where: { $0.key == key }) {
                     MetricDetailView(metric: m)
                 } else {
                     HealthView()

--- a/Strand/Data/MetricCatalog.swift
+++ b/Strand/Data/MetricCatalog.swift
@@ -156,10 +156,13 @@ enum MetricCatalog {
         // ── Effort (was Strain)
         d("strain", String(localized: "Effort"), "Effort", "/100", "my-whoop", "flame", 1, nil,
           String(localized: "Cardiovascular load for the day, on a 0-100 scale (was 0-21).")),
-        // WHOOP 5.0 / MG exposes a measured daily step count. Keep it separate from Apple Health's
-        // identically-keyed series so Today can open the same source it used for the displayed value.
-        d("steps", String(localized: "Steps"), "Effort", "steps", "my-whoop", "figure.walk", 0, true),
         d("steps", String(localized: "Steps"), "Effort", "", "apple-health", "figure.walk", 0, true),
+        // WHOOP 5.0 / MG exposes a measured daily step count. Declared AFTER apple-health on purpose:
+        // the bare-key `first { key == "steps" }` resolvers (LabBookView, CompareView, the TabRoute
+        // `.metric` fallback) keep their prior apple-health default, so this entry's position never
+        // changes where any of them tap through. The Today card/tile route to it EXPLICITLY by source
+        // (`.metricSourced` / `todayStepsMetric`), which is what actually needs it.
+        d("steps", String(localized: "Steps"), "Effort", "steps", "my-whoop", "figure.walk", 0, true),
         // On-device steps ESTIMATE for a WHOOP 4.0 (no real step count over BLE): the strap's daily
         // motion volume scaled by a personal calibration. Stored under the computed "-noop" source, so
         // it reads through the same exploreSeries fallback fitness_age/vitality use. Distinct from the

--- a/Strand/Liquid/LiquidTodayView.swift
+++ b/Strand/Liquid/LiquidTodayView.swift
@@ -623,7 +623,10 @@ struct LiquidTodayView: View {
                      value: unitText(displayDay?.respRateBpm, card.unit, decimals: 1),
                      tint: StrandPalette.accent, frac: fracOver(displayDay?.respRateBpm, 24))
         case .steps:
-            cardLink(.metric(stepsDetailKey), title: card.title, sub: card.subtitle,
+            // Route by exact source (my-whoop for both the measured "steps" and the "steps_est" fallback),
+            // NOT by bare key — bare "steps" resolves to apple-health and would show an empty detail for a
+            // WHOOP user. Order-independent, so the catalog needn't declare my-whoop first.
+            cardLink(.metricSourced(key: stepsDetailKey, source: "my-whoop"), title: card.title, sub: card.subtitle,
                      value: stepsText, tint: StrandPalette.metricCyan, frac: fracOver(stepCount, 10000))
         case .bloodOxygen:
             // Not wired to a real read yet — render EMPTY (not half-full) so it doesn't imply a reading.

--- a/StrandTests/MetricCatalogStepsTests.swift
+++ b/StrandTests/MetricCatalogStepsTests.swift
@@ -7,7 +7,6 @@ final class MetricCatalogStepsTests: XCTestCase {
 
         XCTAssertEqual(metric?.key, "steps")
         XCTAssertEqual(metric?.source, "my-whoop")
-        XCTAssertEqual(MetricCatalog.all.first(where: { $0.key == "steps" })?.source, "my-whoop")
     }
 
     func testTodayStepsUsesWhoopFourEstimateWhenMeasuredSeriesIsUnavailable() {
@@ -21,5 +20,23 @@ final class MetricCatalogStepsTests: XCTestCase {
         let metric = MetricCatalog.metric(key: "steps", source: "apple-health")
 
         XCTAssertEqual(metric?.id, "apple-health:steps")
+    }
+
+    /// Both measured WHOOP steps and the WHOOP 4.0 estimate must be resolvable by EXACT source, so the
+    /// Today card/tile can route to them (via `.metricSourced` / `todayStepsMetric`) without depending on
+    /// catalog declaration order.
+    func testWhoopStepsAreResolvableBySource() {
+        XCTAssertEqual(MetricCatalog.metric(key: "steps", source: "my-whoop")?.id, "my-whoop:steps")
+        XCTAssertEqual(MetricCatalog.metric(key: "steps_est", source: "my-whoop")?.id, "my-whoop:steps_est")
+    }
+
+    /// Regression guard: the bare-key `first { $0.key == "steps" }` resolvers that are NOT source-aware
+    /// (LabBookView's correlation descriptors, CompareView's default/legacy picks, the TabRoute `.metric`
+    /// fallback) must keep resolving Apple Health, exactly as before the measured-WHOOP entry was added.
+    /// The measured entry is declared AFTER apple-health precisely so it never captures these lookups —
+    /// the Today surface reaches it explicitly instead. If a future edit reorders the catalog, this fails
+    /// loudly rather than silently emptying those screens for an Apple-Health-steps user.
+    func testBareKeyStepsResolutionStaysAppleHealth() {
+        XCTAssertEqual(MetricCatalog.all.first(where: { $0.key == "steps" })?.source, "apple-health")
     }
 }


### PR DESCRIPTION
Builds on and completes #551 (@exzanimo) — includes that PR's commit plus one fix on top. Merging this closes #551; if #551 lands first, this reduces to just the follow-up commit.

## What #551 got right, and the one thing it left

#551 correctly fixes the Today steps tile tapping through to an empty `apple-health/steps` detail. But it does so partly by declaring the measured `my-whoop/steps` catalog entry **before** `apple-health/steps`, so `MetricCatalog.all.first { $0.key == "steps" }` now resolves to my-whoop. That lookup is used by three bare-key resolvers the PR doesn't touch:

- `LabBookView:938` `descriptor("steps")` (confirmed reachable — steps is in its analysed set)
- `CompareView`'s picker / legacy resolution
- the `TabRoute.metric` fallback

Since `my-whoop/steps` is empty for anyone not on a 5.0/MG, an **Apple-Health-steps user** (e.g. a WHOOP 4.0 owner who imports Health) would now get an empty LabBook steps correlation and Compare series where they previously saw their data. The reorder is load-bearing for #551's dashboard-card path (which routes by bare key), so it can't simply be dropped — the card needs the my-whoop entry to win.

## The fix: route by source, not by catalog order

- **`TabRoute.metricSourced(key:source:)`** — a new route that resolves the exact `(key, source)` via `MetricCatalog.metric(key:source:)`, order-independent, with a bare-key → Health fallback so a stale route can't dead-end.
- **The Today steps card** routes via `.metricSourced(key: stepsDetailKey, source: "my-whoop")` (both the measured `steps` and the `steps_est` fallback are my-whoop). The compact tile was already source-explicit in #551 via `todayStepsMetric`/`detailMetric`.
- **The reorder is undone** — the measured entry moves back after `apple-health`, so `first { key == "steps" }` returns apple-health again and LabBook / Compare / TabRoute keep their prior behaviour. **No regression**, and the entry's catalog position no longer decides where anything taps through.
- **Tests**: drop the assertion that cemented the reorder; add a source-resolution test and a regression guard asserting bare-key `steps` stays apple-health — so a future reorder fails loudly instead of silently emptying those screens.

Net result: every steps surface that needs my-whoop reaches it explicitly by source; every surface that resolves by bare key is byte-for-byte unchanged from before #551.

## ⚠️ Verification limit — needs an Xcode run before merge

Same gap #551 has, stated plainly: this is **app-target Swift** (`Strand/`, `StrandTests/`), which has **no Linux/CI path** — `swift-packages.yml` covers only `Packages/**` and `app-build.yml` is disabled. This box has no Xcode, so **I could not type-check or run the tests.** What I did verify statically:

- all four changed files pass `swift -frontend -parse` (syntax clean);
- `TabRoute.swift` holds the **only** exhaustive switch over the enum (its unique cases `.fullDayChart` / `.metricExplorer` appear in no other file), so the new `.metricSourced` case is fully handled — no other switch breaks;
- `cardLink(_:)` takes a `TabRoute`; `MetricCatalog.metric(key:source:)` is `static` and reachable; `MetricDetailView(metric:)` is the existing initialiser.

Please run `xcodebuild -project Strand.xcodeproj -scheme Strand test` (or dispatch `app-build.yml`) before merging — that exercises `MetricCatalogStepsTests` and the compile that neither #551 nor this PR has had.

## Not included (separate follow-up)

The card-level Apple-Health steps parity gap — Android's #377 blends imported Apple/Health-Connect steps into the Today steps value (`real ?: imported ?: estimate`) for both card and detail, while iOS omits the imported tier entirely. This PR keeps the iOS detail consistent with the iOS card (both my-whoop-then-estimate); closing the imported-tier gap touches `stepCount` itself and belongs in its own PR.
