### PR TITLE
Emit a localized Android What's New title (#878)

### DIFF
--- a/.github/workflows/tools-python.yml
+++ b/.github/workflows/tools-python.yml
@@ -60,17 +60,19 @@ jobs:
           fi
         working-directory: tools/linux-capture
 
-      # Tools/test_i18n_audit.py covers the audit that gates every PR's translations, and nothing ran it
-      # either: i18n-coverage.yml invokes `i18n_audit.py --ci` but never its own test file. Run from
-      # inside Tools/ because the suite imports the module by bare name.
-      - name: Run Tools/ audit tests
+      # The Tools/ suites: the i18n audit that gates every PR's translations, and the What's New
+      # generator (#878). Neither ran before — i18n-coverage.yml invokes `i18n_audit.py --ci` but never
+      # its test file. `discover`, not named modules, for the same reason as above: naming them meant the
+      # generator's tests would have been added and silently never run. Run from inside Tools/ because
+      # the suites import their modules by bare name.
+      - name: Run Tools/ tests
         run: |
           set -o pipefail   # see above — without this a red suite exits 0 through the pipe.
-          python3 -m unittest test_i18n_audit -v 2>&1 | tee "$RUNNER_TEMP/out.txt"
+          python3 -m unittest discover -p "test_*.py" -v 2>&1 | tee "$RUNNER_TEMP/out.txt"
           ran=$(grep -oE '^Ran [0-9]+ test' "$RUNNER_TEMP/out.txt" | grep -oE '[0-9]+')
           echo "collected ${ran:-0} tests"
-          if [ "${ran:-0}" -lt 30 ]; then
-            echo "::error::expected at least 30 tests, collected ${ran:-0} — discovery is broken, not the suite"
+          if [ "${ran:-0}" -lt 45 ]; then
+            echo "::error::expected at least 45 tests, collected ${ran:-0} — discovery is broken, not the suite"
             exit 1
           fi
         working-directory: Tools

--- a/Tools/appchangelog-gen.py
+++ b/Tools/appchangelog-gen.py
@@ -45,10 +45,6 @@ import re
 import sys
 import pathlib
 
-try:
-    import yaml
-except ImportError:
-    sys.exit("appchangelog-gen: needs PyYAML (pip install pyyaml)")
 
 ROOT = pathlib.Path(__file__).resolve().parent.parent
 KT = ROOT / "android/app/src/main/java/com/noop/ui/AppChangelog.kt"
@@ -103,6 +99,13 @@ def write_title_strings(key: str, title: str, locales: dict) -> None:
 
 
 def frontmatter(md: pathlib.Path) -> dict:
+    # Imported HERE, not at module scope: the pure helpers below carry the #878 key scheme and are
+    # unit-tested, and a test runner should not need PyYAML installed to import them. Parsing the
+    # front-matter is the only thing that actually needs it, and it still fails with the same message.
+    try:
+        import yaml
+    except ImportError:
+        sys.exit("appchangelog-gen: needs PyYAML (pip install pyyaml)")
     m = re.match(r"^---\n(.*?)\n---\n", md.read_text(), re.S)
     if not m:
         sys.exit(f"appchangelog-gen: no YAML front-matter in {md}")

--- a/Tools/appchangelog-gen.py
+++ b/Tools/appchangelog-gen.py
@@ -152,12 +152,33 @@ def sw_block(ver, wn):
     )
 
 
-def apply(path, anchor, block, ver, const_re, const_new):
+def apply(path, anchor, block, ver, const_re, const_new, title_line=None):
+    """Insert `block` at `anchor`, or refresh an existing entry for `ver`, then bump the constant.
+
+    `title_line` is the platform's rendered title assignment (Kotlin's `title = uiString(...)`, Swift's
+    `title: "..."`). It is re-applied to an entry that already exists, because re-running after editing
+    the headline is a normal thing to do during a release — and without this the two halves disagree:
+    `write_title_strings` would mint and write the NEW key while the entry kept referencing the old one,
+    so the card showed the previous headline and the new key sat orphaned in six locale files. Found by
+    doing exactly that.
+    """
     text = path.read_text()
     idx = text.index(anchor) + len(anchor)
     already = f'version = "{ver}"' in text[idx:idx + 400] or f'version: "{ver}"' in text[idx:idx + 400]
     if already:
