### PR TITLE
oura: decode 0x7E/0x7F real_steps_features as Tier-B instrumentation

### DIFF
--- a/Packages/OuraProtocol/Sources/OuraProtocol/Decoders.swift
+++ b/Packages/OuraProtocol/Sources/OuraProtocol/Decoders.swift
@@ -515,4 +515,31 @@ public enum OuraDecoders {
         }
         return OuraActivityInfo(ringTimestamp: rec.ringTimestamp, state: Int(state), met: met)
     }
+
+    // MARK: - Real steps features (0x7E/0x7F; s6.13) - Tier B, third-party formula
+
+    /// Decode a `0x7E`/`0x7F` real_steps_features record: 14 bit-packed fields from a 14-byte body.
+    /// Formula ([oura-rs] - Th0rgal/open_oura `crates/oura-protocol/src/events.rs`, clean-room fact
+    /// citation, no code copied): fields 0 and 8 are 9-bit values built as `byte*2 + carry_bit`, where
+    /// the carry bit is the MSB of a neighboring byte (byte 3's MSB for field 0, byte 11's MSB for
+    /// field 8) - the same byte then also supplies field 3 / field 11 from its own low 7 bits. Fields
+    /// 1, 2, 9, 10 are a bare `byte<<1` (no carry completion). Fields 4-7 and 12-13 are plain bytes.
+    /// Returns nil unless the body is exactly 14 bytes (the source's own length gate).
+    public static func decodeRealStepsFields(_ rec: OuraRecord) -> OuraRealStepsFields? {
+        let p = rec.payload
+        guard p.count == 14 else { return nil }
+        let fields: [Int] = [
+            (Int(p[3] >> 7)) | (Int(p[0]) << 1),
+            Int(p[1]) << 1,
+            Int(p[2]) << 1,
+            Int(p[3] & 0x7f),
+            Int(p[4]), Int(p[5]), Int(p[6]), Int(p[7]),
+            (Int(p[11] >> 7)) | (Int(p[8]) << 1),
+            Int(p[9]) << 1,
+            Int(p[10]) << 1,
+            Int(p[11] & 0x7f),
+            Int(p[12]), Int(p[13]),
+        ]
+        return OuraRealStepsFields(tag: rec.type, ringTimestamp: rec.ringTimestamp, fields: fields)
+    }
 }

--- a/Packages/OuraProtocol/Sources/OuraProtocol/OuraDriver.swift
+++ b/Packages/OuraProtocol/Sources/OuraProtocol/OuraDriver.swift
@@ -407,8 +407,14 @@ public final class OuraDriver {
             return [.tierB(OuraTierBSummary(tag: record.type, ringTimestamp: record.ringTimestamp,
                                             rawPayload: record.payload, kind: "activity"))]
         case .realSteps1, .realSteps2:
-            return [.tierB(OuraTierBSummary(tag: record.type, ringTimestamp: record.ringTimestamp,
-                                            rawPayload: record.payload, kind: "real_steps"))]
+            // Split out of the raw-bytes .tierB wrapper, same as .activityInfo: this tag pair now has a
+            // cited third-party unpack formula (Decoders.decodeRealStepsFields, [oura-rs]). Still Tier B
+            // - only reached behind allowTierB (gated above), and OuraStreamMapping never folds
+            // .realStepsFields into a durable stream. Applies the SAME 14-field unpack to both 0x7E and
+            // 0x7F bodies (the formula is generic over any 14-byte body; NOOP's own investigation found
+            // the movement-correlated fields present in both).
+            guard let fields = OuraDecoders.decodeRealStepsFields(record) else { return [] }
+            return [.realStepsFields(fields)]
         case .spo2Smoothed:
             return [.tierB(OuraTierBSummary(tag: record.type, ringTimestamp: record.ringTimestamp,
                                             rawPayload: record.payload, kind: "spo2_smoothed"))]

--- a/Packages/OuraProtocol/Sources/OuraProtocol/OuraEvents.swift
+++ b/Packages/OuraProtocol/Sources/OuraProtocol/OuraEvents.swift
@@ -221,6 +221,33 @@ public struct OuraActivityInfo: Equatable, Sendable, Codable {
     }
 }
 
+/// One decoded `0x7E`/`0x7F` real_steps_features record: 14 unpacked feature values from a 14-byte
+/// bit-packed body. THIRD-PARTY FORMULA ([oura-rs] - Th0rgal/open_oura `crates/oura-protocol/src/
+/// events.rs`, clean-room fact citation, no code copied; the source itself marks this decode
+/// `"_status": "unvalidated"`): two of the 14 fields (index 0 and 8) are genuine 9-bit values built as
+/// `byte*2 + carry_bit`, where the carry bit is stolen from the MSB of a neighboring byte (index 3 for
+/// field 0, index 11 for field 8); the rest are either plain bytes or a bare `byte<<1` with no carry.
+/// NOOP's OWN investigation (2026-07-30, a 2661-pair real Gen 3 capture cross-correlated against the
+/// already-anchored 0x50 MET corpus) found `fields[0]` and `fields[8]` - the two carry-completed
+/// 9-bit values - are also the ONLY fields with a consistent movement correlation (r≈+0.3 vs mean MET,
+/// effect size +1.5/+1.25 resting-vs-moving), a real convergence between the bit-layout hint and the
+/// empirical signal. Still NOT proof: one capture, correlated against a coarse MET proxy, not against a
+/// ground-truth step count - the honest read is "the leading candidate for the step field," not "the
+/// step field." Stays Tier B end to end: emitted only behind `OuraDriver.allowTierB`, and NEVER folded
+/// into `OuraStreamMapping`/scoring. `fields` holds all 14 values verbatim, in the source's own order,
+/// so a future controlled-walk capture can test every field, not just the current best guess.
+public struct OuraRealStepsFields: Equatable, Sendable, Codable {
+    /// The originating tag byte (`0x7E` realSteps1 or `0x7F` realSteps2) - both route through the same
+    /// decoder and event case, so this is what lets a consumer (or the diagnostic dump) tell which half
+    /// of the pair a given event came from.
+    public let tag: UInt8
+    public let ringTimestamp: UInt32
+    public let fields: [Int]
+    public init(tag: UInt8, ringTimestamp: UInt32, fields: [Int]) {
+        self.tag = tag; self.ringTimestamp = ringTimestamp; self.fields = fields
+    }
+}
+
 // MARK: - The emitted event union
 
 /// What OuraDriver.ingest(record:) emits. A single record can yield several events (e.g. an IBI+amp
@@ -251,11 +278,16 @@ public enum OuraEvent: Equatable, Sendable {
     /// formula, so an investigating consumer can log real MET numbers instead of hex. Same gate
     /// (`allowTierB`), same discipline (never reaches `OuraStreamMapping`).
     case activityInfo(OuraActivityInfo)
+    /// A decoded `0x7E`/`0x7F` real_steps_features record (14 unpacked fields). Still Tier-B (see
+    /// `OuraRealStepsFields` doc) - split out of the raw-bytes `.tierB` wrapper for the same reason
+    /// `.activityInfo` was: a cited third-party unpack formula worth surfacing as real numbers instead
+    /// of hex. Same gate (`allowTierB`), same discipline (never reaches `OuraStreamMapping`).
+    case realStepsFields(OuraRealStepsFields)
 
     /// True for Tier-B events, so a consumer can assert none leaked into a Tier-A-only sink.
     public var isTierB: Bool {
         switch self {
-        case .tierB, .activityInfo: return true
+        case .tierB, .activityInfo, .realStepsFields: return true
         default: return false
         }
     }
@@ -280,6 +312,7 @@ public enum OuraEvent: Equatable, Sendable {
         case .debugText(let rt, _): return rt
         case .tierB(let v): return v.ringTimestamp
         case .activityInfo(let v): return v.ringTimestamp
+        case .realStepsFields(let v): return v.ringTimestamp
         }
     }
 }

