### PR TITLE
Bump to 9.2.2 (versionCode 305) so a testing build can install over 9.2.2/304

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -26,8 +26,8 @@ android {
         applicationId = "com.noop.whoop"
         minSdk = 26
         targetSdk = 34
-        versionCode = 303
-        versionName = "9.2.1"
+        versionCode = 305
+        versionName = "9.2.2"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {

--- a/project.yml
+++ b/project.yml
@@ -17,7 +17,7 @@ configFiles:
   Release: Config/BundleId.xcconfig
 settings:
   base:
-    MARKETING_VERSION: "9.2.1"
+    MARKETING_VERSION: "9.2.2"
     # iOS build number (CFBundleVersion). GLOBAL so the iOS app AND its widget extension inherit the
     # SAME value — they must match or iOS warns "extension version must match parent app" (#416).
     # macOS sets its own CFBundleVersion on the Strand target and is unaffected by this.


### PR DESCRIPTION
Version bump only, no code.

## Why now

The testing build cut from `main` an hour ago compiled green on all three platforms — but would not install on a phone carrying the 29 July staging build:

| | versionName | versionCode |
|---|---|---|
| installed (29 Jul staging) | 9.2.2 | 304 |
| testing build from main | 9.2.1 | **303** |

Android refuses a lower `versionCode` over a higher one and reports it as *"App not installed"*, which names neither the cause nor the file. `main` has sat on 9.2.1 for **42 commits**; the bump was simply overdue and this is what made it visible.

`versionCode` goes to **305**, not 304, because 304 is already published on the rolling `testing-latest` tag — reusing it would leave two different builds sharing a code.

`MARKETING_VERSION` and `versionName` move together, per `CLAUDE.md`.

## Not in this PR

**Release notes.** 9.2.2 still owes users the visible changes from those 42 commits, and they are not cosmetic:

- **Effort shifts twice** — #963 (per-sample HR gap weighting) and #992 (saved workouts now use measured resting HR). Both can move a number in *either* direction, and #963 applies retroactively on recompute.
- **A new Apple Health permission prompt** — existing iOS users will be asked for Water and Caffeine on their next foreground sync (#974/#985).
- **Oura resting-HR heal** — #375 fixes days where a nap fragment beat the real night, producing 90+ bpm resting-HR spikes. Affected users must **re-sync** to heal already-imported days, and will not know to unless the notes say so.
- **Sleep staging changes** — #987 forbids wake → deep/REM. Stored hypnograms are untouched, so timelines mix recipes across the change.

That is a notes-writing job rather than a bump, so it is deliberately separate.