### PR TITLE
Morning recap: dedup on the reported night, not the calendar day (fixes #567 midnight re-fire)

### DIFF
--- a/android/app/src/main/java/com/noop/notif/ScheduledReportNotifier.kt
+++ b/android/app/src/main/java/com/noop/notif/ScheduledReportNotifier.kt
@@ -33,14 +33,17 @@ import kotlin.math.roundToInt
  *  by ScheduledReportPolicyTest independently of the notification plumbing. */
 object ScheduledReportPolicy {
 
-    /** Fire the morning recap at most once per local day: only when enabled, a recap value exists, and we
-     *  haven't already posted for [today]. */
+    /** Fire the morning recap at most once per REPORTED NIGHT: only when enabled, a recap value exists, and
+     *  we haven't already posted for [reportDay]. [reportDay] is the day of the banked night the recap is
+     *  FOR (the resolved today-row's `day`), NOT the phone's calendar day — keying on the calendar day made
+     *  it re-fire at midnight for anyone up late, since the row still resolves to last night's until a new
+     *  night is banked (#567). */
     fun shouldNotifyMorning(
         enabled: Boolean,
         chargeOrRestPresent: Boolean,
         lastNotifiedDay: String?,
-        today: String,
-    ): Boolean = enabled && chargeOrRestPresent && lastNotifiedDay != today
+        reportDay: String,
+    ): Boolean = enabled && chargeOrRestPresent && lastNotifiedDay != reportDay
 
     /** Fire the post-workout summary only for a workout STRICTLY newer than the last one summarised, so a
      *  re-sync of the same backlog never re-notifies. [lastWorkoutTs] is 0 before the first ever. */
@@ -106,13 +109,15 @@ object ScheduledReportNotifier {
      * policy, so the caller can fire it freely each time the days collector republishes.
      */
     @SuppressLint("MissingPermission") // guarded by areNotificationsEnabled() + runCatching
-    fun onMorning(context: Context, chargePct: Int?, restPct: Int?) {
-        val today = java.time.LocalDate.now().toString()
+    fun onMorning(context: Context, reportDay: String, chargePct: Int?, restPct: Int?) {
+        // reportDay is the banked night's day (the resolved today-row's `day`), NOT LocalDate.now() — the
+        // calendar day rolls at midnight while the row still resolves to last night's until a new night is
+        // banked, which re-fired the recap at the start of a new day for late-nighters (#567).
         if (!ScheduledReportPolicy.shouldNotifyMorning(
                 enabled = NoopPrefs.morningReportEnabled(context),
                 chargeOrRestPresent = chargePct != null || restPct != null,
                 lastNotifiedDay = NoopPrefs.reportMorningDay(context),
-                today = today,
+                reportDay = reportDay,
             )
         ) return
         val copy = ScheduledReportPolicy.morningCopy(chargePct, restPct) ?: return
@@ -120,9 +125,9 @@ object ScheduledReportNotifier {
             if (!NotificationManagerCompat.from(context).areNotificationsEnabled()) return
             ensureChannel(context)
             post(context, MORNING_NOTIF_ID, copy.first, copy.second)
-            // Mark fired only after a successful post, so a notifications-disabled morning still notifies
-            // once they're re-enabled the same day.
-            NoopPrefs.setReportMorningDay(context, today)
+            // Mark fired only after a successful post, so a notifications-disabled night still notifies
+            // once they're re-enabled while the same night's row is showing.
+            NoopPrefs.setReportMorningDay(context, reportDay)
         }
     }
 

--- a/android/app/src/main/java/com/noop/ui/AppViewModel.kt
+++ b/android/app/src/main/java/com/noop/ui/AppViewModel.kt
@@ -646,6 +646,9 @@ class AppViewModel(app: Application) : AndroidViewModel(app) {
                     if (todayRow.totalSleepMin != null) {
                         ScheduledReportNotifier.onMorning(
                             context = appContext,
+                            // Key the once-per-recap gate on the banked NIGHT's day, not the calendar day —
+                            // otherwise the midnight rollover re-fires last night's recap for late-nighters (#567).
+                            reportDay = todayRow.day,
                             chargePct = todayRow.recovery.scorePctOrNull(),
                             restPct = RestScorer.restFromDaily(todayRow).scorePctOrNull(),
                         )

--- a/android/app/src/test/java/com/noop/notif/ScheduledReportPolicyTest.kt
+++ b/android/app/src/test/java/com/noop/notif/ScheduledReportPolicyTest.kt
@@ -19,7 +19,7 @@ class ScheduledReportPolicyTest {
     @Test fun morningFiresWhenEnabledScorePresentAndNotYetToday() {
         assertTrue(
             ScheduledReportPolicy.shouldNotifyMorning(
-                enabled = true, chargeOrRestPresent = true, lastNotifiedDay = "2026-06-20", today = "2026-06-21",
+                enabled = true, chargeOrRestPresent = true, lastNotifiedDay = "2026-06-20", reportDay = "2026-06-21",
             ),
         )
     }
@@ -27,7 +27,7 @@ class ScheduledReportPolicyTest {
     @Test fun morningSuppressedWhenDisabled() {
         assertFalse(
             ScheduledReportPolicy.shouldNotifyMorning(
-                enabled = false, chargeOrRestPresent = true, lastNotifiedDay = null, today = "2026-06-21",
+                enabled = false, chargeOrRestPresent = true, lastNotifiedDay = null, reportDay = "2026-06-21",
             ),
         )
     }
@@ -35,7 +35,7 @@ class ScheduledReportPolicyTest {
     @Test fun morningSuppressedWhenAlreadyFiredToday() {
         assertFalse(
             ScheduledReportPolicy.shouldNotifyMorning(
-                enabled = true, chargeOrRestPresent = true, lastNotifiedDay = "2026-06-21", today = "2026-06-21",
+                enabled = true, chargeOrRestPresent = true, lastNotifiedDay = "2026-06-21", reportDay = "2026-06-21",
             ),
         )
     }
@@ -43,7 +43,21 @@ class ScheduledReportPolicyTest {
     @Test fun morningSuppressedWhenNoScore() {
         assertFalse(
             ScheduledReportPolicy.shouldNotifyMorning(
-                enabled = true, chargeOrRestPresent = false, lastNotifiedDay = null, today = "2026-06-21",
+                enabled = true, chargeOrRestPresent = false, lastNotifiedDay = null, reportDay = "2026-06-21",
+            ),
+        )
+    }
+
+    /** #567: after midnight a late-nighter's row still resolves to LAST night (reportDay stays that
+     *  night's day) even though the calendar day has rolled. Keyed on reportDay (not the calendar day),
+     *  the recap must NOT re-fire — it was already posted for that night. Guards the fix against a
+     *  regression back to `LocalDate.now()`. */
+    @Test fun morningDoesNotRefireAtMidnightWhenReportDayIsStillLastNight() {
+        // Fired this morning for the 06-20 night; now it's just past midnight (calendar day 06-21) but the
+        // resolved row is still the 06-20 night → reportDay = "2026-06-20", already notified → suppressed.
+        assertFalse(
+            ScheduledReportPolicy.shouldNotifyMorning(
+                enabled = true, chargeOrRestPresent = true, lastNotifiedDay = "2026-06-20", reportDay = "2026-06-20",
             ),
         )
     }


### PR DESCRIPTION
Fixes #567 (@bartmuskala): the morning recap notification fires at the start of a new day (midnight) instead of once after your night, for anyone up late.

## Cause

`ScheduledReportNotifier.onMorning` deduped on `java.time.LocalDate.now()` — the phone's **calendar** day, which rolls at midnight. But the recap reports a **banked night**, and the today-row is resolved via the **logical** day (rolls at 04:00, with the #304 pre-04:00 carve-out).

For a late-nighter who crosses midnight without sleeping:
1. the new calendar day has no banked night yet, so `resolveTodayRow` **falls back to last night's row** (`totalSleepMin != null`), and `onMorning` gets last night's Charge/Rest;
2. meanwhile the dedup key `LocalDate.now()` has advanced to the new calendar day, so `lastNotifiedDay (D) != today (D+1)` → **fires again**, re-showing the recap already seen that morning.

## Fix

Key the once-per-recap gate on the **reported night's day** (the resolved today-row's `day`), not the calendar day:
- `onMorning` gains a `reportDay` parameter; `AppViewModel` passes `todayRow.day`.
- The policy param is renamed `today` → `reportDay` with a doc note, so nobody re-introduces `LocalDate.now()`. The gate logic is unchanged (`enabled && present && lastNotifiedDay != reportDay`).

At midnight the row still resolves to last night → `reportDay` unchanged → already notified → **no re-fire**. The actual morning's new-night row fires normally.

## No migration

`reportMorningDay` stays an ISO `yyyy-MM-dd` string; a stored calendar day and a row day compare the same way, so an upgrading user just fires normally the next morning — no stuck state, no double-fire.

## Scope

Android-only — the morning recap is an Android feature (no iOS twin). Strap-agnostic (day-key logic, not WHOOP-5.0-specific).

## Verification

`./gradlew compileFullDebugKotlin` + `testFullDebugUnitTest --tests "com.noop.notif.ScheduledReportPolicyTest"` → **16/16**, including a new midnight-rollover regression test (`reportDay` = last night's day after the calendar rolled → must not re-fire). Fully JVM-testable + compiled locally.
