### PR TITLE
Add a read-only extended-battery opcode probe to settle #592 (Android)

### DIFF
--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -2390,6 +2390,10 @@ class WhoopBleClient(
                 // below. NOT hardware-confirmed on 5/MG — rebootStrap() logs the COMMAND_RESPONSE so a strap
                 // log confirms whether the frame is accepted. User-initiated + confirmation-gated only.
                 cmd != CommandNumber.REBOOT_STRAP &&
+                // GET_EXTENDED_BATTERY_INFO (98) over puffin: read-only opcode probe (#592) — a real
+                // WHOOP 5 (fw 50.38.1.0) already answered this number, proving the frame is at least
+                // accepted. Driven only by probeExtendedBatteryInfo() (user-initiated, Test Centre gated).
+                cmd != CommandNumber.GET_EXTENDED_BATTERY_INFO &&
                 // SET_CONFIG (the R22 deep-stream unlock) is allowed ONLY while the deep-data experiment
                 // is opted in — it writes a persistent feature flag to the strap, so it must never fire
                 // on a default install. Reversible; driven only by enableWhoop5DeepData(). (#174)
@@ -2759,6 +2763,21 @@ class WhoopBleClient(
             return
         }
         sendRebootFrame(variant.command, variant.payload, variant)
+    }
+
+    /** #592 opcode probe: send the read-only GET_EXTENDED_BATTERY_INFO(98) and let the COMMAND_RESPONSE
+     *  hook dump the full raw reply to the strap log. The number is disputed (an APK decompile reads 87);
+     *  a battery-shaped payload in the reply confirms 98 on this firmware, a short generic stub keeps it
+     *  ambiguous. Works on both families (the 4.0 is the discriminating device — its firmware banks real
+     *  EXTENDED_BATTERY_INFORMATION event payloads; the 5.0 answered 98 with a stub on fw 50.38.1.0).
+     *  User-initiated only (Devices → strap menu, Test Centre → Connection gated); never automatic. */
+    fun probeExtendedBatteryInfo() {
+        if (!_state.value.connected) {
+            log("Extended-battery probe (#592) ignored — not connected")
+            return
+        }
+        log("Extended-battery probe (#592): sending GET_EXTENDED_BATTERY_INFO(98, read-only) on family=$connectedFamily; the raw COMMAND_RESPONSE is dumped below when it lands")
+        send(CommandNumber.GET_EXTENDED_BATTERY_INFO)
     }
 
     /** Shared reboot send + debug trail + watchdog, used by both the production [rebootStrap] and the
@@ -3840,6 +3859,57 @@ class WhoopBleClient(
                     // stays: on 5/MG it lands word-aligned with the body at 11, and a straddling word
                     // can't fall in the unix-range window. (#78 fork)
                     val cmdOff = if (connectedFamily == DeviceFamily.WHOOP5) 10 else 6
+                    // #592 opcode probe: dump the raw GET_EXTENDED_BATTERY_INFO(98) response in FULL (no
+                    // prefix cap — the tail fields are the evidence) so a normal strap-log export settles
+                    // the disputed number: a battery-shaped payload (mV etc.) confirms 98 on this firmware;
+                    // a short generic stub keeps it ambiguous (see the probe note on the enum case).
+                    if (frame.size > cmdOff && (frame[cmdOff].toInt() and 0xFF) == CommandNumber.GET_EXTENDED_BATTERY_INFO.rawValue) {
+                        log("Extended-battery probe raw response (#592 — full frame, len=${frame.size}): " +
+                            frame.joinToString("") { "%02x".format(it) })
+                        // 5/MG replies carry an explicit result code @12 (0 FAILURE / 1 SUCCESS / 2 PENDING /
+                        // 3 UNSUPPORTED — 3 is hardware-confirmed as the MG's rejection code, #48). UNSUPPORTED
+                        // here is a DECISIVE #592 verdict: the firmware itself says opcode 98 isn't a command,
+                        // which is far stronger than inferring from a short stub.
+                        if (connectedFamily == DeviceFamily.WHOOP5 && frame.size > 12) {
+                            val r = frame[12].toInt() and 0xFF
+                            val label = when (r) {
+                                0 -> "FAILURE"; 1 -> "SUCCESS"; 2 -> "PENDING"; 3 -> "UNSUPPORTED"
+                                else -> "result$r"
+                            }
+                            log("Extended-battery probe result code (#592, 5/MG @12): $label($r)" +
+                                if (r == 3) " — the firmware explicitly does NOT recognise opcode 98; the decompile's 87 becomes the live candidate (gated follow-up)" else "")
+                        }
+                        // #592 payload triage: is there more here than the mV word NOOP already gets from
+                        // the ordinary battery event? Report the payload length (bytes after the command
+                        // byte) and every 16-bit LE word with its payload offset, tagging the mV-band ones
+                        // (3000-4300) vs OTHER in-range values — a rich payload (extra plausible words past
+                        // the mV) means a real battery-health feature to map; just mV/none means #592 is a
+                        // correctness fix with no feature behind it. Read-only scan of the already-logged bytes.
+                        val payStart = cmdOff + 1
+                        // Bound the scan to the DECODABLE payload, excluding the 4-byte CRC32 trailer both
+                        // families carry (total frame = length + 4), so the CRC never reads as a phantom
+                        // "candidate field" and inflates the count. Empty payload ⇒ bare stub.
+                        val payEnd = frame.size - 4
+                        if (payEnd > payStart) {
+                            val pay = frame.copyOfRange(payStart, payEnd)
+                            val words = StringBuilder()
+                            var o = 0
+                            while (o + 1 < pay.size) {
+                                val v = (pay[o].toInt() and 0xFF) or ((pay[o + 1].toInt() and 0xFF) shl 8)
+                                val tag = when {
+                                    v in 3000..4300 -> "mV?"      // battery voltage band (already known)
+                                    v in 1..0xFFFE -> "other"     // any other non-trivial word — candidate field
+                                    else -> null
+                                }
+                                if (tag != null) words.append(" @$o=$v($tag)")
+                                o += 1
+                            }
+                            log("Extended-battery probe payload (#592): len=${pay.size} bytes (CRC excluded), overlapping 16-bit LE words:$words " +
+                                "— words BEYOND an mV are unmapped candidate fields (cycle count / health / temp?); mV-only or none ⇒ no new data over the battery event")
+                        } else {
+                            log("Extended-battery probe payload (#592): no payload beyond the command byte (bare stub) ⇒ no data over the battery event; opcode 98 may be an unknown-command ack on this firmware")
+                        }
+                    }
                     if (frame.size > cmdOff && (frame[cmdOff].toInt() and 0xFF) == CommandNumber.GET_DATA_RANGE.rawValue) {
                         // #451: dump raw GET_DATA_RANGE response bytes unconditionally (even if decode returns
                         // null) so a stale/wrong-epoch "newest" can be told apart from a frame-alignment bug in

--- a/android/app/src/main/java/com/noop/protocol/Enums.kt
+++ b/android/app/src/main/java/com/noop/protocol/Enums.kt
@@ -133,6 +133,14 @@ enum class CommandNumber(val rawValue: Int) {
     SET_DEVICE_CONFIG(119),
     START_RAW_DATA(81),
     STOP_RAW_DATA(82),
+    // GET_EXTENDED_BATTERY_INFO (98) — read-only extended battery read (mV etc.). The NUMBER is disputed
+    // (#592): an independent APK decompile reads this family 11 lower (87), while whoomp's table says 98 —
+    // partially supported by a real WHOOP 5 (fw 50.38.1.0) ANSWERING 98, though with a short stub that
+    // could be valid-but-minimal or a generic unknown-command ack. Sent ONLY by probeExtendedBatteryInfo()
+    // (user-initiated, Test Centre → Connection gated, never automatic); the raw COMMAND_RESPONSE is
+    // dumped in full to the strap log so a normal export settles which number this firmware serves.
+    // Mirrors Swift WhoopCommand.getExtendedBatteryInfo.
+    GET_EXTENDED_BATTERY_INFO(98),
     STOP_HAPTICS(122),
     SELECT_WRIST(123);
 

--- a/android/app/src/main/java/com/noop/ui/AppViewModel.kt
+++ b/android/app/src/main/java/com/noop/ui/AppViewModel.kt
@@ -1669,6 +1669,11 @@ class AppViewModel(app: Application) : AndroidViewModel(app) {
      *  in DevicesScreen; finds the real 4.0 reboot frame when the production one is ignored (#235). */
     fun rebootProbe(variant: com.noop.protocol.RebootProbeVariant) = ble.rebootProbe(variant)
 
