### PR TITLE
ble: stop repeating a BUSY-refused write that was delivered, + the diagnostics that pinned it (#797, #791)

### DIFF
--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -912,17 +912,33 @@ class WhoopBleClient(
          * out, so repeating it delivers the same command to the strap twice — the reported symptom, where one
          * GET_DATA_RANGE drew three responses carrying one unchanged origin-seq echo.
          *
-         * This cannot swallow a legitimate retry. `pendingRetry` is non-null only when the MOST RECENT write
-         * attempt returned BUSY, and the drain never starts a write while one is in flight, so no other
-         * outstanding command-channel write could own this completion. A frame the stack truly refused
-         * produces no completion at all, leaving its retry to fire — the #77/#312 protection against a
-         * silently dropped TOGGLE_REALTIME_HR / SET_CLOCK / offload-ack is untouched.
+         * `pendingRetry` is non-null only when the most recent DRAINED write returned BUSY, and the drain
+         * never starts a write while one is in flight — so within the drain there is no other outstanding
+         * command-channel write this completion could belong to. A frame the stack truly refused produces no
+         * completion at all, leaving its retry to fire, so the #77/#312 protection against a silently dropped
+         * TOGGLE_REALTIME_HR / SET_CLOCK / offload-ack is untouched.
+         *
+         * [writeBondFrame] is the exception that forces the third argument: it writes to the same
+         * characteristic DELIBERATELY outside the queue, so its completion is not evidence about the held
+         * frame. Acting on it would cancel a retry for a frame that never went out — turning the duplicate
+         * this fixes into the silent loss #77/#312 is about, which is strictly worse. Excluded explicitly.
+         *
+         * Only WITH-response writes reach here at all: a without-response write gets no completion callback
+         * (the drain frees its own slot after a pacing gap), so this cannot help those. That happens to cover
+         * the reported case and the commands where a duplicate actually harms — GET_DATA_RANGE, SET_CLOCK,
+         * the historical acks, haptics and RUN_ALARM are all sent with response — but it is a real limit, not
+         * a general guarantee.
          *
          * Pure so it can be tested: the instance-level path cannot be, since the constructor needs a real
          * Looper and Context (see [GattCrashSafetyTest]'s infra note).
          */
-        fun shouldCancelBusyRetryOnCompletion(writtenChar: UUID?, hasFrameHeldForRetry: Boolean): Boolean =
+        fun shouldCancelBusyRetryOnCompletion(
+            writtenChar: UUID?,
+            hasFrameHeldForRetry: Boolean,
+            isBondWriteCompletion: Boolean,
+        ): Boolean =
             hasFrameHeldForRetry &&
+                !isBondWriteCompletion &&
                 (writtenChar == CMD_WRITE_CHAR || writtenChar == WHOOP5_CMD_WRITE_CHAR)
 
         fun writeStatusLabel(status: Int?): String = when (status) {
@@ -2202,6 +2218,11 @@ class WhoopBleClient(
     // write-completion callbacks - the barrier guarantees the main-thread drain sees the flag flip promptly
     // (else a queued write could stall until the next drain trigger).
     @Volatile private var writeInFlight = false
+    /** #791: set while [writeBondFrame]'s out-of-queue confirmed write is outstanding, so its completion is
+     *  not mistaken for evidence about a frame held for retry. @Volatile: set on the main looper, read and
+     *  cleared from the GATT binder thread in onCharacteristicWrite. */
+    @Volatile private var bondWriteOutstanding = false
+
     /** A frame being retried after a transient BUSY rejection. Held here rather than re-added to the
      *  queue so it keeps its place AHEAD of later commands — command order matters (e.g. SET_CLOCK
      *  before GET_CLOCK). Only ever touched on the main looper inside [drainWriteQueue]. */
@@ -2223,8 +2244,8 @@ class WhoopBleClient(
      *
      * No-op when nothing is held for retry, which is the normal case for every successful write.
      */
-    private fun cancelRetryOfWriteDeliveredDespiteBusy(writtenChar: UUID?) {
-        if (!shouldCancelBusyRetryOnCompletion(writtenChar, pendingRetry != null)) return
+    private fun cancelRetryOfWriteDeliveredDespiteBusy(writtenChar: UUID?, fromBondWrite: Boolean) {
+        if (!shouldCancelBusyRetryOnCompletion(writtenChar, pendingRetry != null, fromBondWrite)) return
         val delivered = pendingRetry ?: return
         pendingRetry = null
         writeRetries = 0
@@ -4245,8 +4266,11 @@ class WhoopBleClient(
             // refused produces no completion at all, so its retry still fires — the #77/#312 protection
             // against a silently dropped TOGGLE_REALTIME_HR / SET_CLOCK / offload-ack is untouched.
             // Hops to the main looper because pendingRetry is main-looper-only state, and it is read there
-            // rather than here. Posted with no delay, so it runs ahead of the >=12 ms retry it cancels.
-            handler.post { cancelRetryOfWriteDeliveredDespiteBusy(characteristic.uuid) }
+            // rather than here. Posted with no delay, so it runs ahead of the >=12 ms retry it cancels. The
+            // bond flag is consumed HERE, on the callback, so a later completion cannot inherit it.
+            val wasBondWrite = bondWriteOutstanding
+            bondWriteOutstanding = false
+            handler.post { cancelRetryOfWriteDeliveredDespiteBusy(characteristic.uuid, wasBondWrite) }
 
             // This with-response write is done; release the in-flight slot and send the next.
             writeInFlight = false
@@ -5385,6 +5409,7 @@ class WhoopBleClient(
         val bondFrame = Framing.buildCommand(CommandNumber.GET_BATTERY_LEVEL, byteArrayOf(0), s)
         log("Bonding: confirmed write GET_BATTERY_LEVEL to 61080002")
         writeInFlight = true   // hold the slot until onCharacteristicWrite fires (with response).
+        bondWriteOutstanding = true   // #791: this write bypasses the queue; its ack proves nothing about pendingRetry
         // safeGatt: a throw means the binder died (#314) — teardown, return false, fall into the
         // "rejected" branch which just clears the (now-stale) in-flight slot.
         val ok = safeGatt("writeBondFrame") {
@@ -5392,6 +5417,7 @@ class WhoopBleClient(
         }
         if (!ok) {
             writeInFlight = false
+            bondWriteOutstanding = false
             log("Bond write rejected by stack")
         }
     }
@@ -6458,6 +6484,7 @@ class WhoopBleClient(
         writeInFlight = false
         pendingRetry = null
         writeRetries = 0
+        bondWriteOutstanding = false   // #791: a stale flag would suppress a legitimate cancel next session
         // Cancel any scheduled BUSY-retry kicks so a queued retry can't fire after teardown and
         // re-enter a dead write/descriptor (#314).
         handler.removeCallbacks(drainWriteRetryRunnable)

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -904,6 +904,27 @@ class WhoopBleClient(
          * Literal codes rather than `BluetoothStatusCodes` constants: these are compile-time-inlined API 33
          * values, and spelling them out keeps this readable in a log review and buildable on any compileSdk.
          */
+        /**
+         * #791: may a write-completion callback cancel the BUSY-retry currently held?
+         *
+         * Yes exactly when a frame is held for retry and the completion is for a command-channel write. A
+         * completion for a frame the stack claimed to refuse proves the refusal was wrong and the frame went
+         * out, so repeating it delivers the same command to the strap twice — the reported symptom, where one
+         * GET_DATA_RANGE drew three responses carrying one unchanged origin-seq echo.
+         *
+         * This cannot swallow a legitimate retry. `pendingRetry` is non-null only when the MOST RECENT write
+         * attempt returned BUSY, and the drain never starts a write while one is in flight, so no other
+         * outstanding command-channel write could own this completion. A frame the stack truly refused
+         * produces no completion at all, leaving its retry to fire — the #77/#312 protection against a
+         * silently dropped TOGGLE_REALTIME_HR / SET_CLOCK / offload-ack is untouched.
+         *
+         * Pure so it can be tested: the instance-level path cannot be, since the constructor needs a real
+         * Looper and Context (see [GattCrashSafetyTest]'s infra note).
+         */
+        fun shouldCancelBusyRetryOnCompletion(writtenChar: UUID?, hasFrameHeldForRetry: Boolean): Boolean =
+            hasFrameHeldForRetry &&
+                (writtenChar == CMD_WRITE_CHAR || writtenChar == WHOOP5_CMD_WRITE_CHAR)
+
         fun writeStatusLabel(status: Int?): String = when (status) {
             null -> "status=n/a(legacy-api)"
             0 -> "status=SUCCESS(0)"          // BluetoothStatusCodes.SUCCESS — should not reach the busy path
@@ -2191,6 +2212,28 @@ class WhoopBleClient(
      *  teardown path can cancel a still-pending retry — otherwise a queued retry fires after the link is
      *  dead and re-enters the now-dead write, re-throwing `DeadObjectException` (#314). */
     private val drainWriteRetryRunnable = Runnable { drainWriteQueue() }
+
+    /**
+     * #791: drop a scheduled BUSY-retry because the write it would repeat has just completed.
+     *
+     * Called from `onCharacteristicWrite` (via the main looper, since [pendingRetry] is main-looper-only
+     * state). A completion for a frame the stack said it refused means the refusal was wrong and the frame
+     * went out, so repeating it would deliver the same command to the strap twice. Not re-draining here: the
+     * caller's own `drainWriteQueue()` follows on the same looper and picks up the next queued frame.
+     *
+     * No-op when nothing is held for retry, which is the normal case for every successful write.
+     */
+    private fun cancelRetryOfWriteDeliveredDespiteBusy(writtenChar: UUID?) {
+        if (!shouldCancelBusyRetryOnCompletion(writtenChar, pendingRetry != null)) return
+        val delivered = pendingRetry ?: return
+        pendingRetry = null
+        writeRetries = 0
+        handler.removeCallbacks(drainWriteRetryRunnable)
+        log(
+            "write reported busy but then completed — dropping the duplicate retry of " +
+                "${delivered.cmd?.name ?: "raw frame"} (#791)",
+        )
+    }
 
     /** Descriptor-write queue: enabling notifications is also a one-at-a-time GATT operation. */
     private val cccdQueue = ConcurrentLinkedQueue<BluetoothGattCharacteristic>()
@@ -4189,6 +4232,21 @@ class WhoopBleClient(
                 noteRebootReconnectIfNeeded()
                 runConnectHandshake()
             }
+
+            // #791: a completion callback arriving while a BUSY-refused frame is STILL held for retry is
+            // proof that write was delivered after all — the stack refused it and sent it anyway. Cancel the
+            // retry, or the strap receives the same command twice. Observed on a Galaxy S24 Ultra: one
+            // GET_DATA_RANGE produced three CRC-valid responses with advancing strap-side sequence numbers
+            // and one unchanged origin-seq echo, always after a burst of busy-retries and never without.
+            //
+            // This cannot cancel a legitimate retry. `pendingRetry` is non-null only when the MOST RECENT
+            // write attempt returned BUSY, and the drain never starts a write while one is in flight, so
+            // there is no other outstanding write this completion could belong to. A frame the stack truly
+            // refused produces no completion at all, so its retry still fires — the #77/#312 protection
+            // against a silently dropped TOGGLE_REALTIME_HR / SET_CLOCK / offload-ack is untouched.
+            // Hops to the main looper because pendingRetry is main-looper-only state, and it is read there
+            // rather than here. Posted with no delay, so it runs ahead of the >=12 ms retry it cancels.
+            handler.post { cancelRetryOfWriteDeliveredDespiteBusy(characteristic.uuid) }
 
             // This with-response write is done; release the in-flight slot and send the next.
             writeInFlight = false

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -304,14 +304,35 @@ interface GattOps {
  */
 @SuppressLint("MissingPermission")
 class RealGattOps(private val gatt: BluetoothGatt) : GattOps {
+
+    /**
+     * #791: the raw status of the most recent Android 13+ write, kept because the `Boolean` contract throws
+     * away WHY the stack refused — and that "why" is the open question.
+     *
+     * A reporter on a Galaxy S24 saw one `GET_DATA_RANGE` produce THREE CRC-valid responses with consecutive
+     * strap-side sequence numbers, every time correlating with a burst of busy-retries, and single responses
+     * on ticks with no retries. That means a write the stack reported as refused had in fact been delivered,
+     * and the retry duplicated it. `ERROR_GATT_WRITE_REQUEST_BUSY` is documented as "not initiated", so
+     * either this stack returns it while still delivering, or it is returning something else entirely. The
+     * code distinguishes those, and nothing was recording it.
+     *
+     * Null on pre-TIRAMISU, where the legacy API only ever returned a Boolean.
+     */
+    @Volatile
+    var lastWriteStatus: Int? = null
+        private set
+
     override fun writeCharacteristicCompat(
         ch: BluetoothGattCharacteristic,
         value: ByteArray,
         writeType: Int,
     ): Boolean =
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-            gatt.writeCharacteristic(ch, value, writeType) == BluetoothGatt.GATT_SUCCESS
+            val status = gatt.writeCharacteristic(ch, value, writeType)
+            lastWriteStatus = status
+            status == BluetoothGatt.GATT_SUCCESS
         } else {
+            lastWriteStatus = null
             @Suppress("DEPRECATION")
             run {
                 ch.writeType = writeType
@@ -872,6 +893,30 @@ class WhoopBleClient(
          * Every other dropped frame (haptics, offload-ack, clock, …) has its own recovery and must NOT poke
          * the realtime latch. Pure + instance-free so the unit harness can pin it without a live GATT stack.
          */
+        /**
+         * #791: name an Android 13+ write-refusal code for the strap log.
+         *
+         * The distinction that matters is `ERROR_GATT_WRITE_REQUEST_BUSY` (201), documented as the write not
+         * having been initiated and therefore safe to retry, versus anything else. A reporter's captures show
+         * a refused write being delivered anyway and the retry duplicating it, so which code the stack
+         * returned is the evidence that separates "safe retry" from "we just sent it twice".
+         *
+         * Literal codes rather than `BluetoothStatusCodes` constants: these are compile-time-inlined API 33
+         * values, and spelling them out keeps this readable in a log review and buildable on any compileSdk.
+         */
+        fun writeStatusLabel(status: Int?): String = when (status) {
+            null -> "status=n/a(legacy-api)"
+            0 -> "status=SUCCESS(0)"          // BluetoothStatusCodes.SUCCESS — should not reach the busy path
+            1 -> "status=ERROR_BLUETOOTH_NOT_ENABLED(1)"
+            2 -> "status=ERROR_BLUETOOTH_NOT_ALLOWED(2)"
+            3 -> "status=ERROR_DEVICE_NOT_BONDED(3)"
+            6 -> "status=ERROR_MISSING_BLUETOOTH_CONNECT_PERMISSION(6)"
+            9 -> "status=ERROR_PROFILE_SERVICE_NOT_BOUND(9)"
+            200 -> "status=ERROR_GATT_WRITE_NOT_ALLOWED(200)"
+            201 -> "status=ERROR_GATT_WRITE_REQUEST_BUSY(201)"
+            else -> "status=$status"
+        }
+
         fun shouldReArmRealtimeAfterDrop(droppedCmd: CommandNumber?): Boolean =
             droppedCmd == CommandNumber.TOGGLE_REALTIME_HR
 
@@ -5224,7 +5269,14 @@ class WhoopBleClient(
             if (gatt == null) return
             if (writeRetries < MAX_WRITE_RETRIES) {
                 writeRetries++
-                log("writeCharacteristic busy; retry $writeRetries/$MAX_WRITE_RETRIES")
+                // #791: report WHICH refusal, not just that there was one. A retry is only safe if the write
+                // truly was not initiated, and a reporter's captures show it sometimes WAS — so the status
+                // code is the evidence that tells the two apart. Frame is named too, since the harm from a
+                // duplicate depends entirely on which command got sent twice.
+                log(
+                    "writeCharacteristic busy; retry $writeRetries/$MAX_WRITE_RETRIES " +
+                        "cmd=${item.cmd?.name ?: "raw"} ${writeStatusLabel((ops as? RealGattOps)?.lastWriteStatus)}",
+                )
                 pendingRetry = item
                 // Escalating backoff (12, 24, … capped ~96ms) — ride out a congestion spike instead of
                 // exhausting the budget in a few tens of ms while the stack is still busy (#77). NAMED

--- a/android/app/src/main/java/com/noop/protocol/Framing.kt
+++ b/android/app/src/main/java/com/noop/protocol/Framing.kt
@@ -224,8 +224,10 @@ object Framing {
     private fun commandLabel(v: Int): String =
         CommandNumber.fromRaw(v)?.let { "${it.name}($v)" } ?: hexLabel(v)
 
-    /** 5/MG COMMAND_RESPONSE result codes. 3=UNSUPPORTED matches our own MG haptics-rejection
-     *  capture (#48); 2=PENDING precedes SUCCESS on GET_DATA_RANGE (hardware-confirmed, #78 fork). */
+    /** COMMAND_RESPONSE result codes, on both families. 3=UNSUPPORTED matches our own MG haptics-rejection
+     *  capture (#48); 2=PENDING precedes SUCCESS on GET_DATA_RANGE (hardware-confirmed, #78 fork). The same
+     *  codes appear on a 4.0 at payload[1] — 0x01 on an answered GET_DATA_RANGE, 0x00 on an empty
+     *  extended-battery reply (#791 captures). */
     private fun commandResultLabel(v: Int): String = when (v) {
         0 -> "FAILURE(0)"
         1 -> "SUCCESS(1)"
@@ -467,6 +469,19 @@ object Framing {
         val pay = frame.copyOfRange(7, payEnd)
         val cmd = frame.u8(6) ?: return
         parsed["resp_cmd"] = commandLabel(cmd)
+        // #791: the origin-seq echo and the result code, which the 5/MG path has always exposed (at @11/@12)
+        // and this one never did. Without them a 4.0 strap log cannot say whether a command SUCCEEDED or
+        // FAILED — a reporter had to hand-decode `result=0x00` from raw hex to discover that their strap was
+        // answering GET_EXTENDED_BATTERY_INFO with FAILURE rather than an empty success.
+        //
+        // Grounded in real 4.0 captures, not inferred: an answered GET_DATA_RANGE carries pay[1] = 0x01
+        // (SUCCESS) and the empty extended-battery reply carries 0x00 (FAILURE), and the GET_BATTERY_LEVEL
+        // decode below has always read its value from payload[2..4] — already skipping these two bytes.
+        //
+        // The echo also makes a duplicated write self-evident: the same resp_seq arriving two or three times
+        // for one send is the #791 write-queue bug, visible in a log instead of needing frame archaeology.
+        if (pay.isNotEmpty()) parsed["resp_seq"] = pay[0].toInt() and 0xFF
+        if (pay.size >= 2) parsed["result"] = commandResultLabel(pay[1].toInt() and 0xFF)
         when (CommandNumber.fromRaw(cmd)) {
             CommandNumber.GET_BATTERY_LEVEL -> {
                 if (pay.size >= 4) {

--- a/android/app/src/test/java/com/noop/ble/BusyRetryDuplicateWriteTest.kt
+++ b/android/app/src/test/java/com/noop/ble/BusyRetryDuplicateWriteTest.kt
@@ -18,6 +18,11 @@ import org.junit.Test
  * callback — the proof that the refused write actually landed — left the retry armed. Now a completion
  * cancels it.
  *
+ * Limited to WITH-response writes by nature, since a without-response write gets no completion callback at
+ * all. That covers the reported command and the ones where a duplicate actually harms — `GET_DATA_RANGE`,
+ * `SET_CLOCK`, the historical acks, haptics and `RUN_ALARM` are all sent with response — but it is a limit,
+ * not a general guarantee.
+ *
  * Pins the pure decision only. The instance-level sequencing cannot be exercised in this harness: the
  * constructor builds a `Handler(Looper.getMainLooper())` and calls `context.getSystemService(...)`, both of
  * which throw against the stub `android.jar`, and the project ships no Robolectric — the same constraint
@@ -32,13 +37,13 @@ class BusyRetryDuplicateWriteTest {
     /** The bug: a completion arrived for a frame still held for retry, and the retry fired anyway. */
     @Test
     fun completionWhileAFrameIsHeldForRetryCancelsIt() {
-        assertTrue(WhoopBleClient.shouldCancelBusyRetryOnCompletion(whoop4Cmd, hasFrameHeldForRetry = true))
+        assertTrue(WhoopBleClient.shouldCancelBusyRetryOnCompletion(whoop4Cmd, hasFrameHeldForRetry = true, isBondWriteCompletion = false))
     }
 
     /** Both families write commands on their own characteristic; neither may duplicate. */
     @Test
     fun bothFamiliesCommandChannelsQualify() {
-        assertTrue(WhoopBleClient.shouldCancelBusyRetryOnCompletion(whoop5Cmd, hasFrameHeldForRetry = true))
+        assertTrue(WhoopBleClient.shouldCancelBusyRetryOnCompletion(whoop5Cmd, hasFrameHeldForRetry = true, isBondWriteCompletion = false))
     }
 
     /**
@@ -48,8 +53,8 @@ class BusyRetryDuplicateWriteTest {
      */
     @Test
     fun completionWithNothingHeldIsANoOp() {
-        assertFalse(WhoopBleClient.shouldCancelBusyRetryOnCompletion(whoop4Cmd, hasFrameHeldForRetry = false))
-        assertFalse(WhoopBleClient.shouldCancelBusyRetryOnCompletion(whoop5Cmd, hasFrameHeldForRetry = false))
+        assertFalse(WhoopBleClient.shouldCancelBusyRetryOnCompletion(whoop4Cmd, hasFrameHeldForRetry = false, isBondWriteCompletion = false))
+        assertFalse(WhoopBleClient.shouldCancelBusyRetryOnCompletion(whoop5Cmd, hasFrameHeldForRetry = false, isBondWriteCompletion = false))
     }
 
     /**
@@ -58,8 +63,28 @@ class BusyRetryDuplicateWriteTest {
      */
     @Test
     fun completionOnAnotherCharacteristicNeverCancels() {
-        assertFalse(WhoopBleClient.shouldCancelBusyRetryOnCompletion(someOtherChar, hasFrameHeldForRetry = true))
-        assertFalse(WhoopBleClient.shouldCancelBusyRetryOnCompletion(null, hasFrameHeldForRetry = true))
+        assertFalse(WhoopBleClient.shouldCancelBusyRetryOnCompletion(someOtherChar, hasFrameHeldForRetry = true, isBondWriteCompletion = false))
+        assertFalse(WhoopBleClient.shouldCancelBusyRetryOnCompletion(null, hasFrameHeldForRetry = true, isBondWriteCompletion = false))
+    }
+
+    /**
+     * The case a re-review turned up. [WhoopBleClient.writeBondFrame] writes to the SAME characteristic
+     * deliberately outside the queue and does not consume `pendingRetry`, so its ack is not evidence that a
+     * held frame went out. Cancelling on it would drop a frame that never left — converting the duplicate
+     * this fixes into the silent loss #77/#312 is about, which is strictly worse than a duplicate.
+     */
+    @Test
+    fun theOutOfQueueBondWriteCompletionNeverCancels() {
+        assertFalse(
+            WhoopBleClient.shouldCancelBusyRetryOnCompletion(
+                whoop4Cmd, hasFrameHeldForRetry = true, isBondWriteCompletion = true,
+            ),
+        )
+        assertFalse(
+            WhoopBleClient.shouldCancelBusyRetryOnCompletion(
+                whoop5Cmd, hasFrameHeldForRetry = true, isBondWriteCompletion = true,
+            ),
+        )
     }
 
     /** The refusal codes the log must be able to tell apart, since only one of them means "safe to retry". */

--- a/android/app/src/test/java/com/noop/ble/BusyRetryDuplicateWriteTest.kt
+++ b/android/app/src/test/java/com/noop/ble/BusyRetryDuplicateWriteTest.kt
@@ -1,0 +1,75 @@
+package com.noop.ble
+
+import java.util.UUID
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * #791: a BUSY-refused write that was delivered anyway must not be repeated.
+ *
+ * A reporter on a Galaxy S24 Ultra sent one `GET_DATA_RANGE` and received THREE CRC-valid responses whose
+ * strap-side sequence numbers advanced (0x7e/0x7f/0x80) while the origin-seq echo stayed at 0x0a — so the
+ * strap really did receive the command three times. It happened only after a burst of `writeCharacteristic
+ * busy; retry n/12` lines and never on ticks without them: the stack reported the write as refused, sent it
+ * anyway, and [WhoopBleClient]'s retry duplicated it.
+ *
+ * The mechanism is that `pendingRetry` was only ever cleared when the drain CONSUMED it, so a write-completion
+ * callback — the proof that the refused write actually landed — left the retry armed. Now a completion
+ * cancels it.
+ *
+ * Pins the pure decision only. The instance-level sequencing cannot be exercised in this harness: the
+ * constructor builds a `Handler(Looper.getMainLooper())` and calls `context.getSystemService(...)`, both of
+ * which throw against the stub `android.jar`, and the project ships no Robolectric — the same constraint
+ * [GattCrashSafetyTest] documents, and the same pattern it follows.
+ */
+class BusyRetryDuplicateWriteTest {
+
+    private val whoop4Cmd = UUID.fromString("61080002-8d6d-82b8-614a-1c8cb0f8dcc6")
+    private val whoop5Cmd = UUID.fromString("fd4b0002-cce1-4033-93ce-002d5875f58a")
+    private val someOtherChar = UUID.fromString("00002a37-0000-1000-8000-00805f9b34fb")   // standard HR
+
+    /** The bug: a completion arrived for a frame still held for retry, and the retry fired anyway. */
+    @Test
+    fun completionWhileAFrameIsHeldForRetryCancelsIt() {
+        assertTrue(WhoopBleClient.shouldCancelBusyRetryOnCompletion(whoop4Cmd, hasFrameHeldForRetry = true))
+    }
+
+    /** Both families write commands on their own characteristic; neither may duplicate. */
+    @Test
+    fun bothFamiliesCommandChannelsQualify() {
+        assertTrue(WhoopBleClient.shouldCancelBusyRetryOnCompletion(whoop5Cmd, hasFrameHeldForRetry = true))
+    }
+
+    /**
+     * The #77/#312 protection must survive. A write the stack genuinely refused produces no completion, so
+     * nothing reaches this predicate and the retry fires — but even if a completion arrives with nothing
+     * held, it must not be treated as a cancellation.
+     */
+    @Test
+    fun completionWithNothingHeldIsANoOp() {
+        assertFalse(WhoopBleClient.shouldCancelBusyRetryOnCompletion(whoop4Cmd, hasFrameHeldForRetry = false))
+        assertFalse(WhoopBleClient.shouldCancelBusyRetryOnCompletion(whoop5Cmd, hasFrameHeldForRetry = false))
+    }
+
+    /**
+     * A completion on some other characteristic says nothing about the command frame being held. Cancelling
+     * on it would drop the frame for real, converting a duplicate into the silent loss #77/#312 is about.
+     */
+    @Test
+    fun completionOnAnotherCharacteristicNeverCancels() {
+        assertFalse(WhoopBleClient.shouldCancelBusyRetryOnCompletion(someOtherChar, hasFrameHeldForRetry = true))
+        assertFalse(WhoopBleClient.shouldCancelBusyRetryOnCompletion(null, hasFrameHeldForRetry = true))
+    }
+
+    /** The refusal codes the log must be able to tell apart, since only one of them means "safe to retry". */
+    @Test
+    fun writeStatusLabelNamesTheRefusalThatMatters() {
+        assertTrue(WhoopBleClient.writeStatusLabel(201).contains("ERROR_GATT_WRITE_REQUEST_BUSY"))
+        assertTrue(WhoopBleClient.writeStatusLabel(200).contains("ERROR_GATT_WRITE_NOT_ALLOWED"))
+        assertTrue(WhoopBleClient.writeStatusLabel(3).contains("ERROR_DEVICE_NOT_BONDED"))
+        // Pre-Android-13 has no status to report, and an unseen code must still be legible.
+        assertTrue(WhoopBleClient.writeStatusLabel(null).contains("legacy-api"))
+        assertTrue(WhoopBleClient.writeStatusLabel(4242).contains("4242"))
+    }
+}

--- a/android/app/src/test/java/com/noop/protocol/Whoop4ResponseResultTest.kt
+++ b/android/app/src/test/java/com/noop/protocol/Whoop4ResponseResultTest.kt
@@ -1,0 +1,73 @@
+package com.noop.protocol
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * WHOOP 4.0 COMMAND_RESPONSE origin-seq echo + result code (#791).
+ *
+ * The 5/MG path has always exposed `resp_seq` and `result`; the 4.0 path exposed neither, so a 4.0 strap log
+ * could not say whether a command succeeded or failed. The reporter in #791 had to hand-decode `result=0x00`
+ * out of raw hex to establish that their strap was answering `GET_EXTENDED_BATTERY_INFO` with FAILURE rather
+ * than with an empty success — a materially different conclusion.
+ *
+ * Every frame below is a REAL capture from that report (WHOOP 4.0, Galaxy S24 Ultra), not synthesised, which
+ * is what grounds the claim that payload[0] is the origin-seq echo and payload[1] the result code. The two
+ * frames disagree on the result byte (0x01 vs 0x00) while agreeing on the layout, and the long-standing
+ * `GET_BATTERY_LEVEL` decode has always read its value from payload[2..4] — already skipping both bytes.
+ */
+class Whoop4ResponseResultTest {
+
+    private fun fromHex(s: String): ByteArray {
+        val h = s.replace(" ", "")
+        return ByteArray(h.length / 2) {
+            ((h[it * 2].digitToInt(16) shl 4) or h[it * 2 + 1].digitToInt(16)).toByte()
+        }
+    }
+
+    /** A GET_DATA_RANGE the strap actually answered: result 0x01 = SUCCESS. */
+    @Test
+    fun answeredDataRangeReportsSuccessAndItsOriginSeq() {
+        val frame = fromHex(
+            "aa4c00a7247e220a01010000000050070100a307010050070100000000000000020035030000" +
+                "c2fc13008046394b00000000bbe1636aa02d0000bbe1636aa02d0000c6e4636ac07c000000000447ea04",
+        )
+        val r = Framing.parseFrame(frame, DeviceFamily.WHOOP4)
+        assertEquals("GET_DATA_RANGE(34)", r.parsed["resp_cmd"])
+        assertEquals(0x0A, r.parsed["resp_seq"])
+        assertEquals("SUCCESS(1)", r.parsed["result"])
+    }
+
+    /**
+     * The empty extended-battery reply that is the heart of #791: acknowledged, correct origin-seq echo, and
+     * result FAILURE with an all-zero payload. Before this decode a reader saw only "resp_cmd" and could not
+     * tell this apart from a successful reply that happened to carry zeros.
+     */
+    @Test
+    fun emptyExtendedBatteryReplyReportsFailureNotEmptySuccess() {
+        val frame = fromHex("aa2400fa2495622200" + "00".repeat(27) + "0ac33306")
+        val r = Framing.parseFrame(frame, DeviceFamily.WHOOP4)
+        assertEquals("GET_EXTENDED_BATTERY_INFO(98)", r.parsed["resp_cmd"])
+        assertEquals(0x22, r.parsed["resp_seq"])
+        assertEquals("FAILURE(0)", r.parsed["result"])
+    }
+
+    /**
+     * The duplicate-write symptom the echo makes legible. One `GET_DATA_RANGE` send produced three CRC-valid
+     * responses whose strap-side sequence numbers advanced (0x7e/0x7f/0x80) while the origin-seq echo stayed
+     * the same — so the strap really did receive the command three times. That repeated echo is now visible
+     * in the log rather than requiring frame archaeology.
+     */
+    @Test
+    fun duplicateResponsesShareOneOriginSeqAcrossAdvancingStrapSeq() {
+        val bodyAfterCmd = "0a01010000000050070100a307010050070100000000000000020035030000" +
+            "c2fc13008046394b00000000bbe1636aa02d0000bbe1636aa02d0000c6e4636ac07c000000000447ea04"
+        val seqs = listOf("7e", "7f", "80")
+        val echoes = seqs.map { strapSeq ->
+            val r = Framing.parseFrame(fromHex("aa4c00a724${strapSeq}22$bodyAfterCmd"), DeviceFamily.WHOOP4)
+            assertEquals("GET_DATA_RANGE(34)", r.parsed["resp_cmd"])
+            r.parsed["resp_seq"]
+        }
+        assertEquals(listOf(0x0A, 0x0A, 0x0A), echoes)
+    }
+}


### PR DESCRIPTION
Fixes #797. Refs #791, where this was reported as "finding 1" inside a battery report.

**Two commits at deliberately different risk levels — read the second one carefully.**

| | Risk |
|---|---|
| `e312f3a8` diagnostics — write status code, 4.0 response `result`/`resp_seq` | log output only |
| `2eeb8e06` the fix — cancel a retry the completion callback disproved | **behaviour change in the BLE write path** |

They are together because the fix depends on the first commit: its predicate sits beside `writeStatusLabel`
and its test asserts it. Splitting would have meant a stacked PR, which in this repo has already cost one
branch.

## The bug

One `GET_DATA_RANGE` produced **three** CRC-valid responses whose strap-side sequence advanced (0x7e/0x7f/0x80)
while the origin-seq echo stayed `0x0a` — so the strap received the command three times. Only ever after a
burst of busy-retries, never on quiet ticks. Reproduced three times in one session.

`drainWriteQueue` treats `writeCharacteristicCompat` returning `false` as proof of non-delivery. On this stack
the write was delivered anyway. The reason the retry is never called off is narrow:

```
pendingRetry   set on BUSY, cleared ONLY when the drain consumes it, or on reset
```

Nothing cleared it on a **write-completion callback** — and that callback is exactly the evidence that the
"refused" write landed. The completion released the in-flight slot, left the retry armed, and the retry sent
the frame again.

## The fix

A completion for a frame still held for retry cancels it.

It cannot swallow a legitimate retry: `pendingRetry` is non-null only when the most recent attempt returned
BUSY, and the drain never starts a write while one is in flight, so no other outstanding command-channel write
could own that completion. A frame the stack truly refused produces **no completion at all**, so its retry
still fires — which is why the retry was left in place rather than removed. #77/#312 established that a
dropped `TOGGLE_REALTIME_HR` / `SET_CLOCK` / offload-ack silently breaks live HR, the clock, or the backfill,
and trading a duplicate for a silent loss would be worse.

**Not airtight by construction.** If the completion arrives *after* the retry has fired (12 ms base delay) the
duplicate is already out. This removes the observed case; it does not make duplication impossible.

## Diagnostics (first commit)

- **Which refusal occurred.** `writeCharacteristicCompat` collapsed Android 13+'s `int` into a `Boolean`.
  `ERROR_GATT_WRITE_REQUEST_BUSY` (201) is documented as *not initiated*, so which code the stack returns is
  the difference between "safe retry" and "we just sent it twice". Now logged, with the command name.
- **4.0 `result` and `resp_seq`.** The 5/MG path always exposed both; the 4.0 path exposed neither, so a 4.0
  log could not say whether a command succeeded. The reporter had to hand-decode `result=0x00` from raw hex to
  learn their strap answers `GET_EXTENDED_BATTERY_INFO` with FAILURE rather than an empty success — the
  difference between "battery unreachable here" and "our decode is wrong". Verified against their real frames:
  answered `GET_DATA_RANGE` → `resp_seq=0x0A`, `SUCCESS(1)`; empty extended-battery → `resp_seq=0x22`,
  `FAILURE(0)`. Corroborated by `GET_BATTERY_LEVEL` having always read from `payload[2..4]`, already skipping
  both bytes.

## Testing

The decision is a pure companion predicate because the instance path **cannot** be unit-tested here — the
constructor needs a real `Looper` and `Context` and the project ships no Robolectric. That is the constraint
`GattCrashSafetyTest` documents and the pattern it follows: pin the pure decision the behaviour is built on.

Tests cover: a completion cancelling a held retry on both families' command channels; a completion with
nothing held being a no-op; a completion on another characteristic (or a null UUID) never cancelling, since
doing so would convert a duplicate into the silent loss #77/#312 is about; and the refusal-code labels.
The 4.0 decode tests use the reporter's real frames as vectors.

Statically verified: UUID literals in the test match the production constants byte for byte, the predicate and
`writeStatusLabel` are public companion members, no stale call site remains from the signature change, braces
balanced, `Tools/i18n_audit.py --ci origin/main` → exit 0.

### Corrected during re-review

Two claims in the section above were wrong, and a third commit fixes them.

**The safety argument was overstated.** It said no other outstanding command-channel write could own a
completion, because the drain never starts a write while one is in flight. `writeBondFrame` is exactly such a
write — same characteristic, **deliberately outside the queue**, sets `writeInFlight` itself, never consumes
`pendingRetry`. Its ack proves nothing about a held frame, and acting on it would cancel a retry for a frame
that never left: the duplicate becomes the silent loss #77/#312 exists to prevent, which is worse. Now tracked
and excluded, with the flag consumed on the callback so a later completion cannot inherit it, and cleared in
`reset()` so a stale flag cannot suppress a legitimate cancellation next session.

**The fix covers only WITH-response writes.** A without-response write gets no completion callback — the drain
frees its own slot after a pacing gap — so there is no signal to act on. It happens to cover the reported
command and every case where a duplicate actually harms (`GET_DATA_RANGE`, `SET_CLOCK`, the historical acks,
haptics, `RUN_ALARM` are all `withResponse = true`), which I verified rather than assumed — but that is
fortunate, not by design, and the original text implied generality.

So precisely: **a with-response command frame is no longer repeated when a completion proves the BUSY-refused
write was delivered, except where that completion belongs to the bond write.** Without-response frames, and
completions arriving after the retry has fired, are unchanged.

## What this needs before merge

**Not run: the JUnit suite** — no JDK on this machine and `android.yml` is disabled, so nothing compiled it.

**More importantly, the fix wants a device test.** It changes when a GATT write is repeated, and the failure
mode if the reasoning is wrong is a *silently dropped* command — worse than the duplicate it removes. Worth
confirming on hardware that live HR, the clock handshake and the backfill all still work across a reconnect,
ideally on a stack that produces busy-retries. @bhargav8963 offered to run probe builds and has the device that
reproduces it.
