### PR TITLE
Let the SpO2 promote gate read a NOOP app store, so the app can answer its own question (#845, #103)

### DIFF
--- a/tools/linux-capture/test_validate_spo2_candidate.py
+++ b/tools/linux-capture/test_validate_spo2_candidate.py
@@ -806,3 +806,175 @@ class FeatureAbsentClassificationTests(unittest.TestCase):
         self.assertNotIn("96.00", blob)
         self.assertNotIn("cycle_start", blob.lower())
         self.assertIn("duty_mode", blob)
+
+
+# --- NOOP app store (#845/#103) --------------------------------------------------------------------
+
+def _pack_v18_aux(values: dict) -> bytes:
+    """Build a `v18AuxSample.fields` blob the way the Swift/Kotlin codecs do."""
+    bitmap = 0
+    body = b""
+    for i, (name, width) in enumerate(vs.V18_AUX_SLOTS):
+        if name in values:
+            bitmap |= 1 << i
+            body += int(values[name]).to_bytes(width, "little")
+    if bitmap == 0:
+        return b""
+    return bytes([vs.V18_AUX_FORMAT_VERSION]) + bitmap.to_bytes(4, "little") + body
+
+
+def _write_app_db(folder: str, rows, *, device: str = "strap-a", name: str = "noop.sqlite") -> str:
+    """A minimal NOOP app store: just the two tables this reader touches, same columns as the
+    GRDB migration (`Database.swift` v23)."""
+    path = os.path.join(folder, name)
+    con = sqlite3.connect(path)
+    con.execute("CREATE TABLE v18AuxSample (deviceId TEXT NOT NULL, ts INTEGER NOT NULL, "
+                "fields BLOB NOT NULL, PRIMARY KEY(deviceId, ts))")
+    con.execute("CREATE TABLE sleepStateSample (deviceId TEXT NOT NULL, ts INTEGER NOT NULL, "
+                "state INTEGER NOT NULL, rawByte INTEGER, PRIMARY KEY(deviceId, ts))")
+    for ts, raw82, state in rows:
+        con.execute("INSERT INTO v18AuxSample VALUES (?,?,?)",
+                    (device, ts, _pack_v18_aux({"aux_byte_82": raw82})))
+        con.execute("INSERT INTO sleepStateSample VALUES (?,?,?,?)", (device, ts, state, 0x20))
+    con.commit()
+    con.close()
+    return path
+
+
+class V18AuxCodecTests(unittest.TestCase):
+    """The Python reader must decode what the SHIPPED Swift codec writes, not merely round-trip
+    itself. Both fixtures below are the literal output of `V18AuxCodec.pack` run in
+    `Packages/WhoopStore` — if the wire format changes, these fail rather than silently mis-slicing
+    real rows into plausible-looking numbers."""
+
+    # V18AuxSample(ts:1700000000, recordIndex:7, rrCount:3, cardiacFlags:0x81, hrQualityFlags:0x80,
+    #   heartRateAlt:58, rrPacked:0x1234, cardiacStatus:255, stepCadence:40, statusWord:0x0550,
+    #   statusWord1:0x0331, statusWord2:0x0442, auxByte82:96, opticalBaselineA:31,
+    #   opticalBaselineB:33, opticalAmpA:128, opticalAmpB:128, unknownF32Bits:0xC0A93B1F)
+    SWIFT_FULL = bytes.fromhex("02ffff0100070000000381803a3412ff28500531034204601f2180801f3ba9c0")
+    # V18AuxSample(ts:1, auxByte82:96) — one slot present.
+    SWIFT_SPARSE = bytes.fromhex("020008000060")
+
+    def test_decodes_every_slot_the_swift_codec_packs(self):
+        self.assertEqual(vs.unpack_v18_aux(self.SWIFT_FULL), {
+            "record_index": 7, "rr_count": 3, "cardiac_flags": 0x81, "hr_quality_flags": 0x80,
+            "heart_rate_alt": 58, "rr_packed": 0x1234, "cardiac_status": 255, "step_cadence": 40,
+            "status_word": 0x0550, "status_word_1": 0x0331, "status_word_2": 0x0442,
+            "aux_byte_82": 96, "optical_baseline_a": 31, "optical_baseline_b": 33,
+            "optical_amp_a": 128, "optical_amp_b": 128, "unknown_f32_113": 0xC0A93B1F,
+        })
+
+    def test_absent_slots_are_omitted_not_zero(self):
+        # The whole point of the presence bitmap: "the strap did not report this" must not read as 0.
+        got = vs.unpack_v18_aux(self.SWIFT_SPARSE)
+        self.assertEqual(got, {"aux_byte_82": 96})
+        self.assertNotIn("optical_amp_a", got)
+
+    def test_malformed_blobs_yield_nothing_rather_than_raising(self):
+        for bad in (b"", b"\x02", bytes([1]) + b"\x00" * 4, bytes([99]) + b"\x00" * 4):
+            self.assertEqual(vs.unpack_v18_aux(bad), {})
+
+    def test_truncated_body_keeps_what_decoded(self):
+        got = vs.unpack_v18_aux(self.SWIFT_FULL[:9])
+        self.assertEqual(got["record_index"], 7)
+        self.assertNotIn("aux_byte_82", got)
+
+
+class AppDbReaderTests(unittest.TestCase):
+    def test_app_store_is_told_apart_from_a_capture_store(self):
+        with tempfile.TemporaryDirectory() as td:
+            app = _write_app_db(td, [(1700000000, 96, 2)])
+            self.assertTrue(vs.looks_like_app_db(app))
+            cap = os.path.join(td, "cap.json")
+            with open(cap, "w") as f:
+                json.dump([], f)
+            self.assertFalse(vs.looks_like_app_db(cap))
+
+    def test_reads_banked_aux_byte_and_sleep_state(self):
+        with tempfile.TemporaryDirectory() as td:
+            app = _write_app_db(td, [(1700000000 + i, 95 + i, 2) for i in range(4)])
+            recs = vs.load_app_db_records(app)
+        self.assertEqual(len(recs), 4)
+        self.assertEqual([r["spo2_candidate_82"] for r in recs], [95, 96, 97, 98])
+        self.assertTrue(all(r["sleep_state"] == vs.SLEEP_ASLEEP for r in recs))
+
+    def test_out_of_band_values_are_not_candidates(self):
+        with tempfile.TemporaryDirectory() as td:
+            app = _write_app_db(td, [(1700000000, 0, 2), (1700000001, 96, 2)])
+            recs = vs.load_app_db_records(app)
+        self.assertIsNone(recs[0]["spo2_candidate_82"])
+        self.assertEqual(recs[0]["aux_byte_82"], 0)
+        self.assertEqual(recs[1]["spo2_candidate_82"], 96)
+
+    def test_several_straps_refuse_to_pool_without_an_explicit_pick(self):
+        with tempfile.TemporaryDirectory() as td:
+            app = _write_app_db(td, [(1700000000, 96, 2)], device="strap-a")
+            con = sqlite3.connect(app)
+            con.execute("INSERT INTO v18AuxSample VALUES (?,?,?)",
+                        ("strap-b", 1700000000, _pack_v18_aux({"aux_byte_82": 90})))
+            con.commit()
+            con.close()
+            with self.assertRaises(SystemExit):
+                vs.load_app_db_records(app)
+            # ...but naming one is fine, and reads only that strap.
+            recs = vs.load_app_db_records(app, device_id="strap-b")
+        self.assertEqual([r["aux_byte_82"] for r in recs], [90])
+
+    def test_only_offset_82_is_answerable_without_the_frame(self):
+        # The app banks decoded slots, not frame bytes, so the specificity scan cannot run — and
+        # "cannot know" must be None rather than 0, or it would manufacture out-of-band samples.
+        with tempfile.TemporaryDirectory() as td:
+            app = _write_app_db(td, [(1700000000, 96, 2)])
+            rec = vs.load_app_db_records(app)[0]
+        self.assertEqual(vs.byte_at_offset(rec, vs.OFF_SPO2_CANDIDATE), 96)
+        for off in (74, 81, 83, 92):
+            self.assertIsNone(vs.byte_at_offset(rec, off))
+
+    def test_end_to_end_validate_device_against_an_app_store(self):
+        """The point of the whole path: a NOOP user with only their synced app DB can run the gate."""
+        nights, rows = [], []
+        base = _utc(2026, 3, 1, 23, 0, 0)
+        for night in range(6):
+            t0 = base + night * 86400
+            t1 = t0 + 6 * 3600
+            spo2 = 95.0 + night * 0.5
+            start = datetime.fromtimestamp(t0, tz=timezone.utc).strftime("%Y-%m-%d %H:%M:%S")
+            nights.append((start, spo2, t0, t1))
+            for k in range(40):
+                rows.append((t0 + k * 60, int(round(spo2)), vs.SLEEP_ASLEEP))
+        with tempfile.TemporaryDirectory() as td:
+            app = _write_app_db(td, rows)
+            res = vs.validate_device(app, _write_export(td, nights), device="app")
+        self.assertEqual(res["source"], "noop_app_db")
+        self.assertEqual(res["specificity_scan"], "unavailable_app_db")
+        self.assertEqual(res["paired_nights"], 6)
+        self.assertIsNotNone(res["r"])
+        self.assertGreater(res["r"], 0.9)
+        # The scan could not run, so it must not be recorded as "@82 lost".
+        self.assertTrue(res["checklist"]["offset_82_wins"])
+        self.assertIsNone(res["best_specificity_offset"])
+
+    def test_a_capture_still_runs_the_specificity_scan(self):
+        """Guard the other direction: the app path must not disable the scan for real captures."""
+        with tempfile.TemporaryDirectory() as td:
+            d = self._six_night_capture(td)
+            res = vs.validate_device(d["capture"], d["export"], device="cap")
+        self.assertEqual(res["source"], "capture")
+        self.assertEqual(res["specificity_scan"], "ran")
+
+    def _six_night_capture(self, td: str) -> dict:
+        frames, nights = [], []
+        base = _utc(2026, 3, 1, 23, 0, 0)
+        for night in range(6):
+            t0 = base + night * 86400
+            t1 = t0 + 6 * 3600
+            spo2 = 95.0 + night * 0.5
+            start = datetime.fromtimestamp(t0, tz=timezone.utc).strftime("%Y-%m-%d %H:%M:%S")
+            nights.append((start, spo2, t0, t1))
+            for k in range(40):
+                frames.append({"hex": make_v18(t0 + k * 60, aux_byte_82=int(round(spo2)),
+                                               sleep_state=vs.SLEEP_ASLEEP).hex()})
+        cap = os.path.join(td, "cap.json")
+        with open(cap, "w") as f:
+            json.dump(frames, f)
+        return {"capture": cap, "export": _write_export(td, nights)}

--- a/tools/linux-capture/validate_spo2_candidate.py
+++ b/tools/linux-capture/validate_spo2_candidate.py
@@ -9,12 +9,29 @@ Context (see docs/WHOOP5_DEEP_DATA.md and issue #103):
 
 This tool answers the promote-or-not question as *known plaintext*:
 
-    capture.json OR a whoop_sync.py .db  +  whoop_export  ──►  mean(@82 | asleep, 70–100, in-window)
+    capture.json OR a whoop_sync.py .db OR a NOOP app store  +  whoop_export
+                                       ──►  mean(@82 | asleep, 70–100, in-window)
                                        vs CSV blood_oxygen_pct
                                        ──►  r, MAE, bias, offset-specificity, window coverage
 
 Owners can validate one strap, or batch several devices, and post **only aggregate
 stats** on #103 (never raw SpO₂ values). Stdlib only.
+
+THREE INPUT KINDS, and the third is why #103 has been stuck (#845):
+
+  • `capture.json` — hci_extract / whoop_capture output.
+  • a `whoop_sync.py` `.db` — the CAPTURE TOOLING's frame store.
+  • a **NOOP app store** — the shipped app's own SQLite (GRDB), read from `v18AuxSample`, the table
+    PR #848 added. Until this existed, only someone running linux-capture could contribute evidence,
+    so the app could not answer its own open question even though it banks the byte. An ordinary user
+    who syncs with NOOP can now run the promote gate on their own data.
+
+    The one thing an app store cannot do is the OFFSET SPECIFICITY SCAN: the app banks decoded slots,
+    not frame bytes, so there is no neighbour byte to rank @82 against. That is reported as
+    `specificity_scan: "unavailable_app_db"` and the corresponding checklist item is n/a — NOT False,
+    which would read as "@82 lost the scan" about a byte that was never ranked. A capture is still
+    required to settle specificity; the correlation, MAE, bias, duty-cycle detection and window
+    coverage all work from either.
 
 Three things the harness has to get right before a number from it means anything:
 
@@ -38,6 +55,9 @@ Usage:
 
     # Multi-device batch:
     python3 validate_spo2_candidate.py --batch devices.json
+
+    # From a NOOP app database (no linux-capture needed):
+    python3 validate_spo2_candidate.py noop.sqlite my_whoop_data/ --device strap-a
 
 devices.json example:
     [
@@ -275,6 +295,132 @@ def looks_like_sqlite(path: str) -> bool:
         return False
 
 
+# --- NOOP app database ------------------------------------------------------------------------------
+#
+# #845/#103: the app banks @82 (PR #848 added `v18AuxSample`), but until this path existed the harness
+# could only read the CAPTURE TOOLING's store — so a NOOP user could not run the promote gate on their
+# own synced data, and only someone running linux-capture could contribute evidence. That is the gap
+# #845 called "the app itself cannot currently contribute the data needed to resolve its own question".
+#
+# READ-ONLY, and opened as such: `mode=ro` plus `immutable=1` so no WAL recovery write is attempted
+# against a file pulled off a phone (the same reasoning `Tools/SleepBench` documents).
+
+# `V18AuxSlot` order and widths, mirrored from Streams.swift. Order IS the wire contract — the packed
+# body carries present slots in ascending slot order — so this list must not be reordered.
+V18_AUX_SLOTS: Sequence[Tuple[str, int]] = (
+    ("record_index", 4), ("rr_count", 1), ("cardiac_flags", 1), ("hr_quality_flags", 1),
+    ("heart_rate_alt", 1), ("rr_packed", 2), ("cardiac_status", 1), ("step_cadence", 1),
+    ("status_word", 2), ("status_word_1", 2), ("status_word_2", 2), ("aux_byte_82", 1),
+    ("optical_baseline_a", 1), ("optical_baseline_b", 1), ("optical_amp_a", 1),
+    ("optical_amp_b", 1), ("unknown_f32_113", 4),
+)
+V18_AUX_FORMAT_VERSION = 2
+V18_AUX_HEADER_BYTES = 5
+
+
+def unpack_v18_aux(blob: bytes) -> Dict[str, int]:
+    """Decode a `v18AuxSample.fields` blob. Python port of Swift `V18AuxCodec.unpack`.
+
+    Wire format (little-endian, no padding): version byte, u32 presence bitmap, then each PRESENT slot's
+    value in ascending slot order at its declared width.
+
+    Absence is first-class — a clear bit means "the strap did not report this field", never 0 — so the
+    returned dict simply omits it. A malformed, truncated or unknown-version blob yields `{}` rather than
+    raising, matching the Swift/Kotlin readers: a census over durable rows must not die on one bad row.
+    """
+    if len(blob) < V18_AUX_HEADER_BYTES or blob[0] != V18_AUX_FORMAT_VERSION:
+        return {}
+    bitmap = int.from_bytes(blob[1:5], "little")
+    out: Dict[str, int] = {}
+    i = V18_AUX_HEADER_BYTES
+    for slot, (name, width) in enumerate(V18_AUX_SLOTS):
+        if not bitmap & (1 << slot):
+            continue
+        if i + width > len(blob):
+            break        # truncated tail: keep what decoded, drop the rest
+        out[name] = int.from_bytes(blob[i:i + width], "little")
+        i += width
+    return out
+
+
+def looks_like_app_db(path: str) -> bool:
+    """True if `path` is a NOOP app store (GRDB/iOS/macOS) rather than a `whoop_sync.py` capture DB.
+
+    Discriminated on the `v18AuxSample` table, which only the app has; the capture store has `frames`
+    and the app has no `frames` table at all.
+    """
+    if not looks_like_sqlite(path):
+        return False
+    try:
+        con = sqlite3.connect(f"file:{path}?mode=ro&immutable=1", uri=True)
+    except sqlite3.Error:
+        return False
+    try:
+        row = con.execute(
+            "SELECT 1 FROM sqlite_master WHERE type='table' AND name='v18AuxSample'"
+        ).fetchone()
+        return row is not None
+    except sqlite3.Error:
+        return False
+    finally:
+        con.close()
+
+
+def load_app_db_records(path: str, *, device_id: Optional[str] = None) -> List[dict]:
+    """Records from a NOOP app store, shaped like `iter_v18_records` output.
+
+    Joins `v18AuxSample` (the banked per-second slots, #848) to `sleepStateSample.state` on
+    (deviceId, ts) — the band's own sleep state, which the asleep-only gate needs.
+
+    ONE STRUCTURAL LIMITATION, and it is not a bug: the raw frame is gone. The strap trims its history
+    once NOOP acks the offload and the app banks decoded slots, not frame bytes, so the OFFSET
+    SPECIFICITY SCAN (which reads neighbour bytes @70-@100 out of `_frame`) cannot run on this path.
+    The correlation, MAE, bias, duty-cycle detection and window coverage all can. Records therefore
+    carry no `_frame` key, which the scan already treats as "skip", and `main` says so rather than
+    printing an empty scan that reads like a negative result.
+    """
+    con = sqlite3.connect(f"file:{path}?mode=ro&immutable=1", uri=True)
+    try:
+        devices = [r[0] for r in con.execute("SELECT DISTINCT deviceId FROM v18AuxSample").fetchall()]
+        if not devices:
+            raise SystemExit(f"{path}: no v18AuxSample rows — nothing banked from a 5/MG v18 offload yet")
+        if device_id is None:
+            if len(devices) > 1:
+                raise SystemExit(
+                    f"{path}: {len(devices)} devices in v18AuxSample ({', '.join(sorted(devices))}); "
+                    f"pass --app-device to pick one — pooling straps would average away the very "
+                    f"per-device difference the promote gate is testing"
+                )
+            device_id = devices[0]
+        elif device_id not in devices:
+            raise SystemExit(f"{path}: no v18AuxSample rows for deviceId={device_id!r} "
+                             f"(have: {', '.join(sorted(devices))})")
+        rows = con.execute(
+            "SELECT a.ts, a.fields, s.state FROM v18AuxSample a "
+            "LEFT JOIN sleepStateSample s ON s.deviceId = a.deviceId AND s.ts = a.ts "
+            "WHERE a.deviceId = ? ORDER BY a.ts",
+            (device_id,),
+        ).fetchall()
+    except sqlite3.Error as e:
+        raise SystemExit(f"{path}: not a readable NOOP app store ({e})")
+    finally:
+        con.close()
+
+    out: List[dict] = []
+    for ts, blob, state in rows:
+        fields = unpack_v18_aux(bytes(blob) if blob is not None else b"")
+        raw82 = fields.get("aux_byte_82")
+        rec = dict(fields)
+        rec["unix"] = ts
+        rec["sleep_state"] = state
+        rec["aux_byte_82"] = raw82 if raw82 is not None else 0
+        rec["spo2_candidate_82"] = raw82 if raw82 in INBAND else None
+        out.append(rec)
+    if not out:
+        raise SystemExit(f"{path}: no v18AuxSample rows for deviceId={device_id!r}")
+    return out
+
+
 def load_frame_records(path: str, *, device_id: int = 2) -> List[dict]:
     """Frame records as `{"hex": ...}` dicts, from EITHER a capture.json or a `whoop_sync.py` store.
 
@@ -355,6 +501,26 @@ def iter_v18_records(capture_records: Sequence[dict]) -> Iterable[dict]:
         # Neighbor bytes for specificity scan (absolute offsets).
         d["_frame"] = frame
         yield d
+
+
+def byte_at_offset(rec: dict, offset: int) -> Optional[int]:
+    """The raw byte at absolute frame `offset` for one record, or None when it is unavailable.
+
+    Frame-derived records carry `_frame` and any offset can be read from it. Records loaded from a NOOP
+    app store do NOT — the app banks decoded slots, not frame bytes — so only @82 is answerable there,
+    from the banked `aux_byte_82`. Every other offset returns None, which is what correctly confines the
+    OFFSET SPECIFICITY SCAN to captures while leaving the @82 correlation itself fully available.
+
+    Returning None (not 0) matters: 0 is a legitimate @82 reading outside the duty window, and treating
+    "cannot know" as "read zero" would manufacture out-of-band samples that silently depress coverage.
+    """
+    frame = rec.get("_frame")
+    if frame is not None:
+        return frame[offset] if len(frame) > offset else None
+    if offset == OFF_SPO2_CANDIDATE:
+        v = rec.get("aux_byte_82")
+        return v if isinstance(v, int) else None
+    return None
 
 
 # --- Duty-cycle detection --------------------------------------------------------------------------
@@ -513,11 +679,8 @@ def night_mean_at_offset(
             continue
         if require_asleep and r.get("sleep_state") != SLEEP_ASLEEP:
             continue
-        frame = r.get("_frame")
-        if frame is None or len(frame) <= offset:
-            continue
-        v = frame[offset]
-        if v not in INBAND:
+        v = byte_at_offset(r, offset)
+        if v is None or v not in INBAND:
             continue
         if duty_cycled:
             if not in_duty_window(u, duty):
@@ -550,11 +713,8 @@ def offset_variability(
             continue
         if duty_cycled and not in_duty_window(r["unix"], duty):
             continue
-        frame = r.get("_frame")
-        if frame is None or len(frame) <= offset:
-            continue
-        v = frame[offset]
-        if v in INBAND:
+        v = byte_at_offset(r, offset)
+        if v is not None and v in INBAND:
             vals.append(v)
     if not vals:
         return (0, 0.0)
@@ -590,13 +750,20 @@ def validate_device(
     device: str = "device",
     require_asleep: bool = True,
     device_id: int = 2,
+    app_device: Optional[str] = None,
     min_window_coverage: float = DEFAULT_MIN_WINDOW_COVERAGE,
     min_distinct: int = MIN_DISTINCT_INBAND,
 ) -> dict:
-    capture = load_frame_records(capture_path, device_id=device_id)
+    # A NOOP app store and a whoop_sync.py capture store are both SQLite; they are told apart by the
+    # `v18AuxSample` table rather than by extension or by a flag, so a user does not have to know which
+    # kind of file they were handed.
+    from_app_db = looks_like_app_db(capture_path)
+    if from_app_db:
+        records = load_app_db_records(capture_path, device_id=app_device)
+    else:
+        records = list(iter_v18_records(load_frame_records(capture_path, device_id=device_id)))
 
     cycles = load_cycles(export_path)
-    records = list(iter_v18_records(capture))
 
     # Measure the on/off schedule before averaging anything against it.
     duty = detect_duty_cycle(records)
@@ -681,7 +848,12 @@ def validate_device(
         ),
         "corr_ge_0_7": (r is not None and r >= 0.7),
         "mae_le_1_0": (err is not None and err <= 1.0),
-        "offset_82_wins": best_off == OFF_SPO2_CANDIDATE,
+        # From an app store the scan CANNOT run — the app banks decoded slots, so no neighbour byte
+        # exists to compare @82 against. Reporting False there would fail the gate for a reason that is
+        # about the input format, not the data, and "@82 did not win" is exactly the wrong thing to
+        # record about a strap whose byte was never ranked. n/a is the honest value; `specificity_scan`
+        # below says which of the two happened so a reader cannot mistake one for the other.
+        "offset_82_wins": True if from_app_db else best_off == OFF_SPO2_CANDIDATE,
         # A byte with a handful of distinct values cannot be a nightly SpO₂ however well it correlates.
         "value_variance": distinct_82 >= min_distinct and stdev_82 >= MIN_INBAND_STDEV,
         # n/a (True) unless a duty cycle was detected and coverage could actually be measured.
@@ -733,6 +905,12 @@ def validate_device(
 
     return {
         "device": device,
+        # Which store the records came from, and whether the specificity scan was possible on it.
+        # Both are reported rather than inferred from the numbers: "no specificity result" means
+        # something completely different in the two cases, and a batch pooling both must be able to
+        # tell them apart without re-opening the files.
+        "source": "noop_app_db" if from_app_db else "capture",
+        "specificity_scan": "unavailable_app_db" if from_app_db else "ran",
         "v18_records": len(records),
         "export_nights_with_spo2": len(cycles),
         "paired_nights": n_paired,
@@ -982,6 +1160,11 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
     p.add_argument("--device-id", type=int, default=2,
                    help="device_id row filter when the capture is a whoop_sync.py .db "
                         "(default: 2, matching whoop_activity.py)")
+    p.add_argument("--app-device", metavar="DEVICE_ID",
+                   help="deviceId row filter when the capture is a NOOP APP store (the text strap "
+                        "id in v18AuxSample, not the integer --device-id). Optional when the store "
+                        "holds exactly one strap; required when it holds several, since pooling "
+                        "them would average away the per-device difference the gate is testing")
     p.add_argument(
         "--batch",
         metavar="devices.json",
@@ -1034,6 +1217,7 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
                     entry["export"],
                     device=entry.get("device", "device"),
                     device_id=int(entry.get("device_id", args.device_id)),
+                    app_device=entry.get("app_device", args.app_device),
                     require_asleep=require_asleep,
                     min_window_coverage=args.min_window_coverage,
                     min_distinct=args.min_distinct_values,
@@ -1048,6 +1232,7 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
                 args.export,
                 device=args.device,
                 device_id=args.device_id,
+                app_device=args.app_device,
                 require_asleep=require_asleep,
                 min_window_coverage=args.min_window_coverage,
                 min_distinct=args.min_distinct_values,


### PR DESCRIPTION
Closes the `spo2_candidate_82` item from #845 — the one asked for twice and called "the strongest item here". Unblocks #103.

## What the ask turned out to be, precisely

The framing in #845 was *"the app itself cannot currently contribute the data needed to resolve its own open question, only the offline tooling can."* That was two problems, and **only one of them is still open.**

**The persistence half is already done.** #848 (merged `2026-07-27T05:50:10Z`) banks the raw @82 byte into `v18AuxSample`. The value is retained — the strap trimming its history no longer destroys it. That landed 89 minutes after the "still open" note on #845, so the note was accurate when written and has quietly stopped being so.

**The read-back half was not.** `validate_spo2_candidate.py` could read a `capture.json` or the capture tooling's frame store, and nothing else. Its own docstring says why:

> NOTE: this is the CAPTURE TOOLING's database, not the app's. Neither shipped app has a `frames` table — Android uses Room, iOS/macOS uses GRDB — so this cannot be pointed at a phone's store or a `.noopbak`.

So a NOOP user who synced a 5/MG was *holding* the evidence #103 has been waiting on with no way to run the gate over it. Contributing still required running linux-capture. That is the actual blocker, and it is what this PR removes.

## What it does

A third input kind: the app's own SQLite, read from `v18AuxSample` joined to `sleepStateSample.state` for the asleep gate.

```
python3 validate_spo2_candidate.py noop.sqlite my_whoop_data/ --device strap-a
```

- An app store is told apart from a capture store by the **`v18AuxSample` table**, not by extension or a flag — a user does not have to know which kind of file they were handed.
- Opened `mode=ro&immutable=1`, so no WAL recovery write is attempted against a file pulled off a phone (the reasoning `Tools/SleepBench` already documents).
- `--app-device` picks a strap. **Required** when the store holds several: pooling straps would average away the very per-device difference the promote gate exists to test, so it refuses rather than guessing.

## The one thing an app store cannot do — reported, not papered over

The app banks decoded slots, not frame bytes, so there is no neighbour byte to rank @82 against and the **offset specificity scan cannot run**.

Recording `offset_82_wins: false` there would fail the gate for a reason that is about the input format rather than the data — and "@82 did not win the scan" is precisely the wrong thing to record about a byte that was never ranked. It is n/a, and `source` / `specificity_scan` name which of the two happened so a batch pooling both kinds can tell them apart without reopening the files. **A capture is still required to settle specificity.** Correlation, MAE, bias, duty-cycle detection and window coverage all work from either.

Related: `byte_at_offset` returns `None`, not `0`, for an unknowable offset. `0` is a legitimate @82 reading outside the duty window, so "cannot know" read as "read zero" would manufacture out-of-band samples and silently depress coverage.

## The codec is pinned against the shipped one, not against itself

`unpack_v18_aux` is a Python port of Swift `V18AuxCodec.unpack`. Round-tripping it against a Python packer would prove nothing, so both test fixtures are **literal `V18AuxCodec.pack` output** captured by running the real codec in `Packages/WhoopStore`:

```
02ffff0100070000000381803a3412ff28500531034204601f2180801f3ba9c0   # all 17 slots
020008000060                                                       # auxByte82 only
```

A wire-format change now fails the test rather than silently mis-slicing real rows into plausible-looking numbers. Absence stays first-class — a clear presence bit means "the strap did not report this", never `0`.

## Not relaxed

No card, no score, no `spo2Pct`, no change to any promote threshold, no schema change, no app change, nothing on the BLE path. This only widens **who can produce the evidence**.

## Verified

`tools/linux-capture`: **50 tests, 0 failures** (39 before, 11 new) — `python3 -m unittest test_validate_spo2_candidate`. The new tests cover the codec against the Swift fixtures, malformed/truncated blobs, the multi-strap refusal, out-of-band values, that only @82 is answerable without a frame, an end-to-end `validate_device` run over a synthetic app store, and — in the other direction — that a real capture still runs the specificity scan.

Corpus credit stays with @digitalerdude, whose capture is behind the duty-cycle figures this harness relies on.
