### PR TITLE
Oura: live On-wrist / Off-wrist wear status

### DIFF
--- a/Packages/OuraProtocol/Sources/OuraProtocol/OuraWear.swift
+++ b/Packages/OuraProtocol/Sources/OuraProtocol/OuraWear.swift
@@ -1,0 +1,78 @@
+import Foundation
+
+// OuraWear: infer whether the Oura ring is on a finger, on the charger, or idle — a live wear/charge
+// indicator for the UI ("On wrist" / "Off wrist").
+//
+// The ring emits no dedicated "worn" event in NOOP's captures: open_health documents an `aohr_event`
+// (0x86) that "appears when worn", but that decoder is confirmed by code, not data (ported from
+// libringeventparser.so) and has NEVER appeared in a capture (0 records). So wear is inferred from signals
+// that ARE present and validated by real data:
+//   - a LIVE-HR push (0x2F) exists only while the ring measures on a finger -> WORN;
+//   - a live-HR stream that goes silent while we keep re-engaging it -> the ring came off (there is no
+//     "removed" event) -> NOT WORN;
+//   - the ring's literal "chg. detected" / "chg. stopped" STATE (0x45/0x53) strings -> CHARGING.
+//
+// Platform-pure, value types + one tiny live accumulator. No CoreBluetooth, no clock (the caller owns the
+// watchdog timing). Builds/tests on Linux.
+
+/// The ring's wear / charge state for a live indicator.
+public enum OuraWearState: String, Sendable, Codable, CaseIterable {
+    case worn        // a live-HR beat streamed since the last charge/removal -> on a finger
+    case charging    // between chg.detected and chg.stopped -> on the charger, not worn
+    case off         // came off the charger, or the finger (live-HR went silent) -> not worn, no charger
+    case unknown     // no evidence yet this session
+}
+
+public enum OuraWear {
+
+    // MARK: - STATE-string semantics (clean-room: the ring's own words)
+
+    /// True when a STATE (0x45/0x53) string reports the charger being CONNECTED (observed: "chg. detected").
+    /// Matched on the decoded text, the honest signal — the ring literally says it — never a guessed code
+    /// (the numeric state codes are ambiguous: e.g. code 5 appears as both "hr enable" and "motion det").
+    public static func isChargerStart(_ s: OuraState) -> Bool {
+        let t = (s.text ?? "").lowercased()
+        return (t.contains("chg") || t.contains("charg")) && (t.contains("detect") || t.contains("start"))
+    }
+
+    /// True when a STATE string reports the charger being DISCONNECTED (observed: "chg. stopped").
+    public static func isChargerStop(_ s: OuraState) -> Bool {
+        let t = (s.text ?? "").lowercased()
+        return (t.contains("chg") || t.contains("charg"))
+            && (t.contains("stop") || t.contains("end") || t.contains("done") || t.contains("remov"))
+    }
+}
+
+/// A tiny LIVE state machine for a wear/charge indicator. Feed it STATE events, live-HR pulses, and a
+/// pulse-silence timeout as they happen in real time; read `current`. Live semantics only: latest evidence
+/// wins. A live-HR beat means WORN (a finger); a charge string means CHARGING/OFF; a silent stream past the
+/// caller's grace window means the ring came off. Never feed it a banked/history IBI — that can be a
+/// past-night re-serve and would falsely read worn.
+public final class OuraWearTracker {
+    public private(set) var current: OuraWearState = .unknown
+
+    public init() {}
+
+    /// A decoded STATE (0x45/0x53) event.
+    public func note(state: OuraState) {
+        if OuraWear.isChargerStart(state) { current = .charging }
+        else if OuraWear.isChargerStop(state) { current = .off }
+    }
+
+    /// A LIVE heart-rate beat was streamed (the 0x2F live-HR push) — that stream exists only while the ring
+    /// is measuring on a finger, so the ring is WORN. Do NOT call this for a banked/history IBI: a history
+    /// re-serve can carry beats from a PAST night and would falsely flip the badge to worn while the ring
+    /// is actually on the charger. Live push only.
+    public func notePulse() { current = .worn }
+
+    /// No live beat has arrived for longer than expected while HR was streaming — the ring came off the
+    /// finger (the ring emits no "removed" event; a stopped live-HR stream is the only signal). Downgrades
+    /// `.worn` -> `.off` only; never overrides `.charging` (the charger STATE is authoritative) or a state
+    /// that was already not-worn. The caller owns the timing (a wall-clock watchdog); the tracker stays pure.
+    public func noteLivePulseTimeout() {
+        if current == .worn { current = .off }
+    }
+
+    /// Reset to `.unknown` (a fresh connection / session).
+    public func reset() { current = .unknown }
+}

