### PR TITLE
Add language settings, normalized language in app

### DIFF
--- a/Strand/App/AppLanguage.swift
+++ b/Strand/App/AppLanguage.swift
@@ -14,6 +14,7 @@ enum AppLanguage: String, CaseIterable, Identifiable {
     case spanish = "es"
     case french = "fr"
     case portuguese = "pt-PT"
+    case chinese = "zh"
 
     static let storageKey = "noop.appLanguage"
 
@@ -29,6 +30,7 @@ enum AppLanguage: String, CaseIterable, Identifiable {
         case .spanish:    return "Español"
         case .french:     return "Français"
         case .portuguese: return "Português"
+        case .chinese:    return "中文"
         }
     }
 

--- a/Strand/App/AppLanguage.swift
+++ b/Strand/App/AppLanguage.swift
@@ -1,0 +1,62 @@
+import Foundation
+
+/// The language NOOP uses for app-owned copy. Region-specific measurement and clock preferences remain
+/// separate: this changes words, not the user's unit-system choice or time zone.
+///
+/// Apple chooses a bundle's localization once, when the process launches. `apply(_:)` therefore writes
+/// the standard `AppleLanguages` override and Settings tells the user to reopen NOOP. Applying only a
+/// SwiftUI `locale` live would be incorrect: `Text` would switch immediately while `String(localized:)`
+/// messages, notifications, and strings owned by `StrandDesign.module` stayed in the old language.
+enum AppLanguage: String, CaseIterable, Identifiable {
+    case system
+    case english = "en"
+    case german = "de"
+    case spanish = "es"
+    case french = "fr"
+    case portuguese = "pt-PT"
+
+    static let storageKey = "noop.appLanguage"
+
+    var id: String { rawValue }
+
+    /// Language names are autonyms on purpose, so the picker remains understandable while changing from
+    /// an unfamiliar language. The system choice is localized at its call site.
+    var autonym: String {
+        switch self {
+        case .system:     return ""
+        case .english:    return "English"
+        case .german:     return "Deutsch"
+        case .spanish:    return "Español"
+        case .french:     return "Français"
+        case .portuguese: return "Português"
+        }
+    }
+
+    static func resolve(_ raw: String) -> AppLanguage {
+        AppLanguage(rawValue: raw) ?? .system
+    }
+
+    /// Persist the bundle-language override. Foundation observes it on the next process launch.
+    static func apply(_ raw: String, defaults: UserDefaults = .standard) {
+        let language = resolve(raw)
+        if language == .system {
+            defaults.removeObject(forKey: "AppleLanguages")
+        } else {
+            defaults.set([language.rawValue], forKey: "AppleLanguages")
+        }
+    }
+
+    /// Locale used by SwiftUI format styles for the language that the currently-running bundles chose.
+    /// This deliberately follows `Bundle`, not the pending picker value, so changing the setting cannot
+    /// produce a half-new/half-old UI before the requested reopen.
+    static var activeLocale: Locale {
+        let bundleLanguage = Bundle.main.preferredLocalizations.first ?? "en"
+        let language = bundleLanguage.split(separator: "-").first.map(String.init) ?? bundleLanguage
+        // Preserve the device's regional conventions (24-hour clock, date order, decimal separator) while
+        // taking month/weekday words from the app language: English on a German device becomes `en_DE`.
+        if let region = Locale.autoupdatingCurrent.region?.identifier {
+            return Locale(identifier: "\(language)_\(region)")
+        }
+        return Locale(identifier: language)
+    }
+}

--- a/Strand/App/AppModel.swift
+++ b/Strand/App/AppModel.swift
@@ -1344,7 +1344,7 @@ final class AppModel: ObservableObject {
     /// encoding (#460) so a double-tap buzzes the time the way the user reads it. Derived from the
     /// locale's "j" (hour) template: a 12-hour locale includes the AM/PM ("a") symbol.
     static var localeUses24HourClock: Bool {
-        let fmt = DateFormatter.dateFormat(fromTemplate: "j", options: 0, locale: .current) ?? "h"
+        let fmt = DateFormatter.dateFormat(fromTemplate: "j", options: 0, locale: AppLanguage.activeLocale) ?? "h"
         return !fmt.contains("a")
     }
 

--- a/Strand/App/StrandApp.swift
+++ b/Strand/App/StrandApp.swift
@@ -50,6 +50,9 @@ struct StrandApp: App {
                 .environment(\.stressNudgeCenter, model.stressNudgeCenter)
                 .frame(minWidth: 1000, minHeight: 700)
                 .preferredColorScheme(AppearanceMode.resolve(appearanceRaw).colorScheme)
+                // Keep date/number words on the same bundle language as every localized string. A pending
+                // Settings change intentionally becomes active only after the documented reopen.
+                .environment(\.locale, AppLanguage.activeLocale)
                 .chartStyle(chartStyleRaw)
                 // Dynamic Type now scales the prose/label roles (StrandFont). Cap the upper end so the
                 // fixed-geometry tiles/gauges stay legible at the largest accessibility sizes rather than
@@ -74,11 +77,13 @@ struct StrandApp: App {
                 .environmentObject(model)
                 .environmentObject(model.repo)
                 .environmentObject(model.live)
+                .environment(\.locale, AppLanguage.activeLocale)
         } label: {
             MenuBarLabel()
                 .environmentObject(model)
                 .environmentObject(model.repo)
                 .environmentObject(model.live)
+                .environment(\.locale, AppLanguage.activeLocale)
         }
         .menuBarExtraStyle(.window)
     }

--- a/Strand/Data/SleepMark.swift
+++ b/Strand/Data/SleepMark.swift
@@ -109,7 +109,7 @@ struct SleepMark: Equatable, Sendable {
     /// matching the Sleep screen's Asleep/Woke row.
     private static let clockFormatter: DateFormatter = {
         let f = DateFormatter()
-        f.locale = Locale.current
+        f.locale = AppLanguage.activeLocale
         f.setLocalizedDateFormatFromTemplate("jmm")
         return f
     }()

--- a/Strand/Liquid/LiquidTodayView.swift
+++ b/Strand/Liquid/LiquidTodayView.swift
@@ -170,7 +170,7 @@ struct LiquidTodayView: View {
         case 0: return String(localized: "Today")
         case 1: return String(localized: "Yesterday")
         default:
-            return selectedLogicalDay.formatted(.dateTime.weekday(.wide).locale(Locale.autoupdatingCurrent))
+            return selectedLogicalDay.formatted(.dateTime.weekday(.wide).locale(AppLanguage.activeLocale))
         }
     }
     /// Two-way binding for the graphical calendar: reads the shown day, writes back an offset.
@@ -1378,7 +1378,7 @@ struct LiquidTodayView: View {
         // weekday + month names regardless of the UI language. A locale-aware field template localizes both
         // the names AND the field order (e.g. fr "mercredi 4 juillet") in the user's locale.
         return selectedLogicalDay.formatted(
-            .dateTime.weekday(.wide).day().month(.wide).locale(Locale.autoupdatingCurrent))
+            .dateTime.weekday(.wide).day().month(.wide).locale(AppLanguage.activeLocale))
     }
 
     /// Provenance caption for the recovery-vitals card, keyed on the row a vital actually came from — NOT a

