### PR TITLE
diag: 'Recent Nd' read the wrong device id and mislabelled the range (#731)

### DIFF
--- a/Strand/System/DebugDataDiagnostics.swift
+++ b/Strand/System/DebugDataDiagnostics.swift
@@ -198,21 +198,35 @@ enum DebugDataDiagnostics {
                    "apple-health", "health-connect"].filter { seen.insert($0).inserted }
         var parts: [String] = []
         var spine: [DailyMetric] = []
+        var activeRows: [DailyMetric] = []
         for id in ids {
             let rows = (try? await store.dailyMetrics(deviceId: id, from: "0000-01-01", to: "9999-12-31")) ?? []
             parts.append("\(id)=\(rows.count)")
             if id == "my-whoop" { spine = rows }
+            if id == did { activeRows = rows }
         }
         lines.append("Days: " + parts.joined(separator: "  "))
-        let recent = Array(spine.suffix(7))
-        if !recent.isEmpty {
+        // #731: this line used to read ONLY "my-whoop" and label it "Recent 7d". For a live-BLE user whose
+        // rows land under the ACTIVE strap id that reported sleep=0/7 while every one of the last 7 nights
+        // had sleep — it sent triage hunting for missing data that was never missing. It also took
+        // `suffix(7)` of that id's rows, so "Recent" could be the last 7 IMPORTED days (months old) rather
+        // than the last 7 calendar days. Report the active id (where live data lands) AND the import spine
+        // when they differ, each stamped with the day range it actually covers so staleness is visible.
+        func recentLine(_ rows: [DailyMetric], id: String) -> String? {
+            let recent = Array(rows.suffix(7))
+            guard !recent.isEmpty else { return nil }
             let n = recent.count
-            lines.append("Recent \(n)d (my-whoop): "
+            let span = (recent.first?.day ?? "?") + "…" + (recent.last?.day ?? "?")
+            return "Recent \(n) rows (\(id), \(span)): "
                 + "sleep=\(recent.filter { ($0.totalSleepMin ?? 0) > 0 }.count)/\(n)  "
                 + "recovery=\(recent.filter { $0.recovery != nil }.count)/\(n)  "
                 + "steps=\(recent.filter { $0.steps != nil }.count)/\(n)  "
-                + "kcal=\(recent.filter { $0.activeKcalEst != nil }.count)/\(n)")
-        } else {
+                + "kcal=\(recent.filter { $0.activeKcalEst != nil }.count)/\(n)"
+        }
+        var emitted = false
+        if let l = recentLine(activeRows, id: did) { lines.append(l); emitted = true }
+        if did != "my-whoop", let l = recentLine(spine, id: "my-whoop") { lines.append(l); emitted = true }
+        if !emitted {
             lines.append("Recent: no day rows")
         }
         if let dv = await repo.dataVolumeSnapshot() {


### PR DESCRIPTION
Found while diagnosing #731. Two defects in a single diagnostic line, both of which actively mislead triage.

## 1. It read only `my-whoop`
```swift
if id == "my-whoop" { spine = rows }
let recent = Array(spine.suffix(7))
```
For a live-BLE user, day rows land under the **active strap id**. So the export printed:
```
Recent 7d (my-whoop): sleep=0/7  recovery=0/7  steps=0/7  kcal=0/7
```
…while **every one of the last 7 nights had sleep** (322–525 min each). Diagnosing #731 I spent real time chasing that as "recent data missing" before the per-day trace proved the data was there all along.

## 2. "Recent 7d" wasn't 7 days
`suffix(7)` takes the last 7 **rows** of that id. For this reporter — whose import ends 20 February — the line described **February days** while calling itself recent. A stale import is invisible, and looks identical to a live gap.

## Fix
Report the **active id** (where live data lands) **and** the import spine when they differ, each stamped with the day range it actually covers, and say "rows" since that's what it counts.

Their log would have read:
```
Recent 7 rows (whoop-33E9…, 2026-07-16…2026-07-22): sleep=7/7  recovery=0/7 …
Recent 7 rows (my-whoop,   2026-02-14…2026-02-20): sleep=0/7  recovery=0/7 …
```
Live data present, import stale since February — both visible at a glance, and the `recovery=0/7` immediately points at the baseline rather than the data.

## Verification
Diagnostic strings only; no behaviour change beyond what the export prints. App-target Swift, so **not compiled here** — wants a build. Companion to #786 (which surfaces the recalibration epoch that actually caused #731).