### PR TITLE
Don't show the Sleep journal reminder once today's journal is logged (#684)

### DIFF
--- a/android/app/src/main/java/com/noop/ui/SleepScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/SleepScreen.kt
@@ -283,6 +283,13 @@ fun SleepScreen(
         val hoursAgo = (nowS - latestEnd) / 3600.0
         if (hoursAgo in 0.0..12.0) {
             val today = LocalDate.now().toString()
+            // #684: don't nudge when today's journal is already logged — e.g. via the Today card (#656),
+            // which never sets KEY_LAST_JOURNAL_PROMPT, so the once-per-day dedup alone would still pop
+            // this sheet. Reuse the SAME completion signal the Today card uses (repo.journal for today).
+            val loggedToday = runCatching {
+                vm.repo.journal(JOURNAL_DEVICE_ID, today, today).any { it.day == today }
+            }.getOrDefault(false)
+            if (loggedToday) return@LaunchedEffect
             val prefs = NoopPrefs.of(context)
             val lastPrompted = prefs.getString(NoopPrefs.KEY_LAST_JOURNAL_PROMPT, "")
             if (lastPrompted != today) {


### PR DESCRIPTION
Fixes #684.

## Bug
The Sleep screen's morning journal nudge (`SleepScreen.kt`, PR #260) pops when: the reminder toggle is on (#627), the latest night ended within 12h, and it hasn't been shown today (`KEY_LAST_JOURNAL_PROMPT`). **It never checks whether the journal is already completed.** Logging via the persistent Today card (#656) doesn't set `KEY_LAST_JOURNAL_PROMPT`, so opening the Sleep page still popped the 'Good morning, log your journal' sheet after the user had already logged — bartmuskala's exact repro.

## Fix
Add a completion gate to the sheet's `LaunchedEffect`, reusing the **same** signal the Today card uses (`repo.journal(JOURNAL_DEVICE_ID, today, today)`). If today is logged, return early — no sheet. The existing once-per-day dedup key stays, so a 'maybe later' still isn't re-nagged the same day.

This is the reporter's preferred option 1 ('only show when not completed') rather than option 2 (remove entirely) — the maintainer deliberately kept both the card and the sheet under one shared toggle (#627), so gating on completion preserves the intent.

## Scope
Android-only. iOS `SleepView` has no #260 morning sheet — the journal nudge there lives only in the Today card (`LiquidTodayView`/`TodayView`), so no parity change is owed.

## Verification
`./gradlew compileFullDebugKotlin` ✓. UI gate (LaunchedEffect → modal), not unit-testable; it reuses the completion query `JournalReminderCard` already runs, so no new test. On-device: complete the journal via the Today card, open Sleep → sheet no longer pops.

Reported-by: bartmuskala