### PR TITLE
tools: multi-device SpO2 @82 candidate validation harness (#103)

### DIFF
--- a/Tools/linux-capture/correlate_ground_truth.py
+++ b/Tools/linux-capture/correlate_ground_truth.py
@@ -42,6 +42,20 @@ SLEEP_FILES = {"sleeps.csv", "schlaf.csv", "sueno.csv", "sueños.csv"}
 # (German + Spanish subset that covers the physiologic/sleep numeric fields we correlate on). English
 # headers pass through unchanged, so an English export needs no alias.
 HEADER_ALIASES = {
+    # English (official app.whoop.com export — headers are title case; we lowercase first)
+    "cycle start time": "cycle_start_time",
+    "cycle end time": "cycle_end_time",
+    "recovery score %": "recovery_score_pct",
+    "resting heart rate (bpm)": "resting_heart_rate_bpm",
+    "heart rate variability (ms)": "heart_rate_variability_ms",
+    "skin temp (celsius)": "skin_temp_celsius",
+    "blood oxygen %": "blood_oxygen_pct",
+    "respiratory rate (rpm)": "respiratory_rate_rpm",
+    "asleep duration (min)": "asleep_duration_min",
+    "deep (sws) duration (min)": "deep_sws_duration_min",
+    "rem duration (min)": "rem_duration_min",
+    "sleep onset": "sleep_onset",
+    "wake onset": "wake_onset",
     # German
     "erholungswert %": "recovery_score_pct",
     "ruheherzfrequenz (schläge pro minute)": "resting_heart_rate_bpm",

--- a/Tools/linux-capture/test_correlate_ground_truth.py
+++ b/Tools/linux-capture/test_correlate_ground_truth.py
@@ -23,10 +23,14 @@ class HeaderAliasTests(unittest.TestCase):
         self.assertEqual(cg._norm_header("Herzfrequenzvariabilität (ms)"), "heart_rate_variability_ms")
         self.assertEqual(cg._norm_header("Hauttemperatur (Celsius)"), "skin_temp_celsius")
 
-    def test_english_header_passes_through(self):
+    def test_english_headers_map_to_canonical(self):
+        # Official English exports use title-case headers; without aliases, ground-truth fields
+        # like blood_oxygen_pct were invisible to correlate_ground_truth (#103 SpO₂ work).
         self.assertEqual(cg._norm_header("Heart rate variability (ms)"),
-                         "heart rate variability (ms)")  # English CSV already uses canonical-ish; the
-        # importer's own English path keys on these — the alias table only needs the localized forms.
+                         "heart_rate_variability_ms")
+        self.assertEqual(cg._norm_header("Blood oxygen %"), "blood_oxygen_pct")
+        self.assertEqual(cg._norm_header("Skin temp (celsius)"), "skin_temp_celsius")
+        self.assertEqual(cg._norm_header("Cycle start time"), "cycle_start_time")
 
     def test_bom_stripped(self):
         self.assertEqual(cg._norm_header("﻿Startzeit des Zyklus"), "cycle_start_time")
@@ -49,6 +53,20 @@ class CsvLoadingTests(unittest.TestCase):
         truth = cg.truth_values(rows)
         self.assertEqual(sorted(truth["hrv_ms"]), [92.0, 101.0])
         self.assertEqual(sorted(truth["resting_hr_bpm"]), [53.0, 54.0])
+
+    def test_load_english_cycles_spo2(self):
+        cycles = (
+            "Cycle start time,Blood oxygen %,Skin temp (celsius)\n"
+            "2026-07-15 23:25:58,95.82,34.24\n"
+            "2026-07-14 23:51:24,97.29,34.40\n"
+        )
+        folder = tempfile.mkdtemp()
+        with open(os.path.join(folder, "physiological_cycles.csv"), "w") as f:
+            f.write(cycles)
+        rows = cg.load_ground_truth(folder)
+        truth = cg.truth_values(rows)
+        self.assertEqual(sorted(truth["spo2_pct"]), [95.82, 97.29])
+        self.assertEqual(sorted(truth["skin_temp_c"]), [34.24, 34.40])
 
     def test_merges_cycles_and_sleep_on_cycle_start(self):
         cycles = "Startzeit des Zyklus,Herzfrequenzvariabilität (ms)\n2026-06-20 00:24:31,92\n"

--- a/Tools/linux-capture/test_validate_spo2_candidate.py
+++ b/Tools/linux-capture/test_validate_spo2_candidate.py
@@ -1,0 +1,226 @@
+"""Tests for validate_spo2_candidate — multi-device @82 SpO₂ candidate validation.
+
+Run: python3 -m unittest test_validate_spo2_candidate -v
+Stdlib only; synthetic planted captures — no personal health data.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import struct
+import tempfile
+import unittest
+from datetime import datetime, timezone
+
+import validate_spo2_candidate as vs
+from test_whoop_activity import make_v18
+
+
+def _utc(y, m, d, hh=0, mm=0, ss=0) -> int:
+    return int(datetime(y, m, d, hh, mm, ss, tzinfo=timezone.utc).timestamp())
+
+
+def _plant_night(
+    t0: int,
+    t1: int,
+    spo2: int,
+    *,
+    asleep: bool = True,
+    neighbor_offset: int | None = None,
+    neighbor_value: int = 0,
+    step_s: int = 60,
+) -> list[dict]:
+    """Plant v18 records for one night with @82 = spo2 while asleep (default 1/min)."""
+    out = []
+    sleep_state = 2 if asleep else 0
+    for u in range(t0, t1, step_s):
+        f = bytearray(
+            make_v18(
+                unix=u,
+                sleep_state=sleep_state,
+                aux_byte_82=spo2 if asleep else 0,
+                length=124,
+            )
+        )
+        if neighbor_offset is not None and asleep:
+            f[neighbor_offset] = neighbor_value & 0xFF
+        out.append({"hex": bytes(f).hex(), "dir": "rx"})
+    return out
+
+
+def _write_export(folder: str, nights: list[tuple[str, float, int, int]]) -> str:
+    """nights: (cycle_start_str, spo2_export, sleep_unix, wake_unix)"""
+    path = os.path.join(folder, "physiological_cycles.csv")
+    lines = [
+        "Cycle start time,Cycle end time,Blood oxygen %,Sleep onset,Wake onset\n"
+    ]
+    for start, spo2, t0, t1 in nights:
+        s0 = datetime.fromtimestamp(t0, tz=timezone.utc).strftime("%Y-%m-%d %H:%M:%S")
+        s1 = datetime.fromtimestamp(t1, tz=timezone.utc).strftime("%Y-%m-%d %H:%M:%S")
+        lines.append(f"{start},,{spo2:.2f},{s0},{s1}\n")
+    with open(path, "w") as f:
+        f.writelines(lines)
+    return folder
+
+
+class HeaderAndTsTests(unittest.TestCase):
+    def test_english_blood_oxygen_header(self):
+        self.assertEqual(vs._norm_header("Blood oxygen %"), "blood_oxygen_pct")
+        self.assertEqual(vs._norm_header("Cycle start time"), "cycle_start_time")
+
+    def test_parse_export_ts(self):
+        self.assertEqual(
+            vs._parse_export_ts("2026-07-15 23:25:58"),
+            _utc(2026, 7, 15, 23, 25, 58),
+        )
+
+
+class PlantedValidationTests(unittest.TestCase):
+    def test_recovers_perfect_correlation_across_nights(self):
+        # 6 nights with real spread; @82 equals round(export) while asleep.
+        base = _utc(2026, 6, 1, 0, 0, 0)
+        nights_meta = []
+        frames = []
+        exports = []
+        for i, spo2 in enumerate([95, 96, 97, 98, 94, 99]):
+            t0 = base + i * 86400 + 23 * 3600
+            t1 = t0 + 7 * 3600
+            frames.extend(_plant_night(t0, t1, spo2))
+            start = datetime.fromtimestamp(t0, tz=timezone.utc).strftime("%Y-%m-%d %H:%M:%S")
+            exports.append((start, float(spo2), t0, t1))
+            nights_meta.append(spo2)
+
+        with tempfile.TemporaryDirectory() as td:
+            cap = os.path.join(td, "capture.json")
+            with open(cap, "w") as f:
+                json.dump(frames, f)
+            exp = _write_export(td, exports)
+            res = vs.validate_device(cap, exp, device="planted-a")
+
+        self.assertEqual(res["paired_nights"], 6)
+        self.assertIsNotNone(res["r"])
+        self.assertGreaterEqual(res["r"], 0.99)
+        self.assertLessEqual(res["mae"], 0.01)
+        self.assertEqual(res["best_specificity_offset"], 82)
+        self.assertTrue(res["checklist"]["pass"])
+
+    def test_incomplete_nights_without_export_spo2_are_skipped(self):
+        t0 = _utc(2026, 6, 10, 23, 0, 0)
+        t1 = t0 + 6 * 3600
+        frames = _plant_night(t0, t1, 97)
+        with tempfile.TemporaryDirectory() as td:
+            cap = os.path.join(td, "capture.json")
+            with open(cap, "w") as f:
+                json.dump(frames, f)
+            # Export row with empty SpO₂ — must not pair.
+            path = os.path.join(td, "physiological_cycles.csv")
+            with open(path, "w") as f:
+                f.write(
+                    "Cycle start time,Blood oxygen %,Sleep onset,Wake onset\n"
+                    "2026-06-10 23:00:00,,"
+                    f"{datetime.fromtimestamp(t0, tz=timezone.utc).strftime('%Y-%m-%d %H:%M:%S')},"
+                    f"{datetime.fromtimestamp(t1, tz=timezone.utc).strftime('%Y-%m-%d %H:%M:%S')}\n"
+                )
+            res = vs.validate_device(cap, td, device="empty")
+        self.assertEqual(res["export_nights_with_spo2"], 0)
+        self.assertEqual(res["paired_nights"], 0)
+        self.assertFalse(res["checklist"]["pass"])
+
+    def test_awake_samples_do_not_contribute(self):
+        t0 = _utc(2026, 6, 11, 23, 0, 0)
+        t1 = t0 + 6 * 3600
+        # All wake, @82=97 — should not pair when require_asleep (default).
+        frames = _plant_night(t0, t1, 97, asleep=False)
+        # Force aux byte even while wake for the test plant.
+        for rec in frames:
+            f = bytearray(bytes.fromhex(rec["hex"]))
+            f[82] = 97
+            rec["hex"] = bytes(f).hex()
+        with tempfile.TemporaryDirectory() as td:
+            cap = os.path.join(td, "capture.json")
+            with open(cap, "w") as f:
+                json.dump(frames, f)
+            start = datetime.fromtimestamp(t0, tz=timezone.utc).strftime("%Y-%m-%d %H:%M:%S")
+            exp = _write_export(td, [(start, 97.0, t0, t1)])
+            res = vs.validate_device(cap, exp, device="wake-only")
+        self.assertEqual(res["paired_nights"], 0)
+
+    def test_offset_specificity_prefers_true_offset(self):
+        # Plant signal at @82; put a constant 98 at @80 that should not track spread.
+        base = _utc(2026, 7, 1, 0, 0, 0)
+        frames = []
+        exports = []
+        for i, spo2 in enumerate([92, 94, 96, 98, 95, 97]):
+            t0 = base + i * 86400 + 22 * 3600
+            t1 = t0 + 8 * 3600
+            frames.extend(
+                _plant_night(t0, t1, spo2, neighbor_offset=80, neighbor_value=98)
+            )
+            start = datetime.fromtimestamp(t0, tz=timezone.utc).strftime("%Y-%m-%d %H:%M:%S")
+            exports.append((start, float(spo2), t0, t1))
+        with tempfile.TemporaryDirectory() as td:
+            cap = os.path.join(td, "capture.json")
+            with open(cap, "w") as f:
+                json.dump(frames, f)
+            exp = _write_export(td, exports)
+            res = vs.validate_device(cap, exp, device="spec")
+        self.assertEqual(res["best_specificity_offset"], 82)
+
+    def test_postable_summary_has_no_raw_values(self):
+        # Perfect single-device result → postable block must not contain SpO₂ numbers from nights.
+        base = _utc(2026, 8, 1, 0, 0, 0)
+        frames, exports = [], []
+        for i, spo2 in enumerate([95, 96, 97, 98, 94, 99]):
+            t0 = base + i * 86400 + 23 * 3600
+            t1 = t0 + 7 * 3600
+            frames.extend(_plant_night(t0, t1, spo2))
+            start = datetime.fromtimestamp(t0, tz=timezone.utc).strftime("%Y-%m-%d %H:%M:%S")
+            exports.append((start, float(spo2), t0, t1))
+        with tempfile.TemporaryDirectory() as td:
+            cap = os.path.join(td, "capture.json")
+            with open(cap, "w") as f:
+                json.dump(frames, f)
+            exp = _write_export(td, exports)
+            res = vs.validate_device(cap, exp, device="post")
+        blob = vs.format_postable([res])
+        self.assertIn("spo2_candidate_82 multi-device validation", blob)
+        self.assertIn("checklist_pass", blob)
+        # Nightly export values must not appear as raw 95.00-style lines.
+        self.assertNotIn("95.00", blob)
+        self.assertNotIn("cycle_start", blob.lower())
+
+
+class MultiDeviceBatchTests(unittest.TestCase):
+    def test_batch_all_pass(self):
+        def make_device(td, label, spo2s):
+            base = _utc(2026, 5, 1, 0, 0, 0)
+            frames, exports = [], []
+            for i, spo2 in enumerate(spo2s):
+                t0 = base + i * 86400 + 23 * 3600
+                t1 = t0 + 7 * 3600
+                frames.extend(_plant_night(t0, t1, spo2))
+                start = datetime.fromtimestamp(t0, tz=timezone.utc).strftime(
+                    "%Y-%m-%d %H:%M:%S"
+                )
+                exports.append((start, float(spo2), t0, t1))
+            cap = os.path.join(td, f"{label}.json")
+            with open(cap, "w") as f:
+                json.dump(frames, f)
+            exp_dir = os.path.join(td, label)
+            os.makedirs(exp_dir)
+            _write_export(exp_dir, exports)
+            return {"device": label, "capture": cap, "export": exp_dir}
+
+        with tempfile.TemporaryDirectory() as td:
+            a = make_device(td, "strap-a", [95, 96, 97, 98, 94, 99])
+            b = make_device(td, "strap-b", [93, 94, 95, 96, 97, 98])
+            batch = os.path.join(td, "devices.json")
+            with open(batch, "w") as f:
+                json.dump([a, b], f)
+            rc = vs.main(["--batch", batch, "--postable"])
+            self.assertEqual(rc, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Tools/linux-capture/test_whoop_activity.py
+++ b/Tools/linux-capture/test_whoop_activity.py
@@ -38,11 +38,24 @@ def test_decode_v18_roundtrips_fields():
     d = wa.decode_v18(make_v18(unix=1700000000, hr=58, motion=4000, wear=1, sleep_state=2))
     assert d == {"record_index": 0, "unix": 1700000000, "hr": 58,
                  "onwrist": 0, "wake_quality": 0, "sleep_state": 2, "aux_byte_82": 0,
+                 "spo2_candidate_82": None,  # 0 is out-of-band (not 70–100)
                  "motion_count": 4000, "step_cadence": 0, "motion_wear_quality": 1,
                  "hr_fixed_8_8": 0, "rr_packed": 0, "cardiac_flags": 0, "cardiac_status": 0,
                  "temp_aux_1_raw": 0, "temp_aux_2_raw": 0,
                  "status_word": 0, "status_word_1": 0, "status_word_2": 0,
                  "unknown_f32_113": 0.0}
+
+
+def test_decode_v18_spo2_candidate_82_tri_mode():
+    # Mirrors Swift testHistoricalV18Spo2Candidate82TriMode: in-band 70–100 only.
+    assert wa.decode_v18(make_v18(aux_byte_82=0))["spo2_candidate_82"] is None
+    assert wa.decode_v18(make_v18(aux_byte_82=90))["spo2_candidate_82"] == 90
+    assert wa.decode_v18(make_v18(aux_byte_82=70))["spo2_candidate_82"] == 70
+    assert wa.decode_v18(make_v18(aux_byte_82=100))["spo2_candidate_82"] == 100
+    for raw in (0x80, 0xA0, 0x20, 69, 101):
+        d = wa.decode_v18(make_v18(aux_byte_82=raw))
+        assert d["spo2_candidate_82"] is None
+        assert d["aux_byte_82"] == raw
 
 
 def test_decode_v18_higher_precision_hr():

--- a/Tools/linux-capture/validate_spo2_candidate.py
+++ b/Tools/linux-capture/validate_spo2_candidate.py
@@ -1,0 +1,527 @@
+#!/usr/bin/env python3
+"""Multi-device validation of the WHOOP 5/MG v18 SpO₂ candidate at frame byte @82.
+
+Context (see docs/WHOOP5_DEEP_DATA.md and issue #103):
+  • There is no GET_SPO2 BLE command.
+  • On 5.0/MG, SpO₂ is believed to be a strap-computed scalar banked during sleep.
+  • NOOP decodes in-band values (70–100) at absolute frame offset 82 as spo2_candidate_82
+    (instrumentation only — never spo2Pct until multi-device evidence is solid).
+
+This tool answers the promote-or-not question as *known plaintext*:
+
+    capture.json  +  whoop_export  ──►  nightly mean(@82 | asleep, 70–100)
+                                       vs CSV blood_oxygen_pct
+                                       ──►  r, MAE, bias, offset-specificity
+
+Owners can validate one strap, or batch several devices, and post **only aggregate
+stats** on #103 (never raw SpO₂ values). Stdlib only.
+
+Usage:
+
+    # Single device (privacy-safe summary):
+    python3 validate_spo2_candidate.py capture.json my_whoop_data/ --device strap-a
+
+    # Show per-night table locally (still stays on your machine):
+    python3 validate_spo2_candidate.py capture.json export.zip --show-nights
+
+    # Multi-device batch:
+    python3 validate_spo2_candidate.py --batch devices.json
+
+devices.json example:
+    [
+      {"device": "strap-a", "capture": "a.json", "export": "export_a/"},
+      {"device": "strap-b", "capture": "b.json", "export": "export_b.zip"}
+    ]
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import io
+import json
+import math
+import os
+import statistics
+import sys
+import zipfile
+from datetime import datetime, timezone
+from typing import Dict, Iterable, List, Optional, Sequence, Tuple
+
+import whoop_activity as wa
+import whoop_frame as wf
+
+# Absolute frame offsets (Interpreter.decodeWhoop5Historical / whoop_activity.decode_v18).
+OFF_HIST_VERSION = 9
+OFF_UNIX = 15
+OFF_SLEEP_BYTE = 81
+OFF_SPO2_CANDIDATE = 82
+
+# In-band SpO₂ % range (tri-mode filter — matches Swift spo2_candidate_82).
+INBAND = range(70, 101)
+
+# Band sleep_state high-nibble: 2 = asleep.
+SLEEP_ASLEEP = 2
+
+# Scan window for offset-specificity (docs checklist: only @82 should win).
+SPECIFICITY_SCAN = range(74, 93)
+
+# English + localized cycle headers → canonical keys (mirrors StrandImport HeaderNorm subset).
+HEADER_ALIASES = {
+    # English (official export; lowercase after norm)
+    "cycle start time": "cycle_start_time",
+    "cycle end time": "cycle_end_time",
+    "sleep onset": "sleep_onset",
+    "wake onset": "wake_onset",
+    "blood oxygen %": "blood_oxygen_pct",
+    "skin temp (celsius)": "skin_temp_celsius",
+    "resting heart rate (bpm)": "resting_heart_rate_bpm",
+    "heart rate variability (ms)": "heart_rate_variability_ms",
+    "respiratory rate (rpm)": "respiratory_rate_rpm",
+    # German
+    "startzeit des zyklus": "cycle_start_time",
+    "blutsauerstoff %": "blood_oxygen_pct",
+    "hauttemperatur (celsius)": "skin_temp_celsius",
+    # Spanish
+    "hora de inicio del ciclo": "cycle_start_time",
+    "oxígeno en sangre %": "blood_oxygen_pct",
+    "temp. cutánea (grados centígrados)": "skin_temp_celsius",
+}
+
+CYCLES_FILES = {
+    "physiological_cycles.csv",
+    "physiologische_zyklen.csv",
+    "ciclos_fisiologicos.csv",
+}
+
+
+# --- CSV ground truth ------------------------------------------------------------------------------
+
+def _norm_header(h: str) -> str:
+    key = h.strip().lower().lstrip("\ufeff")
+    return HEADER_ALIASES.get(key, key)
+
+
+def _parse_float(raw: str) -> Optional[float]:
+    raw = (raw or "").strip()
+    if not raw:
+        return None
+    try:
+        return float(raw.replace(",", "."))
+    except ValueError:
+        return None
+
+
+def _parse_export_ts(raw: str) -> Optional[int]:
+    """Parse WHOOP export timestamps to unix seconds (naive wall clock → UTC for windowing).
+
+    Export stamps are wall-clock; for night bucketing we only need a consistent second scale
+    that lines up with the strap's unix field. Absolute TZ offset cancels out when both sides
+    use the same convention for a given local night.
+    """
+    raw = (raw or "").strip()
+    if not raw:
+        return None
+    cleaned = raw.replace("T", " ").rstrip("Z")
+    for n, fmt in ((19, "%Y-%m-%d %H:%M:%S"), (16, "%Y-%m-%d %H:%M")):
+        try:
+            dt = datetime.strptime(cleaned[:n], fmt)
+            return int(dt.replace(tzinfo=timezone.utc).timestamp())
+        except ValueError:
+            continue
+    return None
+
+
+def load_cycles(export_path: str) -> List[dict]:
+    """Load physiological cycle rows with canonical keys from a WHOOP export zip/folder."""
+    files: Dict[str, str] = {}
+    if zipfile.is_zipfile(export_path):
+        with zipfile.ZipFile(export_path) as z:
+            for name in z.namelist():
+                base = name.rsplit("/", 1)[-1].lower()
+                if base.endswith(".csv"):
+                    files[base] = z.read(name).decode("utf-8-sig", errors="replace")
+    else:
+        for root, _dirs, names in os.walk(export_path):
+            for n in names:
+                if n.lower().endswith(".csv"):
+                    with open(os.path.join(root, n), encoding="utf-8-sig", errors="replace") as f:
+                        files[n.lower()] = f.read()
+
+    text = None
+    for base, body in files.items():
+        if base in CYCLES_FILES:
+            text = body
+            break
+    if text is None:
+        # Header sniff: any CSV that carries blood oxygen + cycle start.
+        for body in files.values():
+            head = body.splitlines()[0].lower() if body else ""
+            if "blood oxygen" in head or "blutsauerstoff" in head or "oxígeno en sangre" in head:
+                text = body
+                break
+    if not text:
+        return []
+
+    reader = csv.reader(io.StringIO(text))
+    rows = list(reader)
+    if not rows:
+        return []
+    headers = [_norm_header(h) for h in rows[0]]
+    out = []
+    for raw in rows[1:]:
+        if not any(cell.strip() for cell in raw):
+            continue
+        row = {headers[i]: raw[i] for i in range(min(len(headers), len(raw)))}
+        spo2 = _parse_float(row.get("blood_oxygen_pct", ""))
+        if spo2 is None:
+            continue  # incomplete night / nap without SpO₂ — not a validation target
+        sleep0 = _parse_export_ts(row.get("sleep_onset", ""))
+        sleep1 = _parse_export_ts(row.get("wake_onset", ""))
+        cyc0 = _parse_export_ts(row.get("cycle_start_time", ""))
+        cyc1 = _parse_export_ts(row.get("cycle_end_time", ""))
+        # Prefer sleep window; fall back to cycle span.
+        t0 = sleep0 if sleep0 is not None else cyc0
+        t1 = sleep1 if sleep1 is not None else cyc1
+        if t0 is None:
+            continue
+        if t1 is None:
+            t1 = t0 + 12 * 3600  # open-ended night: generous upper bound
+        if t1 <= t0:
+            t1 = t0 + 12 * 3600
+        out.append({
+            "cycle_start_time": row.get("cycle_start_time", ""),
+            "spo2_export": spo2,
+            "t0": t0,
+            "t1": t1,
+        })
+    return out
+
+
+# --- Capture decode --------------------------------------------------------------------------------
+
+def iter_v18_records(capture_records: Sequence[dict]) -> Iterable[dict]:
+    """Yield decoded v18 fields from capture.json entries (absolute frame offsets)."""
+    for rec in capture_records:
+        hx = rec.get("hex") if isinstance(rec, dict) else None
+        if not hx:
+            continue
+        try:
+            frame = bytes.fromhex(hx)
+        except ValueError:
+            continue
+        if len(frame) <= 116:
+            continue
+        # Prefer CRC-valid WHOOP 5 frames; still accept synthetic absolute buffers used in tests
+        # (make_v18 style: length 124, hist_version @9, no real CRC).
+        if frame[0] == 0xAA and len(frame) > 8:
+            if not (wf.verify_whoop5_frame(frame) or frame[OFF_HIST_VERSION] == 18):
+                continue
+        d = wa.decode_v18(frame)
+        if d is None:
+            continue
+        d = dict(d)
+        raw82 = frame[OFF_SPO2_CANDIDATE] if len(frame) > OFF_SPO2_CANDIDATE else d.get("aux_byte_82", 0)
+        d["aux_byte_82"] = raw82
+        d["spo2_candidate_82"] = raw82 if raw82 in INBAND else None
+        # Neighbor bytes for specificity scan (absolute offsets).
+        d["_frame"] = frame
+        yield d
+
+
+def night_mean_at_offset(
+    records: Sequence[dict],
+    t0: int,
+    t1: int,
+    offset: int,
+    *,
+    require_asleep: bool = True,
+) -> Optional[Tuple[float, int]]:
+    """Mean of in-band u8 samples at `offset` inside [t0, t1). Returns (mean, n) or None."""
+    vals = []
+    for r in records:
+        u = r["unix"]
+        if u < t0 or u >= t1:
+            continue
+        if require_asleep and r.get("sleep_state") != SLEEP_ASLEEP:
+            continue
+        frame = r.get("_frame")
+        if frame is None or len(frame) <= offset:
+            continue
+        v = frame[offset]
+        if v in INBAND:
+            vals.append(v)
+    if not vals:
+        return None
+    return (statistics.fmean(vals), len(vals))
+
+
+def pearson_r(xs: Sequence[float], ys: Sequence[float]) -> Optional[float]:
+    n = len(xs)
+    if n < 2:
+        return None
+    mx = statistics.fmean(xs)
+    my = statistics.fmean(ys)
+    num = sum((x - mx) * (y - my) for x, y in zip(xs, ys))
+    denx = math.sqrt(sum((x - mx) ** 2 for x in xs))
+    deny = math.sqrt(sum((y - my) ** 2 for y in ys))
+    if denx == 0 or deny == 0:
+        return None
+    return num / (denx * deny)
+
+
+def mae(xs: Sequence[float], ys: Sequence[float]) -> Optional[float]:
+    if not xs:
+        return None
+    return statistics.fmean(abs(x - y) for x, y in zip(xs, ys))
+
+
+# --- Per-device validation -------------------------------------------------------------------------
+
+def validate_device(
+    capture_path: str,
+    export_path: str,
+    *,
+    device: str = "device",
+    require_asleep: bool = True,
+) -> dict:
+    with open(capture_path) as f:
+        capture = json.load(f)
+    if not isinstance(capture, list):
+        raise SystemExit(f"{capture_path}: expected a JSON list of frame records")
+
+    cycles = load_cycles(export_path)
+    records = list(iter_v18_records(capture))
+
+    nights = []
+    for c in cycles:
+        hit = night_mean_at_offset(
+            records, c["t0"], c["t1"], OFF_SPO2_CANDIDATE, require_asleep=require_asleep
+        )
+        if hit is None:
+            nights.append({
+                "cycle_start_time": c["cycle_start_time"],
+                "export": c["spo2_export"],
+                "candidate_mean": None,
+                "n_samples": 0,
+                "matched": False,
+            })
+            continue
+        mean_v, n = hit
+        nights.append({
+            "cycle_start_time": c["cycle_start_time"],
+            "export": c["spo2_export"],
+            "candidate_mean": mean_v,
+            "n_samples": n,
+            "matched": True,
+            "abs_err": abs(mean_v - c["spo2_export"]),
+        })
+
+    paired_export = [n["export"] for n in nights if n["matched"]]
+    paired_cand = [n["candidate_mean"] for n in nights if n["matched"]]
+    r = pearson_r(paired_export, paired_cand) if len(paired_cand) >= 2 else None
+    err = mae(paired_export, paired_cand)
+    bias = (
+        statistics.fmean(c - e for c, e in zip(paired_cand, paired_export))
+        if paired_cand else None
+    )
+
+    # Offset specificity: among SPECIFICITY_SCAN, which offset maximises |r| on paired nights?
+    spec_scores = []
+    for off in SPECIFICITY_SCAN:
+        xs, ys = [], []
+        for c in cycles:
+            hit = night_mean_at_offset(
+                records, c["t0"], c["t1"], off, require_asleep=require_asleep
+            )
+            if hit is None:
+                continue
+            xs.append(c["spo2_export"])
+            ys.append(hit[0])
+        rr = pearson_r(xs, ys) if len(xs) >= 2 else None
+        if rr is not None:
+            spec_scores.append({"offset": off, "r": rr, "nights": len(xs)})
+    spec_scores.sort(key=lambda s: abs(s["r"]), reverse=True)
+    best_off = spec_scores[0]["offset"] if spec_scores else None
+    r_at_82 = next((s["r"] for s in spec_scores if s["offset"] == OFF_SPO2_CANDIDATE), r)
+
+    # Checklist gates (docs/WHOOP5_DEEP_DATA.md) — conservative defaults for instrumentation.
+    n_paired = len(paired_cand)
+    checklist = {
+        "min_nights": n_paired >= 5,
+        "real_spread": (
+            (max(paired_export) - min(paired_export) >= 1.0) if n_paired >= 2 else False
+        ),
+        "corr_ge_0_7": (r is not None and r >= 0.7),
+        "mae_le_1_0": (err is not None and err <= 1.0),
+        "offset_82_wins": best_off == OFF_SPO2_CANDIDATE,
+    }
+    checklist["pass"] = all(checklist.values())
+
+    return {
+        "device": device,
+        "v18_records": len(records),
+        "export_nights_with_spo2": len(cycles),
+        "paired_nights": n_paired,
+        "r": r,
+        "r_at_82_specificity": r_at_82,
+        "mae": err,
+        "bias": bias,
+        "best_specificity_offset": best_off,
+        "specificity_top3": spec_scores[:3],
+        "checklist": checklist,
+        "nights": nights,
+        "inband_samples_total": sum(n["n_samples"] for n in nights),
+    }
+
+
+def format_summary(result: dict, *, show_nights: bool = False) -> str:
+    """Privacy-safe summary: aggregates only (no raw SpO₂ unless --show-nights)."""
+    lines = []
+    cl = result["checklist"]
+    lines.append(
+        f"device={result['device']}  v18_records={result['v18_records']}  "
+        f"export_nights={result['export_nights_with_spo2']}  paired={result['paired_nights']}  "
+        f"inband_samples={result['inband_samples_total']}"
+    )
+    r = result["r"]
+    mae_v = result["mae"]
+    bias = result["bias"]
+    lines.append(
+        f"  @82 nightly mean vs export:  r="
+        f"{'n/a' if r is None else f'{r:+.3f}'}  "
+        f"MAE={'n/a' if mae_v is None else f'{mae_v:.3f}'}  "
+        f"bias={'n/a' if bias is None else f'{bias:+.3f}'}"
+    )
+    lines.append(
+        f"  specificity: best_offset={result['best_specificity_offset']}  "
+        f"top3="
+        + ", ".join(
+            f"@{s['offset']} r={s['r']:+.3f} (n={s['nights']})"
+            for s in result.get("specificity_top3", [])
+        )
+    )
+    flags = " ".join(
+        f"{k}={'PASS' if v else 'FAIL'}"
+        for k, v in cl.items()
+        if k != "pass"
+    )
+    lines.append(f"  checklist: {flags}")
+    lines.append(f"  OVERALL: {'PASS (candidate strengthens)' if cl['pass'] else 'FAIL (keep instrumentation-only)'}")
+    if show_nights:
+        lines.append("  per-night (local only — do not post raw values):")
+        for n in result["nights"]:
+            if not n["matched"]:
+                lines.append(f"    {n['cycle_start_time']}: export={n['export']:.2f}  candidate=—  (no in-band samples)")
+            else:
+                lines.append(
+                    f"    {n['cycle_start_time']}: export={n['export']:.2f}  "
+                    f"candidate={n['candidate_mean']:.2f}  n={n['n_samples']}  "
+                    f"|err|={n['abs_err']:.2f}"
+                )
+    return "\n".join(lines)
+
+
+def format_postable(results: Sequence[dict]) -> str:
+    """One-liner block safe to paste on GitHub #103 (no health values)."""
+    lines = [
+        "spo2_candidate_82 multi-device validation (validate_spo2_candidate.py)",
+        "device,paired_nights,r,mae,bias,best_offset,checklist_pass",
+    ]
+    for res in results:
+        r = res["r"]
+        mae_v = res["mae"]
+        bias = res["bias"]
+        lines.append(
+            f"{res['device']},{res['paired_nights']},"
+            f"{'' if r is None else f'{r:.3f}'},"
+            f"{'' if mae_v is None else f'{mae_v:.3f}'},"
+            f"{'' if bias is None else f'{bias:.3f}'},"
+            f"{res['best_specificity_offset']},"
+            f"{res['checklist']['pass']}"
+        )
+    # Multi-device aggregate: promote only if every device with ≥5 paired nights passes.
+    eligible = [res for res in results if res["paired_nights"] >= 5]
+    if eligible:
+        all_pass = all(res["checklist"]["pass"] for res in eligible)
+        lines.append(
+            f"multi_device_eligible={len(eligible)} all_pass={all_pass} "
+            f"(promote spo2Pct only if all_pass and ≥2 devices)"
+        )
+    else:
+        lines.append("multi_device_eligible=0 (need ≥5 paired nights per device)")
+    return "\n".join(lines)
+
+
+# --- CLI -------------------------------------------------------------------------------------------
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    p = argparse.ArgumentParser(
+        description="Validate WHOOP 5/MG v18 spo2_candidate_82 against a CSV export (#103)."
+    )
+    p.add_argument("capture", nargs="?", help="capture.json (from hci_extract / whoop_capture)")
+    p.add_argument("export", nargs="?", help="WHOOP CSV export .zip or folder")
+    p.add_argument("--device", default="device", help="label for this strap (default: device)")
+    p.add_argument(
+        "--batch",
+        metavar="devices.json",
+        help="JSON list of {device,capture,export} for multi-device validation",
+    )
+    p.add_argument(
+        "--show-nights",
+        action="store_true",
+        help="print per-night export vs candidate (local only — contains health values)",
+    )
+    p.add_argument(
+        "--allow-any-sleep-state",
+        action="store_true",
+        help="do not require sleep_state=asleep when averaging @82 (debug)",
+    )
+    p.add_argument(
+        "--postable",
+        action="store_true",
+        help="print a CSV-ish block safe to paste on GitHub (no raw SpO₂ values)",
+    )
+    args = p.parse_args(argv)
+
+    require_asleep = not args.allow_any_sleep_state
+    results: List[dict] = []
+
+    if args.batch:
+        with open(args.batch) as f:
+            batch = json.load(f)
+        if not isinstance(batch, list) or not batch:
+            print("batch file must be a non-empty JSON list", file=sys.stderr)
+            return 1
+        for entry in batch:
+            results.append(
+                validate_device(
+                    entry["capture"],
+                    entry["export"],
+                    device=entry.get("device", "device"),
+                    require_asleep=require_asleep,
+                )
+            )
+    else:
+        if not args.capture or not args.export:
+            p.error("capture and export are required unless --batch is set")
+        results.append(
+            validate_device(
+                args.capture,
+                args.export,
+                device=args.device,
+                require_asleep=require_asleep,
+            )
+        )
+
+    for res in results:
+        print(format_summary(res, show_nights=args.show_nights))
+        print()
+    if args.postable or len(results) > 1:
+        print("--- postable summary (safe for #103) ---")
+        print(format_postable(results))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/Tools/linux-capture/whoop_activity.py
+++ b/Tools/linux-capture/whoop_activity.py
@@ -34,7 +34,10 @@ read off real v18 frames and checked for a behaviour that can only hold if the o
   wake_quality = (frame[81] >> 2) & 3   quality code (b2-3); observed nonzero only in wake.
   sleep_state = (frame[81] >> 4) & 3   high nibble tracks a scored night (wake/still/asleep/up); the
                               low nibble is sub-flags. Deep/REM/light are computed off-band, not here.
-  aux_byte_82 = frame[82]     raw; observed nonzero only while sleep_state = asleep (meaning not pinned).
+  aux_byte_82 = frame[82]     raw; observed nonzero only while sleep_state = asleep.
+  spo2_candidate_82           aux_byte_82 when in 70..100 (inclusive); else absent. Instrumentation
+                              only (#103) — multi-device validation via validate_spo2_candidate.py
+                              before any promote to spo2Pct.
   unknown_f32_113 = f32 LE @113   a float32 (observed range ~ -5.3..0, 0 = unset); purpose unknown,
                               carried raw for completeness.
 
@@ -64,7 +67,9 @@ def decode_v18(frame):
         "onwrist": frame[81] & 3,            # @81 b0-1 on-wrist/validity flag
         "wake_quality": (frame[81] >> 2) & 3,  # @81 b2-3 quality code (nonzero only in wake)
         "sleep_state": (frame[81] >> 4) & 3,
-        "aux_byte_82": frame[82],            # @82 raw (nonzero only while asleep; meaning not pinned)
+        "aux_byte_82": frame[82],            # @82 raw (nonzero only while asleep)
+        # In-band only (70–100): mirrors Swift spo2_candidate_82 / Kotlin twin — instrumentation.
+        "spo2_candidate_82": frame[82] if 70 <= frame[82] <= 100 else None,
         "motion_count": u16le(frame, 57),
         "step_cadence": frame[59],           # @59 cadence-like byte (raw)
         "motion_wear_quality": frame[63],    # @63 3-valued byte (raw; semantics not pinned)

--- a/docs/WHOOP5_DEEP_DATA.md
+++ b/docs/WHOOP5_DEEP_DATA.md
@@ -136,6 +136,27 @@ tracking the WHOOP app's own SpO₂ across many nights on **multiple devices** (
 coincidental match), including on the device where the two checked nights currently move opposite.
 Until that clears the bar, SpO₂ stays import-only on the 5.0.
 
+### Multi-device validation tool (`validate_spo2_candidate.py`)
+
+To make that bar concrete and privacy-preserving, `Tools/linux-capture/validate_spo2_candidate.py`
+turns one or more `(capture.json, WHOOP export)` pairs into a promote checklist:
+
+```bash
+cd Tools/linux-capture
+python3 validate_spo2_candidate.py capture.json my_whoop_data/ --device strap-a --postable
+python3 validate_spo2_candidate.py --batch devices.json --postable
+```
+
+Per device it computes the **nightly mean** of in-band `@82` samples (70–100) while
+`sleep_state = asleep`, pairs each night with CSV `blood_oxygen_pct`, then reports Pearson **r**,
+MAE, bias, and an **offset-specificity** scan over bytes 74–92 (only `@82` should win). Default
+gates: ≥5 paired nights, export range ≥1 %, r ≥ 0.7, MAE ≤ 1.0, best offset = 82.
+
+`--postable` prints a CSV-ish block with **no raw SpO₂ values** — safe to paste on
+[#103](https://github.com/ryanbr/noop/issues/103). Promote `spo2_candidate_82` → `spo2Pct` only when
+**≥2 devices** each PASS (the tool's multi-device footer tracks that). This does **not** change app
+metrics by itself; it is the research harness for the split-evidence problem above.
+
 ## Mapping the layout — ground-truth correlation
 
 An HCI capture on its own is a pile of un-labelled bytes. The fast way to label them is *known
@@ -144,14 +165,17 @@ per-night values — HRV, resting HR, skin temperature, SpO₂, respiratory rate
 in the capture. Searching each record type for the byte offset + encoding that reproduces those known
 values across every night pins the field without guesswork.
 
-Two stdlib tools in [`Tools/linux-capture/`](../Tools/linux-capture/) do this:
+Three stdlib tools in [`Tools/linux-capture/`](../Tools/linux-capture/) do this:
 
 - **`hci_extract.py`** converts a phone HCI log (iOS `.pklg` / Android `btsnoop_hci.log`) of the
   official app into the project's `capture.json` frame format — so an official-app full-sync capture
   feeds the same decoder as a Linux capture. It keeps only CRC-valid WHOOP frames.
 - **`correlate_ground_truth.py`** cross-references those frames against the CSV export and reports
   candidate `(record type, offset, encoding, scale)` tuples, requiring both breadth and a
-  distribution match so constants and coincidences don't score.
+  distribution match so constants and coincidences don't score. English export headers (e.g.
+  `Blood oxygen %`) map to the same canonical keys as DE/ES.
+- **`validate_spo2_candidate.py`** is the SpO₂-specific multi-device harness for `@82` (nightly mean
+  vs export, checklist, postable summary) — see above.
 
 Crucially this is **privacy-preserving**: both tools run locally and the correlation output is only
 offsets/encodings, never health values — so a 5/MG owner can contribute a confirmed field mapping to
@@ -170,6 +194,10 @@ lands in `parseFrameWhoop5` / `whoop_protocol.json`.
    or Android **Developer Options → Bluetooth HCI snoop log** → `btsnoop_hci.log`, opened in Wireshark — the
    same iOS-HCI approach the [judes.club write-up](https://judes.club/writing/cracking-the-whoop-5-bluetooth-protocol/)
    used. Filter to just the WHOOP peripheral and attach it to [#103](https://github.com/ryanbr/noop/issues/103).
+5. **SpO₂ multi-device check:** after you have a history capture + your data export, run
+   `python3 Tools/linux-capture/validate_spo2_candidate.py capture.json export/ --device <label> --postable`
+   and paste the postable summary on [#103](https://github.com/ryanbr/noop/issues/103). Keep the capture
+   and CSV private; only the aggregate r / MAE / checklist line is needed.
 
 Credit to **judes.club**, **Asherlc/dofek**, and **b-nnett/goose** for the public protocol work this
 builds on.

--- a/tools/linux-capture/README.md
+++ b/tools/linux-capture/README.md
@@ -86,7 +86,8 @@ the Python capture side does not require Swift.
 | `whoop_probe.py` | **Read-only status probe.** Reports the strap RTC + whether a historical store is present (`GET_CLOCK` / `GET_DATA_RANGE`) without writing anything. |
 | `whoop_frame.py` | CRC8 / CRC16-Modbus / CRC32, frame builders (`build_command_frame`, `build_puffin_command`, `build_whoop5_buzz` / `build_whoop4_buzz`), the family-aware `Reassembler`, and the standard-HR parser. Stdlib only. |
 | `hci_extract.py` | **Turn a phone HCI capture into `capture.json`.** Parses a btsnoop (`btsnoop_hci.log`) or Apple PacketLogger (`.pklg`) log, reassembles L2CAP/ATT, and extracts the CRC-valid WHOOP frames — so a capture of the **official app** (issue [#103](https://github.com/ryanbr/noop/issues/103)) feeds the same decode pipeline. Only WHOOP streams reach the output. Stdlib only. See [From a phone HCI capture](#from-a-phone-hci-capture-hci_extractpy). |
-| `correlate_ground_truth.py` | **Locate un-decoded record fields using your WHOOP CSV export as known-plaintext.** Cross-references capture frames against the official per-night values (HRV, resting HR, skin temp, SpO₂, respiratory rate) to find each biometric's byte offset + encoding. Reuses the Swift importer's localized header aliases. Reports offsets only — your health values never leave the machine. Stdlib only. See [Ground-truth correlation](#ground-truth-correlation-correlate_ground_truthpy). |
+| `correlate_ground_truth.py` | **Locate un-decoded record fields using your WHOOP CSV export as known-plaintext.** Cross-references capture frames against the official per-night values (HRV, resting HR, skin temp, SpO₂, respiratory rate) to find each biometric's byte offset + encoding. Reuses the Swift importer's localized header aliases (English + DE/ES). Reports offsets only — your health values never leave the machine. Stdlib only. See [Ground-truth correlation](#ground-truth-correlation-correlate_ground_truthpy). |
+| `validate_spo2_candidate.py` | **Multi-device validation of the v18 SpO₂ candidate at frame @82** (`spo2_candidate_82`). Nightly mean of in-band (70–100) samples during `sleep_state=asleep` vs CSV `blood_oxygen_pct`; reports r / MAE / bias / offset-specificity and a promote checklist. Batch mode for several straps. Postable summary has **no raw SpO₂ values** (safe for [#103](https://github.com/ryanbr/noop/issues/103)). Stdlib only. See [SpO₂ candidate validation](#spo₂-candidate-validation-validate_spo2_candidatepy). |
 | `pair_probe.py` | One-shot WHOOP 5 bonding probe: scan → connect → `pair()` → test `fd4b` access. `python3 pair_probe.py <MAC>`. |
 | `analyze_v26_waveform.py` | Characterise the WHOOP 5 **v26** type-47 buffer as PPG @24 Hz using its own co-timestamped HR as ground truth. |
 | `analyze_v25_waveform.py` | **WHOOP 4.0 v25 PPG → HR span-pinning harness ([#194](https://github.com/ryanbr/noop/issues/194)).** Sweeps the unpinned PPG span (start + sample-count) across a corpus of captures at *known* HRs and reports the span where recovered HR **tracks** ground truth instead of the `1440/N` autocorrelation artifact — or, on resting-only data, exactly what capture is still needed. `--selftest` proves it on synthetic pulses; no args runs the bundled-frames demo. Stdlib only. |
@@ -94,6 +95,7 @@ the Python capture side does not require Swift.
 | `test_whoop_frame.py` | Unit tests for framing / reassembly / HR parsing / buzz frames (no `bleak` needed). |
 | `test_hci_extract.py` | Unit tests for the btsnoop/pklg parsers, L2CAP/ATT reassembly, and WHOOP-frame extraction (synthetic fixtures; stdlib only). |
 | `test_correlate_ground_truth.py` | Unit tests for the CSV/alias loading and the known-plaintext field search (planted-value recovery + false-positive rejection; stdlib only). |
+| `test_validate_spo2_candidate.py` | Unit tests for multi-device SpO₂ @82 validation (planted perfect correlation, incomplete nights, awake gating, offset specificity, privacy of postable output; stdlib only). |
 | `test_whoop_spot_hrv.py` | Unit tests for the spot-HRV DSP (synthetic-signal HR/RMSSD recovery, ectopic rejection, grid reconstruction; stdlib only). |
 | `requirements.txt` | `bleak` (runtime dep for capture only). |
 
@@ -575,6 +577,50 @@ type; widen `--tolerance` if a field is stored pre-rounded.
 values — so its output is safe to post on #103 while the CSV export and the capture stay on your
 machine. That's the intended way for other 5/MG owners to contribute field mappings without sharing
 personal data.
+
+## SpO₂ candidate validation (`validate_spo2_candidate.py`)
+
+Once a capture has v18 historical records, this tool tests whether **byte @82** is a trustworthy
+strap-computed SpO₂ scalar (the `spo2_candidate_82` decode already in Swift/Kotlin) by comparing
+**nightly means** against your WHOOP CSV export — the multi-device bar described in
+[`docs/WHOOP5_DEEP_DATA.md`](../../docs/WHOOP5_DEEP_DATA.md).
+
+```bash
+# One strap (summary stays aggregate-only unless you pass --show-nights):
+python3 validate_spo2_candidate.py capture.json my_whoop_data/ --device strap-a --postable
+
+# Several straps at once:
+python3 validate_spo2_candidate.py --batch devices.json --postable
+```
+
+`devices.json`:
+
+```json
+[
+  {"device": "strap-a", "capture": "a.json", "export": "export_a/"},
+  {"device": "strap-b", "capture": "b.json", "export": "export_b.zip"}
+]
+```
+
+What it checks (per device):
+
+| Check | Default gate |
+|-------|----------------|
+| Paired nights with export SpO₂ **and** in-band @82 during sleep | ≥ 5 |
+| Export SpO₂ has real night-to-night spread | range ≥ 1.0 % |
+| Pearson **r** (nightly mean @82 vs export) | ≥ 0.7 |
+| Mean absolute error | ≤ 1.0 % |
+| Offset specificity scan @74–92 | best \|r\| is **@82** |
+
+**Overall PASS** only if every gate clears. NOOP still will not promote `spo2_candidate_82` →
+`spo2Pct` from a single device: need **≥ 2 devices** that each PASS (postable summary prints
+`multi_device_eligible` / `all_pass`).
+
+**Privacy:** default output and `--postable` print only aggregates (r, MAE, bias, offsets, pass/fail).
+`--show-nights` prints per-night values for **local** debugging — do not paste that on GitHub.
+
+Capture sources: `hci_extract.py` on an official-app overnight sync, or `whoop_capture.py` after a
+bonded 5/MG history offload. Synthetic/absolute v18 buffers (test fixtures) are also accepted.
 
 ## Contributing captures back
 


### PR DESCRIPTION
## What this PR does

Adds a **multi-device SpO₂ @82 validation harness** so owners can test whether `spo2_candidate_82` tracks the official export — the bar required before any promote to `spo2Pct` (#103).

### New: `Tools/linux-capture/validate_spo2_candidate.py`
- Nightly mean of in-band `@82` (70–100) while `sleep_state=asleep`
- Paired vs CSV `blood_oxygen_pct` (English + DE/ES headers)
- Pearson **r**, MAE, bias
- Offset-specificity scan over bytes 74–92 (only `@82` should win)
- Checklist gates: ≥5 nights, spread ≥1%, r≥0.7, MAE≤1.0, best offset=82
- `--batch devices.json` for multi-device
- `--postable` summary **without raw SpO₂ values** (safe for #103)
- Does **not** change app metrics or promote `spo2Pct`

### Also
- English export aliases in `correlate_ground_truth.py` (`Blood oxygen %` → `blood_oxygen_pct`) — previously English exports missed SpO₂ ground truth
- `whoop_activity.decode_v18` exposes `spo2_candidate_82` (tri-mode, mirrors Swift/Kotlin)
- Docs in `WHOOP5_DEEP_DATA.md` + linux-capture README
- Unit tests (planted multi-device perfect corr, incomplete nights, awake gating, specificity, privacy)

## Type of change

- [x] New feature (research tooling)
- [x] Documentation

## How it was tested

```bash
cd Tools/linux-capture
python3 -m unittest test_validate_spo2_candidate test_whoop_activity test_correlate_ground_truth -v
# 21 tests, OK (~0.2s)
```

No BLE hardware path changed. Synthetic planted captures only in CI; real multi-device evidence still comes from owner captures on #103.

## Checklist

- [x] Swift package tests N/A (Python tooling + docs)
- [x] Android unit tests N/A
- [x] `python3 -m unittest` for touched Tools/linux-capture tests pass
- [x] No hardcoded hex frame bytes in app code; protocol facts stay in existing decoders
- [x] Follows CONTRIBUTING (no proprietary material; facts only; does not invent SpO₂)
- [x] No secrets / generated project files

## Related issues

- Helps #103 (SpO₂ / deep-data validation)
- Related #761 (capability honesty — still no silent SpO₂ card)
- Follow-up to docs PR #807 (protocol facts)

