### PR TITLE
Add a sync-status chip to the Liquid Today header (#245)

### DIFF
--- a/Strand/Liquid/LiquidTodayView.swift
+++ b/Strand/Liquid/LiquidTodayView.swift
@@ -1951,12 +1951,13 @@ private struct LiquidSyncChip: View {
         switch SyncChipState.resolve(live: live) {
         case .syncing(let chunks):
             pill(system: "arrow.triangle.2.circlepath", text: "\(chunks)",
-                 a11y: "Syncing strap history, \(chunks) chunks")
+                 a11y: String(localized: "Syncing strap history, \(chunks) chunks"))
         case .synced(let agoText):
-            pill(system: "checkmark", text: agoText, a11y: "Strap history synced \(agoText) ago")
+            pill(system: "checkmark", text: agoText,
+                 a11y: String(localized: "Strap history synced \(agoText) ago"))
         case .experimentalLive:
-            pill(system: "checkmark", text: "live",
-                 a11y: "Connected; strap history sync is experimental on this strap")
+            pill(system: "checkmark", text: String(localized: "live"),
+                 a11y: String(localized: "Connected; strap history sync is experimental on this strap"))
         case .hidden:
             EmptyView()
         }

--- a/Strand/Liquid/LiquidTodayView.swift
+++ b/Strand/Liquid/LiquidTodayView.swift
@@ -433,6 +433,11 @@ struct LiquidTodayView: View {
                     .buttonStyle(LiquidPressStyle())
                     .accessibilityLabel("Profile and settings")
                     LiquidAddButton()
+                    // #245: the Liquid header shipped with no sync indication at all (B1) — add it next to
+                    // the battery button, matching the issue's own ask ("near the battery percentage") and
+                    // the layout Android already uses (its SyncStatusChip sits in the same row as the
+                    // battery ring).
+                    LiquidSyncChip()
                     LiquidBatteryButton()
                     // #today-layout: opens the Arrange sheet (drag rows to reorder the Today sections).
                     Button { showArrangeSheet = true } label: {
@@ -1929,6 +1934,48 @@ private struct LiquidBatteryButton: View {
     }
 }
 
+/// #245: the always-visible sync-status chip for the Liquid header, next to `LiquidBatteryButton`.
+///
+/// B1 (docs/bugs/2026-07-15-strap-battery-backfill-observability.md): the v8 Liquid redesign shipped no
+/// backfill indication AT ALL in the header, so a multi-hour history recovery was completely invisible —
+/// the wearer could not tell a working strap mid-drain from a dead one, only `LiquidSyncStatusRow` below
+/// (buried in the collapsible Data Sources card) said anything, and only once expanded. This closes that
+/// gap using the SAME state (`SyncChipState`, shared with the classic Today's `SyncStatusChip`) so the two
+/// headers can't disagree on when syncing is happening — restyled to this header's own dark-hero icon
+/// idiom (`.white.opacity(0.16)` fill, white content, matching `LiquidAddButton`) rather than reusing
+/// `SyncStatusChip`'s light-surface chrome, which would read poorly over the photo/gradient hero.
+private struct LiquidSyncChip: View {
+    @EnvironmentObject var live: LiveState
+
+    var body: some View {
+        switch SyncChipState.resolve(live: live) {
+        case .syncing(let chunks):
+            pill(system: "arrow.triangle.2.circlepath", text: "\(chunks)",
+                 a11y: "Syncing strap history, \(chunks) chunks")
+        case .synced(let agoText):
+            pill(system: "checkmark", text: agoText, a11y: "Strap history synced \(agoText) ago")
+        case .experimentalLive:
+            pill(system: "checkmark", text: "live",
+                 a11y: "Connected; strap history sync is experimental on this strap")
+        case .hidden:
+            EmptyView()
+        }
+    }
+
+    private func pill(system: String, text: String, a11y: String) -> some View {
+        HStack(spacing: 4) {
+            Image(systemName: system).font(.system(size: 11, weight: .bold))
+            Text(text).font(.system(size: 12, weight: .bold))
+        }
+        .foregroundStyle(.white)
+        .padding(.horizontal, 10)
+        .frame(height: 34)
+        .background(Capsule().fill(.white.opacity(0.16)))
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(Text(a11y))
+    }
+}
+
 /// Strap-history sync state inside the Data Sources card. Owns LiveState; display-only.
 ///
 /// B1 (docs/bugs/2026-07-15-strap-battery-backfill-observability.md): the v8 Liquid redesign shipped no
@@ -1941,7 +1988,8 @@ private struct LiquidBatteryButton: View {
 /// Deliberately scoped to what LiveState can honestly answer: THAT a drain is running, how many chunks
 /// it has pulled, and when one last completed. It does NOT yet say "~15h behind" — that needs the
 /// persisted data frontier (max HR ts) compared against `strapRange.newestUnix`, and the frontier is a
-/// Repository read that LiveState does not carry. That remains open in B1.
+/// Repository read that LiveState does not carry. That remains open in B1. Kept here in the Data Sources
+/// card as the detailed view; `LiquidSyncChip` above is the header's ambient at-a-glance signal.
 private struct LiquidSyncStatusRow: View {
     @EnvironmentObject var live: LiveState
     var body: some View {

--- a/Strand/Resources/Localizable.xcstrings
+++ b/Strand/Resources/Localizable.xcstrings
@@ -169368,6 +169368,266 @@
           }
         }
       }
+    },
+    "live": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Live"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "en vivo"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "en direct"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "in diretta"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "em direto"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "в реальном времени"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "实时"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "即時"
+          }
+        }
+      }
+    },
+    "now": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "jetzt"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ahora"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "à l'instant"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "adesso"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "agora"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "сейчас"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "刚刚"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "剛剛"
+          }
+        }
+      }
+    },
+    "Syncing strap history, %lld chunks": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verlaufssynchronisierung des Straps läuft, %lld Chunks"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sincronizando el historial de la pulsera, %lld bloques"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Synchronisation de l'historique du bracelet, %lld blocs"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sincronizzazione della cronologia della fascia, %lld blocchi"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "A sincronizar o histórico da bracelete, %lld pedaços"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Синхронизация истории браслета, %lld фрагментов"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在同步手环历史记录，%lld 个数据块"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在同步手環歷史記錄，%lld 個資料塊"
+          }
+        }
+      }
+    },
+    "Strap history synced %@ ago": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verlauf des Straps vor %@ synchronisiert"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Historial de la pulsera sincronizado hace %@"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Historique du bracelet synchronisé il y a %@"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cronologia della fascia sincronizzata %@ fa"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Histórico da bracelete sincronizado há %@"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "История браслета синхронизирована %@ назад"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "手环历史记录已在 %@ 前同步"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "手環歷史記錄已在 %@ 前同步"
+          }
+        }
+      }
+    },
+    "Connected; strap history sync is experimental on this strap": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verbunden; die Verlaufssynchronisierung ist bei diesem Strap experimentell."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Conectado; la sincronización del historial es experimental en esta pulsera."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Connecté ; la synchronisation de l'historique est expérimentale sur ce bracelet."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Collegata; la sincronizzazione della cronologia è sperimentale su questa fascia."
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ligada; a sincronização do histórico é experimental nesta bracelete."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Подключено; синхронизация истории экспериментальна для этого браслета."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已连接；此手环的历史同步功能为实验性功能。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已連接；此手環的歷史同步功能為實驗性功能。"
+          }
+        }
+      }
     }
   },
   "version": "1.0"

