### PR TITLE
Derive `hrSample` from banked overnight IBI so an Oura night actually scores

### DIFF
--- a/Packages/OuraProtocol/Sources/OuraProtocol/OuraIbiHr.swift
+++ b/Packages/OuraProtocol/Sources/OuraProtocol/OuraIbiHr.swift
@@ -1,0 +1,43 @@
+import Foundation
+
+/// Derive `hrSample`-shaped HR from the ring's BANKED IBI (`OuraIBI`). The Oura ring banks overnight IBI
+/// (`0x60`/`0x80`/`0x6E`) but NO heart-rate stream, so an Oura night otherwise lands only in `rrInterval`
+/// — and the nightly analytics pipeline gates on `hrSample` (`resolveDayOwner`'s presence probe + the
+/// `hr.count >= 200` guard), so with zero overnight HR the day-owner falls back off the ring and the whole
+/// night scores NULL (no restingHr / HRV, and skin temp is gated behind the same probe). Materialising a
+/// per-record HR from the banked IBI unblocks that (issue #728).
+///
+/// Pure + fixture-tested. Called ONLY from the banked/history path (`OuraLiveSource.ingestHistory`); the
+/// live-HR push already emits its own `.hr`, so live HR is never double-counted here. Twin of the Kotlin
+/// `OuraIbiHr`.
+public enum OuraIbiHr {
+
+    /// One median HR per IBI-RECORD. Every IBI decoded from a single record carries that record's ring-time,
+    /// so grouping by `ringTimestamp` == grouping by record; `HR = round(60000 / median(IBI))` over the
+    /// record's PHYSIOLOGICAL beats (IBI 300..2000 ms), gated to a plausible 30..220 bpm. Records are
+    /// returned oldest-ring-time first. A record with no in-range beat, or whose median HR is implausible,
+    /// yields nothing (honest-data invariant: never a guessed beat). Grouping by ring-time also collapses a
+    /// record's 6-or-7 same-timestamped beats into ONE row, matching the `hrSample (deviceId, ts)` key.
+    public static func perRecordMedianHR(_ ibis: [OuraIBI]) -> [OuraHR] {
+        var byRingTime: [UInt32: [Int]] = [:]
+        for ibi in ibis where ibi.ibiMs >= 300 && ibi.ibiMs <= 2000 {
+            byRingTime[ibi.ringTimestamp, default: []].append(ibi.ibiMs)
+        }
+        var out: [OuraHR] = []
+        for rt in byRingTime.keys.sorted() {
+            guard let intervals = byRingTime[rt], !intervals.isEmpty else { continue }
+            let medIbi = Self.median(intervals)
+            let bpm = Int((60_000.0 / Double(medIbi)).rounded())
+            guard bpm >= 30 && bpm <= 220 else { continue }
+            out.append(OuraHR(ringTimestamp: rt, bpm: bpm, ibiMs: medIbi))
+        }
+        return out
+    }
+
+    /// Integer median (even count → mean of the two middle values). Input is copied + sorted.
+    static func median(_ xs: [Int]) -> Int {
+        let s = xs.sorted()
+        let n = s.count
+        return n % 2 == 1 ? s[n / 2] : (s[n / 2 - 1] + s[n / 2]) / 2
+    }
+}

