### PR TITLE
Repository.mergeActivityFileSteps: graceful last-wins on duplicate day (parity + no trap)

### DIFF
--- a/Strand/Data/Repository.swift
+++ b/Strand/Data/Repository.swift
@@ -805,7 +805,10 @@ final class Repository: ObservableObject {
     nonisolated static func mergeActivityFileSteps(into base: [DailyMetric],
                                                    _ activityFile: [DailyMetric]) -> [DailyMetric] {
         guard !activityFile.isEmpty else { return base }
-        var byDay = Dictionary(uniqueKeysWithValues: base.map { ($0.day, $0) })
+        // Last-wins on a duplicate day rather than `uniqueKeysWithValues`, which TRAPS (crashes) if `base`
+        // ever carries two rows for one day. Matches the Kotlin twin's graceful merge and this file's own
+        // safe convention (the other `Dictionary(…, uniquingKeysWith:)` builders here).
+        var byDay = Dictionary(base.map { ($0.day, $0) }, uniquingKeysWith: { _, last in last })
         for row in activityFile {
             guard let steps = row.steps, steps > 0 else { continue }
             if let existing = byDay[row.day] {


### PR DESCRIPTION
A one-line robustness + parity nit, found on a parity pass while investigating #568 (independent of the steps-count fix #584 and the still-open #585).

## The nit

`Repository.mergeActivityFileSteps` (`Strand/Data/Repository.swift`) built its day lookup with:

```swift
Dictionary(uniqueKeysWithValues: base.map { ($0.day, $0) })
```

`uniqueKeysWithValues` **traps (crashes)** if `base` ever contains two rows for the same `day`. Two things make this worth swapping:

- **Parity:** the Kotlin twin `WhoopRepository.mergeActivityFileSteps` already does graceful last-wins (`for (row in base) byDay[row.day] = row`), so the two platforms diverge on duplicate-day input (iOS crashes, Android doesn't).
- **This file's own convention:** the other day-keyed dictionaries in `Repository.swift` use the safe `Dictionary(…, uniquingKeysWith: { _, last in last })`. This call was the odd one out.

## Severity

Likely **latent, not live** — `mergeDaily` (which produces `base`) de-dups by day today, so the trap is probably unreachable right now. But a trapping initializer on merged external data is fragile: it becomes a crash the day an upstream query changes. Matching Android's (and the file's own) graceful form removes that footgun for free.

## Fix

```swift
Dictionary(base.map { ($0.day, $0) }, uniquingKeysWith: { _, last in last })
```

Last-wins, matching Android and the rest of the file. No behaviour change except that a duplicate day no longer crashes.

## Verification

App-target Swift (`Strand/Data/Repository.swift`), so **no local build** (GRDB/Combine wall on Linux). The two-arg `Dictionary` init form was **type-checked in isolation** (compiles), and `mergeActivityFileSteps` is exercised by `VitalSourceResolutionTests` (`testActivityFileStepsFillMissingStepDaysOnly`) on macOS. Needs an `xcodebuild -scheme Strand test` / `app-build.yml` run to fully validate, like the other recent app-target changes.
