### PR TITLE
Journal: 7-day backfill + deep-linked Today widget bars (Android) — #656

### DIFF
--- a/android/app/src/main/java/com/noop/ui/AppViewModel.kt
+++ b/android/app/src/main/java/com/noop/ui/AppViewModel.kt
@@ -251,6 +251,13 @@ class AppViewModel(app: Application) : AndroidViewModel(app) {
     val ouraWearState: StateFlow<com.noop.oura.OuraWearState?> =
         noopApp.sourceCoordinator.ouraWearState
 
+    /** #656: a journal day-offset (daysBack; -1 = Tomorrow) the Today journal widget asks the journal
+     *  (Insights) to open at, so tapping a SPECIFIC day's bar lands on THAT day instead of always today.
+     *  InsightsScreen consumes it on open and clears it via [requestJournalDay]`(null)`. */
+    private val _pendingJournalDayOffset = kotlinx.coroutines.flow.MutableStateFlow<Long?>(null)
+    val pendingJournalDayOffset: StateFlow<Long?> = _pendingJournalDayOffset
+    fun requestJournalDay(offset: Long?) { _pendingJournalDayOffset.value = offset }
+
     /**
      * Point the WHOOP scan at a specific family, then present nearby straps WITHOUT auto-connecting (the
      * Add-a-device wizard's WHOOP path). [WhoopBleClient.prepareForPresentScan] KEEPS a live same-model

--- a/android/app/src/main/java/com/noop/ui/InsightsScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/InsightsScreen.kt
@@ -191,6 +191,12 @@ fun InsightsScreen(vm: AppViewModel, onOpenInsightsHub: () -> Unit = {}) {
     var journalLoaded by remember { mutableStateOf(false) }
     var journalSeq by remember { mutableStateOf(0) }
     var dayOffset by remember { mutableStateOf(0L) }
+    // #656: honour a day the Today journal widget deep-linked to (tapping a bar opens the journal at THAT
+    // day). Consumed once on arrival, then cleared so it doesn't re-apply on the next recomposition.
+    val pendingJournalDay by vm.pendingJournalDayOffset.collectAsStateWithLifecycle()
+    androidx.compose.runtime.LaunchedEffect(pendingJournalDay) {
+        pendingJournalDay?.let { dayOffset = it; vm.requestJournalDay(null) }
+    }
     var importedQuestions by remember { mutableStateOf<List<String>>(emptyList()) }
     var dayAnswers by remember { mutableStateOf<Map<String, Boolean>>(emptyMap()) }
     // #322: the selected day's native numeric values (question -> value), drives the numeric fields.

--- a/android/app/src/main/java/com/noop/ui/JournalLog.kt
+++ b/android/app/src/main/java/com/noop/ui/JournalLog.kt
@@ -7,6 +7,10 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -125,6 +129,21 @@ internal fun mergeJournalEntries(
 internal fun journalDayKey(daysBack: Long = 0L, today: LocalDate = LocalDate.now()): String =
     today.minusDays(daysBack).toString()
 
+/** How many days back the journal day picker can reach (#656): today (0) plus the 6 prior days = a
+ *  7-day backfill window, plus Tomorrow (-1). Bounded on purpose — journal answers feed the
+ *  correlation engine, so unbounded backfill of stale days would distort it (matches WHOOP's limited
+ *  retroactive window and the strip the Today widget shows). */
+internal const val JOURNAL_BACKFILL_DAYS = 6
+
+/** Short chip label for a journal day-picker [offset] (daysBack; -1 = Tomorrow). Hardcoded English to
+ *  match the sibling Yesterday/Today/Tomorrow chips. */
+internal fun journalDayChipLabel(offset: Long): String = when (offset) {
+    -1L -> "Tomorrow"
+    0L -> "Today"
+    1L -> "Yesterday"
+    else -> "$offset days ago"
+}
+
 // MARK: - Custom-question persistence
 //
 // Stored in the shared "noop_prefs" file under a "noop."-prefixed key, newline-joined (a string
@@ -204,13 +223,28 @@ fun JournalLogCard(
                 JournalChip("Done", selected = true) { editing = false }
             } else {
                 JournalChip("Edit", selected = false) { editing = true }
-                Spacer(Modifier.width(6.dp))
-                // Chronological left→right: Yesterday · Today · Tomorrow (#443).
-                JournalChip("Yesterday", selected = dayOffset == 1L) { onDayOffset(1L) }
-                Spacer(Modifier.width(6.dp))
-                JournalChip("Today", selected = dayOffset == 0L) { onDayOffset(0L) }
-                Spacer(Modifier.width(6.dp))
-                JournalChip("Tomorrow", selected = dayOffset == -1L) { onDayOffset(-1L) }
+            }
+        }
+        // Day picker (#656): a bounded, scrollable range — Tomorrow back through the last 7 days — so any
+        // recent day can be backfilled (was Yesterday/Today/Tomorrow only). Chronological left→right
+        // (oldest → Tomorrow, #443); auto-scrolls to the selected day, so a deep-link from the Today
+        // journal widget lands on that day's chip. Only when not editing.
+        if (!editing) {
+            val dayOffsets = remember { (JOURNAL_BACKFILL_DAYS.toLong() downTo -1L).toList() }
+            val dayListState = rememberLazyListState()
+            LaunchedEffect(dayOffset) {
+                // Snap (not animate) to the selected day: an animated scroll would visibly slide from the
+                // leftmost day to Today every time the journal opens.
+                dayOffsets.indexOf(dayOffset).takeIf { it >= 0 }?.let { dayListState.scrollToItem(it) }
+            }
+            LazyRow(
+                state = dayListState,
+                horizontalArrangement = Arrangement.spacedBy(6.dp),
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                items(dayOffsets) { off ->
+                    JournalChip(journalDayChipLabel(off), selected = dayOffset == off) { onDayOffset(off) }
+                }
             }
         }
         NoopCard {

--- a/android/app/src/main/java/com/noop/ui/JournalReminder.kt
+++ b/android/app/src/main/java/com/noop/ui/JournalReminder.kt
@@ -3,6 +3,9 @@ package com.noop.ui
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -84,6 +87,10 @@ fun JournalReminderCard(
 
     NoopCard(
         tint = Palette.accent,
+        // Tapping anywhere but a specific bar opens the journal at TODAY (#656). Deliberately does NOT
+        // set a pending day: `pendingJournalDayOffset` is cleared on every Insights open, so "no pending"
+        // already means today — and NOT touching it here means a bar's tap (which sets its own day) still
+        // wins even in the edge case where a nested-click delivers both taps.
         modifier = Modifier.clickable(onClickLabel = openLabel) { onOpenJournal() },
     ) {
         Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
@@ -109,24 +116,42 @@ fun JournalReminderCard(
                 )
             }
             // The last-N-days strip: one equal-width bar per day. Filled = logged; today is ringed so the
-            // orientation is unambiguous even when nothing is logged yet.
+            // orientation is unambiguous even when nothing is logged yet. Each bar is its own tap target
+            // (#656): tapping a day deep-links the journal to THAT day (requestJournalDay) instead of always
+            // today. The bar sits in a taller invisible Box so the tap target isn't a 10dp sliver.
             Row(
                 modifier = Modifier.fillMaxWidth(),
                 horizontalArrangement = Arrangement.spacedBy(6.dp),
             ) {
                 val shape = RoundedCornerShape(3.dp)
-                for (key in dayKeys) {
+                dayKeys.forEachIndexed { i, key ->
+                    val off = (JOURNAL_STRIP_DAYS - 1 - i).toLong()   // dayKeys[0] = 6 days ago … [last] = today
                     val isLogged = key in logged
-                    val isToday = key == todayKey
-                    var cell = Modifier
-                        .weight(1f)
-                        .height(10.dp)
-                        .background(
-                            if (isLogged) Palette.accent else Palette.textTertiary.copy(alpha = 0.22f),
-                            shape,
-                        )
-                    if (isToday && !isLogged) cell = cell.border(1.dp, Palette.accent, shape)
-                    Spacer(cell)
+                    val isToday = off == 0L
+                    Box(
+                        modifier = Modifier
+                            .weight(1f)
+                            .height(22.dp)
+                            .clickable(onClickLabel = openLabel) {
+                                viewModel.requestJournalDay(off)
+                                onOpenJournal()
+                            }
+                            // Each bar is otherwise an identical sliver to a screen reader; name its day
+                            // (from the shared label helper — not a literal, so no i18n regression) so the
+                            // deep-link target is announced (#656). Logged state is conveyed visually.
+                            .semantics { contentDescription = journalDayChipLabel(off) },
+                        contentAlignment = Alignment.Center,
+                    ) {
+                        var bar = Modifier
+                            .fillMaxWidth()
+                            .height(10.dp)
+                            .background(
+                                if (isLogged) Palette.accent else Palette.textTertiary.copy(alpha = 0.22f),
+                                shape,
+                            )
+                        if (isToday && !isLogged) bar = bar.border(1.dp, Palette.accent, shape)
+                        Spacer(bar)
+                    }
                 }
             }
             Text(


### PR DESCRIPTION
Addresses @bartmuskala's field report #656 (on Android 9.0.3) — Scope A: make the journal day-navigable with a bounded backfill, and deep-link the Today widget's bars.

## What
**(2) "Days before yesterday can't be added"** — the `JournalLogCard` day picker was Yesterday/Today/Tomorrow only. Now a **bounded, scrollable range**: Tomorrow back through the **last 7 days** (`JOURNAL_BACKFILL_DAYS = 6`), chronological, auto-scrolling to the selected day. Bounded on purpose — journal answers feed the correlation engine, so unbounded stale backfill would distort it (matches WHOOP's limited retroactive window and the strip the widget shows). The load/write path already keyed on `journalDayKey(dayOffset)`, so this is a **UI-only** change.

**(1) "Bar always links to today"** — each strip bar in the Today journal widget is now its **own tap target** that deep-links the journal to **that day** (`AppViewModel.requestJournalDay(off)` → `InsightsScreen` consumes it on open, then clears it). Tapping elsewhere on the card still opens today. Bars sit in a taller invisible box so the tap target isn't a 10 dp sliver.

## Verification (Android, all green)
- `compileFullDebugKotlin` ✓ · `testFullDebugUnitTest` ✓ · `lintVitalFullRelease -PstagingRelease` ✓

## Scope / why Android-only here
The reporter is on **Android**, and this is fully verified there. The **iOS mirror is a deliberate follow-up**: iOS `JournalLogCard`'s pills take `LocalizedStringKey` (so dynamic "N days ago" labels need String-Catalog entries + de/es/fr), and the widget needs a SwiftUI gesture rework to make bars individually tappable — neither is compile-verifiable on Linux, and I won't ship that blind. **Part (3)** of #656 — splitting the journal into its own view, separate from Insights — is the larger architectural change, tracked separately.

Partially addresses #656 (parts 1 & 2, Android).