### PR TITLE
oura: decode 0x81 cva_raw_ppg_data as Tier-B instrumentation

### DIFF
--- a/Packages/OuraProtocol/Sources/OuraProtocol/Decoders.swift
+++ b/Packages/OuraProtocol/Sources/OuraProtocol/Decoders.swift
@@ -515,4 +515,48 @@ public enum OuraDecoders {
         }
         return OuraActivityInfo(ringTimestamp: rec.ringTimestamp, state: Int(state), met: met)
     }
+
+    // MARK: - CVA raw PPG, delta + 24-bit absolute anchor (0x81; s6.14) - Tier B, third-party formula
+
+    /// Decode ONE `0x81` cva_raw_ppg_data record's delta/absolute-anchor byte stream into a running
+    /// sample series, given the running total carried in from the previous `0x81` record THIS SESSION
+    /// (`runningIn: nil` at session start or after a reset - see `OuraDriver`'s gap/ring-reset handling).
+    /// Formula (OURA_PROTOCOL.md s6.14, [open_ring], clean-room fact citation): byte `0x80` -> the next 3
+    /// bytes are a LE u24 ABSOLUTE value that re-syncs the running total; a byte with the MSB set
+    /// (`0x81`-`0xFF`) is a signed delta `byte - 0x100`; else (`0x00`-`0x7F`) a signed 7-bit delta
+    /// (`byte - 128` when `byte >= 64`, else `byte`) - both add onto the running total. `runningIn ?? 0`
+    /// starts the chain at 0 when no anchor has synced yet THIS session, the same non-guessing convention
+    /// `decodeSpO2DC` (0x77) already uses for its own delta-with-optional-base stream.
+    ///
+    /// SPLIT MARKER (honest, not a bug): a `0x80` marker with fewer than 3 trailing bytes in THIS record
+    /// means the absolute value would span into the NEXT BLE notification. Per this codebase's
+    /// one-packet-per-notification / no-cross-notification-buffering rule (`Framing.swift`), decoding
+    /// stops at the marker rather than guessing bytes from a notification that has not arrived yet -
+    /// samples already decoded from earlier in the record are still returned. Returns nil when the
+    /// payload is empty or the marker split leaves nothing to return.
+    public static func decodeCvaRawPPG(_ rec: OuraRecord, runningIn: Int?) -> (values: [Int], runningOut: Int)? {
+        let b = rec.payload
+        guard !b.isEmpty else { return nil }
+        var running = runningIn ?? 0
+        var out: [Int] = []
+        var i = 0
+        while i < b.count {
+            let byte = Int(b[i])
+            if byte == 0x80 {
+                guard i + 3 < b.count else { break }   // split marker across a notification boundary
+                running = u24le(b, i + 1)
+                out.append(running)
+                i += 4
+            } else if byte & 0x80 != 0 {
+                running += byte - 0x100
+                out.append(running)
+                i += 1
+            } else {
+                running += (byte >= 64) ? byte - 128 : byte
+                out.append(running)
+                i += 1
+            }
+        }
+        return out.isEmpty ? nil : (out, running)
+    }
 }

--- a/Packages/OuraProtocol/Sources/OuraProtocol/EventTags.swift
+++ b/Packages/OuraProtocol/Sources/OuraProtocol/EventTags.swift
@@ -80,13 +80,16 @@ public enum OuraEventTag: UInt8, Sendable, CaseIterable, Codable {
     // --- Smoothed SpO2 (Tier B, UNVERIFIED) ---
     case spo2Smoothed     = 0x70   // spo2_smoothed, OURA_PROTOCOL.md s6.6 (UNVERIFIED)
 
+    // --- Raw PPG (Tier B, UNVERIFIED) ---
+    case cvaRawPpg        = 0x81   // cva_raw_ppg_data (delta + 24-bit absolute), OURA_PROTOCOL.md s6.14 (UNVERIFIED)
+
     /// The trust tier for this tag. Tier B tags are decoded but the OuraDriver gates their emission
     /// behind an explicit allowTierB flag. Per OURA_PROTOCOL.md s7.3 and the brief's TIER DISCIPLINE.
     public var tier: TrustTier {
         switch self {
         case .sleepSummary1, .sleepSummaryC, .sleepSummaryD, .sleepSummaryE,
              .sleepSummaryF, .activityInfo, .activitySummary1, .activitySummary2,
-             .realSteps1, .realSteps2, .spo2Smoothed,
+             .realSteps1, .realSteps2, .spo2Smoothed, .cvaRawPpg,
              // #287: 0x71 green_ibi_and_amp is NOT corpus-verified — there is no captured 0x71 fixture,
              // and OURA_PROTOCOL.md §6.2 documents a DIFFERENT layout (5 IBI deltas + 6 amplitudes,
              // shift [2:0]) than the 0x60 decoder it was wired to (6 absolute IBIs, 4-bit shift). Decoding
@@ -137,6 +140,7 @@ public enum OuraEventTag: UInt8, Sendable, CaseIterable, Codable {
         case .realSteps1: return "REAL_STEPS_1"
         case .realSteps2: return "REAL_STEPS_2"
         case .spo2Smoothed: return "SPO2_SMOOTHED"
+        case .cvaRawPpg: return "CVA_RAW_PPG"
         }
     }
 }

--- a/Packages/OuraProtocol/Sources/OuraProtocol/OuraDriver.swift
+++ b/Packages/OuraProtocol/Sources/OuraProtocol/OuraDriver.swift
@@ -78,6 +78,16 @@ public final class OuraDriver {
     /// The freshly-provisioned key the transport generated during an adopt flow (s3.2). Once set by
     /// beginKeyInstall it becomes the effective key for the post-install re-auth. nil otherwise.
     private var installedKey: [UInt8]?
+    /// The 0x81 cva_raw_ppg_data running total, carried across records THIS SESSION (OURA_PROTOCOL.md
+    /// s6.14). nil until the first anchor/delta byte of the session, and after a reset (see
+    /// `cvaPpgLastRingTimestamp` below and the `.ringStart` / `stop()` handling).
+    private var cvaPpgRunning: Int?
+    /// The ring-time of the last decoded 0x81 record, used to detect the documented 60 s gap reset. nil
+    /// until the first 0x81 record of the session.
+    private var cvaPpgLastRingTimestamp: UInt32?
+    /// 60 s at the ring's default 100 ms/tick clock (OURA_PROTOCOL.md s5.5) - the documented CVA-PPG
+    /// accumulator reset window (s6.14).
+    private static let cvaPpgGapResetTicks: UInt32 = 600
 
     /// The key the auth handshake should use: the freshly-installed key takes precedence over the
     /// injected one (so re-auth after a key install uses the new key). Per OURA_PROTOCOL.md s3.2.
@@ -211,6 +221,8 @@ public final class OuraDriver {
         installedKey = nil
         anchorUtcMs = nil
         anchorRingTime = nil
+        cvaPpgRunning = nil
+        cvaPpgLastRingTimestamp = nil
     }
 
     // MARK: - Ring-time -> UTC anchor (s5.5)
@@ -382,6 +394,12 @@ public final class OuraDriver {
             // 0x41 ring_start_ind: a lifecycle marker (the app uses it to invalidate the UTC anchor on
             // rt regression). It carries no biometric value, so emit nothing here. Per OURA_PROTOCOL.md
             // s5.5 / s6.15. The app observes ring-start via the record stream directly.
+            // Also the closest wire signal to the 0x81 spec's documented "ring-reset ack" (s6.14) - a
+            // best-current-interpretation, not a wire-confirmed mapping, since no distinct reset-ack
+            // opcode is documented. Invalidate the CVA-PPG running total so a stale baseline never
+            // survives a real ring reboot.
+            cvaPpgRunning = nil
+            cvaPpgLastRingTimestamp = nil
             return []
 
         // --- Tier B (only reached when allowTierB == true; otherwise dropped above) ---
@@ -412,6 +430,24 @@ public final class OuraDriver {
         case .spo2Smoothed:
             return [.tierB(OuraTierBSummary(tag: record.type, ringTimestamp: record.ringTimestamp,
                                             rawPayload: record.payload, kind: "spo2_smoothed"))]
+        case .cvaRawPpg:
+            // Split out of the raw-bytes .tierB wrapper, same as .activityInfo: this ONE tag has a
+            // plausible decode formula (OuraDecoders.decodeCvaRawPPG, third-party [open_ring]). Still
+            // Tier B - only reached behind allowTierB (gated above), and OuraStreamMapping never folds
+            // .cvaRawPpg into a durable stream. A 60 s gap (or a ring-reset, s6.14) invalidates the
+            // running total BEFORE this record is decoded, so a stale accumulator never leaks across a
+            // real session break; an out-of-order re-serve (rt regression) is treated the same as a gap.
+            let gap: UInt32
+            if let last = cvaPpgLastRingTimestamp {
+                gap = record.ringTimestamp >= last ? record.ringTimestamp - last : last - record.ringTimestamp
+                if gap > Self.cvaPpgGapResetTicks { cvaPpgRunning = nil }
+            }
+            cvaPpgLastRingTimestamp = record.ringTimestamp
+            guard let (values, next) = OuraDecoders.decodeCvaRawPPG(record, runningIn: cvaPpgRunning) else {
+                return []
+            }
+            cvaPpgRunning = next
+            return [.cvaRawPpg(OuraCvaPpg(ringTimestamp: record.ringTimestamp, values: values))]
         }
     }
 

--- a/Packages/OuraProtocol/Sources/OuraProtocol/OuraEvents.swift
+++ b/Packages/OuraProtocol/Sources/OuraProtocol/OuraEvents.swift
@@ -221,6 +221,24 @@ public struct OuraActivityInfo: Equatable, Sendable, Codable {
     }
 }
 
+/// One decoded `0x81` cva_raw_ppg_data record: a running, dimensionless ADC-like PPG count reconstructed
+/// from the ring's delta/absolute-anchor byte stream (OURA_PROTOCOL.md s6.14). THIRD-PARTY FORMULA
+/// ([open_ring], clean-room fact citation, no code copied): a marker byte `0x80` re-syncs a running total
+/// from the next 3 bytes (LE u24); every other byte is a delta walked forward from that total (MSB-set =
+/// `byte-0x100`, else signed 7-bit). Validated on a 2169-record real Gen 3 capture (2026-07-30): the
+/// reconstructed series is smooth (median sample-to-sample jump 33, baseline ~390-400K) — consistent with
+/// a real PPG channel — with rare (4-of-22745) anomalous jumps AT an absolute-anchor byte, not yet
+/// explained. NOT independently ground-truth-validated against a known PPG channel, so this stays Tier B
+/// end to end: emitted only behind `OuraDriver.allowTierB`, and NEVER folded into `OuraStreamMapping`/
+/// scoring. `values` holds every sample this ONE record contributed to the running total, in wire order.
+public struct OuraCvaPpg: Equatable, Sendable, Codable {
+    public let ringTimestamp: UInt32
+    public let values: [Int]
+    public init(ringTimestamp: UInt32, values: [Int]) {
+        self.ringTimestamp = ringTimestamp; self.values = values
+    }
+}
+
 // MARK: - The emitted event union
 
 /// What OuraDriver.ingest(record:) emits. A single record can yield several events (e.g. an IBI+amp
@@ -251,11 +269,16 @@ public enum OuraEvent: Equatable, Sendable {
     /// formula, so an investigating consumer can log real MET numbers instead of hex. Same gate
     /// (`allowTierB`), same discipline (never reaches `OuraStreamMapping`).
     case activityInfo(OuraActivityInfo)
+    /// A decoded `0x81` cva_raw_ppg_data record (running PPG count series). Still Tier-B (see
+    /// `OuraCvaPpg` doc) - split out of the raw-bytes `.tierB` wrapper for the same reason `.activityInfo`
+    /// was: a plausible decode formula worth surfacing as real numbers instead of hex. Same gate
+    /// (`allowTierB`), same discipline (never reaches `OuraStreamMapping`).
+    case cvaRawPpg(OuraCvaPpg)
 
     /// True for Tier-B events, so a consumer can assert none leaked into a Tier-A-only sink.
     public var isTierB: Bool {
         switch self {
-        case .tierB, .activityInfo: return true
+        case .tierB, .activityInfo, .cvaRawPpg: return true
         default: return false
         }
     }
@@ -280,6 +303,7 @@ public enum OuraEvent: Equatable, Sendable {
         case .debugText(let rt, _): return rt
         case .tierB(let v): return v.ringTimestamp
         case .activityInfo(let v): return v.ringTimestamp
+        case .cvaRawPpg(let v): return v.ringTimestamp
         }
     }
 }

