### PR TITLE
iOS/macOS twin of the #592 extended-battery probe + voltage

### DIFF
--- a/Packages/WhoopProtocol/Sources/WhoopProtocol/ExtendedBatteryProbe.swift
+++ b/Packages/WhoopProtocol/Sources/WhoopProtocol/ExtendedBatteryProbe.swift
@@ -1,0 +1,116 @@
+import Foundation
+
+/// #592: format a `GET_EXTENDED_BATTERY_INFO` COMMAND_RESPONSE into a clean, readable, copyable report —
+/// a verdict, the full raw hex on one line, an offset-labelled payload hex grid, the decoded pack voltage,
+/// and a per-byte diff vs the previous capture. Pure + deterministic, so it's unit-tested without a strap.
+///
+/// This is the Swift twin of the Android `WhoopBleClient.formatExtendedBatteryProbe`. It lives in the pure
+/// `WhoopProtocol` package (rather than app-side like the Kotlin version) so `swift test` covers it on
+/// every CI run; the behaviour — and the output text — is byte-identical to the Kotlin formatter.
+public enum ExtendedBatteryProbe {
+
+    /// Returns the display text and the payload hex to persist for the next capture's diff (nil when there
+    /// is no decodable payload). `cmdOff` is the response-command byte offset (6 on WHOOP4, 10 on 5/MG);
+    /// the 4-byte CRC32 trailer both families carry is excluded from the payload. The voltage line is only
+    /// printed for WHOOP4 — the `pay[7..8]` offset is confirmed there, but the 5/MG response to 98 is an
+    /// undecoded stub, so a decoded voltage there would be a guess presented as fact.
+    public static func format(frame: [UInt8], cmdOff: Int, isWhoop5: Bool, prevPayloadHex: String?) -> (text: String, payloadHex: String?) {
+        let fam = isWhoop5 ? "WHOOP 5/MG" : "WHOOP 4.0"
+        let payStart = cmdOff + 1
+        let payEnd = frame.count - 4
+        let hasPayload = payEnd > payStart
+        let pay: [UInt8] = hasPayload ? Array(frame[payStart..<payEnd]) : []
+
+        // 5/MG replies carry an explicit result code @12 (0 FAILURE / 1 SUCCESS / 2 PENDING /
+        // 3 UNSUPPORTED — 3 is the MG's hardware-confirmed rejection code, #48).
+        let resultCode: Int? = (isWhoop5 && frame.count > 12) ? Int(frame[12]) : nil
+        let resultLabel: String?
+        switch resultCode {
+        case 0: resultLabel = "FAILURE"
+        case 1: resultLabel = "SUCCESS"
+        case 2: resultLabel = "PENDING"
+        case 3: resultLabel = "UNSUPPORTED"
+        case nil: resultLabel = nil
+        default: resultLabel = "result\(resultCode!)"
+        }
+        let verdict: String
+        if resultCode == 3 {
+            verdict = "opcode 98 REJECTED by firmware (UNSUPPORTED) — evidence for the decompile's 87"
+        } else if hasPayload {
+            verdict = "opcode 98 ACCEPTED — \(pay.count)-byte payload"
+        } else {
+            verdict = "opcode 98 answered with a bare stub — ambiguous"
+        }
+
+        var sb = ""
+        sb += "#592 EXTENDED-BATTERY PROBE — \(fam)\n"
+        sb += "Verdict: \(verdict)\n"
+        if let resultLabel { sb += "Result code @12: \(resultLabel)(\(resultCode!))\n" }
+        // Full raw hex on ONE line so it copies cleanly for sharing.
+        sb += "\nRaw frame (\(frame.count) B):\n"
+        sb += frame.map { String(format: "%02x", $0) }.joined() + "\n"
+
+        var payloadHex: String?
+        if hasPayload {
+            payloadHex = pay.map { String(format: "%02x", $0) }.joined()
+            sb += "\nPayload (\(pay.count) B, CRC excluded):\n"
+            sb += hexGrid(pay)
+            // NOOP's decoder reads the pack voltage at payload bytes 7..8 (LE) — confirmed only on WHOOP4.
+            if !isWhoop5, pay.count >= 9 {
+                let mv = Int(pay[7]) | (Int(pay[8]) << 8)
+                sb += "\nVoltage: " + String(format: "%.2f V", Double(mv) / 1000.0)
+                sb += "  (mV=\(mv) @07) — the field NOOP already reads\n"
+            }
+            // Per-byte diff vs the previous capture — the field-mapping signal.
+            sb += "\n"
+            if let prevPayloadHex, prevPayloadHex.count == payloadHex!.count {
+                let prev = hexToBytes(prevPayloadHex)
+                var deltas = ""
+                for i in pay.indices where prev[i] != Int(pay[i]) {
+                    deltas += String(format: " @%02d:%02x→%02x", i, prev[i], Int(pay[i]))
+                }
+                if deltas.isEmpty {
+                    sb += "Δ vs previous capture: identical — re-probe at a different % / after wear to expose the fields"
+                } else {
+                    sb += "Δ vs previous capture:\(deltas)\n"
+                    sb += "(a byte tracking battery % = SoC/capacity; drifting with wear = temperature; only ever climbing = cycle count)"
+                }
+            } else {
+                sb += "Δ vs previous capture: first capture — probe again at another battery % to diff"
+            }
+        } else {
+            sb += "\nNo payload beyond the command byte (bare stub) — no data over the battery event; "
+            sb += "opcode 98 may be an unknown-command ack on this firmware"
+        }
+        return (sb, payloadHex)
+    }
+
+    /// Offset-labelled hex grid, 8 bytes per row ("  @00  0d 01 …"), for the #592 payload dump.
+    private static func hexGrid(_ bytes: [UInt8]) -> String {
+        var sb = ""
+        var i = 0
+        while i < bytes.count {
+            sb += String(format: "  @%02d ", i)
+            var j = i
+            while j < min(i + 8, bytes.count) {
+                sb += String(format: " %02x", bytes[j])
+                j += 1
+            }
+            sb += "\n"
+            i += 8
+        }
+        return sb
+    }
+
+    private static func hexToBytes(_ hex: String) -> [Int] {
+        let chars = Array(hex)
+        var out: [Int] = []
+        out.reserveCapacity(chars.count / 2)
+        var i = 0
+        while i + 1 < chars.count {
+            out.append((Int(String(chars[i]), radix: 16) ?? 0) << 4 | (Int(String(chars[i + 1]), radix: 16) ?? 0))
+            i += 2
+        }
+        return out
+    }
+}

