### PR TITLE
ui(android): dedupe the liquid hero surface; Health hero now respects card opacity

### DIFF
--- a/android/app/src/main/java/com/noop/ui/BreatheScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/BreatheScreen.kt
@@ -124,13 +124,6 @@ private enum class Phase { Inhale, Exhale }
 
 // MARK: - Liquid hero tokens (the liquid Breathe restyle)
 //
-// The frosted hero panel the breathe vessel floats on, matching the liquid Today heroCard. `heroFill` is a
-// translucent near-black (mock rgba(13,14,20,.80)) so it floats over the day-of-sky and the vessel + white
-// count-up read crisp on it; radius 26 + a white@0.11 hairline give the frosted-glass edge. Declared here
-// (not shared from Today) because the Today copies are file-private — same values, kept in lockstep.
-private val LIQUID_HERO_FILL: Color = Color(red = 13f / 255f, green = 14f / 255f, blue = 20f / 255f, alpha = 0.80f)
-private val LIQUID_HERO_RADIUS = 26.dp
-
 /** The three biofeedback layers as a mode switch (mirrors BreathingView.Mode). */
 private enum class BreatheMode(val label: String) {
     Breathe("Breathe"),
@@ -373,9 +366,7 @@ fun BreatheScreen(viewModel: AppViewModel) {
         Box(
             modifier = Modifier
                 .fillMaxWidth()
-                .clip(RoundedCornerShape(LIQUID_HERO_RADIUS))
-                .background(LIQUID_HERO_FILL.copy(alpha = LIQUID_HERO_FILL.alpha * CardAppearance.opacity))
-                .border(1.dp, Color.White.copy(alpha = 0.11f * CardAppearance.opacity), RoundedCornerShape(LIQUID_HERO_RADIUS))
+                .liquidHeroSurface()
                 .padding(24.dp),
         ) {
             Column(
@@ -416,7 +407,7 @@ fun BreatheScreen(viewModel: AppViewModel) {
                         Text(
                             bpm?.toString() ?: "—",
                             style = NoopType.number(40f, weight = FontWeight.Bold)
-                                .copy(shadow = Shadow(color = Color.Black.copy(alpha = 0.5f), offset = Offset(0f, 1f), blurRadius = 6f)),
+                                .copy(shadow = HeroTextShadow),
                             color = Color.White,
                         )
                         Text("BPM", style = NoopType.footnote.copy(letterSpacing = 0.8.sp), color = Palette.textTertiary)

--- a/android/app/src/main/java/com/noop/ui/Components.kt
+++ b/android/app/src/main/java/com/noop/ui/Components.kt
@@ -75,6 +75,7 @@ import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.graphics.Shadow
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
@@ -114,6 +115,27 @@ object CardAppearance {
     fun init(context: Context) {
         opacity = (NoopPrefs.cardOpacityPercent(context) / 100f).coerceIn(0f, 1f)
     }
+}
+
+// Liquid hero mock spec: rgba(13,14,20,.80), radius 26, white@0.11 hairline.
+val LiquidHeroFill: Color =
+    Color(red = 13f / 255f, green = 14f / 255f, blue = 20f / 255f, alpha = 0.80f)
+val LiquidHeroRadius: Dp = 26.dp
+val HeroTextShadow = Shadow(
+    color = Color.Black.copy(alpha = 0.5f),
+    offset = Offset(0f, 1f),
+    blurRadius = 6f,
+)
+
+fun Modifier.liquidHeroSurface(): Modifier = composed {
+    this
+        .clip(RoundedCornerShape(LiquidHeroRadius))
+        .background(LiquidHeroFill.copy(alpha = LiquidHeroFill.alpha * CardAppearance.opacity))
+        .border(
+            1.dp,
+            Color.White.copy(alpha = 0.11f * CardAppearance.opacity),
+            RoundedCornerShape(LiquidHeroRadius),
+        )
 }
 
 fun Modifier.frostedCardSurface(

--- a/android/app/src/main/java/com/noop/ui/CoupledScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/CoupledScreen.kt
@@ -75,14 +75,6 @@ private const val COUPLED_STRAIN_OUT_OF = 21.0
  *  file-private, so the coupled screen carries its own copy of the same string). */
 private const val COUPLED_NO_DATA = "No Data"
 
-// The liquid hero-card wrapper values, byte-identical to the liquid Today pilot (TodayScreen's
-// LIQUID_HERO_FILL / LIQUID_HERO_RADIUS are file-private, so the coupled screen carries its own copy):
-// a translucent near-black that floats over the day-of-sky so the vessel + white count-up numbers stay
-// crisp — the card does the contrast work, not a muted sky. heroFill = rgba(13,14,20,.80), stroke
-// white@0.11, radius 26. Mirrors the iOS LiquidTodayView heroCard.
-private val LIQUID_HERO_FILL: Color = Color(red = 13f / 255f, green = 14f / 255f, blue = 20f / 255f, alpha = 0.80f)
-private val LIQUID_HERO_RADIUS: Dp = 26.dp
-
 @Composable
 fun CoupledScreen(
     vm: AppViewModel,
@@ -309,9 +301,7 @@ private fun HeroCard(
         modifier = Modifier
             .fillMaxWidth()
             .liquidPress(interaction)
-            .clip(RoundedCornerShape(LIQUID_HERO_RADIUS))
-            .background(LIQUID_HERO_FILL.copy(alpha = LIQUID_HERO_FILL.alpha * CardAppearance.opacity))
-            .border(1.dp, Color.White.copy(alpha = 0.11f * CardAppearance.opacity), RoundedCornerShape(LIQUID_HERO_RADIUS))
+            .liquidHeroSurface()
             .clickable(
                 interactionSource = interaction,
                 indication = null,
@@ -377,7 +367,7 @@ private fun HeroCentre(recovery: Double?, readinessLevel: ReadinessEngine.Level)
                 value = recovery,
                 format = { "${it.roundToInt()}%" },
                 style = NoopType.number(56f, weight = FontWeight.Bold)
-                    .copy(shadow = Shadow(color = Color.Black.copy(alpha = 0.5f), offset = Offset(0f, 1f), blurRadius = 6f)),
+                    .copy(shadow = HeroTextShadow),
                 color = Color.White,
                 modifier = Modifier.clearAndSetSemantics {},
             )
@@ -449,7 +439,7 @@ private fun StrainCard(dayStrain21: Double?, recovery: Double?, calories: Double
                             value = dayStrain21,
                             format = { String.format(Locale.US, "%.1f", it) },
                             style = NoopType.number(30f, weight = FontWeight.Bold)
-                                .copy(shadow = Shadow(color = Color.Black.copy(alpha = 0.5f), offset = Offset(0f, 1f), blurRadius = 6f)),
+                                .copy(shadow = HeroTextShadow),
                             color = Color.White,
                             modifier = Modifier.clearAndSetSemantics {},
                         )
@@ -537,7 +527,7 @@ private fun SleepCard(
                         value = sleepPerformance,
                         format = { it.roundToInt().toString() },
                         style = NoopType.number(26f, weight = FontWeight.Bold)
-                            .copy(shadow = Shadow(color = Color.Black.copy(alpha = 0.5f), offset = Offset(0f, 1f), blurRadius = 6f)),
+                            .copy(shadow = HeroTextShadow),
                         color = Color.White,
                         modifier = Modifier.clearAndSetSemantics {},
                     )

--- a/android/app/src/main/java/com/noop/ui/DevicesScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/DevicesScreen.kt
@@ -96,11 +96,7 @@ import kotlinx.coroutines.launch
 // MARK: - Liquid hero tokens (the liquid Devices restyle)
 //
 // The ACTIVE device card is the screen's hero: it floats over the day-of-sky as a translucent near-black
-// frosted card so the strap name + the live battery tube stay crisp on it. Same tokens as the liquid Today
-// hero (heroFill = rgba(13,14,20,.80), radius 26, white@0.11 hairline). Those Today constants are private to
-// TodayScreen, so the identical values are declared here. Mirrors the iOS liquid heroCard.
-private val LIQUID_HERO_FILL: Color = Color(red = 13f / 255f, green = 14f / 255f, blue = 20f / 255f, alpha = 0.80f)
-private val LIQUID_HERO_RADIUS: Dp = 26.dp
+// frosted card so the strap name + the live battery tube stay crisp on it. Mirrors the iOS liquid heroCard.
 
 @Composable
 fun DevicesScreen(
@@ -670,9 +666,7 @@ private fun DeviceCard(
         Box(
             modifier = cardModifier
                 .fillMaxWidth()
-                .clip(RoundedCornerShape(LIQUID_HERO_RADIUS))
-                .background(LIQUID_HERO_FILL.copy(alpha = LIQUID_HERO_FILL.alpha * CardAppearance.opacity))
-                .border(1.dp, Color.White.copy(alpha = 0.11f * CardAppearance.opacity), RoundedCornerShape(LIQUID_HERO_RADIUS))
+                .liquidHeroSurface()
                 .padding(18.dp),
         ) {
             body()

--- a/android/app/src/main/java/com/noop/ui/HealthScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/HealthScreen.kt
@@ -783,13 +783,6 @@ private fun VitalityHero(
 
 // MARK: - Liquid hero-card wrapper + hero vessel (the pilot idiom)
 //
-// The frosted translucent-black hero-card wrapper (mock rgba(13,14,20,.80), radius 26, white@0.11
-// hairline) that floats the hero over the day-of-sky so the vessel + white count-up stay crisp — the
-// card does the contrast work, not a muted sky. Byte-matched to the Today pilot's LIQUID_HERO_* values.
-private val HEALTH_HERO_FILL: Color =
-    Color(red = 13f / 255f, green = 14f / 255f, blue = 20f / 255f, alpha = 0.80f)
-private val HEALTH_HERO_RADIUS: Dp = 26.dp
-
 /** Wrap a hero's content in the frosted liquid glass surface so it floats over the sky backdrop. Applied
  *  to the HERO cards only (Fitness Age, Vitality), matching the pilot's heroCard: the content sits DIRECTLY
  *  in the translucent box (no inner NoopCard surface to double up on the glass), padded like a card. */
@@ -798,9 +791,7 @@ private fun LiquidHeroCard(content: @Composable () -> Unit) {
     Box(
         modifier = Modifier
             .fillMaxWidth()
-            .clip(RoundedCornerShape(HEALTH_HERO_RADIUS))
-            .background(HEALTH_HERO_FILL)
-            .border(1.dp, Color.White.copy(alpha = 0.11f), RoundedCornerShape(HEALTH_HERO_RADIUS))
+            .liquidHeroSurface()
             .padding(Metrics.cardPadding),
     ) {
         content()
@@ -837,7 +828,7 @@ private fun HealthHeroVessel(
             value = value,
             format = format,
             style = NoopType.number(numberSp, weight = FontWeight.Bold)
-                .copy(shadow = Shadow(color = Color.Black.copy(alpha = 0.5f), offset = Offset(0f, 1f), blurRadius = 6f)),
+                .copy(shadow = HeroTextShadow),
             color = Color.White,
             modifier = Modifier.clearAndSetSemantics {},
         )

--- a/android/app/src/main/java/com/noop/ui/HydrationScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/HydrationScreen.kt
@@ -77,14 +77,6 @@ import java.util.Locale
 private val hydrationAccent: Color
     @Composable get() = if (Palette.isLight) Color(0xFF234F9E) else Color(0xFF60A0E0)
 
-// MARK: - Liquid hero tokens (shared with the liquid Today hero card)
-//
-// The frosted translucent near-black the hydration vessel floats on (mock rgba(13,14,20,.80)), so the vessel
-// + the white count-up litre figure read crisp over the day-of-sky. Radius 26 + a white@0.11 hairline give
-// the frosted-glass edge. Same numbers as the liquid Today heroCard (TodayScreen.kt LIQUID_HERO_*).
-private val LIQUID_HERO_FILL: Color = Color(red = 13f / 255f, green = 14f / 255f, blue = 20f / 255f, alpha = 0.80f)
-private val LIQUID_HERO_RADIUS = 26.dp
-
 /** Upper bound (ml) for a single custom hydration log (#798) - a sane cap so a stray digit can't bank an
  *  absurd 50-litre day. A 3-litre container covers any realistic bottle/jug. Mirrors the iOS clamp. */
 private const val MAX_CUSTOM_ML: Int = 3000
@@ -194,9 +186,7 @@ fun HydrationScreen(viewModel: AppViewModel) {
             Box(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .clip(RoundedCornerShape(LIQUID_HERO_RADIUS))
-                    .background(LIQUID_HERO_FILL.copy(alpha = LIQUID_HERO_FILL.alpha * CardAppearance.opacity))
-                    .border(1.dp, Color.White.copy(alpha = 0.11f * CardAppearance.opacity), RoundedCornerShape(LIQUID_HERO_RADIUS))
+                    .liquidHeroSurface()
                     .padding(20.dp),
             ) {
                 Column(

--- a/android/app/src/main/java/com/noop/ui/LiveScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/LiveScreen.kt
@@ -86,13 +86,6 @@ import com.noop.ble.WhoopModel
 
 // MARK: - Liquid hero tokens (the liquid Live restyle)
 //
-// The hero card the live HR vessel floats on, mirroring the liquid Today hero. A translucent near-black
-// (mock rgba(13,14,20,.80)) so it floats over the day-of-sky; the vessel + the white count-up number read
-// crisp on it. Radius 26 + a white@0.11 hairline give the frosted-glass edge. (Twins of the liquid Today
-// LIQUID_HERO_FILL / LIQUID_HERO_RADIUS, redeclared here since those are file-private to TodayScreen.)
-private val LIVE_HERO_FILL: Color = Color(red = 13f / 255f, green = 14f / 255f, blue = 20f / 255f, alpha = 0.80f)
-private val LIVE_HERO_RADIUS: Dp = 26.dp
-
 @Composable
 fun LiveScreen(viewModel: AppViewModel, onManageDevices: () -> Unit = {}) {
     val live by viewModel.live.collectAsStateWithLifecycle()
@@ -935,9 +928,7 @@ private fun BodyConsole(live: LiveState, bpm: Int?, activeConnection: Boolean, z
     Box(
         modifier = Modifier
             .fillMaxWidth()
-            .clip(RoundedCornerShape(LIVE_HERO_RADIUS))
-            .background(LIVE_HERO_FILL.copy(alpha = LIVE_HERO_FILL.alpha * CardAppearance.opacity))
-            .border(1.dp, Color.White.copy(alpha = 0.11f * CardAppearance.opacity), RoundedCornerShape(LIVE_HERO_RADIUS))
+            .liquidHeroSurface()
             .padding(20.dp),
     ) {
         Column(verticalArrangement = Arrangement.spacedBy(18.dp)) {
@@ -996,7 +987,7 @@ private fun HeartReadout(live: LiveState, bpm: Int?, activeConnection: Boolean, 
                         value = bpm.toDouble(),
                         format = { it.roundToInt().toString() },
                         style = NoopType.number(64f, weight = FontWeight.Bold)
-                            .copy(shadow = Shadow(color = Color.Black.copy(alpha = 0.5f), offset = Offset(0f, 1f), blurRadius = 6f)),
+                            .copy(shadow = HeroTextShadow),
                         color = Color.White,
                         modifier = Modifier.clearAndSetSemantics {},
                     )

--- a/android/app/src/main/java/com/noop/ui/SleepScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/SleepScreen.kt
@@ -833,9 +833,6 @@ private fun DeletedSleepWindowsCard(
 // fill is a translucent near-black (mock rgba(13,14,20,.80)) so the card floats OVER the day-of-sky and the
 // vessel + white count-up number stay crisp — the CARD does the contrast work, not a muted sky. Radius 26 +
 // a white@0.11 hairline give the frosted-glass edge. Same constants as the liquid Today heroCard.
-private val LIQUID_HERO_FILL: Color = Color(red = 13f / 255f, green = 14f / 255f, blue = 20f / 255f, alpha = 0.80f)
-private val LIQUID_HERO_RADIUS: Dp = 26.dp
-
 // MARK: - 0. REST HERO — liquid sky + sleep-performance vessel (liquid restyle)
 //
 // The Rest world's opening, restyled to the liquid pilot: a frosted translucent-black hero card floating on
@@ -856,9 +853,7 @@ private fun RestHero(score: Double?, asleepMin: Double?, source: String, overlin
                 // vessel + white count-up number stay crisp. Rounded 26 corner + a faint white hairline give
                 // the frosted-glass edge of the liquid Today heroCard (fill rgba(13,14,20,.80), stroke
                 // white@0.11). Replaces the per-hero night atmosphere (the sky now lives at screen level).
-                .clip(RoundedCornerShape(LIQUID_HERO_RADIUS))
-                .background(LIQUID_HERO_FILL.copy(alpha = LIQUID_HERO_FILL.alpha * CardAppearance.opacity))
-                .border(1.dp, Color.White.copy(alpha = 0.11f * CardAppearance.opacity), RoundedCornerShape(LIQUID_HERO_RADIUS)),
+                .liquidHeroSurface(),
         ) {
             Column(
                 modifier = Modifier.fillMaxWidth().padding(Metrics.space24),
@@ -925,7 +920,7 @@ private fun SleepHeroVessel(fraction: Double, value: Double, tint: Color, diamet
             value = value,
             format = { it.roundToInt().toString() },
             style = NoopType.number(numberSp, weight = FontWeight.Bold)
-                .copy(shadow = Shadow(color = Color.Black.copy(alpha = 0.5f), offset = Offset(0f, 1f), blurRadius = 6f)),
+                .copy(shadow = HeroTextShadow),
             color = Color.White,
             modifier = Modifier.clearAndSetSemantics {},
         )

--- a/android/app/src/main/java/com/noop/ui/StressScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/StressScreen.kt
@@ -241,15 +241,6 @@ private fun androidx.compose.foundation.lazy.LazyListScope.StressContent(
     item { StressMethodologyCard(model, modifier = Modifier.staggeredAppear(4)) }
 }
 
-// MARK: - Liquid hero tokens (the liquid restyle)
-//
-// The hero card the stress vessel floats on, ported from the iOS liquid heroCard. `LIQUID_HERO_FILL` is a
-// translucent near-black (mock rgba(13,14,20,.80)) so it floats over the day-of-sky; the vessel + white
-// count-up number read crisp on it. Radius 26 + a white@0.11 hairline give the frosted-glass edge. Same
-// numbers as the Today pilot's hero card.
-private val LIQUID_HERO_FILL: Color = Color(red = 13f / 255f, green = 14f / 255f, blue = 20f / 255f, alpha = 0.80f)
-private val LIQUID_HERO_RADIUS = 26.dp
-
 // MARK: - 1 · Hero — the liquid stress VESSEL (the flat PipBar is gone)
 //
 // The liquid restyle: the headline 0–3 read is now a band-tinted [LiquidVessel] filling to score/3, with
@@ -267,9 +258,7 @@ private fun StressHeroCard(model: StressModel, modifier: Modifier = Modifier) {
     Box(
         modifier = modifier
             .fillMaxWidth()
-            .clip(RoundedCornerShape(LIQUID_HERO_RADIUS))
-            .background(LIQUID_HERO_FILL.copy(alpha = LIQUID_HERO_FILL.alpha * CardAppearance.opacity))
-            .border(1.dp, Color.White.copy(alpha = 0.11f * CardAppearance.opacity), RoundedCornerShape(LIQUID_HERO_RADIUS))
+            .liquidHeroSurface()
             .padding(Metrics.cardPadding),
     ) {
         Column(
@@ -316,7 +305,7 @@ private fun StressHeroCard(model: StressModel, modifier: Modifier = Modifier) {
                         value = model.score,
                         format = { String.format(Locale.US, "%.1f", it) },
                         style = NoopType.number(30f, weight = FontWeight.Bold)
-                            .copy(shadow = Shadow(color = Color.Black.copy(alpha = 0.5f), offset = Offset(0f, 1f), blurRadius = 6f)),
+                            .copy(shadow = HeroTextShadow),
                         color = Color.White,
                         modifier = Modifier.clearAndSetSemantics {},
                     )

--- a/android/app/src/main/java/com/noop/ui/TodayScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/TodayScreen.kt
@@ -198,14 +198,6 @@ private const val CARD_CARRIED_SLEEP = "carriedSleep"
  *  and so already re-inits to 0 on every fresh launch, reaching the same offset through the same helper. */
 private var todayDidSnapToTodayThisLaunch = false
 
-// MARK: - Liquid hero tokens (the liquid Today restyle)
-//
-// The hero card the score vessels float on, ported from the iOS LiquidTodayView. `heroFill` is a
-// translucent near-black (mock rgba(13,14,20,.80)) so it floats over the day-of-sky; the vessels + white
-// count-up numbers read crisp on it. Radius 26 + a white@0.11 hairline give the frosted-glass edge.
-private val LIQUID_HERO_FILL: Color = Color(red = 13f / 255f, green = 14f / 255f, blue = 20f / 255f, alpha = 0.80f)
-private val LIQUID_HERO_RADIUS: Dp = 26.dp
-
 // The Vitality vessel purple (#9b7bff) — no exact Palette token in this theme, so a fixed brand literal
 // matching the iOS liquid Today's `liquidPurple` (Color(.sRGB, red:0x9b, green:0x7b, blue:0xff)). Used by
 // the mini "Your cards" vessel so Vitality reads the same purple as iOS.
@@ -1361,11 +1353,7 @@ fun TodayScreen(
                             Box(
                                 modifier = Modifier
                                     .fillMaxWidth()
-                                    .background(
-                                        LIQUID_HERO_FILL.copy(alpha = LIQUID_HERO_FILL.alpha * CardAppearance.opacity),
-                                        RoundedCornerShape(LIQUID_HERO_RADIUS),
-                                    )
-                                    .border(1.dp, Color.White.copy(alpha = 0.11f * CardAppearance.opacity), RoundedCornerShape(LIQUID_HERO_RADIUS))
+                                    .liquidHeroSurface()
                                     .staggeredAppear(stagger),
                             ) {
                                 ScoreHeroRow(
@@ -2590,7 +2578,7 @@ private fun HeroScoreVessel(
                 value = value,
                 format = format,
                 style = NoopType.number(numberSp, weight = FontWeight.Bold)
-                    .copy(shadow = Shadow(color = Color.Black.copy(alpha = 0.5f), offset = Offset(0f, 1f), blurRadius = 6f)),
+                    .copy(shadow = HeroTextShadow),
                 color = Color.White,
                 modifier = Modifier.clearAndSetSemantics {},
             )

--- a/android/app/src/main/java/com/noop/ui/TrendsScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/TrendsScreen.kt
@@ -78,9 +78,6 @@ import kotlin.math.roundToInt
 // (rgba(13,14,20,.80)) rather than the classic frosted surface — the card does the contrast work so the
 // crisp line chart + the count-up vessel accent read clean over the sky. Radius 26 + a white@0.11 hairline
 // give it the frosted-glass edge. Mirrors the liquid Today heroCard (LiquidTodayView / TodayScreen).
-private val LIQUID_HERO_FILL: Color = Color(red = 13f / 255f, green = 14f / 255f, blue = 20f / 255f, alpha = 0.80f)
-private val LIQUID_HERO_RADIUS: Dp = 26.dp
-
 @Composable
 fun TrendsScreen(vm: AppViewModel) {
     // Reactive cache (oldest → newest) as the immediate backing.
@@ -701,9 +698,7 @@ private fun ChartCard(
         Box(
             modifier = modifier
                 .fillMaxWidth()
-                .clip(RoundedCornerShape(LIQUID_HERO_RADIUS))
-                .background(LIQUID_HERO_FILL.copy(alpha = LIQUID_HERO_FILL.alpha * CardAppearance.opacity))
-                .border(1.dp, Color.White.copy(alpha = 0.11f * CardAppearance.opacity), RoundedCornerShape(LIQUID_HERO_RADIUS))
+                .liquidHeroSurface()
                 .padding(Metrics.cardPadding),
         ) {
             body()
@@ -734,7 +729,7 @@ private fun HeadlineVessel(value: Double, tint: Color) {
             value = value,
             format = { "${it.roundToInt()}" },
             style = NoopType.number(17f, weight = FontWeight.Bold)
-                .copy(shadow = Shadow(color = Color.Black.copy(alpha = 0.5f), offset = Offset(0f, 1f), blurRadius = 6f)),
+                .copy(shadow = HeroTextShadow),
             color = Color.White,
             modifier = Modifier.clearAndSetSemantics {},
         )

--- a/android/app/src/main/java/com/noop/ui/WorkoutsScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/WorkoutsScreen.kt
@@ -646,13 +646,6 @@ private fun sessionSelectionKey(row: WorkoutRow): String = "${row.startTs}|${row
 
 // MARK: - Liquid hero tokens (the liquid Workouts restyle)
 //
-// The frosted card the Effort vessel floats on, mirroring the iOS/Today LiquidTodayView heroCard. `fill`
-// is a translucent near-black (mock rgba(13,14,20,.80)) so it floats over the day-of-sky; the vessel + the
-// white count-up read crisp on it. Radius 26 + a white@0.11 hairline give the frosted-glass edge. (These
-// are file-scoped to Workouts — the Today equivalents are private to that file.)
-private val LIQUID_HERO_FILL: Color = Color(red = 13f / 255f, green = 14f / 255f, blue = 20f / 255f, alpha = 0.80f)
-private val LIQUID_HERO_RADIUS: Dp = 26.dp
-
 // MARK: - Effort hero (typical-effort liquid vessel over the day-of-sky)
 //
 // The liquid restyle of the Effort hero: the typical session Effort as a filling LiquidVessel with the
@@ -686,9 +679,7 @@ private fun EffortHero(
     Box(
         modifier = Modifier
             .fillMaxWidth()
-            .clip(RoundedCornerShape(LIQUID_HERO_RADIUS))
-            .background(LIQUID_HERO_FILL.copy(alpha = LIQUID_HERO_FILL.alpha * CardAppearance.opacity))
-            .border(1.dp, Color.White.copy(alpha = 0.11f * CardAppearance.opacity), RoundedCornerShape(LIQUID_HERO_RADIUS))
+            .liquidHeroSurface()
             .padding(20.dp),
     ) {
         Row(verticalAlignment = Alignment.CenterVertically, modifier = Modifier.fillMaxWidth()) {
@@ -714,7 +705,7 @@ private fun EffortHero(
                             value = shownEffort,
                             format = { oneDecimal(it) },
                             style = NoopType.number(30f, weight = FontWeight.Bold)
-                                .copy(shadow = Shadow(color = Color.Black.copy(alpha = 0.5f), offset = Offset(0f, 1f), blurRadius = 6f)),
+                                .copy(shadow = HeroTextShadow),
                             color = Color.White,
                             modifier = Modifier.clearAndSetSemantics {},
                         )


### PR DESCRIPTION
## What

Eleven screens each carried a file-private copy of the liquid hero surface (`LIQUID_HERO_FILL`/`RADIUS` + the clip/background/border chain) — two of them under different names (`LIVE_HERO_*`, `HEALTH_HERO_*`), with comments admitting the redeclaration. This PR promotes ONE shared `Modifier.liquidHeroSurface()` + `HeroTextShadow` into `Components.kt` and deletes the 11 copies (net −73 lines).

## The bug this fixes

`HealthScreen`'s copy omitted the `* CardAppearance.opacity` factor on both the fill and the hairline, so the **Card transparency setting silently didn't apply on the Health screen** — every other hero faded, Health stayed solid. Routing it through the shared modifier fixes that as a side effect of the dedup.

The pasted hero title shadow (`Shadow(Black 0.5, 0/1, blur 6)`, 11 occurrences) is deduped in the same pass; the deliberate 0.35f/0.25f variants in TodayScreen are untouched.

## Verification

- `./gradlew compileFullDebugKotlin` green; `grep -rn HERO_FILL app/src/main/java/com/noop/ui/` → zero hits.
- Behavioral check on a Pixel 7 / API 34 emulator (Demo flavor): with card transparency at 65%, the Health Fitness Age hero now fades like every other screen's hero (before: stayed solid at any setting). Screenshots available on request.
- UI uses the existing token/idiom only — no new colors, no new dp values (the shared vals are the exact bytes the 11 copies carried).
- Android-only: feature-level parity is unchanged (iOS builds its hero from its own `StrandDesign` components; the opacity behavior now matches the other Android screens).

🤖 Generated with [Claude Code](https://claude.com/claude-code)