### PR TITLE
fix(health): feed the Android body clock, closing a live cross-platform gap

### DIFF
--- a/android/app/src/main/java/com/noop/analytics/V5HealthSignals.kt
+++ b/android/app/src/main/java/com/noop/analytics/V5HealthSignals.kt
@@ -57,6 +57,8 @@ object V5HealthSignals {
         loggedPeriodStarts: List<String> = emptyList(),
         journalContext: IllnessSignalEngine.Context = IllnessSignalEngine.Context(),
         habitualWakeHour: Double = 7.0,
+        activityBins: List<CircadianEngine.ActivityBin> = emptyList(),
+        daysObserved: Int = 0,
     ): Snapshot {
         val baselineTrusted = days.count { hasAnyVital(it) } >= MIN_BASELINE_NIGHTS
 
@@ -126,14 +128,28 @@ object V5HealthSignals {
             correlation = null,
         )
 
-        // ── Body clock: needs per-hour rest-activity bins we don't bank here; the planner is on-demand.
-        //    Leave null so the BodyClockCard reads its honest "Calibrating" empty state until a future
-        //    activity-bin source lands (the engine is wired + ready, the input pipe is the gap). ──
-        val bodyClock: CircadianEngine.PhaseEstimate? = null
+        // ── Body clock (#852): the caller pools HR by local hour into [activityBins] — the same
+        //    activity proxy the Swift twin uses in AppModel.computeCircadianPhase, which has shipped
+        //    this card on iOS/macOS all along. Android had the engine, the tests and the card, and only
+        //    ever lacked these twenty lines of input, behind a comment claiming the data did not exist.
+        //
+        //    Under six populated hours is too thin to fit, so it stays null and HealthScreen's `?.let`
+        //    skips the card — no fabricated estimate. Both parameters default, so every existing caller
+        //    is byte-identical. ──
+        val bodyClock: CircadianEngine.PhaseEstimate? =
+            if (activityBins.size >= MIN_CIRCADIAN_BINS) {
+                CircadianEngine.estimatePhase(activityBins, daysObserved, habitualWakeHour)
+            } else {
+                null
+            }
 
         return Snapshot(cycle = cycle, bodyClock = bodyClock, illness = illness,
             illnessDistance = illnessDistance, baselineTrusted = baselineTrusted)
     }
+
+    /** Populated local hours needed before a cosinor fit is worth attempting. Mirrors the Swift
+     *  twin's `guard bins.count >= 6` in AppModel.computeCircadianPhase. */
+    internal const val MIN_CIRCADIAN_BINS = 6
 
     /** A day is "usable" for the baseline if it carries at least one of the four illness/cycle vitals. */
     private fun hasAnyVital(d: DailyMetric): Boolean =

