### PR TITLE
Escalate strap battery alerts: a critical 12% crossing + a bedtime night-guard (Swift + Kotlin)

### DIFF
--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/BatteryEstimator.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/BatteryEstimator.swift
@@ -274,4 +274,205 @@ public enum BatteryEstimator {
         if fire { armedOff = true }
         return (fire, armedOff)
     }
+
+    // MARK: - The ~10% hardware cutoff
+
+    /// The strap stops sampling and drops the link NEAR THIS SoC, not at 0%. Measured on a WHOOP 5.0
+    /// running R22 deep-data + high-rate IMU capture: the SoC series ran 13.1% → 10.9% over 80 min and
+    /// the last HR sample of the session landed 27 min after that 10.9% reading, with no reading below
+    /// 10.9% ever banked. At that run's 1.65 %/h those 27 min are ~0.7 pp — the strap went dark at ~10%
+    /// with ~10 pp of nominal charge still showing.
+    ///
+    /// This matters because `estimate` divides the FULL current SoC by the drain rate, so its
+    /// `remainingHours` is time-to-**0%** and overstates usable life by `cutoffSocPct / rate` — ~6 h for
+    /// that user. Any consumer asking "will the strap survive the next N hours" must ask
+    /// `usableRemainingHours(…)`, never `Estimate.remainingHours`.
+    ///
+    /// Deliberately NOT folded into `estimate` itself: `remainingHours` feeds the Today "~X left" badge
+    /// and the Kotlin twin's shared fixtures, so re-anchoring it there would change a displayed number
+    /// and break documented Swift/Kotlin parity in the same commit. Kept additive instead.
+    public static let cutoffSocPct: Double = 10.0
+
+    /// Runtime left before the strap goes dark at `cutoffSocPct`, derived from an estimate's
+    /// time-to-0% figure. Algebraically `(currentSoc - cutoff) / rate` where `rate = currentSoc /
+    /// remainingHours`, rearranged so the rate is never recovered explicitly — which also carries the
+    /// #99 clamp through CONSERVATIVELY: that clamp only ever lowers `remainingHours`, so the usable
+    /// figure derived from it can only be pessimistic, never optimistic. 0 at or below the cutoff.
+    public static func usableRemainingHours(remainingHours: Double, currentSoc: Double) -> Double {
+        guard currentSoc > 0, remainingHours > 0 else { return 0 }
+        return max(0, remainingHours * (currentSoc - cutoffSocPct) / currentSoc)
+    }
+
+    /// `usableRemainingHours` for a whole `Estimate` — the form callers holding `live.batteryEstimate` want.
+    public static func usableRemainingHours(_ estimate: Estimate) -> Double {
+        usableRemainingHours(remainingHours: estimate.remainingHours, currentSoc: estimate.currentSoc)
+    }
+
+    // MARK: - Critical low-battery alert (the escalation the 15% alert can't give)
+
+    /// SoC at which the CRITICAL "charge it now" alert fires — a second crossing below
+    /// `BatteryNotifier.BatteryAlertPolicy.lowThreshold` (15%), with its own gate.
+    ///
+    /// Derived from `cutoffSocPct`, not picked round. The strap goes dark at ~10%, so the ENTIRE usable
+    /// alert band is (10%, 15%]. A conventional 5% critical threshold is unreachable on this hardware —
+    /// the strap is long dead — and even 10% is a coin flip (the lowest reading ever banked on the
+    /// reference run was 10.9%, and SoC reaches this policy already rounded to an Int). 12% sits
+    /// mid-band, was reliably reported on the reference run (12.4 / 12.1 / 11.9 / 11.6 / 11.4 / 11.1,
+    /// the first of which rounds to 12), and still clears the 15% line by 3 pp, so it is a genuinely
+    /// separate crossing rather than jitter around the same threshold.
+    ///
+    /// Lead time scales with how hard the user drives the strap, which is the point: at the reference
+    /// run's 1.65 %/h (R22 deep-data + high-rate IMU) 12% is ~1.2 h of warning before the cutoff; on a
+    /// stock 5.0 sipping ~0.35 %/h it is ~5.7 h. The 15% alert already carries the "plan to charge"
+    /// message — this one carries "you are about to lose data", which is worth sending even when the
+    /// runway is short.
+    public static let criticalSocPct = 12
+
+    /// Re-arm the critical gate on the same genuine recovery the 15% alert uses
+    /// (`BatteryAlertPolicy.lowRearmAbove` = 25), so one charge re-arms both and 11↔12% jitter can't
+    /// re-fire. Its own constant so the two policies stay independently tunable.
+    public static let criticalRearmAbovePct = 25
+
+    /// Crossing-with-hysteresis decision for the CRITICAL low alert, mirroring
+    /// `BatteryAlertPolicy.evaluate`'s shape: persisted gate in, fire decision plus next gate state out.
+    ///
+    /// Deliberately a SEPARATE policy with its OWN persisted flag rather than a second branch of
+    /// `BatteryAlertPolicy.evaluate`, because the failure this fixes IS the latch: the 15% alert fires
+    /// once and sets `lowAlerted = true` until SoC recovers to 25%, so on the reference incident the
+    /// user got one warning at 15% and then total silence across the ~3 h it took to reach the cutoff.
+    /// A latched `lowAlerted` must never be able to suppress this one.
+    ///
+    /// `charging == nil` (unknown) still fires — only a confirmed `true` suppresses — matching the SoC
+    /// low alert's null-tolerant rule: the strap reports its charge bit only every ~8 min.
+    public static func criticalAlert(pct: Int,
+                                     charging: Bool?,
+                                     alerted: Bool) -> (fire: Bool, newAlerted: Bool) {
+        var armedOff = alerted
+        if pct >= criticalRearmAbovePct { armedOff = false }
+        let fire = !armedOff && pct <= criticalSocPct && charging != true
+        if fire { armedOff = true }
+        return (fire, armedOff)
+    }
+
+    // MARK: - Bedtime night-guard ("this won't last the night")
+
+    /// How long before habitual bedtime the night-guard window opens. Wide enough that the strap's
+    /// ~8-minute battery cadence lands several readings inside it even with link churn, and that the
+    /// user can still act; narrow enough that the question is genuinely about TONIGHT.
+    public static let bedtimeLeadHours: Double = 3.0
+
+    /// Safety margin added on top of "wait until bedtime + tonight's sleep". Covers the slope fit's
+    /// error and the gap between the learned habitual night and any given night running long.
+    public static let bedtimeMarginHours: Double = 1.0
+
+    /// Floor on the number of nights behind `typicalSleepHours`. The midsleep learner's own
+    /// `SleepStageTotals.habitualMinDays` (14) already gates the whole night-guard — with no learned
+    /// midsleep there is no bedtime and `bedtimeAlert` returns silently — so this is a local
+    /// belt-and-braces bound ensuring the duration median itself is never taken off a night or two.
+    public static let bedtimeMinNights = 7
+
+    /// What tonight demands of the strap versus what it has. Returned by `bedtimeAlert` so the notifier
+    /// can word the alert from real numbers and the tests can assert the arithmetic, not just the Bool.
+    public struct NightRunway: Equatable, Sendable {
+        public let hoursUntilBedtime: Double
+        public let sleepHours: Double
+        /// `hoursUntilBedtime + sleepHours + bedtimeMarginHours`.
+        public let requiredHours: Double
+        /// Cutoff-aware runtime (`usableRemainingHours`), NOT the raw time-to-0% estimate.
+        public let usableHours: Double
+
+        public init(hoursUntilBedtime: Double, sleepHours: Double,
+                    requiredHours: Double, usableHours: Double) {
+            self.hoursUntilBedtime = hoursUntilBedtime
+            self.sleepHours = sleepHours
+            self.requiredHours = requiredHours
+            self.usableHours = usableHours
+        }
+
+        /// How far short the strap falls, in hours. 0 when it makes it.
+        public var shortfallHours: Double { max(0, requiredHours - usableHours) }
+    }
+
+    /// Typical night length (hours) for the night-guard: the MEDIAN of the recent per-night sleep
+    /// durations the sleep learner already produces — `IntelligenceEngine.computeHabitualSleep`'s
+    /// `nightlyHours` (TST of the longest block per LOCAL day, so naps drop out). Median rather than
+    /// mean so one all-nighter, or one night the strap itself died at 0.4 h, can't shrink tonight's
+    /// budget. nil under `minNights` — cold-start stays honest rather than inventing a night length.
+    public static func typicalSleepHours(nightlyHours: [Double],
+                                         minNights: Int = bedtimeMinNights) -> Double? {
+        let valid = nightlyHours.filter { $0 > 0 }
+        guard valid.count >= minNights else { return nil }
+        let sorted = valid.sorted()
+        let n = sorted.count
+        return n % 2 == 1 ? sorted[n / 2] : (sorted[n / 2 - 1] + sorted[n / 2]) / 2
+    }
+
+    /// Decide whether to tell the user, BEFORE they go to bed, that the strap won't survive the night.
+    ///
+    /// This is the alert the reference incident actually needed. That user's strap had already fired
+    /// both the 24 h "recharge tonight" runtime alert AND the 15% SoC alert — the device's persisted
+    /// flags confirm both — and both then LATCHED, so nothing spoke again through the final descent to
+    /// the cutoff, and a night of biometrics was lost. This policy is independent of both gates: it
+    /// asks a different question ("does the strap clear tonight specifically?") at a moment when the
+    /// answer is still actionable, so an earlier generic warning can never suppress it.
+    ///
+    /// Bedtime is derived from the sleep model the app ALREADY learns (#547) — `habitualMidsleepSec`
+    /// minus half the typical night — never from a fixed clock band, which would fire at the wrong hour
+    /// for exactly the shift/late sleepers that learner exists to serve.
+    ///
+    /// - Parameters:
+    ///   - nowSecOfDay: local time-of-day seconds in [0, 86400).
+    ///   - habitualMidsleepSec: learned midsleep as local seconds-of-day; nil at cold-start (< 14 nights).
+    ///   - typicalSleepHours: from `typicalSleepHours(nightlyHours:)`; nil at cold-start.
+    ///   - usableRemainingHours: cutoff-aware runtime; nil when there is no estimate at all.
+    ///   - alerted: the PERSISTED once-per-night gate.
+    public static func bedtimeAlert(nowSecOfDay: Int,
+                                    habitualMidsleepSec: Int?,
+                                    typicalSleepHours: Double?,
+                                    usableRemainingHours: Double?,
+                                    charging: Bool?,
+                                    alerted: Bool)
+        -> (fire: Bool, newAlerted: Bool, runway: NightRunway?) {
+        // Cold start: no learned midsleep or no duration history → there is NO honest bedtime to test
+        // against. Inventing one (a fixed 23:00) would fire at the wrong hour for the late/shift
+        // sleepers #547 exists for. Stay silent and leave the gate untouched; the 15% and critical SoC
+        // alerts remain the safety net.
+        guard let midsleep = habitualMidsleepSec,
+              let sleepHours = typicalSleepHours,
+              sleepHours > 0,
+              (0..<secondsPerDay).contains(midsleep),
+              (0..<secondsPerDay).contains(nowSecOfDay) else {
+            return (false, alerted, nil)
+        }
+        // Bedtime = midsleep - half the typical night, CIRCULAR so a 03:30 midsleep on an 8 h night is
+        // a 23:30 bedtime rather than a negative one.
+        let bedtimeSec = floorMod(midsleep - Int((sleepHours * 1800).rounded()), secondsPerDay)
+        let hoursUntilBedtime = Double(floorMod(bedtimeSec - nowSecOfDay, secondsPerDay)) / 3600.0
+        // Outside the pre-bed window — including the moment bedtime passes, when `hoursUntilBedtime`
+        // wraps to ~24 — the gate RE-ARMS. That wrap is what makes this once-per-NIGHT rather than
+        // once-per-discharge: each evening's window is a fresh crossing, so unlike the 15%/24 h alerts
+        // this one can speak again tomorrow without needing a charge to re-arm it.
+        guard hoursUntilBedtime <= bedtimeLeadHours else { return (false, false, nil) }
+        // No estimate at all (no banked SoC history yet) → nothing to judge; hold the gate.
+        guard let usable = usableRemainingHours else { return (false, alerted, nil) }
+        // The strap must survive the wait until bedtime AND the night itself, plus the margin.
+        // Anchoring to `hoursUntilBedtime` rather than a flat `sleepHours` is what keeps the whole lead
+        // window honest: firing 3 h before bed genuinely demands 3 h more runtime than firing at bed.
+        let required = hoursUntilBedtime + sleepHours + bedtimeMarginHours
+        let runway = NightRunway(hoursUntilBedtime: hoursUntilBedtime, sleepHours: sleepHours,
+                                 requiredHours: required, usableHours: usable)
+        let fire = !alerted && usable < required && charging != true
+        // Charging suppression must NOT consume the gate: unplug still inside the window and the alert
+        // must still be able to fire (mirrors `runtimeAlert`'s contract).
+        return (fire, fire ? true : alerted, runway)
+    }
+
+    private static let secondsPerDay = 86_400
+
+    /// Floored modulo — correct for negative operands, unlike Swift's `%`. Bedtime arithmetic wraps
+    /// midnight in both directions.
+    private static func floorMod(_ a: Int, _ n: Int) -> Int {
+        let r = a % n
+        return r < 0 ? r + n : r
+    }
 }

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/BatteryCriticalAlertTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/BatteryCriticalAlertTests.swift
@@ -1,0 +1,382 @@
+import XCTest
+@testable import StrandAnalytics
+
+/// The escalation alerts: the CRITICAL SoC crossing and the BEDTIME night-guard, plus the ~10% cutoff
+/// model they both rest on.
+///
+/// The fixture below is a REAL measured discharge from a WHOOP 5.0 running R22 deep-data + high-rate
+/// IMU capture — the run that lost the user a night of biometrics. Times are PDT; the strap's last HR
+/// sample of the session landed at 13:27, i.e. ~27 min after the final 10.9% reading and with no
+/// reading below 10.9% ever banked. That 27 min is the ground truth the cutoff model is scored against.
+final class BatteryCriticalAlertTests: XCTestCase {
+
+    // MARK: - The real discharge fixture
+
+    /// Arbitrary epoch anchor; only deltas matter to the fit.
+    private static let base = 1_700_000_000
+    /// Seconds after `base` for 13:27, when the strap actually went dark (27 min past the 10.9% read).
+    private static let deathOffset = 6420
+
+    /// The ten real readings, `(seconds after 11:40, SoC%)`.
+    private static let realTail: [(ts: Int, soc: Double)] = [
+        (0,    13.1),  // 11:40
+        (120,  12.9),  // 11:42
+        (660,  12.6),  // 11:51
+        (1020, 12.4),  // 11:57
+        (1620, 12.1),  // 12:07
+        (2160, 11.9),  // 12:16
+        (2760, 11.6),  // 12:26
+        (3060, 11.4),  // 12:31
+        (4080, 11.1),  // 12:48
+        (4800, 10.9),  // 13:00
+    ].map { (base + $0.0, $0.1) }
+
+    /// The tail as the estimator really saw it: `LiveState` seeds the SoC buffer from the persisted
+    /// battery table on connect (#7) and caps it at 400 readings (~53 h at the strap's ~8 min cadence),
+    /// so the fit window in production spans the whole discharge from the last near-full charge — NOT
+    /// just the 80 minutes of tail above. Reconstructed here at the measured 1.65 %/h from 95% down to
+    /// the 13.1% the tail opens on, ~8 min apart, which is what makes `source == .measured` reachable.
+    private static func realFullDischarge() -> [(ts: Int, soc: Double)] {
+        let rate = 1.65
+        let leadSeconds = Int((95.0 - 13.1) / rate * 3600)  // ~49.6 h
+        var out: [(ts: Int, soc: Double)] = []
+        for elapsed in stride(from: 0, to: leadSeconds, by: 480) {
+            out.append((base - leadSeconds + elapsed, 95.0 - rate * Double(elapsed) / 3600.0))
+        }
+        return out + realTail
+    }
+
+    // MARK: - A3 / A4: what the estimator actually says about this run
+
+    func testRealDischargeFitsMeasuredSlopeAtRoughly1Point65PctPerHour() {
+        let e = BatteryEstimator.estimate(samples: Self.realFullDischarge(),
+                                          ratedHours: BatteryEstimator.ratedLifeHoursWhoop5)
+        let est = try! XCTUnwrap(e)
+        XCTAssertEqual(est.source, .measured, "the seeded full-discharge buffer must beat the rated fallback")
+        XCTAssertEqual(est.currentSoc, 10.9, accuracy: 0.001)
+        // Recovered slope = currentSoc / remainingHours.
+        XCTAssertEqual(est.currentSoc / est.remainingHours, 1.65, accuracy: 0.02)
+    }
+
+    /// A4, the headline number: `estimate` divides the FULL SoC by the rate, so it reports time-to-0%.
+    /// At 10.9% and 1.65 %/h that is ~6.6 h of runway — but the strap died 27 min later. ~6 h of the
+    /// estimate is charge the hardware never actually spends.
+    func testRawEstimateOverstatesRunwayByTheWholeCutoffBand() {
+        let est = try! XCTUnwrap(BatteryEstimator.estimate(samples: Self.realFullDischarge(),
+                                                           ratedHours: BatteryEstimator.ratedLifeHoursWhoop5))
+        XCTAssertEqual(est.remainingHours, 6.6, accuracy: 0.15, "time-to-0%, not time-to-death")
+        let usable = BatteryEstimator.usableRemainingHours(est)
+        let overstatementHours = est.remainingHours - usable
+        XCTAssertEqual(overstatementHours, 6.06, accuracy: 0.15, "cutoff / rate = 10 / 1.65")
+    }
+
+    /// The cutoff model scored against ground truth: the strap went dark 27 min after the 10.9% read.
+    func testCutoffAwareRunwayMatchesTheObservedTimeOfDeath() {
+        let est = try! XCTUnwrap(BatteryEstimator.estimate(samples: Self.realFullDischarge(),
+                                                           ratedHours: BatteryEstimator.ratedLifeHoursWhoop5))
+        let usableMinutes = BatteryEstimator.usableRemainingHours(est) * 60
+        let observedMinutes = Double(Self.deathOffset - 4800) / 60  // 13:27 − 13:00 = 27 min
+        XCTAssertEqual(observedMinutes, 27, accuracy: 0.001)
+        XCTAssertEqual(usableMinutes, observedMinutes, accuracy: 10,
+                       "cutoff-aware runway should land within ~10 min of the real time of death")
+    }
+
+    func testUsableRunwayIsZeroAtOrBelowTheCutoff() {
+        XCTAssertEqual(BatteryEstimator.usableRemainingHours(remainingHours: 6.0, currentSoc: 10.0), 0)
+        XCTAssertEqual(BatteryEstimator.usableRemainingHours(remainingHours: 5.0, currentSoc: 8.0), 0)
+        XCTAssertEqual(BatteryEstimator.usableRemainingHours(remainingHours: 0, currentSoc: 50), 0)
+        XCTAssertEqual(BatteryEstimator.usableRemainingHours(remainingHours: 10, currentSoc: 0), 0)
+    }
+
+    func testUsableRunwayIsUnaffectedWellAboveTheCutoff() {
+        // 90% with 100 h to 0% → 100 × 80/90 = 88.9 h to the cutoff. Real but not dramatic up high.
+        XCTAssertEqual(BatteryEstimator.usableRemainingHours(remainingHours: 100, currentSoc: 90),
+                       88.89, accuracy: 0.01)
+    }
+
+    /// A3's latent second bug, isolated: on a WHOOP 5.0's 288 h rated fallback the predictive alert's
+    /// 24 h line sits at 8.3% SoC — BELOW the ~10% cutoff, so it is unreachable. A strap on the rated
+    /// path can therefore never warn before it dies. (The reference device's persisted
+    /// `batteryRuntimeAlerted = true` proves it was on the `.measured` path in practice.)
+    func testRatedFallbackOnWhoop5PutsThePredictiveAlertBelowTheHardwareCutoff() {
+        let ratedRate = 100.0 / BatteryEstimator.ratedLifeHoursWhoop5
+        let socAtAlertLine = BatteryEstimator.runtimeAlertHours * ratedRate
+        XCTAssertEqual(socAtAlertLine, 8.33, accuracy: 0.01)
+        XCTAssertLessThan(socAtAlertLine, BatteryEstimator.cutoffSocPct,
+                          "rated-path predictive alert is unreachable before the strap dies")
+    }
+
+    /// The same trap reached the honest way: a buffer holding ONLY the 80-minute tail spans 1.33 h,
+    /// short of `minSpanHours` (2.0), so the fit is rejected and the estimate falls back to rated —
+    /// reporting ~31 h of life on a strap with ~30 min left, and firing nothing.
+    func testShortBufferFallsBackToRatedAndThePredictiveAlertStaysSilent() {
+        let est = try! XCTUnwrap(BatteryEstimator.estimate(samples: Self.realTail,
+                                                           ratedHours: BatteryEstimator.ratedLifeHoursWhoop5))
+        XCTAssertEqual(est.source, .rated)
+        XCTAssertEqual(est.remainingHours, 31.4, accuracy: 0.2)
+        XCTAssertFalse(BatteryEstimator.runtimeAlert(remainingHours: est.remainingHours,
+                                                     charging: false, alerted: false).fire,
+                       "31 h estimate is above the 24 h line — no predictive alert, ~30 min before death")
+    }
+
+    // MARK: - B1: the critical SoC alert
+
+    /// The alert the incident needed: replay the real curve (SoC reaches the policy rounded, as
+    /// `AppModel` passes `Int(pct.rounded())`) and exactly one critical alert must fire — at 12.4% /
+    /// 11:57, which is 90 minutes of warning before the 13:27 death.
+    func testRealCurveFiresExactlyOneCriticalAlertWithNinetyMinutesOfWarning() {
+        var alerted = false
+        var firedAt: [Int] = []
+        for r in Self.realTail {
+            let out = BatteryEstimator.criticalAlert(pct: Int(r.soc.rounded()),
+                                                     charging: false, alerted: alerted)
+            if out.fire { firedAt.append(r.ts) }
+            alerted = out.newAlerted
+        }
+        XCTAssertEqual(firedAt.count, 1, "exactly once per discharge cycle")
+        let warningMinutes = Double(Self.base + Self.deathOffset - firedAt[0]) / 60
+        XCTAssertEqual(warningMinutes, 90, accuracy: 0.001)
+    }
+
+    /// The threshold is chosen against the cutoff, and the cutoff is what makes the conventional
+    /// choices wrong: on this hardware a 5% critical alert can never fire, and even 10% is a coin flip
+    /// (nothing below 10.9% was ever banked on the real run).
+    func testConventionalCriticalThresholdsAreUnreachableOnThisHardware() {
+        let lowestObserved = Self.realTail.map(\.soc).min()!
+        XCTAssertEqual(lowestObserved, 10.9, accuracy: 0.001)
+        for deadThreshold in [5, 8, 10] {
+            XCTAssertFalse(Self.realTail.contains { Int($0.soc.rounded()) <= deadThreshold },
+                           "\(deadThreshold)% is never reported before the strap dies")
+        }
+        // 12 is reported, and clears the 15% alert by a genuine 3 pp rather than jitter.
+        XCTAssertTrue(Self.realTail.contains { Int($0.soc.rounded()) <= BatteryEstimator.criticalSocPct })
+        XCTAssertEqual(BatteryEstimator.criticalSocPct, 12)
+    }
+
+    /// Latch independence — the actual bug. The critical gate is its OWN parameter (and, at the call
+    /// site, its own persisted key), so a 15% alert that has already fired and latched cannot silence
+    /// it. On the incident `behavior.batteryLowAlerted` was true for the whole final descent.
+    func testCriticalGateIsIndependentOfAnAlreadyLatchedLowAlert() {
+        // Whatever the low alert's gate is doing, a fresh critical gate at 12% fires.
+        XCTAssertTrue(BatteryEstimator.criticalAlert(pct: 12, charging: false, alerted: false).fire)
+        XCTAssertTrue(BatteryEstimator.criticalAlert(pct: 11, charging: nil, alerted: false).fire)
+    }
+
+    func testFiresAtThresholdAndArms() {
+        let r = BatteryEstimator.criticalAlert(pct: 12, charging: false, alerted: false)
+        XCTAssertTrue(r.fire)
+        XCTAssertTrue(r.newAlerted)
+    }
+
+    func testAboveThresholdNoFire() {
+        let r = BatteryEstimator.criticalAlert(pct: 13, charging: false, alerted: false)
+        XCTAssertFalse(r.fire)
+        XCTAssertFalse(r.newAlerted)
+    }
+
+    func testJitterInsideBandCannotRefire() {
+        var alerted = BatteryEstimator.criticalAlert(pct: 12, charging: nil, alerted: false).newAlerted
+        XCTAssertTrue(alerted)
+        for pct in [11, 13, 12, 14, 11] {
+            let r = BatteryEstimator.criticalAlert(pct: pct, charging: nil, alerted: alerted)
+            XCTAssertFalse(r.fire, "re-fired at \(pct)% inside the hysteresis band")
+            alerted = r.newAlerted
+        }
+    }
+
+    func testRearmsOnGenuineRecoveryThenFiresNextCycle() {
+        var alerted = BatteryEstimator.criticalAlert(pct: 11, charging: nil, alerted: false).newAlerted
+        let recovered = BatteryEstimator.criticalAlert(pct: 25, charging: nil, alerted: alerted)
+        XCTAssertFalse(recovered.fire)
+        XCTAssertFalse(recovered.newAlerted, "25% is the re-arm line (inclusive)")
+        alerted = recovered.newAlerted
+        XCTAssertTrue(BatteryEstimator.criticalAlert(pct: 12, charging: nil, alerted: alerted).fire)
+    }
+
+    func testRearmBoundaryIsInclusive() {
+        XCTAssertFalse(BatteryEstimator.criticalAlert(pct: 25, charging: nil, alerted: true).newAlerted)
+        XCTAssertTrue(BatteryEstimator.criticalAlert(pct: 24, charging: nil, alerted: true).newAlerted)
+    }
+
+    func testConfirmedChargingSuppressesButUnknownFires() {
+        XCTAssertFalse(BatteryEstimator.criticalAlert(pct: 8, charging: true, alerted: false).fire)
+        XCTAssertTrue(BatteryEstimator.criticalAlert(pct: 8, charging: nil, alerted: false).fire)
+    }
+
+    func testChargingSuppressionDoesNotArmGate() {
+        let plugged = BatteryEstimator.criticalAlert(pct: 11, charging: true, alerted: false)
+        XCTAssertFalse(plugged.newAlerted)
+        XCTAssertTrue(BatteryEstimator.criticalAlert(pct: 11, charging: false,
+                                                     alerted: plugged.newAlerted).fire)
+    }
+
+    // MARK: - typicalSleepHours
+
+    func testTypicalSleepHoursIsTheMedianAndIgnoresJunkNights() {
+        // A dead-strap 0.3 h night and an all-nighter must not drag the budget.
+        let nights = [7.9, 8.1, 0.3, 7.6, 8.4, 7.8, 8.0, 2.0]
+        let median = try! XCTUnwrap(BatteryEstimator.typicalSleepHours(nightlyHours: nights))
+        XCTAssertEqual(median, 7.85, accuracy: 0.001)
+    }
+
+    func testTypicalSleepHoursColdStart() {
+        XCTAssertNil(BatteryEstimator.typicalSleepHours(nightlyHours: []))
+        XCTAssertNil(BatteryEstimator.typicalSleepHours(nightlyHours: [8, 8, 8]))
+        XCTAssertNil(BatteryEstimator.typicalSleepHours(nightlyHours: Array(repeating: 0, count: 20)),
+                     "zero-length nights are not history")
+        XCTAssertNotNil(BatteryEstimator.typicalSleepHours(nightlyHours: Array(repeating: 8, count: 7)))
+    }
+
+    // MARK: - B2: the bedtime night-guard
+
+    /// 03:30 midsleep on an 8 h night → 23:30 bedtime, computed circularly (naively it is negative).
+    private let midsleep0330 = 3 * 3600 + 1800
+    private let sleep8h = 8.0
+    private func atClock(_ h: Int, _ m: Int = 0) -> Int { h * 3600 + m * 60 }
+
+    func testFiresBeforeBedWhenTheStrapWontClearTheNight() {
+        // 22:00, 1.5 h to a 23:30 bedtime → needs 1.5 + 8 + 1 = 10.5 h; has 5 h.
+        let r = BatteryEstimator.bedtimeAlert(nowSecOfDay: atClock(22), habitualMidsleepSec: midsleep0330,
+                                              typicalSleepHours: sleep8h, usableRemainingHours: 5,
+                                              charging: false, alerted: false)
+        XCTAssertTrue(r.fire)
+        XCTAssertTrue(r.newAlerted)
+        let runway = try! XCTUnwrap(r.runway)
+        XCTAssertEqual(runway.hoursUntilBedtime, 1.5, accuracy: 0.001, "bedtime wrapped midnight correctly")
+        XCTAssertEqual(runway.requiredHours, 10.5, accuracy: 0.001)
+        XCTAssertEqual(runway.shortfallHours, 5.5, accuracy: 0.001)
+    }
+
+    func testStaysSilentWhenTheStrapClearsTheNight() {
+        let r = BatteryEstimator.bedtimeAlert(nowSecOfDay: atClock(22), habitualMidsleepSec: midsleep0330,
+                                              typicalSleepHours: sleep8h, usableRemainingHours: 12,
+                                              charging: false, alerted: false)
+        XCTAssertFalse(r.fire)
+        XCTAssertEqual(try! XCTUnwrap(r.runway).shortfallHours, 0)
+    }
+
+    /// The requirement is anchored to the wait until bedtime, not a flat night: firing 3 h out demands
+    /// 3 h more runtime than firing at bedtime. Same battery, same night, different answer.
+    func testRequirementScalesWithTheWaitUntilBedtime() {
+        let early = BatteryEstimator.bedtimeAlert(nowSecOfDay: atClock(20, 30), habitualMidsleepSec: midsleep0330,
+                                                  typicalSleepHours: sleep8h, usableRemainingHours: 10.5,
+                                                  charging: false, alerted: false)
+        XCTAssertEqual(try! XCTUnwrap(early.runway).requiredHours, 12.0, accuracy: 0.001)
+        XCTAssertTrue(early.fire, "3 h out, 10.5 h of runway does not cover the wait plus the night")
+        let atBed = BatteryEstimator.bedtimeAlert(nowSecOfDay: atClock(23, 30), habitualMidsleepSec: midsleep0330,
+                                                  typicalSleepHours: sleep8h, usableRemainingHours: 10.5,
+                                                  charging: false, alerted: false)
+        XCTAssertEqual(try! XCTUnwrap(atBed.runway).requiredHours, 9.0, accuracy: 0.001)
+        XCTAssertFalse(atBed.fire)
+    }
+
+    func testOutsideTheWindowIsSilentAndRearms() {
+        // 18:00 — 5.5 h before bed, window not open yet. A latched gate re-arms here.
+        let early = BatteryEstimator.bedtimeAlert(nowSecOfDay: atClock(18), habitualMidsleepSec: midsleep0330,
+                                                  typicalSleepHours: sleep8h, usableRemainingHours: 0.5,
+                                                  charging: false, alerted: true)
+        XCTAssertFalse(early.fire)
+        XCTAssertFalse(early.newAlerted)
+        XCTAssertNil(early.runway)
+        // 23:45 — bedtime has passed, `hoursUntilBedtime` wraps to ~23.75. Silent, and re-armed for
+        // tomorrow: this is what makes the night-guard once-per-NIGHT rather than once-per-discharge.
+        let late = BatteryEstimator.bedtimeAlert(nowSecOfDay: atClock(23, 45), habitualMidsleepSec: midsleep0330,
+                                                 typicalSleepHours: sleep8h, usableRemainingHours: 0.5,
+                                                 charging: false, alerted: true)
+        XCTAssertFalse(late.fire)
+        XCTAssertFalse(late.newAlerted)
+    }
+
+    func testFiresOncePerNightThenAgainTheFollowingNight() {
+        var alerted = false
+        // Tonight's window: fires once, then holds across every later reading in the window.
+        for clock in [atClock(21), atClock(21, 30), atClock(22), atClock(23)] {
+            let r = BatteryEstimator.bedtimeAlert(nowSecOfDay: clock, habitualMidsleepSec: midsleep0330,
+                                                  typicalSleepHours: sleep8h, usableRemainingHours: 2,
+                                                  charging: false, alerted: alerted)
+            XCTAssertEqual(r.fire, clock == atClock(21), "exactly one alert per night")
+            alerted = r.newAlerted
+        }
+        XCTAssertTrue(alerted)
+        // Next morning: outside the window → re-armed, WITHOUT needing a charge to do it.
+        alerted = BatteryEstimator.bedtimeAlert(nowSecOfDay: atClock(9), habitualMidsleepSec: midsleep0330,
+                                                typicalSleepHours: sleep8h, usableRemainingHours: 2,
+                                                charging: false, alerted: alerted).newAlerted
+        XCTAssertFalse(alerted)
+        // Tomorrow night: speaks again.
+        XCTAssertTrue(BatteryEstimator.bedtimeAlert(nowSecOfDay: atClock(21), habitualMidsleepSec: midsleep0330,
+                                                    typicalSleepHours: sleep8h, usableRemainingHours: 2,
+                                                    charging: false, alerted: alerted).fire)
+    }
+
+    /// Cold start: no learned bedtime → no alert and no fabricated bedtime.
+    func testColdStartNeverFiresAndInventsNoBedtime() {
+        let noMidsleep = BatteryEstimator.bedtimeAlert(nowSecOfDay: atClock(22), habitualMidsleepSec: nil,
+                                                       typicalSleepHours: sleep8h, usableRemainingHours: 0.1,
+                                                       charging: false, alerted: false)
+        XCTAssertFalse(noMidsleep.fire)
+        XCTAssertNil(noMidsleep.runway)
+        let noDuration = BatteryEstimator.bedtimeAlert(nowSecOfDay: atClock(22), habitualMidsleepSec: midsleep0330,
+                                                       typicalSleepHours: nil, usableRemainingHours: 0.1,
+                                                       charging: false, alerted: false)
+        XCTAssertFalse(noDuration.fire)
+        XCTAssertNil(noDuration.runway)
+        // Cold start must not silently consume a latched gate either.
+        XCTAssertTrue(BatteryEstimator.bedtimeAlert(nowSecOfDay: atClock(22), habitualMidsleepSec: nil,
+                                                    typicalSleepHours: nil, usableRemainingHours: 0.1,
+                                                    charging: false, alerted: true).newAlerted)
+    }
+
+    func testNoEstimateIsSilent() {
+        let r = BatteryEstimator.bedtimeAlert(nowSecOfDay: atClock(22), habitualMidsleepSec: midsleep0330,
+                                              typicalSleepHours: sleep8h, usableRemainingHours: nil,
+                                              charging: false, alerted: false)
+        XCTAssertFalse(r.fire)
+        XCTAssertNil(r.runway)
+    }
+
+    func testConfirmedChargingSuppressesButUnknownFiresAndGateSurvives() {
+        let plugged = BatteryEstimator.bedtimeAlert(nowSecOfDay: atClock(22), habitualMidsleepSec: midsleep0330,
+                                                    typicalSleepHours: sleep8h, usableRemainingHours: 2,
+                                                    charging: true, alerted: false)
+        XCTAssertFalse(plugged.fire)
+        XCTAssertFalse(plugged.newAlerted, "charging suppression must not consume the gate")
+        // Unplugged, still in the window → it fires.
+        XCTAssertTrue(BatteryEstimator.bedtimeAlert(nowSecOfDay: atClock(22), habitualMidsleepSec: midsleep0330,
+                                                    typicalSleepHours: sleep8h, usableRemainingHours: 2,
+                                                    charging: false, alerted: plugged.newAlerted).fire)
+        // Unknown charge bit (the strap only reports it every ~8 min) still fires.
+        XCTAssertTrue(BatteryEstimator.bedtimeAlert(nowSecOfDay: atClock(22), habitualMidsleepSec: midsleep0330,
+                                                    typicalSleepHours: sleep8h, usableRemainingHours: 2,
+                                                    charging: nil, alerted: false).fire)
+    }
+
+    /// A late sleeper: 05:00 midsleep, 7 h night → 01:30 bedtime, so the window opens at 22:30 and
+    /// spans midnight. Nothing here may key off a fixed clock band.
+    func testLateSleeperWindowSpansMidnight() {
+        let midsleep0500 = 5 * 3600
+        let inWindow = BatteryEstimator.bedtimeAlert(nowSecOfDay: atClock(0, 30), habitualMidsleepSec: midsleep0500,
+                                                     typicalSleepHours: 7, usableRemainingHours: 1,
+                                                     charging: false, alerted: false)
+        XCTAssertTrue(inWindow.fire)
+        XCTAssertEqual(try! XCTUnwrap(inWindow.runway).hoursUntilBedtime, 1.0, accuracy: 0.001)
+        // 21:00 is still outside a 01:30 bedtime's 3 h window.
+        XCTAssertFalse(BatteryEstimator.bedtimeAlert(nowSecOfDay: atClock(21), habitualMidsleepSec: midsleep0500,
+                                                     typicalSleepHours: 7, usableRemainingHours: 1,
+                                                     charging: false, alerted: false).fire)
+    }
+
+    /// End to end on the real fixture: at the 13.1% reading the strap has ~32 min of usable runway. If
+    /// that reading had landed in the pre-bed window, the night-guard would have caught what both
+    /// latched alerts missed.
+    func testNightGuardCatchesTheRealIncidentRunway() {
+        let est = try! XCTUnwrap(BatteryEstimator.estimate(samples: Self.realFullDischarge(),
+                                                           ratedHours: BatteryEstimator.ratedLifeHoursWhoop5))
+        let r = BatteryEstimator.bedtimeAlert(nowSecOfDay: atClock(22), habitualMidsleepSec: midsleep0330,
+                                              typicalSleepHours: sleep8h,
+                                              usableRemainingHours: BatteryEstimator.usableRemainingHours(est),
+                                              charging: false, alerted: false)
+        XCTAssertTrue(r.fire)
+        XCTAssertEqual(try! XCTUnwrap(r.runway).shortfallHours, 9.95, accuracy: 0.15)
+    }
+}

