### PR TITLE
Raise backfill auto-continue cap so a deep backlog drains in one connection (#533)

### DIFF
--- a/Strand/BLE/BLEManager.swift
+++ b/Strand/BLE/BLEManager.swift
@@ -310,14 +310,18 @@ struct Whoop5EmptyOffloadTracker {
 /// #1012: a FUTURE-dated `strapNewestTs` (more than `futureSkewSeconds` past the wall clock, #928) not
 /// only nulls guard 2a — it also STOPS guard 2b. A future-clock strap banks future-dated records, so the
 /// rows it hands over are future-timestamped too and "real rows persisted" is no evidence of genuine
-/// backlog; 2b would chase the future-dated range through the whole cap (six back-to-back passes, each to
-/// its idle timeout — the reported ~15-min sync). The stale/PAST-epoch case 2b actually exists for (#451)
+/// backlog; 2b would chase the future-dated range through the whole cap (every consecutive pass back-to-back,
+/// each to its idle timeout — the reported ~15-min sync). The stale/PAST-epoch case 2b actually exists for (#451)
 /// reads BEHIND the frontier, never future-dated, so it is untouched.
 struct BackfillContinuation {
-    /// Hard cap on consecutive auto-continues per connection (resets on disconnect). 6 × ~60s ≈ 6 min of
-    /// back-to-back draining — enough to chew through a multi-night backlog far faster than the 15-min
-    /// floor, without letting a misbehaving strap monopolise Bluetooth.
-    static let defaultMaxAutoContinues = 6
+    /// Hard cap on consecutive auto-continues per connection (resets on disconnect). Guards 1-3 in
+    /// `shouldAutoContinue` (plus the #928/#1012 future-clock exclusion) already stop the pathological
+    /// cases, so this is only the backstop against a strap that advances its trim but never advances OUR
+    /// frontier. #533: at 6, a well-behaved deep backlog hit the cap and got throttled to the 15-min floor
+    /// mid-drain (recent nights landing hours after waking — a false sleep-detection bug in #515). Raised so
+    /// a typical deep backlog drains in ONE connection (~24 productive passes ≈ a few minutes back-to-back);
+    /// the backstop only ever bites the rare data-shape spin. TUNABLE — needs on-strap validation.
+    static let defaultMaxAutoContinues = 24
     /// How far ahead the strap must be (seconds) before "more backlog remains" is real, not clock noise.
     /// Matches StuckStrapDetector.behindGapSeconds (5 min) so the two agree on "behind".
     static let defaultBehindGapSeconds = 300
@@ -372,7 +376,7 @@ struct BackfillContinuation {
         // #1012: a future-dated newest also gates 2b, not just 2a. A strap whose clock is set ahead
         // (#928) BANKED future-dated records, so the rows this session persisted are themselves
         // future-timestamped — "real rows" is NOT evidence of genuine backlog there, and 2b used to
-        // chase the future-dated range through the whole cap (six back-to-back passes, each run to its
+        // chase the future-dated range through the whole cap (every consecutive pass back-to-back, each run to its
         // idle timeout: the reported ~15-min sync). Stop after this single pass; the periodic floor
         // keeps draining across connects, restoring the pre-#928 single-pass behaviour. The stale/
         // PAST-epoch case 2b exists for (#451) reads BEHIND the frontier, never future-dated, so it

--- a/StrandTests/BackfillContinuationTests.swift
+++ b/StrandTests/BackfillContinuationTests.swift
@@ -213,7 +213,9 @@ final class BackfillContinuationTests: XCTestCase {
     /// the strap's newest) until either we catch up OR the cap is hit — never silently stalling at one.
     func testMultiPassDrainUntilCaughtUpOrCapped() {
         let strapNewest = 1_800_000_000
-        var frontier = strapNewest - 7 * 86_400      // a full week behind
+        // Backlog DEEPER than the cap (each pass advances the frontier one day) so the drain is bounded by
+        // the cap, not by catching up — that is the invariant this test pins, independent of the cap value.
+        var frontier = strapNewest - (BackfillContinuation.defaultMaxAutoContinues + 5) * 86_400
         var count = 0
         var passes = 0
         while BackfillContinuation.shouldAutoContinue(
@@ -232,6 +234,20 @@ final class BackfillContinuationTests: XCTestCase {
         }
         // It stopped because it hit the cap (deep backlog), not because it silently stalled at pass 1.
         XCTAssertEqual(count, BackfillContinuation.defaultMaxAutoContinues)
+    }
+
+    /// #533: a genuine deep backlog must keep draining PAST the old 6-pass cap in one connection, instead
+    /// of being throttled to the 15-min floor mid-drain. At 10 consecutive continues with the strap still
+    /// a day ahead of our frontier and the trim advancing, it must still continue (the cap is now higher).
+    func testContinuesPastOldSixCapOnDeepBacklog() {
+        XCTAssertGreaterThan(BackfillContinuation.defaultMaxAutoContinues, 6)   // pins the #533 raise
+        XCTAssertTrue(BackfillContinuation.shouldAutoContinue(
+            stillConnected: true,
+            strapNewestTs: 1_800_000_000,
+            ourFrontierTs: 1_800_000_000 - 86_400,   // a full day behind
+            wallNowUnix: wallNow,
+            lastTrimAdvanced: true,
+            consecutiveCount: 10))                    // well past the old cap of 6
     }
 
     // MARK: #25 — HISTORY_COMPLETE-sliced offloads

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -964,9 +964,16 @@ class WhoopBleClient(
         fun dataRangeOldestUnix(frame: ByteArray): Long? = com.noop.protocol.DataRange.oldestUnix(frame)
 
         /** #364 auto-continue cap: consecutive immediate re-kicks per connection before falling back to
-         *  the 900s periodic timer. 6 × ~60s ≈ 6 min of back-to-back draining without letting a
-         *  misbehaving strap monopolise Bluetooth. Mirrors Swift BackfillContinuation.defaultMaxAutoContinues. */
-        const val MAX_AUTO_CONTINUES = 6
+         *  the 900s periodic timer. Guards 1-3 in [shouldAutoContinue] (healthy link, genuine backlog,
+         *  advancing trim, plus the #928/#1012 future-clock exclusion) already stop the pathological cases;
+         *  this cap is only the backstop against a strap that advances its trim but never advances OUR
+         *  frontier (a data-shape spin). #533: at 6, a WELL-BEHAVED deep backlog hit the cap and got
+         *  throttled to the 15-min floor mid-drain (~9s bursts, 15-20 min apart, 95% waiting), so recent
+         *  nights landed hours after waking (which surfaced as a false sleep-detection bug in #515). Raised
+         *  so a typical deep backlog drains in ONE connection: 24 productive passes (~10-15s each) ≈ a few
+         *  minutes of back-to-back draining; the ~24-min backstop only ever bites the rare data-shape spin.
+         *  Mirrors Swift BackfillContinuation.defaultMaxAutoContinues. TUNABLE — needs on-strap validation. */
+        const val MAX_AUTO_CONTINUES = 24
 
         /** #364 "more backlog remains" margin (seconds): how far ahead the strap must be of our persisted
          *  data frontier before we treat it as behind, not clock noise. Matches the Swift
@@ -1037,8 +1044,8 @@ class WhoopBleClient(
          * #1012: a FUTURE-dated [strapNewestTs] (more than [futureSkewSeconds] past the wall clock, #928)
          * not only nulls guard 2a — it also STOPS guard 2b. A future-clock strap banks future-dated
          * records, so the rows it hands over are future-timestamped too and "real rows persisted" is no
-         * evidence of genuine backlog; 2b would chase the future-dated range through the whole cap (six
-         * back-to-back passes, each to its idle timeout — the reported ~15-min sync). The stale/PAST-epoch
+         * evidence of genuine backlog; 2b would chase the future-dated range through the whole cap (every
+         * consecutive pass back-to-back, each to its idle timeout — the reported ~15-min sync). The stale/PAST-epoch
          * case 2b actually exists for (#451) reads BEHIND the frontier, never future-dated, so it is
          * untouched.
          */
@@ -1069,8 +1076,8 @@ class WhoopBleClient(
             // #1012: a future-dated newest also gates 2b, not just 2a. A strap whose clock is set ahead
             // (#928) BANKED future-dated records, so the rows this session persisted are themselves
             // future-timestamped — "real rows" is NOT evidence of genuine backlog there, and 2b used to
-            // chase the future-dated range through the whole cap (six back-to-back passes, each run to
-            // its idle timeout: the reported ~15-min sync). Stop after this single pass; the periodic
+            // chase the future-dated range through the whole cap (every consecutive pass back-to-back,
+            // each run to its idle timeout: the reported ~15-min sync). Stop after this single pass; the periodic
             // floor keeps draining across connects, restoring the pre-#928 single-pass behaviour. The
             // stale/PAST-epoch case 2b exists for (#451) reads BEHIND the frontier, never future-dated,
             // so it falls through untouched below.

--- a/android/app/src/test/java/com/noop/ble/BackfillContinuationTest.kt
+++ b/android/app/src/test/java/com/noop/ble/BackfillContinuationTest.kt
@@ -139,6 +139,24 @@ class BackfillContinuationTest {
         )
     }
 
+    /** #533: a genuine deep backlog must keep draining PAST the old 6-pass cap in one connection, instead
+     *  of being throttled to the 15-min floor mid-drain. At 10 consecutive continues with the strap still
+     *  a day ahead of our frontier and the trim advancing, it must still continue (the cap is now higher). */
+    @Test
+    fun continues_pastOldSixCap_onDeepBacklog() {
+        assertTrue(WhoopBleClient.MAX_AUTO_CONTINUES > 6)   // pins the #533 raise
+        assertTrue(
+            WhoopBleClient.shouldAutoContinue(
+                stillConnected = true,
+                strapNewestTs = 1_800_000_000L,
+                ourFrontierTs = 1_800_000_000L - 86_400L,   // a full day behind
+                wallNowUnix = wallNow,
+                lastTrimAdvanced = true,
+                consecutiveCount = 10,                       // well past the old cap of 6
+            ),
+        )
+    }
+
     /** Unknown range (no GET_DATA_RANGE answer, or nothing persisted yet) ⇒ don't auto-continue. */
     @Test
     fun stops_whenRangeUnknown() {
@@ -258,7 +276,9 @@ class BackfillContinuationTest {
     @Test
     fun multiPassDrain_untilCaughtUpOrCapped() {
         val strapNewest = 1_800_000_000L
-        var frontier = strapNewest - 7L * 86_400L   // a week behind
+        // Backlog DEEPER than the cap (each pass advances the frontier one day) so the drain is bounded by
+        // the cap, not by catching up — that is the invariant this test pins, independent of the cap value.
+        var frontier = strapNewest - (WhoopBleClient.MAX_AUTO_CONTINUES + 5).toLong() * 86_400L
         var count = 0
         var passes = 0
         while (WhoopBleClient.shouldAutoContinue(


### PR DESCRIPTION
Closes #533.

## The bottleneck
The per-connection consecutive auto-continue cap — `WhoopBleClient.MAX_AUTO_CONTINUES` (Kotlin) / `BackfillContinuation.defaultMaxAutoContinues` (Swift) — was **6**. When the strap has a deep backlog, NOOP drains it in immediate back-to-back offload passes; once it hits the cap it falls back to the **900 s (15-min) periodic timer**.

`#533` field data (≈21k rows, ~9 s productive bursts 15–20 min apart, ~95 % of wall-time idle) shows a **well-behaved** deep backlog hitting the cap at 6 and then being throttled to the 15-min floor **mid-drain** — so recent nights landed hours after waking. That's the same late-arrival that surfaced as the false sleep-detection symptom in **#515**.

Guards 1–3 in `shouldAutoContinue` (healthy link, genuine backlog `newest − frontier > behindGapSeconds`, advancing trim, plus the #928/#1012 future-clock exclusion) already stop the pathological cases. The cap is **only** the backstop against a strap that advances its trim but never advances *our* frontier (a data-shape spin). So raising it doesn't weaken any real safety guard.

## The change
Bump the cap **6 → 24** on both platforms (parity contract — byte-identical scheduler behavior). A typical deep backlog now drains in **one connection** (~24 productive passes ≈ a few minutes back-to-back) instead of stretching across several 15-min windows.

- `android/.../ble/WhoopBleClient.kt` — `MAX_AUTO_CONTINUES`
- `Strand/BLE/BLEManager.swift` — `defaultMaxAutoContinues`

The worst-case backstop window widens from ~6 min to ~24 min of back-to-back radio use *only* in the rare true-spin shape (trim advances, frontier doesn't) — and guards 1–3 already catch the common variants of that before the cap is even consulted.

## Tests (both platforms, in lockstep)
`BackfillContinuationTest.kt` + `BackfillContinuationTests.swift`:
- **multi-pass-drain test** — rewritten to use a **cap-relative** backlog (`cap + 5` days) so it pins the *cap-bounds-a-deep-drain* invariant independent of the value. The old hardcoded 7-day backlog was `> 6` but `< 24`, so with the new cap it now correctly drains to *caught-up* rather than capping (the fix working as intended) — which is why the hardcoded assertion had to become cap-relative.
- **`continues_pastOldSixCap_onDeepBacklog`** — new; pins that a genuine backlog at `consecutiveCount = 10` (past the old cap of 6) still continues.

`./gradlew testFullDebugUnitTest --tests "com.noop.ble.BackfillContinuationTest"` → **22 passed, 0 failed**. The Swift twin mirrors the same two changes (see caveat below re: running it).

## Verification / caveats
- **`24` is TUNABLE and needs on-strap validation before merge** — BLE offload behavior cannot be CI- or Linux-tested. It's sized to drain the observed field backlog in one connection; a real deep-backlog drain on hardware should confirm it caught up in a single session without the radio being monopolised.
- **Swift half is app-target** (`Strand/BLE/BLEManager.swift` + `StrandTests/BackfillContinuationTests.swift`) — not covered by `swift-packages` CI (`app-build.yml` is disabled), so it needs an `xcodebuild`/`app-build.yml` run to confirm it compiles and the two updated tests pass. The Kotlin half compiled + tested clean on Linux.

## Alternative considered (not taken)
A more *principled* fix is to **reset the consecutive counter on every productive pass** (only count *unproductive* re-kicks toward the cap), which removes the "well-behaved deep backlog" from the cap's scope entirely and keeps the backstop tight. It was left out here because it touches the carefully-guarded `shouldAutoContinue` predicate (with its #928/#1012/#451 interactions) and is riskier to land; the constant bump is minimal and reviewable. Happy to follow up with the reset-on-progress version if preferred.