### PR TITLE
Oura: stamp banked IBIs at their real ring-time, not the drain-arrival time

### DIFF
--- a/Strand/BLE/OuraLiveSource.swift
+++ b/Strand/BLE/OuraLiveSource.swift
@@ -699,7 +699,12 @@ public final class OuraLiveSource: NSObject, ObservableObject {
         for pending in pendingAnchorEvents {
             if let ts = driver.unixSeconds(forRingTimestamp: pending.ringTimestamp) {
                 enqueue([pending.event], ts: ts)
-                noteStoredHistoryRingTime(pending.ringTimestamp)   // parked sample placed → advance resume cursor
+                // A parked IBI can be a LIVE beat that arrived before the anchor (see .ibi in ingest());
+                // it must never advance the resume cursor either, or a live push could skip un-drained
+                // backlog on a force-stopped drain. Only the history-only siblings drive the cursor.
+                if case .ibi = pending.event {} else {
+                    noteStoredHistoryRingTime(pending.ringTimestamp)   // parked history sample placed → advance resume cursor
+                }
             } else {
                 enqueue([pending.event], ts: now)   // honest wall-clock fallback; NEVER advances the cursor
             }
@@ -710,12 +715,14 @@ public final class OuraLiveSource: NSObject, ObservableObject {
     // MARK: - Live ingest
 
     /// Fold decoded events into live state (HR / R-R only - skin temp and SpO2 are SLEEP-ONLY on this
-    /// hardware, never a live readout) + the persist buffer. Live-push events (HR/IBI/battery) are stamped
-    /// at wall-clock arrival time, since they genuinely are "now". History-fetched events (temp, SpO2, HRV,
-    /// sleep-phase) are stamped with their REAL ring-time-anchored UTC (s5.5) so last night's data is never
-    /// mis-recorded as happening right now; when no anchor has arrived yet this session, we park the event
-    /// until one does (`pendingAnchorEvents`), rather than immediately guessing wall-clock. Out-of-range
-    /// HR/temp is dropped, never shown.
+    /// hardware, never a live readout) + the persist buffer. Genuinely-live pushes (HR/battery) are stamped
+    /// at wall-clock arrival time, since they really are "now". Ring-time-carrying events (IBI, temp, SpO2,
+    /// HRV, sleep-phase) are stamped with their REAL ring-time-anchored UTC (s5.5) so last night's banked
+    /// data is never mis-recorded as happening right now; when no anchor has arrived yet this session, we
+    /// park the event until one does (`pendingAnchorEvents`), rather than immediately guessing wall-clock.
+    /// (IBI is special: it arrives both live and banked, so it anchors like history but — unlike the
+    /// history-only streams — never advances the resume cursor; see the `.ibi` case.) Out-of-range HR/temp
+    /// is dropped, never shown.
     private func ingest(_ events: [OuraEvent]) {
         guard !events.isEmpty, let driver else { return }
         let now = Int(Date().timeIntervalSince1970)
@@ -754,7 +761,13 @@ public final class OuraLiveSource: NSObject, ObservableObject {
                 // so the sleep window ended up with zero R-R -> no restingHr/avgHrv for the night.
                 if let ts = driver.unixSeconds(forRingTimestamp: ibi.ringTimestamp) {
                     enqueue([e], ts: ts)
-                    noteStoredHistoryRingTime(ibi.ringTimestamp)
+                    // NOTE: unlike the history-only siblings, do NOT noteStoredHistoryRingTime here — IBI is
+                    // the one stream that arrives both LIVE (ring-time ~now) and banked, indistinguishable
+                    // at this call site except by ring-time. Letting a live beat advance the resume cursor
+                    // could leap `maxStoredRingTime` to ~now during a force-stopped drain (300s/stall guard,
+                    // bytes_left > 0) and permanently skip the un-drained backlog. The resume cursor is still
+                    // driven correctly by the history-only siblings (hrv/temp/spo2/sleepPhase) that share the
+                    // same night window; this also matches Kotlin, which notes no stream's ring-time.
                 } else {
                     pendingAnchorEvents.append((e, ibi.ringTimestamp))
                 }

--- a/Strand/BLE/OuraLiveSource.swift
+++ b/Strand/BLE/OuraLiveSource.swift
@@ -748,7 +748,16 @@ public final class OuraLiveSource: NSObject, ObservableObject {
 
             case .ibi(let ibi):
                 if feedsLive { live.setRRIntervals([ibi.ibiMs]) }
-                enqueue([e], ts: now)
+                // A banked IBI is history data: anchor it to its REAL ring-time, exactly like the sibling
+                // banked streams (.hrv/.temp/.spo2/.sleepPhase) below — never the drain-arrival `now`.
+                // Stamping it at `now` (52b6e88d) misfiled every overnight beat to the daytime sync moment,
+                // so the sleep window ended up with zero R-R -> no restingHr/avgHrv for the night.
+                if let ts = driver.unixSeconds(forRingTimestamp: ibi.ringTimestamp) {
+                    enqueue([e], ts: ts)
+                    noteStoredHistoryRingTime(ibi.ringTimestamp)
+                } else {
+                    pendingAnchorEvents.append((e, ibi.ringTimestamp))
+                }
 
             case .battery(let bat):
                 batteryPct = bat.percent

--- a/android/app/src/main/java/com/noop/ble/OuraLiveSource.kt
+++ b/android/app/src/main/java/com/noop/ble/OuraLiveSource.kt
@@ -471,9 +471,9 @@ class OuraLiveSource(
     // MARK: - Sample buffer (flushed in batches off the per-notification hot loop)
 
     /**
-     * One buffered batch of decoded events, stamped with its own [ts] (unix seconds): live-push events
-     * (HR, IBI, battery) are stamped at wall-clock arrival time; history-fetched events (temp, SpO2, HRV,
-     * sleep-phase) are stamped with their REAL ring-time-anchored UTC (s5.5) when an anchor is available,
+     * One buffered batch of decoded events, stamped with its own [ts] (unix seconds): genuinely-live
+     * pushes (HR, battery) are stamped at wall-clock arrival time; ring-time-carrying events (IBI, temp,
+     * SpO2, HRV, sleep-phase) are stamped with their REAL ring-time-anchored UTC (s5.5) when an anchor is available,
      * so last night's data is never mis-recorded as happening right now. Mirrors the Swift buffer
      * `(events, ts)`. [flush] folds each batch through the unit-tested [OuraStreamMapping] so the SAME pure
      * mapping the tests pin is the production path.
@@ -1061,12 +1061,13 @@ class OuraLiveSource(
 
     /**
      * Fold decoded driver events into live-UI updates + the persist buffer (the production path, parity
-     * with Swift's `ingest`). Live-push events (HR/IBI/battery) are stamped at wall-clock arrival time,
-     * since they genuinely are "now"; HR is range-gated for the LIVE display (off-finger / garbage never
-     * shown) and battery surfaces immediately (a status, not a timestamped row). History-fetched events
-     * (temp, SpO2, HRV, sleep-phase - SLEEP-ONLY on this hardware, never a live readout) are stamped with
-     * their REAL ring-time-anchored UTC (s5.5) so last night's data is never mis-recorded as happening
-     * right now; when no anchor has arrived yet this session, the event is PARKED
+     * with Swift's `ingest`). Genuinely-live pushes (HR/battery) are stamped at wall-clock arrival time,
+     * since they really are "now"; HR is range-gated for the LIVE display (off-finger / garbage never
+     * shown) and battery surfaces immediately (a status, not a timestamped row). Ring-time-carrying events
+     * (IBI, temp, SpO2, HRV, sleep-phase) are stamped with their REAL ring-time-anchored UTC (s5.5) so last
+     * night's banked data is never mis-recorded as happening right now (IBI arrives both live and banked, so
+     * it anchors like history but never advances the resume cursor); when no anchor has arrived yet this
+     * session, the event is PARKED
      * ([pendingAnchorEvents]) until one does, rather than immediately guessing wall-clock. A 0x42
      * time-sync (the anchor) drains anything parked. Tier-B events (allowed for INVESTIGATION - see the
      * driver construction comment) are LOGGED only, never enqueued: OuraStreamMapping drops them anyway,

--- a/android/app/src/main/java/com/noop/ble/OuraLiveSource.kt
+++ b/android/app/src/main/java/com/noop/ble/OuraLiveSource.kt
@@ -1114,7 +1114,11 @@ class OuraLiveSource(
             is OuraEvent.Ibi -> {
                 val rr = e.value.ibiMs
                 if (rr in 250..3000) handler.post { guardedCallback("live-sink") { liveSink(0, listOf(rr)) } }
-                enqueue(listOf(e), now)
+                // A banked IBI is history data: anchor it to its REAL ring-time (via [enqueueAnchoredOrPark]),
+                // exactly like the sibling banked streams (.Hrv/.Temp/.Spo2/.SleepPhaseEvent) - never the
+                // drain-arrival `now`. Stamping at `now` misfiled every overnight beat to the daytime sync
+                // moment, so the sleep window ended up with zero R-R -> no restingHr/avgHrv for the night.
+                enqueueAnchoredOrPark(e, e.value.ringTimestamp, d)
             }
             is OuraEvent.Battery -> {
                 handleBattery(e.value.percent)


### PR DESCRIPTION
  ## Summary
  A banked Oura IBI (a `0x60`/`0x80`/`0x6E` history record) is enqueued with `ts: now` — the wall-clock moment the history drain arrived — instead of its real ring-time, unlike every sibling banked
  stream (`.hrv`/`.temp`/`.spo2`/`.sleepPhase`, which anchor via `unixSeconds(forRingTimestamp:)`). The anchor was wired for those streams when it landed (`52b6e88d`) but `.ibi` was left on `now`.

  ## The effect
  A night's history is drained the next day, so **every overnight beat is written to `rrInterval` at the daytime sync moment**: the deep-night hours (00–06 local) come out empty while the sync hour
  piles up an implausible density of beats. Any consumer of the Oura R‑R series (HR charts, HRV / daytime-stress analytics) reads the wrong time axis. The `oura-ibihr` diagnostic corpus was always
  correct (it uses the anchored ring-time), so the *data* is fine — only the datastore timestamp was wrong.

  ## Fix
  Anchor `.ibi` exactly like the sibling banked streams, with the hold-until-anchor `pendingAnchorEvents` fallback for a beat that arrives before the session's UTC anchor lands. **Swift + Android twin**
  (`OuraLiveSource.swift` / `OuraLiveSource.kt`).

  - **Live HR is untouched** — that's the `.hr` live push.
  - The **live R‑R strip** (`setRRIntervals` / `liveSink`) is unchanged — only the *persist* timestamp moves to real time.

  ## Scope note
  `main` has no Oura sleep-session persist yet, so the visible payoff here is a **correctly time-stamped `rrInterval`**. The downstream benefit — a persisted Oura sleep session carrying
  `restingHr`/`avgHrv` — lands once that path merges; this fix is the correct prerequisite either way.

  ## Cross-platform
  Both platforms, same change; the bug and the sibling-stream anchor both exist on each. No stored-data *shape* change — only the timestamp of an already-persisted row — so no migration.

  ## Verification
  - `xcodebuild … -scheme Strand -destination 'platform=macOS'` — **BUILD SUCCEEDED**.
  - Android `./gradlew compileFullDebugKotlin` — **OK**.
  - BLE dispatch isn't unit-testable (the anchor primitive `unixSeconds(forRingTimestamp:)` it reuses already is). **Hardware validation, next drain:** overnight `rrInterval` populates at real times and
  matches the `oura-ibihr` corpus (00–06 local no longer empty).