-        print(f"  {path.name}: v{ver} already the newest entry — leaving entries, refreshing constant")
+        if title_line:
+            pat = re.compile(rf'((?:version = "{re.escape(ver)}",|version: "{re.escape(ver)}",)\s*\n\s*)'
+                             r'(title[ =:][^\n]*)')
+            m = pat.search(text, idx)
+            if not m:
+                sys.exit(f"appchangelog-gen: found a v{ver} entry in {path.name} but not its title line")
+            if m.group(2).rstrip(",") == title_line.rstrip(","):
+                print(f"  {path.name}: v{ver} already the newest entry — title unchanged, refreshing constant")
+            else:
+                text = text[:m.start(2)] + title_line + text[m.end(2):]
+                print(f"  {path.name}: v{ver} already present — title UPDATED to the current headline")
+        else:
+            print(f"  {path.name}: v{ver} already the newest entry — leaving entries, refreshing constant")
     else:
         text = text[:idx] + block + text[idx:]
     text, n = re.subn(const_re, const_new, text, count=1)
@@ -177,9 +198,11 @@ def main():
     print(f"appchangelog-gen: v{ver} — {wn['title']}")
     write_title_strings(title_key(wn["title"]), wn["title"], wn.get("title_locales") or {})
     apply(KT, "val releases: List<Release> = listOf(\n", kt_block(ver, wn), ver,
-          r'(const val CURRENT_VERSION = ")[^"]*(")', rf'\g<1>{ver}\g<2>')
+          r'(const val CURRENT_VERSION = ")[^"]*(")', rf'\g<1>{ver}\g<2>',
+          title_line=f'title = uiString(R.string.{title_key(wn["title"])}),')
     apply(SW, "static let releases: [Release] = [\n", sw_block(ver, wn), ver,
-          r'(static let currentVersion = ")[^"]*(")', rf'\g<1>{ver}\g<2>')
+          r'(static let currentVersion = ")[^"]*(")', rf'\g<1>{ver}\g<2>',
+          title_line=f'title: "{esc_sw(wn["title"])}",')
     print("appchangelog-gen: done. Review the diff, then compile.")
 
 

--- a/Tools/appchangelog-gen.py
+++ b/Tools/appchangelog-gen.py
@@ -11,6 +11,12 @@ A per-version notes file docs/releases/v<VER>.md may carry a YAML front-matter b
       items:
         - "**Bold lead.** One-line description."
         - "**Another.** ..."
+      title_locales:            # OPTIONAL, but see below — without it the card ships English titles
+        de: "Kurze Überschrift"
+        es: "..."
+        fr: "..."
+        pt-PT: "..."
+        zh: "..."
     ---
     # NOOP v<VER>
     <the full release notes — the GitHub release body; the front-matter is stripped there>
@@ -19,7 +25,22 @@ Running `Tools/appchangelog-gen.py docs/releases/v8.2.2.md` prepends the generat
 `releases` in AppChangelog.kt AND AppChangelog.swift and bumps CURRENT_VERSION/currentVersion to that
 version. Idempotent: if the version is already the newest entry it only re-checks the constant. The
 version comes from the filename (v8.2.2.md -> 8.2.2).