--- a/Packages/OuraProtocol/Tests/OuraProtocolTests/OuraWearTests.swift
+++ b/Packages/OuraProtocol/Tests/OuraProtocolTests/OuraWearTests.swift
@@ -1,0 +1,60 @@
+import XCTest
+@testable import OuraProtocol
+
+/// Live wear/charge inference for the "On wrist / Off wrist" indicator. The ring emits no dedicated worn
+/// event in NOOP's captures, so wear is inferred from a LIVE-HR beat (a finger), a silent stream past a
+/// grace window (removed), and the ring's own "chg. detected"/"chg. stopped" STATE strings (charging).
+final class OuraWearTests: XCTestCase {
+
+    private func state(_ rt: UInt32, _ text: String) -> OuraState {
+        OuraState(ringTimestamp: rt, stateCode: 0, text: text)
+    }
+
+    // MARK: - STATE-string semantics
+
+    func testChargerStartStopStringMatching() {
+        XCTAssertTrue(OuraWear.isChargerStart(state(1, "chg. detected")))
+        XCTAssertTrue(OuraWear.isChargerStop(state(1, "chg. stopped")))
+        // not a charger line (these real strings must never be read as charge transitions)
+        XCTAssertFalse(OuraWear.isChargerStart(state(1, "hr enable")))
+        XCTAssertFalse(OuraWear.isChargerStop(state(1, "orientation")))
+        XCTAssertFalse(OuraWear.isChargerStart(state(1, "fea off")))
+        XCTAssertFalse(OuraWear.isChargerStop(state(1, "motion det")))
+        // a nil / empty text never matches
+        XCTAssertFalse(OuraWear.isChargerStart(OuraState(ringTimestamp: 1, stateCode: 8, text: nil)))
+    }
+
+    // MARK: - Live tracker
+
+    func testLiveTrackerPulseMeansWorn() {
+        let t = OuraWearTracker()
+        XCTAssertEqual(t.current, .unknown)
+        t.note(state: state(1, "chg. detected"))
+        XCTAssertEqual(t.current, .charging)
+        t.note(state: state(2, "chg. stopped"))
+        XCTAssertEqual(t.current, .off)
+        t.notePulse()                                  // a live beat can only come from a finger
+        XCTAssertEqual(t.current, .worn)
+        t.note(state: state(3, "chg. detected"))       // back on the charger
+        XCTAssertEqual(t.current, .charging)
+        t.reset()
+        XCTAssertEqual(t.current, .unknown)
+    }
+
+    func testLivePulseTimeoutDowngradesWornToOff() {
+        // The ring emits no "removed" event; a silent live-HR stream is the only signal. A timeout
+        // downgrades worn -> off, but must NOT override charging or fabricate a not-worn from unknown.
+        let t = OuraWearTracker()
+        t.noteLivePulseTimeout()
+        XCTAssertEqual(t.current, .unknown)            // no evidence yet -> unchanged
+        t.notePulse()
+        XCTAssertEqual(t.current, .worn)
+        t.noteLivePulseTimeout()                       // stream went quiet -> removed
+        XCTAssertEqual(t.current, .off)
+        // charging is authoritative: a timeout never flips it to off.
+        t.note(state: state(9, "chg. detected"))
+        XCTAssertEqual(t.current, .charging)
+        t.noteLivePulseTimeout()
+        XCTAssertEqual(t.current, .charging)
+    }
+}

--- a/Strand/BLE/LiveState.swift
+++ b/Strand/BLE/LiveState.swift
@@ -2,6 +2,7 @@ import Foundation
 import Combine
 import StrandAnalytics
 import WhoopProtocol
+import OuraProtocol
 
 /// Observable snapshot of the live connection + biometric state, driven by FrameRouter
 /// (from decoded frames) and BLEManager (from CoreBluetooth callbacks).
