### PR TITLE
docs(whoop5): record the SpO2 protocol facts and the 5.0-vs-MG identity signals

### DIFF
--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -582,6 +582,47 @@ waiting on a network.
 
 ---
 
+## 7.9 WHOOP 5.0 vs MG — telling the hardware apart
+
+Both labels share the `fd4b…` GATT family and the same puffin envelope: framing, CRC, offload and
+historical decode are **identical**, and `DeviceFamily.whoop5` covers both. What differs is hardware —
+an MG carries the ECG-conductive clasp, a 5.0 does not.
+
+`Whoop5Variant` resolves it from the standard BLE Device Information Service, deliberately orthogonal
+to `DeviceFamily` so a capability gate can never change how a frame is parsed:
+
+| Signal | DIS characteristic | Reads |
+|---|---|---|
+| Serial prefix `5AM` | Serial Number String (`0x2A25`) | MG |
+| Serial prefix `5AG` | Serial Number String (`0x2A25`) | 5.0 |
+| Hardware revision contains `WG50` | Hardware Revision String (`0x2A27`) | 5.0 |
+
+Contradictory signals resolve to `.unknown` rather than a guess, and `.unknown` is not MG — an MG-only
+feature stays gated off until the hardware attests to it. Only the 5.0 hardware string is attested on
+real hardware so far; the MG's own revision string is not, so its absence proves nothing.
+
+## 7.10 SpO₂ on 5.0 / MG — what the wire does and does not carry
+
+Recorded because "why is there no blood oxygen?" is a recurring question with a protocol answer.
+
+- **There is no `GET_SPO2`-style opcode.** The `CommandNumber` table carries 80 commands and none is
+  an oxygen/blood-oxygen read. SpO₂ is not a pollable gauge, so looking for a missing opcode is a dead
+  end.
+- **It is computed on-device, during sleep.** Expect values only in overnight windows, never a
+  continuous 24/7 series.
+- **The export is an aggregate.** `blood_oxygen_pct` in a WHOOP CSV is typically one value per recovery
+  cycle, so it will not equal a plain mean of raw wire samples — rounding, quality gates and
+  incomplete nights all move it.
+- **A night with no export value is a real gap**, not a NOOP bug. Naps and incomplete nights routinely
+  carry none.
+
+So the research target is finding the banked on-device sample in the historical type-47 record — not
+inventing a red/IR ratio or reversing a calibration curve. The v18 `@82` candidate and its split
+cross-device evidence are covered in
+[`WHOOP5_DEEP_DATA.md`](WHOOP5_DEEP_DATA.md); the full v18 field map lives in
+[`BLE_REVERSE_ENGINEERING.md`](BLE_REVERSE_ENGINEERING.md#the-whoop-50-type-47-record-version-18) and
+is deliberately **not** duplicated here — one table, one place to keep correct.
+
 ## 8. Decoded output (`ParsedFrame`)
 
 `parseFrame(_:)` returns a `ParsedFrame` with the validated envelope, a typed field list

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -611,8 +611,9 @@ Both labels share the `fd4b…` GATT family and the same puffin envelope: framin
 historical decode are **identical**, and `DeviceFamily.whoop5` covers both. What differs is hardware —
 an MG carries the ECG-conductive clasp, a 5.0 does not.
 
-`Whoop5Variant` resolves it from the standard BLE Device Information Service, deliberately orthogonal
-to `DeviceFamily` so a capability gate can never change how a frame is parsed:
+`Whoop5Variant` resolves it from the standard BLE Device Information Service (`BLEManager` discovers
+both characteristics as `disSerialChar` / `disHwRevChar`), deliberately orthogonal to `DeviceFamily` so
+a capability gate can never change how a frame is parsed:
 
 | Signal | DIS characteristic | Reads |
 |---|---|---|
@@ -633,15 +634,17 @@ Recorded because "why is there no blood oxygen?" is a recurring question with a 
   mapped, not a proof of the strap's whole command space — §6 is explicitly a *safe subset*, and the
   98-vs-87 battery dispute shows the map is incomplete. Treat it as "nobody has found one", which is
   still enough to say hunting for a missing opcode is the wrong lead.
-- **It is computed on-device, during sleep.** Expect values only in overnight windows, never a
-  continuous 24/7 series.
+- **It is computed on-device, during sleep.** Our own decode corroborates the gating: `aux_byte_82` is
+  observed nonzero *only* while the band sleep flag reads asleep. Expect values in overnight windows,
+  never a continuous 24/7 series.
 - **The export is a per-cycle aggregate.** `blood_oxygen_pct` arrives on the physiological-cycles row —
   our own importer reads it beside `recovery_score_pct` and `day_strain`, keyed on
   `cycleStart`/`cycleEnd` (`WhoopExportImporter.swift:272`) — so it is one value per recovery cycle and
   will not equal a plain mean of raw wire samples. Rounding, quality gates and incomplete nights all
   move it.
-- **A night with no export value is a real gap**, not a NOOP bug. Naps and incomplete nights routinely
-  carry none.
+- **A night with no export value is a real gap**, not a NOOP bug — naps and incomplete nights are
+  reported to carry none. (Contributor observation from #807, not something this repo can verify from
+  the wire; recorded because "my SpO₂ is missing" reads as a decode failure otherwise.)
 
 So the research target is finding the banked on-device sample in the historical type-47 record — not
 inventing a red/IR ratio or reversing a calibration curve. The v18 `@82` candidate and its split

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -628,14 +628,18 @@ real hardware so far; the MG's own revision string is not, so its absence proves
 
 Recorded because "why is there no blood oxygen?" is a recurring question with a protocol answer.
 
-- **There is no `GET_SPO2`-style opcode.** The `CommandNumber` table carries 80 commands and none is
-  an oxygen/blood-oxygen read. SpO₂ is not a pollable gauge, so looking for a missing opcode is a dead
-  end.
+- **No SpO₂ read opcode is known.** Our `CommandNumber` catalogue carries 80 commands and none is an
+  oxygen/blood-oxygen read; independent RE reports none either. Note the catalogue is what we have
+  mapped, not a proof of the strap's whole command space — §6 is explicitly a *safe subset*, and the
+  98-vs-87 battery dispute shows the map is incomplete. Treat it as "nobody has found one", which is
+  still enough to say hunting for a missing opcode is the wrong lead.
 - **It is computed on-device, during sleep.** Expect values only in overnight windows, never a
   continuous 24/7 series.
-- **The export is an aggregate.** `blood_oxygen_pct` in a WHOOP CSV is typically one value per recovery
-  cycle, so it will not equal a plain mean of raw wire samples — rounding, quality gates and
-  incomplete nights all move it.
+- **The export is a per-cycle aggregate.** `blood_oxygen_pct` arrives on the physiological-cycles row —
+  our own importer reads it beside `recovery_score_pct` and `day_strain`, keyed on
+  `cycleStart`/`cycleEnd` (`WhoopExportImporter.swift:272`) — so it is one value per recovery cycle and
+  will not equal a plain mean of raw wire samples. Rounding, quality gates and incomplete nights all
+  move it.
 - **A night with no export value is a real gap**, not a NOOP bug. Naps and incomplete nights routinely
   carry none.
 

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -582,47 +582,6 @@ waiting on a network.
 
 ---
 
-## 7.9 WHOOP 5.0 vs MG — telling the hardware apart
-
-Both labels share the `fd4b…` GATT family and the same puffin envelope: framing, CRC, offload and
-historical decode are **identical**, and `DeviceFamily.whoop5` covers both. What differs is hardware —
-an MG carries the ECG-conductive clasp, a 5.0 does not.
-
-`Whoop5Variant` resolves it from the standard BLE Device Information Service, deliberately orthogonal
-to `DeviceFamily` so a capability gate can never change how a frame is parsed:
-
-| Signal | DIS characteristic | Reads |
-|---|---|---|
-| Serial prefix `5AM` | Serial Number String (`0x2A25`) | MG |
-| Serial prefix `5AG` | Serial Number String (`0x2A25`) | 5.0 |
-| Hardware revision contains `WG50` | Hardware Revision String (`0x2A27`) | 5.0 |
-
-Contradictory signals resolve to `.unknown` rather than a guess, and `.unknown` is not MG — an MG-only
-feature stays gated off until the hardware attests to it. Only the 5.0 hardware string is attested on
-real hardware so far; the MG's own revision string is not, so its absence proves nothing.
-
-## 7.10 SpO₂ on 5.0 / MG — what the wire does and does not carry
-
-Recorded because "why is there no blood oxygen?" is a recurring question with a protocol answer.
-
-- **There is no `GET_SPO2`-style opcode.** The `CommandNumber` table carries 80 commands and none is
-  an oxygen/blood-oxygen read. SpO₂ is not a pollable gauge, so looking for a missing opcode is a dead
-  end.
-- **It is computed on-device, during sleep.** Expect values only in overnight windows, never a
-  continuous 24/7 series.
-- **The export is an aggregate.** `blood_oxygen_pct` in a WHOOP CSV is typically one value per recovery
-  cycle, so it will not equal a plain mean of raw wire samples — rounding, quality gates and
-  incomplete nights all move it.
-- **A night with no export value is a real gap**, not a NOOP bug. Naps and incomplete nights routinely
-  carry none.
-
-So the research target is finding the banked on-device sample in the historical type-47 record — not
-inventing a red/IR ratio or reversing a calibration curve. The v18 `@82` candidate and its split
-cross-device evidence are covered in
-[`WHOOP5_DEEP_DATA.md`](WHOOP5_DEEP_DATA.md); the full v18 field map lives in
-[`BLE_REVERSE_ENGINEERING.md`](BLE_REVERSE_ENGINEERING.md#the-whoop-50-type-47-record-version-18) and
-is deliberately **not** duplicated here — one table, one place to keep correct.
-
 ## 8. Decoded output (`ParsedFrame`)
 
 `parseFrame(_:)` returns a `ParsedFrame` with the validated envelope, a typed field list
@@ -646,7 +605,48 @@ inherit a base layout and override only what changed. The streamed decode that f
 
 ---
 
-## 9. File map
+## 9. WHOOP 5.0 vs MG — telling the hardware apart
+
+Both labels share the `fd4b…` GATT family and the same puffin envelope: framing, CRC, offload and
+historical decode are **identical**, and `DeviceFamily.whoop5` covers both. What differs is hardware —
+an MG carries the ECG-conductive clasp, a 5.0 does not.
+
+`Whoop5Variant` resolves it from the standard BLE Device Information Service, deliberately orthogonal
+to `DeviceFamily` so a capability gate can never change how a frame is parsed:
+
+| Signal | DIS characteristic | Reads |
+|---|---|---|
+| Serial prefix `5AM` | Serial Number String (`0x2A25`) | MG |
+| Serial prefix `5AG` | Serial Number String (`0x2A25`) | 5.0 |
+| Hardware revision contains `WG50` | Hardware Revision String (`0x2A27`) | 5.0 |
+
+Contradictory signals resolve to `.unknown` rather than a guess, and `.unknown` is not MG — an MG-only
+feature stays gated off until the hardware attests to it. Only the 5.0 hardware string is attested on
+real hardware so far; the MG's own revision string is not, so its absence proves nothing.
+
+## 10. SpO₂ on 5.0 / MG — what the wire does and does not carry
+
+Recorded because "why is there no blood oxygen?" is a recurring question with a protocol answer.
+
+- **There is no `GET_SPO2`-style opcode.** The `CommandNumber` table carries 80 commands and none is
+  an oxygen/blood-oxygen read. SpO₂ is not a pollable gauge, so looking for a missing opcode is a dead
+  end.
+- **It is computed on-device, during sleep.** Expect values only in overnight windows, never a
+  continuous 24/7 series.
+- **The export is an aggregate.** `blood_oxygen_pct` in a WHOOP CSV is typically one value per recovery
+  cycle, so it will not equal a plain mean of raw wire samples — rounding, quality gates and
+  incomplete nights all move it.
+- **A night with no export value is a real gap**, not a NOOP bug. Naps and incomplete nights routinely
+  carry none.
+
+So the research target is finding the banked on-device sample in the historical type-47 record — not
+inventing a red/IR ratio or reversing a calibration curve. The v18 `@82` candidate and its split
+cross-device evidence are covered in
+[`WHOOP5_DEEP_DATA.md`](WHOOP5_DEEP_DATA.md); the full v18 field map lives in
+[`BLE_REVERSE_ENGINEERING.md`](BLE_REVERSE_ENGINEERING.md#the-whoop-50-type-47-record-version-18) and
+is deliberately **not** duplicated here — one table, one place to keep correct.
+
+## 11. File map
 
 | Path | Responsibility |
 |------|----------------|


### PR DESCRIPTION
Re-implements the landable parts of **#807** (@dnesdan) against current `main`. Their PR picked up a conflict when #814 rewrote the same `@82` paragraph; writing fresh avoids it. Credited as co-author.

**Kept, and theirs — the SpO₂ protocol facts.** These answer a recurring question with a protocol answer, and weren't recorded anywhere:

- **No `GET_SPO2`-style opcode exists.** Verified against our own `CommandNumber` table — 80 commands, none oxygen-related. It isn't a pollable gauge, so hunting a missing opcode is a dead end.
- Computed **on-device, during sleep** — overnight windows only, never a 24/7 series.
- The CSV `blood_oxygen_pct` is a **per-cycle aggregate**, so it won't equal a mean of raw wire samples.
- A night with no export value is a **real gap**, not a NOOP bug.

**Dropped — their model-id range table** (`0…37 = MG`, `48…85 = 5.0`).

Not for provenance: #822 settled today that decompile-sourced facts are admissible with attribution, so my original objection no longer applies. Dropped because **we already do identity better and don't use model-ids anywhere.** `Whoop5Variant` reads the DIS serial prefix (`5AM`/`5AG`) and the `WG50` hardware-revision token — shipped in #781, sourced from #520. Documented here from our own code instead, including that contradictory signals resolve to `.unknown` and that `.unknown` is not MG.

**Changed — the v18 field map is a pointer, not a copy.**

Their `§8.1` duplicated the authoritative table in `BLE_REVERSE_ENGINEERING.md`. Two copies drift, and it had already started: theirs predates the `dynamic_acceleration@41` row added earlier today. One table, one place to keep correct.

**Verification:** both factual claims checked against the tree rather than taken from the source PR — the command table has no SpO₂ opcode, and `Whoop5Variant` carries the three identity signals as described. Links resolve, i18n clean, docs only.

#807 stays open — its author may prefer to land their own version, and that's their call to make rather than mine.
