### PR TITLE
Rescore workouts against the measured resting HR, not a hardcoded 60 (#950)

### DIFF
--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/ManualWorkoutRescore.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/ManualWorkoutRescore.swift
@@ -42,14 +42,22 @@ public enum ManualWorkoutRescore {
     /// Recompute avg/peak HR, strain and calories from `windowSamples` (the HR now stored for the
     /// workout's [start, end]). Returns nil when there are too few samples to score meaningfully — i.e.
     /// nothing better than what we already had.
-    public static func scored(windowSamples: [HRSample], profile: UserProfile, hrMax: Double) -> Scored? {
+    /// `restingHR` is the wearer's MEASURED resting HR (#950): the strain %HRR denominator needs it, and the
+    /// calories model's active-vs-resting threshold sits at resting + 30% HRR, and both used to silently fall back to a hardcoded 60 here while the
+    /// DAY total was scored against the measured value — so a fit wearer's workout was systematically
+    /// under-scored relative to the very day it sat in. nil keeps the old default (a cold start with no
+    /// measured resting yet), so existing callers are byte-identical until they thread one.
+    public static func scored(windowSamples: [HRSample], profile: UserProfile, hrMax: Double,
+                              restingHR: Double? = nil) -> Scored? {
         guard windowSamples.count >= 2 else { return nil }
         let bpms = windowSamples.map(\.bpm)
         let avg = Int((Double(bpms.reduce(0, +)) / Double(bpms.count)).rounded())
         let peak = bpms.max() ?? 0
-        let strain = StrainScorer.strain(windowSamples, maxHR: hrMax, sex: profile.sex)
+        let strain = StrainScorer.strain(windowSamples, maxHR: hrMax,
+                                         restingHR: restingHR ?? StrainScorer.defaultRestingHR,
+                                         sex: profile.sex)
         let kcalRaw = Calories.estimateBoutCalories(windowSamples, profile: profile,
-                                                    hrmax: hrMax, restingHR: nil).0
+                                                    hrmax: hrMax, restingHR: restingHR).0
         return Scored(avgHr: avg, maxHr: peak, strain: strain, kcal: kcalRaw > 0 ? kcalRaw : nil)
     }
 

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/ManualWorkoutRescoreRestingHrTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/ManualWorkoutRescoreRestingHrTests.swift
@@ -1,0 +1,55 @@
+import XCTest
+@testable import StrandAnalytics
+import WhoopProtocol
+
+/// #950, second defect — a rescored workout must be scored against the wearer's MEASURED resting HR
+/// when one exists, not the hardcoded 60 the day total never uses.
+///
+/// The day's Effort passes the measured resting into the %HRR denominator; the workout rescore always
+/// took the default. For a fit wearer (resting well under 60) that widens the true heart-rate reserve,
+/// so every sample sits LOWER in the zone table than it should — the workout under-scores relative to
+/// the very day it sits in, which is the incomparability #950 reports.
+///
+/// Twin of Kotlin `ManualWorkoutRescoreRestingHrTest` — same fixtures, same expectations.
+final class ManualWorkoutRescoreRestingHrTests: XCTestCase {
+
+    private let profile = UserProfile(weightKg: 70, heightCm: 175, age: 35, sex: "male")
+    private let hrMax = 190.0
+
+    /// An hour at 148 bpm, 30 s cadence — chosen because the Edwards zone FLIPS with the reserve:
+    private func window() -> [HRSample] {
+        (0..<120).map { HRSample(ts: $0 * 30, bpm: 148) }
+    }
+
+    /// A measured resting of 45 must score the same window strictly higher than the default 60:
+    /// 148 bpm is 71.0% of a 45-resting reserve (zone 3) but 67.7% of a 60-resting one (zone 2).
+    func testMeasuredRestingScoresHigherThanTheDefaultForAFitWearer() {
+        let def = ManualWorkoutRescore.scored(windowSamples: window(), profile: profile, hrMax: hrMax)
+        let measured = ManualWorkoutRescore.scored(windowSamples: window(), profile: profile,
+                                                   hrMax: hrMax, restingHR: 45)
+        XCTAssertNotNil(def?.strain); XCTAssertNotNil(measured?.strain)
+        XCTAssertGreaterThan(measured!.strain!, def!.strain!)
+    }
+
+    /// nil keeps the old behaviour byte-for-byte — the cold-start path with no measured resting yet.
+    func testNilRestingIsByteIdenticalToTheOldCall() {
+        let old = ManualWorkoutRescore.scored(windowSamples: window(), profile: profile, hrMax: hrMax)
+        let explicit = ManualWorkoutRescore.scored(windowSamples: window(), profile: profile,
+                                                   hrMax: hrMax, restingHR: nil)
+        XCTAssertEqual(old, explicit)
+    }
+
+    /// The resting HR reaches the calories model too — but there it sets the ACTIVE THRESHOLD
+    /// (resting + 30% HRR), not the burn rate, so it only moves kcal when samples straddle the two
+    /// thresholds. 95 bpm does: active under a 45-resting threshold (88.5) and resting-rate under a
+    /// 60-resting one (99). The first version of this test used an all-hard window and failed on both
+    /// platforms with IDENTICAL kcal — asserting a mechanism the model doesn't have.
+    func testCaloriesSeeTheMeasuredRestingThroughTheActiveThreshold() {
+        let warmup = (0..<40).map { HRSample(ts: $0 * 30, bpm: 95) }
+        let mixed = warmup + (40..<160).map { HRSample(ts: $0 * 30, bpm: 148) }
+        let def = ManualWorkoutRescore.scored(windowSamples: mixed, profile: profile, hrMax: hrMax)!
+        let measured = ManualWorkoutRescore.scored(windowSamples: mixed, profile: profile,
+                                                   hrMax: hrMax, restingHR: 45)!
+        XCTAssertNotEqual(def.kcal, measured.kcal)
+    }
+}

--- a/Strand/Data/IntelligenceEngine.swift
+++ b/Strand/Data/IntelligenceEngine.swift
@@ -1485,7 +1485,16 @@ final class IntelligenceEngine: ObservableObject {
         // #137: a manually-started workout is scored from sparse live HR at save time , near-zero
         // calories/strain on a 5/MG. Now that offloaded HR may cover the window, re-score the
         // under-sampled ones from that denser data.
-        await rescoreManualWorkouts(store: store, profile: up)
+        // #950: score the workout against the wearer's MEASURED resting HR, not the hardcoded 60 —
+        // the day total above already uses the measured value, and the mismatch is what made a workout's
+        // Effort incomparable to its own day's. The most recent scored day that has one is the best
+        // available estimate; nil (cold start) keeps the old default. Twin of the Kotlin derivation.
+        // FIRST, not last: `out` is NEWEST-FIRST, because the scoring loop counts backwards from today
+        // (`for offset in 0..<maxDays` with `dayStart = nowLocalMidnight - offset * 86_400`), so out[0] is
+        // today and the tail is the oldest day in the window. Taking the last match would have scored
+        // today's workout against a resting HR up to `maxDays` old.
+        let measuredResting = out.first(where: { $0.rhr != nil })?.rhr.map(Double.init)
+        await rescoreManualWorkouts(store: store, profile: up, restingHR: measuredResting)
 
         results = out
         note = out.isEmpty
@@ -1597,7 +1606,8 @@ final class IntelligenceEngine: ObservableObject {
     /// window, recompute from it. Conservative + idempotent: only `manual` rows that look under-scored
     /// (negligible calories), and only when the recompute is a genuine improvement , so a well-scored
     /// 4.0 workout is never touched and a still-sparse window is a no-op.
-    private func rescoreManualWorkouts(store: WhoopStore, profile up: UserProfile) async {
+    private func rescoreManualWorkouts(store: WhoopStore, profile up: UserProfile,
+                                       restingHR: Double? = nil) async {
         let now = Int(Date().timeIntervalSince1970)
         let since = now - 14 * 86_400
         guard let rows = try? await store.workouts(deviceId: deviceId, from: since, to: now, limit: 200)
@@ -1611,7 +1621,8 @@ final class IntelligenceEngine: ObservableObject {
             && (ManualWorkoutRescore.looksUnderScored(currentKcal: row.energyKcal) || row.strain == nil) {
             guard let samples = try? await store.hrSamples(deviceId: deviceId, from: row.startTs,
                                                            to: row.endTs, limit: 20_000),
-                  let s = ManualWorkoutRescore.scored(windowSamples: samples, profile: up, hrMax: hrMax),
+                  let s = ManualWorkoutRescore.scored(windowSamples: samples, profile: up, hrMax: hrMax,
+                                                      restingHR: restingHR),
                   ManualWorkoutRescore.improves(s, over: row.energyKcal, currentStrain: row.strain,
                                                 allowStrainOnlyFill: true)
             else { continue }

--- a/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
+++ b/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
@@ -1285,7 +1285,16 @@ object IntelligenceEngine {
         // #137: a manually-started workout is scored from sparse live HR at save time , near-zero
         // calories/strain on a 5/MG. Now that offloaded HR may cover the window, re-score the
         // under-sampled ones from that denser data.
-        rescoreManualWorkouts(repo, profile, importedDeviceId, maxHROverride, nowSeconds)
+        // #950: score the workout against the wearer's MEASURED resting HR, not the hardcoded 60 —
+        // the day total two lines up already uses the measured value, and the mismatch is what made a
+        // workout's Effort incomparable to its own day's. The most recent scored day that has one is the
+        // best available estimate; null (cold start) keeps the old default.
+        // FIRST, not last: `out` is NEWEST-FIRST, because the scoring loop counts backwards from today
+        // (`for (offset in 0 until maxDays)` with `dayStart = nowLocalMidnight - offset * SECONDS_PER_DAY`),
+        // so out[0] is today and the tail is the oldest day in the window. Taking the last match would have
+        // scored today's workout against a resting HR up to `maxDays` old.
+        val measuredResting = out.firstOrNull { it.rhr != null }?.rhr?.toDouble()
+        rescoreManualWorkouts(repo, profile, importedDeviceId, maxHROverride, nowSeconds, measuredResting)
 
         return out to healDropped.size
     }
@@ -1339,6 +1348,9 @@ object IntelligenceEngine {
         deviceId: String,
         maxHROverride: Double?,
         nowSeconds: Long,
+        // #950: the wearer's measured resting HR (most recent scored day), threaded into scored() so the
+        // rescore uses the same %HRR denominator as the day total. null → the scorer's default.
+        restingHR: Double? = null,
     ) {
         val since = nowSeconds - 14L * 86_400L
         val rows = runCatching { repo.workouts(deviceId, since, nowSeconds) }.getOrNull() ?: return
@@ -1352,7 +1364,7 @@ object IntelligenceEngine {
             if (!ManualWorkoutRescore.looksUnderScored(row.energyKcal) && row.strain != null) continue
             val samples = runCatching { repo.hrSamples(deviceId, row.startTs, row.endTs, 20_000) }
                 .getOrNull() ?: continue
-            val s = ManualWorkoutRescore.scored(samples, profile, hrMax) ?: continue
+            val s = ManualWorkoutRescore.scored(samples, profile, hrMax, restingHR) ?: continue
             if (!ManualWorkoutRescore.improves(s, row.energyKcal, row.strain, allowStrainOnlyFill = true)) continue
             // Never lower a summed kcal: only take the recomputed kcal when it genuinely beats the stored
             // value; a strain-only fill (merged row) keeps the existing summed energyKcal.

--- a/android/app/src/main/java/com/noop/analytics/ManualWorkoutRescore.kt
+++ b/android/app/src/main/java/com/noop/analytics/ManualWorkoutRescore.kt
@@ -33,16 +33,30 @@ object ManualWorkoutRescore {
         (currentKcal ?: 0.0) <= UNDER_SCORED_KCAL_THRESHOLD
 
     /** Recompute avg/peak HR, strain and calories from [windowSamples] (the HR now stored for the
-     *  workout's [start, end]). Returns null when there are too few samples to score meaningfully. */
-    fun scored(windowSamples: List<HrSample>, profile: UserProfile, hrMax: Double): Scored? {
+     *  workout's [start, end]). Returns null when there are too few samples to score meaningfully.
+     *
+     *  [restingHR] is the wearer's MEASURED resting HR (#950): the strain %HRR denominator needs it, and the
+     *  calories model's active-vs-resting threshold sits at resting + 30% HRR, and both used to silently fall back to a hardcoded 60 here while
+     *  the DAY total was scored against the measured value — so a fit wearer's workout was systematically
+     *  under-scored relative to the very day it sat in. null keeps the old default (a cold start with no
+     *  measured resting yet), so existing callers are byte-identical until they thread one. */
+    fun scored(
+        windowSamples: List<HrSample>,
+        profile: UserProfile,
+        hrMax: Double,
+        restingHR: Double? = null,
+    ): Scored? {
         if (windowSamples.size < 2) return null
         val bpms = windowSamples.map { it.bpm }
         // Integer mean, matching AppViewModel.endWorkout (Android truncates; iOS rounds — each mirrors
         // its own platform's save-time formula).
         val avg = bpms.sum() / bpms.size
         val peak = bpms.maxOrNull() ?: 0
-        val strain = StrainScorer.strain(windowSamples, maxHR = hrMax, sex = profile.sex)
-        val kcalRaw = Calories.estimateBoutCalories(windowSamples, profile, hrMax, null).first
+        val strain = StrainScorer.strain(
+            windowSamples, maxHR = hrMax,
+            restingHR = restingHR ?: StrainScorer.defaultRestingHR, sex = profile.sex,
+        )
+        val kcalRaw = Calories.estimateBoutCalories(windowSamples, profile, hrMax, restingHR).first
         return Scored(avg, peak, strain, if (kcalRaw > 0) kcalRaw else null)
     }
 

--- a/android/app/src/test/java/com/noop/analytics/ManualWorkoutRescoreRestingHrTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/ManualWorkoutRescoreRestingHrTest.kt
@@ -1,0 +1,67 @@
+package com.noop.analytics
+
+import com.noop.data.HrSample
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * #950, second defect — a rescored workout must be scored against the wearer's MEASURED resting HR
+ * when one exists, not the hardcoded 60 the day total never uses.
+ *
+ * The day's Effort passes the measured resting into the %HRR denominator; the workout rescore always
+ * took the default. For a fit wearer (resting well under 60) that widens the true heart-rate reserve,
+ * so every sample sits LOWER in the zone table than it should — the workout under-scores relative to
+ * the very day it sits in, which is the incomparability #950 reports.
+ *
+ * Twin of Swift `ManualWorkoutRescoreRestingHrTests` — same fixtures, same expectations.
+ */
+class ManualWorkoutRescoreRestingHrTest {
+
+    private val profile = UserProfile(weightKg = 70.0, heightCm = 175.0, age = 35.0, sex = "male")
+    private val hrMax = 190.0
+
+    /** An hour at 148 bpm, 30 s cadence — chosen because the Edwards zone FLIPS with the reserve: */
+    private fun window(): List<HrSample> =
+        (0 until 120).map { HrSample(deviceId = "t", ts = it * 30L, bpm = 148) }
+
+    /** A measured resting of 45 must score the same window strictly higher than the default 60:
+     *  148 bpm is 71.0% of a 45-resting reserve (zone 3) but 67.7% of a 60-resting one (zone 2). */
+    @Test
+    fun measuredRestingScoresHigherThanTheDefaultForAFitWearer() {
+        val default = ManualWorkoutRescore.scored(window(), profile, hrMax)
+        val measured = ManualWorkoutRescore.scored(window(), profile, hrMax, restingHR = 45.0)
+        assertNotNull(default?.strain); assertNotNull(measured?.strain)
+        assertTrue(
+            "resting 45 (${measured!!.strain}) must out-score the default 60 (${default!!.strain})",
+            measured.strain!! > default.strain!!,
+        )
+    }
+
+    /** null keeps the old behaviour byte-for-byte — the cold-start path with no measured resting yet. */
+    @Test
+    fun nullRestingIsByteIdenticalToTheOldCall() {
+        val old = ManualWorkoutRescore.scored(window(), profile, hrMax)
+        val explicit = ManualWorkoutRescore.scored(window(), profile, hrMax, restingHR = null)
+        assertEquals(old, explicit)
+    }
+
+    /** The resting HR reaches the calories model too — but there it sets the ACTIVE THRESHOLD
+     *  (resting + 30% HRR), not the burn rate, so it only moves kcal when samples straddle the two
+     *  thresholds. 95 bpm does: active under a 45-resting threshold (88.5) and resting-rate under a
+     *  60-resting one (99). The first version of this test used an all-hard window and failed on both
+     *  platforms with IDENTICAL kcal — asserting a mechanism the model doesn't have. */
+    @Test
+    fun caloriesSeeTheMeasuredRestingThroughTheActiveThreshold() {
+        val warmup = (0 until 40).map { HrSample(deviceId = "t", ts = it * 30L, bpm = 95) }
+        val mixed = warmup + (40 until 160).map { HrSample(deviceId = "t", ts = it * 30L, bpm = 148) }
+        val default = ManualWorkoutRescore.scored(mixed, profile, hrMax)!!
+        val measured = ManualWorkoutRescore.scored(mixed, profile, hrMax, restingHR = 45.0)!!
+        assertTrue(
+            "the 95 bpm warm-up is active under resting 45 but not 60, so kcal must differ " +
+                "(${default.kcal} vs ${measured.kcal})",
+            default.kcal != measured.kcal,
+        )
+    }
+}


### PR DESCRIPTION
Split out of #963 so each half stands on its own evidence. **This one is confirmed against the reporter's
data; the sample-duration half in #963 is not.**

## The bug

The day's Effort passes the wearer's measured resting HR into the %HRR denominator. The workout rescore
never did — `ManualWorkoutRescore.scored` took `StrainScorer`'s default of **60**, and its calories call
passed `null`, which lands on the same default.

For a fit wearer the real reserve is wider, so every sample sits lower in the Edwards zone table than it
should, and the workout under-scores against the very day it sits in. That mismatch is the
incomparability #950 reports.

## Confirmed on real data

#950's export: `rhr day=2026-07-30 floor=50`. His measured resting is 50; his workouts were scored
against 60. A 10 bpm error in the denominator, on a real user, not a modelled shape.

## The change

`scored()` gains `restingHR` — `null` keeps the old behaviour byte for byte, so a cold start with no
measured resting is unchanged rather than inventing a number. It reaches both the strain denominator and
the calories active-threshold.

The engine derives it from the days it just scored: the **first** `Computed` carrying a measured `rhr`,
because `out` is newest-first — both engines run `for offset in 0..<maxDays` counting backwards from
today. Same derivation on both platforms.

**Still default-60, deliberately:** the display-fill and live-session paths. Those are transient
renderings, and threading a resting source through app-target code on both platforms is its own change.

## Tests

Twin files, same fixtures. The strain fixture is **148 bpm** specifically because the Edwards zone flips
with the reserve there (67.7% of a 60-resting reserve = zone 2; 71.0% of a 45-resting one = zone 3) — my
first attempt used 145, which sits in zone 2 under *both* restings and would have passed as a vacuous
equality.

The kcal test straddles the active threshold (a 95 bpm warm-up: active under a 45-resting threshold of
88.5, resting-rate under a 60-resting one of 99). My first version asserted the resting HR reaches the
burn *rate*; it doesn't, it only sets the threshold — and both platforms failed with identical kcal,
which is the parity contract doing its job.

`null`-resting is pinned byte-identical on both sides.
