### PR TITLE
build(ios): Make the bundle id prefix configurable via a project-level xcconfig

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -98,3 +98,6 @@ err.txt
 
 # Oura OAuth app credentials (BYO; never committed)
 Strand/Oura/OuraSecrets.xcconfig
+
+# Personal bundle id prefix (BYO; never committed)
+Config/BundleIdSecrets.xcconfig

--- a/Config/BundleId.xcconfig
+++ b/Config/BundleId.xcconfig
@@ -1,0 +1,14 @@
+// Tracked wrapper so a clean checkout (no local prefix) still generates and builds under the
+// upstream identifiers. Referenced from project.yml's top-level (project-wide) configFiles, so
+// every target picks it up automatically — including targets that also carry their own separate
+// xcconfig (e.g. Strand/Oura/OuraConfig.xcconfig), since Xcode layers project-level xcconfig
+// beneath target-level xcconfig rather than one replacing the other. Feeds
+// PRODUCT_BUNDLE_IDENTIFIER, APP_GROUP_ID, and WKCompanionAppBundleIdentifier across all six
+// targets (see project.yml's use of $(BUNDLE_ID_PREFIX)).
+//
+// BundleIdSecrets.xcconfig is gitignored and user-created (template:
+// BundleIdSecrets.example.xcconfig). Set BUNDLE_ID_PREFIX there when building under your own
+// Apple ID / device so this build's bundle id, App Group, and watch companion pairing don't
+// collide with an installed copy of the official com.noopapp build.
+BUNDLE_ID_PREFIX = com.noopapp
+#include? "BundleIdSecrets.xcconfig"

--- a/Config/BundleIdSecrets.example.xcconfig
+++ b/Config/BundleIdSecrets.example.xcconfig
@@ -1,0 +1,5 @@
+// Copy to BundleIdSecrets.xcconfig (gitignored) and set your own reverse-DNS prefix so this
+// build's identifiers don't collide with an installed copy of the official com.noopapp build —
+// the App Group id and watch companion pairing both key off BUNDLE_ID_PREFIX (see
+// Config/BundleId.xcconfig), not just PRODUCT_BUNDLE_IDENTIFIER.
+BUNDLE_ID_PREFIX = com.yourdomain

--- a/NOOPWatch/Info.plist
+++ b/NOOPWatch/Info.plist
@@ -29,6 +29,6 @@
 	<key>WKApplication</key>
 	<true/>
 	<key>WKCompanionAppBundleIdentifier</key>
-	<string>com.noopapp.noop</string>
+	<string>$(BUNDLE_ID_PREFIX).noop</string>
 </dict>
 </plist>

