### PR TITLE
tools(spo2): account for @82's duty cycle, screen for variance, and classify a strap that never emits it

### DIFF
--- a/docs/WHOOP5_DEEP_DATA.md
+++ b/docs/WHOOP5_DEEP_DATA.md
@@ -147,10 +147,23 @@ python3 validate_spo2_candidate.py capture.json my_whoop_data/ --device strap-a 
 python3 validate_spo2_candidate.py --batch devices.json --postable
 ```
 
-Per device it computes the **nightly mean** of in-band `@82` samples (70–100) while
+Per device it computes the **nightly aggregate** of in-band `@82` samples (70–100) while
 `sleep_state = asleep`, pairs each night with CSV `blood_oxygen_pct`, then reports Pearson **r**,
 MAE, bias, and an **offset-specificity** scan over bytes 74–92 (only `@82` should win). Default
-gates: ≥5 paired nights, export range ≥1 %, r ≥ 0.7, MAE ≤ 1.0, best offset = 82.
+gates: ≥5 paired nights, export range ≥1 %, r ≥ 0.7, MAE ≤ 1.0, best offset = 82, ≥5 distinct
+in-band values at `@82`, and ≥50 % duty-window coverage.
+
+**`@82` is duty-cycled**, which the harness has to account for or its numbers are meaningless.
+Across 18,650 v18 records — 18,602 from [@digitalerdude](https://github.com/digitalerdude)'s public
+PacketLogger capture of an official-app overnight sync, plus 48 from a NOOP sync — the byte is
+nonzero in 450 records (2.4 %), in 15 runs of *exactly* 30 records each, every run starting at the
+same `unix % 1200` with zero phase variance; outside the window it is identically `0x00`. A capture
+not aligned to that phase reads all zeros and is indistinguishable from a strap with the feature off
+— a plausible contributor to the split evidence above. The tool therefore **detects** the period,
+phase and window length per capture (never assuming the phase generalises across firmware),
+aggregates one value **per window** rather than per second, and reports per-night window coverage
+with a loud warning below the floor. A strap whose `@82` is flat `0x00` across a long enough capture
+is classified **`feature_absent`** — neither a PASS nor a FAIL in the multi-device gate.
 
 `--postable` prints a CSV-ish block with **no raw SpO₂ values** — safe to paste on
 [#103](https://github.com/ryanbr/noop/issues/103). Promote `spo2_candidate_82` → `spo2Pct` only when

--- a/tools/linux-capture/README.md
+++ b/tools/linux-capture/README.md
@@ -87,7 +87,7 @@ the Python capture side does not require Swift.
 | `whoop_frame.py` | CRC8 / CRC16-Modbus / CRC32, frame builders (`build_command_frame`, `build_puffin_command`, `build_whoop5_buzz` / `build_whoop4_buzz`), the family-aware `Reassembler`, and the standard-HR parser. Stdlib only. |
 | `hci_extract.py` | **Turn a phone HCI capture into `capture.json`.** Parses a btsnoop (`btsnoop_hci.log`) or Apple PacketLogger (`.pklg`) log, reassembles L2CAP/ATT, and extracts the CRC-valid WHOOP frames — so a capture of the **official app** (issue [#103](https://github.com/ryanbr/noop/issues/103)) feeds the same decode pipeline. Only WHOOP streams reach the output. Stdlib only. See [From a phone HCI capture](#from-a-phone-hci-capture-hci_extractpy). |
 | `correlate_ground_truth.py` | **Locate un-decoded record fields using your WHOOP CSV export as known-plaintext.** Cross-references capture frames against the official per-night values (HRV, resting HR, skin temp, SpO₂, respiratory rate) to find each biometric's byte offset + encoding. Reuses the Swift importer's localized header aliases (English + DE/ES). Reports offsets only — your health values never leave the machine. Stdlib only. See [Ground-truth correlation](#ground-truth-correlation-correlate_ground_truthpy). |
-| `validate_spo2_candidate.py` | **Multi-device validation of the v18 SpO₂ candidate at frame @82** (`spo2_candidate_82`). Nightly mean of in-band (70–100) samples during `sleep_state=asleep` vs CSV `blood_oxygen_pct`; reports r / MAE / bias / offset-specificity and a promote checklist. Batch mode for several straps. Postable summary has **no raw SpO₂ values** (safe for [#103](https://github.com/ryanbr/noop/issues/103)). Stdlib only. See [SpO₂ candidate validation](#spo₂-candidate-validation-validate_spo2_candidatepy). |
+| `validate_spo2_candidate.py` | **Multi-device validation of the v18 SpO₂ candidate at frame @82** (`spo2_candidate_82`). Nightly aggregate of in-band (70–100) samples during `sleep_state=asleep` vs CSV `blood_oxygen_pct`; reports r / MAE / bias / offset-specificity and a promote checklist. **@82 is duty-cycled**, so the tool detects its window schedule per capture, aggregates per window, and reports window coverage; a strap that never emits @82 is classified `feature_absent` rather than failed. Batch mode for several straps. Postable summary has **no raw SpO₂ values** (safe for [#103](https://github.com/ryanbr/noop/issues/103)). Stdlib only. See [SpO₂ candidate validation](#spo₂-candidate-validation-validate_spo2_candidatepy). |
 | `pair_probe.py` | One-shot WHOOP 5 bonding probe: scan → connect → `pair()` → test `fd4b` access. `python3 pair_probe.py <MAC>`. |
 | `analyze_v26_waveform.py` | Characterise the WHOOP 5 **v26** type-47 buffer as PPG @24 Hz using its own co-timestamped HR as ground truth. |
 | `analyze_v25_waveform.py` | **WHOOP 4.0 v25 PPG → HR span-pinning harness ([#194](https://github.com/ryanbr/noop/issues/194)).** Sweeps the unpinned PPG span (start + sample-count) across a corpus of captures at *known* HRs and reports the span where recovered HR **tracks** ground truth instead of the `1440/N` autocorrelation artifact — or, on resting-only data, exactly what capture is still needed. `--selftest` proves it on synthetic pulses; no args runs the bundled-frames demo. Stdlib only. |
@@ -95,7 +95,7 @@ the Python capture side does not require Swift.
 | `test_whoop_frame.py` | Unit tests for framing / reassembly / HR parsing / buzz frames (no `bleak` needed). |
 | `test_hci_extract.py` | Unit tests for the btsnoop/pklg parsers, L2CAP/ATT reassembly, and WHOOP-frame extraction (synthetic fixtures; stdlib only). |
 | `test_correlate_ground_truth.py` | Unit tests for the CSV/alias loading and the known-plaintext field search (planted-value recovery + false-positive rejection; stdlib only). |
-| `test_validate_spo2_candidate.py` | Unit tests for multi-device SpO₂ @82 validation (planted perfect correlation, incomplete nights, awake gating, offset specificity, privacy of postable output; stdlib only). |
+| `test_validate_spo2_candidate.py` | Unit tests for multi-device SpO₂ @82 validation (planted perfect correlation, incomplete nights, awake gating, offset specificity, duty-cycle detection at planted period/phase, window coverage, the variance floor, flat-zero classification, privacy of postable output; stdlib only). |
 | `test_whoop_spot_hrv.py` | Unit tests for the spot-HRV DSP (synthetic-signal HR/RMSSD recovery, ectopic rejection, grid reconstruction; stdlib only). |
 | `requirements.txt` | `bleak` (runtime dep for capture only). |
 
@@ -621,19 +621,54 @@ python3 validate_spo2_candidate.py --batch devices.json --postable
 ]
 ```
 
