### PR TITLE
Fix Dynamic Island rendering in unsigned iOS builds

### DIFF
--- a/.github/workflows/fork-release.yml
+++ b/.github/workflows/fork-release.yml
@@ -246,7 +246,7 @@ jobs:
           -derivedDataPath build/dd
           CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY=""
           build
-      - name: Package unsigned .ipa (strip the embedded watch app + widget extension) + attach
+      - name: Package unsigned .ipa (strip embedded watch app, retain widget extension) + attach
         env:
           GH_TOKEN: ${{ github.token }}
           VER: ${{ needs.bump.outputs.ver }}
@@ -254,12 +254,12 @@ jobs:
           APP=$(find build/dd/Build/Products/Release-iphoneos -maxdepth 1 -name '*.app' -type d | head -1)
           test -n "$APP" || { echo ".app (iphoneos) not found"; exit 1; }
           rm -rf "$APP/Watch"
-          # Also drop the widget extension (NOOPWidgets.appex). On a re-signed sideload it forces a free
-          # Apple ID to register a SECOND app id (com.noopapp.noop.widgets) plus the app group, and free
-          # accounts get only 10 app ids / 7 days — so repeated AltStore attempts exhaust the quota and
-          # return a generic "failed". The main app installs + runs fine without it (the home-screen widget
-          # is the only thing lost), same rationale as the watch-app strip above.
-          rm -rf "$APP/PlugIns"
+          # Keep NOOPWidgets.appex. It renders both the Home/Lock-Screen widgets AND the Live Activity;
+          # deleting PlugIns still lets ActivityKit create an activity, but iOS can only show an empty
+          # Dynamic Island shell because its renderer is gone.
+          test -d "$APP/PlugIns/NOOPWidgets.appex" || {
+            echo "NOOPWidgets.appex missing from iOS build"; exit 1;
+          }
           rm -rf Payload && mkdir Payload && cp -R "$APP" Payload/
           zip -qr "NOOP-ios-unsigned-v${VER}.ipa" Payload
           gh release upload "${{ needs.bump.outputs.tag }}" "NOOP-ios-unsigned-v${VER}.ipa" --repo "$GITHUB_REPOSITORY" --clobber

