### PR TITLE
Oura: read-only SpO2 / real-steps feature-status probe (confirm the server-flag gate)

### DIFF
--- a/Packages/OuraProtocol/Sources/OuraProtocol/Commands.swift
+++ b/Packages/OuraProtocol/Sources/OuraProtocol/Commands.swift
@@ -20,6 +20,9 @@ public enum OuraCommands {
     public static let featureDaytimeHR: UInt8 = 0x02
     // The SpO2 feature id. Per OURA_PROTOCOL.md s7.1.
     public static let featureSpO2: UInt8 = 0x04
+    // The real-steps feature id. Server-flag-gated (activity/real_steps, default off), so it is never
+    // emitted for an offline NOOP-only ring. Per OURA_PROTOCOL.md s7.1 / s7.3 [open_oura-feat].
+    public static let featureRealSteps: UInt8 = 0x0B
 
     // MARK: - Pre-auth / identity (unauthenticated OK)
 
@@ -112,6 +115,23 @@ public enum OuraCommands {
     /// Per OURA_PROTOCOL.md s5.6.
     public static func liveHRDisable() -> OuraCommand {
         OuraCommand(label: "dhr_disable", bytes: [0x2F, 0x03, 0x22, featureDaytimeHR, 0x01])
+    }
+
+    // MARK: - Feature-status diagnostics (READ-ONLY; s5.6 / s7.1)
+
+    /// Read the SpO2 feature status, `2f 02 20 04` — the SAME `0x20` READ verb as `dhr_read`, NOT the
+    /// `0x22` set-mode enable. The `0x21` reply carries feature/mode/status/state/subscription; SpO2 is
+    /// server-flag-gated (`health/spo2`), so the reply is the ring's own report of whether it will emit
+    /// SpO2. Read-only diagnostic — never enables anything, never writes a mode. [open_oura-feat]
+    public static func spo2ReadStatus() -> OuraCommand {
+        OuraCommand(label: "spo2_status", bytes: [0x2F, 0x02, 0x20, featureSpO2])
+    }
+
+    /// Read the real-steps feature status, `2f 02 20 0b` (READ verb, not enable). The `0x21` reply confirms
+    /// the server-flag gate (`activity/real_steps`, default off) from the ring itself. Read-only diagnostic.
+    /// [open_oura-feat]
+    public static func realStepsReadStatus() -> OuraCommand {
+        OuraCommand(label: "realsteps_status", bytes: [0x2F, 0x02, 0x20, featureRealSteps])
     }
 
     /// The ordered live-HR enable triplet (read, enable, subscribe). The driver gates each on its ACK.

--- a/Packages/OuraProtocol/Sources/OuraProtocol/Decoders.swift
+++ b/Packages/OuraProtocol/Sources/OuraProtocol/Decoders.swift
@@ -333,6 +333,19 @@ public enum OuraDecoders {
         return OuraState(ringTimestamp: rec.ringTimestamp, stateCode: Int(code), text: text)
     }
 
+    // MARK: - Feature-status read reply (0x2F sub-op 0x21; s5.6 / s7.1)
+
+    /// Decode a feature-status read reply's SUB-BODY (the bytes AFTER the `0x21` sub-op) into
+    /// `feature, mode, status, state, subscription`, the ring's own feature report [open_oura-feat]. The
+    /// observed daytime-HR reply is `2f 06 21 02 01 11 02 00` → sub-body `02 01 11 02 00`. Returns nil on a
+    /// short body (< 5) so a truncated reply never fabricates a status. READ-ONLY diagnostic.
+    public static func decodeFeatureStatus(_ subBody: [UInt8]) -> OuraFeatureStatus? {
+        guard subBody.count >= 5 else { return nil }
+        return OuraFeatureStatus(feature: Int(subBody[0]), mode: Int(subBody[1]),
+                                 status: Int(subBody[2]), state: Int(subBody[3]),
+                                 subscription: Int(subBody[4]))
+    }
+
     // MARK: - Debug text (0x43; s6.15)
 
     /// Decode the 0x43 debug_event: ASCII state strings. Per OURA_PROTOCOL.md s6.15. Returns nil when

--- a/Packages/OuraProtocol/Sources/OuraProtocol/OuraDriver.swift
+++ b/Packages/OuraProtocol/Sources/OuraProtocol/OuraDriver.swift
@@ -420,7 +420,17 @@ public final class OuraDriver {
         // Live-HR enable ACKs advance the triplet (s5.6): 0x21 is the dhr_read feature-read ACK from
         // step 1 (`2f 06 21 02 01 11 02 00`), 0x23 acks the enable write (step 2), 0x27 acks the
         // subscribe write (step 3). All three must be recognised or the sequencer stalls at step 0.
-        if frame.subop == 0x21 || frame.subop == 0x23 || frame.subop == 0x27 {
+        if frame.subop == 0x21 {
+            // A 0x21 is a feature-status read reply. The daytime-HR read (feature 0x02) is step 1 of the
+            // live-HR triplet and MUST advance it; a diagnostic read (SpO2 0x04 / real_steps 0x0b) instead
+            // surfaces the ring's own feature report so a capture can confirm the server-flag gate.
+            if let st = OuraDecoders.decodeFeatureStatus(frame.subBody),
+               st.feature != Int(OuraCommands.featureDaytimeHR) {
+                return .featureStatus(st)
+            }
+            return .enableAck
+        }
+        if frame.subop == 0x23 || frame.subop == 0x27 {
             return .enableAck
         }
         return .unhandled
@@ -432,6 +442,7 @@ public final class OuraDriver {
         case authStatus(OuraAuthStatus)
         case liveHRPush([UInt8])
         case enableAck
+        case featureStatus(OuraFeatureStatus)
         case unhandled
     }
 }

--- a/Packages/OuraProtocol/Sources/OuraProtocol/OuraEvents.swift
+++ b/Packages/OuraProtocol/Sources/OuraProtocol/OuraEvents.swift
@@ -119,6 +119,22 @@ public struct OuraState: Equatable, Sendable, Codable {
     }
 }
 
+/// A decoded feature-status read reply (the `0x2F` sub-op `0x21` response): the ring's own report of a
+/// feature's mode / status / state / subscription. Read-only diagnostic — used to confirm the server-flag
+/// gate on SpO2 (`0x04`) / real_steps (`0x0b`): a `subscription == 0` with no emitted records is the ring
+/// saying "the cloud has not enabled this", which NOOP cannot override offline. Never scored, never stored.
+public struct OuraFeatureStatus: Equatable, Sendable, Codable {
+    public let feature: Int
+    public let mode: Int
+    public let status: Int
+    public let state: Int
+    public let subscription: Int
+    public init(feature: Int, mode: Int, status: Int, state: Int, subscription: Int) {
+        self.feature = feature; self.mode = mode; self.status = status
+        self.state = state; self.subscription = subscription
+    }
+}
+
 /// A UTC anchor / time-sync event (OURA_PROTOCOL.md s6.11): epoch ms + timezone offset seconds.
 public struct OuraTimeSync: Equatable, Sendable, Codable {
     public let ringTimestamp: UInt32

--- a/Packages/OuraProtocol/Tests/OuraProtocolTests/OuraFeatureStatusTests.swift
+++ b/Packages/OuraProtocol/Tests/OuraProtocolTests/OuraFeatureStatusTests.swift
@@ -1,0 +1,59 @@
+import XCTest
+@testable import OuraProtocol
+
+/// The read-only feature-status diagnostic: NOOP asks the ring its SpO2 (0x04) / real_steps (0x0b) feature
+/// status with the SAME `0x20` read verb as `dhr_read`, decodes the `0x21` reply, and logs it once. It
+/// confirms — from the ring itself — the server-flag gate that keeps those features off for an offline ring.
+/// It must NEVER enable anything (no `0x22` set-mode) and must NOT disturb the live-HR triplet.
+final class OuraFeatureStatusTests: XCTestCase {
+    private let key: [UInt8] = Array(0..<16)
+
+    // MARK: - Command bytes (read verb only)
+
+    func testStatusQueryCommandsAreReadOnly() {
+        XCTAssertEqual(OuraCommands.spo2ReadStatus().bytes, [0x2F, 0x02, 0x20, 0x04])
+        XCTAssertEqual(OuraCommands.realStepsReadStatus().bytes, [0x2F, 0x02, 0x20, 0x0B])
+        // sub-op 0x20 is READ; the enable would be 0x22 — neither query may ever carry it.
+        XCTAssertEqual(OuraCommands.spo2ReadStatus().bytes[2], 0x20)
+        XCTAssertEqual(OuraCommands.realStepsReadStatus().bytes[2], 0x20)
+    }
+
+    // MARK: - Decode
+
+    func testDecodesTheFiveStatusBytes() {
+        // The observed daytime-HR reply `2f 06 21 02 01 11 02 00` → sub-body `02 01 11 02 00`.
+        let st = OuraDecoders.decodeFeatureStatus([0x02, 0x01, 0x11, 0x02, 0x00])
+        XCTAssertEqual(st, OuraFeatureStatus(feature: 0x02, mode: 1, status: 0x11, state: 2, subscription: 0))
+    }
+
+    func testShortBodyDecodesToNil() {
+        XCTAssertNil(OuraDecoders.decodeFeatureStatus([0x04, 0x01]))   // never fabricate a partial status
+        XCTAssertNil(OuraDecoders.decodeFeatureStatus([]))
+    }
+
+    // MARK: - Driver routing (diagnostic vs the triplet)
+
+    func testDaytimeHRReadStillAdvancesTheTriplet() {
+        // A 0x21 for the daytime-HR feature (0x02) is step 1 of the live-HR triplet → must stay `.enableAck`.
+        let d = OuraDriver(ringGen: .gen3, authKey: key)
+        let frame = OuraSecureFrame(subop: 0x21, subBody: [0x02, 0x01, 0x11, 0x02, 0x00])
+        XCTAssertEqual(d.handleSecureFrame(frame), .enableAck)
+    }
+
+    func testSpO2AndStepsReadsSurfaceFeatureStatus() {
+        let d = OuraDriver(ringGen: .gen3, authKey: key)
+        // SpO2 (0x04): subscription 0 → server-gated off.
+        XCTAssertEqual(d.handleSecureFrame(OuraSecureFrame(subop: 0x21, subBody: [0x04, 0x00, 0x00, 0x00, 0x00])),
+                       .featureStatus(OuraFeatureStatus(feature: 0x04, mode: 0, status: 0, state: 0, subscription: 0)))
+        // real_steps (0x0b): subscription 0 → server-gated off.
+        XCTAssertEqual(d.handleSecureFrame(OuraSecureFrame(subop: 0x21, subBody: [0x0B, 0x00, 0x00, 0x00, 0x00])),
+                       .featureStatus(OuraFeatureStatus(feature: 0x0B, mode: 0, status: 0, state: 0, subscription: 0)))
+    }
+
+    func testUndecodableDiagnosticReplyFallsBackToEnableAck() {
+        // A too-short 0x21 (can't decode a feature) must not crash or mis-route; it stays `.enableAck` so
+        // the triplet never stalls on a malformed reply.
+        let d = OuraDriver(ringGen: .gen3, authKey: key)
+        XCTAssertEqual(d.handleSecureFrame(OuraSecureFrame(subop: 0x21, subBody: [0x04])), .enableAck)
+    }
+}

--- a/Strand/BLE/OuraLiveSource.swift
+++ b/Strand/BLE/OuraLiveSource.swift
@@ -176,6 +176,9 @@ public final class OuraLiveSource: NSObject, ObservableObject {
     /// ONLY (see the `allowTierB: true` comment at driver construction) - the log is how we collect raw
     /// captures to validate these layouts; nothing here ever persists or scores. Reset on stop/disconnect.
     private var loggedTierBKinds: Set<String> = []
+    /// Feature ids whose status we have already logged this session (SpO2 0x04 / real_steps 0x0b), so the
+    /// read-only feature-status diagnostic prints once per feature, not on every reconnect.
+    private var loggedFeatureStatuses: Set<Int> = []
 
     // MARK: - Activity (0x50 MET) estimate accumulation — INVESTIGATION ONLY
     // Aggregate the decoded 0x50 MET stream into an honest, clearly-labeled per-day estimate
@@ -546,6 +549,7 @@ public final class OuraLiveSource: NSObject, ObservableObject {
         loggedFirstSpo2 = false
         loggedAnchor = false
         loggedTierBKinds.removeAll()
+        loggedFeatureStatuses.removeAll()
         activityMETByDay.removeAll()
         activityCadenceObs.removeAll()
         lastActivityUtc = nil
@@ -607,6 +611,10 @@ public final class OuraLiveSource: NSObject, ObservableObject {
                 startHistoryFetchTimer()
                 fetchHistoryIfIdle()   // pull last night's banked temp/SpO2/HRV/sleep-phase right away
                 write([OuraCommands.getBattery()])   // ask once HR streams; the 0x0D reply routes to onBattery
+                // Read-only diagnostic: ask the ring its SpO2 / real-steps feature status once, so a capture
+                // confirms (from the ring itself) that these server-flag features are subscription-gated OFF
+                // for an offline ring. NEVER an enable/set-mode write - purely the 0x20 read verb.
+                write([OuraCommands.spo2ReadStatus(), OuraCommands.realStepsReadStatus()])
             }
         default:
             break
@@ -905,6 +913,27 @@ public final class OuraLiveSource: NSObject, ObservableObject {
         }
     }
 
+    /// Log a feature-status read reply once per feature (read-only diagnostic). Confirms, from the ring
+    /// itself, whether a server-flag feature (SpO2 0x04 / real_steps 0x0b) is subscribed/emitting — NOOP
+    /// cannot enable these offline (server ClientConfiguration gate), so a `subscription == 0` here is the
+    /// honest "not a bug, it's a gate" reading. Never scored, never stored.
+    private func logFeatureStatus(_ st: OuraFeatureStatus) {
+        guard loggedFeatureStatuses.insert(st.feature).inserted else { return }
+        let name: String
+        switch UInt8(truncatingIfNeeded: st.feature) {
+        case OuraCommands.featureSpO2:      name = "SpO2 (0x04)"
+        case OuraCommands.featureRealSteps: name = "real_steps (0x0b)"
+        case OuraCommands.featureDaytimeHR: name = "daytime-HR (0x02)"
+        default:                            name = "0x\(String(st.feature, radix: 16))"
+        }
+        // A gated/unavailable feature reports ALL-ZERO (mode/status/state); the streaming daytime-HR, by
+        // contrast, reads mode=1 status=0x11 state=2. Flag the all-zero case as the honest "cloud never
+        // enabled it" — NOT `subscription==0` alone, since daytime-HR is subscription=0 yet active.
+        let off = st.mode == 0 && st.status == 0 && st.state == 0
+        let gate = off ? " - INACTIVE (server-gated off; the cloud never enabled it, not emitted offline)" : ""
+        log("Oura: feature status \(name) mode=\(st.mode) status=\(st.status) state=\(st.state) subscription=\(st.subscription)\(gate)")
+    }
+
     // MARK: - Re-engagement timer (daytime-HR auto-reverts ~20s)
 
     private func startReengageTimer() {
@@ -1058,6 +1087,7 @@ extension OuraLiveSource: @preconcurrency CBCentralManagerDelegate {
         loggedFirstSpo2 = false
         loggedAnchor = false
         loggedTierBKinds.removeAll()
+        loggedFeatureStatuses.removeAll()
         pendingAnchorEvents.removeAll()   // a fresh session must never replay a stale-anchor guess
         pendingInstallKey = nil
         adoptPhase = .idle
@@ -1119,6 +1149,7 @@ extension OuraLiveSource: @preconcurrency CBCentralManagerDelegate {
         loggedFirstSpo2 = false
         loggedAnchor = false
         loggedTierBKinds.removeAll()
+        loggedFeatureStatuses.removeAll()
         activityMETByDay.removeAll()
         activityCadenceObs.removeAll()
         lastActivityUtc = nil
@@ -1273,6 +1304,8 @@ extension OuraLiveSource: @preconcurrency CBPeripheralDelegate {
             advance(.authCompleted(status))
         case .enableAck:
             advance(.enableAckReceived)
+        case .featureStatus(let st):
+            logFeatureStatus(st)   // read-only diagnostic; never advances the state machine
         case .liveHRPush(let body):
             guard let driver else { return }
             ingest(driver.ingestLiveHRPush(body: body))

--- a/android/app/src/main/java/com/noop/ble/OuraLiveSource.kt
+++ b/android/app/src/main/java/com/noop/ble/OuraLiveSource.kt
@@ -259,6 +259,9 @@ class OuraLiveSource(
      *  ONLY (see the `allowTierB = true` comment at driver construction) - the log is how we collect raw
      *  captures to validate these layouts; nothing here ever persists or scores. Reset on stop/disconnect. */
     private val loggedTierBKinds = mutableSetOf<String>()
+    /** Feature ids whose status we have already logged this session (SpO2 0x04 / real_steps 0x0b), so the
+     *  read-only feature-status diagnostic prints once per feature, not on every reconnect. */
+    private val loggedFeatureStatuses = mutableSetOf<Int>()
 
     // MARK: - Auto-reconnect (#912)
 
@@ -568,6 +571,7 @@ class OuraLiveSource(
         loggedFirstSpo2 = false
         loggedAnchor = false
         loggedTierBKinds.clear()
+        loggedFeatureStatuses.clear()
         pendingAnchorEvents.clear()
         // Resume the GetEvents cursor from where the LAST connection to this ring left off (s5.1/5.3), so a
         // routine reconnect doesn't re-fetch the ring's entire banked history every time.
@@ -617,6 +621,7 @@ class OuraLiveSource(
         loggedFirstSpo2 = false
         loggedAnchor = false
         loggedTierBKinds.clear()
+        loggedFeatureStatuses.clear()
         reachedStreaming = false
         // A stop MID-install is an honest failure (no ack will come); a stop after streaming leaves the
         // completed Streaming outcome intact so the wizard's success transition is not undone.
@@ -747,6 +752,7 @@ class OuraLiveSource(
                     loggedFirstSpo2 = false
                     loggedAnchor = false
                     loggedTierBKinds.clear()
+        loggedFeatureStatuses.clear()
                     reachedStreaming = false
                     // A disconnect MID-install is an honest failure (no 0x25 ack will arrive); a disconnect
                     // after streaming leaves the completed Streaming outcome intact. Drop any in-flight key
@@ -899,6 +905,11 @@ class OuraLiveSource(
                     scheduleHistoryFetch()
                     fetchHistoryIfIdle()
                     write(OuraCommands.getBattery())
+                    // Read-only diagnostic: ask the ring its SpO2 / real-steps feature status once, so a
+                    // capture confirms (from the ring itself) that these server-flag features are
+                    // subscription-gated OFF for an offline ring. NEVER an enable/set-mode write.
+                    write(OuraCommands.spo2ReadStatus())
+                    write(OuraCommands.realStepsReadStatus())
                 }
             }
             OuraDriverPhase.NeedsKeyInstall -> {
@@ -1059,9 +1070,32 @@ class OuraLiveSource(
                 advance(OuraTransition.AuthCompleted(routing.status))
             }
             OuraDriver.SecureRouting.EnableAck -> advance(OuraTransition.EnableAckReceived)
+            is OuraDriver.SecureRouting.FeatureStatus -> logFeatureStatus(routing.value)   // read-only; no advance
             is OuraDriver.SecureRouting.LiveHRPush -> emit(d.ingestLiveHRPush(routing.body))
             OuraDriver.SecureRouting.Unhandled -> Unit
         }
+    }
+
+    /**
+     * Log a feature-status read reply once per feature (read-only diagnostic). Confirms, from the ring
+     * itself, whether a server-flag feature (SpO2 0x04 / real_steps 0x0b) is subscribed/emitting — NOOP
+     * cannot enable these offline (server ClientConfiguration gate), so a `subscription == 0` here is the
+     * honest "not a bug, it's a gate" reading. Never scored, never stored.
+     */
+    private fun logFeatureStatus(st: com.noop.oura.OuraFeatureStatus) {
+        if (!loggedFeatureStatuses.add(st.feature)) return
+        val name = when (st.feature) {
+            OuraCommands.featureSpO2 -> "SpO2 (0x04)"
+            OuraCommands.featureRealSteps -> "real_steps (0x0b)"
+            OuraCommands.featureDaytimeHR -> "daytime-HR (0x02)"
+            else -> "0x${st.feature.toString(16)}"
+        }
+        // A gated/unavailable feature reports ALL-ZERO (mode/status/state); the streaming daytime-HR, by
+        // contrast, reads mode=1 status=0x11 state=2. Flag the all-zero case as the honest "cloud never
+        // enabled it" — NOT `subscription==0` alone, since daytime-HR is subscription=0 yet active.
+        val off = st.mode == 0 && st.status == 0 && st.state == 0
+        val gate = if (off) " - INACTIVE (server-gated off; the cloud never enabled it, not emitted offline)" else ""
+        log("Oura: feature status $name mode=${st.mode} status=${st.status} state=${st.state} subscription=${st.subscription}$gate")
     }
 
     /**

--- a/android/app/src/main/java/com/noop/oura/Commands.kt
+++ b/android/app/src/main/java/com/noop/oura/Commands.kt
@@ -27,6 +27,9 @@ object OuraCommands {
 
     // The SpO2 feature id. Per OURA_PROTOCOL.md s7.1.
     const val featureSpO2 = 0x04
+    // The real-steps feature id. Server-flag-gated (activity/real_steps, default off), so it is never
+    // emitted for an offline NOOP-only ring. Per OURA_PROTOCOL.md s7.1 / s7.3 [open_oura-feat].
+    const val featureRealSteps = 0x0b
 
     // MARK: - Pre-auth / identity (unauthenticated OK)
 
@@ -130,6 +133,25 @@ object OuraCommands {
      */
     fun liveHRDisable(): OuraCommand =
         OuraCommand("dhr_disable", intArrayOf(0x2F, 0x03, 0x22, featureDaytimeHR, 0x01))
+
+    // Feature-status diagnostics (READ-ONLY; s5.6 / s7.1)
+
+    /**
+     * Read the SpO2 feature status, `2f 02 20 04` — the SAME `0x20` READ verb as `dhr_read`, NOT the `0x22`
+     * set-mode enable. The `0x21` reply carries feature/mode/status/state/subscription; SpO2 is server-flag-
+     * gated (`health/spo2`), so the reply is the ring's own report of whether it will emit SpO2. Read-only
+     * diagnostic — never enables anything, never writes a mode. [open_oura-feat]
+     */
+    fun spo2ReadStatus(): OuraCommand =
+        OuraCommand("spo2_status", intArrayOf(0x2F, 0x02, 0x20, featureSpO2))
+
+    /**
+     * Read the real-steps feature status, `2f 02 20 0b` (READ verb, not enable). The `0x21` reply confirms
+     * the server-flag gate (`activity/real_steps`, default off) from the ring itself. Read-only diagnostic.
+     * [open_oura-feat]
+     */
+    fun realStepsReadStatus(): OuraCommand =
+        OuraCommand("realsteps_status", intArrayOf(0x2F, 0x02, 0x20, featureRealSteps))
 
     /**
      * The ordered live-HR enable triplet (read, enable, subscribe). The driver gates each on its ACK.

--- a/android/app/src/main/java/com/noop/oura/Decoders.kt
+++ b/android/app/src/main/java/com/noop/oura/Decoders.kt
@@ -366,6 +366,19 @@ object OuraDecoders {
         return OuraState(ringTimestamp = rec.ringTimestamp, stateCode = code, text = text)
     }
 
+    // Feature-status read reply (0x2F sub-op 0x21; s5.6 / s7.1)
+
+    /**
+     * Decode a feature-status read reply's SUB-BODY (the bytes AFTER the `0x21` sub-op) into
+     * feature/mode/status/state/subscription, the ring's own feature report [open_oura-feat]. The observed
+     * daytime-HR reply is `2f 06 21 02 01 11 02 00` → sub-body `02 01 11 02 00`. Returns null on a short body
+     * (< 5) so a truncated reply never fabricates a status. READ-ONLY diagnostic. Kotlin twin of Swift.
+     */
+    fun decodeFeatureStatus(subBody: IntArray): OuraFeatureStatus? {
+        if (subBody.size < 5) return null
+        return OuraFeatureStatus(subBody[0], subBody[1], subBody[2], subBody[3], subBody[4])
+    }
+
     // MARK: - Debug text (0x43; s6.15)
 
     /**

--- a/android/app/src/main/java/com/noop/oura/OuraDriver.kt
+++ b/android/app/src/main/java/com/noop/oura/OuraDriver.kt
@@ -532,7 +532,17 @@ class OuraDriver(
         // Live-HR enable ACKs advance the triplet (s5.6): 0x21 is the dhr_read feature-read ACK from
         // step 1 (`2f 06 21 02 01 11 02 00`), 0x23 acks the enable write (step 2), 0x27 acks the
         // subscribe write (step 3). All three must be recognised or the sequencer stalls at step 0.
-        if (frame.subop == 0x21 || frame.subop == 0x23 || frame.subop == 0x27) {
+        if (frame.subop == 0x21) {
+            // A 0x21 is a feature-status read reply. The daytime-HR read (feature 0x02) is step 1 of the
+            // live-HR triplet and MUST advance it; a diagnostic read (SpO2 0x04 / real_steps 0x0b) instead
+            // surfaces the ring's own feature report so a capture can confirm the server-flag gate.
+            val st = OuraDecoders.decodeFeatureStatus(frame.subBody)
+            if (st != null && st.feature != OuraCommands.featureDaytimeHR) {
+                return SecureRouting.FeatureStatus(st)
+            }
+            return SecureRouting.EnableAck
+        }
+        if (frame.subop == 0x23 || frame.subop == 0x27) {
             return SecureRouting.EnableAck
         }
         return SecureRouting.Unhandled
@@ -561,6 +571,7 @@ class OuraDriver(
         }
 
         object EnableAck : SecureRouting()
+        data class FeatureStatus(val value: OuraFeatureStatus) : SecureRouting()
         object Unhandled : SecureRouting()
     }
 

--- a/android/app/src/main/java/com/noop/oura/OuraEvents.kt
+++ b/android/app/src/main/java/com/noop/oura/OuraEvents.kt
@@ -74,6 +74,21 @@ data class OuraMotion(val ringTimestamp: Long, val index: Int, val state: OuraMo
 /** Device lifecycle state (OURA_PROTOCOL.md s6.15) decoded from a 0x45/0x53 record. */
 data class OuraState(val ringTimestamp: Long, val stateCode: Int, val text: String? = null)
 
+/**
+ * A decoded feature-status read reply (the `0x2F` sub-op `0x21` response): the ring's own report of a
+ * feature's mode / status / state / subscription. Kotlin twin of the Swift `OuraFeatureStatus`. Read-only
+ * diagnostic — used to confirm the server-flag gate on SpO2 (`0x04`) / real_steps (`0x0b`): a
+ * `subscription == 0` with no emitted records is the ring saying "the cloud has not enabled this", which
+ * NOOP cannot override offline. Never scored, never stored.
+ */
+data class OuraFeatureStatus(
+    val feature: Int,
+    val mode: Int,
+    val status: Int,
+    val state: Int,
+    val subscription: Int,
+)
+
 /** A UTC anchor / time-sync event (OURA_PROTOCOL.md s6.11): epoch ms + timezone offset seconds. */
 data class OuraTimeSync(val ringTimestamp: Long, val epochMs: Long, val tzOffsetSeconds: Int)
 

--- a/android/app/src/test/java/com/noop/oura/OuraFeatureStatusTest.kt
+++ b/android/app/src/test/java/com/noop/oura/OuraFeatureStatusTest.kt
@@ -1,0 +1,66 @@
+package com.noop.oura
+
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * The read-only feature-status diagnostic (Kotlin twin of Swift's OuraFeatureStatusTests): NOOP asks the
+ * ring its SpO2 (0x04) / real_steps (0x0b) feature status with the SAME 0x20 read verb as dhr_read, decodes
+ * the 0x21 reply, and logs it once. Must never enable anything (no 0x22 set-mode) nor disturb the live-HR
+ * triplet.
+ */
+class OuraFeatureStatusTest {
+    private val key: IntArray = IntArray(16) { it }
+
+    @Test
+    fun statusQueryCommandsAreReadOnly() {
+        assertArrayEquals(intArrayOf(0x2F, 0x02, 0x20, 0x04), OuraCommands.spo2ReadStatus().bytes)
+        assertArrayEquals(intArrayOf(0x2F, 0x02, 0x20, 0x0B), OuraCommands.realStepsReadStatus().bytes)
+        // sub-op 0x20 is READ; the enable would be 0x22 — neither query may ever carry it.
+        assertEquals(0x20, OuraCommands.spo2ReadStatus().bytes[2])
+        assertEquals(0x20, OuraCommands.realStepsReadStatus().bytes[2])
+    }
+
+    @Test
+    fun decodesTheFiveStatusBytes() {
+        // The observed daytime-HR reply `2f 06 21 02 01 11 02 00` → sub-body `02 01 11 02 00`.
+        val st = OuraDecoders.decodeFeatureStatus(intArrayOf(0x02, 0x01, 0x11, 0x02, 0x00))
+        assertEquals(OuraFeatureStatus(0x02, 1, 0x11, 2, 0), st)
+    }
+
+    @Test
+    fun shortBodyDecodesToNull() {
+        assertNull(OuraDecoders.decodeFeatureStatus(intArrayOf(0x04, 0x01)))
+        assertNull(OuraDecoders.decodeFeatureStatus(intArrayOf()))
+    }
+
+    @Test
+    fun daytimeHRReadStillAdvancesTheTriplet() {
+        val d = OuraDriver(ringGen = OuraRingGen.GEN3, authKey = key)
+        val frame = OuraSecureFrame(0x21, intArrayOf(0x02, 0x01, 0x11, 0x02, 0x00))
+        assertEquals(OuraDriver.SecureRouting.EnableAck, d.handleSecureFrame(frame))
+    }
+
+    @Test
+    fun spo2AndStepsReadsSurfaceFeatureStatus() {
+        val d = OuraDriver(ringGen = OuraRingGen.GEN3, authKey = key)
+        assertEquals(
+            OuraDriver.SecureRouting.FeatureStatus(OuraFeatureStatus(0x04, 0, 0, 0, 0)),
+            d.handleSecureFrame(OuraSecureFrame(0x21, intArrayOf(0x04, 0, 0, 0, 0))),
+        )
+        assertEquals(
+            OuraDriver.SecureRouting.FeatureStatus(OuraFeatureStatus(0x0B, 0, 0, 0, 0)),
+            d.handleSecureFrame(OuraSecureFrame(0x21, intArrayOf(0x0B, 0, 0, 0, 0))),
+        )
+    }
+
+    @Test
+    fun undecodableDiagnosticReplyFallsBackToEnableAck() {
+        // A too-short 0x21 (can't decode a feature) must not mis-route; it stays EnableAck so the triplet
+        // never stalls on a malformed reply.
+        val d = OuraDriver(ringGen = OuraRingGen.GEN3, authKey = key)
+        assertEquals(OuraDriver.SecureRouting.EnableAck, d.handleSecureFrame(OuraSecureFrame(0x21, intArrayOf(0x04))))
+    }
+}


### PR DESCRIPTION
  ## Summary
  SpO2 (`0x6F`…) and real_steps (`0x7E`/`0x7F`) never appear for a NOOP-only ring because they're **server-flag features** (`health/spo2`, `activity/real_steps`)  set by Oura's cloud `ClientConfiguration` — the ring gatekeeps them and no local `SetFeatureMode` can enable them offline ([open_oura-feat]). This adds a
  **read-only diagnostic** that has the ring **confirm that from its own mouth**, so a capture shows "not a bug, it's a gate" instead of just "absent".

  ## What it does
  Once HR streams, send the feature-status **READ** verb — the same `2f 02 20 <id>` as `dhr_read`, **never** the `2f 03 22` set-mode enable — for SpO2 (`0x04`) and  real_steps (`0x0b`), decode the `0x21` reply, and log once per feature:  Oura: feature status SpO2 (0x04) mode=.. status=.. state=.. subscription=0 - server-gated OFF; not emitted offline

  ## Changes (both platforms)
  - **`OuraProtocol`**: `featureRealSteps` + `spo2ReadStatus()`/`realStepsReadStatus()`; `OuraFeatureStatus` + `decodeFeatureStatus` (nil on short body); `handleSecureFrame` splits `0x21` — daytime-HR read (`0x02`) still `.enableAck` (advances the live-HR triplet), a diagnostic read (`0x04`/`0x0b`) returns the new  `.featureStatus`; an undecodable `0x21` falls back to `.enableAck` so the triplet never stalls.
  - **App**: `OuraLiveSource` sends the two reads once, logs once per feature.

  ## Safety
  Read-only — fits the BLE contract (no write-to-enable, no destructive command); never scored, never stored.

  ## Verification
  - `swift test` OuraProtocol **117** (incl. **6 new**); `xcodebuild` Strand macOS **BUILD SUCCEEDED**.
  - Android `compileFullDebugKotlin` **OK**; `testFullDebugUnitTest OuraFeatureStatusTest` **6/6**.
  - Hardware, next connect: the two `feature status …` lines print the ring's own subscription bytes.
