### PR TITLE
ci: gate on doc comments that bind to nothing

### DIFF
--- a/.github/workflows/source-hygiene.yml
+++ b/.github/workflows/source-hygiene.yml
@@ -1,0 +1,40 @@
+# Catches doc comments that bind to nothing, BEFORE merge. Kotlin and Swift attach a doc block to
+# the declaration that FOLLOWS it and keep only the LAST of several stacked ones, so an inserted
+# block or an inserted declaration silently orphans the text above it. Nothing looks wrong: the
+# comment is still there, still above the right function, still correct prose — it just no longer
+# reaches Dokka or IDE hover. That is why review does not catch it.
+#
+# It recurs because it is a side effect of editing by INSERTION rather than in place. #846 fixed
+# three sites in one day, one of which #842 had introduced that same morning, and the block that
+# came adrift was "Byte-parity twin of Swift classifyCoverage" — a parity-contract statement, and
+# parity is the #1 rule in CLAUDE.md. Losing that note is not a cosmetic problem.
+#
+# Pure Python + git, no Xcode/Gradle: runs in seconds on ubuntu-latest, independent of the
+# disabled-by-default app-build.yml / android.yml compile jobs. Same shape as i18n-coverage.yml.
+name: Source Hygiene
+
+on:
+  pull_request:
+    branches: [main]
+  # Audit main itself too, not just PRs into it — a release pushes straight to main with no PR, so a
+  # PR-only trigger would let a regression land unaudited. Same reasoning as i18n-coverage.yml.
+  push:
+    branches: [main]
+
+concurrency:
+  group: source-hygiene-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  doc-comments:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      # Pre-existing sites are grandfathered per-file in Tools/doc_comment_lint_baseline.txt, so this
+      # starts green and fails only on NEW ones. The baseline ratchets DOWN: fixing a site prints an
+      # IMPROVED line telling you to lower the allowance. Raising it to make the job pass defeats the
+      # point — fix the comment instead.
+      - name: Detached doc comments (regression gate)
+        run: python3 Tools/doc_comment_lint.py

