### PR TITLE
iOS widget: Charge · Effort · Rest as score rings

### DIFF
--- a/StrandiOS/Widgets/WidgetPublish.swift
+++ b/StrandiOS/Widgets/WidgetPublish.swift
@@ -45,19 +45,33 @@ extension WidgetSnapshot {
             let anchorIsToday = day.day == Repository.localDayKey(now)
             restScore = restByDay[day.day] ?? (anchorIsToday ? restSeries.last?.value : nil)
         }
+        // #313: honour the user's Effort scale at publish time. The widget extension cannot read the
+        // app's plain `@AppStorage(UnitPrefs.effortScaleKey)` (it is not in the App Group), so we
+        // pre-format the display string here and keep the 0–100 int for the ring fill (the fill
+        // fraction is scale-independent: 38/100 == 8.0/21).
+        let effortScale = UnitPrefs.resolveEffortScale(
+            UserDefaults.standard.string(forKey: UnitPrefs.effortScaleKey) ?? ""
+        )
+        let strain = day?.strain
+        let effortDisplay: String? = strain.map { stored in
+            if effortScale == .whoop {
+                return String(format: "%.1f", UnitFormatter.effortValue(stored, scale: .whoop))
+            }
+            return "\(Int(stored.rounded()))"
+        }
         let snap = WidgetSnapshot(
             recovery: day?.recovery.map { Int($0.rounded()) },
             bpm: model.bpm ?? model.live.heartRate,
             batteryPct: model.live.batteryPct.map { Int($0.rounded()) },
             bonded: model.live.bonded,
             updated: Date(),
-            // Effort is stored on NOOP's 0–100 axis (the same value the Today Effort tile reads), so it
-            // publishes as a whole number without the WHOOP-0–21 toggle the main app applies — the widget
-            // extension can't reach UnitFormatter/UnitPrefs, and 0–100 is the default scale.
-            effort: day?.strain.map { Int($0.rounded()) },
+            // Stored 0–100 axis for ring fill; display string carries the #313 scale.
+            effort: strain.map { Int($0.rounded()) },
             rest: restScore.map { Int($0.rounded()) },
             hrv: day?.avgHrv.map { Int($0.rounded()) },
-            restingHr: day?.restingHr
+            restingHr: day?.restingHr,
+            effortDisplay: effortDisplay,
+            effortWhoop: effortScale == .whoop
         )
         snap.save()
         WidgetCenter.shared.reloadAllTimelines()

