### PR TITLE
Android parity: stop reporting a disarm that never reached the strap (#730)

### DIFF
--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -3289,7 +3289,7 @@ class WhoopBleClient(
     /** Whether a command written right now would actually reach the strap — the same conditions [send]
      *  guards on. Lets a caller that REPORTS an outcome to the user check first, instead of logging
      *  success for a write that was dropped (#730). Twin of macOS `commandChannelReady`. */
-    val commandChannelReady: Boolean get() = gatt != null && cmdCharacteristic != null
+    private val commandChannelReady: Boolean get() = gatt != null && cmdCharacteristic != null
 
     /** Clear the strap's firmware alarm. Port of macOS `BLEManager.disableStrapAlarm`. */
     fun disableStrapAlarm() {

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -3286,17 +3286,29 @@ class WhoopBleClient(
         }
     }
 
+    /** Whether a command written right now would actually reach the strap — the same conditions [send]
+     *  guards on. Lets a caller that REPORTS an outcome to the user check first, instead of logging
+     *  success for a write that was dropped (#730). Twin of macOS `commandChannelReady`. */
+    val commandChannelReady: Boolean get() = gatt != null && cmdCharacteristic != null
+
     /** Clear the strap's firmware alarm. Port of macOS `BLEManager.disableStrapAlarm`. */
     fun disableStrapAlarm() {
+        // #730: report the OUTCOME, not the intent. [send] drops the write when the link isn't up and logs
+        // "ignored — not connected", but this then logged "Alarm: disarmed" anyway — telling the user the
+        // firmware alarm was cleared when the command never reached the strap, so a strap that IS armed
+        // would still buzz. (reconcileStrapAlarm already re-runs on the bond edge, so a deferred disarm is
+        // re-issued once the link is up — Android never had the iOS gap where that re-apply was skipped.)
+        val willReach = commandChannelReady
+        val notSent = "Alarm: disarm NOT sent — not connected; will retry on connect (strap may still be armed)"
         if (connectedFamily == DeviceFamily.WHOOP5) {
             // 5/MG DISABLE_ALARM is REVISION_2 [0x02, 0xFF]. Sent unconditionally (clearing is safe
             // even if arming was gated off — a no-op on a strap with no alarm set). (PR #85)
             send(CommandNumber.DISABLE_ALARM, AlarmPayload.disableRev2())
-            log("Alarm: disarmed (5/MG rev2)")
+            log(if (willReach) "Alarm: disarmed (5/MG rev2)" else notSent)
             return
         }
         send(CommandNumber.DISABLE_ALARM, byteArrayOf(0x01))
-        log("Alarm: disarmed")
+        log(if (willReach) "Alarm: disarmed" else notSent)
     }
 
     // ====================================================================================


### PR DESCRIPTION
Parity follow-up to #784, which fixed this on iOS/macOS. **Android had the identical defect.**

`disableStrapAlarm()` logged `"Alarm: disarmed"` unconditionally, while `send()` drops the write and logs `send(...) ignored — not connected`. So the app claimed the firmware alarm was cleared when the command never reached the strap — and if one **is** armed, the strap still buzzes.

Mirrors the Swift fix exactly: a `commandChannelReady` twin (the same conditions `send()` guards on — `gatt != null && cmdCharacteristic != null`) decides which line gets logged.

## What Android did NOT need
The **second** iOS defect doesn't exist here, and it's worth recording why: `reconcileStrapAlarm()` is the sole caller of arm/disarm, handles the disarm case internally (`epochSec == null → disableStrapAlarm()`), and is called **ungated** on the bond edge (`state.bonded && !lastBonded`) plus the daily tick. So a deferred disarm was already re-issued on reconnect. iOS's `smartAlarmEnabled` guard was the outlier — #784 brought iOS into line with Android, not the other way round.

Minor mechanism difference, feature-level parity intact: Android re-asserts the disarm on every bond edge; iOS (#784) latches `disarmPending` and only re-issues a dropped one, so it doesn't add a `DISABLE_ALARM` to every connect. Observable behaviour is the same — the strap ends up disarmed.

The **#730 restored-connect diagnostic** also doesn't port: Android has no CoreBluetooth state restoration, so that code path has no analogue.

## Verification
⚠️ App-target Android — **not compiled here** (`aapt2` is x86-only on this arm64 host) and not hardware-tested. `WhoopBleClient` is Android-coupled, so the pure-Kotlin test route that verified `Whoop5Variant` doesn't reach it. Small and self-contained (+14/−2); wants a `./gradlew compileFullDebugKotlin`.