### PR TITLE
WHOOP 5/MG: passive optical-block phase experiment (harness for #858, on top of #546)

### DIFF
--- a/Packages/WhoopProtocol/Package.swift
+++ b/Packages/WhoopProtocol/Package.swift
@@ -7,6 +7,7 @@ let package = Package(
     products: [
         .library(name: "WhoopProtocol", targets: ["WhoopProtocol"]),
         .executable(name: "whoop-decode", targets: ["whoop-decode"]),
+        .executable(name: "whoop-optical-experiment", targets: ["whoop-optical-experiment"]),
     ],
     targets: [
         .target(
@@ -15,6 +16,10 @@ let package = Package(
         ),
         .executableTarget(
             name: "whoop-decode",
+            dependencies: ["WhoopProtocol"]
+        ),
+        .executableTarget(
+            name: "whoop-optical-experiment",
             dependencies: ["WhoopProtocol"]
         ),
         .testTarget(

--- a/Packages/WhoopProtocol/Sources/WhoopProtocol/OpticalExperimentAnalysis.swift
+++ b/Packages/WhoopProtocol/Sources/WhoopProtocol/OpticalExperimentAnalysis.swift
@@ -1,0 +1,378 @@
+import Foundation
+
+/// A phase marker written by NOOP while a controlled WHOOP 5/MG optical experiment is running.
+/// `unixTs` deliberately shares a clock domain with each v20 frame's `baseTs`; log-arrival time does
+/// not, because the strap may deliver a buffer minutes or hours later during history offload.
+public struct OpticalExperimentMarker: Codable, Equatable, Sendable {
+    public let label: String
+    public let unixTs: Int
+    public let loggedAtMs: Int?
+
+    public init(label: String, unixTs: Int, loggedAtMs: Int? = nil) {
+        self.label = label
+        self.unixTs = unixTs
+        self.loggedAtMs = loggedAtMs
+    }
+}
+
+public struct OpticalExperimentChannelSummary: Codable, Equatable, Sendable {
+    public let sampleCount: Int
+    public let mean: Double?
+    public let rms: Double?
+    public let standardDeviation: Double?
+    public let minimum: Int32?
+    public let maximum: Int32?
+}
+
+public struct OpticalExperimentBlockSummary: Codable, Equatable, Sendable {
+    public let blockIndex: Int
+    public let frameCount: Int
+    public let sampleCountHistogram: [String: Int]
+    public let uniqueHeaderCount: Int
+    /// A 21-byte header assembled from the independently modal value at each byte offset. This stays
+    /// stable when AGC makes whole-header combinations unique.
+    public let modalHeaderHex: String?
+    public let channels: [OpticalExperimentChannelSummary]
+}
+
+public struct OpticalExperimentPhaseSummary: Codable, Equatable, Sendable {
+    public let label: String
+    public let startUnixTs: Int
+    public let endUnixTs: Int?
+    public let frameCount: Int
+    public let firstFrameUnixTs: Int?
+    public let lastFrameUnixTs: Int?
+    public let blocks: [OpticalExperimentBlockSummary]
+}
+
+public struct OpticalExperimentBlockComparison: Codable, Equatable, Sendable {
+    public let blockIndex: Int
+    public let frameCountDelta: Int
+    public let activationChanged: Bool
+    public let sampleCountHistogramChanged: Bool
+    /// Offsets in the 21-byte block header whose modal values differ between the two phases.
+    public let headerByteOffsetsChanged: [Int]
+    /// `to.mean - from.mean` for the two physical channel slots; nil if either phase has no samples.
+    public let channelMeanDeltas: [Double?]
+}
+
+public struct OpticalExperimentPhaseComparison: Codable, Equatable, Sendable {
+    public let fromLabel: String
+    public let fromStartUnixTs: Int
+    public let toLabel: String
+    public let toStartUnixTs: Int
+    public let blocks: [OpticalExperimentBlockComparison]
+}
+
+public struct OpticalExperimentReport: Codable, Equatable, Sendable {
+    public let markers: [OpticalExperimentMarker]
+    public let phases: [OpticalExperimentPhaseSummary]
+    public let comparisons: [OpticalExperimentPhaseComparison]
+    public let sourceLineCount: Int
+    public let decodedBufferCount: Int
+    public let assignedBufferCount: Int
+    public let ignoredLineCount: Int
+    public let invalidLineCount: Int
+    /// Frames this many seconds after every marker were treated as transition data and not assigned.
+    public let settlingSeconds: Int
+}
+
+/// Compares v20 optical blocks between user-labelled physical phases without assigning wavelengths or
+/// physiological meaning. It reports only directly observed activation, headers, and ADC statistics.
+public enum Whoop5OpticalExperimentAnalyzer {
+    private struct LogLine: Decodable {
+        let kind: String?
+        let label: String?
+        let unixTs: Int?
+        let loggedAtMs: Int?
+        let strapTs: Int?
+        let size: Int?
+        let hex: String?
+
+        enum CodingKeys: String, CodingKey {
+            case kind, label, size, hex
+            case unixTs = "unix_ts"
+            case loggedAtMs = "ts_ms"
+            case strapTs = "strap_ts"
+        }
+    }
+
+    private struct ChannelAccumulator {
+        var count = 0
+        var sum = 0.0
+        var sumSquares = 0.0
+        var minimum: Int32?
+        var maximum: Int32?
+
+        mutating func add(_ values: [Int32]) {
+            for value in values {
+                let d = Double(value)
+                count += 1
+                sum += d
+                sumSquares += d * d
+                minimum = minimum.map { Swift.min($0, value) } ?? value
+                maximum = maximum.map { Swift.max($0, value) } ?? value
+            }
+        }
+
+        func summary() -> OpticalExperimentChannelSummary {
+            OpticalExperimentChannelSummary(
+                sampleCount: count,
+                mean: count == 0 ? nil : sum / Double(count),
+                rms: count == 0 ? nil : sqrt(sumSquares / Double(count)),
+                standardDeviation: count == 0 ? nil : sqrt(max(
+                    0, sumSquares / Double(count) - pow(sum / Double(count), 2))),
+                minimum: minimum,
+                maximum: maximum)
+        }
+    }
+
+    private struct BlockAccumulator {
+        let index: Int
+        var frameCount = 0
+        var sampleCountHistogram: [Int: Int] = [:]
+        var headerCounts: [String: Int] = [:]
+        var headerByteCounts = Array(
+            repeating: [UInt8: Int](), count: Whoop5RawOptical.headerLength)
+        var channels = [ChannelAccumulator(), ChannelAccumulator()]
+
+        mutating func add(_ block: Whoop5OpticalBlock) {
+            frameCount += 1
+            sampleCountHistogram[block.sampleCount, default: 0] += 1
+            let header = block.rawHeader
+            headerCounts[hex(header), default: 0] += 1
+            for (offset, byte) in header.enumerated() where offset < headerByteCounts.count {
+                headerByteCounts[offset][byte, default: 0] += 1
+            }
+            for channelIndex in block.channels.indices where channelIndex < channels.count {
+                channels[channelIndex].add(block.channels[channelIndex].samples)
+            }
+        }
+
+        func summary() -> OpticalExperimentBlockSummary {
+            let modalHeader: String? = frameCount == 0 ? nil : hex(headerByteCounts.compactMap { counts in
+                counts.max {
+                    $0.value == $1.value ? $0.key > $1.key : $0.value < $1.value
+                }?.key
+            })
+            return OpticalExperimentBlockSummary(
+                blockIndex: index,
+                frameCount: frameCount,
+                sampleCountHistogram: Dictionary(uniqueKeysWithValues:
+                    sampleCountHistogram.map { (String($0.key), $0.value) }),
+                uniqueHeaderCount: headerCounts.count,
+                modalHeaderHex: modalHeader,
+                channels: channels.map { $0.summary() })
+        }
+    }
+
+    private struct PhaseAccumulator {
+        let marker: OpticalExperimentMarker
+        let endUnixTs: Int?
+        var frameCount = 0
+        var firstFrameUnixTs: Int?
+        var lastFrameUnixTs: Int?
+        var blocks = (0..<Whoop5RawOptical.blockCount).map { BlockAccumulator(index: $0) }
+
+        mutating func add(_ frame: Whoop5OpticalFrame) {
+            frameCount += 1
+            firstFrameUnixTs = firstFrameUnixTs.map { min($0, frame.baseTs) } ?? frame.baseTs
+            lastFrameUnixTs = lastFrameUnixTs.map { max($0, frame.baseTs) } ?? frame.baseTs
+            for block in frame.blocks where block.index < blocks.count {
+                blocks[block.index].add(block)
+            }
+        }
+
+        func summary() -> OpticalExperimentPhaseSummary {
+            OpticalExperimentPhaseSummary(
+                label: marker.label,
+                startUnixTs: marker.unixTs,
+                endUnixTs: endUnixTs,
+                frameCount: frameCount,
+                firstFrameUnixTs: firstFrameUnixTs,
+                lastFrameUnixTs: lastFrameUnixTs,
+                blocks: blocks.map { $0.summary() })
+        }
+    }
+
+    /// Analyze the append-only `puffin-deepbuffers.jsonl` format. Marker lines may appear after the
+    /// corresponding buffers; attribution uses `unix_ts` versus decoded frame `baseTs`, never line order.
+    public static func analyze(jsonl: String, settlingSeconds: Int = 0) -> OpticalExperimentReport {
+        let settlingSeconds = max(0, settlingSeconds)
+        var markers: [OpticalExperimentMarker] = []
+        jsonl.enumerateLines { line, _ in
+            guard let decoded = decodeLine(line),
+                  decoded.kind == "optical_phase",
+                  let label = decoded.label,
+                  let unixTs = decoded.unixTs else { return }
+            markers.append(OpticalExperimentMarker(
+                label: label, unixTs: unixTs, loggedAtMs: decoded.loggedAtMs))
+        }
+        markers.sort {
+            if $0.unixTs != $1.unixTs { return $0.unixTs < $1.unixTs }
+            return ($0.loggedAtMs ?? 0) < ($1.loggedAtMs ?? 0)
+        }
+
+        // `experiment_end` is a boundary, not a phase. Keep it in `markers` for provenance, but use it
+        // only as the preceding phase's end so later offload records are not attributed past the run.
+        var phases = markers.enumerated().compactMap { index, marker -> PhaseAccumulator? in
+            guard marker.label != "experiment_end" else { return nil }
+            return PhaseAccumulator(
+                marker: marker,
+                endUnixTs: index + 1 < markers.count ? markers[index + 1].unixTs : nil)
+        }
+        let phaseMarkers = phases.map(\.marker)
+        var sourceLineCount = 0
+        var decodedBufferCount = 0
+        var assignedBufferCount = 0
+        var ignoredLineCount = 0
+        var invalidLineCount = 0
+
+        jsonl.enumerateLines { line, _ in
+            sourceLineCount += 1
+            guard let decoded = decodeLine(line) else {
+                invalidLineCount += 1
+                return
+            }
+            if decoded.kind == "optical_phase" { return }
+            guard decoded.size == Whoop5RawOptical.bufferLength,
+                  let strapTs = decoded.strapTs,
+                  let encoded = decoded.hex else {
+                ignoredLineCount += 1
+                return
+            }
+            guard let bytes = bytes(fromHex: encoded),
+                  let frame = Whoop5RawOptical.decode(bytes) else {
+                invalidLineCount += 1
+                return
+            }
+            decodedBufferCount += 1
+            // Trust the decoded timestamp. `strap_ts` is retained as a consistency gate against a
+            // malformed/misassociated JSON envelope rather than as a substitute for frame content.
+            guard frame.baseTs == strapTs else {
+                invalidLineCount += 1
+                return
+            }
+            guard let phaseIndex = phaseIndex(for: frame.baseTs, markers: phaseMarkers),
+                  phases[phaseIndex].endUnixTs.map({ frame.baseTs < $0 }) ?? true else {
+                ignoredLineCount += 1
+                return
+            }
+            guard frame.baseTs >= phaseMarkers[phaseIndex].unixTs + settlingSeconds else {
+                ignoredLineCount += 1
+                return
+            }
+            phases[phaseIndex].add(frame)
+            assignedBufferCount += 1
+        }
+
+        let summaries = phases.map { $0.summary() }
+        return OpticalExperimentReport(
+            markers: markers,
+            phases: summaries,
+            comparisons: adjacentComparisons(summaries),
+            sourceLineCount: sourceLineCount,
+            decodedBufferCount: decodedBufferCount,
+            assignedBufferCount: assignedBufferCount,
+            ignoredLineCount: ignoredLineCount,
+            invalidLineCount: invalidLineCount,
+            settlingSeconds: settlingSeconds)
+    }
+
+    private static func adjacentComparisons(
+        _ phases: [OpticalExperimentPhaseSummary]
+    ) -> [OpticalExperimentPhaseComparison] {
+        guard phases.count > 1 else { return [] }
+        return (1..<phases.count).compactMap { index in
+            let from = phases[index - 1]
+            let to = phases[index]
+            // An explicit `experiment_end` creates a gap: don't present phases from separate runs as
+            // an adjacent controlled comparison merely because they share one file.
+            guard from.endUnixTs == to.startUnixTs else { return nil }
+            let blockCount = min(from.blocks.count, to.blocks.count)
+            let blocks = (0..<blockCount).map { blockIndex in
+                compare(from.blocks[blockIndex], to.blocks[blockIndex])
+            }
+            return OpticalExperimentPhaseComparison(
+                fromLabel: from.label,
+                fromStartUnixTs: from.startUnixTs,
+                toLabel: to.label,
+                toStartUnixTs: to.startUnixTs,
+                blocks: blocks)
+        }
+    }
+
+    private static func compare(
+        _ from: OpticalExperimentBlockSummary,
+        _ to: OpticalExperimentBlockSummary
+    ) -> OpticalExperimentBlockComparison {
+        let fromActive = from.channels.contains { $0.sampleCount > 0 }
+        let toActive = to.channels.contains { $0.sampleCount > 0 }
+        let fromHeader = from.modalHeaderHex.flatMap(bytes(fromHex:)) ?? []
+        let toHeader = to.modalHeaderHex.flatMap(bytes(fromHex:)) ?? []
+        let headerCount = min(fromHeader.count, toHeader.count)
+        var changed = (0..<headerCount).filter { fromHeader[$0] != toHeader[$0] }
+        if fromHeader.count != toHeader.count {
+            changed.append(contentsOf: headerCount..<max(fromHeader.count, toHeader.count))
+        }
+        let channelCount = min(from.channels.count, to.channels.count)
+        let deltas: [Double?] = (0..<channelCount).map { index in
+            guard let a = from.channels[index].mean, let b = to.channels[index].mean else { return nil }
+            return b - a
+        }
+        return OpticalExperimentBlockComparison(
+            blockIndex: from.blockIndex,
+            frameCountDelta: to.frameCount - from.frameCount,
+            activationChanged: fromActive != toActive,
+            sampleCountHistogramChanged: !sameHistogramDistribution(
+                from.sampleCountHistogram, to.sampleCountHistogram),
+            headerByteOffsetsChanged: changed,
+            channelMeanDeltas: deltas)
+    }
+
+    private static func sameHistogramDistribution(
+        _ lhs: [String: Int], _ rhs: [String: Int]
+    ) -> Bool {
+        let lhsTotal = lhs.values.reduce(0, +)
+        let rhsTotal = rhs.values.reduce(0, +)
+        if lhsTotal == 0 || rhsTotal == 0 { return lhsTotal == rhsTotal }
+        let keys = Set(lhs.keys).union(rhs.keys)
+        return keys.allSatisfy { key in
+            lhs[key, default: 0] * rhsTotal == rhs[key, default: 0] * lhsTotal
+        }
+    }
+
+    private static func phaseIndex(for timestamp: Int, markers: [OpticalExperimentMarker]) -> Int? {
+        guard !markers.isEmpty, timestamp >= markers[0].unixTs else { return nil }
+        var low = 0
+        var high = markers.count
+        while low < high {
+            let mid = (low + high) / 2
+            if markers[mid].unixTs <= timestamp { low = mid + 1 } else { high = mid }
+        }
+        return low - 1
+    }
+
+    private static func decodeLine(_ line: String) -> LogLine? {
+        try? JSONDecoder().decode(LogLine.self, from: Data(line.utf8))
+    }
+
+    private static func bytes(fromHex hexString: String) -> [UInt8]? {
+        let value = hexString.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard value.count.isMultiple(of: 2) else { return nil }
+        var output: [UInt8] = []
+        output.reserveCapacity(value.count / 2)
+        var index = value.startIndex
+        while index < value.endIndex {
+            let next = value.index(index, offsetBy: 2)
+            guard let byte = UInt8(value[index..<next], radix: 16) else { return nil }
+            output.append(byte)
+            index = next
+        }
+        return output
+    }
+}
+
+private func hex(_ bytes: [UInt8]) -> String {
+    bytes.map { String(format: "%02x", $0) }.joined()
+}

--- a/Packages/WhoopProtocol/Sources/whoop-optical-experiment/main.swift
+++ b/Packages/WhoopProtocol/Sources/whoop-optical-experiment/main.swift
@@ -1,0 +1,74 @@
+import Foundation
+import WhoopProtocol
+
+let help = """
+whoop-optical-experiment — compare WHOOP 5/MG v20 optical blocks across marked phases.
+
+USAGE:
+  whoop-optical-experiment [--compact] [--settling-seconds N] FILE
+  cat puffin-deepbuffers.jsonl | whoop-optical-experiment
+
+Reads NOOP's append-only deep-buffer JSONL, attributes each v20 frame using its strap timestamp
+(not delayed log-arrival time), and emits a JSON report containing per-phase block/header/channel
+statistics plus adjacent-phase deltas. It does not assign LED wavelengths or calculate SpO2/BP.
+The CLI excludes the first 10 seconds after each marker by default so physical transitions do not
+contaminate a phase; pass --settling-seconds 0 to retain every frame.
+"""
+
+func fail(_ message: String) -> Never {
+    FileHandle.standardError.write(Data((message + "\n").utf8))
+    exit(2)
+}
+
+var compact = false
+var settlingSeconds = 10
+var filePath: String?
+let arguments = Array(CommandLine.arguments.dropFirst())
+var index = 0
+while index < arguments.count {
+    let argument = arguments[index]
+    switch argument {
+    case "-h", "--help":
+        print(help)
+        exit(0)
+    case "--compact":
+        compact = true
+    case "--settling-seconds":
+        index += 1
+        guard index < arguments.count,
+              let value = Int(arguments[index]), value >= 0 else {
+            fail("--settling-seconds needs a non-negative integer")
+        }
+        settlingSeconds = value
+    default:
+        if argument.hasPrefix("-") { fail("unknown option: \(argument)") }
+        if filePath != nil { fail("only one input file is supported") }
+        filePath = argument
+    }
+    index += 1
+}
+
+let data: Data
+if let filePath {
+    guard let loaded = FileManager.default.contents(atPath: filePath) else {
+        fail("cannot read file: \(filePath)")
+    }
+    data = loaded
+} else {
+    data = FileHandle.standardInput.readDataToEndOfFile()
+}
+guard !data.isEmpty else { fail(help) }
+guard let jsonl = String(data: data, encoding: .utf8) else { fail("input is not valid UTF-8") }
+
+let report = Whoop5OpticalExperimentAnalyzer.analyze(
+    jsonl: jsonl, settlingSeconds: settlingSeconds)
+let encoder = JSONEncoder()
+encoder.keyEncodingStrategy = .convertToSnakeCase
+encoder.outputFormatting = compact ? [.sortedKeys] : [.prettyPrinted, .sortedKeys]
+do {
+    let encoded = try encoder.encode(report)
+    FileHandle.standardOutput.write(encoded)
+    FileHandle.standardOutput.write(Data("\n".utf8))
+} catch {
+    fail("could not encode report: \(error)")
+}

--- a/Packages/WhoopProtocol/Tests/WhoopProtocolTests/OpticalExperimentAnalysisTests.swift
+++ b/Packages/WhoopProtocol/Tests/WhoopProtocolTests/OpticalExperimentAnalysisTests.swift
@@ -1,0 +1,184 @@
+import XCTest
+@testable import WhoopProtocol
+
+final class OpticalExperimentAnalysisTests: XCTestCase {
+    func testAssignsDelayedOffloadByStrapTimestampAndComparesBlocks() throws {
+        let baseline = frame(baseTs: 150, block0Value: 10, block0HeaderByte1: 1,
+                             block1SampleCount: 0)
+        let covered = frame(baseTs: 250, block0Value: 30, block0HeaderByte1: 9,
+                            block1SampleCount: 1)
+
+        // Buffers deliberately precede markers in file order. Arrival order must not control phases.
+        let jsonl = [
+            bufferLine(baseline, strapTs: 150),
+            bufferLine(covered, strapTs: 250),
+            markerLine("baseline", unixTs: 100, loggedAtMs: 100_100),
+            markerLine("covered", unixTs: 200, loggedAtMs: 200_100),
+            markerLine("experiment_end", unixTs: 300, loggedAtMs: 300_100),
+        ].joined(separator: "\n")
+
+        let report = Whoop5OpticalExperimentAnalyzer.analyze(jsonl: jsonl)
+
+        XCTAssertEqual(report.decodedBufferCount, 2)
+        XCTAssertEqual(report.assignedBufferCount, 2)
+        XCTAssertEqual(report.phases.map(\.label), ["baseline", "covered"])
+        XCTAssertEqual(report.phases.map(\.frameCount), [1, 1])
+        XCTAssertEqual(report.phases[0].blocks[0].sampleCountHistogram, ["2": 1])
+        XCTAssertEqual(report.phases[0].blocks[0].channels[0].mean, 10)
+        XCTAssertEqual(report.phases[1].blocks[0].channels[0].mean, 30)
+
+        let baselineToCovered = report.comparisons[0]
+        XCTAssertEqual(baselineToCovered.blocks[0].headerByteOffsetsChanged, [1])
+        XCTAssertEqual(baselineToCovered.blocks[0].channelMeanDeltas[0], 20)
+        XCTAssertTrue(baselineToCovered.blocks[1].activationChanged)
+        XCTAssertEqual(baselineToCovered.blocks[1].sampleCountHistogramChanged, true)
+    }
+
+    func testRejectsEnvelopeTimestampMismatchAndCountsNoiseSeparately() {
+        let validFrame = frame(baseTs: 150, block0Value: 10, block0HeaderByte1: 1,
+                               block1SampleCount: 0)
+        let jsonl = [
+            markerLine("baseline", unixTs: 100, loggedAtMs: 100_100),
+            bufferLine(validFrame, strapTs: 151),
+            "{not-json}",
+            "{\"kind\":\"something_else\"}",
+        ].joined(separator: "\n")
+
+        let report = Whoop5OpticalExperimentAnalyzer.analyze(jsonl: jsonl)
+
+        XCTAssertEqual(report.decodedBufferCount, 1)
+        XCTAssertEqual(report.assignedBufferCount, 0)
+        XCTAssertEqual(report.invalidLineCount, 2) // malformed JSON + timestamp mismatch
+        XCTAssertEqual(report.ignoredLineCount, 1)
+    }
+
+    func testSettlingWindowDropsTransitionFrames() {
+        let early = frame(baseTs: 105, block0Value: 10, block0HeaderByte1: 1,
+                          block1SampleCount: 0)
+        let settled = frame(baseTs: 115, block0Value: 20, block0HeaderByte1: 1,
+                            block1SampleCount: 0)
+        let jsonl = [
+            markerLine("baseline", unixTs: 100, loggedAtMs: 100_100),
+            bufferLine(early, strapTs: 105),
+            bufferLine(settled, strapTs: 115),
+        ].joined(separator: "\n")
+
+        let report = Whoop5OpticalExperimentAnalyzer.analyze(jsonl: jsonl, settlingSeconds: 10)
+
+        XCTAssertEqual(report.settlingSeconds, 10)
+        XCTAssertEqual(report.decodedBufferCount, 2)
+        XCTAssertEqual(report.assignedBufferCount, 1)
+        XCTAssertEqual(report.ignoredLineCount, 1)
+        XCTAssertEqual(report.phases[0].blocks[0].channels[0].mean, 20)
+    }
+
+    func testComparisonIgnoresDifferentPhaseDurationsWithSameSampleCount() {
+        let lines = [
+            markerLine("first", unixTs: 100, loggedAtMs: 100_100),
+            bufferLine(frame(baseTs: 110, block0Value: 10, block0HeaderByte1: 1,
+                             block1SampleCount: 0), strapTs: 110),
+            markerLine("second", unixTs: 200, loggedAtMs: 200_100),
+            bufferLine(frame(baseTs: 210, block0Value: 10, block0HeaderByte1: 1,
+                             block1SampleCount: 0), strapTs: 210),
+            bufferLine(frame(baseTs: 211, block0Value: 10, block0HeaderByte1: 1,
+                             block1SampleCount: 0), strapTs: 211),
+        ]
+        let report = Whoop5OpticalExperimentAnalyzer.analyze(jsonl: lines.joined(separator: "\n"))
+
+        XCTAssertFalse(report.comparisons[0].blocks[0].sampleCountHistogramChanged)
+        XCTAssertEqual(report.comparisons[0].blocks[0].frameCountDelta, 1)
+    }
+
+    func testModalHeaderIsComputedPerByteWhenEveryWholeHeaderIsUnique() {
+        var a = frame(baseTs: 110, block0Value: 10, block0HeaderByte1: 1,
+                      block1SampleCount: 0)
+        var b = frame(baseTs: 111, block0Value: 10, block0HeaderByte1: 1,
+                      block1SampleCount: 0)
+        var c = frame(baseTs: 112, block0Value: 10, block0HeaderByte1: 2,
+                      block1SampleCount: 0)
+        let header = Whoop5RawOptical.blockStart
+        a[header + 2] = 3
+        b[header + 2] = 4
+        c[header + 2] = 3
+        let jsonl = [
+            markerLine("baseline", unixTs: 100, loggedAtMs: 100_100),
+            bufferLine(a, strapTs: 110),
+            bufferLine(b, strapTs: 111),
+            bufferLine(c, strapTs: 112),
+        ].joined(separator: "\n")
+
+        let report = Whoop5OpticalExperimentAnalyzer.analyze(jsonl: jsonl)
+
+        XCTAssertEqual(report.phases[0].blocks[0].uniqueHeaderCount, 3)
+        XCTAssertTrue(report.phases[0].blocks[0].modalHeaderHex?.hasPrefix("020103") == true)
+    }
+
+    func testEndMarkerSeparatesRunsAndSettlingUsesTheLaterRunStart() {
+        let earlySecondRun = frame(baseTs: 305, block0Value: 10, block0HeaderByte1: 1,
+                                   block1SampleCount: 0)
+        let settledSecondRun = frame(baseTs: 315, block0Value: 20, block0HeaderByte1: 1,
+                                     block1SampleCount: 0)
+        let jsonl = [
+            markerLine("first_run", unixTs: 100, loggedAtMs: 100_100),
+            markerLine("experiment_end", unixTs: 200, loggedAtMs: 200_100),
+            markerLine("second_run", unixTs: 300, loggedAtMs: 300_100),
+            bufferLine(earlySecondRun, strapTs: 305),
+            bufferLine(settledSecondRun, strapTs: 315),
+        ].joined(separator: "\n")
+
+        let report = Whoop5OpticalExperimentAnalyzer.analyze(jsonl: jsonl, settlingSeconds: 10)
+
+        XCTAssertEqual(report.phases.map(\.label), ["first_run", "second_run"])
+        XCTAssertEqual(report.phases.map(\.frameCount), [0, 1])
+        XCTAssertTrue(report.comparisons.isEmpty)
+    }
+
+    private func markerLine(_ label: String, unixTs: Int, loggedAtMs: Int) -> String {
+        "{\"kind\":\"optical_phase\",\"label\":\"\(label)\",\"unix_ts\":\(unixTs),\"ts_ms\":\(loggedAtMs)}"
+    }
+
+    private func bufferLine(_ frame: [UInt8], strapTs: Int) -> String {
+        "{\"ts_ms\":999999,\"strap_ts\":\(strapTs),\"size\":\(frame.count),\"offload\":true,\"char\":\"fd4b\",\"hex\":\"\(hex(frame))\"}"
+    }
+
+    private func frame(baseTs: Int, block0Value: Int32, block0HeaderByte1: UInt8,
+                       block1SampleCount: Int) -> [UInt8] {
+        var bytes = [UInt8](repeating: 0, count: Whoop5RawOptical.bufferLength)
+        bytes[0] = 0xAA
+        bytes[8] = 0x2F
+        bytes[9] = 20
+        write(UInt32(7), to: &bytes, at: 11)
+        write(UInt32(baseTs), to: &bytes, at: 15)
+
+        let block0 = Whoop5RawOptical.blockStart
+        bytes[block0] = 2
+        bytes[block0 + 1] = block0HeaderByte1
+        for channel in 0..<2 {
+            let samples = block0 + Whoop5RawOptical.headerLength
+                + channel * Whoop5RawOptical.channelSlotLength
+            write(UInt32(bitPattern: block0Value), to: &bytes, at: samples)
+            write(UInt32(bitPattern: block0Value), to: &bytes, at: samples + 4)
+        }
+
+        let block1 = block0 + Whoop5RawOptical.blockLength
+        bytes[block1] = UInt8(block1SampleCount)
+        if block1SampleCount > 0 {
+            let samples = block1 + Whoop5RawOptical.headerLength
+            write(UInt32(bitPattern: 44), to: &bytes, at: samples)
+            write(UInt32(bitPattern: 55), to: &bytes,
+                  at: samples + Whoop5RawOptical.channelSlotLength)
+        }
+        return bytes
+    }
+
+    private func write(_ value: UInt32, to bytes: inout [UInt8], at offset: Int) {
+        bytes[offset] = UInt8(value & 0xFF)
+        bytes[offset + 1] = UInt8((value >> 8) & 0xFF)
+        bytes[offset + 2] = UInt8((value >> 16) & 0xFF)
+        bytes[offset + 3] = UInt8((value >> 24) & 0xFF)
+    }
+
+    private func hex(_ bytes: [UInt8]) -> String {
+        bytes.map { String(format: "%02x", $0) }.joined()
+    }
+}

--- a/Strand/BLE/BLEManager.swift
+++ b/Strand/BLE/BLEManager.swift
@@ -696,6 +696,18 @@ public final class BLEManager: NSObject, ObservableObject {
     /// Force the puffin capture buffer to disk so the Settings export/reveal targets a current file.
     public func flushPuffinCaptures() { puffinRecorder.flush() }
 
+    /// Record a local physical-phase marker for the passive optical experiment. This deliberately has
+    /// no peripheral/write path: it only appends to `puffin-deepbuffers.jsonl` when capture is enabled.
+    @discardableResult
+    func markWhoop5OpticalPhase(_ phase: PuffinOpticalExperimentPhase) -> Bool {
+        puffinDeepBufferLog.appendOpticalPhase(phase)
+    }
+
+    /// Flush and expose the passive deep-buffer experiment log for a user-initiated export.
+    func whoop5OpticalExperimentURL() -> URL? {
+        puffinDeepBufferLog.opticalExperimentURL()
+    }
+
     // MARK: CoreBluetooth
     private var central: CBCentralManager!
     private var peripheral: CBPeripheral?

--- a/Strand/BLE/PuffinDeepBufferLog.swift
+++ b/Strand/BLE/PuffinDeepBufferLog.swift
@@ -3,6 +3,33 @@ import CoreBluetooth
 import WhoopProtocol
 import StrandAnalytics
 
+/// Fixed physical phases for the passive WHOOP 5/MG optical experiment. A marker starts a phase and
+/// does not write anything to the strap; the next marker ends it. Labels are stable machine keys used
+/// by `whoop-optical-experiment`, while `displayName` is the user-facing action in Settings.
+enum PuffinOpticalExperimentPhase: String, CaseIterable, Sendable {
+    case onWristStill = "on_wrist_still"
+    case gentlePressure = "gentle_pressure"
+    case offWristDark = "off_wrist_dark"
+    case offWristRoomLight = "off_wrist_room_light"
+    case onWristAgain = "on_wrist_again"
+    case pacedBreathingSlow = "paced_breathing_slow"
+    case pacedBreathingNormal = "paced_breathing_normal"
+    case experimentEnd = "experiment_end"
+
+    var displayName: String {
+        switch self {
+        case .onWristStill: return String(localized: "On wrist · still")
+        case .gentlePressure: return String(localized: "On wrist · gentle pressure")
+        case .offWristDark: return String(localized: "Off wrist · sensor covered")
+        case .offWristRoomLight: return String(localized: "Off wrist · room light")
+        case .onWristAgain: return String(localized: "On wrist · again")
+        case .pacedBreathingSlow: return String(localized: "On wrist · slow paced breathing")
+        case .pacedBreathingNormal: return String(localized: "On wrist · normal breathing")
+        case .experimentEnd: return String(localized: "End experiment")
+        }
+    }
+}
+
 /// Durable append-only log of WHOOP 5.0/MG **high-rate deep buffers** — the large type-0x2F (R22)
 /// packets that carry tens-of-Hz sensor data (motion + optical) rather than the 1 Hz historical
 /// rollup NOOP already decodes (#423).
@@ -22,7 +49,10 @@ import StrandAnalytics
 /// buffer (`{"ts_ms":…,"strap_ts":…,"size":…,"offload":…,"char":…,"hex":"…"[,"imu":{…}]}`); `strap_ts`
 /// is the unix second the strap stamped at payload offset 15 (frame byte 15), the load-bearing key for
 /// aligning a buffer with what the wearer was doing. The optional `imu` object is the decoded activity
-/// summary present only on the 1244-B 6-axis buffer (see `decodedImuField`). Rotates at a soft cap keeping one previous
+/// summary present only on the 1244-B 6-axis buffer (see `decodedImuField`). Controlled experiments can
+/// append a second line shape (`{"kind":"optical_phase","label":…,"unix_ts":…,"ts_ms":…}`); the phone
+/// Unix second is compared with `strap_ts`, so a delayed offload is not mistaken for the activity at
+/// arrival time. Rotates at a soft cap keeping one previous
 /// generation, the same idiom as `PuffinEventLog`. Swift-only for now (experimental #423 instrument);
 /// a Kotlin twin follows if this graduates past reverse-engineering.
 @MainActor
@@ -55,6 +85,19 @@ final class PuffinDeepBufferLog {
 
     private var isEnabled: Bool {
         UserDefaults.standard.bool(forKey: PuffinFrameRecorder.enabledKey)
+    }
+
+    private struct MarkerLine: Encodable {
+        let kind: String
+        let label: String
+        let unixTs: Int
+        let tsMs: Int
+
+        enum CodingKeys: String, CodingKey {
+            case kind, label
+            case unixTs = "unix_ts"
+            case tsMs = "ts_ms"
+        }
     }
 
     /// `<AppSupport>/OpenWhoop/puffin-deepbuffers.jsonl` — OUTSIDE `puffin-captures/`, whose soft-cap
@@ -107,22 +150,65 @@ final class PuffinDeepBufferLog {
         let line = "{\"ts_ms\":\(tsMs),\"strap_ts\":\(strapTs),\"size\":\(frame.count),"
             + "\"offload\":\(isOffload),\"char\":\"\(char.uuidString.lowercased())\",\"hex\":\"\(hex)\"\(imu)}\n"
         do {
-            var h = try openHandle()
-            if try h.offset() > UInt64(Self.softCapBytes) {
-                close()
-                h = try openHandle()
-            }
-            try h.write(contentsOf: Data(line.utf8))
+            try append(line)
         } catch {
             // A diagnostics log must never affect the connection path: disable for this launch.
             disabled = true
         }
     }
 
+    /// Append a physical phase boundary using the same durable JSONL as the buffers. This is a local
+    /// file operation only: it does not need a BLE connection and never sends a strap command.
+    @discardableResult
+    func appendOpticalPhase(_ phase: PuffinOpticalExperimentPhase, now: Date = Date()) -> Bool {
+        guard !disabled, isEnabled else { return false }
+        let tsMs = Int(now.timeIntervalSince1970 * 1000)
+        let unixTs = Int(now.timeIntervalSince1970)
+        guard let line = Self.markerJSONLine(phase: phase, tsMs: tsMs, unixTs: unixTs) else {
+            return false
+        }
+        do {
+            try append(line + "\n")
+            return true
+        } catch {
+            disabled = true
+            return false
+        }
+    }
+
+    /// Pure encoder pinned by a unit test so the offline analyzer and app cannot silently drift apart.
+    nonisolated static func markerJSONLine(
+        phase: PuffinOpticalExperimentPhase, tsMs: Int, unixTs: Int
+    ) -> String? {
+        let marker = MarkerLine(kind: "optical_phase", label: phase.rawValue,
+                                unixTs: unixTs, tsMs: tsMs)
+        guard let data = try? JSONEncoder().encode(marker) else { return nil }
+        return String(data: data, encoding: .utf8)
+    }
+
+    /// Close the handle and return the live generation for sharing. Experiments are intentionally kept
+    /// short enough to stay below the 60 MB rotation cap; the previous generation remains on disk.
+    func opticalExperimentURL() -> URL? {
+        close()
+        guard let url = try? Self.logURL(), FileManager.default.fileExists(atPath: url.path) else {
+            return nil
+        }
+        return url
+    }
+
     /// Close the handle (e.g. on disconnect) so the file is safe to share/export immediately.
     func close() {
         try? handle?.close()
         handle = nil
+    }
+
+    private func append(_ line: String) throws {
+        var h = try openHandle()
+        if try h.offset() > UInt64(Self.softCapBytes) {
+            close()
+            h = try openHandle()
+        }
+        try h.write(contentsOf: Data(line.utf8))
     }
 
     private func openHandle() throws -> FileHandle {

--- a/Strand/Screens/SettingsView.swift
+++ b/Strand/Screens/SettingsView.swift
@@ -146,6 +146,11 @@ struct SettingsView: View {
     @State private var rawCsvBusy = false
     @State private var lastRawCsvURL: URL?
 
+    /// Passive WHOOP 5/MG optical experiment: the picker writes local timestamp markers into the
+    /// durable deep-buffer JSONL. It never calls a BLE write path.
+    @State private var showOpticalPhasePicker = false
+    @State private var opticalPhaseStatus = ""
+
     /// Confirm gate for the "Recalibrate Charge baseline" action (it re-learns the HRV anchor from tonight).
     @State private var showRecalibrateConfirm = false
 
@@ -234,6 +239,15 @@ struct SettingsView: View {
             Button("Cancel", role: .cancel) { }
         } message: {
             Text("This restarts the roughly 4-night build-up for Charge and your HRV baseline. Your history stays. Use it if a bad first week, like wearing it while sick, set your baseline off.")
+        }
+        .confirmationDialog("Mark optical experiment phase",
+                            isPresented: $showOpticalPhasePicker, titleVisibility: .visible) {
+            ForEach(PuffinOpticalExperimentPhase.allCases, id: \.self) { phase in
+                Button(phase.displayName) { markOpticalPhase(phase) }
+            }
+            Button("Cancel", role: .cancel) { }
+        } message: {
+            Text("A marker starts the selected phase and ends the previous one. This only timestamps the local capture file; it sends nothing to the strap.")
         }
         .sheet(isPresented: $showWhatsNew) {
             WhatsNewView(onClose: { showWhatsNew = false })
@@ -1501,6 +1515,31 @@ struct SettingsView: View {
                     .foregroundStyle(StrandPalette.textTertiary)
                     .fixedSize(horizontal: false, vertical: true)
 
+                if puffinCapture {
+                    Divider().overlay(StrandPalette.hairline)
+                    Text("Optical block experiment")
+                        .font(StrandFont.subhead)
+                        .foregroundStyle(StrandPalette.textPrimary)
+                    Text("Mark the start of each physical phase while wearing or handling the strap. NOOP aligns the marker to the timestamp inside delayed history buffers, then the offline analyzer compares block activation, header bytes and raw ADC changes. It does not assume a wavelength or calculate SpO₂/BP.")
+                        .font(StrandFont.caption)
+                        .foregroundStyle(StrandPalette.textTertiary)
+                        .fixedSize(horizontal: false, vertical: true)
+                    HStack(spacing: NoopMetrics.space3) {
+                        NoopButton("Mark phase…", systemImage: "flag.fill", kind: .primary) {
+                            showOpticalPhasePicker = true
+                        }
+                        NoopButton("Export experiment…", systemImage: "square.and.arrow.up", kind: .secondary) {
+                            exportOpticalExperiment()
+                        }
+                        Spacer(minLength: 0)
+                    }
+                    if !opticalPhaseStatus.isEmpty {
+                        Text(opticalPhaseStatus)
+                            .font(StrandFont.caption)
+                            .foregroundStyle(StrandPalette.textSecondary)
+                    }
+                }
+
                 if live.puffinCaptureCount > 0 {
                     Text(live.puffinCaptureCount == 1
                          ? "1 frame captured this session."
@@ -1656,6 +1695,28 @@ struct SettingsView: View {
         #else
         FileExport.exportFile(at: src, suggestedName: suggested)
         #endif
+    }
+
+    private func markOpticalPhase(_ phase: PuffinOpticalExperimentPhase) {
+        if model.ble.markWhoop5OpticalPhase(phase) {
+            opticalPhaseStatus = String(localized: "Marked: \(phase.displayName)")
+        } else {
+            opticalPhaseStatus = String(localized: "Marker wasn't saved. Keep frame recording on and try again.")
+        }
+    }
+
+    /// Export the durable JSONL used by the optical comparison CLI. Closing its append handle first
+    /// makes the user-selected copy complete; logging reopens lazily on the next buffer or marker.
+    private func exportOpticalExperiment() {
+        guard let src = model.ble.whoop5OpticalExperimentURL() else {
+            backupAlertTitle = String(localized: "Nothing to export")
+            backupAlertMessage = String(localized: "No WHOOP 5/MG deep buffers or phase markers have been recorded yet.")
+            showBackupAlert = true
+            return
+        }
+        FileExport.exportFile(
+            at: src,
+            suggestedName: FileExport.timestampedName("noop-whoop5-optical-experiment", ext: "jsonl"))
     }
 
     /// One-tap matched-pair export (#510): export the raw puffin capture AND the strap log together,

--- a/StrandTests/PuffinDeepBufferLogTests.swift
+++ b/StrandTests/PuffinDeepBufferLogTests.swift
@@ -79,4 +79,18 @@ final class PuffinDeepBufferLogTests: XCTestCase {
         var bogus = [UInt8](repeating: 0, count: 1244); bogus[8] = 0x2F
         XCTAssertEqual(PuffinDeepBufferLog.decodedImuField(bogus), "")
     }
+
+    /// The optical phase marker is a stable machine schema the offline analyzer depends on.
+    func testOpticalMarkerSchemaUsesStableClockAndLabelKeys() throws {
+        let line = try XCTUnwrap(PuffinDeepBufferLog.markerJSONLine(
+            phase: .offWristDark, tsMs: 1_234_567, unixTs: 1_234))
+        let object = try XCTUnwrap(JSONSerialization.jsonObject(with: Data(line.utf8)) as? [String: Any])
+
+        XCTAssertEqual(object["kind"] as? String, "optical_phase")
+        XCTAssertEqual(object["label"] as? String, "off_wrist_dark")
+        XCTAssertEqual(object["unix_ts"] as? Int, 1_234)
+        XCTAssertEqual(object["ts_ms"] as? Int, 1_234_567)
+        XCTAssertNil(object["strap_ts"])
+        XCTAssertNil(object["hex"])
+    }
 }

--- a/docs/WHOOP5_DEEP_DATA.md
+++ b/docs/WHOOP5_DEEP_DATA.md
@@ -1,6 +1,7 @@
 # WHOOP 5.0 / MG deep data — the "R22" unlock
 
-**Status:** experimental, opt-in, awaiting on-hardware confirmation.
+**Status:** experimental, opt-in. Deep-history delivery and v20/v21/v26 structural layouts are
+confirmed on hardware; wavelength identity and product-grade optical ingestion remain open.
 **Tracking:** [#103](https://github.com/ryanbr/noop/issues/103) (raw HCI captures + new deep-record layouts).
 
 ## The problem
@@ -86,9 +87,17 @@ that otherwise reproduced flags 1–15 byte-for-byte in this order.
   confirm is whether a clocked 5/MG already returns deep history through the plain
   `get_data_range`/`send_historical_data` loop NOOP already runs. If it does, the write path is belt-and-
   suspenders.
-- **The decode of what comes back is the next step.** Once a tester confirms deep records start arriving,
-  we map the type-`0x2F` layout (documented as HR @ byte 14, accel x/y/z float32 @ 37/41/45) and feed the
-  motion into NOOP's existing v25-style sleep stager.
+- **The large records are no longer an undifferentiated type-`0x2F` blob.** Layout v21 (1,244 bytes)
+  contains six-axis IMU data; layout v20 (2,140 bytes) contains five repeated optical measurement
+  blocks; layout v26 contains a 24-sample PPG waveform. The v20 blocks are preserved without
+  wavelength labels because the current capture does not prove red/IR identity.
+- **SpO₂ is not “one calibration away.”** The current v20 corpus has three active measurement blocks,
+  but it has not established two separate red and infrared illumination measurements. See
+  [`WHOOP5_OPTICAL_EXPERIMENT.md`](WHOOP5_OPTICAL_EXPERIMENT.md) for the passive controlled experiment
+  that must precede reference-oximeter calibration.
+- **Blood pressure is not a decode target yet.** No hidden BP scalar has been identified. BP would
+  require a validated model, reference-cuff data, population calibration, and an explicitly
+  non-medical product boundary after the underlying optical/motion channels are established.
 
 ## Why SpO₂ (and the raw respiration track) aren't available on 5.0
 

--- a/docs/WHOOP5_OPTICAL_EXPERIMENT.md
+++ b/docs/WHOOP5_OPTICAL_EXPERIMENT.md
@@ -1,0 +1,90 @@
+# WHOOP 5/MG optical block experiment
+
+**Status:** passive capture and offline comparison implemented on branch `whoop-decode-audit`.
+
+## Purpose
+
+The 2,140-byte layout-v20 record is structurally decoded as five repeated measurement blocks. Each
+block has one 21-byte header, two 200-byte readout slots, and one reserved byte. The existing corpus
+always has sample counts `[25, 0, 0, 25, 25]`, so blocks 1 and 2 are configured but inactive.
+
+The experiment answers narrower questions before any SpO₂ work:
+
+- Which blocks respond to wrist contact, darkness, room light, pressure, or paced breathing?
+- Do blocks 1 or 2 ever acquire samples?
+- Which of the 21 header bytes change with each physical condition?
+- Do the two readout slots within one block behave as paired detectors of one measurement?
+
+It intentionally does not call a block red, infrared, green, or ambient. It does not estimate SpO₂ or
+blood pressure.
+
+## Safety and timestamp model
+
+Phase marking is a local file append. It does not call the BLE command path or write a setting to the
+strap. The marker stores phone Unix time. The analyzer compares that time with the Unix timestamp
+inside each v20 frame, rather than the frame's arrival time, because the strap may deliver a buffer
+later during history offload.
+
+The first 10 seconds after every marker are excluded by the CLI by default. This keeps removal,
+replacement, covering, and pressure transitions out of the steady-state summaries.
+
+## Capture procedure
+
+Use a normal connected WHOOP 5/MG with its clock synchronized. Do not change R22/config flags during
+this experiment. If deep-history capture is not already working, establish that separately first.
+
+1. In **Settings → Advanced → Experimental · WHOOP 5 / MG**, enable **Record puffin frames to a
+   file**.
+2. Tap **Mark phase… → On wrist · still**. Sit still for 2 minutes.
+3. Tap **On wrist · gentle pressure**. Apply only comfortable, steady pressure to the strap for 2
+   minutes; stop if there is discomfort.
+4. Tap **Off wrist · sensor covered**. Remove the strap and place the sensor face inside an opaque cup
+   or under opaque cloth for 2 minutes. Do not press material into the sensor window.
+5. Tap **Off wrist · room light**. Leave the sensor face exposed and stationary for 2 minutes.
+6. Put the strap back in its normal position, tap **On wrist · again**, and remain still for 2 minutes.
+7. Optional respiration check: tap **On wrist · slow paced breathing**, breathe comfortably at about
+   6 breaths/min for 3 minutes, then tap **On wrist · normal breathing** and breathe normally for 2
+   minutes. Do not hold your breath or attempt desaturation.
+8. Tap **End experiment**. Leave frame recording enabled until the normal history sync has completed,
+   because some v20 buffers may arrive after the physical phases.
+9. Tap **Export experiment…** and save the `.jsonl` file.
+
+## Analyze the export
+
+From the repository:
+
+```bash
+cd Packages/WhoopProtocol
+swift run whoop-optical-experiment /path/to/noop-whoop5-optical-experiment.jsonl \
+  > optical-report.json
+```
+
+Use `--settling-seconds 0` to retain transition frames or another non-negative value to change the
+default 10-second exclusion. `--compact` emits single-line JSON.
+
+The report contains:
+
+- `phases[].frame_count` and decoded frame timestamp range;
+- each block's sample-count histogram, number of distinct headers, independently modal value for each
+  of the 21 header bytes, and per-slot sample count/mean/RMS/standard-deviation/min/max;
+- each adjacent phase comparison's activation change, sample-count change, exact header-byte offsets
+  that changed, and channel-mean deltas;
+- decoded, assigned, ignored, and invalid line counts so a sparse or malformed capture is visible.
+
+## Evidence rules for the next decision
+
+- A non-zero sample count in block 1 or 2 proves that a separate measurement became active. It does
+  not identify its wavelength.
+- A large room-light response that disappears when covered supports an ambient-sensitive
+  measurement. Repeatability is required before applying an ambient label.
+- A response that appears only on-wrist supports tissue coupling. Brightness alone does not identify
+  red versus infrared.
+- Consistent shared-header changes affect the measurement block; changes confined to one seven-byte
+  channel metadata group affect one readout slot. Register names still require a confirmed mapping or
+  controlled one-variable intervention.
+- Paced-breathing agreement supports a respiratory modulation candidate only if the peak follows two
+  or more commanded rates and dark/off-wrist controls do not reproduce it.
+
+Only after two separate illumination measurements are identified should the project begin reference
+oximeter calibration. Blood pressure remains a separate modeling and clinical-validation problem; it
+is not expected to be a hidden scalar in this record.

--- a/docs/WHOOP5_OPTICAL_EXPERIMENT.md
+++ b/docs/WHOOP5_OPTICAL_EXPERIMENT.md
@@ -1,6 +1,8 @@
 # WHOOP 5/MG optical block experiment
 
-**Status:** passive capture and offline comparison implemented on branch `whoop-decode-audit`.
+**Status:** passive capture and offline comparison implemented. No labelled run has been analysed yet
+— the harness exists so one can be. Related: #423 (the 5/MG high-rate offload thread this came out
+of), #858 (the capture request), #845 (the field inventory that names the open questions).
 
 ## Purpose
 


### PR DESCRIPTION
#546 gave the 2,140-byte layout-v20 record a **neutral** structure: five repeated 422-byte blocks, each with a 21-byte header, two 200-byte readout slots and a reserved byte, with sample counts that are always `[25, 0, 0, 25, 25]` in the existing corpus. Structure, deliberately without names — no block is called red, IR, green or ambient, because nothing in the bytes says so.

This adds the harness that could earn those names: a **passive** experiment that marks physical phases on the phone and compares what each block does across them, offline. It is the thing #858 asks a capture for and the thing #845 says the v18/v20 fields are missing.

## What it does

**Phase marking (app).** Settings → Advanced → Experimental · WHOOP 5/MG gains "Mark phase…" and "Export experiment…", shown only when frame recording is already on. A marker appends one line to the existing `puffin-deepbuffers.jsonl`:

```json
{"kind":"optical_phase","label":"off_wrist_dark","unix_ts":…,"ts_ms":…}
```

Eight fixed phases: on-wrist still, gentle pressure, off-wrist covered, off-wrist room light, on-wrist again, slow paced breathing, normal breathing, end.

**Offline analysis (`whoop-optical-experiment` CLI + `OpticalExperimentAnalysis`).** Reads that JSONL back, attributes each v20 frame to a phase, and emits JSON: per-phase block activation, per-header-byte behaviour, per-channel ADC statistics, and adjacent-phase deltas.

**Docs.** `docs/WHOOP5_OPTICAL_EXPERIMENT.md` — the capture procedure, the timestamp model, and what the output does and does not license you to conclude.

## The two design decisions that matter

**It sends nothing to the strap.** `markWhoop5OpticalPhase` reaches `PuffinDeepBufferLog.appendOpticalPhase`, which is a file append. There is no peripheral, no characteristic, no command path — not a read, not a write. The BLE safety contract is not merely respected here, it is structurally unreachable. This also means the harness needs no new permission, changes no connection behaviour, and cannot affect scoring.

**Attribution uses the strap's timestamp, not arrival time.** Deep buffers arrive during the connect-time offload burst, often minutes after the seconds they describe. Bucketing by log-arrival time would smear every phase into its neighbours. The analyzer compares the marker's phone Unix time against the Unix timestamp *inside* each v20 frame. The CLI also drops the first 10 s after each marker by default (`--settling-seconds`, 0 keeps everything), so putting the strap on, taking it off, covering it and pressing it stay out of the steady-state summaries.

## What it deliberately does not do

It does not assign a wavelength to any block, and it does not compute SpO₂ or blood pressure. Per the repo's rule on deriving a physiological signal from raw sensor data, an experiment that produced one matching number would prove nothing; the questions here are narrower and answerable:

- Which blocks respond to wrist contact, darkness, room light, pressure, paced breathing?
- Do blocks 1 and 2 — configured but showing 0 samples in every record so far — ever acquire?
- Which of the 21 header bytes move with which physical condition?
- Do the two readout slots inside one block behave as paired detectors of one measurement (rather than as two separate measurements)?

Those are the questions that have to be settled *before* anyone can honestly claim a wavelength, let alone a saturation.

## Verification

```
Packages/WhoopProtocol  swift build                      Build complete
Packages/WhoopProtocol  swift test                       343 tests, 0 failures   (184 new lines of tests)
macOS app               xcodebuild -scheme Strand build  ** BUILD SUCCEEDED **
macOS app               xcodebuild -scheme Strand test   959 tests, 1 skipped, 0 failures
                        python3 Tools/i18n_audit.py --ci  pass
                        python3 Tools/doc_comment_lint.py pass (no new detached doc comments)
```

The app-target half (`BLEManager`, `SettingsView`, `PuffinDeepBufferLog`) is compiled and tested locally, since `app-build.yml` is disabled by default.

**Not validated on hardware in this PR**, and it cannot be: the harness exists precisely because nobody has a labelled capture yet. The BLE surface it adds is a file append, so there is no connection behaviour to test on a strap.

## Cross-platform parity

**Swift only, on purpose.** The parity contract binds analytics and stored values; this stores no analytics and changes no scored number. The capture side (`PuffinDeepBufferLog`, `PuffinFrameRecorder`, the whole R22 deep-buffer lane from #423) has no Android counterpart at all, so there is nothing on Android for a marker to mark or an analyzer to read. If the deep-buffer lane is ever ported, the phase marker is ~30 lines of file append and this doc + CLI apply unchanged — the JSONL and the report format are the contract, not the Swift.

## Two small commits on top of the harness

- **i18n**: the four new user-facing strings were English-only, which `Tools/i18n_audit.py --ci` hard-fails. Translated into de/es/fr/pt-PT (zero-tolerance focus locales) and it/ru/zh-Hans/zh-Hant (each of which would otherwise have gone 4 over its ratcheting allowance). Appended textually so the other 3,255 catalog entries keep their bytes and their order.
- **docs**: the status line named a private fork branch nobody can resolve, and implied a result where there is only a harness. Points at #423/#858/#845 instead and says plainly that no labelled run has been analysed yet.

Related: #423, #858, #845. Builds directly on #546.
