### PR TITLE
Health Connect: key each record by the offset it was recorded in (#1002)

### DIFF
--- a/android/app/src/main/java/com/noop/ingest/HealthConnectImporter.kt
+++ b/android/app/src/main/java/com/noop/ingest/HealthConnectImporter.kt
@@ -35,6 +35,7 @@ import com.noop.ui.NoopPrefs
 import java.time.Instant
 import java.time.LocalDate
 import java.time.ZoneId
+import java.time.ZoneOffset
 import kotlin.math.round
 import kotlin.reflect.KClass
 
@@ -220,7 +221,9 @@ object HealthConnectImporter {
 
         // Per-day accumulators. Keyed by "YYYY-MM-DD" (local).
         val acc = HashMap<String, DayAcc>()
-        fun dayOf(instant: Instant): String = LocalDate.ofInstant(instant, zone).toString()
+        // #1002: key each record by the offset it was RECORDED in. See [localDayKey] for why the
+        // phone's zone is still the right fallback, and for what this does and does not fix.
+        fun dayOf(instant: Instant, offset: ZoneOffset?): String = localDayKey(instant, offset, zone)
         fun bucket(day: String): DayAcc = acc.getOrPut(day) { DayAcc() }
 
         // #949: imported water, ml per local day. Separate from `acc` because it is written to the
@@ -232,6 +235,11 @@ object HealthConnectImporter {
         var hydrationReadOk = false
 
         val workouts = ArrayList<WorkoutRow>()
+        // #1002: each workout's day key, computed at READ time while the record's own zone offset is
+        // still in hand. WorkoutRow carries only epoch seconds, so re-deriving the key later would
+        // silently fall back to the phone's zone and undo the fix for exactly the travelled sessions
+        // it exists for. Index-parallel to [workouts] — append to both together.
+        val workoutDays = ArrayList<String>()
         // (startEpochS, endEpochS, kcal) of every active-calorie record, so an imported exercise
         // session can be credited with the calories burned inside its window (#117). Garmin/Fit write
         // ActiveCaloriesBurned as interval records; ExerciseSessionRecord itself carries no energy.
@@ -252,14 +260,14 @@ object HealthConnectImporter {
             // dataOrigin package), then take the MAX source per day at write-out, mirroring the de-overlap
             // already shipped on iOS/macOS and the Android XML importer.
             readAll(client, StepsRecord::class, filter, selfPackage) { r ->
-                val b = bucket(dayOf(r.startTime))
+                val b = bucket(dayOf(r.startTime, r.startZoneOffset))
                 val src = r.metadata.dataOrigin.packageName
                 b.stepsBySource[src] = (b.stepsBySource[src] ?: 0L) + r.count
             }
             // --- Total calories burned (basal + active) ---
             // #589: per-SOURCE sums, max-across-sources at write-out (same overlap reasoning as steps).
             readAll(client, TotalCaloriesBurnedRecord::class, filter, selfPackage) { r ->
-                val b = bucket(dayOf(r.startTime))
+                val b = bucket(dayOf(r.startTime, r.startZoneOffset))
                 val src = r.metadata.dataOrigin.packageName
                 b.totalKcalBySource[src] = (b.totalKcalBySource[src] ?: 0.0) + r.energy.inKilocalories
             totalKcalRecords.add(
@@ -271,7 +279,7 @@ object HealthConnectImporter {
             // de-overlaps by source ITSELF (#835 — it used to cross-source SUM, roughly doubling a ride that
             // two apps both logged), so the per-source map here only governs the day total.
             readAll(client, ActiveCaloriesBurnedRecord::class, filter, selfPackage) { r ->
-                val b = bucket(dayOf(r.startTime))
+                val b = bucket(dayOf(r.startTime, r.startZoneOffset))
                 val src = r.metadata.dataOrigin.packageName
                 b.activeKcalBySource[src] = (b.activeKcalBySource[src] ?: 0.0) + r.energy.inKilocalories
                 activeKcalRecords.add(
@@ -280,26 +288,26 @@ object HealthConnectImporter {
             // --- Heart rate (instantaneous samples) -> per-day average ---
             readAll(client, HeartRateRecord::class, filter, selfPackage) { r ->
                 for (s in r.samples) {
-                    val b = bucket(dayOf(s.time))
+                    val b = bucket(dayOf(s.time, r.startZoneOffset))
                     b.hrSum += s.beatsPerMinute
                     b.hrCount += 1
                 }
             }
             // --- Resting heart rate -> per-day average (rounded to Int) ---
             readAll(client, RestingHeartRateRecord::class, filter, selfPackage) { r ->
-                val b = bucket(dayOf(r.time))
+                val b = bucket(dayOf(r.time, r.zoneOffset))
                 b.rhrSum += r.beatsPerMinute
                 b.rhrCount += 1
             }
             // --- HRV (RMSSD, ms) -> per-day average ---
             readAll(client, HeartRateVariabilityRmssdRecord::class, filter, selfPackage) { r ->
-                val b = bucket(dayOf(r.time))
+                val b = bucket(dayOf(r.time, r.zoneOffset))
                 b.hrvSum += r.heartRateVariabilityMillis
                 b.hrvCount += 1
             }
             // --- Sleep sessions -> per-day total sleep minutes, assigned to the WAKE day ---
             readAll(client, SleepSessionRecord::class, filter, selfPackage) { r ->
-                val day = dayOf(r.endTime)
+                val day = dayOf(r.endTime, r.endZoneOffset)
                 val b = bucket(day)
                 // Prefer summed asleep-stage minutes; fall back to session span when no stages.
                 val asleepMin = asleepMinutes(r)
@@ -320,19 +328,19 @@ object HealthConnectImporter {
             }
             // --- SpO2 (%) -> per-day average ---
             readAll(client, OxygenSaturationRecord::class, filter, selfPackage) { r ->
-                val b = bucket(dayOf(r.time))
+                val b = bucket(dayOf(r.time, r.zoneOffset))
                 b.spo2Sum += r.percentage.value
                 b.spo2Count += 1
             }
             // --- Respiratory rate (breaths/min) -> per-day average ---
             readAll(client, RespiratoryRateRecord::class, filter, selfPackage) { r ->
-                val b = bucket(dayOf(r.time))
+                val b = bucket(dayOf(r.time, r.zoneOffset))
                 b.respSum += r.rate
                 b.respCount += 1
             }
             // --- VO2 max (ml/kg/min) -> latest value of the day wins ---
             readAll(client, Vo2MaxRecord::class, filter, selfPackage) { r ->
-                val b = bucket(dayOf(r.time))
+                val b = bucket(dayOf(r.time, r.zoneOffset))
                 if (r.time.epochSecond >= b.vo2maxTs) {
                     b.vo2max = r.vo2MillilitersPerMinuteKilogram
                     b.vo2maxTs = r.time.epochSecond
@@ -340,7 +348,7 @@ object HealthConnectImporter {
             }
             // --- Weight (kg) -> latest value of the day wins ---
             readAll(client, WeightRecord::class, filter, selfPackage) { r ->
-                val b = bucket(dayOf(r.time))
+                val b = bucket(dayOf(r.time, r.zoneOffset))
                 if (r.time.epochSecond >= b.weightTs) {
                     b.weightKg = r.weight.inKilograms
                     b.weightTs = r.time.epochSecond
@@ -350,7 +358,7 @@ object HealthConnectImporter {
             // already 0-100 (unlike Apple's 0..1 fraction), so it stores as-is and matches the iOS
             // "body_fat" key. ---
             readAll(client, BodyFatRecord::class, filter, selfPackage) { r ->
-                val b = bucket(dayOf(r.time))
+                val b = bucket(dayOf(r.time, r.zoneOffset))
                 if (r.time.epochSecond >= b.bodyFatTs) {
                     b.bodyFatPct = r.percentage.value
                     b.bodyFatTs = r.time.epochSecond
@@ -358,7 +366,7 @@ object HealthConnectImporter {
             }
             // --- Lean body mass (kg) -> latest value of the day wins (iOS "lean_mass" twin). ---
             readAll(client, LeanBodyMassRecord::class, filter, selfPackage) { r ->
-                val b = bucket(dayOf(r.time))
+                val b = bucket(dayOf(r.time, r.zoneOffset))
                 if (r.time.epochSecond >= b.leanMassTs) {
                     b.leanMassKg = r.mass.inKilograms
                     b.leanMassTs = r.time.epochSecond
@@ -390,7 +398,9 @@ object HealthConnectImporter {
                     )
                 )
                 // Count exercises per local day on the start day for the WHOOP daily backfill.
-                bucket(dayOf(r.startTime)).exerciseCount += 1
+                val startDay = dayOf(r.startTime, r.startZoneOffset)
+                workoutDays.add(startDay)   // #1002: index-parallel to the add() just above
+                bucket(startDay).exerciseCount += 1
             }
 
             // --- #835: upgrade each workout's calories now the day aggregate exists ---
@@ -408,7 +418,7 @@ object HealthConnectImporter {
             for (i in workouts.indices) {
                 val w = workouts[i]
                 if (w.endTs <= w.startTs) continue
-                val day = acc[dayOf(Instant.ofEpochSecond(w.startTs))]
+                val day = acc[workoutDays[i]]   // #1002: the key from the record's own offset
                 val dayBasal = day?.let {
                     basalKcal(maxSourceDouble(it.totalKcalBySource), maxSourceDouble(it.activeKcalBySource))
                 }
@@ -502,7 +512,7 @@ object HealthConnectImporter {
             hydrationReadOk = readAll(
                 client, HydrationRecord::class, TimeRangeFilter.between(hydrationStart, end), selfPackage,
             ) { r ->
-                val day = dayOf(r.startTime)
+                val day = dayOf(r.startTime, r.startZoneOffset)
                 hydrationMl[day] = (hydrationMl[day] ?: 0.0) + r.volume.inMilliliters
             }
         } catch (e: Exception) {
@@ -671,7 +681,7 @@ object HealthConnectImporter {
         val touchedDays = sortedSetOf<String>().apply {
             addAll(appleRows.map { it.day })
             addAll(dailyRows.map { it.day })
-            addAll(workouts.map { LocalDate.ofInstant(Instant.ofEpochSecond(it.startTs), zone).toString() })
+            addAll(workoutDays)   // #1002: same keys the workouts were bucketed under
         }
         val firstDay = touchedDays.firstOrNull()
         val lastDay = touchedDays.lastOrNull()
@@ -724,8 +734,10 @@ object HealthConnectImporter {
             selfPackage,
         ) { r ->
             // The filter matches by overlap — drop records that STARTED yesterday so the bucketing
-            // agrees with [import]'s dayOf(r.startTime).
-            if (LocalDate.ofInstant(r.startTime, zone) == today) {
+            // agrees with [import]'s dayOf(r.startTime, r.startZoneOffset). #1002: keyed by the
+            // record's own offset for that agreement; `today` stays the phone's zone, which is what
+            // "today" means for a live top-up of the screen you are looking at.
+            if (localDayKey(r.startTime, r.startZoneOffset, zone) == dayKey) {
                 val src = r.metadata.dataOrigin.packageName
                 stepsBySource[src] = (stepsBySource[src] ?: 0L) + r.count
             }
@@ -908,6 +920,30 @@ object HealthConnectImporter {
      */
     internal fun isSelfWritten(originPackage: String, selfPackage: String): Boolean =
         selfPackage.isNotEmpty() && originPackage == selfPackage
+
+    /**
+     * #1002: which local civil day a record belongs to, keyed by the offset the record was RECORDED
+     * in rather than the phone's zone at import time.
+     *
+     * What this does NOT fix, because it was never broken: DST. [zone] is a REGION id
+     * (`ZoneId.systemDefault()` returns e.g. `Europe/London`, not a fixed `+01:00`), and
+     * `LocalDate.ofInstant` applies that region's rules AT THE GIVEN INSTANT — so a January instant
+     * is already keyed with the January offset even when the import runs in July. Pinning a fixed
+     * current offset is what would break DST, and the importer never did that.
+     *
+     * What it does fix is travel and relocation: a record written at 01:30 in Tokyo is the 16th to
+     * the person who made it, but a phone now set to `Europe/London` resolves the same instant to
+     * the 15th. `WINDOW_YEARS` is 10, so one import keys a decade of history that way, and importing
+     * again after moving re-keys the same records differently — which surfaces as a doubled day
+     * beside a gap rather than as an obviously wrong timestamp.
+     *
+     * [offset] is nullable because Health Connect's `startZoneOffset` / `zoneOffset` are optional and
+     * plenty of writers leave them null; the phone's zone stays the fallback, so behaviour is
+     * unchanged for every record that carries no offset. `ZoneOffset` is a `ZoneId`, so the two cases
+     * differ only in which rules resolve the instant.
+     */
+    internal fun localDayKey(instant: Instant, offset: ZoneOffset?, zone: ZoneId): String =
+        LocalDate.ofInstant(instant, offset ?: zone).toString()
 
     /**
      * #589 de-overlap for a per-source step map: SUM is already folded WITHIN each source by the read

--- a/android/app/src/main/java/com/noop/ingest/HealthConnectImporter.kt
+++ b/android/app/src/main/java/com/noop/ingest/HealthConnectImporter.kt
@@ -741,7 +741,14 @@ object HealthConnectImporter {
         // row below rather than clobbering it with zero.
         readAll(
             client, StepsRecord::class,
-            TimeRangeFilter.between(today.atStartOfDay(zone).toInstant(), Instant.now()),
+            // #1002: reach back an extra day. The FILTER is in the phone's zone but the day key below is
+            // now the record's own, and a record whose offset sits EAST of the phone's zone can belong to
+            // today while having started before the phone's midnight — fetching only from midnight would
+            // miss it, and the write below replaces a stored count with any non-zero sum, so a miss would
+            // overwrite a good figure with a low one. A day of slack covers every real offset (-12..+14).
+            // The `== dayKey` test still decides membership, so the extra records are read and discarded;
+            // step records are coarse interval rows, a handful per day, so this is cheap on a screen refresh.
+            TimeRangeFilter.between(today.minusDays(1).atStartOfDay(zone).toInstant(), Instant.now()),
             selfPackage,
         ) { r ->
             // The filter matches by overlap — drop records that STARTED yesterday so the bucketing

--- a/android/app/src/main/java/com/noop/ingest/HealthConnectImporter.kt
+++ b/android/app/src/main/java/com/noop/ingest/HealthConnectImporter.kt
@@ -307,7 +307,10 @@ object HealthConnectImporter {
             }
             // --- Sleep sessions -> per-day total sleep minutes, assigned to the WAKE day ---
             readAll(client, SleepSessionRecord::class, filter, selfPackage) { r ->
-                val day = dayOf(r.endTime, r.endZoneOffset)
+                // Wake-day keyed, so the END offset is the right one — but a writer that sets only the
+                // start offset is common, and the start is far better evidence of the sleeper's zone than
+                // the phone's zone at import time. Fall through start before giving up.
+                val day = dayOf(r.endTime, r.endZoneOffset ?: r.startZoneOffset)
                 val b = bucket(day)
                 // Prefer summed asleep-stage minutes; fall back to session span when no stages.
                 val asleepMin = asleepMinutes(r)
@@ -512,7 +515,15 @@ object HealthConnectImporter {
             hydrationReadOk = readAll(
                 client, HydrationRecord::class, TimeRangeFilter.between(hydrationStart, end), selfPackage,
             ) { r ->
-                val day = dayOf(r.startTime, r.startZoneOffset)
+                // #1002: hydration deliberately keeps the PHONE's zone, unlike every other record here.
+                // Its write is a windowed REPLACE: `windowDays` below is built from LocalDate.now(zone),
+                // and HydrationStore.importWindow keeps only keys IN that window — anything else is
+                // dropped, not merged. Keying a record by its own offset can move it a day off the phone
+                // zone, so a drink near either edge of the window would land outside it and be silently
+                // discarded. Losing water quietly in a replace path is a worse bug than the one this fixes
+                // (see #986). Correcting it properly means making the window offset-aware too, which is a
+                // change to shared code with an iOS twin, so it is left for its own PR.
+                val day = dayOf(r.startTime, null)
                 hydrationMl[day] = (hydrationMl[day] ?: 0.0) + r.volume.inMilliliters
             }
         } catch (e: Exception) {

--- a/android/app/src/test/java/com/noop/ingest/HealthConnectZoneOffsetTest.kt
+++ b/android/app/src/test/java/com/noop/ingest/HealthConnectZoneOffsetTest.kt
@@ -1,0 +1,110 @@
+package com.noop.ingest
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import java.time.Instant
+import java.time.ZoneId
+import java.time.ZoneOffset
+
+/**
+ * #1002 - which local civil day an imported Health Connect record is keyed under.
+ *
+ * The importer bucketed every record with `ZoneId.systemDefault()`, the phone's zone at import time,
+ * and never read the `startZoneOffset` / `zoneOffset` the record carries. `WINDOW_YEARS` is 10, so a
+ * single import keys a decade of history that way.
+ *
+ * These pin BOTH halves of that, because the two are easy to conflate and only one was ever broken:
+ *
+ *  - DST was already correct and must stay correct. `ZoneId.systemDefault()` returns a REGION id, and
+ *    `LocalDate.ofInstant` resolves it with the rules in force AT THE INSTANT — so a January instant
+ *    is keyed with January's offset even when the import runs in July. A fix that reached for a fixed
+ *    current offset would BREAK this, so it is pinned as a regression guard rather than as a bug.
+ *  - Travel and relocation were broken, and are what the offset actually fixes.
+ */
+class HealthConnectZoneOffsetTest {
+
+    private val london = ZoneId.of("Europe/London")   // region id: +00:00 winter, +01:00 summer
+    private val tokyo = ZoneOffset.ofHours(9)
+
+    // --- the half that was never broken -----------------------------------------------------------
+
+    /**
+     * A winter instant keyed while the phone sits in summer. 23:30 UTC in January is 23:30 local in
+     * London (UTC+0), so it belongs to the 15th. Pinning the current +01:00 instead would call it the
+     * 16th — the failure this test exists to prevent a "fix" from introducing.
+     */
+    @Test fun regionZoneKeysAWinterInstantWithTheWinterOffset() {
+        val winter = Instant.parse("2026-01-15T23:30:00Z")
+        assertEquals("2026-01-15", HealthConnectImporter.localDayKey(winter, null, london))
+        // What pinning the July offset would have produced, stated explicitly so the contrast is legible.
+        assertEquals("2026-01-16", HealthConnectImporter.localDayKey(winter, ZoneOffset.ofHours(1), london))
+    }
+
+    /** The same clock time in July IS +01:00, so 23:30 UTC is 00:30 local and rolls to the next day. */
+    @Test fun regionZoneKeysASummerInstantWithTheSummerOffset() {
+        val summer = Instant.parse("2026-07-15T23:30:00Z")
+        assertEquals("2026-07-16", HealthConnectImporter.localDayKey(summer, null, london))
+    }
+
+    // --- the half that was broken -----------------------------------------------------------------
+
+    /**
+     * The regression itself. A drink logged at 01:30 on the 16th in Tokyo is the 16th to the person who
+     * logged it. Re-resolved in London it is 16:30 on the 15th, so the record lands a day early.
+     */
+    @Test fun aRecordFromAnotherZoneKeepsItsOwnDay() {
+        val recordedInTokyo = Instant.parse("2026-01-15T16:30:00Z")   // 2026-01-16 01:30 +09:00
+        assertEquals("2026-01-16", HealthConnectImporter.localDayKey(recordedInTokyo, tokyo, london))
+        // The old behaviour, for contrast: the phone's zone wins and the day moves.
+        assertEquals("2026-01-15", HealthConnectImporter.localDayKey(recordedInTokyo, null, london))
+    }
+
+    /**
+     * The offset only matters where it changes the civil day. A midday record is the same day in both
+     * zones, so the fix must be a no-op there rather than shifting well-keyed history around.
+     */
+    @Test fun aMiddayRecordIsUnaffectedByWhichZoneResolvesIt() {
+        val midday = Instant.parse("2026-01-15T12:00:00Z")
+        assertEquals("2026-01-15", HealthConnectImporter.localDayKey(midday, null, london))
+        assertEquals("2026-01-15", HealthConnectImporter.localDayKey(midday, ZoneOffset.UTC, london))
+    }
+
+    /**
+     * Health Connect's offset fields are optional and many writers leave them null. A null must fall
+     * back to the phone's zone, i.e. behave exactly as the importer did before — otherwise the change
+     * would alter every record that carries no offset, which is most of them.
+     */
+    @Test fun aNullOffsetFallsBackToThePhoneZone() {
+        // 23:30 UTC on 1 June is 00:30 on the 2nd in London (+01:00 in summer). Asserting the rolled
+        // day proves the fallback really applies the phone's zone, rather than quietly keying in UTC.
+        val t = Instant.parse("2026-06-01T23:30:00Z")
+        assertEquals("2026-06-02", HealthConnectImporter.localDayKey(t, null, london))
+    }
+
+    /**
+     * A negative offset, since the fix must not assume the traveller went east. 02:00 UTC is still the
+     * previous evening in Los Angeles.
+     */
+    @Test fun aWesternOffsetKeysToThePreviousDay() {
+        val t = Instant.parse("2026-01-16T02:00:00Z")               // 2026-01-15 18:00 -08:00
+        assertEquals("2026-01-15", HealthConnectImporter.localDayKey(t, ZoneOffset.ofHours(-8), london))
+        assertEquals("2026-01-16", HealthConnectImporter.localDayKey(t, null, london))
+    }
+
+    /**
+     * The re-import symptom from the report: the same record keyed from two different phone zones gives
+     * two different days when the offset is ignored, and one stable day when it is not. That instability
+     * is what surfaces as a doubled day beside a gap rather than as a visibly wrong timestamp.
+     */
+    @Test fun theRecordsOwnOffsetIsStableAcrossPhoneRelocation() {
+        val t = Instant.parse("2026-01-15T16:30:00Z")
+        val sydney = ZoneId.of("Australia/Sydney")
+        assertEquals(
+            HealthConnectImporter.localDayKey(t, tokyo, london),
+            HealthConnectImporter.localDayKey(t, tokyo, sydney),
+        )
+        // Without the offset the same instant keys differently depending on where the phone is.
+        assertEquals("2026-01-15", HealthConnectImporter.localDayKey(t, null, london))
+        assertEquals("2026-01-16", HealthConnectImporter.localDayKey(t, null, sydney))
+    }
+}


### PR DESCRIPTION
Fixes #1002.

`HealthConnectImporter` bucketed every record with `ZoneId.systemDefault()` — the phone's zone at import time — and never read the `startZoneOffset` / `zoneOffset` Health Connect attaches to each record. `WINDOW_YEARS` is 10, so a single import keys a decade of history that way.

## The reported DST case was not actually broken

Worth stating up front, because I repeated it on the issue before checking. `ZoneId.systemDefault()` returns a **region** id (`Europe/London`), not a fixed offset, and `LocalDate.ofInstant` resolves a region with the rules in force **at that instant**. So a January record is already keyed with January's offset even when the import runs in July. Verified on a JVM first:

```
winter instant in London : 2026-01-15   (offset Z)
summer instant in London : 2026-07-16   (offset +01:00)
same winter instant with a fixed +01:00 pinned: 2026-01-16   <- what would be wrong
```

That last line is what a careless "fix" would have introduced, so it is pinned as a regression guard rather than left implicit.

## What was broken

Travel and relocation — where the record's zone genuinely differs from the phone's current one:

```
record written 01:30 in Tokyo   true local day 2026-01-16
resolved on a phone in London              2026-01-15
```

Because the key is computed at import time, importing the same history again after moving re-keys the same records differently. That is the doubled-day-beside-a-gap symptom in the report, and it needs no travel at import time — only that you have moved since.

## The change

`localDayKey(instant, offset, zone)` uses the record's own offset when present and falls back to the phone's zone when absent. Health Connect's offset fields are optional and many writers leave them null, so **behaviour is unchanged for every record without one** — this can only move a record that carries evidence of a different zone.

Threaded through all 17 call sites: interval records use `startZoneOffset` (sleep uses `endZoneOffset`, since it keys to the wake day), instantaneous records use `zoneOffset`, and heart-rate samples inherit their parent record's.

Workouts needed the key carried forward rather than re-derived. `WorkoutRow` holds only epoch seconds, so recomputing the day in the #835 calorie post-pass would silently fall back to the phone's zone — undoing the fix for exactly the travelled sessions it exists for. `workoutDays` is index-parallel to `workouts` and is also what `touchedDays` now reports, so the summary range agrees with the buckets.

The live steps top-up now keys the same way, keeping the agreement its comment at the read lambda already promised. `today` stays in the phone's zone, which is what "today" means for a live top-up of the screen you are looking at.

## iOS is deliberately not in this PR

Flagging this against the parity rule rather than quietly omitting it. `HealthKitBridge` has the same class of issue (`Calendar.current` at 311/369/597/929, `TimeZone.current` at 688/1189), but it is not the same fix:

- HealthKit exposes no per-record offset. The nearest equivalent is the optional `HKMetadataKeyTimeZone`, which most writers never set.
- `HKStatisticsCollectionQuery` buckets by the anchor calendar, so per-record keying means moving to `HKSampleQuery` plus a fallback that would fire far more often than Android's.

Doing it badly would be worse than not doing it. This PR moves Health Connect onto the convention the export importers already use (`AppleHealthAggregator.localDay`, `AppleHealthImporter.localDay`, `XiaomiBandImporter.dayKey`, and `WhoopDayKeying`, whose doc comment already says "in the cycle's own UTC offset"), and the Apple live path is worth its own change.

## Verification

- **7 new tests, all passing.** Run locally against the function extracted verbatim from the source, not a hand-copy: `OK (7 tests)`. They cover the two DST directions, the Tokyo case, a western offset, a null-offset fallback that must roll the day, a midday no-op, and the relocation-instability case.
- Every assertion independently confirmed against a plain JVM before being written into the test.
- Full `src/main/java` Kotlin compile: 2517 errors on this branch and 2517 on `main`, **0 of them in `HealthConnectImporter.kt`** on either. No new errors. (The 2517 are pre-existing missing-dependency cascades from an ad-hoc classpath.)
- `Tools/doc_comment_lint.py` clean.
- The existing Health Connect suites (`HealthConnectStepsDeOverlapTest`, `HealthConnectActiveKcalTest`, `HealthConnectCoveredDaysTest`, `HealthConnectSelfWriteSkipTest`, `HealthConnectDerivedBmiTest`) are unchanged and run in `build-and-test`.

Not validated against a real Health Connect store — the offsets themselves come from the platform, so the record-shape assumptions are worth a sanity check on a device that has actually travelled.

---

## Re-review: two fixes

**Hydration is deliberately excluded from the offset keying.** Its write is a windowed REPLACE — `windowDays` is built from `LocalDate.now(zone)` and `HydrationStore.importWindow` is `windowDays.associateWith { found[it] ?: 0.0 }`, which keeps only keys *inside* the window and drops anything else rather than merging it. Keying a record by its own offset can move it a day off the phone zone, so a drink near either edge of the window would land outside it and be discarded without a trace.

That is a worse bug than the one this fixes, and the same quiet-loss-in-a-replace-path shape as #986. Correcting it properly means making the window offset-aware too, which is shared code with an iOS twin, so it gets its own PR rather than riding along here.

I checked the other write paths for the same shape: `appleRows` / `dailyRows` are built from `acc`'s own keys with no window clamp, and `coveredDays` is a semantic gate rather than a range. Hydration was the only path that silently drops a key.

**Sleep now falls through `endZoneOffset` to `startZoneOffset`** before the phone's zone. Wake-day keying makes the end offset the right first choice, but writers that set only the start are common, and the start is far better evidence of the sleeper's zone than wherever the phone is at import time.

Also verified in the re-review: `workouts.add` occurs exactly once, and every other access is an in-place `workouts[i] = w.copy(...)` with no removal, sort or filter, so `workoutDays` stays index-parallel. The two appends are unconditional and adjacent, with no early exit between them.

## Second re-review: the steps top-up filter

The live top-up reads with a filter in the **phone's** zone but now keys with the **record's** — and those can disagree. A record whose offset sits east of the phone's zone can belong to today while having started before the phone's midnight, so the filter never fetches it. The sum comes back low, and the write replaces the stored count with any non-zero sum, so the miss overwrites a good figure. Because the full import keys the same way, the two would then disagree and flip-flop the number on each run, which is worse than the undercount alone.

The filter now reaches back a day. A day of slack covers every real offset (-12..+14), the `== dayKey` test still decides membership so the extra rows are read and discarded, and step records are coarse interval rows a handful per day — cheap on a screen refresh.

Worth naming the general shape, since it is what both re-review findings have in common: keying by the record's offset while some *other* part of the same path still reasons in the phone's zone. Hydration was a windowed replace whose window was phone-zone; this was a read filter that was phone-zone. Both were consistent-by-construction before, because the key and the range came from the same zone.
