### PR TITLE
Add opt-in "optimal strain reached" notification (#593)

### DIFF
--- a/android/app/src/main/java/com/noop/notif/StrainTargetNotifier.kt
+++ b/android/app/src/main/java/com/noop/notif/StrainTargetNotifier.kt
@@ -1,0 +1,127 @@
+package com.noop.notif
+
+import android.annotation.SuppressLint
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.content.Context
+import android.os.Build
+import androidx.core.app.NotificationCompat
+import androidx.core.app.NotificationManagerCompat
+import com.noop.R
+import com.noop.ui.NoopPrefs
+import com.noop.ui.appLaunchIntent
+
+// MARK: - Target-strain notification (#593)
+//
+// A single opt-in, default-OFF celebratory nudge: once per day, when the day's Effort (strain) reaches the
+// LOW end of today's recovery-derived OPTIMAL strain band (the #43 coupled read), post a "reached your
+// optimal strain" notification.
+//
+// CLEAN-ROOM: this reimplements the BEHAVIOUR only. The copy is NOOP's own — NOT WHOOP's decompiled
+// strings — and the target is NOOP's own recovery→strain band (#43), not a value read off another app.
+//
+// The gate runs on the 0-21 coupled axis: the day's stored Effort (0-100) is converted with the shipped
+// UnitFormatter.effortValue(_, WHOOP) at the call site, and the target is the optimal band's `low` (already
+// 0-21). It is NOT "the instant" you cross the target — day strain is a per-analytics-pass rollup, so it
+// fires on the first pass at/after the crossing. Once-per-day dedupe via a persisted day flag, the same
+// crossing-dedupe idiom as ScheduledReportPolicy / BatteryAlertPolicy. Default OFF like every automation.
+
+/** Pure, JVM-testable policy + copy for the target-strain notification — no Android types, so the decision
+ *  logic is pinned by StrainTargetPolicyTest independently of the notification plumbing. */
+object StrainTargetPolicy {
+
+    /** Fire at most once per day: only when enabled, BOTH the day strain and the target are known, the day
+     *  strain has reached the target, and we haven't already posted for [today]. [dayStrain] and [target]
+     *  must be on the SAME axis (the 0-21 coupled axis, per the call site). A null [target] means recovery
+     *  is unknown (calibrating / unscored) ⇒ no target ⇒ never fires (never guess a target). */
+    fun shouldNotify(
+        enabled: Boolean,
+        dayStrain: Double?,
+        target: Double?,
+        lastNotifiedDay: String?,
+        today: String,
+    ): Boolean = enabled &&
+        dayStrain != null && target != null &&
+        dayStrain >= target &&
+        lastNotifiedDay != today
+
+    /** Title + body for the nudge. [target] is the optimal-band low on the 0-21 coupled axis. NOOP's OWN
+     *  wording — the feature is reimplemented behaviour, not copied copy. */
+    fun copy(target: Int): Pair<String, String> {
+        val title = "Optimal strain reached"
+        val body = "You've hit today's optimal strain target of $target. Nice work — your recovery earned it."
+        return title to body
+    }
+}
+
+object StrainTargetNotifier {
+    // Reuse the daily-reports channel the scheduled reports post to (same family, same importance).
+    private const val CHANNEL_ID = "noop_scheduled_reports"
+    // #297: distinct id so this never silently replaces another notifier's (4208 morning, 4209 workout).
+    private const val STRAIN_TARGET_NOTIF_ID = 4210
+
+    /**
+     * Post the optimal-strain nudge if enabled and not already posted [day]. [dayStrain21]/[target21] are
+     * on the 0-21 coupled axis (the caller converts the stored 0-100 Effort via UnitFormatter and reads the
+     * target off the #43 optimal band). No-op on every path that fails the policy, so the caller can fire it
+     * freely each time the days collector republishes.
+     */
+    @SuppressLint("MissingPermission") // guarded by areNotificationsEnabled() + runCatching
+    fun onStrainTarget(context: Context, day: String, dayStrain21: Double?, target21: Int?) {
+        if (!StrainTargetPolicy.shouldNotify(
+                enabled = NoopPrefs.strainTargetEnabled(context),
+                dayStrain = dayStrain21,
+                target = target21?.toDouble(),
+                lastNotifiedDay = NoopPrefs.reportStrainTargetDay(context),
+                today = day,
+            )
+        ) return
+        // Non-null: shouldNotify above required target != null before returning true.
+        val copy = StrainTargetPolicy.copy(target21!!)
+        runCatching {
+            if (!NotificationManagerCompat.from(context).areNotificationsEnabled()) return
+            ensureChannel(context)
+            post(context, STRAIN_TARGET_NOTIF_ID, copy.first, copy.second)
+            // Mark fired only after a successful post, so a notifications-disabled day still notifies once
+            // they're re-enabled while the same day still shows the reached target.
+            NoopPrefs.setReportStrainTargetDay(context, day)
+        }
+    }
+
+    @SuppressLint("MissingPermission")
+    private fun post(context: Context, id: Int, title: String, body: String) {
+        val openApp = PendingIntent.getActivity(
+            context, 3,
+            appLaunchIntent(context),
+            PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT,
+        )
+        val n = NotificationCompat.Builder(context, CHANNEL_ID)
+            .setSmallIcon(R.drawable.ic_stat_heart)
+            .setContentTitle(title)
+            .setContentText(body)
+            .setStyle(NotificationCompat.BigTextStyle().bigText(body))
+            .setContentIntent(openApp)
+            .setAutoCancel(true)
+            .setCategory(NotificationCompat.CATEGORY_STATUS)
+            .setPriority(NotificationCompat.PRIORITY_LOW)
+            .build()
+        NotificationManagerCompat.from(context).notify(id, n)
+    }
+
+    private fun ensureChannel(context: Context) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) return
+        runCatching {
+            val mgr = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+            if (mgr.getNotificationChannel(CHANNEL_ID) != null) return
+            mgr.createNotificationChannel(
+                NotificationChannel(
+                    CHANNEL_ID, "Daily reports",
+                    NotificationManager.IMPORTANCE_LOW,
+                ).apply {
+                    description = "A morning recap and post-workout summary, after your strap syncs."
+                },
+            )
+        }
+    }
+}

