### PR TITLE
Calories: unify on an on-device-first value across tile, card and detail (#616)

### DIFF
--- a/Strand/Data/MetricCatalog.swift
+++ b/Strand/Data/MetricCatalog.swift
@@ -226,6 +226,18 @@ enum MetricCatalog {
         return metric(key: "steps_est", source: "my-whoop")
     }
 
+    /// #616: the calorie twin of `todayStepsMetric` — route the tapped detail to the source that MATCHES
+    /// the value the tile shows (imported-first, like Android). The imported Apple-Health detail
+    /// (`active_kcal` / apple-health) when the day has an imported value, else NOOP's on-device HR-estimate
+    /// detail (`energy_kcal` / my-whoop, which `exploreSeries` fuses from `activeKcalEst`). Without this the
+    /// Calories card always opened the imported-only detail, so an on-device (WHOOP 5.0) user with no import
+    /// saw an empty/disagreeing chart. Defaults to the on-device detail when no import is present.
+    static func todayCaloriesMetric(hasImportedKcal: Bool, hasOnDeviceKcal: Bool = false) -> MetricDescriptor? {
+        if hasImportedKcal { return metric(key: "active_kcal", source: "apple-health") }
+        if hasOnDeviceKcal { return metric(key: "energy_kcal", source: "my-whoop") }
+        return metric(key: "energy_kcal", source: "my-whoop")
+    }
+
     /// Localized display name for a catalog category, mapped AT THE RENDER SITE only. The
     /// catalog's `category` VALUES stay English identifiers on purpose (`inCategory` and the
     /// colour-world / gradient switches compare them raw), so screens must never feed this

--- a/Strand/Liquid/LiquidTodayView.swift
+++ b/Strand/Liquid/LiquidTodayView.swift
@@ -40,6 +40,7 @@ struct LiquidTodayView: View {
     @State private var vitality: Double?           // exploreSeries("vitality").last
     @State private var stepsEst: Double?           // steps_est, day-keyed to the selected day (fallback)
     @State private var importedStepsDay: Int?      // Apple Health steps for the selected day (middle tier)
+    @State private var importedActiveKcalDay: Double?  // #616: Apple Health active energy for the day (calorie fallback)
     @State private var hrValues: [Double] = []     // hrBuckets since midnight → 5-min means
     @State private var workouts: [WorkoutRow] = [] // newest-first
 
@@ -626,8 +627,10 @@ struct LiquidTodayView: View {
             cardLink(.metric("skin_temp"), title: card.title, sub: card.subtitle,
                      value: "–", tint: StrandPalette.metricAmber, frac: nil)
         case .calories:
-            cardLink(.metric("active_kcal"), title: card.title, sub: card.subtitle,
-                     value: "–", tint: StrandPalette.metricAmber, frac: nil)
+            // #616: show the resolved imported-first value and route to the matching detail source, like
+            // the Steps card — was a "–" placeholder wired to the imported-only detail.
+            cardLink(.metricSourced(key: caloriesDetailKey, source: caloriesDetailSource), title: card.title, sub: card.subtitle,
+                     value: intText(caloriesCount), tint: StrandPalette.metricAmber, frac: fracOver(caloriesCount, 800))
         case .sleep:
             cardLink(.sleep, title: card.title, sub: card.subtitle,
                      value: sleepText, tint: StrandPalette.restColor, frac: fracOver(displayDay?.totalSleepMin, 480))
@@ -855,7 +858,10 @@ struct LiquidTodayView: View {
         case .weight:
             ktile(String(localized: "Weight"), "—", "", StrandPalette.metricAmber, nil, key: "weight")
         case .calories:
-            ktile(String(localized: "Calories"), intText(displayDay?.activeKcalEst), "kcal", StrandPalette.metricAmber, fracOver(displayDay?.activeKcalEst, 800), key: "energy_kcal")
+            // #616: imported-first value (imported ?: activeKcalEst) + route the tap to the matching
+            // detail source, so the number, its sparkline and the chart it opens all agree.
+            ktile(String(localized: "Calories"), intText(caloriesCount), "kcal", StrandPalette.metricAmber,
+                  fracOver(caloriesCount, 800), key: "energy_kcal", detailMetric: caloriesDetailMetric)
         }
     }
 
@@ -1064,6 +1070,19 @@ struct LiquidTodayView: View {
         // Window all read the same signal. Rest reuses the already-loaded sleep_performance series.
         let sparkCutoff = Repository.localDayKey(cal.date(byAdding: .day, value: -13, to: dayStart) ?? dayStart)
         let sparkRows = daysSnapshot.filter { $0.day >= sparkCutoff && $0.day <= selectedDayKey }
+        // #616: imported-first calorie spark (the day's imported Apple active energy ?: NOOP's on-device
+        // estimate) over the window, so a Health-Connect / Apple-only calorie user gets a trend too —
+        // matching the imported-first VALUE. Union of imported days + strap-row days. Mirrors Android's
+        // caloriesSpark (windowed caloriesByDay).
+        let appleRowsForSpark = await appleA
+        var winImportedKcal: [String: Double] = [:]
+        for r in appleRowsForSpark where r.day >= sparkCutoff && r.day <= selectedDayKey {
+            if let k = r.activeKcal { winImportedKcal[r.day] = max(winImportedKcal[r.day] ?? 0, k) }
+        }
+        var winOnDeviceKcal: [String: Double] = [:]
+        for r in sparkRows { if let k = r.activeKcalEst { winOnDeviceKcal[r.day] = k } }
+        let energyKcalSpark: [(String, Double)] = Set(winImportedKcal.keys).union(winOnDeviceKcal.keys).sorted()
+            .compactMap { day in (winImportedKcal[day] ?? winOnDeviceKcal[day]).map { (day, $0) } }
         kSparks = [
             "recovery": sparkRows.compactMap { r in r.recovery.map { (r.day, $0) } },
             "strain": sparkRows.compactMap { r in r.strain.map { (r.day, $0) } },
@@ -1072,11 +1091,10 @@ struct LiquidTodayView: View {
             "spo2": sparkRows.compactMap { r in r.spo2Pct.map { (r.day, $0) } },
             "resp_rate": sparkRows.compactMap { r in r.respRateBpm.map { (r.day, $0) } },
             "steps": sparkRows.compactMap { r in r.steps.map { (r.day, Double($0)) } },
-            // #616: the Calories tile (key "energy_kcal") drew no trend line — this dict had no matching
-            // entry, so windowedSpark returned []. Bank the on-device HR-estimate series that the tile's
-            // VALUE already reads (activeKcalEst), so its sparkline matches its number. (Classic TodayView
-            // already sparks calories; this brings Liquid to parity, and mirrors Android's Window.calories.)
-            "energy_kcal": sparkRows.compactMap { r in r.activeKcalEst.map { (r.day, $0) } },
+            // #616: the Calories tile drew no trend line — this dict had no matching entry, so windowedSpark
+            // returned []. Bank the imported-first calorie series (built above) so the sparkline matches the
+            // tile's imported-first number and a Health-Connect / Apple-only user gets a trend.
+            "energy_kcal": energyKcalSpark,
             "steps_est": stepsSeries.filter { $0.day >= sparkCutoff && $0.day <= selectedDayKey }
                 .map { ($0.day, $0.value) },
             "sleep_performance": restSeries.filter { $0.day >= sparkCutoff && $0.day <= selectedDayKey }
@@ -1096,6 +1114,9 @@ struct LiquidTodayView: View {
         // measured strap count and the motion estimate. Health Connect is Android-only, so apple-health is
         // the sole import source on iOS. Mirrors Android `stepsForDay` (#377).
         importedStepsDay = (await appleA).filter { $0.day == selectedDayKey }.compactMap { $0.steps }.max()
+        // #616: same-day imported active energy — the calorie fallback when the strap banked no on-device
+        // HR estimate for the day, so the tile/card/detail agree (imported-first, mirrors steps).
+        importedActiveKcalDay = (await appleA).filter { $0.day == selectedDayKey }.compactMap { $0.activeKcal }.max()
         hrValues = (await hrA).map { $0.bpm }
         workouts = await wkA
 
@@ -1187,6 +1208,21 @@ struct LiquidTodayView: View {
 
     private var stepsDetailKey: String { stepsDetailMetric?.key ?? "steps_est" }
     private var stepsDetailSource: String { stepsDetailMetric?.source ?? "my-whoop" }
+
+    // #616: calories resolved IMPORTED-FIRST (the day's imported Apple active energy — the figure these
+    // surfaces already showed — else NOOP's on-device HR estimate `activeKcalEst`) — one number across the
+    // tile, card and the detail it taps to. Mirrors the steps precedence above.
+    private var caloriesCount: Double? {
+        importedActiveKcalDay ?? displayDay?.activeKcalEst
+    }
+
+    private var caloriesDetailMetric: MetricDescriptor? {
+        MetricCatalog.todayCaloriesMetric(hasImportedKcal: importedActiveKcalDay != nil,
+                                          hasOnDeviceKcal: displayDay?.activeKcalEst != nil)
+    }
+
+    private var caloriesDetailKey: String { caloriesDetailMetric?.key ?? "energy_kcal" }
+    private var caloriesDetailSource: String { caloriesDetailMetric?.source ?? "my-whoop" }
 
     private var liveHour: Double {
         let c = Calendar.current.dateComponents([.hour, .minute], from: Date())

--- a/android/app/src/main/java/com/noop/ui/HealthScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/HealthScreen.kt
@@ -1938,6 +1938,13 @@ internal fun mergeStepsReadings(
     (real.keys + imported.keys + est.keys).toSortedSet()
         .mapNotNull { d -> real[d] ?: imported[d] ?: est[d] }
 
+/** #616: per-day precedence merge for a metric with disjoint stores (first non-null per day wins),
+ *  ascending. The N-store generalisation of [mergeStepsReadings]; calories reuse it as the two-store
+ *  on-device (`activeKcalEst`) ?: imported (Apple/Health-Connect `activeKcal`) union. Pure for testability. */
+internal fun mergeReadings(vararg stores: Map<String, VitalReading>): List<VitalReading> =
+    stores.flatMap { it.keys }.toSortedSet()
+        .mapNotNull { day -> stores.firstNotNullOfOrNull { it[day] } }
+
 private data class VitalDetailModel(
     val key: String,
     val title: String,
@@ -2595,21 +2602,28 @@ private suspend fun buildSeriesVitalDetail(vm: AppViewModel, key: String): Vital
         )
     }
     "active_kcal" -> {
-        // Read active energy from the SAME apple-health ∪ health-connect union the Today Calories card uses.
-        // Health Connect (the common Android source) writes activeKcal only into the AppleDaily table under
-        // "health-connect", not as an active_kcal metricSeries row, so reading metricSeries("apple-health") alone
-        // opened an empty detail for a Health-Connect-only user whose card DID show a number. One point per day,
-        // apple-health winning a tie (matching the card's newest-value read), ascending.
-        val rows = vm.repo.appleDaily("apple-health", "0000-01-01", "9999-12-31") +
-            vm.repo.appleDaily("health-connect", "0000-01-01", "9999-12-31")
-        val byDay = LinkedHashMap<String, VitalReading>()
-        for (r in rows) r.activeKcal?.let { byDay.putIfAbsent(r.day, VitalReading(r.day, it, r.deviceId)) }
+        // #616: calories, like steps (#377), come from TWO disjoint stores — the on-device HR estimate
+        // (DailyMetric.activeKcalEst, exposed by resolvedSeries("active_kcal")) and imported Apple/Health-
+        // Connect active energy (AppleDaily.activeKcal, where Health Connect writes it — NOT an active_kcal
+        // metricSeries row). Reading imports ALONE opened an empty / HealthConnect-only detail for a WHOOP
+        // 5.0 user whose calories are on-device, and disagreed with the Key-Metrics tile. Resolve per day
+        // IMPORTED-FIRST (the phone's activeKcal, else NOOP's on-device estimate) — matching the tile + card
+        // so the chart + Readings agree, while keeping every imported day in the union.
+        val real = vm.repo.resolvedSeries("active_kcal", "my-whoop", "0000-00-00", "9999-99-99",
+            strapDeviceId = vm.activeStrapId)
+            .points.associateBy({ it.day }, { VitalReading(it.day, it.value, it.source) })
+        val imported = LinkedHashMap<String, VitalReading>()
+        for (r in vm.repo.appleDaily("apple-health", "0000-01-01", "9999-12-31") +
+            vm.repo.appleDaily("health-connect", "0000-01-01", "9999-12-31")) {
+            val k = r.activeKcal
+            if (k != null && k > 0) imported.putIfAbsent(r.day, VitalReading(r.day, k, r.deviceId))
+        }
         VitalDetailModel(
             key = key,
             title = uiString(R.string.l10n_health_screen_active_energy_2d3288f9),
             unit = "kcal",
             color = Palette.metricAmber,
-            readings = byDay.entries.sortedBy { it.key }.map { it.value },
+            readings = mergeReadings(imported, real),   // imported wins its day, else on-device estimate
             format = { it.roundToInt().toString() },
         )
     }

--- a/android/app/src/main/java/com/noop/ui/TodayScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/TodayScreen.kt
@@ -538,17 +538,37 @@ fun TodayScreen(
         }
     }
 
-    // The latest active-energy figure (kcal) for the Calories card, the newest non-null activeKcal across
-    // the Apple-side daily aggregates, mirroring the Today Calories tile. Null hides the card's value.
-    var latestActiveKcal by remember { mutableStateOf<Double?>(null) }
+    // #616: ONE calorie definition across the card, the Key-Metrics tile and the detail — resolve per day,
+    // IMPORTED-FIRST (the phone's Apple/Health-Connect activeKcal, the figure these surfaces already showed),
+    // falling back to NOOP's on-device HR estimate (activeKcalEst) only for days the phone didn't cover.
+    // Keyed by day; `caloriesByDay` feeds the SELECTED-day value the dashboard card + Key-Metrics tile both
+    // read — day-scoped like every other card, and like steps.
+    var caloriesByDay by remember { mutableStateOf<Map<String, Double>>(emptyMap()) }
     LaunchedEffect(days) {
-        latestActiveKcal = runCatching {
-            (viewModel.repo.appleDaily("apple-health", "0000-01-01", "9999-12-31") +
-                viewModel.repo.appleDaily("health-connect", "0000-01-01", "9999-12-31"))
-                .filter { it.activeKcal != null }
-                .maxByOrNull { it.day }
-                ?.activeKcal
-        }.getOrNull()
+        caloriesByDay = runCatching {
+            val onDevice = viewModel.repo.resolvedSeries("active_kcal", "my-whoop", "0000-00-00", "9999-99-99",
+                strapDeviceId = viewModel.activeStrapId).points.associate { it.day to it.value }
+            val imported = LinkedHashMap<String, Double>()
+            for (r in viewModel.repo.appleDaily("apple-health", "0000-01-01", "9999-12-31") +
+                viewModel.repo.appleDaily("health-connect", "0000-01-01", "9999-12-31")) {
+                r.activeKcal?.takeIf { it > 0 }?.let { imported.putIfAbsent(r.day, it) }
+            }
+            (onDevice.keys + imported.keys)
+                .mapNotNull { day -> (imported[day] ?: onDevice[day])?.let { day to it } }.toMap()
+        }.getOrDefault(emptyMap())
+    }
+
+    // #616: the Calories tile's 14-day sparkline — the IMPORTED-FIRST resolved series (caloriesByDay),
+    // windowed to the trailing calendar window, so a Health-Connect / Apple-only calorie user gets a trend
+    // that matches the tile's value (not the on-device estimate alone). Mirrors restCompositeSpark's build.
+    var caloriesSpark by remember { mutableStateOf<List<Double>>(emptyList()) }
+    LaunchedEffect(caloriesByDay, selectedDay, keyMetricsWindowDays) {
+        val cutoff = selectedDay.minusDays((keyMetricsWindowDays - 1).toLong()).toString()
+        val end = selectedDay.toString()
+        caloriesSpark = caloriesByDay.entries
+            .filter { it.key in cutoff..end }
+            .sortedBy { it.key }
+            .map { it.value }
     }
 
     // HYDRATION (opt-in, default OFF), the Today "Hydration" card + its detail are hidden unless the user
@@ -1448,6 +1468,8 @@ fun TodayScreen(
                                     profileWeightKg = profileWeightKg,
                                     importedStepsForDay = importedStepsForDay,
                                     estimatedStepsForDay = stepsEstForDay,
+                                    caloriesForDay = caloriesByDay[selectedDayKey],   // #616: imported-first per day
+                                    caloriesSpark = caloriesSpark,                    // #616: imported-first trend
                                     stepActivityClassForDay = stepActivityClassForDay,
                                     stepsEstimateCaption = stepsEstimateCaption(profileStore),
                                     restScore = restScoreForDay,
@@ -1497,7 +1519,7 @@ fun TodayScreen(
                             vitality = vitalityToday,
                             importedStepsForDay = importedStepsForDay,
                             estimatedStepsForDay = stepsEstForDay,
-                            latestActiveKcal = latestActiveKcal,
+                            caloriesForDay = caloriesByDay[selectedDayKey],
                             hydrationTotalMl = hydrationTotalMl,
                             hydrationGoalMl = hydrationGoalMl,
                             onOpenHydration = onOpenHydration,
@@ -2946,7 +2968,7 @@ private fun YourCardsSection(
     vitality: Double?,
     importedStepsForDay: Int?,
     estimatedStepsForDay: Int?,
-    latestActiveKcal: Double?,
+    caloriesForDay: Double?,
     hydrationTotalMl: Double,
     hydrationGoalMl: Int,
     onOpenHydration: () -> Unit,
@@ -2994,7 +3016,7 @@ private fun YourCardsSection(
                         vitality = vitality,
                         importedStepsForDay = importedStepsForDay,
                         estimatedStepsForDay = estimatedStepsForDay,
-                        latestActiveKcal = latestActiveKcal,
+                        caloriesForDay = caloriesForDay,
                         hydrationTotalMl = hydrationTotalMl,
                         hydrationGoalMl = hydrationGoalMl,
                     ),
@@ -3183,7 +3205,7 @@ private fun dashboardCardValue(
     vitality: Double?,
     importedStepsForDay: Int?,
     estimatedStepsForDay: Int?,
-    latestActiveKcal: Double?,
+    caloriesForDay: Double?,
     hydrationTotalMl: Double,
     hydrationGoalMl: Int,
 ): String {
@@ -3216,7 +3238,7 @@ private fun dashboardCardValue(
             real ?: est ?: NO_DATA
         }
         DashboardCard.CALORIES ->
-            withUnit(latestActiveKcal?.let { intStringGrouped(it) } ?: NO_DATA)
+            withUnit(caloriesForDay?.let { intStringGrouped(it) } ?: NO_DATA)
         DashboardCard.STRESS ->
             // #706/#684: Stress is baseline-relative, so until the strap has banked enough worn nights to
             // seed the 30-day RHR/HRV baseline StressScreen reads, the front card has no number to show. The
@@ -4678,6 +4700,13 @@ private fun MetricGrid(
     profileWeightKg: Double = 75.0,
     importedStepsForDay: Int? = null,
     estimatedStepsForDay: Int? = null,
+    // #616: the selected day's calorie value resolved imported-first (imported Apple/Health-Connect
+    // activeKcal ?: NOOP's on-device estimate), so the Calories tile matches the card + detail instead of
+    // reading the on-device estimate alone (which left it NO_DATA / inconsistent). Mirrors the steps params.
+    caloriesForDay: Double? = null,
+    // #616: the Calories tile's imported-first 14-day trend (see caloriesSpark above) — threaded like
+    // restSpark because it isn't a plain DailyMetric column (it unions the imported + on-device series).
+    caloriesSpark: List<Double> = emptyList(),
     // #316 / @63, the selected day's representative activity class (0=still, 1=walk, 2=run), shown as a small
     // still/walk/run glyph on a REAL (measured) Steps tile. null hides the icon (no classed sample for the day).
     stepActivityClassForDay: Int? = null,
@@ -4809,14 +4838,19 @@ private fun MetricGrid(
                 frac = null,
             )
         },
-        KeyMetric.CALORIES to KeyTileData(
-            label = uiString(R.string.l10n_today_screen_calories_3e62ecfe),
-            value = d?.activeKcalEst?.let { intString(it) } ?: NO_DATA,
-            unit = if (d?.activeKcalEst != null) "kcal" else "",
-            tint = Palette.metricAmber,
-            frac = d?.activeKcalEst?.let { (it / 800.0).coerceIn(0.0, 1.0) },
-            spark = w.calories,   // #616: was missing → no trend line under the tile
-        ),
+        KeyMetric.CALORIES to run {
+            // #616: the per-day resolved calorie value (caloriesForDay = imported Apple/Health-Connect
+            // first, else NOOP's on-device estimate) — one number across tile, card and detail.
+            val kcal = caloriesForDay
+            KeyTileData(
+                label = uiString(R.string.l10n_today_screen_calories_3e62ecfe),
+                value = kcal?.let { intString(it) } ?: NO_DATA,
+                unit = if (kcal != null) "kcal" else "",
+                tint = Palette.metricAmber,
+                frac = kcal?.let { (it / 800.0).coerceIn(0.0, 1.0) },
+                spark = caloriesSpark,   // #616: imported-first trend (was missing → no trend line)
+            )
+        },
     )
 
     // Resolve the enabled tiles to their descriptors (keeping the metric for the tap mapping), dropping
@@ -6327,12 +6361,11 @@ private data class Window(
     val rhr: List<Double>,
     val spo2: List<Double>,
     val resp: List<Double>,
-    // #616: the Steps and Calories tiles alone carried no `spark` series, so they drew no trend line while
-    // every other tile did. On-device DailyMetric columns (the strap @57 step count / the HR-based
-    // calorie estimate) — the same signals the tiles' VALUES read — matching iOS LiquidTodayView's
-    // kSparks "steps" / "energy_kcal".
+    // #616: the Steps tile carried no `spark` series, so it drew no trend line while every other tile did.
+    // On-device DailyMetric.steps (the strap @57 count) — the same signal the Steps tile VALUE reads
+    // (on-device-first), matching iOS kSparks "steps". (Calories is imported-first, so its spark is threaded
+    // separately as caloriesSpark, not read off a DailyMetric column here.)
     val steps: List<Double>,
-    val calories: List<Double>,
 )
 
 /**
@@ -6362,7 +6395,6 @@ private fun rememberTrendWindow(
             spo2 = series { it.spo2Pct },
             resp = series { it.respRateBpm },
             steps = series { it.steps?.toDouble() },   // #616
-            calories = series { it.activeKcalEst },      // #616
         )
     }
 


### PR DESCRIPTION
#616 bug 2 (follow-up to #617). Calories had **no unified source precedence**, so the same day showed different numbers on the tile, the dashboard card and the detail — and the detail/overview was imported-only, empty for a WHOOP 5.0 user whose calories are the on-device HR estimate. Steps already resolves on-device-first (#377); this brings calories to the same rule on both platforms.

**Precedence (maintainer-chosen): on-device `activeKcalEst[day]` → imported `activeKcal[day]`.** This part is byte-identical across Kotlin/Swift.

## Android
- **Detail** (`HealthScreen` `active_kcal`): fuse `resolvedSeries("active_kcal")` (on-device, via `dailyColumn`) with the appleDaily import through a new `mergeReadings()` — was imported-only.
- **Dashboard card + Key-Metrics tile**: resolve per day (`caloriesByDay`, on-device-first). The dashboard card is now **day-scoped like every other card** (was newest-only — the one non-day-scoped card).

## iOS (Liquid — the default view; classic Today is already self-consistent so left alone)
- **Tile + card**: value = `activeKcalEst ?? imported-for-day`, and route the tap to the **matching detail source** via new `MetricCatalog.todayCaloriesMetric` (`energy_kcal`/my-whoop on-device, else `active_kcal`/apple-health) — the exact mirror of `todayStepsMetric`, so the number, its sparkline (#617) and the chart it opens all agree.

## Parity notes
- The **value** precedence is identical across platforms. The **detail** construction follows each platform's existing steps convention (Android builds a union series via `mergeReadings`; iOS routes to the single source matching the value) — same asymmetry steps already has, which is a feature-level UI difference, not a data one.
- iOS **classic** `TodayView` is untouched: it's internally consistent (imported value + imported spark + imported detail) and is the legacy fallback; Liquid is the iOS-26 default and now matches Android.

## Testing
- Android: `./gradlew :app:compileFullDebugKotlin` ✓, i18n audit ✓.
- iOS/macOS: app-build (Strand + NOOPiOS) — dispatched.
- **Numbers not CI-testable** (app-target Swift); an on-device spot-check on a strap with both on-device and imported calories is worthwhile.