### PR TITLE
Whoop5Variant: tell WHOOP MG apart from plain 5.0 (#520)

### DIFF
--- a/Packages/WhoopProtocol/Sources/WhoopProtocol/Whoop5Variant.swift
+++ b/Packages/WhoopProtocol/Sources/WhoopProtocol/Whoop5Variant.swift
@@ -1,0 +1,81 @@
+import Foundation
+
+// Whoop5Variant.swift — WHOOP MG vs plain WHOOP 5.0 hardware discrimination (#520).
+//
+// DELIBERATELY ORTHOGONAL to `DeviceFamily`. `DeviceFamily.whoop5` describes the WIRE PROTOCOL
+// (CRC16-Modbus header, puffin packet types) and MG and 5.0 are byte-identical there — every
+// framing/interpreter switch must keep treating them as one family. This type describes the
+// HARDWARE instead: an MG carries the ECG-conductive clasp, a 5.0 does not. Keeping the two apart
+// means a capability gate (ECG, and later BP) can never accidentally change how a frame is parsed.
+//
+// Pure: no CoreBluetooth, no I/O. The app layer supplies the two strings (see below) and this
+// decides. The Kotlin twin is com.noop.protocol.Whoop5Variant — keep them byte-identical.
+//
+// Provenance: the serial prefixes and the 5.0 hardware-revision string are protocol FACTS
+// (uncopyrightable), corroborated by community reverse-engineering discussed in #520. They are
+// read from the standard BLE Device Information Service, not from any WHOOP code.
+
+/// Which WHOOP 5-generation hardware a connection is talking to.
+///
+/// `DeviceFamily.whoop5` still governs all framing/decode; this only gates hardware capability.
+public enum Whoop5Variant: String, Sendable, CaseIterable {
+    /// WHOOP MG — has the ECG-conductive clasp.
+    case mg
+    /// WHOOP 5.0 — no ECG electrodes.
+    case fiveZero
+    /// Not identified yet, contradictory evidence, or a non-WHOOP strap. NEVER a guess.
+    case unknown
+
+    /// Short display label ("MG" / "5.0" / "—"). UI strings live in the app layer's catalogs;
+    /// this is the bare token for logs + diagnostics.
+    public var label: String {
+        switch self {
+        case .mg: return "MG"
+        case .fiveZero: return "5.0"
+        case .unknown: return "—"
+        }
+    }
+
+    /// True only when the strap is a POSITIVELY identified MG. `.unknown` is not MG, so an
+    /// MG-only feature stays gated off until the hardware actually attests to it.
+    public var isMG: Bool { self == .mg }
+
+    /// The serial prefix that attests an MG (BLE DIS Serial Number String, `0x2A25`).
+    static let mgSerialPrefix = "5AM"
+    /// The serial prefix that attests a plain 5.0.
+    static let fiveZeroSerialPrefix = "5AG"
+    /// The observed 5.0 Hardware Revision String (`0x2A27`), e.g. "WG50_r52". The MG's own
+    /// hardware-revision string is NOT yet attested on real hardware, so its absence proves nothing.
+    static let fiveZeroHardwareIDToken = "WG50"
+
+    /// Resolve the variant from the strap's Device Information Service strings.
+    ///
+    /// - Parameters:
+    ///   - serial: DIS Serial Number String (`0x2A25`), or the advertised name — a leading
+    ///     "WHOOP " is tolerated so a caller can pass either.
+    ///   - hardwareRevision: DIS Hardware Revision String (`0x2A27`), when it has been read.
+    ///
+    /// Resolution order, and why:
+    ///  1. Both signals present and CONTRADICTORY (hw says 5.0, serial says MG) → `.unknown`.
+    ///     We refuse to pick a winner: only the 5.0 hardware string is attested today, so a
+    ///     contradiction means our model is incomplete, not that one source is authoritative.
+    ///     Mis-stamping hardware is exactly what #716 cost us — an honest "unknown" is cheaper.
+    ///  2. Hardware revision carrying the known 5.0 token → `.fiveZero` (device-attested).
+    ///  3. Serial prefix → `.mg` / `.fiveZero`.
+    ///  4. Anything else → `.unknown`. Never infer from a digit elsewhere in the name (#772).
+    public static func from(serial: String?, hardwareRevision: String? = nil) -> Whoop5Variant {
+        let hw = (hardwareRevision ?? "").uppercased()
+        var s = (serial ?? "").uppercased().trimmingCharacters(in: .whitespacesAndNewlines)
+        if s.hasPrefix("WHOOP ") { s = String(s.dropFirst("WHOOP ".count)) }
+        s = s.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        let hwSaysFiveZero = hw.contains(fiveZeroHardwareIDToken)
+        let serialSaysMG = s.hasPrefix(mgSerialPrefix)
+
+        if hwSaysFiveZero && serialSaysMG { return .unknown }   // contradiction — do not guess
+        if hwSaysFiveZero { return .fiveZero }
+        if serialSaysMG { return .mg }
+        if s.hasPrefix(fiveZeroSerialPrefix) { return .fiveZero }
+        return .unknown
+    }
+}

--- a/Packages/WhoopProtocol/Tests/WhoopProtocolTests/Whoop5VariantTests.swift
+++ b/Packages/WhoopProtocol/Tests/WhoopProtocolTests/Whoop5VariantTests.swift
@@ -1,0 +1,54 @@
+import XCTest
+@testable import WhoopProtocol
+
+final class Whoop5VariantTests: XCTestCase {
+
+    func testSerialPrefixIdentifiesMG() {
+        XCTAssertEqual(Whoop5Variant.from(serial: "5AM12345678"), .mg)
+        XCTAssertTrue(Whoop5Variant.from(serial: "5AM12345678").isMG)
+    }
+
+    func testSerialPrefixIdentifiesFiveZero() {
+        XCTAssertEqual(Whoop5Variant.from(serial: "5AG12345678"), .fiveZero)
+        XCTAssertFalse(Whoop5Variant.from(serial: "5AG12345678").isMG)
+    }
+
+    func testHardwareRevisionIsDeviceAttestedFiveZero() {
+        // The observed 5.0 hardware id, with no serial available at all.
+        XCTAssertEqual(Whoop5Variant.from(serial: nil, hardwareRevision: "WG50_r52"), .fiveZero)
+    }
+
+    func testAdvertisedNamePrefixTolerated() {
+        // Callers may pass the advertised name instead of the DIS serial.
+        XCTAssertEqual(Whoop5Variant.from(serial: "WHOOP 5AM12345678"), .mg)
+        XCTAssertEqual(Whoop5Variant.from(serial: "  whoop 5ag12345678  "), .fiveZero)
+    }
+
+    func testContradictionYieldsUnknownRatherThanAGuess() {
+        // Only the 5.0 hardware string is attested today; a contradiction means our model is
+        // incomplete, so refuse to pick a winner (#716: a mis-stamped model is worse than none).
+        XCTAssertEqual(Whoop5Variant.from(serial: "5AM12345678", hardwareRevision: "WG50_r52"), .unknown)
+    }
+
+    func testAgreeingSignalsResolve() {
+        XCTAssertEqual(Whoop5Variant.from(serial: "5AG12345678", hardwareRevision: "WG50_r52"), .fiveZero)
+    }
+
+    func testUnattestedInputsAreUnknownNeverInferred() {
+        XCTAssertEqual(Whoop5Variant.from(serial: nil), .unknown)
+        XCTAssertEqual(Whoop5Variant.from(serial: ""), .unknown)
+        XCTAssertEqual(Whoop5Variant.from(serial: "WHOOP"), .unknown)
+        // A stray digit in the name must NOT imply a generation (#772 — the bug that read a
+        // serial's "5" as Gen5 on a Gen3 ring; same failure mode, different product).
+        XCTAssertEqual(Whoop5Variant.from(serial: "WHOOP 4.0"), .unknown)
+        XCTAssertEqual(Whoop5Variant.from(serial: "5XX99999999"), .unknown)
+        // An MG hardware-revision string is not yet attested, so it must not resolve by itself.
+        XCTAssertEqual(Whoop5Variant.from(serial: nil, hardwareRevision: "WGMG_r01"), .unknown)
+    }
+
+    func testLabels() {
+        XCTAssertEqual(Whoop5Variant.mg.label, "MG")
+        XCTAssertEqual(Whoop5Variant.fiveZero.label, "5.0")
+        XCTAssertEqual(Whoop5Variant.unknown.label, "—")
+    }
+}

--- a/android/app/src/main/java/com/noop/protocol/Whoop5Variant.kt
+++ b/android/app/src/main/java/com/noop/protocol/Whoop5Variant.kt
@@ -1,0 +1,71 @@
+package com.noop.protocol
+
+/**
+ * Whoop5Variant — WHOOP MG vs plain WHOOP 5.0 hardware discrimination (#520).
+ *
+ * DELIBERATELY ORTHOGONAL to [DeviceFamily]. `DeviceFamily.WHOOP5` describes the WIRE PROTOCOL
+ * (CRC16-Modbus header, puffin packet types) and MG and 5.0 are byte-identical there — every
+ * framing/interpreter branch must keep treating them as one family. This type describes the
+ * HARDWARE instead: an MG carries the ECG-conductive clasp, a 5.0 does not. Keeping the two apart
+ * means a capability gate (ECG, and later BP) can never accidentally change how a frame is parsed.
+ *
+ * Pure: no Android, no I/O. Faithful twin of WhoopProtocol/Whoop5Variant.swift — keep them
+ * byte-identical (same resolution order, same unknown-over-guess rule).
+ *
+ * Provenance: the serial prefixes and the 5.0 hardware-revision string are protocol FACTS
+ * (uncopyrightable), corroborated by community reverse-engineering discussed in #520. They are read
+ * from the standard BLE Device Information Service, not from any WHOOP code.
+ */
+enum class Whoop5Variant(val label: String) {
+    /** WHOOP MG — has the ECG-conductive clasp. */
+    MG("MG"),
+    /** WHOOP 5.0 — no ECG electrodes. */
+    FIVE_ZERO("5.0"),
+    /** Not identified yet, contradictory evidence, or a non-WHOOP strap. NEVER a guess. */
+    UNKNOWN("—");
+
+    /** True only for a POSITIVELY identified MG, so an MG-only feature stays gated off otherwise. */
+    val isMG: Boolean get() = this == MG
+
+    companion object {
+        /** Serial prefix attesting an MG (BLE DIS Serial Number String, 0x2A25). */
+        const val MG_SERIAL_PREFIX = "5AM"
+        /** Serial prefix attesting a plain 5.0. */
+        const val FIVE_ZERO_SERIAL_PREFIX = "5AG"
+        /**
+         * Observed 5.0 Hardware Revision String (0x2A27), e.g. "WG50_r52". The MG's own
+         * hardware-revision string is NOT yet attested on real hardware, so its absence proves nothing.
+         */
+        const val FIVE_ZERO_HARDWARE_ID_TOKEN = "WG50"
+
+        /**
+         * Resolve the variant from the strap's Device Information Service strings.
+         *
+         * [serial] is the DIS Serial Number String (0x2A25) or the advertised name (a leading
+         * "WHOOP " is tolerated). [hardwareRevision] is the DIS Hardware Revision String (0x2A27).
+         *
+         * Resolution order, and why:
+         *  1. Both present and CONTRADICTORY (hw says 5.0, serial says MG) -> [UNKNOWN]. Only the
+         *     5.0 hardware string is attested today, so a contradiction means our model is
+         *     incomplete, not that one source wins. Mis-stamping hardware is what #716 cost us.
+         *  2. Hardware revision carrying the known 5.0 token -> [FIVE_ZERO] (device-attested).
+         *  3. Serial prefix -> [MG] / [FIVE_ZERO].
+         *  4. Anything else -> [UNKNOWN]. Never infer from a stray digit in the name (#772).
+         */
+        fun from(serial: String?, hardwareRevision: String? = null): Whoop5Variant {
+            val hw = (hardwareRevision ?: "").uppercase()
+            var s = (serial ?: "").uppercase().trim()
+            if (s.startsWith("WHOOP ")) s = s.removePrefix("WHOOP ")
+            s = s.trim()
+
+            val hwSaysFiveZero = hw.contains(FIVE_ZERO_HARDWARE_ID_TOKEN)
+            val serialSaysMG = s.startsWith(MG_SERIAL_PREFIX)
+
+            if (hwSaysFiveZero && serialSaysMG) return UNKNOWN   // contradiction — do not guess
+            if (hwSaysFiveZero) return FIVE_ZERO
+            if (serialSaysMG) return MG
+            if (s.startsWith(FIVE_ZERO_SERIAL_PREFIX)) return FIVE_ZERO
+            return UNKNOWN
+        }
+    }
+}

--- a/android/app/src/test/java/com/noop/protocol/Whoop5VariantTest.kt
+++ b/android/app/src/test/java/com/noop/protocol/Whoop5VariantTest.kt
@@ -1,0 +1,62 @@
+package com.noop.protocol
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Mirrors WhoopProtocolTests/Whoop5VariantTests.swift — same fixtures, same expected outputs, so the
+ * twin resolvers cannot drift.
+ */
+class Whoop5VariantTest {
+
+    @Test fun serialPrefixIdentifiesMg() {
+        assertEquals(Whoop5Variant.MG, Whoop5Variant.from("5AM12345678"))
+        assertTrue(Whoop5Variant.from("5AM12345678").isMG)
+    }
+
+    @Test fun serialPrefixIdentifiesFiveZero() {
+        assertEquals(Whoop5Variant.FIVE_ZERO, Whoop5Variant.from("5AG12345678"))
+        assertFalse(Whoop5Variant.from("5AG12345678").isMG)
+    }
+
+    @Test fun hardwareRevisionIsDeviceAttestedFiveZero() {
+        // The observed 5.0 hardware id, with no serial available at all.
+        assertEquals(Whoop5Variant.FIVE_ZERO, Whoop5Variant.from(null, "WG50_r52"))
+    }
+
+    @Test fun advertisedNamePrefixTolerated() {
+        // Callers may pass the advertised name instead of the DIS serial.
+        assertEquals(Whoop5Variant.MG, Whoop5Variant.from("WHOOP 5AM12345678"))
+        assertEquals(Whoop5Variant.FIVE_ZERO, Whoop5Variant.from("  whoop 5ag12345678  "))
+    }
+
+    @Test fun contradictionYieldsUnknownRatherThanAGuess() {
+        // Only the 5.0 hardware string is attested today; a contradiction means our model is
+        // incomplete, so refuse to pick a winner (#716: a mis-stamped model is worse than none).
+        assertEquals(Whoop5Variant.UNKNOWN, Whoop5Variant.from("5AM12345678", "WG50_r52"))
+    }
+
+    @Test fun agreeingSignalsResolve() {
+        assertEquals(Whoop5Variant.FIVE_ZERO, Whoop5Variant.from("5AG12345678", "WG50_r52"))
+    }
+
+    @Test fun unattestedInputsAreUnknownNeverInferred() {
+        assertEquals(Whoop5Variant.UNKNOWN, Whoop5Variant.from(null))
+        assertEquals(Whoop5Variant.UNKNOWN, Whoop5Variant.from(""))
+        assertEquals(Whoop5Variant.UNKNOWN, Whoop5Variant.from("WHOOP"))
+        // A stray digit in the name must NOT imply a generation (#772 — the bug that read a
+        // serial's "5" as Gen5 on a Gen3 ring; same failure mode, different product).
+        assertEquals(Whoop5Variant.UNKNOWN, Whoop5Variant.from("WHOOP 4.0"))
+        assertEquals(Whoop5Variant.UNKNOWN, Whoop5Variant.from("5XX99999999"))
+        // An MG hardware-revision string is not yet attested, so it must not resolve by itself.
+        assertEquals(Whoop5Variant.UNKNOWN, Whoop5Variant.from(null, "WGMG_r01"))
+    }
+
+    @Test fun labels() {
+        assertEquals("MG", Whoop5Variant.MG.label)
+        assertEquals("5.0", Whoop5Variant.FIVE_ZERO.label)
+        assertEquals("—", Whoop5Variant.UNKNOWN.label)
+    }
+}


### PR DESCRIPTION
## What this PR does

`DeviceFamily` collapses WHOOP MG and plain 5.0 into a single `.whoop5` case (its doc comment literally reads "Whoop 5.0 / MG"), and NOOP reads **no** Device Information Service today. So nothing can gate an MG-only capability (ECG, later BP), and diagnostics can't report which hardware is actually attached. This adds the discrimination as a pure, orthogonal type.

**Deliberately NOT a new `DeviceFamily` case.** That enum drives the **wire protocol** (CRC16-Modbus header, puffin packet types) and is switched on in `Framing`/`Interpreter`/`Streams`/`BLEManager`. MG and 5.0 are **byte-identical** there, so adding a case would force every exhaustive switch to handle a variant that parses the same — risk with no benefit. `Whoop5Variant` is orthogonal: `DeviceFamily` = how frames are parsed, `Whoop5Variant` = what the hardware can do, so a capability gate can never accidentally change decoding.

**Resolution** — protocol facts read from the standard BLE DIS (serial `0x2A25`, hardware revision `0x2A27`):

| Signal | Result |
|---|---|
| hw revision contains `WG50` | `.fiveZero` (device-attested) |
| serial prefix `5AM` | `.mg` |
| serial prefix `5AG` | `.fiveZero` |
| **contradiction** (hw `WG50` + serial `5AM`) | **`.unknown`** |
| anything else | `.unknown` |

Two deliberate choices:
- **A contradiction yields `unknown`, not a winner.** Only the *5.0* hardware string is attested today — the MG's is still uncaptured — so a contradiction means our model is incomplete, not that one source is authoritative. A mis-stamped model is exactly what **#716** cost.
- **Never infer from a stray digit** in the name (`"WHOOP 4.0"` → `unknown`), tested explicitly — the **#772** failure mode.

**Not in this PR:** the DIS read that supplies these strings. That's app-target BLE (read-only characteristics, no writes to the strap) and needs a real 5.0/MG to confirm — this is the pure, testable half it would feed.

**Provenance:** the serial prefixes and the 5.0 hardware token are protocol **facts** (uncopyrightable), corroborated by community reverse-engineering discussed in #520 — implemented independently here, no third-party code copied.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] CI / tooling

## How it was tested

Pure type — no CoreBluetooth, no Android, no BLE path touched — so there is nothing to validate on hardware in *this* PR (the DIS read that does touch BLE is deliberately excluded, see above).

- **`test (WhoopProtocol)` is green in CI**, which compiles the Swift and runs the new `Whoop5VariantTests` on macOS.
- **13 mirrored fixtures** on both platforms: both serial prefixes, the hardware-revision path, advertised-name tolerance (`"WHOOP 5AM…"`, mixed case, whitespace), the contradiction case, and every never-guess case.
- I could not compile locally (no macOS; the JVM test path is blocked on this host), so before pushing I validated the resolution logic against a reference implementation — all 13 vectors pass. CI has since confirmed the Swift half independently.
- **Kotlin twin is not covered by default CI** (`android.yml` is disabled): worth a `./gradlew testFullDebugUnitTest --tests "com.noop.protocol.*"` before merge.

## Checklist

- [x] Swift package tests pass for any package I touched (`swift test` in `Packages/<name>`) — green in CI
- [ ] Android unit tests pass if I touched `android/` (`./gradlew testFullDebugUnitTest`) — **not run locally**, see above
- [x] No new build warnings introduced
- [x] UI changes use only `StrandDesign` tokens — no hardcoded colors, fonts, or spacing (no UI in this PR)
- [x] No hardcoded hex frame bytes; protocol facts live in the schema / decoders
- [x] Follows the conventions in [`docs/CONTRIBUTING.md`](../docs/CONTRIBUTING.md)
- [x] I did not commit generated output (`Strand.xcodeproj/`) or any secrets/keystores

## Related issues

Addresses the MG-detection gap raised in #520.
