### PR TITLE
Steps calibration: replace the manual slider with a stepper (#698)

### DIFF
--- a/android/app/src/main/java/com/noop/ui/StepsCalibrationScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/StepsCalibrationScreen.kt
@@ -25,8 +25,6 @@ import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
-import androidx.compose.material3.Slider
-import androidx.compose.material3.SliderDefaults
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -87,8 +85,6 @@ fun StepsCalibrationScreen(
 ) {
     val scroll = rememberScrollState()
 
-    // The draft manual coefficient the slider edits, committed to ProfileStore on release. 0 = auto-fit.
-    var draftManual by remember { mutableStateOf(profile.stepsManualCoefficient.toFloat()) }
     // Recent days that have BOTH an estimate (reconstructed) and a phone count — the accuracy table.
     var comparison by remember { mutableStateOf<List<StepsComparisonRow>>(emptyList()) }
     // A representative recent motion volume (median of the days we measured), seeding the live preview.
@@ -96,9 +92,9 @@ fun StepsCalibrationScreen(
     // Flips true once the load pass has run, so the "no motion synced" note (#37) doesn't flash on first frame.
     var loaded by remember { mutableStateOf(false) }
 
-    // The slider's max anchors to whatever's in force with generous headroom, so a nudge either way is
-    // reachable; a floor keeps it usable before any fit. Mirrors the macOS sliderMax.
-    val sliderMax = (maxOf(profile.stepsCalibrationCoefficient, profile.stepsManualCoefficient, 50.0) * 2).toFloat()
+    // The stepper's ceiling anchors to whatever's in force with generous headroom, so a nudge either way
+    // stays reachable; a floor keeps it usable before any fit. Mirrors the macOS sliderMax.
+    val stepperMax = maxOf(profile.stepsCalibrationCoefficient, profile.stepsManualCoefficient, 50.0) * 2
 
     // Build the comparison table + a typical-day motion, once. The engine stores `steps_est` ONLY for
     // strap-only days (a phone-covered day uses the phone's real count), so an estimate and a phone
@@ -173,18 +169,9 @@ fun StepsCalibrationScreen(
                 ComparisonCard(comparison)
                 ManualAdjustCard(
                     profile = profile,
-                    draftManual = draftManual,
-                    sliderMax = sliderMax,
+                    stepperMax = stepperMax,
                     sampleMotion = sampleMotion,
-                    onDraftChange = { draftManual = it },
-                    onCommit = {
-                        // Commit on release — snap a tiny drag back to 0 (auto) so "auto" is reachable,
-                        // and round to a 0.5 grid (the slider itself is continuous to bound tick count).
-                        val snapped = if (draftManual < 0.5f) 0.0 else (Math.round(draftManual / 0.5f) * 0.5).toDouble()
-                        draftManual = snapped.toFloat()
-                        profile.stepsManualCoefficient = snapped
-                        onProfileChanged()
-                    },
+                    onProfileChanged = onProfileChanged,
                 )
             }
             Hairline()
@@ -396,78 +383,77 @@ private fun ComparisonCard(rows: List<StepsComparisonRow>) {
     }
 }
 
-/** Manual override: a slider bound to a draft, committed on release, with a live preview of what a
- *  typical recent day would estimate at the chosen coefficient. 0 returns to auto-fit. */
+/** One step of the manual coefficient stepper (#698): a slider spanning the full 0..[stepperMax] range
+ *  made a specific one-decimal value (e.g. nudging an auto 1.4 down to 1.2) practically undraggable —
+ *  the whole usable precision was compressed into a handful of drag pixels. A fixed 0.1 tick, like the
+ *  Profile card's age/weight steppers, makes that exact. */
+private const val STEPS_COEFFICIENT_STEP = 0.1
+
+/** Manual override: a stepper (mirrors the Profile card's age/weight [StepperField]s) bound directly to
+ *  [ProfileStore.stepsManualCoefficient], with a live preview of what a typical recent day would
+ *  estimate at the current setting. 0 means auto-fit; stepping down to 0 returns to it. Nudges start
+ *  from whichever value is currently EFFECTIVE (the auto fit, until first overridden), so reaching a
+ *  nearby value like 1.2 from an auto-fitted 1.4 is two taps, not a drag from zero (#698). */
 @Composable
 private fun ManualAdjustCard(
     profile: ProfileStore,
-    draftManual: Float,
-    sliderMax: Float,
+    stepperMax: Double,
     sampleMotion: Double?,
-    onDraftChange: (Float) -> Unit,
-    onCommit: () -> Unit,
+    onProfileChanged: () -> Unit,
 ) {
+    val manual = profile.stepsManualCoefficient
+    val effective = if (manual > 0) manual else profile.stepsCalibrationCoefficient
+
+    fun step(delta: Double) {
+        val next = (Math.round((effective + delta) * 10) / 10.0).coerceIn(0.0, stepperMax)
+        profile.stepsManualCoefficient = next
+        onProfileChanged()
+    }
+
     NoopCard(padding = 20.dp) {
         Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
             Overline("Adjust manually")
             Text(
                 uiString(R.string.l10n_steps_calibration_screen_override_the_automatic_fit_with_your_36a7b6fa) +
                     "has no step history to learn from, or the estimate runs consistently high or low. " +
-                    "Set it back to auto by dragging to the far left.",
+                    "Step all the way down to return to auto.",
                 style = NoopType.footnote,
                 color = Palette.textTertiary,
             )
             Row(verticalAlignment = Alignment.Bottom, horizontalArrangement = Arrangement.spacedBy(8.dp)) {
                 Text(
-                    if (draftManual > 0) String.format(Locale.US, "%.1f", draftManual) else "Auto",
+                    if (manual > 0) String.format(Locale.US, "%.1f", manual) else "Auto",
                     style = NoopType.number(24f),
-                    color = if (draftManual > 0) Palette.accent else Palette.textSecondary,
+                    color = if (manual > 0) Palette.accent else Palette.textSecondary,
                 )
                 Text(
-                    if (draftManual > 0) "steps / motion unit" else "fit from your phone",
+                    if (manual > 0) "steps / motion unit" else "fit from your phone",
                     style = NoopType.footnote,
                     color = Palette.textTertiary,
                     modifier = Modifier.padding(bottom = 4.dp),
                 )
             }
-            Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                Text(uiString(R.string.l10n_steps_calibration_screen_auto_c614ba7c), style = NoopType.caption, color = Palette.textTertiary)
-                Slider(
-                    // Continuous (no discrete `steps`): the coefficient range can be large, so a 0.5-tick
-                    // grid would mean thousands of ticks. The commit rounds to 0.5 instead (see onCommit).
-                    value = draftManual,
-                    onValueChange = onDraftChange,
-                    onValueChangeFinished = onCommit,
-                    valueRange = 0f..sliderMax,
-                    colors = SliderDefaults.colors(
-                        thumbColor = Palette.accent,
-                        activeTrackColor = Palette.accent,
-                        inactiveTrackColor = Palette.surfaceInset,
-                    ),
-                    modifier = Modifier
-                        .weight(1f)
-                        .semantics {
-                            contentDescription = if (draftManual > 0) {
-                                String.format(Locale.US, "Manual steps coefficient, %.1f steps per motion unit", draftManual)
-                            } else {
-                                "Manual steps coefficient, automatic"
-                            }
-                        },
+            Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.Center) {
+                StepperField(
+                    value = if (manual > 0) String.format(Locale.US, "%.1f", manual) else "Auto",
+                    accessibility = if (manual > 0) {
+                        String.format(Locale.US, "Manual steps coefficient, %.1f steps per motion unit", manual)
+                    } else {
+                        "Manual steps coefficient, automatic"
+                    },
+                    onMinus = { step(-STEPS_COEFFICIENT_STEP) },
+                    onPlus = { step(STEPS_COEFFICIENT_STEP) },
                 )
-                Text(uiString(R.string.l10n_steps_calibration_screen_high_b1a5954a), style = NoopType.caption, color = Palette.textTertiary)
             }
-            // Live preview: a typical recent day re-estimated at the draft (or auto) coefficient.
-            if (sampleMotion != null) {
-                val effective = if (draftManual > 0) draftManual.toDouble() else profile.stepsCalibrationCoefficient
-                if (effective > 0) {
-                    val preview = (sampleMotion * effective).roundToInt()
-                    StatLine(
-                        "A typical recent day",
-                        "≈ ${grouped(preview)} steps${if (draftManual > 0) " at this setting" else " (auto)"}",
-                    )
-                }
+            // Live preview: a typical recent day re-estimated at the effective (manual or auto) coefficient.
+            if (sampleMotion != null && effective > 0) {
+                val preview = (sampleMotion * effective).roundToInt()
+                StatLine(
+                    "A typical recent day",
+                    "≈ ${grouped(preview)} steps${if (manual > 0) " at this setting" else " (auto)"}",
+                )
             }
-            if (draftManual > 0) {
+            if (manual > 0) {
                 Text(
                     uiString(R.string.l10n_steps_calibration_screen_takes_effect_on_the_next_analytics_13205327),
                     style = NoopType.caption,

--- a/android/app/src/main/res/values-de/strings.xml
+++ b/android/app/src/main/res/values-de/strings.xml
@@ -805,13 +805,11 @@
     <string name="l10n_smart_alarm_screen_window_length_46179fcb">Fensterlänge</string>
     <string name="l10n_smart_alarm_screen_windowminutes_min_bd89fd82">%1$s min</string>
     <string name="l10n_smart_alarm_screen_your_whoop_5_mg_won_t_75029bae">Ihr WHOOP 5/MG wird dies nicht bewaffnen, bis der Experimentalmodus eingeschaltet ist (Einstellungen)</string>
-    <string name="l10n_steps_calibration_screen_auto_c614ba7c">Automatisch</string>
     <string name="l10n_steps_calibration_screen_calibrate_your_steps_38b4e814">Deine Schritte kalibrieren</string>
     <string name="l10n_steps_calibration_screen_close_bbfa773e">Schließen</string>
     <string name="l10n_steps_calibration_screen_day_987b9ced">Tag</string>
     <string name="l10n_steps_calibration_screen_done_e9b450d1">Fertig</string>
     <string name="l10n_steps_calibration_screen_est_18b405fb">Gesch.</string>
-    <string name="l10n_steps_calibration_screen_high_b1a5954a">Hoch</string>
     <string name="l10n_steps_calibration_screen_how_this_works_b895a8c3">Wie das funktioniert</string>
     <string name="l10n_steps_calibration_screen_no_days_yet_where_both_noop_71d6005b">Noch keine Tage, an denen sowohl NOOP als auch Ihr Telefon Schritte gezählt haben. Sobald Ihr Telefon protokolliert a</string>
     <string name="l10n_steps_calibration_screen_no_motion_synced_yet_65106670">Noch keine Bewegung synchronisiert</string>

--- a/android/app/src/main/res/values-es/strings.xml
+++ b/android/app/src/main/res/values-es/strings.xml
@@ -645,13 +645,11 @@
     <string name="l10n_smart_alarm_screen_window_length_46179fcb">Longitud de ventana</string>
     <string name="l10n_smart_alarm_screen_windowminutes_min_bd89fd82">%1$s min</string>
     <string name="l10n_smart_alarm_screen_your_whoop_5_mg_won_t_75029bae">Su WHOOP 5/MG no armará esto hasta que el modo experimental esté encendido (Configuración →</string>
-    <string name="l10n_steps_calibration_screen_auto_c614ba7c">Auto</string>
     <string name="l10n_steps_calibration_screen_calibrate_your_steps_38b4e814">Calibra tus pasos</string>
     <string name="l10n_steps_calibration_screen_close_bbfa773e">Cerrar</string>
     <string name="l10n_steps_calibration_screen_day_987b9ced">Día</string>
     <string name="l10n_steps_calibration_screen_done_e9b450d1">Listo</string>
     <string name="l10n_steps_calibration_screen_est_18b405fb">Est.</string>
-    <string name="l10n_steps_calibration_screen_high_b1a5954a">Alto</string>
     <string name="l10n_steps_calibration_screen_how_this_works_b895a8c3">Cómo funciona esto</string>
     <string name="l10n_steps_calibration_screen_no_days_yet_where_both_noop_71d6005b">Todavía no hay días donde NOOP y su teléfono cuentan pasos. Una vez que el teléfono inicie sesión a</string>
     <string name="l10n_steps_calibration_screen_no_motion_synced_yet_65106670">Aún no hay movimiento sincronizado</string>

--- a/android/app/src/main/res/values-fr/strings.xml
+++ b/android/app/src/main/res/values-fr/strings.xml
@@ -645,13 +645,11 @@
     <string name="l10n_smart_alarm_screen_window_length_46179fcb">Longueur de la fenêtre</string>
     <string name="l10n_smart_alarm_screen_windowminutes_min_bd89fd82">%1$s min</string>
     <string name="l10n_smart_alarm_screen_your_whoop_5_mg_won_t_75029bae">Votre WHOOP 5/MG n\'armera pas cela jusqu\'à ce que le mode expérimental soit activé (Paramètres →</string>
-    <string name="l10n_steps_calibration_screen_auto_c614ba7c">Auto</string>
     <string name="l10n_steps_calibration_screen_calibrate_your_steps_38b4e814">Calibrez vos pas</string>
     <string name="l10n_steps_calibration_screen_close_bbfa773e">Fermer</string>
     <string name="l10n_steps_calibration_screen_day_987b9ced">Jour</string>
     <string name="l10n_steps_calibration_screen_done_e9b450d1">Terminé</string>
     <string name="l10n_steps_calibration_screen_est_18b405fb">Est.</string>
-    <string name="l10n_steps_calibration_screen_high_b1a5954a">Élevé</string>
     <string name="l10n_steps_calibration_screen_how_this_works_b895a8c3">Comment ça fonctionne</string>
     <string name="l10n_steps_calibration_screen_no_days_yet_where_both_noop_71d6005b">Pas encore de jours où NOOP et votre téléphone ont compté les étapes. Une fois que votre téléphone enregistre un</string>
     <string name="l10n_steps_calibration_screen_no_motion_synced_yet_65106670">Aucun mouvement synchronisé pour l\'instant</string>

--- a/android/app/src/main/res/values-zh/strings.xml
+++ b/android/app/src/main/res/values-zh/strings.xml
@@ -771,13 +771,11 @@
     <string name="l10n_smart_alarm_screen_window_length_46179fcb">唤醒窗口时长</string>
     <string name="l10n_smart_alarm_screen_windowminutes_min_bd89fd82">%1$s 分钟</string>
     <string name="l10n_smart_alarm_screen_your_whoop_5_mg_won_t_75029bae">您的 WHOOP 5 只有在开启实验模式后，才能激活此功能 (设置 →</string>
-    <string name="l10n_steps_calibration_screen_auto_c614ba7c">自动</string>
     <string name="l10n_steps_calibration_screen_calibrate_your_steps_38b4e814">校准您的步数</string>
     <string name="l10n_steps_calibration_screen_close_bbfa773e">关闭</string>
     <string name="l10n_steps_calibration_screen_day_987b9ced">日期</string>
     <string name="l10n_steps_calibration_screen_done_e9b450d1">完成</string>
     <string name="l10n_steps_calibration_screen_est_18b405fb">预估值</string>
-    <string name="l10n_steps_calibration_screen_high_b1a5954a">偏高</string>
     <string name="l10n_steps_calibration_screen_how_this_works_b895a8c3">工作原理</string>
     <string name="l10n_steps_calibration_screen_no_days_yet_where_both_noop_71d6005b">尚未收集到 NOOP 和手机同时记录步数的日期。一旦您的手机记录了...</string>
     <string name="l10n_steps_calibration_screen_no_motion_synced_yet_65106670">暂未同步到体动数据</string>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -814,13 +814,11 @@
     <string name="l10n_smart_alarm_screen_window_length_46179fcb">Window length</string>
     <string name="l10n_smart_alarm_screen_windowminutes_min_bd89fd82">%1$s min</string>
     <string name="l10n_smart_alarm_screen_your_whoop_5_mg_won_t_75029bae">Your WHOOP 5/MG won\'t arm this until Experimental mode is on (Settings → </string>
-    <string name="l10n_steps_calibration_screen_auto_c614ba7c">Auto</string>
     <string name="l10n_steps_calibration_screen_calibrate_your_steps_38b4e814">Calibrate your steps</string>
     <string name="l10n_steps_calibration_screen_close_bbfa773e">Close</string>
     <string name="l10n_steps_calibration_screen_day_987b9ced">Day</string>
     <string name="l10n_steps_calibration_screen_done_e9b450d1">Done</string>
     <string name="l10n_steps_calibration_screen_est_18b405fb">Est.</string>
-    <string name="l10n_steps_calibration_screen_high_b1a5954a">High</string>
     <string name="l10n_steps_calibration_screen_how_this_works_b895a8c3">How this works</string>
     <string name="l10n_steps_calibration_screen_no_days_yet_where_both_noop_71d6005b">No days yet where both NOOP and your phone counted steps. Once your phone logs a </string>
     <string name="l10n_steps_calibration_screen_no_motion_synced_yet_65106670">No motion synced yet</string>


### PR DESCRIPTION
Fixes #698.

## Problem
The manual steps-coefficient override (Settings → Profile → "Steps estimate" → Adjust manually) used a `Slider` spanning `0..stepperMax`, where `stepperMax` is at least 100 (`maxOf(autoFit, manual, 50.0) * 2`). Real-world coefficients sit around 1-2 (the reporter's auto-fit was 1.4), so that whole usable range was compressed into a handful of drag pixels — landing on a specific value like 1.2 instead of 1.3 or 1.5 was essentially impossible by touch.

## Fix
Replaced the slider with a `StepperField` — the same shared component the Profile card already uses for age/weight/height (`-`/`+` buttons + a numeric readout), so this matches an established, already-accessible pattern instead of inventing a new one.

- Each tap moves the coefficient by a fixed 0.1, so any one-decimal value is reachable exactly.
- Nudging starts from whichever value is currently **effective** — the auto-fitted coefficient until the user first overrides it — so going from an auto 1.4 to a manual 1.2 is two taps, not a drag from zero.
- Stepping all the way down to 0.0 still means "auto-fit", matching the old "drag to the far left" behavior; there's no separate reset control needed.
- Since every tap commits immediately (like the other steppers), the old drag-draft/commit-on-release machinery (`draftManual`, `onCommit`, the 0.5 commit-rounding) is no longer needed and is removed.
- Dropped the two now-orphaned "Auto"/"High" slider-endpoint strings (`l10n_steps_calibration_screen_auto_c614ba7c` / `..._high_...`) from all five locale catalogs (en/de/es/fr/zh) — confirmed no other references first.

## Scope
Pure Android/Kotlin UI fix, no analytics/formula/stored-value change (`ProfileStore.stepsManualCoefficient` keeps the exact same meaning and persistence, just written by a stepper instead of a slider) — no iOS twin needed for this.

## Testing
- `./gradlew compileFullDebugKotlin` ✓ (JDK 17 via Homebrew; `android.yml` is disabled so this is local-only for now)
- `./gradlew testFullDebugUnitTest --tests "com.noop.ui.*"` ✓, all existing tests still pass
- `python3 Tools/i18n_audit.py` ✓ — no new hardcoded-literal or missing-translation findings from this diff; the string removals leave zero gaps across de/es/fr/zh
- Not tested on a physical device (no Android device available in this environment) — this is a pure Compose UI control swap with no BLE/analytics path touched, so the main risk is visual/layout, not correctness