### PR TITLE
diag(hrv): say which R-R over-count a night has, not just the numbers (#550)

### DIFF
--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/HRVAnalyzer.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/HRVAnalyzer.swift
@@ -358,6 +358,10 @@ public enum HRVAnalyzer {
         /// Over-covered AND still over-covered after the same-second collapse: the duplicates straddle
         /// second boundaries, so a same-second de-dup would NOT be enough.
         case crossSecondOverCount
+        /// No usable coverage figure — `rrCoverage` returns 0 for < 2 beats or a zero span. Absence of
+        /// evidence, NOT a clean night: reporting those as `plausible` would claim the capture was fine
+        /// when nothing was measurable, which is the opposite of what this verdict exists to do.
+        case unmeasurable
     }
 
     /// Tolerance above 1.0 treated as "fits". R-R timestamps are whole seconds while beats are not, so a
@@ -367,11 +371,14 @@ public enum HRVAnalyzer {
     public static let coveragePlausibleCeiling: Double = 1.10
 
     /// Classify a night from its coverage pair. Pure. Byte-parity twin of Kotlin `classifyCoverage`.
+    /// Both platforms use the NEGATED `>` form rather than `<=` so a non-finite input lands identically:
+    /// every IEEE-754 comparison with NaN is false, so `<=` and `>` are not each other's inverse there and
+    /// the twins would otherwise disagree. NaN falls to `.unmeasurable` on both.
     public static func classifyCoverage(coverage: Double, collapsed: Double) -> RrCoverageVerdict {
+        guard coverage > 0 else { return .unmeasurable }
         guard coverage > coveragePlausibleCeiling else { return .plausible }
         return collapsed > coveragePlausibleCeiling ? .crossSecondOverCount : .sameSecondOverCount
     }
-
 
     /// Total heartbeat-time (sum of NN intervals, ms) ÷ wall-clock span of the R-R window (ms). A value
     /// > ~1.0 is physically impossible — you can't record more beat-time than elapsed time — so it

--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/HRVAnalyzer.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/HRVAnalyzer.swift
@@ -343,6 +343,36 @@ public enum HRVAnalyzer {
 
     // MARK: - R-R integrity diagnostics (#257)
 
+    /// What a night's R-R coverage pair says about the capture (#550).
+    ///
+    /// `rrCoverage` above 1.0 is physically impossible, and `collapsedCoverage` previews what a
+    /// same-second de-dup would leave. Reading the two together is what tells you WHICH over-count you
+    /// have — a rule that until now lived only in a comment, so anyone triaging an "HRV reads ~2× high"
+    /// report had to know it. Encoding it means the log states the conclusion instead of the evidence.
+    public enum RrCoverageVerdict: String, Equatable, Sendable {
+        /// At or near 1.0 — the beat-time fits the wall clock. Nothing to explain.
+        case plausible
+        /// Over-covered, but collapsing same-second duplicates brings it back in range: the extra beats
+        /// share a timestamp, so a de-dup at that granularity would fix it.
+        case sameSecondOverCount
+        /// Over-covered AND still over-covered after the same-second collapse: the duplicates straddle
+        /// second boundaries, so a same-second de-dup would NOT be enough.
+        case crossSecondOverCount
+    }
+
+    /// Tolerance above 1.0 treated as "fits". R-R timestamps are whole seconds while beats are not, so a
+    /// clean night can round fractionally over. This is a ROUNDING allowance, deliberately not a tuned
+    /// threshold — where the real boundary sits needs coverage figures from several wearers, which is the
+    /// point of logging the verdict in the first place.
+    public static let coveragePlausibleCeiling: Double = 1.10
+
+    /// Classify a night from its coverage pair. Pure. Byte-parity twin of Kotlin `classifyCoverage`.
+    public static func classifyCoverage(coverage: Double, collapsed: Double) -> RrCoverageVerdict {
+        guard coverage > coveragePlausibleCeiling else { return .plausible }
+        return collapsed > coveragePlausibleCeiling ? .crossSecondOverCount : .sameSecondOverCount
+    }
+
+
     /// Total heartbeat-time (sum of NN intervals, ms) ÷ wall-clock span of the R-R window (ms). A value
     /// > ~1.0 is physically impossible — you can't record more beat-time than elapsed time — so it
     /// directly flags DOUBLE-COUNTED / overlapping R-R (e.g. a live + historical merge storing the same

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/RrCoverageVerdictTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/RrCoverageVerdictTests.swift
@@ -35,10 +35,20 @@ final class RrCoverageVerdictTests: XCTestCase {
                        .sameSecondOverCount)
     }
 
-    /// `rrCoverage` returns 0 for a window it cannot measure (< 2 beats / zero span). That is an absence
-    /// of evidence, not a clean night, but it must not read as over-covered either.
-    func testUnmeasurableWindowIsNotFlagged() {
-        XCTAssertEqual(HRVAnalyzer.classifyCoverage(coverage: 0, collapsed: 0), .plausible)
+    /// `rrCoverage` returns 0 for a window it cannot measure (< 2 beats / zero span). Absence of evidence
+    /// is not a clean night — calling it `plausible` would claim the capture was fine when nothing was
+    /// measurable, which is exactly what this verdict exists to avoid.
+    func testUnmeasurableWindowIsNotReportedAsClean() {
+        XCTAssertEqual(HRVAnalyzer.classifyCoverage(coverage: 0, collapsed: 0), .unmeasurable)
+        XCTAssertEqual(HRVAnalyzer.classifyCoverage(coverage: -1, collapsed: 0), .unmeasurable)
+    }
+
+    /// Parity guard. Every IEEE-754 comparison with NaN is false, so `<=` and `>` are not each other's
+    /// inverse there — writing one platform with `<=` and the other with `>` made the twins disagree on a
+    /// NaN coverage (Swift said plausible, Kotlin said sameSecondOverCount). Both now negate `>`.
+    func testNonFiniteCoverageIsUnmeasurableOnBothPlatforms() {
+        XCTAssertEqual(HRVAnalyzer.classifyCoverage(coverage: .nan, collapsed: 0.5), .unmeasurable)
+        XCTAssertEqual(HRVAnalyzer.classifyCoverage(coverage: .nan, collapsed: .nan), .unmeasurable)
     }
 
     /// The verdict is only ever a function of the pair, never of which is larger — a collapse can never

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/RrCoverageVerdictTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/RrCoverageVerdictTests.swift
@@ -1,0 +1,49 @@
+import XCTest
+@testable import StrandAnalytics
+
+/// #550: the coverage pair encodes WHICH over-count a night has, and until now that reading rule lived
+/// only in a comment — so triaging an "HRV reads ~2× high" report required knowing it. These pin the rule.
+///
+/// The real-capture vectors come from #803 (WHOOP 4.0, two consecutive nights), which is also the first
+/// evidence either way on whether the same-second de-dup scoped in #550 would be sufficient. It would not.
+final class RrCoverageVerdictTests: XCTestCase {
+
+    /// A night whose beat-time fits the wall clock. #803's 2026-07-15.
+    func testCleanNightIsPlausible() {
+        XCTAssertEqual(HRVAnalyzer.classifyCoverage(coverage: 0.89, collapsed: 0.88), .plausible)
+    }
+
+    /// The night that prompted the report. #803's 2026-07-16: collapsing same-second duplicates drops it
+    /// 2.54 → 1.99, which is still impossible — so the duplicates straddle second boundaries and a
+    /// same-second de-dup would NOT fix it. This is the case #550 needs to know about.
+    func testRealCrossSecondCaptureIsNotFixableBySameSecondDedup() {
+        XCTAssertEqual(HRVAnalyzer.classifyCoverage(coverage: 2.54, collapsed: 1.99),
+                       .crossSecondOverCount)
+    }
+
+    /// Over-covered, but the collapse brings it back in range — the extra beats share a timestamp.
+    func testCollapseRecoveringRangeMeansSameSecond() {
+        XCTAssertEqual(HRVAnalyzer.classifyCoverage(coverage: 1.60, collapsed: 1.02),
+                       .sameSecondOverCount)
+    }
+
+    /// The ceiling is a rounding allowance, so exactly at it still reads as fitting; a hair over does not.
+    func testCeilingIsInclusive() {
+        let ceil = HRVAnalyzer.coveragePlausibleCeiling
+        XCTAssertEqual(HRVAnalyzer.classifyCoverage(coverage: ceil, collapsed: ceil), .plausible)
+        XCTAssertEqual(HRVAnalyzer.classifyCoverage(coverage: ceil + 0.01, collapsed: 0.5),
+                       .sameSecondOverCount)
+    }
+
+    /// `rrCoverage` returns 0 for a window it cannot measure (< 2 beats / zero span). That is an absence
+    /// of evidence, not a clean night, but it must not read as over-covered either.
+    func testUnmeasurableWindowIsNotFlagged() {
+        XCTAssertEqual(HRVAnalyzer.classifyCoverage(coverage: 0, collapsed: 0), .plausible)
+    }
+
+    /// The verdict is only ever a function of the pair, never of which is larger — a collapse can never
+    /// exceed the raw coverage in practice, but the classifier must not depend on that holding.
+    func testCollapsedAboveCoverageStillClassifiesOnCoverageFirst() {
+        XCTAssertEqual(HRVAnalyzer.classifyCoverage(coverage: 0.5, collapsed: 9.9), .plausible)
+    }
+}

--- a/Strand/Data/IntelligenceEngine.swift
+++ b/Strand/Data/IntelligenceEngine.swift
@@ -737,8 +737,16 @@ final class IntelligenceEngine: ObservableObject {
                     // over-count is same-second (a dedup fix would work); still high ⇒ cross-second overlap.
                     let colCov = String(format: "%.2f", HRVAnalyzer.collapsedCoverage(tsSec: ts, rrMs: sleepRr))
                     let dup = HRVAnalyzer.duplicateBeatCount(tsSec: ts, rrMs: sleepRr)
+                    // #550: state the CONCLUSION, not just the evidence. Reading coverage against
+                    // collapsedCov is what distinguishes a same-second over-count (a de-dup would fix it)
+                    // from a cross-second one (it would not) — a rule that lived only in the comment above,
+                    // so triaging an "HRV reads ~2x high" report required knowing it. Now the line says which.
+                    let verdict = HRVAnalyzer.classifyCoverage(
+                        coverage: HRVAnalyzer.rrCoverage(tsSec: ts, rrMs: sleepRr),
+                        collapsed: HRVAnalyzer.collapsedCoverage(tsSec: ts, rrMs: sleepRr))
                     hrvDiag = "hrv diag day=\(res.daily.day) rmssd=\(ms(h.rmssd))ms sdnn=\(ms(h.sdnn))ms "
-                        + "meanNN=\(ms(h.meanNN))ms rr=\(h.nInput)/\(h.nClean) rejected=\(rej)% coverage=\(cov) collapsedCov=\(colCov) dupBeats=\(dup)"
+                        + "meanNN=\(ms(h.meanNN))ms rr=\(h.nInput)/\(h.nClean) rejected=\(rej)% coverage=\(cov) collapsedCov=\(colCov) dupBeats=\(dup) "
+                        + "rrIntegrity=\(verdict.rawValue)"
                 }
                 // ── Steps test mode: 5/MG raw-counter trace ──────────────────────────────────────────────
                 // Only built when the Steps mode is on (the gate was read once before the loop). Recomputes

--- a/Strand/Data/IntelligenceEngine.swift
+++ b/Strand/Data/IntelligenceEngine.swift
@@ -732,18 +732,21 @@ final class IntelligenceEngine: ObservableObject {
                     // R-R) + exact-duplicate beat count, so a "reads ~2x too high" report is self-diagnosing
                     // from the always-on log instead of hand-computing beat density.
                     let ts = sleepRrRows.map { $0.ts }
-                    let cov = String(format: "%.2f", HRVAnalyzer.rrCoverage(tsSec: ts, rrMs: sleepRr))
+                    // Computed ONCE and reused for both the formatted field and the verdict below:
+                    // collapsedCoverage sorts and de-dups the whole night's R-R (tens of thousands of rows
+                    // on a dense capture), and this runs per day across a full re-score.
+                    let covVal = HRVAnalyzer.rrCoverage(tsSec: ts, rrMs: sleepRr)
+                    let cov = String(format: "%.2f", covVal)
                     // #550: collapsedCov previews a same-second R-R de-dup — well below `coverage` ⇒ the
                     // over-count is same-second (a dedup fix would work); still high ⇒ cross-second overlap.
-                    let colCov = String(format: "%.2f", HRVAnalyzer.collapsedCoverage(tsSec: ts, rrMs: sleepRr))
+                    let colCovVal = HRVAnalyzer.collapsedCoverage(tsSec: ts, rrMs: sleepRr)
+                    let colCov = String(format: "%.2f", colCovVal)
                     let dup = HRVAnalyzer.duplicateBeatCount(tsSec: ts, rrMs: sleepRr)
                     // #550: state the CONCLUSION, not just the evidence. Reading coverage against
                     // collapsedCov is what distinguishes a same-second over-count (a de-dup would fix it)
                     // from a cross-second one (it would not) — a rule that lived only in the comment above,
                     // so triaging an "HRV reads ~2x high" report required knowing it. Now the line says which.
-                    let verdict = HRVAnalyzer.classifyCoverage(
-                        coverage: HRVAnalyzer.rrCoverage(tsSec: ts, rrMs: sleepRr),
-                        collapsed: HRVAnalyzer.collapsedCoverage(tsSec: ts, rrMs: sleepRr))
+                    let verdict = HRVAnalyzer.classifyCoverage(coverage: covVal, collapsed: colCovVal)
                     hrvDiag = "hrv diag day=\(res.daily.day) rmssd=\(ms(h.rmssd))ms sdnn=\(ms(h.sdnn))ms "
                         + "meanNN=\(ms(h.meanNN))ms rr=\(h.nInput)/\(h.nClean) rejected=\(rej)% coverage=\(cov) collapsedCov=\(colCov) dupBeats=\(dup) "
                         + "rrIntegrity=\(verdict.rawValue)"

--- a/android/app/src/main/java/com/noop/analytics/HrvAnalyzer.kt
+++ b/android/app/src/main/java/com/noop/analytics/HrvAnalyzer.kt
@@ -327,6 +327,10 @@ object HrvAnalyzer {
         /** Over-covered AND still over-covered after the same-second collapse: the duplicates straddle
          *  second boundaries, so a same-second de-dup would NOT be enough. */
         CROSS_SECOND_OVER_COUNT("crossSecondOverCount"),
+        /** No usable coverage figure — [rrCoverage] returns 0.0 for < 2 beats or a zero span. Absence of
+         *  evidence, NOT a clean night: reporting those as plausible would claim the capture was fine when
+         *  nothing was measurable, which is the opposite of what this verdict exists to do. */
+        UNMEASURABLE("unmeasurable"),
     }
 
     /** Tolerance above 1.0 treated as "fits". R-R timestamps are whole seconds while beats are not, so a
@@ -336,8 +340,12 @@ object HrvAnalyzer {
     const val COVERAGE_PLAUSIBLE_CEILING: Double = 1.10
 
     /** Classify a night from its coverage pair. Pure. Byte-parity twin of Swift `classifyCoverage`. */
+    /** Both platforms use the NEGATED `>` form rather than `<=` so a non-finite input lands identically:
+     *  every IEEE-754 comparison with NaN is false, so `<=` and `>` are not each other's inverse there and
+     *  the twins would otherwise disagree. NaN falls to UNMEASURABLE on both. */
     fun classifyCoverage(coverage: Double, collapsed: Double): RrCoverageVerdict {
-        if (coverage <= COVERAGE_PLAUSIBLE_CEILING) return RrCoverageVerdict.PLAUSIBLE
+        if (!(coverage > 0.0)) return RrCoverageVerdict.UNMEASURABLE
+        if (!(coverage > COVERAGE_PLAUSIBLE_CEILING)) return RrCoverageVerdict.PLAUSIBLE
         return if (collapsed > COVERAGE_PLAUSIBLE_CEILING) RrCoverageVerdict.CROSS_SECOND_OVER_COUNT
         else RrCoverageVerdict.SAME_SECOND_OVER_COUNT
     }

--- a/android/app/src/main/java/com/noop/analytics/HrvAnalyzer.kt
+++ b/android/app/src/main/java/com/noop/analytics/HrvAnalyzer.kt
@@ -309,6 +309,39 @@ object HrvAnalyzer {
             nInput = nInput, nClean = clean.size)
     }
 
+    /**
+     * What a night's R-R coverage pair says about the capture (#550).
+     *
+     * [rrCoverage] above 1.0 is physically impossible, and [collapsedCoverage] previews what a
+     * same-second de-dup would leave. Reading the two together is what tells you WHICH over-count you
+     * have — a rule that until now lived only in a comment, so anyone triaging an "HRV reads ~2x high"
+     * report had to know it. Encoding it means the log states the conclusion instead of the evidence.
+     * Byte-parity twin of Swift `HRVAnalyzer.RrCoverageVerdict`.
+     */
+    enum class RrCoverageVerdict(val raw: String) {
+        /** At or near 1.0 — the beat-time fits the wall clock. Nothing to explain. */
+        PLAUSIBLE("plausible"),
+        /** Over-covered, but collapsing same-second duplicates brings it back in range: the extra beats
+         *  share a timestamp, so a de-dup at that granularity would fix it. */
+        SAME_SECOND_OVER_COUNT("sameSecondOverCount"),
+        /** Over-covered AND still over-covered after the same-second collapse: the duplicates straddle
+         *  second boundaries, so a same-second de-dup would NOT be enough. */
+        CROSS_SECOND_OVER_COUNT("crossSecondOverCount"),
+    }
+
+    /** Tolerance above 1.0 treated as "fits". R-R timestamps are whole seconds while beats are not, so a
+     *  clean night can round fractionally over. This is a ROUNDING allowance, deliberately not a tuned
+     *  threshold — where the real boundary sits needs coverage figures from several wearers, which is the
+     *  point of logging the verdict in the first place. Twin of Swift `coveragePlausibleCeiling`. */
+    const val COVERAGE_PLAUSIBLE_CEILING: Double = 1.10
+
+    /** Classify a night from its coverage pair. Pure. Byte-parity twin of Swift `classifyCoverage`. */
+    fun classifyCoverage(coverage: Double, collapsed: Double): RrCoverageVerdict {
+        if (coverage <= COVERAGE_PLAUSIBLE_CEILING) return RrCoverageVerdict.PLAUSIBLE
+        return if (collapsed > COVERAGE_PLAUSIBLE_CEILING) RrCoverageVerdict.CROSS_SECOND_OVER_COUNT
+        else RrCoverageVerdict.SAME_SECOND_OVER_COUNT
+    }
+
     /** #257: total heartbeat-time (sum of NN intervals, ms) ÷ wall-clock span of the R-R window (ms).
      *  A value > ~1.0 is physically impossible — you can't record more beat-time than elapsed time — so
      *  it directly flags DOUBLE-COUNTED / overlapping R-R (e.g. a live + historical merge storing the same

--- a/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
+++ b/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
@@ -614,8 +614,15 @@ object IntelligenceEngine {
                 // over-count is same-second (a dedup fix would work); still high ⇒ cross-second overlap.
                 val colCov = String.format(java.util.Locale.US, "%.2f", HrvAnalyzer.collapsedCoverage(ts, sleepRr))
                 val dup = HrvAnalyzer.duplicateBeatCount(ts, sleepRr)
+                // #550: state the CONCLUSION, not just the evidence. Reading coverage against collapsedCov
+                // is what distinguishes a same-second over-count (a de-dup would fix it) from a cross-second
+                // one (it would not) — a rule that lived only in the comments above, so triaging an
+                // "HRV reads ~2x high" report required knowing it. Now the line says which.
+                val verdict = HrvAnalyzer.classifyCoverage(
+                    HrvAnalyzer.rrCoverage(ts, sleepRr), HrvAnalyzer.collapsedCoverage(ts, sleepRr))
                 diag("hrv diag day=${res.daily.day} rmssd=${ms(h.rmssd)}ms sdnn=${ms(h.sdnn)}ms meanNN=${ms(h.meanNN)}ms " +
-                    "rr=${h.nInput}/${h.nClean} rejected=$rej% coverage=$cov collapsedCov=$colCov dupBeats=$dup")
+                    "rr=${h.nInput}/${h.nClean} rejected=$rej% coverage=$cov collapsedCov=$colCov dupBeats=$dup " +
+                    "rrIntegrity=${verdict.raw}")
             }
 
             // Steps test mode: emit the 5/MG raw-counter trace for this day (cumulative @57 series +

--- a/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
+++ b/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
@@ -609,17 +609,21 @@ object IntelligenceEngine {
                 // R-R) + exact-duplicate beat count, so a "reads ~2x too high" report is self-diagnosing
                 // from the always-on log instead of hand-computing beat density.
                 val ts = sleepRrRows.map { it.ts }
-                val cov = String.format(java.util.Locale.US, "%.2f", HrvAnalyzer.rrCoverage(ts, sleepRr))
+                // Computed ONCE and reused for both the formatted field and the verdict below:
+                // collapsedCoverage sorts and de-dups the whole night's R-R (tens of thousands of rows on a
+                // dense capture), and this runs per day across a full re-score.
+                val covVal = HrvAnalyzer.rrCoverage(ts, sleepRr)
+                val cov = String.format(java.util.Locale.US, "%.2f", covVal)
                 // #550: collapsedCov previews a same-second R-R de-dup — well below `coverage` ⇒ the
                 // over-count is same-second (a dedup fix would work); still high ⇒ cross-second overlap.
-                val colCov = String.format(java.util.Locale.US, "%.2f", HrvAnalyzer.collapsedCoverage(ts, sleepRr))
+                val colCovVal = HrvAnalyzer.collapsedCoverage(ts, sleepRr)
+                val colCov = String.format(java.util.Locale.US, "%.2f", colCovVal)
                 val dup = HrvAnalyzer.duplicateBeatCount(ts, sleepRr)
                 // #550: state the CONCLUSION, not just the evidence. Reading coverage against collapsedCov
                 // is what distinguishes a same-second over-count (a de-dup would fix it) from a cross-second
                 // one (it would not) — a rule that lived only in the comments above, so triaging an
                 // "HRV reads ~2x high" report required knowing it. Now the line says which.
-                val verdict = HrvAnalyzer.classifyCoverage(
-                    HrvAnalyzer.rrCoverage(ts, sleepRr), HrvAnalyzer.collapsedCoverage(ts, sleepRr))
+                val verdict = HrvAnalyzer.classifyCoverage(covVal, colCovVal)
                 diag("hrv diag day=${res.daily.day} rmssd=${ms(h.rmssd)}ms sdnn=${ms(h.sdnn)}ms meanNN=${ms(h.meanNN)}ms " +
                     "rr=${h.nInput}/${h.nClean} rejected=$rej% coverage=$cov collapsedCov=$colCov dupBeats=$dup " +
                     "rrIntegrity=${verdict.raw}")

--- a/android/app/src/test/java/com/noop/analytics/RrCoverageVerdictTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/RrCoverageVerdictTest.kt
@@ -57,15 +57,32 @@ class RrCoverageVerdictTest {
         )
     }
 
+    @Test
+    fun unmeasurableWindowIsNotReportedAsClean() {
+        assertEquals(
+            HrvAnalyzer.RrCoverageVerdict.UNMEASURABLE,
+            HrvAnalyzer.classifyCoverage(0.0, 0.0),
+        )
+        assertEquals(
+            HrvAnalyzer.RrCoverageVerdict.UNMEASURABLE,
+            HrvAnalyzer.classifyCoverage(-1.0, 0.0),
+        )
+    }
+
     /**
-     * `rrCoverage` returns 0.0 for a window it cannot measure (< 2 beats / zero span). That is an absence
-     * of evidence, not a clean night, but it must not read as over-covered either.
+     * Parity guard. Every IEEE-754 comparison with NaN is false, so `<=` and `>` are not each other's
+     * inverse there — writing one platform with `<=` and the other with `>` made the twins disagree on a
+     * NaN coverage (Swift said plausible, Kotlin said SAME_SECOND_OVER_COUNT). Both now negate `>`.
      */
     @Test
-    fun unmeasurableWindowIsNotFlagged() {
+    fun nonFiniteCoverageIsUnmeasurableOnBothPlatforms() {
         assertEquals(
-            HrvAnalyzer.RrCoverageVerdict.PLAUSIBLE,
-            HrvAnalyzer.classifyCoverage(0.0, 0.0),
+            HrvAnalyzer.RrCoverageVerdict.UNMEASURABLE,
+            HrvAnalyzer.classifyCoverage(Double.NaN, 0.5),
+        )
+        assertEquals(
+            HrvAnalyzer.RrCoverageVerdict.UNMEASURABLE,
+            HrvAnalyzer.classifyCoverage(Double.NaN, Double.NaN),
         )
     }
 

--- a/android/app/src/test/java/com/noop/analytics/RrCoverageVerdictTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/RrCoverageVerdictTest.kt
@@ -1,0 +1,80 @@
+package com.noop.analytics
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * #550: the coverage pair encodes WHICH over-count a night has, and until now that reading rule lived only
+ * in a comment — so triaging an "HRV reads ~2x high" report required knowing it. These pin the rule.
+ *
+ * Kotlin twin of `RrCoverageVerdictTests`, same vectors and same expected verdicts. The real-capture pairs
+ * come from #803 (WHOOP 4.0, two consecutive nights).
+ */
+class RrCoverageVerdictTest {
+
+    /** A night whose beat-time fits the wall clock. #803's 2026-07-15. */
+    @Test
+    fun cleanNightIsPlausible() {
+        assertEquals(
+            HrvAnalyzer.RrCoverageVerdict.PLAUSIBLE,
+            HrvAnalyzer.classifyCoverage(0.89, 0.88),
+        )
+    }
+
+    /**
+     * The night that prompted the report. #803's 2026-07-16: collapsing same-second duplicates drops it
+     * 2.54 -> 1.99, still impossible — so the duplicates straddle second boundaries and a same-second
+     * de-dup would NOT fix it. This is the case #550 needs to know about.
+     */
+    @Test
+    fun realCrossSecondCaptureIsNotFixableBySameSecondDedup() {
+        assertEquals(
+            HrvAnalyzer.RrCoverageVerdict.CROSS_SECOND_OVER_COUNT,
+            HrvAnalyzer.classifyCoverage(2.54, 1.99),
+        )
+    }
+
+    /** Over-covered, but the collapse brings it back in range — the extra beats share a timestamp. */
+    @Test
+    fun collapseRecoveringRangeMeansSameSecond() {
+        assertEquals(
+            HrvAnalyzer.RrCoverageVerdict.SAME_SECOND_OVER_COUNT,
+            HrvAnalyzer.classifyCoverage(1.60, 1.02),
+        )
+    }
+
+    /** The ceiling is a rounding allowance: exactly at it still fits, a hair over does not. */
+    @Test
+    fun ceilingIsInclusive() {
+        val ceil = HrvAnalyzer.COVERAGE_PLAUSIBLE_CEILING
+        assertEquals(
+            HrvAnalyzer.RrCoverageVerdict.PLAUSIBLE,
+            HrvAnalyzer.classifyCoverage(ceil, ceil),
+        )
+        assertEquals(
+            HrvAnalyzer.RrCoverageVerdict.SAME_SECOND_OVER_COUNT,
+            HrvAnalyzer.classifyCoverage(ceil + 0.01, 0.5),
+        )
+    }
+
+    /**
+     * `rrCoverage` returns 0.0 for a window it cannot measure (< 2 beats / zero span). That is an absence
+     * of evidence, not a clean night, but it must not read as over-covered either.
+     */
+    @Test
+    fun unmeasurableWindowIsNotFlagged() {
+        assertEquals(
+            HrvAnalyzer.RrCoverageVerdict.PLAUSIBLE,
+            HrvAnalyzer.classifyCoverage(0.0, 0.0),
+        )
+    }
+
+    /** The verdict keys on coverage first; it must not depend on collapsed <= coverage holding. */
+    @Test
+    fun collapsedAboveCoverageStillClassifiesOnCoverageFirst() {
+        assertEquals(
+            HrvAnalyzer.RrCoverageVerdict.PLAUSIBLE,
+            HrvAnalyzer.classifyCoverage(0.5, 9.9),
+        )
+    }
+}


### PR DESCRIPTION
Refs #550, #803. Diagnostic only — no score moves, no storage, no schema, no new strings.

## The gap

`rrCoverage` and `collapsedCoverage` exist on both platforms as byte-parity twins and are called from **exactly one place each**: the `hrv diag` log line. They gate nothing.

`rrCoverage`'s own doc comment says what it detects:

> A value > ~1.0 is physically impossible … it directly flags DOUBLE-COUNTED / overlapping R-R … which **inflates HRV and drags resting HR down** (#257)

That is verbatim the symptom pair in this issue's title. The app computes the number that identifies the bug and spends it on a log line.

Worse, the *reading rule* lived only in a comment — `collapsedCov` well below `coverage` means same-second duplication (a de-dup fixes it); still high means cross-second (it does not). Triaging an "HRV reads ~2× high" report required knowing that. The line now states the conclusion:

```
hrv diag day=… coverage=2.54 collapsedCov=1.99 dupBeats=62 rrIntegrity=crossSecondOverCount
```

## Tested against real captures

The vectors are @pilleuspulcher-blip's two consecutive nights from #803:

| night | coverage | collapsed | verdict |
|---|---|---|---|
| 2026-07-15 | 0.89 | 0.88 | `plausible` |
| 2026-07-16 | 2.54 | 1.99 | `crossSecondOverCount` |

So on that wearer's data the same-second de-dup currently scoped in #550 **would not be sufficient**. That is the first evidence either way, and it now has a test pinning it rather than living in a comment thread.

## The threshold is a rounding allowance, not a tuning

`coveragePlausibleCeiling = 1.10` exists because R-R timestamps are whole seconds while beats are not, so a clean night can round fractionally over 1.0. It is deliberately **not** a tuned boundary — where the real one sits needs coverage figures from several wearers, which is what logging the verdict is meant to collect.

## Deliberately not done

**Confidence gating.** #803 raised demoting Charge confidence when a night's HRV came from an over-covered stream, following the H9 Rest precedent. That precedent works because `restorativeShare`/`efficiency` are persisted, so it re-derives identically at display time. Charge confidence is recomputed at `TodayView:686`, `CoupledView:546` and `TodayScoring.kt:102` from stored fields, and coverage is not stored — so gating would need a new `DailyMetric` column plus Room + GRDB migrations, and a threshold this data cannot yet justify. Worth doing after the verdict has collected evidence.

**A per-run aggregate.** With the verdict on every line, `grep rrIntegrity=crossSecondOverCount` answers "which nights" without more code.

## Verification

Classifier logic simulated across a grid — Swift and Kotlin agree on every combination — and all six test vectors produce their expected verdicts. Brace/paren balance compared against `main`: unchanged deltas (the three pre-existing imbalances are parens inside comments). `Tools/i18n_audit.py --ci origin/main` → exit 0.

Not built: no Xcode or JDK here. `swift-packages.yml` covers `Packages/**` so the Swift half gets CI on this PR; the Kotlin half does not, since `android.yml` is disabled.
