### PR TITLE
diag(whoop5): log what dynamic_acceleration actually looks like (#520)

### DIFF
--- a/Packages/WhoopProtocol/Sources/WhoopProtocol/HistoricalStreams.swift
+++ b/Packages/WhoopProtocol/Sources/WhoopProtocol/HistoricalStreams.swift
@@ -10,13 +10,6 @@ import Foundation
 /// FUTURE_MARGIN = 1 day — a historical record can never post-date its own capture, so anything more
 /// than a day ahead of wall time is a bad-clock artefact. Keep these in lockstep with the Android
 /// `HistoricalStreams.kt` MIN_PLAUSIBLE_UNIX / FUTURE_MARGIN.
-/// #520: the stillness cut used by the `dynamic_acceleration` diagnostic. Mirrors
-/// `SleepStager.gravityStillThresholdG` (0.01 g) so the diagnostic's still-fraction can be compared
-/// directly against the gravity-delta stillness the stager already computes. Duplicated as a literal
-/// rather than imported — WhoopProtocol is the wire layer and must not depend on StrandAnalytics.
-/// If the stager's constant moves, move this one with it.
-public let dynAccelStillThresholdG = 0.01
-
 public let MIN_PLAUSIBLE_UNIX = 1_700_000_000   // 2023-11
 public let FUTURE_MARGIN = 86_400               // 1 day
 
@@ -28,6 +21,15 @@ public let FUTURE_MARGIN = 86_400               // 1 day
 /// a 2026 strap window). 7 days absorbs marker jitter / a still-banking newest edge / DST while still
 /// catching the months-off garbage. Kept in lockstep with Android `HistoricalStreams.kt` SESSION_RANGE_MARGIN.
 public let SESSION_RANGE_MARGIN = 7 * 86_400    // 7 days
+
+/// #520: the stillness cut for the `dynamic_acceleration` diagnostic. Borrowed from
+/// `SleepStager.gravityStillThresholdG` (0.01 g) as a REFERENCE point, not because the two measure the
+/// same thing — the stager thresholds a per-sample DELTA between consecutive gravity vectors, while this
+/// field is an ABSOLUTE gravity-removed magnitude at one instant. Both approach 0 when the wrist is still,
+/// so the same cut is a sensible starting point, but a matching still-fraction would not prove the two are
+/// equivalent. Duplicated as a literal rather than imported — WhoopProtocol is the wire layer and must not
+/// depend on StrandAnalytics. If the stager's constant moves, move this one with it.
+public let dynAccelStillThresholdG = 0.01
 
 /// True when `ts` is a plausible capture time for a historical record given `wallNow` (#547): on or
 /// after the 2023-11 floor and no more than a day ahead of now. The single predicate the ingest gate
@@ -242,7 +244,8 @@ public func extractHistoricalStreams(_ parsed: [ParsedFrame],
             // #520 diagnostic: fold `dynamic_acceleration@41` into a summary. Counted, never stored —
             // the decoder has emitted this field all along with nothing consuming it, so there is no
             // evidence on whether it beats the gravity-delta stillness the stager derives today. The
-            // threshold matches `SleepStager.gravityStillThresholdG` so the ratios are comparable;
+            // threshold is the stager's own cut, borrowed as a reference point (the stager thresholds a
+            // per-sample delta, this is an absolute magnitude — related, not the same measurement);
             // it is passed as a literal because WhoopProtocol must not depend on StrandAnalytics.
             if let dyn = p["dynamic_acceleration"]?.doubleValue {
                 out.dynAccel.add(dyn, threshold: dynAccelStillThresholdG)

--- a/Packages/WhoopProtocol/Sources/WhoopProtocol/HistoricalStreams.swift
+++ b/Packages/WhoopProtocol/Sources/WhoopProtocol/HistoricalStreams.swift
@@ -10,6 +10,13 @@ import Foundation
 /// FUTURE_MARGIN = 1 day — a historical record can never post-date its own capture, so anything more
 /// than a day ahead of wall time is a bad-clock artefact. Keep these in lockstep with the Android
 /// `HistoricalStreams.kt` MIN_PLAUSIBLE_UNIX / FUTURE_MARGIN.
+/// #520: the stillness cut used by the `dynamic_acceleration` diagnostic. Mirrors
+/// `SleepStager.gravityStillThresholdG` (0.01 g) so the diagnostic's still-fraction can be compared
+/// directly against the gravity-delta stillness the stager already computes. Duplicated as a literal
+/// rather than imported — WhoopProtocol is the wire layer and must not depend on StrandAnalytics.
+/// If the stager's constant moves, move this one with it.
+public let dynAccelStillThresholdG = 0.01
+
 public let MIN_PLAUSIBLE_UNIX = 1_700_000_000   // 2023-11
 public let FUTURE_MARGIN = 86_400               // 1 day
 
@@ -231,6 +238,14 @@ public func extractHistoricalStreams(_ parsed: [ParsedFrame],
             if let gx = p["gravity_x"]?.doubleValue {
                 out.gravity.append(GravitySample(ts: ts, x: gx,
                     y: p["gravity_y"]?.doubleValue ?? 0, z: p["gravity_z"]?.doubleValue ?? 0))
+            }
+            // #520 diagnostic: fold `dynamic_acceleration@41` into a summary. Counted, never stored —
+            // the decoder has emitted this field all along with nothing consuming it, so there is no
+            // evidence on whether it beats the gravity-delta stillness the stager derives today. The
+            // threshold matches `SleepStager.gravityStillThresholdG` so the ratios are comparable;
+            // it is passed as a literal because WhoopProtocol must not depend on StrandAnalytics.
+            if let dyn = p["dynamic_acceleration"]?.doubleValue {
+                out.dynAccel.add(dyn, threshold: dynAccelStillThresholdG)
             }
         case "REALTIME_RAW_DATA":
             // #547 gate: the device-epoch→wall mapping can also land out of bounds on a bad clock, so

--- a/Packages/WhoopProtocol/Sources/WhoopProtocol/Streams.swift
+++ b/Packages/WhoopProtocol/Sources/WhoopProtocol/Streams.swift
@@ -262,8 +262,13 @@ public struct Streams: Equatable, Codable {
 
     /// #520 diagnostic: distribution of `dynamic_acceleration` over one decoded chunk. Deliberately a
     /// summary, not a stream — at 1 Hz a night is ~30k values and the open question needs a shape, not
-    /// samples. `still` counts values under `SleepStager.gravityStillThresholdG` (0.01 g) so the ratio is
-    /// directly comparable to the gravity-delta stillness the stager already uses.
+    /// samples. `still` counts values under `SleepStager.gravityStillThresholdG` (0.01 g) — borrowed as a
+    /// REFERENCE CUT, not because the two quantities are the same thing. The stager thresholds a per-sample
+    /// DELTA (how much the gravity vector moved between consecutive samples); this field is an ABSOLUTE
+    /// gravity-removed magnitude at one instant. Both go to ~0 when the wrist is still, so the same cut is a
+    /// sensible starting point, but the two still-fractions are not measuring the same thing and should not
+    /// be read as if a match proved equivalence. `min`/`max`/`mean` are here so a reader can re-derive any
+    /// other cut from the logs — picking the right one is what this diagnostic exists to inform.
     public struct DynAccelDiag: Equatable, Codable, Sendable {
         public var count = 0
         public var still = 0

--- a/Packages/WhoopProtocol/Sources/WhoopProtocol/Streams.swift
+++ b/Packages/WhoopProtocol/Sources/WhoopProtocol/Streams.swift
@@ -253,6 +253,69 @@ public struct Streams: Equatable, Codable {
     /// The #547 gate discards them like any bad-ts record, but these are the GROUND TRUTH that the clock reset
     /// - so we capture (kind, rawTs) for the strap log before dropping. Transient, empty by default, not encoded.
     public var droppedRtcEvents: [DroppedRtcEvent] = []
+    /// #520 diagnostic: a summary of `dynamic_acceleration@41` (the strap's own gravity-removed motion
+    /// magnitude) over this chunk's v18 records. The field is decoded but has never been persisted or
+    /// scored, so there is no evidence about whether it is a usable stillness signal; this counts what
+    /// arrived so the strap log can answer that from real nights before anyone pays for a migration.
+    /// Transient like the counters above — not in `CodingKeys`, defaults keep golden fixtures identical.
+    public var dynAccel = DynAccelDiag()
+
+    /// #520 diagnostic: distribution of `dynamic_acceleration` over one decoded chunk. Deliberately a
+    /// summary, not a stream — at 1 Hz a night is ~30k values and the open question needs a shape, not
+    /// samples. `still` counts values under `SleepStager.gravityStillThresholdG` (0.01 g) so the ratio is
+    /// directly comparable to the gravity-delta stillness the stager already uses.
+    public struct DynAccelDiag: Equatable, Codable, Sendable {
+        public var count = 0
+        public var still = 0
+        public var min: Double?
+        public var max: Double?
+        /// Mean over `count` values, or nil when nothing arrived. Kept as a running sum so a chunk of any
+        /// size costs O(1) memory.
+        public var sum = 0.0
+        public var mean: Double? { count > 0 ? sum / Double(count) : nil }
+        /// Fraction of values below the stillness threshold, or nil when nothing arrived.
+        public var stillFraction: Double? { count > 0 ? Double(still) / Double(count) : nil }
+
+        public init() {}
+
+        /// Fold another chunk's summary into this one. A chunk is an arbitrary slice of an offload, so the
+        /// still-fraction only means anything once a whole session is merged — the Backfiller accumulates
+        /// with this and logs once at the session boundary. Merging an empty diag is a no-op.
+        public mutating func merge(_ other: DynAccelDiag) {
+            guard other.count > 0 else { return }
+            count += other.count
+            still += other.still
+            sum += other.sum
+            if let lo = other.min { min = min.map { Swift.min($0, lo) } ?? lo }
+            if let hi = other.max { max = max.map { Swift.max($0, hi) } ?? hi }
+        }
+
+        /// The strap-log line for a whole offload session, or nil when nothing arrived (so a WHOOP 4.0 or a
+        /// caught-up session stays quiet). Pure and locale-independent — `String(format:)` with no locale is
+        /// POSIX, and the Kotlin twin passes `Locale.ROOT`, so both platforms emit the same bytes.
+        public func logLine(threshold: Double) -> String? {
+            guard count > 0, let lo = min, let hi = max, let avg = mean, let stillPct = stillFraction else {
+                return nil
+            }
+            // `%ld`, not `%d`: Swift's Int is 64-bit and `%d` reads a 32-bit int, which is undefined for
+            // large counts. Kotlin's `%d` takes a 32-bit Int and is correct there — different specifiers,
+            // identical output bytes, which is what the parity contract is about.
+            return String(format: "Backfill: dynaccel n=%ld still=%.0f%% mean=%.3f range=%.3f..%.3f g "
+                          + "(thr %.2f) — diagnostic only, not stored or scored (#520)",
+                          count, stillPct * 100, avg, lo, hi, threshold)
+        }
+
+        /// Fold one decoded value in. `threshold` is passed rather than imported so WhoopProtocol keeps no
+        /// dependency on StrandAnalytics; the caller supplies the stager's own constant.
+        public mutating func add(_ g: Double, threshold: Double) {
+            guard g.isFinite else { return }
+            count += 1
+            sum += g
+            if g < threshold { still += 1 }
+            if let m = min { self.min = Swift.min(m, g) } else { min = g }
+            if let m = max { self.max = Swift.max(m, g) } else { max = g }
+        }
+    }
     public init(hr: [HRSample] = [], rr: [RRInterval] = [],
                 spo2: [SpO2Sample] = [], skinTemp: [SkinTempSample] = [],
                 resp: [RespSample] = [], gravity: [GravitySample] = [],

--- a/Packages/WhoopProtocol/Sources/WhoopProtocol/Streams.swift
+++ b/Packages/WhoopProtocol/Sources/WhoopProtocol/Streams.swift
@@ -290,19 +290,27 @@ public struct Streams: Equatable, Codable {
             if let hi = other.max { max = max.map { Swift.max($0, hi) } ?? hi }
         }
 
+        /// Milli-g, rounded half-away-from-zero. Integers are the ONLY safe way to render this across the
+        /// two platforms: C's `%.3f` (what Swift's `String(format:)` uses) rounds half-to-EVEN while Java's
+        /// `String.format` rounds HALF_UP, so a tie diverges — 0.0625 g prints `0.062` on Swift and `0.063`
+        /// on Kotlin, and 0.0625 is exactly representable in the f32 the strap sends. Swift's `.rounded()`
+        /// and Kotlin's `round()` agree for non-negative input, and the decoder gates this field to
+        /// `[0, 8] g`, so the two sides round identically here.
+        static func mg(_ g: Double) -> Int { Int((g * 1000).rounded()) }
+
+        /// Whole percent, same rounding rule and the same reason (`%.0f` of 66.5 is 66 on Swift, 67 on Kotlin).
+        static func pct(_ fraction: Double) -> Int { Int((fraction * 100).rounded()) }
+
         /// The strap-log line for a whole offload session, or nil when nothing arrived (so a WHOOP 4.0 or a
-        /// caught-up session stays quiet). Pure and locale-independent — `String(format:)` with no locale is
-        /// POSIX, and the Kotlin twin passes `Locale.ROOT`, so both platforms emit the same bytes.
+        /// caught-up session stays quiet). Every field is an Int rendered by interpolation — no `String(format:)`,
+        /// so neither locale nor printf rounding mode can make the two platforms disagree.
         public func logLine(threshold: Double) -> String? {
-            guard count > 0, let lo = min, let hi = max, let avg = mean, let stillPct = stillFraction else {
+            guard count > 0, let lo = min, let hi = max, let avg = mean, let frac = stillFraction else {
                 return nil
             }
-            // `%ld`, not `%d`: Swift's Int is 64-bit and `%d` reads a 32-bit int, which is undefined for
-            // large counts. Kotlin's `%d` takes a 32-bit Int and is correct there — different specifiers,
-            // identical output bytes, which is what the parity contract is about.
-            return String(format: "Backfill: dynaccel n=%ld still=%.0f%% mean=%.3f range=%.3f..%.3f g "
-                          + "(thr %.2f) — diagnostic only, not stored or scored (#520)",
-                          count, stillPct * 100, avg, lo, hi, threshold)
+            return "Backfill: dynaccel n=\(count) still=\(Self.pct(frac))% mean=\(Self.mg(avg))mg "
+                + "range=\(Self.mg(lo))..\(Self.mg(hi))mg (thr \(Self.mg(threshold))mg) "
+                + "— diagnostic only, not stored or scored (#520)"
         }
 
         /// Fold one decoded value in. `threshold` is passed rather than imported so WhoopProtocol keeps no

--- a/Packages/WhoopProtocol/Tests/WhoopProtocolTests/DynAccelDiagTests.swift
+++ b/Packages/WhoopProtocol/Tests/WhoopProtocolTests/DynAccelDiagTests.swift
@@ -107,8 +107,20 @@ final class DynAccelDiagTests: XCTestCase {
         d.add(2.310, threshold: thr)
         XCTAssertEqual(
             d.logLine(threshold: thr),
-            "Backfill: dynaccel n=3 still=67% mean=0.773 range=0.004..2.310 g "
-            + "(thr 0.01) — diagnostic only, not stored or scored (#520)")
+            "Backfill: dynaccel n=3 still=67% mean=773mg range=4..2310mg "
+            + "(thr 10mg) — diagnostic only, not stored or scored (#520)")
+    }
+
+    /// The line renders integers rather than `%.3f` because the two platforms round ties differently: C
+    /// (Swift) is half-to-EVEN, Java (Kotlin) is HALF_UP, so `%.3f` of 0.0625 g is 0.062 on one and 0.063
+    /// on the other — and 0.0625 is exactly representable in the f32 the strap sends, so it is reachable.
+    /// These are the tie values; `mg`/`pct` must round them half-AWAY-from-zero, which is the one rule both
+    /// languages' rounding functions agree on for non-negative input.
+    func testTiesRoundAwayFromZeroNotPrintfStyle() {
+        XCTAssertEqual(Streams.DynAccelDiag.mg(0.0625), 63, "62.5 mg must round up, not to even")
+        XCTAssertEqual(Streams.DynAccelDiag.mg(0.0135), 14)
+        XCTAssertEqual(Streams.DynAccelDiag.pct(0.665), 67, "66.5% must round up, not to even")
+        XCTAssertEqual(Streams.DynAccelDiag.pct(0.005), 1, "0.5% must round up, not to even")
     }
 
     /// `extractHistoricalStreams` must actually populate the diag off a real frame, not just expose the

--- a/Packages/WhoopProtocol/Tests/WhoopProtocolTests/DynAccelDiagTests.swift
+++ b/Packages/WhoopProtocol/Tests/WhoopProtocolTests/DynAccelDiagTests.swift
@@ -39,9 +39,10 @@ final class DynAccelDiagTests: XCTestCase {
         XCTAssertEqual(d.mean ?? 0, 0.081489 / 6, accuracy: 1e-9)
     }
 
-    /// The threshold is a strict `<`, so a value sitting exactly on it is NOT still. Matters because the
-    /// stager's own comparison is `<` too — an off-by-one boundary here would make the two figures
-    /// non-comparable, which is the whole point of reusing the constant.
+    /// The threshold is a strict `<`, so a value sitting exactly on it is NOT still — matching the stager's
+    /// own `<`. Worth pinning because the cut is borrowed from the stager as a reference point, and a
+    /// boundary that differed would add a second discrepancy on top of the one that already exists (the
+    /// stager thresholds a delta, this an absolute magnitude).
     func testThresholdIsExclusive() {
         var d = Streams.DynAccelDiag()
         d.add(thr, threshold: thr)

--- a/Packages/WhoopProtocol/Tests/WhoopProtocolTests/DynAccelDiagTests.swift
+++ b/Packages/WhoopProtocol/Tests/WhoopProtocolTests/DynAccelDiagTests.swift
@@ -1,0 +1,148 @@
+import XCTest
+@testable import WhoopProtocol
+
+/// #520: `dynamic_acceleration@41` has been decoded on both platforms since the v18 layout was mapped,
+/// and nothing has ever consumed it — so there is no evidence on whether it is a usable stillness signal
+/// or redundant against the gravity deltas `SleepStager` already derives. These pin the diagnostic that
+/// collects that evidence: a summary, not a stream, logged once per offload session.
+///
+/// The Kotlin twin is `DynAccelDiagTest.kt`; both must fold in the same order and format the same bytes.
+final class DynAccelDiagTests: XCTestCase {
+
+    private let thr = dynAccelStillThresholdG   // 0.01 g, mirroring SleepStager.gravityStillThresholdG
+
+    /// Nothing arrived: every derived value is nil and the log line is suppressed, so a WHOOP 4.0 (which
+    /// never emits the field) or a caught-up session stays quiet rather than logging an empty summary.
+    func testEmptyDiagIsSilent() {
+        let d = Streams.DynAccelDiag()
+        XCTAssertEqual(d.count, 0)
+        XCTAssertNil(d.mean)
+        XCTAssertNil(d.stillFraction)
+        XCTAssertNil(d.min)
+        XCTAssertNil(d.max)
+        XCTAssertNil(d.logLine(threshold: thr))
+    }
+
+    /// The real f32@41 values from the six captured v18 frames — three of the six fall under the 0.01 g cut,
+    /// so this pins the arithmetic against numbers that actually came off a strap rather than round ones.
+    func testFoldsRealOracleValues() {
+        var d = Streams.DynAccelDiag()
+        for g in [0.009160, 0.010708, 0.005963, 0.014449, 0.032788, 0.008421] {
+            d.add(g, threshold: thr)
+        }
+        XCTAssertEqual(d.count, 6)
+        // Under 0.01 g: 0.009160, 0.005963, 0.008421.
+        XCTAssertEqual(d.still, 3)
+        XCTAssertEqual(d.stillFraction ?? 0, 0.5, accuracy: 1e-12)
+        XCTAssertEqual(d.min ?? 0, 0.005963, accuracy: 1e-12)
+        XCTAssertEqual(d.max ?? 0, 0.032788, accuracy: 1e-12)
+        XCTAssertEqual(d.mean ?? 0, 0.081489 / 6, accuracy: 1e-9)
+    }
+
+    /// The threshold is a strict `<`, so a value sitting exactly on it is NOT still. Matters because the
+    /// stager's own comparison is `<` too — an off-by-one boundary here would make the two figures
+    /// non-comparable, which is the whole point of reusing the constant.
+    func testThresholdIsExclusive() {
+        var d = Streams.DynAccelDiag()
+        d.add(thr, threshold: thr)
+        XCTAssertEqual(d.still, 0, "a value exactly at the threshold is not still")
+        d.add(thr - 1e-9, threshold: thr)
+        XCTAssertEqual(d.still, 1)
+    }
+
+    /// A non-finite value is dropped entirely rather than counted or folded into the sum — one NaN would
+    /// otherwise poison mean/min/max for the whole session and make the diagnostic unreadable.
+    func testNonFiniteValuesAreIgnored() {
+        var d = Streams.DynAccelDiag()
+        d.add(0.02, threshold: thr)
+        d.add(.nan, threshold: thr)
+        d.add(.infinity, threshold: thr)
+        XCTAssertEqual(d.count, 1)
+        XCTAssertEqual(d.mean ?? 0, 0.02, accuracy: 1e-12)
+        XCTAssertEqual(d.max ?? 0, 0.02, accuracy: 1e-12)
+    }
+
+    /// Merging is what makes the session figure meaningful: a chunk is an arbitrary slice of an offload, so
+    /// the still-fraction only means anything once every chunk is folded together.
+    func testMergeCombinesChunks() {
+        var a = Streams.DynAccelDiag()
+        a.add(0.004, threshold: thr)
+        a.add(0.006, threshold: thr)
+        var b = Streams.DynAccelDiag()
+        b.add(0.500, threshold: thr)
+        a.merge(b)
+        XCTAssertEqual(a.count, 3)
+        XCTAssertEqual(a.still, 2)
+        XCTAssertEqual(a.min ?? 0, 0.004, accuracy: 1e-12)
+        XCTAssertEqual(a.max ?? 0, 0.500, accuracy: 1e-12)
+        XCTAssertEqual(a.mean ?? 0, 0.510 / 3, accuracy: 1e-12)
+    }
+
+    /// Merging an empty diag must not disturb the accumulator — a console-only chunk is common mid-offload.
+    func testMergingEmptyIsNoOp() {
+        var a = Streams.DynAccelDiag()
+        a.add(0.02, threshold: thr)
+        let before = a
+        a.merge(Streams.DynAccelDiag())
+        XCTAssertEqual(a, before)
+    }
+
+    /// Merging INTO an empty accumulator has to adopt the other side's min/max rather than leaving them nil
+    /// — the session accumulator starts empty, so this is the first merge of every session.
+    func testMergeIntoEmptyAdoptsBounds() {
+        var a = Streams.DynAccelDiag()
+        var b = Streams.DynAccelDiag()
+        b.add(0.03, threshold: thr)
+        b.add(0.07, threshold: thr)
+        a.merge(b)
+        XCTAssertEqual(a, b)
+    }
+
+    /// The log line is the deliverable — the byte-identical contract with Kotlin. Pinned exactly so a
+    /// format drift on either platform fails rather than silently producing two different corpora.
+    func testLogLineFormat() {
+        var d = Streams.DynAccelDiag()
+        d.add(0.004, threshold: thr)
+        d.add(0.006, threshold: thr)
+        d.add(2.310, threshold: thr)
+        XCTAssertEqual(
+            d.logLine(threshold: thr),
+            "Backfill: dynaccel n=3 still=67% mean=0.773 range=0.004..2.310 g "
+            + "(thr 0.01) — diagnostic only, not stored or scored (#520)")
+    }
+
+    /// `extractHistoricalStreams` must actually populate the diag off a real frame, not just expose the
+    /// type. Uses the same captured worn frame the oracle pins, whose f32@41 is 0.009160 g.
+    func testExtractionPopulatesDiagFromARealFrame() throws {
+        let hex = try realWornV18Hex()
+        let parsed = parseFrame(hexToBytes(hex), family: .whoop5)
+        let out = extractHistoricalStreams([parsed], deviceClockRef: 0, wallClockRef: 0)
+        XCTAssertEqual(out.dynAccel.count, 1, "the v18 path did not fold dynamic_acceleration")
+        XCTAssertEqual(out.dynAccel.max ?? 0, 0.009160, accuracy: 1e-5)
+        XCTAssertEqual(out.dynAccel.still, 1, "0.00916 g is under the 0.01 g stillness cut")
+    }
+
+    /// Local hex decoder — every other suite in this target keeps its own file-private copy rather than
+    /// widening a shared test helper, so this follows the same convention.
+    private func hexToBytes(_ s: String) -> [UInt8] {
+        var out: [UInt8] = []
+        var idx = s.startIndex
+        while idx < s.endIndex, let next = s.index(idx, offsetBy: 2, limitedBy: s.endIndex) {
+            out.append(UInt8(s[idx..<next], radix: 16) ?? 0)
+            idx = next
+        }
+        return out
+    }
+
+    /// Pull the captured frame out of the shared decoder oracle rather than re-pasting bytes, so this test
+    /// and the cross-platform oracle can never disagree about what the frame is.
+    private func realWornV18Hex() throws -> String {
+        struct Oracle: Decodable {
+            struct Frame: Decodable { let name: String; let hex: String }
+            let frames: [Frame]
+        }
+        let url = try XCTUnwrap(Bundle.module.url(forResource: "decoder_oracle", withExtension: "json"))
+        let oracle = try JSONDecoder().decode(Oracle.self, from: Data(contentsOf: url))
+        return try XCTUnwrap(oracle.frames.first { $0.name == "whoop5_v18_real_worn" }?.hex)
+    }
+}

--- a/Strand/BLE/BLEManager.swift
+++ b/Strand/BLE/BLEManager.swift
@@ -1776,6 +1776,13 @@ public final class BLEManager: NSObject, ObservableObject {
                 log(diag)
             }
         }
+        // #520: the motion-magnitude diagnostic for this session. Emitted independently of the summary
+        // above — a caught-up session banks no rows but can still have decoded records — and silent when
+        // nothing carried the field, which a WHOOP 4.0 never does.
+        if let bf = backfiller,
+           let dynLine = bf.sessionDynAccel.logLine(threshold: dynAccelStillThresholdG) {
+            log(dynLine)
+        }
         // Connection test mode: the offload OUTCOME the readout's lastOffloadResult id binds. Gated
         // zero-cost (the .connection bool is read before any string is built). Diagnostic only - it reads
         // the same per-session tallies the existing summary above does, changing no offload behaviour. A

--- a/Strand/Collect/Backfiller.swift
+++ b/Strand/Collect/Backfiller.swift
@@ -493,15 +493,15 @@ final class Backfiller {
                 log?("Historical records use firmware layout v\(v), which NOOP doesn't decode yet — no motion data, so sleep can't be computed from the strap. Please report this (issue #30).")
             }
             let decoded = d.decoded
+            // #520: accumulate the motion-magnitude diagnostic across the session; logged once at the
+            // session boundary by BLEManager, never per chunk. Merge logic lives in WhoopProtocol so it is
+            // covered by swift-packages CI — this app-target file is not.
+            sessionDynAccel.merge(decoded.dynAccel)
             // #547: surface a bad-clock strap. extractHistoricalStreams DROPPED any record whose own unix
             // timestamp was implausible (far-past / bogus-2027 / future-dated) before it could pollute the
             // DB. Log it (once it's accrued at least one this session, on the first chunk that sees it) so
             // the user's strap log explains why a clock-broken strap banks fewer rows than expected — this
             // is the strap's clock, not a NOOP decode bug. Observability only; the gate already did the work.
-            // #520: accumulate the motion-magnitude diagnostic across the session; logged once at the
-            // session boundary by BLEManager, never per chunk. Merge logic lives in WhoopProtocol so it is
-            // covered by swift-packages CI — this app-target file is not.
-            sessionDynAccel.merge(decoded.dynAccel)
             if decoded.droppedImplausible > 0 {
                 let wasZero = sessionDroppedImplausible == 0
                 sessionDroppedImplausible += decoded.droppedImplausible

--- a/Strand/Collect/Backfiller.swift
+++ b/Strand/Collect/Backfiller.swift
@@ -132,6 +132,11 @@ final class Backfiller {
     /// ingest gate already kept the garbage rows out of the DB).
     private(set) var sessionDroppedImplausible = 0
 
+    /// #520 diagnostic: `dynamic_acceleration` folded across every chunk of this session, logged once at
+    /// the session boundary. Session-scoped rather than per-chunk because a chunk is an arbitrary slice of
+    /// an offload — a still-fraction only means something over a whole night's worth of records.
+    private(set) var sessionDynAccel = Streams.DynAccelDiag()
+
     /// The trim cursor of the LAST chunk this Backfiller acked (durably persisted + confirmed to the
     /// strap). Survives across sessions on the same connection so the auto-continue gate (#364) can ask
     /// "did the offload actually advance the strap's trim this session?" — the spin-detector signal that
@@ -229,6 +234,7 @@ final class Backfiller {
         loggedNoCursor = false
         loggedFutureRtc = false
         sessionDroppedImplausible = 0
+        sessionDynAccel = Streams.DynAccelDiag()
         loggedLayoutVersions.removeAll(keepingCapacity: true)
         spo2Dumped = 0
         // #547: the range markers belong to a connection's GET_DATA_RANGE, which BLEManager re-sets per
@@ -492,6 +498,10 @@ final class Backfiller {
             // DB. Log it (once it's accrued at least one this session, on the first chunk that sees it) so
             // the user's strap log explains why a clock-broken strap banks fewer rows than expected — this
             // is the strap's clock, not a NOOP decode bug. Observability only; the gate already did the work.
+            // #520: accumulate the motion-magnitude diagnostic across the session; logged once at the
+            // session boundary by BLEManager, never per chunk. Merge logic lives in WhoopProtocol so it is
+            // covered by swift-packages CI — this app-target file is not.
+            sessionDynAccel.merge(decoded.dynAccel)
             if decoded.droppedImplausible > 0 {
                 let wasZero = sessionDroppedImplausible == 0
                 sessionDroppedImplausible += decoded.droppedImplausible

--- a/android/app/src/main/java/com/noop/ble/Backfiller.kt
+++ b/android/app/src/main/java/com/noop/ble/Backfiller.kt
@@ -415,13 +415,13 @@ class Backfiller(
                     spo2Dumped++
                 }
             }
+            // #520: accumulate the motion-magnitude diagnostic across the session; logged once at the
+            // session boundary, never per batch.
+            sessionDynAccel.merge(decoded.dynAccel)
             // #547: the strap is emitting records with implausible timestamps (a bad clock/flash —
             // far-past, a year-2027 spike, or future-dated `unix`). The ingest gate dropped them so they
             // can't pollute the day-windowed analytics; surface it ONCE per session so a bad-clock strap
             // is visible in a shared log (the strap clock is genuinely bad — this is NOOP being robust).
-            // #520: accumulate the motion-magnitude diagnostic across the session; logged once at the
-            // session boundary, never per batch.
-            sessionDynAccel.merge(decoded.dynAccel)
             sessionDroppedImplausible += decoded.droppedImplausibleTs
             if (decoded.droppedImplausibleTs > 0 && !loggedImplausibleClock) {
                 loggedImplausibleClock = true

--- a/android/app/src/main/java/com/noop/ble/Backfiller.kt
+++ b/android/app/src/main/java/com/noop/ble/Backfiller.kt
@@ -1,6 +1,7 @@
 package com.noop.ble
 
 import android.content.Context
+import com.noop.data.DynAccelDiag
 import com.noop.data.InsertCounts
 import com.noop.data.StreamBatch
 import com.noop.data.WhoopRepository
@@ -256,6 +257,14 @@ class Backfiller(
      * build whose gate was weaker. Reset in [begin]. Mirrors Swift `Backfiller.sessionDroppedImplausible`.
      */
     var sessionDroppedImplausible = 0
+
+    /**
+     * #520 diagnostic: `dynamic_acceleration` folded across every batch of this session, logged once at the
+     * session boundary. Session-scoped rather than per-batch because a batch is an arbitrary slice of an
+     * offload — a still-fraction only means something over a whole night's worth of records. Twin of Swift
+     * `Backfiller.sessionDynAccel`.
+     */
+    var sessionDynAccel = DynAccelDiag()
         private set
 
     /**
@@ -279,6 +288,7 @@ class Backfiller(
         spo2Dumped = 0
         loggedImplausibleClock = false
         sessionDroppedImplausible = 0
+        sessionDynAccel = DynAccelDiag()
         // #547: the range markers belong to a connection's GET_DATA_RANGE, which the client re-sets per
         // connect; clear them so a fresh session never reuses a previous strap's window (the client
         // re-publishes them as soon as the range reply arrives).
@@ -409,6 +419,9 @@ class Backfiller(
             // far-past, a year-2027 spike, or future-dated `unix`). The ingest gate dropped them so they
             // can't pollute the day-windowed analytics; surface it ONCE per session so a bad-clock strap
             // is visible in a shared log (the strap clock is genuinely bad — this is NOOP being robust).
+            // #520: accumulate the motion-magnitude diagnostic across the session; logged once at the
+            // session boundary, never per batch.
+            sessionDynAccel.merge(decoded.dynAccel)
             sessionDroppedImplausible += decoded.droppedImplausibleTs
             if (decoded.droppedImplausibleTs > 0 && !loggedImplausibleClock) {
                 loggedImplausibleClock = true

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -32,6 +32,7 @@ import com.noop.data.StreamPersistence
 import com.noop.protocol.Whoop5RawImu
 import com.noop.data.WhoopRepository
 import com.noop.protocol.AlarmPayload
+import com.noop.protocol.DYN_ACCEL_STILL_THRESHOLD_G
 import com.noop.protocol.BackfillCaptureJsonl
 import com.noop.protocol.BackfillCaptureRecord
 import com.noop.protocol.BackfillCaptureSummary
@@ -6029,6 +6030,11 @@ class WhoopBleClient(
             // itself - not gated on the Connection test mode. Twin of the macOS LiveState sink hook.
             testCentre.noteDrainedRows(backfiller.sessionRowsPersisted)
         }
+
+        // #520: the motion-magnitude diagnostic for this session. Emitted independently of the summary
+        // above (a caught-up session banks no rows but can still have decoded records), and silent when
+        // nothing carried the field — a WHOOP 4.0 never does. Twin of the macOS exitBackfilling hook.
+        backfiller.sessionDynAccel.logLine(DYN_ACCEL_STILL_THRESHOLD_G)?.let { log(it) }
 
         // Connection test mode: the offload OUTCOME the readout's lastOffloadResult id binds. Gated
         // zero-cost (the CONNECTION bool is read before any string is built). Diagnostic only - it reads

--- a/android/app/src/main/java/com/noop/data/WhoopRepository.kt
+++ b/android/app/src/main/java/com/noop/data/WhoopRepository.kt
@@ -60,11 +60,88 @@ data class StreamBatch(
      * so they are captured here for the strap log. Diag only; empty when none. Mirrors Swift `droppedRtcEvents`.
      */
     val droppedRtcEvents: List<DroppedRtcEvent> = emptyList(),
+    /**
+     * #520 diagnostic: a summary of `dynamic_acceleration@41` (the strap's own gravity-removed motion
+     * magnitude) over this batch's v18 records. The field has been decoded on both platforms all along
+     * with nothing consuming it, so there is no evidence on whether it is a usable stillness signal;
+     * this counts what arrived so the strap log can answer that from real nights before anyone pays for
+     * a migration. Diag only (excluded from [isEmpty]). Byte-identical twin of Swift `Streams.dynAccel`.
+     */
+    val dynAccel: DynAccelDiag = DynAccelDiag(),
 ) {
     val isEmpty: Boolean
         get() = hr.isEmpty() && rr.isEmpty() && events.isEmpty() && battery.isEmpty() &&
             spo2.isEmpty() && skinTemp.isEmpty() && resp.isEmpty() && gravity.isEmpty() &&
             steps.isEmpty() && sleepState.isEmpty() && ppgHr.isEmpty() && ppgWaveform.isEmpty()
+}
+
+/**
+ * #520 diagnostic: distribution of `dynamic_acceleration` over one decoded batch. Deliberately a
+ * summary, not a stream — at 1 Hz a night is ~30k values and the open question needs a shape, not
+ * samples. [still] counts values under `SleepStager.gravityStillThresholdG` (0.01 g) so the ratio is
+ * directly comparable to the gravity-delta stillness the stager already uses. Byte-identical twin of
+ * Swift `Streams.DynAccelDiag` — same fields, same fold order, same nulls.
+ */
+data class DynAccelDiag(
+    var count: Int = 0,
+    var still: Int = 0,
+    var min: Double? = null,
+    var max: Double? = null,
+    /** Running sum, so a batch of any size costs O(1) memory. */
+    var sum: Double = 0.0,
+) {
+    /** Mean over [count] values, or null when nothing arrived. */
+    val mean: Double? get() = if (count > 0) sum / count else null
+
+    /** Fraction of values below the stillness threshold, or null when nothing arrived. */
+    val stillFraction: Double? get() = if (count > 0) still.toDouble() / count else null
+
+    /**
+     * Fold another batch's summary into this one. A batch is an arbitrary slice of an offload, so the
+     * still-fraction only means anything once a whole session is merged — the Backfiller accumulates with
+     * this and logs once at the session boundary. Merging an empty diag is a no-op. Twin of Swift.
+     */
+    fun merge(other: DynAccelDiag) {
+        if (other.count <= 0) return
+        count += other.count
+        still += other.still
+        sum += other.sum
+        other.min?.let { lo -> min = min?.let { kotlin.math.min(it, lo) } ?: lo }
+        other.max?.let { hi -> max = max?.let { kotlin.math.max(it, hi) } ?: hi }
+    }
+
+    /**
+     * The strap-log line for a whole offload session, or null when nothing arrived (so a WHOOP 4.0 or a
+     * caught-up session stays quiet). Pure and locale-independent: [java.util.Locale.ROOT] is mandatory
+     * here — the default locale would render `0,021` in e.g. de/fr and diverge from Swift, whose
+     * `String(format:)` is POSIX. Byte-identical twin of Swift `DynAccelDiag.logLine`.
+     */
+    fun logLine(threshold: Double): String? {
+        val lo = min ?: return null
+        val hi = max ?: return null
+        val avg = mean ?: return null
+        val stillPct = stillFraction ?: return null
+        if (count <= 0) return null
+        return String.format(
+            java.util.Locale.ROOT,
+            "Backfill: dynaccel n=%d still=%.0f%% mean=%.3f range=%.3f..%.3f g " +
+                "(thr %.2f) — diagnostic only, not stored or scored (#520)",
+            count, stillPct * 100, avg, lo, hi, threshold,
+        )
+    }
+
+    /**
+     * Fold one decoded value in. [threshold] is passed rather than imported so the protocol layer keeps
+     * no dependency on the analytics layer; the caller supplies the stager's own constant.
+     */
+    fun add(g: Double, threshold: Double) {
+        if (!g.isFinite()) return
+        count += 1
+        sum += g
+        if (g < threshold) still += 1
+        min = min?.let { kotlin.math.min(it, g) } ?: g
+        max = max?.let { kotlin.math.max(it, g) } ?: g
+    }
 }
 
 // Device-agnostic decoded rows (deviceId attached when inserted). Mirror Streams.swift shapes.

--- a/android/app/src/main/java/com/noop/data/WhoopRepository.kt
+++ b/android/app/src/main/java/com/noop/data/WhoopRepository.kt
@@ -112,22 +112,37 @@ data class DynAccelDiag(
 
     /**
      * The strap-log line for a whole offload session, or null when nothing arrived (so a WHOOP 4.0 or a
-     * caught-up session stays quiet). Pure and locale-independent: [java.util.Locale.ROOT] is mandatory
-     * here — the default locale would render `0,021` in e.g. de/fr and diverge from Swift, whose
-     * `String(format:)` is POSIX. Byte-identical twin of Swift `DynAccelDiag.logLine`.
+     * caught-up session stays quiet). Every field is an Int rendered by interpolation — deliberately NOT
+     * [String.format]. Two separate traps live in that function: the default locale renders `0,021` on a
+     * de/fr device, and Java rounds HALF_UP where C (and so Swift) rounds half-to-EVEN, which makes ties
+     * diverge. Integers avoid both. Byte-identical twin of Swift `DynAccelDiag.logLine`.
      */
     fun logLine(threshold: Double): String? {
         val lo = min ?: return null
         val hi = max ?: return null
         val avg = mean ?: return null
-        val stillPct = stillFraction ?: return null
+        val frac = stillFraction ?: return null
         if (count <= 0) return null
-        return String.format(
-            java.util.Locale.ROOT,
-            "Backfill: dynaccel n=%d still=%.0f%% mean=%.3f range=%.3f..%.3f g " +
-                "(thr %.2f) — diagnostic only, not stored or scored (#520)",
-            count, stillPct * 100, avg, lo, hi, threshold,
-        )
+        return "Backfill: dynaccel n=$count still=${pct(frac)}% mean=${mg(avg)}mg " +
+            "range=${mg(lo)}..${mg(hi)}mg (thr ${mg(threshold)}mg) " +
+            "— diagnostic only, not stored or scored (#520)"
+    }
+
+    companion object {
+        /**
+         * Milli-g, rounded to match Swift's `.rounded()` (ties away from zero).
+         *
+         * [kotlin.math.roundToInt] is REQUIRED here and [kotlin.math.round] is WRONG: `round` is
+         * `Math.rint`, which breaks ties toward the EVEN integer, while `roundToInt` is `Math.round`,
+         * which breaks them toward positive infinity — the same answer as Swift for non-negative input.
+         * With `round`, 62.5 mg would give 62 on Kotlin and 63 on Swift, which is exactly the printf
+         * divergence this integer formatting exists to avoid. The decoder gates this field to `[0, 8] g`
+         * so input is never negative, where the two rules would part company again.
+         */
+        fun mg(g: Double): Int = (g * 1000).roundToInt()
+
+        /** Whole percent, same rounding rule and the same reason. */
+        fun pct(fraction: Double): Int = (fraction * 100).roundToInt()
     }
 
     /**

--- a/android/app/src/main/java/com/noop/data/WhoopRepository.kt
+++ b/android/app/src/main/java/com/noop/data/WhoopRepository.kt
@@ -78,9 +78,13 @@ data class StreamBatch(
 /**
  * #520 diagnostic: distribution of `dynamic_acceleration` over one decoded batch. Deliberately a
  * summary, not a stream — at 1 Hz a night is ~30k values and the open question needs a shape, not
- * samples. [still] counts values under `SleepStager.gravityStillThresholdG` (0.01 g) so the ratio is
- * directly comparable to the gravity-delta stillness the stager already uses. Byte-identical twin of
- * Swift `Streams.DynAccelDiag` — same fields, same fold order, same nulls.
+ * samples. [still] counts values under `SleepStager.gravityStillThresholdG` (0.01 g) — borrowed as a
+ * REFERENCE CUT, not because the two quantities are the same thing. The stager thresholds a per-sample
+ * DELTA (how much the gravity vector moved between consecutive samples); this field is an ABSOLUTE
+ * gravity-removed magnitude at one instant. Both go to ~0 when the wrist is still, so the same cut is a
+ * sensible starting point, but the two still-fractions are not measuring the same thing and a match does
+ * not prove equivalence. [min]/[max]/[mean] let a reader re-derive any other cut from the logs.
+ * Byte-identical twin of Swift `Streams.DynAccelDiag` — same fields, same fold order, same nulls.
  */
 data class DynAccelDiag(
     var count: Int = 0,

--- a/android/app/src/main/java/com/noop/protocol/HistoricalStreams.kt
+++ b/android/app/src/main/java/com/noop/protocol/HistoricalStreams.kt
@@ -49,15 +49,6 @@ import com.noop.data.StreamPersistence
  * "last night · 12 Jul"). Reuses the same 1.7 B floor already used to validate GET_DATA_RANGE words
  * (WhoopBleClient.dataRangeNewestUnix). Below this → drop the record.
  */
-/**
- * #520: the stillness cut used by the `dynamic_acceleration` diagnostic. Mirrors
- * `SleepStager.gravityStillThresholdG` (0.01 g) so the diagnostic's still-fraction can be compared
- * directly against the gravity-delta stillness the stager already computes. Duplicated as a literal
- * rather than imported — this is the wire layer and must not depend on the analytics layer. If the
- * stager's constant moves, move this one with it. Twin of Swift `dynAccelStillThresholdG`.
- */
-const val DYN_ACCEL_STILL_THRESHOLD_G: Double = 0.01
-
 const val MIN_PLAUSIBLE_UNIX: Long = 1_700_000_000L
 
 /**
@@ -77,6 +68,17 @@ const val FUTURE_MARGIN: Long = 86_400L
  * the months-off garbage. Kept in lockstep with Swift `HistoricalStreams.swift` SESSION_RANGE_MARGIN.
  */
 const val SESSION_RANGE_MARGIN: Long = 7L * 86_400L
+
+/**
+ * #520: the stillness cut for the `dynamic_acceleration` diagnostic. Borrowed from
+ * `SleepStager.gravityStillThresholdG` (0.01 g) as a REFERENCE point, not because the two measure the same
+ * thing — the stager thresholds a per-sample DELTA between consecutive gravity vectors, while this field is
+ * an ABSOLUTE gravity-removed magnitude at one instant. Both approach 0 when the wrist is still, so the same
+ * cut is a sensible starting point, but a matching still-fraction would not prove the two are equivalent.
+ * Duplicated as a literal rather than imported — this is the wire layer and must not depend on the analytics
+ * layer. If the stager's constant moves, move this one with it. Twin of Swift `dynAccelStillThresholdG`.
+ */
+const val DYN_ACCEL_STILL_THRESHOLD_G: Double = 0.01
 
 // MARK: - little-endian readers (null when out of range; mirror PostHooks.swift u8/u16/u32/f32)
 
@@ -702,8 +704,9 @@ fun extractHistoricalStreams(
                     )
                 }
                 // #520: fold the gravity-removed motion magnitude into the diagnostic summary. The
-                // threshold matches SleepStager.gravityStillThresholdG so the still-fraction is directly
-                // comparable; passed as a literal because the protocol layer must not depend on analytics.
+                // threshold is the stager's own cut, borrowed as a reference point (the stager thresholds a
+                // per-sample delta, this is an absolute magnitude — related, not the same measurement);
+                // passed as a literal because the protocol layer must not depend on analytics.
                 p.doubleOrNull("dynamic_acceleration")?.let { dynAccel.add(it, DYN_ACCEL_STILL_THRESHOLD_G) }
             }
 

--- a/android/app/src/main/java/com/noop/protocol/HistoricalStreams.kt
+++ b/android/app/src/main/java/com/noop/protocol/HistoricalStreams.kt
@@ -1,6 +1,7 @@
 package com.noop.protocol
 
 import com.noop.data.BatteryRow
+import com.noop.data.DynAccelDiag
 import com.noop.data.EventEntry
 import com.noop.data.GravityRow
 import com.noop.data.HrRow
@@ -48,6 +49,15 @@ import com.noop.data.StreamPersistence
  * "last night · 12 Jul"). Reuses the same 1.7 B floor already used to validate GET_DATA_RANGE words
  * (WhoopBleClient.dataRangeNewestUnix). Below this → drop the record.
  */
+/**
+ * #520: the stillness cut used by the `dynamic_acceleration` diagnostic. Mirrors
+ * `SleepStager.gravityStillThresholdG` (0.01 g) so the diagnostic's still-fraction can be compared
+ * directly against the gravity-delta stillness the stager already computes. Duplicated as a literal
+ * rather than imported — this is the wire layer and must not depend on the analytics layer. If the
+ * stager's constant moves, move this one with it. Twin of Swift `dynAccelStillThresholdG`.
+ */
+const val DYN_ACCEL_STILL_THRESHOLD_G: Double = 0.01
+
 const val MIN_PLAUSIBLE_UNIX: Long = 1_700_000_000L
 
 /**
@@ -538,6 +548,10 @@ fun extractHistoricalStreams(
     var droppedOldest: Long? = null
     var droppedNewest: Long? = null
     val droppedRtcEvents = ArrayList<DroppedRtcEvent>()
+    // #520 diagnostic: running summary of dynamic_acceleration@41 over this batch. Counted, never
+    // stored — the field has been decoded all along with nothing consuming it, so there is no evidence
+    // on whether it beats the gravity-delta stillness the stager derives today. Twin of Swift.
+    val dynAccel = DynAccelDiag()
 
     // The plausible-timestamp window for this batch (#547): the absolute floor [MIN_PLAUSIBLE_UNIX,
     // wallNow + FUTURE_MARGIN] PLUS, when the strap's GET_DATA_RANGE markers are known AND well-formed
@@ -687,6 +701,10 @@ fun extractHistoricalStreams(
                         ),
                     )
                 }
+                // #520: fold the gravity-removed motion magnitude into the diagnostic summary. The
+                // threshold matches SleepStager.gravityStillThresholdG so the still-fraction is directly
+                // comparable; passed as a literal because the protocol layer must not depend on analytics.
+                p.doubleOrNull("dynamic_acceleration")?.let { dynAccel.add(it, DYN_ACCEL_STILL_THRESHOLD_G) }
             }
 
             PacketType.REALTIME_RAW_DATA.rawValue -> {
@@ -760,6 +778,7 @@ fun extractHistoricalStreams(
         droppedImplausibleOldestTs = droppedOldest,   // #324 poisoned-range epoch span (diag only)
         droppedImplausibleNewestTs = droppedNewest,
         droppedRtcEvents = droppedRtcEvents,
+        dynAccel = dynAccel,
     )
 }
 

--- a/android/app/src/test/java/com/noop/data/DynAccelDiagTest.kt
+++ b/android/app/src/test/java/com/noop/data/DynAccelDiagTest.kt
@@ -112,10 +112,24 @@ class DynAccelDiagTest {
         d.add(0.006, thr)
         d.add(2.310, thr)
         assertEquals(
-            "Backfill: dynaccel n=3 still=67% mean=0.773 range=0.004..2.310 g " +
-                "(thr 0.01) — diagnostic only, not stored or scored (#520)",
+            "Backfill: dynaccel n=3 still=67% mean=773mg range=4..2310mg " +
+                "(thr 10mg) — diagnostic only, not stored or scored (#520)",
             d.logLine(thr),
         )
+    }
+
+    /**
+     * The rounding trap. C (Swift) rounds ties half-to-EVEN, Java (Kotlin) rounds HALF_UP, so `%.3f` of
+     * 0.0625 g is 0.062 on one platform and 0.063 on the other — and 0.0625 is exactly representable in the
+     * f32 the strap sends. The line renders integers instead, rounded half-AWAY-from-zero, the one rule both
+     * languages agree on for non-negative input. Same expectations as the Swift twin.
+     */
+    @Test
+    fun tiesRoundAwayFromZeroNotPrintfStyle() {
+        assertEquals(63, DynAccelDiag.mg(0.0625))
+        assertEquals(14, DynAccelDiag.mg(0.0135))
+        assertEquals(67, DynAccelDiag.pct(0.665))
+        assertEquals(1, DynAccelDiag.pct(0.005))
     }
 
     /** The locale trap, asserted directly: the line must not change when the default locale is comma-decimal. */
@@ -129,8 +143,8 @@ class DynAccelDiagTest {
             d.add(0.006, thr)
             d.add(2.310, thr)
             assertEquals(
-                "Backfill: dynaccel n=3 still=67% mean=0.773 range=0.004..2.310 g " +
-                    "(thr 0.01) — diagnostic only, not stored or scored (#520)",
+                "Backfill: dynaccel n=3 still=67% mean=773mg range=4..2310mg " +
+                    "(thr 10mg) — diagnostic only, not stored or scored (#520)",
                 d.logLine(thr),
             )
         } finally {

--- a/android/app/src/test/java/com/noop/data/DynAccelDiagTest.kt
+++ b/android/app/src/test/java/com/noop/data/DynAccelDiagTest.kt
@@ -101,10 +101,7 @@ class DynAccelDiagTest {
         assertEquals(b, a)
     }
 
-    /**
-     * The byte-identical contract with Swift. Locale matters here: the formatter must use Locale.ROOT, or a
-     * de/fr device would render `0,773` and silently produce a different corpus from macOS.
-     */
+    /** The byte-identical contract with Swift — pinned exactly, so a format drift on either side fails. */
     @Test
     fun logLineFormat() {
         val d = DynAccelDiag()
@@ -132,7 +129,11 @@ class DynAccelDiagTest {
         assertEquals(1, DynAccelDiag.pct(0.005))
     }
 
-    /** The locale trap, asserted directly: the line must not change when the default locale is comma-decimal. */
+    /**
+     * The locale trap, asserted directly. The line is built from Int interpolation rather than
+     * [String.format], so locale cannot reach it — this guards that property rather than a formatter
+     * argument, and would fail immediately if anyone reintroduced `String.format` without Locale.ROOT.
+     */
     @Test
     fun logLineIsLocaleIndependent() {
         val previous = java.util.Locale.getDefault()

--- a/android/app/src/test/java/com/noop/data/DynAccelDiagTest.kt
+++ b/android/app/src/test/java/com/noop/data/DynAccelDiagTest.kt
@@ -1,6 +1,10 @@
 package com.noop.data
 
+import com.noop.protocol.DeviceFamily
+import com.noop.protocol.extractHistoricalStreams
+import org.json.JSONObject
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Test
 
@@ -63,9 +67,9 @@ class DynAccelDiagTest {
         assertEquals(0.02, d.max!!, 1e-12)
     }
 
-    /** A batch is an arbitrary slice of an offload; the still-fraction only means anything once merged. */
+    /** A chunk is an arbitrary slice of an offload; the still-fraction only means anything once merged. */
     @Test
-    fun mergeCombinesBatches() {
+    fun mergeCombinesChunks() {
         val a = DynAccelDiag()
         a.add(0.004, thr)
         a.add(0.006, thr)
@@ -127,6 +131,43 @@ class DynAccelDiagTest {
         assertEquals(14, DynAccelDiag.mg(0.0135))
         assertEquals(67, DynAccelDiag.pct(0.665))
         assertEquals(1, DynAccelDiag.pct(0.005))
+    }
+
+    /**
+     * Twin of Swift `testExtractionPopulatesDiagFromARealFrame`. Proves the v18 path actually FOLDS the
+     * field rather than merely exposing the type — the wiring, not the arithmetic. This matters more here
+     * than on Swift: `android.yml` is disabled, so nothing in this file is compiled by default CI, and the
+     * extraction hook is the piece most likely to be dropped by a future refactor.
+     *
+     * Reads the same captured worn frame from the shared oracle rather than pasting bytes, so this test and
+     * the cross-platform oracle can never disagree about what the frame is. Its f32@41 is 0.009160 g.
+     */
+    @Test
+    fun extractionPopulatesDiagFromARealFrame() {
+        val stream = javaClass.classLoader!!.getResourceAsStream("decoder_oracle.json")
+        assertNotNull("decoder_oracle.json missing from test classpath", stream)
+        val oracle = JSONObject(stream!!.bufferedReader().use { it.readText() })
+        val frames = oracle.getJSONArray("frames")
+        var hex: String? = null
+        for (i in 0 until frames.length()) {
+            val f = frames.getJSONObject(i)
+            if (f.getString("name") == "whoop5_v18_real_worn") hex = f.getString("hex")
+        }
+        assertNotNull("whoop5_v18_real_worn missing from the oracle", hex)
+
+        val raw = hex!!
+        val bytes = ByteArray(raw.length / 2) {
+            ((raw[it * 2].digitToInt(16) shl 4) or raw[it * 2 + 1].digitToInt(16)).toByte()
+        }
+        val batch = extractHistoricalStreams(
+            listOf(bytes),
+            deviceClockRef = 0,
+            wallClockRef = 0,
+            family = DeviceFamily.WHOOP5,
+        )
+        assertEquals("the v18 path did not fold dynamic_acceleration", 1, batch.dynAccel.count)
+        assertEquals(0.009160, batch.dynAccel.max!!, 1e-5)
+        assertEquals("0.00916 g is under the 0.01 g stillness cut", 1, batch.dynAccel.still)
     }
 
     /**

--- a/android/app/src/test/java/com/noop/data/DynAccelDiagTest.kt
+++ b/android/app/src/test/java/com/noop/data/DynAccelDiagTest.kt
@@ -1,0 +1,140 @@
+package com.noop.data
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * #520: `dynamic_acceleration@41` has been decoded on both platforms since the v18 layout was mapped, and
+ * nothing has ever consumed it — so there is no evidence on whether it is a usable stillness signal or
+ * redundant against the gravity deltas SleepStager already derives. These pin the diagnostic that collects
+ * that evidence: a summary, not a stream, logged once per offload session.
+ *
+ * Kotlin twin of `DynAccelDiagTests.swift` — same vectors, same expected values, same log-line bytes.
+ */
+class DynAccelDiagTest {
+
+    private val thr = 0.01   // mirrors DYN_ACCEL_STILL_THRESHOLD_G / SleepStager.gravityStillThresholdG
+
+    /** Nothing arrived: derived values are null and the line is suppressed, so a WHOOP 4.0 stays quiet. */
+    @Test
+    fun emptyDiagIsSilent() {
+        val d = DynAccelDiag()
+        assertEquals(0, d.count)
+        assertNull(d.mean)
+        assertNull(d.stillFraction)
+        assertNull(d.min)
+        assertNull(d.max)
+        assertNull(d.logLine(thr))
+    }
+
+    /** The real f32@41 values from the six captured v18 frames; three of the six fall under the cut. */
+    @Test
+    fun foldsRealOracleValues() {
+        val d = DynAccelDiag()
+        listOf(0.009160, 0.010708, 0.005963, 0.014449, 0.032788, 0.008421).forEach { d.add(it, thr) }
+        assertEquals(6, d.count)
+        assertEquals(3, d.still)
+        assertEquals(0.5, d.stillFraction!!, 1e-12)
+        assertEquals(0.005963, d.min!!, 1e-12)
+        assertEquals(0.032788, d.max!!, 1e-12)
+        assertEquals(0.081489 / 6, d.mean!!, 1e-9)
+    }
+
+    /** Strict `<`, matching the stager's own comparison — a value exactly at the cut is not still. */
+    @Test
+    fun thresholdIsExclusive() {
+        val d = DynAccelDiag()
+        d.add(thr, thr)
+        assertEquals(0, d.still)
+        d.add(thr - 1e-9, thr)
+        assertEquals(1, d.still)
+    }
+
+    /** One NaN would otherwise poison mean/min/max for a whole session, so non-finite values are dropped. */
+    @Test
+    fun nonFiniteValuesAreIgnored() {
+        val d = DynAccelDiag()
+        d.add(0.02, thr)
+        d.add(Double.NaN, thr)
+        d.add(Double.POSITIVE_INFINITY, thr)
+        assertEquals(1, d.count)
+        assertEquals(0.02, d.mean!!, 1e-12)
+        assertEquals(0.02, d.max!!, 1e-12)
+    }
+
+    /** A batch is an arbitrary slice of an offload; the still-fraction only means anything once merged. */
+    @Test
+    fun mergeCombinesBatches() {
+        val a = DynAccelDiag()
+        a.add(0.004, thr)
+        a.add(0.006, thr)
+        val b = DynAccelDiag()
+        b.add(0.500, thr)
+        a.merge(b)
+        assertEquals(3, a.count)
+        assertEquals(2, a.still)
+        assertEquals(0.004, a.min!!, 1e-12)
+        assertEquals(0.500, a.max!!, 1e-12)
+        assertEquals(0.510 / 3, a.mean!!, 1e-12)
+    }
+
+    /** A console-only batch is common mid-offload and must not disturb the accumulator. */
+    @Test
+    fun mergingEmptyIsNoOp() {
+        val a = DynAccelDiag()
+        a.add(0.02, thr)
+        a.merge(DynAccelDiag())
+        assertEquals(1, a.count)
+        assertEquals(0.02, a.min!!, 1e-12)
+        assertEquals(0.02, a.max!!, 1e-12)
+    }
+
+    /** The session accumulator starts empty, so merging into empty must adopt the other side's bounds. */
+    @Test
+    fun mergeIntoEmptyAdoptsBounds() {
+        val a = DynAccelDiag()
+        val b = DynAccelDiag()
+        b.add(0.03, thr)
+        b.add(0.07, thr)
+        a.merge(b)
+        assertEquals(b, a)
+    }
+
+    /**
+     * The byte-identical contract with Swift. Locale matters here: the formatter must use Locale.ROOT, or a
+     * de/fr device would render `0,773` and silently produce a different corpus from macOS.
+     */
+    @Test
+    fun logLineFormat() {
+        val d = DynAccelDiag()
+        d.add(0.004, thr)
+        d.add(0.006, thr)
+        d.add(2.310, thr)
+        assertEquals(
+            "Backfill: dynaccel n=3 still=67% mean=0.773 range=0.004..2.310 g " +
+                "(thr 0.01) — diagnostic only, not stored or scored (#520)",
+            d.logLine(thr),
+        )
+    }
+
+    /** The locale trap, asserted directly: the line must not change when the default locale is comma-decimal. */
+    @Test
+    fun logLineIsLocaleIndependent() {
+        val previous = java.util.Locale.getDefault()
+        try {
+            java.util.Locale.setDefault(java.util.Locale.GERMANY)
+            val d = DynAccelDiag()
+            d.add(0.004, thr)
+            d.add(0.006, thr)
+            d.add(2.310, thr)
+            assertEquals(
+                "Backfill: dynaccel n=3 still=67% mean=0.773 range=0.004..2.310 g " +
+                    "(thr 0.01) — diagnostic only, not stored or scored (#520)",
+                d.logLine(thr),
+            )
+        } finally {
+            java.util.Locale.setDefault(previous)
+        }
+    }
+}


### PR DESCRIPTION
`dynamic_acceleration@41` — the strap's own gravity-removed motion magnitude — has been decoded on both platforms since the v18 layout was mapped, and nothing has ever consumed it. So "is this a usable stillness signal, or redundant against what `SleepStager` already derives?" has no evidence either way, and answering it by building a feature would be backwards.

This logs one line per offload session:

```
Backfill: dynaccel n=28714 still=61% mean=21mg range=4..2310mg (thr 10mg) — diagnostic only, not stored or scored (#520)
```

**On the threshold, precisely.** 10 mg is `SleepStager.gravityStillThresholdG`, borrowed as a *reference cut* — not because the two measure the same thing. The stager thresholds a per-sample **delta** between consecutive gravity vectors (how far the wrist rotated in a second); this field is an **absolute** magnitude at one instant. Both approach zero when still, so the same cut is a sensible starting point, but a matching still-fraction would **not** prove equivalence. `min`/`max`/`mean` are in the line so a reader can re-derive any other cut — picking the right one is what this is meant to inform.

A summary, not a stream: at 1 Hz a night is ~30k values and the open question needs a shape. Accumulated across chunks and emitted once at the session boundary, since a chunk is an arbitrary slice of an offload. Silent when nothing carried the field, which a WHOOP 4.0 never does.

**No storage, no migration, no schema, no scores, no strings, no UI.** The field is already decoded; this only counts it.

## Bugs found in review, all in this PR's own code

- **printf ties diverge across platforms.** C's `%.3f` (Swift) rounds half-to-**even**; Java's rounds **HALF_UP**. `%.3f` of 0.0625 g is `0.062` on one and `0.063` on the other — and 0.0625 is exactly representable in the f32 the strap sends. Fixed by rendering integers (milli-g, whole percent) with no float formatting at all.
- **The fix reintroduced it.** `kotlin.math.round` is `Math.rint` — ties to **even** — so `round(62.5)` is 62 while Swift's `.rounded()` gives 63. Corrected to `roundToInt()`, which matches Swift for non-negative input.
- **The threshold constants broke two doc comments.** Inserted directly above `MIN_PLAUSIBLE_UNIX`, they landed between an existing doc block and the declaration it documented, so the `#547` plausibility doc silently re-attached to the new constant and `MIN_PLAUSIBLE_UNIX` lost its documentation — on both platforms. Relocated.
- **A parity gap in the tests.** Swift proved `extractHistoricalStreams` actually *folds* the field off a real frame; Kotlin only tested the arithmetic. The wiring is what a refactor drops, and it was untested on the platform CI never compiles. Twin added.

## Parity

Source: 12/12 elements on both sides — type, `add`, `merge`, `logLine`, `mg`, `pct`, `mean`, `stillFraction`, threshold constant, extraction fold, session accumulator, session-end log.

Tests: 10 shared, plus one deliberate asymmetry — `logLineIsLocaleIndependent` is Kotlin-only, because `String.format` following the default locale has no Swift equivalent.

One difference the table can't show: `DynAccelDiag` is a **struct** in Swift and a **class** in Kotlin. It doesn't bite here — `merge` only ever mutates the session accumulator, never the decoded batch — but it would if anyone stored a `dynAccel` reference expecting a snapshot.

## Verification

`swift-packages` covers the Swift package half, including a test that runs `extractHistoricalStreams` over the oracle's real captured worn frame.

Not compiled locally (no Swift toolchain, no JDK here). The Kotlin half and both app-target call sites are unbuilt: `android.yml` and `app-build.yml` are both `disabled_manually`. So the byte-identical claim rests on both suites asserting the same literal string, and only the Swift one has ever executed.

Leaves #520 open; this collects evidence rather than closing anything.
