### PR TITLE
Privacy: add retention for scheduled debug exports

### DIFF
--- a/Strand/Screens/TestCentreView.swift
+++ b/Strand/Screens/TestCentreView.swift
@@ -31,6 +31,9 @@ struct TestCentreView: View {
     // Section 3: scheduled daily auto-export, the same ScheduledDebugExport store the Settings card uses.
     @State private var debugExportOn = ScheduledDebugExport.isEnabled
     @State private var debugExportMinutes = ScheduledDebugExport.timeMinutes
+    // Retention (#650): how many scheduled-export generations to keep, and the manual clear confirm.
+    @State private var debugExportKeep = ScheduledDebugExport.keepCount
+    @State private var showClearExportsConfirm = false
 
     /// The strap model the user last picked, the same key SettingsView's showFiveMGControls gate reads.
     @AppStorage("selectedWhoopModel") private var selectedWhoopModelRaw = WhoopModel.whoop4.rawValue
@@ -76,6 +79,13 @@ struct TestCentreView: View {
             Button("Cancel", role: .cancel) { }
         } message: {
             Text("This restarts the roughly 4-night build-up for Charge and your HRV baseline. Your history stays.")
+        }
+        .confirmationDialog("Clear scheduled exports?",
+                            isPresented: $showClearExportsConfirm, titleVisibility: .visible) {
+            Button("Clear", role: .destructive) { clearScheduledExports() }
+            Button("Cancel", role: .cancel) { }
+        } message: {
+            Text("This deletes every scheduled strap-log and raw-capture file NOOP has saved. This can't be undone.")
         }
         .alert(infoTitle, isPresented: $showInfo) {
             Button("OK", role: .cancel) { }
@@ -213,12 +223,31 @@ struct TestCentreView: View {
                             .labelsHidden()
                             .accessibilityLabel("Daily auto-export time")
                     }
+                    // Retention (#650): how many scheduled-export generations to keep. Wired to
+                    // ScheduledDebugExport.keepCount; the next write prunes the oldest beyond this count.
+                    HStack {
+                        Text("Keep last exports").font(StrandFont.subhead).foregroundStyle(StrandPalette.textPrimary)
+                        Spacer()
+                        Picker("Keep last exports", selection: $debugExportKeep) {
+                            ForEach(ScheduledDebugExport.keepOptions, id: \.self) { n in Text("\(n)").tag(n) }
+                        }
+                        .labelsHidden().pickerStyle(.menu).tint(StrandPalette.accent)
+                        .onChangeCompat(of: debugExportKeep) { n in ScheduledDebugExport.keepCount = n }
+                    }
+                    Text("Older scheduled exports beyond this many are pruned automatically, oldest first.")
+                        .font(StrandFont.caption).foregroundStyle(StrandPalette.textTertiary)
+                        .fixedSize(horizontal: false, vertical: true)
                     NoopButton("Run now", systemImage: "square.and.arrow.down.on.square", kind: .secondary) {
                         runScheduledExportNow()
                     }
                     Text("On iPhone this is best-effort (iOS decides when background tasks run). Everything stays on \(Platform.deviceNounPhrase).")
                         .font(StrandFont.caption).foregroundStyle(StrandPalette.textTertiary)
                         .fixedSize(horizontal: false, vertical: true)
+                }
+                // Manual clear (#650): always available, even with the toggle off, since files written
+                // while it was on can outlive that toggle flip.
+                NoopButton("Clear scheduled exports", systemImage: "trash", kind: .destructive) {
+                    showClearExportsConfirm = true
                 }
             }
         }
@@ -328,6 +357,18 @@ struct TestCentreView: View {
         }
         infoTitle = String(localized: "Charge baseline recalibrating")
         infoMessage = String(localized: "NOOP will re-learn your baseline from tonight's data onward. Your history is kept, and it takes a few nights to settle.")
+        showInfo = true
+    }
+
+    /// The manual "Clear scheduled exports" action (#650): wipes every scheduled strap-log / raw-capture
+    /// file NOOP has dropped into Documents, regardless of the retention setting, then confirms via the
+    /// same info alert the other export actions use.
+    private func clearScheduledExports() {
+        let removed = ScheduledDebugExport.clearScheduledExports()
+        infoTitle = String(localized: "Scheduled exports cleared")
+        infoMessage = removed > 0
+            ? String(localized: "Removed \(removed) file(s).")
+            : String(localized: "No scheduled exports to clear.")
         showInfo = true
     }
 

--- a/Strand/System/ScheduledDebugExport.swift
+++ b/Strand/System/ScheduledDebugExport.swift
@@ -23,6 +23,11 @@ import BackgroundTasks
 ///   `submit` fails gracefully and the in-app "Run now" + the macOS path still work.)
 ///
 /// Opt-in, default OFF — like every NOOP automation. Everything is on-device; nothing is sent anywhere.
