### PR TITLE
Sleep: correct which stager ships (V2, not V1), and add SleepBench so the claim is measurable

### DIFF
--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/AnalyticsEngine.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/AnalyticsEngine.swift
@@ -319,10 +319,12 @@ public enum AnalyticsEngine {
                                   // pure-function callers/tests free of it; IntelligenceEngine threads the
                                   // night window's persisted band state. (#531 / H8 consume)
                                   bandSleepState: [(ts: Int, state: Int)] = [],
-                                  // Opt-in experimental sleep staging (V2). When true, detected nights are
-                                  // staged by `SleepStagerV2` instead of V1. Default false keeps V1 the
-                                  // byte-identical default for pure-function callers/tests; IntelligenceEngine
-                                  // threads `PuffinExperiment.experimentalSleepV2Enabled`. (V7 / #690)
+                                  // Which sleep-staging recipe runs (V2 vs V1). When true, detected nights
+                                  // are staged by `SleepStagerV2` instead of V1. This PARAMETER defaults
+                                  // false to keep pure-function callers/tests byte-identical — it is NOT
+                                  // the product default. IntelligenceEngine threads
+                                  // `PuffinExperiment.experimentalSleepV2Enabled`, which is default ON
+                                  // (#277/#351), so the shipped app stages with V2. (V7 / #690)
                                   useSleepStagerV2: Bool = false,
                                   // Opt-in motion-aware wake refinement (#364 "Proposal 2" follow-up; density
                                   // gate precedent #345). When true, `WakeMotionRefinement` re-derives each

--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/SleepStager.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/SleepStager.swift
@@ -827,12 +827,16 @@ public enum SleepStager {
     /// re-onset (#531): a daytime block the strap itself scored predominantly "asleep" is KEPT even on a
     /// borderline HR dip. Default empty keeps pure-function callers/tests free of it; IntelligenceEngine
     /// passes the night window's persisted band state. It can only RESCUE a real-sleep block, never fabricate.
-    /// `useSleepStagerV2` (V7 / #690): when true, each accepted night is staged by the experimental
-    /// cardiorespiratory recipe `SleepStagerV2.stageSession` instead of V1's `stageSession`. DETECTION is
-    /// unchanged (same accepted windows); only the per-epoch hypnogram differs. Default false keeps V1 the
-    /// byte-identical default (the frozen-golden tests stay green). The live call site threads
-    /// `PuffinExperiment.experimentalSleepV2Enabled` so the Settings toggle now affects normal detected
-    /// nights, not just the self-heal restage path.
+    /// `useSleepStagerV2` (V7 / #690): which recipe stages an accepted night — the cardiorespiratory
+    /// `SleepStagerV2.stageSession` when true, V1's `stageSession` when false. DETECTION is unchanged
+    /// (same accepted windows); only the per-epoch hypnogram differs.
+    ///
+    /// THE TWO DEFAULTS ARE NOT THE SAME, and reading only the signature gets this backwards. This
+    /// PARAMETER defaults false so pure-function callers and the frozen-golden tests stay byte-identical.
+    /// The SHIPPED app never takes that default: the live call site threads
+    /// `PuffinExperiment.experimentalSleepV2Enabled`, which is **default ON** (V2 was promoted over V1 in
+    /// #277 and extended to every strap family in #351), so a normal user's nights are staged by **V2**.
+    /// `= false` here describes the library's contract with its callers, not the product's behaviour.
     /// `sleepHRBaseline` (motion-corroborated wake, directive b): the wearer's PERSONALISED overnight HR band
     /// (`adaptiveOvernightHRBaseline`), used by `confirmSleepWithHR` in place of the day-median so a supplement /
     /// fitness era self-calibrates the sleep band. Default nil keeps the day-median (byte-identical to before);

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/SleepStagerV2Tests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/SleepStagerV2Tests.swift
@@ -2,10 +2,13 @@ import XCTest
 @testable import StrandAnalytics
 import WhoopProtocol
 
-/// Basic coverage for the OPT-IN experimental stager `SleepStagerV2` (V7 Pillar 3b, reimplemented from
-/// contributor PR #600). These assert the drop-in CONTRACT — same `stageSession` signature + return shape as
-/// V1, segments that tile `[start, end]` with canonical stage labels — and a couple of recipe invariants.
-/// They are NOT a fidelity claim against any reference (the recipe's own validation is n=1).
+/// Basic coverage for `SleepStagerV2` (V7 Pillar 3b, reimplemented from contributor PR #600) — the recipe
+/// that stages a normal user's nights, since `PuffinExperiment.experimentalSleepV2Enabled` is default ON
+/// (#277 promoted it over V1; #351 extended it to every strap family). These assert the drop-in CONTRACT —
+/// same `stageSession` signature + return shape as V1, segments that tile `[start, end]` with canonical
+/// stage labels — and a couple of recipe invariants.
+/// They are NOT a fidelity claim against any reference: the cross-subject evidence behind the promotion is
+/// a 44-subject leave-one-subject-out benchmark, and these unit tests do not re-measure it.
 final class SleepStagerV2Tests: XCTestCase {
 
     // MARK: - fixtures

--- a/Strand/Data/Repository.swift
+++ b/Strand/Data/Repository.swift
@@ -1364,10 +1364,12 @@ final class Repository: ObservableObject {
         let steps = useMotionAwareWake
             ? ((try? await store.stepSamples(deviceId: deviceId, from: lo, to: hi, limit: 200_000)) ?? [])
             : []
-        // Opt-in experimental staging (Settings → Experimental · Sleep staging): when the user has flipped
-        // the V2 flag on, re-stage with the cardiorespiratory recipe `SleepStagerV2`; otherwise the default
-        // V1 `SleepStager`. Read once here off the actor; the switch is purely which engine runs over the
-        // already-detected window , V1 stays the default and is untouched. (V7 Pillar 3b)
+        // Which staging engine re-stages this window (Settings → Experimental · Sleep staging). The flag is
+        // **default ON** (#277 promoted V2 over V1; #351 extended it to every strap family), so unless the
+        // user has explicitly turned it OFF this re-stages with the cardiorespiratory recipe `SleepStagerV2`;
+        // turning it off falls back to V1 `SleepStager`. Read once here off the actor; the switch is purely
+        // which engine runs over the already-detected window — detection is identical either way.
+        // (V7 Pillar 3b)
         let useV2 = PuffinExperiment.experimentalSleepV2Enabled
         let segs = await Task.detached(priority: .utility) {
             let staged = useV2

--- a/Tools/SleepBench/Package.resolved
+++ b/Tools/SleepBench/Package.resolved
@@ -1,0 +1,14 @@
+{
+  "pins" : [
+    {
+      "identity" : "grdb.swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/groue/GRDB.swift.git",
+      "state" : {
+        "revision" : "2cf6c756e1e5ef6901ebae16576a7e4e4b834622",
+        "version" : "6.29.3"
+      }
+    }
+  ],
+  "version" : 2
+}

--- a/Tools/SleepBench/Package.swift
+++ b/Tools/SleepBench/Package.swift
@@ -1,0 +1,23 @@
+// swift-tools-version:5.9
+import PackageDescription
+
+// SleepBench — an offline scoring harness for the sleep stagers.
+//
+// Replays `SleepStager` (V1) and `SleepStagerV2` over real, already-decoded nights held in a NOOP
+// SQLite database and scores each hypnogram against whichever independent references that database
+// carries: the wearer's own manual restages (`sleepSession.userEdited = 1`), the strap's own band
+// sleep_state (`sleepStateSample`, the v18 @81 high nibble), and Apple Health sleep.
+//
+// The database path is ALWAYS a command-line argument — no health data lives in this repository, and
+// none is ever written back. The tool is read-only (`SQLITE_OPEN_READONLY` + `immutable=1`).
+let package = Package(
+    name: "sleepbench",
+    platforms: [.macOS(.v13)],
+    dependencies: [
+        .package(path: "../../Packages/StrandAnalytics"),
+        .package(path: "../../Packages/WhoopProtocol"),
+    ],
+    targets: [
+        .executableTarget(name: "sleepbench", dependencies: ["StrandAnalytics", "WhoopProtocol"]),
+    ]
+)

--- a/Tools/SleepBench/Sources/sleepbench/DB.swift
+++ b/Tools/SleepBench/Sources/sleepbench/DB.swift
@@ -1,0 +1,160 @@
+import Foundation
+import SQLite3
+import StrandAnalytics
+import WhoopProtocol
+
+/// Minimal read-only SQLite reader. Deliberately not GRDB: this tool must be able to open a COPY of a
+/// device database taken at any schema version, including one older or newer than `WhoopStore`'s current
+/// migration set, without running migrations against it. Opened `immutable=1` so it can never write.
+final class ReadOnlyDB {
+    private var handle: OpaquePointer?
+
+    init(path: String) throws {
+        // `immutable=1` promises the file will not change under us and suppresses any journal/WAL
+        // recovery write — the reason a plain read-only open is not enough for a pulled device DB.
+        let uri = "file:\(path)?immutable=1"
+        let rc = sqlite3_open_v2(uri, &handle, SQLITE_OPEN_READONLY | SQLITE_OPEN_URI, nil)
+        guard rc == SQLITE_OK else {
+            throw Err("cannot open \(path): \(String(cString: sqlite3_errstr(rc)))")
+        }
+    }
+    deinit { if let handle { sqlite3_close(handle) } }
+
+    struct Err: Error, CustomStringConvertible {
+        let description: String
+        init(_ d: String) { description = d }
+    }
+
+    /// Run `sql` and hand each row to `each` as a statement cursor.
+    func query(_ sql: String, _ each: (OpaquePointer) -> Void) throws {
+        var stmt: OpaquePointer?
+        guard sqlite3_prepare_v2(handle, sql, -1, &stmt, nil) == SQLITE_OK else {
+            throw Err("prepare failed: \(String(cString: sqlite3_errmsg(handle))) [\(sql)]")
+        }
+        defer { sqlite3_finalize(stmt) }
+        while sqlite3_step(stmt) == SQLITE_ROW { each(stmt!) }
+    }
+
+    static func int(_ s: OpaquePointer, _ i: Int32) -> Int { Int(sqlite3_column_int64(s, i)) }
+    static func dbl(_ s: OpaquePointer, _ i: Int32) -> Double { sqlite3_column_double(s, i) }
+    static func isNull(_ s: OpaquePointer, _ i: Int32) -> Bool {
+        sqlite3_column_type(s, i) == SQLITE_NULL
+    }
+    static func str(_ s: OpaquePointer, _ i: Int32) -> String? {
+        guard let c = sqlite3_column_text(s, i) else { return nil }
+        return String(cString: c)
+    }
+}
+
+// MARK: - Rows
+
+/// One persisted night. `stagesJSON` is the hypnogram CURRENTLY stored; on a `userEdited` row that is the
+/// wearer's manual restage, and `efficiency` is then the STALE pre-edit machine value (the edit path
+/// rewrites the stages but not the summary column) — which is exactly what makes the machine's original
+/// wake total recoverable. See `MachineRecall` in main.swift for the check that establishes this.
+struct SessionRow {
+    let deviceId: String
+    let startTs: Int
+    let endTs: Int
+    let efficiency: Double?
+    let userEdited: Bool
+    let startTsAdjusted: Int?
+    let stages: [StageSegment]
+    let bandStates: [Int]        // persisted per-epoch sleepStateJSON, [] when absent
+    var durMin: Double { Double(endTs - startTs) / 60.0 }
+}
+
+struct Streams {
+    var hr: [HRSample] = []
+    var rr: [RRInterval] = []
+    var grav: [GravitySample] = []
+    var resp: [RespSample] = []
+    var steps: [StepSample] = []
+    var band: [(ts: Int, state: Int)] = []
+}
+
+extension ReadOnlyDB {
+    func sessions(device: String) throws -> [SessionRow] {
+        var out: [SessionRow] = []
+        let sql = """
+        SELECT startTs, endTs, efficiency, userEdited, startTsAdjusted, stagesJSON, sleepStateJSON
+        FROM sleepSession WHERE deviceId = '\(device)' ORDER BY startTs
+        """
+        try query(sql) { s in
+            let stagesJSON = ReadOnlyDB.str(s, 5) ?? "[]"
+            let stages = (try? JSONDecoder().decode([StageSegment].self,
+                                                    from: Data(stagesJSON.utf8))) ?? []
+            var band: [Int] = []
+            if let bj = ReadOnlyDB.str(s, 6) {
+                band = (try? JSONDecoder().decode([Int].self, from: Data(bj.utf8))) ?? []
+            }
+            out.append(SessionRow(
+                deviceId: device,
+                startTs: ReadOnlyDB.int(s, 0),
+                endTs: ReadOnlyDB.int(s, 1),
+                efficiency: ReadOnlyDB.isNull(s, 2) ? nil : ReadOnlyDB.dbl(s, 2),
+                userEdited: ReadOnlyDB.int(s, 3) != 0,
+                startTsAdjusted: ReadOnlyDB.isNull(s, 4) ? nil : ReadOnlyDB.int(s, 4),
+                stages: stages,
+                bandStates: band))
+        }
+        return out
+    }
+
+    /// Every stream the stagers read, over `[from, to]`. The stagers themselves clip to the window they
+    /// need, but detection wants a wider span than the session, hence the caller-chosen padding.
+    func streams(device: String, from: Int, to: Int) throws -> Streams {
+        var st = Streams()
+        let w = "deviceId = '\(device)' AND ts >= \(from) AND ts <= \(to)"
+        try query("SELECT ts, bpm FROM hrSample WHERE \(w) ORDER BY ts") { s in
+            st.hr.append(HRSample(ts: ReadOnlyDB.int(s, 0), bpm: ReadOnlyDB.int(s, 1)))
+        }
+        // `ord` then `seq` preserves the within-second beat order the store guarantees.
+        try query("SELECT ts, rrMs FROM rrInterval WHERE \(w) ORDER BY ts, ord, seq") { s in
+            st.rr.append(RRInterval(ts: ReadOnlyDB.int(s, 0), rrMs: ReadOnlyDB.int(s, 1)))
+        }
+        try query("SELECT ts, x, y, z, dynAccel FROM gravitySample WHERE \(w) ORDER BY ts") { s in
+            st.grav.append(GravitySample(
+                ts: ReadOnlyDB.int(s, 0), x: ReadOnlyDB.dbl(s, 1), y: ReadOnlyDB.dbl(s, 2),
+                z: ReadOnlyDB.dbl(s, 3), unit: "g",
+                dynAccel: ReadOnlyDB.isNull(s, 4) ? nil : ReadOnlyDB.dbl(s, 4)))
+        }
+        try query("SELECT ts, raw FROM respSample WHERE \(w) ORDER BY ts") { s in
+            st.resp.append(RespSample(ts: ReadOnlyDB.int(s, 0), raw: ReadOnlyDB.int(s, 1)))
+        }
+        try query("SELECT ts, counter, activityClass FROM stepSample WHERE \(w) ORDER BY ts") { s in
+            st.steps.append(StepSample(
+                ts: ReadOnlyDB.int(s, 0), counter: ReadOnlyDB.int(s, 1),
+                activityClass: ReadOnlyDB.isNull(s, 2) ? nil : ReadOnlyDB.int(s, 2)))
+        }
+        try query("SELECT ts, state FROM sleepStateSample WHERE \(w) ORDER BY ts") { s in
+            st.band.append((ts: ReadOnlyDB.int(s, 0), state: ReadOnlyDB.int(s, 1)))
+        }
+        return st
+    }
+
+    /// The `stagelock:<deviceId>:<startTs>` cursors. A lock is written ONLY by `CloudEditApplier` when an
+    /// `edit_sleep_stages` payload lands — i.e. only when a human authored the hypnogram itself, as opposed
+    /// to correcting the bed/wake bounds (which re-derives stages from raw and is therefore machine output
+    /// over a human-chosen window). This distinction decides whether a `userEdited` row is usable as a
+    /// stage-level reference at all, so the harness reads it rather than assuming.
+    func stageLockedStarts(device: String) throws -> Set<Int> {
+        var out: Set<Int> = []
+        let prefix = "stagelock:\(device):"
+        try query("SELECT name FROM cursors WHERE value = 1 AND name LIKE '\(prefix)%'") { s in
+            if let n = ReadOnlyDB.str(s, 0), let ts = Int(n.dropFirst(prefix.count)) { out.insert(ts) }
+        }
+        return out
+    }
+
+    /// Mean / min HR over a window — the stratifier for the supplement-HR hypothesis.
+    func hrStats(device: String, from: Int, to: Int) throws -> (mean: Double, n: Int, p10: Double)? {
+        var v: [Double] = []
+        try query("SELECT bpm FROM hrSample WHERE deviceId = '\(device)' AND ts >= \(from) AND ts <= \(to)") { s in
+            v.append(ReadOnlyDB.dbl(s, 0))
+        }
+        guard !v.isEmpty else { return nil }
+        v.sort()
+        return (v.reduce(0, +) / Double(v.count), v.count, v[max(0, Int(Double(v.count) * 0.10) - 1)])
+    }
+}

--- a/Tools/SleepBench/Sources/sleepbench/Metrics.swift
+++ b/Tools/SleepBench/Sources/sleepbench/Metrics.swift
@@ -1,0 +1,146 @@
+import Foundation
+import StrandAnalytics
+
+/// The four scored classes, in a fixed order so every confusion matrix in the run is indexed alike.
+let stageOrder = ["wake", "light", "deep", "rem"]
+
+/// 30 s epochs, matching `SleepStager.epochS` and the grid `stagesJSON` / `sleepStateJSON` are stored on.
+let epochSeconds = 30.0
+
+func epochCount(start: Int, end: Int) -> Int {
+    max(1, Int(ceil(Double(end - start) / epochSeconds)))
+}
+
+/// Expand a `[StageSegment]` tiling into a per-epoch label array on the 30 s grid, taking each epoch's
+/// label from the segment covering its START instant — the same convention `applyBandStateWakeVeto` uses,
+/// so an expand→collapse round-trip is exact.
+func epochLabels(_ stages: [StageSegment], start: Int, end: Int) -> [String] {
+    let n = epochCount(start: start, end: end)
+    var out = [String](repeating: "wake", count: n)
+    guard !stages.isEmpty else { return out }
+    let sorted = stages.sorted { $0.start < $1.start }
+    var si = 0
+    for i in 0..<n {
+        let t = start + Int(Double(i) * epochSeconds)
+        while si + 1 < sorted.count && sorted[si].end <= t { si += 1 }
+        let seg = sorted[si]
+        if seg.start <= t && t < seg.end { out[i] = seg.stage }
+        else if let hit = sorted.first(where: { $0.start <= t && t < $0.end }) { out[i] = hit.stage }
+        else if t >= sorted[sorted.count - 1].end { out[i] = sorted[sorted.count - 1].stage }
+    }
+    return out
+}
+
+/// Minutes at each stage in a label array.
+func stageMinutes(_ labels: [String]) -> [String: Double] {
+    var m: [String: Double] = [:]
+    for l in labels { m[l, default: 0] += epochSeconds / 60.0 }
+    return m
+}
+
+func wakeMinutes(_ labels: [String]) -> Double { stageMinutes(labels)["wake"] ?? 0 }
+func sleepMinutes(_ labels: [String]) -> Double {
+    Double(labels.filter { $0 != "wake" }.count) * epochSeconds / 60.0
+}
+
+/// Index of the first and last non-wake epoch — sleep onset and final wake on this grid.
+func onsetAndFinalWake(_ labels: [String]) -> (onset: Int?, final: Int?) {
+    (labels.firstIndex(where: { $0 != "wake" }), labels.lastIndex(where: { $0 != "wake" }))
+}
+
+// MARK: - Agreement
+
+/// A square confusion matrix over `classes`, rows = reference, cols = prediction.
+struct Confusion {
+    let classes: [String]
+    var m: [[Int]]
+    init(classes: [String]) {
+        self.classes = classes
+        m = Array(repeating: Array(repeating: 0, count: classes.count), count: classes.count)
+    }
+    mutating func add(ref: String, pred: String) {
+        guard let r = classes.firstIndex(of: ref), let c = classes.firstIndex(of: pred) else { return }
+        m[r][c] += 1
+    }
+    mutating func merge(_ o: Confusion) {
+        for i in 0..<m.count { for j in 0..<m.count { m[i][j] += o.m[i][j] } }
+    }
+    var total: Int { m.flatMap { $0 }.reduce(0, +) }
+    var accuracy: Double {
+        let t = total
+        return t == 0 ? 0 : Double((0..<m.count).reduce(0) { $0 + m[$1][$1] }) / Double(t)
+    }
+    /// Cohen's kappa: (p_o - p_e) / (1 - p_e).
+    var kappa: Double {
+        let t = Double(total)
+        guard t > 0 else { return .nan }
+        let po = accuracy
+        var pe = 0.0
+        for i in 0..<m.count {
+            let rowSum = Double(m[i].reduce(0, +))
+            let colSum = Double((0..<m.count).reduce(0) { $0 + m[$1][i] })
+            pe += (rowSum / t) * (colSum / t)
+        }
+        return pe >= 1.0 ? .nan : (po - pe) / (1 - pe)
+    }
+    /// One-vs-rest sensitivity (recall) and specificity for `cls`.
+    func sensSpec(_ cls: String) -> (sens: Double, spec: Double, n: Int) {
+        guard let k = classes.firstIndex(of: cls) else { return (.nan, .nan, 0) }
+        var tp = 0, fn = 0, fp = 0, tn = 0
+        for i in 0..<m.count {
+            for j in 0..<m.count {
+                let v = m[i][j]
+                if i == k && j == k { tp += v }
+                else if i == k { fn += v }
+                else if j == k { fp += v }
+                else { tn += v }
+            }
+        }
+        let sens = (tp + fn) == 0 ? Double.nan : Double(tp) / Double(tp + fn)
+        let spec = (tn + fp) == 0 ? Double.nan : Double(tn) / Double(tn + fp)
+        return (sens, spec, tp + fn)
+    }
+}
+
+func confusion(ref: [String], pred: [String], classes: [String] = stageOrder) -> Confusion {
+    var c = Confusion(classes: classes)
+    for i in 0..<min(ref.count, pred.count) { c.add(ref: ref[i], pred: pred[i]) }
+    return c
+}
+
+/// Collapse a 4-class hypnogram to the 2-class sleep/wake problem the wake over-call lives in.
+func toSleepWake(_ labels: [String]) -> [String] { labels.map { $0 == "wake" ? "wake" : "sleep" } }
+
+// MARK: - Descriptive statistics
+
+func mean(_ v: [Double]) -> Double { v.isEmpty ? .nan : v.reduce(0, +) / Double(v.count) }
+func median(_ v: [Double]) -> Double {
+    guard !v.isEmpty else { return .nan }
+    let s = v.sorted()
+    return s.count % 2 == 1 ? s[s.count / 2] : (s[s.count / 2 - 1] + s[s.count / 2]) / 2
+}
+func sd(_ v: [Double]) -> Double {
+    guard v.count > 1 else { return .nan }
+    let m = mean(v)
+    return (v.reduce(0) { $0 + ($1 - m) * ($1 - m) } / Double(v.count - 1)).squareRoot()
+}
+/// Pearson correlation, plus the two-sided t statistic that goes with it.
+func pearson(_ x: [Double], _ y: [Double]) -> (r: Double, n: Int, t: Double) {
+    let n = min(x.count, y.count)
+    guard n > 2 else { return (.nan, n, .nan) }
+    let mx = mean(Array(x.prefix(n))), my = mean(Array(y.prefix(n)))
+    var sxy = 0.0, sxx = 0.0, syy = 0.0
+    for i in 0..<n {
+        let dx = x[i] - mx, dy = y[i] - my
+        sxy += dx * dy; sxx += dx * dx; syy += dy * dy
+    }
+    guard sxx > 0, syy > 0 else { return (.nan, n, .nan) }
+    let r = sxy / (sxx * syy).squareRoot()
+    let t = r * (Double(n - 2) / max(1e-12, 1 - r * r)).squareRoot()
+    return (r, n, t)
+}
+
+func f(_ v: Double, _ w: Int = 7, _ p: Int = 1) -> String {
+    v.isNaN ? String(repeating: " ", count: w - 3) + "n/a"
+        : String(format: "%\(w).\(p)f", v)
+}

--- a/Tools/SleepBench/Sources/sleepbench/main.swift
+++ b/Tools/SleepBench/Sources/sleepbench/main.swift
@@ -1,0 +1,374 @@
+import Foundation
+import StrandAnalytics
+import WhoopProtocol
+
+// sleepbench — replay the sleep stagers over real recorded nights and score them against every
+// independent reference the database carries.
+//
+// USAGE:  sleepbench --db /path/to/whoop.sqlite [--device my-whoop-noop] [--pad 3600] [--csv out.csv]
+//
+// The database is never written to and never lives in this repository. Pass a COPY; never point this at
+// a device's live database.
+
+struct Args {
+    var db = ""
+    /// The `sleepSession.deviceId` whose nights are scored.
+    var device = "my-whoop-noop"
+    /// The `deviceId` the raw streams are stored under. These genuinely differ in a real database — the
+    /// session rows carry the app's own device identity while the decoded streams carry the strap's — so
+    /// the two are separate arguments rather than one assumed-shared value.
+    var streamDevice = "my-whoop"
+    var pad = 3600
+    var csv: String?
+}
+var a = Args()
+var it = CommandLine.arguments.dropFirst().makeIterator()
+while let k = it.next() {
+    switch k {
+    case "--db": a.db = it.next() ?? ""
+    case "--device": a.device = it.next() ?? a.device
+    case "--stream-device": a.streamDevice = it.next() ?? a.streamDevice
+    case "--pad": a.pad = Int(it.next() ?? "") ?? a.pad
+    case "--csv": a.csv = it.next()
+    default: FileHandle.standardError.write(Data("unknown argument \(k)\n".utf8)); exit(2)
+    }
+}
+guard !a.db.isEmpty else {
+    print("usage: sleepbench --db <sqlite> [--device <id>] [--pad <s>] [--csv <path>]")
+    exit(2)
+}
+
+let db = try ReadOnlyDB(path: a.db)
+let rows = try db.sessions(device: a.device)
+guard !rows.isEmpty else { print("no sessions for device \(a.device)"); exit(1) }
+// Which `userEdited` rows carry a HUMAN-AUTHORED hypnogram rather than machine stages re-derived over a
+// human-corrected window. Only the former can serve as a stage-level reference.
+let stageLocked = try db.stageLockedStarts(device: a.device)
+let editedCount = rows.filter { $0.userEdited }.count
+print("""
+
+================================================================================
+0. GROUND-TRUTH PROVENANCE
+================================================================================
+sessions \(rows.count)   userEdited \(editedCount)   of which stage-locked (human-authored stages) \(rows.filter { $0.userEdited && stageLocked.contains($0.startTs) }.count)
+
+A `userEdited` row alone does NOT prove human stage labels: the local editor corrects bed/wake BOUNDS and
+then re-derives the hypnogram from raw, so its stages are machine output over a human-chosen window. Only
+a row carrying a `stagelock` cursor had its stages authored directly (the cloud `edit_sleep_stages` path).
+Rows without the lock are reported below but are not treated as a stage-level reference.
+""")
+
+func nightLabel(_ ts: Int) -> String {
+    // Name each night by its local-ish calendar date. -7 h keeps a post-midnight start on the prior
+    // night, matching how the app groups a night to a day. Display only; nothing scores on it.
+    let d = Date(timeIntervalSince1970: Double(ts - 7 * 3600))
+    let fm = DateFormatter()
+    fm.dateFormat = "yyyy-MM-dd"; fm.timeZone = TimeZone(identifier: "UTC")
+    return fm.string(from: d)
+}
+
+/// A mirror of PR #738's `SleepStager.applyBandStateWakeVeto`, which is `internal` and so unreachable
+/// from this executable. Logic is transcribed line-for-line from that PR: only band state 2 ("asleep")
+/// vetoes, only INTERIOR wake (between the first and last sleep epoch) is touched, and wake only ever
+/// becomes sleep. `SleepStagerTests` pins the real implementation; this mirror exists purely so the
+/// veto's effect can be scored on the isolated staging path as well as end-to-end.
+func bandVetoMirror(_ labels: [String], bandEpochs: [Int]) -> [String] {
+    guard !bandEpochs.isEmpty, labels.count == bandEpochs.count else { return labels }
+    guard let onset = labels.firstIndex(where: { $0 != "wake" }),
+          let final = labels.lastIndex(where: { $0 != "wake" }), onset <= final else { return labels }
+    var out = labels
+    for i in onset...final where out[i] == "wake" && bandEpochs[i] == SleepStager.bandStateAsleep {
+        out[i] = "light"
+    }
+    return out
+}
+
+// MARK: - Replay every night
+
+struct Night {
+    let row: SessionRow
+    let night: String
+    let truth: [String]?          // the wearer's manual restage, when this night was edited
+    let v1: [String]
+    let v2: [String]
+    let v1Veto: [String]
+    let v2Veto: [String]
+    let band: [Int]               // per-epoch band sleep_state, [] when the strap banked none
+    let meanHR: Double
+    let machineWakeMin: Double?   // wake implied by the STALE pre-edit efficiency column
+    let hasSteps: Bool
+}
+
+var nights: [Night] = []
+FileHandle.standardError.write(Data("replaying \(rows.count) sessions…\n".utf8))
+
+for r in rows {
+    let st = try db.streams(device: a.streamDevice, from: r.startTs - a.pad, to: r.endTs + a.pad)
+    // Both stagers take the same window and the same streams; only the recipe differs.
+    let v1 = SleepStager.stageSession(start: r.startTs, end: r.endTs, grav: st.grav,
+                                      hr: st.hr, rr: st.rr, resp: st.resp)
+    let v2 = SleepStagerV2.stageSession(start: r.startTs, end: r.endTs, grav: st.grav,
+                                        hr: st.hr, rr: st.rr, resp: st.resp)
+    let n = epochCount(start: r.startTs, end: r.endTs)
+    let bandEpochs = SleepStager.sessionEpochSleepState(start: r.startTs, end: r.endTs,
+                                                        sleepState: st.band)
+    let l1 = epochLabels(v1, start: r.startTs, end: r.endTs)
+    let l2 = epochLabels(v2, start: r.startTs, end: r.endTs)
+    let truth = r.userEdited ? epochLabels(r.stages, start: r.startTs, end: r.endTs) : nil
+    let hrS = try db.hrStats(device: a.streamDevice, from: r.startTs, to: r.endTs)
+    // The stale `efficiency` column is the machine's own pre-edit verdict on an edited night.
+    let machineWake = r.userEdited ? r.efficiency.map { (1 - $0) * r.durMin } : nil
+
+    nights.append(Night(
+        row: r, night: nightLabel(r.startTs), truth: truth,
+        v1: l1, v2: l2,
+        v1Veto: bandVetoMirror(l1, bandEpochs: bandEpochs),
+        v2Veto: bandVetoMirror(l2, bandEpochs: bandEpochs),
+        band: bandEpochs.count == n ? bandEpochs : [],
+        meanHR: hrS?.mean ?? .nan,
+        machineWakeMin: machineWake,
+        hasSteps: !st.steps.isEmpty))
+    FileHandle.standardError.write(Data(".".utf8))
+}
+FileHandle.standardError.write(Data("\n".utf8))
+
+// MARK: - A. Which stager actually produced the stored hypnograms?
+
+print("""
+
+================================================================================
+A. WHICH STAGER PRODUCED THE STORED NIGHTS?
+================================================================================
+On an unedited night the stored `stagesJSON` is whatever the live stager emitted. Replaying V1 and V2
+over the identical window + streams and comparing epoch-for-epoch identifies the live recipe. On an
+edited night `stagesJSON` is the wearer's restage, so those are excluded here.
+""")
+var v1Match = 0, v2Match = 0, neither = 0
+/// An edited night whose stored hypnogram is BYTE-IDENTICAL to a fresh V2 replay cannot serve as an
+/// independent reference for V2, whatever produced it: scoring V2 against it would be self-comparison.
+/// This says nothing about HOW the row came to match — the harness reports the fact and excludes the
+/// night, and deliberately does not assert a mechanism it has not established.
+var indistinguishableFromV2: Set<String> = []
+print("night        edited  epochs  V1 agree  V2 agree  verdict")
+for nt in nights {
+    let stored = epochLabels(nt.row.stages, start: nt.row.startTs, end: nt.row.endTs)
+    let a1 = zip(stored, nt.v1).filter { $0 == $1 }.count
+    let a2 = zip(stored, nt.v2).filter { $0 == $1 }.count
+    let p1 = Double(a1) / Double(stored.count) * 100, p2 = Double(a2) / Double(stored.count) * 100
+    let verdict = p2 >= 99.9 ? "V2 exact" : (p1 >= 99.9 ? "V1 exact" : (p2 > p1 ? "V2 closer" : "V1 closer"))
+    if !nt.row.userEdited {
+        if p2 >= 99.9 { v2Match += 1 } else if p1 >= 99.9 { v1Match += 1 } else { neither += 1 }
+    } else if p2 >= 99.9 {
+        indistinguishableFromV2.insert(nt.night + "@\(nt.row.startTs)")
+    }
+    print("\(nt.night.padding(toLength: 12, withPad: " ", startingAt: 0)) \(nt.row.userEdited ? "   yes" : "    no") \(String(format: "%7d", stored.count)) \(f(p1, 8, 2))% \(f(p2, 8, 2))%  \(verdict)")
+}
+print("""
+--------------------------------------------------------------------------------
+UNEDITED nights — exact-V1 reproductions: \(v1Match)   exact-V2 reproductions: \(v2Match)   neither exact: \(neither)
+EDITED nights whose stored hypnogram is a byte-exact V2 replay (excluded as a V2 reference): \(indistinguishableFromV2.count) of \(nights.filter { $0.row.userEdited }.count)
+""")
+
+/// True when this night's stored hypnogram survived as the wearer left it.
+func isGenuineEdit(_ nt: Night) -> Bool {
+    nt.row.userEdited && !indistinguishableFromV2.contains(nt.night + "@\(nt.row.startTs)")
+}
+
+// MARK: - B. Accuracy against the wearer's manual restages
+
+// ONLY nights whose stored hypnogram still differs from a fresh V2 replay are usable as human truth.
+// Scoring V2 against a row V2 itself wrote would be self-comparison and would inflate every V2 figure.
+let edited = nights.filter { $0.truth != nil && isGenuineEdit($0) }
+let selfMatchedNights = nights.filter { $0.row.userEdited && !isGenuineEdit($0) }
+print("""
+
+================================================================================
+B. ACCURACY vs THE WEARER'S MANUAL RESTAGES  (reference (a), n = \(edited.count) nights)
+================================================================================
+`userEdited = 1` rows carry the hypnogram the wearer corrected by hand — the only human-labelled
+reference in the database. `machine` is the ORIGINAL machine wake total, recovered from the stale
+pre-edit `efficiency` column; V1/V2 are fresh replays over the same window.
+""")
+print("night        inbed  truthW  machW   V1 W   V2 W  V1+vetoW V2+vetoW   dMach     dV1     dV2")
+var dMach: [Double] = [], dV1: [Double] = [], dV2: [Double] = [], dV1v: [Double] = [], dV2v: [Double] = []
+for nt in edited {
+    guard let t = nt.truth else { continue }
+    let tw = wakeMinutes(t), w1 = wakeMinutes(nt.v1), w2 = wakeMinutes(nt.v2)
+    let w1v = wakeMinutes(nt.v1Veto), w2v = wakeMinutes(nt.v2Veto)
+    let mw = nt.machineWakeMin
+    if let mw { dMach.append(mw - tw) }
+    dV1.append(w1 - tw); dV2.append(w2 - tw)
+    if !nt.band.isEmpty { dV1v.append(w1v - tw); dV2v.append(w2v - tw) }
+    print("\(nt.night) \(f(nt.row.durMin, 6, 0)) \(f(tw, 7, 0)) \(f(mw ?? .nan, 6, 0)) \(f(w1, 6, 0)) \(f(w2, 6, 0)) \(f(w1v, 9, 0)) \(f(w2v, 8, 0)) \(f((mw ?? .nan) - tw, 7, 0)) \(f(w1 - tw, 7, 0)) \(f(w2 - tw, 7, 0))")
+}
+func summarise(_ name: String, _ v: [Double]) {
+    guard !v.isEmpty else { print("  \(name): no data"); return }
+    print("  \(name.padding(toLength: 22, withPad: " ", startingAt: 0)) n=\(v.count)  mean \(f(mean(v), 7, 1))  median \(f(median(v), 7, 1))  sd \(f(sd(v), 6, 1))  range \(f(v.min()!, 6, 0))..\(f(v.max()!, 6, 0))")
+}
+print("\nWAKE-MINUTE ERROR vs manual restage (positive = OVER-calls wake):")
+summarise("machine-as-stored", dMach)
+summarise("V1 replay", dV1)
+summarise("V2 replay", dV2)
+summarise("V1 + band veto", dV1v)
+summarise("V2 + band veto", dV2v)
+
+// Per-stage agreement, pooled over every edited night.
+print("\n4-CLASS AGREEMENT vs manual restage (epochs pooled over \(edited.count) nights):")
+for (name, get) in [("V1", { (n: Night) in n.v1 }), ("V2", { (n: Night) in n.v2 }),
+                    ("V1+veto", { (n: Night) in n.v1Veto }), ("V2+veto", { (n: Night) in n.v2Veto })] {
+    var c = Confusion(classes: stageOrder)
+    var c2 = Confusion(classes: ["wake", "sleep"])
+    for nt in edited {
+        guard let t = nt.truth else { continue }
+        c.merge(confusion(ref: t, pred: get(nt)))
+        c2.merge(confusion(ref: toSleepWake(t), pred: toSleepWake(get(nt)), classes: ["wake", "sleep"]))
+    }
+    print("  \(name.padding(toLength: 9, withPad: " ", startingAt: 0)) 4-class acc \(f(c.accuracy * 100, 5, 1))%  kappa \(f(c.kappa, 6, 3))   |   sleep/wake acc \(f(c2.accuracy * 100, 5, 1))%  kappa \(f(c2.kappa, 6, 3))")
+    for s in stageOrder {
+        let (sens, spec, n) = c.sensSpec(s)
+        print("      \(s.padding(toLength: 6, withPad: " ", startingAt: 0)) sens \(f(sens * 100, 5, 1))%  spec \(f(spec * 100, 5, 1))%  (ref epochs \(n))")
+    }
+}
+
+// MARK: - C. Accuracy against the strap's own band sleep_state
+
+let banded = nights.filter { !$0.band.isEmpty }
+print("""
+
+================================================================================
+C. AGREEMENT WITH THE STRAP'S OWN BAND sleep_state  (reference (b), n = \(banded.count) nights)
+================================================================================
+The v18 @81 high nibble (0 wake / 1 still / 2 asleep / 3 up) is the strap's OWN scored verdict, not a
+re-derivation of NOOP's. It carries no light/deep/REM, so this is a sleep-vs-wake comparison only.
+STRICT maps band 2 -> sleep and band 0/3 -> wake, and EXCLUDES band 1 ("still", genuinely ambiguous).
+""")
+for (name, get) in [("V1", { (n: Night) in n.v1 }), ("V2", { (n: Night) in n.v2 }),
+                    ("V1+veto", { (n: Night) in n.v1Veto }), ("V2+veto", { (n: Night) in n.v2Veto }),
+                    ("stored", { (n: Night) in epochLabels(n.row.stages, start: n.row.startTs, end: n.row.endTs) })] {
+    var c = Confusion(classes: ["wake", "sleep"])
+    for nt in banded {
+        let pred = toSleepWake(get(nt))
+        for (i, b) in nt.band.enumerated() where i < pred.count {
+            guard b != 1 else { continue }                       // "still" excluded
+            c.add(ref: b == SleepStager.bandStateAsleep ? "sleep" : "wake", pred: pred[i])
+        }
+    }
+    let (sens, spec, n) = c.sensSpec("wake")
+    print("  \(name.padding(toLength: 9, withPad: " ", startingAt: 0)) acc \(f(c.accuracy * 100, 5, 1))%  kappa \(f(c.kappa, 6, 3))  wake sens \(f(sens * 100, 5, 1))%  wake spec \(f(spec * 100, 5, 1))%  (band-wake epochs \(n), total \(c.total))")
+}
+// How much of what each stager calls wake does the strap itself dispute?
+print("\nDISPUTED WAKE — of the epochs each stager calls wake, what fraction did the strap score \"asleep\"?")
+for (name, get) in [("V1", { (n: Night) in n.v1 }), ("V2", { (n: Night) in n.v2 }),
+                    ("stored", { (n: Night) in epochLabels(n.row.stages, start: n.row.startTs, end: n.row.endTs) })] {
+    var wakeEpochs = 0, disputed = 0, sleepEpochs = 0, reverseDisputed = 0
+    for nt in banded {
+        let pred = get(nt)
+        for (i, b) in nt.band.enumerated() where i < pred.count {
+            if pred[i] == "wake" {
+                wakeEpochs += 1
+                if b == SleepStager.bandStateAsleep { disputed += 1 }
+            } else {
+                sleepEpochs += 1
+                if b == 0 || b == 3 { reverseDisputed += 1 }
+            }
+        }
+    }
+    let fwd = wakeEpochs == 0 ? Double.nan : Double(disputed) / Double(wakeEpochs) * 100
+    let rev = sleepEpochs == 0 ? Double.nan : Double(reverseDisputed) / Double(sleepEpochs) * 100
+    print("  \(name.padding(toLength: 9, withPad: " ", startingAt: 0)) stager-wake epochs \(String(format: "%6d", wakeEpochs)), strap says asleep \(f(fwd, 5, 1))%   |   reverse (stager sleep, strap wake/up) \(f(rev, 5, 1))%")
+}
+
+// MARK: - D. The supplement-HR hypothesis
+
+print("""
+
+================================================================================
+D. DOES THE WAKE OVER-CALL TRACK OVERNIGHT HR?  (the supplement hypothesis)
+================================================================================
+The standing inference is that an overnight HR held around 55-60 bpm reads to an HR-led wake detector as
+wakefulness. If true, per-night wake error should RISE with mean overnight HR. Tested here on every night
+that has a human reference.
+""")
+print("night        meanHR   truthW   machW    dMach     dV1     dV2")
+var hrs: [Double] = [], errM: [Double] = [], errV1: [Double] = [], errV2: [Double] = []
+for nt in edited.sorted(by: { $0.meanHR < $1.meanHR }) {
+    guard let t = nt.truth, !nt.meanHR.isNaN else { continue }
+    let tw = wakeMinutes(t)
+    let mw = nt.machineWakeMin ?? .nan
+    hrs.append(nt.meanHR); errM.append(mw - tw)
+    errV1.append(wakeMinutes(nt.v1) - tw); errV2.append(wakeMinutes(nt.v2) - tw)
+    print("\(nt.night) \(f(nt.meanHR, 8, 1)) \(f(tw, 8, 0)) \(f(mw, 7, 0)) \(f(mw - tw, 8, 0)) \(f(wakeMinutes(nt.v1) - tw, 7, 0)) \(f(wakeMinutes(nt.v2) - tw, 7, 0))")
+}
+for (nm, e) in [("machine-as-stored", errM), ("V1 replay", errV1), ("V2 replay", errV2)] {
+    let (r, n, t) = pearson(hrs, e)
+    print("  corr(mean overnight HR, \(nm.padding(toLength: 18, withPad: " ", startingAt: 0)) wake error): r = \(f(r, 6, 3))  n = \(n)  t = \(f(t, 6, 2))")
+}
+
+// The edited nights span only a narrow HR band, so the test above is underpowered by construction. The
+// BAND-disputed-wake fraction needs no human labels, so it can be run over every banded night and covers
+// a far wider HR range — a much stronger test of the same hypothesis.
+print("""
+
+  WIDER TEST — no human labels needed, so every banded night counts. For each night, the fraction of
+  V2's wake epochs that the strap itself scored "asleep" (its false-wake rate by the strap's reckoning)
+  against that night's mean overnight HR. If elevated HR drives the over-call, this must rise with HR.
+""")
+print("  night        meanHR  V2wakeEp  strapDisputed%")
+var bhr: [Double] = [], bdisp: [Double] = []
+for nt in banded.sorted(by: { $0.meanHR < $1.meanHR }) {
+    var wake = 0, disp = 0
+    for (i, b) in nt.band.enumerated() where i < nt.v2.count {
+        if nt.v2[i] == "wake" { wake += 1; if b == SleepStager.bandStateAsleep { disp += 1 } }
+    }
+    guard wake >= 10, !nt.meanHR.isNaN else { continue }
+    let pct = Double(disp) / Double(wake) * 100
+    bhr.append(nt.meanHR); bdisp.append(pct)
+    print("  \(nt.night) \(f(nt.meanHR, 7, 1)) \(String(format: "%9d", wake)) \(f(pct, 15, 1))")
+}
+let (br, bn, bt) = pearson(bhr, bdisp)
+print("  corr(mean overnight HR, strap-disputed wake fraction): r = \(f(br, 6, 3))  n = \(bn)  t = \(f(bt, 6, 2))")
+if !selfMatchedNights.isEmpty {
+    print("""
+
+  NOTE: \(selfMatchedNights.count) `userEdited` night(s) were excluded from the human-reference tests above because
+  their stored hypnogram is a byte-exact replay of the CURRENT V2, so scoring V2 against them would be
+  self-comparison. The harness asserts no mechanism for the match: \(selfMatchedNights.map { $0.night }.joined(separator: ", "))
+""")
+}
+// Stratify rather than rely on a single correlation — n is small and the relation need not be linear.
+let hiCut = 55.0
+let hi = edited.filter { $0.meanHR >= hiCut }, lo = edited.filter { $0.meanHR < hiCut }
+for (nm, grp) in [("mean HR >= \(Int(hiCut))", hi), ("mean HR <  \(Int(hiCut))", lo)] {
+    let e = grp.compactMap { nt -> Double? in
+        guard let t = nt.truth, let mw = nt.machineWakeMin else { return nil }
+        return mw - wakeMinutes(t)
+    }
+    guard !e.isEmpty else { print("  \(nm): no nights"); continue }
+    print("  \(nm.padding(toLength: 18, withPad: " ", startingAt: 0)) n=\(e.count)  mean machine wake error \(f(mean(e), 7, 1)) min  median \(f(median(e), 7, 1))")
+}
+
+// MARK: - E. Machine cohort split — did anything change mid-history?
+
+print("""
+
+================================================================================
+E. PER-NIGHT DETAIL (all \(nights.count) sessions)
+================================================================================
+""")
+print("night        edited band inbed  meanHR storedW    V1 W    V2 W  storedEff")
+for nt in nights {
+    let stored = epochLabels(nt.row.stages, start: nt.row.startTs, end: nt.row.endTs)
+    print("\(nt.night) \(nt.row.userEdited ? "   yes" : "    no") \(nt.band.isEmpty ? "   -" : "   Y") \(f(nt.row.durMin, 5, 0)) \(f(nt.meanHR, 7, 1)) \(f(wakeMinutes(stored), 7, 0)) \(f(wakeMinutes(nt.v1), 7, 0)) \(f(wakeMinutes(nt.v2), 7, 0)) \(f(nt.row.efficiency ?? .nan, 10, 3))")
+}
+
+if let path = a.csv {
+    var out = "night,userEdited,hasBand,inbedMin,meanHR,storedWake,truthWake,machineWake,v1Wake,v2Wake,v1VetoWake,v2VetoWake,storedEff\n"
+    for nt in nights {
+        let stored = epochLabels(nt.row.stages, start: nt.row.startTs, end: nt.row.endTs)
+        let tw = nt.truth.map { String(format: "%.1f", wakeMinutes($0)) } ?? ""
+        let mw = nt.machineWakeMin.map { String(format: "%.1f", $0) } ?? ""
+        out += "\(nt.night),\(nt.row.userEdited),\(!nt.band.isEmpty),\(String(format: "%.1f", nt.row.durMin)),\(String(format: "%.1f", nt.meanHR)),\(String(format: "%.1f", wakeMinutes(stored))),\(tw),\(mw),\(String(format: "%.1f", wakeMinutes(nt.v1))),\(String(format: "%.1f", wakeMinutes(nt.v2))),\(String(format: "%.1f", wakeMinutes(nt.v1Veto))),\(String(format: "%.1f", wakeMinutes(nt.v2Veto))),\(nt.row.efficiency.map { String(format: "%.4f", $0) } ?? "")\n"
+    }
+    try out.write(toFile: path, atomically: true, encoding: .utf8)
+    FileHandle.standardError.write(Data("wrote \(path)\n".utf8))
+}

--- a/android/app/src/main/java/com/noop/analytics/AnalyticsEngine.kt
+++ b/android/app/src/main/java/com/noop/analytics/AnalyticsEngine.kt
@@ -217,9 +217,11 @@ object AnalyticsEngine {
         // empty keeps pure-function callers/tests free of it; IntelligenceEngine threads the night window's
         // persisted band state. Mirrors Swift. (#531 / H8 consume)
         bandSleepState: List<Pair<Long, Int>> = emptyList(),
-        // Opt-in experimental sleep staging (V2). When true, detected nights are staged by [SleepStagerV2]
-        // instead of V1. Default false keeps V1 the byte-identical default for pure-function callers/tests;
-        // IntelligenceEngine threads PuffinExperiment.from(context).experimentalSleepV2. Mirrors Swift. (V7 / #690)
+        // Which sleep-staging recipe runs (V2 vs V1). When true, detected nights are staged by
+        // [SleepStagerV2] instead of V1. This PARAMETER defaults false to keep pure-function callers/tests
+        // byte-identical — it is NOT the product default. IntelligenceEngine threads
+        // PuffinExperiment.from(context).experimentalSleepV2, which is default TRUE (#277/#351), so the
+        // shipped app stages with V2. Mirrors Swift. (V7 / #690)
         useSleepStagerV2: Boolean = false,
         // Opt-in motion-aware wake refinement (#364 "Proposal 2" follow-up; density gate precedent #345).
         // When true, [WakeMotionRefinement] re-derives each detected session's stages, reclassifying a

--- a/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
+++ b/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
@@ -168,11 +168,14 @@ object IntelligenceEngine {
         // are unaffected; the AppViewModel wires it to the BLE client's strap log (ble.externalLog),
         // which PII-scrubs every line at the sink. Pure-JVM (a closure), matching persistStepsCalibration.
         diag: (String) -> Unit = {},
-        // Opt-in "Experimental sleep staging (V2)" flag (Settings → Experimental · Sleep staging). The
-        // analytics layer is Context-free, so the Context-aware caller (AppViewModel / WhoopBleClient) reads
-        // it off SharedPreferences (PuffinExperiment.experimentalSleepV2) and threads it down to the sleep
-        // self-heal, which re-stages with SleepStagerV2 when true. Default false → V1 (the default, untouched
-        // path), so existing callers / tests are unaffected. (V7 Pillar 3b)
+        // "Experimental sleep staging (V2)" flag (Settings → Experimental · Sleep staging). The analytics
+        // layer is Context-free, so the Context-aware caller (AppViewModel / WhoopBleClient) reads it off
+        // SharedPreferences (PuffinExperiment.experimentalSleepV2) and threads it down to the sleep
+        // self-heal, which re-stages with SleepStagerV2 when true.
+        // The stored preference is default TRUE (getBoolean(KEY, true)) — V2 was promoted over V1 in #277
+        // and extended to every strap family in #351 — so the SHIPPED app stages with V2. This PARAMETER
+        // defaults false only so existing callers / tests are unaffected; it is not the product default.
+        // (V7 Pillar 3b)
         useExperimentalSleepV2: Boolean = false,
         // Opt-in "Motion-aware wake refinement" flag (#364 "Proposal 2" follow-up; density gate precedent
         // #345). Same Context-free threading as [useExperimentalSleepV2]: the Context-aware caller reads
@@ -298,7 +301,9 @@ object IntelligenceEngine {
         baselineEpoch: Double = 0.0,
         recoveryEpoch: Double = 0.0,
         diag: (String) -> Unit = {},
-        // Opt-in experimental staging (V2), threaded down to the sleep self-heal. Default false → V1. (3b)
+        // Experimental staging (V2), threaded down to the sleep self-heal. This PARAMETER defaults false so
+        // existing callers / tests are unaffected; the STORED PREFERENCE the app threads in is default TRUE,
+        // so the shipped app stages with V2. Not the same default — see [analyzeRecent]'s note. (3b)
         useExperimentalSleepV2: Boolean = false,
         // Opt-in motion-aware wake refinement (#364 follow-up), threaded the same way. Default false.
         useMotionAwareWake: Boolean = false,

--- a/android/app/src/main/java/com/noop/analytics/SleepStageHealer.kt
+++ b/android/app/src/main/java/com/noop/analytics/SleepStageHealer.kt
@@ -54,9 +54,10 @@ object SleepStageHealer {
         deviceId: String,
         start: Long,
         end: Long,
-        // Opt-in experimental staging (Settings → Experimental · Sleep staging). The analytics layer is
-        // Context-free, so the flag is threaded in from the Context-aware caller (default false → V1, so
-        // existing callers / tests are unaffected). When true, stage with SleepStagerV2; else V1. (V7 3b)
+        // Experimental staging (Settings → Experimental · Sleep staging). The analytics layer is
+        // Context-free, so the flag is threaded in from the Context-aware caller. When true, stage with
+        // SleepStagerV2; else V1. This PARAMETER defaults false so existing callers / tests are unaffected
+        // — the stored preference the app threads in is default TRUE, so the shipped app gets V2. (V7 3b)
         useExperimentalSleepV2: Boolean = false,
         // Opt-in motion-aware wake refinement (#364 "Proposal 2" follow-up; density gate precedent #345).
         // Same Context-free threading as [useExperimentalSleepV2]; default false so existing callers/tests
@@ -146,8 +147,9 @@ object SleepStageHealer {
         strapDeviceId: String,
         windowStart: Long,
         windowEnd: Long,
-        // Opt-in experimental staging, threaded from IntelligenceEngine (read off SharedPreferences by the
-        // Context-aware caller). Default false → V1, so callers/tests that don't pass it are unaffected. (3b)
+        // Experimental staging, threaded from IntelligenceEngine (read off SharedPreferences by the
+        // Context-aware caller). This PARAMETER defaults false so callers/tests that don't pass it are
+        // unaffected; the stored preference is default TRUE, so the shipped app gets V2. (3b)
         useExperimentalSleepV2: Boolean = false,
         // Opt-in motion-aware wake refinement (#364 follow-up), threaded the same way. Default false.
         useMotionAwareWake: Boolean = false,

--- a/android/app/src/main/java/com/noop/analytics/SleepStager.kt
+++ b/android/app/src/main/java/com/noop/analytics/SleepStager.kt
@@ -938,11 +938,14 @@ object SleepStager {
         // HR dip. Default empty keeps pure-function callers/tests free of it; IntelligenceEngine passes the
         // night window's persisted band state. It can only RESCUE a real-sleep block, never fabricate. Mirrors Swift.
         bandSleepState: List<Pair<Long, Int>> = emptyList(),
-        // V7 / #690: when true, each accepted night is staged by the experimental cardiorespiratory recipe
-        // [SleepStagerV2.stageSession] instead of V1's [stageSession]. DETECTION is unchanged (same accepted
-        // windows); only the per-epoch hypnogram differs. Default false keeps V1 the byte-identical default
-        // (frozen-golden tests stay green). The live call site threads the experimentalSleepV2 flag so the
-        // Settings toggle now affects normal detected nights, not just the self-heal restage path. Mirrors Swift.
+        // V7 / #690: which recipe stages an accepted night — the cardiorespiratory
+        // [SleepStagerV2.stageSession] when true, V1's [stageSession] when false. DETECTION is unchanged
+        // (same accepted windows); only the per-epoch hypnogram differs.
+        // THE TWO DEFAULTS DIFFER. This PARAMETER defaults false so pure-function callers and the
+        // frozen-golden tests stay byte-identical. The SHIPPED app never takes that default: the live call
+        // site threads the experimentalSleepV2 preference, which is default TRUE (V2 promoted over V1 in
+        // #277, extended to every strap family in #351), so a normal user's nights are staged by V2.
+        // Mirrors Swift.
         useSleepStagerV2: Boolean = false,
         // Motion-corroborated wake (#462, directive b): the wearer's PERSONALISED overnight HR band
         // ([adaptiveOvernightHRBaseline]), used by [confirmSleepWithHR] in place of the day-median so a

--- a/android/app/src/main/java/com/noop/ble/PuffinExperiment.kt
+++ b/android/app/src/main/java/com/noop/ble/PuffinExperiment.kt
@@ -48,9 +48,10 @@ class PuffinExperiment(private val prefs: SharedPreferences) {
 
     /** True if the user opted in to "Experimental sleep staging (V2)": detected nights are re-staged with
      *  [com.noop.analytics.SleepStagerV2] (the transparent cardiorespiratory recipe, reimplemented from
-     *  contributor PR #600) instead of the default V1 [com.noop.analytics.SleepStager]. Pure analysis switch
+     *  contributor PR #600) instead of the older V1 [com.noop.analytics.SleepStager]. Pure analysis switch
      *  — it changes ONLY which staging engine runs over an already-detected sleep window; detection, scoring
-     *  and the default V1 path are untouched. Model-agnostic (works on WHOOP 4 and 5). **Default true**:
+     *  and the V1 code path itself are untouched. Model-agnostic (works on WHOOP 4 and 5). **Default true —
+     *  V2, not V1, is what stages a normal user's nights**:
      *  V2 was promoted to the default staging engine after a 44-subject cross-subject benchmark (AAUWSS +
      *  Walch sleep-accel, leave-one-subject-out) showed V2 strictly dominates V1 (kappa 0.35 vs 0.03, deep
      *  recall 55% vs 1%) — the multi-subject validation this recipe originally lacked. V1 remains available.

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -2033,9 +2033,11 @@ class WhoopBleClient(
                         // the night MEAN (the other app's number) — from the post-backfill scoring pass, not
                         // only the UI's 15-min loop. log() PII-scrubs at the sink. Best-effort + logging only.
                         diag = { s -> log(s) },
-                        // Opt-in experimental sleep staging (V2): stage this post-backfill pass with the same
+                        // Experimental sleep staging (V2): stage this post-backfill pass with the same
                         // engine the user chose in Settings, read off SharedPreferences here (the analytics
-                        // layer is Context-free). Default off → V1. (V7 Pillar 3b)
+                        // layer is Context-free). The stored preference is default TRUE
+                        // (getBoolean(KEY, true)), so this normally passes V2 — turning the Settings toggle
+                        // off is what falls back to V1. (V7 Pillar 3b)
                         useExperimentalSleepV2 = PuffinExperiment.from(context).experimentalSleepV2,
                         // Opt-in motion-aware wake refinement (#364 follow-up) — same Context-free threading.
                         useMotionAwareWake = PuffinExperiment.from(context).motionAwareWake,

--- a/android/app/src/main/java/com/noop/ui/AppViewModel.kt
+++ b/android/app/src/main/java/com/noop/ui/AppViewModel.kt
@@ -937,8 +937,9 @@ class AppViewModel(app: Application) : AndroidViewModel(app) {
                         // report ships proof of what was computed per day. Mirrors the macOS sink wired to
                         // live.append(log:). (Sleep overhaul §2.5.)
                         diag = { line -> ble.externalLog(line) },
-                        // Opt-in experimental sleep staging (V2) — read off SharedPreferences here (the
-                        // analytics layer is Context-free) and thread it into the sleep self-heal. (V7 3b)
+                        // Experimental sleep staging (V2) — read off SharedPreferences here (the analytics
+                        // layer is Context-free) and thread it into the sleep self-heal. The preference is
+                        // default TRUE, so this normally passes V2. (V7 3b)
                         useExperimentalSleepV2 = PuffinExperiment.from(appContext).experimentalSleepV2,
                         // Opt-in motion-aware wake refinement (#364 follow-up) — same Context-free threading.
                         useMotionAwareWake = PuffinExperiment.from(appContext).motionAwareWake,
@@ -1544,8 +1545,8 @@ class AppViewModel(app: Application) : AndroidViewModel(app) {
                 // would re-score + persist every night's HRV over the WHOLE night, silently overwriting the
                 // deep-window value (the "deep sleep window changes nothing" bug).
                 deepHrvWindow = UnitPrefs.hrvWindow(appContext) == HrvWindow.DEEP_SLEEP,
-                // Opt-in experimental sleep staging (V2) — same flag the 15-min loop reads, so a manual
-                // re-score after an edit stages with the same engine the user chose. (V7 Pillar 3b)
+                // Experimental sleep staging (V2) — same flag the 15-min loop reads (default TRUE), so a
+                // manual re-score after an edit stages with the same engine the user chose. (V7 Pillar 3b)
                 useExperimentalSleepV2 = PuffinExperiment.from(appContext).experimentalSleepV2,
                 // Opt-in motion-aware wake refinement (#364 follow-up) — same flag the 15-min loop reads.
                 useMotionAwareWake = PuffinExperiment.from(appContext).motionAwareWake,

--- a/android/app/src/test/java/com/noop/analytics/SleepStagerV2Test.kt
+++ b/android/app/src/test/java/com/noop/analytics/SleepStagerV2Test.kt
@@ -13,11 +13,15 @@ import kotlin.math.sin
 import kotlin.math.roundToInt
 
 /**
- * Basic coverage for the OPT-IN experimental stager [SleepStagerV2] (V7 Pillar 3b, reimplemented from
- * contributor PR #600), the Android twin of SleepStagerV2Tests.swift. Asserts the drop-in CONTRACT — same
- * [SleepStager.stageSession] signature + return shape, segments that tile [start, end] with canonical stage
- * labels — and that the [SleepStageHealer] V1/V2 switch actually routes to V2 (and defaults to V1, byte for
- * byte). NOT a fidelity claim against any reference (the recipe's own validation is n=1).
+ * Basic coverage for [SleepStagerV2] (V7 Pillar 3b, reimplemented from contributor PR #600), the Android
+ * twin of SleepStagerV2Tests.swift — the recipe that stages a normal user's nights, since the stored
+ * `experimentalSleepV2` preference is default TRUE (#277 promoted it over V1; #351 extended it to every
+ * strap family). Asserts the drop-in CONTRACT — same [SleepStager.stageSession] signature + return shape,
+ * segments that tile [start, end] with canonical stage labels — and that the [SleepStageHealer] V1/V2
+ * switch actually routes to V2 (its PARAMETER defaults to V1 byte for byte, which is the library contract,
+ * not the product default).
+ * NOT a fidelity claim against any reference: the cross-subject evidence behind the promotion is a
+ * 44-subject leave-one-subject-out benchmark, and these unit tests do not re-measure it.
  */
 class SleepStagerV2Test {
 


### PR DESCRIPTION
## What this PR does

Two commits on the sleep-staging subsystem: a documentation correction, and the measuring tool that made the correction provable.

### 1. `docs(sleep)` — say which stager actually ships

Comments on both platforms described `SleepStagerV2` as an "opt-in experimental" stager and V1 as "the default". That is backwards. One comment in `Repository.restageFromRaw` said it outright: *"V1 stays the default and is untouched"*.

Both preferences are default **ON**:

| | |
|---|---|
| `Strand/BLE/PuffinExperiment.swift` | `experimentalSleepV2Enabled` — `object(forKey:) == nil ? true : …` |
| `android/.../ble/PuffinExperiment.kt` | `experimentalSleepV2` — `prefs.getBoolean(KEY, true)` |
| `Strand/Screens/SettingsView.swift` | `@AppStorage(...) private var experimentalSleepV2Enabled = true` |

V2 was promoted over V1 in #277 and extended to every strap family in #351, so **V2 is what stages a normal user's nights**.

The confusion has a single source: `useSleepStagerV2: Bool = false` in the `detectSleep` / `analyzeDay` signatures (`SleepStager.swift:851`, `AnalyticsEngine.swift:328`). That is the **library** default, there so pure-function callers and the frozen-golden tests stay byte-identical. The app never takes it — the live call site threads the preference. Reading the signature alone gets the product's behaviour exactly wrong, so each of these comments now names *both* defaults and says which is which.

Comments only. No behaviour change on either platform.

### 2. `tools(sleep)` — add `Tools/SleepBench`

An offline harness that replays `SleepStager` (V1) and `SleepStagerV2` over every recorded night in a NOOP database and scores each hypnogram against whichever independent references that database carries:

- **(a)** hand-authored hypnograms — `sleepSession.userEdited` rows that *also* carry a `stagelock:<device>:<startTs>` cursor;
- **(b)** the strap's own band `sleep_state` (the v18 `@81` high nibble) — an independent hardware verdict NOOP does not compute, and one that needs no human labelling, so it scales to a whole history for free;
- **(c)** the stored hypnogram itself, which identifies the recipe that produced it.

Reported per stager: wake-minute error, sleep-onset and final-wake offsets, per-stage sensitivity/specificity, Cohen's kappa on both the 4-class and the sleep/wake problem, and per-night variance. #738's band veto is mirrored so its effect can be scored on the isolated staging path too.

Two correctness points the harness makes rather than assumes:

- **`userEdited` alone does not mean human stage labels.** The local editor corrects bed/wake *bounds* and re-derives the hypnogram from raw, so its stages are machine output over a human-chosen window. Only a `stagelock` row had its stages authored directly. Section 0 reports the split so a caller cannot silently score a stager against its own output. On the database I ran it against, this excluded 4 of 15 edited nights as byte-exact replays of the current V2 — i.e. self-comparison.
- **Session rows and stream rows can live under different `deviceId`s** in a real database, so `--device` and `--stream-device` are separate arguments.

## Why

The subsystem has been changing without a shared yardstick. #348 (@tanarchytan) re-tuned the V2 deep boundary on DREAMT (n=100 gold) and merged 2026-07-13; #437 restored the pre-#348 defaults 36 hours later, because the tune *"over-calls awake in the field"* (#431). Both were reasonable calls on the evidence available. Neither side could put a number on the disagreement, because there was no way to score a candidate against a wearer's own recorded nights.

Right now **12 of the 60 open PRs touch a `Sleep`/`Stager`-named file, from 6 contributors** (@Newbbsss, @DX23876, @tigercraft4, @digitalerdude, @pipiche38, and me). None of them shares a metric. This is the missing piece — not a tuning change, just the ability to measure one.

## The measurement that motivated commit 1

Replaying both stagers over one user's 36 recorded sessions, epoch-for-epoch against the stored hypnogram. On the 21 **unedited** nights — where the stored stages are whatever the live stager emitted — V2 reproduces the stored hypnogram **byte-exactly on 21 of 21**; V1 on **0 of 21**, agreeing only 30.6–65.8%.

That is what settles which stager ships, and it is reproducible by anyone with a NOOP database.

**Scope of that evidence, stated plainly:** one user, one strap family, 36 sessions. It establishes *which code path runs* — which is a fact about this repository, not about sleep physiology — and nothing more. It is not a validation of V2's accuracy.

## Safety of the tool

- The database is opened `SQLITE_OPEN_READONLY` with `immutable=1` (`DB.swift:15-16`), so it cannot write, and cannot trigger a WAL/journal recovery write on a pulled device file.
- Its path is always an argument; there is no default and no hardcoded path. Missing `--db` exits 2.
- Nothing is written back to the database. The only file it can create is the optional `--csv <path>` report you explicitly ask for.
- **No health data is added to this repository.** The harness is code only; you point it at your own database.

## Type of change

- [x] Documentation
- [x] CI / tooling

## How it was tested

No BLE path is touched by either commit — commit 1 is comments only, commit 2 is a standalone offline tool that reads a SQLite file.

```
swift test (Packages/StrandAnalytics)                1167 tests, 0 failures
./gradlew assembleFullDebug testFullDebugUnitTest    3201 tests, 0 failures, 5 skipped
swift build -c release (Tools/SleepBench)            clean
```

Android counts were read from `app/build/test-results/testFullDebugUnitTest/TEST-*.xml` rather than the wrapper's exit status, since the Gradle wrapper can report success on a failed build. Built with JDK 17, matching the project's `jvmTarget`.

`sleepbench` was additionally run end-to-end against a real 36-session database to produce the numbers above.

## Checklist

- [x] Swift package tests pass for any package I touched (`swift test` in `Packages/StrandAnalytics`)
- [x] Android unit tests pass if I touched `android/` (`./gradlew testFullDebugUnitTest`)
- [x] No new build warnings introduced
- [x] UI changes use only `StrandDesign` tokens — no hardcoded colors, fonts, or spacing *(n/a — no UI change)*
- [x] No hardcoded hex frame bytes; protocol facts live in the schema / decoders
- [x] Follows the conventions in [`docs/CONTRIBUTING.md`](../docs/CONTRIBUTING.md)
- [x] I did not commit generated output (`Strand.xcodeproj/`) or any secrets/keystores

## Related issues

Context for the documentation fix: #277, #351, #690.
Context for why a shared harness is worth having: #348, #431, #437.
