### PR TITLE
Sleep: forbid wake → deep/REM transitions — the one part of #348 that survives a de-contaminated benchmark

### DIFF
--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/SleepStagerV2.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/SleepStagerV2.swift
@@ -185,13 +185,19 @@ public enum SleepStagerV2 {
     /// part of PR #348's DREAMT re-tune that survives measurement on a de-contaminated reference set; the
     /// rest of that PR (its base priors, motion-gate multipliers, deep gate, awake dead-zone, emission
     /// coefficients and the deep/rem/light transition rows) was reverted by #437 and stays reverted, having
-    /// measured neutral-to-negative here. See the header note on `viterbi` for why a zero is safe.
+    /// measured neutral-to-negative here. See the header note on `viterbi` for why a zero is safe — and note
+    /// that ZERO is a strong prior rather than a prohibition: the viterbi floor turns it into ≈ -20.7 against
+    /// wake→light's ≈ -2.3, an ~18.4 log-unit penalty a sufficiently strong emission can still cross, so a
+    /// genuine sleep-onset REM period stays representable instead of structurally impossible.
     ///
     /// Measured on one wearer's 36 recorded nights, against the strap's own band `sleep_state` (an
     /// independent reference the recipe cannot contaminate — 21 nights, 15 554 epochs): sleep/wake kappa
     /// 0.105 → 0.118 and wake sensitivity 16.0 % → 17.6 %, with the healthy-stratum wake fraction essentially
-    /// unmoved (9.43 % → 9.96 %, i.e. no repeat of the #437 blow-out) and first-REM latency MAE 53.9 → 41.6
-    /// min. n = 1 wearer; see `Tools/SleepBench` and the PR for the full ablation and its limits.
+    /// unmoved (9.43 % → 9.96 %, i.e. no repeat of the #437 blow-out). Confirmed afterwards against
+    /// human-scored PSG hypnograms (PhysioNet sleep-accel, 31 subjects / 26 773 epochs, #991): 4-class kappa
+    /// 0.356 → 0.363, REM F1 0.569 → 0.575, wake sensitivity 30.42 % → 30.84 %, and the #437 stage-fraction
+    /// guard holds against truth as well. n = 1 wearer for the band figures; see `Tools/SleepBench` and the
+    /// PR for the full ablation and its limits.
     static let transition: [String: [String: Double]] = [
         "deep":  ["deep": 0.86, "rem": 0.007, "light": 0.126, "awake": 0.007],
         "rem":   ["deep": 0.005, "rem": 0.88, "light": 0.10, "awake": 0.015],
@@ -476,8 +482,11 @@ public enum SleepStagerV2 {
     /// uniform start. Ties resolve to the earlier stage in `stageNames`.
     static func viterbi(_ emSeq: [[String: Double]]) -> [String] {
         if emSeq.isEmpty { return [] }
-        // Floor before ln so a zeroed transition entry (a legal hand-edit) can never hit ln(0) = -Inf
-        // and poison the lattice. Inert for the current matrix (no zero entries). Kept from #348.
+        // Floor before ln so a zeroed transition entry can never hit ln(0) = -Inf and poison the lattice.
+        // LOAD-BEARING, not defensive: the awake row carries wake→deep = wake→rem = 0.0, so this floor is
+        // the only thing between those two entries and -Inf. Deleting it does not remove dead code, it
+        // breaks the stager. Floored, a zero costs ln(1e-9) ≈ -20.7 against wake→light's ≈ -2.3. The floor
+        // arrived with #348 and survived #437; the zeros it now carries arrived later.
         let logT = transition.mapValues { row in row.mapValues { log(max($0, 1e-9)) } }
         var V = emSeq[0]   // uniform start
         var back: [[String: String]] = []

--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/SleepStagerV2.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/SleepStagerV2.swift
@@ -177,11 +177,26 @@ public enum SleepStagerV2 {
 
     /// Transition matrix (rows = from, cols = to). Self-transitions dominate; deep↔rem rare; wake mostly
     /// to/from light. A priori, not fit.
+    ///
+    /// The AWAKE row encodes sleep-onset physiology directly: a sleeper does not enter N3 or REM straight
+    /// out of wakefulness — descent runs through N1/N2 — so wake→deep and wake→rem are ZERO rather than the
+    /// small non-zero values they used to carry, and the freed mass goes to the wake self-loop, which makes
+    /// a WASO episode span several epochs instead of flickering back to sleep after one. This row is the one
+    /// part of PR #348's DREAMT re-tune that survives measurement on a de-contaminated reference set; the
+    /// rest of that PR (its base priors, motion-gate multipliers, deep gate, awake dead-zone, emission
+    /// coefficients and the deep/rem/light transition rows) was reverted by #437 and stays reverted, having
+    /// measured neutral-to-negative here. See the header note on `viterbi` for why a zero is safe.
+    ///
+    /// Measured on one wearer's 36 recorded nights, against the strap's own band `sleep_state` (an
+    /// independent reference the recipe cannot contaminate — 21 nights, 15 554 epochs): sleep/wake kappa
+    /// 0.105 → 0.118 and wake sensitivity 16.0 % → 17.6 %, with the healthy-stratum wake fraction essentially
+    /// unmoved (9.43 % → 9.96 %, i.e. no repeat of the #437 blow-out) and first-REM latency MAE 53.9 → 41.6
+    /// min. n = 1 wearer; see `Tools/SleepBench` and the PR for the full ablation and its limits.
     static let transition: [String: [String: Double]] = [
         "deep":  ["deep": 0.86, "rem": 0.007, "light": 0.126, "awake": 0.007],
         "rem":   ["deep": 0.005, "rem": 0.88, "light": 0.10, "awake": 0.015],
         "light": ["deep": 0.06, "rem": 0.06, "light": 0.85, "awake": 0.03],
-        "awake": ["deep": 0.01, "rem": 0.02, "light": 0.27, "awake": 0.70]]
+        "awake": ["deep": 0.0, "rem": 0.0, "light": 0.10, "awake": 0.90]]
 
     /// One 30 s epoch's recipe features. Optionals are "no measurement"; the z-score / percentile treat a
     /// missing value as the neutral centre so a sparse channel never blocks a stage.

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/SleepStagerV2Tests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/SleepStagerV2Tests.swift
@@ -327,4 +327,20 @@ final class SleepStagerV2Tests: XCTestCase {
             XCTAssertEqual(row.values.reduce(0, +), 1.0, accuracy: 1e-9, "transition row '\(from)' must sum to 1.0")
         }
     }
+
+    /// Pin the AWAKE transition row directly, for the same reason the deep row is pinned: the end-to-end
+    /// golden is only sensitive where its own input sits near a decision boundary, and it does NOT move when
+    /// this row changes — so without this assertion the row is effectively unguarded. Twin:
+    /// `SleepStagerV2Test.wakeRowForbidsDirectDescentIntoDeepOrRem`.
+    ///
+    /// The zeros are the physiological claim: sleep onset descends through N1/N2, so wake never transitions
+    /// straight into N3 or REM. They are also why `viterbi` floors the log at 1e-9 — asserted here so the two
+    /// can never drift apart and reintroduce ln(0) = -inf.
+    func testWakeRowForbidsDirectDescentIntoDeepOrRem() {
+        XCTAssertEqual(SleepStagerV2.transition["awake"]!,
+                       ["deep": 0.0, "rem": 0.0, "light": 0.10, "awake": 0.90])
+        // A zeroed entry must reach the lattice as a large finite penalty, never -inf.
+        let lp = log(max(SleepStagerV2.transition["awake"]!["deep"]!, 1e-9))
+        XCTAssertTrue(lp.isFinite, "a zeroed transition must not produce a non-finite log-weight")
+    }
 }

--- a/android/app/src/main/java/com/noop/analytics/SleepStagerV2.kt
+++ b/android/app/src/main/java/com/noop/analytics/SleepStagerV2.kt
@@ -206,13 +206,19 @@ object SleepStagerV2 {
      *  part of PR #348's DREAMT re-tune that survives measurement on a de-contaminated reference set; the
      *  rest of that PR (its base priors, motion-gate multipliers, deep gate, awake dead-zone, emission
      *  coefficients and the deep/rem/light transition rows) was reverted by #437 and stays reverted, having
-     *  measured neutral-to-negative here. See the header note on [viterbi] for why a zero is safe.
+     *  measured neutral-to-negative here. See the header note on [viterbi] for why a zero is safe — and note
+     *  that ZERO is a strong prior rather than a prohibition: the viterbi floor turns it into ≈ -20.7 against
+     *  wake→light's ≈ -2.3, an ~18.4 log-unit penalty a sufficiently strong emission can still cross, so a
+     *  genuine sleep-onset REM period stays representable instead of structurally impossible.
      *
      *  Measured on one wearer's 36 recorded nights, against the strap's own band `sleep_state` (an
      *  independent reference the recipe cannot contaminate — 21 nights, 15 554 epochs): sleep/wake kappa
      *  0.105 → 0.118 and wake sensitivity 16.0 % → 17.6 %, with the healthy-stratum wake fraction essentially
-     *  unmoved (9.43 % → 9.96 %, i.e. no repeat of the #437 blow-out) and first-REM latency MAE 53.9 → 41.6
-     *  min. n = 1 wearer; see `Tools/SleepBench` and the PR for the full ablation and its limits. */
+     *  unmoved (9.43 % → 9.96 %, i.e. no repeat of the #437 blow-out). Confirmed afterwards against
+     *  human-scored PSG hypnograms (PhysioNet sleep-accel, 31 subjects / 26 773 epochs, #991): 4-class kappa
+     *  0.356 → 0.363, REM F1 0.569 → 0.575, wake sensitivity 30.42 % → 30.84 %, and the #437 stage-fraction
+     *  guard holds against truth as well. n = 1 wearer for the band figures; see `Tools/SleepBench` and the
+     *  PR for the full ablation and its limits. */
     internal val transition: Map<String, Map<String, Double>> = mapOf(
         "deep" to mapOf("deep" to 0.86, "rem" to 0.007, "light" to 0.126, "awake" to 0.007),
         "rem" to mapOf("deep" to 0.005, "rem" to 0.88, "light" to 0.10, "awake" to 0.015),
@@ -512,8 +518,11 @@ object SleepStagerV2 {
      *  uniform start. Ties resolve to the earlier stage in [stageNames]. */
     private fun viterbi(emSeq: List<Map<String, Double>>): List<String> {
         if (emSeq.isEmpty()) return emptyList()
-        // Floor before ln so a zeroed transition entry (a legal hand-edit) can never hit ln(0) = -Inf
-        // and poison the lattice. Inert for the current matrix (no zero entries). Kept from #348.
+        // Floor before ln so a zeroed transition entry can never hit ln(0) = -Inf and poison the lattice.
+        // LOAD-BEARING, not defensive: the awake row carries wake→deep = wake→rem = 0.0, so this floor is
+        // the only thing between those two entries and -Inf. Deleting it does not remove dead code, it
+        // breaks the stager. Floored, a zero costs ln(1e-9) ≈ -20.7 against wake→light's ≈ -2.3. The floor
+        // arrived with #348 and survived #437; the zeros it now carries arrived later.
         val logT = transition.mapValues { (_, row) -> row.mapValues { (_, v) -> ln(maxOf(v, 1e-9)) } }
         var v = emSeq[0]   // uniform start
         val back = ArrayList<Map<String, String>>()

--- a/android/app/src/main/java/com/noop/analytics/SleepStagerV2.kt
+++ b/android/app/src/main/java/com/noop/analytics/SleepStagerV2.kt
@@ -197,12 +197,27 @@ object SleepStagerV2 {
     private const val respWeight = 0.6
 
     /** Transition matrix (rows = from, cols = to). Self-transitions dominate; deep↔rem rare; wake mostly
-     *  to/from light. A priori, not fit. */
+     *  to/from light. A priori, not fit.
+     *
+     *  The AWAKE row encodes sleep-onset physiology directly: a sleeper does not enter N3 or REM straight
+     *  out of wakefulness — descent runs through N1/N2 — so wake→deep and wake→rem are ZERO rather than the
+     *  small non-zero values they used to carry, and the freed mass goes to the wake self-loop, which makes
+     *  a WASO episode span several epochs instead of flickering back to sleep after one. This row is the one
+     *  part of PR #348's DREAMT re-tune that survives measurement on a de-contaminated reference set; the
+     *  rest of that PR (its base priors, motion-gate multipliers, deep gate, awake dead-zone, emission
+     *  coefficients and the deep/rem/light transition rows) was reverted by #437 and stays reverted, having
+     *  measured neutral-to-negative here. See the header note on [viterbi] for why a zero is safe.
+     *
+     *  Measured on one wearer's 36 recorded nights, against the strap's own band `sleep_state` (an
+     *  independent reference the recipe cannot contaminate — 21 nights, 15 554 epochs): sleep/wake kappa
+     *  0.105 → 0.118 and wake sensitivity 16.0 % → 17.6 %, with the healthy-stratum wake fraction essentially
+     *  unmoved (9.43 % → 9.96 %, i.e. no repeat of the #437 blow-out) and first-REM latency MAE 53.9 → 41.6
+     *  min. n = 1 wearer; see `Tools/SleepBench` and the PR for the full ablation and its limits. */
     internal val transition: Map<String, Map<String, Double>> = mapOf(
         "deep" to mapOf("deep" to 0.86, "rem" to 0.007, "light" to 0.126, "awake" to 0.007),
         "rem" to mapOf("deep" to 0.005, "rem" to 0.88, "light" to 0.10, "awake" to 0.015),
         "light" to mapOf("deep" to 0.06, "rem" to 0.06, "light" to 0.85, "awake" to 0.03),
-        "awake" to mapOf("deep" to 0.01, "rem" to 0.02, "light" to 0.27, "awake" to 0.70))
+        "awake" to mapOf("deep" to 0.0, "rem" to 0.0, "light" to 0.10, "awake" to 0.90))
 
     /** One 30 s epoch's recipe features. Nullable means "no measurement"; the z-score / percentile treat a
      *  missing value as the neutral centre so a sparse channel never blocks a stage. Internal (not private) so

--- a/android/app/src/test/java/com/noop/analytics/SleepStagerV2Test.kt
+++ b/android/app/src/test/java/com/noop/analytics/SleepStagerV2Test.kt
@@ -9,6 +9,7 @@ import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import kotlin.math.PI
+import kotlin.math.ln
 import kotlin.math.sin
 import kotlin.math.roundToInt
 
@@ -356,5 +357,25 @@ class SleepStagerV2Test {
         for ((from, row) in SleepStagerV2.transition) {
             assertEquals("transition row '$from' must sum to 1.0", 1.0, row.values.sum(), 1e-9)
         }
+    }
+
+    /**
+     * Pin the AWAKE transition row directly, for the same reason the deep row is pinned: the end-to-end golden
+     * is only sensitive where its own input sits near a decision boundary, and it does NOT move when this row
+     * changes — so without this assertion the row is effectively unguarded. Twin:
+     * `SleepStagerV2Tests.testWakeRowForbidsDirectDescentIntoDeepOrRem`.
+     *
+     * The zeros are the physiological claim: sleep onset descends through N1/N2, so wake never transitions
+     * straight into N3 or REM. They are also why [SleepStagerV2.viterbi] floors the log at 1e-9 — asserted here
+     * so the two can never drift apart and reintroduce ln(0) = -Inf.
+     */
+    @Test
+    fun wakeRowForbidsDirectDescentIntoDeepOrRem() {
+        assertEquals(
+            mapOf("deep" to 0.0, "rem" to 0.0, "light" to 0.10, "awake" to 0.90),
+            SleepStagerV2.transition["awake"])
+        // A zeroed entry must reach the lattice as a large finite penalty, never -Inf.
+        val lp = ln(maxOf(SleepStagerV2.transition["awake"]!!["deep"]!!, 1e-9))
+        assertTrue("a zeroed transition must not produce a non-finite log-weight", lp.isFinite())
     }
 }


### PR DESCRIPTION
Re-litigates the #437 revert of #348 component-by-component, and lands the one component of seven that survives measurement on a de-contaminated reference set.

#348 re-tuned seven things about `SleepStagerV2` on DREAMT. #437 reverted all seven 48 h later because one healthy night went from 6 % to 23 % awake — *"kappa doesn't guard stage-fraction calibration."* That revert was correct about the outcome. This PR asks the narrower question it did not have the tooling to ask at the time: **was every one of the seven components guilty?**

Six were. One was not.

```diff
-"awake": ["deep": 0.01, "rem": 0.02, "light": 0.27, "awake": 0.70]
+"awake": ["deep": 0.0,  "rem": 0.0,  "light": 0.10, "awake": 0.90]
```

This row is a physiological claim rather than a fitted constant: sleep onset descends through N1/N2, so wake does not transition straight into N3 or REM, and the freed mass makes a WASO episode span several epochs instead of flickering back to sleep after one. The `ln(max(v, 1e-9))` viterbi floor that makes a zeroed entry safe already landed with #348 and survived #437, so nothing else is needed to support it.

## How this was measured

`Tools/SleepBench` over one wearer's 36 recorded nights, using the `--exclude` flag and the `E.-1` self-comparison audit from #935.

**The reference-set contamination is worse than assumed.** On this database the audit reports **10 of 15** stage-locked nights are byte-exact V2 replays and **3 more** sit at ≥ 95 % — 13 of 15 cannot serve as an independent reference for the recipe that produced them. They hand the incumbent free perfect scores and charge every alternative. Any before/after on the full 15 is biased toward "the incumbent is fine": the incumbent scores 4-class κ 0.978 there, which is a measurement of V2 against itself.

So the load-bearing instrument here is **not** the hand labels. It is the strap's own band `sleep_state` (the v18 @81 nibble) — WHOOP's verdict, not a re-derivation of NOOP's, and something the recipe cannot contaminate. 21 banded nights, 15 554 epochs, and the night set is fixed across every build compared.

| | incumbent | this PR |
|---|---|---|
| band sleep/wake κ (21 nights, 15 554 ep) | 0.105 | **0.118** |
| band wake sensitivity | 16.0 % | **17.6 %** |
| band accuracy | 79.1 % | 79.2 % |
| healthy-stratum wake fraction (n = 20) — *the #437 guard* | 9.43 % | 9.96 % |
| healthy deep | 22.09 % | 22.11 % |
| healthy REM | 29.58 % | 28.57 % |
| ~~first-REM latency MAE~~ | ~~53.9 min~~ | ~~41.6 min~~ — **withdrawn, see below** |
| corr(total sleep, REM % of sleep) | +0.579 | +0.563 |

**The first-REM latency row is struck and does not count toward landing this PR.** Measured against human-scored PSG hypnograms instead of the strap's band state, the same change goes **45.1 → 49.9 min** — slightly *worse*, a reversal, not an improvement. It is struck rather than deleted so [the correction comment](https://github.com/ryanbr/noop/pull/987#issuecomment-5137443400) still has something to point at. Treat **every** band-derived first-REM latency figure in this description as unsupported, including the 53.9 → 32.1 min quoted for the emission coefficients below; that component is rejected on other grounds and none of the reasoning here depends on a latency number.

**Everything else survives the PSG instrument, and the case gets stronger.** `Tools/SleepPSG` (#991) replays the shipped `SleepStagerV2.stageSession` over PhysioNet sleep-accel — 31 subjects, 26 773 human-scored epochs. Same cohort, same run: 4-class **κ 0.356 → 0.363**, **REM F1 0.569 → 0.575**, **wake sensitivity 30.42 % → 30.84 %**, and the #437 stage-fraction guard holds against truth as well — wake tightens 4.34 % → 4.15 % and deep does not move (18.94 % → 18.94 %, pooled over all 26 773 scored epochs). So the physiological claim this PR actually rests on is now confirmed against a human-scored reference and not only against another vendor's band. That instrument was built after this PR was opened, which is why the struck row shipped unchallenged.

For scale on the guard column: **#348 in its entirety puts healthy-stratum wake at 32.66 %.** This change puts it at 9.96 %.

On the 2 genuinely independent hand-labelled nights that remain after de-contamination, 4-class κ goes 0.857 → 0.863 — a tie at n = 2, reported for completeness rather than as evidence.

## Why the other six stay reverted

Each measured **alone**, against the same band reference and the same wake guard:

| component | measured alone | verdict |
|---|---|---|
| base priors (deep .15, awake .34) | healthy wake 9.43 % → **17.76 %** | the #437 blow-out, confirmed |
| motion gate (jerk 75/35, boost 4) | healthy wake 9.43 % → **15.92 %** | a **second** wake channel |
| emission coefficients | band κ 0.105 → **0.094** | negative |
| deep gate .25 → .40 | healthy deep 22.09 % → **25.47 %** | worsens an existing over-call |
| awake dead-zone 0.30 | band κ 0.105 → **0.099** | negative |
| deep/rem/light transition rows | band κ 0.105 → 0.101; healthy REM 29.58 % → **33.11 %** | negative |

The motion-gate row is the one worth dwelling on. It is tempting to read #348 as "the prior did the damage, the physiology was fine" — that is not what the data says. The prior and the motion gate are **two independent wake channels**, each roughly doubling the wake fraction on its own; removing only the prior still leaves healthy wake at 16.03 %. #437 was right to take both.

The emission coefficients are the closest call: they cut healthy deep 22.09 % → 15.30 % and first-REM latency MAE 53.9 → 32.1 min. But they cost band κ (0.105 → 0.094), cost the 2 clean hand-labelled nights (κ 0.857 → 0.658), and worsen the REM/night-length coupling below. Their deep correction is only an improvement if a population PSG deep fraction is trusted over this wearer's own labels, which disagree by ~6 pp. Not landed.

## What this PR is *not* entitled to claim

- **#348's out-of-cohort evidence was +0.028 (AAUWSS) and +0.006 (Walch).** The widely-quoted "+0.17" is DREAMT **in-sample** — real, but measured on the cohort whose constants were being fitted, and the number this work is least entitled to lean on. It is not the basis for anything here.
- **Everything above is n = 1 wearer**, on a WHOOP 5. The band reference is independent of NOOP's recipe but is itself a proprietary black box, not truth.
- **The hand labels are worse than n = 1 suggests.** 13 of 15 are unusable as an independent reference, and the survivors were authored against an older, wake-heavier recipe — those restages call 18.26 % of the night awake where a fresh V2 replay calls 11.13 %. That is why this PR rests on the band comparison instead.
- **A note on the direction of the wake defect,** because the record is confusing: a fresh V2 replay currently **under**-calls wake (it labels ~9.9 % of banded epochs wake against the strap's 17.4 %; wake sensitivity 16.0 %). Older notes describing V2 as over-calling wake by +82 min/night described the *stored, at-the-time* hypnogram, not a current replay.

**Request: a second labelled wearer.** The honest ceiling on this line of work is one person's nights. If anyone else has hand-corrected hypnograms — especially on a 4.0, or from a sleeper whose architecture differs — a second subject would do more for `SleepStagerV2` than any further re-tune of these constants. Happy to share the exact SleepBench invocation.

## Separately found, not fixed here

`SleepStagerV2` emits **more REM as a fraction of sleep on longer nights**: corr(total sleep, REM %) = **+0.579** Pearson / +0.501 Spearman over 36 nights, with nights ≥ 9 h running 37.3 % REM against only 37.7 % light, which is not physiological.

The mechanism was tested, not guessed. Two diagnostic builds (neither shipped):

- disable the minute-domain `remLatencyGuard` → corr collapses **+0.579 → +0.241**, long-vs-short spread +5.90 pp → **+0.55 pp**
- re-express the `1.0 * c` REM ramp in the minute domain → corr **worsens** to +0.679, spread +14.28 pp

So the **`1.0 * c` ramp is exonerated**; the coupling comes from the guard. It is a fixed 60-minute, 3.0-log-odds penalty, so it covers ~36 % of a 166-minute night and ~9 % of a 654-minute one, and proportional REM suppression therefore scales inversely with night length. This is a side effect of #930's (correct) move of the guard from the fraction domain to the minute domain — that PR's premise about *latency* is well-evidenced and should stand; what was not measured was the effect on REM *fraction*. Worth its own change, deliberately, rather than folding into this one. This PR is neutral-to-slightly-positive on it (+0.579 → +0.563).

## Review fix, second commit

`bb50f85` takes the one change asked for, on both platforms. The floor comment read *"Inert for the current matrix (no zero entries)"* — the statement this PR falsifies — while the transition docstring sent readers there to learn "why a zero is safe". It now says LOAD-BEARING, names `wake→deep` and `wake→rem` as the two entries that depend on it, and gives the magnitude (−20.7 floored against `wake→light`'s −2.3), so deleting it reads as breaking the stager rather than as tidying dead code.

Also taken, since "ZERO" does read as absolute: the docstring now states that the floored zero is a ~18.4 log-unit penalty a strong enough emission can still cross, so a genuine sleep-onset REM period stays representable rather than structurally impossible. And the withdrawn latency figure is gone from that docstring too — it was quoted there as well, replaced by the PSG figures that do reproduce.

Comments only. Two files, no non-comment line touched.

## Verification

- `swift test` (StrandAnalytics): **1175 tests, 0 failures** — the earlier "1248" in this description does not reproduce and is corrected here; `SleepStagerV2Tests` 14/14 incl. `testFrozenGoldenHypnogram`, `SleepStageTotalsTests` 63/63
- `./gradlew :app:testFullDebugUnitTest --rerun-tasks`: **3232 tests, 0 failures, 0 errors** (5 skipped; counted from the JUnit XML, not the wrapper exit code — which returned 0 on a run that never located the SDK), `SleepStagerV2Test` 12/12
- Swift and Kotlin twins carry the identical row; both **frozen goldens pass unchanged** — they are insensitive to this row, which is precisely why this adds a direct pin for it on both platforms (twin of the existing deep-row pin), asserting the zeros and that a zeroed entry still reaches the lattice as a finite log-weight. The goldens are inline source constants and the review commit does not touch their files.

Refs #348, #437, #935, #930, #991.

