### PR TITLE
Cap + rotate the Oura activity MET research corpus (#676 follow-up)

### DIFF
--- a/Strand/BLE/OuraActivityDump.swift
+++ b/Strand/BLE/OuraActivityDump.swift
@@ -48,7 +48,9 @@ final class OuraActivityDump {
         // #676 follow-up: bound the corpus (rotate to a single ".1", dropping the prior one) so an
         // always-on research sidecar can't grow unbounded — the same rotation the WHOOP5 deep-buffer log
         // uses. Twin of Kotlin OuraActivityDump. Best-effort: a rotation error falls through to the append.
-        let size = (try? url.resourceValues(forKeys: [.fileSizeKey]).fileSize) ?? 0
+        // Read the size via FileManager (a fresh stat) rather than URL.resourceValues, whose cache on the
+        // reused URL object can return a stale small size and skip rotation entirely.
+        let size = ((try? FileManager.default.attributesOfItem(atPath: url.path))?[.size] as? Int) ?? 0
         if size > Self.maxBytes {
             let old = url.deletingLastPathComponent().appendingPathComponent(url.lastPathComponent + ".1")
             try? FileManager.default.removeItem(at: old)

--- a/Strand/BLE/OuraActivityDump.swift
+++ b/Strand/BLE/OuraActivityDump.swift
@@ -20,6 +20,10 @@ final class OuraActivityDump {
     private var resolveFailed = false
     private var announced = false
 
+    /// #676 follow-up: rotate the sidecar past this size (keeping one previous ".1"), so an always-on
+    /// research corpus is bounded to ~2× this on disk instead of growing forever. Matches Kotlin `MAX_BYTES`.
+    private static let maxBytes = 25 * 1024 * 1024
+
     private static let iso: ISO8601DateFormatter = {
         let f = ISO8601DateFormatter()
         f.timeZone = TimeZone(identifier: "UTC")
@@ -40,7 +44,19 @@ final class OuraActivityDump {
     /// anchored on the next drain).
     func record(ringTs: UInt32, utc: Int, state: Int, secPerSample: Int, met: [Double]) {
         guard ringTs > highWater else { return }
-        guard let url = resolveURL() else { return }
+        guard var url = resolveURL() else { return }
+        // #676 follow-up: bound the corpus (rotate to a single ".1", dropping the prior one) so an
+        // always-on research sidecar can't grow unbounded — the same rotation the WHOOP5 deep-buffer log
+        // uses. Twin of Kotlin OuraActivityDump. Best-effort: a rotation error falls through to the append.
+        let size = (try? url.resourceValues(forKeys: [.fileSizeKey]).fileSize) ?? 0
+        if size > Self.maxBytes {
+            let old = url.deletingLastPathComponent().appendingPathComponent(url.lastPathComponent + ".1")
+            try? FileManager.default.removeItem(at: old)
+            try? FileManager.default.moveItem(at: url, to: old)
+            fileURL = nil
+            guard let fresh = resolveURL() else { return }
+            url = fresh
+        }
 
         let line = OuraActivityDumpLine.encode(
             deviceId: deviceId, ringTs: ringTs, utc: utc,

--- a/android/app/src/main/java/com/noop/ble/OuraActivityDump.kt
+++ b/android/app/src/main/java/com/noop/ble/OuraActivityDump.kt
@@ -40,7 +40,20 @@ class OuraActivityDump(
      */
     fun record(ringTs: Long, utc: Long, state: Int, secPerSample: Int, met: List<Double>) {
         if (ringTs <= highWater) return
-        val f = resolveFile() ?: return
+        var f = resolveFile() ?: return
+        // #676 follow-up: bound the corpus so it can't grow unbounded on a long-lived Oura (this is
+        // always-on for every paired ring). At the cap, rotate to a single ".1" (dropping the prior one)
+        // and continue in a fresh file — the same rotation the WHOOP5 deep-buffer log uses. Best-effort:
+        // a rotation error just falls through to the append below.
+        if (f.length() > MAX_BYTES) {
+            runCatching {
+                val old = File(f.parentFile, "${f.name}.1")
+                old.delete()
+                f.renameTo(old)
+            }
+            file = null
+            f = resolveFile() ?: return
+        }
 
         val line = OuraActivityDumpLine.encode(
             deviceId = deviceId, ringTs = ringTs, utc = utc,
@@ -83,5 +96,10 @@ class OuraActivityDump(
 
     private companion object {
         const val PREFS_NAME = "oura_activity_dump"
+
+        /** #676 follow-up: rotate the sidecar past this size (keeping one previous ".1"), so an always-on
+         *  research corpus is bounded to ~2× this on disk instead of growing forever. Generous enough to
+         *  retain a long MET series for offline RE. */
+        const val MAX_BYTES = 25L * 1024 * 1024
     }
 }


### PR DESCRIPTION
Follow-up to #676. That sidecar is always-on for every paired Oura and appends forever with no cap (~100 KB/day → unbounded). Every other diagnostic log is bounded (the WHOOP5 deep-buffer log rotates at 60 MB); this one wasn't.

Adds a **25 MB cap + single-`.1` rotation** on both platforms (bounded ~50 MB on disk), mirroring the deep-buffer log's rotation. Best-effort — a rotation error falls through to the append. No encoder/schema/dedup change; the corpus stays always-on (gating would starve the research data, so bounding is the right lever).

Verified: Android `compileFullDebugKotlin` + `OuraActivityDumpLineTest` ✓. iOS mirrors the Kotlin change (rotation in `record()` + `maxBytes`); compiles on the app-build attached here.