### PR TITLE
diag(oura): raw undecoded history-notification capture → oura-raw-<id…>.jsonl

### DIFF
--- a/Packages/WhoopStore/Sources/WhoopStore/OuraRawDumpLine.swift
+++ b/Packages/WhoopStore/Sources/WhoopStore/OuraRawDumpLine.swift
@@ -1,0 +1,34 @@
+import Foundation
+
+/// Pure, deterministic encoder for ONE line of the Oura RAW capture — a diagnostic JSONL sidecar holding
+/// the UNDECODED TLV-record bytes exactly as received, NOT a datastore row. Complement to the decoded
+/// sidecars (`OuraActivityDumpLine` = MET values, `OuraIbiHrDumpLine` = HR from IBIs): those are what NOOP
+/// *interpreted*; this is what the ring actually *sent*.
+///
+/// WHY a raw file too: the decoded sidecars can only show what we successfully decoded, so a hole in them is
+/// ambiguous — did the ring not send those records, or did we drop/fail to decode them? This capture removes
+/// the ambiguity: reframe it OFFLINE (walk `2+len` TLV records, read the tag + ring-time) and a window that is
+/// empty in the decoded file but present here is a DECODE drop; absent in both is RING-SIDE. It also preserves
+/// tags NOOP does not decode yet (superset of the `0x71` fixture log). Never scored, safe to delete.
+///
+/// SCOPE: the HISTORY-drain record path only (the tap sits where TLV notifications are fed to the driver,
+/// NOT the high-frequency live-HR push), so a night stays bounded. Auth/secure frames are handled+consumed
+/// before the tap, so no challenge/response crypto lands here — only DATA records.
+///
+/// FORMAT: newline-delimited JSON, one received TLV notification per line, hand-built in FIXED key order so
+/// it is byte-stable + testable. `hex` is the notification's raw bytes as contiguous lowercase hex.
+public enum OuraRawDumpLine {
+    /// Bump when the record shape changes so a downstream reader can branch on `schema`.
+    public static let schema = 1
+
+    /// One JSONL record (NO trailing newline — the writer adds it). `deviceId`/`iso` are app-generated, so
+    /// neither needs JSON string-escaping here.
+    ///   - utc:   the wall-clock arrival time (unix seconds) of the notification.
+    ///   - iso:   human-readable UTC of `utc`.
+    ///   - bytes: the raw TLV notification bytes, hex-encoded verbatim (one or more packed `2+len` records).
+    public static func encode(deviceId: String, utc: Int, iso: String, bytes: [UInt8]) -> String {
+        let hex = bytes.map { String(format: "%02x", $0) }.joined()
+        return "{\"schema\":\(schema),\"deviceId\":\"\(deviceId)\",\"utc\":\(utc),"
+             + "\"iso\":\"\(iso)\",\"hex\":\"\(hex)\"}"
+    }
+}

--- a/Packages/WhoopStore/Tests/WhoopStoreTests/OuraRawDumpLineTests.swift
+++ b/Packages/WhoopStore/Tests/WhoopStoreTests/OuraRawDumpLineTests.swift
@@ -1,0 +1,34 @@
+import XCTest
+@testable import WhoopStore
+
+/// The RAW-capture JSONL line encoder. Asserted verbatim so the format (and the contiguous lowercase hex) is
+/// pinned for the offline re-framer.
+final class OuraRawDumpLineTests: XCTestCase {
+
+    func testEncodesFixedShapeVerbatim() {
+        let line = OuraRawDumpLine.encode(
+            deviceId: "oura-5C4C0BF8", utc: 1_783_400_728, iso: "2026-07-14T09:05:28Z",
+            bytes: [0x50, 0x06, 0x01, 0x00, 0x02, 0x00, 0x17, 0x0a])
+        XCTAssertEqual(line,
+            "{\"schema\":1,\"deviceId\":\"oura-5C4C0BF8\",\"utc\":1783400728," +
+            "\"iso\":\"2026-07-14T09:05:28Z\",\"hex\":\"500601000200170a\"}")
+    }
+
+    func testHexIsContiguousLowercaseZeroPadded() {
+        let line = OuraRawDumpLine.encode(deviceId: "d", utc: 1, iso: "x", bytes: [0x00, 0xFF, 0x0A, 0xB3])
+        XCTAssertTrue(line.hasSuffix("\"hex\":\"00ff0ab3\"}"))
+    }
+
+    func testEmptyBytesIsEmptyHex() {
+        let line = OuraRawDumpLine.encode(deviceId: "d", utc: 1, iso: "x", bytes: [])
+        XCTAssertTrue(line.hasSuffix("\"hex\":\"\"}"))
+    }
+
+    func testEachLineIsValidJSON() throws {
+        let line = OuraRawDumpLine.encode(
+            deviceId: "oura-ring", utc: 200, iso: "2026-07-14T00:00:00Z", bytes: [0x80, 0x0e, 0xab])
+        let obj = try JSONSerialization.jsonObject(with: Data(line.utf8)) as? [String: Any]
+        XCTAssertEqual(obj?["hex"] as? String, "800eab")
+        XCTAssertEqual(obj?["schema"] as? Int, OuraRawDumpLine.schema)
+    }
+}

