### PR TITLE
docs: write down the facts-vs-code line, which the docs currently contradict

### DIFF
--- a/ATTRIBUTION.md
+++ b/ATTRIBUTION.md
@@ -41,15 +41,28 @@ The line is between the fact and the expression of it:
 - **The implementation may not be copied** — not verbatim, not transcribed. Nor may string literals,
   assets, or anything else that is authored expression rather than an observation about the wire.
 
-`spo2_candidate_82` is the worked example. WHOOP 5 v18 byte `@82` is read as a strap-computed SpO₂
-percentage; `Interpreter.swift` attributes it as *"a decompile-sourced decode (gen5.rs `spo2_pct`),
-reimplemented here as a protocol fact with attribution"*, a guard test stops it ever writing
-`spo2Pct`, and it remains a candidate because the cross-device evidence is split.
+This is long-standing practice, not a one-off. Worked examples already in the tree:
 
-The `LINK_VALID` handshake is the counter-example, recorded in
-[`docs/BLE_REVERSE_ENGINEERING.md`](docs/BLE_REVERSE_ENGINEERING.md): its reply payload is a literal
-string lifted from the app. That is expression, not a fact about the protocol, so it stays out
-regardless of whether the handshake turns out to be real.
+- **`spo2_candidate_82`** (`Interpreter.swift`) — WHOOP 5 v18 byte `@82` read as a strap-computed SpO₂
+  percentage, attributed as *"a decompile-sourced decode (gen5.rs `spo2_pct`), reimplemented here as a
+  protocol fact with attribution"*. A guard test stops it ever writing `spo2Pct`, and it is still a
+  candidate because the cross-device evidence is split.
+- **The R22 config opcodes** (`Whoop5Config.swift` / `.kt`) — `SET_FF_VALUE (0x78)` and the flag key
+  names, corroborated against *Asherlc/dofek docs/whoop-ble-protocol.md (Android APK decompilation)*
+  and validated byte-for-byte against a decrypted HCI capture.
+- **The disputed battery opcode** (`Commands.swift`, `Enums.kt`) — a decompile reads
+  `GET_EXTENDED_BATTERY_INFO` as 87 where our table says 98. Both readings are recorded and the
+  question is settled by probing real firmware, not by picking a source.
+
+And the line held from the other side:
+
+- **`StrainTargetNotifier`** (both platforms) — *"CLEAN-ROOM: this reimplements the BEHAVIOUR only. The
+  copy is NOOP's own — NOT WHOOP's decompiled strings."* Behaviour re-derived; the user-facing text
+  written fresh.
+- **The `LINK_VALID` handshake**, rejected in
+  [`docs/BLE_REVERSE_ENGINEERING.md`](docs/BLE_REVERSE_ENGINEERING.md) — its reply payload is a
+  literal string lifted from the app. Expression, not a fact about the wire, so it stays out
+  regardless of whether the handshake turns out to be real.
 
 ## Oura ring (gen 3/4/5) protocol
 NOOP's Oura code is **original clean-room** work. The local BLE source

--- a/ATTRIBUTION.md
+++ b/ATTRIBUTION.md
@@ -27,6 +27,30 @@ NOOP builds on prior community reverse-engineering and interoperability work:
   about the live Mi-protobuf BLE stack in the roadmap's research notes. GPLv3; NOOP copies
   **none** of its code and has not built the live lane.
 
+## Facts learned from a decompiled app
+
+The facts-only doctrine above is usually applied to other open-source RE projects. It applies the same
+way when a fact originates in a **decompile of the vendor's own app** — a case that recurs because
+several third-party WHOOP projects are decompile-derived.
+
+The line is between the fact and the expression of it:
+
+- **A protocol fact may be re-derived** — a byte offset, field width, enum value, scale factor. It is
+  attributed at the point of use, and it ships as an **unvalidated candidate**: decoded and logged,
+  never backing a shipped metric, until independent captures from real hardware clear it.
+- **The implementation may not be copied** — not verbatim, not transcribed. Nor may string literals,
+  assets, or anything else that is authored expression rather than an observation about the wire.
+
+`spo2_candidate_82` is the worked example. WHOOP 5 v18 byte `@82` is read as a strap-computed SpO₂
+percentage; `Interpreter.swift` attributes it as *"a decompile-sourced decode (gen5.rs `spo2_pct`),
+reimplemented here as a protocol fact with attribution"*, a guard test stops it ever writing
+`spo2Pct`, and it remains a candidate because the cross-device evidence is split.
+
+The `LINK_VALID` handshake is the counter-example, recorded in
+[`docs/BLE_REVERSE_ENGINEERING.md`](docs/BLE_REVERSE_ENGINEERING.md): its reply payload is a literal
+string lifted from the app. That is expression, not a fact about the protocol, so it stays out
+regardless of whether the handshake turns out to be real.
+
 ## Oura ring (gen 3/4/5) protocol
 NOOP's Oura code is **original clean-room** work. The local BLE source
 (`Strand/BLE/OuraLiveSource.swift` + `android/.../ble/OuraLiveSource.kt`) and the JVM/Swift-pure

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,10 @@ These are hard constraints, not preferences. A PR is out of scope if it:
 - adds a server, account, cloud sync, or sends any data off-device;
 - adds analytics/telemetry/crash-reporting that phones home;
 - adds WHOOP firmware, decompiled app code, logos/assets, or any DRM circumvention. NOOP is
