### PR TITLE
docs: add an in-repo FAQ and point the issue templates at it

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -14,7 +14,7 @@ body:
 
         ### ⛔ Next — is this already answered?
         Many "bugs" are expected behaviour or a known limit. **Please check these before filing — it's the fastest way to an answer:**
-        - **[FAQ](https://github.com/ryanbr/noop/wiki/FAQ)** — live HR, recovery/sleep, steps, importing, privacy, updates.
+        - **[FAQ](https://github.com/ryanbr/noop/blob/main/docs/FAQ.md)** — live HR, recovery/sleep, steps, importing, privacy, updates.
         - **[WHOOP 5.0 / MG status](https://github.com/ryanbr/noop/wiki/WHOOP-5.0-and-MG-Status)** — SpO₂, steps, recovery/sleep on the newer straps (the most common topic).
         - **[Troubleshooting](https://github.com/ryanbr/noop/wiki/Troubleshooting)** — pairing, "syncs but no data", generic HR straps.
 
@@ -147,7 +147,7 @@ body:
           required: true
         - label: I checked the [Troubleshooting guide](https://github.com/ryanbr/noop/wiki/Troubleshooting) — especially "history syncs but no data" (most often the strap isn't banking history to flash; charge it to 100% and reconnect).
           required: true
-        - label: I checked the [FAQ](https://github.com/ryanbr/noop/wiki/FAQ) and — if I'm on a WHOOP 5.0 / MG — the [5.0/MG status page](https://github.com/ryanbr/noop/wiki/WHOOP-5.0-and-MG-Status), and this isn't an already-known limit (e.g. SpO₂, or recovery/sleep on the 5/MG).
+        - label: I checked the [FAQ](https://github.com/ryanbr/noop/blob/main/docs/FAQ.md) and — if I'm on a WHOOP 5.0 / MG — the [5.0/MG status page](https://github.com/ryanbr/noop/wiki/WHOOP-5.0-and-MG-Status), and this isn't an already-known limit (e.g. SpO₂, or recovery/sleep on the 5/MG).
           required: true
         - label: I've left out anything personal (strap serial, account email, raw export).
           required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -4,7 +4,7 @@ contact_links:
     url: https://discord.com/invite/wKgyqVdjrP
     about: "Got a question, stuck on setup, or not sure something's a bug? Discord is the fastest place for a quick answer. (Confirmed bugs still go to a GitHub issue, with a strap log.)"
   - name: ❓ FAQ — start here (most questions are answered)
-    url: https://github.com/ryanbr/noop/wiki/FAQ
+    url: https://github.com/ryanbr/noop/blob/main/docs/FAQ.md
     about: "Live HR, recovery/sleep, steps, importing data, privacy, updates — the common questions are answered here. Please check before filing."
   - name: ⌚ WHOOP 5.0 / MG — what works & what doesn't
     url: https://github.com/ryanbr/noop/wiki/WHOOP-5.0-and-MG-Status

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -1,0 +1,84 @@
+# FAQ
+
+Answers to the questions that come up most often in issues. If your question isn't here,
+[ANALYTICS.md](ANALYTICS.md) documents how every score is computed and
+[PRIVACY_SECURITY.md](PRIVACY_SECURITY.md) covers what stays on your device.
+
+---
+
+## Why is NOOP's resting heart rate lower than the WHOOP app's?
+
+**Because they are different statistics over the same night, and the gap is expected.**
+
+NOOP's resting HR is the **lowest sustained level** during your in-bed window — the minimum of the
+night's 5-minute non-overlapping bin means. That rejects single-beat dips while capturing the night's
+true floor.
+
+The WHOOP app's figure sits closer to the **whole-night average**, which is naturally a few bpm
+higher. Typical reported gaps are 5–8 bpm.
+
+Neither number is wrong. NOOP logs both side by side so you can check it yourself — look for this
+line in your strap log:
+
+```
+rhr day=2026-07-16 floor=44 nightMean=50 inBedSamples=30247
+(floor = WHOOP-style lowest-sustained = NOOP RHR; mean = sleeping-HR-app number)
+```
+
+`floor` is what NOOP shows you; `nightMean` is the number closer to what the WHOOP app displays. If
+the difference between those two is roughly the difference you're seeing between the apps, there is
+nothing wrong with your data.
+
+## Why is my HRV different from the WHOOP app's?
+
+HRV is computed from the R-R (beat-to-beat) intervals your strap banks overnight, and small
+differences in which beats are accepted move the number. A large difference — roughly double — is
+worth reporting, because it usually means the R-R stream is over-covered.
+
+Your strap log carries the diagnostic:
+
+```
+hrv diag day=2026-07-16 rmssd=52ms sdnn=98ms coverage=2.54 collapsedCov=1.99 dupBeats=62
+```
+
+`coverage` above 1.0 means more R-R data arrived than wall-clock time allows, which points at
+duplicated beats. Include that line if you file an issue — it turns a "my HRV looks wrong" report
+into something diagnosable.
+
+## Does my data ever leave my device?
+
+No, unless you export it yourself. NOOP has no servers, no accounts and no cloud sync. The only
+feature that makes a network request is the optional AI Coach, which is off by default and uses an
+API key you supply, to a provider you choose.
+
+Two things do carry your data off-device **when you choose to send them**:
+
+- a `.noopbak` backup, which is a copy of the whole local database
+- the CSV/JSON export
+
+Both are user-initiated. See [docs/PRIVACY_SECURITY.md](PRIVACY_SECURITY.md).
+
+## Which numbers are measured, and which are NOOP's own estimates?
+
+Measured from the strap: heart rate, R-R intervals, resting HR, skin temperature, respiratory rate,
+sleep duration and stages.
+
+NOOP's own on-device scores, not clinical measures: Charge (recovery), Effort (strain), Rest (sleep
+performance), Stress, Fitness Age and Vitality. [docs/ANALYTICS.md](ANALYTICS.md) documents the
+formula behind each one.
+
+NOOP does not invent values it cannot measure. Where a figure needs an input your strap doesn't
+provide, the feature stays locked and says so rather than guessing.
+
+## Why does a score say "Calibrating"?
+
+Baseline-relative scores need history before they mean anything. Charge needs several nights of HRV
+before it can tell a high night from a low one, so it shows a countdown instead of a number.
+
+Tapping **Recalibrate baseline** restarts that countdown from zero — it discards the nights already
+banked. If you're sitting at "Calibrating" and tap it again, you reset your own progress.
+
+## Is NOOP a medical device?
+
+No. It is not a medical device and makes no diagnostic claim. Values are raw readings or
+locally-computed estimates, for personal and informational use only.


### PR DESCRIPTION
The bug template asks every reporter to tick "I checked the FAQ" — and that link is dead. `wiki/FAQ` 302s to the bare wiki root, as do `wiki/Troubleshooting` and `wiki/WHOOP-5.0-and-MG-Status`. The wiki has no pages at all, so `.wiki.git` does not exist and the pages cannot be created by push.

That is the direct cause of the recurring resting-HR reports. NOOP shows the lowest sustained in-bed level; the WHOOP app shows something nearer the whole-night mean, so NOOP reads 5–8 bpm lower **by design**. It is documented in `ANALYTICS.md` and in a v7.0.0 release note that says it is "answerable straight from the log" — which means exporting and reading a log to learn your data is fine. #550 is the master issue; #803 is the latest.

`docs/FAQ.md` answers that plus the questions that arrive with it: HRV differing from the app (including the `coverage` / `collapsedCov` line worth pasting when filing), what leaves the device, measured vs estimated numbers, why a score says Calibrating, and the not-a-medical-device line.

In-repo rather than wiki: versioned, reviewable, and a link to it cannot rot the way these three did.

**Scope:** only the three FAQ links are repointed. `Troubleshooting` and `WHOOP-5.0-and-MG-Status` are still dead in six more places — that needs either real wiki pages or the same in-repo treatment, and I did not want to invent content for them. Worth deciding separately.

Verified: both issue templates still parse as YAML, every relative link in the new doc resolves, i18n gate green.