### PR TITLE
test(tools): collect test_whoop_spot_hrv too — 8 more tests that never ran

### DIFF
--- a/tools/linux-capture/test_whoop_spot_hrv.py
+++ b/tools/linux-capture/test_whoop_spot_hrv.py
@@ -1,8 +1,8 @@
 """Tests for whoop_spot_hrv.py — the spot-HRV DSP, on synthetic signals with KNOWN beats.
 
 These test the algorithm (peak detection, RR, RMSSD, glitch rejection) against signals whose ground truth
-we control — not strap frames. Stdlib only; run with `pytest test_whoop_spot_hrv.py` or
-`python3 -m pytest test_whoop_spot_hrv.py`.
+we control — not strap frames. Stdlib only; runs under either `python3 -m unittest` (the runner the
+README documents and the only one in requirements.txt) or pytest.
 """
 import math
 
@@ -88,3 +88,16 @@ def test_spot_hrv_returns_none_on_flat_signal():
     t = [i / fs for i in range(120)]
     v = [50000.0] * 120
     assert H.spot_hrv(t, v, fs) is None
+
+
+# ── unittest collection ───────────────────────────────────────────────────────────────────────────
+# Same hook, and the same reason, as test_whoop_activity.py: this module is pytest-style (bare
+# `def test_*`, no unittest.TestCase), so `python3 -m unittest` collected NOTHING from it and exited 0
+# — which is indistinguishable from passing. All eight take no fixtures, so wrapping them is enough.
+def load_tests(loader, tests, pattern):    # noqa: ARG001 — unittest protocol signature
+    import unittest
+    suite = unittest.TestSuite(tests)
+    for name, fn in sorted(globals().items()):
+        if name.startswith("test_") and callable(fn):
+            suite.addTest(unittest.FunctionTestCase(fn, description=name))
+    return suite


### PR DESCRIPTION
Follow-up to #814, which fixed unittest collection for `test_whoop_activity.py` and **missed the identical instance in the same directory** — in a file that PR had already moved.

`test_whoop_spot_hrv.py` is also pytest-style: 8 bare `def test_*`, no `unittest.TestCase`. So `python3 -m unittest` collected nothing from it and exited 0, which looks exactly like passing. Its own docstring told readers to run it with `pytest` — which isn't in `requirements.txt` and isn't what the README documents — so in practice these eight tests ran for nobody.

All eight take no fixtures, so the same `load_tests` hook is enough. All pass. Docstring corrected to name both runners.

```
python3 -m unittest discover -s . -p 'test_*.py'
# 159 -> 167 tests, OK (skipped=1)
```

A repo-wide sweep now finds **no** Python test file that unittest silently skips.

I found this by asking whether #814's bug class existed anywhere else instead of assuming one instance was the whole problem. It wasn't — and the second instance was in a file #814 had touched, which is the part I should have caught before merging.

Docs and tests only. No app code, no schema, no scores, no strings.
