### PR TITLE
fix(health-connect): workout calories under-report, and double-count across sources

### DIFF
--- a/android/app/src/main/java/com/noop/ingest/HealthConnectImporter.kt
+++ b/android/app/src/main/java/com/noop/ingest/HealthConnectImporter.kt
@@ -342,12 +342,6 @@ object HealthConnectImporter {
                 bucket(dayOf(r.startTime)).exerciseCount += 1
             }
 
-            // Fill per-workout HR (#77): an ExerciseSessionRecord carries no summary HR, so avg/max
-            // were stored null and every imported workout showed "–". Intersect each session's window
-            // with its HeartRateRecord samples — a targeted per-session read, bounded by workout count
-            // (the day-aggregate HeartRateRecord pass above streams the full range and must not be
-            // buffered). readAll swallows a per-session failure, so one bad session can't fail the
-            // import. ≥60 samples (~1 min) required so a few strays can't fabricate an average.
             // --- #835: upgrade each workout's calories now the day aggregate exists ---
             // Runs here, not at construction, because the Total-derived estimate needs the day's BASAL
             // burn (total − active), which is only known once every record has been read. Purely a
@@ -371,6 +365,12 @@ object HealthConnectImporter {
                 if (better != null) workouts[i] = w.copy(energyKcal = round1(better))
             }
 