--- a/Packages/OuraProtocol/Sources/oura-decode/main.swift
+++ b/Packages/OuraProtocol/Sources/oura-decode/main.swift
@@ -153,6 +153,7 @@ func describe(_ e: OuraEvent) -> String {
     case .debugText(_, let t): return "DEBUG \(t)"
     case .tierB(let v): return "TIER_B[UNVERIFIED] tag=0x\(String(v.tag, radix: 16)) kind=\(v.kind) bytes=\(v.rawPayload.count)"
     case .activityInfo(let v): return "ACTIVITY[TIER-B,UNVERIFIED] state=\(v.state) met=\(v.met) rt=\(v.ringTimestamp)"
+    case .cvaRawPpg(let v): return "CVA_PPG[TIER-B,UNVERIFIED] values=\(v.values) rt=\(v.ringTimestamp)"
     }
 }
 

--- a/Packages/OuraProtocol/Tests/OuraProtocolTests/OuraDriverTests.swift
+++ b/Packages/OuraProtocol/Tests/OuraProtocolTests/OuraDriverTests.swift
@@ -464,6 +464,104 @@ final class OuraDriverTests: XCTestCase {
             OuraRecord(type: OuraEventTag.activityInfo.rawValue, ringTimestamp: rt, payload: [])))
     }
 
+    // MARK: - CVA raw PPG (0x81, Tier B, third-party formula) - real Gen 3 capture (2026-07-30)
+    //
+    // The three payloads below are byte-for-byte three CONSECUTIVE 0x81 records from a real Gen 3
+    // capture (2026-07-30, ring times 3584349-3584351). Expected values are RECOMPUTED from the s6.14
+    // formula (marker 0x80 -> LE u24 absolute; MSB-set byte -> signed byte-0x100 delta; else signed
+    // 7-bit delta), not copied blind. Record 0 also happens to end on a real split marker (a `0x80` at
+    // payload offset 12 with only 1 trailing byte) - genuine capture evidence for the honest-drop path,
+    // not a constructed edge case.
+
+    func testCvaRawPPGDecodesRealCaptureChain() {
+        // Record 0: three back-to-back absolute anchors, then a split marker (payload offset 12) with
+        // only one trailing byte - decoding honestly stops there instead of guessing into record 1.
+        let rec0 = OuraRecord(type: OuraEventTag.cvaRawPpg.rawValue, ringTimestamp: 3_584_349,
+                              payload: bytes("800707068079060680b705068003"))
+        let step0 = OuraDecoders.decodeCvaRawPPG(rec0, runningIn: nil)
+        XCTAssertEqual(step0?.values, [395015, 394873, 394679])
+        XCTAssertEqual(step0?.runningOut, 394679)
+
+        // Record 1 continues the chain from record 0's running total (no anchor of its own).
+        let rec1 = OuraRecord(type: OuraEventTag.cvaRawPpg.rawValue, ringTimestamp: 3_584_350,
+                              payload: bytes("0506804604068090030680f00206"))
+        let step1 = OuraDecoders.decodeCvaRawPPG(rec1, runningIn: step0?.runningOut)
+        XCTAssertEqual(step1?.values, [394684, 394690, 394310, 394128, 393968])
+        XCTAssertEqual(step1?.runningOut, 393968)
+
+        // Record 2 continues from record 1.
+        let rec2 = OuraRecord(type: OuraEventTag.cvaRawPpg.rawValue, ringTimestamp: 3_584_351,
+                              payload: bytes("80300206809b0106800a010694ab"))
+        let step2 = OuraDecoders.decodeCvaRawPPG(rec2, runningIn: step1?.runningOut)
+        XCTAssertEqual(step2?.values, [393776, 393627, 393482, 393374, 393289])
+        XCTAssertEqual(step2?.runningOut, 393289)
+    }
+
+    func testCvaRawPPGSplitMarkerStopsHonestly() {
+        // Same record 0 as above, decoded standalone (runningIn: nil): the trailing split marker at
+        // payload offset 12 (only 1 of the needed 3 trailing bytes present) must not be guessed across
+        // into the next notification (Framing.swift's one-packet-per-notification rule) - decoding stops
+        // there and returns only the 3 samples that decoded cleanly.
+        let rec = OuraRecord(type: OuraEventTag.cvaRawPpg.rawValue, ringTimestamp: 3_584_349,
+                             payload: bytes("800707068079060680b705068003"))
+        let step = OuraDecoders.decodeCvaRawPPG(rec, runningIn: nil)
+        XCTAssertEqual(step?.values, [395015, 394873, 394679])
+    }
+
+    func testCvaRawPPGThroughDriverChainsAcrossRecords() {
+        let d = OuraDriver(ringGen: .gen3, authKey: key, allowTierB: true)
+        let rec0 = OuraRecord(type: OuraEventTag.cvaRawPpg.rawValue, ringTimestamp: 3_584_349,
+                              payload: bytes("800707068079060680b705068003"))
+        XCTAssertEqual(d.ingest(record: rec0),
+                       [.cvaRawPpg(OuraCvaPpg(ringTimestamp: 3_584_349, values: [395015, 394873, 394679]))])
+
+        let rec1 = OuraRecord(type: OuraEventTag.cvaRawPpg.rawValue, ringTimestamp: 3_584_350,
+                              payload: bytes("0506804604068090030680f00206"))
+        let events1 = d.ingest(record: rec1)
+        XCTAssertEqual(events1,
+            [.cvaRawPpg(OuraCvaPpg(ringTimestamp: 3_584_350,
+                                   values: [394684, 394690, 394310, 394128, 393968]))])
+        XCTAssertTrue(events1[0].isTierB, "cvaRawPpg must still report isTierB - the formula is UNVERIFIED")
+    }
+
+    func testCvaRawPPGGapResetsRunningTotal() {
+        let d = OuraDriver(ringGen: .gen3, authKey: key, allowTierB: true)
+        // First record anchors the running total via a 0x80 marker.
+        let rec0 = OuraRecord(type: OuraEventTag.cvaRawPpg.rawValue, ringTimestamp: 1000,
+                              payload: [0x80, 0x10, 0x00, 0x00])   // absolute = 0x000010 = 16
+        XCTAssertEqual(d.ingest(record: rec0), [.cvaRawPpg(OuraCvaPpg(ringTimestamp: 1000, values: [16]))])
+
+        // Second record arrives 601 ticks later (> the 60s/600-tick reset window) with a plain +5 delta.
+        // Without the gap reset this would read 16+5=21; the reset makes it start fresh from 0.
+        let rec1 = OuraRecord(type: OuraEventTag.cvaRawPpg.rawValue, ringTimestamp: 1601, payload: [0x05])
+        XCTAssertEqual(d.ingest(record: rec1), [.cvaRawPpg(OuraCvaPpg(ringTimestamp: 1601, values: [5]))])
+    }
+
+    func testCvaRawPPGRingStartResetsRunningTotal() {
+        let d = OuraDriver(ringGen: .gen3, authKey: key, allowTierB: true)
+        let rec0 = OuraRecord(type: OuraEventTag.cvaRawPpg.rawValue, ringTimestamp: 1000,
+                              payload: [0x80, 0x10, 0x00, 0x00])   // absolute = 16
+        XCTAssertEqual(d.ingest(record: rec0), [.cvaRawPpg(OuraCvaPpg(ringTimestamp: 1000, values: [16]))])
+
+        // A 0x41 ring_start_ind (well within the gap window) must still invalidate the running total.
+        let ringStart = OuraRecord(type: OuraEventTag.ringStart.rawValue, ringTimestamp: 1010, payload: [])
+        XCTAssertEqual(d.ingest(record: ringStart), [])
+
+        let rec1 = OuraRecord(type: OuraEventTag.cvaRawPpg.rawValue, ringTimestamp: 1020, payload: [0x05])
+        XCTAssertEqual(d.ingest(record: rec1), [.cvaRawPpg(OuraCvaPpg(ringTimestamp: 1020, values: [5]))])
+    }
+
+    func testCvaRawPPGDroppedByDefaultLikeOtherTierB() {
+        let d = OuraDriver(ringGen: .gen3, authKey: key)   // allowTierB defaults to false
+        let rec = OuraRecord(type: OuraEventTag.cvaRawPpg.rawValue, ringTimestamp: rt, payload: [0x05])
+        XCTAssertEqual(d.ingest(record: rec), [], "the Tier-B gate must cover .cvaRawPpg too")
+    }
+
+    func testCvaRawPPGEmptyPayloadDecodesToNil() {
+        XCTAssertNil(OuraDecoders.decodeCvaRawPPG(
+            OuraRecord(type: OuraEventTag.cvaRawPpg.rawValue, ringTimestamp: rt, payload: []), runningIn: nil))
+    }
+
     // MARK: - Live-HR push routing + decode
 
     func testHandleSecureFrameRoutesNonceStatusAndPush() {

--- a/Packages/WhoopStore/Sources/WhoopStore/OuraCvaPpgDumpLine.swift
+++ b/Packages/WhoopStore/Sources/WhoopStore/OuraCvaPpgDumpLine.swift
@@ -1,0 +1,28 @@
+import Foundation
+
+/// Pure, deterministic encoder for ONE line of the Oura CVA raw-PPG (0x81) research corpus — a
+/// diagnostic JSONL sidecar, NOT a datastore row.
+///
+/// WHY a sidecar and not a stream/table: the 0x81 decode is Tier-B (a plausible third-party
+/// delta/absolute-anchor formula, not ground-truth-validated — OURA_PROTOCOL.md s6.14). The
+/// honest-data invariant forbids Tier-B ever minting a durable scoring row, so it must never touch
+/// `Streams`/SQLite. This corpus is a separate, clearly-labeled file the app appends to purely so the
+/// reconstructed PPG series can be accumulated for offline investigation (does it correlate with a
+/// known PPG channel? do the rare anchor anomalies recur?). It never feeds scoring and is safe to
+/// delete. Parallels `OuraActivityDumpLine` / `OuraMotionDumpLine`.
+public enum OuraCvaPpgDumpLine {
+    /// Bump when the record shape changes so a downstream reader can branch on `schema`.
+    public static let schema = 1
+
+    /// One JSONL record (NO trailing newline — the writer adds it). `deviceId` is a controlled registry id
+    /// (e.g. `oura-<serial>`) and `iso` is app-generated, so neither needs JSON string-escaping here.
+    ///   - ringTs: the record's raw ring-clock timestamp (the dedup key: strictly increases per record).
+    ///   - utc:    the anchored wall-clock (unix seconds) for the record envelope.
+    ///   - iso:    human-readable UTC of `utc` (convenience for eyeballing).
+    ///   - values: the decoded running-total PPG series this ONE record contributed, verbatim.
+    public static func encode(deviceId: String, ringTs: UInt32, utc: Int, iso: String, values: [Int]) -> String {
+        let valuesStr = values.map { String($0) }.joined(separator: ",")
+        return "{\"schema\":\(schema),\"deviceId\":\"\(deviceId)\",\"ringTs\":\(ringTs),"
+             + "\"utc\":\(utc),\"iso\":\"\(iso)\",\"values\":[\(valuesStr)]}"
+    }
+}

--- a/Packages/WhoopStore/Sources/WhoopStore/OuraStreamMapping.swift
+++ b/Packages/WhoopStore/Sources/WhoopStore/OuraStreamMapping.swift
@@ -131,10 +131,10 @@ public enum OuraStreamMapping {
                 if let hi = m.highIntensity { payload["high_intensity"] = .int(hi) }
                 out.events.append(WhoopEvent(ts: ts, kind: motionEventKind, payload: payload))
 
-            case .motion, .state, .timeSync, .rtcBeacon, .debugText, .tierB, .activityInfo:
+            case .motion, .state, .timeSync, .rtcBeacon, .debugText, .tierB, .activityInfo, .cvaRawPpg:
                 // Not a durable per-device stream row (timeSync/rtcBeacon anchor the transport's clock;
-                // motion/state/debug are diagnostics; Tier-B / .activityInfo are UNVERIFIED and must
-                // never feed scoring or the steps stream).
+                // motion/state/debug are diagnostics; Tier-B / .activityInfo / .cvaRawPpg are UNVERIFIED
+                // and must never feed scoring or the steps stream).
                 continue
             }
         }

