### PR TITLE
FIT import: double total_cycles → steps for foot sports (fixes #568 halving)

### DIFF
--- a/Packages/StrandImport/Sources/StrandImport/FitParser.swift
+++ b/Packages/StrandImport/Sources/StrandImport/FitParser.swift
@@ -462,7 +462,12 @@ private struct FitDecoder {
         let distance = sessionDistance
             ?? (lapDistanceSum > 0 ? lapDistanceSum : (route.count >= 2 ? ActivityFileImporter.routeDistanceM(route) : nil))
         let calories = sessionCalories ?? (lapCalorieSum > 0 ? lapCalorieSum : nil)
-        let steps = Self.isFootSport(sessionSport) ? (sessionSteps ?? (lapStepSum > 0 ? lapStepSum : nil)) : nil
+        // FIT field 10 is total_cycles — for foot sports that's STRIDES (one stride = two steps), so
+        // double it to the real step count. The "converted to steps" note above was never applied, so a
+        // walk logged as 1150 strides read as 1150 steps instead of 2300 (#568).
+        let steps = Self.isFootSport(sessionSport)
+            ? (sessionSteps ?? (lapStepSum > 0 ? lapStepSum : nil)).map { $0 * 2 }
+            : nil
         let ascent = sessionAscent
             ?? (lapAscentSum > 0 ? lapAscentSum : ActivityFileImporter.ascentM(from: samples))
 

--- a/Packages/StrandImport/Tests/StrandImportTests/ActivityFileImporterTests.swift
+++ b/Packages/StrandImport/Tests/StrandImportTests/ActivityFileImporterTests.swift
@@ -205,7 +205,7 @@ final class ActivityFileImporterTests: XCTestCase {
         XCTAssertEqual(a.hrSampleCount, 3)
         XCTAssertEqual(a.distanceM ?? 0, 5.23, accuracy: 0.001)   // session summary
         XCTAssertEqual(a.energyKcal, 300)
-        XCTAssertEqual(a.steps, 1175)
+        XCTAssertEqual(a.steps, 2350)   // FIT field 10 = 1175 strides → ×2 = 2350 steps (#568)
         XCTAssertEqual(a.avgHr, 150)                 // session avg wins over the sampled mean
         XCTAssertEqual(a.maxHr, 182)
         // Coordinates round-trip through semicircles (~1e-7° precision).

--- a/android/app/src/main/java/com/noop/ingest/ActivityFileImporter.kt
+++ b/android/app/src/main/java/com/noop/ingest/ActivityFileImporter.kt
@@ -825,8 +825,11 @@ internal class FitDecoder(raw: ByteArray) {
         val distance = sessionDistance
             ?: if (lapDistanceSum > 0) lapDistanceSum else if (route.size >= 2) ActivityFileImporter.routeDistanceM(route) else null
         val calories = sessionCalories ?: if (lapCalorieSum > 0) lapCalorieSum else null
+        // FIT field 10 is total_cycles — for foot sports that's STRIDES, and one stride = two steps, so
+        // double it to the real step count. Reading it raw showed exactly half (a walk logged as 1150
+        // strides read as 1150 steps instead of 2300, #568). Non-foot sports carry no steps.
         val steps = if (isFootSport(sessionSport)) {
-            sessionSteps ?: if (lapStepSum > 0) lapStepSum else null
+            (sessionSteps ?: if (lapStepSum > 0) lapStepSum else null)?.let { it * 2 }
         } else {
             null
         }

--- a/android/app/src/test/java/com/noop/ingest/ActivityFileImporterTest.kt
+++ b/android/app/src/test/java/com/noop/ingest/ActivityFileImporterTest.kt
@@ -188,7 +188,7 @@ class ActivityFileImporterTest {
         fit.u32(sessionStart)
         fit.u8(1)            // sport = running
         fit.u32(523)         // total_distance → 5.23 m
-        fit.u32(1175)        // total_cycles: Suunto walking/running step total
+        fit.u32(1175)        // total_cycles = STRIDES for a foot sport; 1 stride = 2 steps → 2350 steps (#568)
         fit.u16(300)         // total_calories
         fit.u8(150)          // avg_hr
         fit.u8(182)          // max_hr
@@ -215,7 +215,7 @@ class ActivityFileImporterTest {
         assertEquals(3, a.hrSampleCount)
         assertEquals(5.23, a.distanceM!!, 1e-3)
         assertEquals(300.0, a.energyKcal!!, 1e-6)
-        assertEquals(1175, a.steps)
+        assertEquals(2350, a.steps)   // FIT field 10 = 1175 strides → ×2 = 2350 steps (#568)
         assertEquals(150, a.avgHr)
         assertEquals(182, a.maxHr)
         assertEquals(lat, a.route.first().lat, 1e-4)


### PR DESCRIPTION
Fixes the **halving** half of #568 (@pilleuspulcher-blip): an imported walk/run showed exactly half its steps (a 2300-step Suunto walk imported as 1150).

## Cause

The FIT parser reads message **field 10** as the step count. But field 10 is `total_cycles` — for foot sports that's **strides**, and one stride = two steps. Both parsers read it raw, so strides were shown as steps → exactly half. iOS's own comment even names it: *"total_cycles; converted to steps only for foot activities in buildResult()"* — the ×2 conversion was intended but never implemented, on either platform.

## Fix

Apply `×2` for foot sports in both `buildResult()`s:
- `android/…/ActivityFileImporter.kt`
- `Packages/StrandImport/…/FitParser.swift`

Both step tests updated to the doubled value (fixture field 10 = 1175 strides → **2350** steps).

## Scope / caveat

This is the FIT-standard interpretation — Suunto/Garmin record `total_cycles` = strides, so ×2 is the real step count. A non-standard device that wrote actual steps into field 10 would now be doubled, but that's off-spec; the reporter's exact-half discrepancy plus the pre-existing "converted to steps" intent confirm the mainstream case.

## Verification

- Android: `./gradlew testFullDebugUnitTest --tests "com.noop.ingest.ActivityFileImporterTest"` → **10/10** (compiled + run locally).
- iOS `FitParser` lives in `StrandImport`, which **is** covered by `swift-packages.yml` CI — so the iOS half gets validated there. It can't build on Linux (GRDB/sqlite wall), so I couldn't run it locally, but the edit + test update mirror the Android ones exactly.

## Not included

The **second** bug in #568 — imported activity steps hijacking/duplicating the *daily* total — is deliberately **not** in this PR. It's not a clean fix: the daily-steps write feeds a **deliberate** design (`RegistryDayOwnerSource` #137 ranks activity-file as a day-steps owner), `WorkoutRow` has no steps field, and the reporter's "sum them" is a double-count risk. That one needs a design decision and is better tracked separately.