+    /** #592 opcode probe: read-only GET_EXTENDED_BATTERY_INFO(98) with a full raw-response dump to the
+     *  strap log. Confirmation-gated in DevicesScreen (Test Centre → Connection); settles the disputed
+     *  battery-info opcode (98 vs an APK decompile's 87) from a normal strap-log export. */
+    fun probeExtendedBatteryInfo() = ble.probeExtendedBatteryInfo()
+
     /**
      * Flip the "keep connected in the background" preference (driven by Settings). Turning it on
      * while a strap is live promotes to the foreground immediately; turning it off drops the

--- a/android/app/src/main/java/com/noop/ui/DevicesScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/DevicesScreen.kt
@@ -127,6 +127,7 @@ fun DevicesScreen(
     var rebootTarget by remember { mutableStateOf<PairedDeviceRow?>(null) }
     // WHOOP 4.0 reboot probe (Test Centre → Connection, 4.0 only) — the device whose probe sheet is open.
     var probeTarget by remember { mutableStateOf<PairedDeviceRow?>(null) }
+    var batteryProbeTarget by remember { mutableStateOf<PairedDeviceRow?>(null) }
     // After removing the ACTIVE device with other devices still paired, prompt to pick a new active one.
     var pickNewActive by remember { mutableStateOf(false) }
 
@@ -214,6 +215,13 @@ fun DevicesScreen(
                     SourceCoordinator.isWhoop(device) && !live.whoop5Detected &&
                     TestCentre.from(context).active(TestDomain.CONNECTION)
                 ) { { probeTarget = device } } else null,
+                // #592 extended-battery opcode probe: read-only, BOTH families (the 4.0 is the
+                // discriminating device, but a 5/MG capture is useful too). Same Test Centre →
+                // Connection gate as the reboot probe.
+                onBatteryProbe = if (device.status == DeviceStatus.active.name && live.connected &&
+                    SourceCoordinator.isWhoop(device) &&
+                    TestCentre.from(context).active(TestDomain.CONNECTION)
+                ) { { batteryProbeTarget = device } } else null,
             )
         }
 
@@ -325,6 +333,15 @@ fun DevicesScreen(
         )
     }
 
+    // --- #592 extended-battery opcode probe: read-only, dumps the strap's full raw reply to the log so a
+    //     normal export settles the disputed GET_EXTENDED_BATTERY_INFO number (98 vs an APK decompile's 87). ---
+    batteryProbeTarget?.let {
+        BatteryInfoProbeDialog(
+            onSend = { viewModel.probeExtendedBatteryInfo(); batteryProbeTarget = null },
+            onDismiss = { batteryProbeTarget = null },
+        )
+    }
+
     // --- Second, strongly-worded delete-data confirm (from the Removed card's secondary control) ---
     deleteDataTarget?.let { device ->
         ConfirmDialog(
@@ -394,6 +411,8 @@ private fun DeviceCard(
     // WHOOP 4.0 reboot probe (Test Centre → Connection, 4.0 only). Non-null only when the parent has
     // decided the probe applies (live-connected WHOOP 4.0 + Connection test mode on); null otherwise. (#235)
     onRebootProbe: (() -> Unit)? = null,
+    // #592 extended-battery opcode probe (Test Centre → Connection, both WHOOP families). Read-only.
+    onBatteryProbe: (() -> Unit)? = null,
 ) {
     val profile = deviceProfile(device)
     // The per-device actions menu's open state is hoisted here so the WHOLE card is a tap target that opens
@@ -502,6 +521,7 @@ private fun DeviceCard(
                     onDisconnect = onDisconnect,
                     onReboot = onReboot,
                     onRebootProbe = onRebootProbe,
+                    onBatteryProbe = onBatteryProbe,
                 )
             }
         }
@@ -620,6 +640,7 @@ private fun DeviceActionsMenu(
     onDisconnect: (() -> Unit)? = null,
     onReboot: (() -> Unit)? = null,
     onRebootProbe: (() -> Unit)? = null,
+    onBatteryProbe: (() -> Unit)? = null,
 ) {
     Box {
         IconButton(
@@ -667,6 +688,11 @@ private fun DeviceActionsMenu(
                 // Connection on + a live WHOOP 4.0). Finds the real reboot frame the 4.0 accepts (#235).
                 if (onRebootProbe != null) {
                     MenuItem("Reboot probe (4.0 RE)…", Icons.Filled.BugReport) { onOpenChange(false); onRebootProbe() }
+                }
+                // #592: read-only extended-battery opcode probe — settles the disputed GET_EXTENDED_
+                // BATTERY_INFO number (98 vs an APK decompile's 87) from a strap-log export.
+                if (onBatteryProbe != null) {
+                    MenuItem(uiString(R.string.l10n_devices_screen_battery_info_probe_592_re_1dbd4c0f), Icons.Filled.BugReport) { onOpenChange(false); onBatteryProbe() }
                 }
                 if (onRemove != null) {
                     HorizontalDivider(color = Palette.hairline)
@@ -805,6 +831,38 @@ private fun RebootProbeDialog(
             }
         },
         confirmButton = {},
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text(uiString(R.string.l10n_devices_screen_cancel_77dfd213), style = NoopType.body, color = Palette.textSecondary)
+            }
+        },
+    )
+}
+
+/** #592 extended-battery opcode probe: a single read-only send + a full raw-response dump to the strap
+ *  log. Settles whether GET_EXTENDED_BATTERY_INFO is 98 (this table) or 87 (an independent APK decompile)
+ *  from a normal strap-log export. Gated to Test Centre → Connection + a live WHOOP at the call site. */
+@Composable
+private fun BatteryInfoProbeDialog(
+    onSend: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        containerColor = Palette.surfaceOverlay,
+        title = { Text(uiString(R.string.l10n_devices_screen_battery_info_probe_592_re_1dbd4c0f), style = NoopType.title2, color = Palette.textPrimary) },
+        text = {
+            Text(
+                uiString(R.string.l10n_devices_screen_battery_probe_explainer_2858bb6a),
+                style = NoopType.subhead,
+                color = Palette.textSecondary,
+            )
+        },
+        confirmButton = {
+            TextButton(onClick = onSend) {
+                Text(uiString(R.string.l10n_devices_screen_send_probe_read_only_36b318bc), style = NoopType.body, color = Palette.accent)
+            }
+        },
         dismissButton = {
             TextButton(onClick = onDismiss) {
                 Text(uiString(R.string.l10n_devices_screen_cancel_77dfd213), style = NoopType.body, color = Palette.textSecondary)

--- a/android/app/src/main/res/values-de/strings.xml
+++ b/android/app/src/main/res/values-de/strings.xml
@@ -385,6 +385,8 @@
     <string name="l10n_devices_screen_add_a_device_f90866b8">Gerät hinzufügen</string>
     <string name="l10n_devices_screen_battery_4a9be042">Akku</string>
     <string name="l10n_devices_screen_battery_clamped_2494c8c9">Batterie %1$s%%</string>
+    <string name="l10n_devices_screen_battery_info_probe_592_re_1dbd4c0f">Akku-Info-Test (#592 RE)…</string>
+    <string name="l10n_devices_screen_battery_probe_explainer_2858bb6a">Zwei unabhängige Protokolltabellen widersprechen sich beim Extended-Battery-Opcode (98 vs. 87). Dies sendet das kuratierte, nur lesende 98 und schreibt die vollständige Rohantwort des Bands ins Strap-Log. Eine batterieartige Nutzlast bestätigt 98 auf deiner Firmware; ein kurzer Stub bleibt mehrdeutig. Es wird nichts auf das Band geschrieben. Bitte exportiere und teile danach das Strap-Log.</string>
     <string name="l10n_devices_screen_cancel_77dfd213">Abbrechen</string>
     <string name="l10n_devices_screen_clamped_1f39cebb">%1$s%%</string>
     <string name="l10n_devices_screen_device_name_79d7a157">Gerätename</string>
@@ -394,6 +396,7 @@
     <string name="l10n_devices_screen_paired_locally_noop_owns_this_ring_30c16190">Lokal gepaart. NOOP besitzt diesen Ring, während er den Schlüssel hält. Wenn Sie es erneut zurücksetzen oder einstellen</string>
     <string name="l10n_devices_screen_pick_a_new_active_strap_edd73542">Neuen aktiven Strap auswählen</string>
     <string name="l10n_devices_screen_rename_device_ee233604">Gerät umbenennen</string>
+    <string name="l10n_devices_screen_send_probe_read_only_36b318bc">Test senden (nur lesen)</string>
     <string name="l10n_devices_screen_save_efc007a3">Sichern</string>
     <string name="l10n_devices_screen_the_whoop_4_0_reboot_frame_690a8ff2">Der WHOOP 4.0-Reboot-Frame wird nicht bestätigt - ein normaler Neustart wird ignoriert (# 235).</string>
     <string name="l10n_devices_screen_whoop_4_0_reboot_probe_b51fb50f">WHOOP 4.0-Reboot-Sonde</string>

--- a/android/app/src/main/res/values-es/strings.xml
+++ b/android/app/src/main/res/values-es/strings.xml
@@ -225,6 +225,8 @@
     <string name="l10n_devices_screen_add_a_device_f90866b8">Añadir un dispositivo</string>
     <string name="l10n_devices_screen_battery_4a9be042">Batería</string>
     <string name="l10n_devices_screen_battery_clamped_2494c8c9">Batería %1$s%%</string>
+    <string name="l10n_devices_screen_battery_info_probe_592_re_1dbd4c0f">Sonda de info de batería (#592 RE)…</string>
+    <string name="l10n_devices_screen_battery_probe_explainer_2858bb6a">Dos tablas de protocolo independientes discrepan sobre el opcode de batería extendida (98 vs 87). Esto envía el 98 curado y de solo lectura y vuelca la respuesta cruda completa de la banda al registro. Una carga tipo batería confirma 98 en tu firmware; un stub corto lo deja ambiguo. No se escribe nada en la banda. Exporta y comparte el registro después.</string>
     <string name="l10n_devices_screen_cancel_77dfd213">Cancelar</string>
     <string name="l10n_devices_screen_clamped_1f39cebb">%1$s%%</string>
     <string name="l10n_devices_screen_device_name_79d7a157">Nombre del dispositivo</string>
@@ -234,6 +236,7 @@
     <string name="l10n_devices_screen_paired_locally_noop_owns_this_ring_30c16190">En pareja. NOOP posee este anillo mientras mantiene la llave. Si lo vuelves a restablecer o lo estableces</string>
     <string name="l10n_devices_screen_pick_a_new_active_strap_edd73542">Elige una nueva pulsera activa</string>
     <string name="l10n_devices_screen_rename_device_ee233604">Renombrar dispositivo</string>
+    <string name="l10n_devices_screen_send_probe_read_only_36b318bc">Enviar sonda (solo lectura)</string>
     <string name="l10n_devices_screen_save_efc007a3">Guardar</string>
     <string name="l10n_devices_screen_the_whoop_4_0_reboot_frame_690a8ff2">El marco de reinicio WHOOP 4.0 no está confirmado: se ignora un reinicio normal (#235).</string>
     <string name="l10n_devices_screen_whoop_4_0_reboot_probe_b51fb50f">WHOOP 4.0 sonda de reinicio</string>

--- a/android/app/src/main/res/values-fr/strings.xml
+++ b/android/app/src/main/res/values-fr/strings.xml
@@ -225,6 +225,8 @@
     <string name="l10n_devices_screen_add_a_device_f90866b8">Ajouter un appareil</string>
     <string name="l10n_devices_screen_battery_4a9be042">Batterie</string>
     <string name="l10n_devices_screen_battery_clamped_2494c8c9">Batterie %1$s%%</string>
+    <string name="l10n_devices_screen_battery_info_probe_592_re_1dbd4c0f">Sonde d\'info batterie (#592 RE)…</string>
+    <string name="l10n_devices_screen_battery_probe_explainer_2858bb6a">Deux tables de protocole indépendantes divergent sur l\'opcode de batterie étendue (98 contre 87). Ceci envoie le 98 curé en lecture seule et consigne la réponse brute complète du bracelet dans le journal. Une charge de type batterie confirme 98 sur votre firmware ; un stub court le laisse ambigu. Rien n\'est écrit sur le bracelet. Exportez et partagez le journal ensuite.</string>
     <string name="l10n_devices_screen_cancel_77dfd213">Annuler</string>
     <string name="l10n_devices_screen_clamped_1f39cebb">%1$s%%</string>
     <string name="l10n_devices_screen_device_name_79d7a157">Nom de l\'appareil</string>
@@ -234,6 +236,7 @@
     <string name="l10n_devices_screen_paired_locally_noop_owns_this_ring_30c16190">Jumelé localement. NOOP possède cette bague pendant qu\'elle tient la clé. Si vous le réinitialisez ou le définissez</string>
     <string name="l10n_devices_screen_pick_a_new_active_strap_edd73542">Choisir un nouveau bracelet actif</string>
     <string name="l10n_devices_screen_rename_device_ee233604">Renommer l\'appareil</string>
+    <string name="l10n_devices_screen_send_probe_read_only_36b318bc">Envoyer la sonde (lecture seule)</string>
     <string name="l10n_devices_screen_save_efc007a3">Enregistrer</string>
     <string name="l10n_devices_screen_the_whoop_4_0_reboot_frame_690a8ff2">Le cadre de redémarrage WHOOP 4.0 n\'est pas confirmé – un redémarrage normal est ignoré (#235).</string>
     <string name="l10n_devices_screen_whoop_4_0_reboot_probe_b51fb50f">Sonde de redémarrage WHOOP 4.0</string>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -394,6 +394,8 @@
     <string name="l10n_devices_screen_add_a_device_f90866b8">Add a device</string>
     <string name="l10n_devices_screen_battery_4a9be042">Battery</string>
     <string name="l10n_devices_screen_battery_clamped_2494c8c9">Battery %1$s%%</string>
+    <string name="l10n_devices_screen_battery_info_probe_592_re_1dbd4c0f">Battery-info probe (#592 RE)…</string>
+    <string name="l10n_devices_screen_battery_probe_explainer_2858bb6a">Two independent protocol tables disagree on the extended-battery opcode (98 vs 87). This sends the curated read-only 98 and dumps the strap\'s full raw reply to the strap log. A battery-style payload confirms 98 on your firmware; a short stub means it stays ambiguous. Nothing is written to the strap. Please export and share the strap log afterwards.</string>
     <string name="l10n_devices_screen_cancel_77dfd213">Cancel</string>
     <string name="l10n_devices_screen_clamped_1f39cebb">%1$s%%</string>
     <string name="l10n_devices_screen_device_name_79d7a157">Device name</string>
@@ -403,6 +405,7 @@
     <string name="l10n_devices_screen_paired_locally_noop_owns_this_ring_30c16190">Paired locally. NOOP owns this ring while it holds the key. If you reset it again or set it </string>
     <string name="l10n_devices_screen_pick_a_new_active_strap_edd73542">Pick a new active strap</string>
     <string name="l10n_devices_screen_rename_device_ee233604">Rename device</string>
+    <string name="l10n_devices_screen_send_probe_read_only_36b318bc">Send probe (read-only)</string>
     <string name="l10n_devices_screen_save_efc007a3">Save</string>
     <string name="l10n_devices_screen_the_whoop_4_0_reboot_frame_690a8ff2">The WHOOP 4.0 reboot frame isn\'t confirmed — a normal Restart is ignored (#235). </string>
     <string name="l10n_devices_screen_whoop_4_0_reboot_probe_b51fb50f">WHOOP 4.0 reboot probe</string>


### PR DESCRIPTION
Refs #592. The instrument-first tool that lets a real strap resolve the disputed `GET_EXTENDED_BATTERY_INFO` opcode (98 in `Commands.swift`/`whoop_protocol.json`, 87 in an independent APK decompile — see #598 for the evidence state). Android side; Swift twin to follow.

## What it does
Adds a **read-only** "Battery-info probe (#592 RE)…" action on the live-WHOOP strap card (Devices → ⋮), gated behind **Test Centre → Connection** exactly like the existing reboot probe. It sends the curated `GET_EXTENDED_BATTERY_INFO(98)` and logs **two** lines when the response lands:

```
Extended-battery probe raw response (#592 — full frame, len=NN): <hex>
Extended-battery probe payload (#592): len=M bytes, 16-bit LE words: @0=… @1=… — words BEYOND an mV are unmapped candidate fields …
```

1. **Full raw frame** (no prefix cap — the tail is the evidence).
2. **Payload triage** — the payload length plus every 16-bit LE word with its offset, tagging the **mV-band** values (3000–4300) vs **other** in-range words. This answers the question that actually decides whether #592 is worth acting on: **does the response carry anything beyond the millivolts NOOP already gets from the ordinary battery event?** A rich payload (extra plausible words past the mV) means a real battery-health feature to map (cycle count / wear / temperature?); mV-only or a bare stub means #592 is a **correctness fix with no feature behind it**.

So a normal strap-log export settles both the opcode *and* its value. The **4.0 is the discriminating device** — its firmware banks real `EXTENDED_BATTERY_INFORMATION` payloads — but a 5/MG capture is useful too (a real WHOOP 5, fw 50.38.1.0, already *answered* 98 with a stub).

## Context: NOOP already has the everyday battery data
SoC %, voltage (mV), charging bit, and a derived runtime estimate all come from `GET_BATTERY_LEVEL(26)` + `BATTERY_LEVEL` events today — none via opcode 98. The existing `GET_EXTENDED_BATTERY_INFO` response decoder extracts only **mV**, and the `EXTENDED_BATTERY_INFORMATION` event is annotated *"not decoded by the WHOOP app."* So the probe's real job is to reveal whether there's **more than voltage** in that payload — hence the triage line.

## Why 98 and not 87
Deliberately sends **only the curated 98**, never the decompile's 87. 87 is unknown to NOOP's command table and sits in a **firmware-adjacent band** — `VERIFY_FIRMWARE_IMAGE`=83, `RESET_FUEL_GAUGE`=99 are neighbours — so leading with it violates the curated-safe-subset rule. If 98's response is a generic stub, a **gated 87 variant** (reboot-probe pattern, extra confirmation) is the follow-up.

## Pieces
- `Enums.kt` — curated `CommandNumber.GET_EXTENDED_BATTERY_INFO(98)`, read-only.
- `WhoopBleClient` — 5/MG puffin-path allowlist entry for 98; the full-frame dump **+ the payload-length/word-scan triage line** in the `COMMAND_RESPONSE` hook; `probeExtendedBatteryInfo()` (user-initiated only).
- `AppViewModel` + `DevicesScreen` — the gated menu item + a read-only confirmation dialog that asks for the log.
- `strings.xml` (+de/es/fr) — label, explainer, send button.

## Verification
- Full Android module **compiles**; `testFullDebugUnitTest` **green** (no logic touched — plumbing + log lines); `Tools/i18n_audit.py --ci main` **exit 0**.
- **BLE delivery is not CI/Linux-testable** — the on-strap capture is the deliverable. Run on a 4.0/5.0 via Test Centre → Connection.
- Swift twin to follow.