### PR TITLE
docs+tools: credit release contributors by GitHub handle (#736)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -182,9 +182,10 @@ Swift, you MUST build the app yourself: `xcodebuild … build` locally, or run `
     report with a strap log is often the harder half.
   - **Only third-party contributors.** The maintainer's own handles (`@ryanbr` / `@Fanboynz`) are left
     out: self-credit adds noise and self-mentions notify nobody.
-  - Collect the handles from the merged PRs and closed issues in the release range (e.g.
-    `gh pr list --state merged --search "merged:>=<date>" --json number,author`), so nobody is missed
-    when the notes are written by hand.
+  - Collect the handles with **`Tools/release-contributors.sh <since-date|since-tag>`**, which lists every
+    third-party merged PR and closed issue in the range plus a ready credit line, with the maintainer's
+    own handles filtered out. Writing *what* each person contributed is still by hand — that's the
+    judgement part; hunting logins is not. `Tools/release.sh` warns when the notes carry no `@handle`.
 
 When in doubt, open an issue to coordinate first, and prefer the smallest change that's correct and
 covered by a test that runs without a strap.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -173,6 +173,18 @@ Swift, you MUST build the app yourself: `xcodebuild … build` locally, or run `
   `android/app/build.gradle.kts` together; build numbers increment independently. The parts are
   counters, not decimals (`2.0.10` follows `2.0.9`).
 - **Voice:** docs/comments are neutral, third-person, project-voice. Keep upstream credits intact.
+- **Release-note credits use GitHub handles (#736).** In a release's contributor section, credit
+  **third-party** work by `@handle`, not by display name — a plain name is invisible to GitHub, so it
+  neither notifies the contributor nor links to their profile. A display name may accompany the handle,
+  but the handle is what makes the credit real: `Thanks to @tigercraft4 (Sleep/Health refactors),
+  @digitalerdude (workout backfill), …`.
+  - Credit both **merged PR authors** and the **issue reporters** whose reports drove a fix — a good bug
+    report with a strap log is often the harder half.
+  - **Only third-party contributors.** The maintainer's own handles (`@ryanbr` / `@Fanboynz`) are left
+    out: self-credit adds noise and self-mentions notify nobody.
+  - Collect the handles from the merged PRs and closed issues in the release range (e.g.
+    `gh pr list --state merged --search "merged:>=<date>" --json number,author`), so nobody is missed
+    when the notes are written by hand.
 
 When in doubt, open an issue to coordinate first, and prefer the smallest change that's correct and
 covered by a test that runs without a strap.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -183,9 +183,13 @@ Swift, you MUST build the app yourself: `xcodebuild … build` locally, or run `
   - **Only third-party contributors.** The maintainer's own handles (`@ryanbr` / `@Fanboynz`) are left
     out: self-credit adds noise and self-mentions notify nobody.
   - Collect the handles with **`Tools/release-contributors.sh <since-date|since-tag>`**, which lists every
-    third-party merged PR and closed issue in the range plus a ready credit line, with the maintainer's
-    own handles filtered out. Writing *what* each person contributed is still by hand — that's the
-    judgement part; hunting logins is not. `Tools/release.sh` warns when the notes carry no `@handle`.
+    third-party merged PR and every issue *closed as completed* in the range, plus a ready credit line,
+    with the maintainer's own handles and bot accounts filtered out. A tag argument is bounded at that
+    tag's exact instant, so the previous release's work is not re-credited. Writing *what* each person
+    contributed is still by hand — that's the judgement part; hunting logins is not. Its output is a work
+    list to prune, not a finished line: a reporter whose issue is not worth calling out in the notes can
+    be left to the closing "everyone who filed the reports behind these fixes". `Tools/release.sh` warns
+    when the notes it is about to publish credit no `@handle`.
 
 When in doubt, open an issue to coordinate first, and prefer the smallest change that's correct and
 covered by a test that runs without a strap.

--- a/Tools/release-contributors.sh
+++ b/Tools/release-contributors.sh
@@ -38,9 +38,21 @@ if git rev-parse -q --verify "refs/tags/$SINCE_INPUT" >/dev/null 2>&1; then
   # are actually cut BSD date's -d means daylight-savings, so the tag path would die under `set -e`.
   SINCE="$(TZ=UTC git log -1 --format=%cd --date=format-local:%Y-%m-%dT%H:%M:%SZ "refs/tags/$SINCE_INPUT")"
   echo "# since tag $SINCE_INPUT ($SINCE)"
-else
+elif printf '%s' "$SINCE_INPUT" | grep -qE '^[0-9]{4}-[0-9]{2}-[0-9]{2}(T[0-9]{2}:[0-9]{2}:[0-9]{2}Z?)?$'; then
   SINCE="$SINCE_INPUT"
   echo "# since $SINCE"
+else
+  # Anything unrecognised must be rejected, not passed through as a date. Tags here are v-prefixed, so
+  # "9.0.2" is the natural typo — and GitHub search swallows "merged:>=9.0.2" without complaint, returning
+  # nothing. The author then reads "(none)" as "no third-party contributors" and ships notes crediting
+  # nobody: the same silent miss the gh preflight exists to prevent, arriving through a different door.
+  echo "error: '$SINCE_INPUT' is neither an existing tag nor a YYYY-MM-DD date." >&2
+  case "$SINCE_INPUT" in
+    [0-9]*.[0-9]*) echo "       tags in this repo are v-prefixed — did you mean v$SINCE_INPUT?" >&2 ;;
+  esac
+  echo "       recent tags:" >&2
+  git tag --sort=-creatordate 2>/dev/null | head -5 | sed 's/^/         /' >&2
+  exit 2
 fi
 
 MAINTAINERS="${MAINTAINERS:-ryanbr,Fanboynz}"
