### PR TITLE
Localise the 9.2.1 What's New title (#878)

### DIFF
--- a/android/app/src/main/java/com/noop/ui/AppChangelog.kt
+++ b/android/app/src/main/java/com/noop/ui/AppChangelog.kt
@@ -39,7 +39,7 @@ object AppChangelog {
     val releases: List<Release> = listOf(
         Release(
             version = "9.2.1",
-            title = "Battery saver quiets the gauges, translated Android notifications, and instant chart loads",
+            title = uiString(R.string.l10n_app_changelog_battery_saver_quiets_the_gauges_translated_bdbe8650),
             date = "July 2026",
             items = listOf(
                 "**Battery saver stops the animation (#909).** Turn on Low Power Mode or battery saver and the live gauges, sky and pulsing dots settle into a single still frame. On iPhone that was measured at ~18% of a CPU core with the screen just sitting idle, and 0% posed still. It switches the moment you flip the setting — no restart.",

--- a/android/app/src/main/res/values-de/strings.xml
+++ b/android/app/src/main/res/values-de/strings.xml
@@ -1771,4 +1771,5 @@
     <string name="smart_alarm_body">Dein Smart-Wecker hat gerade geklingelt.</string>
     <string name="battery_channel_name">Akku-Hinweise</string>
     <string name="battery_channel_desc">Hinweise, wenn der Strap-Akku schwach oder voll geladen ist.</string>
+    <string name="l10n_app_changelog_battery_saver_quiets_the_gauges_translated_bdbe8650">Energiesparmodus beruhigt die Anzeigen, übersetzte Android-Benachrichtigungen und sofort geladene Diagramme</string>
 </resources>

--- a/android/app/src/main/res/values-es/strings.xml
+++ b/android/app/src/main/res/values-es/strings.xml
@@ -1756,4 +1756,5 @@
     <string name="smart_alarm_body">Tu alarma inteligente acaba de sonar.</string>
     <string name="battery_channel_name">Alertas de batería</string>
     <string name="battery_channel_desc">Avisos cuando la batería de la pulsera está baja o completamente cargada.</string>
+    <string name="l10n_app_changelog_battery_saver_quiets_the_gauges_translated_bdbe8650">El ahorro de batería calma los indicadores, notificaciones de Android traducidas y gráficos instantáneos</string>
 </resources>

--- a/android/app/src/main/res/values-fr/strings.xml
+++ b/android/app/src/main/res/values-fr/strings.xml
@@ -1756,4 +1756,5 @@
     <string name="smart_alarm_body">Votre alarme intelligente vient de sonner.</string>
     <string name="battery_channel_name">Alertes de batterie</string>
     <string name="battery_channel_desc">Alertes lorsque la batterie du bracelet est faible ou complètement chargée.</string>
+    <string name="l10n_app_changelog_battery_saver_quiets_the_gauges_translated_bdbe8650">L\'économiseur de batterie fige les jauges, notifications Android traduites et graphiques instantanés</string>
 </resources>

--- a/android/app/src/main/res/values-pt-rPT/strings.xml
+++ b/android/app/src/main/res/values-pt-rPT/strings.xml
@@ -1750,4 +1750,5 @@
     <string name="smart_alarm_body">O teu alarme inteligente acabou de tocar.</string>
     <string name="battery_channel_name">Alertas de bateria</string>
     <string name="battery_channel_desc">Avisos quando a bateria da correia está fraca ou totalmente carregada.</string>
+    <string name="l10n_app_changelog_battery_saver_quiets_the_gauges_translated_bdbe8650">A poupança de bateria acalma os indicadores, notificações Android traduzidas e gráficos instantâneos</string>
 </resources>

--- a/android/app/src/main/res/values-zh/strings.xml
+++ b/android/app/src/main/res/values-zh/strings.xml
@@ -1684,4 +1684,5 @@
     <string name="smart_alarm_body">你的智能闹钟刚刚响了。</string>
     <string name="battery_channel_name">电量提醒</string>
     <string name="battery_channel_desc">当手环电量低或已充满时提醒。</string>
+    <string name="l10n_app_changelog_battery_saver_quiets_the_gauges_translated_bdbe8650">省电模式让仪表静止、Android 通知已翻译、图表秒开</string>
 </resources>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -1782,4 +1782,5 @@
     <string name="smart_alarm_body">Your smart alarm just went off.</string>
     <string name="battery_channel_name">Battery alerts</string>
     <string name="battery_channel_desc">Alerts when the strap battery is low or fully charged.</string>
+    <string name="l10n_app_changelog_battery_saver_quiets_the_gauges_translated_bdbe8650">Battery saver quiets the gauges, translated Android notifications, and instant chart loads</string>
 </resources>

--- a/docs/SCOPE.md
+++ b/docs/SCOPE.md
@@ -1,0 +1,47 @@
+# Scope & non-goals
+
+NOOP exists to give you **your own strap data, offline and on-device**. That mission sets hard limits
+on what belongs in the app. This page names the WHOOP-app features that stay **out of scope** — and the
+local equivalents that stay **in scope** — so a parity proposal has a standing answer before a PR is
+opened. It does not change the constraints stated in [CLAUDE.md](../CLAUDE.md), the
+[Contributing guide](CONTRIBUTING.md), or the [Disclaimer](../DISCLAIMER.md); it maps them onto specific
+features so the boundary is discoverable.
+
+## The constraints this follows from
+
+NOOP is **fully offline, on-device, and anonymous**: no server, no account, no cloud sync, no telemetry,
+and **not a medical device** (see the [Disclaimer](../DISCLAIMER.md#5-not-a-medical-device)). Those are
+hard constraints, not preferences. Everything below is a consequence of them, not a separate rule.
+
+## Out of scope
+
+These map to features visible in WHOOP-app reverse-engineering, but they conflict with the constraints
+above. They are out of scope **unless the project deliberately changes its scope** in a tracked issue.
+
+| Feature (WHOOP parity) | Why it's out of scope | Ref |
+|---|---|---|
+| Possible-arrhythmia / diagnostic-style alerts | A medical-device-style claim. NOOP is explicitly **not a medical device** and must not tell a user they may have a health condition. | #752 |
+| Community feeds, team chat, social graph, leaderboards, cloud messaging | Require a **server, accounts, and an identity** — the opposite of anonymous and offline. | #755 |
+| Cloud- or account-dependent coaching / notification parity | Requires cloud identity and server sync. NOOP's coach is strictly bring-your-own-key and on-device. | — |
+| Anything requiring telemetry, server sync, user identity, or medical claims | Fails a hard constraint directly. | — |
+
+## In scope — the local, non-diagnostic equivalents
+
+The point of a boundary is to say what *is* welcome. These stay in scope because they run entirely
+on-device from NOOP's own data and make no medical claim.
+
+- **Local rhythm instrumentation.** Surfacing RR/IBI or beat-to-beat variability for the user's own
+  curiosity is fine **only** as **default-off instrumentation** with explicit **non-diagnostic** wording
+  — never an alert, never a health warning, never "possible arrhythmia" language, and never feeding a
+  downstream gate. This mirrors the physiological-signal rule in
+  [CLAUDE.md](../CLAUDE.md): an unproven derivation lands as instrumentation, not a shipped feature.
+- **Local notifications from NOOP's own metrics** — charge, alarm, sync state — computed on-device.
+- **Local export / import / reporting** — your data leaves only when *you* export it.
+- **Offline insights and explainers** that need no cloud identity.
+
+## Proposing a scope change
+
+Scope changes are deliberate, not incidental. If you believe one of the out-of-scope areas should move,
+open an issue that names the constraint it touches and how it would be satisfied — don't open the PR
+first. A "WHOOP has it" argument, on its own, is not a reason: NOOP is a clean-room, offline, anonymous
+tool, not a WHOOP clone.


### PR DESCRIPTION
**`main` is currently red on the i18n gate, and every open PR inherits it.** This fixes that.

## What happened

Cutting 9.2.1 added a hardcoded UI string. `appchangelog-gen.py` writes the Android title as a raw Kotlin literal:

```python
f'            title = "{esc_kt(wn["title"])}",\n'      # appchangelog-gen.py:60
```

which is precisely what #878 described — *"a raw literal fails i18n on every release and red-checks all open PRs"*. That issue is closed, but the generator was never changed: 9.2.0's title was localised **by hand** in #886 and the issue closed on the strength of that. So the same manual fix applies here, and #878 wants reopening for the generator itself.

## Why nobody saw it

Two things compounded:

1. **The release push produced no CI run at all.** `fork-release.yml` pushes with `GITHUB_TOKEN`, and GitHub does not trigger workflows on those pushes — so there is no run on `7054aef8` or `21e36a2b`. Main went red silently.
2. **The audit is a whole-tree gate, not a diff.** So it fails every open PR on a line none of them touched. #915 hit it first, which is how it surfaced.

## The fix

Key follows the established convention — first six slug words + `sha1(value)[:8]` — which I verified by reproducing 9.2.0's existing key from its title before generating this one. Translated in all five locales alongside the English, matching how every earlier release title is carried.

## The real fix is upstream

This is the second release in a row patched by hand. The generator should emit `uiString(R.string.<key>)` plus the English resource, and warn loudly listing the locales that still need the title translated — it cannot supply translations itself, but it can turn a silent red into an explicit task. Reopening #878 with that scope rather than filing a duplicate.
