### PR TITLE
Fix iOS build break introduced in #720 (missing diag call)

### DIFF
--- a/Strand/Data/IntelligenceEngine.swift
+++ b/Strand/Data/IntelligenceEngine.swift
@@ -509,8 +509,12 @@ final class IntelligenceEngine: ObservableObject {
         // the 5/MG cumulative @57 series + wrap-aware deltas + dropped deltas, replayed below tagged `.steps`.
         // The trace recomputes the SAME wrap-aware sum analyzeDay already did, so the steps total is unchanged.
         let stepsTraceActive = TestCentre.active(.steps)
-        let scanned: [DayScan] = await Task.detached(priority: .utility) {
+        let (scanned, skippedDayLines): ([DayScan], [String]) = await Task.detached(priority: .utility) {
             var out: [DayScan] = []
+            // Days skipped below (too few HR samples) never get a DayScan, so this diagnostic can't ride
+            // along on one; carried out alongside `out` and replayed through `diagnosticSink` on the main
+            // actor below, same as `rhrLine`/the trace arrays. Mirrors the Kotlin `diag` sink.
+            var skippedDayLines: [String] = []
             // #938: the WHOOP 4.0 ADC offset is per-device, not per-night. Learn one anchor per owner
             // from the whole scan window and reuse it for every night so cross-night deviations survive.
             let skinAnchorScanFrom = nowLocalMidnight - (maxDays - 1) * 86_400 - 30 * 3_600
@@ -541,7 +545,7 @@ final class IntelligenceEngine: ObservableObject {
 
                 let hr = (try? await store.hrSamples(deviceId: owner, from: from, to: to, limit: 200_000)) ?? []
                 guard hr.count >= 200 else {
-                    diag("sleep day=\(day) SKIPPED hrSamples=\(hr.count) (need ≥200)")
+                    skippedDayLines.append("sleep day=\(day) SKIPPED hrSamples=\(hr.count) (need ≥200)")
                     continue
                 }
                 let rr = (try? await store.rrIntervals(deviceId: owner, from: from, to: to, limit: 200_000)) ?? []
@@ -776,8 +780,12 @@ final class IntelligenceEngine: ObservableObject {
                                    sleepTrace: sleepTrace, stepsTrace: stepsTrace, hrvTrace: hrvTrace,
                                    hrvDiag: hrvDiag))
             }
-            return out
+            return (out, skippedDayLines)
         }.value
+
+        // #714: replay each skipped day's diagnostic now that we're back on the main actor (diagnosticSink
+        // is MainActor-bound). Always-on , not gated behind a test mode, mirroring the Kotlin `diag` sink.
+        for line in skippedDayLines { diagnosticSink?(line, nil) }
 
         // CAPTURE-B (#814/#799): per-day resolved READ owner + that owner's HR-row count, keyed by day, so
         // the second pass (which has the provenance sets) can emit the universal `dayOwner …` line. The


### PR DESCRIPTION
## Summary
- #720 (`135c724c`, #714) added a `diag("sleep day=… SKIPPED …")` call in `IntelligenceEngine.swift` to mirror the Kotlin per-day diagnostic sink, but Swift has no `diag` function — the call didn't compile, breaking the `NOOPiOS` (and `Strand` macOS) app targets.
- This shipped clean because `app-build.yml` (the only workflow that compiles the app targets) is disabled by default — `swift-packages.yml` only covers `Packages/**`, so no default CI check caught it.
- Swift's equivalent of Kotlin's `diag` is the MainActor-isolated `diagnosticSink`, which can't be called directly from the `Task.detached` scan loop this line lives in. Fixed by collecting the skipped-day lines alongside the loop's other per-day diagnostics (`rhrLine`, `sleepTrace`, `hrvTrace`, `stepsTrace`) and replaying them through `diagnosticSink` back on the main actor, always-on (untagged), matching the Kotlin `diag` sink's behavior.

## Test plan
- [x] `xcodegen generate && xcodebuild -project Strand.xcodeproj -scheme NOOPiOS -destination 'generic/platform=iOS' CODE_SIGNING_ALLOWED=NO build` — succeeds
- [x] `xcodebuild -project Strand.xcodeproj -scheme Strand -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO build` — succeeds (shared file)
- [x] `cd android && ./gradlew compileFullDebugKotlin` — succeeds (Kotlin side of #720 was already valid, untouched here)

https://claude.ai/code/session_01JromGj5eBnU4Lxx7UfNsY5