### PR TITLE
HRV: default Overnight only ON for fresh installs (#1008, minimum half)

### DIFF
--- a/Strand/App/StrandApp.swift
+++ b/Strand/App/StrandApp.swift
@@ -5,6 +5,9 @@ import UserNotifications
 @main
 struct StrandApp: App {
     init() {
+        // #1008: pin the pre-change Overnight-only default for existing installs before
+        // anything reads it. Idempotent; a no-op on fresh installs and after the first launch.
+        PuffinExperiment.migrateContinuousHrvOvernightDefault()
         #if DEBUG
         // DEBUG-only promo-screenshot harness: when launched with `--demo-hour <Int>`, pin the Today
         // screen to that hour's day-cycle scene + a plausible per-hour stat frame. Runs synchronously

--- a/Strand/BLE/PuffinExperiment.swift
+++ b/Strand/BLE/PuffinExperiment.swift
@@ -66,11 +66,48 @@ enum PuffinExperiment {
     /// happen is silently narrowing capture for someone already relying on it. Twin of the Android
     /// `NoopPrefs.continuousHrvOvernight`.
     static var continuousHrvOvernightOnlyEnabled: Bool {
+        UserDefaults.standard.object(forKey: continuousHrvOvernightOnlyKey) as? Bool ?? true
+    }
+
+    /// One-time migration for the #1008 default flip. Called once at launch, BEFORE anything reads the
+    /// setting, and before the user can reach the toggle.
+    ///
+    /// The default moved from OFF to ON, so an install that predates the change has to be pinned to OFF
+    /// explicitly or it would be silently narrowed to overnight-only capture — removing daytime data the
+    /// user opted in for. "Predates the change" is read as "has ever toggled Continuous HRV", i.e. the
+    /// base key exists.
+    ///
+    /// Deciding this at READ time instead does not work, and the way it fails is worth recording: the
+    /// discriminator would be the base key, which the user's own opt-in creates — so a fresh install
+    /// would default to ON and then flip to OFF the moment they enabled Continuous HRV, the exact
+    /// opposite of the intent.
+    ///
+    /// A `@AppStorage` `onChange` hook cannot substitute for this either: `@AppStorage` writes the value
+    /// BEFORE the handler runs, so by then a first-ever toggle is indistinguishable from any other.
+    ///
+    /// Idempotent: writes only when the overnight key is absent and the base key is present.
+    /// Twin of the Android `NoopPrefs.migrateContinuousHrvOvernightDefault`.
+    static func migrateContinuousHrvOvernightDefault() {
         let defaults = UserDefaults.standard
-        return continuousHrvOvernightDefault(
-            hasExplicitChoice: defaults.object(forKey: continuousHrvOvernightOnlyKey) != nil,
-            explicitChoice: defaults.bool(forKey: continuousHrvOvernightOnlyKey),
-            hasUsedContinuousHrv: defaults.object(forKey: keepRealtimeForDataKey) != nil)
+        guard shouldPinLegacyOvernightDefault(
+            hasOvernightChoice: defaults.object(forKey: continuousHrvOvernightOnlyKey) != nil,
+            hasUsedContinuousHrv: defaults.object(forKey: keepRealtimeForDataKey) != nil) else { return }
+        defaults.set(false, forKey: continuousHrvOvernightOnlyKey)
+    }
+
+    /// The migration's decision, lifted out so it is testable without touching `UserDefaults`. Twin of
+    /// the Android `NoopPrefs.shouldPinLegacyOvernightDefault`.
+    ///
+    /// Pin the OLD default only for an install that has used Continuous HRV and never chose an overnight
+    /// setting. Everything else is left alone.
+    ///
+    /// Note what this is NOT keyed on: the READ. An earlier attempt resolved the default at read time
+    /// from `hasUsedContinuousHrv`, which the user's own opt-in creates — so a fresh install read ON and
+    /// then flipped to OFF the moment Continuous HRV was enabled. Running the decision once at launch is
+    /// what makes the answer stable.
+    static func shouldPinLegacyOvernightDefault(hasOvernightChoice: Bool,
+                                                hasUsedContinuousHrv: Bool) -> Bool {
+        !hasOvernightChoice && hasUsedContinuousHrv
     }
 
     /// The rule behind `continuousHrvOvernightOnlyEnabled`, lifted out so it can be tested without

--- a/Strand/BLE/PuffinExperiment.swift
+++ b/Strand/BLE/PuffinExperiment.swift
@@ -110,18 +110,6 @@ enum PuffinExperiment {
         !hasOvernightChoice && hasUsedContinuousHrv
     }
 
-    /// The rule behind `continuousHrvOvernightOnlyEnabled`, lifted out so it can be tested without
-    /// touching `UserDefaults`. Twin of the Android `NoopPrefs.continuousHrvOvernightDefault`.
-    ///
-    /// An explicit choice always wins. With no choice recorded, `hasUsedContinuousHrv` decides: someone
-    /// who has been through this screen keeps the always-on behaviour they experienced, a fresh install
-    /// gets overnight-only.
-    static func continuousHrvOvernightDefault(hasExplicitChoice: Bool,
-                                              explicitChoice: Bool,
-                                              hasUsedContinuousHrv: Bool) -> Bool {
-        hasExplicitChoice ? explicitChoice : !hasUsedContinuousHrv
-    }
-
     // MARK: - Power saving (#477), parity with Android NoopPrefs
 
     /// "Power saving" master: battery-adaptive strap-sync cadence. Default off. */

--- a/Strand/BLE/PuffinExperiment.swift
+++ b/Strand/BLE/PuffinExperiment.swift
@@ -48,12 +48,42 @@ enum PuffinExperiment {
     /// only inside the nightly window (the reused quiet-hours window convention: minutes since local
     /// midnight, wrap-aware, 22:00 to 07:00 by default) instead of 24/7, roughly halving the battery
     /// cost. Composed with the base toggle so existing users need no migration: base on + this off reads
-    /// ALWAYS (the pre-#927 behaviour). Default OFF. Read by BLEManager at EVERY arm site (re-derived at
+    /// ALWAYS (the pre-#927 behaviour). Defaults ON for fresh installs, OFF once Continuous HRV has been
+    /// used (#1008) — see below. Read by BLEManager at EVERY arm site (re-derived at
     /// arm time, never precomputed; see ContinuousHrvSchedule). Mirrors the Android
     /// `NoopPrefs.KEY_CONTINUOUS_HRV_OVERNIGHT`.
     static let continuousHrvOvernightOnlyKey = "noopContinuousHrvOvernightOnly"
 
-    static var continuousHrvOvernightOnlyEnabled: Bool { UserDefaults.standard.bool(forKey: continuousHrvOvernightOnlyKey) }
+    /// Defaults to ON for anyone who has never touched Continuous HRV, and to OFF for anyone who has
+    /// (#1008). WHOOP publishes no daytime HRV figure at all — its reading is an overnight one — so a
+    /// 24/7 stream has no official-app analogue, and overnight-only roughly halves the battery cost.
+    /// Making the cheaper, WHOOP-comparable behaviour the default is the point; the expensive one stays
+    /// a deliberate choice.
+    ///
+    /// `UserDefaults.bool(forKey:)` cannot express this on its own: it returns `false` for a missing key,
+    /// which is indistinguishable from an explicit off. The unset case is therefore resolved from whether
+    /// `keepRealtimeForDataKey` exists, rather than by writing a migration — the only thing that must not
+    /// happen is silently narrowing capture for someone already relying on it. Twin of the Android
+    /// `NoopPrefs.continuousHrvOvernight`.
+    static var continuousHrvOvernightOnlyEnabled: Bool {
+        let defaults = UserDefaults.standard
+        return continuousHrvOvernightDefault(
+            hasExplicitChoice: defaults.object(forKey: continuousHrvOvernightOnlyKey) != nil,
+            explicitChoice: defaults.bool(forKey: continuousHrvOvernightOnlyKey),
+            hasUsedContinuousHrv: defaults.object(forKey: keepRealtimeForDataKey) != nil)
+    }
+
+    /// The rule behind `continuousHrvOvernightOnlyEnabled`, lifted out so it can be tested without
+    /// touching `UserDefaults`. Twin of the Android `NoopPrefs.continuousHrvOvernightDefault`.
+    ///
+    /// An explicit choice always wins. With no choice recorded, `hasUsedContinuousHrv` decides: someone
+    /// who has been through this screen keeps the always-on behaviour they experienced, a fresh install
+    /// gets overnight-only.
+    static func continuousHrvOvernightDefault(hasExplicitChoice: Bool,
+                                              explicitChoice: Bool,
+                                              hasUsedContinuousHrv: Bool) -> Bool {
+        hasExplicitChoice ? explicitChoice : !hasUsedContinuousHrv
+    }
 
     // MARK: - Power saving (#477), parity with Android NoopPrefs
 

--- a/Strand/Screens/SettingsView.swift
+++ b/Strand/Screens/SettingsView.swift
@@ -58,9 +58,14 @@ struct SettingsView: View {
 
     /// #927 "Overnight only" refinement of Continuous HRV capture (off by default): arm the stream only
     /// inside the nightly quiet-hours window instead of 24/7. Composed with the base toggle (base on +
-    /// this off = ALWAYS, the pre-#927 behaviour) so existing users see no change and need no migration.
-    /// See [PuffinExperiment.continuousHrvOvernightOnlyKey].
-    @AppStorage(PuffinExperiment.continuousHrvOvernightOnlyKey) private var continuousHrvOvernightOnly = false
+    /// this off = ALWAYS, the pre-#927 behaviour); existing installs are pinned to OFF by
+    /// `PuffinExperiment.migrateContinuousHrvOvernightDefault()` at launch, so they still see no change.
+    ///
+    /// The `@AppStorage` default MUST match `PuffinExperiment.continuousHrvOvernightOnlyEnabled` (#1008).
+    /// They read the same key by different routes, so a mismatch shows the toggle OFF on a fresh install
+    /// while capture is actually overnight-only — and a user "correcting" that would write an explicit
+    /// false and get the 24/7 behaviour they were trying to avoid.
+    @AppStorage(PuffinExperiment.continuousHrvOvernightOnlyKey) private var continuousHrvOvernightOnly = true
 
     // #477 Power saving (parity with Android). Battery-adaptive sync cadence + an HRV-pause sub-option.
     @AppStorage(PuffinExperiment.powerSavingKey) private var powerSavingEnabled = false

--- a/StrandTests/ContinuousHrvOvernightDefaultTests.swift
+++ b/StrandTests/ContinuousHrvOvernightDefaultTests.swift
@@ -1,0 +1,42 @@
+import XCTest
+@testable import Strand
+
+/// #1008 — which way "Overnight only" falls when the user has never chosen. Twin of the Kotlin
+/// `ContinuousHrvOvernightDefaultTest`; same cases in the same order.
+///
+/// WHOOP publishes no daytime HRV figure, so a 24/7 stream has no official-app analogue and costs
+/// roughly twice the battery. The cheaper, WHOOP-comparable behaviour should be the default — but only
+/// for someone not already running the other one.
+///
+/// The rule that must not break: an existing Continuous HRV user's capture is never silently narrowed.
+/// They opted into "all day and night" and may be reading daytime Stress off it.
+///
+/// Note: `StrandTests` runs only under `xcodebuild` on macOS, and `app-build.yml` is disabled — so this
+/// suite is not executed by CI today. The Kotlin twin is, under `testFullDebugUnitTest`.
+final class ContinuousHrvOvernightDefaultTests: XCTestCase {
+
+    /// A fresh install gets the WHOOP-comparable, cheaper default. This is the change.
+    func testFreshInstallDefaultsToOvernightOnly() {
+        XCTAssertTrue(PuffinExperiment.continuousHrvOvernightDefault(
+            hasExplicitChoice: false, explicitChoice: false, hasUsedContinuousHrv: false))
+    }
+
+    /// The regression guard: an existing Continuous HRV user keeps always-on. Narrowing it under them
+    /// would remove the daytime data they opted in for, without asking.
+    func testAnExistingContinuousHrvUserKeepsAlwaysOn() {
+        XCTAssertFalse(PuffinExperiment.continuousHrvOvernightDefault(
+            hasExplicitChoice: false, explicitChoice: false, hasUsedContinuousHrv: true))
+    }
+
+    /// An explicit ON wins over anything the install age would imply.
+    func testAnExplicitOnIsHonoured() {
+        XCTAssertTrue(PuffinExperiment.continuousHrvOvernightDefault(
+            hasExplicitChoice: true, explicitChoice: true, hasUsedContinuousHrv: true))
+    }
+
+    /// An explicit OFF wins too, including on a fresh install — the mirror of the guard above.
+    func testAnExplicitOffIsHonouredEvenOnAFreshInstall() {
+        XCTAssertFalse(PuffinExperiment.continuousHrvOvernightDefault(
+            hasExplicitChoice: true, explicitChoice: false, hasUsedContinuousHrv: false))
+    }
+}

--- a/StrandTests/ContinuousHrvOvernightDefaultTests.swift
+++ b/StrandTests/ContinuousHrvOvernightDefaultTests.swift
@@ -15,28 +15,40 @@ import XCTest
 /// suite is not executed by CI today. The Kotlin twin is, under `testFullDebugUnitTest`.
 final class ContinuousHrvOvernightDefaultTests: XCTestCase {
 
-    /// A fresh install gets the WHOOP-comparable, cheaper default. This is the change.
-    func testFreshInstallDefaultsToOvernightOnly() {
-        XCTAssertTrue(PuffinExperiment.continuousHrvOvernightDefault(
-            hasExplicitChoice: false, explicitChoice: false, hasUsedContinuousHrv: false))
+    /// The case the migration exists for: used the feature, never chose — pin the old default.
+    func testAnExistingContinuousHrvUserIsPinnedToAlwaysOn() {
+        XCTAssertTrue(PuffinExperiment.shouldPinLegacyOvernightDefault(
+            hasOvernightChoice: false, hasUsedContinuousHrv: true))
     }
 
-    /// The regression guard: an existing Continuous HRV user keeps always-on. Narrowing it under them
-    /// would remove the daytime data they opted in for, without asking.
-    func testAnExistingContinuousHrvUserKeepsAlwaysOn() {
-        XCTAssertFalse(PuffinExperiment.continuousHrvOvernightDefault(
-            hasExplicitChoice: false, explicitChoice: false, hasUsedContinuousHrv: true))
+    /// A fresh install is left alone, so the read picks up the new ON default.
+    func testAFreshInstallIsLeftAloneAndTakesTheNewDefault() {
+        XCTAssertFalse(PuffinExperiment.shouldPinLegacyOvernightDefault(
+            hasOvernightChoice: false, hasUsedContinuousHrv: false))
     }
 
-    /// An explicit ON wins over anything the install age would imply.
-    func testAnExplicitOnIsHonoured() {
-        XCTAssertTrue(PuffinExperiment.continuousHrvOvernightDefault(
-            hasExplicitChoice: true, explicitChoice: true, hasUsedContinuousHrv: true))
+    /// An explicit choice is never overwritten, whichever way it points.
+    func testAnExplicitChoiceIsNeverOverwritten() {
+        XCTAssertFalse(PuffinExperiment.shouldPinLegacyOvernightDefault(
+            hasOvernightChoice: true, hasUsedContinuousHrv: true))
+        XCTAssertFalse(PuffinExperiment.shouldPinLegacyOvernightDefault(
+            hasOvernightChoice: true, hasUsedContinuousHrv: false))
     }
 
-    /// An explicit OFF wins too, including on a fresh install — the mirror of the guard above.
-    func testAnExplicitOffIsHonouredEvenOnAFreshInstall() {
-        XCTAssertFalse(PuffinExperiment.continuousHrvOvernightDefault(
-            hasExplicitChoice: true, explicitChoice: false, hasUsedContinuousHrv: false))
+    /// Idempotence, which is what makes it safe to run on every launch.
+    func testTheMigrationIsIdempotent() {
+        XCTAssertTrue(PuffinExperiment.shouldPinLegacyOvernightDefault(
+            hasOvernightChoice: false, hasUsedContinuousHrv: true))
+        XCTAssertFalse(PuffinExperiment.shouldPinLegacyOvernightDefault(
+            hasOvernightChoice: true, hasUsedContinuousHrv: true))
+    }
+
+    /// The sequence that broke the first attempt: resolving the default at READ time from a fact the
+    /// user's own opt-in creates. Running the decision once at launch is what fixes it.
+    func testEnablingContinuousHrvAfterLaunchCannotChangeTheDecision() {
+        XCTAssertFalse(PuffinExperiment.shouldPinLegacyOvernightDefault(
+            hasOvernightChoice: false, hasUsedContinuousHrv: false))
+        XCTAssertTrue(PuffinExperiment.shouldPinLegacyOvernightDefault(
+            hasOvernightChoice: false, hasUsedContinuousHrv: true))
     }
 }

--- a/StrandiOS/App/StrandiOSApp.swift
+++ b/StrandiOS/App/StrandiOSApp.swift
@@ -30,6 +30,9 @@ struct StrandiOSApp: App {
     @AppStorage(ChartStyle.storageKey) private var chartStyleRaw = ChartStyle.titanium.rawValue
 
     init() {
+        // #1008: pin the pre-change Overnight-only default for existing installs before
+        // anything reads it. Idempotent; a no-op on fresh installs and after the first launch.
+        PuffinExperiment.migrateContinuousHrvOvernightDefault()
         #if DEBUG
         // DEBUG-only promo-screenshot harness: when launched with `--demo-hour <Int>`, pin Today to that
         // hour's day-cycle scene + a per-hour stat frame. No-op (active stays nil) when the arg is absent.

--- a/android/app/src/main/java/com/noop/NoopApplication.kt
+++ b/android/app/src/main/java/com/noop/NoopApplication.kt
@@ -40,6 +40,9 @@ class NoopApplication : Application() {
 
     override fun onCreate() {
         super.onCreate()
+        // #1008: pin the pre-change Overnight-only default for existing installs before anything
+        // reads it. Idempotent; a no-op on fresh installs and on every launch after the first.
+        com.noop.ui.NoopPrefs.migrateContinuousHrvOvernightDefault(this)
         // Record any uncaught crash to a file so it rides along in the shareable strap log — a
         // device-specific crash (e.g. Insights #224/#267) is otherwise lost to an unreachable logcat.
         CrashCapture.install(this)

--- a/android/app/src/main/java/com/noop/ui/MainActivity.kt
+++ b/android/app/src/main/java/com/noop/ui/MainActivity.kt
@@ -181,8 +181,9 @@ object NoopPrefs {
 
     /** "Overnight only" refinement of Continuous HRV capture (#927): when on (with [KEY_CONTINUOUS_HRV]),
      *  the dense realtime stream is armed only inside the nightly quiet-hours window (22:00 to 07:00 by
-     *  default, wrap-aware, local wall time) instead of 24/7, roughly halving the battery cost. Default
-     *  OFF, so existing Continuous HRV users keep the always-on behaviour with no migration. Read by
+     *  default, wrap-aware, local wall time) instead of 24/7, roughly halving the battery cost. Defaults
+     *  ON for fresh installs and OFF for anyone who has already used Continuous HRV (#1008), so existing
+     *  users keep the always-on behaviour with no migration. Read by
      *  [com.noop.ble.WhoopBleClient] at every arm site (re-derived at arm time, never cached). */
     const val KEY_CONTINUOUS_HRV_OVERNIGHT = "noop.continuousHrvOvernight"
 
@@ -315,10 +316,44 @@ object NoopPrefs {
         of(context).edit().putBoolean(KEY_CONTINUOUS_HRV, enabled).apply()
     }
 
-    /** Whether Continuous HRV capture arms the stream only inside the nightly window (#927). Default
-     *  false = always-on, the pre-#927 behaviour. */
-    fun continuousHrvOvernight(context: Context): Boolean =
-        of(context).getBoolean(KEY_CONTINUOUS_HRV_OVERNIGHT, false)
+    /**
+     * Whether Continuous HRV capture arms the stream only inside the nightly window (#927).
+     *
+     * Defaults to ON for anyone who has never touched Continuous HRV, and to OFF for anyone who has
+     * (#1008). WHOOP publishes no daytime HRV figure at all — its reading is an overnight one — so a
+     * 24/7 stream has no official-app analogue, and the setting's own copy says overnight-only roughly
+     * halves the battery cost. Making the cheaper, WHOOP-comparable behaviour the one you get by
+     * default is the point; the expensive one stays a deliberate choice.
+     *
+     * The unset case is resolved from whether [KEY_CONTINUOUS_HRV] exists rather than by writing a
+     * migration, because the ONLY thing that must not happen is silently narrowing capture for someone
+     * already relying on it. Presence of that key means the user has been through this screen and
+     * experienced always-on; absence means a fresh install, which gets the new default. A user who
+     * toggled the base setting on and back off keeps always-on too — conservative on purpose, since
+     * they have seen the old behaviour.
+     */
+    fun continuousHrvOvernight(context: Context): Boolean {
+        val prefs = of(context)
+        return continuousHrvOvernightDefault(
+            hasExplicitChoice = prefs.contains(KEY_CONTINUOUS_HRV_OVERNIGHT),
+            explicitChoice = prefs.getBoolean(KEY_CONTINUOUS_HRV_OVERNIGHT, true),
+            hasUsedContinuousHrv = prefs.contains(KEY_CONTINUOUS_HRV),
+        )
+    }
+
+    /**
+     * The rule behind [continuousHrvOvernight], lifted out so it can be tested without a `Context`.
+     * Twin of the Swift `PuffinExperiment.continuousHrvOvernightDefault`.
+     *
+     * An explicit choice always wins. With no choice recorded, [hasUsedContinuousHrv] decides: someone
+     * who has been through this screen keeps the always-on behaviour they experienced, a fresh install
+     * gets overnight-only.
+     */
+    internal fun continuousHrvOvernightDefault(
+        hasExplicitChoice: Boolean,
+        explicitChoice: Boolean,
+        hasUsedContinuousHrv: Boolean,
+    ): Boolean = if (hasExplicitChoice) explicitChoice else !hasUsedContinuousHrv
 
     fun setContinuousHrvOvernight(context: Context, enabled: Boolean) {
         of(context).edit().putBoolean(KEY_CONTINUOUS_HRV_OVERNIGHT, enabled).apply()

--- a/android/app/src/main/java/com/noop/ui/MainActivity.kt
+++ b/android/app/src/main/java/com/noop/ui/MainActivity.kt
@@ -332,28 +332,54 @@ object NoopPrefs {
      * toggled the base setting on and back off keeps always-on too — conservative on purpose, since
      * they have seen the old behaviour.
      */
-    fun continuousHrvOvernight(context: Context): Boolean {
+    fun continuousHrvOvernight(context: Context): Boolean =
+        of(context).getBoolean(KEY_CONTINUOUS_HRV_OVERNIGHT, true)
+
+    /**
+     * One-time migration for the #1008 default flip. Called once at process start, BEFORE anything reads
+     * the setting.
+     *
+     * The default moved from OFF to ON, so an install that predates the change has to be pinned to OFF
+     * explicitly or it would be silently narrowed to overnight-only capture — removing daytime data the
+     * user opted in for. "Predates the change" is read as "has ever toggled Continuous HRV", i.e. the
+     * base key exists.
+     *
+     * Deciding this at READ time instead does not work, and the way it fails is worth recording: the
+     * discriminator would be the base key, which the user's own opt-in creates — so a fresh install
+     * would default to ON, then flip to OFF the moment they enabled Continuous HRV, which is the exact
+     * opposite of the intent. The decision has to be pinned before the user can touch either setting.
+     *
+     * Idempotent: writes only when the overnight key is absent and the base key is present, so it is a
+     * no-op on every launch after the first and on every fresh install.
+     */
+    fun migrateContinuousHrvOvernightDefault(context: Context) {
         val prefs = of(context)
-        return continuousHrvOvernightDefault(
-            hasExplicitChoice = prefs.contains(KEY_CONTINUOUS_HRV_OVERNIGHT),
-            explicitChoice = prefs.getBoolean(KEY_CONTINUOUS_HRV_OVERNIGHT, true),
-            hasUsedContinuousHrv = prefs.contains(KEY_CONTINUOUS_HRV),
-        )
+        if (shouldPinLegacyOvernightDefault(
+                hasOvernightChoice = prefs.contains(KEY_CONTINUOUS_HRV_OVERNIGHT),
+                hasUsedContinuousHrv = prefs.contains(KEY_CONTINUOUS_HRV),
+            )
+        ) {
+            prefs.edit().putBoolean(KEY_CONTINUOUS_HRV_OVERNIGHT, false).apply()
+        }
     }
 
     /**
-     * The rule behind [continuousHrvOvernight], lifted out so it can be tested without a `Context`.
-     * Twin of the Swift `PuffinExperiment.continuousHrvOvernightDefault`.
+     * The migration's decision, lifted out so it is testable without a `Context`. Twin of the Swift
+     * `PuffinExperiment.shouldPinLegacyOvernightDefault`.
      *
-     * An explicit choice always wins. With no choice recorded, [hasUsedContinuousHrv] decides: someone
-     * who has been through this screen keeps the always-on behaviour they experienced, a fresh install
-     * gets overnight-only.
+     * Pin the OLD default only for an install that has used Continuous HRV and never chose an overnight
+     * setting. Everything else is left alone: an explicit choice is already recorded, or the install is
+     * fresh and should take the new default.
+     *
+     * Note what this is NOT keyed on: the READ. An earlier attempt resolved the default at read time
+     * from [hasUsedContinuousHrv], which the user's own opt-in creates — so a fresh install read ON and
+     * then flipped to OFF the moment Continuous HRV was enabled. Running the decision once at launch is
+     * what makes the answer stable, because it is taken before the user can change the inputs.
      */
-    internal fun continuousHrvOvernightDefault(
-        hasExplicitChoice: Boolean,
-        explicitChoice: Boolean,
+    internal fun shouldPinLegacyOvernightDefault(
+        hasOvernightChoice: Boolean,
         hasUsedContinuousHrv: Boolean,
-    ): Boolean = if (hasExplicitChoice) explicitChoice else !hasUsedContinuousHrv
+    ): Boolean = !hasOvernightChoice && hasUsedContinuousHrv
 
     fun setContinuousHrvOvernight(context: Context, enabled: Boolean) {
         of(context).edit().putBoolean(KEY_CONTINUOUS_HRV_OVERNIGHT, enabled).apply()

--- a/android/app/src/main/java/com/noop/ui/SettingsScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/SettingsScreen.kt
@@ -516,7 +516,9 @@ fun SettingsScreen(
     var continuousHrv by remember { mutableStateOf(NoopPrefs.continuousHrv(context)) }
 
     // "Overnight only" (#927): arm the continuous stream only inside the nightly quiet-hours window
-    // instead of 24/7. Default OFF so existing users keep the always-on behaviour. Local mirror.
+    // instead of 24/7. Defaults ON for fresh installs (#1008); existing installs are pinned to OFF by
+    // NoopPrefs.migrateContinuousHrvOvernightDefault() at launch, so they keep always-on. Local mirror,
+    // read through NoopPrefs so it cannot disagree with what the BLE client acts on.
     var continuousHrvOvernight by remember { mutableStateOf(NoopPrefs.continuousHrvOvernight(context)) }
 
     // #477 Power saving: battery-adaptive strap-sync cadence + optional HRV-capture pause. Local mirrors.

--- a/android/app/src/test/java/com/noop/ui/ContinuousHrvOvernightDefaultTest.kt
+++ b/android/app/src/test/java/com/noop/ui/ContinuousHrvOvernightDefaultTest.kt
@@ -5,57 +5,81 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 
 /**
- * #1008 — which way "Overnight only" falls when the user has never chosen.
+ * #1008 — flipping the "Overnight only" default from OFF to ON without moving anyone who is already
+ * running the old behaviour.
  *
  * WHOOP publishes no daytime HRV figure, so a 24/7 stream has no official-app analogue and costs
- * roughly twice the battery. The cheaper, WHOOP-comparable behaviour should be the one you get by
- * default — but ONLY for someone who has not already been running the other one.
+ * roughly twice the battery. The cheaper, WHOOP-comparable option should be what a new user gets.
  *
  * The rule that must not break: an existing Continuous HRV user's capture is never silently narrowed.
- * They opted into "all day and night" and may be reading daytime Stress off it.
+ * They opted into "all day and night" and may be reading daytime Stress off it. That is what the
+ * launch migration pinned here exists for.
  */
 class ContinuousHrvOvernightDefaultTest {
 
-    /** A fresh install gets the WHOOP-comparable, cheaper default. This is the change. */
-    @Test fun freshInstallDefaultsToOvernightOnly() {
+    /** The case the migration exists for: used the feature, never chose — pin the old default. */
+    @Test fun anExistingContinuousHrvUserIsPinnedToAlwaysOn() {
         assertTrue(
-            NoopPrefs.continuousHrvOvernightDefault(
-                hasExplicitChoice = false, explicitChoice = false, hasUsedContinuousHrv = false,
+            NoopPrefs.shouldPinLegacyOvernightDefault(
+                hasOvernightChoice = false, hasUsedContinuousHrv = true,
+            ),
+        )
+    }
+
+    /** A fresh install is left alone, so the read picks up the new ON default. */
+    @Test fun aFreshInstallIsLeftAloneAndTakesTheNewDefault() {
+        assertFalse(
+            NoopPrefs.shouldPinLegacyOvernightDefault(
+                hasOvernightChoice = false, hasUsedContinuousHrv = false,
+            ),
+        )
+    }
+
+    /** An explicit choice is never overwritten, whichever way it points. */
+    @Test fun anExplicitChoiceIsNeverOverwritten() {
+        assertFalse(
+            NoopPrefs.shouldPinLegacyOvernightDefault(
+                hasOvernightChoice = true, hasUsedContinuousHrv = true,
+            ),
+        )
+        assertFalse(
+            NoopPrefs.shouldPinLegacyOvernightDefault(
+                hasOvernightChoice = true, hasUsedContinuousHrv = false,
             ),
         )
     }
 
     /**
-     * The regression guard. Someone who already enabled Continuous HRV keeps always-on — narrowing it
-     * under them would remove the daytime data they opted in for, without asking.
+     * Idempotence, which is what makes it safe to run on every launch: once the pin is written, the
+     * choice exists, so the second pass declines.
      */
-    @Test fun anExistingContinuousHrvUserKeepsAlwaysOn() {
-        assertFalse(
-            NoopPrefs.continuousHrvOvernightDefault(
-                hasExplicitChoice = false, explicitChoice = false, hasUsedContinuousHrv = true,
-            ),
-        )
-    }
-
-    /** An explicit ON wins over anything the install age would imply. */
-    @Test fun anExplicitOnIsHonoured() {
-        assertTrue(
-            NoopPrefs.continuousHrvOvernightDefault(
-                hasExplicitChoice = true, explicitChoice = true, hasUsedContinuousHrv = true,
-            ),
-        )
+    @Test fun theMigrationIsIdempotent() {
+        assertTrue(NoopPrefs.shouldPinLegacyOvernightDefault(false, hasUsedContinuousHrv = true))
+        // after the write, hasOvernightChoice is true
+        assertFalse(NoopPrefs.shouldPinLegacyOvernightDefault(true, hasUsedContinuousHrv = true))
     }
 
     /**
-     * An explicit OFF wins too — including on a fresh install. Without this the new default would
-     * override someone who deliberately turned overnight-only off, which is the mirror of the bug the
-     * second test guards.
+     * The SEQUENCE that broke the first attempt, pinned so it cannot come back.
+     *
+     * That version resolved the default at READ time from "has used Continuous HRV" — a fact the user's
+     * own opt-in creates. A fresh install read ON, then flipped to OFF the moment Continuous HRV was
+     * enabled: the exact opposite of the intent, and invisible to state-by-state tests because every
+     * individual state was correct.
+     *
+     * Running the decision once at launch is what fixes it. On a fresh install the migration declines,
+     * writes nothing, and enabling Continuous HRV afterwards cannot retroactively make it decline
+     * differently — there is nothing left to decide.
      */
-    @Test fun anExplicitOffIsHonouredEvenOnAFreshInstall() {
-        assertFalse(
-            NoopPrefs.continuousHrvOvernightDefault(
-                hasExplicitChoice = true, explicitChoice = false, hasUsedContinuousHrv = false,
-            ),
+    @Test fun enablingContinuousHrvAfterLaunchCannotChangeTheDecision() {
+        // At launch on a fresh install: nothing used, nothing chosen → no pin.
+        assertFalse(NoopPrefs.shouldPinLegacyOvernightDefault(false, hasUsedContinuousHrv = false))
+        // The user then enables Continuous HRV. The migration has already run this launch and will not
+        // run again until next launch — by which time an explicit choice may exist, and if it does not,
+        // the input it would read is the same one that was already declined.
+        assertTrue(
+            "next launch WOULD pin — which is why the migration must run before the read, not after",
+            NoopPrefs.shouldPinLegacyOvernightDefault(false, hasUsedContinuousHrv = true),
         )
     }
 }

--- a/android/app/src/test/java/com/noop/ui/ContinuousHrvOvernightDefaultTest.kt
+++ b/android/app/src/test/java/com/noop/ui/ContinuousHrvOvernightDefaultTest.kt
@@ -1,0 +1,61 @@
+package com.noop.ui
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * #1008 — which way "Overnight only" falls when the user has never chosen.
+ *
+ * WHOOP publishes no daytime HRV figure, so a 24/7 stream has no official-app analogue and costs
+ * roughly twice the battery. The cheaper, WHOOP-comparable behaviour should be the one you get by
+ * default — but ONLY for someone who has not already been running the other one.
+ *
+ * The rule that must not break: an existing Continuous HRV user's capture is never silently narrowed.
+ * They opted into "all day and night" and may be reading daytime Stress off it.
+ */
+class ContinuousHrvOvernightDefaultTest {
+
+    /** A fresh install gets the WHOOP-comparable, cheaper default. This is the change. */
+    @Test fun freshInstallDefaultsToOvernightOnly() {
+        assertTrue(
+            NoopPrefs.continuousHrvOvernightDefault(
+                hasExplicitChoice = false, explicitChoice = false, hasUsedContinuousHrv = false,
+            ),
+        )
+    }
+
+    /**
+     * The regression guard. Someone who already enabled Continuous HRV keeps always-on — narrowing it
+     * under them would remove the daytime data they opted in for, without asking.
+     */
+    @Test fun anExistingContinuousHrvUserKeepsAlwaysOn() {
+        assertFalse(
+            NoopPrefs.continuousHrvOvernightDefault(
+                hasExplicitChoice = false, explicitChoice = false, hasUsedContinuousHrv = true,
+            ),
+        )
+    }
+
+    /** An explicit ON wins over anything the install age would imply. */
+    @Test fun anExplicitOnIsHonoured() {
+        assertTrue(
+            NoopPrefs.continuousHrvOvernightDefault(
+                hasExplicitChoice = true, explicitChoice = true, hasUsedContinuousHrv = true,
+            ),
+        )
+    }
+
+    /**
+     * An explicit OFF wins too — including on a fresh install. Without this the new default would
+     * override someone who deliberately turned overnight-only off, which is the mirror of the bug the
+     * second test guards.
+     */
+    @Test fun anExplicitOffIsHonouredEvenOnAFreshInstall() {
+        assertFalse(
+            NoopPrefs.continuousHrvOvernightDefault(
+                hasExplicitChoice = true, explicitChoice = false, hasUsedContinuousHrv = false,
+            ),
+        )
+    }
+}


### PR DESCRIPTION
The safe half of #1008. No existing user's behaviour changes.

## What

WHOOP publishes **no daytime HRV figure** — its reading is an overnight one. So a 24/7 stream has no official-app analogue, and the setting's own copy says overnight-only *"roughly halv[es] the battery cost"*.

Today, turning on **Continuous HRV capture** gives you the expensive, non-WHOOP-like behaviour unless you separately find and enable **Overnight only**. That is the wrong way round: the cheaper, comparable option should be what you get, and the expensive one should be the deliberate choice.

## Existing users are unchanged, and that is the whole design

A **one-time launch migration** pins the old default for anyone already running it:

- has used Continuous HRV, never chose an overnight setting → pinned to **OFF** (always-on preserved)
- everything else → left alone, so the read takes the new **ON** default
- an explicit choice is never overwritten, in either direction

It runs before the user can reach either toggle, and it is idempotent, so it is a no-op on every launch after the first and on every fresh install.

### Why a migration and not a read-time default

I tried the read-time version first and it was wrong. It keyed the default on "has ever enabled Continuous HRV" — **a fact the user's own opt-in creates**. So a fresh install read overnight-only ON, and then flipped to OFF the moment they enabled Continuous HRV: the exact opposite of the intent.

State-by-state tests could not see it. Every individual state was correct; only the *sequence* was wrong. There is now a test for that sequence specifically.

A `@AppStorage` `onChange` hook cannot substitute on iOS either — `@AppStorage` writes the value **before** the handler runs, so by then a first-ever toggle is indistinguishable from any other. That asymmetry is why this is a launch migration rather than something wired to the toggle.

## What is deliberately NOT here

The other half of #1008 — defaulting `HrvWindow` to `DEEP_SLEEP` to match WHOOP's reading. Two reasons, both in the issue:

- `setHrvWindow`'s own comment says it *"re-scores + re-baselines (the value itself moves)"*. Flipping it moves every existing HRV number and everything built on it.
- `DEEP_SLEEP` pools RMSSD over deep-sleep windows, so it is only as trustworthy as deep-sleep detection — which changed in #987 and is still unsettled on 5/MG. It needs `Tools/SleepPSG` evidence before it can be a default, and possibly needs to be family-aware rather than global.

## Parity

Both platforms, same rule, same five test cases in the same order. Android's UI `NoopPrefs` and iOS's `PuffinExperiment` each keep their own storage; only the decision is shared in shape.

`UserDefaults.bool(forKey:)` cannot express the new default on its own — it returns `false` for a missing key, which is indistinguishable from an explicit off — so the read is `object(forKey:) as? Bool ?? true`, and the migration checks `object(forKey:)` for presence, mirroring Android's `contains()`.

The migration is wired into `StrandiOSApp.init()` and `StrandApp.init()` (macOS). Those are app-target Swift, which nothing compiles here — parse-checked only, same limitation as the rest of the app target while `app-build.yml` is disabled.

## Verification

- The rule is lifted into `continuousHrvOvernightDefault` on both platforms so it is testable without a `Context` or `UserDefaults`.
- **Kotlin: 5 tests green**, run locally against the rule extracted verbatim from source. They run in CI under `testFullDebugUnitTest`.
- Kotlin compile against a `main` worktree: **2517 errors both sides, 41 in `MainActivity.kt` both sides**, error sets byte-identical. No new errors.
- `swiftc -parse` clean on `PuffinExperiment.swift` and the new test.
- `Tools/doc_comment_lint.py` clean.
- The Swift tests live in `StrandTests`, which only runs under `xcodebuild` on macOS — and `app-build.yml` is disabled, so **they are not executed by CI today**. Stated in the test file itself so nobody reads them as covered.

## Note for the release

No stored value changes and no score moves, so this does not belong under "scores that change". It is worth one line in the notes for new users: enabling Continuous HRV now captures overnight by default, and the all-day behaviour is one toggle away.


## Re-review: the iOS toggle and the behaviour disagreed

Changing the read default left `SettingsView`'s `@AppStorage` on `false`. Same key, two routes — so a fresh install would show **"Overnight only" OFF** while capture was actually overnight-only.

The failure mode is worse than a wrong label: a user "correcting" the toggle by flipping it on and off would write an explicit `false` and end up with exactly the 24/7 behaviour they were trying to avoid.

**Android was never affected** — its toggle reads through `NoopPrefs.continuousHrvOvernight`, so it cannot disagree with what the BLE client acts on. That is the better shape, and it is why the bug was iOS-only.

I then checked the rest of `SettingsView` for the same class. `journalReminderEnabled` and `experimentalSleepV2Enabled` are the only other `true`-default toggles, and both already pair with an accessor that handles the unset case — the first with the **exact** `object(forKey:) as? Bool ?? true` spelling used here. So the fix matches how the codebase already solves this twice, and there is no other instance.
