### PR TITLE
perf(store): let SQLite's MIN/MAX optimization fire on Android's HR frontier too (#908)

### DIFF
--- a/android/app/src/main/java/com/noop/data/WhoopDao.kt
+++ b/android/app/src/main/java/com/noop/data/WhoopDao.kt
@@ -779,12 +779,24 @@ interface WhoopDao : DeviceRegistryDao {
     /** Max HR sample ts for a device, or null if none — the biometric data frontier.
      *  COALESCEs measured `hrSample` with the v26 PPG-derived `ppgHrSample` (#156) so a PPG-only
      *  offload (a v26 WHOOP 5 night with no measured HR) still advances the frontier, matching the
-     *  Swift reader (Reads.swift latestHrSampleTs). Both persist on the same per-second ts grid. */
+     *  Swift reader (Reads.swift latestHrSampleTs). Both persist on the same per-second ts grid.
+     *
+     *  Each arm is its OWN `SELECT MAX(ts)` rather than one `MAX(ts)` over a `UNION ALL` of the two
+     *  timestamp streams. SQLite's MIN/MAX optimization only fires on a bare `SELECT MAX(col)` that can
+     *  seek the last matching index entry; wrapping the columns in a compound subquery first makes the
+     *  planner materialize it and walk EVERY index entry for the device. Measured on Apple against a
+     *  746 MB store (3.1M hrSample rows) at 4.3–5.8 s for the old shape and 0.01–0.07 s for this one
+     *  (#908); Room is SQLite, so the same plan applies here, and this reader is on paths a user waits
+     *  on — FullDayChartScreen's land-on-the-latest-day effect and DataSourcesScreen's load.
+     *
+     *  Identical answer in every case: each scalar subquery is NULL when that stream has no rows for the
+     *  device, MAX() ignores NULLs, and both-empty stays NULL. Both arms are aliased because Room
+     *  verifies queries at compile time and only the first arm's names survive a compound select. */
     @Query(
-        "SELECT MAX(ts) FROM (" +
-            "SELECT ts FROM hrSample WHERE deviceId = :deviceId " +
+        "SELECT MAX(m) FROM (" +
+            "SELECT (SELECT MAX(ts) FROM hrSample WHERE deviceId = :deviceId) AS m " +
             "UNION ALL " +
-            "SELECT ts FROM ppgHrSample WHERE deviceId = :deviceId)",
+            "SELECT (SELECT MAX(ts) FROM ppgHrSample WHERE deviceId = :deviceId) AS m)",
     )
     suspend fun latestHrSampleTs(deviceId: String): Long?
 

--- a/android/app/src/test/java/com/noop/data/HrFrontierQueryShapeTest.kt
+++ b/android/app/src/test/java/com/noop/data/HrFrontierQueryShapeTest.kt
@@ -1,0 +1,99 @@
+package com.noop.data
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.File
+
+/**
+ * #908 — `latestHrSampleTs` must keep the per-arm `SELECT MAX(ts)` shape that lets SQLite's MIN/MAX
+ * optimization fire.
+ *
+ * The old form asked for one `MAX(ts)` over a `UNION ALL` of the two timestamp columns. That is the same
+ * answer and a very different plan: the optimization only applies to a bare `SELECT MAX(col)` that can
+ * seek the last matching index entry, so wrapping the columns in a compound subquery makes the planner
+ * materialize it and walk every index entry for the device. Measured on the Apple twin at 4.3–5.8 s
+ * against a 746 MB store versus 0.01–0.07 s for the per-arm form.
+ *
+ * That is invisible to every behavioural test — both shapes return the identical value, including for a
+ * device with no rows — so the only thing standing between this and a well-meaning "simplification" back
+ * to the readable one-liner is a test that reads the query itself.
+ *
+ * It has to audit the SOURCE rather than reflect over the annotation: Room's `@Query` is `CLASS`-retention,
+ * so it is not visible at runtime. The behavioural half is the Swift twin's `LatestSampleTests`, which CI
+ * runs against a real SQLite; this side has no driver on the unit-test classpath (see
+ * [DeepCaptureMigrationTest]). Follows the source-locating pattern of
+ * [com.noop.ui.ResolvedSeriesCallSiteAuditTest].
+ */
+class HrFrontierQueryShapeTest {
+
+    /**
+     * The DAO source, tolerant of the test host's working dir — verified to resolve from the module dir
+     * (Gradle's default), the `android/` project dir, and the repo root.
+     *
+     * FAILS rather than skipping when it cannot be found, which is the opposite of what a source audit
+     * usually does. [com.noop.ui.ResolvedSeriesCallSiteAuditTest] assumes-and-skips so an unlocatable tree
+     * does not green-wash its census, and that is right for a census: skipping says "not checked this run".
+     * Here it would say something else. This test is the ONLY thing standing between the query and a
+     * silent revert — both shapes return the same value, so no behavioural test can tell them apart — and
+     * a skip is reported by JUnit as a pass. Verified: with no source on the path the assume form printed
+     * `OK (2 tests)`, indistinguishable from the guard actually holding. A loud failure is the honest
+     * signal that the guard is not guarding.
+     */
+    private fun daoSource(): String {
+        val userDir = File(System.getProperty("user.dir") ?: ".")
+        val rel = "src/main/java/com/noop/data/WhoopDao.kt"
+        val found = listOf(File(userDir, rel), File(userDir, "app/$rel"), File(userDir, "android/app/$rel"))
+            .firstOrNull { it.isFile }
+        assertNotNull(
+            "WhoopDao.kt not found from user.dir=$userDir — this guard cannot run, and a skip here reads " +
+                "as a pass. Add this host's working dir to the list rather than letting it slide.",
+            found,
+        )
+        return found!!.readText()
+    }
+
+    /** The `@Query` body attached to `latestHrSampleTs`, string fragments joined, comments excluded. */
+    private fun latestHrQuery(src: String): String {
+        val decl = src.indexOf("suspend fun latestHrSampleTs(")
+        assertTrue("latestHrSampleTs not found — was it renamed?", decl > 0)
+        val annotationStart = src.lastIndexOf("@Query(", decl)
+        assertTrue("no @Query above latestHrSampleTs", annotationStart > 0)
+        val block = src.substring(annotationStart, decl)
+        return Regex("\"([^\"]*)\"").findAll(block).joinToString("") { it.groupValues[1] }
+    }
+
+    @Test
+    fun latestHrSampleTsKeepsThePerArmMaxShape() {
+        val q = latestHrQuery(daoSource()).replace(Regex("\\s+"), " ")
+
+        // Each stream gets its own seekable MAX...
+        assertTrue(
+            "hrSample arm must be its own SELECT MAX(ts): $q",
+            q.contains("(SELECT MAX(ts) FROM hrSample WHERE deviceId = :deviceId)"),
+        )
+        assertTrue(
+            "ppgHrSample arm must be its own SELECT MAX(ts): $q",
+            q.contains("(SELECT MAX(ts) FROM ppgHrSample WHERE deviceId = :deviceId)"),
+        )
+        // ...and neither may go back to feeding a bare column into the compound select, which is the
+        // exact shape that defeats the optimization.
+        assertFalse(
+            "a bare `SELECT ts FROM <table>` arm defeats the MIN/MAX optimization: $q",
+            Regex("SELECT ts FROM (hrSample|ppgHrSample)").containsMatchIn(q),
+        )
+    }
+
+    /**
+     * Both arms carry `AS m`. Only the first arm's column names survive a compound select in SQLite, so
+     * the second alias is redundant to the engine — it is there because Room verifies queries at compile
+     * time and an unnamed second arm is the kind of thing that fails the build rather than a test.
+     */
+    @Test
+    fun bothArmsAreAliasedForRoomsCompileTimeVerifier() {
+        val q = latestHrQuery(daoSource()).replace(Regex("\\s+"), " ")
+        assertTrue("outer aggregate must select the alias: $q", q.contains("SELECT MAX(m) FROM"))
+        assertTrue("both arms should be aliased AS m: $q", Regex("AS m\\b").findAll(q).count() == 2)
+    }
+}


### PR DESCRIPTION
The Android half of #908. Same query, same planner, same user-waited paths.

## Why

`WhoopDao.latestHrSampleTs` carried the identical shape #908 fixes on Apple — one `MAX(ts)` over a `UNION ALL` of the two timestamp columns. Room is SQLite, so the optimization is defeated for the same reason: it only fires on a bare `SELECT MAX(col)` that can seek the last matching index entry, and the compound subquery forces the planner to materialize and walk every index entry for the device.

Measured on the Apple side at **4.3–5.8 s** against a 746 MB store (3.1M `hrSample` rows) versus **0.01–0.07 s**. On Android the reader is on `FullDayChartScreen`'s land-on-the-latest-day effect and `DataSourcesScreen`'s load — both paths a user waits on.

The Kotlin doc comment already claimed to match "the Swift reader (Reads.swift latestHrSampleTs)". After #908 that would have stayed true of the answer and stopped being true of the cost.

## Correctness

Identical in every case. Each scalar subquery is `NULL` when that stream has no rows for the device, `MAX()` ignores `NULL`s, and both-empty stays `NULL` — so PPG-only, measured-only, both and neither all land exactly where they did.

Both arms are aliased `AS m`. Only the first arm's names survive a compound select in SQLite, so the second alias is redundant to the engine; it is there because Room verifies queries at compile time and an unnamed second arm fails the *build*, not a test.

## Scope

Checked rather than assumed: `WhoopDao` has exactly one other `MAX`/`MIN` over a `UNION ALL`, and it computes `COUNT` and `AVG` over a deduplicated bpm stream — it must scan regardless and is not the same bug. Left alone.

## The test, and why it audits source

`HrFrontierQueryShapeTest` pins the per-arm shape. Both forms return the same value, so **no behavioural test can distinguish them** — nothing else stands between this and a well-meaning simplification back to the readable one-liner.

It reads the source rather than reflecting over the annotation because Room's `@Query` is `CLASS`-retention and invisible at runtime, following the pattern of `ResolvedSeriesCallSiteAuditTest`. The behavioural half is the Swift twin's `LatestSampleTests`, which CI runs against a real SQLite; this side has no driver on the unit-test classpath (see `DeepCaptureMigrationTest`).

I checked the guard actually guards: it passes on the new shape and fails on **all five** assertions against the query as it stands on `main`. A shape test that passed either way would be worse than none.

## Verification

Room's compile-time verification of the new SQL is covered by the Android CI build, enabled today — so this PR gets a real `assembleFullDebug` rather than static reasoning.

Independent of #908 and touches no shared file, so it can land in either order.
