### PR TITLE
fix(ble): persist strap family on connect, and reset 5/MG probes on a family switch

### DIFF
--- a/Strand/BLE/BLEManager.swift
+++ b/Strand/BLE/BLEManager.swift
@@ -3378,22 +3378,7 @@ extension BLEManager: @preconcurrency CBCentralManagerDelegate {
             return
         }
         cancelScanFallback()
-        // Persist the family that actually advertised so the next scan starts on the right service —
-        // this is what makes a one-time rotation stick after a stale-preference reconnect, and drives the
-        // Settings 5/MG-controls gate off the ACTUALLY-CONNECTED strap. (PR#195)
-        // On a genuine family switch (4.0 ↔ 5/MG) also untick the 5/MG-only probes so nothing carries
-        // over to the wrong, unsupported strap. Same-family reconnects don't reset (previous == new).
-        // Compare deviceFamily, not the raw value — Swift's WhoopModel already exposes it, and if MG
-        // ever splits from plain 5.0 as its own case the two would share .whoop5, so a raw-value
-        // compare would reset the probes on a same-family switch. Mirrors the Kotlin service compare.
-        let previousSelectedModel = UserDefaults.standard.string(forKey: "selectedWhoopModel")
-        UserDefaults.standard.set(selectedModel.rawValue, forKey: "selectedWhoopModel")
-        if let previousSelectedModel,
-           let previousModel = WhoopModel(rawValue: previousSelectedModel),
-           previousModel.deviceFamily != selectedModel.deviceFamily {
-            PuffinExperiment.resetFiveMGGatedProbes()
-            log("Strap family switched (\(previousSelectedModel) → \(selectedModel.rawValue)) — reset 5/MG-only experimental toggles to off.")
-        }
+        persistSelectedModel(selectedModel)
         log("Discovered \(name) (rssi \(RSSI)) — connecting")
         central.stopScan()
         preparePeripheral(peripheral)
