### PR TITLE
Journal import: recognize the real WHOOP "Answered yes" header (#631)

### DIFF
--- a/Packages/StrandImport/Sources/StrandImport/WhoopExportImporter.swift
+++ b/Packages/StrandImport/Sources/StrandImport/WhoopExportImporter.swift
@@ -384,7 +384,11 @@ public struct WhoopExportImporter {
             r.tzOffsetMin = tz
             r.cycleStart = WhoopTime.parse(row.cell("cycle_start_time"), offsetMinutes: tz)
             r.question = row.cell("question_text", "question")
-            r.answer   = row.cell("answered_yes_no", "answer", "answer_text")
+            // #631: the REAL WHOOP export header is "Answered yes" (-> answered_yes), not the
+            // "Answered yes/no" NOOP's own exporter writes (-> answered_yes_no). Every real WHOOP
+            // journal import silently zeroed out to "without" because neither of the old keys ever
+            // matched, regardless of the account's actual answers.
+            r.answer   = row.cell("answered_yes", "answered_yes_no", "answer", "answer_text")
             r.notes    = row.cell("notes")
 
             // A journal row is only meaningful if it has a question.

--- a/Packages/StrandImport/Tests/StrandImportTests/WhoopExportImporterTests.swift
+++ b/Packages/StrandImport/Tests/StrandImportTests/WhoopExportImporterTests.swift
@@ -159,6 +159,25 @@ final class WhoopExportImporterTests: XCTestCase {
         XCTAssertEqual(rows[1].notes, "One coffee in the morning")
     }
 
+    /// REGRESSION (#631): a REAL WHOOP export names this column "Answered yes" (-> answered_yes), not
+    /// the "Answered yes/no" (-> answered_yes_no) NOOP's own exporter writes -- and above's fixture
+    /// happens to use. Header and TRUE/FALSE casing lifted verbatim from a reporter's actual
+    /// `journal_entries.csv`. Before this fix none of the old candidate keys ever matched a real
+    /// export, so every answer silently read false ("Without" in Insights) regardless of what the
+    /// account actually answered.
+    func testJournalReadsRealWhoopAnsweredYesHeader() throws {
+        let csv = """
+        Cycle start time,Cycle end time,Cycle timezone,Question text,Answered yes,Notes
+        2025-09-14 23:16:59,2025-09-15 23:08:01,UTC+02:00,Have any alcoholic drinks?,TRUE,
+        2025-09-14 23:16:59,2025-09-15 23:08:01,UTC+02:00,Experienced a migraine?,FALSE,
+        """
+        let table = CSVTable(data: Data(csv.utf8))
+        let rows = WhoopExportImporter().parseJournal(table)
+        XCTAssertEqual(rows.count, 2)
+        XCTAssertEqual(rows[0].answer, "TRUE")
+        XCTAssertEqual(rows[1].answer, "FALSE")
+    }
+
     // MARK: - Folder import end to end
 
     func testImportFromFolder() throws {

--- a/android/app/src/main/java/com/noop/ingest/WhoopCsvImporter.kt
+++ b/android/app/src/main/java/com/noop/ingest/WhoopCsvImporter.kt
@@ -584,7 +584,11 @@ object WhoopCsvImporter {
             val tz = WhoopTime.tzOffsetMinutes(row["cycle_timezone"])
             val cycleStart = WhoopTime.parseEpochSeconds(row.cell("cycle_start_time"), tz)
             val question = row.cell("question_text", "question")
-            val answer = row.cell("answered_yes_no", "answer", "answer_text")
+            // #631: the REAL WHOOP export header is "Answered yes" (-> answered_yes), not the
+            // "Answered yes/no" NOOP's own exporter writes (-> answered_yes_no). Every real WHOOP
+            // journal import silently zeroed out to "without" because neither of the old keys ever
+            // matched, regardless of the account's actual answers.
+            val answer = row.cell("answered_yes", "answered_yes_no", "answer", "answer_text")
             val notes = row.cell("notes")
 
             // Swift: a journal row is only meaningful if it has a question/answer/notes.

--- a/android/app/src/test/java/com/noop/ingest/WhoopCsvImporterTest.kt
+++ b/android/app/src/test/java/com/noop/ingest/WhoopCsvImporterTest.kt
@@ -169,6 +169,28 @@ class WhoopCsvImporterTest {
         assertEquals("2026-06-05", entries.single().day)
     }
 
+    /**
+     * REGRESSION (#631): a REAL WHOOP export names this column "Answered yes" (-> answered_yes), not
+     * the "Answered yes/no" (-> answered_yes_no) NOOP's own exporter writes. Header and TRUE/FALSE
+     * casing lifted verbatim from a reporter's actual `journal_entries.csv`. Before this fix none of
+     * the old candidate keys ever matched a real export, so every answer silently read false
+     * ("Without" in Insights) regardless of what the account actually answered.
+     */
+    @Test
+    fun importedJournalReadsRealWhoopAnsweredYesHeader() {
+        val entries = journal(
+            """
+            Cycle start time,Cycle end time,Cycle timezone,Question text,Answered yes,Notes
+            2025-09-14 23:16:59,2025-09-15 23:08:01,UTC+02:00,Have any alcoholic drinks?,TRUE,
+            2025-09-14 23:16:59,2025-09-15 23:08:01,UTC+02:00,Experienced a migraine?,FALSE,
+            """,
+            emptyMap(),
+        )
+        assertEquals(2, entries.size)
+        assertEquals(true, entries[0].answeredYes)
+        assertEquals(false, entries[1].answeredYes)
+    }
+
     // --- Localized (Brazilian Portuguese) headers, issue #692 ---------------------------------
 
     /** Diacritic-folded pt-BR headers land on the canonical English keys (parity with Swift). */


### PR DESCRIPTION
Addresses the confirmed root cause of #631, using the reporter's real `journal_entries.csv` (attached in the issue thread).

## Root cause
Both the Android (`WhoopCsvImporter.parseJournal`) and Swift (`WhoopExportImporter.parseJournal`) importers looked up the answer column only via `answered_yes_no` / `answer` / `answer_text` (normalized keys). That matches NOOP's own exporter, which writes the header `Answered yes/no` — but a **real WHOOP export** names the column `Answered yes` (no `/no`), which normalizes to `answered_yes` and never matched any of the old candidates.

Confirmed directly against the reporter's actual file:
```
Cycle start time,Cycle end time,Cycle timezone,Question text,Answered yes,Notes
2025-09-14 23:16:59,2025-09-15 23:08:01,UTC+02:00,Have any alcoholic drinks?,TRUE,
```
So `answer` was always `null` on a real import, `parseYesNo`/`(j.answer ?? "").lowercased() == "true"` always fell through to `false`, and every single day imported as "Without" in Insights — matching the reporter's account exactly (answered directly for 300+ days, every one zeroed out, while native/live-logged entries were correct).

This also rules out the with/without-partition theory from the earlier discussion (that's the separate #682 fix, which doesn't touch this).

## Fix
Added `answered_yes` as the first candidate key on both platforms:
- `android/app/src/main/java/com/noop/ingest/WhoopCsvImporter.kt`
- `Packages/StrandImport/Sources/StrandImport/WhoopExportImporter.swift`

## Testing
- New regression test on each platform, using the exact header + `TRUE`/`FALSE` casing from the reporter's real export:
  - Android: `WhoopCsvImporterTest.importedJournalReadsRealWhoopAnsweredYesHeader`
  - Swift: `WhoopExportImporterTests.testJournalReadsRealWhoopAnsweredYesHeader`
- `swift test` (Packages/StrandImport): 208 tests, 0 failures ✓
- `./gradlew compileFullDebugKotlin testFullDebugUnitTest --tests "com.noop.ingest.*"` ✓ (JDK 17 via Homebrew; `android.yml`/app-build are disabled so this is local-only for now)

## Scope note
This fixes the confirmed root cause (the header mismatch) but I haven't independently verified it resolves every last row of the reporter's specific export end-to-end — if their file turns out to have an additional quirk beyond this, that would need its own follow-up. Doesn't close #682.