### PR TITLE
Clarify segmented range-control section

### DIFF
--- a/android/app/src/main/java/com/noop/ui/Components.kt
+++ b/android/app/src/main/java/com/noop/ui/Components.kt
@@ -564,7 +564,7 @@ fun InsightCard(
     }
 }
 
-// MARK: - SegmentedPillControl — the ONE segmented control
+// MARK: - SegmentedPillControl — shared segmented range control
 
 @Composable
 fun <T> SegmentedPillControl(


### PR DESCRIPTION
## Summary

Clarifies the inline section label for the shared Android segmented range control.