--- a/Packages/OuraProtocol/Sources/OuraProtocol/OuraEvents.swift
+++ b/Packages/OuraProtocol/Sources/OuraProtocol/OuraEvents.swift
@@ -231,10 +231,13 @@ public struct OuraActivityInfo: Equatable, Sendable, Codable {
 /// already-anchored 0x50 MET corpus) found `fields[0]` and `fields[8]` - the two carry-completed
 /// 9-bit values - are also the ONLY fields with a consistent movement correlation (r≈+0.3 vs mean MET,
 /// effect size +1.5/+1.25 resting-vs-moving), a real convergence between the bit-layout hint and the
-/// empirical signal. Still NOT proof: one capture, correlated against a coarse MET proxy, not against a
-/// ground-truth step count - the honest read is "the leading candidate for the step field," not "the
-/// step field." Stays Tier B end to end: emitted only behind `OuraDriver.allowTierB`, and NEVER folded
-/// into `OuraStreamMapping`/scoring. `fields` holds all 14 values verbatim, in the source's own order,
+/// empirical signal. INDEPENDENTLY REPLICATED the same day on a second, separate 2898-pair capture:
+/// `fields[0]` r=+0.317 (vs +0.317) and `fields[8]` r=+0.302 (vs +0.303) - the same two leading fields,
+/// nearly identical correlation strength, from an unrelated session. Still NOT proof: both captures
+/// correlate against the same coarse MET proxy, not a ground-truth step count, and no field shows a
+/// monotonic/cumulative-counter signature - the honest read is "the leading candidate for the step
+/// field," not "the step field." Stays Tier B end to end: emitted only behind `OuraDriver.allowTierB`,
+/// and NEVER folded into `OuraStreamMapping`/scoring. `fields` holds all 14 values verbatim, in order,
 /// so a future controlled-walk capture can test every field, not just the current best guess.
 public struct OuraRealStepsFields: Equatable, Sendable, Codable {
     /// The originating tag byte (`0x7E` realSteps1 or `0x7F` realSteps2) - both route through the same

--- a/Packages/OuraProtocol/Sources/oura-decode/main.swift
+++ b/Packages/OuraProtocol/Sources/oura-decode/main.swift
@@ -153,6 +153,7 @@ func describe(_ e: OuraEvent) -> String {
     case .debugText(_, let t): return "DEBUG \(t)"
     case .tierB(let v): return "TIER_B[UNVERIFIED] tag=0x\(String(v.tag, radix: 16)) kind=\(v.kind) bytes=\(v.rawPayload.count)"
     case .activityInfo(let v): return "ACTIVITY[TIER-B,UNVERIFIED] state=\(v.state) met=\(v.met) rt=\(v.ringTimestamp)"
+    case .realStepsFields(let v): return "REAL_STEPS[TIER-B,UNVERIFIED] tag=0x\(String(v.tag, radix: 16)) fields=\(v.fields) rt=\(v.ringTimestamp)"
     }
 }
 

--- a/Packages/OuraProtocol/Tests/OuraProtocolTests/OuraDriverTests.swift
+++ b/Packages/OuraProtocol/Tests/OuraProtocolTests/OuraDriverTests.swift
@@ -464,6 +464,72 @@ final class OuraDriverTests: XCTestCase {
             OuraRecord(type: OuraEventTag.activityInfo.rawValue, ringTimestamp: rt, payload: [])))
     }
 
+    // MARK: - Real steps features (0x7E/0x7F, Tier B, third-party formula) - real Gen 3 capture
+    //
+    // PARITY/PROVENANCE: the two pairs below are byte-for-byte two CONSECUTIVE real_steps pairs from a
+    // real Gen 3 capture (2026-07-30, ring times 3499176-3499474 and their +1 0x7F partners). Expected
+    // fields are RECOMPUTED from the [oura-rs] unpack formula, not copied blind.
+
+    func testRealStepsFieldsDecodesRealCapture0x7E() {
+        let d = OuraDriver(ringGen: .gen3, authKey: key, allowTierB: true)
+        let rec = OuraRecord(type: OuraEventTag.realSteps1.rawValue, ringTimestamp: 3_499_176,
+                             payload: bytes("6feb5e0a633e106865da4c136571"))
+        let events = d.ingest(record: rec)
+        XCTAssertEqual(events, [.realStepsFields(OuraRealStepsFields(tag: OuraEventTag.realSteps1.rawValue, ringTimestamp: 3_499_176,
+            fields: [222, 470, 188, 10, 99, 62, 16, 104, 202, 436, 152, 19, 101, 113]))])
+        XCTAssertTrue(events[0].isTierB, "realStepsFields must still report isTierB - the formula is UNVERIFIED")
+    }
+
+    func testRealStepsFieldsDecodesRealCapture0x7F() {
+        let d = OuraDriver(ringGen: .gen3, authKey: key, allowTierB: true)
+        // The 0x7F partner of the same pair (ring time = the 0x7E record's rt + 1).
+        let rec = OuraRecord(type: OuraEventTag.realSteps2.rawValue, ringTimestamp: 3_499_177,
+                             payload: bytes("24d467b25c127e3721a0a34dbde3"))
+        XCTAssertEqual(d.ingest(record: rec), [.realStepsFields(OuraRealStepsFields(tag: OuraEventTag.realSteps2.rawValue, ringTimestamp: 3_499_177,
+            fields: [73, 424, 206, 50, 92, 18, 126, 55, 66, 320, 326, 77, 189, 227]))])
+    }
+
+    func testRealStepsFieldsDecodesSecondRealPair() {
+        let d = OuraDriver(ringGen: .gen3, authKey: key, allowTierB: true)
+        let recE = OuraRecord(type: OuraEventTag.realSteps1.rawValue, ringTimestamp: 3_499_474,
+                              payload: bytes("6b556d05356b1d6faa2c85aa2368"))
+        XCTAssertEqual(d.ingest(record: recE), [.realStepsFields(OuraRealStepsFields(tag: OuraEventTag.realSteps1.rawValue, ringTimestamp: 3_499_474,
+            fields: [214, 170, 218, 5, 53, 107, 29, 111, 341, 88, 266, 42, 35, 104]))])
+
+        let recF = OuraRecord(type: OuraEventTag.realSteps2.rawValue, ringTimestamp: 3_499_475,
+                              payload: bytes("213590eb62a4515c22b4c381512c"))
+        XCTAssertEqual(d.ingest(record: recF), [.realStepsFields(OuraRealStepsFields(tag: OuraEventTag.realSteps2.rawValue, ringTimestamp: 3_499_475,
+            fields: [67, 106, 288, 107, 98, 164, 81, 92, 69, 360, 390, 1, 81, 44]))])
+    }
+
+    func testRealStepsFieldsCarryBitCombinesWithNeighborByte() {
+        // Synthetic, isolating the carry-bit mechanic the [oura-rs] source documents: byte0=0xFF (all
+        // ones) with byte3's MSB SET must read field0 = 0xFF*2 + 1 = 511 (the 9-bit max), and byte3's
+        // own value (field3) must read only its low 7 bits (the MSB was consumed by field0's carry).
+        let rec = OuraRecord(type: OuraEventTag.realSteps1.rawValue, ringTimestamp: rt, payload: [
+            0xFF, 0x00, 0x00, 0x80, 0, 0, 0, 0, 0x00, 0x00, 0x00, 0x00, 0, 0,
+        ])
+        let fields = OuraDecoders.decodeRealStepsFields(rec)?.fields
+        XCTAssertEqual(fields?[0], 511)   // 0xFF<<1 | 1
+        XCTAssertEqual(fields?[3], 0)     // byte3 = 0x80, & 0x7f = 0
+        XCTAssertEqual(fields?[8], 0)     // byte11's MSB is clear -> no carry
+    }
+
+    func testRealStepsFieldsDroppedByDefaultLikeOtherTierB() {
+        let d = OuraDriver(ringGen: .gen3, authKey: key)   // allowTierB defaults to false
+        let rec = OuraRecord(type: OuraEventTag.realSteps1.rawValue, ringTimestamp: rt,
+                             payload: bytes("6feb5e0a633e106865da4c136571"))
+        XCTAssertEqual(d.ingest(record: rec), [], "the Tier-B gate must cover .realStepsFields too")
+    }
+
+    func testRealStepsFieldsWrongLengthDecodesToNil() {
+        // The source's own length gate: anything other than exactly 14 bytes -> honest nil, never a guess.
+        XCTAssertNil(OuraDecoders.decodeRealStepsFields(
+            OuraRecord(type: OuraEventTag.realSteps1.rawValue, ringTimestamp: rt, payload: bytes("00"))))
+        XCTAssertNil(OuraDecoders.decodeRealStepsFields(
+            OuraRecord(type: OuraEventTag.realSteps1.rawValue, ringTimestamp: rt, payload: [])))
+    }
+
     // MARK: - Live-HR push routing + decode
 
     func testHandleSecureFrameRoutesNonceStatusAndPush() {

--- a/Packages/WhoopStore/Sources/WhoopStore/OuraRealStepsDumpLine.swift
+++ b/Packages/WhoopStore/Sources/WhoopStore/OuraRealStepsDumpLine.swift
@@ -1,0 +1,31 @@
+import Foundation
+
+/// Pure, deterministic encoder for ONE line of the Oura real_steps_features (0x7E/0x7F) research corpus
+/// — a diagnostic JSONL sidecar, NOT a datastore row.
+///
+/// WHY a sidecar and not a stream/table: the decode is Tier-B (a cited third-party unpack formula,
+/// [oura-rs], not ground-truth-validated against a known step count — OURA_PROTOCOL.md s6.13). The
+/// honest-data invariant forbids Tier-B ever minting a durable scoring row, so it must never touch
+/// `Streams`/SQLite. This corpus is a separate, clearly-labeled file the app appends to purely so a
+/// future controlled-walk capture (known step count, read against the Oura app's own number) can
+/// correlate every field against ground truth, not just NOOP's current best-guess candidate (fields[0] /
+/// fields[8]). It never feeds scoring and is safe to delete. Parallels `OuraActivityDumpLine` /
+/// `OuraCvaPpgDumpLine`.
+public enum OuraRealStepsDumpLine {
+    /// Bump when the record shape changes so a downstream reader can branch on `schema`.
+    public static let schema = 1
+
+    /// One JSONL record (NO trailing newline — the writer adds it). `deviceId` is a controlled registry id
+    /// (e.g. `oura-<serial>`) and `iso`/`tag` are app-generated, so none need JSON string-escaping here.
+    ///   - tag:    "0x7e" or "0x7f" (which half of the paired record this is).
+    ///   - ringTs: the record's raw ring-clock timestamp (the dedup key: strictly increases per record).
+    ///   - utc:    the anchored wall-clock (unix seconds) for the record envelope.
+    ///   - iso:    human-readable UTC of `utc` (convenience for eyeballing).
+    ///   - fields: the 14 decoded fields this ONE record contributed, verbatim, in the source's own order.
+    public static func encode(deviceId: String, tag: String, ringTs: UInt32, utc: Int, iso: String,
+                              fields: [Int]) -> String {
+        let fieldsStr = fields.map { String($0) }.joined(separator: ",")
+        return "{\"schema\":\(schema),\"deviceId\":\"\(deviceId)\",\"tag\":\"\(tag)\",\"ringTs\":\(ringTs),"
+             + "\"utc\":\(utc),\"iso\":\"\(iso)\",\"fields\":[\(fieldsStr)]}"
+    }
+}

--- a/Packages/WhoopStore/Sources/WhoopStore/OuraStreamMapping.swift
+++ b/Packages/WhoopStore/Sources/WhoopStore/OuraStreamMapping.swift
@@ -131,10 +131,12 @@ public enum OuraStreamMapping {
                 if let hi = m.highIntensity { payload["high_intensity"] = .int(hi) }
                 out.events.append(WhoopEvent(ts: ts, kind: motionEventKind, payload: payload))
 
-            case .motion, .state, .timeSync, .rtcBeacon, .debugText, .tierB, .activityInfo:
+            case .motion, .state, .timeSync, .rtcBeacon, .debugText, .tierB, .activityInfo, .realStepsFields:
                 // Not a durable per-device stream row (timeSync/rtcBeacon anchor the transport's clock;
-                // motion/state/debug are diagnostics; Tier-B / .activityInfo are UNVERIFIED and must
-                // never feed scoring or the steps stream).
+                // motion/state/debug are diagnostics; Tier-B / .activityInfo / .realStepsFields are
+                // UNVERIFIED and must never feed scoring or the steps stream - in particular
+                // .realStepsFields must never mint a `steps` row on its own, even for its leading
+                // candidate field; see OuraRealStepsFields).
                 continue
             }
         }

