### PR TITLE
Fix seeded WHOOP model label and skin-temp scale (#716)

### DIFF
--- a/Packages/WhoopStore/Sources/WhoopStore/DeviceRegistryStore.swift
+++ b/Packages/WhoopStore/Sources/WhoopStore/DeviceRegistryStore.swift
@@ -54,6 +54,14 @@ public struct DeviceRegistryStore: Sendable {
         }
     }
 
+    /// Update the model label for an existing device (e.g. seeded "WHOOP" → "WHOOP 4.0" once the
+    /// strap's service family is known from a live BLE connect).
+    public func setModel(_ id: String, model: String) throws {
+        try dbQueue.write { db in
+            try db.execute(sql: "UPDATE pairedDevice SET model = ? WHERE id = ?", arguments: [model, id])
+        }
+    }
+
     /// Adopt (or clear) the stable BLE identity for a registry row. `peripheralId` is the
     /// CBPeripheral.identifier.uuidString on iOS/Mac; passing nil un-adopts it.
     public func setPeripheralId(_ id: String, peripheralId: String?) throws {

--- a/Strand/BLE/BLEManager.swift
+++ b/Strand/BLE/BLEManager.swift
@@ -475,6 +475,8 @@ public final class BLEManager: NSObject, ObservableObject {
     private var collector: Collector?
     /// #716: stored on bootstrap so the scan callback can fix the seeded "WHOOP" model label.
     private var registryStore: DeviceRegistryStore?
+    /// #716: true once the seeded "WHOOP" model has been stamped to the correct family.
+    private var modelStamped = false
 
     // MARK: Upload / server sync — REMOVED for Strand (standalone, fully on-device).
 
@@ -3185,11 +3187,12 @@ extension BLEManager: @preconcurrency CBCentralManagerDelegate {
         // #716: the seeded "my-whoop" device has model "WHOOP" (no generation). Once a live scan
         // confirms which service family the strap advertises, stamp the correct model so
         // forRegistryModel returns the right DeviceFamily (fixes skin-temp ADC scale + display).
-        if let rs = registryStore,
+        if !modelStamped, let rs = registryStore,
            let stale = try? rs.all().first(where: { $0.status == .active && $0.model == "WHOOP" }) {
             let correct = selectedModel == .whoop4 ? "WHOOP 4.0" : "WHOOP 5.0 / MG"
             try? rs.setModel(stale.id, model: correct)
             log("Updated device model from \"WHOOP\" to \"\(correct)\" (#716)")
+            modelStamped = true
         }
         let advertisedServiceUUIDs = (advertisementData[CBAdvertisementDataServiceUUIDsKey] as? [CBUUID] ?? [])
             .map { $0.uuidString.lowercased() }

--- a/Strand/BLE/BLEManager.swift
+++ b/Strand/BLE/BLEManager.swift
@@ -473,6 +473,8 @@ public final class BLEManager: NSObject, ObservableObject {
     public let state: LiveState
     private let router: FrameRouter
     private var collector: Collector?
+    /// #716: stored on bootstrap so the scan callback can fix the seeded "WHOOP" model label.
+    private var registryStore: DeviceRegistryStore?
 
     // MARK: Upload / server sync — REMOVED for Strand (standalone, fully on-device).
 
@@ -885,7 +887,9 @@ public final class BLEManager: NSObject, ObservableObject {
         // Guarded + best-effort: if the registry is empty/unreadable, deviceId stays as it was, so no
         // crash and no behaviour change. registryWriter is nonisolated/Sendable (the Pool manages
         // its own concurrency).
-        if let activeId = try? DeviceRegistryStore(dbQueue: store.registryWriter).activeDeviceId(),
+        let registry = DeviceRegistryStore(dbQueue: store.registryWriter)
+        self.registryStore = registry
+        if let activeId = try? registry.activeDeviceId(),
            !activeId.isEmpty {
             self.deviceId = activeId
         }
@@ -3178,6 +3182,15 @@ extension BLEManager: @preconcurrency CBCentralManagerDelegate {
                                advertisementData: [String: Any],
                                rssi RSSI: NSNumber) {
         let name = (advertisementData[CBAdvertisementDataLocalNameKey] as? String) ?? peripheral.name ?? "unknown"
+        // #716: the seeded "my-whoop" device has model "WHOOP" (no generation). Once a live scan
+        // confirms which service family the strap advertises, stamp the correct model so
+        // forRegistryModel returns the right DeviceFamily (fixes skin-temp ADC scale + display).
+        if let rs = registryStore,
+           let stale = try? rs.all().first(where: { $0.status == .active && $0.model == "WHOOP" }) {
+            let correct = selectedModel == .whoop4 ? "WHOOP 4.0" : "WHOOP 5.0 / MG"
+            try? rs.setModel(stale.id, model: correct)
+            log("Updated device model from \"WHOOP\" to \"\(correct)\" (#716)")
+        }
         let advertisedServiceUUIDs = (advertisementData[CBAdvertisementDataServiceUUIDsKey] as? [CBUUID] ?? [])
             .map { $0.uuidString.lowercased() }
         let scanDecision = whoopGattScanDecision(

--- a/Strand/Data/DeviceRegistry.swift
+++ b/Strand/Data/DeviceRegistry.swift
@@ -102,4 +102,10 @@ final class DeviceRegistry: ObservableObject {
     func device(forPeripheralId peripheralId: String) -> PairedDevice? {
         (try? store.device(forPeripheralId: peripheralId)) ?? nil
     }
+
+    /// Update the model label for a device and refresh the published list. Best-effort.
+    func setModel(_ id: String, model: String) {
+        try? store.setModel(id, model: model)
+        reload()
+    }
 }

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -1684,6 +1684,8 @@ class WhoopBleClient(
     /// The strap family the user chose to pair, remembered so an auto-reconnect after a
     /// dropout re-scans for the same model instead of falling back to WHOOP 4.0.
     private var selectedModel = WhoopModel.WHOOP4
+    /** #716: true once the seeded "WHOOP" model has been stamped to the correct family. */
+    private var modelStamped = false
     /// The last device we connected to, kept so an auto-reconnect after a dropout can connect
     /// DIRECTLY to it (autoConnect=true) instead of scanning. A bonded strap the OS still holds (or
     /// that simply isn't advertising) won't appear in a scan — so the old scan-only reconnect looped
@@ -3259,6 +3261,22 @@ class WhoopBleClient(
         override fun onScanResult(callbackType: Int, result: ScanResult) {
             val device: BluetoothDevice = result.device
             val name = result.scanRecord?.deviceName ?: device.name ?: "unknown"
+            // #716: the seeded "my-whoop" device has model "WHOOP" (no generation). Once a live
+            // scan confirms which service family the strap advertises, stamp the correct model so
+            // forRegistryModel returns the right DeviceFamily (fixes skin-temp ADC scale + display).
+            if (!modelStamped) {
+                ioScope.launch {
+                    val stale = repository.pairedDevices().firstOrNull {
+                        it.status == "active" && it.model == "WHOOP"
+                    }
+                    if (stale != null) {
+                        val correct = if (selectedModel == WhoopModel.WHOOP4) "WHOOP 4.0" else "WHOOP 5.0 / MG"
+                        repository.setDeviceModel(stale.id, correct)
+                        log("Updated device model from \"WHOOP\" to \"$correct\" (#716)")
+                    }
+                    modelStamped = true
+                }
+            }
             val advertisedServiceUuids = result.scanRecord?.serviceUuids
                 ?.map { it.uuid.toString().lowercase() }
                 .orEmpty()

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -3265,6 +3265,7 @@ class WhoopBleClient(
             // scan confirms which service family the strap advertises, stamp the correct model so
             // forRegistryModel returns the right DeviceFamily (fixes skin-temp ADC scale + display).
             if (!modelStamped) {
+                modelStamped = true
                 ioScope.launch {
                     val stale = repository.pairedDevices().firstOrNull {
                         it.status == "active" && it.model == "WHOOP"
@@ -3274,7 +3275,6 @@ class WhoopBleClient(
                         repository.setDeviceModel(stale.id, correct)
                         log("Updated device model from \"WHOOP\" to \"$correct\" (#716)")
                     }
-                    modelStamped = true
                 }
             }
             val advertisedServiceUuids = result.scanRecord?.serviceUuids

--- a/android/app/src/main/java/com/noop/data/DeviceRegistry.kt
+++ b/android/app/src/main/java/com/noop/data/DeviceRegistry.kt
@@ -56,6 +56,9 @@ class DeviceRegistry(
     /** Archive a device — keeps its row and samples (invariant I4). */
     suspend fun archive(id: String) = dao.archiveDevice(id)
 
+    /** Update the model label for a device. Mirrors the Swift store's `setModel`. */
+    suspend fun setModel(id: String, model: String) = dao.setModel(id, model)
+
     /** Persist (or clear) a device's stable BLE peripheral identifier (the MAC address on Android). Lets
      *  the seeded "my-whoop" adopt its strap's address on first connect and a specific WHOOP confirm its
      *  identity. Façade over [DeviceRegistryDao.setPeripheralId]; mirrors the Swift store. */

--- a/android/app/src/main/java/com/noop/data/DeviceRegistryDao.kt
+++ b/android/app/src/main/java/com/noop/data/DeviceRegistryDao.kt
@@ -43,6 +43,11 @@ interface DeviceRegistryDao {
     @Query("UPDATE pairedDevice SET nickname = :nickname WHERE id = :id")
     suspend fun renameDevice(id: String, nickname: String?)
 
+    /** Update the model label for an existing device (e.g. seeded "WHOOP" → "WHOOP 4.0" once the
+     *  strap's service family is known from a live BLE connect). Twin of the Swift store's `setModel`. */
+    @Query("UPDATE pairedDevice SET model = :model WHERE id = :id")
+    suspend fun setModel(id: String, model: String)
+
     /** Persist (or clear) a device's stable BLE peripheral identifier (the MAC address on Android). Lets
      *  the seeded "my-whoop" adopt its strap's address on first connect and a specific WHOOP confirm its
      *  identity. Twin of the Swift store's `setPeripheralId`. */

--- a/android/app/src/main/java/com/noop/data/WhoopRepository.kt
+++ b/android/app/src/main/java/com/noop/data/WhoopRepository.kt
@@ -211,6 +211,12 @@ class WhoopRepository(private val dao: WhoopDao) {
         )
     }
 
+    /** #716: update the model label for the seeded device once the BLE family is known. */
+    suspend fun setDeviceModel(id: String, model: String) = dao.setModel(id, model)
+
+    /** #716: read all paired devices (thin pass-through for the BLE scan fix). */
+    suspend fun pairedDevices(): List<PairedDeviceRow> = dao.pairedDevices()
+
     // MARK: - Insert decoded streams (idempotent by natural key)
 
     /**


### PR DESCRIPTION
## Summary

Closes #716.

- The DB migration seeds the default `my-whoop` device with `model = "WHOOP"` (no generation suffix).
- `DeviceFamily.forRegistryModel("WHOOP")` returns `.whoop5`, so a WHOOP 4.0 user gets the wrong skin-temp ADC conversion scale (values silently discarded) and the Devices screen falls through to the "Exact model unknown" capability profile.
- On first BLE scan callback, if the active device still has the bare `"WHOOP"` model, stamp it to `"WHOOP 4.0"` or `"WHOOP 5.0 / MG"` based on the selected scan family. One-time fix; the corrected model persists.

## Changes

- `DeviceRegistryStore.setModel(_:model:)` — new store method to update a device's model label
- `DeviceRegistry.setModel(_:model:)` — app-layer wrapper that refreshes the published device list
- `BLEManager.didDiscover` — on scan, if the active device has model `"WHOOP"`, update it to the correct family

## Test plan

- [ ] `swift test --package-path Packages/WhoopStore` — existing 269 tests pass
- [ ] Fresh install with WHOOP 4.0: Devices screen shows "WHOOP 4.0", not "Exact model unknown"
- [ ] Skin temp deviation appears after enough nightly data accumulates (correct ADC scale now applied)
- [ ] Existing installs with model already set to "WHOOP 4.0" or "5.0 MG" are unaffected (guard checks `== "WHOOP"`)