### PR TITLE
iOS: unify Today edit actions to "EDIT" (parity with #563)

### DIFF
--- a/Strand/Liquid/LiquidTodayView.swift
+++ b/Strand/Liquid/LiquidTodayView.swift
@@ -570,7 +570,10 @@ struct LiquidTodayView: View {
                     .foregroundStyle(StrandPalette.textTertiary)
                 Spacer()
                 Button { showCustomise = true } label: {
-                    Text("CUSTOMISE").font(StrandFont.overlineScaled(11)).tracking(1.0)
+                    // #492 item 4 parity: unify the Your Cards / Key Metrics edit affordance to "EDIT" across
+                    // platforms (Android #563). Reuse the localized "Edit" key, uppercased at display, so this
+                    // stays translated (BEARBEITEN / MODIFIER / …) without a new literal.
+                    Text(String(localized: "Edit").uppercased()).font(StrandFont.overlineScaled(11)).tracking(1.0)
                         .foregroundStyle(StrandPalette.accent)
                 }
                 .buttonStyle(.plain)

--- a/Strand/Screens/TodayView.swift
+++ b/Strand/Screens/TodayView.swift
@@ -2063,7 +2063,7 @@ struct TodayView: View {
                     Button {
                         showingDashboardEditor = true
                     } label: {
-                        Label("CUSTOMISE", systemImage: "slider.horizontal.3")
+                        Label(String(localized: "Edit").uppercased(), systemImage: "slider.horizontal.3")   // #492/#563: unified "EDIT"
                             .font(StrandFont.overline)
                             .tracking(StrandFont.overlineTracking)
                     }
@@ -3076,7 +3076,7 @@ struct TodayView: View {
                 Button {
                     showingMetricsEditor = true
                 } label: {
-                    Label("Edit", systemImage: "slider.horizontal.3")
+                    Label(String(localized: "Edit").uppercased(), systemImage: "slider.horizontal.3")   // #492/#563: uppercase to match
                         .font(StrandFont.footnote)
                 }
                 .buttonStyle(.plain)

--- a/android/app/src/main/res/values-de/strings.xml
+++ b/android/app/src/main/res/values-de/strings.xml
@@ -869,7 +869,6 @@
     <string name="l10n_today_screen_calibratingnights_of_baselines_minnightsseed_3b76e55c">%1$s von %2$s</string>
     <string name="l10n_today_screen_choose_which_cards_show_on_today_f79942e1">Wählen Sie, welche Karten auf Heute angezeigt werden, und ordnen Sie sie mit den Pfeilen neu an.</string>
     <string name="l10n_today_screen_close_bbfa773e">Schließen</string>
-    <string name="l10n_today_screen_customise_b378dddc">ANPASSEN</string>
     <string name="l10n_today_screen_customise_your_cards_2428d761">Passe deine Karten an</string>
     <string name="l10n_today_screen_dismiss_70afe9ef">Schließen</string>
     <string name="l10n_today_screen_done_e9b450d1">Fertig</string>

--- a/android/app/src/main/res/values-es/strings.xml
+++ b/android/app/src/main/res/values-es/strings.xml
@@ -709,7 +709,6 @@
     <string name="l10n_today_screen_calibratingnights_of_baselines_minnightsseed_3b76e55c">%1$s de %2$s</string>
     <string name="l10n_today_screen_choose_which_cards_show_on_today_f79942e1">Elija qué tarjetas muestran en Hoy y reordenarlos con las flechas.</string>
     <string name="l10n_today_screen_close_bbfa773e">Cerrar</string>
-    <string name="l10n_today_screen_customise_b378dddc">PERSONALIZAR</string>
     <string name="l10n_today_screen_customise_your_cards_2428d761">Personaliza tus tarjetas</string>
     <string name="l10n_today_screen_dismiss_70afe9ef">Descartar</string>
     <string name="l10n_today_screen_done_e9b450d1">Listo</string>

--- a/android/app/src/main/res/values-fr/strings.xml
+++ b/android/app/src/main/res/values-fr/strings.xml
@@ -709,7 +709,6 @@
     <string name="l10n_today_screen_calibratingnights_of_baselines_minnightsseed_3b76e55c">%1$s de %2$s</string>
     <string name="l10n_today_screen_choose_which_cards_show_on_today_f79942e1">Choisissez les cartes affichées sur Today et réarrangez-les avec les flèches.</string>
     <string name="l10n_today_screen_close_bbfa773e">Fermer</string>
-    <string name="l10n_today_screen_customise_b378dddc">PERSONNALISER</string>
     <string name="l10n_today_screen_customise_your_cards_2428d761">Personnalisez vos cartes</string>
     <string name="l10n_today_screen_dismiss_70afe9ef">Ignorer</string>
     <string name="l10n_today_screen_done_e9b450d1">Terminé</string>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -878,7 +878,6 @@
     <string name="l10n_today_screen_calibratingnights_of_baselines_minnightsseed_3b76e55c">%1$s of %2$s</string>
     <string name="l10n_today_screen_choose_which_cards_show_on_today_f79942e1">Choose which cards show on Today and reorder them with the arrows. </string>
     <string name="l10n_today_screen_close_bbfa773e">Close</string>
-    <string name="l10n_today_screen_customise_b378dddc">CUSTOMISE</string>
     <string name="l10n_today_screen_customise_your_cards_2428d761">Customise your cards</string>
     <string name="l10n_today_screen_dismiss_70afe9ef">Dismiss</string>
     <string name="l10n_today_screen_done_e9b450d1">Done</string>


### PR DESCRIPTION
Follow-up to **#563** (merged). #563 unified Android's Key Metrics + Your Cards edit affordances to a shared uppercase **"EDIT"**. iOS still showed **"CUSTOMISE"** for Your Cards (Liquid + classic) and mixed-case **"Edit"** for Key Metrics — so the same control read differently per platform.

## What this does
- **iOS Your Cards + Key Metrics now show "EDIT"** — `LiquidTodayView:573`, `TodayView:2066` (Your Cards), `TodayView:3079` (classic Key Metrics). Each uses `String(localized: "Edit").uppercased()` — **reusing the existing localized `"Edit"` key**, so the label stays translated (BEARBEITEN / MODIFIER / …) and **no new literal is added** (i18n gate unaffected), mirroring Android's `.uppercase(Locale.getDefault())`.
- **Accessibility labels kept** ("Customise your cards", "Edit Key Metrics") — matching #563's choice to keep action-specific a11y while unifying the visible label. Liquid Key Metrics stays icon-only (pre-existing Liquid minimalism).
- **Removes the orphaned "Customise" visible-label strings** #563 left behind: Android `l10n_today_screen_customise_b378dddc` (en/de/es/fr) and the iOS xcstrings `"CUSTOMISE"` entry. Neither is referenced in code (grep-verified); the xcstrings diff is `-52/0`, just that one entry.

## Testing
- **Android half fully validated**: `compileFullDebugKotlin` ✓, i18n audit ✓ (both platforms), no dangling `R.string` reference.
- **iOS: not compile-verified** — app-target Swift, no local Xcode, and the GitHub Actions incident is still active. These are simple label swaps (verbatim `String` into `Text`/`Label`); **held for the app-build compile-check** when Actions recovers.