### PR TITLE
feat(testcentre): master "Diagnostics capture" switch to gate on-device research artifacts

### DIFF
--- a/Strand/BLE/BLEManager.swift
+++ b/Strand/BLE/BLEManager.swift
@@ -937,9 +937,10 @@ public final class BLEManager: NSObject, ObservableObject {
             self.deviceId = activeId
         }
         try? await store.upsertDevice(id: deviceId, mac: nil, name: "WHOOP 4.0")
-        // Research toggle — OFF by default. When disabled the app is decoded-only and never
-        // persists raw frames. Flip "enableRawCapture" in UserDefaults to capture raw again.
-        let enableRawCapture = UserDefaults.standard.bool(forKey: "enableRawCapture")
+        // Research toggle — OFF by default. When disabled the app is decoded-only and never persists raw
+        // frames. Flip "enableRawCapture" in UserDefaults, OR the Test Centre "Diagnostics capture" master
+        // switch, to capture raw again (see PuffinExperiment.rawCaptureActive).
+        let enableRawCapture = PuffinExperiment.rawCaptureActive
         collector = Collector(store: store, deviceId: deviceId,
                               enableRawCapture: enableRawCapture)
         // The store can finish bootstrapping AFTER connect(model:) already ran (both wait on
@@ -1442,10 +1443,10 @@ public final class BLEManager: NSObject, ObservableObject {
         log("Raw-accel capture: started for \(secs)s")
         DispatchQueue.main.asyncAfter(deadline: .now() + secs) { [weak self] in
             guard let self else { return }
-            // Only stop the raw stream if the 24/7 research toggle is OFF.  When it's ON, the
-            // continuous stream must keep running — we just flush/upload the bounded window we
-            // captured without halting the wider session.
-            if !UserDefaults.standard.bool(forKey: "enableRawCapture") {
+            // Only stop the raw stream if the 24/7 research toggle is OFF.  When it's ON (either the
+            // per-strap flag or the Test Centre "Diagnostics capture" master), the continuous stream must
+            // keep running — we just flush/upload the bounded window we captured without halting the session.
+            if !PuffinExperiment.rawCaptureActive {
                 self.send(.stopRawData, payload: [0x01])
             }
             self.rawCaptureInFlight = false

--- a/Strand/BLE/OuraLiveSource.swift
+++ b/Strand/BLE/OuraLiveSource.swift
@@ -772,10 +772,13 @@ public final class OuraLiveSource: NSObject, ObservableObject {
         self.onSerial = onSerial
         self.feedsLive = feedsLive
         self.adoptIntent = adoptIntent
-        // Tier-B MET research corpus: only on a live/persisting source, never the discovery-only scanner.
-        self.activityDump = feedsLive && !deviceId.isEmpty ? OuraActivityDump(deviceId: deviceId, log: log) : nil
-        // 0x47 motion calibration corpus: same gate as the activity dump (live/persisting source only).
-        self.motionDump = feedsLive && !deviceId.isEmpty ? OuraMotionDump(deviceId: deviceId, log: log) : nil
+        // Tier-B MET research corpus: only on a live/persisting source, never the discovery-only scanner, and
+        // only when the Test Centre "Diagnostics capture" master switch is on (default OFF → no sidecar file).
+        self.activityDump = feedsLive && !deviceId.isEmpty && PuffinExperiment.diagnosticsCaptureEnabled
+            ? OuraActivityDump(deviceId: deviceId, log: log) : nil
+        // 0x47 motion calibration corpus: same gate as the activity dump (incl. the master switch).
+        self.motionDump = feedsLive && !deviceId.isEmpty && PuffinExperiment.diagnosticsCaptureEnabled
+            ? OuraMotionDump(deviceId: deviceId, log: log) : nil
         super.init()
         // Dedicated queue-less central -> callbacks arrive on the main queue, matching @MainActor.
         self.central = CBCentralManager(delegate: self, queue: nil)

--- a/Strand/BLE/PuffinExperiment.swift
+++ b/Strand/BLE/PuffinExperiment.swift
@@ -163,4 +163,24 @@ enum PuffinExperiment {
     static func resetFiveMGGatedProbes() {
         for key in fiveMGGatedKeys { UserDefaults.standard.set(false, forKey: key) }
     }
+
+    // MARK: - Diagnostics capture (Test Centre master switch)
+
+    /// Opt-in "Diagnostics capture" master switch (default OFF): gates the on-device RESEARCH artifacts written
+    /// to `<App Support>/OpenWhoop/Diagnostics` — the Oura Tier-B JSONL sidecars (`oura-activity` / `oura-motion`
+    /// today; `oura-raw` on its own branch) — and ALSO the WHOOP 5/MG raw-frame capture (via `rawCaptureActive`).
+    /// Default OFF keeps the Diagnostics folder empty in normal use; a tester flips it on in the Test Centre for a
+    /// capture session. Read where each dump/capture is CREATED, so a flip takes effect on the next ring/strap
+    /// connection. Mirrors the Android `PuffinExperiment.KEY_DIAGNOSTICS_CAPTURE`.
+    static let diagnosticsCaptureKey = "noopDiagnosticsCapture"
+
+    static var diagnosticsCaptureEnabled: Bool { UserDefaults.standard.bool(forKey: diagnosticsCaptureKey) }
+
+    /// Whether the WHOOP 5/MG continuous raw-frame capture should persist. TRUE when EITHER the long-standing
+    /// per-strap `enableRawCapture` opt-in OR the Test Centre `diagnosticsCapture` master is on — so the master
+    /// switch turns raw capture on too, while the independent `enableRawCapture` flag keeps working on its own.
+    /// (The on-demand bounded raw-capture window is separate and always honoured; this is only the 24/7 gate.)
+    static var rawCaptureActive: Bool {
+        UserDefaults.standard.bool(forKey: "enableRawCapture") || diagnosticsCaptureEnabled
+    }
 }

--- a/Strand/Screens/TestCentreView.swift
+++ b/Strand/Screens/TestCentreView.swift
@@ -41,6 +41,11 @@ struct TestCentreView: View {
     @AppStorage(PuffinExperiment.ppgHrSubLagInterpKey) private var ppgHrSubLagInterpEnabled = false
     @AppStorage(PuffinExperiment.hrvReadinessKey) private var hrvReadinessEnabled = false
 
+    // Section 2: "Diagnostics capture" master switch (default OFF). Bound to the SAME PuffinExperiment key the
+    // Android card writes. Gates the Oura Tier-B JSONL sidecars + the WHOOP raw-frame capture (see
+    // PuffinExperiment.diagnosticsCaptureEnabled / rawCaptureActive). Takes effect on the next connection.
+    @AppStorage(PuffinExperiment.diagnosticsCaptureKey) private var diagnosticsCaptureEnabled = false
+
     /// True when the connected strap is a 5/MG, so the 5/MG experimental block shows. Mirrors the
     /// SettingsView gate (#22): a confident 4.0 owner never sees controls that cannot touch their strap.
     private var is5MG: Bool { selectedWhoopModelRaw == WhoopModel.whoop5mg.rawValue }
@@ -151,6 +156,21 @@ struct TestCentreView: View {
                 NoopButton("Copy environment dump", systemImage: "info.circle", kind: .secondary) {
                     PlatformPasteboard.copy(live.exportableLogText())
                 }
+
+                Divider().overlay(StrandPalette.hairline)
+
+                // Diagnostics capture master switch: gates the on-device research artifacts in the Diagnostics
+                // folder (Oura Tier-B JSONL sidecars + the WHOOP raw-frame capture). Default OFF keeps the
+                // folder empty; flip it on for a capture session. Takes effect on the next ring/strap connection.
+                Toggle(isOn: $diagnosticsCaptureEnabled) {
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text("Diagnostics capture").font(StrandFont.body).foregroundStyle(StrandPalette.textPrimary)
+                        Text("Write research artifacts to the Diagnostics folder: the Oura ring's Tier-B sidecars (activity/MET; IBI-HR and raw once those ship) and the WHOOP 5/MG raw-frame capture. Off by default. Applies on the next connection.")
+                            .font(StrandFont.caption).foregroundStyle(StrandPalette.textTertiary)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+                }
+                .tint(StrandPalette.accent)
             }
         }
     }

--- a/Tools/i18n_extra_locale_baseline.txt
+++ b/Tools/i18n_extra_locale_baseline.txt
@@ -14,8 +14,8 @@ NOOPWatch/Localizable.xcstrings:zh-Hant 3
 NOOPWatchComplications/Localizable.xcstrings:it 25
 NOOPWatchComplications/Localizable.xcstrings:zh-Hans 25
 NOOPWatchComplications/Localizable.xcstrings:zh-Hant 25
-Strand/Resources/Localizable.xcstrings:it 168
-Strand/Resources/Localizable.xcstrings:ru 145
-Strand/Resources/Localizable.xcstrings:zh-Hans 118
-Strand/Resources/Localizable.xcstrings:zh-Hant 168
+Strand/Resources/Localizable.xcstrings:it 170
+Strand/Resources/Localizable.xcstrings:ru 147
+Strand/Resources/Localizable.xcstrings:zh-Hans 120
+Strand/Resources/Localizable.xcstrings:zh-Hant 170
 values-zh/strings.xml 43

--- a/android/app/src/main/java/com/noop/ble/OuraLiveSource.kt
+++ b/android/app/src/main/java/com/noop/ble/OuraLiveSource.kt
@@ -241,14 +241,17 @@ class OuraLiveSource(
     private val adapter: BluetoothAdapter? = bluetoothManager?.adapter
 
     /** Tier-B activity/MET research corpus writer (diagnostic JSONL sidecar; never scored, never a Streams
-     *  row). Null when there is no device id. The Kotlin twin of the Swift `OuraActivityDump`. */
+     *  row). Null when there is no device id OR the Test Centre "Diagnostics capture" master is OFF (default),
+     *  so no sidecar file is written in normal use. The Kotlin twin of the Swift `OuraActivityDump`. */
     private val activityDump: OuraActivityDump? =
-        if (deviceId.isNotEmpty()) OuraActivityDump(appContext, deviceId, log) else null
+        if (deviceId.isNotEmpty() && PuffinExperiment.from(appContext).diagnosticsCapture)
+            OuraActivityDump(appContext, deviceId, log) else null
 
     /** 0x47 motion calibration corpus (Tier-A), for offline LSB→g scale + cadence work (#804). Kotlin twin
-     *  of the Swift `OuraMotionDump`. Null when there is no device id. */
+     *  of the Swift `OuraMotionDump`. Null when there is no device id OR the "Diagnostics capture" master is OFF. */
     private val motionDump: OuraMotionDump? =
-        if (deviceId.isNotEmpty()) OuraMotionDump(appContext, deviceId, log) else null
+        if (deviceId.isNotEmpty() && PuffinExperiment.from(appContext).diagnosticsCapture)
+            OuraMotionDump(appContext, deviceId, log) else null
     private val scanner: BluetoothLeScanner? get() = adapter?.bluetoothLeScanner
 
     private var gatt: BluetoothGatt? = null

--- a/android/app/src/main/java/com/noop/ble/PuffinExperiment.kt
+++ b/android/app/src/main/java/com/noop/ble/PuffinExperiment.kt
@@ -115,6 +115,22 @@ class PuffinExperiment(private val prefs: SharedPreferences) {
         editor.apply()
     }
 
+    /** "Diagnostics capture" master switch (default false): gates the on-device RESEARCH artifacts written to
+     *  the Diagnostics folder — the Oura Tier-B JSONL sidecars (`oura-activity`/`oura-motion` today; `oura-raw`
+     *  on its own branch) — and ALSO the WHOOP 5/MG raw-frame capture (via [rawCaptureActive]). Default OFF keeps
+     *  the folder empty in normal use; a tester flips it on in the Test Centre for a capture session. Read where
+     *  each dump/capture is created, so a flip takes effect on the next connection. Mirrors the macOS
+     *  `PuffinExperiment.diagnosticsCaptureKey`. */
+    var diagnosticsCapture: Boolean
+        get() = prefs.getBoolean(KEY_DIAGNOSTICS_CAPTURE, false)
+        set(v) = prefs.edit().putBoolean(KEY_DIAGNOSTICS_CAPTURE, v).apply()
+
+    /** Whether the WHOOP 5/MG raw-frame capture should persist: TRUE when EITHER the per-strap [isCaptureEnabled]
+     *  opt-in OR the [diagnosticsCapture] master is on. So the Test Centre master turns raw capture on too, while
+     *  the independent capture flag keeps working on its own. Mirrors the macOS `PuffinExperiment.rawCaptureActive`. */
+    val rawCaptureActive: Boolean
+        get() = isCaptureEnabled || diagnosticsCapture
+
     companion object {
         /** Persisted preferences file. Internal so a UI screen can observe external writes to it. */
         internal const val PREFS = "noop_experiments"
@@ -146,6 +162,9 @@ class PuffinExperiment(private val prefs: SharedPreferences) {
 
         /** "Motion-aware wake refinement" opt-in (mirrors macOS `PuffinExperiment.motionAwareWakeKey`). */
         const val KEY_MOTION_AWARE_WAKE = "noopMotionAwareWake"
+
+        /** "Diagnostics capture" master switch (mirrors macOS `PuffinExperiment.diagnosticsCaptureKey`). */
+        const val KEY_DIAGNOSTICS_CAPTURE = "noopDiagnosticsCapture"
 
         fun from(context: Context): PuffinExperiment =
             PuffinExperiment(context.getSharedPreferences(PREFS, Context.MODE_PRIVATE))

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -6096,7 +6096,7 @@ class WhoopBleClient(
         refreshConnectionPriority()   // #477: escalate to HIGH for the offload burst (faster sync). No-op unless enabled.
         applyPreferredPhy()           // #533: prefer LE 2M for the burst (halves air-time). No-op unless enabled.
         // Opt-in raw capture (research aid): pref read fresh per session, like the probes gate.
-        if (connectedFamily == DeviceFamily.WHOOP5 && PuffinExperiment.from(context).isCaptureEnabled) {
+        if (connectedFamily == DeviceFamily.WHOOP5 && PuffinExperiment.from(context).rawCaptureActive) {
             startWhoop5BackfillCapture()
         }
         if (connectedFamily == DeviceFamily.WHOOP5) {
@@ -7116,7 +7116,7 @@ class WhoopBleClient(
      */
     private fun writeWhoop5EventLogIfEvent(characteristic: String, frame: ByteArray) {
         if (eventLogDisabled || !isWhoop5EventFrame(frame)) return
-        if (!PuffinExperiment.from(context).isCaptureEnabled) return
+        if (!PuffinExperiment.from(context).rawCaptureActive) return
         runCatching {
             val f = java.io.File(context.filesDir, WHOOP5_EVENT_LOG_FILE)
             if (f.exists() && f.length() > WHOOP5_EVENT_LOG_MAX_BYTES) {
@@ -7154,7 +7154,7 @@ class WhoopBleClient(
      *  1244-B 6-axis buffer decodes (rawColumns null otherwise). IO-dispatched so it never blocks the GATT
      *  thread; bounded by a rolling retention prune. Raw i16, no downstream consumer yet (instrument-first). */
     private fun storeWhoop5RawImuIfBuffer(frame: ByteArray) {
-        if (!PuffinExperiment.from(context).isCaptureEnabled) return
+        if (!PuffinExperiment.from(context).rawCaptureActive) return
         val cols = Whoop5RawImu.rawColumns(frame) ?: return
         val baseTs = PuffinDeepBufferLog.strapTs(frame)?.toLong() ?: return
         val dev = deviceId
@@ -7178,7 +7178,7 @@ class WhoopBleClient(
 
     private fun writeWhoop5DeepBufferIfBig(characteristic: String, frame: ByteArray, isOffload: Boolean) {
         if (deepBufferDisabled || !PuffinDeepBufferLog.isDeepBuffer(frame)) return
-        if (!PuffinExperiment.from(context).isCaptureEnabled) return
+        if (!PuffinExperiment.from(context).rawCaptureActive) return
         runCatching {
             val f = java.io.File(context.filesDir, WHOOP5_DEEPBUFFER_FILE)
             if (f.exists() && f.length() > WHOOP5_DEEPBUFFER_MAX_BYTES) {

--- a/android/app/src/main/java/com/noop/ui/LogExport.kt
+++ b/android/app/src/main/java/com/noop/ui/LogExport.kt
@@ -240,8 +240,8 @@ object LogExport {
         return when {
             !whoop5Connected ->
                 "Raw capture records WHOOP 5/MG history syncs and doesn't apply to WHOOP 4.0 (already fully decoded).$tail"
-            !PuffinExperiment.from(context).isCaptureEnabled ->
-                "No raw capture yet. Turn on \"Record 5/MG raw capture\" above, then let a history sync run.$tail"
+            !PuffinExperiment.from(context).rawCaptureActive ->
+                "No raw capture yet. Turn on \"Record 5/MG raw capture\" (or the Test Centre \"Diagnostics capture\" switch), then let a history sync run.$tail"
             else ->
                 "Raw capture is on. Let a 5/MG history sync run, then try again.$tail"
         }

--- a/android/app/src/main/java/com/noop/ui/TestCentreScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/TestCentreScreen.kt
@@ -325,6 +325,9 @@ private fun DiagnosticToolsCard(vm: AppViewModel) {
     var showRecalibrate by remember { mutableStateOf(false) }
     // "Debug logging" moved here from Settings: dev-only, mirrors the strap log to logcat over adb.
     var debugLogging by remember { mutableStateOf(NoopPrefs.debugLogging(context)) }
+    // "Diagnostics capture" master switch (default off): the SAME PuffinExperiment key the Swift twin reads.
+    val puffin = remember { PuffinExperiment.from(context) }
+    var diagnosticsCapture by remember { mutableStateOf(puffin.diagnosticsCapture) }
     SettingsSectionTC(
         icon = Icons.Filled.Info,
         title = uiString(R.string.l10n_test_centre_screen_diagnostic_tools_04ba4d3f),
@@ -365,6 +368,31 @@ private fun DiagnosticToolsCard(vm: AppViewModel) {
                 Switch(
                     checked = debugLogging,
                     onCheckedChange = { debugLogging = it; vm.setDebugLogging(it) },
+                    colors = settingsSwitchColors(),
+                )
+            }
+            // Diagnostics capture master switch: gates the on-device research artifacts in the Diagnostics
+            // folder (Oura Tier-B JSONL sidecars + the WHOOP raw-frame capture). Off by default keeps the
+            // folder empty; flip on for a capture session. Applies on the next connection.
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(16.dp),
+            ) {
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(
+                        uiString(R.string.l10n_test_centre_screen_diagnostics_capture_50a07985),
+                        style = NoopType.subhead, color = Palette.textPrimary,
+                    )
+                    Text(
+                        uiString(R.string.l10n_test_centre_screen_write_research_artifacts_to_the_705b2423),
+                        style = NoopType.footnote,
+                        color = Palette.textTertiary,
+                    )
+                }
+                Switch(
+                    checked = diagnosticsCapture,
+                    onCheckedChange = { diagnosticsCapture = it; puffin.diagnosticsCapture = it },
                     colors = settingsSwitchColors(),
                 )
             }

--- a/android/app/src/main/res/values-de/strings.xml
+++ b/android/app/src/main/res/values-de/strings.xml
@@ -1772,4 +1772,6 @@
     <string name="battery_channel_name">Akku-Hinweise</string>
     <string name="battery_channel_desc">Hinweise, wenn der Strap-Akku schwach oder voll geladen ist.</string>
     <string name="l10n_app_changelog_battery_saver_quiets_the_gauges_translated_bdbe8650">Energiesparmodus beruhigt die Anzeigen, übersetzte Android-Benachrichtigungen und sofort geladene Diagramme</string>
+    <string name="l10n_test_centre_screen_diagnostics_capture_50a07985">Diagnose-Aufzeichnung</string>
+    <string name="l10n_test_centre_screen_write_research_artifacts_to_the_705b2423">Schreibt Forschungsartefakte in den Diagnose-Ordner: die Tier-B-Begleitdateien des Oura-Rings (Aktivität/MET; IBI-HR und Rohdaten, sobald verfügbar) und die Rohbild-Aufzeichnung des WHOOP 5/MG. Standardmäßig aus. Wird bei der nächsten Verbindung wirksam.</string>
 </resources>

--- a/android/app/src/main/res/values-es/strings.xml
+++ b/android/app/src/main/res/values-es/strings.xml
@@ -1757,4 +1757,6 @@
     <string name="battery_channel_name">Alertas de batería</string>
     <string name="battery_channel_desc">Avisos cuando la batería de la pulsera está baja o completamente cargada.</string>
     <string name="l10n_app_changelog_battery_saver_quiets_the_gauges_translated_bdbe8650">El ahorro de batería calma los indicadores, notificaciones de Android traducidas y gráficos instantáneos</string>
+    <string name="l10n_test_centre_screen_diagnostics_capture_50a07985">Captura de diagnósticos</string>
+    <string name="l10n_test_centre_screen_write_research_artifacts_to_the_705b2423">Escribe artefactos de investigación en la carpeta Diagnósticos: los archivos complementarios Tier-B del anillo Oura (actividad/MET; IBI-HR y datos sin procesar cuando estén disponibles) y la captura de tramas sin procesar del WHOOP 5/MG. Desactivado de forma predeterminada. Se aplica en la próxima conexión.</string>
 </resources>

--- a/android/app/src/main/res/values-fr/strings.xml
+++ b/android/app/src/main/res/values-fr/strings.xml
@@ -1757,4 +1757,6 @@
     <string name="battery_channel_name">Alertes de batterie</string>
     <string name="battery_channel_desc">Alertes lorsque la batterie du bracelet est faible ou complètement chargée.</string>
     <string name="l10n_app_changelog_battery_saver_quiets_the_gauges_translated_bdbe8650">L\'économiseur de batterie fige les jauges, notifications Android traduites et graphiques instantanés</string>
+    <string name="l10n_test_centre_screen_diagnostics_capture_50a07985">Capture de diagnostics</string>
+    <string name="l10n_test_centre_screen_write_research_artifacts_to_the_705b2423">Écrit les artefacts de recherche dans le dossier Diagnostics : les fichiers annexes Tier-B de la bague Oura (activité/MET ; IBI-HR et données brutes à venir) et la capture de trames brutes du WHOOP 5/MG. Désactivé par défaut. S\'applique à la prochaine connexion.</string>
 </resources>

--- a/android/app/src/main/res/values-pt-rPT/strings.xml
+++ b/android/app/src/main/res/values-pt-rPT/strings.xml
@@ -1751,4 +1751,6 @@
     <string name="battery_channel_name">Alertas de bateria</string>
     <string name="battery_channel_desc">Avisos quando a bateria da correia está fraca ou totalmente carregada.</string>
     <string name="l10n_app_changelog_battery_saver_quiets_the_gauges_translated_bdbe8650">A poupança de bateria acalma os indicadores, notificações Android traduzidas e gráficos instantâneos</string>
+    <string name="l10n_test_centre_screen_diagnostics_capture_50a07985">Captura de diagnósticos</string>
+    <string name="l10n_test_centre_screen_write_research_artifacts_to_the_705b2423">Escreve artefactos de investigação na pasta Diagnósticos: os ficheiros complementares Tier-B do anel Oura (atividade/MET; IBI-HR e dados em bruto quando disponíveis) e a captura de tramas em bruto do WHOOP 5/MG. Desativado por predefinição. Aplica-se na próxima ligação.</string>
 </resources>

--- a/android/app/src/main/res/values-zh/strings.xml
+++ b/android/app/src/main/res/values-zh/strings.xml
@@ -1685,4 +1685,6 @@
     <string name="battery_channel_name">电量提醒</string>
     <string name="battery_channel_desc">当手环电量低或已充满时提醒。</string>
     <string name="l10n_app_changelog_battery_saver_quiets_the_gauges_translated_bdbe8650">省电模式让仪表静止、Android 通知已翻译、图表秒开</string>
+    <string name="l10n_test_centre_screen_diagnostics_capture_50a07985">诊断采集</string>
+    <string name="l10n_test_centre_screen_write_research_artifacts_to_the_705b2423">将研究工件写入诊断文件夹：Oura 戒指的 Tier-B 附属文件（活动/MET；IBI-HR 和原始数据将在后续版本中提供）以及 WHOOP 5/MG 原始帧采集。默认关闭。在下次连接时生效。</string>
 </resources>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -1783,4 +1783,6 @@
     <string name="battery_channel_name">Battery alerts</string>
     <string name="battery_channel_desc">Alerts when the strap battery is low or fully charged.</string>
     <string name="l10n_app_changelog_battery_saver_quiets_the_gauges_translated_bdbe8650">Battery saver quiets the gauges, translated Android notifications, and instant chart loads</string>
+    <string name="l10n_test_centre_screen_diagnostics_capture_50a07985">Diagnostics capture</string>
+    <string name="l10n_test_centre_screen_write_research_artifacts_to_the_705b2423">Write research artifacts to the Diagnostics folder: the Oura ring\'s Tier-B sidecars (activity/MET; IBI-HR and raw once those ship) and the WHOOP 5/MG raw-frame capture. Off by default. Applies on the next connection.</string>
 </resources>


### PR DESCRIPTION
##  Summary

  Adds a single "Diagnostics capture" master switch to Test Centre → Diagnostic tools (default OFF, opt-in). Today the Oura Tier-B JSONL sidecars are always-on and fill <App  Support>/OpenWhoop/Diagnostics during normal use; this puts every on-device research artifact behind one switch a tester flips on for a capture session.

##  Motivation

  The Diagnostics folder accumulates artifacts (oura-activity, and — on other branches — oura-ibihr / oura-raw, plus the WHOOP raw-frame capture) with no user control. A single opt-in switch keeps  the folder empty in normal use and gives a clean way to arm capture only when debugging.

##  What changed

  - Shared pref key noopDiagnosticsCapture — identical string on both platforms (Swift PuffinExperiment.diagnosticsCaptureKey / Kotlin PuffinExperiment.KEY_DIAGNOSTICS_CAPTURE), following the  existing PuffinExperiment cross-platform idiom.
  - Oura sidecars gated — OuraActivityDump is only created when the switch is on (both platforms), so default-off writes no sidecar file. Future oura-ibihr / oura-raw honor the same key when they merge.
  - WHOOP raw-frame capture folded in — a new rawCaptureActive helper (per-strap enableRawCapture/isCaptureEnabled OR the master) drives the 24/7 capture gate, so the master switch turns raw  capture on too while the independent per-strap flag keeps working. The on-demand bounded raw-capture window is untouched.
  - Test Centre UI — a toggle in the Diagnostic tools card on both platforms (Swift @AppStorage, Kotlin Switch), with copy explaining it applies on the next connection.

##  Cross-platform parity

  Symmetric Swift/Kotlin: same pref key, same gate placement (dump creation + raw-capture guard), same UI toggle. No stored-data or analytics change, so nothing crosses the .noopbak boundary.

##  Behavior change

  The Oura activity/MET sidecar was always-on and is now OFF by default — testers must enable the switch before a capture night. This is the intended effect (stop the folder filling).

##  Scope / notes

  - Takes effect on the next ring/strap connection (read where each dump/capture is created), not mid-session.
  - No protocol change — the raw-capture edits only widen a read-only capture gate; no BLE write, no connection-path change.
  - On this branch only oura-activity exists to gate; oura-ibihr / oura-raw live on the combined/anchor branches and plug into the same key on merge.

##  Verification

  - App-target Swift (CI doesn't cover it): Strand macOS xcodebuild … build → BUILD SUCCEEDED.
  - Android: compileFullDebugKotlin → clean.
  - Design system: toggle uses StrandPalette/StrandFont (Swift) and Palette/NoopType (Android) — no hardcoded colors/fonts.
  - 9 files, single commit 5e3fb4db.
  - On-device: pending your confirmation that flipping it toggles the oura-activity sidecar on/off.