--- a/android/app/src/main/java/com/noop/ui/AppViewModel.kt
+++ b/android/app/src/main/java/com/noop/ui/AppViewModel.kt
@@ -44,6 +44,7 @@ import com.noop.ingest.HealthConnectWriter
 import com.noop.ingest.LiftingImporter
 import com.noop.notif.IllnessAlertNotifier
 import com.noop.notif.ScheduledReportNotifier
+import com.noop.notif.StrainTargetNotifier
 import com.noop.notif.ScheduledReportPolicy
 import com.noop.notif.scorePctOrNull
 import com.noop.protocol.CommandNumber
@@ -653,6 +654,17 @@ class AppViewModel(app: Application) : AndroidViewModel(app) {
                             restPct = RestScorer.restFromDaily(todayRow).scorePctOrNull(),
                         )
                     }
+                    // #593: once-a-day optimal-strain-reached nudge. Convert the stored 0-100 Effort to the
+                    // 0-21 coupled axis with the SHIPPED formatter (so it matches every Effort read-out), and
+                    // gate against the LOW end of today's recovery-derived optimal band (#43). The notifier's
+                    // persisted day gate makes this safe to fire on every republish; null recovery (calibrating)
+                    // yields a null band → no target → no notification.
+                    StrainTargetNotifier.onStrainTarget(
+                        context = appContext,
+                        day = todayRow.day,
+                        dayStrain21 = todayRow.strain?.let { UnitFormatter.effortValue(it, EffortScale.WHOOP) },
+                        target21 = optimalStrainRange(todayRow.recovery)?.low,
+                    )
                 }
                 // v5 skin-temp suite: run the Cycle / Body-clock / Illness-heads-up engines over the same
                 // cached history and publish their RESULTS for the Health hub. The richer IllnessSignalEngine

