### PR TITLE
Surface pages-behind on the sync chip while backfilling (#689/#815 follow-up)

### DIFF
--- a/Strand/BLE/BLEManager.swift
+++ b/Strand/BLE/BLEManager.swift
@@ -4216,6 +4216,10 @@ extension BLEManager: @preconcurrency CBPeripheralDelegate {
         // revision ever shifts these fields again, the rejection must be visible rather than silent.
         if let pages = DataRange.pagesBehind(from: frame, cmdOff: cmdOff) {
             log("Strap backlog pages behind: \(pages) (#689 — GET_DATA_RANGE ring backlog, diagnostic only)")
+            // #815: confirmed on both WHOOP 4.0 and 5.0/MG, so bank it unconditionally (unlike newest/oldest,
+            // which stay feedsSync-gated to WHOOP4 until a 5/MG capture confirms them too) — the sync chip's
+            // "N pages behind" detail reads this while `backfilling` is true.
+            state.setPagesBehindAtConnect(pages)
         } else {
             log("Strap backlog pages behind: not decodable from this frame (#689 — offsets may have moved; "
                 + "the raw frame above is the input). Diagnostic only, sync is unaffected.")

--- a/Strand/BLE/LiveState.swift
+++ b/Strand/BLE/LiveState.swift
@@ -204,6 +204,20 @@ public final class LiveState: ObservableObject {
     /// window can't outlive the link.
     public func clearStrapRange() { strapRange = nil }
 
+    /// #689/#815: the strap's ring-buffer page backlog, sampled ONCE from the connect-time GET_DATA_RANGE
+    /// reply — never re-polled mid-offload (the link is already firmware-paced, ~10 records/s, #377). A
+    /// static "this many pages behind" figure, not a live percentage: the strap never reveals a total
+    /// pending-record count, only this bounded ring-buffer measure (write pointer − read pointer against a
+    /// 131072-page ring), confirmed against real captures on both WHOOP 4.0 and 5.0/MG. The sync chip
+    /// appends it to the chunk count while `backfilling` is true. nil before the first reply this session,
+    /// or if the frame didn't decode. Cleared on disconnect so a stale figure can't outlive the link.
+    @Published public private(set) var pagesBehindAtConnect: Int?
+
+    /// Bank the connect-time GET_DATA_RANGE pages-behind sample (see `pagesBehindAtConnect`).
+    public func setPagesBehindAtConnect(_ pages: Int) {
+        pagesBehindAtConnect = pages
+    }
+
     @Published public var lastFrameType: String? = nil
     @Published public var lastEvent: String? = nil
     /// #987: unix of the most recent strap frame FrameRouter routed. Deliberately NOT @Published - the
@@ -492,6 +506,7 @@ public final class LiveState: ObservableObject {
         recentHrSamples.removeAll()       // Sleep readout buffers must not outlive the link (Group E)
         recentGravitySamples.removeAll()
         clearStrapRange()                 // a stale clock-drift window must not outlive the link either
+        pagesBehindAtConnect = nil        // a stale pages-behind sample must not outlive the link either
         lastFrameAtUnix = nil             // #987: a stale "last frame" freshness must not outlive it either
         ouraWearState = nil               // a stale worn/charging badge must not outlive the link either
         // Perf: flush the durable log tail on disconnect (mirroring is batched in `append`), so a completed

--- a/Strand/Liquid/LiquidTodayView.swift
+++ b/Strand/Liquid/LiquidTodayView.swift
@@ -1949,9 +1949,10 @@ private struct LiquidSyncChip: View {
 
     var body: some View {
         switch SyncChipState.resolve(live: live) {
-        case .syncing(let chunks):
+        case .syncing(let chunks, let pagesBehind):
             pill(system: "arrow.triangle.2.circlepath", text: "\(chunks)",
-                 a11y: String(localized: "Syncing strap history, \(chunks) chunks"))
+                 detail: SyncChipState.pagesBehindDetail(pagesBehind),
+                 a11y: SyncChipState.syncingAccessibilityLabel(chunks: chunks, pagesBehind: pagesBehind))
         case .synced(let agoText):
             pill(system: "checkmark", text: agoText,
                  a11y: String(localized: "Strap history synced \(agoText) ago"))
@@ -1963,10 +1964,14 @@ private struct LiquidSyncChip: View {
         }
     }
 
-    private func pill(system: String, text: String, a11y: String) -> some View {
+    private func pill(system: String, text: String, detail: String? = nil, a11y: String) -> some View {
         HStack(spacing: 4) {
             Image(systemName: system).font(.system(size: 11, weight: .bold))
             Text(text).font(.system(size: 12, weight: .bold))
+            // #689/#815: the pages-behind detail, when known — see `SyncChipState.pagesBehindDetail`.
+            if let detail {
+                Text(detail).font(.system(size: 11, weight: .semibold)).foregroundStyle(.white.opacity(0.7))
+            }
         }
         .foregroundStyle(.white)
         .padding(.horizontal, 10)

--- a/Strand/Resources/Localizable.xcstrings
+++ b/Strand/Resources/Localizable.xcstrings
@@ -169628,6 +169628,110 @@
           }
         }
       }
+    },
+    "%lld pages behind": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld Seiten im Rückstand"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld páginas de retraso"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld pages de retard"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld pagine di ritardo"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld páginas em atraso"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld страниц позади"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "落后 %lld 页"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "落後 %lld 頁"
+          }
+        }
+      }
+    },
+    "Syncing strap history, %lld chunks, %lld pages behind": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verlaufssynchronisierung des Straps läuft, %lld Chunks, %lld Seiten im Rückstand"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sincronizando el historial de la pulsera, %lld bloques, %lld páginas de retraso"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Synchronisation de l'historique du bracelet, %lld blocs, %lld pages de retard"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sincronizzazione della cronologia della fascia, %lld blocchi, %lld pagine di ritardo"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "A sincronizar o histórico da bracelete, %lld pedaços, %lld páginas em atraso"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Синхронизация истории браслета, %lld фрагментов, %lld страниц позади"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在同步手环历史记录，%lld 个数据块，落后 %lld 页"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在同步手環歷史記錄，%lld 個資料塊，落後 %lld 頁"
+          }
+        }
+      }
     }
   },
   "version": "1.0"

