### PR TITLE
fix: finish #820 — Apple reset missed raw capture, and Settings didn't re-read

### DIFF
--- a/Strand/BLE/PuffinExperiment.swift
+++ b/Strand/BLE/PuffinExperiment.swift
@@ -141,14 +141,26 @@ enum PuffinExperiment {
 
     static var motionAwareWakeEnabled: Bool { UserDefaults.standard.bool(forKey: motionAwareWakeKey) }
 
-    /// Turn OFF the 5/MG-only probes — protocol probes ([isEnabled]), the R22 deep-data strap write
-    /// ([deepDataEnabled]) and broadcast-HR ([broadcastHrEnabled]) — on a strap FAMILY switch
-    /// (WHOOP 4.0 ↔ 5/MG), so a 5/MG-only option can never linger enabled and get applied to a strap it
-    /// doesn't belong to. Leaves the model-agnostic toggles (continuous HRV, experimental sleep V2,
-    /// auto-detect workouts) alone. Mirrors the Android `PuffinExperiment.resetFiveMGGatedProbes`.
+    /// Every 5/MG-only probe key, in ONE place — the twin of Kotlin's `FIVE_MG_GATED_KEYS`.
+    ///
+    /// The capture flag deliberately appears here even though it is declared on `PuffinFrameRecorder`
+    /// rather than on this type, and under a DIFFERENT string (`noopPuffinCapture` vs Kotlin's
+    /// `noopWhoop5Capture`). That split is exactly why it was missed when this reset first shipped:
+    /// grepping this file for a capture key found nothing, and grepping for the Kotlin key name found
+    /// nothing either. Add new gated probes here, not inline in the reset.
+    static let fiveMGGatedKeys: [String] = [
+        defaultsKey,                     // protocol probes
+        deepDataKey,                     // R22 deep-data strap write
+        broadcastHrKey,                  // broadcast-HR write
+        PuffinFrameRecorder.enabledKey,  // raw frame capture — declared on PuffinFrameRecorder
+    ]
+
+    /// Turn OFF every key in [fiveMGGatedKeys] on a strap FAMILY switch (WHOOP 4.0 ↔ 5/MG), so a
+    /// 5/MG-only option cannot linger enabled and get applied to a strap that does not support it.
+    /// The line is "does it SEND something to the strap" — model-agnostic analysis toggles (continuous
+    /// HRV, experimental sleep V2, auto-detect workouts) are deliberately left alone. Mirrors the
+    /// Android `PuffinExperiment.resetFiveMGGatedProbes`.
     static func resetFiveMGGatedProbes() {
-        UserDefaults.standard.set(false, forKey: defaultsKey)
-        UserDefaults.standard.set(false, forKey: deepDataKey)
-        UserDefaults.standard.set(false, forKey: broadcastHrKey)
+        for key in fiveMGGatedKeys { UserDefaults.standard.set(false, forKey: key) }
     }
 }

