### PR TITLE
Don't let our own decode strictness end the strap's enumeration

### DIFF
--- a/Packages/WhoopProtocol/Sources/WhoopProtocol/FeatureFlagProbe.swift
+++ b/Packages/WhoopProtocol/Sources/WhoopProtocol/FeatureFlagProbe.swift
@@ -286,9 +286,23 @@ public struct FeatureFlagProbeReport: Equatable, Sendable {
         if let c = r.resultCode { line += " result=\(FeatureFlagProbe.resultLabel(c))(\(c))" }
         trace.append(line)
         if r.isExhausted {
-            stopReason = r.index == 0xFF
-                ? "cursor exhausted (index 0xFF)"
-                : "firmware reported validKey=false"
+            if r.index == 0xFF {
+                stopReason = "cursor exhausted (index 0xFF)"
+            } else {
+                // `validKey = 0` is documented as an end marker alongside 0xFF, and it is the firmware's
+                // own flag, so it is trusted here. But nothing observed so far rules out the other
+                // reading — that it marks an EMPTY SLOT and the list continues past it. If so this stops
+                // on the first hole, which is the same truncation `isSkippable` exists to prevent, one
+                // condition over. It cannot be settled without a strap, so instead of guessing we make
+                // the discrepancy loud: stopping here well short of the announced count is exactly the
+                // evidence that would settle it.
+                stopReason = "firmware reported validKey=false"
+                if let count = reportedCount, count > steps {
+                    stopReason = "firmware reported validKey=false at index \(r.index) after \(steps) of "
+                        + "\(count) announced entries — if validKey=0 marks an empty slot rather than the "
+                        + "end of the list, the remainder was NOT walked (see #872 review)"
+                }
+            }
             return false
         }
         if r.isSkippable {

--- a/Packages/WhoopProtocol/Sources/WhoopProtocol/FeatureFlagProbe.swift
+++ b/Packages/WhoopProtocol/Sources/WhoopProtocol/FeatureFlagProbe.swift
@@ -126,9 +126,22 @@ public enum FeatureFlagProbe {
             self.validKey = validKey
             self.key = key
         }
-        /// The cursor is done: the firmware said the entry is invalid, returned the 0xFF end marker, or
-        /// carried no decodable name. Any of the three stops the walk.
-        public var isExhausted: Bool { !validKey || index == 0xFF || key == nil }
+        /// The STRAP said stop: it returned the 0xFF end marker, or flagged the entry as not a real key.
+        /// Both are the firmware's own signal, so both are trusted.
+        ///
+        /// Deliberately does NOT include `key == nil`. That is OUR parser declining a name — a byte outside
+        /// printable ASCII, or one longer than `maxKeyLength` — and it says nothing about whether the strap
+        /// has more entries. Treating it as a terminator meant one undecodable name threw away every entry
+        /// after it: a list of forty with a bad byte at seven yielded six keys. See `isSkippable`.
+        public var isExhausted: Bool { !validKey || index == 0xFF }
+
+        /// The firmware calls this a real key but the name did not decode. Record it and KEEP WALKING.
+        ///
+        /// Safe because the walk was never bounded by this: `maxFlags` caps the replies and the announced
+        /// count bounds it further, so skipping can only spend budget that already exists. And it matters
+        /// most on the run that matters most — the first real capture is the expensive one to obtain, so
+        /// truncating it on our own strictness is the worst possible time to lose entries.
+        public var isSkippable: Bool { validKey && index != 0xFF && key == nil }
     }
 
     // MARK: - Parsing
@@ -244,6 +257,9 @@ public struct FeatureFlagProbeReport: Equatable, Sendable {
     public private(set) var reportedCount: Int?
     /// Result code of the START reply on 5/MG (nil on 4.0, or before it lands).
     public private(set) var startResult: Int?
+    /// Entries the strap flagged as real keys whose NAME did not decode, and which the walk stepped over
+    /// rather than stopping at. Surfaced in the report so a dump with holes never reads as a complete list.
+    public private(set) var skipped = 0
     /// Set once the walk stopped for a reason we can name.
     public private(set) var stopReason: String?
 
@@ -272,8 +288,14 @@ public struct FeatureFlagProbeReport: Equatable, Sendable {
         if r.isExhausted {
             stopReason = r.index == 0xFF
                 ? "cursor exhausted (index 0xFF)"
-                : (r.validKey ? "entry carried no decodable key name" : "firmware reported validKey=false")
+                : "firmware reported validKey=false"
             return false
+        }
+        if r.isSkippable {
+            // Our decode declined the name; the strap still says the entry is real and may have more after
+            // it. Count it so a partial dump describes itself instead of looking complete.
+            skipped += 1
+            trace[trace.count - 1] += "  (name did not decode — skipped, walk continues)"
         }
         if let k = r.key, !keys.contains(k) { keys.append(k) }
         // Bound the walk on REPLIES, not on distinct keys: a firmware whose cursor never advances would
@@ -318,6 +340,7 @@ public struct FeatureFlagProbeReport: Equatable, Sendable {
         if let stopReason { sb += "Stopped: \(stopReason)\n" }
         sb += "\nFlags reported by the strap (\(keys.count)"
         if let reportedCount { sb += " of \(reportedCount) announced" }
+        if skipped > 0 { sb += ", \(skipped) name(s) did not decode and were skipped" }
         sb += "):\n"
         if keys.isEmpty {
             sb += "  (none)\n"

--- a/Packages/WhoopProtocol/Sources/WhoopProtocol/FeatureFlagProbe.swift
+++ b/Packages/WhoopProtocol/Sources/WhoopProtocol/FeatureFlagProbe.swift
@@ -374,8 +374,20 @@ public struct FeatureFlagProbeReport: Equatable, Sendable {
         if keys.isEmpty && reportedCount == nil {
             return "no usable reply — the enumerate path is unconfirmed on this firmware"
         }
+        // "named none" would blame the strap for OUR decode. If entries were skipped the strap did name
+        // them and this parser rejected the names, which is the opposite conclusion and the one a reader
+        // would carry into #103. Same class as `isSkippable`: never report our limitation as the strap's
+        // behaviour.
+        if keys.isEmpty && skipped > 0 {
+            return "strap named \(skipped) flag(s), none of which decoded as printable ASCII within "
+                + "\(FeatureFlagProbe.maxKeyLength) chars — this is our parser rejecting them, NOT the "
+                + "strap serving blanks; see the trace for the raw replies"
+        }
         if keys.isEmpty {
             return "strap announced \(reportedCount ?? 0) flag(s) but named none"
+        }
+        if skipped > 0 {
+            return "enumerated \(keys.count) feature-flag key name(s); \(skipped) further name(s) did not decode"
         }
         return "enumerated \(keys.count) feature-flag key name(s)"
     }

--- a/Packages/WhoopProtocol/Tests/WhoopProtocolTests/FeatureFlagProbeTests.swift
+++ b/Packages/WhoopProtocol/Tests/WhoopProtocolTests/FeatureFlagProbeTests.swift
@@ -166,8 +166,52 @@ final class FeatureFlagProbeTests: XCTestCase {
         guard case .success(let r) = FeatureFlagProbe.parseNext(frame: frame, family: .whoop4) else {
             return XCTFail("expected a decoded NEXT response")
         }
-        XCTAssertNil(r.key)
-        XCTAssertTrue(r.isExhausted, "no decodable name ends the walk rather than inventing one")
+        XCTAssertNil(r.key, "a non-printable run is never invented into a name")
+        // Our decode declining a name is NOT the strap saying stop: the firmware still flagged this entry
+        // valid, so the walk steps over it instead of throwing away everything after it.
+        XCTAssertFalse(r.isExhausted)
+        XCTAssertTrue(r.isSkippable)
+    }
+
+    /// The regression this split exists for: one undecodable entry used to end the enumeration, so a list
+    /// with a bad byte in the middle reported only the keys BEFORE it. The first real capture is the
+    /// expensive one to obtain, and it is exactly the run that must not be truncated by our own strictness.
+    func testAnUndecodableEntryDoesNotHideTheKeysAfterIt() {
+        var report = FeatureFlagProbeReport(family: .whoop4)
+        report.noteStart(FeatureFlagProbe.StartResponse(resultCode: 1, revision: 1, count: 4))
+
+        func next(_ index: Int, _ key: String?) -> FeatureFlagProbe.NextResponse {
+            FeatureFlagProbe.NextResponse(resultCode: 1, revision: 1, index: index, validKey: true, key: key)
+        }
+        XCTAssertTrue(report.noteNext(next(0, "enable_r22_packets")))
+        XCTAssertTrue(report.noteNext(next(1, nil)), "a bad name must not stop the walk")
+        XCTAssertTrue(report.noteNext(next(2, "sigproc_wear_detect")))
+        XCTAssertFalse(report.noteNext(
+            FeatureFlagProbe.NextResponse(resultCode: 1, revision: 1, index: 0xFF,
+                                          validKey: false, key: nil)))
+
+        XCTAssertEqual(report.keys, ["enable_r22_packets", "sigproc_wear_detect"],
+                       "the key after the undecodable entry is collected, not lost")
+        XCTAssertEqual(report.skipped, 1)
+        XCTAssertEqual(report.stopReason, "cursor exhausted (index 0xFF)")
+        XCTAssertTrue(report.render().contains("1 name(s) did not decode and were skipped"),
+                      "a dump with holes must describe itself rather than look complete")
+    }
+
+    /// The skip cannot become an unbounded walk: `maxFlags` still terminates a firmware that answers
+    /// forever with entries whose names never decode.
+    func testEveryReplyUndecodableStillStopsAtTheSafetyCap() {
+        var report = FeatureFlagProbeReport(family: .whoop4)
+        var sent = 0
+        while report.noteNext(FeatureFlagProbe.NextResponse(resultCode: 1, revision: 1, index: 0,
+                                                            validKey: true, key: nil)) {
+            sent += 1
+            XCTAssertLessThan(sent, FeatureFlagProbe.maxFlags + 2, "walk must not run away")
+        }
+        XCTAssertEqual(report.steps, FeatureFlagProbe.maxFlags)
+        XCTAssertEqual(report.skipped, FeatureFlagProbe.maxFlags)
+        XCTAssertEqual(report.stopReason, "safety cap of \(FeatureFlagProbe.maxFlags) replies reached")
+        XCTAssertTrue(report.keys.isEmpty)
     }
 
     func testKeyLongerThanTheSetSideFieldIsRejected() {

--- a/Packages/WhoopProtocol/Tests/WhoopProtocolTests/FeatureFlagProbeTests.swift
+++ b/Packages/WhoopProtocol/Tests/WhoopProtocolTests/FeatureFlagProbeTests.swift
@@ -198,6 +198,32 @@ final class FeatureFlagProbeTests: XCTestCase {
                       "a dump with holes must describe itself rather than look complete")
     }
 
+    /// `validKey = 0` is trusted as an end marker, but the other reading — an EMPTY SLOT with the list
+    /// continuing past it — is not ruled out by anything observed so far. Stopping well short of the
+    /// announced count is the evidence that would settle it, so the report has to say so loudly rather
+    /// than reporting a confident short list.
+    func testStoppingOnValidKeyFalseShortOfTheAnnouncedCountIsFlagged() {
+        var report = FeatureFlagProbeReport(family: .whoop4)
+        report.noteStart(FeatureFlagProbe.StartResponse(resultCode: 1, revision: 1, count: 40))
+        XCTAssertTrue(report.noteNext(FeatureFlagProbe.NextResponse(
+            resultCode: 1, revision: 1, index: 0, validKey: true, key: "enable_r22_packets")))
+        XCTAssertFalse(report.noteNext(FeatureFlagProbe.NextResponse(
+            resultCode: 1, revision: 1, index: 1, validKey: false, key: nil)))
+
+        let why = try! XCTUnwrap(report.stopReason)
+        XCTAssertTrue(why.contains("2 of 40 announced entries"), why)
+        XCTAssertTrue(why.contains("the remainder was NOT walked"), why)
+    }
+
+    /// …and when the count was fully walked, the plain reason stands — no false alarm.
+    func testValidKeyFalseAtTheAnnouncedEndIsNotFlagged() {
+        var report = FeatureFlagProbeReport(family: .whoop4)
+        report.noteStart(FeatureFlagProbe.StartResponse(resultCode: 1, revision: 1, count: 1))
+        XCTAssertFalse(report.noteNext(FeatureFlagProbe.NextResponse(
+            resultCode: 1, revision: 1, index: 0, validKey: false, key: nil)))
+        XCTAssertEqual(report.stopReason, "firmware reported validKey=false")
+    }
+
     /// The skip cannot become an unbounded walk: `maxFlags` still terminates a firmware that answers
     /// forever with entries whose names never decode.
     func testEveryReplyUndecodableStillStopsAtTheSafetyCap() {

--- a/Packages/WhoopProtocol/Tests/WhoopProtocolTests/FeatureFlagProbeTests.swift
+++ b/Packages/WhoopProtocol/Tests/WhoopProtocolTests/FeatureFlagProbeTests.swift
@@ -224,6 +224,36 @@ final class FeatureFlagProbeTests: XCTestCase {
         XCTAssertEqual(report.stopReason, "firmware reported validKey=false")
     }
 
+    /// The verdict must never blame the strap for our own decode. A firmware whose names all fail our
+    /// printable-ASCII/length filter DID name them; reporting "named none" points at the strap and is the
+    /// sentence someone would paste into #103.
+    func testVerdictBlamesOurParserNotTheStrapWhenEveryNameFails() {
+        var report = FeatureFlagProbeReport(family: .whoop4)
+        report.noteStart(FeatureFlagProbe.StartResponse(resultCode: 1, revision: 1, count: 3))
+        for i in 0..<3 {
+            _ = report.noteNext(FeatureFlagProbe.NextResponse(
+                resultCode: 1, revision: 1, index: i, validKey: true, key: nil))
+        }
+        XCTAssertTrue(report.keys.isEmpty)
+        XCTAssertEqual(report.skipped, 3)
+        let v = report.verdict
+        XCTAssertTrue(v.contains("strap named 3 flag(s)"), v)
+        XCTAssertTrue(v.contains("our parser rejecting them"), v)
+        XCTAssertFalse(v.contains("named none"), "must not report our limitation as the strap's behaviour")
+    }
+
+    /// A partial success says so in the headline too, not only in the flag-count line.
+    func testVerdictReportsSkippedAlongsideTheKeysItDidGet() {
+        var report = FeatureFlagProbeReport(family: .whoop4)
+        report.noteStart(FeatureFlagProbe.StartResponse(resultCode: 1, revision: 1, count: 3))
+        _ = report.noteNext(FeatureFlagProbe.NextResponse(
+            resultCode: 1, revision: 1, index: 0, validKey: true, key: "enable_r22_packets"))
+        _ = report.noteNext(FeatureFlagProbe.NextResponse(
+            resultCode: 1, revision: 1, index: 1, validKey: true, key: nil))
+        XCTAssertEqual(report.verdict,
+                       "enumerated 1 feature-flag key name(s); 1 further name(s) did not decode")
+    }
+
     /// The skip cannot become an unbounded walk: `maxFlags` still terminates a firmware that answers
     /// forever with entries whose names never decode.
     func testEveryReplyUndecodableStillStopsAtTheSafetyCap() {

--- a/android/app/src/main/java/com/noop/protocol/FeatureFlagProbe.kt
+++ b/android/app/src/main/java/com/noop/protocol/FeatureFlagProbe.kt
@@ -87,8 +87,27 @@ object FeatureFlagProbe {
         val validKey: Boolean,
         val key: String?,
     ) {
-        /** The firmware said invalid, returned the 0xFF end marker, or carried no decodable name. */
-        val isExhausted: Boolean get() = !validKey || index == 0xFF || key == null
+        /**
+         * The STRAP said stop: it returned the 0xFF end marker, or flagged the entry as not a real key.
+         * Both are the firmware's own signal, so both are trusted.
+         *
+         * Deliberately does NOT include `key == null`. That is OUR parser declining a name — a byte
+         * outside printable ASCII, or one longer than [MAX_KEY_LENGTH] — and it says nothing about
+         * whether the strap has more entries. Treating it as a terminator meant one undecodable name
+         * threw away every entry after it: a list of forty with a bad byte at seven yielded six keys.
+         * See [isSkippable].
+         */
+        val isExhausted: Boolean get() = !validKey || index == 0xFF
+
+        /**
+         * The firmware calls this a real key but the name did not decode. Record it and KEEP WALKING.
+         *
+         * Safe because the walk was never bounded by this: [MAX_FLAGS] caps the replies and the announced
+         * count bounds it further, so skipping can only spend budget that already exists. And it matters
+         * most on the run that matters most — the first real capture is the expensive one to obtain, so
+         * truncating it on our own strictness is the worst possible time to lose entries.
+         */
+        val isSkippable: Boolean get() = validKey && index != 0xFF && key == null
     }
 
     /** One decode outcome: exactly one of [value] / [failure] is non-null. */
@@ -195,6 +214,13 @@ class FeatureFlagProbeReport(private val family: DeviceFamily) {
     var startResult: Int? = null
         private set
 
+    /**
+     * Entries the strap flagged as real keys whose NAME did not decode, and which the walk stepped over
+     * rather than stopping at. Surfaced in the report so a dump with holes never reads as a complete list.
+     */
+    var skipped: Int = 0
+        private set
+
     /** Set once the walk stopped for a reason we can name. */
     var stopReason: String? = null
         private set
@@ -220,12 +246,16 @@ class FeatureFlagProbeReport(private val family: DeviceFamily) {
         r.resultCode?.let { line += " result=${FeatureFlagProbe.resultLabel(it)}($it)" }
         _trace.add(line)
         if (r.isExhausted) {
-            stopReason = when {
-                r.index == 0xFF -> "cursor exhausted (index 0xFF)"
-                r.validKey -> "entry carried no decodable key name"
-                else -> "firmware reported validKey=false"
-            }
+            stopReason = if (r.index == 0xFF) "cursor exhausted (index 0xFF)"
+            else "firmware reported validKey=false"
             return false
+        }
+        if (r.isSkippable) {
+            // Our decode declined the name; the strap still says the entry is real and may have more after
+            // it. Count it so a partial dump describes itself instead of looking complete.
+            skipped += 1
+            _trace[_trace.size - 1] = _trace[_trace.size - 1] +
+                "  (name did not decode — skipped, walk continues)"
         }
         r.key?.let { if (!_keys.contains(it)) _keys.add(it) }
         // Bound the walk on REPLIES, not on distinct keys: a firmware whose cursor never advances would
@@ -284,6 +314,7 @@ class FeatureFlagProbeReport(private val family: DeviceFamily) {
         stopReason?.let { sb.append("Stopped: $it\n") }
         sb.append("\nFlags reported by the strap (${_keys.size}")
         reportedCount?.let { sb.append(" of $it announced") }
+        if (skipped > 0) sb.append(", $skipped name(s) did not decode and were skipped")
         sb.append("):\n")
         if (_keys.isEmpty()) {
             sb.append("  (none)\n")

--- a/android/app/src/main/java/com/noop/protocol/FeatureFlagProbe.kt
+++ b/android/app/src/main/java/com/noop/protocol/FeatureFlagProbe.kt
@@ -246,8 +246,24 @@ class FeatureFlagProbeReport(private val family: DeviceFamily) {
         r.resultCode?.let { line += " result=${FeatureFlagProbe.resultLabel(it)}($it)" }
         _trace.add(line)
         if (r.isExhausted) {
-            stopReason = if (r.index == 0xFF) "cursor exhausted (index 0xFF)"
-            else "firmware reported validKey=false"
+            if (r.index == 0xFF) {
+                stopReason = "cursor exhausted (index 0xFF)"
+            } else {
+                // `validKey = 0` is documented as an end marker alongside 0xFF, and it is the firmware's
+                // own flag, so it is trusted here. But nothing observed so far rules out the other
+                // reading — that it marks an EMPTY SLOT and the list continues past it. If so this stops
+                // on the first hole, which is the same truncation [isSkippable] exists to prevent, one
+                // condition over. It cannot be settled without a strap, so instead of guessing we make
+                // the discrepancy loud: stopping here well short of the announced count is exactly the
+                // evidence that would settle it.
+                stopReason = "firmware reported validKey=false"
+                val count = reportedCount
+                if (count != null && count > steps) {
+                    stopReason = "firmware reported validKey=false at index ${r.index} after $steps of " +
+                        "$count announced entries — if validKey=0 marks an empty slot rather than the " +
+                        "end of the list, the remainder was NOT walked (see #872 review)"
+                }
+            }
             return false
         }
         if (r.isSkippable) {

--- a/android/app/src/main/java/com/noop/protocol/FeatureFlagProbe.kt
+++ b/android/app/src/main/java/com/noop/protocol/FeatureFlagProbe.kt
@@ -315,7 +315,19 @@ class FeatureFlagProbeReport(private val family: DeviceFamily) {
             if (_keys.isEmpty() && reportedCount == null) {
                 return "no usable reply — the enumerate path is unconfirmed on this firmware"
             }
+            // "named none" would blame the strap for OUR decode. If entries were skipped the strap did
+            // name them and this parser rejected the names, which is the opposite conclusion and the one
+            // a reader would carry into #103. Same class as [FeatureFlagProbe.NextResponse.isSkippable]:
+            // never report our limitation as the strap's behaviour.
+            if (_keys.isEmpty() && skipped > 0) {
+                return "strap named $skipped flag(s), none of which decoded as printable ASCII within " +
+                    "${FeatureFlagProbe.MAX_KEY_LENGTH} chars — this is our parser rejecting them, NOT " +
+                    "the strap serving blanks; see the trace for the raw replies"
+            }
             if (_keys.isEmpty()) return "strap announced ${reportedCount ?: 0} flag(s) but named none"
+            if (skipped > 0) {
+                return "enumerated ${_keys.size} feature-flag key name(s); $skipped further name(s) did not decode"
+            }
             return "enumerated ${_keys.size} feature-flag key name(s)"
         }
 

--- a/android/app/src/test/java/com/noop/protocol/FeatureFlagProbeTest.kt
+++ b/android/app/src/test/java/com/noop/protocol/FeatureFlagProbeTest.kt
@@ -170,6 +170,31 @@ class FeatureFlagProbeTest {
     }
 
     /**
+     * `validKey = 0` is trusted as an end marker, but the other reading — an EMPTY SLOT with the list
+     * continuing past it — is not ruled out by anything observed so far. Stopping well short of the
+     * announced count is the evidence that would settle it, so the report has to say so loudly rather
+     * than reporting a confident short list.
+     */
+    @Test fun stoppingOnValidKeyFalseShortOfTheAnnouncedCountIsFlagged() {
+        val report = FeatureFlagProbeReport(DeviceFamily.WHOOP4)
+        report.noteStart(FeatureFlagProbe.StartResponse(1, 1, 40))
+        assertTrue(report.noteNext(FeatureFlagProbe.NextResponse(1, 1, 0, true, "enable_r22_packets")))
+        assertFalse(report.noteNext(FeatureFlagProbe.NextResponse(1, 1, 1, false, null)))
+
+        val why = report.stopReason!!
+        assertTrue(why, why.contains("2 of 40 announced entries"))
+        assertTrue(why, why.contains("the remainder was NOT walked"))
+    }
+
+    /** …and when the count was fully walked, the plain reason stands — no false alarm. */
+    @Test fun validKeyFalseAtTheAnnouncedEndIsNotFlagged() {
+        val report = FeatureFlagProbeReport(DeviceFamily.WHOOP4)
+        report.noteStart(FeatureFlagProbe.StartResponse(1, 1, 1))
+        assertFalse(report.noteNext(FeatureFlagProbe.NextResponse(1, 1, 0, false, null)))
+        assertEquals("firmware reported validKey=false", report.stopReason)
+    }
+
+    /**
      * The skip cannot become an unbounded walk: [FeatureFlagProbe.MAX_FLAGS] still terminates a firmware
      * that answers forever with entries whose names never decode.
      */

--- a/android/app/src/test/java/com/noop/protocol/FeatureFlagProbeTest.kt
+++ b/android/app/src/test/java/com/noop/protocol/FeatureFlagProbeTest.kt
@@ -142,7 +142,48 @@ class FeatureFlagProbeTest {
         val frame = whoop4Response(118, payload(1, record))
         val r = FeatureFlagProbe.parseNext(frame, DeviceFamily.WHOOP4).value!!
         assertNull(r.key)
-        assertTrue(r.isExhausted)
+        // Our decode declining a name is NOT the strap saying stop: the firmware still flagged this entry
+        // valid, so the walk steps over it instead of throwing away everything after it.
+        assertFalse(r.isExhausted)
+        assertTrue(r.isSkippable)
+    }
+
+    /**
+     * The regression this split exists for: one undecodable entry used to end the enumeration, so a list
+     * with a bad byte in the middle reported only the keys BEFORE it. The first real capture is the
+     * expensive one to obtain, and it is exactly the run that must not be truncated by our own strictness.
+     */
+    @Test fun anUndecodableEntryDoesNotHideTheKeysAfterIt() {
+        val report = FeatureFlagProbeReport(DeviceFamily.WHOOP4)
+        report.noteStart(FeatureFlagProbe.StartResponse(1, 1, 4))
+        fun next(index: Int, key: String?) = FeatureFlagProbe.NextResponse(1, 1, index, true, key)
+
+        assertTrue(report.noteNext(next(0, "enable_r22_packets")))
+        assertTrue("a bad name must not stop the walk", report.noteNext(next(1, null)))
+        assertTrue(report.noteNext(next(2, "sigproc_wear_detect")))
+        assertFalse(report.noteNext(FeatureFlagProbe.NextResponse(1, 1, 0xFF, false, null)))
+
+        assertEquals(listOf("enable_r22_packets", "sigproc_wear_detect"), report.keys)
+        assertEquals(1, report.skipped)
+        assertEquals("cursor exhausted (index 0xFF)", report.stopReason)
+        assertTrue(report.render().contains("1 name(s) did not decode and were skipped"))
+    }
+
+    /**
+     * The skip cannot become an unbounded walk: [FeatureFlagProbe.MAX_FLAGS] still terminates a firmware
+     * that answers forever with entries whose names never decode.
+     */
+    @Test fun everyReplyUndecodableStillStopsAtTheSafetyCap() {
+        val report = FeatureFlagProbeReport(DeviceFamily.WHOOP4)
+        var sent = 0
+        while (report.noteNext(FeatureFlagProbe.NextResponse(1, 1, 0, true, null))) {
+            sent += 1
+            assertTrue("walk must not run away", sent < FeatureFlagProbe.MAX_FLAGS + 2)
+        }
+        assertEquals(FeatureFlagProbe.MAX_FLAGS, report.steps)
+        assertEquals(FeatureFlagProbe.MAX_FLAGS, report.skipped)
+        assertEquals("safety cap of ${FeatureFlagProbe.MAX_FLAGS} replies reached", report.stopReason)
+        assertTrue(report.keys.isEmpty())
     }
 
     @Test fun keyLongerThanTheSetSideFieldIsRejected() {

--- a/android/app/src/test/java/com/noop/protocol/FeatureFlagProbeTest.kt
+++ b/android/app/src/test/java/com/noop/protocol/FeatureFlagProbeTest.kt
@@ -195,6 +195,37 @@ class FeatureFlagProbeTest {
     }
 
     /**
+     * The verdict must never blame the strap for our own decode. A firmware whose names all fail our
+     * printable-ASCII/length filter DID name them; reporting "named none" points at the strap and is the
+     * sentence someone would paste into #103.
+     */
+    @Test fun verdictBlamesOurParserNotTheStrapWhenEveryNameFails() {
+        val report = FeatureFlagProbeReport(DeviceFamily.WHOOP4)
+        report.noteStart(FeatureFlagProbe.StartResponse(1, 1, 3))
+        for (i in 0 until 3) {
+            report.noteNext(FeatureFlagProbe.NextResponse(1, 1, i, true, null))
+        }
+        assertTrue(report.keys.isEmpty())
+        assertEquals(3, report.skipped)
+        val v = report.verdict
+        assertTrue(v, v.contains("strap named 3 flag(s)"))
+        assertTrue(v, v.contains("our parser rejecting them"))
+        assertFalse("must not report our limitation as the strap's behaviour", v.contains("named none"))
+    }
+
+    /** A partial success says so in the headline too, not only in the flag-count line. */
+    @Test fun verdictReportsSkippedAlongsideTheKeysItDidGet() {
+        val report = FeatureFlagProbeReport(DeviceFamily.WHOOP4)
+        report.noteStart(FeatureFlagProbe.StartResponse(1, 1, 3))
+        report.noteNext(FeatureFlagProbe.NextResponse(1, 1, 0, true, "enable_r22_packets"))
+        report.noteNext(FeatureFlagProbe.NextResponse(1, 1, 1, true, null))
+        assertEquals(
+            "enumerated 1 feature-flag key name(s); 1 further name(s) did not decode",
+            report.verdict,
+        )
+    }
+
+    /**
      * The skip cannot become an unbounded walk: [FeatureFlagProbe.MAX_FLAGS] still terminates a firmware
      * that answers forever with entries whose names never decode.
      */


### PR DESCRIPTION
Follow-up to #872.

`isExhausted` conflated three different things:

```swift
!validKey || index == 0xFF || key == nil
```

The first two are the **firmware** saying stop — its 0xFF end marker and its own not-a-real-key flag.
The third is **our parser** declining a name: a byte outside printable ASCII, or one longer than
`maxKeyLength`. That says nothing about whether the strap has more entries, and treating it as a
terminator meant one undecodable name threw away every entry after it.

Simulated on a four-entry list with a bad name at index 1:

```
old:  keys=['enable_r22_packets']                              <- lost the one after it
new:  keys=['enable_r22_packets', 'sigproc_wear_detect']  skipped=1
```

### The change

Split into `isExhausted` (the strap said stop) and `isSkippable` (we could not read this one). A
skippable entry is counted and stepped over; the walk continues.

**Safety is unchanged, because the walk was never bounded by this.** `maxFlags` caps the replies and
the announced count bounds it further, so skipping can only spend budget that already existed. Pinned
by a test that answers with nothing *but* undecodable entries and asserts the walk still stops at the
cap having collected no keys.

The report gains `skipped` and renders `N name(s) did not decode and were skipped` beside the
announced count, so a dump with holes describes itself rather than reading as complete.

### Why now, having said in review it should wait for hardware

That was backwards, and it is worth saying so plainly. The first capture is the expensive artefact —
it needs an owner to enable Test Centre, run the probe and paste the result. It is exactly the run
that must not be truncated by our own strictness. Fixing after the first dump means asking someone to
do it twice.

### Tests

Two new each side: a bad entry mid-list not hiding the key after it, and an all-undecodable firmware
still stopping at the cap. The existing non-printable-name tests now assert `isSkippable` rather than
`isExhausted` — the behaviour change stated in test form.

Pure `WhoopProtocol`, so `test (WhoopProtocol)` actually executes the Swift half. The Kotlin twin is
compiled by nothing as usual; render strings and constructor signatures were checked against the
declarations by hand.
