### PR TITLE
DeepCapture test: name the set for what it actually asserts (#979)

### DIFF
--- a/Packages/WhoopProtocol/Tests/WhoopProtocolTests/DeepCaptureChannelsTests.swift
+++ b/Packages/WhoopProtocol/Tests/WhoopProtocolTests/DeepCaptureChannelsTests.swift
@@ -281,17 +281,24 @@ final class DeepCaptureChannelsTests: XCTestCase {
         XCTAssertNotNil(s.gravity.first?.dynAccel)
     }
 
-    /// Everything with an existing durable home is banked once, not twice.
-    func testNoSlotDuplicatesAnAlreadyPersistedField() {
-        let persistedElsewhere: Set<String> = [
+    /// Nothing already reachable from a banked field is banked a second time.
+    ///
+    /// The name matters (#979). Most of these ARE stored under their own column, but two are not:
+    /// `motion_wear_quality@63` is the same byte as `activity_class` under a second name, and
+    /// `spo2_candidate_82` is a gated 70-100 view of `auxByte82`. Neither is persisted in its own
+    /// right — both are RECOVERABLE from a byte that is, which is equally good grounds for refusing
+    /// to bank them and not the same claim. The old name asserted each "already has a durable home",
+    /// which reads as "SpO2 is being stored" and is not true.
+    func testNoSlotDuplicatesAFieldAlreadyReachable() {
+        let recoverableFromABankedField: Set<String> = [
             "unix", "heart_rate", "rr_intervals", "gravity_x", "gravity_y", "gravity_z",
             "dynamic_acceleration", "skin_temp_raw", "temp_aux_1_raw", "temp_aux_2_raw",
             "step_motion_counter", "activity_class", "motion_wear_quality", "sleep_state",
             "sleep_state_byte", "spo2_candidate_82", "ppg_waveform",
         ]
         for slot in V18AuxSlot.allCases {
-            XCTAssertFalse(persistedElsewhere.contains(slot.decoderKey),
-                           "\(slot.decoderKey) already has a durable home — banking it twice is waste")
+            XCTAssertFalse(recoverableFromABankedField.contains(slot.decoderKey),
+                           "\(slot.decoderKey) is already reachable from a banked field — banking it twice is waste")
         }
     }
 }

--- a/android/app/src/test/java/com/noop/protocol/DeepCaptureChannelsTest.kt
+++ b/android/app/src/test/java/com/noop/protocol/DeepCaptureChannelsTest.kt
@@ -298,9 +298,20 @@ class DeepCaptureChannelsTest {
         assertNotNull(s.gravity.single().dynAccel)
     }
 
+    /**
+     * Nothing already reachable from a banked field is banked a second time.
+     *
+     * The name matters (#979). Most of these ARE stored under their own column, but two are not:
+     * `motion_wear_quality@63` is the same byte as `activity_class` under a second name, and
+     * `spo2_candidate_82` is a gated 70-100 view of `auxByte82`. Neither is persisted in its own
+     * right — both are RECOVERABLE from a byte that is, which is equally good grounds for refusing to
+     * bank them and not the same claim. The old name asserted each "already has a durable home",
+     * which reads as "SpO2 is being stored" and is not true. Twin of the Swift
+     * `testNoSlotDuplicatesAFieldAlreadyReachable`.
+     */
     @Test
-    fun noSlotDuplicatesAnAlreadyPersistedField() {
-        val persistedElsewhere = setOf(
+    fun noSlotDuplicatesAFieldAlreadyReachable() {
+        val recoverableFromABankedField = setOf(
             "unix", "heart_rate", "rr_intervals", "gravity_x", "gravity_y", "gravity_z",
             "dynamic_acceleration", "skin_temp_raw", "temp_aux_1_raw", "temp_aux_2_raw",
             "step_motion_counter", "activity_class", "motion_wear_quality", "sleep_state",
@@ -308,8 +319,8 @@ class DeepCaptureChannelsTest {
         )
         for (slot in V18AuxSlot.entries) {
             assertFalse(
-                "${slot.decoderKey} already has a durable home — banking it twice is waste",
-                slot.decoderKey in persistedElsewhere,
+                "${slot.decoderKey} is already reachable from a banked field — banking it twice is waste",
+                slot.decoderKey in recoverableFromABankedField,
             )
         }
     }


### PR DESCRIPTION
From the first side note in #979.

`testNoSlotDuplicatesAnAlreadyPersistedField` checked a set called `persistedElsewhere`, and on failure told the reader the key "already has a durable home". **Two of its seventeen entries do not.**

- `motion_wear_quality@63` is the same byte as `activity_class` under a second name.
- `spo2_candidate_82` is a gated 70-100 view of `auxByte82`.

Neither is persisted in its own right. Both are **recoverable from** a byte that is — which is equally good grounds for refusing to bank them, and is not the same claim. `Streams.swift:401-404` already words it correctly ("is a gated 70-100 view of `auxByte82` and is recoverable from the raw byte"); only the test overstated.

It reads as "SpO2 is being stored", which it is not, and briefly convinced the reporter of exactly that while they were auditing what the decoder keeps.

## Both platforms

The Kotlin twin carried the identical set name and failure message. Neither the issue nor my first pass mentioned it — I found it by grepping for the old name after renaming the Swift side. Renaming one and not the other would leave the two suites asserting the same contract under different names, which is the drift the parity rule exists to stop.

## Behaviour is unchanged

Same set, same assertion, same slots, same pass/fail. What moves is the name, the failure message, and a comment recording why the distinction is worth keeping so it doesn't get "simplified" back.

## Verification

- `swiftc -parse` clean on `DeepCaptureChannelsTests.swift`.
- Kotlin twin syntax-checked; the only errors standalone are missing-module references, as expected outside a full classpath. Both suites run in CI (`test (WhoopProtocol)` and `build-and-test`).
- No reference to the old name remains on either platform.
- `Tools/doc_comment_lint.py` clean.

Separate from #1009 (the `tools/`→`Tools/` normalization) because they are different concerns, and separate from `burst_index`, which is vishk23's PR to send.
