### PR TITLE
Hydration: only write imported water that actually changed (#949)

### DIFF
--- a/Strand/Data/HydrationStore.swift
+++ b/Strand/Data/HydrationStore.swift
@@ -143,14 +143,52 @@ extension Repository {
     /// (#949). Called by the Apple Health sync; the Android twin is `HydrationStore.setImported`.
     ///
     /// REPLACES rather than adds, which is the whole reason this is idempotent — see `importedKey`. Days
-    /// the health store has no water for are written as 0 rather than skipped, so water deleted in the
-    /// source app disappears here too instead of lingering as a stale row.
+    /// the health store has no water for resolve to 0, so water deleted in the source app disappears here
+    /// too instead of lingering as a stale row.
+    ///
+    /// Only days whose value actually MOVED are written. The caller hands over its whole window (31 days
+    /// on iOS) on every sync, and `sync` is driven by six hourly `HKObserverQuery` wakes — so writing it
+    /// wholesale meant ~31 upserts plus a `hydrationSeq` bump, repeatedly through the day, to store
+    /// numbers that were already there. Thirty of those days are historical and immutable; the usual
+    /// honest answer is "nothing changed". One ranged read replaces the write burst.
+    ///
+    /// A day with NO row and a value of 0 is skipped rather than written, because an absent row already
+    /// reads as 0 (`hydrationImportedTotal`). That is what keeps a user with no water in Health from
+    /// accumulating a wall of zero rows. A day that HAS a row and is now 0 is still written — that is the
+    /// deletion propagating, and it must not be mistaken for the no-op case.
     func setImportedHydration(_ mlByDay: [String: Double]) async {
         guard !mlByDay.isEmpty, let store = await storeHandle() else { return }
-        let points = mlByDay.map { MetricPoint(day: $0.key, key: HydrationStore.importedKey,
-                                               value: max(0, $0.value)) }
-        _ = try? await store.upsertMetricSeries(points, deviceId: HydrationStore.sourceId)
-        // Same reason as logHydration: hydration writes never bump refreshSeq.
+        let days = mlByDay.keys.sorted()
+        guard let from = days.first, let to = days.last else { return }
+
+        // No `?? []` here: a FAILED read must not look like "there are no rows". If it did, a day whose
+        // water was just deleted would resolve to the skip-a-zero case below and its stale non-zero row
+        // would survive. Bail instead and let the next sync do it properly — the health store is the
+        // source of truth, so nothing is lost by waiting.
+        guard let existing = try? await store.metricSeries(deviceId: HydrationStore.sourceId,
+                                                           key: HydrationStore.importedKey,
+                                                           from: from, to: to) else { return }
+        var stored: [String: Double] = [:]
+        for p in existing { stored[p.day] = p.value }
+
+        let changed: [MetricPoint] = mlByDay.compactMap { day, ml in
+            let value = max(0, ml)
+            guard let current = stored[day] else {
+                // No row yet: only worth creating one if there is actually something to record.
+                return value == 0 ? nil : MetricPoint(day: day, key: HydrationStore.importedKey, value: value)
+            }
+            // Epsilon rather than ==: the same samples re-summed give the same Double, but a value that
+            // ever drifted by a float hair would otherwise re-write every sync forever and quietly undo
+            // the point of this. Well below a millilitre, so no real change is swallowed.
+            guard abs(current - value) > 1e-9 else { return nil }
+            return MetricPoint(day: day, key: HydrationStore.importedKey, value: value)
+        }
+        guard !changed.isEmpty else { return }
+
+        _ = try? await store.upsertMetricSeries(changed, deviceId: HydrationStore.sourceId)
+        // Only on a real change — this bump re-reads the Today card, and firing it on every sync made the
+        // card redo its hydration read for nothing. Same reason as logHydration: hydration writes never
+        // bump refreshSeq, so the card has no other signal.
         noteHydrationChanged()
     }
 

--- a/Strand/Data/HydrationStore.swift
+++ b/Strand/Data/HydrationStore.swift
@@ -171,7 +171,9 @@ extension Repository {
         var stored: [String: Double] = [:]
         for p in existing { stored[p.day] = p.value }
 
-        let changed: [MetricPoint] = mlByDay.compactMap { day, ml in
+        // Return type spelled out rather than inferred: this file is app-target Swift that no CI
+        // compiles, so a multi-statement closure leaning on inference is a needless place to be wrong.
+        let changed: [MetricPoint] = mlByDay.compactMap { (day, ml) -> MetricPoint? in
             let value = max(0, ml)
             guard let current = stored[day] else {
                 // No row yet: only worth creating one if there is actually something to record.

--- a/Strand/Screens/TodayView.swift
+++ b/Strand/Screens/TodayView.swift
@@ -3897,7 +3897,8 @@ struct TodayView: View {
 
     /// #989: today's hydration total + goal, re-read wherever staleness could show: the history-wide load,
     /// the same-seq cache restore, a hydration mutation (`repo.hydrationSeq`), and the feature toggle.
-    /// One metricSeries row + a UserDefaults read, cheap enough to run on every pass.
+    /// Two metricSeries rows (hand-logged + imported, #949) and a UserDefaults read — still cheap
+    /// enough to run on every pass.
     private func reloadHydration() async {
         if hydrationEnabled {
             hydrationTotalML = await repo.hydrationTotal(day: Repository.localDayKey(Date()))


### PR DESCRIPTION
Follow-up to #974. Behaviour-neutral; this is about idle background work.

## The problem

`sync()` hands `setImportedHydration` its **whole 31-day window on every run**, and `sync` is driven by **six `HKObserverQuery` observers at hourly background delivery** (`heartRateVariabilitySDNN`, `restingHeartRate`, `activeEnergyBurned`, `heartRate`, `vo2Max`, sleep). So a watch user was doing ~31 SQLite upserts plus a `hydrationSeq` bump repeatedly through the day, to store numbers that were already there. Thirty of those days are historical and immutable — the honest answer is almost always "nothing moved".

The seq bump is the worse half: it invalidates the Today card's hydration read, so the card redid that work each time for no change.

## The fix

Read the window's existing imported rows once, upsert only the days whose value actually moved, and bump the seq only when something did. One ranged read replaces the write burst, and the common case now writes **nothing at all**.

## Two edges that matter

**A day with no row and a value of 0 is skipped**, not written — an absent row already reads as 0 via `hydrationImportedTotal`. That is what stops a user with no water in Health from accumulating a wall of zero rows on every sync. **A day that HAS a row and is now 0 is still written**: that is a deletion propagating, and confusing it with the no-op case would strand the old figure. Both paths are explicit in the code.

**The existing-row read does not fall back to `[]`.** Found re-reviewing this change, before pushing it: with `?? []` a failed read looks exactly like "there are no rows", which sends a just-deleted day into the skip path and leaves its stale non-zero figure behind. It bails instead and lets the next sync do it properly — the health store is the source of truth, so nothing is lost by waiting. Same distinction as the read-failure gating in #974; I reintroduced it in the optimisation and caught it on the re-read.

Comparison uses a 1e-9 epsilon rather than `==`. The same samples re-summed give the same `Double`, but a value that ever drifted by a float hair would re-write every sync forever and quietly undo the point of this. Well below a millilitre, so no real change is swallowed.

## Also

Corrects a comment in `TodayView` that still described `hydrationTotal` as reading one metricSeries row — it has read two since the import landed.

## Verification

- `swiftc -parse` clean; `doc_comment_lint` and `i18n_audit --ci` both exit 0.
- **No CI compiles this.** `app-build.yml` is disabled, and both files are app-target Swift shared with the macOS target — so a type error would pass every check and break the desktop build too. I have hand-traced the four cases (no row/zero, no row/value, row unchanged, row changed-to-zero), but that is reasoning, not a compiler.
- Not device-tested, and the win itself is unmeasured: the write count is certain, what it costs on real hardware is not. I have no device to profile on.