### PR TITLE
i18n_audit: trace val-backed accessibility copy (#571)

### DIFF
--- a/Tools/i18n_audit.py
+++ b/Tools/i18n_audit.py
@@ -267,6 +267,8 @@ ANDROID_KWARG_PATTERN = re.compile(r"\b(?:title|label|text|contentDescription|pl
 # `_argument_span_end`, which stops at the enclosing `}`), so unrelated lambda content is never swept in.
 ANDROID_A11Y_ASSIGN_PATTERN = re.compile(r"(?<![.\w])contentDescription\s*=(?!=)\s*")
 _LOCAL_DECL_BEFORE = re.compile(r"\b(?:val|var)\s+\Z")
+_SIMPLE_IDENTIFIER = re.compile(r"[A-Za-z_]\w*\Z")
+_LOCAL_VAL_PATTERN = re.compile(r"\bval\s+([A-Za-z_]\w*)\s*=\s*")
 
 
 def _mask_comments(text: str) -> str:
@@ -304,6 +306,101 @@ def _mask_comments(text: str) -> str:
             continue
         i += 1
     return "".join(out)
+
+
+def _brace_stack_at(text: str, end: int) -> tuple[int, ...]:
+    """Opening `{` offsets whose scopes contain `end`, ignoring string
+    contents. Used for the deliberately small bit of Kotlin name resolution
+    below: a local `val` is visible only while its declaring brace is still
+    open at the use site."""
+    stack: list[int] = []
+    i = 0
+    while i < end:
+        ch = text[i]
+        if ch == '"':
+            i = _skip_string_literal(text, i)
+            continue
+        if ch == "{":
+            stack.append(i)
+        elif ch == "}" and stack:
+            stack.pop()
+        i += 1
+    return tuple(stack)
+
+
+def _statement_span_end(text: str, start: int) -> int:
+    """End of a Kotlin `val` initializer.
+
+    Newlines before the expression are allowed; once the expression starts, a
+    newline or semicolon at top level ends it unless Kotlin syntax clearly
+    continues on the next line (for example `"prefix" +` followed by an
+    `if`). Balanced calls and `when { }` / `if { }` expressions can span lines
+    without exposing the following statements to literal extraction.
+    """
+    depth = 0
+    saw_expression = False
+    i = start
+    while i < len(text):
+        ch = text[i]
+        if ch == '"':
+            saw_expression = True
+            i = _skip_string_literal(text, i)
+            continue
+        if ch in "({[":
+            depth += 1
+            saw_expression = True
+        elif ch in ")}]":
+            if depth == 0:
+                return i
+            depth -= 1
+        elif depth == 0 and ch == ";":
+            return i
+        elif depth == 0 and ch == "\n" and saw_expression:
+            previous = i - 1
+            while previous >= start and text[previous].isspace():
+                previous -= 1
+            following = i + 1
+            while following < len(text) and text[following].isspace():
+                following += 1
+            trails_operator = (
+                previous >= start and text[previous] in "+-*/%&|?:,.="
+            )
+            starts_continuation = (
+                text.startswith(".", following)
+                or text.startswith("?:", following)
+                or re.match(r"else\b", text[following:]) is not None
+            )
+            if not trails_operator and not starts_continuation:
+                return i
+        elif not ch.isspace():
+            saw_expression = True
+        i += 1
+    return i
+
+
+def _visible_val_initializer(
+    text: str, name: str, use_offset: int
+) -> tuple[int, int] | None:
+    """Initializer span for the nearest preceding `val name = ...` visible at
+    `use_offset`.
+
+    This is intentionally lexical rather than general Kotlin dataflow. It
+    covers the common Compose shape `val a11y = when { ... }; semantics {
+    contentDescription = a11y }`, while declining parameters, properties
+    outside a braced scope, computed references, and declarations in sibling
+    blocks. The nearest visible declaration wins, matching local shadowing.
+    """
+    use_scopes = set(_brace_stack_at(text, use_offset))
+    declarations = list(_LOCAL_VAL_PATTERN.finditer(text, 0, use_offset))
+    for declaration in reversed(declarations):
+        if declaration.group(1) != name:
+            continue
+        declaration_scopes = _brace_stack_at(text, declaration.start())
+        if not declaration_scopes or declaration_scopes[-1] not in use_scopes:
+            continue
+        start = declaration.end()
+        return start, _statement_span_end(text, start)
+    return None
 
 
 # Only an argument in actual call-argument position (right after `(` or `,`,
@@ -351,7 +448,19 @@ def scan_android() -> list[tuple[str, int, str]]:
             for m in ANDROID_A11Y_ASSIGN_PATTERN.finditer(text):
                 if _LOCAL_DECL_BEFORE.search(text, 0, m.start()):
                     continue
-                record(m.end(), _argument_span_end(text, m.end()))
+                span_end = _argument_span_end(text, m.end())
+                record(m.end(), span_end)
+
+                # The remaining #571 case: the assignment contains no literal
+                # because a local `val` launders it. Follow only a bare
+                # identifier to the nearest lexically-visible declaration;
+                # pass-through parameters and arbitrary expressions remain
+                # outside this targeted audit rule.
+                reference = text[m.end():span_end].strip()
+                if _SIMPLE_IDENTIFIER.fullmatch(reference):
+                    initializer = _visible_val_initializer(text, reference, m.start())
+                    if initializer is not None:
+                        record(*initializer)
 
     return findings
 

--- a/Tools/i18n_audit_baseline.json
+++ b/Tools/i18n_audit_baseline.json
@@ -77,6 +77,26 @@
       "No caffeine logged. Log an intake to see an estimate."
     ],
     [
+      "android/app/src/main/java/com/noop/ui/Charts.kt",
+      "Bars"
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/Charts.kt",
+      "Breakdown, ${segments.size} segments"
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/Charts.kt",
+      "Breakdown, no data"
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/Charts.kt",
+      "Timeline"
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/Charts.kt",
+      "Trend"
+    ],
+    [
       "android/app/src/main/java/com/noop/ui/CoachScreen.kt",
       "Bring your own API key. It is stored encrypted on this device and only used to "
     ],
@@ -153,6 +173,18 @@
       "A classic one-glance read of NOOP's own scores. Same data, different lens."
     ],
     [
+      "android/app/src/main/java/com/noop/ui/CoupledScreen.kt",
+      "Recovery ${recovery.roundToInt()} percent. See what shaped your Charge"
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/CoupledScreen.kt",
+      "Recovery calibrating, $calibrationNights of ${Baselines.minNightsSeed} nights"
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/CoupledScreen.kt",
+      "Recovery, no data yet"
+    ],
+    [
       "android/app/src/main/java/com/noop/ui/DataSourcesScreen.kt",
       "Imported"
     ],
