### PR TITLE
app-build: drop the push:main leg, keep the PR gate

### DIFF
--- a/.github/workflows/app-build.yml
+++ b/.github/workflows/app-build.yml
@@ -19,16 +19,12 @@ on:
       - 'Packages/**'
       - 'project.yml'
       - '.github/workflows/app-build.yml'
-  push:
-    branches: [main]
-    paths:
-      - 'Strand/**'
-      - 'StrandiOS/**'
-      - 'StrandiOSShared/**'
-      - 'StrandiOSWidgets/**'
-      - 'Packages/**'
-      - 'project.yml'
-      - '.github/workflows/app-build.yml'
+  # No `push: main` leg. Every change reaches main through a PR, which the trigger above already
+  # gates, so a push run rebuilt content that had just been built - on macOS runners, which GitHub
+  # bills at 10x Linux for a two-runner matrix (macos-15 for the universal macOS leg, macos-26 for
+  # the iOS 26 SDK). A RELEASE pushes straight to main with no PR, but fork-release.yml builds both
+  # Strand and NOOPiOS itself, so that path keeps its own compile gate. The gap this leaves is a
+  # direct non-release push to main; `workflow_dispatch` below covers checking one on demand.
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
Re-enables the app-target compile gate at a cost that should be sustainable.

## Where this stood

`app-build.yml` has been `disabled_manually` since **21 July** — the YAML was always fine, the workflow was just switched off in the Actions UI. In the eleven days since, **49 commits touched app-target Swift with no compile verification of any kind.**

That is not theoretical. It cost three near-misses in a single session:

- a doc comment I orphaned in `BLEManager.swift` reached main, because `doc_comment_lint.py` does not cover app-target Swift and nothing compiled it;
- a `[weak bridge]` closure in #1024 had to be cleared by reading `SWIFT_STRICT_CONCURRENCY` out of `project.yml` by hand, rather than by building it;
- #1022 currently carries **190 lines of new SwiftUI** that nothing in CI compiles.

`swiftc -parse` is the strongest local check available, and it is syntax only — no type-checking, no linking.

The workflow also runs **`StrandTests`**, which executes in no other workflow. Those tests had not run since 21 July either, including the Swift twins added in #1019.

## The probe

Dispatched from a disposable `ci/` branch at `8560f9a1` (main's head), so main could not go red:

```
build (NOOPiOS, generic/platform=iOS Simulator, macos-26):        success
build (Strand, generic/platform=macOS, ARCHS="x86_64 arm64"):     success
cleanup:                                                          success
```

**Both legs green in about five minutes**, `StrandTests` included. Eleven days and 49 commits of drift broke nothing — it can come back on as it stands.

## What changes

Only the `push: main` leg goes. Every change reaches main through a PR, which the `pull_request` trigger already gates, so the push run was rebuilding content that had just been built — on a two-runner macOS matrix (`macos-15` for the universal macOS leg, `macos-26` for the iOS 26 SDK) that GitHub bills at 10× Linux. That roughly halves the cost of keeping the gate.

**Releases keep their gate.** A release pushes straight to main with no PR, but `fork-release.yml` builds both `Strand` and `NOOPiOS` itself, so that path is still compile-verified. The gap this leaves is a *direct, non-release* push to main; `workflow_dispatch` covers checking one on demand, and the existing `ci/`-branch convention plus its `cleanup` job make that a one-liner.

## Note

The workflow is **enabled as of now** — that was a prerequisite for dispatching the probe, since a manually-disabled workflow cannot be dispatched at all. If you would rather it stayed off, disabling it again is one API call and this PR can be closed; nothing here depends on it.