### PR TITLE
Android: name all 58 strap events, reviving the dropped-RTC diagnostic (#791)

### DIFF
--- a/android/app/src/main/java/com/noop/protocol/Enums.kt
+++ b/android/app/src/main/java/com/noop/protocol/Enums.kt
@@ -43,21 +43,83 @@ enum class MetadataType(val rawValue: Int) {
     }
 }
 
-/** EVENT frame event code (offset 6 in an EVENT frame). */
+/**
+ * EVENT frame event code (offset 6 in an EVENT frame).
+ *
+ * The FULL shared `EventNumber` catalogue, kept in lockstep with
+ * `WhoopProtocol/Resources/whoop_protocol.json` — the cross-platform contract says a frame must label
+ * identically on both platforms. Only 13 of these were listed before, so everything else rendered as a
+ * bare `0x44(68)` in an Android strap log while iOS named it; #791 was filed partly on the strength of an
+ * "uncatalogued" event that iOS already knew. That gap makes an Android bug report unable to say what the
+ * strap is reporting — RTC_LOST, BOOT, BLE_SYSTEM_RESET and EXTENDED_BATTERY_INFORMATION all arrived
+ * anonymous.
+ *
+ * Names only. Event PAYLOAD decoding stays exactly as it was: family-gated and deliberately conservative,
+ * because several of these payloads have no on-device 5.0 ground truth and are left raw rather than ported
+ * from 4.0 on faith (see `decodeWhoop5Event`). A name here does not imply a decoder.
+ *
+ * A number absent from the schema still falls through to `hexLabel`, and is NEVER given an invented name —
+ * event 68 (`0x44`) observed on a real 4.0 in #791 is unknown to both platforms and stays unknown.
+ */
 enum class EventNumber(val rawValue: Int) {
+    UNDEFINED(0),
+    ERROR(1),
+    CONSOLE_OUTPUT(2),
     BATTERY_LEVEL(3),
+    SYSTEM_CONTROL(4),
+    EXTERNAL_5V_ON(5),
+    EXTERNAL_5V_OFF(6),
     CHARGING_ON(7),
     CHARGING_OFF(8),
     WRIST_ON(9),
     WRIST_OFF(10),
+    BLE_CONNECTION_UP(11),
+    BLE_CONNECTION_DOWN(12),
+    RTC_LOST(13),
     DOUBLE_TAP(14),
+    BOOT(15),
+    SET_RTC(16),
     TEMPERATURE_LEVEL(17),
+    PAIRING_MODE(18),
+    SERIAL_HEAD_CONNECTED(19),
+    SERIAL_HEAD_REMOVED(20),
+    BATTERY_PACK_CONNECTED(21),
+    BATTERY_PACK_REMOVED(22),
     BLE_BONDED(23),
+    BLE_HR_PROFILE_ENABLED(24),
+    BLE_HR_PROFILE_DISABLED(25),
+    TRIM_ALL_DATA(26),
+    TRIM_ALL_DATA_ENDED(27),
+    FLASH_INIT_COMPLETE(28),
+    STRAP_CONDITION_REPORT(29),
+    BOOT_REPORT(30),
+    EXIT_VIRGIN_MODE(31),
+    CAPTOUCH_AUTOTHRESHOLD_ACTION(32),
     BLE_REALTIME_HR_ON(33),
     BLE_REALTIME_HR_OFF(34),
+    ACCELEROMETER_RESET(35),
+    AFE_RESET(36),
+    SHIP_MODE_ENABLED(37),
+    SHIP_MODE_DISABLED(38),
+    SHIP_MODE_BOOT(39),
+    CH1_SATURATION_DETECTED(40),
+    CH2_SATURATION_DETECTED(41),
+    ACCELEROMETER_SATURATION_DETECTED(42),
+    BLE_SYSTEM_RESET(43),
+    BLE_SYSTEM_ON(44),
+    BLE_SYSTEM_INITIALIZED(45),
+    RAW_DATA_COLLECTION_ON(46),
+    RAW_DATA_COLLECTION_OFF(47),
+    STRAP_DRIVEN_ALARM_SET(56),
     STRAP_DRIVEN_ALARM_EXECUTED(57),
     APP_DRIVEN_ALARM_EXECUTED(58),
-    HAPTICS_FIRED(60);
+    STRAP_DRIVEN_ALARM_DISABLED(59),
+    HAPTICS_FIRED(60),
+    EXTENDED_BATTERY_INFORMATION(63),
+    HIGH_FREQ_SYNC_PROMPT(96),
+    HIGH_FREQ_SYNC_ENABLED(97),
+    HIGH_FREQ_SYNC_DISABLED(98),
+    HAPTICS_TERMINATED(100);
 
     companion object {
         private val byRaw = entries.associateBy { it.rawValue }

--- a/android/app/src/test/java/com/noop/protocol/EventCatalogueTest.kt
+++ b/android/app/src/test/java/com/noop/protocol/EventCatalogueTest.kt
@@ -1,0 +1,114 @@
+package com.noop.protocol
+
+import java.io.File
+import org.json.JSONObject
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Holds [EventNumber] in lockstep with the shared schema
+ * (`Packages/WhoopProtocol/Sources/WhoopProtocol/Resources/whoop_protocol.json`), which iOS reads directly
+ * at runtime.
+ *
+ * Android used to name only 13 of the 58 events, so every other event rendered as a bare `0x44(68)` in an
+ * Android strap log while iOS named it. #791 was filed partly on the strength of an "uncatalogued" event
+ * that iOS already knew. A label divergence breaks the cross-platform contract as surely as a value
+ * divergence, and it stays invisible until someone is reading a log.
+ *
+ * This reads the schema rather than restating it, on purpose. The bug being fixed is precisely "the schema
+ * grew and Android did not follow", so a test carrying its own copy of the catalogue would pass straight
+ * through a recurrence — it could only catch a deletion or a renumber.
+ *
+ * The lockstep check `Assume`-skips when the Swift tree is absent, following [DecoderOracleTest]'s
+ * convention, so it is a drift guard for a full checkout and not a hard gate everywhere. The targeted checks
+ * below never skip, so the #791 events and the revived RTC diagnostic stay pinned either way.
+ */
+class EventCatalogueTest {
+
+    /**
+     * Locates the schema the same way [DecoderOracleTest.oracleCopiesAreIdentical] locates the Swift oracle
+     * copy — `user.dir` is the module dir or the repo root depending on how the runner was launched — and
+     * skips gracefully by the same convention if the Swift tree is not present.
+     */
+    @Test
+    fun everyEventInTheSharedSchemaIsNamedOnAndroid() {
+        val rel = "Packages/WhoopProtocol/Sources/WhoopProtocol/Resources/whoop_protocol.json"
+        val userDir = File(System.getProperty("user.dir"))
+        val schemaFile = listOf(File(userDir, rel), File(userDir, "../../$rel")).firstOrNull { it.exists() }
+        org.junit.Assume.assumeTrue(
+            "shared schema not found from user.dir=$userDir — skipping the catalogue lockstep check",
+            schemaFile != null,
+        )
+        val events = JSONObject(schemaFile!!.readText()).getJSONObject("enums").getJSONObject("EventNumber")
+        val schema = events.keys().asSequence().associate { it.toInt() to events.getString(it) }
+        assertTrue("EventNumber block parsed empty", schema.isNotEmpty())
+
+        val kotlin = EventNumber.entries.associate { it.rawValue to it.name }
+        assertEquals("Android is missing events the schema names", emptySet<Int>(), schema.keys - kotlin.keys)
+        assertEquals("Android names events the schema does not", emptySet<Int>(), kotlin.keys - schema.keys)
+        for ((raw, name) in schema) {
+            assertEquals("event $raw", name, kotlin[raw])
+        }
+    }
+
+    /** A copy-paste renumber would otherwise shadow an event silently. */
+    @Test
+    fun rawValuesAreUnique() {
+        assertEquals(
+            EventNumber.entries.size,
+            EventNumber.entries.map { it.rawValue }.toSet().size,
+        )
+    }
+
+    /** The events from #791 that an Android reporter could not previously name. */
+    @Test
+    fun theEventsThatMatterForAndroidBugReportsAreNamed() {
+        assertEquals("EXTENDED_BATTERY_INFORMATION", EventNumber.fromRaw(63)?.name)  // untested battery path
+        assertEquals("RTC_LOST", EventNumber.fromRaw(13)?.name)                      // scrambled RTC
+        assertEquals("SET_RTC", EventNumber.fromRaw(16)?.name)                       // SET_CLOCK not sticking
+        assertEquals("BOOT", EventNumber.fromRaw(15)?.name)                          // brownout/reboot
+        assertEquals("BOOT_REPORT", EventNumber.fromRaw(30)?.name)
+        assertEquals("BLE_SYSTEM_RESET", EventNumber.fromRaw(43)?.name)
+    }
+
+    /**
+     * The behavioural bug the missing names caused, not just the cosmetic one.
+     *
+     * `DroppedRtcEvent.isRtcStateKind` matches the event LABEL by prefix, and the label is built from this
+     * enum (`"NAME(raw)"`, pinned by [FramingTest]). While events 13/15/16/30 were unnamed on Android their
+     * labels were `0x0D(13)` and friends, which match nothing — so the #324 dropped-RTC diagnostic was dead
+     * code on Android even though it mirrors Swift and iOS has captured it since #324
+     * (`HistoricalTimestampGateTests` pins the very string asserted below). That is the diagnostic which
+     * explains a future-dated strap, exactly the symptom reported in #791.
+     */
+    @Test
+    fun rtcStateDiagnosticCanNowActuallyFire() {
+        // The exact label the Swift twin's test asserts.
+        assertTrue(DroppedRtcEvent.isRtcStateKind("RTC_LOST(13)"))
+        assertTrue(DroppedRtcEvent.isRtcStateKind("BOOT(15)"))
+        assertTrue(DroppedRtcEvent.isRtcStateKind("SET_RTC(16)"))
+        assertTrue(DroppedRtcEvent.isRtcStateKind("BOOT_REPORT(30)"))
+
+        // What Android produced before, and why the diagnostic never fired there.
+        assertFalse(DroppedRtcEvent.isRtcStateKind("0x0D(13)"))
+        // Still correctly excluded: not an RTC-state event.
+        assertFalse(DroppedRtcEvent.isRtcStateKind("BATTERY_LEVEL(3)"))
+        assertFalse(DroppedRtcEvent.isRtcStateKind("0x44(68)"))
+    }
+
+    /**
+     * An unnamed number must stay unnamed. Event 68 (`0x44`) was observed on a real WHOOP 4.0 in #791 and is
+     * unknown to both platforms; inventing a name — or borrowing one from `CommandNumber`, where 68 is a
+     * different thing entirely — would put a fiction in the log, which is worse than a hex code.
+     */
+    @Test
+    fun unknownEventsAreNotGivenInventedNames() {
+        assertNull(EventNumber.fromRaw(68))
+        assertNull(EventNumber.fromRaw(48))
+        assertNull(EventNumber.fromRaw(123))
+        assertNull(EventNumber.fromRaw(255))
+    }
+}

--- a/android/app/src/test/java/com/noop/protocol/FramingTest.kt
+++ b/android/app/src/test/java/com/noop/protocol/FramingTest.kt
@@ -482,13 +482,15 @@ class FramingTest {
 
     @Test
     fun whoop5_event_decodesAtPlus4AndPreservesPayload() {
-        // Real 5/MG capture: uncatalogued event 0x1D(29) with a 16-byte payload — kept as hex so
-        // protocol research can classify it later.
+        // Real 5/MG capture: event 29 with a 16-byte payload. The shared catalogue names it
+        // STRAP_CONDITION_REPORT — event NAMES are family-independent (#791) — but its PAYLOAD has no
+        // on-device 5.0 ground truth, so it stays raw hex for protocol research rather than being decoded
+        // on faith. The payload assertion below is what pins that distinction.
         val frame = fromHex("aa011c00010023d130c61d00e61ab7698a390c000e0000000000e8020b000100d2803585")
         val parsed = Framing.parseFrame(frame, DeviceFamily.WHOOP5)
         assertEquals("EVENT", parsed.typeName)
         assertEquals(true, parsed.crcOk)
-        assertEquals("0x1D(29)", parsed.parsed["event"])
+        assertEquals("STRAP_CONDITION_REPORT(29)", parsed.parsed["event"])
         assertEquals(1773607654, parsed.parsed["event_timestamp"])
         assertEquals("8a390c000e0000000000e8020b000100", parsed.parsed["event_payload_hex"])
     }


### PR DESCRIPTION
From reviewing #791. The reporter listed an "uncatalogued event 0x44=68" from an Android capture, which
prompted a look at what Android actually names.

## The gap

The shared schema (`whoop_protocol.json`, which iOS reads at runtime) names **58** strap events. Android's
`EventNumber` enum listed **13**. Everything else reached an Android strap log as a bare `0x44(68)`.

The cosmetic consequence is that an Android bug report cannot say what the strap is reporting. The events
that would have explained #791's other two findings all arrived anonymous:

| Event | Bears on |
|---|---|
| `63 EXTENDED_BATTERY_INFORMATION` | the battery hunt — an event-driven source the report never tested |
| `13 RTC_LOST`, `16 SET_RTC` | finding 2, scrambled RTC and SET_CLOCK not sticking |
| `15 BOOT`, `30 BOOT_REPORT`, `43 BLE_SYSTEM_RESET` | finding 3, the brownout/reboot hypothesis |
| `1 ERROR`, `2 CONSOLE_OUTPUT` | strap-side errors, visible only as numbers |

## The real half: a dead diagnostic

`DroppedRtcEvent.isRtcStateKind` matches the event **label** by prefix (`kind.startsWith("RTC_LOST")`), and
the label is built from this enum as `"NAME(raw)"`. While 13/15/16/30 were unnamed their labels were
`0x0D(13)` and friends, which match nothing — so the **#324 dropped-RTC diagnostic was dead code on
Android**, though it mirrors Swift exactly (`Streams.swift:317`) and iOS has captured it since #324
(`HistoricalTimestampGateTests` pins the string `"RTC_LOST(13)"`).

That is the diagnostic which explains a future-dated strap. #791 reports the strap claiming `2030-01-28`
with nothing recording why — on Android there could not have been.

`droppedRtcEvents` is documented "Diag only" and flows to the strap log via `Backfiller`, so this restores a
diagnostic rather than altering stored data or analytics.

## Scope

**Names only.** Event payload decoding is untouched — it stays family-gated and deliberately conservative,
because several payloads have no on-device 5.0 ground truth and are left raw rather than ported from 4.0 on
faith (`Interpreter.swift:786`). A name here does not imply a decoder. A number absent from the schema still
falls through to the hex label and is never given an invented name: event **68**, observed on real hardware
in #791, is unknown to both platforms and stays unknown.

**No iOS change needed** — iOS resolves names from the shared JSON at runtime and already had all 58.

## Verification

Entries were generated from `whoop_protocol.json`, not transcribed. Verified mechanically:

- Android enum ≡ schema (58/58), no duplicate raw values, all valid Kotlin identifiers, and all 13
  pre-existing names already agreed with the schema so nothing is renamed
- Audited every Android `EventNumber` usage — one label site and two `== BATTERY_LEVEL` comparisons, no
  null-as-invalid checks, so `UNDEFINED(0)` is safe to include for exact label parity
- Checked every Android test for a pinned hex label of a now-named event: only `FramingTest`'s event 29,
  updated here
- No wildcard import of the enum anywhere, so the new entries cannot shadow an identifier
- `org.json` confirmed as a `testImplementation` dependency; the locator resolves from both the module dir
  and the repo root
- `Tools/i18n_audit.py --ci origin/main` → exit 0

### Corrected during review

The first draft of the lockstep test pinned the enum against a **hand-transcribed copy** of the catalogue.
That would have caught a deletion or a renumber but sailed straight through a recurrence of this very bug —
the schema growing while Android stands still, which is exactly how the gap arose. The test now **reads the
schema**, following `DecoderOracleTest`'s existing convention for reaching the Swift tree: `org.json`, the
two-candidate `user.dir` locator, and an `Assume`-skip when that tree is absent. The targeted assertions for
the #791 events and the revived RTC diagnostic never skip, so they hold either way.

Worth being precise about the guard's reach: the lockstep check is a drift guard for a full checkout, not a
hard gate in every context, because it skips when the Swift tree is missing. That is the repo's existing
convention rather than a new compromise.

### Additional checks, no defects found

Recorded so a reviewer need not re-derive them:

- **Ordinal shift.** New entries were inserted *before* `BATTERY_LEVEL`, so every ordinal moved. Nothing
  persists this enum by `ordinal`, `name`, `valueOf`, or a Room `TypeConverter` — the only `.ordinal` uses in
  the app belong to unrelated enums, and the full usage audit found one label site plus two
  `== BATTERY_LEVEL` comparisons. Safe.
- **The shared decoder oracle.** `decoder_oracle.json` is asserted byte-identical across platforms and pins
  expected decodes for both. It contains no event labels at all (type-47 HISTORICAL_DATA frames, not EVENT
  frames), and the two copies remain identical. Unaffected.
- **Stale expectations.** Swept every file under `src/test`, `src/androidTest` and `src/main/assets` for a
  pinned hex label of a now-named event. Only `FramingTest`'s event 29, already updated.
- **The newly-live path under load.** Android's dropped-RTC logging loop is an exact twin of
  `Strand/Collect/Backfiller.swift` — same message, and uncapped on both sides by the same documented
  rationale that these events are sparse rather than per-record. Reviving it introduces no divergence.
- **Style.** No ktlint, detekt, or editorconfig gate in the repo; longest line here is 110 against 129
  elsewhere in `com.noop.protocol`.

The one thing still unverified is compilation. The specific Kotlin surface used — `JSONObject.keys()`
`.asSequence()`, `Assume.assumeTrue(String, Boolean)`, `Set<Int>` difference, `EventNumber.entries` — was
reasoned through rather than compiled, which is not the same thing.

**Not run: the JUnit suite.** This machine has no JDK, so the assertions were verified by mechanically
simulating the same data and parsing against the real schema file rather than by execution. A real
`gradlew test` before merge is worth it — `android.yml` is disabled, so CI will not do it either.

