### PR TITLE
Haptics: stop the app claiming things the 5/MG buzz cannot do (#926)

### DIFF
--- a/Packages/WhoopProtocol/Sources/WhoopProtocol/HapticPayloads.swift
+++ b/Packages/WhoopProtocol/Sources/WhoopProtocol/HapticPayloads.swift
@@ -21,6 +21,14 @@ public enum MaverickHaptics {
     /// 12-byte payload for RUN_HAPTIC_PATTERN_MAVERICK (cmd 19/0x13) — a one-shot buzz on a 5/MG
     /// strap: `[REVISION_1][waveFormEffect1..8][loopControlForEffects u16 LE = 0][overallLoop]`.
     /// `loops` maps to overallWaveformLoopControl; the official "buzz once" notification is 1.
+    ///
+    /// NOTHING SHIPS THIS (#926). `BLEManager.send` / `WhoopBleClient.send` substitute their own literal
+    /// `[0x01, 47, 152, 0, …, 0]` for a 5/MG buzz, whose `overallLoop` is 0 — so the caller's repeat count
+    /// never reaches the wire and this function's only callers are two assertions in
+    /// `DeviceFamilyFramingTests`. There is no Kotlin twin. Kept because it is the only code that knows how
+    /// to build a VARIABLE-loop buzz body, which is exactly what a future test of `overallLoop != 0` would
+    /// need; the shipped literal is hardware-confirmed at 0 and deliberately unchanged until someone probes
+    /// it (the alarm path already ships 7, so the field itself is accepted non-zero).
     public static func notificationBuzz(loops: Int) -> [UInt8] {
         [0x01] + waveformEffects + [0x00, 0x00, UInt8(clamping: loops)]
     }

--- a/Strand/App/AppModel.swift
+++ b/Strand/App/AppModel.swift
@@ -1019,11 +1019,6 @@ final class AppModel: ObservableObject {
         ble.buzzStrapOnce()
     }
 
-    /// Fire a specific preset haptic pattern (patternId 0–6 on Harvard; loops sets length).
-    /// Used by the notification-pattern picker and coaching features.
-    func buzz(pattern: UInt8, loops: UInt8 = 1) {
-        ble.send(.runHapticsPattern, payload: [pattern, loops, 0, 0, 0])
-    }
 
     /// Tell the strap to STOP an in-progress haptic pattern (#769). The biofeedback layers (Breathe /
     /// "Calm me" / resonance) schedule a stream of buzzes; cancelling the app-side DispatchWorkItems stops

--- a/Strand/Screens/NotificationSettingsView.swift
+++ b/Strand/Screens/NotificationSettingsView.swift
@@ -15,6 +15,19 @@ struct NotificationSettingsView: View {
             VStack(alignment: .leading, spacing: NoopMetrics.sectionSpacing) {
                 masterCard
                     .staggeredAppear(index: 0)
+                // #926: on a 5/MG the buzz payload is a hardcoded 12-byte literal whose byte[11]
+                // (overallLoop) is 0, so the caller's repeat count never reaches the wire — every
+                // BuzzPattern produces the same buzz. The picker still offers all four because the choice
+                // is stored per app and DOES apply to a WHOOP 4.0, so hiding it would lose a real setting.
+                // Say so instead, the way SmartAlarmView handles its own 5/MG-unconfirmed case, rather
+                // than leaving a control that silently does nothing.
+                if model.whoop5Detected {
+                    Text("Every pattern buzzes the same on a WHOOP 5/MG — the repeat count isn't sent to that strap. Your choice is saved and applies to a WHOOP 4.0.")
+                        .font(StrandFont.caption)
+                        .foregroundStyle(StrandPalette.textSecondary)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .staggeredAppear(index: 0)
+                }
                 if store.activeCategories.isEmpty {
                     emptyAppsCard
                         .staggeredAppear(index: 1)

--- a/android/app/src/main/java/com/noop/ui/NotificationsSettingsScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/NotificationsSettingsScreen.kt
@@ -354,6 +354,20 @@ fun NotificationsSettingsScreen(vm: AppViewModel) {
             onTest = { vm.buzz(loops = callsPattern.loops) },
         )
 
+        // #926: on a 5/MG the buzz payload is a hardcoded 12-byte literal and byte[11] (overallLoop) is
+        // 0, so the caller's repeat count never reaches the wire — every BuzzPattern produces the same
+        // buzz. The picker still offers all four because the choice is stored per app and DOES apply to a
+        // WHOOP 4.0, so hiding it would lose a real setting. Say so instead, the way SmartAlarmScreen
+        // handles its own 5/MG-unconfirmed case, rather than leaving a control that silently does nothing.
+        if (live.whoop5Detected) {
+            Text(
+                uiString(R.string.l10n_notifications_settings_screen_every_pattern_buzzes_the_same_on_34e873f6),
+                style = NoopType.caption,
+                color = Palette.textSecondary,
+                modifier = Modifier.padding(horizontal = Metrics.space16, vertical = Metrics.space8),
+            )
+        }
+
         // MARK: Category cards
         activeCategories.forEach { cat ->
             CategoryCard(

--- a/android/app/src/main/java/com/noop/ui/NotificationsSettingsScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/NotificationsSettingsScreen.kt
@@ -64,6 +64,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import androidx.core.content.ContextCompat
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.noop.ble.WhoopModel
 import com.noop.notif.CallAlertController
 import com.noop.notif.CallAlertSource
 import java.util.Calendar
@@ -359,7 +360,15 @@ fun NotificationsSettingsScreen(vm: AppViewModel) {
         // buzz. The picker still offers all four because the choice is stored per app and DOES apply to a
         // WHOOP 4.0, so hiding it would lose a real setting. Say so instead, the way SmartAlarmScreen
         // handles its own 5/MG-unconfirmed case, rather than leaving a control that silently does nothing.
-        if (live.whoop5Detected) {
+        // Match the Settings #22 gate (SettingsScreen showFiveMGControls, mirrored in TestCentreScreen:87):
+        // the stored model OR a live-detected 5/MG this session. `live.whoop5Detected` alone is reset on
+        // every scan and disconnect, so keying on it would hide this note whenever the strap is offline —
+        // which is exactly when someone browses notification settings. The Apple side reads `selectedModel`,
+        // which persists, so gating on live detection here would also make the two platforms disagree.
+        val fiveMgSelected = remember {
+            NoopPrefs.of(context).getString("noop.selectedWhoopModel", null) == WhoopModel.WHOOP5_MG.name
+        }
+        if (fiveMgSelected || live.whoop5Detected) {
             Text(
                 uiString(R.string.l10n_notifications_settings_screen_every_pattern_buzzes_the_same_on_34e873f6),
                 style = NoopType.caption,

--- a/android/app/src/main/res/values-de/strings.xml
+++ b/android/app/src/main/res/values-de/strings.xml
@@ -1799,4 +1799,5 @@
     <string name="l10n_app_changelog_battery_saver_quiets_the_gauges_translated_bdbe8650">Energiesparmodus beruhigt die Anzeigen, übersetzte Android-Benachrichtigungen und sofort geladene Diagramme</string>
     <string name="l10n_health_screen_no_spo_import_or_health_value_408f8c55">Kein SpO₂-Import- oder Health-Wert</string>
     <string name="l10n_health_screen_raw_counts_only_needs_an_import_d0e33552">Nur Rohwerte — Import erforderlich</string>
+    <string name="l10n_notifications_settings_screen_every_pattern_buzzes_the_same_on_34e873f6">Auf einer WHOOP 5/MG vibriert jedes Muster gleich — die Wiederholungszahl wird an dieses Band nicht gesendet. Deine Auswahl wird gespeichert und gilt für eine WHOOP 4.0.</string>
 </resources>

--- a/android/app/src/main/res/values-es/strings.xml
+++ b/android/app/src/main/res/values-es/strings.xml
@@ -1784,4 +1784,5 @@
     <string name="l10n_app_changelog_battery_saver_quiets_the_gauges_translated_bdbe8650">El ahorro de batería calma los indicadores, notificaciones de Android traducidas y gráficos instantáneos</string>
     <string name="l10n_health_screen_no_spo_import_or_health_value_408f8c55">Sin importación de SpO₂ ni valor de Health</string>
     <string name="l10n_health_screen_raw_counts_only_needs_an_import_d0e33552">Solo valores brutos — requiere importación</string>
+    <string name="l10n_notifications_settings_screen_every_pattern_buzzes_the_same_on_34e873f6">En una WHOOP 5/MG todos los patrones vibran igual: el número de repeticiones no se envía a esa correa. Tu elección se guarda y se aplica a una WHOOP 4.0.</string>
 </resources>

--- a/android/app/src/main/res/values-fr/strings.xml
+++ b/android/app/src/main/res/values-fr/strings.xml
@@ -1784,4 +1784,5 @@
     <string name="l10n_app_changelog_battery_saver_quiets_the_gauges_translated_bdbe8650">L\'économiseur de batterie fige les jauges, notifications Android traduites et graphiques instantanés</string>
     <string name="l10n_health_screen_no_spo_import_or_health_value_408f8c55">Aucune importation SpO₂ ni valeur Santé</string>
     <string name="l10n_health_screen_raw_counts_only_needs_an_import_d0e33552">Valeurs brutes uniquement — importation requise</string>
+    <string name="l10n_notifications_settings_screen_every_pattern_buzzes_the_same_on_34e873f6">Sur un WHOOP 5/MG, tous les motifs vibrent de la même façon — le nombre de répétitions n\'est pas envoyé à ce bracelet. Votre choix est enregistré et s\'applique à un WHOOP 4.0.</string>
 </resources>

--- a/android/app/src/main/res/values-pt-rPT/strings.xml
+++ b/android/app/src/main/res/values-pt-rPT/strings.xml
@@ -1778,4 +1778,5 @@
     <string name="l10n_app_changelog_battery_saver_quiets_the_gauges_translated_bdbe8650">A poupança de bateria acalma os indicadores, notificações Android traduzidas e gráficos instantâneos</string>
     <string name="l10n_health_screen_no_spo_import_or_health_value_408f8c55">Sem importação de SpO₂ ou valor de saúde</string>
     <string name="l10n_health_screen_raw_counts_only_needs_an_import_d0e33552">Apenas valores brutos — requer importação</string>
+    <string name="l10n_notifications_settings_screen_every_pattern_buzzes_the_same_on_34e873f6">Numa WHOOP 5/MG todos os padrões vibram igual — a contagem de repetições não é enviada para essa bracelete. A tua escolha fica guardada e aplica-se a uma WHOOP 4.0.</string>
 </resources>

--- a/android/app/src/main/res/values-zh/strings.xml
+++ b/android/app/src/main/res/values-zh/strings.xml
@@ -1712,4 +1712,5 @@
     <string name="l10n_app_changelog_battery_saver_quiets_the_gauges_translated_bdbe8650">省电模式让仪表静止、Android 通知已翻译、图表秒开</string>
     <string name="l10n_health_screen_no_spo_import_or_health_value_408f8c55">无 SpO₂ 导入或健康数值</string>
     <string name="l10n_health_screen_raw_counts_only_needs_an_import_d0e33552">仅原始计数 — 需导入</string>
+    <string name="l10n_notifications_settings_screen_every_pattern_buzzes_the_same_on_34e873f6">在 WHOOP 5/MG 上所有模式的震动都相同——重复次数不会发送到该手环。你的选择会被保存，并在 WHOOP 4.0 上生效。</string>
 </resources>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -1810,4 +1810,5 @@
     <string name="l10n_app_changelog_battery_saver_quiets_the_gauges_translated_bdbe8650">Battery saver quiets the gauges, translated Android notifications, and instant chart loads</string>
     <string name="l10n_health_screen_no_spo_import_or_health_value_408f8c55">No SpO₂ import or Health value</string>
     <string name="l10n_health_screen_raw_counts_only_needs_an_import_d0e33552">Raw counts only — needs an import</string>
+    <string name="l10n_notifications_settings_screen_every_pattern_buzzes_the_same_on_34e873f6">Every pattern buzzes the same on a WHOOP 5/MG — the repeat count isn\'t sent to that strap. Your choice is saved and applies to a WHOOP 4.0.</string>
 </resources>

--- a/docs/BLE_REVERSE_ENGINEERING.md
+++ b/docs/BLE_REVERSE_ENGINEERING.md
@@ -741,7 +741,10 @@ as the 4.0 `event` post-hook fail closed.
 ## 6. Haptic preset discovery (GET_ALL_HAPTICS_PATTERN)
 
 The strap has a built-in table of haptic waveforms. `GET_ALL_HAPTICS_PATTERN` (command **80**) reports
-the device's preset patterns — **7 presets on the WHOOP 4.0 (Harvard)**, indexed `0–6`. They are fired
+the device's preset patterns — **7 presets on the WHOOP 4.0 (Harvard)**, indexed `0–6`. That count is
+a claim about the STRAP's own table, not about NOOP: it would be read with `GET_ALL_HAPTICS_PATTERN`
+(80), and neither platform has ever sent that command, so we have never enumerated it (#926). What the
+app exposes is four `BuzzPattern` choices, all sharing patternId 2. They are fired
 with `RUN_HAPTICS_PATTERN` (command **79**):
 
 ```text


### PR DESCRIPTION
Items 1 and 2 from #926 — @vishk23's finding. I verified every claim in that issue against the tree
first; all of them hold, including the two corrections he made to his own earlier statements.

## What users see today

On a 5/MG the buzz payload is a hardcoded 12-byte literal whose byte[11] (`overallLoop`) is **0**, so the
caller's repeat count never reaches the wire. All four `BuzzPattern` choices produce the same buzz — and
the picker offered them **ungated on both platforms** (`NotificationSettingsView.swift:180`,
`NotificationsSettingsScreen.kt:773`).

That is the part worth fixing now: a settings control that does nothing is worse than an absent one,
because the user concludes their strap is broken rather than the feature unsupported.

## What this does

**Keeps the picker, adds the truth.** The choice is stored per app and *does* apply to a WHOOP 4.0, so
hiding it would lose a real setting. The note follows the honesty wording `SmartAlarmView` /
`SmartAlarmScreen` already use for their own 5/MG-unconfirmed case, rather than inventing a pattern.
Translated into all six Android locales and all eight catalogue locales.

**Deletes `AppModel.buzz(pattern:loops:)`** — zero callers, and its docstring claimed *"used by the
notification-pattern picker"* when the picker calls `buzz(loops:)`.

**Corrects two claims that were becoming folklore:**
- `BLE_REVERSE_ENGINEERING.md`'s "7 presets" describes the *strap's* table, read via
  `GET_ALL_HAPTICS_PATTERN` (80) — a command neither platform has ever sent, so NOOP has never enumerated
  it. What the app exposes is four, all sharing patternId 2.
- `MaverickHaptics.notificationBuzz` now says plainly that nothing ships it, and why it is kept: it is the
  only code that can build a variable-loop body, which is exactly what a future `overallLoop != 0` test
  would need.

## What this deliberately does NOT do

**The payload is untouched.** The golden frame is hardware-confirmed at `overallLoop = 0`, nobody has
tried non-zero on `0x13`, and @vishk23 says so himself. The alarm path already ships `7`, so the field is
accepted non-zero by the strap — but proving it on the buzz path wants a staged probe (vary one byte, read
back, stop on refusal, as #932 does), not a blanket change to a proven payload. The `HELD` reasoning in
`CHANGELOG.md:2218` still stands.

The live-session intensity levels are also no-ops on 5/MG, but they are internal — no control claims
otherwise — so they get a code note in the follow-up rather than UI.

## One deliberate asymmetry in the gate

Android uses `stored model || live.whoop5Detected`; Apple uses `model.whoop5Detected` alone. That is not
an oversight:

- Android's `live.whoop5Detected` is reset to `false` on every scan and disconnect
  (`WhoopBleClient.kt:2416,2468`), so gating on it *alone* would hide the note whenever the strap is
  offline — which is exactly when someone browses notification settings. Hence the OR, matching the
  Settings #22 gate and `TestCentreScreen:87`.
- Apple's `isWhoop5` reads `selectedModel`, which persists, so it needs no OR to survive disconnection.

They agree in every settled state. They differ only in the transient first-pair window where a 5/MG is
connected before its pref is written: Android shows the note, Apple doesn't. Closing that would mean
plumbing a live-detection flag onto `LiveState` for a moment when nobody is on this screen, so it is
left — recorded here rather than discovered later as a divergence.

## Verification

`i18n_audit --ci` and `doc_comment_lint` clean. The Kotlin edit compiles: a partial compile of the touched
file yields the same two pre-existing errors as `main` (536 vs 544, the delta being unresolved `R.string`
and `Metrics` refs a single-file compile can't see). Android CI and the catalogue jobs are the real gate.

App-target Swift is not compiled by any CI job, so `NotificationSettingsView.swift` and `AppModel.swift`
rest on review — the change there is a `Text` in an existing `if` and a deletion with no remaining
references, which I checked.
