### PR TITLE
Liquid Today: remount the illness banner, the auto-workout prompt, and the hydration value

### DIFF
--- a/Strand/Liquid/LiquidTodayView.swift
+++ b/Strand/Liquid/LiquidTodayView.swift
@@ -33,6 +33,13 @@ struct LiquidTodayView: View {
 
     /// Shared with the real Today's card-customise editor so the two stay in sync.
     @AppStorage(DashboardCardPrefs.selectionKey) private var dashboardCardsRaw = ""
+    /// #989 parity with classic Today + Android: the hydration card is opt-in twice over — the feature
+    /// toggle AND an explicit add in CUSTOMISE. Liquid filtered on neither, so a user who added the card
+    /// and later switched the feature off kept a permanently-blank row.
+    @AppStorage(HydrationStore.enabledKey) private var hydrationEnabled = false
+    /// Today's hydration total + goal (ml), resolved in `load()`. nil → the card shows "—".
+    @State private var hydrationTotalML: Double?
+    @State private var hydrationGoalML: Int?
 
     // async-loaded via the confirmed Repository accessors
     @State private var restScore: Double?          // sleep_performance, day-keyed
@@ -244,6 +251,15 @@ struct LiquidTodayView: View {
 
                 VStack(alignment: .leading, spacing: 12) {
                     scene
+                    // The strain/illness early-warning banner, dropped in the liquid Home rewrite. Liquid is
+                    // the DEFAULT Today on both platforms (RootTabView.swift's liquidTodayEnabled = true,
+                    // RootView.swift likewise), so while this was unmounted a RAISED health alert had no
+                    // home-screen surface at all: it survived only as one push at the moment it fired
+                    // (IllnessNotifier.post) and as HeadsUpCard two taps deep in More → Health. Pinned ABOVE
+                    // the reorderable block — the same position classic TodayView uses on both platforms and
+                    // the same one Android pins it to (TodayScreen.kt) — so a warning cannot be reordered
+                    // below the fold. Renders nothing when model.healthAlert is nil.
+                    HealthAlertBanner()
                     // #105: the live "workout in progress" card, dropped in the liquid Home rewrite. Restored
                     // here as the SAME leaf the classic TodayView renders (and Android's WorkoutInProgressCard),
                     // pinned above the reorderable block so an active manual workout is immediately visible
@@ -271,6 +287,14 @@ struct LiquidTodayView: View {
                         case .journal: if selectedDayOffset == 0 { JournalReminderCard() }
                         }
                     }
+                    // Opt-in "looks like a workout?" suggestion, dropped in the liquid Home rewrite. Its
+                    // Settings toggle (PuffinExperiment.autoDetectWorkoutsKey) had no visible effect on the
+                    // DEFAULT screen: the card's only mount was classic TodayView, so a user could switch
+                    // auto-detect on and never be shown a single suggestion. Same position classic uses
+                    // (after the cards block, before Data Sources) and the same leaf Android renders.
+                    // Self-gates on the toggle AND on the detector finding an unsaved, un-dismissed window,
+                    // so it renders nothing by default.
+                    AutoWorkoutCard()
                     dataSourcesSection
                     Color.clear.frame(height: 90) // floating tab-bar clearance
                 }
@@ -319,7 +343,9 @@ struct LiquidTodayView: View {
         .liquidSelectionHaptic(trigger: selectedDayOffset)
         // A firm tick when the pull passes the release threshold (the custom liquid refresh).
         .liquidMediumHaptic(trigger: pullHaptic)
-        .task(id: "\(repo.refreshSeq)-\(selectedDayOffset)") { await load() }
+        // hydrationSeq joins the id so logging a drink re-reads the card immediately, the same trigger set
+        // classic TodayView's reloadHydration() uses.
+        .task(id: "\(repo.refreshSeq)-\(selectedDayOffset)-\(repo.hydrationSeq)-\(hydrationEnabled)") { await load() }
         .sheet(item: $guideSection) { section in
             NavigationStack { ScoringGuideView(initialSection: section, onClose: { guideSection = nil }) }
         }
@@ -601,8 +627,10 @@ struct LiquidTodayView: View {
             .padding(.top, 4)
 
             // Data-driven off the SAME @AppStorage the CUSTOMISE editor writes, so add / remove /
-            // reorder in Customise reflects on the home screen live.
-            ForEach(DashboardCardPrefs.decodeEnabled(dashboardCardsRaw)) { card in
+            // reorder in Customise reflects on the home screen live. The hydration filter mirrors classic
+            // TodayView's `enabledDashboardCards` and Android's `it != HYDRATION || hydrationEnabled`.
+            ForEach(DashboardCardPrefs.decodeEnabled(dashboardCardsRaw)
+                        .filter { hydrationEnabled || $0 != .hydration }) { card in
                 liquidCard(for: card)
             }
         }
@@ -657,8 +685,18 @@ struct LiquidTodayView: View {
             cardLink(.sleep, title: card.title, sub: card.subtitle,
                      value: sleepText, tint: StrandPalette.restColor, frac: fracOver(displayDay?.totalSleepMin, 480))
         case .hydration:
+            // #989: was hardcoded "–". `HydrationGoal.cardValueString` is unit-tested and byte-identical to
+            // the Android twin, but classic TodayView was its only caller — so on the DEFAULT screen a
+            // logged drink never appeared. Same "<total> / <goal> L" string and the same goal fraction on
+            // the ring as classic; "—" only when the goal is genuinely underivable.
             cardLink(.hydration, title: card.title, sub: card.subtitle,
-                     value: "–", tint: StrandPalette.metricCyan, frac: nil)
+                     value: hydrationGoalML.map {
+                         HydrationGoal.cardValueString(totalML: hydrationTotalML ?? 0, goalML: $0)
+                     } ?? "—",
+                     tint: StrandPalette.metricCyan,
+                     frac: hydrationGoalML.map {
+                         HydrationGoal.fraction(totalML: hydrationTotalML ?? 0, goalML: $0)
+                     })
         case .coupled:
             // A tap-through to the full Coupled day screen. No value.
             cardLink(.coupled, title: card.title, sub: card.subtitle,
@@ -1063,6 +1101,15 @@ struct LiquidTodayView: View {
     // MARK: - Data
 
     private func load() async {
+        // #989: today's hydration total + goal. One metricSeries row + a UserDefaults read, same as classic
+        // TodayView.reloadHydration(). Cleared when the feature is off so the card can't show a stale total.
+        if hydrationEnabled {
+            hydrationTotalML = await repo.hydrationTotal(day: Repository.localDayKey(Date()))
+            hydrationGoalML = repo.hydrationGoalML(profileSex: profile.sex)
+        } else {
+            hydrationTotalML = nil
+            hydrationGoalML = nil
+        }
         // Resolve the O(days) lookups ONCE here (not on every body re-render): the selected day and the
         // readiness verdict. Both scan repo.days (up to 599 rows); doing it per-render was the stutter.
         let day = resolveDisplayDay()


### PR DESCRIPTION
Liquid is the default Today on both platforms, so anything mounted only in classic `TodayView` is effectively unmounted. Three things were in that state. This restores them at the same positions classic and Android use.

I found these auditing NOOP for things it computes or captures that never reach a user, checking each against a real device DB rather than the schema. Same class as #105 (workout-in-progress card) and the #992 / B1 / #543 restorations already in `LiquidTodayView`.

**Defaults, for reference:** `StrandiOS/App/RootTabView.swift:46` and `Strand/App/RootView.swift:201` both default `liquidTodayEnabled = true`.

### 1. `HealthAlertBanner` — a raised health warning had no home-screen surface

Mounted at `TodayView.swift:1270` (iOS) and `:1272` (macOS), never in Liquid. Android pins it on Today too (`TodayScreen.kt:1306`).

While unmounted, a `.raised` illness/strain alert survived only as one push at the moment it fired (`IllnessNotifier.post`) and as `HeadsUpCard` two taps deep in More → Health. The push is transient and the Health route is not somewhere you land by accident, so in practice the warning was invisible.

Pinned **above** the reorderable block, matching classic, so it can't be dragged below the fold. Renders nothing when `model.healthAlert` is nil.

### 2. `AutoWorkoutCard` — a Settings toggle with no visible effect

`AutoWorkoutCard()` had exactly one instantiation repo-wide, `TodayView.swift:1352`. So on the default screen `PuffinExperiment.autoDetectWorkoutsKey` (`SettingsView.swift:122`) did nothing observable: switch auto-detect on, never get shown a suggestion. Android keeps the card (`TodayScreen.kt:1554`).

Restored to the same slot classic uses (after the cards block, before Data Sources). Self-gates on the toggle and on the detector actually finding an unsaved, un-dismissed window, so it renders nothing by default.

### 3. Hydration card value was the literal `"–"`

`LiquidTodayView.swift:698-699` hardcoded `value: "–"`. `HydrationGoal.cardValueString` is unit-tested and byte-identical to the Android twin (`String.format(Locale.US, "%.1f / %.1f L")`), but classic `TodayView.swift:2237` was its only caller — so a logged drink never appeared on the default screen.

Now reads the same total + goal and shows the goal fraction on the ring. `repo.hydrationSeq` joins the `.task` id, the same trigger set `reloadHydration()` uses, so logging a drink refreshes immediately.

**Also adds the enablement filter Liquid never had.** Classic filters via `enabledDashboardCards` (`TodayView.swift:235-241`) and Android via `it != HYDRATION || hydrationEnabled`; Liquid's `ForEach(DashboardCardPrefs.decodeEnabled(...))` filtered on neither, so anyone who added the card and later switched the feature off kept a permanently-blank row.

### Verification

`xcodebuild -project Strand.xcodeproj -scheme Strand -destination 'platform=macOS' -configuration Debug build` → **BUILD SUCCEEDED**, both on this branch and on my fork's main.

All three are self-contained views or existing store reads — no new types, no migration, no protocol change. `HealthAlertBanner` and `AutoWorkoutCard` take their dependencies from the environment, so the mounts are bare.

### Not included, but found in the same pass

Still classic-only, listed so it's on the record rather than as scope creep — happy to send follow-ups:

- **Updates inbox + unread bell.** `UpdatesInboxView` is instantiated at exactly one site repo-wide (`TodayView.swift:1432`). `seedWhatsNewIfNeeded()` (`StrandiOSApp.swift:339`) still writes a "What's new in NOOP x.y.z" item into `UpdateStore` on every release, and "N new days of history landed" is still posted (`TodayView.swift:4106-4112`). On the default screen nothing reads that store, so every release note is written and discarded.
- **Charge breakdown sheet.** Liquid's Charge cell opens the generic `ScoringGuideView` (`LiquidTodayView.swift:539`) rather than `chargeBreakdownSheet` (`TodayView.swift:1441`), so the per-driver breakdown of the user's own Charge — and the Readiness read S4 deliberately folded behind that tap (`TodayView.swift:1342-1345`) — has no door on the home screen.
- **First-run "Live now. Your scores are building." note** (`TodayView.swift:1291-1294`), including the actionable "import your WHOOP export and it backfills in about a minute". Android keeps it (`TodayScreen.kt:1281-1287`). This is the worst moment to lose an explanation, since every tile is blank.
- **`FullDayChartView.swift:66`, `@State private var reloadTick = 0`** — its own comment says it is "bumped on every settled zoom/metric change so the re-read task re-runs at the new resolution". Nothing bumps it and nothing observes it, so zooming the full-day chart never re-reads at finer resolution. `HydrationView.swift:25/73/364` implements the same idiom correctly, so it looks like a copy that was left unwired.
- **`WeeklyDigestCard` / `WeeklyDigestView`** (`WeeklyDigestView.swift:65`, `:84`) have zero call sites repo-wide, and no `.digest` sidebar case exists. The engine itself is fine — `WeeklyDigestContent` ships inside Trends (`TrendsView.swift:353`) and Android has its own card. It's the two wrappers plus three translated strings that only they reference.