--- a/Strand/App/AppModel.swift
+++ b/Strand/App/AppModel.swift
@@ -262,6 +262,28 @@ final class AppModel: ObservableObject {
                                               charging: self.live.charging,
                                               enabled: self.behavior.batteryAlerts
                                                     && self.behavior.batteryPredictiveAlerts)
+            // ESCALATION (both independent of the two latching gates above). The 15% alert and the
+            // 24 h predictive alert each fire ONCE per discharge cycle and then latch, so a strap that
+            // keeps draining goes silent exactly when the news gets worse — measured: a user got both
+            // alerts, then nothing across the final ~3 h to the ~10% cutoff, and lost the night.
+            //
+            // 1. Critical SoC: a second, lower crossing with its own persisted gate.
+            BatteryNotifier.onCriticalBattery(pct: Int(pct.rounded()),
+                                              charging: self.live.charging,
+                                              enabled: self.behavior.batteryAlerts)
+            // 2. Bedtime night-guard: near the LEARNED habitual bedtime, does the strap actually clear
+            //    tonight? Uses the cutoff-aware runtime (the raw estimate is time-to-0%, and the strap
+            //    dies ~10% above that — ~6 h of phantom runway at this user's drain). Cold-start (no
+            //    learned midsleep / too few nights) → the policy returns silent, no fabricated bedtime.
+            //    Rides the predictive toggle: it IS a prediction.
+            BatteryNotifier.onBedtimeRunway(
+                nowSecOfDay: Self.localSecOfDayNow(),
+                habitualMidsleepSec: self.habitualMidsleepCache,
+                typicalSleepHours: BatteryEstimator.typicalSleepHours(
+                    nightlyHours: self.repo.days.compactMap { $0.totalSleepMin.map { $0 / 60.0 } }),
+                usableRemainingHours: self.live.batteryEstimate.map(BatteryEstimator.usableRemainingHours),
+                charging: self.live.charging,
+                enabled: self.behavior.batteryAlerts && self.behavior.batteryPredictiveAlerts)
         }
         // HR-zone haptic coaching watches the smoothed bpm.
         $bpm.sink { [weak self] hr in self?.coachZone(hr) }.store(in: &hrCancellables)
