### PR TITLE
diag: report the HRV baseline recalibration epoch + dropped nights (#731)

### DIFF
--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/Baselines.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/Baselines.swift
@@ -354,6 +354,30 @@ public enum Baselines {
     /// When `baselineEpoch <= 0` (the default / no recalibration) this is byte-identical to the plain
     /// `foldHistory(_:cfg:)`. When `baselineEpoch` is nil it is read from UserDefaults via
     /// `hrvBaselineEpoch()` so callers that already use the HRV config get recalibration for free.
+    /// Diagnostic companion to the epoch-aware `foldHistory` (#731): how many nights that fold DROPS
+    /// because they predate the recalibration epoch, plus the epoch itself as a `yyyy-MM-dd` day key
+    /// (nil when no recalibration is set).
+    ///
+    /// Exists because a "Charge is stuck" report is otherwise unexplainable from a strap log. A user who
+    /// taps "Recalibrate baseline" discards every earlier night and must re-earn `minNightsSeed` nights;
+    /// tapping it again resets that progress to zero. A reporter did exactly that for two weeks — 15 valid
+    /// HRV nights on file, but `nValid=3` and no Charge — and nothing in the log said the epoch was why.
+    /// Mirrors the fold's drop rule EXACTLY (same UTC day-start parse, same strict `<` comparison), so the
+    /// number reported is the number actually dropped.
+    public static func epochDropDiagnostic(dayKeys: [String],
+                                           baselineEpoch: Double? = nil) -> (dropped: Int, epochDay: String?) {
+        let epoch = baselineEpoch ?? hrvBaselineEpoch()
+        guard epoch > 0 else { return (0, nil) }
+        let fmt = DateFormatter()
+        fmt.calendar = Calendar(identifier: .gregorian)
+        fmt.timeZone = TimeZone(secondsFromGMT: 0)
+        fmt.dateFormat = "yyyy-MM-dd"
+        let dropped = dayKeys.reduce(into: 0) { acc, key in
+            if let d = fmt.date(from: key), d.timeIntervalSince1970 < epoch { acc += 1 }
+        }
+        return (dropped, fmt.string(from: Date(timeIntervalSince1970: epoch)))
+    }
+
     public static func foldHistory(_ values: [Double?], dayKeys: [String], cfg: MetricCfg,
                                    baselineEpoch: Double? = nil) -> BaselineState {
         let epoch = baselineEpoch ?? hrvBaselineEpoch()

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/BaselineEpochDiagnosticTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/BaselineEpochDiagnosticTests.swift
@@ -1,0 +1,50 @@
+import XCTest
+@testable import StrandAnalytics
+
+/// #731: the epoch-drop diagnostic must report exactly what the epoch-aware fold drops, so a "Charge is
+/// stuck" strap log explains itself. Pinned against `foldHistory`'s own behaviour, not just in isolation.
+final class BaselineEpochDiagnosticTests: XCTestCase {
+
+    /// 2026-07-19 00:00:00 UTC — the recalibration instant used throughout.
+    private let epoch: Double = 1_784_419_200
+
+    private let days = ["2026-07-16", "2026-07-17", "2026-07-18",   // before the epoch → dropped
+                        "2026-07-19", "2026-07-20", "2026-07-21"]   // on/after → kept
+
+    func testNoEpochDropsNothing() {
+        let d = Baselines.epochDropDiagnostic(dayKeys: days, baselineEpoch: 0)
+        XCTAssertEqual(d.dropped, 0)
+        XCTAssertNil(d.epochDay, "no recalibration → no epoch day to report")
+    }
+
+    func testDropsOnlyNightsStrictlyBeforeTheEpoch() {
+        let d = Baselines.epochDropDiagnostic(dayKeys: days, baselineEpoch: epoch)
+        XCTAssertEqual(d.dropped, 3, "16/17/18 precede the epoch; the epoch day itself is KEPT")
+        XCTAssertEqual(d.epochDay, "2026-07-19")
+    }
+
+    /// The diagnostic is only useful if it agrees with the fold it describes: dropped + used == total.
+    func testAgreesWithFoldHistory() {
+        let cfg = Baselines.metricCfg["hrv"]!
+        let values: [Double?] = [40, 41, 42, 43, 44, 45]   // all in-range, so every KEPT night is valid
+        let state = Baselines.foldHistory(values, dayKeys: days, cfg: cfg, baselineEpoch: epoch)
+        let d = Baselines.epochDropDiagnostic(dayKeys: days, baselineEpoch: epoch)
+        XCTAssertEqual(d.dropped + state.nValid, days.count,
+                       "every night is either dropped by the epoch or counted by the fold")
+        XCTAssertEqual(state.nValid, 3, "the reporter's exact signature: 6 nights on file, 3 usable")
+    }
+
+    /// The reporter's case (#731): plenty of valid history, but a recent recalibration leaves the
+    /// baseline one night short of `minNightsSeed` — which read as "stuck" with no explanation.
+    func testReproducesTheStuckAtThreeSignature() {
+        let cfg = Baselines.metricCfg["hrv"]!
+        // 15 nights of good HRV, recalibrated so only the last 3 survive.
+        let allDays = (8...22).map { String(format: "2026-07-%02d", $0) }
+        let values: [Double?] = Array(repeating: 45.0, count: allDays.count)
+        let state = Baselines.foldHistory(values, dayKeys: allDays, cfg: cfg, baselineEpoch: 1_784_505_600) // 07-20
+        let d = Baselines.epochDropDiagnostic(dayKeys: allDays, baselineEpoch: 1_784_505_600)
+        XCTAssertEqual(d.dropped, 12)
+        XCTAssertEqual(state.nValid, 3)
+        XCTAssertFalse(state.usable, "3 < minNightsSeed(4) → Charge stays nil, exactly as reported")
+    }
+}


### PR DESCRIPTION
## Why

A reporter spent **two weeks** on "Charge not calculated". Their strap log showed **15 consecutive nights of good HRV** (44k–64k R-R/night, 1–3% rejection) and yet:

```
charge nilScore reason=hrvBaselineNotUsable hrvStatus=calibrating hrvNValid=3 (need nValid>=4)
```

Nothing was broken. They had tapped **Recalibrate baseline**, which deliberately **discards every night before that instant** — and each further tap reset the count to zero, so it could never reach 4. They were one night away, repeatedly.

**The log couldn't say any of that.** Finding it took a full trace through `IntelligenceEngine` → `foldHistory` → the defaulted `baselineEpoch` parameter. That's too expensive for something a single line can state.

## What this adds

`Baselines.epochDropDiagnostic(dayKeys:baselineEpoch:)` → `(dropped: Int, epochDay: String?)`

It mirrors the fold's drop rule **exactly** — same UTC day-start parse, same strict `<` comparison — so the number reported is the number actually dropped, not an approximation. `nil` epoch day when no recalibration is set.

Intended log line:
```
[recovery] hrvBaseline epoch=2026-07-19 (recalibrated) droppedNights=12 usedNights=3 (need >=4)
```

## Tests

Four, including two that matter beyond the happy path:
- **Agreement with the fold it describes:** `dropped + state.nValid == total`, asserted against `foldHistory` itself — so the diagnostic can't drift from reality.
- **The reporter's exact signature reproduced:** 15 nights on file, epoch at day 13 → `dropped=12`, `nValid=3`, `usable == false`. That test now pins the behaviour that caused this report.

Pure and CI-covered (`StrandAnalytics`), so unlike most of what I've touched lately this one is genuinely verified.

## Deliberately not in this PR

- The **app-side log line** that emits it (app-target Swift, no CI).
- The **UX fix** — the calibrating card showing *"3 of 4 nights since you recalibrated on 19 Jul"*. That's the actual cure: the button currently gives no feedback that it reset progress, which is exactly why tapping it again is the natural move. Worth doing, but it's a product decision, not a diagnostic.

Reported back to the user on #731 with the workaround (stop tapping Recalibrate; wait 4 nights).