### PR TITLE
Journal: 7-day backfill + deep-linked widget bars (iOS/macOS) — #656

### DIFF
--- a/Strand/App/NavRouter.swift
+++ b/Strand/App/NavRouter.swift
@@ -78,7 +78,16 @@ final class NavRouter: ObservableObject {
     /// directly today; this route exists for deep-link parity so a future shell/inbox item can raise it
     /// the same way as every other destination.
     func openLiveSession() { requestedDestination = .liveSession }
+    /// A journal day-offset (daysBack; -1 = Tomorrow) the Today journal widget deep-linked to, so tapping
+    /// a SPECIFIC day's bar opens the journal at THAT day instead of always today (#656). InsightsView
+    /// consumes it on appear and clears it back to nil. nil = open at today (the default).
+    @Published var pendingJournalDayOffset: Int?
+
     /// Open the journal (hosted in the classic Insights screen). The #627 Today journal widget taps here;
     /// iOS presents InsightsView (the journal quick-action sheet), macOS selects the Insights sidebar row.
-    func openJournal() { requestedDestination = .journal }
+    /// `day` (#656): a specific day-offset to open at (nil = today) — a tapped strip bar passes its day.
+    func openJournal(day offset: Int? = nil) {
+        pendingJournalDayOffset = offset
+        requestedDestination = .journal
+    }
 }

