### PR TITLE
Fix Today score source badges

### DIFF
--- a/Packages/WhoopStore/Sources/WhoopStore/Database.swift
+++ b/Packages/WhoopStore/Sources/WhoopStore/Database.swift
@@ -564,6 +564,22 @@ extension WhoopStore {
                 t.primaryKey(["deviceId", "ts"])
             }
         }
+
+        // v29: provenance for NOOP-computed headline scores. This is deliberately separate from
+        // `dayOwnership`: ownership controls which device is allowed to supply a day's raw inputs,
+        // while this table records which source actually supplied each persisted computed metric.
+        // Metric-level keys keep mixed-source days honest and make missing legacy metadata explicit.
+        migrator.registerMigration("v29-score-input-provenance") { db in
+            try db.create(table: "scoreInputProvenance") { t in
+                t.column("deviceId", .text).notNull()   // computed "-noop" namespace
+                t.column("day", .text).notNull()
+                t.column("key", .text).notNull()
+                t.column("sourceId", .text).notNull()
+                t.primaryKey(["deviceId", "day", "key"])
+            }
+            try db.create(index: "idx_scoreInputProvenance_source",
+                          on: "scoreInputProvenance", columns: ["sourceId"])
+        }
         return migrator
     }
 }

--- a/Packages/WhoopStore/Sources/WhoopStore/DeviceRegistryStore.swift
+++ b/Packages/WhoopStore/Sources/WhoopStore/DeviceRegistryStore.swift
@@ -88,6 +88,7 @@ public struct DeviceRegistryStore: Sendable {
         "hrSample", "rrInterval", "spo2Sample", "skinTempSample", "respSample", "gravitySample",
         "stepSample", "ppgHrSample", "event", "battery", "dailyMetric", "sleepSession",
         "journal", "workout", "appleDaily", "metricSeries", "dayOwnership",
+        "scoreInputProvenance",
         // Added: device-keyed tables introduced by later migrations that the list previously missed, so a
         // "delete all of this device's data" left raw captures (rawBatch), user-entered lab/blood markers
         // (labMarker), banked band sleep-state (sleepStateSample) and live coaching sessions
@@ -118,6 +119,10 @@ public struct DeviceRegistryStore: Sendable {
             for table in Self.deviceScopedTables {
                 try db.execute(sql: "DELETE FROM \(table) WHERE deviceId = ?", arguments: [deviceId])
             }
+            // Provenance also references the physical/import source separately from its computed
+            // namespace. Forgetting a provider must remove those associations too.
+            try db.execute(sql: "DELETE FROM scoreInputProvenance WHERE sourceId = ?",
+                           arguments: [deviceId])
         }
     }
 

