### PR TITLE
Journal widget: reorderable section + tap-a-day subtitle hint (#656)

### DIFF
--- a/Strand/Data/TodayLayoutPrefs.swift
+++ b/Strand/Data/TodayLayoutPrefs.swift
@@ -27,6 +27,7 @@ enum TodaySection: String, CaseIterable, Identifiable {
     case heartRate
     case recoveryVitals
     case yourCards
+    case journal
 
     var id: String { rawValue }
 
@@ -41,12 +42,15 @@ enum TodaySection: String, CaseIterable, Identifiable {
         case .heartRate:      return String(localized: "Heart Rate")
         case .recoveryVitals: return String(localized: "Recovery Vitals")
         case .yourCards:      return String(localized: "Your Cards")
+        case .journal:        return String(localized: "Journal")
         }
     }
 
-    /// The original, hard-coded section order — the default when the layout isn't customised.
+    /// The original, hard-coded section order — the default when the layout isn't customised. The journal
+    /// widget (#656) is last by default, where it was first added, above the data-sources card.
     static let defaultOrder: [TodaySection] = [
         .hero, .liveSession, .synthesis, .keyMetrics, .workouts, .heartRate, .recoveryVitals, .yourCards,
+        .journal,
     ]
 }
 

--- a/Strand/Liquid/LiquidTodayView.swift
+++ b/Strand/Liquid/LiquidTodayView.swift
@@ -260,11 +260,13 @@ struct LiquidTodayView: View {
                         case .heartRate: heartRateSection
                         case .recoveryVitals: recoveryVitalsSection
                         case .yourCards: yourCardsSection
+                        // #656: the persistent journal widget (last-7-days strip + tap-through). Now a
+                        // reorderable section like the others — the Arrange sheet moves it. Today only;
+                        // the card self-hides when the reminder toggle is off (an empty branch renders
+                        // nothing yet keeps its slot). Twin of Android TodayScreen's JOURNAL arm.
+                        case .journal: if selectedDayOffset == 0 { JournalReminderCard() }
                         }
                     }
-                    // #627: the persistent journal widget (last-7-days strip + tap-through to the journal).
-                    // Today only; self-hides when the reminder toggle is off. Twin of Android JournalReminderCard.
-                    if selectedDayOffset == 0 { JournalReminderCard() }
                     dataSourcesSection
                     Color.clear.frame(height: 90) // floating tab-bar clearance
                 }

--- a/Strand/Screens/JournalReminderCard.swift
+++ b/Strand/Screens/JournalReminderCard.swift
@@ -46,6 +46,12 @@ struct JournalReminderCard: View {
         let keys = Self.dayKeys()
         let todayKey = keys.last ?? ""
         let todayLogged = logged.contains(todayKey)
+        // A recent PAST day with no entry — surfaces the tap-a-bar-to-backfill interaction once today is
+        // done (#656). Accent while anything is actionable; calm secondary once fully caught up.
+        let hasMissed = keys.contains { $0 != todayKey && !logged.contains($0) }
+        let subtitle: String = !todayLogged ? String(localized: "Log today's journal")
+            : hasMissed ? String(localized: "Tap a day to catch up")
+            : String(localized: "Logged today")
         // No outer Button: each bar is its own tap target that deep-links the journal to THAT day (#656),
         // and nested SwiftUI buttons don't work — so header + subtitle carry their own onTapGesture (→
         // today) and the bars carry theirs. The regions are non-overlapping in the VStack, so a tap lands
@@ -99,11 +105,9 @@ struct JournalReminderCard: View {
                             .accessibilityLabel(Self.barLabel(off))
                     }
                 }
-                Text(todayLogged
-                     ? String(localized: "Logged today")
-                     : String(localized: "Log today's journal"))
+                Text(subtitle)
                     .font(StrandFont.footnote)
-                    .foregroundStyle(todayLogged ? StrandPalette.textSecondary : StrandPalette.accent)
+                    .foregroundStyle((!todayLogged || hasMissed) ? StrandPalette.accent : StrandPalette.textSecondary)
                     .contentShape(Rectangle())
                     .onTapGesture { router.openJournal() }
                     .accessibilityAddTraits(.isButton)   // it opens the journal — announce it as one

