### PR TITLE
feat(ios): actually request notification permission during onboarding

### DIFF
--- a/Strand/Onboarding/OnboardingWizard.swift
+++ b/Strand/Onboarding/OnboardingWizard.swift
@@ -2,6 +2,7 @@ import SwiftUI
 import UniformTypeIdentifiers
 import StrandDesign
 import WhoopStore
+import UserNotifications
 
 // MARK: - OnboardingWizard
 //
@@ -212,7 +213,31 @@ public struct OnboardingWizard: View {
 
     // MARK: Navigation
 
+    /// Leaving the Notifications step is the one point in onboarding where we actually ask the OS for
+    /// notification permission — everything before this only explained why (the `NotificationsStep`
+    /// card). Without this, NOOP never showed up under Settings → Notifications at all unless a user
+    /// later found and enabled one of the opt-in automations (wind-down, battery, illness) buried in
+    /// More → Alarms/Automations, each of which lazily requests on its own toggle. Mirrors the Android
+    /// onboarding's `OnboardingPage.Notifications` step (`OnboardingScreen.kt`): request only if not
+    /// already determined (so a re-run/upgrade doesn't re-prompt), and advance once the OS dialog is
+    /// dismissed either way — the per-feature toggles still handle a later denial on their own.
     private func advance() {
+        guard step != .notifications else {
+            UNUserNotificationCenter.current().getNotificationSettings { settings in
+                guard settings.authorizationStatus == .notDetermined else {
+                    Task { @MainActor in advanceStep() }
+                    return
+                }
+                UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .sound]) { _, _ in
+                    Task { @MainActor in advanceStep() }
+                }
+            }
+            return
+        }
+        advanceStep()
+    }
+
+    private func advanceStep() {
         guard let next = Step(rawValue: step.rawValue + 1) else { onFinished(); return }
         withAnimation(StrandMotion.gentle) { step = next }
     }


### PR DESCRIPTION
## Problem

The onboarding wizard's Notifications step explains why NOOP wants notification access (\"A buzz, not a banner\") but never calls \`UNUserNotificationCenter.requestAuthorization\` — it's purely informational about a different feature (strap wrist-buzz relay). So NOOP never appears under Settings → Notifications at all unless a user separately finds and enables one of the opt-in automations (wind-down, battery, illness) buried in More → Alarms/Automations, each of which lazily requests on its own toggle.

Real-world symptom: a user reported \"NOOP doesn't even show up in Settings → Notifications\" — confirmed the onboarding step never actually asks the OS.

## Fix

Request permission when leaving the Notifications step (\`advance()\` in \`OnboardingWizard.swift\`), mirroring the Android onboarding's \`OnboardingPage.Notifications\` handling (\`OnboardingScreen.kt\`):
- Request only if \`authorizationStatus == .notDetermined\` (so a re-run/upgrade doesn't re-prompt a user who already decided).
- Advance once the OS dialog is dismissed either way — the per-feature toggles (wind-down, battery, illness) already handle a later denial on their own (surfaced in #251).

## Scope

One file, iOS/macOS shared (\`Strand/Onboarding/OnboardingWizard.swift\`). No behavior change to any other step; the Notifications step's UI/copy is untouched.

## Testing

macOS \`Strand\` scheme builds clean (0 errors) — \`xcodebuild -scheme Strand -destination 'platform=macOS'\`. Full \`NOOPiOS\` scheme not run locally (missing watchOS SDK in my environment, same constraint as prior PRs); onboarding is shared code exercised by the macOS build.