### PR TITLE
Coupled view: count real workouts, not exerciseCount (#614)

### DIFF
--- a/Strand/Screens/CoupledView.swift
+++ b/Strand/Screens/CoupledView.swift
@@ -46,6 +46,11 @@ struct CoupledView: View {
     /// the cold-start threshold, which keeps the broad overnight-band bonus.
     @State private var habitualMidsleepSec: Int? = nil
 
+    /// #614: TODAY's workout count from the SAME deduped/dismissed-filtered list the Workouts screen shows
+    /// (`repo.workoutRows`), not `DailyMetric.exerciseCount` (strap-DETECTED only — a Health-Connect import
+    /// with auto-detect off read as 0 while the Workouts screen showed it). Loaded in `.task`.
+    @State private var workoutsToday: Int = 0
+
     /// The day the coupled read describes, today's resolved row (the same `resolveToday` #304/#144 boundary
     /// Today anchors on), never a second store read.
     private var day: DailyMetric? { repo.today }
@@ -143,6 +148,14 @@ struct CoupledView: View {
         // bed→wake span below resolves identically (#294). Re-runs on a sync/import refresh.
         .task(id: repo.refreshSeq) {
             habitualMidsleepSec = await repo.habitualMidsleepSec()
+            // #614: count TODAY's workouts by their START's logical day (the SAME 04:00-rollover key
+            // DailyMetric.day uses), so the Coupled stat equals the Workouts overview for today.
+            let key = todayKey
+            // A short window is enough to count today's rows (the cross-source dedup is local to the set),
+            // and avoids loading the full history just for one number.
+            workoutsToday = await repo.workoutRows(days: 2).filter {
+                Repository.logicalDayKey(Date(timeIntervalSince1970: TimeInterval($0.startTs))) == key
+            }.count
         }
     }
 
@@ -315,7 +328,7 @@ struct CoupledView: View {
                                  caloriesText,
                                  tint: StrandPalette.metricAmber)
                         heroStat(String(localized: "Workouts"),
-                                 (day?.exerciseCount).map { "\($0)" } ?? "0",
+                                 "\(workoutsToday)",   // #614: real workout count (all sources), not exerciseCount
                                  tint: StrandPalette.textPrimary)
                     }
                     .frame(maxWidth: .infinity, alignment: .leading)

--- a/android/app/src/main/java/com/noop/ui/CoupledScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/CoupledScreen.kt
@@ -91,6 +91,14 @@ fun CoupledScreen(
     val today by vm.today.collectAsStateWithLifecycle()
     val days by vm.recentDays.collectAsStateWithLifecycle()
 
+    // #614: the Workouts stat must match the Workouts screen, not DailyMetric.exerciseCount (which counts
+    // only strap-DETECTED bouts — a Health-Connect import with auto-detect off read as 0 while the Workouts
+    // screen showed it). vm.workouts is the SAME deduped, dismissed-filtered, all-source list the Workouts
+    // screen renders; loadWorkouts() isn't triggered by opening Coupled, so kick it here (idempotent,
+    // mirrors InsightsScreen).
+    LaunchedEffect(Unit) { vm.loadWorkouts() }
+    val allWorkouts by vm.workouts.collectAsStateWithLifecycle()
+
     // Last night's sleep sessions (imported + computed-only), the SAME resolution SleepScreen uses, keyed on
     // `days` so a sync/import reloads. Only needed for the bed-wake span footnote.
     var sleeps by remember { mutableStateOf<List<SleepSession>>(emptyList()) }
@@ -131,6 +139,14 @@ fun CoupledScreen(
         resolveTodayRow(days, logicalKey, localKey) ?: today
     }
     val todayKey = todayRow?.day ?: logicalKey
+    // #614: count TODAY's workouts by their START's logical day (the SAME 04:00-rollover key DailyMetric.day
+    // uses), so the Coupled stat equals the Workouts overview for today.
+    val workoutsToday = remember(allWorkouts, todayKey) {
+        allWorkouts.count {
+            logicalDay(java.time.Instant.ofEpochSecond(it.startTs).atZone(java.time.ZoneId.systemDefault()))
+                .toString() == todayKey
+        }
+    }
     val carriedRecoveryDay = remember(days, todayKey) {
         days.lastOrNull { it.recovery != null && it.day < todayKey }
     }
@@ -203,7 +219,7 @@ fun CoupledScreen(
             dayStrain21 = dayStrain21,
             recovery = recovery,
             calories = todayRow?.activeKcalEst,
-            workouts = todayRow?.exerciseCount ?: 0,
+            workouts = workoutsToday,   // #614: real workout count (all sources), not exerciseCount
         )
         SleepCard(
             sleepPerformance = sleepPerformance,


### PR DESCRIPTION
Fixes #614 (WHOOP 5.0, Android — but the bug is cross-platform).

## Root cause
The Coupled view's **Workouts** stat read `DailyMetric.exerciseCount`:
- Android `CoupledScreen.kt`, iOS `CoupledView.swift`.

`exerciseCount` counts only strap-**detected** bouts (`AnalyticsEngine` sets it to `workouts.size`). With **auto-detection off** and the workout **imported from Health Connect**, that's `0` — and the daily merge (`exerciseCount = d.exerciseCount ?: c.exerciseCount`, `WhoopRepository:1815`) lets a strap-computed **non-null `0` shadow** the imported `1`. The **Workouts screen** counts the actual `WorkoutRow` list from every source, so it showed `1`. The two disagreed — exactly the report.

## Fix
Count **today's** workouts from the *same* deduped, dismissed-filtered, cross-source-collapsed list the Workouts screen renders:
- **Android:** `vm.workouts` (kick `loadWorkouts()` on open — Coupled didn't trigger it), counting rows whose START maps to today's logical day.
- **iOS:** `repo.workoutRows(days: 2)`, same logical-day filter.

Keyed by each workout's **start logical day** (the 04:00-rollover key `DailyMetric.day` uses), so the stat equals the Workouts overview for today — including the dedup so a detected-and-imported ride isn't double-counted (the reporter's stated expectation).

## Notes
- **Not this PR:** the same card's *calorie* stat still reads the on-device estimate (`activeKcalEst`) rather than #618's imported-first resolution — a separate #616 follow-up, left out to keep this one concern.
- Testing: Android `compileFullDebugKotlin` + i18n audit pass; iOS compile dispatched. The count itself isn't CI-testable (app-target) — worth an on-device check.