### PR TITLE
docs(readme): fix stale root README — missing packages + schema version

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,10 +315,13 @@ guarded with `#if canImport(UIKit)` / `#if canImport(AppKit)`.
 Strand/                  macOS SwiftUI reference app (this is what you build)
 Packages/
   WhoopProtocol/         BLE frame parsing, CRC, command/event/packet decode
+  OuraProtocol/          clean-room Oura ring BLE protocol (framing, auth, decoders, driver)
+  PolarProtocol/         Polar PMD decoder (HR / PPI / ECG / ACC streams)
   WhoopStore/            GRDB/SQLite persistence (migrations, streams, caches)
   StrandAnalytics/       HRV / recovery / strain / sleep / correlation math
   StrandImport/          WHOOP CSV + Apple Health importers
   StrandDesign/          SwiftUI design system (palette, components, charts)
+  NoopLocalAccess/       local read-only data-access layer (on-device, no network)
 Tools/Backfill/          CLI tool for backfilling decoded data
 Fixtures/                sample WHOOP export for tests
 ```
@@ -346,7 +349,7 @@ offload, and live notifications.
 
 Everything is stored on-device in SQLite (using
 [GRDB.swift](https://github.com/groue/GRDB.swift)). The schema is a versioned
-migrator (`Database.swift`, currently through `v9`). Examples of decoded-stream
+migrator (`Database.swift`, currently past `v28`). Examples of decoded-stream
 tables created in `v1`–`v3`:
 
 ```sql


### PR DESCRIPTION
Follow-up to #779: the Android README fix landed there, but this root-`README.md` fix got orphaned by the squash-merge timing. Re-landing it.

Two stale items in the root README (verified against the repo, not eyeballed):
- **Architecture package list** omitted 3 of the 8 packages → added `OuraProtocol`, `PolarProtocol`, `NoopLocalAccess`.
- **Schema version** said "currently through `v9`" but the migrator is at ~`v28` → corrected (as "past v28" so it drifts gracefully).

Verified-accurate and left untouched: `Tools/Backfill` exists, and every `StrandAnalytics` file named is real. Docs-only.