--- a/Strand/Screens/InsightsView.swift
+++ b/Strand/Screens/InsightsView.swift
@@ -263,7 +263,17 @@ struct InsightsView: View {
         .onChangeCompat(of: outcome) { _ in recomputeRanked() }
         // Refresh the day anchor on appear and whenever the app returns to the foreground; if the date has
         // advanced this bumps the `.task(id:)` key and the journal reloads for the new logical day (#860).
-        .onAppear { refreshCurrentDayKey() }
+        .onAppear {
+            refreshCurrentDayKey()
+            // #656: honour a day the Today journal widget deep-linked to (tapping a bar opens the journal
+            // at THAT day). Consumed once on arrival, then cleared. Reload explicitly — setting the offset
+            // here doesn't run the pill's onChanged, and the `.task` keys on the day-key, not the offset.
+            if let day = router.pendingJournalDayOffset {
+                journalDayOffset = day
+                router.pendingJournalDayOffset = nil
+                Task { await load() }
+            }
+        }
         .onChangeCompat(of: scenePhase) { phase in
             if phase == .active { refreshCurrentDayKey() }
         }

--- a/Strand/Screens/JournalLogCard.swift
+++ b/Strand/Screens/JournalLogCard.swift
@@ -86,9 +86,28 @@ struct JournalLogCard: View {
                     pillButton("Done", selected: true) { editing = false }
                 } else {
                     pillButton("Edit", selected: false) { editing = true }
-                    dayPill("Tomorrow", offset: -1)
-                    dayPill("Today", offset: 0)
-                    dayPill("Yesterday", offset: 1)
+                }
+            }
+            // Day picker (#656): a bounded, scrollable range — Tomorrow back through the last 7 days — so
+            // any recent day can be backfilled (was Yesterday/Today/Tomorrow only). Chronological
+            // left→right; snaps to the selected day, so a deep-link from the Today journal widget lands on
+            // that day's pill. Only when not editing.
+            if !editing {
+                ScrollViewReader { proxy in
+                    ScrollView(.horizontal, showsIndicators: false) {
+                        HStack(spacing: 6) {
+                            ForEach(Self.journalDayOffsets, id: \.self) { off in
+                                dayPill(journalDayLabel(off), offset: off).id(off)
+                            }
+                        }
+                        .padding(.horizontal, 1)   // don't clip the selected pill's ring
+                    }
+                    // Defer the initial scroll a tick: scrollTo in onAppear can no-op before the pills lay
+                    // out, which would leave the picker on the oldest day instead of the selected one.
+                    .onAppear { DispatchQueue.main.async { proxy.scrollTo(dayOffset, anchor: .center) } }
+                    // onChangeCompat, not onChange: the zero/two-arg onChange is macOS 14+, and this card
+                    // is shared with the macOS 13 target.
+                    .onChangeCompat(of: dayOffset) { _ in proxy.scrollTo(dayOffset, anchor: .center) }
                 }
             }
             NoopCard(tint: StrandPalette.restColor) {
@@ -332,6 +351,22 @@ struct JournalLogCard: View {
         pillButton(label, selected: dayOffset == offset) {
             dayOffset = offset
             onChanged()   // reload the selected day's answers
+        }
+    }
+
+    /// The bounded day-picker range (#656): Tomorrow (-1) plus today and the 6 prior days, chronological
+    /// oldest → newest left-to-right. Bounded on purpose — journal answers feed the correlation engine, so
+    /// unbounded backfill of stale days would distort it (matches WHOOP's limited retroactive window).
+    private static let journalDayOffsets: [Int] = Array((-1...6).reversed())
+
+    /// Short pill label for a day-picker offset (daysBack; -1 = Tomorrow). "%lld days ago" is a String
+    /// Catalog key, so 2–6 stay localized just like the twin "%lld nights ago" (#527/#656).
+    private func journalDayLabel(_ offset: Int) -> LocalizedStringKey {
+        switch offset {
+        case -1: return "Tomorrow"
+        case 0: return "Today"
+        case 1: return "Yesterday"
+        default: return "\(offset) days ago"
         }
     }
 

--- a/Strand/Screens/JournalReminderCard.swift
+++ b/Strand/Screens/JournalReminderCard.swift
@@ -46,53 +46,79 @@ struct JournalReminderCard: View {
         let keys = Self.dayKeys()
         let todayKey = keys.last ?? ""
         let todayLogged = logged.contains(todayKey)
-        return Button {
-            router.openJournal()
-        } label: {
-            NoopCard(tint: StrandPalette.accent) {
-                VStack(alignment: .leading, spacing: NoopMetrics.space3) {
-                    HStack(spacing: NoopMetrics.space2) {
-                        Image(systemName: "book.closed")
-                            .font(.system(size: 18))
-                            .foregroundStyle(StrandPalette.accent)
-                            .accessibilityHidden(true)
-                        Text(String(localized: "Journal"))
-                            .font(StrandFont.headline)
-                            .foregroundStyle(StrandPalette.textPrimary)
-                        Spacer()
-                        Image(systemName: "chevron.right")
-                            .font(.system(size: 14, weight: .semibold))
-                            .foregroundStyle(StrandPalette.textTertiary)
-                            .accessibilityHidden(true)
-                    }
-                    // The last-N-days strip: one equal-width bar per day. Filled = logged; today is ringed
-                    // so the orientation is unambiguous even when nothing is logged yet.
-                    HStack(spacing: 6) {
-                        ForEach(keys, id: \.self) { key in
-                            let isLogged = logged.contains(key)
-                            RoundedRectangle(cornerRadius: 3)
-                                .fill(isLogged ? StrandPalette.accent : StrandPalette.textTertiary.opacity(0.22))
-                                .frame(maxWidth: .infinity)
-                                .frame(height: 10)
-                                .overlay {
-                                    if key == todayKey, !isLogged {
-                                        RoundedRectangle(cornerRadius: 3)
-                                            .strokeBorder(StrandPalette.accent, lineWidth: 1)
-                                    }
-                                }
-                        }
-                    }
-                    Text(todayLogged
-                         ? String(localized: "Logged today")
-                         : String(localized: "Log today's journal"))
-                        .font(StrandFont.footnote)
-                        .foregroundStyle(todayLogged ? StrandPalette.textSecondary : StrandPalette.accent)
+        // No outer Button: each bar is its own tap target that deep-links the journal to THAT day (#656),
+        // and nested SwiftUI buttons don't work — so header + subtitle carry their own onTapGesture (→
+        // today) and the bars carry theirs. The regions are non-overlapping in the VStack, so a tap lands
+        // on exactly one. Tapping a bar does NOT set today, so a bar's day always wins.
+        return NoopCard(tint: StrandPalette.accent) {
+            VStack(alignment: .leading, spacing: NoopMetrics.space3) {
+                HStack(spacing: NoopMetrics.space2) {
+                    Image(systemName: "book.closed")
+                        .font(.system(size: 18))
+                        .foregroundStyle(StrandPalette.accent)
+                        .accessibilityHidden(true)
+                    Text(String(localized: "Journal"))
+                        .font(StrandFont.headline)
+                        .foregroundStyle(StrandPalette.textPrimary)
+                    Spacer()
+                    Image(systemName: "chevron.right")
+                        .font(.system(size: 14, weight: .semibold))
+                        .foregroundStyle(StrandPalette.textTertiary)
+                        .accessibilityHidden(true)
                 }
+                .contentShape(Rectangle())
+                .onTapGesture { router.openJournal() }
+                .accessibilityElement(children: .combine)
+                .accessibilityAddTraits(.isButton)
+                .accessibilityLabel(Text(String(localized: "Journal")))
+                .accessibilityHint(Text(String(localized: "Open journal")))
+                // The last-N-days strip: one equal-width bar per day, each its own tap target. Filled =
+                // logged; today is ringed. Tapping a bar deep-links the journal to that day (#656).
+                HStack(spacing: 6) {
+                    ForEach(keys.indices, id: \.self) { i in
+                        let key = keys[i]
+                        let off = Self.stripDays - 1 - i          // keys[0] = 6 days ago … last = today
+                        let isLogged = logged.contains(key)
+                        Color.clear
+                            .frame(maxWidth: .infinity)
+                            .frame(height: 22)                    // taller invisible tap target
+                            .overlay {
+                                RoundedRectangle(cornerRadius: 3)
+                                    .fill(isLogged ? StrandPalette.accent : StrandPalette.textTertiary.opacity(0.22))
+                                    .frame(height: 10)
+                                    .overlay {
+                                        if off == 0, !isLogged {
+                                            RoundedRectangle(cornerRadius: 3)
+                                                .strokeBorder(StrandPalette.accent, lineWidth: 1)
+                                        }
+                                    }
+                            }
+                            .contentShape(Rectangle())
+                            .onTapGesture { router.openJournal(day: off) }
+                            .accessibilityAddTraits(.isButton)
+                            .accessibilityLabel(Self.barLabel(off))
+                    }
+                }
+                Text(todayLogged
+                     ? String(localized: "Logged today")
+                     : String(localized: "Log today's journal"))
+                    .font(StrandFont.footnote)
+                    .foregroundStyle(todayLogged ? StrandPalette.textSecondary : StrandPalette.accent)
+                    .contentShape(Rectangle())
+                    .onTapGesture { router.openJournal() }
+                    .accessibilityAddTraits(.isButton)   // it opens the journal — announce it as one
             }
         }
-        .buttonStyle(.plain)
-        .accessibilityLabel(Text(String(localized: "Journal")))
-        .accessibilityHint(Text(String(localized: "Open journal")))
+    }
+
+    /// Screen-reader label for a strip bar (#656): the day it deep-links to. Twin of JournalLogCard's
+    /// day-picker labels; "%lld days ago" is a String Catalog key so it stays localized.
+    private static func barLabel(_ offset: Int) -> LocalizedStringKey {
+        switch offset {
+        case 0: return "Today"
+        case 1: return "Yesterday"
+        default: return "\(offset) days ago"
+        }
     }
 
     private func reload() async {


### PR DESCRIPTION
iOS/macOS mirror of the Android Scope A (#669) for @bartmuskala's #656 — so the journal fix isn't Android-only.

## What
- **A1 — backfill.** `JournalLogCard`'s day picker goes from 3 pills (Tomorrow/Today/Yesterday) to a **bounded, horizontally-scrollable range** (Tomorrow back through the last 7 days), snapping to the selected day. Added **`%lld days ago`** to the String Catalog (de/es/fr) — the extraction key mirrors the shipped **`%lld nights ago`** (#527), so 2–6 stay localized.
- **A2 — deep-link.** Dropped the widget's outer `Button` (nested SwiftUI buttons don't work): each strip bar is its **own tap target** (`onTapGesture → router.openJournal(day: off)`), while header + subtitle tap → today. `NavRouter.pendingJournalDayOffset` carries the day; `InsightsView` consumes it on appear and reloads. The regions are non-overlapping, and a bar tap never sets today, so its day wins.

## Notable
- **`onChangeCompat` (not `onChange`)** for the picker auto-scroll — this card is shared with the **macOS 13** target and the zero/two-arg `onChange` is macOS 14+.
- Per-bar `accessibilityLabel` + `.isButton` so a screen reader announces which day each bar opens.

## Verification / scope
App-target Swift — **no Linux/CI compile.** Verified as far as possible: **i18n audit clean** (the new key has de/es/fr; no new un-extracted literals), **no `Packages/` touched** (swift-packages CI unaffected), and the one macOS-13 API pitfall guarded. **Compile lands on the next staging build**, like the rest of the recent iOS work.

Closes the iOS half of #656 parts 1 & 2. Part 3 (split journal from Insights) remains separate.