### PR TITLE
Android auto-detect: read HR over the active-strap union, not hardcoded my-whoop (#767)

### DIFF
--- a/android/app/src/main/java/com/noop/ui/AutoWorkoutNudge.kt
+++ b/android/app/src/main/java/com/noop/ui/AutoWorkoutNudge.kt
@@ -229,7 +229,11 @@ private suspend fun autoDetectCandidate(
     val fromSec = nowSec - AUTO_DETECT_DAYS_BACK * 86_400L
     val repo = viewModel.repo
 
-    val hr = repo.hrSamples(AUTO_DETECT_DEVICE, fromSec, nowSec, limit = 200_000)
+    // #767/#717: read HR over the ACTIVE-strap UNION, not the hardcoded "my-whoop" id. A live-BLE strap
+    // banks its raw under its OWN fresh id ("whoop-<uuid>", #908), so a read pinned to "my-whoop" finds
+    // NOTHING and auto-detect goes silent — even though sleep/charge (which read the union) keep working.
+    // Mirrors iOS Repository.autoDetectCandidate(), which reads the hrSamples(from:to:) union.
+    val hr = repo.hrSamplesUnion(viewModel.deviceId, fromSec, nowSec, limit = 200_000)
     if (hr.size < 2) return null
 
     // Resting HR: most recent nightly RHR in history, else the detector's own default (60). Byte-faithful


### PR DESCRIPTION
Fixes #767. Very likely also fixes #717 (same symptom, WHOOP 4.0 Android).

## Symptom
Workout **auto-detection silently stopped** for a user — no Today suggestion card, no post-workout popup — while **sleep, charge/recovery and everything else kept syncing and updating normally**. On the latest version.

## Root cause
`AutoWorkoutNudge.maybeDetect` read the detector's heart rate from a **hardcoded device id**:

```kotlin
val hr = repo.hrSamples(AUTO_DETECT_DEVICE, fromSec, nowSec, …)   // AUTO_DETECT_DEVICE = "my-whoop"
```

But a live-BLE strap banks its raw HR under its **own fresh id** (`"whoop-<uuid>"`, see #908), not `"my-whoop"`. So the read returned an empty series and `detect()` bailed immediately at `if (hr.size < 2) return null` — no windows, no card. Meanwhile sleep/charge/steps all read the **active-strap union** (`importedSourceIds(activeDeviceId)`), so they kept working. That asymmetry is exactly the reported symptom: everything syncs, only auto-detect is dead.

This is a leftover from the mid-July **"thread the active strap id"** migration (#175, #178/#191, #359, #512/#513) that moved sleep/charge/health and the iOS workout reads off hardcoded ids — but missed this one Android read.

## Fix
Read the same union everything else uses:

```kotlin
val hr = repo.hrSamplesUnion(viewModel.deviceId, fromSec, nowSec, …)
```

`hrSamplesUnion` reads `importedSourceIds(active) ∪ "my-whoop"`, deduped — the Kotlin twin of iOS `Repository.hrSamples(from:to:)`, which iOS `Repository.autoDetectCandidate()` already uses.

## Parity
**Android-only.** iOS was never affected — `autoDetectCandidate()` already reads the union. This brings Android to parity, per the "read the active strap id, not a hardcoded default" rule.

For **single-WHOOP installs** there's no behaviour change: `activeDeviceId` resolves to `"my-whoop"`, so the union is one id — a byte-identical read.

## Verification
- One-line data-plumbing fix; the pure `AutoWorkoutDetector` logic is unchanged (its tests still pass).
- App-target Android UI, so it isn't covered by default CI and I could not compile it on this host (`aapt2` is x86-only here). Please run `./gradlew compileFullDebugKotlin` before merge.
- Best confirmed on a live-BLE strap: with auto-detect on, a sustained workout should surface the Today suggestion card again.
