### PR TITLE
Make Low Power Mode mean "stop everything decorative", and stop the tilt sensor (#909)

### DIFF
--- a/Packages/StrandDesign/Sources/StrandDesign/Components.swift
+++ b/Packages/StrandDesign/Sources/StrandDesign/Components.swift
@@ -661,6 +661,11 @@ private struct PulseDot: View {
     var size: CGFloat
     @State private var animate = false
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    /// Low Power Mode / "Reduce motion in NOOP". This halo is a `repeatForever` loop that never
+    /// settles and is on screen for long stretches — a connected strap in Settings, a backfill on
+    /// every scaffolded screen — so it belongs behind the same gate as the liquid surfaces.
+    @ObservedObject private var motion = NoopMotionState.shared
+    private var poseStill: Bool { motion.poseStill(reduceMotion) }
     @Environment(\.colorScheme) private var scheme
     var body: some View {
         ZStack {
@@ -682,8 +687,8 @@ private struct PulseDot: View {
                 .shadow(color: color.opacity(0.8), radius: pulsing ? 4 : 2)
         }
         .frame(width: size, height: size)
-        .onAppear { if pulsing && !reduceMotion { animate = true } }
-        .animation(pulsing && !reduceMotion ? StrandMotion.breathe : nil, value: animate)
+        .onAppear { if pulsing && !poseStill { animate = true } }
+        .animation(pulsing && !poseStill ? StrandMotion.breathe : nil, value: animate)
         .accessibilityHidden(true)
     }
 }

--- a/Packages/StrandDesign/Sources/StrandDesign/NoopMotion.swift
+++ b/Packages/StrandDesign/Sources/StrandDesign/NoopMotion.swift
@@ -75,7 +75,13 @@ public enum NoopMotion {
 
 /// "Reduce motion in NOOP" (opt-in, default OFF): pose every looping animation still and stop the
 /// decorative motion sensor, without requiring system Low Power Mode or system Reduce Motion.
-/// Toggled from Settings → Appearance. Mirror in Kotlin via `NoopPrefs.quietMotion`.
+/// Toggled from Settings → Appearance.
+///
+/// **Apple-only for now — there is no Kotlin twin yet, and no parity to claim.** Android's
+/// `rememberPoseStill()` reads two signals (system Reduce Motion ‖ battery saver); this third one is
+/// tracked as #941. The KEY STRING is the cross-platform contract, so it is fixed here and Android must
+/// adopt `"noop.quietMotion"` verbatim when it lands — a `.noopbak` round-trip carries the setting by
+/// key, not by symbol name.
 public enum QuietMotionPrefs {
     /// The `@AppStorage` / `UserDefaults` key shared by the Settings toggle and `NoopMotionState`.
     public static let enabledKey = "noop.quietMotion"

--- a/Packages/StrandDesign/Sources/StrandDesign/NoopMotion.swift
+++ b/Packages/StrandDesign/Sources/StrandDesign/NoopMotion.swift
@@ -56,6 +56,96 @@ public enum NoopMotion {
     }
 }
 
+// MARK: - Quiet Motion — the ONE gate every never-settling animation consults
+//
+// #909 taught the live gauges to pose still in Low Power Mode, but it read the flag inside
+// `Strand/Liquid` and so could only reach the liquid layer. Everything else that never settles —
+// the day-cycle atmosphere drift, the guardian breath, the connection halo — kept running, and a
+// user in Low Power Mode still paid for it. The Android half (#911) had already put its gate in
+// `com.noop.ui.NoopMotion`, one process-wide monitor read through `rememberPoseStill()`; this is
+// that same shape on Apple, moved down into StrandDesign so the design system's own surfaces can
+// reach it too (`LiquidPowerMonitor` in the app target could not).
+//
+// Three signals, OR-ed:
+//   1. `@Environment(\.accessibilityReduceMotion)` — the system-wide setting. Supplied by the call
+//      site, because only a View can read the environment.
+//   2. Low Power Mode — the OS-level "stop discretionary work" signal.
+//   3. "Reduce motion in NOOP" — an in-app preference, default OFF, for people who want the app
+//      quiet without putting the whole phone in battery saver.
+
+/// "Reduce motion in NOOP" (opt-in, default OFF): pose every looping animation still and stop the
+/// decorative motion sensor, without requiring system Low Power Mode or system Reduce Motion.
+/// Toggled from Settings → Appearance. Mirror in Kotlin via `NoopPrefs.quietMotion`.
+public enum QuietMotionPrefs {
+    /// The `@AppStorage` / `UserDefaults` key shared by the Settings toggle and `NoopMotionState`.
+    public static let enabledKey = "noop.quietMotion"
+}
+
+/// Publishes the two motion signals that have no SwiftUI environment key — Low Power Mode and the
+/// in-app "Reduce motion in NOOP" preference — so any view can pose its looping animation still.
+///
+/// A singleton with ONE `NotificationCenter` observer rather than a per-view `DisposableEffect`,
+/// for the reason #911 gives on the Android side: the liquid primitives alone have dozens of call
+/// sites, and registering/unregistering an observer as gauges scroll in and out of view would be
+/// churn introduced by the very change that exists to remove per-frame work.
+///
+/// Worth doing because a continuously-animating `Canvas` is not free: measured on an iPhone 17 Pro
+/// simulator seeded with a real 746 MB store, the default Today screen sitting idle costs ~18% of a
+/// CPU core in BOTH Debug and Release, and 0.0% once the live surfaces pose still.
+@MainActor
+public final class NoopMotionState: ObservableObject {
+    public static let shared = NoopMotionState()
+
+    /// System Low Power Mode / battery saver. Live: `.NSProcessInfoPowerStateDidChange` means
+    /// toggling the setting takes effect without a relaunch.
+    @Published public private(set) var isLowPower: Bool
+
+    /// The in-app "Reduce motion in NOOP" preference. Kept in step with `UserDefaults` so a
+    /// non-SwiftUI reader (the motion sensor) and the `@AppStorage` toggle never disagree.
+    @Published public private(set) var quietMotion: Bool
+
+    private init() {
+        isLowPower = ProcessInfo.processInfo.isLowPowerModeEnabled
+        quietMotion = UserDefaults.standard.bool(forKey: QuietMotionPrefs.enabledKey)
+        NotificationCenter.default.addObserver(
+            forName: .NSProcessInfoPowerStateDidChange, object: nil, queue: .main
+        ) { [weak self] _ in
+            MainActor.assumeIsolated {
+                self?.isLowPower = ProcessInfo.processInfo.isLowPowerModeEnabled
+            }
+        }
+        // `@AppStorage` writes straight to UserDefaults without telling us, so mirror the store.
+        // `.didChangeNotification` is the only signal that covers a write from any target.
+        NotificationCenter.default.addObserver(
+            forName: UserDefaults.didChangeNotification, object: UserDefaults.standard, queue: .main
+        ) { [weak self] _ in
+            MainActor.assumeIsolated {
+                let now = UserDefaults.standard.bool(forKey: QuietMotionPrefs.enabledKey)
+                if self?.quietMotion != now { self?.quietMotion = now }
+            }
+        }
+    }
+
+    /// The gate. `reduceMotion` comes from `@Environment(\.accessibilityReduceMotion)` at the call
+    /// site — the environment is the only place SwiftUI publishes it, and reading it imperatively
+    /// would not invalidate the view when the user changes the setting.
+    ///
+    /// ```swift
+    /// @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    /// @ObservedObject private var motion = NoopMotionState.shared
+    /// private var poseStill: Bool { motion.poseStill(reduceMotion) }
+    /// ```
+    @inline(__always)
+    public func poseStill(_ reduceMotion: Bool) -> Bool {
+        reduceMotion || isLowPower || quietMotion
+    }
+
+    /// The two non-environment signals on their own, for an imperative (non-View) reader that
+    /// supplies its own Reduce Motion read — e.g. the decorative motion sensor deciding whether to
+    /// start at all. Views must use `poseStill(_:)` instead so they invalidate correctly.
+    public var poseStillIgnoringReduceMotion: Bool { isLowPower || quietMotion }
+}
+
 // MARK: - CountUpText
 //
 // Animates a numeric value counting up (or down) to its latest value whenever `value`

--- a/Packages/StrandDesign/Sources/StrandDesign/StatePill.swift
+++ b/Packages/StrandDesign/Sources/StrandDesign/StatePill.swift
@@ -77,6 +77,11 @@ public struct ConnectionDot: View {
 
     @State private var animate = false
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    /// Low Power Mode / "Reduce motion in NOOP". This halo is a `repeatForever` loop that never
+    /// settles and is on screen for long stretches — a connected strap in Settings, a backfill on
+    /// every scaffolded screen — so it belongs behind the same gate as the liquid surfaces.
+    @ObservedObject private var motion = NoopMotionState.shared
+    private var poseStill: Bool { motion.poseStill(reduceMotion) }
     @Environment(\.colorScheme) private var scheme
 
     public init(tone: StrandTone = .positive, pulsing: Bool = false, size: CGFloat = 9) {
@@ -107,10 +112,11 @@ public struct ConnectionDot: View {
                 .shadow(color: tone.color.opacity(0.8), radius: pulsing ? 4 : 2)
         }
         .frame(width: size, height: size)
-        // Honour Reduce Motion: don't kick off the looping pulse (settles at the
-        // resting dot) and never attach the repeatForever breathe animation.
-        .onAppear { if pulsing && !reduceMotion { animate = true } }
-        .animation(pulsing && !reduceMotion ? StrandMotion.breathe : nil, value: animate)
+        // Honour the quiet-motion gate (system Reduce Motion, Low Power Mode, or the in-app
+        // toggle): don't kick off the looping pulse (it settles at the resting dot) and never
+        // attach the repeatForever breathe animation.
+        .onAppear { if pulsing && !poseStill { animate = true } }
+        .animation(pulsing && !poseStill ? StrandMotion.breathe : nil, value: animate)
         .accessibilityHidden(true)
     }
 }

--- a/Packages/StrandDesign/Sources/StrandDesign/TimeOfDayBackground.swift
+++ b/Packages/StrandDesign/Sources/StrandDesign/TimeOfDayBackground.swift
@@ -11,7 +11,8 @@ import SwiftUI
 //    very low opacity; stars are tiny crisp dots. Beauty = restraint, spacing, type, motion.
 //  - TOKENS first (`StrandPalette`). The only literal hexes are the few subtle atmosphere
 //    tints the spec calls for (warm peach lift, indigo wash, etc.) — kept deliberately faint.
-//  - Reduce Motion pins every drifting element still (no looping translation).
+//  - Reduce Motion — and Low Power Mode, and the in-app "Reduce motion in NOOP" toggle —
+//    pin every drifting element still (no looping translation, and the frame loop is `paused:`).
 //  - Light mode is even MORE restrained: warm-paper tints, fewer/softer elements.
 //  - CPU-light: drift runs off a single `TimelineView(.animation)` tick that the system
 //    pauses when the view is off-screen; no per-frame allocation, no timers we own.
@@ -52,14 +53,19 @@ public struct TimeOfDayBackground: View {
 
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @Environment(\.colorScheme) private var colorScheme
+    /// Low Power Mode and the in-app "Reduce motion in NOOP" toggle, neither of which has a SwiftUI
+    /// environment key. The Android twin (`TimeOfDayBackground.kt`) has consulted battery saver since
+    /// #911; this side was left reading Reduce Motion alone.
+    @ObservedObject private var motion = NoopMotionState.shared
 
     public init(dayPart: DayPart, animated: Bool = true) {
         self.dayPart = dayPart
         self.animated = animated
     }
 
-    /// Whether drifting elements should actually move (caller opted in AND Reduce Motion is off).
-    private var drift: Bool { animated && !reduceMotion }
+    /// Whether drifting elements should actually move: the caller opted in AND nothing is asking
+    /// for quiet (system Reduce Motion, Low Power Mode, or the in-app toggle).
+    private var drift: Bool { animated && !motion.poseStill(reduceMotion) }
 
     public var body: some View {
         GeometryReader { geo in

--- a/Packages/StrandDesign/Tests/StrandDesignTests/QuietMotionCoverageTests.swift
+++ b/Packages/StrandDesign/Tests/StrandDesignTests/QuietMotionCoverageTests.swift
@@ -157,8 +157,12 @@ final class QuietMotionCoverageTests: XCTestCase {
                       "Low Power Mode must stay live without a relaunch")
         XCTAssertTrue(src.contains("UserDefaults.didChangeNotification"),
                       "the in-app toggle must stay live — @AppStorage writes straight to UserDefaults")
+        // The key string is the cross-platform contract — it travels in .noopbak by key, not by symbol
+        // name — so it is pinned here even though Android has not adopted it yet (#941). Pinning it now is
+        // the point: whoever writes the Kotlin side must match this string exactly, and a later edit here
+        // would silently break a round-trip that by then has real users.
         XCTAssertEqual(QuietMotionPrefs.enabledKey, "noop.quietMotion",
-                       "the key is the cross-platform contract with Kotlin NoopPrefs.quietMotion")
+                       "the key Android must adopt verbatim when the third signal lands (#941)")
     }
 
     /// Posing the picture still while the sensor keeps running saves nothing. `onDisappear` is not

--- a/Packages/StrandDesign/Tests/StrandDesignTests/QuietMotionCoverageTests.swift
+++ b/Packages/StrandDesign/Tests/StrandDesignTests/QuietMotionCoverageTests.swift
@@ -1,0 +1,179 @@
+import XCTest
+@testable import StrandDesign
+
+/// A source census: every never-settling animation in the Apple UI must consult the quiet-motion gate.
+///
+/// This is the Apple twin of Android's `PoseStillCoverageTest` (#911), and it exists for the reason
+/// that test gives: a survey done by eye misses surfaces. #909 gated the liquid layer and stopped
+/// there, so the day-cycle atmosphere drift, the guardian breath, the two connection-dot halos and
+/// the onboarding glows all kept looping in Low Power Mode — and `RecordingStatusLight` looped under
+/// system Reduce Motion too, which was already a bug. None of that was visible in review.
+///
+/// It also pins that the gate keeps reading all three signals. Losing one half is invisible: the
+/// screen looks right in whichever mode still works.
+///
+/// Lives in the StrandDesign package because `swift-packages.yml` runs it by default, while the app
+/// targets' `StrandTests` only runs under `xcodebuild` (and `app-build.yml` is disabled).
+final class QuietMotionCoverageTests: XCTestCase {
+
+    /// Directories that ship Apple UI. `android/` has its own census in `PoseStillCoverageTest`.
+    private static let uiRoots = [
+        "Strand",
+        "StrandiOS",
+        "StrandiOSShared",
+        "StrandiOSWidgets",
+        "Packages/StrandDesign/Sources",
+        "NOOPWatch",
+        "NOOPWatchComplications",
+    ]
+
+    /// A loop that never settles: an indefinitely repeating implicit animation, or a per-frame
+    /// `TimelineView` clock. `TimelineView(.periodic…)` is deliberately NOT censused — a 1 s or 60 s
+    /// clock is a label ticking over, not the per-frame drawing this gate exists to stop.
+    private static let loopMarkers = ["repeatForever(", "TimelineView(.animation"]
+
+    /// Files allowed to contain a marker without naming the gate, each with the reason.
+    private static let exemptions: [String: String] = [
+        // Defines `StrandMotion.breathe` (and demonstrates it in a `#if DEBUG` preview). Every
+        // shipping call site of it is censused separately by `testBreatheCallSitesConsultTheGate`.
+        "Packages/StrandDesign/Sources/StrandDesign/Motion.swift":
+            "declares the breathe primitive; call sites are censused separately",
+    ]
+
+    private func repoRoot() throws -> URL {
+        // .../Packages/StrandDesign/Tests/StrandDesignTests/QuietMotionCoverageTests.swift -> repo root
+        let root = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()   // StrandDesignTests
+            .deletingLastPathComponent()   // Tests
+            .deletingLastPathComponent()   // StrandDesign
+            .deletingLastPathComponent()   // Packages
+            .deletingLastPathComponent()   // repo root
+        // FAIL rather than skip when the tree cannot be found: a census that silently passes because
+        // it censused nothing is worse than no census (the Android twin makes the same choice).
+        guard FileManager.default.fileExists(atPath: root.appendingPathComponent("project.yml").path) else {
+            throw Failure("repo root not found from #filePath (looked at \(root.path))")
+        }
+        return root
+    }
+
+    private struct Failure: Error, CustomStringConvertible {
+        let description: String
+        init(_ d: String) { description = d }
+    }
+
+    private func swiftFiles(under root: URL) -> [(rel: String, text: String)] {
+        var out: [(String, String)] = []
+        for dir in Self.uiRoots {
+            let base = root.appendingPathComponent(dir)
+            guard let e = FileManager.default.enumerator(at: base, includingPropertiesForKeys: nil) else { continue }
+            for case let url as URL in e where url.pathExtension == "swift" {
+                guard let text = try? String(contentsOf: url, encoding: .utf8) else { continue }
+                let rel = url.path.replacingOccurrences(of: root.path + "/", with: "")
+                out.append((rel, text))
+            }
+        }
+        return out
+    }
+
+    /// Strip `//` line comments so a marker merely *described* in prose is not censused as code.
+    private func codeLines(_ text: String) -> [String] {
+        text.split(separator: "\n", omittingEmptySubsequences: false).map { line in
+            let s = String(line)
+            guard let r = s.range(of: "//") else { return s }
+            return String(s[s.startIndex..<r.lowerBound])
+        }
+    }
+
+    // MARK: - The census
+
+    func testEveryNeverSettlingAnimationConsultsTheQuietMotionGate() throws {
+        let root = try repoRoot()
+        let files = swiftFiles(under: root)
+        XCTAssertGreaterThan(files.count, 100, "census found almost no Swift — the roots are wrong")
+
+        var offenders: [String] = []
+        var censused = 0
+        for (rel, text) in files {
+            let code = codeLines(text)
+            let hits = code.enumerated().filter { _, line in
+                Self.loopMarkers.contains { line.contains($0) }
+            }
+            guard !hits.isEmpty else { continue }
+            censused += 1
+            if Self.exemptions[rel] != nil { continue }
+            guard !text.contains("NoopMotionState") else { continue }
+            for (i, line) in hits {
+                offenders.append("\(rel):\(i + 1): \(line.trimmingCharacters(in: .whitespaces))")
+            }
+        }
+
+        // The census must actually find the known loops; a zero-hit run means the markers drifted.
+        XCTAssertGreaterThanOrEqual(censused, 6, "expected to census the known frame loops, found \(censused)")
+        XCTAssertTrue(offenders.isEmpty, """
+            \(offenders.count) never-settling animation(s) do not consult NoopMotionState. Gate them \
+            with `motion.poseStill(reduceMotion)`, or add the file to `exemptions` WITH a reason:
+            \(offenders.joined(separator: "\n"))
+            """)
+    }
+
+    /// `StrandMotion.breathe` is the shared `repeatForever` primitive, so a call site can loop forever
+    /// without the marker appearing on its own line. Census the call sites too.
+    func testBreatheCallSitesConsultTheGate() throws {
+        let root = try repoRoot()
+        var offenders: [String] = []
+        var sites = 0
+        for (rel, text) in swiftFiles(under: root) where rel != "Packages/StrandDesign/Sources/StrandDesign/Motion.swift" {
+            // The call site must name the composed condition AND the file must reach the shared
+            // monitor — checking only for the token would pass a `poseStill` that is a local alias
+            // for `reduceMotion`, which is exactly the state this change is fixing.
+            let reachesMonitor = text.contains("NoopMotionState")
+            for (i, line) in codeLines(text).enumerated() where line.contains("StrandMotion.breathe") {
+                sites += 1
+                if !line.contains("poseStill") || !reachesMonitor {
+                    offenders.append("\(rel):\(i + 1): \(line.trimmingCharacters(in: .whitespaces))")
+                }
+            }
+        }
+        XCTAssertGreaterThan(sites, 0, "no StrandMotion.breathe call sites censused — the marker drifted")
+        XCTAssertTrue(offenders.isEmpty, """
+            \(offenders.count) StrandMotion.breathe call site(s) are gated on Reduce Motion alone (or \
+            not at all). Pass the composed `poseStill` instead:
+            \(offenders.joined(separator: "\n"))
+            """)
+    }
+
+    // MARK: - The gate itself
+
+    /// Losing one signal is invisible in the app — the screen looks right in whichever mode still
+    /// works — so pin that all three are read, and that the OS flag stays live.
+    func testGateReadsAllThreeSignalsAndStaysLive() throws {
+        let root = try repoRoot()
+        let src = try String(contentsOf: root.appendingPathComponent(
+            "Packages/StrandDesign/Sources/StrandDesign/NoopMotion.swift"), encoding: .utf8)
+        XCTAssertTrue(src.contains("reduceMotion || isLowPower || quietMotion"),
+                      "poseStill must OR all three signals")
+        XCTAssertTrue(src.contains("isLowPowerModeEnabled"), "must read Low Power Mode")
+        XCTAssertTrue(src.contains("NSProcessInfoPowerStateDidChange"),
+                      "Low Power Mode must stay live without a relaunch")
+        XCTAssertTrue(src.contains("UserDefaults.didChangeNotification"),
+                      "the in-app toggle must stay live — @AppStorage writes straight to UserDefaults")
+        XCTAssertEqual(QuietMotionPrefs.enabledKey, "noop.quietMotion",
+                       "the key is the cross-platform contract with Kotlin NoopPrefs.quietMotion")
+    }
+
+    /// Posing the picture still while the sensor keeps running saves nothing. `onDisappear` is not
+    /// called when the app is backgrounded, and NOOP declares background modes, so without an
+    /// explicit app-boundary stop a decorative 60 Hz device-motion feed ran all day behind the lock
+    /// screen.
+    func testDecorativeMotionSensorStopsAtTheAppBoundary() throws {
+        let root = try repoRoot()
+        let src = try String(contentsOf: root.appendingPathComponent(
+            "Strand/Liquid/LiquidCore.swift"), encoding: .utf8)
+        XCTAssertTrue(src.contains("startDeviceMotionUpdates"), "this file owns the decorative sensor")
+        XCTAssertTrue(src.contains("didEnterBackgroundNotification"),
+                      "the sensor must stop when the app leaves the foreground")
+        XCTAssertTrue(src.contains("stopDeviceMotionUpdates"), "and must actually stop it")
+        XCTAssertTrue(src.contains("LiquidMotion.quietNow"),
+                      "starting the sensor must consult the quiet-motion gate, not only the view branch")
+    }
+}

--- a/Strand/Liquid/LiquidCore.swift
+++ b/Strand/Liquid/LiquidCore.swift
@@ -11,6 +11,7 @@
 //  that drifts and re-catches the light, a reflection that follows the tilt.
 
 import SwiftUI
+import StrandDesign   // NoopMotionState / QuietMotionPrefs — the shared quiet-motion gate
 #if canImport(UIKit)
 import UIKit
 #endif
@@ -87,15 +88,56 @@ final class LiquidMotion {
     private var started = false
     private var refCount = 0
 
-    private init() {}
+    private init() {
+        #if os(iOS) && !targetEnvironment(macCatalyst)
+        // Stop at the app boundary. `onDisappear` is NOT called when the app is backgrounded, and
+        // NOOP declares `bluetooth-central` + `location` background modes, so it keeps RUNNING
+        // behind the lock screen while a strap is connected — which meant a decorative 60 Hz
+        // accelerometer+gyro fusion kept being delivered all day for a picture nobody could see.
+        // That is the always-on half of this cost; posing the Canvas still never touched it.
+        let nc = NotificationCenter.default
+        nc.addObserver(forName: UIApplication.didEnterBackgroundNotification,
+                       object: nil, queue: .main) { [weak self] _ in self?.stop() }
+        nc.addObserver(forName: UIApplication.willEnterForegroundNotification,
+                       object: nil, queue: .main) { [weak self] _ in self?.startIfWanted() }
+        // Live response to all three quiet signals, so flipping Low Power Mode / Reduce Motion /
+        // the in-app toggle stops the sensor immediately rather than at the next screen change.
+        nc.addObserver(forName: .NSProcessInfoPowerStateDidChange,
+                       object: nil, queue: .main) { [weak self] _ in self?.syncToPolicy() }
+        nc.addObserver(forName: UIAccessibility.reduceMotionStatusDidChangeNotification,
+                       object: nil, queue: .main) { [weak self] _ in self?.syncToPolicy() }
+        nc.addObserver(forName: UserDefaults.didChangeNotification,
+                       object: UserDefaults.standard, queue: .main) { [weak self] _ in self?.syncToPolicy() }
+        #endif
+    }
+
+    /// The three signals that mean "no decorative motion", read imperatively. Views read
+    /// `NoopMotionState` instead (it publishes, so they invalidate); this is the sensor's own read,
+    /// off the same underlying facts, so the two can never disagree.
+    static var quietNow: Bool {
+        if ProcessInfo.processInfo.isLowPowerModeEnabled { return true }
+        if UserDefaults.standard.bool(forKey: QuietMotionPrefs.enabledKey) { return true }
+        #if canImport(UIKit) && !os(watchOS)
+        if UIAccessibility.isReduceMotionEnabled { return true }
+        #endif
+        return false
+    }
 
     /// Ref-counted start/stop so the sensor only runs while a liquid screen is visible.
+    ///
+    /// The gate is checked HERE and not only at the view branch: a posed vessel renders from the
+    /// static path and never calls this, but a future call site that forgets would otherwise
+    /// re-arm a 60 Hz sensor the user has explicitly asked to be rid of.
     func acquire() {
         refCount += 1
-        guard !started else { return }
+        startIfWanted()
+    }
+
+    private func startIfWanted() {
+        guard !started, refCount > 0, !LiquidMotion.quietNow else { return }
         started = true
         #if os(iOS) && !targetEnvironment(macCatalyst)
-        guard manager.isDeviceMotionAvailable else { return }
+        guard manager.isDeviceMotionAvailable else { started = false; return }
         manager.deviceMotionUpdateInterval = 1.0 / 60.0
         manager.startDeviceMotionUpdates(to: motionQueue) { [weak self] motion, _ in
             guard let self, let m = motion else { return }
@@ -125,12 +167,24 @@ final class LiquidMotion {
 
     func release() {
         refCount = max(0, refCount - 1)
-        guard refCount == 0, started else { return }
+        guard refCount == 0 else { return }
+        stop()
+    }
+
+    /// Stop the sensor but KEEP `refCount` — the screen is still mounted, we simply don't want the
+    /// hardware running (backgrounded, or the user asked for quiet). `startIfWanted` resumes it.
+    private func stop() {
+        guard started else { return }
         started = false
         #if os(iOS) && !targetEnvironment(macCatalyst)
         manager.stopDeviceMotionUpdates()
         #endif
         tilt = 0
+    }
+
+    /// Re-evaluate after a Low Power Mode / Reduce Motion / in-app-toggle change.
+    private func syncToPolicy() {
+        if LiquidMotion.quietNow { stop() } else { startIfWanted() }
     }
 }
 
@@ -285,30 +339,3 @@ func liquidWave(_ x: Double, amp: Double, R: Double, hw: Double,
 
 /// A monotonic seconds clock for a TimelineView date.
 @inline(__always) func liquidSeconds(_ date: Date) -> Double { date.timeIntervalSinceReferenceDate }
-
-// MARK: - Low Power Mode
-
-/// Publishes Low Power Mode so the live gauges can pose still, the way they already do for
-/// Reduce Motion. There is no SwiftUI environment key for this, so the primitives observe this
-/// instead; `.NSProcessInfoPowerStateDidChange` makes the switch live, with no relaunch needed.
-///
-/// Worth doing because a continuously-animating `Canvas` is not free: measured on an iPhone 17 Pro
-/// simulator seeded with a real 746 MB store, the default Today screen sitting idle costs ~18% of a
-/// CPU core in BOTH Debug and Release, and 0.0% once the live gauges pose still. Low Power Mode is
-/// the user telling the system to stop exactly that kind of work.
-@MainActor
-final class LiquidPowerMonitor: ObservableObject {
-    static let shared = LiquidPowerMonitor()
-    @Published private(set) var isLowPower: Bool
-
-    private init() {
-        isLowPower = ProcessInfo.processInfo.isLowPowerModeEnabled
-        NotificationCenter.default.addObserver(
-            forName: .NSProcessInfoPowerStateDidChange, object: nil, queue: .main
-        ) { [weak self] _ in
-            MainActor.assumeIsolated {
-                self?.isLowPower = ProcessInfo.processInfo.isLowPowerModeEnabled
-            }
-        }
-    }
-}

--- a/Strand/Liquid/LiquidPrimitives.swift
+++ b/Strand/Liquid/LiquidPrimitives.swift
@@ -7,6 +7,7 @@
 //  one shared tilt source. Colours come from StrandDesign tokens at the call site.
 
 import SwiftUI
+import StrandDesign   // NoopMotionState — the shared quiet-motion gate
 
 // MARK: - Renderers (pure GraphicsContext drawing)
 
@@ -221,7 +222,7 @@ struct LiquidVessel: View {
     var animated: Bool = true
 
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
-    @ObservedObject private var power = LiquidPowerMonitor.shared
+    @ObservedObject private var motion = NoopMotionState.shared
     @State private var sim: LiquidSim
     @State private var splashes = 0
 
@@ -233,7 +234,7 @@ struct LiquidVessel: View {
     }
 
     var body: some View {
-        if animated && !reduceMotion && !power.isLowPower { gauge } else { staticGauge }
+        if animated && !motion.poseStill(reduceMotion) { gauge } else { staticGauge }
     }
 
     private var gauge: some View {
@@ -276,11 +277,11 @@ struct LiquidTube: View {
     var animated: Bool = true
 
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
-    @ObservedObject private var power = LiquidPowerMonitor.shared
+    @ObservedObject private var motion = NoopMotionState.shared
     @State private var sim = LiquidSim(target: 0)
 
     var body: some View {
-        if animated && !reduceMotion && !power.isLowPower { liveTube } else { staticTube }
+        if animated && !motion.poseStill(reduceMotion) { liveTube } else { staticTube }
     }
 
     private var liveTube: some View {
@@ -313,10 +314,10 @@ struct LiquidThread: View {
     var animated: Bool = true
 
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
-    @ObservedObject private var power = LiquidPowerMonitor.shared
+    @ObservedObject private var motion = NoopMotionState.shared
 
     var body: some View {
-        if animated && !reduceMotion && !power.isLowPower { liveThread } else { staticThread }
+        if animated && !motion.poseStill(reduceMotion) { liveThread } else { staticThread }
     }
 
     private var liveThread: some View {

--- a/Strand/Liquid/LiquidSky.swift
+++ b/Strand/Liquid/LiquidSky.swift
@@ -66,9 +66,15 @@ struct LiquidSky: View {
     /// the atmosphere so the sky still reads under a full-height "sky behind cards" backdrop).
     var settleStrength: Double = 1
     @Environment(\.colorScheme) private var scheme
+    /// The call site already swaps in `LiquidSkyStatic` when motion is unwanted, but this view carried
+    /// no gate of its own — a second call site would have been silently ungated. `paused:` makes the
+    /// frame loop stand down from inside, so the gate travels with the view.
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @ObservedObject private var motion = NoopMotionState.shared
 
     var body: some View {
-        TimelineView(.animation(minimumInterval: 1.0 / 20.0)) { tl in
+        TimelineView(.animation(minimumInterval: 1.0 / 20.0,
+                                paused: motion.poseStill(reduceMotion))) { tl in
             let now = liquidSeconds(tl.date)
             let h = hour ?? liveHour()
             // The sky must dissolve into the SAME canvas colour the body uses (theme-aware surfaceBase),

--- a/Strand/Liquid/LiquidTodayView.swift
+++ b/Strand/Liquid/LiquidTodayView.swift
@@ -26,10 +26,11 @@ struct LiquidTodayView: View {
     // only publishes connect/discovery state, never HR. Injected at the app roots beside .environmentObject(model).
     @EnvironmentObject var ble: BLEManager
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
-    /// Low Power Mode poses the sky still too — the behaviour the comment on the sky branch below
-    /// has always described. There is no environment key for it, hence the shared monitor.
-    @ObservedObject private var powerMonitor = LiquidPowerMonitor.shared
-    private var lowPower: Bool { powerMonitor.isLowPower }
+    /// Low Power Mode — and the in-app "Reduce motion in NOOP" toggle — pose the sky still too, the
+    /// behaviour the comment on the sky branch below has always described. Neither has a SwiftUI
+    /// environment key, hence the shared monitor.
+    @ObservedObject private var motion = NoopMotionState.shared
+    private var poseStill: Bool { motion.poseStill(reduceMotion) }
 
     /// Shared with the real Today's card-customise editor so the two stay in sync.
     @AppStorage(DashboardCardPrefs.selectionKey) private var dashboardCardsRaw = ""
@@ -300,7 +301,7 @@ struct LiquidTodayView: View {
                     // "Sky behind cards" (opt-in): fill the whole backdrop with a softer settle so the sky
                     // reads under every card, instead of the default 340 top band that dissolves to canvas.
                     Group {
-                        if reduceMotion || lowPower || !dataLoaded { LiquidSkyStatic(hour: liveHour, settleStrength: skyBehindCards ? 0.78 : 1) }
+                        if poseStill || !dataLoaded { LiquidSkyStatic(hour: liveHour, settleStrength: skyBehindCards ? 0.78 : 1) }
                         else { LiquidSky(hour: liveHour, settleStrength: skyBehindCards ? 0.78 : 1) }
                     }
                     .frame(maxWidth: .infinity)

--- a/Strand/Liquid/LiveSessionView.swift
+++ b/Strand/Liquid/LiveSessionView.swift
@@ -21,6 +21,10 @@ struct LiveSessionView: View {
     @EnvironmentObject private var repo: Repository
     @EnvironmentObject private var profile: ProfileStore
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    /// Low Power Mode / the in-app quiet-motion toggle. The guardian breath is a `repeatForever`
+    /// animation that never settles, so it belongs behind the same gate as the liquid surfaces.
+    /// The Android twin gated `LiveSessionScreen`'s breath under battery saver in #911.
+    @ObservedObject private var motion = NoopMotionState.shared
 
     /// "Card transparency" (0–100, default 100): fades the live-session cards in lockstep with the frosted
     /// cards; content stays readable. Mirrors Kotlin `NoopPrefs.cardOpacityPercent`.
@@ -166,9 +170,10 @@ struct LiveSessionView: View {
         .accessibilityHint(Text("Long press to show or hide your heart rate."))
     }
 
-    /// Breathing is the "on track" signal: only in band, only once active, never for Reduce Motion.
+    /// Breathing is the "on track" signal: only in band, only once active, never when anything is
+    /// asking for quiet (Reduce Motion, Low Power Mode, or "Reduce motion in NOOP").
     private var isBreathing: Bool {
-        !reduceMotion
+        !motion.poseStill(reduceMotion)
             && runner.output?.status == .active
             && runner.output?.position == .inBand
     }

--- a/Strand/Onboarding/OnboardingWizard.swift
+++ b/Strand/Onboarding/OnboardingWizard.swift
@@ -47,6 +47,10 @@ public struct OnboardingWizard: View {
     @State private var step: Step = .welcome
     @State private var glow = false
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    /// Low Power Mode / "Reduce motion in NOOP" pose these looping glows still too. Onboarding is
+    /// first-run only, but a `repeatForever` is a `repeatForever` wherever it lives.
+    @ObservedObject private var motion = NoopMotionState.shared
+    private var poseStill: Bool { motion.poseStill(reduceMotion) }
 
     public var body: some View {
         ZStack {
@@ -91,7 +95,7 @@ public struct OnboardingWizard: View {
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .background(StrandPalette.surfaceBase.ignoresSafeArea())
         // Reduce Motion: leave the ambient bloom at its resting frame (no breathing).
-        .onAppear { if !reduceMotion { glow = true } }
+        .onAppear { if !poseStill { glow = true } }
         // Isolated live observation — a hidden watcher slides Scan → celebration on bond
         // without subscribing the whole wizard to per-tick updates.
         .background(BondWatcher(onBonded: handleBond))
@@ -116,7 +120,7 @@ public struct OnboardingWizard: View {
             )
             .blendMode(.plusLighter)
             .opacity(glow ? 0.4 : 0.28)
-            .animation(StrandMotion.breathe(reduced: reduceMotion), value: glow)
+            .animation(StrandMotion.breathe(reduced: poseStill), value: glow)
             .ignoresSafeArea()
 
             // A faint indigo wash from the top — instrument-grade depth.
@@ -449,6 +453,10 @@ private struct ExpectationsStep: View {
 private struct BluetoothStep: View {
     @State private var pulse = false
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    /// Low Power Mode / "Reduce motion in NOOP" pose these looping glows still too. Onboarding is
+    /// first-run only, but a `repeatForever` is a `repeatForever` wherever it lives.
+    @ObservedObject private var motion = NoopMotionState.shared
+    private var poseStill: Bool { motion.poseStill(reduceMotion) }
     var body: some View {
         StepShell(title: String(localized: "A quick word before we connect"),
                   subtitle: String(localized: "\(Platform.deviceNoun) will ask for Bluetooth in a moment.")) {
@@ -482,7 +490,7 @@ private struct BluetoothStep: View {
                     .frame(maxWidth: 460)
             }
         }
-        .onAppear { if !reduceMotion { withAnimation(StrandMotion.breathe) { pulse = true } } }
+        .onAppear { if !poseStill { withAnimation(StrandMotion.breathe) { pulse = true } } }
     }
 }
 
@@ -942,6 +950,10 @@ private struct ImportStep: View {
 private struct NotificationsStep: View {
     @State private var pulse = false
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    /// Low Power Mode / "Reduce motion in NOOP" pose these looping glows still too. Onboarding is
+    /// first-run only, but a `repeatForever` is a `repeatForever` wherever it lives.
+    @ObservedObject private var motion = NoopMotionState.shared
+    private var poseStill: Bool { motion.poseStill(reduceMotion) }
     var body: some View {
         StepShell(title: String(localized: "Stay in the loop"),
                   subtitle: String(localized: "NOOP can tap your wrist when your \(Platform.deviceNoun) needs you. No glance at the screen required.")) {
@@ -994,7 +1006,7 @@ private struct NotificationsStep: View {
                 #endif
             }
         }
-        .onAppear { if !reduceMotion { withAnimation(StrandMotion.breathe) { pulse = true } } }
+        .onAppear { if !poseStill { withAnimation(StrandMotion.breathe) { pulse = true } } }
     }
 }
 
@@ -1115,6 +1127,10 @@ private struct RadarSweep: View {
     @State private var angle: Double = 0
     @State private var ping = false
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    /// Low Power Mode / "Reduce motion in NOOP" pose these looping glows still too. Onboarding is
+    /// first-run only, but a `repeatForever` is a `repeatForever` wherever it lives.
+    @ObservedObject private var motion = NoopMotionState.shared
+    private var poseStill: Bool { motion.poseStill(reduceMotion) }
 
     var body: some View {
         GeometryReader { geo in
@@ -1165,7 +1181,7 @@ private struct RadarSweep: View {
         .onChangeCompat(of: active) { isActive in
             if isActive { startSweep() }
         }
-        .animation(StrandMotion.breathe(reduced: reduceMotion), value: ping)
+        .animation(StrandMotion.breathe(reduced: poseStill), value: ping)
     }
 
     private func sweepWedge(size: CGFloat) -> some View {
@@ -1193,7 +1209,7 @@ private struct RadarSweep: View {
     private func startSweep() {
         // Reduce Motion: keep the wedge still (the static rings/crosshairs/blip
         // still convey "searching" / "found") instead of spinning forever.
-        guard !reduceMotion else { return }
+        guard !poseStill else { return }
         angle = 0
         withAnimation(.linear(duration: 2.4).repeatForever(autoreverses: false)) {
             angle = 360

--- a/Strand/Screens/SettingsView.swift
+++ b/Strand/Screens/SettingsView.swift
@@ -99,8 +99,8 @@ struct SettingsView: View {
     // Card-surface opacity percent (100 = solid). Reactive — moving the slider live-updates every card.
     @AppStorage(CardAppearancePrefs.opacityKey) private var cardOpacityPercent = CardAppearancePrefs.defaultPercent
     // "Reduce motion in NOOP" (default OFF): pose every looping animation still and stop the decorative
-    // tilt sensor, without needing system Low Power Mode or system Reduce Motion. Mirrors Kotlin
-    // NoopPrefs.quietMotion.
+    // tilt sensor, without needing system Low Power Mode or system Reduce Motion. Apple-only so far —
+    // Android has no such toggle yet and its gate reads two signals, not three (#941).
     @AppStorage(QuietMotionPrefs.enabledKey) private var quietMotion = false
     // Hydration tracker (opt-in, MVP). Default OFF — when off the hydration dashboard card + detail are
     // hidden. Mirrors the Android pref so the toggle reads the same on both platforms.

--- a/Strand/Screens/SettingsView.swift
+++ b/Strand/Screens/SettingsView.swift
@@ -98,6 +98,10 @@ struct SettingsView: View {
     @AppStorage(SkyBehindCardsPrefs.enabledKey) private var skyBehindCards = true
     // Card-surface opacity percent (100 = solid). Reactive — moving the slider live-updates every card.
     @AppStorage(CardAppearancePrefs.opacityKey) private var cardOpacityPercent = CardAppearancePrefs.defaultPercent
+    // "Reduce motion in NOOP" (default OFF): pose every looping animation still and stop the decorative
+    // tilt sensor, without needing system Low Power Mode or system Reduce Motion. Mirrors Kotlin
+    // NoopPrefs.quietMotion.
+    @AppStorage(QuietMotionPrefs.enabledKey) private var quietMotion = false
     // Hydration tracker (opt-in, MVP). Default OFF — when off the hydration dashboard card + detail are
     // hidden. Mirrors the Android pref so the toggle reads the same on both platforms.
     @AppStorage(HydrationStore.enabledKey) private var hydrationEnabled = false
@@ -770,6 +774,22 @@ struct SettingsView: View {
                 #endif
 
                 Divider().overlay(StrandPalette.hairline).padding(.vertical, 4)
+                // MARK: Reduce motion in NOOP — pose every looping animation still and stop the tilt
+                // sensor, WITHOUT requiring system Low Power Mode. Off by default; system Reduce Motion
+                // and Low Power Mode already force the same behaviour, this is the third, in-app signal.
+                Toggle(isOn: $quietMotion) {
+                    Text("Reduce motion in NOOP")
+                        .font(StrandFont.subhead)
+                        .foregroundStyle(StrandPalette.textPrimary)
+                }
+                .toggleStyle(.switch)
+                .tint(StrandPalette.accent)
+                Text("Holds the liquid gauges, the sky and the tilt response still, and turns off the motion sensor that drives them. Saves battery. Low Power Mode and the system Reduce Motion setting already do this.")
+                    .font(StrandFont.caption)
+                    .foregroundStyle(StrandPalette.textTertiary)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+
                 // MARK: Day-cycle background — the time-of-day scene behind Today (#698). On by default.
                 // Off swaps it for the plain dark canvas for people who find the moving scene distracting.
                 Toggle(isOn: $showDayCycleBackground) {

--- a/Strand/Screens/TodayView.swift
+++ b/Strand/Screens/TodayView.swift
@@ -4602,6 +4602,13 @@ private struct RecordingStatusLight: View {
     /// Drives the syncing pulse; toggled in `.task` while an offload runs (never during body eval).
     @State private var pulsing = false
 
+    /// This `repeatForever` ring had NO motion gate of any kind — it pulsed under system Reduce
+    /// Motion too, which was already a bug (the Android twin's ConnectionDot had the same one, fixed
+    /// in #911). It also ran precisely while the strap was offloading history, i.e. while the app was
+    /// already busy. Gated on all three quiet signals now.
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @ObservedObject private var motion = NoopMotionState.shared
+
     /// Colour for the light: green recording, amber last-synced, red not recording, accent for
     /// experimental history. Mirrors the prior `TodayView.recordingHue` semantics verbatim.
     private func hue(_ state: RecordingState) -> Color {
@@ -4648,10 +4655,12 @@ private struct RecordingStatusLight: View {
         .disabled(state == nil && !syncing)
         .accessibilityLabel(syncing ? syncingAccessibilityLabel
             : (state?.accessibilityText ?? String(localized: "Recording status, not shown for a past day")))
-        // Run the repeating pulse only while syncing; the `.task(id:)` auto-cancels when the flag flips,
-        // so there is no timer left running once the offload ends (or Today goes away).
+        // Run the repeating pulse only while syncing AND nothing is asking for quiet motion; the
+        // `.task(id:)` auto-cancels when the flag flips, so there is no timer left running once the
+        // offload ends (or Today goes away). Without the pulse the steady accent dot still says
+        // "syncing" — the information survives, only the loop stops.
         .task(id: syncing) {
-            guard syncing else { pulsing = false; return }
+            guard syncing, !motion.poseStill(reduceMotion) else { pulsing = false; return }
             withAnimation(.easeOut(duration: 1.1).repeatForever(autoreverses: false)) { pulsing = true }
         }
     }


### PR DESCRIPTION
perf(motion): make Low Power Mode mean "stop everything decorative" (#909)

#909 taught the live gauges to pose still in Low Power Mode, but it read the flag
inside `Strand/Liquid` and so could only ever reach the liquid layer. Two things it
did not reach:

**1. The tilt sensor kept running.** `LiquidMotion` starts `CMMotionManager` device
motion at **60 Hz** — accelerometer + gyro sensor fusion — to drive the decorative
slosh, the "the bubbles shift when you tilt the phone" effect. #909 poses the Canvas
still, and because `acquire()` sits on the animated branch the sensor did stop when a
gauge posed. But `onDisappear` is NOT called when the app is backgrounded, and NOOP
declares `bluetooth-central` + `location` background modes, so the app keeps RUNNING
behind the lock screen while a strap is connected. The 60 Hz fusion kept being
delivered all day, for a picture nobody could see. `LiquidMotion` now stops at the
app boundary and re-arms on foreground, and `startIfWanted()` consults the gate
itself rather than trusting every call site to route around it.

**2. Everything outside the liquid layer.** A census (`QuietMotionCoverageTests`,
the Apple twin of #911's `PoseStillCoverageTest`) found five more never-settling
loops, none of which #909 covered:

  - `TimeOfDayBackground` atmosphere drift — the Android twin has consulted battery
    saver since #911; this side read Reduce Motion alone.
  - `LiveSessionView`'s guardian breath (`repeatForever`).
  - `ConnectionDot` (StatePill) and `PulseDot` (Components) halos — on screen for
    long stretches: a connected strap in Settings, a backfill on every scaffold.
  - `RecordingStatusLight`'s sync ring, which had **no motion gate at all** — it
    pulsed under system Reduce Motion too, which was already a bug, and it ran
    precisely while the strap was offloading history. (Exactly the bug #911 found in
    the Android ConnectionDot.) The steady accent dot still says "syncing"; only the
    loop stops.
  - The onboarding glows and the radar sweep.

The gate moves out of `Strand/Liquid` and into `StrandDesign` as `NoopMotionState`,
so the design system's own surfaces can reach it — the Android twin has been in
`com.noop.ui.NoopMotion` since #911, read through `rememberPoseStill()`. Same shape:
one process-wide monitor, one observer, never per-view (the primitives alone have
dozens of call sites, and registering an observer as gauges scroll in and out would
be churn introduced by the change that exists to remove per-frame work).

**Three signals, OR-ed:** system Reduce Motion, Low Power Mode, and a new in-app
"Reduce motion in NOOP" toggle (Settings → Appearance, default OFF). The third is
the point of this change for the user who asked for it: he wants the app quiet
without putting the whole phone in battery saver. Key `noop.quietMotion`; live via
`UserDefaults.didChangeNotification`, so flipping it stops the sensor and poses the
surfaces without leaving the screen.

> **Correction.** An earlier revision of this description said the key mirrored a
> Kotlin pref `NoopPrefs.quietMotion`. **There is no such pref** — `grep -r
> quietMotion android/` returns nothing, and Android's gate is still the two-signal
> `rememberPoseStill() = rememberReduceMotion() || rememberPowerSaveMode()`
> (`NoopMotion.kt:149`). The first two signals reached parity in #909/#911; the third
> is Apple-only and is tracked as **#941**. The claim was worse than a stale
> reference: `NoopPrefs` does exist, so checking it finds the object and stops, and
> under this repo's parity contract "mirrors Kotlin X" reads as *parity already
> satisfied* — which is exactly what stops anyone noticing that it is not. The name
> was not even spelled the way that file spells things (`NoopPrefs` stores `KEY_*`
> constants, so the eventual symbol is `KEY_QUIET_MOTION`). Three source comments
> carried the same claim and are corrected in this PR.
>
> What the key string still is: the **cross-platform contract**, because `.noopbak`
> carries the setting by key rather than by symbol name. It stays pinned in
> `QuietMotionCoverageTests` so whoever writes the Kotlin side must adopt
> `"noop.quietMotion"` verbatim.

### Measured

iPhone 17 Pro simulator seeded with a real 746 MB store, Today idle, no touch input.
Three 15 s CPU windows after the first-run analysis had fully plateaued (that takes
~340 s at ~110% of a core on a freshly seeded DB — measuring before it settles is
what makes an idle number meaningless). Debug build.

| Today idle | CPU (% of one core) | RSS | load1 |
|---|---|---|---|
| animating (nothing asks for quiet) | 18.9 / 19.8 / 18.9 | 192 MB | 3.8 |
| **"Reduce motion in NOOP" ON** | **0.0 / 0.0 / 0.0** | 97-122 MB | 4.6 |
| system Reduce Motion ON (the #909 path) | 0.0 / 0.0 / 0.0 | 157-182 MB | 4.2 |
| animating, re-checked | 16.8 / 16.1 / 15.2 | 99-115 MB | 9.2-13.4 |

The last row is the not-in-quiet behaviour check: still animating, unchanged. It
reads lower than the first only because the machine was under 2-3x the load — per
process CPU-seconds are depressed by contention, so the two animating rows bracket
the real figure rather than either being it.

Two honest limits on those numbers:

  - I could not toggle real Low Power Mode in the simulator. The Low Power row is
    the Reduce Motion route, which is the same `staticGauge` / `LiquidSkyStatic` /
    `paused:` branch low-power users take. What is inferred, not exercised, is only
    that iOS reports the flag — which `IOSDiagnostics` already relies on.
  - **The sensor saving is not in that table.** `isDeviceMotionAvailable` is false in
    the simulator, so the 60 Hz CoreMotion feed never ran in any of these runs. The
    interval it requests (`deviceMotionUpdateInterval = 1/60`) and the missing
    background stop are read off the code, not measured. On device it is additional
    to the figures above, not included in them.

Scroll was not re-measured: the earlier investigation could not reproduce the user's
jank in the simulator at all (zero `body` rebuilds during driven scrolls, 60 fps),
and the simulator is 60 Hz where his iPhone 16 Pro is 120 Hz with an 8.33 ms budget.
Any claim that this fixes scrolling would be simulator-only and unsupported.

### Not gated, deliberately

  - One-shot animations (`CountUpText`, `staggeredAppear`, `LiquidPressStyle`).
    They settle and stop, so they are not the cost battery saver asks an app to
    avoid — same line #911 drew.
  - `TimelineView(.periodic…)` clocks. A 1 s elapsed-time label is not per-frame
    drawing.
  - The classic Today top-bar "Swipe / Tap" hint cycler. Two runloop wakeups per
    11.5 s, and it carries a discoverability affordance rather than decoration —
    removing it would cost information, not motion.
  - `BreathingView` / `WatchBreatheView` run a 20 Hz `Timer.publish` even when not
    breathing. Real, but bounded by that screen being on-screen, and fixing it means
    restructuring the publisher rather than adding a gate. Left for its own change.

### Verified

`QuietMotionCoverageTests` passes here, and **fails against the ungated tree** —
checked in both directions: removing the gate from `RecordingStatusLight` fails the
loop census by file and line, and aliasing `poseStill` back to bare `reduceMotion` in
`ConnectionDot` fails the breathe-call-site census (the call-site check requires the
file to reach `NoopMotionState`, not merely to contain the token). It fails rather
than skips when the repo root is unlocatable, and it pins that the gate still reads
all three signals and stays live — losing one half is invisible, since the screen
looks right in whichever mode still works.

`swift build` clean for StrandDesign; `xcodebuild` clean for NOOPiOS (simulator) and
the macOS Strand target; `Tools/i18n_audit.py --ci` green with the new Settings copy
translated into all eight catalog locales.


