### PR TITLE
Preserve repeated corrupt-DB quarantines instead of dropping the newest (#661)

### DIFF
--- a/android/app/src/main/java/com/noop/data/DataBackup.kt
+++ b/android/app/src/main/java/com/noop/data/DataBackup.kt
@@ -621,12 +621,14 @@ object DataBackup {
  *
  * The factory wraps the stock [FrameworkSQLiteOpenHelperFactory] and delegates every lifecycle
  * callback (configure/create/migrate/open) to Room's real callback UNCHANGED, so migrations behave
- * exactly as before. Only `onCorruption` is replaced: it logs loudly, closes the handle, sets ONE
- * `.corrupt` sibling copy aside (best-effort, skipped when one already exists so repeated failed
- * opens can't multiply 100 MB files), and — crucially — deletes NOTHING. The trade-off is
- * deliberate and matches [WhoopDatabase]'s no-destructive-fallback doctrine: the app may then fail
- * to open the store (the user sees an error instead of a silently empty app), but the file survives
- * for backup/recovery instead of vanishing.
+ * exactly as before. Only `onCorruption` is replaced: it logs loudly, closes the handle, and moves
+ * the corrupt file aside to a TIMESTAMPED `.corrupt.<epochMillis>` quarantine (best-effort), keeping
+ * the newest [MAX_CORRUPT_QUARANTINES] and pruning older ones so a crash loop can't multiply 100 MB
+ * files (#661). It never silently discards the newest corrupt copy — repeated corruption preserves
+ * the latest (most recovery-worthy) data, not just the first. The trade-off is deliberate and matches
+ * [WhoopDatabase]'s no-destructive-fallback doctrine: the app may then fail to open the store (the
+ * user sees an error instead of a silently empty app), but the corrupt file survives for
+ * backup/recovery instead of vanishing.
  *
  * `allowDataLossOnRecovery` is pinned FALSE for the same reason: androidx's recovery path deletes
  * the file when an open fails, which is exactly the destruction this factory exists to prevent.
@@ -668,30 +670,102 @@ class CorruptionPreservingOpenHelperFactory(
             val path = runCatching { db.path }.getOrNull()
             Log.e(
                 "WhoopDatabase",
-                "SQLite reported corruption in $path — quarantining it to *.corrupt and recreating a fresh " +
-                    "store. The corrupt copy is kept; restore from a backup to get your data back.",
+                "SQLite reported corruption in $path — quarantining it to *.corrupt.<epoch> and recreating " +
+                    "a fresh store. The corrupt copy is kept; restore from a backup to get your data back.",
             )
             runCatching { db.close() }
             if (path != null && path != ":memory:") {
                 val original = File(path)
                 if (original.exists()) {
-                    val preserved = File("$path.corrupt")
-                    if (!preserved.exists()) {
-                        // Move (not copy) so the original is gone and the next open rebuilds clean. Fall
-                        // back to copy+delete if rename fails (e.g. across a storage boundary).
-                        if (!runCatching { original.renameTo(preserved) }.getOrDefault(false)) {
-                            runCatching { original.copyTo(preserved, overwrite = false) }
-                            runCatching { original.delete() }
-                        }
-                    } else {
-                        // A quarantine copy already exists — just drop the still-corrupt original.
+                    // #661: quarantine under a TIMESTAMPED name and keep the newest few, instead of a
+                    // single fixed `.corrupt` slot. The old single-slot logic kept the FIRST corrupt copy
+                    // and deleted every later one — but a later corruption is a rebuilt store that has
+                    // banked new non-resendable strap history since, so the copy it dropped was the most
+                    // recovery-worthy. Keeping the newest N caps disk (a crash loop can't multiply files)
+                    // AND preserves the latest data plus a couple of priors for diagnosing a recurring
+                    // corruption path.
+                    val dir = original.parentFile
+                    val dbName = original.name
+                    val existing = dir?.listFiles()?.map { it.name }
+                        ?.filter {
+                            it.startsWith("$dbName.corrupt.") &&
+                                it.substringAfterLast(".corrupt.").toLongOrNull() != null
+                        } ?: emptyList()
+                    val plan = planCorruptQuarantine(dbName, existing, System.currentTimeMillis())
+                    val preserved = File(dir, plan.quarantineName)
+                    // Move (not copy) so the original is gone and the next open rebuilds clean; fall back
+                    // to copy+delete if rename fails (e.g. across a storage boundary).
+                    if (!runCatching { original.renameTo(preserved) }.getOrDefault(false)) {
+                        // Cross-storage rename fallback. Copy best-effort (overwrite=true so a same-
+                        // millisecond re-entry of the same corrupt lineage still lands), then drop the
+                        // original EITHER WAY: leaving a corrupt file on the live path re-hits corruption
+                        // and crash-loops the app on every launch (#1014). Preservation is best-effort.
+                        runCatching { original.copyTo(preserved, overwrite = true) }
                         runCatching { original.delete() }
                     }
+                    // Move the WAL/SHM sidecars ALONGSIDE the quarantine rather than deleting them: the WAL
+                    // can hold the most recent un-checkpointed writes (the newest strap data). The move
+                    // still clears the live path, so the fresh rebuild can't inherit a stale write-ahead log.
+                    moveSidecarBesideQuarantine("$path-wal", "${preserved.path}-wal")
+                    moveSidecarBesideQuarantine("$path-shm", "${preserved.path}-shm")
+                    // Prune the oldest quarantines beyond the cap (+ their moved sidecars).
+                    plan.evict.forEach { name ->
+                        val stale = File(dir, name)
+                        runCatching { stale.delete() }
+                        runCatching { File("${stale.path}-wal").delete() }
+                        runCatching { File("${stale.path}-shm").delete() }
+                    }
+                } else {
+                    // No original to quarantine — clear any orphan sidecars so the fresh rebuild is clean.
+                    runCatching { File("$path-wal").delete() }
+                    runCatching { File("$path-shm").delete() }
                 }
-                // Drop the WAL/SHM sidecars so a fresh DB can't inherit a stale write-ahead log.
-                runCatching { File("$path-wal").delete() }
-                runCatching { File("$path-shm").delete() }
             }
         }
+    }
+}
+
+/** #661: at most this many `.corrupt.<epoch>` quarantines survive (newest kept), bounding disk on a
+ *  repeated-corruption crash loop while preserving the latest copies for recovery/diagnosis. */
+internal const val MAX_CORRUPT_QUARANTINES = 3
+
+internal data class CorruptQuarantinePlan(
+    val quarantineName: String,
+    val evict: List<String>,
+)
+
+/**
+ * #661: name the new corrupt-DB quarantine (`<dbName>.corrupt.<epochMillis>`) and decide which OLD
+ * quarantines to evict so at most [keep] survive (newest by embedded epoch). Pure / filesystem-free so
+ * it is unit-tested directly. [existing] must already be filtered to `<dbName>.corrupt.<digits>` names.
+ * The just-created quarantine is never evicted, even if [keep] is 0.
+ */
+internal fun planCorruptQuarantine(
+    dbName: String,
+    existing: List<String>,
+    nowMillis: Long,
+    keep: Int = MAX_CORRUPT_QUARANTINES,
+): CorruptQuarantinePlan {
+    val quarantineName = "$dbName.corrupt.$nowMillis"
+    fun epochOf(name: String): Long = name.substringAfterLast(".corrupt.").toLongOrNull() ?: 0L
+    val evict = (existing + quarantineName)
+        .distinct()
+        .sortedByDescending { epochOf(it) }
+        .drop(keep.coerceAtLeast(0))
+        .filter { it != quarantineName }
+    return CorruptQuarantinePlan(quarantineName, evict)
+}
+
+/** Best-effort move of a WAL/SHM sidecar next to its quarantined DB (rename, else copy+delete). */
+private fun moveSidecarBesideQuarantine(fromPath: String, toPath: String) {
+    val src = File(fromPath)
+    if (!src.exists()) return
+    val dst = File(toPath)
+    if (!runCatching { src.renameTo(dst) }.getOrDefault(false)) {
+        // Best-effort preserve, then ALWAYS clear the live sidecar: a stale WAL left on the live path
+        // can be applied to the freshly-rebuilt DB (WAL identity is salt-based only), re-injecting
+        // corrupt pages. Keeping the rebuild clean wins over preserving an un-movable sidecar.
+        runCatching { src.copyTo(dst, overwrite = true) }
+        runCatching { src.delete() }
     }
 }

--- a/android/app/src/test/java/com/noop/data/CorruptDbQuarantineTest.kt
+++ b/android/app/src/test/java/com/noop/data/CorruptDbQuarantineTest.kt
@@ -1,0 +1,68 @@
+package com.noop.data
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * #661: the pure quarantine-planning behind [CorruptionPreservingOpenHelperFactory]'s corruption
+ * handler — timestamped `.corrupt.<epoch>` names, keep-newest-N, and never evicting the copy we just
+ * wrote. The filesystem move/prune is I/O and not unit-tested here; this pins the decision logic.
+ */
+class CorruptDbQuarantineTest {
+
+    @Test fun firstQuarantineEvictsNothing() {
+        val plan = planCorruptQuarantine("whoop.db", emptyList(), nowMillis = 1000)
+        assertEquals("whoop.db.corrupt.1000", plan.quarantineName)
+        assertEquals(emptyList<String>(), plan.evict)
+    }
+
+    @Test fun underTheCapEvictsNothing() {
+        val plan = planCorruptQuarantine(
+            "whoop.db", listOf("whoop.db.corrupt.100", "whoop.db.corrupt.200"), nowMillis = 300, keep = 3,
+        )
+        assertEquals(emptyList<String>(), plan.evict)
+    }
+
+    @Test fun keepsNewestNAndEvictsOldest() {
+        val existing = listOf(
+            "whoop.db.corrupt.100",
+            "whoop.db.corrupt.200",
+            "whoop.db.corrupt.300",
+        )
+        val plan = planCorruptQuarantine("whoop.db", existing, nowMillis = 400, keep = 3)
+        assertEquals("whoop.db.corrupt.400", plan.quarantineName)
+        // Newest 3 kept = 400, 300, 200; only the oldest (100) is evicted.
+        assertEquals(listOf("whoop.db.corrupt.100"), plan.evict)
+    }
+
+    @Test fun evictionOrderIsOldestFirstAcrossManyCopies() {
+        val existing = (10L..14L).map { "whoop.db.corrupt.${it * 100}" } // 1000..1400
+        val plan = planCorruptQuarantine("whoop.db", existing, nowMillis = 1500, keep = 3)
+        // Kept: 1500, 1400, 1300. Evicted: 1200, 1100, 1000 (any order).
+        assertEquals(
+            listOf("whoop.db.corrupt.1000", "whoop.db.corrupt.1100", "whoop.db.corrupt.1200").sorted(),
+            plan.evict.sorted(),
+        )
+        assertFalse("whoop.db.corrupt.1500" in plan.evict)
+    }
+
+    @Test fun theJustWrittenQuarantineIsNeverEvictedEvenIfOlderThanExistingOrKeepZero() {
+        // A clock skew makes the new stamp (50) older than an existing one (100); with keep=0 the plan
+        // must still protect the copy we just wrote and evict only the others.
+        val plan = planCorruptQuarantine("whoop.db", listOf("whoop.db.corrupt.100"), nowMillis = 50, keep = 0)
+        assertEquals("whoop.db.corrupt.50", plan.quarantineName)
+        assertTrue("whoop.db.corrupt.100" in plan.evict)
+        assertFalse("whoop.db.corrupt.50" in plan.evict)
+    }
+
+    @Test fun aReDeliveredExistingStampDoesNotDuplicate() {
+        // If the listing already contains the new stamp (re-entrancy), it is not counted twice.
+        val plan = planCorruptQuarantine(
+            "whoop.db", listOf("whoop.db.corrupt.900", "whoop.db.corrupt.900"), nowMillis = 900, keep = 3,
+        )
+        assertEquals("whoop.db.corrupt.900", plan.quarantineName)
+        assertEquals(emptyList<String>(), plan.evict)
+    }
+}


### PR DESCRIPTION
Fixes #661.

## The bug
The #1014 corruption handler (`CorruptionPreservingOpenHelperFactory.onCorruption`) kept a single fixed `.corrupt` slot: the **first** corrupt copy was preserved and every later one **deleted** (the `else { original.delete() }` branch). But a later corruption is a rebuilt store that has banked new, non-resendable strap history since — so the copy it discarded was the **most recovery-worthy** one, silently defeating the handler's whole purpose. tigercraft4 flagged this in a static data-integrity audit.

The behaviour was a deliberate disk bound ("repeated failed opens can't multiply 100 MB files") — but it picked disk-safety over the newest data.

## The fix
- **Timestamped quarantine names** `whoop.db.corrupt.<epochMillis>` + **keep newest `MAX_CORRUPT_QUARANTINES` (3)**, pruning older ones. Caps disk (a crash loop can't multiply files) **and** preserves the latest data plus a couple of priors for diagnosing a recurring corruption path. Naming/pruning is a pure, unit-tested function (`planCorruptQuarantine`).
- **Move WAL/SHM sidecars alongside the quarantine** rather than deleting them — the WAL can hold the most recent un-checkpointed writes. The **live path is still cleared** (rename, or copy+delete on the cross-storage fallback), so the fresh rebuild can never inherit a stale write-ahead log. (A stale live WAL could otherwise be applied to the new DB by salt match and re-inject corrupt pages — hence live-path clearing always wins over preserving an un-movable sidecar.)
- **Doc fix:** the class-doc claimed the factory "deletes NOTHING", but the old else-branch deleted the original and the sidecars were always dropped.

## Scope / parity
Android-only. iOS/GRDB has **no** delete-on-corruption default (this Android handler exists to neutralise the platform default), and `WhoopStore.quarantineIncompatibleDatabase` already uses timestamped names — so this converges the two rather than diverging. No analytics/stored-data change → parity contract untouched.

## Verification
- `./gradlew compileFullDebugKotlin` ✓
- `./gradlew testFullDebugUnitTest --tests com.noop.data.CorruptDbQuarantineTest` ✓ (first/under-cap/keep-newest-N/eviction-order/never-evict-new/dedup)
- `./gradlew testFullDebugUnitTest --tests com.noop.data.*` ✓ (no existing regressions)
The filesystem move/prune is I/O and validated by inspection; the decision logic is unit-tested.

Reported-by: tigercraft4