### PR TITLE
feat(oura): decode 0x47 motion_events as an averaged accel vector (WHOOP-4.0-gravity-shaped)

### DIFF
--- a/Packages/OuraProtocol/Sources/OuraProtocol/Decoders.swift
+++ b/Packages/OuraProtocol/Sources/OuraProtocol/Decoders.swift
@@ -457,6 +457,31 @@ public enum OuraDecoders {
         return out.isEmpty ? nil : out
     }
 
+    // MARK: - Motion events, averaged accel vector (0x47; s6.13)
+
+    /// Decode a 0x47 `motion_events` record: the ring's averaged accelerometer vector for the period.
+    /// Layout (open_oura `decode_motion`, clean-room fact citation; OURA_PROTOCOL.md s6.13):
+    ///   byte0 low 2 bits = orientation (0…3)
+    ///   byte1 = avg X, signed int8 × 8
+    ///   byte2 = avg Y, signed int8 × 8
+    ///   byte3 = avg Z, signed int8 × 8
+    ///   byte5 = high_intensity count
+    /// byte4 is not yet identified (present in the record, not surfaced). Returns nil on a short body
+    /// rather than guessing a partial layout. This is the SAME averaged-vector shape as a WHOOP 4.0
+    /// gravity sample, so a consumer can map `(avgX, avgY, avgZ)` into the shared motion pipeline (the
+    /// LSB→g scaling for the sleep stager is a downstream calibration, kept out of this pure decode).
+    public static func decodeMotionEvents(_ rec: OuraRecord) -> OuraMotionEvent? {
+        let b = rec.payload
+        guard b.count >= 6 else { return nil }
+        return OuraMotionEvent(
+            ringTimestamp: rec.ringTimestamp,
+            orientation: Int(b[0] & 0x03),
+            avgX: Int(Int8(bitPattern: b[1])) * 8,
+            avgY: Int(Int8(bitPattern: b[2])) * 8,
+            avgZ: Int(Int8(bitPattern: b[3])) * 8,
+            highIntensity: Int(b[5]))
+    }
+
     // MARK: - Activity info (0x50; s6.13) - Tier B, third-party formula
 
     /// Decode the 0x50 activity_info record: byte0 = a `state` code (activity-category; meaning

--- a/Packages/OuraProtocol/Sources/OuraProtocol/Decoders.swift
+++ b/Packages/OuraProtocol/Sources/OuraProtocol/Decoders.swift
@@ -459,27 +459,40 @@ public enum OuraDecoders {
 
     // MARK: - Motion events, averaged accel vector (0x47; s6.13)
 
-    /// Decode a 0x47 `motion_events` record: the ring's averaged accelerometer vector for the period.
-    /// Layout (open_oura `decode_motion`, clean-room fact citation; OURA_PROTOCOL.md s6.13):
-    ///   byte0 low 2 bits = orientation (0…3)
-    ///   byte1 = avg X, signed int8 × 8
-    ///   byte2 = avg Y, signed int8 × 8
-    ///   byte3 = avg Z, signed int8 × 8
-    ///   byte5 = high_intensity count
-    /// byte4 is not yet identified (present in the record, not surfaced). Returns nil on a short body
-    /// rather than guessing a partial layout. This is the SAME averaged-vector shape as a WHOOP 4.0
-    /// gravity sample, so a consumer can map `(avgX, avgY, avgZ)` into the shared motion pipeline (the
-    /// LSB→g scaling for the sleep stager is a downstream calibration, kept out of this pure decode).
+    /// Decode a 0x47 `motion_events` record: a compact per-window motion summary. Layout is a
+    /// byte-for-byte port of open_oura's `decode_motion` / native `parse_api_motion_events`
+    /// (clean-room fact citation; OURA_PROTOCOL.md s6.13):
+    ///   byte0 >> 5      = orientation (0…7)
+    ///   byte0 & 0x1f    = motion_seconds (0…31)
+    ///   byte1/2/3       = avg X/Y/Z, signed int8 × 8
+    ///   byte4 (opt)     = low_intensity: bit 0x40 set ⇒ INVALID (whole record → nil); else `& 0x3f`
+    ///   byte5 (opt)     = high_intensity: bit 0x40 set ⇒ INVALID (whole record → nil); else `& 0x3f`
+    /// Needs ≥ 4 bytes (orientation/motion_seconds + the 3 axes); low/high intensity are optional. The
+    /// avg vector is the SAME averaged-accel shape as a WHOOP 4.0 gravity sample. NOTE (validated
+    /// on-device #804): 0x47 is MOVEMENT-GATED — the ring emits it only while moving, so there is no
+    /// still/1 g sample; `motion_seconds` / intensity are the activity signal, not a gravity magnitude.
     public static func decodeMotionEvents(_ rec: OuraRecord) -> OuraMotionEvent? {
         let b = rec.payload
-        guard b.count >= 6 else { return nil }
+        guard b.count >= 4 else { return nil }
+        var low: Int? = nil
+        if b.count >= 5 {
+            guard b[4] & 0x40 == 0 else { return nil }
+            low = Int(b[4] & 0x3f)
+        }
+        var high: Int? = nil
+        if b.count >= 6 {
+            guard b[5] & 0x40 == 0 else { return nil }
+            high = Int(b[5] & 0x3f)
+        }
         return OuraMotionEvent(
             ringTimestamp: rec.ringTimestamp,
-            orientation: Int(b[0] & 0x03),
+            orientation: Int(b[0] >> 5),
+            motionSeconds: Int(b[0] & 0x1f),
             avgX: Int(Int8(bitPattern: b[1])) * 8,
             avgY: Int(Int8(bitPattern: b[2])) * 8,
             avgZ: Int(Int8(bitPattern: b[3])) * 8,
-            highIntensity: Int(b[5]))
+            lowIntensity: low,
+            highIntensity: high)
     }
 
     // MARK: - Activity info (0x50; s6.13) - Tier B, third-party formula

--- a/Packages/OuraProtocol/Sources/OuraProtocol/OuraDriver.swift
+++ b/Packages/OuraProtocol/Sources/OuraProtocol/OuraDriver.swift
@@ -333,9 +333,10 @@ public final class OuraDriver {
         case .motionPeriod:
             return (OuraDecoders.decodeMotionPeriod(record) ?? []).map { OuraEvent.motion($0) }
         case .motion:
-            // 0x47 motion_events: surfaced as state-free motion is out of v1 scope; decode to nothing
-            // rather than guess the partial layout. Per OURA_PROTOCOL.md s6.13.
-            return []
+            // 0x47 motion_events: the ring's averaged accel vector (orientation + avg x/y/z ×8 +
+            // high_intensity), the same shape as a WHOOP 4.0 gravity sample. open_oura `decode_motion`,
+            // OURA_PROTOCOL.md s6.13. Tier-A.
+            return OuraDecoders.decodeMotionEvents(record).map { [OuraEvent.motionEvent($0)] } ?? []
 
         // --- Tier A: Sleep phase (2-bit codes are verified) ---
         // 0x4B/0x4E/0x5A are the three hypnogram aliases (open_oura decode_sleep_phases); 0x4B was

--- a/Packages/OuraProtocol/Sources/OuraProtocol/OuraEvents.swift
+++ b/Packages/OuraProtocol/Sources/OuraProtocol/OuraEvents.swift
@@ -115,6 +115,29 @@ public struct OuraMotion: Equatable, Sendable, Codable {
     }
 }
 
