### PR TITLE
i18n: fill 52 iOS zh-Hans gaps from Android's Simplified Chinese (#552)

### DIFF
--- a/Packages/StrandDesign/Sources/StrandDesign/Resources/Localizable.xcstrings
+++ b/Packages/StrandDesign/Sources/StrandDesign/Resources/Localizable.xcstrings
@@ -727,6 +727,18 @@
             "value": "Dark"
           }
         },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Oscuro"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Noir"
+          }
+        },
         "pt-PT": {
           "stringUnit": {
             "state": "needs_review",
@@ -739,16 +751,10 @@
             "value": "Тёмная"
           }
         },
-        "es": {
+        "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "Oscuro"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Noir"
+            "value": "深色"
           }
         }
       }
@@ -2022,6 +2028,12 @@
             "state": "translated",
             "value": "Ajouter"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "添加"
+          }
         }
       }
     },
@@ -2197,6 +2209,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Terminé"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "完成"
           }
         }
       }
@@ -2682,6 +2700,12 @@
             "state": "translated",
             "value": "Supprimer"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "移除"
+          }
         }
       }
     },
@@ -2725,6 +2749,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "FC au repos"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "静息心率"
           }
         }
       }
@@ -2857,6 +2887,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Enregistrer"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "保存"
           }
         }
       }


### PR DESCRIPTION
## What

iOS already ships Simplified Chinese (it was added organically alongside `it`/`pt-PT`/`ru`/`zh-Hant`, ungated). But **52 strings that #552 just translated on Android were still English on iOS**. This ports those human translations across so the two platforms agree on the strings they share.

| File | zh-Hans before → after |
|---|---|
| `Strand/Resources/Localizable.xcstrings` | 3079 → 3125 / 3229 |
| `StrandDesign/…/Localizable.xcstrings` | 14 → 20 / 95 |

## Why it's safe

- All 52 are **plain strings, no format specifiers** — direct copies of the Android `values-zh` values (Tartistbz's human translation from #552). **No machine translation.**
- **Only `zh-Hans` stringUnits are added.** Verified programmatically: 0 existing values changed across any locale (de/es/fr/it/pt-PT/ru/zh-Hant), key counts unchanged (Strand 3229, StrandDesign 95).
- `Tools/i18n_audit.py --ci HEAD` → clean (de/es/fr unaffected).

## Scope

Does **not** touch the ~206 iOS-only strings that have no Android counterpart — those would need fresh translation, out of scope here. zh remains ungated in the audit on both platforms.