### PR TITLE
fix(android): fehlende DeviceRegistryDao-Overrides in den drei Test-Fakes nachziehen

### DIFF
--- a/android/app/src/test/java/com/noop/analytics/RegistryDayOwnerSourceTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/RegistryDayOwnerSourceTest.kt
@@ -76,6 +76,41 @@ class RegistryDayOwnerSourceTest {
         override suspend fun deleteLiveSessionsFor(deviceId: String) {}
         override suspend fun deleteDismissedWorkoutsFor(deviceId: String) {}
         override suspend fun deleteDismissedSleepsFor(deviceId: String) {}
+
+        // #771 adopt-serial re-key: sample-table re-keys are unmodelled here (no per-table storage in
+        // this fake), same as the delete*For no-ops above. dayOwnership IS modelled ([owners]), so its
+        // re-key actually mutates state.
+        override suspend fun reKeyHr(from: String, to: String) {}
+        override suspend fun reKeyRr(from: String, to: String) {}
+        override suspend fun reKeySpo2(from: String, to: String) {}
+        override suspend fun reKeySkinTemp(from: String, to: String) {}
+        override suspend fun reKeyResp(from: String, to: String) {}
+        override suspend fun reKeyGravity(from: String, to: String) {}
+        override suspend fun reKeySteps(from: String, to: String) {}
+        override suspend fun reKeyPpgHr(from: String, to: String) {}
+        override suspend fun reKeyPpgWaveform(from: String, to: String) {}
+        override suspend fun reKeyRawImu(from: String, to: String) {}
+        override suspend fun reKeyEvents(from: String, to: String) {}
+        override suspend fun reKeyBattery(from: String, to: String) {}
+        override suspend fun reKeyDailyMetrics(from: String, to: String) {}
+        override suspend fun reKeySleepSessions(from: String, to: String) {}
+        override suspend fun reKeyJournal(from: String, to: String) {}
+        override suspend fun reKeyWorkouts(from: String, to: String) {}
+        override suspend fun reKeyAppleDaily(from: String, to: String) {}
+        override suspend fun reKeyMetricSeries(from: String, to: String) {}
+        override suspend fun reKeyDayOwnership(from: String, to: String) {
+            for ((day, row) in owners) if (row.deviceId == from) owners[day] = row.copy(deviceId = to)
+        }
+        override suspend fun reKeySleepStates(from: String, to: String) {}
+        override suspend fun reKeyLabMarkers(from: String, to: String) {}
+        override suspend fun reKeyLiveSessions(from: String, to: String) {}
+        override suspend fun reKeyDismissedWorkouts(from: String, to: String) {}
+        override suspend fun reKeyDismissedSleeps(from: String, to: String) {}
+
+        override suspend fun pairedDevice(id: String): PairedDeviceRow? = devices[id]
+
+        override suspend fun deletePairedDeviceRow(id: String) { devices.remove(id) }
+        override suspend fun deleteDeviceRow(id: String) {}
     }
 
     private fun registry(dao: FakeDao) = DeviceRegistry(

--- a/android/app/src/test/java/com/noop/ble/SourceCoordinatorAdoptionTest.kt
+++ b/android/app/src/test/java/com/noop/ble/SourceCoordinatorAdoptionTest.kt
@@ -92,6 +92,41 @@ class SourceCoordinatorAdoptionTest {
             owners.entries.removeIf { it.value.deviceId == deviceId }
         }
         override suspend fun deleteScoreInputProvenanceFor(deviceId: String) {}
+
+        // #771 adopt-serial re-key: sample-table re-keys are unmodelled here (no per-table storage in
+        // this fake), same as the delete*For no-ops above. dayOwnership IS modelled ([owners]), so its
+        // re-key actually mutates state.
+        override suspend fun reKeyHr(from: String, to: String) {}
+        override suspend fun reKeyRr(from: String, to: String) {}
+        override suspend fun reKeySpo2(from: String, to: String) {}
+        override suspend fun reKeySkinTemp(from: String, to: String) {}
+        override suspend fun reKeyResp(from: String, to: String) {}
+        override suspend fun reKeyGravity(from: String, to: String) {}
+        override suspend fun reKeySteps(from: String, to: String) {}
+        override suspend fun reKeyPpgHr(from: String, to: String) {}
+        override suspend fun reKeyPpgWaveform(from: String, to: String) {}
+        override suspend fun reKeyRawImu(from: String, to: String) {}
+        override suspend fun reKeyEvents(from: String, to: String) {}
+        override suspend fun reKeyBattery(from: String, to: String) {}
+        override suspend fun reKeyDailyMetrics(from: String, to: String) {}
+        override suspend fun reKeySleepSessions(from: String, to: String) {}
+        override suspend fun reKeyJournal(from: String, to: String) {}
+        override suspend fun reKeyWorkouts(from: String, to: String) {}
+        override suspend fun reKeyAppleDaily(from: String, to: String) {}
+        override suspend fun reKeyMetricSeries(from: String, to: String) {}
+        override suspend fun reKeyDayOwnership(from: String, to: String) {
+            for ((day, row) in owners) if (row.deviceId == from) owners[day] = row.copy(deviceId = to)
+        }
+        override suspend fun reKeySleepStates(from: String, to: String) {}
+        override suspend fun reKeyLabMarkers(from: String, to: String) {}
+        override suspend fun reKeyLiveSessions(from: String, to: String) {}
+        override suspend fun reKeyDismissedWorkouts(from: String, to: String) {}
+        override suspend fun reKeyDismissedSleeps(from: String, to: String) {}
+
+        override suspend fun pairedDevice(id: String): PairedDeviceRow? = devices[id]
+
+        override suspend fun deletePairedDeviceRow(id: String) { devices.remove(id) }
+        override suspend fun deleteDeviceRow(id: String) {}
     }
 
     private fun registryWith(dao: FakeRegistryDao) = DeviceRegistry(

--- a/android/app/src/test/java/com/noop/data/DeviceRegistryTest.kt
+++ b/android/app/src/test/java/com/noop/data/DeviceRegistryTest.kt
@@ -110,6 +110,43 @@ class DeviceRegistryTest {
         override suspend fun deleteLiveSessionsFor(deviceId: String) { deletedTables += "liveSession" to deviceId }
         override suspend fun deleteDismissedWorkoutsFor(deviceId: String) { deletedTables += "dismissedWorkout" to deviceId }
         override suspend fun deleteDismissedSleepsFor(deviceId: String) { deletedTables += "dismissedSleep" to deviceId }
+
+        // #771 adopt-serial re-key: sample-table re-keys are unmodelled here (no per-table storage in
+        // this fake), same as the delete*For no-ops above for those tables. dayOwnership IS modelled
+        // ([owners]), so its re-key actually mutates state, mirroring `UPDATE OR IGNORE ... WHERE
+        // deviceId = :from` (no PK clash possible since `day`, not `deviceId`, is the row's key).
+        override suspend fun reKeyHr(from: String, to: String) {}
+        override suspend fun reKeyRr(from: String, to: String) {}
+        override suspend fun reKeySpo2(from: String, to: String) {}
+        override suspend fun reKeySkinTemp(from: String, to: String) {}
+        override suspend fun reKeyResp(from: String, to: String) {}
+        override suspend fun reKeyGravity(from: String, to: String) {}
+        override suspend fun reKeySteps(from: String, to: String) {}
+        override suspend fun reKeyPpgHr(from: String, to: String) {}
+        override suspend fun reKeyPpgWaveform(from: String, to: String) {}
+        override suspend fun reKeyRawImu(from: String, to: String) {}
+        override suspend fun reKeyEvents(from: String, to: String) {}
+        override suspend fun reKeyBattery(from: String, to: String) {}
+        override suspend fun reKeyDailyMetrics(from: String, to: String) {}
+        override suspend fun reKeySleepSessions(from: String, to: String) {}
+        override suspend fun reKeyJournal(from: String, to: String) {}
+        override suspend fun reKeyWorkouts(from: String, to: String) {}
+        override suspend fun reKeyAppleDaily(from: String, to: String) {}
+        override suspend fun reKeyMetricSeries(from: String, to: String) {}
+        override suspend fun reKeyDayOwnership(from: String, to: String) {
+            for ((day, row) in owners) if (row.deviceId == from) owners[day] = row.copy(deviceId = to)
+        }
+        override suspend fun reKeySleepStates(from: String, to: String) {}
+        override suspend fun reKeyLabMarkers(from: String, to: String) {}
+        override suspend fun reKeyLiveSessions(from: String, to: String) {}
+        override suspend fun reKeyDismissedWorkouts(from: String, to: String) {}
+        override suspend fun reKeyDismissedSleeps(from: String, to: String) {}
+
+        /** The registry row for [id], or null (#771 adopt-serial needs the active row's fields). */
+        override suspend fun pairedDevice(id: String): PairedDeviceRow? = devices[id]
+
+        override suspend fun deletePairedDeviceRow(id: String) { devices.remove(id) }
+        override suspend fun deleteDeviceRow(id: String) {}
     }
 
     /** Registry over the fake DAO with a pass-through transactor (Room's withTransaction stand-in). */


### PR DESCRIPTION
## Zusammenfassung

`./gradlew testFullDebugUnitTest` (bzw. `compileFullDebugUnitTestKotlin`) schlägt aktuell unabhängig
von jeder Feature-Arbeit fehl — reiner Compile-Fehler im Test-Source-Set. `DeviceRegistryDao`
deklariert die komplette `reKey*`-Familie (#771 adopt-serial), `pairedDevice(id)` und
`deletePairedDeviceRow(id)`, aber drei eigenständige In-Memory-Fakes wurden nie nachgezogen:

- `android/app/src/test/java/com/noop/data/DeviceRegistryTest.kt` (`FakeRegistryDao`)
- `android/app/src/test/java/com/noop/ble/SourceCoordinatorAdoptionTest.kt` (`FakeRegistryDao`)
- `android/app/src/test/java/com/noop/analytics/RegistryDayOwnerSourceTest.kt` (`FakeDao`)

Da Kotlin ein Source-Set als eine Einheit kompiliert, hat das den gesamten Testbaum blockiert —
lokal ließ sich kein einziger Android-Unit-Test mehr ausführen, unabhängig vom Thema.

## Änderung

Alle drei Fakes um die fehlenden Overrides ergänzt:
- `reKeyDayOwnership` re-keyed tatsächlich die `owners`-Map (die einzige Tabelle, die diese Fakes mit
  echtem State abbilden) — Parität zum echten DAO-Semantik `UPDATE ... SET deviceId = :to WHERE
  deviceId = :from`.
- Die übrigen `reKey*`-Methoden sind No-Ops, analog zum bestehenden Muster der `delete*For`-No-Ops für
  Tabellen, die diese Fakes nicht modellieren.
- `pairedDevice(id)` liest aus der bestehenden `devices`-Map.
- `deletePairedDeviceRow(id)` entfernt aus `devices`; `deleteDeviceRow(id)` ist ein No-Op (keine
  separate `device`-Tabelle in den Fakes modelliert).

Reiner Test-Code, keine Produktionslogik geändert.

## Test plan

- [x] `cd android && ./gradlew compileFullDebugUnitTestKotlin` — kompiliert jetzt sauber
      (`--dependency-verification=lenient` wegen einer separaten, unabhängigen aapt2-osx-Checksummen-Lücke
      auf macOS ARM in `gradle/verification-metadata.xml`, nicht Teil dieses PRs)
- [x] `cd android && ./gradlew testFullDebugUnitTest` — BUILD SUCCESSFUL
- [x] Alle 22 Tests in den drei betroffenen Klassen laufen grün (5 + 7 + 10, 0 failures/errors)