### PR TITLE
Today: debounce the pull-to-sync vessel so per-chunk backfill can't flicker it (#587 follow-up)

### DIFF
--- a/Strand/Liquid/LiquidTodayView.swift
+++ b/Strand/Liquid/LiquidTodayView.swift
@@ -1417,7 +1417,19 @@ private struct LiquidRefreshIndicator: View {
     @EnvironmentObject private var live: LiveState
 
     private var progress: CGFloat { min(1, max(0, pullY / pullThreshold)) }
-    private var syncing: Bool { refreshing || live.backfilling }
+
+    /// The RAW "a sync is happening" signal. `live.backfilling` toggles false→true between EVERY offload
+    /// chunk (`exitBackfilling` at each HISTORY_END → auto-continue re-kick → `beginBackfill`), with a real
+    /// BLE round-trip gap in between. A deep backlog is now up to ~24 chunks in ONE connection (#594 raised
+    /// the auto-continue cap 6→24), so binding the vessel straight to this strobes it in/out on every chunk
+    /// boundary. The MenuBar header pins a constant height for exactly this reason (see MenuBarContent).
+    private var syncingRaw: Bool { refreshing || live.backfilling }
+
+    /// Debounced visibility that drives the body: goes true INSTANTLY, but only goes false after riding out
+    /// [hideDelay] with no new chunk — so a brief per-chunk `backfilling` gap can't flicker the vessel.
+    @State private var syncing = false
+    @State private var hideTask: Task<Void, Never>?
+    private static let hideDelaySeconds: UInt64 = 3   // comfortably longer than an inter-chunk gap
 
     var body: some View {
         ZStack {
@@ -1439,6 +1451,19 @@ private struct LiquidRefreshIndicator: View {
         .frame(maxWidth: .infinity)
         .frame(height: syncing ? 64 : min(pullY, pullThreshold * 1.15))
         .animation(.easeOut(duration: 0.22), value: syncing)
+        .onAppear { syncing = syncingRaw }
+        .onChangeCompat(of: syncingRaw) { raw in
+            hideTask?.cancel()
+            if raw {
+                syncing = true                       // a sync (or pull) is active — show at once
+            } else {
+                // Might just be the gap between two chunks — wait it out; a new chunk cancels this.
+                hideTask = Task { @MainActor in
+                    try? await Task.sleep(nanoseconds: Self.hideDelaySeconds * 1_000_000_000)
+                    if !Task.isCancelled { syncing = false }
+                }
+            }
+        }
     }
 }
 


### PR DESCRIPTION
Follow-up to #590 (which fixed #587 — the pull-to-sync vessel vanishing mid-sync). #590 tied the vessel + "Syncing…" label to `live.backfilling`, which surfaced a flicker the review flagged.

## The flicker
`state.backfilling` **toggles false→true between every offload chunk**: `exitBackfilling()` sets it false at each `HISTORY_END`, then the auto-continue re-kick calls `beginBackfill()` which sets it true again for the next chunk — with a real BLE round-trip gap in between. So binding the vessel straight to `refreshing || live.backfilling` strobes it in/out (64 pt height animation + label blink) on every chunk boundary. This is the **exact per-chunk toggle the MenuBar header already pins a constant height against** (`MenuBarContent.syncLine`), and it's amplified by **#594** (auto-continue cap raised 6→24), which makes a deep backlog drain in up to ~24 chunks in one connection — so up to ~24 flicker cycles.

## The fix
Debounce the visibility. A new `@State private var syncing` drives the body: it goes **true instantly** when `syncingRaw` (`refreshing || live.backfilling`) becomes true, but goes **false only after a 3 s quiet window with no new chunk** — cancelled the moment the next chunk arrives. So the vessel stays steady through a multi-chunk drain and only drops when the sync is genuinely finished (3 s is comfortably longer than an inter-chunk gap). No visible change for a single-chunk sync or the pull-in-progress/idle states.

## Scope
iOS/macOS shared (`Strand/Liquid/LiquidTodayView.swift`), one file, `LiquidRefreshIndicator` only. No BLE/protocol change — same `live.backfilling` read, just debounced. Uses the existing `onChangeCompat` helper (iOS 17 / macOS 14 split).

## Verification
`swiftc -parse` clean; `i18n_audit.py --ci main` exit 0 (reuses the existing "Syncing…" key — no new literal). App-target compile confirmed via an on-demand `app-build` run (see checks).

## Note — the other review item is deliberately NOT here
#590's `|| live.backfilling` also makes the vessel appear for BACKGROUND syncs (periodic/on-connect/auto-continue), not just the user's pull. That's a behavior *decision* (accept "show syncing whenever syncing" vs. gate to pull-initiated), separate from this flicker fix — happy to follow up if you want it gated.