### PR TITLE
Importers: one capped stream reader instead of five

### DIFF
--- a/android/app/src/main/java/com/noop/ingest/ActivityFileImporter.kt
+++ b/android/app/src/main/java/com/noop/ingest/ActivityFileImporter.kt
@@ -11,8 +11,6 @@ import com.noop.data.WhoopRepository
 import com.noop.data.WorkoutRow
 import org.xmlpull.v1.XmlPullParser
 import java.io.ByteArrayInputStream
-import java.io.ByteArrayOutputStream
-import java.io.InputStream
 import java.time.Instant
 import java.time.ZoneOffset
 import java.util.Locale
@@ -866,17 +864,3 @@ internal class FitDecoder(raw: ByteArray) {
     }
 }
 
-// Stream helper (file-private; the twins in other importers are not visible here).
-private fun InputStream.readCapped(cap: Long): ByteArray {
-    val buffer = ByteArrayOutputStream(64 * 1024)
-    val chunk = ByteArray(64 * 1024)
-    var total = 0L
-    while (true) {
-        val n = read(chunk)
-        if (n < 0) break
-        total += n
-        if (total > cap) throw IllegalStateException("Input exceeds $cap bytes")
-        buffer.write(chunk, 0, n)
-    }
-    return buffer.toByteArray()
-}

--- a/android/app/src/main/java/com/noop/ingest/LabMarkerCsvImport.kt
+++ b/android/app/src/main/java/com/noop/ingest/LabMarkerCsvImport.kt
@@ -7,8 +7,6 @@ import com.noop.analytics.MarkerCatalog
 import com.noop.data.ImportSummary
 import com.noop.data.LabMarkerRow
 import com.noop.data.WhoopRepository
-import java.io.ByteArrayOutputStream
-import java.io.InputStream
 import java.text.SimpleDateFormat
 import java.util.Locale
 import java.util.TimeZone
