### PR TITLE
Don't let the body-location probe's detail line contradict its own verdict (#690)

### DIFF
--- a/Packages/WhoopProtocol/Sources/WhoopProtocol/BodyLocationProbe.swift
+++ b/Packages/WhoopProtocol/Sources/WhoopProtocol/BodyLocationProbe.swift
@@ -99,7 +99,7 @@ public enum BodyLocationProbe {
                 sb += "Δ vs previous capture: first capture — probe again in another position to diff"
             }
         } else {
-            sb += "\nNo payload beyond the command byte (bare stub) — no body-location data on this firmware"
+            sb += "\nNo payload beyond the command byte (bare stub) — this reply carried no body-location data, which is not the same as the firmware having none (see the Verdict above)"
         }
         return (sb, payloadHex)
     }

--- a/Packages/WhoopProtocol/Tests/WhoopProtocolTests/BodyLocationProbeTests.swift
+++ b/Packages/WhoopProtocol/Tests/WhoopProtocolTests/BodyLocationProbeTests.swift
@@ -64,6 +64,12 @@ final class BodyLocationProbeTests: XCTestCase {
         let (text, payHex) = BodyLocationProbe.format(frame: hexToBytes("aa0700fa24005446758858"), cmdOff: 6, isWhoop5: false, prevPayloadHex: nil)
         XCTAssertTrue(text.contains("bare stub"))
         XCTAssertNil(payHex)
+        // A bare stub is one reply, not a firmware capability. The Verdict line already calls it
+        // "ambiguous"; the detail line used to contradict it with "no body-location data on this
+        // firmware", which is the conclusion a reader would quote. Neither line may say it. (#914 class)
+        XCTAssertTrue(text.contains("ambiguous"), text)
+        XCTAssertFalse(text.contains("no body-location data on this firmware"), text)
+        XCTAssertTrue(text.contains("not the same as the firmware having none"), text)
     }
 
     /// Golden FULL-output lock: pins the exact byte-for-byte report so the Swift and Kotlin twins can't

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -1298,7 +1298,7 @@ class WhoopBleClient(
                     sb.append("Δ vs previous capture: first capture — probe again in another position to diff")
                 }
             } else {
-                sb.append("\nNo payload beyond the command byte (bare stub) — no body-location data on this firmware")
+                sb.append("\nNo payload beyond the command byte (bare stub) — this reply carried no body-location data, which is not the same as the firmware having none (see the Verdict above)")
             }
             return sb.toString() to payloadHex
         }

--- a/android/app/src/test/java/com/noop/ble/BodyLocationProbeFormatTest.kt
+++ b/android/app/src/test/java/com/noop/ble/BodyLocationProbeFormatTest.kt
@@ -2,6 +2,7 @@ package com.noop.ble
 
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -61,6 +62,10 @@ class BodyLocationProbeFormatTest {
     @Test fun bareStubIsCalledOut() {
         val (text, payHex) = WhoopBleClient.formatBodyLocationProbe(hexToBytes("aa0700fa24005446758858"), 6, false, null)
         assertTrue(text.contains("bare stub"))
+        // Twin of the Swift assertion: a bare stub is one reply, not a firmware capability.
+        assertTrue(text.contains("ambiguous"))
+        assertFalse(text.contains("no body-location data on this firmware"))
+        assertTrue(text.contains("not the same as the firmware having none"))
         assertNull(payHex)
     }
 


### PR DESCRIPTION
Follow-up from the #913 review — found by sweeping the other probes for the same defect class, not reported.

## The report contradicts itself

A bare-stub run prints both of these:

```
Verdict: opcode 84 answered with a bare stub — ambiguous
...
No payload beyond the command byte (bare stub) — no body-location data on this firmware
```

The verdict is right. The detail line settles what the verdict just called unsettled — and it is the line that reads like a finding.

One reply carrying no payload does not distinguish a firmware without body-location data from one that needs the strap worn, in a determinate position, or asked with an argument this probe does not send. The file's own enum has `UNKNOWN(0)` and `NOT_CONCLUSIVE(128)`, so the firmware explicitly models "cannot tell right now" — precisely the reading the detail line ruled out.

Same class as #913 and #914: a probe asserting a conclusion the run's inputs could not support, in the sentence someone pastes into an issue.

## Both platforms, and it is a shared defect

I checked whether this was a divergence and it is not — Swift and Kotlin carry the byte-identical string, so both are reworded:

> No payload beyond the command byte (bare stub) — this reply carried no body-location data, which is not the same as the firmware having none (see the Verdict above)

## The tests could not have caught it

Both existing bare-stub tests asserted only `text.contains("bare stub")`, which passes under either wording. They now assert the over-claim is **absent** and that the verdict and the hedge are both present. That is the difference between a test that pins behaviour and one that happens to pass.

The golden parity lock is unaffected — it pins a payload-bearing frame, so the bare-stub branch was never inside it. I verified that rather than assuming.