--- a/Packages/WhoopProtocol/Tests/WhoopProtocolTests/ExtendedBatteryProbeTests.swift
+++ b/Packages/WhoopProtocol/Tests/WhoopProtocolTests/ExtendedBatteryProbeTests.swift
@@ -1,0 +1,63 @@
+import XCTest
+@testable import WhoopProtocol
+
+/// #592: the pure formatter for the GET_EXTENDED_BATTERY_INFO probe result. Byte-parity twin of the Kotlin
+/// `ExtendedBatteryProbeFormatTest` (same fixtures, same expectations) — including the REAL WHOOP 4.0
+/// capture that resolved the issue (opcode 98 accepted, 29-byte payload, mV=3970 → 3.97 V).
+final class ExtendedBatteryProbeTests: XCTestCase {
+
+    private func hexToBytes(_ h: String) -> [UInt8] {
+        let c = Array(h)
+        return stride(from: 0, to: c.count, by: 2).map {
+            UInt8((Int(String(c[$0]), radix: 16)! << 4) | Int(String(c[$0 + 1]), radix: 16)!)
+        }
+    }
+
+    // The exact frame captured on a real WHOOP 4.0 (cmd byte 0x62=98 @6; total 40 B, len field 0x24=36).
+    private let realFrame = "aa2400fa24c6620d010165006bff820f0c0128000f05e90321120200010100001a0000004675fe58"
+
+    func testWhoop4RealCapture_acceptedWithVoltageAndGrid() {
+        let (text, payHex) = ExtendedBatteryProbe.format(frame: hexToBytes(realFrame), cmdOff: 6, isWhoop5: false, prevPayloadHex: nil)
+        XCTAssertTrue(text.contains("WHOOP 4.0"))
+        XCTAssertTrue(text.contains("opcode 98 ACCEPTED — 29-byte payload"))
+        XCTAssertTrue(text.contains(realFrame))                  // full raw hex on one copyable line
+        XCTAssertTrue(text.contains("Voltage: 3.97 V"))          // pay[7..8] = 0x0f82 = 3970 mV
+        XCTAssertTrue(text.contains("(mV=3970 @07)"))
+        XCTAssertTrue(text.contains("  @00  0d 01 01 65 00 6b ff 82"))  // offset-labelled hex grid, 8/row
+        XCTAssertTrue(text.contains("first capture"))            // no previous payload to diff
+        XCTAssertEqual(payHex?.count, 29 * 2)                    // 29-byte payload persisted for the next diff
+    }
+
+    func testDiff_flagsTheChangedBytes() {
+        let first = hexToBytes(realFrame)
+        let (_, prev) = ExtendedBatteryProbe.format(frame: first, cmdOff: 6, isWhoop5: false, prevPayloadHex: nil)
+        // Flip one payload byte (frame[10] = payload offset 3) to simulate a second capture at another state.
+        var second = first
+        second[10] = 0x40
+        let (text, _) = ExtendedBatteryProbe.format(frame: second, cmdOff: 6, isWhoop5: false, prevPayloadHex: prev)
+        XCTAssertTrue(text.contains("Δ vs previous capture:"))
+        XCTAssertTrue(text.contains("@03:65→40"))                // payload offset 3 moved 0x65→0x40
+        XCTAssertTrue(text.contains("SoC/capacity"))
+    }
+
+    func testBareStub_isCalledOut() {
+        // 11-byte frame: cmd@6=0x62 then ONLY the 4-byte CRC tail, so payEnd(7) == payStart(7) ⇒ no payload.
+        let (text, payHex) = ExtendedBatteryProbe.format(frame: hexToBytes("aa0700fa24006246758858"), cmdOff: 6, isWhoop5: false, prevPayloadHex: nil)
+        XCTAssertTrue(text.contains("bare stub"))
+        XCTAssertNil(payHex)
+    }
+
+    func testWhoop5Unsupported_isDecisiveVerdict() {
+        // 5/MG frame with the command byte 0x62 @10 and result code 3 (UNSUPPORTED) @12.
+        let (text, _) = ExtendedBatteryProbe.format(frame: hexToBytes("aa000c000000000000006200030046758858"), cmdOff: 10, isWhoop5: true, prevPayloadHex: nil)
+        XCTAssertTrue(text.contains("REJECTED by firmware (UNSUPPORTED)"))
+        XCTAssertTrue(text.contains("Result code @12: UNSUPPORTED(3)"))
+    }
+
+    func testWhoop5Payload_doesNotPrintAGuessedVoltage() {
+        // 5/MG SUCCESS(1) with a ≥9-byte payload: the mV offset is unconfirmed on 5/MG, so NO voltage line.
+        let (text, _) = ExtendedBatteryProbe.format(frame: hexToBytes("aa000c000000000000006200010102030405060708090a46758858"), cmdOff: 10, isWhoop5: true, prevPayloadHex: nil)
+        XCTAssertTrue(text.contains("Result code @12: SUCCESS(1)"))
+        XCTAssertFalse(text.contains("Voltage:"))
+    }
+}

