### PR TITLE
Oura: capture Tier-B activity MET stream to a JSONL research corpus (Swift + Android)

### DIFF
--- a/Packages/WhoopStore/Sources/WhoopStore/OuraActivityDumpLine.swift
+++ b/Packages/WhoopStore/Sources/WhoopStore/OuraActivityDumpLine.swift
@@ -1,0 +1,37 @@
+import Foundation
+
+/// Pure, deterministic encoder for ONE line of the Oura activity (0x50 MET) research corpus — a
+/// diagnostic JSONL sidecar, NOT a datastore row.
+///
+/// WHY a sidecar and not a stream/table: the 0x50 activity/MET decode is Tier-B (a plausible third-party
+/// formula, not ground-truth-validated — OURA_PROTOCOL.md s6.13). The honest-data invariant + the #960
+/// pin forbid Tier-B ever minting a durable scoring row, so it must never touch `Streams`/SQLite. This
+/// corpus is a separate, clearly-labeled file the app appends to purely so the raw MET series can be
+/// accumulated for offline investigation (cadence, state-byte semantics, WHOOP cross-checks). It never
+/// feeds scoring and is safe to delete.
+///
+/// FORMAT: newline-delimited JSON (JSONL) — one record per line, append-only. Chosen over a single JSON
+/// array because appends never rewrite the file, a torn write loses only the last line, and every line
+/// loads directly into pandas/`jq`/DuckDB. The line is hand-built in a FIXED key order so it is stable and
+/// testable byte-for-byte; `met` uses Swift's shortest round-trip `Double` description (lossless, compact).
+public enum OuraActivityDumpLine {
+    /// Bump when the record shape changes so a downstream reader can branch on `schema`.
+    public static let schema = 1
+
+    /// One JSONL record (NO trailing newline — the writer adds it). `deviceId` is a controlled registry id
+    /// (e.g. `oura-<uuid>`) and `iso` is app-generated, so neither needs JSON string-escaping here.
+    ///   - ringTs:       the record's raw ring-clock timestamp (the dedup key: strictly increases per record).
+    ///   - utc:          the anchored wall-clock (unix seconds) for the record envelope.
+    ///   - iso:          human-readable UTC of `utc` (convenience for eyeballing).
+    ///   - state:        the raw 0x50 state byte (semantics unconfirmed — captured verbatim for study).
+    ///   - secPerSample: the ASSUMED per-sample cadence (60 s); downstream can recompute real spacing from
+    ///                   consecutive `utc` deltas.
+    ///   - met:          the decoded per-sample MET series (Tier-B formula output, verbatim).
+    public static func encode(deviceId: String, ringTs: UInt32, utc: Int, iso: String,
+                              state: Int, secPerSample: Int, met: [Double]) -> String {
+        let metStr = met.map { String($0) }.joined(separator: ",")
+        return "{\"schema\":\(schema),\"deviceId\":\"\(deviceId)\",\"ringTs\":\(ringTs),"
+             + "\"utc\":\(utc),\"iso\":\"\(iso)\",\"state\":\(state),"
+             + "\"secPerSample\":\(secPerSample),\"met\":[\(metStr)]}"
+    }
+}

