### PR TITLE
Alarm: log live HR at arm time, to test a morning/evening hypothesis (#34)

### DIFF
--- a/Strand/BLE/BLEManager.swift
+++ b/Strand/BLE/BLEManager.swift
@@ -2874,6 +2874,16 @@ public final class BLEManager: NSObject, ObservableObject {
         // now — tells whether the arm even had a chance (skew ~0 but the strap still rejects ⇒ a corrupted
         // alarm register, not a clock problem).
         d.set(strapClockNow - Int(Date().timeIntervalSince1970), forKey: "alarm.lastArmClockSkew")
+        // #34: live HR at the moment of the arm, purely to test a hypothesis raised on a reporter's log —
+        // morning wake-up and morning short-horizon arms have fired reliably since v9.0.0, but an identical
+        // evening short-horizon arm (same code path, same commands, no day/night branch anywhere in this
+        // function) did not. One firmware-side explanation that would fit every reported case: the
+        // physical alarm haptic might only fire while the strap's OWN sleep/rest detection considers the
+        // wearer sleep-adjacent, independent of anything NOOP sends. This doesn't prove or fix that — it's
+        // a free read of state already tracked live, logged so the next reported failure (ideally an
+        // evening one) can be compared against the resting HR of the successful arms already on file. `nil`
+        // (no key written) means no HR had streamed yet at arm time, not zero.
+        d.set(state.heartRate, forKey: "alarm.lastArmHeartRate")
     }
 
     /// Disarm the currently-armed firmware alarm.

--- a/Strand/System/DebugDataDiagnostics.swift
+++ b/Strand/System/DebugDataDiagnostics.swift
@@ -265,6 +265,11 @@ enum DebugDataDiagnostics {
                 let mag = abs(skew) >= 86400 ? "\(skew / 86400)d" : "\(skew / 3600)h"
                 line += " · strap clock at arm \(skew > 0 ? "+" : "")\(mag)"
             }
+            // #34: live HR at arm, logged only to test whether the strap's own sleep/rest detection (not
+            // anything NOOP sends) gates the physical haptic — see the doc comment on recordAlarmArm.
+            if let hr = d.object(forKey: "alarm.lastArmHeartRate") as? Int {
+                line += " · HR \(hr) bpm at arm"
+            }
             lines.append(line)
             if let reported = d.object(forKey: "alarm.lastReportedEpoch") as? Int {
                 let mismatch = abs(reported - sent) > 120

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -3198,11 +3198,22 @@ class WhoopBleClient(
      *  strap was connected when we sent it), so a "didn't buzz" report shows sent-vs-strap-reports. */
     private fun recordAlarmArm(sentEpoch: Long) {
         runCatching {
-            NoopPrefs.of(context).edit()
+            val editor = NoopPrefs.of(context).edit()
                 .putLong("alarm.lastArmSentEpoch", sentEpoch)
                 .putLong("alarm.lastArmAt", System.currentTimeMillis())
                 .putBoolean("alarm.lastArmConnected", _state.value.connected)
-                .apply()
+            // #34: live HR at the moment of the arm, purely to test a hypothesis raised on a reporter's
+            // log — morning wake-up and morning short-horizon arms have fired reliably since v9.0.0, but
+            // an identical evening short-horizon arm (same code path, same commands, no day/night branch
+            // anywhere in armStrapAlarm) did not. One firmware-side explanation that would fit every
+            // reported case: the physical alarm haptic might only fire while the strap's OWN sleep/rest
+            // detection considers the wearer sleep-adjacent, independent of anything NOOP sends. This
+            // doesn't prove or fix that — it's a free read of state already tracked live, logged so the
+            // next reported failure (ideally an evening one) can be compared against the resting HR of
+            // the successful arms already on file. Absent key means no HR had streamed yet at arm time.
+            val hr = _state.value.heartRate
+            if (hr != null) editor.putInt("alarm.lastArmHeartRate", hr) else editor.remove("alarm.lastArmHeartRate")
+            editor.apply()
         }
     }
 

--- a/android/app/src/main/java/com/noop/testcentre/AndroidDiagnostics.kt
+++ b/android/app/src/main/java/com/noop/testcentre/AndroidDiagnostics.kt
@@ -213,6 +213,9 @@ object AndroidDiagnostics {
                 var line = "Last arm: sent ${alarmStamp(sent)}"
                 if (at > 0L) line += " · ${relTime(System.currentTimeMillis() - at)}"
                 if (!p.getBoolean("alarm.lastArmConnected", false)) line += " · strap NOT connected (queued)"
+                // #34: live HR at arm, logged only to test whether the strap's own sleep/rest detection
+                // (not anything NOOP sends) gates the physical haptic — see recordAlarmArm's doc comment.
+                if (p.contains("alarm.lastArmHeartRate")) line += " · HR ${p.getInt("alarm.lastArmHeartRate", 0)} bpm at arm"
                 add(line)
                 val reported = p.getLong("alarm.lastReportedEpoch", 0L)
                 if (reported > 0L) {


### PR DESCRIPTION
Not a fix — a diagnostic addition to help pin down #34's remaining open question.

## Where #34 stands
Since v9.0.0 the `connectSettled`-gated re-arm (#340) has resolved the original silent-drop failure mode. The reporter's latest log (2026-07-20) shows:
- overnight wake-up alarms: firing reliably for 4-5 days
- morning short-horizon tests (arm a few minutes out): fire correctly, with the new `result=0x01` readback
- **an identical evening short-horizon test does not fire**, even on v9.0.2

`armStrapAlarm` has no day/night branch at all — the exact same commands go out either way. That rules out an obvious app-side conditional bug, but nobody has yet attached a log of the specific failing evening case, so there isn't enough evidence yet to justify a code fix — that would just be guessing.

## What this PR does
One hypothesis fits every reported data point: the physical alarm haptic might only fire while the strap's own sleep/rest detection (not anything NOOP sends) considers the wearer sleep-adjacent. This logs the live HR already tracked in `LiveState`/`_state` at the exact moment of each arm — a free read, zero new BLE traffic, zero behavior change — persisted alongside the existing Alarm-block fields (sent epoch, connected, clock skew) and surfaced in the debug export's "Last arm" line (`… · HR 58 bpm at arm`).

This doesn't confirm or refute the hypothesis by itself. It means the *next* reported failure — ideally a captured evening one — can be compared against the resting HR of the already-successful arms on file, without needing another round-trip to ask for more instrumentation.

Mirrors the #392 precedent (log-only alarm diagnostics landing on both platforms together):
- iOS: `Strand/BLE/BLEManager.swift` (`recordAlarmArm`) + `Strand/System/DebugDataDiagnostics.swift` (Alarm block)
- Android: `android/app/src/main/java/com/noop/ble/WhoopBleClient.kt` (`recordAlarmArm`) + `android/app/src/main/java/com/noop/testcentre/AndroidDiagnostics.kt` (Alarm block)

## Testing
- `xcodegen generate && xcodebuild -project Strand.xcodeproj -scheme Strand -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO build` — BUILD SUCCEEDED
- `xcodebuild -project Strand.xcodeproj -scheme NOOPiOS -destination 'generic/platform=iOS Simulator' CODE_SIGNING_ALLOWED=NO build` — BUILD SUCCEEDED (`BLEManager.swift` is shared with iOS)
- `./gradlew compileFullDebugKotlin` ✓
- `./gradlew testFullDebugUnitTest --tests "com.noop.ble.*" --tests "com.noop.testcentre.*"` — 444/444 pass under `-Duser.language=en -Duser.country=US`; 2 unrelated locale-dependent failures (`StandardHrSensorFormatTest`, decimal-comma vs decimal-point, untouched by this diff) reproduce under the sandbox's default `de_DE` locale, matching the same class of pre-existing flake noted in #340's own test plan
- Not tested on-device (no physical WHOOP 4.0/5.0 available here) — this only reads already-live state and writes a UserDefaults/SharedPreferences key, no BLE command or timing change, so the risk surface is the log line itself