### PR TITLE
Blood O₂: say the strap recorded, when it did

### DIFF
--- a/Strand/Screens/VitalSignsSummary.swift
+++ b/Strand/Screens/VitalSignsSummary.swift
@@ -240,6 +240,12 @@ enum BodyVitalSigns {
                 // fabricate one (spo2Pct is import-only; see Spo2ReTrace). Saying "No SpO₂ import or Health
                 // value" there reads as "your sensor recorded nothing", next to a Raw SpO₂ tile showing a
                 // live number.
+                // The condition is EXACTLY the Raw SpO₂ tile's own value expression (`spo2rawRow`, below)
+                // and must stay that way: the caption's claim is "the tile beside this one is showing a
+                // number", so if the two drift, this says the sensor recorded on a night where the
+                // neighbouring tile is blank. Note `latest()` here resolves `logicalDay ?? most recent`,
+                // where Android resolves the selected day — so the ROW differs across platforms by design
+                // and the parity contract is the relationship between the two tiles, not the row.
                 missingCaption: spo2rawRow != nil
                     ? String(localized: "Raw counts only — needs an import")
                     : String(localized: "No SpO₂ import or Health value"),

--- a/Strand/Screens/VitalSignsSummary.swift
+++ b/Strand/Screens/VitalSignsSummary.swift
@@ -234,7 +234,15 @@ enum BodyVitalSigns {
                 metricColor: StrandPalette.metricCyan,
                 day: spo2Row?.day,
                 source: spo2Row?.source,
-                missingCaption: String(localized: "No SpO₂ import or Health value"),
+                // Two different empty states, and conflating them is what sends people to the forums. When
+                // the night HAS raw red/IR counts, the strap's Blood-O₂ sensor plainly worked — only the
+                // calibrated % is missing, because WHOOP derives it in their cloud and NOOP will not
+                // fabricate one (spo2Pct is import-only; see Spo2ReTrace). Saying "No SpO₂ import or Health
+                // value" there reads as "your sensor recorded nothing", next to a Raw SpO₂ tile showing a
+                // live number.
+                missingCaption: spo2rawRow != nil
+                    ? String(localized: "Raw counts only — needs an import")
+                    : String(localized: "No SpO₂ import or Health value"),
                 sparkline: trail(spo2Points)
             ),
             BodyVitalReading(

--- a/android/app/src/main/java/com/noop/ui/HealthVitalsLogic.kt
+++ b/android/app/src/main/java/com/noop/ui/HealthVitalsLogic.kt
@@ -66,6 +66,24 @@ internal data class Vital(
         } ?: "$label: no data"
 }
 
+/**
+ * Which "no value" line the Blood O₂ tile shows, given whether that night decoded raw red/IR counts.
+ *
+ * Two different empty states, and conflating them is what sends people to the forums. When the night HAS
+ * raw counts the strap's Blood-O₂ sensor plainly worked — only the CALIBRATED % is missing, because WHOOP
+ * derives that in their cloud from the raw ADCs and NOOP will not fabricate one (`spo2Pct` is import-only;
+ * see `Spo2ReTrace`, and the #194 PPG→HR withdrawal for why). Showing "No SpO₂ import or Health value"
+ * there reads as "your sensor recorded nothing" — directly beside a Raw SpO₂ tile displaying a live
+ * number, which is exactly the contradiction that gets reported as a broken strap.
+ *
+ * Split out as a pure function purely so it is TESTABLE: `vitalsFor` resolves strings through
+ * `NoopApplication`, so nothing in this file can run in a JVM unit test. The branch is the part worth
+ * pinning; the resource lookup is not.
+ */
+internal fun spo2MissingCaptionRes(hasRawSpo2: Boolean): Int =
+    if (hasRawSpo2) R.string.l10n_health_screen_raw_counts_only_needs_an_import_d0e33552
+    else R.string.l10n_health_screen_no_spo_import_or_health_value_408f8c55
+
 internal enum class VitalCaptionMode {
     AS_OF,
     RANGE,
@@ -172,7 +190,7 @@ internal fun vitalsFor(
         ),
         Vital(
             key = "spo2", label = uiString(R.string.l10n_health_screen_blood_o_9bf5ed9b), unit = "%",
-            missingCaption = "No SpO₂ import or Health value",
+            missingCaption = uiString(spo2MissingCaptionRes(d?.let(spo2RawMean) != null)),
             value = d?.spo2Pct, format = { String.format("%.0f", it) },
             deltaText = deltaText(d?.spo2Pct, previous { it.spo2Pct }, decimals = 0),
             readingDay = todayKey,

--- a/android/app/src/main/java/com/noop/ui/HealthVitalsLogic.kt
+++ b/android/app/src/main/java/com/noop/ui/HealthVitalsLogic.kt
@@ -190,6 +190,12 @@ internal fun vitalsFor(
         ),
         Vital(
             key = "spo2", label = uiString(R.string.l10n_health_screen_blood_o_9bf5ed9b), unit = "%",
+            // The condition is EXACTLY the Raw SpO₂ tile's own value expression (`d?.let(spo2RawMean)`,
+            // below) and must stay that way: the caption's claim is "the tile beside this one is
+            // showing a number", so if the two expressions drift, this says the sensor recorded on a
+            // night where the neighbouring tile is blank. The platforms pick that row differently —
+            // Android per selected day, Apple `logicalDay ?? most recent` — so the ROW is not the
+            // parity contract here; the relationship between the two tiles is.
             missingCaption = uiString(spo2MissingCaptionRes(d?.let(spo2RawMean) != null)),
             value = d?.spo2Pct, format = { String.format("%.0f", it) },
             deltaText = deltaText(d?.spo2Pct, previous { it.spo2Pct }, decimals = 0),

--- a/android/app/src/main/res/values-de/strings.xml
+++ b/android/app/src/main/res/values-de/strings.xml
@@ -1772,4 +1772,6 @@
     <string name="battery_channel_name">Akku-Hinweise</string>
     <string name="battery_channel_desc">Hinweise, wenn der Strap-Akku schwach oder voll geladen ist.</string>
     <string name="l10n_app_changelog_battery_saver_quiets_the_gauges_translated_bdbe8650">Energiesparmodus beruhigt die Anzeigen, übersetzte Android-Benachrichtigungen und sofort geladene Diagramme</string>
+    <string name="l10n_health_screen_no_spo_import_or_health_value_408f8c55">Kein SpO₂-Import- oder Health-Wert</string>
+    <string name="l10n_health_screen_raw_counts_only_needs_an_import_d0e33552">Nur Rohwerte — Import erforderlich</string>
 </resources>

--- a/android/app/src/main/res/values-es/strings.xml
+++ b/android/app/src/main/res/values-es/strings.xml
@@ -1757,4 +1757,6 @@
     <string name="battery_channel_name">Alertas de batería</string>
     <string name="battery_channel_desc">Avisos cuando la batería de la pulsera está baja o completamente cargada.</string>
     <string name="l10n_app_changelog_battery_saver_quiets_the_gauges_translated_bdbe8650">El ahorro de batería calma los indicadores, notificaciones de Android traducidas y gráficos instantáneos</string>
+    <string name="l10n_health_screen_no_spo_import_or_health_value_408f8c55">Sin importación de SpO₂ ni valor de Health</string>
+    <string name="l10n_health_screen_raw_counts_only_needs_an_import_d0e33552">Solo valores brutos — requiere importación</string>
 </resources>

--- a/android/app/src/main/res/values-fr/strings.xml
+++ b/android/app/src/main/res/values-fr/strings.xml
@@ -1757,4 +1757,6 @@
     <string name="battery_channel_name">Alertes de batterie</string>
     <string name="battery_channel_desc">Alertes lorsque la batterie du bracelet est faible ou complètement chargée.</string>
     <string name="l10n_app_changelog_battery_saver_quiets_the_gauges_translated_bdbe8650">L\'économiseur de batterie fige les jauges, notifications Android traduites et graphiques instantanés</string>
+    <string name="l10n_health_screen_no_spo_import_or_health_value_408f8c55">Aucune importation SpO₂ ni valeur Santé</string>
+    <string name="l10n_health_screen_raw_counts_only_needs_an_import_d0e33552">Valeurs brutes uniquement — importation requise</string>
 </resources>

--- a/android/app/src/main/res/values-pt-rPT/strings.xml
+++ b/android/app/src/main/res/values-pt-rPT/strings.xml
@@ -1751,4 +1751,6 @@
     <string name="battery_channel_name">Alertas de bateria</string>
     <string name="battery_channel_desc">Avisos quando a bateria da correia está fraca ou totalmente carregada.</string>
     <string name="l10n_app_changelog_battery_saver_quiets_the_gauges_translated_bdbe8650">A poupança de bateria acalma os indicadores, notificações Android traduzidas e gráficos instantâneos</string>
+    <string name="l10n_health_screen_no_spo_import_or_health_value_408f8c55">Sem importação de SpO₂ ou valor de saúde</string>
+    <string name="l10n_health_screen_raw_counts_only_needs_an_import_d0e33552">Apenas valores brutos — requer importação</string>
 </resources>

--- a/android/app/src/main/res/values-zh/strings.xml
+++ b/android/app/src/main/res/values-zh/strings.xml
@@ -1685,4 +1685,6 @@
     <string name="battery_channel_name">电量提醒</string>
     <string name="battery_channel_desc">当手环电量低或已充满时提醒。</string>
     <string name="l10n_app_changelog_battery_saver_quiets_the_gauges_translated_bdbe8650">省电模式让仪表静止、Android 通知已翻译、图表秒开</string>
+    <string name="l10n_health_screen_no_spo_import_or_health_value_408f8c55">无 SpO₂ 导入或健康数值</string>
+    <string name="l10n_health_screen_raw_counts_only_needs_an_import_d0e33552">仅原始计数 — 需导入</string>
 </resources>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -1783,4 +1783,6 @@
     <string name="battery_channel_name">Battery alerts</string>
     <string name="battery_channel_desc">Alerts when the strap battery is low or fully charged.</string>
     <string name="l10n_app_changelog_battery_saver_quiets_the_gauges_translated_bdbe8650">Battery saver quiets the gauges, translated Android notifications, and instant chart loads</string>
+    <string name="l10n_health_screen_no_spo_import_or_health_value_408f8c55">No SpO₂ import or Health value</string>
+    <string name="l10n_health_screen_raw_counts_only_needs_an_import_d0e33552">Raw counts only — needs an import</string>
 </resources>

--- a/android/app/src/test/java/com/noop/ui/Spo2MissingCaptionTest.kt
+++ b/android/app/src/test/java/com/noop/ui/Spo2MissingCaptionTest.kt
@@ -1,0 +1,113 @@
+package com.noop.ui
+
+import com.noop.R
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.File
+
+/**
+ * The Blood O₂ tile must distinguish "the sensor recorded nothing" from "the sensor recorded, but the
+ * calibrated % comes from an import".
+ *
+ * A WHOOP 4.0 banks raw red/IR ADC counts and NOT a percentage — the schema says so at the field
+ * (`raw ADC; SpO2 % computed server-side`) — so `spo2Pct` is import-only by design and the raw tile shows
+ * the counts instead. When both tiles render together the old wording contradicted itself: an empty
+ * "No SpO₂ import or Health value" sitting beside a Raw SpO₂ tile displaying a live number, which reads
+ * as a broken strap rather than a missing import. That is a real user report, not a hypothetical.
+ *
+ * `vitalsFor` resolves strings through `NoopApplication`, so it cannot run in a JVM unit test at all;
+ * [spo2MissingCaptionRes] exists to make the BRANCH testable without the resource lookup.
+ */
+class Spo2MissingCaptionTest {
+
+    @Test
+    fun rawCountsPresentGetsTheImportWording() {
+        assertEquals(
+            R.string.l10n_health_screen_raw_counts_only_needs_an_import_d0e33552,
+            spo2MissingCaptionRes(hasRawSpo2 = true),
+        )
+    }
+
+    @Test
+    fun nothingDecodedKeepsTheOriginalWording() {
+        assertEquals(
+            R.string.l10n_health_screen_no_spo_import_or_health_value_408f8c55,
+            spo2MissingCaptionRes(hasRawSpo2 = false),
+        )
+    }
+
+    /** The whole point is that the two states read differently. */
+    @Test
+    fun theTwoEmptyStatesAreNotTheSameString() {
+        assertNotEquals(spo2MissingCaptionRes(true), spo2MissingCaptionRes(false))
+    }
+
+    // --- cross-platform wording parity ---
+
+    private fun repoRoot(): File {
+        val userDir = File(System.getProperty("user.dir") ?: ".")
+        val candidates = listOf(userDir, File(userDir, ".."), File(userDir, "../.."))
+        val found = candidates.firstOrNull { File(it, "Strand/Resources/Localizable.xcstrings").isFile }
+        assertNotNull(
+            "repo root not found from user.dir=$userDir — this guard cannot run, and a skip reads as a " +
+                "pass. Add this host's working dir rather than letting it slide.",
+            found,
+        )
+        return found!!
+    }
+
+    /**
+     * Both captions must carry the SAME English text on both platforms.
+     *
+     * `Vital.missingCaption` is documented as the "Kotlin twin of `BodyVitalReading.missingCaption`
+     * (VitalSignsSummary.swift) — same wording", and nothing enforced it: Apple wrapped these in
+     * `String(localized:)` while Android used raw Kotlin literals, so the two could drift silently and
+     * a German phone got English on exactly one platform. Reading both catalogues is the only check
+     * available here, since the Swift side is app-target and no CI job compiles it.
+     */
+    @Test
+    fun bothCaptionsMatchTheSwiftCatalogueWordForWord() {
+        val root = repoRoot()
+        val androidXml = File(root, "android/app/src/main/res/values/strings.xml").readText()
+        val xcstrings = File(root, "Strand/Resources/Localizable.xcstrings").readText()
+
+        val expected = mapOf(
+            "l10n_health_screen_no_spo_import_or_health_value_408f8c55" to "No SpO₂ import or Health value",
+            "l10n_health_screen_raw_counts_only_needs_an_import_d0e33552" to "Raw counts only — needs an import",
+        )
+        for ((key, en) in expected) {
+            assertTrue(
+                "Android is missing $key -> \"$en\"",
+                androidXml.contains("<string name=\"$key\">$en</string>"),
+            )
+            assertTrue(
+                "the Swift catalogue has no entry for \"$en\" — the twin captions have drifted apart",
+                xcstrings.contains("\"$en\""),
+            )
+        }
+    }
+
+    /**
+     * The new caption must be translated everywhere the one it sits beside is, or the fix lands as English
+     * for precisely the non-English users who hit the confusing version. (The report behind this was a
+     * German screenshot.)
+     */
+    @Test
+    fun theNewCaptionIsTranslatedInEveryLocaleTheSiblingIs() {
+        val root = File(repoRoot(), "android/app/src/main/res")
+        val locales = root.listFiles { f: File -> f.isDirectory && f.name.startsWith("values-") }
+            ?.filterNot { it.name.matches(Regex("values-(night|v\\d+|land|sw\\d+.*)")) }
+            ?.filter { File(it, "strings.xml").isFile }
+            ?: emptyList()
+        assertTrue("no locale dirs found — the census is looking in the wrong place", locales.isNotEmpty())
+
+        val missing = locales.filterNot {
+            File(it, "strings.xml").readText()
+                .contains("l10n_health_screen_raw_counts_only_needs_an_import_d0e33552")
+        }.map { it.name }
+        assertEquals("these locales have the sibling caption but not the new one: $missing", emptyList<String>(), missing)
+    }
+}


### PR DESCRIPTION
From a user report: *"My whoop 4.0 doesn't record any blood oxygen why is that so?"* — with a
screenshot showing **Blood O₂ empty and Raw SpO₂ reading 553 ADC on the same screen**.

Their strap was recording. The app said otherwise.

## Why the tile is empty, and why that is correct

A WHOOP 4.0 banks `spo2_red@68` / `spo2_ir@70` as **raw ADC counts**, not a percentage. The schema says
so at the field — `raw ADC; SpO2 % computed server-side` — and again on the layout: *"Raw ADCs
(SpO2/temp/resp) are NOT converted client-side; WHOOP computes them in cloud."*

So `spo2Pct` is import-only on purpose. Deriving a calibrated % from the raw ADC needs the dense
dual-wavelength waveform plus WHOOP's proprietary curve, and guessing it would manufacture a
plausible-but-wrong health number — the trap that withdrew #194. `Spo2ReTrace` exists precisely to find
out whether the strap banks a computed value we have not mapped, rather than inventing one.

None of that changes here. **No new value is computed and no number moves.**

## What was wrong

The two tiles render together, and the wording contradicted itself:

| | before | after |
|---|---|---|
| Blood O₂, night with raw counts | *No SpO₂ import or Health value* | ***Raw counts only — needs an import*** |
| Blood O₂, nothing decoded | *No SpO₂ import or Health value* | unchanged |
| Raw SpO₂ | *553 ADC · Uncalibrated* | unchanged |

"No SpO₂ import or Health value" is true but reads as *your sensor recorded nothing* — directly beside a
tile showing a live number from that same sensor, on that same night. Two genuinely different empty
states were sharing one sentence, and the one that fires when the hardware WORKED is the one that reads
like it did not.

## The second defect underneath it

The reporter's screenshot is **German**. Every label is translated; the caption explaining the empty
value would not have been.

`Vital.missingCaption` is documented as the *"Kotlin twin of `BodyVitalReading.missingCaption`
(VitalSignsSummary.swift) — same wording"*. Apple wraps all six in `String(localized:)`. Android had
them as raw Kotlin literals. So on a non-English phone, the tile whose entire job is explaining why a
value is missing answered in English — on one platform only.

Both Blood O₂ captions are now localised on Android. The existing one **reuses the translations already
shipping on Apple, verbatim** rather than inventing a second wording. The new one is translated in all
eight Apple locales and all five Android ones.

The other four `missingCaption`s in that file are still raw literals, as is the whole of Android's
`stateCaption` ("In your range", "Uncalibrated", …) where Apple localises every branch. Same defect,
wider than this tile — they belong to #922's sweep and are left alone here rather than half-fixed.

## The invariant this rests on (found re-reviewing, now written down)

The two platforms do **not** resolve the same row. Android keys off the selected day; Apple's `latest()`
is `logicalDay ?? most recent`, so it deliberately falls back to an earlier day rather than blanking
after a night with no wear. The conditions are therefore not the same predicate over the data.

They are the same predicate over **what the user sees**: each is exactly its own platform's Raw SpO₂
tile value expression, so "raw counts only" fires precisely when the tile beside it is showing a number.
That is the relationship the caption asserts, and it holds identically on both. The row difference is
pre-existing and by design; the coupling between the two tiles is the thing that must not drift, so it
is now stated at both branch sites.

## Tests

`vitalsFor` resolves strings through `NoopApplication`, so **nothing in that file can run in a JVM unit
test** — which is why it has none. The branch is split into `spo2MissingCaptionRes` so the part worth
pinning is testable without the resource lookup:

- each branch selects its own caption, and the two are not the same string;
- the English wording matches the Swift catalogue **word for word** — the parity the doc comment claims
  and nothing enforced;
- the new caption exists in **every locale the sibling does**, so the fix cannot land as English for
  exactly the non-English users who hit the confusing version.

`Tools/i18n_audit.py --ci main` and `Tools/doc_comment_lint.py` both clean.

## Verification, stated honestly

Android CI is the gate and it runs the new tests. **`Strand/Screens/VitalSignsSummary.swift` is
app-target Swift, which nothing compiles while `app-build.yml` is disabled** — the change there is a
ternary on an existing local (`spo2rawRow`, already resolved two lines above the tile) plus one
catalogue entry, but it is uncompiled and worth an `xcodebuild` before merge.

Gradle does not run on this arm64 host (`aapt2` is x86-64 only), so the Kotlin was not compiled locally
either; the partial embeddable-compiler run could not resolve `R` / `VitalBands` / `Palette` and proves
nothing. CI is doing the work here, not me.

No hardware involved: this changes a caption, not a decode.
