### PR TITLE
Point issue references at this repo, not a repo that no longer exists

### DIFF
--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/AnalyticsEngine.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/AnalyticsEngine.swift
@@ -324,7 +324,7 @@ public enum AnalyticsEngine {
                                   // false to keep pure-function callers/tests byte-identical — it is NOT
                                   // the product default. IntelligenceEngine threads
                                   // `PuffinExperiment.experimentalSleepV2Enabled`, which is default ON
-                                  // (#277/#351), so the shipped app stages with V2. (V7 / #690)
+                                  // (#277/#351), so the shipped app stages with V2. (7.0.0)
                                   useSleepStagerV2: Bool = false,
                                   // Opt-in motion-aware wake refinement (#364 "Proposal 2" follow-up; density
                                   // gate precedent #345). When true, `WakeMotionRefinement` re-derives each

--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/SleepStager.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/SleepStager.swift
@@ -827,7 +827,7 @@ public enum SleepStager {
     /// re-onset (#531): a daytime block the strap itself scored predominantly "asleep" is KEPT even on a
     /// borderline HR dip. Default empty keeps pure-function callers/tests free of it; IntelligenceEngine
     /// passes the night window's persisted band state. It can only RESCUE a real-sleep block, never fabricate.
-    /// `useSleepStagerV2` (V7 / #690): which recipe stages an accepted night — the cardiorespiratory
+    /// `useSleepStagerV2` (7.0.0; default ON since #277/#351): which recipe stages an accepted night — the cardiorespiratory
     /// `SleepStagerV2.stageSession` when true, V1's `stageSession` when false. DETECTION is unchanged
     /// (same accepted windows); only the per-epoch hypnogram differs.
     ///

--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/SleepStagerV2.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/SleepStagerV2.swift
@@ -5,7 +5,8 @@ import WhoopProtocol
 // percentile-band stager `SleepStager` (V1) after a 44-subject cross-subject benchmark; V1 stays available
 // behind the PuffinExperiment flag.
 //
-// Reimplemented clean from the contributor recipe in NoopApp/noop PR #600 (sunny-noop). We took only the
+// Reimplemented clean from @sunny-noop's contributor recipe (pre-fork PR #600 — NOT this repo's #600,
+// which is an iOS notification). We took only the
 // per-session STAGING engine, not the CLI runner the PR shipped with it. Session DETECTION (the in-bed
 // `[start, end]` spans) still comes entirely from V1 — this file only re-stages a window someone already
 // decided is sleep, so it is a true drop-in for `SleepStager.stageSession(start:end:grav:hr:rr:resp:)`:

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/SleepStagerV2Tests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/SleepStagerV2Tests.swift
@@ -2,7 +2,7 @@ import XCTest
 @testable import StrandAnalytics
 import WhoopProtocol
 
-/// Basic coverage for `SleepStagerV2` (V7 Pillar 3b, reimplemented from contributor PR #600) — the recipe
+/// Basic coverage for `SleepStagerV2` (V7 Pillar 3b, reimplemented from @sunny-noop's recipe) — the recipe
 /// that stages a normal user's nights, since `PuffinExperiment.experimentalSleepV2Enabled` is default ON
 /// (#277 promoted it over V1; #351 extended it to every strap family). These assert the drop-in CONTRACT —
 /// same `stageSession` signature + return shape as V1, segments that tile `[start, end]` with canonical
@@ -207,7 +207,7 @@ final class SleepStagerV2Tests: XCTestCase {
         XCTAssertEqual(path, ["light"])
     }
 
-    // MARK: - #690: the V2 flag drives the NORMAL detected-night staging path
+    // MARK: - 7.0.0: the V2 flag drives the NORMAL detected-night staging path
 
     /// A regular R-R stream at ~1 Hz (steady ~1000 ms beats with a small respiratory sinus oscillation),
     /// long enough for the V2 recipe to express both early deep and later REM across the night.
@@ -218,7 +218,7 @@ final class SleepStagerV2Tests: XCTestCase {
         }
     }
 
-    /// #690 (v7 regression): the "Experimental sleep staging (V2)" toggle must affect a NORMAL detected
+    /// 7.0.0 regression: the "Experimental sleep staging (V2)" toggle must affect a NORMAL detected
     /// night — not only the userEdited self-heal restage. With the flag ON, `detectSleep` stages the
     /// accepted window with V2 (deep + REM present); with the flag OFF it returns the EXACT V1 result, so
     /// the byte-identical default (and the frozen-golden tests) is preserved.

--- a/Strand/System/ReportReviewGate.swift
+++ b/Strand/System/ReportReviewGate.swift
@@ -13,8 +13,8 @@ struct ReportReviewGate {
     init(entries: [FileExport.BundleEntry]) { self.entries = entries }
 
     /// The bundle files that are NEVER shown inline in the review sheet by NAME: the binary screenshot plus
-    /// the large raw research streams (WHOOP raw-capture + the Oura Tier-B sidecars — each up to the 20 MB
-    /// cap). Rendering megabytes of text as a single SwiftUI `Text` pins the main thread in CoreText glyph
+    /// the large raw research streams (WHOOP raw-capture + the Oura Tier-B sidecars — each up to the 25 MB
+    /// cap `OuraActivityDump.maxBytes` / `OuraMotionDump.maxBytes` actually enforce; this said 20 MB). Rendering megabytes of text as a single SwiftUI `Text` pins the main thread in CoreText glyph
     /// layout — a ~12 MB `oura-raw.jsonl` allocated >1 GB and hung the review sheet indefinitely. They are
     /// already PII-scrubbed and are NAMED in the "attached" note below, so the review stays honest without
     /// trying to lay them out.

--- a/android/app/src/main/java/com/noop/analytics/AnalyticsEngine.kt
+++ b/android/app/src/main/java/com/noop/analytics/AnalyticsEngine.kt
@@ -221,7 +221,7 @@ object AnalyticsEngine {
         // [SleepStagerV2] instead of V1. This PARAMETER defaults false to keep pure-function callers/tests
         // byte-identical — it is NOT the product default. IntelligenceEngine threads
         // PuffinExperiment.from(context).experimentalSleepV2, which is default TRUE (#277/#351), so the
-        // shipped app stages with V2. Mirrors Swift. (V7 / #690)
+        // shipped app stages with V2. Mirrors Swift. (7.0.0)
         useSleepStagerV2: Boolean = false,
         // Opt-in motion-aware wake refinement (#364 "Proposal 2" follow-up; density gate precedent #345).
         // When true, [WakeMotionRefinement] re-derives each detected session's stages, reclassifying a

--- a/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
+++ b/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
@@ -575,7 +575,7 @@ object IntelligenceEngine {
                 wristOff = wristOff,
                 habitualMidsleepSec = habitualMidsleepSec,
                 bandSleepState = bandSleepState,
-                // #690: thread the V2 toggle into the NORMAL staging path so it affects detected nights,
+                // 7.0.0: thread the V2 toggle into the NORMAL staging path so it affects detected nights,
                 // not just the userEdited self-heal restage. The Context-aware caller (AppViewModel/
                 // WhoopBleClient) supplied it from PuffinExperiment.from(context).experimentalSleepV2.
                 // V2 is the default staging engine for EVERY strap (toggle defaults on); turn it off for V1.

--- a/android/app/src/main/java/com/noop/analytics/SleepStager.kt
+++ b/android/app/src/main/java/com/noop/analytics/SleepStager.kt
@@ -938,7 +938,7 @@ object SleepStager {
         // HR dip. Default empty keeps pure-function callers/tests free of it; IntelligenceEngine passes the
         // night window's persisted band state. It can only RESCUE a real-sleep block, never fabricate. Mirrors Swift.
         bandSleepState: List<Pair<Long, Int>> = emptyList(),
-        // V7 / #690: which recipe stages an accepted night — the cardiorespiratory
+        // 7.0.0 (default ON since #277/#351): which recipe stages an accepted night — the cardiorespiratory
         // [SleepStagerV2.stageSession] when true, V1's [stageSession] when false. DETECTION is unchanged
         // (same accepted windows); only the per-epoch hypnogram differs.
         // THE TWO DEFAULTS DIFFER. This PARAMETER defaults false so pure-function callers and the

--- a/android/app/src/main/java/com/noop/analytics/SleepStagerV2.kt
+++ b/android/app/src/main/java/com/noop/analytics/SleepStagerV2.kt
@@ -18,7 +18,8 @@ import kotlin.math.sqrt
  * PuffinExperiment flag.
  *
  * Byte-identical-logic Kotlin twin of StrandAnalytics/SleepStagerV2.swift, itself reimplemented clean from
- * the contributor recipe in NoopApp/noop PR #600 (sunny-noop). We took only the per-session STAGING engine,
+ * @sunny-noop's contributor recipe (pre-fork PR #600 — NOT this repo's #600, which is an iOS
+ * notification). We took only the per-session STAGING engine,
  * not the CLI runner the PR shipped with it. Session DETECTION (the in-bed [start, end] spans) still comes
  * entirely from V1 — this file only re-stages a window someone already decided is sleep, so it is a true
  * drop-in for [SleepStager.stageSession]: SAME signature, SAME List<StageSegment> return shape.

--- a/android/app/src/main/java/com/noop/ble/HrBroadcaster.kt
+++ b/android/app/src/main/java/com/noop/ble/HrBroadcaster.kt
@@ -101,7 +101,7 @@ class HrBroadcaster(
      * ENTIRELY to the broadcast (WHOOP-first isolation: it never touches the WHOOP path). iOS gets this
      * free from CBPeripheralManager's state delegate.
      *
-     * Credit: ryanbr (NoopApp/noop#1029).
+     * Credit: ryanbr (pre-fork #1029 — that number is not this repo's).
      */
     private val bluetoothStateReceiver = object : BroadcastReceiver() {
         override fun onReceive(context: Context?, intent: Intent?) {

--- a/android/app/src/test/java/com/noop/analytics/SleepStagerV2Test.kt
+++ b/android/app/src/test/java/com/noop/analytics/SleepStagerV2Test.kt
@@ -13,7 +13,7 @@ import kotlin.math.sin
 import kotlin.math.roundToInt
 
 /**
- * Basic coverage for [SleepStagerV2] (V7 Pillar 3b, reimplemented from contributor PR #600), the Android
+ * Basic coverage for [SleepStagerV2] (V7 Pillar 3b, reimplemented from @sunny-noop's recipe), the Android
  * twin of SleepStagerV2Tests.swift — the recipe that stages a normal user's nights, since the stored
  * `experimentalSleepV2` preference is default TRUE (#277 promoted it over V1; #351 extended it to every
  * strap family). Asserts the drop-in CONTRACT — same [SleepStager.stageSession] signature + return shape,
@@ -114,10 +114,10 @@ class SleepStagerV2Test {
         assertTrue("V2 output is a segment array", v2!!.trimStart().startsWith("["))
     }
 
-    // ── #690: the V2 flag drives the NORMAL detected-night staging path ─────────────────────────────────
+    // ── 7.0.0: the V2 flag drives the NORMAL detected-night staging path ─────────────────────────────────
 
     /**
-     * #690 (v7 regression): the "Experimental sleep staging (V2)" toggle must affect a NORMAL detected
+     * 7.0.0 regression: the "Experimental sleep staging (V2)" toggle must affect a NORMAL detected
      * night — not only the userEdited self-heal restage. With the flag ON, [SleepStager.detectSleep]
      * stages the accepted window with V2 (deep + REM present); with the flag OFF it returns the EXACT V1
      * result, so the byte-identical default (and the frozen-golden tests) is preserved. Android twin of


### PR DESCRIPTION
Comments only — no schema, no behaviour, no stored value.

## The problem

The sleep files carried `#600` and `#690` from the project's pre-fork repo. `github.com/NoopApp/noop`
404s and this repo is a fork whose parent no longer resolves, so those links were dead — and worse, they
collide with real numbers here:

| number | in this repo | in the sleep comments |
|---|---|---|
| `#600` | feat(ios): Target Strain Reached notification | the V2 staging recipe |
| `#690` | GET_BODY_LOCATION_AND_STATUS probe — cited correctly by `BodyLocationProbe` | the V2 staging flag |

So `#690` meant two different things depending on which file you were reading.

## Now pointed at this repo

- **The V2 recipe** keeps its credit as **`@sunny-noop`** and loses the dead path — matching how the same
  contributor is already credited in `HealthExportPlan.kt` and `SpotHrvReading.kt`.
- **The V2-flag sites** cite **7.0.0**, the release that introduced `SleepStagerV2` here
  (`CHANGELOG.md:240`; the file arrives in commit `4da3cfb4`), plus **#277/#351** for the default-ON
  claim — which those same files already cite one line above.
- **`HrBroadcaster`'s credit** keeps ryanbr, loses the dead path.
- `BodyLocationProbe` is untouched. Its `#690` was always right.

**Nothing live pointed at the old repo** — checked, because a dead update endpoint would have mattered
more than any comment. `UpdateChecker.swift:21` and `UpdateCheck.kt:18` both read
`api.github.com/repos/ryanbr/noop/releases/latest`, and both About links go to `github.com/ryanbr/noop`.

**The two `AppChangelog` entries mentioning NoopApp are deliberately left alone.** They are the shipped
release notes for the version that made that change; rewriting them would falsify the record rather than
correct it.

## Also: the Oura sidecar cap

`ReportReviewGate` described the Tier-B sidecars as *"each up to the 20 MB cap"*. Both dumps enforce
`maxBytes = 25 * 1024 * 1024`. Relevant to #937, which adds a third sidecar and should not copy a wrong
number.

## Verification

Comments only — verified mechanically, zero non-comment changed lines across all ten files.
`Tools/doc_comment_lint.py` clean.

*(This also supersedes my review note on #925, which suggested renumbering these to `#347 → #351 → #277`.
That would have destroyed a contributor's provenance — the numbers were pre-fork, not stale.)*
