### PR TITLE
docs: reattach three KDoc blocks that were documenting the wrong thing

### DIFF
--- a/android/app/src/main/java/com/noop/analytics/HrvAnalyzer.kt
+++ b/android/app/src/main/java/com/noop/analytics/HrvAnalyzer.kt
@@ -339,8 +339,9 @@ object HrvAnalyzer {
      *  point of logging the verdict in the first place. Twin of Swift `coveragePlausibleCeiling`. */
     const val COVERAGE_PLAUSIBLE_CEILING: Double = 1.10
 
-    /** Classify a night from its coverage pair. Pure. Byte-parity twin of Swift `classifyCoverage`. */
-    /** Both platforms use the NEGATED `>` form rather than `<=` so a non-finite input lands identically:
+    /** Classify a night from its coverage pair. Pure. Byte-parity twin of Swift `classifyCoverage`.
+     *
+     *  Both platforms use the NEGATED `>` form rather than `<=` so a non-finite input lands identically:
      *  every IEEE-754 comparison with NaN is false, so `<=` and `>` are not each other's inverse there and
      *  the twins would otherwise disagree. NaN falls to UNMEASURABLE on both. */
     fun classifyCoverage(coverage: Double, collapsed: Double): RrCoverageVerdict {

--- a/android/app/src/main/java/com/noop/ble/PuffinExperiment.kt
+++ b/android/app/src/main/java/com/noop/ble/PuffinExperiment.kt
@@ -115,7 +115,6 @@ class PuffinExperiment(private val prefs: SharedPreferences) {
     }
 
     companion object {
-        /** Persisted preferences file. */
         /** Persisted preferences file. Internal so a UI screen can observe external writes to it. */
         internal const val PREFS = "noop_experiments"
 

--- a/android/app/src/main/java/com/noop/ingest/HealthConnectImporter.kt
+++ b/android/app/src/main/java/com/noop/ingest/HealthConnectImporter.kt
@@ -819,7 +819,6 @@ object HealthConnectImporter {
      */
     internal fun maxSourceLong(bySource: Map<String, Long>): Long = bySource.values.maxOrNull() ?: 0L
 
-    /** #589 de-overlap for a per-source calorie map (Double twin of [maxSourceLong]); empty -> 0.0. */
     /** One Health Connect energy record's window + value, tagged with the writing app so the
      *  per-workout credit can de-overlap across sources the way the day totals do (#589, #835). */
     internal data class KcalRecord(
@@ -829,6 +828,7 @@ object HealthConnectImporter {
         val source: String,
     )
 
+    /** #589 de-overlap for a per-source calorie map (Double twin of [maxSourceLong]); empty -> 0.0. */
     internal fun maxSourceDouble(bySource: Map<String, Double>): Double = bySource.values.maxOrNull() ?: 0.0
 
     /**


### PR DESCRIPTION
Kotlin takes only the **last** `/** */` before a declaration as its KDoc. Where two are stacked, the first silently becomes a dangling comment — invisible to Dokka and to IDE hover, while still reading fine to a human scrolling past. That is why these survive review.

Three sites:

| file | detached block | why it matters |
|---|---|---|
| `HrvAnalyzer.classifyCoverage` | *"Byte-parity twin of Swift `classifyCoverage`"* | a **parity-contract** statement, and the parity rule is the first thing in `CLAUDE.md` |
| `PuffinExperiment.PREFS` | *"Persisted preferences file."* | harmless — a strict subset of the block below it |
| `HealthConnectImporter` | *"#589 de-overlap for a per-source calorie map…"* | documented `KcalRecord` instead of `maxSourceDouble`, which lost its docs |

The `HrvAnalyzer` one is the reason this is worth a PR rather than a drive-by: a note asserting byte-parity with the Swift twin should be attached to the function it constrains.

**The third is mine.** I introduced it in #842 this morning by inserting `KcalRecord` between `maxSourceDouble`'s KDoc and `maxSourceDouble` itself — the same mistake I fixed elsewhere in that very PR. Found by sweeping rather than by remembering.

## Verification

**Provably comment-only.** Stripping comments and string literals from each file leaves a byte-identical token stream against `HEAD`:

```
HrvAnalyzer.kt               code identical after stripping comments: True
PuffinExperiment.kt          code identical after stripping comments: True
HealthConnectImporter.kt     code identical after stripping comments: True
```

A repo-wide sweep over `android/**/*.kt`, `Strand/**/*.swift` and `Packages/**/*.swift` now reports **zero** remaining stacked-comment sites.

Two historical copies survive in `docs/superpowers/plans/2026-07-10-android-sleep-stage-timeline.md`. Left deliberately — a dated plan is a record of what was decided then, not a spec to keep current.

## Worth a follow-up

The sweep is ~10 lines and catches a mistake I have now made three times in one day. It does not belong in `i18n-coverage.yml` (wrong concern, and that job is the only thing currently gating PRs), so it needs a home before it can be enforced. Happy to add one if you want it.
