### PR TITLE
Today: hide the pull-to-sync dot at rest, show only on pull (fixes #582)

### DIFF
--- a/android/app/src/main/java/com/noop/ui/TodayScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/TodayScreen.kt
@@ -1529,10 +1529,16 @@ fun TodayScreen(
             )
         }
     }
-        PullToRefreshContainer(
-            state = pullToSyncState,
-            modifier = Modifier.align(Alignment.TopCenter),
-        )
+        // Material3's PullToRefreshContainer draws its indicator circle even at rest (progress 0, not
+        // refreshing), so an idle Today showed a permanent grey dot at the top (#582). Compose it only
+        // while a pull is in progress or a sync is running — the pull GESTURE flows through the Box's
+        // nestedScroll above, not this container, so gating the visual can't disable pull-to-sync.
+        if (pullToSyncState.progress > 0f || pullToSyncState.isRefreshing) {
+            PullToRefreshContainer(
+                state = pullToSyncState,
+                modifier = Modifier.align(Alignment.TopCenter),
+            )
+        }
     }
 
     // Scoring guide sheet, full-screen Dialog, mirroring Settings' What's-new presentation. Opened


### PR DESCRIPTION
Fixes #582 (@bartmuskala): a grey dot always showing at the top of the Android home screen, not just during a pull-to-refresh.

## Cause

The dot is Material3's `PullToRefreshContainer` indicator (`TodayScreen.kt`), rendered **unconditionally** at `Alignment.TopCenter`. Stock Material3's experimental `PullToRefreshContainer` draws its indicator circle even at rest (`progress == 0`, not refreshing) — so an idle Today shows a permanent grey dot.

## Fix

Compose the container only while a pull is in progress or a sync is running:

```kotlin
if (pullToSyncState.progress > 0f || pullToSyncState.isRefreshing) {
    PullToRefreshContainer(state = pullToSyncState, modifier = Modifier.align(Alignment.TopCenter))
}
```

The dot is hidden at rest, appears the moment a pull begins (`progress > 0`), stays through the sync (`isRefreshing`), and is gone once released — exactly the reported expectation.

**Safe:** the pull *gesture* flows through the outer `Box`'s `nestedScroll(pullToSyncState.nestedScrollConnection)`, not this container — so gating the container's composition affects only the visual indicator, never the gesture.

## Scope

Android-only — a Compose Material3 quirk; iOS Today doesn't use this container. Today is the sole `PullToRefreshContainer` site; CoachScreen/HealthScreen already gate a `CircularProgressIndicator` on their own `refreshing` flag, so there's no equivalent dot-at-rest elsewhere.

## Verification

- `./gradlew compileFullDebugKotlin` → clean. `progress` / `isRefreshing` confirmed against the pinned Material3 `PullToRefreshState` API.
- **Needs an on-device glance** to confirm the rendered behaviour: dot gone at rest, appears and eases in on pull. It's a low-risk conditional, but "compiles" ≠ "looks right" for a UI change. (No CI covers `android/` UI, so a local `assembleFullDebug` install or emulator is the check.)
