### PR TITLE
fix(ble): stop hardcoding device.name to "WHOOP 4.0" for every paired device

### DIFF
--- a/Strand/BLE/BLEManager.swift
+++ b/Strand/BLE/BLEManager.swift
@@ -936,7 +936,12 @@ public final class BLEManager: NSObject, ObservableObject {
            !activeId.isEmpty {
             self.deviceId = activeId
         }
-        try? await store.upsertDevice(id: deviceId, mac: nil, name: "WHOOP 4.0")
+        // Look up the active device's real brand/model instead of a hardcoded string — this predated
+        // multi-device support and mislabeled every non-"WHOOP 4.0" device (a WHOOP 5.0/MG strap, an Oura
+        // ring, …) with the same literal "WHOOP 4.0". `device.name` has no production reader today (only
+        // the `deviceRowForTest` helper), so this is dormant, but still wrong data on disk.
+        let registeredName = (try? registry.all())?.first(where: { $0.id == deviceId })?.displayName
+        try? await store.upsertDevice(id: deviceId, mac: nil, name: registeredName)
         // Research toggle — OFF by default. When disabled the app is decoded-only and never
         // persists raw frames. Flip "enableRawCapture" in UserDefaults to capture raw again.
         let enableRawCapture = UserDefaults.standard.bool(forKey: "enableRawCapture")


### PR DESCRIPTION
  ## Summary
  - `bootstrapStore()` (`BLEManager.swift:939`) wrote the literal string
    `"WHOOP 4.0"` into the `device` table's `name` column regardless of which
    device was actually active — a leftover from before multi-device support
    existed. A WHOOP 5.0/MG strap or an Oura ring both got mislabeled the same
    way. Found by exporting a `.noopbak` and inspecting the raw `device` table
    directly (the real registry, `pairedDevice`, was already correct).
  - Fix: look up the active device's real brand/model from the registry —
    `PairedDevice.displayName` already exists for exactly this (nickname, or
    "Brand Model") — instead of the hardcoded literal.

  ## Impact
  `device.name` has no production reader today (only the test-only
  `deviceRowForTest` helper) — this was dormant, visible only by querying the
  DB directly, never in the shipped UI.

  ## Cross-platform
  No Android equivalent to update: no live-BLE `upsertDevice` call for the main
  device row exists in `WhoopBleClient.kt` / `OuraLiveSource.kt`, so there's
  nothing to keep in parity here.

  ## Test plan
  - [x] `xcodebuild -scheme Strand -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO build` — succeeds
  - [x] iOS build (`NOOPiOS`) validated and tested
  
  ## Validation
  
  The fix is working — the device table row is now honest instead of a hardcoded wrong literal:

  device table:  my-whoop | mac= | name="WHOOP" | firstSeen/lastSeen ~09:26 UTC
  pairedDevice:  my-whoop → WHOOP/WHOOP 4.0/paired · oura-2H3B2405003655 → Oura/Oura Ring 3/active

  Two things worth explaining, both expected — not new bugs:

  1. No Oura row in device this time, only my-whoop. bootstrapStore() (the code we touched) runs exactly once per app launch, using whichever device the registry says is active at that instant. In your first backup, the Oura  ring was already active at cold-launch (carried over from the prior session), so that call wrote the (buggy) Oura row. In this session, my-whoop was still active at the moment of launch — Oura only got promoted to active  later, after this one-time bootstrap had already run — so only my-whoop got a row this time. That's a pre-existing quirk of "runs once per launch," unrelated to the fix.
  2. name = "WHOOP", not "WHOOP 4.0". At the exact moment this ran, my-whoop's registry entry still had the generic seeded model "WHOOP" — the #716 correction that upgrades it to "WHOOP 4.0" fires slightly later, once the  app's scan actually discovers and confirms the physical strap. displayName correctly reported reality at that moment: model == brand → collapses to just "WHOOP". Before the fix this would've said "WHOOP 4.0" regardless — an incorrect model, right time. Now it's honest, even if that honesty is "haven't confirmed the generation yet."