### PR TITLE
ci(i18n): cover every shipped locale, not the four in a constant

### DIFF
--- a/Tools/i18n_audit.py
+++ b/Tools/i18n_audit.py
@@ -471,6 +471,12 @@ def scan_android() -> list[tuple[str, int, str]]:
     return findings
 
 
+# Keys that are deliberately identical in every language, so their absence from a locale file is not
+# a gap. ONE definition: both the hard-gated focus locales and the #844 discovered ones subtract this,
+# and a second copy would let the two paths disagree the moment anyone adds a key here.
+ANDROID_EXEMPT_KEYS = {"app_name"}  # brand name
+
+
 def android_strings_xml_gaps() -> dict[str, set[str]]:
     """Keys present in the base values/strings.xml but missing from an
     existing values-<locale>/strings.xml. (Doesn't invent missing locale dirs —
@@ -480,7 +486,6 @@ def android_strings_xml_gaps() -> dict[str, set[str]]:
     # otherwise DROP those keys out of this gate's view entirely, so a locale could silently lose them —
     # fixing the plural model must not open a coverage hole (see #540 for the same class of blind spot).
     base_keys = set(re.findall(r'<(?:string|plurals) name="([^"]+)"', base_path.read_text(encoding="utf-8")))
-    exempt = {"app_name"}  # brand name, deliberately identical everywhere
     gaps: dict[str, set[str]] = {}
     for lang in LANGS:
         locale_dir = ANDROID_LOCALE_DIRS[lang]
@@ -489,7 +494,7 @@ def android_strings_xml_gaps() -> dict[str, set[str]]:
             gaps[lang] = {"<entire %s/ directory is missing>" % locale_dir}
             continue
         lang_keys = set(re.findall(r'<(?:string|plurals) name="([^"]+)"', lang_path.read_text(encoding="utf-8")))
-        missing = (base_keys - exempt) - lang_keys
+        missing = (base_keys - ANDROID_EXEMPT_KEYS) - lang_keys
         if missing:
             gaps[lang] = missing
     return gaps
@@ -1002,8 +1007,18 @@ def ci_check(base_ref: str) -> int:
     ios_fixed = baseline["ios"] - ios_found
     if ios_fixed:
         print(f"  {len(ios_fixed)} baseline entr(y/ies) no longer found — run --update-baseline to shrink the backlog")
+    allowance = extra_locale_allowance()
+    extra_apple_gaps: dict[str, int] = {}
     for _dirs, catalog_path in CATALOGS:
         cat = load_catalog(catalog_path)
+        # #844: count the shipped locales OUTSIDE the focus set while the catalog is already parsed,
+        # and gate them below. Reloading each catalog for a second pass wasted a full re-parse of a
+        # 3255-string file.
+        for extra in sorted(shipped_apple_langs(cat) - set(LANGS)):
+            extra_apple_gaps[f"{catalog_path.relative_to(ROOT)}:{extra}"] = sum(
+                1 for v in cat.get("strings", {}).values()
+                if v.get("shouldTranslate") is not False and not _is_translated(v, extra)
+            )
         for lang in LANGS:
             missing = sum(
                 1 for v in cat.get("strings", {}).values()
@@ -1023,23 +1038,14 @@ def ci_check(base_ref: str) -> int:
     # tolerance; these carry real pre-existing debt (StrandDesign ships 14 of 95 Italian), so the gate
     # blocks GROWTH rather than demanding the backlog be cleared before anyone can merge.
     print("\n--- Locales beyond the focus set: no NEW gaps (ratcheting allowance) ---")
-    allowance = extra_locale_allowance()
     improved: list[str] = []
-    for _dirs, catalog_path in CATALOGS:
-        cat = load_catalog(catalog_path)
-        rel = str(catalog_path.relative_to(ROOT))
-        for lang in sorted(shipped_apple_langs(cat) - set(LANGS)):
-            missing = sum(
-                1 for v in cat.get("strings", {}).values()
-                if v.get("shouldTranslate") is not False and not _is_translated(v, lang)
-            )
-            target = f"{rel}:{lang}"
-            allowed = allowance.get(target, 0)
-            if missing > allowed:
-                failed = True
-                print(f"FAIL {target}: missing={missing} exceeds the allowance of {allowed}")
-            elif missing < allowed:
-                improved.append(f"{target}: {allowed} -> {missing}")
+    for target, missing in sorted(extra_apple_gaps.items()):
+        allowed = allowance.get(target, 0)
+        if missing > allowed:
+            failed = True
+            print(f"FAIL {target}: missing={missing} exceeds the allowance of {allowed}")
+        elif missing < allowed:
+            improved.append(f"{target}: {allowed} -> {missing}")
     base_path = ROOT / "android/app/src/main/res/values/strings.xml"
     base_keys = set(re.findall(r'<(?:string|plurals) name="([^"]+)"', base_path.read_text(encoding="utf-8")))
     for locale_dir in shipped_android_locale_dirs():
@@ -1047,7 +1053,7 @@ def ci_check(base_ref: str) -> int:
             continue   # already hard-gated above
         lang_path = ROOT / f"android/app/src/main/res/{locale_dir}/strings.xml"
         lang_keys = set(re.findall(r'<(?:string|plurals) name="([^"]+)"', lang_path.read_text(encoding="utf-8")))
-        missing = len((base_keys - {"app_name"}) - lang_keys)
+        missing = len((base_keys - ANDROID_EXEMPT_KEYS) - lang_keys)
         target = f"{locale_dir}/strings.xml"
         allowed = allowance.get(target, 0)
         if missing > allowed:
@@ -1088,7 +1094,7 @@ def main() -> int:
     ap.add_argument("--platform", choices=["ios", "android", "all"], default="all")
     ap.add_argument("--full", action="store_true", help="print every finding, not just counts")
     ap.add_argument("--ci", metavar="BASE_REF", help="strict coverage gate (BASE_REF is retained for workflow compatibility); see ci_check() docstring")
-    ap.add_argument("--update-baseline", action="store_true", help="rewrite Tools/i18n_audit_baseline.json from the current hardcoded-literal scan (see load_baseline() docstring)")
+    ap.add_argument("--update-baseline", action="store_true", help="rewrite Tools/i18n_audit_baseline.json from the current hardcoded-literal scan (see load_baseline() docstring). Does NOT touch Tools/i18n_extra_locale_baseline.txt — that one is lowered by hand, so shrinking it stays a deliberate act")
     args = ap.parse_args()
 
     if args.update_baseline:

--- a/Tools/i18n_audit.py
+++ b/Tools/i18n_audit.py
@@ -861,6 +861,55 @@ def scan_ios() -> tuple[list[tuple[str, int, str]], dict[str, list[str]]]:
     return hardcoded, lang_gaps
 
 
+# Languages the audit hard-gates at ZERO missing keys. Historically the ONLY languages it looked at
+# — which is why they sit at 100% while everything else drifted. Unchanged here: still zero tolerance.
+#
+# Every OTHER shipped locale is discovered below and gated against a ratcheting allowance instead, so
+# switching coverage on does not red-check every open PR with hundreds of pre-existing gaps (#844).
+EXTRA_LOCALE_BASELINE_PATH = ROOT / "Tools/i18n_extra_locale_baseline.txt"
+
+
+def shipped_apple_langs(cat: dict) -> set[str]:
+    """Every non-English localization the catalog actually carries.
+
+    Read from the catalog rather than a constant so a language is covered the day it appears. The
+    hardcoded LANGS is what let `it`, `ru`, `zh-Hans` and `zh-Hant` ship for months at up to 85%
+    untranslated while the audit reported green (#844).
+    """
+    langs: set[str] = set()
+    for v in cat.get("strings", {}).values():
+        langs |= set((v.get("localizations") or {}).keys())
+    return langs - {"en"}
+
+
+def shipped_android_locale_dirs() -> list[str]:
+    """Every `values-<locale>` directory on disk, not just the four in ANDROID_LOCALE_DIRS.
+
+    `values-zh` has existed and been unchecked long enough to fall 43 keys behind (#844).
+    """
+    res = ROOT / "android/app/src/main/res"
+    return sorted(d.name for d in res.glob("values-*") if (d / "strings.xml").exists())
+
+
+def extra_locale_allowance() -> dict[str, int]:
+    """`target -> allowed missing count` for the newly-covered locales.
+
+    Counts rather than key lists, for the same reason as Tools/doc_comment_lint_baseline.txt: a key
+    list goes stale on every edit and trains people to regenerate it unread, while a count moves only
+    when someone adds or removes a gap. Ratchets DOWN — closing gaps prints an IMPROVED line.
+    """
+    if not EXTRA_LOCALE_BASELINE_PATH.exists():
+        return {}
+    out: dict[str, int] = {}
+    for raw in EXTRA_LOCALE_BASELINE_PATH.read_text(encoding="utf-8").splitlines():
+        line = raw.split("#", 1)[0].strip()
+        if not line:
+            continue
+        target, _, count = line.rpartition(" ")
+        out[target.strip()] = int(count)
+    return out
+
+
 BASELINE_PATH = ROOT / "Tools/i18n_audit_baseline.json"
 
 
@@ -969,6 +1018,48 @@ def ci_check(base_ref: str) -> int:
             if format_gaps:
                 failed = True
                 print(f"FAIL {catalog_path.relative_to(ROOT)} {lang}: {len(format_gaps)} format mismatch(es): {format_gaps[:10]}")
+
+    # #844: every OTHER shipped locale, gated against a ratcheting allowance. LANGS above stays at zero
+    # tolerance; these carry real pre-existing debt (StrandDesign ships 14 of 95 Italian), so the gate
+    # blocks GROWTH rather than demanding the backlog be cleared before anyone can merge.
+    print("\n--- Locales beyond the focus set: no NEW gaps (ratcheting allowance) ---")
+    allowance = extra_locale_allowance()
+    improved: list[str] = []
+    for _dirs, catalog_path in CATALOGS:
+        cat = load_catalog(catalog_path)
+        rel = str(catalog_path.relative_to(ROOT))
+        for lang in sorted(shipped_apple_langs(cat) - set(LANGS)):
+            missing = sum(
+                1 for v in cat.get("strings", {}).values()
+                if v.get("shouldTranslate") is not False and not _is_translated(v, lang)
+            )
+            target = f"{rel}:{lang}"
+            allowed = allowance.get(target, 0)
+            if missing > allowed:
+                failed = True
+                print(f"FAIL {target}: missing={missing} exceeds the allowance of {allowed}")
+            elif missing < allowed:
+                improved.append(f"{target}: {allowed} -> {missing}")
+    base_path = ROOT / "android/app/src/main/res/values/strings.xml"
+    base_keys = set(re.findall(r'<(?:string|plurals) name="([^"]+)"', base_path.read_text(encoding="utf-8")))
+    for locale_dir in shipped_android_locale_dirs():
+        if locale_dir in ANDROID_LOCALE_DIRS.values():
+            continue   # already hard-gated above
+        lang_path = ROOT / f"android/app/src/main/res/{locale_dir}/strings.xml"
+        lang_keys = set(re.findall(r'<(?:string|plurals) name="([^"]+)"', lang_path.read_text(encoding="utf-8")))
+        missing = len((base_keys - {"app_name"}) - lang_keys)
+        target = f"{locale_dir}/strings.xml"
+        allowed = allowance.get(target, 0)
+        if missing > allowed:
+            failed = True
+            print(f"FAIL {target}: missing={missing} exceeds the allowance of {allowed}")
+        elif missing < allowed:
+            improved.append(f"{target}: {allowed} -> {missing}")
+    for line in improved:
+        print(f"  IMPROVED {line}. Lower it in {EXTRA_LOCALE_BASELINE_PATH.name}.")
+    if not failed:
+        tracked = sum(allowance.values())
+        print(f"  OK no new gaps in the non-focus locales ({tracked} tracked, ratcheting down)")
 
     return 1 if failed else 0
 

--- a/Tools/i18n_audit.py
+++ b/Tools/i18n_audit.py
@@ -1038,11 +1038,18 @@ def ci_check(base_ref: str) -> int:
     # tolerance; these carry real pre-existing debt (StrandDesign ships 14 of 95 Italian), so the gate
     # blocks GROWTH rather than demanding the backlog be cleared before anyone can merge.
     print("\n--- Locales beyond the focus set: no NEW gaps (ratcheting allowance) ---")
+    # Local, NOT the global `failed`: an earlier section failing (a German string, an un-extracted
+    # literal) must not silence this section's own verdict. Reporting nothing here reads as "did not
+    # run", which is the worst thing a gate can say to someone trying to understand a red build.
+    locale_failed = False
     improved: list[str] = []
+    seen_targets: set[str] = set()
     for target, missing in sorted(extra_apple_gaps.items()):
+        seen_targets.add(target)
         allowed = allowance.get(target, 0)
         if missing > allowed:
             failed = True
+            locale_failed = True
             print(f"FAIL {target}: missing={missing} exceeds the allowance of {allowed}")
         elif missing < allowed:
             improved.append(f"{target}: {allowed} -> {missing}")
@@ -1055,15 +1062,21 @@ def ci_check(base_ref: str) -> int:
         lang_keys = set(re.findall(r'<(?:string|plurals) name="([^"]+)"', lang_path.read_text(encoding="utf-8")))
         missing = len((base_keys - ANDROID_EXEMPT_KEYS) - lang_keys)
         target = f"{locale_dir}/strings.xml"
+        seen_targets.add(target)
         allowed = allowance.get(target, 0)
         if missing > allowed:
             failed = True
+            locale_failed = True
             print(f"FAIL {target}: missing={missing} exceeds the allowance of {allowed}")
         elif missing < allowed:
             improved.append(f"{target}: {allowed} -> {missing}")
+    # An allowance for a target that no longer exists (locale removed, catalog dropped) can never be
+    # satisfied and silently inflates the tracked total, so surface it rather than let it rot.
+    for stale in sorted(set(allowance) - seen_targets):
+        print(f"  STALE {stale} is no longer present — drop it from {EXTRA_LOCALE_BASELINE_PATH.name}.")
     for line in improved:
         print(f"  IMPROVED {line}. Lower it in {EXTRA_LOCALE_BASELINE_PATH.name}.")
-    if not failed:
+    if not locale_failed:
         tracked = sum(allowance.values())
         print(f"  OK no new gaps in the non-focus locales ({tracked} tracked, ratcheting down)")
 

--- a/Tools/i18n_audit.py
+++ b/Tools/i18n_audit.py
@@ -1090,7 +1090,11 @@ def catalog_summary() -> None:
         strings = cat.get("strings", {})
         total = len(strings)
         line = f"{catalog_path.relative_to(ROOT)} ({total} keys):"
-        for lang in LANGS:
+        # #844: report every locale the catalog actually ships, not just the focus four. Showing only
+        # LANGS is very likely WHY the drift went unnoticed for so long — this summary read 100% across
+        # the board while `it` sat at 14 of 95. The gate and the human-readable view must see the same
+        # set, or the view quietly reassures you about languages nobody is checking.
+        for lang in sorted(set(LANGS) | shipped_apple_langs(cat)):
             missing = 0
             for v in strings.values():
                 if v.get("shouldTranslate") is False:

--- a/Tools/i18n_extra_locale_baseline.txt
+++ b/Tools/i18n_extra_locale_baseline.txt
@@ -1,0 +1,21 @@
+# Pre-existing gaps in locales the audit did not previously cover (#844), grandfathered so the
+# gate starts green and blocks only NEW ones. Format: <target> <allowed-missing>.
+# Ratchet DOWN as translations land — never up. de/es/fr/pt-PT are NOT here: they stay at zero
+# tolerance in LANGS, which is why they are at 100%.
+
+Packages/StrandDesign/Sources/StrandDesign/Resources/Localizable.xcstrings:it 81
+Packages/StrandDesign/Sources/StrandDesign/Resources/Localizable.xcstrings:ru 54
+Packages/StrandDesign/Sources/StrandDesign/Resources/Localizable.xcstrings:zh-Hans 75
+Packages/StrandDesign/Sources/StrandDesign/Resources/Localizable.xcstrings:zh-Hant 81
+NOOPWatch/Localizable.xcstrings:it 3
+NOOPWatch/Localizable.xcstrings:ru 2
+NOOPWatch/Localizable.xcstrings:zh-Hans 3
+NOOPWatch/Localizable.xcstrings:zh-Hant 3
+NOOPWatchComplications/Localizable.xcstrings:it 25
+NOOPWatchComplications/Localizable.xcstrings:zh-Hans 25
+NOOPWatchComplications/Localizable.xcstrings:zh-Hant 25
+Strand/Resources/Localizable.xcstrings:it 168
+Strand/Resources/Localizable.xcstrings:ru 145
+Strand/Resources/Localizable.xcstrings:zh-Hans 118
+Strand/Resources/Localizable.xcstrings:zh-Hant 168
+values-zh/strings.xml 43


### PR DESCRIPTION
Implements #844.

## The gate covered half the shipped languages

`Tools/i18n_audit.py:34` is `LANGS = ["de", "es", "fr", "pt-PT"]`. The Apple catalogs ship **eight** non-English localizations.

| catalog | de/es/fr/pt-PT | it | ru | zh-Hans | zh-Hant |
|---|---|---|---|---|---|
| `Strand` (3255 keys) | 100 % | 3086 | 3110 | 3136 | 3086 |
| `StrandDesign` (95) | 100 % | **14** | 41 | **20** | **14** |
| `NOOPWatch` (52) | 100 % | 49 | 50 | 49 | 49 |
| `NOOPWatchComplications` (30) | 100 % | **5** | 30 | **5** | **5** |

The four gated languages are at 100 % in every catalog. The four ungated ones are missing up to **85 %** — `StrandDesign` ships 14 of 95 Italian, the watch complications 5 of 30. That is the gate doing its job where it is pointed, and nothing happening where it is not.

Android is the same shape: `ANDROID_LOCALE_DIRS` hardcodes the same four, `values-zh` exists on disk, is never compared, and sits 43 keys behind. That is how #834 passed CI while adding a key to four of five locale files.

## The fix

Both lists are **discovered** rather than declared — Apple languages from the union of each catalog's own `localizations`, Android dirs from `values-*` on disk. A locale is covered the day it appears, not the day someone remembers to update a constant.

**`LANGS` keeps zero tolerance and is untouched.** Those four are perfect precisely because they are hard-gated, and this must not regress that.

The newly-covered locales carry **1019 real pre-existing gaps**, so they gate against a ratcheting allowance. Switching them on hard would red-check every open PR on lines nobody touched — the exact #514 failure this workflow's own comments warn about. Counts rather than key lists, same reasoning as `doc_comment_lint_baseline.txt` (#849): a key list goes stale on every edit and trains people to regenerate it unread. It ratchets **down**, printing `IMPROVED` when a count drops.

## Verification

```
green on main                                            -> exit 0  (1019 tracked)
remove one values-zh key            (43 -> 44)           -> exit 1
remove one StrandDesign Italian string (81 -> 82)        -> exit 1
remove one values-de key                                 -> exit 1  (zero tolerance intact)
```

The last one matters most: this touches the only job currently gating PRs, so the existing hard behaviour had to be shown unchanged.

Worth noting my first probe *didn't* fire — it had removed `app_name`, which is explicitly exempt. The gate was right and the test was wrong; re-run with a real key it fails as intended.

## What this deliberately doesn't do

It translates nothing. It stops the hole growing and makes the debt countable. Whether `it`/`ru`/`zh-*` should ship at 14/95 or be withheld until filled is a product call — I'd rather you make it than have it implied by a linter.
