### PR TITLE
ci(release): keep third-party @handles in the auto release notes (#736)

### DIFF
--- a/.github/workflows/fork-release.yml
+++ b/.github/workflows/fork-release.yml
@@ -126,11 +126,14 @@ jobs:
               AUTO=$(gh api --method POST "repos/${GITHUB_REPOSITORY}/releases/generate-notes" \
                 -f tag_name="$TAG" -f previous_tag_name="$PREV" -f target_commitish="$(git rev-parse HEAD)" \
                 --jq '.body' 2>/dev/null || true)
-              # Drop the per-PR "by @author" credit and any "New Contributors" block — this is a solo fork,
-              # so the auto notes needn't stamp the handle on every line. Keeps the PR titles + links.
+              # Drop only the MAINTAINER's own "by @author" credit (#736). This used to strip every handle
+              # and delete the "New Contributors" block outright, on the premise that this is a solo fork —
+              # a premise that no longer holds: 16 people have landed PRs here, 7 of them in v9.1.0 alone,
+              # and that release's auto notes carried 66 third-party credits, every one of them removed.
+              # Self-credit on nearly every line is still noise and a self-mention notifies nobody, so the
+              # maintainer's handles keep being stripped; everyone else's is the whole point of the section.
               AUTO=$(printf '%s' "$AUTO" \
-                | sed -E 's/ by @[A-Za-z0-9_-]+//g' \
-                | awk 'BEGIN{skip=0} /^#+ *New Contributors/{skip=1; next} /^#+ /{skip=0} skip{next} {print}')
+                | sed -E 's/ by @([Rr]yanbr|[Ff]anboynz)([^A-Za-z0-9_-]|$)/\2/g')
               [ -n "$AUTO" ] && printf '\n---\n\n%s\n' "$AUTO" >> "$BODY"
             else
               echo "First release (no prior release tag) — skipping the auto PR breakdown."


### PR DESCRIPTION
Follow-up to #790, and the part of #736 that fixes what was actually reported.

#790 landed the convention, the corrected v9.1.0 credit line, and a collector for the handles. All of that
governs the **curated** section at the top of a release body. This governs the **auto-generated** PR list
below it, which is where the handles were being destroyed.

## The mechanism

`fork-release.yml` post-processes GitHub's generated notes and did two destructive things:

```bash
| sed -E 's/ by @[A-Za-z0-9_-]+//g' \                       # every handle, gone
| awk '/^#+ *New Contributors/{skip=1; next} ...'           # the whole block, deleted
```

Measured against v9.1.0's real generated notes, that removed **66 `by @handle` credits covering 7 distinct
third-party contributors**, plus the New Contributors block. The issue reads as drift in hand-written prose
because this is invisible from the release page — so implementing its four suggestions literally would still
have left every contributor's handle off the next release.

The comment justified it with "this is a solo fork". That premise has expired: **16 people have landed merged
PRs here**, 7 of them in v9.1.0 alone.

## The fix

Targeted rather than a revert. Un-stripping everything would stamp `by @ryanbr` on nearly every line — the
self-credit noise the convention exists to avoid, and a self-mention notifies nobody. So the maintainer's own
handles keep being stripped and everyone else's is kept:

```bash
| sed -E 's/ by @([Rr]yanbr|[Ff]anboynz)([^A-Za-z0-9_-]|$)/\2/g'
```

Nothing deletes the New Contributors block any more, so it returns.

## Verification

Run against v9.1.0's real generated notes, not a mock:

- third-party credits kept: **35** (was 0)
- maintainer credits surviving: **0** of 31
- New Contributors block: **restored**
- shortened lines stay well-formed — `… (#613) in https://…`; the trailing capture group is what preserves
  the following separator
- YAML re-validated

One workflow file, 7 insertions / 4 deletions. No app or package code, no parity surface.

Closes #736.