### PR TITLE
Persist the WHOOP 5/MG raw-IMU offload buffer (#423)

### DIFF
--- a/Packages/WhoopProtocol/Sources/WhoopProtocol/Whoop5RawImu.swift
+++ b/Packages/WhoopProtocol/Sources/WhoopProtocol/Whoop5RawImu.swift
@@ -77,6 +77,29 @@ public enum Whoop5RawImu {
         return Whoop5ImuFrame(baseTs: baseTs, sampleRateHz: sampleCount, samples: samples)
     }
 
+    /// The raw i16 columns exactly as they sit on the wire — [ax×100, ay×100, az×100, gx×100, gy×100,
+    /// gz×100] — for faithful, compact storage (#423). Same length + sample-count gate and offsets as
+    /// `decode`; nil if `f` isn't a valid IMU buffer. Scales stay documented constants applied at read
+    /// time, so nothing lossy is baked into the stored bytes. Twin of Kotlin `Whoop5RawImu.rawColumns`.
+    public static func rawColumns(_ f: [UInt8]) -> [Int16]? {
+        guard f.count == bufferLength,
+              u16(f, countAOff) == sampleCount, u16(f, countBOff) == sampleCount,
+              gzOff + 2 * sampleCount <= f.count else { return nil }
+        let cols = [axOff, ayOff, azOff, gxOff, gyOff, gzOff]
+        var out = [Int16](repeating: 0, count: 6 * sampleCount)
+        for c in 0..<6 {
+            for i in 0..<sampleCount { out[c * sampleCount + i] = Int16(truncatingIfNeeded: i16(f, cols[c] + 2 * i)) }
+        }
+        return out
+    }
+
+    /// The strap unix-second stamp of this 1-second buffer (frame offset 15), or nil if too short. Public
+    /// so the capture seam can key a stored row without re-reading internal offsets (#423).
+    public static func baseTs(_ f: [UInt8]) -> Int? {
+        guard f.count > tsOff + 3 else { return nil }
+        return Int(u32(f, tsOff))
+    }
+
     // MARK: - Little-endian readers (frame-absolute)
     static func u16(_ f: [UInt8], _ o: Int) -> Int { Int(f[o]) | (Int(f[o + 1]) << 8) }
     static func u32(_ f: [UInt8], _ o: Int) -> UInt32 {

--- a/Packages/WhoopStore/Sources/WhoopStore/Database.swift
+++ b/Packages/WhoopStore/Sources/WhoopStore/Database.swift
@@ -552,6 +552,18 @@ extension WhoopStore {
                 t.primaryKey(["deviceId", "ts"])
             }
         }
+
+        // #423: WHOOP 5/MG raw-IMU offload capture (100 Hz 6-axis). `samples` is a packed i16 LE BLOB of
+        // the six wire columns (ax…az,gx…gz). Twin of the Android `rawImuSample` table (MIGRATION_20_21);
+        // same column order + PK so a `.noopbak` round-trips byte-for-byte.
+        migrator.registerMigration("v28-raw-imu") { db in
+            try db.create(table: "rawImuSample") { t in
+                t.column("deviceId", .text).notNull()
+                t.column("ts", .integer).notNull()
+                t.column("samples", .blob).notNull()
+                t.primaryKey(["deviceId", "ts"])
+            }
+        }
         return migrator
     }
 }

--- a/Packages/WhoopStore/Sources/WhoopStore/DeviceRegistryStore.swift
+++ b/Packages/WhoopStore/Sources/WhoopStore/DeviceRegistryStore.swift
@@ -95,6 +95,9 @@ public struct DeviceRegistryStore: Sendable {
         // "delete all of this device's data" leaves the raw waveform behind (the same privacy defect
         // this list exists to close).
         "ppgWaveformSample",
+        // v28-raw-imu (#423): the opt-in 5/MG raw-IMU offload capture is deviceId-keyed too — "delete all
+        // of this device's data" must clear it, or the raw inertial samples survive deletion (same defect).
+        "rawImuSample",
     ]
 
     /// Permanently delete every recorded sample/derived row belonging to one device, across all

