### PR TITLE
Score an Oura night by feeding the ring's own hypnogram into the scorer (#804 Fix A)

### DIFF
--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/AnalyticsEngine.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/AnalyticsEngine.swift
@@ -212,6 +212,37 @@ public enum AnalyticsEngine {
         return String(data: data, encoding: .utf8)
     }
 
+    /// Inverse of `encodeStages`: decode a stored `stagesJSON` back to `[StageSegment]`. Only the on-device
+    /// SEGMENT-ARRAY shape (`[{start,end,stage}]`) decodes; the imported minute-dict shape
+    /// (`{light,deep,rem,awake}`) is not a segment timeline and yields `[]` (key-order-independent). (#804)
+    public static func decodeStages(_ json: String?) -> [StageSegment] {
+        guard let json, let data = json.data(using: .utf8),
+              let stages = try? JSONDecoder().decode([StageSegment].self, from: data) else { return [] }
+        return stages
+    }
+
+    /// Reconstruct the pure `SleepSession` the analyzer stages from a persisted, device-PROVIDED
+    /// `CachedSleepSession` — e.g. an Oura ring's own SleepNet hypnogram (#773), whose `stagesJSON` uses the
+    /// same `deep/light/rem/wake` vocabulary `hypnogramMetrics` reads. Uses the effective (edit-aware) onset,
+    /// preserves the stored efficiency (deriving it from the decoded stage minutes only when the row stored
+    /// none), and passes `restingHR`/`avgHRV` through as stored — nil for a ring night, which `analyzeDay`
+    /// then re-derives from that day's hr/rr over this window. Returns nil when the row has no decodable
+    /// stage timeline, so a non-hypnogram (minute-dict) row is never injected. (#804 Fix A)
+    public static func sleepSession(fromProvided c: CachedSleepSession) -> SleepSession? {
+        let stages = decodeStages(c.stagesJSON)
+        guard !stages.isEmpty else { return nil }
+        let efficiency: Double
+        if let e = c.efficiency {
+            efficiency = e
+        } else if let m = SleepStageTotals.minutes(fromStagesJSON: c.stagesJSON), m.inBed > 0 {
+            efficiency = m.asleep / m.inBed
+        } else {
+            efficiency = 0
+        }
+        return SleepSession(start: c.effectiveStartTs, end: c.endTs, efficiency: efficiency,
+                            stages: stages, restingHR: c.restingHr, avgHRV: c.avgHrv)
+    }
+
     /// Analyze one day's streams into a `DayResult`.
     ///
     /// - Parameters:
