### PR TITLE
Liquid Today: 'no cardio load yet' Effort note (#530 follow-up)

### DIFF
--- a/Strand/Liquid/LiquidTodayView.swift
+++ b/Strand/Liquid/LiquidTodayView.swift
@@ -692,6 +692,14 @@ struct LiquidTodayView: View {
 
     // MARK: - Synthesis (greeting + readiness pills + one-liner)
 
+    /// Liquid parity with classic `effortZeroNote`: the "no cardio load yet" line shown in the synthesis
+    /// card when today's Effort is ~0, so a calm day explains itself instead of a bare 0. Reuses classic's
+    /// String Catalog entry verbatim — one key serves both Today screens.
+    private var effortZeroNote: String? {
+        guard EffortDisplay.showsZeroNote(strain: displayDay?.strain, isToday: selectedDayOffset == 0) else { return nil }
+        return String(localized: "No cardio load yet. Effort builds once your heart rate climbs into your effort zone (around 50% of your heart-rate reserve). A calm day honestly reads near zero.")
+    }
+
     private var synthesisSection: some View {
         VStack(spacing: 8) {
             HStack {
@@ -740,6 +748,20 @@ struct LiquidTodayView: View {
                         Text(chargeDisplay.calibrationDetail ?? synthLine)
                             .font(StrandFont.body).foregroundStyle(StrandPalette.textPrimary)
                             .fixedSize(horizontal: false, vertical: true)
+                        // #530 follow-up: the classic hero's "no cardio load yet" note (effortZeroNote),
+                        // shown on a calm day so today's ~0 Effort explains itself instead of a bare 0.
+                        if let note = effortZeroNote {
+                            HStack(alignment: .top, spacing: 6) {
+                                Image(systemName: "info.circle")
+                                    .font(StrandFont.footnote)
+                                    .foregroundStyle(StrandPalette.effortColor)
+                                    .accessibilityHidden(true)
+                                Text(note)
+                                    .font(StrandFont.footnote)
+                                    .foregroundStyle(StrandPalette.textTertiary)
+                                    .fixedSize(horizontal: false, vertical: true)
+                            }
+                        }
                         if synthesisExpanded {
                             Text(LocalizedStringKey(readiness.summary)).font(StrandFont.caption)
                                 .foregroundStyle(StrandPalette.textSecondary)
@@ -1727,6 +1749,19 @@ extension LiquidTodayView {
     /// it), so a dead strap kept showing its last % as if live — a 21 h old reading rendered identically
     /// to a fresh one. Gating on `connected` here also makes this ring agree with `LiquidStrapBatteryRow`
     /// directly below it, which already required `live.connected`.
+    /// The Effort hero's "no cardio load yet" honest note (#530 follow-up — Liquid parity with classic
+    /// `TodayView.effortZeroNote`). Pure + static so the gate is testable with no view: the note shows
+    /// ONLY for today when a strain value exists and is ~0 — a genuinely calm day reads near zero, while a
+    /// no-data day shows its own ring overlay and a past day is never annotated. Liquid reads
+    /// `displayDay?.strain` directly (it has no live-strain accumulator like classic's `liveTodayStrain`),
+    /// which is exactly the value its Effort hero draws.
+    enum EffortDisplay {
+        static func showsZeroNote(strain: Double?, isToday: Bool) -> Bool {
+            guard isToday, let s = strain else { return false }
+            return s < 1.0
+        }
+    }
+
     /// (A3/B2, docs/bugs/2026-07-15-strap-battery-backfill-observability.md)
     enum StrapBatteryDisplay: Equatable {
         /// No link — say nothing about charge. A stale % is worse than no %.

--- a/StrandTests/LiquidEffortNoteTests.swift
+++ b/StrandTests/LiquidEffortNoteTests.swift
@@ -1,0 +1,33 @@
+import XCTest
+@testable import Strand
+
+/// Pins the Liquid Today "no cardio load yet" Effort note (#530 follow-up — parity with the classic
+/// `TodayView.effortZeroNote`). The gate is pure, so it pins with no strap, no clock, and no view: the
+/// note appears ONLY for today when a real strain value exists and is ~0 — a genuinely calm day. A
+/// no-data day (nil strain) shows its own ring overlay instead, and a navigated past day is never
+/// annotated.
+final class LiquidEffortNoteTests: XCTestCase {
+
+    private typealias Display = LiquidTodayView.EffortDisplay
+
+    func testCalmTodayShowsTheNote() {
+        XCTAssertTrue(Display.showsZeroNote(strain: 0.0, isToday: true))
+        XCTAssertTrue(Display.showsZeroNote(strain: 0.9, isToday: true))
+    }
+
+    func testEffortAtOrAboveOneDoesNotShow() {
+        // The gauge reads a real number at ≥ 1.0, so the "near zero" note would be a false statement.
+        XCTAssertFalse(Display.showsZeroNote(strain: 1.0, isToday: true))
+        XCTAssertFalse(Display.showsZeroNote(strain: 38.3, isToday: true))
+    }
+
+    func testNoStrainValueDoesNotShow() {
+        // A no-data day shows its own ring overlay; the Effort note must not annotate it.
+        XCTAssertFalse(Display.showsZeroNote(strain: nil, isToday: true))
+    }
+
+    func testPastDayIsNeverAnnotated() {
+        XCTAssertFalse(Display.showsZeroNote(strain: 0.0, isToday: false))
+        XCTAssertFalse(Display.showsZeroNote(strain: nil, isToday: false))
+    }
+}


### PR DESCRIPTION
Follow-up to #530. The classic Today screen explains a ~0 Effort with an honest **"No cardio load yet…"** note; the default **Liquid** screen showed a bare 0. This ports that note — the last of the v8-dropped hero carry-overs in the Effort area — to Liquid, matching classic.

## What
- **New pure `LiquidTodayView.EffortDisplay.showsZeroNote(strain:isToday:)`** — the gate extracted static + testable, **exactly like #530's `ChargeDisplay`/`StrapBatteryDisplay`**. Shows only for today when a real strain value is < 1.0; a no-data day shows its own ring overlay, a past day is never annotated. Liquid reads `displayDay?.strain` directly (it has no live-strain accumulator like classic's `liveTodayStrain`).
- Rendered in the synthesis card with the same `info.circle` + `effortColor` styling as classic.
- **Reuses classic's String Catalog entry verbatim** — one key serves both screens, so no new string and **no i18n change** (verified: the key exists with all 8 locales; audit clean).
- **`LiquidEffortNoteTests`** pins the gate (calm-today shows; ≥ 1.0 / nil / past-day don't).

## Parity
iOS/macOS only. Android's `TodayScreen` **already** surfaces this note (`effortZeroNote` copy + `l10n_` key at `TodayScreen.kt`), so no Kotlin twin — this is iOS/macOS Liquid catching up, same framing as #530.

## Verification
App-target Swift, which no CI job compiles — so verified as far as Linux allows: the `String(localized:)` **exactly matches** classic's existing catalog key (checked byte-for-byte), `Tools/i18n_audit.py --ci HEAD` is clean, and the pure gate carries the behavioural coverage. **Compile lands on the next staging build** (like the rest of the recent iOS work).

The remaining classic hero notes (`explainedScoreNote`, `chargeDeepWindowGapNote`) are entangled with `MetricTileState` / `ChargeBreakdownFormat` (not in Liquid's scope, and `explainedScoreNote` overlaps #530's `ChargeDisplay`), so they're tracked as further follow-ups rather than ported blind here.