### PR TITLE
Draft the 9.2.1 release notes, and stop the staging build landing as a draft

### DIFF
--- a/.github/workflows/fork-testing-build.yml
+++ b/.github/workflows/fork-testing-build.yml
@@ -48,6 +48,14 @@ jobs:
           - **iOS** — \`NOOP-ios-unsigned-v${VER}.ipa\` — sideload via **AltStore / Sideloadly** (re-signs on-device); embedded watch app stripped, widget extension retained for Home/Lock-Screen widgets and Live Activities.
 
           Base app version ${VER} · built ${DATE} · \`${SHA}\`."
+          # Belt-and-braces: a rolling tag is deleted with --cleanup-tag and recreated seconds later, and
+          # that recreate has come back as a DRAFT — the 9.2.1 staging build did, and a draft release does
+          # not create its tag, so the assets were unreachable and the `testing-latest` URL 404'd until
+          # someone noticed. Whatever the cause (the tag delete is not instant on GitHub's side), asserting
+          # the published state costs one idempotent call and cannot make things worse.
+          gh release edit "$TAG" --repo "$GITHUB_REPOSITORY" --draft=false --prerelease
+          DRAFT=$(gh release view "$TAG" --repo "$GITHUB_REPOSITORY" --json isDraft -q .isDraft)
+          [ "$DRAFT" = "false" ] || { echo "::error::$TAG is still a draft — testers cannot download it."; exit 1; }
 
   android:
     needs: meta

--- a/docs/releases/v9.2.1.md
+++ b/docs/releases/v9.2.1.md
@@ -1,0 +1,72 @@
+---
+whatsnew:
+  title: "Battery saver quiets the gauges, translated Android notifications, and instant chart loads"
+  date: "July 2026"
+  items:
+    - "**Battery saver stops the animation (#909).** Turn on Low Power Mode or battery saver and the live gauges, sky and pulsing dots settle into a single still frame. On iPhone that was measured at ~18% of a CPU core with the screen just sitting idle, and 0% posed still. It switches the moment you flip the setting — no restart."
+    - "**Android notifications are translated (#867).** Every notification the app sends shipped in English no matter your language — the always-on connection notice, all five battery alerts, the illness, move and smart-alarm alerts, and both notification categories in system settings. All of them now speak German, Spanish, French, Portuguese and Chinese."
+    - "**Today and the day chart open instantly on a long history (#908).** Finding your most recent reading walked every heart-rate row for the strap. On a large store that took four to six seconds every time the screen opened; it now takes hundredths of a second."
+    - "**The pulsing connection dot honours \"Remove animations\" (#909).** It kept pulsing regardless. It doesn't now."
+    - "**Strap logs name every command (#891).** An Android strap log showed a bare `0x8B(139)` where iPhone showed the command's name, and neither platform said whether a command had actually succeeded. Both now do — which is what makes a pasted log useful to anyone reading it."
+---
+# NOOP v9.2.1
+
+A tidying release on top of 9.2.0: honour the battery-saving setting you already turned on, finish
+translating the Android notifications, and stop a screen re-reading your whole history to find one
+number. Nothing here changes any recorded value. Everything still runs on your own device, offline,
+no account.
+
+## New
+
+- **Low Power Mode and battery saver pose the animations still (#909).** The live gauges, the
+  time-of-day sky, the atmosphere drift, the guardian breath and the pulsing connection dot all
+  collapse to their single posed frame while the setting is on, and come back when it goes off —
+  live, without a restart. Measured on iPhone at ~18% of a CPU core for an idle Today screen with the
+  gauges running and 0% posed still. The picture is otherwise unchanged, and with the setting off
+  nothing about the app moves differently.
+
+## Fixed
+
+- **Android notifications were English in every language (#867).** Twenty-two strings across five
+  notifier files were built from raw Kotlin literals rather than the string catalogue: the
+  foreground-service notice that is on screen the whole time a strap is connected, the five battery
+  alerts, and the illness, inactivity and smart-alarm alerts — plus the names and descriptions of
+  both notification categories, which appear in Android's own settings. All now ship in all six
+  languages. A language change also takes effect immediately: the notification and the category text
+  used to keep the old language until the connection or battery state happened to move, which on a
+  stable link is hours.
+- **The day chart and Today stalled on a long history (#908).** The query that finds your most recent
+  heart-rate reading was shaped so SQLite could not seek straight to it, so it walked every row for
+  that strap instead. On a 746 MB store that measured 4.3–5.8 seconds per call, on two paths you wait
+  on. It now seeks: 0.01–0.07 seconds. Same answer, both platforms.
+- **The pulsing connection dot ignored "Remove animations" (#909).** It had no motion gate at all.
+- **A strap log could not name what the strap answered (#891).** Android printed 46 of the protocol's
+  80 commands as bare hex, and three more under different names than iPhone used for the same byte.
+  Apple, separately, never reported a command's result at all — so a log said which command the strap
+  replied to but not whether it worked. Both are fixed, and the two platforms now render the same
+  bytes the same way.
+
+## Under the hood
+
+- **Android is built and tested by CI again.** The Android workflow had been off, so nothing compiled
+  the Kotlin or ran its unit tests on a pull request. Turning it back on immediately surfaced a unit
+  test that had been failing on `main` since #888 — a retention sweep became amortised on both
+  platforms, but only the Swift tests were updated to match (#904).
+- **Read-only device-config probe (#890, #103).** A Test Centre diagnostic that asks a strap what a
+  named configuration value currently is. It writes nothing.
+- **Room and GRDB schema parity is pinned by a shared oracle both suites check (#889, #775).**
+- **The v18 aux retention sweep is amortised (#888)** rather than running on every inserted batch.
+- **Protocol documentation and fixtures.** The ECG command table's internally inconsistent description
+  is corrected, the first real WHOOP 5 MG failure response is committed as a decode fixture (#906),
+  and fixtures now state where they came from — a hand-built test vector and a real capture are
+  interchangeable for testing a decoder and are not interchangeable as evidence about firmware
+  (#900, #903).
+
+## Thanks
+
+Thanks to **@vishk23** for the low-power gauge work, the SQLite query-plan fix, the read-only
+device-config probe, and the shared Room/GRDB schema oracle — and for the WHOOP 5 MG protocol
+investigation behind several of the fixture and decode changes above, including catching a failing
+test on `main` that belonged to someone else's earlier PR.
+
+Thanks to **@tanarchytan** for the schema-parity report (#775) behind the shared oracle.


### PR DESCRIPTION
Two things, both needed before cutting a real 9.2.1.

## `docs/releases/v9.2.1.md`

`fork-release.yml` reads this to generate the in-app What's New; without it the release publishes with placeholders. Front-matter validated against `appchangelog-gen`'s requirement (`whatsnew.{title,date,items}`), and the title kept to 90 characters because it becomes a card heading — 9.2.0's was 83.

Covers the 15 merges since v9.2.0: battery saver posing the animations still, the Android notification localisation, the HR-frontier query fix on both platforms, the command naming/result decoding, and the CI and fixture work underneath.

**Credits are pruned, not pasted.** `Tools/release-contributors.sh` also lists @pipiche38's two issues, but both were 9.2.0 work that happened to close after the tag and 9.2.0's notes already thank them — re-crediting would be double counting. @tanarchytan's #775 is credited because #889 delivered it in this range.

## The staging release landed as a draft

The 9.2.1 staging build came back as a **draft** even though `fork-testing-build.yml` passes no `--draft`. That matters more than it looks: a draft release **does not create its tag**, so `refs/tags/testing-latest` did not exist and the four assets were unreachable — the stable URL testers are pointed at would have 404'd. The tag appeared the moment it was published by hand, which is how the cause was confirmed rather than assumed.

Most likely the `--cleanup-tag` delete is not instant on GitHub's side and the recreate seconds later lands in a state resolved as a draft. Rather than guess at the race, the meta job now **asserts the outcome**: an idempotent `gh release edit --draft=false --prerelease`, then reads `isDraft` back and fails the job if it is still true.

A staging build testers cannot download should fail loudly, not sit there looking green. That is the same reasoning as the guard tests in #910 and #911 — the failure mode here was silence.

The current `testing-latest` is already published by hand, so this only affects future runs.
