### PR TITLE
iOS: apply Data Protection to the rejected-history archive directory

### DIFF
--- a/StrandTests/RawHistoryArchiveDataProtectionTests.swift
+++ b/StrandTests/RawHistoryArchiveDataProtectionTests.swift
@@ -1,0 +1,50 @@
+import XCTest
+@testable import Strand
+import WhoopProtocol
+
+/// #649: the reject archive lives outside `OpenWhoop`'s protected App Support tree
+/// (`StorePaths.defaultDatabasePath()`, #222) and did not inherit that store's Data Protection
+/// downgrade. On iOS, files default to `NSFileProtectionComplete` — cryptographically UNREADABLE while
+/// the device is locked. `BLEManager.archiveRejectedFrames` writes here to durably bank a frame BEFORE
+/// acking the strap's historical-data trim; a write that throws because the phone is locked trips the
+/// `.failed` path and holds the ack, so the strap re-sends the same chunk in a loop. This test asserts
+/// the fix: after a successful `archive(...)` write, the directory AND the file carry the same
+/// `completeUntilFirstUserAuthentication` protection class `StorePaths` sets on the main SQLite store.
+///
+/// iOS-only: the code under test is itself `#if os(iOS)`-gated (mirroring `StorePaths.swift`, since
+/// `FileProtectionType`/`.protectionKey` are only meaningfully enforced under iOS's Data Protection
+/// entitlement). `StrandTests` runs on the macOS scheme (see `project.yml`), so this assertion can't
+/// execute there today — it skips cleanly on macOS and is ready for the first iOS-capable test run.
+final class RawHistoryArchiveDataProtectionTests: XCTestCase {
+
+    private func tmpDir(_ tag: String) -> URL {
+        URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("noop-protect-\(tag)-\(UUID().uuidString)", isDirectory: true)
+    }
+
+    func testArchiveDirectoryAndFileGetDataProtectionAfterWrite() throws {
+        #if os(iOS)
+        let dir = tmpDir("protect")
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let archive = RawHistoryArchive(directory: dir)
+
+        let frame: [UInt8] = [0xAA, 0x01, 0x00, 0x00, 47, 18] + [UInt8](repeating: 0, count: 24)
+        let result = archive.archive([frame], trim: 1, family: .whoop4)
+        guard case .written = result else {
+            return XCTFail("expected a successful write, got \(result)")
+        }
+
+        let dirAttrs = try FileManager.default.attributesOfItem(atPath: dir.path)
+        XCTAssertEqual(dirAttrs[.protectionKey] as? FileProtectionType,
+                        .completeUntilFirstUserAuthentication,
+                        "archive directory must not default to NSFileProtectionComplete (#649)")
+
+        let fileAttrs = try FileManager.default.attributesOfItem(atPath: archive.fileURL.path)
+        XCTAssertEqual(fileAttrs[.protectionKey] as? FileProtectionType,
+                        .completeUntilFirstUserAuthentication,
+                        "archive file must not default to NSFileProtectionComplete (#649)")
+        #else
+        throw XCTSkip("File Data Protection is iOS-only; StrandTests runs on the macOS scheme.")
+        #endif
+    }
+}


### PR DESCRIPTION
Fixes #649

## Summary

`RawHistoryArchive` durably stores undecodable raw historical BLE frames under `<AppSupport>/com.noopapp.noop/`, a directory separate from the `OpenWhoop` App Support tree that `StorePaths.defaultDatabasePath()` explicitly downgrades to `FileProtectionType.completeUntilFirstUserAuthentication` for background BLE reliability (#222). The archive directory never got the same treatment, so on iOS it defaulted to `NSFileProtectionComplete` — cryptographically unreadable while the device is locked.

`BLEManager.archiveRejectedFrames` must succeed before the backfiller acks a historical-data trim; on failure it holds the ack so the strap re-sends the chunk (no data loss, but a resend loop). If the archive write throws because the phone is locked, this is exactly the failure path that gets hit — silently, in the background, with no user-visible symptom beyond an offload that never seems to finish.

## Fix

Mirrors `StorePaths.swift`'s exact approach in `Strand/Collect/RawHistoryArchive.swift`:
- A private `applyDataProtection()` (iOS-only, `#if os(iOS)`) sets `.protectionKey: FileProtectionType.completeUntilFirstUserAuthentication` on the archive directory, and on the archive file if one already exists — same attribute key, same protection level, same `try?`-and-continue pattern `StorePaths` uses.
- A new `ensureProtectedDirectory()` helper wraps directory creation and calls `applyDataProtection()` immediately after, replacing the two inline `createDirectory` call sites (the fast-append path and the over-cap rewrite path).
- Both write paths call `applyDataProtection()` again immediately after a write that could have created the file for the first time (fresh install / first-ever write), so a brand-new file that iOS would otherwise default to `NSFileProtectionComplete` gets covered too.

No BLE wire-protocol code was touched — this is purely a file-system attribute change on the archive's own directory/file.

## Test

`RawHistoryArchive` already takes an injectable `directory: URL?` (used by the existing eviction/replay tests), so I added `StrandTests/RawHistoryArchiveDataProtectionTests.swift`: it archives a frame into a temp directory and asserts both the directory and the file carry `.completeUntilFirstUserAuthentication`.

This assertion only runs under `#if os(iOS)`, matching the production code it's testing (`FileProtectionType`/`.protectionKey` are only meaningfully enforced under iOS's Data Protection entitlement). `StrandTests` runs on the **macOS** scheme (see `project.yml`), so on macOS the test cleanly `XCTSkip`s instead of asserting nothing — confirmed via `xcodebuild test -only-testing:StrandTests/RawHistoryArchiveDataProtectionTests`, which reports 1 test skipped, 0 failures.

## Verification

- `xcodegen generate && xcodebuild -project Strand.xcodeproj -scheme Strand -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO build` — **BUILD SUCCEEDED**.
- `xcodebuild ... build-for-testing` — **TEST BUILD SUCCEEDED** (confirms the new test file compiles).
- `xcodebuild ... test -only-testing:StrandTests/RawHistoryArchiveDataProtectionTests` — **TEST SUCCEEDED** (1 skipped on macOS, as designed).
- No iOS Xcode build was run in this pass (no iOS SDK/simulator available here) — `Strand/Collect/RawHistoryArchive.swift` and `StrandTests/` are shared between the macOS (`Strand`) and iOS (`NOOPiOS`) targets per `project.yml`, so the macOS build compiling cleanly gives reasonable confidence the `#if os(iOS)` branches are syntactically sound, but the iOS-specific behavior itself was not compiled or exercised on-device in this pass.
- No user-facing strings were added; the i18n audit was not run since there is nothing for it to check.

**BLE-adjacent (feeds `archiveRejectedFrames`'s backfill ack path) — compile success does not prove connection/backfill behavior; needs real-strap validation of the backfill/resend path (specifically: locking the phone mid-offload and confirming the archive write no longer throws, and that a previously-stuck resend loop resolves) before merge.**
