### PR TITLE
Devices: show the #592 battery-probe result in a copyable dialog

### DIFF
--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -973,6 +973,12 @@ class WhoopBleClient(
          *  so a typical deep backlog drains in ONE connection: 24 productive passes (~10-15s each) ≈ a few
          *  minutes of back-to-back draining; the ~24-min backstop only ever bites the rare data-shape spin.
          *  Mirrors Swift BackfillContinuation.defaultMaxAutoContinues. TUNABLE — needs on-strap validation. */
+        /** #592: sentinel value of [extendedBatteryProbe] between sending the probe and its reply landing. */
+        const val WAITING_EXTENDED_BATTERY_PROBE = "__waiting__"
+
+        /** #592: how long to wait for a probe COMMAND_RESPONSE before treating silence as "no reply". */
+        const val EXTENDED_BATTERY_PROBE_TIMEOUT_MS = 8_000L
+
         const val MAX_AUTO_CONTINUES = 24
 
         /** #364 "more backlog remains" margin (seconds): how far ahead the strap must be of our persisted
@@ -1174,6 +1180,11 @@ class WhoopBleClient(
     /** WHOOP straps seen while [scanningForList] is true (the Add-a-device wizard's present-scan), WITHOUT
      *  auto-connecting. Cleared at the start of each [scanForWhoops]. Empty/unused on the default path. */
     val discoveredWhoops: StateFlow<List<DiscoveredWhoop>> = _discoveredWhoops.asStateFlow()
+
+    // #592 extended-battery probe result text (raw hex + payload triage), null until a probe reply lands.
+    // Drives the Devices result dialog so a capture is readable/copyable without a full log export.
+    private val _extendedBatteryProbe = MutableStateFlow<String?>(null)
+    val extendedBatteryProbe: StateFlow<String?> = _extendedBatteryProbe.asStateFlow()
 
     private val _connectedPeripheralAddress = MutableStateFlow<String?>(null)
     /** The BLE address of the strap currently connected, or null when disconnected. Twin of macOS
@@ -2776,9 +2787,30 @@ class WhoopBleClient(
             log("Extended-battery probe (#592) ignored — not connected")
             return
         }
+        // Sentinel so the Devices dialog can show "waiting for the strap's reply…" until the response lands
+        // (or the user closes it). The COMMAND_RESPONSE hook overwrites this with the decoded result text.
+        _extendedBatteryProbe.value = WAITING_EXTENDED_BATTERY_PROBE
         log("Extended-battery probe (#592): sending GET_EXTENDED_BATTERY_INFO(98, read-only) on family=$connectedFamily; the raw COMMAND_RESPONSE is dumped below when it lands")
         send(CommandNumber.GET_EXTENDED_BATTERY_INFO)
+        // #592: if NO COMMAND_RESPONSE for 98 arrives within the window, the silence is itself the verdict —
+        // the firmware served no reply, which is evidence AGAINST 98 (toward the decompile's 87). Surface +
+        // log that instead of a dialog stuck on "waiting" forever. Guarded on the value still being the
+        // sentinel, so a real reply (which overwrites it) is never clobbered by this late timeout.
+        handler.postDelayed({
+            val msg = "Extended-battery probe (#592): no COMMAND_RESPONSE for opcode 98 within " +
+                "${EXTENDED_BATTERY_PROBE_TIMEOUT_MS / 1000}s — the strap served no reply. That silence " +
+                "is evidence AGAINST 98 on this firmware (toward the decompile's 87); a gated 87 probe is " +
+                "the follow-up. (If a sync/offload was mid-flight the response can be delayed — retry idle.)"
+            // ATOMIC compare-and-set: only replace the still-waiting sentinel. If a real reply landed on the
+            // binder thread in the meantime (even microseconds before this fires at the timeout boundary),
+            // it already overwrote the value and the CAS fails — so a genuine capture is never clobbered by
+            // a late "no reply". Log only when the CAS actually wins.
+            if (_extendedBatteryProbe.compareAndSet(WAITING_EXTENDED_BATTERY_PROBE, msg)) log(msg)
+        }, EXTENDED_BATTERY_PROBE_TIMEOUT_MS)
     }
+
+    /** Clear the #592 probe result (Devices dialog dismissed). */
+    fun clearExtendedBatteryProbe() { _extendedBatteryProbe.value = null }
 
     /** Shared reboot send + debug trail + watchdog, used by both the production [rebootStrap] and the
      *  4.0 [rebootProbe]. `probe == null` is the normal restart; a non-null variant is a probe attempt
@@ -3864,31 +3896,30 @@ class WhoopBleClient(
                     // the disputed number: a battery-shaped payload (mV etc.) confirms 98 on this firmware;
                     // a short generic stub keeps it ambiguous (see the probe note on the enum case).
                     if (frame.size > cmdOff && (frame[cmdOff].toInt() and 0xFF) == CommandNumber.GET_EXTENDED_BATTERY_INFO.rawValue) {
-                        log("Extended-battery probe raw response (#592 — full frame, len=${frame.size}): " +
+                        // Build the #592 result as text lines, then BOTH log them (so they ride the strap-log
+                        // bundle) AND publish them to a StateFlow the Devices probe dialog shows + copies —
+                        // so a capture doesn't require a full log export to read/share.
+                        val lines = ArrayList<String>(3)
+                        lines.add("Extended-battery probe raw response (#592 — full frame, len=${frame.size}): " +
                             frame.joinToString("") { "%02x".format(it) })
                         // 5/MG replies carry an explicit result code @12 (0 FAILURE / 1 SUCCESS / 2 PENDING /
                         // 3 UNSUPPORTED — 3 is hardware-confirmed as the MG's rejection code, #48). UNSUPPORTED
-                        // here is a DECISIVE #592 verdict: the firmware itself says opcode 98 isn't a command,
-                        // which is far stronger than inferring from a short stub.
+                        // here is a DECISIVE #592 verdict: the firmware itself says opcode 98 isn't a command.
                         if (connectedFamily == DeviceFamily.WHOOP5 && frame.size > 12) {
                             val r = frame[12].toInt() and 0xFF
                             val label = when (r) {
                                 0 -> "FAILURE"; 1 -> "SUCCESS"; 2 -> "PENDING"; 3 -> "UNSUPPORTED"
                                 else -> "result$r"
                             }
-                            log("Extended-battery probe result code (#592, 5/MG @12): $label($r)" +
+                            lines.add("Result code (#592, 5/MG @12): $label($r)" +
                                 if (r == 3) " — the firmware explicitly does NOT recognise opcode 98; the decompile's 87 becomes the live candidate (gated follow-up)" else "")
                         }
-                        // #592 payload triage: is there more here than the mV word NOOP already gets from
-                        // the ordinary battery event? Report the payload length (bytes after the command
-                        // byte) and every 16-bit LE word with its payload offset, tagging the mV-band ones
-                        // (3000-4300) vs OTHER in-range values — a rich payload (extra plausible words past
-                        // the mV) means a real battery-health feature to map; just mV/none means #592 is a
-                        // correctness fix with no feature behind it. Read-only scan of the already-logged bytes.
+                        // #592 payload triage: is there more here than the mV word NOOP already gets from the
+                        // ordinary battery event? Report the payload length and every 16-bit LE word with its
+                        // offset, tagging the mV-band ones (3000-4300) vs OTHER in-range values. Bound the scan
+                        // to the DECODABLE payload, excluding the 4-byte CRC32 trailer both families carry
+                        // (total frame = length + 4), so the CRC never reads as a phantom "candidate field".
                         val payStart = cmdOff + 1
-                        // Bound the scan to the DECODABLE payload, excluding the 4-byte CRC32 trailer both
-                        // families carry (total frame = length + 4), so the CRC never reads as a phantom
-                        // "candidate field" and inflates the count. Empty payload ⇒ bare stub.
                         val payEnd = frame.size - 4
                         if (payEnd > payStart) {
                             val pay = frame.copyOfRange(payStart, payEnd)
@@ -3904,11 +3935,13 @@ class WhoopBleClient(
                                 if (tag != null) words.append(" @$o=$v($tag)")
                                 o += 1
                             }
-                            log("Extended-battery probe payload (#592): len=${pay.size} bytes (CRC excluded), overlapping 16-bit LE words:$words " +
+                            lines.add("Payload (#592): len=${pay.size} bytes (CRC excluded), overlapping 16-bit LE words:$words " +
                                 "— words BEYOND an mV are unmapped candidate fields (cycle count / health / temp?); mV-only or none ⇒ no new data over the battery event")
                         } else {
-                            log("Extended-battery probe payload (#592): no payload beyond the command byte (bare stub) ⇒ no data over the battery event; opcode 98 may be an unknown-command ack on this firmware")
+                            lines.add("Payload (#592): no payload beyond the command byte (bare stub) ⇒ no data over the battery event; opcode 98 may be an unknown-command ack on this firmware")
                         }
+                        lines.forEach { log(it) }
+                        _extendedBatteryProbe.value = lines.joinToString("\n\n")
                     }
                     if (frame.size > cmdOff && (frame[cmdOff].toInt() and 0xFF) == CommandNumber.GET_DATA_RANGE.rawValue) {
                         // #451: dump raw GET_DATA_RANGE response bytes unconditionally (even if decode returns

--- a/android/app/src/main/java/com/noop/ui/AppViewModel.kt
+++ b/android/app/src/main/java/com/noop/ui/AppViewModel.kt
@@ -1674,6 +1674,11 @@ class AppViewModel(app: Application) : AndroidViewModel(app) {
      *  battery-info opcode (98 vs an APK decompile's 87) from a normal strap-log export. */
     fun probeExtendedBatteryInfo() = ble.probeExtendedBatteryInfo()
 
+    /** #592 probe result text (null until a reply lands; " waiting" sentinel while in flight). */
+    val extendedBatteryProbe = ble.extendedBatteryProbe
+
+    fun clearExtendedBatteryProbe() = ble.clearExtendedBatteryProbe()
+
     /**
      * Flip the "keep connected in the background" preference (driven by Settings). Turning it on
      * while a strap is live promotes to the foreground immediately; turning it off drops the

--- a/android/app/src/main/java/com/noop/ui/DevicesScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/DevicesScreen.kt
@@ -58,7 +58,14 @@ import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.text.selection.SelectionContainer
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.ui.platform.LocalClipboardManager
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.AnnotatedString
+import com.noop.ble.WhoopBleClient
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.Dp
@@ -104,6 +111,8 @@ fun DevicesScreen(
 ) {
     val scope = rememberCoroutineScope()
     val live by viewModel.live.collectAsStateWithLifecycle()
+    // #592 extended-battery probe result — non-null (incl. the " waiting" sentinel) shows the result dialog.
+    val batteryProbeResult by viewModel.extendedBatteryProbe.collectAsStateWithLifecycle()
 
     // Liquid sky backdrop gate — the SAME "Day-cycle background" preference the liquid Today honours (#698,
     // default ON). Off falls back to the flat dark canvas, so the setting governs every liquid screen alike.
@@ -339,6 +348,15 @@ fun DevicesScreen(
         BatteryInfoProbeDialog(
             onSend = { viewModel.probeExtendedBatteryInfo(); batteryProbeTarget = null },
             onDismiss = { batteryProbeTarget = null },
+        )
+    }
+
+    // #592: the probe reply (or the " waiting" sentinel while in flight) — readable + copyable in place,
+    // so a capture doesn't need a full strap-log export to read or share.
+    batteryProbeResult?.let { result ->
+        BatteryInfoProbeResultDialog(
+            text = result,
+            onDismiss = { viewModel.clearExtendedBatteryProbe() },
         )
     }
 
@@ -866,6 +884,43 @@ private fun BatteryInfoProbeDialog(
         dismissButton = {
             TextButton(onClick = onDismiss) {
                 Text(uiString(R.string.l10n_devices_screen_cancel_77dfd213), style = NoopType.body, color = Palette.textSecondary)
+            }
+        },
+    )
+}
+
+/** #592 probe result: shows the raw hex + payload triage from the strap's reply (or a "waiting…" line
+ *  while in flight), with a Copy button so the capture can be pasted into the issue without exporting the
+ *  whole strap log. Read-only; dismiss clears the result. */
+@Composable
+private fun BatteryInfoProbeResultDialog(
+    text: String,
+    onDismiss: () -> Unit,
+) {
+    val clipboard = LocalClipboardManager.current
+    val waiting = text == WhoopBleClient.WAITING_EXTENDED_BATTERY_PROBE
+    val shown = if (waiting) uiString(R.string.l10n_devices_screen_waiting_for_the_straps_reply_5a06e7ac) else text
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        containerColor = Palette.surfaceOverlay,
+        title = { Text(uiString(R.string.l10n_devices_screen_battery_info_probe_result_592_b97c0bb8), style = NoopType.title2, color = Palette.textPrimary) },
+        text = {
+            Column(modifier = Modifier.heightIn(max = 360.dp).verticalScroll(rememberScrollState())) {
+                SelectionContainer {
+                    Text(shown, style = if (waiting) NoopType.subhead else NoopType.mono, color = Palette.textSecondary)
+                }
+            }
+        },
+        confirmButton = {
+            if (!waiting) {
+                TextButton(onClick = { clipboard.setText(AnnotatedString(text)) }) {
+                    Text(uiString(R.string.l10n_devices_screen_copy_af74f7c5), style = NoopType.body, color = Palette.accent)
+                }
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text(uiString(R.string.l10n_devices_screen_close_bbfa773e), style = NoopType.body, color = Palette.textSecondary)
             }
         },
     )

--- a/android/app/src/main/res/values-de/strings.xml
+++ b/android/app/src/main/res/values-de/strings.xml
@@ -386,9 +386,12 @@
     <string name="l10n_devices_screen_battery_4a9be042">Akku</string>
     <string name="l10n_devices_screen_battery_clamped_2494c8c9">Batterie %1$s%%</string>
     <string name="l10n_devices_screen_battery_info_probe_592_re_1dbd4c0f">Akku-Info-Test (#592 RE)…</string>
+    <string name="l10n_devices_screen_battery_info_probe_result_592_b97c0bb8">Ergebnis des Akku-Info-Tests (#592)</string>
     <string name="l10n_devices_screen_battery_probe_explainer_2858bb6a">Zwei unabhängige Protokolltabellen widersprechen sich beim Extended-Battery-Opcode (98 vs. 87). Dies sendet das kuratierte, nur lesende 98 und schreibt die vollständige Rohantwort des Bands ins Strap-Log. Eine batterieartige Nutzlast bestätigt 98 auf deiner Firmware; ein kurzer Stub bleibt mehrdeutig. Es wird nichts auf das Band geschrieben. Bitte exportiere und teile danach das Strap-Log.</string>
     <string name="l10n_devices_screen_cancel_77dfd213">Abbrechen</string>
     <string name="l10n_devices_screen_clamped_1f39cebb">%1$s%%</string>
+    <string name="l10n_devices_screen_close_bbfa773e">Schließen</string>
+    <string name="l10n_devices_screen_copy_af74f7c5">Kopieren</string>
     <string name="l10n_devices_screen_device_name_79d7a157">Gerätename</string>
     <string name="l10n_devices_screen_give_device_brand_device_model_a_7a15585c">Geben Sie %1$s %2$s einen Namen, den Sie erkennen werden.</string>
     <string name="l10n_devices_screen_leave_none_active_b5c858cb">Keins aktiv lassen</string>
@@ -399,6 +402,7 @@
     <string name="l10n_devices_screen_send_probe_read_only_36b318bc">Test senden (nur lesen)</string>
     <string name="l10n_devices_screen_save_efc007a3">Sichern</string>
     <string name="l10n_devices_screen_the_whoop_4_0_reboot_frame_690a8ff2">Der WHOOP 4.0-Reboot-Frame wird nicht bestätigt - ein normaler Neustart wird ignoriert (# 235).</string>
+    <string name="l10n_devices_screen_waiting_for_the_straps_reply_5a06e7ac">Warte auf die Antwort des Bands…</string>
     <string name="l10n_devices_screen_whoop_4_0_reboot_probe_b51fb50f">WHOOP 4.0-Reboot-Sonde</string>
     <string name="l10n_devices_screen_whoop_is_noop_s_primary_fully_1c9e67fd">WHOOP ist das primäre, vollständig unterstützte Band von NOOP. Andere Herzfrequenzbänder sind eine frühe,</string>
     <string name="l10n_devices_screen_you_removed_your_active_strap_choose_2ac91d48">Du hast deinen aktiven Riemen entfernt. Wählen Sie aus, welches gepaarte Band Ihre Live-Daten bereitstellt, oder</string>

--- a/android/app/src/main/res/values-es/strings.xml
+++ b/android/app/src/main/res/values-es/strings.xml
@@ -226,9 +226,12 @@
     <string name="l10n_devices_screen_battery_4a9be042">Batería</string>
     <string name="l10n_devices_screen_battery_clamped_2494c8c9">Batería %1$s%%</string>
     <string name="l10n_devices_screen_battery_info_probe_592_re_1dbd4c0f">Sonda de info de batería (#592 RE)…</string>
+    <string name="l10n_devices_screen_battery_info_probe_result_592_b97c0bb8">Resultado de la sonda de info de batería (#592)</string>
     <string name="l10n_devices_screen_battery_probe_explainer_2858bb6a">Dos tablas de protocolo independientes discrepan sobre el opcode de batería extendida (98 vs 87). Esto envía el 98 curado y de solo lectura y vuelca la respuesta cruda completa de la banda al registro. Una carga tipo batería confirma 98 en tu firmware; un stub corto lo deja ambiguo. No se escribe nada en la banda. Exporta y comparte el registro después.</string>
     <string name="l10n_devices_screen_cancel_77dfd213">Cancelar</string>
     <string name="l10n_devices_screen_clamped_1f39cebb">%1$s%%</string>
+    <string name="l10n_devices_screen_close_bbfa773e">Cerrar</string>
+    <string name="l10n_devices_screen_copy_af74f7c5">Copiar</string>
     <string name="l10n_devices_screen_device_name_79d7a157">Nombre del dispositivo</string>
     <string name="l10n_devices_screen_give_device_brand_device_model_a_7a15585c">Dale a %1$s %2$s un nombre que reconocerás.</string>
     <string name="l10n_devices_screen_leave_none_active_b5c858cb">No dejar ninguna activa</string>
@@ -239,6 +242,7 @@
     <string name="l10n_devices_screen_send_probe_read_only_36b318bc">Enviar sonda (solo lectura)</string>
     <string name="l10n_devices_screen_save_efc007a3">Guardar</string>
     <string name="l10n_devices_screen_the_whoop_4_0_reboot_frame_690a8ff2">El marco de reinicio WHOOP 4.0 no está confirmado: se ignora un reinicio normal (#235).</string>
+    <string name="l10n_devices_screen_waiting_for_the_straps_reply_5a06e7ac">Esperando la respuesta de la banda…</string>
     <string name="l10n_devices_screen_whoop_4_0_reboot_probe_b51fb50f">WHOOP 4.0 sonda de reinicio</string>
     <string name="l10n_devices_screen_whoop_is_noop_s_primary_fully_1c9e67fd">WHOOP es la banda primaria y totalmente apoyada de NOOP. Otras correas de corazón son tempranas,</string>
     <string name="l10n_devices_screen_you_removed_your_active_strap_choose_2ac91d48">Te quitaste la correa activa. Elija qué banda pareada proporciona sus datos en vivo, o</string>

--- a/android/app/src/main/res/values-fr/strings.xml
+++ b/android/app/src/main/res/values-fr/strings.xml
@@ -226,9 +226,12 @@
     <string name="l10n_devices_screen_battery_4a9be042">Batterie</string>
     <string name="l10n_devices_screen_battery_clamped_2494c8c9">Batterie %1$s%%</string>
     <string name="l10n_devices_screen_battery_info_probe_592_re_1dbd4c0f">Sonde d\'info batterie (#592 RE)…</string>
+    <string name="l10n_devices_screen_battery_info_probe_result_592_b97c0bb8">Résultat de la sonde d\'info batterie (#592)</string>
     <string name="l10n_devices_screen_battery_probe_explainer_2858bb6a">Deux tables de protocole indépendantes divergent sur l\'opcode de batterie étendue (98 contre 87). Ceci envoie le 98 curé en lecture seule et consigne la réponse brute complète du bracelet dans le journal. Une charge de type batterie confirme 98 sur votre firmware ; un stub court le laisse ambigu. Rien n\'est écrit sur le bracelet. Exportez et partagez le journal ensuite.</string>
     <string name="l10n_devices_screen_cancel_77dfd213">Annuler</string>
     <string name="l10n_devices_screen_clamped_1f39cebb">%1$s%%</string>
+    <string name="l10n_devices_screen_close_bbfa773e">Fermer</string>
+    <string name="l10n_devices_screen_copy_af74f7c5">Copier</string>
     <string name="l10n_devices_screen_device_name_79d7a157">Nom de l\'appareil</string>
     <string name="l10n_devices_screen_give_device_brand_device_model_a_7a15585c">Donnez %1$s %2$s un nom que vous reconnaîtrez.</string>
     <string name="l10n_devices_screen_leave_none_active_b5c858cb">N\'en laisser aucune active</string>
@@ -239,6 +242,7 @@
     <string name="l10n_devices_screen_send_probe_read_only_36b318bc">Envoyer la sonde (lecture seule)</string>
     <string name="l10n_devices_screen_save_efc007a3">Enregistrer</string>
     <string name="l10n_devices_screen_the_whoop_4_0_reboot_frame_690a8ff2">Le cadre de redémarrage WHOOP 4.0 n\'est pas confirmé – un redémarrage normal est ignoré (#235).</string>
+    <string name="l10n_devices_screen_waiting_for_the_straps_reply_5a06e7ac">En attente de la réponse du bracelet…</string>
     <string name="l10n_devices_screen_whoop_4_0_reboot_probe_b51fb50f">Sonde de redémarrage WHOOP 4.0</string>
     <string name="l10n_devices_screen_whoop_is_noop_s_primary_fully_1c9e67fd">WHOOP est la bande principale et entièrement supportée de NOOP. D\'autres sangles de rythme cardiaque sont un tôt,</string>
     <string name="l10n_devices_screen_you_removed_your_active_strap_choose_2ac91d48">Vous avez enlevé votre sangle active. Choisissez quelle bande jumelée fournit vos données en direct, ou</string>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -395,9 +395,12 @@
     <string name="l10n_devices_screen_battery_4a9be042">Battery</string>
     <string name="l10n_devices_screen_battery_clamped_2494c8c9">Battery %1$s%%</string>
     <string name="l10n_devices_screen_battery_info_probe_592_re_1dbd4c0f">Battery-info probe (#592 RE)…</string>
+    <string name="l10n_devices_screen_battery_info_probe_result_592_b97c0bb8">Battery-info probe result (#592)</string>
     <string name="l10n_devices_screen_battery_probe_explainer_2858bb6a">Two independent protocol tables disagree on the extended-battery opcode (98 vs 87). This sends the curated read-only 98 and dumps the strap\'s full raw reply to the strap log. A battery-style payload confirms 98 on your firmware; a short stub means it stays ambiguous. Nothing is written to the strap. Please export and share the strap log afterwards.</string>
     <string name="l10n_devices_screen_cancel_77dfd213">Cancel</string>
     <string name="l10n_devices_screen_clamped_1f39cebb">%1$s%%</string>
+    <string name="l10n_devices_screen_close_bbfa773e">Close</string>
+    <string name="l10n_devices_screen_copy_af74f7c5">Copy</string>
     <string name="l10n_devices_screen_device_name_79d7a157">Device name</string>
     <string name="l10n_devices_screen_give_device_brand_device_model_a_7a15585c">Give %1$s %2$s a name you\'ll recognise.</string>
     <string name="l10n_devices_screen_leave_none_active_b5c858cb">Leave none active</string>
@@ -408,6 +411,7 @@
     <string name="l10n_devices_screen_send_probe_read_only_36b318bc">Send probe (read-only)</string>
     <string name="l10n_devices_screen_save_efc007a3">Save</string>
     <string name="l10n_devices_screen_the_whoop_4_0_reboot_frame_690a8ff2">The WHOOP 4.0 reboot frame isn\'t confirmed — a normal Restart is ignored (#235). </string>
+    <string name="l10n_devices_screen_waiting_for_the_straps_reply_5a06e7ac">Waiting for the strap\'s reply…</string>
     <string name="l10n_devices_screen_whoop_4_0_reboot_probe_b51fb50f">WHOOP 4.0 reboot probe</string>
     <string name="l10n_devices_screen_whoop_is_noop_s_primary_fully_1c9e67fd">WHOOP is NOOP\'s primary, fully-supported band. Other heart-rate straps are an early, </string>
     <string name="l10n_devices_screen_you_removed_your_active_strap_choose_2ac91d48">You removed your active strap. Choose which paired band provides your live data, or </string>


### PR DESCRIPTION
Follow-up to #599. The probe currently writes its result **only to the strap log**, so reading or sharing a capture means exporting the whole log. This surfaces it **in place** — a result dialog you can read and **copy** straight into the issue.

## What it adds
- **`WhoopBleClient`** — publishes the probe result (raw hex + payload triage + the 5/MG result code) to a new `extendedBatteryProbe: StateFlow<String?>` alongside the existing log lines. A `" waiting"` sentinel is set when the probe is sent so the dialog can show an in-flight state until the reply lands; `clearExtendedBatteryProbe()` resets it.
- **`AppViewModel`** — exposes the flow + clear.
- **`DevicesScreen`** — when a result arrives, a read-only dialog shows the text (monospace, selectable, scrollable to 360dp) with a **Copy** button (`LocalClipboardManager`) and Close. So a capture pastes straight into #592 with no full-log export.
- **`strings.xml` (+de/es/fr)** — dialog title, the waiting line, Copy, Close.

## Notes
- **Log lines unchanged** — the strap-log bundle still carries the capture, so nothing regresses for the existing report flow; this is purely additive UX.
- **Read-only, no new opcode** — same safety envelope as #599; this only *displays* what the probe already produced.
- **Motivation:** in testing, "Send probe" gave no visible result (by design — log-only), which made the capture hard to retrieve. This closes that gap.

## Verification
- Full Android module **compiles**; `testFullDebugUnitTest` **green** (StateFlow + UI only, no analytics logic touched); `Tools/i18n_audit.py --ci main` **exit 0** (4 new keys × de/es/fr, XML validated).
- Delivery/UI aren't CI-testable; the dialog was built against the existing probe/reboot-probe dialog patterns.
- Swift twin to follow together with the probe twin.