--- a/Packages/WhoopStore/Tests/WhoopStoreTests/OuraCvaPpgDumpLineTests.swift
+++ b/Packages/WhoopStore/Tests/WhoopStoreTests/OuraCvaPpgDumpLineTests.swift
@@ -1,0 +1,20 @@
+import XCTest
+@testable import WhoopStore
+
+final class OuraCvaPpgDumpLineTests: XCTestCase {
+    func testEncodeFixedKeyOrderAndValues() {
+        let line = OuraCvaPpgDumpLine.encode(
+            deviceId: "oura-2H3B2405003655", ringTs: 3_584_349, utc: 1_753_440_000,
+            iso: "2026-07-30T09:09:01Z", values: [395015, 394873, 394679])
+        XCTAssertEqual(line,
+            "{\"schema\":1,\"deviceId\":\"oura-2H3B2405003655\",\"ringTs\":3584349,"
+          + "\"utc\":1753440000,\"iso\":\"2026-07-30T09:09:01Z\",\"values\":[395015,394873,394679]}")
+    }
+
+    func testEncodeEmptyValuesIsValidJSON() throws {
+        let line = OuraCvaPpgDumpLine.encode(deviceId: "oura-x", ringTs: 1, utc: 2, iso: "i", values: [])
+        let obj = try JSONSerialization.jsonObject(with: Data(line.utf8)) as? [String: Any]
+        XCTAssertEqual(obj?["schema"] as? Int, OuraCvaPpgDumpLine.schema)
+        XCTAssertEqual((obj?["values"] as? [Any])?.count, 0)
+    }
+}

--- a/Packages/WhoopStore/Tests/WhoopStoreTests/OuraStreamMappingTests.swift
+++ b/Packages/WhoopStore/Tests/WhoopStoreTests/OuraStreamMappingTests.swift
@@ -163,6 +163,9 @@ final class OuraStreamMappingTests: XCTestCase {
             // 0x50 activity/MET (PR #960): decoded but Tier-B/unvalidated - in particular it must never
             // mint a `steps` row (MET is not a step count; the per-source day-owner rules stay intact).
             .activityInfo(OuraActivityInfo(ringTimestamp: 100, state: 0x41, met: [1.8, 1.9])),
+            // 0x81 CVA raw PPG: decoded but Tier-B/unvalidated (third-party [open_ring] formula) - must
+            // never leak a value into a durable stream either.
+            .cvaRawPpg(OuraCvaPpg(ringTimestamp: 100, values: [395015, 394873])),
         ], at: ts)
         XCTAssertTrue(s.isEmpty, "Tier-B and diagnostic events must not produce any durable stream row")
         XCTAssertTrue(s.steps.isEmpty, "activity/MET must never fabricate a steps row")

