### PR TITLE
Fix session-long memory/perf growth: Coach transcript cap + off-hot-path log mirror

### DIFF
--- a/Strand/AI/AICoach.swift
+++ b/Strand/AI/AICoach.swift
@@ -453,6 +453,20 @@ final class AICoachEngine: ObservableObject {
 
     // MARK: Sending
 
+    /// Hard rolling cap on the STORED transcript. The network payload is separately windowed by
+    /// `windowedMessages()` (`maxHistoryMessages`); this bounds the in-memory `messages` array — and the
+    /// SwiftUI transcript rendered from it — so a long-lived session can't grow it without bound. `coach`
+    /// is a single app-lifetime instance on `AppModel`, so before this an active chat grew `messages`
+    /// until the process was killed: the "gets laggy the longer the app runs, reopening fixes it, feels
+    /// like RAM" report. Cap >> the wire window, so it never changes what's sent. (parity with Android)
+    private static let maxStoredMessages = 40
+    private func appendMessage(_ message: ChatMessage) {
+        messages.append(message)
+        if messages.count > Self.maxStoredMessages {
+            messages.removeFirst(messages.count - Self.maxStoredMessages)
+        }
+    }
+
     /// Send a question: append it, build the metrics context, call the chosen provider with the
     /// system prompt + context + running history, parse the reply, append it. Never throws/crashes;
     /// failures land in `errorText`.
@@ -462,7 +476,7 @@ final class AICoachEngine: ObservableObject {
         guard let key = resolvedKey else { errorText = AICoachError.noKey.errorDescription; return }
 
         errorText = nil
-        messages.append(ChatMessage(role: .user, text: trimmed))
+        appendMessage(ChatMessage(role: .user, text: trimmed))
         sending = true
         defer { sending = false }
 
@@ -476,7 +490,7 @@ final class AICoachEngine: ObservableObject {
         do {
             let reply = try await callProvider(key: key, messages: wire)
             let clean = reply.trimmingCharacters(in: .whitespacesAndNewlines)
-            messages.append(ChatMessage(role: .assistant, text: clean.isEmpty ? "(no reply)" : clean))
+            appendMessage(ChatMessage(role: .assistant, text: clean.isEmpty ? "(no reply)" : clean))
         } catch let e as AICoachError {
             errorText = e.errorDescription
         } catch {
@@ -505,7 +519,7 @@ final class AICoachEngine: ObservableObject {
             let reply = try await callProvider(key: key, messages: wire)
             let clean = reply.trimmingCharacters(in: .whitespacesAndNewlines)
             if !clean.isEmpty {
-                messages.append(ChatMessage(role: .assistant, text: "Today's brief\n\n" + clean))
+                appendMessage(ChatMessage(role: .assistant, text: "Today's brief\n\n" + clean))
             }
         } catch let e as AICoachError {
             errorText = e.errorDescription

--- a/Strand/BLE/LiveState.swift
+++ b/Strand/BLE/LiveState.swift
@@ -494,6 +494,10 @@ public final class LiveState: ObservableObject {
         clearStrapRange()                 // a stale clock-drift window must not outlive the link either
         lastFrameAtUnix = nil             // #987: a stale "last frame" freshness must not outlive it either
         ouraWearState = nil               // a stale worn/charging badge must not outlive the link either
+        // Perf: flush the durable log tail on disconnect (mirroring is batched in `append`), so a completed
+        // session's tail is always persisted for a later scheduled export despite the per-line throttle.
+        Self.persistTail(log)
+        logsSincePersist = 0
     }
 
     /// Cap on the in-app strap-log ring buffer. Raised from the old ~1h (200 lines) to retain a rolling
@@ -503,14 +507,35 @@ public final class LiveState: ObservableObject {
     /// unbounded. Drives the Live log card AND the shareable `exportableLogText()`.
     static let maxLogLines = 5_000
 
+    /// Perf: the durable UserDefaults tail (`persistTail`) only feeds a scheduled export that fires hours
+    /// later, so it needn't be current to the last line. Mirroring the whole tail on EVERY append was a
+    /// hot-path cost that grew as more diagnostics (offload/backfill/#700/#714/#720) funnel through this one
+    /// sink. Persist in batches of `persistEveryNLines` instead, and always flush on disconnect
+    /// (`clearBiometrics`) so a finished session stays durable; a few unmirrored lines on an abrupt kill is
+    /// harmless for a debug tail. iOS-only — Android's `logBuffer` is an O(1) `ArrayDeque` with no per-line
+    /// persist, already correct.
+    private static let persistEveryNLines = 32
+    private var logsSincePersist = 0
+    /// Amortize the ring trim: let the buffer overrun by this slack, then trim back to the cap in one batch
+    /// — turning an O(n) `Array.removeFirst` on every line at steady state into one per `trimSlack` lines.
+    /// Still hard-bounded (never exceeds `maxLogLines + trimSlack`).
+    private static let trimSlack = 256
+
     public func append(log line: String, domain: TestDomain? = nil) {
         // Tag inert when nil (today's behaviour, byte-identical). When tagged, prefix a compact,
         // parseable marker the export filters on. Redaction is STILL the only scrub point
         // (redactPii below); tagging happens BEFORE redaction so the scrub covers the whole line.
         let tagged = domain.map { "[\($0.id)] " + line } ?? line
         log.append(Self.redactPii(tagged))
-        if log.count > Self.maxLogLines { log.removeFirst(log.count - Self.maxLogLines) }
-        Self.persistTail(log)
+        // Batched trim: overrun by `trimSlack`, then trim back to the cap in one shot (amortized O(1)/line).
+        if log.count > Self.maxLogLines + Self.trimSlack { log.removeFirst(log.count - Self.maxLogLines) }
+        // Batched durable-tail mirror: persist every `persistEveryNLines` lines, not on every line;
+        // `clearBiometrics()` flushes on disconnect so a completed session is always fully mirrored.
+        logsSincePersist += 1
+        if logsSincePersist >= Self.persistEveryNLines {
+            logsSincePersist = 0
+            Self.persistTail(log)
+        }
         // #990: fold the Backfiller's per-session "session persisted N rows" summary into the persisted
         // ALL-TIME drained-rows tally, right here at the single log sink (no new BLE seam). The summary
         // is emitted unconditionally whenever rows landed (#150), so the cumulative counter accrues on

--- a/Strand/Screens/CoachView.swift
+++ b/Strand/Screens/CoachView.swift
@@ -394,7 +394,9 @@ struct CoachView: View {
             } else {
                 ScrollViewReader { proxy in
                     ScrollView {
-                        VStack(alignment: .leading, spacing: 12) {
+                        // Lazy so off-screen bubbles aren't all resident/laid-out at once; with the
+                        // `maxStoredMessages` cap the transcript is already bounded, this keeps render cost flat.
+                        LazyVStack(alignment: .leading, spacing: 12) {
                             ForEach(coach.messages) { message in
                                 bubble(message).id(message.id)
                             }

--- a/android/app/src/main/java/com/noop/ui/CoachViewModel.kt
+++ b/android/app/src/main/java/com/noop/ui/CoachViewModel.kt
@@ -260,6 +260,12 @@ class CoachViewModel(app: Application) : AndroidViewModel(app) {
 
     // MARK: - Send
 
+    /** Append [msg] to the transcript, trimming to the newest [MAX_STORED_MESSAGES] so the in-memory list
+     *  (and the Compose transcript) stays bounded over a long-lived session. (parity with Swift) */
+    private fun appendMessage(msg: ChatMsg) {
+        _messages.value = (_messages.value + msg).takeLast(MAX_STORED_MESSAGES)
+    }
+
     /**
      * Send [text] as the next user turn: append it, call the coach, then append the reply.
      * No-ops on blank input or while a send is already in flight. All failures land in [error].
@@ -270,7 +276,7 @@ class CoachViewModel(app: Application) : AndroidViewModel(app) {
 
         val appCtx = ctx.applicationContext
         _error.value = null
-        _messages.value = _messages.value + ChatMsg(role = "user", text = question)
+        appendMessage(ChatMsg(role = "user", text = question))
         _sending.value = true
 
         viewModelScope.launch {
@@ -286,7 +292,7 @@ class CoachViewModel(app: Application) : AndroidViewModel(app) {
                     // the second opt-in is set (summary-only, no raw egress, see AiCoach.buildSignalsContext).
                     includeSignals = _consent.value && NoopPrefs.coachSignals(appCtx),
                 )
-                _messages.value = _messages.value + ChatMsg(role = "assistant", text = reply)
+                appendMessage(ChatMsg(role = "assistant", text = reply))
             } catch (e: Exception) {
                 _error.value = e.message ?: "Something went wrong. Please try again."
             } finally {
@@ -301,6 +307,16 @@ class CoachViewModel(app: Application) : AndroidViewModel(app) {
     }
 
     companion object {
+        /**
+         * Hard rolling cap on the STORED transcript. The network payload is separately windowed inside
+         * [AiCoach]; this bounds the in-memory [_messages] list — and the Compose transcript rendered from
+         * it — so a long-lived session can't grow it without bound. The ViewModel survives tab-switching,
+         * so before this an active chat grew until the process was killed: the "gets laggy the longer the
+         * app runs, reopening fixes it, feels like RAM" report. Cap >> the wire window, so it never changes
+         * what's sent. (parity with Swift `maxStoredMessages`)
+         */
+        private const val MAX_STORED_MESSAGES = 40
+
         /**
          * Initial model list for [provider]: its curated ids, plus [selected] appended if it's a
          * custom id not already in that list (so a previously-saved custom model still shows).


### PR DESCRIPTION
## Why

A user reported (no logs, just the symptom): *"performance dropped version by version… it got really laggy and I have to reopen the app to fix it. It seems like a RAM problem."* That signature — progressive slowdown over a session that a restart clears — points at in-memory growth. An investigation across both platforms surfaced two independent causes; this PR fixes both, as two revert-safe commits.

## 1. Coach: cap the stored chat transcript (both platforms)

The AI Coach held its entire chat history in a single app-lifetime object and appended forever with **no cap**:
- iOS — `AICoachEngine.messages` (`@Published`), and `coach` is a `let` on `AppModel`, so it lives for the whole process; the transcript was rendered in a plain `VStack` (every bubble resident).
- Android — `CoachViewModel._messages`; the ViewModel survives tab-switching, so it also only cleared on process death.

The network payload was already windowed (`windowedMessages()` / `maxHistoryMessages`), which is easy to misread as "history is bounded" — but that only trims what's **sent**, never the stored/rendered array. So an active chat grew RAM (and layout cost) until you reopened the app — matching the report exactly.

**Fix:** cap the *stored* array to the newest **40** messages on both engines (cap ≫ the 10-message wire window, so what's sent is unchanged), and render the iOS transcript in a `LazyVStack`. Android keeps its `Column` — a 40-item cap makes a lazy list unnecessary, and nesting a `LazyColumn` in the existing scroll column risks Compose's same-direction-scroll crash. Swift/Kotlin kept in parity.

## 2. LiveState: take the durable log mirror off the per-line hot path (iOS only)

`LiveState.append(log:)` ran on **every** diagnostic line and did two things per line: an O(n) `Array.removeFirst` once the 5k ring was full, and a **synchronous mirror of up to 2000 lines to `UserDefaults`**. That per-line cost has grown release over release as more diagnostics (offload/backfill, #700, #714, #720) funnel through this one sink — so a busy strap session gets laggier the longer it stays connected (a good fit for "dropped version by version").

**Fix:** amortize the trim (let the ring overrun by a 256-line slack, then trim in one shot) and mirror the durable tail **every 32 lines** instead of every line, with an explicit flush on disconnect (`clearBiometrics`) so a finished session's tail is always persisted for the scheduled export. What gets stored/persisted is unchanged — only how often. Buffer stays hard-bounded (≤ `maxLogLines + slack`).

**iOS-only** by design: Android's `log()` already uses an O(1) `ArrayDeque` with no per-line disk write (`WhoopBleClient.kt`), so it needs no twin — the same kind of documented asymmetry as the #700 clock-retry.

## Verification — please read

⚠️ **These are app-target changes with no default CI, and I could not build them locally:** the iOS/macOS targets need Xcode on macOS (unavailable here), and the Android build is blocked on this arm64 host (Google ships `aapt2`/`d8` as x86-64 only). So this has had a **careful manual review but no compile.** Per the app-target CI gap in CLAUDE.md, someone should build both before merge:
- iOS: `xcodebuild … -scheme NOOPiOS build` (and `Strand` macOS, since `AICoach`/`LiveState` are shared).
- Android: `./gradlew compileFullDebugKotlin`.

Changes are comment + small-diff only, no new user-facing strings (i18n gate unaffected), and each commit is independent so either can be dropped.

## Confidence on the diagnosis

The Coach cap (#1) is a **confirmed** unbounded leak regardless of the reporter — worth landing on its own merits. Whether it's *the* cause for this specific user depends on whether they use the Coach; the diag-sink cost (#2) affects every strap user and better matches "version by version." I've asked the reporter for platform + version + whether they use the Coach to confirm which dominates.
