### PR TITLE
Amortize the v18 aux retention sweep instead of running it per insert batch

### DIFF
--- a/Packages/WhoopStore/Sources/WhoopStore/StreamStore.swift
+++ b/Packages/WhoopStore/Sources/WhoopStore/StreamStore.swift
@@ -81,6 +81,12 @@ extension WhoopStore {
     /// years, and the alternative is an invisible table that can outgrow everything a user actually reads.
     public static let v18AuxRetentionRows = 604_800
 
+    /// Rows to bank before running the retention sweep again. The sweep walks up to
+    /// `v18AuxRetentionRows` index entries, so running it per insert batch was the cost; the table may sit
+    /// this many rows (plus the crossing batch) above the cap in exchange, well under a MB against its
+    /// ~50 MB ceiling.
+    public static let v18AuxPruneEveryRows = 10_000
+
     /// Insert or update a device row (natural key = id).
     public func upsertDevice(id: String, mac: String?, name: String?) async throws {
         let now = Int(Date().timeIntervalSince1970)
@@ -128,7 +134,8 @@ extension WhoopStore {
         -> (hr: Int, rr: Int, events: Int, battery: Int,
             spo2: Int, skinTemp: Int, resp: Int, gravity: Int) {
         try await insert(streams, deviceId: deviceId,
-                         v18AuxRetentionRows: WhoopStore.v18AuxRetentionRows)
+                         v18AuxRetentionRows: WhoopStore.v18AuxRetentionRows,
+                         v18AuxPruneEveryRows: WhoopStore.v18AuxPruneEveryRows)
     }
 
     /// `insert(_:deviceId:)` with the v31 aux-table cap made explicit. Internal and a SEPARATE overload
@@ -137,10 +144,13 @@ extension WhoopStore {
     /// list — a default argument does not satisfy it. Exists so a test can prove the rolling delete with a
     /// small cap instead of writing 600k rows; every production caller goes through the wrapper above.
     @discardableResult
-    func insert(_ streams: Streams, deviceId: String, v18AuxRetentionRows: Int) async throws
+    func insert(_ streams: Streams, deviceId: String, v18AuxRetentionRows: Int,
+                v18AuxPruneEveryRows: Int) async throws
         -> (hr: Int, rr: Int, events: Int, battery: Int,
             spo2: Int, skinTemp: Int, resp: Int, gravity: Int) {
-        return try syncWrite { db in
+        // Banked rows, accumulated across batches so the sweep does not run on every one.
+        var v18Written = 0
+        let result: (Int, Int, Int, Int, Int, Int, Int, Int) = try syncWrite { db in
             var hr = 0, rr = 0, ev = 0, bat = 0
             var spo2 = 0, skin = 0, resp = 0, grav = 0
             // Reuse one prepared statement per table instead of recompiling the same SQL on every
@@ -318,27 +328,41 @@ extension WhoopStore {
                     INSERT INTO v18AuxSample (deviceId, ts, fields) VALUES (?, ?, ?)
                     ON CONFLICT(deviceId, ts) DO NOTHING
                     """)
-                var wrote = false
                 for s in streams.v18Aux {
                     let blob = V18AuxCodec.pack(s)
                     if blob.isEmpty { continue }
                     try stmt.execute(arguments: [deviceId, s.ts, blob])
-                    wrote = true
-                }
-                // Rolling retention, the same shape as `insertRawImu` (#423): keep the newest
-                // `v18AuxRetentionRows` for THIS device and drop anything older. Only runs when the batch
-                // actually wrote a row, so a WHOOP 4.0 offload (or any non-v18 second) never pays for the
-                // index scan. Twin of Kotlin `WhoopRepository.insert`'s `pruneV18Aux`.
-                if wrote {
-                    try db.execute(sql: """
-                        DELETE FROM v18AuxSample WHERE deviceId = ? AND ts < (
-                            SELECT MIN(ts) FROM (
-                                SELECT ts FROM v18AuxSample WHERE deviceId = ? ORDER BY ts DESC LIMIT ?))
-                        """, arguments: [deviceId, deviceId, v18AuxRetentionRows])
+                    v18Written += 1
                 }
             }
             return (hr, rr, ev, bat, spo2, skin, resp, grav)
         }
+
+        // Rolling retention (the `insertRawImu` shape, #423) but AMORTISED. The delete finds the
+        // Nth-newest row by rank, so it walks up to `v18AuxRetentionRows` index entries; `insertRawImu`
+        // keeps 3,600 so that is free, this keeps 604,800 and an offload inserts once per chunk. Swept
+        // once per `v18AuxPruneEveryRows` rows instead, which keeps newest-N-rows exactly (a time window
+        // would not — a sporadically-worn strap's rows span far more than a week, and the census wants
+        // that). Counter is per device because the delete is.
+        if v18Written > 0 {
+            let banked = (v18AuxRowsSincePrune[deviceId] ?? 0) + v18Written
+            v18AuxRowsSincePrune[deviceId] = banked
+            // BEST-EFFORT, and it has to be: the rows above are already committed, because the sweep is
+            // now its own transaction rather than riding the insert's. A throw here would surface as an
+            // insert failure and make Backfiller re-send a chunk it has already banked. Leaving the budget
+            // unspent instead means the next batch simply retries the sweep.
+            if banked >= v18AuxPruneEveryRows,
+               (try? syncWrite { db in
+                   try db.execute(sql: """
+                       DELETE FROM v18AuxSample WHERE deviceId = ? AND ts < (
+                           SELECT MIN(ts) FROM (
+                               SELECT ts FROM v18AuxSample WHERE deviceId = ? ORDER BY ts DESC LIMIT ?))
+                       """, arguments: [deviceId, deviceId, v18AuxRetentionRows])
+               }) != nil {
+                v18AuxRowsSincePrune[deviceId] = 0
+            }
+        }
+        return result
     }
 
     // MARK: - Raw sensor CSV export (diagnostic)

--- a/Packages/WhoopStore/Sources/WhoopStore/WhoopStore.swift
+++ b/Packages/WhoopStore/Sources/WhoopStore/WhoopStore.swift
@@ -56,6 +56,10 @@ private actor StoreOpenGate {
 /// caller's (main) thread; what changed is read/write CONCURRENCY at the SQLite layer, not the
 /// data or the query results.
 public actor WhoopStore {
+
+    /// v18 aux rows banked since the retention sweep last ran, PER DEVICE — the sweep is per device too,
+    /// so a shared counter would let one strap spend another's budget. See `StreamStore`.
+    var v18AuxRowsSincePrune: [String: Int] = [:]
     let dbWriter: any DatabaseWriter
 
     /// Read-only handle to the underlying GRDB writer for the synchronous `DeviceRegistryStore`.

--- a/Packages/WhoopStore/Tests/WhoopStoreTests/DeepCaptureChannelsTests.swift
+++ b/Packages/WhoopStore/Tests/WhoopStoreTests/DeepCaptureChannelsTests.swift
@@ -245,7 +245,7 @@ final class DeepCaptureChannelsTests: XCTestCase {
         let s = try await store()
         for ts in 100...109 {
             _ = try await s.insert(Streams(v18Aux: [V18AuxSample(ts: ts, statusWord: ts)]),
-                                   deviceId: "dev1", v18AuxRetentionRows: 3)
+                                   deviceId: "dev1", v18AuxRetentionRows: 3, v18AuxPruneEveryRows: 1)
         }
         let rows = try await s.v18AuxSamples(deviceId: "dev1", from: 0, to: 1_000)
         XCTAssertEqual(rows.count, 3, "the cap must bound the table")
@@ -259,14 +259,75 @@ final class DeepCaptureChannelsTests: XCTestCase {
         try await s.upsertDevice(id: "dev2", mac: nil, name: nil)
         for ts in 100...104 {
             _ = try await s.insert(Streams(v18Aux: [V18AuxSample(ts: ts, statusWord: 1)]),
-                                   deviceId: "dev1", v18AuxRetentionRows: 2)
+                                   deviceId: "dev1", v18AuxRetentionRows: 2, v18AuxPruneEveryRows: 1)
         }
         _ = try await s.insert(Streams(v18Aux: [V18AuxSample(ts: 100, statusWord: 1)]),
-                               deviceId: "dev2", v18AuxRetentionRows: 2)
+                               deviceId: "dev2", v18AuxRetentionRows: 2, v18AuxPruneEveryRows: 1)
         let d1 = try await s.v18AuxSamples(deviceId: "dev1", from: 0, to: 1_000)
         let d2 = try await s.v18AuxSamples(deviceId: "dev2", from: 0, to: 1_000)
         XCTAssertEqual(d1.map(\.ts), [103, 104])
         XCTAssertEqual(d2.map(\.ts), [100], "dev2's single old row must survive dev1's eviction")
+    }
+
+    /// Below the threshold the sweep must not run — the overshoot is the whole point.
+    func testRetentionSweepIsDeferredBelowTheThreshold() async throws {
+        let s = try await store()
+        for ts in 100...109 {
+            _ = try await s.insert(Streams(v18Aux: [V18AuxSample(ts: ts, statusWord: ts)]),
+                                   deviceId: "dev1", v18AuxRetentionRows: 3, v18AuxPruneEveryRows: 5_000)
+        }
+        let rows = try await s.v18AuxSamples(deviceId: "dev1", from: 0, to: 1_000)
+        XCTAssertEqual(rows.count, 10, "under the threshold the sweep must not run — overshoot is the point")
+    }
+
+    /// …and once the threshold is crossed it runs, so amortising did not make the cap unbounded.
+    func testRetentionSweepRunsOnceTheThresholdIsCrossed() async throws {
+        let s = try await store()
+        // Four batches of two rows: the sweep is due on the fourth (8 >= 7) and not before.
+        for batch in 0..<4 {
+            let base = 100 + batch * 2
+            _ = try await s.insert(
+                Streams(v18Aux: [V18AuxSample(ts: base, statusWord: base),
+                                 V18AuxSample(ts: base + 1, statusWord: base + 1)]),
+                deviceId: "dev1", v18AuxRetentionRows: 3, v18AuxPruneEveryRows: 7)
+        }
+        let rows = try await s.v18AuxSamples(deviceId: "dev1", from: 0, to: 1_000)
+        XCTAssertEqual(rows.map(\.ts), [105, 106, 107],
+                       "the sweep still keeps exactly the newest v18AuxRetentionRows")
+    }
+
+    /// The counter resets per sweep, so a long offload sweeps repeatedly rather than latching.
+    func testTheAmortisationCounterResetsAfterEachSweep() async throws {
+        let s = try await store()
+        for ts in 100...111 {
+            _ = try await s.insert(Streams(v18Aux: [V18AuxSample(ts: ts, statusWord: ts)]),
+                                   deviceId: "dev1", v18AuxRetentionRows: 2, v18AuxPruneEveryRows: 4)
+        }
+        // 12 rows banked, sweeps due after the 4th, 8th and 12th — the last one leaves exactly the cap.
+        let rows = try await s.v18AuxSamples(deviceId: "dev1", from: 0, to: 1_000)
+        XCTAssertEqual(rows.map(\.ts), [110, 111],
+                       "a second sweep must happen; the counter cannot latch after the first")
+    }
+
+    /// The budget is per device, because the delete is — one strap must not spend another's.
+    func testTheAmortisationBudgetIsNotSharedBetweenDevices() async throws {
+        let s = try await store()
+        try await s.upsertDevice(id: "dev2", mac: nil, name: nil)
+        // dev1 banks three rows against a threshold of four — one short, so no sweep is due for it.
+        for ts in 100...102 {
+            _ = try await s.insert(Streams(v18Aux: [V18AuxSample(ts: ts, statusWord: ts)]),
+                                   deviceId: "dev1", v18AuxRetentionRows: 1, v18AuxPruneEveryRows: 4)
+        }
+        // dev2 banks one row. With a SHARED counter this crosses the threshold and sweeps — and because
+        // the delete is scoped to dev2, it would evict nothing from dev1 while zeroing dev1's budget.
+        _ = try await s.insert(Streams(v18Aux: [V18AuxSample(ts: 200, statusWord: 1)]),
+                               deviceId: "dev2", v18AuxRetentionRows: 1, v18AuxPruneEveryRows: 4)
+        // dev1's fourth row must now be what crosses ITS OWN threshold and sweeps it to the cap.
+        _ = try await s.insert(Streams(v18Aux: [V18AuxSample(ts: 103, statusWord: 103)]),
+                               deviceId: "dev1", v18AuxRetentionRows: 1, v18AuxPruneEveryRows: 4)
+        let d1 = try await s.v18AuxSamples(deviceId: "dev1", from: 0, to: 1_000)
+        XCTAssertEqual(d1.map(\.ts), [103],
+                       "dev1's own fourth row must trigger dev1's sweep — dev2 cannot spend its budget")
     }
 
     /// A batch that banks no aux row must not run the retention delete at all — a WHOOP 4.0 offload
@@ -275,10 +336,10 @@ final class DeepCaptureChannelsTests: XCTestCase {
         let s = try await store()
         _ = try await s.insert(Streams(v18Aux: [V18AuxSample(ts: 100, statusWord: 1),
                                                 V18AuxSample(ts: 101, statusWord: 2)]),
-                               deviceId: "dev1", v18AuxRetentionRows: 5)
+                               deviceId: "dev1", v18AuxRetentionRows: 5, v18AuxPruneEveryRows: 1)
         // An all-absent sample packs to nothing, so this batch writes no row and must sweep nothing.
         _ = try await s.insert(Streams(v18Aux: [V18AuxSample(ts: 200)]),
-                               deviceId: "dev1", v18AuxRetentionRows: 1)
+                               deviceId: "dev1", v18AuxRetentionRows: 1, v18AuxPruneEveryRows: 1)
         let rows = try await s.v18AuxSamples(deviceId: "dev1", from: 0, to: 1_000)
         XCTAssertEqual(rows.map(\.ts), [100, 101])
     }

--- a/android/app/src/main/java/com/noop/data/WhoopRepository.kt
+++ b/android/app/src/main/java/com/noop/data/WhoopRepository.kt
@@ -338,6 +338,11 @@ object HistoryHeal {
  */
 class WhoopRepository(private val dao: WhoopDao) {
 
+    /** v18 aux rows banked since the retention sweep last ran, PER DEVICE — the sweep is per device too,
+     *  so a shared counter would let one strap spend another's budget. Only the single-threaded offload
+     *  path banks v18 rows, so a plain map is enough. Swift twin: `WhoopStore.v18AuxRowsSincePrune`. */
+    private val v18AuxRowsSincePrune = mutableMapOf<String, Int>()
+
     constructor(db: WhoopDatabase) : this(db.whoopDao())
 
     // MARK: - Device
@@ -438,10 +443,27 @@ class WhoopRepository(private val dao: WhoopDao) {
             }
             if (rows.isNotEmpty()) {
                 dao.insertV18Aux(rows)
-                // Rolling retention, the same shape as insertRawImu (#423): keep the newest
-                // [V18_AUX_RETENTION_ROWS] for THIS device and drop anything older. Only runs when the
-                // batch actually wrote a row, so a WHOOP 4.0 offload never pays for the index scan.
-                dao.pruneV18Aux(deviceId, V18_AUX_RETENTION_ROWS)
+                // Rolling retention (the insertRawImu shape, #423) but AMORTISED. The delete finds the
+                // Nth-newest row by rank, so it walks up to [V18_AUX_RETENTION_ROWS] index entries;
+                // insertRawImu keeps 3,600 so that is free, this keeps 604,800 and an offload inserts once
+                // per chunk. Swept once per [V18_AUX_PRUNE_EVERY_ROWS] rows instead, which keeps
+                // newest-N-rows exactly (a time window would not — a sporadically-worn strap's rows span
+                // far more than a week, and the census wants that). Counter is per device because the
+                // delete is. Swift twin: `WhoopStore.v18AuxRowsSincePrune`.
+                val banked = (v18AuxRowsSincePrune[deviceId] ?: 0) + rows.size
+                v18AuxRowsSincePrune[deviceId] = banked
+                // Best-effort: the rows above are already committed, so a sweep failure must not surface
+                // as an insert failure and make Backfiller re-send a chunk it has already banked. Leaving
+                // the budget unspent means the next batch retries the sweep.
+                if (banked >= V18_AUX_PRUNE_EVERY_ROWS) {
+                    runCatching { dao.pruneV18Aux(deviceId, V18_AUX_RETENTION_ROWS) }
+                        .onSuccess { v18AuxRowsSincePrune[deviceId] = 0 }
+                        // pruneV18Aux is a suspend call, so a scope cancellation arrives here as a
+                        // CancellationException that runCatching would otherwise swallow — the caller would
+                        // then carry on inside a cancelled coroutine. Same rethrow AppViewModel (#125) and
+                        // HealthConnectWriter already use.
+                        .onFailure { if (it is kotlin.coroutines.cancellation.CancellationException) throw it }
+                }
             }
         }
 
@@ -1721,6 +1743,12 @@ class WhoopRepository(private val dao: WhoopDao) {
          * in wall-clock terms. Applied per device, newest-first.
          */
         const val V18_AUX_RETENTION_ROWS = 604_800
+
+        /** Rows to bank before running the retention sweep again. The sweep walks up to
+         *  [V18_AUX_RETENTION_ROWS] index entries, so running it per insert batch was the cost; the table
+         *  may sit this many rows (plus the crossing batch) above the cap in exchange, well under a MB
+         *  against its ~50 MB ceiling. Swift twin: `WhoopStore.v18AuxPruneEveryRows`. */
+        const val V18_AUX_PRUNE_EVERY_ROWS = 10_000
 
         /** #797: dashboard merge window cap (days). The bounded [recentDaysMergedFlow] keeps at most this
          *  many most-recent days per source, so a years-deep import stops re-merging the whole history on


### PR DESCRIPTION
#848 landed rolling retention for `v18AuxSample` by copying the `insertRawImu` shape (#423). The shape
is right; the constant it depends on is **168× larger**, and the cost scales with it.

The delete finds the Nth-newest row by **rank**, and there is no shortcut — SQLite walks N index
entries to know which one is Nth. `insertRawImu` keeps **3,600** rows so that is free. This keeps
**604,800**, and an offload calls `insert()` once per chunk.

Swept once per `V18_AUX_PRUNE_EVERY_ROWS` (10,000) banked rows instead.

## Retention semantics unchanged

Still newest-N-rows, **not** a time window. A window would be cheaper still and wrong: the cap's own
doc notes v18 seconds are a fraction of a day, so a sporadically-worn strap's 604,800 rows span far
more than a week, and the census this table exists for wants that history.

The table may sit up to the threshold plus the crossing batch above the cap — well under a MB against
its ~50 MB ceiling.

The counter is keyed by device because the delete is; a shared one would let one strap's inserts spend
another's budget, and the overshoot bound would not hold.

## Tests

The threshold is injectable because the existing retention tests insert ten rows against a cap of
three and assert three survive — under amortisation they would have seen ten. Those tests pin the
retention SQL, so they now pass `v18AuxPruneEveryRows: 1` and prove exactly what they proved before.

Four new tests cover the amortisation: deferred below the threshold, enforced once crossed, the
counter resetting so a long offload sweeps repeatedly, and the budget not being shared between
devices — the last built to fail against a shared counter.

## Scope

**Preventive rather than urgent.** `LIMIT` walks `min(rowcount, cap)`, and this table was created in
#848 today, so no user has a full one yet — the cost approaches the number quoted above only once a
strap has banked about a week of continuous v18 seconds.

This PR previously also swapped the counter for a `ConcurrentHashMap` and switched it to count rows
written rather than attempted. **Both were dropped.** The race is unreachable (only the
single-threaded offload path banks v18 rows) and re-delivery is uncommon (the strap trims on ack), so
neither fixed a reachable problem and both were scope the original finding did not ask for. The diff
is 125 lines rather than 202, and 29% comment rather than 50%.
