### PR TITLE
Activity import: don't write a single workout's steps as the day total (fixes #568 hijack) — both platforms

### DIFF
--- a/Strand/Screens/DataSourcesView.swift
+++ b/Strand/Screens/DataSourcesView.swift
@@ -573,25 +573,12 @@ struct DataSourcesView: View {
                     let hr = activity.hrSamples.map { HRSample(ts: $0.ts, bpm: $0.bpm) }
                     _ = try? await store.insert(Streams(hr: hr), deviceId: ActivityFileImporter.sourceId)
                 }
-                if let steps = activity.steps, steps > 0 {
-                    let day = Repository.localDayKey(activity.start)
-                    let metric = DailyMetric(
-                        day: day,
-                        totalSleepMin: nil,
-                        efficiency: nil,
-                        deepMin: nil,
-                        remMin: nil,
-                        lightMin: nil,
-                        disturbances: nil,
-                        restingHr: nil,
-                        avgHrv: nil,
-                        recovery: nil,
-                        strain: nil,
-                        exerciseCount: nil,
-                        steps: steps
-                    )
-                    try? await store.upsertDailyMetrics([metric], deviceId: ActivityFileImporter.sourceId)
-                }
+                // #568: do NOT write the activity's steps as a DAILY metric. A single imported workout's
+                // steps are that activity's steps, not the day's total — writing them under the
+                // activity-file day-owner (#137, which exists for HR/Effort) made one walk stand in for
+                // the whole day's step count, shown in place of the on-device total. The steps stay on
+                // the workout (its note carries "<n> steps"). Summing imported steps INTO the daily total
+                // is a separate, double-count-aware feature (see #585), deliberately not done here.
 
                 // #137 (B1): register `activity-file` as an `.activityFile` device so the per-day owner
                 // resolver can pick it as the day owner on a strap-less day (it iterates the registry's

--- a/android/app/src/main/java/com/noop/ingest/ActivityFileImporter.kt
+++ b/android/app/src/main/java/com/noop/ingest/ActivityFileImporter.kt
@@ -4,7 +4,6 @@ import android.content.Context
 import android.net.Uri
 import android.util.Xml
 import com.noop.analytics.RouteMath
-import com.noop.data.DailyMetric
 import com.noop.data.HrSample
 import com.noop.data.ImportSummary
 import com.noop.data.WhoopRepository
@@ -227,14 +226,15 @@ object ActivityFileImporter {
         if (activity.hrSamples.isNotEmpty()) {
             repo.insertHr(activity.hrSamples.map { HrSample(deviceId = deviceId, ts = it.ts, bpm = it.bpm) })
         }
-        if (activity.steps != null && activity.steps > 0) {
-            repo.upsertDailyMetrics(
-                listOf(DailyMetric(deviceId = deviceId, day = localDayString(activity.startTs), steps = activity.steps)),
-            )
-        }
+        // #568: do NOT write the activity's steps as a DAILY metric. A single imported workout's steps are
+        // that activity's steps, not the day's total — writing them under the "activity-file" day-owner
+        // (#137, which exists for HR/Effort) made one walk stand in for the whole day's step count (shown
+        // in place of the on-device total). The steps stay on the workout (its note carries "<n> steps");
+        // matches iOS, whose ActivityFileImporter writes no daily-steps metric either. Summing imported
+        // steps INTO the daily total is a separate, double-count-aware feature (see #585), deliberately not
+        // done here.
 
         val counts = linkedMapOf("workouts" to 1)
-        if (activity.steps != null && activity.steps > 0) counts["dailyMetric"] = 1
         return ImportSummary(
             source = SOURCE_LABEL,
             counts = counts,
@@ -557,9 +557,6 @@ object ActivityFileImporter {
 
     private fun dayString(ts: Long): String =
         Instant.ofEpochSecond(ts).atOffset(ZoneOffset.UTC).toLocalDate().toString()
-
-    private fun localDayString(ts: Long): String =
-        Instant.ofEpochSecond(ts).atZone(java.time.ZoneId.systemDefault()).toLocalDate().toString()
 
     private fun displayName(context: Context, uri: Uri): String? = runCatching {
         context.contentResolver.query(uri, null, null, null, null)?.use { c ->


### PR DESCRIPTION
Fixes the **daily-total hijack** half of #568 (the ×2 halving half was #584). Addresses #585 (the minimal fix; the larger "sum into the day" enhancement stays tracked there).

## The bug

Importing an activity file wrote its steps as a **daily** metric under the `activity-file` source, so a single imported walk stood in for the whole **day's** step total — shown in place of the on-device count, and duplicated.

## Why removing it is right (not a #137 revert)

- A single workout's steps are that activity's steps, **not the day's total**.
- The daily-steps write is **incidental**: #137 makes `activity-file` a day-**owner** for its *HR* (to light a strap-less day's Effort ring). That HR write is untouched — only the steps daily-write is removed.
- **Nothing else reads** `activity-file` daily steps — steps-estimate calibration uses the phone's count via `apple-health` / `health-connect`, never `activity-file`.

The imported steps stay on the workout (its note carries `"<n> steps"`, shown in the workout detail's Notes row).

## Cross-platform (correction from my first draft)

My initial version was **Android-only** and claimed "iOS already does this." **That was wrong** — re-review found iOS does the same write, just in the *caller* (`DataSourcesView.swift`, after `ActivityFileImporter.parse`) rather than the importer. Leaving it would have **broken parity**. So this now removes it on **both**:
- Android — `ActivityFileImporter.kt` (importer write path)
- iOS — `DataSourcesView.swift` (import caller)

Android also drops the now-orphaned `DailyMetric` import and `localDayString` helper (`dayString`, used by the summary, stays).

## Not included (tracked in #585)

Summing imported activity steps **into** the daily total — the reporter's literal expectation — is the double-count trap and a separate aggregation-aware feature.

## Note

Fixes new imports. An already-imported activity's existing daily-steps row isn't retroactively removed; delete + re-import clears it (same caveat as #584).

## Verification

- Android: `compileFullDebugKotlin` + `testFullDebugUnitTest --tests "com.noop.ingest.ActivityFileImporterTest"` → **10/10**.
- iOS: `DataSourcesView.swift` is app-target Swift (no CI; GRDB/SwiftUI wall blocks a local Linux build). The change is a **pure deletion** of a self-contained block — it syntax-parses and leaves no dangling references (`activity.steps` still flows to the workout note) — but it needs an `xcodebuild -scheme Strand build` / `app-build.yml` run to type-check.