### PR TITLE
iOS: disable the tab-swipe with a GestureMask instead of a conditional attach (#519 follow-up)

### DIFF
--- a/StrandiOS/App/RootTabView.swift
+++ b/StrandiOS/App/RootTabView.swift
@@ -118,7 +118,13 @@ struct RootTabView: View {
             // rebuilt the whole TabView subtree and could reset @State inside the tab roots (scroll
             // offsets, chart ranges, expanded sections). `including:` keeps one view type in both
             // states, so nothing is torn down.
-            .simultaneousGesture(tabSwipeGesture, including: tabPaths[selectedTab].isEmpty ? .all : .none)
+            //
+            // The mask MUST be `.subviews`, not `.none`. `.subviews` means "enable the subview
+            // hierarchy's gestures, disable the added one" — exactly this requirement. `.none` disables
+            // the subview hierarchy TOO, which on a pushed screen would take out scrolling, taps and the
+            // interactive-pop itself: far worse than the bug being fixed.
+            .simultaneousGesture(tabSwipeGesture,
+                                 including: tabPaths[selectedTab].isEmpty ? .all : .subviews)
 
             FloatingTabBar(selection: $selectedTab, onReselect: { tag in
                 // Re-tapping the active tab refreshes that page's data (2026-07-02) and, from a

--- a/StrandiOS/App/RootTabView.swift
+++ b/StrandiOS/App/RootTabView.swift
@@ -63,6 +63,28 @@ struct RootTabView: View {
         UITabBar.appearance().scrollEdgeAppearance = appearance
     }
 
+    /// The anywhere-swipe tab-switch drag (2026-07-02). Held as a property so the attachment site can
+    /// enable or disable it through a `GestureMask` instead of attaching it conditionally: a conditional
+    /// attachment changes view identity, and this condition toggles on every push and pop, which would
+    /// rebuild the tab roots underneath it. The same class of rebuild is what #197 caused with an
+    /// `.id()` reset and #198 had to undo — it lost scroll position and re-ran `.task`.
+    ///
+    /// Only a decisive horizontal flick switches tabs, and Today is carved out because it uses
+    /// horizontal swipe to change DAYS. Both thresholds are unchanged from the original gesture.
+    private var tabSwipeGesture: some Gesture {
+        DragGesture(minimumDistance: 24)
+            .onEnded { v in
+                // Today (tab 0) uses horizontal swipe to change DAYS, so tab-swipe is off there.
+                guard selectedTab != 0 else { return }
+                let dx = v.translation.width, dy = v.translation.height
+                guard abs(dx) > 60, abs(dx) > abs(dy) * 1.6 else { return }
+                let next = min(3, max(0, selectedTab + (dx < 0 ? 1 : -1)))
+                if next != selectedTab {
+                    withAnimation(.timingCurve(0.22, 1, 0.36, 1, duration: 0.24)) { selectedTab = next }
+                }
+            }
+    }
+
     var body: some View {
         // The native TabView keeps every existing destination + system gesture; the signature
         // raised gold FAB is overlaid on top, bottom-centre, floating ~20pt above the bar (a
@@ -86,9 +108,17 @@ struct RootTabView: View {
             // tab is at its root. Attaching this ancestor drag gesture unconditionally defeated the
             // edge-restriction of a pushed NavigationStack screen's native interactive-pop gesture —
             // any More-tab subscreen (Settings, Devices, …) became draggable/rubber-banding from
-            // anywhere, not just the left edge. Removing the recognizer entirely once a push is active
-            // (rather than just gating the onEnded action) is what actually stops the interference.
-            .modifier(TabSwipeGestureModifier(isEnabled: tabPaths[selectedTab].isEmpty, selectedTab: $selectedTab))
+            // anywhere, not just the left edge (#519). Disabling the recognizer once a push is active,
+            // rather than just gating the onEnded action, is what stops the interference: the action
+            // never runs early enough, because the recognizer competes during recognition.
+            //
+            // The mask does that WITHOUT changing view identity. #519 attached the gesture through a
+            // conditional ViewModifier, which put the two states in separate _ConditionalContent
+            // branches — and since this condition toggles on every push and pop, each navigation
+            // rebuilt the whole TabView subtree and could reset @State inside the tab roots (scroll
+            // offsets, chart ranges, expanded sections). `including:` keeps one view type in both
+            // states, so nothing is torn down.
+            .simultaneousGesture(tabSwipeGesture, including: tabPaths[selectedTab].isEmpty ? .all : .none)
 
             FloatingTabBar(selection: $selectedTab, onReselect: { tag in
                 // Re-tapping the active tab refreshes that page's data (2026-07-02) and, from a
@@ -484,35 +514,6 @@ private enum MoreDestination: Hashable {
     }
 }
 
-/// Attaches the anywhere-swipe tab-switch gesture only when `isEnabled` (i.e. the current tab has no
-/// pushed subscreen) — conditionally, not just gating the action, so the `UIPanGestureRecognizer`
-/// itself is absent from the hierarchy while a `NavigationStack` push is active. A `Bool` captured
-/// inside `onEnded` alone wouldn't do this: the recognizer would still be attached and able to compete
-/// with (and defeat) the pushed screen's native interactive-pop gesture before `onEnded` ever fires.
-private struct TabSwipeGestureModifier: ViewModifier {
-    let isEnabled: Bool
-    @Binding var selectedTab: Int
-
-    func body(content: Content) -> some View {
-        if isEnabled {
-            content.simultaneousGesture(
-                DragGesture(minimumDistance: 24)
-                    .onEnded { v in
-                        // Today (tab 0) uses horizontal swipe to change DAYS, so tab-swipe is off there.
-                        guard selectedTab != 0 else { return }
-                        let dx = v.translation.width, dy = v.translation.height
-                        guard abs(dx) > 60, abs(dx) > abs(dy) * 1.6 else { return }
-                        let next = min(3, max(0, selectedTab + (dx < 0 ? 1 : -1)))
-                        if next != selectedTab {
-                            withAnimation(.timingCurve(0.22, 1, 0.36, 1, duration: 0.24)) { selectedTab = next }
-                        }
-                    }
-            )
-        } else {
-            content
-        }
-    }
-}
 
 /// One tappable destination row in the More index. A `NavigationLink` whose label is the standard app row:
 /// the SF Symbol icon tinted `StrandPalette.accent`, the title in the body text colour, a `Spacer`, and a


### PR DESCRIPTION
Follow-up to #519, addressing the one concern from its review. Refs #519.

#519's core insight is right and unchanged here: the fix has to gate the gesture's **attachment**, not its
action, because the recognizer competes during recognition and an `onEnded` guard never runs early enough to
stop it defeating a pushed screen's edge-restricted interactive-pop.

## The side effect

Attaching through a conditional `ViewModifier` puts the enabled and disabled states in separate
`_ConditionalContent` branches, which have distinct structural identity. The condition is
`tabPaths[selectedTab].isEmpty` — it **toggles on every push and every pop** — and the content it wraps is the
entire `TabView` with all four tab roots. So each navigation rebuilt that subtree and could reset `@State`
inside the roots: scroll offsets, chart ranges, expanded sections.

**This repo has already paid for that exact rebuild once.** The comment on `tabPaths` records it:

> Re-tapping the already-active tab pops that tab's stack to its root (#135) by clearing its path — an animated
> pop that leaves the root view alive, so an at-root re-tap keeps scroll position and never re-runs `.task`
> (#198; the #197 resetID/`.id()` rebuild reset both).

#197 rebuilt a tab root and lost both scroll position and the `.task`; #198 had to undo it. Reintroducing the
same teardown on every Settings visit walks back into it.

## The change

`simultaneousGesture` takes a `GestureMask`, so the gesture can be turned off without changing view identity:

```swift
.simultaneousGesture(tabSwipeGesture,
                     including: tabPaths[selectedTab].isEmpty ? .all : .subviews)
```

One view type in both states, nothing torn down. The mask also disables the recognizer rather than merely
suppressing its action — the property #519 needed.

**Corrected during self-review, and worth flagging because the naming invites the mistake:** the first push of
this branch used `.none`, which is wrong. `.none` disables *all* gestures in the subview hierarchy, including
the added one — on a pushed screen it would have taken out scrolling, taps and the interactive-pop itself,
dramatically worse than the rubber-banding #519 fixes. `.subviews` is the mask that expresses the requirement:

| mask | added gesture | subview gestures |
| --- | --- | --- |
| `.all` | on | on |
| `.gesture` | on | off |
| `.subviews` | **off** | **on** ← what this needs |
| `.none` | off | off |

A trailing comma in the argument list was also dropped; it only compiles on very recent Swift and there are
zero other instances in this repo.

The gesture moves to a `tabSwipeGesture` property. Its logic, both thresholds (`minimumDistance: 24`,
`abs(dx) > 60`, `abs(dx) > abs(dy) * 1.6`) and the Today day-swipe carve-out are copied verbatim; the
`TabSwipeGestureModifier` struct is removed. Net −32/+33 on one file, no behaviour intended beyond removing
the rebuild.

## Not a criticism of the pattern

The conditional-body shape is fine and already used here — `ScreenScaffold.swift:159` is the same
`if let … { content.refreshable … } else { content }`. The difference is that its condition (`onRefresh != nil`)
is a static property of how the screen was constructed and never toggles, so it never rebuilds anything.

## Verification — please read before merging

**NOT BUILT AND NOT TESTED.** No Xcode in the environment this was written in, so it has neither been compiled
nor run, and `including:` appears nowhere else in this repo. Structural checks only: gesture logic preserved
verbatim, the removed struct leaves no orphaned `func body(content:)`, braces balanced, one definition of
`tabSwipeGesture`, and `Tools/i18n_audit.py --ci origin/main` → exit 0.

@digitalerdude built and simulator-launched #519 but explicitly did not run the interactive check, so the
gesture behaviour is unverified on a device for either version. The deciding test between them:

1. **Does Trends keep its scroll position across a More → Settings round-trip?** #519's version is the one at
   risk of losing it; this one should not.
2. #519's own list, which must still hold: mid-screen drag on Settings does not rubber-band; left-edge swipe
   still pops to More; a decisive flick at a tab root still switches tabs; Today stays day-swipe only.

If `.subviews` turns out not to keep the recognizer out of the competition on-device, #519's version is the
safer one and this should be closed — that failure mode is exactly what a device run distinguishes.

## Re-review: this is a trade, not a strict improvement

Worth being straight about the shape of the choice, because my earlier framing undersold #519.

| | certain | uncertain |
| --- | --- | --- |
| **#519** (merged) | removes the recognizer, so the interference *definitely* stops | rebuilds the TabView subtree every push/pop — the #197/#198 symptom |
| **#798** (this) | identity is stable, so the rebuild *definitely* cannot happen | relies on `.subviews` disabling the recognizer, not merely its action |

Each has one certain benefit and one uncertain cost. So this is not "the correct version" — it is the version that
trades a known rebuild for an unverified assumption about SwiftUI's mask.

The argument for the assumption: a `UIGestureRecognizer` with `isEnabled = false` genuinely does not participate
in recognition or delay touches — that part is UIKit-documented rather than speculative. The open question is
only whether SwiftUI's `GestureMask` maps onto that, and I cannot test it here. Given I got `GestureMask`'s
semantics wrong once already on this branch, that assumption deserves scepticism rather than trust.

I considered a third form that would get both certainties — a conditional gesture inside `.overlay` so only a
stateless subtree rebuilds — and rejected it: a hit-testable clear overlay above the `TabView` changes touch
routing for everything underneath, which is a bigger behavioural surface than either option here.

### Checked this pass, nothing found

Recorded so a reviewer need not repeat them: no surviving reference to the removed `TabSwipeGestureModifier`
anywhere in the repo; `tabSwipeGesture` defined once and used once, no collision; the `simultaneousGesture(_:including:)`
overload exists with `including:` defaulting to `.all`; `some Gesture` satisfies the generic constraint; the
`@State` write from the captured closure is the standard pattern and was equivalent before via `@Binding`; and
the file's 134-character longest line predates this branch — none of the added lines exceed 120.

### Recommendation

Do not merge on my analysis. One device run decides it, and the check is cheap:

- **Trends keeps its scroll position across a More → Settings round-trip** — the property this PR buys.
- Settings does not rubber-band mid-screen; left-edge swipe still pops; a decisive flick at a tab root still
  switches tabs; Today stays day-swipe only — the properties #519 already buys and this must not lose.

If the first passes and the rest hold, merge this. If any of the rest regress, #519's version is correct and this
should be closed.
