### PR TITLE
v18 @82: decode the SpO2 candidate as instrumentation (#103)

### DIFF
--- a/Packages/WhoopProtocol/Sources/WhoopProtocol/Interpreter.swift
+++ b/Packages/WhoopProtocol/Sources/WhoopProtocol/Interpreter.swift
@@ -484,7 +484,25 @@ private func decodeWhoop5Historical(_ frame: [UInt8], fb: FieldBuilder, payloadE
     }
     if let v = readDType(frame, 82, "u8") {
         fb.add(82, 1, "aux_byte_82", "status", value: .int(v),
-               note: "raw; observed nonzero only while sleep_state = asleep (meaning not pinned)")
+               note: "raw; nonzero only while sleep_state = asleep; tri-mode, see spo2_candidate_82")
+        // #103 SpO2 candidate: a decompile-sourced decode (gen5.rs `spo2_pct`, reimplemented here as a
+        // protocol fact with attribution, like the other RE work) reads @82 (= inner 74) as a
+        // strap-computed SpO2 % scalar, tri-mode: 70–100 = a real %, bit-7 values (0x80/0xA0…) =
+        // saturation sentinels, other sub-70 nonzero = diagnostic codes, populated only during sleep.
+        // Evidence is SPLIT: an 8-night independent validation with real spread (corr +0.99, ~0.4 %/night,
+        // tracks a 92 % desat AND a 98 % high; offset-specific — only @82 tracks in a 74–92 scan) meets
+        // the cross-night bar, but the two capture nights checked on the original #103 device moved
+        // OPPOSITE to the app value (95.50→92.83 app vs 93.62→93.80 gated mean) — device/firmware
+        // variance or an extraction error on one side, unresolved. So this ships as an INSTRUMENTATION
+        // CANDIDATE only: the in-band value is decoded and surfaced raw for multi-device correlation
+        // against the app's own nightly SpO2. It must never back a shipped SpO2 metric, never write
+        // `spo2Pct`/`spo2_red`/`spo2_ir` (the testHistoricalV18OpticalFieldsAreNotNamedPhysiologically
+        // guard), and never
+        // feed a downstream gate (recovery/illness) until the cross-device contradiction is resolved.
+        if (70...100).contains(v) {
+            fb.add(82, 1, "spo2_candidate_82", "spo2", value: .int(v),
+                   note: "in-band (70–100) @82 reading; candidate strap-computed SpO2 % (#103) — instrumentation only, cross-device evidence still split, not a shipped metric")
+        }
     }
     // ── The @82–119 "optical/perfusion + tail" span, characterised over 18,602 real v18 records from a
     // third strap (overnight R22 live stream) + cross-checked on the two fixture devices above. The span

--- a/Packages/WhoopProtocol/Tests/WhoopProtocolTests/Whoop5HistoricalTests.swift
+++ b/Packages/WhoopProtocol/Tests/WhoopProtocolTests/Whoop5HistoricalTests.swift
@@ -203,6 +203,27 @@ final class Whoop5HistoricalTests: XCTestCase {
         XCTAssertEqual(parseFrame(f, family: .whoop5).parsed["aux_byte_82"]?.intValue, 0x5A)
     }
 