--- a/Strand/BLE/OuraCvaPpgDump.swift
+++ b/Strand/BLE/OuraCvaPpgDump.swift
@@ -1,0 +1,110 @@
+import Foundation
+import WhoopStore
+
+/// Append-only JSONL sidecar for the Oura 0x81 cva_raw_ppg_data stream — a Tier-B RESEARCH corpus for
+/// investigation, NOT a datastore row (see `OuraCvaPpgDumpLine` for the rationale). Direct twin of
+/// `OuraActivityDump` / `OuraMotionDump`: owns the file handle, the on-disk path, the once-per-launch
+/// "here is the file" log line, and a persistent ring-time high-water so records the ring re-serves
+/// across reconnects are written exactly once instead of duplicating the corpus.
+///
+/// Location: `<Application Support>/OpenWhoop/Diagnostics/oura-cva-ppg-<deviceId>.jsonl` — beside the
+/// app's SQLite so the user can find it. Purely diagnostic and safe to delete; nothing reads it back. It
+/// exists so the reconstructed PPG series (OURA_PROTOCOL.md s6.14, third-party [open_ring] formula) can
+/// be studied offline before any decision to promote it out of Tier B.
+final class OuraCvaPpgDump {
+    private let deviceId: String
+    private let log: (String) -> Void
+    private let highWaterKey: String
+    /// Only records with `ringTs` STRICTLY above this are written; re-served (older) records are dropped.
+    /// Persisted in UserDefaults so the dedup survives app relaunches (a fresh drain re-emits old records).
+    private var highWater: UInt32
+    private var fileURL: URL?
+    private var resolveFailed = false
+    private var announced = false
+
+    /// Rotate the sidecar past this size (keeping one previous ".1"), so an always-on research corpus is
+    /// bounded to ~2× this on disk instead of growing forever. Matches `OuraMotionDump`/`OuraActivityDump`.
+    private static let maxBytes = 25 * 1024 * 1024
+
+    private static let iso: ISO8601DateFormatter = {
+        let f = ISO8601DateFormatter()
+        f.timeZone = TimeZone(identifier: "UTC")
+        return f
+    }()
+
+    init(deviceId: String, log: @escaping (String) -> Void) {
+        self.deviceId = deviceId
+        self.log = log
+        self.highWaterKey = "oura.cvaPpgDump.highwater.\(deviceId)"
+        let stored = UserDefaults.standard.integer(forKey: highWaterKey)   // 0 when unset → writes everything
+        self.highWater = stored > 0 ? UInt32(truncatingIfNeeded: stored) : 0
+    }
+
+    /// Append one anchored CVA-PPG record. No-op when `ringTs` is not above the high-water (a re-serve),
+    /// so the corpus stays deduped. Best-effort: any file error is logged once and never disrupts the
+    /// BLE path. Call ONLY with an anchored `utc` (an un-anchored record has no real time axis and
+    /// re-arrives anchored on the next drain).
+    func record(ringTs: UInt32, utc: Int, values: [Int]) {
+        guard ringTs > highWater else { return }
+        guard var url = resolveURL() else { return }
+        // Bound the corpus (rotate to a single ".1", dropping the prior one) so an always-on research
+        // sidecar can't grow unbounded — same rotation as OuraMotionDump/OuraActivityDump. Read the size
+        // via a fresh FileManager stat rather than URL.resourceValues, whose cache on the reused URL can
+        // return a stale small size.
+        let size = ((try? FileManager.default.attributesOfItem(atPath: url.path))?[.size] as? Int) ?? 0
+        if size > Self.maxBytes {
+            let old = url.deletingLastPathComponent().appendingPathComponent(url.lastPathComponent + ".1")
+            try? FileManager.default.removeItem(at: old)
+            try? FileManager.default.moveItem(at: url, to: old)
+            fileURL = nil
+            guard let fresh = resolveURL() else { return }
+            url = fresh
+        }
+
+        let line = OuraCvaPpgDumpLine.encode(
+            deviceId: deviceId, ringTs: ringTs, utc: utc,
+            iso: Self.iso.string(from: Date(timeIntervalSince1970: TimeInterval(utc))), values: values)
+
+        guard let data = (line + "\n").data(using: .utf8) else { return }
+        do {
+            let handle = try FileHandle(forWritingTo: url)
+            defer { try? handle.close() }
+            try handle.seekToEnd()
+            handle.write(data)
+        } catch {
+            log("Oura: CVA-PPG dump write failed - \(error.localizedDescription)")
+            return
+        }
+
+        highWater = ringTs
+        UserDefaults.standard.set(Int(ringTs), forKey: highWaterKey)
+        if !announced {
+            announced = true
+            log("Oura: CVA raw-PPG 0x81 dump → \(url.path) [Tier-B research corpus, JSONL, deduped by ring-time]")
+        }
+    }
+
+    /// Resolve (and create on first use) the sidecar file + its parent directory. Cached; a failure is
+    /// logged once and latched so we never spam the strap log on a read-only volume.
+    private func resolveURL() -> URL? {
+        if let fileURL { return fileURL }
+        if resolveFailed { return nil }
+        do {
+            let base = try FileManager.default.url(for: .applicationSupportDirectory, in: .userDomainMask,
+                                                   appropriateFor: nil, create: true)
+            let dir = base.appendingPathComponent("OpenWhoop/Diagnostics", isDirectory: true)
+            try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+            let safeId = deviceId.replacingOccurrences(of: "/", with: "_")
+            let url = dir.appendingPathComponent("oura-cva-ppg-\(safeId).jsonl")
+            if !FileManager.default.fileExists(atPath: url.path) {
+                FileManager.default.createFile(atPath: url.path, contents: nil)
+            }
+            fileURL = url
+            return url
+        } catch {
+            resolveFailed = true
+            log("Oura: CVA-PPG dump unavailable - \(error.localizedDescription)")
+            return nil
+        }
+    }
+}

