### PR TITLE
Fix three more date-boundary flaky asserts in ReadSpineActiveDeviceTests

### DIFF
--- a/StrandTests/ReadSpineActiveDeviceTests.swift
+++ b/StrandTests/ReadSpineActiveDeviceTests.swift
@@ -42,7 +42,11 @@ final class ReadSpineActiveDeviceTests: XCTestCase {
 
         // Seeded with the canonical id, the latest data is the stale canonical day.
         let staleLatest = await repo.latestDataDayStart()
-        XCTAssertEqual(staleLatest, Repository.logicalDayStart(Date(timeIntervalSince1970: TimeInterval(staleBase))),
+        // Expected day = the LATEST sample's day (base + 299 for a 300-sample seed), which is what
+        // latestDataDayStart (MAX ts) resolves to — NOT the seed's first sample. When a seed spans the
+        // 04:00 logical-day rollover, base and base+299 land on different days, and asserting against the
+        // first sample flaked in that window (only ever surfaced once app-build began running StrandTests).
+        XCTAssertEqual(staleLatest, Repository.logicalDayStart(Date(timeIntervalSince1970: TimeInterval(staleBase + 299))),
                        "before re-point the read model sees only the canonical namespace")
 
         // Re-add → re-point. The active-strap read id now equals the write id.
@@ -52,7 +56,7 @@ final class ReadSpineActiveDeviceTests: XCTestCase {
 
         // The latest data is now TODAY's (union picks the most recent across both ids), not the stale day.
         let freshLatest = await repo.latestDataDayStart()
-        XCTAssertEqual(freshLatest, Repository.logicalDayStart(Date(timeIntervalSince1970: TimeInterval(freshBase))),
+        XCTAssertEqual(freshLatest, Repository.logicalDayStart(Date(timeIntervalSince1970: TimeInterval(freshBase + 299))),  // latest sample's day (MAX ts); see stale note re: 04:00 rollover straddle
                        "after re-point the auto-land reads today's live data under the new id, not the stale day")
         XCTAssertNotEqual(freshLatest, staleLatest, "Today must not snap back to the stale namespace's day")
     }
@@ -161,7 +165,7 @@ final class ReadSpineActiveDeviceTests: XCTestCase {
 
         // (iii) Today does NOT snap to a stale day: the auto-land anchor is the fresh live day.
         let landDay = await repo.latestDataDayStart()
-        XCTAssertEqual(landDay, Repository.logicalDayStart(Date(timeIntervalSince1970: TimeInterval(liveBase))),
+        XCTAssertEqual(landDay, Repository.logicalDayStart(Date(timeIntervalSince1970: TimeInterval(liveBase + 599))),  // 600-sample seed → latest sample = liveBase+599 (MAX ts); avoids the 04:00 straddle flake
                        "Today must anchor on the fresh live day, not a stale imported day")
     }
 


### PR DESCRIPTION
Same class as #607's `HugeImportFirstPaintStressTests` fix, surfaced by the same cause: now that `app-build` runs StrandTests, these latent time-bombs actually execute.

## The bug
`ReadSpineActiveDeviceTests` seeds HR spanning `[base, base+N-1]` and asserts `latestDataDayStart()` equals `logicalDayStart(base)`. But `latestDataDayStart` resolves to **MAX(ts) = base+N-1** (the newest sample), not the first. When a seed straddles the **04:00 logical-day rollover**, `base` and `base+N-1` land on different logical days and the assert fails in that window. This run hit it at **05:57 UTC** (`freshBase = now − 2h = 03:57` → `freshBase+299 = 04:02`), giving `expected 2026-07-18` vs `actual 2026-07-19`.

Three asserts affected (lines 45/55/164). The #607 confirming run at 05:05 UTC happened to miss all three; this 05:57 run caught the fresh one — confirming they're wall-clock-flaky.

## The fix
Assert against the **latest** sample's day, matching what the code returns: `staleBase+299` / `freshBase+299` (300-sample seeds), `liveBase+599` (600-sample seed). Test-only — `latestDataDayStart` correctly returns the newest data's day; the tests were checking the wrong endpoint.

## Verification
`swiftc -parse` clean; dispatched `app-build` (which now runs StrandTests) to confirm the suite is green. Note: the flake is wall-clock-dependent, so a single run can't reproduce the boundary window, but the fix makes `expected` equal `logicalDayStart(MAX ts)` by construction, which is exactly what the read resolves to.