### PR TITLE
Preview a same-second R-R de-dup in the #257 HRV diag to scope the double-count (#550)

### DIFF
--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/HRVAnalyzer.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/HRVAnalyzer.swift
@@ -367,6 +367,38 @@ public enum HRVAnalyzer {
         return dups
     }
 
+    /// #550: coverage AFTER collapsing SAME-SECOND near-duplicate beats (equal ts AND |Δrr| ≤ `rrTolMs`)
+    /// to a single representative — a PREVIEW of what an R-R de-duplication fix would achieve, for the
+    /// always-on #257 diag ONLY. It does NOT feed the shipped nightly HRV. On clean data (no same-second
+    /// duplicates) it equals `rrCoverage`; when a live+historical merge double-stamps the same beat WITHIN
+    /// one second, it falls toward ~1. If it stays well above 1, the duplication is CROSS-second (the two
+    /// copies land in adjacent seconds), which a same-second collapse cannot catch — telling us the real
+    /// fix must reconcile the two ingest paths rather than dedup within a second. The collapse is
+    /// deliberately same-second-ONLY: R-R ts are stored at second resolution, and at rest genuine
+    /// consecutive beats are ~1 s apart, so collapsing ACROSS a second would drop real beats. Deterministic
+    /// (ts, rr, index) ordering. Byte-parity twin of Kotlin `HrvAnalyzer.collapsedCoverage`.
+    public static func collapsedCoverage(tsSec: [Int], rrMs: [Double], rrTolMs: Double = 30) -> Double {
+        let n = min(tsSec.count, rrMs.count)
+        guard n >= 2 else { return 0 }
+        let order = (0..<n).sorted { a, b in
+            (tsSec[a], rrMs[a], a) < (tsSec[b], rrMs[b], b)
+        }
+        var keptTs: [Int] = []
+        var keptRr: [Double] = []
+        for idx in order {
+            let t = tsSec[idx]
+            let r = rrMs[idx]
+            var dup = false
+            var j = keptTs.count - 1
+            while j >= 0 && keptTs[j] == t {      // inspect only beats already kept in the SAME second
+                if abs(keptRr[j] - r) <= rrTolMs { dup = true; break }
+                j -= 1
+            }
+            if !dup { keptTs.append(t); keptRr.append(r) }
+        }
+        return rrCoverage(tsSec: keptTs, rrMs: keptRr)
+    }
+
     // MARK: - Helpers
 
     /// Median of a non-empty array. (Caller guarantees non-empty.)

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/HRVAnalyzerTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/HRVAnalyzerTests.swift
@@ -213,4 +213,38 @@ final class HRVAnalyzerTests: XCTestCase {
         XCTAssertEqual(HRVAnalyzer.duplicateBeatCount(tsSec: [100, 100, 100], rrMs: [1000, 1000, 1000]), 2)
         XCTAssertEqual(HRVAnalyzer.duplicateBeatCount(tsSec: [100, 100], rrMs: [1000, 1010]), 0)  // diff rr = distinct
     }
+
+    // #550 — collapsedCoverage: previews a SAME-SECOND R-R de-dup so the always-on diag reveals whether
+    // the #257 over-count is same-second (collapsible) or cross-second (needs an ingest-path fix).
+
+    func testCollapsedCoverageNoOpOnCleanStream() {
+        // No same-second collisions → collapse changes nothing → equals rrCoverage.
+        let ts = [100, 101, 102, 103, 104], rr: [Double] = [1000, 1000, 1000, 1000, 1000]
+        XCTAssertEqual(HRVAnalyzer.collapsedCoverage(tsSec: ts, rrMs: rr),
+                       HRVAnalyzer.rrCoverage(tsSec: ts, rrMs: rr), accuracy: 1e-9)
+    }
+
+    func testCollapsedCoverageCollapsesSameSecondNearDuplicates() {
+        // Each beat double-stamped WITHIN one second, the copies within the 30 ms tol (#257 live+historical).
+        let ts = [100, 100, 101, 101, 102, 102]
+        let rr: [Double] = [1000, 1010, 1000, 1015, 1000, 1005]
+        XCTAssertEqual(HRVAnalyzer.rrCoverage(tsSec: ts, rrMs: rr), 3.015, accuracy: 1e-9)       // raw over-counts
+        XCTAssertEqual(HRVAnalyzer.collapsedCoverage(tsSec: ts, rrMs: rr), 1.5, accuracy: 1e-9)  // one per second
+    }
+
+    func testCollapsedCoverageKeepsCrossSecondDuplicates() {
+        // The SAME beat stamped one second apart (live now-anchored vs historical RTC) — a same-second
+        // collapse CANNOT catch it, so collapsedCov stays == raw. This is the discriminating signal.
+        let ts = [100, 101, 102, 103], rr: [Double] = [1000, 1000, 1000, 1000]
+        XCTAssertEqual(HRVAnalyzer.collapsedCoverage(tsSec: ts, rrMs: rr),
+                       HRVAnalyzer.rrCoverage(tsSec: ts, rrMs: rr), accuracy: 1e-9)
+    }
+
+    func testCollapsedCoverageRespectsRrToleranceForGenuineTwoBeatsInOneSecond() {
+        // Two beats in one second whose rr differ by MORE than the tol are genuine distinct beats, not
+        // duplicates — both kept, so collapse is a no-op here too.
+        let ts = [100, 100, 101], rr: [Double] = [900, 1200, 1000]  // |1200-900| = 300 ms > 30 ms tol
+        XCTAssertEqual(HRVAnalyzer.collapsedCoverage(tsSec: ts, rrMs: rr),
+                       HRVAnalyzer.rrCoverage(tsSec: ts, rrMs: rr), accuracy: 1e-9)
+    }
 }

