### PR TITLE
BLE: shorten the connection interval for the WHOOP 4.0 connect handshake (#477 follow-up)

### DIFF
--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -1672,6 +1672,38 @@ class WhoopBleClient(
         }
     }
 
+    /**
+     * Escalate to HIGH for the connect handshake (#477 follow-up).
+     *
+     * The handshake is a burst of writes-with-response — version/hello, both SET_CLOCK forms, both
+     * GET_CLOCK forms, stop-raw, get-range — and every one pays a full connection interval. BALANCED is
+     * roughly 30-50 ms against HIGH's 7.5-15 ms, so the burst is where a shorter interval buys the most
+     * and costs the least: it lasts seconds, not hours.
+     *
+     * Placed AFTER `requestMtu` and service discovery deliberately. Three separate hardware-learned
+     * incidents record the same hazard — #85/#50 (MTU before discovery/subscribe), #241 (the RSSI read
+     * deferred 3 s), #533 (2M PHY moved to offload start) — all of them: an extra GATT op BEFORE
+     * `requestMtu` can make it return false, silently capping the offload. This sits past that point.
+     * `requestConnectionPriority` is also an L2CAP parameter update rather than an ATT operation, so it
+     * should not occupy the single-op slot at all; "should not" is why this ships behind the same gate.
+     *
+     * Nothing restores BALANCED here on purpose: the connect-time offload calls
+     * [refreshConnectionPriority] a beat later, which recomputes from the real policy. Worst case the
+     * link holds HIGH for a second longer than needed.
+     *
+     * Swallowed rather than routed through `safeGatt`, same policy as [refreshConnectionPriority]: a
+     * priority HINT must never tear the link down.
+     */
+    private fun escalateConnectionPriorityForHandshake() {
+        if (!connectionPriorityEnabled) return
+        val ops = gattOps ?: return
+        try {
+            ops.requestConnectionPriorityCompat(BluetoothGatt.CONNECTION_PRIORITY_HIGH)
+        } catch (t: Throwable) {
+            log("handshake connection-priority request failed (${t.javaClass.simpleName}); skipped")
+        }
+    }
+
     /** #533: hand the link back to the stack default (BALANCED) when connection-priority management is
      *  switched off, undoing any escalation still in force. Same swallow-don't-teardown policy as
      *  [refreshConnectionPriority]: a priority hint must never drop the link. */
