### PR TITLE
i18n audit: guard _argument_span_end against both failure directions (#572)

### DIFF
--- a/Tools/test_i18n_audit.py
+++ b/Tools/test_i18n_audit.py
@@ -79,6 +79,38 @@ class AndroidLiteralExtraction(unittest.TestCase):
         self.assertEqual(literals(text), ['$left more ${if (left == 1) "day" else "days"} to go.'])
 
 
+class ArgumentSpanDetection(unittest.TestCase):
+    """`AndroidLiteralExtraction` above hands `_extract_literals` a span that is
+    already correct, so it never exercises `_argument_span_end` — the function
+    that decides where a `Text(...)` argument actually ends in real source, and
+    the piece most likely to break under future edits (nested bracket balancing
+    plus transparent-vs-opaque brace classification).
+
+    Both tests use a multi-arg call whose first argument has braced branches, so
+    they fail in BOTH directions: stopping one brace early truncates the span
+    mid-conditional, and running past the top-level comma swallows the sibling
+    arguments.
+    """
+
+    # `if (x) { … } else { … }` (not the flat ternary) is deliberate: without a
+    # brace in the argument, an early-stopping regression is invisible.
+    SOURCE = 'Text(if (x) { "Saved" } else { "Save" }, modifier = Modifier.testTag("hrv_row"))'
+
+    def test_span_ends_at_top_level_comma_not_at_a_nested_brace(self):
+        start = self.SOURCE.index("(") + 1
+        end = ia._argument_span_end(self.SOURCE, start)
+        self.assertEqual(self.SOURCE[start:end], 'if (x) { "Saved" } else { "Save" }')
+
+    def test_extraction_over_the_real_span_excludes_sibling_arguments(self):
+        # `hrv_row` is the overrun canary: it is only reachable if the span runs
+        # past the comma. (It could not do this job through `scan_android()` —
+        # `is_probably_ui_text` filters snake_case testTags out again.)
+        start = self.SOURCE.index("(") + 1
+        end = ia._argument_span_end(self.SOURCE, start)
+        found = [lit for _offset, lit in ia._extract_literals(self.SOURCE, start, end)]
+        self.assertEqual(found, ["Saved", "Save"])
+
+
 class MaskComments(unittest.TestCase):
     def test_line_comment_blanked(self):
         text = 'val x = 1 // "Take over this ring?"\nText("Real")'


### PR DESCRIPTION
Closes #572. Test-only; no production code changed, no current defect.

## Confirming the gap first

The issue reports that the extraction tests bypass `_argument_span_end`. I checked that by mutation rather than by reading, breaking the function in each direction the issue names and running the suite:

| Mutation | Caught by |
|---|---|
| stop one brace early (`{` not counted toward depth) | **nobody** — 26/26 green |
| overrun (top-level `,` ignored as a boundary) | **nobody** — 26/26 green |

So the gap is slightly wider than described: the `ScanAndroidEndToEnd` tests do drive the real `scan_android()` path, and `test_nested_composable_slot_not_swept` does call `_argument_span_end` directly — but neither catches either mutation. The direct call asserts an *empty* result, which stays empty whether the span is too short or too long, so it is blind in both directions.

## The tests

A new `ArgumentSpanDetection` class, on a multi-arg call whose first argument has braced branches:

```kotlin
Text(if (x) { "Saved" } else { "Save" }, modifier = Modifier.testTag("hrv_row"))
```

- asserts the exact span text is `if (x) { "Saved" } else { "Save" }`
- asserts extraction over that real span yields exactly `["Saved", "Save"]`

Both fail under both mutations, which is the property that makes them worth adding.

## Two deviations from the fix sketched in the issue

- **Braced branches, not the flat ternary.** `Text(if (x) "a" else "b", …)` pins the overrun direction only — with no brace in the argument, an early-stopping regression is invisible.
- **Asserted against `_argument_span_end` directly, not through `scan_android()`.** The overrun canary has to be a literal that only appears if the span crosses the comma, and a realistic one there is a testTag — which `is_probably_ui_text` filters back out, making the overrun direction untestable end-to-end.

## Verification

`python3 -m unittest test_i18n_audit` — 28 tests, green. Both new tests go red under both mutations above. Pure-Python tooling under `Tools/`; no Swift, Kotlin, schema, or BLE surface touched.

One caveat worth stating: these pin today's behaviour as correct. That is reasonable here — the reporter verified span detection on merged main, and I re-checked the boundary by hand — but it is regression protection, not a proof that the function is right for every Kotlin shape.