### PR TITLE
Log why a day is skipped when HR samples are insufficient (#714)

### DIFF
--- a/Strand/Data/IntelligenceEngine.swift
+++ b/Strand/Data/IntelligenceEngine.swift
@@ -540,7 +540,10 @@ final class IntelligenceEngine: ObservableObject {
                                                        registry: registry, fallbackDeviceId: ownerFallbackId)
 
                 let hr = (try? await store.hrSamples(deviceId: owner, from: from, to: to, limit: 200_000)) ?? []
-                guard hr.count >= 200 else { continue }   // need real raw data, not a stray sample
+                guard hr.count >= 200 else {
+                    diag("sleep day=\(day) SKIPPED hrSamples=\(hr.count) (need ≥200)")
+                    continue
+                }
                 let rr = (try? await store.rrIntervals(deviceId: owner, from: from, to: to, limit: 200_000)) ?? []
                 let resp = (try? await store.respSamples(deviceId: owner, from: from, to: to, limit: 200_000)) ?? []
                 let grav = (try? await store.gravitySamples(deviceId: owner, from: from, to: to, limit: 200_000)) ?? []

--- a/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
+++ b/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
@@ -463,7 +463,10 @@ object IntelligenceEngine {
             // scored-days loop, NOT here). Only when the universal sink is on. A day skipped below for too
             // few rows is never scored, so it emits no line, byte-identical to the iOS behaviour.
             if (universalSink != null) readOwnerByDay[day] = OwnerRead(owner, hr.size)
-            if (hr.size < MIN_HR_SAMPLES) continue // need real raw data, not a stray sample
+            if (hr.size < MIN_HR_SAMPLES) {
+                diag("sleep day=$day SKIPPED hrSamples=${hr.size} (need ≥$MIN_HR_SAMPLES)")
+                continue
+            }
             val rr = repo.rrIntervals(owner, from, to, STREAM_LIMIT)
             val resp = repo.respSamples(owner, from, to, STREAM_LIMIT)
             val grav = repo.gravitySamples(owner, from, to, STREAM_LIMIT)


### PR DESCRIPTION
## Summary

When the analytics pass skips a day for having fewer than 200 HR samples, the strap log currently shows `sleep day=… totalSleepMin=nil matched=0` with no indication of *why* — indistinguishable from "stager ran and found no sleep." This adds one diagnostic line per skipped day on both platforms:

```
sleep day=2026-07-20 SKIPPED hrSamples=0 (need ≥200)
```

Makes every "no sleep detected" report (#714) self-diagnosing from the export alone — no back-and-forth needed to determine "no data" vs "data but no sleep found."

## Changes

- `IntelligenceEngine.kt`: `diag()` line before the `continue` in the HR-gate skip
- `IntelligenceEngine.swift`: matching `diag()` line in the `guard` else branch

## Test plan

- [x] `./gradlew compileFullDebugKotlin` — compiles
- [x] No test changes needed — this is a log-only addition with no behavior change
- [x] Cross-platform parity: identical log format on both platforms