--- a/Packages/WhoopStore/Tests/WhoopStoreTests/OuraRealStepsDumpLineTests.swift
+++ b/Packages/WhoopStore/Tests/WhoopStoreTests/OuraRealStepsDumpLineTests.swift
@@ -1,0 +1,24 @@
+import XCTest
+@testable import WhoopStore
+
+final class OuraRealStepsDumpLineTests: XCTestCase {
+    func testEncodeFixedKeyOrderAndValues() {
+        let line = OuraRealStepsDumpLine.encode(
+            deviceId: "oura-2H3B2405003655", tag: "0x7e", ringTs: 3_499_176, utc: 1_753_440_000,
+            iso: "2026-07-30T09:09:01Z",
+            fields: [222, 470, 188, 10, 99, 62, 16, 104, 202, 436, 152, 19, 101, 113])
+        XCTAssertEqual(line,
+            "{\"schema\":1,\"deviceId\":\"oura-2H3B2405003655\",\"tag\":\"0x7e\",\"ringTs\":3499176,"
+          + "\"utc\":1753440000,\"iso\":\"2026-07-30T09:09:01Z\","
+          + "\"fields\":[222,470,188,10,99,62,16,104,202,436,152,19,101,113]}")
+    }
+
+    func testEncodeEmptyFieldsIsValidJSON() throws {
+        let line = OuraRealStepsDumpLine.encode(deviceId: "oura-x", tag: "0x7f", ringTs: 1, utc: 2,
+                                                iso: "i", fields: [])
+        let obj = try JSONSerialization.jsonObject(with: Data(line.utf8)) as? [String: Any]
+        XCTAssertEqual(obj?["schema"] as? Int, OuraRealStepsDumpLine.schema)
+        XCTAssertEqual(obj?["tag"] as? String, "0x7f")
+        XCTAssertEqual((obj?["fields"] as? [Any])?.count, 0)
+    }
+}

--- a/Packages/WhoopStore/Tests/WhoopStoreTests/OuraStreamMappingTests.swift
+++ b/Packages/WhoopStore/Tests/WhoopStoreTests/OuraStreamMappingTests.swift
@@ -163,9 +163,12 @@ final class OuraStreamMappingTests: XCTestCase {
             // 0x50 activity/MET (PR #960): decoded but Tier-B/unvalidated - in particular it must never
             // mint a `steps` row (MET is not a step count; the per-source day-owner rules stay intact).
             .activityInfo(OuraActivityInfo(ringTimestamp: 100, state: 0x41, met: [1.8, 1.9])),
+            // 0x7E/0x7F real_steps_features: decoded but Tier-B/unvalidated - must never mint a `steps`
+            // row either, even from its leading candidate field (see OuraRealStepsFields).
+            .realStepsFields(OuraRealStepsFields(tag: 0x7E, ringTimestamp: 100, fields: Array(0..<14))),
         ], at: ts)
         XCTAssertTrue(s.isEmpty, "Tier-B and diagnostic events must not produce any durable stream row")
-        XCTAssertTrue(s.steps.isEmpty, "activity/MET must never fabricate a steps row")
+        XCTAssertTrue(s.steps.isEmpty, "activity/MET/real_steps must never fabricate a steps row")
     }
 
     // MARK: - Empty batch + multi-signal batch