--- a/android/app/src/main/java/com/noop/ui/AppViewModel.kt
+++ b/android/app/src/main/java/com/noop/ui/AppViewModel.kt
@@ -415,7 +415,11 @@ class AppViewModel(app: Application) : AndroidViewModel(app) {
     private suspend fun circadianActivityBins(): Pair<List<CircadianEngine.ActivityBin>, Int> {
         val now = System.currentTimeMillis() / 1000L
         val from = now - 14L * 86_400L
-        val buckets = runCatching { repository.hrBuckets(deviceId, from, now, 3_600L) }
+        // hrBucketsUnion, not hrBuckets: the Swift twin's `repo.hrBuckets(from:to:)` UNIONs the active
+        // strap with the canonical "my-whoop" (#814 read spine). Reading one id here would give Android
+        // strictly less data than Apple after a strap re-add — enough to miss the 24-bucket floor and
+        // render no estimate where Swift renders one. Single-WHOOP install resolves to one id either way.
+        val buckets = runCatching { repository.hrBucketsUnion(deviceId, from, now, 3_600L) }
             .getOrDefault(emptyList())
         val tz = TimeZone.getDefault().getOffset(now * 1000L) / 1000L
         return circadianBinsFrom(buckets, tz)

--- a/android/app/src/main/java/com/noop/ui/AppViewModel.kt
+++ b/android/app/src/main/java/com/noop/ui/AppViewModel.kt
@@ -14,6 +14,7 @@ import com.noop.analytics.HrZones
 import com.noop.analytics.IllnessSignalEngine
 import com.noop.analytics.IllnessWatch
 import com.noop.analytics.IntelligenceEngine
+import com.noop.analytics.CircadianEngine
 import com.noop.analytics.V5HealthSignals
 import com.noop.analytics.RegistryDayOwnerSource
 import com.noop.analytics.RestScorer
@@ -64,6 +65,7 @@ import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import kotlin.math.roundToInt
+import java.util.TimeZone
 
 /**
  * The single app-wide view model. Holds the BLE client and the Room-backed
@@ -75,6 +77,35 @@ import kotlin.math.roundToInt
 /** Last Health Connect writeback outcome for the Data Sources UI (#660). [code] is a PII-safe
  *  category (see [NoopPrefs.HC_WB_OK] etc.); "" = never attempted. */
 data class HcWritebackStatus(val code: String, val atMs: Long, val written: Int)
+
+/**
+ * The pure half of the body-clock binning (#852): hourly HR buckets + a timezone offset -> a per-hour
+ * activity profile and the number of distinct local days it spans.
+ *
+ * Separated from the store read so it is unit-testable with no Context, no ViewModel and no database.
+ * Byte-for-byte mirror of the maths in Swift `AppModel.computeCircadianPhase`: the >= 24-bucket floor,
+ * pooling by LOCAL hour-of-day, mean bpm per populated hour, and distinct local days as `daysObserved`.
+ */
+internal fun circadianBinsFrom(
+    buckets: List<com.noop.data.HrBucket>,
+    tzOffsetSeconds: Long,
+): Pair<List<CircadianEngine.ActivityBin>, Int> {
+    if (buckets.size < 24) return emptyList<CircadianEngine.ActivityBin>() to 0
+    val sums = DoubleArray(24)
+    val counts = IntArray(24)
+    val days = HashSet<Long>()
+    for (b in buckets) {
+        val local = b.bucket + tzOffsetSeconds
+        val hour = (((local % 86_400L) + 86_400L) % 86_400L / 3_600L).toInt()
+        sums[hour] += b.avgBpm
+        counts[hour] += 1
+        days.add(local / 86_400L)
+    }
+    val bins = (0 until 24).mapNotNull { h ->
+        if (counts[h] > 0) CircadianEngine.ActivityBin(h.toDouble(), sums[h] / counts[h]) else null
+    }
+    return bins to days.size
+}
 
 class AppViewModel(app: Application) : AndroidViewModel(app) {
 
@@ -363,6 +394,32 @@ class AppViewModel(app: Application) : AndroidViewModel(app) {
      *  workout union can follow a re-paired strap's fresh "whoop-<id>" instead of stranding its
      *  recordings under a read pinned to the literal "my-whoop" (#814 twin of the Workouts screen). */
     val deviceId = noopApp.activeDeviceId
+
+    /** Last (bins, daysObserved) computed on the collector pass. Reused by the SYNCHRONOUS settings
+     *  re-evaluate below, which has no coroutine to read the store from — without this, flipping the
+     *  cycle-tracking toggle would blank the body clock until the next collector tick. */
+    private var lastCircadianBins: Pair<List<CircadianEngine.ActivityBin>, Int> =
+        emptyList<CircadianEngine.ActivityBin>() to 0
+
+    /**
+     * Per-hour activity profile for the body clock (#852), from the last ~14 days of hourly HR buckets.
+     * HR amplitude is a usable rest/activity rhythm proxy when raw motion is not to hand.
+     *
+     * Byte-for-byte mirror of Swift `AppModel.computeCircadianPhase`: 3600 s buckets, the >= 24-bucket
+     * floor, pooling by LOCAL hour-of-day, and `daysObserved` as the count of distinct local days. The
+     * binning lives here rather than in `CircadianEngine` precisely because Swift keeps it in AppModel —
+     * the engine stays an untouched byte-for-byte mirror on both platforms.
+     *
+     * Returns an empty list when there is too little to read; the caller treats that as "no estimate".
+     */
+    private suspend fun circadianActivityBins(): Pair<List<CircadianEngine.ActivityBin>, Int> {
+        val now = System.currentTimeMillis() / 1000L
+        val from = now - 14L * 86_400L
+        val buckets = runCatching { repository.hrBuckets(deviceId, from, now, 3_600L) }
+            .getOrDefault(emptyList())
+        val tz = TimeZone.getDefault().getOffset(now * 1000L) / 1000L
+        return circadianBinsFrom(buckets, tz)
+    }
 
     /** Live connection + biometric snapshot, surfaced straight from the BLE client. */
     val live: StateFlow<LiveState> = ble.state
@@ -733,10 +790,13 @@ class AppViewModel(app: Application) : AndroidViewModel(app) {
                 // so the contract the notification path relies on is untouched. Best-effort — never let a
                 // signals hiccup kill the collector.
                 runCatching {
+                    lastCircadianBins = circadianActivityBins()
                     _v5Signals.value = V5HealthSignals.evaluate(
                         days = days,
                         cycleOptedIn = _cycleTrackingEnabled.value,
                         journalContext = illnessJournalContext(days),
+                        activityBins = lastCircadianBins.first,
+                        daysObserved = lastCircadianBins.second,
                     )
                 }
                 // Keep the home-screen widget fresh while the app is open — covers users who turned
@@ -2148,6 +2208,8 @@ class AppViewModel(app: Application) : AndroidViewModel(app) {
                 days = days,
                 cycleOptedIn = enabled,
                 journalContext = illnessJournalContext(days),
+                activityBins = lastCircadianBins.first,
+                daysObserved = lastCircadianBins.second,
             )
         }
     }

--- a/android/app/src/main/java/com/noop/ui/AppViewModel.kt
+++ b/android/app/src/main/java/com/noop/ui/AppViewModel.kt
@@ -397,7 +397,11 @@ class AppViewModel(app: Application) : AndroidViewModel(app) {
 
     /** Last (bins, daysObserved) computed on the collector pass. Reused by the SYNCHRONOUS settings
      *  re-evaluate below, which has no coroutine to read the store from — without this, flipping the
-     *  cycle-tracking toggle would blank the body clock until the next collector tick. */
+     *  cycle-tracking toggle would blank the body clock until the next collector tick.
+     *
+     *  Not volatile and not synchronised, deliberately: the write resumes on `viewModelScope`
+     *  (Dispatchers.Main.immediate) and the read is a UI-thread settings callback, so both touch it on
+     *  the main thread. The Swift twin gets the same guarantee from `@MainActor` on AppModel. */
     private var lastCircadianBins: Pair<List<CircadianEngine.ActivityBin>, Int> =
         emptyList<CircadianEngine.ActivityBin>() to 0
 

--- a/android/app/src/main/java/com/noop/ui/AppViewModel.kt
+++ b/android/app/src/main/java/com/noop/ui/AppViewModel.kt
@@ -64,8 +64,8 @@ import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
-import kotlin.math.roundToInt
 import java.util.TimeZone
+import kotlin.math.roundToInt
 
 /**
  * The single app-wide view model. Holds the BLE client and the Room-backed
@@ -417,7 +417,8 @@ class AppViewModel(app: Application) : AndroidViewModel(app) {
      * Returns an empty list when there is too little to read; the caller treats that as "no estimate".
      */
     private suspend fun circadianActivityBins(): Pair<List<CircadianEngine.ActivityBin>, Int> {
-        val now = System.currentTimeMillis() / 1000L
+        val nowMs = System.currentTimeMillis()
+        val now = nowMs / 1000L
         val from = now - 14L * 86_400L
         // hrBucketsUnion, not hrBuckets: the Swift twin's `repo.hrBuckets(from:to:)` UNIONs the active
         // strap with the canonical "my-whoop" (#814 read spine). Reading one id here would give Android
@@ -425,7 +426,7 @@ class AppViewModel(app: Application) : AndroidViewModel(app) {
         // render no estimate where Swift renders one. Single-WHOOP install resolves to one id either way.
         val buckets = runCatching { repository.hrBucketsUnion(deviceId, from, now, 3_600L) }
             .getOrDefault(emptyList())
-        val tz = TimeZone.getDefault().getOffset(now * 1000L) / 1000L
+        val tz = TimeZone.getDefault().getOffset(nowMs) / 1000L
         return circadianBinsFrom(buckets, tz)
     }
 

--- a/android/app/src/test/java/com/noop/ui/CircadianBinsTest.kt
+++ b/android/app/src/test/java/com/noop/ui/CircadianBinsTest.kt
@@ -1,0 +1,75 @@
+package com.noop.ui
+
+import com.noop.data.HrBucket
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * #852: the pure half of the body-clock binning. Android had the CircadianEngine, its tests and the
+ * BodyClockCard all along, and only ever lacked this input — `V5HealthSignals` hardcoded `bodyClock =
+ * null` behind a comment claiming the data did not exist. It did: Swift derives the same profile from
+ * HR buckets Android also banks (`AppModel.computeCircadianPhase`).
+ *
+ * These pin the maths that has to match that twin: the >= 24-bucket floor, pooling by LOCAL hour, the
+ * mean per populated hour, and `daysObserved` as distinct local days.
+ */
+class CircadianBinsTest {
+
+    /** One bucket per hour for [hours] consecutive hours from [startTs], all at [bpm]. */
+    private fun series(startTs: Long, hours: Int, bpm: Double = 60.0) =
+        (0 until hours).map { HrBucket(bucket = startTs + it * 3_600L, avgBpm = bpm) }
+
+    @Test fun underTwentyFourBucketsIsRefused() {
+        val (bins, days) = circadianBinsFrom(series(0, 23), tzOffsetSeconds = 0)
+        assertTrue("a sub-day span cannot carry a 24 h rhythm", bins.isEmpty())
+        assertEquals(0, days)
+    }
+
+    @Test fun exactlyTwentyFourBucketsGivesTwentyFourBins() {
+        val (bins, days) = circadianBinsFrom(series(0, 24), tzOffsetSeconds = 0)
+        assertEquals(24, bins.size)
+        assertEquals((0..23).map { it.toDouble() }, bins.map { it.hour })
+        assertEquals(1, days)
+    }
+
+    /** The activity value is the MEAN over that local hour across days, not the sum. */
+    @Test fun repeatedHoursAverageRatherThanAccumulate() {
+        val day1 = series(0, 24, bpm = 50.0)
+        val day2 = series(86_400, 24, bpm = 70.0)
+        val (bins, days) = circadianBinsFrom(day1 + day2, tzOffsetSeconds = 0)
+        assertEquals(24, bins.size)
+        assertTrue("every hour should read the mean of 50 and 70", bins.all { it.activity == 60.0 })
+        assertEquals(2, days)
+    }
+
+    /** Pooling is by LOCAL hour: a +1 h zone shifts every bucket one slot, and can roll a day over. */
+    @Test fun poolingUsesTheLocalHourNotUtc() {
+        val utc = circadianBinsFrom(series(0, 48), tzOffsetSeconds = 0)
+        val plus1 = circadianBinsFrom(series(0, 48), tzOffsetSeconds = 3_600)
+        assertEquals(24, utc.first.size)
+        assertEquals(24, plus1.first.size)
+        // 48 h from epoch spans 2 UTC days; shifted +1 h it touches a third local day.
+        assertEquals(2, utc.second)
+        assertEquals(3, plus1.second)
+    }
+
+    /** A negative offset must not produce a negative hour — the double-modulo guards that. */
+    @Test fun negativeOffsetWrapsRatherThanGoingNegative() {
+        val (bins, _) = circadianBinsFrom(series(0, 48), tzOffsetSeconds = -5 * 3_600L)
+        assertTrue("hours stay in 0..23", bins.all { it.hour >= 0.0 && it.hour <= 23.0 })
+        assertEquals(24, bins.size)
+    }
+
+    /** Sparse coverage yields only the populated hours — the caller's >= 6 floor decides usability. */
+    @Test fun onlyPopulatedHoursBecomeBins() {
+        // 30 buckets all landing in the same 6 local hours (one per hour across 5 days).
+        val sparse = (0 until 5).flatMap { d ->
+            (0 until 6).map { h -> HrBucket(bucket = d * 86_400L + h * 3_600L, avgBpm = 55.0) }
+        }
+        val (bins, days) = circadianBinsFrom(sparse, tzOffsetSeconds = 0)
+        assertEquals(6, bins.size)
+        assertEquals((0..5).map { it.toDouble() }, bins.map { it.hour })
+        assertEquals(5, days)
+    }
+}


### PR DESCRIPTION
Closes #852. Supersedes #853, which I closed — that PR proposed *deleting* this, on the mistaken belief there was no Swift twin.

## The gap

Body Clock has shipped on iOS/macOS all along. `AppModel.computeCircadianPhase` pools HR by local hour-of-day as the activity proxy, fits the cosinor, publishes `circadianPhase`, and `SkinTempCardsView` renders it.

Android has a **byte-for-byte twin of the engine**, its own full test suite, and a finished `BodyClockCard` — and never fed any of it. `V5HealthSignals` hardcoded `bodyClock = null`, so `HealthScreen`'s `?.let` skipped the card on every device.

**The comment guarding it was wrong.** It said we lack *"per-hour rest-activity bins we don't bank here"*. Swift doesn't bank them either — it derives them from HR buckets Android also has. The pipe was never built on this side, not missing.

## The change

Two hunks, ~30 lines. Mirrors the Swift maths exactly: 3600 s buckets over 14 days, the `>= 24`-bucket floor, pooling by **local** hour, mean bpm per populated hour, distinct local days as `daysObserved`, and the `>= 6`-bin floor before a fit is attempted.

The binning lives in `AppViewModel`, not `CircadianEngine`, **because Swift keeps it in `AppModel`** — the engine stays an untouched byte-for-byte mirror on both platforms, which is the point.

Its pure half is a top-level `circadianBinsFrom` so it is testable with no Context, no ViewModel and no database.

## Verification

Six tests pin the floors, local-hour pooling, mean-not-sum, the negative-offset wrap and sparse coverage. Every expectation was cross-checked against an independent implementation of the algorithm before commit:

```
OK under24     bins=0  days=0      OK plus1h48   bins=24 days=3
OK exactly24   bins=24 days=1      OK neg5h      bins=24 (hours stay 0..23)
OK meanNotSum  bins=24 mean=60.0   OK sparse6x5  bins=6  days=5
```

Both new parameters default, so every existing `evaluate()` caller is byte-identical. The synchronous settings-toggle re-evaluate reuses the collector pass's cached bins rather than blanking the estimate — it has no coroutine to read the store from.

## Known divergence, deliberately not closed here

Swift derives `habitualWakeHour` from the most recent banked wake, falling back to 07:00. Kotlin has no such helper, so this uses the existing `7.0` default. That shifts `offsetVsScheduleMinutes` for anyone who doesn't wake at 07:00 — real and bounded, worth a follow-up, but a wake-time derivation is a separate change.

## What this does NOT settle

Whether this should ship at all. Without an `observedTempMinHour`, `estimatePhase` derives the CBT minimum as `activityAcrophase − 12.0h` — a population constant — and the confidence bands key on **data sufficiency**, not on whether that constant holds for this person.

That question is about the **already-shipped Apple card**. Leaving Android silently inert was never an answer to it, which is why this lands first: it makes the platforms consistent so the real decision can be made once, for both.

Not compiled — `android.yml` is disabled.
