### PR TITLE
Count the packet types a history offload drops, instead of dropping them silently (#891)

### DIFF
--- a/Packages/WhoopProtocol/Sources/WhoopProtocol/HistoricalStreams.swift
+++ b/Packages/WhoopProtocol/Sources/WhoopProtocol/HistoricalStreams.swift
@@ -1,5 +1,13 @@
 import Foundation
 
+/// #891: packet types an offload legitimately carries that `extractHistoricalStreams` has no rows for, so
+/// reaching `default:` is expected rather than a finding. Both decode to zero rows BY DESIGN — CONSOLE_LOGS
+/// is strap-side debug text, METADATA is envelope bookkeeping — and counting them on every sync would bury
+/// the one signal `Streams.unhandledPacketTypes` exists to surface. Nothing else is excluded, including
+/// named-but-unhandled types like `HISTORICAL_IMU_DATA_STREAM(52)`: those are exactly the interesting ones.
+/// Keep in lockstep with the Android `EXPECTED_UNHANDLED_HISTORICAL_TYPES`.
+let expectedUnhandledHistoricalTypes: Set<String> = ["METADATA", "CONSOLE_LOGS"]
+
 /// Shared plausibility bounds for a type-47 record's own unix timestamp (#547). A WHOOP strap with a
 /// bad clock/flash (repeated trim=0xFFFFFFFF no-cursor) emits records whose decoded unix is scattered
 /// garbage — far-past (2024/2029), a bogus 2027=1827642881, and even FUTURE dates. NOOP used to trust
@@ -191,6 +199,8 @@ public func extractHistoricalStreams(_ parsed: [ParsedFrame],
     // The SAME (ts, samples) are also appended to `out.ppgWaveform` below (issue #156 follow-up) so the
     // raw waveform is durable too, not just the derived estimate this local buffer exists to produce.
     var ppgRecords: [(ts: Int, samples: [Int])] = []
+    // #891: packet types that reach `default:` and are dropped. See `Streams.unhandledPacketTypes`.
+    var unhandledTypes: [String: Int] = [:]
     for r in parsed {
         if !r.ok || r.crcOK == false { continue }
         let p = r.parsed
@@ -364,12 +374,19 @@ public func extractHistoricalStreams(_ parsed: [ParsedFrame],
             // No device timestamp on COMMAND_RESPONSE → stamp battery at wallClockRef.
             appendBattery(&out, ts: wallClockRef, p: p)
         default:
+            // #891: this funnel has no rows for this type, so the record is dropped — count it first, or
+            // an offload carrying a type nobody has mapped reports as a clean sync. See
+            // `Streams.unhandledPacketTypes` for why METADATA/CONSOLE_LOGS are excluded.
+            if !expectedUnhandledHistoricalTypes.contains(r.typeName) {
+                unhandledTypes[r.typeName, default: 0] += 1
+            }
             continue
         }
     }
     // Derive per-second HR from the collected v26 PPG bursts (issue #156). Empty when there were no v26
     // records (the WHOOP 4 / v18-only common case), so this is a no-op cost there.
     out.ppgHr = PpgHr.derivePpgHr(records: ppgRecords, subLagInterp: subLagInterp)
+    out.unhandledPacketTypes = unhandledTypes     // #891 diag census (not persisted, not encoded)
     out.droppedImplausible = droppedImplausible   // #547 diag count (not persisted, not encoded)
     out.droppedImplausibleOldestTs = droppedOldest   // #324 poisoned-range epoch span (diag only)
     out.droppedImplausibleNewestTs = droppedNewest

--- a/Packages/WhoopProtocol/Sources/WhoopProtocol/Streams.swift
+++ b/Packages/WhoopProtocol/Sources/WhoopProtocol/Streams.swift
@@ -523,6 +523,29 @@ public struct Streams: Equatable, Codable {
     /// The #547 gate discards them like any bad-ts record, but these are the GROUND TRUTH that the clock reset
     /// - so we capture (kind, rawTs) for the strap log before dropping. Transient, empty by default, not encoded.
     public var droppedRtcEvents: [DroppedRtcEvent] = []
+    /// #891 diagnostic: packet types this funnel DROPPED this chunk because it has no `case` for them —
+    /// keyed by the rendered type name (`schema.typeName`, so a byte the schema does not name renders
+    /// `type53`), value = how many records carried it.
+    ///
+    /// An offload records nothing about a type it does not handle. `extractHistoricalStreams` switches on
+    /// four of the schema's sixteen packet types and `default: continue`s the rest, and
+    /// `rejectedHistoricalRecords` only archives type-47 — non-47 frames are, in its own words, "excluded
+    /// by construction". So a record type nobody has mapped is dropped twice and counted zero times, and
+    /// the sync reports clean. That is not hypothetical: `HISTORICAL_IMU_DATA_STREAM(52)` is a banked
+    /// raw-stream type our own schema names, and every one of them would vanish here.
+    ///
+    /// The immediate use is #891 — whether a 5/MG banks ECG to flash after the Labrador toggles is the
+    /// leading hypothesis, and it currently cannot be answered by running the experiment, because nothing
+    /// would show the result. The general use is that any future firmware record type is invisible today.
+    ///
+    /// `METADATA` and `CONSOLE_LOGS` are deliberately NOT counted: an offload legitimately carries both,
+    /// they decode to zero rows by design, and tallying them every sync would bury the signal this exists
+    /// to surface. Everything else falls through, including named-but-unhandled types — those are the
+    /// interesting ones.
+    ///
+    /// Transient observability only, like `droppedImplausible`: not persisted, not in `CodingKeys`, empty
+    /// by default so golden fixtures stay byte-identical.
+    public var unhandledPacketTypes: [String: Int] = [:]
     /// #520 diagnostic: a summary of `dynamic_acceleration@41` (the strap's own gravity-removed motion
     /// magnitude) over this chunk's v18 records. The field is decoded but has never been persisted or
     /// scored, so there is no evidence about whether it is a usable stillness signal; this counts what

--- a/Packages/WhoopProtocol/Tests/WhoopProtocolTests/UnhandledPacketTypeTests.swift
+++ b/Packages/WhoopProtocol/Tests/WhoopProtocolTests/UnhandledPacketTypeTests.swift
@@ -92,6 +92,51 @@ final class UnhandledPacketTypeTests: XCTestCase {
         XCTAssertTrue(extract([bad]).unhandledPacketTypes.isEmpty)
     }
 
+    /// END TO END, through the real parser — the test that actually proves the feature works.
+    ///
+    /// Every other case here hand-builds a `ParsedFrame` with `ok: true`, which assumes the thing most
+    /// likely to be wrong: `extractHistoricalStreams` skips `!r.ok` BEFORE its switch, so if `parseFrame`
+    /// marked an unmapped type not-ok the census would never fire on a real frame and every assertion above
+    /// would still pass. It does not — `spec == nil` annotates the payload and falls through to `ok: true` —
+    /// but that is a fact about the parser, and a fact the census depends on belongs in a test rather than
+    /// in my reading of it. The Kotlin twin builds real bytes throughout; this is the Swift equivalent.
+    func testRealFrameOfAnUnmappedTypeReachesTheCensus() {
+        // WHOOP 4.0 envelope: [AA][len lo][len hi][crc8(len)] + inner + crc32(inner). Type byte leads the
+        // inner record, so this is a well-formed frame of a type the schema does not name.
+        let inner: [UInt8] = [99, 0x11, 0x00]
+        var frame: [UInt8] = [0xAA, UInt8(inner.count), 0, 0]
+        frame[3] = crc8(Array(frame[1..<3]))
+        frame += inner
+        let c32 = crc32(inner)
+        frame += [UInt8(c32 & 0xFF), UInt8((c32 >> 8) & 0xFF),
+                  UInt8((c32 >> 16) & 0xFF), UInt8((c32 >> 24) & 0xFF)]
+
+        let parsed = parseFrame(frame)
+        XCTAssertTrue(parsed.ok, "an unmapped type must still parse, or the census is unreachable")
+        XCTAssertEqual(parsed.crcOK, true)
+        XCTAssertEqual(parsed.typeName, "type99")
+
+        let st = extract([parsed])
+        XCTAssertEqual(st.unhandledPacketTypes, ["type99": 1])
+    }
+
+    /// The rendering is FAMILY-AWARE: a WHOOP 4.0 frame renders through `schema.typeName` (no aliasing), a
+    /// 5/MG frame through `canonicalTypeName`.
+    ///
+    /// Type 56 is where that bites. Here it is PUFFIN_METADATA and gets counted; had Android always aliased
+    /// (its `Framing.typeName` does), it would have become METADATA there and been silently EXCLUDED — the
+    /// two platforms disagreeing about an anomalous frame, which is the single case the census exists for.
+    /// A puffin type arriving on a 4.0 is worth reporting, not swallowing.
+    func testPuffinMetadataOnWhoop4IsCountedNotAliasedIntoTheExclusion() {
+        XCTAssertEqual(extract([frame("PUFFIN_METADATA")]).unhandledPacketTypes, ["PUFFIN_METADATA": 1])
+    }
+
+    /// The 4.0 rendering never aliases 38 either — same rule, the other puffin type.
+    func testPuffinCommandResponseOnWhoop4KeepsItsOwnName() {
+        XCTAssertEqual(extract([frame("PUFFIN_COMMAND_RESPONSE")]).unhandledPacketTypes,
+                       ["PUFFIN_COMMAND_RESPONSE": 1])
+    }
+
     /// The census is transient diagnostics: it must not ride the Codable path that golden fixtures assert.
     func testCensusIsNotEncoded() throws {
         var st = Streams()

--- a/Packages/WhoopProtocol/Tests/WhoopProtocolTests/UnhandledPacketTypeTests.swift
+++ b/Packages/WhoopProtocol/Tests/WhoopProtocolTests/UnhandledPacketTypeTests.swift
@@ -104,7 +104,11 @@ final class UnhandledPacketTypeTests: XCTestCase {
         // WHOOP 4.0 envelope: [AA][len lo][len hi][crc8(len)] + inner + crc32(inner). Type byte leads the
         // inner record, so this is a well-formed frame of a type the schema does not name.
         let inner: [UInt8] = [99, 0x11, 0x00]
-        var frame: [UInt8] = [0xAA, UInt8(inner.count), 0, 0]
+        // The length field covers the inner record PLUS the 4-byte CRC32 trailer, not the record alone —
+        // get it wrong and the parser cannot locate the trailer, so `crcOK` comes back nil rather than
+        // true and the frame is malformed in a way that still counts. Same convention as
+        // Whoop4ResponseResultTests ([0xAA, 7, 0, 0] for a 3-byte inner).
+        var frame: [UInt8] = [0xAA, UInt8(inner.count + 4), 0, 0]
         frame[3] = crc8(Array(frame[1..<3]))
         frame += inner
         let c32 = crc32(inner)

--- a/Packages/WhoopProtocol/Tests/WhoopProtocolTests/UnhandledPacketTypeTests.swift
+++ b/Packages/WhoopProtocol/Tests/WhoopProtocolTests/UnhandledPacketTypeTests.swift
@@ -1,0 +1,103 @@
+import XCTest
+@testable import WhoopProtocol
+
+/// #891 — a history offload must not silently discard a packet type nobody has mapped.
+///
+/// `extractHistoricalStreams` switches on four of the schema's sixteen packet types and `default:`s the
+/// rest, and `rejectedHistoricalRecords` archives only type-47 ("Console (50) and METADATA frames have a
+/// different type byte, so they never pass this gate — they are excluded by construction"). So before this
+/// census an unmapped record was dropped twice and counted zero times, and the sync reported clean.
+///
+/// That is not a hypothetical gap. `HISTORICAL_IMU_DATA_STREAM(52)` is a banked raw-stream type the schema
+/// already names and the funnel does not handle. It is also the shape #891's leading hypothesis predicts:
+/// if a 5/MG banks ECG to flash after the Labrador toggles, the experiment that would find it cannot
+/// currently produce a finding, because nothing would report the record.
+///
+/// These mirror the Android `HistoricalStreamsUnhandledTypeTest` 1:1 — SAME exclusions, SAME names.
+final class UnhandledPacketTypeTests: XCTestCase {
+
+    private let wallNow = Int(Date().timeIntervalSince1970) - 7 * 86_400
+
+    /// A CRC-valid frame of `typeName` carrying nothing the funnel wants — the shape of a record whose
+    /// envelope decodes but whose body this decoder has no rows for.
+    private func frame(_ typeName: String) -> ParsedFrame {
+        ParsedFrame(ok: true, typeName: typeName, seq: 0, cmdName: nil, crcOK: true,
+                    lenBytes: 0, rawHex: "", fields: [], parsed: [:])
+    }
+
+    private func histFrame(unix: Int, bpm: Int = 60) -> ParsedFrame {
+        ParsedFrame(
+            ok: true, typeName: "HISTORICAL_DATA", seq: 24, cmdName: nil, crcOK: true,
+            lenBytes: 0, rawHex: "", fields: [],
+            parsed: ["hist_version": .int(24), "unix": .int(unix), "heart_rate": .int(bpm)]
+        )
+    }
+
+    private func extract(_ frames: [ParsedFrame]) -> Streams {
+        extractHistoricalStreams(frames, deviceClockRef: wallNow, wallClockRef: wallNow)
+    }
+
+    // MARK: - the gap this closes
+
+    /// A schema-NAMED type the funnel has no case for is counted, not silently dropped. This is the
+    /// banked-raw-stream type behind #891 hypothesis (b).
+    func testNamedButUnhandledTypeIsCounted() {
+        let st = extract([frame("HISTORICAL_IMU_DATA_STREAM"), frame("HISTORICAL_IMU_DATA_STREAM")])
+        XCTAssertEqual(st.unhandledPacketTypes, ["HISTORICAL_IMU_DATA_STREAM": 2])
+        XCTAssertTrue(st.isEmpty, "it still yields no rows — this is a census, not a decoder")
+    }
+
+    /// A byte the schema does not name at all renders `type<N>` (`Schema.typeName`) and is counted under
+    /// that name, so the number reaches the strap log even with no vocabulary for it.
+    func testUnmappedByteIsCountedUnderItsRenderedName() {
+        let st = extract([frame("type53")])
+        XCTAssertEqual(st.unhandledPacketTypes, ["type53": 1])
+    }
+
+    /// Several unmapped types in one chunk are counted separately, so a report names each.
+    func testDistinctTypesAreTalliedSeparately() {
+        let st = extract([frame("type53"), frame("HISTORICAL_IMU_DATA_STREAM"), frame("type53")])
+        XCTAssertEqual(st.unhandledPacketTypes, ["type53": 2, "HISTORICAL_IMU_DATA_STREAM": 1])
+    }
+
+    // MARK: - and does not cry wolf
+
+    /// METADATA and CONSOLE_LOGS reach `default:` on a normal sync and decode to zero rows BY DESIGN.
+    /// Counting them would put a scary line in every strap log and train people to ignore the one that
+    /// matters, so they are excluded by name.
+    func testExpectedUnhandledTypesAreNotCounted() {
+        let st = extract([frame("CONSOLE_LOGS"), frame("METADATA"), frame("CONSOLE_LOGS")])
+        XCTAssertTrue(st.unhandledPacketTypes.isEmpty)
+    }
+
+    /// The exclusion set is pinned: it must stay exactly these two, and must stay in lockstep with Android.
+    /// Adding to it is how this census would quietly stop reporting the thing it was built for.
+    func testExclusionSetIsExactlyMetadataAndConsole() {
+        XCTAssertEqual(expectedUnhandledHistoricalTypes, ["METADATA", "CONSOLE_LOGS"])
+    }
+
+    /// A normal offload logs nothing — the common case must stay silent or the signal is worthless.
+    func testOrdinaryRecordsProduceNoCensus() {
+        let st = extract([histFrame(unix: wallNow), histFrame(unix: wallNow + 1)])
+        XCTAssertEqual(st.hr.count, 2)
+        XCTAssertTrue(st.unhandledPacketTypes.isEmpty)
+    }
+
+    /// A CRC-failed frame is skipped before the switch and is NOT reported as an unhandled type — it is a
+    /// different failure with its own archive (`rejectedHistoricalRecords`), and conflating them would
+    /// misattribute a corrupt frame to an unknown firmware feature.
+    func testCrcFailedFrameIsNotCountedAsUnhandled() {
+        let bad = ParsedFrame(ok: true, typeName: "HISTORICAL_IMU_DATA_STREAM", seq: 0, cmdName: nil,
+                              crcOK: false, lenBytes: 0, rawHex: "", fields: [], parsed: [:])
+        XCTAssertTrue(extract([bad]).unhandledPacketTypes.isEmpty)
+    }
+
+    /// The census is transient diagnostics: it must not ride the Codable path that golden fixtures assert.
+    func testCensusIsNotEncoded() throws {
+        var st = Streams()
+        st.unhandledPacketTypes = ["HISTORICAL_IMU_DATA_STREAM": 3]
+        let json = String(data: try JSONEncoder().encode(st), encoding: .utf8) ?? ""
+        XCTAssertFalse(json.contains("HISTORICAL_IMU_DATA_STREAM"))
+        XCTAssertFalse(json.contains("unhandledPacketTypes"))
+    }
+}

--- a/Strand/Collect/Backfiller.swift
+++ b/Strand/Collect/Backfiller.swift
@@ -132,6 +132,14 @@ final class Backfiller {
     /// ingest gate already kept the garbage rows out of the DB).
     private(set) var sessionDroppedImplausible = 0
 
+    /// #891 diagnostic: packet types this session's offload carried that the decoder has no rows for,
+    /// folded across chunks. Each type is logged the FIRST time it appears — a 30k-record offload must not
+    /// emit 30k lines — and the running total is what a later line can report. See
+    /// `Streams.unhandledPacketTypes` for why this is not derivable from anything already logged: an
+    /// unmapped type is dropped by the decoder AND excluded from the reject archive, so today it is
+    /// invisible and the sync reports clean.
+    private(set) var sessionUnhandledPacketTypes: [String: Int] = [:]
+
     /// #520 diagnostic: `dynamic_acceleration` folded across every chunk of this session, logged once at
     /// the session boundary. Session-scoped rather than per-chunk because a chunk is an arbitrary slice of
     /// an offload — a still-fraction only means something over a whole night's worth of records.
@@ -234,6 +242,7 @@ final class Backfiller {
         loggedNoCursor = false
         loggedFutureRtc = false
         sessionDroppedImplausible = 0
+        sessionUnhandledPacketTypes = [:]   // #891: a second offload must re-log its first sighting
         sessionDynAccel = Streams.DynAccelDiag()
         loggedLayoutVersions.removeAll(keepingCapacity: true)
         spo2Dumped = 0
@@ -523,6 +532,20 @@ final class Backfiller {
             let nowForRtc = Int(Date().timeIntervalSince1970)
             for ev in decoded.droppedRtcEvents {
                 log?("Backfill: strap reported \(ev.kind) with an implausible own-timestamp \(BadClockDiagnostics.isoDay(ev.rawTs)) (\(BadClockDiagnostics.hoursOffset(ev.rawTs, now: nowForRtc)) vs now) — the strap's RTC reset to a wrong base (#324/#928); this is the ground-truth cause of the future-dated banking, not a NOOP decode bug.")
+            }
+            // #891: packet types this chunk carried that the decoder has no case for. Logged the first
+            // time each type appears so a long offload stays readable. This is the only place such a
+            // record becomes visible: `default:` drops it and `rejectedHistoricalRecords` archives only
+            // type-47, so without this line an offload full of an unmapped type reports a clean sync.
+            for (typeName, n) in decoded.unhandledPacketTypes.sorted(by: { $0.key < $1.key }) {
+                let firstSighting = sessionUnhandledPacketTypes[typeName] == nil
+                sessionUnhandledPacketTypes[typeName, default: 0] += n
+                if firstSighting {
+                    log?("Backfill: the strap sent \(n) record(s) of packet type \(typeName), which this " +
+                         "decoder has no rows for — they are being dropped. If \(typeName) is not a name " +
+                         "you recognise, this is a firmware record type NOOP has never mapped: please " +
+                         "report it on #891 with the strap model and firmware build.")
+                }
             }
             // Diagnostic (#77): the AGGREGATE silent-loss case — frames arrived but produced no rows at
             // all (CRC fail / unmapped layout / out-of-range timestamp), so this chunk persists nothing

--- a/android/app/src/main/java/com/noop/ble/Backfiller.kt
+++ b/android/app/src/main/java/com/noop/ble/Backfiller.kt
@@ -259,6 +259,13 @@ class Backfiller(
     var sessionDroppedImplausible = 0
 
     /**
+     * #891 diagnostic: packet types this session's offload carried that the decoder has no rows for, folded
+     * across batches. Each type is logged the FIRST time it appears — a 30k-record offload must not emit 30k
+     * lines. Reset in [begin]. Twin of Swift `Backfiller.sessionUnhandledPacketTypes`.
+     */
+    val sessionUnhandledPacketTypes = mutableMapOf<String, Int>()
+
+    /**
      * #520 diagnostic: `dynamic_acceleration` folded across every batch of this session, logged once at the
      * session boundary. Session-scoped rather than per-batch because a batch is an arbitrary slice of an
      * offload — a still-fraction only means something over a whole night's worth of records. Twin of Swift
@@ -288,6 +295,7 @@ class Backfiller(
         spo2Dumped = 0
         loggedImplausibleClock = false
         sessionDroppedImplausible = 0
+        sessionUnhandledPacketTypes.clear()   // #891: a second offload must re-log its first sighting
         sessionDynAccel = DynAccelDiag()
         // #547: the range markers belong to a connection's GET_DATA_RANGE, which the client re-sets per
         // connect; clear them so a fresh session never reuses a previous strap's window (the client
@@ -437,6 +445,24 @@ class Backfiller(
                         "implausible timestamp$span (bad strap clock — far-past or future-dated); they are " +
                         "excluded so they can't misdate history.",
                 )
+            }
+            // #891: packet types this batch carried that the decoder has no branch for. Logged the first
+            // time each type appears so a long offload stays readable. This is the only place such a record
+            // becomes visible: the `else` branch drops it and rejectedHistoricalRecords archives only
+            // type-47, so without this line an offload full of an unmapped type reports a clean sync.
+            // Mirrors the Swift Backfiller.
+            for ((typeName, n) in decoded.unhandledPacketTypes.toSortedMap()) {
+                val firstSighting = typeName !in sessionUnhandledPacketTypes
+                sessionUnhandledPacketTypes[typeName] =
+                    (sessionUnhandledPacketTypes[typeName] ?: 0) + n
+                if (firstSighting) {
+                    log(
+                        "Backfill: the strap sent $n record(s) of packet type $typeName, which this " +
+                            "decoder has no rows for — they are being dropped. If $typeName is not a name " +
+                            "you recognise, this is a firmware record type NOOP has never mapped: please " +
+                            "report it on #891 with the strap model and firmware build.",
+                    )
+                }
             }
             // #324: the strap RTC-state events (RTC_LOST / BOOT / SET_RTC) the #547 gate dropped for a bad
             // own-timestamp — the GROUND TRUTH that the clock reset. Sparse (not per-record), so log each as

--- a/android/app/src/main/java/com/noop/data/WhoopRepository.kt
+++ b/android/app/src/main/java/com/noop/data/WhoopRepository.kt
@@ -66,6 +66,21 @@ data class StreamBatch(
      */
     val droppedRtcEvents: List<DroppedRtcEvent> = emptyList(),
     /**
+     * #891 diagnostic: packet types this batch carried that the decoder has no `when` branch for, keyed by
+     * the rendered type name (a byte no enum names renders `type53`), value = record count.
+     *
+     * The decode loop handles four of the schema's sixteen packet types and drops the rest at `else -> Unit`,
+     * and `rejectedHistoricalRecords` archives only type-47 — non-47 frames are excluded from it by
+     * construction. So a record type nobody has mapped was dropped twice and counted zero times, and the sync
+     * reported clean. `HISTORICAL_IMU_DATA_STREAM(52)` is a banked raw-stream type the schema already names
+     * and this funnel does not handle; every one would vanish.
+     *
+     * METADATA and CONSOLE_LOGS are excluded ([EXPECTED_UNHANDLED_HISTORICAL_TYPES]) — an offload legitimately
+     * carries both and they decode to zero rows by design, so counting them would bury the signal. Diag only
+     * (excluded from [isEmpty]); empty when nothing fell through. Mirrors Swift `Streams.unhandledPacketTypes`.
+     */
+    val unhandledPacketTypes: Map<String, Int> = emptyMap(),
+    /**
      * #520 diagnostic: a summary of `dynamic_acceleration@41` (the strap's own gravity-removed motion
      * magnitude) over this batch's v18 records. The field has been decoded on both platforms all along
      * with nothing consuming it, so there is no evidence on whether it is a usable stillness signal;

--- a/android/app/src/main/java/com/noop/protocol/Enums.kt
+++ b/android/app/src/main/java/com/noop/protocol/Enums.kt
@@ -23,7 +23,15 @@ enum class PacketType(val rawValue: Int) {
     METADATA(49),
     CONSOLE_LOGS(50),
     REALTIME_IMU_DATA_STREAM(51),
-    HISTORICAL_IMU_DATA_STREAM(52);
+    HISTORICAL_IMU_DATA_STREAM(52),
+    // 53-55 are decode-only NAMES, added for #891: the unhandled-packet-type census renders a type through
+    // this enum, and without them a 5/MG offload carrying one would report "type53" on Android and
+    // "RELATIVE_PUFFIN_EVENTS" on Apple — the same strap, two different report lines. Nothing dispatches on
+    // them. 56 stays out deliberately: both platforms alias it onto METADATA (PuffinPacketType.PUFFIN_METADATA
+    // / Swift `canonicalTypeName`), so naming it here would DIVERGE from Apple rather than match it.
+    RELATIVE_PUFFIN_EVENTS(53),
+    PUFFIN_EVENTS_FROM_STRAP(54),
+    RELATIVE_BATTERY_PACK_CONSOLE_LOGS(55);
 
     companion object {
         private val byRaw = entries.associateBy { it.rawValue }

--- a/android/app/src/main/java/com/noop/protocol/Enums.kt
+++ b/android/app/src/main/java/com/noop/protocol/Enums.kt
@@ -24,14 +24,20 @@ enum class PacketType(val rawValue: Int) {
     CONSOLE_LOGS(50),
     REALTIME_IMU_DATA_STREAM(51),
     HISTORICAL_IMU_DATA_STREAM(52),
-    // 53-55 are decode-only NAMES, added for #891: the unhandled-packet-type census renders a type through
-    // this enum, and without them a 5/MG offload carrying one would report "type53" on Android and
+    // 53-56 are decode-only NAMES, added for #891: the unhandled-packet-type census renders a type through
+    // this enum, and without them an offload carrying one would report "type53" on Android and
     // "RELATIVE_PUFFIN_EVENTS" on Apple — the same strap, two different report lines. Nothing dispatches on
-    // them. 56 stays out deliberately: both platforms alias it onto METADATA (PuffinPacketType.PUFFIN_METADATA
-    // / Swift `canonicalTypeName`), so naming it here would DIVERGE from Apple rather than match it.
+    // them.
+    //
+    // 56 is here even though both platforms ALIAS it onto METADATA on 5/MG, because the aliasing is
+    // family-aware: Swift renders a WHOOP 4.0 frame through `schema.typeName` (no alias, so PUFFIN_METADATA)
+    // and a 5/MG frame through `canonicalTypeName` (METADATA). Leaving 56 out matched Apple on 5/MG and
+    // diverged on 4.0 — where the census would have rendered "type56" — so the name has to exist and the
+    // caller has to pick the right rendering. `Framing.typeName` still aliases it, which is the 5/MG answer.
     RELATIVE_PUFFIN_EVENTS(53),
     PUFFIN_EVENTS_FROM_STRAP(54),
-    RELATIVE_BATTERY_PACK_CONSOLE_LOGS(55);
+    RELATIVE_BATTERY_PACK_CONSOLE_LOGS(55),
+    PUFFIN_METADATA(56);
 
     companion object {
         private val byRaw = entries.associateBy { it.rawValue }

--- a/android/app/src/main/java/com/noop/protocol/Framing.kt
+++ b/android/app/src/main/java/com/noop/protocol/Framing.kt
@@ -219,8 +219,15 @@ object Framing {
 
     // MARK: - type / enum naming
 
-    /** Canonical packet-type name, aliasing the Whoop 5.0 "puffin" types onto their base names. */
-    private fun typeName(t: Int): String = when (t) {
+    /**
+     * Canonical packet-type name, aliasing the Whoop 5.0 "puffin" types onto their base names: the enum
+     * name, or `type<N>` for a byte nothing names, exactly as Swift's `canonicalTypeName` does.
+     *
+     * Internal rather than private since #891 — the unhandled-packet-type census in `HistoricalStreams`
+     * renders through this so the two platforms report the same string for the same byte, instead of
+     * keeping a second copy of the rules that could drift.
+     */
+    internal fun typeName(t: Int): String = when (t) {
         PuffinPacketType.PUFFIN_COMMAND_RESPONSE -> "COMMAND_RESPONSE"
         PuffinPacketType.PUFFIN_METADATA -> "METADATA"
         else -> PacketType.fromRaw(t)?.name ?: "type$t"

--- a/android/app/src/main/java/com/noop/protocol/HistoricalStreams.kt
+++ b/android/app/src/main/java/com/noop/protocol/HistoricalStreams.kt
@@ -18,6 +18,16 @@ import com.noop.data.StepRow
 import com.noop.data.StreamBatch
 import com.noop.data.StreamPersistence
 
+/**
+ * #891: packet types an offload legitimately carries that [extractHistoricalStreams] has no rows for, so
+ * reaching the `else` branch is expected rather than a finding. Both decode to zero rows BY DESIGN —
+ * CONSOLE_LOGS is strap-side debug text, METADATA is envelope bookkeeping — and counting them on every sync
+ * would bury the one signal [com.noop.data.StreamBatch.unhandledPacketTypes] exists to surface. Nothing else
+ * is excluded, including named-but-unhandled types like `HISTORICAL_IMU_DATA_STREAM(52)`: those are exactly
+ * the interesting ones. Keep in lockstep with Swift's `expectedUnhandledHistoricalTypes`.
+ */
+val EXPECTED_UNHANDLED_HISTORICAL_TYPES: Set<String> = setOf("METADATA", "CONSOLE_LOGS")
+
 /*
  * Historical (offload) decode for the WHOOP 4.0 — the type-47 HISTORICAL_DATA path.
  *
@@ -591,6 +601,8 @@ fun extractHistoricalStreams(
     // Count of records dropped by the #547 plausibility gate this batch, surfaced on the returned
     // StreamBatch so the Backfiller can log "bad strap clock" once per session via its existing seam.
     var droppedImplausible = 0
+    // #891: packet types that reach the `else` branch and are dropped. See StreamBatch.unhandledPacketTypes.
+    val unhandledTypes = mutableMapOf<String, Int>()
     // #324: oldest/newest own-timestamp among the dropped records (the poisoned-range epoch span), and the
     // dropped RTC-state events (RTC_LOST / BOOT / SET_RTC) — the ground truth that the clock reset. Declared
     // before correctedWall so the local function can capture them (Kotlin: no forward reference to locals).
@@ -897,7 +909,22 @@ fun extractHistoricalStreams(
                 appendHistBattery(battery, wallClockRef.toLong(), parsed.parsed)
             }
 
-            else -> Unit
+            // #891: no branch handles this type, so the record is dropped — count it first, or an offload
+            // carrying a type nobody has mapped reports as a clean sync. See StreamBatch.unhandledPacketTypes
+            // for why METADATA/CONSOLE_LOGS are excluded. Mirrors Swift's `default:`.
+            else -> {
+                val name = Framing.typeName(t)
+                if (name !in EXPECTED_UNHANDLED_HISTORICAL_TYPES) {
+                    // Swift skips CRC-failed frames BEFORE its switch; this loop dispatches on the raw type
+                    // byte, so the check has to happen here or a corrupt frame would be reported as an
+                    // unknown firmware feature on Android and not on Apple. A CRC failure is a different
+                    // finding with its own archive (rejectedHistoricalRecords).
+                    val parsed = Framing.parseFrame(frame, family)
+                    if (parsed.ok && parsed.crcOk != false) {
+                        unhandledTypes[name] = (unhandledTypes[name] ?: 0) + 1
+                    }
+                }
+            }
         }
     }
 
@@ -913,6 +940,7 @@ fun extractHistoricalStreams(
         ppgHr = ppgHr,
         ppgWaveform = ppgWaveform,
         v18Aux = v18Aux,
+        unhandledPacketTypes = unhandledTypes,   // #891 diag census (not persisted)
         droppedImplausibleTs = droppedImplausible,
         droppedImplausibleOldestTs = droppedOldest,   // #324 poisoned-range epoch span (diag only)
         droppedImplausibleNewestTs = droppedNewest,

--- a/android/app/src/main/java/com/noop/protocol/HistoricalStreams.kt
+++ b/android/app/src/main/java/com/noop/protocol/HistoricalStreams.kt
@@ -913,7 +913,13 @@ fun extractHistoricalStreams(
             // carrying a type nobody has mapped reports as a clean sync. See StreamBatch.unhandledPacketTypes
             // for why METADATA/CONSOLE_LOGS are excluded. Mirrors Swift's `default:`.
             else -> {
-                val name = Framing.typeName(t)
+                // Family-aware exactly as Swift's `frameTypeName` is: a WHOOP 4.0 frame renders through the
+                // plain enum (`schema.typeName` on Apple), a 5/MG frame through the puffin aliasing
+                // (`canonicalTypeName`). Always aliasing here would have rendered a 4.0 type-56 as METADATA
+                // and then EXCLUDED it, while Apple counted it as PUFFIN_METADATA — the census silently
+                // disagreeing across platforms about an anomalous frame, which is the one case it exists for.
+                val name = if (family == DeviceFamily.WHOOP5) Framing.typeName(t)
+                           else PacketType.fromRaw(t)?.name ?: "type$t"
                 if (name !in EXPECTED_UNHANDLED_HISTORICAL_TYPES) {
                     // Swift skips CRC-failed frames BEFORE its switch; this loop dispatches on the raw type
                     // byte, so the check has to happen here or a corrupt frame would be reported as an

--- a/android/app/src/test/java/com/noop/protocol/HistoricalStreamsUnhandledTypeTest.kt
+++ b/android/app/src/test/java/com/noop/protocol/HistoricalStreamsUnhandledTypeTest.kt
@@ -111,8 +111,7 @@ class HistoricalStreamsUnhandledTypeTest {
 
     /**
      * Packet-type NAMES must match Swift for every byte the census can render, or the same strap produces
-     * two different report lines. 53-55 were missing from the Kotlin enum until #891; 56 must stay absent
-     * because both platforms alias it onto METADATA.
+     * two different report lines. 53-56 were missing from the Kotlin enum until #891.
      */
     @Test
     fun packetTypeNamesMatchTheSwiftSchema() {
@@ -121,7 +120,29 @@ class HistoricalStreamsUnhandledTypeTest {
         assertEquals("RELATIVE_PUFFIN_EVENTS", Framing.typeName(53))
         assertEquals("PUFFIN_EVENTS_FROM_STRAP", Framing.typeName(54))
         assertEquals("RELATIVE_BATTERY_PACK_CONSOLE_LOGS", Framing.typeName(55))
-        assertEquals("METADATA", Framing.typeName(56))   // puffin alias, both platforms
+        assertEquals("METADATA", Framing.typeName(56))   // 5/MG puffin alias, both platforms
         assertEquals("type99", Framing.typeName(99))     // nothing names it
+    }
+
+    /**
+     * The rendering is FAMILY-AWARE, mirroring Swift's `frameTypeName`: a WHOOP 4.0 frame renders through
+     * the plain enum, a 5/MG frame through the puffin aliasing.
+     *
+     * Type 56 is where that bites. Apple parses a 4.0 frame with `schema.typeName` (no alias) and counts it
+     * as PUFFIN_METADATA; if this side always aliased, it would become METADATA and be silently EXCLUDED —
+     * the two platforms disagreeing about an anomalous frame, which is the single case the census exists
+     * for. A puffin type arriving on a 4.0 is exactly the kind of thing worth reporting, not swallowing.
+     */
+    @Test
+    fun puffinMetadataOnWhoop4IsCountedNotAliasedIntoTheExclusion() {
+        val b = extract(listOf(frameOfType(PacketType.PUFFIN_METADATA.rawValue)))
+        assertEquals(mapOf("PUFFIN_METADATA" to 1), b.unhandledPacketTypes)
+    }
+
+    /** The 4.0 rendering never aliases 38 either — same rule, the other puffin type. */
+    @Test
+    fun puffinCommandResponseOnWhoop4KeepsItsOwnName() {
+        val b = extract(listOf(frameOfType(PacketType.PUFFIN_COMMAND_RESPONSE.rawValue)))
+        assertEquals(mapOf("PUFFIN_COMMAND_RESPONSE" to 1), b.unhandledPacketTypes)
     }
 }

--- a/android/app/src/test/java/com/noop/protocol/HistoricalStreamsUnhandledTypeTest.kt
+++ b/android/app/src/test/java/com/noop/protocol/HistoricalStreamsUnhandledTypeTest.kt
@@ -30,11 +30,15 @@ class HistoricalStreamsUnhandledTypeTest {
      */
     private fun frameOfType(t: Int): ByteArray {
         val inner = byteArrayOf(t.toByte(), 0, 0)
+        // Length covers the inner record PLUS the 4-byte CRC32 trailer, not the record alone. Getting this
+        // wrong leaves crcOk null rather than true — the frame still reaches the census, so the test passes
+        // while feeding the decoder something malformed. Swift's twin caught it; pinned here too.
+        val declaredLen = (inner.size + 4).toByte()
         val out = ArrayList<Byte>()
         out.add(0xAA.toByte())
-        out.add(inner.size.toByte())
+        out.add(declaredLen)
         out.add(0)
-        out.add(Crc.crc8(byteArrayOf(inner.size.toByte(), 0)).toByte())
+        out.add(Crc.crc8(byteArrayOf(declaredLen, 0)).toByte())
         inner.forEach { out.add(it) }
         val c32 = Crc.crc32(inner)
         out.add((c32 and 0xFF).toByte())

--- a/android/app/src/test/java/com/noop/protocol/HistoricalStreamsUnhandledTypeTest.kt
+++ b/android/app/src/test/java/com/noop/protocol/HistoricalStreamsUnhandledTypeTest.kt
@@ -1,0 +1,127 @@
+package com.noop.protocol
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * #891 — a history offload must not silently discard a packet type nobody has mapped.
+ *
+ * [extractHistoricalStreams] switches on four of the schema's sixteen packet types and drops the rest at
+ * `else`, and [rejectedHistoricalRecords] archives only type-47 — non-47 frames are excluded from it by
+ * construction. So before this census an unmapped record was dropped twice and counted zero times, and the
+ * sync reported clean.
+ *
+ * That is not a hypothetical gap. `HISTORICAL_IMU_DATA_STREAM(52)` is a banked raw-stream type the schema
+ * already names and the funnel does not handle. It is also the shape #891's leading hypothesis predicts: if
+ * a 5/MG banks ECG to flash after the Labrador toggles, the experiment that would find it cannot currently
+ * produce a finding, because nothing would report the record.
+ *
+ * The Android twin of `UnhandledPacketTypeTests.swift` — SAME exclusions, SAME rendered names.
+ */
+class HistoricalStreamsUnhandledTypeTest {
+
+    private val wallNow = (System.currentTimeMillis() / 1000L).toInt() - 7 * 86_400
+
+    /**
+     * A CRC-valid WHOOP 4.0 frame of packet type [t] with an empty body — the shape of a record whose
+     * envelope decodes but whose body this decoder has no rows for. The census keys off the type byte at
+     * `frame[4]`, which is all these need to carry.
+     */
+    private fun frameOfType(t: Int): ByteArray {
+        val inner = byteArrayOf(t.toByte(), 0, 0)
+        val out = ArrayList<Byte>()
+        out.add(0xAA.toByte())
+        out.add(inner.size.toByte())
+        out.add(0)
+        out.add(Crc.crc8(byteArrayOf(inner.size.toByte(), 0)).toByte())
+        inner.forEach { out.add(it) }
+        val c32 = Crc.crc32(inner)
+        out.add((c32 and 0xFF).toByte())
+        out.add(((c32 shr 8) and 0xFF).toByte())
+        out.add(((c32 shr 16) and 0xFF).toByte())
+        out.add(((c32 shr 24) and 0xFF).toByte())
+        return out.toByteArray()
+    }
+
+    private fun extract(frames: List<ByteArray>) =
+        extractHistoricalStreams(frames, wallNow, wallNow, DeviceFamily.WHOOP4)
+
+    // --- the gap this closes ---
+
+    /**
+     * A schema-NAMED type the funnel has no branch for is counted, not silently dropped. This is the
+     * banked-raw-stream type behind #891 hypothesis (b).
+     */
+    @Test
+    fun namedButUnhandledTypeIsCounted() {
+        val t = PacketType.HISTORICAL_IMU_DATA_STREAM.rawValue
+        val b = extract(listOf(frameOfType(t), frameOfType(t)))
+        assertEquals(mapOf("HISTORICAL_IMU_DATA_STREAM" to 2), b.unhandledPacketTypes)
+        assertTrue("it still yields no rows — this is a census, not a decoder", b.isEmpty)
+    }
+
+    /** Distinct unhandled types are tallied separately, so a report can name each. */
+    @Test
+    fun distinctTypesAreTalliedSeparately() {
+        val imu = PacketType.HISTORICAL_IMU_DATA_STREAM.rawValue
+        val evts = PacketType.PUFFIN_EVENTS_FROM_STRAP.rawValue
+        val b = extract(listOf(frameOfType(imu), frameOfType(evts), frameOfType(imu)))
+        assertEquals(
+            mapOf("HISTORICAL_IMU_DATA_STREAM" to 2, "PUFFIN_EVENTS_FROM_STRAP" to 1),
+            b.unhandledPacketTypes,
+        )
+    }
+
+    /**
+     * A byte no enum names renders `type<N>` and is counted under that name, so the number still reaches
+     * the strap log with no vocabulary for it.
+     */
+    @Test
+    fun unmappedByteIsCountedUnderItsRenderedName() {
+        assertEquals(mapOf("type99" to 1), extract(listOf(frameOfType(99))).unhandledPacketTypes)
+    }
+
+    // --- and does not cry wolf ---
+
+    /**
+     * METADATA and CONSOLE_LOGS reach `else` on a normal sync and decode to zero rows BY DESIGN. Counting
+     * them would put a scary line in every strap log and train people to ignore the one that matters.
+     */
+    @Test
+    fun expectedUnhandledTypesAreNotCounted() {
+        val b = extract(
+            listOf(
+                frameOfType(PacketType.CONSOLE_LOGS.rawValue),
+                frameOfType(PacketType.METADATA.rawValue),
+                frameOfType(PacketType.CONSOLE_LOGS.rawValue),
+            ),
+        )
+        assertTrue(b.unhandledPacketTypes.isEmpty())
+    }
+
+    /**
+     * The exclusion set is pinned and must stay in lockstep with Swift's `expectedUnhandledHistoricalTypes`.
+     * Adding to it is how this census would quietly stop reporting the thing it was built for.
+     */
+    @Test
+    fun exclusionSetIsExactlyMetadataAndConsole() {
+        assertEquals(setOf("METADATA", "CONSOLE_LOGS"), EXPECTED_UNHANDLED_HISTORICAL_TYPES)
+    }
+
+    /**
+     * Packet-type NAMES must match Swift for every byte the census can render, or the same strap produces
+     * two different report lines. 53-55 were missing from the Kotlin enum until #891; 56 must stay absent
+     * because both platforms alias it onto METADATA.
+     */
+    @Test
+    fun packetTypeNamesMatchTheSwiftSchema() {
+        assertEquals("REALTIME_IMU_DATA_STREAM", Framing.typeName(51))
+        assertEquals("HISTORICAL_IMU_DATA_STREAM", Framing.typeName(52))
+        assertEquals("RELATIVE_PUFFIN_EVENTS", Framing.typeName(53))
+        assertEquals("PUFFIN_EVENTS_FROM_STRAP", Framing.typeName(54))
+        assertEquals("RELATIVE_BATTERY_PACK_CONSOLE_LOGS", Framing.typeName(55))
+        assertEquals("METADATA", Framing.typeName(56))   // puffin alias, both platforms
+        assertEquals("type99", Framing.typeName(99))     // nothing names it
+    }
+}


### PR DESCRIPTION
Read-only. No new opcode, no hardware write, no storage, no strings.

## The gap

A history offload silently discards any packet type the decoder has no case for:

- `extractHistoricalStreams` switches on **four** of the schema's **sixteen** packet types and
  `default: continue`s the rest — no counter, no log.
- `rejectedHistoricalRecords` will not catch it either. It is gated `frame[typeIndex] == 47`, and its
  own comment says non-47 types *"never pass this gate — they are excluded by construction"*.

So an unmapped record is dropped twice and counted zero times, and the sync reports clean.

Not hypothetical: **`HISTORICAL_IMU_DATA_STREAM(52)`** is a banked raw-stream type our own schema
already names and this funnel does not handle. Every one would vanish.

## Why now

#891's leading hypothesis (b) is that the 5/MG banks Labrador ECG to flash rather than streaming it,
and the open ask is *"has anyone seen an unrecognised record type or buffer type in a 5/MG offload?"*

**Nobody can answer that today.** There is no instrument that would show one, so running the
experiment cannot produce a finding in either direction — a negative would be indistinguishable from
not looking. This is the instrument.

It is worth having regardless of how #891 resolves: any future firmware record type is invisible right
now, on both platforms.

## What it does

`Streams.unhandledPacketTypes` / `StreamBatch.unhandledPacketTypes` census the types that fall through,
keyed by rendered name. The Backfiller logs each the **first time** it appears — a 30k-record offload
must not emit 30k lines — naming the type and asking for a report on #891 if it is unfamiliar.

Transient diagnostics exactly like `droppedImplausible`, whose pattern this follows: not persisted, not
in `CodingKeys`, excluded from `isEmpty`, empty by default so golden fixtures stay byte-identical.

**`METADATA` and `CONSOLE_LOGS` are excluded.** An offload legitimately carries both and they decode to
zero rows by design; counting them would put a scary line in every strap log and train people to ignore
the one that matters. Named-but-unhandled types are **not** excluded — those are the interesting ones.
The exclusion set is pinned by a test on both platforms, because quietly adding to it is how this stops
reporting the thing it was built for.

## Two parity defects found while writing it

- **`PacketType` 53-56 were missing from the Kotlin enum**, so the same byte would render `type53` on
  Android and `RELATIVE_PUFFIN_EVENTS` on Apple — one strap, two different report lines in a diagnostic
  meant to be pasted into an issue. Added as decode-only names; nothing dispatches on them.
- **The rendering has to be family-aware, and was not.** Swift renders a WHOOP 4.0 frame through
  `schema.typeName` (no aliasing) and a 5/MG frame through `canonicalTypeName`; the Kotlin census always
  aliased. A 4.0 frame of type 56 would have been counted as `PUFFIN_METADATA` on Apple and **silently
  excluded** as `METADATA` on Android — the two platforms disagreeing about an anomalous frame, which is
  the single case this exists for. Kotlin now picks the rendering by family, and both suites pin it.
- **Kotlin dispatches on the raw type byte before any CRC check**, where Swift skips CRC-failed frames
  before its switch. Left alone, a corrupt frame would have been reported as an unknown firmware feature
  on Android and not on Apple. The Kotlin branch now checks CRC explicitly — a CRC failure is a
  different finding with its own archive.

`Framing.typeName` went `private` -> `internal` so both the census and the frame labeller render through
one copy of the aliasing rules rather than two that can drift.

## Verification

- New tests both sides, 1:1: named-but-unhandled counted, unmapped byte counted under its rendered name,
  distinct types tallied separately, METADATA/CONSOLE_LOGS **not** counted, the exclusion set pinned, a
  normal offload producing an empty census, a CRC-failed frame not counted, the census absent from the
  Codable path, both puffin types keeping their own names on 4.0, and packet-type names matching across
  platforms byte for byte.
- **One end-to-end case per platform, through the real parser.** The rest hand-build a decoded frame, which
  assumes the thing most likely to be wrong: the decoder skips not-ok frames BEFORE its switch, so if the
  parser marked an unmapped type not-ok the census would never fire and every other assertion would still
  pass. Writing that test found a second defect — both builders declared the envelope length as the inner
  record alone, where it covers the record PLUS the 4-byte CRC32 trailer, so the parser could not locate the
  trailer and never verified. Kotlin passed anyway (`crcOk` null, not false); Swift caught it. Both fixed.
- `Tools/doc_comment_lint.py` clean.
- Kotlin: `HistoricalStreams.kt`, `Enums.kt` and `Framing.kt` compile clean locally (Gradle itself does
  not run on this arm64 host — `aapt2` is x86-64 only — so this was the embeddable compiler over the
  `protocol` + `data` packages; remaining errors in that partial compile are packages I did not pass it).
  Android CI is the real gate.
- **`Strand/Collect/Backfiller.swift` is app-target Swift, which nothing compiles while `app-build.yml`
  is disabled.** The package half is covered by `swift-packages`. The Backfiller hunk is a `for` over a
  dictionary and a log call, but it is uncompiled and I would rather say so.
- No hardware: this changes what a decode REPORTS, not what is sent. Nothing was run against a strap.

## Where it is surfaced, and where it is not

Verified reachable rather than assumed: there is no early return between decode and the log on either
platform, which matters because a chunk of ONLY unmapped records has `isEmpty == true` and an
empty-chunk shortcut would have made this inert in exactly the case it exists for. Both `log` sinks are
wired in production (`BLEManager` / `WhoopBleClient`), so the line reaches the strap log a user can paste.

**Not surfaced on Android's capture-replay path.** `CaptureImporter` calls the same decoder, so the
census is computed and sits on the `StreamBatch`, but that caller does not log it. The #891 experiment is
a live offload, so the path that matters is covered — noting it rather than leaving it to be discovered.

## One judgement call worth flagging

`RELATIVE_BATTERY_PACK_CONSOLE_LOGS(55)` is left **in** the census rather than excluded with the other
console type. If it turns out a 5/MG carries it routinely in an offload, it becomes noise and wants a
one-line addition to the exclusion set — but there is no evidence in-tree that it appears at all, and
over-reporting once is recoverable in a way that never reporting is not.

Refs #891.
