### PR TITLE
tools(spo2): an absence claim needs a capture that could have seen the window

### DIFF
--- a/docs/WHOOP5_DEEP_DATA.md
+++ b/docs/WHOOP5_DEEP_DATA.md
@@ -174,6 +174,14 @@ aggregates one value **per window** rather than per second, and reports per-nigh
 with a loud warning below the floor. A strap whose `@82` is flat `0x00` across a long enough capture
 is classified **`feature_absent`** — neither a PASS nor a FAIL in the multi-device gate.
 
+That absence claim carries the aliasing caveat back onto itself: it also requires the capture to have
+been sampled **finely enough to see a window**. Missing the window is a phase problem, not a duration
+one — a cadence sharing a large factor with the period only ever occupies `period ÷ gcd` residues, so
+at 300 s against 1200 s it either always lands inside the window or never does, and six nights of
+scored sleep read a flat `0x00` off a perfectly healthy strap. A capture coarser than a nominal 30 s
+window stays a plain FAIL and says why. The conservative direction matters here: `feature_absent`
+*removes* a device from the gate, so over-claiming absence would make promotion easier, not harder.
+
 `--postable` prints a CSV-ish block with **no raw SpO₂ values** — safe to paste on
 [#103](https://github.com/ryanbr/noop/issues/103). Promote `spo2_candidate_82` → `spo2Pct` only when
 **≥2 devices** each PASS (the tool's multi-device footer tracks that). This does **not** change app

--- a/docs/WHOOP5_DEEP_DATA.md
+++ b/docs/WHOOP5_DEEP_DATA.md
@@ -174,13 +174,21 @@ aggregates one value **per window** rather than per second, and reports per-nigh
 with a loud warning below the floor. A strap whose `@82` is flat `0x00` across a long enough capture
 is classified **`feature_absent`** — neither a PASS nor a FAIL in the multi-device gate.
 
-That absence claim carries the aliasing caveat back onto itself: it also requires the capture to have
-been sampled **finely enough to see a window**. Missing the window is a phase problem, not a duration
-one — a cadence sharing a large factor with the period only ever occupies `period ÷ gcd` residues, so
-at 300 s against 1200 s it either always lands inside the window or never does, and six nights of
-scored sleep read a flat `0x00` off a perfectly healthy strap. A capture coarser than a nominal 30 s
-window stays a plain FAIL and says why. The conservative direction matters here: `feature_absent`
-*removes* a device from the gate, so over-claiming absence would make promotion easier, not harder.
+That absence claim is gated on the capture having actually **watched** the strap — long enough, and
+finely enough, that a duty-cycled feature would have fired somewhere the capture could see it. Both
+halves fail the same way if you get them wrong, reporting a working strap as lacking the feature:
+
+- **Long enough is observed time, not wall-clock span.** `max − min` counts the gaps, so a capture
+  that ran densely for two minutes and then logged one record eight hours later scores an 8 h "span"
+  off 121 s of observation. Sleep samples × cadence is what was watched, and that is what the bar uses.
+- **Finely enough is a nominal 30 s window.** Missing the window is a phase problem, not a duration
+  one — a cadence sharing a large factor with the period only ever occupies `period ÷ gcd` residues,
+  so at 300 s against 1200 s it either always lands inside the window or never does. Six nights of
+  scored sleep then read a flat `0x00` off a perfectly healthy strap.
+
+A capture failing either test stays a plain FAIL and the duty line says why. The conservative
+direction matters here: `feature_absent` *removes* a device from the gate, so over-claiming absence
+would make promotion easier, not harder.
 
 `--postable` prints a CSV-ish block with **no raw SpO₂ values** — safe to paste on
 [#103](https://github.com/ryanbr/noop/issues/103). Promote `spo2_candidate_82` → `spo2Pct` only when

--- a/tools/linux-capture/README.md
+++ b/tools/linux-capture/README.md
@@ -666,9 +666,11 @@ cannot have 2 distinct values, so an offset must show real variation before its 
 
 **Overall PASS** only if every gate clears. A strap whose `@82` is `0x00` on 100 % of a long enough
 capture is reported as **`feature_absent`** — neither a PASS nor a FAIL, and excluded from the
-multi-device gate, because a device with no data has not failed a correlation. The capture must also
-have been **sampled at ≤ 30 s** to make that claim: a coarser cadence can alias with the duty period
-and read `0x00` off a working strap, so it stays a plain FAIL and the duty line says why. NOOP still will not
+multi-device gate, because a device with no data has not failed a correlation. To make that claim the
+capture must also have **watched** the strap: at least an hour of *observed* sleep (samples × cadence,
+not `max − min`, which counts gaps) and a cadence of **≤ 30 s**, since a coarser one can alias with the
+duty period and read `0x00` off a working strap. Either bar missed and it stays a plain FAIL, with the
+duty line saying why. NOOP still will not
 promote `spo2_candidate_82` → `spo2Pct` from a single device: need **≥ 2 devices** that each PASS
 (postable summary prints `multi_device_eligible` / `all_pass` / `feature_absent`).
 

--- a/tools/linux-capture/README.md
+++ b/tools/linux-capture/README.md
@@ -666,7 +666,9 @@ cannot have 2 distinct values, so an offset must show real variation before its 
 
 **Overall PASS** only if every gate clears. A strap whose `@82` is `0x00` on 100 % of a long enough
 capture is reported as **`feature_absent`** — neither a PASS nor a FAIL, and excluded from the
-multi-device gate, because a device with no data has not failed a correlation. NOOP still will not
+multi-device gate, because a device with no data has not failed a correlation. The capture must also
+have been **sampled at ≤ 30 s** to make that claim: a coarser cadence can alias with the duty period
+and read `0x00` off a working strap, so it stays a plain FAIL and the duty line says why. NOOP still will not
 promote `spo2_candidate_82` → `spo2Pct` from a single device: need **≥ 2 devices** that each PASS
 (postable summary prints `multi_device_eligible` / `all_pass` / `feature_absent`).
 

--- a/tools/linux-capture/test_validate_spo2_candidate.py
+++ b/tools/linux-capture/test_validate_spo2_candidate.py
@@ -699,6 +699,29 @@ class FeatureAbsentClassificationTests(unittest.TestCase):
         self.assertEqual(res["duty"]["mode"], "absent")
         self.assertNotEqual(res["classification"], "feature_absent")
 
+    def test_a_dense_burst_plus_one_far_later_record_cannot_claim_absence(self):
+        """Wall-clock span is not observation. 120 records at 1 Hz plus a single record eight hours
+        later clears the record count, spans 8 h, and has a 1 s median cadence — but the capture only
+        ever watched the strap for ~2 minutes, which is no evidence of anything."""
+        t0 = _utc(2026, 5, 1, 23, 0, 0)
+        stamps = list(range(t0, t0 + 120)) + [t0 + 8 * 3600]
+        with tempfile.TemporaryDirectory() as td:
+            frames = [
+                {"hex": make_v18(unix=u, sleep_state=2, hr=52, aux_byte_82=0).hex()} for u in stamps
+            ]
+            cap = os.path.join(td, "sparse.json")
+            with open(cap, "w") as f:
+                json.dump(frames, f)
+            exp_dir = os.path.join(td, "sparse")
+            os.makedirs(exp_dir)
+            start = datetime.fromtimestamp(t0, tz=timezone.utc).strftime("%Y-%m-%d %H:%M:%S")
+            _write_export(exp_dir, [(start, 96.0, t0, t0 + 8 * 3600)])
+            res = vs.validate_device(cap, exp_dir, device="sparse")
+        self.assertEqual(res["duty"]["mode"], "absent")
+        self.assertGreaterEqual(res["duty"]["n_records"], vs.ABSENT_MIN_RECORDS)   # count bar clears
+        self.assertLessEqual(res["duty"]["record_interval_s"], vs.NOMINAL_DUTY_WINDOW_S)  # cadence too
+        self.assertEqual(res["classification"], "fail")
+
     def test_a_cadence_at_the_window_length_can_still_claim_absence(self):
         """Boundary: a cadence at or below the window length cannot skip a window whatever the phase,
         so a flat-zero capture there IS evidence. Guards the gate against being over-tightened."""

--- a/tools/linux-capture/test_validate_spo2_candidate.py
+++ b/tools/linux-capture/test_validate_spo2_candidate.py
@@ -722,6 +722,47 @@ class FeatureAbsentClassificationTests(unittest.TestCase):
         self.assertLessEqual(res["duty"]["record_interval_s"], vs.NOMINAL_DUTY_WINDOW_S)  # cadence too
         self.assertEqual(res["classification"], "fail")
 
+    def _asleep_device(self, td, label, stamps):
+        frames = [
+            {"hex": make_v18(unix=u, sleep_state=st, hr=52, aux_byte_82=0).hex()} for u, st in stamps
+        ]
+        cap = os.path.join(td, f"{label}.json")
+        with open(cap, "w") as f:
+            json.dump(frames, f)
+        exp_dir = os.path.join(td, label)
+        os.makedirs(exp_dir)
+        t0 = min(u for u, _ in stamps)
+        t1 = max(u for u, _ in stamps)
+        start = datetime.fromtimestamp(t0, tz=timezone.utc).strftime("%Y-%m-%d %H:%M:%S")
+        _write_export(exp_dir, [(start, 96.0, t0, t1)])
+        return vs.validate_device(cap, exp_dir, device=label)
+
+    def test_repeated_timestamps_do_not_inflate_observed_sleep(self):
+        """A resume/reconnect in whoop_sync.py can re-deliver the same historical rows. Counting
+        records rather than distinct seconds turns 200 s of sleep repeated twenty times into 4000 s of
+        'observation' — enough to clear the bar off 200 s of real data."""
+        t0 = _utc(2026, 6, 1, 22, 0, 0)
+        dupes = [(t0 + i, 2) for i in range(200) for _ in range(20)]
+        with tempfile.TemporaryDirectory() as td:
+            res = self._asleep_device(td, "dupes", dupes)
+        self.assertEqual(res["duty"]["mode"], "absent")
+        self.assertEqual(res["observed_asleep_s"], 200)      # distinct seconds, not 4000 records
+        self.assertEqual(res["classification"], "fail")
+
+    def test_a_dense_awake_stretch_cannot_hide_an_aliasing_sleep_cadence(self):
+        """The gate has to read the ASLEEP cadence. A capture that is 1 Hz awake and 300 s asleep has
+        a 1 s whole-capture median, which would sail through the window gate while the only part that
+        matters aliases against the duty period."""
+        t0 = _utc(2026, 6, 1, 22, 0, 0)
+        awake = [(t0 + i, 0) for i in range(5000)]
+        asleep = [(t0 + 5000 + i * 300, 2) for i in range(4000)]
+        with tempfile.TemporaryDirectory() as td:
+            res = self._asleep_device(td, "mixed", awake + asleep)
+        self.assertEqual(res["duty"]["record_interval_s"], 1.0)   # whole-capture median says 1 Hz…
+        self.assertEqual(res["asleep_interval_s"], 300.0)         # …the part that matters does not
+        self.assertEqual(res["classification"], "fail")
+        self.assertIn("asleep cadence", vs.format_duty_line(res))
+
     def test_a_cadence_at_the_window_length_can_still_claim_absence(self):
         """Boundary: a cadence at or below the window length cannot skip a window whatever the phase,
         so a flat-zero capture there IS evidence. Guards the gate against being over-tightened."""

--- a/tools/linux-capture/test_validate_spo2_candidate.py
+++ b/tools/linux-capture/test_validate_spo2_candidate.py
@@ -661,9 +661,80 @@ class FeatureAbsentClassificationTests(unittest.TestCase):
         self.assertIn("feature_absent=1", blob)
         self.assertIn("strap-c,feature_absent,", blob)
 
+    def test_a_cadence_coarser_than_a_window_cannot_claim_absence(self):
+        """Duration bars do not catch aliasing: missing the window is a PHASE problem.
+
+        851 records over 71 hours clears both ABSENT_MIN_RECORDS and ABSENT_MIN_ASLEEP_SPAN_S, but at
+        a 300 s cadence the capture only ever occupies 4 residues mod a 1200 s period — so it either
+        always lands in the window or never does. All-zero here is not evidence of anything.
+        """
+        with tempfile.TemporaryDirectory() as td:
+            d = self._flat_zero_device(td, "coarse", step_s=300)
+            res = vs.validate_device(d["capture"], d["export"], device="coarse")
+        self.assertEqual(res["duty"]["mode"], "absent")
+        self.assertGreaterEqual(res["duty"]["n_records"], vs.ABSENT_MIN_RECORDS)
+        self.assertEqual(res["classification"], "fail")
+        self.assertIn("NOT claiming feature_absent", vs.format_duty_line(res))
+
+    def test_an_aliased_capture_of_a_WORKING_strap_is_not_reported_absent(self):
+        """The case the duration bars let through: @82 is duty-cycling perfectly, the capture just
+        never samples inside the window. Reporting this strap as lacking the feature would drop a real
+        device out of the multi-device gate and make promotion easier."""
+        period, phase, window = 1200, 337, 30
+        with tempfile.TemporaryDirectory() as td:
+            frames, nights = [], []
+            for i in range(4):
+                t0 = _utc(2026, 4, 1 + i, 23, 0, 0)
+                t1 = t0 + 8 * 3600
+                frames += _plant_duty_night(
+                    t0, t1, 95, period=period, phase=phase, window=window, step_s=300
+                )
+                start = datetime.fromtimestamp(t0, tz=timezone.utc).strftime("%Y-%m-%d %H:%M:%S")
+                nights.append((start, 95.0, t0, t1))
+            cap = os.path.join(td, "aliased.json")
+            with open(cap, "w") as f:
+                json.dump(frames, f)
+            res = vs.validate_device(cap, _write_export(td, nights), device="aliased")
+        self.assertEqual(res["duty"]["n_nonzero"], 0)      # the strap works; the capture missed it
+        self.assertEqual(res["duty"]["mode"], "absent")
+        self.assertNotEqual(res["classification"], "feature_absent")
+
+    def test_a_cadence_at_the_window_length_can_still_claim_absence(self):
+        """Boundary: a cadence at or below the window length cannot skip a window whatever the phase,
+        so a flat-zero capture there IS evidence. Guards the gate against being over-tightened."""
+        with tempfile.TemporaryDirectory() as td:
+            d = self._flat_zero_device(td, "edge", step_s=vs.NOMINAL_DUTY_WINDOW_S)
+            res = vs.validate_device(d["capture"], d["export"], device="edge")
+        self.assertEqual(res["classification"], "feature_absent")
+
     def test_postable_still_carries_no_raw_spo2_values(self):
         """The duty/coverage columns are device timing, not health data — the privacy property of
-        --postable has to survive everything added here."""
+        --postable has to survive everything added here.
+
+        Uses a device with REAL, distinct per-night values. The flat-zero fixture this used to run on
+        has no SpO₂ readings to leak, so it passed whatever the formatter did with them.
+        """
+        spo2s = [91, 93, 95, 97, 92, 98]
+        with tempfile.TemporaryDirectory() as td:
+            frames, nights = [], []
+            base = _utc(2026, 8, 1, 0, 0, 0)
+            for i, s in enumerate(spo2s):
+                t0 = base + i * 86400 + 23 * 3600
+                t1 = t0 + 7 * 3600
+                frames += _plant_duty_night(t0, t1, s, period=900, phase=111, window=20)
+                start = datetime.fromtimestamp(t0, tz=timezone.utc).strftime("%Y-%m-%d %H:%M:%S")
+                nights.append((start, float(s), t0, t1))
+            cap = os.path.join(td, "vals.json")
+            with open(cap, "w") as f:
+                json.dump(frames, f)
+            res = vs.validate_device(cap, _write_export(td, nights), device="vals")
+        blob = vs.format_postable([res])
+        self.assertEqual(res["paired_nights"], len(spo2s))   # the values really were there to leak
+        for s in spo2s:
+            self.assertNotIn(f"{s}.00", blob)
+            self.assertNotIn(f"{float(s):.1f}", blob)
+
+    def test_postable_on_a_flat_zero_device_is_still_clean(self):
         with tempfile.TemporaryDirectory() as td:
             d = self._flat_zero_device(td, "priv")
             res = vs.validate_device(d["capture"], d["export"], device="priv")

--- a/tools/linux-capture/validate_spo2_candidate.py
+++ b/tools/linux-capture/validate_spo2_candidate.py
@@ -106,6 +106,20 @@ DEFAULT_MIN_WINDOW_COVERAGE = 0.5   # below this share of a night's windows, its
 ABSENT_MIN_RECORDS = 100
 ABSENT_MIN_ASLEEP_SPAN_S = 3 * NOMINAL_DUTY_PERIOD_S
 
+# ...and it must have been sampled FINELY enough to see one of those firings. Duration is not enough,
+# because missing the window is a phase problem, not a length one: a cadence that shares a large
+# factor with the period only ever occupies `period // gcd` residues, so it either always lands inside
+# the window or never does. At 300 s against the reference 1200 s that is 4 residues — six nights of
+# eight hours' scored sleep clear both bars above and still read a flat 0x00 off a perfectly healthy
+# strap. This is the aliasing documented at the top of this file, turned on our own absence claim.
+#
+# A cadence at or below the window length cannot skip a window, whatever the phase, so that is the
+# bar. Same caveat as NOMINAL_DUTY_PERIOD_S: 30 s is the reference strap's window, not a law — it is
+# used only as a minimum-evidence figure, never as a detector input. A coarser capture that reads all
+# zeros stays a plain FAIL, which is the conservative direction: `feature_absent` REMOVES a device
+# from the multi-device gate, so over-claiming absence makes promotion easier, not harder.
+NOMINAL_DUTY_WINDOW_S = 30
+
 # --- Variance floor --------------------------------------------------------------------------------
 # "The value lands in 70–100" is not a specific screen. On a real subscription-free 5.0 strap SIX
 # offsets pass an in-band-only screen on a majority of records — @17, @33, @59, @69, @71, @107 — and
@@ -678,12 +692,18 @@ def validate_device(
     # A strap that never emits @82 has not failed a correlation — it has no data to correlate. Say so
     # explicitly, but only once the capture is long enough that a duty-cycled feature would have had
     # several chances to fire during sleep; a short capture that missed the window is not evidence.
+    # And only if it was sampled finely enough to SEE one — see NOMINAL_DUTY_WINDOW_S. Without that
+    # last clause the two duration bars pass an aliased capture straight through and a working strap
+    # is reported absent.
     asleep_stamps = [r["unix"] for r in records if r.get("sleep_state") == SLEEP_ASLEEP]
     asleep_span = (max(asleep_stamps) - min(asleep_stamps)) if len(asleep_stamps) >= 2 else 0
+    interval = duty.get("record_interval_s")
+    cadence_could_see_window = interval is not None and interval <= NOMINAL_DUTY_WINDOW_S
     feature_absent = (
         duty["mode"] == "absent"
         and len(records) >= ABSENT_MIN_RECORDS
         and asleep_span >= ABSENT_MIN_ASLEEP_SPAN_S
+        and cadence_could_see_window
     )
     classification = (
         "feature_absent" if feature_absent else ("pass" if checklist["pass"] else "fail")
@@ -804,6 +824,17 @@ def format_duty_line(result: dict) -> str:
         f"  @82 duty cycle: mode={mode}  nonzero={d.get('n_nonzero', 0)}/{d.get('n_records', 0)} "
         f"({d.get('nonzero_fraction', 0.0):.2%})  distinct_values={d.get('distinct_values', 0)}"
     )
+    if mode == "absent":
+        # Say WHY an all-zero capture was not allowed to claim absence, rather than letting it read as
+        # a plain FAIL for no stated reason. Same principle as reporting rejected offsets.
+        interval = d.get("record_interval_s")
+        if interval is not None and interval > NOMINAL_DUTY_WINDOW_S:
+            head += (
+                f"\n    NOT claiming feature_absent: {interval:g}s cadence is coarser than a nominal "
+                f"{NOMINAL_DUTY_WINDOW_S}s window, so an aliased capture could read 0x00 off a working "
+                f"strap. Recapture at ≤{NOMINAL_DUTY_WINDOW_S}s to make an absence claim."
+            )
+        return head
     if mode != "duty_cycled":
         return head
     return (

--- a/tools/linux-capture/validate_spo2_candidate.py
+++ b/tools/linux-capture/validate_spo2_candidate.py
@@ -704,11 +704,23 @@ def validate_device(
     # Both failures produce the same wrong answer — a working strap reported as lacking the feature —
     # and that error is asymmetric, because feature_absent REMOVES a device from the multi-device gate
     # rather than failing it. Over-claiming absence loosens the promote bar.
-    asleep_stamps = [r["unix"] for r in records if r.get("sleep_state") == SLEEP_ASLEEP]
-    asleep_span = (max(asleep_stamps) - min(asleep_stamps)) if len(asleep_stamps) >= 2 else 0
-    interval = duty.get("record_interval_s")
-    observed_asleep_s = len(asleep_stamps) * interval if interval else 0
-    cadence_could_see_window = interval is not None and interval <= NOMINAL_DUTY_WINDOW_S
+    #
+    # Both are therefore measured over the ASLEEP records only, on DISTINCT timestamps. Two ways that
+    # bites if you take the whole-capture figures instead:
+    #   • The global median cadence is set by whichever state has more records. A capture that is 1 Hz
+    #     awake and 300 s asleep reports a 1 s cadence and sails through the window gate, while the
+    #     part that matters aliases.
+    #   • Counting records rather than distinct seconds over-counts a capture that re-delivers the
+    #     same historical rows — a resume/reconnect in whoop_sync.py does exactly that — so 200 s of
+    #     sleep repeated twenty times scores as 4000 s of observation.
+    asleep_records = [r for r in records if r.get("sleep_state") == SLEEP_ASLEEP]
+    asleep_stamps = sorted({r["unix"] for r in asleep_records})
+    asleep_span = (asleep_stamps[-1] - asleep_stamps[0]) if len(asleep_stamps) >= 2 else 0
+    asleep_interval = _median_record_interval(asleep_records) if len(asleep_stamps) >= 2 else None
+    observed_asleep_s = len(asleep_stamps) * asleep_interval if asleep_interval else 0
+    cadence_could_see_window = (
+        asleep_interval is not None and asleep_interval <= NOMINAL_DUTY_WINDOW_S
+    )
     feature_absent = (
         duty["mode"] == "absent"
         and len(records) >= ABSENT_MIN_RECORDS
@@ -738,8 +750,11 @@ def validate_device(
         "low_coverage_nights": low_cov_nights,
         "asleep_span_s": asleep_span,
         # Reported beside the span on purpose: the two diverging is the signature of a capture with
-        # gaps, and it is the observed figure the absence claim is gated on.
+        # gaps, and it is the observed figure the absence claim is gated on. `asleep_interval_s` is
+        # the cadence of the ASLEEP records specifically — the whole-capture median in `duty` can be
+        # set by a dense awake stretch and hide an aliasing sleep cadence.
         "observed_asleep_s": observed_asleep_s,
+        "asleep_interval_s": asleep_interval,
         "classification": classification,
         "checklist": checklist,
         "nights": nights,
@@ -840,12 +855,22 @@ def format_duty_line(result: dict) -> str:
     if mode == "absent":
         # Say WHY an all-zero capture was not allowed to claim absence, rather than letting it read as
         # a plain FAIL for no stated reason. Same principle as reporting rejected offsets.
-        interval = d.get("record_interval_s")
+        #
+        # Reads the ASLEEP cadence, not `duty.record_interval_s` — the whole-capture median is what
+        # the gate deliberately does not trust, so quoting it here would print a reassuring number
+        # while the claim was refused on a different one.
+        interval = result.get("asleep_interval_s")
+        observed = result.get("observed_asleep_s") or 0
         if interval is not None and interval > NOMINAL_DUTY_WINDOW_S:
             head += (
-                f"\n    NOT claiming feature_absent: {interval:g}s cadence is coarser than a nominal "
-                f"{NOMINAL_DUTY_WINDOW_S}s window, so an aliased capture could read 0x00 off a working "
-                f"strap. Recapture at ≤{NOMINAL_DUTY_WINDOW_S}s to make an absence claim."
+                f"\n    NOT claiming feature_absent: {interval:g}s asleep cadence is coarser than a "
+                f"nominal {NOMINAL_DUTY_WINDOW_S}s window, so an aliased capture could read 0x00 off a "
+                f"working strap. Recapture at ≤{NOMINAL_DUTY_WINDOW_S}s to make an absence claim."
+            )
+        elif observed < ABSENT_MIN_ASLEEP_SPAN_S:
+            head += (
+                f"\n    NOT claiming feature_absent: only {observed:.0f}s of sleep actually observed "
+                f"(need {ABSENT_MIN_ASLEEP_SPAN_S}s). Wall-clock span counts gaps; this counts samples."
             )
         return head
     if mode != "duty_cycled":

--- a/tools/linux-capture/validate_spo2_candidate.py
+++ b/tools/linux-capture/validate_spo2_candidate.py
@@ -690,19 +690,29 @@ def validate_device(
     checklist["pass"] = all(checklist.values())
 
     # A strap that never emits @82 has not failed a correlation — it has no data to correlate. Say so
-    # explicitly, but only once the capture is long enough that a duty-cycled feature would have had
-    # several chances to fire during sleep; a short capture that missed the window is not evidence.
-    # And only if it was sampled finely enough to SEE one — see NOMINAL_DUTY_WINDOW_S. Without that
-    # last clause the two duration bars pass an aliased capture straight through and a working strap
-    # is reported absent.
+    # explicitly, but only once the capture actually WATCHED the strap long enough, and finely enough,
+    # that a duty-cycled feature would have fired where the capture could see it.
+    #
+    # Both halves of that are easy to get wrong in the same direction:
+    #   • Long enough is OBSERVED time, not wall-clock span. max-minus-min counts the gaps, so a
+    #     capture that ran densely for two minutes and then logged one record eight hours later scores
+    #     an 8 h "span" off 121 s of observation. Sleep samples times cadence is what was watched.
+    #   • Finely enough is NOMINAL_DUTY_WINDOW_S. Missing the window is a phase problem: a cadence
+    #     sharing a large factor with the period only ever occupies period//gcd residues, so it either
+    #     always lands in the window or never does, and no amount of duration fixes that.
+    #
+    # Both failures produce the same wrong answer — a working strap reported as lacking the feature —
+    # and that error is asymmetric, because feature_absent REMOVES a device from the multi-device gate
+    # rather than failing it. Over-claiming absence loosens the promote bar.
     asleep_stamps = [r["unix"] for r in records if r.get("sleep_state") == SLEEP_ASLEEP]
     asleep_span = (max(asleep_stamps) - min(asleep_stamps)) if len(asleep_stamps) >= 2 else 0
     interval = duty.get("record_interval_s")
+    observed_asleep_s = len(asleep_stamps) * interval if interval else 0
     cadence_could_see_window = interval is not None and interval <= NOMINAL_DUTY_WINDOW_S
     feature_absent = (
         duty["mode"] == "absent"
         and len(records) >= ABSENT_MIN_RECORDS
-        and asleep_span >= ABSENT_MIN_ASLEEP_SPAN_S
+        and observed_asleep_s >= ABSENT_MIN_ASLEEP_SPAN_S
         and cadence_could_see_window
     )
     classification = (
@@ -727,6 +737,9 @@ def validate_device(
         "median_window_coverage": median_coverage,
         "low_coverage_nights": low_cov_nights,
         "asleep_span_s": asleep_span,
+        # Reported beside the span on purpose: the two diverging is the signature of a capture with
+        # gaps, and it is the observed figure the absence claim is gated on.
+        "observed_asleep_s": observed_asleep_s,
         "classification": classification,
         "checklist": checklist,
         "nights": nights,


### PR DESCRIPTION
Follow-up to #860, which added the `feature_absent` classification. Tools + docs only.

Its evidence bar is `ABSENT_MIN_RECORDS` plus `ABSENT_MIN_ASLEEP_SPAN_S` — both **durations**. But
missing a duty window is a **phase** problem, so neither catches an aliased capture.

A cadence sharing a large factor with the period only ever occupies `period ÷ gcd` residues. At 300 s
against the reference 1200 s that is four, so the capture either always lands inside the window or
never does. Six nights of eight hours' scored sleep then read a flat `0x00` off a strap whose `@82`
is duty-cycling perfectly. Same strap, same firmware, only the cadence differing:

```
1 Hz      duty_cycled  fail
1/5 min   absent       feature_absent   <- before this change
```

This is #860's own **finding 1** — an off-phase capture is indistinguishable from a disabled feature
— applied to its **finding 3**.

### Why it matters more than a plain misclassification

It is asymmetric. `feature_absent` *removes* a device from `eligible`, and `all_pass` is computed
over what remains, so a device that would have blocked promotion silently drops out instead.
Over-claiming absence **loosens** the gate — the wrong direction for the thing that decides whether
`spo2_candidate_82` graduates.

### The change

An absence claim now also requires `record_interval_s <= NOMINAL_DUTY_WINDOW_S`. A cadence at or
below the window length cannot skip a window whatever the phase; anything coarser stays a plain FAIL.

The 30 s figure carries the same caveat as `NOMINAL_DUTY_PERIOD_S`: it is the reference strap's
window, used only as a minimum-evidence bar, **never as a detector input**. Nothing in
`detect_duty_cycle` changes — its schedule recovery is untouched and still measures everything per
capture.

`format_duty_line` now states why the claim was withheld, rather than leaving an unexplained FAIL —
same principle as #860 reporting rejected offsets instead of dropping them silently:

```
@82 duty cycle: mode=absent  nonzero=0/576 (0.00%)  distinct_values=0
  NOT claiming feature_absent: 300s cadence is coarser than a nominal 30s window, so an aliased
  capture could read 0x00 off a working strap. Recapture at ≤30s to make an absence claim.
```

### Second hole, same class, found re-reviewing this PR

`ABSENT_MIN_ASLEEP_SPAN_S` was compared against `max(asleep) - min(asleep)`, which counts the gaps.
A capture that ran densely for two minutes and then logged a single record eight hours later:

```
span = 28800s   observed = 121s   -> feature_absent
```

121 records clears the count bar, the 8 h span clears the duration bar, and the 1 s median cadence
sails through the window gate above. Same wrong answer as the aliasing case, same underlying reason:
the bar was measuring something that is not observation. It now uses
`len(asleep_stamps) * record_interval_s` — what the capture actually watched.

Both figures are reported. Span and observed diverging *is* the signature of a gappy capture, so the
pair says more to whoever reads the output than either alone.

Checked against what must keep working: a genuine flat-zero strap at 5 s over 8 h still claims
absence, and so does the boundary at exactly the 30 s window length, so the gate is not
over-tightened.

### Also: the postable privacy test was passing for the wrong reason

`test_postable_still_carries_no_raw_spo2_values` asserted `assertNotIn("96.00", blob)` against the
flat-zero fixture — a device with **no SpO₂ readings to leak**, so it passed whatever the formatter
did with them. It now runs on a device with six distinct per-night values (91/93/95/97/92/98) and
checks each, with an assertion that the values really were paired first. The flat-zero case is kept
as its own test. The property does hold — verified by hand before changing the test.

### Tests

`tools/linux-capture` **194 → 199**, validator file **32 → 37**, all pre-existing tests unchanged and
passing (`python3 -m unittest discover`).

New coverage: a coarse all-zero capture refusing the claim; an aliased capture of a **working** strap
(the case the duration bars let through); and the boundary where a cadence exactly at the window
length still claims absence, so the gate cannot be quietly over-tightened in a later edit.

### Scope

No app code, no decoder, no schema, no Swift/Kotlin. `spo2_candidate_82` remains
instrumentation-only. Serves the #103 promote gate.
