### PR TITLE
ci(android): give the Kotlin compile daemon its own heap

### DIFF
--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -3,6 +3,16 @@
 # JVM args for the Gradle daemon. 2g heap + file encoding is enough for this single-module app.
 org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
 
+# Heap for the KOTLIN COMPILE DAEMON, which is a separate process from the Gradle daemon above and
+# does NOT inherit org.gradle.jvmargs. Unset, it takes a default that the Compose compiler plugin
+# outgrew: compileFullReleaseKotlin died with `java.lang.OutOfMemoryError: Java heap space` inside
+# androidx.compose.compiler.plugins.kotlin.lower.ComposerTypeRemapper while the debug variant built
+# fine, because the release variant's extra lowering passes push the IR deep-copy over the limit.
+# Gradle's own failure hint names this exact property. Raised here rather than lifting
+# org.gradle.jvmargs so peak memory stays reasonable on a contributor's laptop — Gradle itself was
+# never the process that ran out.
+kotlin.daemon.jvmargs=-Xmx4096m
+
 # Run independent tasks in parallel where the module graph allows.
 org.gradle.parallel=true
 


### PR DESCRIPTION
The 9.1.1 staging build's Android job failed with `java.lang.OutOfMemoryError: Java heap space` in `androidx.compose.compiler.plugins.kotlin.lower.ComposerTypeRemapper`.

**Not a code error.** `compileFullDebugKotlin` passed in the same run; only `compileFullReleaseKotlin` died, and the iOS and macOS jobs succeeded. The release variant's extra lowering passes deepen the Compose IR deep-copy enough to exhaust the heap.

`kotlin.daemon.jvmargs` was never set. The Kotlin compile daemon is a separate process from the Gradle daemon and does **not** inherit `org.gradle.jvmargs`, so it was running on a default heap the Compose compiler plugin has outgrown. Gradle's own failure hint names this property.

Raised the Kotlin daemon to 4g rather than lifting `org.gradle.jvmargs` — Gradle itself never ran out, and raising both would put peak memory somewhere unfriendly on an 8 GB laptop.

Yesterday's staging build passed every job, so this is headroom lost to the Compose UI merged today (#778, #788, #523) rather than a long-standing issue.

Verification is the next staging run — that job is the only thing in CI that builds the release variant, since `android.yml` is disabled.