### PR TITLE
iOS: write to Apple Health when an offload lands, not only on foreground entry (#1021)

### DIFF
--- a/Strand/App/AppModel.swift
+++ b/Strand/App/AppModel.swift
@@ -531,6 +531,14 @@ final class AppModel: ObservableObject {
         await intelligence.analyzeRecent()
     }
 
+    #if os(iOS)
+    /// Push freshly-offloaded data to Apple Health, set by `StrandiOSApp` (#1021).
+    ///
+    /// A closure rather than a direct reference because `HealthKitBridge` owns iOS-only HealthKit state
+    /// while this type is shared with macOS, and the bridge is a `@StateObject` the app scene owns.
+    var healthWriteBack: (() async -> Void)?
+    #endif
+
     private func refreshAfterCompletedBackfill() async {
         live.append(log: "Backfill: refreshing dashboard cache from completed sync")
         await repo.refresh(days: 120)
@@ -548,6 +556,11 @@ final class AppModel: ObservableObject {
         // widget kept showing yesterday's numbers. Publishing here, on the real "new data landed"
         // signal, pushes the fresh snapshot to the home-screen widget without needing a foreground.
         await WidgetSnapshot.publish(from: self)
+        // #1021: same reasoning as the widget publish above, for Apple Health. The only automatic
+        // write-back ran on scenePhase == .active, in the same block that KICKS this offload - so it
+        // raced the data it was meant to publish and last night's sleep reached Health an app-open late.
+        // Set by StrandiOSApp; nil on macOS and in tests, where there is no bridge.
+        await healthWriteBack?()
         #endif
     }
 

--- a/StrandiOS/App/StrandiOSApp.swift
+++ b/StrandiOS/App/StrandiOSApp.swift
@@ -55,11 +55,17 @@ struct StrandiOSApp: App {
         UNUserNotificationCenter.current().delegate = NotificationPresenter.shared
         let model = AppModel()
         _model = StateObject(wrappedValue: model)
-        _health = StateObject(wrappedValue: HealthKitBridge(
+        let bridge = HealthKitBridge(
             repo: model.repo,
             appleDeviceId: model.appleDeviceId,
             noopDeviceId: model.deviceId
-        ))
+        )
+        _health = StateObject(wrappedValue: bridge)
+        // #1021: publish to Apple Health when an offload lands, not only on foreground entry - the
+        // scenePhase pass below starts the offload and wrote to Health in parallel with it, so a night
+        // synced on open only reached Health at the next launch. Weak so the scene owns the bridge's
+        // lifetime; the bridge no-ops unless Health was authorized.
+        model.healthWriteBack = { [weak bridge] in await bridge?.writeBackAfterNewData() }
     }
 
     var body: some Scene {

--- a/StrandiOS/Health/HealthKitBridge.swift
+++ b/StrandiOS/Health/HealthKitBridge.swift
@@ -545,6 +545,33 @@ final class HealthKitBridge: ObservableObject {
         }
     }
 
+    /// Write-back only, for when fresh strap data lands (#1021).
+    ///
+    /// `sync` is the two-way pass and runs on foreground entry, which is the wrong moment: the same
+    /// scenePhase block kicks the strap offload, so the write raced the data it was meant to publish and
+    /// last night's sleep only reached Health on the NEXT app open. `AppModel.refreshAfterCompletedBackfill`
+    /// is the real "new data landed" signal - the same one #980 already publishes the widget from - and it
+    /// also fires for a backfill that completes while the app is backgrounded.
+    ///
+    /// Deliberately not `sync()`: that would re-read 30 days out of Health and re-run the hydration /
+    /// caffeine imports on every offload, to write the same rows. The Android twin is the same shape -
+    /// `WhoopBleClient` calls `HealthConnectWriter.write` after the backfill, not a full re-sync.
+    ///
+    /// `lastSync` is left alone: it marks the last full two-way pass, and a write-only run advancing it
+    /// would misreport when NOOP last READ from Health.
+    func writeBackAfterNewData() async {
+        guard auth == .authorized, !syncing else { return }
+        syncing = true
+        defer { syncing = false }
+        guard let store = await repo.storeHandle() else { return }
+        do {
+            try await writeBack(whoopStore: store)
+            lastError = nil
+        } catch {
+            lastError = String(localized: "Apple Health sync failed: \(error.localizedDescription)")
+        }
+    }
+
     // MARK: - Write back (NOOP → Health)
 
     /// Write NOOP's strap-derived data into Apple Health: sleep sessions with full stage segments,

--- a/StrandiOS/Health/HealthKitBridge.swift
+++ b/StrandiOS/Health/HealthKitBridge.swift
@@ -224,8 +224,13 @@ final class HealthKitBridge: ObservableObject {
             // share status, so declining any checkbox just skips that feature.
             // Raw request, NOT requestAuthorization(): that method reclassifies a thrown error as
             // `.denied`, which must never demote a bridge that just resumed a valid legacy grant.
+            //
+            // FOREGROUND only, for the same reason `requestNewReadTypesIfNeeded` is: this resume is now
+            // also called from the offload write-back (#1021), which runs in processes that were never
+            // foregrounded. Asking there would spend the one request we get where no sheet can be
+            // presented. The status read above is unaffected, so a legacy grant still resumes.
             let newTypesPending = writeTypes.contains { store.authorizationStatus(for: $0) == .notDetermined }
-            if newTypesPending {
+            if newTypesPending, UIApplication.shared.applicationState == .active {
                 Task { try? await store.requestAuthorization(toShare: writeTypes, read: readTypes) }
             }
         }
@@ -559,7 +564,18 @@ final class HealthKitBridge: ObservableObject {
     ///
     /// `lastSync` is left alone: it marks the last full two-way pass, and a write-only run advancing it
     /// would misreport when NOOP last READ from Health.
+    ///
+    /// Shares the `syncing` flag with `sync()` on purpose: two write-backs must never interleave, because
+    /// the vitals dedup deletes our prior samples for a key before saving the fresh batch. The cost is
+    /// that a foreground `sync()` arriving during a background write skips that one read pass and picks
+    /// up on the next open - a few seconds' window, and nothing is lost.
     func writeBackAfterNewData() async {
+        // A backfill routinely completes in a process that was never foregrounded (a background offload,
+        // or a BLE relaunch) - the case this exists for. `auth` is still `.unknown` there, because the
+        // only resume runs on scenePhase == .active, so without this the guard below would silently drop
+        // exactly the writes this is meant to deliver. Idempotent, and never prompts: it reads share
+        // status, and its re-request for new types is foreground-gated.
+        refreshAuthIfPreviouslyGranted()
         guard auth == .authorized, !syncing else { return }
         syncing = true
         defer { syncing = false }


### PR DESCRIPTION
Fixes #1021.

## The gap

The reporter's night showed up in NOOP but not in Apple Health, and their own line — "normally the data would go to Apple Health but it didn't" — is the tell. The export isn't missing; `HealthKitBridge.writeBack` has written sleep stages, the 1-minute HR stream, workouts and nightly vitals since #249. The **trigger** is wrong.

There was one automatic trigger, on `scenePhase == .active`:

```swift
model.ble.requestSync(.foreground)   // starts the strap offload — seconds to minutes
Task {
    health.refreshAuthIfPreviouslyGranted()
    await health.sync()              // writes to Health, in parallel
}
```

Those run concurrently. Open NOOP after a night and it starts pulling the sleep off the strap *and* writes to Health at the same moment — so Health receives the state from before the offload. The sleep lands in the database a minute later and nothing pushes it onward. It arrives at the **next** app open, which is exactly why this usually looks like it works.

## What changes

`refreshAfterCompletedBackfill` is the real "new data landed" signal, and #980 already publishes the widget from it for precisely this reason — a backfill routinely completes while the app is backgrounded, where no scenePhase trigger ever fires. Apple Health was simply missed there.

Three small pieces:

- `HealthKitBridge.writeBackAfterNewData()` — write-only, guarded on `auth == .authorized` and the existing `syncing` flag.
- `AppModel.healthWriteBack` — an optional closure, called inside the existing `#if os(iOS)` block next to the widget publish. A closure rather than a direct reference because `HealthKitBridge` is iOS-only while `AppModel` is shared with macOS.
- `StrandiOSApp` wires the two together at construction.

**Write-only, not `sync()`.** A full pass would re-read 30 days out of Health and re-run the hydration / caffeine imports on every offload, to write the same rows. `lastSync` is left alone — it marks the last two-way pass, so a write-only run advancing it would misreport when NOOP last *read* from Health.

## Parity

This is iOS catching up. Android has done it since #660 — `WhoopBleClient` calls `HealthConnectWriter.write` once the backfill completes, gated on the `hcWriteback` opt-in, with the comment "keep the opt-in Health Connect writeback fresh in background-only operation too." Same signal, same shape.

## Deliberately not included

`writeBack` opens with `guard auth == .authorized else { return }`, and `refreshAuthIfPreviouslyGranted` only reaches that state when **every** core write type is `.sharingAuthorized`. One toggle off in Health → Sources stops the entire write-back — sleep included, even when sleep was granted — silently, with no `lastError` set. That is a real second defect and an independent way to produce the same symptom, but it is not what happened here (it would have been broken on every open, not just the first), and folding a permissions rework into a trigger fix would make both harder to judge.

## Re-review: the first cut didn't work in the case it was written for

The write-back guards on `auth == .authorized`. That state is only reached via the connect button or `refreshAuthIfPreviouslyGranted()` — and the sole caller of that was `scenePhase == .active`.

So for a backfill completing while the app was backgrounded, or in a process BLE relaunched that the user never opened, `auth` was still `.unknown` and the new write was silently dropped. It would only have fired once the app had been foregrounded that process — which is close to the bug it was fixing. The resume now runs on the write path too; it no-ops unless `auth` is `.unknown` and only reads share status.

That resume has one prompting branch — the re-request for write types added since the user's grant — and it is now foreground-gated, for the same reason `requestNewReadTypesIfNeeded` already is: asking where no sheet can be presented spends the single request we get and the user is never actually asked.

Also verified while re-reviewing:

- The hook rides `live.$lastSyncedAt` debounced 2s past the last slice (#755), so it fires **once** per completed backfill, not per offload slice — no write storm on a heavy history.
- Moving the bridge's construction from the `StateObject` autoclosure to eager is benign: its `init` is three assignments plus two capability checks, no queries, no observers, no authorization.
- Sharing the `syncing` flag with `sync()` is deliberate, now documented — two write-backs must not interleave, because the vitals dedup deletes prior samples for a key before saving. The cost is a foreground `sync()` arriving mid-write skipping that one read pass; it picks up on the next open.

Third pass found nothing further to change, and cleared four more things:

- **Sideloaded builds are unaffected by this race.** They can't reach HealthKit at all and use `ShortcutHealthExport` (#155), which fires on `scenePhase == .background` — app exit, after the offload — not on `.active`. It does go stale for a backfill that completes while backgrounded, but it carries a watermark so the next write catches the same span up, and it is opt-in and off by default. Left alone rather than folded in here.
- **Strict concurrency is `minimal` and the target is Swift 5**, so the `[weak bridge]` closure stored on the `@MainActor` `AppModel` is not a concurrency error. The existing `init` already constructs two `@MainActor` types, which is what proves that `init` is main-actor isolated.
- **`enableLiveDelivery()`, now reachable from a background offload via the resume, is benign.** It tears down any prior observer per type before re-registering — written for exactly the "both auth paths ran" case — and HealthKit's background delivery is persistent across launches, so any user who granted access already has it armed. No new background wakes.
- **Ordering inside the hook is right:** `analyzeRecent()` scores the freshly-offloaded night *before* the write runs, and `WidgetSnapshot.publish` goes first, so the widget is never delayed behind a multi-second Health write.

## Verification

Honest about the limits here:

- `swiftc -parse` clean on all three files; `Tools/doc_comment_lint.py` clean; `Tools/i18n_audit.py --ci main` clean (the error string reuses the existing catalogue entry, so no new literal).
- **Not compile-verified.** `app-build.yml` is disabled, so nothing in CI builds app-target Swift, and this host has no macOS toolchain. Worth an `xcodebuild` before merge.
- **No test.** HealthKit needs a real device and the entitlement, `StrandTests` runs in no workflow, and the added logic is a guard plus a call — a test here would assert the mock, not the fix. The behaviour to confirm on device is: sync a night with the app open, background it, and check Health has the sleep without a second launch.


