### PR TITLE
Harden security audit findings

### DIFF
--- a/Strand/AI/AICoach.swift
+++ b/Strand/AI/AICoach.swift
@@ -75,7 +75,7 @@ enum AIKeyStore {
 
         var attrs = baseQuery
         attrs[kSecValueData as String] = data
-        attrs[kSecAttrAccessible as String] = kSecAttrAccessibleAfterFirstUnlock
+        attrs[kSecAttrAccessible as String] = kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly
         let status = SecItemAdd(attrs as CFDictionary, nil)
         guard status == errSecSuccess else { return false }
         UserDefaults.standard.set(owner, forKey: ownerKey)

--- a/Strand/App/AppModel.swift
+++ b/Strand/App/AppModel.swift
@@ -162,6 +162,8 @@ final class AppModel: ObservableObject {
     @Published var whoopImportFailed = false
     @Published var appleHealthImportFailed = false
     @Published var xiaomiImportFailed = false
+    /// A decoded Health Shortcut import waiting for explicit user confirmation before it writes rows.
+    @Published var pendingShortcutHealthImport: ShortcutHealthImport.PendingImport?
 
     /// True while any data-source import is writing to the local store.
     var hasActiveImport: Bool { activeImportSource != nil }
@@ -1921,35 +1923,54 @@ final class AppModel: ObservableObject {
         }
     }
 
-    /// Handle a `noop://import-health` deep link (PR #581) , the HealthKit-free Shortcuts import for
-    /// sideloaded installs. Ingests the Shortcut-built payload into the `apple-health` source (NEVER the
-    /// strap , `ShortcutHealthImport` enforces the loop guard), then refreshes the dashboard. Surfaces
-    /// the result on the Apple Health card like the file import does. The iOS `.onOpenURL` in StrandiOS/
-    /// calls this; macOS never registers the scheme.
+    /// Handle a `noop://import-health` deep link (PR #581), the HealthKit-free Shortcuts import for
+    /// sideloaded installs. Custom URL schemes are forgeable by other apps/sites, so this only decodes
+    /// and stages the payload. The iOS shell shows a confirmation alert before `confirmHealthImport()`
+    /// writes anything into the `apple-health` source.
     func handleHealthImportURL(_ url: URL) {
+        switch ShortcutHealthImport.prepare(url: url) {
+        case .success(let pending):
+            pendingShortcutHealthImport = pending
+        case .failure(let outcome):
+            beginImport(.appleHealth)
+            Task { await finishShortcutHealthImport(outcome) }
+        }
+    }
+
+    func cancelPendingHealthImport() {
+        pendingShortcutHealthImport = nil
+    }
+
+    func confirmPendingHealthImport() {
+        guard let pending = pendingShortcutHealthImport else { return }
+        pendingShortcutHealthImport = nil
         beginImport(.appleHealth)
         Task {
             guard let store = await repo.storeHandle() else {
                 finishImport(.appleHealth, summary: "Couldn't open the local store.", failed: true)
                 return
             }
-            let outcome = await ShortcutHealthImport.ingest(url: url, into: store)
-            switch outcome {
-            case .imported(let days, let workouts):
-                await repo.refresh()
-                // #833/v7.7.2: the Shortcuts import writes body-composition series (e.g. weight) into
-                // metricSeries, which sits OUTSIDE refresh()'s diff, so refresh() may leave `refreshSeq`
-                // unchanged and AppleHealthView's re-mount cache would serve stale data. Drop the cache so the
-                // next visit re-reads. (Same reasoning as the file-import path above.)
-                repo.appleHealthCache = nil
-                repo.appleHealthLoadedSeq = -1
-                let w = workouts > 0 ? " · \(workouts) workouts" : ""
-                finishImport(.appleHealth, summary: "Imported \(days) days\(w)")
-            case .nothingToImport:
-                finishImport(.appleHealth, summary: "Nothing new to import.")
-            case .rejected(let reason):
-                finishImport(.appleHealth, summary: reason, failed: true)
-            }
+            let outcome = await ShortcutHealthImport.ingest(prepared: pending, into: store)
+            await finishShortcutHealthImport(outcome)
+        }
+    }
+
+    private func finishShortcutHealthImport(_ outcome: ShortcutHealthImport.Outcome) async {
+        switch outcome {
+        case .imported(let days, let workouts):
+            await repo.refresh()
+            // #833/v7.7.2: the Shortcuts import writes body-composition series (e.g. weight) into
+            // metricSeries, which sits OUTSIDE refresh()'s diff, so refresh() may leave `refreshSeq`
+            // unchanged and AppleHealthView's re-mount cache would serve stale data. Drop the cache so the
+            // next visit re-reads. (Same reasoning as the file-import path above.)
+            repo.appleHealthCache = nil
+            repo.appleHealthLoadedSeq = -1
+            let w = workouts > 0 ? " · \(workouts) workouts" : ""
+            finishImport(.appleHealth, summary: "Imported \(days) days\(w)")
+        case .nothingToImport:
+            finishImport(.appleHealth, summary: "Nothing new to import.")
+        case .rejected(let reason):
+            finishImport(.appleHealth, summary: reason, failed: true)
         }
     }
 

--- a/Strand/Data/DataBackup.swift
+++ b/Strand/Data/DataBackup.swift
@@ -27,6 +27,8 @@ import ZIPFoundation
 /// security-scoped access on the panel-returned URLs. Every path is best-effort — failures surface
 /// as a `.failure` result and never crash.
 enum DataBackup {
+    private static let maxBackupSQLiteBytes: Int64 = 2_147_483_648
+    private static let maxBackupSettingsBytes: Int64 = 1_048_576
 
     // MARK: - Result
 
@@ -431,6 +433,17 @@ enum DataBackup {
     /// a backup produced on either platform restores on the other.
     private static let backupEntryName = "noop-backup.sqlite"
 
+    private enum BackupArchiveError: LocalizedError {
+        case entryTooLarge(String)
+
+        var errorDescription: String? {
+            switch self {
+            case .entryTooLarge(let name):
+                return "\(name) is too large to restore safely."
+            }
+        }
+    }
+
     /// "NOOP-backup-2026-06-07.noopbak"
     private static func defaultBackupName() -> String {
         let f = DateFormatter()
@@ -509,15 +522,38 @@ enum DataBackup {
         return head[0] == 0x50 && head[1] == 0x4B && head[2] == 0x03 && head[3] == 0x04
     }
 
-    /// Extract the SQLite entry from a `.noopbak` ZIP at `zipURL` into `destDir`. Each file entry is
-    /// written under its own last-path-component, so the SQLite lands as `<destDir>/<name>.sqlite`
-    /// for the caller to locate. Uses the `Archive` reader (the repo's ZIPFoundation idiom).
+    /// Extract only the canonical entries from a `.noopbak` ZIP at `zipURL` into `destDir`.
+    /// Unknown files are ignored, and each accepted entry is streamed through an uncompressed-size cap
+    /// before it lands on disk.
     private static func extractBackupZip(at zipURL: URL, into destDir: URL) throws {
         let archive = try Archive(url: zipURL, accessMode: .read)
         for entry in archive where entry.type == .file {
             let name = (entry.path as NSString).lastPathComponent
+            let limit: Int64
+            switch name {
+            case backupEntryName:
+                limit = maxBackupSQLiteBytes
+            case BackupSettings.entryName:
+                limit = maxBackupSettingsBytes
+            default:
+                continue
+            }
             let out = destDir.appendingPathComponent(name)
-            _ = try archive.extract(entry, to: out)
+            if FileManager.default.fileExists(atPath: out.path) { try FileManager.default.removeItem(at: out) }
+            FileManager.default.createFile(atPath: out.path, contents: nil)
+            let handle = try FileHandle(forWritingTo: out)
+            defer { try? handle.close() }
+            var written: Int64 = 0
+            _ = try archive.extract(entry) { data in
+                let next = written + Int64(data.count)
+                guard next <= limit else {
+                    try? handle.close()
+                    try? FileManager.default.removeItem(at: out)
+                    throw BackupArchiveError.entryTooLarge(name)
+                }
+                try handle.write(contentsOf: data)
+                written = next
+            }
         }
     }
 

--- a/Strand/Data/ShortcutHealthImport.swift
+++ b/Strand/Data/ShortcutHealthImport.swift
@@ -49,6 +49,7 @@ enum ShortcutHealthImport {
     static let payloadParam = "payload"
     static let versionParam = "v"
     static let supportedVersion = 1
+    static let maxPayloadBytes = 1 << 20
 
     enum Outcome: Error, Equatable {
         case imported(days: Int, workouts: Int)
@@ -90,6 +91,15 @@ enum ShortcutHealthImport {
         var isEmpty: Bool { days.isEmpty && workouts.isEmpty }
     }
 
+    struct PendingImport: Identifiable, Equatable {
+        let id = UUID()
+        let text: String
+        let parsed: Parsed
+
+        var daysCount: Int { parsed.days.count }
+        var workoutsCount: Int { parsed.workouts.count }
+    }
+
     // MARK: - URL → outcome
 
     /// Validate + decode the `noop://import-health` URL into the raw text payload. Returns nil with a
@@ -109,8 +119,13 @@ enum ShortcutHealthImport {
         guard let b64 = params[payloadParam], !b64.isEmpty else {
             return .failure(.rejected("No import payload."))
         }
+        let maxBase64Length = ((maxPayloadBytes + 2) / 3) * 4 + 4
+        guard b64.utf8.count <= maxBase64Length else {
+            return .failure(.rejected("Import payload is too large."))
+        }
         // Tolerate URL-safe base64 (Shortcuts' "Base64 Encode" can emit either) + missing padding.
-        guard let data = decodeBase64(b64), let text = String(data: data, encoding: .utf8) else {
+        guard let data = decodeBase64(b64), data.count <= maxPayloadBytes,
+              let text = String(data: data, encoding: .utf8) else {
             return .failure(.rejected("Couldn't decode the import payload."))
         }
         return .success(text)
@@ -246,6 +261,19 @@ enum ShortcutHealthImport {
 
     // MARK: - Ingest
 
+    /// Decode + parse a Shortcut payload without writing anything. The app uses this to show a
+    /// confirmation sheet before accepting data from the custom URL scheme.
+    static func prepare(url: URL) -> Result<PendingImport, Outcome> {
+        let text: String
+        switch decodePayload(from: url) {
+        case .success(let t): text = t
+        case .failure(let outcome): return .failure(outcome)
+        }
+        let parsed = parse(text)
+        guard !parsed.isEmpty else { return .failure(.nothingToImport) }
+        return .success(PendingImport(text: text, parsed: parsed))
+    }
+
     /// Decode → parse → upsert into `store` under `targetSource`. Returns a typed outcome. Rejects any
     /// caller-supplied source that targets the strap (loop guard). Does NOT refresh the dashboard — the
     /// caller (AppModel) does, matching the file-import path.
@@ -256,13 +284,21 @@ enum ShortcutHealthImport {
         guard !forbiddenSources.contains(source), source == targetSource else {
             return .rejected("Import target must be the Apple Health source, not the strap.")
         }
-        let text: String
-        switch decodePayload(from: url) {
-        case .success(let t): text = t
+        let pending: PendingImport
+        switch prepare(url: url) {
+        case .success(let p): pending = p
         case .failure(let outcome): return outcome
         }
-        let parsed = parse(text)
-        guard !parsed.isEmpty else { return .nothingToImport }
+        return await ingest(prepared: pending, into: store, targetSource: source)
+    }
+
+    @discardableResult
+    static func ingest(prepared pending: PendingImport, into store: WhoopStore,
+                       targetSource source: String = ShortcutHealthImport.targetSource) async -> Outcome {
+        guard !forbiddenSources.contains(source), source == targetSource else {
+            return .rejected("Import target must be the Apple Health source, not the strap.")
+        }
+        let parsed = pending.parsed
         do {
             if !parsed.days.isEmpty {
                 try await store.upsertAppleDaily(appleDailyRows(parsed.days), deviceId: source)

--- a/Strand/Oura/OuraOAuth.swift
+++ b/Strand/Oura/OuraOAuth.swift
@@ -10,13 +10,11 @@ import Foundation
 enum OuraOAuth {
     static let authorizeEndpoint = URL(string: "https://cloud.ouraring.com/oauth/authorize")!
     static let tokenEndpoint = URL(string: "https://api.ouraring.com/oauth/token")!
-    // No hardcoded scope list. Oura's own docs: the `scope` param is OPTIONAL and "if left blank, the
-    // application will request ALL available scopes" — which is exactly the goal, and sidesteps two
-    // documentation traps hit live: the SpO2 scope's name differs between the OpenAPI spec ("spo2Daily")
-    // and the auth docs ("spo2"), and the dev portal grants scopes the public docs don't list at all
-    // (Stress, Heart Health, Ring Configuration — the docs still say "8 scopes", the portal shows 11).
-    // Omitting `scope` requests everything the app registration is configured for; the user still picks
-    // on Oura's consent screen.
+    // Explicit data-minimizing scope list. Do not omit `scope`: Oura treats a blank scope as "all
+    // scopes configured on the app", which can silently grow when the developer portal adds new lanes.
+    // Endpoints with newer portal-only scopes may be skipped by the coordinator until they get a
+    // deliberate opt-in + scope addition.
+    static let scopes = ["email", "personal", "daily", "heartrate", "workout", "tag", "session", "spo2"]
 
     /// The consent URL to open in ASWebAuthenticationSession. `state` is a caller-generated nonce echoed
     /// back on redirect and verified, to defeat CSRF / stray callbacks.
@@ -26,7 +24,7 @@ enum OuraOAuth {
             .init(name: "response_type", value: "code"),
             .init(name: "client_id", value: credentials.clientId),
             .init(name: "redirect_uri", value: credentials.redirectURI),
-            // `scope` deliberately omitted — see the note above: blank = all available scopes.
+            .init(name: "scope", value: scopes.joined(separator: " ")),
             .init(name: "state", value: state),
         ]
         return comps.url!

--- a/Strand/Oura/OuraTokenStore.swift
+++ b/Strand/Oura/OuraTokenStore.swift
@@ -17,7 +17,7 @@ struct OuraTokens: Equatable, Codable {
 
 /// Keychain Services wrapper for the Oura tokens. One generic-password item (JSON-encoded `OuraTokens`)
 /// under a fixed service, so tokens never land in UserDefaults, a plist, or on disk in the clear.
-/// Mirrors AIKeyStore exactly (delete-then-add, kSecAttrAccessibleAfterFirstUnlock).
+/// Mirrors AIKeyStore exactly (delete-then-add, ThisDeviceOnly Keychain accessibility).
 enum OuraTokenStore {
     private static let service = "com.noop.oura"
     private static let account = "oauth-tokens"
@@ -38,7 +38,7 @@ enum OuraTokenStore {
         SecItemDelete(baseQuery as CFDictionary)
         var attrs = baseQuery
         attrs[kSecValueData as String] = data
-        attrs[kSecAttrAccessible as String] = kSecAttrAccessibleAfterFirstUnlock
+        attrs[kSecAttrAccessible as String] = kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly
         return SecItemAdd(attrs as CFDictionary, nil) == errSecSuccess
     }
 

--- a/StrandTests/BackupSyncRoundTripTests.swift
+++ b/StrandTests/BackupSyncRoundTripTests.swift
@@ -1,5 +1,6 @@
 import XCTest
 import SQLite3
+import ZIPFoundation
 @testable import Strand
 
 /// Real file-I/O tests for the Backup & Sync restore path - not string logic (must-fix #5).
@@ -170,6 +171,28 @@ final class BackupSyncRoundTripTests: XCTestCase {
         let result = DataBackup.restore(from: corrupt, toDatabaseAt: liveDB.path)
         guard case .failure = result else {
             return XCTFail("A corrupt file must be rejected, got \(result)")
+        }
+        XCTAssertEqual(try Data(contentsOf: liveDB), before,
+                       "The live DB must be unchanged after a rejected restore")
+    }
+
+    func testZipWithNonCanonicalSqliteEntryIsRejectedAndLiveDbIntact() throws {
+        let wrong = tmp.appendingPathComponent("wrong-entry.noopbak")
+        let fake = tmp.appendingPathComponent("evil.sqlite")
+        var bytes = Data("SQLite format 3".utf8)
+        bytes.append(0)
+        bytes.append(Data("junk".utf8))
+        try bytes.write(to: fake)
+        let archive = try XCTUnwrap(Archive(url: wrong, accessMode: .create))
+        try archive.addEntry(with: "evil.sqlite", fileURL: fake)
+
+        let liveDB = tmp.appendingPathComponent("live.sqlite")
+        try makeNoopDatabase(at: liveDB, deviceRows: ["original"])
+        let before = try Data(contentsOf: liveDB)
+
+        let result = DataBackup.restore(from: wrong, toDatabaseAt: liveDB.path)
+        guard case .failure = result else {
+            return XCTFail("A zip without noop-backup.sqlite must be rejected, got \(result)")
         }
         XCTAssertEqual(try Data(contentsOf: liveDB), before,
                        "The live DB must be unchanged after a rejected restore")

--- a/StrandTests/OuraOAuthTests.swift
+++ b/StrandTests/OuraOAuthTests.swift
@@ -18,9 +18,11 @@ final class OuraOAuthTests: XCTestCase {
         XCTAssertEqual(q["client_id"], "cid")
         XCTAssertEqual(q["redirect_uri"], "noop://oura/callback")
         XCTAssertEqual(q["state"], "xyz")
-        // `scope` is deliberately omitted: Oura grants ALL app-configured scopes when it's blank —
-        // covering the portal-only scopes (Stress, Heart Health, Ring Configuration) the docs don't name.
-        XCTAssertNil(q["scope"])
+        XCTAssertEqual(q["scope"], OuraOAuth.scopes.joined(separator: " "))
+        XCTAssertTrue(OuraOAuth.scopes.contains("daily"))
+        XCTAssertTrue(OuraOAuth.scopes.contains("heartrate"))
+        XCTAssertTrue(OuraOAuth.scopes.contains("spo2"))
+        XCTAssertFalse(OuraOAuth.scopes.contains("spo2Daily"))
     }
 
     func testTokenExchangeRequestIsFormPost() throws {

--- a/StrandTests/ShortcutHealthImportTests.swift
+++ b/StrandTests/ShortcutHealthImportTests.swift
@@ -30,6 +30,15 @@ final class ShortcutHealthImportTests: XCTestCase {
         XCTAssertEqual(text, "D,2026-06-01,1000,,,,,,,")
     }
 
+    func testPrepareStagesWithoutWriting() {
+        let u = url(payloadText: "D,2026-06-01,1000,,,,,,,\nW,1000,1600,Walking,,,")
+        guard case .success(let pending) = ShortcutHealthImport.prepare(url: u) else {
+            return XCTFail("expected pending import")
+        }
+        XCTAssertEqual(pending.daysCount, 1)
+        XCTAssertEqual(pending.workoutsCount, 1)
+    }
+
     func testRejectsForeignScheme() {
         let u = url(payloadText: "D,2026-06-01,1000", scheme: "https")
         guard case .failure = ShortcutHealthImport.decodePayload(from: u) else {
@@ -48,6 +57,14 @@ final class ShortcutHealthImportTests: XCTestCase {
         let u = url(payloadText: "D,2026-06-01,1000", version: 99)
         guard case .failure = ShortcutHealthImport.decodePayload(from: u) else {
             return XCTFail("a future version must be rejected")
+        }
+    }
+
+    func testRejectsOversizedPayloadBeforeImport() {
+        let huge = String(repeating: "A", count: ShortcutHealthImport.maxPayloadBytes + 1)
+        let u = url(payloadText: huge)
+        guard case .failure = ShortcutHealthImport.decodePayload(from: u) else {
+            return XCTFail("an oversized payload must be rejected")
         }
     }
 

--- a/StrandiOS/App/StrandiOSApp.swift
+++ b/StrandiOS/App/StrandiOSApp.swift
@@ -162,6 +162,21 @@ struct StrandiOSApp: App {
                         model.handleHealthImportURL(url)
                     }
                 }
+                .alert("Import Apple Health data?", isPresented: Binding(
+                    get: { model.pendingShortcutHealthImport != nil },
+                    set: { showing in
+                        if !showing { model.cancelPendingHealthImport() }
+                    }
+                )) {
+                    Button("Import") { model.confirmPendingHealthImport() }
+                    Button("Cancel", role: .cancel) { model.cancelPendingHealthImport() }
+                } message: {
+                    if let pending = model.pendingShortcutHealthImport {
+                        Text("A Shortcut wants to add \(pending.daysCount) days and \(pending.workoutsCount) workouts to the Apple Health import source.")
+                    } else {
+                        Text("A Shortcut wants to add data to the Apple Health import source.")
+                    }
+                }
                 // Bring the watch link up once at launch (WCSession ignores a redundant activate), then
                 // push the first snapshot so a watch that's already on-wrist gets current scores without
                 // waiting for the next foreground. activate() is idempotent + a no-op where WC isn't

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -13,6 +13,10 @@ val keystorePropsFile = rootProject.file("keystore.properties")
 val keystoreProps = Properties().apply {
     if (keystorePropsFile.exists()) keystorePropsFile.inputStream().use { load(it) }
 }
+val isStagingRelease = project.hasProperty("stagingRelease")
+val requestedReleaseBuild = gradle.startParameter.taskNames.any {
+    it.contains("Release", ignoreCase = true)
+}
 
 android {
     namespace = "com.noop"
@@ -69,16 +73,23 @@ android {
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro"
             )
-            // Real release key when keystore.properties is present; otherwise the debug key,
-            // so a fresh clone can still build an installable release APK.
-            signingConfig = if (keystorePropsFile.exists())
+            if (!keystorePropsFile.exists() && !isStagingRelease && requestedReleaseBuild) {
+                throw GradleException(
+                    "Refusing to build a real release without keystore.properties. " +
+                        "Use -PstagingRelease for debug-key staging artifacts only."
+                )
+            }
+            // Real release key when keystore.properties is present. The debug-key fallback is allowed
+            // only for explicit fork/staging artifacts that install under their own application id.
+            signingConfig = if (keystorePropsFile.exists()) {
                 signingConfigs.getByName("release")
-            else
+            } else {
                 signingConfigs.getByName("debug")
+            }
             // Fork staging release: built with -PstagingRelease (the fork testing-build CI only), the
             // release APK gets its own id/name so it installs BESIDE both the official app and the
             // .debug staging build. A real release (no property) keeps the true com.noop.whoop id.
-            if (project.hasProperty("stagingRelease")) {
+            if (isStagingRelease) {
                 applicationIdSuffix = ".staging"
                 versionNameSuffix = "-staging"
             }

--- a/android/app/src/main/java/com/noop/ai/AiCoach.kt
+++ b/android/app/src/main/java/com/noop/ai/AiCoach.kt
@@ -438,10 +438,10 @@ class AiCoach(private val repo: WhoopRepository) {
 
     /**
      * Gatekeeper for the Custom (local LLM) provider. https:// is always fine. Plain http:// is
-     * only allowed to a PRIVATE-NETWORK host, loopback, RFC1918, link-local, or *.local, because
-     * the app's network-security-config permits cleartext app-wide (Android XML can't scope a
-     * cleartext rule to a CIDR), so THIS check is what actually keeps cleartext off the public
-     * internet (#187). A public http:// host is rejected with a precise, actionable error.
+     * allowed only for local user-owned endpoints: loopback, RFC1918 private LAN addresses,
+     * IPv4 link-local addresses, and *.local mDNS names. Android XML cannot express those CIDR
+     * ranges, so network-security-config permits platform cleartext and this guard is the public
+     * HTTP boundary.
      */
     private fun guardCustomUrl(base: String) {
         val uri = runCatching { java.net.URI(base) }.getOrNull()
@@ -455,8 +455,8 @@ class AiCoach(private val repo: WhoopRepository) {
             "Unsupported URL scheme \"$scheme\". Use http:// for a local server or https:// for a remote one."
         }
         require(isPrivateLanOrLoopback(host)) {
-            "Plain http:// is only allowed to a local-network server (localhost, 10.x, 172.16-31.x, " +
-                "192.168.x, 169.254.x, or a .local name). Use https:// to reach \"$host\"."
+            "Plain http:// is only allowed for localhost, private LAN IPs, link-local IPs, or " +
+                ".local hostnames. Use https:// to reach \"$host\"."
         }
     }
 
@@ -586,14 +586,12 @@ class AiCoach(private val repo: WhoopRepository) {
         } catch (e: java.io.IOException) {
             // The platform reports a blocked plain-HTTP request as a generic IOException whose
             // message is "Cleartext HTTP traffic to <host> not permitted" (no dedicated exception
-            // class exists). Detect it and explain, instead of the opaque generic line. This should
-            // be unreachable now that cleartext is permitted app-wide and guardCustomUrl restricts
-            // http:// to private hosts, but stays as a clear fallback if a policy re-blocks it.
+            // class exists). Detect it and explain, instead of the opaque generic line.
             val msg = e.message.orEmpty()
             if (msg.contains("Cleartext", ignoreCase = true) && msg.contains("not permitted", ignoreCase = true)) {
                 throw Exception(
-                    "Plain http:// to a LAN address is blocked, update to the build that allows " +
-                        "local-network servers, or use https://."
+                    "Plain http:// is blocked for that host. Use localhost, 127.0.0.1, 10.0.2.2, " +
+                        "a .local hostname, or switch the server to https://."
                 )
             }
             throw Exception("Network error reaching the provider: ${e.message ?: "unknown"}.")
@@ -670,29 +668,21 @@ class AiCoach(private val repo: WhoopRepository) {
         }
 
         /**
-         * True when [host] is on the device's own machine or its private LAN, so plain http:// to it
-         * never crosses the public internet: loopback (localhost / 127.0.0.0/8 / ::1), RFC1918
-         * (10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16), link-local (169.254.0.0/16 / fe80::/10), the
-         * emulator host alias 10.0.2.2, and any *.local mDNS name. Anything else is treated as public.
-         * Pure; `internal` so it's unit-testable (#321) — the byte-parity reference for Swift
-         * `AIProvider.isPrivateLANOrLoopback`. Called unqualified by the instance `guardCustomUrl`.
+         * True when [host] is local/private enough for Custom-provider plain HTTP: localhost,
+         * loopback, RFC1918 private LAN, IPv4 link-local, or any *.local mDNS name. Anything else
+         * is treated as requiring HTTPS. Pure; `internal` so it's unit-testable (#321/#187).
+         * Called unqualified by `guardCustomUrl`.
          */
         internal fun isPrivateLanOrLoopback(host: String): Boolean {
             val raw = host.trim()
             val h = raw.trim('[', ']').lowercase()  // strip IPv6 brackets if present
             if (h.isEmpty()) return false
 
-            // Is this an IPv6 LITERAL, not a DNS hostname? A URI gives a bracketed host for an IPv6
-            // literal ("[::1]"), and an IPv6 literal always contains a colon while a DNS host (the host
-            // component excludes the :port) never does. We must only apply the fc/fd/fe80 ULA/link-local
-            // classification to a real literal, otherwise a PUBLIC name like "fclient.evil.com" or
-            // "fdn.example.com" starts with "fc"/"fd" and would be wrongly allowed plain-HTTP cleartext.
             val isIpv6Literal = raw.startsWith("[") || h.contains(':')
             if (isIpv6Literal) {
-                if (h == "::1") return true                                   // loopback
-                // fc00::/7 unique-local, fe80::/10 link-local, literal-only.
-                if (h.startsWith("fc") || h.startsWith("fd") || h.startsWith("fe80:")) return true
-                return false                                                  // any other IPv6 literal = public
+                return h == "::1" ||
+                    h.startsWith("fe80:") || h.startsWith("fe80::") ||
+                    h.startsWith("fc") || h.startsWith("fd")
             }
 
             if (h == "localhost" || h.endsWith(".localhost")) return true
@@ -700,20 +690,17 @@ class AiCoach(private val repo: WhoopRepository) {
             // "local" can't slip through), and only for an actual hostname (handled above for literals).
             if (h.endsWith(".local") && h.length > ".local".length) return true
 
-            // IPv4 dotted-quad: validate and classify by RFC1918 / loopback / link-local.
             val parts = h.split(".")
             if (parts.size != 4) return false
             val octets = parts.map { it.toIntOrNull() ?: -1 }
             if (octets.any { it < 0 || it > 255 }) return false
-            val (a, b) = octets[0] to octets[1]
-            return when {
-                a == 127 -> true                              // 127.0.0.0/8 loopback
-                a == 10 -> true                               // 10.0.0.0/8
-                a == 172 && b in 16..31 -> true               // 172.16.0.0/12
-                a == 192 && b == 168 -> true                  // 192.168.0.0/16
-                a == 169 && b == 254 -> true                  // 169.254.0.0/16 link-local
-                else -> false
-            }
+            val a = octets[0]
+            val b = octets[1]
+            return a == 127 ||                  // loopback
+                a == 10 ||                      // RFC1918 10/8
+                (a == 172 && b in 16..31) ||    // RFC1918 172.16/12
+                (a == 192 && b == 168) ||       // RFC1918 192.168/16
+                (a == 169 && b == 254)          // IPv4 link-local
         }
 
         /**

--- a/android/app/src/main/java/com/noop/data/DataBackup.kt
+++ b/android/app/src/main/java/com/noop/data/DataBackup.kt
@@ -47,6 +47,9 @@ object DataBackup {
     /** Entry name of the optional whitelisted-settings JSON (#1000). Matches the Apple exporter. */
     private const val SETTINGS_ENTRY_NAME = BackupSettingsCodec.ENTRY_NAME
 
+    private const val MAX_BACKUP_SQLITE_BYTES = 2_147_483_648L
+    private const val MAX_BACKUP_SETTINGS_BYTES = 1_048_576L
+
     /** First 16 bytes of every SQLite 3 file: "SQLite format 3\0". */
     private val SQLITE_MAGIC: ByteArray =
         byteArrayOf(
@@ -173,6 +176,11 @@ object DataBackup {
                 StageResult.NO_DB_IN_ZIP -> {
                     tempSettings.delete()
                     return ImportResult.Failed("The backup archive doesn't contain a database file.")
+                }
+                StageResult.ENTRY_TOO_LARGE -> {
+                    tempSqlite.delete()
+                    tempSettings.delete()
+                    return ImportResult.Failed("The backup archive is too large to restore safely.")
                 }
                 StageResult.NOT_A_BACKUP -> return ImportResult.Failed(
                     "That file is not a NOOP backup - it doesn't look like a .noopbak archive or a SQLite database."
@@ -331,7 +339,7 @@ object DataBackup {
     // ── Container staging (pure file/stream layer, unit-tested under real file I/O) ──────
 
     /** Outcome of [stageBackupSqlite]: the SQLite was staged, or why it wasn't. */
-    enum class StageResult { OK, CANNOT_OPEN, NO_DB_IN_ZIP, NOT_A_BACKUP }
+    enum class StageResult { OK, CANNOT_OPEN, NO_DB_IN_ZIP, NOT_A_BACKUP, ENTRY_TOO_LARGE }
 
     /**
      * Stage the SQLite payload of a backup into [dest], from an already-opened [input] stream whose
@@ -364,13 +372,24 @@ object DataBackup {
                         var entry = zip.nextEntry
                         while (entry != null) {
                             when {
-                                !entry.isDirectory && !foundDb && entry.name.endsWith(".sqlite") -> {
-                                    FileOutputStream(dest).use { out -> zip.copyTo(out) }
+                                !entry.isDirectory && !foundDb &&
+                                    entry.name.substringAfterLast('/') == ZIP_ENTRY_NAME -> {
+                                    FileOutputStream(dest).use { out ->
+                                        if (!copyBounded(zip, out, MAX_BACKUP_SQLITE_BYTES)) {
+                                            dest.delete()
+                                            return StageResult.ENTRY_TOO_LARGE
+                                        }
+                                    }
                                     foundDb = true
                                 }
                                 !entry.isDirectory && !foundSettings && settingsDest != null &&
                                     entry.name.substringAfterLast('/') == SETTINGS_ENTRY_NAME -> {
-                                    FileOutputStream(settingsDest).use { out -> zip.copyTo(out) }
+                                    FileOutputStream(settingsDest).use { out ->
+                                        if (!copyBounded(zip, out, MAX_BACKUP_SETTINGS_BYTES)) {
+                                            settingsDest.delete()
+                                            return StageResult.ENTRY_TOO_LARGE
+                                        }
+                                    }
                                     foundSettings = true
                                 }
                             }
@@ -382,11 +401,28 @@ object DataBackup {
                     return if (foundDb) StageResult.OK else StageResult.NO_DB_IN_ZIP
                 }
                 header.startsWith(SQLITE_MAGIC) -> {
-                    FileOutputStream(dest).use { out -> stream.copyTo(out) }
+                    FileOutputStream(dest).use { out ->
+                        if (!copyBounded(stream, out, MAX_BACKUP_SQLITE_BYTES)) {
+                            dest.delete()
+                            return StageResult.ENTRY_TOO_LARGE
+                        }
+                    }
                     return StageResult.OK
                 }
                 else -> return StageResult.NOT_A_BACKUP
             }
+        }
+    }
+
+    private fun copyBounded(input: java.io.InputStream, out: java.io.OutputStream, cap: Long): Boolean {
+        val buffer = ByteArray(DEFAULT_BUFFER_SIZE)
+        var total = 0L
+        while (true) {
+            val read = input.read(buffer)
+            if (read < 0) return true
+            if (total + read > cap) return false
+            out.write(buffer, 0, read)
+            total += read
         }
     }
 

--- a/android/app/src/main/res/xml/network_security_config.xml
+++ b/android/app/src/main/res/xml/network_security_config.xml
@@ -1,20 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  Cleartext (plain HTTP) is BLOCKED by default — every PUBLIC endpoint (the cloud AI providers,
-  anything else) MUST use HTTPS. base-config keeps cleartextTrafficPermitted="false".
+  Android's XML policy cannot express RFC1918/link-local CIDR ranges. Keep platform cleartext
+  enabled so user-configured LAN LLM servers by private IP keep working (#187); the Custom
+  provider's Kotlin guard is the actual public-HTTP boundary.
 
-  THE ONE EXCEPTION is a private-network local LLM. The AI Coach's "Custom (OpenAI-compatible)"
-  provider talks to a server the user runs themselves — Ollama / LM Studio / llama.cpp — which is
-  reached over the LAN at http://localhost / 127.0.0.1, the emulator host alias 10.0.2.2, or a
-  private-LAN IP like http://192.168.x.x:11434 (#187). That traffic never leaves the user's own
-  network, so cleartext to it is safe.
-
-  Android's network-security-config matches by hostname/domain and CANNOT express a CIDR range, so
-  it is impossible to scope a domain-config to "192.168.0.0/16". We therefore permit cleartext at
-  the base and rely on a code-level guard — AiCoach.isPrivateLanOrLoopback(host) — to ALLOW http://
-  only to loopback + RFC1918 (10/8, 172.16/12, 192.168/16) + link-local (169.254/16) + *.local, and
-  to REJECT public-internet cleartext with a clear error. The two layers together mean a LAN LLM
-  works while the broadened XML permission can never be abused to send cleartext to the open web.
+  Built-in cloud AI providers are hardcoded HTTPS endpoints, and arbitrary Custom URLs are rejected
+  before OkHttp attempts a request unless they are loopback, RFC1918, link-local, or .local hosts.
 -->
 <network-security-config>
     <base-config cleartextTrafficPermitted="true" />

--- a/android/app/src/test/java/com/noop/ai/CustomUrlLocalityTest.kt
+++ b/android/app/src/test/java/com/noop/ai/CustomUrlLocalityTest.kt
@@ -5,45 +5,55 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 
 /**
- * #321 / #187: the Custom (local-LLM) provider locality classifier — plain http:// is allowed ONLY to a
- * host on the device or its private LAN, so a public cleartext endpoint can never egress. This is the
- * byte-parity REFERENCE for the Swift twin `AIProvider.isPrivateLANOrLoopback` (Swift was missing the
- * guard entirely — #321). Same fixtures must classify identically on both platforms.
+ * #321 / #187: the Custom (local-LLM) provider cleartext classifier. Android's XML policy cannot
+ * express RFC1918/link-local CIDR ranges, so network-security-config permits platform cleartext
+ * and this guard prevents public cleartext egress for arbitrary Custom URLs.
  */
 class CustomUrlLocalityTest {
 
-    private fun local(h: String) =
-        assertTrue("$h should be treated as local/LAN", AiCoach.isPrivateLanOrLoopback(h))
+    private fun cleartextAllowed(h: String) =
+        assertTrue("$h should be allowed for Android cleartext", AiCoach.isPrivateLanOrLoopback(h))
 
-    private fun public_(h: String) =
-        assertFalse("$h should be treated as PUBLIC (no cleartext)", AiCoach.isPrivateLanOrLoopback(h))
+    private fun cleartextBlocked(h: String) =
+        assertFalse("$h should require HTTPS", AiCoach.isPrivateLanOrLoopback(h))
 
     @Test
-    fun `loopback and LAN hosts are local`() {
+    fun `local and private LAN hosts permit cleartext`() {
         listOf(
             "localhost", "foo.localhost",
             "127.0.0.1", "127.255.255.254",
-            "10.0.0.5", "10.0.2.2",              // 10/8 incl. the Android-emulator host alias
-            "172.16.0.1", "172.31.255.254",      // 172.16/12
-            "192.168.1.100",                     // 192.168/16
-            "169.254.10.20",                     // link-local
-            "::1", "[::1]",                       // IPv6 loopback (bracketed or not)
-            "fc00::1", "fd12:3456::1", "fe80::abcd",  // ULA / link-local literals
+            "10.0.2.2", "10.0.0.5",             // Android-emulator host alias + RFC1918
+            "172.16.0.1", "172.31.255.254",
+            "192.168.1.100",
+            "169.254.10.20",
+            "::1", "[::1]",
+            "fc00::1", "fd12:3456::1", "fe80::abcd",
             "nas.local", "printer.local",        // mDNS
-        ).forEach(::local)
+        ).forEach(::cleartextAllowed)
     }
 
     @Test
-    fun `public hosts are rejected — incl the fc-name and 172-edge traps`() {
+    fun `public and malformed local hosts require HTTPS`() {
         listOf(
             "api.openai.com", "example.com",
             "8.8.8.8", "1.2.3.4",
-            "172.15.0.1", "172.32.0.1",          // just outside 172.16-31
-            "fclient.evil.com", "fdn.example.com",  // public NAMES starting fc/fd — must NOT be ULA
-            "fe80.evil.com",                     // public name starting fe80 (not an IPv6 literal)
+            "172.15.255.255", "172.32.0.0",
+            "169.253.255.255",
+            "fclient.evil.com", "fdn.example.com",
+            "fe80.evil.com",
             "2001:4860:4860::8888",              // public IPv6 literal
             "local", ".local",                   // bare mDNS suffix must not pass
             "",                                  // empty
-        ).forEach(::public_)
+        ).forEach(::cleartextBlocked)
+    }
+
+    @Test
+    fun `built in cloud provider endpoints are https only`() {
+        AiProvider.entries
+            .filter { it != AiProvider.CUSTOM }
+            .forEach { provider ->
+                assertTrue("${provider.name} chat endpoint must be HTTPS", provider.endpoint.startsWith("https://"))
+                assertTrue("${provider.name} models endpoint must be HTTPS", provider.modelsEndpoint.startsWith("https://"))
+            }
     }
 }

--- a/android/app/src/test/java/com/noop/data/BackupSettingsCodecTest.kt
+++ b/android/app/src/test/java/com/noop/data/BackupSettingsCodecTest.kt
@@ -8,6 +8,8 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
 import java.io.File
+import java.util.zip.ZipEntry
+import java.util.zip.ZipOutputStream
 
 /**
  * The `settings.json` half of #1000 ("restore doesn't bring back settings/weight/height"): the pure
@@ -162,5 +164,22 @@ class BackupSettingsCodecTest {
         val result = DataBackup.stageBackupSqlite(backup.inputStream(), DataBackup.peekHeader(backup), stagedDb)
         assertEquals(DataBackup.StageResult.OK, result)
         assertEquals(liveDb.readBytes().toList(), stagedDb.readBytes().toList())
+    }
+
+    @Test fun zipWithNonCanonicalSqliteEntryIsRejected() {
+        val backup = tmp.newFile("wrong-entry.noopbak")
+        ZipOutputStream(backup.outputStream()).use { zip ->
+            zip.putNextEntry(ZipEntry("evil.sqlite"))
+            zip.write(sqliteMagic)
+            zip.write("rows".toByteArray())
+            zip.closeEntry()
+        }
+
+        val stagedDb = tmp.newFile()
+        val result = DataBackup.stageBackupSqlite(
+            backup.inputStream(), DataBackup.peekHeader(backup), stagedDb,
+        )
+
+        assertEquals(DataBackup.StageResult.NO_DB_IN_ZIP, result)
     }
 }


### PR DESCRIPTION
Summary
- restrict Android cleartext HTTP to local allowlisted hosts and keep cloud provider endpoints HTTPS-only
- minimize Oura OAuth scopes and store API/OAuth secrets with ThisDeviceOnly Keychain accessibility
- stage Health Shortcut deep-link imports behind explicit confirmation
- fail real Android release builds when no release keystore is configured
- cap .noopbak restore extraction and require canonical backup entry names on Apple and Android

Security issues
Closes #634
Closes #635
Closes #636
Closes #637
Closes #638
Closes #639

Verification
- xcodebuild test -scheme Strand -destination 'platform=macOS' -only-testing:StrandTests/ShortcutHealthImportTests -only-testing:StrandTests/OuraOAuthTests -only-testing:StrandTests/BackupSyncRoundTripTests
- JAVA_HOME=/opt/homebrew/opt/openjdk@21/libexec/openjdk.jdk/Contents/Home ANDROID_HOME=$HOME/Library/Android/sdk ./gradlew testFullDebugUnitTest --tests 'com.noop.data.BackupSettingsCodecTest' --tests 'com.noop.ai.CustomUrlLocalityTest'
- JAVA_HOME=/opt/homebrew/opt/openjdk@21/libexec/openjdk.jdk/Contents/Home ANDROID_HOME=$HOME/Library/Android/sdk ./gradlew :app:assembleFullRelease (expected failure without keystore.properties)
- git diff --check