### PR TITLE
fix(android): repositoryInsertV18Aux_insertsThenPrunes has been red on main since #888

### DIFF
--- a/android/app/src/main/java/com/noop/data/WhoopRepository.kt
+++ b/android/app/src/main/java/com/noop/data/WhoopRepository.kt
@@ -374,8 +374,17 @@ class WhoopRepository(private val dao: WhoopDao) {
      * Persist one decoded batch under [deviceId]. Returns the number of rows actually inserted
      * per stream (0 for rows that already existed). Empty sub-lists compile/run nothing.
      * Port of WhoopStore.insert(_:deviceId:).
+     *
+     * [v18AuxRetentionRows] and [v18AuxPruneEveryRows] exist so the retention tests can pin the sweep's
+     * behaviour without banking 10,000 rows first; production callers take the shipped constants. Twin of
+     * the Swift `insert(_:deviceId:v18AuxRetentionRows:v18AuxPruneEveryRows:)` overload added in #888.
      */
-    suspend fun insert(streams: StreamBatch, deviceId: String): InsertCounts {
+    suspend fun insert(
+        streams: StreamBatch,
+        deviceId: String,
+        v18AuxRetentionRows: Int = V18_AUX_RETENTION_ROWS,
+        v18AuxPruneEveryRows: Int = V18_AUX_PRUNE_EVERY_ROWS,
+    ): InsertCounts {
         if (streams.isEmpty) return InsertCounts()
 
         val hrIds = if (streams.hr.isEmpty()) emptyList() else
@@ -455,8 +464,8 @@ class WhoopRepository(private val dao: WhoopDao) {
                 // Best-effort: the rows above are already committed, so a sweep failure must not surface
                 // as an insert failure and make Backfiller re-send a chunk it has already banked. Leaving
                 // the budget unspent means the next batch retries the sweep.
-                if (banked >= V18_AUX_PRUNE_EVERY_ROWS) {
-                    runCatching { dao.pruneV18Aux(deviceId, V18_AUX_RETENTION_ROWS) }
+                if (banked >= v18AuxPruneEveryRows) {
+                    runCatching { dao.pruneV18Aux(deviceId, v18AuxRetentionRows) }
                         .onSuccess { v18AuxRowsSincePrune[deviceId] = 0 }
                         // pruneV18Aux is a suspend call, so a scope cancellation arrives here as a
                         // CancellationException that runCatching would otherwise swallow — the caller would

--- a/android/app/src/test/java/com/noop/data/DeepCaptureMigrationTest.kt
+++ b/android/app/src/test/java/com/noop/data/DeepCaptureMigrationTest.kt
@@ -3,6 +3,7 @@ package com.noop.data
 import kotlinx.coroutines.runBlocking
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import java.lang.reflect.Proxy
@@ -84,39 +85,108 @@ class DeepCaptureMigrationTest {
 
     // MARK: - Rolling retention (insert plumbing through a Proxy DAO, the RawImuMigrationTest pattern)
 
-    /**
-     * `v18AuxSample` is CAPPED, not unbounded — the insert must follow the write with the rolling prune,
-     * passing the shipped constant. Twin of the Swift `testAuxRowsAreCappedNewestFirst`; the DELETE's own
-     * semantics are proved end-to-end there (no SQLite driver on this classpath).
-     */
-    @Test
-    fun repositoryInsertV18Aux_insertsThenPrunes() = runBlocking {
-        var inserted: List<V18AuxSampleEntity>? = null
+    /** One aux row banked, and the device+keep the repository passed to the sweep (null = never swept). */
+    private class AuxSweepRecorder {
+        var insertedBatches = 0
+        var insertedRows = 0
         var prunedDevice: String? = null
         var prunedKeep = -1
-        val dao = Proxy.newProxyInstance(
+        var sweeps = 0
+
+        val dao: WhoopDao = Proxy.newProxyInstance(
             WhoopDao::class.java.classLoader,
             arrayOf(WhoopDao::class.java),
         ) { _, method, args ->
             when (method.name) {
                 "insertV18Aux" -> {
                     @Suppress("UNCHECKED_CAST")
-                    inserted = args[0] as List<V18AuxSampleEntity>
-                    listOf(1L)
+                    val rows = args[0] as List<V18AuxSampleEntity>
+                    insertedBatches += 1
+                    insertedRows += rows.size
+                    List(rows.size) { 1L }
                 }
-                "pruneV18Aux" -> { prunedDevice = args[0] as String; prunedKeep = args[1] as Int; Unit }
+                "pruneV18Aux" -> {
+                    prunedDevice = args[0] as String; prunedKeep = args[1] as Int; sweeps += 1; Unit
+                }
                 else -> throw UnsupportedOperationException("v18-aux insert must not call ${method.name}")
             }
         } as WhoopDao
+    }
 
-        WhoopRepository(dao).insert(
-            StreamBatch(v18Aux = listOf(V18AuxRow(ts = 1_780_916_150L, statusWord = 1_792L))),
+    /** [n] aux rows that each pack to a non-empty blob, at distinct timestamps from [firstTs]. */
+    private fun auxRows(n: Int, firstTs: Long = 1_780_916_150L) =
+        StreamBatch(v18Aux = (0 until n).map { V18AuxRow(ts = firstTs + it, statusWord = 1_792L) })
+
+    /**
+     * `v18AuxSample` is CAPPED, not unbounded — the insert must follow the write with the rolling prune,
+     * passing the shipped retention constant. Twin of the Swift `testAuxRowsAreCappedNewestFirst`; the
+     * DELETE's own semantics are proved end-to-end there (no SQLite driver on this classpath).
+     *
+     * Passes `v18AuxPruneEveryRows = 1` for the same reason the Swift retention tests do since #888:
+     * the sweep is amortised in production, so a one-row batch would otherwise bank its row and defer.
+     */
+    @Test
+    fun repositoryInsertV18Aux_insertsThenPrunes() = runBlocking {
+        val rec = AuxSweepRecorder()
+
+        WhoopRepository(rec.dao).insert(
+            auxRows(1),
             "my-whoop",
+            v18AuxPruneEveryRows = 1,
         )
 
-        assertEquals(1, inserted!!.size)
-        assertEquals("my-whoop", prunedDevice)
-        assertEquals(WhoopRepository.V18_AUX_RETENTION_ROWS, prunedKeep)
+        assertEquals(1, rec.insertedRows)
+        assertEquals("my-whoop", rec.prunedDevice)
+        assertEquals(WhoopRepository.V18_AUX_RETENTION_ROWS, rec.prunedKeep)
+    }
+
+    // MARK: - Amortisation (#888) — Kotlin twins of the Swift DeepCaptureChannelsTests cases
+
+    /** Below the threshold the rows are banked and the walk is deferred: written, but never swept. */
+    @Test
+    fun repositoryInsertV18Aux_belowThresholdDefersTheSweep() = runBlocking {
+        val rec = AuxSweepRecorder()
+        WhoopRepository(rec.dao).insert(auxRows(3), "dev1", v18AuxPruneEveryRows = 5_000)
+        assertEquals(3, rec.insertedRows)
+        assertEquals(0, rec.sweeps)
+        assertNull(rec.prunedDevice)
+    }
+
+    /** Crossing the threshold — across batches, since the counter accumulates — sweeps exactly once. */
+    @Test
+    fun repositoryInsertV18Aux_sweepsOnceTheThresholdIsCrossed() = runBlocking {
+        val rec = AuxSweepRecorder()
+        val repo = WhoopRepository(rec.dao)
+        repo.insert(auxRows(3, firstTs = 1_000L), "dev1", v18AuxPruneEveryRows = 7)
+        assertEquals(0, rec.sweeps)
+        repo.insert(auxRows(3, firstTs = 2_000L), "dev1", v18AuxPruneEveryRows = 7)
+        assertEquals(0, rec.sweeps)
+        repo.insert(auxRows(3, firstTs = 3_000L), "dev1", v18AuxPruneEveryRows = 7)
+        assertEquals(1, rec.sweeps)
+        assertEquals("dev1", rec.prunedDevice)
+    }
+
+    /** The counter resets on a successful sweep, so a long offload sweeps repeatedly rather than once. */
+    @Test
+    fun repositoryInsertV18Aux_theAmortisationCounterResetsAfterEachSweep() = runBlocking {
+        val rec = AuxSweepRecorder()
+        val repo = WhoopRepository(rec.dao)
+        repeat(4) { repo.insert(auxRows(4, firstTs = 1_000L * (it + 1)), "dev1", v18AuxPruneEveryRows = 4) }
+        assertEquals(4, rec.sweeps)
+    }
+
+    /** The budget is per device — one strap's inserts must not spend another's. Fails on a shared counter. */
+    @Test
+    fun repositoryInsertV18Aux_theAmortisationBudgetIsNotSharedBetweenDevices() = runBlocking {
+        val rec = AuxSweepRecorder()
+        val repo = WhoopRepository(rec.dao)
+        repo.insert(auxRows(2, firstTs = 1_000L), "dev1", v18AuxPruneEveryRows = 4)
+        repo.insert(auxRows(2, firstTs = 2_000L), "dev2", v18AuxPruneEveryRows = 4)
+        // A shared counter would now stand at 4 and sweep here on dev1's second batch.
+        assertEquals(0, rec.sweeps)
+        repo.insert(auxRows(2, firstTs = 3_000L), "dev1", v18AuxPruneEveryRows = 4)
+        assertEquals(1, rec.sweeps)
+        assertEquals("dev1", rec.prunedDevice)
     }
 
     /** A batch whose aux rows all pack to nothing writes no row, so it must not sweep either. */


### PR DESCRIPTION
`DeepCaptureMigrationTest.repositoryInsertV18Aux_insertsThenPrunes` has been **red on `main` since #888 landed**.

Verified on a clean checkout of `main` at `2ff2af18` with nothing else applied:

```
com.noop.data.DeepCaptureMigrationTest > repositoryInsertV18Aux_insertsThenPrunes FAILED
    java.lang.AssertionError at DeepCaptureMigrationTest.kt:93
7 tests completed, 1 failed
```

I found it while running `testFullDebugUnitTest` as the local gate for an unrelated branch, and traced it back rather than assuming it was mine.

### Why it broke, and why nothing caught it

#888 amortised the `v18AuxSample` retention sweep on both platforms. On the Swift side it also added the seam the tests need: `WhoopStore.insert` gained an internal `v18AuxPruneEveryRows:` parameter, and the existing retention tests pass `1` so they still prove newest-N-rows without banking 10,000 rows first. That is exactly what the PR body describes under TESTS.

The Kotlin twin got the behaviour but not the seam. `WhoopRepository.insert` reads `V18_AUX_PRUNE_EVERY_ROWS` (10,000) directly, so the existing test — which inserts **one** row and then asserts `pruneV18Aux` was called — now asserts a sweep that amortisation correctly defers.

It stays invisible because the Android workflow gates pushes and PRs against this repo's own branches; a Kotlin unit-test regression arriving on a merge does not fail anything. The four new amortisation tests #888 added are Swift-only, so the Kotlin path has had the behaviour with no coverage of it since.

### The change

Mirrors the Swift seam rather than inventing a second one. `WhoopRepository.insert` takes `v18AuxRetentionRows` and `v18AuxPruneEveryRows` as **defaulted** parameters, so every production caller is unchanged and only tests pass anything.

The failing test now passes `v18AuxPruneEveryRows = 1` for the same reason the Swift ones do, and proves what it always meant to: a batch that wrote rows is followed by the rolling prune, carrying the shipped retention constant.

Adds the four amortisation cases as Kotlin twins of the Swift ones:

- deferred below the threshold — written, never swept
- swept once the threshold is crossed, **across batches**, so what is pinned is the counter accumulating rather than one big batch tripping it
- the counter resetting after each sweep, so a long offload sweeps repeatedly rather than once
- the budget not shared between devices — this one fails against a shared counter, which is the invariant #888's per-device map exists for

A shared `Proxy`-DAO recorder replaces the per-test one so the five cases read as variations on one setup instead of five copies of it.

No production behaviour changes: same constants, same sweep, same best-effort `runCatching` with the `CancellationException` rethrow.

### Verification

- `./gradlew testFullDebugUnitTest` on this branch: **3193 tests, 0 failures, 5 skipped** — `DeepCaptureMigrationTest`: 11 passed
- Same command on `main` immediately before: **1 failed**