--- a/Packages/WhoopStore/Sources/WhoopStore/MetricSeriesStore.swift
+++ b/Packages/WhoopStore/Sources/WhoopStore/MetricSeriesStore.swift
@@ -30,19 +30,24 @@ extension WhoopStore {
     @discardableResult
     public func upsertMetricSeries(_ rows: [MetricPoint], deviceId: String) async throws -> Int {
         try syncWrite { db in
-            var n = 0
-            for r in rows {
-                try db.execute(sql: """
-                    INSERT INTO metricSeries
-                        (deviceId, day, key, value)
-                    VALUES (?, ?, ?, ?)
-                    ON CONFLICT(deviceId, day, key) DO UPDATE SET
-                        value = excluded.value
-                    """, arguments: [deviceId, r.day, r.key, r.value])
-                n += db.changesCount
-            }
-            return n
+            try Self.upsertMetricSeries(rows, deviceId: deviceId, in: db)
         }
+    }
+
+    /// Transaction-sharing primitive used by computed-score persistence.
+    static func upsertMetricSeries(_ rows: [MetricPoint], deviceId: String, in db: Database) throws -> Int {
+        var n = 0
+        for r in rows {
+            try db.execute(sql: """
+                INSERT INTO metricSeries
+                    (deviceId, day, key, value)
+                VALUES (?, ?, ?, ?)
+                ON CONFLICT(deviceId, day, key) DO UPDATE SET
+                    value = excluded.value
+                """, arguments: [deviceId, r.day, r.key, r.value])
+            n += db.changesCount
+        }
+        return n
     }
 
     // MARK: - Reads

--- a/Packages/WhoopStore/Sources/WhoopStore/MetricsCache.swift
+++ b/Packages/WhoopStore/Sources/WhoopStore/MetricsCache.swift
@@ -374,44 +374,50 @@ extension WhoopStore {
     @discardableResult
     public func upsertDailyMetrics(_ days: [DailyMetric], deviceId: String) async throws -> Int {
         try syncWrite { db in
-            var n = 0
-            for d in days {
-                try db.execute(sql: """
-                    INSERT INTO dailyMetric
-                        (deviceId, day, totalSleepMin, efficiency, deepMin, remMin, lightMin,
-                         disturbances, restingHr, avgHrv, recovery, strain, exerciseCount,
-                         spo2Pct, skinTempDevC, respRateBpm, steps, activeKcalEst,
-                         spo2Red, spo2Ir)
-                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-                    ON CONFLICT(deviceId, day) DO UPDATE SET
-                        totalSleepMin = excluded.totalSleepMin,
-                        efficiency = excluded.efficiency,
-                        deepMin = excluded.deepMin,
-                        remMin = excluded.remMin,
-                        lightMin = excluded.lightMin,
-                        disturbances = excluded.disturbances,
-                        restingHr = excluded.restingHr,
-                        avgHrv = excluded.avgHrv,
-                        recovery = excluded.recovery,
-                        strain = excluded.strain,
-                        exerciseCount = excluded.exerciseCount,
-                        spo2Pct = excluded.spo2Pct,
-                        skinTempDevC = excluded.skinTempDevC,
-                        respRateBpm = excluded.respRateBpm,
-                        steps = excluded.steps,
-                        activeKcalEst = excluded.activeKcalEst,
-                        spo2Red = excluded.spo2Red,
-                        spo2Ir = excluded.spo2Ir
-                    """, arguments: [deviceId, d.day, d.totalSleepMin, d.efficiency, d.deepMin,
-                                     d.remMin, d.lightMin, d.disturbances, d.restingHr, d.avgHrv,
-                                     d.recovery, d.strain, d.exerciseCount,
-                                     d.spo2Pct, d.skinTempDevC, d.respRateBpm,
-                                     d.steps, d.activeKcalEst,
-                                     d.spo2Red, d.spo2Ir])
-                n += db.changesCount
-            }
-            return n
+            try Self.upsertDailyMetrics(days, deviceId: deviceId, in: db)
         }
+    }
+
+    /// Transaction-sharing primitive used by computed-score persistence. Keeping the SQL here ensures
+    /// ordinary cache writes and score+provenance writes cannot drift.
+    static func upsertDailyMetrics(_ days: [DailyMetric], deviceId: String, in db: Database) throws -> Int {
+        var n = 0
+        for d in days {
+            try db.execute(sql: """
+                INSERT INTO dailyMetric
+                    (deviceId, day, totalSleepMin, efficiency, deepMin, remMin, lightMin,
+                     disturbances, restingHr, avgHrv, recovery, strain, exerciseCount,
+                     spo2Pct, skinTempDevC, respRateBpm, steps, activeKcalEst,
+                     spo2Red, spo2Ir)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT(deviceId, day) DO UPDATE SET
+                    totalSleepMin = excluded.totalSleepMin,
+                    efficiency = excluded.efficiency,
+                    deepMin = excluded.deepMin,
+                    remMin = excluded.remMin,
+                    lightMin = excluded.lightMin,
+                    disturbances = excluded.disturbances,
+                    restingHr = excluded.restingHr,
+                    avgHrv = excluded.avgHrv,
+                    recovery = excluded.recovery,
+                    strain = excluded.strain,
+                    exerciseCount = excluded.exerciseCount,
+                    spo2Pct = excluded.spo2Pct,
+                    skinTempDevC = excluded.skinTempDevC,
+                    respRateBpm = excluded.respRateBpm,
+                    steps = excluded.steps,
+                    activeKcalEst = excluded.activeKcalEst,
+                    spo2Red = excluded.spo2Red,
+                    spo2Ir = excluded.spo2Ir
+                """, arguments: [deviceId, d.day, d.totalSleepMin, d.efficiency, d.deepMin,
+                                 d.remMin, d.lightMin, d.disturbances, d.restingHr, d.avgHrv,
+                                 d.recovery, d.strain, d.exerciseCount,
+                                 d.spo2Pct, d.skinTempDevC, d.respRateBpm,
+                                 d.steps, d.activeKcalEst,
+                                 d.spo2Red, d.spo2Ir])
+            n += db.changesCount
+        }
+        return n
     }
 
     /// Delete a source's cached daily rows whose day-key is in [from, to] (inclusive, yyyy-MM-dd

--- a/Packages/WhoopStore/Sources/WhoopStore/ScoreInputProvenanceStore.swift
+++ b/Packages/WhoopStore/Sources/WhoopStore/ScoreInputProvenanceStore.swift
@@ -1,0 +1,58 @@
+import Foundation
+import GRDB
+
+/// The source whose inputs produced one persisted NOOP-computed score.
+/// Natural key: (computed device namespace, day, metric key).
+public struct ScoreInputProvenanceRow: Equatable, Codable, Sendable {
+    public let day: String
+    public let key: String
+    public let sourceId: String
+
+    public init(day: String, key: String, sourceId: String) {
+        self.day = day
+        self.key = key
+        self.sourceId = sourceId
+    }
+}
+
+extension WhoopStore {
+    /// Persist computed daily/series scores and their input provenance in one SQLite transaction.
+    /// Replacing provenance for the whole scoring window prevents stale attribution when a metric
+    /// disappears or changes provider. Any write failure rolls back both scores and metadata.
+    public func persistComputedScores(
+        dailyMetrics: [DailyMetric],
+        metricPoints: [MetricPoint],
+        provenance: [ScoreInputProvenanceRow],
+        deviceId: String,
+        from: String,
+        to: String
+    ) async throws {
+        try syncWrite { db in
+            _ = try Self.upsertDailyMetrics(dailyMetrics, deviceId: deviceId, in: db)
+            _ = try Self.upsertMetricSeries(metricPoints, deviceId: deviceId, in: db)
+
+            try db.execute(sql: """
+                DELETE FROM scoreInputProvenance
+                WHERE deviceId = ? AND day >= ? AND day <= ?
+                """, arguments: [deviceId, from, to])
+            for row in provenance {
+                try db.execute(sql: """
+                    INSERT INTO scoreInputProvenance (deviceId, day, key, sourceId)
+                    VALUES (?, ?, ?, ?)
+                    ON CONFLICT(deviceId, day,key) DO UPDATE SET sourceId = excluded.sourceId
+                    """, arguments: [deviceId, row.day, row.key, row.sourceId])
+            }
+        }
+    }
+
+    /// Input source for one computed score. Missing means the score predates provenance storage or its
+    /// attribution could not be persisted; callers must omit the badge instead of guessing.
+    public func scoreInputSource(deviceId: String, day: String, key: String) async throws -> String? {
+        try syncRead { db in
+            try String.fetchOne(db, sql: """
+                SELECT sourceId FROM scoreInputProvenance
+                WHERE deviceId = ? AND day = ? AND key = ?
+                """, arguments: [deviceId, day, key])
+        }
+    }
+}

--- a/Packages/WhoopStore/Tests/WhoopStoreTests/ScoreInputProvenanceStoreTests.swift
+++ b/Packages/WhoopStore/Tests/WhoopStoreTests/ScoreInputProvenanceStoreTests.swift
@@ -1,0 +1,93 @@
+import XCTest
+@testable import WhoopStore
+
+final class ScoreInputProvenanceStoreTests: XCTestCase {
+    func testMigrationCreatesMetricLevelTableAndIndex() async throws {
+        let store = try await WhoopStore.inMemory()
+        let tables = try await store.tableNames()
+        let primaryKey = try await store.primaryKeyColumns("scoreInputProvenance")
+        let indexes = try await store.indexNamesForTest(table: "scoreInputProvenance")
+        XCTAssertTrue(tables.contains("scoreInputProvenance"))
+        XCTAssertEqual(primaryKey, ["deviceId", "day", "key"])
+        XCTAssertTrue(indexes.contains("idx_scoreInputProvenance_source"))
+    }
+
+    func testComputedScoresAndProvenancePersistTogether() async throws {
+        let store = try await WhoopStore.inMemory()
+        let daily = makeDaily(day: "2026-07-24", recovery: 71, strain: 42)
+        let rest = MetricPoint(day: daily.day, key: "sleep_performance", value: 83)
+        let provenance = [
+            ScoreInputProvenanceRow(day: daily.day, key: "recovery", sourceId: "polar-1"),
+            ScoreInputProvenanceRow(day: daily.day, key: "strain", sourceId: "polar-1"),
+            ScoreInputProvenanceRow(day: daily.day, key: "sleep_performance", sourceId: "polar-1"),
+        ]
+
+        try await store.persistComputedScores(
+            dailyMetrics: [daily],
+            metricPoints: [rest],
+            provenance: provenance,
+            deviceId: "my-whoop-noop",
+            from: daily.day,
+            to: daily.day
+        )
+
+        let storedDaily = try await store.dailyMetrics(
+            deviceId: "my-whoop-noop", from: daily.day, to: daily.day
+        )
+        let source = try await store.scoreInputSource(
+            deviceId: "my-whoop-noop", day: daily.day, key: "recovery"
+        )
+        XCTAssertEqual(storedDaily.first?.recovery, 71)
+        XCTAssertEqual(source, "polar-1")
+    }
+
+    func testReplacingWindowRemovesProvenanceForMissingMetric() async throws {
+        let store = try await WhoopStore.inMemory()
+        let day = "2026-07-24"
+        try await store.persistComputedScores(
+            dailyMetrics: [makeDaily(day: day, recovery: 71, strain: 42)],
+            metricPoints: [],
+            provenance: [
+                .init(day: day, key: "recovery", sourceId: "polar-1"),
+                .init(day: day, key: "strain", sourceId: "polar-1"),
+            ],
+            deviceId: "my-whoop-noop",
+            from: day,
+            to: day
+        )
+        try await store.persistComputedScores(
+            dailyMetrics: [makeDaily(day: day, recovery: 72, strain: nil)],
+            metricPoints: [],
+            provenance: [.init(day: day, key: "recovery", sourceId: "oura-api")],
+            deviceId: "my-whoop-noop",
+            from: day,
+            to: day
+        )
+
+        let recoverySource = try await store.scoreInputSource(
+            deviceId: "my-whoop-noop", day: day, key: "recovery"
+        )
+        let strainSource = try await store.scoreInputSource(
+            deviceId: "my-whoop-noop", day: day, key: "strain"
+        )
+        XCTAssertEqual(recoverySource, "oura-api")
+        XCTAssertNil(strainSource)
+    }
+
+    private func makeDaily(day: String, recovery: Double?, strain: Double?) -> DailyMetric {
+        DailyMetric(
+            day: day,
+            totalSleepMin: nil,
+            efficiency: nil,
+            deepMin: nil,
+            remMin: nil,
+            lightMin: nil,
+            disturbances: nil,
+            restingHr: nil,
+            avgHrv: nil,
+            recovery: recovery,
+            strain: strain,
+            exerciseCount: nil
+        )
+    }
+}

--- a/Strand/Data/IntelligenceEngine.swift
+++ b/Strand/Data/IntelligenceEngine.swift
@@ -793,6 +793,7 @@ final class IntelligenceEngine: ObservableObject {
         // side uses; when they DIVERGE on a day that has data, that's the #814 read/write split made
         // visible in every export.
         var readOwnerByDay: [String: (owner: String, hrRows: Int)] = [:]
+        var resolvedScoreOwnerByDay: [String: String] = [:]
 
         // Back on the main actor: fold the off-actor results into the pass-2 state in the SAME order the
         // loop produced them. Pure assignment / appends , no further store reads , so this is cheap and the
@@ -800,6 +801,7 @@ final class IntelligenceEngine: ObservableObject {
         for scan in scanned {
             let res = scan.result
             readOwnerByDay[res.daily.day] = (scan.readOwner, scan.hrRows)
+            resolvedScoreOwnerByDay[res.daily.day] = scan.readOwner
             nightlyHrvByDay[res.daily.day] = res.daily.avgHrv
             nightlyRhrByDay[res.daily.day] = res.daily.restingHr.map(Double.init)
             nightlyRespByDay[res.daily.day] = res.daily.respRateBpm
@@ -1147,6 +1149,7 @@ final class IntelligenceEngine: ObservableObject {
                 let scored = row.with(recovery: recovery, skinTempDevC: row.skinTempDevC)
                 dailies.append(scored)
                 importScoredDays.insert(w.day)
+                resolvedScoreOwnerByDay[w.day] = source
                 if let rest = AnalyticsEngine.Rest.composite(daily: scored) {
                     restPoints.append(MetricPoint(day: w.day, key: "sleep_performance", value: rest))
                 }
@@ -1166,8 +1169,34 @@ final class IntelligenceEngine: ObservableObject {
         // Fitness Age gate can't be undercut by this pass's own scoring/eviction. Windowed to the range.
         let faPriorDaily = await repo.dailyMetrics(fromDay: oldestDay, toDay: newestDay)
 
-        // Upsert FIRST so the row count never transiently dips (#521).
-        if !dailies.isEmpty { _ = try? await store.upsertDailyMetrics(dailies, deviceId: computedId) }
+        // Score provenance is metric-specific and lives outside dayOwnership (which remains solely a
+        // resolver override). Persist scores + provenance atomically so a failed write can never label an
+        // older score with a newer provider. The last row for a duplicate day wins, matching the upsert.
+        var provenanceByCell: [String: ScoreInputProvenanceRow] = [:]
+        for daily in dailies {
+            guard let source = resolvedScoreOwnerByDay[daily.day] else { continue }
+            if daily.recovery != nil {
+                provenanceByCell["\(daily.day)\u{1F}recovery"] =
+                    ScoreInputProvenanceRow(day: daily.day, key: "recovery", sourceId: source)
+            }
+            if daily.strain != nil {
+                provenanceByCell["\(daily.day)\u{1F}strain"] =
+                    ScoreInputProvenanceRow(day: daily.day, key: "strain", sourceId: source)
+            }
+        }
+        for point in restPoints {
+            guard let source = resolvedScoreOwnerByDay[point.day] else { continue }
+            provenanceByCell["\(point.day)\u{1F}\(point.key)"] =
+                ScoreInputProvenanceRow(day: point.day, key: point.key, sourceId: source)
+        }
+        try? await store.persistComputedScores(
+            dailyMetrics: dailies,
+            metricPoints: restPoints,
+            provenance: Array(provenanceByCell.values),
+            deviceId: computedId,
+            from: oldestDay,
+            to: newestDay
+        )
 
         // Now evict only the STALE computed rows in the window , those a prior (e.g. UTC-keyed) run left
         // behind that the current local-keyed run no longer produces. Read the window, diff against the
@@ -1179,8 +1208,6 @@ final class IntelligenceEngine: ObservableObject {
         for stale in existingWindow where !freshKeys.contains(stale.day) {
             _ = try? await store.deleteDailyMetrics(deviceId: computedId, from: stale.day, to: stale.day)
         }
-        if !restPoints.isEmpty { _ = try? await store.upsertMetricSeries(restPoints, deviceId: computedId) }
-
         // ── Fitness Age (Phase 2) , weekly, keyed to the week's Saturday ────────────────────────────
         // Roll the last 7 computed days into the Nes/HUNT inputs and upsert a weekly Fitness Age (+ an
         // optional VO₂max when a waist is set) under the same "-noop" source. Idempotent on the Saturday

--- a/Strand/Data/Repository.swift
+++ b/Strand/Data/Repository.swift
@@ -59,6 +59,14 @@ struct MetricSeriesResolution: Equatable, Sendable {
     }
 }
 
+/// The sensor/import provider whose inputs produced a resolved Today score. `sourceId` is durable and
+/// `brand` comes from the paired-device registry when available, so UI code can name every supported
+/// provider without guessing from opaque device ids.
+struct ScoreInputProvider: Equatable, Sendable {
+    let sourceId: String
+    let brand: String?
+}
+
 /// Source provenance for daily rows before product surfaces merge them. The UI uses this to say
 /// where a vital came from without changing the stored data.
 enum DailyMetricSource: Equatable {
@@ -1695,14 +1703,26 @@ final class Repository: ObservableObject {
     /// regardless of `days`; false (the default) honours `days` exactly as before, so existing callers are
     /// byte-identical.
     func resolvedSeries(key: String, source preferredSource: String, days: Int = 4000, fullHistory: Bool = false) async -> MetricSeriesResolution {
+        let now = Date()
+        let from = fullHistory ? "0000-01-01" : Self.dayString(now.addingTimeInterval(-Double(days) * 86_400))
+        let to = fullHistory ? "9999-12-31" : Self.dayString(now.addingTimeInterval(86_400))
+        return await resolvedSeries(key: key, source: preferredSource, from: from, to: to)
+    }
+
+    /// Exact-window variant used when a UI needs a known historical day (for example Charge carry).
+    /// This avoids guessing a relative lookback and keeps the same source precedence as the public
+    /// trailing-window resolver.
+    func resolvedSeries(
+        key: String,
+        source preferredSource: String,
+        from: String,
+        to: String
+    ) async -> MetricSeriesResolution {
         let candidates = Self.sourceCandidates(forKey: key, preferredSource: preferredSource,
                                                actualWhoopSource: deviceId)
         guard let store = await ensureStore() else {
             return MetricSeriesResolution(requestedSource: preferredSource, candidates: candidates, points: [])
         }
-        let now = Date()
-        let from = fullHistory ? "0000-01-01" : Self.dayString(now.addingTimeInterval(-Double(days) * 86_400))
-        let to = fullHistory ? "9999-12-31" : Self.dayString(now.addingTimeInterval(86_400))
 
         // First candidate wins per day; later candidates only fill days no earlier one covered.
         var byDay: [String: ResolvedMetricPoint] = [:]
@@ -1715,6 +1735,31 @@ final class Repository: ObservableObject {
         }
         let points = byDay.values.sorted { $0.day < $1.day }
         return MetricSeriesResolution(requestedSource: preferredSource, candidates: candidates, points: points)
+    }
+
+    /// Resolve a displayed score back to the provider that supplied its inputs. Direct imported points
+    /// already name their provider. A `-noop` point is looked up in the dedicated metric-level provenance
+    /// cache; missing legacy metadata returns nil rather than falsely claiming its parent device.
+    func scoreInputProvider(
+        resolvedSource: String,
+        day: String,
+        metricKey: String
+    ) async -> ScoreInputProvider? {
+        guard let store = await ensureStore() else { return nil }
+        let registry = DeviceRegistryStore(dbQueue: store.registryWriter)
+        let sourceId: String
+        if resolvedSource.hasSuffix("-noop") {
+            guard let cached = try? await store.scoreInputSource(
+                deviceId: resolvedSource,
+                day: day,
+                key: metricKey
+            ) else { return nil }
+            sourceId = cached
+        } else {
+            sourceId = resolvedSource
+        }
+        let brand = (try? registry.all())?.first(where: { $0.id == sourceId })?.brand
+        return ScoreInputProvider(sourceId: sourceId, brand: brand)
     }
 
     /// Read one candidate's rows for the window: its metricSeries, plus the matching DailyMetric column

--- a/Strand/Liquid/LiquidTodayView.swift
+++ b/Strand/Liquid/LiquidTodayView.swift
@@ -32,9 +32,8 @@ struct LiquidTodayView: View {
 
     // async-loaded via the confirmed Repository accessors
     @State private var restScore: Double?          // sleep_performance, day-keyed
-    /// Raw resolver source ids for the three scores, keyed by recovery / strain / sleep_performance.
-    /// Presentation uses Today's shared mapper so Liquid and Classic name a source consistently.
-    @State private var heroProvenanceByMetric: [String: String] = [:]
+    /// Input providers for the three scores, keyed by recovery / strain / sleep_performance.
+    @State private var heroProviderByMetric: [String: ScoreInputProvider] = [:]
     @State private var stress: Double?             // StressModel(...).score, 0–3
     @State private var fitnessAge: Double?         // exploreSeries("fitness_age").last
     @State private var vitality: Double?           // exploreSeries("vitality").last
@@ -520,14 +519,10 @@ struct LiquidTodayView: View {
                 .overlay(alignment: .top) {
                     if let sourceLabel = heroSourceLabel {
                         SourceBadge("\(sourceLabel)", tint: StrandPalette.onDarkSecondary)
-                            // Match the badge's trailing edge to the fixed-width Rest vessel on every card
-                            // width, then lift by the space4 gap above the cells so the badge's TOP sits on
-                            // the card's top edge — tucked into the top-right corner. (#486: the old
-                            // "+ half the badge height" centred it ON the border, reading as a pill floating
-                            // detached above the card; two users flagged it. Twin of Android TodayScreen.)
+                            // Match the badge's trailing edge to the Rest vessel and centre it on the card border.
                             .fixedSize()
                             .frame(width: HeroScoreCell.vesselDiameter, alignment: .trailing)
-                            .offset(y: -NoopMetrics.space4)
+                            .offset(y: -(NoopMetrics.space4 + NoopMetrics.sourceBadgeHeight / 2))
                             .allowsHitTesting(false)
                             .accessibilityLabel(Text("Source: \(sourceLabel)"))
                     }
@@ -1076,12 +1071,15 @@ struct LiquidTodayView: View {
                                                dayKeys: repo.days.map(\.day),
                                                hasRecovery: day?.recovery != nil)
             : nil
+        let priorScored = TodayView.lastScoredRecoveryDay(
+            days: repo.days, selectedDayKey: tkey,
+            isToday: selectedDayOffset == 0,
+            todayScored: day?.recovery != nil,
+            isCalibrating: calNights != nil
+        )
         cachedChargeDisplay = ChargeDisplay.resolve(
             todayRecovery: day?.recovery,
-            priorScored: TodayView.lastScoredRecoveryDay(days: repo.days, selectedDayKey: tkey,
-                                                         isToday: selectedDayOffset == 0,
-                                                         todayScored: day?.recovery != nil,
-                                                         isCalibrating: calNights != nil),
+            priorScored: priorScored,
             calibrationNights: calNights,
             todayKey: tkey)
 
@@ -1102,15 +1100,16 @@ struct LiquidTodayView: View {
         async let hrA = repo.hrBuckets(from: from, to: to, bucketSeconds: 300)
         async let wkA = repo.workoutRows()
         // Ask the same cross-source resolver the Classic Today view uses which source actually won each
-        // displayed score. Limit the read to the selected-day window instead of scanning full history.
+        // displayed score. Include the exact carried-Charge day; a fixed relative lookback can miss a
+        // legitimately old carried score.
         let sourceDayKey = selectedDayKey
-        let sourceLookback = max(2, selectedDayOffset + 2)
+        let sourceFromDay = min(sourceDayKey, priorScored?.day ?? sourceDayKey)
         async let chargeSourceA = repo.resolvedSeries(key: "recovery", source: Repository.whoopSource,
-                                                      days: sourceLookback)
+                                                      from: sourceFromDay, to: sourceDayKey)
         async let effortSourceA = repo.resolvedSeries(key: "strain", source: Repository.whoopSource,
-                                                      days: sourceLookback)
+                                                      from: sourceDayKey, to: sourceDayKey)
         async let restSourceA = repo.resolvedSeries(key: "sleep_performance", source: Repository.whoopSource,
-                                                    days: sourceLookback)
+                                                    from: sourceDayKey, to: sourceDayKey)
 
         let restSeries = await restA
         let stepsSeries = await stepsA
@@ -1193,13 +1192,22 @@ struct LiquidTodayView: View {
             ("strain", effortSource),
             ("sleep_performance", restSource),
         ]
-        var provenance: [String: String] = [:]
+        var providers: [String: ScoreInputProvider] = [:]
         for (metric, resolution) in sourceResolutions {
-            if let winner = resolution.points.last(where: { $0.day == sourceDayKey })?.source {
-                provenance[metric] = winner
+            let selectedPoint = resolution.points.last(where: { $0.day == sourceDayKey })
+            let winner = selectedPoint
+                ?? (metric == "recovery"
+                    ? priorScored.flatMap { prior in resolution.points.last(where: { $0.day == prior.day }) }
+                    : nil)
+            if let winner {
+                providers[metric] = await repo.scoreInputProvider(
+                    resolvedSource: winner.source,
+                    day: winner.day,
+                    metricKey: metric
+                )
             }
         }
-        heroProvenanceByMetric = provenance
+        heroProviderByMetric = providers
 
         // First load done — bring the hero gauges + sky to life now the launch churn has settled.
         if !dataLoaded { withAnimation(.easeIn(duration: 0.4)) { dataLoaded = true } }
@@ -1218,18 +1226,19 @@ struct LiquidTodayView: View {
     /// two distinct winners in Charge / Effort / Rest order so the compact badge stays readable.
     private var heroSourceLabel: String? {
         Self.heroSourceLabel(
-            rawSources: ["recovery", "strain", "sleep_performance"].compactMap { heroProvenanceByMetric[$0] },
-            deviceId: repo.deviceId)
+            providers: ["recovery", "strain", "sleep_performance"].compactMap { heroProviderByMetric[$0] })
     }
 
-    /// Pure aggregation seam for the Liquid hero. The existing Today mapper turns computed siblings into
-    /// "On-device", the Apple Health source into "Apple Watch", and imported strap rows into "Whoop".
-    static func heroSourceLabel(rawSources: [String], deviceId: String) -> String? {
+    /// Pure aggregation seam for the Liquid hero. The provider mapper names the sensors/imports that
+    /// supplied the score inputs; identical names collapse and the compact badge is capped at two.
+    static func heroSourceLabel(providers: [ScoreInputProvider]) -> String? {
         var seen = Set<String>()
         var labels: [String] = []
-        for raw in rawSources {
-            let label = TodayView.todayProvenanceChipLabel(
-                rawSource: raw, deviceId: deviceId, appleHealthSource: Repository.appleHealthSource)
+        for provider in providers {
+            let label = TodayView.todayScoreProviderLabel(
+                sourceId: provider.sourceId,
+                brand: provider.brand
+            )
             if seen.insert(label).inserted { labels.append(label) }
             if labels.count == 2 { break }
         }

--- a/Strand/Screens/TodayView.swift
+++ b/Strand/Screens/TodayView.swift
@@ -271,13 +271,11 @@ struct TodayView: View {
     // tile previously showed hours where the score belonged (#248). nil until loaded / no night yet.
     @State private var restScore: Double?
 
-    // Component 4, the REAL per-day merge winner (provenance) for the selected day's derived scores,
-    // keyed by metric key ("recovery" / "sleep_performance"); the value is the raw source id the resolver
-    // returned (e.g. "my-whoop", "my-whoop-noop", "apple-health"). Resolved once per load via
-    // `resolvedSeries` (the same imported-WHOOP > NOOP-computed > Apple-Health precedence the dashboard
-    // merge uses), so a provenance badge reflects which source actually supplied that day's number rather
-    // than a blanket "on-device" claim. Absent until loaded / when a day has no value. (spec 2026-06-20)
+    // The raw per-day merge winners remain available for watch-specific confidence behavior.
     @State private var provenanceByMetric: [String: String] = [:]
+    /// The sensor/import provider behind each score cell. Computed rows without durable provenance are
+    /// omitted rather than guessed; direct imported rows always resolve.
+    @State private var providerByMetric: [String: ScoreInputProvider] = [:]
 
     // On-device steps ESTIMATE per day (key "steps_est", computed "-noop" source). The Steps tile
     // prefers a REAL step count (strap @57 counter / Apple Health); only when a day has neither does it
@@ -748,13 +746,10 @@ struct TodayView: View {
 
     // MARK: Component 4, provenance badge (the real per-day merge winner)
 
-    /// The display name for a derived score's per-day merge winner ("On-device" / "Whoop" / "Apple
-    /// Health"), or nil when no source supplied that metric for the selected day (the badge is then
-    /// hidden rather than guessing). Delegates to the PURE `provenanceDisplayLabel` mapper so the
-    /// raw-source-id → spec-label mapping unit-tests without the live view.
+    /// The provider name behind a derived score, or nil when the attribution is unavailable.
     private func provenanceLabel(_ metricKey: String) -> String? {
-        guard let raw = provenanceByMetric[metricKey] else { return nil }
-        return Self.provenanceDisplayLabel(rawSource: raw, deviceId: repo.deviceId)
+        guard let provider = providerByMetric[metricKey] else { return nil }
+        return Self.todayScoreProviderLabel(sourceId: provider.sourceId, brand: provider.brand)
     }
 
     /// PURE mapper (unit-testable), a raw resolver source id onto the spec's provenance labels, given
@@ -806,6 +801,29 @@ struct TodayView: View {
     static func todayProvenanceChipLabel(rawSource: String, deviceId: String, appleHealthSource: String) -> String {
         if rawSource == appleHealthSource { return "Apple Watch" }
         return provenanceDisplayLabel(rawSource: rawSource, deviceId: deviceId)
+    }
+
+    /// Today hero wording names the provider that supplied the score inputs, not where NOOP ran the math.
+    /// Registered device brands cover every live source; stable import ids cover providers without a paired
+    /// registry row. Unknown ids remain visible rather than being falsely labelled as Whoop.
+    static func todayScoreProviderLabel(sourceId: String, brand: String?) -> String {
+        let source = sourceId.lowercased()
+        switch source {
+        case Repository.appleHealthSource: return "Apple Watch"
+        case Repository.healthConnectSource: return "Health Connect"
+        case "oura-import", "oura-api": return "Oura"
+        case "fitbit-import": return "Fitbit"
+        case "garmin-import": return "Garmin"
+        case "xiaomi-band": return "Mi Band"
+        case Repository.activityFileSource: return "Workout files"
+        default: break
+        }
+
+        if let brand = brand?.trimmingCharacters(in: .whitespacesAndNewlines), !brand.isEmpty {
+            return brand.caseInsensitiveCompare("WHOOP") == .orderedSame ? "Whoop" : brand
+        }
+        if source == Repository.whoopSource { return "Whoop" }
+        return FusionSource(rawValue: sourceId)?.displayName ?? sourceId
     }
 
     /// True for a watch-context user with no strap supplying scores (Apple-Health days present and no WHOOP
@@ -3833,6 +3851,7 @@ struct TodayView: View {
         sparks["sleep_performance"] = c.restSpark
         restScore = c.restScore
         provenanceByMetric = c.provenanceByMetric
+        providerByMetric = c.providerByMetric
         hrPoints = c.hrPoints
         stepActivityClassToday = c.stepActivityClassToday
         liveTodayStrain = c.liveTodayStrain
@@ -3930,21 +3949,30 @@ struct TodayView: View {
             todayKey: selectedDayKey)
         restScore = restScoreLocal
 
-        // Component 4, resolve the REAL per-day merge winner for the selected day's derived scores. The
-        // cross-source resolver applies the SAME imported-WHOOP > NOOP-computed > Apple-Health precedence
-        // the dashboard merge uses, returning the source that actually supplied each day's value, so the
-        // provenance badge reflects the truth (computed vs imported), never a blanket "on-device". Keyed by
-        // metric so the Charge ring and Rest tile each badge their own winner.
+        // Resolve the displayed score row, then map computed rows through durable input provenance so the
+        // badge names the sensor/import provider rather than the device that ran NOOP's math.
         var provenance: [String: String] = [:]
+        var providers: [String: ScoreInputProvider] = [:]
         let recoveryResolved = await recoveryResolvedA
-        if let win = recoveryResolved.points.last(where: { $0.day == selectedDayKey })?.source {
-            provenance["recovery"] = win
+        if let win = recoveryResolved.points.last(where: { $0.day == selectedDayKey }) {
+            provenance["recovery"] = win.source
+            providers["recovery"] = await repo.scoreInputProvider(
+                resolvedSource: win.source,
+                day: win.day,
+                metricKey: "recovery"
+            )
         }
         let restResolved = await restResolvedA
-        if let win = restResolved.points.last(where: { $0.day == selectedDayKey })?.source {
-            provenance["sleep_performance"] = win
+        if let win = restResolved.points.last(where: { $0.day == selectedDayKey }) {
+            provenance["sleep_performance"] = win.source
+            providers["sleep_performance"] = await repo.scoreInputProvider(
+                resolvedSource: win.source,
+                day: win.day,
+                metricKey: "sleep_performance"
+            )
         }
         provenanceByMetric = provenance
+        providerByMetric = providers
 
         // HR trend for the SELECTED day, 5-minute bucket means from that logical day's local midnight.
         // For today the window runs to now (an in-progress curve); for a navigated past day it runs the
@@ -4035,6 +4063,7 @@ struct TodayView: View {
             restSpark: restSparkLocal,
             restScore: restScoreLocal,
             provenanceByMetric: provenance,
+            providerByMetric: providers,
             hrPoints: hrPointsLocal,
             stepActivityClassToday: stepClassLocal,
             liveTodayStrain: liveStrainLocal,
@@ -4403,6 +4432,7 @@ struct TodayDayScopedCache {
     let restSpark: [Double]
     let restScore: Double?
     let provenanceByMetric: [String: String]
+    let providerByMetric: [String: ScoreInputProvider]
     let hrPoints: [TrendPoint]
     let stepActivityClassToday: Int?
     let liveTodayStrain: Double?

--- a/StrandTests/TodayExplainabilityTests.swift
+++ b/StrandTests/TodayExplainabilityTests.swift
@@ -1,5 +1,6 @@
 import XCTest
 import SwiftUI
+import WhoopStore
 @testable import Strand
 
 /// Renders a `LocalizedStringKey` to its user-visible string so tests can keep pinning verbatim copy.
@@ -323,23 +324,47 @@ final class TodayExplainabilityTests: XCTestCase {
             "Mi Band")
     }
 
-    func testLiquidHeroSourceLabel_deduplicatesOneWinner() {
-        XCTAssertEqual(
-            LiquidTodayView.heroSourceLabel(
-                rawSources: ["my-whoop-noop", "my-whoop-noop", "my-whoop-noop"],
-                deviceId: "my-whoop"),
-            "On-device")
+    func testTodayScoreProviderLabel_coversImportedAndRegisteredProviders() {
+        XCTAssertEqual(TodayView.todayScoreProviderLabel(sourceId: "my-whoop", brand: "WHOOP"), "Whoop")
+        XCTAssertEqual(TodayView.todayScoreProviderLabel(sourceId: "apple-health", brand: nil), "Apple Watch")
+        XCTAssertEqual(TodayView.todayScoreProviderLabel(sourceId: "health-connect", brand: nil), "Health Connect")
+        XCTAssertEqual(TodayView.todayScoreProviderLabel(sourceId: "oura-import", brand: nil), "Oura")
+        XCTAssertEqual(TodayView.todayScoreProviderLabel(sourceId: "fitbit-import", brand: nil), "Fitbit")
+        XCTAssertEqual(TodayView.todayScoreProviderLabel(sourceId: "garmin-import", brand: nil), "Garmin")
+        XCTAssertEqual(TodayView.todayScoreProviderLabel(sourceId: "xiaomi-band", brand: nil), "Mi Band")
+        for brand in DeviceBrandCatalog.all.map(\.brand) {
+            XCTAssertEqual(TodayView.todayScoreProviderLabel(sourceId: "device-\(brand)", brand: brand), brand)
+        }
     }
 
-    func testLiquidHeroSourceLabel_capsMixedWinnersAtTwoInScoreOrder() {
+    func testTodayScoreProviderLabel_unknownSourceDoesNotPretendToBeWhoop() {
+        XCTAssertEqual(TodayView.todayScoreProviderLabel(sourceId: "sensor-42", brand: nil), "sensor-42")
+        XCTAssertEqual(TodayView.todayScoreProviderLabel(sourceId: "not-a-whoop", brand: nil), "not-a-whoop")
+    }
+
+    func testLiquidHeroSourceLabel_deduplicatesOneProvider() {
         XCTAssertEqual(
             LiquidTodayView.heroSourceLabel(
-                rawSources: ["my-whoop", "my-whoop-noop", "apple-health"],
-                deviceId: "my-whoop"),
-            "Whoop + On-device")
+                providers: [
+                    .init(sourceId: "polar-1", brand: "Polar"),
+                    .init(sourceId: "polar-1", brand: "Polar"),
+                    .init(sourceId: "polar-1", brand: "Polar"),
+                ]),
+            "Polar")
+    }
+
+    func testLiquidHeroSourceLabel_capsMixedProvidersAtTwoInScoreOrder() {
+        XCTAssertEqual(
+            LiquidTodayView.heroSourceLabel(
+                providers: [
+                    .init(sourceId: "my-whoop", brand: "WHOOP"),
+                    .init(sourceId: "oura-import", brand: nil),
+                    .init(sourceId: "apple-health", brand: nil),
+                ]),
+            "Whoop + Oura")
     }
 
     func testLiquidHeroSourceLabel_hidesWhenNoScoreHasAResolvedSource() {
-        XCTAssertNil(LiquidTodayView.heroSourceLabel(rawSources: [], deviceId: "my-whoop"))
+        XCTAssertNil(LiquidTodayView.heroSourceLabel(providers: []))
     }
 }

--- a/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
+++ b/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
@@ -2,6 +2,7 @@ package com.noop.analytics
 
 import com.noop.data.DailyMetric
 import com.noop.data.MetricSeriesRow
+import com.noop.data.ScoreInputProvenanceRow
 import com.noop.data.SleepSession
 import com.noop.data.WhoopRepository
 import com.noop.data.WorkoutRow
@@ -374,6 +375,7 @@ object IntelligenceEngine {
         // builds for daySourceToken, so there is no extra read). Only populated when the universal sink is
         // on. Keyed by the local day.
         val readOwnerByDay = LinkedHashMap<String, OwnerRead>()
+        val resolvedScoreOwnerByDay = LinkedHashMap<String, String>()
         // HRV baseline honours the manual "Recalibrate baseline" epoch (noop.hrvBaselineEpoch): pass the
         // per-value "yyyy-MM-dd" day keys (parallel to the values) so foldHistory drops every night before
         // the epoch. baselineEpoch is threaded down from the Context-aware caller (0.0 = no recalibration).
@@ -660,6 +662,7 @@ object IntelligenceEngine {
                 diag(rhrFloorMeanLogLine(day, rhrFloor, inBedBpms))
             }
             scoredNights.add(res)
+            resolvedScoreOwnerByDay[res.daily.day] = owner
         }
 
         // ── Seed the baseline from the UNION of imported nightly history + the nightly
@@ -976,6 +979,11 @@ object IntelligenceEngine {
         // ("my-whoop"), so importedDeviceId is included; a row already carrying its OWN recovery is left
         // alone. Mirrors the Swift fold.
         val importScoredDays = HashSet<String>().apply { addAll(dailies.map { it.day }) }
+        val healthConnectDays = repo.appleDaily(
+            WhoopRepository.HEALTH_CONNECT_SOURCE,
+            oldestDay,
+            newestDay,
+        ).mapTo(HashSet()) { it.day }
         val importSourceIds = buildList {
             add(importedDeviceId) // Health Connect imports its DailyMetric rows under the strap source.
             add(WhoopRepository.APPLE_HEALTH_SOURCE)
@@ -994,6 +1002,15 @@ object IntelligenceEngine {
                 val scored = row.copy(deviceId = computedId, recovery = recovery)
                 dailies.add(scored)
                 importScoredDays.add(w.day)
+                // Health Connect's compatibility DailyMetric row lives under `my-whoop`, while its
+                // AppleDaily row retains the real source. Preserve that provider fact without changing
+                // ingestion or score precedence.
+                resolvedScoreOwnerByDay[w.day] =
+                    if (source == importedDeviceId && w.day in healthConnectDays) {
+                        WhoopRepository.HEALTH_CONNECT_SOURCE
+                    } else {
+                        source
+                    }
                 RestScorer.restFromDaily(scored)?.let { rest ->
                     restRows.add(MetricSeriesRow(deviceId = computedId, day = w.day, key = "sleep_performance", value = rest))
                 }
@@ -1009,7 +1026,6 @@ object IntelligenceEngine {
                 )
             }
         }
-
         // Snapshot the persisted/merged daily history BEFORE the delete+re-upsert below rewrites the
         // computed window. This is the accumulated view the readiness card + dashboard read ("N of 7
         // nights"); captured here so the Fitness Age gate (further down) can't be undercut by this pass's
@@ -1018,14 +1034,37 @@ object IntelligenceEngine {
         // it stays bounded (daysMerged is full-history) and can't drag in stale nights older than the window.
         val faPriorDaily = repo.daysMerged(importedDeviceId).filter { it.day in oldestDay..newestDay }
 
-        repo.deleteComputedDailyInRange(computedId, oldestDay, newestDay)
-
         // Persist the computed scores under the dedicated "-noop" source so the WHOLE
         // dashboard (Today / Recovery / Strain / Sleep / Trends) reads them. The repository
         // merges these UNDER any imported "my-whoop" rows, so a real WHOOP import always wins;
         // this only fills the days the strap collected but no import covered.
-        if (dailies.isNotEmpty()) repo.upsertDailyMetrics(dailies)
-        if (restRows.isNotEmpty()) repo.upsertMetricSeries(restRows)
+        // Persist metric-level input provenance in the SAME Room transaction. dayOwnership remains
+        // exclusively a resolver override, and a failed write can never relabel an older score.
+        val provenanceByCell = LinkedHashMap<Pair<String, String>, ScoreInputProvenanceRow>()
+        for (daily in dailies) {
+            val source = resolvedScoreOwnerByDay[daily.day] ?: continue
+            if (daily.recovery != null) {
+                provenanceByCell[daily.day to "recovery"] =
+                    ScoreInputProvenanceRow(computedId, daily.day, "recovery", source)
+            }
+            if (daily.strain != null) {
+                provenanceByCell[daily.day to "strain"] =
+                    ScoreInputProvenanceRow(computedId, daily.day, "strain", source)
+            }
+        }
+        for (point in restRows) {
+            val source = resolvedScoreOwnerByDay[point.day] ?: continue
+            provenanceByCell[point.day to point.key] =
+                ScoreInputProvenanceRow(computedId, point.day, point.key, source)
+        }
+        repo.replaceComputedScoreWindow(
+            deviceId = computedId,
+            from = oldestDay,
+            to = newestDay,
+            dailyMetrics = dailies,
+            metricPoints = restRows,
+            provenance = provenanceByCell.values.toList(),
+        )
 
         // ── Fitness Age (Phase 2) , weekly, keyed to the week's Saturday ──
         val fa7 = dailies.sortedBy { it.day }.takeLast(7)

--- a/android/app/src/main/java/com/noop/data/DeviceRegistry.kt
+++ b/android/app/src/main/java/com/noop/data/DeviceRegistry.kt
@@ -109,6 +109,7 @@ class DeviceRegistry(
             dao.deleteAppleDailyFor(id)
             dao.deleteMetricSeriesFor(id)
             dao.deleteDayOwnershipFor(id)
+            dao.deleteScoreInputProvenanceFor(id)
             dao.deleteSleepStatesFor(id)
             dao.deleteLabMarkersFor(id)
             dao.deleteLiveSessionsFor(id)

--- a/android/app/src/main/java/com/noop/data/DeviceRegistryDao.kt
+++ b/android/app/src/main/java/com/noop/data/DeviceRegistryDao.kt
@@ -86,6 +86,8 @@ interface DeviceRegistryDao {
     @Query("DELETE FROM appleDaily WHERE deviceId = :deviceId") suspend fun deleteAppleDailyFor(deviceId: String)
     @Query("DELETE FROM metricSeries WHERE deviceId = :deviceId") suspend fun deleteMetricSeriesFor(deviceId: String)
     @Query("DELETE FROM dayOwnership WHERE deviceId = :deviceId") suspend fun deleteDayOwnershipFor(deviceId: String)
+    @Query("DELETE FROM scoreInputProvenance WHERE deviceId = :deviceId OR sourceId = :deviceId")
+    suspend fun deleteScoreInputProvenanceFor(deviceId: String)
     // Added (audit finding): device-keyed tables the delete set previously missed, so "delete all data"
     // left raw band sleep-state (sleepStateSample), user-entered lab/blood markers (labMarker), live
     // coaching sessions (liveSession) and dismissed workout/sleep markers behind — a privacy defect for a

--- a/android/app/src/main/java/com/noop/data/Entities.kt
+++ b/android/app/src/main/java/com/noop/data/Entities.kt
@@ -342,6 +342,22 @@ data class MetricSeriesRow(
 )
 
 /**
+ * Provider provenance for one NOOP-computed score. Separate from `dayOwnership`: ownership controls
+ * raw-input resolution, while this records the source actually used for a persisted metric.
+ */
+@Entity(
+    tableName = "scoreInputProvenance",
+    primaryKeys = ["deviceId", "day", "key"],
+    indices = [Index(name = "idx_scoreInputProvenance_source", value = ["sourceId"])],
+)
+data class ScoreInputProvenanceRow(
+    val deviceId: String,
+    val day: String,
+    @ColumnInfo(name = "key") val key: String,
+    val sourceId: String,
+)
+
+/**
  * Lab Book marker reading (Health Records pillar). Swift `labMarker` (Database.swift v17 /
  * LabMarkerStore.swift). The richer source-of-truth behind the daily `metricSeries` projection:
  * one row per dated reading the USER entered themselves, a day can hold several readings, each

--- a/android/app/src/main/java/com/noop/data/WhoopDao.kt
+++ b/android/app/src/main/java/com/noop/data/WhoopDao.kt
@@ -183,6 +183,41 @@ interface WhoopDao : DeviceRegistryDao {
     suspend fun upsertMetricSeries(rows: List<MetricSeriesRow>)
 
     @Upsert
+    suspend fun upsertScoreInputProvenance(rows: List<ScoreInputProvenanceRow>)
+
+    @Query(
+        "SELECT sourceId FROM scoreInputProvenance " +
+            "WHERE deviceId = :deviceId AND day = :day AND key = :key"
+    )
+    suspend fun scoreInputSource(deviceId: String, day: String, key: String): String?
+
+    @Query(
+        "DELETE FROM scoreInputProvenance " +
+            "WHERE deviceId = :deviceId AND day >= :from AND day <= :to"
+    )
+    suspend fun deleteScoreInputProvenanceInRange(deviceId: String, from: String, to: String)
+
+    /**
+     * Replace a computed scoring window atomically. If any score or provenance write fails, Room rolls
+     * the whole transaction back, so an old score can never be labelled with a newer provider.
+     */
+    @Transaction
+    suspend fun replaceComputedScoreWindow(
+        deviceId: String,
+        from: String,
+        to: String,
+        dailyMetrics: List<DailyMetric>,
+        metricPoints: List<MetricSeriesRow>,
+        provenance: List<ScoreInputProvenanceRow>,
+    ) {
+        deleteDailyMetricsInRange(deviceId, from, to)
+        deleteScoreInputProvenanceInRange(deviceId, from, to)
+        if (dailyMetrics.isNotEmpty()) upsertDailyMetrics(dailyMetrics)
+        if (metricPoints.isNotEmpty()) upsertMetricSeries(metricPoints)
+        if (provenance.isNotEmpty()) upsertScoreInputProvenance(provenance)
+    }
+
+    @Upsert
     suspend fun upsertJournal(rows: List<JournalEntry>)
 
     @Upsert

--- a/android/app/src/main/java/com/noop/data/WhoopDatabase.kt
+++ b/android/app/src/main/java/com/noop/data/WhoopDatabase.kt
@@ -37,6 +37,7 @@ import androidx.sqlite.db.SupportSQLiteDatabase
         DailyMetric::class,
         SleepSession::class,
         MetricSeriesRow::class,
+        ScoreInputProvenanceRow::class,
         JournalEntry::class,
         WorkoutRow::class,
         DismissedWorkout::class,
@@ -50,7 +51,7 @@ import androidx.sqlite.db.SupportSQLiteDatabase
         PpgWaveformSampleEntity::class,
         RawImuSampleEntity::class,
     ],
-    version = 22,
+    version = 23,
     exportSchema = false,
 )
 abstract class WhoopDatabase : RoomDatabase() {
@@ -581,6 +582,22 @@ abstract class WhoopDatabase : RoomDatabase() {
             }
         }
 
+        /** Metric-level provenance for NOOP-computed scores. Additive and intentionally independent
+         *  from dayOwnership, whose resolver semantics remain unchanged. */
+        internal val SCORE_INPUT_PROVENANCE_MIGRATION_SQL: List<String> = listOf(
+            "CREATE TABLE IF NOT EXISTS `scoreInputProvenance` (`deviceId` TEXT NOT NULL, " +
+                "`day` TEXT NOT NULL, `key` TEXT NOT NULL, `sourceId` TEXT NOT NULL, " +
+                "PRIMARY KEY(`deviceId`, `day`, `key`))",
+            "CREATE INDEX IF NOT EXISTS `idx_scoreInputProvenance_source` " +
+                "ON `scoreInputProvenance` (`sourceId`)",
+        )
+
+        internal val MIGRATION_22_23 = object : Migration(22, 23) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                for (stmt in SCORE_INPUT_PROVENANCE_MIGRATION_SQL) db.execSQL(stmt)
+            }
+        }
+
         private fun build(appContext: Context): WhoopDatabase =
             Room.databaseBuilder(appContext, WhoopDatabase::class.java, DB_NAME)
                 // #1014: replace ONLY the corruption handling of the default open-helper. The
@@ -597,6 +614,7 @@ abstract class WhoopDatabase : RoomDatabase() {
                     MIGRATION_10_11, MIGRATION_11_12, MIGRATION_12_13, MIGRATION_13_14,
                     MIGRATION_14_15, MIGRATION_15_16, MIGRATION_16_17, MIGRATION_17_18,
                     MIGRATION_18_19, MIGRATION_19_20, MIGRATION_20_21, MIGRATION_21_22,
+                    MIGRATION_22_23,
                 )
                 // #1037: a FRESH install builds the schema straight at the current version and runs NO
                 // migrations, so the MIGRATION_7_8 "my-whoop" registry seed never fires and the WHOOP,

--- a/android/app/src/main/java/com/noop/data/WhoopRepository.kt
+++ b/android/app/src/main/java/com/noop/data/WhoopRepository.kt
@@ -301,6 +301,20 @@ class WhoopRepository(private val dao: WhoopDao) {
     suspend fun deleteComputedDailyInRange(deviceId: String, from: String, to: String) =
         dao.deleteDailyMetricsInRange(deviceId, from, to)
 
+    suspend fun replaceComputedScoreWindow(
+        deviceId: String,
+        from: String,
+        to: String,
+        dailyMetrics: List<DailyMetric>,
+        metricPoints: List<MetricSeriesRow>,
+        provenance: List<ScoreInputProvenanceRow>,
+    ) = dao.replaceComputedScoreWindow(
+        deviceId, from, to, dailyMetrics, metricPoints, provenance
+    )
+
+    suspend fun scoreInputSource(deviceId: String, day: String, key: String): String? =
+        dao.scoreInputSource(deviceId, day, key)
+
     /** Hand-correct the bed (onset) / wake (end) time of an existing sleep session, DURABLY , port
      *  of iOS PR #395 (Repository.editSleepTimes + MetricsCache.applySleepEdit).
      *

--- a/android/app/src/main/java/com/noop/ui/AppViewModel.kt
+++ b/android/app/src/main/java/com/noop/ui/AppViewModel.kt
@@ -112,6 +112,22 @@ class AppViewModel(app: Application) : AndroidViewModel(app) {
     /** All paired devices (oldest first), read fresh. The screen re-reads after every mutation. */
     suspend fun pairedDevices(): List<com.noop.data.PairedDeviceRow> = noopApp.deviceRegistry.all()
 
+    /** Resolve a displayed score's storage namespace back to its input provider. Missing provenance on
+     *  a legacy computed row returns null rather than guessing from the computed namespace. */
+    internal suspend fun scoreInputProvider(
+        resolvedSource: String,
+        day: String,
+        metricKey: String,
+    ): ScoreInputProvider? {
+        val sourceId = if (resolvedSource.endsWith("-noop")) {
+            repository.scoreInputSource(resolvedSource, day, metricKey) ?: return null
+        } else {
+            resolvedSource
+        }
+        val brand = noopApp.deviceRegistry.all().firstOrNull { it.id == sourceId }?.brand
+        return ScoreInputProvider(sourceId, brand)
+    }
+
     /** Add (or update) a paired device. */
     suspend fun addPairedDevice(row: com.noop.data.PairedDeviceRow) = noopApp.deviceRegistry.add(row)
 

--- a/android/app/src/main/java/com/noop/ui/TodayProvenance.kt
+++ b/android/app/src/main/java/com/noop/ui/TodayProvenance.kt
@@ -67,18 +67,44 @@ internal fun todayProvenanceChipLabel(
     provenanceDisplayLabel(rawSource, deviceId)
 }
 
+/** The sensor/import provider whose inputs produced a Today score. */
+internal data class ScoreInputProvider(val sourceId: String, val brand: String? = null)
+
+/** Provider-facing hero wording. Registered brands cover live devices; stable import ids cover imports. */
+internal fun todayScoreProviderLabel(provider: ScoreInputProvider): String {
+    val source = provider.sourceId.lowercase()
+    return when (source) {
+        WhoopRepository.APPLE_HEALTH_SOURCE -> "Apple Watch"
+        WhoopRepository.HEALTH_CONNECT_SOURCE -> "Health Connect"
+        "oura-import", "oura-api" -> "Oura"
+        "fitbit-import" -> "Fitbit"
+        "garmin-import" -> "Garmin"
+        "xiaomi-band" -> "Mi Band"
+        WhoopRepository.ACTIVITY_FILE_SOURCE -> "Workout files"
+        else -> {
+            val brand = provider.brand?.trim().orEmpty()
+            when {
+                brand.equals("WHOOP", ignoreCase = true) -> "Whoop"
+                brand.isNotEmpty() -> brand
+                source == WhoopRepository.WHOOP_SOURCE -> "Whoop"
+                else -> FusionSource.entries.firstOrNull { it.id == provider.sourceId }?.displayName
+                    ?: provider.sourceId
+            }
+        }
+    }
+}
+
 /**
- * One compact source label for the liquid score hero. Raw winners arrive in Charge / Effort / Rest order;
+ * One compact provider label for the score hero. Providers arrive in Charge / Effort / Rest order;
  * identical display names collapse and mixed winners are capped at two so the badge stays readable.
  * Mirrors LiquidTodayView.heroSourceLabel value-for-value.
  */
 internal fun heroSourceLabel(
-    rawSources: List<String>,
-    deviceId: String = WhoopRepository.WHOOP_SOURCE,
+    providers: List<ScoreInputProvider>,
 ): String? {
     val labels = LinkedHashSet<String>()
-    for (rawSource in rawSources) {
-        labels.add(todayProvenanceChipLabel(rawSource, deviceId))
+    for (provider in providers) {
+        labels.add(todayScoreProviderLabel(provider))
         if (labels.size == 2) break
     }
     return labels.takeIf { it.isNotEmpty() }?.joinToString(" + ")
@@ -87,24 +113,22 @@ internal fun heroSourceLabel(
 /**
  * Source label for the three visible hero scores. Today can show a carried Charge from the previous
  * scored night while today's recovery is still absent (#543); in that state the selected-day
- * "recovery" provenance is also absent, so use the carried night's resolved recovery source instead of
+ * "recovery" provider is also absent, so use the carried night's resolved recovery provider instead of
  * letting the card badge omit or misrepresent the visible Charge (#390).
  */
 internal fun scoreHeroSourceLabel(
-    provenanceByMetric: Map<String, String>,
-    carriedRecoverySource: String?,
+    providerByMetric: Map<String, ScoreInputProvider>,
+    carriedRecoveryProvider: ScoreInputProvider?,
     usesCarriedRecovery: Boolean,
-    deviceId: String = WhoopRepository.WHOOP_SOURCE,
 ): String? {
-    val recoverySource = provenanceByMetric["recovery"]
-        ?: if (usesCarriedRecovery) carriedRecoverySource else null
+    val recoveryProvider = providerByMetric["recovery"]
+        ?: if (usesCarriedRecovery) carriedRecoveryProvider else null
     return heroSourceLabel(
-        rawSources = listOfNotNull(
-            recoverySource,
-            provenanceByMetric["strain"],
-            provenanceByMetric["sleep_performance"],
+        providers = listOfNotNull(
+            recoveryProvider,
+            providerByMetric["strain"],
+            providerByMetric["sleep_performance"],
         ),
-        deviceId = deviceId,
     )
 }
 

--- a/android/app/src/main/java/com/noop/ui/TodayScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/TodayScreen.kt
@@ -833,21 +833,24 @@ fun TodayScreen(
     // keyed by metric key ("recovery" / "strain" / "sleep_performance"); each value is the RAW source id the resolver
     // returned (e.g. "my-whoop", "my-whoop-noop", "apple-health"). resolvedSeries applies the SAME
     // imported-WHOOP > NOOP-computed > Apple-Health precedence the dashboard merge uses field-by-field
-    // (WhoopRepository.mergeDaily), so the card-level badge names the sources that ACTUALLY supplied
-    // that day's scores rather than making a blanket day-level claim. Mirrors the Swift Today lane's
-    // `provenanceByMetric` resolution exactly (the winner is the last resolved point on selectedDayKey).
-    var provenanceByMetric by remember { mutableStateOf<Map<String, String>>(emptyMap()) }
+    // (WhoopRepository.mergeDaily), then computed rows resolve through durable input provenance so the
+    // card-level badge names the sensor/import providers rather than where NOOP ran the math.
+    var providerByMetric by remember { mutableStateOf<Map<String, ScoreInputProvider>>(emptyMap()) }
     LaunchedEffect(days, selectedDayKey, viewModel.activeStrapId) {
-        val resolved = mutableMapOf<String, String>()
+        val resolved = mutableMapOf<String, ScoreInputProvider>()
         for (key in listOf("recovery", "strain", "sleep_performance")) {
             val win = runCatching {
                 viewModel.repo.resolvedSeries(key, "my-whoop", selectedDayKey, selectedDayKey,
                     strapDeviceId = viewModel.activeStrapId)
-                    .points.lastOrNull { it.day == selectedDayKey }?.source
+                    .points.lastOrNull { it.day == selectedDayKey }
             }.getOrNull()
-            if (win != null) resolved[key] = win
+            if (win != null) {
+                viewModel.scoreInputProvider(win.source, win.day, key)?.let {
+                    resolved[key] = it
+                }
+            }
         }
-        provenanceByMetric = resolved
+        providerByMetric = resolved
     }
 
     // LIVE in-progress Effort for TODAY (#402), mirrors the iOS TodayView live-Effort fix. The stored
@@ -958,17 +961,17 @@ fun TodayScreen(
             prior.recovery?.let { LastCharge(it, carriedCaption(prior.day, carryOverTodayKey)) }
         }
     }
-    var carriedRecoverySource by remember { mutableStateOf<String?>(null) }
+    var carriedRecoveryProvider by remember { mutableStateOf<ScoreInputProvider?>(null) }
     LaunchedEffect(lastScoredRecoveryDay?.day, viewModel.activeStrapId) {
         val carriedDay = lastScoredRecoveryDay?.day
-        carriedRecoverySource = if (carriedDay == null) {
+        carriedRecoveryProvider = if (carriedDay == null) {
             null
         } else {
             runCatching {
                 viewModel.repo.resolvedSeries("recovery", "my-whoop", carriedDay, carriedDay,
                     strapDeviceId = viewModel.activeStrapId)
                     .points.lastOrNull { it.day == carriedDay }
-                    ?.source
+                    ?.let { viewModel.scoreInputProvider(it.source, it.day, "recovery") }
             }.getOrNull()
         }
     }
@@ -991,12 +994,11 @@ fun TodayScreen(
 
     // One honest card-level badge, matching LiquidTodayView: identical winners collapse to one label;
     // mixed winners show at most two sources in Charge / Effort / Rest order so the pill stays compact.
-    val heroSourceLabel = remember(provenanceByMetric, carriedRecoverySource, displayMetric?.recovery, lastScoredCharge, viewModel.activeStrapId) {
+    val heroSourceLabel = remember(providerByMetric, carriedRecoveryProvider, displayMetric?.recovery, lastScoredCharge) {
         scoreHeroSourceLabel(
-            provenanceByMetric = provenanceByMetric,
-            carriedRecoverySource = carriedRecoverySource,
+            providerByMetric = providerByMetric,
+            carriedRecoveryProvider = carriedRecoveryProvider,
             usesCarriedRecovery = displayMetric?.recovery == null && lastScoredCharge != null,
-            deviceId = viewModel.activeStrapId,
         )
     }
 
@@ -2456,12 +2458,8 @@ private fun ScoreHeroRow(
                                 // Measure the full label even when it is wider than the Rest vessel, then
                                 // let it overflow left while preserving the vessel-aligned trailing edge.
                                 .wrapContentWidth(unbounded = true, align = Alignment.End)
-                                // #486: the vessel row starts one space16 inside the card, so lifting by
-                                // exactly space16 puts the badge's TOP on the card's top edge — it tucks
-                                // into the top-right corner and hangs into the gap above the vessels. The
-                                // previous "+ half the badge height" centred it ON the border, where it read
-                                // as a pill floating detached above the card (two users flagged it).
-                                .offset(y = -Metrics.space16)
+                                // Match iOS: centre the pill on the card border, aligned with the Rest vessel.
+                                .offset(y = -(Metrics.space16 + Metrics.sourceBadgeHeight / 2))
                                 .semantics { contentDescription = uiString(R.string.l10n_today_screen_source_herosourcelabel_d3363687, heroSourceLabel) },
                         )
                     }

--- a/android/app/src/test/java/com/noop/analytics/RegistryDayOwnerSourceTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/RegistryDayOwnerSourceTest.kt
@@ -40,6 +40,9 @@ class RegistryDayOwnerSourceTest {
         override suspend fun archiveDevice(id: String) {
             devices[id]?.let { devices[id] = it.copy(status = DeviceStatus.archived.name) }
         }
+        override suspend fun setModel(id: String, model: String) {
+            devices[id]?.let { devices[id] = it.copy(model = model) }
+        }
         override suspend fun renameDevice(id: String, nickname: String?) {}
         override suspend fun setPeripheralId(id: String, peripheralId: String?) {
             devices[id]?.let { devices[id] = it.copy(peripheralId = peripheralId) }
@@ -67,6 +70,7 @@ class RegistryDayOwnerSourceTest {
         override suspend fun deleteAppleDailyFor(deviceId: String) {}
         override suspend fun deleteMetricSeriesFor(deviceId: String) {}
         override suspend fun deleteDayOwnershipFor(deviceId: String) {}
+        override suspend fun deleteScoreInputProvenanceFor(deviceId: String) {}
         override suspend fun deleteSleepStatesFor(deviceId: String) {}
         override suspend fun deleteLabMarkersFor(deviceId: String) {}
         override suspend fun deleteLiveSessionsFor(deviceId: String) {}

--- a/android/app/src/test/java/com/noop/ble/SourceCoordinatorAdoptionTest.kt
+++ b/android/app/src/test/java/com/noop/ble/SourceCoordinatorAdoptionTest.kt
@@ -50,6 +50,9 @@ class SourceCoordinatorAdoptionTest {
         override suspend fun archiveDevice(id: String) {
             devices[id]?.let { devices[id] = it.copy(status = DeviceStatus.archived.name) }
         }
+        override suspend fun setModel(id: String, model: String) {
+            devices[id]?.let { devices[id] = it.copy(model = model) }
+        }
         override suspend fun renameDevice(id: String, nickname: String?) {
             devices[id]?.let { devices[id] = it.copy(nickname = nickname) }
         }
@@ -88,6 +91,7 @@ class SourceCoordinatorAdoptionTest {
         override suspend fun deleteDayOwnershipFor(deviceId: String) {
             owners.entries.removeIf { it.value.deviceId == deviceId }
         }
+        override suspend fun deleteScoreInputProvenanceFor(deviceId: String) {}
     }
 
     private fun registryWith(dao: FakeRegistryDao) = DeviceRegistry(

--- a/android/app/src/test/java/com/noop/data/DeviceRegistryTest.kt
+++ b/android/app/src/test/java/com/noop/data/DeviceRegistryTest.kt
@@ -53,6 +53,10 @@ class DeviceRegistryTest {
             devices[id]?.let { devices[id] = it.copy(status = DeviceStatus.archived.name) }
         }
 
+        override suspend fun setModel(id: String, model: String) {
+            devices[id]?.let { devices[id] = it.copy(model = model) }
+        }
+
         override suspend fun renameDevice(id: String, nickname: String?) {
             devices[id]?.let { devices[id] = it.copy(nickname = nickname) }
         }
@@ -97,6 +101,9 @@ class DeviceRegistryTest {
         override suspend fun deleteDayOwnershipFor(deviceId: String) {
             deletedTables += "dayOwnership" to deviceId
             owners.entries.removeIf { it.value.deviceId == deviceId }
+        }
+        override suspend fun deleteScoreInputProvenanceFor(deviceId: String) {
+            deletedTables += "scoreInputProvenance" to deviceId
         }
         override suspend fun deleteSleepStatesFor(deviceId: String) { deletedTables += "sleepStateSample" to deviceId }
         override suspend fun deleteLabMarkersFor(deviceId: String) { deletedTables += "labMarker" to deviceId }
@@ -237,6 +244,7 @@ class DeviceRegistryTest {
             "hrSample", "rrInterval", "spo2Sample", "skinTempSample", "respSample", "gravitySample",
             "stepSample", "ppgHrSample", "ppgWaveformSample", "rawImuSample", "event", "battery", "dailyMetric", "sleepSession",
             "journal", "workout", "appleDaily", "metricSeries", "dayOwnership",
+            "scoreInputProvenance",
             "sleepStateSample", "labMarker", "liveSession", "dismissedWorkout", "dismissedSleep",
         )
         assertEquals(expectedTables, dao.deletedTables.map { it.first }.toSet())

--- a/android/app/src/test/java/com/noop/data/ScoreInputProvenanceMigrationTest.kt
+++ b/android/app/src/test/java/com/noop/data/ScoreInputProvenanceMigrationTest.kt
@@ -1,0 +1,35 @@
+package com.noop.data
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/** Guards the additive score-input provenance schema and its metric-level natural key. */
+class ScoreInputProvenanceMigrationTest {
+    @Test
+    fun migrationIsAdditiveAndMatchesEntityShape() {
+        val sql = WhoopDatabase.SCORE_INPUT_PROVENANCE_MIGRATION_SQL
+        assertEquals(2, sql.size)
+        assertEquals(
+            "CREATE TABLE IF NOT EXISTS `scoreInputProvenance` (`deviceId` TEXT NOT NULL, " +
+                "`day` TEXT NOT NULL, `key` TEXT NOT NULL, `sourceId` TEXT NOT NULL, " +
+                "PRIMARY KEY(`deviceId`, `day`, `key`))",
+            sql[0],
+        )
+        assertEquals(
+            "CREATE INDEX IF NOT EXISTS `idx_scoreInputProvenance_source` " +
+                "ON `scoreInputProvenance` (`sourceId`)",
+            sql[1],
+        )
+        for (statement in sql) {
+            val upper = statement.uppercase()
+            assertTrue(upper.startsWith("CREATE "))
+            for (banned in listOf("DROP ", "DELETE ", "UPDATE ", "INSERT ", "ALTER ")) {
+                assertFalse("migration must not contain $banned", upper.contains(banned))
+            }
+        }
+        assertEquals(22, WhoopDatabase.MIGRATION_22_23.startVersion)
+        assertEquals(23, WhoopDatabase.MIGRATION_22_23.endVersion)
+    }
+}

--- a/android/app/src/test/java/com/noop/ui/TodayExplainabilityTest.kt
+++ b/android/app/src/test/java/com/noop/ui/TodayExplainabilityTest.kt
@@ -305,24 +305,56 @@ class TodayExplainabilityTest {
     }
 
     @Test
-    fun liquidHeroSourceLabel_deduplicatesOneWinner() {
+    fun todayScoreProviderLabel_coversImportedAndRegisteredProviders() {
+        assertEquals("Whoop", todayScoreProviderLabel(ScoreInputProvider("my-whoop", "WHOOP")))
+        assertEquals("Apple Watch", todayScoreProviderLabel(ScoreInputProvider("apple-health")))
+        assertEquals("Health Connect", todayScoreProviderLabel(ScoreInputProvider("health-connect")))
+        assertEquals("Oura", todayScoreProviderLabel(ScoreInputProvider("oura-import")))
+        assertEquals("Fitbit", todayScoreProviderLabel(ScoreInputProvider("fitbit-import")))
+        assertEquals("Garmin", todayScoreProviderLabel(ScoreInputProvider("garmin-import")))
+        assertEquals("Mi Band", todayScoreProviderLabel(ScoreInputProvider("xiaomi-band")))
+        for (brand in com.noop.data.DeviceBrandCatalog.all.map { it.brand }) {
+            assertEquals(brand, todayScoreProviderLabel(ScoreInputProvider("device-$brand", brand)))
+        }
+    }
+
+    @Test
+    fun todayScoreProviderLabel_unknownSourceDoesNotPretendToBeWhoop() {
+        assertEquals("sensor-42", todayScoreProviderLabel(ScoreInputProvider("sensor-42")))
+        assertEquals("not-a-whoop", todayScoreProviderLabel(ScoreInputProvider("not-a-whoop")))
+    }
+
+    @Test
+    fun liquidHeroSourceLabel_deduplicatesOneProvider() {
         assertEquals(
-            "On-device",
-            heroSourceLabel(listOf("my-whoop-noop", "my-whoop-noop", "my-whoop-noop")),
+            "Polar",
+            heroSourceLabel(
+                listOf(
+                    ScoreInputProvider("polar-1", "Polar"),
+                    ScoreInputProvider("polar-1", "Polar"),
+                    ScoreInputProvider("polar-1", "Polar"),
+                ),
+            ),
         )
     }
 
     @Test
-    fun liquidHeroSourceLabel_capsMixedWinnersAtTwoInScoreOrder() {
+    fun liquidHeroSourceLabel_capsMixedProvidersAtTwoInScoreOrder() {
         assertEquals(
-            "Whoop + On-device",
-            heroSourceLabel(listOf("my-whoop", "my-whoop-noop", "health-connect")),
+            "Whoop + Oura",
+            heroSourceLabel(
+                listOf(
+                    ScoreInputProvider("my-whoop", "WHOOP"),
+                    ScoreInputProvider("oura-import"),
+                    ScoreInputProvider("health-connect"),
+                ),
+            ),
         )
     }
 
     @Test
     fun liquidHeroSourceLabel_usesAudienceFacingAppleWatchName() {
-        assertEquals("Apple Watch", heroSourceLabel(listOf("apple-health")))
+        assertEquals("Apple Watch", heroSourceLabel(listOf(ScoreInputProvider("apple-health"))))
     }
 
     @Test
@@ -333,10 +365,10 @@ class TodayExplainabilityTest {
     @Test
     fun liquidHeroSourceLabel_usesCarriedChargeSourceWhenTodayRecoveryIsAbsent() {
         assertEquals(
-            "On-device",
+            "Whoop",
             scoreHeroSourceLabel(
-                provenanceByMetric = emptyMap(),
-                carriedRecoverySource = "my-whoop-noop",
+                providerByMetric = emptyMap(),
+                carriedRecoveryProvider = ScoreInputProvider("my-whoop", "WHOOP"),
                 usesCarriedRecovery = true,
             ),
         )
@@ -345,10 +377,10 @@ class TodayExplainabilityTest {
     @Test
     fun liquidHeroSourceLabel_keepsCurrentDayRecoveryAheadOfCarriedFallback() {
         assertEquals(
-            "Whoop",
+            "Oura",
             scoreHeroSourceLabel(
-                provenanceByMetric = mapOf("recovery" to "my-whoop"),
-                carriedRecoverySource = "my-whoop-noop",
+                providerByMetric = mapOf("recovery" to ScoreInputProvider("oura-import")),
+                carriedRecoveryProvider = ScoreInputProvider("my-whoop", "WHOOP"),
                 usesCarriedRecovery = true,
             ),
         )
@@ -358,8 +390,8 @@ class TodayExplainabilityTest {
     fun liquidHeroSourceLabel_ignoresCarriedSourceWhenChargeIsNotCarried() {
         assertNull(
             scoreHeroSourceLabel(
-                provenanceByMetric = emptyMap(),
-                carriedRecoverySource = "my-whoop-noop",
+                providerByMetric = emptyMap(),
+                carriedRecoveryProvider = ScoreInputProvider("my-whoop", "WHOOP"),
                 usesCarriedRecovery = false,
             ),
         )

--- a/docs/ANDROID.md
+++ b/docs/ANDROID.md
@@ -482,6 +482,7 @@ storage layer holds these invariants — preserve them when extending it:
   | `DailyMetric` | `dailyMetric` | `(deviceId, day)` |
   | `SleepSession` | `sleepSession` | `(deviceId, startTs)` |
   | `MetricSeriesRow` | `metricSeries` | `(deviceId, day, key)` + index `idx_metricSeries_device_key_day (deviceId, key, day)` |
+  | `ScoreInputProvenanceRow` | `scoreInputProvenance` | `(deviceId, day, key)` + index `idx_scoreInputProvenance_source (sourceId)` |
   | `DeviceRow` | `device` | `id` |
 
 - **Timestamps are wall-clock unix seconds.** Swift stores them as `Int`; the entities widen to

--- a/docs/DATA_MODEL.md
+++ b/docs/DATA_MODEL.md
@@ -81,7 +81,7 @@ post-v9 addition currently documented here):
 | **Decoded streams** (durable) | `hrSample`, `rrInterval`, `event`, `battery`, `spo2Sample`, `skinTempSample`, `respSample`, `gravitySample` | Decoded from strap frames on-device |
 | **Raw outbox** (transient) | `rawBatch` | Compressed raw BLE frames, prunable |
 | **Bookkeeping** | `cursors` | Highwater / read cursors |
-| **Metric caches** | `sleepSession`, `dailyMetric`, `journal`, `workout`, `appleDaily`, `metricSeries` | Derived metrics + CSV / Apple-Health imports |
+| **Metric caches** | `sleepSession`, `dailyMetric`, `journal`, `workout`, `appleDaily`, `metricSeries`, `scoreInputProvenance` | Derived metrics + their input-provider provenance + CSV / Apple-Health imports |
 | **Oura raw archive** (durable, v25) | `ouraRaw` | Verbatim Oura API payloads behind the opt-in cloud import — see below |
 
 All timestamp columns named `ts`, `startTs`, `endTs`, `capturedAt`, etc. are **unix seconds**
@@ -106,6 +106,7 @@ Migrations are registered in `Packages/WhoopStore/Sources/WhoopStore/Database.sw
 | **v7** | Adds in-sleep signal aggregates to `dailyMetric`: `spo2Pct`, `skinTempDevC`, `respRateBpm` (all nullable). |
 | **v8** | Adds `journal`, `workout`, and `appleDaily` (Apple-Health daily aggregates). |
 | **v9** | Adds the generic long-format `metricSeries` table and its `(deviceId, key, day)` index. |
+| **v29** | Adds metric-level `scoreInputProvenance` for NOOP-computed headline scores. It does not change `dayOwnership` or score precedence. |
 
 ### The vestigial `synced` column
 
@@ -445,6 +446,23 @@ knowing each source's schema.
 to:)`) or `metricDays(key:)`, which scan `(deviceId, key)` and then walk days. This index makes
 those reads index-only. Accessors: `upsertMetricSeries(...)`, `metricSeries(...)`,
 `metricKeys(...)` (distinct keys for a device), and `metricDays(...)` (`MIN`/`MAX` day per key).
+
+### `scoreInputProvenance` *(v29)*
+
+Records which sensor/import source supplied the inputs for each persisted NOOP-computed score.
+This is deliberately separate from `dayOwnership`, which remains a scoring resolver override.
+Rows are replaced atomically with the corresponding `dailyMetric` / `metricSeries` score writes;
+legacy scores without a row have unknown provenance and the UI omits their provider badge.
+
+| Column | Type | Notes |
+| --- | --- | --- |
+| `deviceId` | TEXT NOT NULL | Computed `-noop` namespace. Part of PK. |
+| `day` | TEXT NOT NULL | `YYYY-MM-DD`. Part of PK. |
+| `key` | TEXT NOT NULL | `recovery`, `strain`, or `sleep_performance`. Part of PK. |
+| `sourceId` | TEXT NOT NULL | Physical device or import source that supplied the inputs. |
+
+**Primary key:** `(deviceId, day, key)`. **Index:** `idx_scoreInputProvenance_source` on
+`sourceId`, used when a provider's data is deleted.
 
 ---
 

--- a/docs/LIBRARY.md
+++ b/docs/LIBRARY.md
@@ -245,6 +245,7 @@ busy timeout so two handles to the same file don't deadlock.
 | `sleepSession`, `dailyMetric` | cached derived metrics | `(deviceId, startTs)` / `(deviceId, day)` |
 | `journal`, `workout`, `appleDaily` | journal + workouts + Apple-Health daily | various |
 | `metricSeries` | generic long-format (EAV) metric store | `(deviceId, day, key)` |
+| `scoreInputProvenance` | input provider for a NOOP-computed score | `(deviceId, day, key)` |
 
 ### Key public API
 


### PR DESCRIPTION
## What this PR does

This PR fixes the source badge on the Today score card so it identifies the devices and imports that supplied the score inputs instead of always describing where NOOP performed the calculation.

Computed recovery, strain, and sleep-performance scores now persist their input provider in a dedicated local provenance table. The provenance update is committed atomically with the corresponding score update, while directly imported scores continue to resolve their provider from their existing source ID. Legacy computed scores without recorded provenance hide the badge rather than guessing.

The shared provider mapping covers paired device brands and stable import sources, including Whoop, Apple Watch, Health Connect, Oura, Fitbit, Garmin, Mi Band, Polar, and other registered devices. Mixed inputs are deduplicated and limited to two names in the compact badge. Carried Charge values resolve the provider from the exact day that supplied the displayed score.

The PR also restores the badge's intended position, centered on the top border and aligned with the Rest vessel, and applies the same behavior to the Classic Today view, Liquid Today view, and Android.

The new storage is documented and removed alongside its device or scoped user data. No BLE, protocol, or scoring-math behavior was changed.

## Type of change

- [x] Bug fix
- [ ] New feature
- [x] Refactor / cleanup
- [x] Documentation
- [ ] CI / tooling

## How it was tested

- Ran `swift test` in `Packages/WhoopStore`: 272 tests passed.
- Ran `./gradlew testFullDebugUnitTest` for Android: passed.
- Ran the 43 focused `TodayExplainabilityTests`: passed.
- Built the `NOOPiOS` Debug configuration without signing for an iPhone 16 Pro simulator.
- Installed and launched the final iOS build in the simulator.
- Manually verified the badge alignment and provider display in the iOS simulator.
- Ran `python3 Tools/i18n_audit.py --ci upstream/main`: Android and Apple localization checks passed.
- Ran `git diff --check`: passed.
- The complete macOS test suite was also attempted, but an unrelated existing `BugReportTemplateTests` file-read test hung; the affected Today test suite completed successfully.

## Checklist

- [x] Swift package tests pass for any package I touched (`swift test` in `Packages/<name>`)
- [x] Android unit tests pass if I touched `android/` (`./gradlew testFullDebugUnitTest`)
- [x] No new build warnings introduced
- [x] UI changes use only `StrandDesign` tokens — no hardcoded colors, fonts, or spacing
- [x] No hardcoded hex frame bytes; protocol facts live in the schema / decoders
- [x] Follows the conventions in [`docs/CONTRIBUTING.md`](../docs/CONTRIBUTING.md)
- [x] I did not commit generated output (`Strand.xcodeproj/`) or any secrets/keystores

## Related issues

None.