--- a/Packages/WhoopStore/Sources/WhoopStore/StreamStore.swift
+++ b/Packages/WhoopStore/Sources/WhoopStore/StreamStore.swift
@@ -81,14 +81,16 @@ extension WhoopStore {
     /// then bound the table to the newest `retentionRows` for the device (rolling retention). Written from
     /// the deep-buffer capture seam, not the normal stream path, so it inserts directly (idempotent by ts).
     /// Twin of Kotlin `WhoopRepository.insertRawImu`.
-    public func insertRawImu(deviceId: String, rows: [(ts: Int, samples: Data)], retentionRows: Int) async throws {
+    public func insertRawImu(deviceId: String, rows: [(ts: Int, cols: [Int16])], retentionRows: Int) async throws {
         guard !rows.isEmpty else { return }
         try syncWrite { db in
             let ins = try db.cachedStatement(sql: """
                 INSERT INTO rawImuSample (deviceId, ts, samples) VALUES (?, ?, ?)
                 ON CONFLICT(deviceId, ts) DO NOTHING
                 """)
-            for r in rows { try ins.execute(arguments: [deviceId, r.ts, r.samples]) }
+            // Pack the raw i16 columns to the LE BLOB HERE (packImuColumns is module-internal), so the
+            // caller passes plain [Int16] and never needs the packer. Mirrors how `insert` packs ppgWaveform.
+            for r in rows { try ins.execute(arguments: [deviceId, r.ts, WhoopStore.packImuColumns(r.cols)]) }
             try db.execute(sql: """
                 DELETE FROM rawImuSample WHERE deviceId = ? AND ts < (
                     SELECT MIN(ts) FROM (SELECT ts FROM rawImuSample WHERE deviceId = ? ORDER BY ts DESC LIMIT ?))

--- a/Packages/WhoopStore/Sources/WhoopStore/StreamStore.swift
+++ b/Packages/WhoopStore/Sources/WhoopStore/StreamStore.swift
@@ -41,6 +41,27 @@ extension WhoopStore {
         return out
     }
 
+    /// #423: pack the raw-IMU i16 columns to a little-endian BLOB (same wire encoding as `packPpgSamples`,
+    /// an `[Int16]` source — the 6×100 columns ax…az,gx…gz). Byte-identical to Kotlin `packImuColumns`.
+    static func packImuColumns(_ cols: [Int16]) -> Data {
+        var buf = Data(capacity: cols.count * 2)
+        for v in cols { buf.append(UInt8(truncatingIfNeeded: v)); buf.append(UInt8(truncatingIfNeeded: v >> 8)) }
+        return buf
+    }
+
+    /// Inverse of `packImuColumns`; a trailing odd byte is dropped so a malformed row never crashes a read.
+    static func unpackImuColumns(_ data: Data) -> [Int16] {
+        let bytes = [UInt8](data)
+        var out = [Int16](); out.reserveCapacity(bytes.count / 2)
+        var i = 0
+        while i + 1 < bytes.count { out.append(Int16(bitPattern: UInt16(bytes[i]) | (UInt16(bytes[i + 1]) << 8))); i += 2 }
+        return out
+    }
+
+    /// #423 rolling retention for the raw-IMU capture table (twin of Kotlin `RAW_IMU_RETENTION_ROWS`):
+    /// ~1 h at 1 row/strap-second (~4 MB) hard-caps the table during a multi-day offload replay.
+    public static let rawImuRetentionRows = 3600
+
     /// Insert or update a device row (natural key = id).
     public func upsertDevice(id: String, mac: String?, name: String?) async throws {
         let now = Int(Date().timeIntervalSince1970)
@@ -53,6 +74,25 @@ extension WhoopStore {
                     name = excluded.name,
                     lastSeen = excluded.lastSeen
                 """, arguments: [id, mac, name, now, now])
+        }
+    }
+
+    /// #423: persist decoded 5/MG raw-IMU offload buffers (one row per strap-second, packed i16 BLOB),
+    /// then bound the table to the newest `retentionRows` for the device (rolling retention). Written from
+    /// the deep-buffer capture seam, not the normal stream path, so it inserts directly (idempotent by ts).
+    /// Twin of Kotlin `WhoopRepository.insertRawImu`.
+    public func insertRawImu(deviceId: String, rows: [(ts: Int, samples: Data)], retentionRows: Int) async throws {
+        guard !rows.isEmpty else { return }
+        try syncWrite { db in
+            let ins = try db.cachedStatement(sql: """
+                INSERT INTO rawImuSample (deviceId, ts, samples) VALUES (?, ?, ?)
+                ON CONFLICT(deviceId, ts) DO NOTHING
+                """)
+            for r in rows { try ins.execute(arguments: [deviceId, r.ts, r.samples]) }
+            try db.execute(sql: """
+                DELETE FROM rawImuSample WHERE deviceId = ? AND ts < (
+                    SELECT MIN(ts) FROM (SELECT ts FROM rawImuSample WHERE deviceId = ? ORDER BY ts DESC LIMIT ?))
+                """, arguments: [deviceId, deviceId, retentionRows])
         }
     }
 

--- a/Strand/BLE/BLEManager.swift
+++ b/Strand/BLE/BLEManager.swift
@@ -4071,6 +4071,9 @@ extension BLEManager: @preconcurrency CBPeripheralDelegate {
                     // reverse-engineering — its own file the bulk-capture eviction never churns.
                     // BEFORE the offload branch so it catches the burst; no-op unless capture is on.
                     puffinDeepBufferLog.appendIfDeepBuffer(frame: frame, char: characteristic.uuid, isOffload: isOffload)
+                    // #423: the queryable twin of that diagnostics line — persist the decoded 100 Hz 6-axis
+                    // IMU samples into the rawImuSample table when raw capture is on (same gate, gated inside).
+                    collector?.storeRawImu(frame: frame)
                     if isOffload {
                         // Same policy as WHOOP4: historical offload frames are bulk sync traffic.
                         // Keep them out of the live UI parser during backfill and let Backfiller

--- a/Strand/Collect/Collector.swift
+++ b/Strand/Collect/Collector.swift
@@ -12,6 +12,12 @@ protocol StoreWriting: AnyObject {
         -> (hr: Int, rr: Int, events: Int, battery: Int,
             spo2: Int, skinTemp: Int, resp: Int, gravity: Int)
     func enqueueRawBatch(_ meta: RawBatchMeta, frames: [[UInt8]]) async throws
+    func insertRawImu(deviceId: String, rows: [(ts: Int, samples: Data)], retentionRows: Int) async throws
+}
+extension StoreWriting {
+    /// #423: default no-op so a test SpyStore needn't implement the raw-IMU capture path. WhoopStore's
+    /// real impl (StreamStore.swift) satisfies the requirement and is used in production.
+    func insertRawImu(deviceId: String, rows: [(ts: Int, samples: Data)], retentionRows: Int) async throws {}
 }
 extension WhoopStore: StoreWriting {}
 
@@ -120,6 +126,22 @@ final class Collector {
     /// `ingest(frame:parsed:)` with the parse it already did.
     func ingest(_ frame: [UInt8]) {
         ingest(frame: frame, parsed: parseFrame(frame, family: family))
+    }
+
+    /// #423: persist the WHOOP 5/MG raw-IMU offload buffer NOOP already decodes for the deep-buffer log —
+    /// the queryable twin of that (table-less) diagnostics line. Same `noopPuffinCapture` gate; only the
+    /// 1244-B 6-axis buffer decodes (rawColumns nil otherwise). Fire-and-forget into the store, bounded by
+    /// a rolling retention prune. Raw i16, no downstream consumer yet. Twin of Android
+    /// `WhoopBleClient.storeWhoop5RawImuIfBuffer`.
+    func storeRawImu(frame: [UInt8]) {
+        guard UserDefaults.standard.bool(forKey: PuffinFrameRecorder.enabledKey) else { return }
+        guard let cols = Whoop5RawImu.rawColumns(frame), let baseTs = Whoop5RawImu.baseTs(frame) else { return }
+        let data = WhoopStore.packImuColumns(cols)
+        let dev = deviceId
+        Task { [store] in
+            try? await store.insertRawImu(
+                deviceId: dev, rows: [(ts: baseTs, samples: data)], retentionRows: WhoopStore.rawImuRetentionRows)
+        }
     }
 
     /// Buffer one complete frame + its pre-parsed decode (synchronous: preserves delegate arrival order).

--- a/Strand/Collect/Collector.swift
+++ b/Strand/Collect/Collector.swift
@@ -12,12 +12,12 @@ protocol StoreWriting: AnyObject {
         -> (hr: Int, rr: Int, events: Int, battery: Int,
             spo2: Int, skinTemp: Int, resp: Int, gravity: Int)
     func enqueueRawBatch(_ meta: RawBatchMeta, frames: [[UInt8]]) async throws
-    func insertRawImu(deviceId: String, rows: [(ts: Int, samples: Data)], retentionRows: Int) async throws
+    func insertRawImu(deviceId: String, rows: [(ts: Int, cols: [Int16])], retentionRows: Int) async throws
 }
 extension StoreWriting {
     /// #423: default no-op so a test SpyStore needn't implement the raw-IMU capture path. WhoopStore's
     /// real impl (StreamStore.swift) satisfies the requirement and is used in production.
-    func insertRawImu(deviceId: String, rows: [(ts: Int, samples: Data)], retentionRows: Int) async throws {}
+    func insertRawImu(deviceId: String, rows: [(ts: Int, cols: [Int16])], retentionRows: Int) async throws {}
 }
 extension WhoopStore: StoreWriting {}
 
@@ -136,11 +136,10 @@ final class Collector {
     func storeRawImu(frame: [UInt8]) {
         guard UserDefaults.standard.bool(forKey: PuffinFrameRecorder.enabledKey) else { return }
         guard let cols = Whoop5RawImu.rawColumns(frame), let baseTs = Whoop5RawImu.baseTs(frame) else { return }
-        let data = WhoopStore.packImuColumns(cols)
         let dev = deviceId
         Task { [store] in
             try? await store.insertRawImu(
-                deviceId: dev, rows: [(ts: baseTs, samples: data)], retentionRows: WhoopStore.rawImuRetentionRows)
+                deviceId: dev, rows: [(ts: baseTs, cols: cols)], retentionRows: WhoopStore.rawImuRetentionRows)
         }
     }
 

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -6248,11 +6248,23 @@ class WhoopBleClient(
         val cols = Whoop5RawImu.rawColumns(frame) ?: return
         val baseTs = PuffinDeepBufferLog.strapTs(frame)?.toLong() ?: return
         val dev = deviceId
+        // #423 debug heartbeat: confirm the offload IMU is arriving + decoding on-device without pulling the
+        // JSONL. Throttled (first buffer, then every 500) so a large offload can't flood the strap log; the
+        // count is a per-connection running total. Off unless raw capture is enabled (gated above).
+        rawImuDecodedCount++
+        if (rawImuDecodedCount == 1 || rawImuDecodedCount % 500 == 0) {
+            log("RAW IMU capture: $rawImuDecodedCount buffer(s) decoded, latest ts=$baseTs " +
+                "(${cols.size / 6} samples/axis) — storing (retain ${WhoopRepository.RAW_IMU_RETENTION_ROWS})")
+        }
         val row = RawImuSampleEntity(dev, baseTs, StreamPersistence.packImuColumns(cols))
         ioScope.launch {
             runCatching { repository.insertRawImu(dev, listOf(row)) }
+                .onFailure { log("RAW IMU capture: store failed (${it.message})") }
         }
     }
+
+    /** #423 debug: raw-IMU buffers decoded this connection (drives the throttled strap-log heartbeat). */
+    private var rawImuDecodedCount = 0
 
     private fun writeWhoop5DeepBufferIfBig(characteristic: String, frame: ByteArray, isOffload: Boolean) {
         if (deepBufferDisabled || !PuffinDeepBufferLog.isDeepBuffer(frame)) return

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -27,7 +27,9 @@ import android.util.Log
 import com.noop.data.HrRow
 import com.noop.data.RrRow
 import com.noop.data.StreamBatch
+import com.noop.data.RawImuSampleEntity
 import com.noop.data.StreamPersistence
+import com.noop.protocol.Whoop5RawImu
 import com.noop.data.WhoopRepository
 import com.noop.protocol.AlarmPayload
 import com.noop.protocol.BackfillCaptureJsonl
@@ -4081,6 +4083,9 @@ class WhoopBleClient(
                         // reverse-engineering — its own file the bulk-capture eviction never churns.
                         // BEFORE the offload branch so it catches the burst; no-op unless capture is on.
                         writeWhoop5DeepBufferIfBig(uuid.toString(), frame, isOffloadFrame(frame, connectedFamily))
+                        // #423: the queryable twin of that diagnostics line — persist the decoded IMU
+                        // samples (100 Hz 6-axis) into the rawImuSample table when raw capture is on.
+                        storeWhoop5RawImuIfBuffer(frame)
                     }
                     if (backfilling) {
                         // Opt-in raw capture: record EVERY frame of the session (offload AND live
@@ -6234,6 +6239,21 @@ class WhoopBleClient(
      * one previous generation. Cheap for every other frame: a length + single-byte compare BEFORE the
      * pref read; no-op unless the capture toggle is on.
      */
+    /** #423: persist the WHOOP 5/MG raw-IMU offload buffer NOOP already decodes for the deep-buffer log —
+     *  the queryable twin of that (table-less) diagnostics line. Same `isCaptureEnabled` gate; only the
+     *  1244-B 6-axis buffer decodes (rawColumns null otherwise). IO-dispatched so it never blocks the GATT
+     *  thread; bounded by a rolling retention prune. Raw i16, no downstream consumer yet (instrument-first). */
+    private fun storeWhoop5RawImuIfBuffer(frame: ByteArray) {
+        if (!PuffinExperiment.from(context).isCaptureEnabled) return
+        val cols = Whoop5RawImu.rawColumns(frame) ?: return
+        val baseTs = PuffinDeepBufferLog.strapTs(frame)?.toLong() ?: return
+        val dev = deviceId
+        val row = RawImuSampleEntity(dev, baseTs, StreamPersistence.packImuColumns(cols))
+        ioScope.launch {
+            runCatching { repository.insertRawImu(dev, listOf(row)) }
+        }
+    }
+
     private fun writeWhoop5DeepBufferIfBig(characteristic: String, frame: ByteArray, isOffload: Boolean) {
         if (deepBufferDisabled || !PuffinDeepBufferLog.isDeepBuffer(frame)) return
         if (!PuffinExperiment.from(context).isCaptureEnabled) return

--- a/android/app/src/main/java/com/noop/data/DeviceRegistry.kt
+++ b/android/app/src/main/java/com/noop/data/DeviceRegistry.kt
@@ -96,6 +96,7 @@ class DeviceRegistry(
             dao.deleteStepsFor(id)
             dao.deletePpgHrFor(id)
             dao.deletePpgWaveformFor(id)
+            dao.deleteRawImuFor(id)   // #423
             dao.deleteEventsFor(id)
             dao.deleteBatteryFor(id)
             dao.deleteDailyMetricsFor(id)

--- a/android/app/src/main/java/com/noop/data/DeviceRegistryDao.kt
+++ b/android/app/src/main/java/com/noop/data/DeviceRegistryDao.kt
@@ -71,6 +71,7 @@ interface DeviceRegistryDao {
     @Query("DELETE FROM stepSample WHERE deviceId = :deviceId") suspend fun deleteStepsFor(deviceId: String)
     @Query("DELETE FROM ppgHrSample WHERE deviceId = :deviceId") suspend fun deletePpgHrFor(deviceId: String)
     @Query("DELETE FROM ppgWaveformSample WHERE deviceId = :deviceId") suspend fun deletePpgWaveformFor(deviceId: String)
+    @Query("DELETE FROM rawImuSample WHERE deviceId = :deviceId") suspend fun deleteRawImuFor(deviceId: String)   // #423
     @Query("DELETE FROM event WHERE deviceId = :deviceId") suspend fun deleteEventsFor(deviceId: String)
     @Query("DELETE FROM battery WHERE deviceId = :deviceId") suspend fun deleteBatteryFor(deviceId: String)
     @Query("DELETE FROM dailyMetric WHERE deviceId = :deviceId") suspend fun deleteDailyMetricsFor(deviceId: String)

--- a/android/app/src/main/java/com/noop/data/Entities.kt
+++ b/android/app/src/main/java/com/noop/data/Entities.kt
@@ -516,6 +516,36 @@ data class PpgWaveformSampleEntity(
 }
 
 /**
+ * One 1-second WHOOP 5/MG raw-IMU offload buffer (#423): 100 Hz 6-axis inertial data. [samples] is a
+ * packed little-endian i16 BLOB of the six columns in wire order — ax×100, ay×100, az×100, gx×100, gy×100,
+ * gz×100 (1200 bytes) — decoded by [com.noop.protocol.Whoop5RawImu] (scales 1/4096 g/LSB, 2000/32768 dps/
+ * LSB). The strap already delivers this in the connect-time offload burst; capturing it needs NO arming.
+ * Instrument-first + bounded: written only when raw capture is enabled, and pruned to a rolling recent
+ * window ([WhoopRepository.RAW_IMU_RETENTION_ROWS]). Twin of the GRDB `rawImuSample` table. Natural key
+ * (deviceId, ts) = one row per strap-second.
+ */
+@Entity(tableName = "rawImuSample", primaryKeys = ["deviceId", "ts"])
+data class RawImuSampleEntity(
+    val deviceId: String,
+    val ts: Long,
+    val samples: ByteArray,
+) {
+    // ByteArray needs structural equals/hashCode (the generated identity ones break round-trip asserts).
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is RawImuSampleEntity) return false
+        return deviceId == other.deviceId && ts == other.ts && samples.contentEquals(other.samples)
+    }
+
+    override fun hashCode(): Int {
+        var result = deviceId.hashCode()
+        result = 31 * result + ts.hashCode()
+        result = 31 * result + samples.contentHashCode()
+        return result
+    }
+}
+
+/**
  * One Live Session (silent guardian) record (v22 / MIGRATION_15_16). Natural key (deviceId, startTs).
  * `endTs` is null while the session is still in progress. Fields are declared in the SAME order as the
  * Swift WhoopStore `liveSession` schema so the migration SQL matches Room's generated shape. Twin of the

--- a/android/app/src/main/java/com/noop/data/StreamPersistence.kt
+++ b/android/app/src/main/java/com/noop/data/StreamPersistence.kt
@@ -70,6 +70,28 @@ object StreamPersistence {
         return out
     }
 
+    /** #423: pack the raw-IMU i16 columns to a little-endian BLOB (same wire encoding as [packPpgSamples],
+     *  just a [ShortArray] source — the 6×100 columns [ax…az,gx…gz]). Byte-identical to Swift's pack. */
+    fun packImuColumns(cols: ShortArray): ByteArray {
+        val buf = ByteArray(cols.size * 2)
+        for (i in cols.indices) {
+            val v = cols[i].toInt()
+            buf[i * 2] = (v and 0xFF).toByte()
+            buf[i * 2 + 1] = ((v shr 8) and 0xFF).toByte()
+        }
+        return buf
+    }
+
+    /** Inverse of [packImuColumns]; a trailing odd byte is dropped so a malformed row never crashes a read. */
+    fun unpackImuColumns(data: ByteArray): ShortArray {
+        val n = data.size / 2
+        val out = ShortArray(n)
+        for (i in 0 until n) {
+            out[i] = ((data[i * 2].toInt() and 0xFF) or ((data[i * 2 + 1].toInt() and 0xFF) shl 8)).toShort()
+        }
+        return out
+    }
+
     /**
      * Deterministic sorted-keys JSON for an event payload. Port of `WhoopStore.encodePayload`.
      *

--- a/android/app/src/main/java/com/noop/data/WhoopDao.kt
+++ b/android/app/src/main/java/com/noop/data/WhoopDao.kt
@@ -87,6 +87,24 @@ interface WhoopDao : DeviceRegistryDao {
     @Insert(onConflict = OnConflictStrategy.IGNORE)
     suspend fun insertPpgWaveform(rows: List<PpgWaveformSampleEntity>): List<Long>
 
+    /** RAW 5/MG IMU offload buffers (packed i16 BLOB). Idempotent by (deviceId, ts). (#423) */
+    @Insert(onConflict = OnConflictStrategy.IGNORE)
+    suspend fun insertRawImu(rows: List<RawImuSampleEntity>): List<Long>
+
+    /** Bound the raw-IMU table to the newest [keep] rows for [deviceId] (rolling retention, #423). */
+    @Query(
+        "DELETE FROM rawImuSample WHERE deviceId = :deviceId AND ts < " +
+            "(SELECT MIN(ts) FROM (SELECT ts FROM rawImuSample WHERE deviceId = :deviceId ORDER BY ts DESC LIMIT :keep))"
+    )
+    suspend fun pruneRawImu(deviceId: String, keep: Int)
+
+    /** RAW 5/MG IMU buffers in [from, to] (ascending), packed i16 BLOB. (#423) */
+    @Query(
+        "SELECT * FROM rawImuSample WHERE deviceId = :deviceId AND ts >= :from AND ts <= :to " +
+            "ORDER BY ts ASC LIMIT :limit"
+    )
+    suspend fun rawImuSamples(deviceId: String, from: Long, to: Long, limit: Int): List<RawImuSampleEntity>
+
     // MARK: - Server-derived caches (latest value wins)
 
     @Upsert

--- a/android/app/src/main/java/com/noop/data/WhoopDatabase.kt
+++ b/android/app/src/main/java/com/noop/data/WhoopDatabase.kt
@@ -48,8 +48,9 @@ import androidx.sqlite.db.SupportSQLiteDatabase
         LabMarkerRow::class,
         LiveSessionRow::class,
         PpgWaveformSampleEntity::class,
+        RawImuSampleEntity::class,
     ],
-    version = 20,
+    version = 21,
     exportSchema = false,
 )
 abstract class WhoopDatabase : RoomDatabase() {
@@ -553,6 +554,20 @@ abstract class WhoopDatabase : RoomDatabase() {
             }
         }
 
+        /** #423: the WHOOP 5/MG raw-IMU offload-capture table. Additive; GRDB twin is `v28-raw-imu`
+         *  (Swift's next slot after v27-ppg-waveform), so the migration COUNTS stay aligned. Column order ==
+         *  [RawImuSampleEntity] field order, matching the GRDB schema's t.column(deviceId/ts/samples). */
+        internal val RAW_IMU_MIGRATION_SQL: List<String> = listOf(
+            "CREATE TABLE IF NOT EXISTS `rawImuSample` (`deviceId` TEXT NOT NULL, " +
+                "`ts` INTEGER NOT NULL, `samples` BLOB NOT NULL, PRIMARY KEY(`deviceId`, `ts`))",
+        )
+
+        internal val MIGRATION_20_21 = object : Migration(20, 21) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                for (stmt in RAW_IMU_MIGRATION_SQL) db.execSQL(stmt)
+            }
+        }
+
         private fun build(appContext: Context): WhoopDatabase =
             Room.databaseBuilder(appContext, WhoopDatabase::class.java, DB_NAME)
                 // #1014: replace ONLY the corruption handling of the default open-helper. The
@@ -568,7 +583,7 @@ abstract class WhoopDatabase : RoomDatabase() {
                     MIGRATION_5_6, MIGRATION_6_7, MIGRATION_7_8, MIGRATION_8_9, MIGRATION_9_10,
                     MIGRATION_10_11, MIGRATION_11_12, MIGRATION_12_13, MIGRATION_13_14,
                     MIGRATION_14_15, MIGRATION_15_16, MIGRATION_16_17, MIGRATION_17_18,
-                    MIGRATION_18_19, MIGRATION_19_20,
+                    MIGRATION_18_19, MIGRATION_19_20, MIGRATION_20_21,
                 )
                 // #1037: a FRESH install builds the schema straight at the current version and runs NO
                 // migrations, so the MIGRATION_7_8 "my-whoop" registry seed never fires and the WHOOP,

--- a/android/app/src/main/java/com/noop/data/WhoopRepository.kt
+++ b/android/app/src/main/java/com/noop/data/WhoopRepository.kt
@@ -590,6 +590,21 @@ class WhoopRepository(private val dao: WhoopDao) {
         dao.ppgWaveformSamples(deviceId, from, to, limit)
             .map { PpgWaveformRow(it.ts, StreamPersistence.unpackPpgSamples(it.samples)) }
 
+    /** #423: persist a batch of decoded 5/MG raw-IMU offload buffers (one row per strap-second, packed i16
+     *  BLOB), then bound the table to the newest [RAW_IMU_RETENTION_ROWS] for the device. Comes from the
+     *  deep-buffer capture seam, not the normal stream path, so it inserts directly (idempotent by ts). */
+    suspend fun insertRawImu(deviceId: String, rows: List<RawImuSampleEntity>) {
+        if (rows.isEmpty()) return
+        dao.insertRawImu(rows)
+        dao.pruneRawImu(deviceId, RAW_IMU_RETENTION_ROWS)
+    }
+
+    /** #423: raw 5/MG IMU buffers in [from, to] as the decoded i16 columns [ax…az,gx…gz] (100/axis). */
+    suspend fun rawImuSamples(deviceId: String, from: Long, to: Long, limit: Int = DEFAULT_LIMIT):
+        List<Pair<Long, ShortArray>> =
+        dao.rawImuSamples(deviceId, from, to, limit)
+            .map { it.ts to StreamPersistence.unpackImuColumns(it.samples) }
+
     /** Downsampled HR (mean bpm per [bucketSeconds]) for the strap, for the Today 24h trend chart. */
     suspend fun hrBuckets(deviceId: String, from: Long, to: Long, bucketSeconds: Long = 300L) =
         dao.hrBuckets(deviceId, from, to, bucketSeconds)
@@ -1444,6 +1459,11 @@ class WhoopRepository(private val dao: WhoopDao) {
 
         /** Default row cap on range reads. Matches the Swift call sites' bounded scans. */
         const val DEFAULT_LIMIT = 100_000
+
+        /** #423: rolling retention for the raw-IMU capture table (1 row/strap-second, ~1.2 KB each). One
+         *  hour ≈ 3600 rows ≈ 4 MB caps the table hard, so an enabled capture can never balloon the DB
+         *  during a multi-day offload replay. Instrument-first bounded window; nothing consumes it yet. */
+        const val RAW_IMU_RETENTION_ROWS = 3600
 
         /** #797: dashboard merge window cap (days). The bounded [recentDaysMergedFlow] keeps at most this
          *  many most-recent days per source, so a years-deep import stops re-merging the whole history on

--- a/android/app/src/main/java/com/noop/protocol/Whoop5RawImu.kt
+++ b/android/app/src/main/java/com/noop/protocol/Whoop5RawImu.kt
@@ -82,6 +82,22 @@ object Whoop5RawImu {
         return Whoop5ImuFrame(baseTs = baseTs, sampleRateHz = sampleCount, samples = samples)
     }
 
+    /** The raw i16 columns exactly as they sit on the wire — [ax×100, ay×100, az×100, gx×100, gy×100,
+     *  gz×100] — for faithful, compact storage (#423). Same length + sample-count gate and same offsets as
+     *  [decode]; null if [f] isn't a valid IMU buffer. The scales ([accelScale]/[gyroScale]) stay documented
+     *  constants applied at read time, so nothing lossy is baked into the stored bytes. */
+    fun rawColumns(f: ByteArray): ShortArray? {
+        if (f.size != bufferLength) return null
+        if (u16(f, countAOff) != sampleCount || u16(f, countBOff) != sampleCount) return null
+        if (gzOff + 2 * sampleCount > f.size) return null
+        val cols = intArrayOf(axOff, ayOff, azOff, gxOff, gyOff, gzOff)
+        val out = ShortArray(6 * sampleCount)
+        for (c in 0 until 6) {
+            for (i in 0 until sampleCount) out[c * sampleCount + i] = i16(f, cols[c] + 2 * i).toShort()
+        }
+        return out
+    }
+
     // Little-endian readers (frame-absolute).
     private fun u16(f: ByteArray, o: Int): Int =
         (f[o].toInt() and 0xFF) or ((f[o + 1].toInt() and 0xFF) shl 8)

--- a/android/app/src/test/java/com/noop/analytics/RegistryDayOwnerSourceTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/RegistryDayOwnerSourceTest.kt
@@ -57,6 +57,7 @@ class RegistryDayOwnerSourceTest {
         override suspend fun deleteStepsFor(deviceId: String) {}
         override suspend fun deletePpgHrFor(deviceId: String) {}
         override suspend fun deletePpgWaveformFor(deviceId: String) {}
+        override suspend fun deleteRawImuFor(deviceId: String) {}
         override suspend fun deleteEventsFor(deviceId: String) {}
         override suspend fun deleteBatteryFor(deviceId: String) {}
         override suspend fun deleteDailyMetricsFor(deviceId: String) {}

--- a/android/app/src/test/java/com/noop/ble/SourceCoordinatorAdoptionTest.kt
+++ b/android/app/src/test/java/com/noop/ble/SourceCoordinatorAdoptionTest.kt
@@ -71,6 +71,7 @@ class SourceCoordinatorAdoptionTest {
         override suspend fun deleteStepsFor(deviceId: String) {}
         override suspend fun deletePpgHrFor(deviceId: String) {}
         override suspend fun deletePpgWaveformFor(deviceId: String) {}
+        override suspend fun deleteRawImuFor(deviceId: String) {}
         override suspend fun deleteEventsFor(deviceId: String) {}
         override suspend fun deleteBatteryFor(deviceId: String) {}
         override suspend fun deleteDailyMetricsFor(deviceId: String) {}

--- a/android/app/src/test/java/com/noop/data/DeviceRegistryTest.kt
+++ b/android/app/src/test/java/com/noop/data/DeviceRegistryTest.kt
@@ -85,6 +85,7 @@ class DeviceRegistryTest {
         override suspend fun deleteStepsFor(deviceId: String) { deletedTables += "stepSample" to deviceId }
         override suspend fun deletePpgHrFor(deviceId: String) { deletedTables += "ppgHrSample" to deviceId }
         override suspend fun deletePpgWaveformFor(deviceId: String) { deletedTables += "ppgWaveformSample" to deviceId }
+        override suspend fun deleteRawImuFor(deviceId: String) { deletedTables += "rawImuSample" to deviceId }
         override suspend fun deleteEventsFor(deviceId: String) { deletedTables += "event" to deviceId }
         override suspend fun deleteBatteryFor(deviceId: String) { deletedTables += "battery" to deviceId }
         override suspend fun deleteDailyMetricsFor(deviceId: String) { deletedTables += "dailyMetric" to deviceId }
@@ -234,7 +235,7 @@ class DeviceRegistryTest {
         // were missing, leaving raw sleep-state, lab markers, live sessions and dismissed markers behind.
         val expectedTables = setOf(
             "hrSample", "rrInterval", "spo2Sample", "skinTempSample", "respSample", "gravitySample",
-            "stepSample", "ppgHrSample", "ppgWaveformSample", "event", "battery", "dailyMetric", "sleepSession",
+            "stepSample", "ppgHrSample", "ppgWaveformSample", "rawImuSample", "event", "battery", "dailyMetric", "sleepSession",
             "journal", "workout", "appleDaily", "metricSeries", "dayOwnership",
             "sleepStateSample", "labMarker", "liveSession", "dismissedWorkout", "dismissedSleep",
         )

--- a/android/app/src/test/java/com/noop/data/RawImuMigrationTest.kt
+++ b/android/app/src/test/java/com/noop/data/RawImuMigrationTest.kt
@@ -1,0 +1,153 @@
+package com.noop.data
+
+import com.noop.protocol.Whoop5RawImu
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.lang.reflect.Proxy
+
+/**
+ * Guards the additive v20 -> v21 Room migration (the `rawImuSample` table, #423), the Android twin of the
+ * Swift WhoopStore `v28-raw-imu` GRDB migration, plus the packed-BLOB encoding that must be byte-identical
+ * to Swift's IMU pack for a `.noopbak` to round-trip, and the decoder's `rawColumns` extraction.
+ *
+ * No Robolectric Room here, so the migration SQL is pinned via [WhoopDatabase.RAW_IMU_MIGRATION_SQL] to
+ * Room's generated shape; the store-write plumbing (insert + rolling prune) is exercised through a Proxy
+ * [WhoopDao] (no DB).
+ */
+class RawImuMigrationTest {
+
+    // MARK: - Migration schema
+
+    @Test
+    fun migration_isAdditive_onlyCreateTable() {
+        val sql = WhoopDatabase.RAW_IMU_MIGRATION_SQL
+        assertEquals("one CREATE TABLE statement", 1, sql.size)
+        for (s in sql) {
+            val up = s.trimStart().uppercase()
+            assertTrue("only CREATE TABLE allowed, got: $s", up.startsWith("CREATE TABLE"))
+            for (banned in listOf("DROP ", "DELETE ", "UPDATE ", "INSERT ", "ALTER ")) {
+                assertTrue("additive migration must not contain '$banned': $s", !up.contains(banned))
+            }
+        }
+    }
+
+    @Test
+    fun migration_createsExactTable() {
+        // deviceId TEXT, ts INTEGER, samples BLOB — column order == entity field order, matching the GRDB
+        // t.column(deviceId/ts/samples) order and PRIMARY KEY(deviceId, ts).
+        assertEquals(
+            listOf(
+                "CREATE TABLE IF NOT EXISTS `rawImuSample` (`deviceId` TEXT NOT NULL, " +
+                    "`ts` INTEGER NOT NULL, `samples` BLOB NOT NULL, PRIMARY KEY(`deviceId`, `ts`))",
+            ),
+            WhoopDatabase.RAW_IMU_MIGRATION_SQL,
+        )
+    }
+
+    @Test
+    fun migration_versionPair_is20to21() {
+        assertEquals(20, WhoopDatabase.MIGRATION_20_21.startVersion)
+        assertEquals(21, WhoopDatabase.MIGRATION_20_21.endVersion)
+    }
+
+    // MARK: - Packed-BLOB encoding (byte-identical i16 LE)
+
+    @Test
+    fun packUnpackRoundTrips() {
+        val cols = shortArrayOf(0, 1, -1, 32767, -32768, -1432, 12345)
+        val packed = StreamPersistence.packImuColumns(cols)
+        assertEquals("2 bytes/sample", cols.size * 2, packed.size)
+        assertArrayEquals(cols, StreamPersistence.unpackImuColumns(packed))
+    }
+
+    @Test
+    fun packIsLittleEndianI16() {
+        // -1432 == 0xFA68: low byte 0x68 first, high byte 0xFA second (matches the GRDB blob bytes).
+        val packed = StreamPersistence.packImuColumns(shortArrayOf(-1432))
+        assertArrayEquals(byteArrayOf(0x68.toByte(), 0xFA.toByte()), packed)
+    }
+
+    @Test
+    fun unpackDropsTrailingOddByte() {
+        val data = StreamPersistence.packImuColumns(shortArrayOf(1, 2, 3)) + byteArrayOf(0xFF.toByte())
+        assertArrayEquals(shortArrayOf(1, 2, 3), StreamPersistence.unpackImuColumns(data))
+    }
+
+    // MARK: - Decoder rawColumns extraction
+
+    @Test
+    fun rawColumns_extractsColumnarWireOrder() {
+        val f = validImuBuffer()
+        // Put a distinct marker at sample 0 of each of the six columns (ax,ay,az,gx,gy,gz).
+        val colOff = intArrayOf(28, 228, 428, 640, 840, 1040)
+        val markers = shortArrayOf(11, -22, 33, -44, 55, -66)
+        for (c in colOff.indices) putI16(f, colOff[c], markers[c])
+        val cols = Whoop5RawImu.rawColumns(f) ?: error("rawColumns returned null for a valid buffer")
+        assertEquals(6 * 100, cols.size)
+        // Column c occupies [c*100, (c+1)*100); its sample-0 sits at c*100.
+        for (c in markers.indices) assertEquals("column $c sample 0", markers[c], cols[c * 100])
+    }
+
+    @Test
+    fun rawColumns_nullOnWrongLengthOrCount() {
+        assertNull("wrong length", Whoop5RawImu.rawColumns(ByteArray(1243)))
+        val f = validImuBuffer()
+        putI16(f, 24, 99)                            // countA != 100
+        assertNull("wrong sample count", Whoop5RawImu.rawColumns(f))
+    }
+
+    // MARK: - Store-write plumbing (repository inserts + rolling prune through the DAO)
+
+    @Test
+    fun repositoryInsertRawImu_insertsThenPrunes() = runBlocking {
+        var inserted: List<RawImuSampleEntity>? = null
+        var prunedDevice: String? = null
+        var prunedKeep = -1
+        val dao = Proxy.newProxyInstance(
+            WhoopDao::class.java.classLoader,
+            arrayOf(WhoopDao::class.java),
+        ) { _, method, args ->
+            when (method.name) {
+                "insertRawImu" -> {
+                    @Suppress("UNCHECKED_CAST")
+                    inserted = args[0] as List<RawImuSampleEntity>
+                    listOf(1L)
+                }
+                "pruneRawImu" -> { prunedDevice = args[0] as String; prunedKeep = args[1] as Int; Unit }
+                else -> throw UnsupportedOperationException("raw-imu insert must not call ${method.name}")
+            }
+        } as WhoopDao
+
+        val row = RawImuSampleEntity("my-whoop", 1_780_917_232L, StreamPersistence.packImuColumns(shortArrayOf(1, -1, 100)))
+        WhoopRepository(dao).insertRawImu("my-whoop", listOf(row))
+
+        assertEquals(listOf(row), inserted)
+        assertEquals("my-whoop", prunedDevice)
+        assertEquals(WhoopRepository.RAW_IMU_RETENTION_ROWS, prunedKeep)
+    }
+
+    @Test
+    fun repositoryInsertRawImu_emptyIsNoOp() = runBlocking {
+        val dao = Proxy.newProxyInstance(
+            WhoopDao::class.java.classLoader,
+            arrayOf(WhoopDao::class.java),
+        ) { _, method, _ -> throw AssertionError("empty insert must not touch the DAO (${method.name})") } as WhoopDao
+        WhoopRepository(dao).insertRawImu("my-whoop", emptyList())
+    }
+
+    private fun validImuBuffer(): ByteArray {
+        val f = ByteArray(Whoop5RawImu.bufferLength)
+        putI16(f, 24, 100)   // countA
+        putI16(f, 630, 100)  // countB
+        return f
+    }
+
+    private fun putI16(f: ByteArray, off: Int, v: Short) {
+        f[off] = (v.toInt() and 0xFF).toByte()
+        f[off + 1] = ((v.toInt() shr 8) and 0xFF).toByte()
+    }
+}


### PR DESCRIPTION
Refs #423. Draft — minimal, receive-side, no arming.

## The finding that reframes #423
#423 is scoped around the **live** raw-accel stream (arm `cmd 81`, which the 5/MG allowlist drops; the full IMU stream is firmware-refused). But `Whoop5RawImu`'s own header — *validated on 1423 real 5.0 buffers* — establishes that the **connect-time offload burst already carries a full 100 Hz 6-axis IMU** (accel + gyro, 1244-B buffer). NOOP already receives and decodes it (`PuffinDeepBufferLog` runs `Whoop5RawImu.decode`), and just logs a summary — **no arming needed, nothing persisted.** This PR adds the missing persistence, which delivers #423's core goal (6-axis IMU on a 5.0) without touching the BLE-send path at all.

## What this does
- **`rawImuSample` table** — one row per strap-second, a packed i16 LE BLOB of the six wire columns (`ax…az,gx…gz`). Room `MIGRATION_20_21` + GRDB `v28-raw-imu`, byte-identical shape + encoding so a `.noopbak` round-trips. `Whoop5RawImu.rawColumns()` keeps the offsets in one place on both platforms.
- **Gated + receive-side** — persists at the same deep-buffer seam that already decodes, behind the existing raw-capture toggle (`noopPuffinCapture`), dispatched off the BLE thread. **No BLE command is sent anywhere in this diff.**
- **Bounded** — rolling retention to the newest ~1 h (3600 rows ≈ 4 MB), so an enabled capture can't balloon the DB during a multi-day offload replay.
- **Instrument-first** — decode → store → *nothing consumes it yet* (no steps/sleep gating), per the derived-signal rule.

## What's deliberately out of scope (stays #423's strap-side work)
- **Arming** (`cmd 81` / un-silencing the 4.0 flood) — the hard-rules BLE write that needs your real 5/MG to validate. This PR makes NOOP *capture* the offload IMU it already receives; it does not turn any stream on.
- **WHOOP 4.0 type-43 live raw** — Swift means it, Android doesn't decode it; a separate change (needs un-silencing).

## Verification
- **Android:** `compileFullDebugKotlin` ✓ · `RawImuMigrationTest` ✓ (additive-SQL pin, 20→21 version pair, i16 pack round-trip, `rawColumns` columnar extraction + null gates, repository insert+prune) · `com.noop.data.*` package ✓
- **iOS:** app-target Swift (no Linux/CI build). The data layer mirrors `ppgWaveformSample` exactly (GRDB migration, `StreamStore` pack/insert, protocol default-no-op so test spies don't break); compile-verified on the app-build run attached to this PR. Runtime capture needs a real 5/MG (your #423 strap).

## Note for #423
Since the offload path already delivers 6-axis IMU arming-free, the live-stream probe may be **unnecessary** for the core goal — worth folding into the issue.