### PR TITLE
i18n_audit: catch contentDescription inside a semantics {} lambda (fixes #571)

### DIFF
--- a/Tools/i18n_audit.py
+++ b/Tools/i18n_audit.py
@@ -259,6 +259,15 @@ ANDROID_DIRS = [
 ANDROID_CALL_PATTERN = re.compile(r"\b(?:Text|Snackbar|TopAppBar)\s*\(")
 ANDROID_KWARG_PATTERN = re.compile(r"\b(?:title|label|text|contentDescription|placeholder)\s*=\s*")
 
+# `contentDescription = <expr>` is UI accessibility text wherever it is ASSIGNED. Unlike the general
+# kwargs it most often sits inside a `Modifier.semantics { }` lambda, whose `{` is NOT an argument
+# boundary — so the kwarg pass skips it and the a11y copy stays invisible in a green audit (#571). Scan
+# the assignment on its own: a bare `contentDescription =` that is not a `==` comparison, a `.member`
+# read, or a `val`/`var` local declaration is a UI-text site. Only its OWN value span is read (via
+# `_argument_span_end`, which stops at the enclosing `}`), so unrelated lambda content is never swept in.
+ANDROID_A11Y_ASSIGN_PATTERN = re.compile(r"(?<![.\w])contentDescription\s*=(?!=)\s*")
+_LOCAL_DECL_BEFORE = re.compile(r"\b(?:val|var)\s+\Z")
+
 
 def _mask_comments(text: str) -> str:
     """`text` with `//...` and `/* ... */` comment BODIES blanked out (same
@@ -334,6 +343,13 @@ def scan_android() -> list[tuple[str, int, str]]:
             # recognize by name, including AlertDialog's named slots.
             for m in ANDROID_KWARG_PATTERN.finditer(text):
                 if not _PRECEDED_BY_ARG_BOUNDARY.search(text, 0, m.start()):
+                    continue
+                record(m.end(), _argument_span_end(text, m.end()))
+
+            # `Modifier.semantics { contentDescription = if (x) "a" else "b" }` and friends — the a11y
+            # assignment the kwarg pass above cannot see (its `{` isn't an arg boundary). (#571)
+            for m in ANDROID_A11Y_ASSIGN_PATTERN.finditer(text):
+                if _LOCAL_DECL_BEFORE.search(text, 0, m.start()):
                     continue
                 record(m.end(), _argument_span_end(text, m.end()))
 

--- a/Tools/i18n_audit_baseline.json
+++ b/Tools/i18n_audit_baseline.json
@@ -5,6 +5,14 @@
       "The most common cause is the ring was not fully reset in the Oura app, or the Oura "
     ],
     [
+      "android/app/src/main/java/com/noop/ui/AppRoot.kt",
+      "Collapsed"
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/AppRoot.kt",
+      "Expanded"
+    ],
+    [
       "android/app/src/main/java/com/noop/ui/BackupSyncScreen.kt",
       "Back up now"
     ],
@@ -74,7 +82,15 @@
     ],
     [
       "android/app/src/main/java/com/noop/ui/CoachScreen.kt",
+      "Collapse coach instructions"
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/CoachScreen.kt",
       "Customised. Your edited instructions frame every reply."
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/CoachScreen.kt",
+      "Edit coach instructions"
     ],
     [
       "android/app/src/main/java/com/noop/ui/CoachScreen.kt",
@@ -165,6 +181,10 @@
       " · FW $it"
     ],
     [
+      "android/app/src/main/java/com/noop/ui/FusedRecordScreen.kt",
+      ", in use"
+    ],
+    [
       "android/app/src/main/java/com/noop/ui/HealthScreen.kt",
       "$displayHr bpm"
     ],
@@ -190,6 +210,14 @@
     ],
     [
       "android/app/src/main/java/com/noop/ui/HealthScreen.kt",
+      "Live heart rate over time, $displayHr beats per minute, zone $zone"
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/HealthScreen.kt",
+      "Live heart rate over time, no data"
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/HealthScreen.kt",
       "Pairing…"
     ],
     [
@@ -207,6 +235,18 @@
     [
       "android/app/src/main/java/com/noop/ui/HealthScreen.kt",
       "Sync now"
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/HealthScreen.kt",
+      "Sync now. A sync is already in progress."
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/HealthScreen.kt",
+      "Sync now. Connect your strap first."
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/HealthScreen.kt",
+      "Sync now. Pulls your strap's stored history immediately, without waiting "
     ],
     [
       "android/app/src/main/java/com/noop/ui/HealthScreen.kt",
@@ -417,6 +457,14 @@
       "Your strap is bonded · ${it.toInt()}% battery."
     ],
     [
+      "android/app/src/main/java/com/noop/ui/PipBar.kt",
+      "$label: $valueText"
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/PipBar.kt",
+      "$label: $valueText $unit"
+    ],
+    [
       "android/app/src/main/java/com/noop/ui/SettingsScreen.kt",
       " · Charging"
     ],
@@ -435,6 +483,14 @@
     [
       "android/app/src/main/java/com/noop/ui/SettingsScreen.kt",
       "Choose photo"
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/SettingsScreen.kt",
+      "Collapsed"
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/SettingsScreen.kt",
+      "Expanded"
     ],
     [
       "android/app/src/main/java/com/noop/ui/SettingsScreen.kt",
@@ -518,6 +574,14 @@
     ],
     [
       "android/app/src/main/java/com/noop/ui/StepsCalibrationScreen.kt",
+      "Manual steps coefficient, %.1f steps per motion unit"
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/StepsCalibrationScreen.kt",
+      "Manual steps coefficient, automatic"
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/StepsCalibrationScreen.kt",
       "fit from your phone"
     ],
     [
@@ -577,8 +641,24 @@
       "What's new in NOOP $version"
     ],
     [
+      "android/app/src/main/java/com/noop/ui/UpdatesInboxScreen.kt",
+      "${item.title}. ${item.message}"
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/UpdatesInboxScreen.kt",
+      "Unread. ${item.title}. ${item.message}"
+    ],
+    [
       "android/app/src/main/java/com/noop/ui/WorkoutStart.kt",
       "%d:%02d"
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/WorkoutsScreen.kt",
+      "0 to 100 Effort"
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/WorkoutsScreen.kt",
+      "0 to 21 strain"
     ],
     [
       "android/app/src/main/java/com/noop/ui/WorkoutsScreen.kt",
@@ -610,6 +690,10 @@
     ],
     [
       "android/app/src/main/java/com/noop/ui/WorkoutsScreen.kt",
+      "Finish selecting"
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/WorkoutsScreen.kt",
       "From strap HR"
     ],
     [
@@ -627,6 +711,10 @@
     [
       "android/app/src/main/java/com/noop/ui/WorkoutsScreen.kt",
       "Select"
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/WorkoutsScreen.kt",
+      "Select sessions to merge or delete"
     ],
     [
       "android/app/src/main/java/com/noop/ui/WorkoutsScreen.kt",

--- a/Tools/test_i18n_audit.py
+++ b/Tools/test_i18n_audit.py
@@ -172,6 +172,49 @@ class ScanAndroidEndToEnd(unittest.TestCase):
         # outer AlertDialog's text= span was swept.
         self.assertEqual(sorted(found), ["First deep child", "Second deep child"])
 
+    # --- #571: contentDescription assigned inside a `semantics {}` lambda ---
+
+    def test_content_description_in_semantics_lambda_found(self):
+        # The standard Compose a11y idiom: the `{` is not an arg boundary, so the
+        # general kwarg pass skips it — the dedicated assignment pass must catch it.
+        self.write(
+            "A.kt",
+            'Modifier.semantics { contentDescription = if (hr) "Recovery ready" else "Recovery, no data yet" }',
+        )
+        found = {lit for _p, _l, lit in ia.scan_android()}
+        self.assertEqual(found, {"Recovery ready", "Recovery, no data yet"})
+
+    def test_content_description_multiline_semantics_found(self):
+        self.write(
+            "A.kt",
+            "Modifier.semantics {\n    contentDescription = \"Charge calibrating tonight\"\n}",
+        )
+        found = {lit for _p, _l, lit in ia.scan_android()}
+        self.assertEqual(found, {"Charge calibrating tonight"})
+
+    def test_content_description_pass_excludes_decl_and_member_read(self):
+        # A `val` local decl and a `.member ==` comparison are NOT a11y UI-text sites;
+        # neither may be flagged (guards the pass against false positives).
+        self.write(
+            "A.kt",
+            'val contentDescription = "local decl not ui"\n'
+            'if (view.contentDescription == "compare not ui") doThing()\n',
+        )
+        found = {lit for _p, _l, lit in ia.scan_android()}
+        self.assertEqual(found, set())
+
+    def test_content_description_lambda_does_not_reopen_unrelated_slot(self):
+        # The a11y pass must not resurrect the 489-explosion: an unrelated slot
+        # lambda beside a contentDescription assignment stays scanned only on its own.
+        self.write(
+            "A.kt",
+            'Box(Modifier.semantics { contentDescription = "Tap target" }) {\n'
+            '    AlertDialog(text = { Column { Text("Deep child") } })\n'
+            "}",
+        )
+        found = sorted(lit for _p, _l, lit in ia.scan_android())
+        self.assertEqual(found, ["Deep child", "Tap target"])
+
 
 class Baseline(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
Addresses the **inline** case of #571. Tools-only Python, so unlike the recent app-target PRs it's **fully tested here** — 26/26 and `--ci` clean, no verification gap.

## The gap

#558 taught the audit to see conditional literals (`Text(if x "a" else "b")`), but a UI-text kwarg assigned **inside a lambda** stayed invisible. `contentDescription` is already in `ANDROID_KWARG_PATTERN`, but that pass is gated on an argument boundary (`(` or `,`), so the standard Compose idiom

```kotlin
Modifier.semantics { contentDescription = if (hr) "Ready" else "No data" }
```

is skipped — its `{` isn't an arg boundary — and the audit reports **clean** while TalkBack reads English regardless of device language.

## The fix

A dedicated assignment pass (`ANDROID_A11Y_ASSIGN_PATTERN`): a bare `contentDescription =` — not a `==` comparison, a `.member` read, or a `val`/`var` local declaration — is a UI-text site wherever it's assigned. It reads only its **own** value span via `_argument_span_end` (which stops at the enclosing `}`), so it does **not** reopen unrelated slot lambdas. The 489-explosion guard from #558 still holds (there's a test for exactly that).

Surfaces **22 pre-existing hardcoded a11y strings** across 9 screens (AppRoot, CoachScreen, FusedRecordScreen, HealthScreen, PipBar, SettingsScreen, StepsCalibrationScreen, UpdatesInboxScreen, WorkoutsScreen) — all `contentDescription = "literal"` / `= if …` forms. Per the #558 pattern these land in the baseline as **tracked backlog** (170 → 192 android), not 22 rushed translations; `--ci` stays green and a genuinely new hardcoded literal still fails the gate.

## Known limitation — val-laundered a11y is still NOT caught (correction to my first draft)

On re-review I confirmed this does **not** catch the specific case #571 cited as motivation. `CoupledScreen.kt` uses:

```kotlin
val a11y = when { … "Recovery calibrating, …" … else -> "Recovery, no data yet" }   // line 276
…
.semantics { contentDescription = a11y }                                           // line 305
```

The assignment's value is the *variable* `a11y`, so my pass finds no literal there; the literals live in the `val a11y = when { … }` declaration, which is deliberately not scanned (the #558 local-decl exclusion, there to avoid flagging a `val text = when{}` that isn't UI). Catching this needs light dataflow — "scan a `val` whose value flows into a `contentDescription`" — which is a distinct, more false-positive-prone change. So **CoupledScreen's a11y strings remain invisible after this PR**, and I'd keep #571 open (or spin a narrower follow-up) for the val-laundered variant rather than have this close it.

A few of the 22 are pure-interpolation (`"$label: $valueText"`) that may need no translation — the baseline is a snapshot to triage, not a mandate.

## Verification

- `python3 -m unittest test_i18n_audit` → **26/26** (4 new: the semantics idiom, multi-line, decl/member-read exclusion, the no-reopen-unrelated-slot guard)
- `python3 Tools/i18n_audit.py --ci origin/main` → exit 0