### PR TITLE
Sleep tab: debt in h+m, true hours-vs-needed %, and dates on chart tap (#691 items 1, 3, 4)

### DIFF
--- a/android/app/src/main/java/com/noop/ui/Charts.kt
+++ b/android/app/src/main/java/com/noop/ui/Charts.kt
@@ -510,8 +510,16 @@ fun BarChart(
     modifier: Modifier,
     color: Color = Palette.accent,
     selectionEnabled: Boolean = false,
+    // Optional per-point display labels index-aligned with [values]; when supplied, a tap shows
+    // "<label> · <value>" (e.g. "16 Jul · 87") instead of the bare value — parity with LineChart (#691).
+    selectionLabels: List<String>? = null,
 ) {
     val cleanValues = remember(values) { values.map { if (it.isFinite() && it > 0.0) it else 0.0 } }
+    // cleanValues ZEROES (never drops) non-finite bars, so indices stay aligned with [values] and the
+    // labels only need a size match — null when absent/mismatched so selection falls back to value-only.
+    val cleanSelectionLabels = remember(values, selectionLabels) {
+        if (selectionLabels == null || selectionLabels.size != values.size) null else selectionLabels
+    }
     var selectedIndex by remember(cleanValues) { mutableIntStateOf(-1) }
     // Pre-laid value-label Paint, remembered rather than allocated inside the draw block (the old code
     // built a fresh android.graphics.Paint every draw). Keyed on color so it tracks a tint change.
@@ -609,7 +617,14 @@ fun BarChart(
                         }
                         if (selectionEnabled && selectedIndex in clean.indices) {
                             drawContext.canvas.nativeCanvas.apply {
-                                drawText(formatLineValue(clean[selectedIndex]), 8f, 32f, barLabelPaint)
+                                drawText(
+                                    lineChartSelectionLabel(
+                                        value = clean[selectedIndex],
+                                        formatValue = null,
+                                        pointLabel = cleanSelectionLabels?.getOrNull(selectedIndex),
+                                    ),
+                                    8f, 32f, barLabelPaint,
+                                )
                             }
                         }
                     }

--- a/android/app/src/main/java/com/noop/ui/SleepScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/SleepScreen.kt
@@ -2681,14 +2681,16 @@ private fun DurationTrend(m: SleepModel) {
 
         ChartCard(
             title = uiString(R.string.l10n_sleep_screen_sleep_debt_3aec7d9c),
-            subtitle = "Hours of sleep debt per day",
-            trailing = m.trendDebtHours.lastOrNull()?.let { String.format(Locale.US, "%.1f h", it) },
+            subtitle = "Sleep debt per day",
+            // #691: sleep debt is usually well under an hour, so decimal hours ("0.6h") reads badly —
+            // show hours+minutes. trendDebtHours is in hours; durationText takes minutes.
+            trailing = m.trendDebtHours.lastOrNull()?.let { durationText(it * 60.0) },
             tint = Palette.restColor,
             footer = {
                 ChartFooter(
                     listOf(
-                        "Avg" to (m.trendDebtHours.averageOrNull()?.let { String.format(Locale.US, "%.1f h", it) } ?: "â€”"),
-                        "Max" to (m.trendDebtHours.maxOrNull()?.let { String.format(Locale.US, "%.1f h", it) } ?: "â€”"),
+                        "Avg" to (m.trendDebtHours.averageOrNull()?.let { durationText(it * 60.0) } ?: "â€”"),
+                        "Max" to (m.trendDebtHours.maxOrNull()?.let { durationText(it * 60.0) } ?: "â€”"),
                         "Days" to "${m.trendDebtHours.size}",
                     ),
                 )
@@ -3004,7 +3006,10 @@ internal fun HoursVsNeededCard(m: SleepModel) {
     val sleptH = m.trendHours.lastOrNull() ?: (m.stages.asleep / 60.0)
     val neededH = (m.trendNeedHours.lastOrNull() ?: 8.0)
     val debtH = m.trendDebtHours.lastOrNull() ?: 0.0
-    val score = (sleptH / neededH * 100.0).coerceIn(0.0, 100.0)
+    // #691: show the TRUE percentage (e.g. 104% when you slept past your need) instead of a capped
+    // "100%" that's indistinguishable from exactly meeting it. The progress-bar fill below stays
+    // clamped to 1.0 (it can't overfill); only the displayed number is uncapped.
+    val score = (sleptH / neededH * 100.0).coerceAtLeast(0.0)
     val trendArrow = if (m.trendHours.size >= 2) {
         val delta = m.trendHours.last() - m.trendHours[m.trendHours.lastIndex - 1]
         when {
@@ -3070,7 +3075,7 @@ internal fun HoursVsNeededCard(m: SleepModel) {
                 listOf(
                     "Slept" to String.format(Locale.US, "%.1f h", sleptH),
                     "Needed" to String.format(Locale.US, "%.1f h", neededH),
-                    "Debt" to if (debtH > 0.05) String.format(Locale.US, "%.1f h", debtH) else "None",
+                    "Debt" to if (debtH > 0.05) durationText(debtH * 60.0) else "None",   // #691: h+m, not "0.6 h"
                 ).forEach { (lbl, v) ->
                     Column(modifier = Modifier.weight(1f)) {
                         Overline(lbl, color = Palette.textTertiary)
@@ -3288,7 +3293,7 @@ private fun sleepMetricSpec(key: String): SleepMetricSpec = when (key) {
     "hours_vs_needed" -> SleepMetricSpec("Hours vs Needed", "%", Palette.restColor) { "${it.roundToInt()}" }
     "restorative"     -> SleepMetricSpec("Restorative", "%", Palette.sleepREM) { "${it.roundToInt()}" }
     "respiratory"     -> SleepMetricSpec("Respiratory Rate", "rpm", Palette.metricPurple) { String.format(Locale.US, "%.1f", it) }
-    "sleep_debt"      -> SleepMetricSpec("Sleep Debt", "h", Palette.metricRose) { String.format(Locale.US, "%.1f", it) }
+    "sleep_debt"      -> SleepMetricSpec("Sleep Debt", "min", Palette.metricRose) { "${it.roundToInt()}" }   // #691: minutes, not decimal hours
     else              -> SleepMetricSpec(key, "", Palette.accent) { "${it.roundToInt()}" }
 }
 
@@ -3320,7 +3325,7 @@ private fun buildSleepMetricPoints(days: List<DailyMetric>, key: String): List<P
                 if (sl > 0.0) (dp + rm) / sl * 100.0 else null
             }
             "respiratory" -> d.respRateBpm
-            "sleep_debt"  -> d.totalSleepMin?.let { max(0.0, needMin - it) / 60.0 }
+            "sleep_debt"  -> d.totalSleepMin?.let { max(0.0, needMin - it) }   // #691: minutes (spec unit "min")
             else          -> null
         }
         v?.takeIf { it.isFinite() }?.let { d.day to it }

--- a/android/app/src/main/java/com/noop/ui/SleepScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/SleepScreen.kt
@@ -2671,6 +2671,9 @@ private fun DurationTrend(m: SleepModel) {
                             .semantics { contentDescription = uiString(R.string.l10n_sleep_screen_sleep_hours_trend_chart_a6fbc46d) },
                         color = Palette.restColor,
                         selectionEnabled = true,
+                        // #691: on tap, show the DATE alongside the value (the shared chart's tooltip),
+                        // matching the other trend graphs. trendDates is index-aligned with the values.
+                        selectionLabels = m.trendDates.map(::shortDayLabel),
                     )
                     DateAxisRow(m.trendDates)
                 }
@@ -2704,6 +2707,7 @@ private fun DurationTrend(m: SleepModel) {
                             .semantics { contentDescription = uiString(R.string.l10n_sleep_screen_sleep_debt_trend_chart_9e178776) },
                         color = Palette.metricRose,
                         selectionEnabled = true,
+                        selectionLabels = m.trendDates.map(::shortDayLabel),   // #691: hover shows date + value
                     )
                     DateAxisRow(m.trendDates)
                 }
@@ -3425,6 +3429,7 @@ private fun SleepMetricDetailSheetContent(vm: AppViewModel, key: String) {
                     color = spec.color,
                     fill = true,
                     selectionEnabled = true,
+                    selectionLabels = filteredPoints.map { shortDayLabel(it.first) },   // #691: hover shows date + value
                 )
             }
             Row(modifier = Modifier.fillMaxWidth()) {


### PR DESCRIPTION
Addresses items **1, 3, and 4** of #691 (bartmuskala) — the Sleep-tab *display* fixes. All three bring Android in line with what iOS already does. (Item **2**, the consistency divergence, is deliberately **not** here: unifying the consistency source re-scores Rest — consistency is a 0.10-weight input — so it needs its own change with Swift parity + validation, not a display PR.)

## Item 1 — sleep debt as h+m, not decimal hours
Debt was `%.1f h` ("0.6 h") in the debt trend card, the Hours-vs-Needed footer, and the metric-detail sheet. Debt is usually under an hour, so decimal hours reads badly. Now **h+m** via `durationText` ("36m" / "1h 30m"); the detail sheet plots **minutes**. Hours-slept/needed stay decimal (conventional).

## Item 3 — show the date on chart tap
The Sleep trend charts (hours, debt) and the metric-detail chart had `selectionEnabled` but passed no labels, so a tap showed the value with **no date**. Gave `BarChart` the same optional `selectionLabels` `LineChart` already has (backward-compatible — existing callers unaffected), and passed the per-night dates, so a tap now reads **"16 Jul · <value>"** like the other trend graphs.

## Item 4 — show the true % (104%), not a capped "100%"
`HoursVsNeededCard` clamped its displayed score to 100, so sleeping past your need showed a flat "100%". Uncapped the **number** (shows e.g. 104%); the progress-bar **fill** stays clamped so it can't overfill.

## Parity
iOS already: shows debt via `durationText`, the hours-vs-needed value uncapped, and dates on chart selection (SwiftUI Charts). So this is Android catching up — **no Swift change**, and it removes real Android↔iOS divergences.

## Verification
`compileFullDebugKotlin` + `com.noop.ui` unit tests pass. Display-only; no analytics/stored-data/strings.xml/migrations touched. `BarChart` gains an optional param (null default), so no existing chart changes behavior.

Item **2** (consistency divergence — a #674-class canonical-source decision) is tracked for a separate PR.