### PR TITLE
Warn that .noopbak is a readable, unencrypted archive

### DIFF
--- a/Strand/Screens/BackupSyncView.swift
+++ b/Strand/Screens/BackupSyncView.swift
@@ -75,6 +75,18 @@ struct BackupSyncView: View {
                 Text("Tip: choose a folder in iCloud Drive and your backups sync to all your Apple devices automatically, no account setup needed.")
                     .font(StrandFont.caption).foregroundStyle(StrandPalette.accent)
                     .fixedSize(horizontal: false, vertical: true)
+                // #644: these .noopbak snapshots are a plain, unencrypted ZIP — pointing this folder at
+                // a cloud sync app (per the tip above) also uploads that readable file there. Say so
+                // plainly next to the folder picker, before anyone turns auto-backup on.
+                HStack(alignment: .top, spacing: 8) {
+                    Image(systemName: "exclamationmark.triangle.fill")
+                        .foregroundStyle(StrandPalette.statusWarning)
+                        .font(.system(size: 12))
+                        .accessibilityHidden(true)
+                    Text("These backups are unencrypted too. If this folder syncs to Drive, Dropbox or iCloud, the readable file goes there as well — only point it at a service you trust.")
+                        .font(StrandFont.caption).foregroundStyle(StrandPalette.statusWarning)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
                 NoopButton(folderLabel == nil ? "Choose folder" : "Change folder",
                            systemImage: "folder", kind: .secondary) { chooseFolder() }
                     .disabled(busy)

--- a/Strand/Screens/SettingsView.swift
+++ b/Strand/Screens/SettingsView.swift
@@ -1815,6 +1815,21 @@ struct SettingsView: View {
                         .fixedSize(horizontal: false, vertical: true)
                 }
 
+                // #644: .noopbak is a plain ZIP, not an encrypted container — anyone who gets the file
+                // can open it in any archive tool. Say so plainly next to the Export button, rather than
+                // let people assume the file itself is protected once it leaves the device (e.g. dropped
+                // into a cloud-synced folder).
+                HStack(alignment: .top, spacing: 10) {
+                    Image(systemName: "exclamationmark.triangle.fill")
+                        .foregroundStyle(StrandPalette.statusWarning)
+                        .font(.system(size: 13))
+                        .accessibilityHidden(true)
+                    Text("This is a plain, unencrypted archive — anyone who gets the file can open it with any zip tool. Store it somewhere you trust.")
+                        .font(StrandFont.footnote)
+                        .foregroundStyle(StrandPalette.statusWarning)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+
                 // Reach the scheduled / folder-based Backup & Sync screen (back up to a chosen folder on
                 // demand or about once a day, restore from a snapshot in that folder).
                 NavigationLink {

--- a/android/app/src/main/java/com/noop/ui/BackupSyncScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/BackupSyncScreen.kt
@@ -16,14 +16,17 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.CloudUpload
 import androidx.compose.material.icons.filled.FolderOpen
 import androidx.compose.material.icons.filled.Restore
+import androidx.compose.material.icons.filled.Warning
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.Icon
 import androidx.compose.material3.Switch
 import androidx.compose.material3.SwitchDefaults
 import androidx.compose.material3.Text
@@ -158,6 +161,21 @@ fun BackupSyncScreen() {
                             "folder a sync app (e.g. FolderSync / Autosync) keeps in your cloud.",
                         style = NoopType.caption, color = Palette.accent,
                     )
+                    // #644: these .noopbak snapshots are a plain, unencrypted ZIP — pointing this folder
+                    // at a cloud sync app (per the tip above) also uploads that readable file there.
+                    // Say so plainly next to the folder picker, before anyone turns auto-backup on.
+                    Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                        Icon(
+                            Icons.Filled.Warning,
+                            contentDescription = null,
+                            tint = Palette.statusWarning,
+                            modifier = Modifier.size(16.dp),
+                        )
+                        Text(
+                            uiString(R.string.l10n_backup_sync_screen_these_backups_are_unencrypted_too_if_53e70fe8),
+                            style = NoopType.caption, color = Palette.statusWarning,
+                        )
+                    }
                     NoopButton(
                         text = if (treeUri == null) "Choose folder" else "Change folder",
                         leadingIcon = Icons.Filled.FolderOpen,

--- a/android/app/src/main/java/com/noop/ui/SettingsScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/SettingsScreen.kt
@@ -57,6 +57,7 @@ import androidx.compose.material.icons.filled.CloudSync
 import androidx.compose.material.icons.filled.Storage
 import androidx.compose.material.icons.filled.Upload
 import androidx.compose.material.icons.filled.Vibration
+import androidx.compose.material.icons.filled.Warning
 import androidx.compose.material.icons.outlined.AccountCircle
 import androidx.compose.material.icons.outlined.Person
 import androidx.compose.material3.AlertDialog
@@ -2415,6 +2416,29 @@ fun SettingsScreen(
                     text = uiString(R.string.l10n_settings_screen_importing_overwrites_everything_currently_on_this_297b76ae) +
                         "Export CSV writes a WHOOP-format zip of your days, sleeps, workouts and journal that re-imports into NOOP on Android or Mac. On-device computed rows are marked APPROXIMATE in its Source column; the .noopbak backup stays the lossless restore path.",
                 )
+
+                // #644: .noopbak is a plain ZIP, not an encrypted container — anyone who gets the file
+                // can open it in any archive tool. Surface that plainly, right next to the Export
+                // button, rather than let people assume the file itself is protected once it leaves
+                // the device (e.g. dropped into a cloud-synced folder).
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .semantics(mergeDescendants = true) {},
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                ) {
+                    Icon(
+                        Icons.Filled.Warning,
+                        contentDescription = null,
+                        tint = Palette.statusWarning,
+                        modifier = Modifier.size(16.dp),
+                    )
+                    Text(
+                        uiString(R.string.l10n_settings_screen_this_is_a_plain_unencrypted_archive_b0dfe63d),
+                        style = NoopType.caption,
+                        color = Palette.statusWarning,
+                    )
+                }
             }
         }
 

--- a/android/app/src/main/res/values-de/strings.xml
+++ b/android/app/src/main/res/values-de/strings.xml
@@ -264,6 +264,7 @@
     <string name="l10n_backup_sync_screen_restore_3cbe6d6b">Wiederherstellen</string>
     <string name="l10n_backup_sync_screen_restore_from_a_backup_c28917c6">Aus einer Sicherung wiederherstellen…</string>
     <string name="l10n_backup_sync_screen_roughly_when_the_daily_backup_runs_71de04e1">Etwa wenn das tägliche Backup läuft (Best-Effort - das System kann es ein wenig rutschen).</string>
+    <string name="l10n_backup_sync_screen_these_backups_are_unencrypted_too_if_53e70fe8">Auch diese Sicherungen sind unverschlüsselt. Wenn dieser Ordner mit Drive, Dropbox oder iCloud synchronisiert wird, landet die lesbare Datei auch dort — zeigen Sie nur auf einen Dienst, dem Sie vertrauen.</string>
     <string name="l10n_backup_sync_screen_tip_a_desktop_drive_dropbox_app_2eaff1e3">Tipp: Eine Desktop Drive / Dropbox App synchronisiert einen ausgewählten Ordner automatisch. Am Telefon speichern Sie eine</string>
     <string name="l10n_backup_sync_screen_writes_a_fresh_dated_backup_to_bd964fc5">Schreibt ein neues datiertes Backup in Ihren Ordner einmal am Tag zu der Zeit unten, halten</string>
     <string name="l10n_breathe_screen_a_relaxation_rhythm_not_cardiac_control_5c2f10a8">Ein Entspannungsrhythmus, keine Herzsteuerung. Er taktet nie unter eine sichere Rate, und du kannst jederzeit aufhören. Wenn sich deine Herzfrequenz nicht beruhigt, sagen wir es klar.</string>
@@ -1518,6 +1519,7 @@
     <string name="l10n_settings_screen_temperature_0a9062a9">Temperatur</string>
     <string name="l10n_settings_screen_test_centre_37b36828">Testzentrum</string>
     <string name="l10n_settings_screen_theme_a797e309">Design</string>
+    <string name="l10n_settings_screen_this_is_a_plain_unencrypted_archive_b0dfe63d">Das ist ein einfaches, unverschlüsseltes Archiv — wer die Datei bekommt, kann sie mit jedem Zip-Programm öffnen. Bewahren Sie sie an einem Ort auf, dem Sie vertrauen.</string>
     <string name="l10n_settings_screen_this_restarts_the_roughly_4_night_c610a93d">Das startet den etwa 4-nächtigen Aufbau für Ladung und deine HRV-Basislinie neu. Dein Verlauf bleibt. Nutze es, wenn eine schlechte erste Woche, etwa krank getragen, deine Basislinie verzerrt hat.</string>
     <string name="l10n_settings_screen_trend_charts_19085c81">Trenddiagramme</string>
     <string name="l10n_settings_screen_try_whoop_5_mg_protocol_probes_1d584653">WHOOP 5/MG-Protokolltests ausprobieren</string>

--- a/android/app/src/main/res/values-es/strings.xml
+++ b/android/app/src/main/res/values-es/strings.xml
@@ -94,6 +94,7 @@
     <string name="l10n_backup_sync_screen_restore_3cbe6d6b">Restaurar</string>
     <string name="l10n_backup_sync_screen_restore_from_a_backup_c28917c6">Restaurar desde una copia de seguridad…</string>
     <string name="l10n_backup_sync_screen_roughly_when_the_daily_backup_runs_71de04e1">Roughly cuando la copia de seguridad diaria funciona (mejor esfuerzo - el sistema puede deslizarlo un poco).</string>
+    <string name="l10n_backup_sync_screen_these_backups_are_unencrypted_too_if_53e70fe8">Estas copias de seguridad tampoco están cifradas. Si esta carpeta se sincroniza con Drive, Dropbox o iCloud, el archivo legible también llegará allí: apunte solo a un servicio de confianza.</string>
     <string name="l10n_backup_sync_screen_tip_a_desktop_drive_dropbox_app_2eaff1e3">Consejo: una aplicación de escritorio Drive / Dropbox auto-syncs una carpeta elegida. Por teléfono, ahorre a un</string>
     <string name="l10n_backup_sync_screen_writes_a_fresh_dated_backup_to_bd964fc5">Escribe una copia de seguridad de fecha nueva en tu carpeta una vez al día en el momento siguiente, manteniendo</string>
     <string name="l10n_breathe_screen_a_relaxation_rhythm_not_cardiac_control_5c2f10a8">Un ritmo de relajación, no un control cardíaco. Nunca marca un ritmo por debajo de un nivel seguro y puedes parar cuando quieras. Si tu frecuencia cardíaca no se calma, te lo diremos claramente.</string>
@@ -1348,6 +1349,7 @@
     <string name="l10n_settings_screen_temperature_0a9062a9">Temperatura</string>
     <string name="l10n_settings_screen_test_centre_37b36828">Centro de pruebas</string>
     <string name="l10n_settings_screen_theme_a797e309">Tema</string>
+    <string name="l10n_settings_screen_this_is_a_plain_unencrypted_archive_b0dfe63d">Es un archivo sencillo y sin cifrar: cualquiera que consiga el archivo puede abrirlo con cualquier herramienta zip. Guárdelo en un lugar de confianza.</string>
     <string name="l10n_settings_screen_this_restarts_the_roughly_4_night_c610a93d">Esto reinicia el período de unas 4 noches de construcción de la Carga y tu línea base de VFC. Tu historial se conserva. Úsalo si una mala primera semana, como usarla estando enfermo, desvió tu línea base.</string>
     <string name="l10n_settings_screen_trend_charts_19085c81">Gráficos de tendencias</string>
     <string name="l10n_settings_screen_try_whoop_5_mg_protocol_probes_1d584653">Prueba las sondas del protocolo WHOOP 5/MG</string>

--- a/android/app/src/main/res/values-fr/strings.xml
+++ b/android/app/src/main/res/values-fr/strings.xml
@@ -94,6 +94,7 @@
     <string name="l10n_backup_sync_screen_restore_3cbe6d6b">Restaurer</string>
     <string name="l10n_backup_sync_screen_restore_from_a_backup_c28917c6">Restaurer à partir d\'une sauvegarde…</string>
     <string name="l10n_backup_sync_screen_roughly_when_the_daily_backup_runs_71de04e1">À peu près quand la sauvegarde quotidienne fonctionne (meilleur effort — le système peut glisser un peu).</string>
+    <string name="l10n_backup_sync_screen_these_backups_are_unencrypted_too_if_53e70fe8">Ces sauvegardes ne sont pas chiffrées non plus. Si ce dossier se synchronise avec Drive, Dropbox ou iCloud, le fichier lisible y sera aussi copié : ne pointez que vers un service de confiance.</string>
     <string name="l10n_backup_sync_screen_tip_a_desktop_drive_dropbox_app_2eaff1e3">Conseil : une application Drive / Dropbox synchronise automatiquement un dossier choisi. Au téléphone, épargnez jusqu\'à</string>
     <string name="l10n_backup_sync_screen_writes_a_fresh_dated_backup_to_bd964fc5">Ecrit une nouvelle sauvegarde datée dans votre dossier une fois par jour à l\'heure ci-dessous, en conservant</string>
     <string name="l10n_breathe_screen_a_relaxation_rhythm_not_cardiac_control_5c2f10a8">Un rythme de relaxation, pas un contrôle cardiaque. Il ne cadence jamais en dessous d\'un rythme sûr et vous pouvez arrêter à tout moment. Si votre fréquence cardiaque ne se stabilise pas, nous vous le dirons clairement.</string>
@@ -1348,6 +1349,7 @@
     <string name="l10n_settings_screen_temperature_0a9062a9">Température</string>
     <string name="l10n_settings_screen_test_centre_37b36828">Centre de test</string>
     <string name="l10n_settings_screen_theme_a797e309">Thème</string>
+    <string name="l10n_settings_screen_this_is_a_plain_unencrypted_archive_b0dfe63d">C\'est une archive simple, non chiffrée : quiconque récupère le fichier peut l\'ouvrir avec n\'importe quel outil zip. Conservez-le dans un endroit de confiance.</string>
     <string name="l10n_settings_screen_this_restarts_the_roughly_4_night_c610a93d">Cela relance la montée en puissance d\'environ 4 nuits pour la charge et votre référence VFC. Votre historique reste. Utilisez-la si une mauvaise première semaine, comme le porter en étant malade, a faussé votre référence.</string>
     <string name="l10n_settings_screen_trend_charts_19085c81">Tableaux de tendances</string>
     <string name="l10n_settings_screen_try_whoop_5_mg_protocol_probes_1d584653">Essayer les sondes de protocole WHOOP 5/MG</string>

--- a/android/app/src/main/res/values-pt-rPT/strings.xml
+++ b/android/app/src/main/res/values-pt-rPT/strings.xml
@@ -247,6 +247,7 @@
     <string name="l10n_backup_sync_screen_restore_3cbe6d6b">Descansoaurar</string>
     <string name="l10n_backup_sync_screen_restore_from_a_backup_c28917c6">Descansoaurar a partir de um cópia de segurança…</string>
     <string name="l10n_backup_sync_screen_roughly_when_the_daily_backup_runs_71de04e1">Aproximadamente quando o cópia de segurança diário é executado (melhor esforço - o sistema pode deslizar um pouco).</string>
+    <string name="l10n_backup_sync_screen_these_backups_are_unencrypted_too_if_53e70fe8">Estas cópias de segurança também não estão encriptadas. Se esta pasta sincronizar com o Drive, o Dropbox ou o iCloud, o ficheiro legível também vai parar lá — aponta apenas para um serviço de confiança.</string>
     <string name="l10n_backup_sync_screen_tip_a_desktop_drive_dropbox_app_2eaff1e3">Dica: uma aplicação Drive/Dropbox para desktop sincroniza automaticamente uma pasta escolhida. No telefone, guarde num </string>
     <string name="l10n_backup_sync_screen_writes_a_fresh_dated_backup_to_bd964fc5">Grava um novo cópia de segurança datado na tua pasta uma vez por dia no horário abaixo, mantendo </string>
     <string name="l10n_breathe_screen_a_relaxation_rhythm_not_cardiac_control_5c2f10a8">Um ritmo de relaxamento, não de controlo cardíaco. Nunca anda abaixo de uma taxa segura e pode parar a qualquer momento. Se a tua frequência cardíaca não acalmar, diremos isso claramente.</string>
@@ -1499,6 +1500,7 @@
     <string name="l10n_settings_screen_temperature_0a9062a9">Temperatura</string>
     <string name="l10n_settings_screen_test_centre_37b36828">Centro de testes</string>
     <string name="l10n_settings_screen_theme_a797e309">Tema</string>
+    <string name="l10n_settings_screen_this_is_a_plain_unencrypted_archive_b0dfe63d">É um arquivo simples, não encriptado — quem tiver o ficheiro pode abri-lo com qualquer ferramenta zip. Guarda-o num sítio de confiança.</string>
     <string name="l10n_settings_screen_this_restarts_the_roughly_4_night_c610a93d">Isto reinicia a acumulação de aproximadamente 4 noites para a Carga e a tua linha de base de HRV. A tua histórico permanece. Usa-o se uma má primeira semana, como usá-lo durante uma doença, definir a tua linha de base.</string>
     <string name="l10n_settings_screen_trend_charts_19085c81">Gráficos de tendências</string>
     <string name="l10n_settings_screen_try_whoop_5_mg_protocol_probes_1d584653">Experimente as sondagens de protocolo WHOOP 5/MG</string>

--- a/android/app/src/main/res/values-zh/strings.xml
+++ b/android/app/src/main/res/values-zh/strings.xml
@@ -245,6 +245,7 @@
     <string name="l10n_backup_sync_screen_restore_3cbe6d6b">恢复</string>
     <string name="l10n_backup_sync_screen_restore_from_a_backup_c28917c6">从备份中恢复…</string>
     <string name="l10n_backup_sync_screen_roughly_when_the_daily_backup_runs_71de04e1">这是每日自动备份触发的大致时间点（系统会尽力保证，但可能会有微小偏差）。</string>
+    <string name="l10n_backup_sync_screen_these_backups_are_unencrypted_too_if_53e70fe8">这些备份同样未加密。如果这个文件夹与 Drive、Dropbox 或 iCloud 同步，可读的文件也会一并上传——只指向你信任的服务。</string>
     <string name="l10n_backup_sync_screen_tip_a_desktop_drive_dropbox_app_2eaff1e3">提示：如果您使用网盘 (Drive / Dropbox 等)，建议将备份文件夹选在云盘自动同步的目录内，实现真正的云端无感备份。</string>
     <string name="l10n_backup_sync_screen_writes_a_fresh_dated_backup_to_bd964fc5">在下方设定的时间点，每天生成一份带日期标记的新备份，并自动清理旧文件。</string>
     <string name="l10n_breathe_screen_a_relaxation_rhythm_not_cardiac_control_5c2f10a8">这是一种放松节律，而非心脏调控。节奏不会低于安全下限，您也可以随时终止。如果您的心率迟迟没有平复，我们会如实告诉您。</string>
@@ -1480,6 +1481,7 @@
     <string name="l10n_settings_screen_temperature_0a9062a9">温度</string>
     <string name="l10n_settings_screen_test_centre_37b36828">测试中心</string>
     <string name="l10n_settings_screen_theme_a797e309">主题</string>
+    <string name="l10n_settings_screen_this_is_a_plain_unencrypted_archive_b0dfe63d">这是一个未加密的普通压缩包——任何拿到文件的人都能用任意压缩工具打开它。请把它存放在你信任的地方。</string>
     <string name="l10n_settings_screen_this_restarts_the_roughly_4_night_c610a93d">这将重新启动大约需要 4 个晚上的充能(Charge)与 HRV 基准建立过程。您的历史数据都会被保留下来。如果因为您第一周佩戴时状态不佳（比如生病），导致基线严重偏离了正常水平，请使用此功能。</string>
     <string name="l10n_settings_screen_trend_charts_19085c81">趋势图表</string>
     <string name="l10n_settings_screen_try_whoop_5_mg_protocol_probes_1d584653">尝试触发 WHOOP 5.0/MG 协议探针</string>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -273,6 +273,7 @@
     <string name="l10n_backup_sync_screen_restore_3cbe6d6b">Restore</string>
     <string name="l10n_backup_sync_screen_restore_from_a_backup_c28917c6">Restore from a backup…</string>
     <string name="l10n_backup_sync_screen_roughly_when_the_daily_backup_runs_71de04e1">Roughly when the daily backup runs (best-effort — the system may slide it a little).</string>
+    <string name="l10n_backup_sync_screen_these_backups_are_unencrypted_too_if_53e70fe8">These backups are unencrypted too. If this folder syncs to Drive, Dropbox or iCloud, the readable file goes there as well — only point it at a service you trust.</string>
     <string name="l10n_backup_sync_screen_tip_a_desktop_drive_dropbox_app_2eaff1e3">Tip: a desktop Drive / Dropbox app auto-syncs a chosen folder. On the phone, save to a </string>
     <string name="l10n_backup_sync_screen_writes_a_fresh_dated_backup_to_bd964fc5">Writes a fresh dated backup to your folder once a day at the time below, keeping </string>
     <string name="l10n_breathe_screen_a_relaxation_rhythm_not_cardiac_control_5c2f10a8">A relaxation rhythm, not cardiac control. It never paces below a safe rate and you can stop anytime. If your heart rate doesn\'t settle, we\'ll say so plainly.</string>
@@ -1527,6 +1528,7 @@
     <string name="l10n_settings_screen_temperature_0a9062a9">Temperature</string>
     <string name="l10n_settings_screen_test_centre_37b36828">Test Centre</string>
     <string name="l10n_settings_screen_theme_a797e309">Theme</string>
+    <string name="l10n_settings_screen_this_is_a_plain_unencrypted_archive_b0dfe63d">This is a plain, unencrypted archive — anyone who gets the file can open it with any zip tool. Store it somewhere you trust.</string>
     <string name="l10n_settings_screen_this_restarts_the_roughly_4_night_c610a93d">This restarts the roughly 4-night build-up for Charge and your HRV baseline. Your history stays. Use it if a bad first week, like wearing it while sick, set your baseline off.</string>
     <string name="l10n_settings_screen_trend_charts_19085c81">Trend charts</string>
     <string name="l10n_settings_screen_try_whoop_5_mg_protocol_probes_1d584653">Try WHOOP 5/MG protocol probes</string>


### PR DESCRIPTION
Fixes #644

## What

`.noopbak` files are plain ZIP containers (SQLite + whitelisted settings) with no
app-level encryption — anyone with the file can rename it to `.zip` and read it in
any archive tool. Users backing up to a folder that's cloud-synced (iCloud Drive,
Google Drive, Dropbox) may assume the app protects the file once it leaves the
device. It doesn't.