--- a/Packages/WhoopStore/Tests/WhoopStoreTests/OuraActivityDumpLineTests.swift
+++ b/Packages/WhoopStore/Tests/WhoopStoreTests/OuraActivityDumpLineTests.swift
@@ -1,0 +1,34 @@
+import XCTest
+@testable import WhoopStore
+
+/// The Tier-B activity research-corpus JSONL line encoder. The line is asserted verbatim so the format is
+/// pinned (any downstream reader can rely on the exact shape + key order).
+final class OuraActivityDumpLineTests: XCTestCase {
+
+    func testEncodesFixedShapeVerbatim() {
+        let line = OuraActivityDumpLine.encode(
+            deviceId: "oura-5C4C0BF8", ringTs: 5_691_839, utc: 1_783_400_728,
+            iso: "2026-07-14T09:05:28Z", state: 23, secPerSample: 60,
+            met: [2.2, 1.5, 1.4])
+        XCTAssertEqual(line,
+            "{\"schema\":1,\"deviceId\":\"oura-5C4C0BF8\",\"ringTs\":5691839," +
+            "\"utc\":1783400728,\"iso\":\"2026-07-14T09:05:28Z\",\"state\":23," +
+            "\"secPerSample\":60,\"met\":[2.2,1.5,1.4]}")
+    }
+
+    func testEmptyMetIsEmptyArray() {
+        let line = OuraActivityDumpLine.encode(
+            deviceId: "d", ringTs: 1, utc: 2, iso: "x", state: 0, secPerSample: 60, met: [])
+        XCTAssertTrue(line.hasSuffix("\"met\":[]}"))
+    }
+
+    func testEachLineIsValidJSON() throws {
+        let line = OuraActivityDumpLine.encode(
+            deviceId: "oura-ring", ringTs: 100, utc: 200, iso: "2026-07-14T00:00:00Z",
+            state: 148, secPerSample: 60, met: [3.0, 4.3, 12.8])
+        let obj = try JSONSerialization.jsonObject(with: Data(line.utf8)) as? [String: Any]
+        XCTAssertEqual(obj?["state"] as? Int, 148)
+        XCTAssertEqual((obj?["met"] as? [Double])?.count, 3)
+        XCTAssertEqual(obj?["schema"] as? Int, OuraActivityDumpLine.schema)
+    }
+}

--- a/Strand/BLE/OuraActivityDump.swift
+++ b/Strand/BLE/OuraActivityDump.swift
@@ -1,0 +1,92 @@
+import Foundation
+import WhoopStore
+
+/// Append-only JSONL sidecar for the Oura 0x50 activity/MET stream — a Tier-B RESEARCH corpus, never a
+/// datastore row (see `OuraActivityDumpLine` for the honest-data rationale). Owns the file handle, the
+/// on-disk path, the once-per-launch "here is the file" log line, and a persistent ring-time high-water so
+/// the records the ring re-serves across reconnects (observed heavily under connection churn) are written
+/// exactly once instead of duplicating the corpus.
+///
+/// Location: `<Application Support>/OpenWhoop/Diagnostics/oura-activity-<deviceId>.jsonl` — beside the app's
+/// SQLite so the user can find it. Purely diagnostic and safe to delete; nothing reads it back.
+final class OuraActivityDump {
+    private let deviceId: String
+    private let log: (String) -> Void
+    private let highWaterKey: String
+    /// Only records with `ringTs` STRICTLY above this are written; re-served (older) records are dropped.
+    /// Persisted in UserDefaults so the dedup survives app relaunches (a fresh drain re-emits old records).
+    private var highWater: UInt32
+    private var fileURL: URL?
+    private var resolveFailed = false
+    private var announced = false
+
+    private static let iso: ISO8601DateFormatter = {
+        let f = ISO8601DateFormatter()
+        f.timeZone = TimeZone(identifier: "UTC")
+        return f
+    }()
+
+    init(deviceId: String, log: @escaping (String) -> Void) {
+        self.deviceId = deviceId
+        self.log = log
+        self.highWaterKey = "oura.activityDump.highwater.\(deviceId)"
+        let stored = UserDefaults.standard.integer(forKey: highWaterKey)   // 0 when unset → writes everything
+        self.highWater = stored > 0 ? UInt32(truncatingIfNeeded: stored) : 0
+    }
+
+    /// Append one anchored activity record. No-op when `ringTs` is not above the high-water (a re-serve),
+    /// so the corpus stays deduped. Best-effort: any file error is logged once and never disrupts the BLE
+    /// path. Call ONLY with an anchored `utc` (an un-anchored record has no real time axis and re-arrives
+    /// anchored on the next drain).
+    func record(ringTs: UInt32, utc: Int, state: Int, secPerSample: Int, met: [Double]) {
+        guard ringTs > highWater else { return }
+        guard let url = resolveURL() else { return }
+
+        let line = OuraActivityDumpLine.encode(
+            deviceId: deviceId, ringTs: ringTs, utc: utc,
+            iso: Self.iso.string(from: Date(timeIntervalSince1970: TimeInterval(utc))),
+            state: state, secPerSample: secPerSample, met: met)
+
+        guard let data = (line + "\n").data(using: .utf8) else { return }
+        do {
+            let handle = try FileHandle(forWritingTo: url)
+            defer { try? handle.close() }
+            try handle.seekToEnd()
+            handle.write(data)
+        } catch {
+            log("Oura: activity MET dump write failed - \(error.localizedDescription)")
+            return
+        }
+
+        highWater = ringTs
+        UserDefaults.standard.set(Int(ringTs), forKey: highWaterKey)
+        if !announced {
+            announced = true
+            log("Oura: activity MET dump → \(url.path) [Tier-B research corpus, JSONL, deduped by ring-time]")
+        }
+    }
+
+    /// Resolve (and create on first use) the sidecar file + its parent directory. Cached; a failure is
+    /// logged once and latched so we never spam the strap log on a read-only volume.
+    private func resolveURL() -> URL? {
+        if let fileURL { return fileURL }
+        if resolveFailed { return nil }
+        do {
+            let base = try FileManager.default.url(for: .applicationSupportDirectory, in: .userDomainMask,
+                                                   appropriateFor: nil, create: true)
+            let dir = base.appendingPathComponent("OpenWhoop/Diagnostics", isDirectory: true)
+            try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+            let safeId = deviceId.replacingOccurrences(of: "/", with: "_")
+            let url = dir.appendingPathComponent("oura-activity-\(safeId).jsonl")
+            if !FileManager.default.fileExists(atPath: url.path) {
+                FileManager.default.createFile(atPath: url.path, contents: nil)
+            }
+            fileURL = url
+            return url
+        } catch {
+            resolveFailed = true
+            log("Oura: activity MET dump unavailable - \(error.localizedDescription)")
+            return nil
+        }
+    }
+}