--- a/Packages/OuraProtocol/Tests/OuraProtocolTests/OuraIbiHrTests.swift
+++ b/Packages/OuraProtocol/Tests/OuraProtocolTests/OuraIbiHrTests.swift
@@ -1,0 +1,45 @@
+import XCTest
+@testable import OuraProtocol
+
+/// Tests for deriving `hrSample`-shaped HR from banked IBI (#728). Kotlin twin: `OuraIbiHrTest`.
+final class OuraIbiHrTests: XCTestCase {
+
+    private func ibi(_ rt: UInt32, _ ms: Int) -> OuraIBI { OuraIBI(ringTimestamp: rt, ibiMs: ms) }
+
+    func testPerRecordMedianHRGroupsByRingTime() {
+        // rt=100: median(1000,1020,980)=1000 → 60 bpm. rt=200: median(900,910)=905 → 66 bpm.
+        let hr = OuraIbiHr.perRecordMedianHR([
+            ibi(100, 1000), ibi(100, 1020), ibi(100, 980), ibi(200, 900), ibi(200, 910),
+        ])
+        XCTAssertEqual(hr, [
+            OuraHR(ringTimestamp: 100, bpm: 60, ibiMs: 1000),
+            OuraHR(ringTimestamp: 200, bpm: 66, ibiMs: 905),
+        ])
+    }
+
+    func testSixBeatsOfOneRecordCollapseToOneRow() {
+        // A 0x60 record's 6 same-ring-time beats → ONE median HR (matches the hrSample (deviceId, ts) key).
+        let hr = OuraIbiHr.perRecordMedianHR((0..<6).map { ibi(500, 1000 + $0) })
+        XCTAssertEqual(hr.count, 1)
+        XCTAssertEqual(hr.first?.ringTimestamp, 500)
+    }
+
+    func testOutOfRangeIBIsExcludedFromMedian() {
+        // 100 ms and 3000 ms are non-physiological (outside 300..2000) → dropped; median{1000} → 60 bpm.
+        XCTAssertEqual(OuraIbiHr.perRecordMedianHR([ibi(1, 100), ibi(1, 1000), ibi(1, 3000)]),
+                       [OuraHR(ringTimestamp: 1, bpm: 60, ibiMs: 1000)])
+    }
+
+    func testRecordWithNoInRangeBeatYieldsNothing() {
+        XCTAssertTrue(OuraIbiHr.perRecordMedianHR([ibi(1, 100), ibi(1, 5000)]).isEmpty)
+    }
+
+    func testEmptyInput() {
+        XCTAssertTrue(OuraIbiHr.perRecordMedianHR([]).isEmpty)
+    }
+
+    func testReturnedOldestRingTimeFirst() {
+        XCTAssertEqual(OuraIbiHr.perRecordMedianHR([ibi(300, 1000), ibi(100, 1000), ibi(200, 1000)])
+                        .map { $0.ringTimestamp }, [100, 200, 300])
+    }
+}

--- a/Strand/BLE/OuraLiveSource.swift
+++ b/Strand/BLE/OuraLiveSource.swift
@@ -1127,6 +1127,23 @@ public final class OuraLiveSource: NSObject, ObservableObject {
                 persistHypnogramBurst(closed)
             }
         }
