### PR TITLE
Oura: feature-ID/enum doc corrections from the Ring-4 APK + name the enums in the #710 probe log

### DIFF
--- a/Strand/BLE/OuraLiveSource.swift
+++ b/Strand/BLE/OuraLiveSource.swift
@@ -953,7 +953,24 @@ public final class OuraLiveSource: NSObject, ObservableObject {
         // enabled it" — NOT `subscription==0` alone, since daytime-HR is subscription=0 yet active.
         let off = st.mode == 0 && st.status == 0 && st.state == 0
         let gate = off ? " - INACTIVE (server-gated off; the cloud never enabled it, not emitted offline)" : ""
-        log("Oura: feature status \(name) mode=\(st.mode) status=\(st.status) state=\(st.state) subscription=\(st.subscription)\(gate)")
+        // Name the enum fields so the log reads plainly (OURA_PROTOCOL.md s7.1 [ring4-ble]) — e.g. a gated
+        // feature prints `mode=0 (off) … subscription=0 (off)`, the active daytime-HR `mode=1 (automatic)`.
+        log("Oura: feature status \(name) mode=\(st.mode) (\(Self.featureModeName(st.mode))) status=\(st.status) state=\(st.state) subscription=\(st.subscription) (\(Self.subscriptionName(st.subscription)))\(gate)")
+    }
+
+    /// The ring's feature-MODE enum (`2f 03 22` write byte), per OURA_PROTOCOL.md s7.1 [ring4-ble].
+    private static func featureModeName(_ m: Int) -> String {
+        switch m {
+        case 0: return "off"; case 1: return "automatic"; case 2: return "requested"; case 3: return "connected_live"
+        default: return "?"
+        }
+    }
+    /// The ring's SUBSCRIPTION enum (`2f 03 26` write byte), per OURA_PROTOCOL.md s7.1 [ring4-ble].
+    private static func subscriptionName(_ s: Int) -> String {
+        switch s {
+        case 0: return "off"; case 1: return "state"; case 2: return "latest"; case 4: return "feature_data"
+        default: return "?"
+        }
     }
 
     // MARK: - Re-engagement timer (daytime-HR auto-reverts ~20s)