--- a/Strand/BLE/OuraLiveSource.swift
+++ b/Strand/BLE/OuraLiveSource.swift
@@ -193,6 +193,10 @@ public final class OuraLiveSource: NSObject, ObservableObject {
     /// Assumed per-sample epoch for the estimate log (the ONE calibration knob; the cadence self-check
     /// above measures the real value). 60 s = Oura's common 1-minute MET resolution.
     private let activityEpochSeconds: Double = 60
+    /// Append-only JSONL research corpus for the raw 0x50 MET series (Tier-B, never scored/persisted to
+    /// SQLite). Created only on a live/persisting source (nil for the discovery-only scanner). Deduped by
+    /// ring-time so re-served records don't duplicate; logs its file path once when the first record lands.
+    private let activityDump: OuraActivityDump?
     /// Cached local-day formatter (the 0x50 stream is high-volume; avoid building one per record).
     private static let activityDayFormatter: DateFormatter = {
         let f = DateFormatter(); f.dateFormat = "yyyy-MM-dd"; return f   // local time zone by default
@@ -454,6 +458,8 @@ public final class OuraLiveSource: NSObject, ObservableObject {
         self.onBattery = onBattery
         self.feedsLive = feedsLive
         self.adoptIntent = adoptIntent
+        // Tier-B MET research corpus: only on a live/persisting source, never the discovery-only scanner.
+        self.activityDump = feedsLive && !deviceId.isEmpty ? OuraActivityDump(deviceId: deviceId, log: log) : nil
         super.init()
         // Dedicated queue-less central -> callbacks arrive on the main queue, matching @MainActor.
         self.central = CBCentralManager(delegate: self, queue: nil)
@@ -848,6 +854,12 @@ public final class OuraLiveSource: NSObject, ObservableObject {
                 let utc = driver.unixSeconds(forRingTimestamp: info.ringTimestamp)
                 let when = utc.map { Self.cursorDateFormatter.string(from: Date(timeIntervalSince1970: TimeInterval($0))) } ?? "no anchor yet"
                 log("Oura: activity (Tier-B) [\(when)] state=\(info.state) met=\(info.met)")
+                // Append the raw record to the Tier-B research corpus (anchored records only; deduped by
+                // ring-time inside the writer). Diagnostic sidecar — never persisted to SQLite, never scored.
+                if let utc = utc {
+                    activityDump?.record(ringTs: info.ringTimestamp, utc: utc, state: info.state,
+                                         secPerSample: Int(activityEpochSeconds), met: info.met)
+                }
                 // Accumulate the MET series by local day for the drain-end estimate, and observe the
                 // per-sample cadence from consecutive record times (both investigation-only, never scored).
                 if let utc = utc {

--- a/android/app/src/main/java/com/noop/ble/OuraActivityDump.kt
+++ b/android/app/src/main/java/com/noop/ble/OuraActivityDump.kt
@@ -1,0 +1,87 @@
+package com.noop.ble
+
+import android.content.Context
+import com.noop.oura.OuraActivityDumpLine
+import java.io.File
+import java.time.Instant
+
+/**
+ * Append-only JSONL sidecar for the Oura 0x50 activity/MET stream — the Kotlin twin of Swift
+ * `OuraActivityDump`. A Tier-B RESEARCH corpus, never a datastore row (see [OuraActivityDumpLine] for the
+ * honest-data rationale). Owns the file, the once-per-launch "here is the file" log line, and a persistent
+ * ring-time high-water so records the ring re-serves across reconnects (observed heavily under connection
+ * churn) are written exactly once instead of duplicating the corpus.
+ *
+ * Location: `<filesDir>/diagnostics/oura-activity-<deviceId>.jsonl` (app-private). Purely diagnostic and
+ * safe to delete; nothing reads it back. (The path is platform-specific; the LINE content is byte-identical
+ * to the Swift corpus — that is the parity-relevant part.)
+ */
+class OuraActivityDump(
+    context: Context,
+    private val deviceId: String,
+    private val log: (String) -> Unit,
+) {
+    private val appContext = context.applicationContext
+    private val prefs = appContext.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+    private val highWaterKey = "highwater.$deviceId"
+
+    /** Only records with `ringTs` STRICTLY above this are written; re-served (older) records are dropped.
+     *  Persisted so the dedup survives relaunches (a fresh drain re-emits old records). */
+    private var highWater: Long = prefs.getLong(highWaterKey, 0L)
+    private var file: File? = null
+    private var resolveFailed = false
+    private var announced = false
+
+    /**
+     * Append one anchored activity record. No-op when [ringTs] is not above the high-water (a re-serve), so
+     * the corpus stays deduped. Best-effort: any file error is logged once and never disrupts the BLE path.
+     * Call ONLY with an anchored [utc] (an un-anchored record has no real time axis and re-arrives anchored
+     * on the next drain).
+     */
+    fun record(ringTs: Long, utc: Long, state: Int, secPerSample: Int, met: List<Double>) {
+        if (ringTs <= highWater) return
+        val f = resolveFile() ?: return
+
+        val line = OuraActivityDumpLine.encode(
+            deviceId = deviceId, ringTs = ringTs, utc = utc,
+            iso = Instant.ofEpochSecond(utc).toString(),
+            state = state, secPerSample = secPerSample, met = met,
+        )
+        try {
+            f.appendText(line + "\n")
+        } catch (e: Exception) {
+            log("Oura: activity MET dump write failed - ${e.message}")
+            return
+        }
+
+        highWater = ringTs
+        prefs.edit().putLong(highWaterKey, ringTs).apply()
+        if (!announced) {
+            announced = true
+            log("Oura: activity MET dump → ${f.absolutePath} [Tier-B research corpus, JSONL, deduped by ring-time]")
+        }
+    }
+
+    /** Resolve (and create on first use) the sidecar file + its parent directory. Cached; a failure is
+     *  logged once and latched so we never spam the strap log on a read-only volume. */
+    private fun resolveFile(): File? {
+        file?.let { return it }
+        if (resolveFailed) return null
+        return try {
+            val dir = File(appContext.filesDir, "diagnostics").apply { mkdirs() }
+            val safeId = deviceId.replace("/", "_")
+            File(dir, "oura-activity-$safeId.jsonl").also {
+                if (!it.exists()) it.createNewFile()
+                file = it
+            }
+        } catch (e: Exception) {
+            resolveFailed = true
+            log("Oura: activity MET dump unavailable - ${e.message}")
+            null
+        }
+    }
+
+    private companion object {
+        const val PREFS_NAME = "oura_activity_dump"
+    }
+}

--- a/android/app/src/main/java/com/noop/ble/OuraLiveSource.kt
+++ b/android/app/src/main/java/com/noop/ble/OuraLiveSource.kt
@@ -220,6 +220,11 @@ class OuraLiveSource(
     private val bluetoothManager: BluetoothManager? =
         appContext.getSystemService(Context.BLUETOOTH_SERVICE) as? BluetoothManager
     private val adapter: BluetoothAdapter? = bluetoothManager?.adapter
+
+    /** Tier-B activity/MET research corpus writer (diagnostic JSONL sidecar; never scored, never a Streams
+     *  row). Null when there is no device id. The Kotlin twin of the Swift `OuraActivityDump`. */
+    private val activityDump: OuraActivityDump? =
+        if (deviceId.isNotEmpty()) OuraActivityDump(appContext, deviceId, log) else null
     private val scanner: BluetoothLeScanner? get() = adapter?.bluetoothLeScanner
 
     private var gatt: BluetoothGatt? = null
@@ -1179,13 +1184,22 @@ class OuraLiveSource(
                     log("Oura: Tier-B ${e.value.kind} seen (tag 0x${e.value.tag.toString(16)}) - raw: $hex")
                 }
             }
-            is OuraEvent.ActivityInfo ->
+            is OuraEvent.ActivityInfo -> {
                 // INVESTIGATION ONLY (0x50 activity/MET, Tier B - a plausible third-party formula, NOT
                 // ground-truth-validated; see OuraActivityInfo). Logged with the DECODED state/MET values
                 // every time (not once-per-kind): this is the tag under active plausibility evaluation, so
                 // every real capture is evidence. Never persisted, never scored, and NEVER converted into
                 // steps (MET is not a step count; OuraStreamMapping drops ActivityInfo unconditionally).
                 log("Oura: activity (Tier-B) state=${e.value.state} met=${e.value.met}")
+                // Append the raw record to the Tier-B research corpus (anchored records only; deduped by
+                // ring-time in the writer). Diagnostic sidecar - never persisted to the DB, never scored.
+                d.unixSeconds(forRingTimestamp = e.value.ringTimestamp)?.let { utc ->
+                    activityDump?.record(
+                        ringTs = e.value.ringTimestamp, utc = utc, state = e.value.state,
+                        secPerSample = 60, met = e.value.met, // 60 s = assumed MET cadence (s6.13)
+                    )
+                }
+            }
             // Motion / debugText / etc: not a durable Streams row (see OuraStreamMapping). StateEvent is
             // handled above (wear badge only, also not a Streams row).
             else -> Unit

--- a/android/app/src/main/java/com/noop/oura/OuraActivityDumpLine.kt
+++ b/android/app/src/main/java/com/noop/oura/OuraActivityDumpLine.kt
@@ -1,0 +1,46 @@
+package com.noop.oura
+
+/**
+ * Pure, deterministic encoder for ONE line of the Oura activity (0x50 MET) research corpus — the Kotlin
+ * twin of Swift `OuraActivityDumpLine`. Byte-identical output (fixed key order; `met` via Kotlin's
+ * shortest round-trip [Double.toString], which matches Swift's `String(_:)` across the MET value range),
+ * so the two platforms' JSONL corpora are interchangeable.
+ *
+ * WHY a sidecar and not a stream/table: the 0x50 activity/MET decode is Tier-B (a plausible third-party
+ * formula, not ground-truth-validated — OURA_PROTOCOL.md s6.13). The honest-data invariant forbids Tier-B
+ * ever minting a durable scoring row, so it must never touch the datastore. This corpus is a separate,
+ * clearly-labelled diagnostic file the app appends to purely so the raw MET series can be accumulated for
+ * offline investigation. It never feeds scoring and is safe to delete.
+ *
+ * FORMAT: newline-delimited JSON (JSONL) — one record per line, append-only. The line is hand-built in a
+ * FIXED key order so it is stable and testable byte-for-byte.
+ */
+object OuraActivityDumpLine {
+    /** Bump when the record shape changes so a downstream reader can branch on `schema`. */
+    const val SCHEMA = 1
+
+    /**
+     * One JSONL record (NO trailing newline — the writer adds it). `deviceId` is a controlled registry id
+     * (e.g. `oura-<uuid>`) and `iso` is app-generated, so neither needs JSON string-escaping here.
+     *   - ringTs:       the record's raw ring-clock timestamp (the dedup key: strictly increases per record).
+     *   - utc:          the anchored wall-clock (unix seconds) for the record envelope.
+     *   - iso:          human-readable UTC of `utc` (convenience for eyeballing).
+     *   - state:        the raw 0x50 state byte (semantics unconfirmed — captured verbatim for study).
+     *   - secPerSample: the ASSUMED per-sample cadence (60 s); downstream can recompute from `utc` deltas.
+     *   - met:          the decoded per-sample MET series (Tier-B formula output, verbatim).
+     */
+    fun encode(
+        deviceId: String,
+        ringTs: Long,
+        utc: Long,
+        iso: String,
+        state: Int,
+        secPerSample: Int,
+        met: List<Double>,
+    ): String {
+        val metStr = met.joinToString(",") { it.toString() }
+        return "{\"schema\":$SCHEMA,\"deviceId\":\"$deviceId\",\"ringTs\":$ringTs," +
+            "\"utc\":$utc,\"iso\":\"$iso\",\"state\":$state," +
+            "\"secPerSample\":$secPerSample,\"met\":[$metStr]}"
+    }
+}

--- a/android/app/src/test/java/com/noop/oura/OuraActivityDumpLineTest.kt
+++ b/android/app/src/test/java/com/noop/oura/OuraActivityDumpLineTest.kt
@@ -1,0 +1,46 @@
+package com.noop.oura
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * The Tier-B activity research-corpus JSONL line encoder. The line is asserted verbatim so the format is
+ * pinned byte-for-byte AND stays interchangeable with the Swift `OuraActivityDumpLine` corpus (same key
+ * order, same `met` formatting).
+ */
+class OuraActivityDumpLineTest {
+
+    @Test
+    fun encodesFixedShapeVerbatim() {
+        val line = OuraActivityDumpLine.encode(
+            deviceId = "oura-5C4C0BF8", ringTs = 5_691_839, utc = 1_783_400_728,
+            iso = "2026-07-14T09:05:28Z", state = 23, secPerSample = 60,
+            met = listOf(2.2, 1.5, 1.4),
+        )
+        assertEquals(
+            "{\"schema\":1,\"deviceId\":\"oura-5C4C0BF8\",\"ringTs\":5691839," +
+                "\"utc\":1783400728,\"iso\":\"2026-07-14T09:05:28Z\",\"state\":23," +
+                "\"secPerSample\":60,\"met\":[2.2,1.5,1.4]}",
+            line,
+        )
+    }
+
+    @Test
+    fun emptyMetIsEmptyArray() {
+        val line = OuraActivityDumpLine.encode("d", 1, 2, "x", 0, 60, emptyList())
+        assertTrue(line.endsWith("\"met\":[]}"))
+    }
+
+    @Test
+    fun wholeAndMultiDigitMetMatchSwift() {
+        // 3.0 / 4.3 / 12.8 format identically in Swift String(Double) and Kotlin Double.toString, so the
+        // two platforms' corpora stay byte-identical across the MET range.
+        val line = OuraActivityDumpLine.encode(
+            "oura-ring", 100, 200, "2026-07-14T00:00:00Z", 148, 60, listOf(3.0, 4.3, 12.8),
+        )
+        assertTrue(line.contains("\"met\":[3.0,4.3,12.8]}"))
+        assertTrue(line.contains("\"state\":148"))
+        assertTrue(line.contains("\"schema\":${OuraActivityDumpLine.SCHEMA}"))
+    }
+}


### PR DESCRIPTION
  ## Summary
  Appends each anchored Oura `0x50` activity record to a **diagnostic JSONL sidecar** so the raw MET series can be accumulated for offline protocol RE (cadence, state-byte semantics, WHOOP
  cross-checks). Instrumentation only — **never scored, never stored as analytics, safe to delete.** Shipped on **both platforms**.

  This is a clean rebuild of the earlier #447 off current `main` (the `0x50` decode has since landed on both platforms), isolated to just the corpus.

  ## Why it's out of the scoring datastore
  The `0x50` MET decode is Tier-B (unvalidated third-party formula), so the honest-data invariant + the #960 pin forbid it minting a durable/scoring row. It goes to a sidecar file, not SQLite/Room.

  ## What's added (8 files)
  **Apple**
  - `Packages/WhoopStore/…/OuraActivityDumpLine.swift` — pure JSONL line encoder (+ 3 verbatim tests).
  - `Strand/BLE/OuraActivityDump.swift` — file writer: handle, path, persistent ring-time high-water dedup (`UserDefaults`).
  - `Strand/BLE/OuraLiveSource.swift` — 12-line wiring into the **existing** `.activityInfo` handler.

  **Android (byte-identical twin)**
  - `com/noop/oura/OuraActivityDumpLine.kt` — pure encoder, same fixed key order; `met` via `Double.toString` (matches Swift `String(_:)` across the MET range) (+ 3 JUnit tests, incl. a verbatim-line
  assertion).
  - `com/noop/ble/OuraActivityDump.kt` — file writer: `<filesDir>/diagnostics/…`, high-water dedup via `SharedPreferences`.
  - `com/noop/ble/OuraLiveSource.kt` — wiring into the existing `OuraEvent.ActivityInfo` handler.

  **Behaviour (both):**
  - JSONL, append-only (crash-safe; loads straight into pandas/jq/DuckDB).
  - File: `…/diagnostics/oura-activity-<deviceId>.jsonl`, beside the app data; path logged once per launch.
  - Deduped by a persistent ring-time high-water, so records the ring re-serves across reconnects are written exactly once.

  ## Cross-platform
  Shipped on both. Paths/prefs are platform-native (`filesDir` + `SharedPreferences` vs App Support + `UserDefaults`); the **JSONL line content is pinned verbatim on both sides**, so the two corpora are
  interchangeable. It's diagnostic instrumentation (never scored / never stored analytics), so there's no byte-identical *datastore* contract in play — the corpus line is twinned regardless.

  ## Verification
  - Swift: `swift test` WhoopStore `OuraActivityDumpLine` **3/3**; `xcodebuild … Strand` macOS **BUILD SUCCEEDED**.
  - Android: `./gradlew compileFullDebugKotlin` **OK**; `testFullDebugUnitTest OuraActivityDumpLineTest` **3/3** (`tests=3 failures=0`).
  - On hardware (Apple): `Oura: activity (Tier-B) …` records + `oura-activity-<id>.jsonl` written (strap logs).
