### PR TITLE
perf(liquid): pose the live gauges still in Low Power Mode

### DIFF
--- a/Strand/Liquid/LiquidCore.swift
+++ b/Strand/Liquid/LiquidCore.swift
@@ -285,3 +285,30 @@ func liquidWave(_ x: Double, amp: Double, R: Double, hw: Double,
 
 /// A monotonic seconds clock for a TimelineView date.
 @inline(__always) func liquidSeconds(_ date: Date) -> Double { date.timeIntervalSinceReferenceDate }
+
+// MARK: - Low Power Mode
+
+/// Publishes Low Power Mode so the live gauges can pose still, the way they already do for
+/// Reduce Motion. There is no SwiftUI environment key for this, so the primitives observe this
+/// instead; `.NSProcessInfoPowerStateDidChange` makes the switch live, with no relaunch needed.
+///
+/// Worth doing because a continuously-animating `Canvas` is not free: measured on an iPhone 17 Pro
+/// simulator seeded with a real 746 MB store, the default Today screen sitting idle costs ~18% of a
+/// CPU core in BOTH Debug and Release, and 0.0% once the live gauges pose still. Low Power Mode is
+/// the user telling the system to stop exactly that kind of work.
+@MainActor
+final class LiquidPowerMonitor: ObservableObject {
+    static let shared = LiquidPowerMonitor()
+    @Published private(set) var isLowPower: Bool
+
+    private init() {
+        isLowPower = ProcessInfo.processInfo.isLowPowerModeEnabled
+        NotificationCenter.default.addObserver(
+            forName: .NSProcessInfoPowerStateDidChange, object: nil, queue: .main
+        ) { [weak self] _ in
+            MainActor.assumeIsolated {
+                self?.isLowPower = ProcessInfo.processInfo.isLowPowerModeEnabled
+            }
+        }
+    }
+}

--- a/Strand/Liquid/LiquidPrimitives.swift
+++ b/Strand/Liquid/LiquidPrimitives.swift
@@ -221,6 +221,7 @@ struct LiquidVessel: View {
     var animated: Bool = true
 
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @ObservedObject private var power = LiquidPowerMonitor.shared
     @State private var sim: LiquidSim
     @State private var splashes = 0
 
@@ -232,7 +233,7 @@ struct LiquidVessel: View {
     }
 
     var body: some View {
-        if animated && !reduceMotion { gauge } else { staticGauge }
+        if animated && !reduceMotion && !power.isLowPower { gauge } else { staticGauge }
     }
 
     private var gauge: some View {
@@ -275,10 +276,11 @@ struct LiquidTube: View {
     var animated: Bool = true
 
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @ObservedObject private var power = LiquidPowerMonitor.shared
     @State private var sim = LiquidSim(target: 0)
 
     var body: some View {
-        if animated && !reduceMotion { liveTube } else { staticTube }
+        if animated && !reduceMotion && !power.isLowPower { liveTube } else { staticTube }
     }
 
     private var liveTube: some View {
@@ -311,9 +313,10 @@ struct LiquidThread: View {
     var animated: Bool = true
 
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @ObservedObject private var power = LiquidPowerMonitor.shared
 
     var body: some View {
-        if animated && !reduceMotion { liveThread } else { staticThread }
+        if animated && !reduceMotion && !power.isLowPower { liveThread } else { staticThread }
     }
 
     private var liveThread: some View {

--- a/Strand/Liquid/LiquidTodayView.swift
+++ b/Strand/Liquid/LiquidTodayView.swift
@@ -26,6 +26,10 @@ struct LiquidTodayView: View {
     // only publishes connect/discovery state, never HR. Injected at the app roots beside .environmentObject(model).
     @EnvironmentObject var ble: BLEManager
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    /// Low Power Mode poses the sky still too — the behaviour the comment on the sky branch below
+    /// has always described. There is no environment key for it, hence the shared monitor.
+    @ObservedObject private var powerMonitor = LiquidPowerMonitor.shared
+    private var lowPower: Bool { powerMonitor.isLowPower }
 
     /// Shared with the real Today's card-customise editor so the two stay in sync.
     @AppStorage(DashboardCardPrefs.selectionKey) private var dashboardCardsRaw = ""
@@ -295,7 +299,7 @@ struct LiquidTodayView: View {
                     // "Sky behind cards" (opt-in): fill the whole backdrop with a softer settle so the sky
                     // reads under every card, instead of the default 340 top band that dissolves to canvas.
                     Group {
-                        if reduceMotion || !dataLoaded { LiquidSkyStatic(hour: liveHour, settleStrength: skyBehindCards ? 0.78 : 1) }
+                        if reduceMotion || lowPower || !dataLoaded { LiquidSkyStatic(hour: liveHour, settleStrength: skyBehindCards ? 0.78 : 1) }
                         else { LiquidSky(hour: liveHour, settleStrength: skyBehindCards ? 0.78 : 1) }
                     }
                     .frame(maxWidth: .infinity)


### PR DESCRIPTION
The sky branch in `LiquidTodayView` is commented:

> Reduce-motion (and low-power) users get the same sky posed still — no twinkle/breath.

but `isLowPowerModeEnabled` appears nowhere in the UI — the only hit in the whole tree is `Strand/System/IOSDiagnostics.swift`, where it is reported, not acted on. The low-power half was never implemented. This implements it, for the sky and for the three live primitives (`LiquidVessel`, `LiquidTube`, `LiquidThread`), reusing the exact static render path that Reduce Motion already routes to.

There is no SwiftUI environment key for Low Power Mode, so `LiquidPowerMonitor` observes `.NSProcessInfoPowerStateDidChange` and publishes it; toggling the setting takes effect without a relaunch.

### Why it is worth doing

A continuously-animating `Canvas` is not free. Measured on an iPhone 17 Pro simulator seeded with a real 746 MB store, default Today screen sitting **idle** with no touch input — three 15 s CPU windows after a 45 s settle, machine otherwise quiet:

| build | live gauges | posed still | 
|---|---|---|
| Debug | 18.4 / 19.3 / 18.3 % of one core, 311 MB RSS | 0.0 / 0.0 / 0.0 %, 290 MB |
| Release | 18.2 / 18.7 % of one core, 298 MB RSS | 0.0 / 0.0 / 0.0 %, 226 MB |

The animation is the *entire* idle cost of that screen. Notably it is the same in Debug and Release, because the per-frame work is `GraphicsContext` drawing rather than Swift arithmetic — optimizing the Swift only moves the smaller half (a standalone `-Onone` vs `-O` benchmark of the `liquidWave` / fleck math gives 0.614 → 0.100 ms per hero-gauge frame, which is real but is not what dominates the frame).

Low Power Mode is the user explicitly asking the system to stop this class of work, so honouring it costs nothing when it is off and saves ~18% of a core when it is on.

### No behaviour change when Low Power Mode is off

Re-measured after the change, not in Low Power Mode: **19.7 / 19.5 / 20.1 %** of one core — still animating, unchanged within noise. Screenshotted the Today screen after the change: gauges, sky, and all card surfaces render identically.

### Scope note

I could not toggle real Low Power Mode in the simulator, so the "posed still" column above is the Reduce Motion route — which is the *same* `staticGauge` / `staticTube` / `staticThread` / `LiquidSkyStatic` branch this change sends low-power users down. The new condition is `animated && !reduceMotion && !power.isLowPower`, so the saving is the measured one; what is inferred rather than directly exercised is only that iOS reports the flag, which `IOSDiagnostics` already relies on.