--- a/Strand/Data/IntelligenceEngine.swift
+++ b/Strand/Data/IntelligenceEngine.swift
@@ -726,9 +726,12 @@ final class IntelligenceEngine: ObservableObject {
                     // from the always-on log instead of hand-computing beat density.
                     let ts = sleepRrRows.map { $0.ts }
                     let cov = String(format: "%.2f", HRVAnalyzer.rrCoverage(tsSec: ts, rrMs: sleepRr))
+                    // #550: collapsedCov previews a same-second R-R de-dup — well below `coverage` ⇒ the
+                    // over-count is same-second (a dedup fix would work); still high ⇒ cross-second overlap.
+                    let colCov = String(format: "%.2f", HRVAnalyzer.collapsedCoverage(tsSec: ts, rrMs: sleepRr))
                     let dup = HRVAnalyzer.duplicateBeatCount(tsSec: ts, rrMs: sleepRr)
                     hrvDiag = "hrv diag day=\(res.daily.day) rmssd=\(ms(h.rmssd))ms sdnn=\(ms(h.sdnn))ms "
-                        + "meanNN=\(ms(h.meanNN))ms rr=\(h.nInput)/\(h.nClean) rejected=\(rej)% coverage=\(cov) dupBeats=\(dup)"
+                        + "meanNN=\(ms(h.meanNN))ms rr=\(h.nInput)/\(h.nClean) rejected=\(rej)% coverage=\(cov) collapsedCov=\(colCov) dupBeats=\(dup)"
                 }
                 // ── Steps test mode: 5/MG raw-counter trace ──────────────────────────────────────────────
                 // Only built when the Steps mode is on (the gate was read once before the loop). Recomputes

--- a/android/app/src/main/java/com/noop/analytics/HrvAnalyzer.kt
+++ b/android/app/src/main/java/com/noop/analytics/HrvAnalyzer.kt
@@ -334,6 +334,36 @@ object HrvAnalyzer {
         return dups
     }
 
+    /** #550: coverage AFTER collapsing SAME-SECOND near-duplicate beats (equal ts AND |Δrr| ≤ [rrTolMs])
+     *  to a single representative — a PREVIEW of what an R-R de-duplication fix would achieve, for the
+     *  always-on #257 diag ONLY. It does NOT feed the shipped nightly HRV. On clean data (no same-second
+     *  duplicates) it equals [rrCoverage]; when a live+historical merge double-stamps the same beat WITHIN
+     *  one second, it falls toward ~1. If it stays well above 1, the duplication is CROSS-second (the two
+     *  copies land in adjacent seconds), which a same-second collapse cannot catch — telling us the real
+     *  fix must reconcile the two ingest paths rather than dedup within a second. The collapse is
+     *  deliberately same-second-ONLY: R-R ts are stored at second resolution, and at rest genuine
+     *  consecutive beats are ~1 s apart, so collapsing ACROSS a second would drop real beats. Deterministic
+     *  (ts, rr, index) ordering. Byte-parity twin of Swift `HRVAnalyzer.collapsedCoverage`. */
+    fun collapsedCoverage(tsSec: List<Long>, rrMs: List<Double>, rrTolMs: Double = 30.0): Double {
+        val n = minOf(tsSec.size, rrMs.size)
+        if (n < 2) return 0.0
+        val order = (0 until n).sortedWith(compareBy({ tsSec[it] }, { rrMs[it] }, { it }))
+        val keptTs = ArrayList<Long>(n)
+        val keptRr = ArrayList<Double>(n)
+        for (idx in order) {
+            val t = tsSec[idx]
+            val r = rrMs[idx]
+            var dup = false
+            var j = keptTs.size - 1
+            while (j >= 0 && keptTs[j] == t) {      // inspect only beats already kept in the SAME second
+                if (abs(keptRr[j] - r) <= rrTolMs) { dup = true; break }
+                j--
+            }
+            if (!dup) { keptTs.add(t); keptRr.add(r) }
+        }
+        return rrCoverage(keptTs, keptRr)
+    }
+
     // ── Rolling / windowed rMSSD (#803) ──────────────────────────────────────
     //
     // The Deep Timeline's "HRV" trace used to plot RAW RR-interval values (ms) and label them "HRV",

