### PR TITLE
Sleep Schedule card: bridge night-tail fragments into one night (#699)

### DIFF
--- a/android/app/src/main/java/com/noop/ui/SleepNightSelection.kt
+++ b/android/app/src/main/java/com/noop/ui/SleepNightSelection.kt
@@ -174,6 +174,27 @@ internal fun mainSleepSpan(blocks: List<SleepSession>, habitualMidsleepSec: Long
     return first.effectiveStartTs to last.endTs
 }
 
+/**
+ * The trailing [limit] nights' bridged bed→wake SPANS — one per local calendar day of wake, grouped the
+ * SAME way [navDays] groups the browsable day list (`localDayString(it.endTs)`), then resolved through
+ * the SAME bridged selector ([mainSleepSpan]) the hero uses. Before this, [SleepConsistencyCard] iterated
+ * raw sessions directly: a briefly-interrupted / biphasic night's night-tail fragment (bridged into the
+ * hero's ONE night) still drew as its OWN low bar, got counted as an extra "night", and skewed the bed/wake
+ * SD and consistency score (#699). A day whose only blocks are naps (no bridgeable main sleep) drops out via
+ * `mapNotNull`, matching [mainSleepSpan]'s null. Ascending by day, oldest first (matches the prior
+ * `sleeps.takeLast(limit)` ordering assumption).
+ */
+internal fun consistencyNightSpans(
+    sleeps: List<SleepSession>,
+    habitualMidsleepSec: Long? = null,
+    limit: Int = 14,
+): List<Pair<Long, Long>> =
+    sleeps.groupBy { localDayString(it.endTs) }
+        .toSortedMap()
+        .values
+        .mapNotNull { blocks -> mainSleepSpan(blocks.sortedBy { it.effectiveStartTs }, habitualMidsleepSec) }
+        .takeLast(limit)
+
 /** Longest a leading block can be and still be treated as a spurious pre-sleep awake stub (lying in bed
  *  before sleep). Generous (a few hours) because the reporter's stub ran 21:41 → 00:27 — ~2h45m of pre-sleep
  *  awake — so a tight cap missed it (#736). The real guard against swallowing a genuine first sleep fragment

--- a/android/app/src/main/java/com/noop/ui/SleepScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/SleepScreen.kt
@@ -638,7 +638,7 @@ fun SleepScreen(
                 item { Spacer(Modifier.height(Metrics.selectorTopUp)) }
                 item { HoursVsNeededCard(m) }
                 item { Spacer(Modifier.height(Metrics.selectorTopUp)) }
-                item { SleepConsistencyCard(sleeps) }
+                item { SleepConsistencyCard(sleeps, habitualMidsleep) }
             }
         }
     }
@@ -3111,21 +3111,22 @@ private data class SleepNightTiming(val label: String, val bedHour: Float, val w
  * of the personal typical. (PR #260)
  */
 @Composable
-internal fun SleepConsistencyCard(sleeps: List<SleepSession>) {
+internal fun SleepConsistencyCard(sleeps: List<SleepSession>, habitualMidsleepSec: Long? = null) {
     // #perf: building the per-night fold allocates 2 Calendars + a SimpleDateFormat per session (~28
     // objects for 14 nights). It's a pure derivation of `sleeps` (no wall-clock input), so memoize it on
     // `sleeps` — scrolling the Sleep screen then reuses it instead of rebuilding it every recompose frame.
-    val timings = remember(sleeps) {
-        val recent = sleeps.takeLast(14)
+    val timings = remember(sleeps, habitualMidsleepSec) {
         val sdf = SimpleDateFormat("EEE", Locale.US)
-        recent.map { s ->
-            val bedCal = Calendar.getInstance().apply { timeInMillis = s.effectiveStartTs * 1000L } // edited bedtime (PR #395)
-            val wakeCal = Calendar.getInstance().apply { timeInMillis = s.endTs * 1000L }
+        // #699: bridged bed→wake spans (one per day, night-tail fragments folded in), not raw sessions —
+        // see consistencyNightSpans.
+        consistencyNightSpans(sleeps, habitualMidsleepSec).map { (onsetTs, wakeTs) ->
+            val bedCal = Calendar.getInstance().apply { timeInMillis = onsetTs * 1000L } // edited bedtime (PR #395)
+            val wakeCal = Calendar.getInstance().apply { timeInMillis = wakeTs * 1000L }
             val bedH = bedCal.get(Calendar.HOUR_OF_DAY) + bedCal.get(Calendar.MINUTE) / 60f
             // Fold an evening bedtime to a negative hour so it sorts ABOVE the next-day wake on the axis.
             val bedNorm = if (bedH > 12f) bedH - 24f else bedH
             val wakeH = wakeCal.get(Calendar.HOUR_OF_DAY) + wakeCal.get(Calendar.MINUTE) / 60f
-            SleepNightTiming(sdf.format(Date(s.endTs * 1000L)), bedNorm, wakeH)
+            SleepNightTiming(sdf.format(Date(wakeTs * 1000L)), bedNorm, wakeH)
         }
     }
     if (timings.size < 3) return

--- a/android/app/src/test/java/com/noop/ui/ConsistencyNightSpansTest.kt
+++ b/android/app/src/test/java/com/noop/ui/ConsistencyNightSpansTest.kt
@@ -1,0 +1,76 @@
+package com.noop.ui
+
+import com.noop.data.SleepSession
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import java.util.Calendar
+import java.util.TimeZone
+
+/**
+ * #699: [SleepConsistencyCard] iterated raw sessions directly, so a bridged night-tail fragment — already
+ * folded into ONE night by the hero via [mainSleepGroup]/[mainSleepSpan] — still drew as its own low bar,
+ * got counted as an extra "night", and skewed the bed/wake SD and consistency score. [consistencyNightSpans]
+ * is the fix: group by local wake-day (the same key [navDays] uses), then resolve each day through the SAME
+ * bridged selector the hero uses, so naps and night-tail fragments are handled identically everywhere.
+ */
+class ConsistencyNightSpansTest {
+
+    private val saved: TimeZone = TimeZone.getDefault()
+
+    @Before fun setUtc() { TimeZone.setDefault(TimeZone.getTimeZone("UTC")) }
+
+    @After fun restore() { TimeZone.setDefault(saved) }
+
+    private fun utc(y: Int, mo: Int, d: Int, h: Int, mi: Int): Long {
+        val cal = Calendar.getInstance(TimeZone.getTimeZone("UTC"))
+        cal.clear()
+        cal.set(y, mo - 1, d, h, mi, 0)
+        return cal.timeInMillis / 1000L
+    }
+
+    @Test
+    fun nightTailFragmentFoldsIntoOneNightNotTwo() {
+        // The #699 report: main night 23:43 -> 07:58, then a 68-min-gap morning fragment 09:06 -> 10:09,
+        // both nap=false. The gap sits inside [GAP_BRIDGE_MAX_MIN, NIGHT_TAIL_BRIDGE_MAX_MIN) and the
+        // fragment's onset is inside the overnight band, so the hero bridges them into one night.
+        val main = SleepSession(deviceId = "my-whoop", startTs = utc(2026, 1, 9, 23, 43), endTs = utc(2026, 1, 10, 7, 58))
+        val fragment = SleepSession(deviceId = "my-whoop", startTs = utc(2026, 1, 10, 9, 6), endTs = utc(2026, 1, 10, 10, 9))
+
+        val spans = consistencyNightSpans(listOf(main, fragment))
+
+        assertEquals("the fragment must fold into the main night, not stand as its own bar", 1, spans.size)
+        assertEquals(main.effectiveStartTs to fragment.endTs, spans.single())
+    }
+
+    @Test
+    fun aRealAfternoonNapIsDroppedNotCountedAsANight() {
+        // Same main night, but the second block is a genuine afternoon nap hours later -- must NOT be
+        // folded in, and must NOT count as a second "night" either.
+        val main = SleepSession(deviceId = "my-whoop", startTs = utc(2026, 1, 9, 23, 30), endTs = utc(2026, 1, 10, 6, 30))
+        val nap = SleepSession(deviceId = "my-whoop", startTs = utc(2026, 1, 10, 14, 0), endTs = utc(2026, 1, 10, 14, 45))
+
+        val spans = consistencyNightSpans(listOf(main, nap))
+
+        assertEquals("a genuine nap must not inflate the night count", 1, spans.size)
+        assertEquals(main.effectiveStartTs to main.endTs, spans.single())
+    }
+
+    @Test
+    fun takesOnlyTheTrailingLimitNights() {
+        val nights = (0 until 20).map { i ->
+            SleepSession(
+                deviceId = "my-whoop",
+                startTs = utc(2026, 1, 1, 23, 0) + i * 86_400L,
+                endTs = utc(2026, 1, 2, 7, 0) + i * 86_400L,
+            )
+        }
+
+        val spans = consistencyNightSpans(nights, limit = 14)
+
+        assertEquals(14, spans.size)
+        // Ascending by day (oldest first), so the LAST entry must be the most recent night.
+        assertEquals(nights.last().endTs, spans.last().second)
+    }
+}


### PR DESCRIPTION
Fixes the bar-chart/night-count/score part of #699. Likely also explains item 2 of #691 ("Consistency shows different numbers") per that issue's own note — the Schedule card's locally-computed % was inflated by exactly this kind of un-bridged fragment.

## Root cause
`SleepConsistencyCard` iterated raw stored sessions directly (`sleeps.takeLast(14)`), one bar per session. Every other Sleep-tab surface (hero, phase breakdown, naps split) resolves a day's sessions through the shared bridged selector (`mainSleepGroup`/`mainSleepSpan`) so a briefly-interrupted or biphasic night reads as ONE night. This card was missed when that bridging rolled out (#555/#561) — was originally added in PR #260, before the shared selector existed.

Concretely: a main night 23:43→07:58 followed by a 68-minute-gap morning re-sleep 09:06→10:09 is correctly bridged into one 23:43→10:09 night everywhere else, but the Schedule card drew the fragment as its own ~09:00 bar, counted it as a 14th "night" (pushing a real night out of the 14-night window), and inflated the bed/wake SD (a ~09:00 "bedtime" next to a typical ~00:00).

## Fix
New `consistencyNightSpans(sleeps, habitualMidsleepSec, limit)` in `SleepNightSelection.kt`: groups sessions by local wake-day (`localDayString(it.endTs)`, the same key `navDays` already uses for the day-nav list), then resolves each day's blocks through `mainSleepSpan` — the same selector the hero uses. `SleepConsistencyCard` now builds its bars from these bridged spans instead of raw sessions, and threads through the same `habitualMidsleepSec` the rest of the screen already loads.

A day whose only blocks are a genuine nap (no real night) contributes nothing (`mainSleepSpan` returns null there), so a same-day nap no longer inflates the night count either — a second case the original code also got wrong, beyond the one in the report.

## Scope
Pure Kotlin/Android UI fix — no analytics formula, stored value, or migration changes, so no Swift twin is needed. iOS's Sleep tab sources its Consistency metric from the imported WHOOP `sleep_consistency` series rather than a locally-computed bed/wake bar chart, so there's no equivalent card there with this bug.

## Testing
- `./gradlew compileFullDebugKotlin` ✓ (JDK 17 via Homebrew, `android.yml` is disabled so this is local-only for now)
- `./gradlew testFullDebugUnitTest --tests "com.noop.ui.*"` ✓, including new `ConsistencyNightSpansTest` (night-tail fragment folds into one span, a genuine nap doesn't get counted as its own night, trailing-14 windowing) and the existing `MainSleepSpanTest` (unaffected)
- Not verified on-device / against real strap data — this is a pure display/derivation fix over stored sessions, no BLE path touched