### PR TITLE
Measure the REM-latency guard in minutes since onset, not as a fraction of the session (#930)

### DIFF
--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/SleepStagerV2.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/SleepStagerV2.swift
@@ -21,7 +21,8 @@ import WhoopProtocol
 // Cole–Kripke actigraphy grid, V2 stages each 30 s epoch from:
 //   1. per-night z-scored cardiorespiratory emissions (HR / HR-variability / movement);
 //   2. a per-night DEEP gate on the 11-min HR-flatness percentile (the strongest deep-vs-light separator);
-//   3. a soft sleep-cycle prior (deep concentrated early; REM suppressed in the first ~12% then rising);
+//   3. a soft sleep-cycle prior (deep concentrated early as a fraction of the session; REM rising with that
+//      same fraction, minus a REM-latency guard that decays over the first 60 MINUTES after sleep onset);
 //   4. a peak-motion (jerk) wake gate, thresholded RELATIVE to the night's own quiescent jerk floor — so
 //      it self-calibrates to the strap's gravity-decode scale and the wearer's fit, not a fixed g;
 //   5. an RR-RSA respiration-regularity term (regular breathing → deep, irregular → REM);
@@ -193,6 +194,13 @@ public enum SleepStagerV2 {
         let respReg: Double?    // RSA spectral peakedness in the 0.15–0.40 Hz band (breathing regularity)
         let clock: Double       // time-of-night fraction in [0, 1]
         let jerkScale: Double   // night quiescent jerk floor (median per-second jerk over the session)
+        /// Elapsed MINUTES from the session window start to this epoch's centre — the minute-domain twin of
+        /// `clock` (#930). `features()` cannot know where sleep actually began, so it fills this relative to
+        /// the window start; `stageEpochs` re-bases it onto the sleep onset its own first pass found, and
+        /// falls back to this window-relative value when a night never sustains sleep. Only the REM-latency
+        /// guard reads it — the deep term and the REM ramp stay fractions of the session, which is what they
+        /// are (see `cyclePrior`).
+        let minutesSinceOnset: Double
     }
 
     // MARK: - Feature extraction
@@ -272,6 +280,7 @@ public enum SleepStagerV2 {
         struct Raw {
             let start: Int; let hr: Double?; let hrVar: Double?; let hrFlat11: Double?
             let jerks: [Double]; let gapSec: Int; let jerkMax: Double; let respReg: Double?; let clock: Double
+            let minutes: Double
         }
         var raws: [Raw] = []
         var allJerks: [Double] = []
@@ -310,7 +319,8 @@ public enum SleepStagerV2 {
 
             raws.append(Raw(start: e, hr: hrMean, hrVar: hrVar, hrFlat11: hrFlat11,
                             jerks: jerks, gapSec: max(1, gseq.count - 1), jerkMax: jerkMax,
-                            respReg: respReg, clock: Double(e + 15 - start) / span))
+                            respReg: respReg, clock: Double(e + 15 - start) / span,
+                            minutes: Double(e + 15 - start) / 60.0))
             e += 30
         }
 
@@ -333,7 +343,7 @@ public enum SleepStagerV2 {
             feats.append(Epoch(
                 start: r.start, hr: r.hr, hrVar: r.hrVar, hrFlat11: r.hrFlat11,
                 moveFrac: Double(moves) / Double(r.gapSec), jerkMax: r.jerkMax, respReg: r.respReg,
-                clock: r.clock, jerkScale: jerkScale))
+                clock: r.clock, jerkScale: jerkScale, minutesSinceOnset: r.minutes))
         }
         return feats
     }
