### PR TITLE
Don't call an unread feature-flag key list "the strap named none" (#761)

### DIFF
--- a/Packages/WhoopProtocol/Sources/WhoopProtocol/FeatureFlagProbe.swift
+++ b/Packages/WhoopProtocol/Sources/WhoopProtocol/FeatureFlagProbe.swift
@@ -366,6 +366,17 @@ public struct FeatureFlagProbeReport: Equatable, Sendable {
         return sb
     }
 
+    /// The announced count as a phrase for the verdict line, qualified when it falls outside the range a
+    /// real key list could occupy. `noteStart` already marks an implausible count in the trace, but the
+    /// verdict is the line that gets pasted into an issue, and restating a number the probe itself
+    /// distrusts as bare fact is the same over-claim in a smaller place. A plausible count renders
+    /// exactly as before, so the common report is unchanged.
+    private var announcedFlags: String {
+        let n = reportedCount ?? 0
+        let plausible = n > 0 && n <= FeatureFlagProbe.maxFlags
+        return plausible ? "\(n) flag(s)" : "an implausible \(n) flag(s)"
+    }
+
     /// One-line summary of what the probe established.
     public var verdict: String {
         if let startResult, startResult == 3 {
@@ -383,8 +394,18 @@ public struct FeatureFlagProbeReport: Equatable, Sendable {
                 + "\(FeatureFlagProbe.maxKeyLength) chars — this is our parser rejecting them, NOT the "
                 + "strap serving blanks; see the trace for the raw replies"
         }
+        // Same discipline one condition over: with no 118 reply decoded, the walk never asked for a
+        // single name, so "named none" would blame the strap for OUR timeout (or our parse failure).
+        // `steps` counts decoded SEND_NEXT replies, so `steps == 0` is exactly "the key list was never
+        // read" — the reachable case being `probeFeatureFlags()` getting its 117 answer and then the 8s
+        // timer firing on the first 118. What the strap would have named is unknown, and the report has
+        // to say unknown. `stopReason`, rendered directly under this line, names which of the two it was.
+        if keys.isEmpty && steps == 0 {
+            return "strap announced \(announcedFlags); no SEND_NEXT_FF(118) reply was decoded — "
+                + "the key list was never read (inconclusive)"
+        }
         if keys.isEmpty {
-            return "strap announced \(reportedCount ?? 0) flag(s) but named none"
+            return "strap announced \(announcedFlags) but named none"
         }
         if skipped > 0 {
             return "enumerated \(keys.count) feature-flag key name(s); \(skipped) further name(s) did not decode"

--- a/Packages/WhoopProtocol/Tests/WhoopProtocolTests/FeatureFlagProbeTests.swift
+++ b/Packages/WhoopProtocol/Tests/WhoopProtocolTests/FeatureFlagProbeTests.swift
@@ -430,7 +430,12 @@ final class FeatureFlagProbeTests: XCTestCase {
         XCTAssertEqual(report.render(), golden)
     }
 
-    func testAnnouncedCountWithNoNamesIsSaidPlainly() {
+    /// The 117 answer landed and then nothing did: `BLEManager.probeFeatureFlags()` sends 118, the 8s
+    /// timer fires, and the report renders with zero SEND_NEXT replies. "Named none" would be a claim
+    /// about the strap's key list that this run's own inputs cannot support — the list was never read.
+    /// Same class as the `skipped > 0` branch beside it: never report our limitation as the strap's
+    /// behaviour.
+    func testAnnouncedCountWithNo118ReplyIsInconclusiveNotBlamedOnTheStrap() {
         var report = FeatureFlagProbeReport(family: .whoop5)
         let start = whoop5Response(cmd: 117, payload: payload(result: 1, record: [0x01, 0x05, 0x00]))
         guard case .success(let s) = FeatureFlagProbe.parseStart(frame: start, family: .whoop5) else {
@@ -438,6 +443,43 @@ final class FeatureFlagProbeTests: XCTestCase {
         }
         report.noteStart(s)
         report.noteTimeout(command: 118, seconds: 8)
+
+        XCTAssertEqual(report.steps, 0, "no SEND_NEXT reply was decoded")
+        let v = report.verdict
+        XCTAssertEqual(v, "strap announced 5 flag(s); no SEND_NEXT_FF(118) reply was decoded — "
+                       + "the key list was never read (inconclusive)")
+        XCTAssertFalse(v.contains("named none"),
+                       "must not report our own timeout as the strap serving no names")
+    }
+
+    /// A 118 reply that DID land and carried no name is the opposite case: the strap walked its own
+    /// cursor straight to the end marker, so "named none" is a fact about the strap and is said plainly.
+    func testAnnouncedCountWithARealEmptyWalkIsSaidPlainly() {
+        var report = FeatureFlagProbeReport(family: .whoop5)
+        let start = whoop5Response(cmd: 117, payload: payload(result: 1, record: [0x01, 0x05, 0x00]))
+        guard case .success(let s) = FeatureFlagProbe.parseStart(frame: start, family: .whoop5) else {
+            return XCTFail("start")
+        }
+        report.noteStart(s)
+        XCTAssertFalse(report.noteNext(FeatureFlagProbe.NextResponse(
+            resultCode: 1, revision: 1, index: 0xFF, validKey: false, key: nil)))
+
+        XCTAssertEqual(report.steps, 1)
+        XCTAssertEqual(report.keys, [])
+        XCTAssertEqual(report.skipped, 0)
         XCTAssertEqual(report.verdict, "strap announced 5 flag(s) but named none")
+    }
+
+    /// The count itself is the strap's claim, not a measurement. `noteStart` already marks an implausible
+    /// one in the trace; the verdict is the line that gets pasted into an issue, so it carries the doubt
+    /// too rather than restating the number as bare fact.
+    func testImplausibleAnnouncedCountIsNotRestatedAsFactInTheVerdict() {
+        var report = FeatureFlagProbeReport(family: .whoop5)
+        report.noteStart(FeatureFlagProbe.StartResponse(resultCode: 1, revision: 1, count: 9999))
+        report.noteTimeout(command: 118, seconds: 8)
+
+        let v = report.verdict
+        XCTAssertTrue(v.contains("an implausible 9999 flag(s)"), v)
+        XCTAssertTrue(v.contains("(inconclusive)"), v)
     }
 }

--- a/android/app/src/main/java/com/noop/protocol/FeatureFlagProbe.kt
+++ b/android/app/src/main/java/com/noop/protocol/FeatureFlagProbe.kt
@@ -306,6 +306,20 @@ class FeatureFlagProbeReport(private val family: DeviceFamily) {
         if (stopReason == null) stopReason = "strap served no reply to opcode $command within ${seconds}s"
     }
 
+    /**
+     * The announced count as a phrase for the verdict line, qualified when it falls outside the range a
+     * real key list could occupy. [noteStart] already marks an implausible count in the trace, but the
+     * verdict is the line that gets pasted into an issue, and restating a number the probe itself
+     * distrusts as bare fact is the same over-claim in a smaller place. A plausible count renders
+     * exactly as before, so the common report is unchanged.
+     */
+    private val announcedFlags: String
+        get() {
+            val n = reportedCount ?: 0
+            val plausible = n > 0 && n <= FeatureFlagProbe.MAX_FLAGS
+            return if (plausible) "$n flag(s)" else "an implausible $n flag(s)"
+        }
+
     /** One-line summary of what the probe established. */
     val verdict: String
         get() {
@@ -324,7 +338,18 @@ class FeatureFlagProbeReport(private val family: DeviceFamily) {
                     "${FeatureFlagProbe.MAX_KEY_LENGTH} chars — this is our parser rejecting them, NOT " +
                     "the strap serving blanks; see the trace for the raw replies"
             }
-            if (_keys.isEmpty()) return "strap announced ${reportedCount ?: 0} flag(s) but named none"
+            // Same discipline one condition over: with no 118 reply decoded, the walk never asked for a
+            // single name, so "named none" would blame the strap for OUR timeout (or our parse failure).
+            // [steps] counts decoded SEND_NEXT replies, so `steps == 0` is exactly "the key list was
+            // never read" — the reachable case being `probeFeatureFlags()` getting its 117 answer and
+            // then the 8s timer firing on the first 118. What the strap would have named is unknown, and
+            // the report has to say unknown. [stopReason], rendered directly under this line, names
+            // which of the two it was.
+            if (_keys.isEmpty() && steps == 0) {
+                return "strap announced $announcedFlags; no SEND_NEXT_FF(118) reply was decoded — " +
+                    "the key list was never read (inconclusive)"
+            }
+            if (_keys.isEmpty()) return "strap announced $announcedFlags but named none"
             if (skipped > 0) {
                 return "enumerated ${_keys.size} feature-flag key name(s); $skipped further name(s) did not decode"
             }

--- a/android/app/src/test/java/com/noop/protocol/FeatureFlagProbeTest.kt
+++ b/android/app/src/test/java/com/noop/protocol/FeatureFlagProbeTest.kt
@@ -385,11 +385,56 @@ class FeatureFlagProbeTest {
         assertEquals(golden, report.render())
     }
 
-    @Test fun announcedCountWithNoNamesIsSaidPlainly() {
+    /**
+     * The 117 answer landed and then nothing did: `probeFeatureFlags()` sends 118, the 8s timer fires,
+     * and the report renders with zero SEND_NEXT replies. "Named none" would be a claim about the
+     * strap's key list that this run's own inputs cannot support — the list was never read. Same class
+     * as the `skipped > 0` branch beside it: never report our limitation as the strap's behaviour.
+     */
+    @Test fun announcedCountWithNo118ReplyIsInconclusiveNotBlamedOnTheStrap() {
         val report = FeatureFlagProbeReport(DeviceFamily.WHOOP5)
         val start = whoop5Response(117, payload(1, byteArrayOf(0x01, 0x05, 0x00)))
         report.noteStart(FeatureFlagProbe.parseStart(start, DeviceFamily.WHOOP5).value!!)
         report.noteTimeout(118, 8)
+
+        assertEquals("no SEND_NEXT reply was decoded", 0, report.steps)
+        val v = report.verdict
+        assertEquals(
+            "strap announced 5 flag(s); no SEND_NEXT_FF(118) reply was decoded — " +
+                "the key list was never read (inconclusive)",
+            v
+        )
+        assertFalse("must not report our own timeout as the strap serving no names", v.contains("named none"))
+    }
+
+    /**
+     * A 118 reply that DID land and carried no name is the opposite case: the strap walked its own
+     * cursor straight to the end marker, so "named none" is a fact about the strap and is said plainly.
+     */
+    @Test fun announcedCountWithARealEmptyWalkIsSaidPlainly() {
+        val report = FeatureFlagProbeReport(DeviceFamily.WHOOP5)
+        val start = whoop5Response(117, payload(1, byteArrayOf(0x01, 0x05, 0x00)))
+        report.noteStart(FeatureFlagProbe.parseStart(start, DeviceFamily.WHOOP5).value!!)
+        assertFalse(report.noteNext(FeatureFlagProbe.NextResponse(1, 1, 0xFF, false, null)))
+
+        assertEquals(1, report.steps)
+        assertTrue(report.keys.isEmpty())
+        assertEquals(0, report.skipped)
         assertEquals("strap announced 5 flag(s) but named none", report.verdict)
+    }
+
+    /**
+     * The count itself is the strap's claim, not a measurement. [FeatureFlagProbeReport.noteStart]
+     * already marks an implausible one in the trace; the verdict is the line that gets pasted into an
+     * issue, so it carries the doubt too rather than restating the number as bare fact.
+     */
+    @Test fun implausibleAnnouncedCountIsNotRestatedAsFactInTheVerdict() {
+        val report = FeatureFlagProbeReport(DeviceFamily.WHOOP5)
+        report.noteStart(FeatureFlagProbe.StartResponse(1, 1, 9999))
+        report.noteTimeout(118, 8)
+
+        val v = report.verdict
+        assertTrue(v, v.contains("an implausible 9999 flag(s)"))
+        assertTrue(v, v.contains("(inconclusive)"))
     }
 }


### PR DESCRIPTION
## The defect

`FeatureFlagProbeReport.verdict` (`Packages/WhoopProtocol/.../FeatureFlagProbe.swift`) returned

> strap announced N flag(s) but named none

whenever `keys` was empty and the strap had answered 117 — with **no check that a single `SEND_NEXT_FF(118)` reply was ever decoded.**

The path is reachable, and it is plausibly the *first-contact* result on a 5/MG:

1. `BLEManager.probeFeatureFlags()` sends `START_FF_KEY_EXCHANGE(117)`
2. the reply lands → `noteStart(r)` records `reportedCount`
3. `sendFeatureFlagStep(.sendNextFeatureFlag)` puts 118 on the wire
4. the 8s timer fires → `noteTimeout(command: 118, seconds: 8)` appends a trace line and sets `stopReason`
5. `finishFeatureFlagProbe()` renders

Zero 118 replies were received — yet the headline asserts a fact about the strap's key list. It blames the strap for **our** timeout, and it's the sentence someone would paste into #103 as evidence that the enumerate verb answers but serves nothing. The run established no such thing.

It also contradicts the principle the file states two branches above and applies correctly to `skipped > 0`:

> `"named none"` would blame the strap for OUR decode. […] **never report our limitation as the strap's behaviour.**

Same defect class as the ECG probe verdict fixed in #896: a verdict asserting a conclusion the run's own inputs could not support.

## The fix

`steps` (the decoded-118-reply counter) already existed, so the gate is one condition:

```swift
if keys.isEmpty && steps == 0 {
    return "strap announced \(announcedFlags); no SEND_NEXT_FF(118) reply was decoded — "
        + "the key list was never read (inconclusive)"
}
```

Worded "no reply was **decoded**" rather than "no reply arrived" because `steps == 0` also covers a 118 reply that failed to parse (`noteFailure`), where the strap *did* answer. `stopReason` renders directly beneath the verdict and names which of the two it was, so one branch covers both without over-claiming either.

A 118 reply that genuinely walked to the end marker carrying no name is the opposite case — a real fact about the strap — and still says `"named none"` plainly, unchanged.

**Secondary (judgement call, flagging it explicitly):** the verdict also restated the announced count as bare fact even when `countIsPlausible` was false. `noteStart` marks an implausible count in the trace (`:277`), but the verdict is the line that gets quoted, so it now carries the same doubt (`an implausible 9999 flag(s)`). A plausible count renders exactly as before — real reports are byte-for-byte unchanged. Happy to drop this half if you'd rather keep the change to the single gate.

## Test change — the old test pinned the bug

`testAnnouncedCountWithNoNamesIsSaidPlainly` did `noteStart` + `noteTimeout(118)` and asserted the `"named none"` string: it pinned the buggy path *as intended behaviour*. Split into the two cases it was conflating:

| test | case | verdict |
|---|---|---|
| `…WithNo118ReplyIsInconclusiveNotBlamedOnTheStrap` | 117 answered, 118 timed out | inconclusive; asserts `!contains("named none")` |
| `…WithARealEmptyWalkIsSaidPlainly` | 118 replied with the `0xFF` end marker | `"named none"` — unchanged |
| `…ImplausibleAnnouncedCountIsNotRestatedAsFactInTheVerdict` | count outside 1…128 | count carries the doubt |

Kotlin twins added for all three; rendered strings stay byte-identical across platforms per the parity contract.

## Verification

Both new tests were confirmed to **fail against the unfixed source** before the fix was restored — Swift 4 assertions, Kotlin 2 tests — so they demonstrably catch the defect rather than merely describing it. The unchanged-behaviour test passed on both sides, as intended.

| suite | result |
|---|---|
| `cd Packages/WhoopProtocol && swift test` | **427 tests, 0 failures** |
| `cd android && ./gradlew testFullDebugUnitTest` (JDK 17) | **3198 tests, 0 failures, 5 skipped** |

Android counts are read from `app/build/test-results/testFullDebugUnitTest/*.xml` (391 files) on a forced `--rerun`, not from the Gradle exit code — a plain `BUILD SUCCESSFUL` can hide a cached or skipped test task.

Pure `Packages/` + Kotlin protocol change: no app-target Swift touched, no BLE behaviour changed, no new storage. The probe stays read-only — this only changes the sentence it prints.

Refs #761.