### PR TITLE
RawOutbox: say that Policy 1 is dormant, and why it is kept (#981)

### DIFF
--- a/Packages/WhoopStore/Sources/WhoopStore/RawOutbox.swift
+++ b/Packages/WhoopStore/Sources/WhoopStore/RawOutbox.swift
@@ -165,6 +165,7 @@ extension WhoopStore {
     }
 
     /// Mark a batch synced (timestamp in unix seconds).
+    ///
     /// #981 — NO production caller, and by design: see the dormancy note on `pruneRaw`'s Policy 1. Kept
     /// because it is the natural hook for a future on-device export lane, not because anything calls it.
     public func markRawBatchSynced(batchId: String, at: Int) async throws {

--- a/Packages/WhoopStore/Sources/WhoopStore/RawOutbox.swift
+++ b/Packages/WhoopStore/Sources/WhoopStore/RawOutbox.swift
@@ -165,6 +165,8 @@ extension WhoopStore {
     }
 
     /// Mark a batch synced (timestamp in unix seconds).
+    /// #981 — NO production caller, and by design: see the dormancy note on `pruneRaw`'s Policy 1. Kept
+    /// because it is the natural hook for a future on-device export lane, not because anything calls it.
     public func markRawBatchSynced(batchId: String, at: Int) async throws {
         try syncWrite { db in
             try db.execute(sql: "UPDATE rawBatch SET syncedAt = ? WHERE batchId = ?",
@@ -176,9 +178,20 @@ extension WhoopStore {
 extension WhoopStore {
     /// Prune raw outbox rows. Returns the number of rawBatch rows deleted.
     ///
-    /// **Policy 1:** Delete SYNCED batches whose `syncedAt` timestamp is older than
-    /// `now - keepWindowSeconds`. Synced raw is safe to drop because the decoded streams
-    /// are persisted separately.
+    /// **Policy 1 — DORMANT in a shipping build (#981):** Delete SYNCED batches whose `syncedAt`
+    /// timestamp is older than `now - keepWindowSeconds`. Synced raw is safe to drop because the decoded
+    /// streams are persisted separately.
+    ///
+    /// It cannot fire today. `syncedAt` is only ever set by `markRawBatchSynced`, which has no production
+    /// caller — and cannot get one, because marking a batch "synced" needs somewhere to sync it to and
+    /// NOOP has no server, no account and no cloud sync by design (`CLAUDE.md`). The API and this policy
+    /// are inherited from the upstream `my-whoop` store (see `ATTRIBUTION.md`), which did have a sync
+    /// lane. Kept rather than deleted: both halves are correct and tested, and an on-device EXPORT lane
+    /// would be a legitimate server-free way to drain the outbox — at which point marking exported
+    /// batches synced and letting this reap them is exactly the right shape.
+    ///
+    /// Nothing is unbounded in the meantime: **Policy 2 is the real growth bound**, and is what the 19 GB
+    /// note below refers to.
     ///
     /// **Policy 2 (size eviction, #27):** Cap the total on-disk raw footprint at
     /// `maxUnsyncedBytes`. Walk the surviving batches newest-first (`capturedAt DESC`),


### PR DESCRIPTION
Smallest of the three items in #981 (@vishk23). **Docs only, no behaviour change.**

`pruneRaw` documents two prune policies as though both operate. **Policy 1 cannot fire in a shipping build.** `syncedAt` is only ever set by `markRawBatchSynced`, which has five call sites and all five are tests — nothing in `Strand/`, `StrandiOS/` or `android/`.

And it cannot get a production caller: marking a batch "synced" needs somewhere to sync it *to*, and `CLAUDE.md` makes "no server, no account, no cloud sync" a hard scope limit. Both halves are inherited from the upstream `my-whoop` store (`ATTRIBUTION.md`), which had a sync lane NOOP deliberately does not.

## Why documented rather than deleted

I argued for deletion on the issue. **On checking the file I think that was wrong**, for two reasons:

- **The docs never actually mislead about growth.** Policy 2 is credited with the bound in its own paragraph — *"Without this an experimental capture toggle could grow local storage without bound (a 5/MG user saw 19 GB)"* — and that is accurate. So there is no false claim to correct, only an unstated dormancy.
- **There is a plausible server-free use.** An on-device **export** lane would be a legitimate way to drain the outbox, and marking exported batches synced so Policy 1 reaps them is exactly the shape this code already has. Deleting removes the natural hook and buys nothing, since nothing is unbounded meanwhile.

What was actually wrong was that a reader sees two policies and reasonably assumes both run. That is now stated at both sites — the policy and `markRawBatchSynced` itself — with the reason and the condition under which it would wake up.

## Not in scope

The other two #981 items are deliberately untouched. `setDayOwner` (item 2) is unreachable on **both** platforms and needs a product decision — pin-a-day-to-a-device is either a feature that wants UI, or a branch that comes out of both. Item 3 (`ouraRaw`) @vishk23 offered to send, and I would rather not duplicate it; my only suggestion there is splitting the `ORDER BY day` → `fetchedAt` fix (two lines, no migration) from the schema cleanup (a versioned migration, governed by `CLAUDE.md`).

## Verification

`swiftc -parse` clean, `doc_comment_lint` 0. Comment-only change to one file — no behaviour, no tests affected, nothing to device-test.