### PR TITLE
Add read-only GET_BODY_LOCATION_AND_STATUS (0x54) probe (#690)

### DIFF
--- a/Packages/WhoopProtocol/Sources/WhoopProtocol/BodyLocationProbe.swift
+++ b/Packages/WhoopProtocol/Sources/WhoopProtocol/BodyLocationProbe.swift
@@ -1,0 +1,152 @@
+import Foundation
+
+/// #690: format a `GET_BODY_LOCATION_AND_STATUS` (84 / 0x54) COMMAND_RESPONSE into a clean, readable,
+/// copyable report — a verdict, the full raw hex on one line, an offset-labelled payload hex grid, and the
+/// four decoded fields (revision / location + enum label / confidence / status). Pure + deterministic, so
+/// it's unit-tested without a strap.
+///
+/// READ-ONLY diagnostic: it never changes wear detection, sleep gating, or scoring. Unknown `location`
+/// values (including the gap at 6) fall through to a raw label, and `confidence`/`status` are always kept
+/// raw — their semantics aren't established, so labelling them would be a guess presented as fact.
+///
+/// Swift twin of the Android `WhoopBleClient.formatBodyLocationProbe`; lives in the pure `WhoopProtocol`
+/// package (like `ExtendedBatteryProbe`) so `swift test` covers it on every CI run, and the output text is
+/// byte-identical to the Kotlin formatter.
+///
+/// Protocol facts — the 0x54 command number, the 4-byte `revision/location/confidence/status` response
+/// layout, and the location enum — are reverse-engineered from the WHOOP app (via the goose reference set)
+/// and reimplemented here in NOOP's own code: facts, not copied expression (see ATTRIBUTION.md).
+public enum BodyLocationProbe {
+
+    /// Returns the display text and the payload hex to persist for the next capture's diff (nil when there
+    /// is no decodable payload). `cmdOff` is the response-command byte offset (6 on WHOOP4, 10 on 5/MG);
+    /// the 4-byte CRC32 trailer both families carry is excluded from the payload.
+    public static func format(frame: [UInt8], cmdOff: Int, isWhoop5: Bool, prevPayloadHex: String?) -> (text: String, payloadHex: String?) {
+        let fam = isWhoop5 ? "WHOOP 5/MG" : "WHOOP 4.0"
+        let payStart = cmdOff + 1
+        let payEnd = frame.count - 4
+        let hasPayload = payEnd > payStart
+        let pay: [UInt8] = hasPayload ? Array(frame[payStart..<payEnd]) : []
+
+        // 5/MG replies carry an explicit result code @12 (0 FAILURE / 1 SUCCESS / 2 PENDING /
+        // 3 UNSUPPORTED — the firmware's rejection code for an opcode it doesn't implement).
+        let resultCode: Int? = (isWhoop5 && frame.count > 12) ? Int(frame[12]) : nil
+        let resultLabel: String?
+        switch resultCode {
+        case 0: resultLabel = "FAILURE"
+        case 1: resultLabel = "SUCCESS"
+        case 2: resultLabel = "PENDING"
+        case 3: resultLabel = "UNSUPPORTED"
+        case nil: resultLabel = nil
+        default: resultLabel = "result\(resultCode!)"
+        }
+        let verdict: String
+        if resultCode == 3 {
+            verdict = "opcode 84 REJECTED by firmware (UNSUPPORTED)"
+        } else if hasPayload {
+            verdict = "opcode 84 ACCEPTED — \(pay.count)-byte payload"
+        } else {
+            verdict = "opcode 84 answered with a bare stub — ambiguous"
+        }
+
+        var sb = ""
+        sb += "#690 BODY-LOCATION PROBE — \(fam)\n"
+        sb += "Verdict: \(verdict)\n"
+        if let resultLabel { sb += "Result code @12: \(resultLabel)(\(resultCode!))\n" }
+        // Full raw hex on ONE line so it copies cleanly for sharing.
+        sb += "\nRaw frame (\(frame.count) B):\n"
+        sb += frame.map { String(format: "%02x", $0) }.joined() + "\n"
+
+        var payloadHex: String?
+        if hasPayload {
+            payloadHex = pay.map { String(format: "%02x", $0) }.joined()
+            sb += "\nPayload (\(pay.count) B, CRC excluded):\n"
+            sb += hexGrid(pay)
+            // GetBodyLocationResponsePacket layout: revision, location, confidence, status (4 bytes) — but
+            // only at cmdOff+1 on WHOOP4, where the inner payload starts right after the command byte. On
+            // 5/MG the puffin envelope inserts a result code @12 (= pay[1] here), so decoding these offsets
+            // would mislabel the RESULT CODE as the location. Until a real 5/MG capture maps the record's
+            // true offset, only WHOOP4 is decoded; 5/MG shows the raw grid, never a guessed field.
+            if !isWhoop5, pay.count >= 4 {
+                let revision = Int(pay[0])
+                let location = Int(pay[1])
+                let confidence = Int(pay[2])
+                let status = Int(pay[3])
+                sb += "\nDecoded:\n"
+                sb += "  revision:   \(revision)\n"
+                sb += "  location:   \(location)  (\(locationLabel(location)))\n"
+                sb += "  confidence: \(confidence)  (raw)\n"
+                sb += "  status:     \(status)  (raw)\n"
+            } else if !isWhoop5 {
+                sb += "\nPayload shorter than the 4-byte body-location record — fields kept raw only\n"
+            } else {
+                sb += "\n5/MG: the record's offset inside the puffin envelope is unconfirmed — NOT decoded (the raw grid above stands); a real capture is needed to map the fields\n"
+            }
+            // Per-byte diff vs the previous capture — helps map confidence/status as they move with wear.
+            sb += "\n"
+            if let prevPayloadHex, prevPayloadHex.count == payloadHex!.count {
+                let prev = hexToBytes(prevPayloadHex)
+                var deltas = ""
+                for i in pay.indices where prev[i] != Int(pay[i]) {
+                    deltas += String(format: " @%02d:%02x→%02x", i, prev[i], Int(pay[i]))
+                }
+                if deltas.isEmpty {
+                    sb += "Δ vs previous capture: identical — re-probe after moving/re-seating the strap to expose the fields"
+                } else {
+                    sb += "Δ vs previous capture:\(deltas)"
+                }
+            } else {
+                sb += "Δ vs previous capture: first capture — probe again in another position to diff"
+            }
+        } else {
+            sb += "\nNo payload beyond the command byte (bare stub) — no body-location data on this firmware"
+        }
+        return (sb, payloadHex)
+    }
+
+    /// 0x54 location enum. Unknown/gap values (e.g. 6) fall through to a raw label so an unfamiliar reading
+    /// is preserved, never crashes, and is never silently coerced to a known position.
+    private static func locationLabel(_ v: Int) -> String {
+        switch v {
+        case 0: return "UNKNOWN"
+        case 1: return "WRIST"
+        case 2: return "BICEP"
+        case 3: return "CALF"
+        case 4: return "SIDE_TORSO"
+        case 5: return "GLUTE"
+        case 7: return "ANKLE"
+        case 128: return "NOT_CONCLUSIVE"
+        case 160: return "UNKNOWN_GARMENT"
+        default: return "raw\(v)"
+        }
+    }
+
+    /// Offset-labelled hex grid, 8 bytes per row ("  @00  01 01 5a 00"), for the payload dump.
+    private static func hexGrid(_ bytes: [UInt8]) -> String {
+        var sb = ""
+        var i = 0
+        while i < bytes.count {
+            sb += String(format: "  @%02d ", i)
+            var j = i
+            while j < min(i + 8, bytes.count) {
+                sb += String(format: " %02x", bytes[j])
+                j += 1
+            }
+            sb += "\n"
+            i += 8
+        }
+        return sb
+    }
+
+    private static func hexToBytes(_ hex: String) -> [Int] {
+        let chars = Array(hex)
+        var out: [Int] = []
+        out.reserveCapacity(chars.count / 2)
+        var i = 0
+        while i + 1 < chars.count {
+            out.append((Int(String(chars[i]), radix: 16) ?? 0) << 4 | (Int(String(chars[i + 1]), radix: 16) ?? 0))
+            i += 2
+        }
+        return out
+    }
+}

--- a/Packages/WhoopProtocol/Tests/WhoopProtocolTests/BodyLocationProbeTests.swift
+++ b/Packages/WhoopProtocol/Tests/WhoopProtocolTests/BodyLocationProbeTests.swift
@@ -1,0 +1,110 @@
+import XCTest
+@testable import WhoopProtocol
+
+/// #690: the pure formatter for the GET_BODY_LOCATION_AND_STATUS (0x54) probe result. Byte-parity twin of
+/// the Kotlin `BodyLocationProbeFormatTest` (same fixtures, same expectations). Fixtures are SYNTHETIC —
+/// the wire layout (4-byte revision/location/confidence/status) is RE'd but not yet hardware-captured, so
+/// these pin the decode/format contract; a real capture can be added when a strap answers 0x54.
+final class BodyLocationProbeTests: XCTestCase {
+
+    private func hexToBytes(_ h: String) -> [UInt8] {
+        let c = Array(h)
+        return stride(from: 0, to: c.count, by: 2).map {
+            UInt8((Int(String(c[$0]), radix: 16)! << 4) | Int(String(c[$0 + 1]), radix: 16)!)
+        }
+    }
+
+    // WHOOP4-shape frame: cmd 0x54 @6, 4-byte payload [revision=01, location=01 WRIST, confidence=5a=90,
+    // status=00], then a 4-byte CRC tail. (deadbeef stands in for the CRC — the formatter never validates it.)
+    private let wristFrame = "aa09000024005401015a00deadbeef"
+
+    func testWhoop4_acceptedDecodesTheFourFields() {
+        let (text, payHex) = BodyLocationProbe.format(frame: hexToBytes(wristFrame), cmdOff: 6, isWhoop5: false, prevPayloadHex: nil)
+        XCTAssertTrue(text.contains("WHOOP 4.0"))
+        XCTAssertTrue(text.contains("opcode 84 ACCEPTED — 4-byte payload"))
+        XCTAssertTrue(text.contains(wristFrame))                 // full raw hex on one copyable line
+        XCTAssertTrue(text.contains("  @00  01 01 5a 00"))       // offset-labelled hex grid
+        XCTAssertTrue(text.contains("revision:   1"))
+        XCTAssertTrue(text.contains("location:   1  (WRIST)"))
+        XCTAssertTrue(text.contains("confidence: 90  (raw)"))    // 0x5a = 90, kept raw
+        XCTAssertTrue(text.contains("status:     0  (raw)"))
+        XCTAssertTrue(text.contains("first capture"))
+        XCTAssertEqual(payHex?.count, 4 * 2)                     // 4-byte payload persisted for the next diff
+    }
+
+    func testUnknownLocation_isPreservedAsRawNotCrashedOrCoerced() {
+        // location = 6 (the enum gap between GLUTE=5 and ANKLE=7): must NOT crash and must NOT map to a
+        // known position — it reads back as raw.
+        let (text, _) = BodyLocationProbe.format(frame: hexToBytes("aa09000024005401060000deadbeef"), cmdOff: 6, isWhoop5: false, prevPayloadHex: nil)
+        XCTAssertTrue(text.contains("location:   6  (raw6)"))
+    }
+
+    func testKnownEnumValues_mapToTheirLabels() {
+        for (raw, label) in [(2, "BICEP"), (3, "CALF"), (4, "SIDE_TORSO"), (5, "GLUTE"), (7, "ANKLE"),
+                             (128, "NOT_CONCLUSIVE"), (160, "UNKNOWN_GARMENT")] {
+            let frame = "aa090000240054" + "01" + String(format: "%02x", raw) + "0000" + "deadbeef"
+            let (text, _) = BodyLocationProbe.format(frame: hexToBytes(frame), cmdOff: 6, isWhoop5: false, prevPayloadHex: nil)
+            XCTAssertTrue(text.contains("(\(label))"), "location \(raw) should read \(label)")
+        }
+    }
+
+    func testDiff_flagsTheChangedLocationByte() {
+        let first = hexToBytes(wristFrame)
+        let (_, prev) = BodyLocationProbe.format(frame: first, cmdOff: 6, isWhoop5: false, prevPayloadHex: nil)
+        var second = first
+        second[8] = 0x03            // payload offset 1 (location) WRIST(01) → CALF(03)
+        let (text, _) = BodyLocationProbe.format(frame: second, cmdOff: 6, isWhoop5: false, prevPayloadHex: prev)
+        XCTAssertTrue(text.contains("Δ vs previous capture:"))
+        XCTAssertTrue(text.contains("@01:01→03"))
+        XCTAssertTrue(text.contains("location:   3  (CALF)"))
+    }
+
+    func testBareStub_isCalledOut() {
+        // 11-byte frame: cmd 0x54 @6 then ONLY the 4-byte CRC tail ⇒ payEnd(7) == payStart(7) ⇒ no payload.
+        let (text, payHex) = BodyLocationProbe.format(frame: hexToBytes("aa0700fa24005446758858"), cmdOff: 6, isWhoop5: false, prevPayloadHex: nil)
+        XCTAssertTrue(text.contains("bare stub"))
+        XCTAssertNil(payHex)
+    }
+
+    /// Golden FULL-output lock: pins the exact byte-for-byte report so the Swift and Kotlin twins can't
+    /// drift on whitespace/labels (the parity contract). The Kotlin `BodyLocationProbeFormatTest` asserts
+    /// this identical line-list against `formatBodyLocationProbe`.
+    func testFullOutput_goldenParityLock() {
+        let (text, _) = BodyLocationProbe.format(frame: hexToBytes(wristFrame), cmdOff: 6, isWhoop5: false, prevPayloadHex: nil)
+        let golden = [
+            "#690 BODY-LOCATION PROBE — WHOOP 4.0",
+            "Verdict: opcode 84 ACCEPTED — 4-byte payload",
+            "",
+            "Raw frame (15 B):",
+            "aa09000024005401015a00deadbeef",
+            "",
+            "Payload (4 B, CRC excluded):",
+            "  @00  01 01 5a 00",
+            "",
+            "Decoded:",
+            "  revision:   1",
+            "  location:   1  (WRIST)",
+            "  confidence: 90  (raw)",
+            "  status:     0  (raw)",
+            "",
+            "Δ vs previous capture: first capture — probe again in another position to diff",
+        ].joined(separator: "\n")
+        XCTAssertEqual(text, golden)
+    }
+
+    func testWhoop5Success_doesNotMisdecodeTheResultCodeAsAField() {
+        // 5/MG SUCCESS(1) with a payload: pay[1] here is the RESULT CODE @12, so decoding the WHOOP4 offsets
+        // would falsely read "location: 1 (WRIST)". The formatter must NOT decode on 5/MG — raw grid only.
+        let (text, _) = BodyLocationProbe.format(frame: hexToBytes("aa000c000000000000005400010102030405060708090a46758858"), cmdOff: 10, isWhoop5: true, prevPayloadHex: nil)
+        XCTAssertTrue(text.contains("Result code @12: SUCCESS(1)"))
+        XCTAssertFalse(text.contains("location:"))       // must never present the result code as a location
+        XCTAssertTrue(text.contains("unconfirmed"))
+    }
+
+    func testWhoop5Unsupported_isDecisiveVerdict() {
+        // 5/MG frame with the command byte 0x54 @10 and result code 3 (UNSUPPORTED) @12.
+        let (text, _) = BodyLocationProbe.format(frame: hexToBytes("aa000c000000000000005400030046758858"), cmdOff: 10, isWhoop5: true, prevPayloadHex: nil)
+        XCTAssertTrue(text.contains("REJECTED by firmware (UNSUPPORTED)"))
+        XCTAssertTrue(text.contains("Result code @12: UNSUPPORTED(3)"))
+    }
+}

--- a/Strand/App/AppModel.swift
+++ b/Strand/App/AppModel.swift
@@ -808,6 +808,10 @@ final class AppModel: ObservableObject {
     func probeExtendedBatteryInfo() { ble.probeExtendedBatteryInfo() }
     func clearExtendedBatteryProbe() { ble.clearExtendedBatteryProbe() }
 
+    // #690: read-only body-location/status probe (0x54). User-initiated, Test-Centre-gated in DevicesView.
+    func probeBodyLocationAndStatus() { ble.probeBodyLocationAndStatus() }
+    func clearBodyLocationProbe() { ble.clearBodyLocationProbe() }
+
     /// Drop the current strap and clear bond state so a newly-picked strap model connects fresh
     /// (lets a user with both a WHOOP 4 and a 5/MG switch between them).
     func prepareStrapSwitch() { ble.prepareForModelSwitch() }

--- a/Strand/BLE/BLEManager.swift
+++ b/Strand/BLE/BLEManager.swift
@@ -1451,6 +1451,10 @@ public final class BLEManager: NSObject, ObservableObject {
                 // GET_EXTENDED_BATTERY_INFO (98) over puffin: read-only opcode probe (#592) — a real WHOOP 5
                 // (fw 50.38.1.0) already answered this number. Driven only by probeExtendedBatteryInfo().
                 || command == .getExtendedBatteryInfo
+                // GET_BODY_LOCATION_AND_STATUS (84) over puffin: read-only opcode probe (#690). Driven only by
+                // probeBodyLocationAndStatus() (user-initiated, Test Centre gated); decoded to a diagnostic
+                // report only, never gates wear/scoring. Whether 5/MG answers is a hardware check.
+                || command == .getBodyLocationAndStatus
                 || command == .sendHistoricalData || command == .historicalDataResult
                 || command == .setClock || command == .getClock
                 // SET_CONFIG (the R22 deep-stream unlock) is allowed ONLY while the deep-data
@@ -2392,6 +2396,11 @@ public final class BLEManager: NSObject, ObservableObject {
     private static let extendedBatteryProbeTimeout: TimeInterval = 8
     private static let extendedBatteryPrevPayloadKey = "noop.592.prevPayload"
 
+    // #690 body-location probe (twins of the #592 constants above).
+    public static let bodyLocationProbeWaiting = "__waiting__"
+    private static let bodyLocationProbeTimeout: TimeInterval = 8
+    private static let bodyLocationPrevPayloadKey = "noop.690.prevPayload"
+
     /// #592 opcode probe: send the read-only GET_EXTENDED_BATTERY_INFO(98) and surface the strap's reply
     /// (raw hex + payload triage + capture diff) on `LiveState.extendedBatteryProbe` for the Devices dialog.
     /// The number is disputed (an APK decompile reads 87); a battery-shaped payload confirms 98 on this
@@ -2428,6 +2437,46 @@ public final class BLEManager: NSObject, ObservableObject {
         log("Extended-battery probe (#592):\n\(text)")
         state.extendedBatteryProbe = text
         if let payHex { UserDefaults.standard.set(payHex, forKey: BLEManager.extendedBatteryPrevPayloadKey) }
+    }
+
+    /// #690 opcode probe: send the read-only GET_BODY_LOCATION_AND_STATUS(84) and surface the strap's reply
+    /// (raw hex + payload triage + capture diff) on `LiveState.bodyLocationProbe` for the Devices dialog.
+    /// READ-ONLY: never changes wear detection, sleep gating, or scoring. User-initiated only. Twin of
+    /// Android WhoopBleClient.probeBodyLocationAndStatus().
+    public func probeBodyLocationAndStatus() {
+        guard state.connected else {
+            log("Body-location probe (#690) ignored — not connected")
+            return
+        }
+        state.bodyLocationProbe = BLEManager.bodyLocationProbeWaiting
+        log("Body-location probe (#690): sending GET_BODY_LOCATION_AND_STATUS(84, read-only) on family=\(selectedModel.deviceFamily); the raw COMMAND_RESPONSE is surfaced when it lands")
+        send(.getBodyLocationAndStatus)
+        // No-reply timeout: silence is itself the verdict (the strap doesn't serve 0x54 on this firmware).
+        // BLE callbacks + this timer both run on the main queue, so the guard-then-set is race-free.
+        DispatchQueue.main.asyncAfter(deadline: .now() + BLEManager.bodyLocationProbeTimeout) { [weak self] in
+            guard let self, self.state.bodyLocationProbe == BLEManager.bodyLocationProbeWaiting else { return }
+            let secs = Int(BLEManager.bodyLocationProbeTimeout)
+            let msg = "Body-location probe (#690): no COMMAND_RESPONSE for opcode 84 within \(secs)s — the strap served no reply (it may not implement 0x54 on this firmware). Retry idle if a sync/offload was mid-flight."
+            self.log(msg)
+            self.state.bodyLocationProbe = msg
+        }
+    }
+
+    /// Clear the #690 probe result (Devices dialog dismissed). Twin of Android clearBodyLocationProbe().
+    public func clearBodyLocationProbe() { state.bodyLocationProbe = nil }
+
+    /// #690: format a GET_BODY_LOCATION_AND_STATUS COMMAND_RESPONSE and publish it, diffing against the
+    /// persisted previous payload. Called from the inbound frame handler for both families. Guarded on a
+    /// probe being IN-FLIGHT (parity with Android): 0x54 could coincide with a data frame's cmd-offset byte,
+    /// and this is a strictly user-triggered diagnostic, so a stray match must never surface a result.
+    private func handleBodyLocationProbeResponse(_ frame: [UInt8], isWhoop5: Bool) {
+        guard state.bodyLocationProbe == BLEManager.bodyLocationProbeWaiting else { return }
+        let prev = UserDefaults.standard.string(forKey: BLEManager.bodyLocationPrevPayloadKey)
+        let (text, payHex) = BodyLocationProbe.format(
+            frame: frame, cmdOff: isWhoop5 ? 10 : 6, isWhoop5: isWhoop5, prevPayloadHex: prev)
+        log("Body-location probe (#690):\n\(text)")
+        state.bodyLocationProbe = text
+        if let payHex { UserDefaults.standard.set(payHex, forKey: BLEManager.bodyLocationPrevPayloadKey) }
     }
 
     /// Shared reboot send + debug trail + watchdog, used by both the production `rebootStrap()` and the
@@ -3293,6 +3342,7 @@ extension BLEManager: @preconcurrency CBCentralManagerDelegate {
         state.batteryMv = nil         // #592: a stale pack voltage must not outlive the link
         state.strapFirmware = nil     // a stale firmware version must not outlive the link
         state.extendedBatteryProbe = nil  // #592: drop a stale probe result on disconnect
+        state.bodyLocationProbe = nil     // #690: drop a stale probe result on disconnect
         state.clearBiometrics()       // and a stale HR / R-R must not outlive the link either
         state.liveFeedActive = false  // a drop while Live is open must not leave a stale "Stop live feed"
         didBond = false
@@ -3970,6 +4020,10 @@ extension BLEManager: @preconcurrency CBPeripheralDelegate {
                 if frame.count > 6, frame[6] == WhoopCommand.getExtendedBatteryInfo.rawValue {
                     handleExtendedBatteryProbeResponse(frame, isWhoop5: false)
                 }
+                // #690: the read-only body-location probe's COMMAND_RESPONSE (in-flight-guarded inside).
+                if frame.count > 6, frame[6] == WhoopCommand.getBodyLocationAndStatus.rawValue {
+                    handleBodyLocationProbeResponse(frame, isWhoop5: false)
+                }
                 if frame.count > 6, frame[6] == WhoopCommand.getDataRange.rawValue {
                     // #451: the decoded "newest" can latch a stale/wrong-epoch field (claypilat saw 2024 when
                     // the real newest was 2026). To tell a genuinely-stale strap apart from a frame-alignment
@@ -4090,6 +4144,10 @@ extension BLEManager: @preconcurrency CBPeripheralDelegate {
                     // @10). Format + publish it for the Devices dialog, exactly like the 4.0 path above.
                     if frame.count > 10, frame[8] == 0x24, frame[10] == WhoopCommand.getExtendedBatteryInfo.rawValue {
                         handleExtendedBatteryProbeResponse(frame, isWhoop5: true)
+                    }
+                    // #690: a 5/MG body-location probe COMMAND_RESPONSE (puffin envelope: type @8, cmd @10).
+                    if frame.count > 10, frame[8] == 0x24, frame[10] == WhoopCommand.getBodyLocationAndStatus.rawValue {
+                        handleBodyLocationProbeResponse(frame, isWhoop5: true)
                     }
                     // NOTE: we deliberately do NOT ingest live 5/MG REALTIME_DATA into the Collector
                     // here. For a 5/MG the standard 0x2A37 Heart-Rate profile is already the RELIABLE,

--- a/Strand/BLE/Commands.swift
+++ b/Strand/BLE/Commands.swift
@@ -79,6 +79,9 @@ public enum WhoopCommand: UInt8, CaseIterable {
     /// payloads. If probing (#592): send THIS curated number first and capture the response — do NOT lead
     /// with the decompile's 87, an opcode unknown to this table (the curated-safe-subset rule).
     case getExtendedBatteryInfo = 98
+    /// #690: read-only body-location/status probe. Documented in the WHOOP protocol; driven only by the
+    /// user-triggered, Test-Centre-gated probeBodyLocationAndStatus(). Decoded to a diagnostic report only.
+    case getBodyLocationAndStatus = 84
     case toggleIMUMode         = 106
     case enableOpticalData     = 107
     /// SET_CONFIG / SET_FF_VALUE (0x78) — write one persistent device feature-flag. Used by the
@@ -145,6 +148,7 @@ public enum WhoopCommand: UInt8, CaseIterable {
         case .enterHighFreqSync:     return "Enter High-Freq Sync"
         case .exitHighFreqSync:      return "Exit High-Freq Sync"
         case .getExtendedBatteryInfo:return "Get Extended Battery Info"
+        case .getBodyLocationAndStatus:return "Get Body Location And Status"
         case .toggleIMUMode:         return "Toggle IMU Mode"
         case .enableOpticalData:     return "Enable Optical Data"
         case .setConfig:             return "Set Config (R22 feature flag)"

--- a/Strand/BLE/LiveState.swift
+++ b/Strand/BLE/LiveState.swift
@@ -240,6 +240,10 @@ public final class LiveState: ObservableObject {
     /// a capture is readable/copyable without a full log export. BLEManager writes it; cleared on disconnect
     /// and on dialog dismiss. Twin of the Android StateFlow LiveState/WhoopBleClient.extendedBatteryProbe.
     @Published public var extendedBatteryProbe: String? = nil
+
+    /// #690: the body-location probe result (or the waiting sentinel), shown + copied in the Devices dialog.
+    /// Cleared on disconnect and on dialog dismiss. Twin of the Android WhoopBleClient.bodyLocationProbe flow.
+    @Published public var bodyLocationProbe: String? = nil
     /// Wrist-wear state from WRIST_ON/WRIST_OFF events. Defaults true so wear-gated features work
     /// before the first event arrives; flipped by FrameRouter on a real event.
     @Published public var worn: Bool = true

--- a/Strand/Screens/DevicesView.swift
+++ b/Strand/Screens/DevicesView.swift
@@ -99,6 +99,11 @@ private struct DevicesContent: View {
                         ? String(localized: "1 paired")
                         : String(localized: "\(activeDevices.count) paired"))
             ForEach(Array(activeDevices.enumerated()), id: \.element.id) { idx, device in
+                // Shared read-only probe gate (Test Centre → Connection + a live WHOOP), hoisted so the two
+                // probe closures below don't each re-inline a 4-term && chain — which tips the iOS Swift
+                // type-checker over its budget ("unable to type-check this expression in reasonable time").
+                let probeGate = device.status == .active && live.connected
+                    && SourceCoordinator.isWhoop(device) && TestCentre.active(.connection)
                 DeviceCard(
                     device: device,
                     isActive: device.status == .active,
@@ -146,13 +151,9 @@ private struct DevicesContent: View {
                                     && TestCentre.active(.connection)) ? { probeTarget = device } : nil,
                     // #592 extended-battery probe: read-only, BOTH families (the 4.0 is discriminating).
                     // Same Test Centre → Connection gate as the reboot probe, minus the 4.0-only clause.
-                    onExtendedBatteryProbe: (device.status == .active && live.connected
-                                             && SourceCoordinator.isWhoop(device)
-                                             && TestCentre.active(.connection)) ? { batteryProbeTarget = device } : nil,
+                    onExtendedBatteryProbe: probeGate ? { batteryProbeTarget = device } : nil,
                     // #690 body-location probe: read-only, both families. Same Test Centre → Connection gate.
-                    onBodyLocationProbe: (device.status == .active && live.connected
-                                          && SourceCoordinator.isWhoop(device)
-                                          && TestCentre.active(.connection)) ? { bodyLocationProbeTarget = device } : nil)
+                    onBodyLocationProbe: probeGate ? { bodyLocationProbeTarget = device } : nil)
                     .staggeredAppear(index: idx)
             }
 

--- a/Strand/Screens/DevicesView.swift
+++ b/Strand/Screens/DevicesView.swift
@@ -61,6 +61,8 @@ private struct DevicesContent: View {
     @State private var probeTarget: PairedDevice?
     /// #592 extended-battery probe (Test Centre → Connection) — the device whose confirm dialog is open.
     @State private var batteryProbeTarget: PairedDevice?
+    /// #690 body-location probe (Test Centre → Connection) — the device whose confirm dialog is open.
+    @State private var bodyLocationProbeTarget: PairedDevice?
     /// After removing the ACTIVE device with other devices still paired, prompt to pick a new active one.
     @State private var pickNewActive = false
 
@@ -146,7 +148,11 @@ private struct DevicesContent: View {
                     // Same Test Centre → Connection gate as the reboot probe, minus the 4.0-only clause.
                     onExtendedBatteryProbe: (device.status == .active && live.connected
                                              && SourceCoordinator.isWhoop(device)
-                                             && TestCentre.active(.connection)) ? { batteryProbeTarget = device } : nil)
+                                             && TestCentre.active(.connection)) ? { batteryProbeTarget = device } : nil,
+                    // #690 body-location probe: read-only, both families. Same Test Centre → Connection gate.
+                    onBodyLocationProbe: (device.status == .active && live.connected
+                                          && SourceCoordinator.isWhoop(device)
+                                          && TestCentre.active(.connection)) ? { bodyLocationProbeTarget = device } : nil)
                     .staggeredAppear(index: idx)
             }
 
@@ -243,6 +249,24 @@ private struct DevicesContent: View {
             ExtendedBatteryProbeResultView(
                 text: live.extendedBatteryProbe ?? "",
                 onClose: { model.clearExtendedBatteryProbe() })
+        }
+        // #690 body-location opcode probe: read-only, decodes revision/location/confidence/status.
+        .confirmationDialog("Body-location probe (#690 RE)",
+                            isPresented: Binding(get: { bodyLocationProbeTarget != nil },
+                                                 set: { if !$0 { bodyLocationProbeTarget = nil } }),
+                            titleVisibility: .visible,
+                            presenting: bodyLocationProbeTarget) { _ in
+            Button("Send probe (read-only)") { model.probeBodyLocationAndStatus(); bodyLocationProbeTarget = nil }
+            Button("Cancel", role: .cancel) { bodyLocationProbeTarget = nil }
+        } message: { _ in
+            Text("Sends the read-only GET_BODY_LOCATION_AND_STATUS (0x54) and shows the strap's full raw reply, decoding the body-location record (revision / location / confidence / status) on WHOOP 4.0. Nothing is written to the strap, and it never changes wear detection or scoring.")
+        }
+        // #690 probe result: the strap's reply (or a "waiting…" state), readable + copyable in place.
+        .sheet(isPresented: Binding(get: { live.bodyLocationProbe != nil },
+                                    set: { if !$0 { model.clearBodyLocationProbe() } })) {
+            BodyLocationProbeResultView(
+                text: live.bodyLocationProbe ?? "",
+                onClose: { model.clearBodyLocationProbe() })
         }
         // Second, strongly-worded delete-data confirm (reached from the Remove card's secondary control)
         .alert("Delete all of this device's data?",
@@ -429,6 +453,7 @@ private struct DeviceCard: View {
     var onRebootProbe: (() -> Void)? = nil
     /// #592 extended-battery opcode probe (Test Centre → Connection, both WHOOP families). Read-only.
     var onExtendedBatteryProbe: (() -> Void)? = nil
+    var onBodyLocationProbe: (() -> Void)? = nil
     /// Removed-section affordances (re-add as active / delete its data).
     var onReAdd: (() -> Void)? = nil
     var onDeleteData: (() -> Void)? = nil
@@ -676,6 +701,10 @@ private struct DeviceCard: View {
                 if let onExtendedBatteryProbe {
                     Button { onExtendedBatteryProbe() } label: { Label("Battery-info probe (#592 RE)…", systemImage: "ladybug") }
                 }
+                // #690 body-location opcode probe (RE): read-only, both families. Test Centre → Connection.
+                if let onBodyLocationProbe {
+                    Button { onBodyLocationProbe() } label: { Label("Body-location probe (#690 RE)…", systemImage: "ladybug") }
+                }
                 if let onRemove {
                     Divider()
                     Button(role: .destructive) { onRemove() } label: {
@@ -917,6 +946,46 @@ private struct ExtendedBatteryProbeResultView: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 16) {
             Text("Battery-info probe result (#592)")
+                .font(StrandFont.title2)
+                .foregroundStyle(StrandPalette.textPrimary)
+            if waiting {
+                Text("Waiting for the strap's reply…")
+                    .font(StrandFont.subhead)
+                    .foregroundStyle(StrandPalette.textSecondary)
+            } else {
+                ScrollView {
+                    Text(text)
+                        .font(StrandFont.mono)
+                        .foregroundStyle(StrandPalette.textSecondary)
+                        .textSelection(.enabled)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                }
+            }
+            HStack {
+                if !waiting {
+                    Button("Copy") { PlatformPasteboard.copy(text) }
+                }
+                Spacer()
+                Button("Close") { onClose() }
+            }
+        }
+        .padding(20)
+        .frame(minWidth: 340, minHeight: 260)
+        .background(StrandPalette.surfaceOverlay)
+    }
+}
+
+/// The #690 body-location probe reply (raw hex + decoded record + capture diff), or a "waiting…" state
+/// while in flight. Read-only; selectable text + a Copy button. Twin of the Android BodyLocationProbe
+/// result dialog and structurally identical to ExtendedBatteryProbeResultView.
+private struct BodyLocationProbeResultView: View {
+    let text: String
+    let onClose: () -> Void
+    private var waiting: Bool { text == BLEManager.bodyLocationProbeWaiting }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            Text("Body-location probe result (#690)")
                 .font(StrandFont.title2)
                 .foregroundStyle(StrandPalette.textPrimary)
             if waiting {

--- a/Strand/Screens/DevicesView.swift
+++ b/Strand/Screens/DevicesView.swift
@@ -251,24 +251,11 @@ private struct DevicesContent: View {
                 text: live.extendedBatteryProbe ?? "",
                 onClose: { model.clearExtendedBatteryProbe() })
         }
-        // #690 body-location opcode probe: read-only, decodes revision/location/confidence/status.
-        .confirmationDialog("Body-location probe (#690 RE)",
-                            isPresented: Binding(get: { bodyLocationProbeTarget != nil },
-                                                 set: { if !$0 { bodyLocationProbeTarget = nil } }),
-                            titleVisibility: .visible,
-                            presenting: bodyLocationProbeTarget) { _ in
-            Button("Send probe (read-only)") { model.probeBodyLocationAndStatus(); bodyLocationProbeTarget = nil }
-            Button("Cancel", role: .cancel) { bodyLocationProbeTarget = nil }
-        } message: { _ in
-            Text("Sends the read-only GET_BODY_LOCATION_AND_STATUS (0x54) and shows the strap's full raw reply, decoding the body-location record (revision / location / confidence / status) on WHOOP 4.0. Nothing is written to the strap, and it never changes wear detection or scoring.")
-        }
-        // #690 probe result: the strap's reply (or a "waiting…" state), readable + copyable in place.
-        .sheet(isPresented: Binding(get: { live.bodyLocationProbe != nil },
-                                    set: { if !$0 { model.clearBodyLocationProbe() } })) {
-            BodyLocationProbeResultView(
-                text: live.bodyLocationProbe ?? "",
-                onClose: { model.clearBodyLocationProbe() })
-        }
+        // #690 body-location probe (confirm + result), isolated into a ViewModifier so its two heavy
+        // dialog modifiers type-check in their OWN scope — the DevicesView dialog chain is already near the
+        // iOS Swift type-checker's budget, and inlining a 6th/7th modifier here tips it over ("unable to
+        // type-check in reasonable time"). macOS tolerates the inline form; iOS's type-inference is stricter.
+        .modifier(BodyLocationProbeSheets(target: $bodyLocationProbeTarget))
         // Second, strongly-worded delete-data confirm (reached from the Remove card's secondary control)
         .alert("Delete all of this device's data?",
                isPresented: Binding(get: { deleteDataTarget != nil },
@@ -973,6 +960,35 @@ private struct ExtendedBatteryProbeResultView: View {
         .padding(20)
         .frame(minWidth: 340, minHeight: 260)
         .background(StrandPalette.surfaceOverlay)
+    }
+}
+
+/// #690: the body-location probe's confirm + result dialogs as one ViewModifier, so they're type-checked
+/// in isolation instead of extending the DevicesView `.confirmationDialog`/`.sheet` chain (which is already
+/// near the iOS Swift type-checker's budget). `model`/`live` auto-inject from the parent's environment.
+private struct BodyLocationProbeSheets: ViewModifier {
+    @EnvironmentObject var model: AppModel
+    @EnvironmentObject var live: LiveState
+    @Binding var target: PairedDevice?
+
+    func body(content: Content) -> some View {
+        content
+            .confirmationDialog("Body-location probe (#690 RE)",
+                                isPresented: Binding(get: { target != nil },
+                                                     set: { if !$0 { target = nil } }),
+                                titleVisibility: .visible,
+                                presenting: target) { _ in
+                Button("Send probe (read-only)") { model.probeBodyLocationAndStatus(); target = nil }
+                Button("Cancel", role: .cancel) { target = nil }
+            } message: { _ in
+                Text("Sends the read-only GET_BODY_LOCATION_AND_STATUS (0x54) and shows the strap's full raw reply, decoding the body-location record (revision / location / confidence / status) on WHOOP 4.0. Nothing is written to the strap, and it never changes wear detection or scoring.")
+            }
+            .sheet(isPresented: Binding(get: { live.bodyLocationProbe != nil },
+                                        set: { if !$0 { model.clearBodyLocationProbe() } })) {
+                BodyLocationProbeResultView(
+                    text: live.bodyLocationProbe ?? "",
+                    onClose: { model.clearBodyLocationProbe() })
+            }
     }
 }
 

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -1085,6 +1085,111 @@ class WhoopBleClient(
             return sb.toString()
         }
 
+        /** #690: sentinel value of [bodyLocationProbe] between sending the probe and its reply landing. */
+        const val WAITING_BODY_LOCATION_PROBE = "__waiting__"
+
+        /** #690: how long to wait for a body-location COMMAND_RESPONSE before treating silence as "no reply". */
+        const val BODY_LOCATION_PROBE_TIMEOUT_MS = 8_000L
+
+        /** #690: persisted previous body-location payload hex, so a new capture can diff against it. */
+        private const val KEY_690_PREV_PAYLOAD = "noop.690.prevPayload"
+
+        /**
+         * #690: format a GET_BODY_LOCATION_AND_STATUS (0x54) COMMAND_RESPONSE into a clean, readable,
+         * copyable report — verdict, full raw hex, an offset-labelled payload grid, the four decoded fields
+         * (revision / location + enum label / confidence / status), and a per-byte diff vs [prevPayloadHex].
+         * READ-ONLY: never changes wear detection, sleep gating, or scoring. Pure + deterministic so it's
+         * unit-tested without a strap. Byte-identical to the Swift [BodyLocationProbe.format]. [cmdOff] is the
+         * response-command byte offset (6 on WHOOP4, 10 on 5/MG); the 4-byte CRC32 trailer is excluded.
+         *
+         * Protocol facts (0x54, the 4-byte layout, the location enum) are RE'd from the WHOOP app and
+         * reimplemented here in NOOP's own code — facts, not copied expression (see ATTRIBUTION.md).
+         */
+        internal fun formatBodyLocationProbe(
+            frame: ByteArray,
+            cmdOff: Int,
+            isWhoop5: Boolean,
+            prevPayloadHex: String?,
+        ): Pair<String, String?> {
+            val fam = if (isWhoop5) "WHOOP 5/MG" else "WHOOP 4.0"
+            val payStart = cmdOff + 1
+            val payEnd = frame.size - 4
+            val hasPayload = payEnd > payStart
+            val pay = if (hasPayload) frame.copyOfRange(payStart, payEnd) else ByteArray(0)
+
+            val resultCode = if (isWhoop5 && frame.size > 12) frame[12].toInt() and 0xFF else null
+            val resultLabel = when (resultCode) {
+                0 -> "FAILURE"; 1 -> "SUCCESS"; 2 -> "PENDING"; 3 -> "UNSUPPORTED"
+                null -> null; else -> "result$resultCode"
+            }
+            val verdict = when {
+                resultCode == 3 -> "opcode 84 REJECTED by firmware (UNSUPPORTED)"
+                hasPayload -> "opcode 84 ACCEPTED — ${pay.size}-byte payload"
+                else -> "opcode 84 answered with a bare stub — ambiguous"
+            }
+
+            val sb = StringBuilder()
+            sb.append("#690 BODY-LOCATION PROBE — ").append(fam).append('\n')
+            sb.append("Verdict: ").append(verdict).append('\n')
+            if (resultLabel != null) sb.append("Result code @12: ").append(resultLabel).append('(').append(resultCode).append(")\n")
+            sb.append("\nRaw frame (").append(frame.size).append(" B):\n")
+            sb.append(frame.joinToString("") { "%02x".format(it) }).append('\n')
+
+            var payloadHex: String? = null
+            if (hasPayload) {
+                payloadHex = pay.joinToString("") { "%02x".format(it) }
+                sb.append("\nPayload (").append(pay.size).append(" B, CRC excluded):\n")
+                sb.append(hexGrid(pay))
+                // 4-byte revision/location/confidence/status record — decoded only on WHOOP4, where the
+                // inner payload starts at cmdOff+1. On 5/MG the puffin envelope inserts a result code @12
+                // (= pay[1]), so decoding here would mislabel the RESULT CODE as the location; until a real
+                // 5/MG capture maps the offset, 5/MG shows the raw grid only. Twin of Swift BodyLocationProbe.
+                if (!isWhoop5 && pay.size >= 4) {
+                    val revision = pay[0].toInt() and 0xFF
+                    val location = pay[1].toInt() and 0xFF
+                    val confidence = pay[2].toInt() and 0xFF
+                    val status = pay[3].toInt() and 0xFF
+                    sb.append("\nDecoded:\n")
+                    sb.append("  revision:   ").append(revision).append('\n')
+                    sb.append("  location:   ").append(location).append("  (").append(bodyLocationLabel(location)).append(")\n")
+                    sb.append("  confidence: ").append(confidence).append("  (raw)\n")
+                    sb.append("  status:     ").append(status).append("  (raw)\n")
+                } else if (!isWhoop5) {
+                    sb.append("\nPayload shorter than the 4-byte body-location record — fields kept raw only\n")
+                } else {
+                    sb.append("\n5/MG: the record's offset inside the puffin envelope is unconfirmed — NOT decoded (the raw grid above stands); a real capture is needed to map the fields\n")
+                }
+                sb.append('\n')
+                if (prevPayloadHex != null && prevPayloadHex.length == payloadHex.length) {
+                    val prev = prevPayloadHex.chunked(2).map { it.toInt(16) }
+                    val deltas = StringBuilder()
+                    for (i in pay.indices) {
+                        val a = prev[i]
+                        val b = pay[i].toInt() and 0xFF
+                        if (a != b) deltas.append(" @%02d:%02x→%02x".format(i, a, b))
+                    }
+                    if (deltas.isEmpty()) {
+                        sb.append("Δ vs previous capture: identical — re-probe after moving/re-seating the strap to expose the fields")
+                    } else {
+                        sb.append("Δ vs previous capture:").append(deltas)
+                    }
+                } else {
+                    sb.append("Δ vs previous capture: first capture — probe again in another position to diff")
+                }
+            } else {
+                sb.append("\nNo payload beyond the command byte (bare stub) — no body-location data on this firmware")
+            }
+            return sb.toString() to payloadHex
+        }
+
+        /** #690: 0x54 location enum. Unknown/gap values (e.g. 6) fall through to a raw label so a reading is
+         *  preserved, never crashes, and is never coerced to a known position. Twin of Swift's locationLabel. */
+        private fun bodyLocationLabel(v: Int): String = when (v) {
+            0 -> "UNKNOWN"; 1 -> "WRIST"; 2 -> "BICEP"; 3 -> "CALF"; 4 -> "SIDE_TORSO"
+            5 -> "GLUTE"; 7 -> "ANKLE"; 128 -> "NOT_CONCLUSIVE"; 160 -> "UNKNOWN_GARMENT"
+            else -> "raw$v"
+        }
+
         const val MAX_AUTO_CONTINUES = 24
 
         /** #364 "more backlog remains" margin (seconds): how far ahead the strap must be of our persisted
@@ -1291,6 +1396,10 @@ class WhoopBleClient(
     // Drives the Devices result dialog so a capture is readable/copyable without a full log export.
     private val _extendedBatteryProbe = MutableStateFlow<String?>(null)
     val extendedBatteryProbe: StateFlow<String?> = _extendedBatteryProbe.asStateFlow()
+
+    // #690: the body-location probe result (or the waiting sentinel), shown + copied in the Devices dialog.
+    private val _bodyLocationProbe = MutableStateFlow<String?>(null)
+    val bodyLocationProbe: StateFlow<String?> = _bodyLocationProbe.asStateFlow()
 
     private val _connectedPeripheralAddress = MutableStateFlow<String?>(null)
     /** The BLE address of the strap currently connected, or null when disconnected. Twin of macOS
@@ -2513,6 +2622,10 @@ class WhoopBleClient(
                 // WHOOP 5 (fw 50.38.1.0) already answered this number, proving the frame is at least
                 // accepted. Driven only by probeExtendedBatteryInfo() (user-initiated, Test Centre gated).
                 cmd != CommandNumber.GET_EXTENDED_BATTERY_INFO &&
+                // GET_BODY_LOCATION_AND_STATUS (84) over puffin: read-only opcode probe (#690). Driven only by
+                // probeBodyLocationAndStatus() (user-initiated, Test Centre gated); response decoded to a
+                // diagnostic report only, never gates wear/scoring. Whether 5/MG answers is a hardware check.
+                cmd != CommandNumber.GET_BODY_LOCATION_AND_STATUS &&
                 // SET_CONFIG (the R22 deep-stream unlock) is allowed ONLY while the deep-data experiment
                 // is opted in — it writes a persistent feature flag to the strap, so it must never fire
                 // on a default install. Reversible; driven only by enableWhoop5DeepData(). (#174)
@@ -2919,6 +3032,30 @@ class WhoopBleClient(
 
     /** Clear the #592 probe result (Devices dialog dismissed). */
     fun clearExtendedBatteryProbe() { _extendedBatteryProbe.value = null }
+
+    /** #690 opcode probe: send the read-only GET_BODY_LOCATION_AND_STATUS(84) and let the COMMAND_RESPONSE
+     *  hook decode + surface it. User-initiated (Test Centre gated). Never changes wear/scoring. */
+    fun probeBodyLocationAndStatus() {
+        if (!_state.value.connected) {
+            log("Body-location probe (#690) ignored — not connected")
+            return
+        }
+        _bodyLocationProbe.value = WAITING_BODY_LOCATION_PROBE
+        log("Body-location probe (#690): sending GET_BODY_LOCATION_AND_STATUS(84, read-only) on family=$connectedFamily; the raw COMMAND_RESPONSE is dumped below when it lands")
+        send(CommandNumber.GET_BODY_LOCATION_AND_STATUS)
+        // If NO COMMAND_RESPONSE for 84 arrives in the window, the silence is itself the verdict (the strap
+        // served no reply / doesn't implement it on this firmware). ATOMIC compare-and-set so a real reply
+        // landing microseconds before the timeout is never clobbered.
+        handler.postDelayed({
+            val msg = "Body-location probe (#690): no COMMAND_RESPONSE for opcode 84 within " +
+                "${BODY_LOCATION_PROBE_TIMEOUT_MS / 1000}s — the strap served no reply (it may not implement " +
+                "0x54 on this firmware). Retry idle if a sync/offload was mid-flight."
+            if (_bodyLocationProbe.compareAndSet(WAITING_BODY_LOCATION_PROBE, msg)) log(msg)
+        }, BODY_LOCATION_PROBE_TIMEOUT_MS)
+    }
+
+    /** Clear the #690 probe result (Devices dialog dismissed). */
+    fun clearBodyLocationProbe() { _bodyLocationProbe.value = null }
 
     /** Shared reboot send + debug trail + watchdog, used by both the production [rebootStrap] and the
      *  4.0 [rebootProbe]. `probe == null` is the normal restart; a non-null variant is a probe attempt
@@ -4015,6 +4152,23 @@ class WhoopBleClient(
                         log("Extended-battery probe (#592):\n$text")
                         _extendedBatteryProbe.value = text
                         if (payHex != null) NoopPrefs.of(context).edit().putString(KEY_592_PREV_PAYLOAD, payHex).apply()
+                    }
+                    // #690 opcode probe: dump the raw GET_BODY_LOCATION_AND_STATUS(84) response in FULL,
+                    // decode the 4-byte revision/location/confidence/status record, log it (rides the
+                    // strap-log bundle) AND publish to the StateFlow the Devices dialog shows + copies.
+                    // Gated on a probe being IN-FLIGHT (the waiting sentinel) — stricter than the #592
+                    // probe on purpose: 0x54 could coincidentally be a data/event frame's cmd-offset byte,
+                    // and this is a strictly user-triggered diagnostic, so a stray match must never pop the
+                    // result dialog. (A reply arriving after the 8s timeout is dropped — acceptable.)
+                    if (frame.size > cmdOff && (frame[cmdOff].toInt() and 0xFF) == CommandNumber.GET_BODY_LOCATION_AND_STATUS.rawValue &&
+                        _bodyLocationProbe.value == WAITING_BODY_LOCATION_PROBE) {
+                        val prevHex = NoopPrefs.of(context).getString(KEY_690_PREV_PAYLOAD, null)
+                        val (text, payHex) = formatBodyLocationProbe(
+                            frame, cmdOff, connectedFamily == DeviceFamily.WHOOP5, prevHex,
+                        )
+                        log("Body-location probe (#690):\n$text")
+                        _bodyLocationProbe.value = text
+                        if (payHex != null) NoopPrefs.of(context).edit().putString(KEY_690_PREV_PAYLOAD, payHex).apply()
                     }
                     if (frame.size > cmdOff && (frame[cmdOff].toInt() and 0xFF) == CommandNumber.GET_DATA_RANGE.rawValue) {
                         // #451: dump raw GET_DATA_RANGE response bytes unconditionally (even if decode returns

--- a/android/app/src/main/java/com/noop/protocol/Enums.kt
+++ b/android/app/src/main/java/com/noop/protocol/Enums.kt
@@ -141,6 +141,9 @@ enum class CommandNumber(val rawValue: Int) {
     // dumped in full to the strap log so a normal export settles which number this firmware serves.
     // Mirrors Swift WhoopCommand.getExtendedBatteryInfo.
     GET_EXTENDED_BATTERY_INFO(98),
+    // #690: read-only body-location/status probe. Documented in the WHOOP protocol; driven only by the
+    // user-triggered, Test-Centre-gated probeBodyLocationAndStatus(). Decoded to a diagnostic report only.
+    GET_BODY_LOCATION_AND_STATUS(84),
     STOP_HAPTICS(122),
     SELECT_WRIST(123);
 

--- a/android/app/src/main/java/com/noop/ui/AppViewModel.kt
+++ b/android/app/src/main/java/com/noop/ui/AppViewModel.kt
@@ -1729,6 +1729,16 @@ class AppViewModel(app: Application) : AndroidViewModel(app) {
 
     fun clearExtendedBatteryProbe() = ble.clearExtendedBatteryProbe()
 
+    /** #690: read-only body-location/status probe (0x54). User-initiated, Test-Centre-gated in
+     *  DevicesScreen; decodes revision/location/confidence/status to a diagnostic report + strap log.
+     *  Never changes wear detection, sleep gating, or scoring. */
+    fun probeBodyLocationAndStatus() = ble.probeBodyLocationAndStatus()
+
+    /** #690 probe result text (null until a reply lands; waiting sentinel while in flight). */
+    val bodyLocationProbe = ble.bodyLocationProbe
+
+    fun clearBodyLocationProbe() = ble.clearBodyLocationProbe()
+
     /**
      * Flip the "keep connected in the background" preference (driven by Settings). Turning it on
      * while a strap is live promotes to the foreground immediately; turning it off drops the

--- a/android/app/src/main/java/com/noop/ui/DevicesScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/DevicesScreen.kt
@@ -113,6 +113,8 @@ fun DevicesScreen(
     val live by viewModel.live.collectAsStateWithLifecycle()
     // #592 extended-battery probe result — non-null (incl. the " waiting" sentinel) shows the result dialog.
     val batteryProbeResult by viewModel.extendedBatteryProbe.collectAsStateWithLifecycle()
+    // #690 body-location probe result — same non-null-shows-the-dialog contract.
+    val bodyLocationProbeResult by viewModel.bodyLocationProbe.collectAsStateWithLifecycle()
 
     // Liquid sky backdrop gate — the SAME "Day-cycle background" preference the liquid Today honours (#698,
     // default ON). Off falls back to the flat dark canvas, so the setting governs every liquid screen alike.
@@ -137,6 +139,7 @@ fun DevicesScreen(
     // WHOOP 4.0 reboot probe (Test Centre → Connection, 4.0 only) — the device whose probe sheet is open.
     var probeTarget by remember { mutableStateOf<PairedDeviceRow?>(null) }
     var batteryProbeTarget by remember { mutableStateOf<PairedDeviceRow?>(null) }
+    var bodyLocationProbeTarget by remember { mutableStateOf<PairedDeviceRow?>(null) }
     // After removing the ACTIVE device with other devices still paired, prompt to pick a new active one.
     var pickNewActive by remember { mutableStateOf(false) }
 
@@ -233,6 +236,11 @@ fun DevicesScreen(
                     SourceCoordinator.isWhoop(device) &&
                     TestCentre.from(context).active(TestDomain.CONNECTION)
                 ) { { batteryProbeTarget = device } } else null,
+                // #690 body-location opcode probe: read-only, both families. Same Test Centre gate.
+                onBodyLocationProbe = if (device.status == DeviceStatus.active.name && live.connected &&
+                    SourceCoordinator.isWhoop(device) &&
+                    TestCentre.from(context).active(TestDomain.CONNECTION)
+                ) { { bodyLocationProbeTarget = device } } else null,
             )
         }
 
@@ -361,6 +369,19 @@ fun DevicesScreen(
             onDismiss = { viewModel.clearExtendedBatteryProbe() },
         )
     }
+    // #690 body-location opcode probe: read-only send + full raw-response dump + decoded record.
+    bodyLocationProbeTarget?.let {
+        BodyLocationProbeDialog(
+            onSend = { viewModel.probeBodyLocationAndStatus(); bodyLocationProbeTarget = null },
+            onDismiss = { bodyLocationProbeTarget = null },
+        )
+    }
+    bodyLocationProbeResult?.let { result ->
+        BodyLocationProbeResultDialog(
+            text = result,
+            onDismiss = { viewModel.clearBodyLocationProbe() },
+        )
+    }
 
     // --- Second, strongly-worded delete-data confirm (from the Removed card's secondary control) ---
     deleteDataTarget?.let { device ->
@@ -434,6 +455,8 @@ private fun DeviceCard(
     onRebootProbe: (() -> Unit)? = null,
     // #592 extended-battery opcode probe (Test Centre → Connection, both WHOOP families). Read-only.
     onBatteryProbe: (() -> Unit)? = null,
+    // #690 body-location opcode probe (Test Centre → Connection, both WHOOP families). Read-only.
+    onBodyLocationProbe: (() -> Unit)? = null,
 ) {
     val profile = deviceProfile(device)
     // The per-device actions menu's open state is hoisted here so the WHOLE card is a tap target that opens
@@ -549,6 +572,7 @@ private fun DeviceCard(
                     onReboot = onReboot,
                     onRebootProbe = onRebootProbe,
                     onBatteryProbe = onBatteryProbe,
+                    onBodyLocationProbe = onBodyLocationProbe,
                 )
             }
         }
@@ -668,6 +692,7 @@ private fun DeviceActionsMenu(
     onReboot: (() -> Unit)? = null,
     onRebootProbe: (() -> Unit)? = null,
     onBatteryProbe: (() -> Unit)? = null,
+    onBodyLocationProbe: (() -> Unit)? = null,
 ) {
     Box {
         IconButton(
@@ -720,6 +745,10 @@ private fun DeviceActionsMenu(
                 // BATTERY_INFO number (98 vs an APK decompile's 87) from a strap-log export.
                 if (onBatteryProbe != null) {
                     MenuItem(uiString(R.string.l10n_devices_screen_battery_info_probe_592_re_1dbd4c0f), Icons.Filled.BugReport) { onOpenChange(false); onBatteryProbe() }
+                }
+                // #690: read-only body-location opcode probe — decodes revision/location/confidence/status.
+                if (onBodyLocationProbe != null) {
+                    MenuItem(uiString(R.string.l10n_devices_screen_body_location_probe_690_re_7def8c39), Icons.Filled.BugReport) { onOpenChange(false); onBodyLocationProbe() }
                 }
                 if (onRemove != null) {
                     HorizontalDivider(color = Palette.hairline)
@@ -913,6 +942,73 @@ private fun BatteryInfoProbeResultDialog(
         onDismissRequest = onDismiss,
         containerColor = Palette.surfaceOverlay,
         title = { Text(uiString(R.string.l10n_devices_screen_battery_info_probe_result_592_b97c0bb8), style = NoopType.title2, color = Palette.textPrimary) },
+        text = {
+            Column(modifier = Modifier.heightIn(max = 360.dp).verticalScroll(rememberScrollState())) {
+                SelectionContainer {
+                    Text(shown, style = if (waiting) NoopType.subhead else NoopType.mono, color = Palette.textSecondary)
+                }
+            }
+        },
+        confirmButton = {
+            if (!waiting) {
+                TextButton(onClick = { clipboard.setText(AnnotatedString(text)) }) {
+                    Text(uiString(R.string.l10n_devices_screen_copy_af74f7c5), style = NoopType.body, color = Palette.accent)
+                }
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text(uiString(R.string.l10n_devices_screen_close_bbfa773e), style = NoopType.body, color = Palette.textSecondary)
+            }
+        },
+    )
+}
+
+/** #690 body-location opcode probe: a single read-only send + a full raw-response dump + decoded record.
+ *  Gated to Test Centre → Connection + a live WHOOP at the call site. */
+@Composable
+private fun BodyLocationProbeDialog(
+    onSend: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        containerColor = Palette.surfaceOverlay,
+        title = { Text(uiString(R.string.l10n_devices_screen_body_location_probe_690_re_7def8c39), style = NoopType.title2, color = Palette.textPrimary) },
+        text = {
+            Text(
+                uiString(R.string.l10n_devices_screen_body_location_probe_explainer_a9363239),
+                style = NoopType.subhead,
+                color = Palette.textSecondary,
+            )
+        },
+        confirmButton = {
+            TextButton(onClick = onSend) {
+                Text(uiString(R.string.l10n_devices_screen_send_probe_read_only_36b318bc), style = NoopType.body, color = Palette.accent)
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text(uiString(R.string.l10n_devices_screen_cancel_77dfd213), style = NoopType.body, color = Palette.textSecondary)
+            }
+        },
+    )
+}
+
+/** #690 probe result: raw hex + decoded body-location record (or a "waiting…" state), with a Copy button.
+ *  Read-only; dismiss clears the result. Twin of the Swift BodyLocationProbeResultView. */
+@Composable
+private fun BodyLocationProbeResultDialog(
+    text: String,
+    onDismiss: () -> Unit,
+) {
+    val clipboard = LocalClipboardManager.current
+    val waiting = text == WhoopBleClient.WAITING_BODY_LOCATION_PROBE
+    val shown = if (waiting) uiString(R.string.l10n_devices_screen_waiting_for_the_straps_reply_5a06e7ac) else text
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        containerColor = Palette.surfaceOverlay,
+        title = { Text(uiString(R.string.l10n_devices_screen_body_location_probe_result_690_60c5ee79), style = NoopType.title2, color = Palette.textPrimary) },
         text = {
             Column(modifier = Modifier.heightIn(max = 360.dp).verticalScroll(rememberScrollState())) {
                 SelectionContainer {

--- a/android/app/src/main/res/values-de/strings.xml
+++ b/android/app/src/main/res/values-de/strings.xml
@@ -387,6 +387,9 @@
     <string name="l10n_devices_screen_battery_clamped_2494c8c9">Batterie %1$s%%</string>
     <string name="l10n_devices_screen_battery_info_probe_592_re_1dbd4c0f">Akku-Info-Test (#592 RE)…</string>
     <string name="l10n_devices_screen_battery_info_probe_result_592_b97c0bb8">Ergebnis des Akku-Info-Tests (#592)</string>
+    <string name="l10n_devices_screen_body_location_probe_690_re_7def8c39">Körperpositions-Test (#690 RE)…</string>
+    <string name="l10n_devices_screen_body_location_probe_result_690_60c5ee79">Ergebnis des Körperpositions-Tests (#690)</string>
+    <string name="l10n_devices_screen_body_location_probe_explainer_a9363239">Sendet den nur lesenden Körperpositions-Befehl (0x54) und schreibt die vollständige Rohantwort des Bands ins Strap-Log, wobei der Datensatz (Revision / Position / Konfidenz / Status) auf der WHOOP 4.0 dekodiert wird. Es wird nichts auf das Band geschrieben, und Trageerkennung oder Bewertung werden nie verändert.</string>
     <string name="l10n_devices_screen_battery_probe_explainer_2858bb6a">Zwei unabhängige Protokolltabellen widersprechen sich beim Extended-Battery-Opcode (98 vs. 87). Dies sendet das kuratierte, nur lesende 98 und schreibt die vollständige Rohantwort des Bands ins Strap-Log. Eine batterieartige Nutzlast bestätigt 98 auf deiner Firmware; ein kurzer Stub bleibt mehrdeutig. Es wird nichts auf das Band geschrieben. Bitte exportiere und teile danach das Strap-Log.</string>
     <string name="l10n_devices_screen_cancel_77dfd213">Abbrechen</string>
     <string name="l10n_devices_screen_clamped_1f39cebb">%1$s%%</string>

--- a/android/app/src/main/res/values-es/strings.xml
+++ b/android/app/src/main/res/values-es/strings.xml
@@ -227,6 +227,9 @@
     <string name="l10n_devices_screen_battery_clamped_2494c8c9">Batería %1$s%%</string>
     <string name="l10n_devices_screen_battery_info_probe_592_re_1dbd4c0f">Sonda de info de batería (#592 RE)…</string>
     <string name="l10n_devices_screen_battery_info_probe_result_592_b97c0bb8">Resultado de la sonda de info de batería (#592)</string>
+    <string name="l10n_devices_screen_body_location_probe_690_re_7def8c39">Sonda de posición corporal (#690 RE)…</string>
+    <string name="l10n_devices_screen_body_location_probe_result_690_60c5ee79">Resultado de la sonda de posición corporal (#690)</string>
+    <string name="l10n_devices_screen_body_location_probe_explainer_a9363239">Envía el comando de posición corporal de solo lectura (0x54) y vuelca la respuesta cruda completa de la banda al registro, decodificando el registro (revisión / posición / confianza / estado) en la WHOOP 4.0. No se escribe nada en la banda y nunca cambia la detección de uso ni la puntuación.</string>
     <string name="l10n_devices_screen_battery_probe_explainer_2858bb6a">Dos tablas de protocolo independientes discrepan sobre el opcode de batería extendida (98 vs 87). Esto envía el 98 curado y de solo lectura y vuelca la respuesta cruda completa de la banda al registro. Una carga tipo batería confirma 98 en tu firmware; un stub corto lo deja ambiguo. No se escribe nada en la banda. Exporta y comparte el registro después.</string>
     <string name="l10n_devices_screen_cancel_77dfd213">Cancelar</string>
     <string name="l10n_devices_screen_clamped_1f39cebb">%1$s%%</string>

--- a/android/app/src/main/res/values-fr/strings.xml
+++ b/android/app/src/main/res/values-fr/strings.xml
@@ -227,6 +227,9 @@
     <string name="l10n_devices_screen_battery_clamped_2494c8c9">Batterie %1$s%%</string>
     <string name="l10n_devices_screen_battery_info_probe_592_re_1dbd4c0f">Sonde d\'info batterie (#592 RE)…</string>
     <string name="l10n_devices_screen_battery_info_probe_result_592_b97c0bb8">Résultat de la sonde d\'info batterie (#592)</string>
+    <string name="l10n_devices_screen_body_location_probe_690_re_7def8c39">Sonde de position corporelle (#690 RE)…</string>
+    <string name="l10n_devices_screen_body_location_probe_result_690_60c5ee79">Résultat de la sonde de position corporelle (#690)</string>
+    <string name="l10n_devices_screen_body_location_probe_explainer_a9363239">Envoie la commande de position corporelle en lecture seule (0x54) et consigne la réponse brute complète du bracelet dans le journal, en décodant l\'enregistrement (révision / position / confiance / état) sur la WHOOP 4.0. Rien n\'est écrit sur le bracelet, et la détection de port ou la notation ne sont jamais modifiées.</string>
     <string name="l10n_devices_screen_battery_probe_explainer_2858bb6a">Deux tables de protocole indépendantes divergent sur l\'opcode de batterie étendue (98 contre 87). Ceci envoie le 98 curé en lecture seule et consigne la réponse brute complète du bracelet dans le journal. Une charge de type batterie confirme 98 sur votre firmware ; un stub court le laisse ambigu. Rien n\'est écrit sur le bracelet. Exportez et partagez le journal ensuite.</string>
     <string name="l10n_devices_screen_cancel_77dfd213">Annuler</string>
     <string name="l10n_devices_screen_clamped_1f39cebb">%1$s%%</string>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -396,6 +396,9 @@
     <string name="l10n_devices_screen_battery_clamped_2494c8c9">Battery %1$s%%</string>
     <string name="l10n_devices_screen_battery_info_probe_592_re_1dbd4c0f">Battery-info probe (#592 RE)…</string>
     <string name="l10n_devices_screen_battery_info_probe_result_592_b97c0bb8">Battery-info probe result (#592)</string>
+    <string name="l10n_devices_screen_body_location_probe_690_re_7def8c39">Body-location probe (#690 RE)…</string>
+    <string name="l10n_devices_screen_body_location_probe_result_690_60c5ee79">Body-location probe result (#690)</string>
+    <string name="l10n_devices_screen_body_location_probe_explainer_a9363239">Sends the read-only body-location command (0x54) and dumps the strap\'s full raw reply to the strap log, decoding the record (revision / location / confidence / status) on WHOOP 4.0. Nothing is written to the strap, and it never changes wear detection or scoring.</string>
     <string name="l10n_devices_screen_battery_probe_explainer_2858bb6a">Two independent protocol tables disagree on the extended-battery opcode (98 vs 87). This sends the curated read-only 98 and dumps the strap\'s full raw reply to the strap log. A battery-style payload confirms 98 on your firmware; a short stub means it stays ambiguous. Nothing is written to the strap. Please export and share the strap log afterwards.</string>
     <string name="l10n_devices_screen_cancel_77dfd213">Cancel</string>
     <string name="l10n_devices_screen_clamped_1f39cebb">%1$s%%</string>

--- a/android/app/src/test/java/com/noop/ble/BodyLocationProbeFormatTest.kt
+++ b/android/app/src/test/java/com/noop/ble/BodyLocationProbeFormatTest.kt
@@ -1,0 +1,104 @@
+package com.noop.ble
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * #690: byte-parity twin of the Swift `BodyLocationProbeTests` — same synthetic fixtures, same expectations
+ * — for `WhoopBleClient.formatBodyLocationProbe`. Fixtures are SYNTHETIC (the 4-byte layout is RE'd, not yet
+ * hardware-captured); they pin the decode/format contract until a strap answers 0x54.
+ */
+class BodyLocationProbeFormatTest {
+
+    private fun hexToBytes(h: String): ByteArray =
+        ByteArray(h.length / 2) { ((h[it * 2].digitToInt(16) shl 4) or h[it * 2 + 1].digitToInt(16)).toByte() }
+
+    // cmd 0x54 @6, payload [revision=01, location=01 WRIST, confidence=5a=90, status=00], then a 4-byte CRC.
+    private val wristFrame = "aa09000024005401015a00deadbeef"
+
+    @Test fun whoop4AcceptedDecodesTheFourFields() {
+        val (text, payHex) = WhoopBleClient.formatBodyLocationProbe(hexToBytes(wristFrame), 6, false, null)
+        assertTrue(text.contains("WHOOP 4.0"))
+        assertTrue(text.contains("opcode 84 ACCEPTED — 4-byte payload"))
+        assertTrue(text.contains(wristFrame))
+        assertTrue(text.contains("  @00  01 01 5a 00"))
+        assertTrue(text.contains("revision:   1"))
+        assertTrue(text.contains("location:   1  (WRIST)"))
+        assertTrue(text.contains("confidence: 90  (raw)"))
+        assertTrue(text.contains("status:     0  (raw)"))
+        assertTrue(text.contains("first capture"))
+        assertEquals(4 * 2, payHex?.length)
+    }
+
+    @Test fun unknownLocationIsPreservedAsRaw() {
+        val (text, _) = WhoopBleClient.formatBodyLocationProbe(hexToBytes("aa09000024005401060000deadbeef"), 6, false, null)
+        assertTrue(text.contains("location:   6  (raw6)"))
+    }
+
+    @Test fun knownEnumValuesMapToTheirLabels() {
+        val cases = listOf(2 to "BICEP", 3 to "CALF", 4 to "SIDE_TORSO", 5 to "GLUTE", 7 to "ANKLE",
+            128 to "NOT_CONCLUSIVE", 160 to "UNKNOWN_GARMENT")
+        for ((raw, label) in cases) {
+            val frame = "aa090000240054" + "01" + "%02x".format(raw) + "0000" + "deadbeef"
+            val (text, _) = WhoopBleClient.formatBodyLocationProbe(hexToBytes(frame), 6, false, null)
+            assertTrue("location $raw should read $label", text.contains("($label)"))
+        }
+    }
+
+    @Test fun diffFlagsTheChangedLocationByte() {
+        val first = hexToBytes(wristFrame)
+        val (_, prev) = WhoopBleClient.formatBodyLocationProbe(first, 6, false, null)
+        val second = first.copyOf()
+        second[8] = 0x03            // location WRIST(01) -> CALF(03)
+        val (text, _) = WhoopBleClient.formatBodyLocationProbe(second, 6, false, prev)
+        assertTrue(text.contains("Δ vs previous capture:"))
+        assertTrue(text.contains("@01:01→03"))
+        assertTrue(text.contains("location:   3  (CALF)"))
+    }
+
+    @Test fun bareStubIsCalledOut() {
+        val (text, payHex) = WhoopBleClient.formatBodyLocationProbe(hexToBytes("aa0700fa24005446758858"), 6, false, null)
+        assertTrue(text.contains("bare stub"))
+        assertNull(payHex)
+    }
+
+    /** Golden FULL-output lock: the exact byte-for-byte report, identical to the Swift
+     *  `BodyLocationProbeTests.testFullOutput_goldenParityLock`, so the two twins can't drift. */
+    @Test fun fullOutputGoldenParityLock() {
+        val (text, _) = WhoopBleClient.formatBodyLocationProbe(hexToBytes(wristFrame), 6, false, null)
+        val golden = listOf(
+            "#690 BODY-LOCATION PROBE — WHOOP 4.0",
+            "Verdict: opcode 84 ACCEPTED — 4-byte payload",
+            "",
+            "Raw frame (15 B):",
+            "aa09000024005401015a00deadbeef",
+            "",
+            "Payload (4 B, CRC excluded):",
+            "  @00  01 01 5a 00",
+            "",
+            "Decoded:",
+            "  revision:   1",
+            "  location:   1  (WRIST)",
+            "  confidence: 90  (raw)",
+            "  status:     0  (raw)",
+            "",
+            "Δ vs previous capture: first capture — probe again in another position to diff",
+        ).joinToString("\n")
+        assertEquals(golden, text)
+    }
+
+    @Test fun whoop5SuccessDoesNotMisdecodeTheResultCodeAsAField() {
+        val (text, _) = WhoopBleClient.formatBodyLocationProbe(hexToBytes("aa000c000000000000005400010102030405060708090a46758858"), 10, true, null)
+        assertTrue(text.contains("Result code @12: SUCCESS(1)"))
+        assertTrue("must never present the result code as a location", !text.contains("location:"))
+        assertTrue(text.contains("unconfirmed"))
+    }
+
+    @Test fun whoop5UnsupportedIsDecisiveVerdict() {
+        val (text, _) = WhoopBleClient.formatBodyLocationProbe(hexToBytes("aa000c000000000000005400030046758858"), 10, true, null)
+        assertTrue(text.contains("REJECTED by firmware (UNSUPPORTED)"))
+        assertTrue(text.contains("Result code @12: UNSUPPORTED(3)"))
+    }
+}

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -356,7 +356,7 @@ public func frame(seq: UInt8, payload: [UInt8] = [0x00]) -> [UInt8] {
 | 79 | `RUN_HAPTICS_PATTERN` | `[patternId, loops, 0,0,0]` | buzz a preset haptic pattern |
 | 80 | `GET_ALL_HAPTICS_PATTERN` | — | enumerate preset patterns |
 | 81 / 82 | `START_RAW_DATA` / `STOP_RAW_DATA` | `[0x01]` | raw-data collection toggle |
-| 84 | `GET_BODY_LOCATION_AND_STATUS` | — | wrist/body-location status |
+| 84 | `GET_BODY_LOCATION_AND_STATUS` | — | wrist/body-location status (read-only diagnostic probe, #690 — below) |
 | 96 / 97 | `ENTER_HIGH_FREQ_SYNC` / `EXIT_HIGH_FREQ_SYNC` | `[0x00]` | high-freq offload mode |
 | 98 | `GET_EXTENDED_BATTERY_INFO` | — | extended battery (mV etc.) |
 | 100 | `CALIBRATE_CAPSENSE` | — | recalibrate cap-touch |
@@ -430,6 +430,20 @@ one non-destructive candidate at a time — `REBOOT_STRAP(29)` empty, `POWER_CYC
 link (worked) vs is ignored. The definitive fix is still an HCI capture of the official app rebooting a
 4.0 (the way the alarm frame was pinned, #535). Driven by `BLEManager.rebootProbe(_:)` /
 `WhoopBleClient.rebootProbe(...)`; candidates enumerated in `RebootProbeVariant`.
+
+**Body-location probe (#690).** A read-only, user-triggered diagnostic (Test Centre → Connection, both
+families) that sends `GET_BODY_LOCATION_AND_STATUS` (84 / `0x54`) and dumps the strap's full raw
+COMMAND_RESPONSE to the strap log + a copyable dialog. The 4-byte inner-payload record is
+`revision · location · confidence · status`; `location` maps `0 UNKNOWN, 1 WRIST, 2 BICEP, 3 CALF,
+4 SIDE_TORSO, 5 GLUTE, 7 ANKLE, 128 NOT_CONCLUSIVE, 160 UNKNOWN_GARMENT` (any other value — including the
+gap at 6 — is kept raw; `confidence`/`status` stay raw until captures establish their semantics). Decoded
+only on WHOOP 4.0, where the inner payload starts at the command byte + 1; on 5/MG the puffin envelope's
+result code sits where `location` would land, so the raw grid is shown and the record is left undecoded
+until a real 5/MG capture maps the offset. **Never** feeds wear detection, sleep gating, or scoring.
+Driven by `BLEManager.probeBodyLocationAndStatus()` / `WhoopBleClient.probeBodyLocationAndStatus()`;
+formatted by the pure `BodyLocationProbe` twin (Swift↔Kotlin byte-parity locked by a golden test). The
+layout + enum facts are reverse-engineered from the WHOOP app and reimplemented in NOOP's own code
+(facts, not copied expression — see [`ATTRIBUTION.md`](../ATTRIBUTION.md)).
 
 **Payload forms** (decoded from the official app's command builders — recorded so the wire format is
 *known*: for the destructive commands, known-and-avoidable; for the one guarded exception,


### PR DESCRIPTION
Fixes #690. Adds the read-only body-location/status diagnostic probe tigercraft4 proposed, at full iOS↔Android parity and mirroring the #592 extended-battery probe.

## What it does
A user-triggered (Test Centre → Connection, both families) read-only send of `GET_BODY_LOCATION_AND_STATUS` (84 / `0x54`). The strap's full raw COMMAND_RESPONSE is dumped to the strap log **and** a copyable dialog, with the 4-byte record decoded: `revision · location · confidence · status`. `location` maps the enum (0 UNKNOWN, 1 WRIST, 2 BICEP, 3 CALF, 4 SIDE_TORSO, 5 GLUTE, 7 ANKLE, 128 NOT_CONCLUSIVE, 160 UNKNOWN_GARMENT); **unknown/gap values (incl. 6) and `confidence`/`status` are kept raw**. **Never** touches wear detection, sleep gating, or scoring (acceptance criteria).

## Design notes
- **Pure parser twins** `BodyLocationProbe` (Swift, in `WhoopProtocol`) / `formatBodyLocationProbe` (Kotlin), **byte-parity locked by a golden full-output test** on both sides.
- **Decoded only on WHOOP 4.0** (inner payload starts at cmd byte + 1). On **5/MG** the puffin envelope's result code sits where `location` would land, so a decode there would mislabel it — the raw grid is shown and the record left undecoded until a real 5/MG capture maps the offset. (Caught in review; pinned by a test.)
- **Response dispatch is in-flight-guarded** (only surfaces a result while a probe is actually waiting), so a stray data frame with `0x54` at the cmd offset can't pop the dialog — stricter than the #592 probe, on purpose.
- Reuses the generic `send()` — no new BLE machinery; one 5/MG allowlist entry.

## Provenance
The layout + enum facts are reverse-engineered from the WHOOP app and **reimplemented in NOOP's own code** — facts, not copied expression (see `ATTRIBUTION.md`; consistent with how goose-sourced protocol facts are handled). Documented in `docs/PROTOCOL.md`.

## Verification
- **Parser:** `swift test` (WhoopProtocol, **302 pass**, incl. 8 body-location + golden parity lock) + Kotlin `BodyLocationProbeFormatTest` green.
- **Android:** `compileFullDebugKotlin` + `Tools/i18n_audit.py` (de/es/fr complete, no gaps) + probe tests — green.
- **macOS:** app-build **green**.
- **iOS:** app-build **green** (after two Swift type-check fixes: hoisting the shared probe gate, and isolating the body-location dialogs into a ViewModifier so the DevicesView modifier chain stays under iOS's type-check budget).
- **i18n:** CI regression gate **green** — the 4 new iOS literals added to `Strand/Resources/Localizable.xcstrings` (de/es/fr); Android `values-de/es/fr` complete.

Reported-by: tigercraft4