@@ -336,6 +367,22 @@ public enum AnalyticsEngine {
                                   // caller/test byte-identical; IntelligenceEngine threads
                                   // `PuffinExperiment.motionAwareWakeEnabled`.
                                   useMotionAwareWake: Bool = false,
+                                  // Caller-supplied, already-staged sleep sessions to fold in ALONGSIDE the
+                                  // motion detector's — the day owner's OWN device-provided hypnogram (an
+                                  // Oura ring's SleepNet night, #773), reconstructed from its persisted
+                                  // `CachedSleepSession` via `sleepSession(fromProvided:)`. This is the fix
+                                  // for #804: a ring sends no gravity vector, so `detectSleep` stages nothing
+                                  // and the night scored blank (totalSleepMin/eff/avgHrv nil) even though the
+                                  // ring's hypnogram was persisted and shown on the timeline. Provided
+                                  // sessions are PRE-staged: they bypass detectSleep AND wake refinement.
+                                  // Where a provided session overlaps a detected one the PROVIDED session
+                                  // wins (authoritative device staging over motion inference); non-overlapping
+                                  // detected sessions (a nap the ring didn't report) are kept. Each provided
+                                  // session's nightly restingHR/avgHRV is (re)derived HERE from this day's
+                                  // hr/rr over its window when the stored row carried none, so the daily
+                                  // RHR/HRV light up. Default `[]` (every WHOOP / pure-function caller) keeps
+                                  // the byte-identical motion-only path.
+                                  providedSleep: [SleepSession] = [],
                                   // Sleep PROVENANCE for the per-day sleep trace (CAPTURE-C / #799). The
                                   // measured BLE path is `.measured` (the default); the caller passes
                                   // `.imported(...)` when a previously-imported sleep row WON the daily merge,
@@ -383,9 +430,31 @@ public enum AnalyticsEngine {
         // night-window stream the caller passed for the rest of this analysis; the pass self-gates on its
         // observed density, so an empty/sparse `steps` (e.g. a WHOOP 4.0, which never emits StepSample at
         // all) is a no-op regardless of `useMotionAwareWake`.
-        let allSessions = useMotionAwareWake
+        let refinedSessions = useMotionAwareWake
             ? detectedSessions.map { WakeMotionRefinement.refine($0, grav: gravity, steps: steps) }
             : detectedSessions
+        // #804 Fix A: fold in the caller's device-provided hypnogram (see `providedSleep`). Empty = the
+        // byte-identical motion-only path. Otherwise enrich each provided session's nightly restingHR/avgHRV
+        // from THIS day's hr/rr over its window (the stored ring row carries neither), using the SAME helpers
+        // detectSleep populates a session with, then keep only the detected sessions that DON'T overlap a
+        // provided one (provided is authoritative where they collide; a separate nap survives).
+        let allSessions: [SleepSession]
+        if providedSleep.isEmpty {
+            allSessions = refinedSessions
+        } else {
+            let rrSorted = rr.sortedByTsStable()
+            let enrichedProvided: [SleepSession] = providedSleep.map { s in
+                guard s.restingHR == nil || s.avgHRV == nil else { return s }
+                let rhr = s.restingHR ?? SleepStager.sessionRestingHR(start: s.start, end: s.end, hr: hr)
+                let hrv = s.avgHRV ?? SleepStager.sessionAvgHRV(start: s.start, end: s.end, rr: rrSorted)
+                return SleepSession(start: s.start, end: s.end, efficiency: s.efficiency,
+                                    stages: s.stages, restingHR: rhr, avgHRV: hrv)
+            }
+            let keptDetected = refinedSessions.filter { d in
+                !enrichedProvided.contains { $0.start < d.end && d.start < $0.end }
+            }
+            allSessions = keptDetected + enrichedProvided
+        }
         // Sessions attributed to `day` = those whose end falls on `day` (LOCAL day, #277). `day` is
         // the caller's local-day key; attribute by the same offset so the bucket and the key agree.
         let matched = allSessions.filter { tsInDay($0.end) }

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/AnalyticsEngineProvidedSleepTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/AnalyticsEngineProvidedSleepTests.swift
@@ -1,0 +1,91 @@
+import XCTest
+@testable import StrandAnalytics
+import WhoopProtocol
+import WhoopStore
+
+/// #804 Fix A: a night the MOTION detector can't stage — an Oura ring sends NO gravity vector, so
+/// `detectSleep` returns nothing and the night scored blank — must still score when the caller hands
+/// `analyzeDay` the ring's OWN persisted hypnogram via `providedSleep`. And the byte-identical default
+/// path (empty `providedSleep`) must be unchanged.
+final class AnalyticsEngineProvidedSleepTests: XCTestCase {
+    private let profile = UserProfile(weightKg: 75, heightCm: 178, age: 30, sex: "male")
+
+    /// Build a night [start, end) of hr (30 s) + rr (2 s, varied so RMSSD is computable) with NO gravity.
+    private func nightStreams(start: Int, end: Int) -> (hr: [HRSample], rr: [RRInterval]) {
+        let hr = stride(from: start, to: end, by: 30).map { HRSample(ts: $0, bpm: 52 + ($0 / 300) % 4) }
+        // rrMs cycles 1080…1120 so successive differences are non-zero → a real (non-nil) RMSSD.
+        var i = 0
+        let rr = stride(from: start, to: end, by: 2).map { ts -> RRInterval in
+            defer { i += 1 }
+            return RRInterval(ts: ts, rrMs: 1080 + (i % 6) * 8)
+        }
+        return (hr, rr)
+    }
+
+    /// A contiguous deep/light/rem/wake hypnogram spanning [start, end), the shape #773 persists.
+    private func hypnogram(start: Int) -> [StageSegment] {
+        var t = start
+        func seg(_ mins: Int, _ stage: String) -> StageSegment {
+            let s = StageSegment(start: t, end: t + mins * 60, stage: stage); t += mins * 60; return s
+        }
+        return [
+            seg(20, "wake"), seg(100, "light"), seg(60, "deep"), seg(60, "light"),
+            seg(60, "rem"), seg(120, "light"), seg(60, "deep"), seg(60, "rem"),
+            seg(40, "light"), seg(20, "wake"),
+        ]   // 600 min in bed; deep 120, rem 120, light 320, wake 40
+    }
+
+    func testProvidedHypnogramScoresANightWithoutGravity() {
+        let day = "2026-07-27"
+        let dayStart = AnalyticsEngine.dayStartUtcSeconds(day)
+        let sleepStart = dayStart - 4 * 3600          // 20:00 the previous evening
+        let sleepEnd = sleepStart + 600 * 60          // +10 h → 06:00, ends on `day`
+        let s = nightStreams(start: sleepStart, end: sleepEnd)
+        let provided = [SleepSession(start: sleepStart, end: sleepEnd, efficiency: 0.75,
+                                     stages: hypnogram(start: sleepStart), restingHR: nil, avgHRV: nil)]
+
+        let res = AnalyticsEngine.analyzeDay(day: day, hr: s.hr, rr: s.rr, profile: profile,
+                                             providedSleep: provided)
+
+        XCTAssertNotNil(res.daily.totalSleepMin, "the provided hypnogram must score the night")
+        XCTAssertEqual(res.daily.totalSleepMin ?? 0, 560, accuracy: 1)   // light 320 + deep 120 + rem 120
+        XCTAssertEqual(res.daily.deepMin ?? 0, 120, accuracy: 1)
+        XCTAssertEqual(res.daily.remMin ?? 0, 120, accuracy: 1)
+        XCTAssertEqual(res.daily.efficiency ?? 0, 0.75, accuracy: 0.001)
+        XCTAssertFalse(res.cachedSleep.isEmpty)
+        // HRV & resting HR are re-derived from THIS day's rr/hr over the provided window (the ring row
+        // carried neither) — the whole point of #804 (avgHrv was nil despite 36 k rr present).
+        XCTAssertNotNil(res.daily.avgHrv, "avgHrv must be derived from rr over the provided sleep window")
+        XCTAssertNotNil(res.daily.restingHr)
+    }
+
+    func testEmptyProvidedSleepIsByteIdenticalToOmitting() {
+        let day = "2026-07-27"
+        let dayStart = AnalyticsEngine.dayStartUtcSeconds(day)
+        let s = nightStreams(start: dayStart - 4 * 3600, end: dayStart + 6 * 3600)
+
+        let omitted = AnalyticsEngine.analyzeDay(day: day, hr: s.hr, rr: s.rr, profile: profile)
+        let empty = AnalyticsEngine.analyzeDay(day: day, hr: s.hr, rr: s.rr, profile: profile,
+                                               providedSleep: [])
+        XCTAssertEqual(omitted.daily, empty.daily)
+        // No gravity + no provided hypnogram = the pre-fix #804 state: the night does not score.
+        XCTAssertNil(omitted.daily.totalSleepMin)
+        XCTAssertNil(omitted.daily.avgHrv)
+    }
+
+    func testProvidedSessionKeepsItsOwnStoredHrvWhenPresent() {
+        // A provided session that already carries restingHR/avgHRV is used verbatim (not recomputed).
+        let day = "2026-07-27"
+        let dayStart = AnalyticsEngine.dayStartUtcSeconds(day)
+        let sleepStart = dayStart - 4 * 3600
+        let sleepEnd = sleepStart + 600 * 60
+        let s = nightStreams(start: sleepStart, end: sleepEnd)
+        let provided = [SleepSession(start: sleepStart, end: sleepEnd, efficiency: 0.8,
+                                     stages: hypnogram(start: sleepStart), restingHR: 48, avgHRV: 65)]
+
+        let res = AnalyticsEngine.analyzeDay(day: day, hr: s.hr, rr: s.rr, profile: profile,
+                                             providedSleep: provided)
+        XCTAssertEqual(res.daily.restingHr, 48)
+        XCTAssertEqual(res.daily.avgHrv ?? 0, 65, accuracy: 0.001)
+    }
+}

--- a/Strand/Data/IntelligenceEngine.swift
+++ b/Strand/Data/IntelligenceEngine.swift
@@ -686,6 +686,23 @@ final class IntelligenceEngine: ObservableObject {
                 // HRV mode (#141): a per-day collector for the nightly per-window RMSSD + summary; nil = default.
                 var hrvTrace: [String] = []
                 let hrvTraceSink: ((String) -> Void)? = hrvTraceActive ? { hrvTrace.append($0) } : nil
+                // #804 Fix A: when this day's owner is a device that sends NO usable gravity vector — so the
+                // motion detector can't stage the night and it scored blank — AND it has persisted its OWN
+                // hypnogram under its device namespace (an Oura ring's SleepNet night, #773), hand that
+                // hypnogram to analyzeDay so the night scores. Gated on absent gravity (`grav.count < 2` — a
+                // ring streams zero; a WHOOP always streams a gravity vector, sparse-but-present on a 4.0) plus
+                // a non-canonical-WHOOP-import owner, so WHOOP straps and the "my-whoop" import namespace are
+                // untouched; analyzeDay still lets a DETECTED session win where the two overlap. Reconstruct the
+                // pure SleepSession from each stored CachedSleepSession (a minute-dict import row decodes to
+                // nothing and is skipped, so only real stage timelines are injected).
+                let providedSleep: [SleepSession]
+                if owner != Repository.whoopSource, grav.count < 2 {
+                    let persisted = (try? await store.sleepSessions(deviceId: owner, from: from, to: to,
+                                                                    limit: 4000)) ?? []
+                    providedSleep = persisted.compactMap { AnalyticsEngine.sleepSession(fromProvided: $0) }
+                } else {
+                    providedSleep = []
+                }
                 let res = AnalyticsEngine.analyzeDay(day: day, hr: hr, rr: rr, resp: resp, gravity: grav,
                                                      steps: steps, dayHr: dayHr, daySteps: daySteps,
                                                      dayGravity: dayGrav,
@@ -703,6 +720,9 @@ final class IntelligenceEngine: ObservableObject {
                                                      // #364 follow-up: same threading for the motion-aware wake
                                                      // refinement post-pass.
                                                      useMotionAwareWake: useMotionAwareWake,
+                                                     // #804 Fix A: the owner's own device-provided hypnogram
+                                                     // (empty for WHOOP / non-ring days → default path).
+                                                     providedSleep: providedSleep,
                                                      traceSink: traceSink,
                                                      hrvTraceSink: hrvTraceSink,
                                                      // Per-window HRV detail ONLY for the most-recent night

--- a/android/app/src/main/java/com/noop/analytics/AnalyticsEngine.kt
+++ b/android/app/src/main/java/com/noop/analytics/AnalyticsEngine.kt
@@ -129,6 +129,51 @@ object AnalyticsEngine {
     }
 
     /**
+     * Inverse of [encodeStages]: decode a stored `stagesJSON` back to a list of [StageSegment]. Only the
+     * on-device SEGMENT-ARRAY shape (`[{start,end,stage}]`) decodes; the imported minute-dict shape
+     * (`{light,deep,rem,awake}`) is not a segment timeline and yields an empty list. Mirrors Swift
+     * `AnalyticsEngine.decodeStages`. (#804)
+     */
+    fun decodeStages(json: String?): List<StageSegment> {
+        if (json == null) return emptyList()
+        return try {
+            val arr = org.json.JSONArray(json)
+            val out = ArrayList<StageSegment>(arr.length())
+            for (i in 0 until arr.length()) {
+                val o = arr.optJSONObject(i) ?: continue
+                if (!o.has("start") || !o.has("end")) continue
+                val stage = o.optString("stage", "")
+                if (stage.isEmpty()) continue
+                out.add(StageSegment(o.getLong("start"), o.getLong("end"), stage))
+            }
+            out
+        } catch (_: Throwable) {
+            emptyList()
+        }
+    }
+
+    /**
+     * Reconstruct the [DetectedSleep] the analyzer stages from a persisted, device-PROVIDED [SleepSession]
+     * row — e.g. an Oura ring's own SleepNet hypnogram (#773), whose `stagesJSON` uses the same
+     * deep/light/rem/wake vocabulary the stager reads. Uses the effective (edit-aware) onset, preserves the
+     * stored efficiency (deriving it from the decoded stage minutes only when the row stored none), and
+     * passes restingHr/avgHrv through as stored — null for a ring night, which [analyzeDay] then re-derives
+     * from that day's hr/rr. Returns null when the row has no decodable stage timeline, so a non-hypnogram
+     * (minute-dict) row is never injected. Mirrors Swift `sleepSession(fromProvided:)`. (#804 Fix A)
+     */
+    fun sleepSessionFromProvided(c: com.noop.data.SleepSession): DetectedSleep? {
+        val stages = decodeStages(c.stagesJSON)
+        if (stages.isEmpty()) return null
+        val efficiency = c.efficiency
+            ?: SleepStageTotals.minutes(c.stagesJSON)?.let { if (it.inBed > 0) it.asleep / it.inBed else null }
+            ?: 0.0
+        return DetectedSleep(
+            start = c.effectiveStartTs, end = c.endTs, efficiency = efficiency,
+            stages = stages, restingHR = c.restingHr, avgHRV = c.avgHrv,
+        )
+    }
+
+    /**
      * Analyze one day's streams into a [DayResult].
      *
      * @param day the calendar day (UTC) this metric is for; a sleep session is
@@ -231,6 +276,15 @@ object AnalyticsEngine {
         // flag. Default false keeps every pure-function caller/test byte-identical; IntelligenceEngine
         // threads PuffinExperiment.from(context).motionAwareWake. Mirrors Swift.
         useMotionAwareWake: Boolean = false,
+        // Caller-supplied, already-staged sessions to fold in ALONGSIDE the motion detector's — the day
+        // owner's OWN device-provided hypnogram (an Oura ring's SleepNet night, #773), reconstructed via
+        // [sleepSessionFromProvided]. The fix for #804: a ring sends no gravity vector, so detectSleep stages
+        // nothing and the night scored blank even though the ring's hypnogram was persisted + shown on the
+        // timeline. Provided sessions are PRE-staged: they bypass detectSleep AND wake refinement. Where a
+        // provided session overlaps a detected one the PROVIDED session wins; a non-overlapping detected nap
+        // survives. Each provided session's nightly restingHR/avgHRV is re-derived here from this day's hr/rr
+        // when the stored row carried none. Default empty (every WHOOP / pure caller) = motion-only path.
+        providedSleep: List<DetectedSleep> = emptyList(),
         // Sleep & Rest test-mode trace sink (E11). null = byte-identical default. When non-null the gate
         // trace from detectSleep and the Rest sub-score line are forwarded line-by-line. Mirrors Swift.
         traceSink: ((String) -> Unit)? = null,
@@ -261,10 +315,31 @@ object AnalyticsEngine {
         // night-window stream the caller passed for the rest of this analysis; the pass self-gates on its
         // observed density, so an empty/sparse `steps` (e.g. a WHOOP 4.0, which never emits a step sample
         // at all) is a no-op regardless of `useMotionAwareWake`.
-        val allSessions = if (useMotionAwareWake) {
+        val refinedSessions = if (useMotionAwareWake) {
             detectedSessions.map { WakeMotionRefinement.refine(it, gravity, steps) }
         } else {
             detectedSessions
+        }
+        // #804 Fix A: fold in the caller's device-provided hypnogram (see [providedSleep]). Empty = the
+        // byte-identical motion-only path. Otherwise enrich each provided session's nightly restingHR/avgHRV
+        // from THIS day's hr/rr over its window (the stored ring row carries neither), using the SAME helpers
+        // detectSleep populates a session with, then keep only the detected sessions that DON'T overlap a
+        // provided one (provided is authoritative where they collide; a separate nap survives).
+        val allSessions: List<DetectedSleep> = if (providedSleep.isEmpty()) {
+            refinedSessions
+        } else {
+            val rrSorted = rr.sortedBy { it.ts }
+            val enrichedProvided = providedSleep.map { s ->
+                if (s.restingHR != null && s.avgHRV != null) s
+                else s.copy(
+                    restingHR = s.restingHR ?: SleepStager.sessionRestingHR(s.start, s.end, hr),
+                    avgHRV = s.avgHRV ?: SleepStager.sessionAvgHRV(s.start, s.end, rrSorted),
+                )
+            }
+            val keptDetected = refinedSessions.filter { d ->
+                enrichedProvided.none { it.start < d.end && d.start < it.end }
+            }
+            keptDetected + enrichedProvided
         }
         // Sessions attributed to `day` = those whose end falls on `day` (LOCAL day, #277). `day` is
         // the caller's local-day key; attribute by the same offset so the bucket and the key agree.

--- a/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
+++ b/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
@@ -554,6 +554,20 @@ object IntelligenceEngine {
                 bandSleepState = bandSleepStateSamples(repo, computedId, from, to)
             }
 
+            // #804 Fix A: when this day's owner sends NO usable gravity vector — so the motion detector can't
+            // stage the night and it scored blank — AND it persisted its OWN hypnogram under its device
+            // namespace (an Oura ring's SleepNet night, #773), hand that hypnogram to analyzeDay so the night
+            // scores. Gated on absent gravity (`grav.size < 2` — a ring streams zero; a WHOOP always streams a
+            // gravity vector) plus a non-canonical-WHOOP-import owner, so WHOOP straps and the "my-whoop"
+            // import namespace are untouched; analyzeDay still lets a DETECTED session win where they overlap.
+            val providedSleep: List<DetectedSleep> =
+                if (owner != importedDeviceId && grav.size < 2) {
+                    repo.sleepSessions(owner, from, to, 4000)
+                        .mapNotNull { AnalyticsEngine.sleepSessionFromProvided(it) }
+                } else {
+                    emptyList()
+                }
+
             val res = AnalyticsEngine.analyzeDay(
                 day = day,
                 hr = hr,
@@ -585,6 +599,8 @@ object IntelligenceEngine {
                 useSleepStagerV2 = useExperimentalSleepV2,
                 // #364 follow-up: same threading for the motion-aware wake refinement post-pass.
                 useMotionAwareWake = useMotionAwareWake,
+                // #804 Fix A: the owner's own device-provided hypnogram (empty for WHOOP/non-ring days).
+                providedSleep = providedSleep,
                 // Sleep & Rest test mode (Test Centre E5): thread the trace sink straight through. null (the
                 // default) keeps analyzeDay's byte-identical untraced path; when the caller passed a non-null
                 // sink (mode on), detectSleep's gate trace + the Rest sub-score line route to the .sleep-tagged

--- a/android/app/src/test/java/com/noop/analytics/AnalyticsEngineProvidedSleepTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/AnalyticsEngineProvidedSleepTest.kt
@@ -1,0 +1,94 @@
+package com.noop.analytics
+
+import com.noop.data.HrSample
+import com.noop.data.RrInterval
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Test
+import java.time.LocalDate
+import java.time.ZoneOffset
+
+/**
+ * #804 Fix A (Kotlin twin of AnalyticsEngineProvidedSleepTests): a night the MOTION detector can't stage —
+ * an Oura ring sends NO gravity vector, so detectSleep returns nothing and the night scored blank — must
+ * still score when the caller hands analyzeDay the ring's OWN persisted hypnogram via `providedSleep`. And
+ * the byte-identical default path (empty `providedSleep`) must be unchanged.
+ */
+class AnalyticsEngineProvidedSleepTest {
+    private val profile = UserProfile(weightKg = 75.0, heightCm = 178.0, age = 30.0, sex = "male")
+    private val dayStart = LocalDate.parse("2026-07-27").atStartOfDay(ZoneOffset.UTC).toEpochSecond()
+    private val day = "2026-07-27"
+
+    /** hr (30 s) + rr (2 s, varied so RMSSD is computable) over [start, end), NO gravity. */
+    private fun nightStreams(start: Long, end: Long): Pair<List<HrSample>, List<RrInterval>> {
+        val hr = (start until end step 30).map { HrSample("t", it, 52 + ((it / 300) % 4).toInt()) }
+        var i = 0
+        val rr = (start until end step 2).map { RrInterval("t", it, 1080 + (i++ % 6) * 8) }
+        return hr to rr
+    }
+
+    /** A contiguous deep/light/rem/wake hypnogram over [start, end): the shape #773 persists. */
+    private fun hypnogram(start: Long): List<StageSegment> {
+        var t = start
+        fun seg(mins: Int, stage: String): StageSegment {
+            val s = StageSegment(t, t + mins * 60L, stage); t += mins * 60L; return s
+        }
+        return listOf(
+            seg(20, "wake"), seg(100, "light"), seg(60, "deep"), seg(60, "light"),
+            seg(60, "rem"), seg(120, "light"), seg(60, "deep"), seg(60, "rem"),
+            seg(40, "light"), seg(20, "wake"),
+        )   // 600 min in bed; deep 120, rem 120, light 320, wake 40
+    }
+
+    @Test
+    fun providedHypnogramScoresANightWithoutGravity() {
+        val sleepStart = dayStart - 4 * 3600            // 20:00 the previous evening
+        val sleepEnd = sleepStart + 600 * 60            // +10 h → 06:00, ends on `day`
+        val (hr, rr) = nightStreams(sleepStart, sleepEnd)
+        val provided = listOf(
+            DetectedSleep(sleepStart, sleepEnd, 0.75, hypnogram(sleepStart), restingHR = null, avgHRV = null),
+        )
+
+        val res = AnalyticsEngine.analyzeDay(day = day, hr = hr, rr = rr, profile = profile,
+            providedSleep = provided)
+
+        assertNotNull("the provided hypnogram must score the night", res.daily.totalSleepMin)
+        assertEquals(560.0, res.daily.totalSleepMin!!, 1.0)   // light 320 + deep 120 + rem 120
+        assertEquals(120.0, res.daily.deepMin!!, 1.0)
+        assertEquals(120.0, res.daily.remMin!!, 1.0)
+        assertEquals(0.75, res.daily.efficiency!!, 0.001)
+        assertFalse(res.sleepSessions.isEmpty())
+        // HRV & resting HR re-derived from THIS day's rr/hr over the provided window (the ring row carried
+        // neither) — the crux of #804 (avgHrv was nil despite 36 k rr present).
+        assertNotNull("avgHrv must be derived from rr over the provided window", res.daily.avgHrv)
+        assertNotNull(res.daily.restingHr)
+    }
+
+    @Test
+    fun emptyProvidedSleepIsByteIdenticalToOmitting() {
+        val (hr, rr) = nightStreams(dayStart - 4 * 3600, dayStart + 6 * 3600)
+        val omitted = AnalyticsEngine.analyzeDay(day = day, hr = hr, rr = rr, profile = profile)
+        val empty = AnalyticsEngine.analyzeDay(day = day, hr = hr, rr = rr, profile = profile,
+            providedSleep = emptyList())
+        assertEquals(omitted.daily, empty.daily)
+        // No gravity + no provided hypnogram = the pre-fix #804 state: the night does not score.
+        assertNull(omitted.daily.totalSleepMin)
+        assertNull(omitted.daily.avgHrv)
+    }
+
+    @Test
+    fun providedSessionKeepsItsOwnStoredHrvWhenPresent() {
+        val sleepStart = dayStart - 4 * 3600
+        val sleepEnd = sleepStart + 600 * 60
+        val (hr, rr) = nightStreams(sleepStart, sleepEnd)
+        val provided = listOf(
+            DetectedSleep(sleepStart, sleepEnd, 0.8, hypnogram(sleepStart), restingHR = 48, avgHRV = 65.0),
+        )
+        val res = AnalyticsEngine.analyzeDay(day = day, hr = hr, rr = rr, profile = profile,
+            providedSleep = provided)
+        assertEquals(48, res.daily.restingHr)
+        assertEquals(65.0, res.daily.avgHrv!!, 0.001)
+    }
+}


### PR DESCRIPTION
  Closes #804.

  An Oura-only night decoded and persisted a complete SleepNet hypnogram (#773) and showed on the Sleep timeline, yet the nightly  summary reported it as blank:

  sleep day=2026-07-27 totalSleepMin=nil stages=nil eff=nil matched=0 source=computed
  hrv   day=2026-07-27 window=whole avgHrv=nil

  Root cause: the nightly scorer (AnalyticsEngine.analyzeDay) stages sleep from the motion/gravity vector, and a ring streams no  gravity at all. So detectSleep returns nothing → the sleep window is empty → avgHrv (computed only over that window) stays nil  despite tens of thousands of R‑R intervals present. The ring's persisted hypnogram only ever fed the display‑path SleepMerge, never  analyzeDay.

  Confirmed on device (app 9.1.1, night 2026‑07‑26→27): the ring produced deep 88 / light 316 / rem 88 / awake 182 min, eff 73%,  persisted and won the merge — and the summary was still totalSleepMin=nil / avgHrv=nil. A fully‑formed hypnogram, still scoring blank
  — proof the blocker is scorer wiring, not decode.

##  The fix (general, not Oura‑hardcoded)

  analyzeDay gains an optional providedSleep: [SleepSession] = []:
  - When non‑empty, each provided session's nightly restingHR / avgHRV is re‑derived from that day's hr/rr over its window (via the  SAME SleepStager.sessionRestingHR / sessionAvgHRV helpers detectSleep uses).
  - Detected sessions that overlap a provided one are dropped (provided is authoritative); a non‑overlapping detected nap survives.
  - Empty providedSleep = byte‑identical motion‑only path.

  IntelligenceEngine supplies it: when the day owner sends no usable gravity vector (grav.count < 2) and isn't the canonical WHOOP  import namespace, it reads the owner's persisted hypnogram and reconstructs pure SleepSessions from the stored CachedSleepSession.
  New shared helpers both platforms: decodeStages + sleepSession(fromProvided:).

##  Scope / safety

  - WHOOP straps unaffected (real gravity → gate false → byte‑identical; 4.0 excluded by the namespace check / having no device  hypnogram).
  - #773 writes deep/light/rem/wake, exactly what hypnogramMetrics reads.
  - The "My WHOOP" provenance mislabel is a separate PR (one concern per PR).

##  Verification

  - Swift StrandAnalytics 1173/0 (3 new); Kotlin AnalyticsEngineProvidedSleepTest + full analytics suite green; macOS app builds.
  - Tests: a provided hypnogram over a gravity‑free night now scores + derives avgHrv/restingHr; empty providedSleep asserted  byte‑identical to omitting (and still nil without gravity — the pre‑fix state).
  - ⏳ Real‑strap validation pending: the next Oura sync should score the 7/26→27 night at ~492 min / eff 73% / non‑nil avgHrv.

##  Cross‑platform

  Swift + Kotlin changed byte‑identically; no schema/migration.