### PR TITLE
Today: Steps and Calories tiles get their trend sparkline (#616)

### DIFF
--- a/Strand/Liquid/LiquidTodayView.swift
+++ b/Strand/Liquid/LiquidTodayView.swift
@@ -1072,6 +1072,11 @@ struct LiquidTodayView: View {
             "spo2": sparkRows.compactMap { r in r.spo2Pct.map { (r.day, $0) } },
             "resp_rate": sparkRows.compactMap { r in r.respRateBpm.map { (r.day, $0) } },
             "steps": sparkRows.compactMap { r in r.steps.map { (r.day, Double($0)) } },
+            // #616: the Calories tile (key "energy_kcal") drew no trend line — this dict had no matching
+            // entry, so windowedSpark returned []. Bank the on-device HR-estimate series that the tile's
+            // VALUE already reads (activeKcalEst), so its sparkline matches its number. (Classic TodayView
+            // already sparks calories; this brings Liquid to parity, and mirrors Android's Window.calories.)
+            "energy_kcal": sparkRows.compactMap { r in r.activeKcalEst.map { (r.day, $0) } },
             "steps_est": stepsSeries.filter { $0.day >= sparkCutoff && $0.day <= selectedDayKey }
                 .map { ($0.day, $0.value) },
             "sleep_performance": restSeries.filter { $0.day >= sparkCutoff && $0.day <= selectedDayKey }

--- a/android/app/src/main/java/com/noop/ui/TodayScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/TodayScreen.kt
@@ -4796,6 +4796,7 @@ private fun MetricGrid(
                 unit = "",
                 tint = Palette.metricCyan,
                 frac = steps?.let { (it / 10000.0).coerceIn(0.0, 1.0) },
+                spark = w.steps,   // #616: was missing → no trend line under the tile
             )
         },
         KeyMetric.WEIGHT to run {
@@ -4814,6 +4815,7 @@ private fun MetricGrid(
             unit = if (d?.activeKcalEst != null) "kcal" else "",
             tint = Palette.metricAmber,
             frac = d?.activeKcalEst?.let { (it / 800.0).coerceIn(0.0, 1.0) },
+            spark = w.calories,   // #616: was missing → no trend line under the tile
         ),
     )
 
@@ -6325,6 +6327,12 @@ private data class Window(
     val rhr: List<Double>,
     val spo2: List<Double>,
     val resp: List<Double>,
+    // #616: the Steps and Calories tiles alone carried no `spark` series, so they drew no trend line while
+    // every other tile did. On-device DailyMetric columns (the strap @57 step count / the HR-based
+    // calorie estimate) — the same signals the tiles' VALUES read — matching iOS LiquidTodayView's
+    // kSparks "steps" / "energy_kcal".
+    val steps: List<Double>,
+    val calories: List<Double>,
 )
 
 /**
@@ -6353,6 +6361,8 @@ private fun rememberTrendWindow(
             rhr = series { it.restingHr?.toDouble() },
             spo2 = series { it.spo2Pct },
             resp = series { it.respRateBpm },
+            steps = series { it.steps?.toDouble() },   // #616
+            calories = series { it.activeKcalEst },      // #616
         )
     }
 


### PR DESCRIPTION
Addresses the "no line chart" half of #616 (Android, WHOOP 5.0), and brings iOS to parity.

## The bug
Every Key-Metrics tile draws a 14-day trend line from a per-metric spark series — **except Steps and Calories**, which passed none, so those two tiles alone showed a number with no trend. Confirmed in code:
- **Android**: `KeyTileData` for STEPS (`TodayScreen.kt:4793`) and CALORIES (`:4811`) omitted `spark`; every other tile sets it (`w.hrv`, `w.recovery`, …).
- **iOS**: classic `TodayView` already sparks both; but `LiquidTodayView`'s `kSparks` dict (`:1067`) had no `energy_kcal` entry, so the Calories tile's `ktile(key: "energy_kcal")` got an empty series and drew nothing. (Steps was present.)

## The fix
Give both tiles their spark series, keyed off the **on-device signal the tile's VALUE already reads** (so the line matches the number):
- **Android**: add `steps` (`DailyMetric.steps`) and `calories` (`activeKcalEst`) series to the tile `Window`; pass `spark = w.steps` / `w.calories`.
- **iOS**: add `"energy_kcal"` (from `activeKcalEst`) to `LiquidTodayView.kSparks`.

Both platforms now use the same on-device signals (`steps`, `activeKcalEst`), so the spark sources are byte-identical across Kotlin/Swift. Additive only — no value/precedence change.

## What this deliberately does NOT change (needs a maintainer decision)
The **calorie number inconsistency** in #616 (bug 2) is *not* fixed here. Calories has no unified source precedence:
- Android: tile = on-device `activeKcalEst`, card = imported, detail = imported-only.
- iOS: classic Today = imported, Liquid Today = on-device, and two disjoint detail metrics (`energy_kcal`/my-whoop = on-device-only, `active_kcal`/apple-health = imported-only).

Unifying it changes the prominent displayed number **and** requires structurally aligning iOS's two-metric calorie model with Android's one-metric model to keep the byte-identical parity contract. It's a genuine design call (is the on-device HR estimate or the imported health-platform value authoritative?), so it should be decided before I wire it. Consequence: for a user whose calories come from Health Connect only (like the reporter), the calorie tile spark can still be empty — the full fix is that precedence unification.

## Testing
- Android: `./gradlew :app:compileFullDebugKotlin` ✓, i18n audit ✓ (no new literals).
- iOS/macOS: app-build (Strand + NOOPiOS) — dispatched.
- On-strap/on-device visual check still worthwhile (BLE not involved; this is pure UI-series wiring).