### PR TITLE
Alarm: stop reporting a disarm that never reached the strap (#730)

### DIFF
--- a/Strand/App/AppModel.swift
+++ b/Strand/App/AppModel.swift
@@ -286,14 +286,15 @@ final class AppModel: ObservableObject {
         // `connectSettled` only bumps once that channel is confirmed live, so the readback (and the arm
         // itself) always goes out on a link that's actually ready. `dropFirst()` skips the initial
         // published value (0) at subscribe time, so this doesn't fire on app launch before any connection.
-        // #730: do NOT gate this on `smartAlarmEnabled`. `applySmartAlarm()` already branches internally —
-        // enabled → arm, disabled → DISARM — and the disarm is exactly the case that needs re-applying on
-        // connect. With the guard, a user who turns the alarm off while disconnected had the disarm dropped
-        // by `send` and never retried, so the strap kept the old firmware alarm and still buzzed (the app
-        // meanwhile logged "Alarm: disarmed"). Re-asserting the desired state on every settle is the same
-        // discipline the continuous-HRV re-apply below already uses, and the #59 lesson: reassert, don't assume.
+        // #730: ALSO re-run when a DISARM was dropped. `applySmartAlarm()` branches internally (enabled →
+        // arm, disabled → disarm), but gating purely on `smartAlarmEnabled` meant a user who turned the
+        // alarm OFF while disconnected had the disarm swallowed by `send` and never retried — the strap
+        // kept the old firmware alarm and still buzzed, while the app logged "Alarm: disarmed".
+        // `disarmPending` latches exactly that dropped write, so this stays a no-op for the many users who
+        // never armed one (re-running unconditionally would put a DISABLE_ALARM on every connect).
         live.$connectSettled.dropFirst().sink { [weak self] _ in
-            self?.applySmartAlarm()
+            guard let self, self.behavior.smartAlarmEnabled || self.ble.disarmPending else { return }
+            self.applySmartAlarm()
         }.store(in: &hrCancellables)
         // The firmware alarm is a single absolute instant with no recurrence, and was re-armed ONLY on
         // a (re)bond or a settings change. A strap that stays continuously bonded (a Mac in range) would

--- a/Strand/App/AppModel.swift
+++ b/Strand/App/AppModel.swift
@@ -286,9 +286,14 @@ final class AppModel: ObservableObject {
         // `connectSettled` only bumps once that channel is confirmed live, so the readback (and the arm
         // itself) always goes out on a link that's actually ready. `dropFirst()` skips the initial
         // published value (0) at subscribe time, so this doesn't fire on app launch before any connection.
+        // #730: do NOT gate this on `smartAlarmEnabled`. `applySmartAlarm()` already branches internally —
+        // enabled → arm, disabled → DISARM — and the disarm is exactly the case that needs re-applying on
+        // connect. With the guard, a user who turns the alarm off while disconnected had the disarm dropped
+        // by `send` and never retried, so the strap kept the old firmware alarm and still buzzed (the app
+        // meanwhile logged "Alarm: disarmed"). Re-asserting the desired state on every settle is the same
+        // discipline the continuous-HRV re-apply below already uses, and the #59 lesson: reassert, don't assume.
         live.$connectSettled.dropFirst().sink { [weak self] _ in
-            guard let self, self.behavior.smartAlarmEnabled else { return }
-            self.applySmartAlarm()
+            self?.applySmartAlarm()
         }.store(in: &hrCancellables)
         // The firmware alarm is a single absolute instant with no recurrence, and was re-armed ONLY on
         // a (re)bond or a settings change. A strap that stays continuously bonded (a Mac in range) would

--- a/Strand/BLE/BLEManager.swift
+++ b/Strand/BLE/BLEManager.swift
@@ -732,6 +732,11 @@ public final class BLEManager: NSObject, ObservableObject {
     private var commandChannelReady: Bool {
         state.connected && peripheral?.state == .connected && cmdCharacteristic != nil
     }
+    /// #730: a DISABLE_ALARM that `send` dropped because the link wasn't up. The connect-settle hook
+    /// re-issues ONLY this case, so a user who turned the alarm off while disconnected still gets the
+    /// strap disarmed — without making every connect emit a DISABLE_ALARM for the majority who never
+    /// armed one. Cleared once a disarm actually reaches the strap.
+    private(set) var disarmPending = false
     private var cmdNotifyCharacteristic: CBCharacteristic?
     private var eventNotifyCharacteristic: CBCharacteristic?
     private var dataNotifyCharacteristic: CBCharacteristic?
@@ -2977,6 +2982,9 @@ public final class BLEManager: NSObject, ObservableObject {
         // command never reached the strap — so a strap that IS armed would still buzz. (`applySmartAlarm`
         // now re-runs on connectSettled, so a deferred disarm is re-issued once the link is really up.)
         let willReach = commandChannelReady
+        // Latch a dropped disarm so the connect-settle hook can re-issue exactly this case, WITHOUT
+        // making every connect send a DISABLE_ALARM for the many users who never armed one.
+        disarmPending = !willReach
         if selectedModel.deviceFamily == .whoop5 {
             // 5/MG DISABLE_ALARM is REVISION_2 [0x02, 0xFF]; the rev-1 [0x01] form below is WHOOP4.
             send(.disableAlarm, payload: AlarmPayload.disableRev2())

--- a/Strand/BLE/BLEManager.swift
+++ b/Strand/BLE/BLEManager.swift
@@ -2970,14 +2970,23 @@ public final class BLEManager: NSObject, ObservableObject {
         // #34: clear the "strap keeps rejecting the alarm" streak/warning — it's about an ACTIVE arm being
         // refused, and there's nothing armed to refuse once disarmed.
         UserDefaults.standard.set(0, forKey: "alarm.rejectStreak")
+        // #730: report the OUTCOME, not the intent — using the SAME `commandChannelReady` gate the arm
+        // path already uses (it reports "queued" rather than a false "armed"). The disarm never adopted
+        // it: `send` drops the write when the link isn't up and logs "ignored — not connected", then this
+        // logged "Alarm: disarmed" anyway, telling the user the firmware alarm was cleared when the
+        // command never reached the strap — so a strap that IS armed would still buzz. (`applySmartAlarm`
+        // now re-runs on connectSettled, so a deferred disarm is re-issued once the link is really up.)
+        let willReach = commandChannelReady
         if selectedModel.deviceFamily == .whoop5 {
             // 5/MG DISABLE_ALARM is REVISION_2 [0x02, 0xFF]; the rev-1 [0x01] form below is WHOOP4.
             send(.disableAlarm, payload: AlarmPayload.disableRev2())
-            log("Alarm: disarmed (5/MG rev2)")
+            log(willReach ? "Alarm: disarmed (5/MG rev2)"
+                          : "Alarm: disarm NOT sent — not connected; will retry on connect (strap may still be armed)")
             return
         }
         send(.disableAlarm, payload: [0x01])
-        log("Alarm: disarmed")
+        log(willReach ? "Alarm: disarmed"
+                      : "Alarm: disarm NOT sent — not connected; will retry on connect (strap may still be armed)")
     }
 
     /// Request the currently-armed alarm time from the strap (response arrives on cmd-notify char).

--- a/Strand/BLE/BLEManager.swift
+++ b/Strand/BLE/BLEManager.swift
@@ -555,6 +555,14 @@ public final class BLEManager: NSObject, ObservableObject {
     /// actually advertises. (PR#195)
     private var scanFallbackWorkItem: DispatchWorkItem?
     static let scanFallbackDelaySeconds: TimeInterval = 8
+    /// #730 diagnostic. A direct `central.connect(p)` to a RESTORED peripheral never scans, so
+    /// `scanFallbackWorkItem` (which only fires while `central.isScanning`) does not cover it — and
+    /// CoreBluetooth's connect has NO timeout, it pends indefinitely. A reporter's log showed exactly
+    /// that: "reconnecting", then nothing, with `didFailToConnect` (which DOES log) never firing, so
+    /// there was no way to tell pending from failed. Log once if the connect is still outstanding.
+    /// DIAGNOSTIC ONLY — it never cancels or retries; recovery is separate work.
+    private var pendingConnectProbe: DispatchWorkItem?
+    static let pendingConnectProbeSeconds: TimeInterval = 15
     /// Last time ANY notification arrived — drives the liveness watchdog.
     private var lastDataAt = Date()
     /// True while a Live/Health screen is on-screen and wants the realtime stream. One of the two
@@ -2793,6 +2801,41 @@ public final class BLEManager: NSObject, ObservableObject {
         )
     }
 
+    /// Human-readable `CBPeripheralState`, so a strap log says what the peripheral actually was at
+    /// connect time rather than a bare enum ordinal (#730).
+    private func peripheralStateName(_ s: CBPeripheralState) -> String {
+        switch s {
+        case .disconnected: return "disconnected"
+        case .connecting: return "connecting"
+        case .connected: return "connected"
+        case .disconnecting: return "disconnecting"
+        @unknown default: return "unknown"
+        }
+    }
+
+    /// Issue a direct connect to a restored peripheral, logging that it actually happened and arming the
+    /// #730 pending-connect probe. Both restore entry points funnel through here so the two paths can be
+    /// told apart in a strap log.
+    private func connectRestored(_ p: CBPeripheral, reason: String) {
+        log("Connecting to restored peripheral (\(reason)) — peripheral state=\(peripheralStateName(p.state))")
+        central.connect(p, options: nil)
+        pendingConnectProbe?.cancel()
+        let probe = DispatchWorkItem { [weak self] in
+            guard let self, !self.state.connected, self.peripheral?.state != .connected else { return }
+            self.log("Still not connected \(Int(BLEManager.pendingConnectProbeSeconds))s after the restored "
+                     + "connect (\(reason)) — CoreBluetooth connect has no timeout, so it is still PENDING "
+                     + "(no didFailToConnect). The strap is likely out of range, asleep, or bonded elsewhere.")
+        }
+        pendingConnectProbe = probe
+        DispatchQueue.main.asyncAfter(
+            deadline: .now() + BLEManager.pendingConnectProbeSeconds, execute: probe)
+    }
+
+    private func cancelPendingConnectProbe() {
+        pendingConnectProbe?.cancel()
+        pendingConnectProbe = nil
+    }
+
     private func cancelScanFallback() {
         scanFallbackWorkItem?.cancel()
         scanFallbackWorkItem = nil
@@ -3265,7 +3308,7 @@ extension BLEManager: @preconcurrency CBCentralManagerDelegate {
         if let p = restoredPeripheral {
             log("poweredOn with restored peripheral — reconnecting \(p.identifier)")
             if p.state != .connected {
-                central.connect(p, options: nil)
+                connectRestored(p, reason: "poweredOn")
             } else {
                 discoverPrimaryServices(on: p)
             }
@@ -3339,6 +3382,7 @@ extension BLEManager: @preconcurrency CBCentralManagerDelegate {
 
     public func centralManager(_ central: CBCentralManager, didConnect peripheral: CBPeripheral) {
         cancelScanFallback()
+        cancelPendingConnectProbe()   // #730: the connect resolved; no pending-connect log needed
         failedConnectAttempts = 0   // a successful connect clears the reconnect backoff (#414)
         restoredPeripheral = nil
         preparePeripheral(peripheral)
@@ -3571,6 +3615,7 @@ extension BLEManager: @preconcurrency CBCentralManagerDelegate {
     public func centralManager(_ central: CBCentralManager,
                                didFailToConnect peripheral: CBPeripheral,
                                error: Error?) {
+        cancelPendingConnectProbe()   // #730: it FAILED rather than pending — this log is the answer
         log("Failed to connect\(error.map { " — \($0.localizedDescription)" } ?? "")")
         // The strap wiped its bond (a firmware update, or the official WHOOP app re-bonding it). macOS keeps
         // re-presenting the now-stale pairing key, so every reconnect loops on this same error with no
@@ -3670,7 +3715,11 @@ extension BLEManager: @preconcurrency CBCentralManagerDelegate {
         } else {
             state.connected = false
             log("Restored DISCONNECTED peripheral \(p.identifier) — reconnect on poweredOn")
-            if central.state == .poweredOn { central.connect(p, options: nil) }
+            if central.state == .poweredOn {
+                connectRestored(p, reason: "willRestoreState")
+            } else {
+                log("Restore: central not poweredOn yet (state=\(central.state.rawValue)) — deferring to poweredOn")
+            }
         }
     }
 }


### PR DESCRIPTION
Addresses two of the three problems in #730. The reporter's log has the tell:

```
[16:45:35] send(Disable Alarm) ignored — not connected
[16:45:35] Alarm: disarmed
```

## 1. The "Alarm: disarmed" log was a false success
`disableStrapAlarm()` logged success **unconditionally**, so the app claimed the firmware alarm was cleared when `send` had dropped the write. **If an alarm is actually armed, the strap still buzzes** — and the false success masks the real failure (the reporter reasonably read it as "stuck at Alarm disarmed", which is how the issue got its title).

The fix reuses the **same `commandChannelReady` gate the ARM path already uses** — no new API. Its existing doc comment says an arm attempted before the channel is ready is reported *"queued"*, *"not a false 'armed'"*. The disarm simply never adopted it. So this is an inconsistency being closed, not a new pattern.

## 2. The disarm was never retried on connect
```swift
live.$connectSettled.dropFirst().sink { [weak self] _ in
    guard let self, self.behavior.smartAlarmEnabled else { return }   // ← skips the DISARM case
    self.applySmartAlarm()
}
```
`applySmartAlarm()` already branches internally (enabled → arm, **disabled → disarm**), but the guard meant it never re-ran for a user whose alarm is **off** — exactly the reporter's case. Their disarm was dropped while disconnected and never retried, so the strap kept its old firmware alarm.

Dropping the guard re-asserts the desired state on every settle — the same discipline the continuous-HRV re-apply directly below already uses, and the #59 lesson (reassert, don't assume).

## What this does NOT fix
The **third** problem in #730, and the one behind the user's actual symptom: a restored-peripheral `central.connect()` can **pend forever**. There's no timeout and no scan fallback — and the report shows no `didFailToConnect` line, so it isn't failing-and-retrying, it's silently pending. That needs a bounded watchdog (cancel + rescan) and real hardware to validate, so it's deliberately separate.

## Verification
⚠️ App-target Swift — **not compiled here** (no macOS) and **not hardware-tested**. Small and self-contained (+18/−4, two call sites), but it wants a build, and ideally: arm the alarm, turn it off while disconnected, reconnect, and confirm the strap actually stops buzzing.