--- a/android/app/src/main/java/com/noop/ble/OuraLiveSource.kt
+++ b/android/app/src/main/java/com/noop/ble/OuraLiveSource.kt
@@ -1095,7 +1095,19 @@ class OuraLiveSource(
         // enabled it" — NOT `subscription==0` alone, since daytime-HR is subscription=0 yet active.
         val off = st.mode == 0 && st.status == 0 && st.state == 0
         val gate = if (off) " - INACTIVE (server-gated off; the cloud never enabled it, not emitted offline)" else ""
-        log("Oura: feature status $name mode=${st.mode} status=${st.status} state=${st.state} subscription=${st.subscription}$gate")
+        // Name the enum fields so the log reads plainly (OURA_PROTOCOL.md s7.1 [ring4-ble]) — e.g. a gated
+        // feature prints `mode=0 (off) … subscription=0 (off)`, the active daytime-HR `mode=1 (automatic)`.
+        log("Oura: feature status $name mode=${st.mode} (${featureModeName(st.mode)}) status=${st.status} " +
+            "state=${st.state} subscription=${st.subscription} (${subscriptionName(st.subscription)})$gate")
+    }
+
+    /** The ring's feature-MODE enum (`2f 03 22` write byte), per OURA_PROTOCOL.md s7.1 [ring4-ble]. */
+    private fun featureModeName(m: Int) = when (m) {
+        0 -> "off"; 1 -> "automatic"; 2 -> "requested"; 3 -> "connected_live"; else -> "?"
+    }
+    /** The ring's SUBSCRIPTION enum (`2f 03 26` write byte), per OURA_PROTOCOL.md s7.1 [ring4-ble]. */
+    private fun subscriptionName(s: Int) = when (s) {
+        0 -> "off"; 1 -> "state"; 2 -> "latest"; 4 -> "feature_data"; else -> "?"
     }
 
     /**

--- a/docs/OURA_PROTOCOL.md
+++ b/docs/OURA_PROTOCOL.md
@@ -13,6 +13,7 @@
 - **[relue]** - relue/oura_ring_reverse `docs/.../heartbeat_replication_guide.md` and `heartbeat_complete_flow.md` (no-license; Ring 3 live-HR).
 - **[oura-rs]** - Th0rgal/open_oura `crates/oura-protocol/src/events.rs` (no-license Rust clean-room decoder; facts cited only, no code copied). Its event tags marked `"_status": "unvalidated"` are treated the same as our Tier B - plausible, not ground-truth-confirmed.
 - **[open_oura-act]** - Th0rgal/open_oura `crates/oura-cli/src/activity_model.rs` (no-license; facts cited only). The activity classifier's input assembly reads four SEPARATE event tags — `met`←`0x50`, motion←`0x47`, temp←`0x46`, `hr_bpm`←`0x80` — establishing which tag each signal comes from (notably HR from the `0x80` IBI record, not `0x50`).
+- **[ring4-ble]** - Defying/oura-ring4-ble `docs/apk-findings.md` + `docs/protocol-notes.md` (no-license; APK static-analysis + Ring-4 BLE captures, facts cited only). Confirms the framing/auth/tag set is generation-invariant (Ring 4 == Ring 3) and pins the full feature-ID table + the feature mode / subscription enums; also confirms the app derives BPM as `round(60000 / ibi_ms)`.
 
 > **CONFLICT NOTE (resolution rule):** The relue archive file `event_data_definition.md` describes events as **protobuf varint** records (e.g. `0x55` SLEEP_HR with field tags). This contradicts the **byte-for-byte verified TLV framing** in [open_ring] and [ringverse]. The TLV/bit-packed model from [open_ring]/[ringverse] is authoritative for our decoders; the protobuf description is treated as unverified/likely AI-fabricated and is NOT used. Where a layout is only attested by a single no-license, AI-generated doc, it is marked **(UNVERIFIED)** and our decoder must gate it behind a fixture test before trusting it.
 
@@ -434,7 +435,7 @@ like its sibling banked streams (`.hrv`/`.temp`/`.spo2`/`.sleepPhase`) — the f
 | `0x00` | Background DFU | - |
 | `0x01` | Research Data (RData) | often server-blocked; returns idle status 3 [open_oura-r3] |
 | `0x02` | Daytime HR | Gen3+; **live-HR path (§5.6)** |
-| `0x03` | Exercise HR (AWHR) | Gen3+; cap version ≥ 2 |
+| `0x03` | Exercise HR (AWHR) | Gen3+; cap version ≥ 2; data arrives as `0x73` `ehr_trace_event` / `0x74` `ehr_acm_intensity_event` [ring4-ble] — never observed in a NOOP capture (server-gated, like SpO2/steps) |
 | `0x04` | SpO2 | Gen3+; server-gated. **Confirmed OFF on a real Gen 3 ring** (2026-07-20 capture): the read-only `2f 02 20 04` feature-status probe NOOP ships (`spo2_status`, §7.4) decoded to `mode=0 status=0 state=0 subscription=0` - all-zero, i.e. the cloud never enabled SpO2 for that ring/account; it is not a NOOP decode issue. SpO2 also never arrives as a live push (unlike HR's feature `0x02`); it only ever arrives via history fetch (§5), same as skin temp. NOOP sends the diagnostic READ only; it does NOT enable/subscribe SpO2 (a live enable produces nothing during the day regardless). |
 | `0x05` | Bundling | - |
 | `0x06` | Encrypted API | (Oura's encrypted channel - NOOP does NOT use) |
@@ -445,10 +446,19 @@ like its sibling banked streams (`.hrv`/`.temp`/`.spo2`/`.sleepPhase`) — the f
 | `0x0B` | Real steps | Gen3+; server-flag-gated (`activity/real_steps`, default false). **Confirmed OFF on a real Gen 3 ring** (2026-07-20 capture): the read-only `2f 02 20 0b` probe (`realsteps_status`, §7.4) decoded to `mode=0 status=0 state=0 subscription=0` - all-zero, matching SpO2, which is why `0x7E`/`0x7F` never appear (§6.13). |
 | `0x0C` | Experimental | server-flag-gated |
 | `0x0D` | CVA PPG sampler | Gen3+; server-flag-gated; feeds `0x81` |
-| `0x10` | Ambient light | capability-dependent |
+| `0x0E` | Charging control | [ring4-ble] |
+| `0x0F` | Ambient light | capability-dependent [ring4-ble] |
+| `0x10` | Special feature | [ring4-ble] |
+| `0x11` | Raw-data sampler | [ring4-ble] |
+| `0x12` | Atlas | [ring4-ble] |
+| `0x16` | Long events | [ring4-ble] |
 
-**Feature modes:** `0x00` off, `0x01` automatic, `0x02` requested, `0x03` requested-subscription. [ringverse]
-**Feature status values:** `0x00` off, `0x01` on, `0x02` searching, `0x03` no-PPG, `0x04` cold, `0x05` movement, `0x06` identifying. [ringverse]
+> **CORRECTION** [ring4-ble]: an earlier draft placed **Ambient light** at `0x10`; the APK enumerates `0x0F` = ambient_light and `0x10` = special_feature. The `0x0E`–`0x16` rows above are the APK's full feature list (22 features `0x00`–`0x12` + `0x16`).
+
+**Feature modes** (write byte of `2f 03 22 <id> <mode>`): `0x00` off, `0x01` automatic, `0x02` requested, `0x03` connected_live. [ring4-ble] — an earlier draft read `0x03` as "requested-subscription" [ringverse]; the APK's `connected_live` is authoritative (it is the mode NOOP writes to enable the live-HR push, §5.6).
+**Subscription modes** (write byte of `2f 03 26 <id> <sub>`): `0x00` off, `0x01` state, `0x02` latest, `0x04` feature_specific_data. [ring4-ble] — NOOP subscribes live HR with `0x02` = latest.
+**Feature request-status** (result code of a `setFeatureMode` command): `0x00` success, `0x01` not_supported, `0x02` not_available, `0x03` not_in_finger, `0x04` message_too_short, `0x05` low_battery. [ring4-ble]
+**Feature status/state values** (the `status`/`state` bytes of the `0x21` read reply, §7.4): `0x00` off, `0x01` on, `0x02` searching, `0x03` no-PPG, `0x04` cold, `0x05` movement, `0x06` identifying. [ringverse]
 **Master gate:** `setFeatureMode` requires ring generation **> 2** (Gen 3+); Gen ≤2 reject all feature-mode changes. [open_oura-feat]
 
 ### 7.2 Generation differences
@@ -502,7 +512,7 @@ Tags that appear in the banked stream but NOOP does not decode. Payloads are the
 | `0x4a` | 8416 | 10 | `00000000000000000000` | payload observed all-zero — likely a keepalive / placeholder |
 | `0x72` | 5723 | 12 | `120027000100150018000200` | six int16-LE small values — a vector (motion / accel?) |
 | `0x6a` | 5689 | 10 | `7e00230b90140001f8b0` | mixed; a `0001f8b0` / `0001feb8` trailer recurs |
-| `0x6d` | 3042 | 13 | `00c4ffffb5ffffd2ffffeaffff` | `00` + four int16-LE **negative** deltas (`0xffc4 = −60`…) — signed deltas (gravity / accel?) |
+| `0x6d` | 3042 | 13 | `00c4ffffb5ffffd2ffffeaffff` | **`measurement_quality`** (24-bit signed) per [ring4-ble] — supersedes the earlier gravity/accel guess; our capture reads `00` + int16-LE-looking negatives |
 | `0x6c` | 1750 | 4 | `02020400` | `02 NN 04 00` — small state / counter |
 | `0x5b` | 416 | 10–13 | `030093dd10dbc7c00000` | variable, leading sub-type byte |
 | `0x79` | 100 | 4–14 | `02000000` | `02` + an incrementing index (`00, 01, 02…`) |


### PR DESCRIPTION
  ## Summary
  Cross-checked our Oura feature model against **Defying/oura-ring4-ble** (APK static analysis + Ring-4 BLE captures). It corrects one mislabeled feature ID, fills in the rest of the table, pins the mode/subscription enum meanings, and — with those  meanings now known — makes the `#710` feature-status probe log self-explanatory. Facts-only clean-room citation (new `[ring4-ble]` key); no code copied.

  ## 1. Docs — `OURA_PROTOCOL.md` (commit 1)
  - **§7.1 correction:** Ambient light is **`0x0F`**, not `0x10` — `0x10` is `special_feature`. Added the APK's full feature list: `0x0E` charging_control, `0x0F` ambient_light, `0x10` special_feature, `0x11` raw_data_sampler, `0x12` atlas, `0x16`  long_events.
  - **Feature MODE enum:** `0x03` = **`connected_live`** (an earlier draft read "requested-subscription"; `connected_live` is the mode NOOP already writes for the live-HR push, §5.6).
  - **Subscription enum** (new): `0` off / `1` state / `2` latest / `4` feature_specific_data — NOOP subscribes live HR with `2` = latest. Plus the feature request-status codes.
  - **`0x03` Exercise HR:** its data arrives as `0x73` `ehr_trace_event` / `0x74` `ehr_acm_intensity_event` — never observed in a NOOP capture (server-gated like SpO2/steps).
  - **§9:** `0x6d` is `measurement_quality` (24-bit signed), superseding the earlier gravity/accel guess.
  - Notes the repo independently confirms the framing/auth/tag set is **generation-invariant (Ring 4 == Ring 3)** and that the app derives BPM as `round(60000 / ibi_ms)`.

  ## 2. Diagnostic — `#710` probe log (commit 2)
  The read-only SpO2/real_steps feature-status probe (`#710`, merged) logged raw enum bytes. With the meanings pinned above, it now names them inline:

  Oura: feature status SpO2 (0x04) mode=0 (off) status=0 state=0 subscription=0 (off) - INACTIVE (server-gated off; …)  …and the active daytime-HR reads `mode=1 (automatic)`. So "server-gated off" is now self-evident in the strap log.

  Log-string only — **no behaviour change, no new writes to the ring.** Both platforms (Swift `Strand/BLE` + Kotlin `com.noop.ble` twin), byte-identical.

  ## Verification
  macOS `Strand` **BUILD SUCCEEDED**; Android `compileFullDebugKotlin` **OK**. No test changes (docs + log strings).

  ## Scope
  Two focused commits (docs, then the `#710` follow-up). No hardware gate — the enum labels will simply appear the next time the probe runs.
