### PR TITLE
Android review sheet: size guard + name every excluded stream (#570 parity)

### DIFF
--- a/android/app/src/main/java/com/noop/testcentre/ReportReviewGate.kt
+++ b/android/app/src/main/java/com/noop/testcentre/ReportReviewGate.kt
@@ -20,21 +20,43 @@ class ReportReviewGate(private val entries: List<Pair<String, ByteArray>>) {
      */
     val previewText: String
         get() {
-            // Text files shown inline; the bounded raw-capture stream and any binary attachment (the
-            // Display mode's screenshot.png) are excluded from the inline text. Mirrors Swift.
+            // #570 parity: text files shown inline; the large raw streams (by NAME), any binary attachment,
+            // and ANYTHING over the size guard are excluded — rendering megabytes as one Compose Text risks
+            // the layout choke iOS hit — and EVERY excluded entry is NAMED below so the review stays honest
+            // about the WHOLE bundle. Mirrors Swift.
             val textBlocks = entries
-                .filter { it.first != "raw-capture.jsonl" && !isBinaryEntry(it.first) }
+                .filterNot { (name, data) -> isExcludedFromInline(name, data.size) }
                 .joinToString("\n\n") { (name, data) -> "=== $name ===\n${String(data)}" }
-            // Name the binary attachments so the review is HONEST about everything in the bundle: the user
-            // sees that a screenshot is attached and can cancel if they don't want to share it.
-            val binaryNames = entries.map { it.first }.filter { isBinaryEntry(it) }
-            if (binaryNames.isEmpty()) return textBlocks
-            val note = "=== attached (not shown above) ===\n" + binaryNames.joinToString("\n")
+            val excludedNames = entries
+                .filter { (name, data) -> isExcludedFromInline(name, data.size) }
+                .map { it.first }
+            if (excludedNames.isEmpty()) return textBlocks
+            val note = "=== attached (not shown above) ===\n" + excludedNames.joinToString("\n")
             return if (textBlocks.isEmpty()) note else textBlocks + "\n\n" + note
         }
 
     /** A bundle entry that is binary image bytes (not text to show inline). screenshot.png is the only one. */
     private fun isBinaryEntry(name: String): Boolean = name == DisplayScreenshot.BUNDLE_NAME
+
+    /** #570 parity: an entry NEVER shown inline — a binary, a large raw research stream (by name), or ANY
+     *  entry over [MAX_INLINE_BYTES] (a future stream, or a pathologically large report.txt). The size guard
+     *  is belt-and-braces so no single Compose Text can choke the review sheet regardless of what a branch
+     *  attaches. Mirrors Swift ReportReviewGate.notShownInline + maxInlineBytes. */
+    private fun isExcludedFromInline(name: String, size: Int): Boolean =
+        isBinaryEntry(name) || name in NOT_SHOWN_INLINE || size > MAX_INLINE_BYTES
+
+    companion object {
+        /** Large raw research streams never shown inline by NAME: the WHOOP frame capture plus the Oura
+         *  Tier-B sidecars (harmless on Android today — it doesn't attach them — but kept for parity and a
+         *  future producer port). The binary screenshot is caught by [isBinaryEntry]. */
+        private val NOT_SHOWN_INLINE = setOf(
+            "raw-capture.jsonl", "oura-raw.jsonl", "oura-ibihr.jsonl", "oura-activity.jsonl",
+        )
+
+        /** 1 MiB — far above a normal report.txt / meta.json (those still show in full) yet well below the
+         *  Compose-text layout-choke point. Mirrors Swift `maxInlineBytes`. */
+        private const val MAX_INLINE_BYTES = 1024 * 1024
+    }
 
     /** Explicit user confirmation: the only way the gate clears. */
     fun confirm() { isCleared = true }

--- a/android/app/src/test/java/com/noop/testcentre/ReportReviewGateTest.kt
+++ b/android/app/src/test/java/com/noop/testcentre/ReportReviewGateTest.kt
@@ -34,4 +34,46 @@ class ReportReviewGateTest {
         gate.confirm()
         assertTrue(gate.isCleared)
     }
+
+    // #570 parity: the large raw-capture stream is excluded from the inline preview (never laid out) but is
+    // NAMED in the "attached" note, so the review stays honest about the whole bundle.
+    @Test
+    fun rawCaptureIsExcludedFromInlineButNamed() {
+        val gate = ReportReviewGate(listOf(
+            "report.txt" to "the report body".toByteArray(),
+            "raw-capture.jsonl" to "{\"hex\":\"deadbeef\"}".toByteArray(),
+        ))
+        val preview = gate.previewText
+        assertTrue("report body is shown inline", preview.contains("the report body"))
+        assertFalse("raw-capture is NOT laid out inline", preview.contains("deadbeef"))
+        assertTrue("raw-capture is named in the attached note", preview.contains("raw-capture.jsonl"))
+    }
+
+    // #570 belt-and-braces: ANY entry over the ~1 MiB guard is excluded even if it isn't a known raw stream —
+    // a future stream, or a pathologically large report.txt, can't choke the review sheet — and is named.
+    @Test
+    fun oversizedEntryIsExcludedByTheSizeGuardAndNamed() {
+        val huge = ByteArray(2 * 1024 * 1024) { 'a'.code.toByte() }
+        val gate = ReportReviewGate(listOf(
+            "meta.json" to "{\"ok\":true}".toByteArray(),
+            "last-crash.txt" to huge,   // over the guard
+        ))
+        val preview = gate.previewText
+        assertTrue("small meta.json still shown inline", preview.contains("\"ok\":true"))
+        assertTrue("the 2 MB entry is not laid out inline", preview.length < 100_000)
+        assertTrue("the oversized entry is named in the attached note", preview.contains("last-crash.txt"))
+    }
+
+    // Normal small text files still show in full, and there is no "attached" note when nothing is excluded.
+    @Test
+    fun normalTextFilesStayInlineWithNoAttachedNote() {
+        val gate = ReportReviewGate(listOf(
+            "report.txt" to "report line".toByteArray(),
+            "meta.json" to "{\"v\":1}".toByteArray(),
+        ))
+        val preview = gate.previewText
+        assertTrue(preview.contains("report line"))
+        assertTrue(preview.contains("{\"v\":1}"))
+        assertFalse(preview.contains("attached (not shown above)"))
+    }
 }


### PR DESCRIPTION
Ports to Android the two **defense-in-depth** pieces of the iOS #570 review-sheet hang fix that the Kotlin `ReportReviewGate` was missing. Android already excluded `raw-capture` from the inline preview (it mirrored the core fix), but it lacked:

1. **A ~1 MiB per-entry size guard.** Android excluded large streams by **name only**, so a pathologically large `report.txt` — or any future attached stream — would still be inlined into one Compose `Text`, the same class of layout choke #570 hardened iOS against. Now ANY entry over `MAX_INLINE_BYTES` is excluded regardless of name.
2. **Naming every excluded stream in the "attached (not shown above)" note.** Android previously listed only binaries, so `raw-capture` was excluded from the preview but never named — the review was slightly less honest than iOS. Now `raw-capture` + any oversized entry are named, so the user sees the whole bundle.

Mirrors `Strand/System/ReportReviewGate.swift` (`notShownInline` + `maxInlineBytes`).

**Not applicable to Android (context from the #570/#621 discussion):** the Oura sidecar *attach* and the field-aware `deviceId` redaction (#621) — Android doesn't attach the Oura sidecars, and its device ids are BLE MACs (already masked), not UUIDs. This PR is only the review-sheet robustness half.

## Testing
Android-only, no iOS change, **no dependency on the GitHub Actions incident** — fully validated locally: `compileFullDebugKotlin` ✓, `ReportReviewGateTest` **6/6** ✓ (raw-capture excluded-but-named; an oversized entry caught by the guard and named; normal small files still shown in full with no note), i18n audit ✓.