--- a/StrandTests/TodayLayoutPrefsTests.swift
+++ b/StrandTests/TodayLayoutPrefsTests.swift
@@ -14,9 +14,10 @@ final class TodayLayoutPrefsTests: XCTestCase {
     func testEncodeDecodeRoundTripsAReorderedList() {
         let reordered: [TodaySection] = [
             .heartRate, .hero, .yourCards, .liveSession, .synthesis, .keyMetrics, .workouts, .recoveryVitals,
+            .journal,
         ]
         let encoded = TodayLayoutPrefs.encode(reordered)
-        XCTAssertEqual(encoded, "heartRate,hero,yourCards,liveSession,synthesis,keyMetrics,workouts,recoveryVitals")
+        XCTAssertEqual(encoded, "heartRate,hero,yourCards,liveSession,synthesis,keyMetrics,workouts,recoveryVitals,journal")
         XCTAssertEqual(TodayLayoutPrefs.decodeOrder(encoded), reordered)
     }
 
@@ -27,7 +28,8 @@ final class TodayLayoutPrefsTests: XCTestCase {
         let firstCut = "synthesis,keyMetrics,workouts,heartRate,recoveryVitals,yourCards"
         XCTAssertEqual(
             TodayLayoutPrefs.decodeOrder(firstCut),
-            [.hero, .liveSession, .synthesis, .keyMetrics, .workouts, .heartRate, .recoveryVitals, .yourCards]
+            // journal(8) follows everything saved → appended.
+            [.hero, .liveSession, .synthesis, .keyMetrics, .workouts, .heartRate, .recoveryVitals, .yourCards, .journal]
         )
     }
 
@@ -35,7 +37,7 @@ final class TodayLayoutPrefsTests: XCTestCase {
         let partial = "heartRate,synthesis,keyMetrics,recoveryVitals"
         XCTAssertEqual(
             TodayLayoutPrefs.decodeOrder(partial),
-            [.hero, .liveSession, .workouts, .heartRate, .synthesis, .keyMetrics, .recoveryVitals, .yourCards]
+            [.hero, .liveSession, .workouts, .heartRate, .synthesis, .keyMetrics, .recoveryVitals, .yourCards, .journal]
         )
     }
 
@@ -43,7 +45,7 @@ final class TodayLayoutPrefsTests: XCTestCase {
         let messy = "yourCards,BOGUS,yourCards,heartRate, ,heartRate"
         XCTAssertEqual(
             TodayLayoutPrefs.decodeOrder(messy),
-            [.hero, .liveSession, .synthesis, .keyMetrics, .workouts, .recoveryVitals, .yourCards, .heartRate]
+            [.hero, .liveSession, .synthesis, .keyMetrics, .workouts, .recoveryVitals, .yourCards, .heartRate, .journal]
         )
     }
 
@@ -64,7 +66,7 @@ final class TodayLayoutPrefsTests: XCTestCase {
         // Pin the exact wire strings — they must match the Android TodaySection byte-for-byte.
         XCTAssertEqual(
             raws,
-            ["hero", "liveSession", "synthesis", "keyMetrics", "workouts", "heartRate", "recoveryVitals", "yourCards"]
+            ["hero", "liveSession", "synthesis", "keyMetrics", "workouts", "heartRate", "recoveryVitals", "yourCards", "journal"]
         )
     }
 }

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -26,7 +26,7 @@ android {
         applicationId = "com.noop.whoop"
         minSdk = 26
         targetSdk = 34
-        versionCode = 295
+        versionCode = 296
         versionName = "9.0.3"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"

--- a/android/app/src/main/java/com/noop/ui/JournalReminder.kt
+++ b/android/app/src/main/java/com/noop/ui/JournalReminder.kt
@@ -154,14 +154,19 @@ fun JournalReminderCard(
                     }
                 }
             }
