### PR TITLE
fix(ios): pull-to-sync shows "Syncing…" and stays up for the real backfill

### DIFF
--- a/Strand/Liquid/LiquidTodayView.swift
+++ b/Strand/Liquid/LiquidTodayView.swift
@@ -349,23 +349,12 @@ struct LiquidTodayView: View {
     static let pullSpace = "liqTodayScroll"
 
     /// Reserves the revealed space at the top and shows a vessel that fills with the pull, then sloshes
-    /// while the refresh runs.
+    /// while the refresh runs. A plain computed property (not a LiveState-isolated leaf) — it doesn't read
+    /// LiveState itself, so it's cheap to re-evaluate as part of the main body. It hands the actual
+    /// visibility decision to `LiquidRefreshIndicator` below, which DOES own LiveState.
     private var liquidRefreshIndicator: some View {
-        let progress = min(1, max(0, pullY / pullThreshold))
-        return ZStack {
-            if refreshing {
-                LiquidVessel(value: 0.6, tint: liquidHeart, animated: true)
-                    .frame(width: 34, height: 34)
-            } else if pullY > 2 {
-                LiquidVessel(value: progress, tint: liquidHeart, animated: false)
-                    .frame(width: 30, height: 30)
-                    .opacity(progress)
-                    .scaleEffect(0.7 + 0.3 * progress)
-            }
-        }
-        .frame(maxWidth: .infinity)
-        .frame(height: refreshing ? 64 : min(pullY, pullThreshold * 1.15))
-        .animation(.easeOut(duration: 0.22), value: refreshing)
+        LiquidRefreshIndicator(pullY: pullY, pullThreshold: pullThreshold, refreshing: refreshing,
+                               liquidHeart: liquidHeart)
     }
 
     /// Arm the refresh once the pull passes the threshold; FIRE it when the finger releases (the pull
@@ -1408,6 +1397,50 @@ private struct HeroScoreCell: View {
 
 
 // MARK: - Scene controls (LiveState-isolated leaves)
+
+/// The liquid pull-to-refresh vessel + a "Syncing…" label. Owns LiveState (isolated leaf, per the file's
+/// convention — see `LiquidLiveHR`) so a live-HR notify doesn't re-render the whole Today, but the vessel
+/// still knows about an ONGOING strap backfill.
+///
+/// Visibility used to be driven only by the local `refreshing` flag, which flips false ~350ms after the
+/// pull releases (once the local repo reload + a short "let the fill read as done" delay complete) — but
+/// `ble.syncNow()` kicks off a real BLE history offload that can run far longer than that. The vessel was
+/// disappearing while the strap was still mid-sync, with no feedback beyond the easy-to-miss header
+/// `SyncStatusChip`. `syncing` now also holds it (and the label) up while `live.backfilling` is true, so
+/// releasing the pull and watching it go away actually means the sync finished.
+private struct LiquidRefreshIndicator: View {
+    let pullY: CGFloat
+    let pullThreshold: CGFloat
+    let refreshing: Bool
+    let liquidHeart: Color
+
+    @EnvironmentObject private var live: LiveState
+
+    private var progress: CGFloat { min(1, max(0, pullY / pullThreshold)) }
+    private var syncing: Bool { refreshing || live.backfilling }
+
+    var body: some View {
+        ZStack {
+            if syncing {
+                VStack(spacing: 6) {
+                    LiquidVessel(value: 0.6, tint: liquidHeart, animated: true)
+                        .frame(width: 34, height: 34)
+                    Text("Syncing…")
+                        .font(StrandFont.caption)
+                        .foregroundStyle(StrandPalette.textSecondary)
+                }
+            } else if pullY > 2 {
+                LiquidVessel(value: progress, tint: liquidHeart, animated: false)
+                    .frame(width: 30, height: 30)
+                    .opacity(progress)
+                    .scaleEffect(0.7 + 0.3 * progress)
+            }
+        }
+        .frame(maxWidth: .infinity)
+        .frame(height: syncing ? 64 : min(pullY, pullThreshold * 1.15))
+        .animation(.easeOut(duration: 0.22), value: syncing)
+    }
+}
 
 /// Quick-actions "+" button. Tap → the shell's quick-action menu.
 /// #today-layout: the Arrange sheet — reorder the Today sections by dragging rows (SwiftUI's native


### PR DESCRIPTION
Fixes #587.

## Problem

`LiquidTodayView`'s pull-to-refresh vessel (#334/#426/#502) is silent — no text — and its visibility is tied only to a local `refreshing` flag:

```swift
ble.syncNow()
await repo.refresh()
await load()
try? await Task.sleep(nanoseconds: 350_000_000)   // let the fill read as "done"
withAnimation(.easeOut(duration: 0.25)) { refreshing = false }
```

`refreshing` flips false ~350ms after release. But `syncNow()` starts a real BLE history offload that can run far longer than that. Releasing the pull makes the vessel disappear while the strap is still mid-sync, with no feedback beyond the header's `SyncStatusChip` (#258) — easy to miss and not visually connected to the gesture the user just performed.

## Fix

- Extracted `liquidRefreshIndicator` into its own `LiquidRefreshIndicator` leaf, following the file's existing `LiveState`-isolation convention (mirrors `LiquidLiveHR`) — it owns `@EnvironmentObject var live: LiveState` itself so a ~1 Hz live-HR notify still doesn't re-render the rest of Today.
- Added a "Syncing…" label next to the vessel.
- Visibility (`syncing`) is now `refreshing || live.backfilling` instead of just `refreshing` — the indicator (vessel + label) stays up until the actual strap backfill finishes, not just the local UI reload.

## Scope

iOS only (`Strand/Liquid/LiquidTodayView.swift`), one file. No BLE/protocol/schema change — reads the existing `LiveState.backfilling` flag the header chip already uses. Android isn't affected (different pull-to-sync implementation, `PullToRefreshContainer` in `TodayScreen.kt`, already fixed for its own visibility bug in #583).

## Testing

macOS `Strand` scheme builds clean (0 errors) — `xcodebuild -scheme Strand -destination 'platform=macOS'`. Full `NOOPiOS` scheme not run locally (missing watchOS SDK in my environment, same constraint as prior PRs); this file is shared between iOS and macOS Today (`liquidTodayEnabled` gate), so the macOS build exercises the same code path.

No behavior change for the non-syncing states (pull-in-progress, idle) — only the syncing branch's visibility condition and content changed.