--- a/Strand/Screens/TodayView.swift
+++ b/Strand/Screens/TodayView.swift
@@ -4467,14 +4467,20 @@ struct TodayDayScopedCache {
 /// yet) → `✓ live`. `.hidden` only on a true cold start (the building-scores note owns that case). Twin
 /// of Android `SyncStatusChip`.
 enum SyncChipState: Equatable {
-    case syncing(chunks: Int)
+    /// #689/#815 follow-up: `pagesBehind` is the strap's GET_DATA_RANGE ring backlog sampled once at
+    /// connect (`LiveState.pagesBehindAtConnect`) — nil until a reply has landed this session, or on a
+    /// device/frame where it didn't decode. Purely additive: nil renders identically to before this field
+    /// existed, so it defaults to the chunk-count-only chip.
+    case syncing(chunks: Int, pagesBehind: Int? = nil)
     case synced(agoText: String)
     case experimentalLive
     case hidden
 
     @MainActor
     static func resolve(live: LiveState) -> SyncChipState {
-        if live.backfilling { return .syncing(chunks: live.syncChunksThisSession) }
+        if live.backfilling {
+            return .syncing(chunks: live.syncChunksThisSession, pagesBehind: live.pagesBehindAtConnect)
+        }
         if let ts = live.lastSyncedAt { return .synced(agoText: shortAgo(ts)) }
         if live.historySyncExperimental { return .experimentalLive }
         return .hidden
@@ -4492,6 +4498,24 @@ enum SyncChipState: Equatable {
         if hrs < 24 { return "\(hrs)h" }
         return "\(hrs / 24)d"
     }
+
+    /// The small trailing fragment the syncing chip appends beside the chunk count when a pages-behind
+    /// sample is known — "494 pages behind". nil (no fragment) when the sample hasn't landed yet, which
+    /// is exactly today's chunk-count-only rendering. Shared by `SyncStatusChip` and `LiquidSyncChip` so
+    /// the two headers can't word this differently.
+    static func pagesBehindDetail(_ pagesBehind: Int?) -> String? {
+        pagesBehind.map { String(localized: "\($0) pages behind") }
+    }
+
+    /// VoiceOver label for the syncing state. Extends the existing chunk-count sentence with the
+    /// pages-behind figure when known, so the detail reaches accessibility users the same way it reaches
+    /// sighted ones via `pagesBehindDetail`, rather than being a sighted-only visual fragment.
+    static func syncingAccessibilityLabel(chunks: Int, pagesBehind: Int?) -> String {
+        if let pagesBehind {
+            return String(localized: "Syncing strap history, \(chunks) chunks, \(pagesBehind) pages behind")
+        }
+        return String(localized: "Syncing strap history, \(chunks) chunks")
+    }
 }
 
 /// #245: a compact sync-status chip for the Today top bar, shown to EVERY user. The full-width
@@ -4504,9 +4528,10 @@ struct SyncStatusChip: View {
 
     var body: some View {
         switch SyncChipState.resolve(live: live) {
-        case .syncing(let chunks):
-            chip(system: "arrow.triangle.2.circlepath", text: "\(chunks)", tint: StrandPalette.accent,
-                 a11y: String(localized: "Syncing strap history, \(chunks) chunks"))
+        case .syncing(let chunks, let pagesBehind):
+            chip(system: "arrow.triangle.2.circlepath", text: "\(chunks)",
+                 detail: SyncChipState.pagesBehindDetail(pagesBehind), tint: StrandPalette.accent,
+                 a11y: SyncChipState.syncingAccessibilityLabel(chunks: chunks, pagesBehind: pagesBehind))
         case .synced(let agoText):
             chip(system: "checkmark", text: agoText, tint: StrandPalette.textSecondary,
                  a11y: String(localized: "Strap history synced \(agoText) ago"))
@@ -4519,10 +4544,15 @@ struct SyncStatusChip: View {
         }
     }
 
-    private func chip(system: String, text: String, tint: Color, a11y: String) -> some View {
+    private func chip(system: String, text: String, detail: String? = nil, tint: Color, a11y: String) -> some View {
         HStack(spacing: 4) {
             Image(systemName: system).font(.system(size: 11, weight: .semibold))
             Text(text).font(StrandFont.captionNumber)
+            // #689/#815: the pages-behind detail, when known. A trailing fragment rather than a redesign
+            // of this DRAFT chip — see `SyncChipState.pagesBehindDetail`.
+            if let detail {
+                Text(detail).font(StrandFont.caption).foregroundStyle(tint.opacity(0.7))
+            }
         }
         .foregroundStyle(tint)
         .padding(.horizontal, 8)

--- a/StrandTests/SyncChipStateTests.swift
+++ b/StrandTests/SyncChipStateTests.swift
@@ -12,7 +12,17 @@ final class SyncChipStateTests: XCTestCase {
         let live = LiveState()
         live.backfilling = true
         live.syncChunksThisSession = 7
-        XCTAssertEqual(SyncChipState.resolve(live: live), .syncing(chunks: 7))
+        XCTAssertEqual(SyncChipState.resolve(live: live), .syncing(chunks: 7, pagesBehind: nil))
+    }
+
+    /// #689/#815 follow-up: when a GET_DATA_RANGE sample has landed this session, it rides along on the
+    /// syncing state so the chip can append the "N pages behind" detail.
+    func testBackfilling_withPagesBehindSample_carriesItOnSyncingState() {
+        let live = LiveState()
+        live.backfilling = true
+        live.syncChunksThisSession = 7
+        live.setPagesBehindAtConnect(494)
+        XCTAssertEqual(SyncChipState.resolve(live: live), .syncing(chunks: 7, pagesBehind: 494))
     }
 
     func testLastSyncedAt_isSyncedWithAgeText() {

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -208,6 +208,14 @@ data class LiveState(
      *  once empty offloads are SUSTAINED; cleared on connect or once the strap banks real records. Twin of
      *  macOS LiveState.historySyncExperimental. */
     val historySyncExperimental: Boolean = false,
+    /** #689/#815: the strap's ring-buffer page backlog, sampled ONCE from the connect-time GET_DATA_RANGE
+     *  reply — never re-polled mid-offload (the link is already firmware-paced, ~10 records/s). A static
+     *  "pages behind" figure, not a live percentage: the strap never reveals a total record count, only
+     *  this bounded ring-buffer measure (write pointer − read pointer against a 131072-page ring),
+     *  confirmed against real captures on both WHOOP 4.0 and 5.0/MG. The Today sync chip appends it to
+     *  the chunk count while [backfilling] is true. null before the first reply this session, or if the
+     *  frame didn't decode. Twin of macOS LiveState.pagesBehindAtConnect. */
+    val pagesBehindAtConnect: Int? = null,
 ) {
     /** Set the fresh-packet [rr] AND append the valid intervals onto the bounded [rrRecent] rolling
      *  buffer (oldest fall off first). Non-positive sentinels are dropped from the rolling buffer.
@@ -973,6 +981,8 @@ class WhoopBleClient(
                 // #580: the 5/MG "history experimental" note is per-link — a fresh connect re-derives it
                 // from the next offload, so it must not outlive the dropped link.
                 historySyncExperimental = false,
+                // A stale pages-behind sample must not outlive the dropped link either (#689/#815).
+                pagesBehindAtConnect = null,
             )
 
         /**
@@ -4484,6 +4494,9 @@ class WhoopBleClient(
                         val pagesBehind = com.noop.protocol.DataRange.pagesBehind(frame, cmdOff)
                         if (pagesBehind != null) {
                             log("Strap backlog pages behind: $pagesBehind (#689 — GET_DATA_RANGE ring backlog, diagnostic only)")
+                            // #815: confirmed on both WHOOP 4.0 and 5.0/MG, so bank it unconditionally — the
+                            // Today sync chip's "N pages behind" detail reads this while backfilling is true.
+                            _state.update { it.copy(pagesBehindAtConnect = pagesBehind) }
                         } else {
                             log(
                                 "Strap backlog pages behind: not decodable from this frame (#689 — offsets may " +

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -4496,7 +4496,7 @@ class WhoopBleClient(
                             log("Strap backlog pages behind: $pagesBehind (#689 — GET_DATA_RANGE ring backlog, diagnostic only)")
                             // #815: confirmed on both WHOOP 4.0 and 5.0/MG, so bank it unconditionally — the
                             // Today sync chip's "N pages behind" detail reads this while backfilling is true.
-                            _state.update { it.copy(pagesBehindAtConnect = pagesBehind) }
+                            _state.update { it.copy(pagesBehindAtConnect = pagesBehind.toInt()) }
                         } else {
                             log(
                                 "Strap backlog pages behind: not decodable from this frame (#689 — offsets may " +

--- a/android/app/src/main/java/com/noop/ui/TodayScoring.kt
+++ b/android/app/src/main/java/com/noop/ui/TodayScoring.kt
@@ -381,7 +381,11 @@ internal fun recordingStateFor(
  *  [Hidden] only on a true cold start (the building-scores note owns that case). Previously this
  *  priority order lived inline inside the `@Composable`, where it could not be unit-tested. */
 sealed class SyncChipState {
-    data class Syncing(val chunks: Int) : SyncChipState()
+    /** #689/#815 follow-up: [pagesBehind] is the strap's GET_DATA_RANGE ring backlog sampled once at
+     *  connect (`LiveState.pagesBehindAtConnect`) — null until a reply has landed this session, or on a
+     *  device/frame where it didn't decode. Purely additive: null renders identically to before this
+     *  field existed, so it defaults to the chunk-count-only chip. Mirrors Swift `SyncChipState.syncing`. */
+    data class Syncing(val chunks: Int, val pagesBehind: Int? = null) : SyncChipState()
     data class Synced(val agoText: String) : SyncChipState()
     object ExperimentalLive : SyncChipState()
     object Hidden : SyncChipState()
@@ -394,8 +398,9 @@ sealed class SyncChipState {
             chunks: Int,
             lastSyncAtSec: Long?,
             historySyncExperimental: Boolean,
+            pagesBehind: Int? = null,
         ): SyncChipState = when {
-            backfilling -> Syncing(chunks)
+            backfilling -> Syncing(chunks, pagesBehind)
             lastSyncAtSec != null -> Synced(shortSyncAgo(lastSyncAtSec))
             historySyncExperimental -> ExperimentalLive
             else -> Hidden
@@ -415,6 +420,21 @@ internal fun shortSyncAgo(unixSec: Long): String {
         else -> "${secs / 86_400}d"
     }
 }
+
+/** #689/#815 follow-up: the small trailing fragment the syncing chip appends beside the chunk count when
+ *  a pages-behind sample is known — "494 pages behind". null (no fragment) when the sample hasn't landed
+ *  yet, which is exactly today's chunk-count-only rendering. Mirrors iOS `SyncChipState.pagesBehindDetail`. */
+internal fun pagesBehindDetail(pagesBehind: Int?): String? =
+    pagesBehind?.let { uiString(R.string.l10n_today_screen_sync_chip_pages_behind_29b5c548, it) }
+
+/** Accessibility/content-description label for the syncing state. Extends the existing chunk-count
+ *  sentence with the pages-behind figure when known. Mirrors iOS `SyncChipState.syncingAccessibilityLabel`. */
+internal fun syncingAccessibilityLabel(chunks: Int, pagesBehind: Int?): String =
+    if (pagesBehind != null) {
+        uiString(R.string.l10n_today_screen_sync_chip_syncing_pages_desc_6c2a5ea9, chunks, pagesBehind)
+    } else {
+        uiString(R.string.l10n_today_screen_sync_chip_syncing_desc_bfc290e7, chunks)
+    }
 
 /** Whether this night's sleep staging is low-confidence, using the core [ScoreConfidence] rule. */
 internal fun restStageLowConfidence(d: DailyMetric?): Boolean {

--- a/android/app/src/main/java/com/noop/ui/TodayScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/TodayScreen.kt
@@ -236,6 +236,9 @@ private data class TodayLiveSnapshot(
     val whoop5: Boolean,
     /** Charging hides the runtime estimate (no "X left" while topping up). Rare flips, snapshot-safe. */
     val charging: Boolean?,
+    /** #689/#815 follow-up: the connect-time GET_DATA_RANGE pages-behind sample, when known. Set once per
+     *  connection, so it doesn't reintroduce per-tick churn either. */
+    val pagesBehindAtConnect: Int?,
 )
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -302,6 +305,7 @@ fun TodayScreen(
                 batteryPct = s.batteryPct,
                 whoop5 = s.whoop5Detected,
                 charging = s.charging,
+                pagesBehindAtConnect = s.pagesBehindAtConnect,
             )
         }
     }

--- a/android/app/src/main/java/com/noop/ui/TodayScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/TodayScreen.kt
@@ -1169,6 +1169,7 @@ fun TodayScreen(
                 syncChunksThisSession = liveSnap.syncChunksThisSession,
                 lastSyncAt = liveSnap.lastSyncAt,
                 historySyncExperimental = liveSnap.historySyncExperimental,
+                pagesBehindAtConnect = liveSnap.pagesBehindAtConnect,
                 onPickDay = { offset -> selectedDayOffset = offset },
                 onQuickActions = onQuickActions,
                 onOpenSettings = onOpenSettings,
@@ -2004,6 +2005,8 @@ private fun LiquidTodayHeader(
     syncChunksThisSession: Int = 0,
     lastSyncAt: Long? = null,
     historySyncExperimental: Boolean = false,
+    // #689/#815 follow-up: the connect-time GET_DATA_RANGE pages-behind sample, when known.
+    pagesBehindAtConnect: Int? = null,
     onPickDay: (Int) -> Unit,
     onQuickActions: () -> Unit,
     onOpenSettings: () -> Unit,
@@ -2093,6 +2096,7 @@ private fun LiquidTodayHeader(
             SyncStatusChip(
                 backfilling = backfilling, chunks = syncChunksThisSession,
                 lastSyncAt = lastSyncAt, historySyncExperimental = historySyncExperimental,
+                pagesBehind = pagesBehindAtConnect,
             )
             // (a) Profile avatar (the photo set in Settings, or the NOOP loop mark) → Settings. Mirrors iOS.
             Box(
@@ -2131,11 +2135,13 @@ private fun SyncStatusChip(
     chunks: Int,
     lastSyncAt: Long?,
     historySyncExperimental: Boolean,
+    pagesBehind: Int? = null,
 ) {
-    when (val state = SyncChipState.resolve(backfilling, chunks, lastSyncAt, historySyncExperimental)) {
+    when (val state = SyncChipState.resolve(backfilling, chunks, lastSyncAt, historySyncExperimental, pagesBehind)) {
         is SyncChipState.Syncing -> ChipCapsule(
             Icons.Filled.Autorenew, "${state.chunks}", Palette.accent,
-            uiString(R.string.l10n_today_screen_sync_chip_syncing_desc_bfc290e7, state.chunks))
+            syncingAccessibilityLabel(state.chunks, state.pagesBehind),
+            detail = pagesBehindDetail(state.pagesBehind))
         is SyncChipState.Synced -> ChipCapsule(
             Icons.Filled.Check, state.agoText, Palette.textSecondary,
             uiString(R.string.l10n_today_screen_sync_chip_synced_desc_4d255944, state.agoText))
@@ -2147,9 +2153,11 @@ private fun SyncStatusChip(
     }
 }
 
-/** The shared sync-chip capsule (icon + terse label). Twin of the iOS `SyncStatusChip.chip`. */
+/** The shared sync-chip capsule (icon + terse label). Twin of the iOS `SyncStatusChip.chip`.
+ *  #689/#815: [detail] is the pages-behind fragment appended beside [text], when known —
+ *  see [pagesBehindDetail]. */
 @Composable
-private fun ChipCapsule(icon: ImageVector, text: String, tint: Color, desc: String) {
+private fun ChipCapsule(icon: ImageVector, text: String, tint: Color, desc: String, detail: String? = null) {
     Row(
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(4.dp),
@@ -2160,6 +2168,9 @@ private fun ChipCapsule(icon: ImageVector, text: String, tint: Color, desc: Stri
     ) {
         Icon(icon, contentDescription = desc, tint = tint, modifier = Modifier.size(14.dp))
         Text(text, style = NoopType.caption, color = tint)
+        if (detail != null) {
+            Text(detail, style = NoopType.caption, color = tint.copy(alpha = 0.7f))
+        }
     }
 }
 

--- a/android/app/src/main/res/values-de/strings.xml
+++ b/android/app/src/main/res/values-de/strings.xml
@@ -1599,6 +1599,8 @@
     <string name="l10n_today_screen_sync_chip_now_c9bc849a">jetzt</string>
     <string name="l10n_today_screen_sync_chip_live_98aadb37">Live</string>
     <string name="l10n_today_screen_sync_chip_syncing_desc_bfc290e7">Verlaufssynchronisierung des Straps läuft, %1$d Chunks</string>
+    <string name="l10n_today_screen_sync_chip_pages_behind_29b5c548">%1$d Seiten im Rückstand</string>
+    <string name="l10n_today_screen_sync_chip_syncing_pages_desc_6c2a5ea9">Verlaufssynchronisierung des Straps läuft, %1$d Chunks, %2$d Seiten im Rückstand</string>
     <string name="l10n_today_screen_sync_chip_synced_desc_4d255944">Verlauf des Straps vor %1$s synchronisiert</string>
     <string name="l10n_today_screen_sync_chip_experimental_desc_3de06a70">Verbunden; die Verlaufssynchronisierung ist bei diesem Strap experimentell.</string>
     <string name="l10n_today_screen_recovery_roundtoint_charge_92fbaa5e">%1$s%% Ladung</string>

--- a/android/app/src/main/res/values-es/strings.xml
+++ b/android/app/src/main/res/values-es/strings.xml
@@ -1439,6 +1439,8 @@
     <string name="l10n_today_screen_sync_chip_now_c9bc849a">ahora</string>
     <string name="l10n_today_screen_sync_chip_live_98aadb37">en vivo</string>
     <string name="l10n_today_screen_sync_chip_syncing_desc_bfc290e7">Sincronizando el historial de la pulsera, %1$d bloques</string>
+    <string name="l10n_today_screen_sync_chip_pages_behind_29b5c548">%1$d páginas de retraso</string>
+    <string name="l10n_today_screen_sync_chip_syncing_pages_desc_6c2a5ea9">Sincronizando el historial de la pulsera, %1$d bloques, %2$d páginas de retraso</string>
     <string name="l10n_today_screen_sync_chip_synced_desc_4d255944">Historial de la pulsera sincronizado hace %1$s</string>
     <string name="l10n_today_screen_sync_chip_experimental_desc_3de06a70">Conectado; la sincronización del historial es experimental en esta pulsera.</string>
     <string name="l10n_today_screen_recovery_roundtoint_charge_92fbaa5e">%1$s%%</string>

--- a/android/app/src/main/res/values-fr/strings.xml
+++ b/android/app/src/main/res/values-fr/strings.xml
@@ -1439,6 +1439,8 @@
     <string name="l10n_today_screen_sync_chip_now_c9bc849a">à l\'instant</string>
     <string name="l10n_today_screen_sync_chip_live_98aadb37">en direct</string>
     <string name="l10n_today_screen_sync_chip_syncing_desc_bfc290e7">Synchronisation de l\'historique du bracelet, %1$d blocs</string>
+    <string name="l10n_today_screen_sync_chip_pages_behind_29b5c548">%1$d pages de retard</string>
+    <string name="l10n_today_screen_sync_chip_syncing_pages_desc_6c2a5ea9">Synchronisation de l\'historique du bracelet, %1$d blocs, %2$d pages de retard</string>
     <string name="l10n_today_screen_sync_chip_synced_desc_4d255944">Historique du bracelet synchronisé il y a %1$s</string>
     <string name="l10n_today_screen_sync_chip_experimental_desc_3de06a70">Connecté ; la synchronisation de l\'historique est expérimentale sur ce bracelet.</string>
     <string name="l10n_today_screen_recovery_roundtoint_charge_92fbaa5e">Charge %1$s%%</string>

--- a/android/app/src/main/res/values-pt-rPT/strings.xml
+++ b/android/app/src/main/res/values-pt-rPT/strings.xml
@@ -1580,6 +1580,8 @@
     <string name="l10n_today_screen_sync_chip_now_c9bc849a">agora</string>
     <string name="l10n_today_screen_sync_chip_live_98aadb37">em direto</string>
     <string name="l10n_today_screen_sync_chip_syncing_desc_bfc290e7">A sincronizar o histórico da bracelete, %1$d pedaços</string>
+    <string name="l10n_today_screen_sync_chip_pages_behind_29b5c548">%1$d páginas em atraso</string>
+    <string name="l10n_today_screen_sync_chip_syncing_pages_desc_6c2a5ea9">A sincronizar o histórico da bracelete, %1$d pedaços, %2$d páginas em atraso</string>
     <string name="l10n_today_screen_sync_chip_synced_desc_4d255944">Histórico da bracelete sincronizado há %1$s</string>
     <string name="l10n_today_screen_sync_chip_experimental_desc_3de06a70">Ligada; a sincronização do histórico é experimental nesta bracelete.</string>
     <string name="l10n_today_screen_recovery_roundtoint_charge_92fbaa5e">%1$s%% Carga</string>

--- a/android/app/src/main/res/values-zh/strings.xml
+++ b/android/app/src/main/res/values-zh/strings.xml
@@ -1561,6 +1561,8 @@
     <string name="l10n_today_screen_sync_chip_now_c9bc849a">刚刚</string>
     <string name="l10n_today_screen_sync_chip_live_98aadb37">实时</string>
     <string name="l10n_today_screen_sync_chip_syncing_desc_bfc290e7">正在同步腕带历史记录，%1$d 个数据块</string>
+    <string name="l10n_today_screen_sync_chip_pages_behind_29b5c548">落后 %1$d 页</string>
+    <string name="l10n_today_screen_sync_chip_syncing_pages_desc_6c2a5ea9">正在同步腕带历史记录，%1$d 个数据块，落后 %2$d 页</string>
     <string name="l10n_today_screen_sync_chip_synced_desc_4d255944">手环历史记录已在 %1$s 前同步</string>
     <string name="l10n_today_screen_sync_chip_experimental_desc_3de06a70">已连接；此手环的历史同步功能为实验性功能。</string>
     <string name="l10n_today_screen_recovery_roundtoint_charge_92fbaa5e">%1$s%% 充能(Charge)</string>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -1608,6 +1608,8 @@
     <string name="l10n_today_screen_sync_chip_now_c9bc849a">now</string>
     <string name="l10n_today_screen_sync_chip_live_98aadb37">live</string>
     <string name="l10n_today_screen_sync_chip_syncing_desc_bfc290e7">Syncing strap history, %1$d chunks</string>
+    <string name="l10n_today_screen_sync_chip_pages_behind_29b5c548">%1$d pages behind</string>
+    <string name="l10n_today_screen_sync_chip_syncing_pages_desc_6c2a5ea9">Syncing strap history, %1$d chunks, %2$d pages behind</string>
     <string name="l10n_today_screen_sync_chip_synced_desc_4d255944">Strap history synced %1$s ago</string>
     <string name="l10n_today_screen_sync_chip_experimental_desc_3de06a70">Connected; strap history sync is experimental on this strap</string>
     <string name="l10n_today_screen_recovery_roundtoint_charge_92fbaa5e">%1$s%% Charge</string>

--- a/android/app/src/test/java/com/noop/ble/GattCrashSafetyTest.kt
+++ b/android/app/src/test/java/com/noop/ble/GattCrashSafetyTest.kt
@@ -82,6 +82,7 @@ class GattCrashSafetyTest {
             historyLayoutVersion = 25,
             backfilling = true,
             syncChunksThisSession = 12,
+            pagesBehindAtConnect = 494,
         )
 
         val after = WhoopBleClient.disconnectedLiveState(live)
@@ -100,6 +101,8 @@ class GattCrashSafetyTest {
         // A stale charging flag must not outlive the link.
         assertNull(after.charging)
         assertNull(after.strapFirmware)
+        // A stale pages-behind sample must not outlive the dropped link either (#689/#815).
+        assertNull(after.pagesBehindAtConnect)
         assertNull(after.historyLayoutVersion)
     }
 

--- a/android/app/src/test/java/com/noop/ui/SyncChipStateTest.kt
+++ b/android/app/src/test/java/com/noop/ui/SyncChipStateTest.kt
@@ -16,7 +16,18 @@ class SyncChipStateTest {
         val state = SyncChipState.resolve(
             backfilling = true, chunks = 7, lastSyncAtSec = null, historySyncExperimental = false,
         )
-        assertEquals(SyncChipState.Syncing(7), state)
+        assertEquals(SyncChipState.Syncing(7, null), state)
+    }
+
+    /** #689/#815 follow-up: when a GET_DATA_RANGE sample has landed this session, it rides along on the
+     *  syncing state so the chip can append the "N pages behind" detail. */
+    @Test
+    fun backfilling_withPagesBehindSample_carriesItOnSyncingState() {
+        val state = SyncChipState.resolve(
+            backfilling = true, chunks = 7, lastSyncAtSec = null, historySyncExperimental = false,
+            pagesBehind = 494,
+        )
+        assertEquals(SyncChipState.Syncing(7, 494), state)
     }
 
     @Test


### PR DESCRIPTION
## Summary

Follow-up to #806, addressing [this comment](https://github.com/ryanbr/noop/pull/806#issuecomment-5082376230): a percentage sync-progress indicator was correctly declined there (the WHOOP protocol never reveals a total pending-record count), but `pagesBehind` — decoded from `GET_DATA_RANGE`'s ring-buffer write/read pointers — is a real, bounded backlog measure, and #818/#821 confirmed the decode against real captures on both WHOOP 4.0 and 5.0/MG. This surfaces it as a static "N pages behind" detail on the sync chip, using the single sample already taken at connect — no new BLE traffic, no re-polling mid-offload (per #377's firmware-pacing concern), no percentage math.

- Swift: `LiveState.pagesBehindAtConnect`, banked in `BLEManager.handleDataRangeResponse` (previously log-only). `SyncChipState.syncing` gained an optional `pagesBehind`, with shared `pagesBehindDetail`/`syncingAccessibilityLabel` helpers used by both `SyncStatusChip` (classic Today) and `LiquidSyncChip` (Liquid Today header).
- Kotlin: `LiveState.pagesBehindAtConnect` (`WhoopBleClient`), `SyncChipState.Syncing` extended (`TodayScoring`), `SyncStatusChip`/`ChipCapsule` render the detail (`TodayScreen`) — including the `TodayLiveSnapshot` recomposition-scoping DTO, which needed the field too.
- Localized into all 8 shipped Apple locales and the 6 shipped Android locale files, following the conventions established in `8d49c380`/#245's review.
- `nil`/`null` (no sample yet, or a family/frame that doesn't decode) renders identically to the chip's existing chunk-count-only behavior — purely additive.

This is scoped deliberately narrow per your "worth revisiting" framing rather than a firm spec — happy to adjust wording or visual treatment (the chip is still marked DRAFT in the code) if you'd rather it look different, or if you'd prefer the detail live somewhere else (e.g. the Data Sources card's `LiquidSyncStatusRow`, which I left untouched to keep this PR to one surface).

## Test plan
- [x] `swift build`/`swift test` for `Packages/WhoopProtocol` (untouched by this PR, sanity-only)
- [x] `xcodegen generate && xcodebuild -scheme Strand -destination 'platform=macOS' build` — succeeds
- [x] `StrandTests.SyncChipStateTests` — 7/7 pass (includes the new pages-behind case)
- [x] `Tools/i18n_audit.py --ci origin/main` — clean on both platforms
- [x] `./gradlew compileFullDebugKotlin` — succeeds (found and fixed two real Kotlin issues along the way: a `Long`→`Int` mismatch since `DataRange.pagesBehind()` returns `Long` on Kotlin vs `Int` on Swift, and the `TodayLiveSnapshot` DTO needing the new field)
- [ ] `./gradlew testFullDebugUnitTest` — blocked module-wide by a **pre-existing, unrelated** gap: three `FakeRegistryDao`/`FakeDao` test fakes are missing methods `DeviceRegistryDao` now declares. Not caused by this change (none of the touched files), and it was already flagged in #806's review thread.
- [ ] Not tested on real hardware — this only reads a value already being decoded and logged; no new BLE commands or timing changes.