### PR TITLE
Show the re-pair guide on Devices, not only on Live (#802)

### DIFF
--- a/Strand/Screens/DevicesView.swift
+++ b/Strand/Screens/DevicesView.swift
@@ -91,8 +91,39 @@ private struct DevicesContent: View {
         return (String(localized: "Clock latched: \(latched) · last frame \(frame)"), warning)
     }
 
+    /// #802: same shape and copy as `LiveView.reconnectGuideBanner`. Duplicated rather than hoisted
+    /// because the two live in different view files with no shared banner container today; the STRING is
+    /// shared, which is the part that must not drift.
+    private func repairGuideBanner(_ guide: String) -> some View {
+        HStack(alignment: .top, spacing: 10) {
+            Image(systemName: "exclamationmark.triangle.fill")
+                .foregroundStyle(StrandPalette.statusWarning)
+                .accessibilityHidden(true)
+            VStack(alignment: .leading, spacing: 3) {
+                Text("Can't connect: your strap's pairing was reset")
+                    .font(StrandFont.subhead).foregroundStyle(StrandPalette.textPrimary)
+                Text(guide)
+                    .font(StrandFont.footnote).foregroundStyle(StrandPalette.textSecondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            Spacer(minLength: 0)
+        }
+        .padding(NoopMetrics.space3)
+        .background(StrandPalette.surfaceRaised, in: RoundedRectangle(cornerRadius: 18, style: .continuous))
+        .overlay(RoundedRectangle(cornerRadius: 18, style: .continuous)
+            .strokeBorder(StrandPalette.statusWarning.opacity(0.5), lineWidth: 1))
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("Reconnect help: \(guide)")
+    }
+
     var body: some View {
         VStack(alignment: .leading, spacing: NoopMetrics.sectionSpacing) {
+            // #802: the re-pair guide belongs HERE too, not only on Live. A strap that connects but never
+            // finishes bonding leaves the user on this screen — it is where you go to fix a device — while
+            // the four steps that resolve it were rendered one tab away. The reporter in #802 filed an issue
+            // with the guide already armed, because nothing on Devices said so. Same state and same string
+            // as LiveView's banner; no new copy.
+            if let guide = live.reconnectGuide { repairGuideBanner(guide) }
             // UPPERCASE overline section header, matching the liquid Today. Counts the paired bands so the
             // multi-WHOOP reality reads at a glance.
             sectionHead("YOUR BANDS", trailing: activeDevices.count == 1

--- a/android/app/src/main/java/com/noop/ui/DevicesScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/DevicesScreen.kt
@@ -166,6 +166,31 @@ fun DevicesScreen(
         // down (Today / Trends / Sleep / metric-detail parity - same two prefs, same two behaviours).
         fullBleedBackground = showDayCycleBackground && skyBehindCards,
     ) {
+        // #802: the re-pair guide belongs HERE too, not only on Live. A strap that connects but never
+        // finishes bonding leaves the user on this screen — it is where you go to fix a device — while the
+        // four steps that actually resolve it were rendered one tab away. The reporter in #802 filed an
+        // issue with the guide already armed, because nothing on Devices said so. Same state, same strings
+        // as LiveScreen; no new copy.
+        live.reconnectGuide?.let { guide ->
+            item {
+                Column(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .background(Palette.surfaceRaised, RoundedCornerShape(12.dp))
+                        .border(1.dp, Palette.statusWarning.copy(alpha = 0.5f), RoundedCornerShape(12.dp))
+                        .padding(12.dp),
+                    verticalArrangement = Arrangement.spacedBy(3.dp),
+                ) {
+                    Text(
+                        uiString(R.string.l10n_live_screen_can_t_connect_your_strap_s_cf78be83),
+                        style = NoopType.subhead,
+                        color = Palette.textPrimary,
+                    )
+                    Text(guide, style = NoopType.footnote, color = Palette.textSecondary)
+                }
+            }
+        }
+
         if (devices == null) {
             // The registry resolves a beat after launch. Show a calm pending note in that brief window.
             item {


### PR DESCRIPTION
A WHOOP 5/MG that connects but never finishes bonding leaves the user on **Devices** — that is where you go to fix a device. The four steps that resolve it rendered only on **Live** (`LiveScreen.kt:262`, `LiveView.swift:92`), one tab away.

#802 is the evidence. That reporter hit the #971 bond-watchdog path, bounced to the give-up threshold (`reconnect n=4`) so the guide was already armed, and filed an issue anyway — because Devices showed a disconnected strap and no reason for it.

Worth noting Devices already surfaces the *adjacent* case: `bondRefused` at `DevicesScreen.kt:190` gates on `live.pairingHint`, which is the #78 **explicit-refusal** path (status 5/15). The watchdog timeout sets `reconnectGuide` instead — so of two neighbouring failure modes, only one said anything on this screen.

**Rendering only.** Both platforms already had `live` in scope there, so no state plumbing.

**No new copy.** Strings are reused verbatim from the Live banners — the iOS literal already resolves across de/es/fr/it/pt-PT/ru/zh-Hans/zh-Hant, and `l10n_live_screen_can_t_connect_your_strap_s_cf78be83` already exists in the Android catalog. Nothing to translate.

The iOS banner is duplicated rather than hoisted: the two views share no banner container today, and the string — the part that must not drift — is shared.

Verified: helper sits inside `DevicesContent` (the struct owning `@EnvironmentObject live`), all Compose imports the new block needs were already present, braces/parens balanced on both files, i18n gate green. Not built — no Xcode or JDK here — though the next staging build covers it.