### PR TITLE
app-build: run StrandTests on the macOS Strand leg + fix the flaky test it surfaced

### DIFF
--- a/.github/workflows/app-build.yml
+++ b/.github/workflows/app-build.yml
@@ -73,6 +73,19 @@ jobs:
           CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO
           build
 
+      # Run the app-target unit tests (StrandTests, wired into the Strand scheme's test action in
+      # project.yml). ONLY the macOS/Strand leg: StrandTests is hosted in the macOS app; the NOOPiOS
+      # leg stays compile-only. Uses a concrete (runnable) macOS destination, not the universal
+      # generic one above. This is what runs the pure app-target logic tests (backfill continuation,
+      # scheduled-report / strain-target policy, etc.) that swift-packages can't reach.
+      - name: Test ${{ matrix.scheme }}
+        if: matrix.scheme == 'Strand'
+        run: >-
+          xcodebuild -scheme Strand -configuration Debug
+          -destination 'platform=macOS'
+          CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO
+          test
+
   # Fork-only housekeeping: on-demand app-build runs are dispatched from disposable `ci/<name>` branches
   # (a PR's content pushed somewhere the workflow can run). Once the build finishes (pass OR fail —
   # always()), delete that branch so GitHub's "Compare & pull request" banner doesn't linger after each

--- a/StrandTests/HugeImportFirstPaintStressTests.swift
+++ b/StrandTests/HugeImportFirstPaintStressTests.swift
@@ -103,8 +103,12 @@ final class HugeImportFirstPaintStressTests: XCTestCase {
         repo.setStoreForTesting(store)
         let latest = await repo.latestDataDayStart()
         XCTAssertNotNil(latest, "the latest-data lookup must resolve over a deep history")
-        // It points at today's dense HR day (the only raw stream), not an arbitrary old daily row.
-        let expected = Repository.logicalDayStart(Date(timeIntervalSince1970: TimeInterval(Int(Date().timeIntervalSince1970) - 3_600)))
+        // It points at today's dense HR day (the only raw stream), not an arbitrary old daily row. The
+        // day of the LATEST seeded sample (todayBase+3599 ≈ now), NOT the earliest (todayBase = now−3600):
+        // the seed spans an hour, so using the earliest landed in the PREVIOUS logical day across the 04:00
+        // rollover and flaked this test in the 04:00–05:00 window (only ever surfaced once app-build began
+        // running StrandTests). The latest sample is what MAX(ts) — and latestDataDayStart — resolves to.
+        let expected = Repository.logicalDayStart(Date())
         XCTAssertEqual(latest, expected)
     }
 }


### PR DESCRIPTION
Re-opened from #606 on a non-`ci/` branch (the app-build `cleanup` job auto-deletes `ci/`-prefixed branches, which broke #606's head ref mid-merge).

## Two changes
1. **`app-build.yml`: run StrandTests on the macOS Strand leg.** The workflow was compile-only, so the app-target unit tests in `StrandTests` never ran anywhere (`swift-packages` only covers `Packages/**`). Adds a macOS-only `xcodebuild -scheme Strand -destination 'platform=macOS' test` step; NOOPiOS stays compile-only. On-demand, like the rest of this disabled-by-default workflow.
2. **Fix the flaky test it immediately surfaced.** `HugeImportFirstPaintStressTests.testLatestDataLookupResolvesWithoutLoadingHistory` asserted `latestDataDayStart()` equals the logical day of `now−3600` — but the seed spans `[now−3600, now−1]`, and `now−3600` falls in the PREVIOUS logical day across the 04:00 rollover, so it failed in the 04:00–05:00 window (the run hit 04:49 UTC). `MAX(ts)`/`latestDataDayStart` resolves to the LATEST sample's day (≈now); assert against that. Test-only — the code is correct.

## Verification
Dispatched app-build with the test step: it executed **918 StrandTests, 917 passed + the 1 flaky failure**, then with the fix **all green** (run 29674198115, all legs success). This is the first time the app-target test suite has ever run in CI — it validates the pure app-target logic tests (backfill continuation #594, strain-target policy #597, etc.) that had been merged compiled-but-never-run.