### PR TITLE
Allow configuring DEVELOPMENT_TEAM via BundleIdSecrets.xcconfig

### DIFF
--- a/Config/BundleId.xcconfig
+++ b/Config/BundleId.xcconfig
@@ -11,4 +11,8 @@
 // Apple ID / device so this build's bundle id, App Group, and watch companion pairing don't
 // collide with an installed copy of the official com.noopapp build.
 BUNDLE_ID_PREFIX = com.noopapp
+// Empty by default: CODE_SIGN_STYLE is Automatic and macOS ad-hoc builds (see docs/BUILD.md) need
+// no team at all. Set DEVELOPMENT_TEAM in BundleIdSecrets.xcconfig to run on a physical iPhone or
+// to stop Xcode from asking you to reselect a team after every `xcodegen generate`.
+DEVELOPMENT_TEAM =
 #include? "BundleIdSecrets.xcconfig"

--- a/Config/BundleIdSecrets.example.xcconfig
+++ b/Config/BundleIdSecrets.example.xcconfig
@@ -3,3 +3,8 @@
 // the App Group id and watch companion pairing both key off BUNDLE_ID_PREFIX (see
 // Config/BundleId.xcconfig), not just PRODUCT_BUNDLE_IDENTIFIER.
 BUNDLE_ID_PREFIX = com.yourdomain
+
+// Optional: set your Apple Developer Team ID here to avoid re-selecting a team in Xcode after every
+// `xcodegen generate` (needed to run on a physical iPhone; macOS ad-hoc builds work with no team).
+// Find your Team ID at https://developer.apple.com/account under Membership details.
+// DEVELOPMENT_TEAM = ABCDE12345

--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -132,10 +132,10 @@ The app is **sandboxed** and requests Bluetooth + user-selected-file access. Fro
 <key>com.apple.security.files.user-selected.read-write</key> <true/>
 ```
 
-`project.yml` deliberately keeps `DEVELOPMENT_TEAM` empty, `ENABLE_HARDENED_RUNTIME: NO`, and uses
-**ad-hoc signing** — no Apple Developer account is required to run a personal build. To produce the
-runnable bundle, build without disabling signing so Xcode applies the sandbox + Bluetooth
-entitlements with an ad-hoc identity:
+`project.yml` deliberately leaves `DEVELOPMENT_TEAM` empty by default (see `Config/BundleId.xcconfig`),
+keeps `ENABLE_HARDENED_RUNTIME: NO`, and uses **ad-hoc signing** — no Apple Developer account is
+required to run a personal build. To produce the runnable bundle, build without disabling signing so
+Xcode applies the sandbox + Bluetooth entitlements with an ad-hoc identity:
 
 ```bash
 xcodebuild \
@@ -255,7 +255,9 @@ Notes:
 - The `NOOPiOS` and `NOOPiOSWidgets` targets deploy to **iOS 17.0**. (The shared packages still
   declare a floor of iOS 16 — `.iOS(.v16)` — but the app targets require iOS 17.)
 - Running on a physical iPhone needs a signing identity selected in Xcode (a free personal Apple ID
-  works for on-device builds). **BLE requires a real device** — the iOS simulator can't reach a
+  works for on-device builds). Set `DEVELOPMENT_TEAM` in `Config/BundleIdSecrets.xcconfig` (see
+  `Config/BundleIdSecrets.example.xcconfig`) to avoid re-selecting a team in Xcode after every
+  `xcodegen generate`. **BLE requires a real device** — the iOS simulator can't reach a
   physical strap.
 - The iOS app reuses `BLEManager` (CoreBluetooth is identical API on iOS) and the shared analytics,
   store, import, and design packages. `StrandDesign` already bridges `NSColor`/`UIColor` behind

--- a/project.yml
+++ b/project.yml
@@ -27,7 +27,6 @@ settings:
     # String Catalog on build (the English (US) base entries).
     SWIFT_EMIT_LOC_STRINGS: YES
     SWIFT_STRICT_CONCURRENCY: minimal
-    DEVELOPMENT_TEAM: ""
     CODE_SIGN_STYLE: Automatic
     # Single source of truth for the App Group id shared by the iOS app + its widget / Live Activity
     # extension. Referenced as $(APP_GROUP_ID) by both targets' entitlements and Info.plist, and read


### PR DESCRIPTION
## Summary
- Selecting a Development Team in Xcode's UI writes `DEVELOPMENT_TEAM` directly into the generated (gitignored) `project.pbxproj`, which `xcodegen generate` silently resets on the next run.
- Moves `DEVELOPMENT_TEAM` onto the same xcconfig chain `BUNDLE_ID_PREFIX` already uses (`Config/BundleId.xcconfig` tracked default, optionally overridden in the gitignored `Config/BundleIdSecrets.xcconfig`), so a team survives regeneration.
- Default behavior is unchanged: no team set anywhere still resolves to empty, matching today's ad-hoc macOS build path (verified via `xcodebuild -showBuildSettings`, no `DEVELOPMENT_TEAM` override lands in `project.pbxproj`).
- Documents the new option in `docs/BUILD.md` near the existing iOS on-device signing note.

## Test plan
- [x] `xcodegen generate` regenerates cleanly
- [x] `xcodebuild -showBuildSettings` confirms `DEVELOPMENT_TEAM` resolves correctly from `BundleIdSecrets.xcconfig` for both `NOOPiOS` and `Strand` targets
- [x] Confirmed `project.pbxproj` carries no hardcoded `DEVELOPMENT_TEAM` override (falls through to xcconfig)
- [ ] Manual: set a real team in `BundleIdSecrets.xcconfig`, open `Strand.xcodeproj`, confirm Signing & Capabilities shows it selected and a re-`xcodegen generate` doesn't reset it

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EhAkbjfHQ6Ja1N6L1DBRbY