### PR TITLE
Android: unblock testFullDebugUnitTest — implement DeviceRegistryDao.setModel in the three fake DAOs

### DIFF
--- a/android/app/src/test/java/com/noop/analytics/RegistryDayOwnerSourceTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/RegistryDayOwnerSourceTest.kt
@@ -41,6 +41,9 @@ class RegistryDayOwnerSourceTest {
             devices[id]?.let { devices[id] = it.copy(status = DeviceStatus.archived.name) }
         }
         override suspend fun renameDevice(id: String, nickname: String?) {}
+        override suspend fun setModel(id: String, model: String) {
+            devices[id]?.let { devices[id] = it.copy(model = model) }
+        }
         override suspend fun setPeripheralId(id: String, peripheralId: String?) {
             devices[id]?.let { devices[id] = it.copy(peripheralId = peripheralId) }
         }

--- a/android/app/src/test/java/com/noop/ble/SourceCoordinatorAdoptionTest.kt
+++ b/android/app/src/test/java/com/noop/ble/SourceCoordinatorAdoptionTest.kt
@@ -53,6 +53,9 @@ class SourceCoordinatorAdoptionTest {
         override suspend fun renameDevice(id: String, nickname: String?) {
             devices[id]?.let { devices[id] = it.copy(nickname = nickname) }
         }
+        override suspend fun setModel(id: String, model: String) {
+            devices[id]?.let { devices[id] = it.copy(model = model) }
+        }
         override suspend fun setPeripheralId(id: String, peripheralId: String?) {
             devices[id]?.let { devices[id] = it.copy(peripheralId = peripheralId) }
         }

--- a/android/app/src/test/java/com/noop/data/DeviceRegistryTest.kt
+++ b/android/app/src/test/java/com/noop/data/DeviceRegistryTest.kt
@@ -57,6 +57,9 @@ class DeviceRegistryTest {
             devices[id]?.let { devices[id] = it.copy(nickname = nickname) }
         }
 
+        override suspend fun setModel(id: String, model: String) {
+            devices[id]?.let { devices[id] = it.copy(model = model) }
+        }
         override suspend fun setPeripheralId(id: String, peripheralId: String?) {
             devices[id]?.let { devices[id] = it.copy(peripheralId = peripheralId) }
         }


### PR DESCRIPTION
 ## Problem
  The Android **Full**-flavor unit test source set does not compile on `main`, so **every** `com.noop.*` JVM unit test is blocked (Android's unit-test CI job is red).

  PR #716 added a method to the `DeviceRegistryDao` interface — and updated the production Room DAO + Swift twin — but not the three hand-written test doubles that implement the interface:

  ```kotlin
  // DeviceRegistryDao.kt (#716)
  @Query("UPDATE pairedDevice SET model = :model WHERE id = :id")  suspend fun setModel(id: String, model: String)

  Each fake is now a non-abstract class missing an abstract member. Because Gradle compiles the whole test source set as one unit, this fails compilation for the entire suite — not just these three files.

  Fix

  Add the setModel override to each fake, backed by the same in-memory devices map they already use for setPeripheralId. It's a real implementation (copy(model = model)), so the fake mirrors Room's UPDATE pairedDevice SET model rather than silently
  no-op'ing:

  - app/src/test/java/com/noop/analytics/RegistryDayOwnerSourceTest.kt — FakeDao
  - app/src/test/java/com/noop/ble/SourceCoordinatorAdoptionTest.kt — FakeRegistryDao
  - app/src/test/java/com/noop/data/DeviceRegistryTest.kt — FakeRegistryDao

  Test-only; no production code changes.

  Verification

  ./gradlew testFullDebugUnitTest \
    --tests com.noop.data.DeviceRegistryTest \
    --tests com.noop.analytics.RegistryDayOwnerSourceTest \
    --tests com.noop.ble.SourceCoordinatorAdoptionTest
  → BUILD SUCCESSFUL   (was: test-source compile failure)
 Compilation succeeding here proves the whole Full-flavor suite compiles again; the three affected classes also pass.

  Scope

  Single concern, three files, test-only. Follow-up to #716.