@@ -3746,6 +3731,23 @@ extension BLEManager: @preconcurrency CBCentralManagerDelegate {
 
 // MARK: - CBPeripheralDelegate
 extension BLEManager: @preconcurrency CBPeripheralDelegate {
+    /// Persist the WHOOP family we are actually talking to, so the next launch scans the right service —
+    /// what makes a one-time fallback rotation stick (PR#195) — and, on a genuine family switch, untick the
+    /// 5/MG-only probes so none carries over to a strap that cannot support it.
+    ///
+    /// Compares `deviceFamily`, not the raw value: if MG ever splits from plain 5.0 into its own case the
+    /// two would share `.whoop5`, and a raw-value compare would then reset on a same-family switch. Mirrors
+    /// the Kotlin `persistSelectedModel` service compare.
+    private func persistSelectedModel(_ model: WhoopModel) {
+        let previous = UserDefaults.standard.string(forKey: "selectedWhoopModel")
+        UserDefaults.standard.set(model.rawValue, forKey: "selectedWhoopModel")
+        guard let previous,
+              let previousModel = WhoopModel(rawValue: previous),
+              previousModel.deviceFamily != model.deviceFamily else { return }
+        PuffinExperiment.resetFiveMGGatedProbes()
+        log("Strap family switched (\(previous) → \(model.rawValue)) — reset 5/MG-only experimental toggles to off.")
+    }
+
     public func peripheral(_ peripheral: CBPeripheral, didDiscoverServices error: Error?) {
         if let error {
             log("Service discovery failed: \(error.localizedDescription)")
@@ -3753,6 +3755,17 @@ extension BLEManager: @preconcurrency CBPeripheralDelegate {
         }
         guard let services = peripheral.services else { return }
         log("Services discovered: \(services.map { $0.uuid.uuidString }.joined(separator: ", "))")
+        // Record the family from the services the strap ACTUALLY exposes, not just from a scan. The adopt
+        // paths in connectCore (`retrieveConnectedPeripherals` / `retrievePeripherals`) reach didConnect
+        // WITHOUT ever passing through didDiscover, so a strap attached that way never persisted its family
+        // and the next launch scanned the wrong service until the fallback rotation recovered. This is the
+        // Apple analogue of the Android fix in WhoopBleClient's connect-time family resolution. Checked
+        // once here rather than inside the loop so a strap exposing both services can't thrash the pref.
+        if services.contains(where: { $0.uuid == BLEManager.whoop5Service }) {
+            persistSelectedModel(.whoop5mg)
+        } else if services.contains(where: { $0.uuid == BLEManager.customService }) {
+            persistSelectedModel(.whoop4)
+        }
         for s in services {
             switch s.uuid {
             case BLEManager.customService:

--- a/Strand/BLE/BLEManager.swift
+++ b/Strand/BLE/BLEManager.swift
@@ -3383,9 +3383,14 @@ extension BLEManager: @preconcurrency CBCentralManagerDelegate {
         // Settings 5/MG-controls gate off the ACTUALLY-CONNECTED strap. (PR#195)
         // On a genuine family switch (4.0 ↔ 5/MG) also untick the 5/MG-only probes so nothing carries
         // over to the wrong, unsupported strap. Same-family reconnects don't reset (previous == new).
+        // Compare deviceFamily, not the raw value — Swift's WhoopModel already exposes it, and if MG
+        // ever splits from plain 5.0 as its own case the two would share .whoop5, so a raw-value
+        // compare would reset the probes on a same-family switch. Mirrors the Kotlin service compare.
         let previousSelectedModel = UserDefaults.standard.string(forKey: "selectedWhoopModel")
         UserDefaults.standard.set(selectedModel.rawValue, forKey: "selectedWhoopModel")
-        if let previousSelectedModel, previousSelectedModel != selectedModel.rawValue {
+        if let previousSelectedModel,
+           let previousModel = WhoopModel(rawValue: previousSelectedModel),
+           previousModel.deviceFamily != selectedModel.deviceFamily {
             PuffinExperiment.resetFiveMGGatedProbes()
             log("Strap family switched (\(previousSelectedModel) → \(selectedModel.rawValue)) — reset 5/MG-only experimental toggles to off.")
         }

--- a/Strand/BLE/BLEManager.swift
+++ b/Strand/BLE/BLEManager.swift
@@ -3379,8 +3379,16 @@ extension BLEManager: @preconcurrency CBCentralManagerDelegate {
         }
         cancelScanFallback()
         // Persist the family that actually advertised so the next scan starts on the right service —
-        // this is what makes a one-time rotation stick after a stale-preference reconnect. (PR#195)
+        // this is what makes a one-time rotation stick after a stale-preference reconnect, and drives the
+        // Settings 5/MG-controls gate off the ACTUALLY-CONNECTED strap. (PR#195)
+        // On a genuine family switch (4.0 ↔ 5/MG) also untick the 5/MG-only probes so nothing carries
+        // over to the wrong, unsupported strap. Same-family reconnects don't reset (previous == new).
+        let previousSelectedModel = UserDefaults.standard.string(forKey: "selectedWhoopModel")
         UserDefaults.standard.set(selectedModel.rawValue, forKey: "selectedWhoopModel")
+        if let previousSelectedModel, previousSelectedModel != selectedModel.rawValue {
+            PuffinExperiment.resetFiveMGGatedProbes()
+            log("Strap family switched (\(previousSelectedModel) → \(selectedModel.rawValue)) — reset 5/MG-only experimental toggles to off.")
+        }
         log("Discovered \(name) (rssi \(RSSI)) — connecting")
         central.stopScan()
         preparePeripheral(peripheral)

--- a/Strand/BLE/PuffinExperiment.swift
+++ b/Strand/BLE/PuffinExperiment.swift
@@ -140,4 +140,15 @@ enum PuffinExperiment {
     static let motionAwareWakeKey = "noopMotionAwareWake"
 
     static var motionAwareWakeEnabled: Bool { UserDefaults.standard.bool(forKey: motionAwareWakeKey) }
+
+    /// Turn OFF the 5/MG-only probes — protocol probes ([isEnabled]), the R22 deep-data strap write
+    /// ([deepDataEnabled]) and broadcast-HR ([broadcastHrEnabled]) — on a strap FAMILY switch
+    /// (WHOOP 4.0 ↔ 5/MG), so a 5/MG-only option can never linger enabled and get applied to a strap it
+    /// doesn't belong to. Leaves the model-agnostic toggles (continuous HRV, experimental sleep V2,
+    /// auto-detect workouts) alone. Mirrors the Android `PuffinExperiment.resetFiveMGGatedProbes`.
+    static func resetFiveMGGatedProbes() {
+        UserDefaults.standard.set(false, forKey: defaultsKey)
+        UserDefaults.standard.set(false, forKey: deepDataKey)
+        UserDefaults.standard.set(false, forKey: broadcastHrKey)
+    }
 }

--- a/android/app/src/main/java/com/noop/ble/PuffinExperiment.kt
+++ b/android/app/src/main/java/com/noop/ble/PuffinExperiment.kt
@@ -95,6 +95,22 @@ class PuffinExperiment(private val prefs: SharedPreferences) {
         get() = prefs.getBoolean(KEY_MOTION_AWARE_WAKE, false)
         set(v) = prefs.edit().putBoolean(KEY_MOTION_AWARE_WAKE, v).apply()
 
+    /**
+     * Turn OFF every 5/MG-only experimental probe: protocol probes ([isEnabled]), raw capture
+     * ([isCaptureEnabled]), the R22 deep-data strap write ([isDeepDataEnabled]) and broadcast-HR
+     * ([broadcastHr]). Called on a strap FAMILY switch (WHOOP 4.0 ↔ 5/MG) so a 5/MG-only option can
+     * never linger enabled and get applied to a strap it doesn't belong to. Deliberately leaves
+     * [experimentalSleepV2] untouched — it is model-agnostic (works on both families). One atomic edit.
+     */
+    fun resetFiveMGGatedProbes() {
+        prefs.edit()
+            .putBoolean(KEY, false)
+            .putBoolean(KEY_CAPTURE, false)
+            .putBoolean(KEY_DEEP_DATA, false)
+            .putBoolean(KEY_BROADCAST_HR, false)
+            .apply()
+    }
+
     companion object {
         /** Persisted preferences file. */
         private const val PREFS = "noop_experiments"

--- a/android/app/src/main/java/com/noop/ble/PuffinExperiment.kt
+++ b/android/app/src/main/java/com/noop/ble/PuffinExperiment.kt
@@ -99,8 +99,14 @@ class PuffinExperiment(private val prefs: SharedPreferences) {
      * Turn OFF every 5/MG-only experimental probe: protocol probes ([isEnabled]), raw capture
      * ([isCaptureEnabled]), the R22 deep-data strap write ([isDeepDataEnabled]) and broadcast-HR
      * ([broadcastHr]). Called on a strap FAMILY switch (WHOOP 4.0 ↔ 5/MG) so a 5/MG-only option can
-     * never linger enabled and get applied to a strap it doesn't belong to. Deliberately leaves
-     * [experimentalSleepV2] untouched — it is model-agnostic (works on both families). One atomic edit.
+     * never linger enabled and get applied to a strap it doesn't belong to. One atomic edit.
+     *
+     * The line is "does it SEND something to the strap": these four arm probes, raw-capture writes, the
+     * R22 deep-data write and the broadcast-HR write, all of which target hardware that may not support
+     * them. Pure analysis flags are deliberately left alone even when they only do anything on one
+     * family — [ppgHrSubLagInterp] only affects v26 optical records, which a 4.0 never sends, so it is
+     * inert rather than misapplied. [experimentalSleepV2], [hrvReadiness] and [motionAwareWake] are
+     * model-agnostic (the last self-gates on observed sample density, never on family, per #345).
      */
     fun resetFiveMGGatedProbes() {
         prefs.edit()

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -3426,13 +3426,33 @@ class WhoopBleClient(
     // ====================================================================================
 
     /** Persist the WHOOP family that actually advertised so a later launch/scan starts on the right
-     *  service — what makes a one-time fallback rotation stick. Mirrors macOS
+     *  service — what makes a one-time fallback rotation stick, and drives the Settings 5/MG-controls
+     *  gate off the ACTUALLY-CONNECTED strap (not a stale device-list default). Mirrors macOS
      *  `UserDefaults.set(rawValue, forKey: "selectedWhoopModel")`. Self-contained in the shared
-     *  noop_prefs store; failures are non-fatal (the rotation still worked this session). (PR#195) */
+     *  noop_prefs store; failures are non-fatal (the rotation still worked this session). (PR#195)
+     *
+     *  On a genuine FAMILY switch (4.0 ↔ 5/MG) it also clears the 5/MG-only experimental toggles via
+     *  [PuffinExperiment.resetFiveMGGatedProbes], so a 5/MG-only probe (raw capture, R22 deep-data
+     *  write, broadcast-HR write) can't stay enabled across a switch and get applied to the wrong,
+     *  unsupported strap. Same-family reconnects don't reset (the previous == new guard). */
     private fun persistSelectedModel(model: WhoopModel) {
         try {
-            context.getSharedPreferences("noop_prefs", Context.MODE_PRIVATE)
-                .edit().putString("noop.selectedWhoopModel", model.name).apply()
+            val prefs = context.getSharedPreferences("noop_prefs", Context.MODE_PRIVATE)
+            val previous = prefs.getString("noop.selectedWhoopModel", null)
+            prefs.edit().putString("noop.selectedWhoopModel", model.name).apply()
+            // Compare the GATT SERVICE, not the enum name — the service UUID is what actually
+            // distinguishes the two families. Identical today (WhoopModel is exactly WHOOP4 and
+            // WHOOP5_MG), but Whoop5Variant already tells MG from plain 5.0 at the hardware level; if
+            // that ever becomes a third WhoopModel it would share WHOOP5_SERVICE, and a name compare
+            // would then reset the probes on a 5.0 <-> MG switch — same family, must not reset.
+            // runCatching: an unrecognised persisted string is a stale pref, not a family change.
+            val previousService = previous?.let { runCatching { WhoopModel.valueOf(it).service }.getOrNull() }
+            if (previousService != null && previousService != model.service) {
+                // Family actually changed — untick the family-gated probes so nothing carries over.
+                PuffinExperiment.from(context).resetFiveMGGatedProbes()
+                log("Strap family switched ($previous → ${model.name}) — reset 5/MG-only experimental " +
+                    "toggles (protocol probes, raw capture, deep-data, broadcast HR) to off.")
+            }
         } catch (t: Throwable) {
             log("Couldn't persist selected model: ${t.message}")
         }

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -4123,6 +4123,11 @@ class WhoopBleClient(
                 // notifications ever enable, so HR/battery/events stay empty (issue #12). The bond write
                 // is deferred to startSession(), which runs once every notification is on.
                 connectedFamily = DeviceFamily.WHOOP4
+                // Record the family on connect, not only in the scan path (persistSelectedModel is
+                // otherwise called only from onScanResult). A strap reached via the co-resident
+                // easy-connect route (getConnectedDevices / bondedDevices adopt, no scan) would never
+                // persist its model, leaving model-gated UI stale for a genuinely-connected strap.
+                persistSelectedModel(WhoopModel.WHOOP4)
                 cmdCharacteristic = whoop4.getCharacteristic(CMD_WRITE_CHAR)
                 whoop4.getCharacteristic(CMD_NOTIFY_CHAR)?.let { cccdQueue.add(it) }
                 whoop4.getCharacteristic(EVENT_NOTIFY_CHAR)?.let { cccdQueue.add(it) }
@@ -4131,6 +4136,11 @@ class WhoopBleClient(
                 // EXPERIMENTAL WHOOP 5.0/MG: opens with CLIENT_HELLO (sent in startSession, after the
                 // standard HR/battery notifications are enabled), not the WHOOP4 confirmed-write bond.
                 connectedFamily = DeviceFamily.WHOOP5
+                // Persist on connect too (see the WHOOP4 branch): otherwise an easy-connect 5/MG never
+                // records WHOOP5_MG, so the 5/MG-only controls (raw capture, broadcast HR, deep data)
+                // gated on noop.selectedWhoopModel stay hidden until the strap is live-detected that
+                // session — even when it is the active paired device. This makes the choice stick.
+                persistSelectedModel(WhoopModel.WHOOP5_MG)
                 log("WHOOP 5/MG detected — will send CLIENT_HELLO after subscribing (experimental).")
                 _state.update { it.copy(
                     whoop5Detected = true,

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -3449,9 +3449,18 @@ class WhoopBleClient(
             val previousService = previous?.let { runCatching { WhoopModel.valueOf(it).service }.getOrNull() }
             if (previousService != null && previousService != model.service) {
                 // Family actually changed — untick the family-gated probes so nothing carries over.
-                PuffinExperiment.from(context).resetFiveMGGatedProbes()
-                log("Strap family switched ($previous → ${model.name}) — reset 5/MG-only experimental " +
-                    "toggles (protocol probes, raw capture, deep-data, broadcast HR) to off.")
+                // Its own runCatching: the persist above has ALREADY succeeded by this point, so letting
+                // a failure here fall into the outer catch would log "couldn't persist" about a write
+                // that worked, and hide which half actually broke.
+                runCatching { PuffinExperiment.from(context).resetFiveMGGatedProbes() }
+                    .onSuccess {
+                        log("Strap family switched ($previous → ${model.name}) — reset 5/MG-only " +
+                            "experimental toggles (protocol probes, raw capture, deep-data, broadcast HR) to off.")
+                    }
+                    .onFailure {
+                        log("Strap family switched ($previous → ${model.name}) but couldn't reset the " +
+                            "5/MG-only toggles: ${it.message} — they may still be on for the wrong family.")
+                    }
             }
         } catch (t: Throwable) {
             log("Couldn't persist selected model: ${t.message}")


### PR DESCRIPTION
Carries two commits from [@tanarchytan](https://github.com/tanarchytan/noop)'s fork, plus fixes found reviewing them. Credited as co-author.

## 1. The bug (their commit, verified on main)

`persistSelectedModel` is called from exactly one place — `onScanResult:3517`. Connect-time family resolution at `WhoopBleClient.kt:4125/4133` doesn't persist. So a strap reached via the co-resident adopt path (`getConnectedDevices`/bonded, no scan) never records its family, and since `SettingsScreen.kt:469` gates on `selectedModelName == WHOOP5_MG || live.whoop5Detected`, the 5/MG-only controls stay hidden for a genuinely-connected MG that wasn't live-detected that session.

**The fix matches documented intent.** `SettingsScreen.kt:460` already says the key is *"rewritten to the family that actually advertised when a strap connects"*. The comment described the design; the code only did it on scan. That also settles the risk I was most worried about — the key is cached detection, not a user choice, so overwriting on connect is correct rather than destructive.

## 2. Reset on family switch (their commit)

A 5/MG-only probe left enabled could carry over to a 4.0. Now cleared on a genuine family change.

## 3. What I changed

**The guard compared model *names*.** That equals family-inequality only because `WhoopModel` is exactly `{WHOOP4, WHOOP5_MG}` today. `Whoop5Variant` already tells MG from plain 5.0 at the hardware level — if that ever becomes a third `WhoopModel`, a name compare would reset the probes on a 5.0↔MG switch, which is the *same family* and must not reset. Kotlin now compares the GATT service UUID; Swift compares `deviceFamily`, which it already exposes.

**Documented where the reset set stops**, because the boundary isn't obvious. All four reset flags *send something to the strap* — probes, raw capture, R22 deep-data write, broadcast HR — so one left on aims at hardware that may not support it. Pure analysis flags stay untouched even when they only bite on one family: `ppgHrSubLagInterp` only affects v26 records, which a 4.0 never sends, so it's inert rather than misapplied.

**Two things in their commit message I checked and one is wrong:**

- *"Swift's three-key reset"* — **correct**, not a parity gap. `noopWhoop5Capture` exists only on Kotlin, so there's no capture key for Swift to clear. I suspected a missing key and was wrong.
- *"CoreBluetooth has no adopt-connected path"* — **wrong**. It does: `retrieveConnectedPeripherals` at `BLEManager.swift:1094`. The conclusion still holds, but for a different reason — that call is scoped to `[model.scanService]` and `connectCore` sets `selectedModel` before it runs, so Apple can only adopt a peripheral matching the already-selected model. Worth correcting, since the stated reason would tell a future reader the gap can't appear there even if the adopt path were widened to several services.

## Verification

Symbols checked to exist on both sides (`WhoopModel.service`, `WhoopModel.deviceFamily`, `WhoopModel: String` for `init?(rawValue:)`, `resetFiveMGGatedProbes` on both). i18n clean, no new strings.

**Not compiled.** No JDK or Xcode here, and neither `android.yml` nor `app-build.yml` runs — this is app-target code on both platforms, so nothing in CI touches it. Their commit reports Android compiled green on the earlier version; my guard change is unbuilt on both. Worth a local compile before merge.


## Known limitation this introduces

If the reset fires **while the Settings screen is open**, the four switches keep showing their old state until you navigate away and back. The stored value is correct — only the on-screen control is stale.

Cause: `SettingsScreen.kt:445-449` snapshots those toggles into `remember { mutableStateOf(...) }` with **no key**, so they read once per composition. Until now nothing outside Settings ever changed them, so that was safe; this PR makes a background BLE callback a writer.

The obvious fix doesn't work. `selectedModelName` next to them uses `remember(rev)`, but `rev` is a local counter bumped only by Settings' own `mutate {}` writes (`:396-397`) — a `WhoopBleClient` callback never touches it. A real fix means signalling the UI through the `live` state Settings already observes, which is a wider change than this PR should carry.

Narrow in practice: it needs a strap family switch *while sitting in Settings*.


## Parity: now fixed on Apple too

An earlier revision documented this as a deliberate asymmetry. It's fixed instead.

Apple's `selectedWhoopModel` had exactly one writer — `didDiscover`, the scan path. Both adopt paths in `connectCore` (`retrieveConnectedPeripherals` for an already-open strap, `retrievePeripherals` for a pinned one) call `central.connect` and return **without** passing through it, so a strap attached either way never recorded its family. Next launch scanned the wrong service until `fallbackScanModel` rotation recovered — a wasted scan cycle every launch. Milder than the Android symptom, same bug.

Persisted at `didDiscoverServices` instead, which is the true analogue of the Android fix: the family comes from the services the strap **actually exposes**, so it's right however the connection was made.

Deliberately **not** at `connectCore` entry — that records an intent rather than a fact, and would break PR#195's rotation by persisting a family that never answered. Checked once before the service loop rather than inside it, so a strap exposing both services can't thrash the pref.

The persist + reset logic is now a shared private helper mirroring Kotlin's `persistSelectedModel`, called from both seams, so the reset can't fire on one path and not the other.