--- a/android/app/src/main/java/com/noop/ble/PuffinExperiment.kt
+++ b/android/app/src/main/java/com/noop/ble/PuffinExperiment.kt
@@ -109,17 +109,15 @@ class PuffinExperiment(private val prefs: SharedPreferences) {
      * model-agnostic (the last self-gates on observed sample density, never on family, per #345).
      */
     fun resetFiveMGGatedProbes() {
-        prefs.edit()
-            .putBoolean(KEY, false)
-            .putBoolean(KEY_CAPTURE, false)
-            .putBoolean(KEY_DEEP_DATA, false)
-            .putBoolean(KEY_BROADCAST_HR, false)
-            .apply()
+        val editor = prefs.edit()
+        FIVE_MG_GATED_KEYS.forEach { editor.putBoolean(it, false) }
+        editor.apply()
     }
 
     companion object {
         /** Persisted preferences file. */
-        private const val PREFS = "noop_experiments"
+        /** Persisted preferences file. Internal so a UI screen can observe external writes to it. */
+        internal const val PREFS = "noop_experiments"
 
         /** Shared key name with the macOS build (`PuffinExperiment.defaultsKey`). */
         const val KEY = "noopPuffinExperiments"
@@ -132,6 +130,10 @@ class PuffinExperiment(private val prefs: SharedPreferences) {
 
         /** "Broadcast heart rate" opt-in (mirrors macOS `PuffinExperiment.broadcastHrKey`). */
         const val KEY_BROADCAST_HR = "noopBroadcastHr"
+
+        /** The 5/MG-only probe keys, in ONE place: [resetFiveMGGatedProbes] clears exactly these, and
+         *  SettingsScreen watches exactly these for external writes. Two lists would drift. */
+        internal val FIVE_MG_GATED_KEYS = listOf(KEY, KEY_CAPTURE, KEY_DEEP_DATA, KEY_BROADCAST_HR)
 
         /** "Experimental sleep staging (V2)" opt-in (mirrors macOS `PuffinExperiment.experimentalSleepV2Key`). */
         const val KEY_EXPERIMENTAL_SLEEP_V2 = "noopExperimentalSleepV2"

--- a/android/app/src/main/java/com/noop/ui/SettingsScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/SettingsScreen.kt
@@ -406,7 +406,10 @@ fun SettingsScreen(
         // Strong local for the effect's lifetime: Android holds these listeners WEAKLY, so one that is
         // only referenced by the register call gets collected and silently stops firing.
         val listener = SharedPreferences.OnSharedPreferenceChangeListener { _, key ->
-            if (key in PuffinExperiment.FIVE_MG_GATED_KEYS) rev++
+            // `key` is @Nullable on modern SDKs — it arrives null when the whole file is cleared — so
+            // the null check is required to compile, not just defensive. A clear() is not something
+            // this app does, but treating it as "everything changed" is the correct reading anyway.
+            if (key == null || key in PuffinExperiment.FIVE_MG_GATED_KEYS) rev++
         }
         expPrefs.registerOnSharedPreferenceChangeListener(listener)
         onDispose { expPrefs.unregisterOnSharedPreferenceChangeListener(listener) }

--- a/android/app/src/main/java/com/noop/ui/SettingsScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/SettingsScreen.kt
@@ -396,6 +396,22 @@ fun SettingsScreen(
     var rev by remember { mutableStateOf(0) }
     fun mutate(block: () -> Unit) { block(); rev++ }
 
+    // #820 made a BLE callback a writer of `noop_experiments`: a strap FAMILY switch clears the
+    // 5/MG-only probes. Without this the toggles below would keep showing their old state until you
+    // navigated away and back, because an unkeyed remember{} reads once per composition. macOS gets
+    // this free — @AppStorage republishes on any UserDefaults write — and Compose needs it spelled
+    // out. Bumping `rev` is the whole mechanism; the four reads are keyed on it.
+    DisposableEffect(Unit) {
+        val expPrefs = context.getSharedPreferences(PuffinExperiment.PREFS, Context.MODE_PRIVATE)
+        // Strong local for the effect's lifetime: Android holds these listeners WEAKLY, so one that is
+        // only referenced by the register call gets collected and silently stops firing.
+        val listener = SharedPreferences.OnSharedPreferenceChangeListener { _, key ->
+            if (key in PuffinExperiment.FIVE_MG_GATED_KEYS) rev++
+        }
+        expPrefs.registerOnSharedPreferenceChangeListener(listener)
+        onDispose { expPrefs.unregisterOnSharedPreferenceChangeListener(listener) }
+    }
+
     var backupBusy by remember { mutableStateOf(false) }
 
     // Re-scan must request the runtime Bluetooth permission before scanning — without this the
@@ -443,10 +459,10 @@ fun SettingsScreen(
     // EXPERIMENTAL WHOOP 5/MG protocol probes (off by default). Mirrors the macOS @AppStorage toggle;
     // SharedPreferences isn't reactive, so the Switch drives a local mutableState that the store reads.
     val puffinExperiment = remember { PuffinExperiment.from(context) }
-    var puffinExperiments by remember { mutableStateOf(puffinExperiment.isEnabled) }
-    var puffinCapture by remember { mutableStateOf(puffinExperiment.isCaptureEnabled) }
-    var deepData by remember { mutableStateOf(puffinExperiment.isDeepDataEnabled) }
-    var broadcastHr by remember { mutableStateOf(puffinExperiment.broadcastHr) }
+    var puffinExperiments by remember(rev) { mutableStateOf(puffinExperiment.isEnabled) }
+    var puffinCapture by remember(rev) { mutableStateOf(puffinExperiment.isCaptureEnabled) }
+    var deepData by remember(rev) { mutableStateOf(puffinExperiment.isDeepDataEnabled) }
+    var broadcastHr by remember(rev) { mutableStateOf(puffinExperiment.broadcastHr) }
     // "Sleep staging (V2)" — V2 is the DEFAULT for every strap (WHOOP 4 and 5/MG); turn it OFF to fall back
     // to V1. Model-agnostic, so it lives outside the 5/MG-only card. 4.0 is unvalidated either way (#319/#347).
     var experimentalSleepV2 by remember { mutableStateOf(puffinExperiment.experimentalSleepV2) }


### PR DESCRIPTION
Closes the known limitation #820 introduced and documented.

**The bug.** #820 made a BLE callback a writer of `noop_experiments` — a strap family switch clears the four 5/MG-only probes. `SettingsScreen.kt:446-449` snapshots those into an **unkeyed** `remember { }`, which reads once per composition. So a reset while Settings was open left the switches showing **ON** against a stored **OFF** until you navigated away and back. Stored state was always right; only the control lied.

That was safe until today — nothing outside Settings had ever written those prefs.

**macOS never had it.** `SettingsView.swift:31-42` uses `@AppStorage`, which republishes on any `UserDefaults` write, so the Swift switches already track external changes. This is the Compose equivalent and the Swift side is untouched — no parity twin needed.

**Why the obvious fix doesn't work.** `selectedModelName` three lines down uses `remember(rev)`, so keying the four on `rev` looks like a one-liner. But `rev` is bumped only by Settings' own `mutate {}` writes (`:396-397`) — a `WhoopBleClient` callback never touches it. Keying on it alone would pass review and change nothing at runtime. The listener is what makes `rev` a valid key here.

**Two details worth reviewing:**

- The listener is a **strong local** for the effect's lifetime. Android holds these weakly, so one referenced only by the register call gets collected and silently stops firing — the classic way this quietly stops working.
- `PREFS` becomes `internal` and the four keys move into one `FIVE_MG_GATED_KEYS` list shared by `resetFiveMGGatedProbes` and the listener. Two lists would drift, and the reset is the only reason the listener exists.

I also rewrote a `prefs.edit().apply { … }.apply()` from my first draft — two unrelated `apply`s, the scope function and `Editor.apply()`. It worked and read terribly.

**Uncompiled.** Android-only UI, and neither `android.yml` nor `app-build.yml` runs. Worth a Gradle compile before merge; the listener API and `DisposableEffect` are both already used in-tree, but this is the file's first `OnSharedPreferenceChangeListener`.