--- a/Strand/BLE/OuraLiveSource.swift
+++ b/Strand/BLE/OuraLiveSource.swift
@@ -268,6 +268,9 @@ public final class OuraLiveSource: NSObject, ObservableObject {
     private let activityDump: OuraActivityDump?
     /// Append-only JSONL sidecar for the 0x47 motion vectors (Tier-A), for offline LSB→g calibration (#804).
     private let motionDump: OuraMotionDump?
+    /// Append-only JSONL research corpus for the reconstructed 0x81 CVA raw-PPG series (Tier-B, third-party
+    /// [open_ring] formula, never scored/persisted to SQLite). See OuraCvaPpgDump.
+    private let cvaPpgDump: OuraCvaPpgDump?
     /// Append-only JSONL capture of the RAW, undecoded history-drain notification bytes (`oura-raw-<id>.jsonl`).
     /// Complement to the decoded sidecars above: those show what NOOP interpreted, this shows exactly what the
     /// ring sent, so after a full connect a hole in a decoded file can be pinned as a decode drop vs ring-side.
@@ -781,6 +784,8 @@ public final class OuraLiveSource: NSObject, ObservableObject {
         self.activityDump = feedsLive && !deviceId.isEmpty ? OuraActivityDump(deviceId: deviceId, log: log) : nil
         // 0x47 motion calibration corpus: same gate as the activity dump (live/persisting source only).
         self.motionDump = feedsLive && !deviceId.isEmpty ? OuraMotionDump(deviceId: deviceId, log: log) : nil
+        // 0x81 CVA raw-PPG research corpus: same gate as the activity/motion dumps.
+        self.cvaPpgDump = feedsLive && !deviceId.isEmpty ? OuraCvaPpgDump(deviceId: deviceId, log: log) : nil
         // RAW undecoded history-drain capture: same live/persisting gate; complements the decoded sidecars.
         self.rawDump = feedsLive && !deviceId.isEmpty ? OuraRawDump(deviceId: deviceId, log: log) : nil
         super.init()
@@ -1372,6 +1377,21 @@ public final class OuraLiveSource: NSObject, ObservableObject {
                     }
                     lastActivityUtc = utc
                     lastActivitySampleCount = info.met.count
+                }
+
+            case .cvaRawPpg(let ppg):
+                // INVESTIGATION ONLY (0x81 CVA raw PPG, Tier B - a plausible third-party [open_ring]
+                // formula, NOT ground-truth-validated; see OuraCvaPpg). Logged once per kind (like the
+                // other raw Tier-B tags) rather than every occurrence - this stream runs at a much higher
+                // rate than 0x50 MET, so the JSONL corpus is the real record; the strap log just confirms
+                // the ring sends it at all. Never persisted, never scored (OuraStreamMapping drops
+                // .cvaRawPpg unconditionally).
+                if !loggedTierBKinds.contains("cva_raw_ppg") {
+                    loggedTierBKinds.insert("cva_raw_ppg")
+                    log("Oura: Tier-B cva_raw_ppg seen (tag 0x81) - first values: \(ppg.values)")
+                }
+                if let utc = driver.unixSeconds(forRingTimestamp: ppg.ringTimestamp) {
+                    cvaPpgDump?.record(ringTs: ppg.ringTimestamp, utc: utc, values: ppg.values)
                 }
 
             case .state(let s):

--- a/android/app/src/main/java/com/noop/ble/OuraCvaPpgDump.kt
+++ b/android/app/src/main/java/com/noop/ble/OuraCvaPpgDump.kt
@@ -1,0 +1,101 @@
+package com.noop.ble
+
+import android.content.Context
+import com.noop.oura.OuraCvaPpgDumpLine
+import java.io.File
+import java.time.Instant
+
+/**
+ * Append-only JSONL sidecar for the Oura 0x81 cva_raw_ppg_data stream — the Kotlin twin of Swift
+ * `OuraCvaPpgDump`. A Tier-B RESEARCH corpus for investigation, never a datastore row (see
+ * [OuraCvaPpgDumpLine] for the rationale). Owns the file, the once-per-launch "here is the file" log
+ * line, and a persistent ring-time high-water so records the ring re-serves across reconnects are
+ * written exactly once instead of duplicating the corpus.
+ *
+ * Location: `<filesDir>/diagnostics/oura-cva-ppg-<deviceId>.jsonl` (app-private). Purely diagnostic
+ * and safe to delete; nothing reads it back. It exists so the reconstructed PPG series
+ * (OURA_PROTOCOL.md s6.14, third-party [open_ring] formula) can be studied offline before any
+ * decision to promote it out of Tier B. The LINE content is byte-identical to the Swift corpus —
+ * that is the parity-relevant part.
+ */
+class OuraCvaPpgDump(
+    context: Context,
+    private val deviceId: String,
+    private val log: (String) -> Unit,
+) {
+    private val appContext = context.applicationContext
+    private val prefs = appContext.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+    private val highWaterKey = "highwater.$deviceId"
+
+    /** Only records with `ringTs` STRICTLY above this are written; re-served (older) records are dropped.
+     *  Persisted so the dedup survives relaunches (a fresh drain re-emits old records). */
+    private var highWater: Long = prefs.getLong(highWaterKey, 0L)
+    private var file: File? = null
+    private var resolveFailed = false
+    private var announced = false
+
+    /**
+     * Append one anchored CVA-PPG record. No-op when [ringTs] is not above the high-water (a
+     * re-serve), so the corpus stays deduped. Best-effort: any file error is logged once and never
+     * disrupts the BLE path. Call ONLY with an anchored [utc].
+     */
+    fun record(ringTs: Long, utc: Long, values: List<Int>) {
+        if (ringTs <= highWater) return
+        var f = resolveFile() ?: return
+        // Bound the corpus so it can't grow unbounded (always-on for every paired ring). At the cap, rotate
+        // to a single ".1" (dropping the prior one) and continue in a fresh file — same as OuraMotionDump.
+        if (f.length() > MAX_BYTES) {
+            runCatching {
+                val old = File(f.parentFile, "${f.name}.1")
+                old.delete()
+                f.renameTo(old)
+            }
+            file = null
+            f = resolveFile() ?: return
+        }
+
+        val line = OuraCvaPpgDumpLine.encode(
+            deviceId = deviceId, ringTs = ringTs, utc = utc,
+            iso = Instant.ofEpochSecond(utc).toString(), values = values,
+        )
+        try {
+            f.appendText(line + "\n")
+        } catch (e: Exception) {
+            log("Oura: CVA-PPG dump write failed - ${e.message}")
+            return
+        }
+
+        highWater = ringTs
+        prefs.edit().putLong(highWaterKey, ringTs).apply()
+        if (!announced) {
+            announced = true
+            log("Oura: CVA raw-PPG 0x81 dump → ${f.absolutePath} [Tier-B research corpus, JSONL, deduped by ring-time]")
+        }
+    }
+
+    /** Resolve (and create on first use) the sidecar file + its parent directory. Cached; a failure is
+     *  logged once and latched so we never spam the strap log on a read-only volume. */
+    private fun resolveFile(): File? {
+        file?.let { return it }
+        if (resolveFailed) return null
+        return try {
+            val dir = File(appContext.filesDir, "diagnostics").apply { mkdirs() }
+            val safeId = deviceId.replace("/", "_")
+            File(dir, "oura-cva-ppg-$safeId.jsonl").also {
+                if (!it.exists()) it.createNewFile()
+                file = it
+            }
+        } catch (e: Exception) {
+            resolveFailed = true
+            log("Oura: CVA-PPG dump unavailable - ${e.message}")
+            null
+        }
+    }
+
+    private companion object {
+        const val PREFS_NAME = "oura_cva_ppg_dump"
+
+        /** Rotate the sidecar past this size (keeping one previous ".1"), bounding it to ~2× on disk. */
+        const val MAX_BYTES = 25L * 1024 * 1024
+    }
+}

--- a/android/app/src/main/java/com/noop/ble/OuraLiveSource.kt
+++ b/android/app/src/main/java/com/noop/ble/OuraLiveSource.kt
@@ -249,6 +249,11 @@ class OuraLiveSource(
      *  of the Swift `OuraMotionDump`. Null when there is no device id. */
     private val motionDump: OuraMotionDump? =
         if (deviceId.isNotEmpty()) OuraMotionDump(appContext, deviceId, log) else null
+
+    /** 0x81 CVA raw-PPG research corpus (Tier-B), for offline investigation. Kotlin twin of the Swift
+     *  `OuraCvaPpgDump`. Null when there is no device id. */
+    private val cvaPpgDump: OuraCvaPpgDump? =
+        if (deviceId.isNotEmpty()) OuraCvaPpgDump(appContext, deviceId, log) else null
     private val scanner: BluetoothLeScanner? get() = adapter?.bluetoothLeScanner
 
     private var gatt: BluetoothGatt? = null
@@ -1720,6 +1725,20 @@ class OuraLiveSource(
                         ringTs = e.value.ringTimestamp, utc = utc, state = e.value.state,
                         secPerSample = 60, met = e.value.met, // 60 s = assumed MET cadence (s6.13)
                     )
+                }
+            }
+            is OuraEvent.CvaRawPpg -> {
+                // INVESTIGATION ONLY (0x81 CVA raw PPG, Tier B - a plausible third-party [open_ring]
+                // formula, NOT ground-truth-validated; see OuraCvaPpg). Logged once per kind (like the
+                // other raw Tier-B tags) rather than every occurrence - this stream runs at a much higher
+                // rate than 0x50 MET, so the JSONL corpus is the real record; the strap log just confirms
+                // the ring sends it at all. Never persisted, never scored (OuraStreamMapping drops
+                // CvaRawPpg unconditionally).
+                if (loggedTierBKinds.add("cva_raw_ppg")) {
+                    log("Oura: Tier-B cva_raw_ppg seen (tag 0x81) - first values: ${e.value.values}")
+                }
+                d.unixSeconds(forRingTimestamp = e.value.ringTimestamp)?.let { utc ->
+                    cvaPpgDump?.record(ringTs = e.value.ringTimestamp, utc = utc, values = e.value.values)
                 }
             }
             is OuraEvent.MotionVectorEvent -> {

--- a/android/app/src/main/java/com/noop/data/OuraStreamMapping.kt
+++ b/android/app/src/main/java/com/noop/data/OuraStreamMapping.kt
@@ -152,11 +152,12 @@ object OuraStreamMapping {
                     out.events.add(WhoopEvent(ts = ts, kind = EVENT_MOTION, payload = payload))
                 }
 
-                // Motion / state / time-sync / rtc / debug / TierB / ActivityInfo never map onto a
-                // scored stream. In particular the 0x50 activity/MET decode (PR #960) NEVER mints a
-                // `steps` row: the formula is third-party and unvalidated (Tier B, OURA_PROTOCOL.md
+                // Motion / state / time-sync / rtc / debug / TierB / ActivityInfo / CvaRawPpg never map
+                // onto a scored stream. In particular the 0x50 activity/MET decode (PR #960) NEVER mints
+                // a `steps` row: the formula is third-party and unvalidated (Tier B, OURA_PROTOCOL.md
                 // s6.13), and MET is not a step count - fabricating one would break the honest-data
-                // invariant and the per-source day-owner rules.
+                // invariant and the per-source day-owner rules. Same discipline applies to 0x81 CVA raw
+                // PPG (OURA_PROTOCOL.md s6.14) - decoded, logged, never scored.
                 else -> Unit
             }
         }

--- a/android/app/src/main/java/com/noop/oura/Decoders.kt
+++ b/android/app/src/main/java/com/noop/oura/Decoders.kt
@@ -572,4 +572,56 @@ object OuraDecoders {
         }
         return OuraActivityInfo(ringTimestamp = rec.ringTimestamp, state = b[0], met = met)
     }
+
+    // MARK: - CVA raw PPG, delta + 24-bit absolute anchor (0x81; s6.14) - Tier B, third-party formula
+
+    /**
+     * Decode ONE `0x81` cva_raw_ppg_data record's delta/absolute-anchor byte stream into a running
+     * sample series, given the running total carried in from the previous `0x81` record THIS SESSION
+     * (`runningIn: null` at session start or after a reset - see OuraDriver's gap/ring-reset handling).
+     * Formula (OURA_PROTOCOL.md s6.14, [open_ring], clean-room fact citation): byte `0x80` -> the next 3
+     * bytes are a LE u24 ABSOLUTE value that re-syncs the running total; a byte with the MSB set
+     * (`0x81`-`0xFF`) is a signed delta `byte - 0x100`; else (`0x00`-`0x7F`) a signed 7-bit delta
+     * (`byte - 128` when `byte >= 64`, else `byte`) - both add onto the running total. `runningIn ?: 0`
+     * starts the chain at 0 when no anchor has synced yet THIS session, the same non-guessing convention
+     * `decodeSpO2DC` (0x77) already uses for its own delta-with-optional-base stream.
+     *
+     * SPLIT MARKER (honest, not a bug): a `0x80` marker with fewer than 3 trailing bytes in THIS record
+     * means the absolute value would span into the NEXT BLE notification. Per this codebase's
+     * one-packet-per-notification / no-cross-notification-buffering rule, decoding stops at the marker
+     * rather than guessing bytes from a notification that has not arrived yet - samples already decoded
+     * from earlier in the record are still returned. Returns null when the payload is empty or the
+     * marker split leaves nothing to return. Byte-identical twin of Swift's `decodeCvaRawPPG`.
+     */
+    fun decodeCvaRawPPG(rec: OuraRecord, runningIn: Int?): OuraCvaPpgDecodeStep? {
+        val b = rec.payload
+        if (b.isEmpty()) return null
+        var running = runningIn ?: 0
+        val out = ArrayList<Int>()
+        var i = 0
+        while (i < b.size) {
+            val byte = b[i]
+            if (byte == 0x80) {
+                if (i + 3 >= b.size) break   // split marker across a notification boundary
+                running = u24le(b, i + 1)
+                out.add(running)
+                i += 4
+            } else if (byte and 0x80 != 0) {
+                running += byte - 0x100
+                out.add(running)
+                i += 1
+            } else {
+                running += if (byte >= 64) byte - 128 else byte
+                out.add(running)
+                i += 1
+            }
+        }
+        return if (out.isEmpty()) null else OuraCvaPpgDecodeStep(out, running)
+    }
 }
+
+/**
+ * The result of decoding one 0x81 record: the samples decoded from THIS record (in wire order) and the
+ * running total to carry into the next record. Twin of the Swift `(values:runningOut:)` tuple return.
+ */
+data class OuraCvaPpgDecodeStep(val values: List<Int>, val runningOut: Int)

