### PR TITLE
Export busy guards: clear in a finally, and share the one spinner row (#961 follow-up)

### DIFF
--- a/Strand/Screens/SettingsView.swift
+++ b/Strand/Screens/SettingsView.swift
@@ -1866,10 +1866,13 @@ struct SettingsView: View {
         let stamp = FileExport.timestamp()
         rawAndLogBusy = true
         Task {
+            // `defer` so the flag is cleared on ANY exit (#961 follow-up), including cancellation. It
+            // cleared correctly before, but only because `exportPair` is non-throwing — the guard should
+            // not depend on that. Otherwise the button stays disabled behind a spinner that never stops.
+            defer { rawAndLogBusy = false }
             await FileExport.exportPair(
                 file: capture, fileSuggestedName: "noop-raw-capture-\(stamp).json",
                 text: live.exportableLogText(), textSuggestedName: "noop-strap-log-\(stamp).txt")
-            rawAndLogBusy = false
         }
     }
 

--- a/android/app/src/main/java/com/noop/ui/NoopButton.kt
+++ b/android/app/src/main/java/com/noop/ui/NoopButton.kt
@@ -14,7 +14,9 @@ import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -210,5 +212,29 @@ fun NoopButton(
             maxLines = 1,
             overflow = TextOverflow.Ellipsis,
         )
+    }
+}
+
+/**
+ * The "an export is running" row: spinner plus a short status word, shown under a button that is
+ * disabled while its work is in flight.
+ *
+ * Five call sites across Settings and Test Centre had this block copied verbatim, down to the 18.dp and
+ * the 2.dp stroke, so a change to how a busy export reads meant editing it five times and the copies
+ * could drift. The update-checker's inline spinner is deliberately NOT folded in here: it is a different
+ * size, sits inside its button rather than under it, and says "Checking…".
+ */
+@Composable
+fun NoopBusyRow() {
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        CircularProgressIndicator(
+            color = Palette.accent,
+            strokeWidth = 2.dp,
+            modifier = Modifier.size(18.dp),
+        )
+        Text(uiString(R.string.l10n_settings_screen_working_13b7bfca), style = NoopType.footnote, color = Palette.textSecondary)
     }
 }