--- a/StrandiOSShared/WidgetSnapshot.swift
+++ b/StrandiOSShared/WidgetSnapshot.swift
@@ -11,13 +11,20 @@ public struct WidgetSnapshot: Codable, Equatable {
     public var updated: Date
     // Richer glance fields (#446). All OPTIONAL with nil defaults so a snapshot written by an OLDER app
     // build (which never encoded these keys) still decodes — Codable fills a missing optional with nil.
-    public var effort: Int?      // Effort / strain on NOOP's 0–100 axis
+    public var effort: Int?      // Effort / strain on NOOP's 0–100 axis (ring fill is always this / 100)
     public var rest: Int?        // Rest (sleep_performance) score, 0–100
     public var hrv: Int?         // HRV (ms), whole-number for the glance
     public var restingHr: Int?   // Resting heart rate (bpm)
+    // #313 Effort scale for the glance. Pre-formatted at publish time because the widget extension
+    // cannot read the app's plain UserDefaults `effort.scale` key (it lives outside the App Group).
+    // When nil (older snapshot), the widget falls back to whole-number `effort` on the 0–100 axis.
+    public var effortDisplay: String?
+    /// True when `effortDisplay` is on WHOOP's 0–21 axis; false/nil means 0–100. Accessibility only.
+    public var effortWhoop: Bool?
 
     public init(recovery: Int?, bpm: Int?, batteryPct: Int?, bonded: Bool, updated: Date,
-                effort: Int? = nil, rest: Int? = nil, hrv: Int? = nil, restingHr: Int? = nil) {
+                effort: Int? = nil, rest: Int? = nil, hrv: Int? = nil, restingHr: Int? = nil,
+                effortDisplay: String? = nil, effortWhoop: Bool? = nil) {
         self.recovery = recovery
         self.bpm = bpm
         self.batteryPct = batteryPct
@@ -27,6 +34,8 @@ public struct WidgetSnapshot: Codable, Equatable {
         self.rest = rest
         self.hrv = hrv
         self.restingHr = restingHr
+        self.effortDisplay = effortDisplay
+        self.effortWhoop = effortWhoop
     }
 
     /// App Group suite the app and widget both use. Injected from the `APP_GROUP_ID` build setting
@@ -56,7 +65,8 @@ public struct WidgetSnapshot: Codable, Equatable {
         // Gallery / pre-publish stand-in: realistic Charge · Effort · Rest on the 0–100 axis so the
         // three-ring Home Screen layouts (and the large grid) preview with filled arcs, not dashes.
         WidgetSnapshot(recovery: 72, bpm: 58, batteryPct: 84, bonded: true, updated: Date(),
-                       effort: 38, rest: 81, hrv: 64, restingHr: 52)
+                       effort: 38, rest: 81, hrv: 64, restingHr: 52,
+                       effortDisplay: "38", effortWhoop: false)
     }
 
     /// Read the last-published snapshot from the shared suite, if any.

--- a/StrandiOSShared/WidgetSnapshot.swift
+++ b/StrandiOSShared/WidgetSnapshot.swift
@@ -53,8 +53,10 @@ public struct WidgetSnapshot: Codable, Equatable {
     }
 
     public static var placeholder: WidgetSnapshot {
+        // Gallery / pre-publish stand-in: realistic Charge · Effort · Rest on the 0–100 axis so the
+        // three-ring Home Screen layouts (and the large grid) preview with filled arcs, not dashes.
         WidgetSnapshot(recovery: 72, bpm: 58, batteryPct: 84, bonded: true, updated: Date(),
-                       effort: 8, rest: 81, hrv: 64, restingHr: 52)
+                       effort: 38, rest: 81, hrv: 64, restingHr: 52)
     }
 
     /// Read the last-published snapshot from the shared suite, if any.

--- a/StrandiOSWidgets/NOOPWidget.swift
+++ b/StrandiOSWidgets/NOOPWidget.swift
@@ -52,21 +52,25 @@ struct NOOPWidgetView: View {
         }
     }
 
-    // MARK: - Colours (match Today tile tints)
+    // MARK: - Colours (match Today's GlowRing domain constants)
 
     private var chargeColor: Color {
-        guard snap.recovery != nil else { return StrandPalette.textTertiary }
-        return StrandPalette.chargeColor
+        snap.recovery != nil ? StrandPalette.chargeColor : StrandPalette.textTertiary
     }
 
+    /// Fixed domain accent — same as `TodayView.effortRing` (`StrandPalette.effortColor`), not the
+    /// value-sampled `effortTint` ramp the old footer bolt used.
     private var effortColor: Color {
-        guard let e = snap.effort else { return StrandPalette.textTertiary }
-        return StrandPalette.effortTint(fraction: Double(e) / 100)
+        snap.effort != nil ? StrandPalette.effortColor : StrandPalette.textTertiary
     }
 
     private var restColor: Color {
-        guard let r = snap.rest else { return StrandPalette.textTertiary }
-        return StrandPalette.restColor
+        snap.rest != nil ? StrandPalette.restColor : StrandPalette.textTertiary
+    }
+
+    /// Effort centre/accessory text: pre-formatted #313 display when present, else whole-number 0–100.
+    private var effortText: String? {
+        snap.effortDisplay ?? snap.effort.map(String.init)
     }
 
     private var inlineText: String {
@@ -103,18 +107,18 @@ struct NOOPWidgetView: View {
                 }
             }
             HStack(alignment: .top, spacing: 0) {
-                accessoryScore("Charge", value: snap.recovery, tint: chargeColor, suffix: "%")
-                accessoryScore("Effort", value: snap.effort, tint: effortColor)
-                accessoryScore("Rest", value: snap.rest, tint: restColor, suffix: "%")
+                accessoryScore("Charge", text: snap.recovery.map { "\($0)%" }, tint: chargeColor)
+                accessoryScore("Effort", text: effortText, tint: effortColor)
+                accessoryScore("Rest", text: snap.rest.map { "\($0)%" }, tint: restColor)
             }
         }
     }
 
