### PR TITLE
app-build: run StrandTests on the macOS Strand leg (app-target test gate)

### DIFF
--- a/.github/workflows/app-build.yml
+++ b/.github/workflows/app-build.yml
@@ -73,6 +73,19 @@ jobs:
           CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO
           build
 
+      # Run the app-target unit tests (StrandTests, wired into the Strand scheme's test action in
+      # project.yml). ONLY the macOS/Strand leg: StrandTests is hosted in the macOS app; the NOOPiOS
+      # leg stays compile-only. Uses a concrete (runnable) macOS destination, not the universal
+      # generic one above. This is what runs the pure app-target logic tests (backfill continuation,
+      # scheduled-report / strain-target policy, etc.) that swift-packages can't reach.
+      - name: Test ${{ matrix.scheme }}
+        if: matrix.scheme == 'Strand'
+        run: >-
+          xcodebuild -scheme Strand -configuration Debug
+          -destination 'platform=macOS'
+          CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO
+          test
+
   # Fork-only housekeeping: on-demand app-build runs are dispatched from disposable `ci/<name>` branches
   # (a PR's content pushed somewhere the workflow can run). Once the build finishes (pass OR fail —
   # always()), delete that branch so GitHub's "Compare & pull request" banner doesn't linger after each


### PR DESCRIPTION
`app-build.yml` was **compile-only** (`xcodebuild … build`), which left a gap: the app-target unit tests in **StrandTests** never ran anywhere. `swift-packages` only covers `Packages/**`, and this workflow only built — so pure app-target logic tests (backfill-continuation predicate #594, scheduled-report / strain-target policy #517/#593, etc.) had been merged **compiled but never executed**.

## Change
Adds a **macOS-only test step** after the build: `xcodebuild -scheme Strand -destination 'platform=macOS' test`. StrandTests is hosted in the macOS app (`project.yml` wires it into the Strand scheme's `test` action), so:
- **Strand (macOS)** leg: builds universal (unchanged) **+ runs StrandTests**.
- **NOOPiOS** leg: stays compile-only (no iOS test target).

Uses a concrete runnable `platform=macOS` destination for `test` (the existing `build` step keeps its universal `generic/platform=macOS` + ARCHS for the x86_64 verify). On-demand only, like the rest of this disabled-by-default workflow.

## Why now
Dispatched on this branch to actually run it — this is the first execution of the app-target test backlog. If green, it clears the long-standing "compiled but never run" caveat on every app-target Swift PR this cycle.