### PR TITLE
SourceBadge: centre the label in the pill on both axes

### DIFF
--- a/Packages/StrandDesign/Sources/StrandDesign/Components.swift
+++ b/Packages/StrandDesign/Sources/StrandDesign/Components.swift
@@ -471,7 +471,12 @@ public struct SourceBadge: View {
     let text: LocalizedStringKey; var tint: Color = StrandPalette.accent
     public init(_ text: LocalizedStringKey, tint: Color = StrandPalette.accent) { self.text = text; self.tint = tint }
     public var body: some View {
+        // `.tracking` adds its gap after EVERY character including the last, so the laid-out text is half a
+        // point wider than the ink. Nudging right by half re-centres the glyphs inside the capsule. The
+        // vertical axis needs nothing here — `.frame(height:)` centres by default, which is exactly the
+        // difference that left the Android twin's label riding high until it was matched to this.
         Text(text).textCase(.uppercase).font(.system(size: 10, weight: .semibold, design: .rounded)).tracking(0.5)
+            .offset(x: 0.25)
             .padding(.horizontal, 9).frame(height: NoopMetrics.sourceBadgeHeight)
             .background(tint.opacity(0.16), in: Capsule(style: .continuous))
             .foregroundStyle(tint)

--- a/Packages/StrandDesign/Sources/StrandDesign/Components.swift
+++ b/Packages/StrandDesign/Sources/StrandDesign/Components.swift
@@ -471,12 +471,10 @@ public struct SourceBadge: View {
     let text: LocalizedStringKey; var tint: Color = StrandPalette.accent
     public init(_ text: LocalizedStringKey, tint: Color = StrandPalette.accent) { self.text = text; self.tint = tint }
     public var body: some View {
-        // `.tracking` adds its gap after EVERY character including the last, so the laid-out text is half a
-        // point wider than the ink. Nudging right by half re-centres the glyphs inside the capsule. The
-        // vertical axis needs nothing here — `.frame(height:)` centres by default, which is exactly the
-        // difference that left the Android twin's label riding high until it was matched to this.
+        // `.frame(height:)` centres its content by default, so the label sits mid-capsule for free. Noted
+        // because the Android twin pinned the same 18 with `heightIn` applied to the label itself, which
+        // top-aligns — same number, different render. That one is matched to this, not the reverse.
         Text(text).textCase(.uppercase).font(.system(size: 10, weight: .semibold, design: .rounded)).tracking(0.5)
-            .offset(x: 0.25)
             .padding(.horizontal, 9).frame(height: NoopMetrics.sourceBadgeHeight)
             .background(tint.opacity(0.16), in: Capsule(style: .continuous))
             .foregroundStyle(tint)

--- a/android/app/src/main/java/com/noop/ui/Components.kt
+++ b/android/app/src/main/java/com/noop/ui/Components.kt
@@ -403,11 +403,6 @@ fun StatePill(
 @Composable
 fun SourceBadge(text: String, tint: Color = Palette.accent, modifier: Modifier = Modifier) {
     val shape = RoundedCornerShape(50)
-    val tracking = 0.5.sp
-    // Half the tracking, in dp. `letterSpacing` adds its gap after EVERY character including the last, so
-    // the measured text is that much wider than the glyphs actually drawn — centring the text node leaves
-    // the glyphs sitting left of true centre by half. Shifting back by half puts the ink in the middle.
-    val trackingNudge = with(LocalDensity.current) { tracking.toDp() } / 2
     Box(
         // The pill itself. The label used to BE this node, with `heightIn` pinning it to 18.dp — and a
         // 10.sp line box is ~13.dp, so the ~5.dp of slack all fell below the text and pushed it upward.
@@ -426,11 +421,10 @@ fun SourceBadge(text: String, tint: Color = Palette.accent, modifier: Modifier =
     ) {
         Text(
             text = text.uppercase(),
-            style = NoopType.overline.copy(fontSize = 10.sp, letterSpacing = tracking),
+            style = NoopType.overline.copy(fontSize = 10.sp, letterSpacing = 0.5.sp),
             color = tint,
             maxLines = 1,                      // #74: e.g. "ON-DEVICE" stays on one line, never wraps the hero
             overflow = TextOverflow.Ellipsis,
-            modifier = Modifier.offset(x = trackingNudge),
         )
     }
 }

--- a/android/app/src/main/java/com/noop/ui/Components.kt
+++ b/android/app/src/main/java/com/noop/ui/Components.kt
@@ -403,12 +403,17 @@ fun StatePill(
 @Composable
 fun SourceBadge(text: String, tint: Color = Palette.accent, modifier: Modifier = Modifier) {
     val shape = RoundedCornerShape(50)
-    Text(
-        text = text.uppercase(),
-        style = NoopType.overline.copy(fontSize = 10.sp, letterSpacing = 0.5.sp),
-        color = tint,
-        maxLines = 1,                          // #74: e.g. "ON-DEVICE" stays on one line, never wraps the hero
-        overflow = TextOverflow.Ellipsis,
+    val tracking = 0.5.sp
+    // Half the tracking, in dp. `letterSpacing` adds its gap after EVERY character including the last, so
+    // the measured text is that much wider than the glyphs actually drawn — centring the text node leaves
+    // the glyphs sitting left of true centre by half. Shifting back by half puts the ink in the middle.
+    val trackingNudge = with(LocalDensity.current) { tracking.toDp() } / 2
+    Box(
+        // The pill itself. The label used to BE this node, with `heightIn` pinning it to 18.dp — and a
+        // 10.sp line box is ~13.dp, so the ~5.dp of slack all fell below the text and pushed it upward.
+        // SwiftUI's twin uses `.frame(height:)`, which centres by default, so the two platforms drew the
+        // same badge differently. A Box that owns the height and centres its content matches iOS and
+        // keeps the label centred at any font scale.
         modifier = modifier
             // Preserve the canonical compact height at the default font scale, but grow instead of clipping
             // when Android's font scaling makes the single-line label taller.
@@ -417,7 +422,17 @@ fun SourceBadge(text: String, tint: Color = Palette.accent, modifier: Modifier =
             .background(tint.copy(alpha = 0.14f))
             .border(1.dp, tint.copy(alpha = 0.30f), shape)
             .padding(horizontal = Metrics.space8),
-    )
+        contentAlignment = Alignment.Center,
+    ) {
+        Text(
+            text = text.uppercase(),
+            style = NoopType.overline.copy(fontSize = 10.sp, letterSpacing = tracking),
+            color = tint,
+            maxLines = 1,                      // #74: e.g. "ON-DEVICE" stays on one line, never wraps the hero
+            overflow = TextOverflow.Ellipsis,
+            modifier = Modifier.offset(x = trackingNudge),
+        )
+    }
 }
 
 // MARK: - TrendChip — a small tinted delta pill with a direction arrow.


### PR DESCRIPTION
Reported from a screenshot: "WHOOP" sits high in its pill on Today, the same on the Sleep tab, and "ON-DEVICE" too.

One component, not several bugs — `SourceBadge` is rendered 20 times across 9 screens (Today, Sleep, Live, Workouts, Intelligence, Rhythm, LabBook, FusedRecord, What's New).

## The bug (Android only)

The label *was* the pill: `heightIn(min = 18.dp)` applied straight to the `Text`. A 10.sp line box is ~13dp, and text lays out from the top of its constraints, so all ~5dp of slack fell below the glyphs and pushed the label up.

The SwiftUI twin pins the same 18 with `.frame(height:)`, **which centres by default**. Both platforms encoded the same number and drew it differently. A `Box` now owns the height and centres its content, so the two implementations agree by construction rather than by coincidence. Growth at large font scale is preserved.

## What was dropped after review

The first revision also nudged the text right by half the tracking on both platforms, on the theory that letter spacing pads only the trailing edge. That holds for SwiftUI `.tracking`, but Android splits letter spacing half before and half after each glyph — the Compose label is already symmetric, and the nudge would have pushed it off centre by the amount it claimed to correct.

Neither behaviour is measurable on the machine this was written on, and at 0.25dp neither is visible. Shipping the unverifiable half into a component used on 9 screens wasn't worth it. Applying one hardcoded nudge to two different text engines would also have repeated the exact bug being fixed here: same number, different render.

Net effect: Android gets the centring fix, iOS gets a comment recording why it needs nothing.

## Scope

`SourceBadge` was the only text component in `Components.kt` with a pinned height and no centring — the other two wrap a card and a row. The `NOOP` wordmark already uses `Row` + `spacedBy(14.dp, Alignment.CenterHorizontally)`, which spaces only *between* characters; that is the correct idiom and needs nothing.

## Verification

- Kotlin: full `src/main/java` compile (356 files) against main — **2516 errors on both, 9 in `Components.kt` on both**. No new errors. (Those are pre-existing missing-dependency cascades from the ad-hoc classpath, not real.)
- The first compile run reported 0 errors; a deliberately injected type error proved the compiler had crashed at startup on a missing `trove4j` and analysed nothing. The numbers above are from the fixed invocation, where the 9 pre-existing `Components.kt` errors confirm the file really is analysed.
- Swift: diff is comment-only; `swiftc -parse` clean.
- `Tools/doc_comment_lint.py` clean. No import changes on either side. All 20 call sites use the default modifier, and nothing in the app uses text baseline alignment, so the `Text`→`Box` swap changes no caller.
- Not rendered here — diagnosed by reading the two implementations against each other. The `heightIn(min:)` vs `.frame(height:)` divergence is unambiguous in the source, but worth an eyeball on the next testing build.
