### PR TITLE
What's New: build the changelog lazily, as iOS already does

### DIFF
--- a/android/app/src/main/java/com/noop/ui/WhatsNewSheet.kt
+++ b/android/app/src/main/java/com/noop/ui/WhatsNewSheet.kt
@@ -6,15 +6,16 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material3.Button
@@ -59,18 +60,34 @@ fun WhatsNewSheet(onClose: () -> Unit) {
             }
             Hairline()
 
-            Column(
+            // PERF: the changelog grows with every release — 267 entries today — so this is an
+            // ever-lengthening column. An eager Column composed EVERY release card up front on each
+            // open: ~267 cards, each a surface plus a version/date row plus one row per bullet, so on
+            // the order of a thousand text nodes measured in the frame the sheet appears. LazyColumn
+            // builds only what is on screen and prefetches the rest.
+            //
+            // The Swift twin already does this and says why (WhatsNewView's LazyVStack); this is the
+            // Android half of that fix, not a new idea. WorkoutsScreen — the other list that grows
+            // without bound — was solved separately by pagination (#797).
+            //
+            // contentPadding, NOT Modifier.padding: the old padding was applied AFTER verticalScroll,
+            // so it scrolled with the content. contentPadding preserves that exactly; a padding
+            // modifier would inset the viewport instead and move where content clips at the edges.
+            LazyColumn(
                 modifier = Modifier
                     .weight(1f)
-                    .fillMaxWidth()
-                    .verticalScroll(rememberScrollState())
-                    .padding(20.dp),
+                    .fillMaxWidth(),
+                contentPadding = PaddingValues(20.dp),
                 verticalArrangement = Arrangement.spacedBy(Metrics.sectionGap),
             ) {
-                ExpectationsCard()
+                item(key = "expectations") { ExpectationsCard() }
                 // The newest release is the headline — give it the brand-green wash; the rest stay
-                // frosted-neutral so the latest stands out at a glance.
-                AppChangelog.releases.forEachIndexed { index, release ->
+                // frosted-neutral so the latest stands out at a glance. Keyed by version (unique and
+                // stable) so recomposition tracks cards across changes, mirroring the Swift `id`.
+                itemsIndexed(
+                    AppChangelog.releases,
+                    key = { _, release -> release.version },
+                ) { index, release ->
                     ReleaseCard(release, isLatest = index == 0)
                 }
             }

--- a/android/app/src/main/java/com/noop/ui/WhatsNewSheet.kt
+++ b/android/app/src/main/java/com/noop/ui/WhatsNewSheet.kt
@@ -80,14 +80,20 @@ fun WhatsNewSheet(onClose: () -> Unit) {
                 contentPadding = PaddingValues(20.dp),
                 verticalArrangement = Arrangement.spacedBy(Metrics.sectionGap),
             ) {
-                item(key = "expectations") { ExpectationsCard() }
+                item { ExpectationsCard() }
                 // The newest release is the headline — give it the brand-green wash; the rest stay
-                // frosted-neutral so the latest stands out at a glance. Keyed by version (unique and
-                // stable) so recomposition tracks cards across changes, mirroring the Swift `id`.
-                itemsIndexed(
-                    AppChangelog.releases,
-                    key = { _, release -> release.version },
-                ) { index, release ->
+                // frosted-neutral so the latest stands out at a glance.
+                //
+                // DELIBERATELY UNKEYED. Keys exist so recomposition can track identity when a list
+                // inserts, removes or reorders; [AppChangelog.releases] is a compile-time constant
+                // that cannot change during a session, so a key buys nothing here — and LazyColumn
+                // THROWS on a duplicate key, where the previous forEachIndexed rendered duplicates
+                // without complaint. Keying by version would hand a generated file the power to crash
+                // this screen: the entries are unique today, but appchangelog-gen.py only guards the
+                // NEWEST entry, so a re-released version or a hand-edit would do it. The Swift twin's
+                // `id:` is not a precedent for adding one — SwiftUI's ForEach requires an identifier,
+                // LazyColumn does not.
+                itemsIndexed(AppChangelog.releases) { index, release ->
                     ReleaseCard(release, isLatest = index == 0)
                 }
             }


### PR DESCRIPTION
Finishes a fix the project already made on iOS.

## What was wrong

`WhatsNewSheet` used `Column` + `verticalScroll`, which composes **every** release card up front on each open. There are **267 entries**, each a surface plus a version/date row plus one row per bullet — on the order of a thousand text nodes measured in the frame the sheet appears. And one more release every time we ship.

## Not a new idea

The Swift twin already does this and left the reasoning in the file:

> *"PERF: the changelog grows with every release, so this is an ever-lengthening column. LazyVStack … builds the off-screen release cards on demand instead of constructing the entire history up-front each time the sheet opens."*

Someone judged it worth fixing on the platform where they could watch it happen, and the Android half was missed. This is that half.

## Swept for the same shape before fixing the one instance

Other `verticalScroll` + `forEach` screens iterate **bounded** collections — settings rows, wizard steps, a day's tiles. The only other list that grows without bound is `WorkoutsScreen`, and it was already solved by pagination in #797 (*"This card lives inside ONE LazyColumn item"*). So the project has now handled this pattern in all three places it occurs.

## The detail that is easy to get wrong

`contentPadding`, **not** `Modifier.padding`. The old padding was applied *after* `verticalScroll`, so it scrolled with the content. `contentPadding` preserves that exactly; a padding modifier would inset the viewport instead and change where content clips at the edges.

`Arrangement.spacedBy(Metrics.sectionGap)` carries over unchanged, so spacing is untouched.

## Parity

**iOS needs nothing** — `WhatsNewView` already uses `LazyVStack`. This PR brings Android level with it rather than introducing a divergence.

No stored value or analytic changes, so the byte-identical contract is not involved.

## Verification

- Kotlin: full `src/main/java` compile against a `main` worktree — **2517 errors both sides, 5 in this file both sides**, error sets byte-identical. No new errors.
- `Tools/doc_comment_lint.py` clean; `Tools/i18n_audit.py --ci` clean.
- Both removed imports (`rememberScrollState`, `verticalScroll`) had no other use in the file.

## What I did not do

**Measure it.** There is no Compose runtime here, so the magnitude is a structural estimate — ~267 cards composed eagerly versus ~4 visible plus prefetch — not a number. It would be worth a frame-time look on a mid-range device if anyone has one to hand, but the direction is not in question and iOS already committed to it.

The change is visually identical: header, hairlines, footer, card styling and the "newest is the headline" rule are all untouched. Only construction becomes on demand.


## Re-review: the item keys were a crash waiting to happen

My first version keyed the items by `release.version`. **`LazyColumn` throws `IllegalArgumentException` on a duplicate key**, where the `forEachIndexed` it replaces rendered duplicates without complaint — so that would have handed a *generated file* the power to crash the What's New screen at runtime.

All 266 entries are unique today; I checked. But `appchangelog-gen.py` only guards the **newest** entry against duplication, so a re-released version or a hand-edit is all it would take, and the failure would land on a user-facing screen rather than in CI.

Keys are now dropped entirely. They exist so recomposition can track identity when a list inserts, removes or reorders — `AppChangelog.releases` is a compile-time constant that cannot change during a session, so there was no identity to track and the key was pure cost.

Worth naming the bad reasoning that put it there: I copied the Swift `ForEach(… id: \.element.id)` as though it were evidence that a key was wanted. It is not — SwiftUI's `ForEach` *requires* an identifier, `LazyColumn` does not. Mirroring a twin is only a good argument when the constraint is the same on both sides.