@@ -68,6 +69,12 @@ public final class LiveState: ObservableObject {
     /// first event of a session; cleared on disconnect so a stale flag can't outlive the link.
     /// Flag ONLY — the battery % keeps its family-specific source (#77).
     @Published public var charging: Bool? = nil
+
+    /// The Oura ring's current wear/charge state (nil for non-Oura straps or before any evidence this
+    /// session). Driven by OuraLiveSource from the live-HR push + the ring's STATE charger strings: a live
+    /// beat only comes from a finger (`.worn`); "chg. detected"/"stopped" bracket `.charging`; a silent
+    /// live-HR stream drops to `.off` (removed). Lets the Live view show On wrist / Off wrist.
+    @Published public var ouraWearState: OuraWearState? = nil
 
     // MARK: - Battery runtime estimate (#713)
 
@@ -482,6 +489,7 @@ public final class LiveState: ObservableObject {
         recentGravitySamples.removeAll()
         clearStrapRange()                 // a stale clock-drift window must not outlive the link either
         lastFrameAtUnix = nil             // #987: a stale "last frame" freshness must not outlive it either
+        ouraWearState = nil               // a stale worn/charging badge must not outlive the link either
     }
 
     /// Cap on the in-app strap-log ring buffer. Raised from the old ~1h (200 lines) to retain a rolling

--- a/Strand/BLE/OuraLiveSource.swift
+++ b/Strand/BLE/OuraLiveSource.swift
@@ -143,6 +143,20 @@ public final class OuraLiveSource: NSObject, ObservableObject {
     /// Reassembles notification fragments into complete TLV inner records across feeds.
     private let reassembler = OuraReassembler()
 
+    /// Live wear/charge indicator: a LIVE-HR push (.hr) means the ring is on a finger; the ring's own "chg.
+    /// detected"/"stopped" STATE strings bracket a charging period. Fed ONLY from the live push and STATE
+    /// (never a banked .ibi, which can be a past-night re-serve) and only while `feedsLive`. Mirrored to
+    /// `live.ouraWearState` for the On-wrist / Off-wrist UI.
+    private let wearTracker = OuraWearTracker()
+    private var loggedWearState: OuraWearState?
+    /// When the last LIVE-HR beat arrived. If the stream goes quiet for `wornPulseTimeout` while we are
+    /// still re-engaging it, the ring came off the finger (there is no "removed" event) -> NOT WORN.
+    private var lastLivePulseAt: Date?
+    /// Grace before a silent live-HR stream means "removed": the ring auto-reverts DHR ~20 s and we
+    /// re-engage every `reengageInterval` (15 s), so a worn ring resumes beats well within this; exceeding
+    /// it means no finger. Checked on the re-engage tick, so worst-case detection is this + one interval.
+    private let wornPulseTimeout: TimeInterval = 40
+
     /// Logs the FIRST live HR sample of a connection only (never every push); reset on stop/disconnect.
     private var loggedFirstHR = false
     /// The ring's optical HR needs a beat or two to settle after (re)subscribe, so the very first live-HR
@@ -519,6 +533,7 @@ public final class OuraLiveSource: NSObject, ObservableObject {
         driver?.stop()
         driver = nil
         reassembler.reset()
+        wearTracker.reset(); loggedWearState = nil; lastLivePulseAt = nil
         loggedFirstHR = false
         droppedFirstLiveHR = false
         loggedFirstTemp = false
@@ -722,6 +737,12 @@ public final class OuraLiveSource: NSObject, ObservableObject {
                 if feedsLive {
                     live.heartRate = hr.bpm
                     live.connected = true
+                    // A LIVE HR push (0x2F) exists only while the ring is measuring on a finger, so it is
+                    // the sole safe "worn now" signal. A banked IBI (.ibi below) can be a history re-serve
+                    // from a past night, so it must NOT flip the badge to worn.
+                    lastLivePulseAt = Date()
+                    wearTracker.notePulse()
+                    publishWearState()
                 }
                 enqueue([e], ts: now)
 
@@ -841,8 +862,33 @@ public final class OuraLiveSource: NSObject, ObservableObject {
                     lastActivitySampleCount = info.met.count
                 }
 
+            case .state(let s):
+                // The ring's own lifecycle strings (0x45/0x53). Charger transitions drive the wear badge;
+                // never a durable Streams row. Only the LIVE stream updates the indicator (a history
+                // re-serve is out of order and would flap it).
+                if feedsLive {
+                    wearTracker.note(state: s)
+                    publishWearState()
+                }
+
             default:
-                break   // motion / state / debugText: not a durable Streams row (see OuraStreamMapping)
+                break   // motion / debugText / etc: not a durable Streams row (see OuraStreamMapping)
+            }
+        }
+    }
+
+    /// Mirror the tracker's current wear/charge state to the observable, and log each TRANSITION once (a
+    /// charger on/off or first pulse is worth a strap-log line; steady state is not).
+    private func publishWearState() {
+        let s = wearTracker.current
+        if feedsLive { live.ouraWearState = s }
+        if s != loggedWearState {
+            loggedWearState = s
+            switch s {
+            case .worn:     log("Oura: ring WORN - live HR streaming")
+            case .charging: log("Oura: ring NOT WORN - on charger (HR/IBI paused until removed)")
+            case .off:      log("Oura: ring NOT WORN - no live HR (removed / off charger)")
+            case .unknown:  break
             }
         }
     }
@@ -866,6 +912,13 @@ public final class OuraLiveSource: NSObject, ObservableObject {
     private func reengageLiveHR() {
         guard let driver, reachedStreaming else { return }
         write(driver.reengageLiveHRCommands())
+        // Live-HR watchdog: if the stream has gone silent past the grace window while we were WORN, the
+        // ring came off the finger (no "removed" event exists) -> NOT WORN. Only meaningful once we have
+        // seen at least one live beat this session.
+        if feedsLive, let last = lastLivePulseAt, Date().timeIntervalSince(last) > wornPulseTimeout {
+            wearTracker.noteLivePulseTimeout()
+            publishWearState()
+        }
     }
 
     // MARK: - Honest needs-pairing fallback (Huami precedent)
@@ -997,6 +1050,7 @@ extension OuraLiveSource: @preconcurrency CBCentralManagerDelegate {
         pendingInstallKey = nil
         adoptPhase = .idle
         reassembler.reset()
+        wearTracker.reset(); loggedWearState = nil; lastLivePulseAt = nil
         // Per-drain cursor state starts clean each session (fetchHistoryIfIdle re-arms it per drain).
         drain.reset()
         resumeCursorAtFetchStart = 0
@@ -1045,6 +1099,7 @@ extension OuraLiveSource: @preconcurrency CBCentralManagerDelegate {
         driver?.stop()
         driver = nil
         reassembler.reset()
+        wearTracker.reset(); loggedWearState = nil; lastLivePulseAt = nil
         writeCharacteristic = nil
         loggedFirstHR = false
         droppedFirstLiveHR = false

--- a/Strand/Screens/LiveView.swift
+++ b/Strand/Screens/LiveView.swift
@@ -6,6 +6,7 @@ import StrandDesign
 import StrandAnalytics
 import WhoopProtocol
 import WhoopStore
+import OuraProtocol
 
 /// Live — the connected strap in real time, in the liquid finish. Built on the shared design system
 /// (ScreenScaffold chrome + day-of-sky backdrop, StrandPalette, StrandFont) and the liquid vocabulary
@@ -705,7 +706,14 @@ private struct LiveHeaderStats: View {
     /// A streaming Oura ring is definitionally worn (PPG needs skin contact), and `worn` isn't reset on a
     /// source switch — so a stale `worn=false` from a prior WHOOP WRIST_OFF must not read "Off wrist"
     /// mid-stream. For WHOOP `ringStreaming` is always false, so this is just `live.worn`. #218.
-    private var wornNow: Bool { live.worn || ringStreaming }
+    private var wornNow: Bool {
+        // An Oura ring reports a precise live wear/charge state (live-HR presence + charger STATE + a
+        // removal watchdog), so prefer it — it drops to not-worn the moment the ring is off the finger or
+        // on the charger, unlike `ringStreaming`, which lingers. WHOOP has no such signal (ouraWearState
+        // stays nil), so it keeps the bond-worn / stream fallback. #218.
+        if let w = live.ouraWearState { return w == .worn }
+        return live.worn || ringStreaming
+    }
 
     var body: some View {
         HStack(spacing: 16) {
@@ -970,7 +978,14 @@ private struct LiveSignalTrustRail: View {
     /// Streaming ⟹ worn: keeps a stale `worn=false` (from a prior WHOOP WRIST_OFF, never reset on a source
     /// switch) from reading "Off wrist" while an Oura ring streams. For WHOOP `ringStreaming` is always
     /// false, so this is just `live.worn`. #218.
-    private var wornNow: Bool { live.worn || ringStreaming }
+    private var wornNow: Bool {
+        // An Oura ring reports a precise live wear/charge state (live-HR presence + charger STATE + a
+        // removal watchdog), so prefer it — it drops to not-worn the moment the ring is off the finger or
+        // on the charger, unlike `ringStreaming`, which lingers. WHOOP has no such signal (ouraWearState
+        // stays nil), so it keeps the bond-worn / stream fallback. #218.
+        if let w = live.ouraWearState { return w == .worn }
+        return live.worn || ringStreaming
+    }
 
     var body: some View {
         LazyVGrid(columns: [GridItem(.adaptive(minimum: 168), spacing: NoopMetrics.gap)],


### PR DESCRIPTION
## Summary
  Surfaces whether the Oura ring is **worn**, **on the charger**, or **off** as a live indicator in the Live view. One self-contained feature — no sleep-session coupling.

## Why
  The ring emits no dedicated "worn" event in NOOP's captures. `open_health` documents an `aohr_event` (`0x86`) that "appears when worn", but that decoder is confirmed by code, not data (ported from  `libringeventparser.so`) and has **never appeared in a capture** (0 records). So wear is inferred from three signals that *are* present and validated by real captures:

  - a **LIVE-HR push (`0x2F`)** exists only while the ring measures on a finger → **worn**;
  - a live-HR stream that goes **silent** past a grace window → **removed** (there is no "removed" event);
  - the ring's own **`chg. detected` / `chg. stopped`** STATE (`0x45/0x53`) strings → **charging**.

## What's in this PR
  **`OuraProtocol` (pure, Linux-testable):**
  - `OuraWearState` (`worn` / `charging` / `off` / `unknown`) + `OuraWear.isChargerStart/isChargerStop` — keyed on the ring's own text, because the numeric state codes are ambiguous (`code 5` appears as  both `"hr enable"` and `"motion det"`).
  - `OuraWearTracker`: `notePulse` (live beat → worn), `note(state:)` (charger strings), `noteLivePulseTimeout` (silent stream → off; never overrides charging).

  **App (Apple):**
  - `OuraLiveSource` drives the tracker from the **live-HR push (`.hr`)** and the STATE strings — never a banked `.ibi` (a past-night re-serve would falsely read worn) — plus a **40 s live-HR watchdog**
  on the re-engage tick that flips worn → off when the ring is removed. Explicit worn/not-worn strap-log lines.
  - `LiveState.ouraWearState` published; cleared on disconnect.
  - `LiveView`'s "Worn" stat and "On wrist" tile prefer `ouraWearState`, so removing the ring or putting it on the charger flips the display to **No / Off wrist** instead of lingering on a stale stream.
  WHOOP is unchanged (`ouraWearState` stays `nil` → bond/stream fallback).

## Cross-platform
  Apple-only, by necessity. Android's `ExperimentalBrand.OURA` is documented **"No open live health stream"** (import-only, no live BLE), so there is no live-HR stream or STATE feed to derive wear from
  — nothing to mirror. This changes **no stored value, analytics, migration, or decoder** (a live UI indicator only), so the byte-identical parity contract does not apply.

## Verification
  - `swift test` OuraProtocol `OuraWearTests` — **3/3**.
  - `xcodebuild … -scheme Strand -destination 'platform=macOS'` — **BUILD SUCCEEDED** (app-target Swift; not covered by default CI).

## Tested on hardware (macOS, Oura Ring Gen3)
  - Wear it → strap log `Oura: ring WORN - live HR streaming`; Live view reads **On wrist** (fires only on the live push, not the history drain).
  - Remove it → after ~40 s the watchdog logs `ring NOT WORN - no live HR (removed / off charger)`; Live view flips to **Off wrist** and stays.
  - On the charger while connected → `chg. detected` → **charging / Off wrist**.

  ## Files
  - `Packages/OuraProtocol/Sources/OuraProtocol/OuraWear.swift` (new)
  - `Packages/OuraProtocol/Tests/OuraProtocolTests/OuraWearTests.swift` (new)
  - `Strand/BLE/LiveState.swift`, `Strand/BLE/OuraLiveSource.swift`, `Strand/Screens/LiveView.swift`