### PR TITLE
Stop the capture check reading its own output as evidence

### DIFF
--- a/android/app/src/main/java/com/noop/testcentre/TestBundleAssembler.kt
+++ b/android/app/src/main/java/com/noop/testcentre/TestBundleAssembler.kt
@@ -172,11 +172,16 @@ object TestBundleAssembler {
             storage = storage ?: TestBundleMeta.Storage(dbBytes = 0, rows = emptyMap(), rawCaptureBytes = 0),
             redaction = REDACTION_VERSION,
             truncated = truncated,
-            // The same completeness guard, machine-readable. Computed over the SHIPPING report.txt (the
-            // capped, redacted one) so meta.capture_check and the report.txt section can never disagree:
-            // a non-MASTER report keeps report.txt small, and the cap only ever trims raw-capture, so the
-            // report body the guard read above is byte-identical to the one in `capped`.
-            captureCheck = ReportCompleteness.captureCheckMeta(reportText, activeDomains).let {
+            // The same completeness guard, machine-readable — over `reportBody`, the SAME text the section
+            // above was computed from, NOT the report.txt that already has that section appended.
+            //
+            // Scanning the appended text made the check poison its own evidence: a MISSING domain renders
+            // as `<id>: MISSING (expected <killer token>)`, and that line CONTAINS the killer token, so the
+            // re-scan found it and recorded "present". Every missing trace flipped, and `complete` went true
+            // while report.txt said INCOMPLETE — seen in the wild on #950, whose export claimed
+            // `workouts: present` above a report reading `workouts: MISSING (expected session event=)`.
+            // The Swift twin never had this: it evaluates once and uses that one result for both.
+            captureCheck = ReportCompleteness.captureCheckMeta(reportBody, activeDomains).let {
                 TestBundleMeta.CaptureCheck(traces = it.traces, complete = it.complete)
             },
         )

--- a/android/app/src/test/java/com/noop/testcentre/ReportCompletenessParityTest.kt
+++ b/android/app/src/test/java/com/noop/testcentre/ReportCompletenessParityTest.kt
@@ -114,6 +114,40 @@ class ReportCompletenessParityTest {
         )
     }
 
+    /**
+     * #950 — the capture check must not read its OWN output as evidence.
+     *
+     * The section renders a missing domain as `<id>: MISSING (expected <killer token>)`, and that line
+     * contains the killer token. meta.json's capture_check was computed over report.txt AFTER the section
+     * was appended, so the re-scan found the token inside its own "expected …" text and recorded the
+     * domain as present. Every missing trace flipped and `complete` went true while report.txt said
+     * INCOMPLETE — a bug report that says it carries a workouts trace, attached to a report that says it
+     * does not. Seen on #950.
+     *
+     * The Swift twin evaluates once and reuses that result, which is why only Android had it.
+     */
+    @Test fun metaMustNotBeComputedOverTextContainingTheSection() {
+        val body = "header\ndayOwner day=D readId=x writeActiveId=x hrRows=0 provenance=none\nbody"
+        val active = setOf(TestDomain.WORKOUTS)
+        val section = ReportCompleteness.captureCheckSection(body, active)
+        // The section itself carries the killer token, in the "expected …" label.
+        assertTrue(section.contains("session event="))
+
+        // Scanned over the body (correct): MISSING and not complete.
+        val fromBody = ReportCompleteness.captureCheckMeta(body, active)
+        assertEquals("MISSING", fromBody.traces["workouts"])
+        assertEquals(false, fromBody.complete)
+
+        // Scanned over body+section (the bug): the check reads its own words back as evidence.
+        val poisoned = ReportCompleteness.captureCheckMeta(body + "\n" + section, active)
+        assertEquals(
+            "the section's own 'expected session event=' must not count as the trace landing",
+            "present", poisoned.traces["workouts"],
+        )
+        // Pinned as the REASON the assembler must pass the pre-append body: if this ever stops being
+        // "present", the self-poisoning is gone at the source and the assembler's argument can relax.
+    }
+
     @Test fun captureCheckSectionExactText_incomplete() {
         // dayOwner present (universal informational), but the active sleep + connection traces never landed.
         val report = "header\ndayOwner day=D readId=x writeActiveId=x hrRows=0 provenance=none\nbody"


### PR DESCRIPTION
Found while reading the export attached to #950.

## The bug

`meta.json`'s `capture_check` was computed over **report.txt after the Capture-check section had been
appended to it**. A missing domain renders as

```
workouts: MISSING (expected session event=)
```

and that line *contains* the killer token `session event=`. So the re-scan found the token inside the
check's own "expected …" label and recorded the domain as **present**. Every missing trace flipped, and
`complete` went `true` while report.txt said `INCOMPLETE`.

## It is not theoretical

The export attached to #950 says this in `meta.json`:

```json
"capture_check": { "complete": true, "traces": { "universal": "present", "workouts": "present" } }
```

directly above a `report.txt` reading `workouts: MISSING (expected session event=)` and
`INCOMPLETE: missing workouts`.

So a reporter attaches a workouts capture that contains no workouts trace, and the machine-readable field
a maintainer would filter on says the capture is complete. I lost a round of investigation on #950 to
exactly this before noticing the two disagreed.

## The fix

Compute it over `reportBody` — the same pre-append text the section itself was built from. One argument.

**Android-only.** The Swift twin never had it: `TestBundleAssembler.swift` evaluates
`CaptureCompleteness.evaluate(...)` once and passes that same `checks` value to both the section and
`meta.json`. Kotlin computed it twice, and the second read was contaminated. Worth noting the comment on
the old line claimed the two "can never disagree" — that was the invariant being broken.

## Test

The regression test asserts the hazard rather than only the fix: it checks that the section *does* carry
the killer token, that scanning the body gives `MISSING` / `complete: false`, and that scanning
body+section still returns `"present"`. If someone reroutes the argument the test speaks up; if the
self-poisoning is ever removed at source, the last assertion is the signal that the assembler's argument
can relax.

Verified `ReportCompleteness.kt` compiles clean (0 errors with the package's deps on the path);
`doc_comment_lint` clean. Android CI runs the suite.
