### PR TITLE
Check a fixture's provenance before citing it as evidence (#900)

### DIFF
--- a/Packages/WhoopProtocol/Tests/WhoopProtocolTests/Whoop4ResponseResultTests.swift
+++ b/Packages/WhoopProtocol/Tests/WhoopProtocolTests/Whoop4ResponseResultTests.swift
@@ -87,22 +87,33 @@ final class Whoop4ResponseResultTests: XCTestCase {
         XCTAssertNil(f.parsed["result"])
     }
 
-    /// A counterexample to the result-byte reading itself, pinned rather than left to surprise someone.
+    /// An oddity in one `GET_BATTERY_LEVEL` fixture, pinned rather than left to surprise someone.
     ///
-    /// This is a real 4.0 `GET_BATTERY_LEVEL` reply carrying a valid 42.5% — it plainly succeeded — and its
-    /// `pay[1]` is `0x00`, which the #791 mapping renders `FAILURE(0)`. The parity corpus frame below and the
-    /// Kotlin `FramingTest` battery fixture (91.2%) both have that shape, so it is not a one-off.
+    /// The frame carries a valid 42.5% — it plainly succeeded — yet `pay[1]` is `0x00`, which the #791
+    /// mapping renders `FAILURE(0)`, and `pay[0]` is `0x00` too, so the whole `[seq][result]` prefix reads
+    /// as zero.
     ///
-    /// The #791 evidence for `pay[1] == result` was an answered `GET_DATA_RANGE` (`0x01`) against an empty
-    /// `GET_EXTENDED_BATTERY_INFO` (`0x00`), which those two frames fit and this one does not.
+    /// **How much that is worth is very little, which #900 established the slow way.** Four in-tree 4.0
+    /// battery fixtures share this shape, and three of them are declared generated in their own files:
+    /// `StreamsTests` ("Synthetic, protocol-valid frames … No real biometric capture is embedded", and
+    /// `(synthetic)` again at the fixture), `FramingTests` ("Synthetic, CRC-valid frames … (no real
+    /// capture)"), and the Kotlin `FramingTest` ("All vectors were generated independently (Python …)").
+    /// Zero bytes in a generated vector are whatever the generator emitted.
     ///
