### PR TITLE
Fix compact detail-page gutters and range selector layouts

### DIFF
--- a/Packages/StrandDesign/Sources/StrandDesign/Components.swift
+++ b/Packages/StrandDesign/Sources/StrandDesign/Components.swift
@@ -365,20 +365,44 @@ public struct InsightCard: View {
 public struct SegmentedPillControl<T: Hashable>: View {
     let items: [T]
     let label: (T) -> String
+    /// When requested, keep the regular intrinsic control wherever it fits and fall back to
+    /// equal-width segments inside the parent's available width on compact screens. This prevents
+    /// long option sets from widening an entire page beyond the viewport while leaving the many
+    /// shorter segmented controls byte-identical.
+    let adaptsToAvailableWidth: Bool
     /// Per-segment availability (#943): a disabled segment stays visible (so users learn the
     /// option exists) but renders extra-dim and ignores taps; VoiceOver announces it dimmed.
     /// Defaults to everything enabled; ADDED additively, no existing call site touched.
     let isEnabled: (T) -> Bool
     @Binding var selection: T
     @Environment(\.colorScheme) private var scheme
-    public init(_ items: [T], selection: Binding<T>, label: @escaping (T) -> String) {
-        self.init(items, selection: selection, isEnabled: { _ in true }, label: label)
-    }
-    public init(_ items: [T], selection: Binding<T>, isEnabled: @escaping (T) -> Bool,
+    public init(_ items: [T], selection: Binding<T>, adaptsToAvailableWidth: Bool = false,
                 label: @escaping (T) -> String) {
-        self.items = items; self._selection = selection; self.isEnabled = isEnabled; self.label = label
+        self.init(items, selection: selection, adaptsToAvailableWidth: adaptsToAvailableWidth,
+                  isEnabled: { _ in true }, label: label)
     }
+    public init(_ items: [T], selection: Binding<T>, adaptsToAvailableWidth: Bool = false,
+                isEnabled: @escaping (T) -> Bool,
+                label: @escaping (T) -> String) {
+        self.items = items
+        self._selection = selection
+        self.adaptsToAvailableWidth = adaptsToAvailableWidth
+        self.isEnabled = isEnabled
+        self.label = label
+    }
+    @ViewBuilder
     public var body: some View {
+        if adaptsToAvailableWidth {
+            ViewThatFits(in: .horizontal) {
+                track(equalWidth: false)
+                track(equalWidth: true)
+            }
+        } else {
+            track(equalWidth: false)
+        }
+    }
+
+    private func track(equalWidth: Bool) -> some View {
         HStack(spacing: 4) {
             ForEach(Array(items.enumerated()), id: \.offset) { _, item in
                 let sel = item == selection
@@ -399,8 +423,10 @@ public struct SegmentedPillControl<T: Hashable>: View {
                         // Fill the segment height so the selected pill has EQUAL margins to the track
                         // on every side. (The old compact pill inside a taller 44pt touch frame left
                         // more vertical margin than horizontal — it read as off-centre.)
-                        .frame(minWidth: 26, maxHeight: .infinity)
-                        .padding(.horizontal, 9)
+                        .frame(minWidth: equalWidth ? nil : 26,
+                               maxWidth: equalWidth ? .infinity : nil,
+                               maxHeight: .infinity)
+                        .padding(.horizontal, equalWidth ? NoopMetrics.space1 : 9)
                         .background(
                             // WHOOP selection chrome: a flat LIGHTER-grey pill on dark (white ink), a flat
                             // blue accent pill on light — no gold, no gradient.
@@ -413,6 +439,7 @@ public struct SegmentedPillControl<T: Hashable>: View {
                         .contentShape(Capsule(style: .continuous))
                 }
                 .buttonStyle(.plain)
+                .frame(maxWidth: equalWidth ? .infinity : nil)
                 .frame(height: 32)   // segment height; the pill fills it for an even inset
                 .disabled(!enabled)
                 // Announce the active range to VoiceOver and give a non-colour cue.
@@ -420,6 +447,7 @@ public struct SegmentedPillControl<T: Hashable>: View {
             }
         }
         .padding(3)
+        .frame(maxWidth: equalWidth ? .infinity : nil)
         .background(StrandPalette.surfaceInset, in: Capsule(style: .continuous))
         .overlay(Capsule(style: .continuous).strokeBorder(StrandPalette.hairline, lineWidth: 1))
     }

--- a/Packages/StrandDesign/Sources/StrandDesign/Components.swift
+++ b/Packages/StrandDesign/Sources/StrandDesign/Components.swift
@@ -376,6 +376,7 @@ public struct SegmentedPillControl<T: Hashable>: View {
     let isEnabled: (T) -> Bool
     @Binding var selection: T
     @Environment(\.colorScheme) private var scheme
+    @Environment(\.dynamicTypeSize) private var dynamicTypeSize
     public init(_ items: [T], selection: Binding<T>, adaptsToAvailableWidth: Bool = false,
                 label: @escaping (T) -> String) {
         self.init(items, selection: selection, adaptsToAvailableWidth: adaptsToAvailableWidth,
@@ -393,9 +394,16 @@ public struct SegmentedPillControl<T: Hashable>: View {
     @ViewBuilder
     public var body: some View {
         if adaptsToAvailableWidth {
-            ViewThatFits(in: .horizontal) {
-                track(equalWidth: false)
-                track(equalWidth: true)
+            if dynamicTypeSize > .large {
+                ScrollView(.horizontal, showsIndicators: false) {
+                    track(equalWidth: false)
+                        .fixedSize(horizontal: true, vertical: false)
+                }
+            } else {
+                ViewThatFits(in: .horizontal) {
+                    track(equalWidth: false)
+                    track(equalWidth: true)
+                }
             }
         } else {
             track(equalWidth: false)
@@ -414,6 +422,7 @@ public struct SegmentedPillControl<T: Hashable>: View {
                 } label: {
                     Text(label(item))
                         .font(StrandFont.captionNumber)
+                        .lineLimit(equalWidth ? 1 : nil)
                         // Active segment is SELECTION CHROME, so it follows the accent: on dark a
                         // gold-gradient pill with gold-deep ink; on light a flat blue accent pill with
                         // white ink (so the light theme's selection matches its blue chrome, not gold).

--- a/Strand/Screens/InsightsView.swift
+++ b/Strand/Screens/InsightsView.swift
@@ -986,14 +986,23 @@ struct InsightsView: View {
         // `ranked` is memoized in @State (see recomputeRanked()); reading it
         // here does no expensive work per render.
         VStack(alignment: .leading, spacing: NoopMetrics.gap) {
-            // Header + the ONE segmented pill control for choosing the outcome.
-            HStack(alignment: .center) {
-                SectionHeader("Behaviour Effects",
-                              overline: "What moves your \(outcome.outcomeName.lowercased())")
-                Spacer()
-                SegmentedPillControl(Outcome.allCases, selection: $outcome) { $0.label }
-                    .fixedSize(horizontal: true, vertical: false)
-                    .accessibilityLabel("Outcome metric")
+            // Keep the outcome labels intrinsic while they fit beside the header. When either
+            // localization or Dynamic Type needs more room, move the control to its own row.
+            ViewThatFits(in: .horizontal) {
+                HStack(alignment: .center) {
+                    SectionHeader("Behaviour Effects",
+                                  overline: "What moves your \(outcome.outcomeName.lowercased())")
+                    Spacer(minLength: NoopMetrics.space2)
+                    behaviourOutcomeControl
+                        .fixedSize(horizontal: true, vertical: false)
+                }
+
+                VStack(alignment: .leading, spacing: NoopMetrics.space2) {
+                    SectionHeader("Behaviour Effects",
+                                  overline: "What moves your \(outcome.outcomeName.lowercased())")
+                    behaviourOutcomeControl
+                        .frame(maxWidth: .infinity, alignment: .trailing)
+                }
             }
 
             if ranked.isEmpty {
@@ -1005,6 +1014,12 @@ struct InsightsView: View {
                 }
             }
         }
+    }
+
+    private var behaviourOutcomeControl: some View {
+        SegmentedPillControl(Outcome.allCases, selection: $outcome,
+                             adaptsToAvailableWidth: true) { $0.label }
+            .accessibilityLabel("Outcome metric")
     }
 
     private var noEffects: some View {

--- a/Strand/Screens/InsightsView.swift
+++ b/Strand/Screens/InsightsView.swift
@@ -992,6 +992,7 @@ struct InsightsView: View {
                               overline: "What moves your \(outcome.outcomeName.lowercased())")
                 Spacer()
                 SegmentedPillControl(Outcome.allCases, selection: $outcome) { $0.label }
+                    .fixedSize(horizontal: true, vertical: false)
                     .accessibilityLabel("Outcome metric")
             }
 

--- a/Strand/Screens/MetricExplorerView.swift
+++ b/Strand/Screens/MetricExplorerView.swift
@@ -774,6 +774,7 @@ struct MetricDetailView: View {
                 }
                 // Range control on its own row beneath the title.
                 SegmentedPillControl(ExploreRange.allCases, selection: selectionBinding,
+                                     adaptsToAvailableWidth: true,
                                      isEnabled: isUnlocked) { $0.label }
 
                 // The headline read-out in the liquid language: for a 0–100 score, the signature
@@ -886,6 +887,7 @@ struct MetricDetailView: View {
                 }
                 Spacer()
                 SegmentedPillControl(ExploreRange.allCases, selection: selectionBinding,
+                                     adaptsToAvailableWidth: true,
                                      isEnabled: isUnlocked) { $0.label }
             }
             Text(caption)

--- a/Strand/Screens/MetricExplorerView.swift
+++ b/Strand/Screens/MetricExplorerView.swift
@@ -878,18 +878,16 @@ struct MetricDetailView: View {
                                    windowed: windowed,
                                    windowFellBack: windowFellBack)
         return VStack(alignment: .leading, spacing: 8) {
-            HStack(alignment: .firstTextBaseline) {
-                VStack(alignment: .leading, spacing: 2) {
-                    Text(MetricCatalog.categoryDisplayName(metric.category).uppercased()).strandOverline()
-                    Text(metric.title)
-                        .font(StrandFont.title2)
-                        .foregroundStyle(StrandPalette.textPrimary)
-                }
-                Spacer()
-                SegmentedPillControl(ExploreRange.allCases, selection: selectionBinding,
-                                     adaptsToAvailableWidth: true,
-                                     isEnabled: isUnlocked) { $0.label }
+            VStack(alignment: .leading, spacing: 2) {
+                Text(MetricCatalog.categoryDisplayName(metric.category).uppercased()).strandOverline()
+                Text(metric.title)
+                    .font(StrandFont.title2)
+                    .foregroundStyle(StrandPalette.textPrimary)
             }
+            SegmentedPillControl(ExploreRange.allCases, selection: selectionBinding,
+                                 adaptsToAvailableWidth: true,
+                                 isEnabled: isUnlocked) { $0.label }
+                .frame(maxWidth: .infinity, alignment: .trailing)
             Text(caption)
                 .font(StrandFont.footnote)
                 .foregroundStyle(windowFellBack ? StrandPalette.statusWarning : StrandPalette.textTertiary)

--- a/Strand/Screens/StressView.swift
+++ b/Strand/Screens/StressView.swift
@@ -499,11 +499,10 @@ struct StressView: View {
                         ("Days", "\(points.count)"),
                     ])
                 }
-                // The one segmented control — full width, right-aligned.
-                HStack {
-                    Spacer()
-                    SegmentedPillControl(ExploreRange.allCases, selection: $range) { $0.label }
-                }
+                // The one segmented control. Its eight options use the shared adaptive-width mode so
+                // the control stays inside the same page gutter as the chart on compact iPhones.
+                SegmentedPillControl(ExploreRange.allCases, selection: $range,
+                                     adaptsToAvailableWidth: true) { $0.label }
             } else {
                 NoopCard(tint: StressRamp.calm) {
                     Text("Not enough recent days to chart a trend yet. Import a history or keep wearing your strap.")
@@ -1178,7 +1177,8 @@ private struct StressPreviewHarness: View {
                 } footer: {
                     ChartFooter([("Today", String(format: "%.1f", score)), ("Average", "1.5"), ("Days", "30")])
                 }
-                HStack { Spacer(); SegmentedPillControl(ExploreRange.allCases, selection: $range) { $0.label } }
+                SegmentedPillControl(ExploreRange.allCases, selection: $range,
+                                     adaptsToAvailableWidth: true) { $0.label }
             }
             .padding(NoopMetrics.screenPadding)
         }

--- a/Strand/Screens/StressView.swift
+++ b/Strand/Screens/StressView.swift
@@ -503,6 +503,7 @@ struct StressView: View {
                 // the control stays inside the same page gutter as the chart on compact iPhones.
                 SegmentedPillControl(ExploreRange.allCases, selection: $range,
                                      adaptsToAvailableWidth: true) { $0.label }
+                    .frame(maxWidth: .infinity, alignment: .trailing)
             } else {
                 NoopCard(tint: StressRamp.calm) {
                     Text("Not enough recent days to chart a trend yet. Import a history or keep wearing your strap.")
@@ -1179,6 +1180,7 @@ private struct StressPreviewHarness: View {
                 }
                 SegmentedPillControl(ExploreRange.allCases, selection: $range,
                                      adaptsToAvailableWidth: true) { $0.label }
+                    .frame(maxWidth: .infinity, alignment: .trailing)
             }
             .padding(NoopMetrics.screenPadding)
         }

--- a/android/app/src/main/java/com/noop/ui/Components.kt
+++ b/android/app/src/main/java/com/noop/ui/Components.kt
@@ -573,6 +573,10 @@ fun <T> SegmentedPillControl(
     label: (T) -> String,
     onSelect: (T) -> Unit,
     modifier: Modifier = Modifier,
+    // Opt-in compact mode for long option sets. The track fills its parent and gives each segment an
+    // equal share instead of letting intrinsic label padding widen the surrounding card past the screen.
+    // Defaulted so the shorter controls keep their existing sizing.
+    adaptsToAvailableWidth: Boolean = false,
     // Per-segment availability (#943): a disabled segment stays VISIBLE (dimmed, not clickable) so the
     // control can teach that an option exists before it is usable, e.g. trend ranges that unlock as
     // history builds. Defaulted so every existing call site is untouched.
@@ -585,6 +589,7 @@ fun <T> SegmentedPillControl(
     // SegmentedPillControl refresh (segment height 36, pill fills it for an even inset).
     Row(
         modifier = modifier
+            .then(if (adaptsToAvailableWidth) Modifier.fillMaxWidth() else Modifier)
             .height(36.dp)
             .clip(outerShape)
             .background(Palette.surfaceInset)
@@ -609,16 +614,18 @@ fun <T> SegmentedPillControl(
             Box(
                 modifier = Modifier
                     // Fill the track height so the pill's inset is equal top/bottom/left/right.
+                    .then(if (adaptsToAvailableWidth) Modifier.weight(1f) else Modifier)
                     .fillMaxHeight()
                     .clip(pillShape)
                     .then(pillBg)
                     .then(if (itemEnabled) Modifier.clickableNoRipple { onSelect(item) } else Modifier)
-                    .padding(horizontal = 12.dp),
+                    .padding(horizontal = if (adaptsToAvailableWidth) Metrics.space4 else 12.dp),
                 contentAlignment = Alignment.Center,
             ) {
                 Text(
                     text = label(item),
                     style = NoopType.captionNumber,
+                    maxLines = if (adaptsToAvailableWidth) 1 else Int.MAX_VALUE,
                     color = when {
                         selected && Palette.isLight -> androidx.compose.ui.graphics.Color.White
                         selected -> Palette.goldDeepText

--- a/android/app/src/main/java/com/noop/ui/Components.kt
+++ b/android/app/src/main/java/com/noop/ui/Components.kt
@@ -26,6 +26,7 @@ import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.foundation.layout.Spacer
@@ -71,6 +72,7 @@ import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.graphics.drawscope.DrawScope
 import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
@@ -583,13 +585,17 @@ fun <T> SegmentedPillControl(
     enabled: (T) -> Boolean = { true },
 ) {
     val outerShape = RoundedCornerShape(50)
+    val scrollsForLargeText = adaptsToAvailableWidth && LocalDensity.current.fontScale > 1f
+    val usesEqualWidth = adaptsToAvailableWidth && !scrollsForLargeText
+    val rangeScrollState = rememberScrollState()
     // The track is a fixed-height pill; the selected pill FILLS that height so its inset is EQUAL on
     // every side (container padding 4, pill horizontal padding only). The old compact pill inside a
     // taller row left more vertical margin than horizontal — it read as off-centre. Mirrors iOS's
     // SegmentedPillControl refresh (segment height 36, pill fills it for an even inset).
     Row(
         modifier = modifier
-            .then(if (adaptsToAvailableWidth) Modifier.fillMaxWidth() else Modifier)
+            .then(if (scrollsForLargeText) Modifier.horizontalScroll(rangeScrollState) else Modifier)
+            .then(if (usesEqualWidth) Modifier.fillMaxWidth() else Modifier)
             .height(36.dp)
             .clip(outerShape)
             .background(Palette.surfaceInset)
@@ -614,18 +620,19 @@ fun <T> SegmentedPillControl(
             Box(
                 modifier = Modifier
                     // Fill the track height so the pill's inset is equal top/bottom/left/right.
-                    .then(if (adaptsToAvailableWidth) Modifier.weight(1f) else Modifier)
+                    .then(if (usesEqualWidth) Modifier.weight(1f) else Modifier)
                     .fillMaxHeight()
                     .clip(pillShape)
                     .then(pillBg)
                     .then(if (itemEnabled) Modifier.clickableNoRipple { onSelect(item) } else Modifier)
-                    .padding(horizontal = if (adaptsToAvailableWidth) Metrics.space4 else 12.dp),
+                    .padding(horizontal = if (usesEqualWidth) Metrics.space4 else 12.dp),
                 contentAlignment = Alignment.Center,
             ) {
                 Text(
                     text = label(item),
                     style = NoopType.captionNumber,
                     maxLines = if (adaptsToAvailableWidth) 1 else Int.MAX_VALUE,
+                    overflow = if (adaptsToAvailableWidth) TextOverflow.Ellipsis else TextOverflow.Clip,
                     color = when {
                         selected && Palette.isLight -> androidx.compose.ui.graphics.Color.White
                         selected -> Palette.goldDeepText

--- a/android/app/src/main/java/com/noop/ui/HealthScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/HealthScreen.kt
@@ -1802,6 +1802,7 @@ fun VitalDetailScreen(vm: AppViewModel, key: String) {
                     selection = effectiveRange,
                     label = { it.label },
                     onSelect = { range = it },
+                    adaptsToAvailableWidth = true,
                     enabled = { it in unlockedRanges },
                 )
                 if (unlockedRanges.size < VitalDetailRange.entries.size) {


### PR DESCRIPTION
## What this PR does

This PR fixes missing side gutters and range-selector layout problems on compact iOS and Android screens.

Long, eight-option selectors used their full intrinsic width. On compact phones, that widened their parent detail pages beyond the viewport, making cards and content appear flush against the screen edges. The Behaviour Effects outcome selector could also be compressed enough for “Charge” to wrap onto two lines.

The PR:

- adds an opt-in adaptive-width mode to the shared iOS segmented control;
- uses that mode for the eight-option metric-detail and Stress selectors;
- keeps shorter existing selectors on their original sizing and overflow behavior;
- keeps the iOS Behaviour Effects selector on one line; and
- adds and applies the equivalent opt-in equal-width mode to the Android vital-detail selector.

No metric calculations, stored data, BLE behavior, or range-selection logic changed.

## Type of change

- [x] Bug fix

## How it was tested

- StrandDesign package tests pass: `swift test` (32 tests).
- Built and launched the `NOOPiOS` Debug configuration on an iPhone 16 Pro simulator.
- Manually checked populated and empty metric details, Stress, Apple Health, Trends, and Behaviour Effects.
- Android Full Debug unit tests pass: `./gradlew testFullDebugUnitTest`.
- Android Demo Debug unit tests pass: `./gradlew testDemoDebugUnitTest`.
- `git diff --check` passes.
- No BLE, protocol, or analytics behavior was changed.

## Checklist

- [x] Swift package tests pass for any package I touched (`swift test` in `Packages/<name>`)
- [x] Android unit tests pass if I touched `android/` (`./gradlew testFullDebugUnitTest`)
- [x] No new build warnings introduced
- [x] UI changes use only `StrandDesign` and shared Android design tokens
- [x] No hardcoded hex frame bytes; protocol facts live in the schema / decoders
- [x] Follows the conventions in [`docs/CONTRIBUTING.md`](../docs/CONTRIBUTING.md)
- [x] I did not commit generated output (`Strand.xcodeproj/`) or any secrets/keystores