### PR TITLE
privacy: drop unused Health Connect WRITE_STEPS / WRITE_ACTIVE_CALORIES perms

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -101,9 +101,10 @@
     <uses-permission android:name="android.permission.health.WRITE_HEART_RATE_VARIABILITY" />
     <uses-permission android:name="android.permission.health.WRITE_OXYGEN_SATURATION" />
     <uses-permission android:name="android.permission.health.WRITE_RESPIRATORY_RATE" />
-    <!-- HR samples, steps, active energy, and sleep writeback (#528, opt-in, default OFF). -->
-    <uses-permission android:name="android.permission.health.WRITE_ACTIVE_CALORIES_BURNED" />
-    <uses-permission android:name="android.permission.health.WRITE_STEPS" />
+    <!-- HR samples and sleep writeback (#528, opt-in, default OFF). Steps + active-calories are
+         deliberately NOT written back (they'd double-count the phone/watch's authoritative totals — see
+         HealthConnectWriter.kt; iOS #249 aligns), so their WRITE permissions are intentionally NOT
+         declared here — the writer's WRITE_RECORDS set never requests them (#659). -->
     <uses-permission android:name="android.permission.health.WRITE_HEART_RATE" />
     <uses-permission android:name="android.permission.health.WRITE_SLEEP" />
     <!-- Exercise-session + distance writeback (GPS workouts, opt-in). MUST be declared or Health


### PR DESCRIPTION
Closes #659.

The Android manifest declared Health Connect **write** permissions for steps and active calories, but NOOP **deliberately never writes those types back** — they'd double-count the phone/watch's authoritative daily totals (`HealthConnectWriter.kt:115`, #528; iOS #249 aligns). And the runtime request is built from `WRITE_RECORDS` = {RestingHR, HRV, OxygenSat, RespRate, HeartRate, SleepSession} (+ a separate Exercise/Distance group) — **neither list includes `StepsRecord`/`ActiveCaloriesBurnedRecord`**. So the two declarations were pure dead privacy surface: declared but never requested or used.

## Change (manifest-only)
- Remove `WRITE_STEPS` + `WRITE_ACTIVE_CALORIES_BURNED` `<uses-permission>`.
- Rewrite the stale comment (which still claimed *"steps, active energy … writeback"*) to document **why** they're intentionally absent — a lightweight guard so a future contributor won't re-add them (the issue's point 3, via rationale-in-comment rather than a full manifest audit test).

## Why it's safe
Health Connect grants a permission only when it's **both** declared *and* requested at runtime. The runtime never requested these, so removing the declarations changes no behaviour — it only shrinks the declared privacy surface and makes the permission prompt honest.

## Verification
- Manifest XML well-formed; both perms gone, all other write perms intact.
- `./gradlew compileFullDebugKotlin` ✓ (manifest processes clean).

No iOS change — iOS already excludes these (#249).