### PR TITLE
feat(oura): persist 0x47 motion as OURA_MOTION events + a "Movement" timeline track

### DIFF
--- a/Packages/WhoopStore/Sources/WhoopStore/OuraStreamMapping.swift
+++ b/Packages/WhoopStore/Sources/WhoopStore/OuraStreamMapping.swift
@@ -30,6 +30,12 @@ public enum OuraStreamMapping {
     public static let hrvEventKind = "OURA_HRV"
     /// WhoopEvent.kind for a decoded sleep-phase code (2-bit: awake/light/deep/rem).
     public static let sleepPhaseEventKind = "OURA_SLEEP_PHASE"
+    /// WhoopEvent.kind for a decoded 0x47 motion_events window (open_oura `decode_motion`). The payload
+    /// carries the ring's OWN per-window motion summary — `orientation` / `motion_seconds` / `x` / `y` / `z`
+    /// (avg accel ×8) / `low_intensity` / `high_intensity` (the last two absent on a short record). This is
+    /// INSTRUMENTATION: an honest activity signal, never scored and never fed to the sleep stager (0x47 is
+    /// movement-gated — a shape mismatch for the gravity-stillness stager, #804). Must match the Kotlin twin.
+    public static let motionEventKind = "OURA_MOTION"
 
     /// Build a `Streams` from a batch of decoded Oura events, all stamped at the arrival wall-clock `ts`
     /// (unix seconds). Pure → unit-testable. Section-4 table:
@@ -108,18 +114,22 @@ public enum OuraStreamMapping {
                     mv: v.voltageMv,
                     charging: v.charging))
 
-            case .motionEvent:
-                // 0x47 averaged accel vector (Tier-A). Decoded and available, but NOT written to any
-                // durable stream. This is NOT merely a "pending LSB→g scale" hold — the open question is
-                // whether `gravitySample` is the right destination AT ALL. 0x47 is MOVEMENT-GATED (the
-                // ring emits it only while moving, validated on-device #804), so it yields NO still
-                // samples; `SleepStager` instead needs a CONTINUOUS gravity stream (≥70% of a rolling
-                // 15-min window with per-sample delta < 0.01 g, and a >20-min gap breaks the run). Missing
-                // samples are not still samples, so feeding 0x47 into gravity is a SHAPE MISMATCH, not an
-                // unscaled one, and synthesising still samples to fill the gaps would be inventing data.
-                // The usable signal is `motion_seconds` / intensity as an ACTIVITY input on a separate path
-                // (#804 option B). Held here until that path lands. Dropped, not faked.
-                continue
+            case .motionEvent(let m):
+                // 0x47 motion window → an OURA_MOTION event carrying the ring's OWN per-window summary. This
+                // is INSTRUMENTATION on the honest activity signal, NOT a gravity stream: 0x47 is
+                // movement-gated (no still samples), a shape mismatch for the gravity-stillness `SleepStager`
+                // (#804), so it is NEVER folded into `gravitySample` and NEVER scored. It rides the SAME
+                // event-table path as OURA_HRV / OURA_SLEEP_PHASE (the ring's other per-record signals), one
+                // row per window at its own anchored `ts`. Keys IDENTICAL to the Kotlin twin. `low_/
+                // high_intensity` are omitted on a short record (absent, never faked to 0).
+                var payload: [String: ParsedValue] = [
+                    "orientation": .int(m.orientation),
+                    "motion_seconds": .int(m.motionSeconds),
+                    "x": .int(m.avgX), "y": .int(m.avgY), "z": .int(m.avgZ),
+                ]
+                if let lo = m.lowIntensity { payload["low_intensity"] = .int(lo) }
+                if let hi = m.highIntensity { payload["high_intensity"] = .int(hi) }
+                out.events.append(WhoopEvent(ts: ts, kind: motionEventKind, payload: payload))
 
             case .motion, .state, .timeSync, .rtcBeacon, .debugText, .tierB, .activityInfo:
                 // Not a durable per-device stream row (timeSync/rtcBeacon anchor the transport's clock;

--- a/Packages/WhoopStore/Tests/WhoopStoreTests/OuraStreamMappingTests.swift
+++ b/Packages/WhoopStore/Tests/WhoopStoreTests/OuraStreamMappingTests.swift
@@ -50,6 +50,40 @@ final class OuraStreamMappingTests: XCTestCase {
         XCTAssertEqual(ev.payload["b2"], .int(3))
     }
 