+/// One decoded 0x47 `motion_events` record: the ring's OWN averaged accelerometer vector for the period,
+/// plus an orientation code and a high-intensity count (open_oura `decode_motion`, clean-room fact
+/// citation; OURA_PROTOCOL.md s6.13). This is the SAME shape as a WHOOP 4.0 gravity sample — an averaged
+/// `(x, y, z)` vector, NOT a per-sample raw accel — so it can feed the same motion pipeline. Axis values
+/// are the signed record bytes scaled ×8 (open_oura's convention); the LSB→g scale for NOOP's stager is
+/// a downstream calibration, so this struct carries the ring's raw ×8 integers, unscaled and honest.
+public struct OuraMotionEvent: Equatable, Sendable, Codable {
+    public let ringTimestamp: UInt32
+    /// Orientation code 0…3 (record byte0, low 2 bits).
+    public let orientation: Int
+    /// Averaged X/Y/Z, signed record byte × 8 (open_oura `decode_motion`).
+    public let avgX: Int
+    public let avgY: Int
+    public let avgZ: Int
+    /// High-intensity count for the period (record byte5).
+    public let highIntensity: Int
+    public init(ringTimestamp: UInt32, orientation: Int, avgX: Int, avgY: Int, avgZ: Int,
+                highIntensity: Int) {
+        self.ringTimestamp = ringTimestamp; self.orientation = orientation
+        self.avgX = avgX; self.avgY = avgY; self.avgZ = avgZ; self.highIntensity = highIntensity
+    }
+}
+
 /// Device lifecycle state (OURA_PROTOCOL.md s6.15) decoded from a 0x45/0x53 record.
 public struct OuraState: Equatable, Sendable, Codable {
     public let ringTimestamp: UInt32
@@ -206,6 +229,9 @@ public enum OuraEvent: Equatable, Sendable {
     case battery(OuraBattery)
     case sleepPhase(OuraSleepPhase)
     case motion(OuraMotion)
+    /// A decoded `0x47` motion_events record: the ring's averaged accel vector (Tier-A). Distinct from
+    /// `.motion` (the 0x6B period's 2-bit state codes).
+    case motionEvent(OuraMotionEvent)
     case state(OuraState)
     case timeSync(OuraTimeSync)
     case rtcBeacon(OuraRtcBeacon)
@@ -240,6 +266,7 @@ public enum OuraEvent: Equatable, Sendable {
         case .battery: return nil
         case .sleepPhase(let v): return v.ringTimestamp
         case .motion(let v): return v.ringTimestamp
+        case .motionEvent(let v): return v.ringTimestamp
         case .state(let v): return v.ringTimestamp
         case .timeSync(let v): return v.ringTimestamp
         case .rtcBeacon(let v): return v.ringTimestamp

--- a/Packages/OuraProtocol/Sources/OuraProtocol/OuraEvents.swift
+++ b/Packages/OuraProtocol/Sources/OuraProtocol/OuraEvents.swift
@@ -123,18 +123,25 @@ public struct OuraMotion: Equatable, Sendable, Codable {
 /// a downstream calibration, so this struct carries the ring's raw ×8 integers, unscaled and honest.
 public struct OuraMotionEvent: Equatable, Sendable, Codable {
     public let ringTimestamp: UInt32
-    /// Orientation code 0…3 (record byte0, low 2 bits).
+    /// Orientation code 0…7 (record byte0, TOP 3 bits: `b0 >> 5`).
     public let orientation: Int
+    /// Seconds of motion in the window (record byte0, low 5 bits: `b0 & 0x1f`, 0…31). A direct
+    /// motion-intensity measure — arguably the cleanest activity signal for sleep staging.
+    public let motionSeconds: Int
     /// Averaged X/Y/Z, signed record byte × 8 (open_oura `decode_motion`).
     public let avgX: Int
     public let avgY: Int
     public let avgZ: Int
-    /// High-intensity count for the period (record byte5).
-    public let highIntensity: Int
-    public init(ringTimestamp: UInt32, orientation: Int, avgX: Int, avgY: Int, avgZ: Int,
-                highIntensity: Int) {
+    /// Low/high-intensity counts (record byte4/byte5, `& 0x3f`, 0…63). nil when the record is short
+    /// (< 5 / < 6 bytes) — both are optional in the wire format.
+    public let lowIntensity: Int?
+    public let highIntensity: Int?
+    public init(ringTimestamp: UInt32, orientation: Int, motionSeconds: Int, avgX: Int, avgY: Int,
+                avgZ: Int, lowIntensity: Int?, highIntensity: Int?) {
         self.ringTimestamp = ringTimestamp; self.orientation = orientation
-        self.avgX = avgX; self.avgY = avgY; self.avgZ = avgZ; self.highIntensity = highIntensity
+        self.motionSeconds = motionSeconds
+        self.avgX = avgX; self.avgY = avgY; self.avgZ = avgZ
+        self.lowIntensity = lowIntensity; self.highIntensity = highIntensity
     }
 }
 

--- a/Packages/OuraProtocol/Sources/oura-decode/main.swift
+++ b/Packages/OuraProtocol/Sources/oura-decode/main.swift
@@ -146,7 +146,7 @@ func describe(_ e: OuraEvent) -> String {
     case .battery(let v): return "BATTERY \(v.percent)% mv=\(v.voltageMv.map(String.init) ?? "-")"
     case .sleepPhase(let v): return "SLEEP_PHASE [\(v.index)]=\(v.stage) rt=\(v.ringTimestamp)"
     case .motion(let v): return "MOTION [\(v.index)]=\(v.state) rt=\(v.ringTimestamp)"
-    case .motionEvent(let v): return "MOTION_EVENT orient=\(v.orientation) xyz=(\(v.avgX),\(v.avgY),\(v.avgZ)) hi=\(v.highIntensity) rt=\(v.ringTimestamp)"
+    case .motionEvent(let v): return "MOTION_EVENT orient=\(v.orientation) motionS=\(v.motionSeconds) xyz=(\(v.avgX),\(v.avgY),\(v.avgZ)) lo=\(v.lowIntensity.map(String.init) ?? "-") hi=\(v.highIntensity.map(String.init) ?? "-") rt=\(v.ringTimestamp)"
     case .state(let v): return "STATE code=\(v.stateCode) text=\(v.text ?? "-") rt=\(v.ringTimestamp)"
     case .timeSync(let v): return "TIME_SYNC epochMs=\(v.epochMs) tz=\(v.tzOffsetSeconds)s"
     case .rtcBeacon(let v): return "RTC_BEACON unix=\(v.unixSeconds)"

--- a/Packages/OuraProtocol/Sources/oura-decode/main.swift
+++ b/Packages/OuraProtocol/Sources/oura-decode/main.swift
@@ -146,6 +146,7 @@ func describe(_ e: OuraEvent) -> String {
     case .battery(let v): return "BATTERY \(v.percent)% mv=\(v.voltageMv.map(String.init) ?? "-")"
     case .sleepPhase(let v): return "SLEEP_PHASE [\(v.index)]=\(v.stage) rt=\(v.ringTimestamp)"
     case .motion(let v): return "MOTION [\(v.index)]=\(v.state) rt=\(v.ringTimestamp)"
+    case .motionEvent(let v): return "MOTION_EVENT orient=\(v.orientation) xyz=(\(v.avgX),\(v.avgY),\(v.avgZ)) hi=\(v.highIntensity) rt=\(v.ringTimestamp)"
     case .state(let v): return "STATE code=\(v.stateCode) text=\(v.text ?? "-") rt=\(v.ringTimestamp)"
     case .timeSync(let v): return "TIME_SYNC epochMs=\(v.epochMs) tz=\(v.tzOffsetSeconds)s"
     case .rtcBeacon(let v): return "RTC_BEACON unix=\(v.unixSeconds)"

--- a/Packages/OuraProtocol/Tests/OuraProtocolTests/DecoderGoldenTests.swift
+++ b/Packages/OuraProtocol/Tests/OuraProtocolTests/DecoderGoldenTests.swift
@@ -151,28 +151,44 @@ final class DecoderGoldenTests: XCTestCase {
     // MARK: - 0x47 motion events (averaged accel vector)
 
     func testMotionEvents0x47() {
-        // open_oura decode_motion vector: body [0x6f,0x0c,0x1d,0x07,0x0c,0x07] →
-        // orientation 3, avg x/y/z = 12/29/7 signed ×8, high_intensity 7.
+        // open_oura decode_motion vector: body [0x6f,0x0c,0x1d,0x07,0x0c,0x07].
+        // byte0 0x6f: orientation = 0x6f>>5 = 3, motion_seconds = 0x6f&0x1f = 15.
+        // avg x/y/z = 12/29/7 signed ×8 = 96/232/56. low=0x0c&0x3f=12, high=0x07&0x3f=7.
         let rec = OuraRecord(type: OuraEventTag.motion.rawValue, ringTimestamp: rt,
                              payload: [0x6f, 0x0c, 0x1d, 0x07, 0x0c, 0x07])
         XCTAssertEqual(OuraDecoders.decodeMotionEvents(rec),
-                       OuraMotionEvent(ringTimestamp: rt, orientation: 3,
-                                       avgX: 96, avgY: 232, avgZ: 56, highIntensity: 7))
+                       OuraMotionEvent(ringTimestamp: rt, orientation: 3, motionSeconds: 15,
+                                       avgX: 96, avgY: 232, avgZ: 56, lowIntensity: 12, highIntensity: 7))
     }
 
-    func testMotionEvents0x47SignedAxes() {
-        // A negative axis byte (0xF4 = -12 as int8) decodes to -96, proving the ×8 sign extension.
+    func testMotionEvents0x47DiscriminatesOrientationFromMotionSeconds() {
+        // byte0 0xB5 = 1011_0101: orientation = 0xB5>>5 = 5 (NOT 0xB5&0x03 = 1), motion_seconds = 0x15 = 21.
+        // This vector fails the old `& 0x03` orientation bug (would give 1). Negative axes prove ×8 sign.
+        // byte4 0x2A → low 42; byte5 0x3F → high 63 (max, still valid).
         let rec = OuraRecord(type: OuraEventTag.motion.rawValue, ringTimestamp: rt,
-                             payload: [0x00, 0xF4, 0x00, 0x80, 0x00, 0x00])
-        let m = OuraDecoders.decodeMotionEvents(rec)
-        XCTAssertEqual(m?.avgX, -96)          // 0xF4 = -12 → ×8
-        XCTAssertEqual(m?.avgZ, -1024)        // 0x80 = -128 → ×8
-        XCTAssertEqual(m?.orientation, 0)
+                             payload: [0xB5, 0xF4, 0x00, 0x80, 0x2A, 0x3F])
+        XCTAssertEqual(OuraDecoders.decodeMotionEvents(rec),
+                       OuraMotionEvent(ringTimestamp: rt, orientation: 5, motionSeconds: 21,
+                                       avgX: -96, avgY: 0, avgZ: -1024, lowIntensity: 42, highIntensity: 63))
     }
 
-    func testMotionEvents0x47ShortBodyIsNil() {
+    func testMotionEvents0x47IntensityValidityBitRejectsRecord() {
+        // A set 0x40 bit in the intensity byte means INVALID per open_oura → the whole record decodes nil.
+        XCTAssertNil(OuraDecoders.decodeMotionEvents(   // byte5 0x47 has 0x40 set
+            OuraRecord(type: OuraEventTag.motion.rawValue, ringTimestamp: rt, payload: [0x00, 0, 0, 0, 0x00, 0x47])))
+        XCTAssertNil(OuraDecoders.decodeMotionEvents(   // byte4 0x40 set
+            OuraRecord(type: OuraEventTag.motion.rawValue, ringTimestamp: rt, payload: [0x00, 0, 0, 0, 0x40, 0x00])))
+    }
+
+    func testMotionEvents0x47OptionalIntensityAndShortBody() {
+        // A 4-byte record is valid (orientation/motion_seconds + 3 axes); intensities are nil.
+        let four = OuraDecoders.decodeMotionEvents(
+            OuraRecord(type: OuraEventTag.motion.rawValue, ringTimestamp: rt, payload: [0x20, 0x0a, 0x00, 0x00]))
+        XCTAssertEqual(four, OuraMotionEvent(ringTimestamp: rt, orientation: 1, motionSeconds: 0,
+                                             avgX: 80, avgY: 0, avgZ: 0, lowIntensity: nil, highIntensity: nil))
+        // A 3-byte body is too short → nil.
         XCTAssertNil(OuraDecoders.decodeMotionEvents(
-            OuraRecord(type: OuraEventTag.motion.rawValue, ringTimestamp: rt, payload: [0x6f, 0x0c])))
+            OuraRecord(type: OuraEventTag.motion.rawValue, ringTimestamp: rt, payload: [0x6f, 0x0c, 0x1d])))
     }
 
     // MARK: - 0x85 RTC beacon (unix_s u32 LE)

--- a/Packages/OuraProtocol/Tests/OuraProtocolTests/DecoderGoldenTests.swift
+++ b/Packages/OuraProtocol/Tests/OuraProtocolTests/DecoderGoldenTests.swift
@@ -148,6 +148,33 @@ final class DecoderGoldenTests: XCTestCase {
         ])
     }
 
+    // MARK: - 0x47 motion events (averaged accel vector)
+
+    func testMotionEvents0x47() {
+        // open_oura decode_motion vector: body [0x6f,0x0c,0x1d,0x07,0x0c,0x07] →
+        // orientation 3, avg x/y/z = 12/29/7 signed ×8, high_intensity 7.
+        let rec = OuraRecord(type: OuraEventTag.motion.rawValue, ringTimestamp: rt,
+                             payload: [0x6f, 0x0c, 0x1d, 0x07, 0x0c, 0x07])
+        XCTAssertEqual(OuraDecoders.decodeMotionEvents(rec),
+                       OuraMotionEvent(ringTimestamp: rt, orientation: 3,
+                                       avgX: 96, avgY: 232, avgZ: 56, highIntensity: 7))
+    }
+
+    func testMotionEvents0x47SignedAxes() {
+        // A negative axis byte (0xF4 = -12 as int8) decodes to -96, proving the ×8 sign extension.
+        let rec = OuraRecord(type: OuraEventTag.motion.rawValue, ringTimestamp: rt,
+                             payload: [0x00, 0xF4, 0x00, 0x80, 0x00, 0x00])
+        let m = OuraDecoders.decodeMotionEvents(rec)
+        XCTAssertEqual(m?.avgX, -96)          // 0xF4 = -12 → ×8
+        XCTAssertEqual(m?.avgZ, -1024)        // 0x80 = -128 → ×8
+        XCTAssertEqual(m?.orientation, 0)
+    }
+
+    func testMotionEvents0x47ShortBodyIsNil() {
+        XCTAssertNil(OuraDecoders.decodeMotionEvents(
+            OuraRecord(type: OuraEventTag.motion.rawValue, ringTimestamp: rt, payload: [0x6f, 0x0c])))
+    }
+
     // MARK: - 0x85 RTC beacon (unix_s u32 LE)
 
     func testRtcBeacon0x85() {

--- a/Packages/WhoopStore/Sources/WhoopStore/OuraMotionDumpLine.swift
+++ b/Packages/WhoopStore/Sources/WhoopStore/OuraMotionDumpLine.swift
@@ -1,0 +1,34 @@
+import Foundation
+
+/// Pure, deterministic encoder for ONE line of the Oura motion (0x47 motion_events) research corpus — a
+/// diagnostic JSONL sidecar, NOT a datastore row.
+///
+/// WHY a sidecar and not a stream/table (yet): the 0x47 decode is Tier-A (validated against open_oura's
+/// `decode_motion`), but mapping its averaged `(x, y, z)` vector into a durable `gravitySample` needs the
+/// LSB→g scale the sleep stager's 0.01 g stillness threshold depends on, and that scale can only be pinned
+/// from a STILL capture (issue #804). Until it is, the honest-data invariant says: decode + store + log the
+/// vector BESIDE the incumbent, never feed it to scoring on a guessed scale. This corpus is that store — a
+/// separate, clearly-labeled file the app appends to so the raw motion series can be calibrated offline
+/// (resting magnitude → g, cadence, coverage during stillness). It never feeds scoring and is safe to delete.
+///
+/// FORMAT: newline-delimited JSON (JSONL), one record per line, append-only, FIXED key order so it is stable
+/// and testable byte-for-byte. Parallels `OuraActivityDumpLine`.
+public enum OuraMotionDumpLine {
+    /// Bump when the record shape changes so a downstream reader can branch on `schema`.
+    public static let schema = 1
+
+    /// One JSONL record (NO trailing newline — the writer adds it). `deviceId` is a controlled registry id
+    /// (e.g. `oura-<serial>`) and `iso` is app-generated, so neither needs JSON string-escaping here.
+    ///   - ringTs:        the record's raw ring-clock timestamp (the dedup key: strictly increases per record).
+    ///   - utc:           the anchored wall-clock (unix seconds) for the record envelope.
+    ///   - iso:           human-readable UTC of `utc` (convenience for eyeballing).
+    ///   - orientation:   0…3 orientation code (record byte0 low 2 bits).
+    ///   - x/y/z:         the ring's averaged accel vector, signed record byte × 8 (open_oura convention).
+    ///   - highIntensity: the period's high-intensity count (record byte5).
+    public static func encode(deviceId: String, ringTs: UInt32, utc: Int, iso: String,
+                              orientation: Int, x: Int, y: Int, z: Int, highIntensity: Int) -> String {
+        return "{\"schema\":\(schema),\"deviceId\":\"\(deviceId)\",\"ringTs\":\(ringTs),"
+             + "\"utc\":\(utc),\"iso\":\"\(iso)\",\"orientation\":\(orientation),"
+             + "\"x\":\(x),\"y\":\(y),\"z\":\(z),\"high_intensity\":\(highIntensity)}"
+    }
+}

--- a/Packages/WhoopStore/Sources/WhoopStore/OuraMotionDumpLine.swift
+++ b/Packages/WhoopStore/Sources/WhoopStore/OuraMotionDumpLine.swift
@@ -14,21 +14,28 @@ import Foundation
 /// FORMAT: newline-delimited JSON (JSONL), one record per line, append-only, FIXED key order so it is stable
 /// and testable byte-for-byte. Parallels `OuraActivityDumpLine`.
 public enum OuraMotionDumpLine {
-    /// Bump when the record shape changes so a downstream reader can branch on `schema`.
-    public static let schema = 1
+    /// Bump when the record shape changes so a downstream reader can branch on `schema`. v2 corrects the
+    /// layout to open_oura's `decode_motion` (orientation = b0>>5, adds motion_seconds + low_intensity,
+    /// masks intensities to 0x3f) — a v1 file had a wrong `orientation` and no motion_seconds.
+    public static let schema = 2
 
     /// One JSONL record (NO trailing newline — the writer adds it). `deviceId` is a controlled registry id
     /// (e.g. `oura-<serial>`) and `iso` is app-generated, so neither needs JSON string-escaping here.
     ///   - ringTs:        the record's raw ring-clock timestamp (the dedup key: strictly increases per record).
     ///   - utc:           the anchored wall-clock (unix seconds) for the record envelope.
     ///   - iso:           human-readable UTC of `utc` (convenience for eyeballing).
-    ///   - orientation:   0…3 orientation code (record byte0 low 2 bits).
+    ///   - orientation:   0…7 orientation code (record byte0 >> 5).
+    ///   - motionSeconds: seconds of motion in the window (record byte0 & 0x1f, 0…31).
     ///   - x/y/z:         the ring's averaged accel vector, signed record byte × 8 (open_oura convention).
-    ///   - highIntensity: the period's high-intensity count (record byte5).
+    ///   - low/highIntensity: period intensity counts (record byte4/byte5 & 0x3f); nil ⇒ JSON `null`.
     public static func encode(deviceId: String, ringTs: UInt32, utc: Int, iso: String,
-                              orientation: Int, x: Int, y: Int, z: Int, highIntensity: Int) -> String {
+                              orientation: Int, motionSeconds: Int, x: Int, y: Int, z: Int,
+                              lowIntensity: Int?, highIntensity: Int?) -> String {
+        let lo = lowIntensity.map(String.init) ?? "null"
+        let hi = highIntensity.map(String.init) ?? "null"
         return "{\"schema\":\(schema),\"deviceId\":\"\(deviceId)\",\"ringTs\":\(ringTs),"
              + "\"utc\":\(utc),\"iso\":\"\(iso)\",\"orientation\":\(orientation),"
-             + "\"x\":\(x),\"y\":\(y),\"z\":\(z),\"high_intensity\":\(highIntensity)}"
+             + "\"motion_seconds\":\(motionSeconds),\"x\":\(x),\"y\":\(y),\"z\":\(z),"
+             + "\"low_intensity\":\(lo),\"high_intensity\":\(hi)}"
     }
 }

--- a/Packages/WhoopStore/Sources/WhoopStore/OuraStreamMapping.swift
+++ b/Packages/WhoopStore/Sources/WhoopStore/OuraStreamMapping.swift
@@ -109,11 +109,16 @@ public enum OuraStreamMapping {
                     charging: v.charging))
 
             case .motionEvent:
-                // 0x47 averaged accel vector (Tier-A, WHOOP-4.0-gravity-shaped). Decoded and available,
-                // but NOT yet folded into a `gravitySample`: the LSB→g scale that the sleep stager's
-                // 0.01 g stillness threshold needs is an unresolved calibration (issue #804). Mapping it
-                // to gravity with a guessed scale would feed staging a wrong signal, so it is held here
-                // until the scale is pinned from a real capture. Dropped, not faked.
+                // 0x47 averaged accel vector (Tier-A). Decoded and available, but NOT written to any
+                // durable stream. This is NOT merely a "pending LSB→g scale" hold — the open question is
+                // whether `gravitySample` is the right destination AT ALL. 0x47 is MOVEMENT-GATED (the
+                // ring emits it only while moving, validated on-device #804), so it yields NO still
+                // samples; `SleepStager` instead needs a CONTINUOUS gravity stream (≥70% of a rolling
+                // 15-min window with per-sample delta < 0.01 g, and a >20-min gap breaks the run). Missing
+                // samples are not still samples, so feeding 0x47 into gravity is a SHAPE MISMATCH, not an
+                // unscaled one, and synthesising still samples to fill the gaps would be inventing data.
+                // The usable signal is `motion_seconds` / intensity as an ACTIVITY input on a separate path
+                // (#804 option B). Held here until that path lands. Dropped, not faked.
                 continue
 
             case .motion, .state, .timeSync, .rtcBeacon, .debugText, .tierB, .activityInfo:

--- a/Packages/WhoopStore/Sources/WhoopStore/OuraStreamMapping.swift
+++ b/Packages/WhoopStore/Sources/WhoopStore/OuraStreamMapping.swift
@@ -108,6 +108,14 @@ public enum OuraStreamMapping {
                     mv: v.voltageMv,
                     charging: v.charging))
 
+            case .motionEvent:
+                // 0x47 averaged accel vector (Tier-A, WHOOP-4.0-gravity-shaped). Decoded and available,
+                // but NOT yet folded into a `gravitySample`: the LSB→g scale that the sleep stager's
+                // 0.01 g stillness threshold needs is an unresolved calibration (issue #804). Mapping it
+                // to gravity with a guessed scale would feed staging a wrong signal, so it is held here
+                // until the scale is pinned from a real capture. Dropped, not faked.
+                continue
+
             case .motion, .state, .timeSync, .rtcBeacon, .debugText, .tierB, .activityInfo:
                 // Not a durable per-device stream row (timeSync/rtcBeacon anchor the transport's clock;
                 // motion/state/debug are diagnostics; Tier-B / .activityInfo are UNVERIFIED and must

--- a/Packages/WhoopStore/Tests/WhoopStoreTests/OuraMotionDumpLineTests.swift
+++ b/Packages/WhoopStore/Tests/WhoopStoreTests/OuraMotionDumpLineTests.swift
@@ -1,0 +1,24 @@
+import XCTest
+@testable import WhoopStore
+
+final class OuraMotionDumpLineTests: XCTestCase {
+    func testEncodeFixedKeyOrderAndValues() {
+        let line = OuraMotionDumpLine.encode(
+            deviceId: "oura-2H3B2405003655", ringTs: 730333, utc: 1_753_440_000,
+            iso: "2026-07-25T09:00:00Z", orientation: 3, x: 96, y: 232, z: 56, highIntensity: 7)
+        XCTAssertEqual(line,
+            "{\"schema\":1,\"deviceId\":\"oura-2H3B2405003655\",\"ringTs\":730333,"
+          + "\"utc\":1753440000,\"iso\":\"2026-07-25T09:00:00Z\",\"orientation\":3,"
+          + "\"x\":96,\"y\":232,\"z\":56,\"high_intensity\":7}")
+    }
+
+    func testEncodeIsValidJSONWithNegativeAxes() throws {
+        let line = OuraMotionDumpLine.encode(
+            deviceId: "oura-x", ringTs: 1, utc: 2, iso: "i", orientation: 0,
+            x: -96, y: 0, z: -1024, highIntensity: 0)
+        let obj = try JSONSerialization.jsonObject(with: Data(line.utf8)) as? [String: Any]
+        XCTAssertEqual(obj?["schema"] as? Int, OuraMotionDumpLine.schema)
+        XCTAssertEqual(obj?["x"] as? Int, -96)
+        XCTAssertEqual(obj?["z"] as? Int, -1024)
+    }
+}

--- a/Packages/WhoopStore/Tests/WhoopStoreTests/OuraMotionDumpLineTests.swift
+++ b/Packages/WhoopStore/Tests/WhoopStoreTests/OuraMotionDumpLineTests.swift
@@ -5,20 +5,21 @@ final class OuraMotionDumpLineTests: XCTestCase {
     func testEncodeFixedKeyOrderAndValues() {
         let line = OuraMotionDumpLine.encode(
             deviceId: "oura-2H3B2405003655", ringTs: 730333, utc: 1_753_440_000,
-            iso: "2026-07-25T09:00:00Z", orientation: 3, x: 96, y: 232, z: 56, highIntensity: 7)
+            iso: "2026-07-25T09:00:00Z", orientation: 3, motionSeconds: 15, x: 96, y: 232, z: 56,
+            lowIntensity: 12, highIntensity: 7)
         XCTAssertEqual(line,
-            "{\"schema\":1,\"deviceId\":\"oura-2H3B2405003655\",\"ringTs\":730333,"
+            "{\"schema\":2,\"deviceId\":\"oura-2H3B2405003655\",\"ringTs\":730333,"
           + "\"utc\":1753440000,\"iso\":\"2026-07-25T09:00:00Z\",\"orientation\":3,"
-          + "\"x\":96,\"y\":232,\"z\":56,\"high_intensity\":7}")
+          + "\"motion_seconds\":15,\"x\":96,\"y\":232,\"z\":56,\"low_intensity\":12,\"high_intensity\":7}")
     }
 
-    func testEncodeIsValidJSONWithNegativeAxes() throws {
+    func testEncodeNullIntensityIsValidJSON() throws {
         let line = OuraMotionDumpLine.encode(
-            deviceId: "oura-x", ringTs: 1, utc: 2, iso: "i", orientation: 0,
-            x: -96, y: 0, z: -1024, highIntensity: 0)
+            deviceId: "oura-x", ringTs: 1, utc: 2, iso: "i", orientation: 0, motionSeconds: 0,
+            x: -96, y: 0, z: -1024, lowIntensity: nil, highIntensity: nil)
         let obj = try JSONSerialization.jsonObject(with: Data(line.utf8)) as? [String: Any]
         XCTAssertEqual(obj?["schema"] as? Int, OuraMotionDumpLine.schema)
         XCTAssertEqual(obj?["x"] as? Int, -96)
-        XCTAssertEqual(obj?["z"] as? Int, -1024)
+        XCTAssertTrue(obj?["high_intensity"] is NSNull)
     }
 }

--- a/Strand/BLE/OuraLiveSource.swift
+++ b/Strand/BLE/OuraLiveSource.swift
@@ -1384,7 +1384,8 @@ public final class OuraLiveSource: NSObject, ObservableObject {
                 // ring-time inside the writer).
                 if let utc = driver.unixSeconds(forRingTimestamp: m.ringTimestamp) {
                     motionDump?.record(ringTs: m.ringTimestamp, utc: utc, orientation: m.orientation,
-                                       x: m.avgX, y: m.avgY, z: m.avgZ, highIntensity: m.highIntensity)
+                                       motionSeconds: m.motionSeconds, x: m.avgX, y: m.avgY, z: m.avgZ,
+                                       lowIntensity: m.lowIntensity, highIntensity: m.highIntensity)
                 }
 
             default:

--- a/Strand/BLE/OuraLiveSource.swift
+++ b/Strand/BLE/OuraLiveSource.swift
@@ -266,6 +266,8 @@ public final class OuraLiveSource: NSObject, ObservableObject {
     /// SQLite). Created only on a live/persisting source (nil for the discovery-only scanner). Deduped by
     /// ring-time so re-served records don't duplicate; logs its file path once when the first record lands.
     private let activityDump: OuraActivityDump?
+    /// Append-only JSONL sidecar for the 0x47 motion vectors (Tier-A), for offline LSB→g calibration (#804).
+    private let motionDump: OuraMotionDump?
     /// Cached local-day formatter (the 0x50 stream is high-volume; avoid building one per record).
     private static let activityDayFormatter: DateFormatter = {
         let f = DateFormatter(); f.dateFormat = "yyyy-MM-dd"; return f   // local time zone by default
@@ -772,6 +774,8 @@ public final class OuraLiveSource: NSObject, ObservableObject {
         self.adoptIntent = adoptIntent
         // Tier-B MET research corpus: only on a live/persisting source, never the discovery-only scanner.
         self.activityDump = feedsLive && !deviceId.isEmpty ? OuraActivityDump(deviceId: deviceId, log: log) : nil
+        // 0x47 motion calibration corpus: same gate as the activity dump (live/persisting source only).
+        self.motionDump = feedsLive && !deviceId.isEmpty ? OuraMotionDump(deviceId: deviceId, log: log) : nil
         super.init()
         // Dedicated queue-less central -> callbacks arrive on the main queue, matching @MainActor.
         self.central = CBCentralManager(delegate: self, queue: nil)
@@ -1372,8 +1376,19 @@ public final class OuraLiveSource: NSObject, ObservableObject {
                     publishWearState()
                 }
 
+            case .motionEvent(let m):
+                // 0x47 averaged accel vector (Tier-A). Diagnostic sidecar ONLY for now: decode + store + log
+                // the vector beside the incumbent so the LSB→g scale + cadence can be pinned offline from a
+                // still capture (issue #804). Never persisted to SQLite, never scored — OuraStreamMapping
+                // drops .motionEvent until the scale is calibrated. Anchored records only (deduped by
+                // ring-time inside the writer).
+                if let utc = driver.unixSeconds(forRingTimestamp: m.ringTimestamp) {
+                    motionDump?.record(ringTs: m.ringTimestamp, utc: utc, orientation: m.orientation,
+                                       x: m.avgX, y: m.avgY, z: m.avgZ, highIntensity: m.highIntensity)
+                }
+
             default:
-                break   // motion / debugText / etc: not a durable Streams row (see OuraStreamMapping)
+                break   // state / debugText / etc: not a durable Streams row (see OuraStreamMapping)
             }
         }
     }

--- a/Strand/BLE/OuraMotionDump.swift
+++ b/Strand/BLE/OuraMotionDump.swift
@@ -1,0 +1,110 @@
+import Foundation
+import WhoopStore
+
+/// Append-only JSONL sidecar for the Oura 0x47 motion_events stream — a Tier-A RESEARCH corpus for
+/// calibration, NOT a datastore row (see `OuraMotionDumpLine` for the rationale). Direct twin of
+/// `OuraActivityDump`: owns the file handle, the on-disk path, the once-per-launch "here is the file" log
+/// line, and a persistent ring-time high-water so records the ring re-serves across reconnects are written
+/// exactly once instead of duplicating the corpus.
+///
+/// Location: `<Application Support>/OpenWhoop/Diagnostics/oura-motion-<deviceId>.jsonl` — beside the app's
+/// SQLite so the user can find it. Purely diagnostic and safe to delete; nothing reads it back. It exists
+/// so the averaged accel vector can be calibrated offline (resting magnitude → g scale, cadence during
+/// stillness) before the mapping wires it into `gravitySample` (issue #804).
+final class OuraMotionDump {
+    private let deviceId: String
+    private let log: (String) -> Void
+    private let highWaterKey: String
+    /// Only records with `ringTs` STRICTLY above this are written; re-served (older) records are dropped.
+    /// Persisted in UserDefaults so the dedup survives app relaunches (a fresh drain re-emits old records).
+    private var highWater: UInt32
+    private var fileURL: URL?
+    private var resolveFailed = false
+    private var announced = false
+
+    /// Rotate the sidecar past this size (keeping one previous ".1"), so an always-on research corpus is
+    /// bounded to ~2× this on disk instead of growing forever. Matches `OuraActivityDump`.
+    private static let maxBytes = 25 * 1024 * 1024
+
+    private static let iso: ISO8601DateFormatter = {
+        let f = ISO8601DateFormatter()
+        f.timeZone = TimeZone(identifier: "UTC")
+        return f
+    }()
+
+    init(deviceId: String, log: @escaping (String) -> Void) {
+        self.deviceId = deviceId
+        self.log = log
+        self.highWaterKey = "oura.motionDump.highwater.\(deviceId)"
+        let stored = UserDefaults.standard.integer(forKey: highWaterKey)   // 0 when unset → writes everything
+        self.highWater = stored > 0 ? UInt32(truncatingIfNeeded: stored) : 0
+    }
+
+    /// Append one anchored motion record. No-op when `ringTs` is not above the high-water (a re-serve), so
+    /// the corpus stays deduped. Best-effort: any file error is logged once and never disrupts the BLE path.
+    /// Call ONLY with an anchored `utc` (an un-anchored record has no real time axis and re-arrives anchored
+    /// on the next drain).
+    func record(ringTs: UInt32, utc: Int, orientation: Int, x: Int, y: Int, z: Int, highIntensity: Int) {
+        guard ringTs > highWater else { return }
+        guard var url = resolveURL() else { return }
+        // Bound the corpus (rotate to a single ".1", dropping the prior one) so an always-on research sidecar
+        // can't grow unbounded — same rotation as OuraActivityDump. Read the size via a fresh FileManager stat
+        // rather than URL.resourceValues, whose cache on the reused URL can return a stale small size.
+        let size = ((try? FileManager.default.attributesOfItem(atPath: url.path))?[.size] as? Int) ?? 0
+        if size > Self.maxBytes {
+            let old = url.deletingLastPathComponent().appendingPathComponent(url.lastPathComponent + ".1")
+            try? FileManager.default.removeItem(at: old)
+            try? FileManager.default.moveItem(at: url, to: old)
+            fileURL = nil
+            guard let fresh = resolveURL() else { return }
+            url = fresh
+        }
+
+        let line = OuraMotionDumpLine.encode(
+            deviceId: deviceId, ringTs: ringTs, utc: utc,
+            iso: Self.iso.string(from: Date(timeIntervalSince1970: TimeInterval(utc))),
+            orientation: orientation, x: x, y: y, z: z, highIntensity: highIntensity)
+
+        guard let data = (line + "\n").data(using: .utf8) else { return }
+        do {
+            let handle = try FileHandle(forWritingTo: url)
+            defer { try? handle.close() }
+            try handle.seekToEnd()
+            handle.write(data)
+        } catch {
+            log("Oura: motion dump write failed - \(error.localizedDescription)")
+            return
+        }
+
+        highWater = ringTs
+        UserDefaults.standard.set(Int(ringTs), forKey: highWaterKey)
+        if !announced {
+            announced = true
+            log("Oura: motion 0x47 dump → \(url.path) [Tier-A calibration corpus, JSONL, deduped by ring-time]")
+        }
+    }
+
+    /// Resolve (and create on first use) the sidecar file + its parent directory. Cached; a failure is
+    /// logged once and latched so we never spam the strap log on a read-only volume.
+    private func resolveURL() -> URL? {
+        if let fileURL { return fileURL }
+        if resolveFailed { return nil }
+        do {
+            let base = try FileManager.default.url(for: .applicationSupportDirectory, in: .userDomainMask,
+                                                   appropriateFor: nil, create: true)
+            let dir = base.appendingPathComponent("OpenWhoop/Diagnostics", isDirectory: true)
+            try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+            let safeId = deviceId.replacingOccurrences(of: "/", with: "_")
+            let url = dir.appendingPathComponent("oura-motion-\(safeId).jsonl")
+            if !FileManager.default.fileExists(atPath: url.path) {
+                FileManager.default.createFile(atPath: url.path, contents: nil)
+            }
+            fileURL = url
+            return url
+        } catch {
+            resolveFailed = true
+            log("Oura: motion dump unavailable - \(error.localizedDescription)")
+            return nil
+        }
+    }
+}

--- a/Strand/BLE/OuraMotionDump.swift
+++ b/Strand/BLE/OuraMotionDump.swift
@@ -44,7 +44,8 @@ final class OuraMotionDump {
     /// the corpus stays deduped. Best-effort: any file error is logged once and never disrupts the BLE path.
     /// Call ONLY with an anchored `utc` (an un-anchored record has no real time axis and re-arrives anchored
     /// on the next drain).
-    func record(ringTs: UInt32, utc: Int, orientation: Int, x: Int, y: Int, z: Int, highIntensity: Int) {
+    func record(ringTs: UInt32, utc: Int, orientation: Int, motionSeconds: Int, x: Int, y: Int, z: Int,
+                lowIntensity: Int?, highIntensity: Int?) {
         guard ringTs > highWater else { return }
         guard var url = resolveURL() else { return }
         // Bound the corpus (rotate to a single ".1", dropping the prior one) so an always-on research sidecar
@@ -63,7 +64,8 @@ final class OuraMotionDump {
         let line = OuraMotionDumpLine.encode(
             deviceId: deviceId, ringTs: ringTs, utc: utc,
             iso: Self.iso.string(from: Date(timeIntervalSince1970: TimeInterval(utc))),
-            orientation: orientation, x: x, y: y, z: z, highIntensity: highIntensity)
+            orientation: orientation, motionSeconds: motionSeconds, x: x, y: y, z: z,
+            lowIntensity: lowIntensity, highIntensity: highIntensity)
 
         guard let data = (line + "\n").data(using: .utf8) else { return }
         do {

--- a/android/app/src/main/java/com/noop/ble/OuraLiveSource.kt
+++ b/android/app/src/main/java/com/noop/ble/OuraLiveSource.kt
@@ -244,6 +244,11 @@ class OuraLiveSource(
      *  row). Null when there is no device id. The Kotlin twin of the Swift `OuraActivityDump`. */
     private val activityDump: OuraActivityDump? =
         if (deviceId.isNotEmpty()) OuraActivityDump(appContext, deviceId, log) else null
+
+    /** 0x47 motion calibration corpus (Tier-A), for offline LSB→g scale + cadence work (#804). Kotlin twin
+     *  of the Swift `OuraMotionDump`. Null when there is no device id. */
+    private val motionDump: OuraMotionDump? =
+        if (deviceId.isNotEmpty()) OuraMotionDump(appContext, deviceId, log) else null
     private val scanner: BluetoothLeScanner? get() = adapter?.bluetoothLeScanner
 
     private var gatt: BluetoothGatt? = null
@@ -1717,8 +1722,22 @@ class OuraLiveSource(
                     )
                 }
             }
-            // Motion / debugText / etc: not a durable Streams row (see OuraStreamMapping). StateEvent is
-            // handled above (wear badge only, also not a Streams row).
+            is OuraEvent.MotionVectorEvent -> {
+                // 0x47 averaged accel vector (Tier-A). Diagnostic sidecar ONLY for now: decode + store + log
+                // the vector beside the incumbent so the LSB→g scale + cadence can be pinned offline from a
+                // still capture (issue #804). Never persisted to the DB, never scored — OuraStreamMapping
+                // drops MotionVectorEvent until the scale is calibrated. Anchored records only (deduped by
+                // ring-time in the writer). Twin of the Swift hook.
+                d.unixSeconds(forRingTimestamp = e.value.ringTimestamp)?.let { utc ->
+                    motionDump?.record(
+                        ringTs = e.value.ringTimestamp, utc = utc, orientation = e.value.orientation,
+                        x = e.value.avgX, y = e.value.avgY, z = e.value.avgZ,
+                        highIntensity = e.value.highIntensity,
+                    )
+                }
+            }
+            // Motion (0x6b) / debugText / etc: not a durable Streams row (see OuraStreamMapping). StateEvent
+            // is handled above (wear badge only, also not a Streams row).
             else -> Unit
         }
     }

--- a/android/app/src/main/java/com/noop/ble/OuraLiveSource.kt
+++ b/android/app/src/main/java/com/noop/ble/OuraLiveSource.kt
@@ -1731,7 +1731,8 @@ class OuraLiveSource(
                 d.unixSeconds(forRingTimestamp = e.value.ringTimestamp)?.let { utc ->
                     motionDump?.record(
                         ringTs = e.value.ringTimestamp, utc = utc, orientation = e.value.orientation,
-                        x = e.value.avgX, y = e.value.avgY, z = e.value.avgZ,
+                        motionSeconds = e.value.motionSeconds, x = e.value.avgX, y = e.value.avgY,
+                        z = e.value.avgZ, lowIntensity = e.value.lowIntensity,
                         highIntensity = e.value.highIntensity,
                     )
                 }

--- a/android/app/src/main/java/com/noop/ble/OuraMotionDump.kt
+++ b/android/app/src/main/java/com/noop/ble/OuraMotionDump.kt
@@ -38,7 +38,10 @@ class OuraMotionDump(
      * the corpus stays deduped. Best-effort: any file error is logged once and never disrupts the BLE path.
      * Call ONLY with an anchored [utc].
      */
-    fun record(ringTs: Long, utc: Long, orientation: Int, x: Int, y: Int, z: Int, highIntensity: Int) {
+    fun record(
+        ringTs: Long, utc: Long, orientation: Int, motionSeconds: Int, x: Int, y: Int, z: Int,
+        lowIntensity: Int?, highIntensity: Int?,
+    ) {
         if (ringTs <= highWater) return
         var f = resolveFile() ?: return
         // Bound the corpus so it can't grow unbounded (always-on for every paired ring). At the cap, rotate
@@ -56,7 +59,8 @@ class OuraMotionDump(
         val line = OuraMotionDumpLine.encode(
             deviceId = deviceId, ringTs = ringTs, utc = utc,
             iso = Instant.ofEpochSecond(utc).toString(),
-            orientation = orientation, x = x, y = y, z = z, highIntensity = highIntensity,
+            orientation = orientation, motionSeconds = motionSeconds, x = x, y = y, z = z,
+            lowIntensity = lowIntensity, highIntensity = highIntensity,
         )
         try {
             f.appendText(line + "\n")

--- a/android/app/src/main/java/com/noop/ble/OuraMotionDump.kt
+++ b/android/app/src/main/java/com/noop/ble/OuraMotionDump.kt
@@ -1,0 +1,101 @@
+package com.noop.ble
+
+import android.content.Context
+import com.noop.oura.OuraMotionDumpLine
+import java.io.File
+import java.time.Instant
+
+/**
+ * Append-only JSONL sidecar for the Oura 0x47 motion_events stream — the Kotlin twin of Swift
+ * `OuraMotionDump`. A Tier-A RESEARCH corpus for calibration, never a datastore row (see
+ * [OuraMotionDumpLine] for the rationale). Owns the file, the once-per-launch "here is the file" log line,
+ * and a persistent ring-time high-water so records the ring re-serves across reconnects are written exactly
+ * once instead of duplicating the corpus.
+ *
+ * Location: `<filesDir>/diagnostics/oura-motion-<deviceId>.jsonl` (app-private). Purely diagnostic and safe
+ * to delete; nothing reads it back. It exists so the averaged accel vector can be calibrated offline
+ * (resting magnitude → g scale, cadence during stillness) before the mapping wires it into gravitySample
+ * (issue #804). The LINE content is byte-identical to the Swift corpus — that is the parity-relevant part.
+ */
+class OuraMotionDump(
+    context: Context,
+    private val deviceId: String,
+    private val log: (String) -> Unit,
+) {
+    private val appContext = context.applicationContext
+    private val prefs = appContext.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+    private val highWaterKey = "highwater.$deviceId"
+
+    /** Only records with `ringTs` STRICTLY above this are written; re-served (older) records are dropped.
+     *  Persisted so the dedup survives relaunches (a fresh drain re-emits old records). */
+    private var highWater: Long = prefs.getLong(highWaterKey, 0L)
+    private var file: File? = null
+    private var resolveFailed = false
+    private var announced = false
+
+    /**
+     * Append one anchored motion record. No-op when [ringTs] is not above the high-water (a re-serve), so
+     * the corpus stays deduped. Best-effort: any file error is logged once and never disrupts the BLE path.
+     * Call ONLY with an anchored [utc].
+     */
+    fun record(ringTs: Long, utc: Long, orientation: Int, x: Int, y: Int, z: Int, highIntensity: Int) {
+        if (ringTs <= highWater) return
+        var f = resolveFile() ?: return
+        // Bound the corpus so it can't grow unbounded (always-on for every paired ring). At the cap, rotate
+        // to a single ".1" (dropping the prior one) and continue in a fresh file — same as OuraActivityDump.
+        if (f.length() > MAX_BYTES) {
+            runCatching {
+                val old = File(f.parentFile, "${f.name}.1")
+                old.delete()
+                f.renameTo(old)
+            }
+            file = null
+            f = resolveFile() ?: return
+        }
+
+        val line = OuraMotionDumpLine.encode(
+            deviceId = deviceId, ringTs = ringTs, utc = utc,
+            iso = Instant.ofEpochSecond(utc).toString(),
+            orientation = orientation, x = x, y = y, z = z, highIntensity = highIntensity,
+        )
+        try {
+            f.appendText(line + "\n")
+        } catch (e: Exception) {
+            log("Oura: motion dump write failed - ${e.message}")
+            return
+        }
+
+        highWater = ringTs
+        prefs.edit().putLong(highWaterKey, ringTs).apply()
+        if (!announced) {
+            announced = true
+            log("Oura: motion 0x47 dump → ${f.absolutePath} [Tier-A calibration corpus, JSONL, deduped by ring-time]")
+        }
+    }
+
+    /** Resolve (and create on first use) the sidecar file + its parent directory. Cached; a failure is
+     *  logged once and latched so we never spam the strap log on a read-only volume. */
+    private fun resolveFile(): File? {
+        file?.let { return it }
+        if (resolveFailed) return null
+        return try {
+            val dir = File(appContext.filesDir, "diagnostics").apply { mkdirs() }
+            val safeId = deviceId.replace("/", "_")
+            File(dir, "oura-motion-$safeId.jsonl").also {
+                if (!it.exists()) it.createNewFile()
+                file = it
+            }
+        } catch (e: Exception) {
+            resolveFailed = true
+            log("Oura: motion dump unavailable - ${e.message}")
+            null
+        }
+    }
+
+    private companion object {
+        const val PREFS_NAME = "oura_motion_dump"
+
+        /** Rotate the sidecar past this size (keeping one previous ".1"), bounding it to ~2× on disk. */
+        const val MAX_BYTES = 25L * 1024 * 1024
+    }
+}

--- a/android/app/src/main/java/com/noop/data/OuraStreamMapping.kt
+++ b/android/app/src/main/java/com/noop/data/OuraStreamMapping.kt
@@ -120,6 +120,13 @@ object OuraStreamMapping {
                     // as a tied-to-ts row here. Leave the batch's battery list empty (honest: no faked ts).
                 }
 
+                // 0x47 averaged accel vector (Tier-A, WHOOP-4.0-gravity-shaped): decoded and available,
+                // but NOT yet folded into a gravitySample. The LSB→g scale the sleep stager's 0.01 g
+                // stillness threshold needs is an unresolved calibration (issue #804); mapping it with a
+                // guessed scale would feed staging a wrong signal, so it is held here until pinned from a
+                // real capture. Dropped, not faked. Mirrors the Swift twin.
+                is OuraEvent.MotionVectorEvent -> Unit
+
                 // Motion / state / time-sync / rtc / debug / TierB / ActivityInfo never map onto a
                 // scored stream. In particular the 0x50 activity/MET decode (PR #960) NEVER mints a
                 // `steps` row: the formula is third-party and unvalidated (Tier B, OURA_PROTOCOL.md

--- a/android/app/src/main/java/com/noop/data/OuraStreamMapping.kt
+++ b/android/app/src/main/java/com/noop/data/OuraStreamMapping.kt
@@ -120,11 +120,16 @@ object OuraStreamMapping {
                     // as a tied-to-ts row here. Leave the batch's battery list empty (honest: no faked ts).
                 }
 
-                // 0x47 averaged accel vector (Tier-A, WHOOP-4.0-gravity-shaped): decoded and available,
-                // but NOT yet folded into a gravitySample. The LSB→g scale the sleep stager's 0.01 g
-                // stillness threshold needs is an unresolved calibration (issue #804); mapping it with a
-                // guessed scale would feed staging a wrong signal, so it is held here until pinned from a
-                // real capture. Dropped, not faked. Mirrors the Swift twin.
+                // 0x47 averaged accel vector (Tier-A): decoded and available, but NOT written to any
+                // durable stream. This is NOT merely a "pending LSB→g scale" hold — the open question is
+                // whether gravitySample is the right destination AT ALL. 0x47 is MOVEMENT-GATED (emitted
+                // only while moving, validated on-device #804), so it yields NO still samples; SleepStager
+                // instead needs a CONTINUOUS gravity stream (≥70% of a rolling 15-min window with
+                // per-sample delta < 0.01 g, a >20-min gap breaks the run). Missing samples are not still
+                // samples, so feeding 0x47 into gravity is a SHAPE MISMATCH, not an unscaled one, and
+                // synthesising still samples to fill the gaps would be inventing data. The usable signal is
+                // motion_seconds / intensity as an ACTIVITY input on a separate path (#804 option B). Held
+                // here until that path lands. Dropped, not faked. Mirrors the Swift twin.
                 is OuraEvent.MotionVectorEvent -> Unit
 
                 // Motion / state / time-sync / rtc / debug / TierB / ActivityInfo never map onto a

--- a/android/app/src/main/java/com/noop/oura/Decoders.kt
+++ b/android/app/src/main/java/com/noop/oura/Decoders.kt
@@ -511,28 +511,40 @@ object OuraDecoders {
     // MARK: - Motion events, averaged accel vector (0x47; s6.13)
 
     /**
-     * Decode a 0x47 motion_events record: the ring's averaged accelerometer vector for the period.
-     * Layout (open_oura decode_motion, clean-room fact citation; OURA_PROTOCOL.md s6.13):
-     *   byte0 low 2 bits = orientation (0..3)
-     *   byte1 = avg X, signed int8 × 8
-     *   byte2 = avg Y, signed int8 × 8
-     *   byte3 = avg Z, signed int8 × 8
-     *   byte5 = high_intensity count
-     * byte4 is not yet identified (present, not surfaced). Returns null on a short body rather than
-     * guessing a partial layout. Same averaged-vector shape as a WHOOP 4.0 gravity sample, so a consumer
-     * can map (avgX, avgY, avgZ) into the shared motion pipeline (the LSB→g scaling for the sleep stager
-     * is a downstream calibration, kept out of this pure decode). Byte-identical twin of Swift.
+     * Decode a 0x47 motion_events record: a compact per-window motion summary. Byte-for-byte port of
+     * open_oura's decode_motion / parse_api_motion_events (clean-room fact citation; OURA_PROTOCOL.md
+     * s6.13):
+     *   byte0 >> 5   = orientation (0..7)
+     *   byte0 & 0x1f = motion_seconds (0..31)
+     *   byte1/2/3    = avg X/Y/Z, signed int8 × 8
+     *   byte4 (opt)  = low_intensity: bit 0x40 set ⇒ INVALID (record → null); else & 0x3f
+     *   byte5 (opt)  = high_intensity: bit 0x40 set ⇒ INVALID (record → null); else & 0x3f
+     * Needs ≥ 4 bytes; low/high optional. 0x47 is MOVEMENT-GATED (validated #804): emitted only while
+     * moving, so there is no still/1 g sample — motion_seconds / intensity are the activity signal, not a
+     * gravity magnitude. Byte-identical twin of Swift.
      */
     fun decodeMotionEvents(rec: OuraRecord): OuraMotionEvent? {
         val b = rec.payload
-        if (b.size < 6) return null
+        if (b.size < 4) return null
+        var low: Int? = null
+        if (b.size >= 5) {
+            if (b[4] and 0x40 != 0) return null
+            low = b[4] and 0x3f
+        }
+        var high: Int? = null
+        if (b.size >= 6) {
+            if (b[5] and 0x40 != 0) return null
+            high = b[5] and 0x3f
+        }
         return OuraMotionEvent(
             ringTimestamp = rec.ringTimestamp,
-            orientation = b[0] and 0x03,
+            orientation = b[0] shr 5,
+            motionSeconds = b[0] and 0x1f,
             avgX = i8(b[1]) * 8,
             avgY = i8(b[2]) * 8,
             avgZ = i8(b[3]) * 8,
-            highIntensity = b[5],
+            lowIntensity = low,
+            highIntensity = high,
         )
     }
 

--- a/android/app/src/main/java/com/noop/oura/Decoders.kt
+++ b/android/app/src/main/java/com/noop/oura/Decoders.kt
@@ -508,6 +508,34 @@ object OuraDecoders {
         return if (out.isEmpty()) null else out
     }
 
+    // MARK: - Motion events, averaged accel vector (0x47; s6.13)
+
+    /**
+     * Decode a 0x47 motion_events record: the ring's averaged accelerometer vector for the period.
+     * Layout (open_oura decode_motion, clean-room fact citation; OURA_PROTOCOL.md s6.13):
+     *   byte0 low 2 bits = orientation (0..3)
+     *   byte1 = avg X, signed int8 × 8
+     *   byte2 = avg Y, signed int8 × 8
+     *   byte3 = avg Z, signed int8 × 8
+     *   byte5 = high_intensity count
+     * byte4 is not yet identified (present, not surfaced). Returns null on a short body rather than
+     * guessing a partial layout. Same averaged-vector shape as a WHOOP 4.0 gravity sample, so a consumer
+     * can map (avgX, avgY, avgZ) into the shared motion pipeline (the LSB→g scaling for the sleep stager
+     * is a downstream calibration, kept out of this pure decode). Byte-identical twin of Swift.
+     */
+    fun decodeMotionEvents(rec: OuraRecord): OuraMotionEvent? {
+        val b = rec.payload
+        if (b.size < 6) return null
+        return OuraMotionEvent(
+            ringTimestamp = rec.ringTimestamp,
+            orientation = b[0] and 0x03,
+            avgX = i8(b[1]) * 8,
+            avgY = i8(b[2]) * 8,
+            avgZ = i8(b[3]) * 8,
+            highIntensity = b[5],
+        )
+    }
+
     // MARK: - Activity info (0x50; s6.13) - Tier B, third-party formula
 
     /**

--- a/android/app/src/main/java/com/noop/oura/OuraDriver.kt
+++ b/android/app/src/main/java/com/noop/oura/OuraDriver.kt
@@ -407,9 +407,11 @@ class OuraDriver(
             OuraEventTag.MOTION_PERIOD ->
                 (OuraDecoders.decodeMotionPeriod(record) ?: emptyList()).map { OuraEvent.MotionEvent(it) }
             OuraEventTag.MOTION ->
-                // 0x47 motion_events: surfaced as state-free motion is out of v1 scope; decode to nothing
-                // rather than guess the partial layout. Per OURA_PROTOCOL.md s6.13.
-                emptyList()
+                // 0x47 motion_events: the ring's averaged accel vector (orientation + avg x/y/z ×8 +
+                // high_intensity), the same shape as a WHOOP 4.0 gravity sample. open_oura decode_motion,
+                // OURA_PROTOCOL.md s6.13. Tier-A. Byte-identical twin of Swift.
+                OuraDecoders.decodeMotionEvents(record)?.let { listOf(OuraEvent.MotionVectorEvent(it)) }
+                    ?: emptyList()
 
             // --- Tier A: Sleep phase (2-bit codes are verified; 0x4B is the same layout, s6.12) ---
             OuraEventTag.SLEEP_PHASE_B, OuraEventTag.SLEEP_PHASE, OuraEventTag.SLEEP_PHASE_ALT ->

--- a/android/app/src/main/java/com/noop/oura/OuraEvents.kt
+++ b/android/app/src/main/java/com/noop/oura/OuraEvents.kt
@@ -80,6 +80,23 @@ enum class OuraMotionState(val raw: Int) {
 /** One decoded motion-state code from a 0x6B motion_period record (OURA_PROTOCOL.md s6.13). */
 data class OuraMotion(val ringTimestamp: Long, val index: Int, val state: OuraMotionState)
 
+/**
+ * One decoded 0x47 motion_events record: the ring's OWN averaged accelerometer vector for the period,
+ * plus an orientation code and a high-intensity count (open_oura decode_motion, clean-room fact citation;
+ * OURA_PROTOCOL.md s6.13). Same shape as a WHOOP 4.0 gravity sample — an averaged (x, y, z) vector, NOT
+ * per-sample raw accel — so it can feed the same motion pipeline. Axis values are the signed record bytes
+ * scaled ×8 (open_oura's convention); the LSB→g scale for the sleep stager is a downstream calibration, so
+ * this holds the ring's raw ×8 integers, unscaled and honest. Twin of Swift OuraMotionEvent.
+ */
+data class OuraMotionEvent(
+    val ringTimestamp: Long,
+    val orientation: Int,
+    val avgX: Int,
+    val avgY: Int,
+    val avgZ: Int,
+    val highIntensity: Int,
+)
+
 /** Device lifecycle state (OURA_PROTOCOL.md s6.15) decoded from a 0x45/0x53 record. */
 data class OuraState(val ringTimestamp: Long, val stateCode: Int, val text: String? = null)
 
@@ -164,6 +181,12 @@ sealed class OuraEvent {
     data class Battery(val value: OuraBattery) : OuraEvent()
     data class SleepPhaseEvent(val value: OuraSleepPhase) : OuraEvent()
     data class MotionEvent(val value: OuraMotion) : OuraEvent()
+
+    /**
+     * A decoded 0x47 motion_events record: the ring's averaged accel vector (Tier-A). Distinct from
+     * [MotionEvent] (the 0x6B period's 2-bit state codes). Twin of Swift OuraEvent.motionEvent.
+     */
+    data class MotionVectorEvent(val value: OuraMotionEvent) : OuraEvent()
     data class StateEvent(val value: OuraState) : OuraEvent()
     data class TimeSyncEvent(val value: OuraTimeSync) : OuraEvent()
     data class RtcBeaconEvent(val value: OuraRtcBeacon) : OuraEvent()
@@ -202,6 +225,7 @@ sealed class OuraEvent {
             is Battery -> null
             is SleepPhaseEvent -> value.ringTimestamp
             is MotionEvent -> value.ringTimestamp
+            is MotionVectorEvent -> value.ringTimestamp
             is StateEvent -> value.ringTimestamp
             is TimeSyncEvent -> value.ringTimestamp
             is RtcBeaconEvent -> value.ringTimestamp

--- a/android/app/src/main/java/com/noop/oura/OuraEvents.kt
+++ b/android/app/src/main/java/com/noop/oura/OuraEvents.kt
@@ -90,11 +90,13 @@ data class OuraMotion(val ringTimestamp: Long, val index: Int, val state: OuraMo
  */
 data class OuraMotionEvent(
     val ringTimestamp: Long,
-    val orientation: Int,
+    val orientation: Int,     // byte0 >> 5 (0..7)
+    val motionSeconds: Int,   // byte0 & 0x1f (0..31): seconds of motion in the window
     val avgX: Int,
     val avgY: Int,
     val avgZ: Int,
-    val highIntensity: Int,
+    val lowIntensity: Int?,   // byte4 & 0x3f, or null when the record is short
+    val highIntensity: Int?,  // byte5 & 0x3f, or null when the record is short
 )
 
 /** Device lifecycle state (OURA_PROTOCOL.md s6.15) decoded from a 0x45/0x53 record. */

--- a/android/app/src/main/java/com/noop/oura/OuraMotionDumpLine.kt
+++ b/android/app/src/main/java/com/noop/oura/OuraMotionDumpLine.kt
@@ -1,0 +1,47 @@
+package com.noop.oura
+
+/**
+ * Pure, deterministic encoder for ONE line of the Oura motion (0x47 motion_events) research corpus — the
+ * Kotlin twin of Swift `OuraMotionDumpLine`. Byte-identical output (fixed key order), so the two platforms'
+ * JSONL corpora are interchangeable.
+ *
+ * WHY a sidecar and not a stream/table (yet): the 0x47 decode is Tier-A (validated against open_oura's
+ * `decode_motion`), but mapping its averaged (x, y, z) vector into a durable gravitySample needs the LSB→g
+ * scale the sleep stager's 0.01 g stillness threshold depends on, and that scale can only be pinned from a
+ * STILL capture (issue #804). Until then, decode + store + log the vector BESIDE the incumbent, never feed
+ * it to scoring on a guessed scale. This corpus is that store — a separate, clearly-labelled diagnostic file
+ * for offline calibration (resting magnitude → g, cadence, coverage). It never feeds scoring, safe to delete.
+ *
+ * FORMAT: newline-delimited JSON (JSONL), one record per line, append-only, FIXED key order so it is stable
+ * and testable byte-for-byte. Parallels [OuraActivityDumpLine].
+ */
+object OuraMotionDumpLine {
+    /** Bump when the record shape changes so a downstream reader can branch on `schema`. */
+    const val SCHEMA = 1
+
+    /**
+     * One JSONL record (NO trailing newline — the writer adds it). `deviceId` is a controlled registry id
+     * (e.g. `oura-<serial>`) and `iso` is app-generated, so neither needs JSON string-escaping here.
+     *   - ringTs:        the record's raw ring-clock timestamp (the dedup key: strictly increases per record).
+     *   - utc:           the anchored wall-clock (unix seconds) for the record envelope.
+     *   - iso:           human-readable UTC of `utc` (convenience for eyeballing).
+     *   - orientation:   0..3 orientation code (record byte0 low 2 bits).
+     *   - x/y/z:         the ring's averaged accel vector, signed record byte × 8 (open_oura convention).
+     *   - highIntensity: the period's high-intensity count (record byte5).
+     */
+    fun encode(
+        deviceId: String,
+        ringTs: Long,
+        utc: Long,
+        iso: String,
+        orientation: Int,
+        x: Int,
+        y: Int,
+        z: Int,
+        highIntensity: Int,
+    ): String {
+        return "{\"schema\":$SCHEMA,\"deviceId\":\"$deviceId\",\"ringTs\":$ringTs," +
+            "\"utc\":$utc,\"iso\":\"$iso\",\"orientation\":$orientation," +
+            "\"x\":$x,\"y\":$y,\"z\":$z,\"high_intensity\":$highIntensity}"
+    }
+}

--- a/android/app/src/main/java/com/noop/oura/OuraMotionDumpLine.kt
+++ b/android/app/src/main/java/com/noop/oura/OuraMotionDumpLine.kt
@@ -16,8 +16,10 @@ package com.noop.oura
  * and testable byte-for-byte. Parallels [OuraActivityDumpLine].
  */
 object OuraMotionDumpLine {
-    /** Bump when the record shape changes so a downstream reader can branch on `schema`. */
-    const val SCHEMA = 1
+    /** Bump when the record shape changes so a downstream reader can branch on `schema`. v2 corrects the
+     *  layout to open_oura's decode_motion (orientation = b0>>5, adds motion_seconds + low_intensity,
+     *  masks intensities to 0x3f). */
+    const val SCHEMA = 2
 
     /**
      * One JSONL record (NO trailing newline — the writer adds it). `deviceId` is a controlled registry id
@@ -25,9 +27,10 @@ object OuraMotionDumpLine {
      *   - ringTs:        the record's raw ring-clock timestamp (the dedup key: strictly increases per record).
      *   - utc:           the anchored wall-clock (unix seconds) for the record envelope.
      *   - iso:           human-readable UTC of `utc` (convenience for eyeballing).
-     *   - orientation:   0..3 orientation code (record byte0 low 2 bits).
+     *   - orientation:   0..7 orientation code (record byte0 >> 5).
+     *   - motionSeconds: seconds of motion in the window (record byte0 & 0x1f, 0..31).
      *   - x/y/z:         the ring's averaged accel vector, signed record byte × 8 (open_oura convention).
-     *   - highIntensity: the period's high-intensity count (record byte5).
+     *   - low/highIntensity: period intensity counts (record byte4/byte5 & 0x3f); null ⇒ JSON `null`.
      */
     fun encode(
         deviceId: String,
@@ -35,13 +38,18 @@ object OuraMotionDumpLine {
         utc: Long,
         iso: String,
         orientation: Int,
+        motionSeconds: Int,
         x: Int,
         y: Int,
         z: Int,
-        highIntensity: Int,
+        lowIntensity: Int?,
+        highIntensity: Int?,
     ): String {
+        val lo = lowIntensity?.toString() ?: "null"
+        val hi = highIntensity?.toString() ?: "null"
         return "{\"schema\":$SCHEMA,\"deviceId\":\"$deviceId\",\"ringTs\":$ringTs," +
             "\"utc\":$utc,\"iso\":\"$iso\",\"orientation\":$orientation," +
-            "\"x\":$x,\"y\":$y,\"z\":$z,\"high_intensity\":$highIntensity}"
+            "\"motion_seconds\":$motionSeconds,\"x\":$x,\"y\":$y,\"z\":$z," +
+            "\"low_intensity\":$lo,\"high_intensity\":$hi}"
     }
 }

--- a/android/app/src/test/java/com/noop/oura/DecoderGoldenTest.kt
+++ b/android/app/src/test/java/com/noop/oura/DecoderGoldenTest.kt
@@ -187,32 +187,51 @@ class DecoderGoldenTest {
 
     @Test
     fun testMotionEvents0x47() {
-        // open_oura decode_motion vector: body [0x6f,0x0c,0x1d,0x07,0x0c,0x07] →
-        // orientation 3, avg x/y/z = 12/29/7 signed ×8, high_intensity 7.
+        // open_oura decode_motion vector [0x6f,0x0c,0x1d,0x07,0x0c,0x07]: orientation 0x6f>>5=3,
+        // motion_seconds 0x6f&0x1f=15, avg 96/232/56, low 12, high 7.
         val rec = OuraRecord(type = 0x47, ringTimestamp = rt,
             payload = intArrayOf(0x6f, 0x0c, 0x1d, 0x07, 0x0c, 0x07))
         assertEquals(
-            OuraMotionEvent(ringTimestamp = rt, orientation = 3,
-                avgX = 96, avgY = 232, avgZ = 56, highIntensity = 7),
+            OuraMotionEvent(ringTimestamp = rt, orientation = 3, motionSeconds = 15,
+                avgX = 96, avgY = 232, avgZ = 56, lowIntensity = 12, highIntensity = 7),
             OuraDecoders.decodeMotionEvents(rec),
         )
     }
 
     @Test
-    fun testMotionEvents0x47SignedAxes() {
-        // Negative axis bytes prove the ×8 sign extension: 0xF4 = -12 → -96, 0x80 = -128 → -1024.
+    fun testMotionEvents0x47DiscriminatesOrientationFromMotionSeconds() {
+        // byte0 0xB5 = 1011_0101: orientation 0xB5>>5=5 (NOT &0x03=1), motion_seconds 0x15=21.
+        // Negative axes prove ×8 sign; byte4 0x2A → low 42; byte5 0x3F → high 63 (max valid).
         val rec = OuraRecord(type = 0x47, ringTimestamp = rt,
-            payload = intArrayOf(0x00, 0xF4, 0x00, 0x80, 0x00, 0x00))
-        val m = OuraDecoders.decodeMotionEvents(rec)
-        assertEquals(-96, m?.avgX)
-        assertEquals(-1024, m?.avgZ)
-        assertEquals(0, m?.orientation)
+            payload = intArrayOf(0xB5, 0xF4, 0x00, 0x80, 0x2A, 0x3F))
+        assertEquals(
+            OuraMotionEvent(ringTimestamp = rt, orientation = 5, motionSeconds = 21,
+                avgX = -96, avgY = 0, avgZ = -1024, lowIntensity = 42, highIntensity = 63),
+            OuraDecoders.decodeMotionEvents(rec),
+        )
     }
 
     @Test
-    fun testMotionEvents0x47ShortBodyIsNull() {
+    fun testMotionEvents0x47IntensityValidityBitRejectsRecord() {
+        // A set 0x40 bit in an intensity byte means INVALID per open_oura → whole record decodes null.
         assertNull(OuraDecoders.decodeMotionEvents(
-            OuraRecord(type = 0x47, ringTimestamp = rt, payload = intArrayOf(0x6f, 0x0c))))
+            OuraRecord(type = 0x47, ringTimestamp = rt, payload = intArrayOf(0x00, 0, 0, 0, 0x00, 0x47))))
+        assertNull(OuraDecoders.decodeMotionEvents(
+            OuraRecord(type = 0x47, ringTimestamp = rt, payload = intArrayOf(0x00, 0, 0, 0, 0x40, 0x00))))
+    }
+
+    @Test
+    fun testMotionEvents0x47OptionalIntensityAndShortBody() {
+        // A 4-byte record is valid; intensities null.
+        assertEquals(
+            OuraMotionEvent(ringTimestamp = rt, orientation = 1, motionSeconds = 0,
+                avgX = 80, avgY = 0, avgZ = 0, lowIntensity = null, highIntensity = null),
+            OuraDecoders.decodeMotionEvents(
+                OuraRecord(type = 0x47, ringTimestamp = rt, payload = intArrayOf(0x20, 0x0a, 0x00, 0x00))),
+        )
+        // A 3-byte body is too short → null.
+        assertNull(OuraDecoders.decodeMotionEvents(
+            OuraRecord(type = 0x47, ringTimestamp = rt, payload = intArrayOf(0x6f, 0x0c, 0x1d))))
     }
 
     // MARK: - 0x85 RTC beacon (unix_s u32 LE)

--- a/android/app/src/test/java/com/noop/oura/DecoderGoldenTest.kt
+++ b/android/app/src/test/java/com/noop/oura/DecoderGoldenTest.kt
@@ -183,6 +183,38 @@ class DecoderGoldenTest {
         )
     }
 
+    // MARK: - 0x47 motion events (averaged accel vector)
+
+    @Test
+    fun testMotionEvents0x47() {
+        // open_oura decode_motion vector: body [0x6f,0x0c,0x1d,0x07,0x0c,0x07] →
+        // orientation 3, avg x/y/z = 12/29/7 signed ×8, high_intensity 7.
+        val rec = OuraRecord(type = 0x47, ringTimestamp = rt,
+            payload = intArrayOf(0x6f, 0x0c, 0x1d, 0x07, 0x0c, 0x07))
+        assertEquals(
+            OuraMotionEvent(ringTimestamp = rt, orientation = 3,
+                avgX = 96, avgY = 232, avgZ = 56, highIntensity = 7),
+            OuraDecoders.decodeMotionEvents(rec),
+        )
+    }
+
+    @Test
+    fun testMotionEvents0x47SignedAxes() {
+        // Negative axis bytes prove the ×8 sign extension: 0xF4 = -12 → -96, 0x80 = -128 → -1024.
+        val rec = OuraRecord(type = 0x47, ringTimestamp = rt,
+            payload = intArrayOf(0x00, 0xF4, 0x00, 0x80, 0x00, 0x00))
+        val m = OuraDecoders.decodeMotionEvents(rec)
+        assertEquals(-96, m?.avgX)
+        assertEquals(-1024, m?.avgZ)
+        assertEquals(0, m?.orientation)
+    }
+
+    @Test
+    fun testMotionEvents0x47ShortBodyIsNull() {
+        assertNull(OuraDecoders.decodeMotionEvents(
+            OuraRecord(type = 0x47, ringTimestamp = rt, payload = intArrayOf(0x6f, 0x0c))))
+    }
+
     // MARK: - 0x85 RTC beacon (unix_s u32 LE)
 
     @Test


### PR DESCRIPTION
The ring streams 0x47 motion_events densely (~10k frames/capture) but NOOP decoded them to nothing ("state-free motion out of v1 scope"). Per open_oura's decode_motion, 0x47 is actually the ring's averaged accelerometer vector for the period — the same shape as a WHOOP 4.0 gravity sample:

  byte0 low 2 bits = orientation (0..3)
  byte1/2/3        = avg X/Y/Z, signed int8 x 8
  byte5            = high_intensity count
  byte4            = unidentified (present, not surfaced)

Add OuraMotionEvent + OuraDecoders.decodeMotionEvents(0x47) and emit it as a Tier-A OuraEvent (Swift .motionEvent / Kotlin MotionVectorEvent). Distinct from the existing 0x6b motion_period (2-bit state codes).

Held at the mapping boundary for now: OuraStreamMapping decodes it but does NOT yet write a gravitySample — the LSB->g scale the sleep stager's 0.01 g stillness threshold needs is an unresolved calibration (issue ryanbr/noop#804). Mapping it with a guessed scale would feed staging a wrong signal, so it is dropped, not faked, until the scale + cadence are pinned from a real capture. Once mapped, the whole existing motion pipeline (SleepStager, the "Motion" chart, wake refinement, sedentary) lights up for an Oura ring unchanged.

Both platforms, byte-identical. Fixture-tested against the exact open_oura decode_motion vector [0x6f,0x0c,0x1d,0x07,0x0c,0x07] -> orient 3, xyz 96/232/56, hi 7, plus a signed-axes case and a short-body nil.

Swift: OuraProtocol 158/0, WhoopStore builds. Kotlin: main compiles, DecoderGoldenTest 24/24. No new i18n strings. Toward ryanbr/noop#804.

