### PR TITLE
Say what actually gates the feature-flag probe on a WHOOP 4.0

### DIFF
--- a/Strand/BLE/BLEManager.swift
+++ b/Strand/BLE/BLEManager.swift
@@ -1504,10 +1504,15 @@ public final class BLEManager: NSObject, ObservableObject {
                 || command == .getBodyLocationAndStatus
                 // START_FF_KEY_EXCHANGE (117) / SEND_NEXT_FF (118) over puffin: the READ-ONLY feature-flag
                 // ENUMERATION probe (#761) — it reads the strap's own flag NAMES and writes no value. Gated
-                // harder than the probes above: allowed ONLY while a probe is actually in flight, so a
-                // default install can never form these bytes. The SET verbs (120 SET_FF_VALUE / 119
-                // SET_DEVICE_CONFIG_VALUE) keep their own separate opt-in clauses below and are never sent
-                // from this path. Driven only by probeFeatureFlags() (user-initiated, Test Centre gated).
+                // harder than the probes above: allowed ONLY while a probe is actually in flight, so on a
+                // 5/MG a default install can never form these bytes. NOTE this whole allowlist is inside the
+                // `deviceFamily == .whoop5` branch — WHOOP 4.0 has no send allowlist at all, so on a 4.0 the
+                // only thing keeping 117/118 off the wire is probeFeatureFlags()'s own Test Centre gate.
+                // Same practical result, different mechanism, and worth knowing because the 4.0 is the
+                // family with a published key dump to reproduce and so the likely first runner.
+                // The SET verbs (120 SET_FF_VALUE / 119 SET_DEVICE_CONFIG_VALUE) keep their own separate
+                // opt-in clauses below and are never sent from this path. Driven only by
+                // probeFeatureFlags() (user-initiated, Test Centre gated).
                 || ((command == .startFeatureFlagKeyExchange || command == .sendNextFeatureFlag)
                     && featureFlagReport != nil)
                 || command == .sendHistoricalData || command == .historicalDataResult
@@ -2584,6 +2589,11 @@ public final class BLEManager: NSObject, ObservableObject {
         }
         // Defence in depth: the menu entry is already Test-Centre gated, but the sender re-checks so no
         // other path can start a probe on a default install.
+        //
+        // On WHOOP 4.0 this check is the ONLY thing standing between a default install and 117/118 on the
+        // wire: the send() allowlist that also gates them lives inside the `deviceFamily == .whoop5`
+        // branch, and 4.0 has no allowlist. So this guard is not merely belt-and-braces on every family —
+        // for the family most likely to run this first, it is the belt.
         guard TestCentre.active(.connection) else {
             log("Feature-flag probe (#761) ignored — Test Centre → Connection is off")
             return

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -2781,8 +2781,12 @@ class WhoopBleClient(
                 cmd != CommandNumber.GET_BODY_LOCATION_AND_STATUS &&
                 // START_FF_KEY_EXCHANGE (117) / SEND_NEXT_FF (118) over puffin: the READ-ONLY feature-flag
                 // ENUMERATION probe (#761) — it reads the strap's own flag NAMES and writes no value. Gated
-                // harder than the probes above: allowed ONLY while a probe is actually in flight, so a
-                // default install can never form these bytes. The SET verbs (120 / 119) keep their own
+                // harder than the probes above: allowed ONLY while a probe is actually in flight, so on a
+                // 5/MG a default install can never form these bytes. NOTE this whole allowlist is the 5/MG
+                // path — WHOOP 4.0 has no send allowlist at all, so on a 4.0 the only thing keeping 117/118
+                // off the wire is probeFeatureFlags()'s own Test Centre gate. Same practical result,
+                // different mechanism, and worth knowing because the 4.0 is the family with a published key
+                // dump to reproduce and so the likely first runner. The SET verbs (120 / 119) keep their own
                 // separate opt-in clauses below and are never sent from this path. Driven only by
                 // probeFeatureFlags() (user-initiated, Test Centre gated).
                 !((cmd == CommandNumber.START_FF_KEY_EXCHANGE || cmd == CommandNumber.SEND_NEXT_FF) &&
@@ -3238,6 +3242,11 @@ class WhoopBleClient(
         }
         // Defence in depth: the menu entry is already Test-Centre gated, but the sender re-checks so no
         // other path can start a probe on a default install (twin of the macOS guard).
+        //
+        // On WHOOP 4.0 this check is the ONLY thing standing between a default install and 117/118 on the
+        // wire: the send() allowlist that also gates them is the 5/MG path, and 4.0 has no allowlist. So
+        // this guard is not merely belt-and-braces on every family — for the family most likely to run
+        // this first, it is the belt.
         if (!testCentre.active(com.noop.testcentre.TestDomain.CONNECTION)) {
             log("Feature-flag probe (#761) ignored — Test Centre → Connection is off")
             return


### PR DESCRIPTION
Follow-up to #872, from its review. **Comments only, no behaviour change.**

Both allowlist comments claimed:

> allowed ONLY while a probe is actually in flight, so a default install can never form these bytes

That is true on 5/MG and **only** there. The whole `send()` allowlist sits inside the
`deviceFamily == .whoop5` branch, and WHOOP 4.0 has no send allowlist at all — so on a 4.0 the only
thing keeping `START_FF_KEY_EXCHANGE`(117) and `SEND_NEXT_FF`(118) off the wire is
`probeFeatureFlags()`'s own Test Centre gate.

Same practical outcome, and it matches how every other 4.0 command already works, so this is **not a
hole**. But the 4.0 is the family with a published key dump to reproduce, which makes it the likely
first runner — and someone auditing the safety story of an opcode nobody has validated on hardware
should not have to discover that the reassuring sentence only covers the other family.

Also adds a line on the Test Centre guard itself: for 4.0 it is not belt-and-braces, it is the belt.
That guard doing its job is load-bearing on that family, and the comment now says so.

Both platforms, both comment sites. `doc_comment_lint` and `i18n_audit.py --ci` green.

Originally offered as a patch on #872, but the push to the fork was refused (`maintainerCanModify`
is on, the token is not), so it lands here instead. Applies unchanged on top of the merge.
