### PR TITLE
app-build: build a PR's merge result without pushing a branch

### DIFF
--- a/.github/workflows/app-build.yml
+++ b/.github/workflows/app-build.yml
@@ -70,16 +70,28 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
         with:
-          # refs/pull/<n>/merge is GitHub's own main+PR merge commit — the same thing the old `ci/`
-          # branch dance produced, without a push. Blank input leaves the default checkout alone.
-          ref: ${{ inputs.pr && format('refs/pull/{0}/merge', inputs.pr) || '' }}
+          # The PR's HEAD, then merge current main below. NOT refs/pull/<n>/merge: GitHub freezes that
+          # ref at the last time the PR merged CLEANLY, so for a conflicting or simply stale PR it is a
+          # merge against an old main and it still resolves. Probing #931 through it would have compiled
+          # main as of 30 July, 30+ commits behind, and reported SUCCESS - a false green, and worse than
+          # the branch it replaced. Merging here is always against main as it is right now.
+          ref: ${{ inputs.pr && format('refs/pull/{0}/head', inputs.pr) || '' }}
+          fetch-depth: ${{ inputs.pr && 0 || 1 }}
+
+      - name: Merge current main
+        if: inputs.pr != ''
+        run: |
+          git fetch --no-tags origin main
+          echo "PR #${{ inputs.pr }} head: $(git log --oneline -1 HEAD)"
+          echo "merging into:  $(git log --oneline -1 FETCH_HEAD)"
+          git -c user.name=ci -c user.email=ci@local merge --no-edit FETCH_HEAD
 
       - name: Say what is being built
         run: |
           if [ -n "${{ inputs.pr }}" ]; then
-            echo "Building PR #${{ inputs.pr }} as merged into main (refs/pull/${{ inputs.pr }}/merge)"
+            echo "Built: PR #${{ inputs.pr }} merged into current main"
           else
-            echo "Building ${GITHUB_REF_NAME} as-is"
+            echo "Built: ${GITHUB_REF_NAME} as-is"
           fi
           git log --oneline -1
 

--- a/.github/workflows/app-build.yml
+++ b/.github/workflows/app-build.yml
@@ -76,7 +76,10 @@ jobs:
           # main as of 30 July, 30+ commits behind, and reported SUCCESS - a false green, and worse than
           # the branch it replaced. Merging here is always against main as it is right now.
           ref: ${{ inputs.pr && format('refs/pull/{0}/head', inputs.pr) || '' }}
-          fetch-depth: ${{ inputs.pr && 0 || 1 }}
+          # QUOTED '0': GitHub expressions treat the number 0 as FALSY, so `inputs.pr && 0 || 1`
+          # silently yields 1 and leaves the clone shallow - the merge below then dies with
+          # "refusing to merge unrelated histories" (exit 128) for EVERY pr, mergeable or not.
+          fetch-depth: ${{ inputs.pr && '0' || '1' }}
 
       - name: Merge current main
         if: inputs.pr != ''

--- a/.github/workflows/app-build.yml
+++ b/.github/workflows/app-build.yml
@@ -123,19 +123,3 @@ jobs:
           -destination 'platform=macOS'
           CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO
           test
-
-  # Fork-only housekeeping: on-demand app-build runs are dispatched from disposable `ci/<name>` branches
-  # (a PR's content pushed somewhere the workflow can run). Once the build finishes (pass OR fail —
-  # always()), delete that branch so GitHub's "Compare & pull request" banner doesn't linger after each
-  # run. Guarded to ci/-prefixed BRANCH refs only — a dispatch from main or any real branch is untouched.
-  cleanup:
-    needs: [build]
-    if: ${{ always() && github.ref_type == 'branch' && startsWith(github.ref_name, 'ci/') }}
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    steps:
-      - name: Delete the disposable CI branch
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh api -X DELETE "repos/${GITHUB_REPOSITORY}/git/refs/heads/${GITHUB_REF_NAME}" || true

--- a/.github/workflows/app-build.yml
+++ b/.github/workflows/app-build.yml
@@ -25,10 +25,24 @@ on:
   # the iOS 26 SDK). A RELEASE pushes straight to main with no PR, but fork-release.yml builds both
   # Strand and NOOPiOS itself, so that path keeps its own compile gate. The gap this leaves is a
   # direct non-release push to main; `workflow_dispatch` below covers checking one on demand.
