### PR TITLE
fix(oura): resolve serial identity pre-auth, not just post-streaming (#771)

### DIFF
--- a/Strand/BLE/OuraLiveSource.swift
+++ b/Strand/BLE/OuraLiveSource.swift
@@ -953,14 +953,11 @@ public final class OuraLiveSource: NSObject, ObservableObject {
                 // confirms (from the ring itself) that these server-flag features are subscription-gated OFF
                 // for an offline ring. NEVER an enable/set-mode write - purely the 0x20 read verb.
                 write([OuraCommands.spo2ReadStatus(), OuraCommands.realStepsReadStatus()])
-                // Read-only capture (#771/#772): the ring's GetProductInfo serial + hardware pages are
-                // pre-auth readable. The SERIAL is a STABLE per-ring identity — unlike the CoreBluetooth UUID,
-                // which rotates on re-pair and orphans the ring's history (#771) — and the HARDWARE id
-                // (e.g. "BLB_03") maps to the generation, confirming it from the ring instead of stray digits
-                // in the advertised name (#772). Here we only ASK and LOG the raw replies to capture their
-                // byte layout; nothing is decoded, minted into an id, or persisted yet (capture-first, so a
-                // real fixture backs the decode before it drives identity/generation). Same read-only class as
-                // the SpO2 / real-steps status reads above; never a set/enable write.
+                // Belt-and-suspenders resend of GetProductInfo (#771/#772): the primary ask now happens
+                // pre-auth in didUpdateNotificationStateFor, so the serial/hardware id is normally already
+                // resolved by the time we get here. Re-asking once streaming costs nothing (the
+                // didUpdateValueFor peek dedupes by content via `loggedProductInfo`) and covers a ring that
+                // didn't answer the pre-auth read.
                 write([OuraCommands.getProductSerial(), OuraCommands.getProductHardware()])
             }
         default:
@@ -1776,6 +1773,14 @@ extension OuraLiveSource: @preconcurrency CBPeripheralDelegate {
             return
         }
         log("Oura: notifications enabled (isNotifying=\(characteristic.isNotifying)) - beginning auth")
+        // #771: GetProductInfo (serial + hardware pages) is pre-auth readable (OURA_PROTOCOL.md s3.1) -
+        // ask for it BEFORE the auth handshake, not just once streaming (as it was until now). This way an
+        // Advanced/"I already have my key" pairing that supplies a WRONG key, or a connection that drops
+        // before ever reaching .streaming, still gets a chance to resolve the ring's stable oura-<serial>
+        // id instead of being stranded on the rotating oura-<CBUUID> id (see AddDeviceWizard.buildOuraDevice).
+        // The reply is handled by didUpdateValueFor's product-info peek, which is phase-independent, so this
+        // is a pure timing change - no new response handling needed.
+        write([OuraCommands.getProductSerial(), OuraCommands.getProductHardware()])
         // Notifications are live: tell the driver we're ready. It returns the auth-nonce request (or, with
         // no key, drives the honest needs-pairing path).
         advance(.ready)
@@ -1830,11 +1835,12 @@ extension OuraLiveSource: @preconcurrency CBPeripheralDelegate {
            let battery = OuraDecoders.decodeBattery(batteryFrame.body) {
             ingest([.battery(battery)])
         }
-        // #771/#772 capture: log the GetProductInfo reply (serial + hardware pages) raw, once per op per
+        // #771/#772: handle the GetProductInfo reply (serial + hardware pages), once per distinct op+body per
         // session. Peek only — like the 0x11 summary / 0x0D battery above, a product-info op is below the
-        // event-tag range (≥ 0x41) so it round-trips through the TLV decoder as a harmless unknown-tag no-op;
-        // nothing here decodes it into a stable id (#771) or a generation (#772) yet — that waits on this
-        // fixture. Rendered as hex AND ASCII, since the serial / hardware id are strings (e.g. "BLB_03").
+        // event-tag range (≥ 0x41) so it round-trips through the TLV decoder as a harmless unknown-tag no-op.
+        // This runs regardless of the driver's current phase (asked pre-auth now, see
+        // didUpdateNotificationStateFor), which is what lets a stable id resolve even if auth later fails.
+        // Rendered as hex AND ASCII, since the serial / hardware id are strings (e.g. "BLB_03").
         for frame in frames where Self.productInfoResponseOps.contains(frame.op) {
             let hex = frame.body.map { String(format: "%02x", $0) }.joined(separator: " ")
             guard loggedProductInfo.insert("\(frame.op):\(hex)").inserted else { continue }

--- a/android/app/src/main/java/com/noop/ble/OuraLiveSource.kt
+++ b/android/app/src/main/java/com/noop/ble/OuraLiveSource.kt
@@ -1149,6 +1149,15 @@ class OuraLiveSource(
             if (descriptor.uuid != CCCD) return@guardedCallback
             if (status == BluetoothGatt.GATT_SUCCESS) {
                 log("Oura: notifications enabled (CCCD write status=$status) - beginning auth")
+                // #771: GetProductInfo (serial + hardware pages) is pre-auth readable (OURA_PROTOCOL.md s3.1)
+                // - ask for it BEFORE the auth handshake, not just once streaming (as it was until now). This
+                // way an Advanced/"I already have my key" pairing that supplies a WRONG key, or a connection
+                // that drops before ever reaching Streaming, still gets a chance to resolve the ring's stable
+                // oura-<serial> id instead of being stranded on the rotating oura-<MAC> id (see
+                // AddDeviceWizard.finishAddOura). handleNotification's product-info peek is phase-independent,
+                // so this is a pure timing change - no new response handling needed.
+                write(OuraCommands.getProductSerial())
+                write(OuraCommands.getProductHardware())
                 // Notifications are live: tell the driver we are Ready. It returns the enable-notify +
                 // get-nonce commands (or drives the honest needs-pairing path when there is no app key).
                 advance(OuraTransition.Ready)
@@ -1247,13 +1256,11 @@ class OuraLiveSource(
                     // subscription-gated OFF for an offline ring. NEVER an enable/set-mode write.
                     write(OuraCommands.spo2ReadStatus())
                     write(OuraCommands.realStepsReadStatus())
-                    // Read-only capture (#771/#772): the ring's GetProductInfo serial + hardware pages are
-                    // pre-auth readable. The SERIAL is a STABLE per-ring identity (Android mints the id from
-                    // the MAC today, but the serial is the platform-neutral identity Swift needs too, #771),
-                    // and the HARDWARE id (e.g. "BLB_03") maps to the generation, confirming it from the ring
-                    // instead of stray digits in the advertised name (#772). Here we only ASK and LOG the raw
-                    // replies to capture their byte layout; nothing is decoded, minted into an id, or persisted
-                    // yet (capture-first). Same read-only class as the SpO2 / real-steps reads above.
+                    // Belt-and-suspenders resend of GetProductInfo (#771/#772): the primary ask now happens
+                    // pre-auth in onDescriptorWrite, so the serial/hardware id is normally already resolved
+                    // by the time we get here. Re-asking once streaming costs nothing (handleNotification's
+                    // peek dedupes by content via `loggedProductInfo`) and covers a ring that didn't answer
+                    // the pre-auth read.
                     write(OuraCommands.getProductSerial())
                     write(OuraCommands.getProductHardware())
                 }
@@ -1371,12 +1378,13 @@ class OuraLiveSource(
         // and feed all other bytes to the TLV reassembler.
         val nonSecure = ArrayList<Int>()
         for (frame in OuraFraming.parseOuterFrames(bytes)) {
-            // #771/#772 capture: log each DISTINCT GetProductInfo reply (serial + hardware pages) raw, once
-            // per op+body per session. Peek only — like the 0x11 summary / 0x0D battery below, a product-info
-            // op is below the event-tag range (>= 0x41), so letting it fall through to the reassembler is a
-            // harmless unknown-tag no-op; nothing here decodes it into a stable id (#771) or a generation
-            // (#772) yet. get_serial and get_hardware both answer under op 0x19, so dedupe by content (not op)
-            // or the second is swallowed. Rendered hex AND ASCII, since both are strings (e.g. "BLB_03").
+            // #771/#772: handle each DISTINCT GetProductInfo reply (serial + hardware pages), once per
+            // op+body per session. Peek only — like the 0x11 summary / 0x0D battery below, a product-info op
+            // is below the event-tag range (>= 0x41), so letting it fall through to the reassembler is a
+            // harmless unknown-tag no-op. This runs regardless of the driver's current phase (asked pre-auth
+            // now, see onDescriptorWrite), which is what lets a stable id resolve even if auth later fails.
+            // get_serial and get_hardware both answer under op 0x19, so dedupe by content (not op) or the
+            // second is swallowed. Rendered hex AND ASCII, since both are strings (e.g. "BLB_03").
             if (frame.op in PRODUCT_INFO_RESPONSE_OPS) {
                 val hex = frame.body.joinToString(" ") { "%02x".format(it) }
                 if (loggedProductInfo.add("${frame.op}:$hex")) {


### PR DESCRIPTION
  ## Summary
  - The Oura "I already have my key" (Advanced) pairing path stayed permanently on the rotating `oura-<CBUUID>` (iOS/macOS) / `oura-<MAC>` (Android) device id if the supplied key was wrong, or the connection dropped before reaching
  `.streaming` — because `getProductSerial()`/`getProductHardware()` were only ever asked once live streaming began, i.e. *after* the app-auth handshake already succeeded.
  - Both commands are protocol-legal **pre-auth** reads (`Commands.swift:34-42`, marked "Pre-auth readable"), so move them to fire right after GATT discovery/notifications-enabled instead — before the auth handshake starts (Swift
  `didUpdateNotificationStateFor`, Kotlin `onDescriptorWrite`).
  - Confirmed the reply-parsing code (`didUpdateValueFor` / `handleNotification`) is already phase-independent (a simple op-code peek, not gated on driver phase), so this is a pure send-timing change — no driver/state-machine changes
  needed. The original post-streaming ask is kept as a harmless, content-deduped fallback.
  - Cleaned up two stale comments left over from PR #776 that claimed the reply was only logged, not decoded into an id (it already was).

  ## Test plan
  - [x] `xcodebuild -scheme Strand -destination 'platform=macOS'` — build succeeds
  - [x] `xcodebuild -scheme NOOPiOS -destination 'generic/platform=iOS Simulator'` — build succeeds
  - [x] Android `./gradlew compileFullDebugKotlin` — succeeds
  - [x] `swift test` in `Packages/OuraProtocol` — 159 tests pass, 0 failures
  - [ ] **On-hardware validation (BLE timing behavior, not CI-testable):** pair via the Advanced-key path with a deliberately wrong key and confirm the device row still migrates to `oura-<serial>` instead of staying stuck on the
  rotating id; repeat with the correct key and confirm normal behavior is unchanged

  Related: #771. Cross-platform: Swift + Kotlin both updated in this PR.