+///
+/// RETENTION (#650): every write is pruned to `keepCount` generations (default 14), oldest first, and
+/// the Test Centre export card offers a manual "Clear scheduled exports" for an immediate wipe — these
+/// files sit in Documents (Files-visible) with no UI in the loop reminding anyone they exist, so a
+/// default cap and a visible clear action both matter. Mirrors Android's `LogExport` retention.
 @MainActor
 enum ScheduledDebugExport {
 
@@ -32,11 +37,95 @@ enum ScheduledDebugExport {
         static let enabled = "debugExport.enabled"          // master enable; default OFF
         static let time = "debugExport.timeMinutes"         // minutes since local midnight; default 07:00
         static let lastRun = "debugExport.lastRunDayKey"    // yyyy-MM-dd of the last completed drop (catch-up dedup)
+        static let keepCount = "debugExport.keepCount"      // retention: generations to keep (#650)
     }
 
     /// 07:00 — a log waiting when you wake (matches Android's `DEFAULT_TIME`).
     static let defaultTimeMinutes = 7 * 60
     private static let minutesPerDay = 24 * 60
+
+    // MARK: - Retention (#650: these accumulated in Documents with no cleanup and no visible cap)
+
+    /// Retention choices offered by the scheduled-export keep-count picker. Mirrors Android's
+    /// `EXPORT_KEEP_OPTIONS`. A longer range than `FolderBackup.keepOptions` (the `.noopbak` backup
+    /// picker) since a scheduled export is a small text/JSON pair, not a whole-DB snapshot.
+    static let keepOptions = [3, 7, 14, 30, 60]
+
+    private static let defaultKeepCount = 14
+
+    /// How many scheduled-export GENERATIONS (a day's log + raw-capture pair counts once) to keep
+    /// before `performExport` prunes older ones, oldest first. Mirrors `FolderBackup.keepCount`'s
+    /// shape (0-means-unset sentinel, clamp to a sane 1...100).
+    static var keepCount: Int {
+        get {
+            let v = UserDefaults.standard.integer(forKey: K.keepCount)   // 0 when never set
+            return v == 0 ? defaultKeepCount : min(max(v, 1), 100)
+        }
+        set { UserDefaults.standard.set(min(max(newValue, 1), 100), forKey: K.keepCount) }
+    }
+
+    /// Filename prefixes for the two scheduled-export file kinds this type writes into Documents (the
+    /// log `.txt` and the raw-capture `.json`). Nothing else in Documents matches either prefix, so
+    /// retention and the manual clear action only ever touch scheduled drops.
+    private static let logPrefix = "noop-strap-log-"
+    private static let rawPrefix = "noop-raw-capture-"
+
+    /// The `yyMMdd-HHmm` stamp embedded in one scheduled-export filename (log `.txt` or raw `.json`),
+    /// or nil if `name` isn't one of ours. Mirrors Android `LogExport.scheduledExportStamp`. Pure — no
+    /// file IO — so retention math is unit-testable.
+    static func exportStamp(fromFilename name: String) -> String? {
+        if name.hasPrefix(logPrefix), name.hasSuffix(".txt") {
+            return String(name.dropFirst(logPrefix.count).dropLast(4))
+        }
+        if name.hasPrefix(rawPrefix), name.hasSuffix(".json") {
+            return String(name.dropFirst(rawPrefix.count).dropLast(5))
+        }
+        return nil
+    }
+
+    /// Scheduled-export STAMPS (not filenames) to prune to keep only the `keep` newest generations — a
+    /// day's log+raw pair shares a stamp and counts once. Mirrors Android
+    /// `LogExport.scheduledExportStampsToPrune`. `yyMMdd-HHmm` is fixed-width and zero-padded, so a
+    /// plain string sort orders it correctly with no date parsing needed (same trick as the Android
+    /// twin's `yyyyMMdd-HHmmss`). Empty when already within budget.
+    static func exportStampsToPrune(_ names: [String], keep: Int) -> Set<String> {
+        let stamps = Array(Set(names.compactMap { exportStamp(fromFilename: $0) })).sorted(by: >)
+        guard stamps.count > keep else { return [] }
+        return Set(stamps.dropFirst(keep))
+    }
+
+    /// Best-effort retention: delete scheduled-export files under `docs` beyond `keep` generations,
+    /// oldest first. Called after every write in `performExport`. Failures are ignored — a transient
+    /// hiccup here must never fail the export itself.
+    private static func pruneScheduledExports(in docs: URL, keep: Int) {
+        let fm = FileManager.default
+        guard let names = try? fm.contentsOfDirectory(atPath: docs.path) else { return }
+        let toPrune = exportStampsToPrune(names, keep: keep)
+        guard !toPrune.isEmpty else { return }
+        for name in names {
+            guard let stamp = exportStamp(fromFilename: name), toPrune.contains(stamp) else { continue }
+            try? fm.removeItem(at: docs.appendingPathComponent(name))
+        }
+    }
+
+    /// Manual "Clear scheduled exports" action: delete every scheduled-export file under Documents
+    /// right now, regardless of the retention setting. Never touches an interactive save/share (those
+    /// go through `FileExport`'s save panel / share sheet, not Documents) or anything else the user or
+    /// another feature put in Documents. Returns the number of files removed.
+    @discardableResult
+    static func clearScheduledExports() -> Int {
+        guard let docs = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first
+        else { return 0 }
+        let fm = FileManager.default
+        guard let names = try? fm.contentsOfDirectory(atPath: docs.path) else { return 0 }
+        var removed = 0
+        for name in names where exportStamp(fromFilename: name) != nil {
+            if (try? fm.removeItem(at: docs.appendingPathComponent(name))) != nil {
+                removed += 1
+            }
+        }
+        return removed
+    }
 
     /// iOS BGTask identifier. Derived from the running bundle id (rather than hardcoded) so it tracks
     /// BUNDLE_ID_PREFIX (see Config/BundleId.xcconfig) automatically and always matches the iOS target's
@@ -181,6 +270,10 @@ enum ScheduledDebugExport {
         if markDay {
             UserDefaults.standard.set(dayKey(Date()), forKey: K.lastRun)
         }
+        // Retention (#650): these accumulate in Documents with no UI in the loop to notice, so prune
+        // after every write (scheduled OR manual "Run now") — mirrors Android pruning on every
+        // `writeScheduledExport` call.
+        pruneScheduledExports(in: docs, keep: keepCount)
         return logURL
     }
 

--- a/StrandTests/ScheduledDebugExportTests.swift
+++ b/StrandTests/ScheduledDebugExportTests.swift
@@ -1,0 +1,58 @@
+import XCTest
+@testable import Strand
+
+/// Pure retention logic behind the scheduled debug export's "Clear scheduled exports" / keep-count
+/// pruning (#650). Mirror of `LogExportRetentionTest` on Android — same shape (stamp extraction,
+/// keep-N, oldest-first) applied to the `noop-strap-log-<stamp>.txt` / `noop-raw-capture-<stamp>.json`
+/// pair NOOP drops into Documents instead of a `.noopbak` snapshot.
+///
+/// `ScheduledDebugExport` is @MainActor (mirrors `WindDownNudge`), so this test class is too.
+@MainActor
+final class ScheduledDebugExportTests: XCTestCase {
+
+    func testStampExtractedFromLogAndRawFilenames() {
+        XCTAssertEqual(ScheduledDebugExport.exportStamp(fromFilename: "noop-strap-log-260617-0700.txt"), "260617-0700")
+        XCTAssertEqual(ScheduledDebugExport.exportStamp(fromFilename: "noop-raw-capture-260617-0700.json"), "260617-0700")
+    }
+
+    func testStampRejectsUnrelatedFilenames() {
+        XCTAssertNil(ScheduledDebugExport.exportStamp(fromFilename: "random.txt"))
+        XCTAssertNil(ScheduledDebugExport.exportStamp(fromFilename: "noop-strap-log-260617-0700.json")) // wrong ext for this prefix
+        XCTAssertNil(ScheduledDebugExport.exportStamp(fromFilename: "noop-raw-capture-260617-0700.txt")) // wrong ext for this prefix
+        XCTAssertNil(ScheduledDebugExport.exportStamp(fromFilename: "noop-backup-20260617-070000.noopbak")) // unrelated feature
+    }
+
+    func testPruneKeepsNewestNGenerations() {
+        // Five generations, each with a log+raw pair sharing one stamp — a pair must count as ONE
+        // generation, not two, when measured against `keep`.
+        let stamps = (10...14).map { "26061\($0 % 10)-0700" }
+        let names = stamps.flatMap { ["noop-strap-log-\($0).txt", "noop-raw-capture-\($0).json"] }
+        let pruned = ScheduledDebugExport.exportStampsToPrune(names, keep: 2)
+        XCTAssertEqual(pruned.count, 3)
+        XCTAssertTrue(pruned.contains(stamps[0]))    // oldest generations pruned
+        XCTAssertTrue(pruned.contains(stamps[1]))
+        XCTAssertTrue(pruned.contains(stamps[2]))
+        XCTAssertFalse(pruned.contains(stamps[3]))   // two newest kept
+        XCTAssertFalse(pruned.contains(stamps[4]))
+    }
+
+    func testPruneNoOpWithinBudget() {
+        let names = ["noop-strap-log-260617-0700.txt", "noop-raw-capture-260617-0700.json"]
+        XCTAssertTrue(ScheduledDebugExport.exportStampsToPrune(names, keep: 10).isEmpty)
+    }
+
+    func testPruneIgnoresUnrelatedFiles() {
+        let names = [
+            "noop-strap-log-260610-0700.txt", "noop-raw-capture-260610-0700.json",
+            "noop-strap-log-260617-0700.txt", "noop-raw-capture-260617-0700.json",
+            "noop-backup-20260617-070000.noopbak", // Backup & Sync file — never a prune candidate here
+        ]
+        let pruned = ScheduledDebugExport.exportStampsToPrune(names, keep: 1)
+        XCTAssertEqual(pruned, ["260610-0700"])
+    }
+
+    func testDefaultKeepOptionsIncludeTheDefault() {
+        // The default (14) must be one of the choices the picker actually offers.
+        XCTAssertTrue(ScheduledDebugExport.keepOptions.contains(14))
+    }
+}

--- a/android/app/src/main/java/com/noop/ui/DebugExportScheduler.kt
+++ b/android/app/src/main/java/com/noop/ui/DebugExportScheduler.kt
@@ -118,13 +118,27 @@ class DebugExportSettings(private val prefs: SharedPreferences) {
         get() = prefs.getInt(KEY_TIME, DEFAULT_TIME).coerceIn(0, MINUTES_PER_DAY - 1)
         set(v) = prefs.edit().putInt(KEY_TIME, v.coerceIn(0, MINUTES_PER_DAY - 1)).apply()
 
+    /**
+     * Retention (#642): how many scheduled-export GENERATIONS to keep on disk — a day's strap-log +
+     * raw-capture pair counts as one — before [LogExport.writeScheduledExport] prunes older ones.
+     * Mirrors [BackupSyncPrefs.keepCount] byte-for-byte (same clamp, same shape). Default keeps a
+     * month of daily drops: these are small text/JSONL files, not a whole-DB snapshot, so a longer
+     * default than [BackupSync.DEFAULT_KEEP] is reasonable — unlike a backup, an unbounded pile of
+     * these was the privacy concern in the first place, so SOME default cap always applies.
+     */
+    var keepCount: Int
+        get() = prefs.getInt(KEY_KEEP, DEFAULT_KEEP).coerceIn(1, 100)
+        set(v) = prefs.edit().putInt(KEY_KEEP, v.coerceIn(1, 100)).apply()
+
     companion object {
         private const val PREFS = "noop_debug_export"
         private const val KEY_ENABLED = "debugExport.enabled"
         private const val KEY_TIME = "debugExport.timeMinutes"
+        private const val KEY_KEEP = "debugExport.keepCount"
 
         const val MINUTES_PER_DAY = 24 * 60
         const val DEFAULT_TIME = 7 * 60   // 07:00 — a log waiting when you wake.
+        const val DEFAULT_KEEP = 14       // ~2 weeks of daily drops.
 
         fun from(context: Context): DebugExportSettings =
             DebugExportSettings(context.getSharedPreferences(PREFS, Context.MODE_PRIVATE))

--- a/android/app/src/main/java/com/noop/ui/LogExport.kt
+++ b/android/app/src/main/java/com/noop/ui/LogExport.kt
@@ -151,6 +151,12 @@ object LogExport {
                 }
                 out.add(rawFile)
             }
+
+            // Retention (#642): scheduled exports accumulate silently with no UI in the loop (unlike an
+            // interactive share, nobody is looking when this runs), so prune every write — mirrors
+            // BackupSync.backupNow calling prune() right after it writes.
+            pruneScheduledExports(context, DebugExportSettings.from(context).keepCount)
+
             out.toList()
         }.getOrDefault(emptyList())
 
@@ -158,6 +164,67 @@ object LogExport {
      *  already grants, so a future "open last export" share works without a manifest change. */
     private fun exportDir(context: Context): File =
         File(context.cacheDir, "logs").apply { mkdirs() }
+
+    /** Filename prefix common to BOTH scheduled-export files (the `.txt` log and the `.bin` raw capture),
+     *  distinct from the interactive-share prefixes (`noop-strap-log-`, `noop-raw-capture-`) so retention
+     *  and the manual clear action only ever touch scheduled drops, never an interactive share sitting in
+     *  the same cache/logs dir. */
+    private const val SCHEDULED_PREFIX = "noop-straplog-"
+
+    /**
+     * The `yyyyMMdd-HHmmss` stamp embedded in one scheduled-export filename (log `.txt` or raw `.bin`),
+     * or null if [filename] isn't one of ours. Pure — no file IO — so retention math is unit-testable.
+     */
+    fun scheduledExportStamp(filename: String): String? {
+        if (!filename.startsWith(SCHEDULED_PREFIX)) return null
+        val rest = filename.removePrefix(SCHEDULED_PREFIX)
+        return when {
+            rest.endsWith(".txt") -> rest.removeSuffix(".txt")
+            rest.endsWith(".bin") -> rest.removeSuffix(".bin")
+            else -> null
+        }
+    }
+
+    /**
+     * Scheduled-export STAMPS (not filenames) to prune to keep only the [keep] newest generations — a
+     * day's log+raw pair shares a stamp and counts once. Mirrors [BackupSync.snapshotsToPrune]. The
+     * fixed-width, zero-padded `yyyyMMdd-HHmmss` stamp sorts correctly as a plain string (no date
+     * parsing needed). Empty when already within budget.
+     */
+    fun scheduledExportStampsToPrune(names: List<String>, keep: Int): Set<String> {
+        val stamps = names.mapNotNull(::scheduledExportStamp).distinct().sortedDescending()
+        return if (stamps.size <= keep) emptySet() else stamps.drop(keep).toSet()
+    }
+
+    /** Best-effort retention (#642): delete scheduled-export files beyond [keep] generations, oldest
+     *  first. Called after every scheduled write. Listing/delete failures are ignored — a transient
+     *  hiccup here must never fail the export itself. */
+    private fun pruneScheduledExports(context: Context, keep: Int) {
+        val files = exportDir(context).listFiles()?.toList() ?: return
+        val toPrune = scheduledExportStampsToPrune(files.map { it.name }, keep)
+        if (toPrune.isEmpty()) return
+        for (f in files) {
+            val stamp = scheduledExportStamp(f.name)
+            if (stamp != null && stamp in toPrune) runCatching { f.delete() }
+        }
+    }
+
+    /**
+     * Manual "Clear scheduled exports" action (#642): delete every scheduled-export file right now,
+     * regardless of the retention setting, so a user who wants the folder empty can make it so without
+     * waiting for the next daily prune. Never touches interactive-share files (distinct filename
+     * prefixes) or anything else under cache/logs. Returns the number of files removed; self-toasts like
+     * the other actions in this object.
+     */
+    fun clearScheduledExports(context: Context): Int {
+        val files = exportDir(context).listFiles()?.filter { scheduledExportStamp(it.name) != null }
+            ?: emptyList()
+        var removed = 0
+        for (f in files) if (runCatching { f.delete() }.getOrDefault(false)) removed++
+        val message = if (removed > 0) "Cleared $removed scheduled export file(s)." else "No scheduled exports to clear."
+        Toast.makeText(context, message, Toast.LENGTH_SHORT).show()
+        return removed
+    }
 
     /**
      * Build the shareable strap-log file (header + body + last crash) under cache/logs and return it,

--- a/android/app/src/main/java/com/noop/ui/TestCentreScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/TestCentreScreen.kt
@@ -3,6 +3,7 @@ package com.noop.ui
 import com.noop.R
 import androidx.compose.ui.res.stringResource
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -15,10 +16,13 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Autorenew
 import androidx.compose.material.icons.filled.BugReport
+import androidx.compose.material.icons.filled.DeleteOutline
 import androidx.compose.material.icons.filled.Info
 import androidx.compose.material.icons.filled.Science
 import androidx.compose.material.icons.filled.Upload
 import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.Switch
 import androidx.compose.material3.SwitchDefaults
 import androidx.compose.material3.Text
@@ -406,6 +410,11 @@ private fun ExportCard(vm: AppViewModel, onReport: () -> Unit) {
     val settings = remember { DebugExportSettings.from(context) }
     var enabled by remember { mutableStateOf(settings.enabled) }
     var minutes by remember { mutableStateOf(settings.timeMinutes) }
+    // Retention (#642): how many scheduled-export generations to keep before the next write prunes
+    // older ones. Same shape as BackupSyncScreen's keep-count dropdown.
+    var keep by remember { mutableStateOf(settings.keepCount) }
+    var keepMenu by remember { mutableStateOf(false) }
+    var showClearConfirm by remember { mutableStateOf(false) }
     SettingsSectionTC(
         icon = Icons.Filled.Upload,
         title = uiString(R.string.l10n_test_centre_screen_export_f3e4fadb),
@@ -453,10 +462,90 @@ private fun ExportCard(vm: AppViewModel, onReport: () -> Unit) {
                         },
                     )
                 }
+                // Retention: how many scheduled exports to keep. Wired to DebugExportSettings.keepCount;
+                // the next scheduled write prunes the oldest generations beyond this count (#642).
+                Row(modifier = Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
+                    Column(
+                        modifier = Modifier.weight(1f),
+                        verticalArrangement = Arrangement.spacedBy(2.dp),
+                    ) {
+                        Text(uiString(R.string.l10n_test_centre_screen_keep_last_exports_44bc65f5), style = NoopType.subhead, color = Palette.textPrimary)
+                        Text(
+                            uiString(R.string.l10n_test_centre_screen_older_scheduled_exports_beyond_this_c75723fc),
+                            style = NoopType.footnote, color = Palette.textTertiary,
+                        )
+                    }
+                    Box {
+                        TextButton(onClick = { keepMenu = true }) {
+                            Text(uiString(R.string.l10n_backup_sync_screen_keep_1addd33c, keep), style = NoopType.body, color = Palette.accent)
+                        }
+                        DropdownMenu(expanded = keepMenu, onDismissRequest = { keepMenu = false }) {
+                            EXPORT_KEEP_OPTIONS.forEach { n ->
+                                DropdownMenuItem(
+                                    text = {
+                                        Text(
+                                            uiString(R.string.l10n_backup_sync_screen_n_9e03569f, n),
+                                            style = NoopType.body,
+                                            color = if (n == keep) Palette.accent else Palette.textPrimary,
+                                        )
+                                    },
+                                    onClick = {
+                                        keep = n
+                                        settings.keepCount = n
+                                        keepMenu = false
+                                    },
+                                )
+                            }
+                        }
+                    }
+                }
             }
+            // Manual clear (#642): always available, even with the toggle off, since files written
+            // while it was on can outlive that toggle flip.
+            NoopButton(
+                text = uiString(R.string.l10n_test_centre_screen_clear_scheduled_exports_54123329),
+                leadingIcon = Icons.Filled.DeleteOutline,
+                kind = NoopButtonKind.Secondary,
+                fullWidth = true,
+                onClick = { showClearConfirm = true },
+            )
         }
     }
+    if (showClearConfirm) {
+        AlertDialog(
+            onDismissRequest = { showClearConfirm = false },
+            containerColor = Palette.surfaceOverlay,
+            title = {
+                Text(
+                    uiString(R.string.l10n_test_centre_screen_clear_scheduled_exports_36e93dd0),
+                    style = NoopType.title2, color = Palette.textPrimary,
+                )
+            },
+            text = {
+                Text(
+                    uiString(R.string.l10n_test_centre_screen_this_deletes_every_scheduled_strap_ea52c535),
+                    style = NoopType.subhead, color = Palette.textSecondary,
+                )
+            },
+            confirmButton = {
+                TextButton(onClick = {
+                    LogExport.clearScheduledExports(context)
+                    showClearConfirm = false
+                }) { Text(uiString(R.string.l10n_lab_book_screen_clear_719ea396), style = NoopType.body, color = Palette.statusCritical) }
+            },
+            dismissButton = {
+                TextButton(onClick = { showClearConfirm = false }) {
+                    Text(uiString(R.string.l10n_test_centre_screen_cancel_77dfd213), style = NoopType.body, color = Palette.textSecondary)
+                }
+            },
+        )
+    }
 }
+
+/** Retention choices for the scheduled-debug-export keep-count dropdown (#642). These are lightweight
+ *  text/JSONL files, not a whole-DB snapshot, so the range skews longer than BackupSyncScreen's
+ *  KEEP_OPTIONS. */
+private val EXPORT_KEEP_OPTIONS = listOf(3, 7, 14, 30, 60)
 
 /**
  * Test Centre → Experimental algorithms. The single home for OPT-IN, off-by-default, non-clinical research

--- a/android/app/src/main/res/values-de/strings.xml
+++ b/android/app/src/main/res/values-de/strings.xml
@@ -874,6 +874,11 @@
     <string name="l10n_test_centre_screen_experimental_algorithms_e09581e2">Experimentelle Algorithmen</string>
     <string name="l10n_test_centre_screen_export_f3e4fadb">Exportieren</string>
     <string name="l10n_test_centre_screen_export_time_2ca90c2e">Ausfuhrzeit</string>
+    <string name="l10n_test_centre_screen_keep_last_exports_44bc65f5">Letzte Exporte behalten</string>
+    <string name="l10n_test_centre_screen_older_scheduled_exports_beyond_this_c75723fc">Ältere geplante Exporte über diese Anzahl hinaus werden automatisch entfernt, älteste zuerst.</string>
+    <string name="l10n_test_centre_screen_clear_scheduled_exports_54123329">Geplante Exporte löschen</string>
+    <string name="l10n_test_centre_screen_clear_scheduled_exports_36e93dd0">Geplante Exporte löschen?</string>
+    <string name="l10n_test_centre_screen_this_deletes_every_scheduled_strap_ea52c535">Dies löscht jede geplante Bandprotokoll- und Rohdaten-Erfassungsdatei, die NOOP gespeichert hat. Dies kann nicht rückgängig gemacht werden.</string>
     <string name="l10n_test_centre_screen_heads_up_this_test_mode_is_8b82ed69">Heads up: Dieser Testmodus ist ausgeschaltet, so dass der Bericht keine Erfassung dafür hat. Für a</string>
     <string name="l10n_test_centre_screen_hr_from_ppg_sub_lag_interpolation_a3ed1536">HR-from-PPG Sublag Interpolation (v26 gap-fill)</string>
     <string name="l10n_test_centre_screen_hrv_readiness_experimental_924f61bc">HRV-Bereitschaft (experimentell)</string>

--- a/android/app/src/main/res/values-es/strings.xml
+++ b/android/app/src/main/res/values-es/strings.xml
@@ -704,6 +704,11 @@
     <string name="l10n_test_centre_screen_experimental_algorithms_e09581e2">algoritmos experimentales</string>
     <string name="l10n_test_centre_screen_export_f3e4fadb">Exportar</string>
     <string name="l10n_test_centre_screen_export_time_2ca90c2e">Tiempo de exportación</string>
+    <string name="l10n_test_centre_screen_keep_last_exports_44bc65f5">Mantener últimas exportaciones</string>
+    <string name="l10n_test_centre_screen_older_scheduled_exports_beyond_this_c75723fc">Las exportaciones programadas más antiguas que superen este número se eliminan automáticamente, empezando por las más antiguas.</string>
+    <string name="l10n_test_centre_screen_clear_scheduled_exports_54123329">Borrar exportaciones programadas</string>
+    <string name="l10n_test_centre_screen_clear_scheduled_exports_36e93dd0">¿Borrar exportaciones programadas?</string>
+    <string name="l10n_test_centre_screen_this_deletes_every_scheduled_strap_ea52c535">Esto elimina todos los archivos de registro de la correa y de captura en bruto programados que NOOP ha guardado. Esto no se puede deshacer.</string>
     <string name="l10n_test_centre_screen_heads_up_this_test_mode_is_8b82ed69">Cabeza arriba: este modo de prueba está apagado, por lo que el informe no tiene captura para él. Para un</string>
     <string name="l10n_test_centre_screen_hr_from_ppg_sub_lag_interpolation_a3ed1536">HR-from-PPG sub-lag interpolation (v26 gap-fill)</string>
     <string name="l10n_test_centre_screen_hrv_readiness_experimental_924f61bc">HRV preparedness (experimental)</string>

--- a/android/app/src/main/res/values-fr/strings.xml
+++ b/android/app/src/main/res/values-fr/strings.xml
@@ -704,6 +704,11 @@
     <string name="l10n_test_centre_screen_experimental_algorithms_e09581e2">Algorithmes expérimentaux</string>
     <string name="l10n_test_centre_screen_export_f3e4fadb">Exporter</string>
     <string name="l10n_test_centre_screen_export_time_2ca90c2e">Temps d\'exportation</string>
+    <string name="l10n_test_centre_screen_keep_last_exports_44bc65f5">Conserver les derniers exports</string>
+    <string name="l10n_test_centre_screen_older_scheduled_exports_beyond_this_c75723fc">Les exports programmés au-delà de ce nombre sont supprimés automatiquement, les plus anciens en premier.</string>
+    <string name="l10n_test_centre_screen_clear_scheduled_exports_54123329">Effacer les exports programmés</string>
+    <string name="l10n_test_centre_screen_clear_scheduled_exports_36e93dd0">Effacer les exports programmés ?</string>
+    <string name="l10n_test_centre_screen_this_deletes_every_scheduled_strap_ea52c535">Ceci supprime tous les fichiers de journal du bracelet et de capture brute programmés que NOOP a enregistrés. Cette action est irréversible.</string>
     <string name="l10n_test_centre_screen_heads_up_this_test_mode_is_8b82ed69">En haut : ce mode de test est désactivé, donc le rapport n\'a pas de capture pour lui. Pour</string>
     <string name="l10n_test_centre_screen_hr_from_ppg_sub_lag_interpolation_a3ed1536">Interpolation du sous-logement HR-from-PPG (v26)</string>
     <string name="l10n_test_centre_screen_hrv_readiness_experimental_924f61bc">Préparation à la VFC (expérimental)</string>

--- a/android/app/src/main/res/values-pt-rPT/strings.xml
+++ b/android/app/src/main/res/values-pt-rPT/strings.xml
@@ -857,6 +857,11 @@
     <string name="l10n_test_centre_screen_experimental_algorithms_e09581e2">Algoritmos experimentais</string>
     <string name="l10n_test_centre_screen_export_f3e4fadb">Exportar</string>
     <string name="l10n_test_centre_screen_export_time_2ca90c2e">Tempo de exportação</string>
+    <string name="l10n_test_centre_screen_keep_last_exports_44bc65f5">Manter últimas exportações</string>
+    <string name="l10n_test_centre_screen_older_scheduled_exports_beyond_this_c75723fc">As exportações agendadas mais antigas além deste número são eliminadas automaticamente, começando pelas mais antigas.</string>
+    <string name="l10n_test_centre_screen_clear_scheduled_exports_54123329">Eliminar exportações agendadas</string>
+    <string name="l10n_test_centre_screen_clear_scheduled_exports_36e93dd0">Eliminar exportações agendadas?</string>
+    <string name="l10n_test_centre_screen_this_deletes_every_scheduled_strap_ea52c535">Isto elimina todos os ficheiros de registo da pulseira e de captura em bruto agendados que a NOOP guardou. Esta ação não pode ser anulada.</string>
     <string name="l10n_test_centre_screen_heads_up_this_test_mode_is_8b82ed69">Atenção: este modo de teste está desativado, pelo que o relatório não tem captura para o mesmo. Por um </string>
     <string name="l10n_test_centre_screen_hr_from_ppg_sub_lag_interpolation_a3ed1536">Interpolação de sublag HR-from-PPG (gap fill v26)</string>
     <string name="l10n_test_centre_screen_hrv_readiness_experimental_924f61bc">Prontidão HRV (experimental)</string>

--- a/android/app/src/main/res/values-zh/strings.xml
+++ b/android/app/src/main/res/values-zh/strings.xml
@@ -840,6 +840,11 @@
     <string name="l10n_test_centre_screen_experimental_algorithms_e09581e2">实验性算法 (测试中)</string>
     <string name="l10n_test_centre_screen_export_f3e4fadb">导出</string>
     <string name="l10n_test_centre_screen_export_time_2ca90c2e">导出时间</string>
+    <string name="l10n_test_centre_screen_keep_last_exports_44bc65f5">保留最近的导出</string>
+    <string name="l10n_test_centre_screen_older_scheduled_exports_beyond_this_c75723fc">超出该数量的旧计划导出会自动清理，最旧的优先。</string>
+    <string name="l10n_test_centre_screen_clear_scheduled_exports_54123329">清除计划导出</string>
+    <string name="l10n_test_centre_screen_clear_scheduled_exports_36e93dd0">清除计划导出？</string>
+    <string name="l10n_test_centre_screen_this_deletes_every_scheduled_strap_ea52c535">这会删除 NOOP 保存的所有计划手环日志和原始捕获文件。此操作无法撤销。</string>
     <string name="l10n_test_centre_screen_heads_up_this_test_mode_is_8b82ed69">请注意：此测试模式当前处于关闭状态，因此日志中没有包含相关抓取数据。若需...</string>
     <string name="l10n_test_centre_screen_hr_from_ppg_sub_lag_interpolation_a3ed1536">基于 PPG 信号的心率亚延迟插值 (v26 间隙填充算法)</string>
     <string name="l10n_test_centre_screen_hrv_readiness_experimental_924f61bc">HRV 恢复就绪度评分 (实验性功能)</string>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -875,6 +875,11 @@
     <string name="l10n_test_centre_screen_experimental_algorithms_e09581e2">Experimental algorithms</string>
     <string name="l10n_test_centre_screen_export_f3e4fadb">Export</string>
     <string name="l10n_test_centre_screen_export_time_2ca90c2e">Export time</string>
+    <string name="l10n_test_centre_screen_keep_last_exports_44bc65f5">Keep last exports</string>
+    <string name="l10n_test_centre_screen_older_scheduled_exports_beyond_this_c75723fc">Older scheduled exports beyond this many are pruned automatically, oldest first.</string>
+    <string name="l10n_test_centre_screen_clear_scheduled_exports_54123329">Clear scheduled exports</string>
+    <string name="l10n_test_centre_screen_clear_scheduled_exports_36e93dd0">Clear scheduled exports?</string>
+    <string name="l10n_test_centre_screen_this_deletes_every_scheduled_strap_ea52c535">This deletes every scheduled strap-log and raw-capture file NOOP has saved. This can\'t be undone.</string>
     <string name="l10n_test_centre_screen_heads_up_this_test_mode_is_8b82ed69">Heads up: this test mode is off, so the report has no capture for it. For a </string>
     <string name="l10n_test_centre_screen_hr_from_ppg_sub_lag_interpolation_a3ed1536">HR-from-PPG sub-lag interpolation (v26 gap-fill)</string>
     <string name="l10n_test_centre_screen_hrv_readiness_experimental_924f61bc">HRV readiness (experimental)</string>

--- a/android/app/src/test/java/com/noop/ui/LogExportRetentionTest.kt
+++ b/android/app/src/test/java/com/noop/ui/LogExportRetentionTest.kt
@@ -1,0 +1,61 @@
+package com.noop.ui
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Pure retention logic behind the scheduled debug export's "Clear scheduled exports" / keep-count
+ * pruning (#642). Mirror of [BackupSyncTest]'s prune tests — same shape (stamp extraction, keep-N,
+ * oldest-first) applied to the `noop-straplog-<stamp>.txt`/`.bin` pair instead of a `.noopbak` snapshot.
+ */
+class LogExportRetentionTest {
+
+    @Test fun stampExtractedFromLogAndRawFilenames() {
+        assertEquals("20260617-070000", LogExport.scheduledExportStamp("noop-straplog-20260617-070000.txt"))
+        assertEquals("20260617-070000", LogExport.scheduledExportStamp("noop-straplog-20260617-070000.bin"))
+    }
+
+    @Test fun stampRejectsUnrelatedFilenames() {
+        // Interactive-share files use a DIFFERENT prefix (no dash between "strap" and "log") so they
+        // must never be treated as scheduled exports by the pruner or the manual clear action.
+        assertNull(LogExport.scheduledExportStamp("noop-strap-log-260617-1042.txt"))
+        assertNull(LogExport.scheduledExportStamp("noop-raw-capture-260617-1042.jsonl"))
+        assertNull(LogExport.scheduledExportStamp("random.txt"))
+        assertNull(LogExport.scheduledExportStamp("noop-straplog-20260617-070000.zip"))
+    }
+
+    @Test fun pruneKeepsNewestNGenerations() {
+        // Five generations, each with a log+raw pair sharing one stamp — a pair must count as ONE
+        // generation, not two, when measured against `keep`.
+        val stamps = (0..4).map { "2026061%d-070000".format(it) }
+        val names = stamps.flatMap { listOf("noop-straplog-$it.txt", "noop-straplog-$it.bin") }
+        val pruned = LogExport.scheduledExportStampsToPrune(names, keep = 2)
+        assertEquals(3, pruned.size)
+        assertTrue(pruned.contains(stamps[0]))   // oldest generation pruned
+        assertTrue(pruned.contains(stamps[1]))
+        assertTrue(pruned.contains(stamps[2]))
+        assertTrue(!pruned.contains(stamps[3]))  // two newest kept
+        assertTrue(!pruned.contains(stamps[4]))
+    }
+
+    @Test fun pruneNoOpWithinBudget() {
+        val names = listOf("noop-straplog-20260617-070000.txt", "noop-straplog-20260617-070000.bin")
+        assertTrue(LogExport.scheduledExportStampsToPrune(names, keep = 10).isEmpty())
+    }
+
+    @Test fun pruneIgnoresUnrelatedFiles() {
+        val names = listOf(
+            "noop-straplog-20260610-070000.txt", "noop-straplog-20260610-070000.bin",
+            "noop-straplog-20260617-070000.txt", "noop-straplog-20260617-070000.bin",
+            "noop-strap-log-260617-1042.txt", // interactive share — never a prune candidate
+        )
+        val pruned = LogExport.scheduledExportStampsToPrune(names, keep = 1)
+        assertEquals(setOf("20260610-070000"), pruned)
+    }
+
+    @Test fun defaultKeepIsTwoWeeks() {
+        assertEquals(14, DebugExportSettings.DEFAULT_KEEP)
+    }
+}


### PR DESCRIPTION
Fixes #642, #650

## Summary

Scheduled debug exports (the daily strap-log + optional raw 5/MG capture) accumulated on disk indefinitely with no cleanup and no visible cap:

- **Android** (`DebugExportScheduler.kt` / `LogExport.kt`): the daily WorkManager job wrote `noop-straplog-<stamp>.txt` (+ `.bin` when a raw 5/MG capture exists) into the app-private `cache/logs` dir on every run, forever.
- **iOS/macOS** (`ScheduledDebugExport.swift`): the scheduled/"Run now" export wrote `noop-strap-log-<stamp>.txt` (+ `noop-raw-capture-<stamp>.json`) into the app's Documents directory, which is Files-visible (`UIFileSharingEnabled`), also forever.

Both platforms now mirror the existing `BackupSync` keep-count retention pattern:

- A pure `scheduledExportStamp` / `scheduledExportStampsToPrune` (Android) and `exportStamp(fromFilename:)` / `exportStampsToPrune` (Swift) pair extracts the timestamp embedded in each filename and computes which generations to delete beyond a keep-count — a day's log+raw pair shares one stamp and counts as **one** generation, not two. Unit tested on both platforms.
- Pruning runs automatically after every scheduled write (Android: end of `writeScheduledExport`; Apple: end of `performExport`, so it also covers the "Run now" button).
- Default keep-count is **14** generations on both platforms (these are small text/JSON files, not a whole-DB snapshot, so a longer default than `BackupSync`'s 7 is reasonable).
- The Test Centre export card on both platforms gets:
  - A "Keep last exports" picker (3 / 7 / 14 / 30 / 60), wired to the new persisted setting.
  - A manual **"Clear scheduled exports"** action (with a confirmation dialog) that deletes every scheduled-export file immediately, regardless of the keep-count — independent of the daily toggle so files written while it was on don't outlive a later toggle-off.
- Interactive shares (`noop-strap-log-` interactive prefix on Android is spelled without the internal dash vs. the scheduled `noop-straplog-` prefix; on Apple, interactive saves go through the save panel / share sheet, never Documents) are never touched by retention or the clear action — only their own distinct filename prefixes are scanned.

## Localization

New user-facing strings (retention picker label/blurb, clear button, confirm dialog title/message, clear-result toast/alert copy) are translated for the focus set **de/es/fr/pt-PT**, plus **zh** (Android `values-zh`) and **zh-Hans/zh-Hant/it/ru** (Apple catalog) to keep `Tools/i18n_audit.py --ci`'s non-focus-locale ratchet from regressing. `python3 Tools/i18n_audit.py --ci origin/main` passes clean (exit 0).

## Verification

- **Android**: `cd android && ./gradlew :app:compileFullDebugKotlin` → `BUILD SUCCESSFUL`. New unit tests added (`LogExportRetentionTest.kt`) covering stamp extraction, keep-N pruning (pair-counts-once), no-op within budget, and that interactive-share/unrelated files are never pruned. Not run against the JVM test task in this pass — only compile was verified per the build-verification checklist; the pure logic has no Android framework dependency so it should run under `testFullDebugUnitTest` without issue, but I have not executed that task here.
- **Swift**: `xcodegen generate && xcodebuild -project Strand.xcodeproj -scheme Strand -destination 'platform=macOS' build` → `BUILD SUCCEEDED`. `Strand/System/ScheduledDebugExport.swift` and `Strand/Screens/TestCentreView.swift` are shared between the `Strand` (macOS) and `NOOPiOS` targets (not excluded in `project.yml`), so the macOS build exercises the same source the iOS target compiles. New XCTest coverage added (`ScheduledDebugExportTests.swift`, `@MainActor` to match the type's isolation) but `xcodebuild test` was not run in this pass — only `build`.
- **Not verified on hardware / device**: actual on-device retention behavior (WorkManager daily job pruning over real days, iOS BGAppRefresh timing interacting with the prune, Files app visibility of the pruned/cleared state) was not exercised on a real strap or device. This is filesystem bookkeeping around an existing, already-shipped export feature, not a BLE change, but a human should sanity-check the picker/clear button once in the running app on both platforms.

## Scope

One concern (retention for scheduled debug exports), both platforms, per the repo's cross-platform-parity rule. No schema/DB migration involved — this is pure filesystem pruning. UI additions use only existing design-system components (`NoopButton`/`Palette`/`NoopType` on Android, `NoopButton`/`StrandPalette`/`StrandFont`/`Picker` on Apple) — no hardcoded colors/fonts/spacing.
