### PR TITLE
Improve layout, spacing, and captions across core screens

### DIFF
--- a/Packages/StrandDesign/Sources/StrandDesign/Components.swift
+++ b/Packages/StrandDesign/Sources/StrandDesign/Components.swift
@@ -29,6 +29,8 @@ public enum NoopMetrics {
     // inset and margin lines up to the same grid. Note `cardPadding` (16) above is
     // the same value as `space4` — kept as a named alias for the existing call sites.
     public static let space1:  CGFloat = 4
+    /// Optical separation for paired labels; structural layout still follows the 4-point ramp.
+    public static let spaceHalf: CGFloat = 2
     public static let space2:  CGFloat = 8
     public static let space3:  CGFloat = 12
     public static let space4:  CGFloat = 16
@@ -50,6 +52,17 @@ public enum NoopMetrics {
     public static let rowSpacing: CGFloat = 10
     /// Standard interactive-control height (buttons, fields, segmented controls).
     public static let controlHeight: CGFloat = 48
+    /// Standard one-pixel edge used by cards and compact controls.
+    public static let hairlineWidth: CGFloat = 1
+    /// Profile form dimensions shared by avatar and numeric controls.
+    public static let profileAvatarDiameter: CGFloat = 44
+    public static let formValueColumnWidth: CGFloat = 48
+    public static let formWideValueColumnWidth: CGFloat = 64
+    /// Compact metadata and explanatory-footer heights.
+    public static let compactMetadataMinHeight: CGFloat = 24
+    public static let compactHintMinHeight: CGFloat = 18
+    /// Canonical thickness for compact horizontal indicator tracks.
+    public static let indicatorTrackHeight: CGFloat = 8
     /// Fully-rounded corner radius — pills, chips, capsule buttons.
     public static let pillRadius: CGFloat = NoopVisualStyle.pillRadius
     /// Minimum desktop size for a navigation-based customization sheet.

--- a/Strand/Liquid/LiquidPrimitives.swift
+++ b/Strand/Liquid/LiquidPrimitives.swift
@@ -133,7 +133,11 @@ enum LiquidRender {
         let outline = Path(roundedRect: CGRect(x: 0.5, y: 0.5, width: w - 1, height: h - 1), cornerRadius: r)
         var ctx = base
         ctx.fill(outline, with: .color(NoopVisualStyle.inset))
-        ctx.stroke(outline, with: .color(NoopVisualStyle.border.opacity(0.72)), lineWidth: 1)
+        ctx.stroke(
+            outline,
+            with: .color(NoopVisualStyle.border.opacity(0.72)),
+            lineWidth: NoopMetrics.hairlineWidth
+        )
 
         var clip = ctx
         clip.clip(to: outline)

--- a/Strand/Liquid/LiquidTodayView.swift
+++ b/Strand/Liquid/LiquidTodayView.swift
@@ -517,7 +517,10 @@ struct LiquidTodayView: View {
                     .foregroundStyle(StrandPalette.textSecondary)
                     .padding(.horizontal, 8).padding(.vertical, 2.5)
                     .background(Capsule().fill(StrandPalette.surfaceInset.opacity(0.72))
-                        .overlay(Capsule().strokeBorder(StrandPalette.hairline, lineWidth: 1)))
+                        .overlay(Capsule().strokeBorder(
+                            StrandPalette.hairline,
+                            lineWidth: NoopMetrics.hairlineWidth
+                        )))
                 Spacer(minLength: 8)
                 Image(systemName: "chevron.right").font(.system(size: 12, weight: .semibold))
                     .foregroundStyle(StrandPalette.textTertiary)

--- a/Strand/Liquid/LiquidTodayView.swift
+++ b/Strand/Liquid/LiquidTodayView.swift
@@ -301,7 +301,7 @@ struct LiquidTodayView: View {
                     dataSourcesSection
                     Color.clear.frame(height: 90) // floating tab-bar clearance
                 }
-                .padding(.horizontal, 16)
+                .padding(.horizontal, NoopMetrics.screenHPadding)
                 .padding(.top, 30) // sit the title lower into the sky, not jammed under the status bar
             }
             #if os(macOS)

--- a/Strand/Resources/Localizable.xcstrings
+++ b/Strand/Resources/Localizable.xcstrings
@@ -145152,6 +145152,58 @@
         }
       }
     },
+    "Trailing": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Letzte"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Últimos"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Derniers"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ultimi"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Últimos"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Последние"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "近"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "過去"
+          }
+        }
+      }
+    },
     "Trailing %lld days": {
       "localizations": {
         "de": {

--- a/Strand/Resources/Localizable.xcstrings
+++ b/Strand/Resources/Localizable.xcstrings
@@ -38693,6 +38693,58 @@
         }
       }
     },
+    "Charge scale, depleted to peaked": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ladeskala, von erschöpft bis zum Höchststand"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Escala de carga, de agotado a su punto máximo"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Échelle de charge, du niveau épuisé au sommet"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Scala della carica, da esaurito al picco"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Escala de carga, de esgotado até ao máximo"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Шкала заряда: от истощения до пика"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "能量刻度，从已耗尽到已达峰值"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "能量刻度，從已耗盡到已達峰值"
+          }
+        }
+      }
+    },
     "Charge trend": {
       "localizations": {
         "de": {
@@ -102748,6 +102800,58 @@
           "stringUnit": {
             "state": "translated",
             "value": "可選。為左上角的頭像新增一張照片。僅儲存在 %@ 上，NOOP 是離線的，因此絕不會上傳。"
+          }
+        }
+      }
+    },
+    "Optional. Add a photo for your avatar. It stays on %@ and is never uploaded.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Optional. Füge ein Foto für deinen Avatar hinzu. Es bleibt auf %@ und wird nie hochgeladen."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Opcional. Añade una foto para tu avatar. Permanece en %@ y nunca se sube."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Facultatif. Ajoutez une photo pour votre avatar. Elle reste sur %@ et n’est jamais mise en ligne."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Facoltativo. Aggiungi una foto per il tuo avatar. Rimane su %@ e non viene mai caricata."
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Opcional. Adiciona uma fotografia para o teu avatar. Fica em %@ e nunca é carregada."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Необязательно. Добавьте фото для аватара. Оно останется на %@ и никогда не будет загружено."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "可选。为头像添加照片。照片仅保留在 %@ 上，绝不会上传。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "可選。為頭像新增照片。照片只會保留在 %@ 上，絕不會上傳。"
           }
         }
       }

