### PR TITLE
Release 9.3.0: water and caffeine import, honest Effort, and an Oura resting-HR fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,61 @@ approximate; downloads are on the [Releases](https://github.com/NoopApp/noop/rel
 
 ---
 
+## 9.3.0: Water and caffeine import, honest Effort, and an Oura resting-heart-rate fix (all platforms)
+
+A release about the numbers being right, on top of 9.2.1.
+
+**Scores that change**
+
+- **Effort is weighted by each sample's own gap (#963).** Strain weighted every heart-rate sample in a window by the gap in front of the *first* one, so uneven streams — a dropped connection, a sparse patch, a backfilled block — were over- or under-counted. Each sample now carries its own gap, capped at two minutes so a long silence cannot read as sustained effort. Clean days barely move; gappy days can move noticeably, in either direction.
+- **A saved workout is scored against your measured resting heart rate (#983, #950),** not a hardcoded 60 bpm. Below 60, workout Effort rises; above 60, it falls.
+- **Sleep staging forbids wake → deep and wake → REM (#348).** The single part of a larger staging proposal that still improved results once the benchmark was cleaned of contamination; the rest was withdrawn rather than shipped on a flattering number.
+- **Oura history needs a re-import (#375).** The fix below corrects the import, not rows already written.
+
+**New**
+
+- **Water imports from Apple Health and Health Connect (#949, #974, #986).** Imported water is stored in its own row and added to the manual total only for display, so a sync can never overwrite, edit or delete a hand-logged entry, and disconnecting removes only the imported side. The sync reads its window once and writes only the days that actually differ.
+- **Caffeine imports from Apple Health (#949, #985).** Each intake keeps Apple's identity, so re-syncing updates existing entries instead of duplicating them, and imported entries cannot be edited or deleted inside NOOP. Health Connect has no caffeine-only scope — caffeine is a field behind the whole nutrition permission — so this is iPhone-only.
+- **iPhone asks for the two new read permissions once (#974).** HealthKit never reports read authorisation, and permission is only ever presented for types not yet determined, so an existing install would otherwise have silently imported nothing. NOOP now records the set of types it has asked for and re-asks when that set grows, in the foreground only.
+- **The R22 deep-data unlock is reversible (#174, #932).** A matching disable sequence with a mandatory read-back, so the strap confirms its actual state rather than NOOP assuming the write landed.
+
+**Fixed**
+
+- **An Oura nap could claim the whole day (#375).** The daily rollup took whichever session the API listed first, and Oura returns naps and fragments alongside the real night with no ordering guarantee. Across a real 24-month dataset this put a 32-minute wake-dominated fragment's 92 bpm on a day whose actual night was 277 minutes at 57 bpm, and left 36 days reading as under 25 minutes of sleep. The main session is now selected explicitly.
+- **The Updates page could not scroll and its release row did nothing (#984, #989).** Every release since the inbox shipped posted a "tap to read what's new" row with no link, so tapping only marked it read — moving it into "Earlier" on a page that could not scroll, which looked like deletion. Rows already in the inbox open too.
+- **A working WHOOP 4.0 battery read logged as a failure (#900, #923).**
+- **Raw sensor export read a legacy identifier instead of the active strap (#175, #924).**
+- **Haptics offered buzz patterns the 5/MG cannot produce (#926, #973).**
+- **Blood oxygen stayed silent when the strap had in fact recorded (#938).**
+- **A live heart-rate subscription leaked (#933).**
+- **Today's editing sheets were inconsistent (#929, #940)** — now one sheet.
+- **A provenance badge label sat high in its pill on Android (#936, #999).** The label was pinned to the pill's height directly, so the slack fell below the text rather than around it; the SwiftUI twin encoded the same height and centred it. Affected every badge across nine screens.
+- **31 French translations corrected from a native-speaker review (#884, #919),** with an Android sweep for the same error classes including agreement (#921).
+- **The Android device-actions menu was untranslated (#946).**
+- **The in-app What's New title now ships translated on Android (#878, #916, #951).** The generator emitted a raw Kotlin literal, which failed the translation gate on every release — and because that gate audits the whole tree, it red-checked every open pull request on a line none of them touched.
+
+**Privacy**
+
+- **Scheduled debug exports have a retention policy on both platforms (#642, #650, #960),** including the iOS ones visible in Files.
+- **`.noopbak` backups warn that they are readable and unencrypted (#644, #962).**
+
+**Diagnostics**
+
+- **A nightly mean and sample count for the 5/MG blood-oxygen candidate (#112, #995),** so the v18 candidate byte can be checked rather than trusted. Still instrumentation, not a shipped metric.
+- **A history offload counts the packet types it drops (#891, #927)** instead of discarding them silently.
+- **Raw Oura history-notification capture to a file (#937).**
+- **The blood-oxygen promote gate can read a NOOP store (#845, #103, #942),** so the diagnostic can answer its own question.
+- **Three probes stopped overstating what they knew (#690, #761, #103, #913, #914, #918).** A body-location probe's detail line contradicted its own verdict; a feature-flag probe reported silence, and one verb's refusal, as a verdict about firmware; and an unread key list was described as a strap named "none".
+
+**Infrastructure**
+
+- **Sleep staging became measurable (#925, #935, #991).** `SleepBench` now reports stage-fraction calibration and first-REM latency rather than kappa alone, `Tools/SleepPSG` scores the shipped stager against PSG truth reproducibly, and the docs were corrected to say which stager ships — V2, not V1. This tooling is what cut #348 down to one transition rule instead of landing it whole.
+- **The REM-latency guard is measured in minutes since onset (#930, #934),** not as a fraction of the session.
+- **Tool tests that nothing was running are now run (#943),** and a capture check no longer reads its own output as evidence (#971).
+- **Documentation corrections.** The circadian model's input is heart rate, not motion (#982, #993); the raw outbox's first policy is dormant by design, and why it is kept is now written down (#981, #994); the protocol's command-response body is documented (#894, #891, #915); and issue references point at this repository rather than one that no longer exists (#939).
+
+---
+
 ## 9.1.0: Workout backfill, strap model fix, supply chain hardening, and Oura improvements (all platforms)
 
 A reliability-and-accuracy release on top of 9.0.2.

--- a/Strand/System/AppChangelog.swift
+++ b/Strand/System/AppChangelog.swift
@@ -7,7 +7,7 @@ enum AppChangelog {
 
     /// Bump this when you add a release below. The "What's New" sheet shows automatically when the
     /// stored last-seen version is behind this. (Decoupled from the bundle version on purpose.)
-    static let currentVersion = "9.2.1"
+    static let currentVersion = "9.3.0"
 
     struct Release: Identifiable {
         let version: String
@@ -19,6 +19,18 @@ enum AppChangelog {
 
     /// Newest first.
     static let releases: [Release] = [
+        Release(
+            version: "9.3.0",
+            title: "Water and caffeine from Apple Health, a sharper Effort score, and an Oura resting-heart-rate fix",
+            date: "July 2026",
+            items: [
+                "**Water and caffeine import themselves (#949).** Log a drink in Apple Health or Health Connect and it shows up in NOOP, kept in its own row so it can never overwrite what you typed by hand. iPhone will ask permission once for the two new data types.",
+                "**Effort is measured more honestly (#963, #983).** Every heart-rate sample is now weighted by its own gap rather than the window's first one, and a saved workout is scored against your measured resting heart rate instead of a hardcoded 60. Your Effort numbers will move — in either direction — including for past days.",
+                "**Oura days no longer spike to 90+ resting heart rate (#375).** A nap or a short fragment could outrank the real night and claim the whole day's numbers. Re-import your Oura history to correct days already stored.",
+                "**Sleep staging can't jump from awake to deep (#348).** A transition no scorer should ever emit is now forbidden outright, which is the part of a larger staging change that survived a clean benchmark.",
+                "**The Updates page scrolls, and its release row opens (#984).** Older entries were unreachable and tapping \"what's new\" did nothing but mark it read, so it looked like the entry had been deleted.",
+            ]
+        ),
         Release(
             version: "9.2.1",
             title: "Battery saver quiets the gauges, translated Android notifications, and instant chart loads",

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -26,8 +26,8 @@ android {
         applicationId = "com.noop.whoop"
         minSdk = 26
         targetSdk = 34
-        versionCode = 305
-        versionName = "9.2.2"
+        versionCode = 306
+        versionName = "9.3.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {

--- a/android/app/src/main/java/com/noop/ui/AppChangelog.kt
+++ b/android/app/src/main/java/com/noop/ui/AppChangelog.kt
@@ -26,7 +26,7 @@ object AppChangelog {
      * Bump this when you add a release below. The "What's New" sheet shows automatically when the
      * stored last-seen version is behind this. (Decoupled from the bundle version on purpose.)
      */
-    const val CURRENT_VERSION = "9.2.1"
+    const val CURRENT_VERSION = "9.3.0"
 
     data class Release(
         val version: String,
@@ -37,6 +37,18 @@ object AppChangelog {
 
     /** Newest first. */
     val releases: List<Release> = listOf(
+        Release(
+            version = "9.3.0",
+            title = uiString(R.string.l10n_app_changelog_water_and_caffeine_from_apple_health_5123b6b0),
+            date = "July 2026",
+            items = listOf(
+                "**Water and caffeine import themselves (#949).** Log a drink in Apple Health or Health Connect and it shows up in NOOP, kept in its own row so it can never overwrite what you typed by hand. iPhone will ask permission once for the two new data types.",
+                "**Effort is measured more honestly (#963, #983).** Every heart-rate sample is now weighted by its own gap rather than the window's first one, and a saved workout is scored against your measured resting heart rate instead of a hardcoded 60. Your Effort numbers will move — in either direction — including for past days.",
+                "**Oura days no longer spike to 90+ resting heart rate (#375).** A nap or a short fragment could outrank the real night and claim the whole day's numbers. Re-import your Oura history to correct days already stored.",
+                "**Sleep staging can't jump from awake to deep (#348).** A transition no scorer should ever emit is now forbidden outright, which is the part of a larger staging change that survived a clean benchmark.",
+                "**The Updates page scrolls, and its release row opens (#984).** Older entries were unreachable and tapping \"what's new\" did nothing but mark it read, so it looked like the entry had been deleted.",
+            ),
+        ),
         Release(
             version = "9.2.1",
             title = uiString(R.string.l10n_app_changelog_battery_saver_quiets_the_gauges_translated_bdbe8650),

--- a/android/app/src/main/res/values-de/strings.xml
+++ b/android/app/src/main/res/values-de/strings.xml
@@ -1812,4 +1812,5 @@
     <string name="l10n_settings_screen_r22_accepted_all">✓ Band hat alle %1$d R22-Flags akzeptiert</string>
     <string name="l10n_settings_screen_r22_accepted_partial">Band hat %1$d/%2$d R22-Flags akzeptiert…</string>
     <string name="l10n_notifications_settings_screen_every_pattern_buzzes_the_same_on_34e873f6">Auf einer WHOOP 5/MG vibriert jedes Muster gleich — die Wiederholungszahl wird an dieses Band nicht gesendet. Deine Auswahl wird gespeichert und gilt für eine WHOOP 4.0.</string>
+    <string name="l10n_app_changelog_water_and_caffeine_from_apple_health_5123b6b0">Wasser und Koffein aus Apple Health, ein genaueres Effort-Ergebnis und ein Oura-Ruhepuls-Fix</string>
 </resources>

--- a/android/app/src/main/res/values-es/strings.xml
+++ b/android/app/src/main/res/values-es/strings.xml
@@ -1797,4 +1797,5 @@
     <string name="l10n_settings_screen_r22_accepted_all">✓ La pulsera aceptó las %1$d marcas R22</string>
     <string name="l10n_settings_screen_r22_accepted_partial">La pulsera aceptó %1$d/%2$d marcas R22…</string>
     <string name="l10n_notifications_settings_screen_every_pattern_buzzes_the_same_on_34e873f6">En una WHOOP 5/MG todos los patrones vibran igual: el número de repeticiones no se envía a esa correa. Tu elección se guarda y se aplica a una WHOOP 4.0.</string>
+    <string name="l10n_app_changelog_water_and_caffeine_from_apple_health_5123b6b0">Agua y cafeína desde Apple Health, una puntuación de Effort más precisa y una corrección del pulso en reposo de Oura</string>
 </resources>

--- a/android/app/src/main/res/values-fr/strings.xml
+++ b/android/app/src/main/res/values-fr/strings.xml
@@ -1797,4 +1797,5 @@
     <string name="l10n_settings_screen_r22_accepted_all">✓ Le bracelet a accepté les %1$d indicateurs R22</string>
     <string name="l10n_settings_screen_r22_accepted_partial">Le bracelet a accepté %1$d/%2$d indicateurs R22…</string>
     <string name="l10n_notifications_settings_screen_every_pattern_buzzes_the_same_on_34e873f6">Sur un WHOOP 5/MG, tous les motifs vibrent de la même façon — le nombre de répétitions n\'est pas envoyé à ce bracelet. Votre choix est enregistré et s\'applique à un WHOOP 4.0.</string>
+    <string name="l10n_app_changelog_water_and_caffeine_from_apple_health_5123b6b0">L\'eau et la caféine depuis Apple Santé, un score Effort plus précis et un correctif de la FC au repos Oura</string>
 </resources>

--- a/android/app/src/main/res/values-pt-rPT/strings.xml
+++ b/android/app/src/main/res/values-pt-rPT/strings.xml
@@ -1791,4 +1791,5 @@
     <string name="l10n_settings_screen_r22_accepted_all">✓ A pulseira aceitou as %1$d marcas R22</string>
     <string name="l10n_settings_screen_r22_accepted_partial">A pulseira aceitou %1$d/%2$d marcas R22…</string>
     <string name="l10n_notifications_settings_screen_every_pattern_buzzes_the_same_on_34e873f6">Numa WHOOP 5/MG todos os padrões vibram igual — a contagem de repetições não é enviada para essa bracelete. A tua escolha fica guardada e aplica-se a uma WHOOP 4.0.</string>
+    <string name="l10n_app_changelog_water_and_caffeine_from_apple_health_5123b6b0">Água e cafeína a partir do Apple Health, uma pontuação de Effort mais precisa e uma correção da FC em repouso do Oura</string>
 </resources>

--- a/android/app/src/main/res/values-zh/strings.xml
+++ b/android/app/src/main/res/values-zh/strings.xml
@@ -1725,4 +1725,5 @@
     <string name="l10n_settings_screen_r22disable_confirm_action">清除手环上的标记</string>
     <string name="l10n_settings_screen_r22disable_confirm_cancel">仅停止发送</string>
     <string name="l10n_notifications_settings_screen_every_pattern_buzzes_the_same_on_34e873f6">在 WHOOP 5/MG 上所有模式的震动都相同——重复次数不会发送到该手环。你的选择会被保存，并在 WHOOP 4.0 上生效。</string>
+    <string name="l10n_app_changelog_water_and_caffeine_from_apple_health_5123b6b0">从 Apple 健康导入饮水与咖啡因、更精确的 Effort 分数，以及 Oura 静息心率修复</string>
 </resources>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -1823,4 +1823,5 @@
     <string name="l10n_settings_screen_r22_accepted_all">✓ Strap accepted all %1$d R22 flags</string>
     <string name="l10n_settings_screen_r22_accepted_partial">Strap accepted %1$d/%2$d R22 flags…</string>
     <string name="l10n_notifications_settings_screen_every_pattern_buzzes_the_same_on_34e873f6">Every pattern buzzes the same on a WHOOP 5/MG — the repeat count isn\'t sent to that strap. Your choice is saved and applies to a WHOOP 4.0.</string>
+    <string name="l10n_app_changelog_water_and_caffeine_from_apple_health_5123b6b0">Water and caffeine from Apple Health, a sharper Effort score, and an Oura resting-heart-rate fix</string>
 </resources>

--- a/docs/releases/v9.3.0.md
+++ b/docs/releases/v9.3.0.md
@@ -1,0 +1,158 @@
+---
+whatsnew:
+  title: "Water and caffeine from Apple Health, a sharper Effort score, and an Oura resting-heart-rate fix"
+  date: "July 2026"
+  items:
+    - "**Water and caffeine import themselves (#949).** Log a drink in Apple Health or Health Connect and it shows up in NOOP, kept in its own row so it can never overwrite what you typed by hand. iPhone will ask permission once for the two new data types."
+    - "**Effort is measured more honestly (#963, #983).** Every heart-rate sample is now weighted by its own gap rather than the window's first one, and a saved workout is scored against your measured resting heart rate instead of a hardcoded 60. Your Effort numbers will move — in either direction — including for past days."
+    - "**Oura days no longer spike to 90+ resting heart rate (#375).** A nap or a short fragment could outrank the real night and claim the whole day's numbers. Re-import your Oura history to correct days already stored."
+    - "**Sleep staging can't jump from awake to deep (#348).** A transition no scorer should ever emit is now forbidden outright, which is the part of a larger staging change that survived a clean benchmark."
+    - "**The Updates page scrolls, and its release row opens (#984).** Older entries were unreachable and tapping \"what's new\" did nothing but mark it read, so it looked like the entry had been deleted."
+  title_locales:
+    de: "Wasser und Koffein aus Apple Health, ein genaueres Effort-Ergebnis und ein Oura-Ruhepuls-Fix"
+    es: "Agua y cafeína desde Apple Health, una puntuación de Effort más precisa y una corrección del pulso en reposo de Oura"
+    fr: "L'eau et la caféine depuis Apple Santé, un score Effort plus précis et un correctif de la FC au repos Oura"
+    pt-PT: "Água e cafeína a partir do Apple Health, uma pontuação de Effort mais precisa e uma correção da FC em repouso do Oura"
+    zh: "从 Apple 健康导入饮水与咖啡因、更精确的 Effort 分数，以及 Oura 静息心率修复"
+---
+# NOOP v9.3.0
+
+A release about the numbers being right. Water and caffeine now arrive from Apple Health and Health
+Connect on their own, Effort is computed from what was actually measured rather than from two
+convenient assumptions, and an Oura import bug that could put a 90+ bpm resting heart rate on a normal
+day is fixed. Several scores will move as a result — the "Scores that change" section below says
+exactly which, and why. Everything still runs on your own device, offline, no account.
+
+## Scores that change
+
+Read this section before wondering why a number moved. Three changes alter values you have already
+seen, and one needs an action from you.
+
+- **Effort, from gap-weighted heart-rate samples (#963).** Strain weighted every sample in a window by
+  the gap in front of the *first* one. On a stream with uneven spacing — a dropped connection, a
+  sparse patch, a backfilled block — that over- or under-counted whole stretches of a day. Each sample
+  now carries its own gap, capped at two minutes so a long silence cannot be counted as sustained
+  effort. Days with clean, evenly spaced data barely move; days with gaps can move noticeably, in
+  either direction.
+- **Effort, from your real resting heart rate (#983, #950).** A saved workout was scored against a
+  hardcoded resting heart rate of 60 bpm. It is now scored against the resting heart rate measured for
+  that day, read at the moment the workout is saved. If your resting rate is well below 60 your
+  workout Effort will rise; above 60 it will fall.
+- **Sleep staging forbids wake → deep and wake → REM (#348).** A sleep scorer should never step
+  straight from awake into deep or REM sleep. That transition is now blocked outright. It is the one
+  piece of a larger staging proposal that still improved results once the benchmark it was measured on
+  was cleaned of contamination — the rest was withdrawn rather than shipped on a flattering number.
+- **Oura history needs a re-import (#375).** The fix below corrects the import, not the rows already
+  written. Re-import your Oura export to clean up days that are already stored.
+
+## New
+
+- **Water imports from Apple Health and Health Connect (#949).** Hydration logged anywhere on your
+  phone flows into NOOP. Imported water is stored in its own row and added to your manual total for
+  display, so a sync can never overwrite, edit or delete something you typed in yourself — and
+  removing the connection removes only the imported side. On Android this rides the existing
+  permission; Health Connect has no caffeine-only scope, so caffeine import is iPhone-only for now.
+- **Caffeine imports from Apple Health (#949).** Each intake keeps the identity Apple gave it, so
+  re-syncing updates the entries you already have instead of duplicating them, and an imported entry
+  cannot be edited or deleted inside NOOP — it belongs to Health.
+- **iPhone will ask for permission once.** The two new data types need read access that an existing
+  install has never been asked for. NOOP requests it the next time you open the app with a Health
+  connection already set up. If you decline, nothing else changes.
+- **The R22 deep-data unlock is reversible (#174).** The unlock now has a matching disable sequence
+  with a mandatory read-back, so the strap confirms the state it is actually in rather than NOOP
+  assuming the write landed.
+
+## Fixed
+
+- **An Oura nap could claim the whole day (#375).** The daily rollup took whichever sleep session the
+  API happened to list first, and Oura returns naps and short fragments alongside the real night with
+  no ordering guarantee. Across a real 24-month dataset this put a 32-minute wake-dominated fragment's
+  92 bpm on a day whose actual night was 277 minutes at 57 bpm, and produced 36 days whose total sleep
+  read as under 25 minutes. The day's main session is now selected explicitly.
+- **The Updates page could not scroll, and its release row did nothing (#984).** Every release since
+  the inbox shipped posted a "tap to read what's new" row carrying no link, so tapping it only marked
+  it read — which moved it down into "Earlier" on a page that could not scroll, and looked exactly
+  like the entry had been deleted. Rows already sitting in your inbox open too.
+- **A working WHOOP 4.0 battery read was logged as a failure (#900).**
+- **Raw sensor export read the wrong strap (#175).** It used a legacy identifier rather than the strap
+  you actually have active.
+- **Haptics claimed buzz patterns the 5/MG cannot produce (#926).** The app now only offers what the
+  strap on your wrist can actually do.
+- **Blood oxygen said nothing when the strap had in fact recorded (#938).**
+- **A live heart-rate subscription leaked (#933).** Repeatedly opening and leaving the live view left
+  listeners attached.
+- **Today's editing sheets behaved inconsistently (#929).** They are now one sheet.
+- **A badge label sat high in its pill on Android (#936).** The label was pinned to the pill's height
+  directly, so the slack fell below the text instead of around it. Affected every provenance badge on
+  Today, Sleep, Live, Workouts and five other screens.
+- **31 French translations corrected from a native-speaker review (#884),** with a follow-up sweep of
+  the Android side for the same error classes, including agreement.
+- **The Android device-actions menu was untranslated (#946).**
+- **The in-app "What's New" title now ships translated on Android (#878).** Its release-note generator
+  emitted a raw literal, which failed the translation gate on every release — and because that gate
+  audits the whole tree, it red-checked every open pull request on a line none of them touched.
+
+## Privacy
+
+- **Scheduled debug exports are cleaned up (#642, #650).** They now have a retention policy on both
+  platforms rather than accumulating indefinitely, including the iOS ones visible in Files.
+- **`.noopbak` backups say what they are (#644).** The archive is readable and unencrypted; the app
+  now warns you rather than leaving that to be discovered.
+
+## Diagnostics
+
+- **A nightly mean for the 5/MG blood-oxygen candidate (#112).** The v18 candidate byte now reports a
+  per-night mean and sample count, so it can be checked against something rather than trusted. It
+  remains instrumentation, not a shipped metric.
+- **A history offload counts what it drops (#891).** Packet types the offload cannot use are counted
+  and reported instead of discarded silently.
+- **Raw Oura history-notification capture (#937).** Undecoded notifications can be captured to a file
+  for protocol work.
+- **The blood-oxygen promote gate can read a NOOP store (#845, #103),** so the diagnostic can answer
+  its own question rather than requiring a separate tool.
+- **Two probes stopped overstating what they knew (#690, #761, #103).** A body-location probe's detail
+  line contradicted its own verdict; a feature-flag probe reported silence, and one verb's refusal, as
+  a verdict about the firmware; and an unread key list was described as a strap named "none".
+
+## Under the hood
+
+- **Sleep staging is now measurable (#925, #935, #991).** `SleepBench` reports stage-fraction
+  calibration and first-REM latency rather than kappa alone, `Tools/SleepPSG` scores the shipped
+  stager against PSG truth reproducibly, and the documentation was corrected to say which stager
+  actually ships — V2, not V1. This tooling is what allowed #348 to be cut down to the single
+  transition rule above instead of landing whole.
+- **The REM-latency guard is measured in minutes since sleep onset (#930)** rather than as a fraction
+  of the session.
+- **Tool tests that nothing was running are now run (#943),** and a capture check no longer reads its
+  own output as evidence (#971).
+- **Imported water is written only where it changed (#949).** The sync reads the window once and
+  updates only the days that actually differ.
+- **Documentation corrections.** The circadian model's input is heart rate, not motion (#982); the raw
+  outbox's first policy is dormant by design and the reason it is kept is now written down (#981); the
+  protocol's command-response body is documented (#894, #891); and issue references point at this
+  repository rather than one that no longer exists.
+
+## Thanks
+
+Thanks to **@vishk23** for the largest share of this release: the Oura main-session fix behind the
+resting-heart-rate spike, the sleep-staging benchmark work (`SleepBench`, `SleepPSG`, and the honest
+result that cut #348 down to one rule), the reversible R22 unlock, the live heart-rate subscription
+leak, the REM-latency guard, and the probes that stopped overstating what they knew.
+
+Thanks to **@tigercraft4** for both privacy items — debug-export retention and the `.noopbak`
+warning — reported and fixed.
+
+Thanks to **@pipiche38** for the raw Oura capture diagnostic, and for #878, the release-note
+translation gate that had been red-checking every open pull request.
+
+Thanks to **@NoBrainNoHeadache** for the hydration feature request that became water and caffeine
+import, and for the French translation review behind 31 corrections.
+
+Thanks to **@bartmuskala** for three reports that all landed: the impossible-looking Effort day, the
+Updates page, and the badge that said the wrong thing.
+
+Thanks to **@longhoang2810** for the Android device-actions localisation, and to **@Malik-HBS** for
+the connection and sync report.
+
+And thanks to everyone who filed the reports behind these fixes — a good report with a strap log is
+often the harder half.

--- a/project.yml
+++ b/project.yml
@@ -17,7 +17,7 @@ configFiles:
   Release: Config/BundleId.xcconfig
 settings:
   base:
-    MARKETING_VERSION: "9.2.2"
+    MARKETING_VERSION: "9.3.0"
     # iOS build number (CFBundleVersion). GLOBAL so the iOS app AND its widget extension inherit the
     # SAME value — they must match or iOS warns "extension version must match parent app" (#416).
     # macOS sets its own CFBundleVersion on the Strand target and is unaffected by this.


### PR DESCRIPTION
Release notes for 9.3.0, covering everything merged since `v9.2.1` (43 PRs), plus the in-app What's New entry and the version bumps.

## What's here

- **`docs/releases/v9.3.0.md`** — the release notes, with the `whatsnew` front-matter the generator reads. Title translations are supplied for all five locales, so the generator has no English fallback to warn about.
- **`AppChangelog.kt` / `AppChangelog.swift` + six `strings.xml`** — generated by `Tools/appchangelog-gen.py`, not hand-written, so both platforms carry byte-identical items and Android gets a localised title rather than a raw literal.
- **`CHANGELOG.md`** — a 9.3.0 section in the existing house format.
- **Versions** — `MARKETING_VERSION` 9.2.2 → 9.3.0, `versionName` 9.2.2 → 9.3.0, `versionCode` 305 → 306.

## Why the notes lead with "Scores that change"

Three merges move numbers users have already seen, and one needs an action from them. Burying that under "Fixed" would have people reading a changed Effort score as a new bug:

- **#963** — strain now weights each HR sample by its own gap instead of the window's first. Gappy days move in either direction.
- **#983 / #950** — a saved workout is scored against measured resting HR, not a hardcoded 60. Below 60 Effort rises, above 60 it falls.
- **#348** — sleep staging forbids wake → deep/REM.
- **#375** — corrects the Oura *importer*, not rows already written, so it needs a re-import to take effect. Called out explicitly for that reason.

The iPhone permission prompt from #974 is also flagged, since an existing install will see a Health dialog it has never seen before and that is otherwise alarming.

## Verification

- `Tools/i18n_audit.py --ci origin/main` — **exit 0**. The new title key is present in all six `strings.xml` with real translations, French apostrophe correctly XML-escaped.
- `Tools/doc_comment_lint.py` — clean.
- Kotlin: full `src/main/java` compile. 2517 errors vs main's 2516; the single delta is one more `unresolved reference: R` in `AppChangelog.kt`, which already has 270 of them because `R` isn't generated in an ad-hoc classpath. Exactly +1 for the +1 new `uiString(R.string…)` line, and Gradle generates the field from the `strings.xml` entry above.
- Swift: `swiftc -parse` clean on `AppChangelog.swift`.
- Contributors collected with `Tools/release-contributors.sh v9.2.1` per CLAUDE.md, credited by `@handle`, third-party only.

## Note, not fixed here

`CHANGELOG.md` has no 9.2.0 or 9.2.1 section — its newest entry before this was 9.1.0, so this commit makes the file read 9.1.0 → 9.3.0. Both versions do have `docs/releases/` notes and in-app entries, so only that one file has the gap. Backfilling it is a separate change and not mixed into a release commit.
