### PR TITLE
Diagnostics: a nightly mean for the 5/MG SpO2 candidate, so it can be checked (#112)

### DIFF
--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/AnalyticsEngine.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/AnalyticsEngine.swift
@@ -962,7 +962,7 @@ public enum AnalyticsEngine {
     /// DIAGNOSTIC ONLY. Nothing scores this, it never writes `spo2Pct`, and it is not a blood-oxygen
     /// reading — it is the raw candidate averaged, surfaced so it can be checked against a real one.
     /// Byte-parity twin of the Kotlin `nightlySpo2CandidateMean`.
-    static func nightlySpo2CandidateMean(_ sessions: [SleepSession],
+    public static func nightlySpo2CandidateMean(_ sessions: [SleepSession],
                                          aux: [V18AuxSample]) -> (mean: Int, samples: Int)? {
         guard !sessions.isEmpty, !aux.isEmpty else { return nil }
         var sum = 0, kept = 0

--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/AnalyticsEngine.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/AnalyticsEngine.swift
@@ -939,6 +939,42 @@ public enum AnalyticsEngine {
         return (red: redSum / kept, ir: irSum / kept)
     }
 
+    /// Nightly gated mean of the 5/MG SpO2 **candidate** byte (`@82`) over the detected in-bed
+    /// `sessions`, with the sample count it rests on — or nil when no in-band reading fell inside any
+    /// span. (#112, tracking #103.)
+    ///
+    /// WHY THIS EXISTS. The candidate is decoded and stored but deliberately never scored: `@82` looks
+    /// like a strap-computed SpO2 %, and on one independent 8-night check it tracked the WHOOP app almost
+    /// exactly, but on the two nights from the strap it was found on it moved the OPPOSITE way. Two
+    /// devices, contradictory answers, so it cannot be promoted. Breaking that tie needs a third strap —
+    /// and until now the only way to read the candidate was to scroll the Deep Timeline chart and eyeball
+    /// it, which is a poor instrument to ask a volunteer to use and produces a number nobody can check.
+    ///
+    /// This makes the comparison one number against one number: the wearer reads this and the figure the
+    /// WHOOP app reports for the same night. `samples` travels with the mean on purpose — a mean over 11
+    /// readings and a mean over 1100 are not the same evidence, and a correlation built from the first
+    /// would be worthless.
+    ///
+    /// Gated to `70...100`, the SAME in-band window the decoder applies when it emits
+    /// `spo2_candidate_82`: sub-70 nonzero values are diagnostic codes and bit-7 values are saturation
+    /// sentinels, so averaging them in would produce a number that is not a percentage of anything.
+    ///
+    /// DIAGNOSTIC ONLY. Nothing scores this, it never writes `spo2Pct`, and it is not a blood-oxygen
+    /// reading — it is the raw candidate averaged, surfaced so it can be checked against a real one.
+    /// Byte-parity twin of the Kotlin `nightlySpo2CandidateMean`.
+    static func nightlySpo2CandidateMean(_ sessions: [SleepSession],
+                                         aux: [V18AuxSample]) -> (mean: Int, samples: Int)? {
+        guard !sessions.isEmpty, !aux.isEmpty else { return nil }
+        var sum = 0, kept = 0
+        for a in aux {
+            guard let v = a.auxByte82, (70...100).contains(v) else { continue }
+            guard sessions.contains(where: { $0.start <= a.ts && a.ts <= $0.end }) else { continue }
+            sum += v; kept += 1
+        }
+        guard kept > 0 else { return nil }
+        return (mean: sum / kept, samples: kept)
+    }
+
     // MARK: - Skin-temp funnel diagnostic (#752)
 
     // Skin temp coming out 0/absent on a WHOOP 4.0 (or any) night is opaque: the user can't tell whether

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/Spo2CandidateNightlyTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/Spo2CandidateNightlyTests.swift
@@ -1,0 +1,75 @@
+import XCTest
+import WhoopProtocol
+import WhoopStore
+@testable import StrandAnalytics
+
+/// #112 / #103 — the nightly gated mean of the 5/MG SpO2 candidate byte.
+///
+/// This exists to make a volunteer's contribution checkable. The candidate cannot be promoted while two
+/// straps disagree about it, and breaking that tie means a third wearer comparing their nightly figure
+/// against the one the WHOOP app reports. Reading it off a scrolling chart is not an instrument; one
+/// number is. These pin what that number counts and — more importantly — what it refuses to count.
+final class Spo2CandidateNightlyTests: XCTestCase {
+
+    private func session(_ start: Int, _ durSec: Int) -> SleepSession {
+        SleepSession(start: start, end: start + durSec, efficiency: 0.9,
+                     stages: [], restingHR: 50, avgHRV: 60)
+    }
+
+    private func aux(_ ts: Int, _ v: Int?) -> V18AuxSample { V18AuxSample(ts: ts, auxByte82: v) }
+
+    func testMeanAndSampleCountOverTheSession() {
+        let r = AnalyticsEngine.nightlySpo2CandidateMean(
+            [session(1000, 600)], aux: [aux(1100, 94), aux(1200, 96), aux(1300, 95)])
+        XCTAssertEqual(r?.mean, 95)
+        XCTAssertEqual(r?.samples, 3)
+    }
+
+    /// The count is not decoration: a mean over 3 readings and a mean over 3000 are different evidence,
+    /// and a volunteer's correlation built on the first would be worthless.
+    func testSampleCountTravelsWithTheMean() {
+        let many = (0..<50).map { aux(1000 + $0, 93) }
+        XCTAssertEqual(AnalyticsEngine.nightlySpo2CandidateMean([session(900, 600)], aux: many)?.samples, 50)
+    }
+
+    /// Out-of-band values are DIAGNOSTIC CODES and SATURATION SENTINELS, not low blood oxygen. Averaging
+    /// them in would produce a number that is not a percentage of anything — the single most damaging
+    /// thing this helper could do, because it would look plausible.
+    func testSubSeventyAndSentinelValuesAreExcluded() {
+        let r = AnalyticsEngine.nightlySpo2CandidateMean(
+            [session(1000, 600)],
+            aux: [aux(1100, 94), aux(1150, 3), aux(1200, 0), aux(1250, 0x80), aux(1300, 96)])
+        XCTAssertEqual(r?.mean, 95, "only the two in-band readings may count")
+        XCTAssertEqual(r?.samples, 2)
+    }
+
+    func testDaytimeSamplesOutsideTheSessionAreExcluded() {
+        let r = AnalyticsEngine.nightlySpo2CandidateMean(
+            [session(1000, 600)], aux: [aux(500, 99), aux(1100, 94), aux(5000, 88)])
+        XCTAssertEqual(r?.samples, 1)
+        XCTAssertEqual(r?.mean, 94)
+    }
+
+    func testNilWhenNothingInBandFallsInsideASession() {
+        XCTAssertNil(AnalyticsEngine.nightlySpo2CandidateMean([session(1000, 600)], aux: [aux(1100, 5)]))
+        XCTAssertNil(AnalyticsEngine.nightlySpo2CandidateMean([session(1000, 600)], aux: [aux(9999, 95)]))
+        XCTAssertNil(AnalyticsEngine.nightlySpo2CandidateMean([], aux: [aux(1100, 95)]))
+        XCTAssertNil(AnalyticsEngine.nightlySpo2CandidateMean([session(1000, 600)], aux: []))
+    }
+
+    /// A record with no @82 at all is not a zero reading.
+    func testMissingBytesAreSkippedNotCountedAsZero() {
+        let r = AnalyticsEngine.nightlySpo2CandidateMean(
+            [session(1000, 600)], aux: [aux(1100, nil), aux(1200, 96)])
+        XCTAssertEqual(r?.mean, 96)
+        XCTAssertEqual(r?.samples, 1)
+    }
+
+    /// The boundaries are inclusive, matching the decoder's own `70...100` emit gate exactly.
+    func testBandBoundariesMatchTheDecoderGate() {
+        XCTAssertEqual(AnalyticsEngine.nightlySpo2CandidateMean(
+            [session(1000, 600)], aux: [aux(1100, 70), aux(1200, 100)])?.samples, 2)
+        XCTAssertNil(AnalyticsEngine.nightlySpo2CandidateMean(
+            [session(1000, 600)], aux: [aux(1100, 69), aux(1200, 101)]))
+    }
+}

--- a/Strand/System/DebugDataDiagnostics.swift
+++ b/Strand/System/DebugDataDiagnostics.swift
@@ -145,6 +145,22 @@ enum DebugDataDiagnostics {
         let devAnchor = family == .whoop4 ? Whoop4SkinTemp.deviceAnchorRaw(windowSkin.map { $0.raw }) : nil
         lines.append(AnalyticsEngine.skinTempFunnel([det], hr: hr, skinTemp: skin,
                                                     family: family, anchorRaw: devAnchor).summary)
+
+        // #112/#103 — the 5/MG SpO2 CANDIDATE (@82), as one number a wearer can check against the figure
+        // the WHOOP app reports for the same night. The candidate cannot be promoted while two straps
+        // disagree about it, and the only way to read it until now was to scroll the Deep Timeline and
+        // eyeball it — which is not an instrument to hand a volunteer. Diagnostic only: nothing scores
+        // this, and it is NOT a blood-oxygen reading. Absent on a WHOOP 4.0, which carries raw red/IR ADC
+        // and no candidate at all — said explicitly so a 4.0 owner is not left wondering.
+        let aux = (try? await store.v18AuxSamples(deviceId: did, from: cs.startTs, to: cs.endTs)) ?? []
+        if let cand = AnalyticsEngine.nightlySpo2CandidateMean([det], aux: aux) {
+            lines.append("SpO₂ candidate @82 (5/MG): mean \(cand.mean) over \(cand.samples) in-band readings "
+                         + "— UNVERIFIED, compare against the WHOOP app's figure for this night (#103).")
+        } else if family == .whoop5 {
+            lines.append("SpO₂ candidate @82 (5/MG): no in-band readings inside this night's span.")
+        } else {
+            lines.append("SpO₂ candidate @82: not carried by a WHOOP 4.0 (raw red/IR ADC only).")
+        }
         return lines
     }
 

--- a/Strand/System/DebugDataDiagnostics.swift
+++ b/Strand/System/DebugDataDiagnostics.swift
@@ -15,6 +15,11 @@ import WhoopStore
 ///     latest night). Used by the interactive "Save…/Share log" buttons, which hold `model.repo`.
 enum DebugDataDiagnostics {
 
+    /// Aux rows read for one night's SpO₂-candidate line (#112). Explicit rather than the store default
+    /// so the Kotlin twin can state the SAME number — a night is ~30k rows at 1 Hz, so this is slack.
+    static let spo2CandidateAuxLimit = 200_000
+
+
     /// Strap identity + timezone from persisted defaults (sync, offline-safe). Mirrors the prefs-backed
     /// portion of the Android strap-state block; keys match the iOS @AppStorage / persisted values.
     static func strapStateLines() -> [String] {
@@ -152,8 +157,17 @@ enum DebugDataDiagnostics {
         // eyeball it — which is not an instrument to hand a volunteer. Diagnostic only: nothing scores
         // this, and it is NOT a blood-oxygen reading. Absent on a WHOOP 4.0, which carries raw red/IR ADC
         // and no candidate at all — said explicitly so a 4.0 owner is not left wondering.
-        let aux = (try? await store.v18AuxSamples(deviceId: did, from: cs.startTs, to: cs.endTs)) ?? []
-        if let cand = AnalyticsEngine.nightlySpo2CandidateMean([det], aux: aux) {
+        //
+        // The read is NOT collapsed to `?? []`. A failed read and a night with no candidate are different
+        // facts, and this is a diagnostic — printing "no in-band readings" because the query threw would
+        // be a confident false statement in the one place whose whole job is to say what is actually
+        // there. Same distinction as the imported-water and caffeine read gates (#949).
+        let auxRead = try? await store.v18AuxSamples(deviceId: did, from: cs.startTs, to: cs.endTs,
+                                                     limit: spo2CandidateAuxLimit)
+        if auxRead == nil {
+            lines.append("SpO₂ candidate @82: could not read the aux stream for this night — "
+                         + "a read failure, NOT an absence of readings.")
+        } else if let cand = AnalyticsEngine.nightlySpo2CandidateMean([det], aux: auxRead ?? []) {
             lines.append("SpO₂ candidate @82 (5/MG): mean \(cand.mean) over \(cand.samples) in-band readings "
                          + "— UNVERIFIED, compare against the WHOOP app's figure for this night (#103).")
         } else if family == .whoop5 {

--- a/android/app/src/main/java/com/noop/analytics/AnalyticsEngine.kt
+++ b/android/app/src/main/java/com/noop/analytics/AnalyticsEngine.kt
@@ -3,6 +3,7 @@ package com.noop.analytics
 import com.noop.data.DailyMetric
 import com.noop.data.EventRow
 import com.noop.data.GravitySample
+import com.noop.data.V18AuxRow
 import com.noop.data.HrSample
 import com.noop.data.SkinTempSample
 import com.noop.data.Spo2Sample
@@ -712,6 +713,47 @@ object AnalyticsEngine {
      * drift to exclude, and the value is surfaced honestly as raw ADC — never scored — so there is
      * nothing to poison into a fake %. Pure + deterministic; twin of the Swift `nightlySpo2RawMeans`. (#93)
      */
+    /**
+     * Nightly gated mean of the 5/MG SpO2 **candidate** byte (`@82`) over the detected in-bed [sessions],
+     * paired with the sample count it rests on — or null when no in-band reading fell inside any span.
+     * (#112, tracking #103.)
+     *
+     * WHY THIS EXISTS. The candidate is decoded and stored but deliberately never scored: `@82` looks like
+     * a strap-computed SpO2 %, and on one independent 8-night check it tracked the WHOOP app almost
+     * exactly, but on the two nights from the strap it was found on it moved the OPPOSITE way. Two
+     * devices, contradictory answers, so it cannot be promoted. Breaking that tie needs a third strap —
+     * and until now the only way to read the candidate was to scroll the Deep Timeline chart and eyeball
+     * it, which is a poor instrument to hand a volunteer and produces a number nobody can check.
+     *
+     * This makes the comparison one number against one number: the wearer reads this and the figure the
+     * WHOOP app reports for the same night. The count travels with the mean on purpose — a mean over 11
+     * readings and a mean over 1100 are not the same evidence.
+     *
+     * Gated to `70..100`, the SAME in-band window the decoder applies when it emits `spo2_candidate_82`:
+     * sub-70 nonzero values are diagnostic codes and bit-7 values are saturation sentinels, so averaging
+     * them in would produce a number that is not a percentage of anything.
+     *
+     * DIAGNOSTIC ONLY. Nothing scores this and it never writes `spo2Pct`. Byte-parity twin of the Swift
+     * `nightlySpo2CandidateMean`.
+     */
+    internal fun nightlySpo2CandidateMean(
+        sessions: List<DetectedSleep>,
+        aux: List<V18AuxRow>,
+    ): Pair<Int, Int>? {
+        if (sessions.isEmpty() || aux.isEmpty()) return null
+        var sum = 0L
+        var kept = 0
+        for (a in aux) {
+            val v = a.auxByte82 ?: continue
+            if (v < 70L || v > 100L) continue
+            if (sessions.none { a.ts in it.start..it.end }) continue
+            sum += v
+            kept += 1
+        }
+        if (kept == 0) return null
+        return Pair((sum / kept).toInt(), kept)
+    }
+
     internal fun nightlySpo2RawMeans(
         sessions: List<DetectedSleep>,
         spo2: List<Spo2Sample>,

--- a/android/app/src/main/java/com/noop/analytics/AnalyticsEngine.kt
+++ b/android/app/src/main/java/com/noop/analytics/AnalyticsEngine.kt
@@ -713,6 +713,24 @@ object AnalyticsEngine {
      * drift to exclude, and the value is surfaced honestly as raw ADC — never scored — so there is
      * nothing to poison into a fake %. Pure + deterministic; twin of the Swift `nightlySpo2RawMeans`. (#93)
      */
+    internal fun nightlySpo2RawMeans(
+        sessions: List<DetectedSleep>,
+        spo2: List<Spo2Sample>,
+    ): Pair<Int, Int>? {
+        if (sessions.isEmpty() || spo2.isEmpty()) return null
+        var redSum = 0L
+        var irSum = 0L
+        var kept = 0
+        for (s in spo2) {
+            if (sessions.none { s.ts in it.start..it.end }) continue
+            redSum += s.red
+            irSum += s.ir
+            kept++
+        }
+        if (kept == 0) return null
+        return (redSum / kept).toInt() to (irSum / kept).toInt()
+    }
+
     /**
      * Nightly gated mean of the 5/MG SpO2 **candidate** byte (`@82`) over the detected in-bed [sessions],
      * paired with the sample count it rests on — or null when no in-band reading fell inside any span.
@@ -752,24 +770,6 @@ object AnalyticsEngine {
         }
         if (kept == 0) return null
         return Pair((sum / kept).toInt(), kept)
-    }
-
-    internal fun nightlySpo2RawMeans(
-        sessions: List<DetectedSleep>,
-        spo2: List<Spo2Sample>,
-    ): Pair<Int, Int>? {
-        if (sessions.isEmpty() || spo2.isEmpty()) return null
-        var redSum = 0L
-        var irSum = 0L
-        var kept = 0
-        for (s in spo2) {
-            if (sessions.none { s.ts in it.start..it.end }) continue
-            redSum += s.red
-            irSum += s.ir
-            kept++
-        }
-        if (kept == 0) return null
-        return (redSum / kept).toInt() to (irSum / kept).toInt()
     }
 
     /** Plausible worn skin-temperature range (°C). Off-wrist/charging samples drift to ambient and are

--- a/android/app/src/main/java/com/noop/testcentre/AndroidDiagnostics.kt
+++ b/android/app/src/main/java/com/noop/testcentre/AndroidDiagnostics.kt
@@ -119,6 +119,24 @@ object AndroidDiagnostics {
             val devAnchor = if (family == com.noop.protocol.DeviceFamily.WHOOP4)
                 com.noop.protocol.Whoop4SkinTemp.deviceAnchorRaw(windowSkin.map { it.raw }) else null
             add(com.noop.analytics.AnalyticsEngine.skinTempFunnel(listOf(det), hr, skin, family, devAnchor).summary)
+
+            // #112/#103 — the 5/MG SpO2 CANDIDATE (@82), as one number a wearer can check against the
+            // figure the WHOOP app reports for the same night. The candidate cannot be promoted while two
+            // straps disagree about it, and until now the only way to read it was to scroll the Deep
+            // Timeline and eyeball it, which is not an instrument to hand a volunteer. Diagnostic only:
+            // nothing scores this and it is NOT a blood-oxygen reading. Absent on a WHOOP 4.0, which
+            // carries raw red/IR ADC and no candidate — said explicitly so a 4.0 owner is not left
+            // wondering. Twin of the Swift `DebugDataDiagnostics` line.
+            val aux = repo.v18AuxSamples(id, session.startTs, session.endTs, Int.MAX_VALUE)
+            val cand = com.noop.analytics.AnalyticsEngine.nightlySpo2CandidateMean(listOf(det), aux)
+            when {
+                cand != null -> add(
+                    "SpO2 candidate @82 (5/MG): mean ${cand.first} over ${cand.second} in-band readings " +
+                        "- UNVERIFIED, compare against the WHOOP app's figure for this night (#103).")
+                family == com.noop.protocol.DeviceFamily.WHOOP5 ->
+                    add("SpO2 candidate @82 (5/MG): no in-band readings inside this night's span.")
+                else -> add("SpO2 candidate @82: not carried by a WHOOP 4.0 (raw red/IR ADC only).")
+            }
         }.onFailure { add("(funnels unavailable: ${it.message})") }
     }
 

--- a/android/app/src/main/java/com/noop/testcentre/AndroidDiagnostics.kt
+++ b/android/app/src/main/java/com/noop/testcentre/AndroidDiagnostics.kt
@@ -18,6 +18,10 @@ import android.os.PowerManager
  */
 object AndroidDiagnostics {
 
+    /** Aux rows read for one night's SpO2-candidate line (#112). Twin of the Swift
+     *  `DebugDataDiagnostics.spo2CandidateAuxLimit`. */
+    private const val SPO2_CANDIDATE_AUX_LIMIT = 200_000
+
     fun summaryLines(context: Context): List<String> = buildList {
         add("Device: ${Build.MANUFACTURER} ${Build.MODEL}")
         add("Android: ${Build.VERSION.RELEASE} (SDK ${Build.VERSION.SDK_INT})")
@@ -127,7 +131,9 @@ object AndroidDiagnostics {
             // nothing scores this and it is NOT a blood-oxygen reading. Absent on a WHOOP 4.0, which
             // carries raw red/IR ADC and no candidate — said explicitly so a 4.0 owner is not left
             // wondering. Twin of the Swift `DebugDataDiagnostics` line.
-            val aux = repo.v18AuxSamples(id, session.startTs, session.endTs, Int.MAX_VALUE)
+            // Same explicit limit as the Swift twin's `spo2CandidateAuxLimit`, rather than Int.MAX_VALUE,
+            // so the two platforms visibly read the same window. A night is ~30k rows at 1 Hz.
+            val aux = repo.v18AuxSamples(id, session.startTs, session.endTs, SPO2_CANDIDATE_AUX_LIMIT)
             val cand = com.noop.analytics.AnalyticsEngine.nightlySpo2CandidateMean(listOf(det), aux)
             when {
                 cand != null -> add(

--- a/android/app/src/main/java/com/noop/testcentre/AndroidDiagnostics.kt
+++ b/android/app/src/main/java/com/noop/testcentre/AndroidDiagnostics.kt
@@ -133,15 +133,29 @@ object AndroidDiagnostics {
             // wondering. Twin of the Swift `DebugDataDiagnostics` line.
             // Same explicit limit as the Swift twin's `spo2CandidateAuxLimit`, rather than Int.MAX_VALUE,
             // so the two platforms visibly read the same window. A night is ~30k rows at 1 Hz.
-            val aux = repo.v18AuxSamples(id, session.startTs, session.endTs, SPO2_CANDIDATE_AUX_LIMIT)
-            val cand = com.noop.analytics.AnalyticsEngine.nightlySpo2CandidateMean(listOf(det), aux)
+            //
+            // The aux read gets its OWN runCatching rather than riding the enclosing one. Letting it
+            // propagate would abort the whole funnels block on a failure here — the skin-temp and REM
+            // lines above would be followed by a generic "(funnels unavailable)" instead of this line
+            // saying which of the two things happened. A failed read and a night with no candidate are
+            // different facts, and this is a diagnostic. Byte-for-byte the same four outcomes, in the
+            // same order, with the same wording as the Swift `DebugDataDiagnostics` twin.
+            val auxRead = runCatching {
+                repo.v18AuxSamples(id, session.startTs, session.endTs, SPO2_CANDIDATE_AUX_LIMIT)
+            }.getOrNull()
+            val cand = auxRead?.let {
+                com.noop.analytics.AnalyticsEngine.nightlySpo2CandidateMean(listOf(det), it)
+            }
             when {
+                auxRead == null -> add(
+                    "SpO₂ candidate @82: could not read the aux stream for this night — " +
+                        "a read failure, NOT an absence of readings.")
                 cand != null -> add(
-                    "SpO2 candidate @82 (5/MG): mean ${cand.first} over ${cand.second} in-band readings " +
-                        "- UNVERIFIED, compare against the WHOOP app's figure for this night (#103).")
+                    "SpO₂ candidate @82 (5/MG): mean ${cand.first} over ${cand.second} in-band readings " +
+                        "— UNVERIFIED, compare against the WHOOP app's figure for this night (#103).")
                 family == com.noop.protocol.DeviceFamily.WHOOP5 ->
-                    add("SpO2 candidate @82 (5/MG): no in-band readings inside this night's span.")
-                else -> add("SpO2 candidate @82: not carried by a WHOOP 4.0 (raw red/IR ADC only).")
+                    add("SpO₂ candidate @82 (5/MG): no in-band readings inside this night's span.")
+                else -> add("SpO₂ candidate @82: not carried by a WHOOP 4.0 (raw red/IR ADC only).")
             }
         }.onFailure { add("(funnels unavailable: ${it.message})") }
     }

--- a/android/app/src/test/java/com/noop/analytics/Spo2CandidateNightlyTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/Spo2CandidateNightlyTest.kt
@@ -1,0 +1,82 @@
+package com.noop.analytics
+
+import com.noop.data.V18AuxRow
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * #112 / #103 — the nightly gated mean of the 5/MG SpO2 candidate byte.
+ *
+ * Byte-parity twin of the Swift `Spo2CandidateNightlyTests`: same fixtures, same expected values.
+ *
+ * This exists to make a volunteer's contribution checkable. The candidate cannot be promoted while two
+ * straps disagree about it, and breaking that tie means a third wearer comparing their nightly figure
+ * against the one the WHOOP app reports. Reading it off a scrolling chart is not an instrument; one
+ * number is. These pin what that number counts and — more importantly — what it refuses to count.
+ */
+class Spo2CandidateNightlyTest {
+
+    private fun session(start: Long, durSec: Long) = DetectedSleep(
+        start = start, end = start + durSec, efficiency = 0.9,
+        stages = emptyList(), restingHR = 50, avgHRV = 60.0,
+    )
+
+    private fun aux(ts: Long, v: Long?) = V18AuxRow(ts = ts, auxByte82 = v)
+
+    @Test fun meanAndSampleCountOverTheSession() {
+        val r = AnalyticsEngine.nightlySpo2CandidateMean(
+            listOf(session(1000, 600)), listOf(aux(1100, 94), aux(1200, 96), aux(1300, 95)))
+        assertEquals(95, r?.first)
+        assertEquals(3, r?.second)
+    }
+
+    /** The count is not decoration: 3 readings and 3000 are different evidence. */
+    @Test fun sampleCountTravelsWithTheMean() {
+        val many = (0 until 50).map { aux(1000L + it, 93L) }
+        assertEquals(50, AnalyticsEngine.nightlySpo2CandidateMean(listOf(session(900, 600)), many)?.second)
+    }
+
+    /**
+     * Out-of-band values are DIAGNOSTIC CODES and SATURATION SENTINELS, not low blood oxygen. Averaging
+     * them in would produce a number that is not a percentage of anything — the most damaging thing this
+     * helper could do, because the result would still look plausible.
+     */
+    @Test fun subSeventyAndSentinelValuesAreExcluded() {
+        val r = AnalyticsEngine.nightlySpo2CandidateMean(
+            listOf(session(1000, 600)),
+            listOf(aux(1100, 94), aux(1150, 3), aux(1200, 0), aux(1250, 0x80), aux(1300, 96)))
+        assertEquals(95, r?.first)
+        assertEquals(2, r?.second)
+    }
+
+    @Test fun daytimeSamplesOutsideTheSessionAreExcluded() {
+        val r = AnalyticsEngine.nightlySpo2CandidateMean(
+            listOf(session(1000, 600)), listOf(aux(500, 99), aux(1100, 94), aux(5000, 88)))
+        assertEquals(1, r?.second)
+        assertEquals(94, r?.first)
+    }
+
+    @Test fun nullWhenNothingInBandFallsInsideASession() {
+        assertNull(AnalyticsEngine.nightlySpo2CandidateMean(listOf(session(1000, 600)), listOf(aux(1100, 5))))
+        assertNull(AnalyticsEngine.nightlySpo2CandidateMean(listOf(session(1000, 600)), listOf(aux(9999, 95))))
+        assertNull(AnalyticsEngine.nightlySpo2CandidateMean(emptyList(), listOf(aux(1100, 95))))
+        assertNull(AnalyticsEngine.nightlySpo2CandidateMean(listOf(session(1000, 600)), emptyList()))
+    }
+
+    /** A record with no @82 at all is not a zero reading. */
+    @Test fun missingBytesAreSkippedNotCountedAsZero() {
+        val r = AnalyticsEngine.nightlySpo2CandidateMean(
+            listOf(session(1000, 600)), listOf(aux(1100, null), aux(1200, 96)))
+        assertEquals(96, r?.first)
+        assertEquals(1, r?.second)
+    }
+
+    /** Boundaries are inclusive, matching the decoder's own 70..100 emit gate exactly. */
+    @Test fun bandBoundariesMatchTheDecoderGate() {
+        assertEquals(2, AnalyticsEngine.nightlySpo2CandidateMean(
+            listOf(session(1000, 600)), listOf(aux(1100, 70), aux(1200, 100)))?.second)
+        assertNull(AnalyticsEngine.nightlySpo2CandidateMean(
+            listOf(session(1000, 600)), listOf(aux(1100, 69), aux(1200, 101))))
+    }
+}


### PR DESCRIPTION
Comes out of #112, where two users are asking why blood oxygen is blank. Diagnostic only — **nothing scores this and it never writes `spo2Pct`**.

## Why

The SpO2 candidate byte (`@82`) is decoded and stored but deliberately never promoted, because two straps disagree about it: on one independent 8-night check it tracked the WHOOP app almost exactly — following a dip to 92 % and a high of 98 % — while on the two nights from the strap it was found on it moved the **opposite** way. Until a third device breaks that tie it stays instrumentation, guarded by `testHistoricalV18OpticalFieldsAreNotNamedPhysiologically`.

Nothing was blocking that tie-break except **how hard the candidate is to read**. Today the only way to see it is to scroll the Deep Timeline chart and eyeball it. That is a poor instrument to hand a volunteer, and it produces a figure nobody else can check — so the ask on #112 currently amounts to *"note the rough nightly level"*, which is not evidence.

This turns the comparison into **one number against one number**: this mean, and the figure the WHOOP app reports for the same night.

## What it does

`nightlySpo2CandidateMean(sessions:aux:)` — the gated mean over detected in-bed sessions, paired with the sample count it rests on. Mirrors the existing `nightlySpo2RawMeans` (the WHOOP 4.0 raw-ADC twin) in shape and placement.

Two decisions worth stating:

**Gated to `70...100`, the SAME window the decoder applies** when it emits `spo2_candidate_82`. Sub-70 nonzero values are diagnostic codes and bit-7 values are saturation sentinels — averaging those in would produce a number that is not a percentage of anything, and it is the most damaging thing this helper could do, because the result would still look plausible. Pinned in both directions, boundaries included.

**The sample count travels with the mean.** A mean over 3 readings and a mean over 3000 are not the same evidence, and a volunteer's correlation built on the first would be worthless.

## Scope

- **Does nothing for a WHOOP 4.0.** Those records carry raw red/IR ADC (`spo2_red@68`/`spo2_ir@70`, v24/v25) and no candidate at all — a 4.0 needs the pulsatile component of both channels, which the strap never transmits. That half of #112 is not unblockable by data.
- No UI yet. This is the computation, tested; where it surfaces is a separate call.

## Verification

- **8 tests per platform, byte-parity twins** — same fixtures, same expectations. Cover the mean, the count, code/sentinel exclusion, daytime exclusion, missing bytes not counting as zero, and the inclusive band boundaries.
- All 8 also **executed locally against the shipped function body**, extracted from source so the probe cannot drift.
- Kotlin compiles with no new errors; `swiftc -parse` clean; `i18n_audit --ci` 0.
- `doc_comment_lint` caught a real mistake mid-change: inserting before the anchor put the new function **between the existing `nightlySpo2RawMeans` KDoc and its function**, orphaning that doc. Moved below instead — second commit. Lint green.