### PR TITLE
Make the Kotlin v18-aux prune threshold injectable, as Swift's already is (#888)

### DIFF
--- a/android/app/src/main/java/com/noop/data/WhoopRepository.kt
+++ b/android/app/src/main/java/com/noop/data/WhoopRepository.kt
@@ -373,9 +373,19 @@ class WhoopRepository(private val dao: WhoopDao) {
     /**
      * Persist one decoded batch under [deviceId]. Returns the number of rows actually inserted
      * per stream (0 for rows that already existed). Empty sub-lists compile/run nothing.
-     * Port of WhoopStore.insert(_:deviceId:).
+     * Port of WhoopStore.insert(_:deviceId:v18AuxRetentionRows:v18AuxPruneEveryRows:).
      */
-    suspend fun insert(streams: StreamBatch, deviceId: String): InsertCounts {
+    suspend fun insert(
+        streams: StreamBatch,
+        deviceId: String,
+        // Injectable for the same reason the Swift twin takes them as parameters rather than reading the
+        // statics: once the v18-aux sweep became amortised, a test could no longer observe it at all
+        // without inserting 10 000 rows. `StreamStore.insert(_:deviceId:v18AuxRetentionRows:
+        // v18AuxPruneEveryRows:)` is the shape being mirrored. Production callers pass neither and get the
+        // shipped constants. (#888)
+        v18AuxRetentionRows: Int = V18_AUX_RETENTION_ROWS,
+        v18AuxPruneEveryRows: Int = V18_AUX_PRUNE_EVERY_ROWS,
+    ): InsertCounts {
         if (streams.isEmpty) return InsertCounts()
 
         val hrIds = if (streams.hr.isEmpty()) emptyList() else
@@ -455,8 +465,8 @@ class WhoopRepository(private val dao: WhoopDao) {
                 // Best-effort: the rows above are already committed, so a sweep failure must not surface
                 // as an insert failure and make Backfiller re-send a chunk it has already banked. Leaving
                 // the budget unspent means the next batch retries the sweep.
-                if (banked >= V18_AUX_PRUNE_EVERY_ROWS) {
-                    runCatching { dao.pruneV18Aux(deviceId, V18_AUX_RETENTION_ROWS) }
+                if (banked >= v18AuxPruneEveryRows) {
+                    runCatching { dao.pruneV18Aux(deviceId, v18AuxRetentionRows) }
                         .onSuccess { v18AuxRowsSincePrune[deviceId] = 0 }
                         // pruneV18Aux is a suspend call, so a scope cancellation arrives here as a
                         // CancellationException that runCatching would otherwise swallow — the caller would

--- a/android/app/src/test/java/com/noop/data/DeepCaptureMigrationTest.kt
+++ b/android/app/src/test/java/com/noop/data/DeepCaptureMigrationTest.kt
@@ -112,11 +112,84 @@ class DeepCaptureMigrationTest {
         WhoopRepository(dao).insert(
             StreamBatch(v18Aux = listOf(V18AuxRow(ts = 1_780_916_150L, statusWord = 1_792L))),
             "my-whoop",
+            // Threshold 1 so a single row crosses it. Before #888 the sweep ran on every batch and this
+            // test passed without saying anything about the threshold; once the sweep became amortised at
+            // 10 000 rows, one row could no longer trigger it and this assertion could not hold. The Swift
+            // twin was given injectable parameters in that PR and this one was not, so it has been failing
+            // on main ever since — invisibly, because android.yml is disabled.
+            v18AuxPruneEveryRows = 1,
         )
 
         assertEquals(1, inserted!!.size)
         assertEquals("my-whoop", prunedDevice)
         assertEquals(WhoopRepository.V18_AUX_RETENTION_ROWS, prunedKeep)
+    }
+
+    /**
+     * Under the threshold the sweep must NOT run — overshoot is the whole point of amortising it, and a
+     * sweep per batch is the cost #888 removed. Twin of Swift's
+     * `testRetentionSweepIsDeferredBelowTheThreshold`.
+     */
+    @Test
+    fun repositoryInsertV18Aux_defersSweepBelowTheThreshold(): Unit = runBlocking {
+        var pruneCalls = 0
+        val dao = Proxy.newProxyInstance(
+            WhoopDao::class.java.classLoader,
+            arrayOf(WhoopDao::class.java),
+        ) { _, method, _ ->
+            when (method.name) {
+                "insertV18Aux" -> listOf(1L)
+                "pruneV18Aux" -> { pruneCalls++; Unit }
+                else -> throw UnsupportedOperationException("v18-aux insert must not call ${method.name}")
+            }
+        } as WhoopDao
+
+        val repo = WhoopRepository(dao)
+        repeat(3) { i ->
+            repo.insert(
+                StreamBatch(v18Aux = listOf(V18AuxRow(ts = 1_780_916_150L + i, statusWord = 1_792L))),
+                "my-whoop",
+                v18AuxPruneEveryRows = 5_000,
+            )
+        }
+        assertEquals("three rows must not reach a 5 000-row budget", 0, pruneCalls)
+    }
+
+    /**
+     * Once the banked count crosses the threshold the sweep runs, and the counter resets so the next
+     * window has to earn its own sweep. Twin of Swift's `testRetentionSweepRunsOnceTheThresholdIsCrossed`
+     * and `testTheAmortisationCounterResetsAfterEachSweep`.
+     */
+    @Test
+    fun repositoryInsertV18Aux_sweepsOnThresholdThenResets(): Unit = runBlocking {
+        var pruneCalls = 0
+        val dao = Proxy.newProxyInstance(
+            WhoopDao::class.java.classLoader,
+            arrayOf(WhoopDao::class.java),
+        ) { _, method, _ ->
+            when (method.name) {
+                "insertV18Aux" -> listOf(1L)
+                "pruneV18Aux" -> { pruneCalls++; Unit }
+                else -> throw UnsupportedOperationException("v18-aux insert must not call ${method.name}")
+            }
+        } as WhoopDao
+
+        val repo = WhoopRepository(dao)
+        // Two rows per batch against a budget of 3: after batch 1 banked=2 (no sweep), after batch 2
+        // banked=4 (sweep, reset to 0), after batch 3 banked=2 (no second sweep).
+        repeat(3) { i ->
+            repo.insert(
+                StreamBatch(
+                    v18Aux = listOf(
+                        V18AuxRow(ts = 1_780_916_150L + i * 2, statusWord = 1_792L),
+                        V18AuxRow(ts = 1_780_916_151L + i * 2, statusWord = 1_792L),
+                    ),
+                ),
+                "my-whoop",
+                v18AuxPruneEveryRows = 3,
+            )
+        }
+        assertEquals("exactly one sweep — the counter must reset after it", 1, pruneCalls)
     }
 
     /** A batch whose aux rows all pack to nothing writes no row, so it must not sweep either. */


### PR DESCRIPTION
`DeepCaptureMigrationTest.repositoryInsertV18Aux_insertsThenPrunes` has been **failing on main since #888**. Found by @vishk23 while running the suite for #896, and correctly identified there as pre-existing rather than theirs.

## What broke

#888 made the v18-aux sweep amortised — `WhoopRepository` prunes once per `V18_AUX_PRUNE_EVERY_ROWS` (10 000) rows instead of on every batch. The test inserts **one** row and asserts `pruneV18Aux` fired, which the amortised path cannot do.

The Swift half of #888 handled exactly this: `StreamStore.insert` takes `v18AuxRetentionRows` and `v18AuxPruneEveryRows` as parameters, and `DeepCaptureChannelsTests` passes `1`, `7` and `5_000` to exercise the sweep, the deferral and the counter reset. The Kotlin twin kept reading the companion constants, so no test could observe a sweep without inserting ten thousand rows — and the one test that tried was left asserting pre-#888 behaviour.

`android.yml` is disabled, so nothing reported it. That is the cost of the gap, made concrete.

## The fix

`WhoopRepository.insert` takes both as defaulted parameters, mirroring the Swift signature. Production callers pass neither and get the shipped constants. Every existing call site passes exactly two arguments, so appending defaulted parameters leaves them binding as before — checked, not assumed.

The alternative was loosening the assertion to accept no sweep, which would have deleted the only Kotlin coverage of the retention path rather than fixing it.

## Coverage brought up to Swift's

The fixed test now says why it needs a threshold of 1. Two more pin the amortisation itself:

- three rows against a 5 000-row budget sweep nothing (`testRetentionSweepIsDeferredBelowTheThreshold`)
- two rows per batch against a budget of 3 sweep exactly once, because the counter resets (`testRetentionSweepRunsOnceTheThresholdIsCrossed` + `testTheAmortisationCounterResetsAfterEachSweep`)

## Verification

- The three expected sweep counts were re-derived by simulating the exact gate — banked accumulates per device, sweeps at `>= budget`, resets only on a successful sweep — rather than by arithmetic in my head. All three match.
- All `.insert(` call sites checked for positional-argument binding.
- `doc_comment_lint` passes.

**Not compiled.** Gradle cannot run on this host (aapt2 is x86-64 only) and no CI job builds Android. Worth a local `./gradlew testFullDebugUnitTest` before merge — and this PR is itself the argument for enabling `android.yml`, since a disabled job is why a red test sat on main unnoticed.
