### PR TITLE
ui(android): design-token + accessibility fixes (accent shadow copies, 48dp targets, StatTile font scale, OnAccent)

### DIFF
--- a/android/app/src/main/java/com/noop/ui/AutoWorkoutNudge.kt
+++ b/android/app/src/main/java/com/noop/ui/AutoWorkoutNudge.kt
@@ -17,7 +17,6 @@ import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
-import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -203,13 +202,15 @@ fun AutoWorkoutNudgeCard(
                     ),
                 ) { Text(uiString(R.string.l10n_auto_workout_nudge_save_it_01d23661)) }
 
-                OutlinedButton(
+                NoopButton(
+                    text = uiString(R.string.l10n_auto_workout_nudge_not_a_workout_15c5f784),
+                    kind = NoopButtonKind.Secondary,
                     onClick = {
                         AutoWorkoutPrefs.dismiss(context, w)
                         handledThisSession = true
                         candidate = null
                     },
-                ) { Text(uiString(R.string.l10n_auto_workout_nudge_not_a_workout_15c5f784), color = Palette.textSecondary) }
+                )
             }
         }
     }

--- a/android/app/src/main/java/com/noop/ui/Components.kt
+++ b/android/app/src/main/java/com/noop/ui/Components.kt
@@ -116,6 +116,9 @@ object CardAppearance {
     }
 }
 
+// Crisp white label on accent and critical fills; white in both schemes (iOS goldDeepText post-reset).
+val OnAccent: Color = Color.White
+
 fun Modifier.frostedCardSurface(
     tint: Color? = null,
     cornerRadius: Dp = Metrics.cardRadius,
@@ -507,7 +510,7 @@ fun StatTile(
 ) {
     // Each tile borrows its accent as a faint card wash, so a metric reads as part of its
     // colour world while staying legible on the deep blue-black. Falls back to the accent.
-    NoopCard(modifier = modifier.height(Metrics.tileHeight), padding = 14.dp, tint = tint ?: accent) {
+    NoopCard(modifier = modifier.heightIn(min = Metrics.tileHeight), padding = 14.dp, tint = tint ?: accent) {
         Column {
             Overline(label)
             Spacer(Modifier.weight(1f))

--- a/android/app/src/main/java/com/noop/ui/ConnectionHelp.kt
+++ b/android/app/src/main/java/com/noop/ui/ConnectionHelp.kt
@@ -14,8 +14,6 @@ import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -122,10 +120,12 @@ fun ConnectionHelp(viewModel: AppViewModel, modifier: Modifier = Modifier) {
                 onAction = {},
             )
 
-            OutlinedButton(
+            NoopButton(
+                text = uiString(R.string.l10n_connection_help_try_connecting_now_41769900),
+                kind = NoopButtonKind.Secondary,
                 onClick = { if (permGranted) viewModel.connect() else permLauncher.launch(perms) },
-                modifier = Modifier.fillMaxWidth(),
-            ) { Text(uiString(R.string.l10n_connection_help_try_connecting_now_41769900), style = NoopType.body) }
+                fullWidth = true,
+            )
         }
     }
 }
@@ -147,9 +147,12 @@ private fun HelpStep(
         )
         Text(body, style = NoopType.footnote, color = Palette.textSecondary)
         if (actionLabel != null) {
-            OutlinedButton(onClick = onAction, enabled = enabled) {
-                Text(actionLabel, style = NoopType.footnote)
-            }
+            NoopButton(
+                text = actionLabel,
+                kind = NoopButtonKind.Secondary,
+                enabled = enabled,
+                onClick = onAction,
+            )
         }
     }
 }

