### PR TITLE
HRV: record the measured deep-staging bias where the window is defined (#1008)

### DIFF
--- a/Strand/Data/Units.swift
+++ b/Strand/Data/Units.swift
@@ -61,7 +61,17 @@ enum TrendChartStyle: String, CaseIterable, Identifiable {
 enum HrvWindow: String, CaseIterable, Identifiable {
     /// RMSSD averaged over every 5-min window of the night (NOOP's long-standing value).
     case whole
-    /// RMSSD over DEEP (slow-wave) sleep windows only — comparable to WHOOP's reading.
+    /// RMSSD over DEEP (slow-wave) sleep windows only — the window WHOOP samples.
+    ///
+    /// "Comparable to WHOOP" describes the METHOD, not the accuracy of the resulting number: the deep
+    /// windows come from NOOP's own stager, not the strap. `Tools/SleepPSG` scores that stager against
+    /// PSG truth over 31 subjects / 26 773 epochs and measures deep at 18.94 % predicted vs 13.76 %
+    /// truth — a +5.18 pp bias, roughly 38 % more deep epochs than exist, at four-class kappa 0.356.
+    /// An over-inclusive deep window pulls this value back toward the whole-night mean, which is the
+    /// one thing the setting exists not to be.
+    ///
+    /// So this stays opt-in and `whole` stays the default. #1008 tracks moving it, gated on that bias
+    /// coming down; re-run the benchmark before changing the default rather than assuming it has.
     case deep
     var id: String { rawValue }
     /// Segmented-control label.

--- a/android/app/src/main/java/com/noop/ui/Units.kt
+++ b/android/app/src/main/java/com/noop/ui/Units.kt
@@ -87,7 +87,19 @@ enum class HrvWindow(val raw: String) {
     /** RMSSD averaged over every 5-min window of the night (NOOP's long-standing value). */
     WHOLE_NIGHT("whole"),
 
-    /** RMSSD over DEEP (slow-wave) sleep windows only — comparable to WHOOP's reading. */
+    /**
+     * RMSSD over DEEP (slow-wave) sleep windows only — the window WHOOP samples.
+     *
+     * "Comparable to WHOOP" describes the METHOD, not the accuracy of the resulting number: the deep
+     * windows come from NOOP's own stager, not the strap. `Tools/SleepPSG` scores that stager against
+     * PSG truth over 31 subjects / 26 773 epochs and measures deep at 18.94 % predicted vs 13.76 %
+     * truth — a +5.18 pp bias, roughly 38 % more deep epochs than exist, at four-class kappa 0.356.
+     * An over-inclusive deep window pulls this value back toward the whole-night mean, which is the
+     * one thing the setting exists not to be.
+     *
+     * So this stays opt-in and WHOLE_NIGHT stays the default. #1008 tracks moving it, gated on that
+     * bias coming down; re-run the benchmark before changing the default rather than assuming it has.
+     */
     DEEP_SLEEP("deep");
 
     companion object {


### PR DESCRIPTION
Follow-up to #1008, which is otherwise correctly parked.

Both `HrvWindow` enums describe `DEEP_SLEEP` as *"comparable to WHOOP's reading"*, and #1008 quoted that line as the justification for making it the default. The phrase is about the **method** — the same window WHOOP samples — but it reads as a claim about the number.

It isn't, because the deep windows come from NOOP's own stager rather than the strap. `Tools/SleepPSG` scores that stager against PSG truth over 31 subjects / 26 773 epochs:

| | predicted | truth | bias |
|---|---|---|---|
| deep, pooled | **18.94 %** | 13.76 % | **+5.18 pp** |
| deep, per-subject mean | 19.24 % | 14.76 % | +4.48 pp |

Four-class kappa **0.356**. That is roughly 38 % more deep epochs than exist, and an over-inclusive deep window pulls the pooled RMSSD back toward the whole-night mean — the one thing the setting exists not to be.

This records that at both definitions, with the re-run instruction, so the next person weighing the default finds it there instead of in an issue thread.

## Why this shape

- **Not a test.** The benchmark needs a PhysioNet dataset that is deliberately never committed, so it cannot run in CI. A recorded figure plus "re-run before changing the default" is the honest version.
- **Not a copy change.** `SettingsView` also says Deep sleep is *"matching WHOOP"*, which overclaims in the same way — but changing user-facing copy means new strings across four focus locales, which is a poor trade for a hedge. Left alone deliberately; worth revisiting if the default ever moves.
- **Not the default itself.** #1008 stays open and gated on the bias coming down.

Docs only: no behaviour change, no schema, no user-facing text. Twin comments so the two platforms keep saying the same thing.