### PR TITLE
Polish metric summary layouts across iOS and Android

### DIFF
--- a/Packages/StrandDesign/Sources/StrandDesign/Components.swift
+++ b/Packages/StrandDesign/Sources/StrandDesign/Components.swift
@@ -12,7 +12,6 @@ public enum NoopMetrics {
     public static let sectionGap: CGFloat = 22   // Apple x WHOOP: breathing room (not cramped)
     public static let screenPadding: CGFloat = 18
     public static let tileHeight: CGFloat = 96   // Design Reset: tighter metric tile
-    public static let compactGaugeDiameter: CGFloat = 82
     // Key Metrics grid: one fixed height every tile snaps to, so a sparkline-and-caption tile and a
     // plain value tile read the same. maxHeight: .infinity can't equalise them inside a LazyVGrid (the
     // grid only offers a cell its content height, so there's nothing for the shorter tile to grow into),

--- a/Packages/StrandDesign/Sources/StrandDesign/Components.swift
+++ b/Packages/StrandDesign/Sources/StrandDesign/Components.swift
@@ -12,6 +12,7 @@ public enum NoopMetrics {
     public static let sectionGap: CGFloat = 22   // Apple x WHOOP: breathing room (not cramped)
     public static let screenPadding: CGFloat = 18
     public static let tileHeight: CGFloat = 96   // Design Reset: tighter metric tile
+    public static let compactGaugeDiameter: CGFloat = 82
     // Key Metrics grid: one fixed height every tile snaps to, so a sparkline-and-caption tile and a
     // plain value tile read the same. maxHeight: .infinity can't equalise them inside a LazyVGrid (the
     // grid only offers a cell its content height, so there's nothing for the shorter tile to grow into),

--- a/Strand/Screens/MetricExplorerView.swift
+++ b/Strand/Screens/MetricExplorerView.swift
@@ -972,8 +972,10 @@ struct MetricDetailView: View {
         let deltaCaption = hasDelta ? String(localized: "vs prev \(effectiveRange.name)")
             : (effectiveRange == .all ? String(localized: "all history") : String(localized: "no prior \(effectiveRange.name)"))
 
+        #if os(iOS)
         return VStack(alignment: .leading, spacing: NoopMetrics.gap) {
-            // Average summarizes the selected range, so it leads at the full two-column width.
+            // On iOS, Average summarizes the selected range, so it leads at the full
+            // two-column width.
             StatTile(label: "Average", value: fmt(s.mean),
                      caption: s.n == 1 ? String(localized: "1 day") : String(localized: "\(s.n) days"),
                      accent: accent,
@@ -998,6 +1000,32 @@ struct MetricDetailView: View {
                          caption: latestCaption, accent: accent)
             }
         }
+        #else
+        // macOS keeps its adaptive multi-column dashboard. Promoting one tile to the
+        // unbounded screen width would turn a phone-specific hierarchy into an oversized
+        // desktop card and could leave the remaining adaptive row uneven.
+        return LazyVGrid(
+            columns: [GridItem(.adaptive(minimum: 168), spacing: NoopMetrics.gap)],
+            alignment: .leading,
+            spacing: NoopMetrics.gap
+        ) {
+            StatTile(label: "Average", value: fmt(s.mean),
+                     caption: s.n == 1 ? String(localized: "1 day") : String(localized: "\(s.n) days"),
+                     accent: accent,
+                     sparkline: windowValues.count > 1 ? windowValues : nil,
+                     sparkColor: accent)
+            StatTile(label: "Min", value: fmt(s.min),
+                     accent: StrandPalette.textPrimary)
+            StatTile(label: "Max", value: fmt(s.max),
+                     accent: StrandPalette.textPrimary)
+            StatTile(label: "Latest", value: latest.map { fmt($0.value) } ?? "—",
+                     caption: latestCaption, accent: accent)
+            StatTile(label: "Δ vs prev", value: deltaText ?? "—",
+                     caption: deltaCaption, accent: StrandPalette.textPrimary,
+                     delta: cmp.pctChange.map { "\($0 >= 0 ? "+" : "")\(String(format: "%.1f", $0))%" },
+                     deltaColor: deltaColor)
+        }
+        #endif
     }
 
     private var latestCaption: String? {

--- a/Strand/Screens/MetricExplorerView.swift
+++ b/Strand/Screens/MetricExplorerView.swift
@@ -972,26 +972,31 @@ struct MetricDetailView: View {
         let deltaCaption = hasDelta ? String(localized: "vs prev \(effectiveRange.name)")
             : (effectiveRange == .all ? String(localized: "all history") : String(localized: "no prior \(effectiveRange.name)"))
 
-        return LazyVGrid(
-            columns: [GridItem(.adaptive(minimum: 168), spacing: NoopMetrics.gap)],
-            alignment: .leading,
-            spacing: NoopMetrics.gap
-        ) {
+        return VStack(alignment: .leading, spacing: NoopMetrics.gap) {
+            // Average summarizes the selected range, so it leads at the full two-column width.
             StatTile(label: "Average", value: fmt(s.mean),
                      caption: s.n == 1 ? String(localized: "1 day") : String(localized: "\(s.n) days"),
                      accent: accent,
                      sparkline: windowValues.count > 1 ? windowValues : nil,
                      sparkColor: accent)
-            StatTile(label: "Min", value: fmt(s.min),
-                     accent: StrandPalette.textPrimary)
-            StatTile(label: "Max", value: fmt(s.max),
-                     accent: StrandPalette.textPrimary)
-            StatTile(label: "Latest", value: latest.map { fmt($0.value) } ?? "—",
-                     caption: latestCaption, accent: accent)
-            StatTile(label: "Δ vs prev", value: deltaText ?? "—",
-                     caption: deltaCaption, accent: StrandPalette.textPrimary,
-                     delta: cmp.pctChange.map { "\($0 >= 0 ? "+" : "")\(String(format: "%.1f", $0))%" },
-                     deltaColor: deltaColor)
+                .frame(maxWidth: .infinity)
+
+            LazyVGrid(
+                columns: [GridItem(.adaptive(minimum: 168), spacing: NoopMetrics.gap)],
+                alignment: .leading,
+                spacing: NoopMetrics.gap
+            ) {
+                StatTile(label: "Min", value: fmt(s.min),
+                         accent: StrandPalette.textPrimary)
+                StatTile(label: "Max", value: fmt(s.max),
+                         accent: StrandPalette.textPrimary)
+                StatTile(label: "Δ vs prev", value: deltaText ?? "—",
+                         caption: deltaCaption, accent: StrandPalette.textPrimary,
+                         delta: cmp.pctChange.map { "\($0 >= 0 ? "+" : "")\(String(format: "%.1f", $0))%" },
+                         deltaColor: deltaColor)
+                StatTile(label: "Latest", value: latest.map { fmt($0.value) } ?? "—",
+                         caption: latestCaption, accent: accent)
+            }
         }
     }
 

--- a/Strand/Screens/SleepView.swift
+++ b/Strand/Screens/SleepView.swift
@@ -1442,6 +1442,18 @@ struct SleepView: View {
 
         VStack(alignment: .leading, spacing: NoopMetrics.gap) {
             SectionHeader("Night detail", overline: "Metrics", trailing: String(localized: "vs typical"))
+
+            // Sleep Debt is the actionable summary for the section, so it leads at the full
+            // two-column width. The remaining six peer metrics keep the established 2 × 3 grid.
+            StatTile(
+                label: "Sleep Debt",
+                value: debt.latest.map { durationText($0) } ?? "—",
+                caption: debtCaption(debt.latest),
+                accent: debtColor(debt.latest),
+                sparkline: spark(debt.series),
+                sparkColor: StrandPalette.metricRose)
+                .frame(maxWidth: .infinity)
+
             LazyVGrid(columns: tileColumns, alignment: .leading, spacing: NoopMetrics.gap) {
 
                 StatTile(
@@ -1491,14 +1503,6 @@ struct SleepView: View {
                     accent: StrandPalette.metricPurple,
                     sparkline: spark(resp.series),
                     sparkColor: StrandPalette.metricPurple)
-
-                StatTile(
-                    label: "Sleep Debt",
-                    value: debt.latest.map { durationText($0) } ?? "—",
-                    caption: debtCaption(debt.latest),
-                    accent: debtColor(debt.latest),
-                    sparkline: spark(debt.series),
-                    sparkColor: StrandPalette.metricRose)
             }
         }
     }

--- a/Strand/Screens/SleepView.swift
+++ b/Strand/Screens/SleepView.swift
@@ -1443,8 +1443,9 @@ struct SleepView: View {
         VStack(alignment: .leading, spacing: NoopMetrics.gap) {
             SectionHeader("Night detail", overline: "Metrics", trailing: String(localized: "vs typical"))
 
-            // Sleep Debt is the actionable summary for the section, so it leads at the full
-            // two-column width. The remaining six peer metrics keep the established 2 × 3 grid.
+            #if os(iOS)
+            // On iOS, Sleep Debt is the actionable summary for the section, so it leads at the
+            // full two-column width. The remaining six peer metrics keep the established 2 × 3 grid.
             StatTile(
                 label: "Sleep Debt",
                 value: debt.latest.map { durationText($0) } ?? "—",
@@ -1453,6 +1454,7 @@ struct SleepView: View {
                 sparkline: spark(debt.series),
                 sparkColor: StrandPalette.metricRose)
                 .frame(maxWidth: .infinity)
+            #endif
 
             LazyVGrid(columns: tileColumns, alignment: .leading, spacing: NoopMetrics.gap) {
 
@@ -1503,6 +1505,18 @@ struct SleepView: View {
                     accent: StrandPalette.metricPurple,
                     sparkline: spark(resp.series),
                     sparkColor: StrandPalette.metricPurple)
+
+                #if !os(iOS)
+                // macOS keeps the original adaptive dashboard instead of stretching one
+                // phone-width summary tile across an unbounded desktop detail pane.
+                StatTile(
+                    label: "Sleep Debt",
+                    value: debt.latest.map { durationText($0) } ?? "—",
+                    caption: debtCaption(debt.latest),
+                    accent: debtColor(debt.latest),
+                    sparkline: spark(debt.series),
+                    sparkColor: StrandPalette.metricRose)
+                #endif
             }
         }
     }

--- a/Strand/Screens/WeeklyDigestView.swift
+++ b/Strand/Screens/WeeklyDigestView.swift
@@ -128,7 +128,7 @@ struct WeeklyDigestContent: View {
 
     /// Display order: the two daily scores first, then the nightly signals.
     private static let order: [WeeklyMetric] = [.charge, .effort, .rest, .hrv, .rhr]
-    /// The three headline 0–100 scores that get their own domain summary card + gauge.
+    /// The three headline 0–100 scores shown as domain summaries.
     private static let scoreOrder: [WeeklyMetric] = [.charge, .effort, .rest]
 
     /// The Bevel colour world for each weekly metric — drives the summary card tint,
@@ -148,8 +148,7 @@ struct WeeklyDigestContent: View {
             // Headline over a subtle scenic backdrop (Charge-tinted starfield).
             header
 
-            // The three headline scores as frosted, domain-tinted summary cards — each a
-            // compact ring gauge + a week-over-week TrendChip.
+            // The three headline scores, each with a domain-tinted gauge and week-over-week context.
             scoreRow
 
             // Focal points + secondary signals + balance footer in one frosted card.
@@ -180,22 +179,49 @@ struct WeeklyDigestContent: View {
         }
     }
 
-    // MARK: Score row — three frosted domain summary cards
+    // MARK: Score row — three domain summaries
 
+    @ViewBuilder
     private var scoreRow: some View {
-        let cols = [GridItem(.adaptive(minimum: compact ? 140 : 168), spacing: NoopMetrics.gap)]
-        return LazyVGrid(columns: cols, spacing: NoopMetrics.gap) {
-            ForEach(Self.scoreOrder, id: \.rawValue) { metric in
-                if let s = digest.summary(metric) {
-                    DigestScoreCard(summary: s,
-                                    domain: domain(for: metric),
-                                    deltaText: deltaText(s),
-                                    deltaTone: chipTone(s),
-                                    accessibility: rowAccessibility(s, effortScale: effortScale),
-                                    effortScale: effortScale)
+        if compact {
+            let summaries = Self.scoreOrder.compactMap { digest.summary($0) }
+            if !summaries.isEmpty {
+                NoopCard(padding: NoopMetrics.space2) {
+                    HStack(spacing: 0) {
+                        ForEach(Array(summaries.enumerated()), id: \.element.metric.rawValue) { index, summary in
+                            scoreCard(summary: summary, presentation: .embedded)
+                            if index < summaries.count - 1 {
+                                Divider()
+                                    .overlay(StrandPalette.hairline)
+                                    .padding(.vertical, NoopMetrics.space3)
+                            }
+                        }
+                    }
+                }
+            }
+        } else {
+            LazyVGrid(
+                columns: [GridItem(.adaptive(minimum: 168), spacing: NoopMetrics.gap)],
+                spacing: NoopMetrics.gap
+            ) {
+                ForEach(Self.scoreOrder, id: \.rawValue) { metric in
+                    if let summary = digest.summary(metric) {
+                        scoreCard(summary: summary, presentation: .standalone)
+                    }
                 }
             }
         }
+    }
+
+    private func scoreCard(summary: WeeklyMetricSummary,
+                           presentation: DigestScoreCard.Presentation) -> some View {
+        DigestScoreCard(summary: summary,
+                        domain: domain(for: summary.metric),
+                        deltaText: deltaText(summary),
+                        deltaTone: chipTone(summary),
+                        accessibility: rowAccessibility(summary, effortScale: effortScale),
+                        effortScale: effortScale,
+                        presentation: presentation)
     }
 
     // MARK: Detail card (focal points · secondary signals · footer)
@@ -416,12 +442,18 @@ enum WeeklyDigestChipStyle {
     static func dropsVerdictFrame(_ s: WeeklyMetricSummary) -> Bool { s.isRoughComparison }
 }
 
-// MARK: - Digest score card (one headline domain: gauge + week-over-week chip)
+// MARK: - Digest score summary (one headline domain: gauge + week-over-week chip)
 
-/// A frosted, domain-tinted summary card for one 0–100 weekly score (Charge / Effort /
-/// Rest): a compact layered ring gauge for the week's mean, the domain label, and a
-/// TrendChip for the week-over-week move. Owns its own gauge draw-in @State, like Today.
+/// A summary for one 0–100 weekly score (Charge / Effort / Rest): a compact layered ring gauge for
+/// the week's mean, the domain label, and a TrendChip for the week-over-week move. It can own its
+/// domain-tinted card surface or sit inside the compact digest's shared surface. Owns its gauge
+/// draw-in @State, like Today.
 private struct DigestScoreCard: View {
+    enum Presentation: Equatable {
+        case embedded
+        case standalone
+    }
+
     let summary: WeeklyMetricSummary
     let domain: DomainTheme
     let deltaText: String
@@ -430,12 +462,14 @@ private struct DigestScoreCard: View {
     /// The Effort display scale (#268). Only consulted for the Effort card; Charge/Rest are genuine
     /// 0–100 scores and ignore it, keeping their "of 100" caption and integer mean.
     var effortScale: EffortScale = .hundred
+    let presentation: Presentation
 
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @State private var animatedFraction: Double = 0
 
     /// The Effort card is the only one that follows the 0–100/0–21 toggle; the rest are fixed 0–100.
     private var isEffort: Bool { summary.metric == .effort }
+    private var isEmbedded: Bool { presentation == .embedded }
 
     private var fraction: Double {
         guard summary.thisWeek.n > 0 else { return 0 }
@@ -452,42 +486,75 @@ private struct DigestScoreCard: View {
         isEffort ? String(localized: "of \(UnitFormatter.effortScaleMax(effortScale))") : String(localized: "of 100")
     }
 
+    @ViewBuilder
     var body: some View {
-        NoopCard(padding: 14, tint: domain.color) {
-            VStack(spacing: 8) {
-                HStack {
-                    Text(summary.metric.label)
-                        .font(StrandFont.overline)
-                        .tracking(StrandFont.overlineTracking)
-                        .textCase(.uppercase)
-                        .foregroundStyle(domain.color)
-                    Spacer(minLength: 0)
-                    if summary.weekOverWeek.current.n > 0, summary.weekOverWeek.previous.n > 0 {
-                        TrendChip(text: deltaSigned, color: deltaTone)
-                    }
+        Group {
+            if isEmbedded {
+                content
+                    .padding(.horizontal, NoopMetrics.space1)
+            } else {
+                NoopCard(padding: 14, tint: domain.color) {
+                    content
                 }
-                BevelGauge(
-                    fraction: fraction,
-                    stops: domain.gradient.stops,
-                    tipColor: domain.bright,
-                    numberText: numberText,
-                    captionText: captionText,
-                    stateText: nil,
-                    supporting: nil,
-                    diameter: 118,
-                    lineWidth: 11,
-                    showsLabel: summary.thisWeek.n > 0,
-                    animatedFraction: animatedFraction
-                )
-                .frame(maxWidth: .infinity)
             }
-            .frame(maxWidth: .infinity)
         }
         .onAppear {
             withAnimation(StrandMotion.drawIn(reduced: reduceMotion)) { animatedFraction = fraction }
         }
         .accessibilityElement(children: .ignore)
         .accessibilityLabel(accessibility)
+    }
+
+    private var content: some View {
+        VStack(spacing: NoopMetrics.space2) {
+            if isEmbedded {
+                Text(summary.metric.label)
+                    .font(StrandFont.overline)
+                    .tracking(StrandFont.overlineTracking)
+                    .textCase(.uppercase)
+                    .foregroundStyle(domain.color)
+                    .lineLimit(1)
+                    .frame(maxWidth: .infinity, alignment: .center)
+            } else {
+                HStack {
+                    metricLabel
+                    Spacer(minLength: 0)
+                    if hasComparison {
+                        TrendChip(text: deltaSigned, color: deltaTone)
+                    }
+                }
+            }
+            BevelGauge(
+                fraction: fraction,
+                stops: domain.gradient.stops,
+                tipColor: domain.bright,
+                numberText: numberText,
+                captionText: captionText,
+                stateText: nil,
+                supporting: nil,
+                diameter: isEmbedded ? NoopMetrics.compactGaugeDiameter : 118,
+                lineWidth: isEmbedded ? NoopMetrics.space2 : 11,
+                showsLabel: summary.thisWeek.n > 0,
+                animatedFraction: animatedFraction
+            )
+            .frame(maxWidth: .infinity)
+            if isEmbedded && hasComparison {
+                TrendChip(text: deltaSigned, color: deltaTone)
+            }
+        }
+        .frame(maxWidth: .infinity)
+    }
+
+    private var metricLabel: some View {
+        Text(summary.metric.label)
+            .font(StrandFont.overline)
+            .tracking(StrandFont.overlineTracking)
+            .textCase(.uppercase)
+            .foregroundStyle(domain.color)
+    }
+
+    private var hasComparison: Bool {
+        summary.weekOverWeek.current.n > 0 && summary.weekOverWeek.previous.n > 0
     }
 
     /// The week-over-week delta carrying a +/− so the TrendChip infers its arrow.

--- a/Strand/Screens/WeeklyDigestView.swift
+++ b/Strand/Screens/WeeklyDigestView.swift
@@ -125,6 +125,9 @@ struct WeeklyDigestContent: View {
     /// and the Trends small-multiple instead of being stuck on "of 100". Charge/Rest stay 0–100.
     @AppStorage(UnitPrefs.effortScaleKey) private var effortScaleRaw = EffortScale.hundred.rawValue
     private var effortScale: EffortScale { UnitPrefs.resolveEffortScale(effortScaleRaw) }
+    #if os(iOS)
+    @Environment(\.dynamicTypeSize) private var dynamicTypeSize
+    #endif
 
     /// Display order: the two daily scores first, then the nightly signals.
     private static let order: [WeeklyMetric] = [.charge, .effort, .rest, .hrv, .rhr]
@@ -183,11 +186,43 @@ struct WeeklyDigestContent: View {
 
     @ViewBuilder
     private var scoreRow: some View {
+        #if os(iOS)
         if compact {
-            let summaries = Self.scoreOrder.compactMap { digest.summary($0) }
-            if !summaries.isEmpty {
-                NoopCard(padding: NoopMetrics.space2) {
-                    HStack(spacing: 0) {
+            compactScoreRow
+        } else {
+            scoreGrid
+        }
+        #else
+        // `compact` describes the embedded digest, not a compact desktop width.
+        // Keep macOS on its original adaptive, individually surfaced score cards.
+        scoreGrid
+        #endif
+    }
+
+    #if os(iOS)
+    @ViewBuilder
+    private var compactScoreRow: some View {
+        let summaries = Self.scoreOrder.compactMap { digest.summary($0) }
+        if !summaries.isEmpty {
+            NoopCard(padding: NoopMetrics.space2) {
+                if dynamicTypeSize.isAccessibilitySize {
+                    // At accessibility text sizes, three narrow columns would either truncate
+                    // localized labels/chips or force gauge text below a readable size.
+                    VStack(spacing: 0) {
+                        ForEach(Array(summaries.enumerated()), id: \.element.metric.rawValue) { index, summary in
+                            scoreCard(summary: summary, presentation: .embedded)
+                            if index < summaries.count - 1 {
+                                Divider()
+                                    .overlay(StrandPalette.hairline)
+                                    .padding(.horizontal, NoopMetrics.space3)
+                                    .padding(.vertical, NoopMetrics.space3)
+                            }
+                        }
+                    }
+                } else {
+                    // Top alignment keeps labels and gauges level when only some metrics have
+                    // enough previous-week data to render the optional comparison chip.
+                    HStack(alignment: .top, spacing: 0) {
                         ForEach(Array(summaries.enumerated()), id: \.element.metric.rawValue) { index, summary in
                             scoreCard(summary: summary, presentation: .embedded)
                             if index < summaries.count - 1 {
@@ -199,15 +234,18 @@ struct WeeklyDigestContent: View {
                     }
                 }
             }
-        } else {
-            LazyVGrid(
-                columns: [GridItem(.adaptive(minimum: 168), spacing: NoopMetrics.gap)],
-                spacing: NoopMetrics.gap
-            ) {
-                ForEach(Self.scoreOrder, id: \.rawValue) { metric in
-                    if let summary = digest.summary(metric) {
-                        scoreCard(summary: summary, presentation: .standalone)
-                    }
+        }
+    }
+    #endif
+
+    private var scoreGrid: some View {
+        LazyVGrid(
+            columns: [GridItem(.adaptive(minimum: compact ? 140 : 168), spacing: NoopMetrics.gap)],
+            spacing: NoopMetrics.gap
+        ) {
+            ForEach(Self.scoreOrder, id: \.rawValue) { metric in
+                if let summary = digest.summary(metric) {
+                    scoreCard(summary: summary, presentation: .standalone)
                 }
             }
         }
@@ -465,11 +503,15 @@ private struct DigestScoreCard: View {
     let presentation: Presentation
 
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @Environment(\.dynamicTypeSize) private var dynamicTypeSize
     @State private var animatedFraction: Double = 0
 
     /// The Effort card is the only one that follows the 0–100/0–21 toggle; the rest are fixed 0–100.
     private var isEffort: Bool { summary.metric == .effort }
     private var isEmbedded: Bool { presentation == .embedded }
+    private var gaugeDiameter: CGFloat {
+        isEmbedded && !dynamicTypeSize.isAccessibilitySize ? 82 : 118
+    }
 
     private var fraction: Double {
         guard summary.thisWeek.n > 0 else { return 0 }
@@ -513,7 +555,8 @@ private struct DigestScoreCard: View {
                     .tracking(StrandFont.overlineTracking)
                     .textCase(.uppercase)
                     .foregroundStyle(domain.color)
-                    .lineLimit(1)
+                    .lineLimit(dynamicTypeSize.isAccessibilitySize ? 2 : 1)
+                    .multilineTextAlignment(.center)
                     .frame(maxWidth: .infinity, alignment: .center)
             } else {
                 HStack {
@@ -529,15 +572,23 @@ private struct DigestScoreCard: View {
                 stops: domain.gradient.stops,
                 tipColor: domain.bright,
                 numberText: numberText,
-                captionText: captionText,
+                // The 82pt embedded gauge would reduce its proportional caption to
+                // roughly 7pt. Render that caption below with the scalable footnote role.
+                captionText: isEmbedded ? nil : captionText,
                 stateText: nil,
                 supporting: nil,
-                diameter: isEmbedded ? NoopMetrics.compactGaugeDiameter : 118,
-                lineWidth: isEmbedded ? NoopMetrics.space2 : 11,
+                diameter: gaugeDiameter,
+                lineWidth: isEmbedded && !dynamicTypeSize.isAccessibilitySize ? NoopMetrics.space2 : 11,
                 showsLabel: summary.thisWeek.n > 0,
                 animatedFraction: animatedFraction
             )
             .frame(maxWidth: .infinity)
+            if isEmbedded && summary.thisWeek.n > 0 {
+                Text(captionText)
+                    .font(StrandFont.footnote)
+                    .foregroundStyle(StrandPalette.textTertiary)
+                    .lineLimit(1)
+            }
             if isEmbedded && hasComparison {
                 TrendChip(text: deltaSigned, color: deltaTone)
             }
@@ -594,6 +645,17 @@ private func previewDigest() -> WeeklyDigest {
         .background(StrandPalette.surfaceBase)
         .preferredColorScheme(.dark)
 }
+
+#if os(iOS)
+#Preview("Weekly digest – card · accessibility text") {
+    WeeklyDigestContent(digest: previewDigest(), compact: true)
+        .padding(24)
+        .frame(width: 390)
+        .background(StrandPalette.surfaceBase)
+        .preferredColorScheme(.dark)
+        .dynamicTypeSize(.accessibility1)
+}
+#endif
 
 #Preview("Weekly digest – full") {
     ScrollView {

--- a/android/app/src/main/java/com/noop/ui/SleepScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/SleepScreen.kt
@@ -2361,20 +2361,22 @@ private fun MetricGrid(m: SleepModel, onMetricClick: (String) -> Unit = {}) {
                 onClick = { onMetricClick("respiratory") },
             )
         },
-        { mod ->
-            SparkTile(
-                mod, "Sleep Debt",
-                value = m.sleepDebt.latest?.let { durationText(it) } ?: "—",
-                caption = debtCaption(m.sleepDebt.latest),
-                accent = debtColor(m.sleepDebt.latest),
-                spark = m.sleepDebt.series, sparkColor = Palette.metricRose,
-                onClick = { onMetricClick("sleep_debt") },
-            )
-        },
     )
 
     Column(verticalArrangement = Arrangement.spacedBy(Metrics.gap)) {
         SectionHeader("Night detail", overline = "Metrics", trailing = "vs typical")
+
+        // Sleep Debt is the actionable summary for the section, so it leads at the full
+        // two-column width. The remaining six peer metrics keep the established 2 × 3 grid.
+        SparkTile(
+            Modifier.fillMaxWidth(), "Sleep Debt",
+            value = m.sleepDebt.latest?.let { durationText(it) } ?: "—",
+            caption = debtCaption(m.sleepDebt.latest),
+            accent = debtColor(m.sleepDebt.latest),
+            spark = m.sleepDebt.series, sparkColor = Palette.metricRose,
+            onClick = { onMetricClick("sleep_debt") },
+        )
+
         // Two-up rows; IntrinsicSize.Max + fillMaxHeight keep row neighbors equal height even when
         // large font scales grow one tile past the tileHeight floor. No empty cells.
         tiles.chunked(2).forEach { rowTiles ->
@@ -2383,7 +2385,6 @@ private fun MetricGrid(m: SleepModel, onMetricClick: (String) -> Unit = {}) {
                 horizontalArrangement = Arrangement.spacedBy(Metrics.gap),
             ) {
                 rowTiles.forEach { it(Modifier.weight(1f).fillMaxHeight()) }
-                if (rowTiles.size == 1) Spacer(Modifier.weight(1f))
             }
         }
     }

--- a/android/app/src/main/java/com/noop/ui/TrendsExploreScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/TrendsExploreScreen.kt
@@ -798,14 +798,15 @@ private fun StatRow(
     Column(verticalArrangement = Arrangement.spacedBy(Metrics.gap)) {
         SectionHeader(stringResource(R.string.explore_summary), overline = stringResource(R.string.explore_over_visible_window), trailing = stringResource(R.string.explore_n_pts, s.n))
 
+        // Average summarizes the selected range, so it leads at the full two-column width.
+        StatTile(
+            modifier = Modifier.fillMaxWidth(),
+            label = stringResource(R.string.explore_average),
+            value = if (s.n > 0) metric.format(s.mean) else ",",
+            caption = pluralStringResource(R.plurals.explore_n_days, s.n, s.n),
+            accent = metric.accent,
+        )
         Row(horizontalArrangement = Arrangement.spacedBy(Metrics.gap)) {
-            StatTile(
-                modifier = Modifier.weight(1f),
-                label = stringResource(R.string.explore_average),
-                value = if (s.n > 0) metric.format(s.mean) else ",",
-                caption = pluralStringResource(R.plurals.explore_n_days, s.n, s.n),
-                accent = metric.accent,
-            )
             StatTile(
                 modifier = Modifier.weight(1f),
                 label = stringResource(R.string.explore_min),
@@ -819,18 +820,8 @@ private fun StatRow(
                 accent = Palette.textPrimary,
             )
         }
-        // Two-up (not three-up + a pad cell): the prev-window comparison tile carries a value, a
-        // delta chip AND a "vs prev <window>" caption, which all clipped at a third of the width ,
-        // "vs prev 6 months" truncated to "vs prev 6 m…" and the delta chip ran off the tile (#443).
-        // Half-width gives every part room; mirrors the 2-up tile rows used on Sleep/Compare.
+        // Half-width gives the comparison tile room for its value, delta chip and window caption.
         Row(horizontalArrangement = Arrangement.spacedBy(Metrics.gap)) {
-            StatTile(
-                modifier = Modifier.weight(1f),
-                label = stringResource(R.string.explore_latest),
-                value = latest?.let { metric.format(it.value) } ?: ",",
-                caption = latest?.day,
-                accent = metric.accent,
-            )
             StatTile(
                 modifier = Modifier.weight(1f),
                 label = stringResource(R.string.explore_delta_vs_prev),
@@ -839,6 +830,13 @@ private fun StatRow(
                 accent = Palette.textPrimary,
                 delta = pctChange?.let { "${if (it >= 0) "+" else ""}${String.format(Locale.US, "%.1f", it)}%" },
                 deltaColor = deltaColor,
+            )
+            StatTile(
+                modifier = Modifier.weight(1f),
+                label = stringResource(R.string.explore_latest),
+                value = latest?.let { metric.format(it.value) } ?: ",",
+                caption = latest?.day,
+                accent = metric.accent,
             )
         }
     }


### PR DESCRIPTION
## What this PR does

This PR removes visually incomplete metric-summary layouts while preserving the existing two-column sizing and metric logic.

On iOS, it:

- combines the compact Weekly Digest Charge, Effort, and Rest summaries into one shared `NoopCard` with three equally weighted sections;
- promotes Sleep Debt to the full-width first tile in Night Detail, leaving the other six sleep metrics in a balanced two-column grid; and
- promotes Average to the full-width first tile on metric-detail pages, followed by Min / Max and Δ vs previous / Latest.

Android receives the same Sleep Night Detail and metric-detail summary hierarchy.

The UI changes are presentation-only: no BLE, protocol, analytics, persistence, or score calculations are modified.

## Type of change

- [x] Bug fix

## How it was tested

- Built, installed, and launched the iOS changes on an iPhone 16 Pro simulator.
- StrandDesign package tests pass: `swift test` (32 tests).
- Android Full Debug unit tests pass: `./gradlew testFullDebugUnitTest`.
- Android Demo Debug unit tests pass: `./gradlew testDemoDebugUnitTest`.
- No BLE or hardware behavior was changed, so real-strap testing is not applicable.

## Checklist

- [x] Swift package tests pass for any package I touched (`swift test` in `Packages/<name>`)
- [x] Android unit tests pass if I touched `android/` (`./gradlew testFullDebugUnitTest`)
- [x] No new build warnings introduced
- [x] UI changes use only `StrandDesign` tokens — no hardcoded colors, fonts, or spacing
- [x] No hardcoded hex frame bytes; protocol facts live in the schema / decoders
- [x] Follows the conventions in [`docs/CONTRIBUTING.md`](../docs/CONTRIBUTING.md)
- [x] I did not commit generated output (`Strand.xcodeproj/`) or any secrets/keystores