--- a/android/app/src/main/java/com/noop/ui/DevicesScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/DevicesScreen.kt
@@ -793,7 +793,6 @@ private fun DeviceActionsMenu(
         IconButton(
             onClick = { onOpenChange(true) },
             modifier = Modifier
-                .size(32.dp)
                 .semantics { contentDescription = uiString(R.string.l10n_devices_screen_device_actions_for_displayname_device_160eb3de, displayName(device)) },
         ) {
             Icon(Icons.Filled.MoreVert, contentDescription = null, tint = Palette.textSecondary, modifier = Modifier.size(20.dp))

--- a/android/app/src/main/java/com/noop/ui/HealthScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/HealthScreen.kt
@@ -998,11 +998,12 @@ private fun FitnessReadinessCard(
                                     color = Palette.accent,
                                 )
                             } else {
-                                IconButton(onClick = onRefresh, modifier = Modifier.size(28.dp)) {
+                                IconButton(onClick = onRefresh) {
                                     Icon(
                                         Icons.Filled.Refresh,
                                         contentDescription = uiString(R.string.l10n_health_screen_refresh_fitness_age_now_85fc516f),
                                         tint = Palette.accent,
+                                        modifier = Modifier.size(20.dp),
                                     )
                                 }
                             }

--- a/android/app/src/main/java/com/noop/ui/HydrationScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/HydrationScreen.kt
@@ -75,7 +75,7 @@ import java.util.Locale
 
 /** The reset accent blue (matches NoopButton's pinned iOS `StrandPalette.accent`: #234F9E / #60A0E0). */
 private val hydrationAccent: Color
-    @Composable get() = if (Palette.isLight) Color(0xFF234F9E) else Color(0xFF60A0E0)
+    @Composable get() = Palette.accent
 
 // MARK: - Liquid hero tokens (shared with the liquid Today hero card)
 //

--- a/android/app/src/main/java/com/noop/ui/NoopButton.kt
+++ b/android/app/src/main/java/com/noop/ui/NoopButton.kt
@@ -85,7 +85,7 @@ private object NoopButtonMetrics {
 
 /** The reset accent blue (iOS `StrandPalette.accent`: #234F9E light / #60A0E0 dark). */
 private val noopAccentBlue: Color
-    @Composable get() = if (Palette.isLight) Color(0xFF234F9E) else Color(0xFF60A0E0)
+    @Composable get() = Palette.accent
 
 /** Crisp white label/icon on accent + critical fills (iOS `goldDeepText` = #FFFFFF post-reset). */
 private val noopOnFill: Color = Color(0xFFFFFFFF)
@@ -154,7 +154,7 @@ fun NoopButton(
     val scale by animateFloatAsState(
         targetValue = targetScale,
         animationSpec = if (reduced) tween(0) else NoopMotion.value(),
-        label = uiString(R.string.l10n_noop_button_noopbutton_scale_1bee88be),
+        label = "NoopButton.scale",
     )
     val opacity = when {
         !enabled -> NoopButtonMetrics.disabledOpacity

--- a/android/app/src/main/java/com/noop/ui/NoopButton.kt
+++ b/android/app/src/main/java/com/noop/ui/NoopButton.kt
@@ -88,7 +88,7 @@ private val noopAccentBlue: Color
     @Composable get() = Palette.accent
 
 /** Crisp white label/icon on accent + critical fills (iOS `goldDeepText` = #FFFFFF post-reset). */
-private val noopOnFill: Color = Color(0xFFFFFFFF)
+private val noopOnFill: Color get() = OnAccent
 
 /** Resolves a [NoopButtonKind] to its concrete fill / label / border tokens. */
 private data class NoopButtonAppearance(

--- a/android/app/src/main/java/com/noop/ui/SkinTempCardsScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/SkinTempCardsScreen.kt
@@ -172,7 +172,11 @@ fun CycleAwarenessCard(
             if (onLogPeriod != null || onOpenDetail != null || onTurnOff != null) {
                 Row(horizontalArrangement = Arrangement.spacedBy(Metrics.gap)) {
                     if (onLogPeriod != null) {
-                        OutlinedButton(onClick = onLogPeriod) { Text(uiString(R.string.l10n_skin_temp_cards_screen_log_period_start_c97241d0)) }
+                        NoopButton(
+                            text = uiString(R.string.l10n_skin_temp_cards_screen_log_period_start_c97241d0),
+                            kind = NoopButtonKind.Secondary,
+                            onClick = onLogPeriod,
+                        )
                     }
                     if (onOpenDetail != null) {
                         OutlinedButton(
@@ -182,7 +186,11 @@ fun CycleAwarenessCard(
                     }
                     // #801: symmetric off-control (turn cycle awareness off where it was turned on).
                     if (onTurnOff != null) {
-                        OutlinedButton(onClick = onTurnOff) { Text(uiString(R.string.l10n_skin_temp_cards_screen_turn_off_8807c2b3)) }
+                        NoopButton(
+                            text = uiString(R.string.l10n_skin_temp_cards_screen_turn_off_8807c2b3),
+                            kind = NoopButtonKind.Secondary,
+                            onClick = onTurnOff,
+                        )
                     }
                 }
             }
@@ -216,7 +224,11 @@ fun CycleAwarenessOptInCard(onEnable: () -> Unit) {
                 color = Palette.textSecondary,
             )
             PrivacyNote()
-            OutlinedButton(onClick = onEnable) { Text(uiString(R.string.l10n_skin_temp_cards_screen_turn_on_cycle_awareness_7c2d328f)) }
+            NoopButton(
+                text = uiString(R.string.l10n_skin_temp_cards_screen_turn_on_cycle_awareness_7c2d328f),
+                kind = NoopButtonKind.Secondary,
+                onClick = onEnable,
+            )
         }
     }
 }

--- a/android/app/src/main/java/com/noop/ui/UpdatesInboxScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/UpdatesInboxScreen.kt
@@ -148,7 +148,7 @@ fun UpdatesInboxScreen(
                     contentPadding = PaddingValues(horizontal = 18.dp, vertical = 8.dp),
                     colors = ButtonDefaults.buttonColors(
                         containerColor = Palette.accent,
-                        contentColor = if (Palette.isLight) Color.White else Palette.goldDeepText,
+                        contentColor = OnAccent,
                         disabledContainerColor = Palette.surfaceInset,
                         disabledContentColor = Palette.textTertiary,
                     ),
@@ -252,7 +252,7 @@ private fun SwipeBackground(direction: SwipeToDismissBoxValue) {
     }
     val washColor =
         if (direction == SwipeToDismissBoxValue.Settled) Color.Transparent else Palette.accent
-    val contentColor = if (Palette.isLight) Color.White else Palette.goldDeepText
+    val contentColor = OnAccent
     Box(
         modifier = Modifier
             .fillMaxSize()

--- a/android/app/src/main/java/com/noop/ui/WorkoutStart.kt
+++ b/android/app/src/main/java/com/noop/ui/WorkoutStart.kt
@@ -145,7 +145,11 @@ fun StartWorkoutSheet(vm: AppViewModel, onDismiss: () -> Unit) {
             }
         },
         dismissButton = {
-            OutlinedButton(onClick = onDismiss) { Text(uiString(R.string.l10n_workout_start_cancel_77dfd213)) }
+            NoopButton(
+                text = uiString(R.string.l10n_workout_start_cancel_77dfd213),
+                kind = NoopButtonKind.Secondary,
+                onClick = onDismiss,
+            )
         },
     )
 }


### PR DESCRIPTION
## What

Four small, related design-system/accessibility fixes:

- **Accent shadow copies:** `NoopButton` and `HydrationScreen` re-declared `Palette.accent`'s exact hex pair (`#234F9E`/`#60A0E0`) as private vals — a future accent re-theme would silently miss the primary buttons. Both now read `Palette.accent`. (Also swaps a localized *animation-inspector debug label* for a plain literal — tooling-only, never user-visible.)
- **48dp touch targets:** the Health refresh (28dp) and Devices actions (32dp) `IconButton`s passed `.size()` on the button itself, which fixes the constraints and defeats M3's 48dp minimum interactive size. The size now lives on the inner `Icon` (20dp, matching the sibling spinner / existing MoreVert glyph), restoring the 48dp target. Note: the Health refresh glyph goes 24→20dp visually.
- **StatTile at large font scales:** the fixed `height(tileHeight)` clipped the value/caption at fontScale ≥ ~1.3 (AutoSizeValue only shrinks for width). Now `heightIn(min = tileHeight)` — identical at default scale, grows instead of clipping.
- **One `OnAccent`:** `NoopButton`'s private white and `UpdatesInboxScreen`'s `if (isLight) White else Palette.goldDeepText` are the same "text on accent fill" concept — the latter only works by accident of the dark `goldDeepText` value (light is `#3A2708`). One shared `OnAccent = Color.White` replaces both spellings.
- **NoopButton adoption:** the 7 `OutlinedButton` sites whose content maps cleanly (text ± one leading icon) migrate to `NoopButton(kind = Secondary)` — same visual role, plus press-scale, Reduce-Motion, and the 44dp hit floor. The 19 remaining sites are deliberately compact/custom (contentPadding, caption type, weight layouts) and are left alone.

## Verification

- `./gradlew compileFullDebugKotlin` + `testFullDebugUnitTest` green.
- Devices actions menu verified opening on first tap on a Pixel 7 / API 34 emulator.
- Tokens only: every color/dimension referenced is an existing `Palette`/`Metrics`/`NoopType` token or the pre-existing literal icon size the row already used.
- Android-only; no analytics/stored-data changes, so no Kotlin/Swift parity impact.

Note: touches `Components.kt` near where #944 adds the shared hero surface — if both land, the later one rebases trivially.

🤖 Generated with [Claude Code](https://claude.com/claude-code)