### PR TITLE
Health Connect import: range-scan the kcal lists instead of walking them per workout

### DIFF
--- a/android/app/src/main/java/com/noop/ingest/HealthConnectImporter.kt
+++ b/android/app/src/main/java/com/noop/ingest/HealthConnectImporter.kt
@@ -418,9 +418,10 @@ object HealthConnectImporter {
             // of rows, so a first import paid that per workout. Now sorted once into a KcalIndex and
             // range-scanned per window — the fix the previous version of this comment nominated.
             // Sorted ONCE for the whole pass, not per workout: two O(n log n) sorts replace the
-            // O(workouts x records) walk the comment above describes.
-            val activeIndex = KcalIndex(activeKcalRecords)
-            val totalIndex = KcalIndex(totalKcalRecords)
+            // O(workouts x records) walk the comment above describes. LAZY because an import with no
+            // exercise sessions must not pay for two sorts of a ten-year record list to answer nothing.
+            val activeIndex by lazy(LazyThreadSafetyMode.NONE) { KcalIndex(activeKcalRecords) }
+            val totalIndex by lazy(LazyThreadSafetyMode.NONE) { KcalIndex(totalKcalRecords) }
             for (i in workouts.indices) {
                 val w = workouts[i]
                 if (w.endTs <= w.startTs) continue
@@ -1033,6 +1034,9 @@ object HealthConnectImporter {
      * arithmetic that decides a calorie figure is not worth duplicating for speed.
      */
     internal class KcalIndex(private val records: List<KcalRecord>) {
+        // NOTE: these three properties initialise in DECLARATION order and each reads the one above —
+        // maxLenS feeds usable, usable gates order. Reordering them would silently yield 0/false/empty
+        // rather than a compile error.
         private val maxLenS: Long = records.maxOfOrNull { it.endS - it.startS } ?: 0L
 
         /**
@@ -1051,18 +1055,32 @@ object HealthConnectImporter {
             span > 0L && maxLenS * 20L < span
         }
 
-        /** Start-sorted, but each entry remembers where it came from — see [sumInWindow]. Empty, and
-         *  never sorted, when [usable] is false. */
-        private val sorted: List<IndexedValue<KcalRecord>> =
-            if (usable) records.withIndex().sortedBy { it.value.startS } else emptyList()
+        /**
+         * Record indices ordered by start time. An `IntArray` rather than a sorted list of records or of
+         * `IndexedValue` wrappers: this runs on a phone mid-import over hundreds of thousands of rows,
+         * and the wrapper form allocates one object per record — megabytes of garbage to answer a few
+         * hundred queries. The indices double as the original ordering [sumInWindow] restores.
+         *
+         * Empty, and never sorted, when [usable] is false.
+         */
+        private val order: IntArray =
+            if (usable) {
+                IntArray(records.size) { it }.also { a ->
+                    // boxed sort once, unboxed thereafter — no comparator allocation per comparison
+                    val sortedIdx = a.toTypedArray().sortedBy { records[it].startS }
+                    for (i in sortedIdx.indices) a[i] = sortedIdx[i]
+                }
+            } else {
+                IntArray(0)
+            }
 
         /** First index whose `startS >= value`; `size` when none. Plain lower-bound bisection. */
         private fun lowerBound(value: Long): Int {
             var lo = 0
-            var hi = sorted.size
+            var hi = order.size
             while (lo < hi) {
                 val mid = (lo + hi) ushr 1
-                if (sorted[mid].value.startS < value) lo = mid + 1 else hi = mid
+                if (records[order[mid]].startS < value) lo = mid + 1 else hi = mid
             }
             return lo
         }
@@ -1089,7 +1107,9 @@ object HealthConnectImporter {
             // list is cheaper to walk than to sort. Either branch ends in the same sumKcalInWindow over
             // the same records, so the answer is identical and only the route changes.
             if ((hi - lo) * 20 > records.size) return sumKcalInWindow(records, startS, endS)
-            val slice = sorted.subList(lo, hi).sortedBy { it.index }.map { it.value }
+            // Sorting the indices ascending IS restoring the original order — they are positions in
+            // `records`. See the note above on why that matters for the arithmetic.
+            val slice = order.copyOfRange(lo, hi).sorted().map { records[it] }
             return sumKcalInWindow(slice, startS, endS)
         }
     }

--- a/android/app/src/main/java/com/noop/ingest/HealthConnectImporter.kt
+++ b/android/app/src/main/java/com/noop/ingest/HealthConnectImporter.kt
@@ -1066,7 +1066,12 @@ object HealthConnectImporter {
         private val order: IntArray =
             if (usable) {
                 IntArray(records.size) { it }.also { a ->
-                    // boxed sort once, unboxed thereafter — no comparator allocation per comparison
+                    // This DOES box, once, to get a comparator sort: what the IntArray buys is the
+                    // RETAINED footprint — the boxes and the temporary list are collectable the moment
+                    // this returns, whereas a sorted List<IndexedValue> would be held for the whole
+                    // import. A primitive sort-by-key would avoid the boxing too, but packing a start
+                    // time and an index into one Long assumes both stay inside 32 bits, and a
+                    // pre-1970 timestamp would break it silently. Not worth that for a one-off sort.
                     val sortedIdx = a.toTypedArray().sortedBy { records[it].startS }
                     for (i in sortedIdx.indices) a[i] = sortedIdx[i]
                 }

--- a/android/app/src/main/java/com/noop/ingest/HealthConnectImporter.kt
+++ b/android/app/src/main/java/com/noop/ingest/HealthConnectImporter.kt
@@ -1032,11 +1032,29 @@ object HealthConnectImporter {
      * proration and the empty/null behaviour are the same code, not a reimplementation of it. The window
      * arithmetic that decides a calorie figure is not worth duplicating for speed.
      */
-    internal class KcalIndex(records: List<KcalRecord>) {
-        /** Start-sorted, but each entry remembers where it came from — see [sumInWindow]. */
+    internal class KcalIndex(private val records: List<KcalRecord>) {
+        private val maxLenS: Long = records.maxOfOrNull { it.endS - it.startS } ?: 0L
+
+        /**
+         * Whether narrowing can narrow anything, decided ONCE here rather than per query.
+         *
+         * The lower bound reaches back by [maxLenS], so a single record spanning a large share of the
+         * corpus — a weekly or lifetime aggregate row, which providers do write — makes every slice the
+         * whole list. Sorting that per query is worse than the scan this replaces. When the longest
+         * record is not comfortably shorter than the whole span, the index simply is not built and
+         * every query goes straight to the original scan, so this can never cost more than it saves.
+         * A per-DAY coarse record, the common case the workoutKcal note describes, passes this easily.
+         */
+        private val usable: Boolean = run {
+            if (records.size < 2 || maxLenS <= 0L) return@run false
+            val span = (records.maxOf { it.endS }) - (records.minOf { it.startS })
+            span > 0L && maxLenS * 20L < span
+        }
+
+        /** Start-sorted, but each entry remembers where it came from — see [sumInWindow]. Empty, and
+         *  never sorted, when [usable] is false. */
         private val sorted: List<IndexedValue<KcalRecord>> =
-            records.withIndex().sortedBy { it.value.startS }
-        private val maxLenS: Long = sorted.maxOfOrNull { it.value.endS - it.value.startS } ?: 0L
+            if (usable) records.withIndex().sortedBy { it.value.startS } else emptyList()
 
         /** First index whose `startS >= value`; `size` when none. Plain lower-bound bisection. */
         private fun lowerBound(value: Long): Int {
@@ -1063,9 +1081,14 @@ object HealthConnectImporter {
          */
         fun sumInWindow(startS: Long, endS: Long): Double? {
             if (endS <= startS) return null
+            if (!usable) return sumKcalInWindow(records, startS, endS)
             val lo = lowerBound(startS - maxLenS)
             val hi = lowerBound(endS)
             if (hi <= lo) return null
+            // Second guard, for a WIDE window rather than a long record: a slice that is most of the
+            // list is cheaper to walk than to sort. Either branch ends in the same sumKcalInWindow over
+            // the same records, so the answer is identical and only the route changes.
+            if ((hi - lo) * 20 > records.size) return sumKcalInWindow(records, startS, endS)
             val slice = sorted.subList(lo, hi).sortedBy { it.index }.map { it.value }
             return sumKcalInWindow(slice, startS, endS)
         }

--- a/android/app/src/main/java/com/noop/ingest/HealthConnectImporter.kt
+++ b/android/app/src/main/java/com/noop/ingest/HealthConnectImporter.kt
@@ -1014,14 +1014,6 @@ object HealthConnectImporter {
     }
 
     /**
-     * Active-calorie kcal attributable to an exercise session: for every active-calorie record that
-     * overlaps [startS, endS], credit the kcal in proportion to the overlap fraction. Time-weighting
-     * (not a flat overlap test) means a per-minute record fully inside the session counts in full,
-     * while a day-spanning total record only contributes the session's slice — so neither under- nor
-     * grossly over-credits. Returns null when nothing overlaps, so an energy-less session stays blank
-     * rather than showing 0. (#117)
-     */
-    /**
      * A start-sorted view of a kcal record list, so a per-workout window query can RANGE-scan instead of
      * walking the whole list (#835 follow-up).
      *
@@ -1065,6 +1057,14 @@ object HealthConnectImporter {
         }
     }
 
+    /**
+     * Active-calorie kcal attributable to an exercise session: for every active-calorie record that
+     * overlaps [startS, endS], credit the kcal in proportion to the overlap fraction. Time-weighting
+     * (not a flat overlap test) means a per-minute record fully inside the session counts in full,
+     * while a day-spanning total record only contributes the session's slice — so neither under- nor
+     * grossly over-credits. Returns null when nothing overlaps, so an energy-less session stays blank
+     * rather than showing 0. (#117)
+     */
     internal fun sumKcalInWindow(
         records: List<KcalRecord>,
         startS: Long,
@@ -1086,25 +1086,6 @@ object HealthConnectImporter {
         return bySource.values.maxOrNull()?.takeIf { it > 0.0 }
     }
 
-    /**
-     * #835 — a workout's active kcal, taking the BEST of the two energy streams Health Connect exposes
-     * rather than only `ActiveCaloriesBurned`.
-     *
-     * Two ways the Active-only credit came out too low:
-     *  - the session's source writes `TotalCaloriesBurned` and no Active at all, so the workout was
-     *    credited only with whatever unrelated background Active happened to overlap it;
-     *  - the only Active cover is a COARSE record (one per day is common), and prorating it by time
-     *    assumes calories burn uniformly — a hard hour inside a 24 h record reads as 1/24 of the day.
-     *
-     * So also derive a candidate from Total: prorated Total over the window, minus the window's share of
-     * the day's basal burn ([dayBasalKcal] spread evenly over 24 h — basal genuinely IS near-uniform, so
-     * prorating THAT is sound in a way prorating a workout's active burn is not). Take whichever estimate
-     * is larger: a stray background record is small, real session coverage is not, so the max picks the
-     * stream that actually resolves this session without needing a threshold. Where both streams cover it
-     * properly they agree, and the max is a no-op.
-     *
-     * Returns null when neither stream yields anything positive — no fabricated number.
-     */
     /**
      * Index-backed twin of [workoutKcal] for the per-workout post-pass (#835 follow-up). Same
      * arithmetic — it differs only in how the two windows are gathered. The list-taking overload below
@@ -1129,6 +1110,25 @@ object HealthConnectImporter {
         return listOfNotNull(fromActive, fromTotal).maxOrNull()?.takeIf { it > 0.0 }
     }
 
+    /**
+     * #835 — a workout's active kcal, taking the BEST of the two energy streams Health Connect exposes
+     * rather than only `ActiveCaloriesBurned`.
+     *
+     * Two ways the Active-only credit came out too low:
+     *  - the session's source writes `TotalCaloriesBurned` and no Active at all, so the workout was
+     *    credited only with whatever unrelated background Active happened to overlap it;
+     *  - the only Active cover is a COARSE record (one per day is common), and prorating it by time
+     *    assumes calories burn uniformly — a hard hour inside a 24 h record reads as 1/24 of the day.
+     *
+     * So also derive a candidate from Total: prorated Total over the window, minus the window's share of
+     * the day's basal burn ([dayBasalKcal] spread evenly over 24 h — basal genuinely IS near-uniform, so
+     * prorating THAT is sound in a way prorating a workout's active burn is not). Take whichever estimate
+     * is larger: a stray background record is small, real session coverage is not, so the max picks the
+     * stream that actually resolves this session without needing a threshold. Where both streams cover it
+     * properly they agree, and the max is a no-op.
+     *
+     * Returns null when neither stream yields anything positive — no fabricated number.
+     */
     internal fun workoutKcal(
         activeRecords: List<KcalRecord>,
         totalRecords: List<KcalRecord>,

--- a/android/app/src/main/java/com/noop/ingest/HealthConnectImporter.kt
+++ b/android/app/src/main/java/com/noop/ingest/HealthConnectImporter.kt
@@ -1033,8 +1033,10 @@ object HealthConnectImporter {
      * arithmetic that decides a calorie figure is not worth duplicating for speed.
      */
     internal class KcalIndex(records: List<KcalRecord>) {
-        private val sorted: List<KcalRecord> = records.sortedBy { it.startS }
-        private val maxLenS: Long = sorted.maxOfOrNull { it.endS - it.startS } ?: 0L
+        /** Start-sorted, but each entry remembers where it came from — see [sumInWindow]. */
+        private val sorted: List<IndexedValue<KcalRecord>> =
+            records.withIndex().sortedBy { it.value.startS }
+        private val maxLenS: Long = sorted.maxOfOrNull { it.value.endS - it.value.startS } ?: 0L
 
         /** First index whose `startS >= value`; `size` when none. Plain lower-bound bisection. */
         private fun lowerBound(value: Long): Int {
@@ -1042,18 +1044,30 @@ object HealthConnectImporter {
             var hi = sorted.size
             while (lo < hi) {
                 val mid = (lo + hi) ushr 1
-                if (sorted[mid].startS < value) lo = mid + 1 else hi = mid
+                if (sorted[mid].value.startS < value) lo = mid + 1 else hi = mid
             }
             return lo
         }
 
-        /** Byte-identical to `sumKcalInWindow(allRecords, startS, endS)`, over a narrowed slice. */
+        /**
+         * Bit-identical to `sumKcalInWindow(allRecords, startS, endS)`, over a narrowed slice.
+         *
+         * The slice is restored to the ORIGINAL record order before delegating, which is not
+         * fussiness: `sumKcalInWindow` accumulates each source with `+`, and floating-point addition
+         * is not associative, so summing the same records start-sorted rather than as-read moves the
+         * result by an ULP or two. Measured on an adversarial corpus, 104 of 595 windows differed by
+         * up to 1.8e-15 before this line existed. `round1` downstream would have absorbed all of it,
+         * but "same numbers as the scan" is a claim worth being literally true rather than nearly
+         * true — the slice is a handful of records, so re-ordering it costs nothing next to the
+         * hundreds of thousands of rows this avoids walking.
+         */
         fun sumInWindow(startS: Long, endS: Long): Double? {
             if (endS <= startS) return null
             val lo = lowerBound(startS - maxLenS)
             val hi = lowerBound(endS)
             if (hi <= lo) return null
-            return sumKcalInWindow(sorted.subList(lo, hi), startS, endS)
+            val slice = sorted.subList(lo, hi).sortedBy { it.index }.map { it.value }
+            return sumKcalInWindow(slice, startS, endS)
         }
     }
 

--- a/android/app/src/main/java/com/noop/ingest/HealthConnectImporter.kt
+++ b/android/app/src/main/java/com/noop/ingest/HealthConnectImporter.kt
@@ -413,11 +413,14 @@ object HealthConnectImporter {
             // session that already had a good Active credit keeps it (the estimate is a max, not a
             // replacement).
             //
-            // Cost: two record-list scans per workout, O(workouts × kcal records). That shape is
-            // pre-existing — the old construction-time call scanned the Active list the same way. This
-            // adds the Total list and drops the now-redundant construction scan, so it is 2 scans where
-            // it was 1, not 3. Fine at realistic sizes; if a multi-year import ever makes it hurt, sort
-            // both lists by start and range-scan rather than filtering the whole list each time.
+            // Cost: was two FULL record-list scans per workout, O(workouts × kcal records). At
+            // WINDOW_YEARS = 10 and ~15-minute provider buckets each list runs to hundreds of thousands
+            // of rows, so a first import paid that per workout. Now sorted once into a KcalIndex and
+            // range-scanned per window — the fix the previous version of this comment nominated.
+            // Sorted ONCE for the whole pass, not per workout: two O(n log n) sorts replace the
+            // O(workouts x records) walk the comment above describes.
+            val activeIndex = KcalIndex(activeKcalRecords)
+            val totalIndex = KcalIndex(totalKcalRecords)
             for (i in workouts.indices) {
                 val w = workouts[i]
                 if (w.endTs <= w.startTs) continue
@@ -425,7 +428,7 @@ object HealthConnectImporter {
                 val dayBasal = day?.let {
                     basalKcal(maxSourceDouble(it.totalKcalBySource), maxSourceDouble(it.activeKcalBySource))
                 }
-                val better = workoutKcal(activeKcalRecords, totalKcalRecords, dayBasal, w.startTs, w.endTs)
+                val better = workoutKcal(activeIndex, totalIndex, dayBasal, w.startTs, w.endTs)
                 if (better != null) workouts[i] = w.copy(energyKcal = round1(better))
             }
 
@@ -1018,6 +1021,50 @@ object HealthConnectImporter {
      * grossly over-credits. Returns null when nothing overlaps, so an energy-less session stays blank
      * rather than showing 0. (#117)
      */
+    /**
+     * A start-sorted view of a kcal record list, so a per-workout window query can RANGE-scan instead of
+     * walking the whole list (#835 follow-up).
+     *
+     * The post-pass calls [sumKcalInWindow] twice per workout, and each call scanned every record in the
+     * import window. `WINDOW_YEARS` is 10 and providers write these in ~15-minute buckets, so each list
+     * runs to hundreds of thousands of rows: the shape is O(workouts x records), which the original
+     * comment flagged as "fine at realistic sizes; if a multi-year import ever makes it hurt, sort both
+     * lists by start and range-scan". This is that.
+     *
+     * Correctness rests on one bound: a record overlaps `[startS, endS)` only if it STARTS before `endS`
+     * and ENDS after `startS`. Sorted by start, the first is a binary search. The second needs a floor,
+     * and [maxLenS] supplies it — no record can reach further back than the longest one in the list. The
+     * resulting slice is therefore a SUPERSET of the overlapping records, never a subset.
+     *
+     * It then hands that slice to [sumKcalInWindow] unchanged, so the per-source max, the partial-overlap
+     * proration and the empty/null behaviour are the same code, not a reimplementation of it. The window
+     * arithmetic that decides a calorie figure is not worth duplicating for speed.
+     */
+    internal class KcalIndex(records: List<KcalRecord>) {
+        private val sorted: List<KcalRecord> = records.sortedBy { it.startS }
+        private val maxLenS: Long = sorted.maxOfOrNull { it.endS - it.startS } ?: 0L
+
+        /** First index whose `startS >= value`; `size` when none. Plain lower-bound bisection. */
+        private fun lowerBound(value: Long): Int {
+            var lo = 0
+            var hi = sorted.size
+            while (lo < hi) {
+                val mid = (lo + hi) ushr 1
+                if (sorted[mid].startS < value) lo = mid + 1 else hi = mid
+            }
+            return lo
+        }
+
+        /** Byte-identical to `sumKcalInWindow(allRecords, startS, endS)`, over a narrowed slice. */
+        fun sumInWindow(startS: Long, endS: Long): Double? {
+            if (endS <= startS) return null
+            val lo = lowerBound(startS - maxLenS)
+            val hi = lowerBound(endS)
+            if (hi <= lo) return null
+            return sumKcalInWindow(sorted.subList(lo, hi), startS, endS)
+        }
+    }
+
     internal fun sumKcalInWindow(
         records: List<KcalRecord>,
         startS: Long,
@@ -1058,6 +1105,30 @@ object HealthConnectImporter {
      *
      * Returns null when neither stream yields anything positive — no fabricated number.
      */
+    /**
+     * Index-backed twin of [workoutKcal] for the per-workout post-pass (#835 follow-up). Same
+     * arithmetic — it differs only in how the two windows are gathered. The list-taking overload below
+     * stays as the reference the unit tests pin.
+     */
+    internal fun workoutKcal(
+        activeIndex: KcalIndex,
+        totalIndex: KcalIndex,
+        dayBasalKcal: Double?,
+        startS: Long,
+        endS: Long,
+    ): Double? {
+        if (endS <= startS) return null
+        val fromActive = activeIndex.sumInWindow(startS, endS)
+        val totalInWindow = totalIndex.sumInWindow(startS, endS)
+        val fromTotal = if (totalInWindow != null && dayBasalKcal != null) {
+            val basalShare = dayBasalKcal * ((endS - startS).toDouble() / 86_400.0)
+            (totalInWindow - basalShare).takeIf { it > 0.0 }
+        } else {
+            totalInWindow
+        }
+        return listOfNotNull(fromActive, fromTotal).maxOrNull()?.takeIf { it > 0.0 }
+    }
+
     internal fun workoutKcal(
         activeRecords: List<KcalRecord>,
         totalRecords: List<KcalRecord>,

--- a/android/app/src/test/java/com/noop/ingest/HealthConnectKcalIndexTest.kt
+++ b/android/app/src/test/java/com/noop/ingest/HealthConnectKcalIndexTest.kt
@@ -51,7 +51,8 @@ class HealthConnectKcalIndexTest {
                 if (expected == null) {
                     assertNull("window [$start, ${start + width}) width=$width", actual)
                 } else {
-                    assertEquals("window [$start, ${start + width}) width=$width", expected, actual!!, 1e-9)
+                    // delta 0.0 — bit-exact, not merely close. See bitExactnessSurvivesUnsortedInput.
+                    assertEquals("window [$start, ${start + width}) width=$width", expected, actual!!, 0.0)
                 }
                 checked += 1
                 start += 137L                                        // prime-ish stride, avoids aligning with record starts
@@ -73,7 +74,7 @@ class HealthConnectKcalIndexTest {
         )
         val index = KcalIndex(recs)
         val expected = sumKcalInWindow(recs, 80_000, 80_600)
-        assertEquals(expected!!, index.sumInWindow(80_000, 80_600)!!, 1e-9)
+        assertEquals(expected!!, index.sumInWindow(80_000, 80_600)!!, 0.0)
     }
 
     /** Degenerate inputs must behave exactly as the scan does, including the null cases. */
@@ -88,6 +89,50 @@ class HealthConnectKcalIndexTest {
         assertNull("inverted window", index.sumInWindow(900, 500))
         assertNull("entirely before the corpus", index.sumInWindow(-9_000, -8_000))
         assertNull("entirely after the corpus", index.sumInWindow(500_000, 510_000))
+    }
+
+    /**
+     * Bit-exactness, on input whose insertion order is deliberately NOT its sorted order.
+     *
+     * `sumKcalInWindow` accumulates each source with `+`, and floating-point addition is not
+     * associative — so a slice summed in start-sorted order rather than as-read drifts by an ULP or
+     * two. Before [KcalIndex] restored the original order within its slice, 104 of 595 windows on this
+     * corpus differed by up to 1.8e-15. `round1` downstream would have swallowed every one of them,
+     * which is exactly why it needs a test: nothing else in the app would ever have noticed the index
+     * quietly ceasing to be equivalent.
+     */
+    @Test fun bitExactnessSurvivesUnsortedInput() {
+        val recs = ArrayList<KcalRecord>()
+        var t = 30_000L
+        for (i in 0 until 4_000) {
+            recs.add(
+                KcalRecord(
+                    startS = t,
+                    endS = t + 700 + (i % 5) * 130L,
+                    kcal = 0.1 + (i % 9) * 0.037,          // not representable in binary
+                    source = if (i % 2 == 0) "a" else "b", // two sources, so the MAX-source rule bites
+                ),
+            )
+            t -= 7L * (i % 11 + 1)                          // descending: insertion order != sorted order
+            if (i % 3 == 0) t += 900
+        }
+        val index = KcalIndex(recs)
+        var compared = 0
+        var s = 0L
+        while (s < 40_000L) {
+            for (w in listOf(600L, 3_600L, 20_000L)) {
+                val expected = sumKcalInWindow(recs, s, s + w)
+                val actual = index.sumInWindow(s, s + w)
+                if (expected == null) {
+                    assertNull("window [$s, ${s + w})", actual)
+                } else {
+                    assertEquals("window [$s, ${s + w})", expected, actual!!, 0.0)  // exact
+                    compared += 1
+                }
+            }
+            s += 91L
+        }
+        assert(compared > 400) { "expected a broad sweep, compared only $compared" }
     }
 
     /** A record that ends exactly where the window begins does not overlap it — on both paths. */

--- a/android/app/src/test/java/com/noop/ingest/HealthConnectKcalIndexTest.kt
+++ b/android/app/src/test/java/com/noop/ingest/HealthConnectKcalIndexTest.kt
@@ -135,6 +135,38 @@ class HealthConnectKcalIndexTest {
         assert(compared > 400) { "expected a broad sweep, compared only $compared" }
     }
 
+    /**
+     * The guard against the index being SLOWER than the scan it replaces.
+     *
+     * The lower bound reaches back by the longest record's span, so one record covering the whole
+     * corpus — a weekly or lifetime aggregate row, which providers do write — makes every slice the
+     * entire list. Sorting that per query measured **931 ms against the scan's 113 ms** before the
+     * guard existed: an eightfold regression from an optimisation.
+     *
+     * `KcalIndex` now declines to build itself in that case and routes every query to the scan, which
+     * benchmarks at parity. This test pins the CORRECTNESS of that route — the results must still be
+     * bit-identical, because it is a different code path through the same class.
+     */
+    @Test fun aCorpusSpanningRecordFallsBackWithoutChangingResults() {
+        val recs = ArrayList<KcalRecord>()
+        var t = 0L
+        for (i in 0 until 2_000) { recs.add(KcalRecord(t, t + 900, 12.0, "watch")); t += 900 }
+        recs.add(KcalRecord(0, t, 100.0, "phone"))   // spans the entire corpus
+        val index = KcalIndex(recs)
+        var compared = 0
+        var s = 0L
+        while (s < t) {
+            val expected = sumKcalInWindow(recs, s, s + 3_600)
+            val actual = index.sumInWindow(s, s + 3_600)
+            if (expected == null) assertNull(actual) else {
+                assertEquals("window [$s, ${s + 3_600})", expected, actual!!, 0.0)   // exact
+                compared += 1
+            }
+            s += 45_000L
+        }
+        assert(compared > 20) { "expected a real sweep, compared only $compared" }
+    }
+
     /** A record that ends exactly where the window begins does not overlap it — on both paths. */
     @Test fun touchingBoundariesDoNotOverlap() {
         val recs = listOf(KcalRecord(startS = 0, endS = 100, kcal = 50.0, source = "phone"))

--- a/android/app/src/test/java/com/noop/ingest/HealthConnectKcalIndexTest.kt
+++ b/android/app/src/test/java/com/noop/ingest/HealthConnectKcalIndexTest.kt
@@ -1,0 +1,100 @@
+package com.noop.ingest
+
+import com.noop.ingest.HealthConnectImporter.KcalIndex
+import com.noop.ingest.HealthConnectImporter.KcalRecord
+import com.noop.ingest.HealthConnectImporter.sumKcalInWindow
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * #835 follow-up — [KcalIndex] range-scans instead of walking every record per workout.
+ *
+ * The post-pass called `sumKcalInWindow` twice per workout and each call scanned the whole import
+ * window. At `WINDOW_YEARS = 10` with ~15-minute provider buckets that is hundreds of thousands of
+ * rows, per workout, on a first import.
+ *
+ * The optimisation is only worth having if it is INDISTINGUISHABLE from the scan it replaces, so these
+ * assert equality against the original function rather than against hand-computed figures. The scan is
+ * the oracle; the index is the thing on trial.
+ */
+class HealthConnectKcalIndexTest {
+
+    /** Deterministic, overlapping, multi-source records — no randomness, so a failure reproduces. */
+    private fun corpus(): List<KcalRecord> {
+        val out = ArrayList<KcalRecord>()
+        var t = 0L
+        var i = 0
+        while (t < 40_000L) {
+            val src = if (i % 3 == 0) "phone" else "watch"          // two sources, so the MAX-source rule bites
+            val len = when (i % 4) { 0 -> 900L; 1 -> 300L; 2 -> 1_200L; else -> 60L }
+            out.add(KcalRecord(startS = t, endS = t + len, kcal = 10.0 + (i % 7), source = src))
+            t += 450L                                               // deliberate overlap between neighbours
+            i += 1
+        }
+        return out
+    }
+
+    /**
+     * The equivalence proof. Every window, against the full-scan oracle. Windows are swept across the
+     * corpus at several widths so partial overlaps, full containment and empty regions are all covered.
+     */
+    @Test fun indexMatchesTheFullScanOnEveryWindow() {
+        val recs = corpus()
+        val index = KcalIndex(recs)
+        var checked = 0
+        for (width in listOf(1L, 60L, 900L, 3_600L, 10_000L)) {
+            var start = -5_000L
+            while (start < 45_000L) {
+                val expected = sumKcalInWindow(recs, start, start + width)
+                val actual = index.sumInWindow(start, start + width)
+                if (expected == null) {
+                    assertNull("window [$start, ${start + width}) width=$width", actual)
+                } else {
+                    assertEquals("window [$start, ${start + width}) width=$width", expected, actual!!, 1e-9)
+                }
+                checked += 1
+                start += 137L                                        // prime-ish stride, avoids aligning with record starts
+            }
+        }
+        // Guard against a future edit silently emptying the sweep and leaving this green on zero windows.
+        assert(checked > 1_000) { "expected a broad sweep, checked only $checked" }
+    }
+
+    /**
+     * The bound the index rests on: a record far LONGER than its neighbours must still be found from a
+     * window that starts well after it began. This is what `maxLenS` exists for — with a naive
+     * "start >= windowStart" search it would be missed entirely.
+     */
+    @Test fun aLongRecordIsFoundFromAWindowStartingInsideIt() {
+        val recs = listOf(
+            KcalRecord(startS = 0, endS = 86_400, kcal = 864.0, source = "phone"),   // a whole-day record
+            KcalRecord(startS = 80_000, endS = 80_600, kcal = 10.0, source = "watch"),
+        )
+        val index = KcalIndex(recs)
+        val expected = sumKcalInWindow(recs, 80_000, 80_600)
+        assertEquals(expected!!, index.sumInWindow(80_000, 80_600)!!, 1e-9)
+    }
+
+    /** Degenerate inputs must behave exactly as the scan does, including the null cases. */
+    @Test fun emptyAndDegenerateWindowsMatchTheScan() {
+        val empty = KcalIndex(emptyList())
+        assertNull(empty.sumInWindow(0, 100))
+        assertNull(sumKcalInWindow(emptyList(), 0, 100))
+
+        val recs = corpus()
+        val index = KcalIndex(recs)
+        assertNull("zero-width window", index.sumInWindow(500, 500))
+        assertNull("inverted window", index.sumInWindow(900, 500))
+        assertNull("entirely before the corpus", index.sumInWindow(-9_000, -8_000))
+        assertNull("entirely after the corpus", index.sumInWindow(500_000, 510_000))
+    }
+
+    /** A record that ends exactly where the window begins does not overlap it — on both paths. */
+    @Test fun touchingBoundariesDoNotOverlap() {
+        val recs = listOf(KcalRecord(startS = 0, endS = 100, kcal = 50.0, source = "phone"))
+        val index = KcalIndex(recs)
+        assertNull(sumKcalInWindow(recs, 100, 200))
+        assertNull(index.sumInWindow(100, 200))
+    }
+}


### PR DESCRIPTION
The one optimisation the code nominated for itself.

## What was slow

The #835 calorie post-pass called `sumKcalInWindow` **twice per workout**, and each call walked *every* record in the import window:

```kotlin
for (r in records) { ... }   // the whole 10-year list, per workout, twice
```

`WINDOW_YEARS` is 10 and providers write calories in ~15-minute buckets, so each list runs to hundreds of thousands of rows. The original comment named both the shape and the fix: *"O(workouts × kcal records) … if a multi-year import ever makes it hurt, sort both lists by start and range-scan rather than filtering the whole list each time."* This is that.

## Measured

Desktop JVM, 350,400 records and 1,500 workouts — one list:

```
full scan   : 423 ms
index build :  50 ms   (once)
index query :   8 ms
bit-exact vs the scan: yes
```

**423 ms → 58 ms.** The real import does this for two lists, and a phone is several times slower than this JVM, so call it a few seconds saved on a first multi-year import. Worth having, and smaller than I first guessed — see the note at the end.

## Why it is safe

Correctness rests on one bound: a record overlaps `[start, end)` only if it **starts** before `end` and **ends** after `start`. Sorted by start, the first is a binary search. The second needs a floor, and the longest record in the list supplies one — nothing can reach further back than that. The slice is therefore a **superset** of the overlapping records, never a subset.

The index then hands that slice to `sumKcalInWindow` **unchanged**. The per-source max (#835), the partial-overlap proration and the empty/null behaviour are the same code, not a reimplementation. The arithmetic that decides a calorie figure is not worth duplicating for speed.

## Verification

- **The existing 15-test `HealthConnectActiveKcalTest` passes unmodified.** It pins `sumKcalInWindow`, which this does not touch — that is the equivalence net, and I kept the list-taking `workoutKcal` overload precisely so it stays valid.
- **The new suite treats the full scan as an oracle**, not hand-computed figures: it sweeps windows of five widths across the corpus at a prime-ish stride and asserts index == scan on every one, with a floor assertion so a future edit cannot empty the sweep and stay green. Plus the long-record case that the `maxLenS` floor exists for, degenerate/empty windows, and exact-boundary touching.
- Checked for **overload ambiguity** against the existing suite rather than assuming: no error, 15/15 still green.
- Kotlin: full `src/main/java` compile against a `main` worktree — **2517 errors both sides, 0 in this file**, error sets identical.
- `Tools/doc_comment_lint.py` clean.

## Correcting my own estimate

When I proposed this I guessed the scan was worth minutes. Measured, it is closer to a second per list on a desktop. The estimate was wrong in the same direction twice, so it is worth stating plainly: **the per-workout scans are the smaller half of this import's cost.**

The larger half is almost certainly the **two `readAll` calls per workout** — the #77 HR fill and the #215 distance fill — each a paginated cross-process query to Health Connect. At 1,500 workouts that is ~3,000 IPC round-trips, which no amount of in-process sorting touches.

I have not fixed those here, deliberately. The clean fix is to read `ExerciseSessionRecord` **before** the full-range `HeartRateRecord` pass and accumulate per-workout HR during the stream that already runs — eliminating those queries entirely rather than batching them. That reorders reads on the import path, and I cannot exercise it against a real Health Connect store from here. It deserves its own PR and someone's device, not a ride-along with a change that is provably equivalent.


## Re-review: "identical results" was not literally true

The benchmark printed `identical results: true` because it compared with a `1e-6` tolerance, and the sweep asserted with `1e-9`. Neither was exactness.

`sumKcalInWindow` accumulates each source with `+`, and floating-point addition is **not associative** — so summing a slice in start-sorted order rather than as-read moves the answer. Measured on an adversarial corpus (insertion order deliberately not sorted order, kcal values not representable in binary): **104 of 595 windows differed, by up to 1.8e-15**.

Nothing in the app would ever have surfaced that. `round1()` absorbs a delta that size before the figure is stored, and both my assertions were looser than the effect. That is precisely what makes it worth fixing rather than documenting — an equivalence that only holds to within a tolerance nobody checks is one that can quietly stop holding.

The slice is now restored to its original record order before delegating. **595/595 bit-exact, max delta 0.0.** It costs 8 ms instead of 4 ms across 1,500 queries — 4 ms against a 365 ms saving.

The sweep now asserts with `delta 0.0`, and a new test pins exactness on the adversarial corpus specifically. That test is the only thing that would notice the index silently ceasing to be equivalent.

Suites after the change: **5 + 15 green**, Kotlin still 2517/0 against main, doc lint clean.


## Second re-review: the index could be 8x SLOWER than the scan

The lower bound reaches back by the longest record's span. So **one** record covering a large share of the corpus makes every slice the whole list — and sorting that per query is O(n log n) against the O(n) scan it replaced.

Measured on a corpus with one such record: **931 ms against the scan's 113 ms.** An eightfold regression, from an optimisation, and my benchmark would never have shown it because it used uniform 15-minute buckets.

Not exotic input either. The `workoutKcal` note already records that providers write COARSE aggregate rows. A per-day one is harmless here — it only reaches the bound back a day, leaving a slice of ~96 records. A weekly or lifetime row is not.

`KcalIndex` now decides **once, at construction**, whether narrowing can narrow anything. When it cannot, it does not sort at all and every query goes straight to the original scan. Warm-up-corrected, that corpus now benchmarks at parity:

```
round  scan  index
  1     127    128
  2     132    129
  3     141    129
  4     128    123
```

A second guard covers the other shape — a wide *window* rather than a long record.

The normal case is unchanged (421 ms → 65 ms) and still 595/595 bit-exact. The new test pins the fallback route's **correctness**, not its speed: it is a different path through the same class, and must still return bit-identical figures.

Suites: **6 + 15 green.** Kotlin 2517/0 against main. Doc lint clean.

## Parity

None required, and not an omission. There is no Swift twin of `sumKcalInWindow` or `workoutKcal`, because `HKWorkout` carries its own `totalEnergyBurned` (`HealthKitBridge.swift:1073`) while Health Connect's `ExerciseSessionRecord` carries no energy at all — which is why the #835 attribution machinery exists only on Android. Stored `energyKcal` semantics are unchanged on both platforms, so the byte-identical contract is untouched.


## Third re-review: nits and one near-miss

None of these changed an answer, but two were real regressions against `main`:

- **The index was built unconditionally.** An import with no exercise sessions paid two sorts of a ten-year record list to answer nothing. Both are now `lazy(NONE)` — the import is single-threaded — so a workout-less import does no sorting at all.
- **`withIndex().sortedBy {}` allocated one `IndexedValue` per record.** On the 350k corpus that is megabytes of garbage on a phone mid-import, to serve a few hundred queries. Replaced with an `IntArray` of record indices, which doubles as the original ordering the slice restores. Query time incidentally fell from 9 ms to 3 ms.
- **`maxLenS`, `usable` and `order` initialise in declaration order**, each reading the one above. Reordering them yields `0`/`false`/empty silently rather than a compile error, so that is now written down beside them.

The rename caught something: `lowerBound` still read `sorted.size`, which — because the property was gone — resolved to the stdlib `sorted` **extension function** rather than failing outright. Four compile errors, found and fixed before committing. Worth noting as the kind of thing a rename can hide when a stdlib name collides with a property name.

Final: normal **458 ms → 71 ms**, pathological at parity, **595/595 bit-exact**, 6 + 15 tests green, Kotlin 2517/0 against main.
