### PR TITLE
Add opt-in "optimal strain reached" notification — iOS/macOS twin (#593)

### DIFF
--- a/Strand/App/AppModel.swift
+++ b/Strand/App/AppModel.swift
@@ -264,7 +264,10 @@ final class AppModel: ObservableObject {
         // HR-zone haptic coaching watches the smoothed bpm.
         $bpm.sink { [weak self] hr in self?.coachZone(hr) }.store(in: &hrCancellables)
         // Illness/strain early-warning recomputes when the daily history changes.
-        repo.$days.sink { [weak self] days in self?.evaluateIllness(days) }.store(in: &hrCancellables)
+        repo.$days.sink { [weak self] days in
+            self?.evaluateIllness(days)
+            self?.evaluateStrainTarget()
+        }.store(in: &hrCancellables)
         // Re-arm the strap's firmware alarm once the connection has SETTLED — not the instant it (re)bonds.
         // A smart-alarm time changed while the strap was away never reached it , the send is gated on bond
         // , so the strap kept the OLD time and fired at it (#59).
@@ -1436,6 +1439,21 @@ final class AppModel: ObservableObject {
         if let alert = healthAlert, previous == nil {
             IllnessNotifier.post(alert)
         }
+    }
+
+    /// #593: once-a-day "optimal strain reached" nudge. Reads the resolved today-row (the same
+    /// logical-day resolution every dashboard surface uses), converts the stored 0-100 Effort to the
+    /// 0-21 coupled axis with the SHIPPED formatter (so it matches every Effort read-out), and gates
+    /// against the LOW end of today's recovery-derived optimal band (#43). The notifier's persisted
+    /// day gate makes this safe to fire on every days republish; nil recovery (calibrating) yields a
+    /// nil band → no target → no notification. Android twin: AppViewModel's days-collector call.
+    func evaluateStrainTarget() {
+        guard let row = repo.today else { return }
+        StrainTargetNotifier.onDayUpdate(
+            day: row.day,
+            dayStrain21: row.strain.map { UnitFormatter.effortValue($0, scale: .whoop) },
+            target21: CoupledView.optimalStrainRange(recovery: row.recovery)?.lowerBound,
+            enabled: behavior.strainTargetNudge)
     }
 
     /// Re-run the illness watch over the cached history. Called when the Automations toggle

--- a/Strand/Data/BehaviorStore.swift
+++ b/Strand/Data/BehaviorStore.swift
@@ -52,6 +52,11 @@ final class BehaviorStore: ObservableObject {
     /// batteryAlerts (both must be on). Default ON so pre-toggle behavior is unchanged.
     @Published var batteryPredictiveAlerts: Bool { didSet { d.set(batteryPredictiveAlerts, forKey: K.batteryPredictiveAlerts) } }
 
+    // MARK: Strain target nudge (#593)
+    /// Once-a-day "optimal strain reached" nudge when the day's Effort hits the low end of today's
+    /// recovery-derived optimal band. Default OFF like every other automation.
+    @Published var strainTargetNudge: Bool { didSet { d.set(strainTargetNudge, forKey: K.strainTargetNudge) } }
+
     private let d = UserDefaults.standard
     private enum K {
         static let dtAction = "behavior.doubleTapAction"
@@ -74,6 +79,7 @@ final class BehaviorStore: ObservableObject {
         static let illness = "behavior.illnessWatch"
         static let batteryAlerts = "behavior.batteryAlerts"
         static let batteryPredictiveAlerts = "behavior.batteryPredictiveAlerts"
+        static let strainTargetNudge = "behavior.strainTargetNudge"
     }
 
     init() {
@@ -95,6 +101,7 @@ final class BehaviorStore: ObservableObject {
         illnessWatch = d.object(forKey: K.illness) as? Bool ?? false
         batteryAlerts = d.object(forKey: K.batteryAlerts) as? Bool ?? true
         batteryPredictiveAlerts = d.object(forKey: K.batteryPredictiveAlerts) as? Bool ?? true
+        strainTargetNudge = d.object(forKey: K.strainTargetNudge) as? Bool ?? false
     }
 
     // MARK: Charge baseline recalibration

--- a/Strand/Screens/AutomationsView.swift
+++ b/Strand/Screens/AutomationsView.swift
@@ -55,6 +55,7 @@ struct AutomationsView: View {
             illnessCard
             healthInsightsCard
             batteryCard
+            strainTargetCard
         }
     }
 
@@ -357,6 +358,27 @@ struct AutomationsView: View {
                           help: String(localized: "An early \"recharge tonight\" heads-up when the strap has about a day of estimated runtime left, at most once per discharge cycle. Turn off to keep only the 15% warning."),
                           isOn: $behavior.batteryPredictiveAlerts)
             }
+        }
+    }
+
+    // MARK: - Strain target nudge (#593)
+
+    private var strainTargetCard: some View {
+        Section2(icon: "flame", title: String(localized: "Strain target"),
+                 blurb: String(localized: "A once-a-day nudge when your Effort reaches the low end of today's optimal strain range, worked out from your recovery."),
+                 active: behavior.strainTargetNudge) {
+            ToggleRow(label: String(localized: "Notify when optimal strain is reached"),
+                      help: String(localized: "Posts after your strap syncs and NOOP scores the day — not the exact second you cross it. At most once per day."),
+                      isOn: $behavior.strainTargetNudge)
+                .onChangeCompat(of: behavior.strainTargetNudge) { on in
+                    if on {
+                        StrainTargetNotifier.requestAuthorization()
+                        // The repo.$days sink only fires on data changes, so if today's target is
+                        // already reached, evaluate now rather than waiting for the next refresh
+                        // (the reevaluateIllness idiom).
+                        model.evaluateStrainTarget()
+                    }
+                }
         }
     }
 

--- a/Strand/System/StrainTargetNotifier.swift
+++ b/Strand/System/StrainTargetNotifier.swift
@@ -1,0 +1,82 @@
+import Foundation
+import UserNotifications
+
+// MARK: - Target-strain notification (#593)
+//
+// A single opt-in, default-OFF celebratory nudge: once per day, when the day's Effort (strain) reaches the
+// LOW end of today's recovery-derived OPTIMAL strain band (the #43 coupled read), post an "optimal strain
+// reached" notification. Twin of the Android `StrainTargetNotifier`/`StrainTargetPolicy` — the pure policy
+// must stay byte-identical (feature-level parity).
+//
+// CLEAN-ROOM: this reimplements the BEHAVIOUR only. The copy is NOOP's own — NOT WHOOP's decompiled
+// strings — and the target is NOOP's own recovery→strain band (#43), not a value read off another app.
+//
+// The gate runs on the 0-21 coupled axis: the day's stored Effort (0-100) is converted with the shipped
+// UnitFormatter.effortValue(_, .whoop) at the call site, and the target is the optimal band's lowerBound
+// (already 0-21). It is NOT "the instant" you cross the target — day strain is a per-analytics-pass
+// rollup, so it fires on the first pass at/after the crossing. Once-per-day dedupe via a persisted day
+// string, the same crossing-dedupe idiom as BatteryNotifier / the Android ScheduledReportPolicy.
+enum StrainTargetNotifier {
+    private static let lastDayKey = "behavior.strainTargetLastDay"
+
+    /// Pure, testable policy + copy — no notification/UserDefaults runtime, so the decision logic is
+    /// pinned by StrainTargetPolicyTests. Byte-identical twin of the Android `StrainTargetPolicy`.
+    enum StrainTargetPolicy {
+        /// Fire at most once per day: only when enabled, BOTH the day strain and the target are known,
+        /// the day strain has reached the target, and we haven't already posted for `today`. `dayStrain`
+        /// and `target` must be on the SAME axis (the 0-21 coupled axis, per the call site). A nil
+        /// `target` means recovery is unknown (calibrating / unscored) ⇒ no target ⇒ never fires
+        /// (never guess a target).
+        static func shouldNotify(enabled: Bool,
+                                 dayStrain: Double?,
+                                 target: Double?,
+                                 lastNotifiedDay: String?,
+                                 today: String) -> Bool {
+            guard enabled, let dayStrain, let target else { return false }
+            return dayStrain >= target && lastNotifiedDay != today
+        }
+
+        /// Title + body for the nudge. `target` is the optimal-band low on the 0-21 coupled axis.
+        /// NOOP's OWN wording — the feature is reimplemented behaviour, not copied copy.
+        static func copy(target: Int) -> (title: String, body: String) {
+            (String(localized: "Optimal strain reached"),
+             String(localized: "You've hit today's optimal strain target of \(target). Nice work — your recovery earned it."))
+        }
+    }
+
+    /// Ask up front (called when the user enables the nudge) so the system dialog appears at a
+    /// predictable moment, not on the first crossing. BatteryNotifier idiom.
+    static func requestAuthorization() {
+        UNUserNotificationCenter.current()
+            .requestAuthorization(options: [.alert, .sound]) { _, _ in }
+    }
+
+    /// Run the policy against the resolved today-row's values and post at most one notification per day.
+    /// `dayStrain21`/`target21` are on the 0-21 coupled axis (the caller converts the stored 0-100 Effort
+    /// via UnitFormatter and reads the target off the #43 optimal band). No-op on every path that fails
+    /// the policy, so the caller can fire it freely each time the day history republishes. The persisted
+    /// day marker advances only after an authorized post, so a notifications-denied day still notifies
+    /// once they're re-enabled while the same day still shows the reached target (Android twin behaviour).
+    static func onDayUpdate(day: String, dayStrain21: Double?, target21: Int?, enabled: Bool) {
+        let d = UserDefaults.standard
+        guard StrainTargetPolicy.shouldNotify(enabled: enabled,
+                                              dayStrain: dayStrain21,
+                                              target: target21.map(Double.init),
+                                              lastNotifiedDay: d.string(forKey: lastDayKey),
+                                              today: day) else { return }
+        // Non-nil: shouldNotify above required a non-nil target before returning true.
+        let copy = StrainTargetPolicy.copy(target: target21!)
+        let center = UNUserNotificationCenter.current()
+        // Authorization is requested once via requestAuthorization() when the toggle is enabled; here we
+        // only check status (no second system prompt) — the BatteryNotifier idiom.
+        center.getNotificationSettings { settings in
+            guard settings.authorizationStatus == .authorized else { return }
+            let content = UNMutableNotificationContent()
+            content.title = copy.title
+            content.body = copy.body
+            content.sound = .default
+            center.add(UNNotificationRequest(identifier: "strain-target", content: content, trigger: nil))
+            UserDefaults.standard.set(day, forKey: lastDayKey)
+        }
+    }
+}

--- a/StrandTests/StrainTargetPolicyTests.swift
+++ b/StrandTests/StrainTargetPolicyTests.swift
@@ -1,0 +1,53 @@
+import XCTest
+@testable import Strand
+
+/// `StrainTargetNotifier.StrainTargetPolicy` — the pure once-per-day crossing gate + copy behind the
+/// #593 optimal-strain-reached nudge. Mirrors the Android `StrainTargetPolicyTest` byte-for-byte (same
+/// fixtures, same expectations). No notification/UserDefaults runtime needed here. Contract: fire at
+/// most once per day, only when strain has genuinely reached a KNOWN target, never on a guessed one.
+final class StrainTargetPolicyTests: XCTestCase {
+    private typealias Policy = StrainTargetNotifier.StrainTargetPolicy
+
+    func testFiresWhenEnabledStrainReachedTargetAndNotYetToday() {
+        XCTAssertTrue(Policy.shouldNotify(
+            enabled: true, dayStrain: 14.0, target: 14.0, lastNotifiedDay: "2026-07-17", today: "2026-07-18"))
+        // Overshooting the target still fires (>= gate), once.
+        XCTAssertTrue(Policy.shouldNotify(
+            enabled: true, dayStrain: 16.2, target: 14.0, lastNotifiedDay: nil, today: "2026-07-18"))
+    }
+
+    func testSuppressedWhenDisabled() {
+        XCTAssertFalse(Policy.shouldNotify(
+            enabled: false, dayStrain: 18.0, target: 14.0, lastNotifiedDay: nil, today: "2026-07-18"))
+    }
+
+    func testSuppressedBeforeTargetIsReached() {
+        XCTAssertFalse(Policy.shouldNotify(
+            enabled: true, dayStrain: 13.9, target: 14.0, lastNotifiedDay: nil, today: "2026-07-18"))
+    }
+
+    func testSuppressedWhenAlreadyFiredToday() {
+        XCTAssertFalse(Policy.shouldNotify(
+            enabled: true, dayStrain: 15.0, target: 14.0, lastNotifiedDay: "2026-07-18", today: "2026-07-18"))
+    }
+
+    func testSuppressedWhenTargetUnknownCalibrating() {
+        // nil recovery ⇒ no optimal band ⇒ nil target ⇒ never fire (never guess a target).
+        XCTAssertFalse(Policy.shouldNotify(
+            enabled: true, dayStrain: 18.0, target: nil, lastNotifiedDay: nil, today: "2026-07-18"))
+    }
+
+    func testSuppressedWhenNoStrainYet() {
+        XCTAssertFalse(Policy.shouldNotify(
+            enabled: true, dayStrain: nil, target: 14.0, lastNotifiedDay: nil, today: "2026-07-18"))
+    }
+
+    func testCopyUsesNoopWordingAndTheTarget() {
+        let copy = Policy.copy(target: 14)
+        // NOOP's own copy — must NOT reproduce WHOOP's decompiled strings.
+        XCTAssertTrue(copy.title.contains("Optimal strain"))
+        XCTAssertFalse(copy.title.contains("Target Strain Reached"))
+        XCTAssertTrue(copy.body.contains("14"))
+        XCTAssertFalse(copy.body.contains("for this activity"))
+    }
+}


### PR DESCRIPTION
The Swift half of #593, twinning the Android implementation in #596 — the pure policy is byte-identical on both platforms (feature-level parity). Independent of #596 (no file overlap); the two can merge in either order.

## What it does
Same opt-in, **default-OFF** nudge as the Android PR: once per day, when the day's Effort reaches the low end of today's recovery-derived optimal strain band (#43), post an "optimal strain reached" notification.

- **`StrainTargetNotifier.StrainTargetPolicy`** — pure gate + copy, semantics identical to Android's `StrainTargetPolicy`: fires only when enabled, both day strain and target are known, strain ≥ target, not already fired today; a nil target (recovery calibrating) never fires. Copy is **NOOP's own wording** — not WHOOP's decompiled strings (same clean-room stance as #596).
- **`onDayUpdate`** — the `BatteryNotifier` idiom: `requestAuthorization()` up front when the toggle is enabled, status-only check at fire time, notification id `"strain-target"`. The persisted day marker advances **only after an authorized post**, matching the Android notifier (a notifications-denied day still notifies once re-enabled while the same day shows the reached target).
- **`BehaviorStore.strainTargetNudge`** — default OFF.
- **`AppModel`** — the existing `repo.$days` sink also evaluates the strain target off the **resolved today-row** (`repo.today`, the same logical-day resolution every dashboard surface uses); converts stored 0–100 Effort → 0–21 via the shipped `UnitFormatter.effortValue(_, .whoop)` and gates on `CoupledView.optimalStrainRange(recovery:).lowerBound` — the exact same formatter + band the Android call site reads.
- **`AutomationsView`** — a "Strain target" card next to Battery alerts. `AutomationsView` is **shared**, so the toggle is reachable on macOS *and* iOS (unlike the macOS-only NotificationSettings screen). Enabling it also evaluates immediately (the `reevaluateIllness` idiom), so flipping it on when today's target is already reached posts without waiting for the next refresh.
- **`Localizable.xcstrings`** — 6 new keys with de/es/fr translations (informal de/es, formal fr, matching the existing catalog tone; Int interpolation as `%lld` per catalog convention).

## Platform-appropriate divergences (deliberate)
- Toggle lives in **Automations** (where battery/illness/inactivity live on Apple platforms) rather than a "Daily reports" section — Android's daily-reports settings screen has no Swift twin (#517 never landed on iOS), and Automations is the established home + is shared with iOS.
- Dedupe day persists in **UserDefaults** (`behavior.strainTargetLastDay`), the BatteryNotifier convention, vs SharedPreferences on Android. Same semantics.

## Tests
`StrandTests/StrainTargetPolicyTests` mirrors the Android `StrainTargetPolicyTest` **byte-for-byte** — same 7 fixtures, same expectations, including the copy assertions that NOOP's wording is present and WHOOP's strings are absent.

## Verification (honest)
- **On Linux:** `swiftc -parse` clean on all six touched files; `Tools/i18n_audit.py --ci main` → exit 0 (no new un-extracted literals, focus locales complete); xcstrings JSON validated.
- **Needs macOS:** everything here is app-target (`Strand/`, `StrandTests/`) — not covered by `swift-packages` CI. An `xcodebuild -scheme Strand … test` / `app-build.yml` run is required to confirm compile + the 7 policy tests, and an on-device smoke test for actual delivery. New files are picked up by XcodeGen's directory globs (no `project.yml` change needed).