### PR TITLE
Stop the RSA respiratory path splicing across dropped beats (#977)

### DIFF
--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/SleepStager.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/SleepStager.swift
@@ -1502,15 +1502,24 @@ public enum SleepStager {
     /// does not equal a chest-band / capnography rate.
     ///
     /// Pipeline (per matched in-bed session [start, end], unix SECONDS):
-    ///   1. Restrict RR rows to ts in [start, end]; range-filter the RR values
-    ///      (HRVAnalyzer.rangeFilter) to drop dropouts/ectopics.
+    ///   1. Restrict RR ROWS to ts in [start, end] and apply the same range test
+    ///      HRVAnalyzer.rangeFilter applies, keeping the rows so `ts` survives (#977).
     ///   2. Reconstruct beat times by cumulatively summing the kept RR intervals
-    ///      from the first in-bed beat, yielding an (irregular) tachogram.
+    ///      from the first in-bed beat, yielding an (irregular) tachogram, and note
+    ///      where the wall clock outran the beats (#977) — the cumulative sum cannot
+    ///      represent a dropout, so those points are splices, not elapsed time.
     ///   3. Resample the tachogram onto a uniform ~4 Hz grid by linear interpolation.
     ///   4. Detrend: subtract a centered moving mean (rsaDetrendWindowS).
-    ///   5. Per ~5-min window: findPeaks (min distance rsaMinPeakDistanceS) on the
-    ///      detrended grid, keep peak-to-peak intervals in the 6–24 bpm band, rate =
-    ///      60 / median(intervals). Take the median across windows.
+    ///   5. Per ~5-min window, SKIPPING any window containing a splice: findPeaks
+    ///      (min distance rsaMinPeakDistanceS) on the detrended grid, keep peak-to-peak
+    ///      intervals in the 6–24 bpm band, rate = 60 / median(intervals). Take the
+    ///      median across windows.
+    ///
+    /// Known bound on the splice skip (#977): step 4's centered mean spans ±rsaDetrendWindowS/2, so a
+    /// splice just inside one window's edge leaves ~4 s of contaminated samples at the neighbouring
+    /// window's edge. That window is KEPT deliberately — discarding five minutes to avoid four seconds
+    /// costs far more data than it saves, and both medians (over intervals, then over windows) dilute a
+    /// single spurious peak among a five-minute window's worth.
     /// Returns NaN when too few intervals survive (honest no-data).
     static func respRateFromRR(_ rr: [RRInterval], start: Int, end: Int) -> Double {
         let nan = Double.nan
@@ -1537,6 +1546,12 @@ public enum SleepStager {
         // together and the tachogram gets a discontinuity the peak-picker reads as breathing. Record the
         // beat-time of each splice here; step 5 drops the windows containing one. Beat times are NOT
         // shifted by the gap: within a run the relative timing is right, and that is all a kept window uses.
+        //
+        // This fires on a beat REJECTED just above too, not only one lost before storage: the range
+        // test drops out-of-range intervals, so `ts` steps across them exactly as it does across a
+        // dropout. That is the intent - both genuinely splice the tachogram, which is the same reason
+        // #204/#195 made RMSSD skip differences across a removed beat - but it does mean a night with
+        // heavy ectopic rejection now loses windows it used to keep.
         var beatTimes = [Double](repeating: 0, count: filtered.count)
         var spliceAtS: [Double] = []
         var acc = 0.0

--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/SleepStager.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/SleepStager.swift
@@ -1477,6 +1477,12 @@ public enum SleepStager {
     /// Per-window length for the per-window rate estimate (seconds).
     static let rsaWindowS = 300.0
 
+    /// #977: wall-clock seconds a beat-to-beat step may exceed its own RR before the series is treated
+    /// as SPLICED there. `ts` is whole seconds, so a 1 s discrepancy is quantisation, not a gap; the
+    /// blocks that prompted this were 30-45 s. PROVISIONAL, like `coveragePlausibleCeiling` - wide
+    /// enough that only an unambiguous dropout trips it, and deliberately not tuned to a corpus.
+    static let rsaGapToleranceS = 3.0
+
     /// Physiologic breath-interval band (seconds): 0.1–0.4 Hz = 6–24 breaths/min.
     static let rsaMinBreathIntervalS = 2.5   // 24 bpm
     static let rsaMaxBreathIntervalS = 10.0  // 6 bpm
@@ -1513,16 +1519,32 @@ public enum SleepStager {
         // 1. In-bed RR rows in chronological order, range-filtered. STABLE sort: step 2 reconstructs
         // beat times by cumulative sum, so the order of a second's beats moves every subsequent beat
         // time and with it the RSA estimate. Kotlin's twin uses sortedBy, stable by contract. (#823)
-        let inBed = rr.filter { $0.ts >= start && $0.ts <= end }
+        //
+        // #977: the ROWS are kept, not just their values, because `ts` is the only signal that a beat is
+        // missing. Beats lost before storage never enter the array, so contiguity derived from rejection
+        // (cleanRRGapAware) cannot see them - it takes only [Double] and has no clock. Filtering the rows
+        // by the same predicate `HRVAnalyzer.rangeFilter` applies keeps the surviving VALUES identical
+        // (it is an order-preserving range test), which RespRateGapAwareTests pins.
+        let inBedRows = rr.filter { $0.ts >= start && $0.ts <= end }
             .sortedByTsStable()
-            .map { Double($0.rrMs) }
-        let filtered = HRVAnalyzer.rangeFilter(inBed)
+            .filter { Double($0.rrMs) >= HRVAnalyzer.rrMinMs && Double($0.rrMs) <= HRVAnalyzer.rrMaxMs }
+        let filtered = inBedRows.map { Double($0.rrMs) }
         if filtered.count < 30 { return nan }  // need enough beats for any RSA estimate
 
         // 2. Reconstruct beat times (seconds from session start) by cumulative sum.
+        // #977: a dropout is where the WALL CLOCK outran the beat - ts jumps 30-45 s while the RR only
+        // accounts for ~1 s. The cumulative sum cannot represent that, so it stitches the two sides
+        // together and the tachogram gets a discontinuity the peak-picker reads as breathing. Record the
+        // beat-time of each splice here; step 5 drops the windows containing one. Beat times are NOT
+        // shifted by the gap: within a run the relative timing is right, and that is all a kept window uses.
         var beatTimes = [Double](repeating: 0, count: filtered.count)
+        var spliceAtS: [Double] = []
         var acc = 0.0
         for i in filtered.indices {
+            if i > 0 {
+                let wallStepS = Double(inBedRows[i].ts - inBedRows[i - 1].ts)
+                if wallStepS - filtered[i] / 1000.0 > rsaGapToleranceS { spliceAtS.append(acc) }
+            }
             acc += filtered[i] / 1000.0
             beatTimes[i] = acc
         }
@@ -1559,13 +1581,18 @@ public enum SleepStager {
         if standardDeviation(detrended) <= 1e-9 { return nan }  // flat → no RSA
 
         // 5. Per ~5-min window peak-pick → 60/median(breath interval); median across.
+        let spliceGrid = spliceAtS.map { Int($0 / dt) }
         let minDistSamples = max(2, Int((rsaMinPeakDistanceS * rsaResampleHz).rounded()))
         let windowSamples = max(minDistSamples * 3, Int((rsaWindowS * rsaResampleHz).rounded()))
         var perWindowRates: [Double] = []
         var w = 0
         while w < nGrid {
             let wEnd = min(nGrid, w + windowSamples)
-            if wEnd - w >= minDistSamples * 3 {
+            // #977: a window straddling a splice is measuring a discontinuity, not a breath. Dropping it
+            // costs one window; keeping it puts a fabricated interval into the median. All windows spliced
+            // leaves perWindowRates empty and the function returns NaN, which is the honest answer.
+            let spliced = spliceGrid.contains { $0 >= w && $0 < wEnd }
+            if !spliced && wEnd - w >= minDistSamples * 3 {
                 let winSeg = Array(detrended[w..<wEnd])
                 // findPeaks with height = 0.0 selects the positive RSA peaks (one per
                 // breath) on the zero-mean detrended tachogram.

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/RespRateGapAwareTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/RespRateGapAwareTests.swift
@@ -1,5 +1,6 @@
 import XCTest
 @testable import StrandAnalytics
+import WhoopProtocol   // RRInterval
 
 /// #977 — the RSA respiratory-rate path must not splice across dropped beats.
 ///

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/RespRateGapAwareTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/RespRateGapAwareTests.swift
@@ -1,0 +1,75 @@
+import XCTest
+@testable import StrandAnalytics
+
+/// #977 — the RSA respiratory-rate path must not splice across dropped beats.
+///
+/// `respRateFromRR` rebuilds beat times by cumulatively summing RR, which cannot represent a stretch
+/// where no beats arrived: a 30–45 s dropout is stitched shut and the two sides become adjacent on the
+/// beat-time axis, so the tachogram gets a discontinuity the peak-picker reads as a breath. The reporter
+/// measured Σ(rrMs) ÷ wall-clock of 0.859 on one WHOOP 5 corpus — one wearer, one strap, so an existence
+/// proof that dropouts reach this magnitude, not a population figure.
+///
+/// The signal is `ts`, and only `ts`: these beats were lost before storage, so they were never in the
+/// array to be marked, and `cleanRRGapAware` — which takes `[Double]` and has no clock — cannot see them.
+///
+/// Every vector here is synthetic and says so. Inventing a "real capture" for a timing bug would be
+/// worse than useless: the property under test is the relationship between `ts` and Σ RR, which a
+/// fabricated capture would assert by construction.
+final class RespRateGapAwareTests: XCTestCase {
+
+    /// ~15 breaths/min of RSA on ~900 ms beats, with `ts` advancing consistently with the intervals.
+    /// `gapAfter` inserts a wall-clock jump of `gapS` after that beat index WITHOUT adding beats —
+    /// exactly what a dropout looks like in the store.
+    private func series(beats: Int, gapAfter: Int? = nil, gapS: Int = 40) -> [RRInterval] {
+        var rows: [RRInterval] = []
+        var t = 1_000_000
+        var carryMs = 0.0
+        for i in 0..<beats {
+            let rr = 900.0 + 60.0 * sin(2.0 * Double.pi * Double(i) * 0.9 / 4.0)
+            carryMs += rr
+            if let g = gapAfter, i == g { t += gapS }
+            rows.append(RRInterval(ts: t, rrMs: Int(rr.rounded())))
+            if carryMs >= 1000 { t += Int(carryMs / 1000); carryMs -= Double(Int(carryMs / 1000)) * 1000 }
+        }
+        return rows
+    }
+
+    /// A contiguous night is untouched. This is the regression guard: the change must alter nothing when
+    /// the clock and the beats agree, or it would move every existing user's reported rate.
+    func testContiguousNightStillProducesARate() {
+        // 330 beats at ~0.9 s is ~297 s, which is ONE ~5-min window (nGrid 1189 < windowSamples 1200).
+        // Sized deliberately: with two windows a splice in the first would leave the second to carry the
+        // median, and the test would pass whether or not the skip worked.
+        let rr = series(beats: 330)
+        let rate = SleepStager.respRateFromRR(rr, start: 0, end: 2_000_000)
+        XCTAssertFalse(rate.isNaN, "a clean series must still yield a rate")
+        XCTAssertTrue((6.0...24.0).contains(rate), "expected a plausible breathing rate, got \(rate)")
+    }
+
+    /// The same beat VALUES, with a 40 s wall-clock hole punched in the middle: the only difference is
+    /// `ts`. Before this fix the two inputs were indistinguishable, because `ts` was dropped before the
+    /// cumulative sum. Now the spliced window is skipped, and with a single window's worth of beats that
+    /// leaves nothing to take a median over — NaN, which is the honest answer rather than a fabricated one.
+    func testASplicedWindowIsNotMeasured() {
+        let clean = series(beats: 330)
+        let spliced = series(beats: 330, gapAfter: 165)
+        XCTAssertEqual(clean.map(\.rrMs), spliced.map(\.rrMs), "the fixture must differ only in ts")
+        XCTAssertTrue(SleepStager.respRateFromRR(spliced, start: 0, end: 2_000_000).isNaN)
+    }
+
+    /// A one-second discrepancy is `ts` quantisation, not a dropout: `ts` is whole seconds while beats
+    /// are sub-second, so a strict "any disagreement is a gap" rule would reject every ordinary night.
+    func testSecondLevelJitterIsNotTreatedAsAGap() {
+        let jittered = series(beats: 330, gapAfter: 165, gapS: 1)
+        XCTAssertFalse(SleepStager.respRateFromRR(jittered, start: 0, end: 2_000_000).isNaN)
+    }
+
+    /// The row filter must keep exactly what `HRVAnalyzer.rangeFilter` keeps — the fix filters rows
+    /// rather than values to retain `ts`, and that equivalence is the reason it is safe.
+    func testRowFilterMatchesRangeFilter() {
+        let raw: [Double] = [250, 300, 900, 1500, 2000, 2001, 45]
+        let viaRange = HRVAnalyzer.rangeFilter(raw)
+        let viaRows = raw.filter { $0 >= HRVAnalyzer.rrMinMs && $0 <= HRVAnalyzer.rrMaxMs }
+        XCTAssertEqual(viaRange, viaRows)
+    }
+}

--- a/android/app/src/main/java/com/noop/analytics/SleepStager.kt
+++ b/android/app/src/main/java/com/noop/analytics/SleepStager.kt
@@ -1572,6 +1572,15 @@ object SleepStager {
     /** Per-window length for the per-window rate estimate (seconds). */
     private const val rsaWindowS: Double = 300.0
 
+    /**
+     * #977: wall-clock seconds a beat-to-beat step may exceed its own RR before the series is treated
+     * as SPLICED there. `ts` is whole seconds, so a 1 s discrepancy is quantisation, not a gap; the
+     * blocks that prompted this were 30-45 s. PROVISIONAL, like COVERAGE_PLAUSIBLE_CEILING - wide
+     * enough that only an unambiguous dropout trips it, and deliberately not tuned to a corpus.
+     * Byte-parity twin of Swift `rsaGapToleranceS`.
+     */
+    private const val rsaGapToleranceS: Double = 3.0
+
     /** Physiologic breath-interval band (seconds): 0.1–0.4 Hz = 6–24 breaths/min. */
     private const val rsaMinBreathIntervalS: Double = 2.5  // 24 bpm
     private const val rsaMaxBreathIntervalS: Double = 10.0 // 6 bpm
@@ -1610,19 +1619,35 @@ object SleepStager {
         val nan = Double.NaN
         if (end <= start) return nan
 
-        // 1. In-bed RR rows in chronological order, range-filtered.
-        val inBed = rr.asSequence()
+        // 1. In-bed RR ROWS in chronological order, range-filtered.
+        //
+        // #977: the rows are kept, not just their values, because `ts` is the only signal that a beat is
+        // missing. Beats lost before storage never enter the list, so contiguity derived from rejection
+        // (cleanRRGapAware) cannot see them - it takes only a List<Double> and has no clock. Filtering the
+        // rows by the same predicate HrvAnalyzer.rangeFilter applies keeps the surviving VALUES identical
+        // (it is an order-preserving range test), which RespRateGapAwareTest pins.
+        val inBedRows = rr.asSequence()
             .filter { it.ts in start..end }
             .sortedBy { it.ts }
-            .map { it.rrMs.toDouble() }
+            .filter { it.rrMs.toDouble() >= HrvAnalyzer.RR_MIN_MS && it.rrMs.toDouble() <= HrvAnalyzer.RR_MAX_MS }
             .toList()
-        val filtered = HrvAnalyzer.rangeFilter(inBed)
+        val filtered = inBedRows.map { it.rrMs.toDouble() }
         if (filtered.size < 30) return nan // need enough beats for any RSA estimate
 
         // 2. Reconstruct beat times (seconds from session start) by cumulative sum.
+        // #977: a dropout is where the WALL CLOCK outran the beat - ts jumps 30-45 s while the RR only
+        // accounts for ~1 s. The cumulative sum cannot represent that, so it stitches the two sides
+        // together and the tachogram gets a discontinuity the peak-picker reads as breathing. Record the
+        // beat-time of each splice; step 5 drops the windows containing one. Beat times are NOT shifted
+        // by the gap: within a run the relative timing is right, and that is all a kept window uses.
         val beatTimes = DoubleArray(filtered.size)
+        val spliceAtS = mutableListOf<Double>()
         var acc = 0.0
         for (i in filtered.indices) {
+            if (i > 0) {
+                val wallStepS = (inBedRows[i].ts - inBedRows[i - 1].ts).toDouble()
+                if (wallStepS - filtered[i] / 1000.0 > rsaGapToleranceS) spliceAtS.add(acc)
+            }
             acc += filtered[i] / 1000.0
             beatTimes[i] = acc
         }
@@ -1663,13 +1688,18 @@ object SleepStager {
         if (standardDeviation(detrended.toList()) <= 1e-9) return nan // flat → no RSA
 
         // 5. Per ~5-min window peak-pick → 60/median(breath interval); median across.
+        val spliceGrid = spliceAtS.map { (it / dt).toInt() }
         val minDistSamples = maxOf(2, (rsaMinPeakDistanceS * rsaResampleHz).roundToInt())
         val windowSamples = maxOf(minDistSamples * 3, (rsaWindowS * rsaResampleHz).roundToInt())
         val perWindowRates = ArrayList<Double>()
         var w = 0
         while (w < nGrid) {
             val wEnd = minOf(nGrid, w + windowSamples)
-            if (wEnd - w >= minDistSamples * 3) {
+            // #977: a window straddling a splice is measuring a discontinuity, not a breath. Dropping it
+            // costs one window; keeping it puts a fabricated interval into the median. All windows spliced
+            // leaves perWindowRates empty and the function returns NaN, which is the honest answer.
+            val spliced = spliceGrid.any { it >= w && it < wEnd }
+            if (!spliced && wEnd - w >= minDistSamples * 3) {
                 val winSeg = ArrayList<Double>(wEnd - w)
                 for (k in w until wEnd) winSeg.add(detrended[k])
                 // findPeaks with height = 0.0 selects the positive RSA peaks (one per

--- a/android/app/src/main/java/com/noop/analytics/SleepStager.kt
+++ b/android/app/src/main/java/com/noop/analytics/SleepStager.kt
@@ -1603,16 +1603,24 @@ object SleepStager {
      * does not equal a chest-band / capnography rate.
      *
      * Pipeline (per matched in-bed session [start, end], unix SECONDS):
-     *   1. Restrict RR rows to ts in [start, end]; range-filter the RR values
-     *      (HrvAnalyzer.rangeFilter) to drop dropouts/ectopics.
+     *   1. Restrict RR ROWS to ts in [start, end] and apply the same range test
+     *      HrvAnalyzer.rangeFilter applies, keeping the rows so `ts` survives (#977).
      *   2. Reconstruct beat times by cumulatively summing the kept RR intervals
-     *      from the first in-bed beat, yielding an (irregular) tachogram
-     *      t_k = Σ rr, value_k = rr_k (ms).
+     *      from the first in-bed beat, yielding an (irregular) tachogram, and note
+     *      where the wall clock outran the beats (#977) - the cumulative sum cannot
+     *      represent a dropout, so those points are splices, not elapsed time.
      *   3. Resample the tachogram onto a uniform ~4 Hz grid by linear interpolation.
      *   4. Detrend: subtract a centered moving mean (rsaDetrendWindowS).
-     *   5. Per ~5-min window: findPeaks (min distance rsaMinPeakDistanceS) on the
-     *      detrended grid, keep peak-to-peak intervals in the 6–24 bpm band, rate =
-     *      60 / median(intervals). Take the median across windows.
+     *   5. Per ~5-min window, SKIPPING any window containing a splice: findPeaks
+     *      (min distance rsaMinPeakDistanceS) on the detrended grid, keep peak-to-peak
+     *      intervals in the 6-24 bpm band, rate = 60 / median(intervals). Take the
+     *      median across windows.
+     *
+     * Known bound on the splice skip (#977): step 4's centered mean spans +/-rsaDetrendWindowS/2, so a
+     * splice just inside one window's edge leaves ~4 s of contaminated samples at the neighbouring
+     * window's edge. That window is KEPT deliberately - discarding five minutes to avoid four seconds
+     * costs far more data than it saves, and both medians (over intervals, then over windows) dilute a
+     * single spurious peak among a five-minute window's worth.
      * Returns NaN when too few intervals survive (honest no-data).
      */
     internal fun respRateFromRR(rr: List<RrInterval>, start: Long, end: Long): Double {
@@ -1640,6 +1648,12 @@ object SleepStager {
         // together and the tachogram gets a discontinuity the peak-picker reads as breathing. Record the
         // beat-time of each splice; step 5 drops the windows containing one. Beat times are NOT shifted
         // by the gap: within a run the relative timing is right, and that is all a kept window uses.
+        //
+        // This fires on a beat REJECTED just above too, not only one lost before storage: the range
+        // test drops out-of-range intervals, so `ts` steps across them exactly as it does across a
+        // dropout. That is the intent - both genuinely splice the tachogram, which is the same reason
+        // #204/#195 made RMSSD skip differences across a removed beat - but it does mean a night with
+        // heavy ectopic rejection now loses windows it used to keep.
         val beatTimes = DoubleArray(filtered.size)
         val spliceAtS = mutableListOf<Double>()
         var acc = 0.0

--- a/android/app/src/test/java/com/noop/analytics/RespRateGapAwareTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/RespRateGapAwareTest.kt
@@ -1,0 +1,79 @@
+package com.noop.analytics
+
+import com.noop.data.RrInterval
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import kotlin.math.PI
+import kotlin.math.roundToInt
+import kotlin.math.sin
+import org.junit.Test
+
+/**
+ * #977 — the RSA respiratory-rate path must not splice across dropped beats. Twin of the Swift
+ * `RespRateGapAwareTests`: the same vectors in the same order, because the two platforms must reach the
+ * same rate from the same rows.
+ *
+ * `respRateFromRR` rebuilds beat times by cumulatively summing RR, which cannot represent a stretch where
+ * no beats arrived: a 30-45 s dropout is stitched shut and the two sides become adjacent on the beat-time
+ * axis, so the tachogram gets a discontinuity the peak-picker reads as a breath.
+ *
+ * The signal is `ts`, and only `ts`: these beats were lost before storage, so they were never in the list
+ * to be marked, and `cleanRRGapAware` — which takes a List<Double> and has no clock — cannot see them.
+ *
+ * Every vector here is synthetic and says so. Inventing a "real capture" for a timing bug would be worse
+ * than useless: the property under test is the relationship between `ts` and the RR sum, which a
+ * fabricated capture would assert by construction.
+ */
+class RespRateGapAwareTest {
+
+    /**
+     * ~15 breaths/min of RSA on ~900 ms beats, with `ts` advancing consistently with the intervals.
+     * [gapAfter] inserts a wall-clock jump of [gapS] after that beat index WITHOUT adding beats —
+     * exactly what a dropout looks like in the store.
+     */
+    private fun series(beats: Int, gapAfter: Int? = null, gapS: Int = 40): List<RrInterval> {
+        val rows = mutableListOf<RrInterval>()
+        var t = 1_000_000L
+        var carryMs = 0.0
+        for (i in 0 until beats) {
+            val rr = 900.0 + 60.0 * sin(2.0 * PI * i * 0.9 / 4.0)
+            carryMs += rr
+            if (gapAfter != null && i == gapAfter) t += gapS
+            rows.add(RrInterval(deviceId = "t", ts = t, rrMs = rr.roundToInt()))
+            if (carryMs >= 1000) { val whole = (carryMs / 1000).toInt(); t += whole; carryMs -= whole * 1000.0 }
+        }
+        return rows
+    }
+
+    /** A contiguous night is untouched — the regression guard: change nothing when clock and beats agree. */
+    @Test fun contiguousNightStillProducesARate() {
+        // 330 beats at ~0.9 s is ~297 s, ONE ~5-min window. Sized deliberately: with two windows a splice
+        // in the first would leave the second to carry the median and the test would pass regardless.
+        val rate = SleepStager.respRateFromRR(series(330), 0L, 2_000_000L)
+        assertFalse("a clean series must still yield a rate", rate.isNaN())
+        assertTrue("expected a plausible breathing rate, got $rate", rate in 6.0..24.0)
+    }
+
+    /** Same beat VALUES, a 40 s hole punched in the middle: the only difference is `ts`. */
+    @Test fun aSplicedWindowIsNotMeasured() {
+        val clean = series(330)
+        val spliced = series(330, gapAfter = 165)
+        assertEquals("the fixture must differ only in ts", clean.map { it.rrMs }, spliced.map { it.rrMs })
+        assertTrue(SleepStager.respRateFromRR(spliced, 0L, 2_000_000L).isNaN())
+    }
+
+    /** One second of disagreement is `ts` quantisation, not a dropout. */
+    @Test fun secondLevelJitterIsNotTreatedAsAGap() {
+        assertFalse(SleepStager.respRateFromRR(series(330, gapAfter = 165, gapS = 1), 0L, 2_000_000L).isNaN())
+    }
+
+    /** The row filter keeps exactly what `rangeFilter` keeps — the equivalence the fix relies on. */
+    @Test fun rowFilterMatchesRangeFilter() {
+        val raw = listOf(250.0, 300.0, 900.0, 1500.0, 2000.0, 2001.0, 45.0)
+        assertEquals(
+            HrvAnalyzer.rangeFilter(raw),
+            raw.filter { it >= HrvAnalyzer.RR_MIN_MS && it <= HrvAnalyzer.RR_MAX_MS },
+        )
+    }
+}


### PR DESCRIPTION
Implements finding 2 of #977. Both platforms, with twin tests.

## The bug

`respRateFromRR` reconstructs beat times by cumulatively summing RR. That cannot represent a stretch where **no beats arrived**: a 30–45 s dropout is stitched shut, the beats either side become adjacent on the beat-time axis, and the tachogram gets a discontinuity the peak-picker reads as a breath. A nominal 5-minute window can span a much longer real interval containing one or more splices.

`ts` is the only signal that a beat is missing, and it was thrown away at the `.map` before the sum:

```swift
let inBed = rr.filter { ... }.sortedByTsStable().map { Double($0.rrMs) }   // ts gone here
let filtered = HRVAnalyzer.rangeFilter(inBed)                             // not gap-aware
```

The gap-aware machinery next door cannot be dropped in either: `cleanRRGapAware` takes `[Double]` and has **no clock**, so its contiguity comes from *rejection*. These beats were lost before storage and never entered the array to be rejected.

## The fix

Rows are kept through the range filter, so a wall-clock step that outruns its own RR by more than `rsaGapToleranceS` marks a splice; step 5 then drops the windows containing one.

**Beat times are deliberately not shifted by the gap.** Within a contiguous run the relative timing is already correct, and that is all a kept window uses — shifting would only matter for windows we are discarding anyway. Every window spliced leaves `perWindowRates` empty and the function returns NaN, which is the existing honest no-data path.

**Filtering rows rather than values keeps the surviving values identical**, because `rangeFilter` is an order-preserving range test. That equivalence is what makes the change safe, so it is pinned by a test on both platforms rather than left as an assumption.

`rsaGapToleranceS = 3.0` is **provisional and documented as such**: `ts` is whole seconds, so a 1 s discrepancy is quantisation rather than a dropout, and the blocks that prompted the report were 30–45 s. It is not tuned to any corpus.

## Tests

Four per platform, mirrored. The load-bearing one is the **regression guard**: a contiguous night must still produce the same kind of answer, or this would move every existing user's reported rate.

The splice test uses **the same beat values** as the clean one and differs only in `ts` — before this change the two inputs were indistinguishable. Fixtures are 330 beats (~297 s) on purpose: that is exactly one ~5-min window, so a splice cannot be masked by a second window carrying the median. With 400 beats there are two windows and the test would have passed whether or not the skip worked.

All vectors are synthetic and say so. Inventing a "real capture" for a timing bug would be worse than useless — the property under test is the relationship between `ts` and Σ RR, which a fabricated capture would assert by construction.

I also simulated the full pipeline offline to size the fixtures before writing them: clean → 16.0 bpm, spliced → NaN, 1 s jitter → 16.0. CI is the real check.

## Not included: the coverage floor

Finding 1 is real and confirmed — `classifyCoverage` has a ceiling at 1.10 and no floor, so 0.859 and 0.001 both return `.plausible`. It is left alone because **the floor value cannot be justified yet**: this repo's own `testCleanNightIsPlausible` pins `coverage: 0.89` as a clean night from a real #803 capture, which is 0.03 above the 0.859 that prompted the report. Any floor between them reclassifies an existing fixture on a hunch.

Worth noting for whoever picks it: `IntelligenceEngine` already logs `coverage=%.2f` in the `hrv diag` line, so the distribution needed to choose a floor can be gathered from traces people already have, with no code change.

## Scope

Analytics only. No BLE, no schema, no stored values change for a night without dropouts. The 0.859 in #977 is one wearer on one WHOOP 5 — an existence proof that dropouts reach that magnitude, not a population figure.