@@ -269,6 +291,8 @@ final class AppModel: ObservableObject {
         repo.$days.sink { [weak self] days in
             self?.evaluateIllness(days)
             self?.evaluateStrainTarget()
+            // Keep the battery night-guard's learned bedtime warm off the same signal (throttled inside).
+            self?.refreshHabitualMidsleep()
         }.store(in: &hrCancellables)
         // Re-arm the strap's firmware alarm once the connection has SETTLED — not the instant it (re)bonds.
         // A smart-alarm time changed while the strap was away never reached it , the send is gated on bond
@@ -1351,6 +1375,35 @@ final class AppModel: ObservableObject {
     /// (alcohol / a hard-or-late workout / etc.) so a night out doesn't cry wolf. The journal context is
     /// read asynchronously, so this kicks a Task; the published `illnessSignal` + the `healthAlert`
     /// banner both come from the engine's single decision. On-device only, APPROXIMATE , not a diagnosis.
+    // MARK: - Battery night-guard: learned bedtime cache
+
+    /// The learned habitual midsleep (local seconds-of-day), cached for the battery night-guard.
+    /// `repo.habitualMidsleepSec()` is an async whole-history store read, but the battery hook runs
+    /// synchronously on the BLE callback, so the value is kept warm here instead. nil = cold-start
+    /// (< `SleepStageTotals.habitualMinDays` nights) → `BatteryEstimator.bedtimeAlert` stays silent.
+    private var habitualMidsleepCache: Int? = nil
+    private var habitualMidsleepCachedAt: Date? = nil
+
+    /// Refresh the cached habitual midsleep, at most hourly. The learner reads the full sleep history
+    /// and the value moves on a timescale of WEEKS, so recomputing it on every `repo.$days` republish
+    /// (several per rollup) would be pure cost for a number that cannot have changed.
+    private func refreshHabitualMidsleep() {
+        if let at = habitualMidsleepCachedAt, Date().timeIntervalSince(at) < 3600 { return }
+        habitualMidsleepCachedAt = Date()
+        Task { [weak self] in
+            guard let self else { return }
+            self.habitualMidsleepCache = await self.repo.habitualMidsleepSec()
+        }
+    }
+
+    /// Local time-of-day in seconds [0, 86400) — the clock the night-guard's bedtime window is in.
+    /// Uses the CURRENT zone, so a traveller's window follows them rather than sticking to home time.
+    static func localSecOfDayNow(_ now: Date = Date()) -> Int {
+        let cal = Calendar.current
+        let c = cal.dateComponents([.hour, .minute, .second], from: now)
+        return (c.hour ?? 0) * 3600 + (c.minute ?? 0) * 60 + (c.second ?? 0)
+    }
+
     private func evaluateIllness(_ days: [DailyMetric]) {
         guard behavior.illnessWatch, days.count >= 14 else {
             healthAlert = nil; illnessSignal = nil; illnessDistance = nil; return

--- a/Strand/System/BatteryNotifier.swift
+++ b/Strand/System/BatteryNotifier.swift
@@ -11,6 +11,10 @@ enum BatteryNotifier {
     private static let lowAlertedKey = "behavior.batteryLowAlerted"
     private static let fullAlertedKey = "behavior.batteryFullAlerted"
     private static let runtimeAlertedKey = "behavior.batteryRuntimeAlerted"
+    /// Gates for the two ESCALATION alerts. Separate keys on purpose — see `onCriticalBattery` /
+    /// `onBedtimeRunway`: a latched `lowAlertedKey`/`runtimeAlertedKey` must never silence them.
+    private static let criticalAlertedKey = "behavior.batteryCriticalAlerted"
+    private static let bedtimeAlertedKey = "behavior.batteryBedtimeAlerted"
 
     /// Pure crossing-with-hysteresis policy, identical on macOS/iOS and Android (#368). The two
     /// `*Alerted` flags are PERSISTED, so they survive process death — and the 25% re-arm band means
@@ -115,7 +119,64 @@ enum BatteryNotifier {
         }
     }
 
-    private static func post(identifier: String, title: String, body: String) {
+    /// CRITICAL low-battery escalation — the second alert below the 15% one (#368 fires at
+    /// `BatteryAlertPolicy.lowThreshold`, this at `BatteryEstimator.criticalSocPct`).
+    ///
+    /// Why a whole second alert rather than a lower first threshold: on the reference incident the
+    /// user's device flags show BOTH the 15% alert and the 24 h predictive alert had already fired —
+    /// and both then LATCHED (`lowAlerted` until 25%, `runtimeAlerted` until a 36 h estimate). So the
+    /// last ~3 h of the discharge, from 15% down to the ~10% cutoff, passed in total silence and cost
+    /// a night of biometrics. This gate is independent of both: `criticalAlertedKey` is its own key, so
+    /// a latched low/runtime alert cannot suppress it. Same discipline as #368 otherwise — self-gates
+    /// on the setting, advances the persisted flag even when delivery is deferred, once per cycle.
+    static func onCriticalBattery(pct: Int, charging: Bool?, enabled: Bool) {
+        guard enabled else { return }
+        let d = UserDefaults.standard
+        let result = BatteryEstimator.criticalAlert(pct: pct,
+                                                    charging: charging,
+                                                    alerted: d.bool(forKey: criticalAlertedKey))
+        d.set(result.newAlerted, forKey: criticalAlertedKey)
+        if result.fire {
+            post(identifier: "battery-critical",
+                 title: String(localized: "Charge your WHOOP now"),
+                 body: String(localized: "\(pct)% left. The strap stops recording near 10% — it won't capture tonight unless you charge it."),
+                 interruptionLevel: .timeSensitive)
+        }
+    }
+
+    /// BEDTIME night-guard — "this won't last the night", delivered while there is still time to act.
+    ///
+    /// Independent of `runtimeAlertedKey` by design: the generic "recharge tonight" alert may well have
+    /// fired (and latched) many hours earlier — on the reference incident it fired ~18 h before the
+    /// strap died. This asks a narrower, time-anchored question at the pre-bed moment, and re-arms
+    /// every night rather than every charge, so it speaks even when everything else has gone quiet.
+    /// `runway` is nil at cold-start (no learned bedtime) — the policy stays silent rather than
+    /// inventing one.
+    static func onBedtimeRunway(nowSecOfDay: Int,
+                                habitualMidsleepSec: Int?,
+                                typicalSleepHours: Double?,
+                                usableRemainingHours: Double?,
+                                charging: Bool?,
+                                enabled: Bool) {
+        guard enabled else { return }
+        let d = UserDefaults.standard
+        let result = BatteryEstimator.bedtimeAlert(nowSecOfDay: nowSecOfDay,
+                                                   habitualMidsleepSec: habitualMidsleepSec,
+                                                   typicalSleepHours: typicalSleepHours,
+                                                   usableRemainingHours: usableRemainingHours,
+                                                   charging: charging,
+                                                   alerted: d.bool(forKey: bedtimeAlertedKey))
+        d.set(result.newAlerted, forKey: bedtimeAlertedKey)
+        if result.fire, let runway = result.runway {
+            post(identifier: "battery-bedtime",
+                 title: String(localized: "Won't last the night"),
+                 body: String(localized: "\(BatteryEstimator.label(hours: runway.usableHours)) of recording left, but tonight needs about \(BatteryEstimator.label(hours: runway.requiredHours)). Charge before bed."),
+                 interruptionLevel: .timeSensitive)
+        }
+    }
+
+    private static func post(identifier: String, title: String, body: String,
+                             interruptionLevel: UNNotificationInterruptionLevel = .active) {
         let center = UNUserNotificationCenter.current()
         // Authorization is requested once via requestAuthorization() when alerts are enabled; here
         // we only check status (no second system prompt).
@@ -125,6 +186,10 @@ enum BatteryNotifier {
             content.title = title
             content.body = body
             content.sound = .default
+            // The two escalation alerts ask for .timeSensitive so they can break through a sleep Focus —
+            // the whole point is reaching the user in the hour before bed. Without the time-sensitive
+            // entitlement the OS silently treats this as .active, so it is safe to request either way.
+            content.interruptionLevel = interruptionLevel
             center.add(UNNotificationRequest(identifier: identifier,
                                              content: content, trigger: nil))
         }

--- a/StrandTests/BatteryAlertPolicyTests.swift
+++ b/StrandTests/BatteryAlertPolicyTests.swift
@@ -1,4 +1,5 @@
 import XCTest
+import StrandAnalytics
 @testable import Strand
 
 /// `BatteryNotifier.BatteryAlertPolicy` — the pure crossing-with-hysteresis logic behind the strap
@@ -124,5 +125,52 @@ final class BatteryAlertPolicyTests: XCTestCase {
         let fresh = Policy.evaluate(pct: 100, charging: nil, lowAlerted: false, fullAlerted: false)
         XCTAssertTrue(fresh.fireFull)
         XCTAssertFalse(fresh.clearFull)
+    }
+
+    // 8. The ESCALATION contract — the bug that cost a real night of biometrics. The 15% alert fires
+    //    once and then LATCHES (`lowAlerted` stays true until SoC recovers to `lowRearmAbove` = 25),
+    //    so nothing speaks again across the final descent. The reference device's persisted flags show
+    //    exactly that state: `behavior.batteryLowAlerted = true` while the strap ran 15% → the ~10%
+    //    cutoff in silence, ~3 h at its measured 1.65 %/h.
+    //
+    //    `BatteryEstimator.criticalAlert` carries its OWN gate (persisted under its own key,
+    //    `behavior.batteryCriticalAlerted`), so it must still fire across that same descent. This is
+    //    the cross-policy assertion the pure StrandAnalytics tests can't make — `BatteryAlertPolicy`
+    //    lives in the app target.
+    func testLatchedLowAlertCannotSuppressTheCriticalAlert() {
+        var lowAlerted = true          // already fired at 15% and latched
+        var criticalAlerted = false
+        var lowFires = 0, criticalFires = 0
+        var criticalFiredAt: Int? = nil
+        for pct in [15, 14, 13, 12, 11] {
+            let low = Policy.evaluate(pct: pct, charging: false,
+                                      lowAlerted: lowAlerted, fullAlerted: false)
+            if low.fireLow { lowFires += 1 }
+            lowAlerted = low.newLowAlerted
+
+            let crit = BatteryEstimator.criticalAlert(pct: pct, charging: false, alerted: criticalAlerted)
+            if crit.fire { criticalFires += 1; criticalFiredAt = pct }
+            criticalAlerted = crit.newAlerted
+        }
+        XCTAssertEqual(lowFires, 0, "the latched low alert stays silent — this is what lost the night")
+        XCTAssertEqual(criticalFires, 1, "the critical alert speaks anyway, exactly once")
+        XCTAssertEqual(criticalFiredAt, BatteryEstimator.criticalSocPct)
+    }
+
+    // 9. The two gates re-arm on the SAME genuine recovery (25%), so one charge re-arms both and the
+    //    next discharge cycle gets the full 15% → critical escalation again.
+    func testBothGatesRearmTogetherOnCharge() {
+        let low = Policy.evaluate(pct: 25, charging: nil, lowAlerted: true, fullAlerted: false)
+        XCTAssertFalse(low.newLowAlerted)
+        XCTAssertFalse(BatteryEstimator.criticalAlert(pct: 25, charging: nil, alerted: true).newAlerted)
+        XCTAssertEqual(BatteryEstimator.criticalRearmAbovePct, Policy.lowRearmAbove)
+    }
+
+    // 10. The critical line sits strictly inside the band the hardware can actually report: below the
+    //     15% alert (a genuinely separate crossing) but above the ~10% cutoff where the strap goes
+    //     dark. A regression that drops it to a conventional 5% would make it unreachable.
+    func testCriticalThresholdSitsBetweenTheLowAlertAndTheHardwareCutoff() {
+        XCTAssertLessThan(BatteryEstimator.criticalSocPct, Policy.lowThreshold)
+        XCTAssertGreaterThan(Double(BatteryEstimator.criticalSocPct), BatteryEstimator.cutoffSocPct)
     }
 }

--- a/android/app/src/main/java/com/noop/analytics/BatteryEstimator.kt
+++ b/android/app/src/main/java/com/noop/analytics/BatteryEstimator.kt
@@ -1,6 +1,7 @@
 package com.noop.analytics
 
 import java.util.Locale
+import kotlin.math.roundToInt
 import kotlin.math.roundToLong
 
 /**
@@ -277,5 +278,207 @@ object BatteryEstimator {
         val fire = !armedOff && remainingHours <= runtimeAlertHours && charging != true
         if (fire) armedOff = true
         return RuntimeAlertDecision(fire, armedOff)
+    }
+
+    // ---- The ~10% hardware cutoff ----
+
+    /** The strap stops sampling and drops the link NEAR THIS SoC, not at 0%. Measured on a WHOOP 5.0
+     *  running R22 deep-data + high-rate IMU capture: the SoC series ran 13.1% → 10.9% over 80 min and
+     *  the last HR sample of the session landed 27 min after that 10.9% reading, with no reading below
+     *  10.9% ever banked. At that run's 1.65 %/h those 27 min are ~0.7 pp — the strap went dark at ~10%
+     *  with ~10 pp of nominal charge still showing.
+     *
+     *  This matters because [estimate] divides the FULL current SoC by the drain rate, so its
+     *  `remainingHours` is time-to-**0%** and overstates usable life by `cutoffSocPct / rate` — ~6 h for
+     *  that user. Any consumer asking "will the strap survive the next N hours" must ask
+     *  [usableRemainingHours], never `Estimate.remainingHours`.
+     *
+     *  Deliberately NOT folded into [estimate] itself: `remainingHours` feeds the Today "~X left" badge
+     *  and the shared Swift/Kotlin fixtures, so re-anchoring it there would change a displayed number
+     *  and break documented cross-platform parity in the same commit. Kept additive instead. */
+    const val cutoffSocPct = 10.0
+
+    /** Runtime left before the strap goes dark at [cutoffSocPct], derived from an estimate's
+     *  time-to-0% figure. Algebraically `(currentSoc - cutoff) / rate` where `rate = currentSoc /
+     *  remainingHours`, rearranged so the rate is never recovered explicitly — which also carries the
+     *  #99 clamp through CONSERVATIVELY: that clamp only ever lowers `remainingHours`, so the usable
+     *  figure derived from it can only be pessimistic, never optimistic. 0 at or below the cutoff. */
+    fun usableRemainingHours(remainingHours: Double, currentSoc: Double): Double {
+        if (currentSoc <= 0 || remainingHours <= 0) return 0.0
+        return maxOf(0.0, remainingHours * (currentSoc - cutoffSocPct) / currentSoc)
+    }
+
+    /** [usableRemainingHours] for a whole [Estimate] — the form callers holding the live estimate want. */
+    fun usableRemainingHours(estimate: Estimate): Double =
+        usableRemainingHours(estimate.remainingHours, estimate.currentSoc)
+
+    // ---- Critical low-battery alert (the escalation the 15% alert can't give) ----
+
+    /** SoC at which the CRITICAL "charge it now" alert fires — a second crossing below
+     *  `BatteryAlertPolicy.LOW_THRESHOLD` (15%), with its own gate.
+     *
+     *  Derived from [cutoffSocPct], not picked round. The strap goes dark at ~10%, so the ENTIRE usable
+     *  alert band is (10%, 15%]. A conventional 5% critical threshold is unreachable on this hardware —
+     *  the strap is long dead — and even 10% is a coin flip (the lowest reading ever banked on the
+     *  reference run was 10.9%, and SoC reaches this policy already rounded to an Int). 12% sits
+     *  mid-band, was reliably reported on the reference run (12.4 / 12.1 / 11.9 / 11.6 / 11.4 / 11.1,
+     *  the first of which rounds to 12), and still clears the 15% line by 3 pp, so it is a genuinely
+     *  separate crossing rather than jitter around the same threshold.
+     *
+     *  Lead time scales with how hard the user drives the strap, which is the point: at the reference
+     *  run's 1.65 %/h (R22 deep-data + high-rate IMU) 12% is ~1.2 h of warning before the cutoff; on a
+     *  stock 5.0 sipping ~0.35 %/h it is ~5.7 h. The 15% alert already carries the "plan to charge"
+     *  message — this one carries "you are about to lose data", which is worth sending even when the
+     *  runway is short. */
+    const val criticalSocPct = 12
+
+    /** Re-arm the critical gate on the same genuine recovery the 15% alert uses
+     *  (`BatteryAlertPolicy.LOW_REARM_ABOVE` = 25), so one charge re-arms both and 11↔12% jitter can't
+     *  re-fire. Its own constant so the two policies stay independently tunable. */
+    const val criticalRearmAbovePct = 25
+
+    data class CriticalAlertDecision(val fire: Boolean, val newAlerted: Boolean)
+
+    /**
+     * Crossing-with-hysteresis decision for the CRITICAL low alert, mirroring `BatteryAlertPolicy`'s
+     * shape: persisted gate in, fire decision plus next gate state out.
+     *
+     * Deliberately a SEPARATE policy with its OWN persisted flag rather than a second branch of
+     * `BatteryAlertPolicy.evaluate`, because the failure this fixes IS the latch: the 15% alert fires
+     * once and sets `lowAlerted = true` until SoC recovers to 25%, so on the reference incident the
+     * user got one warning at 15% and then total silence across the ~3 h it took to reach the cutoff.
+     * A latched `lowAlerted` must never be able to suppress this one.
+     *
+     * `charging == null` (unknown) still fires — only a confirmed `true` suppresses — matching the SoC
+     * low alert's null-tolerant rule: the strap reports its charge bit only every ~8 min.
+     * Behaviour-identical twin of the Swift `BatteryEstimator.criticalAlert`.
+     */
+    fun criticalAlert(pct: Int, charging: Boolean?, alerted: Boolean): CriticalAlertDecision {
+        var armedOff = alerted
+        if (pct >= criticalRearmAbovePct) armedOff = false
+        val fire = !armedOff && pct <= criticalSocPct && charging != true
+        if (fire) armedOff = true
+        return CriticalAlertDecision(fire, armedOff)
+    }
+
+    // ---- Bedtime night-guard ("this won't last the night") ----
+
+    /** How long before habitual bedtime the night-guard window opens. Wide enough that the strap's
+     *  ~8-minute battery cadence lands several readings inside it even with link churn, and that the
+     *  user can still act; narrow enough that the question is genuinely about TONIGHT. */
+    const val bedtimeLeadHours = 3.0
+
+    /** Safety margin added on top of "wait until bedtime + tonight's sleep". Covers the slope fit's
+     *  error and the gap between the learned habitual night and any given night running long. */
+    const val bedtimeMarginHours = 1.0
+
+    /** Floor on the number of nights behind [typicalSleepHours]. The midsleep learner's own
+     *  `SleepStageTotals.HABITUAL_MIN_DAYS` (14) already gates the whole night-guard — with no learned
+     *  midsleep there is no bedtime and [bedtimeAlert] returns silently — so this is a local
+     *  belt-and-braces bound ensuring the duration median itself is never taken off a night or two. */
+    const val bedtimeMinNights = 7
+
+    /** What tonight demands of the strap versus what it has. Returned by [bedtimeAlert] so the notifier
+     *  can word the alert from real numbers and the tests can assert the arithmetic, not just the Bool. */
+    data class NightRunway(
+        val hoursUntilBedtime: Double,
+        val sleepHours: Double,
+        /** `hoursUntilBedtime + sleepHours + bedtimeMarginHours`. */
+        val requiredHours: Double,
+        /** Cutoff-aware runtime ([usableRemainingHours]), NOT the raw time-to-0% estimate. */
+        val usableHours: Double,
+    ) {
+        /** How far short the strap falls, in hours. 0 when it makes it. */
+        val shortfallHours: Double get() = maxOf(0.0, requiredHours - usableHours)
+    }
+
+    data class BedtimeAlertDecision(
+        val fire: Boolean,
+        val newAlerted: Boolean,
+        val runway: NightRunway?,
+    )
+
+    /**
+     * Typical night length (hours) for the night-guard: the MEDIAN of the recent per-night sleep
+     * durations the app already banks — the daily rollup's total sleep (the longest block per LOCAL
+     * day, so naps drop out). Median rather than mean so one all-nighter, or one night the strap itself
+     * died at 0.4 h, can't shrink tonight's budget. null under [minNights] — cold-start stays honest
+     * rather than inventing a night length. Twin of the Swift `typicalSleepHours`.
+     */
+    fun typicalSleepHours(nightlyHours: List<Double>, minNights: Int = bedtimeMinNights): Double? {
+        val valid = nightlyHours.filter { it > 0 }
+        if (valid.size < minNights) return null
+        val sorted = valid.sorted()
+        val n = sorted.size
+        return if (n % 2 == 1) sorted[n / 2] else (sorted[n / 2 - 1] + sorted[n / 2]) / 2
+    }
+
+    /**
+     * Decide whether to tell the user, BEFORE they go to bed, that the strap won't survive the night.
+     *
+     * This is the alert the reference incident actually needed. That user's strap had already fired
+     * both the 24 h "recharge tonight" runtime alert AND the 15% SoC alert — the device's persisted
+     * flags confirm both — and both then LATCHED, so nothing spoke again through the final descent to
+     * the cutoff, and a night of biometrics was lost. This policy is independent of both gates: it
+     * asks a different question ("does the strap clear tonight specifically?") at a moment when the
+     * answer is still actionable, so an earlier generic warning can never suppress it.
+     *
+     * Bedtime is derived from the sleep model the app ALREADY learns (#547) — `habitualMidsleepSec`
+     * minus half the typical night — never from a fixed clock band, which would fire at the wrong hour
+     * for exactly the shift/late sleepers that learner exists to serve.
+     *
+     * @param nowSecOfDay          local time-of-day seconds in [0, 86400).
+     * @param habitualMidsleepSec  learned midsleep as local seconds-of-day; null at cold-start (< 14 nights).
+     * @param typicalSleepHours    from [typicalSleepHours]; null at cold-start.
+     * @param usableRemainingHours cutoff-aware runtime; null when there is no estimate at all.
+     * @param alerted              the PERSISTED once-per-night gate.
+     */
+    fun bedtimeAlert(
+        nowSecOfDay: Int,
+        habitualMidsleepSec: Int?,
+        typicalSleepHours: Double?,
+        usableRemainingHours: Double?,
+        charging: Boolean?,
+        alerted: Boolean,
+    ): BedtimeAlertDecision {
+        // Cold start: no learned midsleep or no duration history → there is NO honest bedtime to test
+        // against. Inventing one (a fixed 23:00) would fire at the wrong hour for the late/shift
+        // sleepers #547 exists for. Stay silent and leave the gate untouched; the 15% and critical SoC
+        // alerts remain the safety net.
+        val sleepHours = typicalSleepHours
+        if (habitualMidsleepSec == null || sleepHours == null || sleepHours <= 0 ||
+            habitualMidsleepSec !in 0 until secondsPerDay || nowSecOfDay !in 0 until secondsPerDay
+        ) {
+            return BedtimeAlertDecision(false, alerted, null)
+        }
+        // Bedtime = midsleep - half the typical night, CIRCULAR so a 03:30 midsleep on an 8 h night is
+        // a 23:30 bedtime rather than a negative one.
+        val bedtimeSec = floorMod(habitualMidsleepSec - (sleepHours * 1800).roundToInt(), secondsPerDay)
+        val hoursUntilBedtime = floorMod(bedtimeSec - nowSecOfDay, secondsPerDay) / 3600.0
+        // Outside the pre-bed window — including the moment bedtime passes, when `hoursUntilBedtime`
+        // wraps to ~24 — the gate RE-ARMS. That wrap is what makes this once-per-NIGHT rather than
+        // once-per-discharge: each evening's window is a fresh crossing, so unlike the 15%/24 h alerts
+        // this one can speak again tomorrow without needing a charge to re-arm it.
+        if (hoursUntilBedtime > bedtimeLeadHours) return BedtimeAlertDecision(false, false, null)
+        // No estimate at all (no banked SoC history yet) → nothing to judge; hold the gate.
+        val usable = usableRemainingHours ?: return BedtimeAlertDecision(false, alerted, null)
+        // The strap must survive the wait until bedtime AND the night itself, plus the margin.
+        // Anchoring to `hoursUntilBedtime` rather than a flat `sleepHours` is what keeps the whole lead
+        // window honest: firing 3 h before bed genuinely demands 3 h more runtime than firing at bed.
+        val required = hoursUntilBedtime + sleepHours + bedtimeMarginHours
+        val runway = NightRunway(hoursUntilBedtime, sleepHours, required, usable)
+        val fire = !alerted && usable < required && charging != true
+        // Charging suppression must NOT consume the gate: unplug still inside the window and the alert
+        // must still be able to fire (mirrors [runtimeAlert]'s contract).
+        return BedtimeAlertDecision(fire, if (fire) true else alerted, runway)
+    }
+
+    private const val secondsPerDay = 86_400
+
+    /** Floored modulo — correct for negative operands, unlike Kotlin's `%`. Bedtime arithmetic wraps
+     *  midnight in both directions. */
+    private fun floorMod(a: Int, n: Int): Int {
+        val r = a % n
+        return if (r < 0) r + n else r
     }
 }

--- a/android/app/src/main/java/com/noop/ble/WhoopConnectionService.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopConnectionService.kt
@@ -76,6 +76,11 @@ private data class NotifyTick(
     val todayRow: DailyMetric?,
     val anchorRow: DailyMetric?,
     val illness: String?,
+    /** The whole merged day list, carried by REFERENCE only. The battery night-guard needs recent
+     *  nightly sleep durations, and this tick is the only place the collector can see them; deriving
+     *  the list here instead would run a map over ~800 rows on every live-HR emission for a value the
+     *  guard reads once per ~8-minute battery reading. */
+    val days: List<DailyMetric>,
 )
 
 class WhoopConnectionService : Service() {
@@ -108,6 +113,15 @@ class WhoopConnectionService : Service() {
      *  more often than the strap's ~8-min battery cadence; gating the Room read + estimator fit on an
      *  actual SoC change keeps the predictive path as cheap as the SoC-only alert beside it. */
     private var lastRuntimeEvalPct: Int? = null
+
+    /** The user's LEARNED habitual midsleep (local seconds-of-day), cached for the battery
+     *  night-guard. null = cold start (< [com.noop.analytics.SleepStageTotals.HABITUAL_MIN_DAYS]
+     *  nights), which is what makes `BatteryEstimator.bedtimeAlert` stay silent instead of testing
+     *  against a fabricated bedtime. */
+    private var habitualMidsleepCache: Int? = null
+
+    /** Wall-clock ms of the last [refreshHabitualMidsleep] attempt; 0 = never. */
+    private var habitualMidsleepCachedAtMs: Long = 0L
 
     /** Smart-alarm light-sleep watcher (#207). Feeds the live HR while we're inside the wake window
      *  and, on a lighter-phase reading, advances the GUARANTEED alarm earlier. It can only ever move
@@ -222,6 +236,7 @@ class WhoopConnectionService : Service() {
                     // only long-lived collector, so this is what makes the early-warning reach a
                     // user who hasn't opened the app today.
                     illness = if (NoopPrefs.illnessWatch(this@WhoopConnectionService)) IllnessWatch.evaluate(days) else null,
+                    days = days,
                 )
             }.catch { /* belt-and-braces: a frozen notification beats a dead process */ }
                 // conflate + collect, NOT collectLatest (#82): the widget push suspends in Glance
@@ -229,7 +244,7 @@ class WhoopConnectionService : Service() {
                 // every push mid-flight and the widget starved on stale data the moment HR started
                 // streaming. Conflation still processes only the latest value — just without the axe.
                 .conflate()
-                .collect { (state, todayRow, anchorRow, illness) ->
+                .collect { (state, todayRow, anchorRow, illness, days) ->
                 // Honest-null: the notification's Recovery line reads the NAIVE today row, never the
                 // carried anchor, so it stays blank until tonight's recovery actually lands (#911).
                 postNotification(state, todayRow?.recovery)
@@ -242,6 +257,17 @@ class WhoopConnectionService : Service() {
                 // Battery alerts — low (≤15%) and charge-complete (100%). The once-per-crossing
                 // dedupe is persisted in NoopPrefs (BatteryAlertPolicy), so no in-memory pct tracking.
                 BatteryAlertNotifier.onBatteryUpdate(
+                    this@WhoopConnectionService,
+                    currPct = state.batteryPct?.roundToInt(),
+                    charging = state.charging,
+                )
+                // ESCALATION 1 — critical SoC (iOS/macOS twin: BatteryNotifier.onCriticalBattery). A
+                // SECOND, lower crossing (12%) with its own persisted gate, because the 15% alert above
+                // latches until the cell recovers to 25%: measured, a user got that one warning and then
+                // total silence across the final ~3 h down to the ~10% hardware cutoff, and lost the
+                // night. Sits beside onBatteryUpdate rather than in the estimator block below because it
+                // is the same kind of pure SoC policy — no Room read, no slope fit.
+                BatteryAlertNotifier.onCriticalBattery(
                     this@WhoopConnectionService,
                     currPct = state.batteryPct?.roundToInt(),
                     charging = state.charging,
@@ -261,9 +287,30 @@ class WhoopConnectionService : Service() {
                             .mapNotNull { s -> s.soc?.let { s.ts to it } }
                         val rated = if (state.whoop5Detected) BatteryEstimator.ratedLifeHoursWhoop5
                                     else BatteryEstimator.ratedLifeHoursWhoop4
+                        val estimate = BatteryEstimator.estimate(samples, rated)
                         BatteryAlertNotifier.onRuntimeEstimate(
                             this@WhoopConnectionService,
-                            remainingHours = BatteryEstimator.estimate(samples, rated)?.hoursRemaining,
+                            remainingHours = estimate?.hoursRemaining,
+                            charging = state.charging,
+                        )
+                        // ESCALATION 2 — bedtime night-guard (iOS/macOS twin:
+                        // BatteryNotifier.onBedtimeRunway). Near the LEARNED habitual bedtime, does the
+                        // strap actually clear TONIGHT? Uses the cutoff-aware runtime, because the raw
+                        // estimate is time-to-0% and the strap dies ~10 pp above that — ~6 h of phantom
+                        // runway at the reference user's drain. Cold start (no learned midsleep, or
+                        // fewer than 7 nights of durations) returns silent rather than inventing a
+                        // bedtime, which would fire at the wrong hour for the shift/late sleepers the
+                        // midsleep learner exists to serve. Rides the same SoC-change gate as the
+                        // runtime alert, so it never adds work to the live-HR path.
+                        refreshHabitualMidsleep()
+                        BatteryAlertNotifier.onBedtimeRunway(
+                            this@WhoopConnectionService,
+                            nowSecOfDay = localSecOfDayNow(),
+                            habitualMidsleepSec = habitualMidsleepCache,
+                            typicalSleepHours = BatteryEstimator.typicalSleepHours(
+                                days.mapNotNull { d -> d.totalSleepMin?.let { it / 60.0 } },
+                            ),
+                            usableRemainingHours = estimate?.let { BatteryEstimator.usableRemainingHours(it) },
                             charging = state.charging,
                         )
                     }
@@ -451,6 +498,32 @@ class WhoopConnectionService : Service() {
             .setVisibility(NotificationCompat.VISIBILITY_PUBLIC)
             .build()
     }
+
+    /**
+     * Refresh [habitualMidsleepCache], at most hourly. `WhoopRepository.habitualMidsleepSec` reads the
+     * WHOLE sleep history (both source namespaces, de-duplicated) and the learned value moves on a
+     * timescale of WEEKS, so recomputing it on every ~8-minute battery reading would be a large read
+     * for a number that cannot have changed. The timestamp advances BEFORE the read, so a failing read
+     * cannot spin the throttle. Mirrors the iOS/macOS `AppModel.refreshHabitualMidsleep` cache.
+     */
+    private suspend fun refreshHabitualMidsleep() {
+        val now = System.currentTimeMillis()
+        if (habitualMidsleepCachedAtMs != 0L && now - habitualMidsleepCachedAtMs < 3_600_000L) return
+        habitualMidsleepCachedAtMs = now
+        // Thread the ACTIVE strap id so the learner unions active + canonical nights (#814/#1008),
+        // exactly as SleepScreen does; the repository resolves the canonical sibling internally.
+        habitualMidsleepCache = runCatching {
+            repo.habitualMidsleepSec((application as NoopApplication).activeDeviceId)?.toInt()
+        }.getOrNull()
+    }
+
+    /**
+     * Local time-of-day in seconds, [0, 86400) — the clock the night-guard's bedtime window is in.
+     * Reads the CURRENT zone, so a traveller's window follows them rather than sticking to home time.
+     * Twin of the Swift `AppModel.localSecOfDayNow`.
+     */
+    private fun localSecOfDayNow(now: java.time.LocalTime = java.time.LocalTime.now()): Int =
+        now.toSecondOfDay()
 
     private fun ensureChannel() {
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) return

--- a/android/app/src/main/java/com/noop/notif/BatteryAlertNotifier.kt
+++ b/android/app/src/main/java/com/noop/notif/BatteryAlertNotifier.kt
@@ -71,16 +71,26 @@ internal object BatteryAlertPolicy {
  * every live-state update, gated behind a user setting and the OS notification permission. The
  * once-per-crossing dedupe lives in [BatteryAlertPolicy] over two persisted NoopPrefs flags.
  *
+ * Four alerts now, each with its OWN persisted gate: the 15%/100% SoC pair ([onBatteryUpdate]), the
+ * 24 h predictive one ([onRuntimeEstimate]), and two ESCALATIONS ([onCriticalBattery],
+ * [onBedtimeRunway]) that exist precisely because the first three latch after firing once — a strap
+ * that keeps draining used to go silent exactly when the news got worse.
+ *
  * With thanks to @ujix (#368) for the original notification copy and channel.
  */
 object BatteryAlertNotifier {
     private const val CHANNEL_ID = "noop_battery_alert"
     // #297: each notifier posts under a DISTINCT id (notify() is tagless, so a shared id silently
     // replaces an undismissed notification). Full map: 4201 connection, 4202 illness, 4203 inactivity,
-    // 4204 smart alarm, 4205/4206/4207 battery (runtime/low/full), 4208/4209 scheduled report.
+    // 4204 smart alarm, 4205/4206/4207 battery (runtime/low/full), 4208/4209 scheduled report,
+    // 4210 strain target, 4211/4212 battery escalation (critical/bedtime). The two escalation alerts
+    // get their own ids on purpose: they must be able to stand BESIDE an undismissed low/runtime
+    // notification, since the whole point is that those two have already fired and gone quiet.
     private const val NOTIF_ID_RUNTIME = 4205
     private const val NOTIF_ID_LOW = 4206
     private const val NOTIF_ID_FULL = 4207
+    private const val NOTIF_ID_CRITICAL = 4211
+    private const val NOTIF_ID_BEDTIME = 4212
 
     /**
      * Predictive twin of [onBatteryUpdate]: run the runtime estimate against
@@ -168,6 +178,117 @@ object BatteryAlertNotifier {
             // ALWAYS persist the updated flags — re-arming must stick even when nothing fired.
             NoopPrefs.setBatteryLowAlerted(context, decision.newLowAlerted)
             NoopPrefs.setBatteryFullAlerted(context, decision.newFullAlerted)
+        }
+    }
+
+    /**
+     * CRITICAL low-battery escalation — the second alert below the 15% one ([onBatteryUpdate] fires at
+     * [BatteryAlertPolicy.LOW_THRESHOLD], this at [com.noop.analytics.BatteryEstimator.criticalSocPct]).
+     *
+     * Why a whole second alert rather than a lower first threshold: on the reference incident the
+     * user's device flags show BOTH the 15% alert and the 24 h predictive alert had already fired —
+     * and both then LATCHED (`lowAlerted` until 25%, `runtimeAlerted` until a 36 h estimate). So the
+     * last ~3 h of the discharge, from 15% down to the ~10% cutoff, passed in total silence and cost
+     * a night of biometrics. This gate is independent of both: KEY_BATTERY_CRITICAL_ALERTED is its own
+     * key, so a latched low/runtime alert cannot suppress it. Same discipline as #368 otherwise —
+     * self-gates on the setting, advances the persisted flag even when delivery is deferred, once per
+     * cycle. iOS/macOS twin: BatteryNotifier.onCriticalBattery.
+     *
+     * Rides the plain battery-alerts toggle, NOT the predictive sub-gate: this is a measured SoC
+     * crossing like the 15% alert, not a forecast.
+     */
+    @SuppressLint("MissingPermission") // guarded by areNotificationsEnabled() + runCatching
+    fun onCriticalBattery(context: Context, currPct: Int?, charging: Boolean?) {
+        if (currPct == null) return
+        if (!NoopPrefs.batteryAlerts(context)) return
+        runCatching {
+            val decision = com.noop.analytics.BatteryEstimator.criticalAlert(
+                pct = currPct,
+                charging = charging,
+                alerted = NoopPrefs.batteryCriticalAlerted(context),
+            )
+            // ALWAYS persist the updated gate — re-arming must stick even when nothing fired.
+            NoopPrefs.setBatteryCriticalAlerted(context, decision.newAlerted)
+            if (!decision.fire) return
+            if (!NotificationManagerCompat.from(context).areNotificationsEnabled()) return
+            ensureChannel(context)
+            val body = context.getString(R.string.battery_critical_body, currPct)
+            val n = NotificationCompat.Builder(context, CHANNEL_ID)
+                .setSmallIcon(R.drawable.ic_stat_heart)
+                .setContentTitle(context.getString(R.string.battery_critical_title))
+                .setContentText(body)
+                .setStyle(NotificationCompat.BigTextStyle().bigText(body))
+                .setContentIntent(openAppIntent(context))
+                .setAutoCancel(true)
+                .setCategory(NotificationCompat.CATEGORY_STATUS)
+                // Android's nearest equivalent of the Swift `.timeSensitive` interruption level is
+                // channel importance, and the shared battery channel is already IMPORTANCE_HIGH, so
+                // both escalation alerts heads-up like the rest. There is no per-notification
+                // time-sensitive flag: actually piercing Do Not Disturb needs channel setBypassDnd(),
+                // which requires user-granted notification-policy access — not something an alert may
+                // take for itself. So: same channel, PRIORITY_HIGH, no DND bypass.
+                .setPriority(NotificationCompat.PRIORITY_HIGH)
+                .build()
+            NotificationManagerCompat.from(context).notify(NOTIF_ID_CRITICAL, n)
+        }
+    }
+
+    /**
+     * BEDTIME night-guard — "this won't last the night", delivered while there is still time to act.
+     *
+     * Independent of the runtime gate by design: the generic "recharge tonight" alert may well have
+     * fired (and latched) many hours earlier — on the reference incident it fired ~18 h before the
+     * strap died. This asks a narrower, time-anchored question at the pre-bed moment, and re-arms
+     * every night rather than every charge, so it speaks even when everything else has gone quiet.
+     * `runway` is null at cold-start (no learned bedtime) — the policy stays silent rather than
+     * inventing one. iOS/macOS twin: BatteryNotifier.onBedtimeRunway.
+     *
+     * Rides the predictive sub-gate as well as the battery toggle: it IS a prediction.
+     */
+    @SuppressLint("MissingPermission") // guarded by areNotificationsEnabled() + runCatching
+    fun onBedtimeRunway(
+        context: Context,
+        nowSecOfDay: Int,
+        habitualMidsleepSec: Int?,
+        typicalSleepHours: Double?,
+        usableRemainingHours: Double?,
+        charging: Boolean?,
+    ) {
+        if (!NoopPrefs.batteryAlerts(context)) return
+        if (!NoopPrefs.predictiveBatteryAlerts(context)) return
+        runCatching {
+            val decision = com.noop.analytics.BatteryEstimator.bedtimeAlert(
+                nowSecOfDay = nowSecOfDay,
+                habitualMidsleepSec = habitualMidsleepSec,
+                typicalSleepHours = typicalSleepHours,
+                usableRemainingHours = usableRemainingHours,
+                charging = charging,
+                alerted = NoopPrefs.batteryBedtimeAlerted(context),
+            )
+            // ALWAYS persist the updated gate — the nightly re-arm must stick even when nothing fired.
+            NoopPrefs.setBatteryBedtimeAlerted(context, decision.newAlerted)
+            val runway = decision.runway
+            if (!decision.fire || runway == null) return
+            if (!NotificationManagerCompat.from(context).areNotificationsEnabled()) return
+            ensureChannel(context)
+            val body = context.getString(
+                R.string.battery_bedtime_body,
+                com.noop.analytics.BatteryEstimator.label(runway.usableHours),
+                com.noop.analytics.BatteryEstimator.label(runway.requiredHours),
+            )
+            val n = NotificationCompat.Builder(context, CHANNEL_ID)
+                .setSmallIcon(R.drawable.ic_stat_heart)
+                .setContentTitle(context.getString(R.string.battery_bedtime_title))
+                .setContentText(body)
+                .setStyle(NotificationCompat.BigTextStyle().bigText(body))
+                .setContentIntent(openAppIntent(context))
+                .setAutoCancel(true)
+                .setCategory(NotificationCompat.CATEGORY_STATUS)
+                // See onCriticalBattery: IMPORTANCE_HIGH channel is the Android stand-in for the
+                // Swift `.timeSensitive` request; no DND bypass is taken.
+                .setPriority(NotificationCompat.PRIORITY_HIGH)
+                .build()
+            NotificationManagerCompat.from(context).notify(NOTIF_ID_BEDTIME, n)
         }
     }
 

--- a/android/app/src/main/java/com/noop/ui/MainActivity.kt
+++ b/android/app/src/main/java/com/noop/ui/MainActivity.kt
@@ -721,6 +721,30 @@ object NoopPrefs {
         of(context).edit().putBoolean(KEY_BATTERY_RUNTIME_ALERTED, alerted).apply()
     }
 
+    /** Persisted gates behind the two ESCALATION alerts. Deliberately separate keys from the low /
+     *  runtime flags above: the bug those alerts fix IS the latch, so a `KEY_BATTERY_LOW_ALERTED` or
+     *  `KEY_BATTERY_RUNTIME_ALERTED` that is already true must never be able to silence them.
+     *  - CRITICAL (BatteryEstimator.criticalAlert): once per discharge cycle, re-arms above 25%.
+     *  - BEDTIME (BatteryEstimator.bedtimeAlert): once per NIGHT — it re-arms whenever the pre-bed
+     *    window is not open, so it speaks again tomorrow without needing a charge.
+     *  iOS/macOS twin keys: behavior.batteryCriticalAlerted / behavior.batteryBedtimeAlerted. */
+    const val KEY_BATTERY_CRITICAL_ALERTED = "noop.batteryCriticalAlerted"
+    const val KEY_BATTERY_BEDTIME_ALERTED = "noop.batteryBedtimeAlerted"
+
+    fun batteryCriticalAlerted(context: Context): Boolean =
+        of(context).getBoolean(KEY_BATTERY_CRITICAL_ALERTED, false)
+
+    fun setBatteryCriticalAlerted(context: Context, alerted: Boolean) {
+        of(context).edit().putBoolean(KEY_BATTERY_CRITICAL_ALERTED, alerted).apply()
+    }
+
+    fun batteryBedtimeAlerted(context: Context): Boolean =
+        of(context).getBoolean(KEY_BATTERY_BEDTIME_ALERTED, false)
+
+    fun setBatteryBedtimeAlerted(context: Context, alerted: Boolean) {
+        of(context).edit().putBoolean(KEY_BATTERY_BEDTIME_ALERTED, alerted).apply()
+    }
+
     /** Scheduled report notifications (#517), opt-in, default OFF, no AI. Two independent toggles:
      *  - [KEY_REPORT_MORNING]: a morning recap (Charge + Rest) posted once after a fresh night is
      *    processed. It is NOT alarm-precise, it lands when the next sync + analytics pass completes,

--- a/android/app/src/main/res/values-de/strings.xml
+++ b/android/app/src/main/res/values-de/strings.xml
@@ -1722,4 +1722,10 @@
         <item quantity="one">Längste: %1$d Tag</item>
         <item quantity="other">Längste: %1$d Tage</item>
     </plurals>
+
+    <!-- Eskalations-Akkuwarnungen (kritischer Ladestand + Schutz vor dem Schlafengehen). -->
+    <string name="battery_critical_title">Lade dein WHOOP jetzt auf</string>
+    <string name="battery_critical_body">%1$d%% übrig. Das Band hört bei etwa 10%% auf aufzuzeichnen – ohne Aufladen erfasst es die heutige Nacht nicht.</string>
+    <string name="battery_bedtime_title">Reicht nicht durch die Nacht</string>
+    <string name="battery_bedtime_body">Noch %1$s Aufzeichnung, aber die heutige Nacht braucht etwa %2$s. Lade vor dem Schlafengehen auf.</string>
 </resources>

--- a/android/app/src/main/res/values-es/strings.xml
+++ b/android/app/src/main/res/values-es/strings.xml
@@ -1707,4 +1707,10 @@
         <item quantity="one">Máxima: %1$d día</item>
         <item quantity="other">Máxima: %1$d días</item>
     </plurals>
+
+    <!-- Alertas de batería escaladas (cruce crítico de carga + guardia nocturna antes de dormir). -->
+    <string name="battery_critical_title">Cargue su WHOOP ahora</string>
+    <string name="battery_critical_body">Queda %1$d%%. La correa deja de registrar cerca del 10%% — no captará esta noche si no la carga.</string>
+    <string name="battery_bedtime_title">No aguantará la noche</string>
+    <string name="battery_bedtime_body">Queda %1$s de registro, pero esta noche necesita alrededor de %2$s. Cárguela antes de acostarse.</string>
 </resources>

--- a/android/app/src/main/res/values-fr/strings.xml
+++ b/android/app/src/main/res/values-fr/strings.xml
@@ -1707,4 +1707,10 @@
         <item quantity="one">Record : %1$d jour</item>
         <item quantity="other">Record : %1$d jours</item>
     </plurals>
+
+    <!-- Alertes de batterie escaladées (passage critique de charge + garde de nuit avant le coucher). -->
+    <string name="battery_critical_title">Rechargez votre WHOOP maintenant</string>
+    <string name="battery_critical_body">Il reste %1$d%%. La sangle cesse d\'enregistrer vers 10%% — elle ne captera pas cette nuit sans recharge.</string>
+    <string name="battery_bedtime_title">Ne tiendra pas la nuit</string>
+    <string name="battery_bedtime_body">Il reste %1$s d\'enregistrement, mais cette nuit en demande environ %2$s. Rechargez avant de vous coucher.</string>
 </resources>

--- a/android/app/src/main/res/values-pt-rPT/strings.xml
+++ b/android/app/src/main/res/values-pt-rPT/strings.xml
@@ -1701,4 +1701,10 @@
         <item quantity="one">Recorde: %1$d dia</item>
         <item quantity="other">Recorde: %1$d dias</item>
     </plurals>
+
+    <!-- Alertas de bateria escalados (cruzamento crítico de carga + guarda noturna antes de deitar). -->
+    <string name="battery_critical_title">Carregue já a sua WHOOP</string>
+    <string name="battery_critical_body">Restam %1$d%%. A bracelete deixa de gravar perto dos 10%% – não vai captar esta noite se não a carregar.</string>
+    <string name="battery_bedtime_title">Não dura a noite</string>
+    <string name="battery_bedtime_body">Restam %1$s de gravação, mas esta noite precisa de cerca de %2$s. Carregue antes de se deitar.</string>
 </resources>

--- a/android/app/src/main/res/values-zh/strings.xml
+++ b/android/app/src/main/res/values-zh/strings.xml
@@ -1635,4 +1635,10 @@
     <string name="l10n_data_sources_screen_last_shared_6bf8389c">"上次分享 "</string>
     <string name="l10n_data_sources_screen_sharing_paused_health_connect_permission_was_e8950315">分享已暂停——Health Connect 权限已被撤销。点按以重新授予。</string>
     <string name="l10n_data_sources_screen_last_share_didn_t_finish_noop_0d6c27f0">上次分享未完成——NOOP 将自动重试。</string>
+
+    <!-- 升级电量提醒（临界电量 + 睡前守护）。 -->
+    <string name="battery_critical_title">请立即为 WHOOP 充电</string>
+    <string name="battery_critical_body">剩余 %1$d%%。手环在约 10%% 时就会停止记录——不充电就无法记录今晚。</string>
+    <string name="battery_bedtime_title">撑不过今晚</string>
+    <string name="battery_bedtime_body">还能记录 %1$s，但今晚约需 %2$s。请在睡前充电。</string>
 </resources>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -1731,4 +1731,12 @@
         <item quantity="one">Longest: %1$d day</item>
         <item quantity="other">Longest: %1$d days</item>
     </plurals>
+
+    <!-- Escalation battery alerts (critical SoC crossing + bedtime night-guard). The strap stops
+         recording near 10% SoC, so the 15% low alert on its own leaves no second warning before the
+         data stops. Twin of the Swift BatteryNotifier copy. -->
+    <string name="battery_critical_title">Charge your WHOOP now</string>
+    <string name="battery_critical_body">%1$d%% left. The strap stops recording near 10%% — it won\'t capture tonight unless you charge it.</string>
+    <string name="battery_bedtime_title">Won\'t last the night</string>
+    <string name="battery_bedtime_body">%1$s of recording left, but tonight needs about %2$s. Charge before bed.</string>
 </resources>

--- a/android/app/src/test/java/com/noop/analytics/BatteryCriticalAlertTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/BatteryCriticalAlertTest.kt
@@ -1,0 +1,491 @@
+package com.noop.analytics
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import kotlin.math.roundToInt
+
+/**
+ * The escalation alerts: the CRITICAL SoC crossing and the BEDTIME night-guard, plus the ~10% cutoff
+ * model they both rest on. Behaviour-identical twin of the Swift BatteryCriticalAlertTests — same
+ * fixture, same numbers.
+ *
+ * The fixture below is a REAL measured discharge from a WHOOP 5.0 running R22 deep-data + high-rate
+ * IMU capture — the run that lost the user a night of biometrics. Times are PDT; the strap's last HR
+ * sample of the session landed at 13:27, i.e. ~27 min after the final 10.9% reading and with no
+ * reading below 10.9% ever banked. That 27 min is the ground truth the cutoff model is scored against.
+ */
+class BatteryCriticalAlertTest {
+
+    // ---- The real discharge fixture ----
+
+    /** Arbitrary epoch anchor; only deltas matter to the fit. */
+    private val base = 1_700_000_000L
+
+    /** Seconds after [base] for 13:27, when the strap actually went dark (27 min past the 10.9% read). */
+    private val deathOffset = 6420L
+
+    /** The ten real readings, `(seconds after 11:40, SoC%)`. */
+    private val realTail: List<Pair<Long, Double>> = listOf(
+        0L to 13.1,     // 11:40
+        120L to 12.9,   // 11:42
+        660L to 12.6,   // 11:51
+        1020L to 12.4,  // 11:57
+        1620L to 12.1,  // 12:07
+        2160L to 11.9,  // 12:16
+        2760L to 11.6,  // 12:26
+        3060L to 11.4,  // 12:31
+        4080L to 11.1,  // 12:48
+        4800L to 10.9,  // 13:00
+    ).map { (base + it.first) to it.second }
+
+    /**
+     * The tail as the estimator really saw it: LiveState seeds the SoC buffer from the persisted
+     * battery table on connect (#7) and caps it at 400 readings (~53 h at the strap's ~8 min cadence),
+     * so the fit window in production spans the whole discharge from the last near-full charge — NOT
+     * just the 80 minutes of tail above. Reconstructed here at the measured 1.65 %/h from 95% down to
+     * the 13.1% the tail opens on, ~8 min apart, which is what makes `source == MEASURED` reachable.
+     */
+    private fun realFullDischarge(): List<Pair<Long, Double>> {
+        val rate = 1.65
+        val leadSeconds = ((95.0 - 13.1) / rate * 3600).toLong()  // ~49.6 h
+        val out = mutableListOf<Pair<Long, Double>>()
+        var elapsed = 0L
+        while (elapsed < leadSeconds) {
+            out.add((base - leadSeconds + elapsed) to (95.0 - rate * elapsed / 3600.0))
+            elapsed += 480
+        }
+        return out + realTail
+    }
+
+    // ---- A3 / A4: what the estimator actually says about this run ----
+
+    @Test
+    fun realDischargeFitsMeasuredSlopeAtRoughly1Point65PctPerHour() {
+        val est = BatteryEstimator.estimate(realFullDischarge(), BatteryEstimator.ratedLifeHoursWhoop5)!!
+        assertEquals(
+            "the seeded full-discharge buffer must beat the rated fallback",
+            BatteryEstimator.Source.MEASURED, est.source,
+        )
+        assertEquals(10.9, est.currentSoc, 0.001)
+        // Recovered slope = currentSoc / remainingHours.
+        assertEquals(1.65, est.currentSoc / est.remainingHours, 0.02)
+    }
+
+    /**
+     * A4, the headline number: `estimate` divides the FULL SoC by the rate, so it reports time-to-0%.
+     * At 10.9% and 1.65 %/h that is ~6.6 h of runway — but the strap died 27 min later. ~6 h of the
+     * estimate is charge the hardware never actually spends.
+     */
+    @Test
+    fun rawEstimateOverstatesRunwayByTheWholeCutoffBand() {
+        val est = BatteryEstimator.estimate(realFullDischarge(), BatteryEstimator.ratedLifeHoursWhoop5)!!
+        assertEquals("time-to-0%, not time-to-death", 6.6, est.remainingHours, 0.15)
+        val usable = BatteryEstimator.usableRemainingHours(est)
+        assertEquals("cutoff / rate = 10 / 1.65", 6.06, est.remainingHours - usable, 0.15)
+    }
+
+    /** The cutoff model scored against ground truth: the strap went dark 27 min after the 10.9% read. */
+    @Test
+    fun cutoffAwareRunwayMatchesTheObservedTimeOfDeath() {
+        val est = BatteryEstimator.estimate(realFullDischarge(), BatteryEstimator.ratedLifeHoursWhoop5)!!
+        val usableMinutes = BatteryEstimator.usableRemainingHours(est) * 60
+        val observedMinutes = (deathOffset - 4800L) / 60.0   // 13:27 − 13:00 = 27 min
+        assertEquals(27.0, observedMinutes, 0.001)
+        assertEquals(
+            "cutoff-aware runway should land within ~10 min of the real time of death",
+            observedMinutes, usableMinutes, 10.0,
+        )
+    }
+
+    @Test
+    fun usableRunwayIsZeroAtOrBelowTheCutoff() {
+        assertEquals(0.0, BatteryEstimator.usableRemainingHours(6.0, 10.0), 0.0)
+        assertEquals(0.0, BatteryEstimator.usableRemainingHours(5.0, 8.0), 0.0)
+        assertEquals(0.0, BatteryEstimator.usableRemainingHours(0.0, 50.0), 0.0)
+        assertEquals(0.0, BatteryEstimator.usableRemainingHours(10.0, 0.0), 0.0)
+    }
+
+    @Test
+    fun usableRunwayIsUnaffectedWellAboveTheCutoff() {
+        // 90% with 100 h to 0% → 100 × 80/90 = 88.9 h to the cutoff. Real but not dramatic up high.
+        assertEquals(88.89, BatteryEstimator.usableRemainingHours(100.0, 90.0), 0.01)
+    }
+
+    /**
+     * A3's latent second bug, isolated: on a WHOOP 5.0's 288 h rated fallback the predictive alert's
+     * 24 h line sits at 8.3% SoC — BELOW the ~10% cutoff, so it is unreachable. A strap on the rated
+     * path can therefore never warn before it dies. (The reference device's persisted
+     * `batteryRuntimeAlerted = true` proves it was on the MEASURED path in practice.)
+     */
+    @Test
+    fun ratedFallbackOnWhoop5PutsThePredictiveAlertBelowTheHardwareCutoff() {
+        val ratedRate = 100.0 / BatteryEstimator.ratedLifeHoursWhoop5
+        val socAtAlertLine = BatteryEstimator.runtimeAlertHours * ratedRate
+        assertEquals(8.33, socAtAlertLine, 0.01)
+        assertTrue(
+            "rated-path predictive alert is unreachable before the strap dies",
+            socAtAlertLine < BatteryEstimator.cutoffSocPct,
+        )
+    }
+
+    /**
+     * The same trap reached the honest way: a buffer holding ONLY the 80-minute tail spans 1.33 h,
+     * short of `minSpanHours` (2.0), so the fit is rejected and the estimate falls back to rated —
+     * reporting ~31 h of life on a strap with ~30 min left, and firing nothing.
+     */
+    @Test
+    fun shortBufferFallsBackToRatedAndThePredictiveAlertStaysSilent() {
+        val est = BatteryEstimator.estimate(realTail, BatteryEstimator.ratedLifeHoursWhoop5)!!
+        assertEquals(BatteryEstimator.Source.RATED, est.source)
+        assertEquals(31.4, est.remainingHours, 0.2)
+        assertFalse(
+            "31 h estimate is above the 24 h line — no predictive alert, ~30 min before death",
+            BatteryEstimator.runtimeAlert(est.remainingHours, charging = false, alerted = false).fire,
+        )
+    }
+
+    // ---- B1: the critical SoC alert ----
+
+    /**
+     * The alert the incident needed: replay the real curve (SoC reaches the policy rounded, as the
+     * call site passes `batteryPct.roundToInt()`) and exactly one critical alert must fire — at 12.4% /
+     * 11:57, which is 90 minutes of warning before the 13:27 death.
+     */
+    @Test
+    fun realCurveFiresExactlyOneCriticalAlertWithNinetyMinutesOfWarning() {
+        var alerted = false
+        val firedAt = mutableListOf<Long>()
+        for ((ts, soc) in realTail) {
+            val out = BatteryEstimator.criticalAlert(soc.roundToInt(), charging = false, alerted = alerted)
+            if (out.fire) firedAt.add(ts)
+            alerted = out.newAlerted
+        }
+        assertEquals("exactly once per discharge cycle", 1, firedAt.size)
+        assertEquals(90.0, (base + deathOffset - firedAt[0]) / 60.0, 0.001)
+    }
+
+    /**
+     * The threshold is chosen against the cutoff, and the cutoff is what makes the conventional
+     * choices wrong: on this hardware a 5% critical alert can never fire, and even 10% is a coin flip
+     * (nothing below 10.9% was ever banked on the real run).
+     */
+    @Test
+    fun conventionalCriticalThresholdsAreUnreachableOnThisHardware() {
+        assertEquals(10.9, realTail.minOf { it.second }, 0.001)
+        for (deadThreshold in listOf(5, 8, 10)) {
+            assertFalse(
+                "$deadThreshold% is never reported before the strap dies",
+                realTail.any { it.second.roundToInt() <= deadThreshold },
+            )
+        }
+        // 12 is reported, and clears the 15% alert by a genuine 3 pp rather than jitter.
+        assertTrue(realTail.any { it.second.roundToInt() <= BatteryEstimator.criticalSocPct })
+        assertEquals(12, BatteryEstimator.criticalSocPct)
+    }
+
+    /**
+     * Latch independence — the actual bug. The critical gate is its OWN parameter (and, at the call
+     * site, its own persisted key), so a 15% alert that has already fired and latched cannot silence
+     * it. On the incident `batteryLowAlerted` was true for the whole final descent.
+     */
+    @Test
+    fun criticalGateIsIndependentOfAnAlreadyLatchedLowAlert() {
+        // Whatever the low alert's gate is doing, a fresh critical gate at 12% fires.
+        assertTrue(BatteryEstimator.criticalAlert(12, charging = false, alerted = false).fire)
+        assertTrue(BatteryEstimator.criticalAlert(11, charging = null, alerted = false).fire)
+    }
+
+    @Test
+    fun firesAtThresholdAndArms() {
+        val r = BatteryEstimator.criticalAlert(12, charging = false, alerted = false)
+        assertTrue(r.fire)
+        assertTrue(r.newAlerted)
+    }
+
+    @Test
+    fun aboveThresholdNoFire() {
+        val r = BatteryEstimator.criticalAlert(13, charging = false, alerted = false)
+        assertFalse(r.fire)
+        assertFalse(r.newAlerted)
+    }
+
+    @Test
+    fun jitterInsideBandCannotRefire() {
+        var alerted = BatteryEstimator.criticalAlert(12, charging = null, alerted = false).newAlerted
+        assertTrue(alerted)
+        for (pct in listOf(11, 13, 12, 14, 11)) {
+            val r = BatteryEstimator.criticalAlert(pct, charging = null, alerted = alerted)
+            assertFalse("re-fired at $pct% inside the hysteresis band", r.fire)
+            alerted = r.newAlerted
+        }
+    }
+
+    @Test
+    fun rearmsOnGenuineRecoveryThenFiresNextCycle() {
+        var alerted = BatteryEstimator.criticalAlert(11, charging = null, alerted = false).newAlerted
+        val recovered = BatteryEstimator.criticalAlert(25, charging = null, alerted = alerted)
+        assertFalse(recovered.fire)
+        assertFalse("25% is the re-arm line (inclusive)", recovered.newAlerted)
+        alerted = recovered.newAlerted
+        assertTrue(BatteryEstimator.criticalAlert(12, charging = null, alerted = alerted).fire)
+    }
+
+    @Test
+    fun rearmBoundaryIsInclusive() {
+        assertFalse(BatteryEstimator.criticalAlert(25, charging = null, alerted = true).newAlerted)
+        assertTrue(BatteryEstimator.criticalAlert(24, charging = null, alerted = true).newAlerted)
+    }
+
+    @Test
+    fun confirmedChargingSuppressesButUnknownFires() {
+        assertFalse(BatteryEstimator.criticalAlert(8, charging = true, alerted = false).fire)
+        assertTrue(BatteryEstimator.criticalAlert(8, charging = null, alerted = false).fire)
+    }
+
+    @Test
+    fun chargingSuppressionDoesNotArmGate() {
+        val plugged = BatteryEstimator.criticalAlert(11, charging = true, alerted = false)
+        assertFalse(plugged.newAlerted)
+        assertTrue(BatteryEstimator.criticalAlert(11, charging = false, alerted = plugged.newAlerted).fire)
+    }
+
+    // ---- typicalSleepHours ----
+
+    @Test
+    fun typicalSleepHoursIsTheMedianAndIgnoresJunkNights() {
+        // A dead-strap 0.3 h night and an all-nighter must not drag the budget.
+        val nights = listOf(7.9, 8.1, 0.3, 7.6, 8.4, 7.8, 8.0, 2.0)
+        assertEquals(7.85, BatteryEstimator.typicalSleepHours(nights)!!, 0.001)
+    }
+
+    @Test
+    fun typicalSleepHoursColdStart() {
+        assertNull(BatteryEstimator.typicalSleepHours(emptyList()))
+        assertNull(BatteryEstimator.typicalSleepHours(listOf(8.0, 8.0, 8.0)))
+        assertNull(
+            "zero-length nights are not history",
+            BatteryEstimator.typicalSleepHours(List(20) { 0.0 }),
+        )
+        assertNotNull(BatteryEstimator.typicalSleepHours(List(7) { 8.0 }))
+    }
+
+    // ---- B2: the bedtime night-guard ----
+
+    /** 03:30 midsleep on an 8 h night → 23:30 bedtime, computed circularly (naively it is negative). */
+    private val midsleep0330 = 3 * 3600 + 1800
+    private val sleep8h = 8.0
+    private fun atClock(h: Int, m: Int = 0): Int = h * 3600 + m * 60
+
+    @Test
+    fun firesBeforeBedWhenTheStrapWontClearTheNight() {
+        // 22:00, 1.5 h to a 23:30 bedtime → needs 1.5 + 8 + 1 = 10.5 h; has 5 h.
+        val r = BatteryEstimator.bedtimeAlert(
+            nowSecOfDay = atClock(22), habitualMidsleepSec = midsleep0330,
+            typicalSleepHours = sleep8h, usableRemainingHours = 5.0,
+            charging = false, alerted = false,
+        )
+        assertTrue(r.fire)
+        assertTrue(r.newAlerted)
+        val runway = r.runway!!
+        assertEquals("bedtime wrapped midnight correctly", 1.5, runway.hoursUntilBedtime, 0.001)
+        assertEquals(10.5, runway.requiredHours, 0.001)
+        assertEquals(5.5, runway.shortfallHours, 0.001)
+    }
+
+    @Test
+    fun staysSilentWhenTheStrapClearsTheNight() {
+        val r = BatteryEstimator.bedtimeAlert(
+            nowSecOfDay = atClock(22), habitualMidsleepSec = midsleep0330,
+            typicalSleepHours = sleep8h, usableRemainingHours = 12.0,
+            charging = false, alerted = false,
+        )
+        assertFalse(r.fire)
+        assertEquals(0.0, r.runway!!.shortfallHours, 0.0)
+    }
+
+    /**
+     * The requirement is anchored to the wait until bedtime, not a flat night: firing 3 h out demands
+     * 3 h more runtime than firing at bedtime. Same battery, same night, different answer.
+     */
+    @Test
+    fun requirementScalesWithTheWaitUntilBedtime() {
+        val early = BatteryEstimator.bedtimeAlert(
+            nowSecOfDay = atClock(20, 30), habitualMidsleepSec = midsleep0330,
+            typicalSleepHours = sleep8h, usableRemainingHours = 10.5,
+            charging = false, alerted = false,
+        )
+        assertEquals(12.0, early.runway!!.requiredHours, 0.001)
+        assertTrue("3 h out, 10.5 h of runway does not cover the wait plus the night", early.fire)
+        val atBed = BatteryEstimator.bedtimeAlert(
+            nowSecOfDay = atClock(23, 30), habitualMidsleepSec = midsleep0330,
+            typicalSleepHours = sleep8h, usableRemainingHours = 10.5,
+            charging = false, alerted = false,
+        )
+        assertEquals(9.0, atBed.runway!!.requiredHours, 0.001)
+        assertFalse(atBed.fire)
+    }
+
+    @Test
+    fun outsideTheWindowIsSilentAndRearms() {
+        // 18:00 — 5.5 h before bed, window not open yet. A latched gate re-arms here.
+        val early = BatteryEstimator.bedtimeAlert(
+            nowSecOfDay = atClock(18), habitualMidsleepSec = midsleep0330,
+            typicalSleepHours = sleep8h, usableRemainingHours = 0.5,
+            charging = false, alerted = true,
+        )
+        assertFalse(early.fire)
+        assertFalse(early.newAlerted)
+        assertNull(early.runway)
+        // 23:45 — bedtime has passed, `hoursUntilBedtime` wraps to ~23.75. Silent, and re-armed for
+        // tomorrow: this is what makes the night-guard once-per-NIGHT rather than once-per-discharge.
+        val late = BatteryEstimator.bedtimeAlert(
+            nowSecOfDay = atClock(23, 45), habitualMidsleepSec = midsleep0330,
+            typicalSleepHours = sleep8h, usableRemainingHours = 0.5,
+            charging = false, alerted = true,
+        )
+        assertFalse(late.fire)
+        assertFalse(late.newAlerted)
+    }
+
+    @Test
+    fun firesOncePerNightThenAgainTheFollowingNight() {
+        var alerted = false
+        // Tonight's window: fires once, then holds across every later reading in the window.
+        for (clock in listOf(atClock(21), atClock(21, 30), atClock(22), atClock(23))) {
+            val r = BatteryEstimator.bedtimeAlert(
+                nowSecOfDay = clock, habitualMidsleepSec = midsleep0330,
+                typicalSleepHours = sleep8h, usableRemainingHours = 2.0,
+                charging = false, alerted = alerted,
+            )
+            assertEquals("exactly one alert per night", clock == atClock(21), r.fire)
+            alerted = r.newAlerted
+        }
+        assertTrue(alerted)
+        // Next morning: outside the window → re-armed, WITHOUT needing a charge to do it.
+        alerted = BatteryEstimator.bedtimeAlert(
+            nowSecOfDay = atClock(9), habitualMidsleepSec = midsleep0330,
+            typicalSleepHours = sleep8h, usableRemainingHours = 2.0,
+            charging = false, alerted = alerted,
+        ).newAlerted
+        assertFalse(alerted)
+        // Tomorrow night: speaks again.
+        assertTrue(
+            BatteryEstimator.bedtimeAlert(
+                nowSecOfDay = atClock(21), habitualMidsleepSec = midsleep0330,
+                typicalSleepHours = sleep8h, usableRemainingHours = 2.0,
+                charging = false, alerted = alerted,
+            ).fire,
+        )
+    }
+
+    /** Cold start: no learned bedtime → no alert and no fabricated bedtime. */
+    @Test
+    fun coldStartNeverFiresAndInventsNoBedtime() {
+        val noMidsleep = BatteryEstimator.bedtimeAlert(
+            nowSecOfDay = atClock(22), habitualMidsleepSec = null,
+            typicalSleepHours = sleep8h, usableRemainingHours = 0.1,
+            charging = false, alerted = false,
+        )
+        assertFalse(noMidsleep.fire)
+        assertNull(noMidsleep.runway)
+        val noDuration = BatteryEstimator.bedtimeAlert(
+            nowSecOfDay = atClock(22), habitualMidsleepSec = midsleep0330,
+            typicalSleepHours = null, usableRemainingHours = 0.1,
+            charging = false, alerted = false,
+        )
+        assertFalse(noDuration.fire)
+        assertNull(noDuration.runway)
+        // Cold start must not silently consume a latched gate either.
+        assertTrue(
+            BatteryEstimator.bedtimeAlert(
+                nowSecOfDay = atClock(22), habitualMidsleepSec = null,
+                typicalSleepHours = null, usableRemainingHours = 0.1,
+                charging = false, alerted = true,
+            ).newAlerted,
+        )
+    }
+
+    @Test
+    fun noEstimateIsSilent() {
+        val r = BatteryEstimator.bedtimeAlert(
+            nowSecOfDay = atClock(22), habitualMidsleepSec = midsleep0330,
+            typicalSleepHours = sleep8h, usableRemainingHours = null,
+            charging = false, alerted = false,
+        )
+        assertFalse(r.fire)
+        assertNull(r.runway)
+    }
+
+    @Test
+    fun confirmedChargingSuppressesButUnknownFiresAndGateSurvives() {
+        val plugged = BatteryEstimator.bedtimeAlert(
+            nowSecOfDay = atClock(22), habitualMidsleepSec = midsleep0330,
+            typicalSleepHours = sleep8h, usableRemainingHours = 2.0,
+            charging = true, alerted = false,
+        )
+        assertFalse(plugged.fire)
+        assertFalse("charging suppression must not consume the gate", plugged.newAlerted)
+        // Unplugged, still in the window → it fires.
+        assertTrue(
+            BatteryEstimator.bedtimeAlert(
+                nowSecOfDay = atClock(22), habitualMidsleepSec = midsleep0330,
+                typicalSleepHours = sleep8h, usableRemainingHours = 2.0,
+                charging = false, alerted = plugged.newAlerted,
+            ).fire,
+        )
+        // Unknown charge bit (the strap only reports it every ~8 min) still fires.
+        assertTrue(
+            BatteryEstimator.bedtimeAlert(
+                nowSecOfDay = atClock(22), habitualMidsleepSec = midsleep0330,
+                typicalSleepHours = sleep8h, usableRemainingHours = 2.0,
+                charging = null, alerted = false,
+            ).fire,
+        )
+    }
+
+    /**
+     * A late sleeper: 05:00 midsleep, 7 h night → 01:30 bedtime, so the window opens at 22:30 and
+     * spans midnight. Nothing here may key off a fixed clock band.
+     */
+    @Test
+    fun lateSleeperWindowSpansMidnight() {
+        val midsleep0500 = 5 * 3600
+        val inWindow = BatteryEstimator.bedtimeAlert(
+            nowSecOfDay = atClock(0, 30), habitualMidsleepSec = midsleep0500,
+            typicalSleepHours = 7.0, usableRemainingHours = 1.0,
+            charging = false, alerted = false,
+        )
+        assertTrue(inWindow.fire)
+        assertEquals(1.0, inWindow.runway!!.hoursUntilBedtime, 0.001)
+        // 21:00 is still outside a 01:30 bedtime's 3 h window.
+        assertFalse(
+            BatteryEstimator.bedtimeAlert(
+                nowSecOfDay = atClock(21), habitualMidsleepSec = midsleep0500,
+                typicalSleepHours = 7.0, usableRemainingHours = 1.0,
+                charging = false, alerted = false,
+            ).fire,
+        )
+    }
+
+    /**
+     * End to end on the real fixture: at the 13.1% reading the strap has ~32 min of usable runway. If
+     * that reading had landed in the pre-bed window, the night-guard would have caught what both
+     * latched alerts missed.
+     */
+    @Test
+    fun nightGuardCatchesTheRealIncidentRunway() {
+        val est = BatteryEstimator.estimate(realFullDischarge(), BatteryEstimator.ratedLifeHoursWhoop5)!!
+        val r = BatteryEstimator.bedtimeAlert(
+            nowSecOfDay = atClock(22), habitualMidsleepSec = midsleep0330,
+            typicalSleepHours = sleep8h,
+            usableRemainingHours = BatteryEstimator.usableRemainingHours(est),
+            charging = false, alerted = false,
+        )
+        assertTrue(r.fire)
+        assertEquals(9.95, r.runway!!.shortfallHours, 0.15)
+    }
+}


### PR DESCRIPTION
Both battery alerts NOOP has today fire at most **once per discharge cycle and then latch**: the 15% SoC alert holds `lowAlerted` until the cell recovers to 25%, and the 24 h predictive alert (#713) holds `runtimeAlerted` until the estimate returns to 36 h. Neither re-arms on anything but a charge — so a strap that just keeps draining goes silent exactly as the news gets worse.

Measured on a WHOOP 5.0 running R22 deep-data + high-rate IMU capture: the device's persisted flags show **both** alerts had already fired, then nothing across the final descent, and a full night of biometrics was lost. At the run's measured **1.65 %/h** (13.1% → 10.9% over 80 min) that silence ran ~3 h, with the app still showing ~6 h of runway.

Two additions, each with its **own** persisted gate so a latched low/runtime alert can never suppress them.

## 1. Critical SoC alert at 12% (`battery-critical`)

Derived from the hardware cutoff, not picked round. The strap goes dark near 10%: on the reference run the last HR sample landed **27 min after** the 10.9% reading and nothing below 10.9% was ever banked, so the whole usable alert band is **(10%, 15%]**. A conventional 5% critical threshold is unreachable on this hardware and 10% is a coin flip. 12% sits mid-band, was reliably reported (12.4 / 12.1 / 11.9 / 11.6 / 11.4 / 11.1), and still clears the 15% line by 3 pp so it is a genuinely separate crossing rather than jitter around the same threshold.

Lead time scales with how hard the user drives the strap, which is the point: at 1.65 %/h that is ~1.2 h of warning; on a stock 5.0 sipping ~0.35 %/h it is ~5.7 h. On the real curve it fires once, at 12.4% / 11:57 — **90 min before death**.

## 2. Bedtime night-guard (`battery-bedtime`)

Near the **learned** habitual bedtime (`habitualMidsleepSec` minus half the median night — the #547 model, reused rather than reinvented), fires when the strap won't clear "wait until bed + the night + a margin".

It re-arms on **leaving the window**, so it is once per **night** rather than once per charge: it speaks even when everything else has latched. Bedtime comes from the learned model rather than a fixed clock band, which would fire at the wrong hour for exactly the shift/late sleepers that learner exists to serve. Cold start (< 14 nights, or too little duration history) returns silent — no fabricated bedtime.

## The estimator gap underneath both: `usableRemainingHours`

`estimate()` divides the **full** SoC by the drain rate, so `remainingHours` is time-to-**0%** and overstates usable life by `cutoff / rate` — ~6 h for this user, who had ~30 min left when the app read 6.6 h. `usableRemainingHours` re-anchors that to the ~10% cutoff, algebraically (`remainingHours × (soc − cutoff) / soc`) so the rate is never recovered explicitly, which also carries the #99 clamp through conservatively: that clamp only ever lowers `remainingHours`, so the usable figure derived from it can only be pessimistic, never optimistic.

**Added additively, on purpose.** `remainingHours` still feeds the Today badge and the Kotlin twin's shared fixtures, so re-anchoring it *there* would change a displayed number and break documented Swift/Kotlin parity in the same commit. Anything asking "will the strap survive the next N hours" must call `usableRemainingHours`; anything displaying "~X left" keeps what it had.

## Relationship to #419 (and vishk23/noop#1)

**No dependency and no duplication.** #419 adds a `NotificationAuthorizer` because *wrist* alerts never requested OS permission. This PR touches nothing on that path: `BatteryNotifier` already calls `requestAuthorization()` when the toggle is enabled and already status-checks in `post()`, and both new alerts go through that same existing `post()`. `NotificationAuthorizer` does not appear anywhere in this diff, and the branch applies to `main` with #419 unlanded (as it is now) or landed.

The two do interact in one benign way worth stating: if #419 lands first, these alerts inherit its authorization improvements for free, because they share `post()`. Merge order does not matter.

The only overlap in `post()` is a new **defaulted** parameter — `interruptionLevel: UNNotificationInterruptionLevel = .active` — so every existing call site is unchanged. The two escalations pass `.timeSensitive` so they can break through a sleep Focus; the whole point is reaching the user in the hour before bed. Without the time-sensitive entitlement the OS silently treats this as `.active`, so requesting it is safe either way.

## Where the code lives

Policy is **pure** and lives in `StrandAnalytics` (following the `runtimeAlert` precedent from #713), so `swift test` reaches it with no app, no strap, no CoreBluetooth. `BatteryNotifier` holds only the gates and the copy; `AppModel` holds the two call sites plus an hourly-throttled cache of the learned midsleep (a whole-history read, so it is not done per battery packet).

## Cross-platform parity

**Both platforms, in this PR** — same names, same constants, same arithmetic:

- `com.noop.analytics.BatteryEstimator` gains `cutoffSocPct`, `usableRemainingHours`, `criticalSocPct`/`criticalRearmAbovePct`/`criticalAlert`, `bedtimeLeadHours`/`bedtimeMarginHours`/`bedtimeMinNights`, `NightRunway`, `typicalSleepHours`, `bedtimeAlert`, with the same median rule and the same floored-modulo circular bedtime (a 03:30 midsleep on an 8 h night is a 23:30 bedtime, and a late sleeper's window spans midnight).
- `com.noop.notif.BatteryAlertNotifier` gains `onCriticalBattery` / `onBedtimeRunway`, each over its own persisted gate and its own notification id — a latched low/runtime alert must not be able to silence them, and the new notes must be able to stand beside an undismissed one. Charging suppression does not consume either gate, so unplugging inside the window can still fire.
- `WhoopConnectionService` wires both: the critical crossing beside the 15% alert (pure SoC, no read), the night-guard on the existing SoC-change gate so it never adds work to the live-HR path.

Android has **no per-notification equivalent** of `.timeSensitive`. The shared battery channel is already `IMPORTANCE_HIGH` so both escalations heads-up; genuinely piercing Do Not Disturb would require channel `setBypassDnd()` plus user-granted notification-policy access, which a battery alert should not take for itself. That is a comment in the Kotlin, not a silent divergence.

## Verification

```
Packages/StrandAnalytics   swift test                        1167 tests, 0 failures        (29 new)
macOS app                  xcodebuild -scheme Strand build   ** BUILD SUCCEEDED **
macOS app  (StrandTests)   BatteryAlertPolicyTests                                          (3 new)
android    ./gradlew compileFullDebugKotlin                  BUILD SUCCESSFUL
android    ./gradlew testFullDebugUnitTest                   3089 tests, 1 failed, 5 skipped
             └ com.noop.analytics.BatteryCriticalAlertTest   29 tests, 0 failures           (29 new)
           python3 Tools/i18n_audit.py --ci                  pass
           python3 Tools/doc_comment_lint.py                 pass
```

The single Android failure is the **pre-existing, unrelated** `com.noop.ui.SyncChipStateTest.lastSyncedAt_takesPriorityOverHistorySyncExperimental` (`IllegalStateException` at `SyncChipStateTest.kt:59`), which fails identically on clean `main`. Every battery test class is green: `BatteryCriticalAlertTest` 29/0, `BatteryRuntimeAlertTest` 7/0, `BatteryEstimatorTest` 13/0, `BatteryEstimatorTraceTest` 4/0, `BatteryAlertPolicyTest` 8/0.

The app-target half is compiled locally, since `app-build.yml` is disabled by default and `swift-packages.yml` does not compile app targets.

**What the tests actually pin**, not just that they pass: the real measured drain curve; the cutoff scored against the observed time of death (~33 min predicted vs 27 min actual); cold start; charging suppression; once-per-cycle; and — in `StrandTests`, where `BatteryAlertPolicy` lives — that a latched low/runtime gate cannot suppress either new alert. The Kotlin suite is one-for-one with the Swift suite over the same reconstructed discharge fixture.

**No hardware test claimed.** Nothing here touches the BLE path: both alerts are pure functions over a SoC reading the app already receives. The evidence is the recorded discharge curve from the incident, replayed in tests, not a fresh strap session.

## Localization

Six new user-facing strings on Android through `strings.xml` with de/es/fr/pt-PT (the zero-tolerance focus locales) plus zh, without which the non-focus ratcheting allowance would have grown. The Apple side follows the existing `BatteryNotifier` convention from #250 — `String(localized:)` at the call site, catalog extraction left to Xcode — and `Tools/i18n_audit.py --ci` passes.
