### PR TITLE
Name every command the schema names in Android strap logs (#891)

### DIFF
--- a/Packages/WhoopProtocol/Tests/WhoopProtocolTests/Whoop5CommandResponseTests.swift
+++ b/Packages/WhoopProtocol/Tests/WhoopProtocolTests/Whoop5CommandResponseTests.swift
@@ -69,4 +69,45 @@ final class Whoop5CommandResponseTests: XCTestCase {
         XCTAssertNil(f.parsed["device_name"])   // pay[16] == 0 → no printable name
         XCTAssertNil(f.parsed["fw_version"])     // pay[93] != 50 → fails the generation guard
     }
+
+    /// Real WHOOP 5 MG (`WS50_r03`) replies to the three ECG/Labrador toggles, posted in #891.
+    ///
+    /// Committed because they are the only real 5/MG COMMAND_RESPONSE frames in the tree whose payload is
+    /// inert — `01 01 00 00` carries no device name, serial or session token — and because they exercise
+    /// the generic response path for commands NOOP does not send, which the battery / data-range / hello
+    /// fixtures above do not. The Kotlin twin asserts the identical values in `CommandCatalogueTest`; that
+    /// pairing is the point, since Android labelled these from its sender enum and rendered them as bare
+    /// hex until #891.
+    ///
+    /// Decode only. No claim is made here about what the strap did with the commands — all three answered
+    /// SUCCESS and produced no ECG data, which is the open question in #891, not something a test settles.
+    ///
+    /// Asserts `resp_cmd` and the envelope, which is what this decoder exposes. The Kotlin twin also
+    /// asserts `resp_seq` and `result` on these same bytes, because the Kotlin decoder publishes both and
+    /// this one publishes neither — on either family. That gap is real and pre-existing (every Swift probe
+    /// re-derives the result byte itself rather than reading a parsed field), but it is the opposite
+    /// divergence from the one this change fixes, so it is filed rather than folded in here.
+    private let mgToggleReplies: [(hex: String, cmd: String)] = [
+        ("aa010c000100271124148b2f01010000845a1705", "TOGGLE_LABRADOR_FILTERED(139)"),
+        ("aa010c000100271124157d300101000067ab1b82", "TOGGLE_LABRADOR_RAW_SAVE(125)"),
+        ("aa010c000100271124167c3101010000ef4bcf45", "TOGGLE_LABRADOR_DATA_GENERATION(124)"),
+    ]
+
+    func testMgToggleRepliesDecode() {
+        for reply in mgToggleReplies {
+            let f = parseFrame(bytes(reply.hex), family: .whoop5)
+            XCTAssertEqual(f.typeName, "COMMAND_RESPONSE", reply.cmd)
+            XCTAssertEqual(f.crcOK, true, reply.cmd)
+            XCTAssertEqual(f.parsed["resp_cmd"]?.stringValue, reply.cmd)
+        }
+    }
+
+    /// Byte 13 — the first response-payload byte, where `GET_BATTERY_LEVEL` returns its percent — is `0x01`
+    /// in all three replies. It is deliberately NOT decoded into a field: whether it echoes the value that
+    /// was written or reads back stored state is precisely what #891 cannot yet distinguish, and naming it
+    /// would put a guess in the log. Fail closed (#194).
+    func testNoValueIsInventedFromAToggleReply() {
+        let f = parseFrame(bytes(mgToggleReplies[0].hex), family: .whoop5)
+        XCTAssertNil(f.parsed["battery_pct"])
+    }
 }