@@ -380,12 +390,70 @@ public enum SleepStagerV2 {
 
     // MARK: - Recipe staging
 
+    // ── the REM-latency guard (#930) ──────────────────────────────────────────────────────────────────
+
+    /// Log-odds penalty applied to the REM emission AT sleep onset. Unchanged in magnitude from the
+    /// `c < 0.12 ? 3.0 : 0.0` step this replaced: e⁻³ ≈ 0.05 on the REM emission — strong suppression that
+    /// sufficient evidence still overcomes, never a veto. Kept at the incumbent value deliberately, because
+    /// the sleep-accel grid ({cliff, graded} × {fraction, minutes} × K ∈ 1…8 × threshold, 210 cells) showed
+    /// every cell tying on accuracy, so nothing in the data discriminates K — and the smallest correct change
+    /// is to fix the UNITS and the SHAPE without also retuning a magnitude no measurement can justify.
+    static let remLatencyPenalty = 3.0
+
+    /// Minutes over which `remLatencyPenalty` decays linearly to zero, measured from sleep ONSET.
+    /// Against PSG truth on sleep-accel (n = 31 subjects), a guard reaching 45 min costs 0.36 % of all real
+    /// REM (1 subject affected) and one reaching 90 min costs 6.85 % (15 subjects); 60 min sits inside that
+    /// band, and because the penalty is GRADED rather than a cliff it is already down to ≤ 0.75 log-odds
+    /// (×0.47, vs ×0.05 at onset) across 45–60 min, so a genuine sleep-onset REM period late in the window is
+    /// held back rather than suppressed. 60 min also stops clear of the ~70–100 min population first-REM
+    /// latency, so the ramp is fully spent before real REM is expected.
+    static let remLatencyMinutes = 60.0
+
+    /// The guard itself: `K` at (and before) sleep onset, decaying linearly to 0 at `M0` minutes after it.
+    /// Clamped to `[0, K]` so a PRE-onset epoch — negative elapsed time, and unbounded when detection places
+    /// the window start hours early (#271) — can never be penalised harder than the onset instant itself.
+    static func remLatencyGuard(_ minutesSinceOnset: Double) -> Double {
+        remLatencyPenalty * min(1.0, max(0.0, 1.0 - minutesSinceOnset / remLatencyMinutes))
+    }
+
     /// Soft sleep-cycle prior added to the log-emission: deep concentrated early (decays, never hard-wiped);
-    /// REM suppressed in the first ~12 % (REM latency) then rising toward morning.
-    static func cyclePrior(_ c: Double) -> [String: Double] {
+    /// REM suppressed around sleep onset (REM latency) then rising toward morning.
+    ///
+    /// PROVENANCE of the constants: `1.2`, `0.55` and the `1.0` REM slope are hand-picked a priori from sleep
+    /// physiology and population base rates, never fit to labels — as is every other coefficient in this file.
+    /// `remLatencyPenalty` / `remLatencyMinutes` carry their own derivations above.
+    ///
+    /// UNITS, and why they differ per term (#930). The deep term and the `1.0 * c` REM ramp take `c`, the
+    /// fraction of the session — correctly, because both describe *where in the night* you are, a quantity
+    /// that is inherently proportional. The REM-LATENCY guard takes `minutesSinceOnset` instead, because
+    /// first-REM latency is an absolute physiological interval and not a proportion of how long you slept: on
+    /// sleep-accel (n = 30 subjects with a scorable first REM period) true latency is uncorrelated with
+    /// session duration (Pearson r = −0.058, Spearman −0.076), and re-expressing latency as a fraction makes
+    /// it MORE variable, not less (CV 0.617 as a fraction vs 0.537 in minutes). The `c < 0.12` step this
+    /// replaced therefore scaled a fixed physiological interval by session length: across one WHOOP 5 user's
+    /// own recorded nights it ranged 7.4–84.5 min, an 11× spread, for the same wearer and the same physiology.
+    static func cyclePrior(_ c: Double, _ minutesSinceOnset: Double) -> [String: Double] {
         ["deep": 1.2 * max(0.0, 1.0 - c / 0.55),
-         "rem": 1.0 * c - (c < 0.12 ? 3.0 : 0.0),
+         "rem": 1.0 * c - remLatencyGuard(minutesSinceOnset),
          "light": 0.0, "awake": 0.0]
+    }
+
+    /// Sustained non-wake run, in 30 s epochs, that establishes sleep onset — 10 epochs = 5 minutes.
+    /// Measured against PSG onset on sleep-accel (n = 31 subjects): bias −3.8 min, MAE 7.4 min.
+    static let onsetSustainedEpochs = 10
+
+    /// Index of the first epoch that begins a run of `onsetSustainedEpochs` consecutive non-"awake" labels,
+    /// or nil when the hypnogram never sustains sleep that long (a nap shorter than the rule, or an all-wake
+    /// window). Runs are counted in epochs, not wall clock, so a coverage gap that drops an epoch cannot
+    /// silently satisfy the rule with less evidence.
+    static func sustainedSleepOnset(_ labels: [String]) -> Int? {
+        var run = 0
+        for i in labels.indices {
+            if labels[i] == "awake" { run = 0; continue }
+            run += 1
+            if run >= onsetSustainedEpochs { return i - onsetSustainedEpochs + 1 }
+        }
+        return nil
     }
 
     /// Viterbi most-likely path over the per-epoch log-emissions with the sticky transition matrix and a
@@ -420,6 +488,15 @@ public enum SleepStagerV2 {
 
     /// Run the full recipe over a night's epochs and return one stage label per epoch (incl. "awake").
     /// All normalisation (z-scores, the HR-flatness percentile) is WITHIN the night.
+    ///
+    /// TWO PASSES (#930). The REM-latency guard is measured from sleep ONSET, and onset is itself a staging
+    /// output, so the recipe cannot know it while building the emissions. Pass 1 stages the night with the
+    /// guard DISABLED (`cyclePrior(c, .infinity)`) and reads the first sustained sleep run out of the result;
+    /// pass 2 adds the guard, re-based on that onset, and re-runs Viterbi. Only the guard differs between the
+    /// passes — every emission term, z-score and percentile is computed ONCE and reused — so the extra cost is
+    /// one Viterbi over an already-built lattice, not a second featurisation, and `stageSession` memoizes the
+    /// whole thing anyway. When no sustained run exists the origin falls back to the window start, which is
+    /// exactly the origin the shipped `c`-based guard used.
     static func stageEpochs(_ feats: [Epoch]) -> [String] {
         if feats.isEmpty { return [] }
 
@@ -464,11 +541,23 @@ public enum SleepStagerV2 {
                 "light": baseLogPrior["light"]!,
                 "awake": 1.0 * zmvv + awakeCardiac + baseLogPrior["awake"]!,
             ]
-            let pr = cyclePrior(f.clock)
+            // Guard DISABLED here (`.infinity` ⇒ `remLatencyGuard` = 0); pass 2 below adds it once onset is known.
+            let pr = cyclePrior(f.clock, .infinity)
             for s in stageNames { em[s]! += pr[s]! }
             if f.jerkMax > f.jerkScale * jerkFloorGateMult { em["awake"]! += motionGateBoost }
             if let rg = f.respReg { let z = zrg(rg); em["deep"]! += respWeight * z; em["rem"]! -= respWeight * z }
             seq.append(em)
+        }
+
+        // PASS 1 — stage without the REM-latency guard purely to locate sleep onset.
+        let provisional = viterbi(seq)
+        // Origin for the guard: the centre of the first sustained-sleep epoch, in the same window-relative
+        // minutes `features()` stamped on every epoch. No sustained run → 0.0, i.e. the window start.
+        let originMin = sustainedSleepOnset(provisional).map { feats[$0].minutesSinceOnset } ?? 0.0
+
+        // PASS 2 — apply the guard against minutes since THAT onset and re-run the lattice.
+        for i in feats.indices {
+            seq[i]["rem"]! -= remLatencyGuard(feats[i].minutesSinceOnset - originMin)
         }
         return viterbi(seq)
     }

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/MotionCorroboratedWakeTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/MotionCorroboratedWakeTests.swift
@@ -133,10 +133,10 @@ final class MotionCorroboratedWakeTests: XCTestCase {
     func testMotionQuiescentPredicate() {
         // A still epoch (no move, jerk at floor) is quiescent; an epoch with a jerk spike above the gate is not.
         let still = SleepStagerV2.Epoch(start: 0, hr: 58, hrVar: 1, hrFlat11: 1, moveFrac: 0.0, jerkMax: 0.001,
-                                        respReg: nil, clock: 0.5, jerkScale: 0.001)
+                                        respReg: nil, clock: 0.5, jerkScale: 0.001, minutesSinceOnset: 120)
         XCTAssertTrue(SleepStagerV2.motionQuiescent(still))
         let moved = SleepStagerV2.Epoch(start: 0, hr: 58, hrVar: 1, hrFlat11: 1, moveFrac: 0.3, jerkMax: 0.2,
-                                        respReg: nil, clock: 0.5, jerkScale: 0.001)
+                                        respReg: nil, clock: 0.5, jerkScale: 0.001, minutesSinceOnset: 120)
         XCTAssertFalse(SleepStagerV2.motionQuiescent(moved))
     }
 

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/SleepStagerV2Tests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/SleepStagerV2Tests.swift
@@ -93,14 +93,112 @@ final class SleepStagerV2Tests: XCTestCase {
 
     // MARK: - recipe invariants
 
-    /// The cycle prior concentrates deep early in the night and suppresses REM in the first ~12 %.
+    /// The cycle prior concentrates deep early in the night and suppresses REM near sleep onset.
     func testCyclePriorShapesDeepAndRem() {
-        let early = SleepStagerV2.cyclePrior(0.05)
-        let late = SleepStagerV2.cyclePrior(0.90)
+        let early = SleepStagerV2.cyclePrior(0.05, 3.0)
+        let late = SleepStagerV2.cyclePrior(0.90, 400.0)
         XCTAssertGreaterThan(early["deep"]!, late["deep"]!, "deep prior is higher early in the night")
         XCTAssertLessThan(early["rem"]!, late["rem"]!, "REM prior is suppressed early, rising toward morning")
         XCTAssertEqual(early["light"]!, 0.0)
         XCTAssertEqual(early["awake"]!, 0.0)
+    }
+
+    // MARK: - #930: the REM-latency guard is measured in MINUTES, not as a fraction of the session
+
+    /// THE point of #930, and the assertion the previous shape could not even express: a 10-hour night and a
+    /// 3-hour fragment must receive the SAME REM-latency guard at the same minute after sleep onset.
+    ///
+    /// Under the replaced `c < 0.12` step the two disagree by construction — 30 min into a 10 h night is
+    /// `c = 0.05` (suppressed by the full 3.0) while 30 min into a 3 h fragment is `c = 0.167` (not suppressed
+    /// at all), so the identical physiological instant got opposite treatment purely because of how long the
+    /// wearer stayed in bed. The guard is isolated from the `1.0 * c` REM ramp (which is CORRECTLY a fraction
+    /// of the session and legitimately differs between the two) by subtracting the ramp back out.
+    func testRemLatencyGuardIsIdenticalAcrossSessionLengths() {
+        let longNight = 10.0 * 60.0   // 600 min
+        let fragment = 3.0 * 60.0     // 180 min
+        for minutes in stride(from: 0.0, through: 180.0, by: 2.5) {
+            let cLong = minutes / longNight, cShort = minutes / fragment
+            // Strip the fraction-of-session REM ramp; what remains is the latency guard alone.
+            let guardLong = 1.0 * cLong - SleepStagerV2.cyclePrior(cLong, minutes)["rem"]!
+            let guardShort = 1.0 * cShort - SleepStagerV2.cyclePrior(cShort, minutes)["rem"]!
+            XCTAssertEqual(guardLong, guardShort, accuracy: 1e-12,
+                           "guard at \(minutes) min must not depend on session length "
+                           + "(10 h gave \(guardLong), 3 h gave \(guardShort))")
+            XCTAssertEqual(guardLong, SleepStagerV2.remLatencyGuard(minutes), accuracy: 1e-12)
+        }
+    }
+
+    /// Shape of the guard: full strength at onset, linear decay, exactly zero at and past `remLatencyMinutes`,
+    /// and clamped (never stronger than at onset) for the pre-onset epochs a mis-placed window start produces.
+    func testRemLatencyGuardShapeAndClamp() {
+        let k = SleepStagerV2.remLatencyPenalty, m0 = SleepStagerV2.remLatencyMinutes
+        XCTAssertEqual(SleepStagerV2.remLatencyGuard(0.0), k, accuracy: 1e-12, "full penalty at onset")
+        XCTAssertEqual(SleepStagerV2.remLatencyGuard(m0 / 2), k / 2, accuracy: 1e-12, "linear halfway")
+        XCTAssertEqual(SleepStagerV2.remLatencyGuard(m0), 0.0, accuracy: 1e-12, "spent at M0")
+        XCTAssertEqual(SleepStagerV2.remLatencyGuard(m0 + 500), 0.0, accuracy: 1e-12, "never negative later")
+        // #271 can place the window start hours before real onset; the guard must stay bounded there.
+        XCTAssertEqual(SleepStagerV2.remLatencyGuard(-240.0), k, accuracy: 1e-12, "clamped pre-onset")
+        XCTAssertEqual(SleepStagerV2.remLatencyGuard(.infinity), 0.0, accuracy: 1e-12,
+                       "the disabled-guard sentinel pass 1 uses must contribute nothing")
+        // Monotone non-increasing across the ramp.
+        var prev = Double.infinity
+        for m in stride(from: -60.0, through: 120.0, by: 1.0) {
+            let g = SleepStagerV2.remLatencyGuard(m)
+            XCTAssertLessThanOrEqual(g, prev + 1e-12, "guard must never increase with elapsed time")
+            prev = g
+        }
+    }
+
+    /// The 5-minute sustained-sleep onset rule (10 epochs on the 30 s grid), measured against PSG onset on
+    /// sleep-accel at bias −3.8 min / MAE 7.4 min. A shorter sleep run must NOT establish onset.
+    func testSustainedSleepOnsetRule() {
+        let wake = [String](repeating: "awake", count: 6)
+        // 9 epochs of sleep (4.5 min) is one short of the rule and must not count.
+        let brief = wake + [String](repeating: "light", count: 9) + wake
+        XCTAssertNil(SleepStagerV2.sustainedSleepOnset(brief))
+        // 10 epochs (5 min) does, and onset is the FIRST epoch of the run, not the tenth.
+        let sustained = wake + [String](repeating: "light", count: 10) + wake
+        XCTAssertEqual(SleepStagerV2.sustainedSleepOnset(sustained), 6)
+        // A brief run before a sustained one must not be mistaken for onset; the counter resets on wake.
+        let both = wake + [String](repeating: "rem", count: 4) + ["awake"]
+            + [String](repeating: "deep", count: 12)
+        XCTAssertEqual(SleepStagerV2.sustainedSleepOnset(both), 11)
+        XCTAssertNil(SleepStagerV2.sustainedSleepOnset([]), "an empty night has no onset")
+        XCTAssertNil(SleepStagerV2.sustainedSleepOnset(wake), "an all-wake window has no onset")
+    }
+
+    /// End-to-end: the same physiological night truncated to a shorter in-bed window must not shift where the
+    /// REM guard stops applying. Both windows start at the same instant and share byte-identical streams, so
+    /// any difference in the first ~60 min of the hypnogram would be the session-length dependence #930 is
+    /// about. (Epochs after the shorter window's end are not compared — they genuinely see different
+    /// per-night z-scores, which is the recipe working as designed.)
+    func testGuardRegionDoesNotDependOnHowLongTheWearerStayedInBed() {
+        let start = 1_749_517_200
+        let longDur = 10 * 60 * 60
+        let shortDur = 3 * 60 * 60
+        let grav = stillGravity(start: start, durationS: longDur)
+        let hr = sleepHR(start: start, durationS: longDur)
+        let rr = regularRR(start: start, durationS: longDur)
+
+        func labels(_ dur: Int) -> [String] {
+            let segs = SleepStagerV2.stageSession(start: start, end: start + dur,
+                                                  grav: grav, hr: hr, rr: rr, resp: [])
+            var out: [String] = []
+            for t in stride(from: start, to: start + dur, by: 30) {
+                out.append(segs.first(where: { $0.start <= t && t < $0.end })?.stage ?? "wake")
+            }
+            return out
+        }
+        let long = labels(longDur), short = labels(shortDur)
+        // Over the first hour — the whole span the guard touches — neither window may call REM, because the
+        // guard reaches the SAME 60 minutes past onset in both. Under `c < 0.12` the 10 h window was guarded
+        // for 72 min and the 3 h window for only 21.6 min, so the two could not agree here by construction.
+        let guardEpochs = Int(SleepStagerV2.remLatencyMinutes * 60 / 30)
+        for i in 0..<guardEpochs {
+            XCTAssertEqual(long[i], short[i],
+                           "epoch \(i) (minute \(Double(i) * 0.5)) differs: 10 h night says \(long[i]), "
+                           + "3 h fragment says \(short[i]) — the guard must not scale with session length")
+        }
     }
 
     /// Viterbi over a single epoch returns the highest-emission stage (uniform start, no transitions).

--- a/android/app/src/main/java/com/noop/analytics/SleepStagerV2.kt
+++ b/android/app/src/main/java/com/noop/analytics/SleepStagerV2.kt
@@ -33,7 +33,8 @@ import kotlin.math.sqrt
  * NOT fit to labels):
  *   1. per-night z-scored cardiorespiratory emissions (HR / HR-variability / movement);
  *   2. a per-night DEEP gate on the 11-min HR-flatness percentile (strongest deep-vs-light separator);
- *   3. a soft sleep-cycle prior (deep concentrated early; REM suppressed in the first ~12% then rising);
+ *   3. a soft sleep-cycle prior (deep concentrated early as a fraction of the session; REM rising with
+ *      that same fraction, minus a REM-latency guard that decays over the first 60 MINUTES after onset);
  *   4. a peak-motion (jerk) wake gate, thresholded RELATIVE to the night's own quiescent jerk floor — so it
  *      self-calibrates to the strap's gravity-decode scale and the wearer's fit, not a fixed g;
  *   5. an RR-RSA respiration-regularity term (regular breathing → deep, irregular → REM);
@@ -215,6 +216,12 @@ object SleepStagerV2 {
         val respReg: Double?,   // RSA spectral peakedness in the 0.15–0.40 Hz band (breathing regularity)
         val clock: Double,      // time-of-night fraction in [0, 1]
         val jerkScale: Double,  // night quiescent jerk floor (median per-second jerk over the session)
+        /** Elapsed MINUTES from the session window start to this epoch's centre — the minute-domain twin of
+         *  [clock] (#930). [features] cannot know where sleep actually began, so it fills this relative to the
+         *  window start; [stageEpochs] re-bases it onto the sleep onset its own first pass found, and falls
+         *  back to this window-relative value when a night never sustains sleep. Only the REM-latency guard
+         *  reads it — the deep term and the REM ramp stay fractions of the session, which is what they are. */
+        val minutesSinceOnset: Double,
     )
 
     // ── Feature extraction ───────────────────────────────────────────────────────────────────────────
@@ -306,6 +313,7 @@ object SleepStagerV2 {
         data class Raw(
             val start: Long, val hr: Double?, val hrVar: Double?, val hrFlat11: Double?,
             val jerks: List<Double>, val gapSec: Int, val jerkMax: Double, val respReg: Double?, val clock: Double,
+            val minutes: Double,
         )
         val raws = ArrayList<Raw>()
         val allJerks = ArrayList<Double>()
@@ -347,7 +355,8 @@ object SleepStagerV2 {
             raws.add(Raw(
                 start = e, hr = hrMean, hrVar = hrVar, hrFlat11 = hrFlat11,
                 jerks = jerks, gapSec = maxOf(1, gseq.size - 1), jerkMax = jerkMax,
-                respReg = respReg, clock = (e + 15 - start).toDouble() / span))
+                respReg = respReg, clock = (e + 15 - start).toDouble() / span,
+                minutes = (e + 15 - start).toDouble() / 60.0))
             e += 30
         }
 