+            // Fill per-workout HR (#77): an ExerciseSessionRecord carries no summary HR, so avg/max
+            // were stored null and every imported workout showed "–". Intersect each session's window
+            // with its HeartRateRecord samples — a targeted per-session read, bounded by workout count
+            // (the day-aggregate HeartRateRecord pass above streams the full range and must not be
+            // buffered). readAll swallows a per-session failure, so one bad session can't fail the
+            // import. ≥60 samples (~1 min) required so a few strays can't fabricate an average.
             for (i in workouts.indices) {
                 val w = workouts[i]
                 if (w.endTs <= w.startTs) continue

--- a/android/app/src/main/java/com/noop/ingest/HealthConnectImporter.kt
+++ b/android/app/src/main/java/com/noop/ingest/HealthConnectImporter.kt
@@ -184,7 +184,10 @@ object HealthConnectImporter {
         // (startEpochS, endEpochS, kcal) of every active-calorie record, so an imported exercise
         // session can be credited with the calories burned inside its window (#117). Garmin/Fit write
         // ActiveCaloriesBurned as interval records; ExerciseSessionRecord itself carries no energy.
-        val activeKcalRecords = ArrayList<Triple<Long, Long, Double>>()
+        val activeKcalRecords = ArrayList<KcalRecord>()
+        // #835: the same per-record windows for TotalCaloriesBurned. A session whose source writes only
+        // Total (common) was previously credited with unrelated background Active alone.
+        val totalKcalRecords = ArrayList<KcalRecord>()
         // #983: HC-only users (no strap) had NO sleep at all — the importer collapsed each
         // SleepSessionRecord to a per-day minute total and never wrote a SleepSession row, so the Sleep
         // screen (which reads repo.sleepSessions) fell to its empty state. Keep each night's bounds +
@@ -208,16 +211,20 @@ object HealthConnectImporter {
                 val b = bucket(dayOf(r.startTime))
                 val src = r.metadata.dataOrigin.packageName
                 b.totalKcalBySource[src] = (b.totalKcalBySource[src] ?: 0.0) + r.energy.inKilocalories
+            totalKcalRecords.add(
+                KcalRecord(r.startTime.epochSecond, r.endTime.epochSecond, r.energy.inKilocalories, src))
             }
             // --- Active calories burned ---
             // #589: per-SOURCE sums, max-across-sources at write-out (same overlap reasoning as steps). The
-            // per-record window list below still gets EVERY record (it credits workouts by time-overlap, a
-            // separate de-overlap), so the per-source map only governs the day total.
+            // per-record window list below gets EVERY record, tagged with its source: the per-workout credit
+            // de-overlaps by source ITSELF (#835 — it used to cross-source SUM, roughly doubling a ride that
+            // two apps both logged), so the per-source map here only governs the day total.
             readAll(client, ActiveCaloriesBurnedRecord::class, filter, selfPackage) { r ->
                 val b = bucket(dayOf(r.startTime))
                 val src = r.metadata.dataOrigin.packageName
                 b.activeKcalBySource[src] = (b.activeKcalBySource[src] ?: 0.0) + r.energy.inKilocalories
-                activeKcalRecords.add(Triple(r.startTime.epochSecond, r.endTime.epochSecond, r.energy.inKilocalories))
+                activeKcalRecords.add(
+                KcalRecord(r.startTime.epochSecond, r.endTime.epochSecond, r.energy.inKilocalories, src))
             }
             // --- Heart rate (instantaneous samples) -> per-day average ---
             readAll(client, HeartRateRecord::class, filter, selfPackage) { r ->
@@ -337,6 +344,23 @@ object HealthConnectImporter {
             // (the day-aggregate HeartRateRecord pass above streams the full range and must not be
             // buffered). readAll swallows a per-session failure, so one bad session can't fail the
             // import. ≥60 samples (~1 min) required so a few strays can't fabricate an average.
+            // --- #835: upgrade each workout's calories now the day aggregate exists ---
+            // Runs here, not at construction, because the Total-derived estimate needs the day's BASAL
+            // burn (total − active), which is only known once every record has been read. Purely a
+            // read-side improvement of an imported value: nothing else about the row changes, and a
+            // session that already had a good Active credit keeps it (the estimate is a max, not a
+            // replacement).
+            for (i in workouts.indices) {
+                val w = workouts[i]
+                if (w.endTs <= w.startTs) continue
+                val day = acc[dayOf(Instant.ofEpochSecond(w.startTs))]
+                val dayBasal = day?.let {
+                    basalKcal(maxSourceDouble(it.totalKcalBySource), maxSourceDouble(it.activeKcalBySource))
+                }
+                val better = workoutKcal(activeKcalRecords, totalKcalRecords, dayBasal, w.startTs, w.endTs)
+                if (better != null) workouts[i] = w.copy(energyKcal = round1(better))
+            }
+
             for (i in workouts.indices) {
                 val w = workouts[i]
                 if (w.endTs <= w.startTs) continue
@@ -786,6 +810,15 @@ object HealthConnectImporter {
     internal fun maxSourceLong(bySource: Map<String, Long>): Long = bySource.values.maxOrNull() ?: 0L
 
     /** #589 de-overlap for a per-source calorie map (Double twin of [maxSourceLong]); empty -> 0.0. */
+    /** One Health Connect energy record's window + value, tagged with the writing app so the
+     *  per-workout credit can de-overlap across sources the way the day totals do (#589, #835). */
+    internal data class KcalRecord(
+        val startS: Long,
+        val endS: Long,
+        val kcal: Double,
+        val source: String,
+    )
+
     internal fun maxSourceDouble(bySource: Map<String, Double>): Double = bySource.values.maxOrNull() ?: 0.0
 
     /**
@@ -823,19 +856,62 @@ object HealthConnectImporter {
      * rather than showing 0. (#117)
      */
     internal fun sumActiveKcalInWindow(
-        records: List<Triple<Long, Long, Double>>,
+        records: List<KcalRecord>,
         startS: Long,
         endS: Long,
     ): Double? {
         if (endS <= startS) return null
-        var total = 0.0
-        for ((rStart, rEnd, kcal) in records) {
-            val overlap = minOf(endS, rEnd) - maxOf(startS, rStart)
+        // #835: sum WITHIN a source, then take the MAX source — never a cross-source sum. A phone and a
+        // watch both writing ActiveCaloriesBurned over the same ride used to be ADDED together, roughly
+        // doubling the session. The day totals already de-overlap this way (#589); the per-workout credit
+        // did not, despite the comment at the read site claiming it did.
+        val bySource = HashMap<String, Double>()
+        for (r in records) {
+            val overlap = minOf(endS, r.endS) - maxOf(startS, r.startS)
             if (overlap <= 0L) continue
-            val recLen = (rEnd - rStart).coerceAtLeast(1L)
-            total += kcal * (overlap.toDouble() / recLen.toDouble())
+            val recLen = (r.endS - r.startS).coerceAtLeast(1L)
+            bySource[r.source] =
+                (bySource[r.source] ?: 0.0) + r.kcal * (overlap.toDouble() / recLen.toDouble())
         }
-        return total.takeIf { it > 0.0 }
+        return bySource.values.maxOrNull()?.takeIf { it > 0.0 }
+    }
+
+    /**
+     * #835 — a workout's active kcal, taking the BEST of the two energy streams Health Connect exposes
+     * rather than only `ActiveCaloriesBurned`.
+     *
+     * Two ways the Active-only credit came out too low:
+     *  - the session's source writes `TotalCaloriesBurned` and no Active at all, so the workout was
+     *    credited only with whatever unrelated background Active happened to overlap it;
+     *  - the only Active cover is a COARSE record (one per day is common), and prorating it by time
+     *    assumes calories burn uniformly — a hard hour inside a 24 h record reads as 1/24 of the day.
+     *
+     * So also derive a candidate from Total: prorated Total over the window, minus the window's share of
+     * the day's basal burn ([dayBasalKcal] spread evenly over 24 h — basal genuinely IS near-uniform, so
+     * prorating THAT is sound in a way prorating a workout's active burn is not). Take whichever estimate
+     * is larger: a stray background record is small, real session coverage is not, so the max picks the
+     * stream that actually resolves this session without needing a threshold. Where both streams cover it
+     * properly they agree, and the max is a no-op.
+     *
+     * Returns null when neither stream yields anything positive — no fabricated number.
+     */
+    internal fun workoutKcal(
+        activeRecords: List<KcalRecord>,
+        totalRecords: List<KcalRecord>,
+        dayBasalKcal: Double?,
+        startS: Long,
+        endS: Long,
+    ): Double? {
+        if (endS <= startS) return null
+        val fromActive = sumActiveKcalInWindow(activeRecords, startS, endS)
+        val totalInWindow = sumActiveKcalInWindow(totalRecords, startS, endS)
+        val fromTotal = if (totalInWindow != null && dayBasalKcal != null) {
+            val basalShare = dayBasalKcal * ((endS - startS).toDouble() / 86_400.0)
+            (totalInWindow - basalShare).takeIf { it > 0.0 }
+        } else {
+            totalInWindow
+        }
+        return listOfNotNull(fromActive, fromTotal).maxOrNull()?.takeIf { it > 0.0 }
     }
 
     /**

--- a/android/app/src/main/java/com/noop/ingest/HealthConnectImporter.kt
+++ b/android/app/src/main/java/com/noop/ingest/HealthConnectImporter.kt
@@ -325,7 +325,11 @@ object HealthConnectImporter {
                         sport = exerciseName(r),
                         source = HC_WORKOUT_SOURCE,
                         durationS = (endS - startS).toDouble().coerceAtLeast(0.0),
-                        energyKcal = sumActiveKcalInWindow(activeKcalRecords, startS, endS),
+                        // Filled by the #835 post-pass below, which needs the day aggregate (basal = total −
+                        // active) and so cannot run until every record has been read. Computing an Active-only
+                        // value here too would just be a third full scan of the record lists per workout,
+                        // thrown away — the post-pass result always supersedes it.
+                        energyKcal = null,
                         avgHr = null,
                         maxHr = null,
                         strain = null,
@@ -350,6 +354,12 @@ object HealthConnectImporter {
             // read-side improvement of an imported value: nothing else about the row changes, and a
             // session that already had a good Active credit keeps it (the estimate is a max, not a
             // replacement).
+            //
+            // Cost: two record-list scans per workout, O(workouts × kcal records). That shape is
+            // pre-existing — the old construction-time call scanned the Active list the same way. This
+            // adds the Total list and drops the now-redundant construction scan, so it is 2 scans where
+            // it was 1, not 3. Fine at realistic sizes; if a multi-year import ever makes it hurt, sort
+            // both lists by start and range-scan rather than filtering the whole list each time.
             for (i in workouts.indices) {
                 val w = workouts[i]
                 if (w.endTs <= w.startTs) continue
@@ -855,7 +865,7 @@ object HealthConnectImporter {
      * grossly over-credits. Returns null when nothing overlaps, so an energy-less session stays blank
      * rather than showing 0. (#117)
      */
-    internal fun sumActiveKcalInWindow(
+    internal fun sumKcalInWindow(
         records: List<KcalRecord>,
         startS: Long,
         endS: Long,
@@ -903,8 +913,8 @@ object HealthConnectImporter {
         endS: Long,
     ): Double? {
         if (endS <= startS) return null
-        val fromActive = sumActiveKcalInWindow(activeRecords, startS, endS)
-        val totalInWindow = sumActiveKcalInWindow(totalRecords, startS, endS)
+        val fromActive = sumKcalInWindow(activeRecords, startS, endS)
+        val totalInWindow = sumKcalInWindow(totalRecords, startS, endS)
         val fromTotal = if (totalInWindow != null && dayBasalKcal != null) {
             val basalShare = dayBasalKcal * ((endS - startS).toDouble() / 86_400.0)
             (totalInWindow - basalShare).takeIf { it > 0.0 }

--- a/android/app/src/main/java/com/noop/ingest/HealthExportPlan.kt
+++ b/android/app/src/main/java/com/noop/ingest/HealthExportPlan.kt
@@ -4,7 +4,7 @@ package com.noop.ingest
  * Pure (Android-free, HC-SDK-free) planning logic for what NOOP exports INTO Health Connect.
  *
  * Everything here operates on plain Kotlin types so it is unit-testable on the JVM, mirroring
- * [HealthConnectImporter.sumActiveKcalInWindow]. [HealthConnectWriter] turns these descriptors into
+ * [HealthConnectImporter.sumKcalInWindow]. [HealthConnectWriter] turns these descriptors into
  * actual Health Connect records (the untestable SDK glue is kept thin, as in `buildExerciseRecords`).
  *
  * #528 (reimplemented from @sunny-noop): close the export gaps so a strap-only user surfaces the

--- a/android/app/src/test/java/com/noop/ingest/HealthConnectActiveKcalTest.kt
+++ b/android/app/src/test/java/com/noop/ingest/HealthConnectActiveKcalTest.kt
@@ -11,7 +11,10 @@ import org.junit.Test
  */
 class HealthConnectActiveKcalTest {
 
-    private fun rec(start: Long, end: Long, kcal: Double) = Triple(start, end, kcal)
+    // Single-source by default: every pre-#835 assertion below is about one writing app, where
+    // "sum within a source, max across sources" is identical to the old plain sum.
+    private fun rec(start: Long, end: Long, kcal: Double, source: String = "app.a") =
+        HealthConnectImporter.KcalRecord(start, end, kcal, source)
 
     @Test fun noRecordsGivesNull() {
         assertNull(HealthConnectImporter.sumActiveKcalInWindow(emptyList(), 100, 200))
@@ -50,5 +53,78 @@ class HealthConnectActiveKcalTest {
         // Record [150,250] of 100 kcal; session [100,200] overlaps [150,200] = 50 of the 100 s span.
         val recs = listOf(rec(150, 250, 100.0))
         assertEquals(50.0, HealthConnectImporter.sumActiveKcalInWindow(recs, 100, 200)!!, 0.001)
+    }
+
+    // --- #835: cross-source double-count ---
+
+    /** Two apps logging the same ride used to be ADDED. Day totals de-overlap per source (#589); this
+     *  did not, so a phone + watch pair roughly doubled a session. Max across sources, sum within one. */
+    @Test fun twoSourcesOverTheSameSessionAreNotAdded() {
+        val recs = listOf(rec(100, 200, 300.0, "phone"), rec(100, 200, 290.0, "watch"))
+        assertEquals(300.0, HealthConnectImporter.sumActiveKcalInWindow(recs, 100, 200)!!, 0.001)
+    }
+
+    @Test fun recordsWithinOneSourceStillSum_acrossSourcesStillMax() {
+        val recs = listOf(
+            rec(100, 150, 50.0, "phone"), rec(150, 200, 60.0, "phone"),  // one source → 110
+            rec(100, 200, 90.0, "watch"),                                 // other source → 90
+        )
+        assertEquals(110.0, HealthConnectImporter.sumActiveKcalInWindow(recs, 100, 200)!!, 0.001)
+    }
+
+    // --- #835: sessions whose source writes only TotalCaloriesBurned ---
+
+    private fun kcal(active: List<HealthConnectImporter.KcalRecord>,
+                     total: List<HealthConnectImporter.KcalRecord>,
+                     basal: Double?, start: Long, end: Long) =
+        HealthConnectImporter.workoutKcal(active, total, basal, start, end)
+
+    /** The reported shape: the ride's app wrote Total only, so the workout was credited with nothing but
+     *  unrelated background Active. Total minus the window's basal share must win. */
+    @Test fun totalOnlySourceBeatsStrayBackgroundActive() {
+        val h = 3600L
+        val strayActive = listOf(rec(0, 86_400, 240.0, "phone"))     // a whole day → 10 kcal for one hour
+        val sessionTotal = listOf(rec(10_000, 10_000 + h, 700.0, "bike"))
+        // basal 1680/day → 70 for the hour ⇒ 700 − 70 = 630, vs 10 from the stray Active.
+        val got = kcal(strayActive, sessionTotal, 1680.0, 10_000, 10_000 + h)!!
+        assertEquals(630.0, got, 0.001)
+    }
+
+    /** A coarse daily Active record prorates to a uniform slice, which badly understates a hard hour.
+     *  A session-scoped Total record resolves the same hour properly and should win. */
+    @Test fun coarseDailyActiveLosesToSessionScopedTotal() {
+        val h = 3600L
+        val coarseActive = listOf(rec(0, 86_400, 1440.0, "phone"))   // → 60 kcal for the hour
+        val sessionTotal = listOf(rec(10_000, 10_000 + h, 500.0, "bike"))
+        val got = kcal(coarseActive, sessionTotal, 1680.0, 10_000, 10_000 + h)!!
+        assertEquals(430.0, got, 0.001)                               // 500 − 70 basal
+    }
+
+    /** A good Active credit must NOT be replaced — the estimate is a max, never an override. */
+    @Test fun aRealActiveCreditIsKeptWhenItIsTheLarger() {
+        val h = 3600L
+        val goodActive = listOf(rec(10_000, 10_000 + h, 650.0, "bike"))
+        val sessionTotal = listOf(rec(10_000, 10_000 + h, 700.0, "bike"))
+        val got = kcal(goodActive, sessionTotal, 1680.0, 10_000, 10_000 + h)!!
+        assertEquals(650.0, got, 0.001)                               // 650 > 700 − 70 = 630
+    }
+
+    /** Basal must not be able to drive the estimate negative or to zero — nulls out instead. */
+    @Test fun basalLargerThanTotalYieldsNoTotalEstimate() {
+        val h = 3600L
+        val total = listOf(rec(10_000, 10_000 + h, 40.0, "bike"))
+        assertNull(kcal(emptyList(), total, 8640.0, 10_000, 10_000 + h))   // basal share 360 > 40
+    }
+
+    /** No basal known (a day with no Total aggregate) falls back to raw Total rather than nothing. */
+    @Test fun missingBasalFallsBackToRawTotal() {
+        val h = 3600L
+        val total = listOf(rec(10_000, 10_000 + h, 500.0, "bike"))
+        assertEquals(500.0, kcal(emptyList(), total, null, 10_000, 10_000 + h)!!, 0.001)
+    }
+
+    /** Neither stream covering the session is still null — no fabricated number. */
+    @Test fun noCoverageAtAllIsNull() {
+        assertNull(kcal(emptyList(), emptyList(), 1680.0, 10_000, 13_600))
     }
 }

--- a/android/app/src/test/java/com/noop/ingest/HealthConnectActiveKcalTest.kt
+++ b/android/app/src/test/java/com/noop/ingest/HealthConnectActiveKcalTest.kt
@@ -17,27 +17,27 @@ class HealthConnectActiveKcalTest {
         HealthConnectImporter.KcalRecord(start, end, kcal, source)
 
     @Test fun noRecordsGivesNull() {
-        assertNull(HealthConnectImporter.sumActiveKcalInWindow(emptyList(), 100, 200))
+        assertNull(HealthConnectImporter.sumKcalInWindow(emptyList(), 100, 200))
     }
 
     @Test fun aRecordFullyInsideCountsInFull() {
         val recs = listOf(rec(120, 180, 300.0))
-        assertEquals(300.0, HealthConnectImporter.sumActiveKcalInWindow(recs, 100, 200)!!, 0.001)
+        assertEquals(300.0, HealthConnectImporter.sumKcalInWindow(recs, 100, 200)!!, 0.001)
     }
 
     @Test fun aRecordExactlyMatchingTheSessionCountsInFull() {
         val recs = listOf(rec(100, 200, 250.0))
-        assertEquals(250.0, HealthConnectImporter.sumActiveKcalInWindow(recs, 100, 200)!!, 0.001)
+        assertEquals(250.0, HealthConnectImporter.sumKcalInWindow(recs, 100, 200)!!, 0.001)
     }
 
     @Test fun aNonOverlappingRecordIsIgnored() {
         val recs = listOf(rec(300, 400, 500.0))
-        assertNull(HealthConnectImporter.sumActiveKcalInWindow(recs, 100, 200))
+        assertNull(HealthConnectImporter.sumKcalInWindow(recs, 100, 200))
     }
 
     @Test fun multiplePerMinuteRecordsInsideAreSummed() {
         val recs = listOf(rec(100, 160, 60.0), rec(160, 200, 40.0))
-        assertEquals(100.0, HealthConnectImporter.sumActiveKcalInWindow(recs, 100, 200)!!, 0.001)
+        assertEquals(100.0, HealthConnectImporter.sumKcalInWindow(recs, 100, 200)!!, 0.001)
     }
 
     @Test fun aDaySpanningRecordOnlyContributesTheSessionsFraction() {
@@ -45,14 +45,14 @@ class HealthConnectActiveKcalTest {
         val dayStart = 0L
         val dayEnd = 86_400L
         val recs = listOf(rec(dayStart, dayEnd, 1440.0))
-        val sessionKcal = HealthConnectImporter.sumActiveKcalInWindow(recs, 10_000, 13_600)!! // 3600 s = 60 min
+        val sessionKcal = HealthConnectImporter.sumKcalInWindow(recs, 10_000, 13_600)!! // 3600 s = 60 min
         assertEquals(1440.0 * (3600.0 / 86_400.0), sessionKcal, 0.001) // = 60.0
     }
 
     @Test fun partialOverlapIsProRated() {
         // Record [150,250] of 100 kcal; session [100,200] overlaps [150,200] = 50 of the 100 s span.
         val recs = listOf(rec(150, 250, 100.0))
-        assertEquals(50.0, HealthConnectImporter.sumActiveKcalInWindow(recs, 100, 200)!!, 0.001)
+        assertEquals(50.0, HealthConnectImporter.sumKcalInWindow(recs, 100, 200)!!, 0.001)
     }
 
     // --- #835: cross-source double-count ---
@@ -61,7 +61,7 @@ class HealthConnectActiveKcalTest {
      *  did not, so a phone + watch pair roughly doubled a session. Max across sources, sum within one. */
     @Test fun twoSourcesOverTheSameSessionAreNotAdded() {
         val recs = listOf(rec(100, 200, 300.0, "phone"), rec(100, 200, 290.0, "watch"))
-        assertEquals(300.0, HealthConnectImporter.sumActiveKcalInWindow(recs, 100, 200)!!, 0.001)
+        assertEquals(300.0, HealthConnectImporter.sumKcalInWindow(recs, 100, 200)!!, 0.001)
     }
 
     @Test fun recordsWithinOneSourceStillSum_acrossSourcesStillMax() {
@@ -69,7 +69,7 @@ class HealthConnectActiveKcalTest {
             rec(100, 150, 50.0, "phone"), rec(150, 200, 60.0, "phone"),  // one source → 110
             rec(100, 200, 90.0, "watch"),                                 // other source → 90
         )
-        assertEquals(110.0, HealthConnectImporter.sumActiveKcalInWindow(recs, 100, 200)!!, 0.001)
+        assertEquals(110.0, HealthConnectImporter.sumKcalInWindow(recs, 100, 200)!!, 0.001)
     }
 
     // --- #835: sessions whose source writes only TotalCaloriesBurned ---


### PR DESCRIPTION
Fixes #835 (the calories half — the Effort request is tracked separately, see below).

Two bugs in the same credit, pulling opposite ways.

## 1. Under-report

A workout's `energyKcal` came only from `ActiveCaloriesBurned` records overlapping its window, prorated by time. That fails two common shapes:

- **The source writes `TotalCaloriesBurned` and no Active at all.** The ride gets credited with nothing but unrelated background Active that happens to overlap — typically phone step-derived burn. The importer's own comment scoped the assumption: *"Garmin/Fit write ActiveCaloriesBurned as interval records."* Plenty of apps don't.
- **The only Active cover is a coarse record.** One per day is common, and prorating assumes calories burn uniformly, so a hard hour inside a 24 h record reads as **1/24 of the day**. This behaviour was deliberate and tested (`aDaySpanningRecordOnlyContributesTheSessionsFraction`), which is exactly why it survived — and on re-review it's the likelier cause of the report than the Total-only story I first posted on the issue.

Now also derives a candidate from Total: **prorated Total over the window, minus the window's share of the day's basal burn**. Prorating *basal* is sound in a way prorating a workout's active burn is not — basal genuinely is near-uniform. Takes whichever estimate is larger, so a stray background record loses to real session coverage **without needing a magic threshold**, and a good Active credit is never replaced. Null when neither stream covers the session — no fabricated number.

## 2. Double-count

`sumActiveKcalInWindow` summed every overlapping record across **all sources**, so a phone and a watch both logging one ride roughly doubled it. Day totals already de-overlap per source (#589), and the read-site comment claimed the workout credit did too:

> *"...it credits workouts by time-overlap, a separate de-overlap..."*

It didn't. Now sums within a source and takes the max across them, matching the day path. Comment corrected rather than left asserting the old claim.

## Notes

- The upgrade runs as a **post-read pass** because the Total-derived estimate needs the day basal (`total − active`), only known once every record is read. The existing HR and distance passes over `workouts` already work this way.
- **Parity:** Health Connect ingestion is Android-only. I checked for a Swift twin rather than assuming — the one hit is a comment reference in `SleepMerge.swift`. No parity obligation here.
- **Tests:** the six existing assertions are unchanged and still pass — proration and partial overlap are preserved deliberately, since they're right for the uniform case. Eight added covering both bugs, both directions, and the null paths. All ten verified against an independent implementation of the algorithm before commit.
- **Not compiled or run by CI** — `android.yml` is disabled. The helpers are pure and fully covered, so a staging build is what actually exercises this.

## What this does not fix

If a source writes **only** coarse daily records for *both* streams, the estimate is still a prorated slice. There's no data to do better with, and inventing a distribution would be a guess. @bartmuskala's export would show which shape their app writes — asked on the issue.

The Effort-instead-of-calories request needs per-sample HR import from Health Connect (the importer currently collapses `HeartRateRecord` to a per-day average), which is a bigger piece of work — filed separately.
