### PR TITLE
diag: say WHY the sparse sleep bridge did nothing (#737)

### DIFF
--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/SleepStager.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/SleepStager.swift
@@ -462,6 +462,57 @@ public enum SleepStager {
         return merged
     }
 
+    /// Why `bridgeSparseSleep` did or did not merge one adjacent pair of runs (#737).
+    ///
+    /// The existing trace reports only `runsBefore`/`runsAfter`, so a bridge that changed NOTHING gives
+    /// no reason — and there are three very different causes (gap over the tolerance, HR outside the
+    /// sleep band, or the pair simply not being two adjacent sleep runs). A reporter's night showed
+    /// `runsBefore=13 runsAfter=13` with 8 runs then discarded by `minSleepMin`, and the log could not
+    /// say which cause applied, so no fix could be chosen responsibly. This names it per pair.
+    struct SparseBridgeAttempt: Equatable, Sendable {
+        /// Gap between the two runs, in whole minutes (negative when they overlap).
+        let gapMin: Int
+        /// Whether the intervening HR stayed in the sleep band (the bridge's second condition).
+        let hrInSleepBand: Bool
+        /// Whether this pair was merged.
+        let bridged: Bool
+        /// Stable token for the log: bridged / gapTooLong / hrOutOfBand / overlap.
+        let reason: String
+    }
+
+    /// Per-pair explanation of `bridgeSparseSleep`, mirroring its rule EXACTLY (same adjacency walk,
+    /// same `gap >= 0 && gap <= sparseBridgeGapMin*60`, same HR-band check) so the reasons describe what
+    /// actually happened rather than an approximation. Only pairs the bridge itself CONSIDERS (two
+    /// adjacent sleep runs) produce an attempt; a pair separated by an active run is never considered,
+    /// which is itself the answer when no attempts are reported. Pure — no I/O, no side effects.
+    static func sparseBridgeAttempts(_ periods: [Period], sparse: Bool,
+                                     hr: [HRSample], baseline: Double?) -> [SparseBridgeAttempt] {
+        guard sparse, !periods.isEmpty else { return [] }
+        let bridgeGapS = sparseBridgeGapMin * 60
+        var attempts: [SparseBridgeAttempt] = []
+        var out: [Period] = []
+        for p in periods {
+            if let last = out.last, last.stage == "sleep", p.stage == "sleep" {
+                let gap = p.start - last.end
+                let inBand = hrSleepBandAcross(last.end, p.start, hr: hr, baseline: baseline)
+                let bridged = gap >= 0 && gap <= bridgeGapS && inBand
+                let reason: String
+                if bridged { reason = "bridged" }
+                else if gap < 0 { reason = "overlap" }
+                else if gap > bridgeGapS { reason = "gapTooLong" }
+                else { reason = "hrOutOfBand" }
+                attempts.append(SparseBridgeAttempt(gapMin: gap / 60, hrInSleepBand: inBand,
+                                                    bridged: bridged, reason: reason))
+                if bridged {
+                    out[out.count - 1] = Period(stage: "sleep", start: last.start, end: p.end)
+                    continue
+                }
+            }
+            out.append(p)
+        }
+        return attempts
+    }
+
     /// Sparse-gravity bridge (#308): merge two adjacent SLEEP runs separated ONLY by a gap up to
     /// sparseBridgeGapMin minutes when the intervening HR stays in the sleep band — so a real night
     /// fragmented by gravity dropouts is re-stitched into one continuous in-bed span BEFORE the
@@ -875,6 +926,10 @@ public enum SleepStager {
         runs = mergePeriods(runs)
         // Re-stitch sleep runs fragmented by pure gravity dropouts (sparse only) before minSleepMin.
         let runsBeforeBridge = traceSink == nil ? 0 : runs.filter { $0.stage == "sleep" }.count
+        // #737: capture the per-pair reasons BEFORE the merge mutates `runs`, so a bridge that changed
+        // nothing still says why (gapTooLong / hrOutOfBand / overlap) instead of only before==after.
+        let bridgeAttempts = traceSink == nil ? [] : sparseBridgeAttempts(runs, sparse: sparse, hr: hrS,
+                                                                         baseline: baseline)
         runs = bridgeSparseSleep(runs, sparse: sparse, hr: hrS, baseline: baseline)
         // Sleep & Rest test mode (E3): record the sparse-gravity bridge result, so a sparse 5.0 night
         // rescued from fragmentation is visible. Only emitted when gravity is sparse (the only case the
@@ -884,6 +939,20 @@ public enum SleepStager {
             traceSink(GateTrace.runLine(index: -1, startTs: 0, endTs: 0,
                 verdict: runsAfterBridge < runsBeforeBridge ? .kept : .dropped, gate: "sparseBridge",
                 detail: "sparse=true gapMin=\(sparseBridgeGapMin) runsBefore=\(runsBeforeBridge) runsAfter=\(runsAfterBridge)"))
+            // #737: one line per pair the bridge CONSIDERED. No lines at all means no two adjacent sleep
+            // runs were ever seen — i.e. the fragments are separated by active runs, which the bridge
+            // deliberately never crosses. That absence is itself the diagnosis.
+            if bridgeAttempts.isEmpty {
+                traceSink(GateTrace.runLine(index: -1, startTs: 0, endTs: 0, verdict: .dropped,
+                    gate: "sparseBridge",
+                    detail: "no adjacent sleep pairs considered (fragments separated by active runs)"))
+            }
+            for (i, a) in bridgeAttempts.enumerated() {
+                traceSink(GateTrace.runLine(index: -1, startTs: 0, endTs: 0,
+                    verdict: a.bridged ? .kept : .dropped, gate: "sparseBridgePair",
+                    detail: "pair=\(i) gapMin=\(a.gapMin) hrInSleepBand=\(a.hrInSleepBand) "
+                        + "reason=\(a.reason)"))
+            }
         }
 
         let minSleepS = minSleepMin * 60

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/SparseBridgeAttemptTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/SparseBridgeAttemptTests.swift
@@ -1,0 +1,99 @@
+import XCTest
+import WhoopProtocol
+@testable import StrandAnalytics
+
+/// #737: the per-pair sparse-bridge diagnostic must describe what `bridgeSparseSleep` ACTUALLY did, so a
+/// "runsBefore == runsAfter" night finally says why. Every test pins the diagnostic against the real
+/// bridge rather than asserting it in isolation.
+final class SparseBridgeAttemptTests: XCTestCase {
+
+    /// Sleep HR well under any plausible baseline, so `hrSleepBandAcross` is satisfied when we want it.
+    private func sleepHR(from: Int, to: Int, bpm: Int = 50) -> [HRSample] {
+        stride(from: from, through: to, by: 30).map { HRSample(ts: $0, bpm: bpm) }
+    }
+
+    private func sleep(_ start: Int, _ end: Int) -> SleepStager.Period {
+        SleepStager.Period(stage: "sleep", start: start, end: end)
+    }
+    private func active(_ start: Int, _ end: Int) -> SleepStager.Period {
+        SleepStager.Period(stage: "active", start: start, end: end)
+    }
+
+    /// The invariant that makes the diagnostic trustworthy: the number of pairs it reports as bridged
+    /// must equal the reduction in sleep-run count the REAL bridge produces.
+    private func assertAgreesWithBridge(_ periods: [SleepStager.Period], hr: [HRSample],
+                                        baseline: Double?, file: StaticString = #filePath, line: UInt = #line) {
+        let attempts = SleepStager.sparseBridgeAttempts(periods, sparse: true, hr: hr, baseline: baseline)
+        let before = periods.filter { $0.stage == "sleep" }.count
+        let after = SleepStager.bridgeSparseSleep(periods, sparse: true, hr: hr, baseline: baseline)
+            .filter { $0.stage == "sleep" }.count
+        XCTAssertEqual(attempts.filter { $0.bridged }.count, before - after,
+                       "bridged-pair count must equal the real bridge's run reduction", file: file, line: line)
+    }
+
+    func testShortGapInSleepBandBridgesAndIsReported() {
+        // Two sleep runs 10 min apart, HR asleep across the gap → bridged.
+        let periods = [sleep(0, 3_600), sleep(4_200, 8_000)]
+        let hr = sleepHR(from: 0, to: 8_000)
+        let a = SleepStager.sparseBridgeAttempts(periods, sparse: true, hr: hr, baseline: 70)
+        XCTAssertEqual(a.count, 1)
+        XCTAssertEqual(a[0].gapMin, 10)
+        XCTAssertTrue(a[0].bridged)
+        XCTAssertEqual(a[0].reason, "bridged")
+        assertAgreesWithBridge(periods, hr: hr, baseline: 70)
+    }
+
+    func testGapBeyondToleranceReportsGapTooLong() {
+        // 120 min apart — over sparseBridgeGapMin (90), so the bridge declines and says so.
+        let gap = (SleepStager.sparseBridgeGapMin + 30) * 60
+        let periods = [sleep(0, 3_600), sleep(3_600 + gap, 3_600 + gap + 3_600)]
+        let hr = sleepHR(from: 0, to: 3_600 + gap + 3_600)
+        let a = SleepStager.sparseBridgeAttempts(periods, sparse: true, hr: hr, baseline: 70)
+        XCTAssertEqual(a.count, 1)
+        XCTAssertFalse(a[0].bridged)
+        XCTAssertEqual(a[0].reason, "gapTooLong")
+        XCTAssertEqual(a[0].gapMin, SleepStager.sparseBridgeGapMin + 30)
+        assertAgreesWithBridge(periods, hr: hr, baseline: 70)
+    }
+
+    func testAwakeHrAcrossGapReportsHrOutOfBand() {
+        // Gap is short enough, but HR across it is clearly awake → the HR condition is what refused.
+        let periods = [sleep(0, 3_600), sleep(4_200, 8_000)]
+        let hr = sleepHR(from: 0, to: 8_000, bpm: 110)
+        let a = SleepStager.sparseBridgeAttempts(periods, sparse: true, hr: hr, baseline: 60)
+        XCTAssertEqual(a.count, 1)
+        XCTAssertFalse(a[0].bridged)
+        XCTAssertFalse(a[0].hrInSleepBand)
+        XCTAssertEqual(a[0].reason, "hrOutOfBand")
+        assertAgreesWithBridge(periods, hr: hr, baseline: 60)
+    }
+
+    /// The reporter's shape (#737): fragments separated by ACTIVE runs are never adjacent sleep pairs, so
+    /// the bridge considers nothing — which is exactly why their log showed runsBefore == runsAfter with
+    /// no explanation. An EMPTY attempt list is the diagnosis, and the emitter says so in words.
+    func testFragmentsSeparatedByActiveRunsProduceNoAttempts() {
+        let periods = [sleep(0, 3_000), active(3_000, 3_300), sleep(3_300, 6_000)]
+        let hr = sleepHR(from: 0, to: 6_000)
+        let a = SleepStager.sparseBridgeAttempts(periods, sparse: true, hr: hr, baseline: 70)
+        XCTAssertTrue(a.isEmpty, "an intervening active run is never a considered pair")
+        assertAgreesWithBridge(periods, hr: hr, baseline: 70)   // and the real bridge merges nothing
+    }
+
+    func testNoOpWhenNotSparse() {
+        let periods = [sleep(0, 3_600), sleep(4_200, 8_000)]
+        let hr = sleepHR(from: 0, to: 8_000)
+        XCTAssertTrue(SleepStager.sparseBridgeAttempts(periods, sparse: false, hr: hr, baseline: 70).isEmpty,
+                      "the dense 4.0 path is untouched, so there is nothing to explain")
+    }
+
+    /// A chain of three bridgeable runs must report two pairs and agree with the real bridge's collapse
+    /// to one run — the case where a naive diagnostic (not re-walking the growing run) would drift.
+    func testChainOfThreeReportsTwoPairsAndAgrees() {
+        let periods = [sleep(0, 3_600), sleep(4_200, 8_000), sleep(8_600, 12_000)]
+        let hr = sleepHR(from: 0, to: 12_000)
+        let a = SleepStager.sparseBridgeAttempts(periods, sparse: true, hr: hr, baseline: 70)
+        XCTAssertEqual(a.count, 2)
+        XCTAssertTrue(a.allSatisfy { $0.bridged })
+        assertAgreesWithBridge(periods, hr: hr, baseline: 70)
+    }
+}


### PR DESCRIPTION
## Why

A reporter's WHOOP 5.0 night (#737 — *"asleep time is incorrect, but bedtime is accurate"*) logged:

```
gate run=-1 DROPPED gate=sparseBridge sparse=true gapMin=90 runsBefore=13 runsAfter=13
gate run=1  spanMin=48  DROPPED minSleepMin=60
gate run=3  spanMin=52  DROPPED minSleepMin=60
gate run=5  spanMin=55  DROPPED minSleepMin=60
…8 of 13 runs discarded
```

Asleep time is the sum of the *kept* fragments, so it under-counts, while the in-bed span (their "bedtime") stays right — exactly the mismatch they described. `bridgeSparseSleep` (#308) exists to re-stitch fragments **before** `minSleepMin`, and it changed nothing — **but the trace gives no reason.**

Three very different causes are possible:
1. gap over the 90-min tolerance,
2. HR outside the sleep band across the gap,
3. the fragments never being two *adjacent* sleep runs at all.

**No fix can be chosen responsibly without knowing which.** Loosening `minSleepMin` on the sparse path and bridging across active runs are mutually exclusive, and both change sleep scoring for **every** user — the class of change this repo's physiological-signal rule exists to gate (the withdrawn PPG→HR #194 is the precedent).

## What this adds

`sparseBridgeAttempts()` — a per-pair explanation that mirrors the bridge's rule **exactly** (same adjacency walk, same `gap >= 0 && gap <= sparseBridgeGapMin*60`, same HR-band check):

```
gate sparseBridgePair pair=0 gapMin=12  hrInSleepBand=true  reason=bridged
gate sparseBridgePair pair=1 gapMin=140 hrInSleepBand=true  reason=gapTooLong
```

And when **no pair was ever considered**, it says so in words — because *"fragments separated by active runs"* is itself the diagnosis, and `runsBefore`/`runsAfter` cannot express it.

## Tests

Pinned against the real bridge, not asserted in isolation. Every case asserts the **agreement invariant** — bridged-pair count must equal `bridgeSparseSleep`'s actual run reduction — including a **three-run chain**, where a naive diagnostic that failed to re-walk the growing merged run would silently drift. Plus `gapTooLong`, `hrOutOfBand`, the reporter's active-run shape, and the non-sparse no-op.

Band arithmetic verified against the real constant (`hrSleepBandMult = 1.05`): 50 bpm vs baseline 70 → in band (≤73.5); 110 bpm vs 60 → out of band (>63.0).

## Scope

**Diagnostics only — no scoring change.** Pure and CI-covered (`StrandAnalytics`), so unlike the app-target work this is genuinely verified.

Deliberately **not** included: any change to `minSleepMin` or the bridge's adjacency rule. Those wait for this trace to name the cause — and for the reporter to identify *which night* looked wrong (their pasted log is truncated mid-line, and the 13 runs total ~22.7 h, so they span the whole analysis window rather than one night).