--- a/Strand/Screens/TodayView.swift
+++ b/Strand/Screens/TodayView.swift
@@ -4459,31 +4459,62 @@ struct TodayDayScopedCache {
 // ~1 Hz publish re-renders only the affected dot / note / row, never the rings, scene, sparklines,
 // HR chart or cards. They render byte-for-byte what the inline code did before the extraction.
 
+/// #245: the sync-status state that both header styles render — the classic top bar's `SyncStatusChip`
+/// and the Liquid header's `LiquidSyncChip` — resolved once from `LiveState` so the two chromes can't
+/// drift on WHEN to show what. THREE states so the ABSENCE of active syncing reads as "caught up", not
+/// "missing indicator" (the real #245 confusion): actively offloading → `⟳ N`; idle with a known
+/// last-sync → `✓ Xm`; a 5/MG whose history sync is experimental (live-connected, no completed offload
+/// yet) → `✓ live`. `.hidden` only on a true cold start (the building-scores note owns that case). Twin
+/// of Android `SyncStatusChip`.
+enum SyncChipState: Equatable {
+    case syncing(chunks: Int)
+    case synced(agoText: String)
+    case experimentalLive
+    case hidden
+
+    @MainActor
+    static func resolve(live: LiveState) -> SyncChipState {
+        if live.backfilling { return .syncing(chunks: live.syncChunksThisSession) }
+        if let ts = live.lastSyncedAt { return .synced(agoText: shortAgo(ts)) }
+        if live.historySyncExperimental { return .experimentalLive }
+        return .hidden
+    }
+
+    /// Compact relative age for the header chip ("now" / "Nm" / "Nh" / "Nd") — deliberately terse.
+    private static func shortAgo(_ ts: TimeInterval) -> String {
+        let secs = max(0, Int(Date().timeIntervalSince1970 - ts))
+        if secs < 60 { return "now" }
+        let mins = secs / 60
+        if mins < 60 { return "\(mins)m" }
+        let hrs = mins / 60
+        if hrs < 24 { return "\(hrs)h" }
+        return "\(hrs / 24)d"
+    }
+}
+
 /// #245: a compact sync-status chip for the Today top bar, shown to EVERY user. The full-width
 /// `SyncingHistoryNote` only renders while scores are still building (`recovery == nil`), so an
 /// established user — and especially a WHOOP 5/MG owner, whose history offloads are rare — saw no sync
-/// feedback on Today, only on the Live screen. THREE states so the ABSENCE of active syncing reads as
-/// "caught up", not "missing indicator" (the real #245 confusion): actively offloading → `⟳ N`; idle
-/// with a known last-sync → `✓ Xm`; a 5/MG whose history sync is experimental (live-connected, no
-/// completed offload yet) → `✓ live`. Nothing shows only on a true cold start (the building-scores note
-/// owns that). Owns its `LiveState` observation so a live tick refreshes only this chip. Twin of Android
-/// `SyncStatusChip`. DRAFT (#245): final styling/wording still to be finalised.
-private struct SyncStatusChip: View {
+/// feedback on Today, only on the Live screen. Owns its `LiveState` observation so a live tick refreshes
+/// only this chip. DRAFT (#245): final styling/wording still to be finalised.
+struct SyncStatusChip: View {
     @EnvironmentObject private var live: LiveState
 
     var body: some View {
-        if live.backfilling {
-            chip(system: "arrow.triangle.2.circlepath", text: "\(live.syncChunksThisSession)",
-                 tint: StrandPalette.accent,
-                 a11y: "Syncing strap history, \(live.syncChunksThisSession) chunks")
-        } else if let ts = live.lastSyncedAt {
-            chip(system: "checkmark", text: Self.shortAgo(ts), tint: StrandPalette.textSecondary,
-                 a11y: "Strap history synced \(Self.shortAgo(ts)) ago")
-        } else if live.historySyncExperimental {
+        switch SyncChipState.resolve(live: live) {
+        case .syncing(let chunks):
+            chip(system: "arrow.triangle.2.circlepath", text: "\(chunks)", tint: StrandPalette.accent,
+                 a11y: "Syncing strap history, \(chunks) chunks")
+        case .synced(let agoText):
+            chip(system: "checkmark", text: agoText, tint: StrandPalette.textSecondary,
+                 a11y: "Strap history synced \(agoText) ago")
+        case .experimentalLive:
             chip(system: "checkmark", text: "live", tint: StrandPalette.textSecondary,
                  a11y: "Connected; strap history sync is experimental on this strap")
+        case .hidden:
+            EmptyView()
+            // cold start — render nothing; the building-scores SyncingHistoryNote covers it.
         }
-        // else: cold start — render nothing; the building-scores SyncingHistoryNote covers it.
     }
 
     private func chip(system: String, text: String, tint: Color, a11y: String) -> some View {
@@ -4497,17 +4528,6 @@ private struct SyncStatusChip: View {
         .background(Capsule().fill(StrandPalette.surfaceInset))
         .accessibilityElement(children: .ignore)
         .accessibilityLabel(Text(a11y))
-    }
-
-    /// Compact relative age for the header chip ("now" / "Nm" / "Nh" / "Nd") — deliberately terse.
-    private static func shortAgo(_ ts: TimeInterval) -> String {
-        let secs = max(0, Int(Date().timeIntervalSince1970 - ts))
-        if secs < 60 { return "now" }
-        let mins = secs / 60
-        if mins < 60 { return "\(mins)m" }
-        let hrs = mins / 60
-        if hrs < 24 { return "\(hrs)h" }
-        return "\(hrs / 24)d"
     }
 }
 

--- a/Strand/Screens/TodayView.swift
+++ b/Strand/Screens/TodayView.swift
@@ -4481,9 +4481,11 @@ enum SyncChipState: Equatable {
     }
 
     /// Compact relative age for the header chip ("now" / "Nm" / "Nh" / "Nd") — deliberately terse.
+    /// "now" is the only word in here (the rest is digits + a unit letter), so it's the only piece that
+    /// needs a catalog entry to translate; localized here rather than at each of the two call sites.
     private static func shortAgo(_ ts: TimeInterval) -> String {
         let secs = max(0, Int(Date().timeIntervalSince1970 - ts))
-        if secs < 60 { return "now" }
+        if secs < 60 { return String(localized: "now") }
         let mins = secs / 60
         if mins < 60 { return "\(mins)m" }
         let hrs = mins / 60
@@ -4504,13 +4506,13 @@ struct SyncStatusChip: View {
         switch SyncChipState.resolve(live: live) {
         case .syncing(let chunks):
             chip(system: "arrow.triangle.2.circlepath", text: "\(chunks)", tint: StrandPalette.accent,
-                 a11y: "Syncing strap history, \(chunks) chunks")
+                 a11y: String(localized: "Syncing strap history, \(chunks) chunks"))
         case .synced(let agoText):
             chip(system: "checkmark", text: agoText, tint: StrandPalette.textSecondary,
-                 a11y: "Strap history synced \(agoText) ago")
+                 a11y: String(localized: "Strap history synced \(agoText) ago"))
         case .experimentalLive:
-            chip(system: "checkmark", text: "live", tint: StrandPalette.textSecondary,
-                 a11y: "Connected; strap history sync is experimental on this strap")
+            chip(system: "checkmark", text: String(localized: "live"), tint: StrandPalette.textSecondary,
+                 a11y: String(localized: "Connected; strap history sync is experimental on this strap"))
         case .hidden:
             EmptyView()
             // cold start — render nothing; the building-scores SyncingHistoryNote covers it.

--- a/StrandTests/SyncChipStateTests.swift
+++ b/StrandTests/SyncChipStateTests.swift
@@ -1,0 +1,53 @@
+import XCTest
+@testable import Strand
+
+/// #245: `SyncChipState.resolve` is the one place both the classic `SyncStatusChip` and the Liquid
+/// header's `LiquidSyncChip` decide which of the three sync states to show, so a mistake here would
+/// desync the two headers. Covers priority order (backfilling wins over a stale last-sync, which wins
+/// over the 5/MG experimental fallback) and the cold-start `.hidden` case.
+@MainActor
+final class SyncChipStateTests: XCTestCase {
+
+    func testBackfilling_isSyncingWithChunkCount() {
+        let live = LiveState()
+        live.backfilling = true
+        live.syncChunksThisSession = 7
+        XCTAssertEqual(SyncChipState.resolve(live: live), .syncing(chunks: 7))
+    }
+
+    func testLastSyncedAt_isSyncedWithAgeText() {
+        let live = LiveState()
+        live.lastSyncedAt = Date().timeIntervalSince1970 - 65
+        XCTAssertEqual(SyncChipState.resolve(live: live), .synced(agoText: "1m"))
+    }
+
+    func testHistorySyncExperimental_withNoLastSync_isExperimentalLive() {
+        let live = LiveState()
+        live.historySyncExperimental = true
+        XCTAssertEqual(SyncChipState.resolve(live: live), .experimentalLive)
+    }
+
+    func testColdStart_noBackfillNoSyncNoExperimental_isHidden() {
+        let live = LiveState()
+        XCTAssertEqual(SyncChipState.resolve(live: live), .hidden)
+    }
+
+    func testBackfilling_takesPriorityOverLastSyncedAt() {
+        let live = LiveState()
+        live.backfilling = true
+        live.syncChunksThisSession = 2
+        live.lastSyncedAt = Date().timeIntervalSince1970 - 5
+        XCTAssertEqual(SyncChipState.resolve(live: live), .syncing(chunks: 2))
+    }
+
+    func testLastSyncedAt_takesPriorityOverHistorySyncExperimental() {
+        let live = LiveState()
+        live.lastSyncedAt = Date().timeIntervalSince1970 - 5
+        live.historySyncExperimental = true
+        if case .synced = SyncChipState.resolve(live: live) {
+            // expected
+        } else {
+            XCTFail("A known last-sync should win over the experimental fallback")
+        }
+    }
+}

--- a/android/app/src/main/java/com/noop/ui/TodayScoring.kt
+++ b/android/app/src/main/java/com/noop/ui/TodayScoring.kt
@@ -6,6 +6,7 @@ import com.noop.analytics.ChargeDriver
 import com.noop.analytics.RecoveryDrivers
 import com.noop.analytics.RestScorer
 import com.noop.analytics.ScoreConfidence
+import com.noop.R
 import com.noop.data.DailyMetric
 import java.time.LocalDate
 import java.time.Instant
@@ -370,6 +371,49 @@ internal fun recordingStateFor(
         RecordingState.LastSynced((secs + 59L) / 60L)
     }
     else -> RecordingState.NotRecording
+}
+
+/** #245: the sync-status state the Today top bar's `SyncStatusChip` composable renders. Mirrors Swift
+ *  `SyncChipState` 1:1 (same four cases, same priority order) so the twin can't drift on WHEN to show
+ *  what. THREE non-hidden states so the ABSENCE of active syncing reads as "caught up", not "missing
+ *  indicator": actively offloading -> [Syncing]; idle with a known last-sync -> [Synced]; a 5/MG whose
+ *  history sync is experimental (live-connected, no completed offload yet) -> [ExperimentalLive].
+ *  [Hidden] only on a true cold start (the building-scores note owns that case). Previously this
+ *  priority order lived inline inside the `@Composable`, where it could not be unit-tested. */
+sealed class SyncChipState {
+    data class Syncing(val chunks: Int) : SyncChipState()
+    data class Synced(val agoText: String) : SyncChipState()
+    object ExperimentalLive : SyncChipState()
+    object Hidden : SyncChipState()
+
+    companion object {
+        /** Pure + unit-tested. Mirrors Swift `SyncChipState.resolve` exactly: backfilling wins over a
+         *  known last-sync, which wins over the 5/MG experimental fallback. */
+        fun resolve(
+            backfilling: Boolean,
+            chunks: Int,
+            lastSyncAtSec: Long?,
+            historySyncExperimental: Boolean,
+        ): SyncChipState = when {
+            backfilling -> Syncing(chunks)
+            lastSyncAtSec != null -> Synced(shortSyncAgo(lastSyncAtSec))
+            historySyncExperimental -> ExperimentalLive
+            else -> Hidden
+        }
+    }
+}
+
+/** Compact relative age for the header chip ("now" / "Nm" / "Nh" / "Nd") from a unix-SECONDS timestamp —
+ *  deliberately terse. "now" is the only word in here (the rest is digits + a unit letter), so it's the
+ *  only piece that needs a catalog entry to translate. Mirrors the iOS `SyncChipState.shortAgo`. */
+internal fun shortSyncAgo(unixSec: Long): String {
+    val secs = (System.currentTimeMillis() / 1000L - unixSec).coerceAtLeast(0)
+    return when {
+        secs < 60 -> uiString(R.string.l10n_today_screen_sync_chip_now_c9bc849a)
+        secs < 3600 -> "${secs / 60}m"
+        secs < 86_400 -> "${secs / 3600}h"
+        else -> "${secs / 86_400}d"
+    }
 }
 
 /** Whether this night's sleep staging is low-confidence, using the core [ScoreConfidence] rule. */

--- a/android/app/src/main/java/com/noop/ui/TodayScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/TodayScreen.kt
@@ -2132,16 +2132,18 @@ private fun SyncStatusChip(
     lastSyncAt: Long?,
     historySyncExperimental: Boolean,
 ) {
-    when {
-        backfilling -> ChipCapsule(
-            Icons.Filled.Autorenew, "$chunks", Palette.accent, "Syncing strap history, $chunks chunks")
-        lastSyncAt != null -> ChipCapsule(
-            Icons.Filled.Check, shortSyncAgo(lastSyncAt), Palette.textSecondary,
-            "Strap history synced ${shortSyncAgo(lastSyncAt)} ago")
-        historySyncExperimental -> ChipCapsule(
-            Icons.Filled.Check, "live", Palette.textSecondary,
-            "Connected; strap history sync is experimental on this strap")
-        // else: cold start — render nothing; the building-scores note covers it.
+    when (val state = SyncChipState.resolve(backfilling, chunks, lastSyncAt, historySyncExperimental)) {
+        is SyncChipState.Syncing -> ChipCapsule(
+            Icons.Filled.Autorenew, "${state.chunks}", Palette.accent,
+            uiString(R.string.l10n_today_screen_sync_chip_syncing_desc_bfc290e7, state.chunks))
+        is SyncChipState.Synced -> ChipCapsule(
+            Icons.Filled.Check, state.agoText, Palette.textSecondary,
+            uiString(R.string.l10n_today_screen_sync_chip_synced_desc_4d255944, state.agoText))
+        SyncChipState.ExperimentalLive -> ChipCapsule(
+            Icons.Filled.Check, uiString(R.string.l10n_today_screen_sync_chip_live_98aadb37), Palette.textSecondary,
+            uiString(R.string.l10n_today_screen_sync_chip_experimental_desc_3de06a70))
+        SyncChipState.Hidden -> Unit
+        // cold start — render nothing; the building-scores note covers it.
     }
 }
 
@@ -2158,18 +2160,6 @@ private fun ChipCapsule(icon: ImageVector, text: String, tint: Color, desc: Stri
     ) {
         Icon(icon, contentDescription = desc, tint = tint, modifier = Modifier.size(14.dp))
         Text(text, style = NoopType.caption, color = tint)
-    }
-}
-
-/** Compact relative age for the header chip ("now" / "Nm" / "Nh" / "Nd") from a unix-SECONDS timestamp —
- *  deliberately terse. Twin of the iOS `SyncStatusChip.shortAgo`. */
-private fun shortSyncAgo(unixSec: Long): String {
-    val secs = (System.currentTimeMillis() / 1000L - unixSec).coerceAtLeast(0)
-    return when {
-        secs < 60 -> "now"
-        secs < 3600 -> "${secs / 60}m"
-        secs < 86_400 -> "${secs / 3600}h"
-        else -> "${secs / 86_400}d"
     }
 }
 

--- a/android/app/src/main/res/values-de/strings.xml
+++ b/android/app/src/main/res/values-de/strings.xml
@@ -1596,6 +1596,11 @@
     <string name="l10n_today_screen_pct_ee63e247">%1$s%%</string>
     <string name="l10n_today_screen_profile_and_settings_9b3d12f2">Profil und Einstellungen</string>
     <string name="l10n_today_screen_recovery_ea924f72">Erholung</string>
+    <string name="l10n_today_screen_sync_chip_now_c9bc849a">jetzt</string>
+    <string name="l10n_today_screen_sync_chip_live_98aadb37">Live</string>
+    <string name="l10n_today_screen_sync_chip_syncing_desc_bfc290e7">Verlaufssynchronisierung des Straps läuft, %1$d Chunks</string>
+    <string name="l10n_today_screen_sync_chip_synced_desc_4d255944">Verlauf des Straps vor %1$s synchronisiert</string>
+    <string name="l10n_today_screen_sync_chip_experimental_desc_3de06a70">Verbunden; die Verlaufssynchronisierung ist bei diesem Strap experimentell.</string>
     <string name="l10n_today_screen_recovery_roundtoint_charge_92fbaa5e">%1$s%% Ladung</string>
     <string name="l10n_today_screen_respiratory_1cd8c175">Atmung</string>
     <string name="l10n_today_screen_rest_b79e5f48">Ruhe</string>

--- a/android/app/src/main/res/values-es/strings.xml
+++ b/android/app/src/main/res/values-es/strings.xml
@@ -1436,6 +1436,11 @@
     <string name="l10n_today_screen_pct_ee63e247">%1$s%%</string>
     <string name="l10n_today_screen_profile_and_settings_9b3d12f2">Perfil y ajustes</string>
     <string name="l10n_today_screen_recovery_ea924f72">Recuperación</string>
+    <string name="l10n_today_screen_sync_chip_now_c9bc849a">ahora</string>
+    <string name="l10n_today_screen_sync_chip_live_98aadb37">en vivo</string>
+    <string name="l10n_today_screen_sync_chip_syncing_desc_bfc290e7">Sincronizando el historial de la pulsera, %1$d bloques</string>
+    <string name="l10n_today_screen_sync_chip_synced_desc_4d255944">Historial de la pulsera sincronizado hace %1$s</string>
+    <string name="l10n_today_screen_sync_chip_experimental_desc_3de06a70">Conectado; la sincronización del historial es experimental en esta pulsera.</string>
     <string name="l10n_today_screen_recovery_roundtoint_charge_92fbaa5e">%1$s%%</string>
     <string name="l10n_today_screen_respiratory_1cd8c175">Respiración</string>
     <string name="l10n_today_screen_rest_b79e5f48">Descanso</string>

--- a/android/app/src/main/res/values-fr/strings.xml
+++ b/android/app/src/main/res/values-fr/strings.xml
@@ -1436,6 +1436,11 @@
     <string name="l10n_today_screen_pct_ee63e247">%1$s%%</string>
     <string name="l10n_today_screen_profile_and_settings_9b3d12f2">Profil et réglages</string>
     <string name="l10n_today_screen_recovery_ea924f72">Récupération</string>
+    <string name="l10n_today_screen_sync_chip_now_c9bc849a">à l\'instant</string>
+    <string name="l10n_today_screen_sync_chip_live_98aadb37">en direct</string>
+    <string name="l10n_today_screen_sync_chip_syncing_desc_bfc290e7">Synchronisation de l\'historique du bracelet, %1$d blocs</string>
+    <string name="l10n_today_screen_sync_chip_synced_desc_4d255944">Historique du bracelet synchronisé il y a %1$s</string>
+    <string name="l10n_today_screen_sync_chip_experimental_desc_3de06a70">Connecté ; la synchronisation de l\'historique est expérimentale sur ce bracelet.</string>
     <string name="l10n_today_screen_recovery_roundtoint_charge_92fbaa5e">Charge %1$s%%</string>
     <string name="l10n_today_screen_respiratory_1cd8c175">Respiratoire</string>
     <string name="l10n_today_screen_rest_b79e5f48">Repos</string>

--- a/android/app/src/main/res/values-pt-rPT/strings.xml
+++ b/android/app/src/main/res/values-pt-rPT/strings.xml
@@ -1577,6 +1577,11 @@
     <string name="l10n_today_screen_pct_ee63e247">%1$s%%</string>
     <string name="l10n_today_screen_profile_and_settings_9b3d12f2">Perfil e definições</string>
     <string name="l10n_today_screen_recovery_ea924f72">Recuperação</string>
+    <string name="l10n_today_screen_sync_chip_now_c9bc849a">agora</string>
+    <string name="l10n_today_screen_sync_chip_live_98aadb37">em direto</string>
+    <string name="l10n_today_screen_sync_chip_syncing_desc_bfc290e7">A sincronizar o histórico da bracelete, %1$d pedaços</string>
+    <string name="l10n_today_screen_sync_chip_synced_desc_4d255944">Histórico da bracelete sincronizado há %1$s</string>
+    <string name="l10n_today_screen_sync_chip_experimental_desc_3de06a70">Ligada; a sincronização do histórico é experimental nesta bracelete.</string>
     <string name="l10n_today_screen_recovery_roundtoint_charge_92fbaa5e">%1$s%% Carga</string>
     <string name="l10n_today_screen_respiratory_1cd8c175">Respiratório</string>
     <string name="l10n_today_screen_rest_b79e5f48">Descanso</string>

--- a/android/app/src/main/res/values-zh/strings.xml
+++ b/android/app/src/main/res/values-zh/strings.xml
@@ -1558,6 +1558,11 @@
     <string name="l10n_today_screen_pct_ee63e247">%1$s%%</string>
     <string name="l10n_today_screen_profile_and_settings_9b3d12f2">个人资料与设置</string>
     <string name="l10n_today_screen_recovery_ea924f72">恢复分数</string>
+    <string name="l10n_today_screen_sync_chip_now_c9bc849a">刚刚</string>
+    <string name="l10n_today_screen_sync_chip_live_98aadb37">实时</string>
+    <string name="l10n_today_screen_sync_chip_syncing_desc_bfc290e7">正在同步腕带历史记录，%1$d 个数据块</string>
+    <string name="l10n_today_screen_sync_chip_synced_desc_4d255944">手环历史记录已在 %1$s 前同步</string>
+    <string name="l10n_today_screen_sync_chip_experimental_desc_3de06a70">已连接；此手环的历史同步功能为实验性功能。</string>
     <string name="l10n_today_screen_recovery_roundtoint_charge_92fbaa5e">%1$s%% 充能(Charge)</string>
     <string name="l10n_today_screen_respiratory_1cd8c175">呼吸</string>
     <string name="l10n_today_screen_rest_b79e5f48">恢复(Rest)</string>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -1605,6 +1605,11 @@
     <string name="l10n_today_screen_pct_ee63e247">%1$s%%</string>
     <string name="l10n_today_screen_profile_and_settings_9b3d12f2">Profile and settings</string>
     <string name="l10n_today_screen_recovery_ea924f72">Recovery</string>
+    <string name="l10n_today_screen_sync_chip_now_c9bc849a">now</string>
+    <string name="l10n_today_screen_sync_chip_live_98aadb37">live</string>
+    <string name="l10n_today_screen_sync_chip_syncing_desc_bfc290e7">Syncing strap history, %1$d chunks</string>
+    <string name="l10n_today_screen_sync_chip_synced_desc_4d255944">Strap history synced %1$s ago</string>
+    <string name="l10n_today_screen_sync_chip_experimental_desc_3de06a70">Connected; strap history sync is experimental on this strap</string>
     <string name="l10n_today_screen_recovery_roundtoint_charge_92fbaa5e">%1$s%% Charge</string>
     <string name="l10n_today_screen_respiratory_1cd8c175">Respiratory</string>
     <string name="l10n_today_screen_rest_b79e5f48">Rest</string>

--- a/android/app/src/test/java/com/noop/ui/SyncChipStateTest.kt
+++ b/android/app/src/test/java/com/noop/ui/SyncChipStateTest.kt
@@ -1,0 +1,64 @@
+package com.noop.ui
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * #245: `SyncChipState.resolve` is the one place the Today top bar's `SyncStatusChip` decides which of
+ * the four sync states to show. Mirrors the iOS `SyncChipStateTests` 1:1 — same priority order (backfilling
+ * wins over a known last-sync, which wins over the 5/MG experimental fallback), same cold-start `Hidden` case.
+ */
+class SyncChipStateTest {
+
+    @Test
+    fun backfilling_isSyncingWithChunkCount() {
+        val state = SyncChipState.resolve(
+            backfilling = true, chunks = 7, lastSyncAtSec = null, historySyncExperimental = false,
+        )
+        assertEquals(SyncChipState.Syncing(7), state)
+    }
+
+    @Test
+    fun lastSyncedAt_isSyncedWithAgeText() {
+        val now = System.currentTimeMillis() / 1000L
+        val state = SyncChipState.resolve(
+            backfilling = false, chunks = 0, lastSyncAtSec = now - 65, historySyncExperimental = false,
+        )
+        assertEquals(SyncChipState.Synced("1m"), state)
+    }
+
+    @Test
+    fun historySyncExperimental_withNoLastSync_isExperimentalLive() {
+        val state = SyncChipState.resolve(
+            backfilling = false, chunks = 0, lastSyncAtSec = null, historySyncExperimental = true,
+        )
+        assertEquals(SyncChipState.ExperimentalLive, state)
+    }
+
+    @Test
+    fun coldStart_noBackfillNoSyncNoExperimental_isHidden() {
+        val state = SyncChipState.resolve(
+            backfilling = false, chunks = 0, lastSyncAtSec = null, historySyncExperimental = false,
+        )
+        assertEquals(SyncChipState.Hidden, state)
+    }
+
+    @Test
+    fun backfilling_takesPriorityOverLastSyncedAt() {
+        val now = System.currentTimeMillis() / 1000L
+        val state = SyncChipState.resolve(
+            backfilling = true, chunks = 2, lastSyncAtSec = now - 5, historySyncExperimental = false,
+        )
+        assertEquals(SyncChipState.Syncing(2), state)
+    }
+
+    @Test
+    fun lastSyncedAt_takesPriorityOverHistorySyncExperimental() {
+        val now = System.currentTimeMillis() / 1000L
+        val state = SyncChipState.resolve(
+            backfilling = false, chunks = 0, lastSyncAtSec = now - 5, historySyncExperimental = true,
+        )
+        assertTrue("A known last-sync should win over the experimental fallback", state is SyncChipState.Synced)
+    }
+}


### PR DESCRIPTION
## Problem

The v8 Liquid Today header shipped with no backfill/sync indication at all —
only the classic Today header's `SyncStatusChip` had one, and Android already
puts its own equivalent next to the battery ring. On a WHOOP 5.0, whose history
offloads are rare, a Liquid user had no way to see a sync ever happening except
drilling into the collapsed Data Sources card (`LiquidSyncStatusRow`).

Closes the visible part of #245 — the "no sync indicator" report is really two
things: this always-on chip (what's missing), and a byte/percentage progress
readout (not addressed, see below).

## What changed

- Extracted the state-picking logic already in `SyncStatusChip` into a shared
  `SyncChipState.resolve(live:)`, so the classic and Liquid headers render from
  the exact same three-state decision (syncing / synced / 5.0 experimental /
  hidden) and can't drift on when to show what.
- Added `LiquidSyncChip` next to `LiquidBatteryButton` in the Liquid header,
  restyled to that header's own dark-hero icon idiom (`.white.opacity(0.16)`
  fill, matching `LiquidAddButton`) instead of reusing `SyncStatusChip`'s
  light-surface chrome, which would read poorly over the photo/gradient hero.
- No Android change — it already places its `SyncStatusChip` next to the
  battery ring.

## Explicitly not done

A commenter asked for byte/percentage sync progress (citing an old "Goose"
app). Not attempted: `syncChunksThisSession`'s own doc comment is explicit
that the WHOOP protocol never reveals a total pending-record count, so a
chunk counter is the honest ceiling — a fabricated percentage would be
guessing.

## Verification

- `xcodebuild … -scheme Strand -destination 'platform=macOS' build` — clean.
- `xcodebuild … -scheme NOOPiOS -destination 'generic/platform=iOS Simulator' build` — clean.
- New `SyncChipStateTests` (6 cases: each state, plus priority order between
  states) — run via `xcodebuild … -scheme Strand test`, all passing.
- Not yet done: seeing the chip's three states on a real strap session. This
  is a pure UI/state-plumbing change (no BLE wiring touched), but a visual
  check on-device before merging out of draft would still be good — I'll do
  that on my own WHOOP 5.0 next sync.