--- a/Strand/BLE/OuraLiveSource.swift
+++ b/Strand/BLE/OuraLiveSource.swift
@@ -268,6 +268,9 @@ public final class OuraLiveSource: NSObject, ObservableObject {
     private let activityDump: OuraActivityDump?
     /// Append-only JSONL sidecar for the 0x47 motion vectors (Tier-A), for offline LSB→g calibration (#804).
     private let motionDump: OuraMotionDump?
+    /// Append-only JSONL research corpus for 0x7E/0x7F real_steps_features (Tier-B, third-party
+    /// [oura-rs] unpack formula, never scored/persisted to SQLite). See OuraRealStepsDump.
+    private let realStepsDump: OuraRealStepsDump?
     /// Append-only JSONL capture of the RAW, undecoded history-drain notification bytes (`oura-raw-<id>.jsonl`).
     /// Complement to the decoded sidecars above: those show what NOOP interpreted, this shows exactly what the
     /// ring sent, so after a full connect a hole in a decoded file can be pinned as a decode drop vs ring-side.
@@ -783,6 +786,8 @@ public final class OuraLiveSource: NSObject, ObservableObject {
         self.motionDump = feedsLive && !deviceId.isEmpty ? OuraMotionDump(deviceId: deviceId, log: log) : nil
         // RAW undecoded history-drain capture: same live/persisting gate; complements the decoded sidecars.
         self.rawDump = feedsLive && !deviceId.isEmpty ? OuraRawDump(deviceId: deviceId, log: log) : nil
+        // 0x7E/0x7F real_steps research corpus: same gate as the other Tier-B dumps.
+        self.realStepsDump = feedsLive && !deviceId.isEmpty ? OuraRealStepsDump(deviceId: deviceId, log: log) : nil
         super.init()
         // Dedicated queue-less central -> callbacks arrive on the main queue, matching @MainActor.
         self.central = CBCentralManager(delegate: self, queue: nil)
@@ -1372,6 +1377,22 @@ public final class OuraLiveSource: NSObject, ObservableObject {
                     }
                     lastActivityUtc = utc
                     lastActivitySampleCount = info.met.count
+                }
+
+            case .realStepsFields(let steps):
+                // INVESTIGATION ONLY (0x7E/0x7F real_steps_features, Tier B - a cited third-party unpack
+                // formula [oura-rs], NOT ground-truth-validated; see OuraRealStepsFields). Logged once per
+                // kind (like the other raw Tier-B tags) rather than every occurrence - this stream runs at
+                // a much higher rate than 0x50 MET, so the JSONL corpus is the real record; the strap log
+                // just confirms the ring sends it at all. Never persisted, never scored, and NEVER
+                // converted into steps (OuraStreamMapping drops .realStepsFields unconditionally) - not
+                // even from fields[0]/fields[8], NOOP's own current leading candidate for the step field.
+                if !loggedTierBKinds.contains("real_steps_fields") {
+                    loggedTierBKinds.insert("real_steps_fields")
+                    log("Oura: Tier-B real_steps_fields seen (tag 0x\(String(steps.tag, radix: 16))) - first fields: \(steps.fields)")
+                }
+                if let utc = driver.unixSeconds(forRingTimestamp: steps.ringTimestamp) {
+                    realStepsDump?.record(tag: steps.tag, ringTs: steps.ringTimestamp, utc: utc, fields: steps.fields)
                 }
 
             case .state(let s):

--- a/Strand/BLE/OuraRealStepsDump.swift
+++ b/Strand/BLE/OuraRealStepsDump.swift
@@ -1,0 +1,112 @@
+import Foundation
+import WhoopStore
+
+/// Append-only JSONL sidecar for the Oura 0x7E/0x7F real_steps_features stream — a Tier-B RESEARCH
+/// corpus for investigation, NOT a datastore row (see `OuraRealStepsDumpLine` for the rationale). Direct
+/// twin of `OuraActivityDump` / `OuraCvaPpgDump`: owns the file handle, the on-disk path, the
+/// once-per-launch "here is the file" log line, and a persistent ring-time high-water so records the
+/// ring re-serves across reconnects are written exactly once instead of duplicating the corpus.
+///
+/// Location: `<Application Support>/OpenWhoop/Diagnostics/oura-real-steps-<deviceId>.jsonl` — beside the
+/// app's SQLite so the user can find it. Purely diagnostic and safe to delete; nothing reads it back. It
+/// exists so a future controlled-walk capture (known step count, cross-read against the Oura app's own
+/// number) can test every unpacked field against ground truth, not just NOOP's current leading candidate
+/// (fields[0] / fields[8] — see OuraRealStepsFields).
+final class OuraRealStepsDump {
+    private let deviceId: String
+    private let log: (String) -> Void
+    private let highWaterKey: String
+    /// Only records with `ringTs` STRICTLY above this are written; re-served (older) records are dropped.
+    /// Persisted in UserDefaults so the dedup survives app relaunches (a fresh drain re-emits old records).
+    private var highWater: UInt32
+    private var fileURL: URL?
+    private var resolveFailed = false
+    private var announced = false
+
+    /// Rotate the sidecar past this size (keeping one previous ".1"), so an always-on research corpus is
+    /// bounded to ~2× this on disk instead of growing forever. Matches the other Oura Tier-B dumps.
+    private static let maxBytes = 25 * 1024 * 1024
+
+    private static let iso: ISO8601DateFormatter = {
+        let f = ISO8601DateFormatter()
+        f.timeZone = TimeZone(identifier: "UTC")
+        return f
+    }()
+
+    init(deviceId: String, log: @escaping (String) -> Void) {
+        self.deviceId = deviceId
+        self.log = log
+        self.highWaterKey = "oura.realStepsDump.highwater.\(deviceId)"
+        let stored = UserDefaults.standard.integer(forKey: highWaterKey)   // 0 when unset → writes everything
+        self.highWater = stored > 0 ? UInt32(truncatingIfNeeded: stored) : 0
+    }
+
+    /// Append one anchored real_steps record. No-op when `ringTs` is not above the high-water (a
+    /// re-serve), so the corpus stays deduped. Best-effort: any file error is logged once and never
+    /// disrupts the BLE path. Call ONLY with an anchored `utc` (an un-anchored record has no real time
+    /// axis and re-arrives anchored on the next drain).
+    func record(tag: UInt8, ringTs: UInt32, utc: Int, fields: [Int]) {
+        guard ringTs > highWater else { return }
+        guard var url = resolveURL() else { return }
+        // Bound the corpus (rotate to a single ".1", dropping the prior one) so an always-on research
+        // sidecar can't grow unbounded — same rotation as the other Oura Tier-B dumps. Read the size via
+        // a fresh FileManager stat rather than URL.resourceValues, whose cache on the reused URL can
+        // return a stale small size.
+        let size = ((try? FileManager.default.attributesOfItem(atPath: url.path))?[.size] as? Int) ?? 0
+        if size > Self.maxBytes {
+            let old = url.deletingLastPathComponent().appendingPathComponent(url.lastPathComponent + ".1")
+            try? FileManager.default.removeItem(at: old)
+            try? FileManager.default.moveItem(at: url, to: old)
+            fileURL = nil
+            guard let fresh = resolveURL() else { return }
+            url = fresh
+        }
+
+        let tagStr = "0x" + String(tag, radix: 16)
+        let line = OuraRealStepsDumpLine.encode(
+            deviceId: deviceId, tag: tagStr, ringTs: ringTs, utc: utc,
+            iso: Self.iso.string(from: Date(timeIntervalSince1970: TimeInterval(utc))), fields: fields)
+
+        guard let data = (line + "\n").data(using: .utf8) else { return }
+        do {
+            let handle = try FileHandle(forWritingTo: url)
+            defer { try? handle.close() }
+            try handle.seekToEnd()
+            handle.write(data)
+        } catch {
+            log("Oura: real_steps dump write failed - \(error.localizedDescription)")
+            return
+        }
+
+        highWater = ringTs
+        UserDefaults.standard.set(Int(ringTs), forKey: highWaterKey)
+        if !announced {
+            announced = true
+            log("Oura: real_steps 0x7E/0x7F dump → \(url.path) [Tier-B research corpus, JSONL, deduped by ring-time]")
+        }
+    }
+
+    /// Resolve (and create on first use) the sidecar file + its parent directory. Cached; a failure is
+    /// logged once and latched so we never spam the strap log on a read-only volume.
+    private func resolveURL() -> URL? {
+        if let fileURL { return fileURL }
+        if resolveFailed { return nil }
+        do {
+            let base = try FileManager.default.url(for: .applicationSupportDirectory, in: .userDomainMask,
+                                                   appropriateFor: nil, create: true)
+            let dir = base.appendingPathComponent("OpenWhoop/Diagnostics", isDirectory: true)
+            try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+            let safeId = deviceId.replacingOccurrences(of: "/", with: "_")
+            let url = dir.appendingPathComponent("oura-real-steps-\(safeId).jsonl")
+            if !FileManager.default.fileExists(atPath: url.path) {
+                FileManager.default.createFile(atPath: url.path, contents: nil)
+            }
+            fileURL = url
+            return url
+        } catch {
+            resolveFailed = true
+            log("Oura: real_steps dump unavailable - \(error.localizedDescription)")
+            return nil
+        }
+    }
+}

--- a/android/app/src/main/java/com/noop/ble/OuraLiveSource.kt
+++ b/android/app/src/main/java/com/noop/ble/OuraLiveSource.kt
@@ -249,6 +249,11 @@ class OuraLiveSource(
      *  of the Swift `OuraMotionDump`. Null when there is no device id. */
     private val motionDump: OuraMotionDump? =
         if (deviceId.isNotEmpty()) OuraMotionDump(appContext, deviceId, log) else null
+
+    /** 0x7E/0x7F real_steps research corpus (Tier-B), for offline investigation. Kotlin twin of the Swift
+     *  `OuraRealStepsDump`. Null when there is no device id. */
+    private val realStepsDump: OuraRealStepsDump? =
+        if (deviceId.isNotEmpty()) OuraRealStepsDump(appContext, deviceId, log) else null
     private val scanner: BluetoothLeScanner? get() = adapter?.bluetoothLeScanner
 
     private var gatt: BluetoothGatt? = null
@@ -1720,6 +1725,21 @@ class OuraLiveSource(
                         ringTs = e.value.ringTimestamp, utc = utc, state = e.value.state,
                         secPerSample = 60, met = e.value.met, // 60 s = assumed MET cadence (s6.13)
                     )
+                }
+            }
+            is OuraEvent.RealStepsFields -> {
+                // INVESTIGATION ONLY (0x7E/0x7F real_steps_features, Tier B - a cited third-party unpack
+                // formula [oura-rs], NOT ground-truth-validated; see OuraRealStepsFields). Logged once per
+                // kind (like the other raw Tier-B tags) rather than every occurrence - this stream runs at
+                // a much higher rate than 0x50 MET, so the JSONL corpus is the real record; the strap log
+                // just confirms the ring sends it at all. Never persisted, never scored, and NEVER
+                // converted into steps (OuraStreamMapping drops RealStepsFields unconditionally) - not
+                // even from fields[0]/fields[8], NOOP's own current leading candidate for the step field.
+                if (loggedTierBKinds.add("real_steps_fields")) {
+                    log("Oura: Tier-B real_steps_fields seen (tag 0x${e.value.tag.toString(16)}) - first fields: ${e.value.fields}")
+                }
+                d.unixSeconds(forRingTimestamp = e.value.ringTimestamp)?.let { utc ->
+                    realStepsDump?.record(tag = e.value.tag, ringTs = e.value.ringTimestamp, utc = utc, fields = e.value.fields)
                 }
             }
             is OuraEvent.MotionVectorEvent -> {

--- a/android/app/src/main/java/com/noop/ble/OuraRealStepsDump.kt
+++ b/android/app/src/main/java/com/noop/ble/OuraRealStepsDump.kt
@@ -1,0 +1,102 @@
+package com.noop.ble
+
+import android.content.Context
+import com.noop.oura.OuraRealStepsDumpLine
+import java.io.File
+import java.time.Instant
+
+/**
+ * Append-only JSONL sidecar for the Oura 0x7E/0x7F real_steps_features stream — the Kotlin twin of Swift
+ * `OuraRealStepsDump`. A Tier-B RESEARCH corpus for investigation, never a datastore row (see
+ * [OuraRealStepsDumpLine] for the rationale). Owns the file, the once-per-launch "here is the file" log
+ * line, and a persistent ring-time high-water so records the ring re-serves across reconnects are
+ * written exactly once instead of duplicating the corpus.
+ *
+ * Location: `<filesDir>/diagnostics/oura-real-steps-<deviceId>.jsonl` (app-private). Purely diagnostic
+ * and safe to delete; nothing reads it back. It exists so a future controlled-walk capture (known step
+ * count, cross-read against the Oura app's own number) can test every unpacked field against ground
+ * truth, not just NOOP's current leading candidate (fields[0]/fields[8] — see OuraRealStepsFields). The
+ * LINE content is byte-identical to the Swift corpus — that is the parity-relevant part.
+ */
+class OuraRealStepsDump(
+    context: Context,
+    private val deviceId: String,
+    private val log: (String) -> Unit,
+) {
+    private val appContext = context.applicationContext
+    private val prefs = appContext.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+    private val highWaterKey = "highwater.$deviceId"
+
+    /** Only records with `ringTs` STRICTLY above this are written; re-served (older) records are dropped.
+     *  Persisted so the dedup survives relaunches (a fresh drain re-emits old records). */
+    private var highWater: Long = prefs.getLong(highWaterKey, 0L)
+    private var file: File? = null
+    private var resolveFailed = false
+    private var announced = false
+
+    /**
+     * Append one anchored real_steps record. No-op when [ringTs] is not above the high-water (a
+     * re-serve), so the corpus stays deduped. Best-effort: any file error is logged once and never
+     * disrupts the BLE path. Call ONLY with an anchored [utc].
+     */
+    fun record(tag: Int, ringTs: Long, utc: Long, fields: List<Int>) {
+        if (ringTs <= highWater) return
+        var f = resolveFile() ?: return
+        // Bound the corpus so it can't grow unbounded (always-on for every paired ring). At the cap, rotate
+        // to a single ".1" (dropping the prior one) and continue in a fresh file — same as the other dumps.
+        if (f.length() > MAX_BYTES) {
+            runCatching {
+                val old = File(f.parentFile, "${f.name}.1")
+                old.delete()
+                f.renameTo(old)
+            }
+            file = null
+            f = resolveFile() ?: return
+        }
+
+        val tagStr = "0x" + tag.toString(16)
+        val line = OuraRealStepsDumpLine.encode(
+            deviceId = deviceId, tag = tagStr, ringTs = ringTs, utc = utc,
+            iso = Instant.ofEpochSecond(utc).toString(), fields = fields,
+        )
+        try {
+            f.appendText(line + "\n")
+        } catch (e: Exception) {
+            log("Oura: real_steps dump write failed - ${e.message}")
+            return
+        }
+
+        highWater = ringTs
+        prefs.edit().putLong(highWaterKey, ringTs).apply()
+        if (!announced) {
+            announced = true
+            log("Oura: real_steps 0x7E/0x7F dump → ${f.absolutePath} [Tier-B research corpus, JSONL, deduped by ring-time]")
+        }
+    }
+
+    /** Resolve (and create on first use) the sidecar file + its parent directory. Cached; a failure is
+     *  logged once and latched so we never spam the strap log on a read-only volume. */
+    private fun resolveFile(): File? {
+        file?.let { return it }
+        if (resolveFailed) return null
+        return try {
+            val dir = File(appContext.filesDir, "diagnostics").apply { mkdirs() }
+            val safeId = deviceId.replace("/", "_")
+            File(dir, "oura-real-steps-$safeId.jsonl").also {
+                if (!it.exists()) it.createNewFile()
+                file = it
+            }
+        } catch (e: Exception) {
+            resolveFailed = true
+            log("Oura: real_steps dump unavailable - ${e.message}")
+            null
+        }
+    }
+
+    private companion object {
+        const val PREFS_NAME = "oura_real_steps_dump"
+
+        /** Rotate the sidecar past this size (keeping one previous ".1"), bounding it to ~2× on disk. */
+        const val MAX_BYTES = 25L * 1024 * 1024
+    }
+}

--- a/android/app/src/main/java/com/noop/data/OuraStreamMapping.kt
+++ b/android/app/src/main/java/com/noop/data/OuraStreamMapping.kt
@@ -152,11 +152,12 @@ object OuraStreamMapping {
                     out.events.add(WhoopEvent(ts = ts, kind = EVENT_MOTION, payload = payload))
                 }
 
-                // Motion / state / time-sync / rtc / debug / TierB / ActivityInfo never map onto a
-                // scored stream. In particular the 0x50 activity/MET decode (PR #960) NEVER mints a
-                // `steps` row: the formula is third-party and unvalidated (Tier B, OURA_PROTOCOL.md
+                // Motion / state / time-sync / rtc / debug / TierB / ActivityInfo / RealStepsFields never
+                // map onto a scored stream. In particular the 0x50 activity/MET decode (PR #960) NEVER
+                // mints a `steps` row: the formula is third-party and unvalidated (Tier B, OURA_PROTOCOL.md
                 // s6.13), and MET is not a step count - fabricating one would break the honest-data
-                // invariant and the per-source day-owner rules.
+                // invariant and the per-source day-owner rules. Same discipline for 0x7E/0x7F real_steps
+                // (s6.13) - decoded, logged, never scored, not even from its leading candidate field.
                 else -> Unit
             }
         }