+  # `pr:` builds a PR's MERGE RESULT without pushing anything. Checking "does this PR compile once
+  # merged?" used to mean creating a throwaway `ci/` branch holding main+PR and dispatching at it —
+  # which left a "Compare & pull request" banner behind for every probe, because GitHub keys that
+  # banner off the PUSH EVENT and it outlives the branch the cleanup job deletes. GitHub already
+  # maintains exactly the ref we were hand-building, at refs/pull/<n>/merge, so no branch is needed.
+  #
+  # Leave it blank to build whatever ref you dispatched against, unchanged.
   workflow_dispatch:
+    inputs:
+      pr:
+        description: "PR number to build as merged into main (blank = build this ref as-is)"
+        required: false
+        default: ""
 
 concurrency:
-  group: app-build-${{ github.ref }}
+  # Keyed on the PR when one is given, so two probes of the SAME pr supersede each other while probes
+  # of different PRs (all dispatched from main) do not cancel one another.
+  group: app-build-${{ inputs.pr && format('pr-{0}', inputs.pr) || github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -55,6 +69,19 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v5
+        with:
+          # refs/pull/<n>/merge is GitHub's own main+PR merge commit — the same thing the old `ci/`
+          # branch dance produced, without a push. Blank input leaves the default checkout alone.
+          ref: ${{ inputs.pr && format('refs/pull/{0}/merge', inputs.pr) || '' }}
+
+      - name: Say what is being built
+        run: |
+          if [ -n "${{ inputs.pr }}" ]; then
+            echo "Building PR #${{ inputs.pr }} as merged into main (refs/pull/${{ inputs.pr }}/merge)"
+          else
+            echo "Building ${GITHUB_REF_NAME} as-is"
+          fi
+          git log --oneline -1
 
       - name: Install XcodeGen
         run: brew install xcodegen


### PR DESCRIPTION
Fixes the stale "Compare & pull request" banners the probe pattern leaves behind — and, on review, two worse problems underneath it.

## The banner

Probing *"does this PR compile once merged?"* meant pushing a throwaway `ci/` branch holding main+PR. That push is what creates the banner, and GitHub keys it to the **push event**, not the branch — so it outlived the `cleanup` job that deleted the branch seconds later. Three probes today, three banners, two pointing at refs that already 404.

## What review changed

**1. `refs/pull/<n>/merge` is not what I first assumed.** My first version checked that ref out, on the belief it is main+PR kept current by GitHub. It is not: GitHub freezes it at the last time the PR merged **cleanly**, and it still resolves afterwards. `refs/pull/931/merge` is dated 30 July with main-as-of-30-July as a parent, 30+ commits behind. Probing #931 through it would have compiled a two-day-old tree and reported **SUCCESS** — a false green, strictly worse than the branch it replaced.

So this checks out `refs/pull/<n>/head` and merges `origin/main` **in the runner**. Always current, and a conflicting PR fails at the merge step before any `xcodebuild`.

**2. `fetch-depth: ${{ inputs.pr && 0 || 1 }}` always evaluated to 1.** GitHub treats the number `0` as falsy, so the `&&` yields `0`, the `||` sees a falsy left side and falls through to `1`. The clone stayed shallow and the merge died with *"refusing to merge unrelated histories"* (exit 128) for **every** PR, mergeable or not. Quoting `'0'` / `'1'` fixes it. This only surfaced by reading the exit code and the `--depth=1` in a run log — the failure looked exactly like the intended conflict failure.

**3. The `cleanup` job is removed.** Its guard was only "ref name starts with `ci/`", so it deletes any `ci/`-prefixed branch dispatched against — including one with an open PR. Not hypothetical: dispatching a test against this very branch deleted it mid-review, and the next dispatch failed with `No ref found`. A `pull_request` run skips the job, which is the only reason it had not bitten sooner. With the `pr:` input there is no disposable branch left to clean up, so it was both dead code and a live footgun.

## Usage

```
gh workflow run app-build.yml --ref main -f pr=931
```

No push, no branch, no banner. Blank input keeps today's behaviour — dispatch a ref, build that ref. Concurrency is keyed per-PR, so probes of different PRs stop cancelling each other.

## Tested, not assumed

Dispatched against this branch, since `workflow_dispatch` uses the workflow file from the ref it runs on.

- **Negative — `pr=931` (conflicting):** `merging into: 5754b171` (current main, not the stale ref), then a real `CONFLICT (content): Merge conflict in Strand/Resources/Localizable.xcstrings`, **exit 1**, about a second in, before any build step.
- **Positive — `pr=1022` (mergeable):** head `fe3ae97b` merged into `5754b171`, **both legs green**. That PR's 190 lines of new SwiftUI had never been compiled by anything until this run.