--- a/android/app/src/main/java/com/noop/oura/EventTags.kt
+++ b/android/app/src/main/java/com/noop/oura/EventTags.kt
@@ -83,7 +83,10 @@ enum class OuraEventTag(val raw: Int) {
     REAL_STEPS_2(0x7F),       // real_steps_features_2, OURA_PROTOCOL.md s6.13 (UNVERIFIED)
 
     // --- Smoothed SpO2 (Tier B, UNVERIFIED) ---
-    SPO2_SMOOTHED(0x70);      // spo2_smoothed, OURA_PROTOCOL.md s6.6 (UNVERIFIED)
+    SPO2_SMOOTHED(0x70),      // spo2_smoothed, OURA_PROTOCOL.md s6.6 (UNVERIFIED)
+
+    // --- Raw PPG (Tier B, UNVERIFIED) ---
+    CVA_RAW_PPG(0x81);        // cva_raw_ppg_data (delta + 24-bit absolute), OURA_PROTOCOL.md s6.14 (UNVERIFIED)
 
     /**
      * The trust tier for this tag. Tier B tags are decoded but the OuraDriver gates their emission
@@ -93,7 +96,7 @@ enum class OuraEventTag(val raw: Int) {
         get() = when (this) {
             SLEEP_SUMMARY_1, SLEEP_SUMMARY_C, SLEEP_SUMMARY_D, SLEEP_SUMMARY_E,
             SLEEP_SUMMARY_F, ACTIVITY_INFO, ACTIVITY_SUMMARY_1, ACTIVITY_SUMMARY_2,
-            REAL_STEPS_1, REAL_STEPS_2, SPO2_SMOOTHED,
+            REAL_STEPS_1, REAL_STEPS_2, SPO2_SMOOTHED, CVA_RAW_PPG,
             // #287: 0x71 green_ibi_and_amp is NOT corpus-verified — no captured 0x71 fixture, and
             // OURA_PROTOCOL.md §6.2 documents a DIFFERENT layout (5 IBI deltas + 6 amplitudes, shift
             // [2:0]) than the 0x60 decoder it was wired to (6 absolute IBIs, 4-bit shift). Decoding it
@@ -141,6 +144,7 @@ enum class OuraEventTag(val raw: Int) {
             REAL_STEPS_1 -> "REAL_STEPS_1"
             REAL_STEPS_2 -> "REAL_STEPS_2"
             SPO2_SMOOTHED -> "SPO2_SMOOTHED"
+            CVA_RAW_PPG -> "CVA_RAW_PPG"
         }
 
     companion object {

--- a/android/app/src/main/java/com/noop/oura/OuraCvaPpgDumpLine.kt
+++ b/android/app/src/main/java/com/noop/oura/OuraCvaPpgDumpLine.kt
@@ -1,0 +1,32 @@
+package com.noop.oura
+
+/**
+ * Pure, deterministic encoder for ONE line of the Oura CVA raw-PPG (0x81) research corpus — the
+ * Kotlin twin of Swift `OuraCvaPpgDumpLine`. Byte-identical output (fixed key order), so the two
+ * platforms' JSONL corpora are interchangeable.
+ *
+ * WHY a sidecar and not a stream/table: the 0x81 decode is Tier-B (a plausible third-party
+ * delta/absolute-anchor formula, not ground-truth-validated — OURA_PROTOCOL.md s6.14). The
+ * honest-data invariant forbids Tier-B ever minting a durable scoring row, so it must never touch
+ * Streams/the DB. This corpus is a separate, clearly-labelled diagnostic file for offline
+ * investigation (does it correlate with a known PPG channel? do the rare anchor anomalies recur?).
+ * It never feeds scoring and is safe to delete. Parallels [OuraActivityDumpLine] / [OuraMotionDumpLine].
+ */
+object OuraCvaPpgDumpLine {
+    /** Bump when the record shape changes so a downstream reader can branch on `schema`. */
+    const val SCHEMA = 1
+
+    /**
+     * One JSONL record (NO trailing newline — the writer adds it). `deviceId` is a controlled registry id
+     * (e.g. `oura-<serial>`) and `iso` is app-generated, so neither needs JSON string-escaping here.
+     *   - ringTs: the record's raw ring-clock timestamp (the dedup key: strictly increases per record).
+     *   - utc:    the anchored wall-clock (unix seconds) for the record envelope.
+     *   - iso:    human-readable UTC of `utc` (convenience for eyeballing).
+     *   - values: the decoded running-total PPG series this ONE record contributed, verbatim.
+     */
+    fun encode(deviceId: String, ringTs: Long, utc: Long, iso: String, values: List<Int>): String {
+        val valuesStr = values.joinToString(",")
+        return "{\"schema\":$SCHEMA,\"deviceId\":\"$deviceId\",\"ringTs\":$ringTs," +
+            "\"utc\":$utc,\"iso\":\"$iso\",\"values\":[$valuesStr]}"
+    }
+}

--- a/android/app/src/main/java/com/noop/oura/OuraDriver.kt
+++ b/android/app/src/main/java/com/noop/oura/OuraDriver.kt
@@ -118,6 +118,20 @@ class OuraDriver(
     private var installedKey: IntArray? = null
 
     /**
+     * The 0x81 cva_raw_ppg_data running total, carried across records THIS SESSION (OURA_PROTOCOL.md
+     * s6.14). null until the first anchor/delta byte of the session, and after a reset (see
+     * [cvaPpgLastRingTimestamp] below and the RING_START / [stop] handling). Kotlin twin of Swift's
+     * cvaPpgRunning.
+     */
+    private var cvaPpgRunning: Int? = null
+
+    /**
+     * The ring-time of the last decoded 0x81 record, used to detect the documented 60 s gap reset. null
+     * until the first 0x81 record of the session.
+     */
+    private var cvaPpgLastRingTimestamp: Long? = null
+
+    /**
      * The key the auth handshake should use: the freshly-installed key takes precedence over the
      * injected one (so re-auth after a key install uses the new key). Per OURA_PROTOCOL.md s3.2.
      */
@@ -284,6 +298,8 @@ class OuraDriver(
         // A stale anchor must not survive stop()/a new session - the ring may have rebooted (s5.5).
         anchorUtcMs = null
         anchorRingTime = null
+        cvaPpgRunning = null
+        cvaPpgLastRingTimestamp = null
     }
 
     // MARK: - Ring-time -> UTC anchor (s5.5)
@@ -443,11 +459,18 @@ class OuraDriver(
                 OuraDecoders.decodeDebugText(record)?.let {
                     listOf(OuraEvent.DebugTextEvent(ringTimestamp = record.ringTimestamp, text = it))
                 } ?: emptyList()
-            OuraEventTag.RING_START ->
+            OuraEventTag.RING_START -> {
                 // 0x41 ring_start_ind: a lifecycle marker (the app uses it to invalidate the UTC anchor on
                 // rt regression). It carries no biometric value, so emit nothing here. Per OURA_PROTOCOL.md
                 // s5.5 / s6.15. The app observes ring-start via the record stream directly.
+                // Also the closest wire signal to the 0x81 spec's documented "ring-reset ack" (s6.14) - a
+                // best-current-interpretation, not a wire-confirmed mapping, since no distinct reset-ack
+                // opcode is documented. Invalidate the CVA-PPG running total so a stale baseline never
+                // survives a real ring reboot.
+                cvaPpgRunning = null
+                cvaPpgLastRingTimestamp = null
                 emptyList()
+            }
 
             // --- Tier B (only reached when allowTierB == true; otherwise dropped above) ---
             OuraEventTag.GREEN_IBI_AMP ->
@@ -508,6 +531,23 @@ class OuraDriver(
                         ),
                     ),
                 )
+            OuraEventTag.CVA_RAW_PPG -> {
+                // Split out of the raw-bytes TierB wrapper, same as ActivityInfo: this ONE tag has a
+                // plausible decode formula (OuraDecoders.decodeCvaRawPPG, third-party [open_ring]). Still
+                // Tier B - only reached behind allowTierB (gated above), and OuraStreamMapping never folds
+                // CvaRawPpg into a durable stream. A 60 s gap (or a ring-reset, s6.14) invalidates the
+                // running total BEFORE this record is decoded, so a stale accumulator never leaks across a
+                // real session break; an out-of-order re-serve (rt regression) is treated the same as a gap.
+                val last = cvaPpgLastRingTimestamp
+                if (last != null) {
+                    val gap = if (record.ringTimestamp >= last) record.ringTimestamp - last else last - record.ringTimestamp
+                    if (gap > CVA_PPG_GAP_RESET_TICKS) cvaPpgRunning = null
+                }
+                cvaPpgLastRingTimestamp = record.ringTimestamp
+                val step = OuraDecoders.decodeCvaRawPPG(record, cvaPpgRunning) ?: return emptyList()
+                cvaPpgRunning = step.runningOut
+                listOf(OuraEvent.CvaRawPpg(OuraCvaPpg(ringTimestamp = record.ringTimestamp, values = step.values)))
+            }
         }
     }
 