+            // A recent PAST day with no entry — surfaces the (otherwise invisible) tap-a-bar-to-backfill
+            // interaction once today is done. #656.
+            val hasMissed = dayKeys.any { it != todayKey && it !in logged }
             Text(
-                if (todayLogged) {
-                    uiString(R.string.l10n_journal_reminder_logged_today_0071a46c)
-                } else {
-                    uiString(R.string.l10n_journal_reminder_log_today_s_journal_cb33be3e)
+                when {
+                    !todayLogged -> uiString(R.string.l10n_journal_reminder_log_today_s_journal_cb33be3e)
+                    hasMissed -> uiString(R.string.l10n_journal_reminder_tap_a_day_to_catch_up_10d16728)
+                    else -> uiString(R.string.l10n_journal_reminder_logged_today_0071a46c)
                 },
                 style = NoopType.footnote,
-                color = if (todayLogged) Palette.textSecondary else Palette.accent,
+                // Accent while there's something actionable (log today, or catch up a missed day);
+                // calm secondary once fully caught up.
+                color = if (!todayLogged || hasMissed) Palette.accent else Palette.textSecondary,
             )
         }
     }

--- a/android/app/src/main/java/com/noop/ui/TodayLayoutPrefs.kt
+++ b/android/app/src/main/java/com/noop/ui/TodayLayoutPrefs.kt
@@ -30,14 +30,17 @@ enum class TodaySection(val raw: String, val title: String) {
     WORKOUTS("workouts", "Workouts"),
     HEART_RATE("heartRate", "Heart Rate"),
     RECOVERY_VITALS("recoveryVitals", "Recovery Vitals"),
-    YOUR_CARDS("yourCards", "Your Cards");
+    YOUR_CARDS("yourCards", "Your Cards"),
+    JOURNAL("journal", "Journal");
 
     companion object {
         fun fromRaw(raw: String?): TodaySection? = entries.firstOrNull { it.raw == raw }
 
-        /** The original, hard-coded section order — the default when the layout isn't customised. */
+        /** The original, hard-coded section order — the default when the layout isn't customised. The
+         *  journal widget (#656) is last by default, where it was first added, above the data-sources card. */
         val defaultOrder: List<TodaySection> = listOf(
             HERO, LIVE_SESSION, SYNTHESIS, KEY_METRICS, WORKOUTS, HEART_RATE, RECOVERY_VITALS, YOUR_CARDS,
+            JOURNAL,
         )
     }
 }

--- a/android/app/src/main/java/com/noop/ui/TodayScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/TodayScreen.kt
@@ -629,6 +629,10 @@ fun TodayScreen(
     var showLiveSession by remember { mutableStateOf(false) }
     val liveSessionsEnabled = remember { LiveSessionPrefs.enabled(context) }
     val activeLiveSession by LiveSessionRunner.active.collectAsStateWithLifecycle()
+    // The journal widget's own opt-out (default ON). Read here too so its reorderable section emits no
+    // item when disabled — an always-present zero-height slot would leave a blank draggable gap. Same
+    // remember-once idiom the card uses; a resume/recompose re-reads it. (#656)
+    val journalReminderOn = remember { NoopPrefs.journalReminderEnabled(context) }
     // S4: the Synthesis card collapses to a one-liner that expands on tap (default collapsed). Mirrors iOS.
     var synthesisExpanded by remember { mutableStateOf(false) }
     // S5: the Key Metrics grid caps at the first METRICS_COLLAPSED_CAP tiles behind a "Show all metrics"
@@ -1327,6 +1331,8 @@ fun TodayScreen(
                     selectedDayOffset == 0 && (liveSessionsEnabled || activeLiveSession != null)
                 TodaySection.YOUR_CARDS ->
                     selectedDayOffset == 0 && visibleDashboardCards.isNotEmpty()
+                TodaySection.JOURNAL ->
+                    selectedDayOffset == 0 && journalReminderOn
                 else -> true
             }
             if (!sectionVisible) return@forEach
@@ -1525,6 +1531,15 @@ fun TodayScreen(
                             onOpenCoupled = onOpenCoupled,
                             onCustomise = { showDashboardEditor = true },
                         )
+                        // #656: the persistent journal widget (last-7-days strip + tap-through). Now a
+                        // reorderable section like the others — hold-drag or Arrange moves it. Today-only
+                        // and enabled-gated at the loop level (sectionVisible) so it never leaves a blank
+                        // draggable slot. Twin of iOS LiquidTodayView's `.journal` arm.
+                        TodaySection.JOURNAL -> JournalReminderCard(
+                            viewModel = viewModel,
+                            days = days,
+                            onOpenJournal = onOpenJournal,
+                        )
                     }
                 }
             }