--- a/Strand/BLE/OuraLiveSource.swift
+++ b/Strand/BLE/OuraLiveSource.swift
@@ -268,6 +268,11 @@ public final class OuraLiveSource: NSObject, ObservableObject {
     private let activityDump: OuraActivityDump?
     /// Append-only JSONL sidecar for the 0x47 motion vectors (Tier-A), for offline LSB→g calibration (#804).
     private let motionDump: OuraMotionDump?
+    /// Append-only JSONL capture of the RAW, undecoded history-drain notification bytes (`oura-raw-<id>.jsonl`).
+    /// Complement to the decoded sidecars above: those show what NOOP interpreted, this shows exactly what the
+    /// ring sent, so after a full connect a hole in a decoded file can be pinned as a decode drop vs ring-side.
+    /// No dedup (a re-serve is still evidence the ring re-sent it); the offline reframer collapses duplicates.
+    private let rawDump: OuraRawDump?
     /// Cached local-day formatter (the 0x50 stream is high-volume; avoid building one per record).
     private static let activityDayFormatter: DateFormatter = {
         let f = DateFormatter(); f.dateFormat = "yyyy-MM-dd"; return f   // local time zone by default
@@ -776,6 +781,8 @@ public final class OuraLiveSource: NSObject, ObservableObject {
         self.activityDump = feedsLive && !deviceId.isEmpty ? OuraActivityDump(deviceId: deviceId, log: log) : nil
         // 0x47 motion calibration corpus: same gate as the activity dump (live/persisting source only).
         self.motionDump = feedsLive && !deviceId.isEmpty ? OuraMotionDump(deviceId: deviceId, log: log) : nil
+        // RAW undecoded history-drain capture: same live/persisting gate; complements the decoded sidecars.
+        self.rawDump = feedsLive && !deviceId.isEmpty ? OuraRawDump(deviceId: deviceId, log: log) : nil
         super.init()
         // Dedicated queue-less central -> callbacks arrive on the main queue, matching @MainActor.
         self.central = CBCentralManager(delegate: self, queue: nil)
@@ -1865,11 +1872,13 @@ extension OuraLiveSource: @preconcurrency CBPeripheralDelegate {
             let tlvBytes = frames.filter { $0.op != OuraFraming.secureSessionOp && $0.op != Self.setAuthKeyRespOp }
                                  .flatMap { [$0.op, UInt8($0.body.count)] + $0.body }
             if !tlvBytes.isEmpty {
+                rawDump?.record(bytes: tlvBytes)
                 ingestHistory(driver.ingest(notification: tlvBytes, reassembler: reassembler))
             }
             return
         }
         // No secure frame in this notification: treat the whole value as TLV record bytes.
+        rawDump?.record(bytes: bytes)
         ingestHistory(driver.ingest(notification: bytes, reassembler: reassembler))
     }
 

--- a/Strand/BLE/OuraRawDump.swift
+++ b/Strand/BLE/OuraRawDump.swift
@@ -1,0 +1,90 @@
+import Foundation
+import WhoopStore
+
+/// Append-only JSONL sidecar for the Oura RAW capture — the UNDECODED history-drain notification bytes,
+/// exactly as received. Complement to the *decoded* sidecars (`OuraActivityDump` = MET, `OuraIbiHrDump` =
+/// HR from IBIs): those show what NOOP interpreted; this shows what the ring actually sent.
+///
+/// WHY: NOOP can drop packets, and the decoded files can only ever show what we decoded — so a hole in them
+/// is ambiguous (ring never sent it, vs we dropped/failed to decode it). This raw capture removes the
+/// ambiguity: after a full connect we know exactly which TLV records arrived. Reframe it OFFLINE (walk the
+/// `2+len` records, read tag + ring-time) and a window empty in a decoded file but present here is a DECODE
+/// drop; absent in both is RING-SIDE. It also preserves tags NOOP does not decode yet. Never scored; nothing
+/// reads it back; safe to delete.
+///
+/// SCOPE: the HISTORY-drain record path only — the tap sits where reassembled TLV notifications are fed to
+/// the driver, NOT the high-frequency live-HR push, so a night stays bounded. Auth/secure frames are
+/// consumed before this tap, so only DATA records land here (no challenge/response crypto). Unlike the
+/// decoded sidecars there is NO dedup high-water: a re-served record is still evidence the ring re-sent it,
+/// and the offline reframer collapses duplicates by (tag, ring-time).
+///
+/// Location: `<Application Support>/OpenWhoop/Diagnostics/oura-raw-<deviceId>.jsonl` — beside the SQLite.
+final class OuraRawDump {
+    private let deviceId: String
+    private let log: (String) -> Void
+    private var fileURL: URL?
+    private var resolveFailed = false
+    private var announced = false
+
+    private static let iso: ISO8601DateFormatter = {
+        let f = ISO8601DateFormatter()
+        f.timeZone = TimeZone(identifier: "UTC")
+        return f
+    }()
+
+    init(deviceId: String, log: @escaping (String) -> Void) {
+        self.deviceId = deviceId
+        self.log = log
+    }
+
+    /// Append one raw notification's bytes verbatim (hex-encoded), stamped with wall-clock arrival time.
+    /// No-op on empty input. Best-effort: any file error is logged once and never disrupts the BLE path.
+    func record(bytes: [UInt8]) {
+        guard !bytes.isEmpty, let url = resolveURL() else { return }
+
+        let now = Date()
+        let line = OuraRawDumpLine.encode(
+            deviceId: deviceId, utc: Int(now.timeIntervalSince1970),
+            iso: Self.iso.string(from: now), bytes: bytes)
+
+        guard let data = (line + "\n").data(using: .utf8) else { return }
+        do {
+            let handle = try FileHandle(forWritingTo: url)
+            defer { try? handle.close() }
+            try handle.seekToEnd()
+            handle.write(data)
+        } catch {
+            log("Oura: raw dump write failed - \(error.localizedDescription)")
+            return
+        }
+
+        if !announced {
+            announced = true
+            log("Oura: raw notification capture → \(url.path) [undecoded TLV bytes, JSONL; reframe offline]")
+        }
+    }
+
+    /// Resolve (and create on first use) the sidecar file + its parent directory. Cached; a failure is
+    /// logged once and latched so we never spam the strap log on a read-only volume.
+    private func resolveURL() -> URL? {
+        if let fileURL { return fileURL }
+        if resolveFailed { return nil }
+        do {
+            let base = try FileManager.default.url(for: .applicationSupportDirectory, in: .userDomainMask,
+                                                   appropriateFor: nil, create: true)
+            let dir = base.appendingPathComponent("OpenWhoop/Diagnostics", isDirectory: true)
+            try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+            let safeId = deviceId.replacingOccurrences(of: "/", with: "_")
+            let url = dir.appendingPathComponent("oura-raw-\(safeId).jsonl")
+            if !FileManager.default.fileExists(atPath: url.path) {
+                FileManager.default.createFile(atPath: url.path, contents: nil)
+            }
+            fileURL = url
+            return url
+        } catch {
+            resolveFailed = true
+            log("Oura: raw dump unavailable - \(error.localizedDescription)")
+            return nil
+        }
+    }
+}

--- a/Strand/BLE/OuraRawDump.swift
+++ b/Strand/BLE/OuraRawDump.swift
@@ -26,6 +26,11 @@ final class OuraRawDump {
     private var resolveFailed = false
     private var announced = false
 
+    /// Rotate the sidecar past this size (keeping one previous ".1"), so an always-on research corpus is
+    /// bounded to ~2× this on disk instead of growing forever. Matches `OuraMotionDump`/`OuraActivityDump` —
+    /// this file needs it MORE than either: full hex of every notification, and no dedup high-water.
+    private static let maxBytes = 25 * 1024 * 1024
+
     private static let iso: ISO8601DateFormatter = {
         let f = ISO8601DateFormatter()
         f.timeZone = TimeZone(identifier: "UTC")
@@ -40,7 +45,20 @@ final class OuraRawDump {
     /// Append one raw notification's bytes verbatim (hex-encoded), stamped with wall-clock arrival time.
     /// No-op on empty input. Best-effort: any file error is logged once and never disrupts the BLE path.
     func record(bytes: [UInt8]) {
-        guard !bytes.isEmpty, let url = resolveURL() else { return }
+        guard !bytes.isEmpty, var url = resolveURL() else { return }
+
+        // Bound the corpus (rotate to a single ".1", dropping the prior one) so an always-on research sidecar
+        // can't grow unbounded — same rotation as OuraMotionDump. Read the size via a fresh FileManager stat
+        // rather than URL.resourceValues, whose cache on the reused URL can return a stale small size.
+        let size = ((try? FileManager.default.attributesOfItem(atPath: url.path))?[.size] as? Int) ?? 0
+        if size > Self.maxBytes {
+            let old = url.deletingLastPathComponent().appendingPathComponent(url.lastPathComponent + ".1")
+            try? FileManager.default.removeItem(at: old)
+            try? FileManager.default.moveItem(at: url, to: old)
+            fileURL = nil
+            guard let fresh = resolveURL() else { return }
+            url = fresh
+        }
 
         let now = Date()
         let line = OuraRawDumpLine.encode(


### PR DESCRIPTION
Thanks for approving this PT which will help me to diagnose new tage (such as Spo2) on iOS

Adds a RAW capture sidecar complementing the decoded MET/motion dumps: it records the undecoded history-drain TLV notification bytes exactly as received, so after a full connect we know precisely which records arrived. A hole in a decoded file can now be pinned as a decode drop (present in raw, absent in decoded) vs ring-side (absent in both), instead of being ambiguous.

Motivation: an iOS 9.2.1 field export (real Oura ring, Diagnostics capture on) carried oura-activity.jsonl but no oura-raw.jsonl — because the raw writer had only ever lived on a feature branch and was never merged to main. The bundle assembler already lists oura-raw.jsonl in its attach-if-present set, so on main it silently attaches nothing. This lands the missing writer.

- OuraRawDumpLine (WhoopStore, pure) + tests: byte-stable {schema,deviceId,utc,iso,hex} line, contiguous lowercase hex. 4 tests green.
- OuraRawDump (app): append-only writer, no dedup (a re-serve is still evidence the ring re-sent it; the offline reframer collapses by tag+ring-time).
- OuraLiveSource: rawDump property + tap on both history TLV feed points (secure and non-secure). Same feedsLive && !deviceId.isEmpty gate as the activity/motion dumps; the live-HR push is excluded so a night stays bounded.

Diagnostic only, never scored, never read back, safe to delete. Cross-platform: the decoded Oura sidecars have Android twins, but this raw capture is Apple-only in origin and is a diagnostic artifact (not stored data / analytics), so it is not parity-gated; the Android twin is a fast-follow and the only parity-sensitive surface is the pure OuraRawDumpLine encoder, which will be mirrored byte-for-byte.

Verified: WhoopStore OuraRawDumpLine 4/4 green; Strand macOS app BUILD SUCCEEDED (app-target Swift — no default CI covers it).

