### PR TITLE
Secure prefs: one helper, opened once per process instead of per operation

### DIFF
--- a/android/app/src/main/java/com/noop/ai/AiKeyStore.kt
+++ b/android/app/src/main/java/com/noop/ai/AiKeyStore.kt
@@ -2,13 +2,12 @@ package com.noop.ai
 
 import android.content.Context
 import android.content.SharedPreferences
-import androidx.security.crypto.EncryptedSharedPreferences
-import androidx.security.crypto.MasterKey
+import com.noop.data.SecurePrefs
 
 /**
  * Secure, at-rest-encrypted storage for the user's AI Coach API key.
  *
- * Backed by Jetpack Security [EncryptedSharedPreferences] — values are encrypted with a
+ * Backed by Jetpack Security `EncryptedSharedPreferences` — values are encrypted with a
  * key held in the Android Keystore (hardware-backed where available). The plaintext API
  * key is never written to disk in the clear. This is the Android counterpart to storing
  * the key in the macOS Keychain.
@@ -30,22 +29,14 @@ object AiKeyStore {
     private fun modelKey(provider: AiProvider) = "model_${provider.name}"
 
     /**
-     * Open (or lazily create) the encrypted preferences file. The [MasterKey] uses the
-     * AES256_GCM key scheme and lives in the Android Keystore.
+     * The encrypted preferences file. The master key uses the AES256_GCM key scheme and lives in the
+     * Android Keystore.
+     *
+     * Delegated to [SecurePrefs] so both credential stores open their file the same way — and so the
+     * Keystore and Tink setup happens once per process rather than on every read and write, which is
+     * what it used to do.
      */
-    private fun prefs(ctx: Context): SharedPreferences {
-        val masterKey = MasterKey.Builder(ctx.applicationContext)
-            .setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
-            .build()
-
-        return EncryptedSharedPreferences.create(
-            ctx.applicationContext,
-            FILE_NAME,
-            masterKey,
-            EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
-            EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM,
-        )
-    }
+    private fun prefs(ctx: Context): SharedPreferences = SecurePrefs.of(ctx, FILE_NAME)
 
     /**
      * Persist the API [key] (encrypted at rest). Blank keys are treated as a clear.

--- a/android/app/src/main/java/com/noop/ble/OuraInstallKeyStore.kt
+++ b/android/app/src/main/java/com/noop/ble/OuraInstallKeyStore.kt
@@ -3,13 +3,12 @@ package com.noop.ble
 import android.content.Context
 import android.content.SharedPreferences
 import android.util.Base64
-import androidx.security.crypto.EncryptedSharedPreferences
-import androidx.security.crypto.MasterKey
+import com.noop.data.SecurePrefs
 
 /**
  * Secure, at-rest-encrypted storage for an Oura ring's 16-byte application install key.
  *
- * Backed by Jetpack Security [EncryptedSharedPreferences] - values are encrypted with a key held in
+ * Backed by Jetpack Security `EncryptedSharedPreferences` - values are encrypted with a key held in
  * the Android Keystore (hardware-backed where available), so the install key is never written to disk
  * in the clear. This is the Android counterpart to storing the key in the macOS Keychain, and the same
  * pattern the AI Coach key uses ([com.noop.ai.AiKeyStore]).
@@ -42,22 +41,14 @@ object OuraInstallKeyStore {
     private fun adoptKey(deviceId: String) = "$ADOPT_PREFIX$deviceId"
 
     /**
-     * Open (or lazily create) the encrypted preferences file. The [MasterKey] uses the AES256_GCM key
-     * scheme and lives in the Android Keystore (mirrors [com.noop.ai.AiKeyStore]).
+     * The encrypted preferences file. The master key uses the AES256_GCM key scheme and lives in the
+     * Android Keystore (mirrors [com.noop.ai.AiKeyStore]).
+     *
+     * Delegated to [SecurePrefs] so both credential stores open their file the same way — and so the
+     * Keystore and Tink setup happens once per process rather than on every read and write, which is
+     * what it used to do.
      */