@@ -1534,11 +1549,6 @@ fun TodayScreen(
         // toggle is off or there's nothing to suggest. Save → a manual "Workout" row; × → dismissed forever.
         if (selectedDayOffset == 0) {
             item { AutoWorkoutNudgeCard(viewModel = viewModel, days = days) }
-        }
-        // #627: a dismissible "log today's journal" reminder — shows only when nothing is logged today
-        // and the reminder is enabled (default ON). Self-hides otherwise. Taps through to the journal.
-        if (selectedDayOffset == 0) {
-            item { JournalReminderCard(viewModel = viewModel, days = days, onOpenJournal = onOpenJournal) }
         }
         // Strap battery only while the link is up AND a real reading exists, a stale % from a
         // dropped connection must not present as live (#159).

--- a/android/app/src/main/res/values-de/strings.xml
+++ b/android/app/src/main/res/values-de/strings.xml
@@ -1343,6 +1343,7 @@
     <string name="l10n_journal_reminder_show_a_today_card_reminding_you_to_log_your_journal_8228bc77">Eine Heute-Karte anzeigen, die dich ans Ausfüllen deines Journals erinnert</string>
     <string name="l10n_journal_reminder_journal_57d7f743">Journal</string>
     <string name="l10n_journal_reminder_logged_today_0071a46c">Heute erfasst</string>
+    <string name="l10n_journal_reminder_tap_a_day_to_catch_up_10d16728">Tippe auf einen Tag zum Nachtragen</string>
     <string name="l10n_liquid_primitives_liquidpressalpha_2c4048a8">liquidPressAlpha</string>
     <string name="l10n_liquid_primitives_liquidpressscale_7520ddb3">liquidPressScale</string>
     <string name="l10n_live_screen_avg_cdc93143">Ø</string>

--- a/android/app/src/main/res/values-es/strings.xml
+++ b/android/app/src/main/res/values-es/strings.xml
@@ -1183,6 +1183,7 @@
     <string name="l10n_journal_reminder_show_a_today_card_reminding_you_to_log_your_journal_8228bc77">Mostrar una tarjeta en Hoy que te recuerde registrar tu diario</string>
     <string name="l10n_journal_reminder_journal_57d7f743">Diario</string>
     <string name="l10n_journal_reminder_logged_today_0071a46c">Registrado hoy</string>
+    <string name="l10n_journal_reminder_tap_a_day_to_catch_up_10d16728">Toca un día para ponerte al día</string>
     <string name="l10n_liquid_primitives_liquidpressalpha_2c4048a8">líquidoPressAlpha</string>
     <string name="l10n_liquid_primitives_liquidpressscale_7520ddb3">líquidoPresiónScale</string>
     <string name="l10n_live_screen_avg_cdc93143">Prom</string>

--- a/android/app/src/main/res/values-fr/strings.xml
+++ b/android/app/src/main/res/values-fr/strings.xml
@@ -1183,6 +1183,7 @@
     <string name="l10n_journal_reminder_show_a_today_card_reminding_you_to_log_your_journal_8228bc77">Afficher une carte Aujourd\'hui vous rappelant de remplir votre journal</string>
     <string name="l10n_journal_reminder_journal_57d7f743">Journal</string>
     <string name="l10n_journal_reminder_logged_today_0071a46c">Enregistré aujourd\'hui</string>
+    <string name="l10n_journal_reminder_tap_a_day_to_catch_up_10d16728">Touchez un jour pour le compléter</string>
     <string name="l10n_liquid_primitives_liquidpressalpha_2c4048a8">liquidePresseAlpha</string>
     <string name="l10n_liquid_primitives_liquidpressscale_7520ddb3">liquidePressScale</string>
     <string name="l10n_live_screen_avg_cdc93143">Moy.</string>

--- a/android/app/src/main/res/values-zh/strings.xml
+++ b/android/app/src/main/res/values-zh/strings.xml
@@ -1308,6 +1308,7 @@
     <string name="l10n_journal_reminder_show_a_today_card_reminding_you_to_log_your_journal_8228bc77">在“今天”页面显示提醒你记录日志的卡片</string>
     <string name="l10n_journal_reminder_journal_57d7f743">日志</string>
     <string name="l10n_journal_reminder_logged_today_0071a46c">今天已记录</string>
+    <string name="l10n_journal_reminder_tap_a_day_to_catch_up_10d16728">点按某一天进行补记</string>
     <string name="l10n_liquid_primitives_liquidpressalpha_2c4048a8">liquidPressAlpha</string>
     <string name="l10n_liquid_primitives_liquidpressscale_7520ddb3">liquidPressScale</string>
     <string name="l10n_live_screen_avg_cdc93143">平均</string>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -1352,6 +1352,7 @@
     <string name="l10n_journal_reminder_show_a_today_card_reminding_you_to_log_your_journal_8228bc77">Show a Today card reminding you to log your journal</string>
     <string name="l10n_journal_reminder_journal_57d7f743">Journal</string>
     <string name="l10n_journal_reminder_logged_today_0071a46c">Logged today</string>
+    <string name="l10n_journal_reminder_tap_a_day_to_catch_up_10d16728">Tap a day to catch up</string>
     <string name="l10n_liquid_primitives_liquidpressalpha_2c4048a8">liquidPressAlpha</string>
     <string name="l10n_liquid_primitives_liquidpressscale_7520ddb3">liquidPressScale</string>
     <string name="l10n_live_screen_avg_cdc93143">Avg</string>

--- a/android/app/src/test/java/com/noop/ui/TodayLayoutPrefsTest.kt
+++ b/android/app/src/test/java/com/noop/ui/TodayLayoutPrefsTest.kt
@@ -23,11 +23,11 @@ class TodayLayoutPrefsTest {
         val reordered = listOf(
             TodaySection.HEART_RATE, TodaySection.HERO, TodaySection.YOUR_CARDS,
             TodaySection.LIVE_SESSION, TodaySection.SYNTHESIS, TodaySection.KEY_METRICS,
-            TodaySection.WORKOUTS, TodaySection.RECOVERY_VITALS,
+            TodaySection.WORKOUTS, TodaySection.RECOVERY_VITALS, TodaySection.JOURNAL,
         )
         val encoded = TodayLayoutPrefs.encode(reordered)
         assertEquals(
-            "heartRate,hero,yourCards,liveSession,synthesis,keyMetrics,workouts,recoveryVitals",
+            "heartRate,hero,yourCards,liveSession,synthesis,keyMetrics,workouts,recoveryVitals,journal",
             encoded,
         )
         assertEquals(reordered, TodayLayoutPrefs.decodeOrder(encoded))
@@ -44,6 +44,8 @@ class TodayLayoutPrefsTest {
                 TodaySection.HERO, TodaySection.LIVE_SESSION,
                 TodaySection.SYNTHESIS, TodaySection.KEY_METRICS, TodaySection.WORKOUTS,
                 TodaySection.HEART_RATE, TodaySection.RECOVERY_VITALS, TodaySection.YOUR_CARDS,
+                // journal(8) follows everything saved → appended:
+                TodaySection.JOURNAL,
             ),
             TodayLayoutPrefs.decodeOrder(firstCut),
         )
@@ -63,8 +65,8 @@ class TodayLayoutPrefsTest {
                 TodaySection.HERO, TodaySection.LIVE_SESSION, TodaySection.WORKOUTS,
                 TodaySection.HEART_RATE, TodaySection.SYNTHESIS, TodaySection.KEY_METRICS,
                 TodaySection.RECOVERY_VITALS,
-                // yourCards(7) follows everything saved → appended:
-                TodaySection.YOUR_CARDS,
+                // yourCards(7) then journal(8) follow everything saved → appended in default order:
+                TodaySection.YOUR_CARDS, TodaySection.JOURNAL,
             ),
             decoded,
         )
