### PR TITLE
Pin the first real 5/MG FAILURE response, from the #891 wrist pair

### DIFF
--- a/Packages/WhoopProtocol/Tests/WhoopProtocolTests/Whoop5CommandResponseTests.swift
+++ b/Packages/WhoopProtocol/Tests/WhoopProtocolTests/Whoop5CommandResponseTests.swift
@@ -112,10 +112,49 @@ final class Whoop5CommandResponseTests: XCTestCase {
         XCTAssertEqual(f.parsed["battery_pct"]?.doubleValue, 47)
     }
 
+    /// A real `SELECT_WRIST(123)` pair from the same MG, one accepted and one refused (#891).
+    ///
+    /// These are the first REAL 5/MG frames in the tree carrying `result = FAILURE(0)` — every other
+    /// non-SUCCESS fixture here is a synthetic `GET_HELLO`. So until now the FAILURE branch of this
+    /// decoder had never been exercised by bytes a strap actually sent, on this family. They are also a
+    /// success/failure pair on ONE opcode, which is the shape that made the 4.0 result mapping credible
+    /// (`GET_EXTENDED_BATTERY_INFO` answering both ways) — 5/MG now has its own.
+    ///
+    /// Provenance: WHOOP 5 MG `WS50_r03`, build 215, posted with the raw frames in #891. Payload is inert —
+    /// `01 01 00 00` and `00 01 00 00`, no name, serial or token. Both re-verified here: CRC16-Modbus
+    /// header, CRC32 tail, declared length.
+    ///
+    /// The strap accepted `arg=1` and refused `arg=0` minutes apart in one session, so the refusal is not
+    /// "the opcode is unknown". Whether that is a strap refusing a real mutation or `0` simply not being a
+    /// valid argument is open — `docs/PROTOCOL.md` flags the right=0/left=1 mapping as inferred from the
+    /// vendor client's enum order, never attested. Nothing here decides it; the frames are pinned so the
+    /// decode of both outcomes is fixed while the meaning is argued elsewhere.
+    func testRealMgSelectWristAcceptedAndRefused() {
+        let accepted = parseFrame(bytes("aa010c000100271124d77b81010100007ce76722"), family: .whoop5)
+        XCTAssertEqual(accepted.crcOK, true)
+        XCTAssertEqual(accepted.parsed["resp_cmd"]?.stringValue, "SELECT_WRIST(123)")
+        XCTAssertEqual(accepted.parsed["resp_seq"]?.intValue, 129)
+        XCTAssertEqual(accepted.parsed["result"]?.stringValue, "SUCCESS(1)")
+
+        let refused = parseFrame(bytes("aa010c000100271124217bcc000100000213163d"), family: .whoop5)
+        XCTAssertEqual(refused.crcOK, true)
+        XCTAssertEqual(refused.parsed["resp_cmd"]?.stringValue, "SELECT_WRIST(123)")
+        XCTAssertEqual(refused.parsed["resp_seq"]?.intValue, 204)
+        XCTAssertEqual(refused.parsed["result"]?.stringValue, "FAILURE(0)")
+    }
+
     /// Byte 13 — the first response-payload byte, where `GET_BATTERY_LEVEL` returns its percent — is `0x01`
