### PR TITLE
 Oura: fix 0x5D hrv_event decode — it's (u8 hr_bpm, u8 rmssd_ms) 5-min pairs, not (u16 time, int8, int8)

### DIFF
--- a/Packages/OuraProtocol/Sources/OuraProtocol/Decoders.swift
+++ b/Packages/OuraProtocol/Sources/OuraProtocol/Decoders.swift
@@ -149,20 +149,24 @@ public enum OuraDecoders {
 
     // MARK: - HRV / RMSSD (0x5D; s6.9)
 
-    /// Decode the 0x5D hrv_event: samples each carrying a time_ms field + two int8 fields (b1, b2).
-    /// Per OURA_PROTOCOL.md s6.9 the per-sample stride is time(2 LE) + b1(1) + b2(1) = 4 bytes.
-    /// Returns nil on a short body. NOOP consumes this as the ring's OWN RMSSD-derived HRV tag.
+    /// Decode the 0x5D hrv_event: a run of `(u8 avg HR bpm, u8 avg RMSSD ms)` pairs, ONE per 5-min bucket
+    /// (per open_oura `decode_hrv` / OURA_PROTOCOL.md s6.9). The previous layout read a 4-byte
+    /// `(u16 time, int8, int8)` stride — a mis-framing: it garbled the first (hr,rmssd) byte-pair into a
+    /// bogus `time_ms`, sign-flipped the RMSSD byte, and only its `b1` accidentally landed on a real HR
+    /// byte. Both bytes are UNSIGNED (no scaling). Returns nil on an empty or ODD-length body (a partial
+    /// pair is never emitted). Validated against a real overnight: the hr byte tracks sleeping HR (~52 bpm,
+    /// matching the #511 IBI-derived median).
     public static func decodeHRV(_ rec: OuraRecord) -> [OuraHRV]? {
         let b = rec.payload
-        guard b.count >= 4 else { return nil }
+        guard b.count >= 2, b.count % 2 == 0 else { return nil }   // N complete (hr, rmssd) pairs
         var out: [OuraHRV] = []
         var i = 0
-        while i + 4 <= b.count {
-            let timeMs = u16le(b, i)
-            let v1 = Int(Int8(bitPattern: b[i + 2]))
-            let v2 = Int(Int8(bitPattern: b[i + 3]))
-            out.append(OuraHRV(ringTimestamp: rec.ringTimestamp, timeMs: timeMs, b1: v1, b2: v2))
-            i += 4
+        var index = 0
+        while i + 2 <= b.count {
+            out.append(OuraHRV(ringTimestamp: rec.ringTimestamp, index: index,
+                               hrBpm: Int(b[i]), rmssdMs: Int(b[i + 1])))
+            i += 2
+            index += 1
         }
         return out.isEmpty ? nil : out
     }

--- a/Packages/OuraProtocol/Sources/OuraProtocol/OuraEvents.swift
+++ b/Packages/OuraProtocol/Sources/OuraProtocol/OuraEvents.swift
@@ -30,16 +30,21 @@ public struct OuraHR: Equatable, Sendable, Codable {
     }
 }
 
-/// One decoded HRV (RMSSD-derived) sample from the ring's own 0x5D tag (OURA_PROTOCOL.md s6.9).
-/// NOOP also reconstructs RMSSD itself from the IBI streams for its own scoring; this is the ring's
-/// open HRV tag, NOT Oura's encrypted readiness score.
+/// One decoded 5-minute HRV bucket from the ring's own 0x5D tag (OURA_PROTOCOL.md s6.9): the ring's
+/// OWN average HR and RMSSD for that bucket. The 0x5D body is a run of `(u8 avg HR bpm, u8 avg RMSSD ms)`
+/// pairs, one per 5 min; `index` is the pair's position in the record. This is the ring's open HRV tag,
+/// NOT Oura's encrypted readiness score. NOOP also reconstructs RMSSD from the IBI streams for its own
+/// scoring; this tag is the ring's own summary (validated overnight — the hr byte tracks sleeping HR).
 public struct OuraHRV: Equatable, Sendable, Codable {
     public let ringTimestamp: UInt32
-    public let timeMs: Int
-    public let b1: Int
-    public let b2: Int
-    public init(ringTimestamp: UInt32, timeMs: Int, b1: Int, b2: Int) {
-        self.ringTimestamp = ringTimestamp; self.timeMs = timeMs; self.b1 = b1; self.b2 = b2
+    /// 0-based pair index within the record; buckets are ~5 min apart (consumer applies the offset).
+    public let index: Int
+    /// The ring's average HR for the 5-min bucket, in bpm (u8, no scaling).
+    public let hrBpm: Int
+    /// The ring's average RMSSD for the 5-min bucket, in ms (u8, no scaling).
+    public let rmssdMs: Int
+    public init(ringTimestamp: UInt32, index: Int, hrBpm: Int, rmssdMs: Int) {
+        self.ringTimestamp = ringTimestamp; self.index = index; self.hrBpm = hrBpm; self.rmssdMs = rmssdMs
     }
 }
 

--- a/Packages/OuraProtocol/Sources/oura-decode/main.swift
+++ b/Packages/OuraProtocol/Sources/oura-decode/main.swift
@@ -140,7 +140,7 @@ func describe(_ e: OuraEvent) -> String {
     switch e {
     case .hr(let v): return "HR bpm=\(v.bpm) ibi=\(v.ibiMs)ms rt=\(v.ringTimestamp)"
     case .ibi(let v): return "IBI \(v.ibiMs)ms amp=\(v.amplitude.map(String.init) ?? "-") rt=\(v.ringTimestamp)"
-    case .hrv(let v): return "HRV t=\(v.timeMs) b1=\(v.b1) b2=\(v.b2) rt=\(v.ringTimestamp)"
+    case .hrv(let v): return "HRV idx=\(v.index) hr=\(v.hrBpm)bpm rmssd=\(v.rmssdMs)ms rt=\(v.ringTimestamp)"
     case .spo2(let v): return "SPO2 \(v.value) (\(v.unit)) rt=\(v.ringTimestamp)"
     case .temp(let v): return "TEMP \(v.celsius)C rt=\(v.ringTimestamp)"
     case .battery(let v): return "BATTERY \(v.percent)% mv=\(v.voltageMv.map(String.init) ?? "-")"

--- a/Packages/OuraProtocol/Tests/OuraProtocolTests/DecoderGoldenTests.swift
+++ b/Packages/OuraProtocol/Tests/OuraProtocolTests/DecoderGoldenTests.swift
@@ -70,10 +70,19 @@ final class DecoderGoldenTests: XCTestCase {
     // MARK: - 0x5D HRV / RMSSD
 
     func testHRV0x5D() {
-        // time 5000, b1=10, b2=-5
-        let rec = record("5d080200010088130afb")
+        // (u8 hr, u8 rmssd) pairs — real overnight bytes: 32 84 32 83 -> (50,132),(50,131).
+        // hr=50 bpm is sleeping HR (validates the layout; matches the #511 IBI-derived median).
+        let rec = record("5d080200010032843283")
         let hrv = OuraDecoders.decodeHRV(rec)
-        XCTAssertEqual(hrv, [OuraHRV(ringTimestamp: rt, timeMs: 5000, b1: 10, b2: -5)])
+        XCTAssertEqual(hrv, [
+            OuraHRV(ringTimestamp: rt, index: 0, hrBpm: 50, rmssdMs: 132),
+            OuraHRV(ringTimestamp: rt, index: 1, hrBpm: 50, rmssdMs: 131),
+        ])
+    }
+
+    func testHRV0x5DOddLengthIsNil() {
+        // A partial trailing pair (odd body length) must decode to nil, never a half-sample.
+        XCTAssertNil(OuraDecoders.decodeHRV(record("5d0702000100328432")))
     }
 
     // MARK: - 0x6F SpO2 per-sample (byte6 high nibble is a base/status field, DISCARDED; samples are

--- a/Packages/WhoopStore/Sources/WhoopStore/OuraStreamMapping.swift
+++ b/Packages/WhoopStore/Sources/WhoopStore/OuraStreamMapping.swift
@@ -24,9 +24,12 @@ import OuraProtocol
 /// Tier-B (UNVERIFIED) events are dropped: only Tier-A decoded signals map into `Streams`, so an
 /// unverified summary can never silently feed scoring.
 public enum OuraStreamMapping {
-    /// WhoopEvent.kind for the ring's own HRV 0x5D tag. The payload carries the RAW decoded fields
-    /// (`time_ms`/`b1`/`b2`) only, never a fabricated `rmssd_ms` (the b1/b2 byte -> ms scale is not
-    /// Tier-A; see OURA_PROTOCOL.md s6.9). Must match the Kotlin twin (OuraStreamMapping.kt) exactly.
+    /// WhoopEvent.kind for the ring's own HRV 0x5D tag. The payload carries the honestly-labelled decoded
+    /// fields `pair_index` / `hr_bpm` / `rmssd_ms` — the 0x5D body is a run of `(u8 avg HR bpm, u8 avg
+    /// RMSSD ms)` pairs, one per 5-min bucket (layout pinned to open_oura, OURA_PROTOCOL.md s6.9). This is
+    /// the ring's OWN summary tag, NOT Oura's readiness score, and NOT NOOP's scoring RMSSD (that is
+    /// reconstructed from `rr`). Each bucket is stamped at its own 5-min offset (see `.hrv` below) so the
+    /// per-bucket series survives the (deviceId, ts, kind) event key. Must match the Kotlin twin exactly.
     public static let hrvEventKind = "OURA_HRV"
     /// WhoopEvent.kind for a decoded sleep-phase code (2-bit: awake/light/deep/rem).
     public static let sleepPhaseEventKind = "OURA_SLEEP_PHASE"
@@ -35,7 +38,7 @@ public enum OuraStreamMapping {
     /// (unix seconds). Pure → unit-testable. Section-4 table:
     ///   - `.hr`         (0x55 live-HR push)            → `hr:[HRSample]`
     ///   - `.ibi`        (0x44/0x60 IBI)                → `rr:[RRInterval]`
-    ///   - `.hrv`        (0x5D HRV tag, raw int8 b1/b2)  → `events:[WhoopEvent(kind: OURA_HRV)]`
+    ///   - `.hrv`        (0x5D HRV tag, u8 hr/rmssd pairs) → `events:[WhoopEvent(kind: OURA_HRV)]` (one row per 5-min bucket)
     ///   - `.spo2`       (0x6F/0x70/0x77)              → `spo2:[SpO2Sample(raw_adc)]`
     ///   - `.temp`       (0x46/0x75)                    → `skinTemp:[SkinTempSample(raw_adc)]`
     ///   - `.sleepPhase` (0x4E/0x5A 2-bit codes)        → `events:[WhoopEvent(kind: OURA_SLEEP_PHASE)]`
@@ -62,11 +65,20 @@ public enum OuraStreamMapping {
                 // The ring's OWN 0x5D 5-min bucket: average HR (bpm) + average RMSSD (ms), both u8, no
                 // scaling (layout pinned to open_oura's (u8 hr, u8 rmssd) pairs — the byte->unit scaling
                 // that was "unpinned" is now known, so these are honestly labelled, not raw bytes).
-                // `pair_index` is the bucket's position in the record (buckets ~5 min apart). This is the
-                // ring's open summary tag, NOT Oura's readiness score; NOOP's own scoring RMSSD still comes
-                // from the IBI stream (`rr`). Keys/values are IDENTICAL to the Kotlin twin so both platforms
-                // emit byte-for-byte the same OURA_HRV payload.
-                out.events.append(WhoopEvent(ts: ts, kind: hrvEventKind, payload: [
+                // `pair_index` is the bucket's position in the record. This is the ring's open summary
+                // tag, NOT Oura's readiness score; NOOP's own scoring RMSSD still comes from the IBI
+                // stream (`rr`). Keys/values are IDENTICAL to the Kotlin twin so both platforms emit
+                // byte-for-byte the same OURA_HRV payload.
+                //
+                // Each bucket gets its OWN timestamp so it lands on a distinct event row. The event PK is
+                // (deviceId, ts, kind), so N pairs sharing the record `ts` would collide on insert and only
+                // one survive — silently dropping the rest of the ring's per-5-min series. The buckets walk
+                // backward from the record time at the documented 5-min cadence (the `OuraHRV.index`
+                // contract in OuraEvents; per-sample times step back from the event time, OURA_PROTOCOL.md
+                // s6): bucket `index` sits `300 * index` seconds before `ts`. This is derived from the known
+                // cadence + record anchor, not a guessed time.
+                let bucketTs = ts - v.index * 300
+                out.events.append(WhoopEvent(ts: bucketTs, kind: hrvEventKind, payload: [
                     "pair_index": .int(v.index),
                     "hr_bpm": .int(v.hrBpm),
                     "rmssd_ms": .int(v.rmssdMs),

--- a/Packages/WhoopStore/Sources/WhoopStore/OuraStreamMapping.swift
+++ b/Packages/WhoopStore/Sources/WhoopStore/OuraStreamMapping.swift
@@ -59,18 +59,17 @@ public enum OuraStreamMapping {
                 out.rr.append(RRInterval(ts: ts, rrMs: v.ibiMs))
 
             case .hrv(let v):
-                // The ring's own 0x5D tag, carried RAW for diagnostics/parity. The two int8 fields
-                // (b1/b2) plus the sample's relative time offset are surfaced under units-neutral keys.
-                // We do NOT mint an `rmssd_ms` here: the int8 b1/b2 byte -> millisecond scaling is NOT
-                // Tier-A (OURA_PROTOCOL.md s6.9 leaves it unpinned), so labelling a raw byte as a
-                // millisecond RMSSD would fabricate units (honest-data invariant). NOOP's own scoring
-                // RMSSD is reconstructed from the IBI stream (`rr`), never from this open tag. Keys and
-                // values are IDENTICAL to the Kotlin twin (OuraStreamMapping.kt) so both platforms emit
-                // byte-for-byte the same OURA_HRV payload.
+                // The ring's OWN 0x5D 5-min bucket: average HR (bpm) + average RMSSD (ms), both u8, no
+                // scaling (layout pinned to open_oura's (u8 hr, u8 rmssd) pairs — the byte->unit scaling
+                // that was "unpinned" is now known, so these are honestly labelled, not raw bytes).
+                // `pair_index` is the bucket's position in the record (buckets ~5 min apart). This is the
+                // ring's open summary tag, NOT Oura's readiness score; NOOP's own scoring RMSSD still comes
+                // from the IBI stream (`rr`). Keys/values are IDENTICAL to the Kotlin twin so both platforms
+                // emit byte-for-byte the same OURA_HRV payload.
                 out.events.append(WhoopEvent(ts: ts, kind: hrvEventKind, payload: [
-                    "time_ms": .int(v.timeMs),
-                    "b1": .int(v.b1),
-                    "b2": .int(v.b2),
+                    "pair_index": .int(v.index),
+                    "hr_bpm": .int(v.hrBpm),
+                    "rmssd_ms": .int(v.rmssdMs),
                 ]))
 
             case .spo2(let v):

--- a/Packages/WhoopStore/Tests/WhoopStoreTests/OuraStreamMappingTests.swift
+++ b/Packages/WhoopStore/Tests/WhoopStoreTests/OuraStreamMappingTests.swift
@@ -41,12 +41,32 @@ final class OuraStreamMappingTests: XCTestCase {
         let ev = s.events[0]
         XCTAssertEqual(ev.kind, OuraStreamMapping.hrvEventKind)
         XCTAssertEqual(ev.kind, "OURA_HRV")
+        // Bucket 0 sits at the record time; later buckets walk back 5 min each (see below).
         XCTAssertEqual(ev.ts, ts)
         // The byte->unit scaling is now pinned (u8 bpm, u8 ms), so the fields are honestly labelled.
         // Keys + values match the Kotlin twin exactly.
         XCTAssertEqual(ev.payload["pair_index"], .int(0))
         XCTAssertEqual(ev.payload["hr_bpm"], .int(52))
         XCTAssertEqual(ev.payload["rmssd_ms"], .int(47))
+    }
+
+    // Each 5-min bucket must land on its OWN timestamp: the event key is (deviceId, ts, kind), so pairs
+    // sharing the record `ts` would collide on insert and only one survive. Buckets walk backward from the
+    // record time at the 5-min cadence, so bucket `index` sits 300 s * index before `ts` — distinct rows,
+    // ordered oldest-last, none dropped. Twin of the Kotlin OuraStreamMapping test.
+    func testHRVMultiBucketGetsDistinctFiveMinTimestamps() {
+        let s = OuraStreamMapping.streams(from: [
+            .hrv(OuraHRV(ringTimestamp: 100, index: 0, hrBpm: 52, rmssdMs: 47)),
+            .hrv(OuraHRV(ringTimestamp: 100, index: 1, hrBpm: 54, rmssdMs: 44)),
+            .hrv(OuraHRV(ringTimestamp: 100, index: 2, hrBpm: 55, rmssdMs: 41)),
+        ], at: ts)
+        XCTAssertEqual(s.events.count, 3)
+        // Distinct, 300 s apart, stepping back from the record time.
+        XCTAssertEqual(s.events.map { $0.ts }, [ts, ts - 300, ts - 600])
+        XCTAssertEqual(Set(s.events.map { $0.ts }).count, 3)
+        XCTAssertEqual(s.events.map { $0.payload["pair_index"] }, [.int(0), .int(1), .int(2)])
+        XCTAssertEqual(s.events.map { $0.payload["hr_bpm"] }, [.int(52), .int(54), .int(55)])
+        XCTAssertEqual(s.events.map { $0.payload["rmssd_ms"] }, [.int(47), .int(44), .int(41)])
     }
 
     // MARK: - SpO2 -> spo2:[SpO2Sample]

--- a/Packages/WhoopStore/Tests/WhoopStoreTests/OuraStreamMappingTests.swift
+++ b/Packages/WhoopStore/Tests/WhoopStoreTests/OuraStreamMappingTests.swift
@@ -31,23 +31,22 @@ final class OuraStreamMappingTests: XCTestCase {
         XCTAssertTrue(s.hr.isEmpty)
     }
 
-    // MARK: - HRV 0x5D -> events[OURA_HRV] with RAW, units-neutral payload (no fabricated rmssd_ms)
+    // MARK: - HRV 0x5D -> events[OURA_HRV] with honest hr_bpm / rmssd_ms (layout pinned)
 
-    func testHRVMapsToEventWithRawNeutralPayload() {
+    func testHRVMapsToEventWithHrAndRmssd() {
         let s = OuraStreamMapping.streams(from: [
-            .hrv(OuraHRV(ringTimestamp: 100, timeMs: 5000, b1: 47, b2: 3)),
+            .hrv(OuraHRV(ringTimestamp: 100, index: 0, hrBpm: 52, rmssdMs: 47)),
         ], at: ts)
         XCTAssertEqual(s.events.count, 1)
         let ev = s.events[0]
         XCTAssertEqual(ev.kind, OuraStreamMapping.hrvEventKind)
         XCTAssertEqual(ev.kind, "OURA_HRV")
         XCTAssertEqual(ev.ts, ts)
-        // HONEST: the ring's OWN raw tag fields only; the b1/b2 byte -> ms scale is not Tier-A, so we
-        // NEVER surface a fabricated rmssd_ms. Keys + values match the Kotlin twin exactly.
-        XCTAssertNil(ev.payload["rmssd_ms"], "must not fabricate rmssd_ms")
-        XCTAssertEqual(ev.payload["time_ms"], .int(5000))
-        XCTAssertEqual(ev.payload["b1"], .int(47))
-        XCTAssertEqual(ev.payload["b2"], .int(3))
+        // The byte->unit scaling is now pinned (u8 bpm, u8 ms), so the fields are honestly labelled.
+        // Keys + values match the Kotlin twin exactly.
+        XCTAssertEqual(ev.payload["pair_index"], .int(0))
+        XCTAssertEqual(ev.payload["hr_bpm"], .int(52))
+        XCTAssertEqual(ev.payload["rmssd_ms"], .int(47))
     }
 
     // MARK: - SpO2 -> spo2:[SpO2Sample]
@@ -141,7 +140,7 @@ final class OuraStreamMappingTests: XCTestCase {
         let s = OuraStreamMapping.streams(from: [
             .hr(OuraHR(ringTimestamp: 1, bpm: 55, ibiMs: 1090)),
             .ibi(OuraIBI(ringTimestamp: 1, ibiMs: 1090)),
-            .hrv(OuraHRV(ringTimestamp: 1, timeMs: 0, b1: 40, b2: 1)),
+            .hrv(OuraHRV(ringTimestamp: 1, index: 0, hrBpm: 40, rmssdMs: 1)),
             .spo2(OuraSpO2(ringTimestamp: 1, value: 965)),
             .temp(OuraTemp(ringTimestamp: 1, celsius: 34.0)),
             .sleepPhase(OuraSleepPhase(ringTimestamp: 1, index: 0, stage: .light)),

--- a/android/app/src/main/java/com/noop/data/OuraStreamMapping.kt
+++ b/android/app/src/main/java/com/noop/data/OuraStreamMapping.kt
@@ -59,17 +59,19 @@ object OuraStreamMapping {
                 }
 
                 is OuraEvent.Hrv -> {
-                    // The ring's OWN open HRV tag, recorded raw for diagnostics/parity. NOT Oura's
-                    // readiness score, and NOT used as NOOP's RMSSD (that comes from `rr`).
+                    // The ring's OWN 0x5D 5-min bucket: avg HR (bpm) + avg RMSSD (ms), both u8, no scaling
+                    // (layout pinned to open_oura's (u8 hr, u8 rmssd) pairs — honestly labelled now). NOT
+                    // Oura's readiness score, and NOT used as NOOP's RMSSD (that comes from `rr`). Keys/values
+                    // IDENTICAL to the Swift twin so both platforms emit the same OURA_HRV payload.
                     val ts = anchor(ev.value.ringTimestamp) ?: continue
                     out.events.add(
                         WhoopEvent(
                             ts = ts,
                             kind = EVENT_HRV,
                             payload = linkedMapOf(
-                                "time_ms" to ev.value.timeMs,
-                                "b1" to ev.value.b1,
-                                "b2" to ev.value.b2,
+                                "pair_index" to ev.value.index,
+                                "hr_bpm" to ev.value.hrBpm,
+                                "rmssd_ms" to ev.value.rmssdMs,
                             ),
                         ),
                     )

--- a/android/app/src/main/java/com/noop/data/OuraStreamMapping.kt
+++ b/android/app/src/main/java/com/noop/data/OuraStreamMapping.kt
@@ -18,9 +18,9 @@ import com.noop.protocol.WhoopEvent
  * own Charge/Rest downstream:
  *   - the IBI stream becomes [Streams.rr], from which RecoveryScorer reconstructs NOOP's OWN RMSSD;
  *   - the HR stream feeds resting-HR + strain;
- *   - the ring's open 0x5D HRV tag is recorded as an `OURA_HRV` diagnostic event carrying ITS RAW
- *     decoded fields (time_ms/b1/b2) ONLY, never a fabricated rmssd_ms (the int8 b1/b2 byte->ms
- *     scale is not Tier-A; NOOP's scoring RMSSD comes from `rr`, not this tag);
+ *   - the ring's open 0x5D HRV tag is recorded as `OURA_HRV` events carrying its honestly-labelled
+ *     decoded fields (pair_index/hr_bpm/rmssd_ms) — the body is a run of (u8 avg HR bpm, u8 avg RMSSD
+ *     ms) pairs, one per 5-min bucket; NOOP's own scoring RMSSD still comes from `rr`, not this tag;
  *   - the open sleep-phase tags become `OURA_SLEEP_PHASE` events folded into a sleep session.
  *
  * Each event carries a ring-clock `ringTimestamp` (not wall-clock). To stay pure and avoid baking a
@@ -63,7 +63,16 @@ object OuraStreamMapping {
                     // (layout pinned to open_oura's (u8 hr, u8 rmssd) pairs — honestly labelled now). NOT
                     // Oura's readiness score, and NOT used as NOOP's RMSSD (that comes from `rr`). Keys/values
                     // IDENTICAL to the Swift twin so both platforms emit the same OURA_HRV payload.
-                    val ts = anchor(ev.value.ringTimestamp) ?: continue
+                    //
+                    // Each bucket gets its OWN timestamp so it lands on a distinct event row. The event PK is
+                    // (deviceId, ts, kind), so N pairs sharing the record ts would collide on insert and only
+                    // one survive — silently dropping the rest of the ring's per-5-min series. Buckets walk
+                    // backward from the record time at the documented 5-min cadence (the OuraHRV.index
+                    // contract; per-sample times step back from the event time, OURA_PROTOCOL.md s6): bucket
+                    // `index` sits 300 * index seconds before the anchored time. Derived from the known
+                    // cadence + record anchor, not a guessed time. Twin of Swift.
+                    val base = anchor(ev.value.ringTimestamp) ?: continue
+                    val ts = base - ev.value.index * 300
                     out.events.add(
                         WhoopEvent(
                             ts = ts,

--- a/android/app/src/main/java/com/noop/oura/Decoders.kt
+++ b/android/app/src/main/java/com/noop/oura/Decoders.kt
@@ -162,21 +162,24 @@ object OuraDecoders {
     // MARK: - HRV / RMSSD (0x5D; s6.9)
 
     /**
-     * Decode the 0x5D hrv_event: samples each carrying a time_ms field + two int8 fields (b1, b2).
-     * Per OURA_PROTOCOL.md s6.9 the per-sample stride is time(2 LE) + b1(1) + b2(1) = 4 bytes.
-     * Returns null on a short body. NOOP consumes this as the ring's OWN RMSSD-derived HRV tag.
+     * Decode the 0x5D hrv_event: a run of (u8 avg HR bpm, u8 avg RMSSD ms) pairs, ONE per 5-min bucket
+     * (per open_oura decode_hrv / OURA_PROTOCOL.md s6.9). The previous layout read a 4-byte
+     * (u16 time, int8, int8) stride — a mis-framing that garbled the first (hr,rmssd) byte-pair into a
+     * bogus time_ms, sign-flipped the RMSSD byte, and only its b1 accidentally landed on a real HR byte.
+     * Both bytes are UNSIGNED (no scaling). Returns null on an empty or ODD-length body (no partial pair).
+     * Validated overnight: the hr byte tracks sleeping HR (~52 bpm, matching the #511 IBI-derived median).
+     * Twin of Swift decodeHRV.
      */
     fun decodeHRV(rec: OuraRecord): List<OuraHRV>? {
         val b = rec.payload
-        if (b.size < 4) return null
+        if (b.size < 2 || b.size % 2 != 0) return null   // N complete (hr, rmssd) pairs
         val out = ArrayList<OuraHRV>()
         var i = 0
-        while (i + 4 <= b.size) {
-            val timeMs = u16le(b, i)
-            val v1 = i8(b[i + 2])
-            val v2 = i8(b[i + 3])
-            out.add(OuraHRV(ringTimestamp = rec.ringTimestamp, timeMs = timeMs, b1 = v1, b2 = v2))
-            i += 4
+        var index = 0
+        while (i + 2 <= b.size) {
+            out.add(OuraHRV(ringTimestamp = rec.ringTimestamp, index = index, hrBpm = b[i], rmssdMs = b[i + 1]))
+            i += 2
+            index += 1
         }
         return if (out.isEmpty()) null else out
     }

--- a/android/app/src/main/java/com/noop/oura/OuraEvents.kt
+++ b/android/app/src/main/java/com/noop/oura/OuraEvents.kt
@@ -25,7 +25,13 @@ data class OuraHR(val ringTimestamp: Long, val bpm: Int, val ibiMs: Int)
  * NOOP also reconstructs RMSSD itself from the IBI streams for its own scoring; this is the ring's
  * open HRV tag, NOT Oura's encrypted readiness score.
  */
-data class OuraHRV(val ringTimestamp: Long, val timeMs: Int, val b1: Int, val b2: Int)
+/**
+ * One decoded 5-min HRV bucket from the ring's own 0x5D tag: the ring's avg HR (bpm) + avg RMSSD (ms),
+ * both u8 (no scaling). The 0x5D body is a run of (u8 hr, u8 rmssd) pairs, one per 5 min; [index] is the
+ * pair's position in the record (buckets ~5 min apart). Ring's open summary tag, NOT Oura's readiness
+ * score. Twin of Swift OuraHRV.
+ */
+data class OuraHRV(val ringTimestamp: Long, val index: Int, val hrBpm: Int, val rmssdMs: Int)
 
 /** One decoded SpO2 sample. `value` is the raw SpO2 reading; `unit` documents its scale. */
 data class OuraSpO2(val ringTimestamp: Long, val value: Int, val unit: String = "raw")

--- a/android/app/src/test/java/com/noop/data/OuraStreamMappingTest.kt
+++ b/android/app/src/test/java/com/noop/data/OuraStreamMappingTest.kt
@@ -45,9 +45,9 @@ class OuraStreamMappingTest {
     }
 
     @Test
-    fun hrvBecomesOuraHrvEventWithRawFieldsNotRmssd() {
+    fun hrvBecomesOuraHrvEventWithHrAndRmssd() {
         val s = OuraStreamMapping.streams(
-            listOf(OuraEvent.Hrv(OuraHRV(ringTimestamp = 5, timeMs = 1000, b1 = 7, b2 = -3))),
+            listOf(OuraEvent.Hrv(OuraHRV(ringTimestamp = 5, index = 0, hrBpm = 52, rmssdMs = 47))),
             anchor,
         )
         assertEquals(1, s.events.size)
@@ -55,11 +55,10 @@ class OuraStreamMappingTest {
         assertEquals(OuraStreamMapping.EVENT_HRV, ev.kind)
         assertEquals("OURA_HRV", ev.kind)
         assertEquals(base + 5, ev.ts)
-        // HONEST: the ring's OWN raw tag fields only; NEVER a fabricated rmssd_ms.
-        assertEquals(1000, ev.payload["time_ms"])
-        assertEquals(7, ev.payload["b1"])
-        assertEquals(-3, ev.payload["b2"])
-        assertTrue("must not fabricate rmssd_ms", !ev.payload.containsKey("rmssd_ms"))
+        // Layout pinned (u8 bpm, u8 ms) → honestly labelled fields; keys/values match the Swift twin.
+        assertEquals(0, ev.payload["pair_index"])
+        assertEquals(52, ev.payload["hr_bpm"])
+        assertEquals(47, ev.payload["rmssd_ms"])
     }
 
     @Test

--- a/android/app/src/test/java/com/noop/data/OuraStreamMappingTest.kt
+++ b/android/app/src/test/java/com/noop/data/OuraStreamMappingTest.kt
@@ -54,11 +54,35 @@ class OuraStreamMappingTest {
         val ev = s.events.first()
         assertEquals(OuraStreamMapping.EVENT_HRV, ev.kind)
         assertEquals("OURA_HRV", ev.kind)
+        // Bucket 0 sits at the record time; later buckets walk back 5 min each (see next test).
         assertEquals(base + 5, ev.ts)
         // Layout pinned (u8 bpm, u8 ms) → honestly labelled fields; keys/values match the Swift twin.
         assertEquals(0, ev.payload["pair_index"])
         assertEquals(52, ev.payload["hr_bpm"])
         assertEquals(47, ev.payload["rmssd_ms"])
+    }
+
+    // Each 5-min bucket must land on its OWN timestamp: the event key is (deviceId, ts, kind), so pairs
+    // sharing the record ts would collide on insert and only one survive. Buckets walk backward from the
+    // record time at the 5-min cadence, so bucket `index` sits 300 s * index before the anchored time —
+    // distinct rows, ordered oldest-last, none dropped. Twin of the Swift OuraStreamMapping test.
+    @Test
+    fun hrvMultiBucketGetsDistinctFiveMinTimestamps() {
+        val s = OuraStreamMapping.streams(
+            listOf(
+                OuraEvent.Hrv(OuraHRV(ringTimestamp = 5, index = 0, hrBpm = 52, rmssdMs = 47)),
+                OuraEvent.Hrv(OuraHRV(ringTimestamp = 5, index = 1, hrBpm = 54, rmssdMs = 44)),
+                OuraEvent.Hrv(OuraHRV(ringTimestamp = 5, index = 2, hrBpm = 55, rmssdMs = 41)),
+            ),
+            anchor,
+        )
+        assertEquals(3, s.events.size)
+        // Distinct, 300 s apart, stepping back from the record time.
+        assertEquals(listOf(base + 5, base + 5 - 300, base + 5 - 600), s.events.map { it.ts })
+        assertEquals(3, s.events.map { it.ts }.toSet().size)
+        assertEquals(listOf(0, 1, 2), s.events.map { it.payload["pair_index"] })
+        assertEquals(listOf(52, 54, 55), s.events.map { it.payload["hr_bpm"] })
+        assertEquals(listOf(47, 44, 41), s.events.map { it.payload["rmssd_ms"] })
     }
 
     @Test

--- a/android/app/src/test/java/com/noop/oura/DecoderGoldenTest.kt
+++ b/android/app/src/test/java/com/noop/oura/DecoderGoldenTest.kt
@@ -78,10 +78,23 @@ class DecoderGoldenTest {
 
     @Test
     fun testHRV0x5D() {
-        // time 5000, b1=10, b2=-5
-        val rec = record("5d080200010088130afb")
+        // (u8 hr, u8 rmssd) pairs — real overnight bytes: 32 84 32 83 -> (50,132),(50,131).
+        // hr=50 bpm is sleeping HR (validates the layout; matches the #511 IBI-derived median).
+        val rec = record("5d080200010032843283")
         val hrv = OuraDecoders.decodeHRV(rec)
-        assertEquals(listOf(OuraHRV(ringTimestamp = rt, timeMs = 5000, b1 = 10, b2 = -5)), hrv)
+        assertEquals(
+            listOf(
+                OuraHRV(ringTimestamp = rt, index = 0, hrBpm = 50, rmssdMs = 132),
+                OuraHRV(ringTimestamp = rt, index = 1, hrBpm = 50, rmssdMs = 131),
+            ),
+            hrv,
+        )
+    }
+
+    @Test
+    fun testHRV0x5DOddLengthIsNull() {
+        // A partial trailing pair (odd body length) must decode to null, never a half-sample.
+        assertNull(OuraDecoders.decodeHRV(record("5d0702000100328432")))
     }
 
     // MARK: - 0x6F SpO2 per-sample (base from high nibble << 7, then u8, 0xFF terminator)

--- a/docs/OURA_PROTOCOL.md
+++ b/docs/OURA_PROTOCOL.md
@@ -369,9 +369,10 @@ like its sibling banked streams (`.hrv`/`.temp`/`.spo2`/`.sleepPhase`) — the f
 - **`0x69` `temp_period`** (6 B): single **int16 LE ÷ 100 = °C**. [ringverse]
 - **`0x75` `sleep_temp_event`** (6–18 B, 30 s spacing): values **uint16 LE ÷ 100 = °C**, timestamps walk backward from event UTC. [ringverse]
 
-### 6.9 HRV / RMSSD - `0x5D` `hrv_event` (6–16 B, 5-min spacing)
-- Samples each with `time_ms` + two int8 fields (`b1`,`b2`); timestamps walk backward from event UTC. [ringverse]
-- **NOOP note:** `0x5D` is the ring's own RMSSD-derived HRV tag; NOOP also reconstructs RMSSD/SDNN itself from the IBI streams (`0x60`/`0x80`) for our own scoring (we do not consume Oura's encrypted scores). [open_ring][ringverse]
+### 6.9 HRV / RMSSD - `0x5D` `hrv_event` (even-length body, 5-min buckets)
+- Body is a run of **`(u8 avg HR bpm, u8 avg RMSSD ms)` PAIRS**, one per 5-min bucket — HR at even byte offsets, RMSSD at odd; both **UNSIGNED, no scaling**. Decodes to nil on an empty or odd-length body. [oura-rs]
+- **DECODE CORRECTION:** earlier drafts read a 4-byte `time_ms(2 LE) + int8 + int8` stride [ringverse]; that mis-framed the first byte-pair into a bogus `time_ms`, sign-flipped the RMSSD byte, and only its `b1` accidentally landed on a real HR byte. Corrected to the pair layout above and validated against a real overnight capture: the HR byte tracks sleeping HR (~52 bpm), matching the #511 IBI-derived median.
+- **NOOP note:** `0x5D` is the ring's own summary HR+RMSSD tag; NOOP also reconstructs RMSSD/SDNN itself from the IBI streams (`0x60`/`0x80`) for its own scoring (we do not consume Oura's encrypted scores). [open_ring][oura-rs]
 
 ### 6.10 Battery - `0x0D` response (8 B body)
 - Layout: `percent, charging_progress, recommended_flag, 3 unknown bytes`. [open_oura-r3]


### PR DESCRIPTION
  ## Problem (related to issue #728) 
  NOOP decoded the `0x5D` hrv_event as a 4-byte `(u16 time_ms, int8 b1, int8 b2)` stride and carried the fields **raw** (units-neutral, never fed to scoring). Cross-checking open_oura's `decode_hrv` and a real overnight capture shows the true layout is  a run of **`(u8 avg HR bpm, u8 avg RMSSD ms)` pairs, one per 5-min bucket**. The old framing:
  - garbled the first `(hr, rmssd)` byte-pair into a bogus `time_ms`,
  - sign-flipped the RMSSD byte (`int8`, so `131` read as `-125`),
  - and only `b1` accidentally landed on a real HR byte.

  ## Validation (real device)
  On a captured 22-Jul night, NOOP's stored `b1` values were **50, 52, 53, 52, 47, 54, 59, 52** — textbook sleeping HR, matching the #511 IBI-derived median of 54 bpm. Reconstructing the bogus `time_ms` (`33842 = 0x8432`) back to bytes gives `[50,  132]` — exactly the `(hr, rmssd)` of the first pair. So `b1` was right by accident; `time_ms` and `b2`'s sign were wrong.

  ## Change (byte-identical Swift/Kotlin twins)
  - **OuraProtocol:** `OuraHRV` now carries `(index, hrBpm, rmssdMs)`; `decodeHRV` walks 2-byte **unsigned** `(hr, rmssd)` pairs and returns nil on an empty or **odd-length** body (never a partial pair). Golden tests use real overnight bytes (`32 84 32  83`) plus an odd-length-nil case. `oura-decode` CLI updated.
  - **WhoopStore / data:** the `OURA_HRV` event payload is now honestly labelled `hr_bpm` / `rmssd_ms` / `pair_index` — the byte→unit scaling is pinned now, so the old "raw, no `rmssd_ms`" honesty caveat no longer applies. Keys/values identical on both  platforms.
  - **docs/OURA_PROTOCOL.md §6.9** corrected, with the decode-correction note.

  ## Scope
  Pure decoder-correctness fix, one concern. It's also the **precursor to #728**: the ring's own overnight HR + RMSSD are now available honestly — feeding `avgHrv` directly and giving a ground-truth HR to validate #728's IBI-derived `hrSample` against.
  (0x5D alone is too sparse — ~40–96 HR/night — to satisfy the pipeline's `≥200` HR gate, so #728 still needs the dense IBI-derived series.)

  ## Verification
  - `swift test` OuraProtocol + WhoopStore **green** (corrected `0x5D` golden + mapping tests).
  - macOS `Strand` **BUILD SUCCEEDED**; Android `compileFullDebugKotlin` **OK**.
  - Android unit-test **run** is blocked only by the unrelated #716 test-fake gap (**PR #725**); the Kotlin `0x5D` tests mirror the passing Swift ones and run once #725 lands.
