### PR TITLE
fix(protocol): correct GET_DATA_RANGE pagesBehind field offsets

### DIFF
--- a/Packages/WhoopProtocol/Sources/WhoopProtocol/DataRange.swift
+++ b/Packages/WhoopProtocol/Sources/WhoopProtocol/DataRange.swift
@@ -57,23 +57,26 @@ public enum DataRange {
         return oldest
     }
 
-    /// #689: the ring-buffer page backlog ("pages behind") the strap reports in a GET_DATA_RANGE response —
-    /// DIAGNOSTIC ONLY. RE'd from the WHOOP app (facts, not copied code; see ATTRIBUTION.md) and NOT yet
-    /// confirmed against real 4.0 / 5-MG captures, so it NEVER gates sync or backfill — it only logs.
+    /// #689/#815: the ring-buffer page backlog ("pages behind") the strap reports in a GET_DATA_RANGE
+    /// response — DIAGNOSTIC ONLY (feeds a future sync-progress UI, never gates sync or backfill itself).
+    /// Confirmed against real captures on both WHOOP 4.0 (#791) and 5.0/MG (#815): the write/read pointers
+    /// and ring capacity below all landed exactly where this predicts, across four independent frames.
     ///
     /// The app reads three u32s from the command-response INNER payload (whose byte 0 is a subtype), at
