### PR TITLE
Raw sensor export reads the active strap, not the legacy id (#175)

### DIFF
--- a/Strand/Screens/SettingsView.swift
+++ b/Strand/Screens/SettingsView.swift
@@ -1619,10 +1619,20 @@ struct SettingsView: View {
     }
 
     /// Export the last 24h of decoded sensor streams for the connected strap to a CSV, then save (macOS
-    /// NSSavePanel) or share (iOS share sheet) — the same pattern as exportPuffinCaptures(). The store
-    /// handle and the strap deviceId both come from the app's single "my-whoop" id.
+    /// NSSavePanel) or share (iOS share sheet) — the same pattern as exportPuffinCaptures().
+    ///
+    /// The strap id comes from `repo.deviceId`, NOT `model.deviceId`. The latter is a hardcoded
+    /// `let "my-whoop"`; the former is seeded with it and then re-pointed to the registry's active strap
+    /// once the store opens (`adoptActiveDeviceId`). This read used the hardcoded one, so after a
+    /// remove+re-add — which mints a fresh "whoop-<uuid>" that the Collector writes today's raw under —
+    /// the CSV exported the legacy id's streams rather than the strap being worn, silently, in the file
+    /// people attach to bug reports. That is #814 on the diagnostic path, and the Android twin of it.
+    ///
+    /// Read on the MainActor before the Task hop, as `LiveSessionRunner` does, rather than reaching into
+    /// the actor-isolated repo from inside the task.
     private func exportRawSensorCSV() {
         rawCsvBusy = true
+        let strapId = model.repo.deviceId
         Task {
             let since = Date().timeIntervalSince1970 - 24 * 60 * 60
             guard let store = await model.repo.storeHandle() else {
@@ -1635,7 +1645,7 @@ struct SettingsView: View {
                 return
             }
             do {
-                let url = try await store.exportRawCSV(deviceId: model.deviceId, since: since)
+                let url = try await store.exportRawCSV(deviceId: strapId, since: since)
                 await MainActor.run {
                     rawCsvBusy = false
                     lastRawCsvURL = url

--- a/android/app/src/main/java/com/noop/ingest/RawSensorExport.kt
+++ b/android/app/src/main/java/com/noop/ingest/RawSensorExport.kt
@@ -141,8 +141,14 @@ object RawSensorExport {
      * Build the last-24 h CSV for the strap source and fire a share sheet (text/csv). Runs the DB read
      * off the main thread; toasts a per-stream summary so the user sees what was captured (and that the
      * deeper 5/MG streams are empty until they've been unlocked). On-device only.
+     *
+     * [deviceId] is REQUIRED, deliberately. It used to default to the canonical "my-whoop", and the one
+     * caller took the default — so after a strap re-add this exported the legacy id's streams rather than
+     * the strap the user is actually wearing, silently, in the CSV people attach to bug reports. That is
+     * the #172/#175 defect exactly: a defaulted strap id that no caller overrides. Removing the default
+     * makes the compiler ask, which is stronger than remembering. (Ported from tanarchytan/noop e4f508f.)
      */
-    suspend fun export(context: Context, repo: WhoopRepository, deviceId: String = "my-whoop") {
+    suspend fun export(context: Context, repo: WhoopRepository, deviceId: String) {
         runCatching {
             val now = System.currentTimeMillis() / 1000
             val dir = File(context.cacheDir, "logs").apply { mkdirs() }

--- a/android/app/src/main/java/com/noop/ui/SettingsScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/SettingsScreen.kt
@@ -2079,7 +2079,7 @@ fun SettingsScreen(
                     leadingIcon = Icons.Filled.Upload,
                     kind = NoopButtonKind.Secondary,
                     fullWidth = true,
-                    onClick = { scope.launch { RawSensorExport.export(context, vm.repo) } },
+                    onClick = { scope.launch { RawSensorExport.export(context, vm.repo, vm.activeStrapId) } },
                 )
                 Text(
                     uiString(R.string.l10n_settings_screen_saves_the_last_24h_of_decoded_f7026f47),


### PR DESCRIPTION
The raw sensor CSV — the file people attach to bug reports — could describe a strap the user
isn't wearing. Fixed on both platforms.

**Android.** `RawSensorExport.export` took `deviceId: String = "my-whoop"` and its one caller
(`SettingsScreen.kt:2082`) took the default. After a remove+re-add the strap gets a fresh
`whoop-<uuid>` that the collector writes today's raw under, so the export read the legacy id's
streams instead. The sibling export four hundred lines up already threads `vm.activeStrapId`.

The default is **removed** rather than corrected, so the compiler asks at every future call site
instead of the next author having to remember. Verified there was exactly one caller first.

**iOS/macOS.** Same defect, worse form: `exportRawSensorCSV` passed `model.deviceId`, which is a
hardcoded `let "my-whoop"`, where ~20 other strap reads use `repo.deviceId` — seeded with that id
and then re-pointed to the registry's active strap by `adoptActiveDeviceId`. Read on the MainActor
before the `Task` hop, matching `LiveSessionRunner`.

This is #814 on the diagnostic path, and the #172/#175 shape that `ResolvedSeriesCallSiteAuditTest`
exists to catch.

**Verification.** Android compiles and its unit tests pass in CI. The Swift side is app-target
(`Strand/`), which nothing compiles while `app-build.yml` is disabled — so it is stated plainly: it
is uncompiled. What supports it is that `LiveSessionRunner.persist()` is the same four lines already
shipping — capture `repo.deviceId`, `Task {`, `await repo.storeHandle()`, pass the captured id — and
the enclosing function mutates `@State` synchronously, so it is MainActor-isolated. Same isolation
shape as working code, but a local `xcodebuild` before merge is still the thing that proves it.

**Not changed, deliberately.** Two other `model.deviceId` readers exist — `WatchSessionBridge.swift:150`
and `StrandiOSApp.swift:58` — and `WhoopRepository` still defaults `strapDeviceId` on four Android
reads. Each needs its own caller audit; bundling them here would hide this one.

Android half ported from `tanarchytan/noop` `e4f508f`, which fixed the caller; the removed default
and the Apple twin are additional.
