### PR TITLE
Workouts: score with the measured resting HR, not the default 60 (#983)

### DIFF
--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/StrainScorerTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/StrainScorerTests.swift
@@ -171,4 +171,25 @@ final class StrainScorerTests: XCTestCase {
     func testFitStrainDenominatorThrowsTooFew() {
         XCTAssertThrowsError(try StrainScorer.fitStrainDenominator([(100, 10)]))
     }
+
+    /// #983 — the resting HR a workout is scored with is not cosmetic; it moves every zone boundary.
+    ///
+    /// %HRR is `(bpm - resting) / (max - resting)`, so scoring someone whose real resting is 50 as if it
+    /// were the hardcoded default of 60 shrinks the reserve AND raises the floor. At 136 bpm that is the
+    /// difference between zone 1 and zone 2 — the same session, two Efforts. The live/manual workout paths
+    /// used to fall back to the default while Today's Effort and the manual rescore threaded the measured
+    /// value, so a session disagreed with its own re-score.
+    ///
+    /// Twin: `StrainRestingHrTest.restingHrChangesTheZoneASampleLandsIn`.
+    func testRestingHrChangesTheZoneASampleLandsIn() {
+        XCTAssertEqual(StrainScorer.zoneWeight(136, restingHR: 60, hrReserve: 130), 1)
+        XCTAssertEqual(StrainScorer.zoneWeight(136, restingHR: 50, hrReserve: 140), 2)
+        // ...and that carries all the way through to the score, not just the zone.
+        let window = hr(136, 1200)   // well past the >=600-sample gate this file pins above
+        let asDefault = StrainScorer.strain(window, maxHR: 190, restingHR: 60)
+        let asMeasured = StrainScorer.strain(window, maxHR: 190, restingHR: 50)
+        XCTAssertNotNil(asDefault); XCTAssertNotNil(asMeasured)
+        XCTAssertGreaterThan(asMeasured!, asDefault!,
+                             "a lower measured resting puts the same HR in a higher zone, so Effort rises")
+    }
 }

--- a/Strand/App/AppModel.swift
+++ b/Strand/App/AppModel.swift
@@ -712,8 +712,14 @@ final class AppModel: ObservableObject {
     /// with Android) , but a GPS-only walk with HR not streaming still saves. Double-buzz confirms.
     func endWorkout() {
         guard let w = activeWorkout else { return }
+        // #983: read the SESSION's latched denominator before tearing the session down. The saved
+        // workout's Effort is computed further down, by which point `activeWorkout` is nil and the latch
+        // is cleared — so reading it there would take the fresh one-shot value and the STORED number
+        // could differ from the one shown on screen during the workout. Cannot simply clear the latch at
+        // the end of this function instead: the too-short discard path returns before it.
+        let sessionResting = workoutRestingHR()
         activeWorkout = nil
-        sessionRestingHR = nil   // #983: the next session latches its own denominator
+        sessionRestingHR = nil   // the next session latches its own denominator
         let wasGps = activeWorkoutIsGps
         activeWorkoutIsGps = false
         // Drop the durable snapshot the instant the session ends , whether it saves below or is discarded
@@ -745,7 +751,7 @@ final class AppModel: ObservableObject {
         let peak = samples.map(\.bpm).max()
         let strain = samples.count >= 2
             ? StrainScorer.strain(samples, maxHR: Double(profile.hrMax),
-                                  restingHR: workoutRestingHR(), sex: profile.sex) : nil
+                                  restingHR: sessionResting, sex: profile.sex) : nil
         // Estimate calories from the captured HR window (same Keytel/Harris–Benedict model the
         // auto-detector uses) so a manual session shows energy too, not just duration/strain. (#117)
         let up = UserProfile(weightKg: profile.weightKg, heightCm: profile.heightCm,

--- a/Strand/App/AppModel.swift
+++ b/Strand/App/AppModel.swift
@@ -49,6 +49,18 @@ final class AppModel: ObservableObject {
     let ble: BLEManager
     /// Read model over the on-device store (dashboard + detail screens).
     let repo: Repository
+
+    /// The wearer's MEASURED resting HR for a workout scored right now (#983), or the documented default
+    /// when today's row has none yet.
+    ///
+    /// The %HRR denominator is `maxHR - restingHR`, so falling back to a hardcoded 60 for someone whose
+    /// real resting is (say) 50 moves every zone boundary and quietly changes the score. Today's Effort
+    /// already threads the measured value and #972 threaded it into the manual rescore; these live/manual
+    /// workout paths were the ones left on the default, so a session's live Effort and the same session
+    /// rescored later did not agree. Byte-parity twin of Kotlin `AppViewModel.workoutRestingHR`.
+    var workoutRestingHR: Double {
+        repo.today?.restingHr.map(Double.init) ?? StrainScorer.defaultRestingHR
+    }
     /// User profile (age/sex/body/HR-max) for zones, calories, baselines.
     let profile = ProfileStore()
     /// Behaviour settings: double-tap action, wear automation, zone coaching, smart alarm, illness watch.
@@ -718,7 +730,8 @@ final class AppModel: ObservableObject {
             : Int((Double(samples.map(\.bpm).reduce(0, +)) / Double(samples.count)).rounded())
         let peak = samples.map(\.bpm).max()
         let strain = samples.count >= 2
-            ? StrainScorer.strain(samples, maxHR: Double(profile.hrMax), sex: profile.sex) : nil
+            ? StrainScorer.strain(samples, maxHR: Double(profile.hrMax),
+                                  restingHR: workoutRestingHR, sex: profile.sex) : nil
         // Estimate calories from the captured HR window (same Keytel/Harris–Benedict model the
         // auto-detector uses) so a manual session shows energy too, not just duration/strain. (#117)
         let up = UserProfile(weightKg: profile.weightKg, heightCm: profile.heightCm,
@@ -765,7 +778,8 @@ final class AppModel: ObservableObject {
         w.samples.append(HRSample(ts: Int(Date().timeIntervalSince1970), bpm: hr))
         w.peakHr = max(w.peakHr, hr)
         w.avgHr = Int((Double(w.samples.map(\.bpm).reduce(0, +)) / Double(w.samples.count)).rounded())
-        w.liveStrain = StrainScorer.strain(w.samples, maxHR: Double(profile.hrMax), sex: profile.sex) ?? 0
+        w.liveStrain = StrainScorer.strain(w.samples, maxHR: Double(profile.hrMax),
+                                           restingHR: workoutRestingHR, sex: profile.sex) ?? 0
         activeWorkout = w
         // Re-snapshot the durable session so a kill keeps the latest accumulated HR window (#529).
         persistActiveWorkout()

--- a/Strand/App/AppModel.swift
+++ b/Strand/App/AppModel.swift
@@ -58,9 +58,22 @@ final class AppModel: ObservableObject {
     /// already threads the measured value and #972 threaded it into the manual rescore; these live/manual
     /// workout paths were the ones left on the default, so a session's live Effort and the same session
     /// rescored later did not agree. Byte-parity twin of Kotlin `AppViewModel.workoutRestingHR`.
-    var workoutRestingHR: Double {
-        repo.today?.restingHr.map(Double.init) ?? StrainScorer.defaultRestingHR
+    func workoutRestingHR() -> Double {
+        let measured = repo.today?.restingHr.map(Double.init) ?? StrainScorer.defaultRestingHR
+        // One-shot scoring (a saved window, no live session) always reads fresh.
+        guard activeWorkout != nil else { return measured }
+        // LATCHED for the life of the session. Live Effort is recomputed over the WHOLE window on every
+        // incoming sample, so reading this fresh each time would let a mid-session refresh of today's row
+        // (a sync landing, the night's resting HR finally populating) change the denominator and re-score
+        // every sample already taken — the number on screen would visibly step mid-workout. One session,
+        // one denominator.
+        if let latched = sessionRestingHR { return latched }
+        sessionRestingHR = measured
+        return measured
     }
+
+    /// The resting HR latched at the start of the current session; cleared by `endWorkout`.
+    private var sessionRestingHR: Double?
     /// User profile (age/sex/body/HR-max) for zones, calories, baselines.
     let profile = ProfileStore()
     /// Behaviour settings: double-tap action, wear automation, zone coaching, smart alarm, illness watch.
@@ -700,6 +713,7 @@ final class AppModel: ObservableObject {
     func endWorkout() {
         guard let w = activeWorkout else { return }
         activeWorkout = nil
+        sessionRestingHR = nil   // #983: the next session latches its own denominator
         let wasGps = activeWorkoutIsGps
         activeWorkoutIsGps = false
         // Drop the durable snapshot the instant the session ends , whether it saves below or is discarded
@@ -731,7 +745,7 @@ final class AppModel: ObservableObject {
         let peak = samples.map(\.bpm).max()
         let strain = samples.count >= 2
             ? StrainScorer.strain(samples, maxHR: Double(profile.hrMax),
-                                  restingHR: workoutRestingHR, sex: profile.sex) : nil
+                                  restingHR: workoutRestingHR(), sex: profile.sex) : nil
         // Estimate calories from the captured HR window (same Keytel/Harris–Benedict model the
         // auto-detector uses) so a manual session shows energy too, not just duration/strain. (#117)
         let up = UserProfile(weightKg: profile.weightKg, heightCm: profile.heightCm,
@@ -779,7 +793,7 @@ final class AppModel: ObservableObject {
         w.peakHr = max(w.peakHr, hr)
         w.avgHr = Int((Double(w.samples.map(\.bpm).reduce(0, +)) / Double(w.samples.count)).rounded())
         w.liveStrain = StrainScorer.strain(w.samples, maxHR: Double(profile.hrMax),
-                                           restingHR: workoutRestingHR, sex: profile.sex) ?? 0
+                                           restingHR: workoutRestingHR(), sex: profile.sex) ?? 0
         activeWorkout = w
         // Re-snapshot the durable session so a kill keeps the latest accumulated HR window (#529).
         persistActiveWorkout()

--- a/android/app/src/main/java/com/noop/ui/AppViewModel.kt
+++ b/android/app/src/main/java/com/noop/ui/AppViewModel.kt
@@ -1343,8 +1343,14 @@ class AppViewModel(app: Application) : AndroidViewModel(app) {
      *  discarded quietly. Double-buzz confirms the save. */
     fun endWorkout() {
         val w = _activeWorkout.value ?: return
+        // #983: read the SESSION's latched denominator before tearing the session down. The saved
+        // workout's Effort is computed further down, by which point `_activeWorkout` is null and the
+        // latch is cleared — so reading it there would take the fresh one-shot value and the STORED
+        // number could differ from the one shown on screen during the workout. Cannot simply clear the
+        // latch at the end of this function instead: the too-short discard path returns before it.
+        val sessionResting = workoutRestingHR()
         _activeWorkout.value = null
-        sessionRestingHR = null   // #983: the next session latches its own denominator
+        sessionRestingHR = null   // the next session latches its own denominator
         gpsJob?.cancel(); gpsJob = null
         // Drop the durable non-GPS snapshot the instant the session ends — whether it saves below or is
         // discarded as too-short — so a relaunch never rehydrates an already-finished session (#529).
@@ -1378,7 +1384,7 @@ class AppViewModel(app: Application) : AndroidViewModel(app) {
         val peak = if (samples.isNotEmpty()) samples.maxOf { it.bpm } else null
         val strain = if (samples.size >= 2)
             StrainScorer.strain(samples, maxHR = profileStore.hrMax.toDouble(),
-                restingHR = workoutRestingHR(), sex = profileStore.sex) else null
+                restingHR = sessionResting, sex = profileStore.sex) else null
         // Estimate calories from the captured HR window (same Keytel/Harris–Benedict model the
         // auto-detector uses) so a manual session shows energy too, not just duration/strain. (#117)
         val energyKcal = if (samples.size >= 2)

--- a/android/app/src/main/java/com/noop/ui/AppViewModel.kt
+++ b/android/app/src/main/java/com/noop/ui/AppViewModel.kt
@@ -584,6 +584,19 @@ class AppViewModel(app: Application) : AndroidViewModel(app) {
     val today: StateFlow<DailyMetric?> = _today.asStateFlow()
 
     /**
+     * The wearer's MEASURED resting HR for a workout scored right now (#983), or the documented default
+     * when today's row has none yet.
+     *
+     * The %HRR denominator is `maxHR - restingHR`, so falling back to a hardcoded 60 for someone whose
+     * real resting is (say) 50 moves every zone boundary and quietly changes the score. The daily Effort
+     * on Today already threads the measured value, and #972 threaded it into the manual rescore — these
+     * live/manual workout paths were the ones left on the default, so a session's live Effort and the
+     * same session rescored later did not agree.
+     */
+    private val workoutRestingHR: Double
+        get() = _today.value?.restingHr?.toDouble() ?: StrainScorer.defaultRestingHR
+
+    /**
      * #849: Today's heavy history-wide reload guard. The Today screen runs a couple of expensive
      * history-wide passes (the workouts/sources footer, which derives HR per imported workout from raw strap
      * samples, and the pinned Stress / Fitness-age / Vitality reads over the whole metric history). Those run
@@ -1350,7 +1363,8 @@ class AppViewModel(app: Application) : AndroidViewModel(app) {
         val avg = if (samples.isNotEmpty()) samples.sumOf { it.bpm } / samples.size else null
         val peak = if (samples.isNotEmpty()) samples.maxOf { it.bpm } else null
         val strain = if (samples.size >= 2)
-            StrainScorer.strain(samples, maxHR = profileStore.hrMax.toDouble(), sex = profileStore.sex) else null
+            StrainScorer.strain(samples, maxHR = profileStore.hrMax.toDouble(),
+                restingHR = workoutRestingHR, sex = profileStore.sex) else null
         // Estimate calories from the captured HR window (same Keytel/Harris–Benedict model the
         // auto-detector uses) so a manual session shows energy too, not just duration/strain. (#117)
         val energyKcal = if (samples.size >= 2)
@@ -1404,7 +1418,8 @@ class AppViewModel(app: Application) : AndroidViewModel(app) {
         @Suppress("UNNECESSARY_SAFE_CALL")
         val w = _activeWorkout?.value ?: return
         val s = w.samples + HrSample(deviceId = deviceId, ts = System.currentTimeMillis() / 1000, bpm = bpm)
-        val strain = StrainScorer.strain(s, maxHR = profileStore.hrMax.toDouble(), sex = profileStore.sex) ?: 0.0
+        val strain = StrainScorer.strain(s, maxHR = profileStore.hrMax.toDouble(),
+            restingHR = workoutRestingHR, sex = profileStore.sex) ?: 0.0
         val updated = w.copy(
             samples = s, avgHr = s.sumOf { it.bpm } / s.size, peakHr = s.maxOf { it.bpm }, liveStrain = strain,
         )

--- a/android/app/src/main/java/com/noop/ui/AppViewModel.kt
+++ b/android/app/src/main/java/com/noop/ui/AppViewModel.kt
@@ -593,8 +593,21 @@ class AppViewModel(app: Application) : AndroidViewModel(app) {
      * live/manual workout paths were the ones left on the default, so a session's live Effort and the
      * same session rescored later did not agree.
      */
-    private val workoutRestingHR: Double
-        get() = _today.value?.restingHr?.toDouble() ?: StrainScorer.defaultRestingHR
+    private fun workoutRestingHR(): Double {
+        val measured = _today.value?.restingHr?.toDouble() ?: StrainScorer.defaultRestingHR
+        // One-shot scoring (a saved window, no live session) always reads fresh.
+        @Suppress("UNNECESSARY_SAFE_CALL")
+        if (_activeWorkout?.value == null) return measured
+        // LATCHED for the life of the session. Live Effort is recomputed over the WHOLE window on every
+        // incoming sample, so reading this fresh each time would let a mid-session refresh of today's row
+        // (a sync landing, the night's resting HR finally populating) change the denominator and re-score
+        // every sample already taken — the number on screen would visibly step up or down mid-workout.
+        // One session, one denominator.
+        return sessionRestingHR ?: measured.also { sessionRestingHR = it }
+    }
+
+    /** The resting HR latched at the start of the current session; cleared by [endWorkout]. */
+    private var sessionRestingHR: Double? = null
 
     /**
      * #849: Today's heavy history-wide reload guard. The Today screen runs a couple of expensive
@@ -1331,6 +1344,7 @@ class AppViewModel(app: Application) : AndroidViewModel(app) {
     fun endWorkout() {
         val w = _activeWorkout.value ?: return
         _activeWorkout.value = null
+        sessionRestingHR = null   // #983: the next session latches its own denominator
         gpsJob?.cancel(); gpsJob = null
         // Drop the durable non-GPS snapshot the instant the session ends — whether it saves below or is
         // discarded as too-short — so a relaunch never rehydrates an already-finished session (#529).
@@ -1364,7 +1378,7 @@ class AppViewModel(app: Application) : AndroidViewModel(app) {
         val peak = if (samples.isNotEmpty()) samples.maxOf { it.bpm } else null
         val strain = if (samples.size >= 2)
             StrainScorer.strain(samples, maxHR = profileStore.hrMax.toDouble(),
-                restingHR = workoutRestingHR, sex = profileStore.sex) else null
+                restingHR = workoutRestingHR(), sex = profileStore.sex) else null
         // Estimate calories from the captured HR window (same Keytel/Harris–Benedict model the
         // auto-detector uses) so a manual session shows energy too, not just duration/strain. (#117)
         val energyKcal = if (samples.size >= 2)
@@ -1419,7 +1433,7 @@ class AppViewModel(app: Application) : AndroidViewModel(app) {
         val w = _activeWorkout?.value ?: return
         val s = w.samples + HrSample(deviceId = deviceId, ts = System.currentTimeMillis() / 1000, bpm = bpm)
         val strain = StrainScorer.strain(s, maxHR = profileStore.hrMax.toDouble(),
-            restingHR = workoutRestingHR, sex = profileStore.sex) ?: 0.0
+            restingHR = workoutRestingHR(), sex = profileStore.sex) ?: 0.0
         val updated = w.copy(
             samples = s, avgHr = s.sumOf { it.bpm } / s.size, peakHr = s.maxOf { it.bpm }, liveStrain = strain,
         )

--- a/android/app/src/test/java/com/noop/analytics/StrainRestingHrTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/StrainRestingHrTest.kt
@@ -1,0 +1,37 @@
+package com.noop.analytics
+
+import com.noop.data.HrSample
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * #983 — the resting HR a workout is scored with is not cosmetic; it moves every zone boundary.
+ *
+ * %HRR is `(bpm - resting) / (max - resting)`, so scoring someone whose real resting is 50 as if it were
+ * the hardcoded default of 60 both shrinks the reserve and raises the floor. At 136 bpm that is exactly
+ * the difference between zone 1 and zone 2 — the same session, two different Efforts.
+ *
+ * This is why the live/manual workout paths threading the measured value matters: Today's Effort and the
+ * manual rescore (#972) already did, so a session used to disagree with its own re-score.
+ *
+ * Twin of `StrainScorerTests.testRestingHrChangesTheZoneASampleLandsIn`.
+ */
+class StrainRestingHrTest {
+
+    @Test
+    fun restingHrChangesTheZoneASampleLandsIn() {
+        // 136 bpm straddles the zone-1/zone-2 boundary depending only on the resting HR used.
+        assertEquals(1, StrainScorer.zoneWeight(136.0, 60.0, 130.0))
+        assertEquals(2, StrainScorer.zoneWeight(136.0, 50.0, 140.0))
+
+        // ...and it carries through to the score, not just the zone.
+        val window = (0 until 1200).map { HrSample(deviceId = "d", ts = 1_700_000_000L + it, bpm = 136) }
+        val asDefault = StrainScorer.strain(window, maxHR = 190.0, restingHR = 60.0)!!
+        val asMeasured = StrainScorer.strain(window, maxHR = 190.0, restingHR = 50.0)!!
+        assertTrue(
+            "a lower measured resting puts the same HR in a higher zone, so Effort rises",
+            asMeasured > asDefault,
+        )
+    }
+}


### PR DESCRIPTION
Found while diagnosing #983. Narrow fix, four call sites, plus one regression it created that I caught on self-review.

## The bug

The live and manual workout paths call `StrainScorer.strain` **without** a `restingHR`, so they silently take the hardcoded default of 60 — on both platforms (`AppViewModel.kt:1353, :1407`; `AppModel.swift:721, :768`).

Not cosmetic. %HRR is `(bpm - resting) / (max - resting)`, so using 60 for someone whose real resting is 50 both **shrinks the reserve and raises the floor**:

```
136 bpm, maxHR 190
  resting 60 (default)  -> 58.5% HRR -> zone 1
  resting 50 (measured) -> 61.4% HRR -> zone 2
```

Both platforms now read today's measured resting HR — the same row Today's Effort uses — falling back to the documented default only when today's row has none yet.

## A regression this PR created, and fixed

The first commit read the resting HR **fresh on every sample**. Live Effort is recomputed over the whole accumulated window each time a sample arrives, so a mid-session refresh of today's row (a sync landing, the night's resting HR finally populating) would change the denominator and re-score everything already taken — the number on screen stepping up or down part-way through a workout. Previously it was pinned at a constant 60, so this was mine, not inherited.

Now latched for the life of the session and cleared by `endWorkout`. Lazily on first use rather than at each start site, because there are three of those and a fourth could not then forget. One-shot scoring (a saved window, no live session) still reads fresh. Expressed as a function rather than a computed property on both platforms — it mutates the latch, and a getter with a side effect is a trap.

## What this does NOT fix — read before merging

**It does not close #983.** A brisk-walking day reads zero because Edwards TRIMP scores nothing below 50% HRR. That is a model question, left open with the numbers.

**It only partly stops a session disagreeing with itself.** An earlier draft of this description overstated that. Today's Effort and the manual rescore (#972) thread the measured value, so live-vs-rescore now agree — but the two **historical backfill** paths (`Repository.swift` workout enrichment, `WhoopRepository.kt` twin) still use 60. Live-vs-backfill still disagree. I left those deliberately: they score rows from arbitrary past days, where today's resting HR is simply a *different* wrong denominator, and doing it properly needs a per-day lookup inside a concurrent block that may only carry Sendable scalars. That is its own change, not a line edit.

**Effort moves in both directions.** For anyone whose measured resting is above 60, workout Effort will now be **lower** than before. That is more accurate, but it will read as the app taking points away unless the release notes say so.

**Workout history becomes mixed.** New workouts use the measured resting; every stored one used 60. This week's ride is not directly comparable with last month's — the same property #963 has, and neither has a changelog line yet.

**It is a no-op exactly when many workouts happen.** `restingHr` comes from the night's sleep processing; a morning workout before that lands falls back to 60 regardless.

Only NEW workouts change; stored rows are untouched.

## Verification

- **A parity test pair** pinning that resting HR moves the zone a sample lands in *and* that it carries through to the score — the claim above made checkable. Both run in CI (`test (StrandAnalytics)`, Android `build-and-test`).
- Android compiles with **no new errors**: `AppViewModel.kt` sits at 18 both before and after, and the two pre-existing `suspension functions` cascade errors simply moved from lines 802/825 to 828/851 — exactly the 26 lines inserted. Probe-confirmed the file is analysed.
- `swiftc -parse` clean; `doc_comment_lint` and `i18n_audit --ci` both 0.
- **`AppModel.swift` is app-target Swift that no CI compiles.** `restingHr.map(Double.init)` verified against the identical idiom at `TodayView.swift:679`/`:3349`, and `@testable import` confirmed to expose the internal `zoneWeight` — but that is reading, not a compiler.
- Not device-tested. The latch behaviour across a mid-session sync is the part I would most want eyes on.