### PR TITLE
Hydration: import water from Apple Health and Health Connect (#949)

### DIFF
--- a/Strand/Data/HydrationStore.swift
+++ b/Strand/Data/HydrationStore.swift
@@ -38,6 +38,21 @@ enum HydrationStore {
     /// AppStorage key for the user's custom container size (ml) (#798). Default `cupML` until set.
     static let customSizeKey = "noop.hydrationCustomSizeML"
 
+    /// metricSeries key for water IMPORTED from the platform health store — Apple Health on iOS,
+    /// Health Connect on Android (#949). MUST match the Android `KEY_IMPORTED`.
+    ///
+    /// Kept in its own row rather than folded into `key` so the two can never be confused, because they
+    /// behave differently on write: `key` ACCUMULATES (each tap adds), while this one is REPLACED with
+    /// the platform's recomputed day sum on every sync. That replacement is what makes re-importing
+    /// idempotent without tracking a single sample id — HealthKit's `HKStatisticsCollectionQuery` and
+    /// Health Connect's day bucket both hand back the whole day's total, so writing it wholesale means a
+    /// second sync of the same day stores the same number, and a drink deleted in the source app makes
+    /// the figure go DOWN on the next sync instead of being stranded forever.
+    ///
+    /// The user's own taps are never touched by a sync, and imported water is never editable here — it
+    /// is owned by the app that logged it.
+    static let importedKey = "hydrationImported"
+
     static func entriesKey(forDay dayKey: String) -> String { entriesKeyPrefix + dayKey }
 }
 
@@ -91,14 +106,52 @@ enum HydrationEntries {
 
 extension Repository {
 
-    /// The total fluid (ml) logged for a local day (yyyy-MM-dd), or 0 when nothing has been logged that
-    /// day. The single row's value IS the day total (additive upsert). Mirrors Android `HydrationStore.total`.
+    /// The total fluid (ml) for a local day (yyyy-MM-dd) as the user should SEE it: what they logged by
+    /// hand plus whatever was imported from Apple Health / Health Connect (#949). 0 when neither exists.
+    /// Mirrors Android `HydrationStore.total`.
+    ///
+    /// Everything that DISPLAYS a day figure (Today card, ring, detail) wants this. Everything that
+    /// WRITES a hand-logged drink must use `hydrationManualTotal` instead — see there.
     func hydrationTotal(day: String) async -> Double {
+        await hydrationManualTotal(day: day) + hydrationImportedTotal(day: day)
+    }
+
+    /// Only what the user logged by hand — the row `logHydration` accumulates into.
+    ///
+    /// The write path MUST read this and not `hydrationTotal`: a quick-add stores `current + amount`, so
+    /// reading the combined figure would fold every imported millilitre into the manual row, and the next
+    /// sync would then add the imported water on top of the copy it had just made. One tap after an
+    /// import would silently double the day, and it would compound on every tap after that.
+    func hydrationManualTotal(day: String) async -> Double {
+        await metricSeriesValue(key: HydrationStore.key, day: day)
+    }
+
+    /// Only what came from the platform health store (#949). Replaced wholesale by each sync.
+    func hydrationImportedTotal(day: String) async -> Double {
+        await metricSeriesValue(key: HydrationStore.importedKey, day: day)
+    }
+
+    /// One day's value for a hydration-source series, or 0 when the row is absent.
+    private func metricSeriesValue(key: String, day: String) async -> Double {
         guard let store = await storeHandle() else { return 0 }
         let pts = (try? await store.metricSeries(deviceId: HydrationStore.sourceId,
-                                                 key: HydrationStore.key,
-                                                 from: day, to: day)) ?? []
+                                                 key: key, from: day, to: day)) ?? []
         return pts.first?.value ?? 0
+    }
+
+    /// Replace the imported-water total for each given local day with the platform's recomputed day sum
+    /// (#949). Called by the Apple Health sync; the Android twin is `HydrationStore.setImported`.
+    ///
+    /// REPLACES rather than adds, which is the whole reason this is idempotent — see `importedKey`. Days
+    /// the health store has no water for are written as 0 rather than skipped, so water deleted in the
+    /// source app disappears here too instead of lingering as a stale row.
+    func setImportedHydration(_ mlByDay: [String: Double]) async {
+        guard !mlByDay.isEmpty, let store = await storeHandle() else { return }
+        let points = mlByDay.map { MetricPoint(day: $0.key, key: HydrationStore.importedKey,
+                                               value: max(0, $0.value)) }
+        _ = try? await store.upsertMetricSeries(points, deviceId: HydrationStore.sourceId)
+        // Same reason as logHydration: hydration writes never bump refreshSeq.
+        noteHydrationChanged()
     }
 
     /// Log `amountMl` of fluid for `day` (defaults to today's local day). Reads the day's current total
@@ -109,7 +162,8 @@ extension Repository {
     func logHydration(amountMl: Int, day: String? = nil) async -> Double {
         let dayKey = day ?? Repository.localDayKey(Date())
         guard amountMl > 0, let store = await storeHandle() else { return await hydrationTotal(day: dayKey) }
-        let current = await hydrationTotal(day: dayKey)
+        // MANUAL total, never the combined one (#949) — see `hydrationManualTotal`.
+        let current = await hydrationManualTotal(day: dayKey)
         let next = current + Double(amountMl)
         _ = try? await store.upsertMetricSeries(
             [MetricPoint(day: dayKey, key: HydrationStore.key, value: next)],
@@ -119,7 +173,10 @@ extension Repository {
         Self.writeHydrationEntries(entries, day: dayKey)
         // #989: hydration writes never bump refreshSeq, so tell the Today card directly.
         noteHydrationChanged()
-        return next
+        // `next` is the manual row; callers of this return value display it, so hand back the combined
+        // figure (#949). Every in-tree caller discards it and re-reads, but a caller that trusted it
+        // would otherwise show a total that drops the imported water.
+        return next + (await hydrationImportedTotal(day: dayKey))
     }
 
     // MARK: - Per-entry edit/delete (#798)
@@ -163,7 +220,9 @@ extension Repository {
         }
         // #989: edits/deletes funnel through here; tell the Today card directly (see logHydration).
         noteHydrationChanged()
-        return total
+        // The entry list only ever describes hand-logged drinks, so re-deriving from it must not be
+        // allowed to erase the imported row — write the manual figure, return the combined one (#949).
+        return total + (await hydrationImportedTotal(day: dayKey))
     }
 
     // MARK: - Entry persistence (UserDefaults JSON, one array per local day)
@@ -192,14 +251,17 @@ extension Repository {
         let from = now.addingTimeInterval(-Double(n - 1) * 86_400)
         let fromKey = Repository.localDayKey(from)
         let toKey = Repository.localDayKey(now)
-        let byDay: [String: Double]
+        var byDay: [String: Double] = [:]
         if let store = await storeHandle() {
-            let pts = (try? await store.metricSeries(deviceId: HydrationStore.sourceId,
-                                                     key: HydrationStore.key,
-                                                     from: fromKey, to: toKey)) ?? []
-            byDay = Dictionary(pts.map { ($0.day, $0.value) }, uniquingKeysWith: { _, last in last })
-        } else {
-            byDay = [:]
+            // Both rows, summed per day (#949) — the bars have to agree with the Today card and the
+            // ring, and those read the combined `hydrationTotal`. Reading only the manual key here is
+            // what would make an imported day render short.
+            for key in [HydrationStore.key, HydrationStore.importedKey] {
+                let pts = (try? await store.metricSeries(deviceId: HydrationStore.sourceId,
+                                                         key: key,
+                                                         from: fromKey, to: toKey)) ?? []
+                for p in pts { byDay[p.day, default: 0] += p.value }
+            }
         }
         return (0..<n).map { i in
             let key = Repository.localDayKey(now.addingTimeInterval(-Double(n - 1 - i) * 86_400))

--- a/Strand/Screens/HydrationView.swift
+++ b/Strand/Screens/HydrationView.swift
@@ -29,6 +29,9 @@ struct HydrationView: View {
     /// #798 - today's individual logged drinks (for swipe-to-delete + tap-to-edit), and the entry being
     /// edited in the amount sheet (nil when the sheet is closed).
     @State private var entries: [HydrationEntry] = []
+    /// Water imported from Apple Health for today (#949) — part of `totalML`, surfaced separately so the
+    /// drinks card can show it as its own, non-editable line.
+    @State private var importedML: Double = 0
     @State private var editingEntry: HydrationEntry?
     /// #798 - the user's custom container size (ml), editable from the custom-size sheet. Persisted local-only.
     @AppStorage(HydrationStore.customSizeKey) private var customSizeML = HydrationGoal.cupML
@@ -183,10 +186,13 @@ struct HydrationView: View {
     // MARK: - Today's logged drinks (#798) - swipe to delete, tap to edit
 
     @ViewBuilder private var entriesSection: some View {
-        if !entries.isEmpty {
+        // Also shown when the only water today came from Apple Health (#949) — otherwise the ring would
+        // count drinks the screen never accounts for, and the day would look like it appeared from nowhere.
+        if !entries.isEmpty || importedML > 0 {
             card(padding: 18) {
                 VStack(alignment: .leading, spacing: NoopMetrics.gap) {
                     Text("Today's drinks").strandOverline()
+                    if importedML > 0 { importedRow }
                     // #842 — render rows in a plain VStack inside the page ScrollView. The previous nested,
                     // scroll-disabled List with a hardcoded `count * 44 + 8` height clipped every row past
                     // the third (real rows are taller than 44pt) and couldn't be scrolled to. Tap a row to
@@ -200,12 +206,40 @@ struct HydrationView: View {
                             }
                         }
                     }
-                    Text("Tap a drink to edit it, or use the trash to delete.")
-                        .font(StrandFont.footnote)
-                        .foregroundStyle(StrandPalette.textTertiary)
+                    if !entries.isEmpty {
+                        Text("Tap a drink to edit it, or use the trash to delete.")
+                            .font(StrandFont.footnote)
+                            .foregroundStyle(StrandPalette.textTertiary)
+                    }
                 }
             }
         }
+    }
+
+    /// Water Apple Health already had, from a hydration app or a smart bottle (#949).
+    ///
+    /// Deliberately not tappable and with no trash: NOOP does not own these drinks, and "deleting" one
+    /// here would be a lie — the next sync re-reads the same day from Health and the figure would come
+    /// straight back. Removing it for real means removing it in the app that logged it.
+    @ViewBuilder private var importedRow: some View {
+        HStack(spacing: 10) {
+            Image(systemName: "heart.text.square")
+                .font(.system(size: 13, weight: .semibold))
+                .foregroundStyle(StrandPalette.textSecondary)
+                .accessibilityHidden(true)
+            Text("From Apple Health")
+                .font(StrandFont.subhead)
+                .foregroundStyle(StrandPalette.textSecondary)
+            Spacer(minLength: 8)
+            Text("\(Int(importedML.rounded())) ml")
+                .font(StrandFont.subhead.weight(.semibold))
+                .foregroundStyle(StrandPalette.textPrimary)
+                .monospacedDigit()
+        }
+        .padding(.vertical, 6)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("\(Int(importedML.rounded())) millilitres from Apple Health. Edit it in the app that logged it.")
+        if !entries.isEmpty { Divider().opacity(0.4) }
     }
 
     /// One logged-drink row: the time it was logged + its amount (tap to edit) with a trailing trash.
@@ -381,6 +415,9 @@ struct HydrationView: View {
         totalML = await repo.hydrationTotal(day: Repository.localDayKey(Date()))
         history = await repo.hydrationHistory(days: 7)
         entries = repo.hydrationEntries()
+        // #949: `totalML` already includes this; read it separately so the drinks card can name where
+        // the difference came from instead of leaving an unexplained gap between the ring and the list.
+        importedML = await repo.hydrationImportedTotal(day: Repository.localDayKey(Date()))
     }
 }
 

--- a/StrandiOS/Health/HealthKitBridge.swift
+++ b/StrandiOS/Health/HealthKitBridge.swift
@@ -371,7 +371,11 @@ final class HealthKitBridge: ObservableObject {
         // sample in the day on each sync, so the figure this produces is a full replacement rather than a
         // delta, which is exactly what `setImportedHydration` wants. `notNoopAuthored` (applied inside
         // `collect`) keeps NOOP's own drinks out, so a tap in NOOP can never come back as an import.
-        await collect(.dietaryWater, unit: .literUnit(with: .milli), start: start, end: end, op: .cumulativeSum) { day, v in
+        //
+        // The result is KEPT here, unlike every aggregate above: the write below replaces the stored
+        // figure, so a failed query must not be mistaken for an authoritative zero and wipe the window.
+        let waterReadOk = await collect(.dietaryWater, unit: .literUnit(with: .milli),
+                                        start: start, end: end, op: .cumulativeSum) { day, v in
             var a = agg(day); a.waterMl = v; byDay[day] = a
         }
 
@@ -454,7 +458,7 @@ final class HealthKitBridge: ObservableObject {
             // Gated on the hydration toggle, which is opt-in and default OFF: an import must not quietly
             // populate a feature the user has turned off, and skipping it avoids writing a window of rows
             // nothing will read.
-            if UserDefaults.standard.bool(forKey: HydrationStore.enabledKey) {
+            if waterReadOk, UserDefaults.standard.bool(forKey: HydrationStore.enabledKey) {
                 var waterByDay: [String: Double] = [:]
                 var cursor = cal.startOfDay(for: start)
                 while cursor <= end {
@@ -843,21 +847,33 @@ final class HealthKitBridge: ObservableObject {
         NSCompoundPredicate(notPredicateWithSubpredicate: HKQuery.predicateForObjects(from: [HKSource.default()]))
     }
 
+    /// Returns TRUE when the query completed, FALSE when HealthKit handed back an error.
+    ///
+    /// Every aggregate caller ignores this: a failed type simply contributes nothing to `DayAgg` and the
+    /// affected fields stay nil, so no row is written for them. It matters only for a caller whose write
+    /// REPLACES rather than adds (#949 imported water), where "read nothing" and "there is nothing" are
+    /// the same empty result — and treating a failed query as an authoritative zero would wipe the
+    /// stored figure for the whole window.
+    @discardableResult
     private func collect(_ id: HKQuantityTypeIdentifier, unit: HKUnit, start: Date, end: Date,
-                         op: HKStatisticsOptions, sink: @escaping (String, Double) -> Void) async {
-        guard let type = HKQuantityType.quantityType(forIdentifier: id) else { return }
+                         op: HKStatisticsOptions, sink: @escaping (String, Double) -> Void) async -> Bool {
+        guard let type = HKQuantityType.quantityType(forIdentifier: id) else { return false }
         let cal = Calendar.current
         let anchor = cal.startOfDay(for: start)
         let predicate = NSCompoundPredicate(andPredicateWithSubpredicates: [
             HKQuery.predicateForSamples(withStart: start, end: end, options: .strictStartDate),
             Self.notNoopAuthored,
         ])
-        await withCheckedContinuation { (cont: CheckedContinuation<Void, Never>) in
+        return await withCheckedContinuation { (cont: CheckedContinuation<Bool, Never>) in
             let q = HKStatisticsCollectionQuery(quantityType: type, quantitySamplePredicate: predicate,
                                                 options: op, anchorDate: anchor,
                                                 intervalComponents: DateComponents(day: 1))
-            q.initialResultsHandler = { _, results, _ in
-                results?.enumerateStatistics(from: start, to: end) { stats, _ in
+            q.initialResultsHandler = { _, results, error in
+                // A nil `results` with an error is a FAILED read, not an empty one — see the note on
+                // the return value. Both are reported as false so the caller can tell them apart from
+                // a query that genuinely found nothing.
+                guard error == nil, let results else { cont.resume(returning: false); return }
+                results.enumerateStatistics(from: start, to: end) { stats, _ in
                     let q: HKQuantity?
                     switch op {
                     case .cumulativeSum:     q = stats.sumQuantity()
@@ -868,7 +884,7 @@ final class HealthKitBridge: ObservableObject {
                     }
                     if let q { sink(HealthKitBridge.dayString(stats.startDate), q.doubleValue(for: unit)) }
                 }
-                cont.resume()
+                cont.resume(returning: true)
             }
             store.execute(q)
         }

--- a/StrandiOS/Health/HealthKitBridge.swift
+++ b/StrandiOS/Health/HealthKitBridge.swift
@@ -1,6 +1,7 @@
 #if os(iOS)
 import Foundation
 import HealthKit
+import UIKit
 import WhoopStore
 import StrandAnalytics
 import StrandImport
@@ -142,7 +143,11 @@ final class HealthKitBridge: ObservableObject {
     /// unchanged sees no UI, and a returning user is asked about exactly the new ones. The signature is
     /// stored only on success, so a failed request is retried rather than silently swallowed.
     private func requestNewReadTypesIfNeeded() async {
+        // FOREGROUND only. `sync` is also driven by background observer wakes, and asking there would
+        // spend the one request we get where no sheet can be presented — if that call reported success
+        // without showing anything, the signature would be stored and the user never asked at all.
         guard auth == .authorized,
+              UIApplication.shared.applicationState == .active,
               UserDefaults.standard.string(forKey: HealthKitBridge.readTypeSignatureKey)
                   != HealthKitBridge.readTypeSignature
         else { return }

--- a/StrandiOS/Health/HealthKitBridge.swift
+++ b/StrandiOS/Health/HealthKitBridge.swift
@@ -135,8 +135,8 @@ final class HealthKitBridge: ObservableObject {
     /// HealthKit never reports read authorization, and `requestAuthorization` is only called from the
     /// connect button. So a read type added in an update stays `.notDetermined` for everyone who granted
     /// access before it existed, and its queries return empty forever — indistinguishable from "you have
-    /// no water in Health", and silent. Water and caffeine would have done nothing at all for every
-    /// existing user, which is most of them.
+    /// no water in Health", and silent. Water would have done nothing at all for every existing user,
+    /// which is most of them.
     ///
     /// Comparing a stored fingerprint of the read set catches that. Re-requesting is cheap and quiet:
     /// HealthKit presents the sheet ONLY for types that are still undetermined, so a user whose set is

--- a/StrandiOS/Health/HealthKitBridge.swift
+++ b/StrandiOS/Health/HealthKitBridge.swift
@@ -117,6 +117,44 @@ final class HealthKitBridge: ObservableObject {
 
     // MARK: - Authorization
 
+    /// UserDefaults key holding the read set the user was last asked about.
+    private static let readTypeSignatureKey = "noop.health.readTypeSignature"
+
+    /// A stable fingerprint of the read types currently requested.
+    private static var readTypeSignature: String {
+        quantityReadIds.map(\.rawValue).sorted().joined(separator: ",")
+    }
+
+    private static func persistReadTypeSignature() {
+        UserDefaults.standard.set(readTypeSignature, forKey: readTypeSignatureKey)
+    }
+
+    /// Re-request authorization when the app has STARTED reading a type it never used to (#949).
+    ///
+    /// HealthKit never reports read authorization, and `requestAuthorization` is only called from the
+    /// connect button. So a read type added in an update stays `.notDetermined` for everyone who granted
+    /// access before it existed, and its queries return empty forever — indistinguishable from "you have
+    /// no water in Health", and silent. Water and caffeine would have done nothing at all for every
+    /// existing user, which is most of them.
+    ///
+    /// Comparing a stored fingerprint of the read set catches that. Re-requesting is cheap and quiet:
+    /// HealthKit presents the sheet ONLY for types that are still undetermined, so a user whose set is
+    /// unchanged sees no UI, and a returning user is asked about exactly the new ones. The signature is
+    /// stored only on success, so a failed request is retried rather than silently swallowed.
+    private func requestNewReadTypesIfNeeded() async {
+        guard auth == .authorized,
+              UserDefaults.standard.string(forKey: HealthKitBridge.readTypeSignatureKey)
+                  != HealthKitBridge.readTypeSignature
+        else { return }
+        do {
+            try await store.requestAuthorization(toShare: writeTypes, read: readTypes)
+            HealthKitBridge.persistReadTypeSignature()
+        } catch {
+            // Leave the signature unset so the next sync tries again. Not surfaced in `lastError`: the
+            // user did not ask for this, and the rest of the sync is unaffected.
+        }
+    }
+
     /// Request read + write permission. HealthKit never reveals whether *read* was granted, so we
     /// treat a successful request as `.authorized` and let queries return empty if the user declined.
     func requestAuthorization() async {
@@ -139,6 +177,8 @@ final class HealthKitBridge: ObservableObject {
             // the authoritative signal; the `.notDetermined` fallback only matters when that check can't
             // run, which on iOS means an App Store build that by definition has the entitlement.
             auth = .authorized
+            // This grant covered the CURRENT read set, so record it — see `requestNewReadTypesIfNeeded`.
+            HealthKitBridge.persistReadTypeSignature()
         } catch {
             // A thrown error here is on a build that carries the entitlement (guarded above), so it's a
             // genuine denial / request failure — keep the normal `.denied` "enable in Settings" path,
@@ -310,6 +350,9 @@ final class HealthKitBridge: ObservableObject {
         guard auth == .authorized, !syncing else { return }
         syncing = true
         defer { syncing = false }
+        // Before reading: pick up any read type this version added that the user was never asked about
+        // (#949). No-op once the stored signature matches, which is every sync after the first.
+        await requestNewReadTypesIfNeeded()
         guard let store = await repo.storeHandle() else { return }
 
         let cal = Calendar.current

--- a/StrandiOS/Health/HealthKitBridge.swift
+++ b/StrandiOS/Health/HealthKitBridge.swift
@@ -99,7 +99,11 @@ final class HealthKitBridge: ObservableObject {
         .basalEnergyBurned, .vo2Max,
         // Body composition — READ-ONLY (#20). Imported under the apple-health source like the file
         // importer already ingests; deliberately NOT in quantityWriteIds (we never write these back).
-        .bodyMass, .bodyFatPercentage, .leanBodyMass, .bodyMassIndex
+        .bodyMass, .bodyFatPercentage, .leanBodyMass, .bodyMassIndex,
+        // Water — READ-ONLY (#949), so drinks logged in a dedicated hydration app (or by a smart bottle)
+        // show up without being typed in twice. Lands in the hydration source rather than apple-health,
+        // because the hydration screen is what consumes it. Never written back.
+        .dietaryWater
     ]
     private static let quantityWriteIds: [HKQuantityTypeIdentifier] = [
         .restingHeartRate, .heartRateVariabilitySDNN, .oxygenSaturation, .respiratoryRate
@@ -363,6 +367,14 @@ final class HealthKitBridge: ObservableObject {
             var a = agg(day); a.bmi = v; byDay[day] = a
         }
 
+        // Water logged in other apps (#949). A cumulative day SUM, like steps — HealthKit re-adds every
+        // sample in the day on each sync, so the figure this produces is a full replacement rather than a
+        // delta, which is exactly what `setImportedHydration` wants. `notNoopAuthored` (applied inside
+        // `collect`) keeps NOOP's own drinks out, so a tap in NOOP can never come back as an import.
+        await collect(.dietaryWater, unit: .literUnit(with: .milli), start: start, end: end, op: .cumulativeSum) { day, v in
+            var a = agg(day); a.waterMl = v; byDay[day] = a
+        }
+
         // Sleep minutes per day (asleep stages summed; attributed to wake day).
         await collectSleep(start: start, end: end) { day, asleepMin, deepMin, remMin, coreMin in
             var a = agg(day)
@@ -433,6 +445,26 @@ final class HealthKitBridge: ObservableObject {
             try await store.upsertDailyMetrics(dmRows, deviceId: appleDeviceId)
             try await store.upsertMetricSeries(points, deviceId: appleDeviceId)
             if !workoutRows.isEmpty { try await store.upsertWorkouts(workoutRows, deviceId: appleDeviceId) }
+            // Imported water (#949) goes to the hydration source, not apple-health, because the hydration
+            // screen is what reads it. Every day in the window is written — including the ones with no
+            // water at all, as 0 — so deleting a drink in the source app takes it away here on the next
+            // sync instead of stranding the old figure. `byDay` only holds days that had SOME metric, so
+            // the zero-fill has to come from the date range rather than from its keys.
+            //
+            // Gated on the hydration toggle, which is opt-in and default OFF: an import must not quietly
+            // populate a feature the user has turned off, and skipping it avoids writing a window of rows
+            // nothing will read.
+            if UserDefaults.standard.bool(forKey: HydrationStore.enabledKey) {
+                var waterByDay: [String: Double] = [:]
+                var cursor = cal.startOfDay(for: start)
+                while cursor <= end {
+                    waterByDay[HealthKitBridge.dayString(cursor)] = 0
+                    guard let next = cal.date(byAdding: .day, value: 1, to: cursor) else { break }
+                    cursor = next
+                }
+                for (day, a) in byDay { if let ml = a.waterMl { waterByDay[day] = ml } }
+                await repo.setImportedHydration(waterByDay)
+            }
             try await writeBack(whoopStore: store)
             lastSync = Date()
             lastError = nil
@@ -800,6 +832,7 @@ final class HealthKitBridge: ObservableObject {
         var activeKcal: Double?; var basalKcal: Double?; var vo2max: Double?
         var weightKg: Double?; var bodyFatPct: Double?; var leanMassKg: Double?; var bmi: Double?
         var asleepMin: Double?; var deepMin: Double?; var remMin: Double?; var coreMin: Double?
+        var waterMl: Double?
     }
 
     /// Excludes NOOP's own write-back samples from reads, so the two-way sync never reads its own

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -116,6 +116,10 @@
     <uses-permission android:name="android.permission.health.READ_BODY_FAT" />
     <uses-permission android:name="android.permission.health.READ_LEAN_BODY_MASS" />
     <uses-permission android:name="android.permission.health.READ_EXERCISE" />
+    <!-- Water logged in other apps (#949), so drinks tracked by a dedicated hydration app or a smart
+         bottle don't have to be entered twice. Read-only; NOOP never writes water back. MUST be
+         declared or Health Connect silently drops the runtime request (same trap as #412 above). -->
+    <uses-permission android:name="android.permission.health.READ_HYDRATION" />
 
     <!-- Resolve the Health Connect provider on Android 14+ (platform) and earlier (app). -->
     <queries>

--- a/android/app/src/main/java/com/noop/analytics/HydrationStore.kt
+++ b/android/app/src/main/java/com/noop/analytics/HydrationStore.kt
@@ -34,6 +34,22 @@ object HydrationStore {
      *  never confused with strap-imported or computed metrics. Matches the Swift source id. */
     const val SOURCE_ID: String = "hydration"
 
+    /**
+     * The series key for water IMPORTED from the platform health store — Health Connect here, Apple
+     * Health on iOS (#949). Keep == the Swift `HydrationStore.importedKey`.
+     *
+     * Its own row rather than folded into [KEY], because the two behave differently on write: [KEY]
+     * ACCUMULATES (each tap adds to it), while this one is REPLACED with the health store's recomputed
+     * day sum on every import. That replacement is what makes re-importing idempotent without tracking
+     * individual sample ids — Health Connect hands back every record in the window, so summing them and
+     * storing the result wholesale means a second import of the same day stores the same number, and a
+     * drink deleted in the source app makes the figure go DOWN next time rather than being stranded.
+     *
+     * Hand-logged water is never touched by an import, and imported water is not editable here — it is
+     * owned by the app that logged it.
+     */
+    const val KEY_IMPORTED: String = "hydrationImported"
+
     /** Seconds EAST of UTC for the device's current zone — the offset [AnalyticsEngine.dayString] needs
      *  to bucket a timestamp on the LOCAL calendar day (matches the dashboard's local "today" read). */
     private fun localOffsetSec(atMillis: Long = System.currentTimeMillis()): Long =
@@ -52,11 +68,15 @@ object HydrationStore {
     suspend fun log(repo: WhoopRepository, amountMl: Int, ts: Long = System.currentTimeMillis() / 1000L): Double {
         if (amountMl <= 0) return total(repo, ts)
         val day = dayKey(ts)
-        val current = total(repo, ts)
+        // The MANUAL row, never the combined figure (#949): a quick-add stores `current + amount`, so
+        // reading the combined total would copy every imported millilitre into the hand-logged row, and
+        // the next import would then add the imported water on top of that copy. One tap after an import
+        // would silently double the day, compounding on every tap after it.
+        val current = manualTotal(repo, ts)
         val next = current + amountMl
         repo.upsertMetricSeries(listOf(MetricSeriesRow(SOURCE_ID, day, KEY, next)))
         mutationSeq.value += 1   // #989: tell Today's card directly (see mutationSeq)
-        return next
+        return next + importedTotal(repo, ts)
     }
 
     /**
@@ -83,9 +103,11 @@ object HydrationStore {
     suspend fun set(repo: WhoopRepository, totalMl: Double, ts: Long = System.currentTimeMillis() / 1000L): Double {
         val day = dayKey(ts)
         val next = clampedTotal(totalMl)
+        // Sets the HAND-LOGGED row only (#949). Imported water is not the user's to correct from here —
+        // it belongs to the app that logged it, and an import would overwrite the edit on the next run.
         repo.upsertMetricSeries(listOf(MetricSeriesRow(SOURCE_ID, day, KEY, next)))
         mutationSeq.value += 1   // #989: edits/deletes route through here too
-        return next
+        return next + importedTotal(repo, ts)
     }
 
     /**
@@ -96,14 +118,70 @@ object HydrationStore {
      */
     suspend fun remove(repo: WhoopRepository, amountMl: Int, ts: Long = System.currentTimeMillis() / 1000L): Double {
         if (amountMl <= 0) return total(repo, ts)
-        return set(repo, afterRemoving(total(repo, ts), amountMl), ts)
+        // Subtract from the MANUAL row (#949). Against the combined figure this would be badly wrong:
+        // with 200 ml logged by hand and 500 ml imported, removing 100 would compute 700-100=600 and
+        // store THAT as the hand-logged total — inflating the day to 1100 instead of reducing it to 600.
+        return set(repo, afterRemoving(manualTotal(repo, ts), amountMl), ts)
     }
 
-    /** The total fluid (ml) logged for the local day containing [ts] (defaults to now), or 0.0 when
-     *  nothing has been logged that day. */
-    suspend fun total(repo: WhoopRepository, ts: Long = System.currentTimeMillis() / 1000L): Double {
-        val day = dayKey(ts)
-        return repo.metricSeries(SOURCE_ID, KEY, day, day).firstOrNull()?.value ?: 0.0
+    /**
+     * The total fluid (ml) for the local day containing [ts] as the user should SEE it: hand-logged plus
+     * whatever was imported from the health store (#949). 0.0 when neither exists.
+     *
+     * Everything that DISPLAYS a day figure wants this. Everything that WRITES a hand-logged amount must
+     * use [manualTotal] — see [log] and [remove].
+     */
+    suspend fun total(repo: WhoopRepository, ts: Long = System.currentTimeMillis() / 1000L): Double =
+        manualTotal(repo, ts) + importedTotal(repo, ts)
+
+    /** Only what the user logged by hand — the row [log] accumulates into and [set] overwrites. */
+    suspend fun manualTotal(repo: WhoopRepository, ts: Long = System.currentTimeMillis() / 1000L): Double =
+        dayValue(repo, KEY, dayKey(ts))
+
+    /** Only what came from the health store (#949). Replaced wholesale by each import. */
+    suspend fun importedTotal(repo: WhoopRepository, ts: Long = System.currentTimeMillis() / 1000L): Double =
+        dayValue(repo, KEY_IMPORTED, dayKey(ts))
+
+    private suspend fun dayValue(repo: WhoopRepository, key: String, day: String): Double =
+        repo.metricSeries(SOURCE_ID, key, day, day).firstOrNull()?.value ?: 0.0
+
+    /**
+     * Pure: sum metric rows into ml-per-day (#949). Rows for the same day ADD, which is the whole point —
+     * the hand-logged and imported series are two rows on the same day, and a plain `associate { }` would
+     * keep only the last one and silently drop the other from every bar in the history chart.
+     */
+    fun sumByDay(rows: List<MetricSeriesRow>): Map<String, Double> {
+        val out = HashMap<String, Double>()
+        for (r in rows) out[r.day] = (out[r.day] ?: 0.0) + r.value
+        return out
+    }
+
+    /**
+     * Pure: what an import should WRITE for a window (#949), given the days it covers and the ml it
+     * actually found. Every day in [windowDays] gets a value — days with no water resolve to 0.0 rather
+     * than being omitted, which is what makes a drink deleted in the source app disappear here instead of
+     * leaving the old figure stranded forever.
+     *
+     * Days found outside the window are dropped: writing them would be a partial update of a day this
+     * import never fully examined, so the figure could not be trusted as a replacement.
+     */
+    fun importWindow(windowDays: List<String>, found: Map<String, Double>): Map<String, Double> =
+        windowDays.associateWith { clampedTotal(found[it] ?: 0.0) }
+
+    /**
+     * Replace the imported-water total for each (dayKey → ml) pair with the health store's recomputed day
+     * sum (#949). Called by the Health Connect import; the iOS twin is `Repository.setImportedHydration`.
+     *
+     * REPLACES rather than adds — that is what makes re-importing idempotent (see [KEY_IMPORTED]). The
+     * caller is expected to pass 0.0 for days it found no water on, so a drink deleted in the source app
+     * disappears here too instead of lingering as a stale row.
+     */
+    suspend fun setImported(repo: WhoopRepository, mlByDay: Map<String, Double>) {
+        if (mlByDay.isEmpty()) return
+        repo.upsertMetricSeries(
+            mlByDay.map { (day, ml) -> MetricSeriesRow(SOURCE_ID, day, KEY_IMPORTED, clampedTotal(ml)) },
+        )
+        mutationSeq.value += 1   // #989: Today's card reads hydration off this
     }
 
     /**
@@ -120,8 +198,13 @@ object HydrationStore {
         val from = nowSec - (n - 1).toLong() * 86_400L
         val fromKey = dayKey(from)
         val toKey = dayKey(nowSec)
-        // One ranged read; project onto the full day grid so empty days read as 0 rather than vanishing.
-        val byDay = repo.metricSeries(SOURCE_ID, KEY, fromKey, toKey).associate { it.day to it.value }
+        // Both rows, summed per day via [sumByDay] (#949) — the bars have to agree with the Today card
+        // and the ring, and those read the combined [total]. Reading only [KEY] renders an imported day
+        // short. Projected onto the full day grid below so empty days read as 0 rather than vanishing.
+        val byDay = sumByDay(
+            repo.metricSeries(SOURCE_ID, KEY, fromKey, toKey) +
+                repo.metricSeries(SOURCE_ID, KEY_IMPORTED, fromKey, toKey),
+        )
         return (0 until n).map { i ->
             val key = dayKey(nowSec - (n - 1 - i).toLong() * 86_400L)
             key to (byDay[key] ?: 0.0)

--- a/android/app/src/main/java/com/noop/ingest/HealthConnectImporter.kt
+++ b/android/app/src/main/java/com/noop/ingest/HealthConnectImporter.kt
@@ -9,6 +9,7 @@ import androidx.health.connect.client.records.DistanceRecord
 import androidx.health.connect.client.records.ExerciseSessionRecord
 import androidx.health.connect.client.records.HeartRateRecord
 import androidx.health.connect.client.records.HeartRateVariabilityRmssdRecord
+import androidx.health.connect.client.records.HydrationRecord
 import androidx.health.connect.client.records.LeanBodyMassRecord
 import androidx.health.connect.client.records.OxygenSaturationRecord
 import androidx.health.connect.client.records.Record
@@ -22,6 +23,7 @@ import androidx.health.connect.client.records.WeightRecord
 import androidx.health.connect.client.request.ReadRecordsRequest
 import androidx.health.connect.client.time.TimeRangeFilter
 import com.noop.analytics.FitnessAgeEngine
+import com.noop.analytics.HydrationStore
 import com.noop.data.AppleDaily
 import com.noop.data.DailyMetric
 import com.noop.data.ImportSummary
@@ -29,6 +31,7 @@ import com.noop.data.MetricSeriesRow
 import com.noop.data.SleepSession
 import com.noop.data.WhoopRepository
 import com.noop.data.WorkoutRow
+import com.noop.ui.NoopPrefs
 import java.time.Instant
 import java.time.LocalDate
 import java.time.ZoneId
@@ -105,7 +108,19 @@ object HealthConnectImporter {
         LeanBodyMassRecord::class,
         ExerciseSessionRecord::class,
         DistanceRecord::class,
+        HydrationRecord::class,
     )
+
+    /**
+     * Hydration import window, in days (#949) — deliberately much shorter than [WINDOW_YEARS].
+     *
+     * Imported water is stored as one REPLACED row per day, and every day in the window is written
+     * (0.0 included) so a drink deleted in the source app disappears here too. Over the 10-year window
+     * that zero-fill would be ~3,650 rows on every import to back a screen that shows today plus a
+     * 7-day bar chart. 30 days covers it, and matches the iOS sync window exactly so the two platforms
+     * import the same span.
+     */
+    private const val HYDRATION_WINDOW_DAYS = 30L
 
     /**
      * The set of Health Connect read-permission strings the UI must request before calling
@@ -179,6 +194,10 @@ object HealthConnectImporter {
         val acc = HashMap<String, DayAcc>()
         fun dayOf(instant: Instant): String = LocalDate.ofInstant(instant, zone).toString()
         fun bucket(day: String): DayAcc = acc.getOrPut(day) { DayAcc() }
+
+        // #949: imported water, ml per local day. Separate from `acc` because it is written to the
+        // hydration source (HydrationStore), not the health-connect aggregates.
+        val hydrationMl = HashMap<String, Double>()
 
         val workouts = ArrayList<WorkoutRow>()
         // (startEpochS, endEpochS, kcal) of every active-calorie record, so an imported exercise
@@ -438,8 +457,45 @@ object HealthConnectImporter {
                     workouts[i] = w.copy(distanceM = round1(meters))
                 }
             }
+            // --- Water (#949) ---
+            // Its own short window (see HYDRATION_WINDOW_DAYS) and its own accumulator, because this
+            // lands in the hydration source rather than the health-connect aggregates below.
+            //
+            // SUMMED across sources, unlike steps/calories which take the max (#589). That rule exists
+            // because a phone and a watch both measure THE SAME walk; two apps writing water are logging
+            // DIFFERENT drinks — a smart bottle and a manual entry are two real glasses, not one counted
+            // twice. Taking the max here would silently drop whichever app logged less.
+            val hydrationStart = LocalDate.now(zone).minusDays(HYDRATION_WINDOW_DAYS - 1)
+                .atStartOfDay(zone).toInstant()
+            readAll(client, HydrationRecord::class, TimeRangeFilter.between(hydrationStart, end), selfPackage) { r ->
+                val day = dayOf(r.startTime)
+                hydrationMl[day] = (hydrationMl[day] ?: 0.0) + r.volume.inMilliliters
+            }
         } catch (e: Exception) {
             return ImportSummary.failure(SOURCE, "Health Connect read failed: ${e.message}")
+        }
+
+        // Zero-fill the whole hydration window and write it, BEFORE the "nothing found" bail below:
+        // `acc` holds only the aggregate types, so a user whose Health Connect has water and nothing
+        // else would otherwise return early and never see a drop of it. Writing the zeros is what makes
+        // a deletion in the source app propagate (see HydrationStore.KEY_IMPORTED).
+        // Only when water is actually granted (#150 partial permissions). Without this check a user who
+        // declined the water scope would get the whole window written as zeros on every import — thirty
+        // pointless rows, and worse, it would erase legitimately imported water the moment the scope was
+        // revoked rather than simply leaving it be.
+        // Hydration tracking is opt-in and default OFF, so an import must not quietly populate a feature
+        // the user has turned off — and skipping it saves writing a window of rows nothing will read.
+        if (HealthPermission.getReadPermission(HydrationRecord::class) in granted &&
+            NoopPrefs.hydrationTracking(context)
+        ) {
+            val today = LocalDate.now(zone)
+            val windowDays = (0 until HYDRATION_WINDOW_DAYS.toInt())
+                .map { today.minusDays(it.toLong()).toString() }
+            try {
+                HydrationStore.setImported(repo, HydrationStore.importWindow(windowDays, hydrationMl))
+            } catch (_: Exception) {
+                // Best-effort: a hydration write failure must not sink an otherwise good import.
+            }
         }
 
         if (acc.isEmpty() && workouts.isEmpty()) {

--- a/android/app/src/main/java/com/noop/ingest/HealthConnectImporter.kt
+++ b/android/app/src/main/java/com/noop/ingest/HealthConnectImporter.kt
@@ -198,6 +198,10 @@ object HealthConnectImporter {
         // #949: imported water, ml per local day. Separate from `acc` because it is written to the
         // hydration source (HydrationStore), not the health-connect aggregates.
         val hydrationMl = HashMap<String, Double>()
+        // Whether the water read actually COMPLETED. Distinct from "found nothing": the write below
+        // replaces the stored figure, so a swallowed read error must not be mistaken for an authoritative
+        // zero and wipe 30 days of imported water.
+        var hydrationReadOk = false
 
         val workouts = ArrayList<WorkoutRow>()
         // (startEpochS, endEpochS, kcal) of every active-calorie record, so an imported exercise
@@ -467,7 +471,9 @@ object HealthConnectImporter {
             // twice. Taking the max here would silently drop whichever app logged less.
             val hydrationStart = LocalDate.now(zone).minusDays(HYDRATION_WINDOW_DAYS - 1)
                 .atStartOfDay(zone).toInstant()
-            readAll(client, HydrationRecord::class, TimeRangeFilter.between(hydrationStart, end), selfPackage) { r ->
+            hydrationReadOk = readAll(
+                client, HydrationRecord::class, TimeRangeFilter.between(hydrationStart, end), selfPackage,
+            ) { r ->
                 val day = dayOf(r.startTime)
                 hydrationMl[day] = (hydrationMl[day] ?: 0.0) + r.volume.inMilliliters
             }
@@ -485,7 +491,8 @@ object HealthConnectImporter {
         // revoked rather than simply leaving it be.
         // Hydration tracking is opt-in and default OFF, so an import must not quietly populate a feature
         // the user has turned off — and skipping it saves writing a window of rows nothing will read.
-        if (HealthPermission.getReadPermission(HydrationRecord::class) in granted &&
+        if (hydrationReadOk &&
+            HealthPermission.getReadPermission(HydrationRecord::class) in granted &&
             NoopPrefs.hydrationTracking(context)
         ) {
             val today = LocalDate.now(zone)
@@ -721,6 +728,12 @@ object HealthConnectImporter {
     /**
      * Read every page of [type] within [filter], invoking [onRecord] for each record.
      * Loops on the response page token so we never miss records past the first page.
+     *
+     * Returns TRUE when the type was read to completion, FALSE when it was skipped by the catch below.
+     * Every accumulating caller ignores this: for them a failed type is simply absent, which costs that
+     * type's contribution and nothing else. It matters for a caller whose write REPLACES rather than adds
+     * (#949 hydration), because there "read nothing" and "there is nothing" are the same empty map — and
+     * treating a swallowed error as an authoritative zero would wipe the stored figure.
      */
     private suspend fun <T : Record> readAll(
         client: HealthConnectClient,
@@ -728,7 +741,7 @@ object HealthConnectImporter {
         filter: TimeRangeFilter,
         selfPackage: String = "",
         onRecord: (T) -> Unit,
-    ) {
+    ): Boolean {
         var pageToken: String? = null
         try {
             do {
@@ -754,7 +767,9 @@ object HealthConnectImporter {
             // keep whatever was read, so every other data type still comes in (issue #34). The reads
             // accumulate into shared buckets, so a partial type is simply absent, never corrupt.
             android.util.Log.w("HealthConnect", "read of ${type.simpleName} failed; skipping: ${e.message}")
+            return false
         }
+        return true
     }
 
     // MARK: - strap-coverage helpers

--- a/android/app/src/main/java/com/noop/ingest/HealthConnectImporter.kt
+++ b/android/app/src/main/java/com/noop/ingest/HealthConnectImporter.kt
@@ -130,6 +130,34 @@ object HealthConnectImporter {
         READ_RECORDS.map { HealthPermission.getReadPermission(it) }.toSet()
 
     /**
+     * Whether the user has been asked about the CURRENT permission set (#949).
+     *
+     * The import gate is `granted.any { ... }` by design (#150): partial grants are legitimate, so
+     * having any one permission is enough to import. But that also means a permission ADDED in an
+     * update is never requested — an existing user goes straight to importing and the new type reads
+     * as empty forever, indistinguishable from "you have no water logged". Water would have done
+     * nothing at all for every existing Android user.
+     *
+     * Comparing a stored fingerprint of [PERMISSIONS] catches that: when the set grows, the caller
+     * launches the request once so the user is asked about the new type, then marks it asked. It is
+     * asked ONCE — declining is remembered, so this never becomes a nag.
+     */
+    fun hasUnaskedPermissions(context: Context): Boolean =
+        prefs(context).getString(PERMISSION_SIGNATURE_KEY, null) != permissionSignature
+
+    /** Record that the user has now been asked about the current [PERMISSIONS] set. */
+    fun markPermissionsAsked(context: Context) {
+        prefs(context).edit().putString(PERMISSION_SIGNATURE_KEY, permissionSignature).apply()
+    }
+
+    private const val PERMISSION_SIGNATURE_KEY = "noop.hc.permissionSignature"
+
+    private val permissionSignature: String get() = PERMISSIONS.sorted().joinToString(",")
+
+    private fun prefs(context: Context) =
+        context.getSharedPreferences(NoopPrefs.NAME, Context.MODE_PRIVATE)
+
+    /**
      * Whether Health Connect is installed/available on this device.
      * One of [HealthConnectClient.SDK_AVAILABLE],
      * [HealthConnectClient.SDK_UNAVAILABLE],

--- a/android/app/src/main/java/com/noop/ui/DataSourcesScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/DataSourcesScreen.kt
@@ -301,9 +301,15 @@ fun DataSourcesScreen(vm: AppViewModel) {
             val granted = runCatching {
                 HealthConnectImporter.client(context).permissionController.getGrantedPermissions()
             }.getOrDefault(emptySet())
-            if (granted.any { it in HealthConnectImporter.PERMISSIONS }) {
+            // `any` (not `all`) is deliberate — partial grants are supported (#150). But that alone
+            // would never ASK about a permission added in an update, so a newly-read type would come
+            // back empty forever (#949). Route through the request once when the set has grown.
+            if (granted.any { it in HealthConnectImporter.PERMISSIONS } &&
+                !HealthConnectImporter.hasUnaskedPermissions(context)
+            ) {
                 runImport { HealthConnectImporter.import(context, vm.repo, ProfileStore.from(context).heightCm) }
             } else {
+                HealthConnectImporter.markPermissionsAsked(context)
                 hcPermissionLauncher.launch(HealthConnectImporter.PERMISSIONS)
             }
         }

--- a/android/app/src/main/java/com/noop/ui/HydrationScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/HydrationScreen.kt
@@ -124,9 +124,13 @@ fun HydrationScreen(viewModel: AppViewModel) {
     var history by remember { mutableStateOf<List<Pair<String, Double>>>(emptyList()) }
     // A simple reload key the log taps bump so the LaunchedEffect re-reads the store.
     var reloadTick by remember { mutableStateOf(0) }
+    // #949: water imported from Health Connect. Already part of [totalMl]; read separately so the screen
+    // can name where it came from rather than leaving an unexplained jump in the day figure.
+    var importedMl by remember { mutableStateOf(0.0) }
     LaunchedEffect(reloadTick) {
         totalMl = runCatching { HydrationStore.total(viewModel.repo) }.getOrDefault(0.0)
         history = runCatching { HydrationStore.history(viewModel.repo, days = 7) }.getOrDefault(emptyList())
+        importedMl = runCatching { HydrationStore.importedTotal(viewModel.repo) }.getOrDefault(0.0)
     }
 
     // #798 - the LAST amount logged this session, so the detail can offer a one-tap "Undo" that removes
@@ -354,6 +358,28 @@ fun HydrationScreen(viewModel: AppViewModel) {
                                 color = Palette.textPrimary,
                             )
                         }
+                        // #949: name the imported share rather than folding it silently into the figure
+                        // above — otherwise the day total moves on its own after a Health Connect import
+                        // and nothing on screen accounts for it.
+                        if (importedMl > 0.0) {
+                            Row(
+                                modifier = Modifier.fillMaxWidth(),
+                                verticalAlignment = Alignment.CenterVertically,
+                            ) {
+                                Spacer(Modifier.width(28.dp))
+                                Text(
+                                    uiString(R.string.l10n_hydration_screen_from_health_connect_4ad037a3),
+                                    style = NoopType.footnote,
+                                    color = Palette.textSecondary,
+                                    modifier = Modifier.weight(1f),
+                                )
+                                Text(
+                                    uiString(R.string.l10n_hydration_screen_totalml_toint_ml_522b262a, importedMl.toInt()),
+                                    style = NoopType.footnote,
+                                    color = Palette.textSecondary,
+                                )
+                            }
+                        }
                         // #798 - undo / correct affordances. "Undo last" appears once something has been logged
                         // this session and removes exactly that container from the day total. "Clear today" zeroes
                         // the day's total outright (the delete-everything correction). Both route through the
@@ -367,12 +393,19 @@ fun HydrationScreen(viewModel: AppViewModel) {
                                     modifier = Modifier.weight(1f),
                                 ) { remove(last) }
                             }
-                            NoopButton(
-                                text = uiString(R.string.l10n_hydration_screen_clear_today_1be870ea),
-                                leadingIcon = Icons.Filled.Delete,
-                                kind = NoopButtonKind.Secondary,
-                                modifier = Modifier.weight(1f),
-                            ) { remove(totalMl.toInt()) }
+                            // #949: clears only what NOOP owns. Passing the COMBINED total here would ask
+                            // the store to subtract imported water from the hand-logged row — the row it
+                            // isn't in — and the button is offered only when there is something of ours
+                            // to clear, so it never sits there doing visibly nothing on an import-only day.
+                            val manualMl = (totalMl - importedMl).toInt()
+                            if (manualMl > 0) {
+                                NoopButton(
+                                    text = uiString(R.string.l10n_hydration_screen_clear_today_1be870ea),
+                                    leadingIcon = Icons.Filled.Delete,
+                                    kind = NoopButtonKind.Secondary,
+                                    modifier = Modifier.weight(1f),
+                                ) { remove(manualMl) }
+                            }
                         }
                     }
                 }

--- a/android/app/src/main/java/com/noop/ui/OnboardingScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/OnboardingScreen.kt
@@ -826,9 +826,14 @@ private fun ImportStep(viewModel: AppViewModel) {
             val granted = runCatching {
                 HealthConnectImporter.client(context).permissionController.getGrantedPermissions()
             }.getOrDefault(emptySet())
-            if (granted.any { it in HealthConnectImporter.PERMISSIONS }) {
+            if (granted.any { it in HealthConnectImporter.PERMISSIONS } &&
+                !HealthConnectImporter.hasUnaskedPermissions(context)
+            ) {
                 runImport { HealthConnectImporter.import(context, viewModel.repo, ProfileStore.from(context).heightCm) }
             } else {
+                // Marked before launching so the request is made ONCE per permission set: a user who
+                // declines is not asked again on every visit (#949).
+                HealthConnectImporter.markPermissionsAsked(context)
                 hcPermissionLauncher.launch(HealthConnectImporter.PERMISSIONS)
             }
         }

--- a/android/app/src/main/res/values-de/strings.xml
+++ b/android/app/src/main/res/values-de/strings.xml
@@ -503,6 +503,7 @@
     <string name="l10n_hydration_screen_kotlin_math_min_100_fraction_100_72f2dfde">%1$s%% des heutigen Ziels</string>
     <string name="l10n_hydration_screen_log_8bf95ea3">Protokoll</string>
     <string name="l10n_hydration_screen_logged_today_0071a46c">Heute erfasst</string>
+    <string name="l10n_hydration_screen_from_health_connect_4ad037a3">Aus Health Connect</string>
     <string name="l10n_hydration_screen_millilitres_ml_0fb0d2a4">Milliliter (ml)</string>
     <string name="l10n_hydration_screen_no_drinks_logged_yet_tap_sip_cc0d2f72">Noch keine Getränke erfasst. Tippe auf Schluck, Tasse oder Flasche, um zu starten.</string>
     <string name="l10n_hydration_screen_no_history_yet_933f417e">Noch kein Verlauf.</string>

--- a/android/app/src/main/res/values-es/strings.xml
+++ b/android/app/src/main/res/values-es/strings.xml
@@ -333,6 +333,7 @@
     <string name="l10n_hydration_screen_kotlin_math_min_100_fraction_100_72f2dfde">%1$s%% del objetivo de hoy</string>
     <string name="l10n_hydration_screen_log_8bf95ea3">Diario</string>
     <string name="l10n_hydration_screen_logged_today_0071a46c">Registrado hoy</string>
+    <string name="l10n_hydration_screen_from_health_connect_4ad037a3">Desde Health Connect</string>
     <string name="l10n_hydration_screen_millilitres_ml_0fb0d2a4">Millilitres (ml)</string>
     <string name="l10n_hydration_screen_no_drinks_logged_yet_tap_sip_cc0d2f72">Aún no hay bebidas registradas. Toca Sorbo, Taza o Botella para empezar.</string>
     <string name="l10n_hydration_screen_no_history_yet_933f417e">Aún no hay historial.</string>

--- a/android/app/src/main/res/values-fr/strings.xml
+++ b/android/app/src/main/res/values-fr/strings.xml
@@ -333,6 +333,7 @@
     <string name="l10n_hydration_screen_kotlin_math_min_100_fraction_100_72f2dfde">%1$s%% de l\'objectif actuel</string>
     <string name="l10n_hydration_screen_log_8bf95ea3">Journal</string>
     <string name="l10n_hydration_screen_logged_today_0071a46c">Enregistré aujourd\'hui</string>
+    <string name="l10n_hydration_screen_from_health_connect_4ad037a3">Depuis Health Connect</string>
     <string name="l10n_hydration_screen_millilitres_ml_0fb0d2a4">Millilitres (ml)</string>
     <string name="l10n_hydration_screen_no_drinks_logged_yet_tap_sip_cc0d2f72">Aucune boisson enregistrée pour l\'instant. Touchez Gorgée, Tasse ou Bouteille pour commencer.</string>
     <string name="l10n_hydration_screen_no_history_yet_933f417e">Aucun historique pour l\'instant.</string>

--- a/android/app/src/main/res/values-pt-rPT/strings.xml
+++ b/android/app/src/main/res/values-pt-rPT/strings.xml
@@ -486,6 +486,7 @@
     <string name="l10n_hydration_screen_kotlin_math_min_100_fraction_100_72f2dfde">%1$s%% da meta de hoje</string>
     <string name="l10n_hydration_screen_log_8bf95ea3">Registo</string>
     <string name="l10n_hydration_screen_logged_today_0071a46c">Registado hoje</string>
+    <string name="l10n_hydration_screen_from_health_connect_4ad037a3">Do Health Connect</string>
     <string name="l10n_hydration_screen_millilitres_ml_0fb0d2a4">Mililitros (ml)</string>
     <string name="l10n_hydration_screen_no_drinks_logged_yet_tap_sip_cc0d2f72">Nenhuma bebida registada ainda. Toque em Sip, Cup ou Bottle para começar.</string>
     <string name="l10n_hydration_screen_no_history_yet_933f417e">Ainda não há histórico.</string>

--- a/android/app/src/main/res/values-zh/strings.xml
+++ b/android/app/src/main/res/values-zh/strings.xml
@@ -473,6 +473,7 @@
     <string name="l10n_hydration_screen_kotlin_math_min_100_fraction_100_72f2dfde">完成今日目标的 %1$s%%</string>
     <string name="l10n_hydration_screen_log_8bf95ea3">记录</string>
     <string name="l10n_hydration_screen_logged_today_0071a46c">今日已喝</string>
+    <string name="l10n_hydration_screen_from_health_connect_4ad037a3">来自 Health Connect</string>
     <string name="l10n_hydration_screen_millilitres_ml_0fb0d2a4">毫升 (ml)</string>
     <string name="l10n_hydration_screen_no_drinks_logged_yet_tap_sip_cc0d2f72">今天还没喝水哦。点击下方的一口、水杯或水壶来记录一下吧。</string>
     <string name="l10n_hydration_screen_no_history_yet_933f417e">暂无记录。</string>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -504,6 +504,7 @@
     <string name="l10n_hydration_screen_kotlin_math_min_100_fraction_100_72f2dfde">%1$s%% of today\'s goal</string>
     <string name="l10n_hydration_screen_log_8bf95ea3">Log</string>
     <string name="l10n_hydration_screen_logged_today_0071a46c">Logged today</string>
+    <string name="l10n_hydration_screen_from_health_connect_4ad037a3">From Health Connect</string>
     <string name="l10n_hydration_screen_millilitres_ml_0fb0d2a4">Millilitres (ml)</string>
     <string name="l10n_hydration_screen_no_drinks_logged_yet_tap_sip_cc0d2f72">No drinks logged yet. Tap Sip, Cup or Bottle to start.</string>
     <string name="l10n_hydration_screen_no_history_yet_933f417e">No history yet.</string>

--- a/android/app/src/test/java/com/noop/analytics/HydrationImportTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/HydrationImportTest.kt
@@ -1,0 +1,129 @@
+package com.noop.analytics
+
+import com.noop.data.MetricSeriesRow
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * #949 — water imported from the health store lives in its OWN series row, and these pin the two pure
+ * pieces that make that safe. Both run on the JVM with no Room, matching the rest of the hydration suite.
+ *
+ * The reason imported water is a second row rather than being folded into the hand-logged total is that
+ * the two behave differently on write: [HydrationStore.KEY] accumulates (each tap adds to it) while
+ * [HydrationStore.KEY_IMPORTED] is REPLACED with the health store's recomputed day sum. Keeping them
+ * apart is what lets a re-import be idempotent without tracking individual sample ids.
+ */
+class HydrationImportTest {
+
+    // --- sumByDay: the history/total merge ---
+
+    /**
+     * The bug this exists to prevent: the merge used `associate { it.day to it.value }`, which keeps the
+     * LAST row for a day. With a hand-logged row and an imported row on the same day, that silently drops
+     * one of them — the history bars would disagree with the Today card for every imported day.
+     */
+    @Test
+    fun rowsForTheSameDayAddRatherThanOverwrite() {
+        val merged = HydrationStore.sumByDay(
+            listOf(
+                MetricSeriesRow(HydrationStore.SOURCE_ID, "2026-07-30", HydrationStore.KEY, 500.0),
+                MetricSeriesRow(HydrationStore.SOURCE_ID, "2026-07-30", HydrationStore.KEY_IMPORTED, 750.0),
+            ),
+        )
+        assertEquals(1250.0, merged["2026-07-30"]!!, 0.0)
+    }
+
+    @Test
+    fun distinctDaysStaySeparate() {
+        val merged = HydrationStore.sumByDay(
+            listOf(
+                MetricSeriesRow(HydrationStore.SOURCE_ID, "2026-07-29", HydrationStore.KEY, 200.0),
+                MetricSeriesRow(HydrationStore.SOURCE_ID, "2026-07-30", HydrationStore.KEY, 300.0),
+            ),
+        )
+        assertEquals(200.0, merged["2026-07-29"]!!, 0.0)
+        assertEquals(300.0, merged["2026-07-30"]!!, 0.0)
+    }
+
+    @Test
+    fun noRowsIsAnEmptyMapNotAZeroDay() {
+        assertTrue(HydrationStore.sumByDay(emptyList()).isEmpty())
+    }
+
+    // --- importWindow: what an import writes ---
+
+    /**
+     * Days the health store had no water for are written as 0.0, NOT omitted. This is the self-healing
+     * half of the design: if the user deletes a drink in the app that logged it, the next import writes
+     * the lower figure — and if they delete every drink, it writes 0 instead of leaving yesterday's
+     * number stranded in the row forever.
+     */
+    @Test
+    fun daysWithNoWaterAreWrittenAsZero() {
+        val window = listOf("2026-07-30", "2026-07-29", "2026-07-28")
+        val out = HydrationStore.importWindow(window, mapOf("2026-07-29" to 900.0))
+        assertEquals(setOf("2026-07-30", "2026-07-29", "2026-07-28"), out.keys)
+        assertEquals(0.0, out["2026-07-30"]!!, 0.0)
+        assertEquals(900.0, out["2026-07-29"]!!, 0.0)
+        assertEquals(0.0, out["2026-07-28"]!!, 0.0)
+    }
+
+    /**
+     * Re-running an import over the same day yields the same value — the property that makes it safe to
+     * write this row wholesale instead of tracking which samples were already seen.
+     */
+    @Test
+    fun reimportingTheSameDayIsIdempotent() {
+        val window = listOf("2026-07-30")
+        val found = mapOf("2026-07-30" to 1500.0)
+        assertEquals(
+            HydrationStore.importWindow(window, found),
+            HydrationStore.importWindow(window, found),
+        )
+    }
+
+    /**
+     * A day outside the window is dropped rather than written. The importer only summed records inside
+     * its time filter, so a day it half-looked-at cannot be trusted as a REPLACEMENT value — writing it
+     * would overwrite a complete figure with a partial one.
+     */
+    @Test
+    fun daysOutsideTheWindowAreNotWritten() {
+        val out = HydrationStore.importWindow(listOf("2026-07-30"), mapOf("2020-01-01" to 400.0))
+        assertEquals(setOf("2026-07-30"), out.keys)
+        assertEquals(0.0, out["2026-07-30"]!!, 0.0)
+    }
+
+    /** A negative volume (a malformed record) can never produce a negative stored total. */
+    @Test
+    fun negativeVolumesClampToZero() {
+        val out = HydrationStore.importWindow(listOf("2026-07-30"), mapOf("2026-07-30" to -50.0))
+        assertEquals(0.0, out["2026-07-30"]!!, 0.0)
+    }
+
+    @Test
+    fun anEmptyWindowWritesNothing() {
+        assertTrue(HydrationStore.importWindow(emptyList(), mapOf("2026-07-30" to 400.0)).isEmpty())
+    }
+
+    // --- the parity contract ---
+
+    /**
+     * The series ids are a cross-platform contract: iOS writes the SAME strings from
+     * `Strand/Data/HydrationStore.swift`. A rename on one platform alone would leave a restored backup
+     * reading water out of a row nothing writes.
+     */
+    @Test
+    fun seriesIdsMatchTheSwiftTwin() {
+        assertEquals("hydration", HydrationStore.SOURCE_ID)
+        assertEquals("hydration", HydrationStore.KEY)
+        assertEquals("hydrationImported", HydrationStore.KEY_IMPORTED)
+    }
+
+    /** Imported water is a DIFFERENT row from hand-logged water, or the write semantics collide. */
+    @Test
+    fun importedKeyIsNotTheManualKey() {
+        assertTrue(HydrationStore.KEY != HydrationStore.KEY_IMPORTED)
+    }
+}


### PR DESCRIPTION
Closes #949 (water half — caffeine is a separate follow-up, see the end).

Drinks logged in a hydration app or by a smart bottle had to be entered into NOOP a second time. Both platforms already read their health store, so this adds water to what they read. Stays on-device: a plain HealthKit / Health Connect read, no network.

## The design decision that matters

Imported water lives in its **own** `metricSeries` row (`hydrationImported`) rather than being folded into the hand-logged total, because the two behave differently on write:

| | hand-logged (`hydration`) | imported (`hydrationImported`) |
|---|---|---|
| write | **accumulates** — each tap adds | **replaced** with the health store's recomputed day sum |
| owner | the user, editable here | the app that logged it, not editable here |

The replacement is what makes re-importing **idempotent without tracking individual sample ids** — HealthKit's `HKStatisticsCollectionQuery` and Health Connect's day bucket both hand back the whole day, so writing it wholesale means a second import of the same day stores the same number. Every day in the window is written, **zeros included**, so a drink deleted in the source app makes the figure go down here rather than being stranded forever.

## Why that separation is load-bearing

A quick-add stores `current + amount`. Reading the **combined** figure there would copy every imported millilitre into the hand-logged row, and the next import would then add the imported water on top of that copy — **one tap after an import would silently double the day**, compounding on every tap after it. Android's `remove` was the sharper version of the same trap: with 200 ml logged and 500 ml imported, removing 100 would have computed 700−100=600 and stored *that* as the hand-logged total, inflating the day to 1100 instead of reducing it to 600.

So `log` / `remove` / `set` all read the manual row; only display reads the sum. `hydrationTotal` (display) and `hydrationManualTotal` (write) are now separate calls on both platforms.

## Sources are SUMMED, not maxed

Steps and calories take the max across sources (#589) because a phone and a watch measure *the same walk*. Water is the opposite: a smart bottle and a manual entry are **two different real glasses**. Taking the max would silently drop whichever app logged less.

## Per platform

- **iOS** — `.dietaryWater` as a cumulative day sum. NOOP's own samples are already excluded by the existing `notNoopAuthored` predicate, so a tap in NOOP can never return as an import. Adding a *read* type is safe for returning users: `refreshAuthIfPreviouslyGranted` resumes off `legacyCoreWriteTypes` (write types only), and HealthKit never exposes read status anyway.
- **Android** — `HydrationRecord` over its **own 30-day window**; the aggregate window is 10 years, which would mean ~3,650 zero-fill rows per import to back a screen showing today plus 7 bars. 30 days matches the iOS sync window exactly. Also declares `READ_HYDRATION`, without which Health Connect silently drops the runtime request (the #412 trap). Respects partial permissions (#150) — skipped entirely when the water scope is not granted, rather than zeroing the window.
- **Both** gate the write on the hydration toggle, which is opt-in and **default OFF**, so an import never quietly populates a feature the user turned off.

## UI

The detail screen names the imported share instead of letting the day total move on its own with nothing on screen accounting for it. It is deliberately **not** editable there — "deleting" it would be a lie, since the next sync re-reads the same day and it would come straight back. Android's "Clear today" now clears only what NOOP owns, and is hidden when there is nothing of ours to clear.

## Verification

- **10 JVM unit tests** (`HydrationImportTest`) over the two pure helpers: the same-day merge (the old `associate { it.day to it.value }` keeps only the last row — with a manual row and an imported row on the same day that silently halves every history bar), and the zero-fill / idempotency / clamping contract. All 10 also executed locally against the shipped function bodies.
- Whole Android module compiles: error count unchanged from main apart from +2 unresolved `R` refs, which are the two new string resources my ad-hoc classpath has no generated `R` for. Both files confirmed analysed by deliberately injecting an error and watching it get reported.
- `Tools/i18n_audit.py --ci` exit 0 — new string added to all 6 Android locales and both new Apple literals added to the catalog with 8 translations each.
- `Tools/doc_comment_lint.py` exit 0. `Tools/` suite 53/53.
- **Not** hardware- or device-tested: no iPhone/Android device here, and app-target Swift has no CI. The Swift app target is unverified by compile — worth a local `xcodebuild` before merging.

## Noticed while in here, NOT fixed (out of scope)

`DistanceRecord` is in `READ_RECORDS`, so `PERMISSIONS` requests `READ_DISTANCE` — but **`READ_DISTANCE` is never declared in the manifest**, which by the same #412 rule means Health Connect silently drops it and distance never imports. Pre-existing and unrelated to hydration; happy to send a one-line PR separately.

## Follow-up: caffeine

Deliberately not here. NOOP already models caffeine, but `DoseResponseEngine` is explicit that the dose is a **timing proxy, never mg**. So the useful part of a HealthKit caffeine sample is its timestamp mapped onto the existing 0–3 time-of-day bucket — a different change against a different engine, and it should not ride along with a storage change.