--- a/Strand/Screens/ScreenScaffold.swift
+++ b/Strand/Screens/ScreenScaffold.swift
@@ -46,9 +46,9 @@ struct ScreenScaffold<Content: View, Trailing: View>: View {
             Color.clear.frame(height: 0).id(screenScaffoldTopAnchorID)
             column
             #if os(iOS)
-            // Unified side margins matching the liquid home (16pt) so every page's cards + header line up
+            // Unified side margins matching the floating navigation bar so every page's cards + header line up
             // to the same edges (2026-07-02); macOS keeps the classic 28 in the #else branch.
-            .padding(.horizontal, 16)
+            .padding(.horizontal, NoopMetrics.screenHPadding)
             .padding(.top, 24)
             // The tab bar floats over the scroll content, so the last card sat hidden behind it.
             // Reserve extra bottom scroll room so every screen's final card clears the floating bar.

--- a/Strand/Screens/SettingsView.swift
+++ b/Strand/Screens/SettingsView.swift
@@ -534,7 +534,10 @@ struct SettingsView: View {
         let hasAvatar = profile.hasAvatar
         return VStack(alignment: .leading, spacing: NoopMetrics.space2) {
             HStack(spacing: NoopMetrics.space3) {
-                ProfileAvatarView(imageData: profile.avatarImageData, size: 44)
+                ProfileAvatarView(
+                    imageData: profile.avatarImageData,
+                    size: NoopMetrics.profileAvatarDiameter
+                )
                     .accessibilityLabel(hasAvatar ? "Your profile photo" : "No profile photo set")
 
                 PhotosPicker(selection: $avatarPickerItem, matching: .images) {
@@ -588,11 +591,11 @@ struct SettingsView: View {
                               range: ClosedRange<Double>, step: Double,
                               format: String, accessibility: String) -> some View {
         HStack(spacing: NoopMetrics.space2) {
-            HStack(alignment: .firstTextBaseline, spacing: 4) {
+            HStack(alignment: .firstTextBaseline, spacing: NoopMetrics.space1) {
                 Text(String(format: format, value.wrappedValue))
                     .font(StrandFont.bodyNumber)
                     .foregroundStyle(StrandPalette.textPrimary)
-                    .frame(width: 48, alignment: .center)
+                    .frame(width: NoopMetrics.formValueColumnWidth, alignment: .center)
                 Text(unit)
                     .font(StrandFont.caption)
                     .foregroundStyle(StrandPalette.textTertiary)
@@ -614,11 +617,11 @@ struct SettingsView: View {
             set: { weightKg.wrappedValue = $0 / UnitFormatter.poundsPerKilogram }
         )
         return HStack(spacing: NoopMetrics.space2) {
-            HStack(alignment: .firstTextBaseline, spacing: 4) {
+            HStack(alignment: .firstTextBaseline, spacing: NoopMetrics.space1) {
                 Text(String(format: "%.0f", lb.wrappedValue))
                     .font(StrandFont.bodyNumber)
                     .foregroundStyle(StrandPalette.textPrimary)
-                    .frame(width: 48, alignment: .center)
+                    .frame(width: NoopMetrics.formValueColumnWidth, alignment: .center)
                 Text("lb")
                     .font(StrandFont.caption)
                     .foregroundStyle(StrandPalette.textTertiary)
@@ -644,7 +647,7 @@ struct SettingsView: View {
             Text("\(parts.feet)′ \(parts.inches)″")
                 .font(StrandFont.bodyNumber)
                 .foregroundStyle(StrandPalette.textPrimary)
-                .frame(width: 64, alignment: .center)
+                .frame(width: NoopMetrics.formWideValueColumnWidth, alignment: .center)
             Stepper("Height in inches", value: inches, in: 47...91, step: 1)
                 .labelsHidden()
                 .accessibilityLabel("Height, \(parts.feet) feet \(parts.inches) inches")
@@ -658,11 +661,11 @@ struct SettingsView: View {
     private func waistCentimetresField(waistCm: Binding<Double>) -> some View {
         let set = waistCm.wrappedValue > 0
         return HStack(spacing: NoopMetrics.space2) {
-            HStack(alignment: .firstTextBaseline, spacing: 4) {
+            HStack(alignment: .firstTextBaseline, spacing: NoopMetrics.space1) {
                 Text(set ? String(format: "%.0f", waistCm.wrappedValue) : String(localized: "Not set"))
                     .font(StrandFont.bodyNumber)
                     .foregroundStyle(set ? StrandPalette.textPrimary : StrandPalette.textTertiary)
-                    .frame(minWidth: 48, alignment: .center)
+                    .frame(minWidth: NoopMetrics.formValueColumnWidth, alignment: .center)
                 if set {
                     Text("cm")
                         .font(StrandFont.caption)
@@ -691,11 +694,11 @@ struct SettingsView: View {
         let set = waistCm.wrappedValue > 0
         let inches = set ? UnitFormatter.cmToInches(waistCm.wrappedValue).rounded() : 0
         return HStack(spacing: NoopMetrics.space2) {
-            HStack(alignment: .firstTextBaseline, spacing: 4) {
+            HStack(alignment: .firstTextBaseline, spacing: NoopMetrics.space1) {
                 Text(set ? "\(Int(inches))" : "Not set")
                     .font(StrandFont.bodyNumber)
                     .foregroundStyle(set ? StrandPalette.textPrimary : StrandPalette.textTertiary)
-                    .frame(minWidth: 48, alignment: .center)
+                    .frame(minWidth: NoopMetrics.formValueColumnWidth, alignment: .center)
                 if set {
                     Text("in")
                         .font(StrandFont.caption)
@@ -721,13 +724,13 @@ struct SettingsView: View {
     /// HR-max override: 0 = auto. Shown as a compact tabular value with a stepper.
     private var hrMaxField: some View {
         HStack(spacing: NoopMetrics.space2) {
-            HStack(alignment: .firstTextBaseline, spacing: 4) {
+            HStack(alignment: .firstTextBaseline, spacing: NoopMetrics.space1) {
                 Text(profile.hrMaxOverride > 0 ? "\(profile.hrMaxOverride)" : "Auto")
                     .font(StrandFont.bodyNumber)
                     .foregroundStyle(profile.hrMaxOverride > 0
                                      ? StrandPalette.textPrimary
                                      : StrandPalette.textTertiary)
-                    .frame(width: 44, alignment: .center)
+                    .frame(width: NoopMetrics.formValueColumnWidth, alignment: .center)
                 Text("bpm")
                     .font(StrandFont.caption)
                     .foregroundStyle(StrandPalette.textTertiary)
@@ -2852,7 +2855,7 @@ private struct SettingsSection<Content: View>: View {
     @ViewBuilder var content: () -> Content
 
     var body: some View {
-        StrandCard(padding: 20) {
+        StrandCard(padding: NoopMetrics.space5) {
             VStack(alignment: .leading, spacing: NoopMetrics.space4) {
                 VStack(alignment: .leading, spacing: 2) {
                     Text("Settings").strandOverline()

--- a/Strand/Screens/SettingsView.swift
+++ b/Strand/Screens/SettingsView.swift
@@ -2843,7 +2843,7 @@ private struct SettingsDisclosureGroup<Content: View>: View {
 // MARK: - Section card
 
 /// A grouped settings card: a "Settings" overline + icon + title header, an explanatory blurb,
-/// then content. A faint accent-blue wash anchors the card to NOOP's neutral chrome (WHOOP skin).
+/// then content. The surface stays neutral; accent blue is reserved for the icon and controls.
 private struct SettingsSection<Content: View>: View {
     let icon: String
     let title: LocalizedStringKey
@@ -2851,7 +2851,7 @@ private struct SettingsSection<Content: View>: View {
     @ViewBuilder var content: () -> Content
 
     var body: some View {
-        StrandCard(padding: 20, tint: StrandPalette.accent) {
+        StrandCard(padding: 20) {
             VStack(alignment: .leading, spacing: NoopMetrics.space4) {
                 VStack(alignment: .leading, spacing: 2) {
                     Text("Settings").strandOverline()

--- a/Strand/Screens/SettingsView.swift
+++ b/Strand/Screens/SettingsView.swift
@@ -463,12 +463,7 @@ struct SettingsView: View {
                 rowDivider
                 FormRow(label: "Max heart rate") {
                     VStack(alignment: .trailing, spacing: 6) {
-                        HStack(spacing: 8) {
-                            hrMaxField
-                            Text("bpm")
-                                .font(StrandFont.caption)
-                                .foregroundStyle(StrandPalette.textTertiary)
-                        }
+                        hrMaxField
                         Text(profile.hrMaxOverride > 0
                              ? "Manual override"
                              : "Auto · \(profile.hrMax) bpm (Tanaka)")
@@ -592,20 +587,23 @@ struct SettingsView: View {
     private func measureField(value: Binding<Double>, unit: String,
                               range: ClosedRange<Double>, step: Double,
                               format: String, accessibility: String) -> some View {
-        HStack(spacing: 10) {
+        HStack(spacing: NoopMetrics.space2) {
             HStack(alignment: .firstTextBaseline, spacing: 4) {
                 Text(String(format: format, value.wrappedValue))
                     .font(StrandFont.bodyNumber)
                     .foregroundStyle(StrandPalette.textPrimary)
-                    .frame(minWidth: 48, alignment: .trailing)
+                    .frame(width: 48, alignment: .center)
                 Text(unit)
                     .font(StrandFont.caption)
                     .foregroundStyle(StrandPalette.textTertiary)
+                    .fixedSize()
             }
+            .fixedSize()
             Stepper(accessibility, value: value, in: range, step: step)
                 .labelsHidden()
                 .accessibilityLabel(accessibility)
         }
+        .fixedSize()
     }
 
     /// Imperial weight entry: shows pounds, steps in 1-lb increments, and writes the kg equivalent back
@@ -615,20 +613,23 @@ struct SettingsView: View {
             get: { UnitFormatter.kgToPounds(weightKg.wrappedValue) },
             set: { weightKg.wrappedValue = $0 / UnitFormatter.poundsPerKilogram }
         )
-        return HStack(spacing: 10) {
+        return HStack(spacing: NoopMetrics.space2) {
             HStack(alignment: .firstTextBaseline, spacing: 4) {
                 Text(String(format: "%.0f", lb.wrappedValue))
                     .font(StrandFont.bodyNumber)
                     .foregroundStyle(StrandPalette.textPrimary)
-                    .frame(minWidth: 48, alignment: .trailing)
+                    .frame(width: 48, alignment: .center)
                 Text("lb")
                     .font(StrandFont.caption)
                     .foregroundStyle(StrandPalette.textTertiary)
+                    .fixedSize()
             }
+            .fixedSize()
             Stepper("Weight in pounds", value: lb, in: 66...551, step: 1)
                 .labelsHidden()
                 .accessibilityLabel("Weight, \(Int(lb.wrappedValue.rounded())) pounds")
         }
+        .fixedSize()
     }
 
     /// Imperial height entry: shows feet′ inches″, steps in whole inches, and writes the cm equivalent
@@ -639,15 +640,16 @@ struct SettingsView: View {
             set: { heightCm.wrappedValue = $0 * UnitFormatter.centimetersPerInch }
         )
         let parts = UnitFormatter.cmToFeetInches(heightCm.wrappedValue)
-        return HStack(spacing: 10) {
+        return HStack(spacing: NoopMetrics.space2) {
             Text("\(parts.feet)′ \(parts.inches)″")
                 .font(StrandFont.bodyNumber)
                 .foregroundStyle(StrandPalette.textPrimary)
-                .frame(minWidth: 56, alignment: .trailing)
+                .frame(width: 64, alignment: .center)
             Stepper("Height in inches", value: inches, in: 47...91, step: 1)
                 .labelsHidden()
                 .accessibilityLabel("Height, \(parts.feet) feet \(parts.inches) inches")
         }
+        .fixedSize()
     }
 
     /// Metric waist entry: 0 = unset (shows a muted "Not set" rather than a misleading 0 cm). Steps in
@@ -655,18 +657,20 @@ struct SettingsView: View {
     /// crawl up from the range floor. Mirrors `measureField` but tolerant of the optional empty state.
     private func waistCentimetresField(waistCm: Binding<Double>) -> some View {
         let set = waistCm.wrappedValue > 0
-        return HStack(spacing: 10) {
+        return HStack(spacing: NoopMetrics.space2) {
             HStack(alignment: .firstTextBaseline, spacing: 4) {
                 Text(set ? String(format: "%.0f", waistCm.wrappedValue) : String(localized: "Not set"))
                     .font(StrandFont.bodyNumber)
                     .foregroundStyle(set ? StrandPalette.textPrimary : StrandPalette.textTertiary)
-                    .frame(minWidth: 48, alignment: .trailing)
+                    .frame(minWidth: 48, alignment: .center)
                 if set {
                     Text("cm")
                         .font(StrandFont.caption)
                         .foregroundStyle(StrandPalette.textTertiary)
+                        .fixedSize()
                 }
             }
+            .fixedSize()
             Stepper("Waist in centimetres") {
                 waistCm.wrappedValue = min(160, (set ? waistCm.wrappedValue : 79) + 1)
             } onDecrement: {
@@ -677,6 +681,7 @@ struct SettingsView: View {
                 .labelsHidden()
                 .accessibilityLabel(set ? "Waist, \(Int(waistCm.wrappedValue.rounded())) centimetres" : "Waist not set")
         }
+        .fixedSize()
     }
 
     /// Imperial waist entry: 0 = unset (muted "Not set"); otherwise shows whole inches and stores the cm
@@ -685,18 +690,20 @@ struct SettingsView: View {
     private func waistInchesField(waistCm: Binding<Double>) -> some View {
         let set = waistCm.wrappedValue > 0
         let inches = set ? UnitFormatter.cmToInches(waistCm.wrappedValue).rounded() : 0
-        return HStack(spacing: 10) {
+        return HStack(spacing: NoopMetrics.space2) {
             HStack(alignment: .firstTextBaseline, spacing: 4) {
                 Text(set ? "\(Int(inches))" : "Not set")
                     .font(StrandFont.bodyNumber)
                     .foregroundStyle(set ? StrandPalette.textPrimary : StrandPalette.textTertiary)
-                    .frame(minWidth: 48, alignment: .trailing)
+                    .frame(minWidth: 48, alignment: .center)
                 if set {
                     Text("in")
                         .font(StrandFont.caption)
                         .foregroundStyle(StrandPalette.textTertiary)
+                        .fixedSize()
                 }
             }
+            .fixedSize()
             Stepper("Waist in inches") {
                 let nextIn = (set ? inches : 30) + 1
                 waistCm.wrappedValue = min(160, nextIn * UnitFormatter.centimetersPerInch)
@@ -708,22 +715,31 @@ struct SettingsView: View {
                 .labelsHidden()
                 .accessibilityLabel(set ? "Waist, \(Int(inches)) inches" : "Waist not set")
         }
+        .fixedSize()
     }
 
     /// HR-max override: 0 = auto. Shown as a compact tabular value with a stepper.
     private var hrMaxField: some View {
-        HStack(spacing: 10) {
-            Text(profile.hrMaxOverride > 0 ? "\(profile.hrMaxOverride)" : "Auto")
-                .font(StrandFont.bodyNumber)
-                .foregroundStyle(profile.hrMaxOverride > 0
-                                 ? StrandPalette.textPrimary
-                                 : StrandPalette.textTertiary)
-                .frame(minWidth: 44, alignment: .trailing)
+        HStack(spacing: NoopMetrics.space2) {
+            HStack(alignment: .firstTextBaseline, spacing: 4) {
+                Text(profile.hrMaxOverride > 0 ? "\(profile.hrMaxOverride)" : "Auto")
+                    .font(StrandFont.bodyNumber)
+                    .foregroundStyle(profile.hrMaxOverride > 0
+                                     ? StrandPalette.textPrimary
+                                     : StrandPalette.textTertiary)
+                    .frame(width: 44, alignment: .center)
+                Text("bpm")
+                    .font(StrandFont.caption)
+                    .foregroundStyle(StrandPalette.textTertiary)
+                    .fixedSize()
+            }
+            .fixedSize()
             Stepper("Max heart rate override",
                     value: $profile.hrMaxOverride, in: 0...230, step: 1)
                 .labelsHidden()
                 .accessibilityLabel("Max heart rate override, \(profile.hrMaxOverride == 0 ? "automatic" : "\(profile.hrMaxOverride) bpm")")
         }
+        .fixedSize()
     }
 
     // MARK: - Units
@@ -3389,6 +3405,7 @@ private struct FormRow<Control: View>: View {
                 .foregroundStyle(StrandPalette.textPrimary)
                 .frame(maxWidth: .infinity, alignment: .leading)
             control()
+                .layoutPriority(1)
         }
         .frame(minHeight: 32)
     }

--- a/Strand/Screens/SettingsView.swift
+++ b/Strand/Screens/SettingsView.swift
@@ -296,14 +296,13 @@ struct SettingsView: View {
                        topBackground: liquidScaffoldSky()) {
             VStack(alignment: .leading, spacing: NoopMetrics.sectionSpacing) {
                 // Everyday sections stay expanded (S3): the ones a first-run user actually needs.
-                profilePhotoCard.staggeredAppear(index: 0)
-                profileCard.staggeredAppear(index: 1)
-                unitsCard.staggeredAppear(index: 2)
-                appearanceCard.staggeredAppear(index: 3)
-                strapCard.staggeredAppear(index: 4)
-                powerSavingCard.staggeredAppear(index: 5)
-                streakCard.staggeredAppear(index: 6)
-                featuresCard.staggeredAppear(index: 7)
+                profileCard.staggeredAppear(index: 0)
+                unitsCard.staggeredAppear(index: 1)
+                appearanceCard.staggeredAppear(index: 2)
+                strapCard.staggeredAppear(index: 3)
+                powerSavingCard.staggeredAppear(index: 4)
+                streakCard.staggeredAppear(index: 5)
+                featuresCard.staggeredAppear(index: 6)
 
                 // Lower-frequency sections collapse behind a single default-closed disclosure so the
                 // screen opens at ~6 sections instead of 11. Nothing is removed; every section here
@@ -379,56 +378,6 @@ struct SettingsView: View {
         #endif
     }
 
-    // MARK: - Profile photo (optional, on-device)
-
-    /// Set / change / remove an optional profile picture. PhotosUI's `PhotosPicker` works on both
-    /// iOS 16+ and macOS 13+ (NOOP's floor), so the same control serves both platforms — no
-    /// availability gating needed. The photo is stored only on this device (NOOP is fully offline).
-    private var profilePhotoCard: some View {
-        // #153: resolve the whole blurb through `String(localized:)` first, then hand SwiftUI the plain
-        // String via `LocalizedStringKey(_:)`. Interpolating `Platform.deviceNounPhrase` (itself an
-        // already-resolved localized String) straight into the `blurb:` `LocalizedStringKey` literal
-        // confused SwiftUI's text-measurement pass — the blurb rendered with zero trailing margin and
-        // clipped to the card edge instead of wrapping inside the card padding. The localization key is
-        // unchanged (`…Stored only on %@…`), so the existing translations still apply.
-        let blurbText = String(localized: "Optional. Add a photo for the avatar in the top-left. Stored only on \(Platform.deviceNounPhrase). NOOP is offline, so it's never uploaded.")
-        return SettingsSection(
-            icon: "person.crop.circle",
-            title: "Profile photo",
-            blurb: LocalizedStringKey(blurbText)
-        ) {
-            HStack(spacing: 16) {
-                ProfileAvatarView(imageData: profile.avatarImageData, size: 64)
-                    .accessibilityLabel(profile.hasAvatar ? "Your profile photo" : "No profile photo set")
-
-                VStack(alignment: .leading, spacing: NoopMetrics.space2) {
-                    PhotosPicker(selection: $avatarPickerItem, matching: .images) {
-                        Text(profile.hasAvatar ? "Change photo" : "Choose photo")
-                    }
-                    .buttonStyle(NoopButtonStyle(.secondary, fullWidth: true))
-
-                    if profile.hasAvatar {
-                        Button("Remove photo") { profile.clearAvatar() }
-                            .buttonStyle(NoopButtonStyle(.tertiary, fullWidth: true))
-                            .accessibilityHint("Reverts to the default profile icon")
-                    }
-                }
-            }
-        }
-        // Load the picked photo's bytes, then hand them to the store (which downscales + persists).
-        // Clearing the selection afterwards lets the user re-pick the same photo if they want.
-        .onChange(of: avatarPickerItem) { newItem in
-            guard let newItem else { return }
-            Task {
-                let data = try? await newItem.loadTransferable(type: Data.self)
-                await MainActor.run {
-                    if let data { profile.setAvatar(data) }
-                    avatarPickerItem = nil
-                }
-            }
-        }
-    }
-
     // MARK: - Profile
 
     private var profileCard: some View {
@@ -438,6 +387,8 @@ struct SettingsView: View {
             blurb: "These power your heart-rate zones, calorie estimates and recovery baselines. Keep them accurate."
         ) {
             VStack(spacing: 0) {
+                profilePhotoRow
+                rowDivider
                 FormRow(label: "Date of birth") {
                     HStack(spacing: 12) {
                         Text("\(profile.age)")
@@ -578,6 +529,51 @@ struct SettingsView: View {
                     .font(StrandFont.footnote)
                     .foregroundStyle(StrandPalette.textTertiary)
                     .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+    }
+
+    /// Compact profile-photo control kept inside the Profile card so the optional avatar does not
+    /// consume a second top-level settings section. PhotosUI works on both supported platforms.
+    private var profilePhotoRow: some View {
+        let hasAvatar = profile.hasAvatar
+        return VStack(alignment: .leading, spacing: NoopMetrics.space2) {
+            HStack(spacing: NoopMetrics.space3) {
+                ProfileAvatarView(imageData: profile.avatarImageData, size: 44)
+                    .accessibilityLabel(hasAvatar ? "Your profile photo" : "No profile photo set")
+
+                PhotosPicker(selection: $avatarPickerItem, matching: .images) {
+                    Text(hasAvatar ? "Change photo" : "Choose photo")
+                }
+                .buttonStyle(NoopButtonStyle(.secondary, fullWidth: true))
+
+                if hasAvatar {
+                    Button {
+                        profile.clearAvatar()
+                    } label: {
+                        Image(systemName: "trash")
+                    }
+                    .buttonStyle(NoopButtonStyle(.tertiary))
+                    .accessibilityLabel("Remove photo")
+                    .accessibilityHint("Reverts to the default profile icon")
+                }
+            }
+
+            Text("Optional. Add a photo for your avatar. It stays on \(Platform.deviceNounPhrase) and is never uploaded.")
+                .font(StrandFont.footnote)
+                .foregroundStyle(StrandPalette.textTertiary)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        // Load the picked photo's bytes, then hand them to the store (which downscales + persists).
+        // Clearing the selection afterwards lets the user re-pick the same photo if they want.
+        .onChange(of: avatarPickerItem) { newItem in
+            guard let newItem else { return }
+            Task {
+                let data = try? await newItem.loadTransferable(type: Data.self)
+                await MainActor.run {
+                    if let data { profile.setAvatar(data) }
+                    avatarPickerItem = nil
+                }
             }
         }
     }

--- a/Strand/Screens/SettingsView.swift
+++ b/Strand/Screens/SettingsView.swift
@@ -975,7 +975,7 @@ struct SettingsView: View {
                 }
                 #endif
 
-                Divider().overlay(StrandPalette.hairline).padding(.vertical, 4)
+                rowDivider
                 // MARK: Reduce motion in NOOP — pose every looping animation still and stop the tilt
                 // sensor, WITHOUT requiring system Low Power Mode. Off by default; system Reduce Motion
                 // and Low Power Mode already force the same behaviour, this is the third, in-app signal.
@@ -992,6 +992,7 @@ struct SettingsView: View {
                     .fixedSize(horizontal: false, vertical: true)
                     .frame(maxWidth: .infinity, alignment: .leading)
 
+                rowDivider
                 // MARK: Day-cycle background — the time-of-day scene behind Today (#698). On by default.
                 // Off swaps it for the plain dark canvas for people who find the moving scene distracting.
                 Toggle(isOn: $showDayCycleBackground) {
@@ -1109,7 +1110,7 @@ struct SettingsView: View {
                     .disabled(!live.connected && !live.bonded)
                 }
 
-                Divider().overlay(StrandPalette.hairline)
+                rowDivider
                 // MARK: Strap log — a Settings shortcut so people don't have to hunt for it on the Live
                 // screen (#507: couldn't find it on Mac; #509: same on iPhone). Same text as the Live card.
                 HStack(spacing: 12) {
@@ -1132,7 +1133,7 @@ struct SettingsView: View {
                     .foregroundStyle(StrandPalette.textTertiary)
                     .fixedSize(horizontal: false, vertical: true)
 
-                Divider().overlay(StrandPalette.hairline)
+                rowDivider
 
                 // MARK: Continuous HRV capture — keep the dense beat-to-beat (R-R) stream armed 24/7.
                 Toggle(isOn: $continuousHrvEnabled) {
@@ -1203,12 +1204,12 @@ struct SettingsView: View {
 
                 // MARK: Strap name — rename the WHOOP 4.0's BLE advertising name (Harvard command set).
                 if live.connected && selectedWhoopModelRaw == WhoopModel.whoop4.rawValue {
-                    Divider().overlay(StrandPalette.hairline)
+                    rowDivider
                     strapNameControl
                 }
 
                 #if os(iOS)
-                Divider().overlay(StrandPalette.hairline)
+                rowDivider
                 // MARK: Live Activity — show live HR on the Lock Screen + Dynamic Island (#336).
                 Toggle(isOn: $liveActivityEnabled) {
                     Text("Live heart rate in Dynamic Island")
@@ -1248,7 +1249,7 @@ struct SettingsView: View {
                     .fixedSize(horizontal: false, vertical: true)
 
                 if powerSavingEnabled {
-                    Divider().overlay(StrandPalette.hairline)
+                    rowDivider
                     HStack {
                         Text("Kick in at (strap battery)")
                             .font(StrandFont.subhead)
@@ -1265,7 +1266,7 @@ struct SettingsView: View {
                     )
                     .tint(StrandPalette.accent)
 
-                    Divider().overlay(StrandPalette.hairline)
+                    rowDivider
                     // HRV pause: a sub-option, ON by default when the master is on (stored inverted).
                     Toggle(isOn: Binding(get: { !pauseHrvDisabled }, set: { pauseHrvDisabled = !$0 })) {
                         Text("Pause HRV capture")
@@ -1443,7 +1444,7 @@ struct SettingsView: View {
                     .foregroundStyle(StrandPalette.textTertiary)
                     .fixedSize(horizontal: false, vertical: true)
 
-                Divider().overlay(StrandPalette.hairline)
+                rowDivider
 
                 Toggle(isOn: $autoDetectWorkoutsEnabled) {
                     Text("Auto-detect workouts")
@@ -1459,7 +1460,7 @@ struct SettingsView: View {
                     .foregroundStyle(StrandPalette.textTertiary)
                     .fixedSize(horizontal: false, vertical: true)
 
-                Divider().overlay(StrandPalette.hairline)
+                rowDivider
 
                 Toggle(isOn: $journalReminderEnabled) {
                     Text("Journal reminder")
@@ -1475,7 +1476,7 @@ struct SettingsView: View {
                     .foregroundStyle(StrandPalette.textTertiary)
                     .fixedSize(horizontal: false, vertical: true)
 
-                Divider().overlay(StrandPalette.hairline)
+                rowDivider
 
                 Toggle(isOn: $workoutKeepScreenOn) {
                     Text("Keep screen on during a workout")
@@ -1583,7 +1584,7 @@ struct SettingsView: View {
                     .foregroundStyle(StrandPalette.textTertiary)
                     .fixedSize(horizontal: false, vertical: true)
 
-                Divider().overlay(StrandPalette.hairline)
+                rowDivider
 
                 // MARK: Motion-aware wake refinement (#364 follow-up) — default OFF.
                 Toggle(isOn: $motionAwareWakeEnabled) {
@@ -1675,7 +1676,7 @@ struct SettingsView: View {
                     .foregroundStyle(StrandPalette.textTertiary)
                     .fixedSize(horizontal: false, vertical: true)
 
-                Divider().overlay(StrandPalette.hairline)
+                rowDivider
 
                 // MARK: R22 deep-data unlock — the one probe that writes to the strap.
                 Toggle(isOn: $deepDataEnabled) {
@@ -1768,7 +1769,7 @@ struct SettingsView: View {
                     }
                 }
 
-                Divider().overlay(StrandPalette.hairline)
+                rowDivider
 
                 // MARK: Broadcast HR — make the strap a standard BLE HR sensor (Garmin/Zwift/gym).
                 Toggle(isOn: $broadcastHrEnabled) {
@@ -1922,7 +1923,7 @@ struct SettingsView: View {
                     .fixedSize(horizontal: false, vertical: true)
 
                 if puffinCapture {
-                    Divider().overlay(StrandPalette.hairline)
+                    rowDivider
                     Text("Optical block experiment")
                         .font(StrandFont.subhead)
                         .foregroundStyle(StrandPalette.textPrimary)

--- a/Strand/Screens/SleepView.swift
+++ b/Strand/Screens/SleepView.swift
@@ -793,7 +793,7 @@ struct SleepView: View {
                                    intervals: [SleepInterval], night: Night) -> some View {
         NoopCard(tint: StrandPalette.restColor) {
             VStack(alignment: .leading, spacing: NoopMetrics.space3) {
-                VStack(alignment: .leading, spacing: 2) {
+                VStack(alignment: .leading, spacing: NoopMetrics.spaceHalf) {
                     Text("Stage breakdown").strandOverline()
                     Text(subtitle)
                         .font(StrandFont.footnote)
@@ -980,7 +980,7 @@ struct SleepView: View {
                     // This is a compact metadata footer inside an already surfaced card. A forced
                     // 44-point label made the WHOOP / Why row look vertically padded despite having
                     // only one line of content.
-                    .frame(minHeight: 24)
+                    .frame(minHeight: NoopMetrics.compactMetadataMinHeight)
                     .contentShape(Rectangle())
                 }
                 .buttonStyle(LiquidPressStyle())
@@ -1233,7 +1233,7 @@ struct SleepView: View {
             // range; otherwise a quiet hint that the rows are tappable. It grows only when a
             // selected-stage comparison needs a second line, avoiding a permanent empty footer.
             stageInsight(s)
-                .frame(minHeight: 18, alignment: .topLeading)
+                .frame(minHeight: NoopMetrics.compactHintMinHeight, alignment: .topLeading)
                 .padding(.horizontal, 2)
         }
     }
@@ -1903,7 +1903,7 @@ struct SleepView: View {
             let sign = $0 >= 0 ? "+" : "−"
             return "\(sign)\(String(format: "%.1f h", abs($0)))"
         }
-        VStack(alignment: .leading, spacing: 2) {
+        VStack(alignment: .leading, spacing: NoopMetrics.spaceHalf) {
             Text("Trend")
                 .textCase(.uppercase)
                 .font(StrandFont.footnote)

--- a/Strand/Screens/SleepView.swift
+++ b/Strand/Screens/SleepView.swift
@@ -1869,15 +1869,56 @@ struct SleepView: View {
                     }
                 },
                 footer: {
-                    ChartFooter([
-                        ("Avg",    avg.map { String(format: "%.1f h", $0) } ?? "—"),
-                        ("Min",    pts.map(\.value).min().map { String(format: "%.1f h", $0) } ?? "—"),
-                        ("Max",    pts.map(\.value).max().map { String(format: "%.1f h", $0) } ?? "—"),
-                        ("Nights", "\(pts.count)"),
-                    ])
+                    HStack {
+                        ChartFooter([
+                            ("Avg",    avg.map { String(format: "%.1f h", $0) } ?? "—"),
+                            ("Min",    pts.map(\.value).min().map { String(format: "%.1f h", $0) } ?? "—"),
+                            ("Max",    pts.map(\.value).max().map { String(format: "%.1f h", $0) } ?? "—"),
+                            ("Nights", "\(pts.count)"),
+                        ])
+                        durationTrendStat(pts)
+                    }
                 }
             )
         }
+    }
+
+    /// Recent-half mean minus earlier-half mean, matching the Trends screen's directional comparison.
+    /// Direction is neutral here: more sleep is not automatically better, so the chip conveys movement
+    /// without assigning a positive/warning colour.
+    private func durationTrendChange(_ points: [TrendPoint]) -> Double? {
+        guard points.count >= 4 else { return nil }
+        let midpoint = points.count / 2
+        let earlier = points.prefix(midpoint).map(\.value)
+        let recent = points.suffix(points.count - midpoint).map(\.value)
+        guard !earlier.isEmpty, !recent.isEmpty else { return nil }
+        return recent.reduce(0, +) / Double(recent.count)
+            - earlier.reduce(0, +) / Double(earlier.count)
+    }
+
+    @ViewBuilder
+    private func durationTrendStat(_ points: [TrendPoint]) -> some View {
+        let delta = durationTrendChange(points)
+        let deltaText = delta.map {
+            let sign = $0 >= 0 ? "+" : "−"
+            return "\(sign)\(String(format: "%.1f h", abs($0)))"
+        }
+        VStack(alignment: .leading, spacing: 2) {
+            Text("Trend")
+                .textCase(.uppercase)
+                .font(StrandFont.footnote)
+                .foregroundStyle(StrandPalette.textTertiary)
+            if let deltaText {
+                TrendChip(text: deltaText, color: StrandPalette.textTertiary)
+            } else {
+                Text("—")
+                    .font(StrandFont.captionNumber)
+                    .foregroundStyle(StrandPalette.textSecondary)
+            }
+        }
+        .fixedSize(horizontal: true, vertical: false)
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(Text(verbatim: "\(String(localized: "Trend")): \(deltaText ?? "—")"))
     }
 
     // MARK: - Memoization plumbing

--- a/Strand/Screens/SleepView.swift
+++ b/Strand/Screens/SleepView.swift
@@ -735,13 +735,7 @@ struct SleepView: View {
                 // stage; the others grey out. Replaces the 4-level hypnogram, whose staircase turned
                 // fragmented on-device staging into an unreadable comb. No separate footer — the
                 // rows ARE the legend.
-                ChartCard(
-                    title: "Stage breakdown",
-                    subtitle: subtitle,
-                    height: 524,
-                    tint: StrandPalette.restColor,
-                    chart: { stageTimeline(s, intervals: intervals, night: night) }
-                )
+                stageTimelineCard(s, subtitle: subtitle, intervals: intervals, night: night)
             } else {
                 ChartCard(
                     title: "Stage breakdown",
@@ -789,6 +783,24 @@ struct SleepView: View {
             nightHR = await repo.hrBuckets(from: night.session.startTs,
                                            to: night.session.endTs,
                                            bucketSeconds: 60)
+        }
+    }
+
+    /// The detailed timeline has a variable-height insight footer, so forcing it into a fixed-height
+    /// chart slot left a visibly empty shelf below the hint. This keeps the standard card header and
+    /// surface while allowing the timeline to size to the content it actually has.
+    private func stageTimelineCard(_ stages: Stages, subtitle: String,
+                                   intervals: [SleepInterval], night: Night) -> some View {
+        NoopCard(tint: StrandPalette.restColor) {
+            VStack(alignment: .leading, spacing: NoopMetrics.space3) {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Stage breakdown").strandOverline()
+                    Text(subtitle)
+                        .font(StrandFont.footnote)
+                        .foregroundStyle(StrandPalette.textTertiary)
+                }
+                stageTimeline(stages, intervals: intervals, night: night)
+            }
         }
     }
 
@@ -965,7 +977,10 @@ struct SleepView: View {
                     }
                     .font(StrandFont.footnote)
                     .foregroundStyle(StrandPalette.restColor)
-                    .frame(minHeight: 44)
+                    // This is a compact metadata footer inside an already surfaced card. A forced
+                    // 44-point label made the WHOOP / Why row look vertically padded despite having
+                    // only one line of content.
+                    .frame(minHeight: 24)
                     .contentShape(Rectangle())
                 }
                 .buttonStyle(LiquidPressStyle())
@@ -1215,10 +1230,10 @@ struct SleepView: View {
             .padding(.horizontal, 10)
             .accessibilityHidden(true)
             // WHOOP's per-stage insight: with a stage selected, tonight vs the 30-day typical
-            // range; otherwise a quiet hint that the rows are tappable. Fixed-height slot so
-            // selecting a stage never reflows the card.
+            // range; otherwise a quiet hint that the rows are tappable. It grows only when a
+            // selected-stage comparison needs a second line, avoiding a permanent empty footer.
             stageInsight(s)
-                .frame(height: 30, alignment: .topLeading)
+                .frame(minHeight: 18, alignment: .topLeading)
                 .padding(.horizontal, 2)
         }
     }

--- a/Strand/Screens/TrendsView.swift
+++ b/Strand/Screens/TrendsView.swift
@@ -528,7 +528,6 @@ struct TrendsView: View {
                 // caption narrower than one word (which wrapped the final G in TRAILING by itself).
                 SegmentedPillControl(Range.allCases, selection: $range,
                                      adaptsToAvailableWidth: true) { $0.label }
-                Spacer(minLength: 0)
                 if range.days == nil {
                     Text(rangeSubtitle)
                         .strandOverline()
@@ -540,9 +539,9 @@ struct TrendsView: View {
                     Text(rangeSubtitle)
                         .strandOverline()
                         .lineLimit(2)
-                        .multilineTextAlignment(.trailing)
+                        .multilineTextAlignment(.leading)
                         .fixedSize(horizontal: false, vertical: true)
-                        .frame(width: 86, alignment: .trailing)
+                        .frame(width: 76, alignment: .leading)
                 }
             }
             Text(cap)

--- a/Strand/Screens/TrendsView.swift
+++ b/Strand/Screens/TrendsView.swift
@@ -215,6 +215,31 @@ struct TrendsView: View {
         return String(localized: "Trailing \(n) days")
     }
 
+    /// The compact selector caption is intentionally split into two intrinsic-width lines.
+    /// Its leading edges line up while the surrounding spacer pins the widest line to the
+    /// screen's shared trailing content edge.
+    @ViewBuilder
+    private var rangeCaption: some View {
+        if let days = range.days {
+            VStack(alignment: .leading, spacing: 0) {
+                Text("Trailing")
+                    .strandOverline()
+                    .lineLimit(1)
+                Text("\(days) days")
+                    .strandOverline()
+                    .lineLimit(1)
+            }
+            .fixedSize(horizontal: true, vertical: false)
+            .accessibilityElement(children: .ignore)
+            .accessibilityLabel(rangeSubtitle)
+        } else {
+            Text(rangeSubtitle)
+                .strandOverline()
+                .lineLimit(1)
+                .fixedSize(horizontal: true, vertical: false)
+        }
+    }
+
     private func name(for r: Range) -> String {
         switch r {
         case .week:    return String(localized: "week")
@@ -542,21 +567,7 @@ struct TrendsView: View {
                 // Keep the caption's two lines internally leading-aligned, but anchor the whole
                 // caption column to the page's trailing edge.
                 Spacer(minLength: NoopMetrics.space2)
-                if range.days == nil {
-                    Text(rangeSubtitle)
-                        .strandOverline()
-                        .lineLimit(1)
-                        .fixedSize(horizontal: true, vertical: false)
-                } else {
-                    // A deliberate two-line column: TRAILING / 90 DAYS. Reserving a word-wide
-                    // column keeps 7, 30 and 90 from producing character-by-character wraps.
-                    Text(rangeSubtitle)
-                        .strandOverline()
-                        .lineLimit(2)
-                        .multilineTextAlignment(.leading)
-                        .fixedSize(horizontal: false, vertical: true)
-                        .frame(width: 76, alignment: .leading)
-                }
+                rangeCaption
             }
             Text(cap)
                 .font(StrandFont.footnote)

--- a/Strand/Screens/TrendsView.swift
+++ b/Strand/Screens/TrendsView.swift
@@ -522,12 +522,28 @@ struct TrendsView: View {
         let cap = recovery.caption
         let isWide = recovery.widened
         return VStack(alignment: .leading, spacing: NoopMetrics.space2) {
-            HStack {
-                SegmentedPillControl(
-                    Range.allCases,
-                    selection: $range,
-                    fillsAvailableWidth: true
-                ) { $0.label }
+            HStack(spacing: NoopMetrics.space2) {
+                // Six ranges plus the trailing-window caption need to share a compact iPhone row.
+                // Let the segmented control collapse to equal-width cells instead of squeezing the
+                // caption narrower than one word (which wrapped the final G in TRAILING by itself).
+                SegmentedPillControl(Range.allCases, selection: $range,
+                                     adaptsToAvailableWidth: true) { $0.label }
+                Spacer(minLength: 0)
+                if range.days == nil {
+                    Text(rangeSubtitle)
+                        .strandOverline()
+                        .lineLimit(1)
+                        .fixedSize(horizontal: true, vertical: false)
+                } else {
+                    // A deliberate two-line column: TRAILING / 90 DAYS. Reserving a word-wide
+                    // column keeps 7, 30 and 90 from producing character-by-character wraps.
+                    Text(rangeSubtitle)
+                        .strandOverline()
+                        .lineLimit(2)
+                        .multilineTextAlignment(.trailing)
+                        .fixedSize(horizontal: false, vertical: true)
+                        .frame(width: 86, alignment: .trailing)
+                }
             }
             Text(cap)
                 .font(StrandFont.footnote)

--- a/Strand/Screens/TrendsView.swift
+++ b/Strand/Screens/TrendsView.swift
@@ -190,11 +190,22 @@ struct TrendsView: View {
     private func changeChip(_ pts: [TrendPoint], higherIsBetter: Bool?, fmt: @escaping (Double) -> String) -> some View {
         if let d = periodChange(pts), abs(d) > 0.0001 {
             let sign = d >= 0 ? "+" : "−"
+            let deltaText = "\(sign)\(fmt(abs(d)))"
             let color: Color = {
                 guard let better = higherIsBetter else { return StrandPalette.textTertiary }
                 return (d > 0) == better ? StrandPalette.statusPositive : StrandPalette.metricRose
             }()
-            TrendChip(text: "\(sign)\(fmt(abs(d)))", color: color)
+            VStack(alignment: .leading, spacing: 2) {
+                // Match the neighbouring ChartFooter columns so the delta is self-describing instead
+                // of appearing as an unlabeled pill at the edge of the statistics row.
+                Text("Trend")
+                    .textCase(.uppercase)
+                    .font(StrandFont.footnote)
+                    .foregroundStyle(StrandPalette.textTertiary)
+                TrendChip(text: deltaText, color: color)
+            }
+            .accessibilityElement(children: .ignore)
+            .accessibilityLabel(Text(verbatim: "\(String(localized: "Trend")): \(deltaText)"))
         }
     }
 

--- a/Strand/Screens/TrendsView.swift
+++ b/Strand/Screens/TrendsView.swift
@@ -539,6 +539,9 @@ struct TrendsView: View {
                 // caption narrower than one word (which wrapped the final G in TRAILING by itself).
                 SegmentedPillControl(Range.allCases, selection: $range,
                                      adaptsToAvailableWidth: true) { $0.label }
+                // Keep the caption's two lines internally leading-aligned, but anchor the whole
+                // caption column to the page's trailing edge.
+                Spacer(minLength: NoopMetrics.space2)
                 if range.days == nil {
                     Text(rangeSubtitle)
                         .strandOverline()

--- a/Strand/Screens/TrendsView.swift
+++ b/Strand/Screens/TrendsView.swift
@@ -195,7 +195,7 @@ struct TrendsView: View {
                 guard let better = higherIsBetter else { return StrandPalette.textTertiary }
                 return (d > 0) == better ? StrandPalette.statusPositive : StrandPalette.metricRose
             }()
-            VStack(alignment: .leading, spacing: 2) {
+            VStack(alignment: .leading, spacing: NoopMetrics.spaceHalf) {
                 // Match the neighbouring ChartFooter columns so the delta is self-describing instead
                 // of appearing as an unlabeled pill at the edge of the statistics row.
                 Text("Trend")
@@ -221,7 +221,7 @@ struct TrendsView: View {
     @ViewBuilder
     private var rangeCaption: some View {
         if let days = range.days {
-            VStack(alignment: .leading, spacing: 0) {
+            VStack(alignment: .leading, spacing: .zero) {
                 Text("Trailing")
                     .strandOverline()
                     .lineLimit(1)
@@ -773,7 +773,7 @@ struct TrendsView: View {
                 .fixedSize()
             LinearGradient(gradient: StrandPalette.recoveryGradient, startPoint: .leading, endPoint: .trailing)
                 .frame(maxWidth: .infinity)
-                .frame(height: 8)
+                .frame(height: NoopMetrics.indicatorTrackHeight)
                 .clipShape(Capsule())
                 .accessibilityHidden(true)
             Text("Peaked")

--- a/Strand/Screens/TrendsView.swift
+++ b/Strand/Screens/TrendsView.swift
@@ -727,13 +727,23 @@ struct TrendsView: View {
 
     private var legend: some View {
         HStack(spacing: NoopMetrics.space2) {
-            Text("Depleted").font(StrandFont.footnote).foregroundStyle(StrandPalette.textTertiary)
+            Text("Depleted")
+                .font(StrandFont.footnote)
+                .foregroundStyle(StrandPalette.textTertiary)
+                .fixedSize()
             LinearGradient(gradient: StrandPalette.recoveryGradient, startPoint: .leading, endPoint: .trailing)
-                .frame(width: 120, height: 8)
+                .frame(maxWidth: .infinity)
+                .frame(height: 8)
                 .clipShape(Capsule())
-            Text("Peaked").font(StrandFont.footnote).foregroundStyle(StrandPalette.textTertiary)
-            Spacer()
+                .accessibilityHidden(true)
+            Text("Peaked")
+                .font(StrandFont.footnote)
+                .foregroundStyle(StrandPalette.textTertiary)
+                .fixedSize()
         }
+        .frame(maxWidth: .infinity)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("Charge scale, depleted to peaked")
     }
 
     // MARK: Shared bits

--- a/Strand/Screens/WeeklyDigestView.swift
+++ b/Strand/Screens/WeeklyDigestView.swift
@@ -185,7 +185,7 @@ struct WeeklyDigestContent: View {
             NoopPanelSurface(cornerRadius: NoopMetrics.cardRadius,
                              elevated: true)
             HStack(alignment: .firstTextBaseline) {
-                VStack(alignment: .leading, spacing: 2) {
+                VStack(alignment: .leading, spacing: NoopMetrics.spaceHalf) {
                     Text("Week in review").strandOverline()
                     Text(weekRangeLabel)
                         .font(StrandFont.title2)

--- a/android/app/src/main/java/com/noop/ui/TrendsScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/TrendsScreen.kt
@@ -38,6 +38,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.clearAndSetSemantics
+import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
@@ -146,6 +147,9 @@ fun TrendsScreen(vm: AppViewModel) {
         resolveMetric(days, range) { d -> sleepPerfByDay[d.day] }
     }
     val recAvg = recovery.values.averageOrNull()
+    val rangeSubtitle = range.days?.let { dayCount ->
+        stringResource(R.string.trends_trailing_days, dayCount)
+    } ?: stringResource(R.string.trends_all_history)
 
     LazyScreenScaffold(
         title = stringResource(R.string.nav_trends),
@@ -210,7 +214,7 @@ fun TrendsScreen(vm: AppViewModel) {
                         onSelect = { range = it },
                     )
                     Spacer(Modifier.weight(1f))
-                    Overline(range.subtitle, color = Palette.textTertiary)
+                    TrendsRangeCaption(range = range, fullSubtitle = rangeSubtitle)
                 }
                 Text(
                     recovery.caption,
@@ -228,7 +232,7 @@ fun TrendsScreen(vm: AppViewModel) {
                 title = stringResource(R.string.trends_charge),
                 // The range bar above already prints the authoritative reading-count caption;
                 // the hero only names its window so the count isn't doubled in one card height.
-                subtitle = range.subtitle,
+                subtitle = rangeSubtitle,
                 trailing = recAvg?.let { "${it.roundToInt()}" },
                 // LIQUID hero: the translucent-black frosted wrapper + a small count-up Charge vessel accent
                 // in the header (the screen's one headline single value — the window-average Charge). The
@@ -521,12 +525,32 @@ private enum class TrendsRange(val days: Int?, val label: String, val longName: 
     Year(365, "1Y", "year"),
     All(null, "ALL", "all history");
 
-    /** "Trailing 90 days" / "All history" , the card/range subtitle. */
-    val subtitle: String get() = days?.let { "Trailing $it days" } ?: "All history"
-
     /** This range plus every LARGER range, ascending , the auto-expand search order. */
     val widening: List<TrendsRange>
         get() = entries.dropWhile { it != this }
+}
+
+@Composable
+private fun TrendsRangeCaption(range: TrendsRange, fullSubtitle: String) {
+    val days = range.days
+    if (days == null) {
+        Overline(fullSubtitle, color = Palette.textTertiary)
+    } else {
+        // Keep both lines leading-aligned while the row's weighted spacer pins this
+        // intrinsic-width column to the shared trailing content edge.
+        Column(
+            modifier = Modifier.clearAndSetSemantics {
+                contentDescription = fullSubtitle
+            },
+            horizontalAlignment = Alignment.Start,
+        ) {
+            Overline(stringResource(R.string.trends_trailing), color = Palette.textTertiary)
+            Overline(
+                pluralStringResource(R.plurals.trends_n_days, days, days),
+                color = Palette.textTertiary,
+            )
+        }
+    }
 }
 
 // MARK: - Resolved metric (mirrors TrendsView.ResolvedMetric / resolve)

--- a/android/app/src/main/res/values-de/strings.xml
+++ b/android/app/src/main/res/values-de/strings.xml
@@ -93,6 +93,13 @@
     <!-- Trends / Explore / Deep Timeline , see the English values/strings.xml comment for scope.
          Wording matches the existing iOS/macOS German catalog entries where one exists. -->
     <string name="trends_subtitle">Der rote Faden deiner Zeit.</string>
+    <string name="trends_trailing">Letzte</string>
+    <string name="trends_trailing_days">Letzte %1$d Tage</string>
+    <string name="trends_all_history">Gesamter Verlauf</string>
+    <plurals name="trends_n_days">
+        <item quantity="one">%1$d Tag</item>
+        <item quantity="other">%1$d Tage</item>
+    </plurals>
     <string name="trends_charge">Ladung</string>
     <string name="trends_effort">Anstrengung</string>
     <string name="trends_rest">Ruhe</string>

--- a/android/app/src/main/res/values-es/strings.xml
+++ b/android/app/src/main/res/values-es/strings.xml
@@ -1596,6 +1596,13 @@
     <string name="terms_checkbox">He leído y acepto estos términos, y uso NOOP con mi propio dispositivo y mis propios datos, bajo mi propio riesgo.</string>
     <string name="terms_accept">Aceptar y continuar</string>
     <string name="trends_subtitle">El hilo de ti a lo largo del tiempo.</string>
+    <string name="trends_trailing">Últimos</string>
+    <string name="trends_trailing_days">Últimos %1$d días</string>
+    <string name="trends_all_history">Todo el historial</string>
+    <plurals name="trends_n_days">
+        <item quantity="one">%1$d día</item>
+        <item quantity="other">%1$d días</item>
+    </plurals>
     <string name="trends_charge">Carga</string>
     <string name="trends_effort">Esfuerzo</string>
     <string name="trends_rest">Descanso</string>

--- a/android/app/src/main/res/values-fr/strings.xml
+++ b/android/app/src/main/res/values-fr/strings.xml
@@ -1596,6 +1596,13 @@
     <string name="terms_checkbox">J\'ai lu et j\'accepte ces conditions, et j\'utilise NOOP avec mon propre appareil et mes propres données, à mes propres risques.</string>
     <string name="terms_accept">Accepter et continuer</string>
     <string name="trends_subtitle">Le fil de vous au fil du temps.</string>
+    <string name="trends_trailing">Derniers</string>
+    <string name="trends_trailing_days">%1$d derniers jours</string>
+    <string name="trends_all_history">Tout l’historique</string>
+    <plurals name="trends_n_days">
+        <item quantity="one">%1$d jour</item>
+        <item quantity="other">%1$d jours</item>
+    </plurals>
     <string name="trends_charge">Charge</string>
     <string name="trends_effort">Effort</string>
     <string name="trends_rest">Repos</string>

--- a/android/app/src/main/res/values-pt-rPT/strings.xml
+++ b/android/app/src/main/res/values-pt-rPT/strings.xml
@@ -82,6 +82,13 @@
     <string name="terms_checkbox">Li e aceito estes termos e estou a utilizar o NOOP com o meu próprio dispositivo e os meus próprios dados, por minha conta e risco.</string>
     <string name="terms_accept">Aceitar e continuar</string>
     <string name="trends_subtitle">O teu fio ao longo do tempo.</string>
+    <string name="trends_trailing">Últimos</string>
+    <string name="trends_trailing_days">Últimos %1$d dias</string>
+    <string name="trends_all_history">Todo o histórico</string>
+    <plurals name="trends_n_days">
+        <item quantity="one">%1$d dia</item>
+        <item quantity="other">%1$d dias</item>
+    </plurals>
     <string name="trends_charge">Carga</string>
     <string name="trends_effort">Esforço</string>
     <string name="trends_rest">Descanso</string>

--- a/android/app/src/main/res/values-zh/strings.xml
+++ b/android/app/src/main/res/values-zh/strings.xml
@@ -80,6 +80,12 @@
     <string name="terms_checkbox">我已阅读并接受上述条款，我正在使用我个人的设备和数据，风险由我自己承担。</string>
     <string name="terms_accept">接受并继续</string>
     <string name="trends_subtitle">时间长河中，你身体的轨迹。</string>
+    <string name="trends_trailing">近</string>
+    <string name="trends_trailing_days">近 %1$d 天</string>
+    <string name="trends_all_history">全部历史</string>
+    <plurals name="trends_n_days">
+        <item quantity="other">%1$d 天</item>
+    </plurals>
     <string name="trends_charge">充能</string>
     <string name="trends_effort">负荷</string>
     <string name="trends_rest">恢复</string>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -102,6 +102,13 @@
          hardcoded English throughout. Direct Compose copy and data-driven MetricSpec/TimelineMetric
          labels now live in resources; German wording follows the Apple catalogs where available. -->
     <string name="trends_subtitle">The thread of you over time.</string>
+    <string name="trends_trailing">Trailing</string>
+    <string name="trends_trailing_days">Trailing %1$d days</string>
+    <string name="trends_all_history">All history</string>
+    <plurals name="trends_n_days">
+        <item quantity="one">%1$d day</item>
+        <item quantity="other">%1$d days</item>
+    </plurals>
     <string name="trends_charge">Charge</string>
     <string name="trends_effort">Effort</string>
     <string name="trends_rest">Rest</string>


### PR DESCRIPTION
## What this PR improves

Improves layout consistency, readability, and use of space across Settings, Today, Trends, Sleep, and the weekly review, with Android parity for the Trends range control.

### Improvements

1. Combines Profile Photo and Profile into one Settings card to reduce vertical space while preserving choose, change, and remove actions.
2. Centers profile numeric values and keeps Weight, Height, Waist, and Max Heart Rate units visible.
3. Keeps Settings section chrome neutral and gives dividers consistent left and right insets.
4. Aligns shared page gutters, including Today, with the floating navigation bar.
5. Expands the Trends calendar legend so Depleted, the Charge scale, and Peaked use the full card width.
6. Keeps the Trends range caption readable, close to the selector, and anchored to the trailing content edge with its two lines internally aligned.
7. Adds a localized “Trend” label above directional change indicators.
8. Matches the Trends range-caption layout and localized copy on Android.
9. Reduces excess vertical space in the Sleep main-night footer.
10. Lets the Sleep stage-breakdown card size to its real content instead of reserving an empty shelf below the comparison hint.
11. Uses the open side of the Sleep Duration footer for a clearly labeled trend statistic.
12. Replaces touched layout literals with shared `NoopMetrics` tokens and localizes the new profile and Charge-scale copy.

`Palette.swift` is intentionally unchanged from `main`. The proposed global surface and hairline re-tint is no longer part of this PR.

## Why

Several screens used inconsistent spacing, alignment, and compact-card layouts for similar elements. These improvements move the touched layouts onto the shared design system and make better use of limited phone width without changing data, analytics, BLE, or persistence behavior.

## Type of change

- [x] Refactor / cleanup

## How it was tested

- `python3 Tools/i18n_audit.py --ci upstream/main`
- `swift test` in `Packages/StrandDesign` — 42 tests passed
- `xcodegen generate`
- Universal macOS `Strand` Debug build for arm64 and x86_64
- Full macOS `StrandTests` suite
- `NOOPiOS` Debug build for a generic iOS Simulator
- `./gradlew assembleFullDebug` on JDK 17
- `./gradlew testFullDebugUnitTest --rerun-tasks` on JDK 17
- `git diff --check upstream/main...HEAD`
- Confirmed `Palette.swift` has no diff from `upstream/main`

The Apple app builds and macOS test suite passed in the repository’s standard two-runner matrix on the [fork verification run](https://github.com/Quaii/noop/actions/runs/31311725409).

## Checklist

- [x] Swift package tests pass for the touched package
- [x] Android unit tests pass
- [x] No new build warnings introduced
- [x] UI changes use `StrandDesign` tokens — no new hardcoded colors, fonts, or spacing
- [x] No hardcoded hex frame bytes
- [x] Follows `docs/CONTRIBUTING.md`
- [x] No generated project output, secrets, keystores, or `local.properties` committed

## Related issues

None.
