### PR TITLE
fix(ble): log when pagesBehind fails to decode, not only when it succeeds

### DIFF
--- a/Strand/BLE/BLEManager.swift
+++ b/Strand/BLE/BLEManager.swift
@@ -4208,10 +4208,17 @@ extension BLEManager: @preconcurrency CBPeripheralDelegate {
         // unconditionally, even if decode returns nil) so the field offsets are inspectable from a strap log.
         let hex = frame.map { String(format: "%02x", $0) }.joined()
         log("Get Data Range raw frame (#451 — for offset analysis): \(hex)")
-        // #689: ring-buffer page backlog, DIAGNOSTIC ONLY (RE'd, unconfirmed — never gates sync/backfill).
-        // Logged only when it decodes plausibly; a short/garbage frame → nil.
+        // #689: ring-buffer page backlog, DIAGNOSTIC ONLY — never gates sync/backfill.
+        // BOTH branches log, deliberately. Until #818 the offsets were two bytes early, so ring capacity
+        // always read 0, the `t > 0` guard rejected every real frame, and this logged NOTHING — a strap
+        // log was indistinguishable from one where the strap never answered, which is why a broken decode
+        // survived unnoticed. The raw-frame dump above is unconditional for the same reason. If a firmware
+        // revision ever shifts these fields again, the rejection must be visible rather than silent.
         if let pages = DataRange.pagesBehind(from: frame, cmdOff: cmdOff) {
             log("Strap backlog pages behind: \(pages) (#689 — GET_DATA_RANGE ring backlog, diagnostic only)")
+        } else {
+            log("Strap backlog pages behind: not decodable from this frame (#689 — offsets may have moved; "
+                + "the raw frame above is the input). Diagnostic only, sync is unaffected.")
         }
         if let newest = BLEManager.dataRangeNewestUnix(from: frame) {
             // #695: the sync-affecting side-effects (strapNewestTs, backfill window, LiveState range) only

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -4475,10 +4475,20 @@ class WhoopBleClient(
                         // dataRangeNewestUnix straight from a normal strap-log export. Mirrors the Swift line.
                         val hex = frame.joinToString("") { "%02x".format(it) }
                         log("Get Data Range raw frame (#451 — for offset analysis): $hex")
-                        // #689: ring-buffer page backlog, DIAGNOSTIC ONLY (RE'd, unconfirmed — never gates
-                        // sync/backfill). Logged only when it decodes plausibly; a short/garbage frame → null.
-                        com.noop.protocol.DataRange.pagesBehind(frame, cmdOff)?.let {
-                            log("Strap backlog pages behind: $it (#689 — GET_DATA_RANGE ring backlog, diagnostic only)")
+                        // #689: ring-buffer page backlog, DIAGNOSTIC ONLY — never gates sync/backfill.
+                        // BOTH branches log, deliberately. Until #818 the offsets were two bytes early, so
+                        // ring capacity always read 0, the `t > 0` guard rejected every real frame, and this
+                        // logged NOTHING — a strap log was indistinguishable from one where the strap never
+                        // answered, which is why a broken decode survived unnoticed. The raw-frame dump above
+                        // is unconditional for the same reason. Twin of the Swift branch.
+                        val pagesBehind = com.noop.protocol.DataRange.pagesBehind(frame, cmdOff)
+                        if (pagesBehind != null) {
+                            log("Strap backlog pages behind: $pagesBehind (#689 — GET_DATA_RANGE ring backlog, diagnostic only)")
+                        } else {
+                            log(
+                                "Strap backlog pages behind: not decodable from this frame (#689 — offsets may " +
+                                    "have moved; the raw frame above is the input). Diagnostic only, sync is unaffected.",
+                            )
                         }
                         dataRangeNewestUnix(frame)?.let {
                             strapNewestTs = it


### PR DESCRIPTION
Follow-up to #818, from reviewing it.

**The silence is why that bug lasted.** Both platforms logged the ring backlog only on success:

```swift
if let pages = DataRange.pagesBehind(from: frame, cmdOff: cmdOff) { log(…) }   // no else
```

The offsets were two bytes early, so ring capacity always read `0`, the `t > 0` plausibility guard rejected **100% of real frames**, and nothing anywhere said so. A strap log looked exactly like one where the strap never answered a `GET_DATA_RANGE`. The doc comment's *"RE'd, unconfirmed"* was read as "probably fine" because there was no evidence to the contrary — there couldn't be.

**The file already knew better three lines up.** The raw-frame dump is logged unconditionally, with the comment *"even if decode returns nil, so the field offsets are inspectable from a strap log."* The same reasoning applies to the field parsed **from** that frame; it just wasn't carried across.

Both branches now log. The failure line points at the raw frame above it as the input to inspect, so if a firmware revision shifts these fields again the rejection is visible rather than silent.

**Verification:** the two runtime strings are byte-identical across platforms — checked by reconstructing the concatenated literals, not by eye, since the source wrapping differs. No `?.let` form left on the Kotlin side. i18n clean (strap-log text, not user-facing strings).

Diagnostic only — sync and backfill are untouched either way.

Not compiled: app-target code on both platforms, and neither `android.yml` nor `app-build.yml` runs. The last staging build (`7bed0b4`) was green on all four platforms, so the surrounding code compiles; these are two log statements on top of it.
