### PR TITLE
Surface Health Connect writeback failures instead of silent zero (#660)

### DIFF
--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -1828,8 +1828,10 @@ class WhoopBleClient(
                 }
                 // Keep the opt-in Health Connect writeback fresh in background-only operation too.
                 if (NoopPrefs.hcWriteback(context)) {
+                    // #660: log the count AND any PII-safe failure categories (the writer also persists
+                    // the outcome to prefs, so Data Sources surfaces a failing background share).
                     runCatching { HealthConnectWriter.write(context, repository, deviceId) }
-                        .onSuccess { log("HC writeback: $it record(s)") }
+                        .onSuccess { r -> log("HC writeback: ${r.written} record(s)" + if (r.ok) "" else " (failed: ${r.failures.joinToString()})") }
                 }
             } finally {
                 analyzeAfterBackfillScheduled.set(false)

--- a/android/app/src/main/java/com/noop/ingest/HealthConnectWriter.kt
+++ b/android/app/src/main/java/com/noop/ingest/HealthConnectWriter.kt
@@ -24,6 +24,37 @@ import java.time.LocalTime
 import java.time.ZoneId
 import kotlin.reflect.KClass
 
+/** PII-safe category of a Health Connect writeback failure — a coarse reason, never a raw message. */
+enum class WritebackFailure { PERMISSION_DENIED, REMOTE_ERROR }
+
+/**
+ * Outcome of a writeback attempt (#660): how many records landed, plus any per-concern failure
+ * categories. Lets callers/UI distinguish "wrote 0 because nothing to share" from "wrote 0 because
+ * the write FAILED" — the silent-zero the previous `Int` return couldn't express.
+ */
+data class WritebackResult(val written: Int, val failures: List<WritebackFailure>) {
+    val ok: Boolean get() = failures.isEmpty()
+
+    /** PII-safe status code persisted for the UI — a permission failure outranks a generic one, since it
+     *  needs a distinct "re-grant" action. Pure/testable; must equal the `NoopPrefs.HC_WB_*` constants. */
+    val statusCode: String get() = when {
+        WritebackFailure.PERMISSION_DENIED in failures -> "PERMISSION_DENIED"
+        failures.isNotEmpty() -> "REMOTE_ERROR"
+        else -> "OK"
+    }
+
+    companion object {
+        /** HC unavailable / nothing attempted — benign, not a failure. */
+        val UNAVAILABLE = WritebackResult(0, emptyList())
+    }
+}
+
+/** Map a thrown write error to a PII-safe category; rethrow coroutine cancellation (never a "failure"). */
+private fun Throwable.writebackCategory(): WritebackFailure {
+    if (this is kotlin.coroutines.cancellation.CancellationException) throw this
+    return if (this is SecurityException) WritebackFailure.PERMISSION_DENIED else WritebackFailure.REMOTE_ERROR
+}
+
 /**
  * OPT-IN writeback: pushes NOOP's on-device computed nightly metrics (resting HR, HRV RMSSD, sleep
  * SpO2, respiratory rate) INTO Health Connect, so other apps can see what the strap measured.
@@ -57,16 +88,17 @@ object HealthConnectWriter {
         WRITE_RECORDS.map { HealthPermission.getWritePermission(it) }.toSet()
 
     /**
-     * Write the last [WINDOW_DAYS] of computed metrics. Returns the number of records written,
-     * 0 when HC is unavailable / nothing computed yet. Assumes [PERMISSIONS] are granted (HC
-     * throws SecurityException otherwise — callers wrap in runCatching).
+     * Write the last [WINDOW_DAYS] of computed metrics. Returns a [WritebackResult] — the record
+     * count PLUS any per-concern failure categories, so a revoked permission no longer looks like a
+     * benign "wrote 0" (#660). Persists the outcome via [recordStatus] for the Data Sources UI.
+     * Assumes [PERMISSIONS] are granted (HC throws SecurityException otherwise — caught + categorized).
      *
      * [deviceId] must be the registry's ACTIVE strap id (SPINE / #814): a wizard-paired strap banks
      * rows under `whoop-<address>`, so a hardcoded legacy "my-whoop" id reads empty tables and
      * exports nothing.
      */
-    suspend fun write(context: Context, repo: WhoopRepository, deviceId: String): Int {
-        if (HealthConnectClient.getSdkStatus(context) != HealthConnectClient.SDK_AVAILABLE) return 0
+    suspend fun write(context: Context, repo: WhoopRepository, deviceId: String): WritebackResult {
+        if (HealthConnectClient.getSdkStatus(context) != HealthConnectClient.SDK_AVAILABLE) return WritebackResult.UNAVAILABLE
         val client = HealthConnectClient.getOrCreate(context)
 
         val cutoff = LocalDate.now().minusDays(WINDOW_DAYS).toString()
@@ -118,15 +150,27 @@ object HealthConnectWriter {
         // totals. iOS (#249) excludes them for the same reason; this keeps the two platforms aligned.
         // The unique strap signals (vitals, HR, sleep, workouts) are still written below.
 
-        // Each export concern inserts independently (own runCatching) so a failure in one — e.g. a
-        // revoked per-type WRITE permission — can't suppress the others.
+        // Each export concern inserts independently so a failure in one — e.g. a revoked per-type WRITE
+        // permission — can't suppress the others. Failures are CATEGORIZED (PII-safe, never raw messages)
+        // and folded into the result instead of collapsing to a silent 0, so the UI can surface them (#660).
         var total = 0
+        val failures = mutableListOf<WritebackFailure>()
         if (records.isNotEmpty()) {
-            total += runCatching { client.insertRecords(records); records.size }.getOrDefault(0)
+            runCatching { client.insertRecords(records); records.size }
+                .fold({ total += it }, { failures += it.writebackCategory() })
         }
-        total += runCatching { writeHeartRate(client, context, repo, deviceId, version) }.getOrDefault(0)
-        total += runCatching { writeSleep(client, repo, deviceId) }.getOrDefault(0)
-        return total
+        runCatching { writeHeartRate(client, context, repo, deviceId, version) }
+            .fold({ total += it }, { failures += it.writebackCategory() })
+        runCatching { writeSleep(client, repo, deviceId) }
+            .fold({ total += it }, { failures += it.writebackCategory() })
+        val result = WritebackResult(total, failures.distinct())
+        recordStatus(context, result)
+        return result
+    }
+
+    /** Persist the last writeback outcome (PII-safe category + count + time) for the Data Sources UI (#660). */
+    private fun recordStatus(context: Context, result: WritebackResult) {
+        NoopPrefs.setHcWritebackStatus(context, result.statusCode, result.written, System.currentTimeMillis())
     }
 
     private fun meta(metric: String, day: String, version: Long) = Metadata(
@@ -273,11 +317,14 @@ object HealthConnectWriter {
         return out
     }
 
-    /** Insert one workout's records into Health Connect. Opt-in caller; wrap in runCatching. */
-    suspend fun writeExercise(context: Context, row: WorkoutRow, exerciseType: Int): Int {
-        if (HealthConnectClient.getSdkStatus(context) != HealthConnectClient.SDK_AVAILABLE) return 0
+    /** Insert one workout's records into Health Connect. Opt-in caller. Returns a [WritebackResult] so a
+     *  failed exercise share is visible instead of silently swallowed, and records the outcome (#660). */
+    suspend fun writeExercise(context: Context, row: WorkoutRow, exerciseType: Int): WritebackResult {
+        if (HealthConnectClient.getSdkStatus(context) != HealthConnectClient.SDK_AVAILABLE) return WritebackResult.UNAVAILABLE
         val recs = buildExerciseRecords(row, exerciseType)
-        HealthConnectClient.getOrCreate(context).insertRecords(recs)
-        return recs.size
+        val result = runCatching { HealthConnectClient.getOrCreate(context).insertRecords(recs); recs.size }
+            .fold({ WritebackResult(it, emptyList()) }, { WritebackResult(0, listOf(it.writebackCategory())) })
+        recordStatus(context, result)
+        return result
     }
 }

--- a/android/app/src/main/java/com/noop/ingest/HealthConnectWriter.kt
+++ b/android/app/src/main/java/com/noop/ingest/HealthConnectWriter.kt
@@ -99,10 +99,19 @@ object HealthConnectWriter {
      */
     suspend fun write(context: Context, repo: WhoopRepository, deviceId: String): WritebackResult {
         if (HealthConnectClient.getSdkStatus(context) != HealthConnectClient.SDK_AVAILABLE) return WritebackResult.UNAVAILABLE
-        val client = HealthConnectClient.getOrCreate(context)
 
-        val cutoff = LocalDate.now().minusDays(WINDOW_DAYS).toString()
-        val days = repo.days(repo.computedDeviceId(deviceId)).filter { it.day >= cutoff }
+        // Guard the pre-insert work (client acquisition + the day read) the same way the concern inserts
+        // below are guarded, so a provider race or DB error can't throw PAST recordStatus and leave the
+        // UI showing a stale "OK" while sharing is actually broken (#660). Cancellation still propagates.
+        val (client, days) = runCatching {
+            val c = HealthConnectClient.getOrCreate(context)
+            val cutoff = LocalDate.now().minusDays(WINDOW_DAYS).toString()
+            c to repo.days(repo.computedDeviceId(deviceId)).filter { it.day >= cutoff }
+        }.getOrElse { t ->
+            val result = WritebackResult(0, listOf(t.writebackCategory()))
+            recordStatus(context, result)
+            return result
+        }
 
         val zone = ZoneId.systemDefault()
         // Stamp every record in this batch with one version so a later recompute (higher stamp)

--- a/android/app/src/main/java/com/noop/ui/AppViewModel.kt
+++ b/android/app/src/main/java/com/noop/ui/AppViewModel.kt
@@ -72,6 +72,10 @@ import kotlin.math.roundToInt
  * daily metrics. Mirrors the macOS AppModel responsibilities (LiveState bridge,
  * `bpm` smoothing, health-alert string) without any networking.
  */
+/** Last Health Connect writeback outcome for the Data Sources UI (#660). [code] is a PII-safe
+ *  category (see [NoopPrefs.HC_WB_OK] etc.); "" = never attempted. */
+data class HcWritebackStatus(val code: String, val atMs: Long, val written: Int)
+
 class AppViewModel(app: Application) : AndroidViewModel(app) {
 
     /** Process-wide context for prefs + the background-connection service. */
@@ -904,6 +908,7 @@ class AppViewModel(app: Application) : AndroidViewModel(app) {
                 // update) break the analysis loop.
                 if (_hcWriteback.value) {
                     runCatching { HealthConnectWriter.write(appContext, repository, deviceId) }
+                    refreshHcWritebackStatus()   // #660: reflect the outcome the writer just persisted
                 }
                 // 15-min backstop cadence, but wake EARLY on an app-resume kick (#386 self-heal) so a
                 // night the overnight tick was killed before scoring catches up the moment the user opens
@@ -1825,6 +1830,19 @@ class AppViewModel(app: Application) : AndroidViewModel(app) {
     private val _hcWriteback = MutableStateFlow(NoopPrefs.hcWriteback(appContext))
     val hcWriteback: StateFlow<Boolean> = _hcWriteback.asStateFlow()
 
+    // Last writeback outcome (#660). Read from prefs (the writer persists it — including on the
+    // background BLE path, which never touches this VM), so Data Sources shows a failing share
+    // instead of a healthy-looking toggle. [refreshHcWritebackStatus] re-reads after each attempt.
+    private val _hcWritebackStatus = MutableStateFlow(readHcWritebackStatus())
+    val hcWritebackStatus: StateFlow<HcWritebackStatus> = _hcWritebackStatus.asStateFlow()
+    private fun readHcWritebackStatus() = HcWritebackStatus(
+        code = NoopPrefs.hcWritebackStatus(appContext),
+        atMs = NoopPrefs.hcWritebackAt(appContext),
+        written = NoopPrefs.hcWritebackWritten(appContext),
+    )
+    /** Re-read the persisted writeback outcome (a background BLE-path write updates prefs, not this VM). */
+    fun refreshHcWritebackStatus() { _hcWritebackStatus.value = readHcWritebackStatus() }
+
     init {
         // On app open, catch up the Health Connect sync if it's overdue. This on-open import is the
         // ONLY auto-sync path: we deliberately skip a true-background worker — it needs a sensitive
@@ -1871,6 +1889,7 @@ class AppViewModel(app: Application) : AndroidViewModel(app) {
             withContext(Dispatchers.IO) {
                 runCatching { HealthConnectWriter.write(appContext, repository, deviceId) }
             }
+            refreshHcWritebackStatus()   // #660: surface the just-recorded outcome in Data Sources
         }
     }
 

--- a/android/app/src/main/java/com/noop/ui/DataSourcesScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/DataSourcesScreen.kt
@@ -117,6 +117,10 @@ fun DataSourcesScreen(vm: AppViewModel) {
     val hcSyncHours by vm.hcSyncHours.collectAsStateWithLifecycle()
     val hcLastSync by vm.hcLastSync.collectAsStateWithLifecycle()
     val hcWriteback by vm.hcWriteback.collectAsStateWithLifecycle()
+    val hcWbStatus by vm.hcWritebackStatus.collectAsStateWithLifecycle()
+    // A background (BLE-path) writeback updates prefs, not the VM's flow — re-read on entry so the
+    // status line reflects the latest attempt whenever this screen is opened (#660).
+    LaunchedEffect(Unit) { vm.refreshHcWritebackStatus() }
 
     // Cached-store counts, loaded once from the repo (newest data is fine to recount).
     var whoopDays by remember { mutableStateOf<Int?>(null) }
@@ -535,6 +539,32 @@ fun DataSourcesScreen(vm: AppViewModel) {
                             contentDescription = uiString(R.string.l10n_data_sources_screen_share_computed_metrics_back_to_health_c11f5d70)
                         },
                     )
+                }
+                // #660: surface the last writeback OUTCOME so a silently-failing share (revoked
+                // permission, provider error) is visible instead of a healthy-looking toggle. Only
+                // while enabled and after at least one attempt (empty status = never tried).
+                if (hcWriteback && hcWbStatus.code.isNotEmpty()) {
+                    when (hcWbStatus.code) {
+                        NoopPrefs.HC_WB_PERMISSION_DENIED -> Text(
+                            uiString(R.string.l10n_data_sources_screen_sharing_paused_health_connect_permission_was_e8950315),
+                            style = NoopType.footnote,
+                            color = Palette.accent,
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .clickable { startWriteback() },   // tap re-requests the WRITE permissions
+                        )
+                        NoopPrefs.HC_WB_REMOTE_ERROR -> Text(
+                            uiString(R.string.l10n_data_sources_screen_last_share_didn_t_finish_noop_0d6c27f0),
+                            style = NoopType.footnote,
+                            color = Palette.accent,
+                        )
+                        else -> Text(   // HC_WB_OK
+                            uiString(R.string.l10n_data_sources_screen_last_shared_6bf8389c) +
+                                DateUtils.getRelativeTimeSpanString(hcWbStatus.atMs).toString(),
+                            style = NoopType.footnote,
+                            color = Palette.textTertiary,
+                        )
+                    }
                 }
             } else {
                 RoadmapNote("Health Connect isn't set up on this device. Install it from Google Play, then return here to import.")

--- a/android/app/src/main/java/com/noop/ui/MainActivity.kt
+++ b/android/app/src/main/java/com/noop/ui/MainActivity.kt
@@ -417,6 +417,27 @@ object NoopPrefs {
         of(context).edit().putBoolean(KEY_HC_WRITEBACK, enabled).apply()
     }
 
+    /** Last writeback OUTCOME (#660) — surfaced in Data Sources so a silently-failing share (revoked
+     *  permission, provider error) is visible instead of a healthy-looking toggle. [KEY_HC_WB_STATUS]
+     *  holds a PII-safe category ([HC_WB_OK] / [HC_WB_PERMISSION_DENIED] / [HC_WB_REMOTE_ERROR]); "" = never. */
+    const val KEY_HC_WB_STATUS = "noop.hcWritebackStatus"
+    const val KEY_HC_WB_AT = "noop.hcWritebackAtMs"
+    const val KEY_HC_WB_WRITTEN = "noop.hcWritebackWritten"
+    const val HC_WB_OK = "OK"
+    const val HC_WB_PERMISSION_DENIED = "PERMISSION_DENIED"
+    const val HC_WB_REMOTE_ERROR = "REMOTE_ERROR"
+
+    fun hcWritebackStatus(context: Context): String = of(context).getString(KEY_HC_WB_STATUS, "") ?: ""
+    fun hcWritebackAt(context: Context): Long = of(context).getLong(KEY_HC_WB_AT, 0L)
+    fun hcWritebackWritten(context: Context): Int = of(context).getInt(KEY_HC_WB_WRITTEN, 0)
+    fun setHcWritebackStatus(context: Context, code: String, written: Int, atMs: Long) {
+        of(context).edit()
+            .putString(KEY_HC_WB_STATUS, code)
+            .putInt(KEY_HC_WB_WRITTEN, written)
+            .putLong(KEY_HC_WB_AT, atMs)
+            .apply()
+    }
+
     /** #528, last HR sample epoch-second exported to Health Connect (0 = nothing exported yet). The
      *  HR share-back only emits samples newer than this, so each writeback is incremental. */
     const val KEY_HC_HR_FRONTIER = "noop.hcHrFrontierTs"

--- a/android/app/src/main/res/values-de/strings.xml
+++ b/android/app/src/main/res/values-de/strings.xml
@@ -1697,4 +1697,7 @@
         <item quantity="one">%1$d Workout</item>
         <item quantity="other">%1$d Workouts</item>
     </plurals>
+    <string name="l10n_data_sources_screen_last_shared_6bf8389c">"Zuletzt geteilt "</string>
+    <string name="l10n_data_sources_screen_sharing_paused_health_connect_permission_was_e8950315">Teilen pausiert – die Health-Connect-Berechtigung wurde entzogen. Zum erneuten Erteilen tippen.</string>
+    <string name="l10n_data_sources_screen_last_share_didn_t_finish_noop_0d6c27f0">Letztes Teilen unvollständig – NOOP versucht es automatisch erneut.</string>
 </resources>

--- a/android/app/src/main/res/values-es/strings.xml
+++ b/android/app/src/main/res/values-es/strings.xml
@@ -1682,4 +1682,7 @@
         <item quantity="one">%1$d entrenamiento</item>
         <item quantity="other">%1$d entrenamientos</item>
     </plurals>
+    <string name="l10n_data_sources_screen_last_shared_6bf8389c">"Compartido por última vez "</string>
+    <string name="l10n_data_sources_screen_sharing_paused_health_connect_permission_was_e8950315">Uso compartido en pausa: se revocó el permiso de Health Connect. Toca para volver a concederlo.</string>
+    <string name="l10n_data_sources_screen_last_share_didn_t_finish_noop_0d6c27f0">El último uso compartido no se completó: NOOP lo reintentará automáticamente.</string>
 </resources>

--- a/android/app/src/main/res/values-fr/strings.xml
+++ b/android/app/src/main/res/values-fr/strings.xml
@@ -1682,4 +1682,7 @@
         <item quantity="one">%1$d entraînement</item>
         <item quantity="other">%1$d entraînements</item>
     </plurals>
+    <string name="l10n_data_sources_screen_last_shared_6bf8389c">"Dernier partage "</string>
+    <string name="l10n_data_sources_screen_sharing_paused_health_connect_permission_was_e8950315">Partage en pause — l’autorisation Health Connect a été révoquée. Touchez pour l’accorder à nouveau.</string>
+    <string name="l10n_data_sources_screen_last_share_didn_t_finish_noop_0d6c27f0">Le dernier partage n’a pas abouti — NOOP réessaiera automatiquement.</string>
 </resources>

--- a/android/app/src/main/res/values-zh/strings.xml
+++ b/android/app/src/main/res/values-zh/strings.xml
@@ -1623,4 +1623,7 @@
     <string name="explore_description_charge">你当前的恢复水平，以 HRV 相对于你个人基线的表现为主导。</string>
     <string name="explore_description_effort">全天累积的心血管负荷，采用 0-100 分制（旧版为 0-21）。</string>
     <string name="explore_description_rest">你的睡眠质量与修复力：综合睡眠时长、睡眠效率、深睡+REM占比以及入睡时机等。</string>
+    <string name="l10n_data_sources_screen_last_shared_6bf8389c">"上次分享 "</string>
+    <string name="l10n_data_sources_screen_sharing_paused_health_connect_permission_was_e8950315">分享已暂停——Health Connect 权限已被撤销。点按以重新授予。</string>
+    <string name="l10n_data_sources_screen_last_share_didn_t_finish_noop_0d6c27f0">上次分享未完成——NOOP 将自动重试。</string>
 </resources>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -1706,4 +1706,7 @@
         <item quantity="one">%1$d workout</item>
         <item quantity="other">%1$d workouts</item>
     </plurals>
+    <string name="l10n_data_sources_screen_last_shared_6bf8389c">"Last shared "</string>
+    <string name="l10n_data_sources_screen_sharing_paused_health_connect_permission_was_e8950315">Sharing paused — Health Connect permission was revoked. Tap to re-grant.</string>
+    <string name="l10n_data_sources_screen_last_share_didn_t_finish_noop_0d6c27f0">Last share didn’t finish — NOOP will retry automatically.</string>
 </resources>

--- a/android/app/src/test/java/com/noop/ingest/WritebackResultTest.kt
+++ b/android/app/src/test/java/com/noop/ingest/WritebackResultTest.kt
@@ -1,0 +1,47 @@
+package com.noop.ingest
+
+import com.noop.ui.NoopPrefs
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Pure coverage for the Health Connect writeback OUTCOME model (#660): the `ok` flag and the PII-safe
+ * status-code mapping the writer persists for the Data Sources UI. No Android context — this is the
+ * logic that decides whether a share looked healthy or silently failed.
+ */
+class WritebackResultTest {
+
+    @Test
+    fun ok_isTrueOnlyWhenThereAreNoFailures() {
+        assertTrue(WritebackResult(written = 12, failures = emptyList()).ok)
+        assertTrue(WritebackResult(written = 0, failures = emptyList()).ok)   // nothing to share is still OK
+        assertFalse(WritebackResult(0, listOf(WritebackFailure.REMOTE_ERROR)).ok)
+        assertFalse(WritebackResult(5, listOf(WritebackFailure.PERMISSION_DENIED)).ok)  // partial write still failed
+    }
+
+    @Test
+    fun statusCode_permissionDeniedOutranksGenericError() {
+        // A revoked permission needs the distinct "re-grant" action, so it wins even when a generic
+        // error is also present in the same attempt.
+        val mixed = WritebackResult(0, listOf(WritebackFailure.REMOTE_ERROR, WritebackFailure.PERMISSION_DENIED))
+        assertEquals("PERMISSION_DENIED", mixed.statusCode)
+    }
+
+    @Test
+    fun statusCode_mapsEachOutcome() {
+        assertEquals("OK", WritebackResult(3, emptyList()).statusCode)
+        assertEquals("REMOTE_ERROR", WritebackResult(0, listOf(WritebackFailure.REMOTE_ERROR)).statusCode)
+        assertEquals("PERMISSION_DENIED", WritebackResult(0, listOf(WritebackFailure.PERMISSION_DENIED)).statusCode)
+    }
+
+    /** The code strings cross into the UI as [NoopPrefs] constants; pin them equal so the writer's
+     *  persisted status and the Data Sources `when` branches can never drift apart. */
+    @Test
+    fun statusCode_matchesTheUiConstants() {
+        assertEquals(NoopPrefs.HC_WB_OK, WritebackResult(1, emptyList()).statusCode)
+        assertEquals(NoopPrefs.HC_WB_REMOTE_ERROR, WritebackResult(0, listOf(WritebackFailure.REMOTE_ERROR)).statusCode)
+        assertEquals(NoopPrefs.HC_WB_PERMISSION_DENIED, WritebackResult(0, listOf(WritebackFailure.PERMISSION_DENIED)).statusCode)
+    }
+}


### PR DESCRIPTION
Fixes #660.

## Problem
Health Connect writeback failures were swallowed. `HealthConnectWriter.write()` returned a bare `Int`, and each concern was wrapped in `runCatching { … }.getOrDefault(0)`, so a revoked `WRITE` permission (or a provider error) collapsed to `0` — indistinguishable from "nothing to share." The background BLE-path write even logged a total failure as success (`onSuccess`-only). Net effect: a user could believe Health Connect sharing was active while every write silently failed. (Audited across **four** call sites, not just the two in the report.)

## Fix
- **Structured result.** `write()` / `writeExercise()` now return a `WritebackResult(written, failures)` where `failures` are **PII-safe categories** (`PERMISSION_DENIED` / `REMOTE_ERROR`) — never raw messages (the repo has a `PiiRedactionTest`; kept in that spirit). Coroutine `CancellationException` is rethrown, never mislabeled a failure.
- **Persisted, observable outcome.** The writer records the last outcome to `NoopPrefs`, so even the **background BLE-path** write (which never touches the ViewModel) is visible. `AppViewModel` exposes it as a `StateFlow` and re-reads it when Data Sources opens.
- **UI.** Under the writeback toggle, Data Sources now shows:
  - healthy → `Last shared <ago>` (calm/tertiary),
  - `PERMISSION_DENIED` → an accent line **"Sharing paused — permission was revoked. Tap to re-grant."** that relaunches the permission request,
  - transient → **"Last share didn't finish — will retry."**
- **Deliberately not auto-disabling** the user's opt-in on a transient error (the report floated that) — a blip would thrash their setting and lose intent; a re-grant affordance is the safer surface.
- **Drift guard.** `WritebackResult.statusCode` is pure and unit-tested, and pinned **equal to** the UI's `NoopPrefs.HC_WB_*` constants so the writer's persisted status and the Data Sources branches can't diverge.

## Scope / parity
Android-only — Health Connect has no iOS equivalent (iOS writes to HealthKit), so no parity twin. If we want symmetry later, the iOS HealthKit writeback path is worth a parallel look, but it's out of scope for this HC-specific issue. New status strings localized **de/es/fr/zh**.

One intentional nuance: on a workout save, `writeExercise` runs then the periodic `write()` follows, so the persisted status reflects the **last** attempt (vitals). The 15-min vitals write is the dominant, always-running signal; exercise-only permission loss post-enable is a narrow case already re-prompted at enable time.

## Verification
- `./gradlew compileFullDebugKotlin` ✓
- `./gradlew testFullDebugUnitTest --tests com.noop.ingest.WritebackResultTest --tests com.noop.ingest.HealthConnect*` ✓ (new test pins the `ok` flag, the permission-outranks-generic mapping, and the UI-constant contract)
- `python3 Tools/i18n_audit.py` ✓ (0 gaps, no new hardcoded literals)
- `./gradlew lintVitalFullRelease -PstagingRelease` ✓