### PR TITLE
tools(spo2): let the @82 validator read a whoop_sync.py capture DB directly (#103)

### DIFF
--- a/tools/linux-capture/README.md
+++ b/tools/linux-capture/README.md
@@ -592,6 +592,11 @@ capture DB `whoop_sync.py` writes** (`captures/whoop.db`) — the same `frames` 
 it. The file is identified by its SQLite header rather than its extension, since capture DBs get
 renamed freely. Use `--device-id` if yours is not the default `2`.
 
+Only v18 rows are read, filtered in SQL rather than after loading: newer 5/MG firmware serves a
+v20 (2140 B) + v21 (1244 B) pair every second alongside the 124-byte v18, and only v18 carries
+`@82`. On a mixed corpus that is the difference between 115 MB and 28 MB to reach the same 20k
+usable records.
+
 > **This is the capture tooling's database, not the app's.** Neither shipped app has a `frames`
 > table — Android uses Room, iOS/macOS uses GRDB — so this cannot be pointed at a phone's store or a
 > `.noopbak`. Validating a strap still requires a capture.

--- a/tools/linux-capture/README.md
+++ b/tools/linux-capture/README.md
@@ -585,11 +585,23 @@ strap-computed SpO₂ scalar (the `spo2_candidate_82` decode already in Swift/Ko
 **nightly means** against your WHOOP CSV export — the multi-device bar described in
 [`docs/WHOOP5_DEEP_DATA.md`](../../docs/WHOOP5_DEEP_DATA.md).
 
+The frame source can be **either** an `hci_extract` / `whoop_capture` `capture.json` **or a NOOP
+SQLite store** — the same `frames` table `whoop_activity.py` reads, which is where an install's own
+offloaded history already sits. The file is identified by its SQLite header, not its extension, so a
+store copied off a phone under any name works. Use `--device-id` if yours is not the default `2`.
+
+That matters for the open question: the #103 bar needs nightly candidate values across **several
+straps**, and requiring everyone to re-capture over HCI first is a much harder ask than pointing this
+at a database they already have.
+
 ```bash
-# One strap (summary stays aggregate-only unless you pass --show-nights):
+# One strap from a capture (summary stays aggregate-only unless you pass --show-nights):
 python3 validate_spo2_candidate.py capture.json my_whoop_data/ --device strap-a --postable
 
-# Several straps at once:
+# ...or straight from a NOOP store:
+python3 validate_spo2_candidate.py whoop.db my_whoop_data/ --device strap-a --postable
+
+# Several straps at once (entries may mix .json and .db, and carry their own device_id):
 python3 validate_spo2_candidate.py --batch devices.json --postable
 ```
 

--- a/tools/linux-capture/README.md
+++ b/tools/linux-capture/README.md
@@ -585,21 +585,23 @@ strap-computed SpO₂ scalar (the `spo2_candidate_82` decode already in Swift/Ko
 **nightly means** against your WHOOP CSV export — the multi-device bar described in
 [`docs/WHOOP5_DEEP_DATA.md`](../../docs/WHOOP5_DEEP_DATA.md).
 
-The frame source can be **either** an `hci_extract` / `whoop_capture` `capture.json` **or a NOOP
-SQLite store** — the same `frames` table `whoop_activity.py` reads, which is where an install's own
-offloaded history already sits. The file is identified by its SQLite header, not its extension, so a
-store copied off a phone under any name works. Use `--device-id` if yours is not the default `2`.
+The frame source can be **either** an `hci_extract` / `whoop_capture` `capture.json` **or the SQLite
+capture DB `whoop_sync.py` writes** (`captures/whoop.db`) — the same `frames` table
+`whoop_activity.py` reads. Previously a Linux capture had to be round-tripped through
+`whoop_sync.py export --only-type 47` before this tool, which sits in the same directory, could read
+it. The file is identified by its SQLite header rather than its extension, since capture DBs get
+renamed freely. Use `--device-id` if yours is not the default `2`.
 
-That matters for the open question: the #103 bar needs nightly candidate values across **several
-straps**, and requiring everyone to re-capture over HCI first is a much harder ask than pointing this
-at a database they already have.
+> **This is the capture tooling's database, not the app's.** Neither shipped app has a `frames`
+> table — Android uses Room, iOS/macOS uses GRDB — so this cannot be pointed at a phone's store or a
+> `.noopbak`. Validating a strap still requires a capture.
 
 ```bash
 # One strap from a capture (summary stays aggregate-only unless you pass --show-nights):
 python3 validate_spo2_candidate.py capture.json my_whoop_data/ --device strap-a --postable
 
-# ...or straight from a NOOP store:
-python3 validate_spo2_candidate.py whoop.db my_whoop_data/ --device strap-a --postable
+# ...or straight from a whoop_sync.py capture DB, skipping the export step:
+python3 validate_spo2_candidate.py captures/whoop.db my_whoop_data/ --device strap-a --postable
 
 # Several straps at once (entries may mix .json and .db, and carry their own device_id):
 python3 validate_spo2_candidate.py --batch devices.json --postable

--- a/tools/linux-capture/test_validate_spo2_candidate.py
+++ b/tools/linux-capture/test_validate_spo2_candidate.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import json
 import os
+import sqlite3
 import struct
 import tempfile
 import unittest
@@ -224,3 +225,65 @@ class MultiDeviceBatchTests(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class LoadFrameRecordsTest(unittest.TestCase):
+    """#103: the validator originally read capture.json only, so it could not be pointed at the place a
+    NOOP install's own history already lives — the SQLite `frames` table `whoop_activity.records()`
+    reads. Requiring an HCI re-capture instead is a far harder ask than opening the existing database,
+    and it was the practical blocker on getting multi-device @82 evidence at all."""
+
+    def _store(self, rows, *, device_id=2, inner_type=47):
+        path = tempfile.mktemp(suffix=".db")
+        con = sqlite3.connect(path)
+        con.execute("CREATE TABLE frames (device_id INT, inner_type INT, hex TEXT)")
+        for h in rows:
+            con.execute("INSERT INTO frames VALUES (?,?,?)", (device_id, inner_type, h))
+        con.commit()
+        con.close()
+        self.addCleanup(lambda: os.path.exists(path) and os.unlink(path))
+        return path
+
+    def test_reads_frames_from_a_noop_sqlite_store(self):
+        frames = [make_v18(unix=1780000000 + i * 60, sleep_state=2, aux_byte_82=96).hex()
+                  for i in range(5)]
+        recs = vs.load_frame_records(self._store(frames), device_id=2)
+        self.assertEqual(len(recs), 5)
+        decoded = list(vs.iter_v18_records(recs))
+        self.assertEqual([d["spo2_candidate_82"] for d in decoded], [96] * 5)
+
+    def test_detects_sqlite_by_header_not_extension(self):
+        """A store copied off a phone is often renamed; trusting the suffix would send it to json.load."""
+        path = self._store([make_v18(sleep_state=2, aux_byte_82=95).hex()])
+        renamed = path + ".capture"
+        os.rename(path, renamed)
+        self.addCleanup(lambda: os.path.exists(renamed) and os.unlink(renamed))
+        self.assertTrue(vs.looks_like_sqlite(renamed))
+        self.assertEqual(len(vs.load_frame_records(renamed)), 1)
+
+    def test_json_captures_still_load_unchanged(self):
+        path = tempfile.mktemp(suffix=".json")
+        with open(path, "w") as f:
+            json.dump([{"hex": make_v18(sleep_state=2, aux_byte_82=94).hex()}], f)
+        self.addCleanup(lambda: os.path.exists(path) and os.unlink(path))
+        self.assertFalse(vs.looks_like_sqlite(path))
+        self.assertEqual(len(vs.load_frame_records(path)), 1)
+
+    def test_wrong_device_id_says_so_instead_of_reporting_zero_nights(self):
+        """Silently finding nothing would read as 'the candidate does not track', which is the wrong
+        conclusion to hand someone from a filter mismatch."""
+        path = self._store([make_v18(sleep_state=2, aux_byte_82=96).hex()], device_id=2)
+        with self.assertRaises(SystemExit) as cm:
+            vs.load_frame_records(path, device_id=99)
+        self.assertIn("device-id", str(cm.exception))
+
+    def test_a_sqlite_file_that_is_not_a_frame_store_is_rejected_clearly(self):
+        path = tempfile.mktemp(suffix=".db")
+        con = sqlite3.connect(path)
+        con.execute("CREATE TABLE unrelated (x INT)")
+        con.commit()
+        con.close()
+        self.addCleanup(lambda: os.path.exists(path) and os.unlink(path))
+        with self.assertRaises(SystemExit) as cm:
+            vs.load_frame_records(path)
+        self.assertIn("not a NOOP frame store", str(cm.exception))

--- a/tools/linux-capture/test_validate_spo2_candidate.py
+++ b/tools/linux-capture/test_validate_spo2_candidate.py
@@ -289,3 +289,44 @@ class LoadFrameRecordsTest(unittest.TestCase):
         with self.assertRaises(SystemExit) as cm:
             vs.load_frame_records(path)
         self.assertIn("not a whoop_sync.py frame store", str(cm.exception))
+
+
+class SqliteV18FilterTest(unittest.TestCase):
+    """Newer 5/MG firmware serves a v20 (2140 B) + v21 (1244 B) pair every second alongside the
+    124-byte v18, so `inner_type=47` alone loads mostly bytes this tool discards — only v18 carries
+    @82. Filtering by version in SQL took a mixed 20k-usable-record corpus from 115 MB to 28 MB."""
+
+    def _mixed_store(self, n_v18=5, n_v20=5, device_id=2):
+        path = tempfile.mktemp(suffix=".db")
+        con = sqlite3.connect(path)
+        con.execute("CREATE TABLE frames (device_id INT, inner_type INT, hex TEXT)")
+        for i in range(n_v18):
+            f = make_v18(unix=1780000000 + i * 60, sleep_state=2, aux_byte_82=96)
+            con.execute("INSERT INTO frames VALUES (?,47,?)", (device_id, f.hex()))
+        for _ in range(n_v20):
+            v20 = bytearray(2140)
+            v20[0], v20[8], v20[9] = 0xAA, 47, 20
+            con.execute("INSERT INTO frames VALUES (?,47,?)", (device_id, bytes(v20).hex()))
+        con.commit()
+        con.close()
+        self.addCleanup(lambda: os.path.exists(path) and os.unlink(path))
+        return path
+
+    def test_v20_v21_rows_are_filtered_in_sql_not_after_loading(self):
+        recs = vs.load_frame_records(self._mixed_store(n_v18=5, n_v20=5))
+        self.assertEqual(len(recs), 5, "v20 rows should never reach Python")
+        self.assertTrue(all(bytes.fromhex(r["hex"])[9] == 18 for r in recs))
+
+    def test_a_store_with_type47_but_no_v18_says_so(self):
+        """Different fix from an empty store: the frames are there, they are the wrong layout."""
+        with self.assertRaises(SystemExit) as cm:
+            vs.load_frame_records(self._mixed_store(n_v18=0, n_v20=3))
+        msg = str(cm.exception)
+        self.assertIn("none are v18", msg)
+        self.assertIn("3 type-47 frames", msg)
+
+    def test_wrong_device_id_still_reports_the_device_id_cause(self):
+        """The v18 filter must not mask the pre-existing device-id diagnostic."""
+        with self.assertRaises(SystemExit) as cm:
+            vs.load_frame_records(self._mixed_store(n_v18=5), device_id=99)
+        self.assertIn("device-id", str(cm.exception))

--- a/tools/linux-capture/test_validate_spo2_candidate.py
+++ b/tools/linux-capture/test_validate_spo2_candidate.py
@@ -228,10 +228,12 @@ if __name__ == "__main__":
 
 
 class LoadFrameRecordsTest(unittest.TestCase):
-    """#103: the validator originally read capture.json only, so it could not be pointed at the place a
-    NOOP install's own history already lives — the SQLite `frames` table `whoop_activity.records()`
-    reads. Requiring an HCI re-capture instead is a far harder ask than opening the existing database,
-    and it was the practical blocker on getting multi-device @82 evidence at all."""
+    """#103: `whoop_sync.py` writes its captures to a SQLite `frames` table, but this validator read
+    only capture.json — so a Linux capture had to be round-tripped through
+    `whoop_sync.py export --only-type 47` to be analysed by a tool sitting in the same directory.
+
+    This is the CAPTURE TOOLING's database, not the app's: neither shipped app has a `frames` table
+    (Android is Room, iOS/macOS is GRDB), so this path cannot reach a phone store or a .noopbak."""
 
     def _store(self, rows, *, device_id=2, inner_type=47):
         path = tempfile.mktemp(suffix=".db")
@@ -286,4 +288,4 @@ class LoadFrameRecordsTest(unittest.TestCase):
         self.addCleanup(lambda: os.path.exists(path) and os.unlink(path))
         with self.assertRaises(SystemExit) as cm:
             vs.load_frame_records(path)
-        self.assertIn("not a NOOP frame store", str(cm.exception))
+        self.assertIn("not a whoop_sync.py frame store", str(cm.exception))

--- a/tools/linux-capture/validate_spo2_candidate.py
+++ b/tools/linux-capture/validate_spo2_candidate.py
@@ -9,7 +9,7 @@ Context (see docs/WHOOP5_DEEP_DATA.md and issue #103):
 
 This tool answers the promote-or-not question as *known plaintext*:
 
-    capture.json OR whoop.db  +  whoop_export  ──►  nightly mean(@82 | asleep, 70–100)
+    capture.json OR a whoop_sync.py .db  +  whoop_export  ──►  mean(@82 | asleep, 70–100)
                                        vs CSV blood_oxygen_pct
                                        ──►  r, MAE, bias, offset-specificity
 
@@ -202,8 +202,8 @@ def load_cycles(export_path: str) -> List[dict]:
 # --- Capture decode --------------------------------------------------------------------------------
 
 def looks_like_sqlite(path: str) -> bool:
-    """True if `path` is a SQLite file. Sniffs the 16-byte header rather than trusting the extension —
-    NOOP's Android store is `whoop.db` but a copied/renamed capture is common."""
+    """True if `path` is a SQLite file. Sniffs the 16-byte header rather than trusting the extension,
+    since capture DBs get renamed freely (`whoop.db`, `strap-a.db`, no suffix at all)."""
     try:
         with open(path, "rb") as f:
             return f.read(16) == b"SQLite format 3\x00"
@@ -212,12 +212,16 @@ def looks_like_sqlite(path: str) -> bool:
 
 
 def load_frame_records(path: str, *, device_id: int = 2) -> List[dict]:
-    """Frame records as `{"hex": ...}` dicts, from EITHER a capture.json or a NOOP SQLite store.
+    """Frame records as `{"hex": ...}` dicts, from EITHER a capture.json or a `whoop_sync.py` store.
 
-    The JSON path is what hci_extract / whoop_capture produce. The SQLite path reads the same
-    `frames` table `whoop_activity.records()` reads, which is where a NOOP install's own offloaded
-    history already lives — without it this tool can only validate data that was re-captured over
-    HCI, which is a far harder ask than pointing it at the database the app already wrote.
+    The JSON path is what hci_extract / whoop_capture produce. The SQLite path reads the `frames`
+    table that `whoop_sync.py` writes (`captures/whoop.db`) and `whoop_activity.py` reads.
+
+    NOTE: this is the CAPTURE TOOLING's database, not the app's. Neither shipped app has a `frames`
+    table — Android uses Room, iOS/macOS uses GRDB — so this cannot be pointed at a phone's store or
+    a `.noopbak`. It exists because `whoop_sync.py` writes `.db` while this tool read only `.json`,
+    forcing a `whoop_sync.py export --only-type 47` round-trip between two tools in the same
+    directory.
     """
     if looks_like_sqlite(path):
         con = sqlite3.connect(path)
@@ -226,7 +230,7 @@ def load_frame_records(path: str, *, device_id: int = 2) -> List[dict]:
                 "SELECT hex FROM frames WHERE device_id=? AND inner_type=47", (device_id,)
             ).fetchall()
         except sqlite3.Error as e:
-            raise SystemExit(f"{path}: not a NOOP frame store ({e})")
+            raise SystemExit(f"{path}: not a whoop_sync.py frame store ({e})")
         finally:
             con.close()
         if not rows:
@@ -239,7 +243,7 @@ def load_frame_records(path: str, *, device_id: int = 2) -> List[dict]:
     with open(path) as f:
         capture = json.load(f)
     if not isinstance(capture, list):
-        raise SystemExit(f"{path}: expected a JSON list of frame records, or a NOOP SQLite store")
+        raise SystemExit(f"{path}: expected a JSON list of frame records, or a whoop_sync.py .db")
     return capture
 
 
@@ -504,7 +508,7 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
     p.add_argument("export", nargs="?", help="WHOOP CSV export .zip or folder")
     p.add_argument("--device", default="device", help="label for this strap (default: device)")
     p.add_argument("--device-id", type=int, default=2,
-                   help="device_id row filter when the capture is a NOOP SQLite store "
+                   help="device_id row filter when the capture is a whoop_sync.py .db "
                         "(default: 2, matching whoop_activity.py)")
     p.add_argument(
         "--batch",

--- a/tools/linux-capture/validate_spo2_candidate.py
+++ b/tools/linux-capture/validate_spo2_candidate.py
@@ -226,9 +226,26 @@ def load_frame_records(path: str, *, device_id: int = 2) -> List[dict]:
     if looks_like_sqlite(path):
         con = sqlite3.connect(path)
         try:
+            # Filter to v18 IN SQL, not after loading. hist_version sits at frame offset 9, i.e. hex
+            # chars 19-20 (substr is 1-indexed), and 0x12 == 18. Newer 5/MG firmware serves a
+            # v20 (2140 B) + v21 (1244 B) pair every second alongside the 124-byte v18, so a mixed
+            # corpus is mostly bytes this tool discards: measured 115 MB to reach 20k usable records
+            # unfiltered, against 56 MB for 50k when the store is pure v18. Only v18 carries @82.
             rows = con.execute(
-                "SELECT hex FROM frames WHERE device_id=? AND inner_type=47", (device_id,)
+                "SELECT hex FROM frames WHERE device_id=? AND inner_type=47 "
+                "AND substr(hex, 19, 2) = '12'",
+                (device_id,),
             ).fetchall()
+            if not rows:
+                # Distinguish "no v18" from "no frames at all" — they need different fixes.
+                any47 = con.execute(
+                    "SELECT COUNT(*) FROM frames WHERE device_id=? AND inner_type=47", (device_id,)
+                ).fetchone()[0]
+                if any47:
+                    raise SystemExit(
+                        f"{path}: {any47} type-47 frames for device_id={device_id}, but none are "
+                        f"v18 — @82 only exists in the v18 layout"
+                    )
         except sqlite3.Error as e:
             raise SystemExit(f"{path}: not a whoop_sync.py frame store ({e})")
         finally:

--- a/tools/linux-capture/validate_spo2_candidate.py
+++ b/tools/linux-capture/validate_spo2_candidate.py
@@ -9,7 +9,7 @@ Context (see docs/WHOOP5_DEEP_DATA.md and issue #103):
 
 This tool answers the promote-or-not question as *known plaintext*:
 
-    capture.json  +  whoop_export  ──►  nightly mean(@82 | asleep, 70–100)
+    capture.json OR whoop.db  +  whoop_export  ──►  nightly mean(@82 | asleep, 70–100)
                                        vs CSV blood_oxygen_pct
                                        ──►  r, MAE, bias, offset-specificity
 
@@ -42,6 +42,7 @@ import io
 import json
 import math
 import os
+import sqlite3
 import statistics
 import sys
 import zipfile
@@ -200,6 +201,48 @@ def load_cycles(export_path: str) -> List[dict]:
 
 # --- Capture decode --------------------------------------------------------------------------------
 
+def looks_like_sqlite(path: str) -> bool:
+    """True if `path` is a SQLite file. Sniffs the 16-byte header rather than trusting the extension —
+    NOOP's Android store is `whoop.db` but a copied/renamed capture is common."""
+    try:
+        with open(path, "rb") as f:
+            return f.read(16) == b"SQLite format 3\x00"
+    except OSError:
+        return False
+
+
+def load_frame_records(path: str, *, device_id: int = 2) -> List[dict]:
+    """Frame records as `{"hex": ...}` dicts, from EITHER a capture.json or a NOOP SQLite store.
+
+    The JSON path is what hci_extract / whoop_capture produce. The SQLite path reads the same
+    `frames` table `whoop_activity.records()` reads, which is where a NOOP install's own offloaded
+    history already lives — without it this tool can only validate data that was re-captured over
+    HCI, which is a far harder ask than pointing it at the database the app already wrote.
+    """
+    if looks_like_sqlite(path):
+        con = sqlite3.connect(path)
+        try:
+            rows = con.execute(
+                "SELECT hex FROM frames WHERE device_id=? AND inner_type=47", (device_id,)
+            ).fetchall()
+        except sqlite3.Error as e:
+            raise SystemExit(f"{path}: not a NOOP frame store ({e})")
+        finally:
+            con.close()
+        if not rows:
+            raise SystemExit(
+                f"{path}: no type-47 frames for device_id={device_id} "
+                f"(try --device-id; whoop_activity.py defaults to 2)"
+            )
+        return [{"hex": r[0]} for r in rows]
+
+    with open(path) as f:
+        capture = json.load(f)
+    if not isinstance(capture, list):
+        raise SystemExit(f"{path}: expected a JSON list of frame records, or a NOOP SQLite store")
+    return capture
+
+
 def iter_v18_records(capture_records: Sequence[dict]) -> Iterable[dict]:
     """Yield decoded v18 fields from capture.json entries (absolute frame offsets)."""
     for rec in capture_records:
@@ -284,11 +327,9 @@ def validate_device(
     *,
     device: str = "device",
     require_asleep: bool = True,
+    device_id: int = 2,
 ) -> dict:
-    with open(capture_path) as f:
-        capture = json.load(f)
-    if not isinstance(capture, list):
-        raise SystemExit(f"{capture_path}: expected a JSON list of frame records")
+    capture = load_frame_records(capture_path, device_id=device_id)
 
     cycles = load_cycles(export_path)
     records = list(iter_v18_records(capture))
@@ -462,6 +503,9 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
     p.add_argument("capture", nargs="?", help="capture.json (from hci_extract / whoop_capture)")
     p.add_argument("export", nargs="?", help="WHOOP CSV export .zip or folder")
     p.add_argument("--device", default="device", help="label for this strap (default: device)")
+    p.add_argument("--device-id", type=int, default=2,
+                   help="device_id row filter when the capture is a NOOP SQLite store "
+                        "(default: 2, matching whoop_activity.py)")
     p.add_argument(
         "--batch",
         metavar="devices.json",
@@ -499,6 +543,7 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
                     entry["capture"],
                     entry["export"],
                     device=entry.get("device", "device"),
+                    device_id=int(entry.get("device_id", args.device_id)),
                     require_asleep=require_asleep,
                 )
             )
@@ -510,6 +555,7 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
                 args.capture,
                 args.export,
                 device=args.device,
+                device_id=args.device_id,
                 require_asleep=require_asleep,
             )
         )


### PR DESCRIPTION
Removes an export round-trip between two tools in the same directory.

**Correction first, since it was my argument for opening this.** I originally justified this as letting the validator read "the database the app already wrote." That's wrong. The SQLite `frames` table is created and written by **`whoop_sync.py`** (`captures/whoop.db`) — the Linux capture script. Neither shipped app has a `frames` table: Android uses Room, iOS/macOS uses GRDB. **This cannot be pointed at a phone's store or a `.noopbak`.** I inferred it from `whoop_activity.py` reading a `.db` and never checked what writes it.

**The honest benefit, which is smaller.** `whoop_sync.py` writes `.db`; this validator read only `.json`. So a Linux capture had to be round-tripped through `whoop_sync.py export --only-type 47` before a tool sitting in the same directory could analyse it. This removes that step.

```bash
python3 validate_spo2_candidate.py captures/whoop.db my_whoop_data/ --device strap-a --postable
```

It does **not** make an existing corpus reachable unless that corpus came from `whoop_sync.py`.

**The change itself.** The SQLite path reads the same `frames WHERE device_id=? AND inner_type=47` that `whoop_activity.records()` uses and yields the same `{"hex": ...}` shape the existing decode seam takes. Nightly means, pairing, r/MAE/bias and the offset-specificity scan are untouched.

- **Detected by the 16-byte SQLite header, not the extension** — capture DBs get renamed freely.
- **Both failure modes report rather than returning nothing.** A wrong `--device-id`, and a SQLite file that isn't a frame store, each exit naming the cause. Silently finding zero nights would read as *"the candidate doesn't track"*, which is the wrong conclusion to draw from a filter mismatch.

**Verification:** 5 new tests (SQLite read, header-not-extension, JSON path unchanged, both error paths). Suite **170 → 175**, OK (1 skipped), on Linux. Measured at scale too — 50k frames peak ~93 MB RSS, extrapolating to ~290 MB for a 258k-frame DB, which is fine for a desktop diagnostic but worth knowing before pointing it at something much larger.

Python tooling and docs only. #103 stays open — this is plumbing for the instrument, not the answer.
