### PR TITLE
iOS: report BGTask export success accurately and add expiration handler

### DIFF
--- a/Strand/System/ScheduledDebugExport.swift
+++ b/Strand/System/ScheduledDebugExport.swift
@@ -127,15 +127,22 @@ enum ScheduledDebugExport {
 
     /// If today's drop is due (we're at/after the chosen time and haven't written today), write it once.
     /// Covers macOS launches where the time passed while the app wasn't open, and the iOS foreground path.
-    private static func catchUpIfDue() {
-        guard isEnabled else { return }
+    ///
+    /// Returns whether this call can be considered successful: `true` when there was nothing to do
+    /// (feature off, not yet time, or already ran today — nothing was attempted, so nothing failed) or the
+    /// export was attempted and wrote successfully; `false` only when an export was actually attempted and
+    /// `performExport` failed to write. The iOS BGTask handler uses this to report the real outcome to
+    /// `setTaskCompleted(success:)` instead of a hardcoded success.
+    @discardableResult
+    private static func catchUpIfDue() -> Bool {
+        guard isEnabled else { return true }
         let now = Date()
         let cal = Calendar.current
         let comps = cal.dateComponents([.hour, .minute], from: now)
         let nowMinutes = (comps.hour ?? 0) * 60 + (comps.minute ?? 0)
-        guard nowMinutes >= timeMinutes else { return }      // not yet time today
-        guard UserDefaults.standard.string(forKey: K.lastRun) != dayKey(now) else { return } // already ran today
-        _ = performExport(markDay: true)
+        guard nowMinutes >= timeMinutes else { return true }      // not yet time today
+        guard UserDefaults.standard.string(forKey: K.lastRun) != dayKey(now) else { return true } // already ran today
+        return performExport(markDay: true) != nil
     }
 
     /// Seconds from now until the next wall-clock occurrence of `minuteOfDay` (today if still ahead, else
@@ -201,10 +208,36 @@ enum ScheduledDebugExport {
     /// uncalled: `submitBackgroundRequest()` fails gracefully and the macOS path + "Run now" still work.
     static func register() {
         BGTaskScheduler.shared.register(forTaskWithIdentifier: bgTaskIdentifier, using: nil) { task in
+            let completion = TaskCompletionGuard(task: task)
+            // iOS can kill the process before our work below returns if the background budget runs out;
+            // report that honestly as a failure (so the run is retried) instead of leaving the task
+            // marked incomplete, and instead of the old hardcoded `success: true`.
+            task.expirationHandler = { completion.finish(success: false) }
             // Write the drop, then immediately request the next one (BGAppRefresh is single-shot).
-            if isEnabled { catchUpIfDue() }
+            // `catchUpIfDue()` already no-ops (returning true) when the feature is off.
+            let succeeded = catchUpIfDue()
             submitBackgroundRequest()
-            task.setTaskCompleted(success: true)
+            completion.finish(success: succeeded)
+        }
+    }
+
+    /// Guards `BGTask.setTaskCompleted` against being called twice — once from the normal completion
+    /// path and once from `expirationHandler` — which BGTaskScheduler treats as a programmer error.
+    /// Plain lock rather than actor isolation: the expiration handler can be invoked by the system on a
+    /// queue other than the one running the registration closure.
+    private final class TaskCompletionGuard {
+        private let task: BGTask
+        private let lock = NSLock()
+        private var finished = false
+
+        init(task: BGTask) { self.task = task }
+
+        func finish(success: Bool) {
+            lock.lock()
+            defer { lock.unlock() }
+            guard !finished else { return }
+            finished = true
+            task.setTaskCompleted(success: success)
         }
     }
 


### PR DESCRIPTION
Fixes #654

## Summary

The scheduled debug-export BGTask handler (`Strand/System/ScheduledDebugExport.swift`)
always called `task.setTaskCompleted(success: true)` unconditionally, regardless of
whether the write actually succeeded, and had no `expirationHandler`. A failed write
(e.g. `LiveState.scheduledExportText(...).write(to:...)` throwing) or the background
budget running out before the work finished could still be reported to iOS as a
successful run.

Changes, both in `Strand/System/ScheduledDebugExport.swift`:

- `catchUpIfDue()` now returns `@discardableResult Bool` instead of `Void`. It returns
  `true` when there was nothing to do (feature disabled, not yet time, or already ran
  today — nothing was attempted, so nothing failed), and otherwise propagates
  `performExport(markDay:)`'s actual result (`URL?` — non-nil means the write
  succeeded). The two existing callers (`setEnabled`, `activateIfEnabled`) don't use
  the return value and are unaffected by the signature change.
- `register()`'s BGTask handler now captures `catchUpIfDue()`'s real result and passes
  it to `setTaskCompleted(success:)` instead of a hardcoded `true`.
- Added `task.expirationHandler`, set before the work runs, so if iOS is about to kill
  the process before the (normally fast, synchronous) export finishes, the task is
  reported as failed — so it gets retried — instead of iOS force-terminating the
  process without `setTaskCompleted` ever being called.
- Added a small `TaskCompletionGuard` helper (private, iOS-only, inside the
  `#if os(iOS)` block) so the expiration path and the normal completion path can't
  both call `setTaskCompleted` (BGTaskScheduler treats a double call as a programmer
  error). It's a plain `NSLock`-guarded flag rather than actor isolation, since the
  expiration handler can be invoked by the system on a different queue than the one
  running the registration closure.

No behavior change to the actual export logic (`performExport`) or to the macOS timer
path — this only fixes what gets reported to `BGTaskScheduler` on the iOS path.

## Out of scope

One concern per PR: this only touches the BGTask completion/expiration reporting. It
doesn't change the export content, scheduling cadence, or add retry/backoff logic
beyond what `expirationHandler` reporting `false` naturally gives you (iOS may
reschedule a failed `BGAppRefreshTaskRequest` sooner).

## Verification

- **Build**: `xcodegen generate && xcodebuild -project Strand.xcodeproj -scheme Strand
  -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO build` — **BUILD SUCCEEDED**,
  no errors/warnings introduced. This compiles the whole `Strand` target including this
  file's non-iOS code paths (the `#if os(iOS)` block, including the new
  `expirationHandler`/`TaskCompletionGuard` code, is skipped on this platform since
  `BGTaskScheduler`/`BGTask` are iOS-only APIs).
- **Not verified**: the iOS-specific `#if os(iOS)` block (the actual `BGTaskScheduler`
  registration, `expirationHandler`, and `TaskCompletionGuard`) has not been compiled
  under the `NOOPiOS` scheme or exercised on a device/simulator in this pass — I don't
  have an iOS SDK build available here. `app-build.yml` (compile-only for `NOOPiOS`) is
  disabled by default and would be the way to validate the iOS compile on CI; happy to
  trigger it on request. BGTask expiration timing in particular can only really be
  observed on-device (Xcode's "Simulate Background App Refresh" / expiration debugging
  tools), which wasn't exercised here — this is a logic fix reviewed by inspection, not
  hardware-tested.
- **Tests**: no existing test file exercises `ScheduledDebugExport` (checked
  `StrandTests/` — none found), and I didn't add one — `catchUpIfDue`/`register` are
  private/iOS-only and depend on `BGTaskScheduler`, `UserDefaults`, and the filesystem,
  which would need more scaffolding (fakes/mocks) than fits a small, well-scoped fix.
  Flagging this as a gap for reviewer judgment rather than skipping silently.
- **i18n**: no new user-facing strings; `Tools/i18n_audit.py` not run since nothing
  string-related changed.
