### PR TITLE
Fix iOS widgets showing only sample data

### DIFF
--- a/.github/workflows/fork-release.yml
+++ b/.github/workflows/fork-release.yml
@@ -249,7 +249,7 @@ jobs:
           -derivedDataPath build/dd
           CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY=""
           build
-      - name: Package unsigned .ipa (strip embedded watch app, retain widget extension) + attach
+      - name: Package sideload .ipa (strip watch, preserve app/widget capabilities) + attach
         env:
           GH_TOKEN: ${{ github.token }}
           VER: ${{ needs.bump.outputs.ver }}
@@ -263,6 +263,10 @@ jobs:
           test -d "$APP/PlugIns/NOOPWidgets.appex" || {
             echo "NOOPWidgets.appex missing from iOS build"; exit 1;
           }
+          # The device build is intentionally produced without an Apple identity. Add an ad-hoc
+          # capability template after the final bundle mutation so AltStore/SideStore can discover,
+          # provision and re-sign the App Group shared by the app and widget.
+          Tools/prepare-ios-sideload-app.sh "$APP"
           rm -rf Payload && mkdir Payload && cp -R "$APP" Payload/
           zip -qr "NOOP-ios-unsigned-v${VER}.ipa" Payload
           gh release upload "${{ needs.bump.outputs.tag }}" "NOOP-ios-unsigned-v${VER}.ipa" --repo "$GITHUB_REPOSITORY" --clobber

--- a/.github/workflows/fork-testing-build.yml
+++ b/.github/workflows/fork-testing-build.yml
@@ -146,7 +146,7 @@ jobs:
           -derivedDataPath build/dd
           CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY=""
           build
-      - name: Package unsigned .ipa (strip embedded watch app, retain widget extension) + attach
+      - name: Package sideload .ipa (strip watch, preserve app/widget capabilities) + attach
         env:
           GH_TOKEN: ${{ github.token }}
           VER: ${{ needs.meta.outputs.ver }}
@@ -160,6 +160,9 @@ jobs:
           test -d "$APP/PlugIns/NOOPWidgets.appex" || {
             echo "NOOPWidgets.appex missing from iOS build"; exit 1;
           }
+          # Preserve the requested App Group in a replaceable ad-hoc signature so the sideloader
+          # provisions the shared container instead of treating both executables as entitlement-free.
+          Tools/prepare-ios-sideload-app.sh "$APP"
           rm -rf Payload && mkdir Payload && cp -R "$APP" Payload/
           zip -qr "NOOP-ios-unsigned-v${VER}.ipa" Payload
           gh release upload "${{ needs.meta.outputs.tag }}" "NOOP-ios-unsigned-v${VER}.ipa" --repo "$GITHUB_REPOSITORY" --clobber

--- a/StrandTests/WidgetSnapshotTests.swift
+++ b/StrandTests/WidgetSnapshotTests.swift
@@ -1,0 +1,56 @@
+import XCTest
+
+final class WidgetSnapshotTests: XCTestCase {
+    func testAltStoreProvisionedGroupWinsOverBuildTimeIdentifier() {
+        let configured = "group.com.noopapp.noop.staging"
+        let remapped = configured + ".TEAM123456"
+
+        XCTAssertEqual(
+            WidgetSnapshot.resolveSuiteName(infoDictionary: [
+                "AppGroupIdentifier": configured,
+                "ALTAppGroups": [remapped]
+            ]),
+            remapped
+        )
+    }
+
+    func testXcodeBuildFallsBackToConfiguredGroup() {
+        XCTAssertEqual(
+            WidgetSnapshot.resolveSuiteName(infoDictionary: [
+                "AppGroupIdentifier": "group.example.noop"
+            ]),
+            "group.example.noop"
+        )
+    }
+
+    func testUnrelatedAltStoreGroupsDoNotOverrideConfiguredGroup() {
+        XCTAssertEqual(
+            WidgetSnapshot.resolveSuiteName(infoDictionary: [
+                "AppGroupIdentifier": "group.example.noop",
+                "ALTAppGroups": [
+                    "group.example.first",
+                    "group.example.second"
+                ]
+            ]),
+            "group.example.noop"
+        )
+    }
+
+    func testSingleProvisionedGroupIsUsableWithoutConfiguredIdentifier() {
+        XCTAssertEqual(
+            WidgetSnapshot.resolveSuiteName(infoDictionary: [
+                "ALTAppGroups": ["group.example.noop.TEAM123456"]
+            ]),
+            "group.example.noop.TEAM123456"
+        )
+    }
+
+    func testRuntimeUnavailableSnapshotContainsNoDemoValues() {
+        let snapshot = WidgetSnapshot.unavailable
+
+        XCTAssertNil(snapshot.recovery)
+        XCTAssertNil(snapshot.bpm)
+        XCTAssertNil(snapshot.batteryPct)
+        XCTAssertFalse(snapshot.bonded)
+    }
+}

