### PR TITLE
Localize the 9.2.0 What's New title, and unbreak main

### DIFF
--- a/android/app/src/main/java/com/noop/ui/AppChangelog.kt
+++ b/android/app/src/main/java/com/noop/ui/AppChangelog.kt
@@ -39,7 +39,7 @@ object AppChangelog {
     val releases: List<Release> = listOf(
         Release(
             version = "9.2.0",
-            title = "HRV accuracy fix, Oura sleep and motion, richer 5/MG decoding, and a stoppable sync",
+            title = uiString(R.string.l10n_app_changelog_hrv_accuracy_fix_oura_sleep_and_motion_4ed31e39),
             date = "July 2026",
             items = listOf(
                 "**HRV was reading low (#823).** Same-second R-R beats were sorted by size instead of the order the strap sent them, which biased RMSSD downward. Fixed on both platforms — your HRV numbers will shift slightly, and the new ones are the correct ones.",

--- a/android/app/src/main/res/values-de/strings.xml
+++ b/android/app/src/main/res/values-de/strings.xml
@@ -1164,6 +1164,7 @@
     <string name="l10n_app_changelog_personal_vital_baselines_mac_analytics_parity_744972d1">Persönliche Vital Baselines + Mac Analytics Parität</string>
     <string name="l10n_app_changelog_polish_matched_to_the_iphone_mac_cc34126b">Polnisch - abgestimmt auf das iPhone &amp; Mac Design</string>
     <string name="l10n_app_changelog_german_french_spanish_pull_to_sync_1109bda2">Deutsch, Französisch und Spanisch, Pull-to-Sync auf Today und viele Verbesserungen</string>
+    <string name="l10n_app_changelog_hrv_accuracy_fix_oura_sleep_and_motion_4ed31e39">HRV-Korrektur, Oura-Schlaf und -Bewegung, mehr 5/MG-Daten und ein stoppbarer Sync</string>
     <string name="l10n_app_changelog_optimal_strain_alerts_faster_history_sync_6488a27a">Hinweise zur optimalen Anstrengung, schnellere Verlaufssynchronisierung und viele Genauigkeitskorrekturen</string>
     <string name="l10n_app_changelog_power_saving_that_protects_your_strap_57a32503">Energieeinsparung, die Ihren Riemen schützt, ein Gemini-powered Coach auf Android und reichere metrische Details</string>
     <string name="l10n_app_changelog_raw_spo_honest_units_and_a_55e83a59">Raw SpO2, ehrliche Einheiten und eine leichtere App</string>

--- a/android/app/src/main/res/values-es/strings.xml
+++ b/android/app/src/main/res/values-es/strings.xml
@@ -1004,6 +1004,7 @@
     <string name="l10n_app_changelog_personal_vital_baselines_mac_analytics_parity_744972d1">Bases vitales personales + Paridad analítica de Mac</string>
     <string name="l10n_app_changelog_polish_matched_to_the_iphone_mac_cc34126b">Polaco - compatible con el diseño iPhone &amp;amp; Mac</string>
     <string name="l10n_app_changelog_german_french_spanish_pull_to_sync_1109bda2">Alemán, francés y español, deslizar para sincronizar en Today y una oleada de mejoras</string>
+    <string name="l10n_app_changelog_hrv_accuracy_fix_oura_sleep_and_motion_4ed31e39">Corrección de HRV, sueño y movimiento de Oura, más datos 5/MG y una sincronización que puedes detener</string>
     <string name="l10n_app_changelog_optimal_strain_alerts_faster_history_sync_6488a27a">Avisos de esfuerzo óptimo, sincronización del historial más rápida y una oleada de correcciones de precisión</string>
     <string name="l10n_app_changelog_power_saving_that_protects_your_strap_57a32503">Ahorro de energía que protege su correa, un entrenador con Géminis en Android, y detalles métricos más ricos</string>
     <string name="l10n_app_changelog_raw_spo_honest_units_and_a_55e83a59">Raw SpO2, unidades honestas y una aplicación más ligera</string>

--- a/android/app/src/main/res/values-fr/strings.xml
+++ b/android/app/src/main/res/values-fr/strings.xml
@@ -1004,6 +1004,7 @@
     <string name="l10n_app_changelog_personal_vital_baselines_mac_analytics_parity_744972d1">Bases vitales personnelles + parité d\'analyse Mac</string>
     <string name="l10n_app_changelog_polish_matched_to_the_iphone_mac_cc34126b">Polonais - adapté au design iPhone &amp; Mac</string>
     <string name="l10n_app_changelog_german_french_spanish_pull_to_sync_1109bda2">Allemand, français et espagnol, glisser pour synchroniser sur Today et une vague d\'améliorations</string>
+    <string name="l10n_app_changelog_hrv_accuracy_fix_oura_sleep_and_motion_4ed31e39">Correction de la VFC, sommeil et mouvement Oura, plus de données 5/MG et une synchronisation interruptible</string>
     <string name="l10n_app_changelog_optimal_strain_alerts_faster_history_sync_6488a27a">Alertes d\'effort optimal, synchronisation de l\'historique plus rapide et une vague de corrections de précision</string>
     <string name="l10n_app_changelog_power_saving_that_protects_your_strap_57a32503">Économie d\'énergie qui protège votre sangle, un entraîneur Gemini sur Android, et plus riche détail métrique</string>
     <string name="l10n_app_changelog_raw_spo_honest_units_and_a_55e83a59">Raw SpO2, des unités honnêtes, et une application plus légère</string>

--- a/android/app/src/main/res/values-pt-rPT/strings.xml
+++ b/android/app/src/main/res/values-pt-rPT/strings.xml
@@ -1145,6 +1145,7 @@
     <string name="l10n_app_changelog_personal_vital_baselines_mac_analytics_parity_744972d1">Linhas de base vitais pessoais + paridade analítica Mac</string>
     <string name="l10n_app_changelog_polish_matched_to_the_iphone_mac_cc34126b">Polaco - compatível com o design do iPhone e Mac</string>
     <string name="l10n_app_changelog_german_french_spanish_pull_to_sync_1109bda2">Alemão, francês e espanhol, pull-to-sync no Today e uma onda de polimento</string>
+    <string name="l10n_app_changelog_hrv_accuracy_fix_oura_sleep_and_motion_4ed31e39">Correção da VFC, sono e movimento Oura, mais dados 5/MG e uma sincronização que podes parar</string>
     <string name="l10n_app_changelog_optimal_strain_alerts_faster_history_sync_6488a27a">Alertas de tensão ideal, sincronização mais rápida do histórico e uma onda de correções de precisão</string>
     <string name="l10n_app_changelog_power_saving_that_protects_your_strap_57a32503">Economia de energia que protege a tua bracelete, treinador com tecnologia Gemini no Android e detalhes métricos mais ricos</string>
     <string name="l10n_app_changelog_raw_spo_honest_units_and_a_55e83a59">SpO₂ bruto, unidades honestas e uma aplicação mais leve</string>

--- a/android/app/src/main/res/values-zh/strings.xml
+++ b/android/app/src/main/res/values-zh/strings.xml
@@ -969,6 +969,7 @@
     <string name="l10n_add_device_wizard_not_now_e4571490">暂不</string>
     <string name="l10n_add_device_wizard_take_over_2c7f5505">接管</string>
     <string name="l10n_add_device_wizard_take_over_this_ring_cc79ef5e">接管这枚智能戒指吗？</string>
+    <string name="l10n_app_changelog_hrv_accuracy_fix_oura_sleep_and_motion_4ed31e39">HRV 修正、Oura 睡眠与运动、更丰富的 5/MG 解码，以及可中断的同步</string>
     <string name="l10n_app_changelog_5_mg_bonding_on_android_health_c94c46ac">Android 版 5.0/MG 配对绑定 + 健康监测器修复</string>
     <string name="l10n_app_changelog_a_beautiful_new_look_aa8c910c">焕然一新的绝美外观设计</string>
     <string name="l10n_app_changelog_a_big_bug_fix_sweep_with_65335764">大规模 Bug 修复，并全新引入“测试中心”用于排查问题</string>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -1173,6 +1173,7 @@
     <string name="l10n_app_changelog_personal_vital_baselines_mac_analytics_parity_744972d1">Personal vital baselines + Mac analytics parity</string>
     <string name="l10n_app_changelog_polish_matched_to_the_iphone_mac_cc34126b">Polish - matched to the iPhone &amp; Mac design</string>
     <string name="l10n_app_changelog_german_french_spanish_pull_to_sync_1109bda2">German, French &amp; Spanish, pull-to-sync on Today, and a wave of polish</string>
+    <string name="l10n_app_changelog_hrv_accuracy_fix_oura_sleep_and_motion_4ed31e39">HRV accuracy fix, Oura sleep and motion, richer 5/MG decoding, and a stoppable sync</string>
     <string name="l10n_app_changelog_optimal_strain_alerts_faster_history_sync_6488a27a">Optimal-strain alerts, faster history sync, and a wave of accuracy fixes</string>
     <string name="l10n_app_changelog_power_saving_that_protects_your_strap_57a32503">Power saving that protects your strap, a Gemini-powered coach on Android, and richer metric detail</string>
     <string name="l10n_app_changelog_raw_spo_honest_units_and_a_55e83a59">Raw SpO₂, honest units, and a lighter app</string>


### PR DESCRIPTION
The 9.2.0 release left `main` **failing i18n-coverage**.

`appchangelog-gen` writes the in-app What's New entry with the title as a raw Kotlin literal; extracting it into a string resource is a separate step that normally happens in the PR flow, where the gate catches it. `fork-release.yml` commits the generated entry straight to main, so nothing caught it.

That also means **the 9.2.0 What's New title shipped untranslated on Android** — the only one of 240+ release entries to do so. Every other `Release(...)` reads `title = uiString(R.string.l10n_app_changelog_…)`; only `items` are raw, which is the established pattern.

Adds the resource under the existing convention — `l10n_app_changelog_<slug>_<sha1(value)[:8]>`, confirmed by reproducing `6488a27a` from the 9.1.0 title — with translations in all five locale files, and points `AppChangelog.kt` at it.

`values-zh` is included deliberately rather than raising its allowance: the extra-locale ratchet flagged 44 missing against 43 allowed, and `Tools/i18n_extra_locale_baseline.txt` says in its own header to ratchet **down, never up**. Closing the gap keeps it at 43.

**This will recur on every release** until the extraction runs inside `fork-release.yml`, or the audit learns the generated changelog entry is extracted separately. Worth its own issue; this is the immediate unbreak.