### PR TITLE
Surface "no new nights for N days" on the calibrating Charge card (#612)

### DIFF
--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/Baselines.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/Baselines.swift
@@ -187,6 +187,36 @@ public enum Baselines {
         return .trusted
     }
 
+    /// #612: calendar days since the newest night that carried a usable HRV reading (the baseline's input),
+    /// or nil when there is none / a key can't be parsed. This is DISTINCT from `calibrationNights` (which
+    /// counts progress TOWARD a usable baseline) — it measures staleness, so a surface can say "no new nights
+    /// from your strap for N days" when the baseline aged out silently instead of only "building your
+    /// baseline". Pure and TZ-free (civil-day arithmetic); mirror EXACTLY in the Kotlin twin.
+    /// `dayKeys`/`nightlyHrv` are parallel (same night per index); `today` is an ISO `yyyy-MM-dd` key.
+    public static func nightsSinceNewestValidNight(dayKeys: [String], nightlyHrv: [Double?], today: String) -> Int? {
+        var newest: String? = nil
+        for i in 0..<Swift.min(dayKeys.count, nightlyHrv.count) where nightlyHrv[i] != nil {
+            let k = dayKeys[i]
+            if newest == nil || k > newest! { newest = k }
+        }
+        guard let n = newest, let a = isoEpochDay(n), let b = isoEpochDay(today) else { return nil }
+        let d = b - a
+        return d >= 0 ? d : nil
+    }
+
+    /// Days from civil epoch (proleptic Gregorian) for an ISO `yyyy-MM-dd`, or nil if unparseable. TZ-free
+    /// (Howard Hinnant's algorithm), so Swift and Kotlin agree bit-for-bit on the day difference.
+    static func isoEpochDay(_ iso: String) -> Int? {
+        let p = iso.split(separator: "-")
+        guard p.count == 3, let y = Int(p[0]), let m = Int(p[1]), let d = Int(p[2]), m >= 1, m <= 12 else { return nil }
+        let yy = m <= 2 ? y - 1 : y
+        let era = (yy >= 0 ? yy : yy - 399) / 400
+        let yoe = yy - era * 400
+        let doy = (153 * (m > 2 ? m - 3 : m + 9) + 2) / 5 + d - 1
+        let doe = yoe * 365 + yoe / 4 - yoe / 100 + doy
+        return era * 146097 + doe - 719468
+    }
+
     // MARK: - Winsorized EWMA update (production model)
 
     /// Incorporate one new nightly value into the baseline state.

--- a/Strand/Liquid/LiquidTodayView.swift
+++ b/Strand/Liquid/LiquidTodayView.swift
@@ -1179,6 +1179,16 @@ struct LiquidTodayView: View {
     }
 
     private var synthLine: String {
+        // #612: when still calibrating BECAUSE the strap stopped delivering nights (connected, but no new
+        // night for > staleDays), say so directly instead of "still learning your baseline" — the honest
+        // calibrating state with its reason attached. `stale` is always > staleDays (14), so always plural.
+        if readiness.level == .insufficient,
+           let stale = Baselines.nightsSinceNewestValidNight(dayKeys: repo.days.map(\.day),
+                                                             nightlyHrv: repo.days.map(\.avgHrv),
+                                                             today: Repository.logicalDayKey(Date())),
+           stale > Baselines.staleDays {
+            return String(localized: "No new nights from your strap for \(stale) days. Check it's connected and saving data.")
+        }
         switch readiness.level {
         case .primed: return String(localized: "You're primed. A hard session should land well today.")
         case .balanced: return String(localized: "You're in a good spot for training.")

--- a/Strand/Screens/TodayView.swift
+++ b/Strand/Screens/TodayView.swift
@@ -939,6 +939,15 @@ struct TodayView: View {
     }
     private var calibrationDetail: LocalizedStringKey? {
         guard let n = recoveryCalibration else { return nil }
+        // #612: if the baseline aged out silently — connected, but no new night for > staleDays — say WHY
+        // it's calibrating instead of only "learning your baseline". The honest calibrating state is correct;
+        // this attaches its reason. `stale` is always > staleDays (14) here, so the copy is always plural.
+        if let stale = Baselines.nightsSinceNewestValidNight(dayKeys: repo.days.map(\.day),
+                                                             nightlyHrv: repo.days.map(\.avgHrv),
+                                                             today: Repository.logicalDayKey(Date())),
+           stale > Baselines.staleDays {
+            return "No new nights from your strap for \(stale) days. Check it's connected and saving data."
+        }
         return "Learning your baseline, \(n) of \(Baselines.minNightsSeed) nights."
     }
 

--- a/android/app/src/main/java/com/noop/analytics/Baselines.kt
+++ b/android/app/src/main/java/com/noop/analytics/Baselines.kt
@@ -149,6 +149,43 @@ object Baselines {
         return BaselineStatus.TRUSTED
     }
 
+    /** #612: calendar days since the newest night that carried a usable HRV reading (the baseline's input),
+     *  or null when there is none / a key can't be parsed. DISTINCT from `calibrationNights` (which counts
+     *  progress TOWARD a usable baseline) — this measures staleness, so a surface can say "no new nights from
+     *  your strap for N days" when the baseline aged out silently instead of only "building your baseline".
+     *  Pure and TZ-free (civil-day arithmetic); byte-identical mirror of the Swift twin. `dayKeys`/`nightlyHrv`
+     *  are parallel (same night per index); `today` is an ISO `yyyy-MM-dd` key. */
+    fun nightsSinceNewestValidNight(dayKeys: List<String>, nightlyHrv: List<Double?>, today: String): Int? {
+        var newest: String? = null
+        for (i in 0 until minOf(dayKeys.size, nightlyHrv.size)) {
+            if (nightlyHrv[i] == null) continue
+            val k = dayKeys[i]
+            if (newest == null || k > newest!!) newest = k
+        }
+        val n = newest ?: return null
+        val a = isoEpochDay(n) ?: return null
+        val b = isoEpochDay(today) ?: return null
+        val d = b - a
+        return if (d >= 0) d else null
+    }
+
+    /** Days from civil epoch (proleptic Gregorian) for an ISO `yyyy-MM-dd`, or null if unparseable. TZ-free
+     *  (Howard Hinnant's algorithm), so Kotlin and Swift agree bit-for-bit on the day difference. */
+    internal fun isoEpochDay(iso: String): Int? {
+        val p = iso.split("-")
+        if (p.size != 3) return null
+        val y = p[0].toIntOrNull() ?: return null
+        val m = p[1].toIntOrNull() ?: return null
+        val d = p[2].toIntOrNull() ?: return null
+        if (m < 1 || m > 12) return null
+        val yy = if (m <= 2) y - 1 else y
+        val era = (if (yy >= 0) yy else yy - 399) / 400
+        val yoe = yy - era * 400
+        val doy = (153 * (if (m > 2) m - 3 else m + 9) + 2) / 5 + d - 1
+        val doe = yoe * 365 + yoe / 4 - yoe / 100 + doy
+        return era * 146097 + doe - 719468
+    }
+
     // ─────────────────────────────────────────────────────────────────────────
     // Winsorized EWMA update (production model)
     // ─────────────────────────────────────────────────────────────────────────

--- a/android/app/src/main/java/com/noop/ui/TodayScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/TodayScreen.kt
@@ -2714,9 +2714,16 @@ private fun SynthesisHeroCard(
         // the SAME in both states, only the detail body and chrome fold, never the read (#506).
         val status = if (recoveryCalibration != null) "Calibrating" else synthesisWord(recovery)
         val detail = if (recoveryCalibration != null) {
-            // Comma (not the old em-dash) to match the Swift canonical synthesis copy VERBATIM
-            // (TodayView "Learning your baseline, N of M nights.") and the no-em-dash standing rule.
-            "Learning your baseline, $recoveryCalibration of ${Baselines.minNightsSeed} nights."
+            // #612: if the baseline aged out silently — connected, but no new night for > staleDays — say WHY
+            // it's calibrating instead of only "learning your baseline". `stale` is always > staleDays (14).
+            val stale = Baselines.nightsSinceNewestValidNight(days.map { it.day }, days.map { it.avgHrv }, logicalDayKeyNow())
+            if (stale != null && stale > Baselines.staleDays) {
+                uiString(R.string.l10n_today_screen_no_new_nights_from_your_strap_for_stale_days_8863bcfe, stale)
+            } else {
+                // Comma (not the old em-dash) to match the Swift canonical synthesis copy VERBATIM
+                // (TodayView "Learning your baseline, N of M nights.") and the no-em-dash standing rule.
+                "Learning your baseline, $recoveryCalibration of ${Baselines.minNightsSeed} nights."
+            }
         } else if (carriedDay != null) {
             // Carried prior-day read, summarise that day + stamp it so it isn't passed off as today's.
             synthesisDetail(carriedDay) + " ${carriedCaption(carriedDay.day)}."

--- a/android/app/src/main/res/values-de/strings.xml
+++ b/android/app/src/main/res/values-de/strings.xml
@@ -865,6 +865,7 @@
     <string name="l10n_time_of_day_background_atmospherephase_5ce21300">AtmosphärePhase</string>
     <string name="l10n_today_screen_arrange_today_6b699147">Heute vereinbaren</string>
     <string name="l10n_today_screen_calibrating_37c2c9bd">Kalibrierung</string>
+    <string name="l10n_today_screen_no_new_nights_from_your_strap_for_stale_days_8863bcfe">Seit %1$d Tagen keine neuen Nächte von deinem Strap. Prüfe, ob er verbunden ist und Daten speichert.</string>
     <string name="l10n_today_screen_calibratingnights_of_baselines_minnightsseed_3b76e55c">%1$s von %2$s</string>
     <string name="l10n_today_screen_choose_which_cards_show_on_today_f79942e1">Wählen Sie, welche Karten auf Heute angezeigt werden, und ordnen Sie sie mit den Pfeilen neu an.</string>
     <string name="l10n_today_screen_close_bbfa773e">Schließen</string>

--- a/android/app/src/main/res/values-es/strings.xml
+++ b/android/app/src/main/res/values-es/strings.xml
@@ -705,6 +705,7 @@
     <string name="l10n_time_of_day_background_atmospherephase_5ce21300">atmósferaPhase</string>
     <string name="l10n_today_screen_arrange_today_6b699147">Arregla hoy</string>
     <string name="l10n_today_screen_calibrating_37c2c9bd">Calibrando</string>
+    <string name="l10n_today_screen_no_new_nights_from_your_strap_for_stale_days_8863bcfe">Sin nuevas noches de tu strap desde hace %1$d días. Comprueba que esté conectado y guardando datos.</string>
     <string name="l10n_today_screen_calibratingnights_of_baselines_minnightsseed_3b76e55c">%1$s de %2$s</string>
     <string name="l10n_today_screen_choose_which_cards_show_on_today_f79942e1">Elija qué tarjetas muestran en Hoy y reordenarlos con las flechas.</string>
     <string name="l10n_today_screen_close_bbfa773e">Cerrar</string>

--- a/android/app/src/main/res/values-fr/strings.xml
+++ b/android/app/src/main/res/values-fr/strings.xml
@@ -705,6 +705,7 @@
     <string name="l10n_time_of_day_background_atmospherephase_5ce21300">atmosphèrePhase</string>
     <string name="l10n_today_screen_arrange_today_6b699147">Arrange aujourd\'hui</string>
     <string name="l10n_today_screen_calibrating_37c2c9bd">Calibration en cours</string>
+    <string name="l10n_today_screen_no_new_nights_from_your_strap_for_stale_days_8863bcfe">Aucune nouvelle nuit de votre strap depuis %1$d jours. Vérifiez qu\'il est connecté et enregistre les données.</string>
     <string name="l10n_today_screen_calibratingnights_of_baselines_minnightsseed_3b76e55c">%1$s de %2$s</string>
     <string name="l10n_today_screen_choose_which_cards_show_on_today_f79942e1">Choisissez les cartes affichées sur Today et réarrangez-les avec les flèches.</string>
     <string name="l10n_today_screen_close_bbfa773e">Fermer</string>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -874,6 +874,7 @@
     <string name="l10n_time_of_day_background_atmospherephase_5ce21300">atmospherePhase</string>
     <string name="l10n_today_screen_arrange_today_6b699147">Arrange Today</string>
     <string name="l10n_today_screen_calibrating_37c2c9bd">Calibrating</string>
+    <string name="l10n_today_screen_no_new_nights_from_your_strap_for_stale_days_8863bcfe">No new nights from your strap for %1$d days. Check it\'s connected and saving data.</string>
     <string name="l10n_today_screen_calibratingnights_of_baselines_minnightsseed_3b76e55c">%1$s of %2$s</string>
     <string name="l10n_today_screen_choose_which_cards_show_on_today_f79942e1">Choose which cards show on Today and reorder them with the arrows. </string>
     <string name="l10n_today_screen_close_bbfa773e">Close</string>

--- a/android/app/src/test/java/com/noop/analytics/NightsSinceNewestValidNightTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/NightsSinceNewestValidNightTest.kt
@@ -1,0 +1,45 @@
+package com.noop.analytics
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/** #612: the "days since the newest night with a usable HRV" helper behind the "no new nights for N days"
+ *  calibrating copy. Byte-identical twin of the Swift `Baselines.nightsSinceNewestValidNight`. */
+class NightsSinceNewestValidNightTest {
+
+    @Test
+    fun `days since the newest night carrying a valid hrv`() {
+        val days = listOf("2026-07-01", "2026-07-02", "2026-07-03")
+        val hrv = listOf(60.0, null, 62.0) // newest valid night = 07-03
+        assertEquals(14, Baselines.nightsSinceNewestValidNight(days, hrv, "2026-07-17"))
+    }
+
+    @Test
+    fun `a null-hrv newer night does not count as the newest valid night`() {
+        val days = listOf("2026-07-01", "2026-07-10")
+        val hrv = listOf(55.0, null) // 07-10 has no hrv, so newest valid = 07-01
+        assertEquals(16, Baselines.nightsSinceNewestValidNight(days, hrv, "2026-07-17"))
+    }
+
+    @Test
+    fun `null when there is no valid night at all`() {
+        assertNull(Baselines.nightsSinceNewestValidNight(listOf("2026-07-01"), listOf(null), "2026-07-17"))
+    }
+
+    @Test
+    fun `null when today precedes the newest night (would be negative)`() {
+        assertNull(Baselines.nightsSinceNewestValidNight(listOf("2026-07-20"), listOf(60.0), "2026-07-17"))
+    }
+
+    @Test
+    fun `civil-day arithmetic crosses month and year boundaries`() {
+        assertEquals(1, Baselines.nightsSinceNewestValidNight(listOf("2025-12-31"), listOf(50.0), "2026-01-01"))
+        assertEquals(31, Baselines.nightsSinceNewestValidNight(listOf("2026-01-31"), listOf(50.0), "2026-03-03")) // Jan31->Mar3 (2026 not leap): 28-31=... 31 days
+    }
+
+    @Test
+    fun `null on an unparseable day key`() {
+        assertNull(Baselines.nightsSinceNewestValidNight(listOf("not-a-date"), listOf(50.0), "2026-07-17"))
+    }
+}


### PR DESCRIPTION
Implements the **core of #612** (parts 1 + a light 3), both platforms. Diagnostics/UX only — no analytics change, nothing stored differently.

## The problem
A strap that keeps *connecting* but stops delivering nightly data silently ages the Charge/HRV baseline out to "building your baseline" — up to `staleDays (14)` after the actual cause, so it misleadingly lands on whatever the user did that week (the reporter's case was later filed as #613, now fixed; this is the general *reporting*).

## What changed
- **New shared pure helper** `Baselines.nightsSinceNewestValidNight(dayKeys:nightlyHrv:today:)` — calendar days since the newest night carrying a usable HRV. TZ-free civil-day arithmetic, **byte-identical Swift/Kotlin**, unit-tested. Distinct from `calibrationNights` (progress toward a usable baseline).
- When that age exceeds `staleDays`, the calibrating detail on the Charge card reads **"No new nights from your strap for N days. Check it's connected and saving data."** instead of only "building your baseline":
  - iOS classic `TodayView.calibrationDetail`
  - iOS Liquid `LiquidTodayView.synthLine` (`.insufficient`)
  - Android `TodayScreen` synthesis detail
- N is always `> 14` here, so the copy is always plural (no singular variant needed).

## Scope
- **Part 2** of #612 (a dedicated "connected, but no data" chip) is **deferred** — it overlaps the existing Recording chip and #245, so it wants design coordination.
- **Coupled view** is a trivial fast-follow (same one-line pattern).

## Testing
- Android: `compileFullDebugKotlin` ✓, `NightsSinceNewestValidNightTest` ✓ (civil-day math incl. month/year boundaries), i18n audit ✓ (new string + de/es/fr).
- **iOS: not compile-verified** — the GitHub Actions incident (dispatch/cancel APIs 500ing) is still active, so app-build can't run. **Hold this PR for the iOS compile-check** once Actions recovers. The iOS xcstrings entry (de/es/fr) was added by hand (JSON round-trip verified) since Xcode couldn't extract it during the incident.