### PR TITLE
perf(store): let SQLite's MIN/MAX optimization fire on the HR data frontier

### DIFF
--- a/Packages/WhoopStore/Sources/WhoopStore/Reads.swift
+++ b/Packages/WhoopStore/Sources/WhoopStore/Reads.swift
@@ -281,13 +281,19 @@ extension WhoopStore {
     /// Coalesces measured `hrSample` with PPG-derived `ppgHrSample` (#156) so a PPG-only offload (a v26
     /// WHOOP 5 night with no measured HR) still advances the frontier. The two persist in the same
     /// offload, so this only ever moves the watchdog forward when the strap really logged + offloaded.
+    /// Each arm is its OWN `SELECT MAX(ts)` rather than one `MAX(ts)` over a `UNION ALL` of the two
+    /// timestamp streams. SQLite's MIN/MAX optimization only fires on a bare `SELECT MAX(col)` that can
+    /// seek the last matching index entry; wrapping the columns in a compound subquery first makes the
+    /// planner materialize that subquery, walking EVERY index entry for the device. On a 746 MB store
+    /// (3.1M hrSample rows) the old shape measured 4.3–5.8 s per call and this one 0.01–0.07 s — the
+    /// same answer, verified equal for every device id including one with no rows (both NULL).
     public func latestHRSampleTs(deviceId: String) async throws -> Int? {
         try syncRead { db in
             try Int.fetchOne(db, sql: """
-                SELECT MAX(ts) FROM (
-                    SELECT ts FROM hrSample WHERE deviceId = ?
+                SELECT MAX(m) FROM (
+                    SELECT (SELECT MAX(ts) FROM hrSample WHERE deviceId = ?) AS m
                     UNION ALL
-                    SELECT ts FROM ppgHrSample WHERE deviceId = ?
+                    SELECT (SELECT MAX(ts) FROM ppgHrSample WHERE deviceId = ?)
                 )
                 """, arguments: [deviceId, deviceId])
         }

--- a/Packages/WhoopStore/Tests/WhoopStoreTests/LatestSampleTests.swift
+++ b/Packages/WhoopStore/Tests/WhoopStoreTests/LatestSampleTests.swift
@@ -28,4 +28,36 @@ final class LatestSampleTests: XCTestCase {
         let latest = try await store.latestHRSampleTs(deviceId: "d")
         XCTAssertEqual(latest, 300)
     }
+
+    /// The mirror of the test above: when the MEASURED stream is the newer one, it must win. Together
+    /// the pair pins "max over BOTH streams" rather than "whichever stream is checked last", which is
+    /// the property the per-arm `SELECT MAX(ts)` form has to preserve.
+    func testLatestHRSampleTsPrefersNewerMeasuredRowOverOlderPpg() async throws {
+        let store = try await WhoopStore.inMemory()
+        try await store.upsertDevice(id: "d", mac: nil, name: nil)
+        _ = try await store.insert(
+            Streams(ppgHr: [PpgHrSample(ts: 300, bpm: 62, conf: 0.8)]), deviceId: "d")
+        _ = try await store.insert(Streams(hr: [HRSample(ts: 900, bpm: 60)]), deviceId: "d")
+
+        let latest = try await store.latestHRSampleTs(deviceId: "d")
+        XCTAssertEqual(latest, 900)
+    }
+
+    /// The frontier is per-device: a second strap's newer rows must not advance this one's watchdog.
+    func testLatestHRSampleTsIsScopedToTheRequestedDevice() async throws {
+        let store = try await WhoopStore.inMemory()
+        try await store.upsertDevice(id: "a", mac: nil, name: nil)
+        try await store.upsertDevice(id: "b", mac: nil, name: nil)
+        _ = try await store.insert(Streams(hr: [HRSample(ts: 100, bpm: 60)]), deviceId: "a")
+        _ = try await store.insert(Streams(hr: [HRSample(ts: 9_000, bpm: 61)]), deviceId: "b")
+        _ = try await store.insert(
+            Streams(ppgHr: [PpgHrSample(ts: 8_000, bpm: 62, conf: 0.8)]), deviceId: "b")
+
+        let a = try await store.latestHRSampleTs(deviceId: "a")
+        XCTAssertEqual(a, 100)
+        // And a device that has never reported stays nil even while other devices have rows.
+        try await store.upsertDevice(id: "c", mac: nil, name: nil)
+        let c = try await store.latestHRSampleTs(deviceId: "c")
+        XCTAssertNil(c)
+    }
 }


### PR DESCRIPTION
`latestHRSampleTs` — the biometric "data frontier" behind the stuck-strap watchdog and `FullDayChartView`'s land-on-the-latest-day `.task` — asks for `MAX(ts)` over a `UNION ALL` of the `hrSample` and `ppgHrSample` timestamp columns.

SQLite's MIN/MAX optimization only applies to a bare `SELECT MAX(col)` that can seek the last matching index entry. Putting the columns inside a compound subquery first defeats it: the planner materializes the subquery, so the query walks **every** index entry for that device rather than seeking two.

Giving each stream its own scalar `SELECT MAX(ts)` returns the identical answer and lets both arms seek.

### Query plan

Before — two full covering-index scans feeding a co-routine:

```
|--CO-ROUTINE (subquery-2)
|  `--COMPOUND QUERY
|     |--LEFT-MOST SUBQUERY
|     |  `--SEARCH hrSample USING COVERING INDEX sqlite_autoindex_hrSample_1 (deviceId=?)
|     `--UNION ALL
|        `--SEARCH ppgHrSample USING COVERING INDEX sqlite_autoindex_ppgHrSample_1 (deviceId=?)
`--SEARCH (subquery-2)
```

After — two seeks:

```
|--CO-ROUTINE (subquery-4)
|  `--COMPOUND QUERY
|     |--LEFT-MOST SUBQUERY
|     |  |--SCAN CONSTANT ROW
|     |  `--SCALAR SUBQUERY 1
|     |     `--SEARCH hrSample USING COVERING INDEX sqlite_autoindex_hrSample_1 (deviceId=?)
|     `--UNION ALL
|        |--SCAN CONSTANT ROW
|        `--SCALAR SUBQUERY 3
|           `--SEARCH ppgHrSample USING COVERING INDEX sqlite_autoindex_ppgHrSample_1 (deviceId=?)
`--SEARCH (subquery-4)
```

### Measurement

Real 746 MB store (3,180,711 `hrSample` rows, 36,589 `ppgHrSample`), warm cache, with the app's own pragmas (`cache_size=-16000`, `mmap_size=268435456`, `temp_store=MEMORY`), three runs each:

| | run 1 | run 2 | run 3 |
|---|---|---|---|
| before | 4.29 s | 5.55 s | 5.84 s |
| after | 0.07 s | 0.01 s | 0.02 s |

Cold-cache first call was 8.15 s before / 0.04 s after.

The absolute numbers scale with history size — a small store will not notice — but the shape is wrong at any size, and this is on two paths a user waits on.

### Correctness

Verified identical on every device id in that store, plus one that does not exist (both `NULL`):

| deviceId | before | after |
|---|---|---|
| `my-whoop` | 1785173103 | 1785173103 |
| `oura-api` | 1781359879 | 1781359879 |
| (nonexistent) | NULL | NULL |

`MAX` ignores `NULL`, so a device with rows in only one stream still returns that stream's max, and one with no rows in either still returns `NULL` — the existing `testLatestHRSampleTs` (empty → nil) and `testLatestHRSampleTsIncludesPpgFallbackRows` (#156 PPG-only offload) both pass unchanged.

Two tests added to pin the property the rewrite has to preserve, since the two arms are now evaluated independently:

- `testLatestHRSampleTsPrefersNewerMeasuredRowOverOlderPpg` — the mirror of the existing PPG test, so the pair pins "max over **both** streams" rather than "whichever arm is checked last".
- `testLatestHRSampleTsIsScopedToTheRequestedDevice` — a second strap's newer rows must not advance this one's frontier, and a device that never reported stays `nil` while others have rows.

`swift test` in `Packages/WhoopStore`: **332 tests, 0 failures.**
