### PR TITLE
refactor(sleep): one stage-key canonicalisation, not two kept in parity by comment

### DIFF
--- a/android/app/src/main/java/com/noop/ui/SleepStageBreakdownUi.kt
+++ b/android/app/src/main/java/com/noop/ui/SleepStageBreakdownUi.kt
@@ -226,10 +226,12 @@ internal fun ClockLabelRow(onsetTs: Long, wakeTs: Long) {
 }
 
 /** Map a stage name to its design-system sleep tone (case-insensitive). */
-private fun stageColorFor(name: String): Color = when (name.trim().lowercase()) {
+/** Stage tint. Keys off [canonicalStage] rather than repeating the trim/lowercase/"wake"-fold, so a
+ *  new stage alias added there is picked up here automatically instead of needing a matching edit. */
+private fun stageColorFor(name: String): Color = when (canonicalStage(name)) {
     "deep" -> Palette.sleepDeep
     "rem" -> Palette.sleepREM
     "light" -> Palette.sleepLight
-    "awake", "wake" -> Palette.sleepAwake
+    "awake" -> Palette.sleepAwake
     else -> Palette.sleepLight
 }

--- a/android/app/src/main/java/com/noop/ui/SleepStageBreakdownUi.kt
+++ b/android/app/src/main/java/com/noop/ui/SleepStageBreakdownUi.kt
@@ -225,9 +225,10 @@ internal fun ClockLabelRow(onsetTs: Long, wakeTs: Long) {
     }
 }
 
-/** Map a stage name to its design-system sleep tone (case-insensitive). */
-/** Stage tint. Keys off [canonicalStage] rather than repeating the trim/lowercase/"wake"-fold, so a
- *  new stage alias added there is picked up here automatically instead of needing a matching edit. */
+/** Map a stage name to its design-system sleep tone (case-insensitive). Keys off [canonicalStage]
+ *  rather than repeating the trim/lowercase/"wake"-fold, so a new alias added there is picked up
+ *  here automatically instead of needing a matching edit. Unknown stages fall back to the Light
+ *  tone, as they did before. */
 private fun stageColorFor(name: String): Color = when (canonicalStage(name)) {
     "deep" -> Palette.sleepDeep
     "rem" -> Palette.sleepREM

--- a/android/app/src/main/java/com/noop/ui/SleepStageTimelineLogic.kt
+++ b/android/app/src/main/java/com/noop/ui/SleepStageTimelineLogic.kt
@@ -125,7 +125,9 @@ internal fun displaySmoothed(
     return ivs
 }
 
-/** Canonical stage key: trims, lowercases, and folds the "wake"/"awake" alias (stageColorFor parity). */
+/** Canonical stage key: trims, lowercases, and folds the "wake"/"awake" alias. The single definition of
+ *  a stage key in the UI layer — [stageColorFor] keys off this rather than repeating the rule, so adding
+ *  an alias here is all that is needed. */
 internal fun canonicalStage(name: String): String {
     val n = name.trim().lowercase()
     return if (n == "wake") "awake" else n

--- a/android/app/src/main/java/com/noop/ui/SleepStageTimelineLogic.kt
+++ b/android/app/src/main/java/com/noop/ui/SleepStageTimelineLogic.kt
@@ -126,8 +126,9 @@ internal fun displaySmoothed(
 }
 
 /** Canonical stage key: trims, lowercases, and folds the "wake"/"awake" alias. The single definition of
- *  a stage key in the UI layer — [stageColorFor] keys off this rather than repeating the rule, so adding
- *  an alias here is all that is needed. */
+ *  a stage key in the UI layer — `stageColorFor` (SleepStageBreakdownUi.kt) keys off this rather than
+ *  repeating the rule, so adding an alias here is all that is needed. Written as code rather than a
+ *  KDoc link because the target is private in another file and would not resolve. */
 internal fun canonicalStage(name: String): String {
     val n = name.trim().lowercase()
     return if (n == "wake") "awake" else n

--- a/android/app/src/test/java/com/noop/ui/StageRowSpansTest.kt
+++ b/android/app/src/test/java/com/noop/ui/StageRowSpansTest.kt
@@ -30,7 +30,9 @@ class StageRowSpansTest {
 
     @Test
     fun awakeAndWakeAreAliases() {
-        // Row label "Awake" must catch both the "wake" and "Awake" segments (stageColorFor parity).
+        // Row label "Awake" must catch both the "wake" and "Awake" segments. The tint now follows from
+        // the same canonicalStage call, so this covers the colour path too — stageColorFor is private
+        // and can't be asserted on directly.
         val spans = stageRowSpans(ivs, "Awake", 3600.0)
         assertEquals(2, spans.size)
         assertEquals(0.0f, spans[0].first, 1e-6f)


### PR DESCRIPTION
Follow-up to #733, found reviewing it.

**Two implementations of one rule, and the code already knew.** `stageColorFor` did its own `trim().lowercase()` and folded `"awake", "wake"` in a `when` branch, while `canonicalStage()` in `SleepStageTimelineLogic.kt` does exactly the same — carrying the comment *"(stageColorFor parity)"*. A drift risk documented instead of removed.

```kotlin
// before
private fun stageColorFor(name: String): Color = when (name.trim().lowercase()) {
    …
    "awake", "wake" -> Palette.sleepAwake

// after
private fun stageColorFor(name: String): Color = when (canonicalStage(name)) {
    …
    "awake" -> Palette.sleepAwake
```

Both files are `package com.noop.ui` and `canonicalStage` is `internal`, so no plumbing. **Adding a stage alias is now a one-place edit** — before, a new alias in `canonicalStage` would silently fail to pick up a colour, which is the quiet-wrong-answer failure mode rather than a visible one.

**Behaviour-identical, verified across every input the old branch accepted:** `"deep"`, `" REM "`, `"Light"`, `"awake"`, `"WAKE"`, `"wake"`, whitespace variants, empty string and unknown all resolve to the same tint before and after, fallback included.

**#733 didn't create this** — it made it visible by moving the two halves into adjacent files, which is a good argument for that refactor rather than against it.

Android only, no schema, no scores, no strings; i18n clean. Not compiled — `android.yml` is disabled — though this is a two-line change to a `when` subject within one package.
