### PR TITLE
Backup diagnostics: drop folder name (PII), report iCloud-vs-local (#555 follow-up)

### DIFF
--- a/Strand/Data/BackupSync.swift
+++ b/Strand/Data/BackupSync.swift
@@ -283,12 +283,16 @@ enum FolderBackup {
     /// chosen. Lets a "restore shows no files" report (#278) distinguish a genuinely empty folder from a
     /// resolution problem (e.g. undownloaded iCloud placeholders, see `iCloudPlaceholderRealName`)
     /// without needing a live repro. Used by `DebugDataDiagnostics`.
-    static func restoreListHealth() -> (folderName: String, rawEntries: Int, snapshots: Int)? {
+    static func restoreListHealth() -> (isICloud: Bool, rawEntries: Int, snapshots: Int)? {
         guard let folder = resolveFolder() else { return nil }
         let scoped = folder.startAccessingSecurityScopedResource()
         defer { if scoped { folder.stopAccessingSecurityScopedResource() } }
         let raw = (try? FileManager.default.contentsOfDirectory(atPath: folder.path))?.count ?? 0
-        return (folder.lastPathComponent, raw, listSnapshots().count)
+        // Report iCloud-vs-local (the actual #278 triage signal — undownloaded placeholders live in the
+        // iCloud container) WITHOUT the folder's user-chosen name, which redactPii can't scrub and the
+        // iOS twin never exposes. The iCloud ubiquity container path contains "Mobile Documents".
+        let isICloud = folder.path.contains("Mobile Documents")
+        return (isICloud, raw, listSnapshots().count)
     }
 
     // MARK: - Restore from the configured folder (must-fix #1)

--- a/Strand/System/DebugDataDiagnostics.swift
+++ b/Strand/System/DebugDataDiagnostics.swift
@@ -67,8 +67,8 @@ enum DebugDataDiagnostics {
         // placeholder, see `BackupSync.iCloudPlaceholderRealName`) looks very different from a genuinely
         // empty folder, and neither was visible in a debug export before this.
         if let health = FolderBackup.restoreListHealth() {
-            lines.append("Backup folder: \(health.folderName)")
-            lines.append("Restore list: \(health.snapshots) snapshot(s) recognized of \(health.rawEntries) folder entrie(s)")
+            lines.append("Backup folder: \(health.isICloud ? "iCloud Drive" : "local")")
+            lines.append("Restore list: \(health.snapshots) snapshot(s) recognized of \(health.rawEntries) folder entries")
         } else {
             lines.append("Backup folder: none chosen")
         }


### PR DESCRIPTION
Follow-up to #555 (merged). Addresses the two actionable points from its review.

## The PII fix

#555's macOS restore-list block wrote the backup folder's user-chosen name (`folder.lastPathComponent`) into the debug export. Two problems:

- **`redactPii` can't scrub it** — its patterns are MAC / CoreBluetooth-UUID / `WHOOP <serial>`, so a free-text folder name (`Backup folder: John's NOOP`) ships verbatim in the maintainer-shared bundle.
- **The iOS twin it mirrors never exposes a name** — only the mode (`external folder` / `none chosen`). So the macOS block leaked strictly more.

`restoreListHealth()` now returns `isICloud: Bool` instead of `folderName: String` — computed from the path, but only the Bool leaves the function. The line reads **`Backup folder: iCloud Drive`** or **`local`**, which is the actually-useful #278 triage signal (undownloaded placeholders are an iCloud-only phenomenon) with no free text. For an offline/anonymous-by-design app, that keeps the diagnostic value and drops the leak.

Also fixes `folder entrie(s)` → `folder entries` (`entrie` isn't a word).

## Note on the iCloud check

`folder.path.contains("Mobile Documents")` — the macOS iCloud ubiquity container always sits under `~/Library/Mobile Documents/…`. `FileManager.default.isUbiquitousItem(at:)` is the API-correct alternative; I used the path substring for simplicity and to avoid the API's placeholder/folder edge cases. Happy to swap to the API form if you'd rather.

## Verification

App-target Swift, no Linux/CI path, no Xcode here — syntax-parses clean, but **needs an `xcodebuild -project Strand.xcodeproj -scheme Strand build`**: the return-type reshape touches `restoreListHealth`'s one call site (`DebugDataDiagnostics`), which I updated. No other callers (grep-verified). Still read-only, no backup/restore behaviour change — same as #555.
