### PR TITLE
Oura: live On-wrist / Off-wrist wear status — Android twin (#628)

### DIFF
--- a/android/app/src/main/java/com/noop/ble/OuraLiveSource.kt
+++ b/android/app/src/main/java/com/noop/ble/OuraLiveSource.kt
@@ -36,6 +36,8 @@ import com.noop.oura.OuraOuterFrame
 import com.noop.oura.OuraReassembler
 import com.noop.oura.OuraRingGen
 import com.noop.oura.OuraTransition
+import com.noop.oura.OuraWearState
+import com.noop.oura.OuraWearTracker
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -159,6 +161,28 @@ class OuraLiveSource(
     /** The live adopt outcome (see [AdoptPhase]). The wizard observes this to leave its Adopting step. Reset
      *  to [AdoptPhase.Idle] on every connect/stop/disconnect so a stale outcome never drives a transition. */
     val adoptPhase: StateFlow<AdoptPhase> = _adoptPhase.asStateFlow()
+
+    // MARK: - Live wear/charge indicator (#628 twin) — On wrist / Off wrist / charging
+    //
+    // The ring emits no "worn" event, so wear is inferred: a LIVE-HR push (0x2F) means a finger; a silent
+    // live stream past a grace window means it came off; the ring's "chg. detected"/"stopped" STATE strings
+    // mean charging. All pure logic lives in [OuraWearTracker]; this source just feeds it the live signals.
+    // Faithful twin of Strand/BLE/OuraLiveSource.swift's wear wiring.
+    private val wearTracker = OuraWearTracker()
+    /** The last published wear state, so each TRANSITION is logged once (steady state is not). */
+    private var loggedWearState: OuraWearState? = null
+    /** When the last LIVE-HR beat arrived (epoch ms). If the stream goes quiet for [wornPulseTimeoutMs]
+     *  while we keep re-engaging it, the ring came off the finger -> NOT WORN. null until the first beat. */
+    private var lastLivePulseAt: Long? = null
+    /** Grace before a silent live-HR stream reads as "removed": the ring auto-reverts live HR ~20 s and we
+     *  re-engage every [reengageIntervalMs] (15 s), so a worn ring resumes beats well within this window;
+     *  exceeding it means no finger. Checked on the re-engage tick. Mirrors iOS `wornPulseTimeout` (40 s). */
+    private val wornPulseTimeoutMs = 40_000L
+
+    private val _ouraWearState = MutableStateFlow<OuraWearState?>(null)
+    /** The ring's live wear/charge state (worn/charging/off), or null before any evidence this session and
+     *  after disconnect (a stale badge must not outlive the link). Twin of iOS `LiveState.ouraWearState`. */
+    val ouraWearState: StateFlow<OuraWearState?> = _ouraWearState.asStateFlow()
 
     // MARK: - Adopt consent (gates the DANGEROUS post-factory-reset key install, OURA_PROTOCOL.md s3.2)
 
@@ -333,6 +357,15 @@ class OuraLiveSource(
             val d = driver ?: return
             if (d.phase == OuraDriverPhase.Streaming) {
                 for (cmd in d.reengageLiveHRCommands()) write(cmd)
+            }
+            // Removal watchdog (#628): if the live-HR stream has gone silent past the grace window while we
+            // keep re-engaging it, the ring came off the finger (there is no "removed" event). Downgrades
+            // WORN -> OFF; the tracker never overrides CHARGING. Mirrors the iOS re-engage-tick watchdog.
+            lastLivePulseAt?.let { last ->
+                if (System.currentTimeMillis() - last > wornPulseTimeoutMs) {
+                    wearTracker.noteLivePulseTimeout()
+                    publishWearState()
+                }
             }
             // Reschedule only while a session is live; stop() clears reengageScheduled + removes callbacks.
             if (reengageScheduled) handler.postDelayed(this, reengageIntervalMs)
@@ -523,6 +556,7 @@ class OuraLiveSource(
         reassembler.reset()
         pendingInstallKey = null       // a new connection starts with no install in flight
         _adoptPhase.value = AdoptPhase.Idle   // a stale outcome must never drive the wizard's transition
+        resetWear()   // #628: fresh session — clear any stale worn/charging badge
         // A fresh session: reset the one-shot streaming/anchor state, and never replay a stale-anchor guess.
         reachedStreaming = false
         loggedFirstTemp = false
@@ -584,6 +618,7 @@ class OuraLiveSource(
         if (_adoptPhase.value == AdoptPhase.InstallingKey) _adoptPhase.value = AdoptPhase.Failed
         pendingInstallKey = null
         _batteryPct.value = null   // a stale charge must not outlive the link
+        resetWear()                // #628: clear the wear badge too
         flush()
     }
 
@@ -695,6 +730,7 @@ class OuraLiveSource(
                     log("Oura: disconnected (status=$status)")
                     loggedFirstHr = false   // a reconnect should log its first sample again
                     _batteryPct.value = null
+                    resetWear()             // #628: the wear badge must not survive the link dropping
                     cancelReengage()
                     cancelHistoryFetch()
                     // Drain BEFORE the driver's anchor is gone (same reasoning as stop()): a pending event
@@ -1050,7 +1086,30 @@ class OuraLiveSource(
                     }
                     handler.post { guardedCallback("live-sink") { liveSink(bpm, emptyList()) } }
                 }
+                // A LIVE HR push (0x2F) exists only while the ring is measuring on a finger, so it is the
+                // sole safe "worn now" signal — fed unconditionally (even a gated-out bpm still proves the
+                // ring is on a finger). NEVER fed from OuraEvent.Ibi below: the history path decodes IBI
+                // tags to .Ibi only (never .Hr), so a past-night re-serve can't reach here and falsely
+                // flip the badge to worn. Mirrors iOS OuraLiveSource `.hr` case. Posted to the main looper
+                // (emit runs on the GATT binder thread) so ALL wear-tracker access — here + the re-engage
+                // watchdog — is single-threaded, matching how liveSink is posted just above.
+                val pulseAt = System.currentTimeMillis()
+                handler.post {
+                    lastLivePulseAt = pulseAt
+                    wearTracker.notePulse()
+                    publishWearState()
+                }
                 enqueue(listOf(e), now)
+            }
+            is OuraEvent.StateEvent -> {
+                // The ring's own lifecycle strings (0x45/0x53). Charger transitions drive the wear badge;
+                // never a durable Streams row. Posted to the main looper (see the .Hr note) so wear-tracker
+                // access stays single-threaded. Mirrors iOS OuraLiveSource `.state` case.
+                val st = e.value
+                handler.post {
+                    wearTracker.note(st)
+                    publishWearState()
+                }
             }
             is OuraEvent.Ibi -> {
                 val rr = e.value.ibiMs
@@ -1127,8 +1186,39 @@ class OuraLiveSource(
                 // every real capture is evidence. Never persisted, never scored, and NEVER converted into
                 // steps (MET is not a step count; OuraStreamMapping drops ActivityInfo unconditionally).
                 log("Oura: activity (Tier-B) state=${e.value.state} met=${e.value.met}")
-            // Motion / state / rtcBeacon / debugText: not a durable Streams row (see OuraStreamMapping).
+            // Motion / debugText / etc: not a durable Streams row (see OuraStreamMapping). StateEvent is
+            // handled above (wear badge only, also not a Streams row).
             else -> Unit
+        }
+    }
+
+    /** Mirror the tracker's current wear/charge state to [ouraWearState], logging each TRANSITION once (a
+     *  charger on/off or first pulse is worth a strap-log line; steady state is not). Twin of iOS
+     *  `publishWearState`. */
+    private fun publishWearState() {
+        val s = wearTracker.current
+        _ouraWearState.value = s
+        if (s != loggedWearState) {
+            loggedWearState = s
+            when (s) {
+                OuraWearState.WORN -> log("Oura: ring WORN - live HR streaming")
+                OuraWearState.CHARGING -> log("Oura: ring NOT WORN - on charger (HR/IBI paused until removed)")
+                OuraWearState.OFF -> log("Oura: ring NOT WORN - no live HR (removed / off charger)")
+                OuraWearState.UNKNOWN -> Unit
+            }
+        }
+    }
+
+    /** Reset the wear indicator on a fresh session / disconnect: a stale worn/charging badge must not
+     *  outlive the link. Twin of the iOS resets at connect/stop/disconnect. Posted to the main looper so
+     *  the wear-tracker mutation stays single-threaded even when called from the GATT-thread disconnect
+     *  handler — the queued reset lands in FIFO order relative to any pending live-pulse posts. */
+    private fun resetWear() {
+        handler.post {
+            wearTracker.reset()
+            loggedWearState = null
+            lastLivePulseAt = null
+            _ouraWearState.value = null
         }
     }
 

--- a/android/app/src/main/java/com/noop/ble/SourceCoordinator.kt
+++ b/android/app/src/main/java/com/noop/ble/SourceCoordinator.kt
@@ -8,6 +8,7 @@ import com.noop.data.SourceKind
 import com.noop.data.StreamBatch
 import com.noop.data.WhoopRepository
 import com.noop.oura.OuraRingGen
+import com.noop.oura.OuraWearState
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -121,6 +122,11 @@ class SourceCoordinator(
      *  source is live. Mirrors Swift `AppModel.ouraNeedsPairing`. */
     private val _ouraNeedsPairing = MutableStateFlow<String?>(null)
     val ouraNeedsPairing: StateFlow<String?> = _ouraNeedsPairing.asStateFlow()
+
+    /** The active Oura source's live wear/charge state (worn / charging / off), or null when no Oura source
+     *  is live. Drives the Live screen's On-wrist / Off-wrist read (#628). Mirrors iOS `LiveState.ouraWearState`. */
+    private val _ouraWearState = MutableStateFlow<OuraWearState?>(null)
+    val ouraWearState: StateFlow<OuraWearState?> = _ouraWearState.asStateFlow()
 
     /** Collects the active Oura source's adoptPhase / needsPairing into the mirrors above; cancelled and
      *  nulled on teardown so a forgotten ring never leaks a stale outcome. */
@@ -430,6 +436,7 @@ class SourceCoordinator(
         ouraStateJob = scope.launch {
             launch { source.adoptPhase.collect { _ouraAdoptPhase.value = it } }
             launch { source.needsPairing.collect { _ouraNeedsPairing.value = it } }
+            launch { source.ouraWearState.collect { _ouraWearState.value = it } }
         }
         return source
     }
@@ -444,6 +451,7 @@ class SourceCoordinator(
         ouraStateJob?.cancel(); ouraStateJob = null
         _ouraAdoptPhase.value = OuraLiveSource.AdoptPhase.Idle
         _ouraNeedsPairing.value = null
+        _ouraWearState.value = null   // #628: no live Oura source -> no wear badge
         // A stale speed/cadence/power readout must not outlive the strap session (the source's own stop()
         // already pushes an empty SensorMetrics, but reset here too so leaving for WHOOP / FTMS / Huami —
         // none of which feed this flow — is clean and immediate).

--- a/android/app/src/main/java/com/noop/oura/OuraWear.kt
+++ b/android/app/src/main/java/com/noop/oura/OuraWear.kt
@@ -1,0 +1,80 @@
+package com.noop.oura
+
+// OuraWear: infer whether the Oura ring is on a finger, on the charger, or idle — a live wear/charge
+// indicator for the UI ("On wrist" / "Off wrist").
+//
+// Kotlin twin of Packages/OuraProtocol/Sources/OuraProtocol/OuraWear.swift. The ring emits no dedicated
+// "worn" event in NOOP's captures (the documented aohr_event 0x86 has NEVER appeared — 0 records), so
+// wear is inferred from signals that ARE present and validated by real data:
+//   - a LIVE-HR push (0x2F) exists only while the ring measures on a finger -> WORN;
+//   - a live-HR stream that goes silent while we keep re-engaging it -> the ring came off -> NOT WORN;
+//   - the ring's literal "chg. detected" / "chg. stopped" STATE (0x45/0x53) strings -> CHARGING.
+//
+// Platform-pure (no android.*), value types + one tiny live accumulator. No clock (the caller owns the
+// watchdog timing). Runs in JVM unit tests — see OuraWearTest.
+
+/** The ring's wear / charge state for a live indicator. */
+enum class OuraWearState {
+    WORN,       // a live-HR beat streamed since the last charge/removal -> on a finger
+    CHARGING,   // between chg.detected and chg.stopped -> on the charger, not worn
+    OFF,        // came off the charger, or the finger (live-HR went silent) -> not worn, no charger
+    UNKNOWN,    // no evidence yet this session
+}
+
+object OuraWear {
+
+    // MARK: - STATE-string semantics (clean-room: the ring's own words)
+
+    /** True when a STATE (0x45/0x53) string reports the charger being CONNECTED (observed: "chg.
+     *  detected"). Matched on the decoded text — the honest signal, the ring literally says it — never a
+     *  guessed numeric code (the state codes are ambiguous: code 5 appears as both "hr enable" and
+     *  "motion det"). Twin of OuraWear.isChargerStart (Swift). */
+    fun isChargerStart(state: OuraState): Boolean {
+        val t = (state.text ?: "").lowercase()
+        return (t.contains("chg") || t.contains("charg")) && (t.contains("detect") || t.contains("start"))
+    }
+
+    /** True when a STATE string reports the charger being DISCONNECTED (observed: "chg. stopped"). */
+    fun isChargerStop(state: OuraState): Boolean {
+        val t = (state.text ?: "").lowercase()
+        return (t.contains("chg") || t.contains("charg")) &&
+            (t.contains("stop") || t.contains("end") || t.contains("done") || t.contains("remov"))
+    }
+}
+
+/**
+ * A tiny LIVE state machine for a wear/charge indicator. Feed it STATE events, live-HR pulses, and a
+ * pulse-silence timeout as they happen in real time; read [current]. Live semantics only: latest
+ * evidence wins. A live-HR beat means WORN; a charge string means CHARGING/OFF; a silent stream past
+ * the caller's grace window means the ring came off. Never feed it a banked/history IBI — that can be a
+ * past-night re-serve and would falsely read worn. Twin of OuraWearTracker (Swift).
+ */
+class OuraWearTracker {
+    var current: OuraWearState = OuraWearState.UNKNOWN
+        private set
+
+    /** A decoded STATE (0x45/0x53) event. */
+    fun note(state: OuraState) {
+        when {
+            OuraWear.isChargerStart(state) -> current = OuraWearState.CHARGING
+            OuraWear.isChargerStop(state) -> current = OuraWearState.OFF
+        }
+    }
+
+    /** A LIVE heart-rate beat was streamed (the 0x2F live-HR push) — that stream exists only while the
+     *  ring is measuring on a finger, so the ring is WORN. Do NOT call this for a banked/history IBI: a
+     *  history re-serve can carry beats from a PAST night and would falsely flip the badge to worn while
+     *  the ring is actually on the charger. Live push only. */
+    fun notePulse() { current = OuraWearState.WORN }
+
+    /** No live beat has arrived for longer than expected while HR was streaming — the ring came off the
+     *  finger (there is no "removed" event; a stopped live-HR stream is the only signal). Downgrades
+     *  WORN -> OFF only; never overrides CHARGING (the charger STATE is authoritative) or a state that
+     *  was already not-worn. The caller owns the timing (a wall-clock watchdog); this stays pure. */
+    fun noteLivePulseTimeout() {
+        if (current == OuraWearState.WORN) current = OuraWearState.OFF
+    }
+
+    /** Reset to UNKNOWN (a fresh connection / session). */
+    fun reset() { current = OuraWearState.UNKNOWN }
+}

--- a/android/app/src/main/java/com/noop/ui/AppViewModel.kt
+++ b/android/app/src/main/java/com/noop/ui/AppViewModel.kt
@@ -245,6 +245,12 @@ class AppViewModel(app: Application) : AndroidViewModel(app) {
      *  failure too. Mirrors Swift `AppModel.ouraNeedsPairing`. */
     val ouraNeedsPairing: StateFlow<String?> = noopApp.sourceCoordinator.ouraNeedsPairing
 
+    /** The active Oura ring's live wear/charge state (worn / charging / off), or null when no Oura source
+     *  is live. The Live screen prefers this for its On-wrist / Off-wrist read (#628). Mirrors iOS
+     *  `LiveState.ouraWearState`. */
+    val ouraWearState: StateFlow<com.noop.oura.OuraWearState?> =
+        noopApp.sourceCoordinator.ouraWearState
+
     /**
      * Point the WHOOP scan at a specific family, then present nearby straps WITHOUT auto-connecting (the
      * Add-a-device wizard's WHOOP path). [WhoopBleClient.prepareForPresentScan] KEEPS a live same-model

--- a/android/app/src/main/java/com/noop/ui/LiveScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/LiveScreen.kt
@@ -74,6 +74,7 @@ import com.noop.analytics.SpotHrvReading
 import com.noop.analytics.Sport
 import com.noop.analytics.WorkoutSport
 import com.noop.ble.LiveState
+import com.noop.oura.OuraWearState
 import com.noop.ble.WhoopModel
 
 /**
@@ -95,6 +96,9 @@ private val LIVE_HERO_RADIUS: Dp = 26.dp
 @Composable
 fun LiveScreen(viewModel: AppViewModel, onManageDevices: () -> Unit = {}) {
     val live by viewModel.live.collectAsStateWithLifecycle()
+    // #628: the Oura ring's live wear/charge state (null for WHOOP / before evidence). Preferred by the
+    // "Worn" stat below, so removing the ring or putting it on the charger flips it instead of lingering.
+    val ouraWear by viewModel.ouraWearState.collectAsStateWithLifecycle()
     val bpm by viewModel.bpm.collectAsStateWithLifecycle()
     val selectedModel by viewModel.selectedModel.collectAsStateWithLifecycle()
     // Active band name (MW-6) — names the band whose live data the console shows; falls back to "WHOOP".
@@ -225,7 +229,7 @@ fun LiveScreen(viewModel: AppViewModel, onManageDevices: () -> Unit = {}) {
         // Console header — the pill + a connection-mode badge (+ a live SYNCING badge during a history
         // offload), with battery / worn / last-sync stats. Mirrors the macOS consoleHeader.
         item {
-        ConsoleHeader(live = live, activeConnection = activeConnection)
+        ConsoleHeader(live = live, activeConnection = activeConnection, ouraWear = ouraWear)
         }
 
         // Primary Connect affordance, surfaced ABOVE the fold whenever there's no link — the real
@@ -740,7 +744,7 @@ private fun ActiveBandRow(name: String, onManageDevices: () -> Unit) {
 }
 
 @Composable
-private fun ConsoleHeader(live: LiveState, activeConnection: Boolean) {
+private fun ConsoleHeader(live: LiveState, activeConnection: Boolean, ouraWear: OuraWearState? = null) {
     NoopCard(padding = 14.dp) {
         Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
             // Badges row — pill + connection-mode badge + a live SYNCING badge during an offload.
@@ -777,7 +781,7 @@ private fun ConsoleHeader(live: LiveState, activeConnection: Boolean) {
                     live.batteryPct?.let { "${it.toInt()}%" } ?: "—",
                     charging = live.charging == true,
                 )
-                HeaderStat("Worn", if (activeConnection) (if (live.worn) "Yes" else "No") else "—")
+                HeaderStat("Worn", wornLabel(live, activeConnection, ouraWear))
                 HeaderStat("Last sync", lastSyncLabel(live))
             }
         }
@@ -871,6 +875,21 @@ private fun OfflineConnectCallout(scanning: Boolean, onConnect: () -> Unit) {
  *  the bond-only feature gates (buzz, alarm, HRV snapshot) keep keying off `activeConnection`. Twin of the
  *  iOS LiveView.ringStreaming. */
 private fun ringStreaming(live: LiveState): Boolean = live.connected && live.streamingLiveHR
+
+/** The "Worn" stat text. An Oura ring reports a precise live wear/charge state (live-HR presence + charger
+ *  STATE + a removal watchdog), so prefer it — it flips to not-worn the moment the ring is off the finger
+ *  or on the charger, unlike the WHOOP wrist boolean which lingers. WHOOP has no such signal ([ouraWear]
+ *  stays null) so it keeps the wrist-event read. "—" off a live link; because an Oura ring streams WITHOUT
+ *  bonding, a live stream counts as a link too (not just [activeConnection]). Mirrors iOS LiveView.wornNow
+ *  (#628 / #218). */
+private fun wornLabel(live: LiveState, activeConnection: Boolean, ouraWear: OuraWearState?): String {
+    val liveLink = activeConnection || ringStreaming(live)
+    return when {
+        !liveLink -> "—"
+        ouraWear != null -> if (ouraWear == OuraWearState.WORN) "Yes" else "No"
+        else -> if (live.worn) "Yes" else "No"
+    }
+}
 
 private fun connectionModeBadge(live: LiveState, activeConnection: Boolean): String = when {
     activeConnection && live.encryptedBond -> "FULL BOND"

--- a/android/app/src/test/java/com/noop/oura/OuraWearTest.kt
+++ b/android/app/src/test/java/com/noop/oura/OuraWearTest.kt
@@ -1,0 +1,68 @@
+package com.noop.oura
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * JVM twin of Packages/OuraProtocol/Tests/OuraProtocolTests/OuraWearTests.swift — the pure wear/charge
+ * state machine: a live pulse means WORN, a silence timeout downgrades WORN->OFF (but never overrides
+ * CHARGING), and the charger STATE strings drive CHARGING/OFF.
+ */
+class OuraWearTest {
+
+    private fun state(text: String?) = OuraState(ringTimestamp = 0L, stateCode = 0, text = text)
+
+    @Test
+    fun testChargerStartStopStringMatching() {
+        // The ring's own words drive charging; matched case-insensitively on the decoded text.
+        assertTrue(OuraWear.isChargerStart(state("chg. detected")))
+        assertTrue(OuraWear.isChargerStart(state("Charger started")))
+        assertFalse(OuraWear.isChargerStart(state("chg. stopped")))
+
+        assertTrue(OuraWear.isChargerStop(state("chg. stopped")))
+        assertTrue(OuraWear.isChargerStop(state("charger removed")))
+        assertFalse(OuraWear.isChargerStop(state("chg. detected")))
+
+        // Non-charger STATE strings (and null text) match neither — code 5 is both "hr enable"/"motion det".
+        assertFalse(OuraWear.isChargerStart(state("hr enable")))
+        assertFalse(OuraWear.isChargerStop(state("motion det")))
+        assertFalse(OuraWear.isChargerStart(state(null)))
+        assertFalse(OuraWear.isChargerStop(state(null)))
+    }
+
+    @Test
+    fun testLiveTrackerPulseMeansWorn() {
+        val t = OuraWearTracker()
+        assertEquals(OuraWearState.UNKNOWN, t.current)
+        t.notePulse()
+        assertEquals(OuraWearState.WORN, t.current)
+    }
+
+    @Test
+    fun testLivePulseTimeoutDowngradesWornToOff() {
+        val t = OuraWearTracker()
+        t.notePulse()
+        assertEquals(OuraWearState.WORN, t.current)
+
+        // Silent stream past the grace window -> removed.
+        t.noteLivePulseTimeout()
+        assertEquals(OuraWearState.OFF, t.current)
+
+        // Charger STATE is authoritative: a pulse-timeout must NEVER override CHARGING.
+        t.note(state("chg. detected"))
+        assertEquals(OuraWearState.CHARGING, t.current)
+        t.noteLivePulseTimeout()
+        assertEquals(OuraWearState.CHARGING, t.current)
+
+        // Charger stop -> off; a fresh pulse -> worn again.
+        t.note(state("chg. stopped"))
+        assertEquals(OuraWearState.OFF, t.current)
+        t.notePulse()
+        assertEquals(OuraWearState.WORN, t.current)
+
+        t.reset()
+        assertEquals(OuraWearState.UNKNOWN, t.current)
+    }
+}


### PR DESCRIPTION
Ports @pipiche38's Apple Oura wear indicator (#628) to Android, so the Live screen's **Worn** stat flips to **No / —** the moment the ring comes off the finger or goes on the charger — instead of lingering on a stale stream.

## Why Android *can* mirror this (the original PR said it couldn't)
#628 was landed Apple-only on the basis that Android's Oura is import-only with no live stream. That's **not accurate**: `android/.../ble/OuraLiveSource.kt` is *"a faithful Kotlin twin of Strand/BLE/OuraLiveSource.swift"*, instantiated in `SourceCoordinator`, and it already:
- streams the **live-HR push (0x2F)** → `OuraEvent.Hr`
- decodes the ring's **STATE (0x45/0x53)** charger strings → `OuraEvent.StateEvent(OuraState)`

So both wear-inference signals are present, and this mirrors the Swift design 1:1.

## What's in it
- **Pure `com.noop.oura.OuraWear`** (`OuraWearState` + `OuraWearTracker`) — byte-faithful twin of `Packages/OuraProtocol/.../OuraWear.swift`, with `OuraWearTest` (**3/3**, JVM-pure).
- **`OuraLiveSource`** drives the tracker: `notePulse()` from the live-HR push **only** (the history path decodes IBI tags to `OuraEvent.Ibi`, **never** `.Hr`, so a past-night re-serve can't falsely read worn), `note(state)` from `StateEvent`, and a **40 s removal watchdog** on the 15 s re-engage tick. Publishes `ouraWearState`; reset on connect/stop/disconnect.
- **`SourceCoordinator`** mirrors `ouraWearState` (same pattern as `ouraAdoptPhase`/`needsPairing`) → **`AppViewModel`** exposes it → **`LiveScreen`** "Worn" stat prefers it, gated on a live stream (an Oura ring streams **without** bonding, so it can't require `activeConnection`). WHOOP is unchanged (`ouraWearState` stays null → the existing wrist-event fallback).

## Parity / scope
No stored value, analytics, migration, or decoder change — a **live UI indicator only** — so the byte-identical contract doesn't apply (matches the iOS PR's reasoning). Behavior mirrors iOS `LiveView.wornNow`.

## Verification (all local, all green)
- `./gradlew testFullDebugUnitTest --tests "com.noop.oura.OuraWearTest"` → **3/3**, and the **full** `testFullDebugUnitTest` passes (no regression)
- `./gradlew compileFullDebugKotlin` ✓
- `./gradlew lintVitalFullRelease` ✓

Credit to @pipiche38 for the original Apple feature + the wear-inference design this ports.

Closes the Android half of #628.