--- a/android/app/src/main/java/com/noop/oura/Decoders.kt
+++ b/android/app/src/main/java/com/noop/oura/Decoders.kt
@@ -572,4 +572,34 @@ object OuraDecoders {
         }
         return OuraActivityInfo(ringTimestamp = rec.ringTimestamp, state = b[0], met = met)
     }
+
+    // MARK: - Real steps features (0x7E/0x7F; s6.13) - Tier B, third-party formula
+
+    /**
+     * Decode a `0x7E`/`0x7F` real_steps_features record: 14 bit-packed fields from a 14-byte body.
+     * Formula ([oura-rs] - Th0rgal/open_oura `crates/oura-protocol/src/events.rs`, clean-room fact
+     * citation, no code copied): fields 0 and 8 are 9-bit values built as `byte*2 + carry_bit`, where
+     * the carry bit is the MSB of a neighboring byte (byte 3's MSB for field 0, byte 11's MSB for
+     * field 8) - the same byte then also supplies field 3 / field 11 from its own low 7 bits. Fields
+     * 1, 2, 9, 10 are a bare `byte<<1` (no carry completion). Fields 4-7 and 12-13 are plain bytes.
+     * Returns null unless the body is exactly 14 bytes (the source's own length gate). Byte-identical
+     * twin of Swift's `decodeRealStepsFields`.
+     */
+    fun decodeRealStepsFields(rec: OuraRecord): OuraRealStepsFields? {
+        val p = rec.payload
+        if (p.size != 14) return null
+        val fields = listOf(
+            (p[3] shr 7) or (p[0] shl 1),
+            p[1] shl 1,
+            p[2] shl 1,
+            p[3] and 0x7f,
+            p[4], p[5], p[6], p[7],
+            (p[11] shr 7) or (p[8] shl 1),
+            p[9] shl 1,
+            p[10] shl 1,
+            p[11] and 0x7f,
+            p[12], p[13],
+        )
+        return OuraRealStepsFields(tag = rec.type, ringTimestamp = rec.ringTimestamp, fields = fields)
+    }
 }

--- a/android/app/src/main/java/com/noop/oura/OuraDriver.kt
+++ b/android/app/src/main/java/com/noop/oura/OuraDriver.kt
@@ -490,15 +490,16 @@ class OuraDriver(
                         ),
                     ),
                 )