--- a/.github/workflows/fork-testing-build.yml
+++ b/.github/workflows/fork-testing-build.yml
@@ -45,7 +45,7 @@ jobs:
           - **Android (release)** — \`NOOP-android-v${VER}.apk\` — optimized, non-debuggable build; installs beside the official app. \`com.noop.whoop.staging\`.
           - **Android (debug)** — \`NOOP-android-debug-v${VER}.apk\` — debuggable build. \`com.noop.whoop.debug\`.
           - **macOS** — \`NOOP-macos-v${VER}.zip\` — unzip, then **right-click → Open** (ad-hoc signed, not notarized; Gatekeeper warns once). If it says *\"damaged\"*, run \`xattr -dr com.apple.quarantine /Applications/NOOP.app\`.
-          - **iOS** — \`NOOP-ios-unsigned-v${VER}.ipa\` — sideload via **AltStore / Sideloadly** (re-signs on-device); embedded watch app + widget extension stripped for free-account install reliability.
+          - **iOS** — \`NOOP-ios-unsigned-v${VER}.ipa\` — sideload via **AltStore / Sideloadly** (re-signs on-device); embedded watch app stripped, widget extension retained for Home/Lock-Screen widgets and Live Activities.
 
           Base app version ${VER} · built ${DATE} · \`${SHA}\`."
 
@@ -146,7 +146,7 @@ jobs:
           -derivedDataPath build/dd
           CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY=""
           build
-      - name: Package unsigned .ipa (strip the embedded watch app + widget extension) + attach
+      - name: Package unsigned .ipa (strip embedded watch app, retain widget extension) + attach
         env:
           GH_TOKEN: ${{ github.token }}
           VER: ${{ needs.meta.outputs.ver }}
@@ -154,12 +154,12 @@ jobs:
           APP=$(find build/dd/Build/Products/Release-iphoneos -maxdepth 1 -name '*.app' -type d | head -1)
           test -n "$APP" || { echo ".app (iphoneos) not found"; exit 1; }
           rm -rf "$APP/Watch"
-          # Also drop the widget extension (NOOPWidgets.appex). On a re-signed sideload it forces a free
-          # Apple ID to register a SECOND app id (com.noopapp.noop.widgets) plus the app group, and free
-          # accounts get only 10 app ids / 7 days — so repeated AltStore attempts exhaust the quota and
-          # return a generic "failed". The main app installs + runs fine without it (the home-screen widget
-          # is the only thing lost), same rationale as the watch-app strip above.
-          rm -rf "$APP/PlugIns"
+          # Keep NOOPWidgets.appex. It renders both the Home/Lock-Screen widgets AND the Live Activity;
+          # deleting PlugIns still lets ActivityKit create an activity, but iOS can only show an empty
+          # Dynamic Island shell because its renderer is gone.
+          test -d "$APP/PlugIns/NOOPWidgets.appex" || {
+            echo "NOOPWidgets.appex missing from iOS build"; exit 1;
+          }
           rm -rf Payload && mkdir Payload && cp -R "$APP" Payload/
           zip -qr "NOOP-ios-unsigned-v${VER}.ipa" Payload
           gh release upload "${{ needs.meta.outputs.tag }}" "NOOP-ios-unsigned-v${VER}.ipa" --repo "$GITHUB_REPOSITORY" --clobber

--- a/docs/IOS.md
+++ b/docs/IOS.md
@@ -52,8 +52,10 @@ hunting for the `.ipa` each time.
 >   widgets may not work** on a free-signed sideload. The core app — pairing your strap, live HR,
 >   recovery/strain/sleep, history, the AI Coach, everything on-device — works regardless. This is an
 >   Apple signing constraint, not a NOOP limitation, and it's why a HealthKit toggle can appear to do
->   nothing on a sideloaded build. (Building from source with your own Apple ID in Xcode grants these
->   entitlements normally.)
+>   nothing on a sideloaded build. The release IPA retains `NOOPWidgets.appex`, so AltStore/Sideloadly
+>   must provision one additional app extension for widgets and Live Activities; removing app extensions
+>   while signing disables those surfaces. Building from source with your own Apple ID in Xcode and
+>   selecting your Team for both targets grants these entitlements normally.
 
 iOS shares the cross-platform Swift packages with macOS, so the number-crunching (recovery, strain,
 HRV, sleep) is the **same code** and produces the same results. iOS is newer and less battle-tested


### PR DESCRIPTION
## What this PR does

This PR fixes empty Dynamic Island and Live Activity shells in unsigned iOS builds produced by the fork release workflows.

The app was correctly requesting and updating a Live Activity, but the packaging steps removed the entire `PlugIns` directory. That also removed `NOOPWidgets.appex`, which contains the WidgetKit renderer for both widgets and Live Activities. ActivityKit could therefore create an activity while iOS had no extension available to draw its content.

The PR:

- keeps `NOOPWidgets.appex` in unsigned IPA artifacts while continuing to strip the embedded watch app;
- fails packaging clearly if the expected widget extension is missing; and
- documents the additional extension-provisioning requirement for sideloading.

The app and widget runtime code are unchanged. Android and BLE behavior are also unchanged.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [x] Documentation
- [x] CI / tooling

## How it was tested

- Both modified workflow files parse as valid YAML.
- `git diff --check` passes.
- Verified that the packaging steps remove only the embedded watch app and assert that `NOOPWidgets.appex` remains.
- The unsigned release workflow was not executed locally; real-device sideloading remains the final validation.
- No BLE, protocol, analytics, macOS, or Android behavior was changed.

## Checklist

- [x] Swift package tests pass for any package I touched (`swift test` in `Packages/<name>`) — no Swift package was touched
- [x] Android unit tests pass if I touched `android/` (`./gradlew testFullDebugUnitTest`) — Android was not touched
- [x] No new build warnings introduced
- [x] UI changes use only `StrandDesign` tokens — no app UI was changed
- [x] No hardcoded hex frame bytes; protocol facts live in the schema / decoders
- [x] Follows the conventions in [`docs/CONTRIBUTING.md`](../docs/CONTRIBUTING.md)
- [x] I did not commit generated output (`Strand.xcodeproj/`) or any secrets/keystores

## Related issues

None.