@@ -5394,6 +5426,9 @@ class WhoopBleClient(
         // firmware-load opcodes. Pick the family-appropriate one; a strap silently ignores the command
         // meant for the other generation. The response decodes to fw_harvard (4.0) / fw_version (5/MG)
         // in Framing.
+        // #477 follow-up: shorten the interval for the write-with-response burst below. No-op unless
+        // connection-priority management is enabled, which it is not by default — see the helper.
+        escalateConnectionPriorityForHandshake()
         when (connectedFamily) {
             DeviceFamily.WHOOP4 -> send(CommandNumber.REPORT_VERSION_INFO)
             DeviceFamily.WHOOP5 -> send(CommandNumber.GET_HELLO)


### PR DESCRIPTION
Follow-up to #477. Twelve lines, one call site, and it ships dormant.

## What

The connect handshake is a burst of writes-with-response — version/hello, both `SET_CLOCK` forms, both `GET_CLOCK` forms, stop-raw, get-range — and every one pays a full connection interval. BALANCED is roughly **30–50 ms** against HIGH's **7.5–15 ms**.

The offload burst already escalates to HIGH via `offloadActive`. Live HR deliberately does not (#533 — an overnight stream would hold it for hours and gains nothing). **The handshake was the one uncovered stretch**, and it is the case that most wants a short interval and least minds the cost: it lasts seconds.

## It cannot execute today

Gated on `connectionPriorityEnabled`, the same flag as the rest of #477 — which is **default off** and, by its own comment, *"not yet wired to a persisted Settings toggle"*. So this issues **zero new BLE ops for anyone** until that gate opens after on-strap validation.

That is the point: it joins #477's existing validation queue rather than opening a new risk surface. When someone validates #477 on hardware, this is validated with it.

## The hazard, and why the placement is what it is

I argued against this change before checking that gate, on the strength of three hardware-learned incidents that all say the same thing:

- **#85/#50** — request the MTU *before* discovery/subscribe, with discovery gated on the result
- **#241** — the RSSI read is deferred **3 seconds**: *"Android runs ONE GATT op at a time, so reading RSSI here (before requestMtu) could make requestMtu return false → MTU skipped → offload capped"*
- **#533** — the 2M PHY is requested at offload start, not connect, *"ON PURPOSE: the connect handshake is fragile"*

The call therefore sits **after `requestMtu` and after service discovery**, past the documented danger point. `requestConnectionPriority` is also an L2CAP parameter update rather than an ATT operation, so it should not occupy the single-op slot at all — but "should not" is exactly why it stays behind the gate rather than shipping live.

## Deliberately absent

- **No restore.** The connect-time offload calls `refreshConnectionPriority()` a beat later and recomputes from the real policy. Worst case the link holds HIGH a second longer than needed.
- **No new state.** An earlier draft added a `handshakeActive` flag and threaded it through `connectionPriorityFor`. That meant new state to get wrong on reconnect and teardown, and a changed signature on a pure function with existing tests. This version touches neither.

## Verification

- Kotlin: full `src/main/java` compile against a `main` worktree — **2517 errors both sides, 128 in this file both sides**, error sets byte-identical. No new errors.
- `Tools/doc_comment_lint.py` clean.
- **No unit test, deliberately.** There is nothing here a JVM test can assert: the branch is a one-line gate and the effect is a radio parameter. `connectionPriorityFor` is untouched, so its existing tests still cover the policy this does not change.

## What it needs before the gate is ever opened

CLAUDE.md is explicit that BLE behaviour cannot be CI- or Linux-tested and must be validated on a real strap. For this specifically, on a 4.0 **and** a 5/MG:

- connect/reconnect cycles with no `requestMtu rejected` in the strap log — that is the silent failure mode
- offload throughput unchanged or better afterwards, since a capped MTU shows up there and nowhere else
- ideally a before/after timing from connect to first history frame, which is the number this is meant to move

I have not measured that gain. The 30–50 ms vs 7.5–15 ms figures are the Android interval ranges, not an observed improvement, and the real number depends on how many round-trips the burst actually costs on each firmware.

## Re-review: this is WHOOP 4.0 only, and the win is smaller than I said

Two corrections, both to the description rather than the code.

**Scope.** `runConnectHandshake()` has exactly one caller, and it is gated `connectedFamily == DeviceFamily.WHOOP4`. The 5/MG never reaches it — it has its own sequence in the CCCD drain (`WHOOP5 && didBond && !connectHandshakeDone`). So this affects **WHOOP 4.0 only**, which I should have said at the top given the thread that prompted it is a 5/MG battery report.

**I am deliberately not extending it to the 5/MG**, for two reasons:

- Its burst is **two** writes-with-response (`SET_CLOCK`, `GET_CLOCK`), not seven. The battery and DIS reads are already deferred out of it by 1.5 s and 3 s. So the available saving is roughly 50–85 ms, against a few hundred on the 4.0.
- It runs **inside `drainCccdQueue`**, and the adjacent comments are explicitly about contention there — the DIS read is *"staggered after the battery read so the two do not contend for the serialized GATT queue"*. Inserting a GATT op mid-drain is the shape of hazard #241 and #533 record, for a fifth of the benefit.

**Magnitude.** I estimated "about a second" earlier. Sizing it properly: ~7 writes-with-response, each a round trip of at least two connection intervals, at roughly 40 ms versus 12 ms — so **a few hundred milliseconds**, not a second. Still worth having on a path that runs on every connect, but the honest number is smaller than my first claim.

**One observation, not fixed here:** `runConnectHandshake` contains a `DeviceFamily.WHOOP5 -> send(GET_HELLO)` branch that its only caller can never reach. Dead as written. Left alone rather than tidied inside a BLE change that already needs hardware validation.
