### PR TITLE
test(tools): pin find_peaks' four behaviours, and fix the docstring that described two of them wrongly

### DIFF
--- a/tools/linux-capture/test_whoop_spot_hrv.py
+++ b/tools/linux-capture/test_whoop_spot_hrv.py
@@ -96,6 +96,21 @@ def test_find_peaks_enforces_min_prom():
     v = [0.0, 2.0, 0.0, 9.0, 0.0]
     assert H.find_peaks(v, min_dist=1, min_prom=5.0) == [3]
     assert H.find_peaks(v, min_dist=1, min_prom=1.0) == [1, 3]
+    # Strict `>`: a maximum sitting exactly ON the threshold is rejected. The docstring used to say
+    # `>= min_prom`, which is the opposite; the code was right and the doc has been corrected.
+    assert H.find_peaks([0.0, 5.0, 0.0], min_dist=1, min_prom=5.0) == []
+    assert H.find_peaks([0.0, 5.0, 0.0], min_dist=1, min_prom=4.9) == [1]
+
+
+def test_find_peaks_plateau_yields_one_index():
+    """A flat plateau is one peak, not one per sample.
+
+    The neighbour test is asymmetric on purpose (`> left`, `>= right`). Symmetric `>=` would emit a
+    duplicate for every plateau sample and inflate the beat count; symmetric `>` would drop plateaus
+    altogether. Nothing pinned that before, and the docstring described it wrongly as `>= neighbours`.
+    """
+    assert H.find_peaks([0.0, 5.0, 5.0, 0.0], min_dist=1, min_prom=0.0) == [1]
+    assert H.find_peaks([0.0, 5.0, 5.0, 5.0, 0.0], min_dist=1, min_prom=0.0) == [1]
 
 
 def test_spot_hrv_returns_none_on_too_few_samples():

--- a/tools/linux-capture/test_whoop_spot_hrv.py
+++ b/tools/linux-capture/test_whoop_spot_hrv.py
@@ -77,6 +77,27 @@ def test_find_peaks_counts_beats():
     assert 9 <= len(pk) <= 11, len(pk)
 
 
+def test_find_peaks_enforces_min_dist_keeping_the_taller():
+    """Two maxima closer together than min_dist: only the taller survives.
+
+    Guards the spacing filter specifically. `test_find_peaks_counts_beats` above does not — its beats
+    are already well separated, so deleting the min_dist check entirely leaves it passing.
+    """
+    v = [0.0, 5.0, 0.0, 9.0, 0.0]           # maxima at 1 (5) and 3 (9), two samples apart
+    assert H.find_peaks(v, min_dist=3, min_prom=0.0) == [3]
+    assert H.find_peaks(v, min_dist=2, min_prom=0.0) == [1, 3]
+
+
+def test_find_peaks_enforces_min_prom():
+    """A local maximum below min_prom is not a peak.
+
+    Guards the prominence gate specifically — deleting it also leaves the beat-count test passing.
+    """
+    v = [0.0, 2.0, 0.0, 9.0, 0.0]
+    assert H.find_peaks(v, min_dist=1, min_prom=5.0) == [3]
+    assert H.find_peaks(v, min_dist=1, min_prom=1.0) == [1, 3]
+
+
 def test_spot_hrv_returns_none_on_too_few_samples():
     # too few samples → None (no false HRV)
     assert H.spot_hrv([0, 1, 2], [1.0, 2.0, 1.0], 24.0) is None

--- a/tools/linux-capture/whoop_spot_hrv.py
+++ b/tools/linux-capture/whoop_spot_hrv.py
@@ -52,7 +52,15 @@ def detrend(v, win):
 
 
 def find_peaks(v, min_dist, min_prom):
-    """Local maxima >= neighbours and >= min_prom, spaced >= min_dist (keep the taller on conflict)."""
+    """Local maxima strictly above min_prom, spaced >= min_dist (keep the taller on conflict).
+
+    The neighbour test is deliberately ASYMMETRIC — `v[i] > v[i-1] and v[i] >= v[i+1]` — so a flat
+    plateau yields ONE index (its left edge) instead of one per sample. Making it symmetric `>=`
+    would emit a duplicate peak for every plateau sample; making it symmetric `>` would drop
+    plateaus entirely. Both are pinned by tests.
+
+    `min_prom` is a strict `>`: a maximum sitting exactly ON the threshold is rejected.
+    """
     cand = [i for i in range(1, len(v) - 1) if v[i] > v[i - 1] and v[i] >= v[i + 1] and v[i] > min_prom]
     cand.sort(key=lambda i: -v[i])
     kept = []


### PR DESCRIPTION
Closes the coverage gap #815 recorded rather than fixed.

Mutation-testing #815 before merging showed its eight newly-collected spot-HRV tests catch a grossly broken peak detector but miss two of `find_peaks`' three behaviours:

| mutation to `find_peaks` | before | after |
|---|---|---|
| drop the `min_dist` spacing filter | **survived** | killed |
| drop the `min_prom` prominence gate | **survived** | killed |
| invert the local-maximum comparison | killed (2 tests) | killed (4 tests) |

`test_find_peaks_counts_beats` can't cover either by construction — its synthetic beats are already well separated and well above the noise floor, so both filters are no-ops on that input. Passing it says nothing about whether they exist.

These use minimal hand-built arrays, and each asserts **both** directions so it can't pass vacuously:

- **`min_dist`** — `[0, 5, 0, 9, 0]`, maxima two samples apart. `min_dist=3` keeps only the taller (`[3]`); `min_dist=2` keeps both (`[1, 3]`).
- **`min_prom`** — `[0, 2, 0, 9, 0]`. `min_prom=5.0` rejects the 2.0 maximum; `min_prom=1.0` keeps it.

Mutants killed 3/3, up from 1/3. Suite **167 → 169**, OK (1 skipped).

One practical note for anyone repeating the exercise: clear `__pycache__` between mutations. A stale `.pyc` kept reporting failures from a mutant after the source had been restored — indistinguishable from a real regression in code that was actually clean.

Tests only. No app code, no tooling behaviour, no schema, no strings.
