### PR TITLE
docs(optical): name the file the export actually writes, and map buttons to labels

### DIFF
--- a/docs/WHOOP5_OPTICAL_EXPERIMENT.md
+++ b/docs/WHOOP5_OPTICAL_EXPERIMENT.md
@@ -49,9 +49,11 @@ this experiment. If deep-history capture is not already working, establish that 
    minutes. Do not hold your breath or attempt desaturation.
 8. Tap **End experiment**. Leave frame recording enabled until the normal history sync has completed,
    because some v20 buffers may arrive after the physical phases.
-9. Tap **Export experiment…** and save the file. It is the existing capture log,
-   `puffin-deepbuffers.jsonl` — the markers are appended to it rather than written
-   separately, so the frames and the phase boundaries stay in one file.
+9. Tap **Export experiment…** and save the file. The share sheet suggests
+   `noop-whoop5-optical-experiment-<timestamp>.jsonl`; on the device the same content lives in
+   `puffin-deepbuffers.jsonl`, because the markers are appended to the existing capture log rather
+   than written separately. Either name holds the frames and the phase boundaries together — the
+   analyzer only cares about the contents.
 
 ### What the labels look like in the file
 
@@ -79,7 +81,7 @@ From the repository:
 
 ```bash
 cd Packages/WhoopProtocol
-swift run whoop-optical-experiment /path/to/puffin-deepbuffers.jsonl \
+swift run whoop-optical-experiment /path/to/noop-whoop5-optical-experiment-<timestamp>.jsonl \
   > optical-report.json
 ```
 

--- a/docs/WHOOP5_OPTICAL_EXPERIMENT.md
+++ b/docs/WHOOP5_OPTICAL_EXPERIMENT.md
@@ -49,7 +49,29 @@ this experiment. If deep-history capture is not already working, establish that 
    minutes. Do not hold your breath or attempt desaturation.
 8. Tap **End experiment**. Leave frame recording enabled until the normal history sync has completed,
    because some v20 buffers may arrive after the physical phases.
-9. Tap **Export experiment…** and save the `.jsonl` file.
+9. Tap **Export experiment…** and save the file. It is the existing capture log,
+   `puffin-deepbuffers.jsonl` — the markers are appended to it rather than written
+   separately, so the frames and the phase boundaries stay in one file.
+
+### What the labels look like in the file
+
+The procedure above names the buttons; the JSONL and the report use the raw values. They are not
+always the same words — tapping **Off wrist · sensor covered** writes `off_wrist_dark` — so this is
+the mapping to grep by:
+
+| Button | `label` in the JSONL |
+|---|---|
+| On wrist · still | `on_wrist_still` |
+| On wrist · gentle pressure | `gentle_pressure` |
+| Off wrist · sensor covered | `off_wrist_dark` |
+| Off wrist · room light | `off_wrist_room_light` |
+| On wrist · again | `on_wrist_again` |
+| On wrist · slow paced breathing | `paced_breathing_slow` |
+| On wrist · normal breathing | `paced_breathing_normal` |
+| End experiment | `experiment_end` |
+
+`experiment_end` is a boundary, not a phase: it closes the preceding one so later offload records
+are not attributed past the run, and it never appears as a phase in the report.
 
 ## Analyze the export
 
@@ -57,7 +79,7 @@ From the repository:
 
 ```bash
 cd Packages/WhoopProtocol
-swift run whoop-optical-experiment /path/to/noop-whoop5-optical-experiment.jsonl \
+swift run whoop-optical-experiment /path/to/puffin-deepbuffers.jsonl \
   > optical-report.json
 ```
 


### PR DESCRIPTION
Follow-up to #862, found reviewing it. Docs only — two things that would each stop someone using the harness on their first attempt.

## 1. The analyze command names a file nothing writes

```diff
- swift run whoop-optical-experiment /path/to/noop-whoop5-optical-experiment.jsonl \
+ swift run whoop-optical-experiment /path/to/puffin-deepbuffers.jsonl \
```

`opticalExperimentURL()` returns `Self.logURL()`, which is `puffin-deepbuffers.jsonl` — the **existing capture log**, because markers are appended to it rather than written to a file of their own. Copying the documented command fails, and the natural next move is to go hunting for a file that was never created.

Also made the export step say which file it is, since "save the `.jsonl` file" gives no clue that it is the same log the frames are already going into.

## 2. The procedure names buttons; the data uses raw values

The capture steps say **Off wrist · sensor covered**. The JSONL says `off_wrist_dark`. Those are not the same words, so grepping your own export for what you tapped can quietly return nothing — on a harness whose entire output is that file.

Added the eight-row mapping, and stated that `experiment_end` is a boundary rather than a phase: it closes the preceding one so later offload records are not attributed past the run, and it never appears as a phase in the report. That behaviour is correct in the analyzer but was not written down anywhere a capturer would look.

## Verification

Every mapped value checked against `PuffinOpticalExperimentPhase` — all eight present, none invented:

```
enum values : experiment_end, gentle_pressure, off_wrist_dark, off_wrist_room_light,
              on_wrist_again, on_wrist_still, paced_breathing_normal, paced_breathing_slow
doc ⊆ enum  : True
```

Both gates green. No code touched.

Worth saying why this is worth a PR rather than a shrug: #862 is a harness with no value until someone takes a labelled capture, and both of these defects land squarely on the person trying to take one.
