### PR TITLE
fix(android): make the sync chip's state decision resolvable without an Application

### DIFF
--- a/android/app/src/main/java/com/noop/ui/TodayScoring.kt
+++ b/android/app/src/main/java/com/noop/ui/TodayScoring.kt
@@ -6,7 +6,6 @@ import com.noop.analytics.ChargeDriver
 import com.noop.analytics.RecoveryDrivers
 import com.noop.analytics.RestScorer
 import com.noop.analytics.ScoreConfidence
-import com.noop.R
 import com.noop.data.DailyMetric
 import java.time.LocalDate
 import java.time.Instant
@@ -388,15 +387,29 @@ sealed class SyncChipState {
 
     companion object {
         /** Pure + unit-tested. Mirrors Swift `SyncChipState.resolve` exactly: backfilling wins over a
-         *  known last-sync, which wins over the 5/MG experimental fallback. */
+         *  known last-sync, which wins over the 5/MG experimental fallback.
+         *
+         *  [nowSec] (unix seconds) and [nowLabel] (the already-translated "now" word) are PARAMETERS
+         *  rather than things this function reaches for, which is what keeps "pure" true. Resolving the
+         *  word in here instead cost the twin its own test: it goes through `NoopApplication`, which
+         *  throws `IllegalStateException: NoopApplication is not attached` under a plain JVM unit test —
+         *  these run without Robolectric, so no Application is ever attached. Only the `< 60s` branch of
+         *  [shortSyncAgo] wants a word, so the failure was invisible until a case landed in it. Same
+         *  injected-clock style as [recordingStateFor] just above.
+         *
+         *  Swift's twin keeps both inside its own `shortAgo` and is fine there — XCTest runs against a
+         *  real bundle, so `String(localized:)` resolves. The two SIGNATURES therefore differ on purpose;
+         *  the decision they encode does not. Don't "restore parity" by moving the lookup back in here. */
         fun resolve(
             backfilling: Boolean,
             chunks: Int,
             lastSyncAtSec: Long?,
             historySyncExperimental: Boolean,
+            nowSec: Long,
+            nowLabel: String,
         ): SyncChipState = when {
             backfilling -> Syncing(chunks)
-            lastSyncAtSec != null -> Synced(shortSyncAgo(lastSyncAtSec))
+            lastSyncAtSec != null -> Synced(shortSyncAgo(lastSyncAtSec, nowSec, nowLabel))
             historySyncExperimental -> ExperimentalLive
             else -> Hidden
         }
@@ -405,11 +418,13 @@ sealed class SyncChipState {
 
 /** Compact relative age for the header chip ("now" / "Nm" / "Nh" / "Nd") from a unix-SECONDS timestamp —
  *  deliberately terse. "now" is the only word in here (the rest is digits + a unit letter), so it's the
- *  only piece that needs a catalog entry to translate. Mirrors the iOS `SyncChipState.shortAgo`. */
-internal fun shortSyncAgo(unixSec: Long): String {
-    val secs = (System.currentTimeMillis() / 1000L - unixSec).coerceAtLeast(0)
+ *  only piece that needs a catalog entry to translate; it arrives as [nowLabel], resolved by the
+ *  composable that owns the chip, so the bucketing stays framework-free. [nowSec] is unix seconds,
+ *  injected for the same reason. Mirrors the iOS `SyncChipState.shortAgo`. */
+internal fun shortSyncAgo(unixSec: Long, nowSec: Long, nowLabel: String): String {
+    val secs = (nowSec - unixSec).coerceAtLeast(0)
     return when {
-        secs < 60 -> uiString(R.string.l10n_today_screen_sync_chip_now_c9bc849a)
+        secs < 60 -> nowLabel
         secs < 3600 -> "${secs / 60}m"
         secs < 86_400 -> "${secs / 3600}h"
         else -> "${secs / 86_400}d"

--- a/android/app/src/main/java/com/noop/ui/TodayScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/TodayScreen.kt
@@ -2132,7 +2132,19 @@ private fun SyncStatusChip(
     lastSyncAt: Long?,
     historySyncExperimental: Boolean,
 ) {
-    when (val state = SyncChipState.resolve(backfilling, chunks, lastSyncAt, historySyncExperimental)) {
+    // The clock and the translated "now" word are resolved HERE, in the composable that already depends
+    // on both, and handed down — so `SyncChipState.resolve` stays a genuinely pure decision that a plain
+    // JVM unit test can call with no attached Application. Reading the clock at composition time (rather
+    // than snapshotting it) is unchanged behaviour: `shortSyncAgo` did exactly this on every recomposition.
+    val state = SyncChipState.resolve(
+        backfilling = backfilling,
+        chunks = chunks,
+        lastSyncAtSec = lastSyncAt,
+        historySyncExperimental = historySyncExperimental,
+        nowSec = System.currentTimeMillis() / 1000L,
+        nowLabel = uiString(R.string.l10n_today_screen_sync_chip_now_c9bc849a),
+    )
+    when (state) {
         is SyncChipState.Syncing -> ChipCapsule(
             Icons.Filled.Autorenew, "${state.chunks}", Palette.accent,
             uiString(R.string.l10n_today_screen_sync_chip_syncing_desc_bfc290e7, state.chunks))

--- a/android/app/src/test/java/com/noop/ui/SyncChipStateTest.kt
+++ b/android/app/src/test/java/com/noop/ui/SyncChipStateTest.kt
@@ -8,22 +8,37 @@ import org.junit.Test
  * #245: `SyncChipState.resolve` is the one place the Today top bar's `SyncStatusChip` decides which of
  * the four sync states to show. Mirrors the iOS `SyncChipStateTests` 1:1 — same priority order (backfilling
  * wins over a known last-sync, which wins over the 5/MG experimental fallback), same cold-start `Hidden` case.
+ *
+ * Every case pins [NOW] instead of reading the system clock, and passes the "now" word in as [NOW_LABEL]
+ * instead of letting `resolve` resolve it: these are plain JVM tests with no Robolectric, so there is no
+ * attached `NoopApplication` to read the string catalog from. That is what made the `< 60s` cases below
+ * throw `IllegalStateException: NoopApplication is not attached` while every other case passed — only the
+ * sub-minute branch of `shortSyncAgo` needs a translated word.
  */
 class SyncChipStateTest {
+
+    private companion object {
+        /** Any fixed instant works now that `resolve` takes its clock as an argument. */
+        const val NOW = 1_700_000_000L
+
+        /** Stand-in for the `l10n_today_screen_sync_chip_now_*` catalog entry the composable passes in. */
+        const val NOW_LABEL = "now"
+    }
 
     @Test
     fun backfilling_isSyncingWithChunkCount() {
         val state = SyncChipState.resolve(
             backfilling = true, chunks = 7, lastSyncAtSec = null, historySyncExperimental = false,
+            nowSec = NOW, nowLabel = NOW_LABEL,
         )
         assertEquals(SyncChipState.Syncing(7), state)
     }
 
     @Test
     fun lastSyncedAt_isSyncedWithAgeText() {
-        val now = System.currentTimeMillis() / 1000L
         val state = SyncChipState.resolve(
-            backfilling = false, chunks = 0, lastSyncAtSec = now - 65, historySyncExperimental = false,
+            backfilling = false, chunks = 0, lastSyncAtSec = NOW - 65, historySyncExperimental = false,
+            nowSec = NOW, nowLabel = NOW_LABEL,
         )
         assertEquals(SyncChipState.Synced("1m"), state)
     }
@@ -32,6 +47,7 @@ class SyncChipStateTest {
     fun historySyncExperimental_withNoLastSync_isExperimentalLive() {
         val state = SyncChipState.resolve(
             backfilling = false, chunks = 0, lastSyncAtSec = null, historySyncExperimental = true,
+            nowSec = NOW, nowLabel = NOW_LABEL,
         )
         assertEquals(SyncChipState.ExperimentalLive, state)
     }
@@ -40,25 +56,42 @@ class SyncChipStateTest {
     fun coldStart_noBackfillNoSyncNoExperimental_isHidden() {
         val state = SyncChipState.resolve(
             backfilling = false, chunks = 0, lastSyncAtSec = null, historySyncExperimental = false,
+            nowSec = NOW, nowLabel = NOW_LABEL,
         )
         assertEquals(SyncChipState.Hidden, state)
     }
 
     @Test
     fun backfilling_takesPriorityOverLastSyncedAt() {
-        val now = System.currentTimeMillis() / 1000L
         val state = SyncChipState.resolve(
-            backfilling = true, chunks = 2, lastSyncAtSec = now - 5, historySyncExperimental = false,
+            backfilling = true, chunks = 2, lastSyncAtSec = NOW - 5, historySyncExperimental = false,
+            nowSec = NOW, nowLabel = NOW_LABEL,
         )
         assertEquals(SyncChipState.Syncing(2), state)
     }
 
     @Test
     fun lastSyncedAt_takesPriorityOverHistorySyncExperimental() {
-        val now = System.currentTimeMillis() / 1000L
         val state = SyncChipState.resolve(
-            backfilling = false, chunks = 0, lastSyncAtSec = now - 5, historySyncExperimental = true,
+            backfilling = false, chunks = 0, lastSyncAtSec = NOW - 5, historySyncExperimental = true,
+            nowSec = NOW, nowLabel = NOW_LABEL,
         )
         assertTrue("A known last-sync should win over the experimental fallback", state is SyncChipState.Synced)
+    }
+
+    /**
+     * Regression guard for the branch that used to be unreachable from a unit test: a sub-minute sync must
+     * render the caller-supplied word verbatim. This fails to even compile — let alone pass — if the string
+     * lookup ever moves back inside `shortSyncAgo`, which is the whole point of keeping it out. No iOS twin:
+     * Swift's `shortAgo` resolves its own clock and `String(localized:)`, and can afford to because XCTest
+     * runs against a real bundle.
+     */
+    @Test
+    fun lastSyncedUnderAMinute_isSyncedWithTheInjectedNowLabel() {
+        val state = SyncChipState.resolve(
+            backfilling = false, chunks = 0, lastSyncAtSec = NOW - 5, historySyncExperimental = false,
+            nowSec = NOW, nowLabel = NOW_LABEL,
+        )
+        assertEquals(SyncChipState.Synced("now"), state)
     }
 }


### PR DESCRIPTION
Follow-up to the note I left in review on #738 — kept separate so an unrelated UI test fix doesn't ride along with a sleep-staging change.

## The failure

`SyncChipStateTest.lastSyncedAt_takesPriorityOverHistorySyncExperimental` fails on `main` (verified at cca23d66 on a clean checkout). It is the **only** failure in the suite — 3060 tests, 1 failure.

```
java.lang.IllegalStateException: NoopApplication is not attached
  at com.noop.NoopApplication$Companion.localizedString(NoopApplication.kt:134)
  at com.noop.ui.UiStringsKt.uiString(UiStrings.kt:16)
  at com.noop.ui.TodayScoringKt.shortSyncAgo(TodayScoring.kt:412)
  at com.noop.ui.SyncChipState$Companion.resolve(TodayScoring.kt:399)
  at com.noop.ui.SyncChipStateTest.lastSyncedAt_takesPriorityOverHistorySyncExperimental(SyncChipStateTest.kt:59)
```

Repro:

```
cd android && ./gradlew testFullDebugUnitTest --tests '*SyncChipStateTest*'
```

## Root cause

`SyncChipState.resolve` is documented `Pure + unit-tested`, but it reached for two ambient dependencies: the process-wide Application's resources (via `shortSyncAgo` → `uiString` → `NoopApplication.localizedString`) and the system clock. These are plain JVM tests with no Robolectric, so no Application is ever attached and the resource lookup throws.

What made it look arbitrary: **only the `< 60s` branch of `shortSyncAgo` needs a translated word** — every other bucket is digits plus a unit letter. So five of the six cases passed, and the one with a 5-second-old sync did not. It is also why `lastSyncedAt_isSyncedWithAgeText` survives: it uses 65 seconds and lands in the `Nm` branch.

## The fix

Hoist both dependencies to parameters. `SyncStatusChip` — a composable that already depends on the clock and the string catalog — resolves them and passes them down, so the decision itself becomes genuinely pure. This is the same injected-clock shape as `recordingStateFor` directly above it, which already takes its own `nowSec`.

**No behaviour change.** The clock is still read at composition time, exactly as `shortSyncAgo` did on every recomposition, and the chip renders identical text in every bucket.

The tests become deterministic (a fixed `nowSec` instead of `System.currentTimeMillis()`) and gain one case for the sub-minute branch — previously impossible to reach from a unit test, and now the regression guard against the lookup migrating back inside.

## On the parity contract

The Swift twin is **deliberately unchanged**, calling that out per CLAUDE.md. `SyncChipState.shortAgo` resolves its own `Date()` and `String(localized:)` and is fine doing so — XCTest runs against a real bundle, and `SyncChipStateTests` passes. The two signatures now differ on purpose; the four cases and the priority order they encode do not. There is a KDoc note saying so, so it doesn't get "restored" later.

## Verification

| | before | after |
|---|---|---|
| tests | 3060 | 3061 |
| failures | 1 | 0 |
| test classes | 381 | 381 |

Measured on this machine by running the full suite against a pristine `upstream/main` tree, then against the patch. The `+1` is the new sub-minute case; no test was dropped.

`i18n-coverage` and `source-hygiene` (the two workflows that actually run) are both green locally:

```
OK no new hardcoded literals (215 pre-existing, tracked in the baseline)
OK no new un-extracted literals (64 pre-existing, tracked in the baseline)
OK no NEW detached doc comments (1387 files, 25 baselined site(s) remaining)
```

The `l10n_today_screen_sync_chip_now_c9bc849a` catalog entry is still referenced, just from `TodayScreen.kt` now.

## Why CI didn't catch it

`android.yml` is disabled by default, so nothing runs the Android unit tests on a PR. Worth a separate conversation about whether the `testFullDebugUnitTest` job is cheap enough to enable on its own (it is pure JVM — ~2 min here, no emulator, no SDK-heavy steps) even while the full compile job stays off.
