### PR TITLE
Test Centre: field-aware deviceId redaction for the Oura sidecars (#572 follow-up)

### DIFF
--- a/Strand/System/TestBundleAssembler.swift
+++ b/Strand/System/TestBundleAssembler.swift
@@ -23,6 +23,17 @@ enum TestBundleAssembler {
         "raw-capture.jsonl", "oura-raw.jsonl", "oura-ibihr.jsonl", "oura-activity.jsonl",
     ]
 
+    /// #572 follow-up: the Oura Tier-B sidecars carry the ring id in a `"deviceId"` JSON field. The
+    /// whole-bundle UUID scrub (`LiveState.redactPii`) masks it only when it is a CANONICAL dashed
+    /// `uuidString`; a dashless or truncated id would leak verbatim into a bundle the user shares. For these
+    /// sidecars we ALSO mask the `deviceId` VALUE by field name — format-independent, so any id shape is
+    /// covered, and (unlike broadening the UUID regex to dashless hex) it CANNOT touch the raw `hex` capture
+    /// field, which a greedier rule would shred. Scoped to the sidecars so a non-PII logical `deviceId`
+    /// (e.g. "my-whoop") elsewhere in the bundle stays readable. NORMALIZED names (ring id already dropped).
+    static let ouraSidecarNames: Set<String> = [
+        "oura-raw.jsonl", "oura-ibihr.jsonl", "oura-activity.jsonl",
+    ]
+
     /// Re-run the redaction sink over every entry. Text entries are decoded as UTF-8, scrubbed via the same
     /// LiveState.redactPii used by the live sink, and re-encoded. A non-UTF-8 entry (none today) passes
     /// through untouched rather than risk corrupting binary. meta.json and report.txt have no PII shapes so
@@ -30,7 +41,16 @@ enum TestBundleAssembler {
     static func redactEntries(_ entries: [FileExport.BundleEntry]) -> [FileExport.BundleEntry] {
         entries.map { entry in
             guard let text = String(data: entry.data, encoding: .utf8) else { return entry }
-            let scrubbed = LiveState.redactPii(text)
+            var scrubbed = LiveState.redactPii(text)
+            // #572 follow-up: field-aware deviceId mask for the Oura sidecars (see `ouraSidecarNames`). Runs
+            // AFTER redactPii, so it catches a non-canonical id that the dash-anchored UUID rule misses; on an
+            // already-canonical id redactPii turned into `<device>`, this is a no-op. Key-anchored to
+            // "deviceId", so it never touches the raw `hex` field. `[^"]*` stops at the value's closing quote.
+            if ouraSidecarNames.contains(entry.name) {
+                scrubbed = scrubbed.replacingOccurrences(
+                    of: "(\"deviceId\"\\s*:\\s*\")[^\"]*(\")",
+                    with: "$1<device>$2", options: .regularExpression)
+            }
             return FileExport.BundleEntry(name: entry.name, data: Data(scrubbed.utf8))
         }
     }

--- a/StrandTests/TestBundleAssemblerTests.swift
+++ b/StrandTests/TestBundleAssemblerTests.swift
@@ -123,4 +123,30 @@ final class TestBundleAssemblerTests: XCTestCase {
         // …while the raw capture bytes pass through byte-for-byte (redaction must never corrupt the capture).
         XCTAssertTrue(out.contains("\"hex\":\"\(hex)\""), "the raw hex bytes must survive redaction intact")
     }
+
+    /// #572 follow-up: the field-aware `deviceId` mask closes the gap the canonical-only contract left — a
+    /// DASHLESS (or truncated) ring id, which the dash-anchored UUID rule can't match and would otherwise
+    /// leak verbatim, is still masked to `<device>`, and the raw `hex` capture is STILL untouched (the mask
+    /// is key-anchored to "deviceId", not a greedier hex rule that would shred it). This is the direction the
+    /// earlier hardcoded contract test could not enforce.
+    func testSidecarRedactionMasksDashlessRingIdAndKeepsHexIntact() {
+        let dashless = "5C4C0BF82DF61B3A18D03DF0B3590148" // no dashes → redactPii's UUID rule cannot match it
+        let hex = "0b3c1e00a1b2c3d4e5f60718293a4b5c6d7e8f90aabbccdd"
+        let line = "{\"schema\":1,\"deviceId\":\"\(dashless)\",\"utc\":1,\"hex\":\"\(hex)\"}"
+        let out = String(data: TestBundleAssembler.redactEntries(
+            [FileExport.BundleEntry(name: "oura-ibihr.jsonl", data: Data(line.utf8))]).first!.data, encoding: .utf8)!
+        XCTAssertFalse(out.contains(dashless), "a dashless ring id must not survive the scrub")
+        XCTAssertTrue(out.contains("\"deviceId\":\"<device>\""), "the deviceId value must be masked to <device>")
+        XCTAssertTrue(out.contains("\"hex\":\"\(hex)\""), "the raw hex bytes must survive redaction intact")
+    }
+
+    /// The field-aware mask is SCOPED to the Oura sidecars: it must NOT rewrite a non-PII logical `deviceId`
+    /// (e.g. "my-whoop") in a non-sidecar entry, which would strip useful, non-sensitive context from the
+    /// report body the user reviews.
+    func testSidecarDeviceIdMaskDoesNotTouchNonSidecarEntries() {
+        let line = "{\"deviceId\":\"my-whoop\",\"note\":\"hi\"}"
+        let out = String(data: TestBundleAssembler.redactEntries(
+            [FileExport.BundleEntry(name: "report.txt", data: Data(line.utf8))]).first!.data, encoding: .utf8)!
+        XCTAssertTrue(out.contains("\"deviceId\":\"my-whoop\""), "a non-sidecar logical deviceId must be left readable")
+    }
 }


### PR DESCRIPTION
Follow-up to #570 (merged). #570 closed the Oura ring-id leak with a **contract** — the whole-bundle UUID scrub (`LiveState.redactPii`) masks the id only when it's a canonical dashed `uuidString`; a dashless/truncated id would leak verbatim, and a hardcoded test could only *document* that, not enforce it. #570 rightly refused to broaden the UUID regex to dashless hex, because a greedier rule would **shred the raw `hex` capture** field.

**This closes the leak by construction instead.** In `redactEntries`, for the Oura sidecars only, also mask the `deviceId` JSON **value** by field name: `("deviceId"\s*:\s*")[^"]*(")` → `<device>`.

Why this is the right shape:
- **Format-independent** — any id (dashless, truncated) is masked, so the producer no longer has to get the id format exactly right (removes #570's fragile contract).
- **Safe for the capture** — key-anchored to `deviceId`, so it *cannot* touch `hex` (the exact reason #570 wouldn't broaden the scrub).
- **Scoped** to the sidecars, so a non-PII logical `deviceId` (`"my-whoop"`) elsewhere in the bundle stays readable.
- Runs **after** `redactPii` (no-op on a canonical id it already masked; catches the non-canonical ones it can't).

Two tests: a **dashless** id is masked while `hex` survives byte-for-byte (the direction #570's contract test couldn't enforce), and a non-sidecar `deviceId` is left readable (scoping).

**Parity:** Apple-only (Android has no SwiftUI review sheet / doesn't attach these sidecars).

**Testing:** app-target Swift, so not CI-covered and **not compile-verified here** — no local Xcode, and the GitHub Actions incident is still active (dispatch/cancel 500ing). Logic reviewed (incl. a self re-review). **Held for an `xcodebuild StrandTests` pass** once Actions/Xcode is available. This also composes with the still-dormant Oura producer PR — with this in place, the producers are leak-safe regardless of the exact id format they write.