-    private func accessoryScore(_ label: String, value: Int?, tint: Color, suffix: String = "") -> some View {
+    private func accessoryScore(_ label: String, text: String?, tint: Color) -> some View {
         VStack(alignment: .leading, spacing: 0) {
-            Text(value.map { "\($0)\(suffix)" } ?? "–")
+            Text(text ?? "–")
                 .font(.system(size: 16, weight: .semibold, design: .rounded))
-                .foregroundStyle(value == nil ? StrandPalette.textTertiary : tint)
+                .foregroundStyle(text == nil ? StrandPalette.textTertiary : tint)
                 .minimumScaleFactor(0.7)
             Text(label)
                 .font(.system(size: 9))
@@ -125,12 +129,13 @@ struct NOOPWidgetView: View {
 
     // MARK: - Home Screen: systemSmall
 
-    /// Compact three-ring hero: Charge · Effort · Rest. HR + battery stay on a thin footer so the
-    /// rings own the card (the old big Charge-% layout hid Effort/Rest entirely on small).
+    /// Compact three-ring hero. Diameter is capped so three hard-framed circles fit the narrowest
+    /// systemSmall content width (SE ~128pt after padding) without overlapping — see review on #1022.
     private var small: some View {
         VStack(spacing: 6) {
             headerRow
-            scoreRings(diameter: 52, lineWidth: 5, labelFont: .system(size: 9, weight: .medium))
+            // 40pt × 3 = 120 ≤ 128 (SE) / 138 (15 Pro) content widths after 10pt padding.
+            scoreRings(diameter: 40, lineWidth: 4, labelFont: .system(size: 9, weight: .medium))
             Spacer(minLength: 0)
             vitalsFooter(compact: true)
         }
@@ -189,28 +194,35 @@ struct NOOPWidgetView: View {
     private func scoreRings(diameter: CGFloat, lineWidth: CGFloat, labelFont: Font) -> some View {
         HStack(alignment: .top, spacing: 0) {
             WidgetScoreRing(
-                value: snap.recovery,
+                text: snap.recovery.map(String.init),
+                fraction: snap.recovery.map { Double($0) / 100 },
                 label: "Charge",
                 color: chargeColor,
                 diameter: diameter,
                 lineWidth: lineWidth,
-                labelFont: labelFont
+                labelFont: labelFont,
+                accessibilityOutOf: 100
             )
             WidgetScoreRing(
-                value: snap.effort,
+                text: effortText,
+                // Fill is always the stored 0–100 axis so WHOOP 0–21 and native 0–100 agree on arc length.
+                fraction: snap.effort.map { Double($0) / 100 },
                 label: "Effort",
                 color: effortColor,
                 diameter: diameter,
                 lineWidth: lineWidth,
-                labelFont: labelFont
+                labelFont: labelFont,
+                accessibilityOutOf: (snap.effortWhoop == true) ? 21 : 100
             )
             WidgetScoreRing(
-                value: snap.rest,
+                text: snap.rest.map(String.init),
+                fraction: snap.rest.map { Double($0) / 100 },
                 label: "Rest",
                 color: restColor,
                 diameter: diameter,
                 lineWidth: lineWidth,
-                labelFont: labelFont
+                labelFont: labelFont,
+                accessibilityOutOf: 100
             )
         }
         .frame(maxWidth: .infinity)
@@ -255,16 +267,20 @@ struct NOOPWidgetView: View {
 /// Deliberately avoids `GlowRing`'s draw-in `@State` animation — WidgetKit timelines don't reliably
 /// fire `onAppear`, so an animated ring can freeze empty (0 fill) until the next timeline rebuild.
 private struct WidgetScoreRing: View {
-    let value: Int?
+    /// Centre read-out already formatted (whole number, or one-decimal WHOOP Effort).
+    let text: String?
+    /// Arc fill 0…1; nil draws the empty track only (unscored).
+    let fraction: Double?
     let label: String
     let color: Color
     let diameter: CGFloat
     let lineWidth: CGFloat
     let labelFont: Font
+    let accessibilityOutOf: Int
 
-    private var fraction: CGFloat {
-        guard let value else { return 0 }
-        return CGFloat(min(max(Double(value) / 100.0, 0), 1))
+    private var clampedFraction: CGFloat {
+        guard let fraction else { return 0 }
+        return CGFloat(min(max(fraction, 0), 1))
     }
 
     var body: some View {
@@ -273,15 +289,16 @@ private struct WidgetScoreRing: View {
                 Circle()
                     .stroke(StrandPalette.textPrimary.opacity(0.10),
                             style: StrokeStyle(lineWidth: lineWidth, lineCap: .round))
-                if value != nil {
+                if fraction != nil {
                     Circle()
-                        .trim(from: 0, to: max(0.0001, fraction))
+                        // A genuine zero still draws a round-cap bead so scored-0 reads as data, not absence.
+                        .trim(from: 0, to: max(0.0001, clampedFraction))
                         .stroke(color, style: StrokeStyle(lineWidth: lineWidth, lineCap: .round))
                         .rotationEffect(.degrees(-90))
                 }
-                Text(value.map(String.init) ?? "–")
+                Text(text ?? "–")
                     .font(StrandFont.rounded(diameter * 0.34, weight: .bold))
-                    .foregroundStyle(value == nil ? StrandPalette.textTertiary : StrandPalette.textPrimary)
+                    .foregroundStyle(text == nil ? StrandPalette.textTertiary : StrandPalette.textPrimary)
                     .monospacedDigit()
                     .lineLimit(1)
                     .minimumScaleFactor(0.5)
@@ -297,7 +314,7 @@ private struct WidgetScoreRing: View {
         .frame(maxWidth: .infinity)
         .accessibilityElement(children: .ignore)
         .accessibilityLabel(Text(label))
-        .accessibilityValue(Text(value.map { "\($0) out of 100" } ?? "unavailable"))
+        .accessibilityValue(Text(text.map { "\($0) out of \(accessibilityOutOf)" } ?? "unavailable"))
     }
 }
 

--- a/StrandiOSWidgets/NOOPWidget.swift
+++ b/StrandiOSWidgets/NOOPWidget.swift
@@ -25,8 +25,9 @@ struct NOOPProvider: TimelineProvider {
     }
 }
 
-/// The glanceable widget — the iOS analogue of the macOS menu-bar extra. Recovery, live/last HR,
-/// and strap battery.
+/// The glanceable widget — the iOS analogue of the macOS menu-bar extra.
+/// Home Screen families mirror Today's hero trio (Charge · Effort · Rest) as score rings; Lock Screen
+/// accessories stay compact single-line / gauge layouts.
 struct NOOPWidgetView: View {
     @Environment(\.widgetFamily) private var family
     let entry: NOOPEntry
@@ -43,18 +44,21 @@ struct NOOPWidgetView: View {
             rectangular
         case .systemLarge:
             large
+        case .systemMedium:
+            medium
         default:
-            home
+            // systemSmall (and any future compact family)
+            small
         }
     }
 
-    private var recoveryColor: Color {
-        guard let r = snap.recovery else { return StrandPalette.textTertiary }
-        return r >= 67 ? StrandPalette.statusPositive : r >= 34 ? StrandPalette.statusWarning : StrandPalette.statusCritical
+    // MARK: - Colours (match Today tile tints)
+
+    private var chargeColor: Color {
+        guard snap.recovery != nil else { return StrandPalette.textTertiary }
+        return StrandPalette.chargeColor
     }
 
-    /// Effort is on the 0–100 axis (`StrainScorer.maxStrain == 100`), so the fraction is just the value
-    /// over 100 — the same input `effortTint` takes on the Today Effort tile.
     private var effortColor: Color {
         guard let e = snap.effort else { return StrandPalette.textTertiary }
         return StrandPalette.effortTint(fraction: Double(e) / 100)
@@ -62,7 +66,7 @@ struct NOOPWidgetView: View {
 
     private var restColor: Color {
         guard let r = snap.rest else { return StrandPalette.textTertiary }
-        return StrandPalette.recoveryColor(Double(r))
+        return StrandPalette.restColor
     }
 
     private var inlineText: String {
@@ -72,6 +76,8 @@ struct NOOPWidgetView: View {
         return parts.isEmpty ? "NOOP" : parts.joined(separator: " · ")
     }
 
+    // MARK: - Lock Screen accessories
+
     private var recoveryGauge: some View {
         Gauge(value: Double(snap.recovery ?? 0), in: 0...100) {
             Image(systemName: "heart.fill")
@@ -79,83 +85,81 @@ struct NOOPWidgetView: View {
             Text(snap.recovery.map { "\($0)" } ?? "–")
         }
         .gaugeStyle(.accessoryCircular)
-        .tint(recoveryColor)
+        .tint(chargeColor)
     }
 
-    /// Lock-Screen rectangular accessory. Two lines (#446): line 1 the Charge headline, line 2 the live
-    /// HR alongside Effort so the at-a-glance pair the users asked for both fit the tinted accessory.
+    /// Lock-Screen rectangular accessory: Charge · Effort · Rest, same trio as the Home Screen rings.
     private var rectangular: some View {
         VStack(alignment: .leading, spacing: 2) {
             HStack(spacing: 4) {
-                Image(systemName: "heart.fill").foregroundStyle(recoveryColor)
-                Text("Charge \(snap.recovery.map(String.init) ?? "–")%").font(.headline)
+                Text("NOOP")
+                    .font(.system(size: 11, weight: .bold))
+                    .foregroundStyle(StrandPalette.textSecondary)
+                Spacer(minLength: 0)
+                if let bpm = snap.bpm {
+                    Text("\(bpm) bpm")
+                        .font(.caption2)
+                        .foregroundStyle(StrandPalette.textTertiary)
+                }
             }
-            Text("HR \(snap.bpm.map(String.init) ?? "–") · Effort \(snap.effort.map(String.init) ?? "–")")
-                .font(.caption)
+            HStack(alignment: .top, spacing: 0) {
+                accessoryScore("Charge", value: snap.recovery, tint: chargeColor, suffix: "%")
+                accessoryScore("Effort", value: snap.effort, tint: effortColor)
+                accessoryScore("Rest", value: snap.rest, tint: restColor, suffix: "%")
+            }
         }
     }
 
-    private var home: some View {
-        VStack(alignment: .leading, spacing: 10) {
-            HStack {
-                Text("NOOP").font(.system(size: 13, weight: .bold))
-                    .foregroundStyle(StrandPalette.textSecondary)
-                Spacer()
-                Circle().fill(snap.bonded ? StrandPalette.statusPositive : StrandPalette.statusCritical)
-                    .frame(width: 8, height: 8)
-            }
+    private func accessoryScore(_ label: String, value: Int?, tint: Color, suffix: String = "") -> some View {
+        VStack(alignment: .leading, spacing: 0) {
+            Text(value.map { "\($0)\(suffix)" } ?? "–")
+                .font(.system(size: 16, weight: .semibold, design: .rounded))
+                .foregroundStyle(value == nil ? StrandPalette.textTertiary : tint)
+                .minimumScaleFactor(0.7)
+            Text(label)
+                .font(.system(size: 9))
+                .foregroundStyle(StrandPalette.textTertiary)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    // MARK: - Home Screen: systemSmall
+
+    /// Compact three-ring hero: Charge · Effort · Rest. HR + battery stay on a thin footer so the
+    /// rings own the card (the old big Charge-% layout hid Effort/Rest entirely on small).
+    private var small: some View {
+        VStack(spacing: 6) {
+            headerRow
+            scoreRings(diameter: 52, lineWidth: 5, labelFont: .system(size: 9, weight: .medium))
             Spacer(minLength: 0)
-            HStack(alignment: .firstTextBaseline, spacing: 4) {
-                Text(snap.recovery.map(String.init) ?? "–")
-                    .font(.system(size: 40, weight: .bold, design: .rounded))
-                    .foregroundStyle(recoveryColor)
-                Text("%").font(.headline).foregroundStyle(StrandPalette.textTertiary)
-            }
-            Text("Charge").font(.caption).foregroundStyle(StrandPalette.textTertiary)
+            vitalsFooter(compact: true)
+        }
+        .padding(10)
+    }
+
+    // MARK: - Home Screen: systemMedium
+
+    /// Wider three-ring row with room for a fuller vitals footer (live HR + strap battery).
+    private var medium: some View {
+        VStack(spacing: 8) {
+            headerRow
+            scoreRings(diameter: 72, lineWidth: 7, labelFont: .caption2)
             Spacer(minLength: 0)
-            HStack {
-                Label("\(snap.bpm.map(String.init) ?? "–")", systemImage: "waveform.path.ecg")
-                // Medium has room for one more stat (#446); small stays a clean Charge + HR + battery.
-                if family == .systemMedium {
-                    Spacer()
-                    Label("\(snap.effort.map(String.init) ?? "–")", systemImage: "bolt.fill")
-                }
-                Spacer()
-                Label("\(snap.batteryPct.map { "\($0)%" } ?? "–")", systemImage: "battery.50")
-            }
-            .font(.caption2).foregroundStyle(StrandPalette.textSecondary)
+            vitalsFooter(compact: false)
         }
         .padding(12)
     }
 
-    /// The rich `systemLarge` layout (#446): the Charge headline plus a stat grid of Effort, Rest, HRV,
-    /// Resting HR, live HR and strap battery — the "show me more" the issue asked for.
+    // MARK: - Home Screen: systemLarge
+
+    /// Rings on top, then the richer stat grid (HRV, RHR, live HR, battery) — "show me more".
     private var large: some View {
         VStack(alignment: .leading, spacing: 12) {
-            HStack {
-                Text("NOOP").font(.system(size: 13, weight: .bold))
-                    .foregroundStyle(StrandPalette.textSecondary)
-                Spacer()
-                Circle().fill(snap.bonded ? StrandPalette.statusPositive : StrandPalette.statusCritical)
-                    .frame(width: 8, height: 8)
-            }
-            HStack(alignment: .firstTextBaseline, spacing: 4) {
-                Text(snap.recovery.map(String.init) ?? "–")
-                    .font(.system(size: 48, weight: .bold, design: .rounded))
-                    .foregroundStyle(recoveryColor)
-                Text("%").font(.title3).foregroundStyle(StrandPalette.textTertiary)
-                Text("Charge").font(.subheadline).foregroundStyle(StrandPalette.textTertiary)
-                    .padding(.leading, 2)
-            }
+            headerRow
+            scoreRings(diameter: 88, lineWidth: 8, labelFont: .caption)
             Divider()
-            // Two-by-three stat grid of the richer scores. Each cell is a value + label pairing, tinted to
-            // match its Today tile where a token exists (Effort, Rest); raw vitals stay neutral.
             HStack(alignment: .top, spacing: 0) {
-                statCell("Effort", value: snap.effort.map(String.init), tint: effortColor)
-                statCell("Rest", value: snap.rest.map { "\($0)%" }, tint: restColor)
                 statCell("HRV", value: snap.hrv.map { "\($0)" }, unit: "ms")
-            }
-            HStack(alignment: .top, spacing: 0) {
                 statCell("Rest HR", value: snap.restingHr.map { "\($0)" }, unit: "bpm")
                 statCell("HR", value: snap.bpm.map { "\($0)" }, unit: "bpm")
                 statCell("Battery", value: snap.batteryPct.map { "\($0)%" })
@@ -165,7 +169,69 @@ struct NOOPWidgetView: View {
         .padding(16)
     }
 
-    /// One labelled stat in the large grid — value over a caption, equal-width so the three columns align.
+    // MARK: - Shared pieces
+
+    private var headerRow: some View {
+        HStack {
+            Text("NOOP")
+                .font(.system(size: 13, weight: .bold))
+                .foregroundStyle(StrandPalette.textSecondary)
+            Spacer()
+            Circle()
+                .fill(snap.bonded ? StrandPalette.statusPositive : StrandPalette.statusCritical)
+                .frame(width: 8, height: 8)
+                .accessibilityLabel(snap.bonded ? Text("Connected") : Text("Disconnected"))
+        }
+    }
+
+    /// The Today hero trio as static score rings (widget-safe: no draw-in animation / onAppear race).
+    /// Order matches TodayView: Charge · Effort · Rest. Each cell is honest-null ("–") until scored.
+    private func scoreRings(diameter: CGFloat, lineWidth: CGFloat, labelFont: Font) -> some View {
+        HStack(alignment: .top, spacing: 0) {
+            WidgetScoreRing(
+                value: snap.recovery,
+                label: "Charge",
+                color: chargeColor,
+                diameter: diameter,
+                lineWidth: lineWidth,
+                labelFont: labelFont
+            )
+            WidgetScoreRing(
+                value: snap.effort,
+                label: "Effort",
+                color: effortColor,
+                diameter: diameter,
+                lineWidth: lineWidth,
+                labelFont: labelFont
+            )
+            WidgetScoreRing(
+                value: snap.rest,
+                label: "Rest",
+                color: restColor,
+                diameter: diameter,
+                lineWidth: lineWidth,
+                labelFont: labelFont
+            )
+        }
+        .frame(maxWidth: .infinity)
+    }
+
+    private func vitalsFooter(compact: Bool) -> some View {
+        HStack {
+            Label(snap.bpm.map(String.init) ?? "–", systemImage: "waveform.path.ecg")
+            Spacer()
+            if !compact, let hrv = snap.hrv {
+                Label("\(hrv)", systemImage: "heart.fill")
+                Spacer()
+            }
+            Label(snap.batteryPct.map { "\($0)%" } ?? "–", systemImage: "battery.50")
+        }
+        .font(.caption2)
+        .foregroundStyle(StrandPalette.textSecondary)
+        .labelStyle(.titleAndIcon)
+    }
+
+    /// One labelled stat in the large grid — value over a caption, equal-width so the columns align.
     private func statCell(_ label: String, value: String?, unit: String? = nil,
                           tint: Color = StrandPalette.textPrimary) -> some View {
         VStack(alignment: .leading, spacing: 2) {
@@ -183,6 +249,58 @@ struct NOOPWidgetView: View {
     }
 }
 
+// MARK: - WidgetScoreRing
+
+/// A static, widget-safe score ring: full-circle track + solid arc + centre number + caption.
+/// Deliberately avoids `GlowRing`'s draw-in `@State` animation — WidgetKit timelines don't reliably
+/// fire `onAppear`, so an animated ring can freeze empty (0 fill) until the next timeline rebuild.
+private struct WidgetScoreRing: View {
+    let value: Int?
+    let label: String
+    let color: Color
+    let diameter: CGFloat
+    let lineWidth: CGFloat
+    let labelFont: Font
+
+    private var fraction: CGFloat {
+        guard let value else { return 0 }
+        return CGFloat(min(max(Double(value) / 100.0, 0), 1))
+    }
+
+    var body: some View {
+        VStack(spacing: 4) {
+            ZStack {
+                Circle()
+                    .stroke(StrandPalette.textPrimary.opacity(0.10),
+                            style: StrokeStyle(lineWidth: lineWidth, lineCap: .round))
+                if value != nil {
+                    Circle()
+                        .trim(from: 0, to: max(0.0001, fraction))
+                        .stroke(color, style: StrokeStyle(lineWidth: lineWidth, lineCap: .round))
+                        .rotationEffect(.degrees(-90))
+                }
+                Text(value.map(String.init) ?? "–")
+                    .font(StrandFont.rounded(diameter * 0.34, weight: .bold))
+                    .foregroundStyle(value == nil ? StrandPalette.textTertiary : StrandPalette.textPrimary)
+                    .monospacedDigit()
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.5)
+                    .padding(.horizontal, lineWidth + 2)
+            }
+            .frame(width: diameter, height: diameter)
+            Text(label)
+                .font(labelFont)
+                .foregroundStyle(StrandPalette.textTertiary)
+                .lineLimit(1)
+                .minimumScaleFactor(0.7)
+        }
+        .frame(maxWidth: .infinity)
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(Text(label))
+        .accessibilityValue(Text(value.map { "\($0) out of 100" } ?? "unavailable"))
+    }
+}
+
 struct NOOPWidget: Widget {
     let kind = "NOOPWidget"
 
@@ -197,8 +315,8 @@ struct NOOPWidget: Widget {
                     .background(StrandPalette.surfaceBase)
             }
         }
-        .configurationDisplayName("NOOP Charge")
-        .description("Charge, Effort, Rest, HRV, resting and live heart rate, and strap battery at a glance.")
+        .configurationDisplayName("NOOP")
+        .description("Charge, Effort and Rest as score rings, plus live HR and strap battery at a glance.")
         .supportedFamilies([
             .systemSmall, .systemMedium, .systemLarge,
             .accessoryCircular, .accessoryInline, .accessoryRectangular


### PR DESCRIPTION
## Summary

Improves the iOS Home Screen / Lock Screen widget so it shows the same three daily scores as Today's hero — **Charge** (Erholung), **Effort** (Belastung), and **Rest** (Ruhe) — as score rings, instead of only a large Charge percentage with sparse footer icons.

### Before
- Small/medium: big Charge `%` + HR + battery (medium also showed Effort as a bolt icon)
- Effort and Rest were already in `WidgetSnapshot` from `#446` but mostly unused on compact families

### After
- **systemSmall / systemMedium**: three equal score rings (Charge · Effort · Rest), matching TodayView order and domain colours (`chargeColor` / effort tint / `restColor`)
- Footer keeps live HR + strap battery (medium also shows HRV when present)
- **systemLarge**: the same three rings on top, then HRV / Rest HR / live HR / battery grid
- **Lock Screen rectangular**: Charge · Effort · Rest triplet (was Charge + HR · Effort only)
- Widget-safe static ring (no `GlowRing` draw-in `@State`) so arcs don't freeze empty when WidgetKit skips `onAppear`
- Gallery placeholder Effort set to a realistic 0–100 value so previews show filled arcs

Data path is unchanged: `WidgetSnapshot.publish` already writes recovery / effort / rest / hrv / restingHr / bpm / battery.

## Test plan

- [x] `xcodegen generate`
- [x] `xcodebuild -project Strand.xcodeproj -scheme NOOPiOS -destination 'generic/platform=iOS' CODE_SIGNING_ALLOWED=NO build` (succeeds)
- [x] On device / simulator: open NOOP so a snapshot publishes, add the NOOP widget (small, medium, large) and confirm three rings match Today
- [x] Unscored day: rings show `–` with empty track, not fabricated zeros
- [x] Lock Screen rectangular accessory shows Charge · Effort · Rest
- [x] Bonded/disconnected dot still reflects connection state