--- a/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
+++ b/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
@@ -605,9 +605,12 @@ object IntelligenceEngine {
                 // from the always-on log instead of hand-computing beat density.
                 val ts = sleepRrRows.map { it.ts }
                 val cov = String.format(java.util.Locale.US, "%.2f", HrvAnalyzer.rrCoverage(ts, sleepRr))
+                // #550: collapsedCov previews a same-second R-R de-dup — well below `coverage` ⇒ the
+                // over-count is same-second (a dedup fix would work); still high ⇒ cross-second overlap.
+                val colCov = String.format(java.util.Locale.US, "%.2f", HrvAnalyzer.collapsedCoverage(ts, sleepRr))
                 val dup = HrvAnalyzer.duplicateBeatCount(ts, sleepRr)
                 diag("hrv diag day=${res.daily.day} rmssd=${ms(h.rmssd)}ms sdnn=${ms(h.sdnn)}ms meanNN=${ms(h.meanNN)}ms " +
-                    "rr=${h.nInput}/${h.nClean} rejected=$rej% coverage=$cov dupBeats=$dup")
+                    "rr=${h.nInput}/${h.nClean} rejected=$rej% coverage=$cov collapsedCov=$colCov dupBeats=$dup")
             }
 
             // Steps test mode: emit the 5/MG raw-counter trace for this day (cumulative @57 series +

--- a/android/app/src/test/java/com/noop/analytics/HrvRrCoverageTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/HrvRrCoverageTest.kt
@@ -46,4 +46,40 @@ class HrvRrCoverageTest {
         // same ts but DIFFERENT rrMs are distinct beats, not duplicates.
         assertEquals(0, HrvAnalyzer.duplicateBeatCount(listOf(100L, 100L), listOf(1000.0, 1010.0)))
     }
+
+    // #550 — collapsedCoverage: previews a SAME-SECOND R-R de-dup so the always-on diag reveals whether
+    // the #257 over-count is same-second (collapsible) or cross-second (needs an ingest-path fix).
+
+    @Test fun collapsedCoverage_noOpOnCleanStream() {
+        // No same-second collisions → collapse changes nothing → equals rrCoverage.
+        val ts = listOf(100L, 101L, 102L, 103L, 104L)
+        val rr = listOf(1000.0, 1000.0, 1000.0, 1000.0, 1000.0)
+        assertEquals(HrvAnalyzer.rrCoverage(ts, rr), HrvAnalyzer.collapsedCoverage(ts, rr), 1e-9)
+    }
+
+    @Test fun collapsedCoverage_collapsesSameSecondNearDuplicates() {
+        // Each beat double-stamped WITHIN one second, the copies within the 30 ms tol (#257 live+historical).
+        val ts = listOf(100L, 100L, 101L, 101L, 102L, 102L)
+        val rr = listOf(1000.0, 1010.0, 1000.0, 1015.0, 1000.0, 1005.0)
+        // Raw over-counts: sum 6030 ms over a 2 s span → 3.015.
+        assertEquals(3.015, HrvAnalyzer.rrCoverage(ts, rr), 1e-9)
+        // Collapsed keeps one per second (1000 each) → 3000 ms / 2 s → 1.5, far below raw.
+        assertEquals(1.5, HrvAnalyzer.collapsedCoverage(ts, rr), 1e-9)
+    }
+
+    @Test fun collapsedCoverage_keepsCrossSecondDuplicates() {
+        // The SAME beat stamped one second apart (live now-anchored vs historical RTC) — a same-second
+        // collapse CANNOT catch it, so collapsedCov stays == raw. This is the discriminating signal.
+        val ts = listOf(100L, 101L, 102L, 103L)
+        val rr = listOf(1000.0, 1000.0, 1000.0, 1000.0)
+        assertEquals(HrvAnalyzer.rrCoverage(ts, rr), HrvAnalyzer.collapsedCoverage(ts, rr), 1e-9)
+    }
+
+    @Test fun collapsedCoverage_respectsRrToleranceForGenuineTwoBeatsInOneSecond() {
+        // Two beats in one second whose rr differ by MORE than the tol are genuine distinct beats (a brief
+        // >60 bpm moment), not duplicates — both are kept, so collapse is a no-op here too.
+        val ts = listOf(100L, 100L, 101L)
+        val rr = listOf(900.0, 1200.0, 1000.0)   // |1200-900| = 300 ms > 30 ms tol
+        assertEquals(HrvAnalyzer.rrCoverage(ts, rr), HrvAnalyzer.collapsedCoverage(ts, rr), 1e-9)
+    }
 }


