### PR TITLE
Oura: persist the ring's SleepNet hypnogram as a stage-timeline sleep session, shown honestly as "Oura"

### DIFF
--- a/Packages/OuraProtocol/Sources/OuraProtocol/Commands.swift
+++ b/Packages/OuraProtocol/Sources/OuraProtocol/Commands.swift
@@ -57,15 +57,19 @@ public enum OuraCommands {
 
     // MARK: - Time sync
 
-    /// SyncTime: `12 09 <token:1> <counter:3 LE> 00 00 00 00 f6` where counter = floor(unix_s / 256)
-    /// and the trailer 0xf6 is fixed. Per OURA_PROTOCOL.md s5.4. `token` defaults to 0.
-    public static func syncTime(unixSeconds: Int, token: UInt8 = 0x00) -> OuraCommand {
-        let counter = unixSeconds / 256
-        let c0 = UInt8(counter & 0xFF)
-        let c1 = UInt8((counter >> 8) & 0xFF)
-        let c2 = UInt8((counter >> 16) & 0xFF)
-        return OuraCommand(label: "sync_time",
-                           bytes: [0x12, 0x09, token, c0, c1, c2, 0x00, 0x00, 0x00, 0x00, 0xF6])
+    /// SyncTime (`0x12`): hand the ring the current wall-clock so it can emit a usable `0x42` UTC anchor
+    /// (§5.5). Layout `12 09 <unix_secs: u64 LE (8 B)> <tz: i8 half-hours>` — unix **seconds**, 8-byte
+    /// little-endian, one signed timezone byte in 30-minute units. Matches the authoritative open_oura
+    /// `req_sync_time(secs, 0)` ([oura-proto]/[oura-link], OURA_PROTOCOL.md §5.4/§9.2). Supersedes an
+    /// earlier reverse-engineered guess (`token` + `unix_s/256` in 3 bytes + `0xF6` trailer) that did NOT
+    /// match the native client. `tzHalfHours` defaults to 0 (UTC), exactly as the reference client sends;
+    /// NOOP does its own LOCAL-day bucketing downstream regardless of what the ring is told here.
+    /// On-device proven (2026-07-08..10): sending this on connect makes the ring emit the 0x42 anchor.
+    public static func syncTime(unixSeconds: Int, tzHalfHours: Int8 = 0) -> OuraCommand {
+        let secs = UInt64(bitPattern: Int64(unixSeconds))
+        var body: [UInt8] = (0..<8).map { UInt8((secs >> (UInt64($0) * 8)) & 0xFF) }   // u64 seconds, LE
+        body.append(UInt8(bitPattern: tzHalfHours))                                    // i8 tz (30-min units)
+        return OuraCommand(label: "sync_time", bytes: [0x12, UInt8(body.count)] + body)
     }
 
     // MARK: - Event fetch (cursor)

--- a/Packages/OuraProtocol/Sources/OuraProtocol/Decoders.swift
+++ b/Packages/OuraProtocol/Sources/OuraProtocol/Decoders.swift
@@ -90,6 +90,45 @@ public enum OuraDecoders {
         return out.isEmpty ? nil : out
     }
 
+    // MARK: - Green IBI + amplitude CANDIDATE decode (0x71; s6.2, upstream #287)
+
+    /// CANDIDATE decode of the 0x71 green_ibi_and_amp_event, ported verbatim from ringverse's
+    /// `p_green_ibi_and_amp` (parse.js, firmware @0x503960): 5 densely bit-packed 11-bit IBIs +
+    /// amplitudes (7-bit mantissa << shift), first entry amplitude-only (`ibiMs == 0`), timestamps
+    /// walking backward from the event time by each IBI in turn (caller's job — entries are returned
+    /// in that walk order). `shift` comes from payload[13] bits [2:0] (`s == 7 → 0`, else `s+1`);
+    /// bit [3] set means a firmware-layout mismatch → nil (never guess).
+    ///
+    /// TIER-B (#287): this layout has NO verified NOOP capture yet — the result is for the 0x71
+    /// fixture-capture log ONLY (side-by-side with the raw bytes, cross-checked against concurrent
+    /// live-HR R-R), never a stored rrInterval. Promote only after a real capture validates it.
+    /// Payload indexing: ringverse's `b[i]` spans the whole frame (type/len/rt4/body); our `payload`
+    /// starts at spec offset 6, so `b[i] == payload[i-6]`. Strict 14-byte gate (= wire len 18).
+    public static func decodeGreenIBIAmpCandidate(payload p: [UInt8], ringTimestamp: UInt32)
+        -> (shift: Int, samples: [OuraIBI])? {
+        guard p.count == 14 else { return nil }
+        let b13 = Int(p[13])
+        guard (b13 >> 3) & 1 == 0 else { return nil }   // reserved bit set → firmware mismatch
+        let s = b13 & 7
+        let shift = (s == 7) ? 0 : s + 1
+        let b12 = Int(p[12])
+        // Each 11-bit IBI: 1 low bit (an amplitude byte's LSB) | 8 mid bits (a full byte << 3)
+        // | 2 bits [2:1] from the pack bytes. Ordering per the firmware's scrambled layout.
+        let ds = [
+            (Int(p[10]) & 1) | (Int(p[4]) << 3) | ((b13 >> 5) & 6),
+            (Int(p[9]) & 1) | (Int(p[3]) << 3) | ((b12 & 3) << 1),
+            (Int(p[8]) & 1) | (Int(p[2]) << 3) | ((b12 >> 1) & 6),
+            (Int(p[7]) & 1) | (Int(p[1]) << 3) | ((b12 >> 3) & 6),
+            (Int(p[6]) & 1) | (Int(p[0]) << 3) | ((b12 >> 5) & 6),
+        ]
+        let amps = (6...10).map { (Int(p[$0]) >> 1) << shift }
+        var samples = [OuraIBI(ringTimestamp: ringTimestamp, ibiMs: 0, amplitude: amps[0])]
+        for i in 0..<5 {
+            samples.append(OuraIBI(ringTimestamp: ringTimestamp, ibiMs: ds[i], amplitude: amps[i]))
+        }
+        return (shift, samples)
+    }
+
     // MARK: - Green IBI quality, 2 bytes/sample (0x80; s6.4)
 
     /// Decode the 0x80 green_ibi_quality_event: per 2-byte sample `ibi_ms = (b1 & 7) | (b0 << 3)`
@@ -358,8 +397,9 @@ public enum OuraDecoders {
     // MARK: - Sleep phase, 2-bit codes (0x4E / 0x5A; s6.12)
 
     /// Decode the 0x4E/0x5A sleep_phase_details: byte6 = header; phase codes are 2-bit, 4 per byte
-    /// (bits [7:6][5:4][3:2][1:0]); codes 0=awake,1=light,2=deep,3=REM. Per OURA_PROTOCOL.md s6.12.
-    /// Returns nil on a short body. The header byte is skipped; phase bytes follow.
+    /// (bits [7:6][5:4][3:2][1:0]); codes 0=deep, 1=light, 2=rem, 3=awake per open_oura's VALIDATED
+    /// `decode_sleep_phases` mapping (see OuraSleepStage). Returns nil on a short body. The header
+    /// byte is skipped; phase bytes follow.
     public static func decodeSleepPhase(_ rec: OuraRecord) -> [OuraSleepPhase]? {
         let b = rec.payload
         // body[0] is the header (spec offset 6); phase codes begin at body[1].

--- a/Packages/OuraProtocol/Sources/OuraProtocol/Framing.swift
+++ b/Packages/OuraProtocol/Sources/OuraProtocol/Framing.swift
@@ -47,6 +47,25 @@ public enum OuraFraming {
     /// caller fails to special-case it.
     public static let batteryResponseOp: UInt8 = 0x0D
 
+    /// The SyncTime response outer opcode (OURA_PROTOCOL.md s5.4, [ringverse BLE.md]). Below the
+    /// event-tag range, so it round-trips safely through the TLV decoder as an "unknown tag" no-op if a
+    /// caller fails to special-case it.
+    public static let syncTimeResponseOp: UInt8 = 0x13
+
+    /// Parse a 0x13 SyncTime response body per ringverse BLE.md:
+    /// `current_device_timestamp:4 LE  status:1`. The device timestamp is the ring's own clock counter
+    /// AT THE MOMENT it processed our SyncTime — paired with the host wall-clock at receipt it forms a
+    /// deterministic ring-time→UTC anchor available at EVERY connect (the 0x42 time-sync record is only
+    /// logged when the ring actually adjusts its clock, so a session on an already-synced ring may never
+    /// see one — observed 2026-07-13: a whole night's drain with no anchor). ringverse labels the field
+    /// "seconds" but the tick unit is unconfirmed; the caller disambiguates against the persisted resume
+    /// cursor (OuraDriver.syncTimeAnchorCandidate). Returns nil on a short body.
+    public static func parseSyncTimeResponse(_ body: [UInt8]) -> (deviceTimestamp: UInt32, status: UInt8)? {
+        guard body.count >= 5 else { return nil }
+        let ts = UInt32(body[0]) | (UInt32(body[1]) << 8) | (UInt32(body[2]) << 16) | (UInt32(body[3]) << 24)
+        return (ts, body[4])
+    }
+
     /// Parse a 0x11 GetEvents response body per open_oura's `EventBatchSummary`:
     /// `events_received:1  sleep_analysis_progress:1  bytes_left:4LE  [pad:2]`. The drain loop runs
     /// until `bytes_left == 0`; there is NO resume cursor in this packet — the resume position is a

--- a/Packages/OuraProtocol/Sources/OuraProtocol/HypnogramAssembler.swift
+++ b/Packages/OuraProtocol/Sources/OuraProtocol/HypnogramAssembler.swift
@@ -1,0 +1,128 @@
+import Foundation
+
+// HypnogramAssembler: reconstruct the TIME AXIS of the ring's sleep-phase hypnogram.
+//
+// THE PROBLEM (observed on-device 2026-07-12, Gen3): the ring's SleepNet finalizes a night's staging
+// AFTER wake and writes the whole hypnogram to its event log in ONE BURST — e.g. 23 records x 52 codes,
+// all sharing essentially the same envelope ring-time (~09:30, the WRITE moment). The envelope
+// timestamp therefore marks WHEN THE ANALYSIS WAS SAVED, not when the sleep happened; anchoring each
+// record at its envelope collapses an entire night onto a few seconds.
+//
+// THE RECONSTRUCTION: the burst's codes are one contiguous sequence at 30 s/code, ENDING at the burst's
+// envelope time. Laying N codes backward from the anchored burst end recovers the real window. The
+// 30 s epoch is triple-confirmed: open_oura's sleepnet.md ("DEEP/LIGHT/REM/WAKE classification at
+// 30-second intervals"), the observed window math (1,196 codes over a ~23:35-09:00 night), and the
+// 0x49 summary's 600-minute window over those same 1,196 codes (~30.1 s/code).
+//
+// Platform-pure, value types + one small accumulator class; no CoreBluetooth, no clock (the caller
+// resolves the anchored end time). Builds and tests on Linux.
+
+/// One completed burst of consecutive sleep-phase records (usually a whole night's hypnogram).
+public struct OuraHypnogramBurst: Equatable, Sendable {
+    /// The records in arrival (= log) order, each with its envelope ring-time and decoded codes.
+    public let records: [OuraHypnogramRecord]
+
+    public init(records: [OuraHypnogramRecord]) {
+        self.records = records
+    }
+
+    /// Total 2-bit codes across the burst.
+    public var totalCodes: Int { records.reduce(0) { $0 + $1.phases.count } }
+
+    /// The burst's LAST envelope ring-time — the write/finalization moment the reconstruction anchors
+    /// its END to, and the resume-cursor note for the whole burst.
+    public var lastRingTimestamp: UInt32 { records.last?.ringTimestamp ?? 0 }
+
+    /// True when any record's envelope ring-time is LOWER than its predecessor's within this burst —
+    /// the one signal that the arrival order (which the layout trusts as the sequence ground truth)
+    /// might not be chronological. Surfaced so the caller can LOG it rather than fail silently;
+    /// re-sorting is deliberately not done (envelope ring-times of a burst are near-identical write
+    /// moments, so a sort on them could scramble the true code sequence).
+    public var hasNonMonotonicRingTimes: Bool {
+        zip(records, records.dropFirst()).contains { $1.ringTimestamp < $0.ringTimestamp }
+    }
+
+    /// Lay the burst's codes out backward from `endUnixSeconds` at `secondsPerCode`. Code j of N gets
+    /// `ts = end - (N - j) * secondsPerCode` — i.e. each ts marks the START of that code's interval and
+    /// the final code's interval ends exactly at the burst end. Order: records in arrival order, codes
+    /// by their in-record index (the sequence is the ground truth; the spacing is the documented 30 s
+    /// SleepNet epoch). Arrival order is deliberately NOT re-sorted by envelope ring-time: the envelopes
+    /// mark the near-identical WRITE moments of a finalization burst, so they are useless as a sort key
+    /// (an unstable sort on near-equal keys could scramble the true sequence) — see
+    /// `hasNonMonotonicRingTimes` for the surfaced escape hatch.
+    public func codesWithTimes(endUnixSeconds: Int, secondsPerCode: Int = 30)
+        -> [(phase: OuraSleepPhase, ts: Int)] {
+        let n = totalCodes
+        var out: [(OuraSleepPhase, Int)] = []
+        out.reserveCapacity(n)
+        var j = 0
+        for record in records {
+            for phase in record.phases {
+                out.append((phase, endUnixSeconds - (n - j) * secondsPerCode))
+                j += 1
+            }
+        }
+        return out
+    }
+}
+
+/// One sleep-phase record as fed to the assembler: its envelope ring-time + decoded codes in order.
+public struct OuraHypnogramRecord: Equatable, Sendable {
+    public let ringTimestamp: UInt32
+    public let phases: [OuraSleepPhase]
+    public init(ringTimestamp: UInt32, phases: [OuraSleepPhase]) {
+        self.ringTimestamp = ringTimestamp
+        self.phases = phases
+    }
+}
+
+/// Accumulate consecutive sleep-phase records into bursts. Records whose envelope ring-times sit
+/// within `burstGapTicks` of the previous record belong to the same burst (a finalization write-out);
+/// a larger gap (a different night / a separate analysis pass) closes the burst and starts a new one.
+public final class OuraHypnogramAssembler {
+    /// Max envelope ring-time gap (ticks, 100 ms each) between records of ONE burst. Observed bursts
+    /// share rts within a few seconds; 600 ticks = 60 s is generous while still splitting nights
+    /// (separate finalizations are hours apart).
+    public let burstGapTicks: UInt32
+    private var current: [OuraHypnogramRecord] = []
+
+    public init(burstGapTicks: UInt32 = 600) {
+        self.burstGapTicks = burstGapTicks
+    }
+
+    /// Feed one record. Returns the PREVIOUS burst when this record's ring-time gap closes it (the fed
+    /// record then starts the next burst); nil while the current burst is still growing. Records with
+    /// no codes are ignored (nothing to place).
+    public func feed(ringTimestamp: UInt32, phases: [OuraSleepPhase]) -> OuraHypnogramBurst? {
+        guard !phases.isEmpty else { return nil }
+        let record = OuraHypnogramRecord(ringTimestamp: ringTimestamp, phases: phases)
+        if let last = current.last {
+            let gap = ringTimestamp >= last.ringTimestamp
+                ? ringTimestamp - last.ringTimestamp
+                : last.ringTimestamp - ringTimestamp
+            if gap > burstGapTicks {
+                let done = OuraHypnogramBurst(records: current)
+                current = [record]
+                return done
+            }
+        }
+        current.append(record)
+        return nil
+    }
+
+    /// Close and return the in-progress burst (call at drain end / teardown), or nil if none.
+    public func flush() -> OuraHypnogramBurst? {
+        guard !current.isEmpty else { return nil }
+        let done = OuraHypnogramBurst(records: current)
+        current = []
+        return done
+    }
+
+    /// Discard any partial state (fresh session).
+    public func reset() {
+        current = []
+    }
+
+    /// Number of records currently accumulating (observability only).
+    public var pendingRecordCount: Int { current.count }
+}

--- a/Packages/OuraProtocol/Sources/OuraProtocol/OuraDriver.swift
+++ b/Packages/OuraProtocol/Sources/OuraProtocol/OuraDriver.swift
@@ -159,8 +159,11 @@ public final class OuraDriver {
                 phase = .streaming
                 return []
             }
-            // Ack-fetch (max=0) at the new cursor advances without re-pulling data (s5.3 step 4).
-            return [OuraCommands.getEvents(cursor: cursor, maxEvents: 0)]
+            // Continuation fetch at the ADVANCED cursor (max seen ring-time + 1), same shape as the
+            // initial request — open_oura `drain_events` re-issues `req_get_event(start, 255, -1)` every
+            // batch. The old open_ring "ack-fetch" (max=0 at a non-advancing cursor) made the ring
+            // RESTART serving from that cursor: the observed same-window re-serve loop (s5.3).
+            return [OuraCommands.getEvents(cursor: cursor, maxEvents: 255)]
         }
     }
 
@@ -226,6 +229,35 @@ public final class OuraDriver {
         let seconds = ms / 1000
         guard seconds >= Self.minPlausibleEpochSeconds, seconds <= Self.maxPlausibleEpochSeconds else { return nil }
         return Int(seconds)
+    }
+
+    /// Resolve the 0x13 SyncTime-response device timestamp into ring TICKS, or nil when no unambiguous
+    /// reading exists. ringverse BLE.md labels the field "seconds" but the ring's record clock runs in
+    /// 100 ms ticks, so both readings are tried: the raw value (already ticks) and value×10 (seconds→
+    /// ticks). The ring's clock at connect must sit shortly AFTER where the last drain ended, so a
+    /// candidate is plausible iff it falls in `[historyCursor, historyCursor + 7 days]`; exactly one
+    /// must fit (ambiguity or a fresh/reset cursor → nil → the caller logs raw instead of guessing).
+    /// Pure and testable; the honest-data invariant is "no anchor beats a wrong anchor".
+    public static func syncTimeAnchorCandidate(responseValue: UInt32, historyCursor: UInt32) -> UInt32? {
+        guard historyCursor > 0 else { return nil }
+        let lower = Int64(historyCursor)
+        let upper = lower + 6_048_000   // 7 days of 100 ms ticks
+        let readings = [Int64(responseValue), Int64(responseValue) * 10]
+        let fits = readings.filter { $0 >= lower && $0 <= upper && $0 <= Int64(UInt32.max) }
+        guard fits.count == 1 else { return nil }
+        return UInt32(fits[0])
+    }
+
+    /// Adopt a ring-time→UTC anchor from the 0x13 SyncTime response pair (`rt` = the ring's clock counter
+    /// in ticks when it processed our SyncTime, `unixSeconds` = host wall-clock at receipt). Same
+    /// plausibility gate as the 0x42/0x85 paths; returns whether the anchor was set. The freshest
+    /// possible pair, so it overwrites any earlier anchor (an in-log 0x42 from the same clock domain
+    /// yields the same mapping anyway).
+    public func adoptSyncTimeAnchor(ringTimestamp rt: UInt32, unixSeconds: Int64) -> Bool {
+        guard let ms = Self.plausibleAnchorMs(fromEpochSeconds: unixSeconds) else { return false }
+        anchorUtcMs = ms
+        anchorRingTime = rt
+        return true
     }
 
     /// Bounds for a plausible anchor epoch (unix seconds): 2020-01-01 to 2035-01-01. A decoded 0x42/0x85

--- a/Packages/OuraProtocol/Sources/OuraProtocol/OuraEvents.swift
+++ b/Packages/OuraProtocol/Sources/OuraProtocol/OuraEvents.swift
@@ -73,12 +73,18 @@ public struct OuraBattery: Equatable, Sendable, Codable {
     }
 }
 
-/// Sleep phase code (OURA_PROTOCOL.md s6.12): 2-bit codes 0=awake, 1=light, 2=deep, 3=REM.
+/// The 2-bit sleep-phase code values, per open_oura's VALIDATED `decode_sleep_phases` mapping
+/// (events.rs `PHASE = ["deep", "light", "rem", "awake"]`): 0=deep, 1=light, 2=rem, 3=awake.
+///
+/// CORRECTION (2026-07-11): NOOP previously mapped 0=awake/2=deep/3=rem from the same unverified doc
+/// as the rest of s6.12. Two live captures contradict that: phase records decoded AT WAKE (wearer
+/// demonstrably awake) carry code 3 — awake under open_oura's mapping, "REM" under the old one. The
+/// raw code is what persists (`stage.rawValue`); only these LABELS changed, so stored rows are stable.
 public enum OuraSleepStage: Int, Sendable, Equatable, Codable {
-    case awake = 0
+    case deep  = 0
     case light = 1
-    case deep = 2
-    case rem = 3
+    case rem   = 2
+    case awake = 3
 }
 
 /// One decoded sleep-phase code in order within a 0x4E/0x5A record (OURA_PROTOCOL.md s6.12).
@@ -218,6 +224,28 @@ public enum OuraEvent: Equatable, Sendable {
         switch self {
         case .tierB, .activityInfo: return true
         default: return false
+        }
+    }
+
+    /// The record's envelope ring-time, when it carries one (battery is a plain response, not a log
+    /// record). Feeds the history drain's in-session continuation cursor: open_oura's `drain_events`
+    /// advances `start` past the max timestamp of EVERY event in a batch, whatever its tag.
+    public var envelopeRingTimestamp: UInt32? {
+        switch self {
+        case .hr(let v): return v.ringTimestamp
+        case .ibi(let v): return v.ringTimestamp
+        case .hrv(let v): return v.ringTimestamp
+        case .spo2(let v): return v.ringTimestamp
+        case .temp(let v): return v.ringTimestamp
+        case .battery: return nil
+        case .sleepPhase(let v): return v.ringTimestamp
+        case .motion(let v): return v.ringTimestamp
+        case .state(let v): return v.ringTimestamp
+        case .timeSync(let v): return v.ringTimestamp
+        case .rtcBeacon(let v): return v.ringTimestamp
+        case .debugText(let rt, _): return rt
+        case .tierB(let v): return v.ringTimestamp
+        case .activityInfo(let v): return v.ringTimestamp
         }
     }
 }

--- a/Packages/OuraProtocol/Sources/OuraProtocol/OuraHistoryDrain.swift
+++ b/Packages/OuraProtocol/Sources/OuraProtocol/OuraHistoryDrain.swift
@@ -25,6 +25,13 @@ public struct OuraHistoryDrain: Sendable, Equatable {
     private var stallCount = 0
     /// Newest STORED ring-time seen this drain — the value the resume cursor commits to at drain end.
     public private(set) var maxStoredRingTime: UInt32 = 0
+    /// Newest ring-time SEEN this drain across ALL history records (anchored or not) — the in-session
+    /// continuation cursor's source. Kept separate from [maxStoredRingTime]: the continuation cursor may
+    /// advance on unanchored records (they were served, so the ring must not re-serve them this session),
+    /// while the DURABLE cursor still only commits from anchored, stored samples.
+    public private(set) var maxSeenRingTime: UInt32 = 0
+    /// History records seen since the last GetEvents request — open_oura's `batch_events` progress test.
+    public private(set) var eventsSinceLastRequest: UInt32 = 0
     /// A real stored sample older than where we sought this fetch: the ring's clock reset (or it ignored
     /// the seek), so the persisted cursor is stale → full pull next connect.
     public private(set) var sawPreResumeData = false
@@ -36,6 +43,8 @@ public struct OuraHistoryDrain: Sendable, Equatable {
         minBytesLeftSeen = .max
         stallCount = 0
         maxStoredRingTime = 0
+        maxSeenRingTime = 0
+        eventsSinceLastRequest = 0
         sawPreResumeData = false
     }
 
@@ -66,6 +75,28 @@ public struct OuraHistoryDrain: Sendable, Equatable {
         guard rt <= Self.maxPlausibleResumeTicks else { return }
         if rt > maxStoredRingTime { maxStoredRingTime = rt }
         if resumeCursorAtFetchStart > 0, rt < resumeCursorAtFetchStart { sawPreResumeData = true }
+    }
+
+    /// Record ANY history record's ring-time toward the in-session continuation cursor (anchored or not),
+    /// and count it toward the batch-progress test. Ignores corrupt (over-ceiling) times. Call once per
+    /// decoded history record that carries an envelope ring-time.
+    public mutating func noteSeenRingTime(_ rt: UInt32) {
+        guard rt <= Self.maxPlausibleResumeTicks else { return }
+        if rt > maxSeenRingTime { maxSeenRingTime = rt }
+        eventsSinceLastRequest &+= 1
+    }
+
+    /// The cursor for the NEXT in-session GetEvents request, or nil to stop (open_oura `drain_events`:
+    /// `progressed = batch_events > 0 && next > start; if !progressed break`). Re-sending a non-advancing
+    /// cursor makes the ring RESTART serving from it — the observed 5x same-window re-serve loop — so a
+    /// flat batch ends the drain instead of retrying. On advance, the batch counter re-arms for the next
+    /// request's progress test.
+    public mutating func continuationCursor(lastRequestCursor: UInt32) -> UInt32? {
+        guard eventsSinceLastRequest > 0 else { return nil }
+        let next = maxSeenRingTime &+ 1
+        guard next > lastRequestCursor else { return nil }
+        eventsSinceLastRequest = 0
+        return next
     }
 
     /// The cursor to persist at drain end, given the current cursor and whether `maxStoredRingTime`

--- a/Packages/OuraProtocol/Tests/OuraProtocolTests/DecoderGoldenTests.swift
+++ b/Packages/OuraProtocol/Tests/OuraProtocolTests/DecoderGoldenTests.swift
@@ -122,14 +122,15 @@ final class DecoderGoldenTests: XCTestCase {
     // MARK: - 0x4E sleep phase (2-bit codes MSB-first; header byte skipped)
 
     func testSleepPhase0x4E() {
-        // header 0x00, phase byte 0x6C = bits 01 10 11 00 -> light, deep, rem, awake.
+        // header 0x00, phase byte 0x6C = bits 01 10 11 00 = codes 1,2,3,0. Per open_oura's VALIDATED
+        // mapping (0=deep, 1=light, 2=rem, 3=awake) -> light, rem, awake, deep.
         let rec = record("4e0602000100006c")
         let phases = OuraDecoders.decodeSleepPhase(rec)
         XCTAssertEqual(phases, [
             OuraSleepPhase(ringTimestamp: rt, index: 0, stage: .light),
-            OuraSleepPhase(ringTimestamp: rt, index: 1, stage: .deep),
-            OuraSleepPhase(ringTimestamp: rt, index: 2, stage: .rem),
-            OuraSleepPhase(ringTimestamp: rt, index: 3, stage: .awake),
+            OuraSleepPhase(ringTimestamp: rt, index: 1, stage: .rem),
+            OuraSleepPhase(ringTimestamp: rt, index: 2, stage: .awake),
+            OuraSleepPhase(ringTimestamp: rt, index: 3, stage: .deep),
         ])
     }
 
@@ -212,6 +213,58 @@ final class DecoderGoldenTests: XCTestCase {
 
         let hr = OuraDecoders.decodeLiveHRPush(subBody, ringTimestamp: rt)
         XCTAssertEqual(hr, OuraHR(ringTimestamp: rt, bpm: 59, ibiMs: 1025))
+    }
+
+    // MARK: - 0x71 green_ibi_and_amp CANDIDATE decode (ringverse @0x503960, upstream #287)
+
+    /// Inverse of the firmware's scrambled packing (ringverse `p_green_ibi_and_amp`): middle-8 bytes
+    /// at p[4..0] (ds0..ds4), amplitude bytes p[6..10] carry the mantissa in bits [7:1] and the
+    /// PAIRED IBI's low bit in bit [0] (ds4..ds0 order), bits [2:1] of ds1..ds4 pack into p[12]
+    /// two bits at a time, ds0's into p[13] bits [7:6] alongside the shift field.
+    private func packGreenIBIAmp(ibis: [Int], mants: [Int], s: Int) -> [UInt8] {
+        var p = [UInt8](repeating: 0, count: 14)
+        for (i, mid) in [4, 3, 2, 1, 0].enumerated() { p[mid] = UInt8((ibis[i] >> 3) & 0xFF) }
+        for (i, amp) in [10, 9, 8, 7, 6].enumerated() {
+            p[amp] = UInt8((mants[4 - i] << 1) | (ibis[i] & 1))
+        }
+        var pack12 = (ibis[1] >> 1) & 3
+        pack12 |= ((ibis[2] >> 1) & 3) << 2
+        pack12 |= ((ibis[3] >> 1) & 3) << 4
+        pack12 |= ((ibis[4] >> 1) & 3) << 6
+        p[12] = UInt8(pack12)
+        p[13] = UInt8((s & 7) | (((ibis[0] >> 1) & 3) << 6))
+        return p
+    }
+
+    func testGreenIBIAmpCandidateRoundTrip() {
+        // 11-bit IBIs exercising every packed bit field; 7-bit mantissas; s=3 -> shift 4.
+        let ibis = [1023, 800, 517, 2046, 901]
+        let mants = [1, 64, 100, 127, 33]
+        let p = packGreenIBIAmp(ibis: ibis, mants: mants, s: 3)
+        let decoded = OuraDecoders.decodeGreenIBIAmpCandidate(payload: p, ringTimestamp: rt)
+        XCTAssertNotNil(decoded)
+        XCTAssertEqual(decoded!.shift, 4)
+        let samples = decoded!.samples
+        XCTAssertEqual(samples.count, 6)
+        // First entry is amplitude-only (ibi 0, amp = as[0] = mantissa of p[6] << shift).
+        XCTAssertEqual(samples[0].ibiMs, 0)
+        XCTAssertEqual(samples[0].amplitude, mants[0] << 4)
+        // The five IBI entries recover the exact packed values; amps pair as[i] per the firmware order.
+        XCTAssertEqual(samples.dropFirst().map { $0.ibiMs }, ibis)
+        XCTAssertEqual(samples.dropFirst().map { $0.amplitude ?? -1 }, mants.map { $0 << 4 })
+    }
+
+    func testGreenIBIAmpCandidateGates() {
+        // s == 7 means shift 0 (identity amplitudes).
+        let p7 = packGreenIBIAmp(ibis: [500, 500, 500, 500, 500], mants: [10, 10, 10, 10, 10], s: 7)
+        XCTAssertEqual(OuraDecoders.decodeGreenIBIAmpCandidate(payload: p7, ringTimestamp: rt)?.shift, 0)
+        // Reserved bit [3] of p[13] set -> firmware mismatch -> nil, never a guessed decode.
+        var bad = p7
+        bad[13] |= 0x08
+        XCTAssertNil(OuraDecoders.decodeGreenIBIAmpCandidate(payload: bad, ringTimestamp: rt))
+        // Strict 14-byte gate: any other length is a different firmware layout -> nil.
+        XCTAssertNil(OuraDecoders.decodeGreenIBIAmpCandidate(payload: Array(p7.dropLast()), ringTimestamp: rt))
+        XCTAssertNil(OuraDecoders.decodeGreenIBIAmpCandidate(payload: p7 + [0x00], ringTimestamp: rt))
     }
 
     // MARK: - Honest-data invariant: short / malformed records decode to nil

--- a/Packages/OuraProtocol/Tests/OuraProtocolTests/FramingTests.swift
+++ b/Packages/OuraProtocol/Tests/OuraProtocolTests/FramingTests.swift
@@ -204,4 +204,47 @@ final class FramingTests: XCTestCase {
         r.reset()
         XCTAssertEqual(r.bufferedByteCount, 0)
     }
+
+    // MARK: - 0x13 SyncTime response (ringverse BLE.md: device_ts u32 LE + status)
+
+    func testParseSyncTimeResponse() {
+        // ringverse example body: 4b ed a9 00 00 -> device_ts 0x00A9ED4B, status 0.
+        let r = OuraFraming.parseSyncTimeResponse(bytes("4beda90000"))
+        XCTAssertEqual(r?.deviceTimestamp, 0x00A9_ED4B)
+        XCTAssertEqual(r?.status, 0)
+        // Short body -> nil, never a guessed timestamp.
+        XCTAssertNil(OuraFraming.parseSyncTimeResponse(bytes("4beda900")))
+    }
+
+    // MARK: - 0x13 -> anchor tick disambiguation (OuraDriver.syncTimeAnchorCandidate)
+
+    func testSyncTimeAnchorCandidateResolvesUnit() {
+        // The 2026-07-13 shape: cursor banked at 4_413_933 (last night's log end); ~11 h later the
+        // ring's clock is ~4.81M ticks. A raw-ticks response fits the [cursor, cursor+7d] window and
+        // the seconds x10 reading does not -> unambiguous ticks.
+        XCTAssertEqual(OuraDriver.syncTimeAnchorCandidate(responseValue: 4_810_000, historyCursor: 4_413_933),
+                       4_810_000)
+        // A seconds-unit response (481_000 s = 4.81M ticks) only fits when multiplied x10.
+        XCTAssertEqual(OuraDriver.syncTimeAnchorCandidate(responseValue: 481_000, historyCursor: 4_413_933),
+                       4_810_000)
+        // Below the cursor in both readings (ring reboot / stale value) -> nil.
+        XCTAssertNil(OuraDriver.syncTimeAnchorCandidate(responseValue: 100_000, historyCursor: 4_413_933))
+        // Beyond cursor+7d in both readings -> nil.
+        XCTAssertNil(OuraDriver.syncTimeAnchorCandidate(responseValue: 40_000_000, historyCursor: 4_413_933))
+        // A fresh/reset cursor gives no reference -> nil (never guess on a full pull).
+        XCTAssertNil(OuraDriver.syncTimeAnchorCandidate(responseValue: 4_810_000, historyCursor: 0))
+        // Ambiguity guard: BOTH readings inside the window -> nil.
+        XCTAssertNil(OuraDriver.syncTimeAnchorCandidate(responseValue: 150_000, historyCursor: 140_000))
+    }
+
+    func testAdoptSyncTimeAnchorResolvesHistoryTimes() {
+        let d = OuraDriver(ringGen: .gen3, authKey: nil)
+        let now: Int64 = 1_784_000_000                     // inside the 2020-2035 plausibility window
+        XCTAssertNil(d.unixSeconds(forRingTimestamp: 4_800_000), "no anchor yet")
+        XCTAssertTrue(d.adoptSyncTimeAnchor(ringTimestamp: 4_810_000, unixSeconds: now))
+        // A record 10_000 ticks (1000 s) before the anchor resolves to now - 1000.
+        XCTAssertEqual(d.unixSeconds(forRingTimestamp: 4_800_000), Int(now) - 1000)
+        // An implausible host epoch is refused (never anchors to a garbage clock).
+        XCTAssertFalse(d.adoptSyncTimeAnchor(ringTimestamp: 4_810_000, unixSeconds: 100))
+    }
 }

--- a/Packages/OuraProtocol/Tests/OuraProtocolTests/HypnogramAssemblerTests.swift
+++ b/Packages/OuraProtocol/Tests/OuraProtocolTests/HypnogramAssemblerTests.swift
@@ -1,0 +1,107 @@
+import XCTest
+@testable import OuraProtocol
+
+/// Tests for the hypnogram time-axis reconstruction (OuraHypnogramAssembler): burst grouping by
+/// envelope ring-time gap, and the 30 s/code backward layout from the anchored burst end.
+final class HypnogramAssemblerTests: XCTestCase {
+
+    private func phases(_ stages: [OuraSleepStage], rt: UInt32) -> [OuraSleepPhase] {
+        stages.enumerated().map { OuraSleepPhase(ringTimestamp: rt, index: $0.offset, stage: $0.element) }
+    }
+
+    // MARK: - Backward layout
+
+    func testSingleRecordLaysCodesBackwardFromEnd() {
+        let a = OuraHypnogramAssembler()
+        XCTAssertNil(a.feed(ringTimestamp: 1000, phases: phases([.awake, .light, .deep, .rem], rt: 1000)))
+        let burst = a.flush()!
+        // 4 codes ending at t=10_000: starts at 10_000 - 4*30 = 9_880, spaced 30 s.
+        let laid = burst.codesWithTimes(endUnixSeconds: 10_000)
+        XCTAssertEqual(laid.map { $0.ts }, [9_880, 9_910, 9_940, 9_970])
+        XCTAssertEqual(laid.map { $0.phase.stage }, [.awake, .light, .deep, .rem])
+        // The final code's 30 s interval ends exactly at the burst end.
+        XCTAssertEqual(laid.last!.ts + 30, 10_000)
+    }
+
+    func testBurstWriteRecordsShareOneSequence() {
+        // The on-device shape: multiple records written in one burst (envelope rts a few ticks apart)
+        // form ONE contiguous sequence — record 2's codes precede the end, record 1's come before them.
+        let a = OuraHypnogramAssembler()
+        XCTAssertNil(a.feed(ringTimestamp: 5_000, phases: phases([.awake, .light], rt: 5_000)))
+        XCTAssertNil(a.feed(ringTimestamp: 5_010, phases: phases([.deep, .awake], rt: 5_010)))
+        let burst = a.flush()!
+        XCTAssertEqual(burst.totalCodes, 4)
+        XCTAssertEqual(burst.lastRingTimestamp, 5_010)
+        let laid = burst.codesWithTimes(endUnixSeconds: 100_000)
+        XCTAssertEqual(laid.map { $0.ts }, [99_880, 99_910, 99_940, 99_970])
+        XCTAssertEqual(laid.map { $0.phase.stage }, [.awake, .light, .deep, .awake])
+    }
+
+    func testFullNightScaleWindow() {
+        // The real 2026-07-12 shape: 23 records x 52 codes = 1,196 codes -> 9 h 58 m window ending at
+        // the finalization time. Start must be end - 1,196 * 30 s.
+        let a = OuraHypnogramAssembler()
+        for k in 0..<23 {
+            _ = a.feed(ringTimestamp: 3_970_000 + UInt32(k), phases: phases(Array(repeating: .light, count: 52), rt: 3_970_000))
+        }
+        let burst = a.flush()!
+        XCTAssertEqual(burst.totalCodes, 1_196)
+        let end = 1_760_000_000
+        let laid = burst.codesWithTimes(endUnixSeconds: end)
+        XCTAssertEqual(laid.first!.ts, end - 1_196 * 30)          // 35,880 s = 9 h 58 m before end
+        XCTAssertEqual(laid.count, 1_196)
+        // Strictly increasing, 30 s apart — every code lands on a unique persistence slot.
+        XCTAssertTrue(zip(laid, laid.dropFirst()).allSatisfy { $1.ts - $0.ts == 30 })
+    }
+
+    // MARK: - Burst splitting
+
+    func testLargeRingTimeGapSplitsBursts() {
+        // Two nights in one full dump: finalization writes hours apart must NOT merge.
+        let a = OuraHypnogramAssembler()
+        XCTAssertNil(a.feed(ringTimestamp: 1_000_000, phases: phases([.light, .light], rt: 1_000_000)))
+        // 24 h later in deciseconds = 864_000 ticks — far beyond the 600-tick burst gap.
+        let closed = a.feed(ringTimestamp: 1_864_000, phases: phases([.deep], rt: 1_864_000))
+        XCTAssertNotNil(closed, "a big rt gap must close the previous burst")
+        XCTAssertEqual(closed!.totalCodes, 2)
+        XCTAssertEqual(closed!.lastRingTimestamp, 1_000_000)
+        // The new record started the next burst.
+        let second = a.flush()!
+        XCTAssertEqual(second.totalCodes, 1)
+        XCTAssertEqual(second.lastRingTimestamp, 1_864_000)
+    }
+
+    func testFlushEmptyReturnsNilAndResetClears() {
+        let a = OuraHypnogramAssembler()
+        XCTAssertNil(a.flush())
+        _ = a.feed(ringTimestamp: 10, phases: phases([.rem], rt: 10))
+        a.reset()
+        XCTAssertNil(a.flush(), "reset discards partial state")
+        XCTAssertEqual(a.pendingRecordCount, 0)
+    }
+
+    func testNonMonotonicRingTimesAreSurfacedNotResorted() {
+        // A record whose envelope rt steps BACKWARD (within the burst gap) must be flagged — but the
+        // layout still trusts arrival order (envelope rts of a burst are near-identical write moments;
+        // re-sorting on them could scramble the true code sequence).
+        let a = OuraHypnogramAssembler()
+        XCTAssertNil(a.feed(ringTimestamp: 5_010, phases: phases([.light, .deep], rt: 5_010)))
+        XCTAssertNil(a.feed(ringTimestamp: 5_000, phases: phases([.rem, .awake], rt: 5_000)))   // backward
+        let burst = a.flush()!
+        XCTAssertTrue(burst.hasNonMonotonicRingTimes)
+        // Arrival order preserved in the layout.
+        XCTAssertEqual(burst.codesWithTimes(endUnixSeconds: 1_000).map { $0.phase.stage },
+                       [.light, .deep, .rem, .awake])
+        // And a clean forward burst is NOT flagged.
+        let b = OuraHypnogramAssembler()
+        _ = b.feed(ringTimestamp: 100, phases: phases([.light], rt: 100))
+        _ = b.feed(ringTimestamp: 110, phases: phases([.deep], rt: 110))
+        XCTAssertFalse(b.flush()!.hasNonMonotonicRingTimes)
+    }
+
+    func testEmptyRecordIsIgnored() {
+        let a = OuraHypnogramAssembler()
+        XCTAssertNil(a.feed(ringTimestamp: 10, phases: []))
+        XCTAssertNil(a.flush(), "a record with no codes never opens a burst")
+    }
+}

--- a/Packages/OuraProtocol/Tests/OuraProtocolTests/OuraDriverTests.swift
+++ b/Packages/OuraProtocol/Tests/OuraProtocolTests/OuraDriverTests.swift
@@ -155,7 +155,7 @@ final class OuraDriverTests: XCTestCase {
 
     // MARK: - History fetch loop
 
-    func testHistoryFetchFlushesThenFetchesThenAcks() {
+    func testHistoryFetchFlushesThenFetchesThenContinues() {
         let d = OuraDriver(ringGen: .gen3, authKey: key)
         let start = d.nextStep(after: .startHistoryFetch(cursor: 0))
         XCTAssertEqual(d.phase, .fetchingHistory)
@@ -163,10 +163,11 @@ final class OuraDriverTests: XCTestCase {
         // get_events cursor 0, max 255, flags FFFFFFFF.
         XCTAssertEqual(start[1].bytes, [0x10, 0x09, 0x00, 0x00, 0x00, 0x00, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF])
 
-        // More data -> ack-fetch (max 0) at the advanced cursor.
-        let ack = d.nextStep(after: .historyCursorAdvanced(cursor: 0x12345678, moreData: true))
-        XCTAssertEqual(ack.count, 1)
-        XCTAssertEqual(ack[0].bytes, [0x10, 0x09, 0x78, 0x56, 0x34, 0x12, 0x00, 0xFF, 0xFF, 0xFF, 0xFF])
+        // More data -> continuation fetch at the ADVANCED cursor, SAME shape as the initial request
+        // (max 255, open_oura drain_events). The old max=0 "ack" made the ring restart its serve.
+        let cont = d.nextStep(after: .historyCursorAdvanced(cursor: 0x12345678, moreData: true))
+        XCTAssertEqual(cont.count, 1)
+        XCTAssertEqual(cont[0].bytes, [0x10, 0x09, 0x78, 0x56, 0x34, 0x12, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF])
 
         // No more -> back to streaming.
         let stop = d.nextStep(after: .historyCursorAdvanced(cursor: 0x12345678, moreData: false))
@@ -353,16 +354,17 @@ final class OuraDriverTests: XCTestCase {
         // 0x4B was previously a Tier-B "sleep summary" (dropped by default). It is actually a hypnogram
         // alias (open_oura `0x4b | 0x4e | 0x5a => decode_sleep_phases`), so it now decodes with the SAME
         // validated 2-bit phase decoder as 0x4E/0x5A and emits Tier-A sleep-phase events even when
-        // allowTierB == false. Same payload as the 0x4E golden -> light, deep, rem, awake.
+        // allowTierB == false. Same payload as the 0x4E golden; open_oura's validated stage mapping
+        // (0=deep, 1=light, 2=rem, 3=awake) -> codes 1,2,3,0 = light, rem, awake, deep.
         XCTAssertEqual(OuraEventTag(rawValue: 0x4B), .sleepPhaseB)
         XCTAssertEqual(OuraEventTag.sleepPhaseB.tier, .tierA)
         let d = OuraDriver(ringGen: .gen3, authKey: key)   // allowTierB defaults to false
         let rec = OuraFraming.parseRecord(bytes("4b0602000100006c"))!
         XCTAssertEqual(d.ingest(record: rec), [
             .sleepPhase(OuraSleepPhase(ringTimestamp: rt, index: 0, stage: .light)),
-            .sleepPhase(OuraSleepPhase(ringTimestamp: rt, index: 1, stage: .deep)),
-            .sleepPhase(OuraSleepPhase(ringTimestamp: rt, index: 2, stage: .rem)),
-            .sleepPhase(OuraSleepPhase(ringTimestamp: rt, index: 3, stage: .awake)),
+            .sleepPhase(OuraSleepPhase(ringTimestamp: rt, index: 1, stage: .rem)),
+            .sleepPhase(OuraSleepPhase(ringTimestamp: rt, index: 2, stage: .awake)),
+            .sleepPhase(OuraSleepPhase(ringTimestamp: rt, index: 3, stage: .deep)),
         ])
     }
 
@@ -539,10 +541,18 @@ final class OuraDriverTests: XCTestCase {
         XCTAssertTrue(OuraRingGen.gen3.capabilities.contains(.hrv))
     }
 
-    func testSyncTimeCommandCounter() {
-        // counter = floor(unix / 256). For unix = 256 -> counter 1 -> bytes 01 00 00, trailer 0xF6.
-        let cmd = OuraCommands.syncTime(unixSeconds: 256)
-        XCTAssertEqual(cmd.bytes, [0x12, 0x09, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xF6])
+    func testSyncTimeCommandIsU64SecondsLEPlusTz() {
+        // Authoritative layout: 12 09 <unix_secs u64 LE> <tz i8>. 1_700_000_000 = 0x6553F100
+        // -> LE 00 F1 53 65 00 00 00 00, tz 0. (Supersedes the old unix/256 + 0xF6-trailer guess.)
+        let cmd = OuraCommands.syncTime(unixSeconds: 1_700_000_000)
+        XCTAssertEqual(cmd.bytes,
+                       [0x12, 0x09, 0x00, 0xF1, 0x53, 0x65, 0x00, 0x00, 0x00, 0x00, 0x00])
+    }
+
+    func testSyncTimeCommandTimezoneByte() {
+        // tz is a signed half-hour offset in the trailing byte: +4 (=UTC+2) -> 0x04; -4 -> 0xFC.
+        XCTAssertEqual(OuraCommands.syncTime(unixSeconds: 0, tzHalfHours: 4).bytes.last, 0x04)
+        XCTAssertEqual(OuraCommands.syncTime(unixSeconds: 0, tzHalfHours: -4).bytes.last, 0xFC)
     }
 
     // MARK: - Dangerous commands are isolated and labelled

--- a/Packages/OuraProtocol/Tests/OuraProtocolTests/OuraHistoryDrainTests.swift
+++ b/Packages/OuraProtocol/Tests/OuraProtocolTests/OuraHistoryDrainTests.swift
@@ -117,11 +117,67 @@ final class OuraHistoryDrainTests: XCTestCase {
         var d = OuraHistoryDrain()
         d.noteStoredRingTime(3_453_828, resumeCursorAtFetchStart: 1000)
         d.noteStoredRingTime(500, resumeCursorAtFetchStart: 1000)
+        d.noteSeenRingTime(3_453_900)
         _ = d.onSummary(bytesLeft: 1000, moreData: true, elapsedSeconds: 1)
         d.reset()
         XCTAssertEqual(d.maxStoredRingTime, 0)
+        XCTAssertEqual(d.maxSeenRingTime, 0)
+        XCTAssertEqual(d.eventsSinceLastRequest, 0)
         XCTAssertFalse(d.sawPreResumeData)
         // Stall floor reset: a fresh flat sequence starts counting from scratch.
         XCTAssertTrue(d.onSummary(bytesLeft: 1000, moreData: true, elapsedSeconds: 1))
+    }
+
+    // MARK: in-session continuation cursor (open_oura drain_events `progressed`)
+
+    func testContinuationCursorAdvancesPastMaxSeen() {
+        var d = OuraHistoryDrain()
+        // The 2026-07-12 shape: sought from 1_681_398, batch served records up to rt 3_595_428.
+        d.noteSeenRingTime(1_686_000)
+        d.noteSeenRingTime(3_595_428)
+        d.noteSeenRingTime(2_000_000)   // out-of-order within the batch, doesn't lower the max
+        XCTAssertEqual(d.continuationCursor(lastRequestCursor: 1_681_398), 3_595_429,
+                       "next request starts one past the newest record served")
+    }
+
+    func testContinuationStopsOnEmptyBatch() {
+        var d = OuraHistoryDrain()
+        XCTAssertNil(d.continuationCursor(lastRequestCursor: 1_681_398),
+                     "no records since the last request → no progress → stop, never re-request")
+    }
+
+    func testContinuationStopsWhenCursorWouldNotAdvance() {
+        var d = OuraHistoryDrain()
+        // A re-served window: records arrived but none newer than where we already asked from.
+        d.noteSeenRingTime(1_686_000)
+        d.noteSeenRingTime(3_595_428)
+        XCTAssertNil(d.continuationCursor(lastRequestCursor: 3_595_429),
+                     "a batch that only re-serves old records must stop the drain (the 5x re-serve loop)")
+    }
+
+    func testContinuationReArmsProgressTestPerRequest() {
+        var d = OuraHistoryDrain()
+        d.noteSeenRingTime(2_000_000)
+        XCTAssertEqual(d.continuationCursor(lastRequestCursor: 1_000_000), 2_000_001)
+        // No new records after the advanced request: the next decision is stop, not a re-request at
+        // the same cursor.
+        XCTAssertNil(d.continuationCursor(lastRequestCursor: 2_000_001))
+        // Fresh records past the new cursor re-enable progress.
+        d.noteSeenRingTime(2_500_000)
+        XCTAssertEqual(d.continuationCursor(lastRequestCursor: 2_000_001), 2_500_001)
+    }
+
+    func testSeenRingTimeIgnoresCorruptAndIsIndependentOfStored() {
+        var d = OuraHistoryDrain()
+        d.noteSeenRingTime(OuraHistoryDrain.maxPlausibleResumeTicks + 1)
+        XCTAssertEqual(d.maxSeenRingTime, 0, "over-ceiling ring-time must not steer the continuation")
+        // Unanchored records advance the CONTINUATION cursor without touching the durable one: the
+        // ring served them (must not re-serve this session), but only anchored stored samples commit.
+        d.noteSeenRingTime(3_000_000)
+        XCTAssertEqual(d.maxSeenRingTime, 3_000_000)
+        XCTAssertEqual(d.maxStoredRingTime, 0)
+        d.noteStoredRingTime(2_900_000, resumeCursorAtFetchStart: 0)
+        XCTAssertEqual(d.maxStoredRingTime, 2_900_000)
+        XCTAssertEqual(d.maxSeenRingTime, 3_000_000, "stored notes don't inflate the seen max")
     }
 }

--- a/Packages/WhoopStore/Sources/WhoopStore/DeviceBrandCatalog.swift
+++ b/Packages/WhoopStore/Sources/WhoopStore/DeviceBrandCatalog.swift
@@ -81,4 +81,12 @@ public enum DeviceBrandCatalog {
     public static func spec(forBrand brand: String) -> DeviceBrandSpec? {
         all.first { $0.brand == brand }
     }
+
+    /// True when a registry deviceId belongs to an Oura ring, resolved from its "<idPrefix>-" prefix against
+    /// this canonical table (never an ad-hoc "oura" literal — the registry mints every non-WHOOP id as
+    /// "<idPrefix>-<uuid>", so the prefix IS the brand key). Read/UI side only: it lets the sleep surfaces
+    /// name an Oura night's provenance "Oura". Twin of Kotlin `DeviceBrandCatalog.isOura`.
+    public static func isOura(_ deviceId: String) -> Bool {
+        all.first { deviceId.hasPrefix($0.idPrefix + "-") }?.sourceKind == .oura
+    }
 }

--- a/Packages/WhoopStore/Sources/WhoopStore/OuraSleepSessionMapping.swift
+++ b/Packages/WhoopStore/Sources/WhoopStore/OuraSleepSessionMapping.swift
@@ -1,0 +1,78 @@
+import Foundation
+import OuraProtocol
+
+/// Pure, testable mapping from a reconstructed Oura hypnogram (the anchored per-code stage sequence
+/// `OuraHypnogramAssembler.codesWithTimes` lays at the 30 s SleepNet epoch) onto a `CachedSleepSession`
+/// whose `stagesJSON` is the SAME `[{start,end,stage}]` segment shape the on-device `SleepStager` and the
+/// Apple-Health / Health-Connect importers write (see `SleepStageTotals.minutes`).
+///
+/// WHY a session and not just the stream: the raw per-code stages already persist as `OURA_SLEEP_PHASE`
+/// events (`OuraStreamMapping`), but nothing turns them into a NIGHT with a stage breakdown that the sleep
+/// surfaces read. Banking the ring-PROVIDED hypnogram as a `CachedSleepSession` under the ring's OWN
+/// deviceId (the imported/measured side, not the `-noop` computed sibling) lets `SleepMerge`'s existing
+/// imported-over-computed rule make Oura's own SleepNet staging win over NOOP's sparse-motion computed
+/// staging for that night — "richer record wins", reusing the exact arbitration that already picks a
+/// WHOOP/HC import over a computed night (ryanbr/noop#240). The richness exception in `SleepMerge` still
+/// protects a stage-rich computed night from a stage-less import, and vice-versa.
+///
+/// HONEST-DATA: this is PROVIDED data (Oura's on-ring classifier), not a NOOP-COMPUTED derivation — it is
+/// the Tier-A sleep-phase codes already surfaced, only reshaped into the session's segment JSON. No new
+/// physiological signal is invented here.
+///
+/// PARITY: the `stagesJSON` string is built by hand in a FIXED key order (`start`,`end`,`stage`) so Swift
+/// and Kotlin emit the BYTE-IDENTICAL segment JSON for the same codes (the cross-platform stored-value
+/// contract). Must stay in lockstep with the Kotlin twin (`OuraSleepSessionMapping.kt`).
+public enum OuraSleepSessionMapping {
+
+    /// Stage token per code — the on-device stager / importer convention `SleepStageTotals` decodes:
+    /// "deep"/"light"/"rem"/"wake" (awake is written "wake"). `OuraSleepStage`: 0=deep,1=light,2=rem,3=awake.
+    static func token(_ stage: OuraSleepStage) -> String {
+        switch stage {
+        case .deep:  return "deep"
+        case .light: return "light"
+        case .rem:   return "rem"
+        case .awake: return "wake"
+        }
+    }
+
+    /// Build a `CachedSleepSession` from the anchored per-code stage sequence (ascending `ts`, one code per
+    /// `secondsPerCode` epoch, exactly as `OuraHypnogramAssembler.codesWithTimes` produces after the burst
+    /// end is anchored + 0x49-refined). Adjacent equal stages are merged into one `[start,end]` segment.
+    /// `startTs` = first code's ts; `endTs` = last code's ts + one epoch (the anchored true sleep end).
+    /// `efficiency` = asleep / (asleep + awake) as a 0–1 fraction (nil when nothing is in bed). Returns nil
+    /// for an empty sequence (never a zero-length night). `restingHr`/`avgHrv` stay nil — those are NOOP's
+    /// own downstream computations from the ring's IBI stream, not part of the ring's provided hypnogram.
+    public static func session(fromCodes codes: [(ts: Int, stage: OuraSleepStage)],
+                               secondsPerCode: Int = 30) -> CachedSleepSession? {
+        guard let first = codes.first, let last = codes.last else { return nil }
+
+        // Merge adjacent equal stages into contiguous [start,end] segments.
+        struct Seg { var start: Int; var end: Int; let stage: OuraSleepStage }
+        var segs: [Seg] = []
+        for c in codes {
+            let segEnd = c.ts + secondsPerCode
+            if var lastSeg = segs.last, lastSeg.stage == c.stage, lastSeg.end == c.ts {
+                lastSeg.end = segEnd
+                segs[segs.count - 1] = lastSeg
+            } else {
+                segs.append(Seg(start: c.ts, end: segEnd, stage: c.stage))
+            }
+        }
+
+        // Hand-built JSON, fixed key order → byte-identical to the Kotlin twin.
+        let json = "[" + segs.map {
+            "{\"start\":\($0.start),\"end\":\($0.end),\"stage\":\"\(token($0.stage))\"}"
+        }.joined(separator: ",") + "]"
+
+        var asleepSec = 0, awakeSec = 0
+        for c in codes {
+            if c.stage == .awake { awakeSec += secondsPerCode } else { asleepSec += secondsPerCode }
+        }
+        let inBedSec = asleepSec + awakeSec
+        let efficiency = inBedSec > 0 ? Double(asleepSec) / Double(inBedSec) : nil
+
+        return CachedSleepSession(startTs: first.ts, endTs: last.ts + secondsPerCode,
+                                  efficiency: efficiency, restingHr: nil, avgHrv: nil,
+                                  stagesJSON: json)
+    }
+}

--- a/Packages/WhoopStore/Sources/WhoopStore/OuraStreamMapping.swift
+++ b/Packages/WhoopStore/Sources/WhoopStore/OuraStreamMapping.swift
@@ -90,6 +90,12 @@ public enum OuraStreamMapping {
                 out.skinTemp.append(SkinTempSample(ts: ts, raw: Int((v.celsius * 100).rounded()), unit: "centi_c"))
 
             case .sleepPhase(let v):
+                // Each code arrives with its RECONSTRUCTED time as `ts` (OuraHypnogramAssembler lays the
+                // burst's codes backward at the documented 30 s SleepNet epoch from the anchored burst
+                // end — the record envelope marks the analysis WRITE moment, not the sleep). 30 s spacing
+                // makes every code a distinct (deviceId, ts, kind) row; the earlier provisional
+                // `ts + index` offset is gone (it would double-shift reconstructed codes). The raw 2-bit
+                // code persists unchanged; `index` (position within the wire record) is kept for audit.
                 out.events.append(WhoopEvent(ts: ts, kind: sleepPhaseEventKind, payload: [
                     "phase": .int(v.stage.rawValue),
                     "index": .int(v.index),

--- a/Packages/WhoopStore/Tests/WhoopStoreTests/DeviceBrandCatalogTests.swift
+++ b/Packages/WhoopStore/Tests/WhoopStoreTests/DeviceBrandCatalogTests.swift
@@ -74,4 +74,22 @@ final class DeviceBrandCatalogTests: XCTestCase {
         let brands = DeviceBrandCatalog.all.map(\.brand)
         XCTAssertEqual(Set(brands).count, brands.count)
     }
+
+    /// `isOura` resolves a registry deviceId to its brand by the "<idPrefix>-" prefix, and is true ONLY for
+    /// the Oura ring — this is what lets the sleep surfaces name an Oura night's provenance "Oura". The Kotlin
+    /// twin `DeviceBrandCatalogTest` asserts the SAME cases.
+    func testIsOuraByRegistryIdPrefix() {
+        XCTAssertTrue(DeviceBrandCatalog.isOura("oura-5C4C0BF8-2DF6-1B3A-18D0-3DF0B3590148"))
+        XCTAssertTrue(DeviceBrandCatalog.isOura("oura-anything"))
+        // Other brands / WHOOP / computed / imports are NOT Oura.
+        XCTAssertFalse(DeviceBrandCatalog.isOura("whoop-1234"))
+        XCTAssertFalse(DeviceBrandCatalog.isOura("garmin-1234"))
+        XCTAssertFalse(DeviceBrandCatalog.isOura("strap-1234"))
+        XCTAssertFalse(DeviceBrandCatalog.isOura("huami-1234"))
+        XCTAssertFalse(DeviceBrandCatalog.isOura("some-noop"))
+        XCTAssertFalse(DeviceBrandCatalog.isOura(""))
+        // Prefix must be delimited: a bare "oura" with no "-" (or an unrelated id) is not a registry ring id.
+        XCTAssertFalse(DeviceBrandCatalog.isOura("oura"))
+        XCTAssertFalse(DeviceBrandCatalog.isOura("neuraloura-1"))
+    }
 }

--- a/Packages/WhoopStore/Tests/WhoopStoreTests/OuraSleepSessionMappingTests.swift
+++ b/Packages/WhoopStore/Tests/WhoopStoreTests/OuraSleepSessionMappingTests.swift
@@ -1,0 +1,59 @@
+import XCTest
+import OuraProtocol
+@testable import WhoopStore
+
+/// The ring-PROVIDED hypnogram → `CachedSleepSession` reshaper. Value-for-value twin of the Kotlin
+/// `OuraSleepSessionMappingTest`; the `stagesJSON` byte string is asserted verbatim so both platforms
+/// stay on the cross-platform stored-value contract.
+final class OuraSleepSessionMappingTests: XCTestCase {
+
+    // A tiny anchored sequence: deep,deep,light,rem,awake at 30 s epochs from t0.
+    private func codes(from t0: Int) -> [(ts: Int, stage: OuraSleepStage)] {
+        [(t0, .deep), (t0 + 30, .deep), (t0 + 60, .light), (t0 + 90, .rem), (t0 + 120, .awake)]
+    }
+
+    func testEmptySequenceYieldsNoSession() {
+        XCTAssertNil(OuraSleepSessionMapping.session(fromCodes: []))
+    }
+
+    func testBoundsAreFirstTsToLastTsPlusEpoch() {
+        let t0 = 1_700_000_000
+        let s = OuraSleepSessionMapping.session(fromCodes: codes(from: t0))
+        XCTAssertEqual(s?.startTs, t0)
+        XCTAssertEqual(s?.endTs, t0 + 150)   // last code ts (t0+120) + one 30 s epoch
+    }
+
+    func testAdjacentEqualStagesMergeIntoOneSegment() {
+        let t0 = 1_700_000_000
+        let s = OuraSleepSessionMapping.session(fromCodes: codes(from: t0))
+        // deep merges the first two codes into [t0, t0+60]; the rest are single 30 s segments.
+        let expected = "[" +
+            "{\"start\":\(t0),\"end\":\(t0 + 60),\"stage\":\"deep\"}," +
+            "{\"start\":\(t0 + 60),\"end\":\(t0 + 90),\"stage\":\"light\"}," +
+            "{\"start\":\(t0 + 90),\"end\":\(t0 + 120),\"stage\":\"rem\"}," +
+            "{\"start\":\(t0 + 120),\"end\":\(t0 + 150),\"stage\":\"wake\"}" +
+        "]"
+        XCTAssertEqual(s?.stagesJSON, expected)
+    }
+
+    func testEfficiencyIsAsleepOverInBed() {
+        let t0 = 1_700_000_000
+        let s = OuraSleepSessionMapping.session(fromCodes: codes(from: t0))
+        // 4 asleep epochs (deep,deep,light,rem) + 1 awake → 4/5.
+        XCTAssertEqual(s?.efficiency ?? 0, 0.8, accuracy: 1e-9)
+    }
+
+    func testAllAwakeIsZeroEfficiencyNotNil() {
+        let t0 = 1_700_000_000
+        let s = OuraSleepSessionMapping.session(fromCodes: [(t0, .awake), (t0 + 30, .awake)])
+        XCTAssertEqual(s?.efficiency ?? -1, 0.0, accuracy: 1e-9)
+        XCTAssertEqual(s?.stagesJSON, "[{\"start\":\(t0),\"end\":\(t0 + 60),\"stage\":\"wake\"}]")
+    }
+
+    func testStageTokensMatchOnDeviceStagerConvention() {
+        XCTAssertEqual(OuraSleepSessionMapping.token(.deep), "deep")
+        XCTAssertEqual(OuraSleepSessionMapping.token(.light), "light")
+        XCTAssertEqual(OuraSleepSessionMapping.token(.rem), "rem")
+        XCTAssertEqual(OuraSleepSessionMapping.token(.awake), "wake")   // awake persists as "wake"
+    }
+}

--- a/Packages/WhoopStore/Tests/WhoopStoreTests/OuraStreamMappingTests.swift
+++ b/Packages/WhoopStore/Tests/WhoopStoreTests/OuraStreamMappingTests.swift
@@ -80,15 +80,18 @@ final class OuraStreamMappingTests: XCTestCase {
     // MARK: - Sleep phase -> events[OURA_SLEEP_PHASE]
 
     func testSleepPhaseMapsToEventWithPhaseCode() {
+        // Raw codes persist per open_oura's validated mapping (deep=0, light=1, rem=2, awake=3). Each
+        // code arrives with its RECONSTRUCTED ts (30 s-spaced by OuraHypnogramAssembler upstream), so
+        // the mapping stores the given ts verbatim — no synthetic index offset.
         let s = OuraStreamMapping.streams(from: [
             .sleepPhase(OuraSleepPhase(ringTimestamp: 100, index: 0, stage: .deep)),
             .sleepPhase(OuraSleepPhase(ringTimestamp: 100, index: 1, stage: .rem)),
         ], at: ts)
         XCTAssertEqual(s.events.count, 2)
         XCTAssertTrue(s.events.allSatisfy { $0.kind == OuraStreamMapping.sleepPhaseEventKind })
-        XCTAssertEqual(s.events.map { $0.payload["phase"] }, [.int(2), .int(3)])
+        XCTAssertEqual(s.events.map { $0.payload["phase"] }, [.int(0), .int(2)])
         XCTAssertEqual(s.events.map { $0.payload["index"] }, [.int(0), .int(1)])
-        XCTAssertEqual(s.events.map { $0.ts }, [ts, ts])
+        XCTAssertEqual(s.events.map { $0.ts }, [ts, ts], "ts is stored verbatim; spacing happens upstream")
     }
 
     // MARK: - Battery -> battery:[BatterySample]

--- a/Strand/BLE/OuraLiveSource.swift
+++ b/Strand/BLE/OuraLiveSource.swift
@@ -117,6 +117,12 @@ public final class OuraLiveSource: NSObject, ObservableObject {
     private let live: LiveState
     private let deviceId: String
     private let persist: (Streams) -> Void
+    /// Upsert the ring-PROVIDED reconstructed hypnogram as a `CachedSleepSession` (banked under the ring's
+    /// own `deviceId`, the imported/measured side, so `SleepMerge`'s imported-over-computed rule makes
+    /// Oura's own SleepNet staging win over NOOP's sparse-motion computed night — "richer record wins").
+    /// Wired at the composition root to `store.upsertSleepSessions([_], deviceId:)`; default no-op so the
+    /// discovery-only scanner and tests take the byte-identical inert path.
+    private let persistSleepSession: (CachedSleepSession) -> Void
     private let log: (String) -> Void
     private let onBattery: (Int) -> Void
     /// The ring generation (carried on `PairedDevice.model`, recovered via `OuraRingGen.from(model:)`).
@@ -142,6 +148,16 @@ public final class OuraLiveSource: NSObject, ObservableObject {
     private var driver: OuraDriver?
     /// Reassembles notification fragments into complete TLV inner records across feeds.
     private let reassembler = OuraReassembler()
+    /// Accumulates the ring's burst-written sleep-phase records so a night's hypnogram can be laid out
+    /// backward at the 30 s SleepNet epoch from the anchored burst end (the envelope time marks the
+    /// analysis WRITE moment, not the sleep). Flushed at drain end and teardown; reset per connection.
+    private let hypnogramAssembler = OuraHypnogramAssembler()
+    /// Closed bursts that could not anchor yet (no 0x42 this session so far) — held and reconstructed
+    /// the moment the anchor lands, mirroring the pendingAnchorEvents hold-until-anchor discipline.
+    /// NEVER persisted at wall-clock (the burst end IS the night's time axis); if the session ends
+    /// unanchored they are dropped honestly — the resume cursor did not advance, so the ring re-serves
+    /// the same records next drain. Reset per connection.
+    private var pendingUnanchoredBursts: [OuraHypnogramBurst] = []
 
     /// Live wear/charge indicator: a LIVE-HR push (.hr) means the ring is on a finger; the ring's own "chg.
     /// detected"/"stopped" STATE strings bracket a charging period. Fed ONLY from the live push and STATE
@@ -180,6 +196,29 @@ public final class OuraLiveSource: NSObject, ObservableObject {
     /// read-only feature-status diagnostic prints once per feature, not on every reconnect.
     private var loggedFeatureStatuses: Set<Int> = []
 
+    /// 0x71 green_ibi_amp fixture capture (upstream #287/#333): EVERY occurrence is logged with its
+    /// anchored time + envelope rt + length + full raw bytes (a verified decoder needs several real
+    /// payloads, and the anchored time aligns each with concurrent live-HR R-R). Capped per session so a
+    /// night-long green-IBI wall can't flood the log; the count + observed lengths are summarized at
+    /// drain end regardless. Reset on stop/disconnect/connect.
+    private var greenIbiAmpCount = 0
+    private var greenIbiAmpLengths: Set<Int> = []
+    private static let greenIbiAmpLogCap = 50
+
+    /// The recent 0x49 sleep_summary_1 windows (ringverse: start/end offsets in MINUTES BEFORE the event
+    /// time), stashed so the hypnogram burst each one belongs to can anchor its END at the TRUE sleep end
+    /// (`event − end_offset`) instead of the SleepNet WRITE moment. Validated 2026-07-13: the write
+    /// trailed the real sleep end by 43 min, shifting the whole reconstructed night +43 min; the 0x49
+    /// window matched the wearer's report within minutes (23:32→08:08 vs 23:34→08:03). The 0x49 arrives
+    /// in the same finalization burst right BEFORE the phase records, so stash-then-match by ring-time
+    /// proximity pairs them. A single drain can carry SEVERAL windows (e.g. an overnight AND a daytime
+    /// nap), so this is a COLLECTION, not a single slot: keeping only the latest let a nap's 0x49 clobber
+    /// the overnight's before the overnight burst finalized, and the overnight then fell back to its
+    /// +4 h write time (2026-07-17 capture). Each burst matches its OWN window by ring-time proximity.
+    /// Bounded (oldest dropped past the cap); reset per session.
+    private var recentSleepWindows049: [(ringTimestamp: UInt32, startOffMin: Int, endOffMin: Int)] = []
+    private static let recentSleepWindows049Cap = 16
+
     // MARK: - Activity (0x50 MET) estimate accumulation — INVESTIGATION ONLY
     // Aggregate the decoded 0x50 MET stream into an honest, clearly-labeled per-day estimate
     // (OuraActivityEstimator) logged at drain-end, for eyeballing against WHOOP active minutes / Apple
@@ -204,6 +243,15 @@ public final class OuraLiveSource: NSObject, ObservableObject {
     private static let activityDayFormatter: DateFormatter = {
         let f = DateFormatter(); f.dateFormat = "yyyy-MM-dd"; return f   // local time zone by default
     }()
+
+    // MARK: - Sleep-phase arrival visibility — INVESTIGATION ONLY
+    // Log every 0x4B/0x4E/0x5A hypnogram record (anchored time + code count + stage histogram) so a
+    // capture shows inline when/whether the ring transmits the night's phase timeline, and observe the
+    // per-CODE cadence (record gap ÷ previous record's code count) to pin the ring's phase epoch — the
+    // same technique that pinned the 60 s activity MET epoch. Reset per connection.
+    private var lastPhaseUtc: Int?
+    private var lastPhaseCodeCount = 0
+    private var phaseCadenceObs: [Double] = []
 
     /// History-fetched events decoded BEFORE a ring-time -> UTC anchor exists this session, held here
     /// (with their own ring timestamp) until the anchor lands (`drainPendingAnchorEvents`), so they get
@@ -292,6 +340,27 @@ public final class OuraLiveSource: NSObject, ObservableObject {
     private var resumeCursorAtFetchStart: UInt32 = 0
     /// Wall-clock start of the current drain; `drain`'s deadline guard force-stops one running too long.
     private var drainStartedAt: Date?
+    /// The cursor the LAST GetEvents request was issued at — the `start` of open_oura's progress test
+    /// (`next > start`). Continuation requests must advance past it or the drain stops.
+    private var lastRequestCursor: UInt32 = 0
+    /// True between a `0x11` summary that wants more data and the batch-quiet continuation request. The
+    /// ring emits the summary EARLY (observed before its batch finished streaming), so the next request
+    /// waits for the stream to go quiet — open_oura's `transact()` collects until a 1.5 s silence for the
+    /// same reason. Re-requesting mid-stream at a stale cursor restarts the ring's serve (the re-serve loop).
+    private var pendingContinuation = false
+    /// Debounce for the batch-quiet window: restarted on every history record while a continuation is
+    /// pending; fires = the ring finished streaming the batch and the next request can go out.
+    private var batchQuietTimer: Timer?
+    private let batchQuietInterval: TimeInterval = 1.5
+    /// Self-chained drain passes: when a drain ends with KNOWN remaining work — a detected ring reboot
+    /// (cursor honestly reset to 0, full pull pending) or a deadline-guard stop with banked progress —
+    /// the next pass starts itself a few seconds later instead of waiting for a manual reconnect or the
+    /// 15 min periodic timer. Capped per session; a stall/no-progress stop never chains (that is the
+    /// ring looping, and re-asking would loop with it).
+    private var chainedDrainPasses = 0
+    private static let maxChainedDrainPasses = 6
+    /// One-shot delay before a self-chained drain pass (see `finishDrain`). Invalidated on teardown.
+    private var chainedDrainTimer: Timer?
     /// Periodic re-fetch while connected, so an overnight-connected session (or one left open after a nap)
     /// picks up freshly-banked sleep data without needing a reconnect. Mirrors BLEManager's ~15 min
     /// periodic WHOOP history-offload floor.
@@ -308,6 +377,9 @@ public final class OuraLiveSource: NSObject, ObservableObject {
         resumeCursorAtFetchStart = historyCursor
         drainStartedAt = Date()
         drain.reset()
+        lastRequestCursor = historyCursor
+        pendingContinuation = false
+        stopBatchQuietTimer()
         log("Oura: fetching history from cursor \(historyCursor) (\(describeCursor(historyCursor))) [cursor-fix]")
         advance(.startHistoryFetch(cursor: historyCursor))
     }
@@ -346,12 +418,85 @@ public final class OuraLiveSource: NSObject, ObservableObject {
                 : "bytes_left stalled"
             log("Oura: history drain force-stopped - \(reason) at bytes_left \(summary.bytesLeft) (guard)")
         }
-        if !continueDrain {
-            commitResumeCursor(drainCompleted: !summary.moreData)
-            logActivityEstimateSummary()
+        guard continueDrain else {
+            // A deadline stop with more data behind it is resumable backlog (progress banked, the ring
+            // is healthy — we just chose to breathe); a STALL stop is the ring looping and must not chain.
+            let deadlineBacklog = summary.moreData && elapsed > OuraHistoryDrain.maxDrainSeconds
+            finishDrain(completed: !summary.moreData, resumeBacklog: deadlineBacklog)
+            return
         }
-        // The continuation cursor is the resume point; the ring streams the remainder (maxEvents=0 ack).
-        advance(.historyCursorAdvanced(cursor: historyCursor, moreData: continueDrain))
+        // More data behind this batch. Do NOT re-request yet: the ring emits the 0x11 summary EARLY
+        // (observed arriving before its batch finished streaming), and a mid-stream request at a stale
+        // cursor restarts the serve from that cursor (the 5x same-window re-serve, 2026-07-12). Wait for
+        // the batch to go quiet, then continue from max-seen-ring-time + 1 (open_oura drain_events).
+        pendingContinuation = true
+        restartBatchQuietTimer()
+    }
+
+    /// The batch went quiet after a more-data summary: issue the next GetEvents at the ADVANCED cursor,
+    /// or end the drain when the batch made no progress (open_oura `!progressed → break` — re-sending a
+    /// non-advancing cursor is exactly what loops the ring).
+    private func continueDrainAfterQuiet() {
+        stopBatchQuietTimer()
+        guard pendingContinuation else { return }
+        pendingContinuation = false
+        guard let driver, driver.phase == .fetchingHistory else { return }
+        if let next = drain.continuationCursor(lastRequestCursor: lastRequestCursor) {
+            lastRequestCursor = next
+            log("Oura: history batch done - continuing from cursor \(next) [\(describeCursor(next))]")
+            advance(.historyCursorAdvanced(cursor: next, moreData: true))
+        } else {
+            log("Oura: history batch made no cursor progress - stopping drain (ring would re-serve)")
+            finishDrain(completed: false, resumeBacklog: false)
+        }
+    }
+
+    /// Common drain-end path: close the in-progress hypnogram burst BEFORE committing the cursor (so its
+    /// banked ring-time can advance the resume point in the same drain), commit, log the estimates, and
+    /// return the driver to `.streaming`. When the drain ends with KNOWN remaining work — a detected ring
+    /// reboot (`sawPreResumeData` just reset the cursor to 0; the full pull is pending) or a deadline stop
+    /// with backlog (`resumeBacklog`) — the next pass self-schedules a few seconds later, so catching up
+    /// never needs a manual reconnect (progress banks between passes).
+    private func finishDrain(completed: Bool, resumeBacklog: Bool) {
+        pendingContinuation = false
+        stopBatchQuietTimer()
+        if let burst = hypnogramAssembler.flush() {
+            persistHypnogramBurst(burst)
+        }
+        let rebootFullPullPending = drain.sawPreResumeData
+        commitResumeCursor(drainCompleted: completed)
+        logActivityEstimateSummary()
+        advance(.historyCursorAdvanced(cursor: historyCursor, moreData: false))
+        if rebootFullPullPending || resumeBacklog {
+            guard chainedDrainPasses < Self.maxChainedDrainPasses else {
+                log("Oura: drain pass cap (\(Self.maxChainedDrainPasses)) reached with work remaining - next periodic fetch / reconnect continues from the banked cursor")
+                return
+            }
+            chainedDrainPasses += 1
+            let why = rebootFullPullPending
+                ? "ring reboot detected - starting the honest full re-pull"
+                : "backlog remains after the deadline guard"
+            log("Oura: \(why); next drain pass in 5 s (\(chainedDrainPasses)/\(Self.maxChainedDrainPasses))")
+            let t = Timer.scheduledTimer(withTimeInterval: 5, repeats: false) { [weak self] _ in
+                Task { @MainActor in self?.fetchHistoryIfIdle() }
+            }
+            chainedDrainTimer = t
+        } else if completed {
+            chainedDrainPasses = 0   // healthy full completion re-arms the cap for future backlogs
+        }
+    }
+
+    private func restartBatchQuietTimer() {
+        batchQuietTimer?.invalidate()
+        let t = Timer.scheduledTimer(withTimeInterval: batchQuietInterval, repeats: false) { [weak self] _ in
+            Task { @MainActor in self?.continueDrainAfterQuiet() }
+        }
+        batchQuietTimer = t
+    }
+
+    private func stopBatchQuietTimer() {
+        batchQuietTimer?.invalidate()
+        batchQuietTimer = nil
     }
 
     /// Commit the durable resume cursor at drain end. Only a cursor that (a) moved forward, (b) is below
@@ -377,6 +522,111 @@ public final class OuraLiveSource: NSObject, ObservableObject {
         }
     }
 
+    /// The 0x49 window in `windows` whose envelope ring-time is nearest `rt` and within `tolerance` ticks,
+    /// or nil when none is in range. A drain can hold several windows (overnight + nap); each burst must
+    /// pair with its OWN, so match by ring-time proximity — keeping a single latest slot mis-anchored the
+    /// overnight burst to the nap's window when both finalized in one drain (2026-07-17 capture). Pure +
+    /// static so the pairing is unit-testable without a strap. Twin of Kotlin's closestSleepWindow049.
+    nonisolated static func closestSleepWindow049(
+        in windows: [(ringTimestamp: UInt32, startOffMin: Int, endOffMin: Int)],
+        toRingTimestamp rt: UInt32,
+        within tolerance: UInt32
+    ) -> (ringTimestamp: UInt32, startOffMin: Int, endOffMin: Int)? {
+        var best: (ringTimestamp: UInt32, startOffMin: Int, endOffMin: Int)?
+        var bestGap = UInt32.max
+        for w in windows {
+            let gap = w.ringTimestamp >= rt ? w.ringTimestamp - rt : rt - w.ringTimestamp
+            if gap <= tolerance, gap < bestGap {
+                bestGap = gap
+                best = w
+            }
+        }
+        return best
+    }
+
+    /// Persist a closed hypnogram burst with its RECONSTRUCTED time axis: codes laid backward at the
+    /// 30 s SleepNet epoch from the anchored burst END. The end is the matching 0x49 window's TRUE
+    /// sleep end (`event − end_offset` min, ringverse-validated within minutes of the wearer's report)
+    /// when one arrived in the same finalization burst; otherwise the last record's envelope time (the
+    /// analysis WRITE moment — observed trailing the real sleep end by 10–43 min, so 0x49 wins when
+    /// available). Logs the reconstructed window + stage minutes so a capture is self-evident.
+    private func persistHypnogramBurst(_ burst: OuraHypnogramBurst) {
+        guard let driver, burst.totalCodes > 0 else { return }
+        // HOLD-UNTIL-ANCHOR (same discipline as pendingAnchorEvents): the burst end IS the night's whole
+        // time axis, so guessing it from wall-clock would persist real stage codes at fabricated times.
+        // An unanchored burst is parked and re-tried when the 0x42 anchor lands; if the session ends
+        // without one it is DROPPED honestly — safe, because the resume cursor only advances on an
+        // anchored persist, so the ring re-serves the same records next drain.
+        guard let writeEnd = driver.unixSeconds(forRingTimestamp: burst.lastRingTimestamp) else {
+            pendingUnanchoredBursts.append(burst)
+            log("Oura: hypnogram burst (\(burst.totalCodes) codes) held - no anchor yet; reconstructs when the 0x42 lands")
+            return
+        }
+        var end = writeEnd
+        // Same-finalization match: the 0x49 and the phase records carry near-identical envelope ring-times
+        // (observed seconds apart). 6000 ticks = 10 min is generous while still never pairing a different
+        // night's summary. Pick the CLOSEST window, not merely the newest — a drain can hold an overnight
+        // AND a nap, and the newer (nap) window would otherwise mis-anchor the overnight burst.
+        if let w = Self.closestSleepWindow049(in: recentSleepWindows049, toRingTimestamp: burst.lastRingTimestamp, within: 6_000),
+           let eventUtc = driver.unixSeconds(forRingTimestamp: w.ringTimestamp) {
+            let sleepEnd = eventUtc - w.endOffMin * 60
+            // Sanity: the true end precedes the write and by a plausible margin (< 6 h).
+            if sleepEnd <= writeEnd, writeEnd - sleepEnd < 6 * 3600 {
+                end = sleepEnd
+                let fmt = Self.cursorDateFormatter
+                log("Oura: hypnogram burst end refined by 0x49 - SleepNet write \(fmt.string(from: Date(timeIntervalSince1970: TimeInterval(writeEnd)))) → true sleep end \(fmt.string(from: Date(timeIntervalSince1970: TimeInterval(sleepEnd)))) (event-\(w.endOffMin) min)")
+            }
+        }
+        if burst.hasNonMonotonicRingTimes {
+            // The layout trusts arrival order as the code sequence; a backwards envelope ring-time inside
+            // a burst is the one signal that assumption may not hold. Surface it, never fail silent.
+            log("Oura: hypnogram burst has NON-MONOTONIC envelope ring-times (\(burst.records.count) records) - sequence order taken from arrival order")
+        }
+        let laid = burst.codesWithTimes(endUnixSeconds: end)
+        for code in laid {
+            enqueue([.sleepPhase(code.phase)], ts: code.ts)
+        }
+        noteStoredHistoryRingTime(burst.lastRingTimestamp)   // banked → the resume cursor may advance
+        var mins = [0.0, 0.0, 0.0, 0.0]
+        for code in laid { mins[code.phase.stage.rawValue] += 0.5 }   // 30 s/code = 0.5 min
+        let fmt = Self.cursorDateFormatter
+        let startStr = fmt.string(from: Date(timeIntervalSince1970: TimeInterval(laid.first!.ts)))
+        let endStr = fmt.string(from: Date(timeIntervalSince1970: TimeInterval(end)))
+        log(String(format: "Oura: hypnogram reconstructed [%@ → %@, anchored] codes=%d deep/light/rem/awake=%.0f/%.0f/%.0f/%.0f min",
+                   startStr, endStr, burst.totalCodes, mins[0], mins[1], mins[2], mins[3]))
+        // Bank the SAME anchored codes as a ring-PROVIDED night: a CachedSleepSession with the
+        // `[{start,end,stage}]` stage breakdown, upserted under the ring's own deviceId so SleepMerge's
+        // imported-over-computed rule surfaces Oura's SleepNet staging as the night's stages (#325 persist).
+        // Reuses the anchored+0x49-refined `end` via `laid`, so the session end IS the true sleep end. The
+        // confirmation line makes the persist self-evident in the strap log for on-device validation.
+        if let session = OuraSleepSessionMapping.session(fromCodes: laid.map { (ts: $0.ts, stage: $0.phase.stage) }) {
+            persistSleepSession(session)
+            let effStr = session.efficiency.map { String(format: "%.0f%%", $0 * 100) } ?? "n/a"
+            log("Oura: sleep session persisted [\(startStr) → \(endStr)] eff=\(effStr) → \(deviceId) (ring-provided night; wins merge over computed)")
+        }
+    }
+
+    /// Re-try bursts parked while unanchored (called right after the 0x42 anchor lands, alongside
+    /// drainPendingAnchorEvents). A burst that still cannot resolve goes back on the pending list.
+    private func drainPendingHypnogramBursts() {
+        guard !pendingUnanchoredBursts.isEmpty else { return }
+        let held = pendingUnanchoredBursts
+        pendingUnanchoredBursts.removeAll()
+        for burst in held {
+            persistHypnogramBurst(burst)
+        }
+    }
+
+    /// Teardown for bursts that never anchored this session: DROP them with an honest log instead of
+    /// persisting a wall-clock-guessed time axis. Nothing is lost — the resume cursor only advances on
+    /// an anchored persist, so the ring re-serves the same records on the next drain.
+    private func dropUnanchoredHypnogramBursts() {
+        guard !pendingUnanchoredBursts.isEmpty else { return }
+        let codes = pendingUnanchoredBursts.reduce(0) { $0 + $1.totalCodes }
+        log("Oura: dropping \(pendingUnanchoredBursts.count) unanchored hypnogram burst(s) (\(codes) codes) - no anchor this session; cursor did not advance, so they re-arrive next drain")
+        pendingUnanchoredBursts.removeAll()
+    }
+
     /// Record a STORED history sample's ring-time toward the resume cursor (open_oura `nextEventToSync`).
     /// Called only where a sample resolved a REAL anchored time and was enqueued — never for a no-anchor
     /// wall-clock fallback. Also flags a reboot: a real sample older than where we sought this fetch.
@@ -392,6 +642,18 @@ public final class OuraLiveSource: NSObject, ObservableObject {
     /// reports the ring's real per-sample spacing so `activityEpochSeconds` can be pinned. Never
     /// persisted, never scored, never a step count.
     private func logActivityEstimateSummary() {
+        // 0x71 fixture-capture roll-up (#287): even when the per-record cap truncated the stream, the
+        // session total + observed payload lengths are what a decoder verification needs to plan with.
+        if greenIbiAmpCount > 0 {
+            log("Oura: 0x71 green_ibi_amp capture - \(greenIbiAmpCount) record(s) this session, payload lengths \(greenIbiAmpLengths.sorted()) (fixture material, #287)")
+        }
+        // Sleep-phase cadence (investigation): pins the ring's per-code phase epoch from the stream,
+        // exactly like the activity 60 s pin. Logged whenever any hypnogram records arrived this drain.
+        if !phaseCadenceObs.isEmpty {
+            let sorted = phaseCadenceObs.sorted()
+            log(String(format: "Oura: sleep-phase cadence self-check - median %.1fs/code over %d gaps",
+                       sorted[sorted.count / 2], phaseCadenceObs.count))
+        }
         guard !activityMETByDay.isEmpty else { return }
         if !activityCadenceObs.isEmpty {
             let sorted = activityCadenceObs.sorted()
@@ -448,6 +710,7 @@ public final class OuraLiveSource: NSObject, ObservableObject {
                 ringGen: OuraRingGen,
                 authKey: @escaping () -> Data?,
                 persist: @escaping (Streams) -> Void = { _ in },
+                persistSleepSession: @escaping (CachedSleepSession) -> Void = { _ in },
                 log: @escaping (String) -> Void = { _ in },
                 onBattery: @escaping (Int) -> Void = { _ in },
                 feedsLive: Bool = true,
@@ -457,6 +720,7 @@ public final class OuraLiveSource: NSObject, ObservableObject {
         self.ringGen = ringGen
         self.authKey = authKey
         self.persist = persist
+        self.persistSleepSession = persistSleepSession
         self.log = log
         self.onBattery = onBattery
         self.feedsLive = feedsLive
@@ -537,8 +801,13 @@ public final class OuraLiveSource: NSObject, ObservableObject {
         peripheral = nil
         writeCharacteristic = nil
         // Drain BEFORE driver.stop() clears its anchor, so a pending event still gets a real anchored
-        // time if one exists rather than always falling back to wall-clock at teardown.
+        // time if one exists rather than always falling back to wall-clock at teardown. Same for a
+        // hypnogram burst still accumulating (e.g. the session ended mid-drain).
+        if let burst = hypnogramAssembler.flush() {
+            persistHypnogramBurst(burst)
+        }
         drainPendingAnchorEvents()
+        dropUnanchoredHypnogramBursts()   // never wall-clock a night's time axis; they re-arrive next drain
         driver?.stop()
         driver = nil
         reassembler.reset()
@@ -550,13 +819,25 @@ public final class OuraLiveSource: NSObject, ObservableObject {
         loggedAnchor = false
         loggedTierBKinds.removeAll()
         loggedFeatureStatuses.removeAll()
+        greenIbiAmpCount = 0
+        greenIbiAmpLengths.removeAll()
+        recentSleepWindows049.removeAll()
         activityMETByDay.removeAll()
         activityCadenceObs.removeAll()
         lastActivityUtc = nil
         lastActivitySampleCount = 0
+        phaseCadenceObs.removeAll()
+        lastPhaseUtc = nil
+        lastPhaseCodeCount = 0
         drain.reset()
         resumeCursorAtFetchStart = 0
         drainStartedAt = nil
+        lastRequestCursor = 0
+        pendingContinuation = false
+        stopBatchQuietTimer()
+        chainedDrainPasses = 0
+        chainedDrainTimer?.invalidate()
+        chainedDrainTimer = nil
         reachedStreaming = false
         pendingInstallKey = nil
         adoptPhase = .idle
@@ -609,6 +890,13 @@ public final class OuraLiveSource: NSObject, ObservableObject {
                 log("Oura: live-HR enabled - streaming HR / IBI")
                 startReengageTimer()
                 startHistoryFetchTimer()
+                // §5.3 step 1 / open_oura sync recipe: hand the ring the current UTC BEFORE draining
+                // history so it can emit a usable 0x42 time-sync anchor (§5.5). Without this a short
+                // resume drain carries NO 0x42 at all — every fetched record stays "[no anchor yet]",
+                // the night's hypnogram gets wall-clock-stamped at connect time, and the resume cursor
+                // can never commit (observed 2026-07-12: 4 connects re-dumped the same window). Sent
+                // ONCE per session, before the first fetch; the ack-fetch loop never re-sends it.
+                write([OuraCommands.syncTime(unixSeconds: Int(Date().timeIntervalSince1970))])
                 fetchHistoryIfIdle()   // pull last night's banked temp/SpO2/HRV/sleep-phase right away
                 write([OuraCommands.getBattery()])   // ask once HR streams; the 0x0D reply routes to onBattery
                 // Read-only diagnostic: ask the ring its SpO2 / real-steps feature status once, so a capture
@@ -728,6 +1016,21 @@ public final class OuraLiveSource: NSObject, ObservableObject {
 
     // MARK: - Live ingest
 
+    /// Fold TLV records decoded from the notify stream — these are HISTORY-LOG records (the live-HR path
+    /// is `ingestLiveHRPush`): every envelope ring-time advances the drain's in-session continuation
+    /// cursor (open_oura `drain_events` tracks the max timestamp of EVERY batch event), and while a
+    /// continuation is pending the batch-quiet window stays open as long as records keep arriving.
+    private func ingestHistory(_ events: [OuraEvent]) {
+        guard !events.isEmpty else { return }
+        for e in events {
+            if let rt = e.envelopeRingTimestamp {
+                drain.noteSeenRingTime(rt)
+            }
+        }
+        if pendingContinuation { restartBatchQuietTimer() }
+        ingest(events)
+    }
+
     /// Fold decoded events into live state (HR / R-R only - skin temp and SpO2 are SLEEP-ONLY on this
     /// hardware, never a live readout) + the persist buffer. Genuinely-live pushes (HR/battery) are stamped
     /// at wall-clock arrival time, since they really are "now". Ring-time-carrying events (IBI, temp, SpO2,
@@ -740,6 +1043,35 @@ public final class OuraLiveSource: NSObject, ObservableObject {
     private func ingest(_ events: [OuraEvent]) {
         guard !events.isEmpty, let driver else { return }
         let now = Int(Date().timeIntervalSince1970)
+        // Sleep-phase record visibility (investigation): one 0x4B/0x4E/0x5A record's codes arrive as one
+        // events array; log it whole (time + count + histogram) and feed the per-code cadence observer.
+        let phases = events.compactMap { e -> OuraSleepPhase? in
+            if case .sleepPhase(let v) = e { return v } else { return nil }
+        }
+        if let firstPhase = phases.first {
+            let utc = driver.unixSeconds(forRingTimestamp: firstPhase.ringTimestamp)
+            let when = utc.map { Self.cursorDateFormatter.string(from: Date(timeIntervalSince1970: TimeInterval($0))) } ?? "no anchor yet"
+            var counts = [0, 0, 0, 0]
+            for p in phases { counts[p.stage.rawValue] += 1 }
+            log("Oura: sleep-phase record [\(when)] codes=\(phases.count) deep/light/rem/awake=\(counts[0])/\(counts[1])/\(counts[2])/\(counts[3])")
+            if let utc {
+                if let prev = lastPhaseUtc, lastPhaseCodeCount > 0, utc > prev {
+                    let perCode = Double(utc - prev) / Double(lastPhaseCodeCount)
+                    // Keep only plausible epoch spacings; a gap across sessions/naps is not a cadence.
+                    if perCode >= 5, perCode <= 3600 { phaseCadenceObs.append(perCode) }
+                }
+                lastPhaseUtc = utc
+                lastPhaseCodeCount = phases.count
+            }
+            // TIME-AXIS RECONSTRUCTION: the ring writes a night's whole hypnogram in one burst AFTER
+            // wake, every record stamped with the WRITE moment — so the codes are accumulated here and
+            // laid out backward (30 s/code from the anchored burst end) when the burst closes, instead
+            // of being persisted at the (meaningless for sleep) envelope time. A returned burst means a
+            // ring-time gap just closed the previous one.
+            if let closed = hypnogramAssembler.feed(ringTimestamp: firstPhase.ringTimestamp, phases: phases) {
+                persistHypnogramBurst(closed)
+            }
+        }
         for e in events {
             switch e {
             case .hr(let hr):
@@ -825,13 +1157,11 @@ public final class OuraLiveSource: NSObject, ObservableObject {
                     pendingAnchorEvents.append((e, v.ringTimestamp))
                 }
 
-            case .sleepPhase(let v):
-                if let ts = driver.unixSeconds(forRingTimestamp: v.ringTimestamp) {
-                    enqueue([e], ts: ts)
-                    noteStoredHistoryRingTime(v.ringTimestamp)
-                } else {
-                    pendingAnchorEvents.append((e, v.ringTimestamp))
-                }
+            case .sleepPhase:
+                // Handled at the record level above (hypnogramAssembler): the envelope time marks the
+                // analysis WRITE moment, not the sleep, so per-code enqueue here would mis-place the
+                // night. Codes persist when the burst closes (persistHypnogramBurst).
+                break
 
             case .timeSync(let ts):
                 // #91: a 0x42 whose epoch is outside the 2020–2035 plausibility window is silently ignored,
@@ -850,6 +1180,7 @@ public final class OuraLiveSource: NSObject, ObservableObject {
                 // The 0x42 time-sync can arrive ANYWHERE in a history-fetch stream, not necessarily first.
                 // Anything parked while unanchored gets its real time retroactively the moment an anchor lands.
                 drainPendingAnchorEvents()
+                drainPendingHypnogramBursts()
 
             case .rtcBeacon(let r):
                 // #91: the 0x85 beacon is the SECONDARY anchor (fills the gap only until a 0x42 arrives). A
@@ -860,12 +1191,68 @@ public final class OuraLiveSource: NSObject, ObservableObject {
                 }
 
             case .tierB(let summary):
-                // INVESTIGATION ONLY (real_steps / activity-summary / sleep-summary / smoothed-SpO2,
-                // OURA_PROTOCOL.md s7.3 Tier B; PR #960). Logged ONCE PER KIND with the raw bytes so we
-                // can see whether the ring sends these tags at all and collect capture material - e.g.
-                // real_steps 0x7E/0x7F is server-flag-gated OFF by default ([open_oura-feat]), so its
-                // continued absence here is the ring's doing, not a decode gap. Never persisted, never
-                // scored (OuraStreamMapping drops .tierB unconditionally regardless of this log).
+                // 0x71 green_ibi_amp FIXTURE CAPTURE (upstream #287/#333): unlike the other Tier-B tags,
+                // EVERY occurrence is logged (up to a flood cap) with its anchored time, envelope rt,
+                // length, and full raw bytes — a verified decoder needs several real payloads (5 IBI
+                // deltas + 6 amplitudes + [2:0] shift per open_oura decode_green_ibi_and_amp), and the
+                // anchored time is what aligns each record with concurrent live-HR R-R (the ground truth).
+                // Never persisted, never scored (OuraStreamMapping drops .tierB unconditionally).
+                if summary.kind == "green_ibi_amp" {
+                    greenIbiAmpCount += 1
+                    greenIbiAmpLengths.insert(summary.rawPayload.count)
+                    if greenIbiAmpCount <= Self.greenIbiAmpLogCap {
+                        let utc = driver.unixSeconds(forRingTimestamp: summary.ringTimestamp)
+                        let when = utc.map { Self.cursorDateFormatter.string(from: Date(timeIntervalSince1970: TimeInterval($0))) } ?? "no anchor yet"
+                        let hex = summary.rawPayload.map { String(format: "%02x", $0) }.joined(separator: " ")
+                        var line = "Oura: 0x71 green_ibi_amp #\(greenIbiAmpCount) [\(when)] rt=\(summary.ringTimestamp) len=\(summary.rawPayload.count) raw: \(hex)"
+                        // Side-by-side CANDIDATE decode (ringverse p_green_ibi_and_amp @0x503960, Tier-B):
+                        // printed for the R-R cross-check only, never stored. nil = gate failed (length /
+                        // reserved bit), which is itself capture evidence.
+                        if let cand = OuraDecoders.decodeGreenIBIAmpCandidate(payload: summary.rawPayload,
+                                                                              ringTimestamp: summary.ringTimestamp) {
+                            let ibis = cand.samples.dropFirst().map { String($0.ibiMs) }.joined(separator: ",")
+                            let amps = cand.samples.map { String($0.amplitude ?? 0) }.joined(separator: ",")
+                            line += " | candidate [ringverse]: shift=\(cand.shift) ibis_ms=[\(ibis)] amps=[\(amps)]"
+                        } else {
+                            line += " | candidate [ringverse]: GATE FAILED (len != 14 or reserved bit set)"
+                        }
+                        log(line)
+                        if greenIbiAmpCount == Self.greenIbiAmpLogCap {
+                            log("Oura: 0x71 log cap (\(Self.greenIbiAmpLogCap)) reached - further records counted, summarized at drain end")
+                        }
+                    }
+                    break
+                }
+                // 0x49 sleep_summary_1 window candidate (ringverse, VALIDATED against our own samples:
+                // 600/10 on the 2026-07-11→12 night = write−600 min → write−10 min = 23:30→09:20, matching
+                // the reconstructed hypnogram): both uint16 LE fields are MINUTES BEFORE the event time —
+                // start_offset / end_offset of the ring's tracked sleep window. Logged EVERY occurrence
+                // (one per night) as an independent cross-check of the burst reconstruction axis. Tier-B:
+                // log-only, never persisted. Falls through to the once-per-kind raw line below.
+                if summary.tag == 0x49, summary.rawPayload.count >= 4 {
+                    let startOff = Int(summary.rawPayload[0]) | (Int(summary.rawPayload[1]) << 8)
+                    let endOff = Int(summary.rawPayload[2]) | (Int(summary.rawPayload[3]) << 8)
+                    // Stash for the hypnogram burst of the SAME finalization (it follows right after):
+                    // its end anchors at the TRUE sleep end (event − end_offset), not the write moment.
+                    // Append (don't overwrite): a drain may carry an overnight AND a nap window, and each
+                    // burst pairs with its OWN by ring-time proximity. Bounded — oldest dropped past the cap.
+                    recentSleepWindows049.append((summary.ringTimestamp, startOff, endOff))
+                    if recentSleepWindows049.count > Self.recentSleepWindows049Cap {
+                        recentSleepWindows049.removeFirst(recentSleepWindows049.count - Self.recentSleepWindows049Cap)
+                    }
+                    if let utc = driver.unixSeconds(forRingTimestamp: summary.ringTimestamp) {
+                        let startStr = Self.cursorDateFormatter.string(from: Date(timeIntervalSince1970: TimeInterval(utc - startOff * 60)))
+                        let endStr = Self.cursorDateFormatter.string(from: Date(timeIntervalSince1970: TimeInterval(utc - endOff * 60)))
+                        log("Oura: 0x49 sleep window candidate [ringverse] \(startStr) -> \(endStr) (event-\(startOff)/-\(endOff) min)")
+                    } else {
+                        log("Oura: 0x49 sleep window candidate [ringverse] offsets start-\(startOff)min end-\(endOff)min [no anchor yet]")
+                    }
+                }
+                // Other Tier-B tags (real_steps / activity-summary / sleep-summary / smoothed-SpO2,
+                // OURA_PROTOCOL.md s7.3; PR #960): logged ONCE PER KIND with the raw bytes so we can see
+                // whether the ring sends these tags at all and collect capture material - e.g. real_steps
+                // 0x7E/0x7F is server-flag-gated OFF by default ([open_oura-feat]), so its continued
+                // absence here is the ring's doing, not a decode gap.
                 if !loggedTierBKinds.contains(summary.kind) {
                     loggedTierBKinds.insert(summary.kind)
                     let hex = summary.rawPayload.map { String(format: "%02x", $0) }.joined(separator: " ")
@@ -972,8 +1359,11 @@ public final class OuraLiveSource: NSObject, ObservableObject {
     }
 
     /// Re-send the live-HR enable+subscribe so the ~20 s auto-revert never silently stops the stream.
+    /// Skipped while a history drain is in flight: the Oura app never runs live mode during a sync, and
+    /// interleaving enable writes with the batch stream is off-model noise (live HR resumes on the next
+    /// 15 s tick after the drain returns to `.streaming`).
     private func reengageLiveHR() {
-        guard let driver, reachedStreaming else { return }
+        guard let driver, reachedStreaming, driver.phase != .fetchingHistory else { return }
         write(driver.reengageLiveHRCommands())
         // Live-HR watchdog: if the stream has gone silent past the grace window while we were WORN, the
         // ring came off the finger (no "removed" event exists) -> NOT WORN. Only meaningful once we have
@@ -1110,7 +1500,12 @@ extension OuraLiveSource: @preconcurrency CBCentralManagerDelegate {
         loggedAnchor = false
         loggedTierBKinds.removeAll()
         loggedFeatureStatuses.removeAll()
+        greenIbiAmpCount = 0
+        greenIbiAmpLengths.removeAll()
+        recentSleepWindows049.removeAll()
         pendingAnchorEvents.removeAll()   // a fresh session must never replay a stale-anchor guess
+        hypnogramAssembler.reset()        // ditto for a half-accumulated burst from a dead session
+        pendingUnanchoredBursts.removeAll()
         pendingInstallKey = nil
         adoptPhase = .idle
         reassembler.reset()
@@ -1119,6 +1514,12 @@ extension OuraLiveSource: @preconcurrency CBCentralManagerDelegate {
         drain.reset()
         resumeCursorAtFetchStart = 0
         drainStartedAt = nil
+        lastRequestCursor = 0
+        pendingContinuation = false
+        stopBatchQuietTimer()
+        chainedDrainPasses = 0
+        chainedDrainTimer?.invalidate()
+        chainedDrainTimer = nil
         // Resume the GetEvents cursor from where the LAST connection to this ring left off (s5.1/5.3), so
         // a routine reconnect doesn't re-fetch the ring's entire banked history every time. A persisted
         // value above the plausibility ceiling is garbage banked by a pre-fix build (a bytes_left count or
@@ -1158,8 +1559,18 @@ extension OuraLiveSource: @preconcurrency CBCentralManagerDelegate {
         }
         stopReengageTimer()
         stopHistoryFetchTimer()
-        // Drain BEFORE driver.stop() clears its anchor (same reasoning as stop()).
+        stopBatchQuietTimer()
+        pendingContinuation = false
+        chainedDrainPasses = 0
+        chainedDrainTimer?.invalidate()
+        chainedDrainTimer = nil
+        // Drain BEFORE driver.stop() clears its anchor (same reasoning as stop()); a hypnogram burst
+        // still accumulating flushes first for the same reason.
+        if let burst = hypnogramAssembler.flush() {
+            persistHypnogramBurst(burst)
+        }
         drainPendingAnchorEvents()
+        dropUnanchoredHypnogramBursts()   // never wall-clock a night's time axis; they re-arrive next drain
         driver?.stop()
         driver = nil
         reassembler.reset()
@@ -1172,10 +1583,16 @@ extension OuraLiveSource: @preconcurrency CBCentralManagerDelegate {
         loggedAnchor = false
         loggedTierBKinds.removeAll()
         loggedFeatureStatuses.removeAll()
+        greenIbiAmpCount = 0
+        greenIbiAmpLengths.removeAll()
+        recentSleepWindows049.removeAll()
         activityMETByDay.removeAll()
         activityCadenceObs.removeAll()
         lastActivityUtc = nil
         lastActivitySampleCount = 0
+        phaseCadenceObs.removeAll()
+        lastPhaseUtc = nil
+        lastPhaseCodeCount = 0
         reachedStreaming = false
         pendingInstallKey = nil
         // A disconnect MID-install is an honest failure (no ack came); a disconnect after streaming leaves
@@ -1285,6 +1702,15 @@ extension OuraLiveSource: @preconcurrency CBPeripheralDelegate {
                 handleHistorySummary(summary)
             }
         }
+        // The `0x13` SyncTime response is ALSO an outer frame (ringverse BLE.md), peeked the same
+        // non-destructive way: it carries the ring's CURRENT clock counter, which paired with the host
+        // wall-clock right now is a DETERMINISTIC anchor — the 0x42 record is only logged when the ring
+        // actually adjusts its clock, so an already-synced ring can serve a whole drain with no anchor
+        // (observed 2026-07-13: a full night parked unanchored, cursor unable to advance).
+        if let syncFrame = frames.first(where: { $0.op == OuraFraming.syncTimeResponseOp }),
+           let resp = OuraFraming.parseSyncTimeResponse(syncFrame.body) {
+            handleSyncTimeResponse(resp)
+        }
         // The `0x0D` GetBattery response is ALSO an outer frame (never a TLV record, s6.10), detected the
         // same non-destructive way as the 0x11 summary: its op is below the event-tag range (>= 0x41), so
         // it round-trips safely through the TLV decoder as an "unknown tag" no-op if left unfiltered. Routed
@@ -1303,12 +1729,37 @@ extension OuraLiveSource: @preconcurrency CBPeripheralDelegate {
             let tlvBytes = frames.filter { $0.op != OuraFraming.secureSessionOp && $0.op != Self.setAuthKeyRespOp }
                                  .flatMap { [$0.op, UInt8($0.body.count)] + $0.body }
             if !tlvBytes.isEmpty {
-                ingest(driver.ingest(notification: tlvBytes, reassembler: reassembler))
+                ingestHistory(driver.ingest(notification: tlvBytes, reassembler: reassembler))
             }
             return
         }
         // No secure frame in this notification: treat the whole value as TLV record bytes.
-        ingest(driver.ingest(notification: bytes, reassembler: reassembler))
+        ingestHistory(driver.ingest(notification: bytes, reassembler: reassembler))
+    }
+
+    /// Anchor from the 0x13 SyncTime response (ringverse BLE.md `13 05 <device_ts:4LE> <status:1>`):
+    /// the ring's clock counter at the moment it processed our SyncTime, paired with the host wall-clock
+    /// at receipt. The tick unit is disambiguated against the persisted resume cursor
+    /// (OuraDriver.syncTimeAnchorCandidate — raw ticks vs seconds×10, exactly one must be plausible);
+    /// no unambiguous reading → log the raw value for investigation and adopt NOTHING (an honest missing
+    /// anchor beats a guessed one). On success everything parked while unanchored resolves immediately.
+    private func handleSyncTimeResponse(_ resp: (deviceTimestamp: UInt32, status: UInt8)) {
+        guard let driver else { return }
+        let now = Int64(Date().timeIntervalSince1970)
+        let raw = String(format: "0x%08x", resp.deviceTimestamp)
+        if let rt = OuraDriver.syncTimeAnchorCandidate(responseValue: resp.deviceTimestamp,
+                                                       historyCursor: historyCursor),
+           driver.adoptSyncTimeAnchor(ringTimestamp: rt, unixSeconds: now) {
+            let unit = rt == resp.deviceTimestamp ? "ticks" : "seconds x10"
+            if !loggedAnchor {
+                loggedAnchor = true
+                log("Oura: UTC anchor from SyncTime response (0x13) - device rt \(rt) [\(unit), raw \(raw), status \(resp.status)] = now; no 0x42 needed this session")
+            }
+            drainPendingAnchorEvents()
+            drainPendingHypnogramBursts()
+        } else {
+            log("Oura: SyncTime response (0x13) raw \(raw) status \(resp.status) - no unambiguous tick reading vs cursor \(historyCursor); anchor NOT adopted (investigation)")
+        }
     }
 
     /// Act on what the driver resolved a 0x2F secure sub-frame to.

--- a/Strand/BLE/SourceCoordinator.swift
+++ b/Strand/BLE/SourceCoordinator.swift
@@ -356,6 +356,12 @@ final class SourceCoordinator: ObservableObject {
             persist: { [storeHandle] streams in
                 Task { if let store = await storeHandle() { _ = try? await store.insert(streams, deviceId: id) } }
             },
+            persistSleepSession: { [storeHandle] session in
+                // The ring-PROVIDED hypnogram night, upserted under the ring's OWN id (the imported/measured
+                // side, NOT the "-noop" computed sibling) so SleepMerge's imported-over-computed rule makes
+                // Oura's SleepNet staging win over NOOP's sparse-motion computed night (#325).
+                Task { if let store = await storeHandle() { _ = try? await store.upsertSleepSessions([session], deviceId: id) } }
+            },
             log: straplog,
             onBattery: { [live] pct in live.setBattery(Double(pct)) },
             adoptIntent: adoptIntent)

--- a/Strand/Data/Repository.swift
+++ b/Strand/Data/Repository.swift
@@ -156,6 +156,14 @@ final class Repository: ObservableObject {
     var computedReadIds: [String] {
         computedDeviceId == canonicalComputedId ? [computedDeviceId] : [computedDeviceId, canonicalComputedId]
     }
+
+    /// True when the ACTIVE strap is an Oura ring, resolved from its registry id prefix against the canonical
+    /// brand table (`DeviceBrandCatalog.idPrefix`) rather than an ad-hoc "oura" literal. The device registry
+    /// mints every non-WHOOP id as "<idPrefix>-<uuid>", so the stored id's prefix IS its brand key. Read/UI
+    /// side only — it lets the sleep surfaces name an Oura night's provenance "Oura" (a ring-PROVIDED
+    /// hypnogram) instead of the generic "On-device", and flag the split as the ring's RAW on-device stages.
+    /// Not a stored value and never crosses `.noopbak`, so no Android twin is required.
+    var activeDeviceIsOura: Bool { DeviceBrandCatalog.isOura(deviceId) }
     private var store: WhoopStore?
 
     /// Daily metrics (recovery/strain/sleep/HRV/RHR…) over the recent window, oldest→newest.

--- a/Strand/Screens/SleepView.swift
+++ b/Strand/Screens/SleepView.swift
@@ -429,7 +429,7 @@ struct SleepView: View {
                     .padding(.vertical, NoopMetrics.space5)
                     .accessibilityElement(children: .combine)
                 }
-                SourceBadge(score != nil ? heroSource(for: night) : "On-device", tint: StrandPalette.restColor)
+                SourceBadge(score != nil ? heroSource(for: night) : (repo.activeDeviceIsOura ? "Oura" : "On-device"), tint: StrandPalette.restColor)
             }
             .padding(NoopMetrics.cardInnerPadding + NoopMetrics.space1)
             .frame(maxWidth: .infinity)
@@ -448,13 +448,14 @@ struct SleepView: View {
         }
     }
 
-    /// Whether a SPECIFIC night's sleep-performance score is WHOOP's own imported figure or NOOP's
-    /// on-device approximation — so the hero is honest about provenance, like Today's badges. Keyed
-    /// by the night's wake-day (matching `performanceScore(for:)`) so a navigated night's badge
-    /// tracks ITS OWN score's provenance, not last night's. LocalizedStringKey to match `SourceBadge`.
+    /// Whether a SPECIFIC night's sleep-performance score is WHOOP's own imported figure, an Oura
+    /// ring-provided figure, or NOOP's on-device approximation — so the hero is honest about provenance,
+    /// like Today's badges. Keyed by the night's wake-day (matching `performanceScore(for:)`) so a
+    /// navigated night's badge tracks ITS OWN score's provenance, not last night's.
     private func heroSource(for night: Night) -> LocalizedStringKey {
         let wakeDay = Repository.localDayKey(Date(timeIntervalSince1970: TimeInterval(night.session.endTs)))
-        return repo.importedSleep[wakeDay]?.performancePct != nil ? "Whoop" : "On-device"
+        if repo.importedSleep[wakeDay]?.performancePct != nil { return "Whoop" }
+        return repo.activeDeviceIsOura ? "Oura" : "On-device"
     }
 
     // MARK: - Provenance for the displayed night (COMPONENT 4, spec 2026-06-20)
@@ -468,7 +469,13 @@ struct SleepView: View {
     /// carries no sleep into `importedSleep`, so the sleep merge winner is only ever Whoop vs on-device. (C4)
     private func nightSource(_ night: Night) -> String {
         let wakeDay = Repository.localDayKey(Date(timeIntervalSince1970: TimeInterval(night.session.endTs)))
-        return repo.importedSleep[wakeDay] != nil ? String(localized: "Whoop") : String(localized: "On-device")
+        if repo.importedSleep[wakeDay] != nil { return String(localized: "Whoop") }
+        // An Oura ring PROVIDES the night's stages (its own SleepNet hypnogram, banked as the imported
+        // session that wins the merge), so name it "Oura" — not the generic "On-device" that implies a
+        // NOOP computation. WHOOP import still wins above; only a night surfaced under a live Oura strap
+        // reaches here as "Oura".
+        if repo.activeDeviceIsOura { return String(localized: "Oura") }
+        return String(localized: "On-device")
     }
 
     // MARK: - 0b. SLEEP MARKS — tap to log "going to sleep" / "I'm awake" (#461, Phase 1)
@@ -666,8 +673,14 @@ struct SleepView: View {
     private func stageCard(_ night: Night, intervals: [SleepInterval]) -> some View {
         let s = night.stages
         let isPersisted = (night.realSegments?.count ?? 0) >= 2
+        // An Oura night's stages are the ring's RAW on-device SleepNet classification (decoded off the 0x49
+        // phase stream), NOT a NOOP approximation — so it gets its own honest caption instead of the
+        // "stages approximate (on-device)" one that describes NOOP's own sparse-motion staging.
+        let stageCaption = repo.activeDeviceIsOura
+            ? String(localized: "raw on-device stages")
+            : String(localized: "stages approximate (on-device)")
         let subtitle = isPersisted
-            ? String(localized: "\(durationText(night.timeInBed)) in bed · \(efficiencyText(night)) efficiency · stages approximate (on-device)")
+            ? String(localized: "\(durationText(night.timeInBed)) in bed · \(efficiencyText(night)) efficiency · \(stageCaption)")
             : String(localized: "\(durationText(night.timeInBed)) in bed · \(efficiencyText(night)) efficiency")
         VStack(alignment: .leading, spacing: NoopMetrics.space2) {
             if intervals.count >= 2 {
@@ -710,6 +723,12 @@ struct SleepView: View {
             // SAME engine call the daily pass uses — so the badge can never disagree with the score.
             if stageStagingIsLowConfidence(night) {
                 stageLowConfidenceNote
+            }
+            // For an Oura-provided night, say plainly that this split is the ring's RAW on-device
+            // classification — so the larger Awake / smaller Deep+REM here isn't misread as the polished
+            // numbers the Oura app shows for the same night (the app post-processes the same stream).
+            if repo.activeDeviceIsOura {
+                ouraRawStagesNote
             }
         }
         // WHOOP top-chart data (ryanAtriumAi #988): 1-min sleeping-HR buckets for THIS night, reloaded
@@ -804,6 +823,23 @@ struct SleepView: View {
         .padding(.horizontal, 2)
         .accessibilityElement(children: .combine)
         .accessibilityLabel("Low confidence staging. This night scored high efficiency but very little deep or REM, more likely an estimate miss than a real restorative shortfall.")
+    }
+
+    /// Honest caveat for an Oura-provided night: the stage split shown here is the ring's RAW on-device
+    /// SleepNet classification, read straight off the BLE phase stream — NOT the adjusted stages the Oura
+    /// app displays. The app post-processes the same night, so its Deep/REM run higher and its Awake lower;
+    /// cross-checks put our Awake well above the app's. Surfaced so the breakdown isn't taken for the app's.
+    private var ouraRawStagesNote: some View {
+        HStack(alignment: .top, spacing: 8) {
+            SourceBadge("Raw on-device stages", tint: StrandPalette.restColor)
+            Text("This split is the ring's raw on-device classification read over Bluetooth, not the adjusted stages the Oura app shows. Expect more Awake and less Deep/REM here than in the Oura app for the same night.")
+                .font(StrandFont.footnote)
+                .foregroundStyle(StrandPalette.textTertiary)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .padding(.horizontal, 2)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("Raw on-device stages. This split is the ring's raw on-device classification read over Bluetooth, not the adjusted stages the Oura app shows. Expect more awake and less deep or REM here than in the Oura app for the same night.")
     }
 
     /// The night's clock window — when you fell asleep and when you woke — as its own clearly

--- a/StrandTests/OuraSleepWindowPairingTests.swift
+++ b/StrandTests/OuraSleepWindowPairingTests.swift
@@ -1,0 +1,60 @@
+import XCTest
+@testable import Strand
+
+/// Regression for the 2026-07-17 capture: an overnight hypnogram burst and a ~3PM nap burst finalized in
+/// the SAME history drain. The old single-slot `lastSleepWindow049` let the nap's 0x49 window overwrite
+/// the overnight's before the overnight burst persisted, so the overnight fell back to its SleepNet WRITE
+/// time (10:58, ~4 h after the true 07:00 sleep end) instead of the 0x49-refined end. The fix keeps a
+/// COLLECTION and pairs each burst with the CLOSEST window by ring-time — these tests pin that picker.
+final class OuraSleepWindowPairingTests: XCTestCase {
+
+    // Ring-time is deciseconds; 6000 ticks = 10 min is the pairing tolerance. Two windows a night apart.
+    private let overnight: (ringTimestamp: UInt32, startOffMin: Int, endOffMin: Int) = (8_400_000, 778, 238)
+    private let nap: (ringTimestamp: UInt32, startOffMin: Int, endOffMin: Int) = (8_512_000, 44, 34)
+
+    // THE bug: with both windows stashed (nap appended LAST), the overnight burst must still pick the
+    // overnight window, not the most-recent (nap) one.
+    func testOvernightBurstPicksOvernightWindowDespiteLaterNap() {
+        let windows = [overnight, nap]
+        let overnightBurstRt: UInt32 = overnight.ringTimestamp + 50   // 5 s after the 0x49 event
+        let picked = OuraLiveSource.closestSleepWindow049(in: windows, toRingTimestamp: overnightBurstRt, within: 6_000)
+        XCTAssertEqual(picked?.ringTimestamp, overnight.ringTimestamp)
+        XCTAssertEqual(picked?.endOffMin, 238)
+    }
+
+    // The nap burst still pairs with the nap window.
+    func testNapBurstPicksNapWindow() {
+        let windows = [overnight, nap]
+        let napBurstRt: UInt32 = nap.ringTimestamp + 30
+        let picked = OuraLiveSource.closestSleepWindow049(in: windows, toRingTimestamp: napBurstRt, within: 6_000)
+        XCTAssertEqual(picked?.ringTimestamp, nap.ringTimestamp)
+        XCTAssertEqual(picked?.endOffMin, 34)
+    }
+
+    // A burst with no window within tolerance gets nil (caller keeps the write-time fallback) — never a
+    // far-off mis-pair. This is the honest degradation the old code lost when it grabbed the last slot.
+    func testNoWindowInRangeReturnsNil() {
+        let windows = [nap]   // only the nap stashed; an overnight burst is ~3 h away
+        let overnightBurstRt: UInt32 = overnight.ringTimestamp + 50
+        XCTAssertNil(OuraLiveSource.closestSleepWindow049(in: windows, toRingTimestamp: overnightBurstRt, within: 6_000))
+    }
+
+    // Closest wins when two windows both sit within tolerance.
+    func testClosestOfTwoInRangeWins() {
+        let near: (ringTimestamp: UInt32, startOffMin: Int, endOffMin: Int) = (10_000, 600, 10)
+        let far: (ringTimestamp: UInt32, startOffMin: Int, endOffMin: Int) = (13_000, 600, 20)
+        let picked = OuraLiveSource.closestSleepWindow049(in: [far, near], toRingTimestamp: 10_500, within: 6_000)
+        XCTAssertEqual(picked?.endOffMin, 10)   // near (gap 500) beats far (gap 2500)
+    }
+
+    // Exact tolerance boundary is inclusive; one past it is excluded.
+    func testToleranceBoundaryInclusive() {
+        let w: (ringTimestamp: UInt32, startOffMin: Int, endOffMin: Int) = (100_000, 600, 10)
+        XCTAssertNotNil(OuraLiveSource.closestSleepWindow049(in: [w], toRingTimestamp: 100_000 - 6_000, within: 6_000))
+        XCTAssertNil(OuraLiveSource.closestSleepWindow049(in: [w], toRingTimestamp: 100_000 - 6_001, within: 6_000))
+    }
+
+    func testEmptyReturnsNil() {
+        XCTAssertNil(OuraLiveSource.closestSleepWindow049(in: [], toRingTimestamp: 8_400_000, within: 6_000))
+    }
+}

--- a/android/app/src/main/java/com/noop/ble/OuraLiveSource.kt
+++ b/android/app/src/main/java/com/noop/ble/OuraLiveSource.kt
@@ -32,9 +32,14 @@ import com.noop.oura.OuraFraming
 import com.noop.oura.OuraGatt
 import com.noop.oura.OuraCommands
 import com.noop.oura.OuraDecoders
+import com.noop.oura.OuraHistoryDrain
+import com.noop.oura.OuraHypnogramAssembler
+import com.noop.oura.OuraHypnogramBurst
 import com.noop.oura.OuraOuterFrame
 import com.noop.oura.OuraReassembler
 import com.noop.oura.OuraRingGen
+import com.noop.oura.OuraSleepSession
+import com.noop.oura.OuraSleepSessionMapping
 import com.noop.oura.OuraTransition
 import com.noop.oura.OuraWearState
 import com.noop.oura.OuraWearTracker
@@ -94,6 +99,11 @@ class OuraLiveSource(
     private val authKey: () -> IntArray?,
     /** Persist a batch under [deviceId] - wired to `repository.insert`. Mirrors the other sources. */
     private val persist: (StreamBatch, String) -> Unit = { _, _ -> },
+    /** Upsert the ring-PROVIDED reconstructed hypnogram as a night under [deviceId] (the imported/measured
+     *  side, NOT the "-noop" computed sibling) so `mergeSleepRichness`'s imported-over-computed rule makes
+     *  Oura's SleepNet staging win over NOOP's sparse-motion computed night. Wired to
+     *  `repository.upsertSleepSessions`; default no-op so the discovery-only scanner + tests stay inert. */
+    private val persistSleepSession: (OuraSleepSession, String) -> Unit = { _, _ -> },
     /** Diagnostic sink for the connect/auth/stream lifecycle - the SAME exportable strap log (#421).
      *  Every line is prefixed "Oura: ". Statuses / UUIDs / counts only, NEVER a device address. Default
      *  no-op keeps existing call sites compiling and tests silent. */
@@ -419,6 +429,70 @@ class OuraLiveSource(
     private val pendingAnchorEvents = ArrayList<Pair<OuraEvent, Long>>()
 
     /**
+     * Pure decision core for the drain guards + resume cursor (#91). Twin of the Swift `drain` field;
+     * see [OuraHistoryDrain] for the two-cursor model (seen = in-session continuation, stored = durable).
+     */
+    private val drain = OuraHistoryDrain()
+
+    /** Where this fetch sought from (reboot detection floor); armed per drain. */
+    private var resumeCursorAtFetchStart = 0L
+
+    /** Wall-clock start of the current drain; feeds the deadline guard. */
+    private var drainStartedAtMs: Long? = null
+
+    /**
+     * The cursor the LAST GetEvents request was issued at — the `start` of open_oura's progress test
+     * (`next > start`). Continuation requests must advance past it or the drain stops.
+     */
+    private var lastRequestCursor = 0L
+
+    /**
+     * True between a `0x11` summary that wants more data and the batch-quiet continuation request. The
+     * ring emits the summary EARLY (observed before its batch finished streaming), so the next request
+     * waits for the stream to go quiet — open_oura's `transact()` collects until a 1.5 s silence for
+     * the same reason. Re-requesting mid-stream at a stale cursor restarts the ring's serve.
+     */
+    private var pendingContinuation = false
+    private val batchQuietMs = 1_500L
+    private val batchQuietRunnable = Runnable { continueDrainAfterQuiet() }
+
+    /**
+     * Self-chained drain passes: a drain that ends with KNOWN remaining work (ring reboot → full pull
+     * pending, or a deadline stop with banked progress) schedules its own next pass instead of waiting
+     * for a reconnect / the 15 min periodic fetch. Capped per session; a stall/no-progress stop never
+     * chains (that is the ring looping). Twin of Swift's chainedDrainPasses.
+     */
+    private var chainedDrainPasses = 0
+    private val chainedDrainRunnable = Runnable { fetchHistoryIfIdle() }
+
+    /**
+     * TIME-AXIS RECONSTRUCTION (twin of Swift): the ring's SleepNet writes a night's whole hypnogram in
+     * one burst AFTER wake, every record stamped with the WRITE moment — codes are accumulated here and
+     * laid out backward (30 s/code from the anchored burst end) when the burst closes, instead of being
+     * persisted at the (meaningless for sleep) envelope time.
+     */
+    private val hypnogramAssembler = OuraHypnogramAssembler()
+
+    /** Bursts held while unanchored (park-until-anchor; dropped honestly at teardown — they re-arrive). */
+    private val pendingUnanchoredBursts = ArrayList<OuraHypnogramBurst>()
+
+    /**
+     * The recent 0x49 sleep_summary_1 windows (rt, start/end offsets in MINUTES BEFORE the event time,
+     * ringverse-validated): each pairs with the hypnogram burst of the SAME finalization so its end
+     * anchors at the TRUE sleep end (`event − end_offset`) instead of the write moment (observed trailing
+     * the real sleep end by 10–43 min). A COLLECTION, not a single slot: a drain can carry an overnight
+     * AND a daytime nap, and keeping only the latest let the nap's 0x49 clobber the overnight's before
+     * its burst finalized (overnight then fell back to its +4 h write time, 2026-07-17 capture). Each
+     * burst matches its OWN by ring-time proximity. Bounded (oldest dropped past the cap). Twin of Swift's
+     * recentSleepWindows049.
+     */
+    private val recentSleepWindows049 = ArrayList<Triple<Long, Int, Int>>()
+
+    /** 0x71 fixture capture (#287): per-session count + observed payload lengths; log cap vs flooding. */
+    private var greenIbiAmpCount = 0
+    private val greenIbiAmpLengths = sortedSetOf<Int>()
+
+    /**
      * Kick a history-fetch pass at the current cursor, but ONLY when the driver is idle-streaming (never
      * overlaps a fetch already in flight - the driver's own phase is the guard, so this is safe to call
      * both right after reaching Streaming and from the periodic timer). Kotlin twin of Swift's
@@ -427,7 +501,15 @@ class OuraLiveSource(
     private fun fetchHistoryIfIdle(): Unit = guardedCallback("history-fetch") {
         val d = driver ?: return@guardedCallback
         if (d.phase != OuraDriverPhase.Streaming) return@guardedCallback
-        log("Oura: fetching history from cursor $historyCursor")
+        // Arm the per-drain state: where we sought from (reboot detection), the seen/stored high-water
+        // marks, and the stall/deadline guards.
+        resumeCursorAtFetchStart = historyCursor
+        drainStartedAtMs = System.currentTimeMillis()
+        drain.reset()
+        lastRequestCursor = historyCursor
+        pendingContinuation = false
+        handler.removeCallbacks(batchQuietRunnable)
+        log("Oura: fetching history from cursor $historyCursor [cursor-fix]")
         advance(OuraTransition.StartHistoryFetch(cursor = historyCursor))
     }
 
@@ -443,37 +525,221 @@ class OuraLiveSource(
     }
 
     /**
-     * Handle a `0x11` GetEvents response (OURA_PROTOCOL.md s5.2): persist the advanced cursor (so a LATER
-     * connection resumes rather than re-fetching everything) and drive the driver's cursor-loop state
-     * machine, which asks for another ack-fetch while `moreData` or returns to Streaming once caught up.
-     *
-     * The ring's terminal "no more data" response (moreData=false, status 0x00) zero-fills the cursor
-     * field, whereas a mid-fetch response (moreData=true) carries a real advancing nonzero cursor. So the
-     * cursor is only trusted/persisted while the response is actually carrying new data - persisting the
-     * terminal zero would reset the cursor to 0 on every fetch and force a full backlog re-fetch forever.
-     *
-     * A cursor persisted from one BLE connection can come back SMALLER on the next connection's first real
-     * cursor: `ringTimestamp = (session << 16) | counter` (s2.3), and the ring's internal `session`
-     * component can shift across reconnects/restarts. Resuming from a cursor whose session no longer matches
-     * the ring's current one is not a real resume - the ring just re-dumps its whole backlog anyway - so we
-     * detect the regression and reset to an honest, explicit 0 rather than feed the ring a now-meaningless
-     * reference. Kotlin twin of Swift's `handleHistorySummary`.
+     * Handle a `0x11` GetEvents summary (open_oura `EventBatchSummary`): the drain continues while
+     * `bytes_left > 0` and is complete at `bytes_left == 0`. The response's byte-count is NEVER
+     * persisted — persisting it and comparing byte-counts across sessions as clocks was the #91
+     * re-dump loop. The durable resume point is the newest STORED sample's ring-time, committed at
+     * drain end. Kotlin twin of Swift's `handleHistorySummary` (2bbdaa42).
      */
     private fun handleHistorySummary(summary: com.noop.oura.GetEventsSummary): Unit = guardedCallback("history-summary") {
-        if (summary.moreData) {
-            if (summary.cursor < historyCursor) {
-                log("Oura: ring-time regression detected (fetch cursor ${summary.cursor} < persisted " +
-                    "$historyCursor) - the ring's session likely reset; resetting our cursor to 0")
-                historyCursor = 0
-                OuraHistoryCursorStore.save(appContext, deviceId, 0)
+        val elapsed = drainStartedAtMs?.let { (System.currentTimeMillis() - it) / 1000.0 } ?: 0.0
+        val continueDrain = drain.onSummary(summary.bytesLeft, summary.moreData, elapsed)
+        if (summary.moreData && !continueDrain) {
+            val reason = if (elapsed > OuraHistoryDrain.MAX_DRAIN_SECONDS) {
+                "exceeded ${OuraHistoryDrain.MAX_DRAIN_SECONDS.toInt()}s deadline"
             } else {
-                historyCursor = summary.cursor
-                OuraHistoryCursorStore.save(appContext, deviceId, summary.cursor)
+                "bytes_left stalled"
             }
-        } else {
-            log("Oura: history fetch caught up (cursor $historyCursor)")
+            log("Oura: history drain force-stopped - $reason at bytes_left ${summary.bytesLeft} (guard)")
         }
-        advance(OuraTransition.HistoryCursorAdvanced(cursor = summary.cursor, moreData = summary.moreData))
+        if (!continueDrain) {
+            // A deadline stop with more data behind it is resumable backlog (progress banked); a STALL
+            // stop is the ring looping and must not chain.
+            val deadlineBacklog = summary.moreData && elapsed > OuraHistoryDrain.MAX_DRAIN_SECONDS
+            finishDrain(completed = !summary.moreData, resumeBacklog = deadlineBacklog)
+            return@guardedCallback
+        }
+        // More data behind this batch. Do NOT re-request yet: the ring emits the 0x11 summary EARLY
+        // (observed arriving before its batch finished streaming), and a mid-stream request at a stale
+        // cursor restarts the serve from that cursor (the 5x same-window re-serve, 2026-07-12). Wait
+        // for the batch to go quiet, then continue from max-seen-ring-time + 1 (open_oura drain_events).
+        pendingContinuation = true
+        handler.removeCallbacks(batchQuietRunnable)
+        handler.postDelayed(batchQuietRunnable, batchQuietMs)
+    }
+
+    /**
+     * The batch went quiet after a more-data summary: issue the next GetEvents at the ADVANCED cursor,
+     * or end the drain when the batch made no progress (open_oura `!progressed → break` — re-sending a
+     * non-advancing cursor is exactly what loops the ring).
+     */
+    private fun continueDrainAfterQuiet(): Unit = guardedCallback("batch-quiet") {
+        if (!pendingContinuation) return@guardedCallback
+        pendingContinuation = false
+        val d = driver ?: return@guardedCallback
+        if (d.phase != OuraDriverPhase.FetchingHistory) return@guardedCallback
+        val next = drain.continuationCursor(lastRequestCursor)
+        if (next != null) {
+            lastRequestCursor = next
+            log("Oura: history batch done - continuing from cursor $next")
+            advance(OuraTransition.HistoryCursorAdvanced(cursor = next, moreData = true))
+        } else {
+            log("Oura: history batch made no cursor progress - stopping drain (ring would re-serve)")
+            finishDrain(completed = false, resumeBacklog = false)
+        }
+    }
+
+    /**
+     * Common drain-end path: close the in-progress hypnogram burst BEFORE committing the cursor (so
+     * its banked ring-time can advance the resume point in the same drain), commit, and return the
+     * driver to Streaming. When the drain ends with KNOWN remaining work — a detected ring reboot
+     * (cursor honestly reset to 0; full pull pending) or a deadline stop with backlog — the next pass
+     * self-schedules 5 s later, so catching up never needs a manual reconnect.
+     */
+    private fun finishDrain(completed: Boolean, resumeBacklog: Boolean) {
+        pendingContinuation = false
+        handler.removeCallbacks(batchQuietRunnable)
+        hypnogramAssembler.flush()?.let { persistHypnogramBurst(it) }
+        val rebootFullPullPending = drain.sawPreResumeData
+        commitResumeCursor(completed)
+        advance(OuraTransition.HistoryCursorAdvanced(cursor = historyCursor, moreData = false))
+        if (rebootFullPullPending || resumeBacklog) {
+            if (chainedDrainPasses >= MAX_CHAINED_DRAIN_PASSES) {
+                log("Oura: drain pass cap ($MAX_CHAINED_DRAIN_PASSES) reached with work remaining - " +
+                    "next periodic fetch / reconnect continues from the banked cursor")
+                return
+            }
+            chainedDrainPasses += 1
+            val why = if (rebootFullPullPending) {
+                "ring reboot detected - starting the honest full re-pull"
+            } else {
+                "backlog remains after the deadline guard"
+            }
+            log("Oura: $why; next drain pass in 5 s ($chainedDrainPasses/$MAX_CHAINED_DRAIN_PASSES)")
+            handler.postDelayed(chainedDrainRunnable, 5_000L)
+        } else if (completed) {
+            chainedDrainPasses = 0   // healthy full completion re-arms the cap for future backlogs
+        }
+    }
+
+    /**
+     * Commit the durable resume cursor at drain end. Only a cursor that (a) moved forward, (b) is
+     * below the plausibility ceiling, and (c) resolves to a real time under the CURRENT anchor is
+     * persisted; a reboot (`sawPreResumeData`) resets to 0 so next connect does an honest full pull.
+     */
+    private fun commitResumeCursor(drainCompleted: Boolean) {
+        val how = if (drainCompleted) "caught up (bytes_left 0)" else "stopped early"
+        val resolves = drain.maxStoredRingTime > 0 &&
+            driver?.unixSeconds(forRingTimestamp = drain.maxStoredRingTime) != null
+        val newCursor = drain.resumeCursorAtDrainEnd(historyCursor, resolves)
+        if (drain.sawPreResumeData) {
+            log("Oura: history $how but the ring served data older than cursor $resumeCursorAtFetchStart" +
+                " - clock reset/seek ignored; next connect does a full pull")
+            historyCursor = 0
+            OuraHistoryCursorStore.save(appContext, deviceId, 0)
+        } else if (newCursor != historyCursor) {
+            historyCursor = newCursor
+            OuraHistoryCursorStore.save(appContext, deviceId, newCursor)
+            log("Oura: history $how - resume cursor advanced to $historyCursor")
+        } else if (drain.maxStoredRingTime > historyCursor) {
+            log("Oura: history $how but resume candidate ${drain.maxStoredRingTime} does not resolve " +
+                "under the current anchor - keeping cursor $historyCursor")
+        } else {
+            log("Oura: history $how (resume cursor unchanged $historyCursor)")
+        }
+    }
+
+    /**
+     * Persist a closed hypnogram burst with its RECONSTRUCTED time axis: codes laid backward at the
+     * 30 s SleepNet epoch from the anchored burst END — the matching 0x49 window's TRUE sleep end
+     * (`event − end_offset`) when one arrived in the same finalization burst, else the write-moment
+     * envelope. HOLD-UNTIL-ANCHOR: an unanchored burst is parked (re-tried when the anchor lands) or
+     * dropped honestly at teardown — safe, the cursor only advances on an anchored persist, so the
+     * ring re-serves the same records next drain. Kotlin twin of Swift's persistHypnogramBurst.
+     */
+    private fun persistHypnogramBurst(burst: OuraHypnogramBurst) {
+        val d = driver ?: return
+        if (burst.totalCodes <= 0) return
+        val writeEnd = d.unixSeconds(forRingTimestamp = burst.lastRingTimestamp)
+        if (writeEnd == null) {
+            pendingUnanchoredBursts.add(burst)
+            log("Oura: hypnogram burst (${burst.totalCodes} codes) held - no anchor yet; reconstructs when the anchor lands")
+            return
+        }
+        if (burst.hasNonMonotonicRingTimes) {
+            log("Oura: hypnogram burst has NON-MONOTONIC envelope ring-times (${burst.records.size} records)" +
+                " - sequence order taken from arrival order")
+        }
+        var end = writeEnd
+        // Same-finalization match: the 0x49 and the phase records carry near-identical envelope ring-times
+        // (observed seconds apart); 6000 ticks = 10 min never pairs a different night. Pick the CLOSEST
+        // window, not merely the newest — a drain can hold an overnight AND a nap, and the newer (nap)
+        // window would otherwise mis-anchor the overnight burst.
+        val w = closestSleepWindow049(recentSleepWindows049, burst.lastRingTimestamp, 6_000L)
+        if (w != null) {
+            val eventUtc = d.unixSeconds(forRingTimestamp = w.first)
+            if (eventUtc != null) {
+                val sleepEnd = eventUtc - w.third * 60L
+                // Sanity: the true end precedes the write and by a plausible margin (< 6 h).
+                if (sleepEnd <= writeEnd && writeEnd - sleepEnd < 6 * 3600L) {
+                    end = sleepEnd
+                    log("Oura: hypnogram burst end refined by 0x49 - SleepNet write $writeEnd -> " +
+                        "true sleep end $sleepEnd (event-${w.third} min)")
+                }
+            }
+        }
+        val laid = burst.codesWithTimes(endUnixSeconds = end)
+        for (code in laid) enqueue(listOf(OuraEvent.SleepPhaseEvent(code.phase)), code.ts.toInt())
+        drain.noteStoredRingTime(burst.lastRingTimestamp, resumeCursorAtFetchStart)
+        val mins = DoubleArray(4)
+        for (code in laid) mins[code.phase.stage.raw] += 0.5   // 30 s/code = 0.5 min
+        log("Oura: hypnogram reconstructed [${laid.first().ts} -> $end, anchored] codes=${burst.totalCodes}" +
+            " deep/light/rem/awake=${mins[0].toInt()}/${mins[1].toInt()}/${mins[2].toInt()}/${mins[3].toInt()} min")
+        // Bank the SAME anchored codes as a ring-PROVIDED night (a SleepSession with the [{start,end,stage}]
+        // breakdown) under the ring's own deviceId, so mergeSleepRichness surfaces Oura's SleepNet staging
+        // over NOOP's computed night (#325 persist). Uses the anchored+0x49-refined `end` via `laid`. The
+        // confirmation line makes the persist self-evident in the strap log for on-device validation.
+        OuraSleepSessionMapping.session(laid.map { it.ts to it.phase.stage })?.let {
+            persistSleepSession(it, deviceId)
+            val effStr = it.efficiency?.let { e -> "${(e * 100).toInt()}%" } ?: "n/a"
+            log("Oura: sleep session persisted [${laid.first().ts} -> $end] eff=$effStr -> $deviceId (ring-provided night; wins merge over computed)")
+        }
+    }
+
+    /** Re-try bursts parked while unanchored (called right after an anchor lands). */
+    private fun drainPendingHypnogramBursts() {
+        if (pendingUnanchoredBursts.isEmpty()) return
+        val held = ArrayList(pendingUnanchoredBursts)
+        pendingUnanchoredBursts.clear()
+        for (burst in held) persistHypnogramBurst(burst)
+    }
+
+    /**
+     * Teardown for bursts that never anchored this session: DROP them honestly instead of persisting a
+     * wall-clock-guessed time axis. Nothing is lost — the resume cursor only advances on an anchored
+     * persist, so the ring re-serves the same records on the next drain.
+     */
+    private fun dropUnanchoredHypnogramBursts() {
+        if (pendingUnanchoredBursts.isEmpty()) return
+        val codes = pendingUnanchoredBursts.sumOf { it.totalCodes }
+        log("Oura: dropping ${pendingUnanchoredBursts.size} unanchored hypnogram burst(s) ($codes codes)" +
+            " - no anchor this session; cursor did not advance, so they re-arrive next drain")
+        pendingUnanchoredBursts.clear()
+    }
+
+    /**
+     * Anchor from the 0x13 SyncTime response (ringverse: the ring's clock counter when it processed
+     * our SyncTime, paired with host wall-clock at receipt). The tick unit is disambiguated against
+     * the persisted resume cursor; no unambiguous reading → log the raw value and adopt NOTHING (an
+     * honest missing anchor beats a guessed one). Kotlin twin of Swift's handleSyncTimeResponse.
+     */
+    private fun handleSyncTimeResponse(d: OuraDriver, resp: com.noop.oura.SyncTimeResponse) {
+        val now = System.currentTimeMillis() / 1000L
+        val raw = "0x%08x".format(resp.deviceTimestamp)
+        val rt = OuraDriver.syncTimeAnchorCandidate(resp.deviceTimestamp, historyCursor)
+        if (rt != null && d.adoptSyncTimeAnchor(ringTimestamp = rt, unixSeconds = now)) {
+            val unit = if (rt == resp.deviceTimestamp) "ticks" else "seconds x10"
+            if (!loggedAnchor) {
+                loggedAnchor = true
+                log("Oura: UTC anchor from SyncTime response (0x13) - device rt $rt [$unit, raw $raw, " +
+                    "status ${resp.status}] = now; no 0x42 needed this session")
+            }
+            drainPendingAnchorEvents()
+            drainPendingHypnogramBursts()
+        } else {
+            log("Oura: SyncTime response (0x13) raw $raw status ${resp.status} - no unambiguous tick " +
+                "reading vs cursor $historyCursor; anchor NOT adopted (investigation)")
+        }
     }
 
     // MARK: - Sample buffer (flushed in batches off the per-notification hot loop)
@@ -573,9 +839,29 @@ class OuraLiveSource(
         loggedTierBKinds.clear()
         loggedFeatureStatuses.clear()
         pendingAnchorEvents.clear()
+        // Per-drain / per-session protocol state starts clean (twin of Swift's connect-setup reset).
+        drain.reset()
+        resumeCursorAtFetchStart = 0
+        drainStartedAtMs = null
+        lastRequestCursor = 0
+        pendingContinuation = false
+        handler.removeCallbacks(batchQuietRunnable)
+        chainedDrainPasses = 0
+        handler.removeCallbacks(chainedDrainRunnable)
+        hypnogramAssembler.reset()        // never replay a half-accumulated burst from a dead session
+        pendingUnanchoredBursts.clear()
+        recentSleepWindows049.clear()
+        greenIbiAmpCount = 0
+        greenIbiAmpLengths.clear()
         // Resume the GetEvents cursor from where the LAST connection to this ring left off (s5.1/5.3), so a
-        // routine reconnect doesn't re-fetch the ring's entire banked history every time.
-        historyCursor = OuraHistoryCursorStore.read(appContext, deviceId)
+        // routine reconnect doesn't re-fetch the ring's entire banked history every time. A persisted value
+        // above the plausibility ceiling is pre-fix garbage; reset to a full pull instead of seeking to it.
+        val loadedCursor = OuraHistoryCursorStore.read(appContext, deviceId)
+        historyCursor = OuraHistoryDrain.sanitizeLoadedCursor(loadedCursor)
+        if (historyCursor != loadedCursor) {
+            log("Oura: persisted resume cursor $loadedCursor exceeds the plausibility ceiling (pre-fix garbage) - full pull")
+            OuraHistoryCursorStore.save(appContext, deviceId, 0)
+        }
         // connectGatt can throw (SecurityException if BLUETOOTH_CONNECT was revoked mid-session,
         // IllegalArgumentException on a stale device) - never let that crash the app; a failed start
         // simply leaves the previous source in place (mirrors [StandardHrSource]).
@@ -607,9 +893,17 @@ class OuraLiveSource(
         pendingConnectAddress = null
         cancelReengage()
         cancelHistoryFetch()
+        handler.removeCallbacks(batchQuietRunnable)
+        handler.removeCallbacks(chainedDrainRunnable)
+        pendingContinuation = false
+        chainedDrainPasses = 0
         // Drain BEFORE driver.stop() clears its anchor, so a pending event still gets a real anchored time
         // if one exists rather than always falling back to wall-clock at teardown (mirrors Swift's stop()).
+        // Same for a hypnogram burst still accumulating (e.g. the session ended mid-drain); one that never
+        // anchored is dropped honestly — the cursor did not advance, so it re-arrives next drain.
+        hypnogramAssembler.flush()?.let { persistHypnogramBurst(it) }
         drainPendingAnchorEvents()
+        dropUnanchoredHypnogramBursts()
         driver?.stop()
         gatt?.let { runCatching { it.disconnect(); it.close() } }
         gatt = null
@@ -743,10 +1037,16 @@ class OuraLiveSource(
                     resetWear()             // #628: the wear badge must not survive the link dropping
                     cancelReengage()
                     cancelHistoryFetch()
+                    handler.removeCallbacks(batchQuietRunnable)
+                    handler.removeCallbacks(chainedDrainRunnable)
+                    pendingContinuation = false
                     // Drain BEFORE the driver's anchor is gone (same reasoning as stop()): a pending event
                     // still gets a real anchored time if the current session set one, else an honest
-                    // wall-clock fallback rather than being silently dropped.
+                    // wall-clock fallback rather than being silently dropped. A hypnogram burst still
+                    // accumulating flushes first for the same reason; unanchored ones drop honestly.
+                    hypnogramAssembler.flush()?.let { persistHypnogramBurst(it) }
                     drainPendingAnchorEvents()
+                    dropUnanchoredHypnogramBursts()
                     reassembler.reset()
                     loggedFirstTemp = false
                     loggedFirstSpo2 = false
@@ -900,6 +1200,10 @@ class OuraLiveSource(
                     pendingInstallKey = null
                     log("Oura: live HR enabled - streaming")
                     scheduleReengage()
+                    // SyncTime FIRST (s5.4, twin of Swift): sets the ring clock AND its 0x13 response
+                    // carries the ring's current clock counter — the deterministic anchor that lets the
+                    // whole drain below resolve real times without waiting for a lucky 0x42.
+                    write(OuraCommands.syncTime(System.currentTimeMillis() / 1000L))
                     // Pull last night's banked temp/SpO2/HRV/sleep-phase right away + keep a periodic pass
                     // running, and ask for battery once (the 0x0D reply routes to onBattery).
                     scheduleHistoryFetch()
@@ -1041,6 +1345,13 @@ class OuraLiveSource(
                 // 0x25 ack above - handled, not re-serialised).
                 val summary = OuraFraming.parseGetEventsResponse(frame.body)
                 if (summary != null) handleHistorySummary(summary)
+            } else if (frame.op == OuraFraming.syncTimeResponseOp) {
+                // The `0x13` SyncTime response is ALSO an OUTER frame ([ringverse BLE.md]): it carries the
+                // ring's CURRENT clock counter, which paired with the host wall-clock right now is a
+                // DETERMINISTIC anchor — the 0x42 record is only logged when the ring actually adjusts its
+                // clock, so an already-synced ring can serve a whole drain with no anchor (2026-07-13).
+                val resp = OuraFraming.parseSyncTimeResponse(frame.body)
+                if (resp != null) handleSyncTimeResponse(d, resp)
             } else if (frame.op == OuraFraming.batteryResponseOp) {
                 // The `0x0D` GetBattery response is ALSO an OUTER frame (never a TLV record, s6.10). Its op
                 // is below the event-tag range too, so it is a safe no-op if it ever fell through; we route
@@ -1057,7 +1368,21 @@ class OuraLiveSource(
         }
         if (nonSecure.isNotEmpty()) {
             val records = reassembler.feed(IntArray(nonSecure.size) { nonSecure[it] })
-            for (rec in records) emit(d.ingest(rec))
+            for (rec in records) {
+                // HISTORY-LOG records (the live-HR path is ingestLiveHRPush via routeSecure): every
+                // envelope ring-time advances the drain's in-session continuation cursor (open_oura
+                // drain_events tracks the max timestamp of EVERY batch event), and while a continuation
+                // is pending the batch-quiet window stays open as long as records keep arriving.
+                val events = d.ingest(rec)
+                for (e in events) {
+                    e.envelopeRingTimestamp?.let { drain.noteSeenRingTime(it) }
+                }
+                if (pendingContinuation && events.isNotEmpty()) {
+                    handler.removeCallbacks(batchQuietRunnable)
+                    handler.postDelayed(batchQuietRunnable, batchQuietMs)
+                }
+                emit(events)
+            }
         }
     }
 
@@ -1116,6 +1441,19 @@ class OuraLiveSource(
         if (events.isEmpty()) return@guardedCallback
         val d = driver ?: return@guardedCallback
         val now = (System.currentTimeMillis() / 1000L).toInt()
+        // TIME-AXIS RECONSTRUCTION (twin of Swift): one 0x4B/0x4E/0x5A record's codes arrive as one
+        // events list; the codes are accumulated per burst and laid out backward from the anchored
+        // burst end when it closes (persistHypnogramBurst), instead of being persisted at the
+        // (meaningless for sleep) envelope time. A returned burst means a ring-time gap closed the
+        // previous one.
+        val phases = events.mapNotNull { (it as? OuraEvent.SleepPhaseEvent)?.value }
+        if (phases.isNotEmpty()) {
+            val counts = IntArray(4)
+            for (p in phases) counts[p.stage.raw] += 1
+            log("Oura: sleep-phase record codes=${phases.size} " +
+                "deep/light/rem/awake=${counts[0]}/${counts[1]}/${counts[2]}/${counts[3]}")
+            hypnogramAssembler.feed(phases.first().ringTimestamp, phases)?.let { persistHypnogramBurst(it) }
+        }
         for (e in events) when (e) {
             is OuraEvent.Hr -> {
                 val bpm = e.value.bpm
@@ -1182,7 +1520,10 @@ class OuraLiveSource(
                 enqueueAnchoredOrPark(e, e.value.ringTimestamp, d)
             }
             is OuraEvent.Hrv -> enqueueAnchoredOrPark(e, e.value.ringTimestamp, d)
-            is OuraEvent.SleepPhaseEvent -> enqueueAnchoredOrPark(e, e.value.ringTimestamp, d)
+            is OuraEvent.SleepPhaseEvent -> Unit
+            // ^ handled at the record level above (hypnogramAssembler): the envelope time marks the
+            //   analysis WRITE moment, not the sleep, so a per-code enqueue here would mis-place the
+            //   night. Codes persist when the burst closes (persistHypnogramBurst).
             is OuraEvent.TimeSyncEvent -> {
                 // #91: a 0x42 whose epoch is outside the 2020–2035 plausibility window is silently ignored,
                 // so history samples stay unanchored (no sleep/daily). Log the rejection with the offending
@@ -1201,6 +1542,7 @@ class OuraLiveSource(
                 // The 0x42 time-sync can arrive ANYWHERE in a history-fetch stream, not necessarily first.
                 // Anything parked while unanchored gets its real time retroactively the moment it lands.
                 drainPendingAnchorEvents()
+                drainPendingHypnogramBursts()
             }
             is OuraEvent.RtcBeaconEvent -> {
                 // #91: the 0x85 beacon is the SECONDARY anchor (fills the gap only until a 0x42 arrives). A
@@ -1212,15 +1554,56 @@ class OuraLiveSource(
                 }
             }
             is OuraEvent.TierB -> {
-                // INVESTIGATION ONLY (real_steps / activity-summary / sleep-summary / smoothed-SpO2,
-                // OURA_PROTOCOL.md s7.3 Tier B; PR #960). Logged ONCE PER KIND with the raw bytes so we
-                // can see whether the ring sends these tags at all and collect capture material - e.g.
-                // real_steps 0x7E/0x7F is server-flag-gated OFF by default ([open_oura-feat]), so its
-                // continued absence here is the ring's doing, not a decode gap. Never persisted, never
-                // scored (OuraStreamMapping drops TierB unconditionally regardless of this log).
-                if (loggedTierBKinds.add(e.value.kind)) {
-                    val hex = e.value.rawPayload.joinToString(" ") { "%02x".format(it) }
-                    log("Oura: Tier-B ${e.value.kind} seen (tag 0x${e.value.tag.toString(16)}) - raw: $hex")
+                // 0x71 green_ibi_amp FIXTURE CAPTURE (upstream #287/#333): unlike the other Tier-B
+                // tags, EVERY occurrence is logged (up to a flood cap) with its envelope rt, length,
+                // full raw bytes, and the ringverse candidate decode side by side — a verified decoder
+                // needs several real payloads cross-checked against concurrent live-HR R-R. Never
+                // persisted, never scored (OuraStreamMapping drops TierB unconditionally).
+                if (e.value.kind == "green_ibi_amp") {
+                    greenIbiAmpCount += 1
+                    greenIbiAmpLengths.add(e.value.rawPayload.size)
+                    if (greenIbiAmpCount <= GREEN_IBI_AMP_LOG_CAP) {
+                        val hex = e.value.rawPayload.joinToString(" ") { "%02x".format(it) }
+                        val cand = OuraDecoders.decodeGreenIBIAmpCandidate(e.value.rawPayload, e.value.ringTimestamp)
+                        val candStr = if (cand != null) {
+                            val ibis = cand.samples.drop(1).joinToString(",") { it.ibiMs.toString() }
+                            val amps = cand.samples.joinToString(",") { (it.amplitude ?: 0).toString() }
+                            "candidate [ringverse]: shift=${cand.shift} ibis_ms=[$ibis] amps=[$amps]"
+                        } else {
+                            "candidate [ringverse]: GATE FAILED (len != 14 or reserved bit set)"
+                        }
+                        log("Oura: 0x71 green_ibi_amp #$greenIbiAmpCount rt=${e.value.ringTimestamp} " +
+                            "len=${e.value.rawPayload.size} raw: $hex | $candStr")
+                        if (greenIbiAmpCount == GREEN_IBI_AMP_LOG_CAP) {
+                            log("Oura: 0x71 log cap ($GREEN_IBI_AMP_LOG_CAP) reached - further records counted only")
+                        }
+                    }
+                } else {
+                    // 0x49 sleep_summary_1 window (ringverse, VALIDATED 2026-07-13: both uint16 LE
+                    // fields are MINUTES BEFORE the event time — the tracked sleep window). Stash for
+                    // the hypnogram burst of the SAME finalization (it follows right after) and log the
+                    // window as an independent cross-check of the reconstruction axis. Tier-B: log-only.
+                    if (e.value.tag == 0x49 && e.value.rawPayload.size >= 4) {
+                        val startOff = (e.value.rawPayload[0] and 0xFF) or ((e.value.rawPayload[1] and 0xFF) shl 8)
+                        val endOff = (e.value.rawPayload[2] and 0xFF) or ((e.value.rawPayload[3] and 0xFF) shl 8)
+                        // Append (don't overwrite): a drain may carry an overnight AND a nap window, and
+                        // each burst pairs with its OWN by ring-time proximity. Bounded — oldest dropped.
+                        recentSleepWindows049.add(Triple(e.value.ringTimestamp, startOff, endOff))
+                        if (recentSleepWindows049.size > RECENT_SLEEP_WINDOWS_049_CAP) {
+                            recentSleepWindows049.subList(0, recentSleepWindows049.size - RECENT_SLEEP_WINDOWS_049_CAP).clear()
+                        }
+                        log("Oura: 0x49 sleep window candidate [ringverse] offsets start-${startOff}min " +
+                            "end-${endOff}min")
+                    }
+                    // Other Tier-B tags (real_steps / activity-summary / sleep-summary / smoothed-SpO2,
+                    // OURA_PROTOCOL.md s7.3; PR #960): logged ONCE PER KIND with the raw bytes so we can
+                    // see whether the ring sends these tags at all and collect capture material - e.g.
+                    // real_steps 0x7E/0x7F is server-flag-gated OFF by default ([open_oura-feat]), so its
+                    // continued absence here is the ring's doing, not a decode gap.
+                    if (loggedTierBKinds.add(e.value.kind)) {
+                        val hex = e.value.rawPayload.joinToString(" ") { "%02x".format(it) }
+                        log("Oura: Tier-B ${e.value.kind} seen (tag 0x${e.value.tag.toString(16)}) - raw: $hex")
+                    }
                 }
             }
             is OuraEvent.ActivityInfo -> {
@@ -1362,6 +1745,40 @@ class OuraLiveSource(
         /** Android's infamous generic GATT connect failure (`BluetoothGatt.GATT_ERROR`, not a public
          *  constant). We auto-retry it once. */
         private const val GATT_ERROR_133 = 133
+
+        /** Max self-chained drain passes per session (twin of Swift's maxChainedDrainPasses). */
+        private const val MAX_CHAINED_DRAIN_PASSES = 6
+
+        /** Per-session cap on individually-logged 0x71 records (twin of Swift's greenIbiAmpLogCap). */
+        private const val GREEN_IBI_AMP_LOG_CAP = 50
+
+        /** Bound on stashed 0x49 windows (twin of Swift's recentSleepWindows049Cap). */
+        private const val RECENT_SLEEP_WINDOWS_049_CAP = 16
+
+        /**
+         * The 0x49 window in [windows] whose envelope ring-time is nearest [rt] and within [tolerance]
+         * ticks, or null when none is in range. A drain can hold several windows (overnight + nap); each
+         * burst must pair with its OWN, so match by ring-time proximity — keeping a single latest slot
+         * mis-anchored the overnight burst to the nap's window when both finalized in one drain
+         * (2026-07-17 capture). Pure + static so the pairing is unit-testable. Twin of Swift's
+         * closestSleepWindow049.
+         */
+        internal fun closestSleepWindow049(
+            windows: List<Triple<Long, Int, Int>>,
+            rt: Long,
+            tolerance: Long,
+        ): Triple<Long, Int, Int>? {
+            var best: Triple<Long, Int, Int>? = null
+            var bestGap = Long.MAX_VALUE
+            for (w in windows) {
+                val gap = if (w.first >= rt) w.first - rt else rt - w.first
+                if (gap <= tolerance && gap < bestGap) {
+                    bestGap = gap
+                    best = w
+                }
+            }
+            return best
+        }
 
         /** The SetAuthKey-response OUTER opcode (`0x25`) and its OK status byte (`0x00`). The ring replies
          *  `25 01 00` to a successful `0x24` key install (OURA_PROTOCOL.md s3.2). */

--- a/android/app/src/main/java/com/noop/ble/SourceCoordinator.kt
+++ b/android/app/src/main/java/com/noop/ble/SourceCoordinator.kt
@@ -417,6 +417,18 @@ class SourceCoordinator(
             persist = { batch: StreamBatch, deviceId: String ->
                 scope.launch { runCatching { repo.insert(batch, deviceId) } }
             },
+            persistSleepSession = { s: com.noop.oura.OuraSleepSession, deviceId: String ->
+                // The ring-PROVIDED hypnogram night, upserted under the ring's OWN id (imported/measured
+                // side, NOT the "-noop" computed sibling) so mergeSleepRichness surfaces Oura's SleepNet
+                // staging over NOOP's sparse-motion computed night (#325).
+                scope.launch {
+                    runCatching {
+                        repo.upsertSleepSessions(listOf(com.noop.data.SleepSession(
+                            deviceId = deviceId, startTs = s.startTs, endTs = s.endTs,
+                            efficiency = s.efficiency, stagesJSON = s.stagesJson)))
+                    }
+                }
+            },
             log = straplog,           // Oura connect/auth/stream lifecycle → the SAME exported strap log (#421)
             onBattery = batterySink,  // ring battery → the same live state the WHOOP strap battery uses
         )

--- a/android/app/src/main/java/com/noop/data/DeviceBrandCatalog.kt
+++ b/android/app/src/main/java/com/noop/data/DeviceBrandCatalog.kt
@@ -73,4 +73,11 @@ object DeviceBrandCatalog {
     /** The row for a known brand string ("Amazfit", …), or null. Lets the typed `ExperimentalBrand` derive
      *  its facts (capability/routing) from this table rather than re-declaring them. */
     fun specForBrand(brand: String): DeviceBrandSpec? = all.firstOrNull { it.brand == brand }
+
+    /** True when a registry deviceId belongs to an Oura ring, resolved from its "<idPrefix>-" prefix against
+     *  this canonical table (never an ad-hoc "oura" literal — the registry mints every non-WHOOP id as
+     *  "<idPrefix>-<uuid>", so the prefix IS the brand key). Read/UI side only: it lets the sleep surfaces
+     *  name an Oura night's provenance "Oura". Twin of Swift `DeviceBrandCatalog.isOura`. */
+    fun isOura(deviceId: String): Boolean =
+        all.firstOrNull { deviceId.startsWith(it.idPrefix + "-") }?.sourceKind == SourceKind.oura
 }

--- a/android/app/src/main/java/com/noop/oura/Commands.kt
+++ b/android/app/src/main/java/com/noop/oura/Commands.kt
@@ -64,18 +64,24 @@ object OuraCommands {
     // MARK: - Time sync
 
     /**
-     * SyncTime: `12 09 <token:1> <counter:3 LE> 00 00 00 00 f6` where counter = floor(unix_s / 256)
-     * and the trailer 0xf6 is fixed. Per OURA_PROTOCOL.md s5.4. `token` defaults to 0.
+     * SyncTime: `12 09 <unix_seconds:8 LE> <tz:1>` — unix seconds as uint64 LE, then the timezone as a
+     * SIGNED byte in HALF-HOURS from UTC. Per OURA_PROTOCOL.md s5.4 [ringverse BLE.md][open_oura
+     * `req_sync_time`]; on-device proven 2026-07-12 (this layout made the ring emit its first 0x42 and
+     * anchored history). Byte-identical twin of Swift's syncTime.
+     *
+     * SUPERSEDED (open_ring): the previous `token + unix_s/256 + 0xF6` layout never anchored on real
+     * hardware. `tzHalfHours` defaults to 0 (UTC), exactly as the reference client sends; NOOP does its
+     * own LOCAL-day bucketing downstream regardless of what the ring is told here.
      */
-    fun syncTime(unixSeconds: Long, token: Int = 0x00): OuraCommand {
-        val counter = unixSeconds / 256
-        val c0 = (counter and 0xFFL).toInt()
-        val c1 = ((counter shr 8) and 0xFFL).toInt()
-        val c2 = ((counter shr 16) and 0xFFL).toInt()
-        return OuraCommand(
-            "sync_time",
-            intArrayOf(0x12, 0x09, token and 0xFF, c0, c1, c2, 0x00, 0x00, 0x00, 0x00, 0xF6),
-        )
+    fun syncTime(unixSeconds: Long, tzHalfHours: Int = 0): OuraCommand {
+        val body = IntArray(11)
+        body[0] = 0x12
+        body[1] = 0x09
+        for (i in 0 until 8) {
+            body[2 + i] = ((unixSeconds ushr (i * 8)) and 0xFFL).toInt()
+        }
+        body[10] = tzHalfHours and 0xFF
+        return OuraCommand("sync_time", body)
     }
 
     // MARK: - Event fetch (cursor)

--- a/android/app/src/main/java/com/noop/oura/Decoders.kt
+++ b/android/app/src/main/java/com/noop/oura/Decoders.kt
@@ -98,6 +98,50 @@ object OuraDecoders {
         return if (out.isEmpty()) null else out
     }
 
+    // MARK: - Green IBI + amplitude CANDIDATE decode (0x71; s6.2, upstream #287)
+
+    /** Result of [decodeGreenIBIAmpCandidate]: the amplitude exponent + the six walk-order entries. */
+    data class GreenIBIAmpCandidate(val shift: Int, val samples: List<OuraIBI>)
+
+    /**
+     * CANDIDATE decode of the 0x71 green_ibi_and_amp_event, ported verbatim from ringverse's
+     * `p_green_ibi_and_amp` (parse.js, firmware @0x503960): 5 densely bit-packed 11-bit IBIs +
+     * amplitudes (7-bit mantissa << shift), first entry amplitude-only (`ibiMs == 0`), timestamps
+     * walking backward from the event time by each IBI in turn (caller's job — entries are returned
+     * in that walk order). `shift` comes from payload[13] bits [2:0] (`s == 7 → 0`, else `s+1`);
+     * bit [3] set means a firmware-layout mismatch → null (never guess).
+     *
+     * TIER-B (#287): this layout has NO verified NOOP capture yet — the result is for the 0x71
+     * fixture-capture log ONLY (side-by-side with the raw bytes, cross-checked against concurrent
+     * live-HR R-R), never a stored rrInterval. Payload indexing: ringverse's `b[i]` spans the whole
+     * frame (type/len/rt4/body); our `payload` starts at spec offset 6, so `b[i] == payload[i-6]`.
+     * Strict 14-byte gate (= wire len 18). Byte-identical twin of Swift's decodeGreenIBIAmpCandidate.
+     */
+    fun decodeGreenIBIAmpCandidate(payload: IntArray, ringTimestamp: Long): GreenIBIAmpCandidate? {
+        if (payload.size != 14) return null
+        val b13 = payload[13] and 0xFF
+        if ((b13 shr 3) and 1 == 1) return null   // reserved bit set → firmware mismatch
+        val s = b13 and 7
+        val shift = if (s == 7) 0 else s + 1
+        val b12 = payload[12] and 0xFF
+        // Each 11-bit IBI: 1 low bit (an amplitude byte's LSB) | 8 mid bits (a full byte << 3)
+        // | 2 bits [2:1] from the pack bytes. Ordering per the firmware's scrambled layout.
+        val ds = intArrayOf(
+            (payload[10] and 1) or ((payload[4] and 0xFF) shl 3) or ((b13 shr 5) and 6),
+            (payload[9] and 1) or ((payload[3] and 0xFF) shl 3) or ((b12 and 3) shl 1),
+            (payload[8] and 1) or ((payload[2] and 0xFF) shl 3) or ((b12 shr 1) and 6),
+            (payload[7] and 1) or ((payload[1] and 0xFF) shl 3) or ((b12 shr 3) and 6),
+            (payload[6] and 1) or ((payload[0] and 0xFF) shl 3) or ((b12 shr 5) and 6),
+        )
+        val amps = IntArray(5) { ((payload[6 + it] and 0xFF) shr 1) shl shift }
+        val samples = ArrayList<OuraIBI>(6)
+        samples.add(OuraIBI(ringTimestamp = ringTimestamp, ibiMs = 0, amplitude = amps[0]))
+        for (i in 0 until 5) {
+            samples.add(OuraIBI(ringTimestamp = ringTimestamp, ibiMs = ds[i], amplitude = amps[i]))
+        }
+        return GreenIBIAmpCandidate(shift = shift, samples = samples)
+    }
+
     // MARK: - Green IBI quality, 2 bytes/sample (0x80; s6.4)
 
     /**

--- a/android/app/src/main/java/com/noop/oura/EventTags.kt
+++ b/android/app/src/main/java/com/noop/oura/EventTags.kt
@@ -59,13 +59,17 @@ enum class OuraEventTag(val raw: Int) {
 
     // --- Sleep summaries (Tier B, UNVERIFIED) ---
     SLEEP_SUMMARY_1(0x49),    // sleep_summary_1, OURA_PROTOCOL.md s6.12 (UNVERIFIED)
-    SLEEP_SUMMARY_B(0x4B),    // sleep summary variant, OURA_PROTOCOL.md s6.12 (UNVERIFIED)
     SLEEP_SUMMARY_C(0x4C),    // sleep summary variant, OURA_PROTOCOL.md s6.12 (UNVERIFIED)
     SLEEP_SUMMARY_D(0x4F),    // sleep summary variant, OURA_PROTOCOL.md s6.12 (UNVERIFIED)
     SLEEP_SUMMARY_E(0x57),    // sleep summary variant, OURA_PROTOCOL.md s6.12 (UNVERIFIED)
     SLEEP_SUMMARY_F(0x58),    // sleep summary variant, OURA_PROTOCOL.md s6.12 (UNVERIFIED)
 
     // --- Sleep phase codes (Tier A: 2-bit phase codes are byte-for-byte verified) ---
+    // 0x4B/0x4E/0x5A are the three aliases the ring emits for the SAME hypnogram layout — a header
+    // byte then 2-bit stage codes, 4/byte MSB-first (open_oura decode_sleep_phases routes all three,
+    // events.rs). 0x4B was previously misfiled as a Tier-B "sleep summary"; it is the same validated
+    // phase record. Parity with Swift's sleepPhaseB reclassification (dddbe952).
+    SLEEP_PHASE_B(0x4B),      // sleep_phase_details alias (was SLEEP_SUMMARY_B), OURA_PROTOCOL.md s6.12
     SLEEP_PHASE(0x4E),        // sleep_phase_details (2-bit codes), OURA_PROTOCOL.md s6.12
     SLEEP_PHASE_ALT(0x5A),    // sleep_phase_details alias, OURA_PROTOCOL.md s6.12
 
@@ -87,7 +91,7 @@ enum class OuraEventTag(val raw: Int) {
      */
     val tier: TrustTier
         get() = when (this) {
-            SLEEP_SUMMARY_1, SLEEP_SUMMARY_B, SLEEP_SUMMARY_C, SLEEP_SUMMARY_D, SLEEP_SUMMARY_E,
+            SLEEP_SUMMARY_1, SLEEP_SUMMARY_C, SLEEP_SUMMARY_D, SLEEP_SUMMARY_E,
             SLEEP_SUMMARY_F, ACTIVITY_INFO, ACTIVITY_SUMMARY_1, ACTIVITY_SUMMARY_2,
             REAL_STEPS_1, REAL_STEPS_2, SPO2_SMOOTHED,
             // #287: 0x71 green_ibi_and_amp is NOT corpus-verified — no captured 0x71 fixture, and
@@ -124,7 +128,7 @@ enum class OuraEventTag(val raw: Int) {
             MOTION -> "MOTION"
             MOTION_PERIOD -> "MOTION_PERIOD"
             SLEEP_SUMMARY_1 -> "SLEEP_SUMMARY_1"
-            SLEEP_SUMMARY_B -> "SLEEP_SUMMARY_4B"
+            SLEEP_PHASE_B -> "SLEEP_PHASE_4B"
             SLEEP_SUMMARY_C -> "SLEEP_SUMMARY_4C"
             SLEEP_SUMMARY_D -> "SLEEP_SUMMARY_4F"
             SLEEP_SUMMARY_E -> "SLEEP_SUMMARY_57"

--- a/android/app/src/main/java/com/noop/oura/Framing.kt
+++ b/android/app/src/main/java/com/noop/oura/Framing.kt
@@ -85,12 +85,27 @@ data class OuraRecord(val type: Int, val ringTimestamp: Long, val payload: IntAr
 }
 
 /**
- * The parsed result of a 0x11 GetEvents response (OURA_PROTOCOL.md s5.2). Kotlin twin of the Swift
- * `(cursor: UInt32, moreData: Bool)` tuple. `cursor` is the new resume cursor (an unsigned 32-bit ring
- * timestamp carried as a Long, 0..0xFFFFFFFF); `moreData` is true while the ring still has banked events
- * to hand over.
+ * The parsed result of a 0x11 GetEvents response (OURA_PROTOCOL.md s5.2), per open_oura's
+ * `EventBatchSummary`. Kotlin twin of the Swift `(eventsReceived: UInt8, bytesLeft: UInt32,
+ * moreData: Bool)` tuple. The summary carries **no cursor** — the resume position is a CLIENT-managed
+ * event-envelope ring-time (see OuraHistoryDrain), never read back from here.
+ *
+ * #91 (fixed here in parity with Swift): an earlier revision decoded bytes 2–5 as a
+ * `last_ring_timestamp` cursor and body[0] as a status. Both are wrong: body[0] is `events_received`
+ * (a batch COUNT — treating 0 as "done" stopped a drain with data still banked), and bytes 2–5 are
+ * `bytes_left` (a remaining-BYTE count — persisting it as a cursor minted a phantom "ring-time
+ * regression" → reset-to-0 → full history re-dump on every connect).
  */
-data class GetEventsSummary(val cursor: Long, val moreData: Boolean)
+data class GetEventsSummary(val eventsReceived: Int, val bytesLeft: Long, val moreData: Boolean)
+
+/**
+ * The parsed result of a 0x13 SyncTime response (OURA_PROTOCOL.md s5.4, [ringverse BLE.md]):
+ * `current_device_timestamp:4 LE  status:1`. The device timestamp is the ring's own clock counter AT
+ * THE MOMENT it processed our SyncTime — paired with the host wall-clock at receipt it forms a
+ * deterministic ring-time→UTC anchor available at EVERY connect (the 0x42 record is only logged when
+ * the ring actually adjusts its clock). Kotlin twin of Swift's parseSyncTimeResponse tuple.
+ */
+data class SyncTimeResponse(val deviceTimestamp: Long, val status: Int)
 
 object OuraFraming {
     /** The secure-session / extended opcode. Per OURA_PROTOCOL.md s2.2 / s4.1. */
@@ -111,24 +126,45 @@ object OuraFraming {
      */
     const val batteryResponseOp = 0x0D
 
+    /**
+     * The SyncTime response outer opcode (OURA_PROTOCOL.md s5.4, [ringverse BLE.md]). Below the
+     * event-tag range, so it round-trips safely through the TLV decoder as an "unknown tag" no-op if a
+     * caller fails to special-case it. Kotlin twin of Swift's syncTimeResponseOp.
+     */
+    const val syncTimeResponseOp = 0x13
+
     /** The minimum legal TLV `len` field: it must cover the 4 timestamp bytes. Per OURA_PROTOCOL.md s2.3. */
     const val minRecordLen = 4
 
     /**
-     * Parse a 0x11 GetEvents response body: `status:1 sub_status:1 last_ring_timestamp:4LE pad:2`
-     * (OURA_PROTOCOL.md s5.2). `status` 0x00 = empty/no more; any other value = data follows. The
-     * `last_ring_timestamp` is the new cursor to resume the fetch from. Returns null on a short body
-     * (never guesses a cursor). Kotlin twin of Swift's parseGetEventsResponse; `cursor` is the unsigned
-     * 32-bit ring timestamp carried as a Long (0..0xFFFFFFFF).
+     * Parse a 0x11 GetEvents response body per open_oura's `EventBatchSummary`:
+     * `events_received:1  sleep_analysis_progress:1  bytes_left:4LE  [pad:2]` (OURA_PROTOCOL.md s5.2).
+     * The drain loop runs until `bytes_left == 0`; there is NO resume cursor in this packet. Returns
+     * null on a short body. Byte-identical twin of Swift's parseGetEventsResponse (#91 fix).
      */
     fun parseGetEventsResponse(body: IntArray): GetEventsSummary? {
         if (body.size < 6) return null
-        val status = body[0]
-        val cursor = (body[2].toLong() and 0xFFL) or
+        val eventsReceived = body[0] and 0xFF
+        val bytesLeft = (body[2].toLong() and 0xFFL) or
             ((body[3].toLong() and 0xFFL) shl 8) or
             ((body[4].toLong() and 0xFFL) shl 16) or
             ((body[5].toLong() and 0xFFL) shl 24)
-        return GetEventsSummary(cursor = cursor, moreData = status != 0x00)
+        return GetEventsSummary(eventsReceived = eventsReceived, bytesLeft = bytesLeft, moreData = bytesLeft > 0)
+    }
+
+    /**
+     * Parse a 0x13 SyncTime response body: `current_device_timestamp:4 LE  status:1` (s5.4,
+     * [ringverse BLE.md]). ringverse labels the field "seconds" but the tick unit is unconfirmed; the
+     * caller disambiguates against the persisted resume cursor (OuraDriver.syncTimeAnchorCandidate).
+     * Returns null on a short body. Byte-identical twin of Swift's parseSyncTimeResponse.
+     */
+    fun parseSyncTimeResponse(body: IntArray): SyncTimeResponse? {
+        if (body.size < 5) return null
+        val ts = (body[0].toLong() and 0xFFL) or
+            ((body[1].toLong() and 0xFFL) shl 8) or
+            ((body[2].toLong() and 0xFFL) shl 16) or
+            ((body[3].toLong() and 0xFFL) shl 24)
+        return SyncTimeResponse(deviceTimestamp = ts, status = body[4] and 0xFF)
     }
 
     /**
@@ -171,85 +207,70 @@ object OuraFraming {
     }
 
     /**
-     * Parse one TLV inner record from the front of `bytes`. Returns null when the header or the full
-     * `len`-described body is not present (so the Reassembler can wait), or when `len < 4` (a record
-     * must cover its 4 timestamp bytes). A malformed/short record decodes to null, never a guess
-     * (honest-data invariant). Per OURA_PROTOCOL.md s2.3.
+     * Parse one TLV inner record LENIENTLY, per open_oura's `Packet::parse` (protocol.rs): the payload
+     * is whatever bytes are present up to `min(2 + len, bytes.size)`. The `len` field is NOT required
+     * to equal the notification length; open_oura tolerates that disagreement, and honoring it is what
+     * keeps NOOP from (a) minting phantom records out of a "too-small" len's leftover bytes or (b)
+     * swallowing the next notification on a "too-big" len. Returns null only when the 4 timestamp
+     * bytes are not even present (`size < 6`) or `len < 4` — a genuinely unusable frame, never a guess
+     * (honest-data invariant). Byte-identical twin of Swift's lenient parseRecord. Per s2.3.
      */
     fun parseRecord(bytes: IntArray): OuraRecord? {
-        if (bytes.size < 2) return null
+        if (bytes.size < 6) return null   // 2 header + 4 timestamp bytes, the record floor
         val type = bytes[0]
         val len = bytes[1]
         if (len < minRecordLen) return null
-        val total = 2 + len
-        if (bytes.size < total) return null
         // ringTimestamp is the 4 bytes at offset 2 as a u32 LE (counter low, session high).
         val rt = (bytes[2].toLong() and 0xFFL) or
             ((bytes[3].toLong() and 0xFFL) shl 8) or
             ((bytes[4].toLong() and 0xFFL) shl 16) or
             ((bytes[5].toLong() and 0xFFL) shl 24)
-        val payload = bytes.copyOfRange(6, total)
+        // Lenient payload: min(declared end, notification end). Trailing bytes beyond `len` are
+        // ignored; a truncated payload uses what arrived. Never waits for a next notification.
+        val end = minOf(2 + len, bytes.size)
+        val payload = if (end > 6) bytes.copyOfRange(6, end) else IntArray(0)
         return OuraRecord(type = type, ringTimestamp = rt, payload = payload)
     }
 }
 
 /**
- * Accumulate BLE notification fragments into complete TLV inner records. A record never spans two
- * notifications in the verified corpus, but the parser is still defensive: it buffers partial
- * trailing bytes across feeds and only emits complete `2 + len` records (OURA_PROTOCOL.md s2.4).
+ * Turn each BLE notification into (at most) one TLV inner record, matching open_oura's
+ * `Packet::parse` (protocol.rs): ONE packet per notification, parsed leniently, with NO
+ * cross-notification buffering, NO multi-record loop, and NO byte-drop resync.
  *
- * This handles BOTH the multi-record-per-notification case (several records packed into one value)
- * and the partial-trailing-bytes case (a record split across two notifications). Mirrors the Swift
- * OuraReassembler, value-type and platform-pure.
+ * WHY (parity with Swift `dae3d7a4`, the phantom-storm fix): the previous model treated the byte
+ * stream as continuous — it buffered partial trailing bytes and looped extracting `2+len` records.
+ * Whenever a packet's `len` disagreed with the notification length — which open_oura explicitly
+ * tolerates — a too-small `len` made the loop mint phantom records from the leftover bytes (aliased
+ * `0x42`/`0x85`/`0x57`/`0x70` tags → the reject/drop storm), and a too-big `len` made it wait and
+ * swallow the following notification. Parsing exactly one lenient packet per notification removes
+ * both failure modes at the source.
+ *
+ * The type name and `feed`/`reset` API are kept so the driver call sites are unchanged; there is
+ * simply no longer any state to carry. Platform-pure. Byte-identical twin of Swift's OuraReassembler.
  */
 class OuraReassembler {
-    private val buf = ArrayList<Int>()
-
     /** Feed one notification value (BLE callback ByteArray). Convenience over [feed]. */
     fun feed(fragment: ByteArray): List<OuraRecord> =
         feed(IntArray(fragment.size) { fragment[it].toInt() and 0xFF })
 
     /**
-     * Feed one notification value. Returns every complete TLV record now available, in order. Partial
-     * trailing bytes are retained for the next feed. Per OURA_PROTOCOL.md s2.3 / s2.4.
+     * Parse one notification value into at most one record (open_oura `Packet::parse`, lenient).
+     * Returns `[]` when the notification is not a usable TLV record (too short, or `len < 4`). Never
+     * buffers, never spans, never resyncs — a garbled notification is dropped whole, not walked
+     * byte-by-byte.
      */
     fun feed(fragment: IntArray): List<OuraRecord> {
-        for (b in fragment) buf.add(b and 0xFF)
-        val out = ArrayList<OuraRecord>()
-        while (buf.size >= 2) {
-            val len = buf[1]
-            // A record must cover its 4 timestamp bytes. A len < 4 here is a misaligned byte: drop one
-            // and resync rather than emit garbage (honest-data invariant).
-            if (len < OuraFraming.minRecordLen) {
-                buf.removeAt(0)
-                continue
-            }
-            val total = 2 + len
-            if (buf.size < total) break   // wait for the rest of this record
-            val slice = IntArray(total) { buf[it] }
-            OuraFraming.parseRecord(slice)?.let { out.add(it) }
-            repeat(total) { buf.removeAt(0) }
-        }
-        return out
+        val rec = OuraFraming.parseRecord(fragment) ?: return emptyList()
+        return listOf(rec)
     }
 
     /**
-     * Discard any buffered partial bytes (call on disconnect so a half-record does not bleed into the
-     * next session). Mirrors the StandardHRSource stop()/reset discipline.
+     * No-op retained for call-site compatibility (disconnect teardown). There is no buffered state to
+     * clear in the one-packet-per-notification model, so a half-record can never bleed across sessions.
      */
-    fun reset() {
-        buf.clear()
-    }
+    fun reset() {}
 
-    /** Number of bytes currently buffered awaiting completion (observability only). */
-    val bufferedByteCount: Int get() = buf.size
-
-    companion object {
-        /**
-         * A declared total beyond this is a corrupt/misaligned length, not a real record. The largest
-         * real Oura record is ~18 bytes (s6); `len` is a single byte (max 255), so 2 + 255 = 257 is
-         * the hard ceiling regardless; this constant documents the intent.
-         */
-        const val maxRecordBytes = 257
-    }
+    /** Always 0: no bytes are ever buffered between notifications (observability only). */
+    val bufferedByteCount: Int get() = 0
 }

--- a/android/app/src/main/java/com/noop/oura/HypnogramAssembler.kt
+++ b/android/app/src/main/java/com/noop/oura/HypnogramAssembler.kt
@@ -1,0 +1,126 @@
+package com.noop.oura
+
+// HypnogramAssembler: reconstruct the TIME AXIS of the ring's sleep-phase hypnogram. Byte-identical
+// Kotlin twin of Swift's HypnogramAssembler.swift.
+//
+// THE PROBLEM (observed on-device 2026-07-12, Gen3): the ring's SleepNet finalizes a night's staging
+// AFTER wake and writes the whole hypnogram to its event log in ONE BURST — e.g. 23 records x 52
+// codes, all sharing essentially the same envelope ring-time (the WRITE moment). The envelope
+// timestamp therefore marks WHEN THE ANALYSIS WAS SAVED, not when the sleep happened; anchoring each
+// record at its envelope collapses an entire night onto a few seconds.
+//
+// THE RECONSTRUCTION: the burst's codes are one contiguous sequence at 30 s/code, ENDING at the
+// anchored burst end. Laying N codes backward from that end recovers the real window. The 30 s epoch
+// is triple-confirmed: open_oura's sleepnet.md ("DEEP/LIGHT/REM/WAKE classification at 30-second
+// intervals"), the observed window math (1,196 codes over a ~10 h night), and the 0x49 summary's
+// window minutes over those same codes. The burst end itself is the matching 0x49 window's TRUE
+// sleep end when available (the write moment trails it by 10–43 min observed) — that pairing lives
+// in the live source; this assembler only groups and lays out.
+//
+// Platform-pure, no android.bluetooth, no clock (the caller resolves the anchored end time).
+
+/** One sleep-phase record as fed to the assembler: its envelope ring-time + decoded codes in order. */
+data class OuraHypnogramRecord(val ringTimestamp: Long, val phases: List<OuraSleepPhase>)
+
+/** One reconstructed code with its laid-out unix-seconds timestamp (interval START). */
+data class OuraHypnogramCode(val phase: OuraSleepPhase, val ts: Long)
+
+/** One completed burst of consecutive sleep-phase records (usually a whole night's hypnogram). */
+data class OuraHypnogramBurst(val records: List<OuraHypnogramRecord>) {
+    /** Total 2-bit codes across the burst. */
+    val totalCodes: Int get() = records.sumOf { it.phases.size }
+
+    /**
+     * The burst's LAST envelope ring-time — the write/finalization moment the reconstruction anchors
+     * its END to (absent a 0x49 refinement), and the resume-cursor note for the whole burst.
+     */
+    val lastRingTimestamp: Long get() = records.lastOrNull()?.ringTimestamp ?: 0
+
+    /**
+     * True when any record's envelope ring-time is LOWER than its predecessor's within this burst —
+     * the one signal that the arrival order (which the layout trusts as the sequence ground truth)
+     * might not be chronological. Surfaced so the caller can LOG it rather than fail silently;
+     * re-sorting is deliberately not done (envelope ring-times of a burst are near-identical write
+     * moments, so a sort on them could scramble the true code sequence).
+     */
+    val hasNonMonotonicRingTimes: Boolean
+        get() = records.zipWithNext().any { (a, b) -> b.ringTimestamp < a.ringTimestamp }
+
+    /**
+     * Lay the burst's codes out backward from [endUnixSeconds] at [secondsPerCode]. Code j of N gets
+     * `ts = end - (N - j) * secondsPerCode` — i.e. each ts marks the START of that code's interval
+     * and the final code's interval ends exactly at the burst end. Order: records in arrival order,
+     * codes by their in-record index (the sequence is the ground truth; the spacing is the documented
+     * 30 s SleepNet epoch). Arrival order is deliberately NOT re-sorted by envelope ring-time — see
+     * [hasNonMonotonicRingTimes] for the surfaced escape hatch.
+     */
+    fun codesWithTimes(endUnixSeconds: Long, secondsPerCode: Long = 30): List<OuraHypnogramCode> {
+        val n = totalCodes
+        val out = ArrayList<OuraHypnogramCode>(n)
+        var j = 0
+        for (record in records) {
+            for (phase in record.phases) {
+                out.add(OuraHypnogramCode(phase, endUnixSeconds - (n - j) * secondsPerCode))
+                j += 1
+            }
+        }
+        return out
+    }
+}
+
+/**
+ * Accumulate consecutive sleep-phase records into bursts. Records whose envelope ring-times sit
+ * within [burstGapTicks] of the previous record belong to the same burst (a finalization write-out);
+ * a larger gap (a different night / a separate analysis pass) closes the burst and starts a new one.
+ */
+class OuraHypnogramAssembler(
+    /**
+     * Max envelope ring-time gap (ticks, 100 ms each) between records of ONE burst. Observed bursts
+     * share rts within a few seconds; 600 ticks = 60 s is generous while still splitting nights
+     * (separate finalizations are hours apart).
+     */
+    val burstGapTicks: Long = 600,
+) {
+    private var current = ArrayList<OuraHypnogramRecord>()
+
+    /**
+     * Feed one record. Returns the PREVIOUS burst when this record's ring-time gap closes it (the fed
+     * record then starts the next burst); null while the current burst is still growing. Records with
+     * no codes are ignored (nothing to place).
+     */
+    fun feed(ringTimestamp: Long, phases: List<OuraSleepPhase>): OuraHypnogramBurst? {
+        if (phases.isEmpty()) return null
+        val record = OuraHypnogramRecord(ringTimestamp, phases)
+        val last = current.lastOrNull()
+        if (last != null) {
+            val gap = if (ringTimestamp >= last.ringTimestamp) {
+                ringTimestamp - last.ringTimestamp
+            } else {
+                last.ringTimestamp - ringTimestamp
+            }
+            if (gap > burstGapTicks) {
+                val done = OuraHypnogramBurst(current)
+                current = arrayListOf(record)
+                return done
+            }
+        }
+        current.add(record)
+        return null
+    }
+
+    /** Close and return the in-progress burst (call at drain end / teardown), or null if none. */
+    fun flush(): OuraHypnogramBurst? {
+        if (current.isEmpty()) return null
+        val done = OuraHypnogramBurst(current)
+        current = ArrayList()
+        return done
+    }
+
+    /** Discard any partial state (fresh session). */
+    fun reset() {
+        current = ArrayList()
+    }
+
+    /** Number of records currently accumulating (observability only). */
+    val pendingRecordCount: Int get() = current.size
+}

--- a/android/app/src/main/java/com/noop/oura/OuraDriver.kt
+++ b/android/app/src/main/java/com/noop/oura/OuraDriver.kt
@@ -216,8 +216,12 @@ class OuraDriver(
                 phase = OuraDriverPhase.Streaming
                 emptyList()
             } else {
-                // Ack-fetch (max=0) at the new cursor advances without re-pulling data (s5.3 step 4).
-                listOf(OuraCommands.getEvents(cursor = after.cursor, maxEvents = 0))
+                // Continuation fetch at the ADVANCED cursor (max seen ring-time + 1), same shape as the
+                // initial request — open_oura drain_events re-issues (start, 255, -1) every batch. The
+                // old open_ring "ack-fetch" (max=0 at a non-advancing cursor) made the ring RESTART its
+                // serve from that cursor: the observed same-window re-serve loop (s5.3). Parity with
+                // Swift 2bbdaa42.
+                listOf(OuraCommands.getEvents(cursor = after.cursor, maxEvents = 255))
             }
         }
     }
@@ -338,6 +342,20 @@ class OuraDriver(
      */
     fun isPlausibleAnchorEpoch(epochSeconds: Long): Boolean = plausibleAnchorMs(epochSeconds) != null
 
+    /**
+     * Adopt a ring-time→UTC anchor from the 0x13 SyncTime response pair (`rt` = the ring's clock
+     * counter in ticks when it processed our SyncTime, `unixSeconds` = host wall-clock at receipt).
+     * Same plausibility gate as the 0x42/0x85 paths; returns whether the anchor was set. The freshest
+     * possible pair, so it overwrites any earlier anchor (an in-log 0x42 from the same clock domain
+     * yields the same mapping anyway). Byte-identical twin of Swift's adoptSyncTimeAnchor.
+     */
+    fun adoptSyncTimeAnchor(ringTimestamp: Long, unixSeconds: Long): Boolean {
+        val ms = plausibleAnchorMs(unixSeconds) ?: return false
+        anchorUtcMs = ms
+        anchorRingTime = ringTimestamp
+        return true
+    }
+
     // MARK: - Record ingest (decode)
 
     /**
@@ -393,8 +411,8 @@ class OuraDriver(
                 // rather than guess the partial layout. Per OURA_PROTOCOL.md s6.13.
                 emptyList()
 
-            // --- Tier A: Sleep phase (2-bit codes are verified) ---
-            OuraEventTag.SLEEP_PHASE, OuraEventTag.SLEEP_PHASE_ALT ->
+            // --- Tier A: Sleep phase (2-bit codes are verified; 0x4B is the same layout, s6.12) ---
+            OuraEventTag.SLEEP_PHASE_B, OuraEventTag.SLEEP_PHASE, OuraEventTag.SLEEP_PHASE_ALT ->
                 (OuraDecoders.decodeSleepPhase(record) ?: emptyList()).map { OuraEvent.SleepPhaseEvent(it) }
 
             // --- Tier A: Lifecycle / state / time ---
@@ -444,7 +462,7 @@ class OuraDriver(
                         ),
                     ),
                 )
-            OuraEventTag.SLEEP_SUMMARY_1, OuraEventTag.SLEEP_SUMMARY_B, OuraEventTag.SLEEP_SUMMARY_C,
+            OuraEventTag.SLEEP_SUMMARY_1, OuraEventTag.SLEEP_SUMMARY_C,
             OuraEventTag.SLEEP_SUMMARY_D, OuraEventTag.SLEEP_SUMMARY_E, OuraEventTag.SLEEP_SUMMARY_F ->
                 listOf(
                     OuraEvent.TierB(
@@ -585,5 +603,24 @@ class OuraDriver(
          */
         private const val MIN_PLAUSIBLE_EPOCH_SECONDS = 1_577_836_800L
         private const val MAX_PLAUSIBLE_EPOCH_SECONDS = 2_051_222_400L
+
+        /**
+         * Resolve the 0x13 SyncTime-response device timestamp into ring TICKS, or null when no
+         * unambiguous reading exists. ringverse BLE.md labels the field "seconds" but the ring's record
+         * clock runs in 100 ms ticks, so both readings are tried: the raw value (already ticks) and
+         * value×10 (seconds→ticks). The ring's clock at connect must sit shortly AFTER where the last
+         * drain ended, so a candidate is plausible iff it falls in `[historyCursor, historyCursor +
+         * 7 days]`; exactly one must fit (ambiguity or a fresh/reset cursor → null → the caller logs
+         * raw instead of guessing). Pure. Byte-identical twin of Swift's syncTimeAnchorCandidate.
+         */
+        fun syncTimeAnchorCandidate(responseValue: Long, historyCursor: Long): Long? {
+            if (historyCursor <= 0) return null
+            val lower = historyCursor
+            val upper = lower + 6_048_000L   // 7 days of 100 ms ticks
+            val readings = listOf(responseValue, responseValue * 10)
+            val fits = readings.filter { it in lower..upper && it <= 0xFFFF_FFFFL }
+            if (fits.size != 1) return null
+            return fits[0]
+        }
     }
 }

--- a/android/app/src/main/java/com/noop/oura/OuraEvents.kt
+++ b/android/app/src/main/java/com/noop/oura/OuraEvents.kt
@@ -39,12 +39,21 @@ data class OuraTemp(val ringTimestamp: Long, val celsius: Double)
  */
 data class OuraBattery(val percent: Int, val voltageMv: Int? = null, val charging: Boolean? = null)
 
-/** Sleep phase code (OURA_PROTOCOL.md s6.12): 2-bit codes 0=awake, 1=light, 2=deep, 3=REM. */
+/**
+ * The 2-bit sleep-phase code values, per open_oura's VALIDATED `decode_sleep_phases` mapping
+ * (events.rs `PHASE = ["deep", "light", "rem", "awake"]`): 0=deep, 1=light, 2=rem, 3=awake.
+ *
+ * CORRECTION (2026-07-12, PARITY twin of Swift `OuraSleepStage`): the old mapping
+ * (0=awake/2=deep/3=REM) came from the same unverified doc as the rest of s6.12 and was contradicted
+ * by live captures — phase records decoded AT WAKE (wearer demonstrably awake) carry code 3, which is
+ * awake under open_oura's mapping and "REM" under the old one. The raw wire code persists unchanged
+ * (`stage.raw` is what's stored); only these LABELS changed, byte-identical on both platforms.
+ */
 enum class OuraSleepStage(val raw: Int) {
-    AWAKE(0),
+    DEEP(0),
     LIGHT(1),
-    DEEP(2),
-    REM(3);
+    REM(2),
+    AWAKE(3);
 
     companion object {
         private val byRaw = entries.associateBy { it.raw }
@@ -176,4 +185,28 @@ sealed class OuraEvent {
 
     /** True for Tier-B events, so a consumer can assert none leaked into a Tier-A-only sink. */
     val isTierB: Boolean get() = this is TierB || this is ActivityInfo
+
+    /**
+     * The record's envelope ring-time, when it carries one (battery is a plain response, not a log
+     * record). Feeds the history drain's in-session continuation cursor: open_oura's `drain_events`
+     * advances `start` past the max timestamp of EVERY event in a batch, whatever its tag.
+     * Byte-identical twin of Swift's envelopeRingTimestamp.
+     */
+    val envelopeRingTimestamp: Long?
+        get() = when (this) {
+            is Hr -> value.ringTimestamp
+            is Ibi -> value.ringTimestamp
+            is Hrv -> value.ringTimestamp
+            is Spo2 -> value.ringTimestamp
+            is Temp -> value.ringTimestamp
+            is Battery -> null
+            is SleepPhaseEvent -> value.ringTimestamp
+            is MotionEvent -> value.ringTimestamp
+            is StateEvent -> value.ringTimestamp
+            is TimeSyncEvent -> value.ringTimestamp
+            is RtcBeaconEvent -> value.ringTimestamp
+            is DebugTextEvent -> ringTimestamp
+            is TierB -> value.ringTimestamp
+            is ActivityInfo -> value.ringTimestamp
+        }
 }

--- a/android/app/src/main/java/com/noop/oura/OuraHistoryDrain.kt
+++ b/android/app/src/main/java/com/noop/oura/OuraHistoryDrain.kt
@@ -1,0 +1,149 @@
+package com.noop.oura
+
+/**
+ * Pure, testable decision core for the Oura history drain + durable resume cursor (#91 / #291).
+ * Byte-identical Kotlin twin of Swift's `OuraHistoryDrain` struct.
+ *
+ * The `0x11` history summary carries no cursor — only `bytes_left` (a remaining-byte count) and a
+ * `moreData` flag. A healthy drain runs until `bytes_left == 0`; the resume cursor commits from the
+ * newest STORED sample's ring-time at drain end. Byte counts are never persisted.
+ *
+ * Two cursors, deliberately separate:
+ *  - [maxSeenRingTime] tracks EVERY history record (anchored or not) and steers only the in-session
+ *    CONTINUATION requests (open_oura `drain_events` advances `start = max_ts + 1` per batch — a
+ *    non-advancing re-request makes the ring restart its serve: the observed 5x re-serve loop).
+ *  - [maxStoredRingTime] tracks only anchored, STORED samples and is the only value the DURABLE
+ *    cursor may commit from (honest-data invariant).
+ *
+ * All ring-times are the unsigned 32-bit value carried as a Long (0..0xFFFFFFFF), the Kotlin
+ * stand-in for Swift's UInt32.
+ */
+class OuraHistoryDrain {
+    private var minBytesLeftSeen = Long.MAX_VALUE
+    private var stallCount = 0
+
+    /** Newest STORED ring-time seen this drain — the value the resume cursor commits to at drain end. */
+    var maxStoredRingTime: Long = 0
+        private set
+
+    /**
+     * Newest ring-time SEEN this drain across ALL history records (anchored or not) — the in-session
+     * continuation cursor's source.
+     */
+    var maxSeenRingTime: Long = 0
+        private set
+
+    /** History records seen since the last GetEvents request — open_oura's `batch_events` progress test. */
+    var eventsSinceLastRequest: Long = 0
+        private set
+
+    /**
+     * A real stored sample older than where we sought this fetch: the ring's clock reset (or it ignored
+     * the seek), so the persisted cursor is stale → full pull next connect.
+     */
+    var sawPreResumeData = false
+        private set
+
+    /** Reset the per-drain state at the start of a fetch. Mirrors the live source's fetch-start reset. */
+    fun reset() {
+        minBytesLeftSeen = Long.MAX_VALUE
+        stallCount = 0
+        maxStoredRingTime = 0
+        maxSeenRingTime = 0
+        eventsSinceLastRequest = 0
+        sawPreResumeData = false
+    }
+
+    /**
+     * Fold in one history summary; returns whether the drain should CONTINUE.
+     *
+     * `moreData == false` (`bytes_left == 0`) always completes. Otherwise two backstops force-stop a
+     * misbehaving ring while keeping banked progress: the STALL guard (`bytes_left` must shrink across
+     * summaries — [MAX_STALL_SUMMARIES] flat reads means it's looping) and the DEADLINE guard
+     * (`elapsedSeconds` past [MAX_DRAIN_SECONDS]).
+     */
+    fun onSummary(bytesLeft: Long, moreData: Boolean, elapsedSeconds: Double): Boolean {
+        if (!moreData) return false
+        if (bytesLeft < minBytesLeftSeen) {
+            minBytesLeftSeen = bytesLeft
+            stallCount = 0
+        } else {
+            stallCount += 1
+            if (stallCount >= MAX_STALL_SUMMARIES) return false
+        }
+        if (elapsedSeconds > MAX_DRAIN_SECONDS) return false
+        return true
+    }
+
+    /**
+     * Record a STORED history sample's ring-time toward the resume cursor. Call ONLY where a sample
+     * resolved a REAL anchored time (never a wall-clock fallback). Ignores corrupt (over-ceiling)
+     * times, and flags a reboot when a real sample predates `resumeCursorAtFetchStart` (0 = full pull,
+     * no floor).
+     */
+    fun noteStoredRingTime(rt: Long, resumeCursorAtFetchStart: Long) {
+        if (rt > MAX_PLAUSIBLE_RESUME_TICKS) return
+        if (rt > maxStoredRingTime) maxStoredRingTime = rt
+        if (resumeCursorAtFetchStart > 0 && rt < resumeCursorAtFetchStart) sawPreResumeData = true
+    }
+
+    /**
+     * Record ANY history record's ring-time toward the in-session continuation cursor (anchored or
+     * not), and count it toward the batch-progress test. Ignores corrupt (over-ceiling) times.
+     */
+    fun noteSeenRingTime(rt: Long) {
+        if (rt > MAX_PLAUSIBLE_RESUME_TICKS) return
+        if (rt > maxSeenRingTime) maxSeenRingTime = rt
+        eventsSinceLastRequest += 1
+    }
+
+    /**
+     * The cursor for the NEXT in-session GetEvents request, or null to stop (open_oura `drain_events`:
+     * `progressed = batch_events > 0 && next > start; if !progressed break`). Re-sending a
+     * non-advancing cursor makes the ring RESTART serving from it, so a flat batch ends the drain
+     * instead of retrying. On advance, the batch counter re-arms for the next request's progress test.
+     */
+    fun continuationCursor(lastRequestCursor: Long): Long? {
+        if (eventsSinceLastRequest <= 0) return null
+        val next = maxSeenRingTime + 1
+        if (next <= lastRequestCursor) return null
+        eventsSinceLastRequest = 0
+        return next
+    }
+
+    /**
+     * The cursor to persist at drain end, given the current cursor and whether [maxStoredRingTime]
+     * resolves under the CURRENT anchor. A reboot ([sawPreResumeData]) resets to 0 (honest full pull
+     * next connect); otherwise the cursor advances to [maxStoredRingTime] only if it moved forward AND
+     * resolves. Unchanged in every other case.
+     */
+    fun resumeCursorAtDrainEnd(currentCursor: Long, resolvesUnderAnchor: Boolean): Long {
+        if (sawPreResumeData) return 0
+        if (maxStoredRingTime > currentCursor && resolvesUnderAnchor) return maxStoredRingTime
+        return currentCursor
+    }
+
+    companion object {
+        /**
+         * A ring-time above this is corrupt (~1.6 years of ticks) and must not set the resume cursor,
+         * or the next session would seek into nonsense. Bounds the cursor at the source.
+         */
+        const val MAX_PLAUSIBLE_RESUME_TICKS = 500_000_000L
+
+        /** `bytes_left` not shrinking for this many straight summaries = the ring is looping; stop. */
+        const val MAX_STALL_SUMMARIES = 3
+
+        /**
+         * A healthy full pull finishes in ~1-2 min; past this something upstream is wrong — stop, keep
+         * the banked progress, and let the next self-chained pass / periodic re-fetch continue.
+         */
+        const val MAX_DRAIN_SECONDS = 300.0
+
+        /**
+         * Sanitize a cursor loaded from persistence: a value above the plausibility ceiling is pre-fix
+         * garbage and must reset to a full pull.
+         */
+        fun sanitizeLoadedCursor(persisted: Long): Long =
+            if (persisted in 0..MAX_PLAUSIBLE_RESUME_TICKS) persisted else 0
+    }
+}

--- a/android/app/src/main/java/com/noop/oura/OuraSleepSessionMapping.kt
+++ b/android/app/src/main/java/com/noop/oura/OuraSleepSessionMapping.kt
@@ -1,0 +1,85 @@
+package com.noop.oura
+
+/**
+ * Platform-neutral holder for the ring-PROVIDED reconstructed hypnogram night: the session bounds +
+ * efficiency + the `[{start,end,stage}]` stage breakdown JSON. Kept free of the Room `SleepSession`
+ * entity (it lives in `com.noop.data`) so this mapper is pure + unit-testable without the DB; the ble
+ * layer converts it to the entity and upserts it under the ring's own deviceId.
+ */
+data class OuraSleepSession(
+    val startTs: Long,
+    val endTs: Long,
+    val efficiency: Double?,
+    val stagesJson: String,
+)
+
+/**
+ * Pure twin of Swift `WhoopStore.OuraSleepSessionMapping`. Reshapes the anchored per-code hypnogram (the
+ * sequence `OuraHypnogramAssembler.codesWithTimes` lays at the 30 s SleepNet epoch, after its end is
+ * anchored + 0x49-refined) into a `CachedSleepSession`-shaped night.
+ *
+ * WHY: the raw per-code stages already persist as `OURA_SLEEP_PHASE` stream events, but nothing turns
+ * them into a NIGHT with a stage breakdown the sleep surfaces read. Banking the ring-provided hypnogram
+ * as a `SleepSession` under the ring's OWN deviceId (the imported/measured side, NOT the "-noop" computed
+ * sibling) lets `WhoopRepository.mergeSleepRichness`'s imported-over-computed rule surface Oura's own
+ * SleepNet staging over NOOP's sparse-motion computed night — "richer record wins", reusing the exact
+ * arbitration that already picks a WHOOP/HC import over a computed night (#240).
+ *
+ * HONEST-DATA: this is PROVIDED data (Oura's on-ring classifier), only reshaped — never a new derivation.
+ *
+ * PARITY: the `stagesJson` string is built by hand in a FIXED key order (`start`,`end`,`stage`) so it is
+ * BYTE-IDENTICAL to the Swift twin for the same codes. Keep in lockstep with `OuraSleepSessionMapping.swift`.
+ */
+object OuraSleepSessionMapping {
+
+    /** Stage token per code — the on-device stager / importer convention: deep/light/rem/wake. */
+    fun token(stage: OuraSleepStage): String = when (stage) {
+        OuraSleepStage.DEEP -> "deep"
+        OuraSleepStage.LIGHT -> "light"
+        OuraSleepStage.REM -> "rem"
+        OuraSleepStage.AWAKE -> "wake"
+    }
+
+    /**
+     * Build the night from the anchored per-code stage sequence (ascending `ts`, one code per
+     * [secondsPerCode] epoch). Adjacent equal stages merge into one `[start,end]` segment. `startTs` = first
+     * code's ts; `endTs` = last code's ts + one epoch (the anchored true sleep end). `efficiency` = asleep /
+     * (asleep + awake) as a 0–1 fraction (null when nothing is in bed). Returns null for an empty sequence.
+     */
+    fun session(codes: List<Pair<Long, OuraSleepStage>>, secondsPerCode: Long = 30L): OuraSleepSession? {
+        val first = codes.firstOrNull() ?: return null
+        val last = codes.last()
+
+        // Merge adjacent equal stages into contiguous [start,end] segments.
+        data class Seg(val start: Long, var end: Long, val stage: OuraSleepStage)
+        val segs = ArrayList<Seg>()
+        for ((ts, stage) in codes) {
+            val segEnd = ts + secondsPerCode
+            val lastSeg = segs.lastOrNull()
+            if (lastSeg != null && lastSeg.stage == stage && lastSeg.end == ts) {
+                lastSeg.end = segEnd
+            } else {
+                segs.add(Seg(ts, segEnd, stage))
+            }
+        }
+
+        val json = segs.joinToString(separator = ",", prefix = "[", postfix = "]") {
+            "{\"start\":${it.start},\"end\":${it.end},\"stage\":\"${token(it.stage)}\"}"
+        }
+
+        var asleepSec = 0L
+        var awakeSec = 0L
+        for ((_, stage) in codes) {
+            if (stage == OuraSleepStage.AWAKE) awakeSec += secondsPerCode else asleepSec += secondsPerCode
+        }
+        val inBedSec = asleepSec + awakeSec
+        val efficiency = if (inBedSec > 0L) asleepSec.toDouble() / inBedSec.toDouble() else null
+
+        return OuraSleepSession(
+            startTs = first.first,
+            endTs = last.first + secondsPerCode,
+            efficiency = efficiency,
+            stagesJson = json,
+        )
+    }
+}

--- a/android/app/src/main/java/com/noop/ui/IntelligenceScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/IntelligenceScreen.kt
@@ -483,6 +483,10 @@ internal fun daySourceBadge(deviceId: String): Pair<String, Color> = when {
     deviceId.endsWith("-noop") -> "On-device" to Palette.chargeColor
     deviceId == com.noop.data.WhoopRepository.APPLE_HEALTH_SOURCE ||
         deviceId == com.noop.data.WhoopRepository.HEALTH_CONNECT_SOURCE -> "Apple Health" to Palette.accent
+    // An Oura night is persisted under the ring's "oura-<uuid>" id (the ring PROVIDES its own SleepNet
+    // hypnogram, banked as the merge-winning session) — name it "Oura", not the generic "Whoop" the
+    // else-branch would give a non-"-noop" id. Resolved off the canonical brand table, not an "oura" literal.
+    com.noop.data.DeviceBrandCatalog.isOura(deviceId) -> "Oura" to Palette.restColor
     else -> "Whoop" to Palette.accent
 }
 

--- a/android/app/src/main/java/com/noop/ui/SleepHeroLogic.kt
+++ b/android/app/src/main/java/com/noop/ui/SleepHeroLogic.kt
@@ -40,10 +40,16 @@ internal fun heroPerformanceScore(
 }
 
 /**
- * Whether a SPECIFIC night's sleep-performance score is WHOOP's own imported figure or NOOP's
- * on-device approximation — so the hero is honest about provenance, like Today's badges. Keyed by the
- * night's wake-day (matching [heroPerformanceScore]) so a navigated night's badge tracks ITS OWN
- * score's provenance, not last night's. Mirrors the macOS SleepView.heroSource.
+ * Whether a SPECIFIC night's sleep-performance score is WHOOP's own imported figure, an Oura
+ * ring-provided figure, or NOOP's on-device approximation — so the hero is honest about provenance, like
+ * Today's badges. Keyed by the night's wake-day (matching [heroPerformanceScore]) so a navigated night's
+ * badge tracks ITS OWN score's provenance, not last night's. WHOOP import wins first; only a night
+ * surfaced under a live Oura strap reads "Oura". Mirrors the macOS SleepView.heroSource.
  */
-internal fun restHeroSource(imported: ImportedSleepSeries, wakeDay: String?): String =
-    if (wakeDay != null && imported.performance[wakeDay] != null) "Whoop" else "On-device"
+internal fun restHeroSource(
+    imported: ImportedSleepSeries, wakeDay: String?, activeIsOura: Boolean = false,
+): String = when {
+    wakeDay != null && imported.performance[wakeDay] != null -> "Whoop"
+    activeIsOura -> "Oura"
+    else -> "On-device"
+}

--- a/android/app/src/main/java/com/noop/ui/SleepScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/SleepScreen.kt
@@ -134,6 +134,10 @@ fun SleepScreen(
     onOpenJournal: () -> Unit = {},
 ) {
     val days by vm.recentDays.collectAsStateWithLifecycle()
+    // Whether the ACTIVE strap is an Oura ring, off the canonical brand table (not an "oura" literal) — so
+    // the sleep surfaces name a ring-PROVIDED night's provenance "Oura" and flag its split as the ring's
+    // RAW on-device stages. Read/UI only, no stored value. Mirrors macOS Repository.activeDeviceIsOura.
+    val activeIsOura = com.noop.data.DeviceBrandCatalog.isOura(vm.activeStrapId)
 
     // PERF (#scroll-jank): the BLE live state ticks ~1Hz. This screen reads `live` ONLY for the
     // "syncing history" note (backfilling + the chunk count), so reading the whole `live` object at
@@ -494,7 +498,7 @@ fun SleepScreen(
                     score = if (night != null) heroPerformanceScore(night, days, imported)
                             else tilesModel?.performance?.latest,
                     asleepMin = model?.stages?.asleep,
-                    source = restHeroSource(imported, night?.dayKey ?: days.lastOrNull()?.day),
+                    source = restHeroSource(imported, night?.dayKey ?: days.lastOrNull()?.day, activeIsOura),
                     overline = nightRelativeLabel(nightOffset),
                 )
             }
@@ -521,6 +525,7 @@ fun SleepScreen(
             item {
             Hero(
                 display = display,
+                activeIsOura = activeIsOura,
                 clock = night?.clockLabel ?: model?.clockLabel,
                 nightOffset = nightOffset,
                 lastIndex = max(navDays.lastIndex, 0),
@@ -933,6 +938,9 @@ private fun SleepHeroVessel(fraction: Double, value: Double, tint: Color, diamet
 @Composable
 private fun Hero(
     display: HeroDisplay?,
+    // Whether the active strap is an Oura ring — names an Oura night's provenance and captions its split as
+    // the ring's RAW on-device stages. Read/UI only. Mirrors macOS Repository.activeDeviceIsOura.
+    activeIsOura: Boolean = false,
     clock: String?,
     nightOffset: Int,
     lastIndex: Int,
@@ -991,8 +999,12 @@ private fun Hero(
             val inBedMin = groupInBedMin
                 ?: session?.let { (it.endTs - it.effectiveStartTs) / 60.0 }
                 ?: s.total
+            // An Oura night's stages are the ring's RAW on-device SleepNet classification (decoded off the
+            // 0x49 phase stream), NOT a NOOP approximation — so it gets its own honest caption instead of the
+            // "approx. stages (on-device)" one that describes NOOP's own sparse-motion staging.
+            val stageCaption = if (activeIsOura) " · raw on-device stages" else " · approx. stages (on-device)"
             val subtitle = "${durationText(inBedMin)} in bed · ${display.efficiencyText} efficiency" +
-                (if (display.realSegments != null) " · approx. stages (on-device)" else "")
+                (if (display.realSegments != null) stageCaption else "")
             // iOS #988 port: true per-epoch segments (≥ 2 — a single run has no transitions to lay
             // out) get the per-stage timeline rows; the rows ARE the legend, so no footer. Anything
             // else keeps the honest proportional strip + StageBreakdownRows footer.
@@ -1043,6 +1055,10 @@ private fun Hero(
                     }
                 }
             }
+            // For an Oura-provided night, say plainly this split is the ring's RAW on-device classification —
+            // so the larger Awake / smaller Deep+REM here isn't misread as the polished numbers the Oura app
+            // shows for the same night (the app post-processes the same stream). Mirrors iOS ouraRawStagesNote.
+            if (activeIsOura) OuraRawStagesNote()
         }
         // Naps card (#508/#518): the day's blocks OTHER than the main night, each editable / deletable
         // with the SAME mechanism main sleep uses, plus a Main / Nap(s) / Total split so what drives the
@@ -1054,6 +1070,7 @@ private fun Hero(
                 onEditNapTimes = onUpdateTimes,
                 onDeleteNap = onDeleteSession,
                 habitualMidsleepSec = habitualMidsleepSec,
+                activeIsOura = activeIsOura,
             )
         }
     }
@@ -1076,6 +1093,8 @@ private fun NapsCard(
     // The LEARNED habitual midsleep, fed to the main-night selector so the "why this is your main sleep"
     // reason matches the block the hero shows. null = cold-start band. Mirrors iOS SleepView. (C1)
     habitualMidsleepSec: Long? = null,
+    // Active strap is an Oura ring → a computed night's provenance reads "Oura" not "On-device" (C4).
+    activeIsOura: Boolean = false,
 ) {
     val mainMin = (main.endTs - main.effectiveStartTs) / 60.0
     val napMin = naps.sumOf { (it.endTs - it.effectiveStartTs) / 60.0 }
@@ -1109,8 +1128,33 @@ private fun NapsCard(
             // per-day merge winner; the info affordance reveals the foundation reason for the pick. Mirrors
             // iOS SleepView.mainSleepFooter. (spec 2026-06-20 C1/C4)
             Box(Modifier.fillMaxWidth().height(Metrics.divider).background(Palette.hairline))
-            MainSleepFooter(main = main, naps = naps, habitualMidsleepSec = habitualMidsleepSec)
+            MainSleepFooter(main = main, naps = naps, habitualMidsleepSec = habitualMidsleepSec, activeIsOura = activeIsOura)
         }
+    }
+}
+
+/**
+ * Honest caveat for an Oura-provided night: the stage split shown is the ring's RAW on-device SleepNet
+ * classification read straight off the BLE phase stream — NOT the adjusted stages the Oura app displays.
+ * The app post-processes the same night, so its Deep/REM run higher and its Awake lower; cross-checks put
+ * our Awake well above the app's. Surfaced so the breakdown isn't taken for the app's. Mirrors iOS
+ * SleepView.ouraRawStagesNote. Copy + tint (design token [Palette.restColor]) match Swift.
+ */
+@Composable
+private fun OuraRawStagesNote() {
+    Row(
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+        verticalAlignment = Alignment.Top,
+        modifier = Modifier.padding(horizontal = 2.dp),
+    ) {
+        SourceBadge(text = "Raw on-device stages", tint = Palette.restColor)
+        Text(
+            "This split is the ring's raw on-device classification read over Bluetooth, not the adjusted " +
+                "stages the Oura app shows. Expect more Awake and less Deep/REM here than in the Oura app " +
+                "for the same night.",
+            style = NoopType.caption,
+            color = Palette.textTertiary,
+        )
     }
 }
 
@@ -1127,11 +1171,16 @@ private fun MainSleepFooter(
     main: SleepSession,
     naps: List<SleepSession>,
     habitualMidsleepSec: Long?,
+    activeIsOura: Boolean = false,
 ) {
     val reason = mainSleepReasonText(listOf(main) + naps, habitualMidsleepSec)
-    // C4 — the real merge winner, the SAME wording the By-Day badge uses ("On-device" / "Whoop" /
-    // "Apple Health"), keyed on the main block's source. Mirrors iOS SleepView.nightSource.
-    val (sourceText, sourceTint) = daySourceBadge(main.deviceId)
+    // C4 — the real merge winner, the SAME wording the By-Day badge uses ("Oura" / "On-device" / "Whoop" /
+    // "Apple Health"), keyed on the main block's source. A persisted Oura night already carries the ring id
+    // (→ "Oura" from daySourceBadge); a night that merely COMPUTED under a live Oura strap reads "On-device"
+    // there, so flip it to "Oura" too, matching iOS SleepView.nightSource (WHOOP/Apple imports still win).
+    val base = daySourceBadge(main.deviceId)
+    val (sourceText, sourceTint) =
+        if (base.first == "On-device" && activeIsOura) "Oura" to Palette.restColor else base
     var showWhy by remember(main.startTs) { mutableStateOf(false) }
     Column(verticalArrangement = Arrangement.spacedBy(Metrics.space10)) {
         Row(verticalAlignment = Alignment.CenterVertically) {

--- a/android/app/src/test/java/com/noop/ble/OuraSleepWindowPairingTest.kt
+++ b/android/app/src/test/java/com/noop/ble/OuraSleepWindowPairingTest.kt
@@ -1,0 +1,55 @@
+package com.noop.ble
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * Kotlin twin of Swift's OuraSleepWindowPairingTests. Regression for the 2026-07-17 capture: an overnight
+ * hypnogram burst and a ~3PM nap burst finalized in the SAME history drain. The old single-slot window
+ * let the nap's 0x49 overwrite the overnight's before the overnight burst persisted, so the overnight fell
+ * back to its SleepNet WRITE time (10:58, ~4 h after the true 07:00 sleep end). The fix keeps a COLLECTION
+ * and pairs each burst with the CLOSEST window by ring-time — these tests pin that picker.
+ */
+class OuraSleepWindowPairingTest {
+
+    // (ringTimestamp deciseconds, startOffMin, endOffMin). 6000 ticks = 10 min pairing tolerance.
+    private val overnight = Triple(8_400_000L, 778, 238)
+    private val nap = Triple(8_512_000L, 44, 34)
+
+    @Test fun overnightBurstPicksOvernightWindowDespiteLaterNap() {
+        val windows = listOf(overnight, nap)   // nap appended LAST (the old code grabbed it)
+        val picked = OuraLiveSource.closestSleepWindow049(windows, overnight.first + 50L, 6_000L)
+        assertEquals(overnight.first, picked?.first)
+        assertEquals(238, picked?.third)
+    }
+
+    @Test fun napBurstPicksNapWindow() {
+        val windows = listOf(overnight, nap)
+        val picked = OuraLiveSource.closestSleepWindow049(windows, nap.first + 30L, 6_000L)
+        assertEquals(nap.first, picked?.first)
+        assertEquals(34, picked?.third)
+    }
+
+    @Test fun noWindowInRangeReturnsNull() {
+        // Only the nap stashed; an overnight burst is ~3 h away → nil (caller keeps write-time fallback).
+        assertNull(OuraLiveSource.closestSleepWindow049(listOf(nap), overnight.first + 50L, 6_000L))
+    }
+
+    @Test fun closestOfTwoInRangeWins() {
+        val near = Triple(10_000L, 600, 10)
+        val far = Triple(13_000L, 600, 20)
+        val picked = OuraLiveSource.closestSleepWindow049(listOf(far, near), 10_500L, 6_000L)
+        assertEquals(10, picked?.third)   // near (gap 500) beats far (gap 2500)
+    }
+
+    @Test fun toleranceBoundaryInclusive() {
+        val w = Triple(100_000L, 600, 10)
+        assertEquals(w, OuraLiveSource.closestSleepWindow049(listOf(w), 100_000L - 6_000L, 6_000L))
+        assertNull(OuraLiveSource.closestSleepWindow049(listOf(w), 100_000L - 6_001L, 6_000L))
+    }
+
+    @Test fun emptyReturnsNull() {
+        assertNull(OuraLiveSource.closestSleepWindow049(emptyList(), 8_400_000L, 6_000L))
+    }
+}

--- a/android/app/src/test/java/com/noop/data/DeviceBrandCatalogTest.kt
+++ b/android/app/src/test/java/com/noop/data/DeviceBrandCatalogTest.kt
@@ -78,4 +78,21 @@ class DeviceBrandCatalogTest {
         val brands = DeviceBrandCatalog.all.map { it.brand }
         assertEquals(brands.size, brands.toSet().size)
     }
+
+    /** `isOura` resolves a registry deviceId to its brand by the "<idPrefix>-" prefix, true ONLY for the Oura
+     *  ring — what lets the sleep surfaces name an Oura night's provenance "Oura". Twin of Swift
+     *  `DeviceBrandCatalogTests.testIsOuraByRegistryIdPrefix` (SAME cases). */
+    @Test
+    fun isOuraByRegistryIdPrefix() {
+        assertTrue(DeviceBrandCatalog.isOura("oura-5C4C0BF8-2DF6-1B3A-18D0-3DF0B3590148"))
+        assertTrue(DeviceBrandCatalog.isOura("oura-anything"))
+        assertFalse(DeviceBrandCatalog.isOura("whoop-1234"))
+        assertFalse(DeviceBrandCatalog.isOura("garmin-1234"))
+        assertFalse(DeviceBrandCatalog.isOura("strap-1234"))
+        assertFalse(DeviceBrandCatalog.isOura("huami-1234"))
+        assertFalse(DeviceBrandCatalog.isOura("some-noop"))
+        assertFalse(DeviceBrandCatalog.isOura(""))
+        assertFalse(DeviceBrandCatalog.isOura("oura"))
+        assertFalse(DeviceBrandCatalog.isOura("neuraloura-1"))
+    }
 }

--- a/android/app/src/test/java/com/noop/data/OuraStreamMappingTest.kt
+++ b/android/app/src/test/java/com/noop/data/OuraStreamMappingTest.kt
@@ -75,9 +75,9 @@ class OuraStreamMappingTest {
         val deep = s.events[0]
         assertEquals(OuraStreamMapping.EVENT_SLEEP_PHASE, deep.kind)
         assertEquals("OURA_SLEEP_PHASE", deep.kind)
-        assertEquals(2, deep.payload["phase"])           // OuraSleepStage.DEEP.raw == 2
+        assertEquals(0, deep.payload["phase"])           // OuraSleepStage.DEEP.raw == 0 (open_oura validated)
         assertEquals(0, deep.payload["index"])
-        assertEquals(3, s.events[1].payload["phase"])     // REM.raw == 3
+        assertEquals(2, s.events[1].payload["phase"])     // REM.raw == 2 (open_oura validated)
         // PARITY: the payload is exactly { phase, index } - the Swift twin emits no phase_name, so neither
         // does Kotlin. Pin it so a re-added phase_name key breaks this test.
         assertNull(deep.payload["phase_name"])

--- a/android/app/src/test/java/com/noop/oura/DecoderGoldenTest.kt
+++ b/android/app/src/test/java/com/noop/oura/DecoderGoldenTest.kt
@@ -2,7 +2,9 @@ package com.noop.oura
 
 import org.junit.Assert.assertArrayEquals
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 /**
@@ -137,18 +139,30 @@ class DecoderGoldenTest {
 
     @Test
     fun testSleepPhase0x4E() {
-        // header 0x00, phase byte 0x6C = bits 01 10 11 00 -> light, deep, rem, awake.
+        // header 0x00, phase byte 0x6C = bits 01 10 11 00 = codes 1,2,3,0. Per open_oura's VALIDATED
+        // mapping (0=deep, 1=light, 2=rem, 3=awake) -> light, rem, awake, deep. PARITY: byte-identical
+        // to the Swift golden (DecoderGoldenTests.testSleepPhase0x4E).
         val rec = record("4e0602000100006c")
         val phases = OuraDecoders.decodeSleepPhase(rec)
         assertEquals(
             listOf(
                 OuraSleepPhase(ringTimestamp = rt, index = 0, stage = OuraSleepStage.LIGHT),
-                OuraSleepPhase(ringTimestamp = rt, index = 1, stage = OuraSleepStage.DEEP),
-                OuraSleepPhase(ringTimestamp = rt, index = 2, stage = OuraSleepStage.REM),
-                OuraSleepPhase(ringTimestamp = rt, index = 3, stage = OuraSleepStage.AWAKE),
+                OuraSleepPhase(ringTimestamp = rt, index = 1, stage = OuraSleepStage.REM),
+                OuraSleepPhase(ringTimestamp = rt, index = 2, stage = OuraSleepStage.AWAKE),
+                OuraSleepPhase(ringTimestamp = rt, index = 3, stage = OuraSleepStage.DEEP),
             ),
             phases,
         )
+    }
+
+    @Test
+    fun testSleepStageRawValuesMatchOpenOura() {
+        // Pin the validated open_oura order (0=deep, 1=light, 2=rem, 3=awake) so a regression to the
+        // old unverified mapping (0=awake/2=deep/3=REM) breaks loudly. Twin of the Swift enum.
+        assertEquals(0, OuraSleepStage.DEEP.raw)
+        assertEquals(1, OuraSleepStage.LIGHT.raw)
+        assertEquals(2, OuraSleepStage.REM.raw)
+        assertEquals(3, OuraSleepStage.AWAKE.raw)
     }
 
     // MARK: - 0x6B motion period (2-bit MOTION_STATE codes; 2 header bytes skipped)
@@ -242,6 +256,83 @@ class DecoderGoldenTest {
 
         val hr = OuraDecoders.decodeLiveHRPush(subBody, rt)
         assertEquals(OuraHR(ringTimestamp = rt, bpm = 59, ibiMs = 1025), hr)
+    }
+
+    // MARK: - 0x71 green_ibi_and_amp CANDIDATE decode (ringverse @0x503960, upstream #287)
+
+    /**
+     * Inverse of the firmware's scrambled packing (ringverse `p_green_ibi_and_amp`): middle-8 bytes
+     * at p[4..0] (ds0..ds4), amplitude bytes p[6..10] carry the mantissa in bits [7:1] and the
+     * PAIRED IBI's low bit in bit [0] (ds4..ds0 order), bits [2:1] of ds1..ds4 pack into p[12]
+     * two bits at a time, ds0's into p[13] bits [7:6] alongside the shift field. Twin of the Swift
+     * packGreenIBIAmp test helper.
+     */
+    private fun packGreenIBIAmp(ibis: IntArray, mants: IntArray, s: Int): IntArray {
+        val p = IntArray(14)
+        val mids = intArrayOf(4, 3, 2, 1, 0)
+        for (i in 0 until 5) p[mids[i]] = (ibis[i] shr 3) and 0xFF
+        val amps = intArrayOf(10, 9, 8, 7, 6)
+        for (i in 0 until 5) p[amps[i]] = ((mants[4 - i] shl 1) or (ibis[i] and 1)) and 0xFF
+        var pack12 = (ibis[1] shr 1) and 3
+        pack12 = pack12 or (((ibis[2] shr 1) and 3) shl 2)
+        pack12 = pack12 or (((ibis[3] shr 1) and 3) shl 4)
+        pack12 = pack12 or (((ibis[4] shr 1) and 3) shl 6)
+        p[12] = pack12
+        p[13] = (s and 7) or (((ibis[0] shr 1) and 3) shl 6)
+        return p
+    }
+
+    @Test
+    fun testGreenIBIAmpCandidateRoundTrip() {
+        // 11-bit IBIs exercising every packed bit field; 7-bit mantissas; s=3 -> shift 4.
+        val ibis = intArrayOf(1023, 800, 517, 2046, 901)
+        val mants = intArrayOf(1, 64, 100, 127, 33)
+        val p = packGreenIBIAmp(ibis, mants, s = 3)
+        val decoded = OuraDecoders.decodeGreenIBIAmpCandidate(p, rt)
+        assertNotNull(decoded)
+        assertEquals(4, decoded!!.shift)
+        val samples = decoded.samples
+        assertEquals(6, samples.size)
+        // First entry is amplitude-only (ibi 0, amp = as[0] = mantissa of p[6] << shift).
+        assertEquals(0, samples[0].ibiMs)
+        assertEquals(mants[0] shl 4, samples[0].amplitude)
+        // The five IBI entries recover the exact packed values; amps pair as[i] per the firmware order.
+        assertEquals(ibis.toList(), samples.drop(1).map { it.ibiMs })
+        assertEquals(mants.map { it shl 4 }, samples.drop(1).map { it.amplitude })
+    }
+
+    @Test
+    fun testGreenIBIAmpCandidateGates() {
+        // s == 7 means shift 0 (identity amplitudes).
+        val p7 = packGreenIBIAmp(intArrayOf(500, 500, 500, 500, 500), intArrayOf(10, 10, 10, 10, 10), s = 7)
+        assertEquals(0, OuraDecoders.decodeGreenIBIAmpCandidate(p7, rt)?.shift)
+        // Reserved bit [3] of p[13] set -> firmware mismatch -> null, never a guessed decode.
+        val bad = p7.copyOf()
+        bad[13] = bad[13] or 0x08
+        assertNull(OuraDecoders.decodeGreenIBIAmpCandidate(bad, rt))
+        // Strict 14-byte gate: any other length is a different firmware layout -> null.
+        assertNull(OuraDecoders.decodeGreenIBIAmpCandidate(p7.copyOfRange(0, 13), rt))
+        assertNull(OuraDecoders.decodeGreenIBIAmpCandidate(p7 + intArrayOf(0x00), rt))
+    }
+
+    // MARK: - 0x4B routes to the SAME validated phase decode as 0x4E/0x5A (parity with Swift dddbe952)
+
+    @Test
+    fun testSleepPhase4BDecodesAsHypnogramNotSummary() {
+        // 4b 07 <rt:4> <header> <1b = 00 01 10 11 MSB-first = deep,light,rem,awake>.
+        val rec = record("4b070200010000" + "1b")
+        assertEquals(OuraEventTag.SLEEP_PHASE_B, OuraEventTag.fromRaw(rec.type))
+        assertEquals(TrustTier.TIER_A, OuraEventTag.SLEEP_PHASE_B.tier)
+        val phases = OuraDecoders.decodeSleepPhase(rec)
+        assertEquals(
+            listOf(OuraSleepStage.DEEP, OuraSleepStage.LIGHT, OuraSleepStage.REM, OuraSleepStage.AWAKE),
+            phases?.map { it.stage },
+        )
+        // And the driver ingests it as SleepPhaseEvent(s), not a Tier-B summary wrapper.
+        val d = OuraDriver(ringGen = OuraRingGen.GEN3, authKey = null)
+        val events = d.ingest(rec)
+        assertEquals(4, events.size)
+        assertTrue(events.all { it is OuraEvent.SleepPhaseEvent })
     }
 
     // MARK: - Honest-data invariant: short / malformed records decode to null

--- a/android/app/src/test/java/com/noop/oura/FramingTest.kt
+++ b/android/app/src/test/java/com/noop/oura/FramingTest.kt
@@ -2,14 +2,15 @@ package com.noop.oura
 
 import org.junit.Assert.assertArrayEquals
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
 /**
  * Framing tests: outer command/response frames, the 0x2F secure-session sub-frame, and the TLV
- * inner-record Reassembler (multi-record-per-notification + partial-trailing-bytes buffering).
- * Kotlin twin of the Swift FramingTests.swift.
+ * inner-record parse — open_oura's ONE-packet-per-notification model (lenient `len`, no buffering,
+ * no multi-record loop, no byte-drop resync). Kotlin twin of the Swift FramingTests.swift.
  *
  * PARITY NOTE: every fixture hex string here is byte-for-byte identical to the Swift FramingTests
  * fixtures, so the same wire bytes parse + reassemble to the same records across both ports.
@@ -58,30 +59,74 @@ class FramingTest {
         assertEquals(0x57, battery?.percent)   // 87%
     }
 
-    // MARK: - GetEvents response (0x11, s5.2)
+    // MARK: - GetEvents response (0x11, s5.2 — open_oura EventBatchSummary, #91 twin)
 
     @Test
     fun testParseGetEventsResponseMoreDataFollows() {
-        // 11 08 <status=ff> <sub_status=00> <last_rt:4LE=78563412> <pad:2>
-        val outer = OuraFraming.parseOuterFrame(bytes("1108ff00785634120000"))
+        // 11 08 <events=ff> <progress=00> <bytes_left:4LE=0x00145d39> <pad:2> (a real on-device body).
+        val outer = OuraFraming.parseOuterFrame(bytes("1108ff00395d14000300"))
         assertEquals(OuraFraming.getEventsResponseOp, outer?.op)
         val summary = OuraFraming.parseGetEventsResponse(outer!!.body)
-        assertEquals(0x1234_5678L, summary?.cursor)
+        assertEquals(0xFF, summary?.eventsReceived)
+        assertEquals(0x0014_5D39L, summary?.bytesLeft)
         assertEquals(true, summary?.moreData)
     }
 
     @Test
-    fun testParseGetEventsResponseNoMoreData() {
-        // status 0x00 -> caught up, no more data.
-        val outer = OuraFraming.parseOuterFrame(bytes("11080000785634120000"))
+    fun testParseGetEventsResponseBytesLeftZeroIsDone() {
+        // bytes_left == 0 -> drain complete, even with a nonzero events count in body[0] (#91: body[0]
+        // is a batch COUNT, not a status; bytes 2-5 are bytes_left, never a cursor).
+        val outer = OuraFraming.parseOuterFrame(bytes("11081000000000000300"))
         val summary = OuraFraming.parseGetEventsResponse(outer!!.body)
-        assertEquals(0x1234_5678L, summary?.cursor)
+        assertEquals(0x10, summary?.eventsReceived)
+        assertEquals(0L, summary?.bytesLeft)
         assertEquals(false, summary?.moreData)
     }
 
     @Test
     fun testParseGetEventsResponseShortBodyReturnsNil() {
         assertNull(OuraFraming.parseGetEventsResponse(bytes("ff0012")))
+    }
+
+    // MARK: - SyncTime response (0x13, s5.4 [ringverse]) + anchor tick disambiguation
+
+    @Test
+    fun testParseSyncTimeResponse() {
+        // ringverse example body: 4b ed a9 00 00 -> device_ts 0x00A9ED4B, status 0.
+        val resp = OuraFraming.parseSyncTimeResponse(bytes("4beda90000"))
+        assertEquals(0x00A9_ED4BL, resp?.deviceTimestamp)
+        assertEquals(0, resp?.status)
+        // Short body -> null, never a guessed timestamp.
+        assertNull(OuraFraming.parseSyncTimeResponse(bytes("4beda900")))
+    }
+
+    @Test
+    fun testSyncTimeAnchorCandidateResolvesUnit() {
+        // The 2026-07-13 shape: cursor banked at 4_413_933; ~11 h later the ring's clock is ~4.81M
+        // ticks. A raw-ticks response fits [cursor, cursor+7d] and the seconds x10 reading does not.
+        assertEquals(4_810_000L, OuraDriver.syncTimeAnchorCandidate(4_810_000L, 4_413_933L))
+        // A seconds-unit response (481_000 s = 4.81M ticks) only fits when multiplied x10.
+        assertEquals(4_810_000L, OuraDriver.syncTimeAnchorCandidate(481_000L, 4_413_933L))
+        // Below the cursor in both readings (ring reboot / stale value) -> null.
+        assertNull(OuraDriver.syncTimeAnchorCandidate(100_000L, 4_413_933L))
+        // Beyond cursor+7d in both readings -> null.
+        assertNull(OuraDriver.syncTimeAnchorCandidate(40_000_000L, 4_413_933L))
+        // A fresh/reset cursor gives no reference -> null (never guess on a full pull).
+        assertNull(OuraDriver.syncTimeAnchorCandidate(4_810_000L, 0L))
+        // Ambiguity guard: BOTH readings inside the window -> null.
+        assertNull(OuraDriver.syncTimeAnchorCandidate(150_000L, 140_000L))
+    }
+
+    @Test
+    fun testAdoptSyncTimeAnchorResolvesHistoryTimes() {
+        val d = OuraDriver(ringGen = OuraRingGen.GEN3, authKey = null)
+        val now = 1_784_000_000L                     // inside the 2020-2035 plausibility window
+        assertNull("no anchor yet", d.unixSeconds(forRingTimestamp = 4_800_000L))
+        assertTrue(d.adoptSyncTimeAnchor(ringTimestamp = 4_810_000L, unixSeconds = now))
+        // A record 10_000 ticks (1000 s) before the anchor resolves to now - 1000.
+        assertEquals(now - 1000L, d.unixSeconds(forRingTimestamp = 4_800_000L))
+        // An implausible host epoch is refused (never anchors to a garbage clock).
+        assertFalse(d.adoptSyncTimeAnchor(ringTimestamp = 4_810_000L, unixSeconds = 100L))
     }
 
     // MARK: - Secure-session sub-frame (0x2F)
@@ -135,80 +180,69 @@ class FramingTest {
         assertNull(OuraFraming.parseRecord(intArrayOf(0x7B, 0x03, 0x00, 0x01, 0x02)))
     }
 
-    // MARK: - Reassembler: multiple records per notification
+    // MARK: - Lenient TLV parse + one-packet-per-notification reassembler (open_oura Packet::parse,
+    // twin of Swift dae3d7a4 — the phantom-storm fix)
 
     @Test
-    fun testReassemblerMultipleRecordsInOneNotification() {
-        // Two complete records packed into one notification value.
-        val r = OuraReassembler()
-        val recs = r.feed(bytes("7b060200010003ca" + "4e0602000100006c"))
-        assertEquals(2, recs.size)
-        assertEquals(0x7B, recs[0].type)
-        assertEquals(0x4E, recs[1].type)
-        assertEquals(0, r.bufferedByteCount)
+    fun testParseRecordTooBigLenUsesWhatArrived() {
+        // len 0x10 (16) declared but only 4 payload bytes present: the lenient parse uses what
+        // arrived instead of waiting for (and swallowing) the next notification.
+        val rec = OuraFraming.parseRecord(bytes("7b100200010003ca0102"))
+        assertEquals(0x7B, rec?.type)
+        assertArrayEquals(bytes("03ca0102"), rec?.payload)
     }
 
-    // MARK: - Reassembler: partial trailing bytes buffered across notifications
+    @Test
+    fun testParseRecordTrailingBytesBeyondLenAreIgnored() {
+        // len 0x06 but extra trailing bytes follow (BLE padding / an unpacked second frame): the
+        // payload stops at the declared end; the tail is never minted into a phantom record.
+        val rec = OuraFraming.parseRecord(bytes("7b060200010003ca" + "4e0602000100006c"))
+        assertEquals(0x7B, rec?.type)
+        assertArrayEquals(bytes("03ca"), rec?.payload)
+    }
 
     @Test
-    fun testReassemblerPartialTrailingBytesBuffered() {
-        val full = bytes("7b060200010003ca")   // one complete 8-byte record
+    fun testFeedReturnsAtMostOneRecordPerNotification() {
+        // Two records packed into one value: the one-packet model parses the FIRST leniently and
+        // ignores the tail (the ring sends one packet per notification; a packed tail is padding).
         val r = OuraReassembler()
-        // Feed only the first 5 bytes -> nothing complete yet, the rest is buffered.
-        assertTrue(r.feed(full.copyOfRange(0, 5)).isEmpty())
-        assertEquals(5, r.bufferedByteCount)
-        // Feed the remaining 3 bytes -> the record now completes.
-        val recs = r.feed(full.copyOfRange(5, full.size))
+        val recs = r.feed(bytes("7b060200010003ca" + "4e0602000100006c"))
         assertEquals(1, recs.size)
         assertEquals(0x7B, recs[0].type)
         assertEquals(0, r.bufferedByteCount)
     }
 
     @Test
-    fun testReassemblerSplitAcrossThreeFragments() {
-        // A record split byte-by-byte still reassembles, and a second record packed behind it emerges.
-        val recHex = "4e0602000100006c"          // 8 bytes
-        val trailing = "7b060200010003ca"         // 8 bytes
-        val all = bytes(recHex + trailing)
+    fun testFeedNeverBuffersAcrossNotifications() {
+        // A truncated notification is dropped whole (nothing buffered), and the next notification is
+        // parsed on its own — no cross-notification reassembly, so a garbled value can never corrupt
+        // the following one (the phantom-storm failure mode).
+        val full = bytes("7b060200010003ca")
         val r = OuraReassembler()
-        val out = ArrayList<OuraRecord>()
-        // Feed in 3-byte chunks.
-        var i = 0
-        while (i < all.size) {
-            out.addAll(r.feed(all.copyOfRange(i, minOf(i + 3, all.size))))
-            i += 3
-        }
-        assertArrayEquals(intArrayOf(0x4E, 0x7B), out.map { it.type }.toIntArray())
-    }
-
-    @Test
-    fun testReassemblerResetClearsBuffer() {
-        val r = OuraReassembler()
-        r.feed(intArrayOf(0x7B, 0x06, 0x02))   // partial
-        assertTrue(r.bufferedByteCount > 0)
-        r.reset()
+        assertTrue(r.feed(full.copyOfRange(0, 5)).isEmpty())
+        assertEquals(0, r.bufferedByteCount)
+        val recs = r.feed(full)
+        assertEquals(1, recs.size)
+        assertEquals(0x7B, recs[0].type)
         assertEquals(0, r.bufferedByteCount)
     }
 
     @Test
-    fun testReassemblerDrainsPureNoiseWithoutEmittingOrWedging() {
-        // The TLV format has NO start-of-frame marker, so a stream of bytes whose len field is < 4
-        // cannot be realigned to an arbitrary later record (unlike WHOOP's 0xAA SOF). The len < 4
-        // guard's job is narrower but important: never EMIT a garbage record, and never WEDGE waiting
-        // for bytes that cannot complete. A pure-noise burst drains to a tiny tail with no emissions.
+    fun testFeedDropsUnusableNotificationWholeNoResync() {
+        // A noise value (len < 4 / too short) yields nothing — never walked byte-by-byte for a
+        // resync, never a type-0 garbage record.
         val r = OuraReassembler()
-        val recs = r.feed(intArrayOf(0x00, 0x01, 0x02, 0x03, 0x01, 0x02))   // every len field < 4
-        assertTrue("noise must not produce false records", recs.isEmpty())
-        assertTrue("noise must drain, not accumulate forever", r.bufferedByteCount <= 1)
+        assertTrue(r.feed(intArrayOf(0x00, 0x01, 0x02, 0x03, 0x01, 0x02)).isEmpty())
+        assertTrue(r.feed(intArrayOf(0x00, 0x01) + bytes("4e0602000100006c")).isEmpty())
+        assertEquals(0, r.bufferedByteCount)
     }
 
     @Test
-    fun testReassemblerLenBelowFourDoesNotEmitGarbageBeforeValidRecord() {
-        // A 2-byte garbage header whose len is < 4 is dropped one byte at a time; because TLV has no
-        // SOF this does not realign to the trailing valid record, but it must NOT emit a bogus record.
-        val valid = bytes("4e0602000100006c")
+    fun testResetIsANoOpWithNoBufferedState() {
         val r = OuraReassembler()
-        val recs = r.feed(intArrayOf(0x00, 0x01) + valid)   // 00 01 = len 1 (< 4)
-        assertTrue("must never emit a type-0 garbage record", recs.all { it.type != 0x00 })
+        assertTrue(r.feed(intArrayOf(0x7B, 0x06, 0x02)).isEmpty())   // below floor, nothing retained
+        assertEquals(0, r.bufferedByteCount)
+        r.reset()
+        assertEquals(0, r.bufferedByteCount)
     }
 }

--- a/android/app/src/test/java/com/noop/oura/HypnogramAssemblerTest.kt
+++ b/android/app/src/test/java/com/noop/oura/HypnogramAssemblerTest.kt
@@ -1,0 +1,128 @@
+package com.noop.oura
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Tests for the hypnogram time-axis reconstruction (OuraHypnogramAssembler): burst grouping by
+ * envelope ring-time gap, and the 30 s/code backward layout from the anchored burst end. Kotlin twin
+ * of the Swift HypnogramAssemblerTests — same values, same assertions.
+ */
+class HypnogramAssemblerTest {
+
+    private fun phases(stages: List<OuraSleepStage>, rt: Long): List<OuraSleepPhase> =
+        stages.mapIndexed { i, stage -> OuraSleepPhase(ringTimestamp = rt, index = i, stage = stage) }
+
+    // MARK: - Backward layout
+
+    @Test
+    fun testSingleRecordLaysCodesBackwardFromEnd() {
+        val a = OuraHypnogramAssembler()
+        val stages = listOf(OuraSleepStage.AWAKE, OuraSleepStage.LIGHT, OuraSleepStage.DEEP, OuraSleepStage.REM)
+        assertNull(a.feed(ringTimestamp = 1000, phases = phases(stages, rt = 1000)))
+        val burst = a.flush()!!
+        // 4 codes ending at t=10_000: starts at 10_000 - 4*30 = 9_880, spaced 30 s.
+        val laid = burst.codesWithTimes(endUnixSeconds = 10_000)
+        assertEquals(listOf(9_880L, 9_910L, 9_940L, 9_970L), laid.map { it.ts })
+        assertEquals(stages, laid.map { it.phase.stage })
+        // The final code's 30 s interval ends exactly at the burst end.
+        assertEquals(10_000L, laid.last().ts + 30)
+    }
+
+    @Test
+    fun testBurstWriteRecordsShareOneSequence() {
+        // The on-device shape: multiple records written in one burst (envelope rts a few ticks apart)
+        // form ONE contiguous sequence — record 2's codes precede the end, record 1's come before them.
+        val a = OuraHypnogramAssembler()
+        assertNull(a.feed(5_000, phases(listOf(OuraSleepStage.AWAKE, OuraSleepStage.LIGHT), rt = 5_000)))
+        assertNull(a.feed(5_010, phases(listOf(OuraSleepStage.DEEP, OuraSleepStage.AWAKE), rt = 5_010)))
+        val burst = a.flush()!!
+        assertEquals(4, burst.totalCodes)
+        assertEquals(5_010L, burst.lastRingTimestamp)
+        val laid = burst.codesWithTimes(endUnixSeconds = 100_000)
+        assertEquals(listOf(99_880L, 99_910L, 99_940L, 99_970L), laid.map { it.ts })
+        assertEquals(
+            listOf(OuraSleepStage.AWAKE, OuraSleepStage.LIGHT, OuraSleepStage.DEEP, OuraSleepStage.AWAKE),
+            laid.map { it.phase.stage },
+        )
+    }
+
+    @Test
+    fun testFullNightScaleWindow() {
+        // The real 2026-07-12 shape: 23 records x 52 codes = 1,196 codes -> 9 h 58 m window ending at
+        // the anchored end. Start must be end - 1,196 * 30 s.
+        val a = OuraHypnogramAssembler()
+        for (k in 0 until 23) {
+            a.feed(3_970_000L + k, phases(List(52) { OuraSleepStage.LIGHT }, rt = 3_970_000))
+        }
+        val burst = a.flush()!!
+        assertEquals(1_196, burst.totalCodes)
+        val end = 1_760_000_000L
+        val laid = burst.codesWithTimes(endUnixSeconds = end)
+        assertEquals(end - 1_196 * 30, laid.first().ts)          // 35,880 s = 9 h 58 m before end
+        assertEquals(1_196, laid.size)
+        // Strictly increasing, 30 s apart — every code lands on a unique persistence slot.
+        assertTrue(laid.zipWithNext().all { (a1, b1) -> b1.ts - a1.ts == 30L })
+    }
+
+    // MARK: - Burst splitting
+
+    @Test
+    fun testLargeRingTimeGapSplitsBursts() {
+        // Two nights in one full dump: finalization writes hours apart must NOT merge.
+        val a = OuraHypnogramAssembler()
+        assertNull(a.feed(1_000_000, phases(listOf(OuraSleepStage.LIGHT, OuraSleepStage.LIGHT), rt = 1_000_000)))
+        // 24 h later in deciseconds = 864_000 ticks — far beyond the 600-tick burst gap.
+        val closed = a.feed(1_864_000, phases(listOf(OuraSleepStage.DEEP), rt = 1_864_000))
+        assertNotNull("a big rt gap must close the previous burst", closed)
+        assertEquals(2, closed!!.totalCodes)
+        assertEquals(1_000_000L, closed.lastRingTimestamp)
+        // The new record started the next burst.
+        val second = a.flush()!!
+        assertEquals(1, second.totalCodes)
+        assertEquals(1_864_000L, second.lastRingTimestamp)
+    }
+
+    @Test
+    fun testFlushEmptyReturnsNullAndResetClears() {
+        val a = OuraHypnogramAssembler()
+        assertNull(a.flush())
+        a.feed(10, phases(listOf(OuraSleepStage.REM), rt = 10))
+        a.reset()
+        assertNull("reset discards partial state", a.flush())
+        assertEquals(0, a.pendingRecordCount)
+    }
+
+    @Test
+    fun testNonMonotonicRingTimesAreSurfacedNotResorted() {
+        // A record whose envelope rt steps BACKWARD (within the burst gap) must be flagged — but the
+        // layout still trusts arrival order (envelope rts of a burst are near-identical write moments;
+        // re-sorting on them could scramble the true code sequence).
+        val a = OuraHypnogramAssembler()
+        assertNull(a.feed(5_010, phases(listOf(OuraSleepStage.LIGHT, OuraSleepStage.DEEP), rt = 5_010)))
+        assertNull(a.feed(5_000, phases(listOf(OuraSleepStage.REM, OuraSleepStage.AWAKE), rt = 5_000)))   // backward
+        val burst = a.flush()!!
+        assertTrue(burst.hasNonMonotonicRingTimes)
+        // Arrival order preserved in the layout.
+        assertEquals(
+            listOf(OuraSleepStage.LIGHT, OuraSleepStage.DEEP, OuraSleepStage.REM, OuraSleepStage.AWAKE),
+            burst.codesWithTimes(endUnixSeconds = 1_000).map { it.phase.stage },
+        )
+        // And a clean forward burst is NOT flagged.
+        val b = OuraHypnogramAssembler()
+        b.feed(100, phases(listOf(OuraSleepStage.LIGHT), rt = 100))
+        b.feed(110, phases(listOf(OuraSleepStage.DEEP), rt = 110))
+        assertFalse(b.flush()!!.hasNonMonotonicRingTimes)
+    }
+
+    @Test
+    fun testEmptyRecordIsIgnored() {
+        val a = OuraHypnogramAssembler()
+        assertNull(a.feed(10, emptyList()))
+        assertNull("a record with no codes never opens a burst", a.flush())
+    }
+}

--- a/android/app/src/test/java/com/noop/oura/OuraDriverTest.kt
+++ b/android/app/src/test/java/com/noop/oura/OuraDriverTest.kt
@@ -181,7 +181,7 @@ class OuraDriverTest {
     // MARK: - History fetch loop
 
     @Test
-    fun testHistoryFetchFlushesThenFetchesThenAcks() {
+    fun testHistoryFetchFlushesThenFetchesThenContinues() {
         val d = OuraDriver(ringGen = OuraRingGen.GEN3, authKey = key)
         val start = d.nextStep(OuraTransition.StartHistoryFetch(cursor = 0L))
         assertEquals(OuraDriverPhase.FetchingHistory, d.phase)
@@ -192,18 +192,31 @@ class OuraDriverTest {
             start[1].bytes,
         )
 
-        // More data -> ack-fetch (max 0) at the advanced cursor.
-        val ack = d.nextStep(OuraTransition.HistoryCursorAdvanced(cursor = 0x12345678L, moreData = true))
-        assertEquals(1, ack.size)
+        // More data -> continuation fetch at the ADVANCED cursor, SAME shape as the initial request
+        // (max 255, open_oura drain_events). The old max=0 "ack" made the ring restart its serve.
+        val cont = d.nextStep(OuraTransition.HistoryCursorAdvanced(cursor = 0x12345678L, moreData = true))
+        assertEquals(1, cont.size)
         assertArrayEquals(
-            intArrayOf(0x10, 0x09, 0x78, 0x56, 0x34, 0x12, 0x00, 0xFF, 0xFF, 0xFF, 0xFF),
-            ack[0].bytes,
+            intArrayOf(0x10, 0x09, 0x78, 0x56, 0x34, 0x12, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF),
+            cont[0].bytes,
         )
 
         // No more -> back to streaming.
         val stop = d.nextStep(OuraTransition.HistoryCursorAdvanced(cursor = 0x12345678L, moreData = false))
         assertTrue(stop.isEmpty())
         assertEquals(OuraDriverPhase.Streaming, d.phase)
+    }
+
+    @Test
+    fun testSyncTimeCommandIsU64SecondsPlusTz() {
+        // 12 09 <unix_seconds:8 LE> <tz:1> (s5.4, ringverse/open_oura layout — on-device proven; the
+        // old open_ring token/counter/0xF6 guess never anchored on real hardware).
+        val cmd = OuraCommands.syncTime(0x1061BCL, tzHalfHours = 4)
+        assertEquals("sync_time", cmd.label)
+        assertArrayEquals(
+            intArrayOf(0x12, 0x09, 0xBC, 0x61, 0x10, 0x00, 0x00, 0x00, 0x00, 0x00, 0x04),
+            cmd.bytes,
+        )
     }
 
     // MARK: - Ring-time -> UTC anchor (s5.5)
@@ -603,21 +616,23 @@ class OuraDriverTest {
         )
     }
 
-    // MARK: - Notification-level ingest via reassembler
+    // MARK: - Notification-level ingest (one-packet-per-notification, twin of Swift dae3d7a4)
 
     @Test
-    fun testIngestNotificationReassemblesAndDecodes() {
+    fun testIngestNotificationParsesOnePacketPerValue() {
         val d = OuraDriver(ringGen = OuraRingGen.GEN3, authKey = key)
         val reassembler = OuraReassembler()
-        // Two records packed together: 0x7B SpO2 then 0x46 temp.
+        // A second record packed behind the first is padding under the one-packet model: only the
+        // FIRST record decodes (the old buffering loop minted phantom records from such tails).
         val value = bytes("7b060200010003ca" + "460802000100420e470e")
         val events = d.ingest(notification = value, reassembler = reassembler)
-        // 36.50 and 36.55 are computed identically (IEEE-754 Int/100.0) in both ports.
-        assertEquals(3, events.size)
+        assertEquals(1, events.size)
         assertEquals(OuraEvent.Spo2(OuraSpO2(ringTimestamp = rt, value = 970)), events[0])
-        assertTrue(events[1] is OuraEvent.Temp)
-        assertEquals(36.50, (events[1] as OuraEvent.Temp).value.celsius, 1e-9)
-        assertEquals(36.55, (events[2] as OuraEvent.Temp).value.celsius, 1e-9)
+        // Each notification decodes on its own: the temp record in its OWN value decodes fully.
+        val tempEvents = d.ingest(notification = bytes("460802000100420e470e"), reassembler = reassembler)
+        assertEquals(2, tempEvents.size)
+        assertEquals(36.50, (tempEvents[0] as OuraEvent.Temp).value.celsius, 1e-9)
+        assertEquals(36.55, (tempEvents[1] as OuraEvent.Temp).value.celsius, 1e-9)
     }
 
     // MARK: - Generation-driven command set / MTU
@@ -631,16 +646,6 @@ class OuraDriverTest {
         assertEquals(OuraRingGen.GEN5, OuraRingGen.from("Oura Ring 5"))
         assertEquals(OuraRingGen.GEN3, OuraRingGen.from("Oura Ring 3"))
         assertTrue(OuraRingGen.GEN3.capabilities.contains(OuraMetric.HRV))
-    }
-
-    @Test
-    fun testSyncTimeCommandCounter() {
-        // counter = floor(unix / 256). For unix = 256 -> counter 1 -> bytes 01 00 00, trailer 0xF6.
-        val cmd = OuraCommands.syncTime(unixSeconds = 256L)
-        assertArrayEquals(
-            intArrayOf(0x12, 0x09, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xF6),
-            cmd.bytes,
-        )
     }
 
     // MARK: - Dangerous commands are isolated and labelled

--- a/android/app/src/test/java/com/noop/oura/OuraHistoryDrainTest.kt
+++ b/android/app/src/test/java/com/noop/oura/OuraHistoryDrainTest.kt
@@ -1,0 +1,208 @@
+package com.noop.oura
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Pins the Oura history drain + resume-cursor decisions (#91 / #291). Kotlin twin of the Swift
+ * OuraHistoryDrainTests — same values, same assertions, so the drain decisions are byte-identical
+ * across both ports. Pure decisions — no ring, no BLE.
+ */
+class OuraHistoryDrainTest {
+
+    // MARK: drain continuation
+
+    @Test
+    fun testDrainCompletesWhenBytesLeftZero() {
+        val d = OuraHistoryDrain()
+        // moreData == false is the healthy end, regardless of the counters.
+        assertFalse(d.onSummary(bytesLeft = 0, moreData = false, elapsedSeconds = 0.0))
+    }
+
+    @Test
+    fun testDrainContinuesWhileBytesLeftShrinks() {
+        val d = OuraHistoryDrain()
+        assertTrue(d.onSummary(bytesLeft = 400_873, moreData = true, elapsedSeconds = 1.0))
+        assertTrue(d.onSummary(bytesLeft = 200_000, moreData = true, elapsedSeconds = 2.0))
+        assertTrue(d.onSummary(bytesLeft = 1, moreData = true, elapsedSeconds = 3.0))
+    }
+
+    @Test
+    fun testStallGuardStopsAfterMaxFlatSummaries() {
+        val d = OuraHistoryDrain()
+        assertTrue(d.onSummary(bytesLeft = 1000, moreData = true, elapsedSeconds = 1.0)) // sets the floor
+        // Same bytes_left repeated — no progress. Stops on the MAX_STALL_SUMMARIES-th flat read.
+        assertTrue(d.onSummary(bytesLeft = 1000, moreData = true, elapsedSeconds = 2.0))  // stall 1
+        assertTrue(d.onSummary(bytesLeft = 1000, moreData = true, elapsedSeconds = 3.0))  // stall 2
+        assertFalse(d.onSummary(bytesLeft = 1000, moreData = true, elapsedSeconds = 4.0)) // stall 3 -> stop
+    }
+
+    @Test
+    fun testStallCounterResetsOnFreshProgress() {
+        val d = OuraHistoryDrain()
+        assertTrue(d.onSummary(bytesLeft = 1000, moreData = true, elapsedSeconds = 1.0))
+        assertTrue(d.onSummary(bytesLeft = 1000, moreData = true, elapsedSeconds = 2.0)) // stall 1
+        assertTrue(d.onSummary(bytesLeft = 900, moreData = true, elapsedSeconds = 3.0))  // progress -> reset
+        assertTrue(d.onSummary(bytesLeft = 900, moreData = true, elapsedSeconds = 4.0))  // stall 1 again
+        assertTrue(d.onSummary(bytesLeft = 900, moreData = true, elapsedSeconds = 5.0))  // stall 2 (not stopped)
+    }
+
+    @Test
+    fun testDeadlineGuardStopsPastMaxDrainSeconds() {
+        val d = OuraHistoryDrain()
+        assertTrue(d.onSummary(bytesLeft = 500, moreData = true, elapsedSeconds = 299.0))
+        assertFalse(
+            d.onSummary(
+                bytesLeft = 400, moreData = true,
+                elapsedSeconds = OuraHistoryDrain.MAX_DRAIN_SECONDS + 0.1,
+            ),
+        )
+    }
+
+    // MARK: stored ring-time → cursor
+
+    @Test
+    fun testNoteStoredRingTimeTracksMaxAndIgnoresCorrupt() {
+        val d = OuraHistoryDrain()
+        d.noteStoredRingTime(100, resumeCursorAtFetchStart = 0)
+        d.noteStoredRingTime(3_453_828, resumeCursorAtFetchStart = 0)
+        d.noteStoredRingTime(50, resumeCursorAtFetchStart = 0) // older, doesn't lower the max
+        assertEquals(3_453_828L, d.maxStoredRingTime)
+        d.noteStoredRingTime(OuraHistoryDrain.MAX_PLAUSIBLE_RESUME_TICKS + 1, resumeCursorAtFetchStart = 0)
+        assertEquals("over-ceiling ring-time must be ignored", 3_453_828L, d.maxStoredRingTime)
+        assertFalse(d.sawPreResumeData)
+    }
+
+    @Test
+    fun testPreResumeDataFlagsReboot() {
+        val d = OuraHistoryDrain()
+        d.noteStoredRingTime(500, resumeCursorAtFetchStart = 1000)
+        assertTrue("a stored sample OLDER than the seek floor means the ring clock reset", d.sawPreResumeData)
+    }
+
+    @Test
+    fun testFullPullSeekNeverFlagsReboot() {
+        val d = OuraHistoryDrain()
+        d.noteStoredRingTime(500, resumeCursorAtFetchStart = 0)   // cursor 0 = full pull, no floor
+        assertFalse(d.sawPreResumeData)
+    }
+
+    @Test
+    fun testResumeCursorAdvancesWhenForwardAndResolves() {
+        val d = OuraHistoryDrain()
+        d.noteStoredRingTime(3_453_828, resumeCursorAtFetchStart = 1000)
+        assertEquals(3_453_828L, d.resumeCursorAtDrainEnd(currentCursor = 1000, resolvesUnderAnchor = true))
+    }
+
+    @Test
+    fun testResumeCursorUnchangedWhenNotResolving() {
+        val d = OuraHistoryDrain()
+        d.noteStoredRingTime(3_453_828, resumeCursorAtFetchStart = 1000)
+        assertEquals(1000L, d.resumeCursorAtDrainEnd(currentCursor = 1000, resolvesUnderAnchor = false))
+    }
+
+    @Test
+    fun testRebootResetsCursorToFullPull() {
+        val d = OuraHistoryDrain()
+        d.noteStoredRingTime(500, resumeCursorAtFetchStart = 1000)     // reboot flagged
+        d.noteStoredRingTime(2000, resumeCursorAtFetchStart = 1000)    // forward sample too
+        assertEquals(
+            "a reboot forces 0 (full pull) even if a forward sample also arrived",
+            0L, d.resumeCursorAtDrainEnd(currentCursor = 1000, resolvesUnderAnchor = true),
+        )
+    }
+
+    // MARK: in-session continuation cursor (open_oura drain_events `progressed`)
+
+    @Test
+    fun testContinuationCursorAdvancesPastMaxSeen() {
+        val d = OuraHistoryDrain()
+        // The 2026-07-12 shape: sought from 1_681_398, batch served records up to rt 3_595_428.
+        d.noteSeenRingTime(1_686_000)
+        d.noteSeenRingTime(3_595_428)
+        d.noteSeenRingTime(2_000_000)   // out-of-order within the batch, doesn't lower the max
+        assertEquals(
+            "next request starts one past the newest record served",
+            3_595_429L, d.continuationCursor(lastRequestCursor = 1_681_398),
+        )
+    }
+
+    @Test
+    fun testContinuationStopsOnEmptyBatch() {
+        val d = OuraHistoryDrain()
+        assertNull(
+            "no records since the last request → no progress → stop, never re-request",
+            d.continuationCursor(lastRequestCursor = 1_681_398),
+        )
+    }
+
+    @Test
+    fun testContinuationStopsWhenCursorWouldNotAdvance() {
+        val d = OuraHistoryDrain()
+        // A re-served window: records arrived but none newer than where we already asked from.
+        d.noteSeenRingTime(1_686_000)
+        d.noteSeenRingTime(3_595_428)
+        assertNull(
+            "a batch that only re-serves old records must stop the drain (the 5x re-serve loop)",
+            d.continuationCursor(lastRequestCursor = 3_595_429),
+        )
+    }
+
+    @Test
+    fun testContinuationReArmsProgressTestPerRequest() {
+        val d = OuraHistoryDrain()
+        d.noteSeenRingTime(2_000_000)
+        assertEquals(2_000_001L, d.continuationCursor(lastRequestCursor = 1_000_000))
+        // No new records after the advanced request: the next decision is stop, not a re-request at
+        // the same cursor.
+        assertNull(d.continuationCursor(lastRequestCursor = 2_000_001))
+        // Fresh records past the new cursor re-enable progress.
+        d.noteSeenRingTime(2_500_000)
+        assertEquals(2_500_001L, d.continuationCursor(lastRequestCursor = 2_000_001))
+    }
+
+    @Test
+    fun testSeenRingTimeIgnoresCorruptAndIsIndependentOfStored() {
+        val d = OuraHistoryDrain()
+        d.noteSeenRingTime(OuraHistoryDrain.MAX_PLAUSIBLE_RESUME_TICKS + 1)
+        assertEquals("over-ceiling ring-time must not steer the continuation", 0L, d.maxSeenRingTime)
+        // Unanchored records advance the CONTINUATION cursor without touching the durable one.
+        d.noteSeenRingTime(3_000_000)
+        assertEquals(3_000_000L, d.maxSeenRingTime)
+        assertEquals(0L, d.maxStoredRingTime)
+        d.noteStoredRingTime(2_900_000, resumeCursorAtFetchStart = 0)
+        assertEquals(2_900_000L, d.maxStoredRingTime)
+        assertEquals("stored notes don't inflate the seen max", 3_000_000L, d.maxSeenRingTime)
+    }
+
+    // MARK: loaded-cursor sanitize + reset
+
+    @Test
+    fun testSanitizeLoadedCursor() {
+        assertEquals(3_453_828L, OuraHistoryDrain.sanitizeLoadedCursor(3_453_828))
+        assertEquals(0L, OuraHistoryDrain.sanitizeLoadedCursor(0))
+        assertEquals(
+            "a persisted cursor above the ceiling is pre-fix garbage → full pull",
+            0L, OuraHistoryDrain.sanitizeLoadedCursor(OuraHistoryDrain.MAX_PLAUSIBLE_RESUME_TICKS + 1),
+        )
+    }
+
+    @Test
+    fun testResetClearsState() {
+        val d = OuraHistoryDrain()
+        d.noteStoredRingTime(3_453_828, resumeCursorAtFetchStart = 1000)
+        d.noteStoredRingTime(500, resumeCursorAtFetchStart = 1000)
+        d.noteSeenRingTime(3_453_900)
+        d.onSummary(bytesLeft = 1000, moreData = true, elapsedSeconds = 1.0)
+        d.reset()
+        assertEquals(0L, d.maxStoredRingTime)
+        assertEquals(0L, d.maxSeenRingTime)
+        assertEquals(0L, d.eventsSinceLastRequest)
+        assertFalse(d.sawPreResumeData)
+        // Stall floor reset: a fresh flat sequence starts counting from scratch.
+        assertTrue(d.onSummary(bytesLeft = 1000, moreData = true, elapsedSeconds = 1.0))
+    }
+}

--- a/android/app/src/test/java/com/noop/oura/OuraSleepSessionMappingTest.kt
+++ b/android/app/src/test/java/com/noop/oura/OuraSleepSessionMappingTest.kt
@@ -1,0 +1,66 @@
+package com.noop.oura
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * Kotlin twin of Swift `OuraSleepSessionMappingTests`. The `stagesJson` byte string is asserted verbatim
+ * so both platforms stay on the cross-platform stored-value contract (byte-identical segment JSON).
+ */
+class OuraSleepSessionMappingTest {
+
+    // A tiny anchored sequence: deep,deep,light,rem,awake at 30 s epochs from t0.
+    private fun codes(t0: Long): List<Pair<Long, OuraSleepStage>> = listOf(
+        t0 to OuraSleepStage.DEEP,
+        t0 + 30 to OuraSleepStage.DEEP,
+        t0 + 60 to OuraSleepStage.LIGHT,
+        t0 + 90 to OuraSleepStage.REM,
+        t0 + 120 to OuraSleepStage.AWAKE,
+    )
+
+    @Test fun emptySequenceYieldsNoSession() {
+        assertNull(OuraSleepSessionMapping.session(emptyList()))
+    }
+
+    @Test fun boundsAreFirstTsToLastTsPlusEpoch() {
+        val t0 = 1_700_000_000L
+        val s = OuraSleepSessionMapping.session(codes(t0))!!
+        assertEquals(t0, s.startTs)
+        assertEquals(t0 + 150, s.endTs)   // last code ts (t0+120) + one 30 s epoch
+    }
+
+    @Test fun adjacentEqualStagesMergeIntoOneSegment() {
+        val t0 = 1_700_000_000L
+        val s = OuraSleepSessionMapping.session(codes(t0))!!
+        val expected = "[" +
+            "{\"start\":$t0,\"end\":${t0 + 60},\"stage\":\"deep\"}," +
+            "{\"start\":${t0 + 60},\"end\":${t0 + 90},\"stage\":\"light\"}," +
+            "{\"start\":${t0 + 90},\"end\":${t0 + 120},\"stage\":\"rem\"}," +
+            "{\"start\":${t0 + 120},\"end\":${t0 + 150},\"stage\":\"wake\"}" +
+        "]"
+        assertEquals(expected, s.stagesJson)
+    }
+
+    @Test fun efficiencyIsAsleepOverInBed() {
+        val t0 = 1_700_000_000L
+        val s = OuraSleepSessionMapping.session(codes(t0))!!
+        // 4 asleep epochs (deep,deep,light,rem) + 1 awake → 4/5.
+        assertEquals(0.8, s.efficiency!!, 1e-9)
+    }
+
+    @Test fun allAwakeIsZeroEfficiencyNotNull() {
+        val t0 = 1_700_000_000L
+        val s = OuraSleepSessionMapping.session(
+            listOf(t0 to OuraSleepStage.AWAKE, t0 + 30 to OuraSleepStage.AWAKE))!!
+        assertEquals(0.0, s.efficiency!!, 1e-9)
+        assertEquals("[{\"start\":$t0,\"end\":${t0 + 60},\"stage\":\"wake\"}]", s.stagesJson)
+    }
+
+    @Test fun stageTokensMatchOnDeviceStagerConvention() {
+        assertEquals("deep", OuraSleepSessionMapping.token(OuraSleepStage.DEEP))
+        assertEquals("light", OuraSleepSessionMapping.token(OuraSleepStage.LIGHT))
+        assertEquals("rem", OuraSleepSessionMapping.token(OuraSleepStage.REM))
+        assertEquals("wake", OuraSleepSessionMapping.token(OuraSleepStage.AWAKE))   // awake persists as "wake"
+    }
+}

--- a/docs/OURA_PROTOCOL.md
+++ b/docs/OURA_PROTOCOL.md
@@ -240,22 +240,56 @@ Gen 5 example `0912 020100 020103 010001 090329 665544332211`. [open_oura-r5]
 
 ### 5.2 GetEvents response / summary (`0x11`)
 ```
-11 08 <status:1> <sub_status:1> <last_ring_timestamp:4 LE> <pad:2>
+11 08 <events_received:1> <progress:1> <bytes_left:4 LE> <pad:2>
 ```
-[open_ring]
-- `status` - `0x00` = empty/no more; `0xFF` = data follows (event records arrive as inner TLV stream, §2.3). [open_ring]
-- `last_ring_timestamp` - new cursor value to use next fetch.
+[open_oura `EventBatchSummary`]
+- `events_received` - COUNT of events in the batch (`0xFF` = 255, the legacy max). NOT a status byte.
+- `progress` - `sleepAnalysisProgress`, informational only (never a block).
+- `bytes_left` - the ring's remaining buffered bytes; the drain is done at `bytes_left == 0`.
+- The summary carries **no cursor**. An earlier revision read bytes 2–5 as `last_ring_timestamp` — that
+  value is `bytes_left`, and persisting it as a cursor caused the #91 full re-dump loop.
+- Observed on-device (2026-07-12): the `0x11` can arrive BEFORE its batch finishes streaming.
 
-### 5.3 Canonical fetch loop (NOOP)
-1. SyncTime (§5.4). 2. Send `0x10` with stored cursor, `max=255`. 3. Receive inner TLV records (§6). 4. ~100 ms later send ack-fetch (`max=0`, cursor = `last_ring_timestamp`) to advance. 5. Repeat until `status=0x00`. [open_ring]
-6. Optionally `28 01 00` to flush flash-buffered events first. [open_ring]
+### 5.3 Canonical fetch loop (NOOP, aligned with open_oura `drain_events`)
+1. SyncTime (§5.4). 2. Optionally `28 01 00` to flush flash-buffered events first. [open_ring]
+3. Send `0x10` with the stored cursor, `max=255`, flags `FF FF FF FF` (open_oura's `flags=-1`).
+4. Collect the batch until the stream goes QUIET (~1.5 s of no records — open_oura's `transact()`
+   window). The `0x11` summary is NOT an end-of-batch marker (§5.2); never re-request mid-stream.
+5. Next cursor = max envelope ring-time seen across ALL batch records + 1. If the batch had no records,
+   or the cursor did not advance past the previous request's, STOP (open_oura `!progressed`).
+6. Repeat from step 3 while the summary reports `bytes_left > 0`; done at `bytes_left == 0`.
 
-### 5.4 SyncTime (`0x12`)
+**SUPERSEDED (open_ring):** an earlier revision taught an ack-fetch (`max=0`, cursor =
+`last_ring_timestamp`) ~100 ms after the records. Re-sending `0x10` at a non-advancing cursor — and
+especially mid-stream — makes the ring RESTART serving from that cursor: observed on-device 2026-07-12
+as five identical ~955 KB re-serves of one window while the tail (`bytes_left` 409 KB) was never
+reached. open_oura has no ack-fetch; every request is the same `(cursor, max=255, flags=-1)` shape
+with the cursor advanced per batch.
+
+### 5.4 SyncTime (`0x12`) and its response (`0x13`)
 ```
-12 09 <token:1> <counter:3 LE> 00 00 00 00 f6
+12 09 <unix_seconds:8 LE> <tz:1>
 ```
-where `counter = floor(unix_seconds / 256)`, trailer `0xf6` fixed. [open_ring]
-Response: `13 05 <ack> <counter_echo:3 LE> 00`. [open_ring]
+`unix_seconds` = host UTC as uint64 seconds; `tz` = signed offset in HALF-HOURS from UTC.
+[ringverse BLE.md][open_oura `req_sync_time`] — validated on-device 2026-07-12 (this layout made the
+ring emit its first 0x42 and anchored history).
+
+Response:
+```
+13 05 <current_device_timestamp:4 LE> <status:1>
+```
+`current_device_timestamp` is the ring's OWN clock counter when it processed the SyncTime. [ringverse]
+**NOOP anchor use (2026-07-13):** paired with the host wall-clock at receipt this is a DETERMINISTIC
+ring-time→UTC anchor available at every connect. Needed because the `0x42` time_sync_ind record is
+only logged when the ring actually ADJUSTS its clock — an already-synced ring can serve an entire
+drain with no 0x42 (observed: a whole night parked unanchored). ringverse labels the field "seconds"
+while the record clock runs in 100 ms ticks; NOOP disambiguates raw-ticks vs seconds×10 against the
+persisted resume cursor (exactly one reading must land within cursor…cursor+7 days) and adopts
+nothing when ambiguous.
+
+**SUPERSEDED (open_ring):** `12 09 <token:1> <counter:3 LE> 00 00 00 00 f6` with
+`counter = floor(unix_seconds/256)` and response `13 05 <ack> <counter_echo:3 LE> 00` — that request
+layout never anchored on real hardware.
 
 ### 5.5 Ring-time → UTC anchoring
 - The ring clock is in **ticks**: default **100 ms/tick** (10 Hz); burst mode **1 ms/tick** (`factor_flag=1`). [open_ring]
@@ -300,13 +334,35 @@ All records share the §2.3 TLV header (`type`, `len`, 4-byte `ringTimestamp`). 
   — i.e. 1 LSB from an amplitude byte, 8 mid bits from `b[k]`, 2 high bits from the pack bytes. [oura-rs]
 - Each **amplitude** = `(b[6+k] >> 1) << shift` (7-bit mantissa `[7:1]` shifted by the exponent). [oura-rs]
 - Per-sample timestamp: walk backward from event UTC by each IBI duration. [ringverse]
-- **Validated (decode fix):** the earlier linear-MSB-first bitstream reading recovered only the FIRST IBI and
-  scrambled the rest (a real overnight capture → 82% non-physiological beat-to-beat jumps). The byte-scatter
-  layout above, cross-checked on the same capture, yields a coherent ~60 bpm train (10% jumps) that tracks the
-  night's sleep stages and day/night dip. Matches `open_oura`'s decompiled `parse_api_ibi_and_amplitude_event`.
+- **WARNING (2026-07-12, ringverse ingest):** ringverse's `p_ibi_and_amplitude` shows the byte order
+  is **SCRAMBLED** (each 11-bit IBI rebuilt from three non-adjacent pieces, exact indices in
+  parse.js), while NOOP's `decodeIBIAmplitude` reads the fields with a naive SEQUENTIAL BitReader —
+  the two do not agree, so our 0x60 IBI values are SUSPECT until cross-checked against concurrent
+  live-HR R-R (same method as the 0x71 fixture plan). Part of the parked history-IBI work.
 
 ### 6.2 Green-LED IBI+amp - `0x71` `green_ibi_and_amp_event` (18 B)
-- 5 IBI deltas + 6 amplitudes; shift from byte19 bits `[2:0]`; same 11-bit IBI / 7-bit amplitude structure. [ringverse]
+Full layout per ringverse `p_green_ibi_and_amp` (parse.js, firmware `@0x503960`); payload = 14 body
+bytes (indices below are payload offsets = spec offsets − 6). Strict length gate: wire len == 18.
+- `p13` (spec byte 19): bit `[3]` RESERVED — set means a firmware-layout mismatch, do not decode;
+  `s = p13 & 7`, `shift = (s == 7) ? 0 : s + 1`.
+- 5 IBIs, each an **11-bit** value from three scrambled pieces (bit 0 | bits 2:1 | bits 10:3):
+```
+ibi0 = (p10 & 1) | (p4 << 3) | ((p13 >> 5) & 6)
+ibi1 = (p9  & 1) | (p3 << 3) | ((p12 & 3) << 1)
+ibi2 = (p8  & 1) | (p2 << 3) | ((p12 >> 1) & 6)
+ibi3 = (p7  & 1) | (p1 << 3) | ((p12 >> 3) & 6)
+ibi4 = (p6  & 1) | (p0 << 3) | ((p12 >> 5) & 6)
+```
+- 5 amplitudes: `amp[i] = (p[6+i] >> 1) << shift` (7-bit mantissa in bits `[7:1]` of `p6..p10`).
+- Emission order: first entry is **amplitude-only** (`ibi = 0`, `amp[0]`), then 5 entries
+  `{ibi[i], amp[i]}`; per-sample timestamps walk BACKWARD from the event UTC by each IBI (same
+  model as 0x60). `p5`/`p11` unused. [ringverse]
+- NOOP: `OuraDecoders.decodeGreenIBIAmpCandidate` implements this verbatim as a **Tier-B CANDIDATE**
+  (#287) — used only in the 0x71 fixture-capture log, side by side with the raw bytes, until a real
+  capture cross-checked against concurrent live-HR R-R validates it.
+- CORRECTION: an earlier revision summarized this as "5 IBI deltas + 6 amplitudes" — the five values
+  are full 11-bit IBIs (0–2047 ms) used as backward TIME deltas, and only 5 amplitude bytes exist
+  (the first emitted entry reuses `amp[0]`).
 
 ### 6.3 SpO2 IBI+amp - `0x6E` `spo2_ibi_and_amplitude_event` (17 B)
 - Byte 6: bits `[7:6]` = flag(1)+shift(3); bits `[3:0]` = mode(4). [ringverse]
@@ -384,10 +440,20 @@ like its sibling banked streams (`.hrv`/`.temp`/`.spo2`/`.sleepPhase`) — the f
 - This is the primary UTC anchor (§5.5). [open_ring][ringverse]
 
 ### 6.12 Sleep architecture
-- **`0x4E` / `0x5A` `sleep_phase_details`** (≥19 B): byte6 = header; phase codes are **2-bit**, 4 per byte (bits `[7:6][5:4][3:2][1:0]`); codes **0=awake, 1=light, 2=deep, 3=REM**. [ringverse]
+- **`0x4B` / `0x4E` / `0x5A` `sleep_phase_details`** (≥19 B): byte6 = header; phase codes are **2-bit**, 4 per byte (bits `[7:6][5:4][3:2][1:0]`); codes **0=deep, 1=light, 2=rem, 3=awake** per open_oura's VALIDATED `decode_sleep_phases` (events.rs `PHASE = ["deep","light","rem","awake"]`). **CORRECTION:** an earlier revision of this line taught `0=awake, 1=light, 2=deep, 3=REM` from [ringverse] (unverified); live captures contradicted it (records decoded at wake carry code 3 = awake under open_oura's mapping), and both platform decoders inherited the bug from this exact text. [open_oura]
 - **`0x6A` `sleep_period_info`** (14 B): bytes6–9 four int8 metrics; bytes10–11 `uint8/8.0`; byte12 motion-seconds uint8; byte13 sleep-state int8; bytes14–15 `uint16 LE / 65536`. [ringverse]
 - **`0x72` `sleep_acm_period`** (16 B): values0–2 = `whole(8)+frac(8)/255`; values3–5 = `whole(4)+frac(12)/4095`. [ringverse]
-- **`0x49` `sleep_summary_1`**: start/end as uint16 LE minutes-before-event. [ringverse]
+- **`0x49` `sleep_summary_1`**: `start_offset_min` / `end_offset_min`, both uint16 LE **minutes
+  before the event time** — the ring's tracked sleep window is
+  `[event_utc − start_offset·60 s, event_utc − end_offset·60 s]`. [ringverse]
+  **VALIDATED against NOOP captures 2026-07-12**: the `600/10` sample on the 7/11→12 night decodes
+  to 23:30→09:20, matching the reconstructed 1196-code hypnogram (23:32→09:30 write-anchored) and
+  the reported sleep (23:35–09:00). Earlier samples fit the same shape (688/101, 584/108, 716/164).
+  Note the window END trails the SleepNet WRITE by `end_offset` minutes (10–43 min observed).
+  **NOOP anchors the hypnogram burst end at `event − end_offset`** when a same-finalization 0x49
+  (envelope ring-time within 10 min of the burst's) is present — the write-moment envelope shifted a
+  whole reconstructed night +43 min on 2026-07-13 before this refinement; the 0x49 window matched the
+  wearer's report within minutes (23:32→08:08 vs 23:34→08:03).
 - **`0x76` `bedtime_period`**: start/end as uint32 LE ringTimestamps → map to UTC (§5.5). [ringverse]
 - Tags `0x48,0x4A–0x4D,0x4F,0x57,0x58` are additional sleep summary/feature variants in the dictionary; layouts **(UNVERIFIED)** - decode only after fixtures. [ringverse]
 


### PR DESCRIPTION
  ## Summary
  The Oura ring banks its whole-night SleepNet phase codes (2-bit deep/light/rem/awake, 4/byte) in one burst after wake. This PR decodes that burst, reconstructs its time axis, refines the true sleep end with the `0x49` sleep-summary window, and  upserts the night as a `CachedSleepSession` under the ring's own deviceId — so SleepMerge's imported-over-computed rule surfaces **Oura's own staging** instead of a computed guess. The sleep surfaces then label that night honestly as **"Oura"** with  a caveat that its stages are the ring's *raw on-device* classification.

  Two halves, both platforms, byte-identical Swift/Kotlin twins:

  ### 1. Persist the hypnogram (data)
  - **`OuraProtocol`** (pure): `HypnogramAssembler` (30 s/code time-axis, laid backward from burst end), `0x49` sleep_summary decode + window pairing in `OuraHistoryDrain`, plus `OuraEvents`/`Decoders`/`Framing`/`OuraDriver` additions. No  CoreBluetooth; covered by `swift test` / JVM tests.
  - **`WhoopStore`**: `OuraSleepSessionMapping` (anchored per-code hypnogram → `CachedSleepSession` stage breakdown), `OuraStreamMapping` sleepPhase pass-through.
  - **App**: `OuraLiveSource` assembles the burst, anchors it to ring-time, `0x49`-refines the end, and calls `persistSleepSession`; `SourceCoordinator` wires the persist closure.

  ### 2. Show provenance honestly (UI)
  A persisted Oura night is the ring's *own* SleepNet output — not a NOOP computation — so the surfaces say so, instead of the generic "On-device":
  - **One canonical resolver:** `DeviceBrandCatalog.isOura(deviceId)` on **both** platforms (brand-table prefix, never an `"oura"` literal). Swift `Repository.activeDeviceIsOura` + Kotlin `SleepScreen` both call it.
  - **Labels:** hero + main-sleep badges read **"Oura"**; `daySourceBadge` gains the Oura brand so the ring-id session (and By-Day) label correctly; WHOOP + Apple imports still win the provenance order above Oura.
  - **Honest caveat (`ouraRawStagesNote`):** the stage caption reads **"raw on-device stages"**, and a note states plainly:

    > *"This split is the ring's raw on-device classification read over Bluetooth, not the adjusted stages the Oura app shows. Expect more Awake and less Deep/REM here than in the Oura app for the same night."*

    This is deliberate: the ring's raw BLE codes differ from the vendor's cloud-post-processed hypnogram, so the breakdown isn't mistaken for the Oura app's polished numbers.
  - **Design tokens only** (`restColor` / `textTertiary` / `caption`); read/UI-only, not stored, never crosses `.noopbak` (no data twin needed).

  ## Tier discipline
  The persisted session is a ring-PROVIDED night, not a NOOP-computed score. Activity/MET (Tier-B) is untouched.

  ## Tests — automated
  - `swift test` **OuraProtocol** + **WhoopStore** green, incl. the new `DeviceBrandCatalog.isOura` case (both platforms).
  - macOS **Strand BUILD SUCCEEDED**; Android **`compileFullDebugKotlin` OK**.
  - ⚠️ The Android unit-test *run* is currently blocked by an unrelated 9.1.0 gap — #716 added `DeviceRegistryDao.setModel` without updating three test fakes, so `testFullDebugUnitTest` can't compile its source set. A separate one-commit fix  (`fix/android-registry-fake-setmodel`) unblocks it; the Kotlin `isOura` test here mirrors the passing Swift one and runs once that lands. (PR #725 is fixing it)

  ## Tests — real hardware (2026-07-22, Oura Gen 3, macOS 9.1.0)
  Validated end-to-end on a live overnight + nap, cross-checked against the WHOOP app for the same night.

  **Persist fired correctly:**
  0x49 sleep window candidate            22:09:31 → 08:25:31
  hypnogram burst end refined by 0x49 —  SleepNet write 12:15:37 → true sleep end 08:25:31 (−230 min)
  hypnogram reconstructed [22:01:31 → 08:25:31, anchored] codes=1248
  sleep session persisted [22:01:31 → 08:25:31] eff=70% → oura-<device> (wins merge over computed)

  **Anti-phantom `0x49` refinement worked:** the ring wrote the whole burst at **12:15** while on the charger; the refinement trimmed **3h50m** of post-wake write-tail to a true end of **08:25** — without it, the night would have been mis-dated ending
  at noon.

  **Oura vs WHOOP — close:** onset **22:01** vs 22:13; wake **08:25** vs 08:02.

  **Stage split — diverges exactly as `ouraRawStagesNote` warns** (raw on-device ⇒ more Awake, less Deep/REM):

  | Stage | Oura raw (this PR) | WHOOP |
  |---|---|---|
  | Awake | **3:06 (30%)** | 1:16 (12%) |
  | Light | 5:16 (51%) | 4:37 (49%) |
  | Deep | 1:13 (12%) | 1:40 (16%) |
  | REM | **0:50 (8%)** | 2:16 (23%) |
  | Asleep | 7:19 | 8:33 |

  The ~2.4× Awake and <½ REM is precisely the behaviour the caveat note describes — the honesty layer is doing its job, not a regression.

  **Also confirmed live:**
  - The **nap** persisted as a second Oura session: `[13:59:31 → 14:25:31] eff=56%`.
  - **UI:** the Sleep screen shows the night labelled **"Oura"** (author-confirmed on device).
  - **Wear detection (#628):** charger at 08:40 → worn again 10:01 — correct.
  - **Feature-status probe (#710):** SpO2 + real_steps both `INACTIVE (server-gated)` — reconfirmed.

  **Provenance ordering note:** an Oura night shows "Oura" only while no WHOOP import covers that day; once a WHOOP export is imported for the same day, WHOOP wins the merge and the label flips to "Whoop" — by design.

  ## Scope
  Supersedes DRAFT #446 (`oura-sleep-stage-timeline-persist`). Clean single commit off `main`; no ibiHrDump/rawDump/activity-corpus carried in.
