### PR TITLE
Today steps: blend imported Apple Health count on iOS (parity with Android #377)

### DIFF
--- a/Strand/Data/MetricCatalog.swift
+++ b/Strand/Data/MetricCatalog.swift
@@ -216,11 +216,14 @@ enum MetricCatalog {
         all.first { $0.key == key && $0.source == source }
     }
 
-    /// The Today screen prefers the measured WHOOP 5.0 / MG count and falls back to the WHOOP 4.0
-    /// motion estimate. Apple Health remains an independent catalog metric and is never substituted
-    /// for a WHOOP value after the tile has already chosen what to display.
-    static func todayStepsMetric(hasMeasuredSteps: Bool) -> MetricDescriptor? {
-        metric(key: hasMeasuredSteps ? "steps" : "steps_est", source: "my-whoop")
+    /// The source the Today steps tile taps through to, matching the value it displays. Precedence
+    /// mirrors Android's `TodayScreen` (#377): the measured WHOOP 5.0 / MG count, else the imported
+    /// Apple Health count, else the WHOOP 4.0 motion estimate. `hasImportedSteps` defaults false so
+    /// existing callers keep the measured-or-estimate behaviour unchanged.
+    static func todayStepsMetric(hasMeasuredSteps: Bool, hasImportedSteps: Bool = false) -> MetricDescriptor? {
+        if hasMeasuredSteps { return metric(key: "steps", source: "my-whoop") }
+        if hasImportedSteps { return metric(key: "steps", source: "apple-health") }
+        return metric(key: "steps_est", source: "my-whoop")
     }
 
     /// Localized display name for a catalog category, mapped AT THE RENDER SITE only. The

--- a/Strand/Liquid/LiquidTodayView.swift
+++ b/Strand/Liquid/LiquidTodayView.swift
@@ -39,6 +39,7 @@ struct LiquidTodayView: View {
     @State private var fitnessAge: Double?         // exploreSeries("fitness_age").last
     @State private var vitality: Double?           // exploreSeries("vitality").last
     @State private var stepsEst: Double?           // steps_est, day-keyed to the selected day (fallback)
+    @State private var importedStepsDay: Int?      // Apple Health steps for the selected day (middle tier)
     @State private var hrValues: [Double] = []     // hrBuckets since midnight → 5-min means
     @State private var workouts: [WorkoutRow] = [] // newest-first
 
@@ -623,10 +624,10 @@ struct LiquidTodayView: View {
                      value: unitText(displayDay?.respRateBpm, card.unit, decimals: 1),
                      tint: StrandPalette.accent, frac: fracOver(displayDay?.respRateBpm, 24))
         case .steps:
-            // Route by exact source (my-whoop for both the measured "steps" and the "steps_est" fallback),
-            // NOT by bare key — bare "steps" resolves to apple-health and would show an empty detail for a
-            // WHOOP user. Order-independent, so the catalog needn't declare my-whoop first.
-            cardLink(.metricSourced(key: stepsDetailKey, source: "my-whoop"), title: card.title, sub: card.subtitle,
+            // Route by the EXACT (key, source) the tile chose to display — measured my-whoop, imported
+            // apple-health, or the my-whoop estimate — NOT by bare key (bare "steps" resolves to
+            // apple-health and would mismatch a WHOOP-measured value). Order-independent.
+            cardLink(.metricSourced(key: stepsDetailKey, source: stepsDetailSource), title: card.title, sub: card.subtitle,
                      value: stepsText, tint: StrandPalette.metricCyan, frac: fracOver(stepCount, 10000))
         case .bloodOxygen:
             // Not wired to a real read yet — render EMPTY (not half-full) so it doesn't imply a reading.
@@ -1035,6 +1036,7 @@ struct LiquidTodayView: View {
         async let fitA = repo.exploreSeries(key: "fitness_age", source: "my-whoop")
         async let vitA = repo.exploreSeries(key: "vitality", source: "my-whoop")
         async let stepsA = repo.exploreSeries(key: "steps_est", source: "my-whoop")
+        async let appleA = repo.appleDailyRows()
         async let hrA = repo.hrBuckets(from: from, to: to, bucketSeconds: 300)
         async let wkA = repo.workoutRows()
         // Ask the same cross-source resolver the Classic Today view uses which source actually won each
@@ -1096,6 +1098,10 @@ struct LiquidTodayView: View {
         // `.last` value) instead of that day's. Mirrors the classic Today's stepsEstByDay[selectedDayKey].
         let stepsByDay = Dictionary(stepsSeries.map { ($0.day, $0.value) }, uniquingKeysWith: { _, last in last })
         stepsEst = stepsByDay[selectedDayKey] ?? (selectedDayOffset == 0 ? stepsSeries.last?.value : nil)
+        // Imported Apple Health steps for the SELECTED day (max across rows), the middle tier between the
+        // measured strap count and the motion estimate. Health Connect is Android-only, so apple-health is
+        // the sole import source on iOS. Mirrors Android `stepsForDay` (#377).
+        importedStepsDay = (await appleA).filter { $0.day == selectedDayKey }.compactMap { $0.steps }.max()
         hrValues = (await hrA).map { $0.bpm }
         workouts = await wkA
 
@@ -1174,13 +1180,19 @@ struct LiquidTodayView: View {
             : String(localized: "Good evening")
     }
 
-    private var stepCount: Double? { displayDay?.steps.map(Double.init) ?? stepsEst }
+    // Measured strap count ?: imported Apple Health count ?: motion estimate — the same precedence the
+    // detail routing follows below, so the tapped-through source always matches the number shown (#377).
+    private var stepCount: Double? {
+        displayDay?.steps.map(Double.init) ?? importedStepsDay.map(Double.init) ?? stepsEst
+    }
 
     private var stepsDetailMetric: MetricDescriptor? {
-        MetricCatalog.todayStepsMetric(hasMeasuredSteps: displayDay?.steps != nil)
+        MetricCatalog.todayStepsMetric(hasMeasuredSteps: displayDay?.steps != nil,
+                                       hasImportedSteps: importedStepsDay != nil)
     }
 
     private var stepsDetailKey: String { stepsDetailMetric?.key ?? "steps_est" }
+    private var stepsDetailSource: String { stepsDetailMetric?.source ?? "my-whoop" }
 
     private var liveHour: Double {
         let c = Calendar.current.dateComponents([.hour, .minute], from: Date())

--- a/StrandTests/MetricCatalogStepsTests.swift
+++ b/StrandTests/MetricCatalogStepsTests.swift
@@ -16,6 +16,23 @@ final class MetricCatalogStepsTests: XCTestCase {
         XCTAssertEqual(metric?.source, "my-whoop")
     }
 
+    /// #377 parity: with no measured strap count but an imported Apple Health count for the day, Today
+    /// shows and taps through to the imported value — NOT the motion estimate.
+    func testTodayStepsPrefersImportedAppleHealthOverEstimate() {
+        let metric = MetricCatalog.todayStepsMetric(hasMeasuredSteps: false, hasImportedSteps: true)
+
+        XCTAssertEqual(metric?.key, "steps")
+        XCTAssertEqual(metric?.source, "apple-health")
+    }
+
+    /// A measured strap count always wins, even when an import also exists (real ?: imported ?: estimate).
+    func testMeasuredStepsWinOverImported() {
+        let metric = MetricCatalog.todayStepsMetric(hasMeasuredSteps: true, hasImportedSteps: true)
+
+        XCTAssertEqual(metric?.key, "steps")
+        XCTAssertEqual(metric?.source, "my-whoop")
+    }
+
     func testAppleHealthStepsRemainsAnIndependentCatalogMetric() {
         let metric = MetricCatalog.metric(key: "steps", source: "apple-health")
 


### PR DESCRIPTION
Closes the iOS↔Android steps parity gap found while reviewing #551/#574.

## The gap

iOS Today steps resolved `measured WHOOP count ?: motion estimate` — **no tier for an imported Apple Health count**. I traced it to the source: `stepCount = displayDay?.steps ?? stepsEst`, where `displayDay.steps` is `AnalyticsEngine.stepsTotal` = the WHOOP @57 tick counter only (no import fold), and `stepsEst` is the motion estimate.

So a WHOOP **4.0** user (no @57 measured steps) who imports Apple Health steps sees the **approximate motion estimate** on Today, while the **same user on Android** sees their **real Apple Health count** — Android's `TodayScreen` blends `real ?: imported ?: estimate` (#377). Same user, same data, different number per platform.

(iOS does have blending machinery — `MetricArbitrationPolicy` ranks appleHealth above whoopImport for steps — but it feeds the Fused/Sources view, not the Today tile.)

## The fix — mirror #377, in value AND routing

The routing has to move in lockstep with the value or it reintroduces the card/detail mismatch #551 just fixed. So both change together:

- **Value**: `stepCount = displayDay.steps ?: importedStepsDay ?: stepsEst`. `importedStepsDay` is the selected day's Apple Health steps (max across rows), loaded from `repo.appleDailyRows()` in the same per-day load as `stepsEst`. Health Connect is Android-only, so apple-health is the sole import source on iOS. Mirrors Android `stepsForDay`.
- **Routing**: `todayStepsMetric` gains `hasImportedSteps` (**defaulted false**, so #574's callers/tests are untouched) → measured `my-whoop:steps`, imported `apple-health:steps`, else `my-whoop:steps_est`. The steps card routes `.metricSourced(key: stepsDetailKey, source: stepsDetailSource)`, so an imported value taps through to the `apple-health:steps` history (`exploreSeries` routes apple-health via `series()`, so that detail is populated) — not an empty my-whoop detail.
- **Tests**: measured wins over imported; imported wins over estimate.

## Known minor (deliberately not fixed here)

The tile's mini-sparkline keys on the `"steps"` series = measured `DailyMetric.steps`, so an **import-only** user's value and tap-through are now correct but the tiny trend line under the tile stays flat. Blending the trail needs a dedicated imported-steps sparkline series; left as a follow-up to keep this change minimal. The number and the detail — the actual reported gap — are fixed.

## ⚠️ Verification limit — needs an Xcode run before merge

App-target Swift (`Strand/`, `StrandTests/`), which has **no Linux/CI path** and I have no Xcode, so I **could not type-check or run** this. Static checks: all three files pass `swift -frontend -parse`; `appleDailyRows()` and `AppleDaily.day/.steps` exist; the types line up (`[AppleDaily].compactMap { $0.steps }.max() -> Int?`, threaded into the `Double?` chain). Please run `xcodebuild -project Strand.xcodeproj -scheme Strand test` (or dispatch `app-build.yml`) — that's the first compile/test this has had. Fast revert if it fails.

Android unchanged — it already does this (#377); this is iOS catching up.