--- a/Tools/doc_comment_lint.py
+++ b/Tools/doc_comment_lint.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+"""Catch doc comments that are silently attached to nothing.
+
+Kotlin and Swift both bind a doc comment to the declaration that FOLLOWS it, and both
+take only the LAST one when several are stacked. So a doc block can end up documenting
+nothing at all while still reading correctly to a human scrolling past the file — the
+text is right there, above the right function, in the right order. That is exactly why
+this class of mistake survives review: nothing looks wrong.
+
+It is caused by editing by INSERTION rather than in place — adding a new block above an
+existing one, or dropping a new declaration into the gap between a comment and the thing
+it documents. Both happened repeatedly in one day (#846 fixed three sites, one of which
+had been introduced by #842 that same morning), which is why this exists.
+
+Two patterns, both of which detach the FIRST block:
+
+    /** Byte-parity twin of Swift `classifyCoverage`. */   <- becomes a dangling comment
+    /** Both platforms use the NEGATED `>` form ... */     <- this one is the KDoc
+    fun classifyCoverage(...)
+
+    /** Persisted preferences file. */
+
+    internal const val PREFS = "..."                       <- blank line detaches the doc
+
+The cost is not cosmetic when the detached text is load-bearing. In #846 the block that
+came adrift was a parity-contract statement, and the parity rule is the first thing in
+CLAUDE.md — precisely the note you want attached to the function it constrains.
+
+Pre-existing sites are grandfathered in Tools/doc_comment_lint_baseline.txt so the gate
+starts green and blocks only NEW ones. It ratchets DOWN: fixing a baselined site prints an
+IMPROVED line so the allowance can be lowered.
+
+Usage:  python3 Tools/doc_comment_lint.py
+Exit 0 when no file exceeds its allowance, 1 otherwise (with file:line for each).
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+
+GLOBS = ("android/**/*.kt", "Strand/**/*.swift", "Packages/**/*.swift", "NOOPWatch/**/*.swift")
+
+# A doc block sitting above these is a FILE header, not a declaration doc — the blank line
+# after it is conventional and correct, so it must not be reported.
+FILE_LEVEL_PREFIXES = ("package ", "import ", "@file:")
+
+SKIP_PARTS = ("/build/", "/.build/", "/DerivedData/")
+
+
+def _is_doc_open(line: str) -> bool:
+    """A doc-comment opener: `/**`, but not the empty block `/**/`."""
+    s = line.strip()
+    return s.startswith("/**") and s != "/**/"
+
+
+def findings(path: Path) -> list[tuple[int, str]]:
+    """(1-indexed line, reason) for every detached doc block in one file."""
+    lines = path.read_text(errors="ignore").splitlines()
+    out: list[tuple[int, str]] = []
+    i = 0
+    while i < len(lines):
+        if not _is_doc_open(lines[i]):
+            i += 1
+            continue
+        start = i
+        # Walk to the block's close. A single-line `/** … */` closes on its own line.
+        end = start
+        if not lines[start].strip().endswith("*/") or lines[start].strip() == "/**":
+            end += 1
+            while end < len(lines) and not lines[end].strip().endswith("*/"):
+                end += 1
+            if end >= len(lines):
+                break  # unterminated block — a compile error, not this tool's business
+
+        nxt = end + 1
+        if nxt < len(lines):
+            after = lines[nxt].strip()
+            if _is_doc_open(lines[nxt]):
+                out.append((start + 1, "stacked: the block below it wins, this one documents nothing"))
+            elif after == "":
+                # Blank line, then a real declaration ⇒ detached. A file header is exempt.
+                follow = nxt + 1
+                while follow < len(lines) and lines[follow].strip() == "":
+                    follow += 1
+                if follow < len(lines):
+                    code = lines[follow].strip()
+                    is_header = code.startswith(FILE_LEVEL_PREFIXES)
+                    is_comment = code.startswith(("//", "/*", "*"))
+                    if code and not is_header and not is_comment:
+                        out.append((start + 1, "blank line before the declaration detaches it"))
+        i = end + 1
+    return out
+
+
+BASELINE = ROOT / "Tools/doc_comment_lint_baseline.txt"
+
+
+def read_baseline() -> dict[str, int]:
+    """`path -> allowed count` of pre-existing sites.
+
+    Counts, not line numbers: line numbers churn on every edit above them, so a
+    line-keyed baseline would go stale constantly and train people to regenerate it
+    without looking. A count only moves when someone adds or removes a site, which is
+    exactly the event worth gating on. It ratchets DOWN — fixing sites below the
+    allowance is reported so the entry can be lowered.
+    """
+    if not BASELINE.exists():
+        return {}
+    out: dict[str, int] = {}
+    for raw in BASELINE.read_text().splitlines():
+        line = raw.split("#", 1)[0].strip()
+        if not line:
+            continue
+        path, _, count = line.rpartition(" ")
+        out[path.strip()] = int(count)
+    return out
+
+
+def main() -> int:
+    baseline = read_baseline()
+    by_file: dict[str, list[str]] = {}
+    scanned = 0
+    for glob in GLOBS:
+        for path in sorted(ROOT.glob(glob)):
+            if any(p in str(path) for p in SKIP_PARTS):
+                continue
+            scanned += 1
+            found = findings(path)
+            if found:
+                rel = str(path.relative_to(ROOT))
+                by_file[rel] = [f"{rel}:{ln}  {why}" for ln, why in found]
+
+    regressions = [h for f, hs in sorted(by_file.items())
+                   for h in hs if len(hs) > baseline.get(f, 0)]
+    improved = [(f, baseline[f], len(by_file.get(f, [])))
+                for f in sorted(baseline) if len(by_file.get(f, [])) < baseline[f]]
+
+    for f, was, now in improved:
+        print(f"IMPROVED {f}: {was} -> {now}. Lower it in {BASELINE.name}"
+              + (" (or drop the line)." if now == 0 else "."))
+
+    if regressions:
+        print(f"\nFAIL {len(regressions)} detached doc comment(s) beyond the baseline:\n")
+        for h in regressions:
+            print(f"  {h}")
+        print(
+            "\nBoth patterns leave the text readable but bound to nothing — Dokka and IDE\n"
+            "hover will not show it. Merge the blocks, or move the inserted declaration\n"
+            "above the doc. Do NOT raise the baseline to make this pass."
+        )
+        return 1
+
+    total = sum(len(v) for v in by_file.values())
+    print(f"OK no NEW detached doc comments ({scanned} files, {total} baselined site(s) remaining)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/Tools/doc_comment_lint_baseline.txt
+++ b/Tools/doc_comment_lint_baseline.txt
@@ -1,0 +1,18 @@
+# Pre-existing detached doc comments, grandfathered so the gate starts green.
+# Format: <path> <count>.  The gate fails when a file EXCEEDS its count, or when a
+# file not listed here has any. Ratchet DOWN as they are fixed — never up.
+# Generated at the time Tools/doc_comment_lint.py landed; see #846 for the pattern.
+
+android/app/src/main/java/com/noop/analytics/AnalyticsEngine.kt 1
+android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt 5
+android/app/src/main/java/com/noop/ble/WhoopBleClient.kt 8
+android/app/src/main/java/com/noop/ble/WhoopConnectionService.kt 1
+android/app/src/main/java/com/noop/ingest/CaptureImporter.kt 1
+android/app/src/main/java/com/noop/protocol/PpgHr.kt 1
+android/app/src/main/java/com/noop/ui/AddDeviceWizard.kt 1
+android/app/src/main/java/com/noop/ui/AppViewModel.kt 1
+android/app/src/main/java/com/noop/ui/BackupSyncScreen.kt 1
+android/app/src/main/java/com/noop/ui/Components.kt 1
+android/app/src/main/java/com/noop/ui/HealthVitalDetailLogic.kt 1
+android/app/src/main/java/com/noop/ui/TodayScreen.kt 1
+android/app/src/main/java/com/noop/ui/WorkoutsScreen.kt 2


### PR DESCRIPTION
Follow-up to #846.

## Why gate rather than just fix

Kotlin and Swift attach a doc block to the declaration that **follows** it, and keep only the **last** of several stacked ones. Insert a block above an existing one — or a declaration into the gap between a comment and the thing it documents — and the text is silently orphaned.

Nothing looks wrong on review. The prose is still there, still above the right function, still correct. It just no longer reaches Dokka or IDE hover. That is exactly why it survives.

#846 fixed three sites in one day, **one of which #842 had introduced that same morning**, and the block that came adrift was *"Byte-parity twin of Swift `classifyCoverage`"* — a parity-contract statement, with parity being the first rule in `CLAUDE.md`. Not a cosmetic loss.

## Correcting #846

That PR claimed the tree was clean afterwards. **It wasn't.** My sweep only matched *single-line* blocks. A scanner handling multi-line blocks finds **25 more pre-existing sites across 13 files** — 8 in `WhoopBleClient.kt` alone. `AppViewModel.kt:68` is a class doc detached by an inserted `data class`: the same shape as my #842 slip. Corrected on that PR too.

## The baseline, and why it's counts

Those 25 are grandfathered per-file so the gate **starts green** and blocks only new ones.

Keyed by **count, not line number**. Line numbers churn on every edit above them, so a line-keyed baseline goes stale constantly and trains people to regenerate it without looking. A count moves only when someone adds or removes a site — precisely the event worth gating on. It ratchets **down**: fixing a site prints an `IMPROVED` line asking for the allowance to be lowered.

## Verification

Three ways, because a gate that never fires is worthless:

```
1. clean main            -> exit 0   "no NEW detached doc comments (1386 files, 25 baselined)"
2. all three pre-#846 sites reconstructed  -> caught 3/3
3a. new site, unbaselined file           -> exit 1
3b. EXTRA site in an already-baselined file -> exit 1   (count enforced, not mere presence)
```

3b is the one that matters — a presence-only baseline would let `WhoopBleClient.kt` grow from 8 to 80 unnoticed.

## Cost

Pure Python + git on ubuntu, seconds. No Xcode, no Gradle — so unlike the app-target and Android checks it actually runs, given `app-build.yml` and `android.yml` are disabled. Same shape and triggers as `i18n-coverage.yml`, including auditing pushes to `main` so a release landing without a PR is still covered.

New workflow rather than a step in `i18n-coverage.yml`: different concern, and that job is currently the only thing gating PRs — I'd rather not have a docs regression report itself as an i18n failure.

## Not included

Fixing the 25. Each needs a judgement call about how to merge the two blocks, and doing 25 of those at volume is how the mistake gets made in the first place. The baseline makes them visible and burnable-down without blocking anyone.
