### PR TITLE
Fix the HrBroadcaster subscription leak, and mark the v18AuxSample reader as intentionally unread

### DIFF
--- a/Packages/WhoopStore/Sources/WhoopStore/Database.swift
+++ b/Packages/WhoopStore/Sources/WhoopStore/Database.swift
@@ -655,6 +655,22 @@ extension WhoopStore {
         // point of this migration is that the data starts accruing NOW so a validated consumer is possible
         // LATER; landing a consumer at the same time would be scoring on evidence that does not exist yet.
         //
+        // CONSUMER STATUS — deliberately none, stated here so nobody has to re-derive it, and in the same
+        // shape as the `ppgWaveformSample` note above (v27). The writers are live on both platforms, but
+        // every `v18AuxSamples` call site on BOTH platforms is a TEST: no analytic, no score, no gate, no
+        // UI, no export reads a row. **Do NOT "clean up" the reader as dead code** — the rows are the point,
+        // and the reader is how they become reachable once a consumer is validated. The same applies to the
+        // four named columns added just below (`gravitySample.dynAccel`, `sleepStateSample.rawByte`,
+        // `skinTempSample.aux1Raw/aux2Raw`): they are SELECTed into their structs, and no consumer touches
+        // the properties, on purpose.
+        //
+        // Why the rows still matter even unread: before this migration these fields were not merely unread,
+        // they were DESTROYED. The strap trims its history the moment an offload is acked, so every one of
+        // them was unrecoverable. This migration converts permanent loss into retained-but-unread, which is
+        // the whole fix and is complete. Fifteen of the slots are unpinned bytes whose names deliberately
+        // assert nothing; wiring them to anything before a census would be exactly the overclaiming this
+        // project has already had to retract. The capture IS the deliverable.
+        //
         // The remaining fifteen v18 slots go to their OWN narrow table rather than fifteen more columns
         // (see `V18AuxCodec` for the wire format and the column-vs-blob tradeoff). Three reasons this is
         // a table and not another column on an existing row:

--- a/Strand/BLE/HrBroadcaster.swift
+++ b/Strand/BLE/HrBroadcaster.swift
@@ -60,7 +60,10 @@ public final class HrBroadcaster: NSObject, ObservableObject {
     /// first sample of a session; cleared on stop so a stale bpm can't outlive the broadcast.
     private var lastBpm: Int?
 
-    private var cancellables = Set<AnyCancellable>()
+    /// `private(set)` rather than `private` so `HrBroadcasterEncodeTests` can assert that ``bind(to:)``
+    /// leaves exactly one subscription however many times it is called — the leak it fixes is invisible
+    /// from the outside, so the count is the only thing a test can pin.
+    private(set) var cancellables = Set<AnyCancellable>()
 
     /// Diagnostic sink for the broadcast lifecycle, wired (when the composition root chooses to) to the
     /// SAME exportable strap log the WHOOP path uses, so a tester whose gym kit can't see NOOP has a
@@ -110,10 +113,19 @@ public final class HrBroadcaster: NSObject, ObservableObject {
     }
 
     /// Bind to a `LiveState` so every live HR change is broadcast automatically. Optional convenience the
-    /// app's composition root can call once; the broadcaster works equally well by polling
+    /// app's composition root can call; the broadcaster works equally well by polling
     /// ``update(heartRate:)`` directly. Observing `$heartRate` keeps this a pure CONSUMER of the existing
     /// live value — it never drives or mutates the WHOOP/central path.
+    ///
+    /// **Idempotent.** The previous subscription is cancelled before the new one is stored, so calling this
+    /// twice leaves exactly one sink. That is not hypothetical tidiness: the only call site is
+    /// `DataSourcesView.onAppear`, and `onAppear` fires on EVERY appearance — every tab switch back to Data
+    /// Sources, every push-and-pop — while the broadcaster itself is a `@StateObject` that outlives all of
+    /// them. Without this reset the sinks accumulated one per visit, and each one called
+    /// ``update(heartRate:)`` for the same sample, so a user who had visited the screen N times sent N
+    /// duplicate 0x2A37 notifications per heartbeat to every subscribed central.
     public func bind(to live: LiveState) {
+        cancellables.removeAll()
         live.$heartRate
             .removeDuplicates()
             .sink { [weak self] hr in self?.update(heartRate: hr) }

--- a/StrandTests/HrBroadcasterEncodeTests.swift
+++ b/StrandTests/HrBroadcasterEncodeTests.swift
@@ -53,6 +53,32 @@ final class HrBroadcasterEncodeTests: XCTestCase {
         XCTAssertEqual(HrBroadcaster.measurement(bpm: 1_000_000), [0x01, 0xFF, 0xFF])
     }
 
+    // MARK: - bind(to:) is idempotent (the duplicate-notification leak)
+
+    /// `bind(to:)`'s only call site is `DataSourcesView.onAppear`, which fires on EVERY appearance — every
+    /// tab switch back to Data Sources — while the broadcaster is a `@StateObject` that outlives all of
+    /// them. Each bind used to append another sink, so a user who had visited the screen N times sent N
+    /// duplicate 0x2A37 notifications per heartbeat. Binding must therefore be idempotent.
+    func testRepeatedBindLeavesExactlyOneSubscription() {
+        let broadcaster = HrBroadcaster(log: { _ in })
+        let live = LiveState()
+        XCTAssertEqual(broadcaster.cancellables.count, 0, "nothing subscribed before the first bind")
+        broadcaster.bind(to: live)
+        XCTAssertEqual(broadcaster.cancellables.count, 1)
+        for _ in 0..<10 { broadcaster.bind(to: live) }
+        XCTAssertEqual(broadcaster.cancellables.count, 1,
+                       "eleven binds must leave ONE sink, not eleven — see DataSourcesView.onAppear")
+    }
+
+    /// Re-binding to a DIFFERENT LiveState must also leave one sink: the old screen's state should stop
+    /// feeding the broadcaster entirely, not keep a second stream alive alongside the new one.
+    func testRebindingToAnotherLiveStateReplacesTheSubscription() {
+        let broadcaster = HrBroadcaster(log: { _ in })
+        broadcaster.bind(to: LiveState())
+        broadcaster.bind(to: LiveState())
+        XCTAssertEqual(broadcaster.cancellables.count, 1)
+    }
+
     // MARK: - Round-trip against the parser (the encoder is the parser's exact inverse)
 
     func testRoundTripThroughParser() {

--- a/android/app/src/main/java/com/noop/data/Entities.kt
+++ b/android/app/src/main/java/com/noop/data/Entities.kt
@@ -651,6 +651,21 @@ data class LiveSessionRow(
  * existing per-second tables widen rows that were already being written.
  *
  * INSTRUMENTATION ONLY: nothing reads these rows.
+ *
+ * CONSUMER STATUS — deliberately none, stated here so nobody has to re-derive it. The writer is live, but
+ * every `v18AuxSamples` call site on BOTH platforms is a TEST: no analytic, no score, no gate, no UI, no
+ * export reads a row. **Do NOT "clean up" the reader as dead code** — the rows are the point, and the
+ * reader is how they become reachable once a consumer is validated. The same applies to the four named
+ * columns v31/MIGRATION_24_25 added alongside this table (`gravitySample.dynAccel`,
+ * `sleepStateSample.rawByte`, `skinTempSample.aux1Raw/aux2Raw`): they are read into their entities and no
+ * consumer touches the properties, on purpose.
+ *
+ * Why the rows still matter unread: before this migration these fields were not merely unread, they were
+ * DESTROYED — the strap trims its history the moment an offload is acked, so each one was unrecoverable.
+ * This converts permanent loss into retained-but-unread, which is the whole fix and is complete. Fifteen
+ * of the slots are unpinned bytes whose names deliberately assert nothing; wiring them to anything before
+ * a census would be exactly the overclaiming this project has already had to retract. The capture IS the
+ * deliverable. Twin of the Swift `v31-deep-capture-channels` migration note in `Database.swift`.
  */
 @Entity(tableName = "v18AuxSample", primaryKeys = ["deviceId", "ts"])
 data class V18AuxSampleEntity(


### PR DESCRIPTION
Two small, independent fixes found while auditing what the app captures versus what it reads. Separate commits; either can be dropped without touching the other.

## 1. `HrBroadcaster.bind` stacked a subscription on every screen visit

`bind(to:)`'s only call site is `DataSourcesView.onAppear`, and `onAppear` fires on **every** appearance — every tab switch back to Data Sources, every push-and-pop — while the broadcaster is a `@StateObject` that outlives all of them. Each call appended another sink to `cancellables` and nothing removed one, so a user who had visited the screen N times sent **N duplicate 0x2A37 notifications per heartbeat** to every subscribed central (a Garmin, Zwift, a gym treadmill). The call site's own comment says "bind ... once", which is what it intended and not what `onAppear` does.

Fixed inside `bind(to:)` rather than at the call site, so it holds for any future caller: the previous subscription is cancelled before the new one is stored. Re-binding to a *different* `LiveState` also replaces rather than adds, so an old screen's state stops feeding the broadcaster instead of racing the new one.

`cancellables` becomes `private(set)` (internal get) purely so the regression test can pin the count — the leak is invisible from outside, so the number of sinks is the only observable that carries it.

**Verified:** `xcodebuild ... test -only-testing:StrandTests/HrBroadcasterEncodeTests` — 9 tests, 0 failures (2 new). I confirmed the new test **fails without the fix** (`("11") is not equal to ("1")`), so it covers the bug rather than passing vacuously.

Android has no twin — its `HrBroadcaster` has no `bind`; the Compose screen pushes samples in directly.

## 2. Say on the `v18AuxSample` migration that its unread reader is by design

`ppgWaveformSample`'s migration (v27) carries an explicit CONSUMER STATUS note ending *"Do NOT 'clean up' the reader as dead code: the rows are the point, and the reader is how they are reachable."* `v18AuxSample` (v31 / Room `MIGRATION_24_25`) is in exactly the same position — I checked, and every `v18AuxSamples` call site on **both** platforms is a test (Swift: `DeepCaptureChannelsTests`, `TimestampHealTests`; Kotlin: the reader exists in `WhoopDao`/`WhoopRepository` with no caller at all) — and carried no such note. A future tidy-up pass reading that migration cold would delete a reader that is deliberately unused, and with it the only route back to the banked rows.

Adds the equivalent note on both platforms, and records the part that is easy to lose from #848: before that migration these fields were not merely unread, they were **destroyed**. The strap trims its history the moment an offload is acked, so each one was unrecoverable and could never be censused. The migration converts permanent loss into retained-but-unread, which is the whole fix and is complete.

Also names the four sibling columns the same migration added (`gravitySample.dynAccel`, `sleepStateSample.rawByte`, `skinTempSample.aux1Raw/aux2Raw`), which are SELECTed into their structs with no consumer touching the properties, on purpose.

Comments only — no schema, no behaviour, no stored value changes.

## Verification

- `swift build` (WhoopStore) clean; macOS `Strand` builds (`app-build.yml` is disabled, so this was run locally).
- Android `assembleFullDebug` + `testFullDebugUnitTest` — **3209 tests, 0 failures**, counted from the JUnit XML rather than the wrapper exit code.
- `StrandTests/HrBroadcasterEncodeTests` — 9 tests, 0 failures.

Context for #2 is in #845, which I have commented on separately: the inventory question that issue opened is now finished, and only the per-signal "does this one deserve a consumer" question remains.
