### PR TITLE
Read the v18 aux keys from V18AuxSlot instead of repeating them in the extractor

### DIFF
--- a/Packages/WhoopProtocol/Sources/WhoopProtocol/HistoricalStreams.swift
+++ b/Packages/WhoopProtocol/Sources/WhoopProtocol/HistoricalStreams.swift
@@ -289,27 +289,35 @@ public func extractHistoricalStreams(_ parsed: [ParsedFrame],
             // `rr_count` IS shared with the 4.0 schema and a presence-based test would start banking a
             // near-empty row for every WHOOP 4.0 second.
             if p["hist_version"]?.intValue == 18 {
+                // Read through `V18AuxSlot.decoderKey` rather than repeating the key strings here. They
+                // used to be two independent literals per slot — the enum's and this extractor's — and
+                // `testEverySlotIsPopulatedFromARealV18Frame` exists precisely because those two can drift
+                // apart while each looks right on its own. With one source there is nothing to drift: a
+                // slot pointed at a retired key now fails BOTH tripwires instead of only the second.
+                func slot(_ s: V18AuxSlot) -> Int? { p[s.decoderKey]?.intValue }
                 let aux = V18AuxSample(
                     ts: ts,
-                    recordIndex: p["record_index"]?.intValue,
-                    rrCount: p["rr_count"]?.intValue,
-                    cardiacFlags: p["cardiac_flags"]?.intValue,
-                    hrQualityFlags: p["hr_quality_flags"]?.intValue,
-                    heartRateAlt: p["heart_rate_alt"]?.intValue,
-                    rrPacked: p["rr_packed"]?.intValue,
-                    cardiacStatus: p["cardiac_status"]?.intValue,
-                    stepCadence: p["step_cadence"]?.intValue,
-                    statusWord: p["status_word"]?.intValue,
-                    statusWord1: p["status_word_1"]?.intValue,
-                    statusWord2: p["status_word_2"]?.intValue,
-                    auxByte82: p["aux_byte_82"]?.intValue,
-                    opticalBaselineA: p["optical_baseline_a"]?.intValue,
-                    opticalBaselineB: p["optical_baseline_b"]?.intValue,
-                    opticalAmpA: p["optical_amp_a"]?.intValue,
-                    opticalAmpB: p["optical_amp_b"]?.intValue,
+                    recordIndex: slot(.recordIndex),
+                    rrCount: slot(.rrCount),
+                    cardiacFlags: slot(.cardiacFlags),
+                    hrQualityFlags: slot(.hrQualityFlags),
+                    heartRateAlt: slot(.heartRateAlt),
+                    rrPacked: slot(.rrPacked),
+                    cardiacStatus: slot(.cardiacStatus),
+                    stepCadence: slot(.stepCadence),
+                    statusWord: slot(.statusWord),
+                    statusWord1: slot(.statusWord1),
+                    statusWord2: slot(.statusWord2),
+                    auxByte82: slot(.auxByte82),
+                    opticalBaselineA: slot(.opticalBaselineA),
+                    opticalBaselineB: slot(.opticalBaselineB),
+                    opticalAmpA: slot(.opticalAmpA),
+                    opticalAmpB: slot(.opticalAmpB),
                     // Banked as the float's raw 32-bit pattern, not a decoded value — the decoder gates this
                     // field to finite floats, which round-trip Double->Float exactly, so no precision is lost.
-                    unknownF32Bits: p["unknown_f32_113"]?.doubleValue.map {
+                    // Reads `doubleValue`, so it cannot use `slot(_:)` above, but the KEY still comes from
+                    // the enum.
+                    unknownF32Bits: p[V18AuxSlot.unknownF32At113.decoderKey]?.doubleValue.map {
                         Int(Float($0).bitPattern)
                     })
                 // A record that decoded none of the slots banks no row at all — absence stays absence.

--- a/Packages/WhoopProtocol/Sources/WhoopProtocol/HistoricalStreams.swift
+++ b/Packages/WhoopProtocol/Sources/WhoopProtocol/HistoricalStreams.swift
@@ -279,9 +279,9 @@ public func extractHistoricalStreams(_ parsed: [ParsedFrame],
             // rename silent: the key stops existing, the slot banks nothing, and neither the compiler
             // (the type is `Int?`) nor a runtime check (absence is a legal state here) says a word — in a
             // capture format whose only job is preserving fields before the strap trims them. Each key
-            // below is also declared as `V18AuxSlot.decoderKey`, and
-            // `testEverySlotDecoderKeyExistsInARealV18Decode` asserts every one of those still decodes
-            // off a real v18 frame, so a future rename fails a test instead of quietly losing a channel.
+            // below comes from `V18AuxSlot.decoderKey` and is written down nowhere else on this side, so
+            // `testEverySlotDecoderKeyExistsInARealV18Decode` — which asserts every one still decodes off
+            // a real v18 frame — is checking the same string this code reads with, not a copy of it.
             //
             // Gated on `hist_version == 18` — the exact layout these offsets were read off. Every other
             // layout adds NOTHING: a WHOOP 4.0 v24/v25 record and a 5/MG v20/v21/v26 record are untouched.

--- a/android/app/src/main/java/com/noop/protocol/HistoricalStreams.kt
+++ b/android/app/src/main/java/com/noop/protocol/HistoricalStreams.kt
@@ -12,6 +12,7 @@ import com.noop.data.RrRow
 import com.noop.data.SkinTempRow
 import com.noop.data.SleepStateRow
 import com.noop.data.V18AuxRow
+import com.noop.data.V18AuxSlot
 import com.noop.data.Spo2Row
 import com.noop.data.StepRow
 import com.noop.data.StreamBatch
@@ -808,27 +809,35 @@ fun extractHistoricalStreams(
                 // positive. `asU32` puts both back in the 0..4294967295 domain, so the two platforms
                 // agree on the NUMBER and not merely on the blob bytes.
                 if (p.intOrNull("hist_version") == 18) {
+                    // Read through [V18AuxSlot.decoderKey] rather than repeating the key strings here.
+                    // They used to be two independent literals per slot — the enum's and this extractor's
+                    // — and `everySlotIsPopulatedFromARealV18Frame` exists precisely because those two can
+                    // drift apart while each looks right on its own. With one source there is nothing to
+                    // drift: a slot pointed at a retired key now fails BOTH tripwires, not only the second.
+                    fun slot(s: V18AuxSlot): Long? = p.intOrNull(s.decoderKey)?.toLong()
                     val aux = V18AuxRow(
                         ts = ts,
-                        recordIndex = p.intOrNull("record_index").asU32(),
-                        rrCount = p.intOrNull("rr_count")?.toLong(),
-                        cardiacFlags = p.intOrNull("cardiac_flags")?.toLong(),
-                        hrQualityFlags = p.intOrNull("hr_quality_flags")?.toLong(),
-                        heartRateAlt = p.intOrNull("heart_rate_alt")?.toLong(),
-                        rrPacked = p.intOrNull("rr_packed")?.toLong(),
-                        cardiacStatus = p.intOrNull("cardiac_status")?.toLong(),
-                        stepCadence = p.intOrNull("step_cadence")?.toLong(),
-                        statusWord = p.intOrNull("status_word")?.toLong(),
-                        statusWord1 = p.intOrNull("status_word_1")?.toLong(),
-                        statusWord2 = p.intOrNull("status_word_2")?.toLong(),
-                        auxByte82 = p.intOrNull("aux_byte_82")?.toLong(),
-                        opticalBaselineA = p.intOrNull("optical_baseline_a")?.toLong(),
-                        opticalBaselineB = p.intOrNull("optical_baseline_b")?.toLong(),
-                        opticalAmpA = p.intOrNull("optical_amp_a")?.toLong(),
-                        opticalAmpB = p.intOrNull("optical_amp_b")?.toLong(),
+                        // Needs asU32(), so it cannot use slot() — but the KEY still comes from the enum.
+                        recordIndex = p.intOrNull(V18AuxSlot.RECORD_INDEX.decoderKey).asU32(),
+                        rrCount = slot(V18AuxSlot.RR_COUNT),
+                        cardiacFlags = slot(V18AuxSlot.CARDIAC_FLAGS),
+                        hrQualityFlags = slot(V18AuxSlot.HR_QUALITY_FLAGS),
+                        heartRateAlt = slot(V18AuxSlot.HEART_RATE_ALT),
+                        rrPacked = slot(V18AuxSlot.RR_PACKED),
+                        cardiacStatus = slot(V18AuxSlot.CARDIAC_STATUS),
+                        stepCadence = slot(V18AuxSlot.STEP_CADENCE),
+                        statusWord = slot(V18AuxSlot.STATUS_WORD),
+                        statusWord1 = slot(V18AuxSlot.STATUS_WORD_1),
+                        statusWord2 = slot(V18AuxSlot.STATUS_WORD_2),
+                        auxByte82 = slot(V18AuxSlot.AUX_BYTE_82),
+                        opticalBaselineA = slot(V18AuxSlot.OPTICAL_BASELINE_A),
+                        opticalBaselineB = slot(V18AuxSlot.OPTICAL_BASELINE_B),
+                        opticalAmpA = slot(V18AuxSlot.OPTICAL_AMP_A),
+                        opticalAmpB = slot(V18AuxSlot.OPTICAL_AMP_B),
                         // Banked as the float's raw 32-bit pattern, not a decoded value — the decoder
                         // gates this field to finite floats, which round-trip Double->Float exactly.
-                        unknownF32Bits = p.doubleOrNull("unknown_f32_113")
+                        // Reads doubleOrNull, so it cannot use slot() either; same rule for the key.
+                        unknownF32Bits = p.doubleOrNull(V18AuxSlot.UNKNOWN_F32_113.decoderKey)
                             ?.let { f -> f.toFloat().toRawBits() }.asU32(),
                     )
                     // A record that decoded none of the slots banks no row at all — absence stays absence.

--- a/android/app/src/main/java/com/noop/protocol/HistoricalStreams.kt
+++ b/android/app/src/main/java/com/noop/protocol/HistoricalStreams.kt
@@ -797,11 +797,11 @@ fun extractHistoricalStreams(
                 //
                 // Every lookup below is BY DECODER KEY, and every one is nullable. That makes a decoder
                 // rename silent: the key stops existing, the slot banks nothing, and neither the compiler
-                // nor a runtime check says a word (absence is a legal state here). Each key is also
-                // declared as `V18AuxSlot.decoderKey`, and
-                // `DeepCaptureChannelsTest.everySlotDecoderKeyExistsInARealV18Decode` asserts every one
-                // still decodes off a real v18 frame, so a rename fails a test instead of losing a
-                // channel. Swift twin: `extractHistoricalStreams`.
+                // nor a runtime check says a word (absence is a legal state here). Each key comes from
+                // `V18AuxSlot.decoderKey` and is written down nowhere else on this side, so
+                // `DeepCaptureChannelsTest.everySlotDecoderKeyExistsInARealV18Decode` — which asserts every
+                // one still decodes off a real v18 frame — is checking the same string this code reads
+                // with, not a copy of it. Swift twin: `extractHistoricalStreams`.
                 // Every slot is carried as a Long in the UNSIGNED domain, matching Swift's 64-bit Int.
                 // The 1- and 2-byte slots are already non-negative, but the two 4-byte ones are not: the
                 // decoder narrows `record_index` to an Int (`histU32(11)!!.toInt()`) and `toRawBits`


### PR DESCRIPTION
Follow-up to #848 — the non-blocking nit from its review.

Each aux slot's decoder key existed as **two independent string literals**: the one on
`V18AuxSlot.decoderKey`, and the one `extractHistoricalStreams` passed to the parsed-dictionary
lookup. Nothing tied them together, and both look correct in isolation — which is exactly why #848
needed `testEverySlotIsPopulatedFromARealV18Frame` as a *second* tripwire beside the decoder-key one.

That is a test holding two strings in step. This makes them one string, so there is nothing to hold:

```diff
-    recordIndex: p["record_index"]?.intValue,
-    rrCount: p["rr_count"]?.intValue,
+    func slot(_ s: V18AuxSlot) -> Int? { p[s.decoderKey]?.intValue }
+    recordIndex: slot(.recordIndex),
+    rrCount: slot(.rrCount),
```

A slot pointed at a retired key now fails **both** tripwires rather than only the second, and the
ordinary case — someone updates the enum and forgets the extractor — cannot happen at all.

### What deliberately keeps its literals

**Three call sites**, because they do not go through `intOrNull`: `record_index` needs `asU32()`, and
`unknown_f32_113` reads `doubleOrNull` on both platforms. Those still take the *key* from the enum,
just not the helper.

**The decoder.** It is the producer and owns the vocabulary; `V18AuxSlot` documents "the decoder's
own key" and points at it. Having the protocol decoder read a storage enum would invert the layering
those files exist to keep apart — on Swift they are not even in the same file. The extractor is the
consumer, and the consumer is where a stale key goes unnoticed, which is the failure #848 actually
hit.

### Verification

Both extractors now contain **zero** aux key literals; the 18 that remain in the Kotlin file are all
`out[...]` decoder emits. Every one of the 17 `V18AuxSlot` members is referenced exactly once per
platform — checked mechanically against the declarations on both sides, since a typo across 17
renames is precisely the kind of thing that would compile on Swift and never compile at all on
Kotlin. Kotlin needed the `V18AuxSlot` import added.

No behaviour change: same keys, same lookups, same values, same order. Storage contract untouched, no
migration, no schema.

The Swift half is covered by `test (WhoopProtocol)` / `test (WhoopStore)`. The Kotlin half is not
compiled by anything, as usual — the name check above is the substitute.
