### PR TITLE
Correct 31 French translations from a native-speaker review (#884)

### DIFF
--- a/Packages/StrandDesign/Sources/StrandDesign/Resources/Localizable.xcstrings
+++ b/Packages/StrandDesign/Sources/StrandDesign/Resources/Localizable.xcstrings
@@ -2628,7 +2628,7 @@
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Plongez pour lire le VHR de chaque jour en ms."
+            "value": "Survolez pour lire la VFC de chaque jour en ms."
           }
         },
         "pt-PT": {
@@ -2796,7 +2796,7 @@
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "GRADIENTS DE RECOUVREMENT"
+            "value": "GRADIENT DE RÉCUPÉRATION"
           }
         },
         "pt-PT": {


### PR DESCRIPTION
Part of #884 — the issue stays open; see the completeness note at the end. @NoBrainNoHeadache — a native French speaker, first contribution — reviewed the catalogue's French and attached a corrected file. This applies it as a **cherry-pick of exactly the 31 changed fr entries**, not the wholesale file, for two reasons found in review:

- their base predated #890, so wholesale replacement would have **deleted 4 keys**;
- Xcode's re-extraction had added **209 keys** the catalogue deliberately does not carry.

## What it fixes

Not polish — machine-translation output that was wrong to the point of nonsense:

| key | old French | which means |
|---|---|---|
| RESTORATIVE SLEEP | `POULET RESTORATOIRE` | restorative **chicken** |
| "one-glance read" | `lecture d'un verre` | reading of a drinking **glass** |
| "Deep sleep pools HRV" | `piscines de sommeil` | **swimming pools** of sleep |
| HOURS OF SLEEP | `HORAIRES DE DOUCEE` | not a French word |
| RECOVERY | `RECOUVREMENT` | **debt collection** — the same error #902 found in Android's catalogue exists here too |

Plus consistent terminology: HRV → **VFC** everywhere (replacing the invented VHR/VRH), RHR → **FCR**, strap → **bracelet** (replacing bande/sangle).

## The change verified against code, not language

The bare `"W"`/`"M"` keys. Every localized use is `case .week` / `case .month` in seven range pickers — so their W→`S` (Semaine) / M→`M` (Mois) is correct, and the **old** French had M→`L` (someone's Monday→Lundi guess): French users have been seeing an L on a Month toggle. A translation fix that is also a UI bug fix.

## Two integration repairs, both mechanical

1. The Charge explainer carried `%6$lldcalculée` — a positional `%6$` against an English string with a **single** argument, so `String(format:)` reaches for a sixth argument that does not exist. **Correction to an earlier revision of this description:** the `%6$` is NOT from the contributor's edit or Xcode's editor — it is on `main` today, and not only in French: **German and Spanish carry the identical broken specifier** (pt-PT is already correct). All three are repaired here to `%lld` (fr also gains its missing space); the es prose around it has separate MT damage (« de vez en cuando » for "from time in zones") noted on #884 rather than touched here.
2. All 31 arrived `state=needs_review`, which `Tools/i18n_audit.py` counts as untranslated — a straight merge would have **hard-failed the fr focus-locale gate**. Flipped to `translated` after reading all 31.

## Verification

- Diff is 31 value lines and nothing else — checked, not assumed; serialization confirmed byte-stable before writing.
- Format specifiers verified preserved on the other 30.
- Only `fr` differs from main; no other locale touched.
- `i18n --ci` passes.



## Completeness (added after a scoping re-check)

- **+2 strings from the StrandDesign catalogue**, same error class found by sweeping the other three Apple catalogues: `GRADIENTS DE RECOUVREMENT` → `GRADIENT DE RÉCUPÉRATION`, and `Plongez pour lire le VHR` ("dive to read") → `Survolez pour lire la VFC`. The two Watch catalogues are clean.
- **Not in this PR, still open on #884:** (a) the contributor also translated **209 un-extracted keys** Xcode pulled from source — real work, preserved on the issue, adoptable only when those strings are extracted with the other focus locales filled; (b) **Android'''s French has the same error classes at larger scale** — VHR×7, RECOUVREMENT×1, `sangle`×80, `bande`×6 — and the sangle→bracelet sweep flips grammatical gender, so it needs a careful pass, not a sed.