+
+ANDROID TITLE LOCALIZATION (#878). Compose has no auto-extraction, so a raw Kotlin `title = "..."`
+is a hardcoded literal: the i18n gate fails on it, and because that gate audits the WHOLE tree the
+failure red-checks every open PR on a line none of them touched. Apple is unaffected (SwiftUI
+auto-extracts into the catalog), so the Swift entry keeps its literal title.
+
+This script therefore emits `title = uiString(R.string.<key>)` for Kotlin and writes the string
+itself, using the repo's key scheme: `l10n_app_changelog_<first 6 alnum words, lowercased>_<sha1 of
+the exact title>[:8]` — verified to reproduce the existing 9.2.0 and 9.2.1 keys.
+
+Translations come from `whatsnew.title_locales`. A locale with no entry falls back to the ENGLISH
+title and is named in a warning, because the alternative — leaving the key out of that locale — is
+the same red gate this exists to prevent. An English title in a German card is a visible, fixable
+wart; a red main after every release is not.
 """
+import hashlib
 import re
 import sys
 import pathlib
@@ -32,6 +53,53 @@ except ImportError:
 ROOT = pathlib.Path(__file__).resolve().parent.parent
 KT = ROOT / "android/app/src/main/java/com/noop/ui/AppChangelog.kt"
 SW = ROOT / "Strand/System/AppChangelog.swift"
+RES = ROOT / "android/app/src/main/res"
+
+#: The locale resource dirs the i18n gate treats as the focus set. `values` is the English source.
+LOCALE_DIRS = {"en": "values", "de": "values-de", "es": "values-es",
+               "fr": "values-fr", "pt-PT": "values-pt-rPT", "zh": "values-zh"}
+
+
+def title_key(title: str) -> str:
+    """`l10n_app_changelog_<first 6 alnum words>_<sha1(title)[:8]>` — the repo's existing scheme.
+
+    Hashed on the EXACT title text, so an edited headline mints a new key rather than silently
+    re-pointing the old one's translations at different words.
+    """
+    slug = "_".join(re.findall(r"[A-Za-z0-9]+", title.lower())[:6])
+    return f"l10n_app_changelog_{slug}_{hashlib.sha1(title.encode()).hexdigest()[:8]}"
+
+
+def esc_xml(s: str) -> str:
+    """Android resource escaping: XML entities, plus the apostrophe Android requires backslashed."""
+    return (s.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
+             .replace("'", "\\'"))
+
+
+def write_title_strings(key: str, title: str, locales: dict) -> None:
+    """Add `key` to values/ and each focus locale, before </resources>. Idempotent."""
+    missing = []
+    for loc, d in LOCALE_DIRS.items():
+        path = RES / d / "strings.xml"
+        if not path.is_file():
+            print(f"  WARNING: {path} not found — skipped")
+            continue
+        text = path.read_text()
+        if f'name="{key}"' in text:
+            continue
+        value = title if loc == "en" else locales.get(loc)
+        if value is None:
+            value, fell_back = title, True
+            missing.append(loc)
+        else:
+            fell_back = False
+        text = text.replace("</resources>",
+                            f'    <string name="{key}">{esc_xml(value)}</string>\n</resources>')
+        path.write_text(text)
+        print(f"  {d}/strings.xml: + {key}" + ("  (ENGLISH FALLBACK)" if fell_back else ""))
+    if missing:
+        print(f"  WARNING: no whatsnew.title_locales for {', '.join(missing)} — those cards show the "
+              f"English title. Add them to the release notes front-matter and re-run to fix.")
 
 
 def frontmatter(md: pathlib.Path) -> dict:
@@ -54,10 +122,11 @@ def esc_sw(s: str) -> str:
 
 def kt_block(ver, wn):
     items = "\n".join(f'                "{esc_kt(i)}",' for i in wn["items"])
+    # #878: a resource reference, never a literal — see the module docstring.
     return (
         "        Release(\n"
         f'            version = "{ver}",\n'
-        f'            title = "{esc_kt(wn["title"])}",\n'
+        f'            title = uiString(R.string.{title_key(wn["title"])}),\n'
         f'            date = "{esc_kt(wn["date"])}",\n'
         "            items = listOf(\n"
         f"{items}\n"
@@ -103,6 +172,7 @@ def main():
     ver = md.stem.lstrip("vV")
     wn = frontmatter(md)
     print(f"appchangelog-gen: v{ver} — {wn['title']}")
+    write_title_strings(title_key(wn["title"]), wn["title"], wn.get("title_locales") or {})
     apply(KT, "val releases: List<Release> = listOf(\n", kt_block(ver, wn), ver,
           r'(const val CURRENT_VERSION = ")[^"]*(")', rf'\g<1>{ver}\g<2>')
     apply(SW, "static let releases: [Release] = [\n", sw_block(ver, wn), ver,

--- a/Tools/test_appchangelog_gen.py
+++ b/Tools/test_appchangelog_gen.py
@@ -94,6 +94,68 @@ class EmittedBlockTests(unittest.TestCase):
             self.assertIn('"**One.** A thing."', block)
 
 
+class TitleRefreshTests(unittest.TestCase):
+    """Re-running after editing the headline must update the entry, not leave it stale.
+
+    The bug this pins: `apply()` skipped an entry that already existed, while the string writer ran
+    unconditionally — so an edited headline minted and wrote a NEW key into six locale files while the
+    entry kept referencing the OLD one. The card showed the previous headline and the new key was an
+    orphan, with nothing failing. Found by doing it.
+    """
+
+    KT_HEAD = ("object AppChangelog {\n"
+               "    const val CURRENT_VERSION = \"0.0.0\"\n"
+               "    val releases: List<Release> = listOf(\n")
+    KT_TAIL = "    )\n}\n"
+
+    def _file(self, body):
+        import tempfile
+        f = tempfile.NamedTemporaryFile("w", suffix=".kt", delete=False)
+        f.write(self.KT_HEAD + body + self.KT_TAIL)
+        f.close()
+        return pathlib.Path(f.name)
+
+    ENTRY = ('        Release(\n'
+             '            version = "9.9.9",\n'
+             '            title = uiString(R.string.l10n_app_changelog_old_one_aaaaaaaa),\n'
+             '            date = "July 2026",\n'
+             '        ),\n')
+
+    def test_existing_entry_gets_its_title_updated(self):
+        path = self._file(self.ENTRY)
+        acg.apply(path, "val releases: List<Release> = listOf(\n", "IGNORED", "9.9.9",
+                  r'(const val CURRENT_VERSION = ")[^"]*(")', r'\g<1>9.9.9\g<2>',
+                  title_line="title = uiString(R.string.l10n_app_changelog_new_one_bbbbbbbb),")
+        out = path.read_text()
+        self.assertIn("l10n_app_changelog_new_one_bbbbbbbb", out)
+        self.assertNotIn("l10n_app_changelog_old_one_aaaaaaaa", out)
+        path.unlink()
+
+    def test_it_does_not_duplicate_the_entry(self):
+        path = self._file(self.ENTRY)
+        acg.apply(path, "val releases: List<Release> = listOf(\n", "SHOULD_NOT_APPEAR", "9.9.9",
+                  r'(const val CURRENT_VERSION = ")[^"]*(")', r'\g<1>9.9.9\g<2>',
+                  title_line="title = uiString(R.string.l10n_app_changelog_new_one_bbbbbbbb),")
+        out = path.read_text()
+        self.assertEqual(1, out.count('version = "9.9.9"'))
+        self.assertNotIn("SHOULD_NOT_APPEAR", out)
+        path.unlink()
+
+    def test_unchanged_title_is_left_alone(self):
+        """The ENTRY is untouched when the headline has not moved. Asserting the title line rather than
+        the whole file, because `apply()` legitimately rewrites the version constant on every run —
+        which is what this test got wrong the first time."""
+        same = "title = uiString(R.string.l10n_app_changelog_old_one_aaaaaaaa),"
+        path = self._file(self.ENTRY)
+        acg.apply(path, "val releases: List<Release> = listOf(\n", "IGNORED", "9.9.9",
+                  r'(const val CURRENT_VERSION = ")[^"]*(")', r'\g<1>9.9.9\g<2>', title_line=same)
+        out = path.read_text()
+        self.assertEqual(1, out.count(same))
+        self.assertEqual(1, out.count('version = "9.9.9"'))
+        self.assertIn('const val CURRENT_VERSION = "9.9.9"', out)   # the constant DOES move
+        path.unlink()
+
+
 class LocaleTargetTests(unittest.TestCase):
 
     def test_focus_locales_match_the_resource_dirs_on_disk(self):

--- a/Tools/test_appchangelog_gen.py
+++ b/Tools/test_appchangelog_gen.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+"""#878 — the generated Android What's New title must be a resource reference, not a literal.
+
+A raw Kotlin `title = "..."` is a hardcoded literal that the i18n gate rejects, and because that gate
+audits the WHOLE tree, one bad line red-checks every open PR on code none of them touched. That is not
+hypothetical: it happened on 9.2.0 and again on 9.2.1, and both times it was cleared by hand afterwards
+rather than by the generator getting it right.
+
+These pin the two things that would bring it back: the emitted shape, and the key scheme that shape
+depends on. The scheme is pinned against a title that is actually shipping, so the test fails if either
+the hashing or the slugging drifts from what is already in strings.xml.
+"""
+import hashlib
+import importlib.util
+import pathlib
+import re
+import unittest
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+_spec = importlib.util.spec_from_file_location("acg", ROOT / "Tools/appchangelog-gen.py")
+acg = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(acg)
+
+# The 9.2.1 headline and the key it actually ships under, copied from values/strings.xml.
+SHIPPED_TITLE = ("Battery saver quiets the gauges, translated Android notifications, "
+                 "and instant chart loads")
+SHIPPED_KEY = "l10n_app_changelog_battery_saver_quiets_the_gauges_translated_bdbe8650"
+
+
+class TitleKeyTests(unittest.TestCase):
+
+    def test_reproduces_a_key_that_is_actually_shipping(self):
+        """Pinned against the real artifact, not against the function's own output."""
+        self.assertEqual(SHIPPED_KEY, acg.title_key(SHIPPED_TITLE))
+
+    def test_that_key_really_is_in_strings_xml(self):
+        """If someone renames the key in the resources, this test's premise is gone — say so loudly
+        rather than keep asserting against a string nothing uses."""
+        xml = (ROOT / "android/app/src/main/res/values/strings.xml").read_text()
+        self.assertIn(f'name="{SHIPPED_KEY}"', xml)
+
+    def test_editing_the_title_mints_a_new_key(self):
+        """The hash covers the exact title, so a reworded headline cannot silently inherit the old
+        key — and with it, translations of different words."""
+        self.assertNotEqual(acg.title_key(SHIPPED_TITLE), acg.title_key(SHIPPED_TITLE + " and more"))
+
+    def test_slug_is_six_words_and_hash_is_eight_hex(self):
+        key = acg.title_key("One two three four five six seven eight")
+        self.assertTrue(key.startswith("l10n_app_changelog_one_two_three_four_five_six_"))
+        self.assertRegex(key.rsplit("_", 1)[-1], r"^[0-9a-f]{8}$")
+
+    def test_hash_is_of_the_title_text_itself(self):
+        t = "Anything at all"
+        self.assertTrue(acg.title_key(t).endswith(hashlib.sha1(t.encode()).hexdigest()[:8]))
+
+
+class EscapingTests(unittest.TestCase):
+
+    def test_apostrophe_is_backslashed_for_android(self):
+        """An unescaped ' in a resource value is an aapt2 error, and release titles have them."""
+        self.assertEqual(r"L\'économiseur", acg.esc_xml("L'économiseur"))
+
+    def test_xml_entities(self):
+        self.assertEqual("a &amp; b &lt;c&gt;", acg.esc_xml("a & b <c>"))
+
+    def test_ampersand_is_escaped_before_the_others(self):
+        """Escaping & last would double-escape the entities introduced by < and >."""
+        self.assertEqual("&lt;a&gt; &amp; &lt;b&gt;", acg.esc_xml("<a> & <b>"))
+
+
+class EmittedBlockTests(unittest.TestCase):
+
+    WN = {"title": SHIPPED_TITLE, "date": "July 2026", "items": ["**One.** A thing."]}
+
+    def test_kotlin_title_is_a_resource_reference(self):
+        block = acg.kt_block("9.2.1", self.WN)
+        self.assertIn(f"title = uiString(R.string.{SHIPPED_KEY})", block)
+
+    def test_kotlin_title_is_not_a_literal(self):
+        """The regression itself: `title = "…"` is what fails the gate."""
+        block = acg.kt_block("9.2.1", self.WN)
+        self.assertNotRegex(block, r'title\s*=\s*"')
+
+    def test_swift_title_stays_a_literal(self):
+        """SwiftUI auto-extracts into the catalog, so Apple needs no reference — and changing it
+        would break the baseline that tracks these titles."""
+        block = acg.sw_block("9.2.1", self.WN)
+        self.assertIn(f'title: "{SHIPPED_TITLE}"', block)
+
+    def test_items_stay_literals_on_both_platforms(self):
+        """Only the title moved. Items are long-form prose the gate does not require extracting, and
+        turning them into 60 resources per release was never the ask."""
+        for block in (acg.kt_block("9.2.1", self.WN), acg.sw_block("9.2.1", self.WN)):
+            self.assertIn('"**One.** A thing."', block)
+
+
+class LocaleTargetTests(unittest.TestCase):
+
+    def test_focus_locales_match_the_resource_dirs_on_disk(self):
+        """A renamed or added locale dir must not leave the generator writing into nowhere."""
+        for loc, d in acg.LOCALE_DIRS.items():
+            self.assertTrue((ROOT / "android/app/src/main/res" / d / "strings.xml").is_file(),
+                            f"{loc} -> {d}/strings.xml is missing")
+
+    def test_english_source_is_the_values_dir(self):
+        self.assertEqual("values", acg.LOCALE_DIRS["en"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #878, from @pipiche38's write-up — the diagnosis and the proposed key scheme are theirs.

## The problem, reproduced before fixing

`appchangelog-gen.py` wrote the Kotlin title as a raw literal. Compose has no auto-extraction, so the
i18n gate rejects it — and because that gate audits the **whole tree**, one generated line red-checks
every open PR on code none of them touched. It happened on 9.2.0 and again on 9.2.1, cleared by hand
both times.

Confirmed rather than assumed: reverting 9.2.1's title to a literal gives

```
FAIL 1 NEW hardcoded literal(s): android/.../AppChangelog.kt:42
```

Only the title ever failed. Items are long-form prose the gate doesn't require extracting, and Swift is
unaffected because SwiftUI auto-extracts — so both keep their literals.

## The fix

The generator now emits `title = uiString(R.string.<key>)` and writes the string itself, keyed by the
repo's existing scheme (first six slugged words + `sha1(title)[:8]`). Verified against the key **already
shipping** for 9.2.1, and a test pins it to that live artifact — so a drift in the hashing or the
slugging fails, rather than quietly minting a key nothing translates.

Translations come from an optional `whatsnew.title_locales` block in the release notes front-matter.

## The trade I want checked

**A locale with no translation gets the English title, plus a named warning.** The alternative — leaving
the key out of that locale — fails the very gate this exists to prevent. An English title on a German
card is visible and fixable; a red `main` after every release, silently, because release pushes use
`GITHUB_TOKEN` and trigger no CI, is neither. Say if you'd rather it hard-fail instead; it is one line.

## Verified

Ran it end to end against a synthetic release file: correct key, correct `uiString` reference, strings
written to all six locale files, apostrophes escaped for aapt2, warning naming the three locales I left
out — and `i18n_audit.py --ci` passes on the result, which is the whole point. Reverted those artifacts;
this PR touches only the tooling.

14 new tests, all passing.

## One thing this PR also fixes about #943

That PR's `Tools/` step ran `test_i18n_audit` **by name**, so these 14 tests would have been added and
never run — the exact hole #943 was meant to close. Switched to `discover`, floor raised to 45.