+### @82 is duty-cycled — read this before trusting a run
+
+`@82` is **not** sampled every second. On a corpus of 18,650 v18 records — 18,602 of them from
+[@digitalerdude](https://github.com/digitalerdude)'s public PacketLogger capture of an official-app
+overnight sync (see [#103](https://github.com/ryanbr/noop/issues/103)), plus 48 from a NOOP sync — it
+is nonzero in only **450 records (2.4 %)**, in **15 runs, every one exactly 30 records long**, each
+starting at the same `unix % 1200`, with **zero phase variance**. Outside that window the byte is
+identically `0x00`.
+
+So a capture (or a sampling scheme) that is not aligned to the phase reads all zeros and looks
+exactly like a strap with the feature switched off. The tool therefore:
+
+- **detects** the schedule per capture — period, phase, window length, jitter — and prints what it
+  found. The window's *existence and stable length* is the robust fact; the phase offset is **not**
+  assumed to generalise across straps or firmware, so it is never hard-coded;
+- **aggregates per window**, not per second: a 30-second burst is one measurement the strap took, so
+  a densely-sampled window cannot outvote a sparse one;
+- **reports coverage** per night (windows sampled ÷ windows expected) and warns loudly below
+  `--min-window-coverage` (default 0.5), because a night built on 2 of 21 windows is not comparable
+  to one built on all of them.
+
+If your run reports low coverage, re-capture aligned to the phase the tool printed rather than
+reading the correlation.
+
 What it checks (per device):
 
 | Check | Default gate |
 |-------|----------------|
 | Paired nights with export SpO₂ **and** in-band @82 during sleep | ≥ 5 |
 | Export SpO₂ has real night-to-night spread | range ≥ 1.0 % |
-| Pearson **r** (nightly mean @82 vs export) | ≥ 0.7 |
+| Pearson **r** (nightly aggregate @82 vs export) | ≥ 0.7 |
 | Mean absolute error | ≤ 1.0 % |
 | Offset specificity scan @74–92 | best \|r\| is **@82** |
+| Distinct in-band values at @82 (variance floor) | ≥ 5, stdev ≥ 0.5 |
+| Median share of the night's duty windows sampled | ≥ 0.5 (n/a if not duty-cycled) |
 
-**Overall PASS** only if every gate clears. NOOP still will not promote `spo2_candidate_82` →
-`spo2Pct` from a single device: need **≥ 2 devices** that each PASS (postable summary prints
-`multi_device_eligible` / `all_pass`).
+The variance floor exists because "the value lands in 70–100" is **not** a specific screen. On a real
+subscription-free 5.0 strap six offsets pass an in-band-only screen on a majority of records — `@17`,
+`@33`, `@59`, `@69`, `@71`, `@107` — and every one is either an already-decoded non-SpO₂ field (`@33`
+`cardiac_flags`, `@59` `step_cadence`, `@69`/`@71` the two aux thermal channels) or near-constant
+(`@17` is byte 2 of the u32 unix timestamp at `@15`; `@107` has 4 distinct values). A nightly SpO₂
+cannot have 2 distinct values, so an offset must show real variation before its correlation is ranked.
+
+**Overall PASS** only if every gate clears. A strap whose `@82` is `0x00` on 100 % of a long enough
+capture is reported as **`feature_absent`** — neither a PASS nor a FAIL, and excluded from the
+multi-device gate, because a device with no data has not failed a correlation. NOOP still will not
+promote `spo2_candidate_82` → `spo2Pct` from a single device: need **≥ 2 devices** that each PASS
+(postable summary prints `multi_device_eligible` / `all_pass` / `feature_absent`).
 
 **Privacy:** default output and `--postable` print only aggregates (r, MAE, bias, offsets, pass/fail).
 `--show-nights` prints per-night values for **local** debugging — do not paste that on GitHub.

--- a/tools/linux-capture/test_validate_spo2_candidate.py
+++ b/tools/linux-capture/test_validate_spo2_candidate.py
@@ -22,6 +22,11 @@ def _utc(y, m, d, hh=0, mm=0, ss=0) -> int:
     return int(datetime(y, m, d, hh, mm, ss, tzinfo=timezone.utc).timestamp())
 
 
+def _unix_of(rec: dict) -> int:
+    """The u32 unix at frame offset 15, straight off a planted capture record."""
+    return int.from_bytes(bytes.fromhex(rec["hex"])[15:19], "little")
+
+
 def _plant_night(
     t0: int,
     t1: int,
@@ -41,6 +46,43 @@ def _plant_night(
                 unix=u,
                 sleep_state=sleep_state,
                 aux_byte_82=spo2 if asleep else 0,
+                length=124,
+            )
+        )
+        if neighbor_offset is not None and asleep:
+            f[neighbor_offset] = neighbor_value & 0xFF
+        out.append({"hex": bytes(f).hex(), "dir": "rx"})
+    return out
+
+
+def _plant_duty_night(
+    t0: int,
+    t1: int,
+    spo2: int,
+    *,
+    period: int,
+    phase: int,
+    window: int,
+    step_s: int = 1,
+    asleep: bool = True,
+    neighbor_offset: int | None = None,
+    neighbor_value: int = 0,
+) -> list[dict]:
+    """Plant v18 records where @82 is nonzero ONLY inside a duty window, as the real strap does.
+
+    `phase` is the residue `unix % period` at which the window opens. Tests deliberately use periods
+    and phases that are *not* the ones measured on the reference corpus — the tool must recover them
+    from the capture, never assume them.
+    """
+    out = []
+    sleep_state = 2 if asleep else 0
+    for u in range(t0, t1, step_s):
+        in_window = (u - phase) % period < window
+        f = bytearray(
+            make_v18(
+                unix=u,
+                sleep_state=sleep_state,
+                aux_byte_82=spo2 if (in_window and asleep) else 0,
                 length=124,
             )
         )
@@ -330,3 +372,302 @@ class SqliteV18FilterTest(unittest.TestCase):
         with self.assertRaises(SystemExit) as cm:
             vs.load_frame_records(self._mixed_store(n_v18=5), device_id=99)
         self.assertIn("device-id", str(cm.exception))
+
+
+class DutyCycleDetectionTests(unittest.TestCase):
+    """@82 is duty-cycled: on the reference corpus (18,650 v18 records, 18,602 of them from
+    @digitalerdude's public PacketLogger capture) it is nonzero in 450 records — 15 runs, every one
+    exactly 30 records long, every one starting at the same `unix % 1200`.
+
+    The *existence* of a periodic window is the robust fact. The period and especially the phase are
+    not: these tests plant schedules that are nothing like 1200/337 and require the tool to measure
+    them, so a hard-coded constant would fail here rather than silently mis-score someone's strap."""
+
+    def _records(self, frames):
+        return list(vs.iter_v18_records(frames))
+
+    def test_recovers_period_phase_and_window_without_being_told(self):
+        t0 = _utc(2026, 3, 2, 0, 0, 0)
+        frames = _plant_duty_night(t0, t0 + 6 * 900, 96, period=900, phase=111, window=20)
+        duty = vs.detect_duty_cycle(self._records(frames))
+        self.assertEqual(duty["mode"], "duty_cycled")
+        self.assertEqual(duty["period_s"], 900)
+        self.assertEqual(duty["window_len_s"], 20)
+        self.assertEqual(duty["phase_s"], 111 % 900)
+        self.assertEqual(duty["windows_observed"], 6)
+        self.assertEqual(duty["phase_jitter_s"], 0)
+        self.assertTrue(duty["window_len_stable"])
+
+    def test_a_second_unrelated_schedule_is_recovered_too(self):
+        """Two different plants must give two different answers — the guard against a constant."""
+        t0 = _utc(2026, 3, 3, 0, 0, 0)
+        frames = _plant_duty_night(t0, t0 + 8 * 600, 95, period=600, phase=42, window=10)
+        duty = vs.detect_duty_cycle(self._records(frames))
+        self.assertEqual(
+            (duty["period_s"], duty["phase_s"], duty["window_len_s"]), (600, 42, 10)
+        )
+
+    def test_a_capture_where_82_is_always_on_is_not_reweighted(self):
+        """No duty cycle to correct for ⇒ 'continuous', and the per-second path is left alone."""
+        t0 = _utc(2026, 3, 4, 0, 0, 0)
+        duty = vs.detect_duty_cycle(self._records(_plant_night(t0, t0 + 3600, 97)))
+        self.assertEqual(duty["mode"], "continuous")
+        self.assertIsNone(duty["period_s"])
+
+    def test_a_flat_zero_capture_reports_absent(self):
+        t0 = _utc(2026, 3, 5, 0, 0, 0)
+        duty = vs.detect_duty_cycle(self._records(_plant_night(t0, t0 + 3600, 0)))
+        self.assertEqual(duty["mode"], "absent")
+        self.assertEqual(duty["n_nonzero"], 0)
+
+    def test_scattered_firings_with_no_period_are_called_irregular_not_duty_cycled(self):
+        """Claiming a period the data does not support would reweight nights on an invented schedule."""
+        t0 = _utc(2026, 3, 6, 0, 0, 0)
+        frames = []
+        for i, gap in enumerate([0, 137, 490, 601, 1900, 2050]):
+            f = bytearray(make_v18(unix=t0 + gap, sleep_state=2, aux_byte_82=95, length=124))
+            frames.append({"hex": bytes(f).hex()})
+        for u in range(t0, t0 + 3000):          # bulk of zero records around them
+            frames.append({"hex": make_v18(unix=u, sleep_state=2, aux_byte_82=0).hex()})
+        duty = vs.detect_duty_cycle(self._records(frames))
+        self.assertIn(duty["mode"], ("irregular", "duty_cycled"))
+        if duty["mode"] == "duty_cycled":
+            self.fail(f"scattered firings should not be claimed as a schedule: {duty}")
+
+
+class WindowCoverageTests(unittest.TestCase):
+    """The failure mode this closes: a capture not aligned to the duty phase reads all zeros and is
+    indistinguishable from a strap with the feature off. Measured, not assumed — a plausible
+    contributor to the contradictory cross-device evidence on #103."""
+
+    def setUp(self):
+        self.t0 = _utc(2026, 4, 1, 23, 0, 0)
+        self.t1 = self.t0 + 4 * 3600
+        self.period, self.phase, self.window = 1200, 337, 30
+        self.frames = _plant_duty_night(
+            self.t0, self.t1, 96,
+            period=self.period, phase=self.phase, window=self.window,
+        )
+        self.records = list(vs.iter_v18_records(self.frames))
+        self.duty = vs.detect_duty_cycle(self.records)
+
+    def test_an_aligned_capture_covers_every_window(self):
+        covered, expected = vs.night_window_coverage(self.records, self.t0, self.t1, self.duty)
+        self.assertEqual(expected, 12)          # 4 h / 20 min
+        self.assertEqual(covered, expected)
+
+    def test_a_phase_misaligned_sample_reads_as_no_feature_at_all(self):
+        """One record per minute, landing outside the window every time: zero nonzero @82, zero
+        coverage. Reported as such instead of as a device whose candidate does not track."""
+        stride = [f for f in self.frames if _unix_of(f) % 60 == 30]
+        recs = list(vs.iter_v18_records(stride))
+        self.assertEqual(vs.detect_duty_cycle(recs)["n_nonzero"], 0)
+        covered, expected = vs.night_window_coverage(recs, self.t0, self.t1, self.duty)
+        self.assertEqual(covered, 0)
+        self.assertEqual(expected, 12)
+
+    def test_coverage_is_reported_per_night_and_low_nights_are_flagged(self):
+        # Capture only the first hour, then claim the whole 4-hour night in the export.
+        frames = [f for f in self.frames if _unix_of(f) < self.t0 + 3600]
+        with tempfile.TemporaryDirectory() as td:
+            cap = os.path.join(td, "capture.json")
+            with open(cap, "w") as fh:
+                json.dump(frames, fh)
+            start = datetime.fromtimestamp(self.t0, tz=timezone.utc).strftime("%Y-%m-%d %H:%M:%S")
+            exp = _write_export(td, [(start, 96.0, self.t0, self.t1)])
+            res = vs.validate_device(cap, exp, device="partial")
+        night = res["nights"][0]
+        self.assertEqual(night["windows_expected"], 12)
+        self.assertEqual(night["windows_sampled"], 3)       # 1 h of a 4 h night
+        self.assertAlmostEqual(night["coverage"], 0.25)
+        self.assertTrue(night["low_coverage"])
+        self.assertFalse(res["checklist"]["window_coverage"])
+        self.assertTrue(any("duty" in w or "window" in w for w in vs.coverage_warnings(res)))
+
+    def test_the_nightly_aggregate_is_per_window_not_per_second(self):
+        """A 30-second burst is one measurement the strap took, not 30 independent ones.
+
+        Windows contribute unequal numbers of *in-band* samples for a reason visible on the reference
+        corpus: only 148 of the 450 in-window values there are in 70–100 — the rest are out-of-band
+        sentinels (0x80, 0xA0, 0x20). Here window A yields 30 in-band samples and windows B and C
+        yield 3 each. Per-second averaging hands the night to A; per-window averaging does not."""
+        frames = []
+        for u in range(0, 3600):
+            in_window = (u - 337) % 1200 < 30
+            if not in_window:
+                v = 0
+            elif u < 1200:
+                v = 90                                     # window A: every second in-band
+            else:
+                v = 100 if (u % 1200) in (337, 347, 357) else 128   # B/C: 3 in-band, rest sentinel
+            frames.append({"hex": make_v18(unix=u, sleep_state=2, aux_byte_82=v).hex()})
+        recs = list(vs.iter_v18_records(frames))
+        duty = vs.detect_duty_cycle(recs)
+        self.assertEqual(duty["mode"], "duty_cycled")
+        self.assertEqual((duty["period_s"], duty["phase_s"], duty["window_len_s"]), (1200, 337, 30))
+        per_second = vs.night_mean_at_offset(recs, 0, 3600, 82)
+        per_window = vs.night_mean_at_offset(recs, 0, 3600, 82, duty=duty)
+        self.assertAlmostEqual(per_second[0], (30 * 90 + 6 * 100) / 36)   # 91.67, burst-weighted
+        self.assertAlmostEqual(per_window[0], (90 + 100 + 100) / 3)       # 96.67, window-weighted
+        self.assertEqual(per_window[1], 36)      # sample count still reported honestly
+
+
+class VarianceFloorTests(unittest.TestCase):
+    """`value in 70..100` is not a specific screen. On a real subscription-free strap six offsets pass
+    an in-band-only screen on a majority of records — @17, @33, @59, @69, @71, @107 — and each is
+    either an already-decoded non-SpO₂ field (@33 cardiac_flags, @59 step_cadence, @69/@71 the aux
+    thermal channels) or near-constant (@17 is byte 2 of the u32 unix timestamp). A nightly SpO₂
+    cannot have 2 distinct values."""
+
+    def _device(self, td, *, spo2s, neighbor_offset, neighbor_values, jitter):
+        base = _utc(2026, 2, 1, 0, 0, 0)
+        frames, exports = [], []
+        for i, spo2 in enumerate(spo2s):
+            t0 = base + i * 86400 + 23 * 3600
+            t1 = t0 + 6 * 3600
+            night = _plant_night(t0, t1, spo2 + jitter[i])
+            for rec in night:                    # a 2-valued byte that tracks export perfectly
+                f = bytearray(bytes.fromhex(rec["hex"]))
+                f[neighbor_offset] = neighbor_values[i]
+                rec["hex"] = bytes(f).hex()
+            frames.extend(night)
+            start = datetime.fromtimestamp(t0, tz=timezone.utc).strftime("%Y-%m-%d %H:%M:%S")
+            exports.append((start, float(spo2), t0, t1))
+        cap = os.path.join(td, "capture.json")
+        with open(cap, "w") as f:
+            json.dump(frames, f)
+        return cap, _write_export(td, exports)
+
+    def test_a_near_constant_in_band_byte_cannot_win_the_specificity_scan(self):
+        """@84 holds two values that correlate perfectly with the export; @82 tracks it imperfectly.
+        Without a variance floor the flag wins and the tool reports 'not specific to @82'."""
+        spo2s = [94, 95, 96, 97, 98, 99]
+        with tempfile.TemporaryDirectory() as td:
+            cap, exp = self._device(
+                td,
+                spo2s=spo2s,
+                neighbor_offset=84,
+                neighbor_values=[80, 80, 80, 81, 81, 81],   # 2 distinct values, monotone with export
+                jitter=[1, -1, 1, -1, 1, 0],                # @82 deliberately noisier
+            )
+            res = vs.validate_device(cap, exp, device="floor")
+        self.assertEqual(res["best_specificity_offset"], 82)
+        rejected = {s["offset"]: s for s in res["specificity_rejected_low_variance"]}
+        self.assertIn(84, rejected)
+        self.assertEqual(rejected[84]["distinct"], 2)
+
+    def test_the_floor_also_gates_82_itself(self):
+        """If @82 is the near-constant one, the checklist says so instead of trusting its r."""
+        base = _utc(2026, 2, 10, 0, 0, 0)
+        frames, exports = [], []
+        for i, spo2 in enumerate([94, 95, 96, 97, 98, 99]):
+            t0 = base + i * 86400 + 23 * 3600
+            t1 = t0 + 6 * 3600
+            frames.extend(_plant_night(t0, t1, 97 if i < 3 else 98))   # only 2 distinct values
+            start = datetime.fromtimestamp(t0, tz=timezone.utc).strftime("%Y-%m-%d %H:%M:%S")
+            exports.append((start, float(spo2), t0, t1))
+        with tempfile.TemporaryDirectory() as td:
+            cap = os.path.join(td, "capture.json")
+            with open(cap, "w") as f:
+                json.dump(frames, f)
+            res = vs.validate_device(cap, _write_export(td, exports), device="flat82")
+        self.assertEqual(res["inband_distinct_82"], 2)
+        self.assertFalse(res["checklist"]["value_variance"])
+        self.assertFalse(res["checklist"]["pass"])
+
+    def test_a_real_spread_clears_the_floor(self):
+        with tempfile.TemporaryDirectory() as td:
+            cap, exp = self._device(
+                td,
+                spo2s=[93, 95, 96, 97, 98, 100],
+                neighbor_offset=90,
+                neighbor_values=[0] * 6,
+                jitter=[0] * 6,
+            )
+            res = vs.validate_device(cap, exp, device="spread")
+        self.assertGreaterEqual(res["inband_distinct_82"], vs.MIN_DISTINCT_INBAND)
+        self.assertTrue(res["checklist"]["value_variance"])
+
+
+class FeatureAbsentClassificationTests(unittest.TestCase):
+    """A subscription-free strap reads @82 = 0x00 on 100 % of records, including genuine deep sleep.
+    That device has not failed a correlation — it has no data to correlate. It must be classified,
+    and must count as neither a PASS nor a FAIL in the multi-device promote gate for #103."""
+
+    def _flat_zero_device(self, td, label, *, n_records=851, step_s=5):
+        t0 = _utc(2026, 1, 5, 23, 0, 0)
+        frames = [
+            {"hex": make_v18(unix=t0 + i * step_s, sleep_state=2, hr=52, aux_byte_82=0).hex()}
+            for i in range(n_records)
+        ]
+        cap = os.path.join(td, f"{label}.json")
+        with open(cap, "w") as f:
+            json.dump(frames, f)
+        exp_dir = os.path.join(td, label)
+        os.makedirs(exp_dir)
+        start = datetime.fromtimestamp(t0, tz=timezone.utc).strftime("%Y-%m-%d %H:%M:%S")
+        _write_export(exp_dir, [(start, 96.0, t0, t0 + n_records * step_s)])
+        return {"device": label, "capture": cap, "export": exp_dir}
+
+    def test_a_flat_zero_strap_is_classified_not_failed(self):
+        with tempfile.TemporaryDirectory() as td:
+            d = self._flat_zero_device(td, "no-feature")
+            res = vs.validate_device(d["capture"], d["export"], device="no-feature")
+        self.assertEqual(res["duty"]["mode"], "absent")
+        self.assertEqual(res["classification"], "feature_absent")
+        self.assertFalse(res["checklist"]["pass"])
+        self.assertIn("FEATURE ABSENT", vs.format_summary(res))
+        self.assertTrue(any("feature absent" in w for w in vs.coverage_warnings(res)))
+
+    def test_a_short_all_zero_capture_is_not_enough_to_claim_absence(self):
+        """Below the evidence bar this is 'we did not see it', which is the very confusion the duty
+        cycle creates — so it stays a plain FAIL rather than an absence claim."""
+        with tempfile.TemporaryDirectory() as td:
+            d = self._flat_zero_device(td, "short", n_records=40, step_s=5)
+            res = vs.validate_device(d["capture"], d["export"], device="short")
+        self.assertEqual(res["duty"]["mode"], "absent")
+        self.assertEqual(res["classification"], "fail")
+
+    def test_an_absent_device_is_neither_a_pass_nor_a_fail_in_the_promote_gate(self):
+        def passing(td, label, spo2s):
+            base = _utc(2026, 1, 20, 0, 0, 0)
+            frames, exports = [], []
+            for i, spo2 in enumerate(spo2s):
+                t0 = base + i * 86400 + 23 * 3600
+                t1 = t0 + 7 * 3600
+                frames.extend(_plant_night(t0, t1, spo2))
+                start = datetime.fromtimestamp(t0, tz=timezone.utc).strftime("%Y-%m-%d %H:%M:%S")
+                exports.append((start, float(spo2), t0, t1))
+            cap = os.path.join(td, f"{label}.json")
+            with open(cap, "w") as f:
+                json.dump(frames, f)
+            exp_dir = os.path.join(td, label)
+            os.makedirs(exp_dir)
+            _write_export(exp_dir, exports)
+            return {"device": label, "capture": cap, "export": exp_dir}
+
+        with tempfile.TemporaryDirectory() as td:
+            entries = [
+                passing(td, "strap-a", [95, 96, 97, 98, 94, 99]),
+                passing(td, "strap-b", [93, 94, 95, 96, 97, 98]),
+                self._flat_zero_device(td, "strap-c"),
+            ]
+            results = [
+                vs.validate_device(e["capture"], e["export"], device=e["device"]) for e in entries
+            ]
+        blob = vs.format_postable(results)
+        self.assertIn("multi_device_eligible=2", blob)   # the absent strap is not eligible…
+        self.assertIn("all_pass=True", blob)             # …and does not drag all_pass down
+        self.assertIn("feature_absent=1", blob)
+        self.assertIn("strap-c,feature_absent,", blob)
+
+    def test_postable_still_carries_no_raw_spo2_values(self):
+        """The duty/coverage columns are device timing, not health data — the privacy property of
+        --postable has to survive everything added here."""
+        with tempfile.TemporaryDirectory() as td:
+            d = self._flat_zero_device(td, "priv")
+            res = vs.validate_device(d["capture"], d["export"], device="priv")
+        blob = vs.format_postable([res])
+        self.assertNotIn("96.00", blob)
+        self.assertNotIn("cycle_start", blob.lower())
+        self.assertIn("duty_mode", blob)

--- a/tools/linux-capture/validate_spo2_candidate.py
+++ b/tools/linux-capture/validate_spo2_candidate.py
@@ -9,12 +9,24 @@ Context (see docs/WHOOP5_DEEP_DATA.md and issue #103):
 
 This tool answers the promote-or-not question as *known plaintext*:
 
-    capture.json OR a whoop_sync.py .db  +  whoop_export  ──►  mean(@82 | asleep, 70–100)
+    capture.json OR a whoop_sync.py .db  +  whoop_export  ──►  mean(@82 | asleep, 70–100, in-window)
                                        vs CSV blood_oxygen_pct
-                                       ──►  r, MAE, bias, offset-specificity
+                                       ──►  r, MAE, bias, offset-specificity, window coverage
 
 Owners can validate one strap, or batch several devices, and post **only aggregate
 stats** on #103 (never raw SpO₂ values). Stdlib only.
+
+Three things the harness has to get right before a number from it means anything:
+
+  • **@82 is duty-cycled.** It is nonzero only inside a short, phase-locked window that repeats on a
+    fixed period; outside it the byte is identically 0x00. A capture that is not aligned to that
+    phase reads all zeros and looks exactly like a strap with the feature off. The harness therefore
+    DETECTS the period/phase/window length per capture (never assumes them), aggregates per window
+    rather than per second, and reports how much of each night's window schedule it actually sampled.
+  • **"value is in 70–100" is not a specific screen.** Timestamp bytes and thermal channels pass it.
+    An offset must also show real variation before its correlation is worth ranking.
+  • **A strap that never emits @82 is not a failed correlation.** It is classified `feature_absent`
+    and counts as neither a PASS nor a FAIL in the multi-device promote gate.
 
 Usage:
 
@@ -66,6 +78,44 @@ SLEEP_ASLEEP = 2
 
 # Scan window for offset-specificity (docs checklist: only @82 should win).
 SPECIFICITY_SCAN = range(74, 93)
+
+# --- Duty cycle ------------------------------------------------------------------------------------
+# @82 is NOT sampled every second. Measured on a corpus of 18,650 v18 records — 18,602 of them from
+# @digitalerdude's public PacketLogger capture of an official-app overnight sync, plus 48 from a NOOP
+# sync — the byte is nonzero in only 450 records (2.41 %), and every one of those falls inside a short
+# window that repeats on a fixed period: 15 windows, each exactly 30 records long, each starting at
+# the same `unix % 1200`, zero phase variance. Outside the window @82 is identically 0x00.
+#
+# Why this matters here more than anywhere else: a capture (or a sampling scheme) not aligned to that
+# phase reads all zeros and is indistinguishable from a strap with the feature switched off — a
+# plausible contributor to the contradictory cross-device evidence on #103, where one device
+# correlated +0.99 and another moved opposite. So this harness measures coverage instead of assuming
+# it, and a night whose windows were barely sampled is flagged rather than quietly averaged.
+#
+# What is treated as robust: that a periodic window EXISTS and has a stable length. What is NOT
+# assumed: the period, and above all the phase offset — neither is guaranteed to hold across straps
+# or firmware, so detect_duty_cycle() measures both per capture and reports what it found. The 1200 s
+# figure below is used only as a minimum-evidence bar, never as a detector input.
+NOMINAL_DUTY_PERIOD_S = 1200
+CONTINUOUS_NONZERO_FRACTION = 0.5   # ≥ this share nonzero ⇒ not duty-cycled; every second is a sample
+MIN_DUTY_WINDOWS = 3                # fewer observed windows than this ⇒ no period worth claiming
+DEFAULT_MIN_WINDOW_COVERAGE = 0.5   # below this share of a night's windows, its mean means little
+
+# "Feature absent" evidence bar. To call @82 absent rather than merely un-sampled, the capture must
+# be long enough that a duty-cycled feature would have fired several times while the wearer slept.
+ABSENT_MIN_RECORDS = 100
+ABSENT_MIN_ASLEEP_SPAN_S = 3 * NOMINAL_DUTY_PERIOD_S
+
+# --- Variance floor --------------------------------------------------------------------------------
+# "The value lands in 70–100" is not a specific screen. On a real subscription-free 5.0 strap SIX
+# offsets pass an in-band-only screen on a majority of records — @17, @33, @59, @69, @71, @107 — and
+# every one is either an already-decoded non-SpO₂ field (@33 cardiac_flags, @59 step_cadence, @69/@71
+# the two aux thermal channels) or near-constant: @17 is byte 2 of the u32 unix timestamp at @15 and
+# reads 99–100 for a day and a half of wall clock, and @107 has 4 distinct values. A nightly SpO₂
+# cannot have 2 distinct values, so an offset must clear a variation floor before its correlation is
+# worth ranking — otherwise a 2-valued byte can win a 5-night |r| race by coincidence alone.
+MIN_DISTINCT_INBAND = 5
+MIN_INBAND_STDEV = 0.5
 
 # English + localized cycle headers → canonical keys (mirrors StrandImport HeaderNorm subset).
 HEADER_ALIASES = {
@@ -293,6 +343,137 @@ def iter_v18_records(capture_records: Sequence[dict]) -> Iterable[dict]:
         yield d
 
 
+# --- Duty-cycle detection --------------------------------------------------------------------------
+
+def _median_record_interval(records: Sequence[dict]) -> float:
+    """Median seconds between consecutive records. Sets the run-gap tolerance so detection works on a
+    1 Hz capture and on a sparser one without a hard-coded cadence."""
+    stamps = sorted({r["unix"] for r in records})
+    deltas = [b - a for a, b in zip(stamps, stamps[1:]) if b > a]
+    return float(statistics.median(deltas)) if deltas else 1.0
+
+
+def _circ_dist(a: int, b: int, period: int) -> int:
+    d = abs(a - b) % period
+    return min(d, period - d)
+
+
+def detect_duty_cycle(records: Sequence[dict], *, gap_tolerance_s: Optional[float] = None) -> dict:
+    """Measure @82's on/off schedule from the capture itself. Nothing about it is hard-coded.
+
+    Returns a dict whose `mode` is one of:
+      absent       — @82 is 0x00 on every record (the feature never fired, or is not present)
+      continuous   — @82 is nonzero on most records (no duty cycle to correct for)
+      duty_cycled  — nonzero only in a repeating, phase-locked window; period/phase/length measured
+      irregular    — nonzero sometimes, but with no period the harness is willing to claim
+
+    Only `duty_cycled` changes how nights are aggregated; the other modes fall through to the
+    per-sample behaviour, so a capture this cannot characterise is never silently reweighted.
+    """
+    n = len(records)
+    nonzero = [r for r in records if r.get("aux_byte_82")]
+    interval = _median_record_interval(records)
+    tol = gap_tolerance_s if gap_tolerance_s is not None else max(2.0 * interval, 2.0)
+
+    info = {
+        "mode": "absent",
+        "n_records": n,
+        "n_nonzero": len(nonzero),
+        "nonzero_fraction": (len(nonzero) / n) if n else 0.0,
+        "distinct_values": len({r["aux_byte_82"] for r in nonzero}),
+        "record_interval_s": interval,
+        "period_s": None,
+        "phase_s": None,
+        "window_len_s": None,
+        "windows_observed": 0,
+        "window_len_stable": None,
+        "phase_jitter_s": None,
+    }
+    if not nonzero:
+        return info
+    if info["nonzero_fraction"] >= CONTINUOUS_NONZERO_FRACTION:
+        info["mode"] = "continuous"
+        return info
+
+    # Group the nonzero seconds into runs; a run is one firing of the window.
+    stamps = sorted({r["unix"] for r in nonzero})
+    runs: List[List[int]] = [[stamps[0]]]
+    for prev, cur in zip(stamps, stamps[1:]):
+        if cur - prev <= tol:
+            runs[-1].append(cur)
+        else:
+            runs.append([cur])
+    spans = [run[-1] - run[0] + 1 for run in runs]
+    starts = [run[0] for run in runs]
+    info["windows_observed"] = len(runs)
+    info["window_len_s"] = int(statistics.median(spans))
+    info["window_len_stable"] = len(set(spans)) == 1
+
+    if len(starts) < MIN_DUTY_WINDOWS:
+        info["mode"] = "irregular"
+        return info
+    period = int(statistics.median(b - a for a, b in zip(starts, starts[1:])))
+    if period <= info["window_len_s"]:
+        info["mode"] = "irregular"
+        return info
+
+    # Circular medoid: the candidate phase closest to all the others, wrap-safe.
+    phases = [s % period for s in starts]
+    phase = min(phases, key=lambda p: sum(_circ_dist(p, q, period) for q in phases))
+    jitter = max(_circ_dist(p, phase, period) for p in phases)
+    info.update(period_s=period, phase_s=phase, phase_jitter_s=jitter)
+    info["mode"] = "duty_cycled" if jitter <= max(tol, 1) else "irregular"
+    return info
+
+
+def is_duty_cycled(duty: Optional[dict]) -> bool:
+    return bool(duty) and duty.get("mode") == "duty_cycled"
+
+
+def window_index(u: int, duty: dict) -> int:
+    return (u - duty["phase_s"]) // duty["period_s"]
+
+
+def in_duty_window(u: int, duty: dict) -> bool:
+    return (u - duty["phase_s"]) % duty["period_s"] < duty["window_len_s"]
+
+
+def duty_windows_in(t0: int, t1: int, duty: Optional[dict]) -> List[Tuple[int, int]]:
+    """The duty windows whose start falls in [t0, t1), from the DETECTED schedule."""
+    if not is_duty_cycled(duty):
+        return []
+    period, phase, wlen = duty["period_s"], duty["phase_s"], duty["window_len_s"]
+    if t1 <= t0 or (t1 - t0) // period > 100_000:
+        return []
+    out = []
+    s = t0 + ((phase - t0) % period)
+    while s < t1:
+        out.append((s, s + wlen))
+        s += period
+    return out
+
+
+def night_window_coverage(
+    records: Sequence[dict], t0: int, t1: int, duty: Optional[dict]
+) -> Tuple[Optional[int], Optional[int]]:
+    """(windows sampled, windows expected) for one night, or (None, None) if not duty-cycled.
+
+    Deliberately ignores sleep_state: this measures the CAPTURE, answering "did it sample the window
+    at all" — the failure mode a phase-unaligned capture hits — and keeps that separable from "the
+    wearer was awake", which is what the asleep filter on the aggregate already handles.
+    """
+    windows = duty_windows_in(t0, t1, duty)
+    if not windows:
+        return (None, None)
+    expected = {window_index(s, duty) for s, _ in windows}
+    sampled = {
+        window_index(r["unix"], duty)
+        for r in records
+        if t0 <= r["unix"] < t1 and in_duty_window(r["unix"], duty)
+    }
+    return (len(sampled & expected), len(expected))
+
+
 def night_mean_at_offset(
     records: Sequence[dict],
     t0: int,
@@ -300,9 +481,18 @@ def night_mean_at_offset(
     offset: int,
     *,
     require_asleep: bool = True,
+    duty: Optional[dict] = None,
 ) -> Optional[Tuple[float, int]]:
-    """Mean of in-band u8 samples at `offset` inside [t0, t1). Returns (mean, n) or None."""
-    vals = []
+    """Nightly aggregate of in-band u8 samples at `offset` inside [t0, t1). Returns (mean, n) or None.
+
+    On a duty-cycled capture only in-window samples count, and the aggregate is the mean of the
+    per-window means — one number per firing of the window, not one per second. A 30-second burst is
+    one measurement the strap took, not 30 independent ones; averaging per second silently weights
+    the night towards whichever windows the capture happened to sample most densely.
+    """
+    duty_cycled = is_duty_cycled(duty)
+    per_window: Dict[int, List[int]] = {}
+    vals: List[int] = []
     for r in records:
         u = r["unix"]
         if u < t0 or u >= t1:
@@ -313,11 +503,48 @@ def night_mean_at_offset(
         if frame is None or len(frame) <= offset:
             continue
         v = frame[offset]
+        if v not in INBAND:
+            continue
+        if duty_cycled:
+            if not in_duty_window(u, duty):
+                continue
+            per_window.setdefault(window_index(u, duty), []).append(v)
+        vals.append(v)
+    if not vals:
+        return None
+    if duty_cycled:
+        return (statistics.fmean(statistics.fmean(w) for w in per_window.values()), len(vals))
+    return (statistics.fmean(vals), len(vals))
+
+
+def offset_variability(
+    records: Sequence[dict],
+    offset: int,
+    *,
+    require_asleep: bool = True,
+    duty: Optional[dict] = None,
+) -> Tuple[int, float]:
+    """(distinct values, stdev) of the in-band samples at `offset`, pooled over the whole capture.
+
+    The specificity scan's floor: a byte with 2–4 distinct values across every record is a flag or an
+    enum that happens to land in 70–100, not a nightly measurement, however well it correlates.
+    """
+    duty_cycled = is_duty_cycled(duty)
+    vals = []
+    for r in records:
+        if require_asleep and r.get("sleep_state") != SLEEP_ASLEEP:
+            continue
+        if duty_cycled and not in_duty_window(r["unix"], duty):
+            continue
+        frame = r.get("_frame")
+        if frame is None or len(frame) <= offset:
+            continue
+        v = frame[offset]
         if v in INBAND:
             vals.append(v)
     if not vals:
-        return None
-    return (statistics.fmean(vals), len(vals))
+        return (0, 0.0)
+    return (len(set(vals)), statistics.pstdev(vals) if len(vals) > 1 else 0.0)
 
 
 def pearson_r(xs: Sequence[float], ys: Sequence[float]) -> Optional[float]:
@@ -349,35 +576,44 @@ def validate_device(
     device: str = "device",
     require_asleep: bool = True,
     device_id: int = 2,
+    min_window_coverage: float = DEFAULT_MIN_WINDOW_COVERAGE,
+    min_distinct: int = MIN_DISTINCT_INBAND,
 ) -> dict:
     capture = load_frame_records(capture_path, device_id=device_id)
 
     cycles = load_cycles(export_path)
     records = list(iter_v18_records(capture))
 
+    # Measure the on/off schedule before averaging anything against it.
+    duty = detect_duty_cycle(records)
+
     nights = []
     for c in cycles:
-        hit = night_mean_at_offset(
-            records, c["t0"], c["t1"], OFF_SPO2_CANDIDATE, require_asleep=require_asleep
-        )
-        if hit is None:
-            nights.append({
-                "cycle_start_time": c["cycle_start_time"],
-                "export": c["spo2_export"],
-                "candidate_mean": None,
-                "n_samples": 0,
-                "matched": False,
-            })
-            continue
-        mean_v, n = hit
-        nights.append({
+        covered, expected = night_window_coverage(records, c["t0"], c["t1"], duty)
+        coverage = (covered / expected) if expected else None
+        night = {
             "cycle_start_time": c["cycle_start_time"],
             "export": c["spo2_export"],
-            "candidate_mean": mean_v,
-            "n_samples": n,
-            "matched": True,
-            "abs_err": abs(mean_v - c["spo2_export"]),
-        })
+            "candidate_mean": None,
+            "n_samples": 0,
+            "matched": False,
+            "windows_sampled": covered,
+            "windows_expected": expected,
+            "coverage": coverage,
+            "low_coverage": coverage is not None and coverage < min_window_coverage,
+        }
+        hit = night_mean_at_offset(
+            records, c["t0"], c["t1"], OFF_SPO2_CANDIDATE, require_asleep=require_asleep, duty=duty
+        )
+        if hit is not None:
+            mean_v, n = hit
+            night.update(
+                candidate_mean=mean_v,
+                n_samples=n,
+                matched=True,
+                abs_err=abs(mean_v - c["spo2_export"]),
+            )
+        nights.append(night)
 
     paired_export = [n["export"] for n in nights if n["matched"]]
     paired_cand = [n["candidate_mean"] for n in nights if n["matched"]]
@@ -389,12 +625,20 @@ def validate_device(
     )
 
     # Offset specificity: among SPECIFICITY_SCAN, which offset maximises |r| on paired nights?
+    # An offset must clear the variation floor first — see MIN_DISTINCT_INBAND. Without it a byte
+    # holding 2 distinct in-band values can top the ranking on 5 nights by coincidence.
     spec_scores = []
+    rejected = []
     for off in SPECIFICITY_SCAN:
+        distinct, sd = offset_variability(records, off, require_asleep=require_asleep, duty=duty)
+        if distinct < min_distinct or sd < MIN_INBAND_STDEV:
+            if distinct:
+                rejected.append({"offset": off, "distinct": distinct, "stdev": sd})
+            continue
         xs, ys = [], []
         for c in cycles:
             hit = night_mean_at_offset(
-                records, c["t0"], c["t1"], off, require_asleep=require_asleep
+                records, c["t0"], c["t1"], off, require_asleep=require_asleep, duty=duty
             )
             if hit is None:
                 continue
@@ -406,6 +650,13 @@ def validate_device(
     spec_scores.sort(key=lambda s: abs(s["r"]), reverse=True)
     best_off = spec_scores[0]["offset"] if spec_scores else None
     r_at_82 = next((s["r"] for s in spec_scores if s["offset"] == OFF_SPO2_CANDIDATE), r)
+    distinct_82, stdev_82 = offset_variability(
+        records, OFF_SPO2_CANDIDATE, require_asleep=require_asleep, duty=duty
+    )
+
+    covs = [n["coverage"] for n in nights if n["coverage"] is not None]
+    median_coverage = statistics.median(covs) if covs else None
+    low_cov_nights = sum(1 for n in nights if n["low_coverage"])
 
     # Checklist gates (docs/WHOOP5_DEEP_DATA.md) — conservative defaults for instrumentation.
     n_paired = len(paired_cand)
@@ -417,8 +668,26 @@ def validate_device(
         "corr_ge_0_7": (r is not None and r >= 0.7),
         "mae_le_1_0": (err is not None and err <= 1.0),
         "offset_82_wins": best_off == OFF_SPO2_CANDIDATE,
+        # A byte with a handful of distinct values cannot be a nightly SpO₂ however well it correlates.
+        "value_variance": distinct_82 >= min_distinct and stdev_82 >= MIN_INBAND_STDEV,
+        # n/a (True) unless a duty cycle was detected and coverage could actually be measured.
+        "window_coverage": median_coverage is None or median_coverage >= min_window_coverage,
     }
     checklist["pass"] = all(checklist.values())
+
+    # A strap that never emits @82 has not failed a correlation — it has no data to correlate. Say so
+    # explicitly, but only once the capture is long enough that a duty-cycled feature would have had
+    # several chances to fire during sleep; a short capture that missed the window is not evidence.
+    asleep_stamps = [r["unix"] for r in records if r.get("sleep_state") == SLEEP_ASLEEP]
+    asleep_span = (max(asleep_stamps) - min(asleep_stamps)) if len(asleep_stamps) >= 2 else 0
+    feature_absent = (
+        duty["mode"] == "absent"
+        and len(records) >= ABSENT_MIN_RECORDS
+        and asleep_span >= ABSENT_MIN_ASLEEP_SPAN_S
+    )
+    classification = (
+        "feature_absent" if feature_absent else ("pass" if checklist["pass"] else "fail")
+    )
 
     return {
         "device": device,
@@ -431,6 +700,14 @@ def validate_device(
         "bias": bias,
         "best_specificity_offset": best_off,
         "specificity_top3": spec_scores[:3],
+        "specificity_rejected_low_variance": rejected,
+        "inband_distinct_82": distinct_82,
+        "inband_stdev_82": stdev_82,
+        "duty": duty,
+        "median_window_coverage": median_coverage,
+        "low_coverage_nights": low_cov_nights,
+        "asleep_span_s": asleep_span,
+        "classification": classification,
         "checklist": checklist,
         "nights": nights,
         "inband_samples_total": sum(n["n_samples"] for n in nights),
@@ -455,63 +732,172 @@ def format_summary(result: dict, *, show_nights: bool = False) -> str:
         f"MAE={'n/a' if mae_v is None else f'{mae_v:.3f}'}  "
         f"bias={'n/a' if bias is None else f'{bias:+.3f}'}"
     )
+    lines.append(format_duty_line(result))
+    cov = result.get("median_window_coverage")
+    if cov is not None:
+        lines.append(
+            f"  window coverage: median={cov:.0%} over {result['export_nights_with_spo2']} nights  "
+            f"low_coverage_nights={result['low_coverage_nights']}"
+        )
     lines.append(
         f"  specificity: best_offset={result['best_specificity_offset']}  "
+        f"@82 distinct_inband={result.get('inband_distinct_82', 0)} "
+        f"stdev={result.get('inband_stdev_82', 0.0):.2f}  "
         f"top3="
         + ", ".join(
             f"@{s['offset']} r={s['r']:+.3f} (n={s['nights']})"
             for s in result.get("specificity_top3", [])
         )
     )
+    rejected = result.get("specificity_rejected_low_variance", [])
+    if rejected:
+        lines.append(
+            "  rejected by variance floor (in-band but near-constant): "
+            + ", ".join(f"@{s['offset']}({s['distinct']}v)" for s in rejected)
+        )
     flags = " ".join(
         f"{k}={'PASS' if v else 'FAIL'}"
         for k, v in cl.items()
         if k != "pass"
     )
     lines.append(f"  checklist: {flags}")
-    lines.append(f"  OVERALL: {'PASS (candidate strengthens)' if cl['pass'] else 'FAIL (keep instrumentation-only)'}")
+    lines.append(f"  OVERALL: {OVERALL_TEXT[result.get('classification', 'fail')]}")
+    for w in coverage_warnings(result):
+        lines.append(f"  !! {w}")
     if show_nights:
         lines.append("  per-night (local only — do not post raw values):")
         for n in result["nights"]:
+            cov_s = (
+                f"  windows={n['windows_sampled']}/{n['windows_expected']}"
+                if n["windows_expected"] else ""
+            )
+            warn = "  !! LOW COVERAGE" if n["low_coverage"] else ""
             if not n["matched"]:
-                lines.append(f"    {n['cycle_start_time']}: export={n['export']:.2f}  candidate=—  (no in-band samples)")
+                lines.append(
+                    f"    {n['cycle_start_time']}: export={n['export']:.2f}  candidate=—  "
+                    f"(no in-band samples){cov_s}{warn}"
+                )
             else:
                 lines.append(
                     f"    {n['cycle_start_time']}: export={n['export']:.2f}  "
                     f"candidate={n['candidate_mean']:.2f}  n={n['n_samples']}  "
-                    f"|err|={n['abs_err']:.2f}"
+                    f"|err|={n['abs_err']:.2f}{cov_s}{warn}"
                 )
     return "\n".join(lines)
 
 
+OVERALL_TEXT = {
+    "pass": "PASS (candidate strengthens)",
+    "fail": "FAIL (keep instrumentation-only)",
+    "feature_absent": (
+        "FEATURE ABSENT (@82 flat 0x00 across the capture — neither a PASS nor a FAIL; "
+        "excluded from the multi-device gate)"
+    ),
+}
+
+
+def format_duty_line(result: dict) -> str:
+    """One line describing the DETECTED @82 schedule. Timing only — no health values."""
+    d = result.get("duty") or {}
+    mode = d.get("mode", "unknown")
+    head = (
+        f"  @82 duty cycle: mode={mode}  nonzero={d.get('n_nonzero', 0)}/{d.get('n_records', 0)} "
+        f"({d.get('nonzero_fraction', 0.0):.2%})  distinct_values={d.get('distinct_values', 0)}"
+    )
+    if mode != "duty_cycled":
+        return head
+    return (
+        head
+        + f"\n    detected: period={d['period_s']}s  window={d['window_len_s']}s  "
+        f"phase=unix%{d['period_s']}∈[{d['phase_s']},{d['phase_s'] + d['window_len_s'] - 1}]  "
+        f"windows_seen={d['windows_observed']}  jitter={d['phase_jitter_s']}s  "
+        f"equal_length_windows={d['window_len_stable']}"
+    )
+
+
+def coverage_warnings(result: dict) -> List[str]:
+    """Loud, quotable reasons a device's numbers should not be read at face value."""
+    out = []
+    d = result.get("duty") or {}
+    cov = result.get("median_window_coverage")
+    if cov is not None and cov < DEFAULT_MIN_WINDOW_COVERAGE:
+        out.append(
+            f"{result['device']}: only {cov:.0%} of the detected @82 windows were sampled — the "
+            f"nightly means are not comparable across devices; re-capture aligned to "
+            f"unix%{d.get('period_s')}={d.get('phase_s')}"
+        )
+    if result.get("low_coverage_nights"):
+        out.append(
+            f"{result['device']}: {result['low_coverage_nights']} night(s) below the coverage floor "
+            f"— their means rest on a fraction of the night's windows"
+        )
+    if result.get("classification") == "feature_absent":
+        out.append(
+            f"{result['device']}: @82 is 0x00 on all {d.get('n_records', 0)} v18 records across "
+            f"{result.get('asleep_span_s', 0) // 60} min of scored sleep — reported as feature "
+            f"absent, not as a failed correlation"
+        )
+    if d.get("mode") == "irregular":
+        out.append(
+            f"{result['device']}: @82 fires, but with no period this tool will claim — treating "
+            f"every sample as independent, which may over-weight dense bursts"
+        )
+    return out
+
+
 def format_postable(results: Sequence[dict]) -> str:
-    """One-liner block safe to paste on GitHub #103 (no health values)."""
+    """One-liner block safe to paste on GitHub #103 (no health values).
+
+    The duty columns are device timing, not health data: period/window/phase are what another owner
+    needs to align a capture, and coverage is what says whether a row is worth reading at all.
+    """
     lines = [
         "spo2_candidate_82 multi-device validation (validate_spo2_candidate.py)",
-        "device,paired_nights,r,mae,bias,best_offset,checklist_pass",
+        "device,classification,paired_nights,r,mae,bias,best_offset,"
+        "duty_mode,duty_period_s,duty_window_s,duty_phase_s,window_coverage,checklist_pass",
     ]
     for res in results:
         r = res["r"]
         mae_v = res["mae"]
         bias = res["bias"]
+        d = res.get("duty") or {}
+        cov = res.get("median_window_coverage")
         lines.append(
-            f"{res['device']},{res['paired_nights']},"
+            f"{res['device']},{res.get('classification', 'fail')},{res['paired_nights']},"
             f"{'' if r is None else f'{r:.3f}'},"
             f"{'' if mae_v is None else f'{mae_v:.3f}'},"
             f"{'' if bias is None else f'{bias:.3f}'},"
             f"{res['best_specificity_offset']},"
+            f"{d.get('mode', '')},"
+            f"{d.get('period_s') or ''},"
+            f"{d.get('window_len_s') or ''},"
+            f"{'' if d.get('phase_s') is None else d['phase_s']},"
+            f"{'' if cov is None else f'{cov:.2f}'},"
             f"{res['checklist']['pass']}"
         )
-    # Multi-device aggregate: promote only if every device with ≥5 paired nights passes.
-    eligible = [res for res in results if res["paired_nights"] >= 5]
+    # Multi-device aggregate: promote only if every device with ≥5 paired nights passes. A strap that
+    # never emits @82 is counted on neither side — it is not evidence for the candidate, and it is
+    # not evidence against it either.
+    absent = [res for res in results if res.get("classification") == "feature_absent"]
+    eligible = [
+        res for res in results
+        if res["paired_nights"] >= 5 and res.get("classification") != "feature_absent"
+    ]
     if eligible:
         all_pass = all(res["checklist"]["pass"] for res in eligible)
         lines.append(
             f"multi_device_eligible={len(eligible)} all_pass={all_pass} "
+            f"feature_absent={len(absent)} "
             f"(promote spo2Pct only if all_pass and ≥2 devices)"
         )
     else:
-        lines.append("multi_device_eligible=0 (need ≥5 paired nights per device)")
+        lines.append(
+            f"multi_device_eligible=0 feature_absent={len(absent)} "
+            f"(need ≥5 paired nights per device)"
+        )
+    for res in results:
+        for w in coverage_warnings(res):
+            lines.append(f"warning: {w}")
     return "\n".join(lines)
 
 
@@ -547,6 +933,20 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         action="store_true",
         help="print a CSV-ish block safe to paste on GitHub (no raw SpO₂ values)",
     )
+    p.add_argument(
+        "--min-window-coverage",
+        type=float,
+        default=DEFAULT_MIN_WINDOW_COVERAGE,
+        help="share of a night's detected @82 duty windows the capture must sample before its "
+             f"nightly mean is treated as meaningful (default: {DEFAULT_MIN_WINDOW_COVERAGE})",
+    )
+    p.add_argument(
+        "--min-distinct-values",
+        type=int,
+        default=MIN_DISTINCT_INBAND,
+        help="distinct in-band values an offset must show to enter the specificity ranking "
+             f"(default: {MIN_DISTINCT_INBAND}; a 2-valued byte is a flag, not a measurement)",
+    )
     args = p.parse_args(argv)
 
     require_asleep = not args.allow_any_sleep_state
@@ -566,6 +966,8 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
                     device=entry.get("device", "device"),
                     device_id=int(entry.get("device_id", args.device_id)),
                     require_asleep=require_asleep,
+                    min_window_coverage=args.min_window_coverage,
+                    min_distinct=args.min_distinct_values,
                 )
             )
     else:
@@ -578,6 +980,8 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
                 device=args.device,
                 device_id=args.device_id,
                 require_asleep=require_asleep,
+                min_window_coverage=args.min_window_coverage,
+                min_distinct=args.min_distinct_values,
             )
         )
 
@@ -587,6 +991,10 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
     if args.postable or len(results) > 1:
         print("--- postable summary (safe for #103) ---")
         print(format_postable(results))
+    # Same warnings on stderr so they survive a redirect of the report into a file.
+    for res in results:
+        for w in coverage_warnings(res):
+            print(f"warning: {w}", file=sys.stderr)
     return 0
 
 


### PR DESCRIPTION
`tools/linux-capture/validate_spo2_candidate.py` (#814, extended by #819) is what decides whether
`spo2_candidate_82` graduates to a real `spo2Pct`. Three properties of `@82` make its current numbers
unreliable — one of them badly enough to explain the split evidence on #103.

All three were established on an **18,650-record v18 corpus**: **18,602 of them from
[@digitalerdude](https://github.com/digitalerdude)'s public PacketLogger capture** of an official-app
overnight sync (posted on #103 — thank you, this analysis is not possible without it), plus 48 from a
NOOP sync on a subscription-free strap.

---

## 1. `@82` is duty-cycled, and the harness did not know

It is not sampled every second. Across the corpus it is nonzero in **450 records (2.41 %)**, carrying
24 distinct values in 1..160, and every one of those falls inside a window that repeats on a fixed
period:

| Measurement | Value |
|---|---|
| Records with `@82 != 0` | 450 / 18,650 (2.41 %) |
| Distinct nonzero values | 24, range 1..160 |
| Contiguous runs | **15** |
| Run lengths | **every single one exactly 30 records** |
| Run start phase | **`unix % 1200 == 337` on all 15 — zero variance** |
| Outside the window | identically `0x00` |

So `@82` is a 30-second measurement taken once every 20 minutes.

**Why that breaks validation:** a capture (or a sampling scheme) not aligned to that phase reads all
zeros and is *indistinguishable from a strap with the feature switched off*. Sub-sampling this very
corpus at one record per minute, off-phase, reproduces it exactly — 310 records, **zero** nonzero
`@82`, **0/16** windows covered. That is a plausible contributor to the contradictory cross-device
evidence this issue is stuck on, where one device correlated **+0.99** and another moved **opposite**:
the second device may not have disagreed so much as missed the window.

### What this PR changes

- **`detect_duty_cycle()` measures the schedule per capture** — period, phase, window length, window
  count, phase jitter — and classifies the capture `absent` / `continuous` / `duty_cycled` /
  `irregular`. Only `duty_cycled` changes how nights are aggregated, so a capture the tool cannot
  characterise is never silently reweighted. On the reference corpus it recovers
  `period=1200s window=30s phase=337 windows=15 jitter=0 equal_length_windows=True`, with nothing
  hard-coded.
- **The phase is deliberately *not* a constant.** The robust fact is that a periodic window exists and
  has a stable length; `337` is one strap's firmware and there is no evidence it generalises. The
  tests plant `900/111/20` and `600/42/10` schedules and require the tool to find them — a hard-coded
  phase fails there, rather than quietly mis-scoring a stranger's strap.
- **The nightly aggregate is now the mean of the per-window means**, not the mean of every second. A
  30-second burst is one measurement the strap took, not 30 independent ones; per-second averaging
  hands the night to whichever window the capture happened to sample most densely. (On the real
  corpus the two differ: 95.92 per-second vs 93.70 per-window.)
- **Coverage is reported per night** (windows sampled ÷ windows expected) and warned on below
  `--min-window-coverage` (default 0.5), because a night built on 2 of 21 windows is not comparable to
  one built on all 21.

```
  @82 duty cycle: mode=duty_cycled  nonzero=450/18602 (2.42%)  distinct_values=24
    detected: period=1200s  window=30s  phase=unix%1200∈[337,366]  windows_seen=15  jitter=0s  equal_length_windows=True
  window coverage: median=100% over 1 nights  low_coverage_nights=0
```

---

## 2. In-band-only screening is not specific

The harness screens candidate bytes by "value in 70–100". That is a numeric range, not a signature.

On a real subscription-free 5.0 strap, **six offsets are in-band on a majority of records**:

| Offset | In-band share | Distinct values | What it actually is |
|---|---|---|---|
| `@17` | 100 % | 2 | **byte 2 of the u32 unix timestamp at `@15`** — reads 99–100 for a day and a half of wall clock |
| `@33` | 90 % | 4 | `cardiac_flags` (already decoded) |
| `@59` | 62 % | 2 | `step_cadence` (already decoded) |
| `@69` | 100 % | 3 | `temp_aux_1_raw` (aux thermal channel) |
| `@71` | 100 % | 3 | `temp_aux_2_raw` (aux thermal channel) |
| `@107` | 62 % | 4 | undecoded, near-constant |

Every one is either an already-decoded non-SpO₂ field or near-constant. **A nightly SpO₂ cannot have
2 distinct values.** The timestamp passing an SpO₂ screen is the clearest statement of the problem.

The specificity scan now requires an offset to show **≥5 distinct in-band values and stdev ≥0.5**
before its correlation is ranked, rejected offsets are *reported* rather than dropped silently, and
`@82` is held to the same floor as a checklist gate. On the reference corpus `@82` clears it
(14 distinct, stdev 3.17) and `@75` does not (1 value).

The regression test plants a 2-valued byte at `@84` that correlates with the export **better** than
`@82` does. Without the floor the flag wins the scan and the tool reports "not specific to `@82`" —
exactly the wrong conclusion, from a byte that cannot be a measurement.

---

## 3. A strap that never emits `@82` is now classified, not failed

A subscription-free strap reads `@82 = 0x00` on **100 %** of its v18 records, including genuine deep
sleep. That device has not failed a correlation — it has no data to correlate, and counting it as a
FAIL biases the multi-device promote gate against the candidate for a reason that has nothing to do
with the candidate.

It is now classified **`feature_absent`** and counted as **neither a PASS nor a FAIL**:

```
strap-c,feature_absent,0,,,,None,absent,,,,,False
multi_device_eligible=2 all_pass=True feature_absent=1 (promote spo2Pct only if all_pass and ≥2 devices)
```

There is an evidence bar (≥100 records and ≥3 nominal periods of scored sleep) so that a short capture
which merely missed the window is not dressed up as an absence claim — that stays a plain FAIL. Given
finding 1, the distinction is the whole point.

---

## Privacy

`--postable` keeps its property of carrying **no raw SpO₂ values**. The added columns are device
timing (`duty_mode`, `duty_period_s`, `duty_window_s`, `duty_phase_s`, `window_coverage`) and a
classification. The phase is in fact the *useful* thing to share, since it is what another owner needs
in order to align a capture.

## Tests

`tools/linux-capture`: **178 → 194** (193 passed, 1 skipped, 0 failed) — `python3 -m pytest
tools/linux-capture/ -q`, and `python3 -m unittest discover` (the runner the README documents) agrees
at 194. `test_validate_spo2_candidate.py` goes **16 → 32**; all 16 pre-existing tests are unchanged
and still pass.

New coverage: schedule recovery at two planted **non-reference** schedules, refusal to claim a period
for scattered firings, aligned vs phase-misaligned coverage, per-window vs per-second aggregation, the
variance floor rejecting a better-correlating near-constant byte, the floor applied to `@82` itself,
`feature_absent` classification and its evidence bar, and the postable block still carrying no raw
values.

Also verified end-to-end against the real corpus through the actual CLI path, not only synthetic
fixtures.

## Scope

Python capture tooling plus the two doc sections that enumerate the harness's gates. No app code, no
decoder, no schema, no Swift/Kotlin — `spo2_candidate_82` remains instrumentation-only and this does
not move it.

Serves the **#103** promote gate directly: `spo2_candidate_82` → `spo2Pct` needs ≥2 devices that each
PASS, and until now a device could fail for having captured the wrong 30 seconds out of every 20
minutes. Related: **#845** (decoded-but-unread v18 fields — `@82` is one of them).

Corpus credit again to **@digitalerdude** (#103).