### PR DESCRIPTION
Draft — diagnostic-only step toward the #550 HRV/RHR bug. Refs #550, #257.

## Background
#550: on a WHOOP 4.0, nightly **resting HR reads ~5 bpm low** and **HRV reads high** (49 ms vs 30 ms on both the WHOOP app and a Polar H10). Instantaneous live HR matches, so the derived nightly aggregates are wrong, not the HR decode.

The reporter's strap log is decisive on the HRV side:
```
hrv diag rmssd=52ms sdnn=125ms meanNN=1133ms rr=47421/46537 rejected=2% coverage=2.12 dupBeats=59
```
- `coverage` (Σ R-R ÷ wall span) is **2.12–2.75** across nights — the nightly R-R series contains ~2× as many beats as elapsed time allows.
- Only **~59 exact duplicates**, so it's *near*-duplicates, not exact re-inserts (which the v18 `seq`/`(ts,rrMs)` key already handles).
- `meanNN=1133ms` ⇒ ≈53 bpm, which **matches the real sleeping HR** (`floor=43 nightMean=51`) — so it's excess *beats*, not inflated interval magnitudes (rules out a units bug).

## Root cause (confirmed by tracing, mechanism not fully quantified)
R-R reaches the scored store from two paths that timestamp the same beat differently:

| Path | Frame | `ts` |
|---|---|---|
| Live | type-40 `REALTIME_DATA` | **now-anchored** `now + (deviceTs − newestRealtimeTs)` (`WhoopBleClient.kt:4991`) — realtime clock is untrusted (#126) |
| Historical | type-47 banked record | **true RTC** `unix` (identity clockRef, `RawHistoryArchive.swift:249`) |

For a period worn *while connected* (the reporter is live + draining a backlog, so this also ties to #533), the same beat persists under two near-but-unequal `(ts, rrMs)` keys → the exact-match dedup can't collapse them → coverage > 1 → inflated RMSSD.

**Honest caveat:** two sources cap at 2.0×, but the log shows up to **2.75×**, so there is additional over-coverage I have not pinned. That's precisely why this PR ships a *measurement*, not a behavior change.

## Why not just collapse the duplicates now
R-R timestamps are stored at **second resolution**, and at rest genuine consecutive beats are ~1 s apart. Any collapse threshold wide enough to catch *cross-second* duplicates would also drop **real** beats (it would halve a clean night). A blind shipped collapse would corrupt good data.

## What this PR does (diagnostic only)
Adds `HrvAnalyzer.collapsedCoverage` / `HRVAnalyzer.collapsedCoverage` (both platforms) — coverage after collapsing **same-second** near-duplicates (equal `ts` **and** `|Δrr| ≤ 30 ms`) to one representative — and surfaces it as **`collapsedCov=`** on the always-on `hrv diag` line. It **does not touch the shipped nightly HRV**.

It's the decisive next measurement:
- **`collapsedCov ≈ 1`** → the over-count is same-second ⇒ a dedup fix will work, and this is the exact algorithm to promote.
- **`collapsedCov` stays high** → the duplication is cross-second ⇒ the fix must reconcile the two ingest paths (not dedup within a second).

On clean data it equals `rrCoverage` (no-op). Deterministic `(ts, rr, index)` ordering for Swift↔Kotlin parity.

## Tests
`HrvRrCoverageTest` gains: no-op-on-clean, collapses-same-second-near-dups, **keeps-cross-second** (the discriminator), respects-rr-tolerance. Kotlin compiles and **all 9 pass** (`./gradlew testFullDebugUnitTest --tests "com.noop.analytics.HrvRrCoverageTest"`).

## Verification / caveats
- **Swift half is package/app code** (`StrandAnalytics` + `Strand/Data`) — the `StrandAnalytics` package needs macOS (GRDB `sqlite3.h` wall) and the diag line lives in the macOS/iOS app target, so `swift test` + an `app-build.yml`/`xcodebuild` run are needed to confirm it compiles. The Swift twin mirrors the Kotlin logic line-for-line.
- **Draft on purpose:** this is the measurement gate. The actual RHR fix (route the shipped nightly resting-HR through the already-tested `RecoveryScorer.restingHR` #686 guards) is independent and will be its own PR; the actual R-R de-dup fix waits on what `collapsedCov` reports from a real export.