### PR TITLE
Battery drain: diagnose the reconnect loop, and stop re-asking the battery policies every second

### DIFF
--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -2117,6 +2117,29 @@ class WhoopBleClient(
     /** Wall time (ms) the current connect attempt began, to measure connect latency at onConnectionStateChange
      *  CONNECTED. null between attempts; set when connect() kicks the radio. */
     private var connectAttemptStartedAtMs: Long? = null
+
+    /**
+     * Wall time (ms) this link reached STATE_CONNECTED, or null while down. Read only to LOG how long a
+     * connection was held before it dropped.
+     *
+     * Why it is worth a field: reaching STATE_CONNECTED zeroes [failedReconnectAttempts], and that
+     * counter is the ONLY input to [scanModeForReconnectAttempts]. So a strap that connects and drops
+     * repeatedly — edge of range, phone in another room — never accumulates a streak and every rescan
+     * stays on the battery-hungry SCAN_MODE_LOW_LATENCY, which the PR #588 backoff was meant to escape.
+     * The #982 guard covers the never-bonded variant of that loop; a bonded-but-short-lived link is not
+     * covered. Printing the hold time makes the pattern readable in an ordinary strap log: a run of
+     * drops that all say `attempt 1` with a short `held` is that bug, with no instrumentation needed.
+     *
+     * Diagnostic only — nothing reads this to make a decision.
+     */
+    @Volatile
+    private var linkUpSinceMs: Long? = null
+
+    /** `, held 24s` for the drop log, or an empty string if we never reached STATE_CONNECTED. */
+    private fun heldForLogSuffix(): String {
+        val since = linkUpSinceMs ?: return ""
+        return ", held ${(System.currentTimeMillis() - since) / 1000}s"
+    }
     /** Count of INVOLUNTARY reconnects this run, surfaced as the reconnect-churn count. Reset by an
      *  intentional disconnect. */
     private var connReconnectCount = 0
@@ -4183,6 +4206,10 @@ class WhoopBleClient(
                     // climb on a flapping co-resident band froze the link, and with it the keep-alive battery
                     // poll and every historical offload: sync + battery stopped updating (regression of #173).
                     resetReconnectBackoff()
+                    // Diagnostic only (see linkUpSinceMs): how long this link is held before it drops is
+                    // exactly what distinguishes a healthy connection from the flapping loop that keeps
+                    // the reconnect streak — and so the scan mode — pinned at its most power-hungry.
+                    linkUpSinceMs = System.currentTimeMillis()
                     // A connect succeeded → clear the stale-bond re-pair guide UNLESS we are in a known
                     // bond-loop (#617). In that loop the strap "connects" every ~3 s before timing out
                     // again, so clearing here wiped the guide on EVERY cycle: it flashed for ~1 s and
@@ -6495,6 +6522,11 @@ class WhoopBleClient(
 
     @SuppressLint("MissingPermission")
     private fun handleDisconnect(status: Int) {
+        // Snapshot the hold time and clear it IMMEDIATELY: every drop log below reads the snapshot, and a
+        // stale `linkUpSinceMs` surviving into the next drop would report a hold time for a link that never
+        // reached STATE_CONNECTED — the diagnostic would then invent exactly the evidence it exists to find.
+        val heldSuffix = heldForLogSuffix()
+        linkUpSinceMs = null
         // Reboot trail: if a user reboot is in flight, this drop is the strap acting on it. Log how long the
         // link stayed up (a real reboot drops within ~1-2s) and cancel the no-disconnect watchdog. The
         // reconnect time is logged separately once the handshake completes; rebootRequestedAtMs stays set so
@@ -6714,12 +6746,12 @@ class WhoopBleClient(
                 // count — keep it DIRECT; only a genuinely-out-of-range band escalates to PASSIVE for power.
                 val aclHeld = isStrapAclHeld(dev.address)
                 val passiveReconnect = passiveReconnectDecision(failedReconnectAttempts, aclHeld)
-                log("Disconnected (status=$status); reconnecting ${if (passiveReconnect) "passively" else "directly"} in ${directDelay / 1000}s (attempt $failedReconnectAttempts${if (aclHeld) ", ACL-held" else ""})")
+                log("Disconnected (status=$status); reconnecting ${if (passiveReconnect) "passively" else "directly"} in ${directDelay / 1000}s (attempt $failedReconnectAttempts$heldSuffix${if (aclHeld) ", ACL-held" else ""})")
                 // #1030 (ryanbr): cancellable backoff timer (see scheduleReconnect).
                 scheduleReconnect(directDelay) { connectToDevice(dev, autoConnect = passiveReconnect) }
             } else {
                 val rescanDelay = nextReconnectDelayMs()
-                log("Disconnected (status=$status); rescanning in ${rescanDelay / 1000}s (attempt $failedReconnectAttempts)")
+                log("Disconnected (status=$status); rescanning in ${rescanDelay / 1000}s (attempt $failedReconnectAttempts$heldSuffix)")
                 // #1030 (ryanbr): cancellable backoff timer (see scheduleReconnect).
                 scheduleReconnect(rescanDelay) { connect(selectedModel) }
             }

--- a/android/app/src/main/java/com/noop/ble/WhoopConnectionService.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopConnectionService.kt
@@ -114,6 +114,22 @@ class WhoopConnectionService : Service() {
      *  actual SoC change keeps the predictive path as cheap as the SoC-only alert beside it. */
     private var lastRuntimeEvalPct: Int? = null
 
+    /**
+     * Last (SoC %, charging) pair the battery-alert policies were evaluated for, so they run on a CHANGE
+     * rather than on every live-state emission.
+     *
+     * The collector below ticks at live-HR cadence (~1/s while connected). Both notifiers early-exit on
+     * their own PERSISTED once-per-crossing gates, but not before each has done a SharedPreferences read,
+     * a `NotificationManagerCompat.areNotificationsEnabled()` binder call and an `ensureChannel()` —
+     * roughly two binder calls and half a dozen prefs reads every second, to re-answer a question the
+     * strap only changes every ~8 minutes.
+     *
+     * Gated on the PAIR, not the percentage alone: [BatteryAlertNotifier.onBatteryUpdate] owns the
+     * charge-complete and re-arm transitions, which key off `charging`. A user plugging in before the
+     * percentage ticks would otherwise have their re-arm deferred by up to a battery-report cycle.
+     */
+    private var lastBatteryAlertKey: Pair<Int?, Boolean?>? = null
+
     /** The user's LEARNED habitual midsleep (local seconds-of-day), cached for the battery
      *  night-guard. null = cold start (< [com.noop.analytics.SleepStageTotals.HABITUAL_MIN_DAYS]
      *  nights), which is what makes `BatteryEstimator.bedtimeAlert` stay silent instead of testing
@@ -254,24 +270,31 @@ class WhoopConnectionService : Service() {
                     IllnessAlertNotifier.onEvaluated(this@WhoopConnectionService, illness)
                 }
                 lastIllnessAlert = illness
-                // Battery alerts — low (≤15%) and charge-complete (100%). The once-per-crossing
-                // dedupe is persisted in NoopPrefs (BatteryAlertPolicy), so no in-memory pct tracking.
-                BatteryAlertNotifier.onBatteryUpdate(
-                    this@WhoopConnectionService,
-                    currPct = state.batteryPct?.roundToInt(),
-                    charging = state.charging,
-                )
-                // ESCALATION 1 — critical SoC (iOS/macOS twin: BatteryNotifier.onCriticalBattery). A
-                // SECOND, lower crossing (12%) with its own persisted gate, because the 15% alert above
-                // latches until the cell recovers to 25%: measured, a user got that one warning and then
-                // total silence across the final ~3 h down to the ~10% hardware cutoff, and lost the
-                // night. Sits beside onBatteryUpdate rather than in the estimator block below because it
-                // is the same kind of pure SoC policy — no Room read, no slope fit.
-                BatteryAlertNotifier.onCriticalBattery(
-                    this@WhoopConnectionService,
-                    currPct = state.batteryPct?.roundToInt(),
-                    charging = state.charging,
-                )
+                // Evaluated only when (SoC, charging) actually MOVES — see [lastBatteryAlertKey]. Both policies
+                // are once-per-crossing and persisted, so re-running them on an unchanged pair can only repeat
+                // work that already decided nothing.
+                val batteryKey = state.batteryPct?.roundToInt() to state.charging
+                if (batteryKey != lastBatteryAlertKey) {
+                    // Battery alerts — low (≤15%) and charge-complete (100%). The once-per-crossing
+                    // dedupe is persisted in NoopPrefs (BatteryAlertPolicy), so no in-memory pct tracking.
+                    BatteryAlertNotifier.onBatteryUpdate(
+                        this@WhoopConnectionService,
+                        currPct = state.batteryPct?.roundToInt(),
+                        charging = state.charging,
+                    )
+                    // ESCALATION 1 — critical SoC (iOS/macOS twin: BatteryNotifier.onCriticalBattery). A
+                    // SECOND, lower crossing (12%) with its own persisted gate, because the 15% alert above
+                    // latches until the cell recovers to 25%: measured, a user got that one warning and then
+                    // total silence across the final ~3 h down to the ~10% hardware cutoff, and lost the
+                    // night. Sits beside onBatteryUpdate rather than in the estimator block below because it
+                    // is the same kind of pure SoC policy — no Room read, no slope fit.
+                    BatteryAlertNotifier.onCriticalBattery(
+                        this@WhoopConnectionService,
+                        currPct = state.batteryPct?.roundToInt(),
+                        charging = state.charging,
+                    )
+                }
+
                 // Predictive runtime alert (iOS/macOS twin: BatteryNotifier.onRuntimeEstimate):
                 // re-fit the "~X left" estimate from the persisted SoC series and warn at ≤24 h of
                 // runtime, whatever the strap generation. Evaluated only when the battery % actually

--- a/android/app/src/main/java/com/noop/ui/AppChangelog.kt
+++ b/android/app/src/main/java/com/noop/ui/AppChangelog.kt
@@ -39,7 +39,7 @@ object AppChangelog {
     val releases: List<Release> = listOf(
         Release(
             version = "9.2.0",
-            title = "HRV accuracy fix, Oura sleep and motion, richer 5/MG decoding, and a stoppable sync",
+            title = uiString(R.string.l10n_app_changelog_hrv_accuracy_fix_oura_sleep_and_motion_4ed31e39),
             date = "July 2026",
             items = listOf(
                 "**HRV was reading low (#823).** Same-second R-R beats were sorted by size instead of the order the strap sent them, which biased RMSSD downward. Fixed on both platforms — your HRV numbers will shift slightly, and the new ones are the correct ones.",

--- a/android/app/src/main/java/com/noop/ui/AppChangelog.kt
+++ b/android/app/src/main/java/com/noop/ui/AppChangelog.kt
@@ -39,7 +39,7 @@ object AppChangelog {
     val releases: List<Release> = listOf(
         Release(
             version = "9.2.0",
-            title = uiString(R.string.l10n_app_changelog_hrv_accuracy_fix_oura_sleep_and_motion_4ed31e39),
+            title = uiString(R.string.l10n_app_changelog_hrv_accuracy_fix_oura_sleep_and_4ed31e39),
             date = "July 2026",
             items = listOf(
                 "**HRV was reading low (#823).** Same-second R-R beats were sorted by size instead of the order the strap sent them, which biased RMSSD downward. Fixed on both platforms — your HRV numbers will shift slightly, and the new ones are the correct ones.",

--- a/android/app/src/main/res/values-de/strings.xml
+++ b/android/app/src/main/res/values-de/strings.xml
@@ -1164,6 +1164,7 @@
     <string name="l10n_app_changelog_personal_vital_baselines_mac_analytics_parity_744972d1">Persönliche Vital Baselines + Mac Analytics Parität</string>
     <string name="l10n_app_changelog_polish_matched_to_the_iphone_mac_cc34126b">Polnisch - abgestimmt auf das iPhone &amp; Mac Design</string>
     <string name="l10n_app_changelog_german_french_spanish_pull_to_sync_1109bda2">Deutsch, Französisch und Spanisch, Pull-to-Sync auf Today und viele Verbesserungen</string>
+    <string name="l10n_app_changelog_hrv_accuracy_fix_oura_sleep_and_motion_4ed31e39">HRV-Korrektur, Oura-Schlaf und -Bewegung, mehr 5/MG-Daten und ein stoppbarer Sync</string>
     <string name="l10n_app_changelog_optimal_strain_alerts_faster_history_sync_6488a27a">Hinweise zur optimalen Anstrengung, schnellere Verlaufssynchronisierung und viele Genauigkeitskorrekturen</string>
     <string name="l10n_app_changelog_power_saving_that_protects_your_strap_57a32503">Energieeinsparung, die Ihren Riemen schützt, ein Gemini-powered Coach auf Android und reichere metrische Details</string>
     <string name="l10n_app_changelog_raw_spo_honest_units_and_a_55e83a59">Raw SpO2, ehrliche Einheiten und eine leichtere App</string>

--- a/android/app/src/main/res/values-de/strings.xml
+++ b/android/app/src/main/res/values-de/strings.xml
@@ -1164,7 +1164,7 @@
     <string name="l10n_app_changelog_personal_vital_baselines_mac_analytics_parity_744972d1">Persönliche Vital Baselines + Mac Analytics Parität</string>
     <string name="l10n_app_changelog_polish_matched_to_the_iphone_mac_cc34126b">Polnisch - abgestimmt auf das iPhone &amp; Mac Design</string>
     <string name="l10n_app_changelog_german_french_spanish_pull_to_sync_1109bda2">Deutsch, Französisch und Spanisch, Pull-to-Sync auf Today und viele Verbesserungen</string>
-    <string name="l10n_app_changelog_hrv_accuracy_fix_oura_sleep_and_motion_4ed31e39">HRV-Korrektur, Oura-Schlaf und -Bewegung, mehr 5/MG-Daten und ein stoppbarer Sync</string>
+    <string name="l10n_app_changelog_hrv_accuracy_fix_oura_sleep_and_4ed31e39">HRV-Korrektur, Oura-Schlaf und -Bewegung, mehr 5/MG-Daten und ein stoppbarer Sync</string>
     <string name="l10n_app_changelog_optimal_strain_alerts_faster_history_sync_6488a27a">Hinweise zur optimalen Anstrengung, schnellere Verlaufssynchronisierung und viele Genauigkeitskorrekturen</string>
     <string name="l10n_app_changelog_power_saving_that_protects_your_strap_57a32503">Energieeinsparung, die Ihren Riemen schützt, ein Gemini-powered Coach auf Android und reichere metrische Details</string>
     <string name="l10n_app_changelog_raw_spo_honest_units_and_a_55e83a59">Raw SpO2, ehrliche Einheiten und eine leichtere App</string>

--- a/android/app/src/main/res/values-es/strings.xml
+++ b/android/app/src/main/res/values-es/strings.xml
@@ -1004,7 +1004,7 @@
     <string name="l10n_app_changelog_personal_vital_baselines_mac_analytics_parity_744972d1">Bases vitales personales + Paridad analítica de Mac</string>
     <string name="l10n_app_changelog_polish_matched_to_the_iphone_mac_cc34126b">Polaco - compatible con el diseño iPhone &amp;amp; Mac</string>
     <string name="l10n_app_changelog_german_french_spanish_pull_to_sync_1109bda2">Alemán, francés y español, deslizar para sincronizar en Today y una oleada de mejoras</string>
-    <string name="l10n_app_changelog_hrv_accuracy_fix_oura_sleep_and_motion_4ed31e39">Corrección de HRV, sueño y movimiento de Oura, más datos 5/MG y una sincronización que puedes detener</string>
+    <string name="l10n_app_changelog_hrv_accuracy_fix_oura_sleep_and_4ed31e39">Corrección de HRV, sueño y movimiento de Oura, más datos 5/MG y una sincronización que puedes detener</string>
     <string name="l10n_app_changelog_optimal_strain_alerts_faster_history_sync_6488a27a">Avisos de esfuerzo óptimo, sincronización del historial más rápida y una oleada de correcciones de precisión</string>
     <string name="l10n_app_changelog_power_saving_that_protects_your_strap_57a32503">Ahorro de energía que protege su correa, un entrenador con Géminis en Android, y detalles métricos más ricos</string>
     <string name="l10n_app_changelog_raw_spo_honest_units_and_a_55e83a59">Raw SpO2, unidades honestas y una aplicación más ligera</string>

--- a/android/app/src/main/res/values-es/strings.xml
+++ b/android/app/src/main/res/values-es/strings.xml
@@ -1004,6 +1004,7 @@
     <string name="l10n_app_changelog_personal_vital_baselines_mac_analytics_parity_744972d1">Bases vitales personales + Paridad analítica de Mac</string>
     <string name="l10n_app_changelog_polish_matched_to_the_iphone_mac_cc34126b">Polaco - compatible con el diseño iPhone &amp;amp; Mac</string>
     <string name="l10n_app_changelog_german_french_spanish_pull_to_sync_1109bda2">Alemán, francés y español, deslizar para sincronizar en Today y una oleada de mejoras</string>
+    <string name="l10n_app_changelog_hrv_accuracy_fix_oura_sleep_and_motion_4ed31e39">Corrección de HRV, sueño y movimiento de Oura, más datos 5/MG y una sincronización que puedes detener</string>
     <string name="l10n_app_changelog_optimal_strain_alerts_faster_history_sync_6488a27a">Avisos de esfuerzo óptimo, sincronización del historial más rápida y una oleada de correcciones de precisión</string>
     <string name="l10n_app_changelog_power_saving_that_protects_your_strap_57a32503">Ahorro de energía que protege su correa, un entrenador con Géminis en Android, y detalles métricos más ricos</string>
     <string name="l10n_app_changelog_raw_spo_honest_units_and_a_55e83a59">Raw SpO2, unidades honestas y una aplicación más ligera</string>

--- a/android/app/src/main/res/values-fr/strings.xml
+++ b/android/app/src/main/res/values-fr/strings.xml
@@ -1004,7 +1004,7 @@
     <string name="l10n_app_changelog_personal_vital_baselines_mac_analytics_parity_744972d1">Bases vitales personnelles + parité d\'analyse Mac</string>
     <string name="l10n_app_changelog_polish_matched_to_the_iphone_mac_cc34126b">Polonais - adapté au design iPhone &amp; Mac</string>
     <string name="l10n_app_changelog_german_french_spanish_pull_to_sync_1109bda2">Allemand, français et espagnol, glisser pour synchroniser sur Today et une vague d\'améliorations</string>
-    <string name="l10n_app_changelog_hrv_accuracy_fix_oura_sleep_and_motion_4ed31e39">Correction de la VFC, sommeil et mouvement Oura, plus de données 5/MG et une synchronisation interruptible</string>
+    <string name="l10n_app_changelog_hrv_accuracy_fix_oura_sleep_and_4ed31e39">Correction de la VFC, sommeil et mouvement Oura, plus de données 5/MG et une synchronisation interruptible</string>
     <string name="l10n_app_changelog_optimal_strain_alerts_faster_history_sync_6488a27a">Alertes d\'effort optimal, synchronisation de l\'historique plus rapide et une vague de corrections de précision</string>
     <string name="l10n_app_changelog_power_saving_that_protects_your_strap_57a32503">Économie d\'énergie qui protège votre sangle, un entraîneur Gemini sur Android, et plus riche détail métrique</string>
     <string name="l10n_app_changelog_raw_spo_honest_units_and_a_55e83a59">Raw SpO2, des unités honnêtes, et une application plus légère</string>

--- a/android/app/src/main/res/values-fr/strings.xml
+++ b/android/app/src/main/res/values-fr/strings.xml
@@ -1004,6 +1004,7 @@
     <string name="l10n_app_changelog_personal_vital_baselines_mac_analytics_parity_744972d1">Bases vitales personnelles + parité d\'analyse Mac</string>
     <string name="l10n_app_changelog_polish_matched_to_the_iphone_mac_cc34126b">Polonais - adapté au design iPhone &amp; Mac</string>
     <string name="l10n_app_changelog_german_french_spanish_pull_to_sync_1109bda2">Allemand, français et espagnol, glisser pour synchroniser sur Today et une vague d\'améliorations</string>
+    <string name="l10n_app_changelog_hrv_accuracy_fix_oura_sleep_and_motion_4ed31e39">Correction de la VFC, sommeil et mouvement Oura, plus de données 5/MG et une synchronisation interruptible</string>
     <string name="l10n_app_changelog_optimal_strain_alerts_faster_history_sync_6488a27a">Alertes d\'effort optimal, synchronisation de l\'historique plus rapide et une vague de corrections de précision</string>
     <string name="l10n_app_changelog_power_saving_that_protects_your_strap_57a32503">Économie d\'énergie qui protège votre sangle, un entraîneur Gemini sur Android, et plus riche détail métrique</string>
     <string name="l10n_app_changelog_raw_spo_honest_units_and_a_55e83a59">Raw SpO2, des unités honnêtes, et une application plus légère</string>

--- a/android/app/src/main/res/values-pt-rPT/strings.xml
+++ b/android/app/src/main/res/values-pt-rPT/strings.xml
@@ -1145,6 +1145,7 @@
     <string name="l10n_app_changelog_personal_vital_baselines_mac_analytics_parity_744972d1">Linhas de base vitais pessoais + paridade analítica Mac</string>
     <string name="l10n_app_changelog_polish_matched_to_the_iphone_mac_cc34126b">Polaco - compatível com o design do iPhone e Mac</string>
     <string name="l10n_app_changelog_german_french_spanish_pull_to_sync_1109bda2">Alemão, francês e espanhol, pull-to-sync no Today e uma onda de polimento</string>
+    <string name="l10n_app_changelog_hrv_accuracy_fix_oura_sleep_and_motion_4ed31e39">Correção da VFC, sono e movimento Oura, mais dados 5/MG e uma sincronização que podes parar</string>
     <string name="l10n_app_changelog_optimal_strain_alerts_faster_history_sync_6488a27a">Alertas de tensão ideal, sincronização mais rápida do histórico e uma onda de correções de precisão</string>
     <string name="l10n_app_changelog_power_saving_that_protects_your_strap_57a32503">Economia de energia que protege a tua bracelete, treinador com tecnologia Gemini no Android e detalhes métricos mais ricos</string>
     <string name="l10n_app_changelog_raw_spo_honest_units_and_a_55e83a59">SpO₂ bruto, unidades honestas e uma aplicação mais leve</string>

--- a/android/app/src/main/res/values-pt-rPT/strings.xml
+++ b/android/app/src/main/res/values-pt-rPT/strings.xml
@@ -1145,7 +1145,7 @@
     <string name="l10n_app_changelog_personal_vital_baselines_mac_analytics_parity_744972d1">Linhas de base vitais pessoais + paridade analítica Mac</string>
     <string name="l10n_app_changelog_polish_matched_to_the_iphone_mac_cc34126b">Polaco - compatível com o design do iPhone e Mac</string>
     <string name="l10n_app_changelog_german_french_spanish_pull_to_sync_1109bda2">Alemão, francês e espanhol, pull-to-sync no Today e uma onda de polimento</string>
-    <string name="l10n_app_changelog_hrv_accuracy_fix_oura_sleep_and_motion_4ed31e39">Correção da VFC, sono e movimento Oura, mais dados 5/MG e uma sincronização que podes parar</string>
+    <string name="l10n_app_changelog_hrv_accuracy_fix_oura_sleep_and_4ed31e39">Correção da VFC, sono e movimento Oura, mais dados 5/MG e uma sincronização que podes parar</string>
     <string name="l10n_app_changelog_optimal_strain_alerts_faster_history_sync_6488a27a">Alertas de tensão ideal, sincronização mais rápida do histórico e uma onda de correções de precisão</string>
     <string name="l10n_app_changelog_power_saving_that_protects_your_strap_57a32503">Economia de energia que protege a tua bracelete, treinador com tecnologia Gemini no Android e detalhes métricos mais ricos</string>
     <string name="l10n_app_changelog_raw_spo_honest_units_and_a_55e83a59">SpO₂ bruto, unidades honestas e uma aplicação mais leve</string>

--- a/android/app/src/main/res/values-zh/strings.xml
+++ b/android/app/src/main/res/values-zh/strings.xml
@@ -969,6 +969,7 @@
     <string name="l10n_add_device_wizard_not_now_e4571490">暂不</string>
     <string name="l10n_add_device_wizard_take_over_2c7f5505">接管</string>
     <string name="l10n_add_device_wizard_take_over_this_ring_cc79ef5e">接管这枚智能戒指吗？</string>
+    <string name="l10n_app_changelog_hrv_accuracy_fix_oura_sleep_and_motion_4ed31e39">HRV 修正、Oura 睡眠与运动、更丰富的 5/MG 解码，以及可中断的同步</string>
     <string name="l10n_app_changelog_5_mg_bonding_on_android_health_c94c46ac">Android 版 5.0/MG 配对绑定 + 健康监测器修复</string>
     <string name="l10n_app_changelog_a_beautiful_new_look_aa8c910c">焕然一新的绝美外观设计</string>
     <string name="l10n_app_changelog_a_big_bug_fix_sweep_with_65335764">大规模 Bug 修复，并全新引入“测试中心”用于排查问题</string>

--- a/android/app/src/main/res/values-zh/strings.xml
+++ b/android/app/src/main/res/values-zh/strings.xml
@@ -969,7 +969,7 @@
     <string name="l10n_add_device_wizard_not_now_e4571490">暂不</string>
     <string name="l10n_add_device_wizard_take_over_2c7f5505">接管</string>
     <string name="l10n_add_device_wizard_take_over_this_ring_cc79ef5e">接管这枚智能戒指吗？</string>
-    <string name="l10n_app_changelog_hrv_accuracy_fix_oura_sleep_and_motion_4ed31e39">HRV 修正、Oura 睡眠与运动、更丰富的 5/MG 解码，以及可中断的同步</string>
+    <string name="l10n_app_changelog_hrv_accuracy_fix_oura_sleep_and_4ed31e39">HRV 修正、Oura 睡眠与运动、更丰富的 5/MG 解码，以及可中断的同步</string>
     <string name="l10n_app_changelog_5_mg_bonding_on_android_health_c94c46ac">Android 版 5.0/MG 配对绑定 + 健康监测器修复</string>
     <string name="l10n_app_changelog_a_beautiful_new_look_aa8c910c">焕然一新的绝美外观设计</string>
     <string name="l10n_app_changelog_a_big_bug_fix_sweep_with_65335764">大规模 Bug 修复，并全新引入“测试中心”用于排查问题</string>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -1173,7 +1173,7 @@
     <string name="l10n_app_changelog_personal_vital_baselines_mac_analytics_parity_744972d1">Personal vital baselines + Mac analytics parity</string>
     <string name="l10n_app_changelog_polish_matched_to_the_iphone_mac_cc34126b">Polish - matched to the iPhone &amp; Mac design</string>
     <string name="l10n_app_changelog_german_french_spanish_pull_to_sync_1109bda2">German, French &amp; Spanish, pull-to-sync on Today, and a wave of polish</string>
-    <string name="l10n_app_changelog_hrv_accuracy_fix_oura_sleep_and_motion_4ed31e39">HRV accuracy fix, Oura sleep and motion, richer 5/MG decoding, and a stoppable sync</string>
+    <string name="l10n_app_changelog_hrv_accuracy_fix_oura_sleep_and_4ed31e39">HRV accuracy fix, Oura sleep and motion, richer 5/MG decoding, and a stoppable sync</string>
     <string name="l10n_app_changelog_optimal_strain_alerts_faster_history_sync_6488a27a">Optimal-strain alerts, faster history sync, and a wave of accuracy fixes</string>
     <string name="l10n_app_changelog_power_saving_that_protects_your_strap_57a32503">Power saving that protects your strap, a Gemini-powered coach on Android, and richer metric detail</string>
     <string name="l10n_app_changelog_raw_spo_honest_units_and_a_55e83a59">Raw SpO₂, honest units, and a lighter app</string>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -1173,6 +1173,7 @@
     <string name="l10n_app_changelog_personal_vital_baselines_mac_analytics_parity_744972d1">Personal vital baselines + Mac analytics parity</string>
     <string name="l10n_app_changelog_polish_matched_to_the_iphone_mac_cc34126b">Polish - matched to the iPhone &amp; Mac design</string>
     <string name="l10n_app_changelog_german_french_spanish_pull_to_sync_1109bda2">German, French &amp; Spanish, pull-to-sync on Today, and a wave of polish</string>
+    <string name="l10n_app_changelog_hrv_accuracy_fix_oura_sleep_and_motion_4ed31e39">HRV accuracy fix, Oura sleep and motion, richer 5/MG decoding, and a stoppable sync</string>
     <string name="l10n_app_changelog_optimal_strain_alerts_faster_history_sync_6488a27a">Optimal-strain alerts, faster history sync, and a wave of accuracy fixes</string>
     <string name="l10n_app_changelog_power_saving_that_protects_your_strap_57a32503">Power saving that protects your strap, a Gemini-powered coach on Android, and richer metric detail</string>
     <string name="l10n_app_changelog_raw_spo_honest_units_and_a_55e83a59">Raw SpO₂, honest units, and a lighter app</string>


### PR DESCRIPTION
From a user report of NOOP at **51.75% of battery over 6h31m**, confirmed by a second user. Two safe
changes plus the release-hygiene fix that was blocking any Android PR from going green.

## 1. Log how long a link was held

Reaching `STATE_CONNECTED` zeroes `failedReconnectAttempts`, and that counter is the **only** input to
`scanModeForReconnectAttempts`. So a strap that connects and drops repeatedly — edge of range, phone
in another room — never accumulates a streak, and every rescan stays on `SCAN_MODE_LOW_LATENCY`,
which is exactly what the PR #588 backoff exists to escape. The #982 guard covers the *never-bonded*
variant of that loop; a bonded-but-short-lived link is not covered.

**That is a hypothesis, not a measurement**, so this changes no behaviour. It makes the pattern
readable in an ordinary strap log:

```
Disconnected (status=19); rescanning in 3s (attempt 1, held 24s)
```

A run of drops that all say `attempt 1` with a short `held` **is** the bug, with no instrumentation.
Attempts climbing normally rules it out and points elsewhere.

Snapshotted and cleared at the top of `handleDisconnect`: a stale `linkUpSinceMs` surviving into a
drop that never reached `STATE_CONNECTED` would report a hold time for a link that was never up — the
diagnostic inventing the evidence it exists to find.

## 2. Stop re-asking the battery policies every second

The FGS collector ticks at live-HR cadence (~1/s while connected) and ran `onBatteryUpdate` **and**
`onCriticalBattery` on every tick. Both early-exit on their own persisted once-per-crossing gates —
but not before each does a SharedPreferences read, a `areNotificationsEnabled()` binder call and an
`ensureChannel()`. Roughly **two binder calls and half a dozen prefs reads every second**, to
re-answer a question the strap only changes every ~8 minutes.

Now gated on `(SoC, charging)` changing — the same shape as the `lastRuntimeEvalPct` gate two lines
below. Gated on the **pair**, not the percentage: `onBatteryUpdate` owns the charge-complete and
re-arm transitions, which key off `charging`.

**One behavioural delta**, stated rather than papered over: enabling the battery-alerts pref while
already past a threshold now waits for the next `(pct, charging)` change instead of firing within a
second — up to one battery-report cycle.

## 3. Localize the 9.2.0 What's New title (unbreaks main)

The 9.2.0 release left `main` failing i18n-coverage. `appchangelog-gen` writes the title as a raw
Kotlin literal; extraction into a string resource is a separate step that normally happens in the PR
flow where the gate catches it, and `fork-release.yml` commits straight to main.

That also means **the 9.2.0 What's New title shipped untranslated on Android** — the only one of 240+
release entries to do so. Resource added under the existing convention
(`l10n_app_changelog_<slug>_<sha1(value)[:8]>`, confirmed by reproducing `6488a27a` from the 9.1.0
title), translated in all five locale files. `values-zh` closed rather than its allowance raised: the
ratchet flagged 44 against 43, and its own header says ratchet **down, never up**.

This will recur on every release until the extraction runs inside `fork-release.yml`. Worth an issue.

## Ruled out while looking

All already defended, worth recording so nobody re-treads it: the FGS notification dedupes on a
`connected|backfilling|recovery|battery` key (live HR is not in it); the Glance widget push has a
cheap non-suspending `PushGate`; the offload chunk counter republishes every ~10 chunks; connection
priority does not escalate for live HR by default; reconnect backoff is capped 3s→60s;
`IllnessWatch.evaluate` is bounded to ≤31 days of means.

## Not done, deliberately

Making the reconnect streak survive a short-lived connection — the actual suspected cause. That reset
exists to stop a flapping co-resident band from freezing the link (#173 regression: a climbing counter
escalated to PASSIVE `autoConnect` and stalled). Changing it blind, on an unverified hypothesis, on
the path that keeps the strap connected at all, trades a battery complaint for a strap that does not
come back. The hold-time log is what tells us whether it is worth doing.

No CI job compiles Kotlin, so every symbol was checked against its declaration by hand.
