### PR TITLE
v20 optical: Kotlin RawImu gate parity + restore the corroborating RE evidence (#546 follow-up)

### DIFF
--- a/Packages/WhoopProtocol/Sources/WhoopProtocol/Whoop5RawOptical.swift
+++ b/Packages/WhoopProtocol/Sources/WhoopProtocol/Whoop5RawOptical.swift
@@ -10,6 +10,13 @@ import Foundation
 // split consistently into six block-level bytes and seven bytes per channel. That split is exposed as
 // raw metadata: its register meanings and the LED wavelength assigned to each block are not yet proven.
 //
+// RE notes (issue #423, NOT authoritative — no labelled/moving v20 capture exists): the record's config
+// header carries an LED-current field @28 and per-photodiode offset DACs @38/@45. Under the split above
+// those land as ONE drive current in a block's shared bytes (@27...32 for block 0) and ONE offset DAC in
+// each of its two 7-byte channel descriptors (@33...39 and @40...46) — i.e. one LED per block, one detector
+// per channel. That aligns with the "two readout channels share one measurement config" model, and is a
+// line of evidence for treating the slots as a paired detector/readout rather than two wavelengths.
+//
 // In the 29,203-record corpus used to establish this layout, block counts are always [25, 0, 0, 25,
 // 25]. Active channels contain 25 signed 20-bit readings in sign-extended i32 containers; slots 25...49
 // are zero padding. Two channels in the same block therefore belong to one shared measurement/config,

--- a/android/app/src/main/java/com/noop/protocol/Whoop5RawImu.kt
+++ b/android/app/src/main/java/com/noop/protocol/Whoop5RawImu.kt
@@ -61,7 +61,7 @@ object Whoop5RawImu {
     /** Decode a raw-IMU buffer, or null if it isn't one. Gates on the exact length + the two in-packet
      *  sample counts (=100) rather than the type byte, so it can't misfire on a same-type non-IMU frame. */
     fun decode(f: ByteArray): Whoop5ImuFrame? {
-        if (f.size < bufferLength) return null
+        if (f.size != bufferLength) return null   // exact length, matching Swift's `f.count == bufferLength` (#546)
         if (u16(f, countAOff) != sampleCount || u16(f, countBOff) != sampleCount) return null
         if (gzOff + 2 * sampleCount > f.size) return null
         val baseTs = u32(f, tsOff)   // full u32 (matches Swift `Int(u32(...))` on 64-bit — no truncation)

--- a/android/app/src/main/java/com/noop/protocol/Whoop5RawOptical.kt
+++ b/android/app/src/main/java/com/noop/protocol/Whoop5RawOptical.kt
@@ -40,6 +40,12 @@ data class Whoop5OpticalFrame(
  * metadata. In the 29,203-record corpus used to establish this layout, counts are always
  * `[25, 0, 0, 25, 25]`; active slots contain 25 sign-extended i32 readings followed by zero padding.
  * The two slots under one header must not be named as two wavelengths without independent evidence.
+ *
+ * RE notes (issue #423, NOT authoritative): the record's config header carries an LED-current field @28
+ * and per-photodiode offset DACs @38/@45. Under the split above those land as ONE drive current in a
+ * block's shared bytes (@27..32 for block 0) and ONE offset DAC in each of its two 7-byte channel
+ * descriptors (@33..39 and @40..46) — one LED per block, one detector per channel, which aligns with the
+ * "two readout channels share one measurement config" model. Kotlin twin of the Swift note.
  */
 object Whoop5RawOptical {
     const val BUFFER_LENGTH = 2140

--- a/android/app/src/test/java/com/noop/protocol/Whoop5RawImuTest.kt
+++ b/android/app/src/test/java/com/noop/protocol/Whoop5RawImuTest.kt
@@ -44,6 +44,11 @@ class Whoop5RawImuTest {
     @Test
     fun rejectsWrongLengthOrCounts() {
         assertNull(Whoop5RawImu.decode(ByteArray(500)))            // too short
+        // Exact-length contract (parity with Swift Whoop5RawImuTests): a valid buffer plus one trailing
+        // byte still has countA/countB == 100 and enough bytes, but must be rejected — an over-length
+        // frame is not a valid prefix. Pins the `f.size != bufferLength` gate (was `< bufferLength`).
+        val oversized = syntheticFrame(i = 0, axLSB = 0, gxLSB = 0).copyOf(Whoop5RawImu.bufferLength + 1)
+        assertNull(Whoop5RawImu.decode(oversized))
         val f = syntheticFrame(i = 0, axLSB = 0, gxLSB = 0)
         f[24] = 0.toByte(); f[25] = 0.toByte()                     // countA != 100
         assertNull(Whoop5RawImu.decode(f))


### PR DESCRIPTION
Follow-up to #546 (merged). Addresses the two actionable points from its review; unlike the recent app-target PRs this is the pure WhoopProtocol package + Kotlin, so it's **fully tested on both platforms** (Swift 289/289, Kotlin 164/164) — no verification gap.

## 1. `Whoop5RawImu` length-gate parity (Kotlin)

#546 tightened the **Swift** decoder's gate `>= bufferLength` → `== bufferLength` so the 1244-B IMU and 2140-B optical decoders can't cross-misfire. The **Kotlin** twin still read `f.size < bufferLength` (i.e. accepted anything ≥ 1244), and its own KDoc already claimed *"exact length"* — so the code now matches both the doc and Swift:

```kotlin
if (f.size != bufferLength) return null   // was: f.size < bufferLength
```

The only caller (`PuffinDeepBufferLog`) already gates exact length, so this is a no-op on real frames — it just closes the same cross-misfire on Android that #546 closed on Apple. `Whoop5RawImuTest` stays 3/3.

## 2. Restore the RE evidence #546 dropped — because it *corroborates* the new model

#546 removed the superseded decoder's citation of issue #423's config-header fields (LED-current `@28`, per-photodiode offset DACs `@38`/`@45`) while upgrading *"inferred to be optical"* to *"is optical"*. But those notes are the **strongest independent support** for the paired-block model this PR introduced. Under the 21-byte split:

| #423 field | lands in (block 0) | meaning |
|---|---|---|
| LED-current `@28` | shared bytes `@27..32` | **one drive current per block** |
| photodiode DAC `@38` | channel-0 descriptor `@33..39` | one offset DAC per detector |
| photodiode DAC `@45` | channel-1 descriptor `@40..46` | one offset DAC per detector |

One LED per block, one detector per channel — exactly what *"two readout channels share one measurement config, not two wavelengths"* predicts. Re-added to both `Whoop5RawOptical` docs (Swift + Kotlin twin) as the evidence for the detector/readout reading, so the model is self-justifying rather than asserted.

## Not included

The `sensor_channel_samples` = `max(block counts)` naming point (review item 3) — a judgement call on a field name with no consumers. Left for the maintainer rather than bundled here.

## Verification

- `swift test` (WhoopProtocol) → **289/289**
- `./gradlew testFullDebugUnitTest --tests "com.noop.protocol.*"` → **164/164**

Swift change is comment-only; the Kotlin change is a stricter length gate with zero test regressions.