-            OuraEventTag.REAL_STEPS_1, OuraEventTag.REAL_STEPS_2 ->
-                listOf(
-                    OuraEvent.TierB(
-                        OuraTierBSummary(
-                            tag = record.type, ringTimestamp = record.ringTimestamp,
-                            rawPayload = record.payload, kind = "real_steps",
-                        ),
-                    ),
-                )
+            OuraEventTag.REAL_STEPS_1, OuraEventTag.REAL_STEPS_2 -> {
+                // Split out of the raw-bytes TierB wrapper, same as ActivityInfo: this tag pair now has a
+                // cited third-party unpack formula (OuraDecoders.decodeRealStepsFields, [oura-rs]). Still
+                // Tier B - only reached behind allowTierB (gated above), and OuraStreamMapping never folds
+                // RealStepsFields into a durable stream. Applies the SAME 14-field unpack to both 0x7E and
+                // 0x7F bodies (the formula is generic over any 14-byte body; NOOP's own investigation
+                // found the movement-correlated fields present in both).
+                val fields = OuraDecoders.decodeRealStepsFields(record) ?: return emptyList()
+                listOf(OuraEvent.RealStepsFields(fields))
+            }
             OuraEventTag.SPO2_SMOOTHED ->
                 listOf(
                     OuraEvent.TierB(

--- a/android/app/src/main/java/com/noop/oura/OuraEvents.kt
+++ b/android/app/src/main/java/com/noop/oura/OuraEvents.kt
@@ -164,6 +164,26 @@ data class OuraTierBSummary(
  */
 data class OuraActivityInfo(val ringTimestamp: Long, val state: Int, val met: List<Double>)
 
+/**
+ * One decoded `0x7E`/`0x7F` real_steps_features record: 14 unpacked feature values from a 14-byte
+ * bit-packed body. THIRD-PARTY FORMULA ([oura-rs] - Th0rgal/open_oura `crates/oura-protocol/src/
+ * events.rs`, clean-room fact citation, no code copied; the source itself marks this decode
+ * `"_status": "unvalidated"`): two of the 14 fields (index 0 and 8) are genuine 9-bit values built as
+ * `byte*2 + carry_bit`, where the carry bit is stolen from the MSB of a neighboring byte (index 3 for
+ * field 0, index 11 for field 8); the rest are either plain bytes or a bare `byte<<1` with no carry.
+ * NOOP's OWN investigation (2026-07-30, a 2661-pair real Gen 3 capture cross-correlated against the
+ * already-anchored 0x50 MET corpus) found `fields[0]` and `fields[8]` - the two carry-completed 9-bit
+ * values - are also the ONLY fields with a consistent movement correlation (r~+0.3 vs mean MET, effect
+ * size +1.5/+1.25 resting-vs-moving), a real convergence between the bit-layout hint and the empirical
+ * signal. Still NOT proof: one capture, correlated against a coarse MET proxy, not against a
+ * ground-truth step count - the honest read is "the leading candidate for the step field," not "the
+ * step field." Stays Tier B end to end: emitted only behind `OuraDriver.allowTierB`, and NEVER folded
+ * into `OuraStreamMapping`/scoring. `fields` holds all 14 values verbatim, in the source's own order, so
+ * a future controlled-walk capture can test every field, not just the current best guess. Kotlin twin of
+ * the Swift `OuraRealStepsFields`.
+ */
+data class OuraRealStepsFields(val tag: Int, val ringTimestamp: Long, val fields: List<Int>)
+
 // MARK: - The emitted event union
 
 /**
@@ -208,8 +228,16 @@ sealed class OuraEvent {
      */
     data class ActivityInfo(val value: OuraActivityInfo) : OuraEvent()
 
+    /**
+     * A decoded `0x7E`/`0x7F` real_steps_features record (14 unpacked fields). Still Tier-B (see
+     * [OuraRealStepsFields] doc) - split out of the raw-bytes [TierB] wrapper for the same reason
+     * [ActivityInfo] was: a cited third-party unpack formula worth surfacing as real numbers instead of
+     * hex. Same gate (`allowTierB`), same discipline (never reaches `OuraStreamMapping`).
+     */
+    data class RealStepsFields(val value: OuraRealStepsFields) : OuraEvent()
+
     /** True for Tier-B events, so a consumer can assert none leaked into a Tier-A-only sink. */
-    val isTierB: Boolean get() = this is TierB || this is ActivityInfo
+    val isTierB: Boolean get() = this is TierB || this is ActivityInfo || this is RealStepsFields
 
     /**
      * The record's envelope ring-time, when it carries one (battery is a plain response, not a log
@@ -234,5 +262,6 @@ sealed class OuraEvent {
             is DebugTextEvent -> ringTimestamp
             is TierB -> value.ringTimestamp
             is ActivityInfo -> value.ringTimestamp
+            is RealStepsFields -> value.ringTimestamp
         }
 }

--- a/android/app/src/main/java/com/noop/oura/OuraEvents.kt
+++ b/android/app/src/main/java/com/noop/oura/OuraEvents.kt
@@ -175,12 +175,15 @@ data class OuraActivityInfo(val ringTimestamp: Long, val state: Int, val met: Li
  * already-anchored 0x50 MET corpus) found `fields[0]` and `fields[8]` - the two carry-completed 9-bit
  * values - are also the ONLY fields with a consistent movement correlation (r~+0.3 vs mean MET, effect
  * size +1.5/+1.25 resting-vs-moving), a real convergence between the bit-layout hint and the empirical
- * signal. Still NOT proof: one capture, correlated against a coarse MET proxy, not against a
- * ground-truth step count - the honest read is "the leading candidate for the step field," not "the
- * step field." Stays Tier B end to end: emitted only behind `OuraDriver.allowTierB`, and NEVER folded
- * into `OuraStreamMapping`/scoring. `fields` holds all 14 values verbatim, in the source's own order, so
- * a future controlled-walk capture can test every field, not just the current best guess. Kotlin twin of
- * the Swift `OuraRealStepsFields`.
+ * signal. INDEPENDENTLY REPLICATED the same day on a second, separate 2898-pair capture: `fields[0]`
+ * r=+0.317 (vs +0.317) and `fields[8]` r=+0.302 (vs +0.303) - the same two leading fields, nearly
+ * identical correlation strength, from an unrelated session. Still NOT proof: both captures correlate
+ * against the same coarse MET proxy, not a ground-truth step count, and no field shows a
+ * monotonic/cumulative-counter signature - the honest read is "the leading candidate for the step
+ * field," not "the step field." Stays Tier B end to end: emitted only behind `OuraDriver.allowTierB`,
+ * and NEVER folded into `OuraStreamMapping`/scoring. `fields` holds all 14 values verbatim, in order,
+ * so a future controlled-walk capture can test every field, not just the current best guess. Kotlin
+ * twin of the Swift `OuraRealStepsFields`.
  */
 data class OuraRealStepsFields(val tag: Int, val ringTimestamp: Long, val fields: List<Int>)
 

--- a/android/app/src/main/java/com/noop/oura/OuraRealStepsDumpLine.kt
+++ b/android/app/src/main/java/com/noop/oura/OuraRealStepsDumpLine.kt
@@ -1,0 +1,34 @@
+package com.noop.oura
+
+/**
+ * Pure, deterministic encoder for ONE line of the Oura real_steps_features (0x7E/0x7F) research corpus —
+ * the Kotlin twin of Swift `OuraRealStepsDumpLine`. Byte-identical output (fixed key order), so the two
+ * platforms' JSONL corpora are interchangeable.
+ *
+ * WHY a sidecar and not a stream/table: the decode is Tier-B (a cited third-party unpack formula,
+ * [oura-rs], not ground-truth-validated against a known step count — OURA_PROTOCOL.md s6.13). The
+ * honest-data invariant forbids Tier-B ever minting a durable scoring row, so it must never touch
+ * Streams/the DB. This corpus is a separate, clearly-labelled diagnostic file for a future
+ * controlled-walk capture (known step count, read against the Oura app's own number) to correlate every
+ * field against ground truth, not just NOOP's current best-guess candidate (fields[0]/fields[8]).
+ * Parallels [OuraActivityDumpLine] / [OuraCvaPpgDumpLine].
+ */
+object OuraRealStepsDumpLine {
+    /** Bump when the record shape changes so a downstream reader can branch on `schema`. */
+    const val SCHEMA = 1
+
+    /**
+     * One JSONL record (NO trailing newline — the writer adds it). `deviceId` is a controlled registry id
+     * (e.g. `oura-<serial>`) and `iso`/`tag` are app-generated, so none need JSON string-escaping here.
+     *   - tag:    "0x7e" or "0x7f" (which half of the paired record this is).
+     *   - ringTs: the record's raw ring-clock timestamp (the dedup key: strictly increases per record).
+     *   - utc:    the anchored wall-clock (unix seconds) for the record envelope.
+     *   - iso:    human-readable UTC of `utc` (convenience for eyeballing).
+     *   - fields: the 14 decoded fields this ONE record contributed, verbatim, in the source's own order.
+     */
+    fun encode(deviceId: String, tag: String, ringTs: Long, utc: Long, iso: String, fields: List<Int>): String {
+        val fieldsStr = fields.joinToString(",")
+        return "{\"schema\":$SCHEMA,\"deviceId\":\"$deviceId\",\"tag\":\"$tag\",\"ringTs\":$ringTs," +
+            "\"utc\":$utc,\"iso\":\"$iso\",\"fields\":[$fieldsStr]}"
+    }
+}

--- a/android/app/src/test/java/com/noop/data/OuraStreamMappingTest.kt
+++ b/android/app/src/test/java/com/noop/data/OuraStreamMappingTest.kt
@@ -185,6 +185,11 @@ class OuraStreamMappingTest {
                 OuraEvent.ActivityInfo(
                     com.noop.oura.OuraActivityInfo(ringTimestamp = 100, state = 0x41, met = listOf(1.8, 1.9)),
                 ),
+                // 0x7E/0x7F real_steps_features: decoded but Tier-B/unvalidated - must never mint a
+                // `steps` row either, even from its leading candidate field.
+                OuraEvent.RealStepsFields(
+                    com.noop.oura.OuraRealStepsFields(tag = 0x7E, ringTimestamp = 100, fields = (0..13).toList()),
+                ),
             ),
             anchor,
         )

--- a/android/app/src/test/java/com/noop/oura/OuraDriverTest.kt
+++ b/android/app/src/test/java/com/noop/oura/OuraDriverTest.kt
@@ -567,6 +567,125 @@ class OuraDriverTest {
         )
     }
 
+    // MARK: - Real steps features (0x7E/0x7F, Tier B, third-party formula) - real Gen 3 capture
+    //
+    // PARITY/PROVENANCE: the two pairs below are byte-for-byte the same two CONSECUTIVE real_steps pairs
+    // pinned in the Swift OuraDriverTests (real capture, ring times 3499176-3499474 and their +1 0x7F
+    // partners). Expected fields are RECOMPUTED from the [oura-rs] unpack formula, not copied blind.
+
+    @Test
+    fun testRealStepsFieldsDecodesRealCapture0x7E() {
+        val d = OuraDriver(ringGen = OuraRingGen.GEN3, authKey = key, allowTierB = true)
+        val rec = OuraRecord(type = OuraEventTag.REAL_STEPS_1.raw, ringTimestamp = 3_499_176,
+                             payload = bytes("6feb5e0a633e106865da4c136571"))
+        val events = d.ingest(rec)
+        assertEquals(
+            listOf<OuraEvent>(
+                OuraEvent.RealStepsFields(
+                    OuraRealStepsFields(
+                        tag = OuraEventTag.REAL_STEPS_1.raw, ringTimestamp = 3_499_176,
+                        fields = listOf(222, 470, 188, 10, 99, 62, 16, 104, 202, 436, 152, 19, 101, 113),
+                    ),
+                ),
+            ),
+            events,
+        )
+        assertTrue("realStepsFields must still report isTierB - the formula is UNVERIFIED", events[0].isTierB)
+    }
+
+    @Test
+    fun testRealStepsFieldsDecodesRealCapture0x7F() {
+        val d = OuraDriver(ringGen = OuraRingGen.GEN3, authKey = key, allowTierB = true)
+        // The 0x7F partner of the same pair (ring time = the 0x7E record's rt + 1).
+        val rec = OuraRecord(type = OuraEventTag.REAL_STEPS_2.raw, ringTimestamp = 3_499_177,
+                             payload = bytes("24d467b25c127e3721a0a34dbde3"))
+        assertEquals(
+            listOf<OuraEvent>(
+                OuraEvent.RealStepsFields(
+                    OuraRealStepsFields(
+                        tag = OuraEventTag.REAL_STEPS_2.raw, ringTimestamp = 3_499_177,
+                        fields = listOf(73, 424, 206, 50, 92, 18, 126, 55, 66, 320, 326, 77, 189, 227),
+                    ),
+                ),
+            ),
+            d.ingest(rec),
+        )
+    }
+
+    @Test
+    fun testRealStepsFieldsDecodesSecondRealPair() {
+        val d = OuraDriver(ringGen = OuraRingGen.GEN3, authKey = key, allowTierB = true)
+        val recE = OuraRecord(type = OuraEventTag.REAL_STEPS_1.raw, ringTimestamp = 3_499_474,
+                              payload = bytes("6b556d05356b1d6faa2c85aa2368"))
+        assertEquals(
+            listOf<OuraEvent>(
+                OuraEvent.RealStepsFields(
+                    OuraRealStepsFields(
+                        tag = OuraEventTag.REAL_STEPS_1.raw, ringTimestamp = 3_499_474,
+                        fields = listOf(214, 170, 218, 5, 53, 107, 29, 111, 341, 88, 266, 42, 35, 104),
+                    ),
+                ),
+            ),
+            d.ingest(recE),
+        )
+
+        val recF = OuraRecord(type = OuraEventTag.REAL_STEPS_2.raw, ringTimestamp = 3_499_475,
+                              payload = bytes("213590eb62a4515c22b4c381512c"))
+        assertEquals(
+            listOf<OuraEvent>(
+                OuraEvent.RealStepsFields(
+                    OuraRealStepsFields(
+                        tag = OuraEventTag.REAL_STEPS_2.raw, ringTimestamp = 3_499_475,
+                        fields = listOf(67, 106, 288, 107, 98, 164, 81, 92, 69, 360, 390, 1, 81, 44),
+                    ),
+                ),
+            ),
+            d.ingest(recF),
+        )
+    }
+
+    @Test
+    fun testRealStepsFieldsCarryBitCombinesWithNeighborByte() {
+        // Synthetic, isolating the carry-bit mechanic the [oura-rs] source documents: byte0=0xFF (all
+        // ones) with byte3's MSB SET must read field0 = 0xFF*2 + 1 = 511 (the 9-bit max), and byte3's
+        // own value (field3) must read only its low 7 bits (the MSB was consumed by field0's carry).
+        val rec = OuraRecord(
+            type = OuraEventTag.REAL_STEPS_1.raw, ringTimestamp = rt,
+            payload = intArrayOf(0xFF, 0x00, 0x00, 0x80, 0, 0, 0, 0, 0x00, 0x00, 0x00, 0x00, 0, 0),
+        )
+        val fields = OuraDecoders.decodeRealStepsFields(rec)?.fields
+        assertEquals(511, fields?.get(0))   // 0xFF<<1 | 1
+        assertEquals(0, fields?.get(3))     // byte3 = 0x80, & 0x7f = 0
+        assertEquals(0, fields?.get(8))     // byte11's MSB is clear -> no carry
+    }
+
+    @Test
+    fun testRealStepsFieldsDroppedByDefaultLikeOtherTierB() {
+        val d = OuraDriver(ringGen = OuraRingGen.GEN3, authKey = key)   // allowTierB defaults to false
+        val rec = OuraRecord(type = OuraEventTag.REAL_STEPS_1.raw, ringTimestamp = rt,
+                             payload = bytes("6feb5e0a633e106865da4c136571"))
+        assertEquals(
+            "the Tier-B gate must cover RealStepsFields too",
+            emptyList<OuraEvent>(),
+            d.ingest(rec),
+        )
+    }
+
+    @Test
+    fun testRealStepsFieldsWrongLengthDecodesToNull() {
+        // The source's own length gate: anything other than exactly 14 bytes -> honest null, never a guess.
+        assertNull(
+            OuraDecoders.decodeRealStepsFields(
+                OuraRecord(type = OuraEventTag.REAL_STEPS_1.raw, ringTimestamp = rt, payload = bytes("00")),
+            ),
+        )
+        assertNull(
+            OuraDecoders.decodeRealStepsFields(
+                OuraRecord(type = OuraEventTag.REAL_STEPS_1.raw, ringTimestamp = rt, payload = intArrayOf()),
+            ),
+        )
+    }
+
     // MARK: - Live-HR push routing + decode
 
     @Test

--- a/android/app/src/test/java/com/noop/oura/OuraRealStepsDumpLineTest.kt
+++ b/android/app/src/test/java/com/noop/oura/OuraRealStepsDumpLineTest.kt
@@ -1,0 +1,34 @@
+package com.noop.oura
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * The Tier-B real_steps research-corpus JSONL line encoder. The line is asserted verbatim so the format
+ * is pinned byte-for-byte AND stays interchangeable with the Swift `OuraRealStepsDumpLine` corpus (same
+ * key order, same `fields` formatting).
+ */
+class OuraRealStepsDumpLineTest {
+
+    @Test
+    fun encodesFixedShapeVerbatim() {
+        val line = OuraRealStepsDumpLine.encode(
+            deviceId = "oura-2H3B2405003655", tag = "0x7e", ringTs = 3_499_176, utc = 1_753_440_000,
+            iso = "2026-07-30T09:09:01Z",
+            fields = listOf(222, 470, 188, 10, 99, 62, 16, 104, 202, 436, 152, 19, 101, 113),
+        )
+        assertEquals(
+            "{\"schema\":1,\"deviceId\":\"oura-2H3B2405003655\",\"tag\":\"0x7e\",\"ringTs\":3499176," +
+                "\"utc\":1753440000,\"iso\":\"2026-07-30T09:09:01Z\"," +
+                "\"fields\":[222,470,188,10,99,62,16,104,202,436,152,19,101,113]}",
+            line,
+        )
+    }
+
+    @Test
+    fun emptyFieldsIsEmptyArray() {
+        val line = OuraRealStepsDumpLine.encode("d", "0x7f", 1, 2, "x", emptyList())
+        assertTrue(line.endsWith("\"fields\":[]}"))
+    }
+}

--- a/docs/OURA_PROTOCOL.md
+++ b/docs/OURA_PROTOCOL.md
@@ -533,6 +533,13 @@ edit of the ring's tag.
     signature was found in ANY of the 14 fields (all show ~50/50 increase/decrease with frequent large
     resets), so if a step count is in here at all it reads as a per-30s-window value, not a running total.
     Cadence is fixed: 300 ring-ticks (30 s) between consecutive pairs.
+  - **Independently replicated the same day on a second, separate capture** (2898 real_steps pairs, a
+    different connect session, standard app build): `fields[0]` r=+0.317 (vs +0.317 on the first capture)
+    and `fields[8]` r=+0.302 (vs +0.303) - the same two leading fields, correlation strength nearly
+    identical to the thousandths place, from an unrelated session. Meaningfully strengthens the "real
+    signal, not coincidence" read, but still not ground truth: both captures correlate against the same
+    coarse MET proxy. The rigorous next step (a controlled walk read against the Oura app's own step
+    count) remains open.
   - Still Tier B end to end: decoded only behind `allowTierB`, logged once per session + appended to a
     diagnostic JSONL sidecar (`oura-real-steps-<id>.jsonl`, deduped by ring-time), never folded into
     `OuraStreamMapping`/scoring - not even from fields[0]/fields[8]. The rigorous next step is a

--- a/docs/OURA_PROTOCOL.md
+++ b/docs/OURA_PROTOCOL.md
@@ -516,6 +516,29 @@ edit of the ring's tag.
     `0x50` `met` as one input to its activity classifier (`activity_model.rs`). [open_oura-act]
   - **Real Steps (feature `0x0B`) server gating [open_oura-feat]:** real_steps is behind the server flag `activity/real_steps` (default **false**; `FeatureDefinitions.ActivityRealSteps`, Gen 3+), the same server-flag-off pattern as SpO2 (§7.1). This explains `0x7E`/`0x7F` never once appearing across the PR #960 live sessions - the ring isn't sending them, it is not a NOOP decode gap. `0x50` itself is an always-on base stream (not feature-gated), matching it appearing in every session.
 - **`0x7E`/`0x7F` real_steps_features 1/2** (18 B each): bit-packed step features merged across the paired events. **(UNVERIFIED - partial)** [ringverse]
+  - **Unpack formula ([oura-rs] - Th0rgal/open_oura `crates/oura-protocol/src/events.rs#L566`, clean-room
+    fact citation): 14 fields from the 14-byte body.** Fields 0 and 8 are genuine 9-bit values built as
+    `byte*2 + carry_bit`, where the carry bit is stolen from the MSB of a neighboring byte (byte 3's MSB
+    for field 0, byte 11's MSB for field 8) - the same byte then supplies field 3 / field 11 from its own
+    low 7 bits. Fields 1, 2, 9, 10 are a bare `byte<<1` (no carry completion). Fields 4-7 and 12-13 are
+    plain bytes. The source itself marks this decode `"_status": "unvalidated"`.
+  - **Wired into a decoder (both platforms, Tier B) and cross-correlated against a real capture**
+    (2026-07-30, 2661 real_steps pairs anchored against the already-anchored 0x50 MET corpus from the
+    SAME session): `fields[0]` and `fields[8]` - the two carry-completed 9-bit values - are the ONLY
+    fields with a consistent movement correlation (r≈+0.3 vs mean MET; effect size +1.5/+1.25
+    resting-vs-moving on the same capture). This is a real convergence between the bit-layout hint (these
+    two fields are structurally distinct from the other 12) and the empirical signal, and the current
+    leading candidate for "the step field" - but it is NOT proof: one capture, correlated against a
+    coarse 60 s MET proxy, not against a ground-truth step count. No monotonic/cumulative counter
+    signature was found in ANY of the 14 fields (all show ~50/50 increase/decrease with frequent large
+    resets), so if a step count is in here at all it reads as a per-30s-window value, not a running total.
+    Cadence is fixed: 300 ring-ticks (30 s) between consecutive pairs.
+  - Still Tier B end to end: decoded only behind `allowTierB`, logged once per session + appended to a
+    diagnostic JSONL sidecar (`oura-real-steps-<id>.jsonl`, deduped by ring-time), never folded into
+    `OuraStreamMapping`/scoring - not even from fields[0]/fields[8]. The rigorous next step is a
+    controlled-walk capture: a known step count read against the Oura app's own number, to test every
+    field against ground truth rather than a proxy. `OuraDecoders.decodeRealStepsFields` (Swift) /
+    `Decoders.decodeRealStepsFields` (Kotlin).
 
 ### 6.14 Raw PPG
 - **`0x67` raw_ppg_summary** (12–13 B): start-UTC, type, scale, session header for following data. [ringverse]


### PR DESCRIPTION
  ## Summary
  - Wires a cited third-party unpack formula ([oura-rs] - Th0rgal/open_oura
    `crates/oura-protocol/src/events.rs#L566`, clean-room fact citation) into a real decoder on both
    platforms: 14 fields from a 14-byte body. Two fields (0 and 8) are genuine 9-bit values built as
    `byte*2 + carry_bit`, where the carry bit is stolen from a neighboring byte's MSB; the rest are plain
    bytes or a bare `byte<<1`. Applies the same unpack to both `0x7E` and `0x7F` bodies.
  - Cross-correlated the decode against a real 2661-pair Gen 3 capture (2026-07-30), anchored against the
    already-anchored `0x50` MET corpus from the same session: `fields[0]` and `fields[8]` - the two
    carry-completed 9-bit values - are the ONLY fields with a consistent movement correlation (r≈+0.3 vs
    mean MET, effect size +1.5/+1.25 resting-vs-moving). Real convergence between the bit-layout hint and
    the empirical signal, and the current leading candidate for "the step field" - but explicitly **not
    proof**: one capture against a coarse MET proxy, not a ground-truth step count, and no field shows a
    monotonic/cumulative-counter signature.
  - Stays **Tier B end to end**: `allowTierB`-gated, `OuraStreamMapping` drops it unconditionally on both
    platforms, surfaced only via a diagnostic JSONL sidecar (`oura-real-steps-<id>.jsonl`, deduped by
    ring-time) so a future controlled-walk capture (known step count vs the Oura app's own number) can test
    every field against ground truth.
  - `docs/OURA_PROTOCOL.md` §6.13 updated with the wiring + validation findings.

  ## Test plan
  - [x] `swift test` — `Packages/OuraProtocol` (165 tests) and `Packages/WhoopStore` (all green), including
        new real-capture golden fixtures (two consecutive real 0x7E/0x7F pairs) + a synthetic carry-bit
        isolation test + Tier-B-gate/wrong-length drop tests.
  - [x] `xcodebuild -scheme Strand -destination 'platform=macOS'` — compiles clean with the new
        `OuraRealStepsDump` sidecar wired into `OuraLiveSource.swift`.
  - [x] `./gradlew compileFullDebugKotlin` — compiles clean.
  - [x] `./gradlew testFullDebugUnitTest` — all 6 new `RealStepsFields*` tests pass, plus updated
        `OuraStreamMappingTest`/`OuraRealStepsDumpLineTest`. The only 3 failures in the full 3236-test run
        (`AiCoachContextTest`, `StandardHrSensorFormatTest` x2) are pre-existing and unrelated — confirmed
        identical failures on unmodified `main` in a clean worktree.
  - [ ] Not yet cross-checked against a known step count on hardware (controlled walk) - stays Tier B /
        diagnostic-only until that happens.