+        // #728: materialise `hrSample` from BANKED IBI. A batch with NO live-HR push (`.hr`) is history
+        // data — the ring banks overnight IBI (0x60/0x80/0x6E) but no HR, and the nightly pipeline gates on
+        // `hrSample` (day-owner probe + `hr.count >= 200`), so an Oura night otherwise never scores. Derive
+        // one median HR per IBI-record (`OuraIbiHr`) and enqueue it as `.hr` → the mapping writes
+        // `hrSample`, WITHOUT this switch's wear/live-badge side-effects (enqueue buffers for the mapping,
+        // it never re-enters ingest). Live batches ([.hr, .ibi]) are excluded, so live HR is never
+        // double-counted. Per-record ring-time anchored; an unanchored record is skipped (re-derived when
+        // it re-serves after the 0x42 anchor, exactly like the sibling `.ibi` rows).
+        let hasLiveHR = events.contains { if case .hr = $0 { return true } else { return false } }
+        if !hasLiveHR {
+            let bankedIbis: [OuraIBI] = events.compactMap { if case .ibi(let v) = $0 { return v } else { return nil } }
+            for hr in OuraIbiHr.perRecordMedianHR(bankedIbis) {
+                if let ts = driver.unixSeconds(forRingTimestamp: hr.ringTimestamp) {
+                    enqueue([.hr(hr)], ts: ts)
+                }
+            }
+        }
         for e in events {
             switch e {
             case .hr(let hr):

--- a/android/app/src/main/java/com/noop/ble/OuraLiveSource.kt
+++ b/android/app/src/main/java/com/noop/ble/OuraLiveSource.kt
@@ -29,6 +29,7 @@ import com.noop.oura.OuraDriver
 import com.noop.oura.OuraDriverPhase
 import com.noop.oura.OuraEvent
 import com.noop.oura.OuraFraming
+import com.noop.oura.OuraIbiHr
 import com.noop.oura.OuraGatt
 import com.noop.oura.OuraCommands
 import com.noop.oura.OuraDecoders
@@ -1532,6 +1533,21 @@ class OuraLiveSource(
             log("Oura: sleep-phase record codes=${phases.size} " +
                 "deep/light/rem/awake=${counts[0]}/${counts[1]}/${counts[2]}/${counts[3]}")
             hypnogramAssembler.feed(phases.first().ringTimestamp, phases)?.let { persistHypnogramBurst(it) }
+        }
+        // #728: materialise hrSample from BANKED IBI. A batch with NO live-HR push (Hr) is history data —
+        // the ring banks overnight IBI (0x60/0x80/0x6E) but no HR, and the nightly pipeline gates on
+        // hrSample (day-owner probe + hr.count >= 200), so an Oura night otherwise never scores. Derive one
+        // median HR per IBI-record (OuraIbiHr) and enqueue it as Hr → the mapping writes hrSample, WITHOUT
+        // this switch's wear/live-badge side-effects (enqueue buffers for the mapping, it never re-enters
+        // emit). Live batches ([Hr, Ibi]) are excluded, so live HR is never double-counted. Per-record
+        // ring-time anchored; an unanchored record is skipped (re-derived when it re-serves after 0x42).
+        val hasLiveHR = events.any { it is OuraEvent.Hr }
+        if (!hasLiveHR) {
+            val bankedIbis = events.mapNotNull { (it as? OuraEvent.Ibi)?.value }
+            for (hr in OuraIbiHr.perRecordMedianHR(bankedIbis)) {
+                val ts = d.unixSeconds(forRingTimestamp = hr.ringTimestamp)
+                if (ts != null) enqueue(listOf(OuraEvent.Hr(hr)), ts.toInt())
+            }
         }
         for (e in events) when (e) {
             is OuraEvent.Hr -> {

--- a/android/app/src/main/java/com/noop/oura/OuraIbiHr.kt
+++ b/android/app/src/main/java/com/noop/oura/OuraIbiHr.kt
@@ -1,0 +1,47 @@
+package com.noop.oura
+
+/**
+ * Derive `hrSample`-shaped HR from the ring's BANKED IBI ([OuraIBI]). The Oura ring banks overnight IBI
+ * (0x60/0x80/0x6E) but NO heart-rate stream, so an Oura night otherwise lands only in `rrInterval` — and
+ * the nightly analytics pipeline gates on `hrSample` (the day-owner presence probe + the `hr.count >= 200`
+ * guard), so with zero overnight HR the day-owner falls back off the ring and the whole night scores NULL
+ * (no restingHr / HRV, and skin temp is gated behind the same probe). Materialising a per-record HR from
+ * the banked IBI unblocks that (issue #728).
+ *
+ * Pure + fixture-tested. Called ONLY from the banked/history path (OuraLiveSource.ingestHistory); the
+ * live-HR push already emits its own `.hr`, so live HR is never double-counted here. Twin of the Swift
+ * OuraIbiHr.
+ */
+object OuraIbiHr {
+
+    /**
+     * One median HR per IBI-RECORD. Every IBI decoded from a single record carries that record's ring-time,
+     * so grouping by [OuraIBI.ringTimestamp] == grouping by record; `HR = round(60000 / median(IBI))` over
+     * the record's PHYSIOLOGICAL beats (IBI 300..2000 ms), gated to a plausible 30..220 bpm. Records are
+     * returned oldest-ring-time first. A record with no in-range beat, or whose median HR is implausible,
+     * yields nothing (honest-data invariant). Grouping by ring-time also collapses a record's 6-or-7
+     * same-timestamped beats into ONE row, matching the `hrSample (deviceId, ts)` key.
+     */
+    fun perRecordMedianHR(ibis: List<OuraIBI>): List<OuraHR> {
+        val byRingTime = HashMap<Long, MutableList<Int>>()
+        for (ibi in ibis) {
+            if (ibi.ibiMs in 300..2000) byRingTime.getOrPut(ibi.ringTimestamp) { ArrayList() }.add(ibi.ibiMs)
+        }
+        val out = ArrayList<OuraHR>()
+        for (rt in byRingTime.keys.sorted()) {
+            val intervals = byRingTime[rt] ?: continue
+            if (intervals.isEmpty()) continue
+            val medIbi = median(intervals)
+            val bpm = Math.round(60_000.0 / medIbi).toInt()
+            if (bpm in 30..220) out.add(OuraHR(ringTimestamp = rt, bpm = bpm, ibiMs = medIbi))
+        }
+        return out
+    }
+
+    /** Integer median (even count → mean of the two middle values). Input is copied + sorted. */
+    private fun median(xs: List<Int>): Int {
+        val s = xs.sorted()
+        val n = s.size
+        return if (n % 2 == 1) s[n / 2] else (s[n / 2 - 1] + s[n / 2]) / 2
+    }
+}

--- a/android/app/src/test/java/com/noop/oura/OuraIbiHrTest.kt
+++ b/android/app/src/test/java/com/noop/oura/OuraIbiHrTest.kt
@@ -1,0 +1,60 @@
+package com.noop.oura
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/** Tests for deriving hrSample-shaped HR from banked IBI (#728). Twin of Swift OuraIbiHrTests. */
+class OuraIbiHrTest {
+
+    private fun ibi(rt: Long, ms: Int) = OuraIBI(ringTimestamp = rt, ibiMs = ms)
+
+    @Test
+    fun perRecordMedianHRGroupsByRingTime() {
+        // rt=100: median(1000,1020,980)=1000 -> 60 bpm. rt=200: median(900,910)=905 -> 66 bpm.
+        val hr = OuraIbiHr.perRecordMedianHR(
+            listOf(ibi(100, 1000), ibi(100, 1020), ibi(100, 980), ibi(200, 900), ibi(200, 910)),
+        )
+        assertEquals(
+            listOf(
+                OuraHR(ringTimestamp = 100, bpm = 60, ibiMs = 1000),
+                OuraHR(ringTimestamp = 200, bpm = 66, ibiMs = 905),
+            ),
+            hr,
+        )
+    }
+
+    @Test
+    fun sixBeatsOfOneRecordCollapseToOneRow() {
+        val hr = OuraIbiHr.perRecordMedianHR((0 until 6).map { ibi(500, 1000 + it) })
+        assertEquals(1, hr.size)
+        assertEquals(500L, hr.first().ringTimestamp)
+    }
+
+    @Test
+    fun outOfRangeIBIsExcludedFromMedian() {
+        assertEquals(
+            listOf(OuraHR(ringTimestamp = 1, bpm = 60, ibiMs = 1000)),
+            OuraIbiHr.perRecordMedianHR(listOf(ibi(1, 100), ibi(1, 1000), ibi(1, 3000))),
+        )
+    }
+
+    @Test
+    fun recordWithNoInRangeBeatYieldsNothing() {
+        assertTrue(OuraIbiHr.perRecordMedianHR(listOf(ibi(1, 100), ibi(1, 5000))).isEmpty())
+    }
+
+    @Test
+    fun emptyInput() {
+        assertTrue(OuraIbiHr.perRecordMedianHR(emptyList()).isEmpty())
+    }
+
+    @Test
+    fun returnedOldestRingTimeFirst() {
+        assertEquals(
+            listOf(100L, 200L, 300L),
+            OuraIbiHr.perRecordMedianHR(listOf(ibi(300, 1000), ibi(100, 1000), ibi(200, 1000)))
+                .map { it.ringTimestamp },
+        )
+    }
+}


### PR DESCRIPTION
**Branch:** `fix/oura-ibi-hrsample` → `main`
**Closes / refs:** #728

## Problem

An Oura ring banks overnight IBI (`0x60`/`0x80`/`0x6E`) but **no heart-rate stream**, so an Oura night
lands only in `rrInterval`. The nightly analytics pipeline gates on `hrSample`:
- `resolveDayOwner`'s presence probe, and
- the `hr.count >= 200` guard.

With zero overnight HR the day-owner falls back **off the ring** and the whole night scores NULL — no
`restingHr`, no `avgHrv`, and skin temp (gated behind the same probe) never surfaces. Confirmed on
device: overnight `rrInterval` ~25k/night but `hrSample` **0**.

## Fix

Materialise **one median HR per IBI-record** as `hrSample`.

- `OuraIbiHr.perRecordMedianHR([OuraIBI]) -> [OuraHR]` (pure, both platforms). Every IBI decoded from a
  record shares that record's ring-time, so grouping by `ringTimestamp` == grouping by record.
  `HR = round(60000 / median(IBI))` over the record's physiological beats (IBI 300..2000 ms), gated to
  30..220 bpm. Grouping also collapses a record's 6-or-7 same-ts beats into ONE row, matching
  `hrSample`'s `(deviceId, ts)` key.
- Wired **only into the banked path**: in `ingest`/`emit`, a batch with **no** live-HR push (`.hr`) is
  history data (the live push always emits `[.hr, .ibi]` together), so live HR is never double-counted.
  The derived HR is enqueued as `.hr` → the mapping writes `hrSample`, but it does **not** pass through
  the `.hr` switch case, so it triggers no wear/live-badge side-effects.
- Per-record **ring-time anchored** (#677); an unanchored record is skipped and re-derived when it
  re-serves after the `0x42` anchor. `hrSample`'s `(deviceId, ts)` primary key makes re-drains
  idempotent.

`OuraHR`'s existing physiological gate and the live-HR path are untouched.

## Why this is honest (not fabricated HR)

The IBIs are real, Tier-A, per-beat intervals the ring already banks; `60000 / median(IBI)` is the
definitional beats-per-minute of that record — no model, no interpolation, no invented samples. It
simply exposes, as an HR row, a rate the `rrInterval` data already encodes. The pipeline can then score
the night the same way it scores any HR-bearing source.

## Cross-platform parity

Byte-identical Swift/Kotlin twins (`OuraIbiHr.swift` / `OuraIbiHr.kt`), fixture-tested on both:
grouping, median, IBI gate, 6-beats-collapse, ordering, empties.

## Verification

- `swift test` — **OuraProtocol** green incl. `OuraIbiHrTests` (6/0) after rebase onto current `main`.
- `Android compileFullDebugKotlin` OK; **macOS Strand BUILD SUCCEEDED** (app-target Swift touched in
  `OuraLiveSource`, which default CI does not compile).
- **Simulation-validated** vs the `0x5D` `hr_bpm` ground truth: median **52 vs 48**, RHR **p5 44 vs
  floor 46** — the derived per-record median tracks the ring's own reported HR.
- **Remaining on-device gate:** one overnight where the Oura night **scores** — skin temp / RHR / HRV
  populate instead of NULL. (WHOOP per-second HR is not available for a per-beat cross-check; the
  WHOOP import is per-day RHR only, so any further cross-check stays RHR-level. Option-2 follow-up —
  motion-gate / cross-record-median cleanup — is documented but out of scope for this PR.)