@@ -605,6 +645,12 @@ class OuraDriver(
          */
         private const val MIN_PLAUSIBLE_EPOCH_SECONDS = 1_577_836_800L
         private const val MAX_PLAUSIBLE_EPOCH_SECONDS = 2_051_222_400L
+
+        /**
+         * 60 s at the ring's default 100 ms/tick clock (OURA_PROTOCOL.md s5.5) - the documented CVA-PPG
+         * accumulator reset window (s6.14). Byte-identical to Swift's cvaPpgGapResetTicks.
+         */
+        private const val CVA_PPG_GAP_RESET_TICKS = 600L
 
         /**
          * Resolve the 0x13 SyncTime-response device timestamp into ring TICKS, or null when no

--- a/android/app/src/main/java/com/noop/oura/OuraEvents.kt
+++ b/android/app/src/main/java/com/noop/oura/OuraEvents.kt
@@ -164,6 +164,21 @@ data class OuraTierBSummary(
  */
 data class OuraActivityInfo(val ringTimestamp: Long, val state: Int, val met: List<Double>)
 
+/**
+ * One decoded `0x81` cva_raw_ppg_data record: a running, dimensionless ADC-like PPG count reconstructed
+ * from the ring's delta/absolute-anchor byte stream (OURA_PROTOCOL.md s6.14). THIRD-PARTY FORMULA
+ * ([open_ring], clean-room fact citation, no code copied): a marker byte `0x80` re-syncs a running total
+ * from the next 3 bytes (LE u24); every other byte is a delta walked forward from that total (MSB-set =
+ * `byte-0x100`, else signed 7-bit). Validated on a 2169-record real Gen 3 capture (2026-07-30): the
+ * reconstructed series is smooth (median sample-to-sample jump 33, baseline ~390-400K) - consistent with a
+ * real PPG channel - with rare (4-of-22745) anomalous jumps AT an absolute-anchor byte, not yet explained.
+ * NOT independently ground-truth-validated against a known PPG channel, so this stays Tier B end to end:
+ * emitted only behind `OuraDriver.allowTierB`, and NEVER folded into `OuraStreamMapping`/scoring. `values`
+ * holds every sample this ONE record contributed to the running total, in wire order. Kotlin twin of the
+ * Swift `OuraCvaPpg`.
+ */
+data class OuraCvaPpg(val ringTimestamp: Long, val values: List<Int>)
+
 // MARK: - The emitted event union
 
 /**
@@ -208,8 +223,16 @@ sealed class OuraEvent {
      */
     data class ActivityInfo(val value: OuraActivityInfo) : OuraEvent()
 
+    /**
+     * A decoded `0x81` cva_raw_ppg_data record (running PPG count series). Still Tier-B (see
+     * [OuraCvaPpg] doc) - split out of the raw-bytes [TierB] wrapper for the same reason [ActivityInfo]
+     * was: a plausible decode formula worth surfacing as real numbers instead of hex. Same gate
+     * (`allowTierB`), same discipline (never reaches `OuraStreamMapping`).
+     */
+    data class CvaRawPpg(val value: OuraCvaPpg) : OuraEvent()
+
     /** True for Tier-B events, so a consumer can assert none leaked into a Tier-A-only sink. */
-    val isTierB: Boolean get() = this is TierB || this is ActivityInfo
+    val isTierB: Boolean get() = this is TierB || this is ActivityInfo || this is CvaRawPpg
 
     /**
      * The record's envelope ring-time, when it carries one (battery is a plain response, not a log
@@ -234,5 +257,6 @@ sealed class OuraEvent {
             is DebugTextEvent -> ringTimestamp
             is TierB -> value.ringTimestamp
             is ActivityInfo -> value.ringTimestamp
+            is CvaRawPpg -> value.ringTimestamp
         }
 }

--- a/android/app/src/test/java/com/noop/data/OuraStreamMappingTest.kt
+++ b/android/app/src/test/java/com/noop/data/OuraStreamMappingTest.kt
@@ -185,6 +185,11 @@ class OuraStreamMappingTest {
                 OuraEvent.ActivityInfo(
                     com.noop.oura.OuraActivityInfo(ringTimestamp = 100, state = 0x41, met = listOf(1.8, 1.9)),
                 ),
+                // 0x81 CVA raw PPG: decoded but Tier-B/unvalidated (third-party [open_ring] formula) -
+                // must never leak a value into a durable stream either.
+                OuraEvent.CvaRawPpg(
+                    com.noop.oura.OuraCvaPpg(ringTimestamp = 100, values = listOf(395015, 394873)),
+                ),
             ),
             anchor,
         )

--- a/android/app/src/test/java/com/noop/oura/OuraCvaPpgDumpLineTest.kt
+++ b/android/app/src/test/java/com/noop/oura/OuraCvaPpgDumpLineTest.kt
@@ -1,0 +1,32 @@
+package com.noop.oura
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * The Tier-B CVA raw-PPG research-corpus JSONL line encoder. The line is asserted verbatim so the
+ * format is pinned byte-for-byte AND stays interchangeable with the Swift `OuraCvaPpgDumpLine` corpus
+ * (same key order, same `values` formatting).
+ */
+class OuraCvaPpgDumpLineTest {
+
+    @Test
+    fun encodesFixedShapeVerbatim() {
+        val line = OuraCvaPpgDumpLine.encode(
+            deviceId = "oura-2H3B2405003655", ringTs = 3_584_349, utc = 1_753_440_000,
+            iso = "2026-07-30T09:09:01Z", values = listOf(395015, 394873, 394679),
+        )
+        assertEquals(
+            "{\"schema\":1,\"deviceId\":\"oura-2H3B2405003655\",\"ringTs\":3584349," +
+                "\"utc\":1753440000,\"iso\":\"2026-07-30T09:09:01Z\",\"values\":[395015,394873,394679]}",
+            line,
+        )
+    }
+
+    @Test
+    fun emptyValuesIsEmptyArray() {
+        val line = OuraCvaPpgDumpLine.encode("d", 1, 2, "x", emptyList())
+        assertTrue(line.endsWith("\"values\":[]}"))
+    }
+}

--- a/android/app/src/test/java/com/noop/oura/OuraDriverTest.kt
+++ b/android/app/src/test/java/com/noop/oura/OuraDriverTest.kt
@@ -567,6 +567,139 @@ class OuraDriverTest {
         )
     }
 
+    // MARK: - CVA raw PPG (0x81, Tier B, third-party formula) - real Gen 3 capture (2026-07-30)
+    //
+    // PARITY: the three payloads below are byte-for-byte the same three CONSECUTIVE 0x81 records pinned
+    // in the Swift OuraDriverTests (real capture, ring times 3584349-3584351). Expected values are
+    // RECOMPUTED from the s6.14 formula (marker 0x80 -> LE u24 absolute; MSB-set byte -> signed
+    // byte-0x100 delta; else signed 7-bit delta), not copied blind. Record 0 also happens to end on a
+    // real split marker (payload offset 12, only 1 trailing byte) - genuine capture evidence for the
+    // honest-drop path, not a constructed edge case.
+
+    @Test
+    fun testCvaRawPPGDecodesRealCaptureChain() {
+        // Record 0: three back-to-back absolute anchors, then a split marker (payload offset 12) with
+        // only one trailing byte - decoding honestly stops there instead of guessing into record 1.
+        val rec0 = OuraRecord(type = OuraEventTag.CVA_RAW_PPG.raw, ringTimestamp = 3_584_349,
+                              payload = bytes("800707068079060680b705068003"))
+        val step0 = OuraDecoders.decodeCvaRawPPG(rec0, null)
+        assertEquals(listOf(395015, 394873, 394679), step0?.values)
+        assertEquals(394679, step0?.runningOut)
+
+        // Record 1 continues the chain from record 0's running total (no anchor of its own).
+        val rec1 = OuraRecord(type = OuraEventTag.CVA_RAW_PPG.raw, ringTimestamp = 3_584_350,
+                              payload = bytes("0506804604068090030680f00206"))
+        val step1 = OuraDecoders.decodeCvaRawPPG(rec1, step0?.runningOut)
+        assertEquals(listOf(394684, 394690, 394310, 394128, 393968), step1?.values)
+        assertEquals(393968, step1?.runningOut)
+
+        // Record 2 continues from record 1.
+        val rec2 = OuraRecord(type = OuraEventTag.CVA_RAW_PPG.raw, ringTimestamp = 3_584_351,
+                              payload = bytes("80300206809b0106800a010694ab"))
+        val step2 = OuraDecoders.decodeCvaRawPPG(rec2, step1?.runningOut)
+        assertEquals(listOf(393776, 393627, 393482, 393374, 393289), step2?.values)
+        assertEquals(393289, step2?.runningOut)
+    }
+
+    @Test
+    fun testCvaRawPPGSplitMarkerStopsHonestly() {
+        // Same record 0 as above, decoded standalone (runningIn: null): the trailing split marker at
+        // payload offset 12 (only 1 of the needed 3 trailing bytes present) must not be guessed across
+        // into the next notification - decoding stops there and returns only the 3 clean samples.
+        val rec = OuraRecord(type = OuraEventTag.CVA_RAW_PPG.raw, ringTimestamp = 3_584_349,
+                             payload = bytes("800707068079060680b705068003"))
+        val step = OuraDecoders.decodeCvaRawPPG(rec, null)
+        assertEquals(listOf(395015, 394873, 394679), step?.values)
+    }
+
+    @Test
+    fun testCvaRawPPGThroughDriverChainsAcrossRecords() {
+        val d = OuraDriver(ringGen = OuraRingGen.GEN3, authKey = key, allowTierB = true)
+        val rec0 = OuraRecord(type = OuraEventTag.CVA_RAW_PPG.raw, ringTimestamp = 3_584_349,
+                              payload = bytes("800707068079060680b705068003"))
+        assertEquals(
+            listOf<OuraEvent>(
+                OuraEvent.CvaRawPpg(OuraCvaPpg(ringTimestamp = 3_584_349, values = listOf(395015, 394873, 394679))),
+            ),
+            d.ingest(rec0),
+        )
+
+        val rec1 = OuraRecord(type = OuraEventTag.CVA_RAW_PPG.raw, ringTimestamp = 3_584_350,
+                              payload = bytes("0506804604068090030680f00206"))
+        val events1 = d.ingest(rec1)
+        assertEquals(
+            listOf<OuraEvent>(
+                OuraEvent.CvaRawPpg(
+                    OuraCvaPpg(ringTimestamp = 3_584_350, values = listOf(394684, 394690, 394310, 394128, 393968)),
+                ),
+            ),
+            events1,
+        )
+        assertTrue("cvaRawPpg must still report isTierB - the formula is UNVERIFIED", events1[0].isTierB)
+    }
+
+    @Test
+    fun testCvaRawPPGGapResetsRunningTotal() {
+        val d = OuraDriver(ringGen = OuraRingGen.GEN3, authKey = key, allowTierB = true)
+        // First record anchors the running total via a 0x80 marker.
+        val rec0 = OuraRecord(type = OuraEventTag.CVA_RAW_PPG.raw, ringTimestamp = 1000,
+                              payload = intArrayOf(0x80, 0x10, 0x00, 0x00))   // absolute = 0x000010 = 16
+        assertEquals(
+            listOf<OuraEvent>(OuraEvent.CvaRawPpg(OuraCvaPpg(ringTimestamp = 1000, values = listOf(16)))),
+            d.ingest(rec0),
+        )
+
+        // Second record arrives 601 ticks later (> the 60s/600-tick reset window) with a plain +5 delta.
+        // Without the gap reset this would read 16+5=21; the reset makes it start fresh from 0.
+        val rec1 = OuraRecord(type = OuraEventTag.CVA_RAW_PPG.raw, ringTimestamp = 1601, payload = intArrayOf(0x05))
+        assertEquals(
+            listOf<OuraEvent>(OuraEvent.CvaRawPpg(OuraCvaPpg(ringTimestamp = 1601, values = listOf(5)))),
+            d.ingest(rec1),
+        )
+    }
+
+    @Test
+    fun testCvaRawPPGRingStartResetsRunningTotal() {
+        val d = OuraDriver(ringGen = OuraRingGen.GEN3, authKey = key, allowTierB = true)
+        val rec0 = OuraRecord(type = OuraEventTag.CVA_RAW_PPG.raw, ringTimestamp = 1000,
+                              payload = intArrayOf(0x80, 0x10, 0x00, 0x00))   // absolute = 16
+        assertEquals(
+            listOf<OuraEvent>(OuraEvent.CvaRawPpg(OuraCvaPpg(ringTimestamp = 1000, values = listOf(16)))),
+            d.ingest(rec0),
+        )
+
+        // A 0x41 ring_start_ind (well within the gap window) must still invalidate the running total.
+        val ringStart = OuraRecord(type = OuraEventTag.RING_START.raw, ringTimestamp = 1010, payload = intArrayOf())
+        assertEquals(emptyList<OuraEvent>(), d.ingest(ringStart))
+
+        val rec1 = OuraRecord(type = OuraEventTag.CVA_RAW_PPG.raw, ringTimestamp = 1020, payload = intArrayOf(0x05))
+        assertEquals(
+            listOf<OuraEvent>(OuraEvent.CvaRawPpg(OuraCvaPpg(ringTimestamp = 1020, values = listOf(5)))),
+            d.ingest(rec1),
+        )
+    }
+
+    @Test
+    fun testCvaRawPPGDroppedByDefaultLikeOtherTierB() {
+        val d = OuraDriver(ringGen = OuraRingGen.GEN3, authKey = key)   // allowTierB defaults to false
+        val rec = OuraRecord(type = OuraEventTag.CVA_RAW_PPG.raw, ringTimestamp = rt, payload = intArrayOf(0x05))
+        assertEquals(
+            "the Tier-B gate must cover CvaRawPpg too",
+            emptyList<OuraEvent>(),
+            d.ingest(rec),
+        )
+    }
+
+    @Test
+    fun testCvaRawPPGEmptyPayloadDecodesToNull() {
+        assertNull(
+            OuraDecoders.decodeCvaRawPPG(
+                OuraRecord(type = OuraEventTag.CVA_RAW_PPG.raw, ringTimestamp = rt, payload = intArrayOf()),
+                null,
+            ),
+        )
+    }
+
     // MARK: - Live-HR push routing + decode
 
     @Test