@@ -55,9 +67,12 @@ LIMIT=300
 # published credit line, and a bot is not someone to thank. GitHub suffixes every bot login with "[bot]".
 drop_uncredited() {
   awk -F'\t' -v ex="$MAINTAINERS" '
-    BEGIN { n = split(tolower(ex), m, ",") }
+    # Entries are trimmed: MAINTAINERS="digitalerdude, ryanbr" is how a human writes a two-name list, and
+    # an untrimmed " ryanbr" matches nothing — putting the maintainer back in their own credit line.
+    BEGIN { n = split(tolower(ex), m, ",")
+            for (i = 1; i <= n; i++) gsub(/^[ \t]+|[ \t]+$/, "", m[i]) }
     { h = tolower($1); skip = 0
-      for (i = 1; i <= n; i++) if (h == m[i]) skip = 1
+      for (i = 1; i <= n; i++) if (m[i] != "" && h == m[i]) skip = 1
       if (h ~ /\[bot\]$/) skip = 1
       if (!skip) print }'
 }

--- a/Tools/release-contributors.sh
+++ b/Tools/release-contributors.sh
@@ -34,7 +34,9 @@ gh auth status >/dev/null 2>&1 || { echo "error: gh is not authenticated (run: g
 # day, so it re-credits everything merged earlier on release day — work that shipped in the PREVIOUS
 # release. On v9.0.2 (tagged 06:15Z) that was 14 PRs. GitHub search honours an ISO8601 instant, so use one.
 if git rev-parse -q --verify "refs/tags/$SINCE_INPUT" >/dev/null 2>&1; then
-  SINCE="$(date -u -d "$(git log -1 --format=%cI "refs/tags/$SINCE_INPUT")" +%Y-%m-%dT%H:%M:%SZ)"
+  # git does the UTC conversion, not `date -u -d`: that flag is GNU-only, and on the macOS where releases
+  # are actually cut BSD date's -d means daylight-savings, so the tag path would die under `set -e`.
+  SINCE="$(TZ=UTC git log -1 --format=%cd --date=format-local:%Y-%m-%dT%H:%M:%SZ "refs/tags/$SINCE_INPUT")"
   echo "# since tag $SINCE_INPUT ($SINCE)"
 else
   SINCE="$SINCE_INPUT"
@@ -60,13 +62,14 @@ drop_maintainers() {
 # MAINTAINER-authored issue leaks its title fragments into the third-party listing. Flatten first.
 JQ_ROW='.[] | "\(.author.login)\t#\(.number)\t\(.title | gsub("[\r\n\t]+"; " "))"'
 
-# Only COMPLETED issues. A report closed as not-planned or duplicate did not drive a fix, and crediting it
-# is the same kind of noise the handle convention exists to remove.
 prs="$(gh pr list --repo "$REPO" --state merged --limit "$LIMIT" \
         --search "merged:>=$SINCE" --json number,author,title --jq "$JQ_ROW")"
-issues="$(gh issue list --repo "$REPO" --state closed --limit "$LIMIT" \
+# stateReason rides along as a 4th column so the truncation guard below can count what was FETCHED.
+# Filtering inside the jq would hide truncation: 300 issues fetched of which 260 are completed leaves 260
+# rows, under the limit, and the guard stays silent about the 300-item wall it just hit.
+issues_raw="$(gh issue list --repo "$REPO" --state closed --limit "$LIMIT" \
         --search "closed:>=$SINCE" --json number,author,title,stateReason \
-        --jq '[.[] | select(.stateReason == "COMPLETED")] | '"$JQ_ROW")"
+        --jq '.[] | "\(.author.login)\t#\(.number)\t\(.title | gsub("[\r\n\t]+"; " "))\t\(.stateReason // "NULL")"')"
 
 # A silent top-N cap would read as "that is everyone" when it is not.
 warn_if_truncated() {   # warn_if_truncated <what> <rows>
@@ -75,7 +78,12 @@ warn_if_truncated() {   # warn_if_truncated <what> <rows>
   fi
 }
 warn_if_truncated "pull requests" "$prs"
-warn_if_truncated "issues" "$issues"
+warn_if_truncated "issues" "$issues_raw"
+
+# Only COMPLETED issues. A report closed as not-planned or duplicate did not drive a fix, and crediting it
+# is the same kind of noise the handle convention exists to remove. (Checked: this repo has no closed issue
+# with a null reason, so nothing legitimately fixed is dropped by requiring the field.)
+issues="$(printf '%s\n' "$issues_raw" | awk -F'\t' '$4 == "COMPLETED" { print $1 "\t" $2 "\t" $3 }')"
 
 section() {   # section <heading> <rows>
   echo

--- a/Tools/release-contributors.sh
+++ b/Tools/release-contributors.sh
@@ -13,11 +13,12 @@
 # nobody. Override with MAINTAINERS="a,b" if the set ever changes.
 #
 # Usage:
-#   Tools/release-contributors.sh 2026-07-20              # since a date (inclusive)
-#   Tools/release-contributors.sh v9.0.2                  # since a tag's commit date
+#   Tools/release-contributors.sh 2026-07-20              # since a date (inclusive, whole day)
+#   Tools/release-contributors.sh v9.0.2                  # since that tag's exact commit time
 #   MAINTAINERS="ryanbr,Fanboynz" Tools/release-contributors.sh 2026-07-20
 #
-# Requires: gh (authenticated), jq-free (uses gh's --jq).
+# Requires: gh, authenticated. A dead or unauthenticated gh is a hard error, never an empty list —
+# for a tool whose whole job is "nobody is missed", silently missing EVERYBODY is the worst failure mode.
 set -euo pipefail
 
 SINCE_INPUT="${1:-}"
@@ -26,9 +27,14 @@ if [ -z "$SINCE_INPUT" ]; then
   exit 2
 fi
 
-# A tag resolves to its commit date; a date is used as-is.
+command -v gh >/dev/null 2>&1 || { echo "error: gh not found on PATH" >&2; exit 1; }
+gh auth status >/dev/null 2>&1 || { echo "error: gh is not authenticated (run: gh auth login)" >&2; exit 1; }
+
+# A tag resolves to its exact commit TIME, not just its date. A date-only bound is inclusive of the whole
+# day, so it re-credits everything merged earlier on release day — work that shipped in the PREVIOUS
+# release. On v9.0.2 (tagged 06:15Z) that was 14 PRs. GitHub search honours an ISO8601 instant, so use one.
 if git rev-parse -q --verify "refs/tags/$SINCE_INPUT" >/dev/null 2>&1; then
-  SINCE="$(git log -1 --format=%cs "refs/tags/$SINCE_INPUT")"
+  SINCE="$(date -u -d "$(git log -1 --format=%cI "refs/tags/$SINCE_INPUT")" +%Y-%m-%dT%H:%M:%SZ)"
   echo "# since tag $SINCE_INPUT ($SINCE)"
 else
   SINCE="$SINCE_INPUT"
@@ -36,43 +42,62 @@ else
 fi
 
 MAINTAINERS="${MAINTAINERS:-ryanbr,Fanboynz}"
-# Field-exact, case-insensitive filter. The listings are "handle<TAB>#N<TAB>title", so a whole-line
-# anchor would never match and the maintainer would leak into the output (caught by running it);
-# compare only field 1. The bare-login list below uses an exact whole-line match instead.
-drop_maintainers_field1() {
+REPO="${GH_REPO:-ryanbr/noop}"
+LIMIT=300
+
+# Field-exact, case-insensitive. The rows are "handle<TAB>#N<TAB>title", so a whole-line anchor never
+# matches and the maintainer leaks through; compare only field 1.
+drop_maintainers() {
   awk -F'\t' -v ex="$MAINTAINERS" '
     BEGIN { n = split(tolower(ex), m, ",") }
     { h = tolower($1); skip = 0
       for (i = 1; i <= n; i++) if (h == m[i]) skip = 1
       if (!skip) print }'
 }
-EXCLUDE_EXACT="^($(printf '%s' "$MAINTAINERS" | tr ',' '|'))$"
 
-REPO="${GH_REPO:-ryanbr/noop}"
+# Titles are user-supplied and 3 of this repo's issues contain a newline or tab (e.g. #717). Left raw they
+# split one record across several lines, and a continuation line has no handle in field 1 — so a
+# MAINTAINER-authored issue leaks its title fragments into the third-party listing. Flatten first.
+JQ_ROW='.[] | "\(.author.login)\t#\(.number)\t\(.title | gsub("[\r\n\t]+"; " "))"'
 
-echo
-echo "## Merged PRs by third-party contributors"
-gh pr list --repo "$REPO" --state merged --limit 300 \
-  --search "merged:>=$SINCE" --json number,author,title \
-  --jq '.[] | "\(.author.login)\t#\(.number)\t\(.title)"' 2>/dev/null \
-  | drop_maintainers_field1 \
-  | sort -f || true
+# Only COMPLETED issues. A report closed as not-planned or duplicate did not drive a fix, and crediting it
+# is the same kind of noise the handle convention exists to remove.
+prs="$(gh pr list --repo "$REPO" --state merged --limit "$LIMIT" \
+        --search "merged:>=$SINCE" --json number,author,title --jq "$JQ_ROW")"
+issues="$(gh issue list --repo "$REPO" --state closed --limit "$LIMIT" \
+        --search "closed:>=$SINCE" --json number,author,title,stateReason \
+        --jq '[.[] | select(.stateReason == "COMPLETED")] | '"$JQ_ROW")"
 
-echo
-echo "## Issues reported by third-party contributors (closed in range)"
-gh issue list --repo "$REPO" --state closed --limit 300 \
-  --search "closed:>=$SINCE" --json number,author,title \
-  --jq '.[] | "\(.author.login)\t#\(.number)\t\(.title)"' 2>/dev/null \
-  | drop_maintainers_field1 \
-  | sort -f || true
+# A silent top-N cap would read as "that is everyone" when it is not.
+warn_if_truncated() {   # warn_if_truncated <what> <rows>
+  if [ -n "$2" ] && [ "$(printf '%s\n' "$2" | wc -l)" -ge "$LIMIT" ]; then
+    echo "# warning: hit the $LIMIT-item limit for $1 — the range may be truncated" >&2
+  fi
+}
+warn_if_truncated "pull requests" "$prs"
+warn_if_truncated "issues" "$issues"
+
+section() {   # section <heading> <rows>
+  echo
+  echo "$1"
+  # Emptiness is judged AFTER filtering: rows that exist but are all the maintainer's still mean
+  # "nothing to credit here", and a bare heading reads as a glitch rather than an answer.
+  local kept; kept="$(printf '%s\n' "$2" | drop_maintainers | grep -v '^$' | sort -f || true)"
+  if [ -z "$kept" ]; then echo "(none)"; else printf '%s\n' "$kept"; fi
+}
+section "## Merged PRs by third-party contributors"                       "$prs"
+section "## Issues reported by third-party contributors (closed as completed)" "$issues"
 
 echo
 echo "## Credit line (add what each person contributed, then paste into the release notes)"
-{
-  gh pr list --repo "$REPO" --state merged --limit 300 --search "merged:>=$SINCE" \
-    --json author --jq '.[].author.login' 2>/dev/null || true
-  gh issue list --repo "$REPO" --state closed --limit 300 --search "closed:>=$SINCE" \
-    --json author --jq '.[].author.login' 2>/dev/null || true
-} | grep -viE "$EXCLUDE_EXACT" | sort -uf \
-  | awk 'BEGIN { ORS="" } { if (NR > 1) print ", "; print "@" $0 } END { print "\n" }' \
-  | sed 's/^/Thanks to /'
+# Derived from the rows already fetched, so the line can never disagree with the listings above.
+handles="$(printf '%s\n%s\n' "$prs" "$issues" | drop_maintainers | cut -f1 | grep -v '^$' | sort -uf || true)"
+if [ -z "$handles" ]; then
+  # Legitimate for a maintainer-only hotfix. Emitting a dangling "Thanks to" would be worse than saying so,
+  # and exiting non-zero here (grep finding no match under pipefail) made the tool look broken.
+  echo "(no third-party contributors in range — omit the credit section)"
+else
+  printf '%s\n' "$handles" \
+    | awk 'BEGIN { ORS="" } { if (NR > 1) print ", "; print "@" $0 } END { print "\n" }' \
+    | sed 's/^/Thanks to /'
+fi

--- a/Tools/release-contributors.sh
+++ b/Tools/release-contributors.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# release-contributors.sh — collect THIRD-PARTY contributor handles for a release's credit line (#736).
+#
+# Release notes used to credit people by display name ("FF", "Pipiche"), which GitHub cannot resolve: the
+# contributor is thanked visibly but never notified, and the credit links nowhere. Getting the handles right
+# by hand means cross-referencing every merged PR and closed issue in the range, which is exactly the sort
+# of chore that silently drifts. This does the mechanical half.
+#
+# It prints each third-party @handle with the PRs they landed and the issues they reported, so the release
+# author only has to write WHAT each person contributed — the judgement part — instead of hunting logins.
+#
+# The maintainer's own handles are excluded on purpose: self-credit is noise, and a self-mention notifies
+# nobody. Override with MAINTAINERS="a,b" if the set ever changes.
+#
+# Usage:
+#   Tools/release-contributors.sh 2026-07-20              # since a date (inclusive)
+#   Tools/release-contributors.sh v9.0.2                  # since a tag's commit date
+#   MAINTAINERS="ryanbr,Fanboynz" Tools/release-contributors.sh 2026-07-20
+#
+# Requires: gh (authenticated), jq-free (uses gh's --jq).
+set -euo pipefail
+
+SINCE_INPUT="${1:-}"
+if [ -z "$SINCE_INPUT" ]; then
+  echo "usage: $(basename "$0") <since-date|since-tag>" >&2
+  exit 2
+fi
+
+# A tag resolves to its commit date; a date is used as-is.
+if git rev-parse -q --verify "refs/tags/$SINCE_INPUT" >/dev/null 2>&1; then
+  SINCE="$(git log -1 --format=%cs "refs/tags/$SINCE_INPUT")"
+  echo "# since tag $SINCE_INPUT ($SINCE)"
+else
+  SINCE="$SINCE_INPUT"
+  echo "# since $SINCE"
+fi
+
+MAINTAINERS="${MAINTAINERS:-ryanbr,Fanboynz}"
+# Field-exact, case-insensitive filter. The listings are "handle<TAB>#N<TAB>title", so a whole-line
+# anchor would never match and the maintainer would leak into the output (caught by running it);
+# compare only field 1. The bare-login list below uses an exact whole-line match instead.
+drop_maintainers_field1() {
+  awk -F'\t' -v ex="$MAINTAINERS" '
+    BEGIN { n = split(tolower(ex), m, ",") }
+    { h = tolower($1); skip = 0
+      for (i = 1; i <= n; i++) if (h == m[i]) skip = 1
+      if (!skip) print }'
+}
+EXCLUDE_EXACT="^($(printf '%s' "$MAINTAINERS" | tr ',' '|'))$"
+
+REPO="${GH_REPO:-ryanbr/noop}"
+
+echo
+echo "## Merged PRs by third-party contributors"
+gh pr list --repo "$REPO" --state merged --limit 300 \
+  --search "merged:>=$SINCE" --json number,author,title \
+  --jq '.[] | "\(.author.login)\t#\(.number)\t\(.title)"' 2>/dev/null \
+  | drop_maintainers_field1 \
+  | sort -f || true
+
+echo
+echo "## Issues reported by third-party contributors (closed in range)"
+gh issue list --repo "$REPO" --state closed --limit 300 \
+  --search "closed:>=$SINCE" --json number,author,title \
+  --jq '.[] | "\(.author.login)\t#\(.number)\t\(.title)"' 2>/dev/null \
+  | drop_maintainers_field1 \
+  | sort -f || true
+
+echo
+echo "## Credit line (add what each person contributed, then paste into the release notes)"
+{
+  gh pr list --repo "$REPO" --state merged --limit 300 --search "merged:>=$SINCE" \
+    --json author --jq '.[].author.login' 2>/dev/null || true
+  gh issue list --repo "$REPO" --state closed --limit 300 --search "closed:>=$SINCE" \
+    --json author --jq '.[].author.login' 2>/dev/null || true
+} | grep -viE "$EXCLUDE_EXACT" | sort -uf \
+  | awk 'BEGIN { ORS="" } { if (NR > 1) print ", "; print "@" $0 } END { print "\n" }' \
+  | sed 's/^/Thanks to /'

--- a/Tools/release-contributors.sh
+++ b/Tools/release-contributors.sh
@@ -49,11 +49,16 @@ LIMIT=300
 
 # Field-exact, case-insensitive. The rows are "handle<TAB>#N<TAB>title", so a whole-line anchor never
 # matches and the maintainer leaks through; compare only field 1.
-drop_maintainers() {
+#
+# Bot accounts are dropped in the same pass. This repo has none today, so it is precaution rather than a
+# fix: nothing in the release flow would stop a merged Dependabot PR from putting "@dependabot[bot]" in a
+# published credit line, and a bot is not someone to thank. GitHub suffixes every bot login with "[bot]".
+drop_uncredited() {
   awk -F'\t' -v ex="$MAINTAINERS" '
     BEGIN { n = split(tolower(ex), m, ",") }
     { h = tolower($1); skip = 0
       for (i = 1; i <= n; i++) if (h == m[i]) skip = 1
+      if (h ~ /\[bot\]$/) skip = 1
       if (!skip) print }'
 }
 
@@ -90,7 +95,7 @@ section() {   # section <heading> <rows>
   echo "$1"
   # Emptiness is judged AFTER filtering: rows that exist but are all the maintainer's still mean
   # "nothing to credit here", and a bare heading reads as a glitch rather than an answer.
-  local kept; kept="$(printf '%s\n' "$2" | drop_maintainers | grep -v '^$' | sort -f || true)"
+  local kept; kept="$(printf '%s\n' "$2" | drop_uncredited | grep -v '^$' | sort -f || true)"
   if [ -z "$kept" ]; then echo "(none)"; else printf '%s\n' "$kept"; fi
 }
 section "## Merged PRs by third-party contributors"                       "$prs"
@@ -99,7 +104,7 @@ section "## Issues reported by third-party contributors (closed as completed)" "
 echo
 echo "## Credit line (add what each person contributed, then paste into the release notes)"
 # Derived from the rows already fetched, so the line can never disagree with the listings above.
-handles="$(printf '%s\n%s\n' "$prs" "$issues" | drop_maintainers | cut -f1 | grep -v '^$' | sort -uf || true)"
+handles="$(printf '%s\n%s\n' "$prs" "$issues" | drop_uncredited | cut -f1 | grep -v '^$' | sort -uf || true)"
 if [ -z "$handles" ]; then
   # Legitimate for a maintainer-only hotfix. Emitting a dangling "Thanks to" would be worse than saying so,
   # and exiting non-zero here (grep finding no match under pipefail) made the tool look broken.

--- a/Tools/release.sh
+++ b/Tools/release.sh
@@ -41,11 +41,18 @@ done
 # #736: release notes credit third-party contributors by @handle, not display name — a plain name
 # neither notifies them nor links anywhere. Nothing here can know who contributed, so this only
 # nudges when the notes carry no handle at all (the default stub never does). Non-fatal by design:
-# a hotfix release with no outside contributions is legitimate.
-case "$NOTES" in
-  *@*) ;;
-  *) echo "  note: notes have no @handle — see Tools/release-contributors.sh \"\$(git describe --tags --abbrev=0)\" (#736)" ;;
-esac
+# a hotfix release with no outside contributions is legitimate, and re-running refreshes the notes.
+#
+# A bare `*@*` glob would count an email address as a credit, silencing the nudge on notes that credit
+# nobody; require an @ that is NOT preceded by an email local-part character. `=~` is bash 3.2-safe.
+NOTES_HANDLE_RE='(^|[^A-Za-z0-9._%+-])@[A-Za-z0-9]'
+if [[ ! "$NOTES" =~ $NOTES_HANDLE_RE ]]; then
+  # The tag is created by `gh release create` further down, so the latest tag right now is the PREVIOUS
+  # release — exactly the point to collect contributors since. Fall back to a placeholder in a bare repo.
+  PREV_TAG="$(git describe --tags --abbrev=0 2>/dev/null || echo '<previous-tag>')"
+  echo "  note: these notes credit no @handle (#736) — Tools/release-contributors.sh $PREV_TAG"
+  echo "        re-run release.sh with -- \"<notes>\" to refresh them; publishing is idempotent"
+fi
 
 # ── iOS asset: ONE canonical name ────────────────────────────────────────────
 # The iOS .ipa ships under a SINGLE name: NOOP-v<V>-ios.ipa, which every doc

--- a/Tools/release.sh
+++ b/Tools/release.sh
@@ -38,6 +38,15 @@ while [ $# -gt 0 ]; do
   ASSETS+=("$1"); shift
 done
 
+# #736: release notes credit third-party contributors by @handle, not display name — a plain name
+# neither notifies them nor links anywhere. Nothing here can know who contributed, so this only
+# nudges when the notes carry no handle at all (the default stub never does). Non-fatal by design:
+# a hotfix release with no outside contributions is legitimate.
+case "$NOTES" in
+  *@*) ;;
+  *) echo "  note: notes have no @handle — see Tools/release-contributors.sh \"\$(git describe --tags --abbrev=0)\" (#736)" ;;
+esac
+
 # ── iOS asset: ONE canonical name ────────────────────────────────────────────
 # The iOS .ipa ships under a SINGLE name: NOOP-v<V>-ios.ipa, which every doc
 # (README, docs/IOS.md, the wiki) and the AltStore source point at. We used to

--- a/docs/releases/v9.1.0.md
+++ b/docs/releases/v9.1.0.md
@@ -43,4 +43,4 @@ A reliability-and-accuracy release on top of 9.0.2. The headline is **workout HR
 
 ## Notes for contributors
 
-Thanks to FF (Today/Sleep/Health refactors, GATT family detection), digitalerdude (workout backfill, journal fix, sleep consistency, SpO2 instrumentation, steps stepper, alarm diagnostic), Pipiche (Oura IBI fix, feature-status probe, protocol docs), Kaveman (Gradle supply chain), and Jonas Bergler (bundle ID prefix, development team config, build fix) — and to everyone who filed the reports behind these fixes.
+Thanks to [@tigercraft4](https://github.com/tigercraft4) (Today/Sleep/Health refactors, GATT family detection), [@digitalerdude](https://github.com/digitalerdude) (workout backfill, journal fix, sleep consistency, SpO2 instrumentation, steps stepper, alarm diagnostic), [@pipiche38](https://github.com/pipiche38) (Oura IBI fix, feature-status probe, protocol docs), [@kavemang](https://github.com/kavemang) (Gradle supply chain), and [@jbergler](https://github.com/jbergler) (bundle ID prefix, development team config, build fix) — and to everyone who filed the reports behind these fixes.


### PR DESCRIPTION
Closes #736.

Release notes credited contributors by display name ("FF", "Pipiche", "Kaveman"). GitHub cannot resolve a
plain name, so the person is thanked visibly but never notified, and the credit links nowhere.

**Convention (CLAUDE.md).** Credit third-party work by `@handle`. A display name may accompany the handle,
but the handle is what makes the credit real. Both merged-PR authors and the issue reporters whose reports
drove a fix get credited — a good bug report with a strap log is often the harder half. The maintainer's own
handles are deliberately left out: self-credit is noise and a self-mention notifies nobody.

**Backfill (docs/releases/v9.1.0.md).** The five names in the v9.1.0 contributor line become handle links:
`@tigercraft4`, `@digitalerdude`, `@pipiche38`, `@kavemang`, `@jbergler`.

**Tooling, so it holds for future releases.** A convention that depends on remembering it at release time
drifts, and gathering handles by hand means cross-referencing every merged PR and closed issue in the range.

- `Tools/release-contributors.sh <since-date|since-tag>` prints the third-party merged PRs, the third-party
  closed issues, and a ready-to-edit credit line, with the maintainer's handles filtered out. Writing *what*
  each person contributed stays by hand — that's the judgement part; hunting logins is not.
- `Tools/release.sh` prints a one-line reminder when the notes it is about to publish carry no `@handle`
  (the default `see CHANGELOG.md` stub never does). Non-fatal on purpose: a hotfix release with no outside
  contributions is legitimate.

## Verification

Re-reviewed by running the script against real repo data, which found five defects that reading it did not.
Each was reproduced first, then fixed, then re-run.

| Defect | Reproduction | Fix |
| --- | --- | --- |
| Unauthenticated `gh` printed empty sections — indistinguishable from "no contributors" | `GH_TOKEN=invalid` → headings with nothing under them, exit 0 | hard preflight error, exit 1 |
| No third-party contributors → exit 1 and a dangling `Thanks to ` | `grep -viE` no-match is exit 1; `set -e`+`pipefail` failed the script | says so explicitly, exit 0 |
| Multi-line issue titles corrupted the listing | 3 issues (incl. #717) contain a newline/tab; continuation lines have no handle in field 1, so a maintainer-authored issue leaked title fragments into the third-party list | titles flattened before formatting |
| Issues closed as not-planned were credited | #662 closed `NOT_PLANNED`, still counted as driving a fix | `COMPLETED` only |
| Tag path re-credited the previous release | a tag resolved to its *date*; a date bound covers the whole day, so 14 PRs already shipped in v9.0.2 (tagged 06:15Z) counted again | tag's exact ISO8601 instant, which GitHub search honours |

Also from the re-review: the credit line is now derived from the rows already fetched instead of two further
queries, so it cannot disagree with the listings and makes half the API calls; a hit top-N cap warns rather
than silently truncating; and a section whose rows are all filtered prints `(none)` instead of a bare heading.

Post-fix state, all measured rather than assumed: 0 maintainer rows leak, 0 malformed rows, #717 renders on
one line, #662 absent, tag bound yields fewer rows than the date bound, and the all-filtered range exits 0.
`bash -n` clean on both scripts; the `release.sh` nudge is silent on handle-bearing notes and fires on the
default stub; `python3 Tools/i18n_audit.py --ci origin/main` → exit 0.

Each of the five v9.1.0 handles was checked against the actual author of the work credited to it — a wrong
handle is worse than a display name, since it notifies a stranger: `@tigercraft4` (#686, #711, #712, #713),
`@digitalerdude` (#703, #704, #706, #707, #708, #709), `@pipiche38` (#678, #710), `@kavemang` (#683),
`@jbergler` (#701, #722, #723).

### Third pass

`release.sh` notes at line 119 that it must survive macOS's stock **bash 3.2** — a constraint this new
script inherits, since releases are cut there and not on the Linux box it was written on.

| Defect | Reproduction | Fix |
| --- | --- | --- |
| `date -u -d` is GNU-only — the tag path would die on macOS | BSD `date -d` sets daylight-savings, it does not parse; under `set -e` that aborts | git does the conversion via `--date=format-local`, byte-identical instant |
| Truncation guard counted the **filtered** rows | issues were narrowed to `COMPLETED` inside the jq, so 300 fetched / 260 completed left 260 rows — under the limit, guard silent about the wall it hit | `stateReason` rides along as a 4th column; guard counts fetched, filter runs after |
| The `release.sh` nudge treated any `@` as a credit | notes mentioning `support@example.com` silenced it while crediting nobody | requires an `@` not preceded by an email local-part char (bash 3.2-safe `=~`) |

Swept the script for the same class of portability problem as the first: 0 bash-4 constructs, 0 GNU-only
flags. The nudge now resolves the previous tag itself instead of printing an unevaluated command
substitution, and states that re-running refreshes the notes — the warning necessarily arrives after this
run's notes are fixed, so idempotence is the actionable part.

Two suspicions from this pass were **measured and dismissed** rather than "fixed": PR numbers leaking into
the issues section (0 real overlap — my first probe wrongly counted issue numbers cited inside PR *titles*),
and `COMPLETED`-only dropping legitimately-fixed issues with a null reason (0 nulls across 150 closed
issues; the other reasons present are `NOT_PLANNED` and `DUPLICATE`, both correctly excluded).

Exit codes, measured: date bound 0, tag bound 0, no-arg 2, unauthenticated 1. Nudge correct on all 6 note
shapes tested. `i18n_audit --ci` exit 0.

### Fourth pass

No new defect in the output. Both candidates checked came back clean, and are recorded here so the next
reader does not re-derive them: **0 bot accounts** and **0 null/deleted authors** across this repo's merged
PRs and closed issues, so neither `@dependabot[bot]` nor `@null` can reach a credit line today.

The bot guard went in regardless, as precaution rather than a fix — nothing in the release flow would stop a
future merged Dependabot PR from landing `@dependabot[bot]` in published notes, the failure is visible to
every reader of the release, and the guard is one condition. It is anchored to GitHub's `[bot]` login suffix,
so a human whose login merely contains "bot" survives (covered by test). The filter drops more than
maintainers now, so it is renamed for what it does.

`CLAUDE.md` had drifted from the script across the earlier passes: it promised "every closed issue" when the
script requires closed-as-*completed*, and mentioned neither the tag instant bound nor the bot filter. It now
also states outright that the output is a **work list to prune**, not a finished credit line — a 4-day window
yields 15 handles, and a reporter not worth calling out belongs in the closing "everyone who filed the reports
behind these fixes". A doc that implies otherwise invites a 15-name paste.

Regression-checked: real output byte-identical to the previous pass, `i18n_audit --ci` exit 0.

### Fifth pass

Two more silent defects, both of which end with the maintainer — or nobody — in a published credit line.

| Defect | Reproduction | Fix |
| --- | --- | --- |
| A mistyped tag was treated as a date | tags here are v-prefixed, so `9.0.2` is the natural slip; GitHub search swallows `merged:>=9.0.2` and returns nothing, so `(none)` reads as "no third-party contributors" | argument must be a resolvable tag or a `YYYY-MM-DD`/ISO8601 date; else exit 2, and a version-shaped argument is told to try the `v` prefix |
| `MAINTAINERS` entries were not trimmed | `MAINTAINERS="digitalerdude, ryanbr"` — the natural way to write a two-name list — yields `" ryanbr"`, matching no login: **33 maintainer rows leaked back** into the third-party listing | entries trimmed; an empty entry matches nothing |

The first is the same failure mode the `gh` preflight was added to prevent, arriving through a different
door: a tool that silently reports "nobody contributed" is worse than one that crashes.

Also **proved rather than assumed** that the truncation guard fires — with the limit lowered to 5 it warns on
both queries. It had only ever been reasoned about. No change needed.

Exit-code matrix, all measured: `2026-07-20`→0, `v9.0.2`→0, `9.0.2`→2, empty→2, unauthenticated→1. `main` and
`HEAD` rejected. Default-path output byte-identical to the previous pass; `i18n_audit --ci` exit 0.

### Sixth pass — checking the PR against the issue's intent rather than for defects

This pass asked a different question, and found the one that mattered.

**`fork-release.yml` was deleting the handles this issue is about.** The release body builder stripped *every*
`by @author` credit from GitHub's generated notes and removed the "New Contributors" block outright. Measured
against v9.1.0's real auto-notes: **66 credits covering 7 distinct third-party contributors, plus the block —
all removed.** The issue reads as hand-written process drift; the mechanical cause was automation, and fixing
only the curated credit line would have left it running on every future release.

Its premise, in the comment itself, was "this is a solo fork". That no longer holds: **16 people have landed
merged PRs here**, 7 in v9.1.0 alone.

The fix is targeted rather than a revert. Un-stripping everything would stamp `by @ryanbr` on nearly every
line — the self-credit noise this convention exists to avoid, and a self-mention notifies nobody. So the
maintainer's handles keep being stripped and everyone else's is kept. On v9.1.0's notes: **35 third-party
credits kept, all 31 maintainer credits removed, New Contributors restored**, and the shortened lines read
cleanly (`… (#613) in https://…`). YAML re-validated.

**Corrected from earlier passes:** I had described `docs/releases/<TAG>.md` as a side-artifact and the
published release body as the real target. It is the other way round — `fork-release.yml:105-113` builds the
release body *from* that file, so it is the source of truth and the right thing to have fixed.

Also verified the issue's own claim set: its handle list is accurate, including `#677` → `@pipiche38`, which my
earlier per-handle check had skipped.

**Deliberately not done:** the *published* v9.1.0 body still carries the display-name text the issue quotes.
The workflow only creates a release when one is missing (`:102`), so it will not refresh from the corrected
file. Per maintainer decision this is left as-is — the convention governs future releases, and rewriting
published pages is out of scope.

**Scope note:** this PR credits issue reporters as well as PR authors. The issue asks only for merged-PR
authors; the wider scope is a deliberate maintainer instruction, not drift.

Four files plus one release-workflow filter. No app or package code, no parity surface.
