### PR TITLE
Security hardening: pin release workflow deps and action refs

### DIFF
--- a/.github/workflows/fork-release.yml
+++ b/.github/workflows/fork-release.yml
@@ -26,8 +26,13 @@ on:
         required: false
         default: ""
 
+# Workflow-level default is read-only; each job below that actually pushes a commit or
+# publishes/uploads a release grants itself `contents: write` explicitly (issue #657 — every job
+# here does end up needing it, since each one either commits a version bump, creates the release,
+# uploads a release asset, or pushes the AltStore manifest, but scoping it per-job means a future
+# job added to this workflow doesn't silently inherit write access it doesn't need).
 permissions:
-  contents: write
+  contents: read
 
 concurrency:
   group: release-build
@@ -36,13 +41,16 @@ concurrency:
 jobs:
   bump:
     runs-on: ubuntu-latest
+    # Pushes the version-bump commit to the dispatched branch and creates the GitHub release.
+    permissions:
+      contents: write
     outputs:
       ver: ${{ steps.b.outputs.ver }}
       tag: ${{ steps.b.outputs.tag }}
       sha: ${{ steps.b.outputs.sha }}
       buildVersion: ${{ steps.b.outputs.buildVersion }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
       - id: b
         env:
           GH_TOKEN: ${{ github.token }}
@@ -81,7 +89,7 @@ jobs:
             # from docs/releases/<TAG>.md's whatsnew: front-matter, so the in-app card ships in sync with
             # this version. Warn (don't fail) if the notes file / its front-matter is missing.
             if [ -f "docs/releases/${TAG}.md" ]; then
-              python3 -m pip install --quiet pyyaml >/dev/null 2>&1 || true
+              python3 -m pip install --quiet pyyaml==6.0.2 >/dev/null 2>&1 || true
               python3 Tools/appchangelog-gen.py "docs/releases/${TAG}.md" \
                 || echo "::warning::appchangelog-gen failed for ${TAG} — in-app 'What's New' not updated."
             else
@@ -151,19 +159,22 @@ jobs:
   android:
     needs: bump
     runs-on: ubuntu-latest
+    # Uploads the built APK to the release created by the `bump` job.
+    permissions:
+      contents: write
     defaults:
       run:
         working-directory: android
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
           ref: ${{ needs.bump.outputs.sha }}   # build the bumped commit
-      - uses: actions/setup-java@v5
+      - uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5.6.0
         with:
           distribution: temurin
           java-version: '17'
-      - uses: gradle/actions/wrapper-validation@v5
-      - uses: gradle/actions/setup-gradle@v5
+      - uses: gradle/actions/wrapper-validation@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
+      - uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
       # Release-only (no debug APK). Signed with the committed fork-debug.keystore via the debug
       # signingConfig storeFile (release falls back to it when no keystore.properties is present);
       # -PstagingRelease gives it the .staging app id so it installs beside the official app.
@@ -182,11 +193,18 @@ jobs:
     needs: bump
     runs-on: macos-15
     timeout-minutes: 40
+    # Uploads the built .app zip to the release created by the `bump` job.
+    permissions:
+      contents: write
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
           ref: ${{ needs.bump.outputs.sha }}
       - name: Install XcodeGen
+        # Known unpinned-tooling gap (issue #657): Homebrew core doesn't keep old formula versions
+        # around, so `brew install xcodegen@<version>` / a version-pin syntax isn't available here —
+        # this always installs whatever xcodegen is current in homebrew-core on the runner image at
+        # run time. Left as a tracked gap rather than silently unaddressed.
         run: brew install xcodegen
       - name: Generate Xcode project
         run: xcodegen generate
@@ -232,11 +250,18 @@ jobs:
     # iOS 26 Liquid Glass (glassEffect) needs the iOS 26 SDK → Xcode 26 → macos-26.
     runs-on: macos-26
     timeout-minutes: 40
+    # Uploads the built .ipa to the release created by the `bump` job.
+    permissions:
+      contents: write
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
           ref: ${{ needs.bump.outputs.sha }}
       - name: Install XcodeGen
+        # Known unpinned-tooling gap (issue #657): Homebrew core doesn't keep old formula versions
+        # around, so `brew install xcodegen@<version>` / a version-pin syntax isn't available here —
+        # this always installs whatever xcodegen is current in homebrew-core on the runner image at
+        # run time. Left as a tracked gap rather than silently unaddressed.
         run: brew install xcodegen
       - name: Generate Xcode project
         run: xcodegen generate
@@ -274,8 +299,11 @@ jobs:
   altstore:
     needs: [bump, ios]
     runs-on: ubuntu-latest
+    # Pushes the altstore-source.json update commit directly to main.
+    permissions:
+      contents: write
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
           ref: main   # AltStore reads the manifest from main, so commit there regardless of the release branch.
       - name: Add this release to the AltStore source


### PR DESCRIPTION
Fixes #657

## Summary

`.github/workflows/fork-release.yml` published release artifacts with a broad `contents: write`
permission at workflow scope, and installed/executed several unpinned dependencies (mutable action
tags, an unpinned `pyyaml` install, an unpinned Homebrew `xcodegen` install). This PR pins what can be
pinned and scopes the write permission down to only the jobs that need it.

**Note:** the actions in the file were already on `@v5` tags (`actions/checkout@v5`,
`actions/setup-java@v5`, `gradle/actions/*@v5`) rather than the `@v4` tags cited in the issue — version
drift since #657 was filed. This PR pins the SHAs for the tags actually in the file today.

## Changes

### 1. Pinned every `uses:` action reference to its immutable commit SHA (tag kept as a trailing comment)

| Action | Tag | Resolved SHA |
|---|---|---|
| `actions/checkout` | `v5` (currently `v5.1.0`) | `fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09` |
| `actions/setup-java` | `v5` (currently `v5.6.0`) | `03ad4de0992f5dab5e18fcb136590ce7c4a0ac95` |
| `gradle/actions/wrapper-validation` | `v5` (currently `v5.0.2`) | `0723195856401067f7a2779048b490ace7a47d7c` |
| `gradle/actions/setup-gradle` | `v5` (currently `v5.0.2`) | `0723195856401067f7a2779048b490ace7a47d7c` |

Every `uses:` line in the file was covered (grepped for all occurrences, not just the lines called out
in the issue) — `actions/checkout` appears 5 times (once per job), `actions/setup-java` and both
`gradle/actions/*` once each in the `android` job.

### 2. Pinned `pyyaml` to `6.0.2` in the `pip install` used by the changelog generator step.

### 3. Scoped `permissions: contents: write` down from workflow-level to job-level

Workflow-level `permissions:` is now `contents: read`. Reading through the full job graph:

- `bump` — pushes the version-bump commit and creates the GitHub release (`gh release create`) → needs write.
- `android` / `macos` / `ios` — each uploads a release asset (`gh release upload`) → needs write.
- `altstore` — pushes the `altstore-source.json` update commit to `main` → needs write.

Every job in this workflow does, in fact, commit/publish something, so all five jobs carry their own
explicit `permissions: contents: write`. This isn't a no-op, though: the workflow-level default is now
`read`, so a job added to this file in the future no longer silently inherits write access unless it
opts in explicitly. No permission was added anywhere it didn't already exist — this is a pure scope-down.

### 4. Noted the `xcodegen` Homebrew install as a known unpinned-tooling gap

`brew install xcodegen` (macOS + iOS jobs) is not pinned to a specific version. Homebrew core doesn't
retain old formula versions, so there's no clean `brew install xcodegen@<version>` equivalent available
for this formula. Added a comment at both call sites documenting this as a known, accepted gap rather
than leaving it silently unaddressed.

## Verification

This is a YAML-only change to a `workflow_dispatch`-gated release workflow, so it **could not be tested
by actually running the release workflow** (that requires a real dispatch, which cuts a real release).
What was verified:

- YAML syntax: `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/fork-release.yml'))"` — passes.
- Each SHA was resolved directly against the GitHub API (`gh api repos/<owner>/<repo>/commits/<tag>`)
  and cross-checked against `gh api repos/<owner>/<repo>/tags` to confirm which exact version tag
  (`v5.1.0` / `v5.6.0` / `v5.0.2`) each SHA corresponds to.
- `git diff --stat` confirms only `.github/workflows/fork-release.yml` changed.
- Job/permission structure was worked out by reading the entire file end to end (not just the lines
  cited in the issue) to confirm which jobs actually push commits or publish/upload release assets,
  so the permission scope-down doesn't break the publish path.

Not verified (and can't be, outside an actual dispatch): that the pinned SHAs behave identically to the
previous tags at runtime, or that the job-level `permissions:` blocks don't break the real release job
graph under GitHub Actions' actual permission-inheritance rules. Given how this workflow works — direct
`git push` + `gh release create/upload` via `GH_TOKEN: ${{ github.token }}`, no third-party actions
doing implicit writes — the explicit per-job `contents: write` should be equivalent to the previous
workflow-level grant for these jobs, but flagging this for maintainer review before merge/first dispatch.