@@ -100,7 +98,7 @@ object LabMarkerCsvImport {
         deviceId: String = LAB_STRAP_DEVICE_ID,
     ): ImportSummary {
         val bytes: ByteArray = try {
-            context.contentResolver.openInputStream(uri)?.use { it.readCappedBytes(MAX_BYTES) }
+            context.contentResolver.openInputStream(uri)?.use { it.readCapped(MAX_BYTES) }
                 ?: throw IllegalStateException("Could not open input stream for $uri")
         } catch (e: Exception) {
             return ImportSummary.failure(SOURCE_LABEL, "Could not read CSV: ${e.message ?: "unknown error"}")
@@ -564,17 +562,3 @@ object LabMarkerCsvImport {
 
 // MARK: - Stream helper (file-private; the other importers' twins are not visible here)
 
-/** Read a whole stream, throwing if it exceeds [cap] bytes (memory guard). */
-private fun InputStream.readCappedBytes(cap: Long): ByteArray {
-    val buffer = ByteArrayOutputStream(64 * 1024)
-    val chunk = ByteArray(64 * 1024)
-    var total = 0L
-    while (true) {
-        val n = read(chunk)
-        if (n < 0) break
-        total += n
-        if (total > cap) throw IllegalStateException("Input exceeds $cap bytes")
-        buffer.write(chunk, 0, n)
-    }
-    return buffer.toByteArray()
-}

--- a/android/app/src/main/java/com/noop/ingest/LiftingImporter.kt
+++ b/android/app/src/main/java/com/noop/ingest/LiftingImporter.kt
@@ -7,8 +7,6 @@ import com.noop.data.WhoopRepository
 import com.noop.data.WorkoutRow
 import org.json.JSONArray
 import org.json.JSONObject
-import java.io.ByteArrayOutputStream
-import java.io.InputStream
 import java.text.NumberFormat
 import java.time.Instant
 import java.time.LocalDate
@@ -452,17 +450,3 @@ object LiftingImporter {
 
 // MARK: - Stream helper (file-private; the twin in NutritionCsvImporter.kt is not visible here)
 
-/** Read a whole stream, throwing if it exceeds [cap] bytes (memory guard). */
-private fun InputStream.readCapped(cap: Long): ByteArray {
-    val buffer = ByteArrayOutputStream(64 * 1024)
-    val chunk = ByteArray(64 * 1024)
-    var total = 0L
-    while (true) {
-        val n = read(chunk)
-        if (n < 0) break
-        total += n
-        if (total > cap) throw IllegalStateException("Input exceeds $cap bytes")
-        buffer.write(chunk, 0, n)
-    }
-    return buffer.toByteArray()
-}

--- a/android/app/src/main/java/com/noop/ingest/NutritionCsvImporter.kt
+++ b/android/app/src/main/java/com/noop/ingest/NutritionCsvImporter.kt
@@ -5,8 +5,6 @@ import android.net.Uri
 import com.noop.data.ImportSummary
 import com.noop.data.MetricSeriesRow
 import com.noop.data.WhoopRepository
-import java.io.ByteArrayOutputStream
-import java.io.InputStream
 import java.time.Instant
 import java.time.LocalDate
 import java.time.ZoneOffset
@@ -284,17 +282,3 @@ object NutritionCsvImporter {
 
 // MARK: - Stream helper (file-private; WhoopCsvImporter's twin is not visible here)
 
-/** Read a whole stream, throwing if it exceeds [cap] bytes (memory guard). */
-private fun InputStream.readCapped(cap: Long): ByteArray {
-    val buffer = ByteArrayOutputStream(64 * 1024)
-    val chunk = ByteArray(64 * 1024)
-    var total = 0L
-    while (true) {
-        val n = read(chunk)
-        if (n < 0) break
-        total += n
-        if (total > cap) throw IllegalStateException("Input exceeds $cap bytes")
-        buffer.write(chunk, 0, n)
-    }
-    return buffer.toByteArray()
-}

--- a/android/app/src/main/java/com/noop/ingest/StreamCap.kt
+++ b/android/app/src/main/java/com/noop/ingest/StreamCap.kt
@@ -1,0 +1,42 @@
+package com.noop.ingest
+
+import java.io.ByteArrayOutputStream
+import java.io.InputStream
+
+/**
+ * Read a whole stream into memory, refusing to exceed [cap] bytes.
+ *
+ * The memory-exhaustion guard for user-supplied import files: a `content://` URI or a zip entry can
+ * claim any size it likes, and every importer reads the whole thing before parsing. Without a ceiling
+ * a malicious or merely broken file takes the process down with an OOM.
+ *
+ * This existed FIVE times — `ActivityFileImporter`, `NutritionCsvImporter`, `LiftingImporter`,
+ * `LabMarkerCsvImport` and `WearableExportImporter` — with identical bodies under two different names
+ * (`readCapped` / `readCappedBytes`) and two different shapes (extension / member). Each carried a
+ * comment noting that the twins elsewhere "are not visible here", so the duplication was known rather
+ * than accidental. A guard is the wrong thing to keep five copies of: a fix or a hardening lands on one
+ * and misses four.
+ *
+ * The CAP itself is deliberately NOT centralised. It is policy, and it legitimately differs by file
+ * type — 32 MB for a lab-marker CSV against 512 MB for a Xiaomi zip entry. Each importer keeps its own
+ * constant and passes it here; only the mechanism is shared.
+ *
+ * [what] names the thing in the failure message so the wording each importer already produced is
+ * preserved exactly — "Input exceeds …" everywhere except the zip-entry path, which says "Entry".
+ *
+ * @throws IllegalStateException as soon as the running total passes [cap] — before the offending chunk
+ *   is buffered, so the peak allocation stays bounded by the cap rather than the file.
+ */
+fun InputStream.readCapped(cap: Long, what: String = "Input"): ByteArray {
+    val buffer = ByteArrayOutputStream(64 * 1024)
+    val chunk = ByteArray(64 * 1024)
+    var total = 0L
+    while (true) {
+        val n = read(chunk)
+        if (n < 0) break
+        total += n
+        if (total > cap) throw IllegalStateException("$what exceeds $cap bytes")
+        buffer.write(chunk, 0, n)
+    }
+    return buffer.toByteArray()
+}

--- a/android/app/src/main/java/com/noop/ingest/StreamCap.kt
+++ b/android/app/src/main/java/com/noop/ingest/StreamCap.kt
@@ -24,10 +24,15 @@ import java.io.InputStream
  * [what] names the thing in the failure message so the wording each importer already produced is
  * preserved exactly — "Input exceeds …" everywhere except the zip-entry path, which says "Entry".
  *
+ * `internal`, not public: every copy this replaces was file-private, and nothing outside
+ * `com.noop.ingest` calls it. Kotlin has no package-private, so `internal` is the tightest scope that
+ * still lets the five importers and the unit tests reach it — widening a private helper to public API
+ * would be an unrelated change riding along with a refactor.
+ *
  * @throws IllegalStateException as soon as the running total passes [cap] — before the offending chunk
  *   is buffered, so the peak allocation stays bounded by the cap rather than the file.
  */
-fun InputStream.readCapped(cap: Long, what: String = "Input"): ByteArray {
+internal fun InputStream.readCapped(cap: Long, what: String = "Input"): ByteArray {
     val buffer = ByteArrayOutputStream(64 * 1024)
     val chunk = ByteArray(64 * 1024)
     var total = 0L

--- a/android/app/src/main/java/com/noop/ingest/WearableExportImporter.kt
+++ b/android/app/src/main/java/com/noop/ingest/WearableExportImporter.kt
@@ -9,7 +9,6 @@ import com.noop.data.SleepSession
 import com.noop.data.WhoopRepository
 import org.json.JSONArray
 import org.json.JSONObject
-import java.io.ByteArrayOutputStream
 import java.io.InputStream
 import java.time.Instant
 import java.time.LocalDateTime
@@ -804,7 +803,7 @@ object WearableExportImporter {
         val isZip = head.size >= 2 && head[0] == 'P'.code.toByte() && head[1] == 'K'.code.toByte()
 
         if (!isZip) {
-            val bytes = context.contentResolver.openInputStream(uri)?.use { readCapped(it, MAX_ENTRY_BYTES) }
+            val bytes = context.contentResolver.openInputStream(uri)?.use { it.readCapped(MAX_ENTRY_BYTES, what = "Entry") }
                 ?: throw IllegalStateException("Couldn't open the selected file.")
             val name = displayName(context, uri)?.lowercase() ?: "export.json"
             // A single file is one entry — the aggregate budget can't trip here.
@@ -834,7 +833,7 @@ object WearableExportImporter {
                 val path = entry.name.lowercase()
                 val base = last(path)
                 if (!entry.isDirectory && (base.endsWith(".json") || base.endsWith(".csv"))) {
-                    val bytes = runCatching { readCapped(zin, MAX_ENTRY_BYTES) }.getOrNull()
+                    val bytes = runCatching { zin.readCapped(MAX_ENTRY_BYTES, what = "Entry") }.getOrNull()
                     // First-wins dedup (was last-wins overwrite) so the running `total` matches the retained
                     // bytes exactly; mirrors the Swift zip loader's `if result[path] == nil` guard.
                     if (bytes != null && bytes.isNotEmpty() && isWellnessFile(base, bytes) && !out.containsKey(path)) {
@@ -864,19 +863,6 @@ object WearableExportImporter {
         return hints.any { name.contains(it) }
     }
 
-    private fun readCapped(input: InputStream, cap: Long): ByteArray {
-        val buffer = ByteArrayOutputStream(64 * 1024)
-        val chunk = ByteArray(64 * 1024)
-        var total = 0L
-        while (true) {
-            val n = input.read(chunk)
-            if (n < 0) break
-            total += n
-            if (total > cap) throw IllegalStateException("Entry exceeds $cap bytes")
-            buffer.write(chunk, 0, n)
-        }
-        return buffer.toByteArray()
-    }
 
     // ------------------------------------------------------------------------
     // Helpers

--- a/android/app/src/test/java/com/noop/ingest/StreamCapTest.kt
+++ b/android/app/src/test/java/com/noop/ingest/StreamCapTest.kt
@@ -1,0 +1,82 @@
+package com.noop.ingest
+
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertThrows
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.ByteArrayInputStream
+import java.io.InputStream
+
+/**
+ * The memory-exhaustion guard on user-supplied import files.
+ *
+ * It existed five times across the importers with identical bodies and no test anywhere — a guard
+ * whose boundary nobody had pinned. These pin it once, now that there is one implementation.
+ */
+class StreamCapTest {
+
+    private fun stream(n: Int): InputStream = ByteArrayInputStream(ByteArray(n) { (it % 251).toByte() })
+
+    /** Content below the cap comes back byte-for-byte — the guard must not corrupt what it allows. */
+    @Test fun readsContentUnderTheCapExactly() {
+        val src = ByteArray(5_000) { (it % 251).toByte() }
+        assertArrayEquals(src, ByteArrayInputStream(src).readCapped(10_000))
+    }
+
+    /** Spans many read() calls: the buffer is 64 KiB, so this exercises the accumulate path. */
+    @Test fun readsAcrossMultipleChunks() {
+        val size = 64 * 1024 * 3 + 17
+        assertEquals(size, stream(size).readCapped(1L shl 20).size)
+    }
+
+    /** Exactly at the cap is allowed — the check is `total > cap`, not `>=`. */
+    @Test fun exactlyAtTheCapIsAllowed() {
+        assertEquals(1_000, stream(1_000).readCapped(1_000L).size)
+    }
+
+    /** One byte over throws. This is the boundary the five copies all encoded and none tested. */
+    @Test fun oneByteOverTheCapThrows() {
+        assertThrows(IllegalStateException::class.java) { stream(1_001).readCapped(1_000L) }
+    }
+
+    /** An empty stream is not an error — an empty import file should fail in the parser, not here. */
+    @Test fun emptyStreamIsAllowed() {
+        assertEquals(0, stream(0).readCapped(1_000L).size)
+    }
+
+    /**
+     * The wording each importer already produced is preserved: everything says "Input" except the
+     * zip-entry path, which says "Entry". These messages reach the user through an import failure.
+     */
+    @Test fun theFailureMessageNamesTheThingAndTheCap() {
+        val input = assertThrows(IllegalStateException::class.java) { stream(50).readCapped(10L) }
+        assertEquals("Input exceeds 10 bytes", input.message)
+
+        val entry = assertThrows(IllegalStateException::class.java) {
+            stream(50).readCapped(10L, what = "Entry")
+        }
+        assertEquals("Entry exceeds 10 bytes", entry.message)
+    }
+
+    /**
+     * The guard has to bound PEAK memory, not just the return value — it must refuse before buffering
+     * the chunk that crosses the line. Asserted by reading a stream far larger than the cap and
+     * checking it fails without having consumed it all: a guard that buffered first would still throw,
+     * but only after allocating the whole thing, which is the failure it exists to prevent.
+     */
+    @Test fun throwsBeforeBufferingTheWholeOversizeStream() {
+        var consumed = 0
+        val counting = object : InputStream() {
+            private val inner = stream(64 * 1024 * 40)   // 2.5 MiB
+            override fun read(): Int = inner.read().also { if (it >= 0) consumed += 1 }
+            override fun read(b: ByteArray, off: Int, len: Int): Int =
+                inner.read(b, off, len).also { if (it > 0) consumed += it }
+        }
+        assertThrows(IllegalStateException::class.java) { counting.readCapped(128L * 1024) }
+        assertTrue(
+            "should stop near the cap, consumed $consumed bytes",
+            consumed <= 128 * 1024 + 64 * 1024,   // the cap plus at most one buffer
+        )
+    }
+}


### PR DESCRIPTION
Five copies of a safety guard become one, with the tests none of them had.

## What `readCapped` is

The memory-exhaustion guard on user-supplied import files. A `content://` URI or a zip entry can claim any size it likes, and every importer reads the whole thing into memory before parsing — so without a ceiling a malicious or merely broken file takes the process down with an OOM.

It existed **five times**, with identical bodies, under **two names** (`readCapped` / `readCappedBytes`) and **two shapes** (extension function / member function):

| File | Name | Shape | Cap |
|---|---|---|---|
| `ActivityFileImporter` | `readCapped` | extension | 128 MB |
| `NutritionCsvImporter` | `readCapped` | extension | 64 MB |
| `LiftingImporter` | `readCapped` | extension | 64 MB |
| `LabMarkerCsvImport` | `readCappedBytes` | extension | 32 MB |
| `WearableExportImporter` | `readCapped` | member | 256 MB |

**The duplication was known, not accidental** — each copy carried a comment noting that the twins elsewhere "are not visible here". That is the wrong thing to accept for a guard: a hardening or a fix lands on one and misses four.

## What is deliberately NOT shared

**The cap.** It is policy and it legitimately differs by file type — 32 MB for a lab-marker CSV against 512 MB for a Xiaomi zip entry. Each importer keeps its own constant and passes it in. Only the mechanism moves.

**The failure wording**, preserved exactly via a `what` parameter: everything says `"Input exceeds …"` except the zip-entry path, which says `"Entry exceeds …"`. Those messages reach users through an import failure, so none of them change.

## Tests

Seven, where the five copies had **none between them**:

- content under the cap returned byte-for-byte (a guard must not corrupt what it allows)
- reads spanning multiple 64 KiB chunks
- **exactly at the cap is allowed** — the check is `> cap`, not `>=`, and nothing pinned that
- one byte over throws
- an empty stream is allowed (an empty file should fail in the parser, not here)
- both failure messages, verbatim
- **it throws before buffering the whole oversize stream** — asserted with a counting `InputStream`, because "returns an error eventually" is not the property this exists for; bounded peak allocation is

## Verification

- Kotlin: full `src/main/java` compile against a `main` worktree — **2517 errors both sides**, error sets byte-identical, **0 in any of the six touched files**.
- The new suite runs green locally: `OK (7 tests)`.
- `Tools/doc_comment_lint.py` clean.
- **Nine orphaned `java.io` imports removed** with the bodies. Kotlin only warns on unused imports and the ad-hoc compile runs `-nowarn`, so these would have sat there unnoticed — worth flagging as a gap in how I verify, not just a tidy-up.

Net: **81 lines deleted, 7 added** across the importers, plus one 40-line helper and its tests.

## Parity

Android-only. The Swift importers take `Data` from the document picker rather than streaming an `InputStream`, so there is no equivalent read loop to consolidate. No stored value or analytic changes.


## Re-review: the extraction silently widened visibility

All five originals were **file-private**. Extracting them produced a **public** extension on `InputStream` — a wider API than the refactor asked for, surfacing on every `InputStream` in the module's autocomplete and callable from anywhere.

Nothing outside `com.noop.ingest` calls it, and Kotlin has no package-private, so it is now `internal`: the tightest scope that still reaches the five importers and the unit tests. Precedent in the tree — `HealthConnectImporter.maxSourceLong` is `internal` and tested the same way.

Worth naming because it is a whole class of quiet change: **moving code between scopes alters its visibility, and the compiler never complains about getting *more* access than you had.** Widening a private helper to public API should be asked for, not arrive as a side effect of a refactor.

Also re-verified this pass: `zin` is a `ZipInputStream`, so the extension resolves on the subclass and `read()` still returns -1 at the end of the *entry* rather than the stream — the behaviour the removed member function relied on is preserved. And `WearableExportImporter` legitimately still imports `InputStream`, which is why only its `ByteArrayOutputStream` import was removed.