-    /// in all three replies. It is deliberately NOT decoded into a field: whether it echoes the value that
-    /// was written or reads back stored state is precisely what #891 cannot yet distinguish, and naming it
-    /// would put a guess in the log. Fail closed (#194).
+    /// in every one of these replies, and is deliberately NOT decoded into a field.
+    ///
+    /// #891 has since narrowed what it is without settling it. A `SELECT_WRIST` sent with `arg=0` came back
+    /// with byte 13 = 1, which refutes the echo reading outright — an echo would have returned 0. It does
+    /// not establish the read-back reading, though: across all eight MG command responses on record, over
+    /// four opcodes and both result codes, byte 13 has taken exactly one value. A constant fits every
+    /// observation as well as stored state does, and is simpler. Separating them needs a reply whose stored
+    /// value is 0 — a strap set to the other wrist.
+    ///
+    /// So the slot stays undecoded, for a sharper reason than before: naming it would encode the unproven
+    /// half of a result that only refuted the alternative. Fail closed (#194).
     func testNoValueIsInventedFromAToggleReply() {
         let f = parseFrame(bytes(mgToggleReplies[0].hex), family: .whoop5)
         XCTAssertNil(f.parsed["battery_pct"])

--- a/android/app/src/test/java/com/noop/protocol/CommandCatalogueTest.kt
+++ b/android/app/src/test/java/com/noop/protocol/CommandCatalogueTest.kt
@@ -206,6 +206,34 @@ class CommandCatalogueTest {
     }
 
     /**
+     * A real `SELECT_WRIST(123)` pair from the same MG, one accepted and one refused (#891).
+     *
+     * The refusal is the first REAL 5/MG frame in the tree carrying `result = FAILURE(0)` — every other
+     * non-SUCCESS fixture on this family is a synthetic `GET_HELLO`, so that branch of the decode had
+     * never been exercised by bytes a strap actually sent. Together they are a success/failure pair on
+     * one opcode, the shape that made the 4.0 result mapping credible.
+     *
+     * Provenance: WHOOP 5 MG `WS50_r03`, build 215, posted with the raw frames in #891. Payload inert.
+     * The strap accepted `arg=1` and refused `arg=0` minutes apart in one session, so the refusal is not
+     * "unknown opcode"; whether it refuses a real mutation or `0` is simply invalid is open, and nothing
+     * here decides it. The Swift twin asserts these identical bytes.
+     */
+    @Test
+    fun realMgSelectWristAcceptedAndRefused() {
+        val accepted = Framing.parseFrame(bytes("aa010c000100271124d77b81010100007ce76722"), DeviceFamily.WHOOP5)
+        assertEquals(true, accepted.crcOk)
+        assertEquals("SELECT_WRIST(123)", accepted.parsed["resp_cmd"])
+        assertEquals(129, accepted.parsed["resp_seq"])
+        assertEquals("SUCCESS(1)", accepted.parsed["result"])
+
+        val refused = Framing.parseFrame(bytes("aa010c000100271124217bcc000100000213163d"), DeviceFamily.WHOOP5)
+        assertEquals(true, refused.crcOk)
+        assertEquals("SELECT_WRIST(123)", refused.parsed["resp_cmd"])
+        assertEquals(204, refused.parsed["resp_seq"])
+        assertEquals("FAILURE(0)", refused.parsed["result"])
+    }
+
+    /**
      * The toggles are not battery reads, so nothing may be claimed from the value slot.
      *
      * Byte 13 — the first response-payload byte, where `GET_BATTERY_LEVEL` returns its percent — is `0x01`


### PR DESCRIPTION
Fixtures and rationale only — no production code changes.

## The gap

No real WHOOP 5/MG frame in the tree carries `result = FAILURE(0)`. The only non-SUCCESS fixtures on that family are the two **synthetic** `GET_HELLO` frames, so the FAILURE branch of the result decode added in #899 has never been exercised by bytes a strap actually sent.

#891's latest hardware runs supply one. The same MG **accepted** `SELECT_WRIST` with `arg=1` and **refused** it with `arg=0`, minutes apart in one session:

| frame | resp_cmd | resp_seq | result |
|---|---|---:|---|
| `aa010c…d77b81010100007ce76722` | `SELECT_WRIST(123)` | 129 | `SUCCESS(1)` |
| `aa010c…217bcc000100000213163d` | `SELECT_WRIST(123)` | 204 | `FAILURE(0)` |

That is a success/failure pair on one opcode — the shape that made the 4.0 result mapping credible once `GET_EXTENDED_BATTERY_INFO` was seen answering both ways, and which 5/MG had no equivalent of. It is also the first fixture for opcode 123 on either family.

## Verification

Both frames re-decoded before committing — CRC16-Modbus header, CRC32 tail, declared length, and every field checked against the decoder rather than by hand. Provenance stated at the fixture per #903: WHOOP 5 MG `WS50_r03`, build 215, posted with the raw bytes in #891. Payloads are inert (`01 01 00 00` and `00 01 00 00`) — no name, serial or token. Swift and Kotlin assert the identical bytes.

## What is deliberately not decided

The refusal is not interpreted. The strap ran the same opcode successfully minutes earlier so it is not "unknown command", but whether it refuses a real mutation or whether `0` is simply not a valid argument is open — `docs/PROTOCOL.md` flags right=0/left=1 as inferred from the vendor client's enum order, never attested. The test pins the decode of both outcomes and leaves the meaning to #891.

Also sharpens why **byte 13 stays undecoded**. The new run sent `arg=0` and got byte 13 = `1`, which refutes the echo reading outright. It does not establish read-back: across all eight MG command responses now on record — four opcodes, both result codes — byte 13 has taken exactly one value, so a constant fits every observation as well as stored state does and is simpler. Naming the slot would encode the unproven half of a result that only refuted the alternative.

`docs/PROTOCOL.md` is deliberately untouched: #896 is revising that same ECG section, and the hardware finding is already recorded in #891 and now at the fixture. Happy to add a paragraph there once #896 lands.