Per the issue's own scoping: **this PR implements the "clearer warning" option
only, not encryption.** Encryption would need its own dedicated design/key-management
PR (secure key storage, passphrase UX, recovery story) that this kind of change
shouldn't attempt as a drive-by fix.

## Changes

UI-copy only — no changes to the backup file format, ZIP creation logic, or
BackupSync's sync mechanics.

- **Manual export** (Settings → Backup & restore, both platforms): a warning line
  next to the Export button, reusing the existing info-row pattern already used for
  the "importing overwrites everything" note, stating the file is a readable,
  unencrypted archive and should be stored somewhere trusted.
- **Folder auto-backup / cloud-sync** (Backup & Sync screen, both platforms): a
  warning line next to the folder picker (reusing the existing "Tip:" caption
  pattern), calling out specifically that syncing the chosen folder to a cloud
  service uploads the readable file there too.
- Both warnings use existing design tokens only (`Palette.statusWarning` /
  `StrandPalette.statusWarning`, `NoopType`/`StrandFont`) — no hardcoded colors or
  fonts.
- Translations added for de, es, fr, pt-PT, and zh (Android `values-zh` / Apple
  `zh-Hans`+`zh-Hant`, to satisfy the i18n audit's ratcheting allowance), plus it/ru
  on the Apple side for the same reason.

## Verification

- `python3 Tools/i18n_audit.py --ci origin/main` — clean (no new hardcoded copy, all
  focus locales complete, no new gaps in the ratcheted extra-locale set).
- Android: `./gradlew :app:compileFullDebugKotlin` — `BUILD SUCCESSFUL`.
- Apple: `xcodegen generate && xcodebuild -project Strand.xcodeproj -scheme Strand
  -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO build` — `BUILD SUCCEEDED`.
- Not tested: on-device/on-simulator visual check of the new warning rows (no
  BLE/strap interaction involved — this is copy-only UI text in an existing card
  layout, so compile success plus reusing an established row pattern is the
  practical bar here).
