### PR TITLE
fix(hrv): read same-second R-R beats in emission order, not magnitude order

### DIFF
--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/AnalyticsEngine.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/AnalyticsEngine.swift
@@ -520,7 +520,7 @@ public enum AnalyticsEngine {
                 // from, so the displayed value equals the `deepOnly` figure the trace logs. rr sorted (RMSSD
                 // = successive diffs). nil when no deep sleep is detected (WHOOP-4.0 staging can be sparse) —
                 // the caller shows calibrating, never a fabricated number.
-                let rrSorted = rr.sorted { $0.ts < $1.ts }
+                let rrSorted = rr.sortedByTsStable()
                 let deep = matched.flatMap { s in
                     SleepStager.sessionHrvWindows(start: s.start, end: s.end, rr: rrSorted, stages: s.stages)
                         .filter { $0.stage == "deep" }.compactMap { $0.rmssd }
@@ -546,7 +546,7 @@ public enum AnalyticsEngine {
             func r2(_ x: Double) -> Double { (x * 100).rounded() / 100 }
             // sessionHrvWindows requires ts-sorted rr (RMSSD = successive diffs); the value path passes the
             // stager's pre-sorted rrS, so sort our own copy of the day's raw rr once here for the re-window.
-            let rrSorted = rr.sorted { $0.ts < $1.ts }
+            let rrSorted = rr.sortedByTsStable()
             var allWin: [SleepStager.HrvWindow] = []
             for s in matched {
                 let wins = SleepStager.sessionHrvWindows(start: s.start, end: s.end, rr: rrSorted, stages: s.stages)

--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/HRVAnalyzer.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/HRVAnalyzer.swift
@@ -320,7 +320,8 @@ public enum HRVAnalyzer {
                                     stepSec: Int = 0,
                                     minBeatsPerWindow: Int = 8) -> [RollingRmssdPoint] {
         guard windowSec > 0, rr.count >= minBeatsPerWindow else { return [] }
-        let sorted = rr.sorted { $0.ts < $1.ts }
+        // Stable: preserves the store's #823 emission order for same-second beats, which RMSSD needs.
+        let sorted = rr.sortedByTsStable()
         var out: [RollingRmssdPoint] = []
         var lastEmitTs: Int? = nil
         var left = 0   // index of the oldest interval still inside the trailing window

--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/HRVFreqDomain.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/HRVFreqDomain.swift
@@ -92,7 +92,8 @@ public enum HRVFreqDomain {
     /// (`HRVAnalyzer.cleanRR`) before the tachogram is built, so an artifact beat cannot inject spurious
     /// power. Returns nil when there are too few clean beats or the R-R span is under `minSpanForHFSec`.
     public static func freqDomain(rr: [RRInterval]) -> Bands? {
-        let raw = rr.sorted { $0.ts < $1.ts }.map { Double($0.rrMs) }
+        // Stable sort: same-second beats keep their #823 emission order (see sortedByTsStable).
+        let raw = rr.sortedByTsStable().map { Double($0.rrMs) }
         return freqDomain(rawRR: raw)
     }
 

--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/ResonanceEngine.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/ResonanceEngine.swift
@@ -119,9 +119,19 @@ public enum ResonanceEngine {
 
         // Steady window: from startTs + transient to endTs.
         let windowStart = sample.startTs + transientDropSeconds
+        // STABLE sort: cleanRR below feeds RMSSD, which is all successive differences, so the order of
+        // same-second beats changes the score. Kotlin's twin uses sortedBy, stable by contract. (#823)
+        // STABLE sort: cleanRR below feeds RMSSD, which is all successive differences, so the order of
+        // same-second beats changes the score. Swift's sorted(by:) is NOT guaranteed stable; decorating
+        // with the offset makes the comparator total. Kotlin's twin uses sortedBy, stable by contract.
+        // Spelled out here rather than reusing WhoopProtocol's Array<RRInterval>.sortedByTsStable: this
+        // file is deliberately DB-free and takes pure inputs, and one shared comparator is not worth the
+        // module dependency. Keep the two in step. (#823)
         let steady = sample.rr
             .filter { $0.ts >= windowStart && $0.ts <= sample.endTs }
-            .sorted { $0.ts < $1.ts }
+            .enumerated()
+            .sorted { ($0.element.ts, $0.offset) < ($1.element.ts, $1.offset) }
+            .map(\.element)
 
         // Clean R-R (range + Malik) for both the RMSSD and the swing, so ectopic beats can't fabricate
         // an RSA swing. Cleaning operates on the rrMs values; we keep ts alongside for cycle bucketing.

--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/SleepStager.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/SleepStager.swift
@@ -910,7 +910,7 @@ public enum SleepStager {
         if grav.count < 2 { return [] }
 
         let hrS = hr.sorted { $0.ts < $1.ts }
-        let rrS = rr.sorted { $0.ts < $1.ts }
+        let rrS = rr.sortedByTsStable()   // stable: keeps #823 emission order within a second
         let respS = resp.sorted { $0.ts < $1.ts }
 
         let baseline = hrBaseline(hrS)

--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/SleepStager.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/SleepStager.swift
@@ -1506,9 +1506,11 @@ public enum SleepStager {
         let nan = Double.nan
         if end <= start { return nan }
 
-        // 1. In-bed RR rows in chronological order, range-filtered.
+        // 1. In-bed RR rows in chronological order, range-filtered. STABLE sort: step 2 reconstructs
+        // beat times by cumulative sum, so the order of a second's beats moves every subsequent beat
+        // time and with it the RSA estimate. Kotlin's twin uses sortedBy, stable by contract. (#823)
         let inBed = rr.filter { $0.ts >= start && $0.ts <= end }
-            .sorted { $0.ts < $1.ts }
+            .sortedByTsStable()
             .map { Double($0.rrMs) }
         let filtered = HRVAnalyzer.rangeFilter(inBed)
         if filtered.count < 30 { return nan }  // need enough beats for any RSA estimate

--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/SleepStagerV2.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/SleepStagerV2.swift
@@ -111,7 +111,7 @@ public enum SleepStagerV2 {
         // assumes its callers pass roughly-sorted streams; we make no such assumption here).
         let gravS = grav.sorted { $0.ts < $1.ts }
         let hrS = hr.sorted { $0.ts < $1.ts }
-        let rrS = rr.sorted { $0.ts < $1.ts }
+        let rrS = rr.sortedByTsStable()   // stable: keeps #823 emission order within a second
 
         let feats = features(start: start, end: end, grav: gravS, hr: hrS, rr: rrS)
         if feats.isEmpty { return [StageSegment(start: start, end: end, stage: "light")] }

--- a/Packages/WhoopProtocol/Sources/WhoopProtocol/Streams.swift
+++ b/Packages/WhoopProtocol/Sources/WhoopProtocol/Streams.swift
@@ -16,6 +16,29 @@ public struct RRInterval: Equatable, Codable {
     public init(ts: Int, rrMs: Int) { self.ts = ts; self.rrMs = rrMs }
 }
 
+public extension Array where Element == RRInterval {
+    /// Ascending by `ts`, GUARANTEED stable — same-second beats keep the relative order they came in.
+    ///
+    /// Swift's `sorted(by:)` is explicitly documented as NOT stable. Since #823 the store returns a
+    /// second's beats in EMISSION order, and RMSSD is built entirely from successive differences, so an
+    /// unstable sort anywhere downstream could silently re-scramble them and reintroduce exactly the
+    /// bias the store fix removes. Every analytics entry point re-sorts defensively ("the table read is
+    /// already ordered, but we don't assume it"), which is where that would happen.
+    ///
+    /// Decorating with the original offset makes the comparator TOTAL, so no two elements compare equal
+    /// and stability becomes a property of this code rather than of the current stdlib implementation.
+    /// (Swift's sort is timsort today and stable in practice — but that is unguaranteed, and a metric
+    /// that silently drifts if the stdlib changes is not one you can trust.)
+    ///
+    /// Kotlin needs no equivalent: `sortedBy` delegates to `java.util.Arrays.sort`, which is stable by
+    /// contract. This makes the twins match on paper as well as in behaviour.
+    func sortedByTsStable() -> [RRInterval] {
+        enumerated()
+            .sorted { ($0.element.ts, $0.offset) < ($1.element.ts, $1.offset) }
+            .map(\.element)
+    }
+}
+
 public struct WhoopEvent: Equatable, Codable {
     public let ts: Int          // real unix seconds (event RTC; never offset)
     public let kind: String

--- a/Packages/WhoopProtocol/Tests/WhoopProtocolTests/RRStableSortTests.swift
+++ b/Packages/WhoopProtocol/Tests/WhoopProtocolTests/RRStableSortTests.swift
@@ -1,0 +1,63 @@
+import Foundation
+import XCTest
+@testable import WhoopProtocol
+
+/// #823 follow-through. The store now returns a second's R-R beats in EMISSION order, but every
+/// analytics entry point re-sorts by `ts` defensively before computing RMSSD. Swift's `sorted(by:)`
+/// is explicitly documented as NOT stable, so that re-sort was free to re-scramble same-second beats
+/// and undo the store fix. `sortedByTsStable` makes the comparator total instead of relying on the
+/// current stdlib implementation happening to be timsort.
+final class RRStableSortTests: XCTestCase {
+
+    /// The property that matters: equal `ts` keeps input order, whatever the values are.
+    func testSameSecondBeatsKeepEmissionOrder() {
+        let emission = [812, 795, 840, 801, 833]
+        let rr = emission.map { RRInterval(ts: 100, rrMs: $0) }
+        XCTAssertEqual(rr.sortedByTsStable().map(\.rrMs), emission,
+                       "a stable sort must not reorder beats that share a ts")
+    }
+
+    /// It must still actually sort — stability is worthless if the ordering is wrong.
+    func testStillOrdersBySecond() {
+        let rr = [RRInterval(ts: 300, rrMs: 700), RRInterval(ts: 100, rrMs: 800),
+                  RRInterval(ts: 200, rrMs: 900)]
+        XCTAssertEqual(rr.sortedByTsStable().map(\.ts), [100, 200, 300])
+    }
+
+    /// Interleaved seconds: each second's internal order is preserved while the seconds are ordered.
+    func testInterleavedSecondsSortWithoutDisturbingWithinSecondOrder() {
+        let rr = [RRInterval(ts: 200, rrMs: 810), RRInterval(ts: 100, rrMs: 795),
+                  RRInterval(ts: 200, rrMs: 780), RRInterval(ts: 100, rrMs: 840),
+                  RRInterval(ts: 200, rrMs: 830)]
+        let out = rr.sortedByTsStable()
+        XCTAssertEqual(out.map(\.ts), [100, 100, 200, 200, 200])
+        XCTAssertEqual(out.map(\.rrMs), [795, 840, 810, 780, 830],
+                       "within each second, the original relative order must survive")
+    }
+
+    /// The consequence, on the issue's own example: an unstable sort that happened to order a second
+    /// by value would read 12.72 ms where the truth is 34.85 ms. Guarding the number, not just the order.
+    func testStabilityPreservesRmssd() {
+        func rmssd(_ v: [Int]) -> Double {
+            let d = zip(v, v.dropFirst()).map { pow(Double($1 - $0), 2) }
+            return (d.reduce(0, +) / Double(d.count)).squareRoot()
+        }
+        let emission = [812, 795, 840, 801, 833]
+        let rr = emission.map { RRInterval(ts: 100, rrMs: $0) }
+        XCTAssertEqual(rmssd(rr.sortedByTsStable().map(\.rrMs)), 34.85, accuracy: 0.01)
+        XCTAssertEqual(rmssd(emission.sorted()), 12.72, accuracy: 0.01)
+    }
+
+    func testEmptyAndSingleAreHandled() {
+        XCTAssertEqual([RRInterval]().sortedByTsStable().count, 0)
+        XCTAssertEqual([RRInterval(ts: 1, rrMs: 800)].sortedByTsStable().map(\.rrMs), [800])
+    }
+
+    /// Duplicate (ts, rrMs) beats — the v24 case where two EQUAL intervals share a second — must all
+    /// survive the sort. A comparator that treated them as interchangeable could drop or duplicate.
+    func testEqualBeatsAllSurvive() {
+        let rr = [RRInterval(ts: 100, rrMs: 600), RRInterval(ts: 100, rrMs: 600),
+                  RRInterval(ts: 100, rrMs: 610)]
+        XCTAssertEqual(rr.sortedByTsStable().map(\.rrMs), [600, 600, 610])
+    }
+}

--- a/Packages/WhoopStore/Sources/WhoopStore/Database.swift
+++ b/Packages/WhoopStore/Sources/WhoopStore/Database.swift
@@ -580,6 +580,28 @@ extension WhoopStore {
             try db.create(index: "idx_scoreInputProvenance_source",
                           on: "scoreInputProvenance", columns: ["sourceId"])
         }
+
+        // v30 (#823): record each R-R beat's EMISSION order within its second. Reads ordered by
+        // `rrMs`, i.e. by VALUE, which makes successive beats similar by construction and biases
+        // RMSSD — built entirely from successive differences — DOWNWARD. `seq` cannot serve here:
+        // it counts repeats of an identical (ts, rrMs) beat, so every DISTINCT beat in a second
+        // carries seq 0 and they all tie.
+        //
+        // Additive nullable column, no table rebuild, no existing row touched. Deliberately NOT in
+        // the primary key, which stays (deviceId, ts, rrMs, seq) from v24 — an insertion counter in
+        // the key would collide distinct beats arriving in separate batches, the data-loss
+        // regression the v24 note warns about. `ord` only informs read order.
+        //
+        // Pre-v30 rows stay NULL: the order was never recorded, so it cannot be backfilled and a
+        // guess would be worse than an admission. SQLite sorts NULL first in ASC, so an all-NULL
+        // second ties on `ord` and falls through to the old (rrMs, seq) order, unchanged.
+        //
+        // Twin of Room MIGRATION_23_24. Both stores are SQLite, so NULL-ordering matches exactly.
+        migrator.registerMigration("v30-rr-ord") { db in
+            try db.alter(table: "rrInterval") { t in
+                t.add(column: "ord", .integer)
+            }
+        }
         return migrator
     }
 }

--- a/Packages/WhoopStore/Sources/WhoopStore/Reads.swift
+++ b/Packages/WhoopStore/Sources/WhoopStore/Reads.swift
@@ -107,12 +107,17 @@ extension WhoopStore {
         }
     }
 
+    /// R-R intervals in EMISSION order (#823). `ord` leads the sort: ordering by `rrMs` returned a
+    /// second's beats sorted by VALUE, which makes successive beats similar by construction and biases
+    /// RMSSD — all successive differences — downward. Pre-v30 rows have `ord` NULL and SQLite sorts NULL
+    /// first in ASC, so an all-NULL second ties and falls through to the old (rrMs, seq) order unchanged.
+    /// Byte-parity twin of Kotlin `WhoopDao.rrIntervals`; both are SQLite, so NULL ordering matches.
     public func rrIntervals(deviceId: String, from: Int, to: Int, limit: Int) async throws -> [RRInterval] {
         try syncRead { db in
             try Row.fetchAll(db, sql: """
                 SELECT ts, rrMs FROM rrInterval
                 WHERE deviceId = ? AND ts >= ? AND ts <= ?
-                ORDER BY ts ASC, rrMs ASC, seq ASC LIMIT ?
+                ORDER BY ts ASC, ord ASC, rrMs ASC, seq ASC LIMIT ?
                 """, arguments: [deviceId, from, to, limit])
                 .map { RRInterval(ts: $0["ts"], rrMs: $0["rrMs"]) }
         }

--- a/Packages/WhoopStore/Sources/WhoopStore/StreamStore.swift
+++ b/Packages/WhoopStore/Sources/WhoopStore/StreamStore.swift
@@ -128,18 +128,29 @@ extension WhoopStore {
             }
             if !streams.rr.isEmpty {
                 let stmt = try db.cachedStatement(sql: """
-                    INSERT INTO rrInterval (deviceId, ts, rrMs, seq) VALUES (?, ?, ?, ?)
+                    INSERT INTO rrInterval (deviceId, ts, rrMs, seq, ord) VALUES (?, ?, ?, ?, ?)
                     ON CONFLICT(deviceId, ts, rrMs, seq) DO NOTHING
                     """)
                 // v24 (#163): number EQUAL (ts, rrMs) beats 0, 1, … within this batch so both survive;
                 // distinct beats keep seq 0 and their own (ts, rrMs, 0) key, so a distinct beat is never
                 // dropped even across batches (rrMs stays in the key). Re-syncing identical rows reproduces
                 // the same (ts, rrMs, seq) → still idempotent. Nested dict = (ts, rrMs) occurrence counter.
+                //
+                // v30 (#823): `ord` is the beat's position among ALL beats sharing this ts in this batch —
+                // its emission order. `seq` cannot express it (it keys on (ts, rrMs), so distinct beats in
+                // a second are all 0). Not in the key, never changes which rows survive; it exists so reads
+                // return beats in heart order rather than sorted by value, which biases RMSSD down. Same
+                // batch-local caveat as seq: a second split across two live flushes restarts ord at 0 and
+                // DO NOTHING keeps the first row. The historical path delivers a second atomically.
+                // Twin of Kotlin assignRrSeq.
                 var seqByTsRr: [Int: [Int: Int]] = [:]
+                var ordByTs: [Int: Int] = [:]
                 for r in streams.rr {
                     let seq = seqByTsRr[r.ts]?[r.rrMs] ?? 0
                     seqByTsRr[r.ts, default: [:]][r.rrMs] = seq + 1
-                    try stmt.execute(arguments: [deviceId, r.ts, r.rrMs, seq])
+                    let ord = ordByTs[r.ts] ?? 0
+                    ordByTs[r.ts] = ord + 1
+                    try stmt.execute(arguments: [deviceId, r.ts, r.rrMs, seq, ord])
                     rr += db.changesCount
                 }
             }
@@ -298,9 +309,12 @@ extension WhoopStore {
                 row.cols[1] = WhoopStore.intStr(r["bpm"])
                 out.append(row)
             }
-            // rr: stream=rr → rr_ms (col 4).
+            // rr: stream=rr → rr_ms (col 4). Same-second beats need the #823 tiebreak here too, and
+            // more so: bare "ORDER BY ts" left their order UNDEFINED, so a raw export could differ
+            // between runs over identical data. Emission order first, then the pre-v30 fallback.
             for r in try Row.fetchAll(db, sql:
-                "SELECT ts, rrMs FROM rrInterval WHERE deviceId = ? AND ts >= ? ORDER BY ts",
+                "SELECT ts, rrMs FROM rrInterval WHERE deviceId = ? AND ts >= ? " +
+                "ORDER BY ts, ord, rrMs, seq",
                 arguments: [deviceId, floor]) {
                 var row = RawCSVRow(ts: r["ts"]); row.cols[0] = "rr"
                 row.cols[2] = WhoopStore.intStr(r["rrMs"])
@@ -507,6 +521,29 @@ extension WhoopStore {
                 return nil
             }
             return (row["mac"], row["name"])
+        }
+    }
+
+    /// Write an R-R row the way a PRE-v30 build did: `ord` left NULL, emission order never recorded.
+    /// The normal insert path always stamps `ord`, so there is otherwise no way to construct the
+    /// legacy shape — and the read-order fallback for existing user data is exactly the branch most
+    /// worth testing rather than assuming. Test-only (#823).
+    public func insertLegacyRrWithoutOrdForTest(deviceId: String, ts: Int, rrMs: Int) async throws {
+        try syncWrite { db in
+            try db.execute(sql: """
+                INSERT INTO rrInterval (deviceId, ts, rrMs, seq, ord) VALUES (?, ?, ?, 0, NULL)
+                ON CONFLICT(deviceId, ts, rrMs, seq) DO NOTHING
+                """, arguments: [deviceId, ts, rrMs])
+        }
+    }
+
+    /// The stored `ord` values for one second, in read order. Test-only (#823).
+    public func rrOrdValuesForTest(deviceId: String, ts: Int) async throws -> [Int?] {
+        try syncRead { db in
+            try Row.fetchAll(db, sql: """
+                SELECT ord FROM rrInterval WHERE deviceId = ? AND ts = ?
+                ORDER BY ts ASC, ord ASC, rrMs ASC, seq ASC
+                """, arguments: [deviceId, ts]).map { $0["ord"] }
         }
     }
 }

--- a/Packages/WhoopStore/Tests/WhoopStoreTests/MigrationTests.swift
+++ b/Packages/WhoopStore/Tests/WhoopStoreTests/MigrationTests.swift
@@ -91,7 +91,8 @@ final class MigrationTests: XCTestCase {
         let read = try await store.rrIntervals(deviceId: "dev1", from: 0, to: 1_000, limit: 100)
         XCTAssertEqual(read.map(\.rrMs), emission,
                        "beats must read back in emission order, not magnitude order")
-        XCTAssertEqual(try await store.rrOrdValuesForTest(deviceId: "dev1", ts: 100), [0, 1, 2, 3, 4])
+        let ords = try await store.rrOrdValuesForTest(deviceId: "dev1", ts: 100)
+        XCTAssertEqual(ords, [0, 1, 2, 3, 4])
 
         // The measurable consequence, on the issue's own example: magnitude order reads 12.72 ms,
         // emission order 34.85 ms. A one-directional −22 ms bias in a headline metric.
@@ -117,8 +118,8 @@ final class MigrationTests: XCTestCase {
         let read = try await store.rrIntervals(deviceId: "dev1", from: 0, to: 1_000, limit: 100)
         XCTAssertEqual(read.map(\.rrMs), [795, 801, 812, 833, 840],
                        "pre-v30 rows must keep the old (rrMs, seq) order, unchanged and deterministic")
-        XCTAssertEqual(try await store.rrOrdValuesForTest(deviceId: "dev1", ts: 200),
-                       [nil, nil, nil, nil, nil])
+        let ords = try await store.rrOrdValuesForTest(deviceId: "dev1", ts: 200)
+        XCTAssertEqual(ords, [nil, nil, nil, nil, nil])
     }
 
     /// A second holding both legacy and post-v30 rows (possible via import/merge) must still be

--- a/Packages/WhoopStore/Tests/WhoopStoreTests/MigrationTests.swift
+++ b/Packages/WhoopStore/Tests/WhoopStoreTests/MigrationTests.swift
@@ -65,6 +65,76 @@ final class MigrationTests: XCTestCase {
         XCTAssertEqual(n.rr, 3)
     }
 
+    // MARK: - v30 R-R emission order (#823)
+
+    /// `ord` must exist and must stay OUT of the primary key. An insertion counter in the key would
+    /// collide distinct beats arriving in separate batches — the data-loss regression v24's note warns
+    /// about, and the reason the obvious `ORDER BY ts, seq` fix was rejected.
+    func testV30AddsOrdColumnAndKeepsItOutOfThePrimaryKey() async throws {
+        let store = try await WhoopStore.inMemory()
+        let cols = try await store.columnNamesForTest(table: "rrInterval")
+        XCTAssertTrue(cols.contains("ord"), "rrInterval missing v30 ord column")
+        let pk = try await store.primaryKeyColumns("rrInterval")
+        XCTAssertEqual(pk, ["deviceId", "ts", "rrMs", "seq"], "ord must not enter the key")
+    }
+
+    /// The bug itself: a second's beats came back sorted by VALUE. Sorting makes successive beats
+    /// similar by construction, and RMSSD is built entirely from successive differences.
+    func testV30ReadsSameSecondBeatsInEmissionOrder() async throws {
+        let store = try await WhoopStore.inMemory()
+        try await store.upsertDevice(id: "dev1", mac: nil, name: nil)
+        let emission = [812, 795, 840, 801, 833]
+        let n = try await store.insert(
+            Streams(rr: emission.map { RRInterval(ts: 100, rrMs: $0) }), deviceId: "dev1")
+        XCTAssertEqual(n.rr, emission.count, "every distinct beat must still be stored")
+
+        let read = try await store.rrIntervals(deviceId: "dev1", from: 0, to: 1_000, limit: 100)
+        XCTAssertEqual(read.map(\.rrMs), emission,
+                       "beats must read back in emission order, not magnitude order")
+        XCTAssertEqual(try await store.rrOrdValuesForTest(deviceId: "dev1", ts: 100), [0, 1, 2, 3, 4])
+
+        // The measurable consequence, on the issue's own example: magnitude order reads 12.72 ms,
+        // emission order 34.85 ms. A one-directional −22 ms bias in a headline metric.
+        func rmssd(_ v: [Int]) -> Double {
+            let d = zip(v, v.dropFirst()).map { pow(Double($1 - $0), 2) }
+            return (d.reduce(0, +) / Double(d.count)).squareRoot()
+        }
+        XCTAssertEqual(rmssd(read.map(\.rrMs)), rmssd(emission), accuracy: 1e-9)
+        XCTAssertEqual(rmssd(read.map(\.rrMs)), 34.85, accuracy: 0.01)
+        XCTAssertGreaterThan(rmssd(read.map(\.rrMs)), rmssd(emission.sorted()) + 20.0,
+                             "sorted order should be the badly-biased one this fix avoids")
+    }
+
+    /// Rows written before v30 have `ord` NULL — the order was never recorded, so it cannot be
+    /// backfilled. SQLite sorts NULL first in ASC, so an all-legacy second ties on `ord` and falls
+    /// through to the old (rrMs, seq) order: existing data reads back exactly as it did before.
+    func testV30LegacyNullOrdRowsKeepTheOldDeterministicOrder() async throws {
+        let store = try await WhoopStore.inMemory()
+        try await store.upsertDevice(id: "dev1", mac: nil, name: nil)
+        for v in [812, 795, 840, 801, 833] {
+            try await store.insertLegacyRrWithoutOrdForTest(deviceId: "dev1", ts: 200, rrMs: v)
+        }
+        let read = try await store.rrIntervals(deviceId: "dev1", from: 0, to: 1_000, limit: 100)
+        XCTAssertEqual(read.map(\.rrMs), [795, 801, 812, 833, 840],
+                       "pre-v30 rows must keep the old (rrMs, seq) order, unchanged and deterministic")
+        XCTAssertEqual(try await store.rrOrdValuesForTest(deviceId: "dev1", ts: 200),
+                       [nil, nil, nil, nil, nil])
+    }
+
+    /// A second holding both legacy and post-v30 rows (possible via import/merge) must still be
+    /// deterministic. NULL-first is arbitrary but fixed, which is the property that matters:
+    /// the same data must never read back two different ways.
+    func testV30MixedLegacyAndOrderedRowsAreDeterministic() async throws {
+        let store = try await WhoopStore.inMemory()
+        try await store.upsertDevice(id: "dev1", mac: nil, name: nil)
+        _ = try await store.insert(Streams(rr: [RRInterval(ts: 300, rrMs: 700)]), deviceId: "dev1")
+        try await store.insertLegacyRrWithoutOrdForTest(deviceId: "dev1", ts: 300, rrMs: 650)
+        let first = try await store.rrIntervals(deviceId: "dev1", from: 0, to: 1_000, limit: 100)
+        let again = try await store.rrIntervals(deviceId: "dev1", from: 0, to: 1_000, limit: 100)
+        XCTAssertEqual(first.map(\.rrMs), [650, 700], "NULL ord sorts first")
+        XCTAssertEqual(first.map(\.rrMs), again.map(\.rrMs), "repeated reads must not differ")
+    }
+
     /// v5 adds a `synced` column to all 8 decoded tables.
     func testV5AddsSyncedColumnToDecodedTables() async throws {
         let store = try await WhoopStore.inMemory()

--- a/Packages/WhoopStore/Tests/WhoopStoreTests/ReadTests.swift
+++ b/Packages/WhoopStore/Tests/WhoopStoreTests/ReadTests.swift
@@ -65,6 +65,9 @@ final class ReadTests: XCTestCase {
         XCTAssertEqual(other, [HRBucket(ts: 200, bpm: 99)])
     }
 
+    /// Both same-second beats survive the v24 key. Since #823 the read order is EMISSION order, and
+    /// `seeded()` happens to insert these two ascending — so the expectation is unchanged, but it now
+    /// holds because 800 was sent first, not because 800 < 820.
     func testRrIntervalsReturnsBothTiedRows() async throws {
         let store = try await seeded()
         let rr = try await store.rrIntervals(deviceId: "dev1", from: 0, to: 1000, limit: 100)

--- a/Strand/Data/ShortcutHealthExport.swift
+++ b/Strand/Data/ShortcutHealthExport.swift
@@ -144,7 +144,7 @@ enum ShortcutHealthExport {
         // HRV — rolling RMSSD per window via the shared analyzer (Task Force RMSSD over Malik-cleaned
         // NN intervals). nil rmssd (< 20 clean beats in the window) leaves the field empty.
         var rrByWindow: [Int: [Double]] = [:]
-        for s in rr.sorted(by: { $0.ts < $1.ts }) where s.ts < end {
+        for s in rr.sortedByTsStable() where s.ts < end {
             rrByWindow[windowStart(s.ts), default: []].append(Double(s.rrMs))
         }
         for (start, values) in rrByWindow {

--- a/android/app/src/main/java/com/noop/data/Entities.kt
+++ b/android/app/src/main/java/com/noop/data/Entities.kt
@@ -94,9 +94,22 @@ data class HrWindowStats(
  * ever dropped — including across separate insert batches or the live/historical merge (rrMs stays in the
  * key). Re-syncing identical records reproduces the same (ts, rrMs, seq), so the insert stays idempotent.
  *
- * PARITY NOTE: this intentionally diverges from the Swift `rrInterval` key, which is still
- * (deviceId, ts, rrMs); the identical value-key drop exists in `WhoopStore` (Database.swift / StreamStore /
- * Reads) and should get the same widening in a follow-up. See the PR description.
+ * `ord` (Room v24, #823) is the beat's EMISSION order within its (deviceId, ts) group — the position the
+ * strap sent it in, recorded at decode time. It is deliberately NOT in the key: the key must stay
+ * (deviceId, ts, rrMs, seq) for the dedup/idempotency reasons above, and an insertion counter in the key
+ * would collide distinct beats across batches. `ord` exists purely so reads can restore emission order.
+ * Reads MUST order by it — see WhoopDao.rrIntervals. Without it, reads came back in MAGNITUDE order
+ * (`ORDER BY ts, rrMs`), which sorts successive beats to be similar by construction and biases RMSSD
+ * DOWN, since RMSSD is built entirely from successive differences.
+ *
+ * NULL means "emission order unknown": every row written before v24, and any row from a source that
+ * cannot supply it. That is honest rather than a guess, and it sorts correctly for free — SQLite orders
+ * NULL first in ASC, so a pre-v24 second (all NULL) ties on `ord` and falls through to the old
+ * `rrMs, seq` order exactly. Not backfillable: the order was never recorded.
+ *
+ * PARITY: the Swift `rrInterval` key was widened to match in WhoopStore `v24-rr-seq`, and `ord` lands
+ * there as `v30-rr-ord`. (An earlier revision of this note said the Swift widening was still pending;
+ * it had already shipped.)
  */
 @Entity(tableName = "rrInterval", primaryKeys = ["deviceId", "ts", "rrMs", "seq"])
 data class RrInterval(
@@ -105,6 +118,7 @@ data class RrInterval(
     val rrMs: Int,
     val seq: Int = 0,
     val synced: Int = 0,
+    val ord: Int? = null,
 )
 
 /**

--- a/android/app/src/main/java/com/noop/data/WhoopDao.kt
+++ b/android/app/src/main/java/com/noop/data/WhoopDao.kt
@@ -298,9 +298,15 @@ interface WhoopDao : DeviceRegistryDao {
     suspend fun hrWindowStats(deviceId: String, from: Long, to: Long): HrWindowStats
 
     @Query(
-        // ts, rrMs matches Swift Reads.swift; seq only tiebreaks the rare EQUAL same-second beats (v18).
+        // #823: `ord` FIRST, so same-second beats come back in EMISSION order. Ordering by rrMs made
+        // successive beats similar by construction and biased RMSSD (all successive differences) down.
+        // Pre-v24 rows have ord NULL and SQLite sorts NULL first in ASC, so an all-NULL second ties here
+        // and falls through to the old (rrMs, seq) order — unchanged for existing data, and deterministic.
+        // Byte-parity twin of Swift Reads.swift rrIntervals; both are SQLite, so NULL ordering matches.
+        // Note this no longer matches the PK index (ts, rrMs, seq), so SQLite sorts; see the PR for why
+        // that is acceptable at this query's size rather than adding a covering index.
         "SELECT * FROM rrInterval WHERE deviceId = :deviceId AND ts >= :from AND ts <= :to " +
-            "ORDER BY ts ASC, rrMs ASC, seq ASC LIMIT :limit"
+            "ORDER BY ts ASC, ord ASC, rrMs ASC, seq ASC LIMIT :limit"
     )
     suspend fun rrIntervals(deviceId: String, from: Long, to: Long, limit: Int): List<RrInterval>
 

--- a/android/app/src/main/java/com/noop/data/WhoopDatabase.kt
+++ b/android/app/src/main/java/com/noop/data/WhoopDatabase.kt
@@ -51,7 +51,7 @@ import androidx.sqlite.db.SupportSQLiteDatabase
         PpgWaveformSampleEntity::class,
         RawImuSampleEntity::class,
     ],
-    version = 23,
+    version = 24,
     exportSchema = false,
 )
 abstract class WhoopDatabase : RoomDatabase() {
@@ -598,6 +598,32 @@ abstract class WhoopDatabase : RoomDatabase() {
             }
         }
 
+        /**
+         * #823: record each R-R beat's EMISSION order within its second so reads can stop returning
+         * them in magnitude order (which biases RMSSD down — see the RrInterval doc).
+         *
+         * Additive and nullable, the MIGRATION_3_4 form: no table rebuild, no row touched, and
+         * critically NOT part of the primary key, which must stay (deviceId, ts, rrMs, seq) — an
+         * insertion counter in the key would collide distinct beats across insert batches, the
+         * data-loss regression assignRrSeq's doc warns about.
+         *
+         * Existing rows stay NULL. The order was never recorded, so it cannot be backfilled and a
+         * guess would be worse than an admission; NULL sorts first in SQLite ASC, so a pre-v24
+         * second ties on `ord` and falls through to the old (rrMs, seq) order unchanged.
+         *
+         * Exposed as [RR_ORD_MIGRATION_SQL] so a plain-JVM unit test can assert its shape without an
+         * emulator, like the migrations above.
+         */
+        internal val RR_ORD_MIGRATION_SQL: List<String> = listOf(
+            "ALTER TABLE `rrInterval` ADD COLUMN `ord` INTEGER",
+        )
+
+        internal val MIGRATION_23_24 = object : Migration(23, 24) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                for (stmt in RR_ORD_MIGRATION_SQL) db.execSQL(stmt)
+            }
+        }
+
         private fun build(appContext: Context): WhoopDatabase =
             Room.databaseBuilder(appContext, WhoopDatabase::class.java, DB_NAME)
                 // #1014: replace ONLY the corruption handling of the default open-helper. The
@@ -614,7 +640,7 @@ abstract class WhoopDatabase : RoomDatabase() {
                     MIGRATION_10_11, MIGRATION_11_12, MIGRATION_12_13, MIGRATION_13_14,
                     MIGRATION_14_15, MIGRATION_15_16, MIGRATION_16_17, MIGRATION_17_18,
                     MIGRATION_18_19, MIGRATION_19_20, MIGRATION_20_21, MIGRATION_21_22,
-                    MIGRATION_22_23,
+                    MIGRATION_22_23, MIGRATION_23_24,
                 )
                 // #1037: a FRESH install builds the schema straight at the current version and runs NO
                 // migrations, so the MIGRATION_7_8 "my-whoop" registry seed never fires and the WHOOP,

--- a/android/app/src/main/java/com/noop/data/WhoopRepository.kt
+++ b/android/app/src/main/java/com/noop/data/WhoopRepository.kt
@@ -181,14 +181,25 @@ data class RrRow(val ts: Long, val rrMs: Int)
  * straddle a live-flush boundary still collide (batch-local), the same narrow case the old key dropped and
  * strictly no worse; the authoritative historical path delivers a second's beats atomically in one batch.
  * Pure so it is unit-testable.
+ *
+ * Also stamps `ord` (Room v24, #823): the beat's position among ALL beats sharing this `ts` in this batch —
+ * its emission order, which `seq` cannot express because `seq` keys on (ts, rrMs) and so is 0 for every
+ * DISTINCT beat in a second. `ord` is NOT in the key and never affects which rows survive; it exists so
+ * reads can return beats in the order the heart produced them rather than sorted by value, which biases
+ * RMSSD down. Same batch-local caveat as `seq`: a second split across two live flushes restarts `ord` at 0,
+ * and ON CONFLICT DO NOTHING keeps whichever row landed first. The historical path delivers a second
+ * atomically, so the authoritative copy is correctly ordered.
  */
 internal fun assignRrSeq(deviceId: String, rows: List<RrRow>): List<RrInterval> {
     val seqByBeat = HashMap<Pair<Long, Int>, Int>()
+    val ordByTs = HashMap<Long, Int>()
     return rows.map { row ->
         val key = row.ts to row.rrMs
         val s = seqByBeat.getOrDefault(key, 0)
         seqByBeat[key] = s + 1
-        RrInterval(deviceId = deviceId, ts = row.ts, rrMs = row.rrMs, seq = s)
+        val o = ordByTs.getOrDefault(row.ts, 0)
+        ordByTs[row.ts] = o + 1
+        RrInterval(deviceId = deviceId, ts = row.ts, rrMs = row.rrMs, seq = s, ord = o)
     }
 }
 

--- a/android/app/src/test/java/com/noop/data/RrOrdMigrationTest.kt
+++ b/android/app/src/test/java/com/noop/data/RrOrdMigrationTest.kt
@@ -1,0 +1,102 @@
+package com.noop.data
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import kotlin.math.sqrt
+
+/**
+ * #823: R-R beats must be READ in the order the heart produced them, not sorted by value.
+ *
+ * Guards the additive `ord` migration and the [assignRrSeq] stamping. The read order itself is SQL
+ * and is exercised end-to-end on the Swift twin (WhoopStoreTests MigrationTests, which CI actually
+ * runs); these JVM tests assert the migration shape and the pure stamping function, matching how the
+ * other migrations here are covered — there is no SQLite driver on the unit-test classpath.
+ */
+class RrOrdMigrationTest {
+
+    @Test
+    fun migrationIsAdditiveNullableAndNotAKeyChange() {
+        val sql = WhoopDatabase.RR_ORD_MIGRATION_SQL
+        assertEquals(1, sql.size)
+        // Nullable INTEGER: no NOT NULL, no DEFAULT. NULL means "emission order unknown", which is
+        // every pre-v24 row — it was never recorded, so it cannot be backfilled.
+        assertEquals("ALTER TABLE `rrInterval` ADD COLUMN `ord` INTEGER", sql[0])
+        val upper = sql[0].uppercase()
+        assertTrue(upper.startsWith("ALTER TABLE"))
+        assertTrue("must be additive", upper.contains("ADD COLUMN"))
+        assertFalse("ord must be nullable", upper.contains("NOT NULL"))
+        assertFalse("no default — absent means unknown", upper.contains("DEFAULT"))
+        for (banned in listOf("DROP ", "DELETE ", "UPDATE ", "INSERT ", "PRIMARY KEY")) {
+            assertFalse("migration must not contain $banned", upper.contains(banned))
+        }
+        assertEquals(23, WhoopDatabase.MIGRATION_23_24.startVersion)
+        assertEquals(24, WhoopDatabase.MIGRATION_23_24.endVersion)
+    }
+
+    @Test
+    fun ord_numbersEveryBeatInTheSecondInEmissionOrder() {
+        val ts = 1_780_916_150L
+        val emission = listOf(812, 795, 840, 801, 833)
+        val out = assignRrSeq("d", emission.map { RrRow(ts, it) })
+
+        assertEquals("stamped in arrival order", listOf(0, 1, 2, 3, 4), out.map { it.ord })
+        assertEquals("rrMs untouched", emission, out.map { it.rrMs })
+        // seq is 0 for every DISTINCT beat — which is precisely why it cannot carry emission order,
+        // and why the two-line `ORDER BY ts, seq` fix would have made the order undefined instead.
+        assertEquals(listOf(0, 0, 0, 0, 0), out.map { it.seq })
+    }
+
+    @Test
+    fun ord_isPerSecond_andRestartsOnTheNextSecond() {
+        val out = assignRrSeq(
+            "d",
+            listOf(RrRow(100L, 812), RrRow(100L, 795), RrRow(101L, 840), RrRow(101L, 801)),
+        )
+        assertEquals(listOf(0, 1, 0, 1), out.map { it.ord })
+    }
+
+    @Test
+    fun ord_andSeq_areIndependent_equalBeatsGetDistinctBoth() {
+        // Two EQUAL beats plus a distinct one. seq disambiguates the equal pair for the KEY;
+        // ord records where all three sat in the second. Neither substitutes for the other.
+        val out = assignRrSeq("d", listOf(RrRow(100L, 600), RrRow(100L, 600), RrRow(100L, 610)))
+        assertEquals(listOf(0, 1, 0), out.map { it.seq })
+        assertEquals(listOf(0, 1, 2), out.map { it.ord })
+        assertEquals("all three keep distinct keys", 3, out.map { "${it.ts}/${it.rrMs}/${it.seq}" }.toSet().size)
+    }
+
+    @Test
+    fun ord_doesNotDisturbTheKey_soResyncStaysIdempotent() {
+        val batch = listOf(RrRow(100L, 812), RrRow(100L, 795), RrRow(100L, 812))
+        fun keys(rows: List<RrInterval>) = rows.map { "${it.deviceId}/${it.ts}/${it.rrMs}/${it.seq}" }
+        assertEquals("same input → same keys", keys(assignRrSeq("d", batch)), keys(assignRrSeq("d", batch)))
+        assertEquals("same input → same ord", assignRrSeq("d", batch).map { it.ord },
+            assignRrSeq("d", batch).map { it.ord })
+    }
+
+    @Test
+    fun entityDefaultsOrdToNull_soLegacyRowsStayHonest() {
+        // A row constructed without ord (any pre-#823 call site, or a source that cannot supply it)
+        // records "unknown" rather than guessing 0, which would assert an order nobody observed.
+        assertNull(RrInterval(deviceId = "d", ts = 1L, rrMs = 800).ord)
+    }
+
+    /**
+     * The consequence being fixed, on the issue's own example. Not a test of the SQL — a guard on the
+     * claim that motivates the schema change, so the number stays honest if anyone revisits it.
+     */
+    @Test
+    fun magnitudeOrderBiasesRmssdDownByAbout22ms() {
+        fun rmssd(v: List<Int>): Double {
+            val d = v.zipWithNext { a, b -> (b - a).toDouble() * (b - a) }
+            return sqrt(d.sum() / d.size)
+        }
+        val emission = listOf(812, 795, 840, 801, 833)
+        assertEquals(34.85, rmssd(emission), 0.01)
+        assertEquals(12.72, rmssd(emission.sorted()), 0.01)
+        assertTrue("sorting biases RMSSD DOWN, never up", rmssd(emission.sorted()) < rmssd(emission))
+    }
+}


### PR DESCRIPTION
Implements #823.

## The bug

Both platforms read a second's R-R intervals sorted by **value**:

```
ORDER BY ts ASC, rrMs ASC, seq ASC
```

Sorting makes adjacent values similar by construction, and RMSSD is built entirely from *successive differences*. So this is a one-directional downward bias in a headline metric that feeds Charge. On the issue's five-beat example:

| order | beats | RMSSD |
|---|---|---|
| emission | 812, 795, 840, 801, 833 | **34.85 ms** |
| magnitude (shipped) | 795, 801, 812, 833, 840 | **12.72 ms** |
| | | **−22.14 ms** |

~1.1% of same-second groups on 5/MG.

## The fix

A new `ord` column: the beat's position among all beats sharing its `ts`, stamped at decode time, leading the read sort.

**Why not `ORDER BY ts, seq`** (the fork's two-line version): it assumes `seq` is an insertion counter. It isn't — `assignRrSeq` keys on `(ts, rrMs)`, so `seq` counts repeats of an *identical* beat and every **distinct** beat in a second carries `0`. They'd all tie and the order would become whatever the scan returns, trading a deterministic wrong order for an **undefined** one. RMSSD could then vary between reads of the same data.

**Why `ord` isn't in the key.** The key stays `(deviceId, ts, rrMs, seq)`. A per-second insertion counter *in the key* restarts per batch and collides distinct beats arriving in separate flushes — the data-loss regression `assignRrSeq`'s own comment warns about. `ord` never decides which rows survive.

**Legacy rows stay NULL.** The order was never recorded, so it can't be backfilled, and a guess would assert something nobody observed. SQLite sorts NULL first in ASC, so an all-legacy second ties on `ord` and falls through to the old `(rrMs, seq)` order — existing data reads back exactly as before. No `COALESCE`, no sentinel.

## Parity

Room v23→24 and GRDB `v30-rr-ord`, both additive nullable `ALTER`s — no table rebuild, no row touched. I extracted the `ORDER BY` from both sources and compared token-by-token, then ran both against real SQLite:

```
Kotlin ORDER BY: ORDER BY ts ASC, ord ASC, rrMs ASC, seq ASC
Swift  ORDER BY: ORDER BY ts ASC, ord ASC, rrMs ASC, seq ASC
Kotlin  v24+ [812, 795, 840, 801, 833] RMSSD 34.85 | legacy [795, 801, 812, 833, 840] RMSSD 12.72
Swift   v24+ [812, 795, 840, 801, 833] RMSSD 34.85 | legacy [795, 801, 812, 833, 840] RMSSD 12.72
```

## Also in scope

- **Raw-CSV export** ordered by `ts` alone, leaving same-second beats *undefined* — identical data could export two different ways. Now uses the same clause.
- **Stale doc**: `RrInterval`'s PARITY NOTE said the Swift key widening was still pending. It shipped as `v24-rr-seq`.

## Testing

Swift tests run in CI (`swift-packages.yml` covers `Packages/**`) and cover this end-to-end: emission order restored, RMSSD back to 34.85, legacy NULL rows unchanged, mixed seconds deterministic across repeated reads, `ord` absent from the primary key. Added one test-only seam to write a legacy NULL-`ord` row, since the normal path always stamps it and the existing-data fallback is the branch most worth testing rather than assuming.

Checked every existing R-R read assertion: `ReadTests` seeds ascending so it still passes (now for a different reason — noted in a comment), and the store-backed analytics test seeds one beat per second, so `ord` is always 0.

**Not verified:** the Kotlin half is unrun. There's no SQLite driver on the JVM unit-test classpath, so those tests assert migration shape and the pure stamping function only, and `android.yml` is disabled so nothing compiles it. The SQL itself is identical to the Swift clause that CI does execute.

**Performance:** the sort no longer matches the PK index `(ts, rrMs, seq)`, so SQLite sorts. At this query's size (a night, ceiling 200k rows) that's tens of ms; I'd rather measure than add a covering index to a large table pre-emptively.

Open question from the issue that this does **not** settle: whether a real night shows the 1.1% figure translating into a meaningful nightly RMSSD delta. The fix is correct regardless, but that number would tell us whether it matters clinically.