+    func testHistoricalV18Spo2Candidate82TriMode() {
+        // #103: the @82 SpO2 candidate surfaces ONLY the tri-mode in-band values (70–100). The raw byte
+        // stays under aux_byte_82 in every mode; sentinels (bit-7: 0x80/0xA0), diagnostic codes (<70
+        // nonzero) and the awake 0 must NOT produce a candidate — mirroring gen5.rs's filter(70..=100).
+        // Instrumentation only: this key must never be wired into spo2Pct or any score.
+        let base = parseFrame(bytes(historicalHex), family: .whoop5).parsed
+        XCTAssertNil(base["spo2_candidate_82"], "awake 0 must not read as a candidate")
+        for (raw, want) in [(0x5A, 90), (70, 70), (100, 100)] {   // in-band values pass through
+            var f = bytes(historicalHex)
+            f[82] = UInt8(raw)
+            XCTAssertEqual(parseFrame(f, family: .whoop5).parsed["spo2_candidate_82"]?.intValue, want)
+        }
+        for raw in [0x80, 0xA0, 0x20, 69, 101] {                  // sentinels / diagnostics / out-of-band
+            var f = bytes(historicalHex)
+            f[82] = UInt8(raw)
+            let p = parseFrame(f, family: .whoop5).parsed
+            XCTAssertNil(p["spo2_candidate_82"], "raw 0x\(String(raw, radix: 16)) must not read as a candidate")
+            XCTAssertEqual(p["aux_byte_82"]?.intValue, raw, "raw byte must stay visible in every mode")
+        }
+    }
+
     func testHistoricalV18SleepStateMapping() {
         // @81's high nibble (bits 4-5) is the band's sleep state; the low nibble is sub-flags. Exercise
         // the mapping by overriding just that byte on the existing real fixture — no extra captures.

--- a/android/app/src/main/java/com/noop/protocol/HistoricalStreams.kt
+++ b/android/app/src/main/java/com/noop/protocol/HistoricalStreams.kt
@@ -336,8 +336,22 @@ private fun decodeWhoop5Historical(frame: ByteArray): Map<String, Any?>? {
         out["wake_quality"] = (it shr 2) and 3
         out["onwrist"] = it and 3
     }
-    // @82 a single raw byte adjacent to the flag byte; carried raw, meaning not pinned.
-    frame.histU8(82)?.let { out["aux_byte_82"] = it }
+    // @82 a single raw byte adjacent to the flag byte; nonzero only while sleep_state = asleep.
+    // #103 SpO2 candidate: a decompile-sourced decode (gen5.rs `spo2_pct`, reimplemented here as a
+    // protocol fact with attribution, like the other RE work) reads @82 (= inner 74) as a strap-computed
+    // SpO2 % scalar, tri-mode: 70–100 = a real %, bit-7 values (0x80/0xA0…) = saturation sentinels,
+    // other sub-70 nonzero = diagnostic codes, populated only during sleep. Evidence is SPLIT: an
+    // 8-night independent validation with real spread (corr +0.99, ~0.4 %/night) meets the cross-night
+    // bar, but the two capture nights checked on the original #103 device moved OPPOSITE to the app
+    // value — unresolved. So this ships as an INSTRUMENTATION CANDIDATE only: the in-band value is
+    // decoded and surfaced raw for multi-device correlation against the app's own nightly SpO2. It must
+    // never back a shipped SpO2 metric, never write spo2Pct/spo2_red/spo2_ir, and never feed a
+    // downstream gate (recovery/illness) until the cross-device contradiction is resolved. Mirror of
+    // Swift Interpreter (@82 block).
+    frame.histU8(82)?.let {
+        out["aux_byte_82"] = it
+        if (it in 70..100) out["spo2_candidate_82"] = it
+    }
     // ── The @82–119 "optical/tail" span, reverse-engineered over 18,602 real v18 records (a third strap's
     // overnight R22 stream) + cross-checked on two fixture devices: it is ~85% ZERO PADDING (83–103,
     // 110–112, 117–119 constant 0x00; @104 a constant 0x01 marker). Only @106 (u16), @108/@109 (a paired

--- a/android/app/src/test/java/com/noop/protocol/Whoop5HistoricalDecodeTest.kt
+++ b/android/app/src/test/java/com/noop/protocol/Whoop5HistoricalDecodeTest.kt
@@ -127,6 +127,27 @@ class Whoop5HistoricalDecodeTest {
     }
 
     @Test
+    fun spo2Candidate82SurfacesOnlyInBandValues() {
+        // #103: the @82 SpO2 candidate surfaces ONLY the tri-mode in-band values (70–100). The raw byte
+        // stays under aux_byte_82 in every mode; sentinels (bit-7: 0x80/0xA0), diagnostic codes (<70
+        // nonzero) and the awake 0 must NOT produce a candidate — mirroring gen5.rs's filter(70..=100).
+        // Instrumentation only: this key must never be wired into spo2Pct or any score. Twin of the Swift
+        // testHistoricalV18Spo2Candidate82TriMode.
+        val base = decodeHistorical(bytes(wornV18), DeviceFamily.WHOOP5)!!
+        assertEquals(0, base["aux_byte_82"])
+        assertEquals(null, base["spo2_candidate_82"])           // awake 0 is not a candidate
+        for ((raw, want) in listOf(0x5A to 90, 70 to 70, 100 to 100)) {
+            val p = decodeHistorical(mutateAndReCrc(82, raw), DeviceFamily.WHOOP5)!!
+            assertEquals(want, p["spo2_candidate_82"])
+        }
+        for (raw in listOf(0x80, 0xA0, 0x20, 69, 101)) {        // sentinels / diagnostics / out-of-band
+            val p = decodeHistorical(mutateAndReCrc(82, raw), DeviceFamily.WHOOP5)!!
+            assertEquals(null, p["spo2_candidate_82"])
+            assertEquals(raw, p["aux_byte_82"])                 // raw byte stays visible in every mode
+        }
+    }
+
+    @Test
     fun band81NibblesSplitIndependently() {
         // @81 packs sleep_state (bits 4-5), wake_quality (bits 2-3) and onwrist (bits 0-1). Override the
         // byte on the real fixture and re-stamp the CRC32 (over frame[8..len-4], per Framing) so it passes

--- a/docs/WHOOP5_DEEP_DATA.md
+++ b/docs/WHOOP5_DEEP_DATA.md
@@ -99,11 +99,19 @@ so the reasoning in one place:
 sleep, and the whole optical tail. Nothing on the wire is hidden behind a cipher NOOP would need a key
 for. The barrier is that the SpO₂ data simply isn't *in* the stream in a usable form:
 
-- **No SpO₂ field on the 5.0 wire.** The v18 historical layout carries no blood-oxygen value. The raw
-  optical tail (`@106` baseline, `@108/@109` amplitude pair, `@113` float) was checked against WHOOP-app
-  SpO₂ across 18,602 real records — it does not match; those channels track HR/motion, and there is no
-  identifiable red/IR pair. Pulse oximetry fundamentally needs two wavelengths; the 5.0's decodable
-  stream doesn't expose them (the v26 PPG waveform is single-channel, HR only).
+- **No *confirmed* SpO₂ field on the 5.0 wire — but there is now a candidate.** The raw optical tail
+  (`@106` baseline, `@108/@109` amplitude pair, `@113` float) was checked against WHOOP-app SpO₂ across
+  18,602 real records — it does not match; those channels track HR/motion, and there is no identifiable
+  red/IR pair. Pulse oximetry fundamentally needs two wavelengths; the 5.0's decodable stream doesn't
+  expose them (the v26 PPG waveform is single-channel, HR only). However, a decompile-sourced decode
+  ([#103](https://github.com/ryanbr/noop/issues/103)) reads v18 byte `@82` as a **strap-computed SpO₂ %
+  scalar** (tri-mode: 70–100 = real %, bit-7 = saturation sentinel, other sub-70 = diagnostic code;
+  sleep-only). The evidence is currently **split**: an 8-night independent validation with real spread
+  (corr +0.99, ~0.4 %/night) clears the cross-night bar, but the two nights checked on the original #103
+  capture device moved *opposite* to the app value — unresolved device/firmware variance or an extraction
+  error on one side. NOOP therefore decodes `@82` as `spo2_candidate_82` (deep-timeline instrumentation
+  only, in-band values only) so more devices can correlate it against the app's nightly SpO₂; it does
+  **not** populate `spo2Pct` or any card/score until the contradiction is resolved.
 - **A calibrated % needs WHOOP's proprietary curve.** Even where raw optical exists, turning a red/IR
   ratio into a real SpO₂ % requires a device-specific calibration NOOP does not have — and NOOP will not
   fabricate one from unvalidated optical (the withdrawn #194 PPG→HR estimate is the cautionary
@@ -122,8 +130,10 @@ the R-R interval stream (RSA) and shown on the Health screen when enough overnig
 **To see SpO₂ in NOOP on a 5.0:** import it. A WHOOP data export carries `blood_oxygen_pct`, and Health
 Connect import works too — both populate the Blood Oxygen card with WHOOP's own computed values.
 
-**Could it ever change?** Only via research, not decryption: capture the 5.0's raw optical alongside a
-reference oximeter and prove a channel tracks true SpO₂ (a varying signal, not one coincidental match).
+**Could it ever change?** Only via research, not decryption — and the `@82` candidate above is exactly
+that research in progress. What would flip it to a real reading: the `spo2_candidate_82` nightly values
+tracking the WHOOP app's own SpO₂ across many nights on **multiple devices** (a varying signal, not one
+coincidental match), including on the device where the two checked nights currently move opposite.
 Until that clears the bar, SpO₂ stays import-only on the 5.0.
 
 ## Mapping the layout — ground-truth correlation


### PR DESCRIPTION
Follows up on the latest #103 developments (2026-07-17). **Instrumentation only — this does not ship an SpO2 metric.**

## Where #103 stands
Three things happened in the thread, in order:
1. A decompile-sourced decode (gen5.rs, reimplemented here as a protocol fact with attribution, like the repo's other RE work) reads v18 byte `@82` (= inner 74) as a **strap-computed SpO2 % scalar**: tri-mode — 70–100 a real %, bit-7 values (0x80/0xA0…) saturation sentinels, other sub-70 nonzero diagnostic codes; populated only during sleep.
2. The two nights checked on the original #103 capture device **failed** the cross-night test even with that gate applied (app 95.50→92.83 falling, gated mean 93.62→93.80 rising) — and the thread set the bar explicitly: the gate must track the app number across nights where the true value actually moves.
3. An 8-night independent validation **with real spread** then met exactly that bar: corr +0.99, ~0.4 %/night error, tracks a 92 % desat and a 98 % high, and only byte 82 tracks in a 74–92 offset scan.

So the evidence is currently **split across devices** — the strongest yes so far, against an unexplained no on one device. Per the derived-biosignal rule (never a shipped metric on contested evidence; instrumentation first), the honest next step is to decode the candidate raw on every install so multiple devices can correlate it against the WHOOP app's own nightly SpO2 — which is what this PR does, and nothing more.

## What changes
- **Both decoders** (`Packages/WhoopProtocol/Sources/WhoopProtocol/Interpreter.swift` / `android/.../protocol/HistoricalStreams.kt`, byte-parity): alongside the existing raw `aux_byte_82`, an in-band (70–100) value now also surfaces as **`spo2_candidate_82`** with an explicit instrumentation-only note. Sentinels, diagnostic codes and the awake 0 produce no candidate key.
- **No consumer changes**: `spo2Pct` stays null on every WHOOP 5.0, no card, no score, no persistence-schema change. The existing never-invent-physiology guard (`testHistoricalV18OpticalFieldsAreNotNamedPhysiologically`, `spo2_red`/`spo2_ir` absent on v18) passes untouched.
- **Tests**: new twin tests on both platforms pinning the tri-mode gating (in-band passes, 0x80/0xA0/0x20/69/101 and awake-0 do not; the raw byte stays visible in every mode). The shared decoder-oracle fixtures are unaffected (`@82` = 0 on every fixture frame, verified by the byte-identical-copies drift guard).
- **`docs/WHOOP5_DEEP_DATA.md`**: the SpO2 section no longer claims "the v18 layout carries no blood-oxygen value" — it now describes the candidate, the split evidence, and what would flip it (multi-device cross-night tracking, including on the device where the two checked nights move opposite).

## Testing
- `swift test` (Packages/WhoopProtocol): **308 tests, 0 failures** — includes the new `testHistoricalV18Spo2Candidate82TriMode`
- `./gradlew compileFullDebugKotlin testFullDebugUnitTest --tests "com.noop.protocol.*"` ✓ — includes the new `spo2Candidate82SurfacesOnlyInBandValues` and the `DecoderOracleTest` drift guard
- No BLE path, UI, or stored-value shape touched, so no app-target build or on-device run is required for this change