--- a/android/app/src/main/java/com/noop/ui/SettingsScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/SettingsScreen.kt
@@ -428,6 +428,10 @@ fun SettingsScreen(
     // caller, so these buttons no longer freeze the UI — but nothing else stopped a second tap mid-export
     // either. A big raw capture is exactly when someone taps twice, firing two zips / two chooser
     // intents. Same disable-while-busy + spinner shape as backupBusy above, one flag per button.
+    // Each clears in a `finally`, not after the call: they only cleared correctly before because every
+    // LogExport entry point happens to wrap its body in runCatching. The guard should not depend on a
+    // callee's error handling - a throw would strand the button disabled behind a spinner that never
+    // stops, with no way back short of leaving the screen.
     var strapLogBusy by remember { mutableStateOf(false) }
     var whoop5CaptureBusy by remember { mutableStateOf(false) }
     var rawAndLogBusy by remember { mutableStateOf(false) }
@@ -1653,23 +1657,17 @@ fun SettingsScreen(
                     onClick = {
                         strapLogBusy = true
                         scope.launch {
-                            LogExport.shareStrapLog(context, vm.ble.exportLogText())
-                            strapLogBusy = false
+                            // try/finally: the flag must clear on any exit, not just the happy path (#961 follow-up).
+                            try {
+                                LogExport.shareStrapLog(context, vm.ble.exportLogText())
+                            } finally {
+                                strapLogBusy = false
+                            }
                         }
                     },
                 )
                 if (strapLogBusy) {
-                    Row(
-                        verticalAlignment = Alignment.CenterVertically,
-                        horizontalArrangement = Arrangement.spacedBy(8.dp),
-                    ) {
-                        CircularProgressIndicator(
-                            color = Palette.accent,
-                            strokeWidth = 2.dp,
-                            modifier = Modifier.size(18.dp),
-                        )
-                        Text(uiString(R.string.l10n_settings_screen_working_13b7bfca), style = NoopType.footnote, color = Palette.textSecondary)
-                    }
+                    NoopBusyRow()
                 }
 
                 // "WHOOP 4.0 vs 5.0/MG — what each can read and why" (FI-2 / #490). Shown to BOTH model
@@ -2076,23 +2074,17 @@ fun SettingsScreen(
                     onClick = {
                         whoop5CaptureBusy = true
                         scope.launch {
-                            LogExport.shareWhoop5Capture(context, live.whoop5Detected)
-                            whoop5CaptureBusy = false
+                            // try/finally: the flag must clear on any exit, not just the happy path (#961 follow-up).
+                            try {
+                                LogExport.shareWhoop5Capture(context, live.whoop5Detected)
+                            } finally {
+                                whoop5CaptureBusy = false
+                            }
                         }
                     },
                 )
                 if (whoop5CaptureBusy) {
-                    Row(
-                        verticalAlignment = Alignment.CenterVertically,
-                        horizontalArrangement = Arrangement.spacedBy(8.dp),
-                    ) {
-                        CircularProgressIndicator(
-                            color = Palette.accent,
-                            strokeWidth = 2.dp,
-                            modifier = Modifier.size(18.dp),
-                        )
-                        Text(uiString(R.string.l10n_settings_screen_working_13b7bfca), style = NoopType.footnote, color = Palette.textSecondary)
-                    }
+                    NoopBusyRow()
                 }
 
                 // One-tap "matched pair" export (#510): hands a reporter BOTH the raw capture file and
@@ -2107,23 +2099,17 @@ fun SettingsScreen(
                     onClick = {
                         rawAndLogBusy = true
                         scope.launch {
-                            LogExport.shareRawAndLog(context, vm.ble.exportLogText(), live.whoop5Detected)
-                            rawAndLogBusy = false
+                            // try/finally: the flag must clear on any exit, not just the happy path (#961 follow-up).
+                            try {
+                                LogExport.shareRawAndLog(context, vm.ble.exportLogText(), live.whoop5Detected)
+                            } finally {
+                                rawAndLogBusy = false
+                            }
                         }
                     },
                 )
                 if (rawAndLogBusy) {
-                    Row(
-                        verticalAlignment = Alignment.CenterVertically,
-                        horizontalArrangement = Arrangement.spacedBy(8.dp),
-                    ) {
-                        CircularProgressIndicator(
-                            color = Palette.accent,
-                            strokeWidth = 2.dp,
-                            modifier = Modifier.size(18.dp),
-                        )
-                        Text(uiString(R.string.l10n_settings_screen_working_13b7bfca), style = NoopType.footnote, color = Palette.textSecondary)
-                    }
+                    NoopBusyRow()
                 }
             }
         }
