### PR TITLE
Workouts: score the SAVED workout with the measured resting HR (#983)

### DIFF
--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/StrainScorerTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/StrainScorerTests.swift
@@ -171,4 +171,25 @@ final class StrainScorerTests: XCTestCase {
     func testFitStrainDenominatorThrowsTooFew() {
         XCTAssertThrowsError(try StrainScorer.fitStrainDenominator([(100, 10)]))
     }
+
+    /// #983 — the resting HR a workout is scored with is not cosmetic; it moves every zone boundary.
+    ///
+    /// %HRR is `(bpm - resting) / (max - resting)`, so scoring someone whose real resting is 50 as if it
+    /// were the hardcoded default of 60 shrinks the reserve AND raises the floor. At 136 bpm that is the
+    /// difference between zone 1 and zone 2 — the same session, two Efforts. The saved-workout path
+    /// used to fall back to the default while Today's Effort and the manual rescore threaded the measured
+    /// value, so the SAVED workout disagreed with its own re-score.
+    ///
+    /// Twin: `StrainRestingHrTest.restingHrChangesTheZoneASampleLandsIn`.
+    func testRestingHrChangesTheZoneASampleLandsIn() {
+        XCTAssertEqual(StrainScorer.zoneWeight(136, restingHR: 60, hrReserve: 130), 1)
+        XCTAssertEqual(StrainScorer.zoneWeight(136, restingHR: 50, hrReserve: 140), 2)
+        // ...and that carries all the way through to the score, not just the zone.
+        let window = hr(136, 1200)   // well past the >=600-sample gate this file pins above
+        let asDefault = StrainScorer.strain(window, maxHR: 190, restingHR: 60)
+        let asMeasured = StrainScorer.strain(window, maxHR: 190, restingHR: 50)
+        XCTAssertNotNil(asDefault); XCTAssertNotNil(asMeasured)
+        XCTAssertGreaterThan(asMeasured!, asDefault!,
+                             "a lower measured resting puts the same HR in a higher zone, so Effort rises")
+    }
 }

--- a/Strand/App/AppModel.swift
+++ b/Strand/App/AppModel.swift
@@ -717,8 +717,16 @@ final class AppModel: ObservableObject {
         let avg = samples.isEmpty ? nil
             : Int((Double(samples.map(\.bpm).reduce(0, +)) / Double(samples.count)).rounded())
         let peak = samples.map(\.bpm).max()
+        // #983: score the SAVED workout with the wearer's measured resting HR, not the hardcoded
+        // default of 60. %HRR is (bpm - resting) / (max - resting), so the default moves every zone
+        // boundary — at 136 bpm with maxHR 190 it is the difference between zone 1 and zone 2. Today's
+        // Effort and the manual rescore (#972) already thread this, so the stored number used to
+        // disagree with its own re-score. Read once here, at save time; the live readout during the
+        // session is a transient running estimate and deliberately left alone.
+        let restingHR = repo.today?.restingHr.map(Double.init) ?? StrainScorer.defaultRestingHR
         let strain = samples.count >= 2
-            ? StrainScorer.strain(samples, maxHR: Double(profile.hrMax), sex: profile.sex) : nil
+            ? StrainScorer.strain(samples, maxHR: Double(profile.hrMax),
+                                  restingHR: restingHR, sex: profile.sex) : nil
         // Estimate calories from the captured HR window (same Keytel/Harris–Benedict model the
         // auto-detector uses) so a manual session shows energy too, not just duration/strain. (#117)
         let up = UserProfile(weightKg: profile.weightKg, heightCm: profile.heightCm,

--- a/Strand/App/AppModel.swift
+++ b/Strand/App/AppModel.swift
@@ -732,7 +732,12 @@ final class AppModel: ObservableObject {
         let up = UserProfile(weightKg: profile.weightKg, heightCm: profile.heightCm,
                              age: Double(profile.age), sex: profile.sex)
         let kcal = samples.count >= 2
-            ? Calories.estimateBoutCalories(samples, profile: up, hrmax: Double(profile.hrMax), restingHR: nil).0
+            // #983: same measured resting HR as the strain above, not nil. The calories model's
+            // active-vs-resting threshold sits at resting + 30% HRR, so the default silently shifts what
+            // counts as active — and #972 already threads it in the rescore path, so leaving it nil here
+            // meant a saved workout's kcal disagreed with its own re-score just as its Effort did.
+            ? Calories.estimateBoutCalories(samples, profile: up, hrmax: Double(profile.hrMax),
+                                            restingHR: restingHR).0
             : 0
         let startTs = Int(w.start.timeIntervalSince1970)
         let row = WorkoutRow(

--- a/android/app/src/main/java/com/noop/ui/AppViewModel.kt
+++ b/android/app/src/main/java/com/noop/ui/AppViewModel.kt
@@ -1362,7 +1362,11 @@ class AppViewModel(app: Application) : AndroidViewModel(app) {
         // Estimate calories from the captured HR window (same Keytel/Harris–Benedict model the
         // auto-detector uses) so a manual session shows energy too, not just duration/strain. (#117)
         val energyKcal = if (samples.size >= 2)
-            Calories.estimateBoutCalories(samples, currentProfile(), profileStore.hrMax.toDouble(), null)
+            // #983: same measured resting HR as the strain above, not null. The calories model's
+            // active-vs-resting threshold sits at resting + 30% HRR, so the default silently shifts what
+            // counts as active — and #972 already threads it in the rescore path, so leaving it null here
+            // meant a saved workout's kcal disagreed with its own re-score just as its Effort did.
+            Calories.estimateBoutCalories(samples, currentProfile(), profileStore.hrMax.toDouble(), restingHR)
                 .first.takeIf { it > 0 }
         else null
         val row = WorkoutRow(

--- a/android/app/src/main/java/com/noop/ui/AppViewModel.kt
+++ b/android/app/src/main/java/com/noop/ui/AppViewModel.kt
@@ -1349,8 +1349,16 @@ class AppViewModel(app: Application) : AndroidViewModel(app) {
         val endMs = System.currentTimeMillis()
         val avg = if (samples.isNotEmpty()) samples.sumOf { it.bpm } / samples.size else null
         val peak = if (samples.isNotEmpty()) samples.maxOf { it.bpm } else null
+        // #983: score the SAVED workout with the wearer's measured resting HR, not the hardcoded
+        // default of 60. %HRR is (bpm - resting) / (max - resting), so the default moves every zone
+        // boundary — at 136 bpm with maxHR 190 it is the difference between zone 1 and zone 2. Today's
+        // Effort and the manual rescore (#972) already thread this, so the stored number used to
+        // disagree with its own re-score. Read once here, at save time; the live readout during the
+        // session is a transient running estimate and deliberately left alone.
+        val restingHR = _today.value?.restingHr?.toDouble() ?: StrainScorer.defaultRestingHR
         val strain = if (samples.size >= 2)
-            StrainScorer.strain(samples, maxHR = profileStore.hrMax.toDouble(), sex = profileStore.sex) else null
+            StrainScorer.strain(samples, maxHR = profileStore.hrMax.toDouble(),
+                restingHR = restingHR, sex = profileStore.sex) else null
         // Estimate calories from the captured HR window (same Keytel/Harris–Benedict model the
         // auto-detector uses) so a manual session shows energy too, not just duration/strain. (#117)
         val energyKcal = if (samples.size >= 2)

--- a/android/app/src/test/java/com/noop/analytics/StrainRestingHrTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/StrainRestingHrTest.kt
@@ -1,0 +1,37 @@
+package com.noop.analytics
+
+import com.noop.data.HrSample
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * #983 — the resting HR a workout is scored with is not cosmetic; it moves every zone boundary.
+ *
+ * %HRR is `(bpm - resting) / (max - resting)`, so scoring someone whose real resting is 50 as if it were
+ * the hardcoded default of 60 both shrinks the reserve and raises the floor. At 136 bpm that is exactly
+ * the difference between zone 1 and zone 2 — the same session, two different Efforts.
+ *
+ * This is why the saved-workout path threading the measured value matters: Today's Effort and the
+ * manual rescore (#972) already did, so a stored workout used to disagree with its own re-score.
+ *
+ * Twin of `StrainScorerTests.testRestingHrChangesTheZoneASampleLandsIn`.
+ */
+class StrainRestingHrTest {
+
+    @Test
+    fun restingHrChangesTheZoneASampleLandsIn() {
+        // 136 bpm straddles the zone-1/zone-2 boundary depending only on the resting HR used.
+        assertEquals(1, StrainScorer.zoneWeight(136.0, 60.0, 130.0))
+        assertEquals(2, StrainScorer.zoneWeight(136.0, 50.0, 140.0))
+
+        // ...and it carries through to the score, not just the zone.
+        val window = (0 until 1200).map { HrSample(deviceId = "d", ts = 1_700_000_000L + it, bpm = 136) }
+        val asDefault = StrainScorer.strain(window, maxHR = 190.0, restingHR = 60.0)!!
+        val asMeasured = StrainScorer.strain(window, maxHR = 190.0, restingHR = 50.0)!!
+        assertTrue(
+            "a lower measured resting puts the same HR in a higher zone, so Effort rises",
+            asMeasured > asDefault,
+        )
+    }
+}


### PR DESCRIPTION
Replaces #990, cut back after two rounds of self-review each found a defect **that PR had introduced**.

## The bug (unchanged)

The workout paths called `StrainScorer.strain` without a `restingHR`, so they silently took the hardcoded default of 60. %HRR is `(bpm - resting) / (max - resting)`, so the default moves every zone boundary:

```
136 bpm, maxHR 190
  resting 60 (default)  -> 58.5% HRR -> zone 1
  resting 50 (measured) -> 61.4% HRR -> zone 2
```

Today's Effort and the manual rescore (#972) already thread the measured value, so **a stored workout disagreed with its own re-score**.

## What changed from #990

This fixes **only the saved workout**, on both platforms. One read at save time. No new state, no lifecycle, nothing to clear.

#990 also threaded it into the live per-sample readout, which needs the value latched for the session — and that latch is where both of its bugs came from:

1. It re-read the denominator on **every sample**, so a mid-session sync could re-score the whole accumulated window and visibly step the number mid-workout.
2. With the latch in place, `endWorkout` cleared it **before** the save — so the number written to the database could differ from the one shown on screen during the session.

Neither was inherited. Both were introduced by that PR, in the same small area: the lifecycle of a value it added. The underlying one-line idea was never the risky part; deciding when to capture and release it was. Two passes, two bugs, and I would not have claimed a third pass would find nothing — hence cutting the risky half rather than iterating on it again.

## The trade-off, stated plainly

The live readout stays on the default, so **it can now differ from the saved figure at the end of a session**. That is accepted deliberately:

- the **stored** number is what history compares and what the rescore path already agrees with — that is the disagreement worth removing;
- the live figure is an explicitly transient running estimate;
- and a per-sample denominator has now been got wrong twice, in code that no test covers and that no CI compiles on the Swift side.

Fixing the live path properly is still worth doing — most likely by hanging the value off the `ActiveWorkout` object so it lives and dies with the session rather than in a separate latch. That is a different change with its own design, and it should not ride along with a one-line correctness fix.

## Also unchanged from #990

- **Does not close #983.** The brisk-walk zero is the Edwards 50%-HRR floor, a model question, left open with the numbers.
- The two **historical backfill** paths still use 60 — they score rows from arbitrary past days, where today's resting HR is simply a different wrong denominator.
- **Effort moves in both directions:** anyone whose measured resting is above 60 will see saved workout Effort go *down*. Worth a release-note line.
- **Workout history becomes mixed:** new saves use the measured value, stored rows keep 60.
- Only NEW workouts change; stored rows are untouched.

## Verification

- Parity test pair (carried over unchanged) pinning that resting HR moves the zone a sample lands in and that it carries through to the score. Runs in CI on both platforms.
- Android compiles with no new errors — `AppViewModel.kt` at 18 before and after, all pre-existing kotlinx-coroutines classpath cascade.
- `swiftc -parse` clean; `doc_comment_lint` and `i18n_audit --ci` both 0.
- `AppModel.swift` is app-target Swift **no CI compiles**; the idiom is verified against `TodayView.swift:679`/`:3349`, which is reading, not a compiler. The change there is now two lines with no state, which is about as small as that residual risk gets.