### PR TITLE
ci: move actions off the deprecated Node 20 runtime

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -31,19 +31,19 @@ jobs:
         working-directory: android
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: '17'
 
       - name: Validate Gradle wrapper
-        uses: gradle/actions/wrapper-validation@v4
+        uses: gradle/actions/wrapper-validation@v5
 
       - name: Set up Gradle
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@v5
 
       - name: Build debug APK
         run: ./gradlew assembleFullDebug

--- a/.github/workflows/app-build.yml
+++ b/.github/workflows/app-build.yml
@@ -58,7 +58,7 @@ jobs:
             runner: macos-26
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install XcodeGen
         run: brew install xcodegen

--- a/.github/workflows/fork-release.yml
+++ b/.github/workflows/fork-release.yml
@@ -42,7 +42,7 @@ jobs:
       sha: ${{ steps.b.outputs.sha }}
       buildVersion: ${{ steps.b.outputs.buildVersion }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - id: b
         env:
           GH_TOKEN: ${{ github.token }}
@@ -155,15 +155,15 @@ jobs:
       run:
         working-directory: android
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: ${{ needs.bump.outputs.sha }}   # build the bumped commit
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: '17'
-      - uses: gradle/actions/wrapper-validation@v4
-      - uses: gradle/actions/setup-gradle@v4
+      - uses: gradle/actions/wrapper-validation@v5
+      - uses: gradle/actions/setup-gradle@v5
       # Release-only (no debug APK). Signed with the committed fork-debug.keystore via the debug
       # signingConfig storeFile (release falls back to it when no keystore.properties is present);
       # -PstagingRelease gives it the .staging app id so it installs beside the official app.
@@ -183,7 +183,7 @@ jobs:
     runs-on: macos-15
     timeout-minutes: 40
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: ${{ needs.bump.outputs.sha }}
       - name: Install XcodeGen
@@ -233,7 +233,7 @@ jobs:
     runs-on: macos-26
     timeout-minutes: 40
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: ${{ needs.bump.outputs.sha }}
       - name: Install XcodeGen
@@ -275,7 +275,7 @@ jobs:
     needs: [bump, ios]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: main   # AltStore reads the manifest from main, so commit there regardless of the release branch.
       - name: Add this release to the AltStore source

--- a/.github/workflows/fork-testing-build.yml
+++ b/.github/workflows/fork-testing-build.yml
@@ -24,7 +24,7 @@ jobs:
       tag: ${{ steps.m.outputs.tag }}
       ver: ${{ steps.m.outputs.ver }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - id: m
         env:
           GH_TOKEN: ${{ github.token }}
@@ -56,13 +56,13 @@ jobs:
       run:
         working-directory: android
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-java@v4
+      - uses: actions/checkout@v5
+      - uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: '17'
-      - uses: gradle/actions/wrapper-validation@v4
-      - uses: gradle/actions/setup-gradle@v4
+      - uses: gradle/actions/wrapper-validation@v5
+      - uses: gradle/actions/setup-gradle@v5
       # NOTE: both APKs are signed with the committed android/fork-debug.keystore via an explicit
       # storeFile in the debug signingConfig (build.gradle.kts, injected by rebuild-staging.sh) — the
       # release build falls back to the debug key when no keystore.properties is present. We do NOT
@@ -87,7 +87,7 @@ jobs:
     runs-on: macos-15
     timeout-minutes: 40
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Install XcodeGen
         run: brew install xcodegen
       - name: Generate Xcode project
@@ -132,7 +132,7 @@ jobs:
     runs-on: macos-26
     timeout-minutes: 40
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Install XcodeGen
         run: brew install xcodegen
       - name: Generate Xcode project

--- a/.github/workflows/i18n-coverage.yml
+++ b/.github/workflows/i18n-coverage.yml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 

--- a/.github/workflows/swift-packages.yml
+++ b/.github/workflows/swift-packages.yml
@@ -41,7 +41,7 @@ jobs:
           - NoopLocalAccess
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Build ${{ matrix.package }}
         run: swift build


### PR DESCRIPTION
GitHub is forcing Node 20 actions onto Node 24 ahead of removing the runtime. All four actions here were on node20 — the warning only named `checkout`:

| action | was | now |
|---|---|---|
| `actions/checkout` | v4 (node20) | v5 (node24) |
| `actions/setup-java` | v4 (node20) | v5 (node24) |
| `gradle/actions/wrapper-validation` | v4 (node20) | v5 (node24) |
| `gradle/actions/setup-gradle` | v4 (node20) | v5 (node24) |

22 references across six workflows.

Bumped to the **lowest** node24 major, not the newest: `checkout` is at v7 and `gradle/actions` at v6, so going to latest would carry two or three majors of behaviour change for what is a runtime fix. Inputs in use are unaffected either way — `setup-java` takes only `distribution` + `java-version`, and neither gradle action is passed inputs.

Runtime per major was read from each tag's `action.yml` rather than assumed. YAML re-validated on all six files. This PR's own checks exercise the new versions in `i18n-coverage.yml` and `swift-packages.yml`; the Android and app-build workflows are disabled so their bumps are untested here.