--- a/NOOPWatch/WatchScoreStore.swift
+++ b/NOOPWatch/WatchScoreStore.swift
@@ -20,14 +20,11 @@ final class WatchScoreStore: NSObject, ObservableObject, WCSessionDelegate {
     /// The latest snapshot the watch knows about. nil = nothing has ever synced (fresh install).
     @Published private(set) var snapshot: WatchScoreSnapshot?
 
-    /// The shared App Group suite the watch app + its complication both read/write. The watch reads its
-    /// own bundle's AppGroupIdentifier Info.plist key (injected from $(APP_GROUP_ID) in project.yml) so
-    /// the value is never hard-coded in Swift, then falls back to the canonical group defined ONCE in
-    /// the shared contract (StrandDesign) so the writer and readers can't desync on it.
-    static let suiteName: String = {
-        Bundle.main.object(forInfoDictionaryKey: "AppGroupIdentifier") as? String
-            ?? WatchScoreSnapshot.appGroupId
-    }()
+    /// The shared App Group suite the watch app + its complication both read/write. `Bundle.main` is
+    /// process-global, so this is exactly the lookup `WatchScoreSnapshot.appGroupId` itself performs —
+    /// deferring to it directly (rather than repeating the lookup here) keeps the resolution in ONE
+    /// place so the writer and readers can't desync on it.
+    static let suiteName: String = WatchScoreSnapshot.appGroupId
 
     /// The key the complication also reads. The single source of truth lives in the shared contract.
     static let storageKey = WatchScoreSnapshot.storageKey

--- a/NOOPWatchComplications/NOOPWatchComplication.swift
+++ b/NOOPWatchComplications/NOOPWatchComplication.swift
@@ -21,19 +21,17 @@ import StrandDesign
 //
 // We read the app group directly here rather than depending on a loader symbol from the bridge
 // lane, so this extension only needs the shared `WatchScoreSnapshot` type from StrandDesign. The
-// suite + key match the cross-lane contract: the phone-side bridge writes the latest snapshot to
-// `group.com.noopapp.noop` under `latestWatchSnapshot`, and the watch app + this complication read
-// it. The suite name is read from the extension's own Info.plist (AppGroupIdentifier) so it lives
-// in one place, with the canonical group as a fallback.
+// suite + key match the cross-lane contract: the phone-side bridge writes the latest snapshot under
+// `latestWatchSnapshot` to whatever app group `WatchScoreSnapshot.appGroupId` resolves to (the
+// extension's own AppGroupIdentifier Info.plist key, injected from $(APP_GROUP_ID)/$(BUNDLE_ID_PREFIX)
+// in project.yml, falling back to the canonical upstream group), and the watch app + this
+// complication read the same value.
 
 enum WatchSnapshotAccess {
-    // The app group is read from the extension's own Info.plist (AppGroupIdentifier) so the entitled
-    // value wins, then falls back to the canonical group the contract pins. The storage KEY is the
-    // shared one from StrandDesign so the writer and every reader can never desync on it.
-    static let suiteName: String = {
-        Bundle.main.object(forInfoDictionaryKey: "AppGroupIdentifier") as? String
-            ?? WatchScoreSnapshot.appGroupId
-    }()
+    /// `Bundle.main` is process-global, so this is exactly the lookup `WatchScoreSnapshot.appGroupId`
+    /// itself performs — deferring to it directly keeps the resolution in ONE place so the writer and
+    /// every reader can never desync on it.
+    static let suiteName: String = WatchScoreSnapshot.appGroupId
 
     static let storageKey = WatchScoreSnapshot.storageKey
 

--- a/Packages/StrandDesign/Sources/StrandDesign/WatchScoreSnapshot.swift
+++ b/Packages/StrandDesign/Sources/StrandDesign/WatchScoreSnapshot.swift
@@ -74,8 +74,15 @@ public struct WatchScoreSnapshot: Codable, Equatable, Sendable {
     // the group too (belt and braces alongside updateApplicationContext), so a freshly launched watch
     // reads the last known value immediately.
 
-    /// The shared app group both the watch app and its complication read the snapshot from.
-    public static let appGroupId = "group.com.noopapp.noop"
+    /// The shared app group both the watch app and its complication read the snapshot from. Injected
+    /// from the `APP_GROUP_ID` build setting (see project.yml) via the `AppGroupIdentifier` Info.plist
+    /// key on every target that touches it (NOOPiOS, NOOPWatch, NOOPWatchComplications), mirroring
+    /// `WidgetSnapshot.suiteName` — this package builds standalone (`swift test`) with no host bundle,
+    /// so the fallback below is the canonical upstream group and only applies there.
+    public static let appGroupId: String = {
+        Bundle.main.object(forInfoDictionaryKey: "AppGroupIdentifier") as? String
+            ?? "group.com.noopapp.noop"
+    }()
     /// The UserDefaults key the latest snapshot is stored under in the shared app group.
     public static let storageKey = "latestWatchSnapshot"
 

--- a/Strand/System/ScheduledDebugExport.swift
+++ b/Strand/System/ScheduledDebugExport.swift
@@ -38,9 +38,11 @@ enum ScheduledDebugExport {
     static let defaultTimeMinutes = 7 * 60
     private static let minutesPerDay = 24 * 60
 
-    /// iOS BGTask identifier. Must also appear in the iOS target's `BGTaskSchedulerPermittedIdentifiers`
-    /// (Info.plist) and be registered at launch for `submit` to succeed — wired in the app entry point.
-    static let bgTaskIdentifier = "com.noopapp.noop.debugexport"
+    /// iOS BGTask identifier. Derived from the running bundle id (rather than hardcoded) so it tracks
+    /// BUNDLE_ID_PREFIX (see Config/BundleId.xcconfig) automatically and always matches the iOS target's
+    /// `BGTaskSchedulerPermittedIdentifiers` (Info.plist), which is built from `$(PRODUCT_BUNDLE_IDENTIFIER)`
+    /// the same way. Must also be registered at launch for `submit` to succeed — wired in the app entry point.
+    static let bgTaskIdentifier = (Bundle.main.bundleIdentifier ?? "com.noopapp.noop") + ".debugexport"
 
     static var isEnabled: Bool { UserDefaults.standard.bool(forKey: K.enabled) }
 

--- a/StrandTests/WatchScoreSnapshotTests.swift
+++ b/StrandTests/WatchScoreSnapshotTests.swift
@@ -100,7 +100,10 @@ final class WatchScoreSnapshotTests: XCTestCase {
     }
 
     func testStorageContractMatchesWatchSideExpectation() {
-        // The cross-lane contract: app group + key are fixed strings both sides hard-agree on.
+        // storageKey is a fixed string all sides hard-agree on. appGroupId is dynamic (resolved from
+        // the running bundle's AppGroupIdentifier Info.plist key — see WatchScoreSnapshot.swift); this
+        // test process carries no such key (StrandTests hosts inside the macOS Strand target, which
+        // has none), so this only pins the canonical UPSTREAM fallback, not the real cross-target value.
         XCTAssertEqual(WatchScoreSnapshot.appGroupId, "group.com.noopapp.noop")
         XCTAssertEqual(WatchScoreSnapshot.storageKey, "latestWatchSnapshot")
     }

--- a/StrandiOS/Resources/Info.plist
+++ b/StrandiOS/Resources/Info.plist
@@ -6,7 +6,7 @@
 	<string>$(APP_GROUP_ID)</string>
 	<key>BGTaskSchedulerPermittedIdentifiers</key>
 	<array>
-		<string>com.noopapp.noop.debugexport</string>
+		<string>$(PRODUCT_BUNDLE_IDENTIFIER).debugexport</string>
 	</array>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>

--- a/docs/IOS.md
+++ b/docs/IOS.md
@@ -67,20 +67,20 @@ Prefer to build it yourself (which also grants HealthKit/widgets under your own 
 [PR #42](../../../pull/42) port onto current `main` is summarised in **"Lessons from the fold-in"**
 below.
 
-> 🛠️ **Signing it under your own Apple ID** (thanks @gingerbeardman for the recipe). Apple requires a
-> bundle id and an app group that are unique to *your* developer account, so for each target that has
-> them (the `NOOPiOS` app **and** the `NOOPiOSWidgets` extension):
-> 1. **Select your Team** (Signing & Capabilities).
-> 2. **Change the bundle id** to your own reverse-domain prefix (e.g. `com.yourdomain.noop`).
-> 3. **Change the App Group** to match (e.g. `group.com.yourdomain.noop`) — the app and the widget
->    extension must share the *same* group.
+> 🛠️ **Signing it under your own Apple ID** (thanks @gingerbeardman for the original recipe). Apple
+> requires a bundle id and app group unique to *your* developer account — otherwise the build collides
+> with any other NOOP install already on your device (an AltStore/SideStore sideload, or someone
+> else's build). Two steps:
+> 1. `cp Config/BundleIdSecrets.example.xcconfig Config/BundleIdSecrets.xcconfig` and set
+>    `BUNDLE_ID_PREFIX` to your own reverse-domain prefix (e.g. `com.yourdomain`), then re-run
+>    `xcodegen generate`. This one gitignored file drives **every** target's bundle id *and* the shared
+>    App Group together (`$(BUNDLE_ID_PREFIX).noop`, `group.$(BUNDLE_ID_PREFIX).noop.staging`) — nothing
+>    hard-coded in Swift, nothing else to edit, and it survives future regenerates.
+> 2. In Xcode, **select your Team** (Signing & Capabilities) for the `NOOPiOS` **and** `NOOPiOSWidgets`
+>    targets — the one step Apple still requires you to do by hand.
 >
-> Set the team + bundle prefix in **`project.yml`**, and set the App Group **once** via the
-> **`APP_GROUP_ID`** build setting there — both targets' entitlements/Info.plist reference
-> `$(APP_GROUP_ID)`, and the runtime `WidgetSnapshot.suiteName` reads it back from the Info.plist, so
-> there's a single value to change and nothing hard-coded in Swift. Then re-run `xcodegen` so the
-> change survives regeneration instead of being overwritten. The App Group is only needed for the
-> **widgets / Live Activity** — if you don't need those, you can skip wiring it and the core app still builds.
+> Skip step 1 and the build still works under the default `com.noopapp` identifiers — fine if this is
+> the only NOOP install on your device.
 
 > ℹ️ **Cross-platform engineering lives in [`CROSS_PLATFORM.md`](CROSS_PLATFORM.md)** — the shared-code
 > boundary across the macOS / iOS / Android clients, the `Platform.swift` shim convention, the

--- a/project.yml
+++ b/project.yml
@@ -1,6 +1,5 @@
 name: Strand
 options:
-  bundleIdPrefix: com.noopapp
   deploymentTarget:
     macOS: "13.0"
   createIntermediateGroups: true
@@ -9,6 +8,13 @@ options:
   # the String Catalog (Strand/Resources/Localizable.xcstrings) carries this as the
   # source language and is where additional languages are added.
   developmentLanguage: en
+# Project-level xcconfig: Xcode layers this beneath every target's OWN configFiles (a target-level
+# xcconfig only shadows keys it redefines itself), so this is the one place BUNDLE_ID_PREFIX is
+# defined — every target picks it up automatically, including Strand/StrandTests/NOOPiOS, which also
+# carry Strand/Oura/OuraConfig.xcconfig for their unrelated Oura credentials. See Config/BundleId.xcconfig.
+configFiles:
+  Debug: Config/BundleId.xcconfig
+  Release: Config/BundleId.xcconfig
 settings:
   base:
     MARKETING_VERSION: "9.0.3"
@@ -26,8 +32,9 @@ settings:
     # Single source of truth for the App Group id shared by the iOS app + its widget / Live Activity
     # extension. Referenced as $(APP_GROUP_ID) by both targets' entitlements and Info.plist, and read
     # at runtime via the AppGroupIdentifier Info.plist key (WidgetSnapshot.suiteName) so the value is
-    # never hard-coded in Swift. Change it in this one place when building under your own Apple ID.
-    APP_GROUP_ID: group.com.noopapp.noop.staging
+    # never hard-coded in Swift. Built from $(BUNDLE_ID_PREFIX) (see Config/BundleId.xcconfig) — set
+    # BUNDLE_ID_PREFIX in a gitignored Config/BundleIdSecrets.xcconfig to build under your own Apple ID.
+    APP_GROUP_ID: group.$(BUNDLE_ID_PREFIX).noop.staging
     # Build for both Apple Silicon and Intel so the release runs on every Mac.
     ARCHS: "$(ARCHS_STANDARD)"
   configs:
@@ -122,7 +129,7 @@ targets:
         com.apple.security.network.client: true
     settings:
       base:
-        PRODUCT_BUNDLE_IDENTIFIER: com.noopapp.noop.staging
+        PRODUCT_BUNDLE_IDENTIFIER: $(BUNDLE_ID_PREFIX).noop.staging
         PRODUCT_NAME: "NOOP Staging"
         # Pin the Swift module name so `@testable import Strand` resolves even though PRODUCT_NAME is
         # NOOP — the test target and shared sources refer to the app module as `Strand`.
@@ -161,7 +168,7 @@ targets:
     settings:
       base:
         GENERATE_INFOPLIST_FILE: YES
-        PRODUCT_BUNDLE_IDENTIFIER: com.noopapp.strandtests
+        PRODUCT_BUNDLE_IDENTIFIER: $(BUNDLE_ID_PREFIX).strandtests
         # Host the unit tests in the app so `@testable import Strand` links against the real app module.
         # NOTE: must track the app target's PRODUCT_NAME ("NOOP Staging" since the staging rename).
         TEST_HOST: "$(BUILT_PRODUCTS_DIR)/NOOP Staging.app/Contents/MacOS/NOOP Staging"
@@ -248,11 +255,12 @@ targets:
           # launch in StrandiOSApp.init) or the submit fails gracefully and only the foreground/"Run now"
           # paths run.
           - fetch
-        # #510: permit the scheduled debug auto-export's BGAppRefreshTask identifier. MUST match
-        # ScheduledDebugExport.bgTaskIdentifier EXACTLY and be registered at launch (StrandiOSApp.init);
-        # otherwise iOS refuses to schedule or deliver the background drop.
+        # #510: permit the scheduled debug auto-export's BGAppRefreshTask identifier. Built from
+        # $(PRODUCT_BUNDLE_IDENTIFIER) so it tracks BUNDLE_ID_PREFIX automatically; MUST still match
+        # ScheduledDebugExport.bgTaskIdentifier EXACTLY (which derives it from Bundle.main the same
+        # way) and be registered at launch (StrandiOSApp.init), or iOS refuses to schedule/deliver it.
         BGTaskSchedulerPermittedIdentifiers:
-          - com.noopapp.noop.debugexport
+          - $(PRODUCT_BUNDLE_IDENTIFIER).debugexport
         NSBluetoothAlwaysUsageDescription: "NOOP connects directly to your WHOOP strap over Bluetooth to read heart rate, R-R intervals, battery, and sensor data locally on your iPhone. Nothing leaves your device."
         NSLocationWhenInUseUsageDescription: "NOOP records your route during an outdoor workout to show distance, pace, and a map, and keeps recording while the screen is off. The route stays on your device. Nothing leaves it."
         NSHealthShareUsageDescription: "NOOP reads your own Apple Health data on-device to compute recovery, strain, and sleep. Nothing leaves your device."
@@ -287,7 +295,7 @@ targets:
           - $(APP_GROUP_ID)
     settings:
       base:
-        PRODUCT_BUNDLE_IDENTIFIER: com.noopapp.noop
+        PRODUCT_BUNDLE_IDENTIFIER: $(BUNDLE_ID_PREFIX).noop
         PRODUCT_NAME: "NOOP Staging"
         ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon
         # Ship every *.appiconset (not just the primary AppIcon) so the alternate "AppIcon-Navy"
@@ -346,7 +354,7 @@ targets:
           - $(APP_GROUP_ID)
     settings:
       base:
-        PRODUCT_BUNDLE_IDENTIFIER: com.noopapp.noop.widgets
+        PRODUCT_BUNDLE_IDENTIFIER: $(BUNDLE_ID_PREFIX).noop.widgets
         PRODUCT_NAME: NOOPWidgets
         GENERATE_INFOPLIST_FILE: NO
         TARGETED_DEVICE_FAMILY: "1,2"
@@ -386,7 +394,9 @@ targets:
         # Modern single-target watchOS app — no separate WatchKit extension.
         WKApplication: true
         # Pairs this watch app to the iPhone companion (must match NOOPiOS PRODUCT_BUNDLE_IDENTIFIER).
-        WKCompanionAppBundleIdentifier: com.noopapp.noop
+        # Built from the same $(BUNDLE_ID_PREFIX) rather than $(PRODUCT_BUNDLE_IDENTIFIER) because that
+        # build setting would resolve to THIS target's own id, not NOOPiOS's.
+        WKCompanionAppBundleIdentifier: $(BUNDLE_ID_PREFIX).noop
         NSHealthShareUsageDescription: "NOOP reads your heart rate from the Watch sensor to show a live readout on your wrist. It stays on your device."
         NSHealthUpdateUsageDescription: "NOOP records a basic workout session on your Watch for a higher-fidelity heart rate. The session stays on your device."
     entitlements:
@@ -398,7 +408,7 @@ targets:
           - $(APP_GROUP_ID)
     settings:
       base:
-        PRODUCT_BUNDLE_IDENTIFIER: com.noopapp.noop.watch
+        PRODUCT_BUNDLE_IDENTIFIER: $(BUNDLE_ID_PREFIX).noop.watch
         # The bundle FILE is NOOPWatch.app so it doesn't collide with the iPhone app's NOOP.app when it is
         # embedded at NOOP.app/Watch/NOOPWatch.app. The user still sees "NOOP" on the wrist via the
         # CFBundleName / CFBundleDisplayName above.
@@ -448,7 +458,7 @@ targets:
           - $(APP_GROUP_ID)
     settings:
       base:
-        PRODUCT_BUNDLE_IDENTIFIER: com.noopapp.noop.watch.complications
+        PRODUCT_BUNDLE_IDENTIFIER: $(BUNDLE_ID_PREFIX).noop.watch.complications
         PRODUCT_NAME: NOOPWatchComplications
         GENERATE_INFOPLIST_FILE: NO
         TARGETED_DEVICE_FAMILY: "4"


### PR DESCRIPTION
## What this PR does

Every target hardcoded identifiers under com.noopapp, so building under your own Apple ID meant hand-editing project.yml in six places to avoid colliding with an installed official/sideloaded copy.

This change introduces a BUNDLE_ID_PREFIX xcconfig variable that every target picks up automatically. Users can override this in a gitignored Config/BundleIdSecrets.xcconfig. 

Update docs/IOS.md's "build from source" instructions to match.
## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [X] CI / tooling

## How it was tested

Built locally with + without the local config file.

## Checklist

- [x] Swift package tests pass for any package I touched (`swift test` in `Packages/<name>`)
- [x] Android unit tests pass if I touched `android/` (`./gradlew testFullDebugUnitTest`)
- [x] No new build warnings introduced
- [x] UI changes use only `StrandDesign` tokens — no hardcoded colors, fonts, or spacing
- [x] No hardcoded hex frame bytes; protocol facts live in the schema / decoders
- [x] Follows the conventions in [`docs/CONTRIBUTING.md`](../docs/CONTRIBUTING.md)
- [x] I did not commit generated output (`Strand.xcodeproj/`) or any secrets/keystores

## Related issues

<!-- Closes #N -->