@@ -2586,17 +2572,7 @@ fun SettingsScreen(
                 }
 
                 if (backupBusy) {
-                    Row(
-                        verticalAlignment = Alignment.CenterVertically,
-                        horizontalArrangement = Arrangement.spacedBy(8.dp),
-                    ) {
-                        CircularProgressIndicator(
-                            color = Palette.accent,
-                            strokeWidth = 2.dp,
-                            modifier = Modifier.size(18.dp),
-                        )
-                        Text(uiString(R.string.l10n_settings_screen_working_13b7bfca), style = NoopType.footnote, color = Palette.textSecondary)
-                    }
+                    NoopBusyRow()
                 }
 
                 NoteRow(

--- a/android/app/src/main/java/com/noop/ui/TestCentreScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/TestCentreScreen.kt
@@ -21,7 +21,6 @@ import androidx.compose.material.icons.filled.Info
 import androidx.compose.material.icons.filled.Science
 import androidx.compose.material.icons.filled.Upload
 import androidx.compose.material3.AlertDialog
-import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.Switch
@@ -196,17 +195,21 @@ fun TestCentreScreen(vm: AppViewModel) {
                     reportShareBusy = true
                     p.gate.confirm()
                     scope.launch {
-                        TestReportFlow.run(
-                            context = context,
-                            profile = p.profile,
-                            title = p.title,
-                            version = BuildConfig.VERSION_NAME,
-                            platform = "Android",
-                            osVersion = android.os.Build.VERSION.RELEASE ?: "?",
-                            gate = p.gate,
-                            entries = p.entries,
-                        )
-                        reportShareBusy = false
+                        // try/finally: the flag must clear on any exit, not just the happy path (#961 follow-up).
+                        try {
+                            TestReportFlow.run(
+                                context = context,
+                                profile = p.profile,
+                                title = p.title,
+                                version = BuildConfig.VERSION_NAME,
+                                platform = "Android",
+                                osVersion = android.os.Build.VERSION.RELEASE ?: "?",
+                                gate = p.gate,
+                                entries = p.entries,
+                            )
+                        } finally {
+                            reportShareBusy = false
+                        }
                     }
                     pendingReport = null
                 }
@@ -364,23 +367,17 @@ private fun DiagnosticToolsCard(vm: AppViewModel) {
                 onClick = {
                     strapLogBusy = true
                     scope.launch {
-                        LogExport.shareStrapLog(context, vm.ble.exportLogText())
-                        strapLogBusy = false
+                        // try/finally: the flag must clear on any exit, not just the happy path (#961 follow-up).
+                        try {
+                            LogExport.shareStrapLog(context, vm.ble.exportLogText())
+                        } finally {
+                            strapLogBusy = false
+                        }
                     }
                 },
             )
             if (strapLogBusy) {
-                Row(
-                    verticalAlignment = Alignment.CenterVertically,
-                    horizontalArrangement = Arrangement.spacedBy(8.dp),
-                ) {
-                    CircularProgressIndicator(
-                        color = Palette.accent,
-                        strokeWidth = 2.dp,
-                        modifier = Modifier.size(18.dp),
-                    )
-                    Text(uiString(R.string.l10n_settings_screen_working_13b7bfca), style = NoopType.footnote, color = Palette.textSecondary)
-                }
+                NoopBusyRow()
             }
             // Recalibrate Charge baseline, the same Baselines.recalibrateRecoveryBaselines call.
             NoopButton(


### PR DESCRIPTION
Follow-up to #961, from the nits on that review. No behaviour change.

## The guards only cleared on the happy path

#961 added disable-while-busy guards to the export buttons, each shaped like this:

```kotlin
strapLogBusy = true
scope.launch {
    LogExport.shareStrapLog(context, vm.ble.exportLogText())
    strapLogBusy = false          // last statement — skipped if the call throws
}
```

That cleared correctly, but only because every callee happens to swallow its own errors: `LogExport`'s four entry points, `TestReportFlow.run`, and Swift's non-throwing `exportPair` all wrap in `runCatching` or can't throw at all.

The guard shouldn't depend on that. It is an implicit coupling to a callee's internals, and the failure mode is bad out of proportion to the odds: a throw strands the button **permanently disabled behind a spinner that never stops**, with no way back short of leaving the screen. One `finally` removes the dependency entirely.

Four Android sites move to `try`/`finally`; the Swift one gets `defer`, which also covers cancellation.

## One spinner row instead of five

The busy row was copied verbatim at five call sites across Settings and Test Centre — identical down to the `18.dp` and the `2.dp` stroke — so changing how a busy export reads meant five edits, and the copies could drift.

Now `NoopBusyRow`, beside `NoopButton`. One of the five predates #961, so this is slightly wider than the review noted.

The update checker's spinner is deliberately **not** folded in: different size, sits inside its button rather than under it, and says "Checking…" rather than "Working…". Folding it in would have meant parameterising the helper into something that earns its keep less than the duplication did.

## Not included

The copy mismatch I raised on the review — Android says `Working…`, the Swift button says `Exporting…`. I withdrew it: no `Exporting` string exists on Android, and `Working…` is already translated across the focus locales, so harmonising costs a new string plus four translations in either direction. Not worth it for one word.

### `backupBusy` is left alone, deliberately

The three backup/import/CSV launchers in the same file clear `backupBusy` the same way — last statement after the work, safe only because `runCatching` sits inside their `withContext`. Same pattern, same implicit coupling.

Not folded in here: it is a different feature (SAF launcher callbacks, not the export coroutines #961 changed), it handles its own cancel path (`uri == null`), and widening a follow-up into unrelated code makes both halves harder to judge. Worth the same one-line treatment if anyone is in there for another reason.

## Verification

- `Tools/doc_comment_lint.py` and `Tools/i18n_audit.py --ci main` clean; `swiftc -parse` clean on `SettingsView.swift`.
- Checked the collapse for fallout: `CircularProgressIndicator` was left orphaned in `TestCentreScreen` and is removed here; it is still used in `SettingsScreen` by the update checker, so that import stays. `Row` / `Arrangement` / `Alignment` / `Modifier.size` all remain heavily used in both files.
- `NoopBusyRow` needs no import at either call site — all three files are `package com.noop.ui` — and is `public` to match `NoopButton` beside it.
- The Android compile is CI's to confirm: Gradle can't run on this host.