-  **clean-room interoperability** with hardware the user owns — keep it that way.
+  **clean-room interoperability** with hardware the user owns — keep it that way. (That bars
+  *implementations* and literals, not every fact learned from one: a protocol offset may be
+  re-derived with attribution as an unvalidated candidate — see the "facts vs code" bullet in
+  [`docs/CONTRIBUTING.md`](docs/CONTRIBUTING.md) before telling a contributor no.)
 
 Licensing: by opening a PR you agree your contribution is under the repo's
 [PolyForm Noncommercial 1.0.0](LICENSE) license.

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -506,6 +506,18 @@ Schema lives in `Packages/WhoopStore/Sources/WhoopStore/Database.swift` as a **v
 - **No proprietary material.** Don't add WHOOP firmware, decompiled app code, logos, or assets, and
   don't introduce DRM circumvention. Keep contributions to clean-room interoperability with hardware
   the user owns.
+- **Facts vs code — the line that actually gets tested.** The rule above is about *code*: verbatim or
+  transcribed implementations, string literals, and assets stay out however correct they are. A
+  **protocol fact** — a byte offset, a field width, an enum value — is not code and may be
+  reimplemented, *provided* it is attributed and lands as an **unvalidated candidate**: decoded and
+  logged, never backing a shipped metric, until independent captures clear it. `spo2_candidate_82`
+  (v18 byte `@82`) is the worked example — sourced from a decompile, attributed as such in
+  `Interpreter.swift`, gated by a test that stops it ever writing `spo2Pct`, and still a candidate
+  because the cross-device evidence is split. See [`ATTRIBUTION.md`](../ATTRIBUTION.md).
+
+  This matters because third-party WHOOP projects are frequently decompile-derived. "It came from a
+  decompile" doesn't by itself rule a finding out; **copying their implementation does**, and so does
+  shipping a metric on an unvalidated one.
 - **Licensing.** By opening a pull request you agree your contribution is licensed under the same
   [PolyForm Noncommercial License 1.0.0](../LICENSE) as the rest of NOOP. Forks and personal,
   non-commercial use are welcome under those terms.

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -508,8 +508,8 @@ Schema lives in `Packages/WhoopStore/Sources/WhoopStore/Database.swift` as a **v
   the user owns.
 - **Facts vs code — the line that actually gets tested.** The rule above is about *code*: verbatim or
   transcribed implementations, string literals, and assets stay out however correct they are. A
-  **protocol fact** — a byte offset, a field width, an enum value — is not code and may be
-  reimplemented, *provided* it is attributed and lands as an **unvalidated candidate**: decoded and
+  **protocol fact** — a byte offset, a field width, an enum value — is an observation about the wire,
+  and this project's practice is that it may be reimplemented, *provided* it is attributed and lands as an **unvalidated candidate**: decoded and
   logged, never backing a shipped metric, until independent captures clear it. `spo2_candidate_82`
   (v18 byte `@82`) is the worked example — sourced from a decompile, attributed as such in
   `Interpreter.swift`, gated by a test that stops it ever writing `spo2Pct`, and still a candidate


### PR DESCRIPTION
Docs only. Fixes a contradiction between what we tell contributors and what the code does.

**The problem.** `docs/CONTRIBUTING.md:506` and `CLAUDE.md:19` both say *"don't add decompiled app code"*, full stop. But `Interpreter.swift:489` describes `@82` as *"a decompile-sourced decode (gen5.rs `spo2_pct`), **reimplemented here as a protocol fact with attribution, like the other RE work**"*.

Those disagree, and the permissive version lives only in that comment and its Kotlin twin — not anywhere a contributor reads.

**It has already cost us something.** I read the strict version and told a9eelsh on #715 that we *"can't take anything carrying a `[WHOOP-app]`/`[JAVA]` tag, no matter how correct it is."* That's not our rule. They may have filtered their own findings against a standard stricter than ours before offering them.

It'll keep recurring: several third-party WHOOP projects are decompile-derived, so "can we use this?" comes up on most of them.

**The line as actually practised:**

- **A protocol fact may be re-derived** — byte offset, field width, enum value, scale factor — attributed at the point of use, shipping as an **unvalidated candidate**: decoded and logged, never backing a shipped metric, until independent captures clear it.
- **The implementation may not be copied** — not verbatim, not transcribed, and neither may string literals or assets.

`spo2_candidate_82` is the worked example on one side: decompile-sourced, attributed, guard-tested against ever writing `spo2Pct`, still a candidate because the cross-device evidence is split. The `LINK_VALID` handshake is the counter-example on the other — its reply payload is a literal string from the app, which is expression rather than a fact about the wire, so it stays out regardless.

Written into both places the doctrine already lives: the CONTRIBUTING bullet stating the prohibition, and the `ATTRIBUTION.md` section that already explains facts-only sourcing from other RE projects but never covered a decompile.

**This documents existing behaviour rather than proposing a change.** If the intended rule really is the strict one, then the code comment and `@82`'s shipped decode are what need revisiting — but the docs shouldn't disagree with the decoder either way. That call is yours; I've written down what the code does today.

Links checked, i18n clean, no code touched.