--- a/android/app/src/main/java/com/noop/protocol/Enums.kt
+++ b/android/app/src/main/java/com/noop/protocol/Enums.kt
@@ -246,6 +246,116 @@ enum class CommandNumber(val rawValue: Int) {
 }
 
 /**
+ * DECODE-ONLY command names, mirroring the `CommandNumber` table in the canonical protocol schema
+ * (`Packages/WhoopProtocol/…/Resources/whoop_protocol.json`).
+ *
+ * This is NOT a send surface and must never become one. [CommandNumber] above is the curated *sender*
+ * enum and deliberately omits every destructive opcode; this map is the *reader's* dictionary, so it
+ * names opcodes NOOP will never emit (FORCE_TRIM, the firmware-load family, ENTER_BLE_DFU) purely so an
+ * inbound COMMAND_RESPONSE echoing one is legible in a strap log.
+ *
+ * Nothing here widens what can be sent, but note where that guarantee actually comes from: the 4.0
+ * builder `Framing.buildCommand` takes a [CommandNumber], so the omission is enforced by the type; the
+ * 5/MG `Framing.puffinCommandFrame` takes a raw `Int`, so there it is enforced by the send allowlist in
+ * `WhoopBleClient` instead. Either way a name in this map is never an input to either builder — it is
+ * only ever an output of decoding a frame the strap sent.
+ *
+ * Why it exists: Swift labels a response by asking the schema (`Schema.enumName("CommandNumber", …)`),
+ * which knows all 80 opcodes. Kotlin labelled it from the sender enum, which knows 34 — so the same
+ * strap log rendered `TOGGLE_LABRADOR_FILTERED(139)` on Apple and `0x8B(139)` on Android, and three
+ * opcodes (77, 119, 120) printed *different names* on the two platforms because the sender enum uses
+ * its own short case names. Reports pasted from the two apps could not be compared by eye. (#891)
+ */
+object CommandNames {
+    /** Raw opcode → schema name. Keep byte-identical to the schema's `CommandNumber` table. */
+    val byRaw: Map<Int, String> = mapOf(
+        1 to "LINK_VALID",
+        2 to "GET_MAX_PROTOCOL_VERSION",
+        3 to "TOGGLE_REALTIME_HR",
+        7 to "REPORT_VERSION_INFO",
+        10 to "SET_CLOCK",
+        11 to "GET_CLOCK",
+        14 to "TOGGLE_GENERIC_HR_PROFILE",
+        16 to "TOGGLE_R7_DATA_COLLECTION",
+        19 to "RUN_HAPTIC_PATTERN_MAVERICK",
+        20 to "ABORT_HISTORICAL_TRANSMITS",
+        22 to "SEND_HISTORICAL_DATA",
+        23 to "HISTORICAL_DATA_RESULT",
+        25 to "FORCE_TRIM",
+        26 to "GET_BATTERY_LEVEL",
+        29 to "REBOOT_STRAP",
+        32 to "POWER_CYCLE_STRAP",
+        33 to "SET_READ_POINTER",
+        34 to "GET_DATA_RANGE",
+        35 to "GET_HELLO_HARVARD",
+        36 to "START_FIRMWARE_LOAD",
+        37 to "LOAD_FIRMWARE_DATA",
+        38 to "PROCESS_FIRMWARE_IMAGE",
+        39 to "SET_LED_DRIVE",
+        40 to "GET_LED_DRIVE",
+        41 to "SET_TIA_GAIN",
+        42 to "GET_TIA_GAIN",
+        43 to "SET_BIAS_OFFSET",
+        44 to "GET_BIAS_OFFSET",
+        45 to "ENTER_BLE_DFU",
+        48 to "SEND_EVENT_PACKETS",
+        52 to "SET_DP_TYPE",
+        53 to "FORCE_DP_TYPE",
+        61 to "SET_AFE_PARAMETERS",
+        62 to "GET_AFE_PARAMETERS",
+        63 to "SEND_R10_R11_REALTIME",
+        66 to "SET_ALARM_TIME",
+        67 to "GET_ALARM_TIME",
+        68 to "RUN_ALARM",
+        69 to "DISABLE_ALARM",
+        76 to "GET_ADVERTISING_NAME_HARVARD",
+        77 to "SET_ADVERTISING_NAME_HARVARD",
+        79 to "RUN_HAPTICS_PATTERN",
+        80 to "GET_ALL_HAPTICS_PATTERN",
+        81 to "START_RAW_DATA",
+        82 to "STOP_RAW_DATA",
+        83 to "VERIFY_FIRMWARE_IMAGE",
+        84 to "GET_BODY_LOCATION_AND_STATUS",
+        96 to "ENTER_HIGH_FREQ_SYNC",
+        97 to "EXIT_HIGH_FREQ_SYNC",
+        98 to "GET_EXTENDED_BATTERY_INFO",
+        99 to "RESET_FUEL_GAUGE",
+        100 to "CALIBRATE_CAPSENSE",
+        105 to "TOGGLE_IMU_MODE_HISTORICAL",
+        106 to "TOGGLE_IMU_MODE",
+        107 to "ENABLE_OPTICAL_DATA",
+        108 to "TOGGLE_OPTICAL_MODE",
+        115 to "START_DEVICE_CONFIG_KEY_EXCHANGE",
+        116 to "SEND_NEXT_DEVICE_CONFIG",
+        117 to "START_FF_KEY_EXCHANGE",
+        118 to "SEND_NEXT_FF",
+        119 to "SET_DEVICE_CONFIG_VALUE",
+        120 to "SET_FF_VALUE",
+        121 to "GET_DEVICE_CONFIG_VALUE",
+        122 to "STOP_HAPTICS",
+        123 to "SELECT_WRIST",
+        124 to "TOGGLE_LABRADOR_DATA_GENERATION",
+        125 to "TOGGLE_LABRADOR_RAW_SAVE",
+        128 to "GET_FF_VALUE",
+        131 to "SET_RESEARCH_PACKET",
+        132 to "GET_RESEARCH_PACKET",
+        139 to "TOGGLE_LABRADOR_FILTERED",
+        140 to "SET_ADVERTISING_NAME",
+        141 to "GET_ADVERTISING_NAME",
+        142 to "START_FIRMWARE_LOAD_NEW",
+        143 to "LOAD_FIRMWARE_DATA_NEW",
+        144 to "PROCESS_FIRMWARE_IMAGE_NEW",
+        145 to "GET_HELLO",
+        151 to "GET_BATTERY_PACK_INFO",
+        153 to "TOGGLE_PERSISTENT_R20",
+        154 to "TOGGLE_PERSISTENT_R21",
+    )
+
+    /** `"NAME(raw)"` for a known opcode, else `"0xHH(raw)"` — byte-identical to Swift `Schema.enumName`. */
+    fun label(v: Int): String = byRaw[v]?.let { "$it($v)" } ?: "0x%02X(%d)".format(v, v)
+}
+
+/**
  * Candidate reboot frames for the WHOOP 4.0 reboot probe (Test Centre → Connection, WHOOP 4.0 only).
  *
  * A real WHOOP 4.0 silently ignores NOOP's production reboot frame (opcode 29 REBOOT_STRAP, empty body

--- a/android/app/src/main/java/com/noop/protocol/Framing.kt
+++ b/android/app/src/main/java/com/noop/protocol/Framing.kt
@@ -233,8 +233,12 @@ object Framing {
     private fun metaLabel(v: Int): String =
         MetadataType.fromRaw(v)?.let { "${it.name}($v)" } ?: hexLabel(v)
 
-    private fun commandLabel(v: Int): String =
-        CommandNumber.fromRaw(v)?.let { "${it.name}($v)" } ?: hexLabel(v)
+    // Labels from the schema-mirroring [CommandNames] table, NOT from the CommandNumber sender enum:
+    // the sender enum is deliberately curated down to safe opcodes, so labelling from it left 46 of the
+    // schema's 80 commands rendering as bare hex on Android while Apple named them, and printed a
+    // different name than Apple for 77/119/120. Read path only; naming an opcode does not make it
+    // sendable. (#891)
+    private fun commandLabel(v: Int): String = CommandNames.label(v)
 
     /** COMMAND_RESPONSE result codes, on both families. 3=UNSUPPORTED matches our own MG haptics-rejection
      *  capture (#48); 2=PENDING precedes SUCCESS on GET_DATA_RANGE (hardware-confirmed, #78 fork). The same

--- a/android/app/src/test/java/com/noop/protocol/CommandCatalogueTest.kt
+++ b/android/app/src/test/java/com/noop/protocol/CommandCatalogueTest.kt
@@ -1,0 +1,222 @@
+package com.noop.protocol
+
+import java.io.File
+import org.json.JSONObject
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Holds [CommandNames] in lockstep with the shared schema
+ * (`Packages/WhoopProtocol/Sources/WhoopProtocol/Resources/whoop_protocol.json`), which iOS reads directly
+ * at runtime — the [EventCatalogueTest] treatment of `EventNumber` (#791), applied to the command table it
+ * did not cover.
+ *
+ * Android named only 34 of the schema's 80 commands, so 46 rendered as a bare `0x8B(139)` in an Android
+ * strap log while iOS named them, and three more (77, 119, 120) printed a *different* name on each platform.
+ * #891 is the case that made it matter: an MG owner's three ECG-toggle replies are the evidence the issue
+ * turns on, and its ask is for other owners to run the same probes and post what they see. Half of them
+ * would have posted hex.
+ *
+ * **Why a separate map rather than growing the enum.** [CommandNumber] is the *sender* enum — the 5/MG send
+ * path and the 4.0 builders both take one, and it is curated precisely so destructive opcodes cannot be
+ * expressed (its own doc comment says so). `EventNumber` could simply be completed because nothing sends an
+ * event. Completing `CommandNumber` the same way would have made `FORCE_TRIM` and the firmware-load family
+ * constructible, which is the opposite of the safety property. So the reader gets its own dictionary and the
+ * sender enum is left alone; [senderEnumStaysCuratedAfterTheLabelFix] pins that separation.
+ *
+ * The lockstep check `Assume`-skips when the Swift tree is absent, following [EventCatalogueTest] and
+ * [DecoderOracleTest]. The targeted checks never skip.
+ */
+class CommandCatalogueTest {
+
+    private fun bytes(s: String): ByteArray =
+        ByteArray(s.length / 2) { ((s[it * 2].digitToInt(16) shl 4) or s[it * 2 + 1].digitToInt(16)).toByte() }
+
+    /** Reads the schema rather than restating it: the bug is "the schema grew and Android did not follow". */
+    @Test
+    fun everyCommandInTheSharedSchemaIsNamedOnAndroid() {
+        val rel = "Packages/WhoopProtocol/Sources/WhoopProtocol/Resources/whoop_protocol.json"
+        val userDir = File(System.getProperty("user.dir"))
+        val schemaFile = listOf(File(userDir, rel), File(userDir, "../../$rel")).firstOrNull { it.exists() }
+        org.junit.Assume.assumeTrue(
+            "shared schema not found from user.dir=$userDir — skipping the catalogue lockstep check",
+            schemaFile != null,
+        )
+        val cmds = JSONObject(schemaFile!!.readText()).getJSONObject("enums").getJSONObject("CommandNumber")
+        val schema = cmds.keys().asSequence().associate { it.toInt() to cmds.getString(it) }
+        assertTrue("CommandNumber block parsed empty", schema.isNotEmpty())
+
+        assertEquals(
+            "Android is missing commands the schema names",
+            emptySet<Int>(), schema.keys - CommandNames.byRaw.keys,
+        )
+        assertEquals(
+            "Android names commands the schema does not",
+            emptySet<Int>(), CommandNames.byRaw.keys - schema.keys,
+        )
+        for ((raw, name) in schema) {
+            assertEquals("command $raw", name, CommandNames.byRaw[raw])
+        }
+    }
+
+    /**
+     * The regression this change could itself cause, in the opposite direction.
+     *
+     * Labels used to come from the sender enum, so every sendable command was named by construction. They
+     * now come from the schema, so a command added to the sender enum but not to the schema would render
+     * as bare hex — reintroducing, for the commands NOOP actually sends, exactly the defect this fixes for
+     * the ones it does not. No opcode is in that state today; this keeps it that way without depending on
+     * the Swift tree being present, unlike the lockstep check above.
+     */
+    @Test
+    fun everySendableCommandIsStillNamed() {
+        for (cmd in CommandNumber.entries) {
+            val label = CommandNames.label(cmd.rawValue)
+            assertTrue(
+                "${cmd.name}(${cmd.rawValue}) is sendable but would log as $label",
+                !label.startsWith("0x"),
+            )
+        }
+    }
+
+    /**
+     * The safety property that forced a separate table. Naming an opcode for the reader must never make it
+     * sendable: every one of these must stay out of the sender enum while remaining legible in a log.
+     *
+     * All nine are on the "do not send" list in `docs/PROTOCOL.md` — 142/143/144 only as of this change,
+     * which is the point. They were named by the schema, absent from both platforms' sender enums, and
+     * missing from that table, so nothing recorded that keeping them out was deliberate. `REBOOT_STRAP`
+     * (29) and `POWER_CYCLE_STRAP` (32) are excluded here: both are on the destructive list but are the
+     * documented, confirmation-gated restart exceptions, so they legitimately are in the sender enum.
+     */
+    @Test
+    fun senderEnumStaysCuratedAfterTheLabelFix() {
+        val destructive = mapOf(
+            25 to "FORCE_TRIM",
+            36 to "START_FIRMWARE_LOAD",
+            37 to "LOAD_FIRMWARE_DATA",
+            38 to "PROCESS_FIRMWARE_IMAGE",
+            45 to "ENTER_BLE_DFU",
+            99 to "RESET_FUEL_GAUGE",
+            142 to "START_FIRMWARE_LOAD_NEW",
+            143 to "LOAD_FIRMWARE_DATA_NEW",
+            144 to "PROCESS_FIRMWARE_IMAGE_NEW",
+        )
+        for ((raw, name) in destructive) {
+            assertNull("opcode $raw must not be sendable", CommandNumber.fromRaw(raw))
+            assertEquals("opcode $raw must still be readable", name, CommandNames.byRaw[raw])
+        }
+    }
+
+    /** The ECG family #891 turns on. None is sendable; all three are now legible. */
+    @Test
+    fun theMgEcgTogglesAreNamedButNotSendable() {
+        assertEquals("TOGGLE_LABRADOR_DATA_GENERATION", CommandNames.byRaw[124])
+        assertEquals("TOGGLE_LABRADOR_RAW_SAVE", CommandNames.byRaw[125])
+        assertEquals("TOGGLE_LABRADOR_FILTERED", CommandNames.byRaw[139])
+        assertNull(CommandNumber.fromRaw(124))
+        assertNull(CommandNumber.fromRaw(125))
+        assertNull(CommandNumber.fromRaw(139))
+    }
+
+    /**
+     * Three opcodes where the two platforms printed different names for the same byte, because Android
+     * labelled from the sender enum's short case names while iOS asked the schema. The sender enum keeps its
+     * own names (they are referenced across the BLE layer on both platforms); only the *label* changes.
+     */
+    @Test
+    fun opcodesThatPrintedDifferentNamesOnEachPlatformNowAgree() {
+        assertEquals("SET_ADVERTISING_NAME_HARVARD(77)", CommandNames.label(77))
+        assertEquals("SET_DEVICE_CONFIG_VALUE(119)", CommandNames.label(119))
+        assertEquals("SET_FF_VALUE(120)", CommandNames.label(120))
+        // 140 is the schema's SET_ADVERTISING_NAME — the name Android previously printed for 77.
+        assertEquals("SET_ADVERTISING_NAME(140)", CommandNames.label(140))
+    }
+
+    /**
+     * The labels that are load-bearing, not cosmetic.
+     *
+     * `WhoopBleClient` reads `parsed["resp_cmd"]` back as a String and branches on `startsWith` — the same
+     * shape as the `isRtcStateKind` coupling that made #791's missing event names a behavioural bug rather
+     * than a display one. Two of these gate real work: a `GET_DATA_RANGE` + `SUCCESS` pair releases the
+     * 5/MG history request during backfill (a drifted label would silently demote that to the 2 s fail-open
+     * timer), and the reboot/power-cycle branch is the accept-or-reject signal a 5/MG owner's strap log is
+     * read for.
+     *
+     * Moving the label source from the sender enum to the schema is safe today only because these five
+     * names are identical in both. That is currently a coincidence rather than a guarantee, so it is
+     * asserted here: if a future schema edit renames one, this fails instead of the backfill quietly
+     * getting slower.
+     */
+    @Test
+    fun labelsThatGateBleBehaviourAreUnchangedByTheSchemaSwitch() {
+        val loadBearing = mapOf(
+            34 to "GET_DATA_RANGE",     // releases the 5/MG history request
+            29 to "REBOOT_STRAP",       // reboot accept/reject signal
+            32 to "POWER_CYCLE_STRAP",  // same branch
+            66 to "SET_ALARM_TIME",     // 4.0 alarm readback
+            67 to "GET_ALARM_TIME",     // 4.0 alarm readback
+        )
+        for ((raw, prefix) in loadBearing) {
+            assertTrue(
+                "opcode $raw must still label as $prefix — WhoopBleClient branches on this prefix",
+                CommandNames.label(raw).startsWith(prefix),
+            )
+            // The sender enum reaches the same name, which is why the switch is behaviour-preserving.
+            assertEquals("opcode $raw", prefix, CommandNumber.fromRaw(raw)?.name)
+        }
+    }
+
+    /** An opcode neither platform knows must stay hex: a borrowed or invented name is worse than a number. */
+    @Test
+    fun unknownCommandsAreNotGivenInventedNames() {
+        assertNull(CommandNames.byRaw[200])
+        assertEquals("0xC8(200)", CommandNames.label(200))
+        assertEquals("0xFF(255)", CommandNames.label(255))
+    }
+
+    /**
+     * The real WHOOP 5 MG (`WS50_r03`) replies posted in #891, decoded end to end.
+     *
+     * All three are structurally valid — declared length, CRC16-Modbus header and CRC32 tail all verify —
+     * and each answers SUCCESS. Before this change `resp_cmd` read `0x8B(139)` / `0x7D(125)` / `0x7C(124)`
+     * on Android and the named form on Apple, from the identical bytes. Committed as fixtures because they
+     * are the only real 5/MG COMMAND_RESPONSE frames in the tree whose payload is inert: `01 01 00 00`
+     * carries no device name, serial or session token.
+     */
+    @Test
+    fun realMgToggleRepliesNameTheirCommand() {
+        val replies = listOf(
+            Triple("aa010c000100271124148b2f01010000845a1705", "TOGGLE_LABRADOR_FILTERED(139)", 47),
+            Triple("aa010c000100271124157d300101000067ab1b82", "TOGGLE_LABRADOR_RAW_SAVE(125)", 48),
+            Triple("aa010c000100271124167c3101010000ef4bcf45", "TOGGLE_LABRADOR_DATA_GENERATION(124)", 49),
+        )
+        for ((hex, label, respSeq) in replies) {
+            val f = Framing.parseFrame(bytes(hex), DeviceFamily.WHOOP5)
+            assertTrue("frame did not parse: $hex", f.ok)
+            assertEquals("CRC must verify: $hex", true, f.crcOk)
+            assertEquals("COMMAND_RESPONSE", f.typeName)
+            assertEquals(label, f.parsed["resp_cmd"])
+            assertEquals(respSeq, f.parsed["resp_seq"])
+            assertEquals("SUCCESS(1)", f.parsed["result"])
+        }
+    }
+
+    /**
+     * The toggles are not battery reads, so nothing may be claimed from the value slot.
+     *
+     * Byte 13 — the first response-payload byte, where `GET_BATTERY_LEVEL` returns its percent — is `0x01`
+     * in all three replies. That is the only positive signal in #891 that a flag took a value, and it is
+     * deliberately NOT decoded into a field: whether it echoes the requested value or reads back stored
+     * state is exactly what the issue cannot yet distinguish (#194).
+     */
+    @Test
+    fun noValueIsInventedFromTheToggleReplies() {
+        val f = Framing.parseFrame(bytes("aa010c000100271124148b2f01010000845a1705"), DeviceFamily.WHOOP5)
+        assertNotNull(f.parsed["result"])
+        assertNull("no battery percent may be read from a non-battery reply", f.parsed["battery_pct"])
+    }
+}

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -410,10 +410,26 @@ On MAVERICK the clock commands also answer in the high opcode space — `SET_CLO
 and `GET_CLOCK` at 147 (0x93), alongside `GET_HELLO` at 145 (0x91) — distinct from the 4.0
 numbers (10 / 11) above.
 
-The strap further exposes an ECG/HeartKey command family (`ECG_MAIN_CONTROL`, `ECG_SEND_RAW`,
-`ECG_SAVE_RAW`, `ECG_SAVE_FILTERED`, `ECG_SELECT_WRIST`; five consecutive codes around 0x7B–0x8B),
-an `IMU_SET_DATA_STREAM` (code 106, shared with `TOGGLE_IMU_MODE`), and a `UART_DISABLE` (0x61–0x69).
-Exact codes for these are unconfirmed.
+The strap further exposes an ECG/HeartKey command family. The `CommandNumber` table carries four codes
+for it — 123 `SELECT_WRIST`, 124 `TOGGLE_LABRADOR_DATA_GENERATION`, 125 `TOGGLE_LABRADOR_RAW_SAVE`,
+139 `TOGGLE_LABRADOR_FILTERED` — which are **not** contiguous, and an earlier revision of this section
+described "five consecutive codes around 0x7B–0x8B" against five names (`ECG_MAIN_CONTROL`,
+`ECG_SEND_RAW`, `ECG_SAVE_RAW`, `ECG_SAVE_FILTERED`, `ECG_SELECT_WRIST`). Both cannot be right:
+`ECG_SEND_RAW` has no code, and 139 (0x8B) is separated from 123–125 (0x7B–0x7D). Treat the name↔code
+mapping as unconfirmed — the 5/MG is known to remap opcodes into the high space (the clock family answers
+at 145/146/147 there versus 10/11 on a 4.0), so a code that is accepted is not evidence that it means
+what the name says.
+
+What is confirmed: on a real WHOOP 5 MG (`WS50_r03`), 124, 125 and 139 are all **accepted** — each
+answers `COMMAND_RESPONSE` with result `SUCCESS(1)` — and no ECG-shaped data followed in a 30-second
+window. That is a null result with several live explanations (an open electrode circuit, flash rather
+than a realtime channel, a wrong opcode mapping, no start verb, a flag block, an entitlement gate); see
+#891. **NOOP does not send any of these** — none is in the sender enum on either platform, and the 5/MG
+send path is an allowlist. The three reply frames are pinned as decode fixtures in
+`Whoop5CommandResponseTests` / `CommandCatalogueTest`.
+
+The strap also exposes an `IMU_SET_DATA_STREAM` (code 106, shared with `TOGGLE_IMU_MODE`) and a
+`UART_DISABLE` (0x61–0x69). Exact codes for these are unconfirmed.
 
 ### Destructive commands — *do not send*
 
@@ -429,6 +445,14 @@ data, brick, or power-cycle the strap. NOOP must never send them.
 | 38 | `PROCESS_FIRMWARE_IMAGE` | firmware write |
 | 45 | `ENTER_BLE_DFU` | enters DFU bootloader |
 | 99 | `RESET_FUEL_GAUGE` | resets battery fuel gauge |
+| 142 | `START_FIRMWARE_LOAD_NEW` | firmware write |
+| 143 | `LOAD_FIRMWARE_DATA_NEW` | firmware write |
+| 144 | `PROCESS_FIRMWARE_IMAGE_NEW` | firmware write |
+
+The 142–144 family is the high-opcode-space counterpart of 36/37/38, in the same style as the clock
+family answering at 145–147 on MAVERICK. It is named by the schema and absent from the sender enum on
+both platforms; it was missing from this table, so nothing recorded that it must stay that way. (83
+`VERIFY_FIRMWARE_IMAGE` is part of the same flow but is not itself a write, and is likewise unsent.)
 
 **Two guarded exceptions — both restarts, both non-destructive** (a restart keeps the strap's stored
 data and just re-advertises after boot). Neither is ever sent automatically or on any connect/offload path.

--- a/docs/WHOOP5_DEEP_DATA.md
+++ b/docs/WHOOP5_DEEP_DATA.md
@@ -57,7 +57,9 @@ Commands use the maverick/puffin envelope NOOP already implements
 ## The enable sequence (`Whoop5Config`)
 
 One `SET_CONFIG` (cmd `0x78`) per flag; the 40-byte body is the flag name as ASCII NUL-padded to 32
-bytes, the value byte (an ASCII `'1'`/`'2'`) at offset 32, then 7 zeros. The exact ordered set, with
+bytes, the value byte (an ASCII `'1'`/`'2'`) at offset 32, then 7 zeros. `SET_CONFIG` is the sender
+enum's name for it on both platforms; the protocol schema calls 120 `SET_FF_VALUE`, so that is what a
+strap log shows when the strap answers one. Same opcode, two names. The exact ordered set, with
 values, is in [`Whoop5Config.swift`](../Packages/WhoopProtocol/Sources/WhoopProtocol/Whoop5Config.swift)
 and [`Whoop5Config.kt`](../android/app/src/main/java/com/noop/protocol/Whoop5Config.kt), golden-tested on
 both platforms. `enable_r22_packets` is the one that opens the type-`0x2F` biometric stream; the rest


### PR DESCRIPTION
Android labelled an inbound `COMMAND_RESPONSE` from `CommandNumber` — the curated **sender** enum, 34 opcodes, destructive ones deliberately absent. iOS labels from the shared schema, which knows 80. The same strap bytes rendered `TOGGLE_LABRADOR_FILTERED(139)` on Apple and `0x8B(139)` on Android; 46 opcodes were hex-only there, and 77/119/120 printed a *different name* on each platform because the sender enum uses its own short case names.

#891 is what made it bite. An MG owner's three ECG-toggle replies are the evidence that issue turns on, and its ask is for other owners to run the same probes and post what they see. Half of them would have posted hex.

## The fix, and why not the obvious one

This is the #791 `EventNumber` treatment applied to the command table it never covered — with one difference. `EventNumber` could simply be completed, because nothing sends an event. Completing `CommandNumber` the same way would make `FORCE_TRIM`, `ENTER_BLE_DFU` and the firmware-load family constructible, which is the opposite of what its own doc comment promises ("curated, SAFE command codes for *sending*… so the in-app sender can never brick or wipe the device").

So the reader gets its own dictionary: a decode-only `CommandNames` map mirroring the schema, with `commandLabel()` reading from it. The sender enum is untouched.

## The label is load-bearing

Worth stating plainly, because it makes this more than a display change. `WhoopBleClient` reads `parsed["resp_cmd"]` back **as a String** and branches on `startsWith` — the same coupling that made #791's missing event names a behavioural bug rather than a cosmetic one. A `GET_DATA_RANGE` + `SUCCESS` pair releases the 5/MG history request during backfill, so a drifted label would silently demote that to the 2 s fail-open timer.

All five prefixes matched there (`GET_DATA_RANGE`, `REBOOT_STRAP`, `POWER_CYCLE_STRAP`, `SET_ALARM_TIME`, `GET_ALARM_TIME`) are byte-identical in the sender enum and the schema, which is why moving the source is behaviour-preserving. That was a coincidence rather than a guarantee, so it is now asserted. Swift has no `resp_cmd` consumer at all, so this coupling is Android-only.

The switch can also regress the *other* way: a command added to the sender enum but not the schema would log as bare hex — this same defect, aimed at the commands NOOP actually sends. Nothing is in that state today, and `everySendableCommandIsStillNamed` keeps it that way without depending on the Swift tree being present.

## Tests

`CommandCatalogueTest` holds the map in lockstep with the schema by **reading** it rather than restating it — the bug is "the schema grew and Android did not follow", so a test carrying its own copy would pass straight through a recurrence. It also asserts the destructive opcodes stay unsendable, that every sendable command stays named, that the load-bearing labels stay stable, that unknown opcodes stay hex, and decodes the three real MG replies. The Swift twin decodes the same frames and runs in CI, while `android.yml` is disabled.

The frames are committed as fixtures because they are the only real 5/MG `COMMAND_RESPONSE` frames in the tree with an inert payload — `01 01 00 00`, no device name, serial or session token. Byte 13 is `0x01` in all three and is deliberately **not** decoded into a field: whether it echoes the written value or reads back stored state is precisely what #891 cannot yet distinguish, and naming it would put a guess in a log (#194).

**The fixture earned its keep twice.** It caught a second, opposite divergence: Kotlin publishes `resp_seq` and `result` on a command response and Swift publishes neither, on either family — every Swift probe re-derives the result byte privately instead. Pre-existing and wider than this change, so filed as #894 rather than folded in; the Swift test asserts what that decoder exposes today.

## Docs

`docs/PROTOCOL.md` described the ECG family as "five consecutive codes around 0x7B–0x8B" against five names, while the table carries four non-contiguous codes and no code for `ECG_SEND_RAW` — the inconsistency #891 raises as hypothesis (c). Corrected, with what the MG actually confirmed (all three accepted, `SUCCESS(1)`, no data followed) and the note that NOOP sends none of them.

Also adds **142/143/144** to the destructive-command table. They are the high-opcode-space counterpart of 36/37/38, named by the schema, absent from both platforms' sender enums — and missing from that table, so nothing recorded that keeping them out was deliberate.

`docs/WHOOP5_DEEP_DATA.md` notes that 120 is `SET_CONFIG` in the sender enum and `SET_FF_VALUE` in the schema. That doc is read with a strap log open, and the log now prints the schema name on both platforms.

## Verification

No hardware. Nothing on the BLE write path changes — read-path labelling only, and the ECG question in #891 stays open.

- All 10 CI checks green.
- Kotlin protocol sources and the test compile (kotlinc 1.9.22 against the module's sources).
- 8 of 9 test methods run green locally. The ninth is the schema-lockstep check, which needs `org.json` this host lacks; its property was verified directly instead — 80/80 exact, both directions, and no sender-enum opcode absent from the schema.
- Decode re-run on all four frames: the three MG replies name their command with CRC16 header and CRC32 tail both valid, and the pre-existing battery fixture still reads 47.0% — no regression on the shared path.
- `Tools/doc_comment_lint.py` and `Tools/i18n_audit.py` pass.