--- a/docs/OURA_PROTOCOL.md
+++ b/docs/OURA_PROTOCOL.md
@@ -520,7 +520,29 @@ edit of the ring's tag.
 ### 6.14 Raw PPG
 - **`0x67` raw_ppg_summary** (12–13 B): start-UTC, type, scale, session header for following data. [ringverse]
 - **`0x68` raw_ppg_data** (variable, delta-encoded): needs scale/accumulator from the paired `0x67`. [ringverse]
-- **`0x81` cva_raw_ppg_data** (variable): delta + 24-bit absolute, session-stateful. Decode: byte `0x80` → next 3 bytes absolute u24; MSB-set byte → signed delta `b-0x100`; else signed 7-bit `+= b`. Reset on ring-reset ack or 60 s gap. [open_ring]
+- **`0x81` cva_raw_ppg_data** (variable): delta + 24-bit absolute, session-stateful. Decode: byte `0x80` → next 3 bytes absolute u24 (LE); MSB-set byte → signed delta `b-0x100`; else signed 7-bit delta (`b-128` when `b>=64`, else `b`). Reset on ring-reset ack or 60 s gap. [open_ring]
+  - **Wired into a decoder (both platforms, Tier B) and validated against a real capture** (2026-07-30, a
+    2169-record Gen 3 session, plain NOOP pairing - no Advanced-key handshake in that session's log,
+    server-gated-unlock persistence not otherwise investigated here): chaining the running total across
+    records the whole session yields a SMOOTH series (median sample-to-sample jump 33, baseline
+    ~390-400K counts) consistent with a real PPG channel, not noise - the strongest evidence yet that the
+    [open_ring] formula's core (LE u24 absolute anchor + delta walk) is right. 4-of-22745 samples show an
+    anomalous jump to ~8.39M and back within 2 anchor reads, cause not yet explained (candidates: a
+    genuine sensor artifact, or the anchor's 3-byte field not being plain LE in that instance) - left
+    unresolved, Tier B stays UNVERIFIED.
+  - **Split markers are common, not exceptional:** in the same capture, roughly a quarter of records end
+    on a `0x80` marker with fewer than 3 trailing bytes (the absolute value would span into the next BLE
+    notification). Per this codebase's one-packet-per-notification / no-cross-notification-buffering rule
+    (`Framing.swift` / `Framing.kt`), the decoder stops at the marker instead of guessing into the next
+    notification - samples already decoded earlier in the record are still returned, honestly.
+  - **"Ring-reset ack" is not a distinct documented opcode.** NOOP's decoder invalidates the running
+    total on the 0x41 `ring_start_ind` lifecycle marker (the same signal that already invalidates the UTC
+    anchor on rt regression) as the closest wire analogue - a best-current-interpretation, not a
+    wire-confirmed mapping.
+  - Still Tier B end to end: decoded only behind `allowTierB`, logged once per session + appended to a
+    diagnostic JSONL sidecar (`oura-cva-ppg-<id>.jsonl`, deduped by ring-time), never folded into
+    `OuraStreamMapping`/scoring. `OuraDecoders.decodeCvaRawPPG` (Swift) / `Decoders.decodeCvaRawPPG`
+    (Kotlin).
 
 ### 6.15 Lifecycle / state
 - **`0x41` ring_start_ind** (18 B): bytes6–10 = 40-bit device id; bytes15–19 config; triggers anchor invalidation on rt regress. [ringverse][open_ring]


### PR DESCRIPTION
  ## Summary
  - Wires the documented ([open_ring]) delta/absolute-anchor formula for `0x81` cva_raw_ppg_data into a
    real decoder on both platforms: a running total re-synced by a marker byte (`0x80` → LE u24 absolute)
    and walked forward by MSB-set (`byte-0x100`) or signed-7-bit deltas, carried across records for the
  - Session reset on a 60s gap or the closest wire analogue to a "ring-reset ack" (`0x41 ring_start_ind`) -
    called out in the doc/comments as a best-current interpretation, not a wire-confirmed mapping, since no
    distinct reset-ack opcode is documented.
  - A `0x80` marker split across a notification boundary (no 3 trailing bytes in the record - observed in
    roughly a quarter of records in the validation capture) is handled honestly: decoding stops at the
    marker instead of guessing into the next notification, per this codebase's existing
    one-packet-per-notification / no-cross-notification-buffering rule.
  - Stays **Tier B end to end**: gated behind `allowTierB`, `OuraStreamMapping` explicitly drops it on both
    platforms (never scored, never a DB row), surfaced only via a diagnostic JSONL sidecar
    (`oura-cva-ppg-<id>.jsonl`, deduped by ring-time, rotated) mirroring `OuraMotionDump`/`OuraActivityDump`.
  - `docs/OURA_PROTOCOL.md` §6.14 updated with the wiring + validation findings.

  ## Validation
  Replayed a real 2169-record Gen 3 capture (2026-07-30) through the new decoder:
  - Reconstructed series is **smooth** (median sample-to-sample jump 33, baseline ~390-400K counts) -
    consistent with a real PPG channel, not noise. Strongest evidence yet the formula's core is right.
  - 4-of-22745 samples show an unexplained jump to ~8.39M and back within 2 anchor reads - left
    unresolved and called out explicitly; this is why the tag stays Tier B rather than being promoted.
  - NOT yet cross-checked against a known PPG channel on hardware - that remains open.

  ## Test plan
  - [x] `swift test` — `Packages/OuraProtocol` (166 tests) and `Packages/WhoopStore` (338 tests), all
        passing, including new real-capture golden fixtures (the exact 3-record chain + the split-marker
        record) and synthetic gap-reset / ring-reset / Tier-B-gate tests.
  - [x] `xcodebuild -scheme Strand -destination 'platform=macOS'` — compiles clean with the new
        `OuraCvaPpgDump` sidecar wired into `OuraLiveSource.swift`.
  - [x] `./gradlew compileFullDebugKotlin` — compiles clean.
  - [x] `./gradlew testFullDebugUnitTest` — all new tests pass (`OuraDriverTest` 7 new `CvaRawPPG*` cases,
        `OuraCvaPpgDumpLineTest` 2 cases, `OuraStreamMappingTest` updated drop-coverage case). The only 3
        failures in the full 3236-test run (`AiCoachContextTest`, `StandardHrSensorFormatTest` x2) are
        pre-existing and unrelated - confirmed identical failures on unmodified `main` in a clean worktree.
  - [ ] Not yet cross-checked against a known PPG channel on hardware - stays Tier B / diagnostic-only
        until that happens (see the 4 unresolved anchor anomalies above).