### PR TITLE
iOS: avoid main-actor full rewrites in PuffinFrameRecorder

### DIFF
--- a/Packages/WhoopProtocol/Sources/WhoopProtocol/PuffinCapture.swift
+++ b/Packages/WhoopProtocol/Sources/WhoopProtocol/PuffinCapture.swift
@@ -6,7 +6,7 @@ import Foundation
 /// The `hex` key is intentionally the same shape the test fixtures use (`frames.json` is an array of
 /// `{"hex": …}`), so a capture file is *directly* usable as a parity fixture — the extra fields are a
 /// superset the decoder ignores. Keys are snake_case to match the existing `golden.json` style.
-public struct PuffinCaptureRecord: Codable, Equatable {
+public struct PuffinCaptureRecord: Codable, Equatable, Sendable {
     /// Full on-wire frame as lowercase hex — the canonical `ParsedFrame.rawHex`.
     public let hex: String
     /// Source notify characteristic UUID (e.g. `fd4b0005-…`) — tells you which channel the frame

--- a/Strand/BLE/BLEManager.swift
+++ b/Strand/BLE/BLEManager.swift
@@ -694,7 +694,9 @@ public final class BLEManager: NSObject, ObservableObject {
     private lazy var puffinDeepBufferLog = PuffinDeepBufferLog()
 
     /// Force the puffin capture buffer to disk so the Settings export/reveal targets a current file.
-    public func flushPuffinCaptures() { puffinRecorder.flush() }
+    /// `async` because the actual encode + write now happens off the main actor (#652); callers that
+    /// need the file to be current when this returns (export, reveal) must await it.
+    public func flushPuffinCaptures() async { await puffinRecorder.flush() }
 
     /// Record a local physical-phase marker for the passive optical experiment. This deliberately has
     /// no peripheral/write path: it only appends to `puffin-deepbuffers.jsonl` when capture is enabled.
@@ -3896,7 +3898,9 @@ extension BLEManager: @preconcurrency CBCentralManagerDelegate {
         keepAliveTimer?.cancel()
         keepAliveTimer = nil
         resetCharacteristics()
-        puffinRecorder.flush()   // persist any buffered puffin capture frames before reconnect
+        // Best-effort, fire-and-forget: nothing below depends on this write completing, and the
+        // recorder keeps writing the same session file after reconnect (#652: encode+write off-main).
+        Task { @MainActor in await puffinRecorder.flush() }   // persist any buffered puffin capture frames
         puffinEventLog.close()   // release the event-log handle so the file is safe to export
         puffinDeepBufferLog.close()   // same for the high-rate deep-buffer log (#423)
         Task { @MainActor in await collector?.flushStandardHR() }   // persist any buffered 0x2A37 HR

--- a/Strand/BLE/PuffinFrameRecorder.swift
+++ b/Strand/BLE/PuffinFrameRecorder.swift
@@ -8,7 +8,13 @@ import WhoopProtocol
 /// that already arrived, it never writes to the device — so it is always safe to leave on.
 ///
 /// `@MainActor` because it reads `LiveState.heartRate` and updates published capture status; the
-/// BLEManager delegate callbacks that feed it are already on the main queue.
+/// BLEManager delegate callbacks that feed it are already on the main queue. The actual JSON encode +
+/// atomic file write + old-capture eviction — the part whose cost grows with the capture size — does
+/// NOT run on the main actor: it is handed off to the `fileWriter` background actor (#652) so a flush
+/// never blocks the main thread / SwiftUI, no matter how large the in-memory buffer has grown this
+/// session. Only the cheap bookkeeping (appending to `buffer`, bumping counters, snapshotting the
+/// buffer for a flush) stays on the main actor, since that is what other code reads synchronously for
+/// live-state display (`LiveState.puffinCaptureCount`/`puffinCaptureURL`, read by SettingsView et al).
 @MainActor
 final class PuffinFrameRecorder {
     /// UserDefaults flag, mirrored by the Settings toggle (`@AppStorage`). Separate from the puffin
@@ -23,12 +29,23 @@ final class PuffinFrameRecorder {
     /// capture toggle a 5/MG user left on reached 19 GB. After each flush, oldest files are evicted
     /// (by filename, which is timestamp-sorted) until the total is back under the cap. Never deletes
     /// the file the current session is still writing.
-    private static let directorySoftCapBytes = 50 * 1024 * 1024
+    private nonisolated static let directorySoftCapBytes = 50 * 1024 * 1024
 
     private weak var state: LiveState?
     private let buffer = PuffinCapture()
     private var sinceFlush = 0
     private var fileURL: URL?
+
+    /// Performs the encode + write + eviction off the main actor. An `actor`, so overlapping flushes
+    /// serialize on it rather than racing two writes at the same file.
+    private let fileWriter = PuffinFileWriter()
+
+    /// Non-nil while a flush's background write is in-flight. Lets `capture()` skip redundant
+    /// auto-flush triggers while one is already running, and lets a concurrent explicit `flush()` call
+    /// (export/reveal/disconnect) await the SAME write instead of racing a second one for the same
+    /// file — which could otherwise let an older, smaller snapshot's write land after a newer one's
+    /// and regress the on-disk capture.
+    private var flushTask: Task<Void, Never>?
 
     init(state: LiveState) {
         self.state = state
@@ -36,8 +53,9 @@ final class PuffinFrameRecorder {
 
     private var isEnabled: Bool { UserDefaults.standard.bool(forKey: Self.enabledKey) }
 
-    /// `<AppSupport>/OpenWhoop/puffin-captures/`, created on demand.
-    private static func captureDirectory() throws -> URL {
+    /// `<AppSupport>/OpenWhoop/puffin-captures/`, created on demand. `nonisolated` so the background
+    /// `fileWriter` actor can call it (via `evictOldCaptures`) without hopping back to the main actor.
+    private nonisolated static func captureDirectory() throws -> URL {
         let fm = FileManager.default
         let dir = try fm.url(for: .applicationSupportDirectory, in: .userDomainMask,
                              appropriateFor: nil, create: true)
@@ -48,6 +66,9 @@ final class PuffinFrameRecorder {
     }
 
     /// Record one puffin frame (off `fd4b0003/0004/0005/0007`). No-op unless capture is enabled.
+    /// Synchronous — this is called directly from a CoreBluetooth delegate callback on the main queue
+    /// and must never block on file I/O, so a due auto-flush is only ever *triggered* here, never
+    /// awaited (see `flush()`).
     func capture(frame: [UInt8], char: CBUUID) {
         guard isEnabled else { return }
         let tsMs = Int(Date().timeIntervalSince1970 * 1000)
@@ -55,30 +76,53 @@ final class PuffinFrameRecorder {
                       tsMs: tsMs, hr: state?.heartRate)
         sinceFlush += 1
         state?.puffinCaptureCount = buffer.count
-        if sinceFlush >= Self.flushEvery { flush() }
+        if sinceFlush >= Self.flushEvery && flushTask == nil {
+            flushTask = Task { [weak self] in
+                guard let self else { return }
+                await self.runFlush()
+            }
+        }
     }
 
-    /// Write the full capture to disk (best-effort, atomic). Called periodically and on disconnect.
-    func flush() {
-        guard buffer.count > 0 else { return }
-        do {
-            let url = try sessionFileURL()
-            let data = try buffer.encodedJSON()
-            try data.write(to: url, options: .atomic)
+    /// Flush the buffered frames to disk (best-effort, atomic). Awaited by explicit callers (export,
+    /// reveal, disconnect-before-reconnect) so the on-disk file is guaranteed current by the time this
+    /// returns — joins an in-flight auto-flush instead of starting a second, racing write when one is
+    /// already running.
+    func flush() async {
+        if let inFlight = flushTask {
+            await inFlight.value
+            return
+        }
+        let task = Task { [weak self] in
+            guard let self else { return }
+            await self.runFlush()
+        }
+        flushTask = task
+        await task.value
+    }
+
+    /// The actual flush body: snapshot the buffer on the main actor (an O(1) copy-on-write of a
+    /// value-type array, not a re-encode), then hand the JSON encode + atomic write + eviction to the
+    /// `fileWriter` background actor. Only the state hand-off crosses the actor boundary.
+    private func runFlush() async {
+        defer { flushTask = nil }
+        guard buffer.count > 0, let url = try? sessionFileURL() else { return }
+        let snapshot = buffer.records
+        let ok = await fileWriter.write(records: snapshot, to: url)
+        if ok {
             sinceFlush = 0
             state?.puffinCaptureURL = url
-            // Bound on-disk growth (#27): evict oldest captures beyond the soft cap, never the
-            // file this session is still writing.
-            Self.evictOldCaptures(keeping: url)
-        } catch {
-            // Best-effort: a failed flush just means the next one rewrites the whole file.
         }
+        // A failed write is best-effort, exactly as before: `sinceFlush` and `puffinCaptureURL` are
+        // left alone, so the next flush just rewrites the whole file again.
     }
 
     /// Enforce the directory soft cap by deleting the oldest capture files (best-effort). Filenames are
     /// `puffin-yyyyMMdd-HHmmss.json`, so lexicographic order is chronological — delete from the front
     /// until the total is back under the cap. `keep` (the active session file) is never deleted.
-    private static func evictOldCaptures(keeping keep: URL) {
+    /// `fileprivate nonisolated` so the background `fileWriter` actor can call it directly after a
+    /// write, without hopping back to the main actor.
+    fileprivate nonisolated static func evictOldCaptures(keeping keep: URL) {
         let fm = FileManager.default
         guard let dir = try? captureDirectory() else { return }
         guard let entries = try? fm.contentsOfDirectory(
@@ -117,4 +161,35 @@ final class PuffinFrameRecorder {
         f.dateFormat = "yyyyMMdd-HHmmss"
         return f
     }()
+}
+
+/// Off-main-actor home for the expensive part of a puffin flush: encoding the (growing) in-memory
+/// capture to JSON and atomically rewriting the session file, then evicting old captures. `actor`
+/// isolation means two overlapping calls (an auto-flush racing an explicit flush) are serialized
+/// rather than both touching the same file at once — `PuffinFrameRecorder.flush()` additionally
+/// coalesces callers onto a single in-flight `Task` so a second write for the same generation of data
+/// is never even started, but the actor boundary is kept as a second, independent safety net.
+///
+/// This still re-encodes+rewrites the WHOLE capture on every flush (the JSON-array-of-objects format
+/// that downstream tooling — the export/share/bundle paths and the protocol-mapping fixture format —
+/// already expects is kept as-is here; switching to an append-only JSONL format was judged a bigger
+/// format-migration risk than the win of avoiding the O(n) re-encode, see #652). What moved is WHERE
+/// that encode+write runs, not how much work it does per flush.
+private actor PuffinFileWriter {
+    /// Encode `records` and atomically write them to `url`, then run the directory eviction. Returns
+    /// whether the write succeeded; best-effort exactly like the flush this replaces.
+    func write(records: [PuffinCaptureRecord], to url: URL) -> Bool {
+        do {
+            let enc = JSONEncoder()
+            enc.outputFormatting = [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]
+            let data = try enc.encode(records)
+            try data.write(to: url, options: .atomic)
+            // Bound on-disk growth (#27): evict oldest captures beyond the soft cap, never the file
+            // this session is still writing. Runs off the main actor too, alongside the write.
+            PuffinFrameRecorder.evictOldCaptures(keeping: url)
+            return true
+        } catch {
+            return false
+        }
+    }
 }

--- a/Strand/Screens/SettingsView.swift
+++ b/Strand/Screens/SettingsView.swift
@@ -1682,29 +1682,31 @@ struct SettingsView: View {
     /// Flush the in-flight capture, then copy it to a user-chosen location (save panel on macOS) or
     /// hand it to the system share sheet (iOS).
     private func exportPuffinCaptures() {
-        model.ble.flushPuffinCaptures()
-        guard let src = live.puffinCaptureURL else { return }
-        // Suggest a friendly, timestamped name so a reporter saving several captures gets sortable,
-        // non-colliding files (#510) — e.g. noop-raw-capture-260617-1042.json.
-        let suggested = FileExport.timestampedName("noop-raw-capture", ext: "json")
-        #if os(macOS)
-        let panel = NSSavePanel()
-        panel.allowedContentTypes = [.json]
-        panel.nameFieldStringValue = suggested
-        panel.canCreateDirectories = true
-        guard panel.runModal() == .OK, let dest = panel.url else { return }
-        let fm = FileManager.default
-        do {
-            if fm.fileExists(atPath: dest.path) { try fm.removeItem(at: dest) }
-            try fm.copyItem(at: src, to: dest)
-        } catch {
-            backupAlertTitle = String(localized: "Export failed")
-            backupAlertMessage = error.localizedDescription
-            showBackupAlert = true
+        Task { @MainActor in
+            await model.ble.flushPuffinCaptures()
+            guard let src = live.puffinCaptureURL else { return }
+            // Suggest a friendly, timestamped name so a reporter saving several captures gets sortable,
+            // non-colliding files (#510) — e.g. noop-raw-capture-260617-1042.json.
+            let suggested = FileExport.timestampedName("noop-raw-capture", ext: "json")
+            #if os(macOS)
+            let panel = NSSavePanel()
+            panel.allowedContentTypes = [.json]
+            panel.nameFieldStringValue = suggested
+            panel.canCreateDirectories = true
+            guard panel.runModal() == .OK, let dest = panel.url else { return }
+            let fm = FileManager.default
+            do {
+                if fm.fileExists(atPath: dest.path) { try fm.removeItem(at: dest) }
+                try fm.copyItem(at: src, to: dest)
+            } catch {
+                backupAlertTitle = String(localized: "Export failed")
+                backupAlertMessage = error.localizedDescription
+                showBackupAlert = true
+            }
+            #else
+            FileExport.exportFile(at: src, suggestedName: suggested)
+            #endif
         }
-        #else
-        FileExport.exportFile(at: src, suggestedName: suggested)
-        #endif
     }
 
     private func markOpticalPhase(_ phase: PuffinOpticalExperimentPhase) {
@@ -1734,25 +1736,29 @@ struct SettingsView: View {
     /// export utilities — `FileExport.exportPair` shares both files in one iOS share sheet, and saves
     /// each via its own NSSavePanel on macOS (no new file plumbing).
     private func exportRawAndLog() {
-        model.ble.flushPuffinCaptures()
-        guard let capture = live.puffinCaptureURL else {
-            backupAlertTitle = String(localized: "Nothing to export")
-            backupAlertMessage = String(localized: "No raw capture has been recorded yet this session.")
-            showBackupAlert = true
-            return
+        Task { @MainActor in
+            await model.ble.flushPuffinCaptures()
+            guard let capture = live.puffinCaptureURL else {
+                backupAlertTitle = String(localized: "Nothing to export")
+                backupAlertMessage = String(localized: "No raw capture has been recorded yet this session.")
+                showBackupAlert = true
+                return
+            }
+            let stamp = FileExport.timestamp()
+            FileExport.exportPair(
+                file: capture, fileSuggestedName: "noop-raw-capture-\(stamp).json",
+                text: live.exportableLogText(), textSuggestedName: "noop-strap-log-\(stamp).txt")
         }
-        let stamp = FileExport.timestamp()
-        FileExport.exportPair(
-            file: capture, fileSuggestedName: "noop-raw-capture-\(stamp).json",
-            text: live.exportableLogText(), textSuggestedName: "noop-strap-log-\(stamp).txt")
     }
 
     #if os(macOS)
     /// Flush, then reveal the capture file in Finder so the user can grab it directly.
     private func revealPuffinCaptures() {
-        model.ble.flushPuffinCaptures()
-        guard let url = live.puffinCaptureURL else { return }
-        NSWorkspace.shared.activateFileViewerSelecting([url])
+        Task { @MainActor in
+            await model.ble.flushPuffinCaptures()
+            guard let url = live.puffinCaptureURL else { return }
+            NSWorkspace.shared.activateFileViewerSelecting([url])
+        }
     }
     #endif
 

--- a/Strand/Screens/TestCentreView.swift
+++ b/Strand/Screens/TestCentreView.swift
@@ -349,20 +349,22 @@ struct TestCentreView: View {
     }
 
     private func runScheduledExportNow() {
-        model.ble.flushPuffinCaptures()
-        let url = ScheduledDebugExport.runNow(captureURL: live.puffinCaptureURL)
-        if let url {
-            infoTitle = String(localized: "Strap log exported")
-            #if os(iOS)
-            infoMessage = String(localized: "Saved \(url.lastPathComponent) to NOOP's folder in the Files app.")
-            #else
-            infoMessage = String(localized: "Saved \(url.lastPathComponent) to your Documents folder.")
-            #endif
-        } else {
-            infoTitle = String(localized: "Export failed")
-            infoMessage = String(localized: "Couldn't write the strap log right now.")
+        Task { @MainActor in
+            await model.ble.flushPuffinCaptures()
+            let url = ScheduledDebugExport.runNow(captureURL: live.puffinCaptureURL)
+            if let url {
+                infoTitle = String(localized: "Strap log exported")
+                #if os(iOS)
+                infoMessage = String(localized: "Saved \(url.lastPathComponent) to NOOP's folder in the Files app.")
+                #else
+                infoMessage = String(localized: "Saved \(url.lastPathComponent) to your Documents folder.")
+                #endif
+            } else {
+                infoTitle = String(localized: "Export failed")
+                infoMessage = String(localized: "Couldn't write the strap log right now.")
+            }
+            showInfo = true
         }
-        showInfo = true
     }
 }
 


### PR DESCRIPTION
Fixes #652

## Summary

`PuffinFrameRecorder` is `@MainActor` and, every 25 frames, flushed by JSON-encoding the *entire* in-memory capture and atomically rewriting the whole file — all synchronously on the main actor. As a capture session grows, both the encode cost and the write cost grow with it, so the periodic auto-flush increasingly blocks the main thread / SwiftUI.

- The JSON encode + atomic file write + old-capture eviction (`evictOldCaptures`, the #27 directory-size cap) now run on a new background `actor` (`PuffinFileWriter`) instead of inline on `@MainActor`.
- Only the cheap bookkeeping stays on the main actor: appending a frame to the buffer, bumping `sinceFlush`/`state.puffinCaptureCount` (read live by `SettingsView`), and taking a snapshot of the buffer (`buffer.records`, an O(1) copy-on-write of a value-type array — not a re-encode) to hand off to the background actor.
- `flush()` is now `async`. The periodic auto-flush trigger inside `capture()` stays a synchronous, fire-and-forget call (`capture()` runs directly on a CoreBluetooth delegate callback and must never block), while explicit callers — export, reveal-in-Finder, and the disconnect-before-reconnect flush in `BLEManager` — now `await` it, so the file on disk is guaranteed current by the time they read `LiveState.puffinCaptureURL`.
- Concurrent flushes (an in-flight auto-flush racing an explicit export/disconnect flush) are coalesced onto a single `Task` so a smaller/older snapshot's write can never land after a newer one's and regress the on-disk capture — the actor boundary on `PuffinFileWriter` is a second, independent safety net against the same race.

**Format choice:** kept the existing JSON-array-of-objects file format rather than switching to append-only JSONL. The export/share/reveal paths (`SettingsView`, `TestCentreView`, `TestBundleAssembler`, `ScheduledDebugExport`) and the protocol-mapping fixture format (`PuffinCaptureRecord`'s doc comment: "directly usable as a parity fixture") all depend on the current shape. Moving to JSONL is the "real fix" the issue calls out for the O(n) re-encode cost itself, but it's a bigger format-migration risk than this PR's scope — this PR moves *where* the encode+write runs (off the main actor), not how much work it does per flush. Filed as a natural follow-up if the O(n) cost itself becomes the bottleneck.

Also added `Sendable` conformance to `PuffinCaptureRecord` (pure `WhoopProtocol` package) since a snapshot of it now crosses the new actor boundary.

## Verification

- `cd Packages/WhoopProtocol && swift build && swift test --filter PuffinCaptureTests` — passes (6/6), unaffected by the `Sendable` addition.
- `xcodegen generate && xcodebuild -project Strand.xcodeproj -scheme Strand -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO build` — **BUILD SUCCEEDED**, zero errors, zero warnings in any file this PR touches (a few pre-existing, unrelated actor-isolation warnings elsewhere in `Strand/BLE` are unchanged from `main`).
- No new user-facing strings were introduced (existing `String(localized:)` calls were only re-indented inside new `Task { @MainActor in ... }` wrappers), so `Tools/i18n_audit.py` was not run.

**BLE-adjacent (live capture recorder) — compile success proves nothing about actual capture behavior under active BLE connection; this needs validation on a real strap capturing live data before merge, confirming no dropped/corrupted frames and no live-state display lag.** I did not have hardware available to test this myself. Specifically worth checking on-strap:
- Toggle "Record puffin frames" on a connected WHOOP 5.0/MG and confirm the frame counter (`live.puffinCaptureCount`) keeps updating live and the "Export frames…" / "Export raw + log" / "Reveal in Finder" buttons produce a complete, valid JSON file (not truncated/stale) immediately after tapping.
- Confirm no jank/dropped frames during a long capture session (the actual motivation for this issue) compared to before.
- Confirm a disconnect/reconnect cycle mid-capture still ends up with a complete file (the fire-and-forget flush at disconnect, `BLEManager.swift` around the `didDisconnectPeripheral` delegate).

## Scope

Only touches `PuffinFrameRecorder`'s I/O path and its explicit-flush call sites. No BLE wire-protocol code, no frame parsing/decoding, no destructive/write commands to the strap — this file only persists already-decoded frames to disk.
