### PR TITLE
diag(oura): connect-error logging + pending-connect probe; document confirmed macOS pairing limitation

### DIFF
--- a/Strand/BLE/OuraLiveSource.swift
+++ b/Strand/BLE/OuraLiveSource.swift
@@ -1643,9 +1643,23 @@ extension OuraLiveSource: @preconcurrency CBCentralManagerDelegate {
         peripheral.discoverServices([Self.service])
     }
 
+    /// Stable, loggable token for a CoreBluetooth connect/disconnect error - twin of BLEManager's
+    /// `connErrorToken`. Oura's own connect-failure handling only ever branched on ONE CBError case
+    /// (peerRemovedPairingInformation); every other failure just fell through to a free-text
+    /// `localizedDescription`, which isn't diagnosable across reports (its wording isn't a stable
+    /// identifier). This makes every case loggable the same way, notably so a macOS Advanced-key pairing
+    /// attempt against a ring that's never been OS-bonded to that Mac (no Oura app exists there to have
+    /// done it) produces a code we can actually act on instead of prose.
+    private static func connErrorToken(_ error: Error?) -> String {
+        guard let error else { return "none" }
+        if let cb = error as? CBError { return "cbError\(cb.code.rawValue)" }
+        if let att = error as? CBATTError { return "cbAttError\(att.code.rawValue)" }
+        return "unknown"
+    }
+
     public func centralManager(_ central: CBCentralManager,
                                didFailToConnect peripheral: CBPeripheral, error: Error?) {
-        log("Oura: WARNING failed to connect - \(error?.localizedDescription ?? "unknown error")")
+        log("Oura: WARNING failed to connect (\(Self.connErrorToken(error))) - \(error?.localizedDescription ?? "unknown error")")
         if feedsLive { live.connected = false; live.streamingLiveHR = false }
         // The ring wiped its bond (re-paired in the Oura app, or a firmware reset). CoreBluetooth surfaces
         // this as a stable CBError, and re-issuing connect just loops the same stale-pairing failure and
@@ -1663,7 +1677,7 @@ extension OuraLiveSource: @preconcurrency CBCentralManagerDelegate {
     public func centralManager(_ central: CBCentralManager,
                                didDisconnectPeripheral peripheral: CBPeripheral, error: Error?) {
         if let error = error {
-            log("Oura: disconnected - \(error.localizedDescription)")
+            log("Oura: disconnected (\(Self.connErrorToken(error))) - \(error.localizedDescription)")
         } else {
             log("Oura: disconnected (clean)")
         }

--- a/Strand/BLE/OuraLiveSource.swift
+++ b/Strand/BLE/OuraLiveSource.swift
@@ -326,6 +326,32 @@ public final class OuraLiveSource: NSObject, ObservableObject {
     /// (#414) and the Android `ReconnectBackoff` so a ring genuinely out of range doesn't hammer BLE.
     private var failedReconnectAttempts = 0
 
+    /// Twin of BLEManager's `pendingConnectProbe`/`pendingConnectProbeSeconds` (#730): CoreBluetooth's
+    /// `connect()` has NO built-in timeout, so an unanswered connect just stays pending forever with
+    /// neither `didConnect` nor `didFailToConnect` ever firing - Oura had no equivalent probe, so a stalled
+    /// connect (e.g. a ring that's already bonded/busy with another central, such as a phone running the
+    /// official Oura app) looked identical to "still working" with nothing in the log to tell them apart.
+    private var pendingConnectProbe: DispatchWorkItem?
+    private static let pendingConnectProbeSeconds: TimeInterval = 15
+
+    private func armPendingConnectProbe(for id: UUID) {
+        pendingConnectProbe?.cancel()
+        let probe = DispatchWorkItem { [weak self] in
+            guard let self, self.peripheral?.identifier == id, self.peripheral?.state != .connected else { return }
+            self.log("Oura: WARNING still not connected \(Int(Self.pendingConnectProbeSeconds))s after connect(\(id)) "
+                     + "- CoreBluetooth connect has no timeout, so this is still PENDING (no didFailToConnect). The "
+                     + "ring is likely out of range, asleep, or already bonded to another device (e.g. a phone "
+                     + "running the official Oura app).")
+        }
+        pendingConnectProbe = probe
+        DispatchQueue.main.asyncAfter(deadline: .now() + Self.pendingConnectProbeSeconds, execute: probe)
+    }
+
+    private func cancelPendingConnectProbe() {
+        pendingConnectProbe?.cancel()
+        pendingConnectProbe = nil
+    }
+
     /// Next backoff delay, capped at 60s, matching BLEManager's `min(60, 3 * 2^(n-1))` and the Android twin.
     private func nextReconnectDelay() -> TimeInterval {
         min(60.0, 3.0 * pow(2.0, Double(max(0, failedReconnectAttempts - 1))))
@@ -833,6 +859,7 @@ public final class OuraLiveSource: NSObject, ObservableObject {
         }
         log("Oura: connecting to \(id)")
         central.connect(p, options: nil)
+        armPendingConnectProbe(for: id)
     }
 
     /// Tear down: cancel the connection, stop scanning, flush, clear all transient state. Idempotent.
@@ -842,6 +869,7 @@ public final class OuraLiveSource: NSObject, ObservableObject {
         intentionalDisconnect = true
         reconnectID = nil
         failedReconnectAttempts = 0
+        cancelPendingConnectProbe()
         stopScan()
         pendingConnectID = nil
         stopReengageTimer()
@@ -1545,6 +1573,7 @@ extension OuraLiveSource: @preconcurrency CBCentralManagerDelegate {
             if let id = pendingConnectID, let p = seenPeripherals[id] {
                 pendingConnectID = nil
                 central.connect(p, options: nil)
+                armPendingConnectProbe(for: id)
             } else if scanning {
                 central.scanForPeripherals(withServices: [Self.service],
                                            options: [CBCentralManagerScanOptionAllowDuplicatesKey: false])
@@ -1585,6 +1614,7 @@ extension OuraLiveSource: @preconcurrency CBCentralManagerDelegate {
     }
 
     public func centralManager(_ central: CBCentralManager, didConnect peripheral: CBPeripheral) {
+        cancelPendingConnectProbe()   // the connect resolved; no pending-connect warning needed
         log("Oura: connected - discovering services")
         failedReconnectAttempts = 0   // a real connection clears the reconnect backoff (#912)
         peripheral.delegate = self
@@ -1659,6 +1689,7 @@ extension OuraLiveSource: @preconcurrency CBCentralManagerDelegate {
 
     public func centralManager(_ central: CBCentralManager,
                                didFailToConnect peripheral: CBPeripheral, error: Error?) {
+        cancelPendingConnectProbe()   // it FAILED rather than pending — this log is the answer
         log("Oura: WARNING failed to connect (\(Self.connErrorToken(error))) - \(error?.localizedDescription ?? "unknown error")")
         if feedsLive { live.connected = false; live.streamingLiveHR = false }
         // The ring wiped its bond (re-paired in the Oura app, or a firmware reset). CoreBluetooth surfaces

--- a/Strand/Screens/AddDeviceWizard.swift
+++ b/Strand/Screens/AddDeviceWizard.swift
@@ -720,6 +720,22 @@ struct AddDeviceWizard: View {
         .background(StrandPalette.statusWarning.opacity(0.10),
                     in: RoundedRectangle(cornerRadius: 12, style: .continuous))
 
+        #if os(macOS)
+        HStack(alignment: .top, spacing: 10) {
+            Image(systemName: "exclamationmark.triangle")
+                .foregroundStyle(StrandPalette.statusCritical)
+                .accessibilityHidden(true)
+            Text("This currently doesn't work on a Mac: a ring that's only ever been Bluetooth-bonded to a phone (via the Oura app) fails to connect from macOS - CoreBluetooth never completes the connection, even with that phone's Bluetooth off. iPhone/Android are unaffected. See docs/OURA_PROTOCOL.md §3.7.")
+                .font(StrandFont.footnote)
+                .foregroundStyle(StrandPalette.statusCritical)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .padding(12)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(StrandPalette.statusCritical.opacity(0.10),
+                    in: RoundedRectangle(cornerRadius: 12, style: .continuous))
+        #endif
+
         Text("Ring key (32 hex characters)").strandOverline()
         TextField("0123456789abcdef0123456789abcdef", text: $ouraKeyDraft)
             .textFieldStyle(.plain)

--- a/docs/OURA_PROTOCOL.md
+++ b/docs/OURA_PROTOCOL.md
@@ -151,6 +151,27 @@ ring  → phone: 2f 02 2e <status>
 ### 3.6 Pre-auth readable / gated commands
 Before app-auth, the ring answers a small set unauthenticated: firmware (`0x08`), product serial/hardware (`0x18`). Auth-required commands return `2f 02 2f 01` until authenticated: battery (`0x0c`), history events (`0x10`), feature status (`0x2f…0x20`), realtime/feature-latest. [open_oura-r3][open_oura-r5]
 
+### 3.7 macOS pairing limitation (observed, 2026-07-29)
+
+Pairing an Oura ring that has never been Bluetooth-bonded to the Mac (i.e. any ring whose only prior
+bond is with the official Oura app on a phone) reproducibly fails on macOS. `CBCentralManager.connect()`
+is issued cleanly (scanning stopped first, `central.state == .poweredOn`, a valid, in-range peripheral -
+observed RSSI as good as -55), but **no CoreBluetooth delegate callback ever arrives** - not
+`didConnect`, not `didFailToConnect`. The ring never appears in System Settings ▸ Bluetooth either
+(no partial bond record is created). Ruled out: a second central holding the ring - the same failure
+reproduces with the paired phone's Bluetooth fully off. This matches CoreBluetooth's documented
+behavior that `connect()` has no built-in timeout (an unanswered connect just stays pending forever),
+so the practical symptom is a silent, permanent hang rather than an error.
+
+This is a different (and apparently more total) failure surface than the already-known WHOOP 5.0/MG
+macOS limitation (§ see `docs/WHOOP5_DEEP_DATA.md` "iOS / Android only") - WHOOP 5/MG at least connects
+and discovers services, failing only at an authenticated characteristic write (`CBATTError` "Encryption
+is insufficient"). Oura's connect doesn't get that far at all. The exact CoreBluetooth/bluetoothd
+mechanism isn't diagnosed further than this (would need a low-level HCI/SMP trace), but the practical
+conclusion is the same as WHOOP 5/MG's: **treat Oura ring pairing as iOS/Android-only** until proven
+otherwise on macOS. Not yet tested: whether a genuinely never-bonded-anywhere (factory-reset) ring
+behaves differently from the already-Oura-app-owned case tested here.
+
 ---
 
 ## 4. Opcode Table


### PR DESCRIPTION
  ## Summary
  - Oura's `didFailToConnect` only ever branched on one `CBError` case (`peerRemovedPairingInformation`); every other connect failure, and every disconnect, logged only `Error.localizedDescription` (free text, not a stable code). Added
  `connErrorToken` (twin of `BLEManager.connErrorToken`) so every CBError/CBATTError logs a stable `cbError<N>`/`cbAttError<N>` token. Android already logs a numeric GATT status on both paths, so no Android change was needed.
  - Oura also had no connect-timeout watchdog: CoreBluetooth's `connect()` has no built-in timeout, so an unanswered connect just sits pending forever with zero delegate callback and nothing in the log to show it. Added
  `pendingConnectProbe` (twin of `BLEManager.pendingConnectProbe`, #730) that logs an explicit warning 15s after an unanswered connect.
  - Used both to root-cause a real user report ("Advanced-key pairing doesn't work on macOS"): on real hardware, `connect()` was issued cleanly (scan stopped, central `.poweredOn`, valid in-range peripheral) but **no CoreBluetooth
  callback ever arrived** — confirmed by the new probe firing every time. The ring never appeared in macOS System Settings ▸ Bluetooth. Ruled out "ring already bonded to another central": identical failure with the paired iPhone's
  Bluetooth fully off.
  - This is a genuine macOS CoreBluetooth platform limitation, in the same family as the already-documented WHOOP 5.0/MG macOS bonding limitation (though more total — WHOOP at least connects and discovers services, failing only at an
  authenticated write with a real ATT error). Documented in `docs/OURA_PROTOCOL.md` §3.7, and added a macOS-only warning banner to the Advanced-key wizard screen (`AddDeviceWizard.swift`) so this shows up as an honest explanation
  instead of a silent multi-minute hang. New string localized for the four focus locales (de/es/fr/pt-PT) plus it/ru/zh-Hans/zh-Hant to match the file's existing coverage.

  ## Test plan
  - [x] `xcodebuild -scheme Strand -destination 'platform=macOS'` — build succeeds
  - [x] `xcodebuild -scheme NOOPiOS -destination 'generic/platform=iOS Simulator'` — build succeeds
  - [x] `python3 Tools/i18n_audit.py --ci origin/main` — passes, all four focus locales complete
  - [x] **Verified on real hardware (macOS + real Oura ring):** the pending-connect probe fired as designed and was the key piece of evidence in root-causing the underlying macOS limitation documented in this PR

  ## Scope caveat
  Only tested against a ring already owned by the official Oura app. A genuinely factory-reset (never-bonded-anywhere) ring might behave differently on macOS — the warning is scoped to the Advanced-key screen only; the standard
  scan-and-adopt Oura pairing UI is left untouched pending further evidence.

  Cross-platform: Swift-only change (the Android GATT status logging already covers the diagnostic need there).
