### PR TITLE
Support custom AI gateway auth

### DIFF
--- a/Strand/AI/AICoach.swift
+++ b/Strand/AI/AICoach.swift
@@ -183,6 +183,9 @@ final class AICoachEngine: ObservableObject {
     @Published var customBaseURL: String {
         didSet { UserDefaults.standard.set(customBaseURL, forKey: AIProvider.customBaseURLKey) }
     }
+    @Published var customAuthHeader: CustomAIAuthHeader {
+        didSet { UserDefaults.standard.set(customAuthHeader.rawValue, forKey: AIProvider.customAuthHeaderKey) }
+    }
     /// Whether the user has committed the Custom provider (tapped Connect with a base URL). Lets the
     /// keyless local path reach the chat without a stored key, while avoiding a flip mid-typing.
     @Published var customConnected: Bool {
@@ -303,6 +306,7 @@ final class AICoachEngine: ObservableObject {
 
         self.dataConsent = UserDefaults.standard.bool(forKey: Self.consentKey)
         self.customBaseURL = UserDefaults.standard.string(forKey: AIProvider.customBaseURLKey) ?? ""
+        self.customAuthHeader = AIProvider.customAuthHeader
         self.customConnected = UserDefaults.standard.bool(forKey: Self.customConnectedKey)
         self.includeOnDeviceSignals = UserDefaults.standard.bool(forKey: Self.onDeviceSignalsKey)
     }

--- a/Strand/AI/AIProvider.swift
+++ b/Strand/AI/AIProvider.swift
@@ -90,11 +90,27 @@ enum AIProvider: String, CaseIterable, Identifiable {
     /// UserDefaults key for the Custom provider's base URL (e.g. a local LLM server such as Ollama /
     /// LM Studio / llama.cpp: `http://localhost:11434/v1`). `AICoachEngine` exposes it for editing.
     static let customBaseURLKey = "ai.customBaseURL"
+    static let customAuthHeaderKey = "ai.customAuthHeader"
 
     /// The user-set Custom base URL, trimmed.
     static var customBaseURL: String {
         (UserDefaults.standard.string(forKey: customBaseURLKey) ?? "")
             .trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    static var customAuthHeader: CustomAIAuthHeader {
+        let raw = UserDefaults.standard.string(forKey: customAuthHeaderKey)
+        return CustomAIAuthHeader(rawValue: raw ?? "") ?? .bearer
+    }
+
+    static func applyCustomAuthHeader(_ key: String, to request: inout URLRequest) {
+        guard !key.isEmpty else { return }
+        switch customAuthHeader {
+        case .bearer:
+            request.setValue("Bearer \(key)", forHTTPHeaderField: "Authorization")
+        case .xAPIKey:
+            request.setValue(key, forHTTPHeaderField: "x-api-key")
+        }
     }
 
     /// Build a Custom endpoint by appending `path` to the user's base URL (trailing slashes tolerated).
@@ -162,6 +178,20 @@ enum AIProvider: String, CaseIterable, Identifiable {
         case a == 192 && b == 168: return true           // 192.168.0.0/16
         case a == 169 && b == 254: return true           // 169.254.0.0/16 link-local
         default: return false
+        }
+    }
+}
+
+enum CustomAIAuthHeader: String, CaseIterable, Identifiable {
+    case bearer
+    case xAPIKey
+
+    var id: String { rawValue }
+
+    var displayName: String {
+        switch self {
+        case .bearer: return "Bearer"
+        case .xAPIKey: return "x-api-key"
         }
     }
 }

--- a/Strand/AI/Providers/Custom.swift
+++ b/Strand/AI/Providers/Custom.swift
@@ -3,7 +3,7 @@ import Foundation
 /// A generic OpenAI-compatible provider pointed at a user-set base URL — e.g. a local LLM server such
 /// as Ollama, LM Studio or llama.cpp (`http://localhost:11434/v1`), or any self-hosted gateway. Speaks
 /// the OpenAI chat-completions wire format against `AIProvider.custom` endpoints. The API key is
-/// optional — local servers usually need none — so the `Authorization` header is sent only when set.
+/// optional — local servers usually need none — so the configured auth header is sent only when set.
 struct CustomClient: AIProviderClient {
 
     func send(
@@ -61,25 +61,37 @@ struct CustomClient: AIProviderClient {
         try AIProvider.guardCustomBaseURL()   // #321: reject a public cleartext Custom URL before egress
         var req = URLRequest(url: AIProvider.custom.modelsEndpoint)
         req.httpMethod = "GET"
-        if !key.isEmpty { req.setValue("Bearer \(key)", forHTTPHeaderField: "Authorization") }
+        AIProvider.applyCustomAuthHeader(key, to: &req)
 
         return parseModels(try await performRequest(req, session: session))
     }
 
-    /// Pure: unwrap an OpenAI-compatible `/models` body into ids. Unlike OpenAI we keep *all* ids —
-    /// a local server names models freely (`llama3.1`, `qwen2.5`, …). No network — unit-tested.
+    /// Pure: unwrap an OpenAI-compatible `/models` body into ids. Unlike OpenAI we keep *all* ids.
+    /// Some enterprise gateways return a catalog (`catalog[].models`) rather than `data[].id`; keep
+    /// those ids too so users do not have to type every supported model by hand.
     func parseModels(_ json: [String: Any]) -> [String] {
-        guard let list = json["data"] as? [[String: Any]] else { return [] }
-        return list.compactMap { row in
-            guard let id = row["id"] as? String, !id.isEmpty else { return nil }
-            return id
+        if let list = json["data"] as? [[String: Any]] {
+            return list.compactMap { row in
+                guard let id = row["id"] as? String, !id.isEmpty else { return nil }
+                return id
+            }
+        }
+        guard let catalog = json["catalog"] as? [[String: Any]] else { return [] }
+        var seen = Set<String>()
+        return catalog.flatMap { row -> [String] in
+            guard let models = row["models"] as? [String] else { return [] }
+            return models.filter { !$0.isEmpty }
+        }.filter { id in
+            if seen.contains(id) { return false }
+            seen.insert(id)
+            return true
         }
     }
 
     // MARK: Private
 
     /// `modernParams`: use `max_completion_tokens`, drop `temperature` — for gateways fronting
-    /// reasoning models. The `Authorization` header is omitted when `key` is empty (local servers).
+    /// reasoning models. The auth header is omitted when `key` is empty (local servers).
     private func chat(
         key: String,
         model: String,
@@ -97,7 +109,7 @@ struct CustomClient: AIProviderClient {
 
         var req = URLRequest(url: AIProvider.custom.endpoint)
         req.httpMethod = "POST"
-        if !key.isEmpty { req.setValue("Bearer \(key)", forHTTPHeaderField: "Authorization") }
+        AIProvider.applyCustomAuthHeader(key, to: &req)
         req.setValue("application/json", forHTTPHeaderField: "Content-Type")
         req.httpBody = try JSONSerialization.data(withJSONObject: body)
 

--- a/Strand/Screens/CoachView.swift
+++ b/Strand/Screens/CoachView.swift
@@ -255,6 +255,22 @@ struct CoachView: View {
                             .foregroundStyle(StrandPalette.textSecondary)
                             .fixedSize(horizontal: false, vertical: true)
                     }
+
+                    VStack(alignment: .leading, spacing: 6) {
+                        Text("Key header").strandOverline()
+                        Picker("Key header", selection: $coach.customAuthHeader) {
+                            ForEach(CustomAIAuthHeader.allCases) { header in
+                                Text(header.displayName).tag(header)
+                            }
+                        }
+                        .labelsHidden()
+                        .pickerStyle(.segmented)
+                        .accessibilityLabel("Key header")
+                        Text("Use Bearer for most local servers; use x-api-key for gateways that require the key in that header.")
+                            .font(StrandFont.footnote)
+                            .foregroundStyle(StrandPalette.textSecondary)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
                 }
 
                 // Model

--- a/StrandTests/AIProviderModelListTests.swift
+++ b/StrandTests/AIProviderModelListTests.swift
@@ -96,4 +96,16 @@ final class AIProviderModelListTests: XCTestCase {
         let body: [String: Any] = ["models": [["name": "models/llama3.1"]]]
         XCTAssertTrue(CustomClient().parseModels(body).isEmpty)
     }
+
+    func testCustomKeepsGatewayCatalogModels() {
+        let body: [String: Any] = [
+            "service": "Gateway",
+            "catalog": [
+                ["tool": "OpenAI", "models": ["gpt-5", "gpt-5.5"]],
+                ["tool": "Other", "models": ["claude-sonnet-4-6@default", "gpt-5"]]
+            ]
+        ]
+        XCTAssertEqual(CustomClient().parseModels(body),
+                       ["gpt-5", "gpt-5.5", "claude-sonnet-4-6@default"])
+    }
 }

--- a/android/app/src/main/java/com/noop/ai/AiCoach.kt
+++ b/android/app/src/main/java/com/noop/ai/AiCoach.kt
@@ -67,6 +67,7 @@ class AiCoach(private val repo: WhoopRepository) {
         model: String,
         consent: Boolean = false,
         customBaseUrl: String = "",
+        customAuthHeader: CustomAiAuthHeader = CustomAiAuthHeader.BEARER,
         includeSignals: Boolean = false,
     ): String = withContext(Dispatchers.IO) {
         // Local (Custom) servers usually need no key; the cloud providers always do. The guarded read
@@ -125,7 +126,15 @@ class AiCoach(private val repo: WhoopRepository) {
             AiProvider.GEMINI ->
                 callGemini(provider, model, key!!, grounded, systemPrompt)
             AiProvider.CUSTOM ->
-                callOpenAiCompatible(provider, customChatUrl(customBaseUrl), model, key, grounded, systemPrompt)
+                callOpenAiCompatible(
+                    provider,
+                    customChatUrl(customBaseUrl),
+                    model,
+                    key,
+                    grounded,
+                    systemPrompt,
+                    customAuthHeader,
+                )
         }
     }
 
@@ -158,6 +167,7 @@ class AiCoach(private val repo: WhoopRepository) {
         ctx: Context,
         provider: AiProvider,
         customBaseUrl: String = "",
+        customAuthHeader: CustomAiAuthHeader = CustomAiAuthHeader.BEARER,
     ): List<String> = withContext(Dispatchers.IO) {
         // Guarded read: only a key saved for THIS provider (or a legacy cloud key) is used, never one
         // provider's key against another's models endpoint.
@@ -184,7 +194,7 @@ class AiCoach(private val repo: WhoopRepository) {
                 builder.addHeader("anthropic-version", "2023-06-01")
             }
             AiProvider.GEMINI -> builder.addHeader("x-goog-api-key", key!!)
-            AiProvider.CUSTOM -> if (!key.isNullOrBlank()) builder.addHeader("Authorization", "Bearer $key")
+            AiProvider.CUSTOM -> applyCustomAuthHeader(builder, key, customAuthHeader)
         }
 
         runCatching {
@@ -195,21 +205,7 @@ class AiCoach(private val repo: WhoopRepository) {
             // parse; every other provider is OpenAI-shaped ({"data":[{"id":"…"}]}).
             if (provider == AiProvider.GEMINI) return@runCatching parseGeminiModels(text)
 
-            val data = JSONObject(text).optJSONArray("data") ?: return@runCatching emptyList<String>()
-            val ids = ArrayList<String>(data.length())
-            for (i in 0 until data.length()) {
-                val id = data.optJSONObject(i)?.optString("id")?.trim().orEmpty()
-                if (id.isEmpty()) continue
-                val keep = when (provider) {
-                    AiProvider.OPENAI -> id.startsWith("gpt") || id.startsWith("o")
-                    // Anthropic + a local server name models freely → keep all.
-                    AiProvider.ANTHROPIC, AiProvider.CUSTOM -> true
-                    // GEMINI returned early above.
-                    AiProvider.GEMINI -> true
-                }
-                if (keep) ids.add(id)
-            }
-            ids.distinct()
+            parseOpenAiCompatibleModels(provider, text)
         }.getOrDefault(emptyList())
     }
 
@@ -382,6 +378,7 @@ class AiCoach(private val repo: WhoopRepository) {
         key: String?,
         history: List<ChatMsg>,
         systemPrompt: String,
+        customAuthHeader: CustomAiAuthHeader = CustomAiAuthHeader.BEARER,
     ): String {
         val messages = JSONArray()
         messages.put(JSONObject().put("role", "system").put("content", systemPrompt))
@@ -390,23 +387,34 @@ class AiCoach(private val repo: WhoopRepository) {
             messages.put(JSONObject().put("role", m.role).put("content", m.text))
         }
 
-        val body = JSONObject()
-            .put("model", model)
-            .put("messages", messages)
-            .put("temperature", 0.6)
-            .put("max_tokens", 900)
-            .toString()
+        val (code, text) = executeOpenAiCompatible(
+            provider = provider,
+            url = url,
+            model = model,
+            messages = messages,
+            key = key,
+            customAuthHeader = customAuthHeader,
+            modernParams = false,
+        )
+        val responseText = if (code in 200..299) {
+            text
+        } else if (code == 400 && shouldRetryOpenAiModernParams(text)) {
+            val (retryCode, retryText) = executeOpenAiCompatible(
+                provider = provider,
+                url = url,
+                model = model,
+                messages = messages,
+                key = key,
+                customAuthHeader = customAuthHeader,
+                modernParams = true,
+            )
+            if (retryCode !in 200..299) throw httpError(provider, retryCode, retryText)
+            retryText
+        } else {
+            throw httpError(provider, code, text)
+        }
 
-        val builder = Request.Builder()
-            .url(url)
-            .addHeader("Content-Type", "application/json")
-            .post(body.toRequestBody(JSON))
-        if (!key.isNullOrBlank()) builder.addHeader("Authorization", "Bearer $key")
-
-        val (code, text) = execute(builder.build())
-        if (code !in 200..299) throw httpError(provider, code, text)
-
-        val json = parse(text)
+        val json = parse(responseText)
         val firstChoice = json.optJSONArray("choices")?.optJSONObject(0)
         val content = firstChoice
             ?.optJSONObject("message")
@@ -419,6 +427,56 @@ class AiCoach(private val repo: WhoopRepository) {
         // and give NO error, keep the partial text and append the actionable notice so it isn't silent.
         val truncated = firstChoice.optString("finish_reason").lowercase() == "length"
         return if (truncated) content + TRUNCATION_NOTE else content
+    }
+
+    private fun executeOpenAiCompatible(
+        provider: AiProvider,
+        url: String,
+        model: String,
+        messages: JSONArray,
+        key: String?,
+        customAuthHeader: CustomAiAuthHeader,
+        modernParams: Boolean,
+    ): Pair<Int, String> {
+        val body = JSONObject()
+            .put("model", model)
+            .put("messages", messages)
+        if (modernParams) {
+            body.put("max_completion_tokens", 900)
+        } else {
+            body.put("temperature", 0.6)
+            body.put("max_tokens", 900)
+        }
+
+        val builder = Request.Builder()
+            .url(url)
+            .addHeader("Content-Type", "application/json")
+            .post(body.toString().toRequestBody(JSON))
+        when (provider) {
+            AiProvider.CUSTOM -> applyCustomAuthHeader(builder, key, customAuthHeader)
+            else -> if (!key.isNullOrBlank()) builder.addHeader("Authorization", "Bearer $key")
+        }
+        return execute(builder.build())
+    }
+
+    private fun applyCustomAuthHeader(
+        builder: Request.Builder,
+        key: String?,
+        customAuthHeader: CustomAiAuthHeader,
+    ) {
+        if (key.isNullOrBlank()) return
+        when (customAuthHeader) {
+            CustomAiAuthHeader.BEARER -> builder.addHeader("Authorization", "Bearer $key")
+            CustomAiAuthHeader.X_API_KEY -> builder.addHeader("x-api-key", key)
+        }
+    }
+
+    private fun shouldRetryOpenAiModernParams(text: String): Boolean {
+        val detail = runCatching { parse(text).toString() }.getOrDefault(text).lowercase()
+        return detail.contains("max_completion_tokens") ||
+            detail.contains("max_tokens") ||
+            detail.contains("temperature") ||
+            detail.contains("unsupported")
     }
 
     /** Base for the Custom provider, the user's URL with any trailing slashes trimmed. */
@@ -663,6 +721,40 @@ class AiCoach(private val repo: WhoopRepository) {
                 if (name.isEmpty()) continue
                 val id = if (name.startsWith("models/")) name.removePrefix("models/") else name
                 if (id.startsWith("gemini") && !id.contains("embedding") && !id.contains("aqa")) ids.add(id)
+            }
+            return ids.distinct()
+        }
+
+        /**
+         * Pure: unwrap OpenAI-compatible `/models` ids. Custom gateways may return either the normal
+         * `data[].id` envelope or a gateway catalog with `catalog[].models`; keep all Custom ids.
+         */
+        internal fun parseOpenAiCompatibleModels(provider: AiProvider, text: String): List<String> {
+            val json = runCatching { JSONObject(text) }.getOrNull() ?: return emptyList()
+            val data = json.optJSONArray("data")
+            if (data != null) {
+                val ids = ArrayList<String>(data.length())
+                for (i in 0 until data.length()) {
+                    val id = data.optJSONObject(i)?.optString("id")?.trim().orEmpty()
+                    if (id.isEmpty()) continue
+                    val keep = when (provider) {
+                        AiProvider.OPENAI -> id.startsWith("gpt") || id.startsWith("o")
+                        AiProvider.ANTHROPIC, AiProvider.CUSTOM -> true
+                        AiProvider.GEMINI -> true
+                    }
+                    if (keep) ids.add(id)
+                }
+                return ids.distinct()
+            }
+
+            val catalog = json.optJSONArray("catalog") ?: return emptyList()
+            val ids = ArrayList<String>()
+            for (i in 0 until catalog.length()) {
+                val models = catalog.optJSONObject(i)?.optJSONArray("models") ?: continue
+                for (j in 0 until models.length()) {
+                    val id = models.optString(j).trim()
+                    if (id.isNotEmpty()) ids.add(id)
+                }
             }
             return ids.distinct()
         }

--- a/android/app/src/main/java/com/noop/ai/AiKeyStore.kt
+++ b/android/app/src/main/java/com/noop/ai/AiKeyStore.kt
@@ -24,6 +24,7 @@ object AiKeyStore {
     private const val KEY_KEY_OWNER = "key_provider"
     private const val KEY_CONSENT = "data_consent"
     private const val KEY_CUSTOM_URL = "custom_base_url"
+    private const val KEY_CUSTOM_AUTH_HEADER = "custom_auth_header"
     private const val KEY_CUSTOM_CONNECTED = "custom_connected"
 
     /** Per-provider model preference key, so each provider remembers its own last model. */
@@ -154,6 +155,15 @@ object AiKeyStore {
     /** Read the Custom provider's base URL, or empty string if unset. */
     fun readCustomBaseUrl(ctx: Context): String =
         prefs(ctx).getString(KEY_CUSTOM_URL, null)?.trim().orEmpty()
+
+    /** Persist which header the Custom provider should use when an API key is present. */
+    fun saveCustomAuthHeader(ctx: Context, header: CustomAiAuthHeader) {
+        prefs(ctx).edit().putString(KEY_CUSTOM_AUTH_HEADER, header.name).apply()
+    }
+
+    /** Read the Custom provider auth header. Defaults to Bearer for existing local setups. */
+    fun readCustomAuthHeader(ctx: Context): CustomAiAuthHeader =
+        CustomAiAuthHeader.fromName(prefs(ctx).getString(KEY_CUSTOM_AUTH_HEADER, null))
 
     /**
      * Persist whether the user has committed the Custom provider (entered a URL and tapped

--- a/android/app/src/main/java/com/noop/ai/AiProvider.kt
+++ b/android/app/src/main/java/com/noop/ai/AiProvider.kt
@@ -98,3 +98,13 @@ enum class AiProvider(
             entries.firstOrNull { it.name == name } ?: OPENAI
     }
 }
+
+enum class CustomAiAuthHeader(val displayName: String) {
+    BEARER("Bearer"),
+    X_API_KEY("x-api-key");
+
+    companion object {
+        fun fromName(name: String?): CustomAiAuthHeader =
+            entries.firstOrNull { it.name == name } ?: BEARER
+    }
+}

--- a/android/app/src/main/java/com/noop/ui/CoachScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/CoachScreen.kt
@@ -53,6 +53,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.noop.ai.AiProvider
 import com.noop.ai.ChatMsg
+import com.noop.ai.CustomAiAuthHeader
 
 /**
  * AI Coach, the single opt-in, bring-your-own-key feature.
@@ -108,6 +109,7 @@ private fun CoachSetup(vm: CoachViewModel) {
     val availableModels by vm.availableModels.collectAsStateWithLifecycle()
     val refreshingModels by vm.refreshingModels.collectAsStateWithLifecycle()
     val customBaseUrl by vm.customBaseUrl.collectAsStateWithLifecycle()
+    val customAuthHeader by vm.customAuthHeader.collectAsStateWithLifecycle()
     var keyInput by remember { mutableStateOf("") }
     val isCustom = provider == AiProvider.CUSTOM
 
@@ -154,6 +156,21 @@ private fun CoachSetup(vm: CoachViewModel) {
                         keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Uri),
                         colors = coachFieldColors(),
                         shape = RoundedCornerShape(14.dp),
+                    )
+                }
+
+                Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                    Overline(uiString(R.string.l10n_coach_screen_key_header_3f2a9b10))
+                    SegmentedPillControl(
+                        items = CustomAiAuthHeader.entries,
+                        selection = customAuthHeader,
+                        label = { it.displayName },
+                        onSelect = { vm.setCustomAuthHeader(context, it) },
+                    )
+                    Text(
+                        uiString(R.string.l10n_coach_screen_use_bearer_for_most_local_servers_4429ab64),
+                        style = NoopType.footnote,
+                        color = Palette.textSecondary,
                     )
                 }
             }

--- a/android/app/src/main/java/com/noop/ui/CoachViewModel.kt
+++ b/android/app/src/main/java/com/noop/ui/CoachViewModel.kt
@@ -8,6 +8,7 @@ import com.noop.ai.AiCoach
 import com.noop.ai.AiKeyStore
 import com.noop.ai.AiProvider
 import com.noop.ai.ChatMsg
+import com.noop.ai.CustomAiAuthHeader
 import com.noop.data.WhoopDatabase
 import com.noop.data.WhoopRepository
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -83,6 +84,10 @@ class CoachViewModel(app: Application) : AndroidViewModel(app) {
     /** Base URL for the Custom (OpenAI-compatible) provider, e.g. http://localhost:11434/v1. */
     val customBaseUrl: StateFlow<String> = _customBaseUrl.asStateFlow()
 
+    private val _customAuthHeader = MutableStateFlow(AiKeyStore.readCustomAuthHeader(app.applicationContext))
+    /** Header used by the Custom provider when an API key is present. */
+    val customAuthHeader: StateFlow<CustomAiAuthHeader> = _customAuthHeader.asStateFlow()
+
     private val _customConnected = MutableStateFlow(AiKeyStore.readCustomConnected(app.applicationContext))
     /** True once the user has committed the Custom provider (entered a URL and tapped Connect). */
     val customConnected: StateFlow<Boolean> = _customConnected.asStateFlow()
@@ -91,6 +96,11 @@ class CoachViewModel(app: Application) : AndroidViewModel(app) {
     fun setCustomBaseUrl(ctx: Context, url: String) {
         _customBaseUrl.value = url
         AiKeyStore.saveCustomBaseUrl(ctx, url)
+    }
+
+    fun setCustomAuthHeader(ctx: Context, header: CustomAiAuthHeader) {
+        _customAuthHeader.value = header
+        AiKeyStore.saveCustomAuthHeader(ctx, header)
     }
 
     /** Grant or revoke data access; persisted. */
@@ -193,7 +203,7 @@ class CoachViewModel(app: Application) : AndroidViewModel(app) {
         _refreshingModels.value = true
         viewModelScope.launch {
             try {
-                val live = aiCoach.fetchModels(appCtx, p, url)
+                val live = aiCoach.fetchModels(appCtx, p, url, _customAuthHeader.value)
                 if (p == _provider.value) {
                     val merged = (_availableModels.value + live).distinct()
                     _availableModels.value = merged
@@ -288,6 +298,7 @@ class CoachViewModel(app: Application) : AndroidViewModel(app) {
                     model = _model.value,
                     consent = _consent.value,
                     customBaseUrl = _customBaseUrl.value,
+                    customAuthHeader = _customAuthHeader.value,
                     // v5: only include the on-device-signals summary when BOTH the data consent is on AND
                     // the second opt-in is set (summary-only, no raw egress, see AiCoach.buildSignalsContext).
                     includeSignals = _consent.value && NoopPrefs.coachSignals(appCtx),

--- a/android/app/src/main/res/values-de/strings.xml
+++ b/android/app/src/main/res/values-de/strings.xml
@@ -328,6 +328,7 @@
     <string name="l10n_coach_screen_e_g_gpt_4o_1da2e4d2">z. B. gpt-4o</string>
     <string name="l10n_coach_screen_enter_any_model_id_the_provider_dce4bbcb">Geben Sie eine Modell-ID ein, die der Anbieter akzeptiert.</string>
     <string name="l10n_coach_screen_fetch_models_from_provider_6654e1a0">Modelle von Anbietern abrufen</string>
+    <string name="l10n_coach_screen_key_header_3f2a9b10">Schlüssel-Header</string>
     <string name="l10n_coach_screen_let_the_coach_use_my_data_405d1188">Dem Coach erlauben, meine Daten zu nutzen</string>
     <string name="l10n_coach_screen_model_selected_tap_to_change_043056c1">Modell: %1$s. Tap zum Ändern.</string>
     <string name="l10n_coach_screen_provider_displayname_model_8b39f761">%1$s · %2$s</string>
@@ -337,6 +338,7 @@
     <string name="l10n_coach_screen_server_url_1d5d1eff">Server-URL</string>
     <string name="l10n_coach_screen_suggested_prompt_prompt_379c0b15">Vorgeschlagene Aufforderung: %1$s</string>
     <string name="l10n_coach_screen_thinking_a60d9c9c">Denken...</string>
+    <string name="l10n_coach_screen_use_bearer_for_most_local_servers_4429ab64">Verwende Bearer für die meisten lokalen Server; verwende x-api-key für Gateways, die den Schlüssel in diesem Header verlangen.</string>
     <string name="l10n_coach_screen_use_model_8d558ce2">Verwendungsmodell</string>
     <string name="l10n_compare_screen_add_a_metric_to_compare_e6a7c9f1">Eine Metrik zum Vergleich hinzufügen</string>
     <string name="l10n_compare_screen_compare_8d105cf4">Vergleichen</string>

--- a/android/app/src/main/res/values-es/strings.xml
+++ b/android/app/src/main/res/values-es/strings.xml
@@ -158,6 +158,7 @@
     <string name="l10n_coach_screen_e_g_gpt_4o_1da2e4d2">gpt-4o</string>
     <string name="l10n_coach_screen_enter_any_model_id_the_provider_dce4bbcb">Introduzca cualquier modelo id que el proveedor acepte.</string>
     <string name="l10n_coach_screen_fetch_models_from_provider_6654e1a0">Modelos de captura del proveedor</string>
+    <string name="l10n_coach_screen_key_header_3f2a9b10">Encabezado de clave</string>
     <string name="l10n_coach_screen_let_the_coach_use_my_data_405d1188">Permitir que el entrenador use mis datos</string>
     <string name="l10n_coach_screen_model_selected_tap_to_change_043056c1">Modelo: %1$s. Toca para cambiar.</string>
     <string name="l10n_coach_screen_provider_displayname_model_8b39f761">%1$s · %2$s</string>
@@ -167,6 +168,7 @@
     <string name="l10n_coach_screen_server_url_1d5d1eff">URL del servidor</string>
     <string name="l10n_coach_screen_suggested_prompt_prompt_379c0b15">Se sugiere el siguiente mensaje: %1$s</string>
     <string name="l10n_coach_screen_thinking_a60d9c9c">Pensando...</string>
+    <string name="l10n_coach_screen_use_bearer_for_most_local_servers_4429ab64">Usa Bearer para la mayoría de los servidores locales; usa x-api-key para las pasarelas que requieren la clave en ese encabezado.</string>
     <string name="l10n_coach_screen_use_model_8d558ce2">Modelo de uso</string>
     <string name="l10n_compare_screen_add_a_metric_to_compare_e6a7c9f1">Añade una métrica para comparar</string>
     <string name="l10n_compare_screen_compare_8d105cf4">Comparar</string>

--- a/android/app/src/main/res/values-fr/strings.xml
+++ b/android/app/src/main/res/values-fr/strings.xml
@@ -158,6 +158,7 @@
     <string name="l10n_coach_screen_e_g_gpt_4o_1da2e4d2">Par exemple gpt-4o</string>
     <string name="l10n_coach_screen_enter_any_model_id_the_provider_dce4bbcb">Entrez n\'importe quel modèle id que le fournisseur accepte.</string>
     <string name="l10n_coach_screen_fetch_models_from_provider_6654e1a0">Obtenez des modèles du fournisseur</string>
+    <string name="l10n_coach_screen_key_header_3f2a9b10">En-tête de clé</string>
     <string name="l10n_coach_screen_let_the_coach_use_my_data_405d1188">Laisser le coach utiliser mes données</string>
     <string name="l10n_coach_screen_model_selected_tap_to_change_043056c1">Modèle : %1$s. Appuyez sur pour changer.</string>
     <string name="l10n_coach_screen_provider_displayname_model_8b39f761">%1$s · %2$s</string>
@@ -167,6 +168,7 @@
     <string name="l10n_coach_screen_server_url_1d5d1eff">URL du serveur</string>
     <string name="l10n_coach_screen_suggested_prompt_prompt_379c0b15">Indicatif suggéré : %1$s</string>
     <string name="l10n_coach_screen_thinking_a60d9c9c">Penser...</string>
+    <string name="l10n_coach_screen_use_bearer_for_most_local_servers_4429ab64">Utilisez Bearer pour la plupart des serveurs locaux ; utilisez x-api-key pour les passerelles qui exigent la clé dans cet en-tête.</string>
     <string name="l10n_coach_screen_use_model_8d558ce2">Utiliser le modèle</string>
     <string name="l10n_compare_screen_add_a_metric_to_compare_e6a7c9f1">Ajouter une métrique à comparer</string>
     <string name="l10n_compare_screen_compare_8d105cf4">Comparer</string>

--- a/android/app/src/main/res/values-pt-rPT/strings.xml
+++ b/android/app/src/main/res/values-pt-rPT/strings.xml
@@ -311,6 +311,7 @@
     <string name="l10n_coach_screen_e_g_gpt_4o_1da2e4d2">por exemplo gpt-4o</string>
     <string name="l10n_coach_screen_enter_any_model_id_the_provider_dce4bbcb">Introduza qualquer ID de modelo que o fornecedor aceite.</string>
     <string name="l10n_coach_screen_fetch_models_from_provider_6654e1a0">Procurar modelos do provedor</string>
+    <string name="l10n_coach_screen_key_header_3f2a9b10">Cabeçalho da chave</string>
     <string name="l10n_coach_screen_let_the_coach_use_my_data_405d1188">Deixe o treinador usar os meus dados</string>
     <string name="l10n_coach_screen_model_selected_tap_to_change_043056c1">Modelo: %1$s. Toque em para alterar.</string>
     <string name="l10n_coach_screen_provider_displayname_model_8b39f761">%1$s · %2$s</string>
@@ -320,6 +321,7 @@
     <string name="l10n_coach_screen_server_url_1d5d1eff">URL do servidor</string>
     <string name="l10n_coach_screen_suggested_prompt_prompt_379c0b15">Prompt sugerido: %1$s</string>
     <string name="l10n_coach_screen_thinking_a60d9c9c">A pensar…</string>
+    <string name="l10n_coach_screen_use_bearer_for_most_local_servers_4429ab64">Usa Bearer para a maioria dos servidores locais; usa x-api-key para gateways que exigem a chave nesse cabeçalho.</string>
     <string name="l10n_coach_screen_use_model_8d558ce2">Usar modelo</string>
     <string name="l10n_compare_screen_add_a_metric_to_compare_e6a7c9f1">Adicione uma métrica para comparar</string>
     <string name="l10n_compare_screen_compare_8d105cf4">Comparar</string>

--- a/android/app/src/main/res/values-zh/strings.xml
+++ b/android/app/src/main/res/values-zh/strings.xml
@@ -309,6 +309,7 @@
     <string name="l10n_coach_screen_e_g_gpt_4o_1da2e4d2">例如：gpt-4o</string>
     <string name="l10n_coach_screen_enter_any_model_id_the_provider_dce4bbcb">输入该服务商支持的任意模型 ID。</string>
     <string name="l10n_coach_screen_fetch_models_from_provider_6654e1a0">从服务商获取模型列表</string>
+    <string name="l10n_coach_screen_key_header_3f2a9b10">密钥请求头</string>
     <string name="l10n_coach_screen_let_the_coach_use_my_data_405d1188">允许 AI 教练访问我的数据</string>
     <string name="l10n_coach_screen_model_selected_tap_to_change_043056c1">当前模型：%1$s (点击更换)</string>
     <string name="l10n_coach_screen_provider_displayname_model_8b39f761">%1$s · %2$s</string>
@@ -318,6 +319,7 @@
     <string name="l10n_coach_screen_server_url_1d5d1eff">服务器 URL</string>
     <string name="l10n_coach_screen_suggested_prompt_prompt_379c0b15">建议提问：%1$s</string>
     <string name="l10n_coach_screen_thinking_a60d9c9c">思考中…</string>
+    <string name="l10n_coach_screen_use_bearer_for_most_local_servers_4429ab64">大多数本地服务器请使用 Bearer；如果网关要求将密钥放在该请求头中，请使用 x-api-key。</string>
     <string name="l10n_coach_screen_use_model_8d558ce2">使用模型</string>
     <string name="l10n_compare_screen_add_a_metric_to_compare_e6a7c9f1">添加要对比的指标</string>
     <string name="l10n_compare_screen_compare_8d105cf4">数据对比</string>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -337,6 +337,7 @@
     <string name="l10n_coach_screen_e_g_gpt_4o_1da2e4d2">e.g. gpt-4o</string>
     <string name="l10n_coach_screen_enter_any_model_id_the_provider_dce4bbcb">Enter any model id the provider accepts.</string>
     <string name="l10n_coach_screen_fetch_models_from_provider_6654e1a0">Fetch models from provider</string>
+    <string name="l10n_coach_screen_key_header_3f2a9b10">Key header</string>
     <string name="l10n_coach_screen_let_the_coach_use_my_data_405d1188">Let the coach use my data</string>
     <string name="l10n_coach_screen_model_selected_tap_to_change_043056c1">Model: %1$s. Tap to change.</string>
     <string name="l10n_coach_screen_provider_displayname_model_8b39f761">%1$s · %2$s</string>
@@ -346,6 +347,7 @@
     <string name="l10n_coach_screen_server_url_1d5d1eff">Server URL</string>
     <string name="l10n_coach_screen_suggested_prompt_prompt_379c0b15">Suggested prompt: %1$s</string>
     <string name="l10n_coach_screen_thinking_a60d9c9c">Thinking…</string>
+    <string name="l10n_coach_screen_use_bearer_for_most_local_servers_4429ab64">Use Bearer for most local servers; use x-api-key for gateways that require the key in that header.</string>
     <string name="l10n_coach_screen_use_model_8d558ce2">Use model</string>
     <string name="l10n_compare_screen_add_a_metric_to_compare_e6a7c9f1">Add a metric to compare</string>
     <string name="l10n_compare_screen_compare_8d105cf4">Compare</string>

--- a/android/app/src/test/java/com/noop/ai/CustomModelCatalogTest.kt
+++ b/android/app/src/test/java/com/noop/ai/CustomModelCatalogTest.kt
@@ -1,0 +1,43 @@
+package com.noop.ai
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class CustomModelCatalogTest {
+
+    @Test
+    fun `custom provider keeps gateway catalog models`() {
+        val body = """
+            {
+              "service": "Gateway",
+              "catalog": [
+                {"tool": "OpenAI", "models": ["gpt-5", "gpt-5.5"]},
+                {"tool": "Other", "models": ["claude-sonnet-4-6@default", "gpt-5"]}
+              ]
+            }
+        """.trimIndent()
+
+        assertEquals(
+            listOf("gpt-5", "gpt-5.5", "claude-sonnet-4-6@default"),
+            AiCoach.parseOpenAiCompatibleModels(AiProvider.CUSTOM, body),
+        )
+    }
+
+    @Test
+    fun `openai provider still filters data envelope to chat models`() {
+        val body = """
+            {
+              "data": [
+                {"id": "gpt-5"},
+                {"id": "o4-mini"},
+                {"id": "text-embedding-3-large"}
+              ]
+            }
+        """.trimIndent()
+
+        assertEquals(
+            listOf("gpt-5", "o4-mini"),
+            AiCoach.parseOpenAiCompatibleModels(AiProvider.OPENAI, body),
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- add a Custom AI Coach auth-header selector for Bearer vs x-api-key on Apple and Android
- use the selected header for Custom chat and model-list requests while keeping Bearer as the default
- parse catalog-shaped custom `/models` responses and add Android fallback to `max_completion_tokens`


Closes #765


## Verification
- `xcodegen generate && xcodebuild -project Strand.xcodeproj -scheme Strand -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO build`
- `xcodegen generate && xcodebuild -project Strand.xcodeproj -scheme Strand -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO -only-testing:StrandTests/AIProviderModelListTests test`
- `JAVA_HOME=/opt/homebrew/opt/openjdk@21 ANDROID_HOME=$HOME/Library/Android/sdk ./gradlew --dependency-verification lenient compileFullDebugKotlin`
- Android unit-test command was attempted, but this checkout currently fails compiling unrelated tests whose fake `DeviceRegistryDao` implementations do not implement `setModel`; app Kotlin compile passes.