-    /// `V(i) = word @ (i*4 + 1)`: write page `W = V(2)`, read pointer `U = V(3)`, ring capacity `T = V(5)`.
-    /// The inner payload starts at `cmdOff + 1`, so those words sit at frame offsets `cmdOff + 10/14/22`
-    /// here. Read u32 LITTLE-endian to match the frame's other words (the app's ByteBuffer default is
-    /// big-endian, but this frame carries its unix words LE — a fixture will settle it; a flip is one line).
-    /// Backlog with wraparound: `W < U ? W + (T - U) : W - U`.
+    /// `V(i) = word @ (i*4 + 3)`: write pointer `W = V(2)`, read pointer `U = V(3)`, ring capacity `T = V(5)`.
+    /// The inner payload starts at `cmdOff + 1`, so those words sit at frame offsets `cmdOff + 12/16/24`
+    /// here. Read u32 LITTLE-endian to match the frame's other words. Backlog with wraparound (unverified —
+    /// no real capture has crossed it yet, but harmless to ship since this only ever feeds a diagnostic):
+    /// `W < U ? W + (T - U) : W - U`. `T` has been `131072` in every real capture so far (both families) but
+    /// is still read from the frame each time rather than hardcoded, in case a firmware revision differs.
     ///
     /// Returns nil for a too-short frame or implausible values — a capacity that is 0 or above a sane
     /// ceiling (a misaligned read hitting a timestamp / `0xFFFFFFFF`), a pointer at/beyond capacity, or a
     /// backlog past capacity — so a garbage frame can never log a nonsense number.
     public static func pagesBehind(from frame: [UInt8], cmdOff: Int) -> Int? {
         guard cmdOff >= 0 else { return nil }
-        let wOff = cmdOff + 10, uOff = cmdOff + 14, tOff = cmdOff + 22
+        let payloadOffset = cmdOff + 1
+        let wOff = payloadOffset + 11, uOff = payloadOffset + 15, tOff = payloadOffset + 23
         guard tOff + 4 <= frame.count else { return nil }
         func u32(_ o: Int) -> Int {
             Int(frame[o]) | Int(frame[o + 1]) << 8 | Int(frame[o + 2]) << 16 | Int(frame[o + 3]) << 24

--- a/Packages/WhoopProtocol/Tests/WhoopProtocolTests/DataRangeTests.swift
+++ b/Packages/WhoopProtocol/Tests/WhoopProtocolTests/DataRangeTests.swift
@@ -78,13 +78,13 @@ final class DataRangeTests: XCTestCase {
         XCTAssertEqual(DataRange.oldestUnix(from: frame), 1_750_000_000)
     }
 
-    // MARK: - #689 pagesBehind (ring backlog). Byte-parity twin of the Kotlin DataRangeScanTest cases.
+    // MARK: - #689/#815 pagesBehind (ring backlog). Byte-parity twin of the Kotlin DataRangeScanTest cases.
 
-    /// Frame (zero-filled) with W/U/T u32 LE at the pagesBehind offsets (cmdOff+10/14/22).
+    /// Frame (zero-filled) with W/U/T u32 LE at the pagesBehind offsets (cmdOff+12/16/24).
     private func pagesFrame(cmdOff: Int, w: Int, u: Int, t: Int, size: Int = 40) -> [UInt8] {
         var b = [UInt8](repeating: 0, count: size)
         func put(_ off: Int, _ v: Int) { for k in 0..<4 { b[off + k] = UInt8((v >> (8 * k)) & 0xFF) } }
-        put(cmdOff + 10, w); put(cmdOff + 14, u); put(cmdOff + 22, t)
+        put(cmdOff + 12, w); put(cmdOff + 16, u); put(cmdOff + 24, t)
         return b
     }
 
@@ -92,12 +92,8 @@ final class DataRangeTests: XCTestCase {
         XCTAssertEqual(DataRange.pagesBehind(from: pagesFrame(cmdOff: 6, w: 500, u: 200, t: 1024), cmdOff: 6), 300)
     }
 
-    func testPagesBehind_wraparound() {     // W < U ⇒ W + (T − U)
+    func testPagesBehind_wraparound() {     // W < U ⇒ W + (T − U); synthetic — no real capture has crossed the wrap yet
         XCTAssertEqual(DataRange.pagesBehind(from: pagesFrame(cmdOff: 6, w: 100, u: 800, t: 1000), cmdOff: 6), 300)
-    }
-
-    func testPagesBehind_whoop5CmdOff10() { // offsets shift with cmdOff; same math
-        XCTAssertEqual(DataRange.pagesBehind(from: pagesFrame(cmdOff: 10, w: 500, u: 200, t: 1024), cmdOff: 10), 300)
     }
 
     func testPagesBehind_tooShortIsNil() {
@@ -108,5 +104,26 @@ final class DataRangeTests: XCTestCase {
         XCTAssertNil(DataRange.pagesBehind(from: pagesFrame(cmdOff: 6, w: 1, u: 1, t: 0), cmdOff: 6))               // capacity 0
         XCTAssertNil(DataRange.pagesBehind(from: pagesFrame(cmdOff: 6, w: 1, u: 1, t: 1_783_785_625), cmdOff: 6))  // T is a timestamp → over ceiling
         XCTAssertNil(DataRange.pagesBehind(from: pagesFrame(cmdOff: 6, w: 5, u: 2000, t: 1000), cmdOff: 6))        // U ≥ T
+    }
+
+    /// Real captures (#791 WHOOP4, #815 WHOOP 5.0/MG) — confirms the offset fix against hardware, not just
+    /// synthetic math. All four are the non-wrapped case (W > U); ring capacity `T` is 131072 in every one.
+    func testPagesBehind_realCaptures() {
+        let cases: [(String, Int, Int)] = [
+            // WHOOP4, cmdOff 6 (Galaxy S24 Ultra capture, #791)
+            ("aa4c00a7247e220a01010000000050070100a307010050070100000000000000020035030000" +
+             "c2fc13008046394b00000000bbe1636aa02d0000bbe1636aa02d0000c6e4636ac07c000000000447ea04", 6, 83),
+            // WHOOP 5.0/MG, cmdOff 10 (#815)
+            ("aa014c00010032d124cc22040101c0890100b4890100b6890100b4890100110000000000020012000000" +
+             "e2ff1d00785ac169707d0000edeb626a5c0f0000edeb626a5c0f0000feeb626a5c0f00000000a7c3ec16", 10, 2),
+            ("aa014c00010032d1241e22050101008a0100dd890100e5890100dd890100110000000000020" +
+             "05d00000088ff1d00da5dc169b87e000002ee626a0000000002ee626a000000005dee626a140e000000009f8dfab4", 10, 8),
+            ("aa014c00010032d124982207010180b901005ab7010048b901005ab7010010000000000002" +
+             "00da1b00000ee31d00b0e1ff69d7430000a3ab266a3d4a0000a3ab266a3d4a00007cc7266a5c4f00000000623977f5", 10, 494),
+        ]
+        for (h, cmdOff, expected) in cases {
+            XCTAssertEqual(DataRange.pagesBehind(from: hex(h), cmdOff: cmdOff), expected,
+                           "pagesBehind for \(h) at cmdOff \(cmdOff) should be \(expected)")
+        }
     }
 }

--- a/android/app/src/main/java/com/noop/protocol/DataRange.kt
+++ b/android/app/src/main/java/com/noop/protocol/DataRange.kt
@@ -66,20 +66,25 @@ object DataRange {
     }
 
     /**
-     * #689: the ring-buffer page backlog ("pages behind") the strap reports in a GET_DATA_RANGE response —
-     * DIAGNOSTIC ONLY. RE'd from the WHOOP app (facts, not copied code; see ATTRIBUTION.md), NOT yet
-     * confirmed against real 4.0 / 5-MG captures, so it NEVER gates sync or backfill — only logged.
+     * #689/#815: the ring-buffer page backlog ("pages behind") the strap reports in a GET_DATA_RANGE
+     * response — DIAGNOSTIC ONLY (feeds a future sync-progress UI, never gates sync or backfill itself).
+     * Confirmed against real captures on both WHOOP 4.0 (#791) and 5.0/MG (#815): the write/read pointers
+     * and ring capacity below all landed exactly where this predicts, across four independent frames.
      * Mirrors Swift `DataRange.pagesBehind`.
      *
-     * Reads three u32s from the command-response INNER payload (byte 0 a subtype), `V(i) = @ (i*4 + 1)`:
-     * write page W=V(2), read pointer U=V(3), ring capacity T=V(5) — at frame offsets cmdOff + 10/14/22
+     * Reads three u32s from the command-response INNER payload (byte 0 a subtype), `V(i) = @ (i*4 + 3)`:
+     * write pointer W=V(2), read pointer U=V(3), ring capacity T=V(5) — at frame offsets cmdOff + 12/16/24
      * (inner payload starts at cmdOff + 1). u32 LITTLE-endian to match the frame's other words. Backlog
-     * with wraparound: W<U ? W+(T-U) : W-U. Returns null for a too-short frame or implausible values
-     * (capacity 0 or over a sane ceiling, a pointer at/beyond capacity, or a backlog past capacity).
+     * with wraparound (unverified — no real capture has crossed it yet, but harmless since this only ever
+     * feeds a diagnostic): W<U ? W+(T-U) : W-U. T has been 131072 in every real capture so far (both
+     * families) but is still read from the frame each time rather than hardcoded, in case a firmware
+     * revision differs. Returns null for a too-short frame or implausible values (capacity 0 or over a
+     * sane ceiling, a pointer at/beyond capacity, or a backlog past capacity).
      */
     fun pagesBehind(frame: ByteArray, cmdOff: Int): Long? {
         if (cmdOff < 0) return null
-        val wOff = cmdOff + 10; val uOff = cmdOff + 14; val tOff = cmdOff + 22
+        val payloadOffset = cmdOff + 1
+        val wOff = payloadOffset + 11; val uOff = payloadOffset + 15; val tOff = payloadOffset + 23
         if (tOff + 4 > frame.size) return null
         fun u32(o: Int): Long =
             (frame[o].toLong() and 0xFFL) or

--- a/android/app/src/test/java/com/noop/ble/DataRangeScanTest.kt
+++ b/android/app/src/test/java/com/noop/ble/DataRangeScanTest.kt
@@ -95,23 +95,20 @@ class DataRangeScanTest {
         assertEquals(1_750_000_000L, WhoopBleClient.dataRangeOldestUnix(frame))
     }
 
-    // #689 pagesBehind (ring backlog): byte-parity twin of the Swift DataRangeTests cases.
+    // #689/#815 pagesBehind (ring backlog): byte-parity twin of the Swift DataRangeTests cases.
 
     private fun pagesFrame(cmdOff: Int, w: Long, u: Long, t: Long, size: Int = 40): ByteArray {
         val b = ByteArray(size)
         fun put(off: Int, v: Long) { for (k in 0..3) b[off + k] = ((v shr (8 * k)) and 0xFF).toByte() }
-        put(cmdOff + 10, w); put(cmdOff + 14, u); put(cmdOff + 22, t)
+        put(cmdOff + 12, w); put(cmdOff + 16, u); put(cmdOff + 24, t)
         return b
     }
 
     @Test fun `pagesBehind normal no wrap`() =
         assertEquals(300L, DataRange.pagesBehind(pagesFrame(6, 500, 200, 1024), 6))
 
-    @Test fun `pagesBehind wraparound`() =
+    @Test fun `pagesBehind wraparound`() =    // synthetic — no real capture has crossed the wrap yet
         assertEquals(300L, DataRange.pagesBehind(pagesFrame(6, 100, 800, 1000), 6))
-
-    @Test fun `pagesBehind whoop5 cmdOff 10`() =
-        assertEquals(300L, DataRange.pagesBehind(pagesFrame(10, 500, 200, 1024), 10))
 
     @Test fun `pagesBehind too short is null`() =
         assertNull(DataRange.pagesBehind(ByteArray(20), 6))
@@ -120,5 +117,43 @@ class DataRangeScanTest {
         assertNull(DataRange.pagesBehind(pagesFrame(6, 1, 1, 0), 6))                // capacity 0
         assertNull(DataRange.pagesBehind(pagesFrame(6, 1, 1, 1_783_785_625L), 6))  // T is a timestamp
         assertNull(DataRange.pagesBehind(pagesFrame(6, 5, 2000, 1000), 6))         // U >= T
+    }
+
+    /**
+     * Real captures (#791 WHOOP4, #815 WHOOP 5.0/MG) — confirms the offset fix against hardware, not just
+     * synthetic math. All four are the non-wrapped case (W > U); ring capacity T is 131072 in every one.
+     */
+    @Test fun `pagesBehind real captures`() {
+        val cases = listOf(
+            // WHOOP4, cmdOff 6 (Galaxy S24 Ultra capture, #791)
+            Triple(
+                "aa4c00a7247e220a01010000000050070100a307010050070100000000000000020035030000" +
+                    "c2fc13008046394b00000000bbe1636aa02d0000bbe1636aa02d0000c6e4636ac07c000000000447ea04",
+                6, 83L,
+            ),
+            // WHOOP 5.0/MG, cmdOff 10 (#815)
+            Triple(
+                "aa014c00010032d124cc22040101c0890100b4890100b6890100b4890100110000000000020012000000" +
+                    "e2ff1d00785ac169707d0000edeb626a5c0f0000edeb626a5c0f0000feeb626a5c0f00000000a7c3ec16",
+                10, 2L,
+            ),
+            Triple(
+                "aa014c00010032d1241e22050101008a0100dd890100e5890100dd890100110000000000020" +
+                    "05d00000088ff1d00da5dc169b87e000002ee626a0000000002ee626a000000005dee626a140e000000009f8dfab4",
+                10, 8L,
+            ),
+            Triple(
+                "aa014c00010032d124982207010180b901005ab7010048b901005ab7010010000000000002" +
+                    "00da1b00000ee31d00b0e1ff69d7430000a3ab266a3d4a0000a3ab266a3d4a00007cc7266a5c4f00000000623977f5",
+                10, 494L,
+            ),
+        )
+        for ((h, cmdOff, expected) in cases) {
+            assertEquals(
+                "pagesBehind for $h at cmdOff $cmdOff should be $expected",
+                expected,
+                DataRange.pagesBehind(hex(h), cmdOff),
+            )
+        }
     }
 }


### PR DESCRIPTION
## Summary
- `DataRange.pagesBehind` (Swift) / `DataRange.pagesBehind` (Kotlin) read the write/read/ring-capacity triplet 2 bytes early (`cmdOff+10/14/22` instead of `cmdOff+12/16/24`). The ring-capacity field always landed on padding (`0`), so the plausibility guard rejected every real frame — `pagesBehind` never actually fired on hardware, despite the doc comment implying it just hadn't been checked yet.
- Corrected offsets confirmed against 4 real GET_DATA_RANGE captures across both WHOOP 4.0 (#791) and WHOOP 5.0/MG (#815/#520) — ring capacity is `131072` in every one, and pagesBehind computes cleanly (83, 2, 8, 494 pages).
- Renamed the synthetic-only `whoop5CmdOff10` test (misleading — implied hardware validation that didn't exist) for real fixtures on both platforms.
- No behavior change beyond the fix itself: still diagnostic-only (logs, never gates sync/backfill), still `Int?`/`Long?` return, wraparound branch still unverified against real hardware (no capture has crossed it) but left as-is since it's low-risk (UI-diagnostic only).

## Test plan
- [x] `swift test` — full `WhoopProtocol` package suite (331 tests) passes, including new `testPagesBehind_realCaptures`.
- [ ] Kotlin `DataRangeScanTest` — mirrored byte-for-byte from the Swift change (same offsets, same fixtures, same expected values) but **not run locally** (no JDK in this environment). Should pass under `android.yml` / `./gradlew testFullDebugUnitTest --tests "com.noop.ble.DataRangeScanTest"`.
- Not app-target Swift/Kotlin — no BLE/hardware testing needed for this PR; the fix is confined to `Packages/WhoopProtocol` (pure) and its Kotlin twin.