--- a/StrandiOSShared/WidgetSnapshot.swift
+++ b/StrandiOSShared/WidgetSnapshot.swift
@@ -39,10 +39,40 @@ public struct WidgetSnapshot: Codable, Equatable {
     /// key is somehow absent (each process reads its OWN bundle, so the app and the widget extension
     /// each carry the key in their generated Info.plist).
     public static let suiteName: String = {
-        Bundle.main.object(forInfoDictionaryKey: "AppGroupIdentifier") as? String
-            ?? "group.com.noopapp.noop"
+        resolveSuiteName(infoDictionary: Bundle.main.infoDictionary ?? [:])
     }()
     public static let storageKey = "noop.widget.snapshot"
+
+    /// Resolve the App Group the current signature actually grants.
+    ///
+    /// AltStore / SideStore must make every App Group unique to the user's signing team. During
+    /// re-signing they append the team identifier to the group requested by the downloaded app and
+    /// publish the resulting, provisioned identifiers in `ALTAppGroups` in each bundle's Info.plist.
+    /// Reading only the build-time `AppGroupIdentifier` therefore points at an unprovisioned container
+    /// in a sideloaded build, even though the host app and widget extension were both signed correctly.
+    ///
+    /// Normal Xcode builds don't carry `ALTAppGroups`, so they keep using `AppGroupIdentifier`.
+    static func resolveSuiteName(infoDictionary: [String: Any]) -> String {
+        let configured = (infoDictionary["AppGroupIdentifier"] as? String)?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        let altGroups = (infoDictionary["ALTAppGroups"] as? [String])?
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { $0.hasPrefix("group.") && !$0.isEmpty } ?? []
+
+        if let configured, !configured.isEmpty,
+           let provisioned = altGroups.first(where: {
+               $0 == configured || $0.hasPrefix(configured + ".")
+           }) {
+            return provisioned
+        }
+        if altGroups.count == 1, let provisioned = altGroups.first {
+            return provisioned
+        }
+        if let configured, !configured.isEmpty {
+            return configured
+        }
+        return "group.com.noopapp.noop"
+    }
 
     /// Debug-only canary: trips on the first run after a misprovisioning so the silent no-op gets
     /// caught immediately rather than masquerading as "widget shows nothing yet." Release builds do
@@ -55,6 +85,12 @@ public struct WidgetSnapshot: Codable, Equatable {
     public static var placeholder: WidgetSnapshot {
         WidgetSnapshot(recovery: 72, bpm: 58, batteryPct: 84, bonded: true, updated: Date(),
                        effort: 8, rest: 81, hrv: 64, restingHr: 52)
+    }
+
+    /// Honest runtime state when the app has not published a readable snapshot yet. Unlike
+    /// `placeholder`, this is user-visible and must never imply that sample data is real.
+    static var unavailable: WidgetSnapshot {
+        WidgetSnapshot(recovery: nil, bpm: nil, batteryPct: nil, bonded: false, updated: .distantPast)
     }
 
     /// Read the last-published snapshot from the shared suite, if any.

--- a/StrandiOSWidgets/NOOPWidget.swift
+++ b/StrandiOSWidgets/NOOPWidget.swift
@@ -14,11 +14,14 @@ struct NOOPProvider: TimelineProvider {
     }
 
     func getSnapshot(in context: Context, completion: @escaping (NOOPEntry) -> Void) {
-        completion(NOOPEntry(date: Date(), snapshot: WidgetSnapshot.load() ?? .placeholder))
+        let fallback: WidgetSnapshot = context.isPreview ? .placeholder : .unavailable
+        completion(NOOPEntry(date: Date(), snapshot: WidgetSnapshot.load() ?? fallback))
     }
 
     func getTimeline(in context: Context, completion: @escaping (Timeline<NOOPEntry>) -> Void) {
-        let snap = WidgetSnapshot.load() ?? .placeholder
+        // Gallery previews use `placeholder(in:)` / getSnapshot's preview branch. A real timeline
+        // with no shared snapshot must show missing data honestly, never plausible sample numbers.
+        let snap = WidgetSnapshot.load() ?? .unavailable
         // Refresh roughly every 15 minutes; the app also forces a reload when it publishes fresh data.
         let next = Calendar.current.date(byAdding: .minute, value: 15, to: Date()) ?? Date().addingTimeInterval(900)
         completion(Timeline(entries: [NOOPEntry(date: Date(), snapshot: snap)], policy: .after(next)))

--- a/Tools/build-v7-artifacts.sh
+++ b/Tools/build-v7-artifacts.sh
@@ -75,11 +75,13 @@ if [ -d "$IOSAPP" ]; then
   # complication under a free Apple ID is an Apple limitation that crashes AltStore / SideStore mid-install
   # with InvalidCompanionAppBundleIdentifier (the v7.2.0 regression). Build-from-source still ships the watch
   # ($IOSAPP, already anonymized + leak-checked, is untouched); only this staged copy is thinned. The iOS app
-  # has no runtime dependency on the watch bundle and the IPA is unsigned, so there is no signature to break.
+  # has no runtime dependency on the watch bundle. The replaceable capability-template signature is
+  # deliberately applied only after this final bundle mutation.
   if [ -d "$STAGE/Payload/NOOP.app/Watch" ]; then
     rm -rf "$STAGE/Payload/NOOP.app/Watch"
     echo "  ✓ stripped embedded watch app from the sideload IPA (free-Apple-ID install fix; #751 mp3geek)"
   fi
+  Tools/prepare-ios-sideload-app.sh "$STAGE/Payload/NOOP.app" 2>&1 | sed 's/^/  /'
   ( cd "$STAGE" && zip -qry "$OLDPWD/$DIST/NOOP-v$VER.ipa" Payload )
   [ -f "$DIST/NOOP-v$VER.ipa" ] && ok_ios=1 && echo "  ✓ dist/NOOP-v$VER.ipa ($(( $(stat -f '%z' "$DIST/NOOP-v$VER.ipa")/1024/1024 ))MB)"
 else echo "  ✗ iOS build FAILED"; grep -E 'error:' /tmp/v7a-ios.log | sed 's#.*Strand/##' | sort -u | head; fi

--- a/Tools/prepare-ios-sideload-app.sh
+++ b/Tools/prepare-ios-sideload-app.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+#
+# Embed discoverable entitlements in an otherwise anonymously-built iOS app before packaging it
+# for AltStore / SideStore. The ad-hoc signature is not an Apple distribution signature and is
+# replaced by the user's sideloader. Its purpose is to preserve the capability request inside each
+# Mach-O so AltSign can provision the matching App IDs and shared App Group before re-signing.
+#
+# Usage:
+#   Tools/prepare-ios-sideload-app.sh path/to/NOOP.app
+
+set -euo pipefail
+
+APP="${1:?usage: $0 path/to/NOOP.app}"
+[ -d "$APP" ] || { echo "no such app bundle: $APP" >&2; exit 1; }
+
+WIDGET="$APP/PlugIns/NOOPWidgets.appex"
+[ -d "$WIDGET" ] || { echo "widget extension missing: $WIDGET" >&2; exit 1; }
+
+APP_INFO="$APP/Info.plist"
+WIDGET_INFO="$WIDGET/Info.plist"
+APP_GROUP=$(/usr/libexec/PlistBuddy -c 'Print :AppGroupIdentifier' "$APP_INFO")
+WIDGET_GROUP=$(/usr/libexec/PlistBuddy -c 'Print :AppGroupIdentifier' "$WIDGET_INFO")
+
+[ -n "$APP_GROUP" ] || { echo "app AppGroupIdentifier is empty" >&2; exit 1; }
+[ "$APP_GROUP" = "$WIDGET_GROUP" ] || {
+  echo "App Group mismatch: app=$APP_GROUP widget=$WIDGET_GROUP" >&2
+  exit 1
+}
+
+ENTITLEMENTS_DIR=$(mktemp -d /tmp/noop-sideload-entitlements.XXXXXX)
+cleanup() {
+  if [ -n "${ENTITLEMENTS_DIR:-}" ] && [ -d "$ENTITLEMENTS_DIR" ]; then
+    rm -rf "$ENTITLEMENTS_DIR"
+  fi
+}
+trap cleanup EXIT
+
+APP_ENTITLEMENTS="$ENTITLEMENTS_DIR/app.plist"
+WIDGET_ENTITLEMENTS="$ENTITLEMENTS_DIR/widget.plist"
+
+plutil -create xml1 "$APP_ENTITLEMENTS"
+plutil -insert 'com\.apple\.developer\.healthkit' -bool YES "$APP_ENTITLEMENTS"
+plutil -insert 'com\.apple\.developer\.healthkit\.access' -array "$APP_ENTITLEMENTS"
+plutil -insert 'com\.apple\.security\.application-groups' -array "$APP_ENTITLEMENTS"
+plutil -insert 'com\.apple\.security\.application-groups.0' -string "$APP_GROUP" "$APP_ENTITLEMENTS"
+
+plutil -create xml1 "$WIDGET_ENTITLEMENTS"
+plutil -insert 'com\.apple\.security\.application-groups' -array "$WIDGET_ENTITLEMENTS"
+plutil -insert 'com\.apple\.security\.application-groups.0' -string "$APP_GROUP" "$WIDGET_ENTITLEMENTS"
+
+# First sign every nested framework/bundle so the outer seal can be verified. Then replace the
+# extension and app signatures with their target-specific entitlements, signing from the inside out.
+codesign --force --deep --sign - "$APP"
+codesign --force --sign - --entitlements "$WIDGET_ENTITLEMENTS" "$WIDGET"
+codesign --force --sign - --entitlements "$APP_ENTITLEMENTS" "$APP"
+
+SIGNED_APP_ENTITLEMENTS="$ENTITLEMENTS_DIR/signed-app.plist"
+SIGNED_WIDGET_ENTITLEMENTS="$ENTITLEMENTS_DIR/signed-widget.plist"
+codesign -d --entitlements :- "$APP" 2>/dev/null > "$SIGNED_APP_ENTITLEMENTS"
+codesign -d --entitlements :- "$WIDGET" 2>/dev/null > "$SIGNED_WIDGET_ENTITLEMENTS"
+
+SIGNED_APP_GROUP=$(/usr/libexec/PlistBuddy \
+  -c 'Print :com.apple.security.application-groups:0' "$SIGNED_APP_ENTITLEMENTS")
+SIGNED_WIDGET_GROUP=$(/usr/libexec/PlistBuddy \
+  -c 'Print :com.apple.security.application-groups:0' "$SIGNED_WIDGET_ENTITLEMENTS")
+
+[ "$SIGNED_APP_GROUP" = "$APP_GROUP" ] || {
+  echo "signed app lost App Group entitlement" >&2
+  exit 1
+}
+[ "$SIGNED_WIDGET_GROUP" = "$APP_GROUP" ] || {
+  echo "signed widget lost App Group entitlement" >&2
+  exit 1
+}
+
+codesign --verify --deep --strict "$APP"
+echo "✓ sideload capability template embedded for app + widget: $APP_GROUP"

--- a/altstore-source.json
+++ b/altstore-source.json
@@ -1318,7 +1318,8 @@
       ],
       "appPermissions": {
         "entitlements": [
-          "com.apple.developer.healthkit"
+          "com.apple.developer.healthkit",
+          "com.apple.security.application-groups"
         ],
         "privacy": {
           "NSBluetoothAlwaysUsageDescription": "NOOP connects directly to your WHOOP strap over Bluetooth to read heart rate, R-R intervals, battery, and sensor data locally on your iPhone. Nothing leaves your device.",

--- a/docs/IOS.md
+++ b/docs/IOS.md
@@ -3,17 +3,20 @@
 > **iOS is now a direct download (v1.96).** Grab **`NOOP-v<version>-ios.ipa`** from the
 > [Releases](https://github.com/ryanbr/noop/releases) page and install it with **AltStore** or **SideStore** — see
 > **[Install (sideload)](#install-sideload)** below. No Mac, no Xcode, no App Store, and no Apple
-> Developer account needed — **and NOOP stays anonymous**, because the `.ipa` we ship is *unsigned*
-> and **you** sign it on your own iPhone with your own free Apple ID. The app target (`NOOPiOS` +
+> Developer account needed — **and NOOP stays anonymous**, because the `.ipa` has no Apple developer
+> signature and **you** sign it on your own iPhone with your own free Apple ID. It carries only a
+> replaceable ad-hoc capability template so the sideloader can provision HealthKit and the App Group
+> shared with the widget. The app target (`NOOPiOS` +
 > `NOOPiOSWidgets`) also still builds from source in Xcode if you'd rather (**[Build from source](#build-from-source)**).
 > A CI job ([`app-build.yml`](../.github/workflows/app-build.yml)) compiles both the macOS and iOS
 > targets on every change so iOS can't silently break.
 
 ## Install (sideload)
 
-The `.ipa` is **unsigned on purpose** — that's what keeps the project anonymous. iOS won't run an
-unsigned app, so a free sideloading tool signs it **on your device, with your own free Apple ID**.
-Nothing about this touches NOOP's identity or Apple's servers on our side.
+The `.ipa` is **not signed by an Apple developer identity** — that's what keeps the project
+anonymous. Its replaceable ad-hoc signature only describes the capabilities AltStore/SideStore must
+provision; iOS won't run it until the sideloader signs it **on your device, with your own free Apple
+ID**. Nothing about this touches NOOP's identity or Apple's servers on our side.
 
 1. **Install a sideloader on your computer** — [AltStore](https://altstore.io) or
    [SideStore](https://sidestore.io) (both free). Follow their one-time setup (it installs a helper +
@@ -47,15 +50,12 @@ hunting for the `.ipa` each time.
 > - **7-day expiry.** Apps signed with a *free* Apple ID stop launching after 7 days and need
 >   re-signing. **AltStore/SideStore refresh this automatically** in the background — keep the
 >   sideloader installed and NOOP keeps working.
-> - **Some Apple-only features may be limited.** A free signing identity can't grant certain Apple
->   entitlements, so **Apple Health (HealthKit) read/write and the Live Activity / lock-screen
->   widgets may not work** on a free-signed sideload. The core app — pairing your strap, live HR,
->   recovery/strain/sleep, history, the AI Coach, everything on-device — works regardless. This is an
->   Apple signing constraint, not a NOOP limitation, and it's why a HealthKit toggle can appear to do
->   nothing on a sideloaded build. The release IPA retains `NOOPWidgets.appex`, so AltStore/Sideloadly
->   must provision one additional app extension for widgets and Live Activities; removing app extensions
->   while signing disables those surfaces. Building from source with your own Apple ID in Xcode and
->   selecting your Team for both targets grants these entitlements normally.
+> - **Apple-only features require their extensions and capabilities.** Keep the
+>   `NOOPWidgets.appex` extension enabled when AltStore/SideStore asks: it renders the Home/Lock-Screen
+>   widgets and Live Activities and shares data through the provisioned App Group. Removing app
+>   extensions while signing disables those surfaces. Other signing tools must likewise preserve and
+>   provision the requested HealthKit and App Group entitlements. Building from source with your own
+>   Apple ID in Xcode and selecting your Team for both targets configures them automatically.
 
 iOS shares the cross-platform Swift packages with macOS, so the number-crunching (recovery, strain,
 HRV, sleep) is the **same code** and produces the same results. iOS is newer and less battle-tested

--- a/project.yml
+++ b/project.yml
@@ -154,6 +154,9 @@ targets:
     deploymentTarget: "13.0"
     sources:
       - StrandTests
+      # Compile the exact cross-target snapshot source into the test bundle so the AltStore App Group
+      # resolver is covered without adding this iOS/widget-only type to the macOS application module.
+      - StrandiOSShared/WidgetSnapshot.swift
     # Same wrapper as the app target, so the OURA_CLOUD_IMPORT-gated Oura tests compile exactly
     # when the app's Oura lane does (flag + creds both come from the untracked OuraSecrets.xcconfig).
     configFiles:


### PR DESCRIPTION
## What this PR does

Fixes iOS Home Screen widgets showing the same sample values — 72% Charge, 58 bpm, and 84% battery — for every user instead of the snapshot published by the app.

The issue had three connected causes:

1. The sideload IPA was built with code signing disabled, so its app and widget Mach-O files did not retain the App Group capability request that AltStore/SideStore use while provisioning and re-signing.
2. AltStore/SideStore make App Groups unique to the user's signing team and expose the provisioned identifiers through `ALTAppGroups`, while NOOP continued opening only its build-time `AppGroupIdentifier`.
3. When the widget could not read the shared snapshot, its real timeline fell back to the gallery placeholder, making sample data look genuine.

This change:

- embeds a replaceable ad-hoc capability template in the app and widget before packaging so sideloaders can provision their shared App Group;
- resolves the App Group from `ALTAppGroups` in sideloaded builds while preserving the normal Xcode-build path;
- limits sample values to WidgetKit previews and shows unavailable values when no real snapshot exists;
- declares the App Group in the AltStore source metadata;
- covers the remapped-group and honest-fallback behavior with focused tests; and
- updates the sideload documentation to describe the actual signing flow.

Dynamic Island and Lock Screen Live Activities were unaffected because they receive ActivityKit state directly rather than reading this WidgetKit snapshot path.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [x] Documentation
- [x] CI / tooling

## How it was tested

- Generated the Xcode project from `project.yml`.
- Built, installed, and launched the `NOOPiOS` Release scheme on an iPhone 16e simulator running iOS 26.3.
- Added the Home Screen widget and confirmed it rendered the simulator's current 49% Charge snapshot instead of the 72% placeholder.
- Ran `StrandTests/WidgetSnapshotTests`: 5 tests passed with 0 failures.
- Applied the packaging helper to the existing unsigned release IPA and confirmed the app and widget contained the same `group.com.noopapp.noop.staging` entitlement.
- Ran `codesign --verify --deep --strict` successfully.
- Passed `git diff --check`, shell syntax checks, JSON validation, and workflow YAML parsing.

A fresh AltStore/SideStore installation on a physical iPhone remains the final device-level validation for the complete third-party re-signing path. This PR does not change BLE behavior.

## Checklist

- [x] Swift package tests are not required; no `Packages/**` files changed
- [x] Android tests are not required; no Android files changed
- [x] No new build warnings introduced by this change
- [x] No visual styling was changed; the widget continues using the existing `StrandDesign` implementation
- [x] No protocol or BLE frame changes
- [x] Follows the conventions in `docs/CONTRIBUTING.md`
- [x] No generated Xcode project, build output, secrets, keystores, or new dependencies committed

## Related issues

No issue is linked.