-    /// The telling detail is that `resp_seq` is `0` here too — the whole two-byte prefix is zeroed, where
-    /// every other real capture in the tree (both families) carries a plausible non-zero echo. So the likely
-    /// reading is not that `0x00` means something other than FAILURE, but that a 4.0 battery reply does not
-    /// carry a `[seq][result]` prefix at all, its value simply sitting at a fixed `pay[2..4]`. Android has
-    /// rendered this same frame as FAILURE since #791, so the question is upstream of this change rather
-    /// than introduced by it — matching the twin is the point here. Tracked in #900; asserted meanwhile so
-    /// the behaviour is deliberate and a future correction has to come past this test.
+    /// That leaves this one, from the parity corpus, which `docs/BLE_REVERSE_ENGINEERING.md` describes as
+    /// captured frames — but it shares a byte-identical header with the synthetic `StreamsTests` frame
+    /// (`aa0f00c324141a`, differing only in the value bytes), which is what one test vector derived from
+    /// another looks like, and the repo's single squashed initial commit leaves no history to check. So the
+    /// count of confirmed-real captures behind the apparent counterexample is somewhere between zero and
+    /// one.
+    ///
+    /// Meanwhile the mapping itself is supported by real captures: `GET_EXTENDED_BATTERY_INFO` answers
+    /// `SUCCESS(1)` with `resp_seq` 13 and real data in `ExtendedBatteryProbeTests.realFrame`, and
+    /// `FAILURE(0)` with `resp_seq` 34 and an empty body in the #791 capture — the same command, both
+    /// outcomes, the byte discriminating them correctly.
+    ///
+    /// So this is asserted to keep the behaviour deliberate, not as evidence against #791. #900 tracks the
+    /// one thing that would resolve it: a single 4.0 battery capture of known provenance.
     func testSuccessfulBatteryReadStillReportsResultZero() {
         let f = parseFrame(bytes("aa0f00c324141a0000a9010000000052cd1a49"))
         XCTAssertEqual(f.crcOK, true)

--- a/android/app/src/test/java/com/noop/protocol/FramingTest.kt
+++ b/android/app/src/test/java/com/noop/protocol/FramingTest.kt
@@ -240,6 +240,10 @@ class FramingTest {
     @Test
     fun parse_commandResponse_getBatteryLevel() {
         // COMMAND_RESPONSE GET_BATTERY_LEVEL(26): soc=912 -> 91.2%.
+        // GENERATED, not captured — see this class's header. Its [seq][result] prefix is 00 00 on a
+        // reply that succeeded, which reads as a counterexample to the #791 result-byte mapping, and it
+        // was cited as one in #900 by someone who had not read that header. Zero bytes in a generated
+        // vector are whatever the generator emitted. Nothing below asserts the result byte. (#900)
         val frame = bytes(
             0xaa, 0x0b, 0x00, 0x97, 0x24, 0x00, 0x1a, 0x00, 0x00, 0x90, 0x03, 0x72,
             0x96, 0x86, 0x64,

--- a/docs/BLE_REVERSE_ENGINEERING.md
+++ b/docs/BLE_REVERSE_ENGINEERING.md
@@ -861,6 +861,27 @@ output in `Tests/WhoopProtocolTests/Resources/` (`frames.json`, `golden.json`,
 decoder reproduces them byte-for-byte. Prefer real captures over invented offsets — unmapped regions
 are kept raw and labelled rather than guessed.
 
+**Check where a fixture came from before citing it as evidence.** A generated vector and a real
+capture are interchangeable for testing a decoder and are *not* interchangeable as evidence about
+firmware — once committed they look identical, and a CRC-valid synthetic frame is as convincing as a
+captured one.
+
+Provenance is generally declared, but **at the top of the file, not at each fixture**: `StreamsTests`
+and `FramingTests` both open by saying their frames are synthetic and that no real capture is
+embedded, the Kotlin `FramingTest` says its vectors were generated independently in Python, and
+`ExtendedBatteryProbeTests.realFrame` names the device it came off. Read that header before quoting a
+frame in an issue.
+
+This is not bookkeeping. #900 was filed against a decode that four in-tree fixtures appeared to
+contradict; three of the four declare themselves generated in exactly those headers, and the fourth
+shares a byte-identical envelope with one of them — a vector derived from another vector keeps its
+header, so a synthetic frame can read as corroboration of the original it was copied from. The issue
+went through two rounds of correction before anyone opened the files.
+
+Two habits follow: state provenance for a new fixture, at the fixture when the frame is the kind
+likely to be quoted outside its own file; and when a decode looks contradicted, check what the
+contradicting bytes actually are before changing the decoder.
+
 ### A note on whoop5 offsets
 
 If you map the WHOOP 5.0 biometric fields, do it in `parseFrameWhoop5` (inner record at offset 8) and


### PR DESCRIPTION
No behaviour change, no assertion change. This corrects claims in the tree, and the habit that produced them.

## What happened

#900 was filed against a decode that four in-tree WHOOP 4.0 battery fixtures appeared to contradict — each shows a zeroed `[seq][result]` prefix on a reply carrying a valid percentage, so a successful read renders `FAILURE(0)`.

**Three of the four declare themselves generated, in their own file headers:**

| fixture | what its file says |
|---|---|
| `StreamsTests` (25.5%) | "Synthetic, protocol-valid frames … No real biometric capture is embedded" — plus `(synthetic)` at the fixture |
| `FramingTests` (25.5%) | "Synthetic, CRC-valid frames built by `scripts/gen_synthetic_fixtures.py` (no real capture)" |
| Kotlin `FramingTest` (91.2%) | "All vectors were generated independently (Python: zlib CRC-32, table CRC-8, CRC16-Modbus)" |

Zero bytes in a generated vector are whatever the generator emitted. The fourth is the parity-corpus frame, which `BLE_REVERSE_ENGINEERING.md` describes as captured — but it shares a **byte-identical envelope** with the `StreamsTests` synthetic (`aa0f00c324141a`, differing only in the value bytes), which is what a vector derived from another vector looks like, and the repo's single squashed initial commit leaves no history to check.

So the confirmed-real captures behind the counterexample number between zero and one. Meanwhile the mapping it questioned has real support, same command, both outcomes:

| capture | resp_seq | result | body |
|---|---:|---|---|
| `GET_EXTENDED_BATTERY_INFO` (`ExtendedBatteryProbeTests.realFrame`) | 13 | `SUCCESS(1)` | 29 bytes, mV=3970 |
| `GET_EXTENDED_BATTERY_INFO` (#791) | 34 | `FAILURE(0)` | all zeros |

## Why the decoder is not being changed

Special-casing `GET_BATTERY_LEVEL` to withhold the two fields would mean reacting to generator output, against a mapping real captures support. That would be the actual mistake.

## What changes

- The Swift test's doc states what each fixture's provenance actually is, quoting the headers, so the assertion reads as pinning behaviour rather than as evidence against #791.
- The Kotlin fixture is annotated **GENERATED, not captured**, pointing at its own class header.
- `BLE_REVERSE_ENGINEERING.md` records that provenance is declared **at the top of the file, not at each fixture**, and asks that it be read before a frame is quoted in an issue.

That last point is the real finding, and it is not the one I expected. The repo's provenance hygiene was already good — every one of those files says what it is. The failure was mine: I read the ten lines around each fixture and never the header, and #900 went through two rounds of correction because of it. The guidance now says where to look, and asks for a fixture-level note only for frames likely to be quoted outside their own file.

Every phrase attributed to a source file in the diff was checked to appear in it verbatim.
