### PR TITLE
docs(protocol): document the COMMAND_RESPONSE body (#894, #891)

### DIFF
--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -188,7 +188,46 @@ public func parseFrame(_ frame: [UInt8], family: DeviceFamily) -> ParsedFrame
 `38 PUFFIN_COMMAND_RESPONSE` and `56 PUFFIN_METADATA` are aliased onto `COMMAND_RESPONSE` /
 `METADATA` by `canonicalTypeName(_:schema:)` so they never decode as "unknown".
 
-### 2.4 Checksums
+### 2.4 COMMAND_RESPONSE body
+
+Every reply to a command (`COMMAND_RESPONSE`, type 36 — and its 5/MG alias 38) opens with two bytes
+before whatever the command itself returns:
+
+```
+WHOOP 4.0    [6] resp_cmd   [7] resp_seq   [8] result   [9..] per-command body
+WHOOP 5/MG   [10] resp_cmd  [11] resp_seq  [12] result  [13..] per-command body
+```
+
+the 5/MG offsets being the 4.0 ones + 4, like the rest of the puffin inner record.
+
+- **`resp_cmd`** — the command being answered (`CommandNumber`).
+- **`resp_seq`** — the strap's own per-response counter. Not the envelope `seq` at `[5]`/`[9]`, which is
+  host-assigned and echoed back: a single capture shows envelope `seq` 147 alongside `resp_seq` 2. A
+  repeated `resp_seq` across replies is how a duplicated write was identified in #791.
+- **`result`** — `CommandResult`: `0` FAILURE, `1` SUCCESS, `2` PENDING, `3` UNSUPPORTED. `GET_DATA_RANGE`
+  answers PENDING then SUCCESS; `3` is what a real MG returned when it rejected `RUN_HAPTICS_PATTERN`
+  (#48). Both fields are decoded from the bounded payload slice, so a reply too short to carry them
+  yields neither rather than reading the CRC32 trailer (#894).
+
+**The first body byte is per-command, and is not a status flag.** `GET_BATTERY_LEVEL` puts the charge
+percentage there — `47` in the hardware-confirmed fixture — so the slot carries real data. On other
+commands it has only ever been observed as `1`:
+
+| capture | command | result | first body byte |
+|---|---|---|---:|
+| real 5/MG | `GET_BATTERY_LEVEL` | SUCCESS | **47** (= 47%) |
+| real 5/MG | `GET_DATA_RANGE` | SUCCESS | 1 |
+| real MG | `SELECT_WRIST`, accepted | SUCCESS | 1 |
+| real MG | `SELECT_WRIST`, refused | FAILURE | 1 |
+| real MG | `TOGGLE_LABRADOR_*` | SUCCESS | 1 |
+
+For the wrist and ECG commands what that `1` means is **open**. A capture that sent `SELECT_WRIST` with
+argument `0` got `1` back, which refutes an echo of the request — but every frame anyone has captured had
+a stored value of `1`, so "reads back stored state" and "this handler writes a literal `1`" make identical
+predictions on all of them. It is therefore left undecoded rather than named; settling it needs a reply
+from a strap whose stored value is `0`. See #891.
+
+### 2.5 Checksums
 
 | Algorithm | Function | Parameters |
 |-----------|----------|------------|
@@ -202,7 +241,7 @@ and `classifyHistoricalMeta(_:)` refuses to act on a frame where `p.crcOK == fal
 that gate a garbled or hostile peer could forge a `HISTORY_END`/`HISTORY_COMPLETE` and advance
 the strap's trim cursor, discarding data that was never durably stored.
 
-### 2.5 Reassembly
+### 2.6 Reassembly
 
 BLE notifications arrive as MTU-sized fragments. `Reassembler` (`Framing.swift`) accumulates
 bytes, finds the `0xAA` SOF, reads the `u16` LE length at `buf[1..3]`, and emits a complete


### PR DESCRIPTION
Docs only. Fills a gap #899 opened and I did not close.

## The gap

`PROTOCOL.md` documents the envelope down to `payload [11..]` and stops — so the two bytes every reply actually opens with are described nowhere, even though #899 made both decoders publish them and added `CommandResult` to the shared schema.

Three places were describing the same layout ad hoc instead: `DeviceConfigReadProbe` and `FeatureFlagProbe` each say "the 2-byte response header (`pay[1]` is the 5/MG result code)" in their own comments, and the ECG paragraph mentions a result code in passing.

New **§2.4** states it once, for both families — `resp_cmd`/`resp_seq`/`result` at `[6][7][8]` on 4.0 and the same `+4` on 5/MG — plus that `resp_seq` is the strap's own counter, not the echoed host-assigned envelope `seq` (a real capture shows envelope `seq` 147 beside `resp_seq` 2, and a repeated `resp_seq` is what identified a duplicated write in #791).

## The part worth writing down

The first **body** byte. `GET_BATTERY_LEVEL` puts the charge percentage there — `47` in the hardware-confirmed fixture — so the slot carries real data. On every other captured command it has only ever been `1`:

| capture | command | result | first body byte |
|---|---|---|---:|
| real 5/MG | `GET_BATTERY_LEVEL` | SUCCESS | **47** |
| real 5/MG | `GET_DATA_RANGE` | SUCCESS | 1 |
| real MG | `SELECT_WRIST`, accepted | SUCCESS | 1 |
| real MG | `SELECT_WRIST`, refused | FAILURE | 1 |
| real MG | `TOGGLE_LABRADOR_*` | SUCCESS | 1 |

For the wrist and ECG commands what that `1` means is **recorded as open**. Sending `SELECT_WRIST` with argument `0` got `1` back, which refutes an echo of the request — but every frame captured had a stored value of `1`, so "reads back stored state" and "this handler writes a literal `1`" predict identically on all of them. The decoder deliberately leaves the byte unnamed; this documents *why*, and what would settle it (a reply from a strap whose stored value is `0` — the #891 ask).

## Mechanics

Old §2.4 Checksums and §2.5 Reassembly shift to §2.5/§2.6. I checked: no cross-reference anywhere in the tree points at either, and the only internal PROTOCOL.md section reference is §2.2, unchanged.

Section is in §2 near the envelope, so it does not collide with #896, #898 or #907 — all three touch `PROTOCOL.md` but in the ECG and device-config sections.

Every claim was verified against source before writing: both platforms' offsets read out of the decoders, the PENDING-then-SUCCESS and `UNSUPPORTED(3)`-on-haptics results traced to the captures that produced them, and the body-byte table recomputed from the committed fixtures rather than copied from the issue thread.