@@ -368,7 +377,7 @@ object SleepStagerV2 {
             feats.add(Epoch(
                 start = r.start, hr = r.hr, hrVar = r.hrVar, hrFlat11 = r.hrFlat11,
                 moveFrac = moves.toDouble() / r.gapSec, jerkMax = r.jerkMax, respReg = r.respReg,
-                clock = r.clock, jerkScale = jerkScale))
+                clock = r.clock, jerkScale = jerkScale, minutesSinceOnset = r.minutes))
         }
         return feats
     }
@@ -417,12 +426,71 @@ object SleepStagerV2 {
 
     // ── Recipe staging ────────────────────────────────────────────────────────────────────────────────
 
+    // ── the REM-latency guard (#930) ──────────────────────────────────────────────────────────────────
+
+    /** Log-odds penalty applied to the REM emission AT sleep onset. Unchanged in magnitude from the
+     *  `c < 0.12 ? 3.0 : 0.0` step this replaced: e⁻³ ≈ 0.05 on the REM emission — strong suppression that
+     *  sufficient evidence still overcomes, never a veto. Kept at the incumbent value deliberately, because
+     *  the sleep-accel grid ({cliff, graded} × {fraction, minutes} × K ∈ 1…8 × threshold, 210 cells) showed
+     *  every cell tying on accuracy, so nothing in the data discriminates K — and the smallest correct change
+     *  is to fix the UNITS and the SHAPE without also retuning a magnitude no measurement can justify.
+     *  Internal so the parity test can pin it, matching the Swift `remLatencyPenalty` visibility. */
+    internal const val remLatencyPenalty = 3.0
+
+    /** Minutes over which [remLatencyPenalty] decays linearly to zero, measured from sleep ONSET.
+     *  Against PSG truth on sleep-accel (n = 31 subjects), a guard reaching 45 min costs 0.36 % of all real
+     *  REM (1 subject affected) and one reaching 90 min costs 6.85 % (15 subjects); 60 min sits inside that
+     *  band, and because the penalty is GRADED rather than a cliff it is already down to ≤ 0.75 log-odds
+     *  (×0.47, vs ×0.05 at onset) across 45–60 min, so a genuine sleep-onset REM period late in the window is
+     *  held back rather than suppressed. 60 min also stops clear of the ~70–100 min population first-REM
+     *  latency, so the ramp is fully spent before real REM is expected. */
+    internal const val remLatencyMinutes = 60.0
+
+    /** The guard itself: `K` at (and before) sleep onset, decaying linearly to 0 at `M0` minutes after it.
+     *  Clamped to `[0, K]` so a PRE-onset epoch — negative elapsed time, and unbounded when detection places
+     *  the window start hours early (#271) — can never be penalised harder than the onset instant itself. */
+    internal fun remLatencyGuard(minutesSinceOnset: Double): Double =
+        remLatencyPenalty * minOf(1.0, maxOf(0.0, 1.0 - minutesSinceOnset / remLatencyMinutes))
+
     /** Soft sleep-cycle prior added to the log-emission: deep concentrated early (decays, never hard-wiped);
-     *  REM suppressed in the first ~12 % (REM latency) then rising toward morning. */
-    private fun cyclePrior(c: Double): Map<String, Double> = mapOf(
+     *  REM suppressed around sleep onset (REM latency) then rising toward morning.
+     *
+     *  PROVENANCE of the constants: `1.2`, `0.55` and the `1.0` REM slope are hand-picked a priori from sleep
+     *  physiology and population base rates, never fit to labels — as is every other coefficient in this file.
+     *  [remLatencyPenalty] / [remLatencyMinutes] carry their own derivations above.
+     *
+     *  UNITS, and why they differ per term (#930). The deep term and the `1.0 * c` REM ramp take `c`, the
+     *  fraction of the session — correctly, because both describe *where in the night* you are, a quantity
+     *  that is inherently proportional. The REM-LATENCY guard takes `minutesSinceOnset` instead, because
+     *  first-REM latency is an absolute physiological interval and not a proportion of how long you slept: on
+     *  sleep-accel (n = 30 subjects with a scorable first REM period) true latency is uncorrelated with
+     *  session duration (Pearson r = −0.058, Spearman −0.076), and re-expressing latency as a fraction makes
+     *  it MORE variable, not less (CV 0.617 as a fraction vs 0.537 in minutes). The `c < 0.12` step this
+     *  replaced therefore scaled a fixed physiological interval by session length: across one WHOOP 5 user's
+     *  own recorded nights it ranged 7.4–84.5 min, an 11× spread, for the same wearer and the same physiology.
+     *  Internal so the parity test can call it, matching the Swift `cyclePrior` visibility. */
+    internal fun cyclePrior(c: Double, minutesSinceOnset: Double): Map<String, Double> = mapOf(
         "deep" to 1.2 * maxOf(0.0, 1.0 - c / 0.55),
-        "rem" to 1.0 * c - (if (c < 0.12) 3.0 else 0.0),
+        "rem" to 1.0 * c - remLatencyGuard(minutesSinceOnset),
         "light" to 0.0, "awake" to 0.0)
+
+    /** Sustained non-wake run, in 30 s epochs, that establishes sleep onset — 10 epochs = 5 minutes.
+     *  Measured against PSG onset on sleep-accel (n = 31 subjects): bias −3.8 min, MAE 7.4 min. */
+    internal const val onsetSustainedEpochs = 10
+
+    /** Index of the first epoch that begins a run of [onsetSustainedEpochs] consecutive non-"awake" labels,
+     *  or null when the hypnogram never sustains sleep that long (a nap shorter than the rule, or an all-wake
+     *  window). Runs are counted in epochs, not wall clock, so a coverage gap that drops an epoch cannot
+     *  silently satisfy the rule with less evidence. */
+    internal fun sustainedSleepOnset(labels: List<String>): Int? {
+        var run = 0
+        for (i in labels.indices) {
+            if (labels[i] == "awake") { run = 0; continue }
+            run++
+            if (run >= onsetSustainedEpochs) return i - onsetSustainedEpochs + 1
+        }
+        return null
+    }
 
     /** Viterbi most-likely path over the per-epoch log-emissions with the sticky transition matrix and a
      *  uniform start. Ties resolve to the earlier stage in [stageNames]. */
@@ -456,7 +524,16 @@ object SleepStagerV2 {
     }
 
     /** Run the full recipe over a night's epochs and return one stage label per epoch (incl. "awake").
-     *  All normalisation (z-scores, the HR-flatness percentile) is WITHIN the night. */
+     *  All normalisation (z-scores, the HR-flatness percentile) is WITHIN the night.
+     *
+     *  TWO PASSES (#930). The REM-latency guard is measured from sleep ONSET, and onset is itself a staging
+     *  output, so the recipe cannot know it while building the emissions. Pass 1 stages the night with the
+     *  guard DISABLED (`cyclePrior(c, POSITIVE_INFINITY)`) and reads the first sustained sleep run out of the
+     *  result; pass 2 adds the guard, re-based on that onset, and re-runs Viterbi. Only the guard differs
+     *  between the passes — every emission term, z-score and percentile is computed ONCE and reused — so the
+     *  extra cost is one Viterbi over an already-built lattice, not a second featurisation, and
+     *  [stageSession] memoizes the whole thing anyway. When no sustained run exists the origin falls back to
+     *  the window start, which is exactly the origin the shipped `c`-based guard used. */
     private fun stageEpochs(feats: List<Epoch>): List<String> {
         if (feats.isEmpty()) return emptyList()
 
@@ -483,7 +560,9 @@ object SleepStagerV2 {
             return lo.toDouble() / fsorted.size
         }
 
-        val seq = ArrayList<Map<String, Double>>(feats.size)
+        // Held as the concrete HashMap (not the read-only `Map` view) so pass 2 can add the REM-latency guard
+        // in place; `viterbi` still takes `List<Map<…>>`, which this satisfies by List's covariance.
+        val seq = ArrayList<HashMap<String, Double>>(feats.size)
         for (f in feats) {
             val zhrv = zhr(f.hr); val zhvv = zhv(f.hrVar); val zmvv = zmv(f.moveFrac)
             val gate = deepGateSlope * maxOf(0.0, fpct(f.hrFlat11) - deepGateThresh)
@@ -499,11 +578,23 @@ object SleepStagerV2 {
             em["rem"] = 0.6 * zhvv - 0.6 * zmvv + 0.4 * zhrv + baseLogPrior["rem"]!!
             em["light"] = baseLogPrior["light"]!!
             em["awake"] = 1.0 * zmvv + awakeCardiac + baseLogPrior["awake"]!!
-            val pr = cyclePrior(f.clock)
+            // Guard DISABLED here (infinity ⇒ [remLatencyGuard] = 0); pass 2 below adds it once onset is known.
+            val pr = cyclePrior(f.clock, Double.POSITIVE_INFINITY)
             for (s in stageNames) em[s] = em[s]!! + pr[s]!!
             if (f.jerkMax > f.jerkScale * jerkFloorGateMult) em["awake"] = em["awake"]!! + motionGateBoost
             f.respReg?.let { rg -> val z = zrg(rg); em["deep"] = em["deep"]!! + respWeight * z; em["rem"] = em["rem"]!! - respWeight * z }
             seq.add(em)
+        }
+
+        // PASS 1 — stage without the REM-latency guard purely to locate sleep onset.
+        val provisional = viterbi(seq)
+        // Origin for the guard: the centre of the first sustained-sleep epoch, in the same window-relative
+        // minutes [features] stamped on every epoch. No sustained run → 0.0, i.e. the window start.
+        val originMin = sustainedSleepOnset(provisional)?.let { feats[it].minutesSinceOnset } ?: 0.0
+
+        // PASS 2 — apply the guard against minutes since THAT onset and re-run the lattice.
+        for (i in feats.indices) {
+            seq[i]["rem"] = seq[i]["rem"]!! - remLatencyGuard(feats[i].minutesSinceOnset - originMin)
         }
         return viterbi(seq)
     }

--- a/android/app/src/test/java/com/noop/analytics/MotionCorroboratedWakeTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/MotionCorroboratedWakeTest.kt
@@ -142,11 +142,11 @@ class MotionCorroboratedWakeTest {
     fun motionQuiescentPredicate() {
         val still = SleepStagerV2.Epoch(
             start = 0, hr = 58.0, hrVar = 1.0, hrFlat11 = 1.0, moveFrac = 0.0, jerkMax = 0.001,
-            respReg = null, clock = 0.5, jerkScale = 0.001)
+            respReg = null, clock = 0.5, jerkScale = 0.001, minutesSinceOnset = 120.0)
         assertTrue(SleepStagerV2.motionQuiescent(still))
         val moved = SleepStagerV2.Epoch(
             start = 0, hr = 58.0, hrVar = 1.0, hrFlat11 = 1.0, moveFrac = 0.3, jerkMax = 0.2,
-            respReg = null, clock = 0.5, jerkScale = 0.001)
+            respReg = null, clock = 0.5, jerkScale = 0.001, minutesSinceOnset = 120.0)
         assertFalse(SleepStagerV2.motionQuiescent(moved))
     }
 

--- a/android/app/src/test/java/com/noop/analytics/SleepStagerV2Test.kt
+++ b/android/app/src/test/java/com/noop/analytics/SleepStagerV2Test.kt
@@ -218,6 +218,127 @@ class SleepStagerV2Test {
         }
     }
 
+    // ── #930: the REM-latency guard is measured in MINUTES, not as a fraction of the session ────────────────
+
+    /**
+     * THE point of #930, and the assertion the previous shape could not even express: a 10-hour night and a
+     * 3-hour fragment must receive the SAME REM-latency guard at the same minute after sleep onset. Swift twin:
+     * `SleepStagerV2Tests.testRemLatencyGuardIsIdenticalAcrossSessionLengths`.
+     *
+     * Under the replaced `c < 0.12` step the two disagree by construction — 30 min into a 10 h night is
+     * `c = 0.05` (suppressed by the full 3.0) while 30 min into a 3 h fragment is `c = 0.167` (not suppressed at
+     * all), so the identical physiological instant got opposite treatment purely because of how long the wearer
+     * stayed in bed. The guard is isolated from the `1.0 * c` REM ramp (which is CORRECTLY a fraction of the
+     * session and legitimately differs between the two) by subtracting the ramp back out.
+     */
+    @Test
+    fun remLatencyGuardIsIdenticalAcrossSessionLengths() {
+        val longNight = 10.0 * 60.0   // 600 min
+        val fragment = 3.0 * 60.0     // 180 min
+        var minutes = 0.0
+        while (minutes <= 180.0) {
+            val cLong = minutes / longNight
+            val cShort = minutes / fragment
+            // Strip the fraction-of-session REM ramp; what remains is the latency guard alone.
+            val guardLong = 1.0 * cLong - SleepStagerV2.cyclePrior(cLong, minutes)["rem"]!!
+            val guardShort = 1.0 * cShort - SleepStagerV2.cyclePrior(cShort, minutes)["rem"]!!
+            assertEquals(
+                "guard at $minutes min must not depend on session length",
+                guardLong, guardShort, 1e-12)
+            assertEquals(guardLong, SleepStagerV2.remLatencyGuard(minutes), 1e-12)
+            minutes += 2.5
+        }
+    }
+
+    /**
+     * Shape of the guard: full strength at onset, linear decay, exactly zero at and past `remLatencyMinutes`,
+     * and clamped (never stronger than at onset) for the pre-onset epochs a mis-placed window start produces.
+     * Also pins the two constants themselves, so a one-sided Swift/Kotlin edit fails immediately. Swift twin:
+     * `SleepStagerV2Tests.testRemLatencyGuardShapeAndClamp`.
+     */
+    @Test
+    fun remLatencyGuardShapeAndClamp() {
+        val k = SleepStagerV2.remLatencyPenalty
+        val m0 = SleepStagerV2.remLatencyMinutes
+        assertEquals("K is pinned across platforms", 3.0, k, 0.0)
+        assertEquals("M0 is pinned across platforms", 60.0, m0, 0.0)
+        assertEquals("full penalty at onset", k, SleepStagerV2.remLatencyGuard(0.0), 1e-12)
+        assertEquals("linear halfway", k / 2, SleepStagerV2.remLatencyGuard(m0 / 2), 1e-12)
+        assertEquals("spent at M0", 0.0, SleepStagerV2.remLatencyGuard(m0), 1e-12)
+        assertEquals("never negative later", 0.0, SleepStagerV2.remLatencyGuard(m0 + 500), 1e-12)
+        // #271 can place the window start hours before real onset; the guard must stay bounded there.
+        assertEquals("clamped pre-onset", k, SleepStagerV2.remLatencyGuard(-240.0), 1e-12)
+        assertEquals(
+            "the disabled-guard sentinel pass 1 uses must contribute nothing",
+            0.0, SleepStagerV2.remLatencyGuard(Double.POSITIVE_INFINITY), 1e-12)
+        var prev = Double.POSITIVE_INFINITY
+        var m = -60.0
+        while (m <= 120.0) {
+            val g = SleepStagerV2.remLatencyGuard(m)
+            assertTrue("guard must never increase with elapsed time", g <= prev + 1e-12)
+            prev = g
+            m += 1.0
+        }
+    }
+
+    /**
+     * The 5-minute sustained-sleep onset rule (10 epochs on the 30 s grid), measured against PSG onset on
+     * sleep-accel at bias −3.8 min / MAE 7.4 min. A shorter sleep run must NOT establish onset. Swift twin:
+     * `SleepStagerV2Tests.testSustainedSleepOnsetRule`.
+     */
+    @Test
+    fun sustainedSleepOnsetRule() {
+        val wake = List(6) { "awake" }
+        // 9 epochs of sleep (4.5 min) is one short of the rule and must not count.
+        assertEquals(null, SleepStagerV2.sustainedSleepOnset(wake + List(9) { "light" } + wake))
+        // 10 epochs (5 min) does, and onset is the FIRST epoch of the run, not the tenth.
+        assertEquals(6, SleepStagerV2.sustainedSleepOnset(wake + List(10) { "light" } + wake))
+        // A brief run before a sustained one must not be mistaken for onset; the counter resets on wake.
+        assertEquals(
+            11,
+            SleepStagerV2.sustainedSleepOnset(wake + List(4) { "rem" } + listOf("awake") + List(12) { "deep" }))
+        assertEquals("an empty night has no onset", null, SleepStagerV2.sustainedSleepOnset(emptyList()))
+        assertEquals("an all-wake window has no onset", null, SleepStagerV2.sustainedSleepOnset(wake))
+    }
+
+    /**
+     * End-to-end: the same physiological night truncated to a shorter in-bed window must not shift where the
+     * REM guard stops applying. Both windows start at the same instant and share byte-identical streams, so any
+     * difference in the first ~60 min of the hypnogram would be the session-length dependence #930 is about.
+     * Swift twin: `SleepStagerV2Tests.testGuardRegionDoesNotDependOnHowLongTheWearerStayedInBed`.
+     */
+    @Test
+    fun guardRegionDoesNotDependOnHowLongTheWearerStayedInBed() {
+        val start = refMidnight + 3_600L
+        val longDur = 10 * 60 * 60
+        val shortDur = 3 * 60 * 60
+        val grav = stillGravity(start, longDur)
+        val hr = sleepHR(start, longDur)
+        val rr = regularRR(start, longDur)
+
+        fun labels(dur: Int): List<String> {
+            val segs = SleepStagerV2.stageSession(start, start + dur, grav, hr, rr, emptyList())
+            val out = ArrayList<String>()
+            var t = start
+            while (t < start + dur) {
+                out.add(segs.firstOrNull { it.start <= t && t < it.end }?.stage ?: "wake")
+                t += 30
+            }
+            return out
+        }
+        val long = labels(longDur)
+        val short = labels(shortDur)
+        // Over the first hour — the whole span the guard touches — the two windows must agree, because the
+        // guard reaches the SAME 60 minutes past onset in both. Under `c < 0.12` the 10 h window was guarded
+        // for 72 min and the 3 h window for only 21.6 min, so they could not agree here by construction.
+        val guardEpochs = (SleepStagerV2.remLatencyMinutes * 60 / 30).toInt()
+        for (i in 0 until guardEpochs) {
+            assertEquals(
+                "epoch $i (minute ${i * 0.5}) differs — the guard must not scale with session length",
+                long[i], short[i])
+        }
+    }
+
     /**
      * Directly pin the #277 deep-boundary tune — the reliable guard the end-to-end golden can't be (a golden is
      * only sensitive where the input sits near a decision boundary). Asserts the exact tuned VALUES and their


### PR DESCRIPTION
Fixes the design bug in `SleepStagerV2.cyclePrior` documented in #930, in the direction that issue and its follow-up comment argued for: graded rather than a cliff, absolute minutes rather than a fraction of session length, measured from a detected onset rather than from the window start.

**Read the "what this is not" section before the numbers.** This is a robustness fix. It does not buy accuracy, and I am not claiming it does.

---

## The change

`Packages/StrandAnalytics/Sources/StrandAnalytics/SleepStagerV2.swift`, Kotlin twin at `android/app/src/main/java/com/noop/analytics/SleepStagerV2.kt`:

```diff
-static func cyclePrior(_ c: Double) -> [String: Double] {
+static func cyclePrior(_ c: Double, _ minutesSinceOnset: Double) -> [String: Double] {
     ["deep": 1.2 * max(0.0, 1.0 - c / 0.55),
-     "rem": 1.0 * c - (c < 0.12 ? 3.0 : 0.0),
+     "rem": 1.0 * c - remLatencyGuard(minutesSinceOnset),
      "light": 0.0, "awake": 0.0]
 }
+
+static func remLatencyGuard(_ minutesSinceOnset: Double) -> Double {
+    remLatencyPenalty * min(1.0, max(0.0, 1.0 - minutesSinceOnset / remLatencyMinutes))
+}
+static let remLatencyPenalty = 3.0    // K
+static let remLatencyMinutes = 60.0   // M0
```

So: **`K · clamp01(1 − m / M0)` with `K = 3.0`, `M0 = 60 min`**, where `m` is minutes since a *measured* sleep onset.

**The `1.0 * c` ramp and the whole deep term are untouched, deliberately.** Both are correctly fractions of the session — they describe *where in the night* you are, which is inherently proportional. Only the latency guard changes units, because only it describes an absolute physiological interval. Ablating the ramp entirely collapses REM to 1.4 % of night and kappa to 0.143 (sleep-accel, LOSO), so it is load-bearing and I did not touch it.

---

## What this is NOT

**There is no accuracy win here, and reviewers should not accept one.** On sleep-accel the `-3.0` step is measurably inert:

| | with the step | step removed |
|---|---|---|
| kappa (4-class, LOSO) | 0.349 | 0.349 |
| median first-REM latency | 142.0 min | 141.0 min |

All **210** tested grid cells — {cliff, graded} x {fraction, minutes} x K in 1..8 x threshold — tie, because the recipe's own first-REM latency already sits beyond every guard width tested. The step is not currently *doing* anything to accuracy on that cohort.

The justification is that the term is **parameterised in the wrong units**, which is a correctness property, not a score. A term that is inert today on one cohort is not thereby correct; it is untested. Anchoring it in minutes means it stays inert for the right reason instead of by arithmetic coincidence.

---

## Why minutes, and why that part is settled (CONFIRMED)

Measured on PhysioNet `sleep-accel` (Walch et al., *SLEEP* 2019; ODC-By v1.0), n = 31 subjects / 26,773 PSG-scored 30 s epochs, leave-one-**subject**-out:

- True first-REM latency is **uncorrelated with session duration**: Pearson r = **-0.058**, Spearman **-0.076** (n = 30 subjects with a scorable first REM period).
- Re-expressing latency as a fraction of session makes it **more** variable, not less: CV **0.617** as a fraction vs **0.537** in minutes.
- Continuous elapsed time beats a threshold at equal feature count: binary `c < 0.12` adds **+0.009 kappa** over physiology alone; continuous time adds **+0.051**. A threshold captures ~18 % of what continuous time provides.

The shipped guard works on that cohort only by coincidence — 12 % of a near-uniform 476-min recording is 57 min, just under the 88.5-min median true latency. **That cohort spans only 2.4x in session length, so it understates the problem.** On my own device database (n = 36 recorded sessions, one WHOOP 5 wearer) sessions span **11.5x** and the guard width therefore ranges **7.4 - 84.5 min** for the same wearer and the same physiology, exactly as reported in #930.

*Provenance of the sleep-accel figures:* the harness compiles `SleepStagerV2.swift` verbatim and reproduces **11,460 / 11,460** epoch labels identically across 48 randomised nights against the in-app stager, so these measure this code, not a re-implementation of it.

## Choosing K and M0

**K = 3.0 — the incumbent step's own magnitude, kept on purpose.** e^-3 ~ 0.05 on the REM emission: strong suppression that sufficient evidence still overcomes, never a veto (#930 established the step was never a hard mask — REM still occurred at 6.8 % during hour 0 as shipped). Since all 210 grid cells tie, *nothing in the data discriminates K*. The smallest correct change fixes the units and the shape without also retuning a magnitude no measurement can justify. Note the graded form is strictly gentler in aggregate: mean penalty over [0, M0] is K/2 = 1.5 against the incumbent's flat 3.0.

**M0 = 60 min.** Cost against PSG truth of a guard extending to a given width:

| guard width | share of all real REM inside it | subjects affected |
|---|---|---|
| 45 min | 0.36 % | 1 of 31 |
| 90 min | 6.85 % | 15 of 31 |

60 min sits inside the defensible band. Because the penalty is graded rather than a cliff it is already down to <= 0.75 log-odds (x0.47, against x0.05 at onset) across 45-60 min, so a genuine sleep-onset REM period late in the window is *held back* rather than suppressed. 60 min also stops clear of the ~70-100 min population first-REM latency, so the ramp is spent before real REM is expected.

This matters for the population #930 flagged as **INFERRED, not measured**: REM latency shortens with age, and a minority of people show sleep-onset REM periods. A graded, bounded, soft ramp degrades for them instead of cliff-edging, but I have no data on that group and am not claiming otherwise.

---

## Before/after on real nights — kappa **and** stage fractions

Replayed with `Tools/SleepBench`'s reader over a copy of a real device database: **36 sessions**, of which **15 carry a `stagelock` cursor** (human-*authored* hypnograms via the cloud edit path — not merely `userEdited`, which re-derives stages machine-side over a human-chosen window). **9,163 reference epochs.**

The reference set is the stage-locked rows precisely because that set comes from `cursors` and therefore does **not** move when the recipe changes. (SleepBench's "byte-exact replay of the current V2" exclusion is version-dependent by construction — a night can leave the exclusion just because the recipe changed, silently swapping the denominator underneath a before/after. That happened to me on the first pass: 11 nights before, 12 after.)

### kappa — essentially flat, as predicted

| | before | after |
|---|---|---|
| 4-class accuracy | 78.2 % | 78.2 % |
| **4-class kappa** | **0.691** | **0.689** |
| sleep/wake kappa | 0.583 | 0.582 |

### Per-stage fraction calibration — the guard kappa does not provide

#437 reverted #348 with the words *"kappa doesn't guard **stage-fraction calibration** — a systematic wake-fraction bias sails through it."* A cliff term is exactly the shape that moves stage fractions without moving kappa, so:

**Per-night bias vs the human reference (predicted - truth, percentage points; n = 15):**

| stage | before | after | |
|---|---|---|---|
| wake | -7.26 | **-7.13** | improves |
| light | -7.54 | **-6.10** | improves |
| deep | +6.65 | **+6.65** | unchanged |
| rem | +8.15 | **+6.57** | improves |

Total absolute bias 29.60 -> 26.45 pp. MAE improves on light (8.52 -> 7.41) and rem (9.01 -> 8.33), is unchanged on deep, and worsens 0.11 pp on wake (8.01 -> 8.12).

**Healthy-sleeper stratum (in-bed >= 5 h, n = 20) — the cohort #348 broke:**

| stage | before | after | delta |
|---|---|---|---|
| wake | 9.40 % | 9.43 % | **+0.03 pp** |
| light | 38.50 % | 38.91 % | +0.41 pp |
| deep | 22.09 % | 22.09 % | 0.00 pp |
| rem | 30.00 % | 29.58 % | -0.42 pp |

For scale, the #348 field symptom was a healthy night moving wake 6 % -> 23 % (~17 pp). Nothing here moves more than 0.42 pp, and wake moves 0.03 pp.

**Deep is byte-identical on all 36 nights** (max |delta deep| = 0.00 pp), which is the direct check that the deep term was not disturbed.

### Where the change actually lands

12 of 36 nights change at all; 24 are byte-identical. The effect is monotone in session length — i.e. it lands on precisely the sessions the fractional guard was mis-scaling:

| stratum | nights | changed | mean delta rem | mean delta wake | max abs delta wake |
|---|---|---|---|---|---|
| < 2 h in bed | 4 | 4 | **-20.90 pp** | +2.12 pp | 4.90 pp |
| 2-5 h in bed | 12 | 4 | -2.37 pp | +0.15 pp | 1.60 pp |
| >= 5 h in bed | 20 | 4 | -0.43 pp | +0.03 pp | 0.20 pp |

**First-REM latency** (the quantity this term controls), all 36 nights: median 72.2 -> **83.2 min**, p10 37.0 -> 58.0, **min 10.0 -> 43.0 min**. The sub-15-minute sleep-onset-REM calls are gone.

**I want to be explicit about the largest behavioural change, because it is the one worth arguing with:** four sessions of 61-81 min drop from 11.7-35.5 % REM to 3.7-5.7 %. Under a 60-minute guard, a nap shorter than an hour is suppressed for most of its length. I believe that is the physiologically right prior — REM in a sub-hour nap is uncommon outside REM rebound — and the guard remains soft, which is why those nights still call 3.7-5.7 % REM rather than zero. But it is a real change in what a nap looks like in the app, it is by design, and if anyone thinks a shorter M0 is warranted for naps specifically, 45 min is equally defensible on the measured cost table above.

---

## Plumbing

`Epoch` gains `minutesSinceOnset`, and `stageEpochs` becomes two passes: stage once with the guard disabled (`cyclePrior(c, .infinity)`), take the first sustained non-wake run as onset, then apply the guard and re-run Viterbi. The onset rule is **5 minutes sustained sleep (10 epochs on the 30 s grid)**, measured against PSG onset on sleep-accel at **bias -3.8 min, MAE 7.4 min (n = 31)**.

Only the guard differs between the passes — every emission term, z-score and percentile is computed once and reused — so the cost is one extra Viterbi over an already-built lattice, not a second featurisation, and `stageSession` memoizes the result anyway.

Two deliberate degradation choices:
- **No sustained run** (a nap below the rule, an all-wake window) -> the origin falls back to the window start, which is exactly the origin the shipped `c`-based guard used.
- **The guard is clamped to `[0, K]`**, so a pre-onset epoch cannot be penalised harder than onset itself. #930's follow-up comment noted that the origin inherits detection error and that #271 can place a window start ~4 h early on WHOOP 4.0; without the clamp such an epoch would take an unbounded penalty.

---

## Tests

**The regression test the previous shape could not express** — a 10-hour night and a 3-hour fragment must receive the *same* guard at the same minute after onset. Under `c < 0.12` they disagree by construction: 30 min in is `c = 0.05` (fully suppressed) on the long night and `c = 0.167` (not suppressed at all) on the fragment. The test isolates the guard from the `1.0 * c` ramp (which legitimately differs) by subtracting the ramp back out, and there is an end-to-end twin that stages the same streams under both window lengths and asserts the first 60 minutes agree epoch-for-epoch.

Also added, in both languages: guard shape / clamp / monotonicity with the constants pinned across platforms, and the sustained-onset rule (9 epochs must not qualify, 10 must, a brief run before a sustained one must not be mistaken for onset).

| suite | result |
|---|---|
| `swift test` (Packages/StrandAnalytics, on this branch) | **1171 passed, 0 failed** |
| `./gradlew testFullDebugUnitTest` | **3213 passed, 0 failed, 5 skipped** (392 suites) |

Android counts read from `app/build/test-results/testFullDebugUnitTest/*.xml`, not the wrapper exit code. `android.yml` is disabled so CI does not run Kotlin tests on PRs — local verification is the only gate, and I ran it against JDK 17.

**Both frozen goldens are unchanged**, in Swift and Kotlin — the pinned end-to-end recipe shape and the Swift/Kotlin parity it proves both survive this change, which is the cheapest evidence that the two implementations still agree epoch-for-epoch.

Per the parity contract the Kotlin twin changes in this same PR, including the constants; `remLatencyPenalty` / `remLatencyMinutes` / `cyclePrior` / `sustainedSleepOnset` are `internal` on Android so the parity test can pin them, matching the Swift visibility.

---

## Known, and NOT addressed here

Two real defects this work surfaced that are **not** caused by this term and are tracked separately:

1. **Median first-REM latency runs ~54 min late** against PSG — 142 min predicted vs 88.5 min truth. Removing the step gives 141, so the guard is not the cause.
2. **Deep is under-called 2-3x** — 4.7-6.2 % predicted vs 14.8 % truth. Visible in the table above as the +6.65 pp deep bias, unchanged by this PR because the deep term is untouched.

Neither is in scope; fixing them inside a units correction would make both un-reviewable.

## Caveats

- The sleep-accel figures are **CONFIRMED** measurements at the stated sample sizes (n = 31 subjects, LOSO). The device-replay figures are **one wearer, one strap family (WHOOP 5), 36 sessions, 15 human-authored references** — descriptive of that database, not population values. The *structural* claims (guard width scaling with session length, deep untouched, the monotone-in-duration effect) are properties of the code.
- The `< 2 h` stratum is 4 nights. The mean -20.9 pp REM shift there is the direction the design intends, but the magnitude rests on very little data.
- The second-order concern about older wearers and sleep-onset-REM populations is **INFERRED from the literature, not measured** — I have no data on it. It argues for a graded shape over a cliff, which is what this does; it does not justify any particular M0.

Refs #930. Prior art on changing V2's staging constants: #348 and its #437 revert — the "kappa doesn't guard stage-fraction calibration" line from #437 is why the stage-fraction and healthy-stratum tables above exist at all.
