### PR TITLE
Insights: don't count never-answered journal days as "without"

### DIFF
--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/BehaviorInsights.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/BehaviorInsights.swift
@@ -78,18 +78,25 @@ public enum BehaviorInsights {
     // MARK: - Single behavior effect
 
     /// Compute the effect of `behavior` on `outcome`. Days are partitioned into
-    /// "with" (day ∈ behaviorDays) and "without" (day ∉ behaviorDays), restricted
-    /// to days that have an outcome value in `outcomeByDay`.
+    /// "with" (day ∈ behaviorDays) and "without" (day ∈ askedDays, day ∉ behaviorDays),
+    /// restricted to days that have an outcome value in `outcomeByDay`. A day that was never
+    /// asked/answered (day ∉ behaviorDays ∪ askedDays) counts in NEITHER group — a day just
+    /// missing a journal answer is not the same as an explicit "no" (issue #631).
+    ///
+    /// `behaviorDays` is expected to be a subset of `askedDays`; the check below is an OR so a
+    /// "with" day is never dropped even if a caller's askedDays build has a gap.
     ///
     /// Returns nil unless BOTH groups are non-empty AND the total is large enough
     /// to form a variance estimate (at least 1 value per side and ≥ 3 total).
     public static func effect(behaviorDays: Set<String>,
+                              askedDays: Set<String>,
                               outcomeByDay: [String: Double],
                               behavior: String,
                               outcome: String) -> BehaviorEffect? {
         var withVals: [Double] = []
         var withoutVals: [Double] = []
         for (day, value) in outcomeByDay {
+            guard behaviorDays.contains(day) || askedDays.contains(day) else { continue }
             if behaviorDays.contains(day) { withVals.append(value) }
             else { withoutVals.append(value) }
         }
@@ -125,11 +132,13 @@ public enum BehaviorInsights {
     /// return them sorted by |cohensD| descending, with significant effects first.
     /// Behaviors that don't yield a computable effect are dropped.
     public static func rank(behaviors: [String: Set<String>],
+                            asked: [String: Set<String>],
                             outcomeByDay: [String: Double],
                             outcome: String) -> [BehaviorEffect] {
         var effects: [BehaviorEffect] = []
         for (name, days) in behaviors {
-            if let e = effect(behaviorDays: days, outcomeByDay: outcomeByDay,
+            let askedDays = asked[name] ?? days
+            if let e = effect(behaviorDays: days, askedDays: askedDays, outcomeByDay: outcomeByDay,
                               behavior: name, outcome: outcome) {
                 effects.append(e)
             }

--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/EffectRanker.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/EffectRanker.swift
@@ -104,13 +104,15 @@ public enum EffectRanker {
     ///   significant-first, |cohensD| desc, then behaviour name asc. Behaviours with no
     ///   computable lag are dropped.
     public static func rank(behaviors: [String: Set<String>],
+                            asked: [String: Set<String>],
                             outcomeByDay: [String: Double],
                             outcome: String) -> [RankedEffect] {
         var rows: [RankedEffect] = []
         // Sort behaviour names so the build order is deterministic regardless of dict order.
         for name in behaviors.keys.sorted() {
             let days = behaviors[name]!
-            if let row = bestLag(behaviorDays: days, outcomeByDay: outcomeByDay,
+            let askedDays = asked[name] ?? days
+            if let row = bestLag(behaviorDays: days, askedDays: askedDays, outcomeByDay: outcomeByDay,
                                  behavior: name, outcome: outcome) {
                 rows.append(row)
             }
@@ -121,13 +123,17 @@ public enum EffectRanker {
     /// Find the best-lag RankedEffect for ONE behaviour against ONE outcome, or nil when no
     /// lag in `lagSet` yields a computable effect that clears the group gate.
     public static func bestLag(behaviorDays: Set<String>,
+                               askedDays: Set<String>,
                                outcomeByDay: [String: Double],
                                behavior: String,
                                outcome: String) -> RankedEffect? {
         var best: (lag: Int, effect: BehaviorEffect)?
         for lag in lagSet {
             let shifted = shiftedOutcome(outcomeByDay, byLag: lag)
+            // askedDays/behaviorDays already live in behaviour-day space — only the outcome
+            // series gets re-keyed per lag, never the asked/behaviour sets.
             guard let e = BehaviorInsights.effect(behaviorDays: behaviorDays,
+                                                  askedDays: askedDays,
                                                   outcomeByDay: shifted,
                                                   behavior: behavior,
                                                   outcome: outcome) else { continue }

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/BehaviorInsightsTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/BehaviorInsightsTests.swift
@@ -14,7 +14,8 @@ final class BehaviorInsightsTests: XCTestCase {
             "d13": 70, "d14": 68,
         ]
         let behaviorDays: Set<String> = ["d01", "d02", "d03", "d04", "d05", "d06"]
-        let e = BehaviorInsights.effect(behaviorDays: behaviorDays, outcomeByDay: outcome,
+        let e = BehaviorInsights.effect(behaviorDays: behaviorDays, askedDays: Set(outcome.keys),
+                                        outcomeByDay: outcome,
                                         behavior: "Alcohol", outcome: "Recovery")!
         XCTAssertEqual(e.nWith, 6)
         XCTAssertEqual(e.nWithout, 8)
@@ -34,6 +35,7 @@ final class BehaviorInsightsTests: XCTestCase {
             "f": 70, "g": 72, "h": 68, "i": 71, "j": 69,   // without (mean 70)
         ]
         let e = BehaviorInsights.effect(behaviorDays: ["a", "b", "c", "d", "e"],
+                                        askedDays: Set(outcome.keys),
                                         outcomeByDay: outcome,
                                         behavior: "Meditation", outcome: "Recovery")!
         XCTAssertEqual(e.delta, 10.0, accuracy: 1e-9)
@@ -46,10 +48,12 @@ final class BehaviorInsightsTests: XCTestCase {
         // Behavior logged every day → no "without" group.
         let outcome: [String: Double] = ["a": 60, "b": 61, "c": 62]
         XCTAssertNil(BehaviorInsights.effect(behaviorDays: ["a", "b", "c"],
+                                             askedDays: Set(outcome.keys),
                                              outcomeByDay: outcome,
                                              behavior: "X", outcome: "Recovery"))
         // Behavior never logged → no "with" group.
         XCTAssertNil(BehaviorInsights.effect(behaviorDays: [],
+                                             askedDays: Set(outcome.keys),
                                              outcomeByDay: outcome,
                                              behavior: "X", outcome: "Recovery"))
     }
@@ -58,10 +62,63 @@ final class BehaviorInsightsTests: XCTestCase {
         // "z" is in behaviorDays but has no outcome value → not counted in nWith.
         let outcome: [String: Double] = ["a": 60, "b": 62, "c": 70, "d": 72]
         let e = BehaviorInsights.effect(behaviorDays: ["a", "b", "z"],
+                                        askedDays: Set(outcome.keys).union(["z"]),
                                         outcomeByDay: outcome,
                                         behavior: "X", outcome: "Recovery")!
         XCTAssertEqual(e.nWith, 2)        // a, b only
         XCTAssertEqual(e.nWithout, 2)     // c, d
+    }
+
+    // MARK: - never-asked days (#631: a missing journal answer is not an implicit "no")
+
+    func testEffectExcludesUnaskedDaysFromBothGroups() {
+        // "z" has an outcome value but was never asked (not in behaviorDays or askedDays) →
+        // dropped entirely, not counted as "without".
+        let outcome: [String: Double] = ["a": 60, "b": 62, "c": 70, "d": 72, "z": 65]
+        let e = BehaviorInsights.effect(behaviorDays: ["a", "b"],
+                                        askedDays: ["a", "b", "c", "d"],
+                                        outcomeByDay: outcome,
+                                        behavior: "X", outcome: "Recovery")!
+        XCTAssertEqual(e.nWith, 2)      // a, b
+        XCTAssertEqual(e.nWithout, 2)   // c, d — "z" excluded, not counted as without
+    }
+
+    func testEffectAskedNoStillCountsAsWithout() {
+        // A day that WAS asked and explicitly answered "no" (in askedDays, not in behaviorDays)
+        // still counts as "without" — the fix only excludes NEVER-asked days.
+        let outcome: [String: Double] = ["a": 60, "b": 61, "c": 70, "d": 71, "e": 72]
+        let e = BehaviorInsights.effect(behaviorDays: ["a", "b"],
+                                        askedDays: ["a", "b", "c", "d", "e"],
+                                        outcomeByDay: outcome,
+                                        behavior: "X", outcome: "Recovery")!
+        XCTAssertEqual(e.nWith, 2)
+        XCTAssertEqual(e.nWithout, 3)
+    }
+
+    func testEffectBehaviorDayNotInAskedStillCountsAsWith() {
+        // Defensive OR: a "yes" day missing from askedDays (a caller build gap) is never dropped
+        // from "with".
+        let outcome: [String: Double] = ["a": 80, "b": 60, "c": 61]
+        let e = BehaviorInsights.effect(behaviorDays: ["a"],
+                                        askedDays: ["b", "c"],   // "a" deliberately missing
+                                        outcomeByDay: outcome,
+                                        behavior: "X", outcome: "Recovery")!
+        XCTAssertEqual(e.nWith, 1)      // "a" still counted despite the askedDays gap
+        XCTAssertEqual(e.nWithout, 2)
+    }
+
+    func testEffectRealisticSparseJournalQuestion() {
+        // #631 shape: a rarely-asked question logged "yes" on 3 days and "no" on 2 days, out of
+        // 300 total outcome-days. The other 295 days must be excluded, not lumped into "without".
+        var outcome: [String: Double] = [:]
+        for i in 0..<300 { outcome["d\(i)"] = Double(60 + i % 10) }
+        let behaviorDays: Set<String> = ["d0", "d1", "d2"]
+        let askedDays: Set<String> = behaviorDays.union(["d3", "d4"])
+        let e = BehaviorInsights.effect(behaviorDays: behaviorDays, askedDays: askedDays,
+                                        outcomeByDay: outcome,
+                                        behavior: "Travelled in a car or train?", outcome: "Charge")!
+        XCTAssertEqual(e.nWith, 3)
+        XCTAssertEqual(e.nWithout, 2)   // NOT 297
     }
 
     // MARK: - significance flips
@@ -74,6 +131,7 @@ final class BehaviorInsightsTests: XCTestCase {
             "o1": 70, "o2": 71, "o3": 69, "o4": 70,
         ]
         let small = BehaviorInsights.effect(behaviorDays: ["w1", "w2", "w3", "w4"],
+                                            askedDays: Set(smallOutcome.keys),
                                             outcomeByDay: smallOutcome,
                                             behavior: "X", outcome: "Recovery")!
         XCTAssertLessThan(small.pApprox, 0.05)       // strong evidence numerically…
@@ -86,6 +144,7 @@ final class BehaviorInsightsTests: XCTestCase {
             "o1": 70, "o2": 71, "o3": 69, "o4": 70, "o5": 70,
         ]
         let big = BehaviorInsights.effect(behaviorDays: ["w1", "w2", "w3", "w4", "w5"],
+                                          askedDays: Set(bigOutcome.keys),
                                           outcomeByDay: bigOutcome,
                                           behavior: "X", outcome: "Recovery")!
         XCTAssertEqual(Swift.min(big.nWith, big.nWithout), 5)
@@ -99,6 +158,7 @@ final class BehaviorInsightsTests: XCTestCase {
             "o1": 64, "o2": 72, "o3": 61, "o4": 74, "o5": 67, "o6": 69,
         ]
         let e = BehaviorInsights.effect(behaviorDays: ["w1", "w2", "w3", "w4", "w5", "w6"],
+                                        askedDays: Set(outcome.keys),
                                         outcomeByDay: outcome,
                                         behavior: "X", outcome: "Recovery")!
         XCTAssertGreaterThan(e.pApprox, 0.05)    // no separation → weak evidence
@@ -119,8 +179,12 @@ final class BehaviorInsightsTests: XCTestCase {
         let weak: Set<String> = ["d1", "d7", "d2"]
         // Tiny-but-significant-impossible: 2 days only.
         let tiny: Set<String> = ["d3", "d9"]
+        let asked: [String: Set<String>] = [
+            "Strong": Set(outcome.keys), "Weak": Set(outcome.keys), "Tiny": Set(outcome.keys),
+        ]
 
         let ranked = BehaviorInsights.rank(behaviors: ["Strong": strong, "Weak": weak, "Tiny": tiny],
+                                           asked: asked,
                                            outcomeByDay: outcome, outcome: "Recovery")
         XCTAssertEqual(ranked.count, 3)
         XCTAssertEqual(ranked.first?.behavior, "Strong")   // significant + largest |d|
@@ -138,9 +202,23 @@ final class BehaviorInsightsTests: XCTestCase {
         let ranked = BehaviorInsights.rank(behaviors: [
             "AllDays": ["a", "b", "c", "d"],
             "Half": ["a", "b"],
+        ], asked: [
+            "AllDays": Set(outcome.keys),
+            "Half": Set(outcome.keys),
         ], outcomeByDay: outcome, outcome: "Recovery")
         XCTAssertEqual(ranked.count, 1)
         XCTAssertEqual(ranked.first?.behavior, "Half")
+    }
+
+    func testRankAskedDaysFallsBackToBehaviorDaysWhenMissing() {
+        // A behaviour missing from `asked` falls back to its own behaviorDays — i.e. only the
+        // "with" days count as asked, so there's no "without" group and the behaviour is dropped,
+        // rather than crashing or silently reproducing the old "everything else is without" bug.
+        let outcome: [String: Double] = ["a": 60, "b": 62, "c": 70, "d": 72]
+        let ranked = BehaviorInsights.rank(behaviors: ["Half": ["a", "b"]],
+                                           asked: [:],
+                                           outcomeByDay: outcome, outcome: "Recovery")
+        XCTAssertTrue(ranked.isEmpty)
     }
 
     // MARK: - sentence
@@ -153,6 +231,7 @@ final class BehaviorInsightsTests: XCTestCase {
             "o1": 78, "o2": 82, "o3": 80, "o4": 79, "o5": 81,   // mean 80
         ]
         let e = BehaviorInsights.effect(behaviorDays: ["w1", "w2", "w3", "w4", "w5"],
+                                        askedDays: Set(outcome.keys),
                                         outcomeByDay: outcome,
                                         behavior: "Alcohol", outcome: "Recovery")!
         let s = BehaviorInsights.sentence(e)
@@ -165,6 +244,7 @@ final class BehaviorInsightsTests: XCTestCase {
             "o1": 49, "o2": 51, "o3": 50,    // mean 50
         ]
         let e = BehaviorInsights.effect(behaviorDays: ["w1", "w2", "w3"],
+                                        askedDays: Set(outcome.keys),
                                         outcomeByDay: outcome,
                                         behavior: "Meditation", outcome: "Recovery")!
         let s = BehaviorInsights.sentence(e)
@@ -179,6 +259,7 @@ final class BehaviorInsightsTests: XCTestCase {
             "o1": 0, "o2": 0, "o3": 0,
         ]
         let e = BehaviorInsights.effect(behaviorDays: ["w1", "w2", "w3"],
+                                        askedDays: Set(outcome.keys),
                                         outcomeByDay: outcome,
                                         behavior: "X", outcome: "HRV")!
         XCTAssertNil(e.pctChange)

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/EffectRankerTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/EffectRankerTests.swift
@@ -36,8 +36,10 @@ final class EffectRankerTests: XCTestCase {
             let dip = 2 + 4 * i   // day-of-month of anchor+1 (2,6,10,14,18,22)
             outcome[ymd(2026, 6, dip)] = 50 + jitter(dip)
         }
+        let askedDays = Set(outcome.keys)   // reproduce old semantics: every outcome day was "asked"
 
         let out = EffectRanker.rank(behaviors: ["Alcohol": behaviorDays],
+                                    asked: ["Alcohol": askedDays],
                                     outcomeByDay: outcome, outcome: "Charge")
         let r = row(out, "Alcohol")
         XCTAssertNotNil(r)
@@ -52,18 +54,46 @@ final class EffectRankerTests: XCTestCase {
         // Lag 1 must dominate lag 0 and lag 2 in |cohensD|. Read each lag's effect directly via
         // the same internal alignment the engine uses.
         let d1 = abs(r!.effect.cohensD)
-        let d0 = abs(effectAtLag(behaviorDays, outcome, 0)!.cohensD)
-        let d2 = abs(effectAtLag(behaviorDays, outcome, 2)!.cohensD)
+        let d0 = abs(effectAtLag(behaviorDays, askedDays, outcome, 0)!.cohensD)
+        let d2 = abs(effectAtLag(behaviorDays, askedDays, outcome, 2)!.cohensD)
         XCTAssertGreaterThan(d1, d0)
         XCTAssertGreaterThan(d1, d2)
     }
 
     /// Test-only: the BehaviorEffect at a specific lag, via the engine's own shift alignment.
-    private func effectAtLag(_ behaviorDays: Set<String>, _ outcome: [String: Double],
-                             _ lag: Int) -> BehaviorEffect? {
+    private func effectAtLag(_ behaviorDays: Set<String>, _ askedDays: Set<String>,
+                             _ outcome: [String: Double], _ lag: Int) -> BehaviorEffect? {
         let shifted = EffectRanker.shiftedOutcome(outcome, byLag: lag)
-        return BehaviorInsights.effect(behaviorDays: behaviorDays, outcomeByDay: shifted,
+        return BehaviorInsights.effect(behaviorDays: behaviorDays, askedDays: askedDays,
+                                       outcomeByDay: shifted,
                                        behavior: "Alcohol", outcome: "Charge")
+    }
+
+    // MARK: - askedDays membership does not shift with the lag (#631)
+
+    /// `askedDays`/`behaviorDays` live in the fixed "behaviour day" keyspace; only `outcomeByDay`
+    /// gets re-keyed per lag. Outcome is defined for a full flat range so a shifted value always
+    /// exists, isolating whether askedDays membership itself is (incorrectly) being re-keyed.
+    func testAskedDaysNotShiftedAcrossLags() {
+        var outcome: [String: Double] = [:]
+        for d in 1...40 { outcome[ymd(2026, 6, d)] = 70 + jitter(d) }
+        // 5 spaced-out "yes" days and 5 spaced-out "no" days, far enough apart that no lag in
+        // {0,1,2} makes one resolve into the other.
+        var behaviorDays: Set<String> = []
+        var askedNo: Set<String> = []
+        for i in 0..<5 {
+            behaviorDays.insert(ymd(2026, 6, 1 + 6 * i))     // 1,7,13,19,25
+            askedNo.insert(ymd(2026, 6, 3 + 6 * i))          // 3,9,15,21,27
+        }
+        let askedDays = behaviorDays.union(askedNo)
+
+        for lag in EffectRanker.lagSet {
+            let shifted = EffectRanker.shiftedOutcome(outcome, byLag: lag)
+            let e = BehaviorInsights.effect(behaviorDays: behaviorDays, askedDays: askedDays,
+                                            outcomeByDay: shifted, behavior: "X", outcome: "Charge")!
+            XCTAssertEqual(e.nWith, 5, "lag \(lag)")
+            XCTAssertEqual(e.nWithout, 5, "lag \(lag)")   // must stay 5, not shift with the lag
+        }
     }
 
     // MARK: - Group gate suppresses thin behaviours
@@ -82,6 +112,7 @@ final class EffectRankerTests: XCTestCase {
         for d in 1...8 { outcome[ymd(2026, 7, d)] = 70 + jitter(d) }   // plenty of "without"
 
         let out = EffectRanker.rank(behaviors: ["Sparse": thin],
+                                    asked: ["Sparse": Set(outcome.keys)],
                                     outcomeByDay: outcome, outcome: "Charge")
         XCTAssertTrue(out.isEmpty)
     }
@@ -108,8 +139,10 @@ final class EffectRankerTests: XCTestCase {
         }
         // Shared "without" baseline at 70 (a block neither behaviour touches at any lag).
         for d in 10...20 { outcome[ymd(2026, 5, d)] = 70 + jitter(d) }
+        let askedDays = Set(outcome.keys)
 
         let out = EffectRanker.rank(behaviors: ["Big": big, "Small": small],
+                                    asked: ["Big": askedDays, "Small": askedDays],
                                     outcomeByDay: outcome, outcome: "Charge")
         XCTAssertEqual(out.map { $0.behavior }, ["Big", "Small"])   // |d| Big > Small
         XCTAssertEqual(row(out, "Big")!.lag, 0)                     // both are same-day effects

--- a/Strand/AI/AICoach.swift
+++ b/Strand/AI/AICoach.swift
@@ -563,12 +563,17 @@ final class AICoachEngine: ObservableObject {
         // 1. Strongest behaviour→outcome associations (EffectRanker over the journal × Charge).
         let entries = await repo.journalEntries()
         var byBehaviour: [String: Set<String>] = [:]
-        for e in entries where e.answeredYes { byBehaviour[e.question, default: []].insert(e.day) }
+        var byAskedBehaviour: [String: Set<String>] = [:]
+        for e in entries {
+            byAskedBehaviour[e.question, default: []].insert(e.day)
+            if e.answeredYes { byBehaviour[e.question, default: []].insert(e.day) }
+        }
         if !byBehaviour.isEmpty {
             let outcomeByDay = Dictionary(
                 repo.days.compactMap { d in d.recovery.map { (d.day, $0) } },
                 uniquingKeysWith: { _, last in last })
-            let ranked = EffectRanker.rank(behaviors: byBehaviour, outcomeByDay: outcomeByDay, outcome: "Charge")
+            let ranked = EffectRanker.rank(behaviors: byBehaviour, asked: byAskedBehaviour,
+                                           outcomeByDay: outcomeByDay, outcome: "Charge")
                 .filter { $0.effect.significant }
                 .prefix(3)
             if !ranked.isEmpty {

--- a/Strand/Screens/InsightsHubView.swift
+++ b/Strand/Screens/InsightsHubView.swift
@@ -546,6 +546,8 @@ final class InsightsHubViewModel: ObservableObject {
     // MARK: Loaded inputs (kept so the outcome segmented control can re-rank cheaply)
 
     private var behaviours: [String: Set<String>] = [:]
+    /// behaviour question → set of days it was actually asked/answered (yes OR no); see #631.
+    private var askedBehaviours: [String: Set<String>] = [:]
     private var outcomeByKey: [String: [String: Double]] = [:]
     private var currentOutcome: Outcome = .recovery
 
@@ -557,11 +559,14 @@ final class InsightsHubViewModel: ObservableObject {
     // MARK: Load
 
     func load(repo: Repository) async {
-        // Journal → behaviour → days (only "yes" answers count as the behaviour occurring).
+        // Journal → behaviour → days ("yes" days) + askedBehaviours (yes OR no days; #631 — a day
+        // never asked/answered must not silently count as "without").
         let entries = await repo.journalEntries()
         var byBehaviour: [String: Set<String>] = [:]
-        for e in entries where e.answeredYes {
-            byBehaviour[e.question, default: []].insert(e.day)
+        var byAskedBehaviour: [String: Set<String>] = [:]
+        for e in entries {
+            byAskedBehaviour[e.question, default: []].insert(e.day)
+            if e.answeredYes { byBehaviour[e.question, default: []].insert(e.day) }
         }
 
         // Outcome series: imported metricSeries ∪ the DailyMetric column fallback so an
@@ -611,6 +616,7 @@ final class InsightsHubViewModel: ObservableObject {
         }
 
         self.behaviours = byBehaviour
+        self.askedBehaviours = byAskedBehaviour
         self.outcomeByKey = byKey
         self.doseCards = cards
         self.loaded = true
@@ -622,6 +628,7 @@ final class InsightsHubViewModel: ObservableObject {
         currentOutcome = outcome
         let outcomeDays = outcomeByKey[outcome.key] ?? [:]
         ranked = EffectRanker.rank(behaviors: behaviours,
+                                   asked: askedBehaviours,
                                    outcomeByDay: outcomeDays,
                                    outcome: outcome.outcomeName)
     }

--- a/Strand/Screens/InsightsView.swift
+++ b/Strand/Screens/InsightsView.swift
@@ -40,6 +40,10 @@ private struct InsightsLoadKey: Equatable {
 /// the seq AND the dayKey still match (see `Repository.insightsLoadedSeq` / `insightsLoadedDayKey`).
 struct InsightsLoadCache {
     let behaviours: [String: Set<String>]
+    /// behaviour question → set of days it was actually asked/answered (yes OR no). Days outside
+    /// this set are excluded from both "with" and "without" — a missing journal answer is not an
+    /// implicit "no" (#631).
+    let askedBehaviours: [String: Set<String>]
     let importedQuestions: [String]
     let dayAnswers: [String: Bool]
     /// The journal day offset the `dayAnswers` were read for (0 = today, 1 = yesterday, -1 = tomorrow). The
@@ -152,6 +156,8 @@ struct InsightsView: View {
 
     /// behaviour question → set of days where it was answered yes.
     @State private var behaviours: [String: Set<String>] = [:]
+    /// behaviour question → set of days it was actually asked/answered (yes OR no); see #631.
+    @State private var askedBehaviours: [String: Set<String>] = [:]
     /// outcome key → [day: value].
     @State private var outcomeByKey: [String: [String: Double]] = [:]
     /// outcome key → ordered (day, value) series for correlations.
@@ -346,15 +352,18 @@ struct InsightsView: View {
             return
         }
 
-        // Journal → behaviours map (only "yes" answers count as the behaviour occurring).
-        // journalEntries() is the imported ∪ native union (native wins per day+question). A numeric
-        // log writes answeredYes=true too (#322), so a numeric item lands in the with/without split
-        // here unchanged, on top of the numeric series read below.
+        // Journal → behaviours map ("yes" days) + askedBehaviours (yes OR no days; #631 — a day
+        // never asked/answered must not silently count as "without"). journalEntries() is the
+        // imported ∪ native union (native wins per day+question). A numeric log writes
+        // answeredYes=true too (#322), so a numeric item lands in the with/without split here
+        // unchanged, on top of the numeric series read below.
         let entries = await repo.journalEntries()
         var byBehaviour: [String: Set<String>] = [:]
+        var byAskedBehaviour: [String: Set<String>] = [:]
         var numericByBehaviour: [String: [String: Double]] = [:]
-        for e in entries where e.answeredYes {
-            byBehaviour[e.question, default: []].insert(e.day)
+        for e in entries {
+            byAskedBehaviour[e.question, default: []].insert(e.day)
+            if e.answeredYes { byBehaviour[e.question, default: []].insert(e.day) }
         }
         // #322: per-question numeric series (question → [day: value]) for numeric journal items. A
         // numeric series is the same [day: value] shape a metric outcome is, so the effect ranker can
@@ -415,6 +424,7 @@ struct InsightsView: View {
 
         await MainActor.run {
             self.behaviours = byBehaviour
+            self.askedBehaviours = byAskedBehaviour
             self.importedQuestions = importedQs
             self.dayAnswers = nativeAnswers
             self.dayNumeric = nativeNumeric
@@ -432,6 +442,7 @@ struct InsightsView: View {
             // freshest read, a subsequent re-mount never restores stale data behind a journal toggle.
             self.repo.insightsCache = InsightsLoadCache(
                 behaviours: byBehaviour,
+                askedBehaviours: byAskedBehaviour,
                 importedQuestions: importedQs,
                 dayAnswers: nativeAnswers,
                 journalDayOffset: self.journalDayOffset,
@@ -450,6 +461,7 @@ struct InsightsView: View {
     @MainActor
     private func restoreFromCache(_ c: InsightsLoadCache) {
         behaviours = c.behaviours
+        askedBehaviours = c.askedBehaviours
         importedQuestions = c.importedQuestions
         dayAnswers = c.dayAnswers
         // Numeric journal rows are native-only (imported WHOOP rows never carry a numericValue), so the
@@ -516,6 +528,7 @@ struct InsightsView: View {
         let outcomeDays = outcomeByKey[outcome.key] ?? [:]
         ranked = BehaviorInsights.rank(
             behaviors: behaviours,
+            asked: askedBehaviours,
             outcomeByDay: outcomeDays,
             outcome: outcome.outcomeName
         )

--- a/android/app/src/main/java/com/noop/ai/AiCoach.kt
+++ b/android/app/src/main/java/com/noop/ai/AiCoach.kt
@@ -300,11 +300,12 @@ class AiCoach(private val repo: WhoopRepository) {
         val sb = StringBuilder()
 
         // --- Strongest associations on the user's own logged days (recovery as the outcome) ---
-        val behaviours = runCatching { journalBehaviours() }.getOrDefault(emptyMap())
+        val sets = runCatching { journalBehaviours() }.getOrDefault(JournalBehaviourSets(emptyMap(), emptyMap()))
+        val behaviours = sets.yes
         val days = runCatching { repo.daysMerged(deviceId) }.getOrDefault(emptyList())
         if (behaviours.isNotEmpty() && days.isNotEmpty()) {
             val recoveryByDay = days.mapNotNull { d -> d.recovery?.let { d.day to it } }.toMap()
-            val ranked = runCatching { EffectRanker.rank(behaviours, recoveryByDay, "Charge") }
+            val ranked = runCatching { EffectRanker.rank(behaviours, sets.asked, recoveryByDay, "Charge") }
                 .getOrDefault(emptyList())
                 .take(3)
             if (ranked.isNotEmpty()) {
@@ -333,16 +334,25 @@ class AiCoach(private val repo: WhoopRepository) {
         return sb.toString().trim().takeIf { it.isNotEmpty() }
     }
 
-    /** Behaviour → set of "yyyy-MM-dd" days it was logged "yes" (imported ∪ native), for EffectRanker. */
-    private suspend fun journalBehaviours(): Map<String, Set<String>> {
+    /** Behaviour → set of "yyyy-MM-dd" days it was logged "yes" ([yes]) and behaviour → set of days it
+     *  was actually asked/answered, yes OR no ([asked]) — see #631: a day never asked must not count
+     *  as "without". */
+    private data class JournalBehaviourSets(val yes: Map<String, Set<String>>, val asked: Map<String, Set<String>>)
+
+    /** Behaviour → days it was logged "yes"/asked (imported ∪ native), for EffectRanker. */
+    private suspend fun journalBehaviours(): JournalBehaviourSets {
         val imported = repo.journal(deviceId, "0000-01-01", "9999-12-31")
         val native = repo.journal(journalDeviceId, "0000-01-01", "9999-12-31")
         val byKey = LinkedHashMap<Pair<String, String>, JournalEntry>()
         for (e in imported) byKey[e.day to e.question] = e
         for (e in native) byKey[e.day to e.question] = e   // native wins on a collision
-        val out = HashMap<String, MutableSet<String>>()
-        for (e in byKey.values) if (e.answeredYes) out.getOrPut(e.question) { mutableSetOf() }.add(e.day)
-        return out.mapValues { it.value.toSet() }
+        val yes = HashMap<String, MutableSet<String>>()
+        val asked = HashMap<String, MutableSet<String>>()
+        for (e in byKey.values) {
+            asked.getOrPut(e.question) { mutableSetOf() }.add(e.day)
+            if (e.answeredYes) yes.getOrPut(e.question) { mutableSetOf() }.add(e.day)
+        }
+        return JournalBehaviourSets(yes.mapValues { it.value.toSet() }, asked.mapValues { it.value.toSet() })
     }
 
     /** The latest reading per Lab Book marker key (stored under the strap deviceId). */

--- a/android/app/src/main/java/com/noop/analytics/EffectRanker.kt
+++ b/android/app/src/main/java/com/noop/analytics/EffectRanker.kt
@@ -114,18 +114,24 @@ object EffectRanker {
      * best lag. Mirrors Swift's ordering on the surviving rows.
      *
      * @param behaviors per behaviour name, the SET of "yyyy-MM-dd" days it was logged (dose ≥ 1).
+     * @param asked per behaviour name, the SET of "yyyy-MM-dd" days it was actually asked/answered
+     *   (yes OR no). A day outside this set (and outside [behaviors]) counts in neither with nor
+     *   without — a missing journal answer is not an implicit "no" (#631). Falls back to the
+     *   behaviour's own days when a key is missing.
      * @param outcomeByDay the daily outcome series keyed "yyyy-MM-dd".
      * @param outcome the outcome label carried onto each RankedEffect.
      */
     fun rank(
         behaviors: Map<String, Set<String>>,
+        asked: Map<String, Set<String>>,
         outcomeByDay: Map<String, Double>,
         outcome: String,
     ): List<RankedEffect> {
         val rows = ArrayList<RankedEffect>()
         for (name in behaviors.keys.sorted()) {
             val days = behaviors.getValue(name)
-            val r = bestLag(days, outcomeByDay, name, outcome)
+            val askedDays = asked[name] ?: days
+            val r = bestLag(days, askedDays, outcomeByDay, name, outcome)
             if (r != null) rows.add(r)
         }
         return sorted(rows)
@@ -134,6 +140,7 @@ object EffectRanker {
     /** Find the best-lag RankedEffect for ONE behaviour against ONE outcome, or null. */
     fun bestLag(
         behaviorDays: Set<String>,
+        askedDays: Set<String>,
         outcomeByDay: Map<String, Double>,
         behavior: String,
         outcome: String,
@@ -142,7 +149,9 @@ object EffectRanker {
         var bestEffect: BehaviorEffect? = null
         for (lag in lagSet) {
             val shifted = shiftedOutcome(outcomeByDay, lag)
-            val e = effect(behaviorDays, shifted, behavior, outcome) ?: continue
+            // askedDays/behaviorDays already live in behaviour-day space — only the outcome
+            // series gets re-keyed per lag, never the asked/behaviour sets.
+            val e = effect(behaviorDays, askedDays, shifted, behavior, outcome) ?: continue
             if (minOf(e.nWith, e.nWithout) < minGroupForSignificance) continue
 
             val cur = bestEffect
@@ -183,11 +192,18 @@ object EffectRanker {
 
     /**
      * Compute the effect of [behavior] on [outcome]. Days are partitioned into "with"
-     * (day ∈ behaviorDays) and "without", restricted to days with an outcome value. Returns
-     * null unless both groups are non-empty AND there are ≥ 3 points total.
+     * (day ∈ behaviorDays) and "without" (day ∈ askedDays, day ∉ behaviorDays), restricted to
+     * days with an outcome value. A day never asked/answered (day ∉ behaviorDays ∪ askedDays)
+     * counts in NEITHER group — a missing journal answer is not an implicit "no" (#631).
+     *
+     * [behaviorDays] is expected to be a subset of [askedDays]; the check below is an OR so a
+     * "with" day is never dropped even if a caller's askedDays build has a gap.
+     *
+     * Returns null unless both groups are non-empty AND there are ≥ 3 points total.
      */
     internal fun effect(
         behaviorDays: Set<String>,
+        askedDays: Set<String>,
         outcomeByDay: Map<String, Double>,
         behavior: String,
         outcome: String,
@@ -195,6 +211,7 @@ object EffectRanker {
         val withVals = ArrayList<Double>()
         val withoutVals = ArrayList<Double>()
         for ((day, value) in outcomeByDay) {
+            if (!behaviorDays.contains(day) && !askedDays.contains(day)) continue
             if (behaviorDays.contains(day)) withVals.add(value) else withoutVals.add(value)
         }
 

--- a/android/app/src/main/java/com/noop/ui/InsightsHubScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/InsightsHubScreen.kt
@@ -546,6 +546,8 @@ internal class InsightsHubViewModel {
     data class Snapshot(
         val loaded: Boolean = false,
         val behaviours: Map<String, Set<String>> = emptyMap(),
+        /** behaviour question → set of days it was actually asked/answered (yes OR no); #631. */
+        val askedBehaviours: Map<String, Set<String>> = emptyMap(),
         val outcomeByKey: Map<String, Map<String, Double>> = emptyMap(),
         val doseCards: List<DoseCardData> = emptyList(),
     )
@@ -577,13 +579,19 @@ internal class InsightsHubViewModel {
     }
 
     suspend fun load(vm: AppViewModel, days: List<DailyMetric>) {
-        // Journal → behaviour → days (imported ∪ native, native wins; only "yes" counts).
+        // Journal → behaviour → days ("yes" days) + askedBehaviours (yes OR no days; #631 — a day
+        // never asked/answered must not silently count as "without"). imported ∪ native, native wins.
         val imported = vm.repo.journal("my-whoop", "0000-01-01", "9999-12-31")
         val native = vm.repo.journal(JOURNAL_DEVICE_ID, "0000-01-01", "9999-12-31")
         val entries = mergeJournalEntries(imported, native)
         val byBehaviour = HashMap<String, MutableSet<String>>()
-        for (e in entries) if (e.answeredYes) byBehaviour.getOrPut(e.question) { mutableSetOf() }.add(e.day)
+        val byAskedBehaviour = HashMap<String, MutableSet<String>>()
+        for (e in entries) {
+            byAskedBehaviour.getOrPut(e.question) { mutableSetOf() }.add(e.day)
+            if (e.answeredYes) byBehaviour.getOrPut(e.question) { mutableSetOf() }.add(e.day)
+        }
         val behaviours = byBehaviour.mapValues { it.value.toSet() }
+        val askedBehaviours = byAskedBehaviour.mapValues { it.value.toSet() }
 
         // Outcome series straight off the cached DailyMetric rows (the guaranteed Android source).
         val outcomeByKey = HashMap<String, Map<String, Double>>()
@@ -615,6 +623,7 @@ internal class InsightsHubViewModel {
         _state.value = Snapshot(
             loaded = true,
             behaviours = behaviours,
+            askedBehaviours = askedBehaviours,
             outcomeByKey = outcomeByKey,
             doseCards = doseCards,
         )
@@ -624,7 +633,7 @@ internal class InsightsHubViewModel {
     fun rankFor(snapshot: Snapshot, outcome: InsightsOutcome): List<RankedEffect> {
         if (!snapshot.loaded) return emptyList()
         val outcomeDays = snapshot.outcomeByKey[outcome.key] ?: emptyMap()
-        return EffectRanker.rank(snapshot.behaviours, outcomeDays, outcome.outcomeName)
+        return EffectRanker.rank(snapshot.behaviours, snapshot.askedBehaviours, outcomeDays, outcome.outcomeName)
     }
 }
 

--- a/android/app/src/main/java/com/noop/ui/InsightsScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/InsightsScreen.kt
@@ -153,6 +153,9 @@ private data class Relationship(
 private data class InsightModel(
     /** behaviour question → set of days it was answered "yes". */
     val behaviours: Map<String, Set<String>>,
+    /** behaviour question → set of days it was actually asked/answered (yes OR no); #631 — a day
+     *  never asked/answered must not silently count as "without". */
+    val askedBehaviours: Map<String, Set<String>> = emptyMap(),
     /** day → value, per outcome. */
     val outcomeByDay: Map<Outcome, Map<String, Double>>,
     /** ordered (day, value) per outcome for correlations. */
@@ -184,6 +187,9 @@ fun InsightsScreen(vm: AppViewModel, onOpenInsightsHub: () -> Unit = {}) {
     // rows (native wins per (day, question)). Keyed on journalSeq so the logging card's saves and
     // clears refresh the effects immediately; re-loaded too when the cached days change underneath.
     var behaviours by remember { mutableStateOf<Map<String, Set<String>>>(emptyMap()) }
+    // behaviour question → set of days it was actually asked/answered (yes OR no); see #631 — a
+    // day never asked must not silently count as "without".
+    var askedBehaviours by remember { mutableStateOf<Map<String, Set<String>>>(emptyMap()) }
     // #322: numeric journal item (question) -> [day: value]. A numeric journal series is a daily series
     // the effect ranker consumes exactly like a metric series (EffectRanker.effect already takes a
     // Map<String, Double> outcome), so "caffeine mg" / "alcohol units" can rank as a numeric outcome.
@@ -233,15 +239,20 @@ fun InsightsScreen(vm: AppViewModel, onOpenInsightsHub: () -> Unit = {}) {
         val native = vm.repo.journal(JOURNAL_DEVICE_ID, "0000-01-01", "9999-12-31")
         val entries = mergeJournalEntries(imported, native)
         val byBehaviour = mutableMapOf<String, MutableSet<String>>()
+        // #631: track every day a question was asked/answered (yes OR no), not just "yes" days,
+        // so a never-answered day doesn't silently count as "without" in rankEffects.
+        val byAskedBehaviour = mutableMapOf<String, MutableSet<String>>()
         // #322: a numeric log writes answeredYes=true too, so a numeric item lands in the with/without
         // split here unchanged; its per-day value is captured separately for a numeric series the effect
         // ranker can consume like any metric outcome (dose-response lands in the v5 hub). Additive.
         val numericByBehaviour = mutableMapOf<String, MutableMap<String, Double>>()
         for (e in entries) {
+            byAskedBehaviour.getOrPut(e.question) { mutableSetOf() }.add(e.day)
             if (e.answeredYes) byBehaviour.getOrPut(e.question) { mutableSetOf() }.add(e.day)
             e.numericValue?.let { v -> numericByBehaviour.getOrPut(e.question) { mutableMapOf() }[e.day] = v }
         }
         behaviours = byBehaviour.mapValues { it.value.toSet() }
+        askedBehaviours = byAskedBehaviour.mapValues { it.value.toSet() }
         numericJournalSeries = numericByBehaviour.mapValues { it.value.toMap() }
         importedQuestions = imported.map { it.question }.distinct()
         val key = journalDayKey(dayOffset)
@@ -290,7 +301,9 @@ fun InsightsScreen(vm: AppViewModel, onOpenInsightsHub: () -> Unit = {}) {
 
     // Build outcome day-maps + ordered series off the cached daily metrics. Cheap and
     // recomputed only when `days` changes (not on every recomposition).
-    val model = remember(days, behaviours, numericJournalSeries) { buildModel(days, behaviours, numericJournalSeries) }
+    val model = remember(days, behaviours, askedBehaviours, numericJournalSeries) {
+        buildModel(days, behaviours, askedBehaviours, numericJournalSeries)
+    }
 
     // Ranked behaviour effects for the current outcome (recomputed when outcome/data change).
     val ranked = remember(model, outcome) { rankEffects(model, outcome) }
@@ -1585,6 +1598,7 @@ private fun RBar(r: Double, color: Color) {
 private fun buildModel(
     days: List<DailyMetric>,
     behaviours: Map<String, Set<String>>,
+    askedBehaviours: Map<String, Set<String>> = emptyMap(),
     numericJournalSeries: Map<String, Map<String, Double>> = emptyMap(),
 ): InsightModel {
     val outcomeByDay = mutableMapOf<Outcome, Map<String, Double>>()
@@ -1595,7 +1609,7 @@ private fun buildModel(
         seriesByOutcome[o] = series
         outcomeByDay[o] = series.toMap()
     }
-    return InsightModel(behaviours, outcomeByDay, seriesByOutcome, numericJournalSeries)
+    return InsightModel(behaviours, askedBehaviours, outcomeByDay, seriesByOutcome, numericJournalSeries)
 }
 
 /** Rank behaviour effects for one outcome by |Cohen's d|, significant first. */
@@ -1604,9 +1618,14 @@ private fun rankEffects(model: InsightModel, outcome: Outcome): List<BehaviorEff
     if (outcomeDays.isEmpty()) return emptyList()
 
     val effects = model.behaviours.mapNotNull { (behaviour, yesDays) ->
+        // #631: a day never asked/answered (∉ yesDays ∪ askedDays) counts in NEITHER group — a
+        // missing journal answer is not an implicit "no". Falls back to yesDays when a behaviour
+        // is missing from askedBehaviours, so a "yes" day is never dropped.
+        val askedDays = model.askedBehaviours[behaviour] ?: yesDays
         val with = mutableListOf<Double>()
         val without = mutableListOf<Double>()
         for ((day, value) in outcomeDays) {
+            if (day !in yesDays && day !in askedDays) continue
             if (day in yesDays) with.add(value) else without.add(value)
         }
         // Need both groups to compare; require ≥2 each so a mean/SD is meaningful.

--- a/android/app/src/test/java/com/noop/analytics/EffectRankerTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/EffectRankerTest.kt
@@ -24,8 +24,8 @@ class EffectRankerTest {
     private fun jitter(dayOfMonth: Int): Double = ((dayOfMonth * 7) % 5 - 2).toDouble()
 
     /** Test-only: the BehaviorEffect at a specific lag, via the engine's own shift alignment. */
-    private fun effectAtLag(behaviorDays: Set<String>, outcome: Map<String, Double>, lag: Int) =
-        EffectRanker.effect(behaviorDays, EffectRanker.shiftedOutcome(outcome, lag), "Alcohol", "Charge")
+    private fun effectAtLag(behaviorDays: Set<String>, askedDays: Set<String>, outcome: Map<String, Double>, lag: Int) =
+        EffectRanker.effect(behaviorDays, askedDays, EffectRanker.shiftedOutcome(outcome, lag), "Alcohol", "Charge")
 
     // Planted lag-1 effect is found at L=1 and beats L=0/L=2
 
@@ -42,8 +42,9 @@ class EffectRankerTest {
             val dip = 2 + 4 * i
             outcome[ymd(2026, 6, dip)] = 50.0 + jitter(dip)
         }
+        val askedDays = outcome.keys.toSet()   // reproduce old semantics: every outcome day was "asked"
 
-        val out = EffectRanker.rank(mapOf("Alcohol" to behaviorDays), outcome, "Charge")
+        val out = EffectRanker.rank(mapOf("Alcohol" to behaviorDays), mapOf("Alcohol" to askedDays), outcome, "Charge")
         val r = row(out, "Alcohol")
         assertNotNull(r)
         assertEquals(1, r!!.lag)
@@ -54,10 +55,77 @@ class EffectRankerTest {
         assertTrue(r.effect.meanWithout > 65)
 
         val d1 = abs(r.effect.cohensD)
-        val d0 = abs(effectAtLag(behaviorDays, outcome, 0)!!.cohensD)
-        val d2 = abs(effectAtLag(behaviorDays, outcome, 2)!!.cohensD)
+        val d0 = abs(effectAtLag(behaviorDays, askedDays, outcome, 0)!!.cohensD)
+        val d2 = abs(effectAtLag(behaviorDays, askedDays, outcome, 2)!!.cohensD)
         assertTrue(d1 > d0)
         assertTrue(d1 > d2)
+    }
+
+    // askedDays membership does not shift with the lag (#631)
+
+    @Test
+    fun askedDaysNotShiftedAcrossLags() {
+        val outcome = HashMap<String, Double>()
+        for (d in 1..40) outcome[ymd(2026, 6, d)] = 70.0 + jitter(d)
+        val behaviorDays = HashSet<String>()
+        val askedNo = HashSet<String>()
+        for (i in 0 until 5) {
+            behaviorDays.add(ymd(2026, 6, 1 + 6 * i))     // 1,7,13,19,25
+            askedNo.add(ymd(2026, 6, 3 + 6 * i))          // 3,9,15,21,27
+        }
+        val askedDays = behaviorDays + askedNo
+
+        for (lag in EffectRanker.lagSet) {
+            val shifted = EffectRanker.shiftedOutcome(outcome, lag)
+            val e = EffectRanker.effect(behaviorDays, askedDays, shifted, "X", "Charge")!!
+            assertEquals("lag $lag", 5, e.nWith)
+            assertEquals("lag $lag", 5, e.nWithout)   // must stay 5, not shift with the lag
+        }
+    }
+
+    // effect() partition — never-asked days (#631: a missing journal answer is not an implicit "no")
+
+    @Test
+    fun effectExcludesUnaskedDaysFromBothGroups() {
+        // "z" has an outcome value but was never asked (not in behaviorDays or askedDays) →
+        // dropped entirely, not counted as "without".
+        val outcome = mapOf("a" to 60.0, "b" to 62.0, "c" to 70.0, "d" to 72.0, "z" to 65.0)
+        val e = EffectRanker.effect(setOf("a", "b"), setOf("a", "b", "c", "d"), outcome, "X", "Recovery")!!
+        assertEquals(2, e.nWith)      // a, b
+        assertEquals(2, e.nWithout)   // c, d — "z" excluded, not counted as without
+    }
+
+    @Test
+    fun effectAskedNoStillCountsAsWithout() {
+        // A day that WAS asked and explicitly answered "no" still counts as "without" — the fix
+        // only excludes NEVER-asked days.
+        val outcome = mapOf("a" to 60.0, "b" to 61.0, "c" to 70.0, "d" to 71.0, "e" to 72.0)
+        val e = EffectRanker.effect(setOf("a", "b"), setOf("a", "b", "c", "d", "e"), outcome, "X", "Recovery")!!
+        assertEquals(2, e.nWith)
+        assertEquals(3, e.nWithout)
+    }
+
+    @Test
+    fun effectBehaviorDayNotInAskedStillCountsAsWith() {
+        // Defensive OR: a "yes" day missing from askedDays (a caller build gap) is never dropped
+        // from "with".
+        val outcome = mapOf("a" to 80.0, "b" to 60.0, "c" to 61.0)
+        val e = EffectRanker.effect(setOf("a"), setOf("b", "c"), outcome, "X", "Recovery")!!
+        assertEquals(1, e.nWith)      // "a" still counted despite the askedDays gap
+        assertEquals(2, e.nWithout)
+    }
+
+    @Test
+    fun effectRealisticSparseJournalQuestion() {
+        // #631 shape: a rarely-asked question logged "yes" on 3 days and "no" on 2 days, out of
+        // 300 total outcome-days. The other 295 days must be excluded, not lumped into "without".
+        val outcome = HashMap<String, Double>()
+        for (i in 0 until 300) outcome["d$i"] = (60 + i % 10).toDouble()
+        val behaviorDays = setOf("d0", "d1", "d2")
+        val askedDays = behaviorDays + setOf("d3", "d4")
+        val e = EffectRanker.effect(behaviorDays, askedDays, outcome, "Travelled in a car or train?", "Charge")!!
+        assertEquals(3, e.nWith)
+        assertEquals(2, e.nWithout)   // NOT 297
     }
 
     // Group gate suppresses thin behaviours
@@ -74,7 +142,7 @@ class EffectRankerTest {
         }
         for (d in 1..8) outcome[ymd(2026, 7, d)] = 70.0 + jitter(d)
 
-        val out = EffectRanker.rank(mapOf("Sparse" to thin), outcome, "Charge")
+        val out = EffectRanker.rank(mapOf("Sparse" to thin), mapOf("Sparse" to outcome.keys.toSet()), outcome, "Charge")
         assertTrue(out.isEmpty())
     }
 
@@ -96,8 +164,13 @@ class EffectRankerTest {
             outcome[day] = 66.0 + jitter(d)
         }
         for (d in 10..20) outcome[ymd(2026, 5, d)] = 70.0 + jitter(d)
+        val askedDays = outcome.keys.toSet()
 
-        val out = EffectRanker.rank(mapOf("Big" to big, "Small" to small), outcome, "Charge")
+        val out = EffectRanker.rank(
+            mapOf("Big" to big, "Small" to small),
+            mapOf("Big" to askedDays, "Small" to askedDays),
+            outcome, "Charge",
+        )
         assertEquals(listOf("Big", "Small"), out.map { it.behavior })
         assertEquals(0, row(out, "Big")!!.lag)
         assertEquals(0, row(out, "Small")!!.lag)


### PR DESCRIPTION
## Summary

Standalone fix, split off after [review discussion](https://github.com/ryanbr/noop/pull/682#pullrequestreview) on this PR — **does not fully resolve #631** (see below), but addresses a real, separate bug in the same area.

The "Behaviour Effects" with/without split (`BehaviorInsights.effect` /
`EffectRanker`, both platforms) partitioned every outcome-day into "with" or "without"
based solely on whether a journal question was answered "yes" — a day it was never
asked/answered fell into "without" right alongside a genuine "no" answer. For a rarely
logged question this makes "without" wildly outnumber real "no" days. A screenshot
attached to #631 shows exactly this: `with n=3` vs `without n=305` for a question asked
on only a handful of days — the 305 are almost all "never answered", not "no".

**This is not the #631 root cause.** bartmuskala confirmed (in the PR comments) that
he answered every question directly for 300+ days and imported answers were still all
mislabeled, while native logging is fine — an import-specific symptom this
source-agnostic partition fix can't explain. #631 stays open for that; current lead is
a missing Dutch locale entry in the CSV header/value alias tables (`CsvParser.kt` /
`CSVParsing.swift`), pending confirmation from the reporter's actual export.

The earlier #136 fix only corrected which *day* a journal entry lands on (onset evening
→ wake day); it never touched this with/without partition, so the underlying mislabeling
survived independently of this bug.

## Fix

Thread an `askedDays`/`asked` set alongside the existing "yes" set through the effect
computation, so a day only counts in `with` or `without` when it was actually
answered (yes or no) — a never-asked day is now excluded from both groups, on both
platforms:

- Swift core: `BehaviorInsights.effect`/`.rank` (`Packages/StrandAnalytics`) and
  `EffectRanker.bestLag`/`.rank`.
- Kotlin core: `com.noop.analytics.EffectRanker.effect`/`.bestLag`/`.rank` (the
  byte-identical port), plus the separate, non-shared partition logic still living
  inline in `InsightsScreen.kt` (the older Insights tab never called the shared
  `EffectRanker`).
- All 6 call sites that build the behaviour-days maps (3 per platform: the Insights
  tab, the v5 Insights Hub, and the AI coach) now build an "asked" set in the same
  loop, no extra DB query.

The partition change is additive/defensive: `behaviorDays` OR `askedDays` membership
gates a day into the comparison, so a "yes" day is never dropped even if a caller's
`askedDays` build has a gap.

Out of scope (separate, unrelated, and less-verified issue — flagging for a future
PR rather than bundling): `Strand/Data/WhoopImporter.swift:156` does an exact-match
`.lowercased() == "true"` when parsing the imported CSV's yes/no column, which would
mis-parse any other real-world spelling (e.g. "Yes"/"1") of a positive answer. It's
Swift-only (Android's `parseYesNo` already accepts "yes"/"1"/"y") and unrelated to
this partition bug.

## Test plan

- [x] `swift test` in `Packages/StrandAnalytics` — full suite (1113 tests) passes,
  including new/migrated `BehaviorInsightsTests` and `EffectRankerTests` cases
  covering: a never-asked day excluded from both groups, an asked-"no" day still
  counting as without, the defensive OR-gate, a realistic sparse-question shape
  matching the #631 screenshot (asked on 5/300 days), and `askedDays` staying
  un-shifted across the lag search.
- [x] `./gradlew testFullDebugUnitTest` — full Android unit suite (2866 tests)
  passes, including the mirrored `EffectRankerTest` cases.
- [x] `./gradlew compileFullDebugKotlin` — Android app module compiles.
- [x] `xcodegen generate && xcodebuild -scheme Strand -destination 'platform=macOS'
  CODE_SIGNING_ALLOWED=NO build` — macOS app target (which the changed
  `InsightsView.swift`/`InsightsHubView.swift`/`AICoach.swift` live under, not
  covered by `swift-packages.yml`) builds clean.
- [ ] Not tested on-device/in a running app (no strap session this pass) — the
  fix is pure in-memory analytics over already-persisted journal data, no
  migration/schema/backup involved.