@@ -183,6 +215,14 @@
     [
       "android/app/src/main/java/com/noop/ui/FusedRecordScreen.kt",
       ", in use"
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/FusedRecordScreen.kt",
+      "Scores still calibrating, no single day-owner yet"
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/FusedRecordScreen.kt",
+      "Today's scores owned by ${owner.displayName}"
     ],
     [
       "android/app/src/main/java/com/noop/ui/HealthScreen.kt",
@@ -259,6 +299,14 @@
     [
       "android/app/src/main/java/com/noop/ui/HealthScreen.kt",
       "about your age"
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/HrvSnapshotScreen.kt",
+      "$value $unit"
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/HrvSnapshotScreen.kt",
+      "Capturing. $value milliseconds RMSSD so far. $sub."
     ],
     [
       "android/app/src/main/java/com/noop/ui/HrvSnapshotScreen.kt",
@@ -418,6 +466,10 @@
     ],
     [
       "android/app/src/main/java/com/noop/ui/MindSection.kt",
+      "${face.word}, mood ${face.value.toInt()} of 5"
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/MindSection.kt",
       "r = %+.2f"
     ],
     [
@@ -553,6 +605,14 @@
       "Removes this sleep and recomputes the day without it. You can undo for a few seconds after."
     ],
     [
+      "android/app/src/main/java/com/noop/ui/SleepScreen.kt",
+      "Sleep deleted."
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/SleepScreen.kt",
+      "Sleep deleted. NOOP won't detect sleep between $startText and $endText again."
+    ],
+    [
       "android/app/src/main/java/com/noop/ui/SmartAlarmScreen.kt",
       "Armed on the strap itself with the experimental 5/MG command. A strap-driven wake is still unconfirmed on 5/MG on our side (confirmed only on WHOOP 4.0), so keep a backup alarm for anything you truly can't miss."
     ],
@@ -571,14 +631,6 @@
     [
       "android/app/src/main/java/com/noop/ui/StepsCalibrationScreen.kt",
       "Auto"
-    ],
-    [
-      "android/app/src/main/java/com/noop/ui/StepsCalibrationScreen.kt",
-      "Manual steps coefficient, %.1f steps per motion unit"
-    ],
-    [
-      "android/app/src/main/java/com/noop/ui/StepsCalibrationScreen.kt",
-      "Manual steps coefficient, automatic"
     ],
     [
       "android/app/src/main/java/com/noop/ui/StepsCalibrationScreen.kt",
@@ -603,6 +655,14 @@
     [
       "android/app/src/main/java/com/noop/ui/TodayScreen.kt",
       "Calibrating , no heart rate banked yet today. Your curve fills in as the strap offloads."
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/TodayScreen.kt",
+      "How ${it.label} is calculated"
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/TodayScreen.kt",
+      "How this score is calculated"
     ],
     [
       "android/app/src/main/java/com/noop/ui/TodayScreen.kt",
@@ -634,6 +694,14 @@
     ],
     [
       "android/app/src/main/java/com/noop/ui/TodayScreen.kt",
+      "Strap battery"
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/TodayScreen.kt",
+      "Strap battery ${it.roundToInt()} percent"
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/TodayScreen.kt",
       "Zoomed in · drag to pan"
     ],
     [
@@ -651,6 +719,22 @@
     [
       "android/app/src/main/java/com/noop/ui/WorkoutStart.kt",
       "%d:%02d"
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/WorkoutsScreen.kt",
+      "${WorkoutEditing.displaySport(row.sport)}, ${dateLabel(row.startTs)}"
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/WorkoutsScreen.kt",
+      ". Imported, can't be merged."
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/WorkoutsScreen.kt",
+      ". Not selected."
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/WorkoutsScreen.kt",
+      ". Selected."
     ],
     [
       "android/app/src/main/java/com/noop/ui/WorkoutsScreen.kt",

--- a/Tools/test_i18n_audit.py
+++ b/Tools/test_i18n_audit.py
@@ -247,6 +247,98 @@ class ScanAndroidEndToEnd(unittest.TestCase):
         found = sorted(lit for _p, _l, lit in ia.scan_android())
         self.assertEqual(found, ["Deep child", "Tap target"])
 
+    def test_content_description_follows_visible_local_val(self):
+        # The remaining #571 case: the a11y assignment contains only a
+        # reference, while its visible local initializer carries the UI copy.
+        self.write(
+            "Coupled.kt",
+            "fun Hero() {\n"
+            "    val a11y = when {\n"
+            '        ready -> "Recovery $score percent"\n'
+            '        calibrating -> "Recovery calibrating, $n nights"\n'
+            '        else -> "Recovery, no data yet"\n'
+            "    }\n"
+            "    Box(Modifier.semantics { contentDescription = a11y })\n"
+            "}\n",
+        )
+        found = {lit for _p, _l, lit in ia.scan_android()}
+        self.assertEqual(
+            found,
+            {
+                "Recovery $score percent",
+                "Recovery calibrating, $n nights",
+                "Recovery, no data yet",
+            },
+        )
+
+    def test_content_description_does_not_follow_parameter(self):
+        self.write(
+            "Component.kt",
+            "fun Label(content: String) {\n"
+            "    Box(Modifier.semantics { contentDescription = content })\n"
+            "}\n",
+        )
+        found = {lit for _p, _l, lit in ia.scan_android()}
+        self.assertEqual(found, set())
+
+    def test_content_description_respects_val_scope(self):
+        self.write(
+            "Sibling.kt",
+            "fun Screen() {\n"
+            "    if (condition) {\n"
+            '        val a11y = "Sibling-only text"\n'
+            "    }\n"
+            "    Box(Modifier.semantics { contentDescription = a11y })\n"
+            "}\n",
+        )
+        found = {lit for _p, _l, lit in ia.scan_android()}
+        self.assertEqual(found, set())
+
+    def test_content_description_uses_nearest_shadowing_val(self):
+        self.write(
+            "Shadowed.kt",
+            "fun Screen() {\n"
+            '    val a11y = "Outer hardcoded text"\n'
+            "    if (condition) {\n"
+            "        val a11y = uiString(R.string.localized)\n"
+            "        Box(Modifier.semantics { contentDescription = a11y })\n"
+            "    }\n"
+            "}\n",
+        )
+        found = {lit for _p, _l, lit in ia.scan_android()}
+        self.assertEqual(found, set())
+
+    def test_val_initializer_does_not_sweep_following_statements(self):
+        self.write(
+            "Bounded.kt",
+            "fun Screen() {\n"
+            '    val a11y = "Target text"\n'
+            '    val internal = "Not accessibility text"\n'
+            "    Box(Modifier.semantics { contentDescription = a11y })\n"
+            "}\n",
+        )
+        found = {lit for _p, _l, lit in ia.scan_android()}
+        self.assertEqual(found, {"Target text"})
+
+    def test_val_initializer_follows_explicit_line_continuation(self):
+        self.write(
+            "Continued.kt",
+            "fun Screen() {\n"
+            '    val a11y = "Workout row" +\n'
+            "        if (selected) {\n"
+            '            ". Selected."\n'
+            "        } else {\n"
+            '            ". Not selected."\n'
+            "        }\n"
+            "    Box(Modifier.semantics { contentDescription = a11y })\n"
+            "}\n",
+        )
+        found = {lit for _p, _l, lit in ia.scan_android()}
+        self.assertEqual(
+            found,
+            {"Workout row", ". Selected.", ". Not selected."},
+        )
+
 
 class Baseline(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
Closes #571.

## What changed

- Follow a bare `contentDescription = name` reference to the nearest lexically visible `val name = ...` initializer.
- Bound initializer scanning across balanced expressions and explicit Kotlin line continuations without sweeping later statements or unrelated Compose lambdas.
- Add regression coverage for the reported `CoupledScreen` shape, parameters, sibling scopes, local shadowing, statement bounds, and multiline concatenation.
- Refresh the audit baseline with 24 newly visible accessibility literals across eight Android files, including the three reported in `CoupledScreen.kt`.

## Why

#581 taught the Android audit to see literals assigned directly inside a `semantics {}` lambda, but it still saw no literal when a local variable carried the copy:

```kotlin
val a11y = when { ... }
Modifier.semantics { contentDescription = a11y }
```

This adds deliberately narrow lexical flow for that remaining #571 case. Pass-through parameters, arbitrary expressions, declarations in sibling scopes, and shadowed outer values are not followed.

## Validation

- `cd Tools && python3 -m unittest test_i18n_audit -v` — 34/34 passed
- `python3 Tools/i18n_audit.py --ci origin/main` — passed; Android baseline 213, Apple baseline 64
- `git diff --check` — passed
