### PR TITLE
fix(oura): gate RSA respiration to nil when the R‑R stream isn't beat-accurate

### DIFF
--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/SleepStager.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/SleepStager.swift
@@ -1481,6 +1481,18 @@ public enum SleepStager {
     static let rsaMinBreathIntervalS = 2.5   // 24 bpm
     static let rsaMaxBreathIntervalS = 10.0  // 6 bpm
 
+    /// Beat-accuracy gate for RSA (see `respRateFromRR`). RSA is a FREQUENCY-domain method: it recovers
+    /// the ~0.2–0.3 Hz breathing oscillation from beat TIMING, so it needs a per-beat-accurate R-R stream
+    /// (each row's wall-clock gap ≈ its own R-R value). Time-domain HRV (RMSSD) is order-only and does NOT
+    /// need this. A banked/batched stream — e.g. an Oura ring's OVERNIGHT IBI, which stamps many beats at
+    /// one coarse ring-time (validated: only ~2% of beats are time-accurate, 25 k beats packed into a 3.5 h
+    /// timestamp span vs a 7.9 h R-R sum) — cannot support RSA; the tachogram's time axis is corrupted and
+    /// the estimate collapses to a confidently-wrong ~7–10 bpm. So gate: a beat is "time-accurate" when its
+    /// wall-clock gap matches its R-R value within `beatAccuracyToleranceS`; if fewer than
+    /// `beatAccuracyMinFraction` of beats qualify, return NaN (honest no-data) instead of a bad number.
+    static let beatAccuracyToleranceS = 0.5
+    static let beatAccuracyMinFraction = 0.5
+
     /// THE canonical plausible sleeping-respiratory-rate band (bpm). The RSA peak-pick below can
     /// yield 6–8 bpm at its noise floor, but every consumer (illness/readiness gates) only acts on
     /// 8–25 — so respRateFromRR clamps its output to this band (NaN outside it) and the stored
@@ -1513,9 +1525,23 @@ public enum SleepStager {
         // 1. In-bed RR rows in chronological order, range-filtered. STABLE sort: step 2 reconstructs
         // beat times by cumulative sum, so the order of a second's beats moves every subsequent beat
         // time and with it the RSA estimate. Kotlin's twin uses sortedBy, stable by contract. (#823)
-        let inBed = rr.filter { $0.ts >= start && $0.ts <= end }
-            .sortedByTsStable()
-            .map { Double($0.rrMs) }
+        let inBedRows = rr.filter { $0.ts >= start && $0.ts <= end }.sortedByTsStable()
+
+        // Beat-accuracy gate: RSA needs per-beat-accurate TIMING (each row's wall-clock gap ≈ its own
+        // R-R value). A banked/batched stream (an Oura overnight IBI stamps many beats at one coarse
+        // ring-time) fails this and yields a confidently-wrong ~7–10 bpm; return NaN instead. Beat-accurate
+        // callers (WHOOP R-R, the synthetic RSA fixtures) are ~100% accurate and pass unchanged. Needs a
+        // few beats to judge; below that the count gate below handles it.
+        if inBedRows.count >= 30 {
+            var accurate = 0
+            for i in 1..<inBedRows.count {
+                let gapS = Double(inBedRows[i].ts - inBedRows[i - 1].ts)
+                if abs(gapS - Double(inBedRows[i].rrMs) / 1000.0) <= beatAccuracyToleranceS { accurate += 1 }
+            }
+            if Double(accurate) / Double(inBedRows.count - 1) < beatAccuracyMinFraction { return nan }
+        }
+
+        let inBed = inBedRows.map { Double($0.rrMs) }
         let filtered = HRVAnalyzer.rangeFilter(inBed)
         if filtered.count < 30 { return nan }  // need enough beats for any RSA estimate
 

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/RespRateRsaTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/RespRateRsaTests.swift
@@ -57,6 +57,29 @@ final class RespRateRsaTests: XCTestCase {
         XCTAssertLessThan(est, 16.0, "resp estimate must not be doubled toward ~22 (#958)")
     }
 
+    /// A banked/batched R-R stream whose timestamps are NOT beat-accurate (an Oura overnight IBI stamps
+    /// many beats at one coarse ring-time) must return NaN — RSA is a frequency-domain method and cannot
+    /// recover breathing from a corrupted time axis, so the honest answer is no-data, not a wrong ~8 bpm.
+    /// Same R-R VALUES as the recovering test, only the TIMESTAMPS are batched.
+    func testRespRateFromRRBatchedTimestampsIsNaN() {
+        let breathHz = 0.25
+        let baseRrMs = 1000.0, ampMs = 40.0
+        let start = 1_700_000_000
+        var rows: [RRInterval] = []
+        var tSec = 0.0
+        var beat = 0
+        while tSec < 600.0 {
+            let rrMs = baseRrMs + ampMs * sin(2.0 * Double.pi * breathHz * tSec)
+            tSec += rrMs / 1000.0
+            // Batched stamp: 6 beats share one coarse second, then jump — like a banked-IBI record.
+            // The wall-clock gap (mostly 0) no longer matches the ~1 s R-R value.
+            rows.append(RRInterval(ts: start + (beat / 6), rrMs: Int(rrMs)))
+            beat += 1
+        }
+        let est = SleepStager.respRateFromRR(rows, start: start, end: start + 600)
+        XCTAssertTrue(est.isNaN, "batched (non-beat-accurate) timestamps must gate to NaN, got \(est)")
+    }
+
     func testRespRateFromRRTooFewBeatsIsNaN() {
         let start = 1_700_000_000
         let rows = [

--- a/android/app/src/main/java/com/noop/analytics/SleepStager.kt
+++ b/android/app/src/main/java/com/noop/analytics/SleepStager.kt
@@ -1576,6 +1576,16 @@ object SleepStager {
     private const val rsaMinBreathIntervalS: Double = 2.5  // 24 bpm
     private const val rsaMaxBreathIntervalS: Double = 10.0 // 6 bpm
 
+    // Beat-accuracy gate for RSA (see respRateFromRR). RSA is a FREQUENCY-domain method: it recovers the
+    // ~0.2–0.3 Hz breathing oscillation from beat TIMING, so it needs a per-beat-accurate R-R stream (each
+    // row's wall-clock gap ≈ its own R-R value). Time-domain HRV (RMSSD) is order-only and does NOT need
+    // this. A banked/batched stream — an Oura overnight IBI stamps many beats at one coarse ring-time
+    // (validated: only ~2% of beats are time-accurate) — cannot support RSA; the estimate collapses to a
+    // confidently-wrong ~7–10 bpm. Gate: if fewer than beatAccuracyMinFraction of beats have a wall-clock
+    // gap within beatAccuracyToleranceS of their R-R value, return NaN. Byte-identical twin of Swift.
+    private const val beatAccuracyToleranceS: Double = 0.5
+    private const val beatAccuracyMinFraction: Double = 0.5
+
     /**
      * THE canonical plausible sleeping-respiratory-rate band (bpm). The RSA peak-pick above can yield
      * 6–8 bpm at its noise floor, but every consumer (ReadinessEngine illness/readiness) only acts on
@@ -1611,11 +1621,22 @@ object SleepStager {
         if (end <= start) return nan
 
         // 1. In-bed RR rows in chronological order, range-filtered.
-        val inBed = rr.asSequence()
-            .filter { it.ts in start..end }
-            .sortedBy { it.ts }
-            .map { it.rrMs.toDouble() }
-            .toList()
+        val inBedRows = rr.filter { it.ts in start..end }.sortedBy { it.ts }
+
+        // Beat-accuracy gate: RSA needs per-beat-accurate TIMING (each row's wall-clock gap ≈ its own R-R
+        // value). A banked/batched stream (an Oura overnight IBI stamps many beats at one coarse ring-time)
+        // fails this and yields a confidently-wrong ~7–10 bpm; return NaN instead. Beat-accurate callers
+        // (WHOOP R-R, the synthetic RSA fixtures) are ~100% accurate and pass unchanged.
+        if (inBedRows.size >= 30) {
+            var accurate = 0
+            for (i in 1 until inBedRows.size) {
+                val gapS = (inBedRows[i].ts - inBedRows[i - 1].ts).toDouble()
+                if (kotlin.math.abs(gapS - inBedRows[i].rrMs.toDouble() / 1000.0) <= beatAccuracyToleranceS) accurate++
+            }
+            if (accurate.toDouble() / (inBedRows.size - 1).toDouble() < beatAccuracyMinFraction) return nan
+        }
+
+        val inBed = inBedRows.map { it.rrMs.toDouble() }
         val filtered = HrvAnalyzer.rangeFilter(inBed)
         if (filtered.size < 30) return nan // need enough beats for any RSA estimate
 

--- a/android/app/src/test/java/com/noop/analytics/RespRateRsaTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/RespRateRsaTest.kt
@@ -72,6 +72,29 @@ class RespRateRsaTest {
     }
 
     @Test
+    fun respRateFromRR_batchedTimestampsIsNaN() {
+        // A banked/batched R-R stream whose timestamps are NOT beat-accurate (an Oura overnight IBI stamps
+        // many beats at one coarse ring-time) must return NaN — RSA cannot recover breathing from a
+        // corrupted time axis. Same R-R VALUES as the recovering test, only the TIMESTAMPS are batched.
+        val breathHz = 0.25
+        val baseRrMs = 1000.0
+        val ampMs = 40.0
+        val start = 1_700_000_000L
+        val rows = ArrayList<RrInterval>()
+        var tSec = 0.0
+        var beat = 0
+        while (tSec < 600.0) {
+            val rrMs = baseRrMs + ampMs * Math.sin(2.0 * Math.PI * breathHz * tSec)
+            tSec += rrMs / 1000.0
+            // Batched stamp: 6 beats share one coarse second, then jump — like a banked-IBI record.
+            rows.add(RrInterval(deviceId = "test", ts = start + (beat / 6).toLong(), rrMs = rrMs.toInt()))
+            beat++
+        }
+        val est = SleepStager.respRateFromRR(rows, start, start + 600)
+        assertTrue("batched (non-beat-accurate) timestamps must gate to NaN, got $est", est.isNaN())
+    }
+
+    @Test
     fun respRateFromRR_tooFewBeatsIsNaN() {
         val start = 1_700_000_000L
         val rows = listOf(


### PR DESCRIPTION
As described in #882  adding a **beat-accuracy precondition** to `SleepStager.respRateFromRR` (both platforms): a beat is "time-accurate" when its wall-clock gap matches its own R‑R value within `beatAccuracyToleranceS` (0.5 s); if fewer than `beatAccuracyMinFraction` (50 %) of beats qualify, return `NaN` (honest no-data) instead of a wrong ~10. General, not Oura-specific — WHOOP's beat-accurate R‑R (~100 %) and the synthetic RSA fixtures pass unchanged; Oura's banked IBI (~2 %) is gated. So the Oura night simply shows **no** respiration rather than a confidently-wrong one.
