### PR TITLE
Today: journal widget — last-7-days strip + reminder (#627)

### DIFF
--- a/Strand/App/NavRouter.swift
+++ b/Strand/App/NavRouter.swift
@@ -28,6 +28,7 @@ final class NavRouter: ObservableObject {
         case trends
         case activeWorkout
         case liveSession
+        case journal
 
         var id: String { rawValue }
 
@@ -77,4 +78,7 @@ final class NavRouter: ObservableObject {
     /// directly today; this route exists for deep-link parity so a future shell/inbox item can raise it
     /// the same way as every other destination.
     func openLiveSession() { requestedDestination = .liveSession }
+    /// Open the journal (hosted in the classic Insights screen). The #627 Today journal widget taps here;
+    /// iOS presents InsightsView (the journal quick-action sheet), macOS selects the Insights sidebar row.
+    func openJournal() { requestedDestination = .journal }
 }

--- a/Strand/App/RootView.swift
+++ b/Strand/App/RootView.swift
@@ -318,6 +318,8 @@ struct RootView: View {
             // Live Sessions is presented from Today's own Start entry (a cover, not a sidebar item), so a
             // deep-link lands the user on Today where that entry lives.
             case .liveSession: selection = .today
+            // The #627 Today journal widget routes to the Insights sidebar row (which hosts the journal card).
+            case .journal: selection = .insights
             case nil: break
             }
             if dest != nil { router.requestedDestination = nil }

--- a/Strand/BLE/PuffinExperiment.swift
+++ b/Strand/BLE/PuffinExperiment.swift
@@ -113,6 +113,17 @@ enum PuffinExperiment {
 
     static var autoDetectWorkoutsEnabled: Bool { UserDefaults.standard.bool(forKey: autoDetectWorkoutsKey) }
 
+    /// "Journal reminder" (#627). When ON, Today shows a persistent journal widget (a last-7-days
+    /// completion strip that taps through to the journal) and nudges when today isn't logged yet.
+    /// Default ON — gates both the widget and (on Android) the morning sleep sheet. Mirrors the Android
+    /// `NoopPrefs.KEY_JOURNAL_REMINDER_ENABLED`. Default-true, so a bare `bool(forKey:)` can't be used to
+    /// read it (that defaults false); read it through @AppStorage(...) = true or `object(forKey:)`.
+    static let journalReminderKey = "noopJournalReminder"
+
+    static var journalReminderEnabled: Bool {
+        UserDefaults.standard.object(forKey: journalReminderKey) as? Bool ?? true
+    }
+
     /// Opt-in "Motion-aware wake refinement" (default OFF, #364 "Proposal 2" follow-up): a post-pass
     /// (`WakeMotionRefinement`) over the already-staged hypnogram that reclassifies a scored WAKE segment
     /// to `light` when its per-minute step-tick cadence shows no locomotion AND its per-minute gravity

--- a/Strand/Data/Repository.swift
+++ b/Strand/Data/Repository.swift
@@ -1945,6 +1945,17 @@ final class Repository: ObservableObject {
         return out
     }
 
+    /// Distinct local-day keys (yyyy-MM-dd) in the inclusive range [from, to] that carry at least one
+    /// NATIVE journal entry (the "noop-journal" device id only — matching the Android widget's
+    /// `repo.journal(JOURNAL_DEVICE_ID, from, to)`). Backs the #627 Today journal widget's completion
+    /// strip. Read-only.
+    func nativeJournalDays(from: String, to: String) async -> Set<String> {
+        guard let store = await ensureStore() else { return [] }
+        let rows = (try? await store.journalEntries(deviceId: Self.journalDeviceId,
+                                                    from: from, to: to)) ?? []
+        return Set(rows.map { $0.day })
+    }
+
     /// Union; the NATIVE row wins per (day, question) , the in-app answer is the user's most recent
     /// explicit action and stays editable, unlike the immutable imported history.
     nonisolated static func mergeJournal(imported: [JournalEntry], native: [JournalEntry]) -> [JournalEntry] {

--- a/Strand/Liquid/LiquidTodayView.swift
+++ b/Strand/Liquid/LiquidTodayView.swift
@@ -256,6 +256,9 @@ struct LiquidTodayView: View {
                         case .yourCards: yourCardsSection
                         }
                     }
+                    // #627: the persistent journal widget (last-7-days strip + tap-through to the journal).
+                    // Today only; self-hides when the reminder toggle is off. Twin of Android JournalReminderCard.
+                    if selectedDayOffset == 0 { JournalReminderCard() }
                     dataSourcesSection
                     Color.clear.frame(height: 90) // floating tab-bar clearance
                 }

--- a/Strand/Screens/JournalReminderCard.swift
+++ b/Strand/Screens/JournalReminderCard.swift
@@ -1,0 +1,119 @@
+import SwiftUI
+import StrandDesign
+
+// MARK: - Journal widget (Today screen) — #627
+//
+// A persistent Today widget for the Journal: a WHOOP-style strip of the last `stripDays` days
+// (filled = a journal entry that day, today ringed) plus an always-present tap-through to the journal.
+// The Journal (behavioural logging that feeds Insights / "What Moves You") is otherwise only reachable
+// inside the Insights screen, which isn't a primary destination — easy to forget, and the only proactive
+// prompt is the once-a-morning sleep sheet — missed on any day you don't open Sleep. This surfaces it on
+// Today where it can't be missed, and doubles as the "direct link to Insights" the report (#627) asked for.
+//
+// Opt-out via `PuffinExperiment.journalReminderKey` (default ON — the same key also gates the Android
+// morning sleep sheet twin). Read-only: it never writes a journal entry. Twin of Android
+// `JournalReminderCard` (android/.../ui/JournalReminder.kt). Design-Reset compliant — a flat accent-tinted
+// NoopCard, NoopMetrics / StrandPalette / StrandFont tokens, matching the other Today cards.
+
+struct JournalReminderCard: View {
+
+    @EnvironmentObject var repo: Repository
+    @EnvironmentObject var router: NavRouter
+
+    /// Default ON so the reminder works out of the box; the Settings toggle / this key opt out.
+    @AppStorage(PuffinExperiment.journalReminderKey) private var reminderEnabled = true
+
+    /// Which of the last `stripDays` day-keys carry a native journal entry. nil = still loading / read
+    /// error → render nothing (never a misleading all-empty strip).
+    @State private var loggedDays: Set<String>?
+
+    private static let stripDays = 7
+
+    var body: some View {
+        Group {
+            if reminderEnabled, let logged = loggedDays {
+                card(logged)
+            }
+        }
+        // Re-read whenever a sync bumps refreshSeq or the toggle flips (mirrors AutoWorkoutCard's task id),
+        // so the strip and the "logged today" state stay current after the user logs and comes back.
+        .task(id: JournalReminderLoadKey(seq: repo.refreshSeq, enabled: reminderEnabled)) {
+            await reload()
+        }
+    }
+
+    private func card(_ logged: Set<String>) -> some View {
+        let keys = Self.dayKeys()
+        let todayKey = keys.last ?? ""
+        let todayLogged = logged.contains(todayKey)
+        return Button {
+            router.openJournal()
+        } label: {
+            NoopCard(tint: StrandPalette.accent) {
+                VStack(alignment: .leading, spacing: NoopMetrics.space3) {
+                    HStack(spacing: NoopMetrics.space2) {
+                        Image(systemName: "book.closed")
+                            .font(.system(size: 18))
+                            .foregroundStyle(StrandPalette.accent)
+                            .accessibilityHidden(true)
+                        Text(String(localized: "Journal"))
+                            .font(StrandFont.headline)
+                            .foregroundStyle(StrandPalette.textPrimary)
+                        Spacer()
+                        Image(systemName: "chevron.right")
+                            .font(.system(size: 14, weight: .semibold))
+                            .foregroundStyle(StrandPalette.textTertiary)
+                            .accessibilityHidden(true)
+                    }
+                    // The last-N-days strip: one equal-width bar per day. Filled = logged; today is ringed
+                    // so the orientation is unambiguous even when nothing is logged yet.
+                    HStack(spacing: 6) {
+                        ForEach(keys, id: \.self) { key in
+                            let isLogged = logged.contains(key)
+                            RoundedRectangle(cornerRadius: 3)
+                                .fill(isLogged ? StrandPalette.accent : StrandPalette.textTertiary.opacity(0.22))
+                                .frame(maxWidth: .infinity)
+                                .frame(height: 10)
+                                .overlay {
+                                    if key == todayKey, !isLogged {
+                                        RoundedRectangle(cornerRadius: 3)
+                                            .strokeBorder(StrandPalette.accent, lineWidth: 1)
+                                    }
+                                }
+                        }
+                    }
+                    Text(todayLogged
+                         ? String(localized: "Logged today")
+                         : String(localized: "Log today's journal"))
+                        .font(StrandFont.footnote)
+                        .foregroundStyle(todayLogged ? StrandPalette.textSecondary : StrandPalette.accent)
+                }
+            }
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(Text(String(localized: "Journal")))
+        .accessibilityHint(Text(String(localized: "Open journal")))
+    }
+
+    private func reload() async {
+        guard reminderEnabled else { loggedDays = nil; return }
+        let keys = Self.dayKeys()
+        loggedDays = await repo.nativeJournalDays(from: keys.first ?? "", to: keys.last ?? "")
+    }
+
+    /// The `stripDays` local-day keys (yyyy-MM-dd), oldest → today, matching Android's `journalDayKey`
+    /// (civil-day arithmetic via Calendar so a DST edge can't mislabel a day).
+    private static func dayKeys() -> [String] {
+        let cal = Calendar.current
+        let today = Date()
+        return (0..<stripDays).reversed().map { n in
+            Repository.localDayKey(cal.date(byAdding: .day, value: -n, to: today) ?? today)
+        }
+    }
+}
+
+/// Reload key: a sync (seq) or toggle flip re-reads completion. Mirrors `AutoWorkoutLoadKey`.
+private struct JournalReminderLoadKey: Equatable {
+    let seq: Int
+    let enabled: Bool
+}

--- a/Strand/Screens/SettingsView.swift
+++ b/Strand/Screens/SettingsView.swift
@@ -107,6 +107,10 @@ struct SettingsView: View {
     /// Nothing is ever created automatically. Mirrors the Android `NoopPrefs.KEY_AUTO_DETECT_WORKOUTS`.
     @AppStorage(PuffinExperiment.autoDetectWorkoutsKey) private var autoDetectWorkoutsEnabled = false
 
+    /// "Journal reminder" (#627, default ON). When ON, Today shows the persistent journal widget
+    /// (last-7-days strip + tap-through). Mirrors the Android `NoopPrefs.KEY_JOURNAL_REMINDER_ENABLED`.
+    @AppStorage(PuffinExperiment.journalReminderKey) private var journalReminderEnabled = true
+
     /// Opt-in "Keep screen on during a workout" (default OFF, #703). When ON, the live-workout view
     /// holds the screen awake while a manual recording is running so you can glance at your live HR
     /// without the device dimming. The live-workout view reads this same key. The string is shared
@@ -1186,6 +1190,22 @@ struct SettingsView: View {
                 .accessibilityHint("Offers to save a workout when it spots sustained elevated heart rate")
 
                 Text("After a sync, NOOP looks over your recent heart rate for a sustained, raised stretch that looks like exercise and offers to save it. It only ever suggests. Nothing is saved until you tap Save, and you can dismiss any suggestion. Deliberately conservative, so the odd workout may be missed. On \(Platform.deviceNounPhrase) only.")
+                    .font(StrandFont.caption)
+                    .foregroundStyle(StrandPalette.textTertiary)
+                    .fixedSize(horizontal: false, vertical: true)
+
+                Divider().overlay(StrandPalette.hairline)
+
+                Toggle(isOn: $journalReminderEnabled) {
+                    Text("Journal reminder")
+                        .font(StrandFont.subhead)
+                        .foregroundStyle(StrandPalette.textPrimary)
+                }
+                .toggleStyle(.switch)
+                .tint(StrandPalette.accent)
+                .accessibilityHint("Show a Today card reminding you to log your journal")
+
+                Text("Show a Today card reminding you to log your journal")
                     .font(StrandFont.caption)
                     .foregroundStyle(StrandPalette.textTertiary)
                     .fixedSize(horizontal: false, vertical: true)

--- a/Strand/Screens/TodayView.swift
+++ b/Strand/Screens/TodayView.swift
@@ -1332,6 +1332,9 @@ struct TodayView: View {
                 // Opt-in "looks like a workout?" suggestion (default OFF). Renders only when the
                 // Settings toggle is on AND the detector finds a recent unsaved, un-dismissed window.
                 AutoWorkoutCard()
+                // #627: the persistent journal widget (last-7-days strip + tap-through to the journal).
+                // Today only; self-hides when the reminder toggle is off. Twin of Android JournalReminderCard.
+                if selectedDayOffset == 0 { JournalReminderCard() }
                 sourcesSection
             }
             #if os(iOS)

--- a/StrandiOS/App/RootTabView.swift
+++ b/StrandiOS/App/RootTabView.swift
@@ -161,6 +161,11 @@ struct RootTabView: View {
                 // so a deep-link lands on the Today tab where that entry lives.
                 withAnimation(.timingCurve(0.22, 1, 0.36, 1, duration: 0.24)) { selectedTab = 0 }
                 router.requestedDestination = nil
+            case .journal:
+                // The #627 Today journal widget opens the journal through the quick-action Journal sheet
+                // (InsightsView), matching the FAB's "Log journal" action. Calm sheet easing.
+                withAnimation(Self.sheetEase) { quickAction = .journal }
+                router.requestedDestination = nil
             case nil:
                 break
             }
@@ -195,6 +200,9 @@ struct RootTabView: View {
                 // .liveSession routes to the Today tab (handled above — its Start entry owns the cover);
                 // this keeps the switch exhaustive and falls back to Today if it ever reaches the host.
                 case .liveSession: LiquidTodayView()
+                // .journal opens through the quick-action Journal sheet (handled above); this keeps the
+                // switch exhaustive and falls back to the journal's Insights host if it ever reaches here.
+                case .journal: InsightsView()
                 }
             }
             // The Trends/Today fallbacks above emit TabRoute value pushes (#198), which need a

--- a/android/app/src/main/java/com/noop/ui/AppRoot.kt
+++ b/android/app/src/main/java/com/noop/ui/AppRoot.kt
@@ -340,6 +340,9 @@ fun AppRoot(viewModel: AppViewModel = viewModel()) {
                         // The liquid header's strap battery ring taps through to Devices (iOS parity: the
                         // battery ring → router.openDevices()).
                         onOpenDevices = { nav.navigateTopLevel(Destination.Devices.route) },
+                        // #627: the journal-reminder card opens the journal (hosted in Insights), same
+                        // destination the Sleep screen's morning sheet uses.
+                        onOpenJournal = { nav.navigateTopLevel(Destination.Insights.route) },
                     )
                 }
                 composable(Destination.Live.route) {

--- a/android/app/src/main/java/com/noop/ui/JournalReminder.kt
+++ b/android/app/src/main/java/com/noop/ui/JournalReminder.kt
@@ -1,0 +1,143 @@
+package com.noop.ui
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.MenuBook
+import androidx.compose.material.icons.filled.ChevronRight
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.dp
+import com.noop.R
+import com.noop.data.DailyMetric
+
+/** How many days the completion strip shows (a week, ending today). */
+private const val JOURNAL_STRIP_DAYS = 7
+
+/**
+ * JournalReminderCard — a persistent Today widget for the journal (#627).
+ *
+ * The Journal (behavioural logging that feeds Insights / "What Moves You") is otherwise only reachable
+ * inside the Insights screen, which isn't a primary destination — easy to forget, and the only proactive
+ * prompt today is the once-a-morning sleep sheet (PR #260) that a user skips whenever they don't open
+ * Sleep. This surfaces, on Today where it can't be missed, a WHOOP-style strip of the last
+ * [JOURNAL_STRIP_DAYS] days (filled = logged that day, today ringed) plus an always-present tap-through
+ * to the journal — so it doubles as a reminder AND the "direct link to Insights" the report asked for.
+ *
+ * Opt-out via [NoopPrefs.journalReminderEnabled] (default ON — the same toggle also gates the morning
+ * sleep sheet, so one switch silences both). Renders only for today (the call site gates
+ * `selectedDayOffset == 0`) once the completion read returns. Read-only: it never writes a journal entry.
+ * The whole card taps through to the journal; when today isn't logged yet the subtitle nudges in accent.
+ *
+ * iOS twin `JournalReminderCard.swift` is a fast-follow. Design-Reset compliant — a flat accent-tinted
+ * [NoopCard], NoopType/Palette tokens, matching the other Today cards.
+ */
+@Composable
+fun JournalReminderCard(
+    viewModel: AppViewModel,
+    days: List<DailyMetric>,
+    onOpenJournal: () -> Unit,
+) {
+    val context = LocalContext.current
+    // Read once — SharedPreferences isn't reactive; when off the whole card is invisible + inert.
+    val enabled = remember { NoopPrefs.journalReminderEnabled(context) }
+    if (!enabled) return
+
+    // The N day keys the strip covers, oldest (left) → today (right). journalDayKey(n) = today − n days,
+    // the same wake/cycle key the logging card writes under, so a filled cell == "logged that day".
+    val dayKeys = remember { (JOURNAL_STRIP_DAYS - 1 downTo 0).map { journalDayKey(it.toLong()) } }
+    val todayKey = dayKeys.last()
+
+    // Which of those days have any journal entry. null = still loading / read error → render nothing.
+    var loggedDays by remember { mutableStateOf<Set<String>?>(null) }
+    // Re-query whenever Today's data refreshes (a resume/sync bumps `days`) so the strip and the "logged
+    // today" state stay current after the user logs the journal and comes back. Mirrors AutoWorkoutNudge.
+    LaunchedEffect(days) {
+        loggedDays = runCatching {
+            viewModel.repo.journal(JOURNAL_DEVICE_ID, dayKeys.first(), todayKey)
+                .map { it.day }.toSet()
+        }.getOrNull()
+    }
+
+    val logged = loggedDays ?: return
+    val todayLogged = todayKey in logged
+    val openLabel = uiString(R.string.l10n_journal_reminder_open_journal_bbd88cc1)
+
+    NoopCard(
+        tint = Palette.accent,
+        modifier = Modifier.clickable(onClickLabel = openLabel) { onOpenJournal() },
+    ) {
+        Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
+            Row(modifier = Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
+                Icon(
+                    Icons.AutoMirrored.Filled.MenuBook,
+                    contentDescription = null,
+                    tint = Palette.accent,
+                    modifier = Modifier.size(18.dp),
+                )
+                Spacer(Modifier.width(8.dp))
+                Text(
+                    uiString(R.string.l10n_journal_reminder_journal_57d7f743),
+                    style = NoopType.headline,
+                    color = Palette.textPrimary,
+                )
+                Spacer(Modifier.weight(1f))
+                Icon(
+                    Icons.Filled.ChevronRight,
+                    contentDescription = null,
+                    tint = Palette.textTertiary,
+                    modifier = Modifier.size(18.dp),
+                )
+            }
+            // The last-N-days strip: one equal-width bar per day. Filled = logged; today is ringed so the
+            // orientation is unambiguous even when nothing is logged yet.
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(6.dp),
+            ) {
+                val shape = RoundedCornerShape(3.dp)
+                for (key in dayKeys) {
+                    val isLogged = key in logged
+                    val isToday = key == todayKey
+                    var cell = Modifier
+                        .weight(1f)
+                        .height(10.dp)
+                        .background(
+                            if (isLogged) Palette.accent else Palette.textTertiary.copy(alpha = 0.22f),
+                            shape,
+                        )
+                    if (isToday && !isLogged) cell = cell.border(1.dp, Palette.accent, shape)
+                    Spacer(cell)
+                }
+            }
+            Text(
+                if (todayLogged) {
+                    uiString(R.string.l10n_journal_reminder_logged_today_0071a46c)
+                } else {
+                    uiString(R.string.l10n_journal_reminder_log_today_s_journal_cb33be3e)
+                },
+                style = NoopType.footnote,
+                color = if (todayLogged) Palette.textSecondary else Palette.accent,
+            )
+        }
+    }
+}

--- a/android/app/src/main/java/com/noop/ui/MainActivity.kt
+++ b/android/app/src/main/java/com/noop/ui/MainActivity.kt
@@ -190,6 +190,15 @@ object NoopPrefs {
      *  Sleep screen's "Good morning" sheet to at most once per day. */
     const val KEY_LAST_JOURNAL_PROMPT = "noop.lastJournalPromptDay"
 
+    /** "Journal reminder" (#627). When ON, Today shows a dismissible card whenever nothing has been
+     *  logged to today's journal yet, and the Sleep screen's morning sheet may fire — one switch gates
+     *  both surfaces. Default ON. Mirrors iOS @AppStorage("noopJournalReminder"). */
+    const val KEY_JOURNAL_REMINDER_ENABLED = "noop.journalReminder"
+
+    /** The calendar day (yyyy-MM-dd) on which the Today journal-reminder card was last dismissed, so an
+     *  X hides it until the next day (per-day, like [KEY_LAST_JOURNAL_PROMPT]). */
+    const val KEY_JOURNAL_REMINDER_DISMISSED_DAY = "noop.journalReminderDismissedDay"
+
     /** "Debug logging", when on, the strap log is also written to logcat (`adb`). Default OFF so a
      *  normal user never emits the connection log to the system log; the in-app ring buffer (and the
      *  "Share strap log" export) work regardless. See [com.noop.ble.WhoopBleClient.debugLogcat]. */
@@ -616,6 +625,13 @@ object NoopPrefs {
 
     fun setAutoDetectWorkouts(context: Context, enabled: Boolean) {
         of(context).edit().putBoolean(KEY_AUTO_DETECT_WORKOUTS, enabled).apply()
+    }
+
+    fun journalReminderEnabled(context: Context): Boolean =
+        of(context).getBoolean(KEY_JOURNAL_REMINDER_ENABLED, true)
+
+    fun setJournalReminderEnabled(context: Context, enabled: Boolean) {
+        of(context).edit().putBoolean(KEY_JOURNAL_REMINDER_ENABLED, enabled).apply()
     }
 
     /** Last local day (ISO yyyy-MM-dd) an illness notification was posted, the once-a-day gate,

--- a/android/app/src/main/java/com/noop/ui/SettingsScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/SettingsScreen.kt
@@ -498,6 +498,7 @@ fun SettingsScreen(
     var rhythmEnabled by remember { mutableStateOf(RhythmConsent.isEnabled(context)) }
     var coachSignals by remember { mutableStateOf(NoopPrefs.coachSignals(context)) }
     var autoDetectWorkouts by remember { mutableStateOf(NoopPrefs.autoDetectWorkouts(context)) }
+    var journalReminder by remember { mutableStateOf(NoopPrefs.journalReminderEnabled(context)) }
     // Keep the screen on during a manual workout recording (#703), default OFF. The live-workout
     // screen reads this same "workoutKeepScreenOn" key. String shared verbatim with the iOS/Mac twin
     // (AppStorage "workoutKeepScreenOn"). Read/written inline against the shared prefs store.
@@ -2127,6 +2128,16 @@ fun SettingsScreen(
                     onCheckedChange = {
                         autoDetectWorkouts = it
                         NoopPrefs.setAutoDetectWorkouts(context, it)
+                    },
+                )
+                RowDivider()
+                ToggleRow(
+                    title = uiString(R.string.l10n_journal_reminder_journal_reminder_0fdc0d9c),
+                    detail = uiString(R.string.l10n_journal_reminder_show_a_today_card_reminding_you_to_log_your_journal_8228bc77),
+                    checked = journalReminder,
+                    onCheckedChange = {
+                        journalReminder = it
+                        NoopPrefs.setJournalReminderEnabled(context, it)
                     },
                 )
                 RowDivider()

--- a/android/app/src/main/java/com/noop/ui/SleepScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/SleepScreen.kt
@@ -275,6 +275,9 @@ fun SleepScreen(
     var showJournalPrompt by remember { mutableStateOf(false) }
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
     LaunchedEffect(sleeps) {
+        // #627: the journal-reminder toggle (default ON) gates this morning sheet too, so disabling the
+        // reminder silences both the Today card and this sheet with one switch.
+        if (!NoopPrefs.journalReminderEnabled(context)) return@LaunchedEffect
         val latestEnd = sleeps.lastOrNull()?.endTs ?: return@LaunchedEffect
         val nowS = System.currentTimeMillis() / 1000L
         val hoursAgo = (nowS - latestEnd) / 3600.0

--- a/android/app/src/main/java/com/noop/ui/TodayScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/TodayScreen.kt
@@ -274,6 +274,9 @@ fun TodayScreen(
     // The liquid header battery ring taps through to Devices (iOS parity: the battery ring → router.openDevices()).
     // Defaulted to fall back to Settings so the call site stays compiling; AppRoot binds it to the Devices route.
     onOpenDevices: () -> Unit = onOpenSettings,
+    // The #627 journal-reminder card links straight to the journal (Insights). Defaulted to a no-op so
+    // the call site stays compiling; AppRoot binds it to nav.navigateTopLevel(Insights), same as Sleep.
+    onOpenJournal: () -> Unit = {},
 ) {
     val today by viewModel.today.collectAsStateWithLifecycle()
     val alert by viewModel.healthAlert.collectAsStateWithLifecycle()
@@ -1531,6 +1534,11 @@ fun TodayScreen(
         // toggle is off or there's nothing to suggest. Save → a manual "Workout" row; × → dismissed forever.
         if (selectedDayOffset == 0) {
             item { AutoWorkoutNudgeCard(viewModel = viewModel, days = days) }
+        }
+        // #627: a dismissible "log today's journal" reminder — shows only when nothing is logged today
+        // and the reminder is enabled (default ON). Self-hides otherwise. Taps through to the journal.
+        if (selectedDayOffset == 0) {
+            item { JournalReminderCard(viewModel = viewModel, days = days, onOpenJournal = onOpenJournal) }
         }
         // Strap battery only while the link is up AND a real reading exists, a stale % from a
         // dropped connection must not present as live (#159).

--- a/android/app/src/main/res/values-de/strings.xml
+++ b/android/app/src/main/res/values-de/strings.xml
@@ -1337,6 +1337,12 @@
     <string name="l10n_insights_screen_rest_b79e5f48">Ruhe</string>
     <string name="l10n_insights_screen_rhr_04edf9b3">RHR</string>
     <string name="l10n_journal_log_journal_57d7f743">Tagebuch</string>
+    <string name="l10n_journal_reminder_log_today_s_journal_cb33be3e">Heutiges Journal ausfüllen</string>
+    <string name="l10n_journal_reminder_open_journal_bbd88cc1">Journal öffnen</string>
+    <string name="l10n_journal_reminder_journal_reminder_0fdc0d9c">Journal-Erinnerung</string>
+    <string name="l10n_journal_reminder_show_a_today_card_reminding_you_to_log_your_journal_8228bc77">Eine Heute-Karte anzeigen, die dich ans Ausfüllen deines Journals erinnert</string>
+    <string name="l10n_journal_reminder_journal_57d7f743">Journal</string>
+    <string name="l10n_journal_reminder_logged_today_0071a46c">Heute erfasst</string>
     <string name="l10n_liquid_primitives_liquidpressalpha_2c4048a8">liquidPressAlpha</string>
     <string name="l10n_liquid_primitives_liquidpressscale_7520ddb3">liquidPressScale</string>
     <string name="l10n_live_screen_avg_cdc93143">Ø</string>

--- a/android/app/src/main/res/values-es/strings.xml
+++ b/android/app/src/main/res/values-es/strings.xml
@@ -1177,6 +1177,12 @@
     <string name="l10n_insights_screen_rest_b79e5f48">Descanso</string>
     <string name="l10n_insights_screen_rhr_04edf9b3">RHR</string>
     <string name="l10n_journal_log_journal_57d7f743">Diario</string>
+    <string name="l10n_journal_reminder_log_today_s_journal_cb33be3e">Registra el diario de hoy</string>
+    <string name="l10n_journal_reminder_open_journal_bbd88cc1">Abrir diario</string>
+    <string name="l10n_journal_reminder_journal_reminder_0fdc0d9c">Recordatorio del diario</string>
+    <string name="l10n_journal_reminder_show_a_today_card_reminding_you_to_log_your_journal_8228bc77">Mostrar una tarjeta en Hoy que te recuerde registrar tu diario</string>
+    <string name="l10n_journal_reminder_journal_57d7f743">Diario</string>
+    <string name="l10n_journal_reminder_logged_today_0071a46c">Registrado hoy</string>
     <string name="l10n_liquid_primitives_liquidpressalpha_2c4048a8">líquidoPressAlpha</string>
     <string name="l10n_liquid_primitives_liquidpressscale_7520ddb3">líquidoPresiónScale</string>
     <string name="l10n_live_screen_avg_cdc93143">Prom</string>

--- a/android/app/src/main/res/values-fr/strings.xml
+++ b/android/app/src/main/res/values-fr/strings.xml
@@ -1177,6 +1177,12 @@
     <string name="l10n_insights_screen_rest_b79e5f48">Repos</string>
     <string name="l10n_insights_screen_rhr_04edf9b3">RHR</string>
     <string name="l10n_journal_log_journal_57d7f743">Journal</string>
+    <string name="l10n_journal_reminder_log_today_s_journal_cb33be3e">Remplir le journal du jour</string>
+    <string name="l10n_journal_reminder_open_journal_bbd88cc1">Ouvrir le journal</string>
+    <string name="l10n_journal_reminder_journal_reminder_0fdc0d9c">Rappel du journal</string>
+    <string name="l10n_journal_reminder_show_a_today_card_reminding_you_to_log_your_journal_8228bc77">Afficher une carte Aujourd\'hui vous rappelant de remplir votre journal</string>
+    <string name="l10n_journal_reminder_journal_57d7f743">Journal</string>
+    <string name="l10n_journal_reminder_logged_today_0071a46c">Enregistré aujourd\'hui</string>
     <string name="l10n_liquid_primitives_liquidpressalpha_2c4048a8">liquidePresseAlpha</string>
     <string name="l10n_liquid_primitives_liquidpressscale_7520ddb3">liquidePressScale</string>
     <string name="l10n_live_screen_avg_cdc93143">Moy.</string>

--- a/android/app/src/main/res/values-zh/strings.xml
+++ b/android/app/src/main/res/values-zh/strings.xml
@@ -1305,6 +1305,12 @@
     <string name="l10n_insights_screen_rest_b79e5f48">恢复(Rest)</string>
     <string name="l10n_insights_screen_rhr_04edf9b3">静息心率(RHR)</string>
     <string name="l10n_journal_log_journal_57d7f743">日记</string>
+    <string name="l10n_journal_reminder_log_today_s_journal_cb33be3e">记录今天的日志</string>
+    <string name="l10n_journal_reminder_open_journal_bbd88cc1">打开日志</string>
+    <string name="l10n_journal_reminder_journal_reminder_0fdc0d9c">日志提醒</string>
+    <string name="l10n_journal_reminder_show_a_today_card_reminding_you_to_log_your_journal_8228bc77">在“今天”页面显示提醒你记录日志的卡片</string>
+    <string name="l10n_journal_reminder_journal_57d7f743">日志</string>
+    <string name="l10n_journal_reminder_logged_today_0071a46c">今天已记录</string>
     <string name="l10n_liquid_primitives_liquidpressalpha_2c4048a8">liquidPressAlpha</string>
     <string name="l10n_liquid_primitives_liquidpressscale_7520ddb3">liquidPressScale</string>
     <string name="l10n_live_screen_avg_cdc93143">平均</string>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -1346,6 +1346,12 @@
     <string name="l10n_insights_screen_rest_b79e5f48">Rest</string>
     <string name="l10n_insights_screen_rhr_04edf9b3">RHR</string>
     <string name="l10n_journal_log_journal_57d7f743">Journal</string>
+    <string name="l10n_journal_reminder_log_today_s_journal_cb33be3e">Log today\'s journal</string>
+    <string name="l10n_journal_reminder_open_journal_bbd88cc1">Open journal</string>
+    <string name="l10n_journal_reminder_journal_reminder_0fdc0d9c">Journal reminder</string>
+    <string name="l10n_journal_reminder_show_a_today_card_reminding_you_to_log_your_journal_8228bc77">Show a Today card reminding you to log your journal</string>
+    <string name="l10n_journal_reminder_journal_57d7f743">Journal</string>
+    <string name="l10n_journal_reminder_logged_today_0071a46c">Logged today</string>
     <string name="l10n_liquid_primitives_liquidpressalpha_2c4048a8">liquidPressAlpha</string>
     <string name="l10n_liquid_primitives_liquidpressscale_7520ddb3">liquidPressScale</string>
     <string name="l10n_live_screen_avg_cdc93143">Avg</string>


### PR DESCRIPTION
Implements #627 on **both platforms**. A persistent Today widget for the Journal — matching all three things the report asked for.

## What the report asked → what this does
| #627 asked for | delivered |
|---|---|
| optional **home-screen reminder** to log the journal | ✅ Today widget, opt-out toggle (default ON), nudges in accent when today isn't logged |
| breaks the *"only reminded via sleep"* problem | ✅ no longer sleep-gated — it's on Today |
| **"Last X days"** visual (per the attached WHOOP screenshot) | ✅ a 7-day completion strip: filled = logged that day, today ringed |
| *"Insights are at the bottom … a direct link"* | ✅ the whole card taps through to the journal — a **permanent** link |

## Android (`JournalReminder.kt`) — compile-verified
Reads the last 7 days' completion (`repo.journal(JOURNAL_DEVICE_ID, …)`), renders the strip, taps through to Insights. One toggle (`NoopPrefs.journalReminder`, default ON) gates both the widget and the existing #260 morning sleep sheet. Settings toggle + de/es/fr(+zh) strings.
- `compileFullDebugKotlin` ✓ · `testFullDebugUnitTest` ✓ · `i18n_audit --ci HEAD` ✓

## iOS/macOS (`JournalReminderCard.swift`) — twin, needs app-build to compile
Mirrors the Android widget and `AutoWorkoutCard.swift` patterns: `@AppStorage(journalReminderKey)` default ON, `Repository.nativeJournalDays(from:to:)`, re-reads on `refreshSeq`. Rendered on **both** `LiquidTodayView` (default home) and the classic `TodayView`, today only. Nav: `NavRouter.openJournal()` → iOS opens the journal quick-action sheet (`InsightsView`), macOS selects the Insights sidebar row — **all three exhaustive `NavRouter.Destination` switches updated**. Settings toggle + 4 new xcstrings (de/es/fr/zh-Hans); "Journal"/"Logged today" already existed. i18n audit clean.

**Caveat:** app-target Swift can't compile on Linux and `swift-packages` CI doesn't cover app targets, so the iOS side is **unvalidated until an `app-build` run** (currently blocked by the Actions write-API incident). Written to mirror existing patterns exactly; nav wiring reviewed against every `NavRouter.Destination` switch. Fix-forward on any app-build error.

## Product decision for you
Defaulted **ON** so it works out of the box (the report wants a reminder; WHOOP defaults it on). `AutoWorkoutNudge` defaults **OFF** — flip `journalReminderEnabled` default to `false` (both platforms) if you'd rather it be opt-in.
