### PR TITLE
Move quick export zip/read work off the main thread and main actor

### DIFF
--- a/Strand/Screens/SettingsView.swift
+++ b/Strand/Screens/SettingsView.swift
@@ -1828,6 +1828,9 @@ struct SettingsView: View {
     /// both stamped with the same `yyMMdd-HHmm` minute so they're obviously a pair. Reuses the existing
     /// export utilities — `FileExport.exportPair` shares both files in one iOS share sheet, and saves
     /// each via its own NSSavePanel on macOS (no new file plumbing).
+    ///
+    /// #646/#651: `exportPair` is now async (its file read + zip build run off the main actor), so this
+    /// launches it in a `Task` — the button action itself stays synchronous from the caller's perspective.
     private func exportRawAndLog() {
         model.ble.flushPuffinCaptures()
         guard let capture = live.puffinCaptureURL else {
@@ -1837,9 +1840,11 @@ struct SettingsView: View {
             return
         }
         let stamp = FileExport.timestamp()
-        FileExport.exportPair(
-            file: capture, fileSuggestedName: "noop-raw-capture-\(stamp).json",
-            text: live.exportableLogText(), textSuggestedName: "noop-strap-log-\(stamp).txt")
+        Task {
+            await FileExport.exportPair(
+                file: capture, fileSuggestedName: "noop-raw-capture-\(stamp).json",
+                text: live.exportableLogText(), textSuggestedName: "noop-strap-log-\(stamp).txt")
+        }
     }
 
     #if os(macOS)

--- a/Strand/Screens/SettingsView.swift
+++ b/Strand/Screens/SettingsView.swift
@@ -156,6 +156,12 @@ struct SettingsView: View {
     @State private var rawCsvBusy = false
     @State private var lastRawCsvURL: URL?
 
+    /// #646/#651: the "Export raw + log" button's zip build now runs off the main actor, so a second tap
+    /// mid-export would fire a second `exportPair` — two staged zips, two save panels / stacked share
+    /// sheets (see the `present(activityItems:)` #455 comment). Same disable-while-busy guard as
+    /// `rawCsvBusy` above.
+    @State private var rawAndLogBusy = false
+
     /// Passive WHOOP 5/MG optical experiment: the picker writes local timestamp markers into the
     /// durable deep-buffer JSONL. It never calls a BLE write path.
     @State private var showOpticalPhasePicker = false
@@ -1656,9 +1662,20 @@ struct SettingsView: View {
                     // One-tap "matched pair" export (#510): hands a reporter BOTH the raw capture file
                     // and the strap log together (timestamped, same minute) so a protocol-mapping issue
                     // arrives with the frames AND the context that produced them.
-                    NoopButton("Export raw + log", systemImage: "square.and.arrow.up.on.square", kind: .secondary) {
+                    Button {
                         exportRawAndLog()
+                    } label: {
+                        if rawAndLogBusy {
+                            HStack(spacing: NoopMetrics.space1 + 2) {
+                                ProgressView().controlSize(.small)
+                                Text("Exporting…")
+                            }
+                        } else {
+                            Label("Export raw + log", systemImage: "square.and.arrow.up.on.square")
+                        }
                     }
+                    .buttonStyle(NoopButtonStyle(.secondary))
+                    .disabled(rawAndLogBusy)
                     Text("Saves the raw capture and the strap log together as a matched pair. Attach both to a protocol-mapping issue.")
                         .font(StrandFont.caption)
                         .foregroundStyle(StrandPalette.textTertiary)
@@ -1831,6 +1848,8 @@ struct SettingsView: View {
     ///
     /// #646/#651: `exportPair` is now async (its file read + zip build run off the main actor), so this
     /// launches it in a `Task` — the button action itself stays synchronous from the caller's perspective.
+    /// `rawAndLogBusy` disables the button for the duration: without it a second tap mid-export fires a
+    /// second `exportPair` (two staged zips, two save panels / stacked share sheets).
     private func exportRawAndLog() {
         model.ble.flushPuffinCaptures()
         guard let capture = live.puffinCaptureURL else {
@@ -1840,10 +1859,12 @@ struct SettingsView: View {
             return
         }
         let stamp = FileExport.timestamp()
+        rawAndLogBusy = true
         Task {
             await FileExport.exportPair(
                 file: capture, fileSuggestedName: "noop-raw-capture-\(stamp).json",
                 text: live.exportableLogText(), textSuggestedName: "noop-strap-log-\(stamp).txt")
+            rawAndLogBusy = false
         }
     }
 

--- a/Strand/System/FileExport.swift
+++ b/Strand/System/FileExport.swift
@@ -93,15 +93,21 @@ enum FileExport {
     /// panels back-to-back; the bundle is one panel). The caller's text is already redacted by its sink;
     /// the file's bytes are passed through unchanged here. If the source file is absent, falls back to a
     /// single-entry bundle (just the text) so the tap is never a dead end.
+    ///
+    /// #646/#651: reading `src` off disk is staged on a detached task, same as `exportBundle`'s zip build,
+    /// so a multi-MB raw capture doesn't block the main actor before the share sheet / save panel appears.
     @MainActor
     static func exportPair(file src: URL, fileSuggestedName: String,
-                           text: String, textSuggestedName: String) {
-        var entries: [BundleEntry] = [BundleEntry(name: textSuggestedName, data: Data(text.utf8))]
-        if FileManager.default.fileExists(atPath: src.path), let fileData = try? Data(contentsOf: src) {
-            entries.insert(BundleEntry(name: fileSuggestedName, data: fileData), at: 0)
-        }
+                           text: String, textSuggestedName: String) async {
         let zipName = timestampedName("noop-export", ext: "zip")
-        _ = exportBundle(entries: entries, suggestedName: zipName)
+        let entries = await Task.detached(priority: .userInitiated) { () -> [BundleEntry] in
+            var entries: [BundleEntry] = [BundleEntry(name: textSuggestedName, data: Data(text.utf8))]
+            if FileManager.default.fileExists(atPath: src.path), let fileData = try? Data(contentsOf: src) {
+                entries.insert(BundleEntry(name: fileSuggestedName, data: fileData), at: 0)
+            }
+            return entries
+        }.value
+        await exportBundle(entries: entries, suggestedName: zipName)
     }
 
     #if os(iOS)
@@ -175,11 +181,18 @@ enum FileExport {
     /// Zip `entries` into one `.zip` and hand it to the user (NSSavePanel on macOS, share sheet on iOS).
     /// EVERY entry must already be redacted by the caller (section 5.3); the 20 MB cap (section 5.4) is the
     /// assembler's job before it calls here. Returns the staged / saved zip URL, nil on cancel or failure.
+    ///
+    /// #646/#651: `zipData` (the actual DEFLATE + write) runs off the main actor via a detached task, same
+    /// pattern as `DataBackup.runExport`, so building a multi-entry bundle never beach-balls the UI. Only
+    /// the save panel / share sheet presentation below hops back to the main actor.
     @MainActor @discardableResult
     static func exportBundle(entries: [BundleEntry], suggestedName: String,
-                             completion: (() -> Void)? = nil) -> URL? {
+                             completion: (() -> Void)? = nil) async -> URL? {
         let base = suggestedName.hasSuffix(".zip") ? String(suggestedName.dropLast(4)) : suggestedName
-        guard let staged = zipData(entries: entries, baseName: base) else { completion?(); return nil }
+        let stagingTask = Task.detached(priority: .userInitiated) {
+            zipData(entries: entries, baseName: base)
+        }
+        guard let staged = await stagingTask.value else { completion?(); return nil }
         #if os(macOS)
         let panel = NSSavePanel()
         panel.nameFieldStringValue = suggestedName

--- a/Strand/System/TestCentreReport.swift
+++ b/Strand/System/TestCentreReport.swift
@@ -111,16 +111,20 @@ final class TestCentreReport: ObservableObject {
         let seed = TestModeRegistry.mode(p.profile).flatMap {
             TestReportLink.whatHappensSeed(questionnaire: $0.questionnaire, answers: TestCentre.answers(p.profile))
         }
-        TestReportFlow.run(
-            profile: p.profile, title: p.title,
-            version: version, platform: platform, osVersion: osVersion,
-            gate: p.gate,
-            entries: p.gate.entries,
-            showToast: { [weak self] msg in self?.lastStatus = msg },
-            // M3: prime the clipboard AND surface the report for a visible "Copy report.txt" button so the
-            // documented mobile fallback is reachable, not just silently on the pasteboard.
-            copyToPasteboard: { [weak self] text in PlatformPasteboard.copy(text); self?.copyableReport = text },
-            whatHappensSeed: seed)
+        // Launched (#646/#651): TestReportFlow.run is now async since it awaits FileExport.exportBundle's
+        // off-main zip build.
+        Task {
+            await TestReportFlow.run(
+                profile: p.profile, title: p.title,
+                version: version, platform: platform, osVersion: osVersion,
+                gate: p.gate,
+                entries: p.gate.entries,
+                showToast: { [weak self] msg in self?.lastStatus = msg },
+                // M3: prime the clipboard AND surface the report for a visible "Copy report.txt" button so
+                // the documented mobile fallback is reachable, not just silently on the pasteboard.
+                copyToPasteboard: { [weak self] text in PlatformPasteboard.copy(text); self?.copyableReport = text },
+                whatHappensSeed: seed)
+        }
         pending = nil
     }
 

--- a/Strand/System/TestReportFlow.swift
+++ b/Strand/System/TestReportFlow.swift
@@ -49,6 +49,9 @@ enum TestReportFlow {
     /// TestBundleAssembler.redactEntries + capEntries + meta.json). `showToast` and `copyToPasteboard`
     /// are injected so the call site supplies the platform presenters. Review-before-share is mandatory:
     /// nothing is shared, no URL opened and no toast shown until the gate is cleared (spec section 12).
+    ///
+    /// Async (#646/#651): `FileExport.exportBundle` now stages its zip off the main actor, so this awaits
+    /// it before continuing to the toast/pasteboard steps below (same ordering as before, just non-blocking).
     @MainActor
     static func run(profile: TestDomain, title: String,
                     version: String, platform: String, osVersion: String,
@@ -59,7 +62,7 @@ enum TestReportFlow {
                     // CAPTURE-A (#812): the questionnaire-derived one-liner seeding the form's what_happens
                     // box. nil leaves that required field for the user. The report.txt tail is read from
                     // `entries` below, so a report submitted without the .zip still carries the trace.
-                    whatHappensSeed: String? = nil) {
+                    whatHappensSeed: String? = nil) async {
         // Review-before-share is mandatory: do nothing until the user has confirmed.
         guard shouldProceed(gate: gate) else { return }
         let name = Plan.bundleName(profile: profile, platform: platform, version: version)
@@ -77,11 +80,11 @@ enum TestReportFlow {
         // is dismissed) keeps the SafariVC from racing the share sheet and lets the user attach the .zip
         // they just saved. macOS opens in the default browser via NSWorkspace (no hijack there).
         #if canImport(UIKit)
-        _ = FileExport.exportBundle(entries: entries, suggestedName: name, completion: {
+        _ = await FileExport.exportBundle(entries: entries, suggestedName: name, completion: {
             if let issueURL { presentInSafari(issueURL) }
         })
         #elseif canImport(AppKit)
-        _ = FileExport.exportBundle(entries: entries, suggestedName: name)
+        _ = await FileExport.exportBundle(entries: entries, suggestedName: name)
         if let issueURL { NSWorkspace.shared.open(issueURL) }
         #endif
         showToast(Plan.attachToast(savedName: name))

--- a/android/app/src/main/java/com/noop/testcentre/TestReportFlow.kt
+++ b/android/app/src/main/java/com/noop/testcentre/TestReportFlow.kt
@@ -41,8 +41,11 @@ object TestReportFlow {
 
     /** Share the already-redacted bundle, open the prefilled issue, toast, and prime the copy fallback.
      *  `entries` is the redacted, capped bundle the caller assembled. Review-before-share is mandatory:
-     *  nothing is shared until the gate is cleared (spec section 12). */
-    fun run(context: Context, profile: TestDomain, title: String,
+     *  nothing is shared until the gate is cleared (spec section 12).
+     *
+     *  Suspend (#646/#651): [LogExport.exportBundle] moved its zip build + write off the caller's
+     *  dispatcher, so this now awaits it rather than blocking Main on a multi-MB bundle. */
+    suspend fun run(context: Context, profile: TestDomain, title: String,
             version: String, platform: String, osVersion: String,
             gate: ReportReviewGate,
             entries: List<Pair<String, ByteArray>>) {

--- a/android/app/src/main/java/com/noop/ui/LogExport.kt
+++ b/android/app/src/main/java/com/noop/ui/LogExport.kt
@@ -7,6 +7,8 @@ import android.widget.Toast
 import androidx.core.content.FileProvider
 import com.noop.BuildConfig
 import com.noop.ble.PuffinExperiment
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import java.io.File
 
 /**
@@ -76,13 +78,19 @@ object LogExport {
      * Zip `entries` into one `.zip` under cache/logs (the FileProvider path) and fire the share chooser,
      * returning the staged file or null. Twin of Swift `FileExport.exportBundle`. EVERY entry must already
      * be redacted by the caller; the 20 MB cap is the assembler's job before this is called.
+     *
+     * The zip build + write (`zipEntries` + `writeBytes`) runs on [Dispatchers.IO] (#646/#651) so a
+     * multi-MB bundle doesn't stall the caller's dispatcher; only the chooser intent fires back on
+     * whatever dispatcher the caller resumed on (Main, for every UI call site today).
      */
-    fun exportBundle(context: Context, entries: List<Pair<String, ByteArray>>, suggestedName: String): File? =
+    suspend fun exportBundle(context: Context, entries: List<Pair<String, ByteArray>>, suggestedName: String): File? =
         runCatching {
-            val bytes = zipEntries(entries) ?: return null
-            val dir = File(context.cacheDir, "logs").apply { mkdirs() }
-            val file = File(dir, suggestedName)
-            file.writeBytes(bytes)
+            val file = withContext(Dispatchers.IO) {
+                zipEntries(entries)?.let { bytes ->
+                    val dir = File(context.cacheDir, "logs").apply { mkdirs() }
+                    File(dir, suggestedName).also { it.writeBytes(bytes) }
+                }
+            } ?: return null
             val send = Intent(Intent.ACTION_SEND).apply {
                 type = "application/zip"
                 putExtra(Intent.EXTRA_STREAM, fileUri(context, file))
@@ -284,7 +292,9 @@ object LogExport {
 
     suspend fun shareStrapLog(context: Context, logText: String) {
         runCatching {
-            val file = writeStrapLogFile(context, logText)
+            // writeStrapLogFile does blocking file IO (#646/#651) — keep it off whatever dispatcher the
+            // caller is on (Main, for every UI call site today).
+            val file = withContext(Dispatchers.IO) { writeStrapLogFile(context, logText) }
             val send = Intent(Intent.ACTION_SEND).apply {
                 type = "text/plain"
                 putExtra(Intent.EXTRA_STREAM, fileUri(context, file))
@@ -320,9 +330,11 @@ object LogExport {
      * covers cache/logs) and prepends a header with an informed-consent line: the file holds raw
      * biometric frames and the strap's own console text.
      */
-    fun shareWhoop5Capture(context: Context, whoop5Connected: Boolean) {
+    suspend fun shareWhoop5Capture(context: Context, whoop5Connected: Boolean) {
         runCatching {
-            val out = writeCaptureFile(context)
+            // writeCaptureFile does blocking file IO (#646/#651) — keep it off whatever dispatcher the
+            // caller is on (Main, for every UI call site today).
+            val out = withContext(Dispatchers.IO) { writeCaptureFile(context) }
             if (out == null) {
                 Toast.makeText(context, noCaptureMsg(context, whoop5Connected, sharingLog = false), Toast.LENGTH_LONG).show()
                 return
@@ -345,16 +357,23 @@ object LogExport {
      * not loose .txt files). If there's no capture yet, falls back to just the log so the tap isn't a dead
      * end. Reuses the same file-builders the single-share paths use; both entries are already redacted by
      * their writers.
+     *
+     * Building the files AND reading them back into memory (`readBytes`) is blocking file IO (#646/#651):
+     * it runs on [Dispatchers.IO], off the caller's dispatcher (Main, from the Settings/Test Centre share
+     * buttons), so a large raw capture doesn't stall the UI. Only the "no capture" toast and the
+     * [exportBundle] call (which does its own IO hop for the zip) run back on the caller's dispatcher.
      */
     suspend fun shareRawAndLog(context: Context, logText: String, whoop5Connected: Boolean) {
         runCatching {
-            val logFile = writeStrapLogFile(context, logText)
-            val capture = writeCaptureFile(context)
-            val entries = arrayListOf("report.txt" to logFile.readBytes())
-            if (capture == null) {
+            val (entries, hasCapture) = withContext(Dispatchers.IO) {
+                val logFile = writeStrapLogFile(context, logText)
+                val capture = writeCaptureFile(context)
+                val entries = arrayListOf("report.txt" to logFile.readBytes())
+                if (capture != null) entries.add(0, "raw-capture.jsonl" to capture.readBytes())
+                entries to (capture != null)
+            }
+            if (!hasCapture) {
                 Toast.makeText(context, noCaptureMsg(context, whoop5Connected, sharingLog = true), Toast.LENGTH_LONG).show()
-            } else {
-                entries.add(0, "raw-capture.jsonl" to capture.readBytes())
             }
             val name = "noop-export-${timestamp()}.zip"
             exportBundle(context, entries, name)

--- a/android/app/src/main/java/com/noop/ui/SettingsScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/SettingsScreen.kt
@@ -424,6 +424,14 @@ fun SettingsScreen(
 
     var backupBusy by remember { mutableStateOf(false) }
 
+    // #646/#651: LogExport's zip build + file read now run on Dispatchers.IO instead of blocking the
+    // caller, so these buttons no longer freeze the UI — but nothing else stopped a second tap mid-export
+    // either. A big raw capture is exactly when someone taps twice, firing two zips / two chooser
+    // intents. Same disable-while-busy + spinner shape as backupBusy above, one flag per button.
+    var strapLogBusy by remember { mutableStateOf(false) }
+    var whoop5CaptureBusy by remember { mutableStateOf(false) }
+    var rawAndLogBusy by remember { mutableStateOf(false) }
+
     // Re-scan must request the runtime Bluetooth permission before scanning — without this the
     // button calls connect() directly and silently no-ops on Android 12+ when the permission was
     // denied/revoked (issue #1). Shared with Live's Connect via the one rememberRequestScan gate.
@@ -1639,8 +1647,28 @@ fun SettingsScreen(
                     leadingIcon = Icons.Filled.Upload,
                     kind = NoopButtonKind.Secondary,
                     fullWidth = true,
-                    onClick = { scope.launch { LogExport.shareStrapLog(context, vm.ble.exportLogText()) } },
+                    enabled = !strapLogBusy,
+                    onClick = {
+                        strapLogBusy = true
+                        scope.launch {
+                            LogExport.shareStrapLog(context, vm.ble.exportLogText())
+                            strapLogBusy = false
+                        }
+                    },
                 )
+                if (strapLogBusy) {
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    ) {
+                        CircularProgressIndicator(
+                            color = Palette.accent,
+                            strokeWidth = 2.dp,
+                            modifier = Modifier.size(18.dp),
+                        )
+                        Text(uiString(R.string.l10n_settings_screen_working_13b7bfca), style = NoopType.footnote, color = Palette.textSecondary)
+                    }
+                }
 
                 // "WHOOP 4.0 vs 5.0/MG — what each can read and why" (FI-2 / #490). Shown to BOTH model
                 // owners, so a 4.0 user understands their strap is fully supported (and why the firmware
@@ -2042,8 +2070,28 @@ fun SettingsScreen(
                     leadingIcon = Icons.Filled.Upload,
                     kind = NoopButtonKind.Secondary,
                     fullWidth = true,
-                    onClick = { scope.launch { LogExport.shareWhoop5Capture(context, live.whoop5Detected) } },
+                    enabled = !whoop5CaptureBusy,
+                    onClick = {
+                        whoop5CaptureBusy = true
+                        scope.launch {
+                            LogExport.shareWhoop5Capture(context, live.whoop5Detected)
+                            whoop5CaptureBusy = false
+                        }
+                    },
                 )
+                if (whoop5CaptureBusy) {
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    ) {
+                        CircularProgressIndicator(
+                            color = Palette.accent,
+                            strokeWidth = 2.dp,
+                            modifier = Modifier.size(18.dp),
+                        )
+                        Text(uiString(R.string.l10n_settings_screen_working_13b7bfca), style = NoopType.footnote, color = Palette.textSecondary)
+                    }
+                }
 
                 // One-tap "matched pair" export (#510): hands a reporter BOTH the raw capture file and
                 // the strap log together (timestamped, same minute) so a protocol-mapping issue arrives
@@ -2053,8 +2101,28 @@ fun SettingsScreen(
                     leadingIcon = Icons.Filled.IosShare,
                     kind = NoopButtonKind.Secondary,
                     fullWidth = true,
-                    onClick = { scope.launch { LogExport.shareRawAndLog(context, vm.ble.exportLogText(), live.whoop5Detected) } },
+                    enabled = !rawAndLogBusy,
+                    onClick = {
+                        rawAndLogBusy = true
+                        scope.launch {
+                            LogExport.shareRawAndLog(context, vm.ble.exportLogText(), live.whoop5Detected)
+                            rawAndLogBusy = false
+                        }
+                    },
                 )
+                if (rawAndLogBusy) {
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    ) {
+                        CircularProgressIndicator(
+                            color = Palette.accent,
+                            strokeWidth = 2.dp,
+                            modifier = Modifier.size(18.dp),
+                        )
+                        Text(uiString(R.string.l10n_settings_screen_working_13b7bfca), style = NoopType.footnote, color = Palette.textSecondary)
+                    }
+                }
             }
         }
         } // end if (showFiveMGControls)

--- a/android/app/src/main/java/com/noop/ui/SettingsScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/SettingsScreen.kt
@@ -2042,7 +2042,7 @@ fun SettingsScreen(
                     leadingIcon = Icons.Filled.Upload,
                     kind = NoopButtonKind.Secondary,
                     fullWidth = true,
-                    onClick = { LogExport.shareWhoop5Capture(context, live.whoop5Detected) },
+                    onClick = { scope.launch { LogExport.shareWhoop5Capture(context, live.whoop5Detected) } },
                 )
 
                 // One-tap "matched pair" export (#510): hands a reporter BOTH the raw capture file and

--- a/android/app/src/main/java/com/noop/ui/TestCentreScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/TestCentreScreen.kt
@@ -21,6 +21,7 @@ import androidx.compose.material.icons.filled.Info
 import androidx.compose.material.icons.filled.Science
 import androidx.compose.material.icons.filled.Upload
 import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.Switch
@@ -89,6 +90,11 @@ fun TestCentreScreen(vm: AppViewModel) {
     // A report awaiting the mandatory review-before-share gate (spec section 12). Non-null shows the
     // review dialog; confirming runs TestReportFlow.run.
     var pendingReport by remember { mutableStateOf<PendingReport?>(null) }
+
+    // #646/#651: TestReportFlow.run now awaits LogExport.exportBundle's off-main zip build instead of
+    // blocking the caller, so a re-entrancy guard is needed on the dialog's Share button — without it a
+    // fast double-tap before the dialog dismisses fires two zips / two chooser intents.
+    var reportShareBusy by remember { mutableStateOf(false) }
 
     // The Display frame monitor follows the screen: if the Display mode was already on when the screen
     // appears, (re)start it; always tear it down when the screen leaves so no Choreographer callback
@@ -184,22 +190,26 @@ fun TestCentreScreen(vm: AppViewModel) {
             modeInactive = p.modeInactive,
             onCancel = { pendingReport = null },
             onShare = {
-                p.gate.confirm()
-                // Launched (#646/#651): TestReportFlow.run is now suspend since it awaits
-                // LogExport.exportBundle's off-main zip build.
-                scope.launch {
-                    TestReportFlow.run(
-                        context = context,
-                        profile = p.profile,
-                        title = p.title,
-                        version = BuildConfig.VERSION_NAME,
-                        platform = "Android",
-                        osVersion = android.os.Build.VERSION.RELEASE ?: "?",
-                        gate = p.gate,
-                        entries = p.entries,
-                    )
+                // Guard against a fast double-tap firing TestReportFlow.run twice before the dialog
+                // dismisses (#646/#651 — run() now awaits the off-main zip build instead of blocking).
+                if (!reportShareBusy) {
+                    reportShareBusy = true
+                    p.gate.confirm()
+                    scope.launch {
+                        TestReportFlow.run(
+                            context = context,
+                            profile = p.profile,
+                            title = p.title,
+                            version = BuildConfig.VERSION_NAME,
+                            platform = "Android",
+                            osVersion = android.os.Build.VERSION.RELEASE ?: "?",
+                            gate = p.gate,
+                            entries = p.entries,
+                        )
+                        reportShareBusy = false
+                    }
+                    pendingReport = null
                 }
-                pendingReport = null
             },
         )
     }
@@ -333,6 +343,11 @@ private fun DiagnosticToolsCard(vm: AppViewModel) {
     var showRecalibrate by remember { mutableStateOf(false) }
     // "Debug logging" moved here from Settings: dev-only, mirrors the strap log to logcat over adb.
     var debugLogging by remember { mutableStateOf(NoopPrefs.debugLogging(context)) }
+    // #646/#651: LogExport.shareStrapLog's file write now runs on Dispatchers.IO instead of blocking the
+    // caller, so nothing else stops a second tap mid-share. Same disable-while-busy + spinner shape as
+    // Settings' backupBusy pattern — this screen has its own local flag, this button being a separate
+    // instance from the Settings "Share strap log" button.
+    var strapLogBusy by remember { mutableStateOf(false) }
     SettingsSectionTC(
         icon = Icons.Filled.Info,
         title = uiString(R.string.l10n_test_centre_screen_diagnostic_tools_04ba4d3f),
@@ -345,8 +360,28 @@ private fun DiagnosticToolsCard(vm: AppViewModel) {
                 leadingIcon = Icons.Filled.Upload,
                 kind = NoopButtonKind.Secondary,
                 fullWidth = true,
-                onClick = { scope.launch { LogExport.shareStrapLog(context, vm.ble.exportLogText()) } },
+                enabled = !strapLogBusy,
+                onClick = {
+                    strapLogBusy = true
+                    scope.launch {
+                        LogExport.shareStrapLog(context, vm.ble.exportLogText())
+                        strapLogBusy = false
+                    }
+                },
             )
+            if (strapLogBusy) {
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                ) {
+                    CircularProgressIndicator(
+                        color = Palette.accent,
+                        strokeWidth = 2.dp,
+                        modifier = Modifier.size(18.dp),
+                    )
+                    Text(uiString(R.string.l10n_settings_screen_working_13b7bfca), style = NoopType.footnote, color = Palette.textSecondary)
+                }
+            }
             // Recalibrate Charge baseline, the same Baselines.recalibrateRecoveryBaselines call.
             NoopButton(
                 text = uiString(R.string.l10n_test_centre_screen_recalibrate_charge_baseline_52a05a26),

--- a/android/app/src/main/java/com/noop/ui/TestCentreScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/TestCentreScreen.kt
@@ -185,16 +185,20 @@ fun TestCentreScreen(vm: AppViewModel) {
             onCancel = { pendingReport = null },
             onShare = {
                 p.gate.confirm()
-                TestReportFlow.run(
-                    context = context,
-                    profile = p.profile,
-                    title = p.title,
-                    version = BuildConfig.VERSION_NAME,
-                    platform = "Android",
-                    osVersion = android.os.Build.VERSION.RELEASE ?: "?",
-                    gate = p.gate,
-                    entries = p.entries,
-                )
+                // Launched (#646/#651): TestReportFlow.run is now suspend since it awaits
+                // LogExport.exportBundle's off-main zip build.
+                scope.launch {
+                    TestReportFlow.run(
+                        context = context,
+                        profile = p.profile,
+                        title = p.title,
+                        version = BuildConfig.VERSION_NAME,
+                        platform = "Android",
+                        osVersion = android.os.Build.VERSION.RELEASE ?: "?",
+                        gate = p.gate,
+                        entries = p.entries,
+                    )
+                }
                 pendingReport = null
             },
         )


### PR DESCRIPTION
Fixes #646, #651

## Summary

The one-tap "raw + log" matched-pair export and the Test Centre report bundle both built their zip and read the staged files back into memory on whatever dispatcher/actor the caller was on — Main, for every UI call site today. A large raw capture or report bundle could stall the Android UI thread or beach-ball the macOS/iOS main actor while the zip was assembled.

- **Android** (`android/app/src/main/java/com/noop/ui/LogExport.kt`): the file writers/readers and `zipEntries`/`writeBytes` now run under `Dispatchers.IO`; only the `ACTION_SEND` chooser fires back on the caller's (Main) dispatcher. `exportBundle`, `shareRawAndLog`, `shareStrapLog` and `shareWhoop5Capture` are now `suspend` (they already were, except `exportBundle`/`shareWhoop5Capture`, which needed to become suspend to move their IO off-thread). `com.noop.testcentre.TestReportFlow.run` awaits `exportBundle` and is now `suspend` too; its one call site in `TestCentreScreen.kt` is launched from the existing `rememberCoroutineScope()`.
- **Apple** (`Strand/System/FileExport.swift`): `exportBundle` now stages the zip via a detached task (mirroring the existing `DataBackup.runExport` pattern) before hopping back to `@MainActor` to present the save panel / share sheet. `exportPair` reads the source file the same way. Both are `async` now. `TestReportFlow.run` (Swift) awaits `exportBundle` and is `async`; its callers — `SettingsView.exportRawAndLog()` and `TestCentreReport.confirm()` — wrap the call in a `Task { }` so the button-action call sites stay synchronous from the caller's perspective.

No behavior change beyond threading: same files, same zip contents, same share sheet / save panel / toast ordering — just off the UI thread/actor while building them.

This is a pure concurrency fix — no new user-facing strings, no BLE changes.

## Verification

- Kotlin: `cd android && JAVA_HOME=/opt/homebrew/Cellar/openjdk@21/21.0.11/libexec/openjdk.jdk/Contents/Home ANDROID_HOME=$HOME/Library/Android/sdk ./gradlew :app:compileFullDebugKotlin --console=plain` — **BUILD SUCCESSFUL** (only pre-existing, unrelated "parameter never used" warnings elsewhere in the tree).
- Swift: `xcodegen generate && xcodebuild -project Strand.xcodeproj -scheme Strand -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO build` — **BUILD SUCCEEDED**, no new warnings in the touched files. All touched Swift files (`Strand/Screens/SettingsView.swift`, `Strand/System/FileExport.swift`, `Strand/System/TestReportFlow.swift`, `Strand/System/TestCentreReport.swift`) are shared (not excluded) between the macOS `Strand` target and `NOOPiOS`, so this build exercises the same source.
- **Not verified**: a direct `NOOPiOS` simulator build. `build_sim` failed in this sandbox with `This scheme builds an embedded Apple Watch app. watchOS 26.5 must be installed in order to run the scheme` — a missing watchOS runtime in the sandbox, unrelated to this change (fails before any Swift file compiles). Since every touched Swift file compiled cleanly under the macOS target with no `#if os(iOS)`-only errors, and the iOS-specific branches (`present(activityItems:...)`, `UIActivityViewController`) are unchanged aside from the actor hop, I'm fairly confident in the iOS path but it would benefit from a human/CI check via `app-build.yml` (macos-26 runner) before merge.
- Not tested on a physical strap — this PR touches no BLE code.
- No new user-facing strings were added, so no i18n audit was needed.