--- a/Strand/Resources/Localizable.xcstrings
+++ b/Strand/Resources/Localizable.xcstrings
@@ -173095,6 +173095,45 @@
         }
       }
     },
+    "Language": {
+      "localizations": {
+        "de": { "stringUnit": { "state": "translated", "value": "Sprache" } },
+        "en": { "stringUnit": { "state": "translated", "value": "Language" } },
+        "es": { "stringUnit": { "state": "translated", "value": "Idioma" } },
+        "fr": { "stringUnit": { "state": "translated", "value": "Langue" } },
+        "it": { "stringUnit": { "state": "translated", "value": "Lingua" } },
+        "pt-PT": { "stringUnit": { "state": "translated", "value": "Idioma" } },
+        "ru": { "stringUnit": { "state": "translated", "value": "Язык" } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "语言" } },
+        "zh-Hant": { "stringUnit": { "state": "translated", "value": "語言" } }
+      }
+    },
+    "Language changes take effect after you reopen NOOP.": {
+      "localizations": {
+        "de": { "stringUnit": { "state": "translated", "value": "Sprachänderungen werden wirksam, nachdem du NOOP erneut geöffnet hast." } },
+        "en": { "stringUnit": { "state": "translated", "value": "Language changes take effect after you reopen NOOP." } },
+        "es": { "stringUnit": { "state": "translated", "value": "Los cambios de idioma se aplican cuando vuelvas a abrir NOOP." } },
+        "fr": { "stringUnit": { "state": "translated", "value": "Les changements de langue prennent effet après la réouverture de NOOP." } },
+        "it": { "stringUnit": { "state": "translated", "value": "Le modifiche della lingua vengono applicate dopo aver riaperto NOOP." } },
+        "pt-PT": { "stringUnit": { "state": "translated", "value": "As alterações de idioma são aplicadas depois de reabrires o NOOP." } },
+        "ru": { "stringUnit": { "state": "translated", "value": "Изменения языка вступят в силу после повторного запуска NOOP." } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "重新打开 NOOP 后，语言更改将会生效。" } },
+        "zh-Hant": { "stringUnit": { "state": "translated", "value": "重新開啟 NOOP 後，語言變更將會生效。" } }
+      }
+    },
+    "System default": {
+      "localizations": {
+        "de": { "stringUnit": { "state": "translated", "value": "Systemstandard" } },
+        "en": { "stringUnit": { "state": "translated", "value": "System default" } },
+        "es": { "stringUnit": { "state": "translated", "value": "Predeterminado del sistema" } },
+        "fr": { "stringUnit": { "state": "translated", "value": "Réglage système" } },
+        "it": { "stringUnit": { "state": "translated", "value": "Predefinita di sistema" } },
+        "pt-PT": { "stringUnit": { "state": "translated", "value": "Predefinição do sistema" } },
+        "ru": { "stringUnit": { "state": "translated", "value": "Системный" } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "跟随系统" } },
+        "zh-Hant": { "stringUnit": { "state": "translated", "value": "跟隨系統" } }
+      }
+    },
     "✓": {
       "localizations": {
         "de": {

--- a/Strand/Screens/AutoWorkoutCard.swift
+++ b/Strand/Screens/AutoWorkoutCard.swift
@@ -133,7 +133,7 @@ struct AutoWorkoutCard: View {
     /// HH:mm in the user's locale/timezone.
     private static let timeFmt: DateFormatter = {
         let f = DateFormatter()
-        f.locale = .current
+        f.locale = AppLanguage.activeLocale
         f.timeStyle = .short
         f.dateStyle = .none
         return f
@@ -142,7 +142,7 @@ struct AutoWorkoutCard: View {
     /// Localized medium date ("Jun 23, 2026") for a bout older than yesterday.
     private static let dateFmt: DateFormatter = {
         let f = DateFormatter()
-        f.locale = .current
+        f.locale = AppLanguage.activeLocale
         f.dateStyle = .medium
         f.timeStyle = .none
         return f

--- a/Strand/Screens/AutomationsView.swift
+++ b/Strand/Screens/AutomationsView.swift
@@ -136,10 +136,10 @@ struct AutomationsView: View {
     }
     private static let momentFormatter: DateFormatter = {
         let f = DateFormatter()
-        f.locale = Locale.current
+        f.locale = AppLanguage.activeLocale
         // Keep the "EEE d MMM ·" layout but honor the device's 12-/24-hour clock (#337): the "j"
         // template resolves to a 12-hour pattern (contains "a") only where the user prefers it.
-        let uses24h = !(DateFormatter.dateFormat(fromTemplate: "j", options: 0, locale: .current) ?? "H").contains("a")
+        let uses24h = !(DateFormatter.dateFormat(fromTemplate: "j", options: 0, locale: AppLanguage.activeLocale) ?? "H").contains("a")
         f.dateFormat = "EEE d MMM · " + (uses24h ? "HH:mm" : "h:mm a")
         return f
     }()

--- a/Strand/Screens/ChargeBreakdownFormat.swift
+++ b/Strand/Screens/ChargeBreakdownFormat.swift
@@ -133,7 +133,7 @@ enum ChargeBreakdownFormat {
     /// The recalibration epoch as a short display day ("19 Jul"), or nil when none is set. Pure — the
     /// caller supplies the epoch (`Baselines.hrvBaselineEpoch()`), so this stays testable. Locale-aware
     /// via `DateFormatter.setLocalizedDateFormatFromTemplate`, so the day/month order follows the user.
-    static func recalibrationDay(epoch: Double, locale: Locale = .current) -> String? {
+    static func recalibrationDay(epoch: Double, locale: Locale = AppLanguage.activeLocale) -> String? {
         guard epoch > 0 else { return nil }
         let fmt = DateFormatter()
         fmt.locale = locale

--- a/Strand/Screens/CoupledView.swift
+++ b/Strand/Screens/CoupledView.swift
@@ -163,7 +163,7 @@ struct CoupledView: View {
 
     private var subtitleText: LocalizedStringKey {
         let f = DateFormatter()
-        f.locale = Locale.current
+        f.locale = AppLanguage.activeLocale
         f.setLocalizedDateFormatFromTemplate("d MMM")
         return LocalizedStringKey("Today, \(f.string(from: Date()))")
     }
@@ -698,7 +698,7 @@ struct CoupledView: View {
 
     private static let clockFmt: DateFormatter = {
         let f = DateFormatter()
-        f.locale = Locale.current
+        f.locale = AppLanguage.activeLocale
         f.setLocalizedDateFormatFromTemplate("jmm")
         return f
     }()

--- a/Strand/Screens/SettingsView.swift
+++ b/Strand/Screens/SettingsView.swift
@@ -775,7 +775,7 @@ struct SettingsView: View {
                     .font(StrandFont.footnote)
                     .foregroundStyle(StrandPalette.textTertiary)
                     .frame(maxWidth: .infinity, alignment: .leading)
-                    .padding(.top, 6)
+                    .padding(.top, NoopMetrics.space1)
                 rowDivider
                 FormRow(label: "Theme") {
                     Picker("Theme", selection: $appearanceRaw) {

--- a/Strand/Screens/SettingsView.swift
+++ b/Strand/Screens/SettingsView.swift
@@ -108,6 +108,9 @@ struct SettingsView: View {
     @AppStorage("appIcon.alt") private var useNavyIcon = false
     // Light/Dark/System theme. Read by both app roots' .preferredColorScheme; default follows the OS.
     @AppStorage(AppearanceMode.storageKey) private var appearanceRaw = AppearanceMode.system.rawValue
+    // App-owned copy language. Apple binds a bundle localization at process launch, so this writes the
+    // standard AppleLanguages override and takes effect after the user reopens NOOP.
+    @AppStorage(AppLanguage.storageKey) private var appLanguageRaw = AppLanguage.system.rawValue
     // Chart colour style: Titanium (brand) or Classic (throwback red→green). Re-colours gauges + charts.
     @AppStorage(ChartStyle.storageKey) private var chartStyleRaw = ChartStyle.titanium.rawValue
     // Day-cycle scene backdrop behind Today (#698). Default ON. Off swaps the scene for a plain dark
@@ -755,6 +758,25 @@ struct SettingsView: View {
             blurb: "Choose Light, Dark, or follow your system. Dark is the signature near-black; Light keeps the same clean look on a bright canvas."
         ) {
             VStack(spacing: 0) {
+                FormRow(label: "Language") {
+                    Picker("Language", selection: $appLanguageRaw) {
+                        ForEach(AppLanguage.allCases) { language in
+                            Text(language == .system ? String(localized: "System default") : language.autonym)
+                                .tag(language.rawValue)
+                        }
+                    }
+                    .labelsHidden()
+                    .pickerStyle(.menu)
+                    .tint(StrandPalette.accent)
+                    .accessibilityLabel("Language")
+                    .onChangeCompat(of: appLanguageRaw) { AppLanguage.apply($0) }
+                }
+                Text("Language changes take effect after you reopen NOOP.")
+                    .font(StrandFont.footnote)
+                    .foregroundStyle(StrandPalette.textTertiary)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(.top, 6)
+                rowDivider
                 FormRow(label: "Theme") {
                     Picker("Theme", selection: $appearanceRaw) {
                         ForEach(AppearanceMode.allCases) { mode in

--- a/Strand/Screens/SleepView.swift
+++ b/Strand/Screens/SleepView.swift
@@ -1129,7 +1129,7 @@ struct SleepView: View {
 
     /// Clock labels for the timeline axis; "jmm" respects the device 12/24-hour setting.
     private static let stageAxisFormatter: DateFormatter = {
-        let f = DateFormatter(); f.locale = .current; f.setLocalizedDateFormatFromTemplate("jmm"); return f
+        let f = DateFormatter(); f.locale = AppLanguage.activeLocale; f.setLocalizedDateFormatFromTemplate("jmm"); return f
     }()
 
     /// The WHOOP sleep-stages chart: a stack of four per-stage timeline rows (AWAKE · LIGHT ·
@@ -2947,7 +2947,7 @@ private struct Night {
     // on everyone, matching the HR-tooltip / workout times (#337).
     private static let timeFmt: DateFormatter = {
         let f = DateFormatter()
-        f.locale = Locale.current
+        f.locale = AppLanguage.activeLocale
         f.setLocalizedDateFormatFromTemplate("jmm")
         return f
     }()

--- a/Strand/Screens/TodayView.swift
+++ b/Strand/Screens/TodayView.swift
@@ -895,7 +895,7 @@ struct TodayView: View {
     private static func lastChargeDateFmt(_ dayKey: String) -> String {
         guard let date = dayKeyParser.date(from: dayKey) else { return dayKey }
         let f = DateFormatter()
-        f.locale = Locale.current
+        f.locale = AppLanguage.activeLocale
         f.setLocalizedDateFormatFromTemplate("dMMM")
         return f.string(from: date)
     }
@@ -4453,7 +4453,7 @@ struct TodayView: View {
     /// where 12-hour is preferred, "19:10" where 24-hour is, instead of forcing one on everyone.
     static let hrTimeFmt: DateFormatter = {
         let f = DateFormatter()
-        f.locale = Locale.current
+        f.locale = AppLanguage.activeLocale
         f.setLocalizedDateFormatFromTemplate("jmm")
         return f
     }()

--- a/Strand/Screens/WorkoutDetailView.swift
+++ b/Strand/Screens/WorkoutDetailView.swift
@@ -534,13 +534,13 @@ struct WorkoutDetailView: View {
     }()
     private static let timeFmt: DateFormatter = {
         let f = DateFormatter()
-        f.locale = Locale.current
+        f.locale = AppLanguage.activeLocale
         f.setLocalizedDateFormatFromTemplate("jmm")
         return f
     }()
     private static let tooltipTime: DateFormatter = {
         let f = DateFormatter()
-        f.locale = Locale.current
+        f.locale = AppLanguage.activeLocale
         f.setLocalizedDateFormatFromTemplate("jmm")
         return f
     }()

--- a/Strand/Screens/WorkoutsView.swift
+++ b/Strand/Screens/WorkoutsView.swift
@@ -1594,7 +1594,7 @@ struct WorkoutsView: View {
     // preferred, "16:34" where 24-hour is — instead of forcing 24-hour on everyone (matches TodayView).
     private static let timeFmt: DateFormatter = {
         let f = DateFormatter()
-        f.locale = Locale.current
+        f.locale = AppLanguage.activeLocale
         f.setLocalizedDateFormatFromTemplate("jmm")
         return f
     }()

--- a/StrandTests/AppLanguageTests.swift
+++ b/StrandTests/AppLanguageTests.swift
@@ -1,0 +1,20 @@
+import XCTest
+@testable import Strand
+
+final class AppLanguageTests: XCTestCase {
+    func testUnknownStoredValueFallsBackToSystem() {
+        XCTAssertEqual(AppLanguage.resolve("unsupported"), .system)
+    }
+
+    func testExplicitLanguageWritesAndSystemRemovesAppleOverride() throws {
+        let suiteName = "AppLanguageTests.\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        AppLanguage.apply(AppLanguage.german.rawValue, defaults: defaults)
+        XCTAssertEqual(defaults.stringArray(forKey: "AppleLanguages"), ["de"])
+
+        AppLanguage.apply(AppLanguage.system.rawValue, defaults: defaults)
+        XCTAssertNil(defaults.object(forKey: "AppleLanguages"))
+    }
+}

--- a/StrandTests/AppLanguageTests.swift
+++ b/StrandTests/AppLanguageTests.swift
@@ -6,6 +6,11 @@ final class AppLanguageTests: XCTestCase {
         XCTAssertEqual(AppLanguage.resolve("unsupported"), .system)
     }
 
+    func testChineseCatalogTagIsSupported() {
+        XCTAssertEqual(AppLanguage.resolve("zh"), .chinese)
+        XCTAssertEqual(AppLanguage.chinese.autonym, "中文")
+    }
+
     func testExplicitLanguageWritesAndSystemRemovesAppleOverride() throws {
         let suiteName = "AppLanguageTests.\(UUID().uuidString)"
         let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))

--- a/StrandiOS/App/StrandiOSApp.swift
+++ b/StrandiOS/App/StrandiOSApp.swift
@@ -86,6 +86,9 @@ struct StrandiOSApp: App {
                 // card observes the SAME instance the central detector (AppModel.evaluateStress) posts to.
                 .environment(\.stressNudgeCenter, model.stressNudgeCenter)
                 .preferredColorScheme(AppearanceMode.resolve(appearanceRaw).colorScheme)
+                // Match SwiftUI format styles to the localization selected by the app's bundles. Language
+                // changes are process-wide on Apple and are applied after the documented reopen.
+                .environment(\.locale, AppLanguage.activeLocale)
                 .chartStyle(chartStyleRaw)
                 // Dynamic Type now scales the prose/label roles (StrandFont). Cap the upper end so the
                 // fixed-geometry tiles/gauges stay legible at the largest accessibility sizes rather than

--- a/android/app/src/main/java/com/noop/NoopApplication.kt
+++ b/android/app/src/main/java/com/noop/NoopApplication.kt
@@ -12,6 +12,7 @@ import com.noop.data.DeviceRegistry
 import com.noop.data.WhoopDatabase
 import com.noop.data.WhoopRepository
 import com.noop.ui.NoopPrefs
+import com.noop.ui.AppLanguagePrefs
 import kotlinx.coroutines.runBlocking
 
 /**
@@ -30,7 +31,7 @@ import kotlinx.coroutines.runBlocking
 class NoopApplication : Application() {
 
     override fun attachBaseContext(base: Context) {
-        super.attachBaseContext(base)
+        super.attachBaseContext(AppLanguagePrefs.wrap(base))
         // UI resource lookup is intentionally available before onCreate: data-driven presentation
         // helpers (release notes, metric catalogs) can resolve a resource without becoming
         // @Composable or retaining an Activity. The Application is process-scoped, so this does not

--- a/android/app/src/main/java/com/noop/ui/AppLanguage.kt
+++ b/android/app/src/main/java/com/noop/ui/AppLanguage.kt
@@ -1,0 +1,75 @@
+package com.noop.ui
+
+import android.content.Context
+import android.content.res.Configuration
+import android.content.res.Resources
+import android.os.LocaleList
+import java.util.Locale
+
+/** App-owned UI language. Units, time zone, and other regional preferences remain independent. */
+enum class AppLanguage(val storageValue: String?, val autonym: String) {
+    SYSTEM(null, ""),
+    ENGLISH("en", "English"),
+    GERMAN("de", "Deutsch"),
+    SPANISH("es", "Español"),
+    FRENCH("fr", "Français"),
+    PORTUGUESE("pt-PT", "Português");
+
+    companion object {
+        fun fromStorage(raw: String?): AppLanguage =
+            entries.firstOrNull { it.storageValue == raw } ?: SYSTEM
+    }
+}
+
+/**
+ * Process-wide locale owner. Both the Application and Activity wrap their base contexts through this
+ * object, which keeps composable `stringResource`, non-composable `uiString`, services, and widgets on
+ * one locale. `Locale.setDefault` also keeps date/month words and locale-aware casing aligned with the
+ * selected UI language instead of leaking the phone language into otherwise translated copy.
+ */
+object AppLanguagePrefs {
+    private const val FILE = "noop_prefs"
+    private const val KEY = "noop.appLanguage"
+
+    private fun prefs(context: Context) =
+        context.getSharedPreferences(FILE, Context.MODE_PRIVATE)
+
+    fun selected(context: Context): AppLanguage =
+        AppLanguage.fromStorage(prefs(context).getString(KEY, null))
+
+    fun wrap(context: Context): Context {
+        val language = selected(context)
+        val locales = localesFor(language)
+        Locale.setDefault(locales[0])
+        if (language == AppLanguage.SYSTEM) return context
+
+        val configuration = Configuration(context.resources.configuration)
+        configuration.setLocales(locales)
+        return context.createConfigurationContext(configuration)
+    }
+
+    fun set(context: Context, language: AppLanguage) {
+        prefs(context).edit().apply {
+            if (language == AppLanguage.SYSTEM) remove(KEY)
+            else putString(KEY, language.storageValue)
+        }.apply()
+
+        // The Application outlives Activity.recreate(), so update its Resources too. That keeps
+        // uiString() and a running foreground service from retaining the previous language.
+        val appResources = context.applicationContext.resources
+        val configuration = Configuration(appResources.configuration)
+        val locales = localesFor(language)
+        configuration.setLocales(locales)
+        Locale.setDefault(locales[0])
+        @Suppress("DEPRECATION")
+        appResources.updateConfiguration(configuration, appResources.displayMetrics)
+    }
+
+    private fun localesFor(language: AppLanguage): LocaleList {
+        if (language == AppLanguage.SYSTEM) {
+            val system = Resources.getSystem().configuration.locales
+            return if (system.isEmpty) LocaleList(Locale.ENGLISH) else system
+        }
+        return LocaleList(Locale.forLanguageTag(checkNotNull(language.storageValue)))
+    }
+}

--- a/android/app/src/main/java/com/noop/ui/AppLanguage.kt
+++ b/android/app/src/main/java/com/noop/ui/AppLanguage.kt
@@ -6,14 +6,20 @@ import android.content.res.Resources
 import android.os.LocaleList
 import java.util.Locale
 
-/** App-owned UI language. Units, time zone, and other regional preferences remain independent. */
+/**
+ * App-owned UI language. Units and time zone remain independent, while locale-sensitive display
+ * formatting follows this selection through [Locale.setDefault]. Adding a language here therefore
+ * requires auditing default-locale parsers and formatters, especially persistent day keys: storage
+ * formats must pin their locale and chronology before supporting different numeral or calendar systems.
+ */
 enum class AppLanguage(val storageValue: String?, val autonym: String) {
     SYSTEM(null, ""),
     ENGLISH("en", "English"),
     GERMAN("de", "Deutsch"),
     SPANISH("es", "Español"),
     FRENCH("fr", "Français"),
-    PORTUGUESE("pt-PT", "Português");
+    PORTUGUESE("pt-PT", "Português"),
+    CHINESE("zh", "中文");
 
     companion object {
         fun fromStorage(raw: String?): AppLanguage =

--- a/android/app/src/main/java/com/noop/ui/MainActivity.kt
+++ b/android/app/src/main/java/com/noop/ui/MainActivity.kt
@@ -39,6 +39,10 @@ import kotlinx.coroutines.launch
  */
 class MainActivity : ComponentActivity() {
 
+    override fun attachBaseContext(newBase: Context) {
+        super.attachBaseContext(AppLanguagePrefs.wrap(newBase))
+    }
+
     private val permissionLauncher =
         registerForActivityResult(ActivityResultContracts.RequestMultiplePermissions()) {
             // Permission results flow back into the BLE client's own runtime checks;

--- a/android/app/src/main/java/com/noop/ui/SettingsScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/SettingsScreen.kt
@@ -1,8 +1,10 @@
 package com.noop.ui
 
+import android.app.Activity
 import android.content.ActivityNotFoundException
 import android.content.ComponentName
 import android.content.Context
+import android.content.ContextWrapper
 import android.content.Intent
 import android.content.SharedPreferences
 import android.content.pm.PackageManager
@@ -574,6 +576,9 @@ fun SettingsScreen(
 
     // Theme (System / Light / Dark) — drives NoopTheme; AppearancePrefs mirrors it in snapshot state.
     var themeMode by remember { mutableStateOf(AppearancePrefs.mode) }
+    // App language owns the process resource locale; changing it recreates this Activity below so every
+    // composable and non-composable resource lookup switches together.
+    var appLanguage by remember { mutableStateOf(AppLanguagePrefs.selected(context)) }
     // Chart colours (Titanium / Classic) — re-colours gauges + charts; ChartStylePrefs mirrors it live.
     var chartStyle by remember { mutableStateOf(ChartStylePrefs.style) }
     // Trend charts (Line / Bar) — flips the Trends tab between the gradient line and value-ramp bars.
@@ -1036,13 +1041,42 @@ fun SettingsScreen(
         SettingsCard(
             icon = Icons.Filled.Brightness6,
             title = uiString(R.string.l10n_settings_screen_appearance_41def7a0),
-            blurb = "Choose Light, Dark, or follow your system. Dark is the signature near-black; Light keeps the same clean look on a bright canvas.",
+            blurb = uiString(R.string.settings_appearance_detail),
         ) {
+            val languages = AppLanguage.entries
+            val languageLabels = languages.map {
+                if (it == AppLanguage.SYSTEM) uiString(R.string.settings_language_system)
+                else it.autonym
+            }
+            SettingsFormRow(label = uiString(R.string.settings_language)) {
+                WheelPickerField(
+                    value = languageLabels[languages.indexOf(appLanguage)],
+                    accessibility = uiString(R.string.settings_language),
+                    options = languageLabels,
+                    selectedIndex = languages.indexOf(appLanguage),
+                    dialogTitle = uiString(R.string.settings_choose_language),
+                    onSelected = { index ->
+                        val selected = languages[index]
+                        if (selected != appLanguage) {
+                            appLanguage = selected
+                            AppLanguagePrefs.set(context, selected)
+                            context.hostingActivity()?.recreate()
+                        }
+                    },
+                )
+            }
+            SettingsRowDivider()
             SettingsFormRow(label = uiString(R.string.l10n_settings_screen_theme_a797e309)) {
                 SegmentedPillControl(
                     items = listOf(AppearanceMode.SYSTEM, AppearanceMode.LIGHT, AppearanceMode.DARK),
                     selection = themeMode,
-                    label = { it.label },
+                    label = {
+                        when (it) {
+                            AppearanceMode.SYSTEM -> uiString(R.string.settings_language_system)
+                            AppearanceMode.LIGHT -> uiString(R.string.settings_theme_light)
+                            AppearanceMode.DARK -> uiString(R.string.settings_theme_dark)
+                        }
+                    },
                     onSelect = { mode ->
                         themeMode = mode
                         AppearancePrefs.set(context, mode)
@@ -1057,7 +1091,10 @@ fun SettingsScreen(
                 SegmentedPillControl(
                     items = listOf(ChartStyle.TITANIUM, ChartStyle.CLASSIC),
                     selection = chartStyle,
-                    label = { it.label },
+                    label = {
+                        if (it == ChartStyle.CLASSIC) uiString(R.string.settings_chart_classic)
+                        else uiString(R.string.settings_chart_default)
+                    },
                     onSelect = { style ->
                         chartStyle = style
                         ChartStylePrefs.set(context, style)
@@ -1071,7 +1108,10 @@ fun SettingsScreen(
                 SegmentedPillControl(
                     items = listOf(TrendChartStyle.LINE, TrendChartStyle.BAR),
                     selection = trendChartStyle,
-                    label = { if (it == TrendChartStyle.BAR) "Bars" else "Line" },
+                    label = {
+                        if (it == TrendChartStyle.BAR) uiString(R.string.settings_trend_bars)
+                        else uiString(R.string.settings_trend_line)
+                    },
                     onSelect = { style ->
                         trendChartStyle = style
                         UnitPrefs.setTrendChartStyle(context, style)
@@ -3074,4 +3114,14 @@ private fun setAppIcon(context: Context, navy: Boolean) {
         else PackageManager.COMPONENT_ENABLED_STATE_ENABLED,
         PackageManager.DONT_KILL_APP,
     )
+}
+
+/** Compose may provide a themed ContextWrapper rather than the Activity directly. */
+private fun Context.hostingActivity(): Activity? {
+    var current: Context = this
+    while (current is ContextWrapper) {
+        if (current is Activity) return current
+        current = current.baseContext
+    }
+    return current as? Activity
 }

--- a/android/app/src/main/res/values-de/strings.xml
+++ b/android/app/src/main/res/values-de/strings.xml
@@ -1900,4 +1900,14 @@
     <string name="l10n_app_changelog_widgets_stop_inventing_numbers_naps_count_4f7491bb">Widgets erfinden keine Zahlen mehr, Nickerchen zählen für die Schlafschuld, und die Android-Statusanzeigen sprechen deine Sprache</string>
     <string name="l10n_sleep_screen_may_be_incomplete_7230dc27">Möglicherweise unvollständig</string>
     <string name="l10n_sleep_screen_little_motion_was_recorded_over_f061b7e4">Über Nacht wurde wenig Bewegung aufgezeichnet, daher wurde diese Nacht möglicherweise nicht vollständig erfasst und die Schlafdauer kann zu kurz erscheinen. Stelle sicher, dass das Band vollständig synchronisiert wurde.</string>
+    <string name="settings_language">Sprache</string>
+    <string name="settings_choose_language">Sprache auswählen</string>
+    <string name="settings_language_system">Systemstandard</string>
+    <string name="settings_appearance_detail">Wähle Hell, Dunkel oder folge deinem System. Dunkel ist das charakteristische Fast-Schwarz; Hell behält denselben klaren Look auf heller Fläche.</string>
+    <string name="settings_theme_light">Hell</string>
+    <string name="settings_theme_dark">Dunkel</string>
+    <string name="settings_chart_default">Standard</string>
+    <string name="settings_chart_classic">Klassisch</string>
+    <string name="settings_trend_line">Linie</string>
+    <string name="settings_trend_bars">Balken</string>
 </resources>

--- a/android/app/src/main/res/values-es/strings.xml
+++ b/android/app/src/main/res/values-es/strings.xml
@@ -1885,4 +1885,14 @@
     <string name="l10n_app_changelog_widgets_stop_inventing_numbers_naps_count_4f7491bb">Los widgets dejan de inventar números, las siestas cuentan para la deuda de sueño y los indicadores de Android hablan tu idioma</string>
     <string name="l10n_sleep_screen_may_be_incomplete_7230dc27">Puede estar incompleto</string>
     <string name="l10n_sleep_screen_little_motion_was_recorded_over_f061b7e4">Se registró poco movimiento durante la noche, por lo que esta noche puede haberse detectado de forma incompleta y el total de sueño puede parecer corto. Asegúrate de que la correa se haya sincronizado por completo.</string>
+    <string name="settings_language">Idioma</string>
+    <string name="settings_choose_language">Elegir idioma</string>
+    <string name="settings_language_system">Predeterminado del sistema</string>
+    <string name="settings_appearance_detail">Elige Claro, Oscuro o seguir tu sistema. Oscuro es el casi negro característico; Claro mantiene el mismo aspecto limpio sobre un lienzo brillante.</string>
+    <string name="settings_theme_light">Claro</string>
+    <string name="settings_theme_dark">Oscuro</string>
+    <string name="settings_chart_default">Predeterminado</string>
+    <string name="settings_chart_classic">Clásico</string>
+    <string name="settings_trend_line">Línea</string>
+    <string name="settings_trend_bars">Barras</string>
 </resources>

--- a/android/app/src/main/res/values-fr/strings.xml
+++ b/android/app/src/main/res/values-fr/strings.xml
@@ -1885,4 +1885,14 @@
     <string name="l10n_app_changelog_widgets_stop_inventing_numbers_naps_count_4f7491bb">Les widgets n\'inventent plus de chiffres, les siestes comptent pour la dette de sommeil, et les indicateurs Android parlent votre langue</string>
     <string name="l10n_sleep_screen_may_be_incomplete_7230dc27">Peut être incomplet</string>
     <string name="l10n_sleep_screen_little_motion_was_recorded_over_f061b7e4">Peu de mouvement a été enregistré cette nuit ; cette nuit peut donc être sous-détectée et le total de sommeil peut sembler court. Assurez-vous que le bracelet est entièrement synchronisé.</string>
+    <string name="settings_language">Langue</string>
+    <string name="settings_choose_language">Choisir la langue</string>
+    <string name="settings_language_system">Réglage système</string>
+    <string name="settings_appearance_detail">Choisissez Clair, Sombre, ou suivez votre système. Sombre est le noir profond caractéristique ; Clair conserve le même look épuré sur un fond clair.</string>
+    <string name="settings_theme_light">Clair</string>
+    <string name="settings_theme_dark">Sombre</string>
+    <string name="settings_chart_default">Par défaut</string>
+    <string name="settings_chart_classic">Classique</string>
+    <string name="settings_trend_line">Courbe</string>
+    <string name="settings_trend_bars">Barres</string>
 </resources>

--- a/android/app/src/main/res/values-pt-rPT/strings.xml
+++ b/android/app/src/main/res/values-pt-rPT/strings.xml
@@ -1879,4 +1879,14 @@
     <string name="l10n_app_changelog_widgets_stop_inventing_numbers_naps_count_4f7491bb">Os widgets deixam de inventar números, as sestas contam para a dívida de sono, e os indicadores Android falam a tua língua</string>
     <string name="l10n_sleep_screen_may_be_incomplete_7230dc27">Pode estar incompleto</string>
     <string name="l10n_sleep_screen_little_motion_was_recorded_over_f061b7e4">Foi registado pouco movimento durante a noite, por isso esta noite pode ter sido subdetetada e o total de sono pode parecer curto. Certifique-se de que a pulseira sincronizou totalmente.</string>
+    <string name="settings_language">Idioma</string>
+    <string name="settings_choose_language">Escolher idioma</string>
+    <string name="settings_language_system">Predefinição do sistema</string>
+    <string name="settings_appearance_detail">Escolhe Claro, Escuro ou segue o teu sistema. Escuro é o característico quase preto; Claro mantém o mesmo visual limpo num ecrã luminoso.</string>
+    <string name="settings_theme_light">Claro</string>
+    <string name="settings_theme_dark">Escuro</string>
+    <string name="settings_chart_default">Predefinição</string>
+    <string name="settings_chart_classic">Clássico</string>
+    <string name="settings_trend_line">Linha</string>
+    <string name="settings_trend_bars">Barras</string>
 </resources>

--- a/android/app/src/main/res/values-zh/strings.xml
+++ b/android/app/src/main/res/values-zh/strings.xml
@@ -1813,4 +1813,14 @@
     <string name="l10n_app_changelog_widgets_stop_inventing_numbers_naps_count_4f7491bb">小组件不再编造数字、小睡计入睡眠债，Android 状态提示也终于会说你的语言</string>
     <string name="l10n_sleep_screen_may_be_incomplete_7230dc27">可能不完整</string>
     <string name="l10n_sleep_screen_little_motion_was_recorded_over_f061b7e4">夜间记录到的动作很少，因此这一夜可能未被完整检测，睡眠总时长可能偏短。请确保表带已完全同步。</string>
+    <string name="settings_language">语言</string>
+    <string name="settings_choose_language">选择语言</string>
+    <string name="settings_language_system">跟随系统</string>
+    <string name="settings_appearance_detail">选择浅色、深色，或跟随系统。深色是标志性的近黑色；浅色在明亮画布上保持同样简洁的外观。</string>
+    <string name="settings_theme_light">浅色</string>
+    <string name="settings_theme_dark">深色</string>
+    <string name="settings_chart_default">默认</string>
+    <string name="settings_chart_classic">经典</string>
+    <string name="settings_trend_line">折线</string>
+    <string name="settings_trend_bars">柱形</string>
 </resources>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -1911,4 +1911,14 @@
     <string name="l10n_app_changelog_widgets_stop_inventing_numbers_naps_count_4f7491bb">Widgets stop inventing numbers, naps count toward sleep debt, and the Android status chips speak your language</string>
     <string name="l10n_sleep_screen_may_be_incomplete_7230dc27">May be incomplete</string>
     <string name="l10n_sleep_screen_little_motion_was_recorded_over_f061b7e4">Little motion was recorded overnight, so this night may be under-detected and the sleep total can read short. Make sure the strap fully synced.</string>
+    <string name="settings_language">Language</string>
+    <string name="settings_choose_language">Choose language</string>
+    <string name="settings_language_system">System default</string>
+    <string name="settings_appearance_detail">Choose Light, Dark, or follow your system. Dark is the signature near-black; Light keeps the same clean look on a bright canvas.</string>
+    <string name="settings_theme_light">Light</string>
+    <string name="settings_theme_dark">Dark</string>
+    <string name="settings_chart_default">Default</string>
+    <string name="settings_chart_classic">Classic</string>
+    <string name="settings_trend_line">Line</string>
+    <string name="settings_trend_bars">Bars</string>
 </resources>

--- a/android/app/src/test/java/com/noop/ui/AppLanguageTest.kt
+++ b/android/app/src/test/java/com/noop/ui/AppLanguageTest.kt
@@ -1,0 +1,19 @@
+package com.noop.ui
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class AppLanguageTest {
+    @Test
+    fun unknownOrMissingStoredLanguageFallsBackToSystem() {
+        assertEquals(AppLanguage.SYSTEM, AppLanguage.fromStorage(null))
+        assertEquals(AppLanguage.SYSTEM, AppLanguage.fromStorage("unsupported"))
+    }
+
+    @Test
+    fun everyExplicitLanguageRoundTripsItsStableTag() {
+        AppLanguage.entries.filter { it != AppLanguage.SYSTEM }.forEach { language ->
+            assertEquals(language, AppLanguage.fromStorage(language.storageValue))
+        }
+    }
+}

--- a/android/app/src/test/java/com/noop/ui/AppLanguageTest.kt
+++ b/android/app/src/test/java/com/noop/ui/AppLanguageTest.kt
@@ -11,6 +11,12 @@ class AppLanguageTest {
     }
 
     @Test
+    fun chineseCatalogTagIsSupported() {
+        assertEquals(AppLanguage.CHINESE, AppLanguage.fromStorage("zh"))
+        assertEquals("中文", AppLanguage.CHINESE.autonym)
+    }
+
+    @Test
     fun everyExplicitLanguageRoundTripsItsStableTag() {
         AppLanguage.entries.filter { it != AppLanguage.SYSTEM }.forEach { language ->
             assertEquals(language, AppLanguage.fromStorage(language.storageValue))


### PR DESCRIPTION
## What this PR does

Fixes mixed-language UI by applying the selected language consistently to localized copy and locale-sensitive formatting.

Adds an app-language setting on Apple and Android with:

- System default
- English
- Deutsch
- Español
- Français
- Português
- 中文

Apple preserves the device region while applying the selected UI language and requires reopening NOOP. Android applies the language immediately and updates its process locale, so locale-sensitive date order and number formatting may also change. Units and time zone remain independently configured.

## Type of change

- [x] Bug fix
- [x] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] CI / tooling

## How it was tested

- Added Apple and Android language-selection unit tests, including explicit coverage for the Chinese `zh` tag.
- `Tools/i18n_audit.py --ci origin/main` passes.
- All 36 localization-audit unit tests pass.
- `Tools/doc_comment_lint.py` passes.
- Verified localization catalogs parse and Android resource references resolve.
- `git diff --check` passes.
- Android unit tests could not run locally because the Android SDK is unavailable.
- Apple app tests could not run because this environment does not have Xcode.
- No BLE, protocol, or analytics behavior changed; hardware testing is not applicable.

## Checklist

- [x] Swift package tests pass for any package I touched (`swift test` in `Packages/<name>`) — not applicable; no package was touched
- [ ] Android unit tests pass if I touched `android/` — blocked locally by the missing Android SDK
- [ ] No new build warnings introduced — platform builds were unavailable
- [x] UI changes use only `StrandDesign` tokens — the restart note uses `NoopMetrics.space1`
- [x] No hardcoded hex frame bytes; protocol facts live in the schema / decoders
- [x] Follows the conventions in [`docs/CONTRIBUTING.md`](../docs/CONTRIBUTING.md)
- [x] I did not commit generated output (`Strand.xcodeproj/`) or any secrets/keystores

## Related issues

None