--- a/Strand/App/AppModel.swift
+++ b/Strand/App/AppModel.swift
@@ -802,6 +802,10 @@ final class AppModel: ObservableObject {
     /// in DevicesView; finds the real 4.0 reboot frame when the production one is ignored (#235).
     func rebootProbe(_ variant: RebootProbeVariant) { ble.rebootProbe(variant) }
 
+    /// #592 read-only extended-battery opcode probe (Devices → strap menu, Test Centre → Connection gated).
+    func probeExtendedBatteryInfo() { ble.probeExtendedBatteryInfo() }
+    func clearExtendedBatteryProbe() { ble.clearExtendedBatteryProbe() }
+
     /// Drop the current strap and clear bond state so a newly-picked strap model connects fresh
     /// (lets a user with both a WHOOP 4 and a 5/MG switch between them).
     func prepareStrapSwitch() { ble.prepareForModelSwitch() }

--- a/Strand/BLE/BLEManager.swift
+++ b/Strand/BLE/BLEManager.swift
@@ -1432,6 +1432,9 @@ public final class BLEManager: NSObject, ObservableObject {
                 // below. NOT hardware-confirmed on 5/MG — rebootStrap() logs the COMMAND_RESPONSE so a strap
                 // log confirms whether the frame is accepted. User-initiated + confirmation-gated only.
                 || command == .rebootStrap
+                // GET_EXTENDED_BATTERY_INFO (98) over puffin: read-only opcode probe (#592) — a real WHOOP 5
+                // (fw 50.38.1.0) already answered this number. Driven only by probeExtendedBatteryInfo().
+                || command == .getExtendedBatteryInfo
                 || command == .sendHistoricalData || command == .historicalDataResult
                 || command == .setClock || command == .getClock
                 // SET_CONFIG (the R22 deep-stream unlock) is allowed ONLY while the deep-data
@@ -2367,6 +2370,50 @@ public final class BLEManager: NSObject, ObservableObject {
         sendRebootFrame(command: variant.command, payload: variant.payload, probe: variant)
     }
 
+    /// #592: sentinel value of `LiveState.extendedBatteryProbe` between sending the probe and its reply
+    /// landing (or the no-reply timeout). The result dialog shows a "waiting…" line for this value.
+    public static let extendedBatteryProbeWaiting = "__waiting__"
+    private static let extendedBatteryProbeTimeout: TimeInterval = 8
+    private static let extendedBatteryPrevPayloadKey = "noop.592.prevPayload"
+
+    /// #592 opcode probe: send the read-only GET_EXTENDED_BATTERY_INFO(98) and surface the strap's reply
+    /// (raw hex + payload triage + capture diff) on `LiveState.extendedBatteryProbe` for the Devices dialog.
+    /// The number is disputed (an APK decompile reads 87); a battery-shaped payload confirms 98 on this
+    /// firmware. Works on both families (the 4.0 is the discriminating device). User-initiated only.
+    public func probeExtendedBatteryInfo() {
+        guard state.connected else {
+            log("Extended-battery probe (#592) ignored — not connected")
+            return
+        }
+        state.extendedBatteryProbe = BLEManager.extendedBatteryProbeWaiting
+        log("Extended-battery probe (#592): sending GET_EXTENDED_BATTERY_INFO(98, read-only) on family=\(selectedModel.deviceFamily); the raw COMMAND_RESPONSE is surfaced when it lands")
+        send(.getExtendedBatteryInfo)
+        // No-reply timeout: if no COMMAND_RESPONSE for 98 arrives, the silence is itself the verdict (98 not
+        // served → toward the decompile's 87). BLE callbacks + this timer both run on the main queue, so the
+        // guard-then-set is race-free (no CAS needed): a real reply already overwrote the sentinel.
+        DispatchQueue.main.asyncAfter(deadline: .now() + BLEManager.extendedBatteryProbeTimeout) { [weak self] in
+            guard let self, self.state.extendedBatteryProbe == BLEManager.extendedBatteryProbeWaiting else { return }
+            let secs = Int(BLEManager.extendedBatteryProbeTimeout)
+            let msg = "Extended-battery probe (#592): no COMMAND_RESPONSE for opcode 98 within \(secs)s — the strap served no reply. That silence is evidence AGAINST 98 on this firmware (toward the decompile's 87); a gated 87 probe is the follow-up. (If a sync/offload was mid-flight the response can be delayed — retry idle.)"
+            self.log(msg)
+            self.state.extendedBatteryProbe = msg
+        }
+    }
+
+    /// Clear the #592 probe result (Devices dialog dismissed). Twin of Android clearExtendedBatteryProbe().
+    public func clearExtendedBatteryProbe() { state.extendedBatteryProbe = nil }
+
+    /// #592: format a GET_EXTENDED_BATTERY_INFO COMMAND_RESPONSE and publish it, diffing against the
+    /// persisted previous payload. Called from the inbound frame handler for both families.
+    private func handleExtendedBatteryProbeResponse(_ frame: [UInt8], isWhoop5: Bool) {
+        let prev = UserDefaults.standard.string(forKey: BLEManager.extendedBatteryPrevPayloadKey)
+        let (text, payHex) = ExtendedBatteryProbe.format(
+            frame: frame, cmdOff: isWhoop5 ? 10 : 6, isWhoop5: isWhoop5, prevPayloadHex: prev)
+        log("Extended-battery probe (#592):\n\(text)")
+        state.extendedBatteryProbe = text
+        if let payHex { UserDefaults.standard.set(payHex, forKey: BLEManager.extendedBatteryPrevPayloadKey) }
+    }
+
     /// Shared reboot send + debug trail + watchdog, used by both the production `rebootStrap()` and the
     /// 4.0 `rebootProbe(_:)`. `probe == nil` is the normal restart; a non-nil variant is a probe attempt
     /// (its `logTag` is stamped first so the strap log correlates the attempt with what the strap did).
@@ -3213,7 +3260,9 @@ extension BLEManager: @preconcurrency CBCentralManagerDelegate {
         state.connected = false
         state.encryptedBond = false   // cleared with didBond; next session must re-prove the bond (#69)
         state.charging = nil          // a stale charging flag must not outlive the link
+        state.batteryMv = nil         // #592: a stale pack voltage must not outlive the link
         state.strapFirmware = nil     // a stale firmware version must not outlive the link
+        state.extendedBatteryProbe = nil  // #592: drop a stale probe result on disconnect
         state.clearBiometrics()       // and a stale HR / R-R must not outlive the link either
         state.liveFeedActive = false  // a drop while Live is open must not leave a stale "Stop live feed"
         didBond = false
@@ -3871,6 +3920,11 @@ extension BLEManager: @preconcurrency CBPeripheralDelegate {
                 // the router + collector re-checks the invariant).
                 let parsed = parseFrame(frame, family: .whoop4)
                 router.handle(parsed: parsed, frame: frame)       // live/UI path
+                // #592: the read-only extended-battery probe's COMMAND_RESPONSE — format + publish it for the
+                // Devices dialog (raw hex + payload triage + capture diff). Sibling of the #451 dump below.
+                if frame.count > 6, frame[6] == WhoopCommand.getExtendedBatteryInfo.rawValue {
+                    handleExtendedBatteryProbeResponse(frame, isWhoop5: false)
+                }
                 if frame.count > 6, frame[6] == WhoopCommand.getDataRange.rawValue {
                     // #451: the decoded "newest" can latch a stale/wrong-epoch field (claypilat saw 2024 when
                     // the real newest was 2026). To tell a genuinely-stale strap apart from a frame-alignment
@@ -3984,6 +4038,11 @@ extension BLEManager: @preconcurrency CBPeripheralDelegate {
                         continue
                     }
                     router.handle(frame: frame)
+                    // #592: a 5/MG extended-battery probe COMMAND_RESPONSE (puffin envelope: type @8, cmd
+                    // @10). Format + publish it for the Devices dialog, exactly like the 4.0 path above.
+                    if frame.count > 10, frame[8] == 0x24, frame[10] == WhoopCommand.getExtendedBatteryInfo.rawValue {
+                        handleExtendedBatteryProbeResponse(frame, isWhoop5: true)
+                    }
                     // NOTE: we deliberately do NOT ingest live 5/MG REALTIME_DATA into the Collector
                     // here. For a 5/MG the standard 0x2A37 Heart-Rate profile is already the RELIABLE,
                     // continuously-persisted live source (see didUpdateValueFor 0x2A37 → ingestStandardHR);

--- a/Strand/BLE/FrameRouter.swift
+++ b/Strand/BLE/FrameRouter.swift
@@ -88,6 +88,10 @@ public final class FrameRouter {
             if let pct = parsed.parsed["battery_pct"]?.doubleValue {
                 state.setBattery(pct)
             }
+            // #592: GET_EXTENDED_BATTERY_INFO / GET_BATTERY_LEVEL responses may carry pack voltage.
+            if let mv = parsed.parsed["battery_mV"]?.intValue {
+                state.batteryMv = mv
+            }
             // Firmware version from the connect handshake: WHOOP 4.0 decodes `fw_harvard`
             // (REPORT_VERSION_INFO), WHOOP 5/MG decodes `fw_version` (GET_HELLO). Take whichever the
             // decoder produced; one branch covers both families. It's stable for the connection, so
@@ -202,6 +206,10 @@ public final class FrameRouter {
                 if ev.hasPrefix("BATTERY_LEVEL"),
                    let ch = parsed.parsed["battery_charging"]?.intValue {
                     state.charging = (ch != 0)
+                }
+                // #592: the same battery event carries pack voltage (mv@21) — surface it on the Devices card.
+                if ev.hasPrefix("BATTERY_LEVEL"), let mv = parsed.parsed["battery_mV"]?.intValue {
+                    state.batteryMv = mv
                 }
                 // Physical inputs the strap exposes — live only (this path never sees historical
                 // replay, which goes through the Backfiller). Event strings are "NAME(rawValue)".

--- a/Strand/BLE/LiveState.swift
+++ b/Strand/BLE/LiveState.swift
@@ -59,6 +59,10 @@ public final class LiveState: ObservableObject {
     /// replaced) by `setRRIntervals(_:)`; emptied by `clearBiometrics()`.
     @Published public private(set) var rrRecent: [Int] = []
     @Published public var batteryPct: Double? = nil
+    /// Strap battery pack VOLTAGE (mV), decoded from the ~8-min BATTERY_LEVEL event (mv@21/@25) and the
+    /// GET_EXTENDED_BATTERY_INFO response (#592). Shown on the Devices card as a "x.xx V" readout beside the
+    /// percent; nil until the first battery event lands. Twin of the Android LiveState.batteryMv.
+    @Published public var batteryMv: Int? = nil
     /// Charging flag from the strap's BATTERY_LEVEL events — wire observation: u8 bit0 in the
     /// event payload (4.0 @26 / 5.0 @30), pushed ~every 8 min on captured links. nil until the
     /// first event of a session; cleared on disconnect so a stale flag can't outlive the link.
@@ -224,6 +228,11 @@ public final class LiveState: ObservableObject {
     /// SET_ADVERTISING_NAME_HARVARD ack, or a local validation message from BLEManager.renameStrap.
     /// Surfaced under the rename field; overwritten by the next attempt.
     @Published public var renameStatus: String? = nil
+    /// #592: the read-only extended-battery probe result (raw hex + payload triage + capture diff), or a
+    /// `" waiting"` sentinel while a probe is in flight; nil otherwise. Drives the Devices result dialog so
+    /// a capture is readable/copyable without a full log export. BLEManager writes it; cleared on disconnect
+    /// and on dialog dismiss. Twin of the Android StateFlow LiveState/WhoopBleClient.extendedBatteryProbe.
+    @Published public var extendedBatteryProbe: String? = nil
     /// Wrist-wear state from WRIST_ON/WRIST_OFF events. Defaults true so wear-gated features work
     /// before the first event arrives; flipped by FrameRouter on a real event.
     @Published public var worn: Bool = true

--- a/Strand/Screens/DevicesView.swift
+++ b/Strand/Screens/DevicesView.swift
@@ -59,6 +59,8 @@ private struct DevicesContent: View {
     @State private var rebootTarget: PairedDevice?
     /// WHOOP 4.0 reboot probe (Test Centre → Connection, 4.0 only) — the device whose probe sheet is open.
     @State private var probeTarget: PairedDevice?
+    /// #592 extended-battery probe (Test Centre → Connection) — the device whose confirm dialog is open.
+    @State private var batteryProbeTarget: PairedDevice?
     /// After removing the ACTIVE device with other devices still paired, prompt to pick a new active one.
     @State private var pickNewActive = false
 
@@ -114,6 +116,7 @@ private struct DevicesContent: View {
                     // The live battery belongs to whichever device is ACTIVE + connected (the WHOOP, a
                     // generic strap, or an FTMS machine all funnel into live.batteryPct). nil otherwise.
                     liveBatteryPct: (device.status == .active && live.connected) ? live.batteryPct.map { Int($0.rounded()) } : nil,
+                    liveBatteryMv: (device.status == .active && live.connected) ? live.batteryMv : nil,
                     // Firmware version belongs to the active + connected strap only; nil otherwise (and
                     // for a non-WHOOP source that never reports one).
                     liveFirmware: (device.status == .active && live.connected) ? live.strapFirmware : nil,
@@ -138,7 +141,12 @@ private struct DevicesContent: View {
                     onRebootProbe: (device.status == .active && live.connected
                                     && SourceCoordinator.isWhoop(device)
                                     && model.ble.isWhoop4
-                                    && TestCentre.active(.connection)) ? { probeTarget = device } : nil)
+                                    && TestCentre.active(.connection)) ? { probeTarget = device } : nil,
+                    // #592 extended-battery probe: read-only, BOTH families (the 4.0 is discriminating).
+                    // Same Test Centre → Connection gate as the reboot probe, minus the 4.0-only clause.
+                    onExtendedBatteryProbe: (device.status == .active && live.connected
+                                             && SourceCoordinator.isWhoop(device)
+                                             && TestCentre.active(.connection)) ? { batteryProbeTarget = device } : nil)
                     .staggeredAppear(index: idx)
             }
 
@@ -216,6 +224,25 @@ private struct DevicesContent: View {
             Button("Cancel", role: .cancel) { probeTarget = nil }
         } message: { _ in
             Text("The WHOOP 4.0 reboot frame isn't confirmed — a normal Restart is ignored (#235). Send each candidate and watch BOTH the strap log and the strap itself. “no disconnect within 12s” means the strap ignored the frame. A “link dropped” line means the frame reached the strap — but a dropped link alone isn't a reboot: a real reboot also switches the strap's sensor light off for a few seconds, so if the light stayed on it was just a dropped connection, not a reboot. Non-destructive — your data is kept. Please share the log so we can pin the real frame.")
+        }
+        // #592 extended-battery opcode probe: read-only, dumps the strap's full raw reply so a capture
+        // settles the disputed GET_EXTENDED_BATTERY_INFO number (98 vs an APK decompile's 87).
+        .confirmationDialog("Battery-info probe (#592 RE)",
+                            isPresented: Binding(get: { batteryProbeTarget != nil },
+                                                 set: { if !$0 { batteryProbeTarget = nil } }),
+                            titleVisibility: .visible,
+                            presenting: batteryProbeTarget) { _ in
+            Button("Send probe (read-only)") { model.probeExtendedBatteryInfo(); batteryProbeTarget = nil }
+            Button("Cancel", role: .cancel) { batteryProbeTarget = nil }
+        } message: { _ in
+            Text("Two independent protocol tables disagree on the extended-battery opcode (98 vs 87). This sends the curated read-only 98 and shows the strap's full raw reply. A battery-style payload confirms 98 on your firmware; a short stub means it stays ambiguous. Nothing is written to the strap.")
+        }
+        // #592 probe result: the strap's reply (or a "waiting…" state), readable + copyable in place.
+        .sheet(isPresented: Binding(get: { live.extendedBatteryProbe != nil },
+                                    set: { if !$0 { model.clearExtendedBatteryProbe() } })) {
+            ExtendedBatteryProbeResultView(
+                text: live.extendedBatteryProbe ?? "",
+                onClose: { model.clearExtendedBatteryProbe() })
         }
         // Second, strongly-worded delete-data confirm (reached from the Remove card's secondary control)
         .alert("Delete all of this device's data?",
@@ -376,6 +403,8 @@ private struct DeviceCard: View {
     /// for WHOOP, a generic strap, or an FTMS machine. nil when not the active/connected device or
     /// the source hasn't reported a battery (e.g. a strap/machine without the 0x180F service).
     var liveBatteryPct: Int? = nil
+    /// #592: strap pack voltage (mV) for the active+connected strap; nil otherwise. Shown beside the percent.
+    var liveBatteryMv: Int? = nil
     /// The active+connected strap's firmware version (from the connect handshake). nil when not the
     /// active/connected device, or for a source that reports no firmware (e.g. a non-WHOOP strap).
     var liveFirmware: String? = nil
@@ -398,6 +427,8 @@ private struct DeviceCard: View {
     /// WHOOP 4.0 reboot probe (Test Centre → Connection, 4.0 only). Non-nil only when the parent has
     /// decided the probe applies (live-connected WHOOP 4.0 + Connection test mode on); nil otherwise. (#235)
     var onRebootProbe: (() -> Void)? = nil
+    /// #592 extended-battery opcode probe (Test Centre → Connection, both WHOOP families). Read-only.
+    var onExtendedBatteryProbe: (() -> Void)? = nil
     /// Removed-section affordances (re-add as active / delete its data).
     var onReAdd: (() -> Void)? = nil
     var onDeleteData: (() -> Void)? = nil
@@ -497,6 +528,14 @@ private struct DeviceCard: View {
                             .font(StrandFont.footnote)
                             .foregroundStyle(StrandPalette.textSecondary)
                             .accessibilityLabel("Firmware version \(fw)")
+                    }
+                    // #592: strap pack voltage beside the percent, when the battery event has reported it.
+                    if let mv = liveBatteryMv {
+                        Text("·").font(StrandFont.footnote).foregroundStyle(StrandPalette.textTertiary)
+                        Text(String(format: "%.2f V", Double(mv) / 1000.0))
+                            .font(StrandFont.footnote)
+                            .foregroundStyle(StrandPalette.textSecondary)
+                            .accessibilityLabel(String(format: "Battery voltage %.2f volts", Double(mv) / 1000.0))
                     }
                     if let layout = liveHistoryLayout {
                         Text("·").font(StrandFont.footnote).foregroundStyle(StrandPalette.textTertiary)
@@ -632,6 +671,10 @@ private struct DeviceCard: View {
                 // Connection on + a live WHOOP 4.0). Finds the real reboot frame the 4.0 accepts (#235).
                 if let onRebootProbe {
                     Button { onRebootProbe() } label: { Label("Reboot probe (4.0 RE)…", systemImage: "ladybug") }
+                }
+                // #592 extended-battery opcode probe (RE): read-only, both families. Test Centre → Connection.
+                if let onExtendedBatteryProbe {
+                    Button { onExtendedBatteryProbe() } label: { Label("Battery-info probe (#592 RE)…", systemImage: "ladybug") }
                 }
                 if let onRemove {
                     Divider()
@@ -858,6 +901,48 @@ struct SignalBars: View {
         }
         .frame(width: 22, height: 18, alignment: .bottom)
         .accessibilityHidden(true)
+    }
+}
+
+// MARK: - #592 extended-battery probe result
+
+/// The #592 probe reply (raw hex + payload triage + capture diff), or a "waiting…" state while in flight.
+/// Read-only; the text is selectable and a Copy button puts it on the clipboard so a capture pastes into
+/// the issue without a full strap-log export. Twin of the Android BatteryInfoProbeResultDialog.
+private struct ExtendedBatteryProbeResultView: View {
+    let text: String
+    let onClose: () -> Void
+    private var waiting: Bool { text == BLEManager.extendedBatteryProbeWaiting }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            Text("Battery-info probe result (#592)")
+                .font(StrandFont.title2)
+                .foregroundStyle(StrandPalette.textPrimary)
+            if waiting {
+                Text("Waiting for the strap's reply…")
+                    .font(StrandFont.subhead)
+                    .foregroundStyle(StrandPalette.textSecondary)
+            } else {
+                ScrollView {
+                    Text(text)
+                        .font(StrandFont.mono)
+                        .foregroundStyle(StrandPalette.textSecondary)
+                        .textSelection(.enabled)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                }
+            }
+            HStack {
+                if !waiting {
+                    Button("Copy") { PlatformPasteboard.copy(text) }
+                }
+                Spacer()
+                Button("Close") { onClose() }
+            }
+        }
+        .padding(20)
+        .frame(minWidth: 340, minHeight: 260)
+        .background(StrandPalette.surfaceOverlay)
     }
 }
 

--- a/Strand/Screens/DevicesView.swift
+++ b/Strand/Screens/DevicesView.swift
@@ -532,10 +532,10 @@ private struct DeviceCard: View {
                     // #592: strap pack voltage beside the percent, when the battery event has reported it.
                     if let mv = liveBatteryMv {
                         Text("·").font(StrandFont.footnote).foregroundStyle(StrandPalette.textTertiary)
-                        Text(String(format: "%.2f V", Double(mv) / 1000.0))
+                        Text("\(Double(mv) / 1000.0, specifier: "%.2f") V")
                             .font(StrandFont.footnote)
                             .foregroundStyle(StrandPalette.textSecondary)
-                            .accessibilityLabel(String(format: "Battery voltage %.2f volts", Double(mv) / 1000.0))
+                            .accessibilityLabel("Battery voltage \(Double(mv) / 1000.0, specifier: "%.2f") volts")
                     }
                     if let layout = liveHistoryLayout {
                         Text("·").font(StrandFont.footnote).foregroundStyle(StrandPalette.textTertiary)


### PR DESCRIPTION
The Swift twin of the Android #592 tooling (#599/#601/#603/#604) — feature parity on macOS/iOS: the read-only probe, its copyable result dialog, the strap voltage on the Devices card, and the field-mapping capture diff.

## What's verified now vs. what needs the app-build
- **`WhoopProtocol.ExtendedBatteryProbe.format(...)`** — the pure formatter. Deliberately placed in the **package** (not app-side like the Kotlin twin) so `swift test` covers it on Linux/CI. **Built + all 294 WhoopProtocol tests pass**, including 5 new ones pinned against the **real 4.0 capture** (98 accepted, mV=3970→3.97 V), the diff, a bare stub, and a 5/MG `UNSUPPORTED(3)` verdict. Output is byte-identical to the Kotlin formatter.
- **App-target wiring** (BLEManager / FrameRouter / LiveState / AppModel / DevicesView) — `swiftc -parse` clean on every file, but the full compile is app-target (not covered by `swift-packages`), so it needs an **`app-build.yml` run** to confirm. Flagged, same as every prior app-target Swift PR.

## Pieces (mirroring the merged Android code)
- **BLEManager** — `probeExtendedBatteryInfo()` with an 8s no-reply timeout (guard-then-set is race-free here: BLE callbacks and the timer both run on the main queue, so no CAS is needed unlike Android's binder-thread case); `clearExtendedBatteryProbe()`; the `frame[6]` (4.0) and `frame[8]==0x24 / frame[10]` (5/MG) COMMAND_RESPONSE dumps; the 5/MG puffin allowlist entry for opcode 98; prev-payload persisted in `UserDefaults` (`noop.592.prevPayload`).
- **LiveState** — `batteryMv` + `extendedBatteryProbe`, both reset on disconnect.
- **FrameRouter** — consumes `battery_mV` → `state.batteryMv` from both the BATTERY_LEVEL event and the command response (the Swift parser already emits `battery_mV`).
- **AppModel** — the two forwarding funcs.
- **DevicesView** — the "Battery-info probe (#592 RE)…" menu item (both families, Test Centre → Connection gated), a read-only confirm dialog, a **copyable result sheet** (selectable monospace text + a `PlatformPasteboard` Copy button + Close), and the `x.xx V` voltage readout beside the battery percent. Design tokens only.

## Parity notes
- Same behaviour, same output text, same 5/MG voltage-guard (no guessed voltage on 5/MG) as the Android formatter.
- One deliberate structural divergence: the pure formatter lives in `WhoopProtocol` (CI-testable) rather than app-side; behaviour parity holds, and it's *better* covered than the Kotlin placement.

Closes the Swift-twin follow-ups noted on #599/#601/#603/#604.