-    private fun prefs(ctx: Context): SharedPreferences {
-        val masterKey = MasterKey.Builder(ctx.applicationContext)
-            .setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
-            .build()
-
-        return EncryptedSharedPreferences.create(
-            ctx.applicationContext,
-            FILE_NAME,
-            masterKey,
-            EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
-            EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM,
-        )
-    }
+    private fun prefs(ctx: Context): SharedPreferences = SecurePrefs.of(ctx, FILE_NAME)
 
     /**
      * Persist the 16-byte install [key] (encrypted at rest) for [deviceId]. The key is supplied as

--- a/android/app/src/main/java/com/noop/data/SecurePrefs.kt
+++ b/android/app/src/main/java/com/noop/data/SecurePrefs.kt
@@ -34,7 +34,21 @@ object SecurePrefs {
 
     private val cache = ConcurrentHashMap<String, SharedPreferences>()
 
-    /** The encrypted prefs for [fileName], created once per process and reused thereafter. */
+    /**
+     * The encrypted prefs for [fileName], created once per process and reused thereafter.
+     *
+     * [ConcurrentHashMap.computeIfAbsent] guarantees the construction happens EXACTLY once under a
+     * race — a second thread asking for the same file blocks and receives the same instance rather
+     * than building a second one. If the build throws, the exception propagates and NO mapping is
+     * recorded, so a transient Keystore failure is retried on the next call instead of being
+     * memoised into a permanently broken store.
+     *
+     * Caveat worth knowing: `ConcurrentHashMap` documents that the mapping function should be "short
+     * and simple", and this one is neither — a Keystore round trip plus Tink setup, with the bin
+     * locked throughout. It is acceptable here because there are exactly two files, each built once
+     * per process, and the function never re-enters the map, so the worst case is one thread briefly
+     * serialising behind another. It would not be acceptable if this map grew keys at runtime.
+     */
     fun of(ctx: Context, fileName: String): SharedPreferences =
         cache.computeIfAbsent(fileName) {
             val app = ctx.applicationContext

--- a/android/app/src/main/java/com/noop/data/SecurePrefs.kt
+++ b/android/app/src/main/java/com/noop/data/SecurePrefs.kt
@@ -1,0 +1,52 @@
+package com.noop.data
+
+import android.content.Context
+import android.content.SharedPreferences
+import androidx.security.crypto.EncryptedSharedPreferences
+import androidx.security.crypto.MasterKey
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * The one place an encrypted `SharedPreferences` file is opened.
+ *
+ * Two credential stores needed this and each grew its own copy: `AiKeyStore` (the AI provider API key)
+ * and `OuraInstallKeyStore` (per-ring install keys). The bodies were byte-identical apart from the file
+ * name, which is the shape that lets a hardening change, a key-scheme migration or a fallback fix land
+ * on one store and silently miss the other. They are the app's only two encrypted files, so one helper
+ * covers all of it.
+ *
+ * **Cached, which is the part that matters at runtime.** `EncryptedSharedPreferences.create` is not a
+ * cheap accessor: it builds a [MasterKey] — an Android Keystore round trip — and sets up Tink AEAD
+ * primitives, on every call. Neither store cached it, so all twenty of their read/write sites paid that
+ * cost per operation. `CoachViewModel` reads five values in PROPERTY INITIALISERS, so opening the Coach
+ * screen ran five full Keystore + Tink setups synchronously on the main thread. They now collapse to one
+ * per file for the process lifetime.
+ *
+ * Instances are safe to hold: `SharedPreferences` is designed as a long-lived singleton (the platform
+ * caches the plaintext kind by name internally; the encrypted wrapper is what does not), and only the
+ * application context is captured, so nothing leaks an Activity.
+ *
+ * [ConcurrentHashMap.computeIfAbsent] rather than a plain map: `AiKeyStore` is reached from the main
+ * thread through `CoachViewModel`, while `OuraInstallKeyStore` is reached from BLE callbacks on binder
+ * threads. Two threads racing the first call must get the same instance, not two.
+ */
+object SecurePrefs {
+
+    private val cache = ConcurrentHashMap<String, SharedPreferences>()
+
+    /** The encrypted prefs for [fileName], created once per process and reused thereafter. */
+    fun of(ctx: Context, fileName: String): SharedPreferences =
+        cache.computeIfAbsent(fileName) {
+            val app = ctx.applicationContext
+            val masterKey = MasterKey.Builder(app)
+                .setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
+                .build()
+            EncryptedSharedPreferences.create(
+                app,
+                fileName,
+                masterKey,
+                EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
+                EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM,
+            )
+        }
+}


### PR DESCRIPTION
Started as a duplication cleanup and turned into a main-thread latency fix.

## The duplication

`AiKeyStore.prefs()` and `OuraInstallKeyStore.prefs()` were **byte-identical** — same `MasterKey`, same `AES256_SIV`/`AES256_GCM` schemes — differing only in a filename constant. They are the app's **only two** `EncryptedSharedPreferences` constructions, and they hold the **AI provider API key** and the **per-ring Oura install keys**.

That is the shape where a hardening change, a key-scheme migration or a fallback fix lands on one store and silently misses the other.

## The part that actually matters

**Neither store cached the result.** `EncryptedSharedPreferences.create` is not a cheap accessor — it builds a `MasterKey` (an Android Keystore round trip) and sets up Tink AEAD primitives, **on every call**. Between them the two stores call `prefs(ctx)` from **twenty** read/write sites, so every single get and put paid that cost.

The worst instance is not on a background path. `CoachViewModel` reads five values in **property initialisers**:

```kotlin
private val _provider  = MutableStateFlow(AiKeyStore.readProvider(app.applicationContext))
private val _model     = MutableStateFlow(AiKeyStore.readModel(app.applicationContext, _provider.value))
private val _consent   = MutableStateFlow(AiKeyStore.readConsent(app.applicationContext))
private val _customBaseUrl   = MutableStateFlow(AiKeyStore.readCustomBaseUrl(app.applicationContext))
private val _customConnected = MutableStateFlow(AiKeyStore.readCustomConnected(app.applicationContext))
```

Property initialisers run during construction, so opening the Coach screen ran **five full Keystore + Tink setups synchronously on the main thread**. They now collapse to one per file for the process lifetime.

## Why `ConcurrentHashMap.computeIfAbsent`

Not decoration. `AiKeyStore` is reached from the main thread through `CoachViewModel`; `OuraInstallKeyStore` is reached from BLE callbacks on binder threads. Two threads racing the first call must get the same instance, not two — and a plain `by lazy` on an object would serialise every access rather than just the first.

Only the application context is captured, so nothing holds an Activity.

## Verification

- Kotlin: full `src/main/java` compile against a `main` worktree — **2517 errors both sides**, error sets byte-identical, **0 in any of the three files** on either. No new errors.
- `Tools/doc_comment_lint.py` clean, after it caught me stacking a new doc comment above an existing one — the two `prefs()` docs are merged rather than duplicated, and the now-unresolvable `[MasterKey]` / `[EncryptedSharedPreferences]` KDoc links are softened to plain code spans since the imports moved.
- No behaviour change: same file names, same key schemes, same call sites, same return type.

## Not measured

I have not put a number on the Coach-screen saving. `EncryptedSharedPreferences.create` is widely 10–50 ms per call depending on device and Keystore state, so five of them is plausibly 50–250 ms of blocked main thread — but that is an estimate from the API's known cost, not something I profiled here. The structural claim (five constructions become one) is exact; the milliseconds are not.

## Parity

Android-only. Jetpack Security `EncryptedSharedPreferences` has no Swift twin — iOS stores its equivalents in the Keychain (`OuraTokenStore` and friends), which has different caching characteristics entirely. No stored value or analytic changes, so the byte-identical contract is not involved.