+    // MARK: - Motion 0x47 -> events[OURA_MOTION]
+
+    func testMotionMapsToOuraMotionEvent() {
+        let s = OuraStreamMapping.streams(from: [
+            .motionEvent(OuraMotionEvent(ringTimestamp: 100, orientation: 5, motionSeconds: 21,
+                                         avgX: -96, avgY: 0, avgZ: -1024, lowIntensity: 42, highIntensity: 63)),
+        ], at: ts)
+        XCTAssertEqual(s.events.count, 1)
+        let ev = s.events[0]
+        XCTAssertEqual(ev.kind, OuraStreamMapping.motionEventKind)
+        XCTAssertEqual(ev.kind, "OURA_MOTION")
+        XCTAssertEqual(ev.ts, ts)
+        // The ring's OWN per-window motion summary; keys/values must match the Kotlin twin exactly.
+        XCTAssertEqual(ev.payload["orientation"], .int(5))
+        XCTAssertEqual(ev.payload["motion_seconds"], .int(21))
+        XCTAssertEqual(ev.payload["x"], .int(-96))
+        XCTAssertEqual(ev.payload["y"], .int(0))
+        XCTAssertEqual(ev.payload["z"], .int(-1024))
+        XCTAssertEqual(ev.payload["low_intensity"], .int(42))
+        XCTAssertEqual(ev.payload["high_intensity"], .int(63))
+    }
+
+    func testMotionShortRecordOmitsIntensityKeys() {
+        // A short (4-byte) record decodes with nil low/high — the keys are ABSENT, never faked to 0.
+        let s = OuraStreamMapping.streams(from: [
+            .motionEvent(OuraMotionEvent(ringTimestamp: 100, orientation: 1, motionSeconds: 0,
+                                         avgX: 80, avgY: 0, avgZ: 0, lowIntensity: nil, highIntensity: nil)),
+        ], at: ts)
+        let ev = s.events[0]
+        XCTAssertEqual(ev.payload["motion_seconds"], .int(0))
+        XCTAssertNil(ev.payload["low_intensity"], "absent intensity must not be faked")
+        XCTAssertNil(ev.payload["high_intensity"], "absent intensity must not be faked")
+    }
+
     // MARK: - SpO2 -> spo2:[SpO2Sample]
 
     func testSpO2MapsToSpO2StreamPreservingUnit() {

--- a/Strand/BLE/OuraLiveSource.swift
+++ b/Strand/BLE/OuraLiveSource.swift
@@ -1377,15 +1377,19 @@ public final class OuraLiveSource: NSObject, ObservableObject {
                 }
 
             case .motionEvent(let m):
-                // 0x47 averaged accel vector (Tier-A). Diagnostic sidecar ONLY for now: decode + store + log
-                // the vector beside the incumbent so the LSB→g scale + cadence can be pinned offline from a
-                // still capture (issue #804). Never persisted to SQLite, never scored — OuraStreamMapping
-                // drops .motionEvent until the scale is calibrated. Anchored records only (deduped by
-                // ring-time inside the writer).
-                if let utc = driver.unixSeconds(forRingTimestamp: m.ringTimestamp) {
-                    motionDump?.record(ringTs: m.ringTimestamp, utc: utc, orientation: m.orientation,
+                // 0x47 averaged accel vector (Tier-A). Persisted as an OURA_MOTION event (same event-table
+                // path as OURA_HRV / OURA_SLEEP_PHASE — see OuraStreamMapping), AND appended to the raw
+                // calibration sidecar. Instrumentation only: never scored, never fed to the sleep stager
+                // (0x47 is movement-gated, a shape mismatch for the gravity-stillness stager, #804). Anchor
+                // per record (its own ring-time) so each window lands on a distinct (deviceId, ts, kind) row.
+                if let ts = driver.unixSeconds(forRingTimestamp: m.ringTimestamp) {
+                    motionDump?.record(ringTs: m.ringTimestamp, utc: ts, orientation: m.orientation,
                                        motionSeconds: m.motionSeconds, x: m.avgX, y: m.avgY, z: m.avgZ,
                                        lowIntensity: m.lowIntensity, highIntensity: m.highIntensity)
+                    enqueue([e], ts: ts)
+                    noteStoredHistoryRingTime(m.ringTimestamp)
+                } else {
+                    pendingAnchorEvents.append((e, m.ringTimestamp))
                 }
 
             default:

--- a/Strand/Data/Repository.swift
+++ b/Strand/Data/Repository.swift
@@ -1414,7 +1414,7 @@ final class Repository: ObservableObject {
     /// A metric the Deep Timeline can plot. HR is the always-present hero (adaptively downsampled);
     /// the rest are lower-frequency raw-sample streams shown where the strap offloaded them.
     enum TimelineMetric: String, CaseIterable, Identifiable, Sendable {
-        case hr, hrv, spo2, skinTemp, respiration, motion, bandSleepState
+        case hr, hrv, spo2, skinTemp, respiration, motion, bandSleepState, ouraMovement
         var id: String { rawValue }
 
         /// User-facing pill label.
@@ -1434,6 +1434,11 @@ final class Repository: ObservableObject {
             // NOT a stage NOOP trusts as truth — the pill names it "Band Sleep State" so it can't be
             // mistaken for the derived stages.
             case .bandSleepState: return String(localized: "Band Sleep State")
+            // The Oura ring's OWN per-window motion: seconds of movement in each ~30 s window (0x47,
+            // OURA_MOTION events). An honest ACTIVITY signal — NOT gravity magnitude (the ring sends no
+            // continuous gravity) and NEVER a step count. Empty for a WHOOP strap. Labelled "Movement" so
+            // it can't be mistaken for the derived stages or for steps.
+            case .ouraMovement: return String(localized: "Movement")
             }
         }
     }
@@ -1636,6 +1641,18 @@ final class Repository: ObservableObject {
             let s = (try? await store.sleepStateSamples(deviceId: source, from: from, to: to)) ?? []
             return await Task.detached(priority: .utility) {
                 s.map { Self.timelinePoint($0.ts, Double($0.state)) }
+            }.value
+        case .ouraMovement:
+            // The ring's OWN per-window motion from OURA_MOTION events (0x47, movement-gated): plot
+            // `motion_seconds` (0 when still, up to 31 s of movement in the ~30 s window). An honest
+            // activity track, NEVER scored and NEVER a step count; empty for a WHOOP strap (no such events).
+            let evs = (try? await store.events(deviceId: source, from: from, to: to, limit: 200_000)) ?? []
+            return await Task.detached(priority: .utility) {
+                evs.compactMap { e -> TrendPoint? in
+                    guard e.kind == OuraStreamMapping.motionEventKind,
+                          let ms = e.payload["motion_seconds"]?.intValue else { return nil }
+                    return Self.timelinePoint(e.ts, Double(ms))
+                }
             }.value
         }
     }

--- a/Strand/Screens/FullDayChartView.swift
+++ b/Strand/Screens/FullDayChartView.swift
@@ -433,13 +433,15 @@ struct FullDayChartView: View {
         // Gravity-vector magnitude (#102): tag it "g" so the readout doesn't read as a bare, unexplained
         // number — spo2/bandSleepState stay unitless (unitless ratio / a named state, not a magnitude).
         case .motion: return " g"
+        // Seconds of movement per ~30 s window (the ring's OWN 0x47 activity), so tag it "s".
+        case .ouraMovement: return " s"
         case .spo2, .bandSleepState: return ""
         }
     }
 
     private func format(_ v: Double) -> String {
         switch metric {
-        case .hr, .respiration, .hrv: return String(Int(v.rounded()))
+        case .hr, .respiration, .hrv, .ouraMovement: return String(Int(v.rounded()))
         // `v` already arrives in the displayed unit — callers read from `displayPoints`, which converts
         // skin temp to °F upfront so the chart's own axis (plotted from the same points) agrees. (#101)
         case .skinTemp: return String(format: "%.1f", v)
@@ -481,7 +483,7 @@ struct FullDayChartView: View {
             return Gradient(colors: [StrandPalette.strain033.opacity(0.55), StrandPalette.strain033])
         case .hrv, .spo2:
             return Gradient(colors: [StrandPalette.sleepLight.opacity(0.55), StrandPalette.sleepLight])
-        case .respiration, .motion:
+        case .respiration, .motion, .ouraMovement:
             return Gradient(colors: [StrandPalette.textSecondary.opacity(0.5), StrandPalette.textSecondary])
         // #175: the band-state track uses the deep-sleep hue so it reads as a distinct sleep track.
         case .bandSleepState:

--- a/android/app/src/main/java/com/noop/ble/OuraLiveSource.kt
+++ b/android/app/src/main/java/com/noop/ble/OuraLiveSource.kt
@@ -1723,11 +1723,11 @@ class OuraLiveSource(
                 }
             }
             is OuraEvent.MotionVectorEvent -> {
-                // 0x47 averaged accel vector (Tier-A). Diagnostic sidecar ONLY for now: decode + store + log
-                // the vector beside the incumbent so the LSB→g scale + cadence can be pinned offline from a
-                // still capture (issue #804). Never persisted to the DB, never scored — OuraStreamMapping
-                // drops MotionVectorEvent until the scale is calibrated. Anchored records only (deduped by
-                // ring-time in the writer). Twin of the Swift hook.
+                // 0x47 averaged accel vector (Tier-A). Persisted as an OURA_MOTION event (same event-table
+                // path as OURA_HRV / OURA_SLEEP_PHASE — see OuraStreamMapping), AND appended to the raw
+                // calibration sidecar. Instrumentation only: never scored, never fed to the sleep stager
+                // (0x47 is movement-gated, a shape mismatch for the gravity-stillness stager, #804). Anchor
+                // per record so each window lands on a distinct (deviceId, ts, kind) row. Twin of Swift.
                 d.unixSeconds(forRingTimestamp = e.value.ringTimestamp)?.let { utc ->
                     motionDump?.record(
                         ringTs = e.value.ringTimestamp, utc = utc, orientation = e.value.orientation,
@@ -1736,6 +1736,7 @@ class OuraLiveSource(
                         highIntensity = e.value.highIntensity,
                     )
                 }
+                enqueueAnchoredOrPark(e, e.value.ringTimestamp, d)
             }
             // Motion (0x6b) / debugText / etc: not a durable Streams row (see OuraStreamMapping). StateEvent
             // is handled above (wear badge only, also not a Streams row).

--- a/android/app/src/main/java/com/noop/data/OuraStreamMapping.kt
+++ b/android/app/src/main/java/com/noop/data/OuraStreamMapping.kt
@@ -37,6 +37,9 @@ object OuraStreamMapping {
     /** The event `kind` recorded for the ring's own open sleep-phase (0x49.../0x58) tags. */
     const val EVENT_SLEEP_PHASE = "OURA_SLEEP_PHASE"
 
+    /** The event `kind` for a decoded 0x47 motion window (activity instrumentation). Must match Swift. */
+    const val EVENT_MOTION = "OURA_MOTION"
+
     /**
      * Fold a batch of decoded [events] into a protocol [Streams] for one flush. [anchor] maps a
      * ring-clock timestamp to wall-clock unix seconds (null => drop the sample). Pure: no BLE, no DB,
@@ -130,7 +133,24 @@ object OuraStreamMapping {
                 // synthesising still samples to fill the gaps would be inventing data. The usable signal is
                 // motion_seconds / intensity as an ACTIVITY input on a separate path (#804 option B). Held
                 // here until that path lands. Dropped, not faked. Mirrors the Swift twin.
-                is OuraEvent.MotionVectorEvent -> Unit
+                is OuraEvent.MotionVectorEvent -> {
+                    // 0x47 motion window → an OURA_MOTION event: the ring's OWN per-window motion summary
+                    // (orientation / motion_seconds / x / y / z / low_/high_intensity). INSTRUMENTATION only
+                    // — an honest activity signal, never scored and never fed to the sleep stager (0x47 is
+                    // movement-gated, a shape mismatch for the gravity-stillness stager, #804). Rides the SAME
+                    // event-table path as OURA_HRV / OURA_SLEEP_PHASE, one row per window at its own anchored
+                    // ts. Keys IDENTICAL to the Swift twin; low_/high_intensity omitted on a short record.
+                    val ts = anchor(ev.value.ringTimestamp) ?: continue
+                    val m = ev.value
+                    val payload = linkedMapOf<String, Any?>(
+                        "orientation" to m.orientation,
+                        "motion_seconds" to m.motionSeconds,
+                        "x" to m.avgX, "y" to m.avgY, "z" to m.avgZ,
+                    )
+                    m.lowIntensity?.let { payload["low_intensity"] = it }
+                    m.highIntensity?.let { payload["high_intensity"] = it }
+                    out.events.add(WhoopEvent(ts = ts, kind = EVENT_MOTION, payload = payload))
+                }
 
                 // Motion / state / time-sync / rtc / debug / TierB / ActivityInfo never map onto a
                 // scored stream. In particular the 0x50 activity/MET decode (PR #960) NEVER mints a

--- a/android/app/src/main/java/com/noop/ui/FullDayChartScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/FullDayChartScreen.kt
@@ -58,6 +58,11 @@ private enum class TimelineMetric(val title: String) {
     // stepped track alongside the derived hypnogram. This is the band's REPORTED state, NOT a stage NOOP
     // trusts as truth — the pill names it "Band Sleep State" so it can't be mistaken for the derived stages.
     BandSleepState(uiString(R.string.timeline_metric_band_sleep_state)),
+
+    // The Oura ring's OWN per-window motion (0x47, OURA_MOTION events): seconds of movement in each ~30 s
+    // window. An honest ACTIVITY signal — NOT gravity magnitude (the ring sends no continuous gravity) and
+    // NEVER a step count. Empty for a WHOOP strap. Twin of Swift TimelineMetric.ouraMovement.
+    Movement(uiString(R.string.timeline_metric_movement)),
 }
 
 @Composable
@@ -413,6 +418,17 @@ private suspend fun readTimeline(
             // which the view renders as its honest "nothing here" state — never a fabricated flat line.
             runCatching { repo.sleepStateSamples(deviceId, from, to, 200_000) }.getOrDefault(emptyList())
                 .map { TimelinePoint(it.ts, it.state.toDouble()) }
+        TimelineMetric.Movement ->
+            // The ring's OWN per-window motion from OURA_MOTION events (0x47): plot `motion_seconds`
+            // (0 when still, up to 31 s in the ~30 s window). Honest activity, NEVER scored/steps; empty
+            // for a WHOOP strap. Twin of Swift's ouraMovement series.
+            runCatching { repo.events(deviceId, from, to, 200_000) }.getOrDefault(emptyList())
+                .filter { it.kind == com.noop.data.OuraStreamMapping.EVENT_MOTION }
+                .mapNotNull { row ->
+                    val ms = runCatching { org.json.JSONObject(row.payloadJSON).optInt("motion_seconds", -1) }
+                        .getOrDefault(-1)
+                    if (ms < 0) null else TimelinePoint(row.ts, ms.toDouble())
+                }
     }
     if (raw.isEmpty() || bucket <= 1L) return@withContext raw
     downsampleTimeline(raw, bucket)
@@ -448,7 +464,7 @@ private fun metricColor(metric: TimelineMetric): Color = when (metric) {
     TimelineMetric.Hr -> Palette.metricRose
     TimelineMetric.SkinTemp -> Palette.strain033
     TimelineMetric.Hrv, TimelineMetric.Spo2 -> Palette.sleepLight
-    TimelineMetric.Respiration, TimelineMetric.Motion -> Palette.textSecondary
+    TimelineMetric.Respiration, TimelineMetric.Motion, TimelineMetric.Movement -> Palette.textSecondary
     // #175: the band-state track uses the deep-sleep hue so it reads as a distinct sleep track.
     TimelineMetric.BandSleepState -> Palette.sleepDeep
 }
@@ -457,11 +473,12 @@ private fun unitSuffix(metric: TimelineMetric, tempUnit: TemperatureUnit): Strin
     TimelineMetric.Hr -> " bpm"
     TimelineMetric.SkinTemp -> UnitFormatter.temperatureUnit(tempUnit)   // #101: °C / °F per preference
     TimelineMetric.Hrv -> " ms"
+    TimelineMetric.Movement -> " s"   // seconds of movement per ~30 s window (ring's 0x47 activity)
     else -> ""
 }
 
 private fun formatValue(metric: TimelineMetric, v: Double): String = when (metric) {
-    TimelineMetric.Hr, TimelineMetric.Respiration, TimelineMetric.Hrv -> v.toInt().toString()
+    TimelineMetric.Hr, TimelineMetric.Respiration, TimelineMetric.Hrv, TimelineMetric.Movement -> v.toInt().toString()
     // `v` already arrives in the displayed unit — callers read from `displayPoints`, which converts skin
     // temp to °F upfront so the chart's axis (plotted from the same points) agrees with this readout (#101).
     TimelineMetric.SkinTemp -> String.format(Locale.US, "%.1f", v)

--- a/android/app/src/main/res/values-de/strings.xml
+++ b/android/app/src/main/res/values-de/strings.xml
@@ -1648,6 +1648,7 @@
     <string name="timeline_metric_respiration">Atmung</string>
     <string name="timeline_metric_motion">Bewegung</string>
     <string name="timeline_metric_band_sleep_state">Schlafstatus des Bands</string>
+    <string name="timeline_metric_movement">Bewegung</string>
     <string name="explore_category_charge">Ladung</string>
     <string name="explore_category_effort">Anstrengung</string>
     <string name="explore_category_rest">Ruhe</string>

--- a/android/app/src/main/res/values-es/strings.xml
+++ b/android/app/src/main/res/values-es/strings.xml
@@ -1633,6 +1633,7 @@
     <string name="timeline_metric_respiration">Respiración</string>
     <string name="timeline_metric_motion">Movimiento</string>
     <string name="timeline_metric_band_sleep_state">Estado de sueño de la pulsera</string>
+    <string name="timeline_metric_movement">Movimiento</string>
     <string name="explore_category_charge">Carga</string>
     <string name="explore_category_effort">Esfuerzo</string>
     <string name="explore_category_rest">Descanso</string>

--- a/android/app/src/main/res/values-fr/strings.xml
+++ b/android/app/src/main/res/values-fr/strings.xml
@@ -1633,6 +1633,7 @@
     <string name="timeline_metric_respiration">Respiration</string>
     <string name="timeline_metric_motion">Mouvement</string>
     <string name="timeline_metric_band_sleep_state">État de sommeil du bracelet</string>
+    <string name="timeline_metric_movement">Mouvement</string>
     <string name="explore_category_charge">Charge</string>
     <string name="explore_category_effort">Effort</string>
     <string name="explore_category_rest">Repos</string>

--- a/android/app/src/main/res/values-pt-rPT/strings.xml
+++ b/android/app/src/main/res/values-pt-rPT/strings.xml
@@ -1627,6 +1627,7 @@
     <string name="timeline_metric_respiration">Respiração</string>
     <string name="timeline_metric_motion">Movimento</string>
     <string name="timeline_metric_band_sleep_state">Estado de suspensão da banda</string>
+    <string name="timeline_metric_movement">Movimento</string>
     <string name="explore_category_charge">Carga</string>
     <string name="explore_category_effort">Esforço</string>
     <string name="explore_category_rest">Descanso</string>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -1657,6 +1657,7 @@
     <string name="timeline_metric_respiration">Respiration</string>
     <string name="timeline_metric_motion">Motion</string>
     <string name="timeline_metric_band_sleep_state">Band Sleep State</string>
+    <string name="timeline_metric_movement">Movement</string>
     <string name="explore_category_charge">Charge</string>
     <string name="explore_category_effort">Effort</string>
     <string name="explore_category_rest">Rest</string>

--- a/android/app/src/test/java/com/noop/data/OuraStreamMappingTest.kt
+++ b/android/app/src/test/java/com/noop/data/OuraStreamMappingTest.kt
@@ -4,6 +4,7 @@ import com.noop.oura.OuraEvent
 import com.noop.oura.OuraHR
 import com.noop.oura.OuraHRV
 import com.noop.oura.OuraIBI
+import com.noop.oura.OuraMotionEvent
 import com.noop.oura.OuraSleepPhase
 import com.noop.oura.OuraSleepStage
 import com.noop.oura.OuraSpO2
@@ -60,6 +61,43 @@ class OuraStreamMappingTest {
         assertEquals(7, ev.payload["b1"])
         assertEquals(-3, ev.payload["b2"])
         assertTrue("must not fabricate rmssd_ms", !ev.payload.containsKey("rmssd_ms"))
+    }
+
+    @Test
+    fun motionBecomesOuraMotionEvent() {
+        val s = OuraStreamMapping.streams(
+            listOf(OuraEvent.MotionVectorEvent(OuraMotionEvent(
+                ringTimestamp = 5, orientation = 5, motionSeconds = 21,
+                avgX = -96, avgY = 0, avgZ = -1024, lowIntensity = 42, highIntensity = 63))),
+            anchor,
+        )
+        assertEquals(1, s.events.size)
+        val ev = s.events.first()
+        assertEquals(OuraStreamMapping.EVENT_MOTION, ev.kind)
+        assertEquals("OURA_MOTION", ev.kind)
+        assertEquals(base + 5, ev.ts)
+        // Keys/values must match the Swift twin exactly.
+        assertEquals(5, ev.payload["orientation"])
+        assertEquals(21, ev.payload["motion_seconds"])
+        assertEquals(-96, ev.payload["x"])
+        assertEquals(0, ev.payload["y"])
+        assertEquals(-1024, ev.payload["z"])
+        assertEquals(42, ev.payload["low_intensity"])
+        assertEquals(63, ev.payload["high_intensity"])
+    }
+
+    @Test
+    fun motionShortRecordOmitsIntensityKeys() {
+        val s = OuraStreamMapping.streams(
+            listOf(OuraEvent.MotionVectorEvent(OuraMotionEvent(
+                ringTimestamp = 5, orientation = 1, motionSeconds = 0,
+                avgX = 80, avgY = 0, avgZ = 0, lowIntensity = null, highIntensity = null))),
+            anchor,
+        )
+        val ev = s.events.first()
+        assertEquals(0, ev.payload["motion_seconds"])
+        assertTrue("absent intensity must not be faked", !ev.payload.containsKey("low_intensity"))
+        assertTrue("absent intensity must not be faked", !ev.payload.containsKey("high_intensity"))
     }
 
     @Test


### PR DESCRIPTION
##  What this does

  Builds on #805 (the 0x47 motion decoder) to persist the ring's per-window motion and surface it:

  1. Persist — each 0x47 window is written to the DB as an OURA_MOTION event (payload: orientation, motion_seconds, x, y, z, and  low_/high_intensity when the record carries them), one row per window at its own anchored ts.  2. Surface — a new "Movement" metric in the Full Day Chart / timeline picker, plotting motion_seconds (0 when still, up to 31 s of  movement per ~30 s window).

##  Why the event table (no migration)

  Motion is a per-record signal, exactly like the ring's other open tags (OURA_HRV, OURA_SLEEP_PHASE), which already persist as event  rows. Reusing that path means no schema migration and no new table — the lowest-risk way to land it. Windows are ~30 s apart so they  never collide on the (deviceId, ts, kind) key.

##  Honest-data framing

  This is instrumentation only — an honest per-window activity signal. It is never scored and never fed to the sleep stager: 0x47 is  movement-gated (no still samples), a shape mismatch for the gravity-stillness SleepStager (see #804/#805 discussion). The "Movement"  track is explicitly not a step count and not gravity magnitude; it's empty for a WHOOP strap (rendered as the view's honest "nothing  here" state).

##  Validated on-device

  On an Oura ring: OURA_MOTION events persist on every sync, and the Movement track shows the ring's activity (near-0 through still  sleep, rising at turn-overs/wake) — matching the ring's own hypnogram. gravitySample stays 0 for the ring, so the older gravity  "Motion" metric is correctly empty.

##  Both platforms

  Byte-identical payload keys. Swift OuraStreamMapping + OuraLiveSource + Repository/FullDayChartView; Kotlin twins in
  OuraStreamMapping + OuraLiveSource + FullDayChartScreen (+ timeline_metric_movement in en/de/es/fr/pt-PT).

##  Testing

  - Swift: WhoopStore mapping tests (incl. 2 new motion cases + short-record intensity-omission), macOS app BUILD SUCCEEDED.
  - Kotlin: OuraStreamMappingTest +2, Android compiles, i18n passes.

  Relates to #804; builds on #805.