--- a/android/app/src/main/java/com/noop/ui/MainActivity.kt
+++ b/android/app/src/main/java/com/noop/ui/MainActivity.kt
@@ -697,6 +697,9 @@ object NoopPrefs {
     const val KEY_REPORT_MORNING = "noop.report.morningRecap"
     const val KEY_REPORT_WORKOUT = "noop.report.postWorkout"
     const val KEY_REPORT_MORNING_DAY = "noop.report.lastMorningDay"
+    // #593 target-strain nudge: opt-in enable flag + the once-per-day dedupe (last local day it fired).
+    const val KEY_REPORT_STRAIN_TARGET = "noop.report.strainTarget"
+    const val KEY_REPORT_STRAIN_TARGET_DAY = "noop.report.lastStrainTargetDay"
     const val KEY_REPORT_LAST_WORKOUT_TS = "noop.report.lastWorkoutTs"
 
     fun morningReportEnabled(context: Context): Boolean =
@@ -719,6 +722,22 @@ object NoopPrefs {
 
     fun setReportMorningDay(context: Context, day: String) {
         of(context).edit().putString(KEY_REPORT_MORNING_DAY, day).apply()
+    }
+
+    /** #593: opt-in (default OFF) for the once-a-day optimal-strain-reached nudge. */
+    fun strainTargetEnabled(context: Context): Boolean =
+        of(context).getBoolean(KEY_REPORT_STRAIN_TARGET, false)
+
+    fun setStrainTargetEnabled(context: Context, enabled: Boolean) {
+        of(context).edit().putBoolean(KEY_REPORT_STRAIN_TARGET, enabled).apply()
+    }
+
+    /** Last local day (ISO yyyy-MM-dd) the strain-target nudge was posted, the once-a-day gate. */
+    fun reportStrainTargetDay(context: Context): String? =
+        of(context).getString(KEY_REPORT_STRAIN_TARGET_DAY, null)
+
+    fun setReportStrainTargetDay(context: Context, day: String) {
+        of(context).edit().putString(KEY_REPORT_STRAIN_TARGET_DAY, day).apply()
     }
 
     /** Start-ts (epoch seconds) of the most recent workout already summarised, only a STRICTLY newer

--- a/android/app/src/main/java/com/noop/ui/NotificationsSettingsScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/NotificationsSettingsScreen.kt
@@ -239,6 +239,7 @@ fun NotificationsSettingsScreen(vm: AppViewModel) {
     // each Switch mirrors into local state and writes straight through to NoopPrefs.
     var morningReport by remember { mutableStateOf(NoopPrefs.morningReportEnabled(context)) }
     var postWorkoutReport by remember { mutableStateOf(NoopPrefs.postWorkoutReportEnabled(context)) }
+    var strainTargetReport by remember { mutableStateOf(NoopPrefs.strainTargetEnabled(context)) }
     var phonePermissionDenied by remember { mutableStateOf(false) }
     val phonePermissionLauncher = rememberLauncherForActivityResult(
         ActivityResultContracts.RequestPermission(),
@@ -471,6 +472,18 @@ fun NotificationsSettingsScreen(vm: AppViewModel) {
                     // Seed the frontier to the newest existing workout when turning ON, so enabling it
                     // doesn't immediately fire a summary for a session already in history.
                     if (it) vm.seedWorkoutReportFrontier()
+                },
+            )
+            RowDivider()
+            // #593: NOOP's own optimal-strain-reached nudge (not WHOOP's copy).
+            FormToggleRow(
+                label = uiString(R.string.l10n_notifications_settings_screen_optimal_strain_reached_2862ec2b),
+                help = "Once a day, a notification when your Effort reaches the low end of today's optimal " +
+                    "strain range (from your recovery). Posts after your strap syncs and NOOP scores the day.",
+                checked = strainTargetReport,
+                onChange = {
+                    strainTargetReport = it
+                    NoopPrefs.setStrainTargetEnabled(context, it)
                 },
             )
         }

--- a/android/app/src/main/res/values-de/strings.xml
+++ b/android/app/src/main/res/values-de/strings.xml
@@ -638,6 +638,7 @@
     <string name="l10n_notifications_settings_screen_only_buzz_when_worn_6211cee3">Nur vibrieren, wenn getragen</string>
     <string name="l10n_notifications_settings_screen_open_notification_access_658fd30f">Offener Benachrichtigungszugang</string>
     <string name="l10n_notifications_settings_screen_open_notification_access_settings_93fcd1bf">Einstellungen für Benachrichtigungszugriff öffnen</string>
+    <string name="l10n_notifications_settings_screen_optimal_strain_reached_2862ec2b">Optimale Anstrengung erreicht</string>
     <string name="l10n_notifications_settings_screen_phone_calls_b79420d9">Telefongespräche</string>
     <string name="l10n_notifications_settings_screen_phone_permission_was_denied_so_phone_db0ebdd8">Die telefonerlaubnis wurde verweigert, so dass das telefongespräch ausgeschaltet ist.</string>
     <string name="l10n_notifications_settings_screen_post_workout_summary_13e488f5">Zusammenfassung nach dem Training</string>

--- a/android/app/src/main/res/values-es/strings.xml
+++ b/android/app/src/main/res/values-es/strings.xml
@@ -478,6 +478,7 @@
     <string name="l10n_notifications_settings_screen_only_buzz_when_worn_6211cee3">Vibrar solo cuando se lleva puesta</string>
     <string name="l10n_notifications_settings_screen_open_notification_access_658fd30f">Acceso de notificación abierta</string>
     <string name="l10n_notifications_settings_screen_open_notification_access_settings_93fcd1bf">Configuración de acceso de notificación abierta</string>
+    <string name="l10n_notifications_settings_screen_optimal_strain_reached_2862ec2b">Esfuerzo óptimo alcanzado</string>
     <string name="l10n_notifications_settings_screen_phone_calls_b79420d9">Llamadas telefónicas</string>
     <string name="l10n_notifications_settings_screen_phone_permission_was_denied_so_phone_db0ebdd8">Se denegó el permiso del teléfono, así que el zumbido del teléfono está apagado.</string>
     <string name="l10n_notifications_settings_screen_post_workout_summary_13e488f5">Resumen posterior al ejercicio</string>

--- a/android/app/src/main/res/values-fr/strings.xml
+++ b/android/app/src/main/res/values-fr/strings.xml
@@ -478,6 +478,7 @@
     <string name="l10n_notifications_settings_screen_only_buzz_when_worn_6211cee3">Vibrer uniquement si porté</string>
     <string name="l10n_notifications_settings_screen_open_notification_access_658fd30f">Accès ouvert aux notifications</string>
     <string name="l10n_notifications_settings_screen_open_notification_access_settings_93fcd1bf">Paramètres d\'accès à la notification ouverte</string>
+    <string name="l10n_notifications_settings_screen_optimal_strain_reached_2862ec2b">Effort optimal atteint</string>
     <string name="l10n_notifications_settings_screen_phone_calls_b79420d9">Appels téléphoniques</string>
     <string name="l10n_notifications_settings_screen_phone_permission_was_denied_so_phone_db0ebdd8">La permission du téléphone a été refusée, donc l\'appel est éteint.</string>
     <string name="l10n_notifications_settings_screen_post_workout_summary_13e488f5">Résumé après l\'entraînement</string>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -647,6 +647,7 @@
     <string name="l10n_notifications_settings_screen_only_buzz_when_worn_6211cee3">Only buzz when worn</string>
     <string name="l10n_notifications_settings_screen_open_notification_access_658fd30f">Open Notification Access</string>
     <string name="l10n_notifications_settings_screen_open_notification_access_settings_93fcd1bf">Open Notification Access settings</string>
+    <string name="l10n_notifications_settings_screen_optimal_strain_reached_2862ec2b">Optimal strain reached</string>
     <string name="l10n_notifications_settings_screen_phone_calls_b79420d9">Phone calls</string>
     <string name="l10n_notifications_settings_screen_phone_permission_was_denied_so_phone_db0ebdd8">Phone permission was denied, so phone-call buzzing is off.</string>
     <string name="l10n_notifications_settings_screen_post_workout_summary_13e488f5">Post-workout summary</string>

--- a/android/app/src/test/java/com/noop/notif/StrainTargetPolicyTest.kt
+++ b/android/app/src/test/java/com/noop/notif/StrainTargetPolicyTest.kt
@@ -1,0 +1,78 @@
+package com.noop.notif
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Pins the pure gate + copy of the #593 optimal-strain-reached notification (the ScheduledReportPolicy /
+ * BatteryAlertPolicy crossing-dedupe idiom). The Android notifier just wires this to a channel + the
+ * persisted day marker, so all the decision logic is verified here without android.*. Contract: fire at
+ * most once per day, only when strain has genuinely reached a KNOWN target, never on a guessed one.
+ */
+class StrainTargetPolicyTest {
+
+    @Test fun firesWhenEnabledStrainReachedTargetAndNotYetToday() {
+        assertTrue(
+            StrainTargetPolicy.shouldNotify(
+                enabled = true, dayStrain = 14.0, target = 14.0, lastNotifiedDay = "2026-07-17", today = "2026-07-18",
+            ),
+        )
+        // Overshooting the target still fires (>= gate), once.
+        assertTrue(
+            StrainTargetPolicy.shouldNotify(
+                enabled = true, dayStrain = 16.2, target = 14.0, lastNotifiedDay = null, today = "2026-07-18",
+            ),
+        )
+    }
+
+    @Test fun suppressedWhenDisabled() {
+        assertFalse(
+            StrainTargetPolicy.shouldNotify(
+                enabled = false, dayStrain = 18.0, target = 14.0, lastNotifiedDay = null, today = "2026-07-18",
+            ),
+        )
+    }
+
+    @Test fun suppressedBeforeTargetIsReached() {
+        assertFalse(
+            StrainTargetPolicy.shouldNotify(
+                enabled = true, dayStrain = 13.9, target = 14.0, lastNotifiedDay = null, today = "2026-07-18",
+            ),
+        )
+    }
+
+    @Test fun suppressedWhenAlreadyFiredToday() {
+        assertFalse(
+            StrainTargetPolicy.shouldNotify(
+                enabled = true, dayStrain = 15.0, target = 14.0, lastNotifiedDay = "2026-07-18", today = "2026-07-18",
+            ),
+        )
+    }
+
+    @Test fun suppressedWhenTargetUnknownCalibrating() {
+        // Null recovery ⇒ no optimal band ⇒ null target ⇒ never fire (never guess a target).
+        assertFalse(
+            StrainTargetPolicy.shouldNotify(
+                enabled = true, dayStrain = 18.0, target = null, lastNotifiedDay = null, today = "2026-07-18",
+            ),
+        )
+    }
+
+    @Test fun suppressedWhenNoStrainYet() {
+        assertFalse(
+            StrainTargetPolicy.shouldNotify(
+                enabled = true, dayStrain = null, target = 14.0, lastNotifiedDay = null, today = "2026-07-18",
+            ),
+        )
+    }
+
+    @Test fun copyUsesNoopWordingAndTheTarget() {
+        val (title, body) = StrainTargetPolicy.copy(target = 14)
+        // NOOP's own copy — must NOT reproduce WHOOP's decompiled strings.
+        assertTrue(title.contains("Optimal strain"))
+        assertFalse(title.contains("Target Strain Reached"))
+        assertTrue(body.contains("14"))
+        assertFalse(body.contains("for this activity"))
+    }
+}


### PR DESCRIPTION
Implements #593 (Android). A single opt-in, **default-OFF** celebratory nudge: once per day, when the day's Effort reaches the low end of today's recovery-derived optimal strain band, post an "optimal strain reached" notification — the same crossing-dedupe idiom as `ScheduledReportPolicy` / `BatteryAlertPolicy`.

## Clean-room (important)
The request quoted WHOOP's decompiled strings ("Target Strain Reached" / "You've hit your target Strain of %s for this activity!"). Those are **not** used. This reimplements the **behaviour** only:
- Copy is **NOOP's own**: "Optimal strain reached" / "You've hit today's optimal strain target of N. Nice work — your recovery earned it."
- Target is **NOOP's own** recovery→strain band (`optimalStrainRange`, task #43), not a value read off another app.

## What it does
- **`StrainTargetPolicy`** — pure, JVM-testable gate + copy. Fires only when enabled, both the day strain and target are known, strain has reached the target, and it hasn't already fired today. A **null target** (recovery still calibrating) never fires — no guessed targets.
- **`StrainTargetNotifier`** — thin poster; distinct notif id **4210** (4208/4209 already taken per the #297 id map); reuses the daily-reports channel.
- **`NoopPrefs`** — opt-in enable flag + a once-a-day dedupe day marker, mirroring the morning recap.
- **Wiring** — in the days collector next to `onMorning`. The stored 0–100 Effort is converted to the 0–21 coupled axis with the **shipped** `UnitFormatter.effortValue(_, WHOOP)` (so it matches every other Effort read-out) and gated against `optimalStrainRange(recovery).low`. The persisted day gate makes it safe to fire on every republish.
- **Settings toggle** in `NotificationsSettingsScreen`, default OFF like the rest of the daily reports. Label is extracted to `strings.xml` with de/es/fr translations (`Tools/i18n_audit.py --ci main` passes — no new hardcoded literals).

## Design choices (open to feedback)
- **Target = band `low`** ("you've reached today's optimal floor"), not `high` — this makes it a genuine celebratory nudge that fires appropriately (low-recovery days get a low, easy-to-reach target; high-recovery days a higher one), rather than only firing when you max out the zone. Easy to switch to `high`/midpoint if preferred.
- **Timing:** not "the instant" you cross the target — day strain is a per-analytics-pass rollup, so it fires on the first pass at/after the crossing (the toggle help is upfront about "after your strap syncs").
- **Day keying:** both the strain value and the once-per-day dedupe key come from the same resolved today-row (`todayRow.day`), so the value and the gate can never disagree across the midnight rollover (the #567 lesson).
- **No enable-time seed** (unlike the post-workout summary): matches the morning recap — enabling it after you've already reached today's target will post once for today.

## Tests / verification
- `StrainTargetPolicyTest` (7): fires on reach/overshoot; suppressed when disabled, below target, already-fired-today, target-unknown (calibrating), or no strain yet; and asserts the copy uses NOOP's wording and does **not** contain WHOOP's strings. `./gradlew testFullDebugUnitTest --tests "com.noop.notif.StrainTargetPolicyTest"` → 7 passed.
- Full Android module compiles clean.
- `python3 Tools/i18n_audit.py --ci main` → exit 0 (label extracted + focus locales complete).

## Scope / follow-ups
- **Android only.** The pure `StrainTargetPolicy` mirrors trivially to Swift and should follow as a fast-follow so the tested logic doesn't diverge (feature-level parity). The request said iOS-first; I did Android because it's the shipped app and is verifiable here.
- **Notification delivery + the settings UI are not CI/Linux-testable** — the pure policy is fully covered; the notifier/toggle are compile-checked only and want an on-device smoke test.