@@ -82,6 +84,8 @@ class TodayLayoutPrefsTest {
                 TodaySection.HERO, TodaySection.LIVE_SESSION, TodaySection.SYNTHESIS,
                 TodaySection.KEY_METRICS, TodaySection.WORKOUTS, TodaySection.RECOVERY_VITALS,
                 TodaySection.YOUR_CARDS, TodaySection.HEART_RATE,
+                // journal(8) follows everything → appended last:
+                TodaySection.JOURNAL,
             ),
             decoded,
         )
@@ -108,7 +112,7 @@ class TodayLayoutPrefsTest {
         assertEquals(
             listOf(
                 "hero", "liveSession", "synthesis", "keyMetrics",
-                "workouts", "heartRate", "recoveryVitals", "yourCards",
+                "workouts", "heartRate", "recoveryVitals", "yourCards", "journal",
             ),
             raws,
         )

--- a/project.yml
+++ b/project.yml
@@ -15,7 +15,7 @@ settings:
     # iOS build number (CFBundleVersion). GLOBAL so the iOS app AND its widget extension inherit the
     # SAME value — they must match or iOS warns "extension version must match parent app" (#416).
     # macOS sets its own CFBundleVersion on the Strand target and is unaffected by this.
-    CURRENT_PROJECT_VERSION: "205"
+    CURRENT_PROJECT_VERSION: "206"
     SWIFT_VERSION: "5.0"
     # Emit localizable strings so Xcode auto-extracts every LocalizedStringKey into the
     # String Catalog on build (the English (US) base entries).


### PR DESCRIPTION
Two follow-ons to #669/#670 for the journal widget, from bartmuskala's field feedback (#656).

## 1 — Make the widget a reorderable section
The journal widget was a fixed insertion *outside* the reorderable Today system, so — unlike every other card — it couldn't be moved by hold-drag or reached from **Arrange**. The report asked to move it like the others.

Rather than add new drag/arrange code, it now **reuses the existing `TodaySection` machinery**: a new `JOURNAL` case (byte-identical raw `journal` on both platforms) at the end of `defaultOrder` — where the widget already sat, above the data-sources card — rendered through the same section switch every other card uses.
- Hold-drag (Android) and the Arrange sheet/editor (both) pick it up for free.
- `decodeOrder` auto-inserts it into any saved order, so existing layouts migrate with **no `.noopbak` change**.
- Today-gated as before; Android also gates section visibility on the journal-reminder opt-out so a disabled widget leaves **no blank draggable slot**.
- Old fixed insertions removed from `TodayScreen.kt` + `LiquidTodayView.swift`; classic non-reorderable `TodayView` keeps its own. Pinning tests updated both platforms.

## 2 — Tap-a-day subtitle hint
Now that each strip bar deep-links to its day, a three-state subtitle surfaces that (otherwise invisible) gesture:
- today not logged → **"Log today's journal"** (accent) — unchanged
- today logged **but a recent day isn't** → **"Tap a day to catch up"** (accent) — *new*
- fully caught up → **"Logged today"** (calm secondary) — unchanged

Deliberately **not a legend**: the completion squares stay self-explanatory (bartmuskala read them fine — *"correctly shows which days are or are not completed"*); only the new gesture gets a one-line nudge. New string `Tap a day to catch up` with de/es/fr (+zh on Android).

## Verification
- **Android:** `compileFullDebugKotlin` ✓ · `testFullDebugUnitTest --tests TodayLayoutPrefsTest` ✓ · `i18n_audit` ✓ · `lintVitalFullRelease -PstagingRelease` ✓
- **iOS:** app-target Swift — compiles on the next staging build (mirror of the Android logic; `TodayLayoutPrefsTests` updated in lockstep; audit clean).

Refs #656 (parts 1 & 2 shipped in #669/#670; this is the discoverability + arrange polish).